### PR TITLE
[Auth] Add centralized test to detect unimplemented gRPC endpoints

### DIFF
--- a/lib/auth/authtest/authtest.go
+++ b/lib/auth/authtest/authtest.go
@@ -35,6 +35,7 @@ import (
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace"
 	"golang.org/x/crypto/bcrypt"
 	"golang.org/x/crypto/ssh"
+	"google.golang.org/grpc"
 	"google.golang.org/grpc/test/bufconn"
 
 	"github.com/gravitational/teleport"
@@ -945,6 +946,14 @@ func WithoutJoinV1() TestTLSServerOption {
 	}
 }
 
+// WithAdditionalUnaryInterceptors prepends interceptors to the gRPC unary
+// interceptor chain. Useful for injecting a recovery interceptor in tests.
+func WithAdditionalUnaryInterceptors(interceptors ...grpc.UnaryServerInterceptor) TestTLSServerOption {
+	return func(cfg *TLSServerConfig) {
+		cfg.AdditionalUnaryInterceptors = append(cfg.AdditionalUnaryInterceptors, interceptors...)
+	}
+}
+
 // NewRemoteClient creates new client to the remote server using identity
 // generated for this certificate authority
 func (a *AuthServer) NewRemoteClient(identity TestIdentity, addr net.Addr, pool *x509.CertPool) (*authclient.Client, error) {
@@ -984,6 +993,9 @@ type TLSServerConfig struct {
 	AuthDialer client.ContextDialer
 	// AcceptedUsage is a list of accepted usage restrictions
 	AcceptedUsage []string
+	// AdditionalUnaryInterceptors are prepended to the gRPC unary interceptor
+	// chain. Useful for injecting a recovery interceptor in tests.
+	AdditionalUnaryInterceptors []grpc.UnaryServerInterceptor
 }
 
 // Auth returns auth server used by this TLS server
@@ -1082,13 +1094,14 @@ func NewTestTLSServer(cfg TLSServerConfig) (*TLSServer, error) {
 
 	srv.Mux = mux
 	srv.TLSServer, err = auth.NewTLSServer(context.Background(), auth.TLSServerConfig{
-		Listener:             mux.TLS(),
-		AccessPoint:          srv.AuthServer.AuthServer.Cache,
-		TLS:                  tlsConfig,
-		GetClientCertificate: func() (*tls.Certificate, error) { return &tlsCert, nil },
-		APIConfig:            *srv.APIConfig,
-		LimiterConfig:        *srv.Limiter,
-		AcceptedUsage:        cfg.AcceptedUsage,
+		Listener:                    mux.TLS(),
+		AccessPoint:                 srv.AuthServer.AuthServer.Cache,
+		TLS:                         tlsConfig,
+		GetClientCertificate:        func() (*tls.Certificate, error) { return &tlsCert, nil },
+		APIConfig:                   *srv.APIConfig,
+		LimiterConfig:               *srv.Limiter,
+		AcceptedUsage:               cfg.AcceptedUsage,
+		AdditionalUnaryInterceptors: cfg.AdditionalUnaryInterceptors,
 	})
 	if err != nil {
 		mux.Close()

--- a/lib/auth/grpc_services_test.go
+++ b/lib/auth/grpc_services_test.go
@@ -1,0 +1,148 @@
+/*
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package auth_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/gravitational/trace"
+	"github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/recovery"
+	"github.com/jonboulle/clockwork"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/emptypb"
+
+	"github.com/gravitational/teleport/lib/auth/authtest"
+)
+
+// TestGRPCServiceEndpointsImplemented verifies that every unary RPC method
+// registered on the auth gRPC server has an actual implementation rather than
+// falling through to the Unimplemented stub. This catches cases where a method
+// is accidentally implemented on the wrong service (e.g., on GRPCServer instead
+// of the dedicated service), or added to a proto without a corresponding
+// Go implementation.
+//
+// The test uses [grpc.Server.GetServiceInfo] to discover all registered
+// services and methods at runtime so new services/methods are automatically
+// covered without manual updates.
+func TestGRPCServiceEndpointsImplemented(t *testing.T) {
+	t.Parallel()
+
+	as, err := authtest.NewAuthServer(authtest.AuthServerConfig{
+		Dir:   t.TempDir(),
+		Clock: clockwork.NewFakeClockAt(time.Now().Round(time.Second).UTC()),
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, as.Close()) })
+
+	// A recovery interceptor is required because some handlers panic on
+	// zero-value requests (e.g., nil proto fields). Without recovery, a
+	// single panic kills the entire test process.
+	srv, err := as.NewTestTLSServer(
+		authtest.WithAdditionalUnaryInterceptors(recovery.UnaryServerInterceptor()),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		err := srv.Close()
+		if errors.Is(err, net.ErrClosed) {
+			return
+		}
+		require.NoError(t, err)
+	})
+
+	ctx := context.Background()
+
+	grpcServer, err := srv.TLSServer.GRPCServer().GetServer()
+	require.NoError(t, err)
+
+	// Use an admin identity so authz doesn't mask the Unimplemented error
+	client, err := srv.NewClient(authtest.TestAdmin())
+	require.NoError(t, err)
+	conn := client.GetConnection()
+
+	// Services excluded from this check. Each entry should document
+	// why the service or specific method is allowed to return Unimplemented.
+	skipServices := map[string]string{
+		// Enterprise-only; OSS registers a NotImplementedService stub.
+		"teleport.loginrule.v1.LoginRuleService":   "enterprise-only",
+		"teleport.secreports.v1.SecReportsService": "enterprise-only",
+
+		// proto.AuthService is being wound down. Deprecated RPCs are
+		// intentionally removed from GRPCServer as callers migrate to
+		// dedicated v1 services (e.g., users.v1, presence.v1).
+		"proto.AuthService": "deprecated; methods migrated to v1 services",
+	}
+	skipMethods := map[string]string{
+		// Enterprise-only stubs that fall through to Unimplemented instead
+		// of returning a licensing error.
+		// TODO(kiosion): Should be brought in-line to return license errs instead.
+		"teleport.summarizer.v1.SummarizerService/GetSummary":                             "enterprise-only",
+		"teleport.summarizer.v1.SummarizerService/TestInferenceModel":                     "enterprise-only",
+		"teleport.summarizer.v1.SummarizerService/CreateRetrievalModel":                   "enterprise-only",
+		"teleport.summarizer.v1.SummarizerService/GetRetrievalModel":                      "enterprise-only",
+		"teleport.summarizer.v1.SummarizerService/UpdateRetrievalModel":                   "enterprise-only",
+		"teleport.summarizer.v1.SummarizerService/UpsertRetrievalModel":                   "enterprise-only",
+		"teleport.summarizer.v1.SummarizerService/DeleteRetrievalModel":                   "enterprise-only",
+		"teleport.summarizer.v1.SummarizerService/TestRetrievalModel":                     "enterprise-only",
+		"teleport.workloadidentity.v1.SigstorePolicyResourceService/UpsertSigstorePolicy": "enterprise-only",
+
+		// Alpha service; these RPCs are deliberately not yet implemented.
+		// EvaluateSSHAccess is implemented; these two are not yet.
+		"teleport.decision.v1alpha1.DecisionService/EvaluateSSHJoin":        "alpha; not yet implemented",
+		"teleport.decision.v1alpha1.DecisionService/EvaluateDatabaseAccess": "alpha; not yet implemented",
+	}
+
+	for serviceName, serviceInfo := range grpcServer.GetServiceInfo() {
+		if reason, ok := skipServices[serviceName]; ok {
+			t.Logf("Skipping service %s (%s)", serviceName, reason)
+			continue
+		}
+
+		for _, method := range serviceInfo.Methods {
+			if method.IsClientStream || method.IsServerStream {
+				continue
+			}
+
+			fullName := serviceName + "/" + method.Name
+			if reason, ok := skipMethods[fullName]; ok {
+				t.Logf("Skipping %s (%s)", fullName, reason)
+				continue
+			}
+
+			t.Run(fmt.Sprintf("%s/%s", serviceName, method.Name), func(t *testing.T) {
+				fullMethod := "/" + fullName
+				// Invoke with an empty request. The call may fail with bad
+				// parameter, permission denied, etc. That's fine; the only
+				// failure we're guarding against is Unimplemented, which
+				// means the method hit the Unimplemented stub rather than a
+				// real handler.
+				err := conn.Invoke(ctx, fullMethod, &emptypb.Empty{}, &emptypb.Empty{})
+				if err == nil {
+					return
+				}
+				require.False(t, trace.IsNotImplemented(err),
+					"RPC %s returned Unimplemented. The method may be missing from its service implementation", fullName)
+			})
+		}
+	}
+}

--- a/lib/auth/middleware.go
+++ b/lib/auth/middleware.go
@@ -88,6 +88,10 @@ type TLSServerConfig struct {
 	ID string
 	// Metrics are optional TLSServer metrics
 	Metrics *Metrics
+	// AdditionalUnaryInterceptors are prepended to the gRPC unary interceptor
+	// chain. This is useful in tests to inject a recovery interceptor so that
+	// handler panics don't crash the test process.
+	AdditionalUnaryInterceptors []grpc.UnaryServerInterceptor
 }
 
 // CheckAndSetDefaults checks and sets default values
@@ -238,7 +242,7 @@ func NewTLSServer(ctx context.Context, cfg TLSServerConfig) (*TLSServer, error) 
 		TLS:                tlsConfig,
 		Middleware:         authMiddleware,
 		APIConfig:          cfg.APIConfig,
-		UnaryInterceptors:  authMiddleware.UnaryInterceptors(),
+		UnaryInterceptors:  append(cfg.AdditionalUnaryInterceptors, authMiddleware.UnaryInterceptors()...),
 		StreamInterceptors: authMiddleware.StreamInterceptors(),
 	})
 	if err != nil {


### PR DESCRIPTION
## Context
- Adds `AdditionalUnaryInterceptors` to `auth.TLSServerConfig` / `authtest.TLSServerConfig`, allowing tests to prepend interceptors to the gRPC chain.
- Adds `TestGRPCServiceEndpointsImplemented` to discover all registered gRPC services/methods via `GetServiceInfo()` and verify none return Unimplemented errors. New services and methods are automatically covered by this without manual updates.
  - Known exclusions (deprecated legacy AuthService, enterprise-only stubs, alpha RPCs) are documented inline.

Quick note on `AdditionalUnaryInterceptors`:

The test needs a recovery interceptor because some h andlers panic on zero-value requests, which kills the test process. Currently this is injected via the new opt.

An alternative would be to add the recovery interceptor to the default chain in `Middleware.UnaryInterceptors()` - `tbot`'s `WorkloadAPIService` already does this: 
https://github.com/gravitational/teleport/blob/d0165123a9ce4739f73aa8b51a70b79069b1c2c3/lib/tbot/services/workloadidentity/workload_api.go#L188-L195

The upside is that a panicking handler in production would return an internal error instead of crashing auth. I think this is worth discussing whether this is a change worth making / that we want to make.

## Related
- See #65966
- Requires https://github.com/gravitational/teleport/pull/66150
- Requires https://github.com/gravitational/teleport/pull/66408

## Manual Test Plan
### Test Environment

### Test Cases
- [ ] Verify the added `TestGRPCServiceEndpointsImplemented` test passes.
- [x] Verify that removing a real method implementation (e.g., commenting-out `ListReverseTunnels` in `presencev1.Service` causes the test to fail for that endpoint.
