### PR TITLE
vnet: Stop re-applying utun alias every 10s on macOS

### DIFF
--- a/lib/vnet/osconfig.go
+++ b/lib/vnet/osconfig.go
@@ -126,7 +126,11 @@ func tunIPv6ForPrefix(ipv6Prefix string) (string, error) {
 	return addr.Next().String(), nil
 }
 
-func runCommand(ctx context.Context, path string, args ...string) error {
+// runCommand is a test seam aliased to shellOut.
+var runCommand = shellOut
+
+// shellOut runs path with args. Errors include combined stdout/stderr.
+func shellOut(ctx context.Context, path string, args ...string) error {
 	cmdString := strings.Join(append([]string{path}, args...), " ")
 	log.DebugContext(ctx, "Running command", "cmd", cmdString)
 	cmd := exec.CommandContext(ctx, path, args...)

--- a/lib/vnet/osconfig_darwin.go
+++ b/lib/vnet/osconfig_darwin.go
@@ -22,22 +22,39 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"slices"
 
 	"github.com/google/renameio/v2"
 	"github.com/gravitational/trace"
 )
 
-// platformOSConfigState is not used on darwin.
-type platformOSConfigState struct{}
+// platformOSConfigState tracks applied OS-mutating calls so the
+// 10-second config loop can skip unchanged ones. macOS implements
+// `SIOCSIFADDR` as a delete-then-add, so re-issuing `ifconfig` flaps
+// the alias and breaks linkmon subscribers like Tailscale's
+// magicsock.
+type platformOSConfigState struct {
+	configuredIPv4       bool
+	configuredIPv6Alias  bool
+	configuredIPv6Route  bool
+	configuredCidrRanges []string
+}
 
-// platformConfigureOS configures the host OS according to cfg. It is safe to
-// call repeatedly, and it is meant to be called with an empty osConfig to
-// deconfigure anything necessary before exiting.
-func platformConfigureOS(ctx context.Context, cfg *osConfig, _ *platformOSConfigState) error {
-	// There is no need to remove IP addresses or routes, they will automatically be cleaned up when the
-	// process exits and the TUN is deleted.
+// platformConfigureOS reconciles host OS state for cfg. It is safe
+// to call repeatedly. An empty cfg deconfigures by resetting the
+// cached state so the next call re-applies.
+func platformConfigureOS(ctx context.Context, cfg *osConfig, state *platformOSConfigState) error {
+	// IPs and routes are cleaned up when the TUN is deleted on exit,
+	// so no removal is needed here.
+	if cfg.tunName == "" {
+		if err := configureDNS(ctx, cfg.dnsAddrs, cfg.dnsZones); err != nil {
+			return trace.Wrap(err, "configuring DNS")
+		}
+		*state = platformOSConfigState{}
+		return nil
+	}
 
-	if cfg.tunIPv4 != "" {
+	if cfg.tunIPv4 != "" && !state.configuredIPv4 {
 		log.InfoContext(ctx, "Setting IPv4 address for the TUN device.",
 			"device", cfg.tunName, "address", cfg.tunIPv4)
 		if err := runCommand(ctx,
@@ -45,30 +62,44 @@ func platformConfigureOS(ctx context.Context, cfg *osConfig, _ *platformOSConfig
 		); err != nil {
 			return trace.Wrap(err)
 		}
+		state.configuredIPv4 = true
 	}
 	for _, cidrRange := range cfg.cidrRanges {
+		if slices.Contains(state.configuredCidrRanges, cidrRange) {
+			continue
+		}
 		log.InfoContext(ctx, "Setting an IP route for the VNet.", "netmask", cidrRange)
 		if err := runCommand(ctx,
 			"route", "add", "-net", cidrRange, "-interface", cfg.tunName,
 		); err != nil {
 			return trace.Wrap(err)
 		}
+		state.configuredCidrRanges = append(state.configuredCidrRanges, cidrRange)
 	}
 
-	if cfg.tunIPv6 != "" {
-		log.InfoContext(ctx, "Setting IPv6 address for the TUN device.", "device", cfg.tunName, "address", cfg.tunIPv6)
+	if cfg.tunIPv6 != "" && !state.configuredIPv6Alias {
+		log.InfoContext(ctx, "Setting IPv6 address for the TUN device.",
+			"device", cfg.tunName, "address", cfg.tunIPv6)
 		if err := runCommand(ctx,
 			"ifconfig", cfg.tunName, "inet6", cfg.tunIPv6, "prefixlen", "64",
 		); err != nil {
 			return trace.Wrap(err)
 		}
+		state.configuredIPv6Alias = true
+	}
 
+	// Track the IPv6 route separately from the alias so a transient
+	// route-add failure can be retried on the next tick without
+	// re-running the ifconfig (which would re-trigger the alias flap
+	// this gating exists to prevent).
+	if cfg.tunIPv6 != "" && !state.configuredIPv6Route {
 		log.InfoContext(ctx, "Setting an IPv6 route for the VNet.")
 		if err := runCommand(ctx,
 			"route", "add", "-inet6", cfg.tunIPv6, "-prefixlen", "64", "-interface", cfg.tunName,
 		); err != nil {
 			return trace.Wrap(err)
 		}
+		state.configuredIPv6Route = true
 	}
 
 	if err := configureDNS(ctx, cfg.dnsAddrs, cfg.dnsZones); err != nil {

--- a/lib/vnet/osconfig_darwin.go
+++ b/lib/vnet/osconfig_darwin.go
@@ -28,11 +28,9 @@ import (
 	"github.com/gravitational/trace"
 )
 
-// platformOSConfigState tracks applied OS-mutating calls so the
-// 10-second config loop can skip unchanged ones. macOS implements
-// `SIOCSIFADDR` as a delete-then-add, so re-issuing `ifconfig` flaps
-// the alias and breaks linkmon subscribers like Tailscale's
-// magicsock.
+// platformOSConfigState caches applied calls so the reconcile loop
+// can skip unchanged ones. macOS SIOCSIFADDR is delete-then-add, so
+// re-issuing ifconfig flaps the alias and trips linkmon subscribers.
 type platformOSConfigState struct {
 	configuredIPv4       bool
 	configuredIPv6Alias  bool
@@ -45,7 +43,7 @@ type platformOSConfigState struct {
 // cached state so the next call re-applies.
 func platformConfigureOS(ctx context.Context, cfg *osConfig, state *platformOSConfigState) error {
 	// IPs and routes are cleaned up when the TUN is deleted on exit,
-	// so no removal is needed here.
+	// so no removal is needed.
 	if cfg.tunName == "" {
 		if err := configureDNS(ctx, cfg.dnsAddrs, cfg.dnsZones); err != nil {
 			return trace.Wrap(err, "configuring DNS")

--- a/lib/vnet/osconfig_darwin.go
+++ b/lib/vnet/osconfig_darwin.go
@@ -33,7 +33,7 @@ import (
 // re-issuing ifconfig flaps the alias and trips linkmon subscribers.
 type platformOSConfigState struct {
 	configuredIPv4       bool
-	configuredIPv6Alias  bool
+	configuredIPv6       bool
 	configuredIPv6Route  bool
 	configuredCidrRanges []string
 }
@@ -75,7 +75,7 @@ func platformConfigureOS(ctx context.Context, cfg *osConfig, state *platformOSCo
 		state.configuredCidrRanges = append(state.configuredCidrRanges, cidrRange)
 	}
 
-	if cfg.tunIPv6 != "" && !state.configuredIPv6Alias {
+	if cfg.tunIPv6 != "" && !state.configuredIPv6 {
 		log.InfoContext(ctx, "Setting IPv6 address for the TUN device.",
 			"device", cfg.tunName, "address", cfg.tunIPv6)
 		if err := runCommand(ctx,
@@ -83,7 +83,7 @@ func platformConfigureOS(ctx context.Context, cfg *osConfig, state *platformOSCo
 		); err != nil {
 			return trace.Wrap(err)
 		}
-		state.configuredIPv6Alias = true
+		state.configuredIPv6 = true
 	}
 
 	// Track the IPv6 route separately from the alias so a transient

--- a/lib/vnet/osconfig_darwin_test.go
+++ b/lib/vnet/osconfig_darwin_test.go
@@ -1,0 +1,269 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package vnet
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+type recordedCmd struct {
+	path string
+	args []string
+}
+
+// cmdRecorder captures runCommand invocations for tests.
+type cmdRecorder struct {
+	cmds []recordedCmd
+}
+
+func (r *cmdRecorder) run(_ context.Context, path string, args ...string) error {
+	r.cmds = append(r.cmds, recordedCmd{path: path, args: args})
+	return nil
+}
+
+// setupOSConfigTest installs a cmdRecorder in place of runCommand
+// and points resolverPath at a temp dir for the duration of t. Tests
+// that use this helper mutate package-level vars, so they must not
+// call t.Parallel.
+func setupOSConfigTest(t *testing.T) *cmdRecorder {
+	t.Helper()
+
+	recorder := &cmdRecorder{}
+
+	prevRunCommand := runCommand
+	runCommand = recorder.run
+	t.Cleanup(func() { runCommand = prevRunCommand })
+
+	prevResolverPath := resolverPath
+	resolverPath = t.TempDir()
+	t.Cleanup(func() { resolverPath = prevResolverPath })
+
+	return recorder
+}
+
+func TestPlatformConfigureOS_AppliesIPv4OnFirstCall(t *testing.T) {
+	recorder := setupOSConfigTest(t)
+	state := &platformOSConfigState{}
+
+	require.NoError(t, platformConfigureOS(t.Context(), &osConfig{
+		tunName: "utun4",
+		tunIPv4: "100.64.0.1",
+	}, state))
+
+	require.Equal(t, []recordedCmd{
+		{path: "ifconfig", args: []string{"utun4", "100.64.0.1", "100.64.0.1", "up"}},
+	}, recorder.cmds)
+}
+
+// Regression guard: the per-tick alias flap that motivated this gating.
+func TestPlatformConfigureOS_SkipsIPv4OnSecondCall(t *testing.T) {
+	recorder := setupOSConfigTest(t)
+	state := &platformOSConfigState{}
+	cfg := &osConfig{
+		tunName: "utun4",
+		tunIPv4: "100.64.0.1",
+	}
+
+	require.NoError(t, platformConfigureOS(t.Context(), cfg, state))
+	require.NoError(t, platformConfigureOS(t.Context(), cfg, state))
+
+	require.Equal(t, []recordedCmd{
+		{path: "ifconfig", args: []string{"utun4", "100.64.0.1", "100.64.0.1", "up"}},
+	}, recorder.cmds, "second call must not re-run ifconfig")
+}
+
+func TestPlatformConfigureOS_AppliesNewCidrRange(t *testing.T) {
+	recorder := setupOSConfigTest(t)
+	state := &platformOSConfigState{}
+
+	require.NoError(t, platformConfigureOS(t.Context(), &osConfig{
+		tunName:    "utun4",
+		tunIPv4:    "100.64.0.1",
+		cidrRanges: []string{"100.64.0.0/10"},
+	}, state))
+	require.NoError(t, platformConfigureOS(t.Context(), &osConfig{
+		tunName:    "utun4",
+		tunIPv4:    "100.64.0.1",
+		cidrRanges: []string{"100.64.0.0/10", "10.0.0.0/8"},
+	}, state))
+
+	require.Equal(t, []recordedCmd{
+		{path: "ifconfig", args: []string{"utun4", "100.64.0.1", "100.64.0.1", "up"}},
+		{path: "route", args: []string{"add", "-net", "100.64.0.0/10", "-interface", "utun4"}},
+		{path: "route", args: []string{"add", "-net", "10.0.0.0/8", "-interface", "utun4"}},
+	}, recorder.cmds)
+}
+
+func TestPlatformConfigureOS_SkipsExistingCidrRange(t *testing.T) {
+	recorder := setupOSConfigTest(t)
+	state := &platformOSConfigState{}
+	cfg := &osConfig{
+		tunName:    "utun4",
+		tunIPv4:    "100.64.0.1",
+		cidrRanges: []string{"100.64.0.0/10"},
+	}
+
+	require.NoError(t, platformConfigureOS(t.Context(), cfg, state))
+	require.NoError(t, platformConfigureOS(t.Context(), cfg, state))
+
+	require.Equal(t, []recordedCmd{
+		{path: "ifconfig", args: []string{"utun4", "100.64.0.1", "100.64.0.1", "up"}},
+		{path: "route", args: []string{"add", "-net", "100.64.0.0/10", "-interface", "utun4"}},
+	}, recorder.cmds, "second call must not re-run ifconfig or route add")
+}
+
+func TestPlatformConfigureOS_SkipsIPv6OnSecondCall(t *testing.T) {
+	recorder := setupOSConfigTest(t)
+	state := &platformOSConfigState{}
+	cfg := &osConfig{
+		tunName: "utun4",
+		tunIPv6: "fdd4:a23:da97::1",
+	}
+
+	require.NoError(t, platformConfigureOS(t.Context(), cfg, state))
+	require.NoError(t, platformConfigureOS(t.Context(), cfg, state))
+
+	require.Equal(t, []recordedCmd{
+		{path: "ifconfig", args: []string{"utun4", "inet6", "fdd4:a23:da97::1", "prefixlen", "64"}},
+		{path: "route", args: []string{"add", "-inet6", "fdd4:a23:da97::1", "-prefixlen", "64", "-interface", "utun4"}},
+	}, recorder.cmds, "second call must not re-run IPv6 ifconfig or route add")
+}
+
+// Deconfigure (empty osConfig) must reset cached state so a
+// subsequent populated call re-applies. Pins the invariant that lets
+// a future refactor reuse osConfigState across a clean shutdown
+// without silently caching stale entries.
+func TestPlatformConfigureOS_ReappliesAfterDeconfigure(t *testing.T) {
+	recorder := setupOSConfigTest(t)
+	state := &platformOSConfigState{}
+	cfg := &osConfig{
+		tunName: "utun4",
+		tunIPv4: "100.64.0.1",
+	}
+	ifconfigCmd := recordedCmd{
+		path: "ifconfig",
+		args: []string{"utun4", "100.64.0.1", "100.64.0.1", "up"},
+	}
+
+	require.NoError(t, platformConfigureOS(t.Context(), cfg, state))
+	require.Equal(t, []recordedCmd{ifconfigCmd}, recorder.cmds)
+
+	require.NoError(t, platformConfigureOS(t.Context(), &osConfig{}, state))
+	require.Equal(t, []recordedCmd{ifconfigCmd}, recorder.cmds,
+		"deconfigure call must not run any commands")
+
+	require.NoError(t, platformConfigureOS(t.Context(), cfg, state))
+	require.Equal(t, []recordedCmd{ifconfigCmd, ifconfigCmd}, recorder.cmds,
+		"post-deconfigure call must re-apply the original ifconfig")
+}
+
+// Pins the "do not cache failed state" invariant: a runCommand error
+// must leave the corresponding flag unset so the next call retries.
+// Guards against future refactors that move the state assignment
+// ahead of the runCommand call.
+func TestPlatformConfigureOS_PropagatesRunCommandError(t *testing.T) {
+	recorder := setupOSConfigTest(t)
+	state := &platformOSConfigState{}
+	cfg := &osConfig{
+		tunName: "utun4",
+		tunIPv4: "100.64.0.1",
+	}
+
+	wantErr := errors.New("ifconfig boom")
+	runCommand = func(_ context.Context, _ string, _ ...string) error {
+		recorder.cmds = append(recorder.cmds, recordedCmd{path: "ifconfig"})
+		return wantErr
+	}
+
+	err := platformConfigureOS(t.Context(), cfg, state)
+	require.ErrorIs(t, err, wantErr)
+	require.False(t, state.configuredIPv4,
+		"state must not record success on a failing runCommand")
+
+	runCommand = recorder.run
+
+	require.NoError(t, platformConfigureOS(t.Context(), cfg, state))
+	require.True(t, state.configuredIPv4,
+		"successful retry must mark state configured")
+	require.Len(t, recorder.cmds, 2,
+		"failing call plus successful retry must record two ifconfig invocations")
+}
+
+// A transient `route add -inet6` failure must leave configuredIPv6Route
+// unset so the next tick retries just the route. The ifconfig alias
+// must not re-run, otherwise the alias flap returns.
+func TestPlatformConfigureOS_RetriesIPv6RouteAfterFailure(t *testing.T) {
+	recorder := setupOSConfigTest(t)
+	state := &platformOSConfigState{}
+	cfg := &osConfig{
+		tunName: "utun4",
+		tunIPv6: "fdd4:a23:da97::1",
+	}
+
+	wantErr := errors.New("route boom")
+	runCommand = func(_ context.Context, path string, args ...string) error {
+		recorder.cmds = append(recorder.cmds, recordedCmd{path: path, args: args})
+		if path == "route" {
+			return wantErr
+		}
+		return nil
+	}
+
+	err := platformConfigureOS(t.Context(), cfg, state)
+	require.ErrorIs(t, err, wantErr)
+	require.True(t, state.configuredIPv6Alias,
+		"alias must be marked configured after ifconfig succeeds")
+	require.False(t, state.configuredIPv6Route,
+		"route must not be marked configured on a failing route add")
+
+	runCommand = recorder.run
+
+	require.NoError(t, platformConfigureOS(t.Context(), cfg, state))
+	require.True(t, state.configuredIPv6Route)
+
+	require.Equal(t, []recordedCmd{
+		{path: "ifconfig", args: []string{"utun4", "inet6", "fdd4:a23:da97::1", "prefixlen", "64"}},
+		{path: "route", args: []string{"add", "-inet6", "fdd4:a23:da97::1", "-prefixlen", "64", "-interface", "utun4"}},
+		{path: "route", args: []string{"add", "-inet6", "fdd4:a23:da97::1", "-prefixlen", "64", "-interface", "utun4"}},
+	}, recorder.cmds, "ifconfig must run only once; route must be retried")
+}
+
+// Covers the typical production cfg: IPv4, IPv6 and a CIDR together.
+func TestPlatformConfigureOS_FullConfigSkipsOnSecondCall(t *testing.T) {
+	recorder := setupOSConfigTest(t)
+	state := &platformOSConfigState{}
+	cfg := &osConfig{
+		tunName:    "utun4",
+		tunIPv4:    "100.64.0.1",
+		tunIPv6:    "fdd4:a23:da97::1",
+		cidrRanges: []string{"100.64.0.0/10"},
+	}
+
+	require.NoError(t, platformConfigureOS(t.Context(), cfg, state))
+	require.NoError(t, platformConfigureOS(t.Context(), cfg, state))
+
+	require.Equal(t, []recordedCmd{
+		{path: "ifconfig", args: []string{"utun4", "100.64.0.1", "100.64.0.1", "up"}},
+		{path: "route", args: []string{"add", "-net", "100.64.0.0/10", "-interface", "utun4"}},
+		{path: "ifconfig", args: []string{"utun4", "inet6", "fdd4:a23:da97::1", "prefixlen", "64"}},
+		{path: "route", args: []string{"add", "-inet6", "fdd4:a23:da97::1", "-prefixlen", "64", "-interface", "utun4"}},
+	}, recorder.cmds, "second call with unchanged cfg must record zero new commands")
+}

--- a/lib/vnet/osconfig_darwin_test.go
+++ b/lib/vnet/osconfig_darwin_test.go
@@ -229,7 +229,7 @@ func TestPlatformConfigureOS_RetriesIPv6RouteAfterFailure(t *testing.T) {
 
 	err := platformConfigureOS(t.Context(), cfg, state)
 	require.ErrorIs(t, err, wantErr)
-	require.True(t, state.configuredIPv6Alias,
+	require.True(t, state.configuredIPv6,
 		"alias must be marked configured after ifconfig succeeds")
 	require.False(t, state.configuredIPv6Route,
 		"route must not be marked configured on a failing route add")


### PR DESCRIPTION
Before this fix, on macOS the VNet OS-configuration loop re-issued `ifconfig` and `route add` for the TUN interface on every 10-second tick, even when the desired state was unchanged. macOS implements the underlying `SIOCSIFADDR` as a delete-then-add, so each tick emitted an `RTM_DELADDR`/`RTM_NEWADDR` pair on the kernel route socket. Other linkmon subscribers, notably Tailscale's magicsock embedded in the Coder client, read that pair as a major link change, tore down their DERP relay and WireGuard handshake, and reconnected. When Coder traffic was routed through `utun4`, the reconnect cost showed up as multi-second latency spikes on inflight pings, recurring on the 10-second cadence.

Track the configured IPv4, IPv6, and CIDR ranges in `platformOSConfigState` on darwin so the next tick skips re-applying unchanged values. linux and windows already do this.

Verified locally on AU Mac client:

| metric `coder ping`| base (HTTP/no-VNet) | pre-fix (TCP/VNet) | post-fix (TCP/VNet) |
|---|---|---|---|
| min | 355 ms | 356 ms | 362 ms |
| avg | 361 ms | 473 ms (+112) | 384 ms (+23) |
| max | 394 ms | **2,692 ms** | **577 ms** |
| stddev | 8 ms | 141 ms | **1.46 ms** |
| spikes ≥ 1s in 180 pings | 0 | **7** | **0** |
| `RTM_DELADDR`/`NEWADDR` pairs per 270s | 0 | **28** | **0** |

## Manual Test Plan

### Test Environment

macOS (tested on Darwin 25.3.0, arm64) with `tsh vnet` running and a Teleport cluster with at least one app or workspace reachable via VNet. A second tool that subscribes to the macOS route socket helps observe the symptom: a Coder client (which uses Tailscale's magicsock) is the canonical case, but `route monitor` is enough to see the kernel events.

### Test Cases

#### Test 1: No alias flap on `utun` while VNet is running (with fix)

Start `tsh vnet`. In a separate terminal:

```
sudo route -n monitor 2>&1 | tee /tmp/vnet-flap.log
```

Leave both running for at least 270 seconds (27 ticks at 10s cadence).

- [x] After the initial setup, no further `RTM_DELADDR` / `RTM_NEWADDR` events appear on the VNet `utun*` interface.
- [x] One `RTM_DELADDR` / `RTM_NEWADDR` pair on shutdown (when `tsh vnet` exits) is acceptable; the steady-state cycle is what was regressing.

#### Test 2: New CIDR ranges still get added on next tick (with fix)

With `tsh vnet` running, log in to a second cluster (whose VNet CIDR differs from the first):

```
tsh login --proxy=<second-proxy>
```

Watch the daemon log for the next OS-config-loop iteration.

- [x] A `route add -net <new-CIDR> -interface utun*` log line appears within the next 10 seconds.
- [x] No `ifconfig` re-application accompanies it.

#### Test 3: Shutdown still removes VNet state (with fix)

Stop `tsh vnet` cleanly (Ctrl-C or `kill`).

- [x] The `utun*` interface goes away after shutdown (the kernel cleans up the device when the daemon exits, as before).
- [x] No leftover routes targeting the destroyed interface.

#### Test 4: Coder ping stability (with fix)

If a Coder workspace is available, with `tsh vnet` running and Coder traffic routed through `utun*` (Config D, direct TCP through VNet, not HTTP+mTLS):

```
coder ping <workspace> --num 180
```

- [x] Zero pings >= 1 second. Before the fix, the same run produced multiple multi-second spikes (7 in 180, max ~2.7 s).
- [x] Standard deviation collapses to a few ms (was ~140 ms pre-fix).

#### Test 5: Regression baseline (without fix)

Build from `master` (before this PR) and repeat Test 1.

- [x] An `RTM_DELADDR` / `RTM_NEWADDR` pair appears on `utun*` every ~10 seconds, wall-clock aligned. Confirms the bug exists pre-fix.

