### PR TITLE
[v18] Convert desktop discovery tests to synctest

### DIFF
--- a/lib/srv/desktop/discovery_test.go
+++ b/lib/srv/desktop/discovery_test.go
@@ -27,14 +27,15 @@ import (
 	"net"
 	"strconv"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/go-ldap/ldap/v3"
 	"github.com/jonboulle/clockwork"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/auth"
 	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/auth/authtest"
 	"github.com/gravitational/teleport/lib/events/eventstest"
@@ -176,236 +177,212 @@ func TestDNSErrors(t *testing.T) {
 
 func TestDynamicWindowsDiscovery(t *testing.T) {
 	t.Parallel()
-	authServer, err := authtest.NewAuthServer(authtest.AuthServerConfig{
-		ClusterName: "test",
-		Dir:         t.TempDir(),
-		AuditLog:    &eventstest.MockAuditLog{Emitter: new(eventstest.MockRecorderEmitter)},
-	})
-	require.NoError(t, err)
-	t.Cleanup(func() {
-		require.NoError(t, authServer.Close())
-	})
 
-	tlsServer, err := authServer.NewTestTLSServer()
-	require.NoError(t, err)
-	t.Cleanup(func() {
-		require.NoError(t, tlsServer.Close())
-	})
-
-	client, err := tlsServer.NewClient(authtest.TestServerID(types.RoleWindowsDesktop, "test-host-id"))
-	require.NoError(t, err)
-	t.Cleanup(func() {
-		require.NoError(t, client.Close())
-	})
-
-	dynamicWindowsClient := client.DynamicDesktopClient()
-
-	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
-	defer cancel()
-
-	for _, testCase := range []struct {
-		name     string
-		labels   map[string]string
-		expected int
-	}{
-		{
-			name:     "no labels",
-			expected: 0,
-		},
-		{
-			name:     "no matching labels",
-			labels:   map[string]string{"xyz": "abc"},
-			expected: 0,
-		},
-		{
-			name:     "matching labels",
-			labels:   map[string]string{"foo": "bar"},
-			expected: 1,
-		},
-		{
-			name:     "matching wildcard labels",
-			labels:   map[string]string{"abc": "abc"},
-			expected: 1,
-		},
-	} {
-		t.Run(testCase.name, func(t *testing.T) {
-			s := &WindowsService{
-				cfg: WindowsServiceConfig{
-					Heartbeat: HeartbeatConfig{
-						HostUUID: "1234",
-					},
-					Logger:               slog.New(slog.DiscardHandler),
-					Clock:                clockwork.NewFakeClock(),
-					AuthClient:           client,
-					AccessPoint:          client,
-					ConnectedProxyGetter: reversetunnel.NewConnectedProxyGetter(),
-					ResourceMatchers: []services.ResourceMatcher{{
-						Labels: types.Labels{
-							"foo": {"bar"},
-						},
-					}, {
-						Labels: types.Labels{
-							"abc": {"*"},
-						},
-					}},
-				},
-				dnsResolver: &net.Resolver{
-					PreferGo: true,
-					Dial: func(ctx context.Context, network, address string) (net.Conn, error) {
-						return nil, errors.New("this resolver always fails")
-					},
-				},
-			}
-
-			require.NoError(t, s.startDynamicReconciler(t.Context()))
-			t.Cleanup(func() {
-				require.NoError(t, authServer.AuthServer.DeleteAllWindowsDesktops(ctx))
-				var key string
-				for {
-					page, next, err := authServer.AuthServer.ListDynamicWindowsDesktops(ctx, 0, key)
-					require.NoError(t, err)
-					for _, dwd := range page {
-						require.NoError(t, authServer.AuthServer.DeleteDynamicWindowsDesktop(ctx, dwd.GetName()))
-					}
-					if next == "" {
-						break
-					}
-					key = next
-				}
-			})
-
-			desktop, err := types.NewDynamicWindowsDesktopV1("test", testCase.labels, types.DynamicWindowsDesktopSpecV1{
-				Addr: "addr",
-			})
-			require.NoError(t, err)
-
-			_, err = dynamicWindowsClient.CreateDynamicWindowsDesktop(ctx, desktop)
-			require.NoError(t, err)
-
-			require.EventuallyWithT(t, func(t *assert.CollectT) {
-				desktops, err := client.GetWindowsDesktops(ctx, types.WindowsDesktopFilter{})
-				if !assert.NoError(t, err) {
-					return
-				}
-				if !assert.Len(t, desktops, testCase.expected) {
-					return
-				}
-
-				if testCase.expected > 0 {
-					assert.Equal(t, desktop.GetName(), desktops[0].GetName())
-					assert.Equal(t, desktop.GetAddr(), desktops[0].GetAddr())
-				}
-			}, 5*time.Second, 50*time.Millisecond)
-
-			desktop.Spec.Addr = "addr2"
-			_, err = dynamicWindowsClient.UpsertDynamicWindowsDesktop(ctx, desktop)
-			require.NoError(t, err)
-
-			require.EventuallyWithT(t, func(t *assert.CollectT) {
-				desktops, err := client.GetWindowsDesktops(ctx, types.WindowsDesktopFilter{})
-				if !assert.NoError(t, err) {
-					return
-				}
-				if !assert.Len(t, desktops, testCase.expected) {
-					return
-				}
-				if testCase.expected > 0 {
-					assert.Equal(t, desktop.GetName(), desktops[0].GetName())
-					assert.Equal(t, desktop.GetAddr(), desktops[0].GetAddr())
-				}
-			}, 5*time.Second, 50*time.Millisecond)
-
-			require.NoError(t, dynamicWindowsClient.DeleteDynamicWindowsDesktop(ctx, "test"))
-
-			require.EventuallyWithT(t, func(t *assert.CollectT) {
-				desktops, err := client.GetWindowsDesktops(ctx, types.WindowsDesktopFilter{})
-				assert.NoError(t, err)
-				assert.Empty(t, desktops)
-			}, 5*time.Second, 50*time.Millisecond)
+	synctest.Test(t, func(t *testing.T) {
+		authServer, err := authtest.NewAuthServer(authtest.AuthServerConfig{
+			ClusterName: "test",
+			Dir:         t.TempDir(),
+			AuditLog:    &eventstest.MockAuditLog{Emitter: new(eventstest.MockRecorderEmitter)},
 		})
-	}
+		require.NoError(t, err)
+		t.Cleanup(func() { require.NoError(t, authServer.Close()) })
+
+		tlsServer, err := authServer.NewTestTLSServer(authtest.WithBufconnListener())
+		require.NoError(t, err)
+		t.Cleanup(func() { require.NoError(t, tlsServer.Close()) })
+
+		client, err := tlsServer.NewClient(authtest.TestServerID(types.RoleWindowsDesktop, "test-host-id"))
+		require.NoError(t, err)
+		t.Cleanup(func() { require.NoError(t, client.Close()) })
+
+		for _, testCase := range []struct {
+			name     string
+			labels   map[string]string
+			expected int
+		}{
+			{
+				name:     "no labels",
+				expected: 0,
+			},
+			{
+				name:     "no matching labels",
+				labels:   map[string]string{"xyz": "abc"},
+				expected: 0,
+			},
+			{
+				name:     "matching labels",
+				labels:   map[string]string{"foo": "bar"},
+				expected: 1,
+			},
+			{
+				name:     "matching wildcard labels",
+				labels:   map[string]string{"abc": "abc"},
+				expected: 1,
+			},
+		} {
+			// We can't use t.Run() as we're already in a synctest bubble.
+			t.Logf("executing test case %v", testCase.name)
+			testDynamicWindowsDiscovery(t, client, authServer.AuthServer, testCase.labels, testCase.expected)
+		}
+	})
 }
 
-func TestDynamicWindowsDiscoveryExpiry(t *testing.T) {
-	authServer, err := authtest.NewAuthServer(authtest.AuthServerConfig{
-		ClusterName: "test",
-		Dir:         t.TempDir(),
-		AuditLog:    &eventstest.MockAuditLog{Emitter: new(eventstest.MockRecorderEmitter)},
-	})
-	require.NoError(t, err)
-	t.Cleanup(func() { require.NoError(t, authServer.Close()) })
-
-	tlsServer, err := authServer.NewTestTLSServer()
-	require.NoError(t, err)
-	t.Cleanup(func() { require.NoError(t, tlsServer.Close()) })
-
-	client, err := tlsServer.NewClient(authtest.TestServerID(types.RoleWindowsDesktop, "test-host-id"))
-	require.NoError(t, err)
-	t.Cleanup(func() { require.NoError(t, client.Close()) })
-
-	dynamicWindowsClient := client.DynamicDesktopClient()
-
-	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
-	defer cancel()
-
-	clock := clockwork.NewFakeClock()
+func testDynamicWindowsDiscovery(t *testing.T, client *authclient.Client, auth *auth.Server, labels map[string]string, wantCount int) {
 	s := &WindowsService{
 		cfg: WindowsServiceConfig{
 			Heartbeat: HeartbeatConfig{
 				HostUUID: "1234",
 			},
-			Logger:      slog.New(logutils.NewSlogTextHandler(io.Discard, logutils.SlogTextHandlerConfig{})),
-			Clock:       clock,
-			AuthClient:  client,
-			AccessPoint: client,
-			ResourceMatchers: []services.ResourceMatcher{{
-				Labels: types.Labels{
-					"foo": {"bar"},
-				},
-			}},
-		},
-		dnsResolver: &net.Resolver{
-			PreferGo: true,
-			Dial: func(ctx context.Context, network, address string) (net.Conn, error) {
-				return nil, errors.New("this resolver always fails")
+			Logger:               slog.New(slog.DiscardHandler),
+			Clock:                clockwork.NewRealClock(),
+			AuthClient:           client,
+			AccessPoint:          client,
+			ConnectedProxyGetter: reversetunnel.NewConnectedProxyGetter(),
+			ResourceMatchers: []services.ResourceMatcher{
+				{Labels: types.Labels{"foo": {"bar"}}},
+				{Labels: types.Labels{"abc": {"*"}}},
 			},
 		},
 	}
 
-	require.NoError(t, s.startDynamicReconciler(t.Context()))
+	// Clear all desktops to start the test case fresh.
+	require.NoError(t, auth.DeleteAllWindowsDesktops(t.Context()))
+	var key string
+	for {
+		page, next, err := auth.ListDynamicWindowsDesktops(t.Context(), 0, key)
+		require.NoError(t, err)
+		for _, dwd := range page {
+			require.NoError(t, auth.DeleteDynamicWindowsDesktop(t.Context(), dwd.GetName()))
+		}
+		if next == "" {
+			break
+		}
+		key = next
+	}
 
-	desktop, err := types.NewDynamicWindowsDesktopV1("test", map[string]string{
-		"foo": "bar",
-	}, types.DynamicWindowsDesktopSpecV1{
-		Addr: "addr",
-	})
+	// Defer cancellation (instead of t.Cleanup) because this
+	// function is called for multiple test cases in a single Go test.
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	require.NoError(t, s.startDynamicReconciler(ctx))
+	synctest.Wait()
+
+	desktop, err := types.NewDynamicWindowsDesktopV1(
+		"test", labels,
+		types.DynamicWindowsDesktopSpecV1{Addr: "addr"},
+	)
 	require.NoError(t, err)
 
+	dynamicWindowsClient := client.DynamicDesktopClient()
 	_, err = dynamicWindowsClient.CreateDynamicWindowsDesktop(ctx, desktop)
 	require.NoError(t, err)
 
-	require.EventuallyWithT(t, func(t *assert.CollectT) {
-		desktops, err := client.GetWindowsDesktops(ctx, types.WindowsDesktopFilter{})
-		require.NoError(t, err)
-		require.Len(t, desktops, 1)
-		require.Equal(t, "test", desktops[0].GetName())
-	}, 5*time.Second, 50*time.Millisecond)
-
-	err = client.DeleteWindowsDesktop(ctx, s.cfg.Heartbeat.HostUUID, "test")
-	require.NoError(t, err)
+	synctest.Wait()
 
 	desktops, err := client.GetWindowsDesktops(ctx, types.WindowsDesktopFilter{})
 	require.NoError(t, err)
+	require.Len(t, desktops, wantCount)
+	if wantCount > 0 {
+		require.Equal(t, desktop.GetName(), desktops[0].GetName())
+		require.Equal(t, desktop.GetAddr(), desktops[0].GetAddr())
+	}
+
+	desktop.Spec.Addr = "addr2"
+	_, err = dynamicWindowsClient.UpsertDynamicWindowsDesktop(ctx, desktop)
+	require.NoError(t, err)
+
+	synctest.Wait()
+
+	desktops, err = client.GetWindowsDesktops(ctx, types.WindowsDesktopFilter{})
+	require.NoError(t, err)
+	require.Len(t, desktops, wantCount)
+	if wantCount > 0 {
+		require.Equal(t, desktop.GetName(), desktops[0].GetName())
+		require.Equal(t, desktop.GetAddr(), desktops[0].GetAddr())
+	}
+
+	require.NoError(t, dynamicWindowsClient.DeleteDynamicWindowsDesktop(ctx, "test"))
+
+	synctest.Wait()
+
+	desktops, err = client.GetWindowsDesktops(ctx, types.WindowsDesktopFilter{})
+	require.NoError(t, err)
 	require.Empty(t, desktops)
+}
 
-	clock.Advance(5 * time.Minute)
+func TestDynamicWindowsDiscoveryExpiry(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		authServer, err := authtest.NewAuthServer(authtest.AuthServerConfig{
+			ClusterName: "test",
+			Dir:         t.TempDir(),
+			AuditLog:    &eventstest.MockAuditLog{Emitter: new(eventstest.MockRecorderEmitter)},
+		})
+		require.NoError(t, err)
+		t.Cleanup(func() { require.NoError(t, authServer.Close()) })
 
-	require.EventuallyWithT(t, func(t *assert.CollectT) {
-		desktops, err := client.GetWindowsDesktops(ctx, types.WindowsDesktopFilter{})
+		tlsServer, err := authServer.NewTestTLSServer(authtest.WithBufconnListener())
+		require.NoError(t, err)
+		t.Cleanup(func() { require.NoError(t, tlsServer.Close()) })
+
+		client, err := tlsServer.NewClient(authtest.TestServerID(types.RoleWindowsDesktop, "test-host-id"))
+		require.NoError(t, err)
+		t.Cleanup(func() { require.NoError(t, client.Close()) })
+
+		dynamicWindowsClient := client.DynamicDesktopClient()
+
+		s := &WindowsService{
+			cfg: WindowsServiceConfig{
+				Heartbeat: HeartbeatConfig{
+					HostUUID: "1234",
+				},
+				Logger:      slog.New(slog.DiscardHandler),
+				Clock:       clockwork.NewRealClock(),
+				AuthClient:  client,
+				AccessPoint: client,
+				ResourceMatchers: []services.ResourceMatcher{
+					{Labels: types.Labels{"foo": {"bar"}}},
+				},
+			},
+		}
+
+		require.NoError(t, s.startDynamicReconciler(t.Context()))
+
+		synctest.Wait()
+
+		desktop, err := types.NewDynamicWindowsDesktopV1(
+			"test",
+			map[string]string{"foo": "bar"},
+			types.DynamicWindowsDesktopSpecV1{Addr: "addr"},
+		)
+		require.NoError(t, err)
+
+		_, err = dynamicWindowsClient.CreateDynamicWindowsDesktop(t.Context(), desktop)
+		require.NoError(t, err)
+
+		synctest.Wait()
+
+		desktops, err := client.GetWindowsDesktops(t.Context(), types.WindowsDesktopFilter{})
 		require.NoError(t, err)
 		require.Len(t, desktops, 1)
 		require.Equal(t, "test", desktops[0].GetName())
-	}, 5*time.Second, 50*time.Millisecond)
+
+		err = client.DeleteWindowsDesktop(t.Context(), s.cfg.Heartbeat.HostUUID, "test")
+		require.NoError(t, err)
+
+		desktops, err = client.GetWindowsDesktops(t.Context(), types.WindowsDesktopFilter{})
+		require.NoError(t, err)
+		require.Empty(t, desktops)
+
+		synctest.Wait()
+		time.Sleep(5 * time.Minute)
+		synctest.Wait()
+
+		desktops, err = client.GetWindowsDesktops(t.Context(), types.WindowsDesktopFilter{})
+		require.NoError(t, err)
+		require.Len(t, desktops, 1)
+		require.Equal(t, "test", desktops[0].GetName())
+	})
 }
 
 func TestCurrentDesktops(t *testing.T) {
@@ -418,7 +395,7 @@ func TestCurrentDesktops(t *testing.T) {
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, authServer.Close()) })
 
-	tlsServer, err := authServer.NewTestTLSServer()
+	tlsServer, err := authServer.NewTestTLSServer(authtest.WithBufconnListener())
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, tlsServer.Close()) })
 
@@ -538,86 +515,87 @@ func (a *smallPageAccessPoint) ListWindowsDesktops(ctx context.Context, req type
 func TestLDAPDiscoveryFailurePreservesDesktops(t *testing.T) {
 	t.Parallel()
 
-	authServer, err := authtest.NewAuthServer(authtest.AuthServerConfig{
-		ClusterName: "test",
-		Dir:         t.TempDir(),
-		AuditLog:    &eventstest.MockAuditLog{Emitter: new(eventstest.MockRecorderEmitter)},
-	})
-	require.NoError(t, err)
-	t.Cleanup(func() { require.NoError(t, authServer.Close()) })
-
-	tlsServer, err := authServer.NewTestTLSServer()
-	require.NoError(t, err)
-	t.Cleanup(func() { require.NoError(t, tlsServer.Close()) })
-
-	const hostUUID = "test-host-uuid"
-	client, err := tlsServer.NewClient(authtest.TestServerID(types.RoleWindowsDesktop, hostUUID))
-	require.NoError(t, err)
-	t.Cleanup(func() { require.NoError(t, client.Close()) })
-
-	clock := clockwork.NewFakeClock()
-
-	s := &WindowsService{
-		closeCtx: t.Context(),
-		cfg: WindowsServiceConfig{
-			Heartbeat:         HeartbeatConfig{HostUUID: hostUUID},
-			Logger:            slog.New(slog.DiscardHandler),
-			Clock:             clock,
-			AccessPoint:       client,
-			AuthClient:        client,
-			DiscoveryInterval: 5 * time.Minute,
-		},
-
-		// pre-cache a TLS config so we don't ask auth to issue a real cert
-		// (there isn't a real LDAP server here to connect to)
-		ldapTLSConfig:          new(tls.Config),
-		ldapTLSConfigExpiresAt: clock.Now().Add(24 * time.Hour),
-	}
-
-	originalExpiry := clock.Now().Add(s.cfg.DiscoveryInterval * 3)
-
-	// Populate last discovery results with some desktops
-	lastDiscoveryResults := map[string]types.WindowsDesktop{}
-	for i := 1; i <= 3; i++ {
-		name := "desktop-" + strconv.Itoa(i)
-		desktop, err := types.NewWindowsDesktopV3(name, map[string]string{
-			types.OriginLabel:                      types.OriginDynamic,
-			types.DiscoveryLabelWindowsDNSHostName: name + ".example.com",
-			types.DiscoveryLabelWindowsOS:          "Windows Server 2019",
-		}, types.WindowsDesktopSpecV3{
-			HostID: hostUUID,
-			Addr:   name + ".example.com:3389",
+	synctest.Test(t, func(t *testing.T) {
+		authServer, err := authtest.NewAuthServer(authtest.AuthServerConfig{
+			ClusterName: "test",
+			Dir:         t.TempDir(),
+			AuditLog:    &eventstest.MockAuditLog{Emitter: new(eventstest.MockRecorderEmitter)},
 		})
 		require.NoError(t, err)
-		desktop.SetExpiry(originalExpiry)
-		lastDiscoveryResults[name] = desktop
+		t.Cleanup(func() { require.NoError(t, authServer.Close()) })
 
-		require.NoError(t, tlsServer.Auth().UpsertWindowsDesktop(t.Context(), desktop))
-	}
-	s.lastDiscoveryResults = lastDiscoveryResults
-
-	// Force the reconciler to run.
-	// It will fail because we aren't running a real LDAP server in the test.
-	require.NoError(t, s.startDesktopDiscovery())
-	clock.BlockUntilContext(t.Context(), 1)
-	clock.Advance(15 * time.Second)
-	preReconcile := clock.Now()
-	clock.BlockUntilContext(t.Context(), 1)
-
-	// Verify that the reconciler failure did not delete desktops and that
-	// their expiry times were updated.
-	for i := 1; i <= 3; i++ {
-		name := "desktop-" + strconv.Itoa(i)
-		desktops, err := client.GetWindowsDesktops(
-			t.Context(),
-			types.WindowsDesktopFilter{HostID: hostUUID, Name: name},
-		)
+		tlsServer, err := authServer.NewTestTLSServer(authtest.WithBufconnListener())
 		require.NoError(t, err)
-		require.Len(t, desktops, 1)
-		require.Equal(t, name, desktops[0].GetName())
+		t.Cleanup(func() { require.NoError(t, tlsServer.Close()) })
 
-		// Verify the TTL was updated (3x the discovery interval).
-		actualExpiry := desktops[0].Expiry()
-		require.Equal(t, 15*time.Minute, actualExpiry.Sub(preReconcile))
-	}
+		const hostUUID = "test-host-uuid"
+		client, err := tlsServer.NewClient(authtest.TestServerID(types.RoleWindowsDesktop, hostUUID))
+		require.NoError(t, err)
+		t.Cleanup(func() { require.NoError(t, client.Close()) })
+
+		s := &WindowsService{
+			closeCtx: t.Context(),
+			cfg: WindowsServiceConfig{
+				Heartbeat:         HeartbeatConfig{HostUUID: hostUUID},
+				Logger:            slog.New(slog.DiscardHandler),
+				Clock:             clockwork.NewRealClock(),
+				AccessPoint:       client,
+				AuthClient:        client,
+				DiscoveryInterval: 5 * time.Minute,
+			},
+
+			// pre-cache a TLS config so we don't ask auth to issue a real cert
+			// (there isn't a real LDAP server here to connect to)
+			ldapTLSConfig:          new(tls.Config),
+			ldapTLSConfigExpiresAt: time.Now().Add(24 * time.Hour),
+		}
+
+		originalExpiry := time.Now().Add(s.cfg.DiscoveryInterval * 3)
+
+		// Populate last discovery results with some desktops
+		lastDiscoveryResults := map[string]types.WindowsDesktop{}
+		for i := 1; i <= 3; i++ {
+			name := "desktop-" + strconv.Itoa(i)
+			desktop, err := types.NewWindowsDesktopV3(name, map[string]string{
+				types.OriginLabel:                      types.OriginDynamic,
+				types.DiscoveryLabelWindowsDNSHostName: name + ".example.com",
+				types.DiscoveryLabelWindowsOS:          "Windows Server 2019",
+			}, types.WindowsDesktopSpecV3{
+				HostID: hostUUID,
+				Addr:   name + ".example.com:3389",
+			})
+			require.NoError(t, err)
+			desktop.SetExpiry(originalExpiry)
+			lastDiscoveryResults[name] = desktop
+
+			require.NoError(t, tlsServer.Auth().UpsertWindowsDesktop(t.Context(), desktop))
+		}
+		s.lastDiscoveryResults = lastDiscoveryResults
+
+		// Force the reconciler to run.
+		// It will fail because we aren't running a real LDAP server in the test.
+		require.NoError(t, s.startDesktopDiscovery())
+		synctest.Wait()
+
+		time.Sleep(15 * time.Second)
+		preReconcile := time.Now()
+		synctest.Wait()
+
+		// Verify that the reconciler failure did not delete desktops and that
+		// their expiry times were updated.
+		for i := 1; i <= 3; i++ {
+			name := "desktop-" + strconv.Itoa(i)
+			desktops, err := client.GetWindowsDesktops(
+				t.Context(),
+				types.WindowsDesktopFilter{HostID: hostUUID, Name: name},
+			)
+			require.NoError(t, err)
+			require.Len(t, desktops, 1)
+			require.Equal(t, name, desktops[0].GetName())
+
+			// Verify the TTL was updated
+			actualExpiry := desktops[0].Expiry()
+			require.Equal(t, 3*s.cfg.DiscoveryInterval, actualExpiry.Sub(preReconcile))
+		}
+	})
 }


### PR DESCRIPTION
Removes all uses of require.Eventually. Package test runtime decreases from 3.5 seconds to 2.1 seconds (40% reduction).