### PR TITLE
Discover: do not prompt when leaving Connect My Computer

### DIFF
--- a/web/packages/teleport/src/Discover/ConnectMyComputer/index.ts
+++ b/web/packages/teleport/src/Discover/ConnectMyComputer/index.ts
@@ -26,6 +26,7 @@ import { TestConnection } from './TestConnection';
 
 export const ConnectMyComputerResource: ResourceViewConfig<ResourceSpec> = {
   kind: ResourceKind.ConnectMyComputer,
+  shouldPrompt: () => false,
   views: [
     {
       title: 'Set Up Teleport Connect',

--- a/web/packages/teleport/src/Discover/Discover.test.tsx
+++ b/web/packages/teleport/src/Discover/Discover.test.tsx
@@ -327,3 +327,19 @@ test('update flow: agentMeta is prepopulated based on agentMeta', () => {
 
   expect(screen.getByText('saml2')).toBeInTheDocument();
 });
+
+test('Connect My Computer does not prompt when leaving the flow', async () => {
+  renderUpdate({
+    resourceSpec: resourceSpecConnectMyComputer,
+    agentMeta: { resourceName: '' },
+  });
+
+  const text = await screen.findByText('Sign In & Connect My Computer');
+  expect(text).toBeInTheDocument();
+
+  // Simulate closing the tab / opening a deep link.
+  const event = new Event('beforeunload', { cancelable: true });
+  window.dispatchEvent(event);
+
+  expect(event.defaultPrevented).toBe(false);
+});


### PR DESCRIPTION
Closes https://github.com/gravitational/teleport/issues/65215

During the React Router upgrade, we introduced a custom version of `Prompt` that triggers not only on SPA route changes but also on the `beforeunload` event.

The latter causes an unintended prompt to appear in the Connect My Computer Discover flow. When you click a deep link, it first emits the `beforeunload` event which blocks opening Teleport Connect.

A similar issue also exists in v17 and v18. Navigating away from this screen via the sidebar menu triggers the prompt for an SPA route change.

Since there is no user state to preserve on this screen, the simplest and safest fix is to disable the prompt entirely for it.

<!-- Provide a descriptive entry for the changelog of the next release. -->


<!-- Include manual testing efforts to verify the change. -->
<!-- Detail where the tests where run and what configurations were used. -->
<!-- Include all the test cases which were run to validate the change. -->

## Manual Test Plan
### Test Environment
`pnpm start-teleport`.

### Test Cases
- [x] Opening a Connect My Computer deep link doesn't trigger the prompt.
- [x] Navigating away from the Connect My Computer page doesn't trigger the prompt. 
