### PR TITLE
[v18] kube: wire streaming JSON filter into list resource path

### DIFF
--- a/lib/kube/proxy/compression.go
+++ b/lib/kube/proxy/compression.go
@@ -119,3 +119,24 @@ type nopCloserWrapper struct {
 func (*nopCloserWrapper) Close() error {
 	return nil
 }
+
+// wrapContentEncoding returns a reader/writer pair that handles Content-Encoding.
+// For gzip, it wraps the reader in a gzip decompressor and the writer in a pooled gzip compressor.
+// For identity or no encoding, it returns no-op closers.
+// Returns an error for unsupported encodings.
+func wrapContentEncoding(r io.Reader, w io.Writer, contentEncoding string) (io.ReadCloser, io.WriteCloser, error) {
+	switch contentEncoding {
+	case "", "identity":
+		return io.NopCloser(r), &nopCloserWrapper{w}, nil
+	case "gzip":
+		gzReader, err := gzip.NewReader(r)
+		if err != nil {
+			return nil, nil, trace.Wrap(err)
+		}
+		gzWriter := gzipPool.Get().(*gzip.Writer)
+		gzWriter.Reset(w)
+		return gzReader, &gzipWrapper{gzWriter}, nil
+	default:
+		return nil, nil, trace.BadParameter("unsupported Content-Encoding: %s", contentEncoding)
+	}
+}

--- a/lib/kube/proxy/compression_test.go
+++ b/lib/kube/proxy/compression_test.go
@@ -1,0 +1,114 @@
+/*
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package proxy
+
+import (
+	"bytes"
+	"compress/gzip"
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func Test_wrapContentEncoding(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		encoding string
+		wantErr  string
+		check    func(t *testing.T)
+	}{
+		{
+			name:     "unsupported encoding",
+			encoding: "br",
+			wantErr:  "unsupported Content-Encoding",
+		},
+		{
+			name:     "deflate unsupported",
+			encoding: "deflate",
+			wantErr:  "unsupported Content-Encoding",
+		},
+		{
+			name:     "empty encoding",
+			encoding: "",
+			check: func(t *testing.T) {
+				r, w, err := wrapContentEncoding(bytes.NewReader(nil), io.Discard, "")
+				require.NoError(t, err)
+				require.NoError(t, r.Close())
+				require.NoError(t, w.Close())
+			},
+		},
+		{
+			name:     "identity encoding",
+			encoding: "identity",
+			check: func(t *testing.T) {
+				r, w, err := wrapContentEncoding(bytes.NewReader(nil), io.Discard, "identity")
+				require.NoError(t, err)
+				require.NoError(t, r.Close())
+				require.NoError(t, w.Close())
+			},
+		},
+		{
+			name:     "gzip round trip",
+			encoding: "gzip",
+			check: func(t *testing.T) {
+				original := []byte("hello, gzip world!")
+
+				var compressed bytes.Buffer
+				gz := gzip.NewWriter(&compressed)
+				_, err := gz.Write(original)
+				require.NoError(t, err)
+				require.NoError(t, gz.Close())
+
+				var recompressed bytes.Buffer
+				reader, writer, err := wrapContentEncoding(&compressed, &recompressed, "gzip")
+				require.NoError(t, err)
+
+				decompressed, err := io.ReadAll(reader)
+				require.NoError(t, err)
+				require.NoError(t, reader.Close())
+				require.Equal(t, original, decompressed)
+
+				_, err = writer.Write(original)
+				require.NoError(t, err)
+				require.NoError(t, writer.Close())
+
+				gzr, err := gzip.NewReader(&recompressed)
+				require.NoError(t, err)
+				result, err := io.ReadAll(gzr)
+				require.NoError(t, err)
+				require.Equal(t, original, result)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if tt.wantErr != "" {
+				_, _, err := wrapContentEncoding(bytes.NewReader(nil), io.Discard, tt.encoding)
+				require.ErrorContains(t, err, tt.wantErr)
+				return
+			}
+			tt.check(t)
+		})
+	}
+}

--- a/lib/kube/proxy/fast_matcher.go
+++ b/lib/kube/proxy/fast_matcher.go
@@ -1,0 +1,236 @@
+/*
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package proxy
+
+import (
+	"regexp"
+	"strings"
+
+	"github.com/gravitational/trace"
+
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/utils"
+)
+
+// fastMatcher is a precompiled per-request RBAC matcher that reduces per-item matching overhead.
+// Instead of calling matchKubernetesResource per item (which does cache lookups, rule iteration, per-field matching),
+// the fast matcher resolves constant fields at compile time and only checks per-item fields during matching.
+//
+// Of the five rule fields:
+//   - Kind: exact-match or wildcard only, constant per request, resolved at compile time.
+//   - Verb: exact-match or wildcard only, constant per request, resolved at compile time.
+//   - APIGroup: supports regex/glob, constant per request, resolved at compile time.
+//   - Namespace: supports regex/glob, varies per item, checked per item.
+//   - Name: supports regex/glob, varies per item, checked per item.
+//
+// The fast matcher handles the common "default" case in KubeResourceMatchesRegex.
+// It cannot handle namespace special cases (when the requested kind is "namespaces").
+type fastMatcher struct {
+	allowRules []compiledMatchRule
+	denyRules  []compiledMatchRule
+}
+
+// compiledMatchRule is a single RBAC rule with pre-compiled name and namespace matchers.
+// Kind, verb, and apiGroup have already been resolved during rule filtering.
+type compiledMatchRule struct {
+	name      fieldMatcher
+	namespace fieldMatcher
+	// requiresNamespace is true when the original rule had a non-empty, non-wildcard namespace pattern.
+	// When true, resources with an empty namespace cannot match this rule.
+	requiresNamespace bool
+}
+
+// fieldMatcher matches a string either by exact literal comparison or by compiled regex.
+type fieldMatcher struct {
+	literal string         // set for exact match
+	re      *regexp.Regexp // set for pattern match
+}
+
+func (f fieldMatcher) match(s string) bool {
+	if f.re == nil {
+		return f.literal == s
+	}
+	return f.re.MatchString(s)
+}
+
+// newFastMatcher filters rules by request parameters and compiles a fast matcher.
+func newFastMatcher(mr metaResource, allowed, denied []types.KubernetesResource) (*fastMatcher, error) {
+	// Local cache for this compilation pass.
+	// Many rules share the same patterns, so this avoids compiling the same expression multiple times.
+	cache := make(map[string]*regexp.Regexp)
+
+	filteredAllowed, err := filterRules(mr, allowed, cache)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	filteredDenied, err := filterRules(mr, denied, cache)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	allowRules, err := compileMatchRules(filteredAllowed, cache)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	denyRules, err := compileMatchRules(filteredDenied, cache)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return &fastMatcher{
+		allowRules: allowRules,
+		denyRules:  denyRules,
+	}, nil
+}
+
+// filterRules returns the subset of rules that match the given request parameters.
+func filterRules(mr metaResource, rules []types.KubernetesResource, cache map[string]*regexp.Regexp) ([]types.KubernetesResource, error) {
+	filtered := make([]types.KubernetesResource, 0, len(rules))
+	for _, r := range rules {
+		if !kindAllowed(r.Kind, mr.requestedResource.resourceKind) {
+			continue
+		}
+		if !verbAllowed(r.Verbs, mr.verb) {
+			continue
+		}
+		if !namespaceAllowed(r.Namespace, mr.requestedResource.namespace) {
+			continue
+		}
+		match, err := apiGroupMatches(r.APIGroup, mr.requestedResource.apiGroup, cache)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		if !match {
+			continue
+		}
+		filtered = append(filtered, r)
+	}
+	return filtered, nil
+}
+
+func kindAllowed(ruleKind, requestedKind string) bool {
+	return ruleKind == types.Wildcard || ruleKind == requestedKind
+}
+
+func verbAllowed(allowedVerbs []string, verb string) bool {
+	return utils.IsVerbAllowed(allowedVerbs, verb)
+}
+
+func namespaceAllowed(ruleNamespace, requestedNamespace string) bool {
+	if requestedNamespace == "" {
+		// Cluster-wide request: all rules pass since items may come from any namespace.
+		return true
+	}
+	// Empty rule namespace targets cluster-wide resources.
+	// Keep it during pre-filtering; the compiled matcher only matches items with empty namespace.
+	if ruleNamespace == "" {
+		return true
+	}
+	// Pattern namespaces are kept since they need compilation.
+	if isGlobOrRegexp(ruleNamespace) {
+		return true
+	}
+	return ruleNamespace == requestedNamespace
+}
+
+func apiGroupMatches(ruleAPIGroup, requestedAPIGroup string, cache map[string]*regexp.Regexp) (bool, error) {
+	if !isGlobOrRegexp(ruleAPIGroup) {
+		return ruleAPIGroup == requestedAPIGroup, nil
+	}
+	if re, ok := cache[ruleAPIGroup]; ok {
+		return re.MatchString(requestedAPIGroup), nil
+	}
+	re, err := utils.CompileExpression(ruleAPIGroup)
+	if err != nil {
+		return false, trace.Wrap(err)
+	}
+	cache[ruleAPIGroup] = re
+	return re.MatchString(requestedAPIGroup), nil
+}
+
+func isGlobOrRegexp(expr string) bool {
+	return strings.Contains(expr, "*") || utils.IsRegexp(expr)
+}
+
+func compileMatchRules(resources []types.KubernetesResource, cache map[string]*regexp.Regexp) ([]compiledMatchRule, error) {
+	rules := make([]compiledMatchRule, 0, len(resources))
+	for _, r := range resources {
+		nameM, err := compileFieldMatcher(r.Name, cache)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		nsM, err := compileFieldMatcher(r.Namespace, cache)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+
+		rules = append(rules, compiledMatchRule{
+			name:              nameM,
+			namespace:         nsM,
+			requiresNamespace: r.Namespace != "" && r.Namespace != types.Wildcard,
+		})
+	}
+	return rules, nil
+}
+
+// compileFieldMatcher returns a fieldMatcher for the given expression.
+// Literal expressions (no wildcards or regex) use direct string comparison.
+// Patterns are compiled to regex, with results cached across rules.
+func compileFieldMatcher(expression string, cache map[string]*regexp.Regexp) (fieldMatcher, error) {
+	if !isGlobOrRegexp(expression) {
+		return fieldMatcher{literal: expression}, nil
+	}
+	if re, ok := cache[expression]; ok {
+		return fieldMatcher{re: re}, nil
+	}
+	re, err := utils.CompileExpression(expression)
+	if err != nil {
+		return fieldMatcher{}, trace.Wrap(err)
+	}
+	cache[expression] = re
+	return fieldMatcher{re: re}, nil
+}
+
+// match checks if a resource with the given name and namespace is allowed by the precompiled RBAC rules.
+func (m *fastMatcher) match(name, namespace string) (bool, error) {
+	for i := range m.denyRules {
+		if m.denyRules[i].matches(name, namespace) {
+			return false, nil
+		}
+	}
+	for i := range m.allowRules {
+		if m.allowRules[i].matches(name, namespace) {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// matches checks whether a single compiled rule matches the given fields.
+// This mirrors the "default" case in KubeResourceMatchesRegex.
+// Kind, verb, and apiGroup are already resolved during rule filtering.
+func (r *compiledMatchRule) matches(name, namespace string) bool {
+	if !r.name.match(name) {
+		return false
+	}
+	if r.requiresNamespace && namespace == "" {
+		return false
+	}
+	return r.namespace.match(namespace)
+}

--- a/lib/kube/proxy/fast_matcher.go
+++ b/lib/kube/proxy/fast_matcher.go
@@ -207,8 +207,8 @@ func compileFieldMatcher(expression string, cache map[string]*regexp.Regexp) (fi
 	return fieldMatcher{re: re}, nil
 }
 
-// match checks if a resource with the given name and namespace is allowed by the precompiled RBAC rules.
-func (m *fastMatcher) match(name, namespace string) (bool, error) {
+// Match checks if a resource with the given name and namespace is allowed by the precompiled RBAC rules.
+func (m *fastMatcher) Match(name, namespace string) (bool, error) {
 	for i := range m.denyRules {
 		if m.denyRules[i].matches(name, namespace) {
 			return false, nil

--- a/lib/kube/proxy/fast_matcher_test.go
+++ b/lib/kube/proxy/fast_matcher_test.go
@@ -1,0 +1,879 @@
+/*
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package proxy
+
+import (
+	"fmt"
+	"log/slog"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/kube/proxy/responsewriters"
+)
+
+func TestNewMatcher(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		kind           string
+		verb           string
+		apiGroup       string
+		namespace      string
+		allowed        []types.KubernetesResource
+		wantDefault    bool
+		wantAllowCount int
+		wantDenyCount  int
+	}{
+		{
+			name:        "returns defaultMatcher for namespace kind",
+			kind:        "namespaces",
+			verb:        types.KubeVerbList,
+			wantDefault: true,
+		},
+		{
+			name: "compiles successfully for pod kind",
+			kind: types.KindKubePod,
+			verb: types.KubeVerbList,
+			allowed: []types.KubernetesResource{
+				{Kind: types.KindKubePod, Namespace: "default", Name: "*", Verbs: []string{types.KubeVerbList}, APIGroup: ""},
+			},
+			wantAllowCount: 1,
+		},
+		{
+			name: "filters out rules with non-matching kind",
+			kind: types.KindKubePod,
+			verb: types.KubeVerbList,
+			allowed: []types.KubernetesResource{
+				{Kind: types.KindKubePod, Namespace: "*", Name: "*", Verbs: []string{types.KubeVerbList}, APIGroup: "*"},
+				{Kind: types.KindKubeConfigmap, Namespace: "*", Name: "*", Verbs: []string{types.KubeVerbList}, APIGroup: "*"},
+			},
+			wantAllowCount: 1,
+		},
+		{
+			name: "includes wildcard kind rules",
+			kind: types.KindKubePod,
+			verb: types.KubeVerbList,
+			allowed: []types.KubernetesResource{
+				{Kind: types.Wildcard, Namespace: "*", Name: "*", Verbs: []string{types.Wildcard}, APIGroup: "*"},
+			},
+			wantAllowCount: 1,
+		},
+		{
+			name: "filters out rules with non-matching verb",
+			kind: types.KindKubePod,
+			verb: types.KubeVerbList,
+			allowed: []types.KubernetesResource{
+				{Kind: types.KindKubePod, Namespace: "*", Name: "*", Verbs: []string{types.KubeVerbCreate}, APIGroup: "*"},
+			},
+			wantAllowCount: 0,
+		},
+		{
+			name: "wildcard verb only recognized as first element",
+			kind: types.KindKubePod,
+			verb: types.KubeVerbList,
+			allowed: []types.KubernetesResource{
+				{Kind: types.KindKubePod, Namespace: "*", Name: "*", Verbs: []string{types.KubeVerbGet, types.Wildcard}, APIGroup: "*"},
+			},
+			wantAllowCount: 0,
+		},
+		{
+			name: "wildcard verb as first element matches any verb",
+			kind: types.KindKubePod,
+			verb: types.KubeVerbList,
+			allowed: []types.KubernetesResource{
+				{Kind: types.KindKubePod, Namespace: "*", Name: "*", Verbs: []string{types.Wildcard}, APIGroup: "*"},
+			},
+			wantAllowCount: 1,
+		},
+		{
+			name: "empty verbs matches nothing",
+			kind: types.KindKubePod,
+			verb: types.KubeVerbList,
+			allowed: []types.KubernetesResource{
+				{Kind: types.KindKubePod, Namespace: "*", Name: "*", Verbs: []string{}, APIGroup: "*"},
+			},
+			wantAllowCount: 0,
+		},
+		{
+			name: "returns defaultMatcher for invalid regex",
+			kind: types.KindKubePod,
+			verb: types.KubeVerbList,
+			allowed: []types.KubernetesResource{
+				{Kind: types.KindKubePod, Namespace: "^[invalid$", Name: "*", Verbs: []string{types.KubeVerbList}, APIGroup: "*"},
+			},
+			wantDefault: true,
+		},
+		{
+			name:     "filters out rules with non-matching literal API group",
+			kind:     types.KindKubePod,
+			verb:     types.KubeVerbList,
+			apiGroup: "",
+			allowed: []types.KubernetesResource{
+				{Kind: types.KindKubePod, Namespace: "*", Name: "*", Verbs: []string{types.KubeVerbList}, APIGroup: "apps"},
+				{Kind: types.KindKubePod, Namespace: "*", Name: "*", Verbs: []string{types.KubeVerbList}, APIGroup: ""},
+			},
+			wantAllowCount: 1,
+		},
+		{
+			name:     "keeps rules with wildcard API group",
+			kind:     types.KindKubePod,
+			verb:     types.KubeVerbList,
+			apiGroup: "",
+			allowed: []types.KubernetesResource{
+				{Kind: types.KindKubePod, Namespace: "*", Name: "*", Verbs: []string{types.KubeVerbList}, APIGroup: "*"},
+			},
+			wantAllowCount: 1,
+		},
+		{
+			name:     "keeps rules with regex API group",
+			kind:     types.KindKubePod,
+			verb:     types.KubeVerbList,
+			apiGroup: "apps",
+			allowed: []types.KubernetesResource{
+				{Kind: types.KindKubePod, Namespace: "*", Name: "*", Verbs: []string{types.KubeVerbList}, APIGroup: "^apps|extensions$"},
+			},
+			wantAllowCount: 1,
+		},
+		{
+			name:      "filters out rules with non-matching literal namespace",
+			kind:      types.KindKubePod,
+			verb:      types.KubeVerbList,
+			namespace: "default",
+			allowed: []types.KubernetesResource{
+				{Kind: types.KindKubePod, Namespace: "staging", Name: "*", Verbs: []string{types.KubeVerbList}, APIGroup: ""},
+				{Kind: types.KindKubePod, Namespace: "default", Name: "*", Verbs: []string{types.KubeVerbList}, APIGroup: ""},
+			},
+			wantAllowCount: 1,
+		},
+		{
+			name:      "keeps all rules when request is cluster-wide",
+			kind:      types.KindKubePod,
+			verb:      types.KubeVerbList,
+			namespace: "",
+			allowed: []types.KubernetesResource{
+				{Kind: types.KindKubePod, Namespace: "staging", Name: "*", Verbs: []string{types.KubeVerbList}, APIGroup: ""},
+				{Kind: types.KindKubePod, Namespace: "default", Name: "*", Verbs: []string{types.KubeVerbList}, APIGroup: ""},
+			},
+			wantAllowCount: 2,
+		},
+		{
+			name:      "keeps rules with wildcard namespace when targeting specific namespace",
+			kind:      types.KindKubePod,
+			verb:      types.KubeVerbList,
+			namespace: "default",
+			allowed: []types.KubernetesResource{
+				{Kind: types.KindKubePod, Namespace: "*", Name: "*", Verbs: []string{types.KubeVerbList}, APIGroup: ""},
+			},
+			wantAllowCount: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			mr := metaResource{
+				requestedResource: apiResource{resourceKind: tt.kind, apiGroup: tt.apiGroup, namespace: tt.namespace},
+				verb:              tt.verb,
+			}
+			log := slog.New(slog.DiscardHandler)
+			m := newMatcher(mr, tt.allowed, nil, log)
+			if tt.wantDefault {
+				require.IsType(t, &defaultMatcher{}, m)
+				return
+			}
+			fm, ok := m.(*fastMatcher)
+			require.True(t, ok, "expected *fastMatcher, got %T", m)
+			require.Len(t, fm.allowRules, tt.wantAllowCount)
+			require.Len(t, fm.denyRules, tt.wantDenyCount)
+		})
+	}
+}
+
+// TestNamespaceKindFallback verifies that namespace kind requests go through defaultMatcher
+// and produce correct results for all the special cases in KubeResourceMatchesRegex:
+// - pod rule in namespace "foo" → user can list namespace "foo"
+// - explicit namespace rule → matched by name
+// - wildcard kind with namespace swapping
+// If someone removes the namespace guard from newMatcher, these will fail.
+func TestNamespaceKindFallback(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		verb    string
+		allowed []types.KubernetesResource
+		denied  []types.KubernetesResource
+		input   types.KubernetesResource
+	}{
+		{
+			name: "pod rule grants read-only namespace visibility",
+			verb: types.KubeVerbList,
+			allowed: []types.KubernetesResource{
+				{Kind: types.KindKubePod, Namespace: "production", Name: "*", Verbs: []string{types.Wildcard}},
+			},
+			input: types.KubernetesResource{Kind: "namespaces", Name: "production", Verbs: []string{types.KubeVerbList}},
+		},
+		{
+			name: "pod rule does not grant visibility to other namespaces",
+			verb: types.KubeVerbList,
+			allowed: []types.KubernetesResource{
+				{Kind: types.KindKubePod, Namespace: "production", Name: "*", Verbs: []string{types.Wildcard}},
+			},
+			input: types.KubernetesResource{Kind: "namespaces", Name: "staging", Verbs: []string{types.KubeVerbList}},
+		},
+		{
+			name: "explicit namespace rule matched by name",
+			verb: types.KubeVerbGet,
+			allowed: []types.KubernetesResource{
+				{Kind: "namespaces", Name: "default", Verbs: []string{types.KubeVerbGet}},
+			},
+			input: types.KubernetesResource{Kind: "namespaces", Name: "default", Verbs: []string{types.KubeVerbGet}},
+		},
+		{
+			name: "explicit namespace rule does not match different name",
+			verb: types.KubeVerbGet,
+			allowed: []types.KubernetesResource{
+				{Kind: "namespaces", Name: "default", Verbs: []string{types.KubeVerbGet}},
+			},
+			input: types.KubernetesResource{Kind: "namespaces", Name: "staging", Verbs: []string{types.KubeVerbGet}},
+		},
+		{
+			name: "wildcard kind with wildcard namespace uses name as target",
+			verb: types.KubeVerbGet,
+			allowed: []types.KubernetesResource{
+				{Kind: types.Wildcard, APIGroup: types.Wildcard, Namespace: types.Wildcard, Name: types.Wildcard, Verbs: []string{types.Wildcard}},
+			},
+			input: types.KubernetesResource{Kind: "namespaces", Name: "anything", Verbs: []string{types.KubeVerbGet}},
+		},
+		{
+			name: "deny rule blocks namespace visibility",
+			verb: types.KubeVerbGet,
+			allowed: []types.KubernetesResource{
+				{Kind: types.Wildcard, APIGroup: types.Wildcard, Namespace: types.Wildcard, Name: types.Wildcard, Verbs: []string{types.Wildcard}},
+			},
+			denied: []types.KubernetesResource{
+				{Kind: types.Wildcard, APIGroup: types.Wildcard, Namespace: types.Wildcard, Name: types.Wildcard, Verbs: []string{types.Wildcard}},
+			},
+			input: types.KubernetesResource{Kind: "namespaces", Name: "default", Verbs: []string{types.KubeVerbGet}},
+		},
+		{
+			name: "pod rule does not grant write access to namespace",
+			verb: types.KubeVerbUpdate,
+			allowed: []types.KubernetesResource{
+				{Kind: types.KindKubePod, Namespace: "production", Name: "*", Verbs: []string{types.Wildcard}},
+			},
+			input: types.KubernetesResource{Kind: "namespaces", Name: "production", Verbs: []string{types.KubeVerbUpdate}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			mr := metaResource{
+				requestedResource: apiResource{resourceKind: "namespaces"},
+				verb:              tt.verb,
+			}
+			log := slog.New(slog.DiscardHandler)
+			m := newMatcher(mr, tt.allowed, tt.denied, log)
+			require.IsType(t, &defaultMatcher{}, m)
+
+			expected, err := matchKubernetesResource(tt.input, true, tt.allowed, tt.denied)
+			require.NoError(t, err)
+
+			got, err := m.match(tt.input.Name, tt.input.Namespace)
+			require.NoError(t, err)
+			require.Equal(t, expected, got)
+		})
+	}
+}
+
+// TestMatcherEquivalence verifies that fastMatcher and defaultMatcher produce the same results.
+// The original function is the source of truth, no hardcoded expected values.
+func TestMatcherEquivalence(t *testing.T) {
+	t.Parallel()
+
+	type input struct {
+		resource              types.KubernetesResource
+		isClusterWideResource bool
+	}
+	pod := func(ns, name string) input {
+		return input{resource: types.KubernetesResource{Kind: types.KindKubePod, Namespace: ns, Name: name, Verbs: []string{types.KubeVerbList}, APIGroup: ""}}
+	}
+	deploy := func(ns, name, apiGroup string) input {
+		return input{resource: types.KubernetesResource{Kind: types.KindKubeDeployment, Namespace: ns, Name: name, Verbs: []string{types.KubeVerbList}, APIGroup: apiGroup}}
+	}
+
+	tests := []struct {
+		name     string
+		kind     string
+		verb     string
+		apiGroup string
+		allowed  []types.KubernetesResource
+		denied   []types.KubernetesResource
+		inputs   []input
+	}{
+		// -- allow rule patterns --
+		{
+			name: "wildcard allows everything",
+			kind: types.KindKubePod,
+			verb: types.KubeVerbList,
+			allowed: []types.KubernetesResource{
+				{Kind: types.KindKubePod, Namespace: "*", Name: "*", Verbs: []string{types.KubeVerbList}, APIGroup: "*"},
+			},
+			inputs: []input{
+				pod("default", "nginx"),
+				pod("kube-system", "coredns"),
+				pod("", "orphan"),
+			},
+		},
+		{
+			name: "exact namespace and name matching",
+			kind: types.KindKubePod,
+			verb: types.KubeVerbList,
+			allowed: []types.KubernetesResource{
+				{Kind: types.KindKubePod, Namespace: "default", Name: "nginx", Verbs: []string{types.KubeVerbList}, APIGroup: ""},
+			},
+			inputs: []input{
+				pod("default", "nginx"),
+				pod("default", "redis"),
+				pod("kube-system", "nginx"),
+			},
+		},
+		{
+			name: "glob name pattern",
+			kind: types.KindKubePod,
+			verb: types.KubeVerbList,
+			allowed: []types.KubernetesResource{
+				{Kind: types.KindKubePod, Namespace: "*", Name: "nginx-*", Verbs: []string{types.KubeVerbList}, APIGroup: ""},
+			},
+			inputs: []input{
+				pod("default", "nginx-deployment-abc123"),
+				pod("default", "redis"),
+			},
+		},
+		{
+			name: "regex name pattern",
+			kind: types.KindKubePod,
+			verb: types.KubeVerbList,
+			allowed: []types.KubernetesResource{
+				{Kind: types.KindKubePod, Namespace: "*", Name: "^nginx-[a-z]+$", Verbs: []string{types.KubeVerbList}, APIGroup: ""},
+			},
+			inputs: []input{
+				pod("default", "nginx-deployment"),
+				pod("default", "nginx-123"),
+				pod("default", "redis"),
+			},
+		},
+		{
+			name: "multiple allow rules",
+			kind: types.KindKubePod,
+			verb: types.KubeVerbList,
+			allowed: []types.KubernetesResource{
+				{Kind: types.KindKubePod, Namespace: "default", Name: "*", Verbs: []string{types.KubeVerbList}, APIGroup: ""},
+				{Kind: types.KindKubePod, Namespace: "staging", Name: "*", Verbs: []string{types.KubeVerbList}, APIGroup: ""},
+			},
+			inputs: []input{
+				pod("default", "nginx"),
+				pod("staging", "nginx"),
+				pod("production", "nginx"),
+			},
+		},
+		{
+			name:    "no allow rules means no access",
+			kind:    types.KindKubePod,
+			verb:    types.KubeVerbList,
+			allowed: []types.KubernetesResource{},
+			inputs: []input{
+				pod("default", "nginx"),
+			},
+		},
+		{
+			name: "empty namespace input with specific and wildcard rules",
+			kind: types.KindKubePod,
+			verb: types.KubeVerbList,
+			allowed: []types.KubernetesResource{
+				{Kind: types.KindKubePod, Namespace: "default", Name: "*", Verbs: []string{types.KubeVerbList}, APIGroup: ""},
+				{Kind: types.KindKubePod, Namespace: "*", Name: "*", Verbs: []string{types.KubeVerbList}, APIGroup: ""},
+			},
+			inputs: []input{
+				pod("", "nginx"),
+				pod("default", "nginx"),
+			},
+		},
+		{
+			name:     "apigroup match",
+			kind:     types.KindKubeDeployment,
+			verb:     types.KubeVerbList,
+			apiGroup: "apps",
+			allowed: []types.KubernetesResource{
+				{Kind: types.KindKubeDeployment, Namespace: "*", Name: "*", Verbs: []string{types.KubeVerbList}, APIGroup: "apps"},
+			},
+			inputs: []input{
+				deploy("default", "nginx", "apps"),
+			},
+		},
+		{
+			name:     "apigroup mismatch",
+			kind:     types.KindKubeDeployment,
+			verb:     types.KubeVerbList,
+			apiGroup: "extensions",
+			allowed: []types.KubernetesResource{
+				{Kind: types.KindKubeDeployment, Namespace: "*", Name: "*", Verbs: []string{types.KubeVerbList}, APIGroup: "apps"},
+			},
+			inputs: []input{
+				deploy("default", "nginx", "extensions"),
+			},
+		},
+		// -- glob and exact patterns with deny --
+		{
+			name: "glob and exact patterns with deny",
+			kind: types.KindKubePod,
+			verb: types.KubeVerbList,
+			allowed: []types.KubernetesResource{
+				{Kind: types.KindKubePod, Namespace: "default", Name: "nginx-*", Verbs: []string{types.KubeVerbList}, APIGroup: ""},
+				{Kind: types.KindKubePod, Namespace: "staging", Name: "*", Verbs: []string{types.KubeVerbList}, APIGroup: ""},
+				{Kind: types.Wildcard, Namespace: "monitoring", Name: "*", Verbs: []string{types.Wildcard}, APIGroup: "*"},
+			},
+			denied: []types.KubernetesResource{
+				{Kind: types.KindKubePod, Namespace: "staging", Name: "secret-*", Verbs: []string{types.KubeVerbList}, APIGroup: ""},
+			},
+			inputs: []input{
+				pod("default", "nginx-abc"),
+				pod("default", "redis"),
+				pod("staging", "app"),
+				pod("staging", "secret-data"),
+				pod("monitoring", "prometheus"),
+				pod("production", "app"),
+				pod("", "orphan"),
+				{resource: types.KubernetesResource{Kind: types.KindKubePod, Namespace: "", Name: "cluster-wide-pod", Verbs: []string{types.KubeVerbList}, APIGroup: ""}, isClusterWideResource: true},
+			},
+		},
+		// -- deny rule patterns --
+		{
+			name: "deny with exact namespace",
+			kind: types.KindKubePod,
+			verb: types.KubeVerbList,
+			allowed: []types.KubernetesResource{
+				{Kind: types.KindKubePod, Namespace: "*", Name: "*", Verbs: []string{types.KubeVerbList}, APIGroup: "*"},
+			},
+			denied: []types.KubernetesResource{
+				{Kind: types.KindKubePod, Namespace: "kube-system", Name: "*", Verbs: []string{types.KubeVerbList}, APIGroup: "*"},
+			},
+			inputs: []input{
+				pod("kube-system", "coredns"),
+				pod("default", "nginx"),
+			},
+		},
+		{
+			name: "deny with regex namespace pattern",
+			kind: types.KindKubePod,
+			verb: types.KubeVerbList,
+			allowed: []types.KubernetesResource{
+				{Kind: types.KindKubePod, Namespace: "*", Name: "*", Verbs: []string{types.KubeVerbList}, APIGroup: ""},
+			},
+			denied: []types.KubernetesResource{
+				{Kind: types.KindKubePod, Namespace: "^kube-.*$", Name: "*", Verbs: []string{types.KubeVerbList}, APIGroup: ""},
+			},
+			inputs: []input{
+				pod("kube-system", "coredns"),
+				pod("kube-public", "info"),
+				pod("default", "nginx"),
+			},
+		},
+		{
+			name: "deny with regex name pattern",
+			kind: types.KindKubePod,
+			verb: types.KubeVerbList,
+			allowed: []types.KubernetesResource{
+				{Kind: types.KindKubePod, Namespace: "*", Name: "*", Verbs: []string{types.KubeVerbList}, APIGroup: ""},
+			},
+			denied: []types.KubernetesResource{
+				{Kind: types.KindKubePod, Namespace: "*", Name: "^(secret|internal)-.*$", Verbs: []string{types.KubeVerbList}, APIGroup: ""},
+			},
+			inputs: []input{
+				pod("default", "secret-data"),
+				pod("default", "internal-api"),
+				pod("default", "nginx"),
+				pod("default", "secret"),
+			},
+		},
+		{
+			name: "deny with glob name pattern",
+			kind: types.KindKubePod,
+			verb: types.KubeVerbList,
+			allowed: []types.KubernetesResource{
+				{Kind: types.KindKubePod, Namespace: "*", Name: "*", Verbs: []string{types.KubeVerbList}, APIGroup: "*"},
+			},
+			denied: []types.KubernetesResource{
+				{Kind: types.KindKubePod, Namespace: "*", Name: "secret-*", Verbs: []string{types.KubeVerbList}, APIGroup: "*"},
+			},
+			inputs: []input{
+				pod("default", "secret-data"),
+				pod("default", "nginx"),
+			},
+		},
+		{
+			name: "deny with exact name",
+			kind: types.KindKubePod,
+			verb: types.KubeVerbList,
+			allowed: []types.KubernetesResource{
+				{Kind: types.KindKubePod, Namespace: "*", Name: "*", Verbs: []string{types.KubeVerbList}, APIGroup: "*"},
+			},
+			denied: []types.KubernetesResource{
+				{Kind: types.KindKubePod, Namespace: "*", Name: "secret-data", Verbs: []string{types.KubeVerbList}, APIGroup: "*"},
+			},
+			inputs: []input{
+				pod("default", "secret-data"),
+				pod("default", "secret-other"),
+				pod("default", "nginx"),
+			},
+		},
+		{
+			name: "multiple deny rules with mixed patterns",
+			kind: types.KindKubePod,
+			verb: types.KubeVerbList,
+			allowed: []types.KubernetesResource{
+				{Kind: types.KindKubePod, Namespace: "*", Name: "*", Verbs: []string{types.KubeVerbList}, APIGroup: ""},
+			},
+			denied: []types.KubernetesResource{
+				{Kind: types.KindKubePod, Namespace: "kube-system", Name: "*", Verbs: []string{types.KubeVerbList}, APIGroup: ""},
+				{Kind: types.KindKubePod, Namespace: "*", Name: "secret-*", Verbs: []string{types.KubeVerbList}, APIGroup: ""},
+			},
+			inputs: []input{
+				pod("kube-system", "coredns"),
+				pod("default", "secret-data"),
+				pod("default", "nginx"),
+				pod("kube-system", "secret-data"),
+			},
+		},
+		{
+			name: "deny with glob namespace pattern",
+			kind: types.KindKubePod,
+			verb: types.KubeVerbList,
+			allowed: []types.KubernetesResource{
+				{Kind: types.KindKubePod, Namespace: "*", Name: "*", Verbs: []string{types.KubeVerbList}, APIGroup: ""},
+			},
+			denied: []types.KubernetesResource{
+				{Kind: types.KindKubePod, Namespace: "kube-*", Name: "*", Verbs: []string{types.KubeVerbList}, APIGroup: ""},
+			},
+			inputs: []input{
+				pod("kube-system", "coredns"),
+				pod("kube-public", "info"),
+				pod("default", "nginx"),
+			},
+		},
+		{
+			name:     "deny with regex apigroup",
+			kind:     types.KindKubeDeployment,
+			verb:     types.KubeVerbList,
+			apiGroup: "apps",
+			allowed: []types.KubernetesResource{
+				{Kind: types.KindKubeDeployment, Namespace: "*", Name: "*", Verbs: []string{types.KubeVerbList}, APIGroup: "*"},
+			},
+			denied: []types.KubernetesResource{
+				{Kind: types.KindKubeDeployment, Namespace: "*", Name: "*", Verbs: []string{types.KubeVerbList}, APIGroup: "^apps|extensions$"},
+			},
+			inputs: []input{
+				deploy("default", "nginx", "apps"),
+				deploy("staging", "redis", "apps"),
+			},
+		},
+		{
+			name: "narrow allow with overlapping deny",
+			kind: types.KindKubePod,
+			verb: types.KubeVerbList,
+			allowed: []types.KubernetesResource{
+				{Kind: types.KindKubePod, Namespace: "default", Name: "nginx-*", Verbs: []string{types.KubeVerbList}, APIGroup: ""},
+			},
+			denied: []types.KubernetesResource{
+				{Kind: types.KindKubePod, Namespace: "*", Name: "nginx-secret", Verbs: []string{types.KubeVerbList}, APIGroup: ""},
+			},
+			inputs: []input{
+				pod("default", "nginx-web"),
+				pod("default", "nginx-secret"),
+				pod("default", "redis"),
+				pod("staging", "nginx-web"),
+			},
+		},
+		// -- namespace edge cases --
+		{
+			name: "allow with empty namespace rule",
+			kind: types.KindKubePod,
+			verb: types.KubeVerbList,
+			allowed: []types.KubernetesResource{
+				{Kind: types.KindKubePod, Namespace: "", Name: "*", Verbs: []string{types.KubeVerbList}, APIGroup: ""},
+			},
+			inputs: []input{
+				pod("default", "nginx"),
+				pod("", "orphan"),
+				{resource: types.KubernetesResource{Kind: types.KindKubePod, Namespace: "", Name: "orphan", Verbs: []string{types.KubeVerbList}, APIGroup: ""}, isClusterWideResource: true},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			mr := metaResource{
+				requestedResource: apiResource{resourceKind: tc.kind, apiGroup: tc.apiGroup},
+				verb:              tc.verb,
+			}
+
+			log := slog.New(slog.DiscardHandler)
+			fm := newMatcher(mr, tc.allowed, tc.denied, log)
+			require.IsType(t, &fastMatcher{}, fm)
+
+			dm := &defaultMatcher{
+				kind:             tc.kind,
+				verb:             tc.verb,
+				apiGroup:         tc.apiGroup,
+				allowedResources: tc.allowed,
+				deniedResources:  tc.denied,
+			}
+
+			for _, tt := range tc.inputs {
+				t.Run(fmt.Sprintf("%s/%s", tt.resource.Namespace, tt.resource.Name), func(t *testing.T) {
+					t.Parallel()
+
+					// Use the original matchKubernetesResource as source of truth.
+					expected, err := matchKubernetesResource(tt.resource, tt.isClusterWideResource, tc.allowed, tc.denied)
+					require.NoError(t, err)
+
+					fastResult, err := fm.match(tt.resource.Name, tt.resource.Namespace)
+					require.NoError(t, err)
+					require.Equal(t, expected, fastResult, "fastMatcher mismatch for %s/%s", tt.resource.Namespace, tt.resource.Name)
+
+					defaultResult, err := dm.match(tt.resource.Name, tt.resource.Namespace)
+					require.NoError(t, err)
+					require.Equal(t, expected, defaultResult, "defaultMatcher mismatch for %s/%s", tt.resource.Namespace, tt.resource.Name)
+				})
+			}
+		})
+	}
+}
+
+// TestMatcherEquivalenceMatrix generates a cross product of rule patterns and resource inputs.
+// Then verifies fastMatcher, defaultMatcher and the original matchKubernetesResource all agree.
+// This catches regressions that hand-picked cases might miss.
+func TestMatcherEquivalenceMatrix(t *testing.T) {
+	t.Parallel()
+
+	// Rule patterns covering literals, globs, regexes, wildcards, and empty strings.
+	namePatterns := []string{"nginx", "nginx-*", "^nginx-[a-z]+$", "*", ""}
+	nsPatterns := []string{"default", "kube-*", "^staging-.*$", "*", ""}
+	apiGroupPatterns := []string{"", "apps", "*"}
+
+	// Resources to match against each rule set.
+	names := []string{"nginx", "nginx-web", "nginx-123", "redis", ""}
+	namespaces := []string{"default", "kube-system", "staging-prod", "other", ""}
+	apiGroups := []string{"", "apps"}
+
+	kind := types.KindKubePod
+	verb := types.KubeVerbList
+
+	for _, nameP := range namePatterns {
+		for _, nsP := range nsPatterns {
+			for _, agP := range apiGroupPatterns {
+				allowed := []types.KubernetesResource{
+					{Kind: kind, Namespace: nsP, Name: nameP, Verbs: []string{verb}, APIGroup: agP},
+				}
+
+				for _, inputName := range names {
+					for _, inputNS := range namespaces {
+						for _, inputAG := range apiGroups {
+							mr := metaResource{
+								requestedResource: apiResource{resourceKind: kind, apiGroup: inputAG},
+								verb:              verb,
+							}
+							log := slog.New(slog.DiscardHandler)
+							m := newMatcher(mr, allowed, nil, log)
+							fm, ok := m.(*fastMatcher)
+							if !ok {
+								// Invalid regex — fell back to defaultMatcher. Skip.
+								continue
+							}
+
+							resource := types.KubernetesResource{
+								Kind: kind, Namespace: inputNS, Name: inputName,
+								Verbs: []string{verb}, APIGroup: inputAG,
+							}
+
+							expected, err := matchKubernetesResource(resource, false, allowed, nil)
+							if err != nil {
+								continue
+							}
+
+							fastResult, err := fm.match(inputName, inputNS)
+							if err != nil {
+								continue
+							}
+
+							dm := &defaultMatcher{
+								kind: kind, verb: verb, apiGroup: inputAG,
+								allowedResources: allowed,
+							}
+							defaultResult, err := dm.match(inputName, inputNS)
+							if err != nil {
+								continue
+							}
+
+							label := fmt.Sprintf("allow[ns=%q,name=%q,ag=%q]/input[ns=%q,name=%q,ag=%q]",
+								nsP, nameP, agP, inputNS, inputName, inputAG)
+
+							if fastResult != expected {
+								t.Errorf("fastMatcher mismatch: %s: got %v, want %v", label, fastResult, expected)
+							}
+							if defaultResult != expected {
+								t.Errorf("defaultMatcher mismatch: %s: got %v, want %v", label, defaultResult, expected)
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+}
+
+// buildUnstructuredList creates an unstructured list with the given items for benchmarks.
+func buildUnstructuredList(listKind, apiVersion string, items []map[string]any) *unstructured.Unstructured {
+	anyItems := make([]any, len(items))
+	for i, item := range items {
+		anyItems[i] = item
+	}
+	return &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": apiVersion,
+			"kind":       listKind,
+			"metadata":   map[string]any{"resourceVersion": ""},
+			"items":      anyItems,
+		},
+	}
+}
+
+// BenchmarkFilterObj benchmarks the full FilterObj path through newResourceFilterer,
+// comparing fast matcher vs fallback at different item and rule counts.
+func BenchmarkFilterObj(b *testing.B) {
+	log := slog.New(slog.DiscardHandler)
+
+	mr := metaResource{
+		requestedResource: apiResource{
+			resourceKind: types.KindKubePod,
+			apiGroup:     "",
+		},
+		resourceDefinition: &metav1.APIResource{Namespaced: true},
+		verb:               types.KubeVerbList,
+	}
+
+	namespaces := []string{"default", "staging", "monitoring", "kube-system", "production"}
+
+	buildRules := func(ruleCount int) (allowed, denied []types.KubernetesResource) {
+		for i := range ruleCount {
+			allowed = append(allowed, types.KubernetesResource{
+				Kind:      types.KindKubePod,
+				Namespace: namespaces[i%len(namespaces)],
+				Name:      fmt.Sprintf("app-%d-*", i),
+				Verbs:     []string{types.KubeVerbList},
+				APIGroup:  "",
+			})
+		}
+		denied = []types.KubernetesResource{
+			{Kind: types.KindKubePod, Namespace: "default", Name: "secret-*", Verbs: []string{types.KubeVerbList}, APIGroup: ""},
+		}
+		return allowed, denied
+	}
+
+	buildItems := func(count int) ([]map[string]any, []any) {
+		items := make([]map[string]any, count)
+		for i := range items {
+			items[i] = map[string]any{
+				"apiVersion": "v1",
+				"kind":       "Pod",
+				"metadata": map[string]any{
+					"name":      fmt.Sprintf("pod-%d", i),
+					"namespace": namespaces[i%len(namespaces)],
+				},
+			}
+		}
+		saved := make([]any, len(items))
+		for i, item := range items {
+			saved[i] = item
+		}
+		return items, saved
+	}
+
+	newFilterer := func(b *testing.B, items []map[string]any, allowed, denied []types.KubernetesResource, useFastMatcher bool) (*resourceFilterer, *unstructured.Unstructured) {
+		b.Helper()
+		wrapper := newResourceFilterer(mr, &globalKubeCodecs, allowed, denied, log)
+		filter, err := wrapper(responsewriters.DefaultContentType, 200)
+		require.NoError(b, err)
+		rf := filter.(*resourceFilterer)
+		if useFastMatcher {
+			require.IsType(b, &fastMatcher{}, rf.matcher)
+		} else {
+			rf.matcher = &defaultMatcher{
+				kind:             mr.requestedResource.resourceKind,
+				verb:             mr.verb,
+				apiGroup:         mr.requestedResource.apiGroup,
+				isClusterWide:    mr.isClusterWideResource(),
+				allowedResources: allowed,
+				deniedResources:  denied,
+			}
+		}
+		obj := buildUnstructuredList("PodList", "v1", items)
+		return rf, obj
+	}
+
+	for _, ruleCount := range []int{4, 50, 150, 4000} {
+		allowed, denied := buildRules(ruleCount)
+
+		for _, itemCount := range []int{500, 5000} {
+			items, savedItems := buildItems(itemCount)
+			prefix := fmt.Sprintf("%d_rules/%d_items", ruleCount, itemCount)
+
+			b.Run(prefix+"/fast_matcher", func(b *testing.B) {
+				rf, obj := newFilterer(b, items, allowed, denied, true)
+				require.IsType(b, &fastMatcher{}, rf.matcher)
+				b.ReportAllocs()
+				b.ResetTimer()
+				for b.Loop() {
+					obj.Object["items"] = savedItems
+					rf.FilterObj(obj)
+				}
+			})
+
+			b.Run(prefix+"/default_matcher", func(b *testing.B) {
+				rf, obj := newFilterer(b, items, allowed, denied, false)
+				require.IsType(b, &defaultMatcher{}, rf.matcher)
+				b.ReportAllocs()
+				b.ResetTimer()
+				for b.Loop() {
+					obj.Object["items"] = savedItems
+					rf.FilterObj(obj)
+				}
+			})
+		}
+	}
+}

--- a/lib/kube/proxy/fast_matcher_test.go
+++ b/lib/kube/proxy/fast_matcher_test.go
@@ -302,7 +302,7 @@ func TestNamespaceKindFallback(t *testing.T) {
 			expected, err := matchKubernetesResource(tt.input, true, tt.allowed, tt.denied)
 			require.NoError(t, err)
 
-			got, err := m.match(tt.input.Name, tt.input.Namespace)
+			got, err := m.Match(tt.input.Name, tt.input.Namespace)
 			require.NoError(t, err)
 			require.Equal(t, expected, got)
 		})
@@ -662,11 +662,11 @@ func TestMatcherEquivalence(t *testing.T) {
 					expected, err := matchKubernetesResource(tt.resource, tt.isClusterWideResource, tc.allowed, tc.denied)
 					require.NoError(t, err)
 
-					fastResult, err := fm.match(tt.resource.Name, tt.resource.Namespace)
+					fastResult, err := fm.Match(tt.resource.Name, tt.resource.Namespace)
 					require.NoError(t, err)
 					require.Equal(t, expected, fastResult, "fastMatcher mismatch for %s/%s", tt.resource.Namespace, tt.resource.Name)
 
-					defaultResult, err := dm.match(tt.resource.Name, tt.resource.Namespace)
+					defaultResult, err := dm.Match(tt.resource.Name, tt.resource.Namespace)
 					require.NoError(t, err)
 					require.Equal(t, expected, defaultResult, "defaultMatcher mismatch for %s/%s", tt.resource.Namespace, tt.resource.Name)
 				})
@@ -726,7 +726,7 @@ func TestMatcherEquivalenceMatrix(t *testing.T) {
 								continue
 							}
 
-							fastResult, err := fm.match(inputName, inputNS)
+							fastResult, err := fm.Match(inputName, inputNS)
 							if err != nil {
 								continue
 							}
@@ -735,7 +735,7 @@ func TestMatcherEquivalenceMatrix(t *testing.T) {
 								kind: kind, verb: verb, apiGroup: inputAG,
 								allowedResources: allowed,
 							}
-							defaultResult, err := dm.match(inputName, inputNS)
+							defaultResult, err := dm.Match(inputName, inputNS)
 							if err != nil {
 								continue
 							}
@@ -826,7 +826,7 @@ func BenchmarkFilterObj(b *testing.B) {
 
 	newFilterer := func(b *testing.B, items []map[string]any, allowed, denied []types.KubernetesResource, useFastMatcher bool) (*resourceFilterer, *unstructured.Unstructured) {
 		b.Helper()
-		wrapper := newResourceFilterer(mr, &globalKubeCodecs, allowed, denied, log)
+		wrapper := newResourceFilterer(mr, &globalKubeCodecs, newMatcher(mr, allowed, denied, log), log)
 		filter, err := wrapper(responsewriters.DefaultContentType, 200)
 		require.NoError(b, err)
 		rf := filter.(*resourceFilterer)

--- a/lib/kube/proxy/filtering_response_writer.go
+++ b/lib/kube/proxy/filtering_response_writer.go
@@ -1,0 +1,184 @@
+/*
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package proxy
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"maps"
+	"net/http"
+	"strings"
+	"sync"
+
+	"github.com/gravitational/trace"
+	semconv "go.opentelemetry.io/otel/semconv/v1.4.0"
+	oteltrace "go.opentelemetry.io/otel/trace"
+
+	"github.com/gravitational/teleport/lib/kube/proxy/responsewriters"
+	"github.com/gravitational/teleport/lib/kube/proxy/streamfilter"
+)
+
+// filteringResponseWriter is an http.ResponseWriter that intercepts the upstream response,
+// inspects headers to decide between streaming and buffered filtering, and routes the body accordingly.
+type filteringResponseWriter struct {
+	target  http.ResponseWriter
+	headers http.Header
+	status  int
+	body    io.Writer
+	once    sync.Once
+
+	matcher         resourceMatcher
+	filterWrapper   responsewriters.FilterWrapper
+	log             *slog.Logger
+	ctx             context.Context
+	tracer          oteltrace.Tracer
+	kubeServiceType string
+
+	pipeWriter *io.PipeWriter
+	memBuffer  *responsewriters.MemoryResponseWriter
+	filterErr  error
+	filterDone chan struct{} // closed when the streaming goroutine finishes
+	streaming  bool
+}
+
+func newFilteringResponseWriter(
+	target http.ResponseWriter,
+	matcher resourceMatcher,
+	filterWrapper responsewriters.FilterWrapper,
+	log *slog.Logger,
+	ctx context.Context,
+	tracer oteltrace.Tracer,
+	kubeServiceType string,
+) *filteringResponseWriter {
+	return &filteringResponseWriter{
+		target:          target,
+		headers:         make(http.Header),
+		matcher:         matcher,
+		filterWrapper:   filterWrapper,
+		log:             log,
+		ctx:             ctx,
+		tracer:          tracer,
+		kubeServiceType: kubeServiceType,
+	}
+}
+
+func (fw *filteringResponseWriter) Header() http.Header {
+	return fw.headers
+}
+
+func (fw *filteringResponseWriter) WriteHeader(statusCode int) {
+	fw.once.Do(func() {
+		fw.status = statusCode
+
+		if statusCode == http.StatusOK {
+			if fw.tryStreaming() {
+				return
+			}
+		}
+
+		fw.memBuffer = responsewriters.NewMemoryResponseWriter()
+		maps.Copy(fw.memBuffer.Header(), fw.headers)
+		fw.memBuffer.WriteHeader(statusCode)
+		fw.body = fw.memBuffer.Buffer()
+	})
+}
+
+// tryStreaming attempts to set up the streaming filter path.
+// Returns true if streaming was activated, false to fall back to buffered.
+func (fw *filteringResponseWriter) tryStreaming() bool {
+	contentType := responsewriters.GetContentTypeHeader(fw.headers)
+	if !strings.Contains(contentType, "application/json") {
+		return false
+	}
+	sf := streamfilter.NewJSONFilter(fw.matcher, fw.log)
+
+	contentEncoding := fw.headers.Get("Content-Encoding")
+	if contentEncoding != "" && contentEncoding != "identity" && contentEncoding != "gzip" {
+		fw.log.WarnContext(fw.ctx, "Unexpected Content-Encoding, falling back to buffered filter", "content_encoding", contentEncoding)
+		return false
+	}
+
+	maps.Copy(fw.target.Header(), fw.headers)
+	fw.target.Header().Del("Content-Length")
+	fw.target.WriteHeader(fw.status)
+
+	pr, pw := io.Pipe()
+	fw.pipeWriter = pw
+	fw.streaming = true
+	fw.filterDone = make(chan struct{})
+	fw.body = pw
+
+	// wrapContentEncoding is called inside the goroutine because gzip.NewReader
+	// reads the gzip header from the pipe, which blocks until Write provides data.
+	// Calling it here in WriteHeader would deadlock.
+	go func() {
+		defer close(fw.filterDone)
+		// Close the read end of the pipe when done to unblock any pending
+		// pipeWriter.Write in ServeHTTP (e.g. if the filter exits early
+		// due to a client disconnect).
+		defer pr.Close()
+		src, dst, err := wrapContentEncoding(pr, fw.target, contentEncoding)
+		if err != nil {
+			fw.filterErr = trace.ConnectionProblem(err, "failed to initialize content encoding wrapper for %q", contentEncoding)
+			fw.log.ErrorContext(fw.ctx, "Streaming filter content encoding setup failed", "error", fw.filterErr)
+			return
+		}
+		filterErr := sf.Filter(src, dst)
+		fw.filterErr = trace.NewAggregate(filterErr, dst.Close(), src.Close())
+		if fw.filterErr != nil {
+			fw.log.ErrorContext(fw.ctx, "Streaming filter failed mid-write, client received truncated response", "error", fw.filterErr)
+		}
+	}()
+	return true
+}
+
+func (fw *filteringResponseWriter) Write(b []byte) (int, error) {
+	fw.WriteHeader(http.StatusOK)
+	return fw.body.Write(b)
+}
+
+// Finish completes filtering and returns the status code and any error.
+func (fw *filteringResponseWriter) Finish() (int, error) {
+	if fw.status == 0 {
+		return http.StatusBadGateway, trace.ConnectionProblem(nil, "upstream closed without response")
+	}
+
+	if fw.streaming {
+		fw.pipeWriter.Close()
+		<-fw.filterDone
+		return fw.status, fw.filterErr
+	}
+
+	_, filterSpan := fw.tracer.Start(fw.ctx, "kube.Forwarder/listResourcesList/filterBuffer",
+		oteltrace.WithSpanKind(oteltrace.SpanKindServer),
+		oteltrace.WithAttributes(
+			semconv.RPCServiceKey.String(fw.kubeServiceType),
+			semconv.RPCSystemKey.String("kube"),
+		),
+	)
+	err := filterBuffer(fw.filterWrapper, fw.memBuffer)
+	filterSpan.End()
+	if err != nil {
+		return fw.memBuffer.Status(), trace.Wrap(err)
+	}
+
+	err = fw.memBuffer.CopyInto(fw.target)
+	return fw.memBuffer.Status(), trace.Wrap(err)
+}

--- a/lib/kube/proxy/filtering_response_writer_test.go
+++ b/lib/kube/proxy/filtering_response_writer_test.go
@@ -1,0 +1,160 @@
+/*
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package proxy
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/trace/noop"
+
+	"github.com/gravitational/teleport/lib/utils/log/logtest"
+)
+
+// fwTestMatcher is a mock resourceMatcher for filteringResponseWriter tests.
+type fwTestMatcher struct {
+	allowFn func(name, namespace string) (bool, error)
+}
+
+func (m *fwTestMatcher) Match(name, ns string) (bool, error) { return m.allowFn(name, ns) }
+
+func fwMatcherAllowAll() *fwTestMatcher {
+	return &fwTestMatcher{allowFn: func(_, _ string) (bool, error) { return true, nil }}
+}
+
+func fwMatcherAllowNamespace(ns string) *fwTestMatcher {
+	return &fwTestMatcher{allowFn: func(_, namespace string) (bool, error) { return namespace == ns, nil }}
+}
+
+func newTestFW(t *testing.T, matcher resourceMatcher) (*filteringResponseWriter, *httptest.ResponseRecorder) {
+	t.Helper()
+	rec := httptest.NewRecorder()
+	fw := newFilteringResponseWriter(
+		rec,
+		matcher,
+		nil,
+		logtest.NewLogger(),
+		t.Context(),
+		noop.NewTracerProvider().Tracer("test"),
+		"test",
+	)
+	t.Cleanup(func() { fw.Finish() })
+	return fw, rec
+}
+
+func TestFilteringResponseWriter_routing(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		ct        string
+		encoding  string
+		status    int
+		streaming bool
+	}{
+		{"json 200 streams", "application/json", "", http.StatusOK, true},
+		{"json with charset streams", "application/json; charset=utf-8", "", http.StatusOK, true},
+		{"json table streams", "application/json;as=Table;g=meta.k8s.io;v=v1", "", http.StatusOK, true},
+		{"empty ct defaults to json", "", "", http.StatusOK, true},
+		{"identity encoding streams", "application/json", "identity", http.StatusOK, true},
+		{"gzip encoding streams", "application/json", "gzip", http.StatusOK, true},
+		{"protobuf buffers", "application/vnd.kubernetes.protobuf", "", http.StatusOK, false},
+		{"yaml buffers", "application/yaml", "", http.StatusOK, false},
+		{"non-200 buffers", "application/json", "", http.StatusForbidden, false},
+		{"unsupported encoding buffers", "application/json", "br", http.StatusOK, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			fw, _ := newTestFW(t, fwMatcherAllowAll())
+			if tt.ct != "" {
+				fw.Header().Set("Content-Type", tt.ct)
+			}
+			if tt.encoding != "" {
+				fw.Header().Set("Content-Encoding", tt.encoding)
+			}
+			fw.WriteHeader(tt.status)
+			require.Equal(t, tt.streaming, fw.streaming)
+			if !tt.streaming {
+				require.NotNil(t, fw.memBuffer)
+			}
+		})
+	}
+}
+
+func TestFilteringResponseWriter_streaming_filters_items(t *testing.T) {
+	t.Parallel()
+	fw, rec := newTestFW(t, fwMatcherAllowNamespace("default"))
+
+	fw.Header().Set("Content-Type", "application/json")
+	fw.Header().Set("X-Custom", "hello")
+	fw.WriteHeader(http.StatusOK)
+
+	fw.Write([]byte(`{"apiVersion":"v1","kind":"PodList","metadata":{},"items":[` +
+		`{"metadata":{"name":"nginx","namespace":"default"}},` +
+		`{"metadata":{"name":"redis","namespace":"kube-system"}}` +
+		`]}`))
+
+	status, err := fw.Finish()
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, status)
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Empty(t, rec.Header().Get("Content-Length"))
+	require.Equal(t, "hello", rec.Header().Get("X-Custom"))
+
+	body := rec.Body.String()
+	require.Contains(t, body, `"nginx"`)
+	require.NotContains(t, body, `"redis"`)
+}
+
+func TestFilteringResponseWriter_implicit_200(t *testing.T) {
+	t.Parallel()
+	fw, _ := newTestFW(t, fwMatcherAllowAll())
+
+	fw.Header().Set("Content-Type", "application/json")
+	fw.Write([]byte(`{"items":[]}`))
+
+	require.Equal(t, http.StatusOK, fw.status)
+	require.True(t, fw.streaming)
+}
+
+func TestFilteringResponseWriter_finish_no_writeheader(t *testing.T) {
+	t.Parallel()
+	fw, _ := newTestFW(t, fwMatcherAllowAll())
+
+	status, err := fw.Finish()
+	require.Error(t, err)
+	require.Equal(t, http.StatusBadGateway, status)
+}
+
+func TestFilteringResponseWriter_writeheader_idempotent(t *testing.T) {
+	t.Parallel()
+	fw, _ := newTestFW(t, fwMatcherAllowAll())
+
+	fw.Header().Set("Content-Type", "application/json")
+	fw.WriteHeader(http.StatusOK)
+	require.True(t, fw.streaming)
+
+	fw.WriteHeader(http.StatusNotFound)
+	require.Equal(t, http.StatusOK, fw.status)
+	require.True(t, fw.streaming)
+}

--- a/lib/kube/proxy/resource_filters.go
+++ b/lib/kube/proxy/resource_filters.go
@@ -56,15 +56,14 @@ func newResourceFilterer(mr metaResource, codecs *serializer.CodecFactory, allow
 			return nil, trace.Wrap(err)
 		}
 		return &resourceFilterer{
-			encoder:          encoder,
-			decoder:          decoder,
-			contentType:      contentType,
-			responseCode:     responseCode,
-			negotiator:       negotiator,
-			allowedResources: allowedResources,
-			deniedResources:  deniedResources,
-			log:              log,
-			metaResource:     mr,
+			encoder:      encoder,
+			decoder:      decoder,
+			contentType:  contentType,
+			responseCode: responseCode,
+			negotiator:   negotiator,
+			log:          log,
+			metaResource: mr,
+			matcher:      newMatcher(mr, allowedResources, deniedResources, log),
 		}, nil
 	}
 }
@@ -104,16 +103,45 @@ type resourceFilterer struct {
 	// negotiator is an instance of a client negotiator.
 	negotiator runtime.ClientNegotiator
 
-	// allowedResources is the list of kubernetes resources the user has access to.
-	allowedResources []types.KubernetesResource
-	// deniedResources is the list of kubernetes resources the user must not access.
-	deniedResources []types.KubernetesResource
-
 	// log is the logger.
 	log *slog.Logger
 
 	// metaResource contains the information about the resource being filtered.
 	metaResource metaResource
+
+	// matcher is the per-item RBAC matcher (either fast precompiled or fallback per-item).
+	matcher resourceMatcher
+}
+
+// resourceMatcher matches a Kubernetes resource by name and namespace.
+//
+// A Teleport RBAC rule has five fields: kind, verb, apiGroup, namespace, and name.
+// Only name and namespace vary per item in a list response.
+// The rest are constant for the entire request (determined by the URL and HTTP method),
+// so can be resolved once when the matcher is constructed.
+type resourceMatcher interface {
+	match(name, namespace string) (bool, error)
+}
+
+func newMatcher(mr metaResource, allowed, denied []types.KubernetesResource, log *slog.Logger) resourceMatcher {
+	// The fast matcher cannot handle namespace special cases in KubeResourceMatchesRegex
+	// (read-only namespace visibility, namespace kind matching with different target selection).
+	if mr.requestedResource.resourceKind != "namespaces" {
+		fm, err := newFastMatcher(mr, allowed, denied)
+		if err != nil {
+			log.DebugContext(context.Background(), "Failed to compile fast matcher, falling back to per-item matching", "error", err)
+		} else {
+			return fm
+		}
+	}
+	return &defaultMatcher{
+		kind:             mr.requestedResource.resourceKind,
+		verb:             mr.verb,
+		apiGroup:         mr.requestedResource.apiGroup,
+		isClusterWide:    mr.isClusterWideResource(),
+		allowedResources: allowed,
+		deniedResources:  denied,
+	}
 }
 
 // FilterBuffer receives a byte array, decodes the response into the appropriate
@@ -166,11 +194,7 @@ func (d *resourceFilterer) FilterObj(obj runtime.Object) (isAllowed bool, isList
 			return hasElemts, true, nil
 		}
 
-		r := getKubeResource(d.metaResource.requestedResource.resourceKind, d.metaResource.requestedResource.apiGroup, d.metaResource.verb, o)
-		result, err := matchKubernetesResource(
-			r, d.metaResource.isClusterWideResource(),
-			d.allowedResources, d.deniedResources,
-		)
+		result, err := d.matcher.match(o.GetName(), o.GetNamespace())
 		if err != nil {
 			d.log.WarnContext(ctx, "Unable to compile regex expressions within kubernetes_resources", "error", err)
 		}
@@ -178,7 +202,7 @@ func (d *resourceFilterer) FilterObj(obj runtime.Object) (isAllowed bool, isList
 		return result, false, nil
 
 	case *metav1.Table:
-		_, err := d.filterMetaV1Table(o, d.allowedResources, d.deniedResources)
+		_, err := d.filterMetaV1Table(o)
 		if err != nil {
 			return false, false, trace.Wrap(err)
 		}
@@ -278,12 +302,7 @@ type kubeObjectInterface interface {
 
 // filterResource validates if the user should access the current resource.
 func (d *resourceFilterer) filterResource(resource kubeObjectInterface) (bool, error) {
-	result, err := matchKubernetesResource(
-		getKubeResource(d.metaResource.requestedResource.resourceKind, d.metaResource.requestedResource.apiGroup, d.metaResource.verb, resource),
-		d.metaResource.isClusterWideResource(),
-		d.allowedResources, d.deniedResources,
-	)
-	return result, trace.Wrap(err)
+	return d.matcher.match(resource.GetName(), resource.GetNamespace())
 }
 
 func getKubeResource(kind, group, verb string, obj kubeObjectInterface) types.KubernetesResource {
@@ -298,7 +317,7 @@ func getKubeResource(kind, group, verb string, obj kubeObjectInterface) types.Ku
 
 // filterMetaV1Table filters the serverside printed table to exclude resources
 // that the user must not have access to.
-func (d *resourceFilterer) filterMetaV1Table(table *metav1.Table, allowedResources, deniedResources []types.KubernetesResource) (*metav1.Table, error) {
+func (d *resourceFilterer) filterMetaV1Table(table *metav1.Table) (*metav1.Table, error) {
 	resources := make([]metav1.TableRow, 0, len(table.Rows))
 	for i := range table.Rows {
 		row := &(table.Rows[i])
@@ -309,10 +328,10 @@ func (d *resourceFilterer) filterMetaV1Table(table *metav1.Table, allowedResourc
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
-		if result, err := matchKubernetesResource(resource, d.metaResource.isClusterWideResource(), allowedResources, deniedResources); err == nil && result {
-			resources = append(resources, *row)
-		} else if err != nil {
+		if result, err := d.matcher.match(resource.Name, resource.Namespace); err != nil {
 			d.log.WarnContext(context.Background(), "Unable to compile regex expression", "error", err)
+		} else if result {
+			resources = append(resources, *row)
 		}
 	}
 	table.Rows = resources
@@ -441,17 +460,33 @@ func (d *resourceFilterer) filterUnstructuredList(obj *unstructured.Unstructured
 
 	filteredList := make([]any, 0, len(objList.Items))
 	for _, resource := range objList.Items {
-		gvk := resource.GroupVersionKind()
-		r := getKubeResource(d.metaResource.requestedResource.resourceKind, gvk.Group, d.metaResource.verb, &resource)
-		if result, err := matchKubernetesResource(
-			r, d.metaResource.isClusterWideResource(),
-			d.allowedResources, d.deniedResources,
-		); result {
-			filteredList = append(filteredList, resource.Object)
-		} else if err != nil {
+		if result, err := d.matcher.match(resource.GetName(), resource.GetNamespace()); err != nil {
 			slog.WarnContext(context.Background(), "Unable to compile regex expressions within kubernetes_resources", "error", err)
+		} else if result {
+			filteredList = append(filteredList, resource.Object)
 		}
 	}
 	obj.Object[itemsKey] = filteredList
 	return len(filteredList) > 0
+}
+
+// defaultMatcher uses the existing matchKubernetesResource path for per-item matching.
+type defaultMatcher struct {
+	kind             string
+	verb             string
+	apiGroup         string
+	isClusterWide    bool
+	allowedResources []types.KubernetesResource
+	deniedResources  []types.KubernetesResource
+}
+
+func (m *defaultMatcher) match(name, namespace string) (bool, error) {
+	resource := types.KubernetesResource{
+		Kind:      m.kind,
+		Namespace: namespace,
+		Name:      name,
+		Verbs:     []string{m.verb},
+		APIGroup:  m.apiGroup,
+	}
+	return matchKubernetesResource(resource, m.isClusterWide, m.allowedResources, m.deniedResources)
 }

--- a/lib/kube/proxy/resource_filters.go
+++ b/lib/kube/proxy/resource_filters.go
@@ -37,18 +37,18 @@ import (
 	"github.com/gravitational/teleport/lib/kube/proxy/responsewriters"
 )
 
+// needsFiltering returns true if RBAC filtering is required for the given rules.
+func needsFiltering(allowedResources, deniedResources []types.KubernetesResource) bool {
+	return !containsWildcard(allowedResources) || len(deniedResources) != 0
+}
+
 // newResourceFilterer creates a wrapper function that once executed creates
 // a runtime filter for kubernetes resources.
 // The filter exclusion criteria is:
 // - deniedResources: excluded if (namespace,name) matches an entry even if it matches
 // the allowedResources's list.
 // - allowedResources: excluded if (namespace,name) not match a single entry.
-func newResourceFilterer(mr metaResource, codecs *serializer.CodecFactory, allowedResources, deniedResources []types.KubernetesResource, log *slog.Logger) responsewriters.FilterWrapper {
-	// If the list of allowed resources contains a wildcard and no deniedResources, then we
-	// don't need to filter anything.
-	if containsWildcard(allowedResources) && len(deniedResources) == 0 {
-		return nil
-	}
+func newResourceFilterer(mr metaResource, codecs *serializer.CodecFactory, matcher resourceMatcher, log *slog.Logger) responsewriters.FilterWrapper {
 	return func(contentType string, responseCode int) (responsewriters.Filter, error) {
 		negotiator := newClientNegotiator(codecs)
 		encoder, decoder, err := newEncoderAndDecoderForContentType(contentType, negotiator)
@@ -63,7 +63,7 @@ func newResourceFilterer(mr metaResource, codecs *serializer.CodecFactory, allow
 			negotiator:   negotiator,
 			log:          log,
 			metaResource: mr,
-			matcher:      newMatcher(mr, allowedResources, deniedResources, log),
+			matcher:      matcher,
 		}, nil
 	}
 }
@@ -120,7 +120,7 @@ type resourceFilterer struct {
 // The rest are constant for the entire request (determined by the URL and HTTP method),
 // so can be resolved once when the matcher is constructed.
 type resourceMatcher interface {
-	match(name, namespace string) (bool, error)
+	Match(name, namespace string) (bool, error)
 }
 
 func newMatcher(mr metaResource, allowed, denied []types.KubernetesResource, log *slog.Logger) resourceMatcher {
@@ -194,7 +194,7 @@ func (d *resourceFilterer) FilterObj(obj runtime.Object) (isAllowed bool, isList
 			return hasElemts, true, nil
 		}
 
-		result, err := d.matcher.match(o.GetName(), o.GetNamespace())
+		result, err := d.matcher.Match(o.GetName(), o.GetNamespace())
 		if err != nil {
 			d.log.WarnContext(ctx, "Unable to compile regex expressions within kubernetes_resources", "error", err)
 		}
@@ -302,7 +302,7 @@ type kubeObjectInterface interface {
 
 // filterResource validates if the user should access the current resource.
 func (d *resourceFilterer) filterResource(resource kubeObjectInterface) (bool, error) {
-	return d.matcher.match(resource.GetName(), resource.GetNamespace())
+	return d.matcher.Match(resource.GetName(), resource.GetNamespace())
 }
 
 func getKubeResource(kind, group, verb string, obj kubeObjectInterface) types.KubernetesResource {
@@ -328,7 +328,7 @@ func (d *resourceFilterer) filterMetaV1Table(table *metav1.Table) (*metav1.Table
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
-		if result, err := d.matcher.match(resource.Name, resource.Namespace); err != nil {
+		if result, err := d.matcher.Match(resource.Name, resource.Namespace); err != nil {
 			d.log.WarnContext(context.Background(), "Unable to compile regex expression", "error", err)
 		} else if result {
 			resources = append(resources, *row)
@@ -460,7 +460,7 @@ func (d *resourceFilterer) filterUnstructuredList(obj *unstructured.Unstructured
 
 	filteredList := make([]any, 0, len(objList.Items))
 	for _, resource := range objList.Items {
-		if result, err := d.matcher.match(resource.GetName(), resource.GetNamespace()); err != nil {
+		if result, err := d.matcher.Match(resource.GetName(), resource.GetNamespace()); err != nil {
 			slog.WarnContext(context.Background(), "Unable to compile regex expressions within kubernetes_resources", "error", err)
 		} else if result {
 			filteredList = append(filteredList, resource.Object)
@@ -480,7 +480,7 @@ type defaultMatcher struct {
 	deniedResources  []types.KubernetesResource
 }
 
-func (m *defaultMatcher) match(name, namespace string) (bool, error) {
+func (m *defaultMatcher) Match(name, namespace string) (bool, error) {
 	resource := types.KubernetesResource{
 		Kind:      m.kind,
 		Namespace: namespace,

--- a/lib/kube/proxy/resource_filters_test.go
+++ b/lib/kube/proxy/resource_filters_test.go
@@ -186,7 +186,7 @@ func Test_filterBuffer(t *testing.T) {
 					},
 					verb: types.KubeVerbList,
 				}
-				err = filterBuffer(newResourceFilterer(mr, &globalKubeCodecs, allowedResources, nil, logtest.NewLogger()), buf)
+				err = filterBuffer(newResourceFilterer(mr, &globalKubeCodecs, newMatcher(mr, allowedResources, nil, logtest.NewLogger()), logtest.NewLogger()), buf)
 				require.NoError(t, err)
 
 				// Decompress the buffer to compare the result.

--- a/lib/kube/proxy/resource_list.go
+++ b/lib/kube/proxy/resource_list.go
@@ -62,6 +62,16 @@ func (f *Forwarder) listResources(sess *clusterSession, w http.ResponseWriter, r
 
 	// status holds the returned response code.
 	var status int
+	defer func() {
+		if err != nil {
+			return
+		}
+		if status == 0 {
+			// Preserve pre-streaming behavior: treat unset status as 200 OK.
+			status = http.StatusOK
+		}
+		f.emitAuditEvent(req, sess, status)
+	}()
 	// Check if the target Kubernetes cluster is not served by the current service.
 	// If it's the case, forward the request to the target Kube Service where the
 	// filtering logic will be applied.
@@ -100,7 +110,6 @@ func (f *Forwarder) listResources(sess *clusterSession, w http.ResponseWriter, r
 		}
 	}
 
-	f.emitAuditEvent(req, sess, status)
 	return nil, nil
 }
 
@@ -129,8 +138,7 @@ func (f *Forwarder) listResourcesList(req *http.Request, w http.ResponseWriter, 
 	// Check if filtering is needed before buffering the entire response.
 	// If the user has wildcard access and no denied resources, we can skip
 	// buffering and directly forward the response for better performance.
-	filterWrapper := newResourceFilterer(sess.metaResource, sess.codecFactory, allowedResources, deniedResources, f.log)
-	if filterWrapper == nil {
+	if !needsFiltering(allowedResources, deniedResources) {
 		// No filtering needed - use direct forwarding with status recording only.
 		// This avoids buffering the entire response in memory and the subsequent
 		// deserialization/re-serialization overhead.
@@ -139,33 +147,13 @@ func (f *Forwarder) listResourcesList(req *http.Request, w http.ResponseWriter, 
 		return rw.Status(), nil
 	}
 
-	// Filtering is needed - buffer the response in memory.
-	// Creates a memory response writer that collects the response status, headers
-	// and payload into memory.
-	memBuffer := responsewriters.NewMemoryResponseWriter()
-	// Forward the request to the target cluster.
-	sess.forwarder.ServeHTTP(memBuffer, req)
-
-	// filterBuffer filters the response to exclude resources the user doesn't have access to.
-	// The filtered payload will be written into memBuffer again.
-	_, filterSpan := f.cfg.tracer.Start(ctx, "kube.Forwarder/listResourcesList/filterBuffer",
-		oteltrace.WithSpanKind(oteltrace.SpanKindServer),
-		oteltrace.WithAttributes(
-			semconv.RPCServiceKey.String(f.cfg.KubeServiceType),
-			semconv.RPCSystemKey.String("kube"),
-		),
-	)
-	if err := filterBuffer(filterWrapper, memBuffer); err != nil {
-		filterSpan.End()
-		return memBuffer.Status(), trace.Wrap(err)
-	}
-	filterSpan.End()
-
-	// Copy the filtered payload into target http.ResponseWriter.
-	err := memBuffer.CopyInto(w)
-
-	// Returns the status and any filter error.
-	return memBuffer.Status(), trace.Wrap(err)
+	// Filtering is needed. Use a filtering response writer that inspects headers
+	// and routes the body to either the streaming or buffered filter path.
+	matcher := newMatcher(sess.metaResource, allowedResources, deniedResources, f.log)
+	filterWrapper := newResourceFilterer(sess.metaResource, sess.codecFactory, matcher, f.log)
+	fw := newFilteringResponseWriter(w, matcher, filterWrapper, f.log, ctx, f.cfg.tracer, f.cfg.KubeServiceType)
+	sess.forwarder.ServeHTTP(fw, req)
+	return fw.Finish()
 }
 
 // matchListRequestShouldBeAllowed assess whether the user is permitted to perform its request
@@ -222,16 +210,21 @@ func (f *Forwarder) listResourcesWatcher(req *http.Request, w http.ResponseWrite
 	if !ok {
 		return http.StatusBadRequest, trace.BadParameter("unknown resource kind %q", sess.metaResource.requestedResource.resourceKind)
 	}
+
+	var filter responsewriters.FilterWrapper
+	if needsFiltering(allowedResources, deniedResources) {
+		filter = newResourceFilterer(
+			sess.metaResource,
+			sess.codecFactory,
+			newMatcher(sess.metaResource, allowedResources, deniedResources, f.log),
+			f.log,
+		)
+	}
+
 	rw, err := responsewriters.NewWatcherResponseWriter(
 		w,
 		negotiator,
-		newResourceFilterer(
-			sess.metaResource,
-			sess.codecFactory,
-			allowedResources,
-			deniedResources,
-			f.log,
-		),
+		filter,
 	)
 	if err != nil {
 		return http.StatusInternalServerError, trace.Wrap(err)

--- a/lib/kube/proxy/resource_list_test.go
+++ b/lib/kube/proxy/resource_list_test.go
@@ -1,0 +1,277 @@
+/*
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package proxy
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"testing"
+	"text/template"
+
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/kube/proxy/responsewriters"
+	"github.com/gravitational/teleport/lib/kube/proxy/streamfilter"
+	"github.com/gravitational/teleport/lib/utils/log/logtest"
+)
+
+func Test_jsonStreamFilter_roundTrip(t *testing.T) {
+	t.Parallel()
+
+	allowedResources := []types.KubernetesResource{
+		{
+			Kind:      types.KindKubePod,
+			APIGroup:  "*",
+			Namespace: "default",
+			Name:      "*",
+			Verbs:     []string{types.KubeVerbList},
+		},
+	}
+
+	mr := metaResource{
+		requestedResource: apiResource{
+			resourceKind: types.KindKubePod,
+			apiGroup:     "",
+		},
+		resourceDefinition: &metav1.APIResource{Namespaced: true},
+		verb:               types.KubeVerbList,
+	}
+
+	log := logtest.NewLogger()
+
+	// JSON templates for realistic Kubernetes responses.
+	podListTpl := template.Must(template.New("podlist").Parse(`{
+		"apiVersion":"v1","kind":"PodList",
+		"metadata":{"resourceVersion":"999"},
+		"items":[
+			{{- range $i, $p := .Pods}}{{if $i}},{{end}}
+			{"apiVersion":"v1","kind":"Pod","metadata":{"name":"{{$p.Name}}","namespace":"{{$p.Namespace}}","uid":"uid-{{$p.Name}}"}}
+			{{- end}}
+		]
+	}`))
+
+	tableTpl := template.Must(template.New("table").Parse(`{
+		"kind":"Table","apiVersion":"meta.k8s.io/v1",
+		"metadata":{"resourceVersion":"999"},
+		"columnDefinitions":[{"name":"Name","type":"string"}],
+		"rows":[
+			{{- range $i, $p := .Pods}}{{if $i}},{{end}}
+			{"cells":["{{$p.Name}}"],"object":{"kind":"PartialObjectMetadata","apiVersion":"meta.k8s.io/v1","metadata":{"name":"{{$p.Name}}","namespace":"{{$p.Namespace}}","uid":"uid-{{$p.Name}}"}}}
+			{{- end}}
+		]
+	}`))
+
+	tableFullObjTpl := template.Must(template.New("tablefull").Parse(`{
+		"kind":"Table","apiVersion":"meta.k8s.io/v1",
+		"metadata":{"resourceVersion":"999"},
+		"columnDefinitions":[{"name":"Name","type":"string"}],
+		"rows":[
+			{{- range $i, $p := .Pods}}{{if $i}},{{end}}
+			{"cells":["{{$p.Name}}"],"object":{"apiVersion":"v1","kind":"Pod","metadata":{"name":"{{$p.Name}}","namespace":"{{$p.Namespace}}","uid":"uid-{{$p.Name}}"}}}
+			{{- end}}
+		]
+	}`))
+
+	type pod struct{ Name, Namespace string }
+	pods := struct{ Pods []pod }{
+		Pods: []pod{
+			{"nginx", "default"},
+			{"redis", "kube-system"},
+			{"postgres", "default"},
+			{"etcd", "kube-system"},
+		},
+	}
+
+	tests := []struct {
+		name string
+		tpl  *template.Template
+		key  string // "items" or "rows"
+	}{
+		{"resource list", podListTpl, "items"},
+		{"table response", tableTpl, "rows"},
+		{"table response full object", tableFullObjTpl, "rows"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			var rawBuf bytes.Buffer
+			require.NoError(t, tt.tpl.Execute(&rawBuf, pods))
+			rawJSON := rawBuf.Bytes()
+
+			// --- Streaming path ---
+			matcher := newMatcher(mr, allowedResources, nil, log)
+			sf := streamfilter.NewJSONFilter(matcher, log)
+			var streamOut bytes.Buffer
+			require.NoError(t, sf.Filter(bytes.NewReader(rawJSON), &streamOut))
+
+			var streamParsed map[string]any
+			require.NoError(t, json.Unmarshal(streamOut.Bytes(), &streamParsed))
+
+			var streamNames []string
+			if _, ok := streamParsed["items"]; ok {
+				streamNames = itemNames(t, streamParsed, "items")
+			} else if _, ok := streamParsed["rows"]; ok {
+				streamNames = itemNames(t, streamParsed, "rows")
+			}
+
+			// --- Buffered path ---
+			buf := responsewriters.NewMemoryResponseWriter()
+			buf.Header().Set(responsewriters.ContentTypeHeader, responsewriters.DefaultContentType)
+			buf.Write(rawJSON)
+			filter := newResourceFilterer(mr, &globalKubeCodecs, newMatcher(mr, allowedResources, nil, log), log)
+			require.NoError(t, filterBuffer(filter, buf))
+
+			// Parse the buffered output as generic JSON to extract names,
+			// same as the streaming path comparison.
+			var bufferedParsed map[string]any
+			require.NoError(t, json.Unmarshal(buf.Buffer().Bytes(), &bufferedParsed))
+			var bufferedNames []string
+			if _, ok := bufferedParsed["items"]; ok {
+				bufferedNames = itemNames(t, bufferedParsed, "items")
+			} else if _, ok := bufferedParsed["rows"]; ok {
+				bufferedNames = itemNames(t, bufferedParsed, "rows")
+			}
+
+			require.ElementsMatch(t, bufferedNames, streamNames,
+				"streaming and buffered paths should produce the same filtered set")
+		})
+	}
+}
+
+// itemNames extracts item names from parsed JSON output.
+func itemNames(t *testing.T, parsed map[string]any, key string) []string {
+	t.Helper()
+	arr, ok := parsed[key].([]any)
+	if !ok {
+		return nil
+	}
+	var names []string
+	for _, raw := range arr {
+		item, ok := raw.(map[string]any)
+		require.True(t, ok)
+		var name string
+		switch key {
+		case "items":
+			meta := item["metadata"].(map[string]any)
+			name = meta["namespace"].(string) + "/" + meta["name"].(string)
+		case "rows":
+			obj := item["object"].(map[string]any)
+			meta := obj["metadata"].(map[string]any)
+			name = meta["namespace"].(string) + "/" + meta["name"].(string)
+		}
+		names = append(names, name)
+	}
+	return names
+}
+
+func BenchmarkStreamFilter(b *testing.B) {
+	log := slog.New(slog.DiscardHandler)
+
+	mr := metaResource{
+		requestedResource: apiResource{
+			resourceKind: types.KindKubePod,
+			apiGroup:     "",
+		},
+		resourceDefinition: &metav1.APIResource{Namespaced: true},
+		verb:               types.KubeVerbList,
+	}
+
+	namespaces := []string{"default", "staging", "monitoring", "kube-system", "production"}
+
+	buildRules := func(ruleCount int) (allowed, denied []types.KubernetesResource) {
+		for i := range ruleCount {
+			allowed = append(allowed, types.KubernetesResource{
+				Kind:      types.KindKubePod,
+				Namespace: namespaces[i%len(namespaces)],
+				Name:      fmt.Sprintf("app-%d-*", i),
+				Verbs:     []string{types.KubeVerbList},
+				APIGroup:  "",
+			})
+		}
+		denied = []types.KubernetesResource{
+			{Kind: types.KindKubePod, Namespace: "default", Name: "secret-*", Verbs: []string{types.KubeVerbList}, APIGroup: ""},
+		}
+		return allowed, denied
+	}
+
+	buildJSON := func(itemCount int) []byte {
+		items := make([]map[string]any, itemCount)
+		for i := range items {
+			items[i] = map[string]any{
+				"apiVersion": "v1",
+				"kind":       "Pod",
+				"metadata": map[string]any{
+					"name":      fmt.Sprintf("pod-%d", i),
+					"namespace": namespaces[i%len(namespaces)],
+				},
+			}
+		}
+		data, err := json.Marshal(map[string]any{
+			"apiVersion": "v1",
+			"kind":       "PodList",
+			"metadata":   map[string]any{"resourceVersion": ""},
+			"items":      items,
+		})
+		if err != nil {
+			b.Fatal(err)
+		}
+		return data
+	}
+
+	for _, ruleCount := range []int{4, 50, 150} {
+		allowed, denied := buildRules(ruleCount)
+
+		for _, itemCount := range []int{500, 5000} {
+			jsonPayload := buildJSON(itemCount)
+			prefix := fmt.Sprintf("%d_rules/%d_items", ruleCount, itemCount)
+
+			b.Run(prefix+"/stream_filter", func(b *testing.B) {
+				matcher := newMatcher(mr, allowed, denied, log)
+				sf := streamfilter.NewJSONFilter(matcher, log)
+				b.ReportAllocs()
+				b.ResetTimer()
+				for b.Loop() {
+					if err := sf.Filter(bytes.NewReader(jsonPayload), io.Discard); err != nil {
+						b.Fatal(err)
+					}
+				}
+			})
+
+			b.Run(prefix+"/buffered_filter", func(b *testing.B) {
+				factory := newResourceFilterer(mr, &globalKubeCodecs, newMatcher(mr, allowed, denied, log), log)
+				b.ReportAllocs()
+				b.ResetTimer()
+				for b.Loop() {
+					buf := responsewriters.NewMemoryResponseWriter()
+					buf.Header().Set(responsewriters.ContentTypeHeader, responsewriters.DefaultContentType)
+					buf.Write(jsonPayload)
+					if err := filterBuffer(factory, buf); err != nil {
+						b.Fatal(err)
+					}
+				}
+			})
+		}
+	}
+}

--- a/lib/kube/proxy/resource_rbac_test.go
+++ b/lib/kube/proxy/resource_rbac_test.go
@@ -30,6 +30,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/uuid"
@@ -51,6 +52,7 @@ import (
 	controllerclient "sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/gravitational/teleport/api/types"
+	apievents "github.com/gravitational/teleport/api/types/events"
 	"github.com/gravitational/teleport/lib/kube/proxy/responsewriters"
 	tkm "github.com/gravitational/teleport/lib/kube/proxy/testing/kube_server"
 	"github.com/gravitational/teleport/lib/utils/log/logtest"
@@ -565,6 +567,69 @@ func TestListPodRBAC(t *testing.T) {
 	}
 }
 
+// TestListResourcesAuditResponseCode verifies that the KubeRequest audit event
+// emitted after a list request captures the upstream response code.
+func TestListResourcesAuditResponseCode(t *testing.T) {
+	t.Parallel()
+	kubeMock, err := tkm.NewKubeAPIMock()
+	require.NoError(t, err)
+	t.Cleanup(func() { kubeMock.Close() })
+
+	var (
+		mu            sync.Mutex
+		kubeRequestEv *apievents.KubeRequest
+	)
+	testCtx := SetupTestContext(
+		context.Background(),
+		t,
+		TestConfig{
+			Clusters: []KubeClusterConfig{{Name: kubeCluster, APIEndpoint: kubeMock.URL}},
+			OnEvent: func(evt apievents.AuditEvent) {
+				mu.Lock()
+				defer mu.Unlock()
+				if kr, ok := evt.(*apievents.KubeRequest); ok && kr.Verb == http.MethodGet {
+					kubeRequestEv = kr
+				}
+			},
+		},
+	)
+	t.Cleanup(func() { require.NoError(t, testCtx.Close()) })
+
+	user, _ := testCtx.CreateUserAndRole(
+		testCtx.Context,
+		t,
+		"audit_user",
+		RoleSpec{
+			Name:       "audit_user",
+			KubeUsers:  roleKubeUsers,
+			KubeGroups: roleKubeGroups,
+			SetupRoleFunc: func(r types.Role) {
+				r.SetKubeResources(types.Allow, []types.KubernetesResource{{
+					Kind:      "pods",
+					Name:      types.Wildcard,
+					Namespace: metav1.NamespaceDefault,
+					Verbs:     []string{types.Wildcard},
+					APIGroup:  types.Wildcard,
+				}})
+			},
+		},
+	)
+	client, _ := testCtx.GenTestKubeClientTLSCert(t, user.GetName(), kubeCluster)
+
+	_, err = client.CoreV1().Pods(metav1.NamespaceDefault).List(testCtx.Context, metav1.ListOptions{})
+	require.NoError(t, err)
+
+	require.Eventually(t, func() bool {
+		mu.Lock()
+		defer mu.Unlock()
+		return kubeRequestEv != nil
+	}, 5*time.Second, 50*time.Millisecond, "expected KubeRequest audit event")
+
+	mu.Lock()
+	defer mu.Unlock()
+	require.Equal(t, int32(http.StatusOK), kubeRequestEv.ResponseCode)
+}
+
 func TestWatcherResponseWriter(t *testing.T) {
 	defaultNamespace := "default"
 	devNamespace := "dev"
@@ -695,7 +760,7 @@ func TestWatcherResponseWriter(t *testing.T) {
 				},
 				verb: types.KubeVerbWatch,
 			}
-			filterWrapper := newResourceFilterer(mr, &globalKubeCodecs, tt.args.allowed, tt.args.denied, logtest.NewLogger())
+			filterWrapper := newResourceFilterer(mr, &globalKubeCodecs, newMatcher(mr, tt.args.allowed, tt.args.denied, logtest.NewLogger()), logtest.NewLogger())
 			// watcher parses the data written into itself and if the user is allowed to
 			// receive the update, it writes the event into target.
 			watcher, err := responsewriters.NewWatcherResponseWriter(newFakeResponseWriter(userWriter) /*target*/, negotiator, filterWrapper)

--- a/lib/kube/proxy/streamfilter/streamfilter.go
+++ b/lib/kube/proxy/streamfilter/streamfilter.go
@@ -1,0 +1,299 @@
+/*
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+// Package streamfilter implements streaming RBAC filtering for Kubernetes
+// list responses. It uses json.Decoder with json.RawMessage to decode
+// individual items incrementally, apply a matcher to each item, and write
+// matching items to the output without buffering the entire response.
+package streamfilter
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"log/slog"
+
+	"github.com/gravitational/trace"
+)
+
+// Matcher matches a Kubernetes resource by name and namespace.
+type Matcher interface {
+	Match(name, namespace string) (bool, error)
+}
+
+// Filter filters a Kubernetes list response by reading from src and
+// writing filtered output to dst, without buffering the entire response.
+type Filter interface {
+	Filter(src io.Reader, dst io.Writer) error
+}
+
+// NewJSONFilter returns a streaming filter for Kubernetes JSON list responses.
+// Callers are responsible for ensuring the upstream response is JSON
+// (e.g. by forcing Accept: application/json on the upstream request).
+// If log is nil, slog.Default() is used.
+func NewJSONFilter(matcher Matcher, log *slog.Logger) *JSONFilter {
+	if log == nil {
+		log = slog.Default()
+	}
+	return &JSONFilter{matcher: matcher, log: log}
+}
+
+// JSONFilter performs streaming RBAC filtering on a Kubernetes JSON list response.
+// It parses the top-level JSON object incrementally using json.Decoder,
+// writes non-items fields through unchanged,
+// and filters the items/rows array one element at a time using the matcher.
+// This avoids buffering the entire response in memory.
+//
+// Supports both regular list responses ("items" array)
+// and server-side Table format ("rows" array with nested object.metadata).
+type JSONFilter struct {
+	matcher Matcher
+	log     *slog.Logger
+}
+
+func (f *JSONFilter) Filter(src io.Reader, dst io.Writer) error {
+	decoder := json.NewDecoder(src)
+	w := &jsonStreamWriter{dst: dst, firstField: true}
+	scratch := make(json.RawMessage, 0, 2048)
+
+	// Read opening { of the list object.
+	if err := expectDelim(decoder, '{'); err != nil {
+		return trace.Wrap(err)
+	}
+	if err := w.writeRaw("{"); err != nil {
+		return trace.Wrap(err)
+	}
+
+	for decoder.More() {
+		key, err := decodeStringToken(decoder)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+
+		switch key {
+		case "items":
+			if err := w.writeKey(key); err != nil {
+				return trace.Wrap(err)
+			}
+			scratch, err = f.filterArray(decoder, w, scratch, extractItemMeta)
+			if err != nil {
+				return trace.Wrap(err)
+			}
+
+		case "rows":
+			if err := w.writeKey(key); err != nil {
+				return trace.Wrap(err)
+			}
+			scratch, err = f.filterArray(decoder, w, scratch, extractTableRowMeta)
+			if err != nil {
+				return trace.Wrap(err)
+			}
+
+		default:
+			scratch = scratch[:0]
+			if err := decoder.Decode(&scratch); err != nil {
+				return trace.Wrap(err)
+			}
+			if err := w.writeKeyValue(key, scratch); err != nil {
+				return trace.Wrap(err)
+			}
+		}
+	}
+
+	if err := expectDelim(decoder, '}'); err != nil {
+		return trace.Wrap(err)
+	}
+	return w.writeRaw("}")
+}
+
+// metaExtractor extracts name and namespace from a JSON item for RBAC matching.
+type metaExtractor func(item json.RawMessage) (name, namespace string, err error)
+
+// filterArray reads a JSON array from the decoder, applies RBAC filtering
+// to each element, and writes the filtered array to the writer.
+// The scratch buffer is reused across calls to reduce allocations.
+// Returns the (possibly grown) scratch buffer for reuse.
+func (f *JSONFilter) filterArray(
+	decoder *json.Decoder,
+	w *jsonStreamWriter,
+	scratch json.RawMessage,
+	extract metaExtractor,
+) (json.RawMessage, error) {
+	// Check if the next token is null (items: null).
+	token, err := decoder.Token()
+	if err != nil {
+		return scratch, trace.Wrap(err)
+	}
+	if token == nil {
+		return scratch, w.writeRaw("null")
+	}
+	delim, ok := token.(json.Delim)
+	if !ok || delim != '[' {
+		return scratch, trace.BadParameter("expected [ or null, got %v", token)
+	}
+
+	if err := w.writeRaw("["); err != nil {
+		return scratch, trace.Wrap(err)
+	}
+
+	firstItem := true
+	for decoder.More() {
+		scratch = scratch[:0]
+		if err := decoder.Decode(&scratch); err != nil {
+			return scratch, trace.Wrap(err)
+		}
+
+		name, namespace, err := extract(scratch)
+		if err != nil {
+			// Can't extract metadata — fail closed (deny).
+			f.log.WarnContext(context.Background(), "Unable to extract name/namespace from list item", "error", err)
+			continue
+		}
+
+		allowed, err := f.matcher.Match(name, namespace)
+		if err != nil {
+			f.log.WarnContext(context.Background(), "Unable to compile regex expressions within kubernetes_resources", "error", err)
+			continue
+		}
+		if !allowed {
+			continue
+		}
+
+		if !firstItem {
+			if err := w.writeRaw(","); err != nil {
+				return scratch, trace.Wrap(err)
+			}
+		}
+		firstItem = false
+
+		if _, err := w.dst.Write(scratch); err != nil {
+			return scratch, trace.Wrap(err)
+		}
+	}
+
+	if err := expectDelim(decoder, ']'); err != nil {
+		return scratch, trace.Wrap(err)
+	}
+	return scratch, trace.Wrap(w.writeRaw("]"))
+}
+
+// kubeItemEnvelope is the minimal struct needed to extract name and namespace
+// from a regular Kubernetes list item for RBAC filtering.
+type kubeItemEnvelope struct {
+	Metadata struct {
+		Name      string `json:"name"`
+		Namespace string `json:"namespace"`
+	} `json:"metadata"`
+}
+
+// kubeTableRowEnvelope is the minimal struct needed to extract name and namespace
+// from a Kubernetes Table row for RBAC filtering.
+type kubeTableRowEnvelope struct {
+	Object *struct {
+		Metadata struct {
+			Name      string `json:"name"`
+			Namespace string `json:"namespace"`
+		} `json:"metadata"`
+	} `json:"object"`
+}
+
+func extractItemMeta(item json.RawMessage) (name, namespace string, err error) {
+	var env kubeItemEnvelope
+	if err := json.Unmarshal(item, &env); err != nil {
+		return "", "", trace.Wrap(err)
+	}
+	if env.Metadata.Name == "" {
+		return "", "", trace.BadParameter("item has no name")
+	}
+	return env.Metadata.Name, env.Metadata.Namespace, nil
+}
+
+func extractTableRowMeta(item json.RawMessage) (name, namespace string, err error) {
+	var env kubeTableRowEnvelope
+	if err := json.Unmarshal(item, &env); err != nil {
+		return "", "", trace.Wrap(err)
+	}
+	if env.Object == nil {
+		return "", "", trace.BadParameter("table row has no embedded object")
+	}
+	if env.Object.Metadata.Name == "" {
+		return "", "", trace.BadParameter("table row embedded object has no name")
+	}
+	return env.Object.Metadata.Name, env.Object.Metadata.Namespace, nil
+}
+
+// jsonStreamWriter handles JSON output formatting with comma tracking.
+type jsonStreamWriter struct {
+	dst        io.Writer
+	firstField bool // tracks whether the next top-level field is the first
+}
+
+func (w *jsonStreamWriter) writeRaw(s string) error {
+	_, err := io.WriteString(w.dst, s)
+	return trace.Wrap(err)
+}
+
+func (w *jsonStreamWriter) writeKey(key string) error {
+	if !w.firstField {
+		if err := w.writeRaw(","); err != nil {
+			return trace.Wrap(err)
+		}
+	}
+	w.firstField = false
+
+	keyBytes, err := json.Marshal(key)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	if _, err := w.dst.Write(keyBytes); err != nil {
+		return trace.Wrap(err)
+	}
+	return trace.Wrap(w.writeRaw(":"))
+}
+
+func (w *jsonStreamWriter) writeKeyValue(key string, value json.RawMessage) error {
+	if err := w.writeKey(key); err != nil {
+		return trace.Wrap(err)
+	}
+	_, err := w.dst.Write(value)
+	return trace.Wrap(err)
+}
+
+func expectDelim(decoder *json.Decoder, expected rune) error {
+	token, err := decoder.Token()
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	delim, ok := token.(json.Delim)
+	if !ok || delim != json.Delim(expected) {
+		return trace.BadParameter("expected %c, got %v", expected, token)
+	}
+	return nil
+}
+
+func decodeStringToken(decoder *json.Decoder) (string, error) {
+	token, err := decoder.Token()
+	if err != nil {
+		return "", trace.Wrap(err)
+	}
+	s, ok := token.(string)
+	if !ok {
+		return "", trace.BadParameter("expected string key, got %v", token)
+	}
+	return s, nil
+}

--- a/lib/kube/proxy/streamfilter/streamfilter_test.go
+++ b/lib/kube/proxy/streamfilter/streamfilter_test.go
@@ -1,0 +1,476 @@
+/*
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package streamfilter
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"io"
+	"slices"
+	"testing"
+	"testing/synctest"
+
+	"github.com/stretchr/testify/require"
+)
+
+// testMatcher is a mock Matcher for testing.
+type testMatcher struct {
+	allowFn func(name, namespace string) (bool, error)
+}
+
+func (m *testMatcher) Match(name, ns string) (bool, error) { return m.allowFn(name, ns) }
+
+func matcherAllowAll() *testMatcher {
+	return &testMatcher{allowFn: func(_, _ string) (bool, error) { return true, nil }}
+}
+
+func matcherDenyAll() *testMatcher {
+	return &testMatcher{allowFn: func(_, _ string) (bool, error) { return false, nil }}
+}
+
+func matcherAllowNamespace(ns string) *testMatcher {
+	return &testMatcher{allowFn: func(_, namespace string) (bool, error) { return namespace == ns, nil }}
+}
+
+func matcherAllowNames(names ...string) *testMatcher {
+	return &testMatcher{allowFn: func(name, _ string) (bool, error) { return slices.Contains(names, name), nil }}
+}
+
+// testItem represents a Kubernetes resource for building test JSON.
+type testItem struct {
+	Name      string
+	Namespace string
+}
+
+func buildListJSON(t *testing.T, apiVersion, kind string, items []testItem) []byte {
+	t.Helper()
+	list := map[string]any{
+		"apiVersion": apiVersion,
+		"kind":       kind,
+		"metadata":   map[string]any{"resourceVersion": "12345"},
+	}
+	jsonItems := make([]map[string]any, len(items))
+	for i, item := range items {
+		jsonItems[i] = map[string]any{
+			"apiVersion": apiVersion,
+			"kind":       kind[:len(kind)-len("List")],
+			"metadata": map[string]any{
+				"name":      item.Name,
+				"namespace": item.Namespace,
+			},
+		}
+	}
+	list["items"] = jsonItems
+	data, err := json.Marshal(list)
+	require.NoError(t, err)
+	return data
+}
+
+func buildTableJSON(t *testing.T, rows []testItem) []byte {
+	t.Helper()
+	tableRows := make([]map[string]any, len(rows))
+	for i, item := range rows {
+		tableRows[i] = map[string]any{
+			"cells": []any{item.Name, "ClusterIP", "10.0.0.1"},
+			"object": map[string]any{
+				"kind":       "PartialObjectMetadata",
+				"apiVersion": "meta.k8s.io/v1",
+				"metadata": map[string]any{
+					"name":      item.Name,
+					"namespace": item.Namespace,
+				},
+			},
+		}
+	}
+	table := map[string]any{
+		"kind":       "Table",
+		"apiVersion": "meta.k8s.io/v1",
+		"metadata":   map[string]any{"resourceVersion": "99999"},
+		"columnDefinitions": []map[string]any{
+			{"name": "Name", "type": "string"},
+			{"name": "Type", "type": "string"},
+			{"name": "Cluster-IP", "type": "string"},
+		},
+		"rows": tableRows,
+	}
+	data, err := json.Marshal(table)
+	require.NoError(t, err)
+	return data
+}
+
+func filterJSON(t *testing.T, input []byte, matcher Matcher) map[string]any {
+	t.Helper()
+	var buf bytes.Buffer
+	sf := NewJSONFilter(matcher, nil)
+	err := sf.Filter(bytes.NewReader(input), &buf)
+	require.NoError(t, err)
+	var result map[string]any
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &result), "output is not valid JSON: %s", buf.String())
+	return result
+}
+
+func itemNames(t *testing.T, parsed map[string]any, key string) []string {
+	t.Helper()
+	arr, ok := parsed[key].([]any)
+	if !ok {
+		return nil
+	}
+	var names []string
+	for _, raw := range arr {
+		item, ok := raw.(map[string]any)
+		require.True(t, ok)
+		var name string
+		switch key {
+		case "items":
+			meta := item["metadata"].(map[string]any)
+			name = meta["namespace"].(string) + "/" + meta["name"].(string)
+		case "rows":
+			obj := item["object"].(map[string]any)
+			meta := obj["metadata"].(map[string]any)
+			name = meta["namespace"].(string) + "/" + meta["name"].(string)
+		}
+		names = append(names, name)
+	}
+	return names
+}
+
+func TestFilter_items(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		items   []testItem
+		matcher Matcher
+		want    []string
+	}{
+		{
+			name:    "all allowed",
+			items:   []testItem{{"nginx-1", "default"}, {"nginx-2", "default"}, {"redis-1", "kube-system"}, {"postgres-1", "kube-system"}},
+			matcher: matcherAllowAll(),
+			want:    []string{"default/nginx-1", "default/nginx-2", "kube-system/redis-1", "kube-system/postgres-1"},
+		},
+		{
+			name:    "filter by namespace",
+			items:   []testItem{{"nginx-1", "default"}, {"nginx-2", "default"}, {"redis-1", "kube-system"}, {"postgres-1", "kube-system"}},
+			matcher: matcherAllowNamespace("default"),
+			want:    []string{"default/nginx-1", "default/nginx-2"},
+		},
+		{
+			name:    "filter by name",
+			items:   []testItem{{"nginx-1", "default"}, {"nginx-2", "default"}, {"redis-1", "kube-system"}, {"postgres-1", "kube-system"}},
+			matcher: matcherAllowNames("nginx-1", "postgres-1"),
+			want:    []string{"default/nginx-1", "kube-system/postgres-1"},
+		},
+		{
+			name:    "all denied",
+			items:   []testItem{{"nginx-1", "default"}, {"nginx-2", "default"}, {"redis-1", "kube-system"}, {"postgres-1", "kube-system"}},
+			matcher: matcherDenyAll(),
+			want:    nil,
+		},
+		{
+			name:    "single item allowed",
+			items:   []testItem{{"nginx", "default"}},
+			matcher: matcherAllowAll(),
+			want:    []string{"default/nginx"},
+		},
+		{
+			name:    "single item denied",
+			items:   []testItem{{"nginx", "default"}},
+			matcher: matcherDenyAll(),
+			want:    nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			input := buildListJSON(t, "v1", "PodList", tt.items)
+			result := filterJSON(t, input, tt.matcher)
+			got := itemNames(t, result, "items")
+			require.ElementsMatch(t, tt.want, got)
+
+			require.Equal(t, "v1", result["apiVersion"])
+			require.Equal(t, "PodList", result["kind"])
+			meta, ok := result["metadata"].(map[string]any)
+			require.True(t, ok)
+			require.Equal(t, "12345", meta["resourceVersion"])
+		})
+	}
+}
+
+func TestFilter_table(t *testing.T) {
+	t.Parallel()
+
+	rows := []testItem{
+		{"kubernetes", "default"},
+		{"kube-dns", "kube-system"},
+		{"metrics-server", "kube-system"},
+	}
+
+	tests := []struct {
+		name    string
+		matcher Matcher
+		want    []string
+	}{
+		{
+			name:    "all rows allowed",
+			matcher: matcherAllowAll(),
+			want:    []string{"default/kubernetes", "kube-system/kube-dns", "kube-system/metrics-server"},
+		},
+		{
+			name:    "filter by namespace",
+			matcher: matcherAllowNamespace("default"),
+			want:    []string{"default/kubernetes"},
+		},
+		{
+			name:    "all rows denied",
+			matcher: matcherDenyAll(),
+			want:    nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			input := buildTableJSON(t, rows)
+			result := filterJSON(t, input, tt.matcher)
+			got := itemNames(t, result, "rows")
+			require.ElementsMatch(t, tt.want, got)
+
+			require.Equal(t, "Table", result["kind"])
+			require.Equal(t, "meta.k8s.io/v1", result["apiVersion"])
+			colDefs, ok := result["columnDefinitions"].([]any)
+			require.True(t, ok)
+			require.Len(t, colDefs, 3)
+		})
+	}
+}
+
+func TestFilter_edgeCases(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		input   []byte
+		matcher Matcher
+		wantErr string
+		check   func(t *testing.T, result map[string]any)
+	}{
+		{
+			name:    "null items array",
+			input:   []byte(`{"apiVersion":"v1","kind":"PodList","metadata":{},"items":null}`),
+			matcher: matcherAllowAll(),
+			check: func(t *testing.T, result map[string]any) {
+				require.Nil(t, result["items"])
+			},
+		},
+		{
+			name:    "empty items array",
+			input:   []byte(`{"apiVersion":"v1","kind":"PodList","metadata":{},"items":[]}`),
+			matcher: matcherAllowAll(),
+			check: func(t *testing.T, result map[string]any) {
+				arr, ok := result["items"].([]any)
+				require.True(t, ok)
+				require.Empty(t, arr)
+			},
+		},
+		{
+			name:    "item with missing metadata denied",
+			input:   []byte(`{"apiVersion":"v1","kind":"PodList","metadata":{},"items":[{"kind":"Pod"},{"metadata":{"name":"good","namespace":"default"}}]}`),
+			matcher: matcherAllowNamespace("default"),
+			check: func(t *testing.T, result map[string]any) {
+				got := itemNames(t, result, "items")
+				require.Equal(t, []string{"default/good"}, got)
+			},
+		},
+		{
+			name:    "malformed item metadata skipped",
+			input:   []byte(`{"apiVersion":"v1","kind":"PodList","metadata":{},"items":[{"metadata":"broken"},{"metadata":{"name":"good","namespace":"ns"}}]}`),
+			matcher: matcherAllowAll(),
+			check: func(t *testing.T, result map[string]any) {
+				got := itemNames(t, result, "items")
+				require.Equal(t, []string{"ns/good"}, got)
+			},
+		},
+		{
+			name:    "extra top-level fields preserved",
+			input:   []byte(`{"apiVersion":"v1","kind":"PodList","metadata":{},"extraField":"hello","count":42,"items":[]}`),
+			matcher: matcherAllowAll(),
+			check: func(t *testing.T, result map[string]any) {
+				require.Equal(t, "hello", result["extraField"])
+				require.InDelta(t, float64(42), result["count"], 0)
+			},
+		},
+		{
+			name:    "matcher error denies item",
+			input:   []byte(`{"apiVersion":"v1","kind":"PodList","metadata":{},"items":[{"metadata":{"name":"x","namespace":"y"}}]}`),
+			matcher: &testMatcher{allowFn: func(_, _ string) (bool, error) { return false, errors.New("boom") }},
+			check: func(t *testing.T, result map[string]any) {
+				arr, ok := result["items"].([]any)
+				require.True(t, ok)
+				require.Empty(t, arr)
+			},
+		},
+		{
+			name:    "empty JSON object",
+			input:   []byte(`{}`),
+			matcher: matcherAllowAll(),
+			check: func(t *testing.T, result map[string]any) {
+				require.Empty(t, result)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			var buf bytes.Buffer
+			sf := NewJSONFilter(tt.matcher, nil)
+			err := sf.Filter(bytes.NewReader(tt.input), &buf)
+			if tt.wantErr != "" {
+				require.ErrorContains(t, err, tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			var result map[string]any
+			require.NoError(t, json.Unmarshal(buf.Bytes(), &result), "output is not valid JSON: %s", buf.String())
+			if tt.check != nil {
+				tt.check(t, result)
+			}
+		})
+	}
+}
+
+func TestExtractItemMeta(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name      string
+		input     string
+		wantName  string
+		wantNS    string
+		wantError bool
+	}{
+		{"valid", `{"metadata":{"name":"nginx","namespace":"default"}}`, "nginx", "default", false},
+		{"missing namespace", `{"metadata":{"name":"nginx"}}`, "nginx", "", false},
+		{"missing metadata", `{"kind":"Pod"}`, "", "", true},
+		{"empty object", `{}`, "", "", true},
+		{"invalid JSON", `not-json`, "", "", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			name, ns, err := extractItemMeta(json.RawMessage(tt.input))
+			if tt.wantError {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tt.wantName, name)
+				require.Equal(t, tt.wantNS, ns)
+			}
+		})
+	}
+}
+
+func TestExtractTableRowMeta(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name      string
+		input     string
+		wantName  string
+		wantNS    string
+		wantError bool
+	}{
+		{"valid", `{"object":{"metadata":{"name":"svc","namespace":"default"}}}`, "svc", "default", false},
+		{"missing object", `{"cells":["a"]}`, "", "", true},
+		{"missing metadata in object", `{"object":{"kind":"Pod"}}`, "", "", true},
+		{"empty object", `{}`, "", "", true},
+		{"invalid JSON", `{broken`, "", "", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			name, ns, err := extractTableRowMeta(json.RawMessage(tt.input))
+			if tt.wantError {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tt.wantName, name)
+				require.Equal(t, tt.wantNS, ns)
+			}
+		})
+	}
+}
+
+// TestFilter_streaming verifies that items are written to the output incrementally
+// as they arrive from the upstream, not buffered until the entire response is received.
+// It also verifies that denied items never appear in the output.
+func TestFilter_streaming(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		matcher := matcherAllowNamespace("default")
+		sf := NewJSONFilter(matcher, nil)
+
+		// src pipe: test writes upstream JSON, filter reads.
+		// dst: plain buffer is safe because synctest.Wait() guarantees the
+		// filter goroutine is idle (blocked on pipe read) before we inspect output.
+		srcR, srcW := io.Pipe()
+		var dst bytes.Buffer
+
+		filterErr := make(chan error, 1)
+		go func() {
+			filterErr <- sf.Filter(srcR, &dst)
+		}()
+
+		// Write preamble + first item (allowed).
+		io.WriteString(srcW, `{"apiVersion":"v1","kind":"PodList","metadata":{"resourceVersion":"1"},"items":[`)
+		io.WriteString(srcW, `{"metadata":{"name":"nginx","namespace":"default"}}`)
+		synctest.Wait()
+
+		out := dst.String()
+		require.Contains(t, out, `"apiVersion"`, "preamble should be written before all items arrive")
+		require.Contains(t, out, `"nginx"`, "first allowed item should arrive incrementally")
+
+		// Write denied item.
+		io.WriteString(srcW, `,{"metadata":{"name":"coredns","namespace":"kube-system"}}`)
+		synctest.Wait()
+
+		out = dst.String()
+		require.NotContains(t, out, `"coredns"`, "denied item must not appear in output")
+
+		// Write second allowed item.
+		io.WriteString(srcW, `,{"metadata":{"name":"redis","namespace":"default"}}`)
+		synctest.Wait()
+
+		out = dst.String()
+		require.Contains(t, out, `"redis"`, "second allowed item should arrive incrementally")
+
+		// Close the JSON list and upstream pipe.
+		io.WriteString(srcW, `]}`)
+		srcW.Close()
+		synctest.Wait()
+
+		require.NoError(t, <-filterErr)
+
+		// Final output should be valid JSON with exactly the allowed items.
+		var result map[string]any
+		require.NoError(t, json.Unmarshal(dst.Bytes(), &result), "output should be valid JSON: %s", dst.String())
+		names := itemNames(t, result, "items")
+		require.Equal(t, []string{"default/nginx", "default/redis"}, names)
+	})
+}

--- a/lib/utils/replace.go
+++ b/lib/utils/replace.go
@@ -77,12 +77,7 @@ func replaceRegexCached(expression string, config RegexpConfig) (*regexp.Regexp,
 		return expr, nil
 	}
 
-	if !strings.HasPrefix(expression, "^") || !strings.HasSuffix(expression, "$") {
-		// replace glob-style wildcards with regexp wildcards
-		// for plain strings, and quote all characters that could
-		// be interpreted in regular expression
-		expression = "^" + GlobToRegexp(expression) + "$"
-	}
+	expression = expressionToRegexp(expression)
 	if config.IgnoreCase {
 		expression = "(?i)" + expression
 	}
@@ -197,7 +192,7 @@ func KubeResourceMatchesRegex(input types.KubernetesResource, isClusterWideResou
 		// it doesn't match.
 		// When the resource has a wildcard verb, we only allow one verb in the
 		// resource input.
-		if !isVerbAllowed(resource.Verbs, verb) {
+		if !IsVerbAllowed(resource.Verbs, verb) {
 			continue
 		}
 		switch {
@@ -293,7 +288,7 @@ func KubeResourceCouldMatchRules(input types.KubernetesResource, isClusterWideRe
 		// it doesn't match.
 		// When the resource has a wildcard verb, we only allow one verb in the
 		// resource input.
-		if !isVerbAllowed(resource.Verbs, verb) {
+		if !IsVerbAllowed(resource.Verbs, verb) {
 			continue
 		}
 		switch {
@@ -362,10 +357,9 @@ func KubeResourceCouldMatchRules(input types.KubernetesResource, isClusterWideRe
 	return false, nil
 }
 
-// isVerbAllowed returns true if the verb is allowed in the resource.
-// If the resource has a wildcard verb, it matches all verbs, otherwise
-// the resource must have the verb we're looking for.
-func isVerbAllowed(allowedVerbs []string, verb string) bool {
+// IsVerbAllowed returns true if the verb is allowed in the resource.
+// It short-circuits on a wildcard in position 0, otherwise checks whether the verb appears in the list.
+func IsVerbAllowed(allowedVerbs []string, verb string) bool {
 	return len(allowedVerbs) != 0 && (allowedVerbs[0] == types.Wildcard || slices.Contains(allowedVerbs, verb))
 }
 
@@ -425,16 +419,26 @@ func MatchString(input, expression string) (bool, error) {
 	return expr.MatchString(input), nil
 }
 
+// IsRegexp returns true if the expression is a raw regex pattern (starts with ^ and ends with $).
+func IsRegexp(expression string) bool {
+	return strings.HasPrefix(expression, "^") && strings.HasSuffix(expression, "$")
+}
+
+// expressionToRegexp converts a Teleport expression to a regexp string.
+func expressionToRegexp(expression string) string {
+	if IsRegexp(expression) {
+		return expression
+	}
+	// replace glob-style wildcards with regexp wildcards
+	// for plain strings, and quote all characters that could
+	// be interpreted in regular expression
+	return "^" + GlobToRegexp(expression) + "$"
+}
+
 // CompileExpression compiles the given regex expression with Teleport's custom globbing
 // and quoting logic.
 func CompileExpression(expression string) (*regexp.Regexp, error) {
-	if !strings.HasPrefix(expression, "^") || !strings.HasSuffix(expression, "$") {
-		// replace glob-style wildcards with regexp wildcards
-		// for plain strings, and quote all characters that could
-		// be interpreted in regular expression
-		expression = "^" + GlobToRegexp(expression) + "$"
-	}
-
+	expression = expressionToRegexp(expression)
 	expr, err := regexp.Compile(expression)
 	if err != nil {
 		return nil, trace.BadParameter("%s", err)


### PR DESCRIPTION
Backport #65763 to branch/v18.

Stacked on:
- #66404 (backport of #64588)
- #66403 (backport of #65762)

This branch contains the cherry-picks of all three commits (64588, 65762, 65763) since 65763's diff against branch/v18 depends on the prior two. Once #66404 and #66403 merge into branch/v18, this PR's diff will reduce to just the 65763 changes.

Cherry-pick of 65763 was clean once 64588 and 65762 were applied.

## Manual Test Plan

### Test Environment

Kind cluster with a custom Teleport build from this branch (all three cherry-picks applied). Same setup as the [original PR](https://github.com/gravitational/teleport/pull/65763).

### Test Cases

- [x] Replayed the [Kubernetes RBAC test plan](https://github.com/gravitational/teleport/blob/master/.github/ISSUE_TEMPLATE/testplan.md#kubernetes-rbac) from #64588 — all 35 cases (role v7, v7→v8 upgrade, role v8) passed with no regressions through the streaming filter path.