### PR TITLE
fix: Impl `GetClusterAuditConfig`/`ListUserLoginStates`

### DIFF
--- a/lib/auth/clusterconfig/clusterconfigv1/service.go
+++ b/lib/auth/clusterconfig/clusterconfigv1/service.go
@@ -38,6 +38,7 @@ import (
 // Cache is used by the [Service] to query cluster config resources.
 type Cache interface {
 	GetAuthPreference(context.Context) (types.AuthPreference, error)
+	GetClusterAuditConfig(ctx context.Context) (types.ClusterAuditConfig, error)
 	GetClusterNetworkingConfig(ctx context.Context) (types.ClusterNetworkingConfig, error)
 	GetSessionRecordingConfig(ctx context.Context) (types.SessionRecordingConfig, error)
 	GetAccessGraphSettings(context.Context) (*clusterconfigpb.AccessGraphSettings, error)
@@ -711,6 +712,32 @@ func ValidateCloudNetworkConfigUpdate(authzCtx authz.Context, modules modules.Mo
 	}
 
 	return nil
+}
+
+// GetClusterAuditConfig returns the cluster audit configuration.
+func (s *Service) GetClusterAuditConfig(ctx context.Context, _ *clusterconfigpb.GetClusterAuditConfigRequest) (*types.ClusterAuditConfigV2, error) {
+	authzCtx, err := s.authorizer.Authorize(ctx)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	if err := authzCtx.CheckAccessToKind(types.KindClusterAuditConfig, types.VerbRead); err != nil {
+		if err2 := authzCtx.CheckAccessToKind(types.KindClusterConfig, types.VerbRead); err2 != nil {
+			return nil, trace.Wrap(err)
+		}
+	}
+
+	auditConfig, err := s.cache.GetClusterAuditConfig(ctx)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	cfgV2, ok := auditConfig.(*types.ClusterAuditConfigV2)
+	if !ok {
+		return nil, trace.BadParameter("unexpected cluster audit config type %T", auditConfig)
+	}
+
+	return cfgV2, nil
 }
 
 // GetSessionRecordingConfig returns the locally cached networking configuration.

--- a/lib/auth/grpcserver.go
+++ b/lib/auth/grpcserver.go
@@ -3887,6 +3887,8 @@ func (g *GRPCServer) DeleteAllNodes(ctx context.Context, req *types.ResourcesInN
 }
 
 // GetClusterAuditConfig gets cluster audit configuration.
+// TODO(kiosion) DELETE IN 21.0.0
+// Deprecated: Use [clusterconfigv1.Service.GetClusterAuditConfig] instead.
 func (g *GRPCServer) GetClusterAuditConfig(ctx context.Context, _ *emptypb.Empty) (*types.ClusterAuditConfigV2, error) {
 	auth, err := g.authenticate(ctx)
 	if err != nil {

--- a/lib/auth/userloginstate/userloginstatev1/service.go
+++ b/lib/auth/userloginstate/userloginstatev1/service.go
@@ -82,6 +82,33 @@ func NewService(cfg ServiceConfig) (*Service, error) {
 	}, nil
 }
 
+// ListUserLoginStates returns a paginated list of all user login states.
+func (s *Service) ListUserLoginStates(ctx context.Context, req *userloginstatev1.ListUserLoginStatesRequest) (*userloginstatev1.ListUserLoginStatesResponse, error) {
+	authCtx, err := s.authorizer.Authorize(ctx)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	if err := authCtx.CheckAccessToKind(types.KindUserLoginState, types.VerbRead, types.VerbList); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	results, nextToken, err := s.userLoginStates.ListUserLoginStates(ctx, int(req.GetPageSize()), req.GetPageToken())
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	ulsList := make([]*userloginstatev1.UserLoginState, len(results))
+	for i, r := range results {
+		ulsList[i] = conv.ToProto(r)
+	}
+
+	return &userloginstatev1.ListUserLoginStatesResponse{
+		UserLoginStates: ulsList,
+		NextPageToken:   nextToken,
+	}, nil
+}
+
 // GetUserLoginStates returns a list of all user login states.
 // deprecated: Use paginated version ListUserLoginStates
 // TODO(smallinsky) Remove in v21.0.0


### PR DESCRIPTION
## Context
- Implement `GetClusterAuditConfig`/`ListUserLoginStates` on their respective proper services.

## Related
- See #65966
