### PR TITLE
Vite dev server fixes for IP based and non-http2 targes

### DIFF
--- a/web/packages/build/vite/config.ts
+++ b/web/packages/build/vite/config.ts
@@ -17,7 +17,10 @@
  */
 
 import { existsSync, readFileSync } from 'fs';
+import { Agent as HttpsAgent, type RequestOptions } from 'https';
+import { isIP } from 'net';
 import { resolve } from 'path';
+import type { Duplex } from 'stream';
 
 import { visualizer } from 'rollup-plugin-visualizer';
 import { defineConfig, type ProxyOptions, type UserConfig } from 'vite';
@@ -266,6 +269,7 @@ function wsRoute(target: string, path: string): [string, ProxyOptions] {
       ws: true,
       changeOrigin,
       rewriteWsOrigin: changeOrigin,
+      agent: getProxyAgent(target),
     },
   ];
 }
@@ -277,6 +281,31 @@ function httpRoute(target: string, path: string): [string, ProxyOptions] {
       target: `https://${target}`,
       secure: false,
       changeOrigin: shouldChangeOrigin(target),
+      agent: getProxyAgent(target),
     },
   ];
+}
+
+// Suppress SNI for IP-literal targets. Newer Node either warns (DEP0123) or
+// drops the IP servername outright, which can break the upstream TLS handshake.
+class NoSniAgent extends HttpsAgent {
+  createConnection(
+    options: RequestOptions,
+    callback?: (err: Error | null, stream: Duplex) => void
+  ) {
+    return super.createConnection({ ...options, servername: '' }, callback);
+  }
+}
+
+let cachedNoSniAgent: NoSniAgent | null = null;
+
+function getProxyAgent(target: string): HttpsAgent | undefined {
+  const { hostname } = new URL(`https://${target}`);
+  if (!isIP(hostname)) {
+    return undefined;
+  }
+  if (!cachedNoSniAgent) {
+    cachedNoSniAgent = new NoSniAgent({ rejectUnauthorized: false });
+  }
+  return cachedNoSniAgent;
 }

--- a/web/packages/build/vite/config.ts
+++ b/web/packages/build/vite/config.ts
@@ -29,7 +29,7 @@ import { guardWasmPlugin } from './guard-wasm';
 import { htmlPlugin, transformPlugin } from './html';
 import { reactPlugin } from './react.mjs';
 
-const DEFAULT_PROXY_TARGET = '127.0.0.1:3080';
+const DEFAULT_PROXY_TARGET = 'localhost:3080';
 const ENTRY_FILE_NAME = 'app/app.js';
 
 export function createViteConfig(

--- a/web/packages/build/vite/config.ts
+++ b/web/packages/build/vite/config.ts
@@ -242,15 +242,30 @@ function resolveTargetURL(url: string) {
   return parsed.host;
 }
 
+// Rewrite Host / Origin only when VITE_HOST is set and its hostname differs
+// from the proxy target. Otherwise the original headers are correct as-is.
+function shouldChangeOrigin(target: string): boolean {
+  if (!process.env.VITE_HOST) {
+    return false;
+  }
+
+  const { hostname: viteHost } = new URL(`https://${process.env.VITE_HOST}`);
+  const { hostname: targetHost } = new URL(`https://${target}`);
+
+  return viteHost !== targetHost;
+}
+
 function wsRoute(target: string, path: string): [string, ProxyOptions] {
+  const changeOrigin = shouldChangeOrigin(target);
+
   return [
     path,
     {
       target: `wss://${target}`,
       secure: false,
       ws: true,
-      changeOrigin: true,
-      rewriteWsOrigin: true,
+      changeOrigin,
+      rewriteWsOrigin: changeOrigin,
     },
   ];
 }
@@ -261,7 +276,7 @@ function httpRoute(target: string, path: string): [string, ProxyOptions] {
     {
       target: `https://${target}`,
       secure: false,
-      changeOrigin: true,
+      changeOrigin: shouldChangeOrigin(target),
     },
   ];
 }

--- a/web/packages/build/vite/html.ts
+++ b/web/packages/build/vite/html.ts
@@ -20,6 +20,7 @@ import { readFileSync } from 'fs';
 import type * as http from 'http';
 import type * as http2 from 'http2';
 import { connect } from 'http2';
+import { isIP } from 'net';
 import { resolve } from 'path';
 
 import type { Plugin } from 'vite';
@@ -130,8 +131,14 @@ function getSession(target: string) {
     return session;
   }
 
+  const { hostname } = new URL(`https://${target}`);
+
   const created = connect(`https://${target}`, {
     rejectUnauthorized: false,
+    // SNI must not be an IP literal. Newer Node will silently drop the IP
+    // servername, which can leave the h2 session in a broken state; suppress
+    // it explicitly here.
+    ...(isIP(hostname) && { servername: '' }),
   });
 
   function invalidate() {

--- a/web/packages/build/vite/html.ts
+++ b/web/packages/build/vite/html.ts
@@ -18,8 +18,7 @@
 
 import { readFileSync } from 'fs';
 import type * as http from 'http';
-import type * as http2 from 'http2';
-import { connect } from 'http2';
+import * as https from 'https';
 import { isIP } from 'net';
 import { resolve } from 'path';
 
@@ -97,8 +96,8 @@ export function transformPlugin(): Plugin {
   };
 }
 
-// Headers that can't cross into HTTP/2. `host` is covered by `:authority` instead.
-const H2_FORBIDDEN_HEADERS = new Set([
+// Headers that shouldn't be forwarded to the upstream request.
+const FORBIDDEN_HEADERS = new Set([
   'connection',
   'proxy-connection',
   'keep-alive',
@@ -122,46 +121,30 @@ const indexHtmlPath = resolve(process.cwd(), 'index.html');
 // read it once.
 let cachedTemplate: string | null = null;
 
-// One long-lived h2 session keeps every SPA-shell request on the same TCP + TLS +
-// SETTINGS handshake. Recreated lazily on close / error / GOAWAY.
-let session: http2.ClientHttp2Session | null = null;
+// Cached HTTPS agent for connection reuse.
+let cachedAgent: https.Agent | null = null;
 
-function getSession(target: string) {
-  if (session && !session.closed && !session.destroyed) {
-    return session;
+function getAgent(target: string): https.Agent {
+  if (cachedAgent) {
+    return cachedAgent;
   }
 
   const { hostname } = new URL(`https://${target}`);
 
-  const created = connect(`https://${target}`, {
+  cachedAgent = new https.Agent({
     rejectUnauthorized: false,
     // SNI must not be an IP literal. Newer Node will silently drop the IP
-    // servername, which can leave the h2 session in a broken state; suppress
+    // servername, which can leave the connection in a broken state; suppress
     // it explicitly here.
     ...(isIP(hostname) && { servername: '' }),
   });
 
-  function invalidate() {
-    if (session === created) {
-      session = null;
-    }
-  }
-
-  created.on('close', invalidate);
-  created.on('error', invalidate);
-  created.on('goaway', invalidate);
-
-  session = created;
-
-  return created;
+  return cachedAgent;
 }
 
 function fetchIndexHtml(reqHeaders: http.IncomingHttpHeaders, target: string) {
-  const h2Headers: http2.OutgoingHttpHeaders = {
-    ':method': 'GET',
-    ':path': '/web',
-    ':scheme': 'https',
-    ':authority': target,
+  const headers: http.OutgoingHttpHeaders = {
+    host: target,
   };
 
   for (const [name, value] of Object.entries(reqHeaders)) {
@@ -169,28 +152,36 @@ function fetchIndexHtml(reqHeaders: http.IncomingHttpHeaders, target: string) {
       continue;
     }
 
-    if (H2_FORBIDDEN_HEADERS.has(name.toLowerCase())) {
+    if (FORBIDDEN_HEADERS.has(name.toLowerCase())) {
       continue;
     }
 
-    h2Headers[name] = value;
+    headers[name] = value;
   }
 
-  return new Promise<{ body: string; headers: http2.IncomingHttpHeaders }>(
+  const { hostname, port } = new URL(`https://${target}`);
+
+  return new Promise<{ body: string; headers: http.IncomingHttpHeaders }>(
     (resolve, reject) => {
-      const req = getSession(target).request(h2Headers);
+      const req = https.request(
+        {
+          hostname,
+          port: port || 443,
+          path: '/web',
+          method: 'GET',
+          headers,
+          agent: getAgent(target),
+        },
+        res => {
+          let body = '';
+          res.setEncoding('utf8');
+          res.on('data', chunk => {
+            body += chunk;
+          });
+          res.on('end', () => resolve({ body, headers: res.headers }));
+        }
+      );
 
-      let body = '';
-      let headers: http2.IncomingHttpHeaders = {};
-
-      req.setEncoding('utf8');
-      req.on('response', h => {
-        headers = h;
-      });
-      req.on('data', chunk => {
-        body += chunk;
-      });
-      req.on('end', () => resolve({ body, headers }));
       req.on('error', reject);
       req.end();
     }


### PR DESCRIPTION
For some reason some Teleport proxies don't respond well to http2 requests. This changes the HTML plugin back to http 1.1

Also adds support for targeting IP addresses, changes the default proxy target to `localhost` instead of `127.0.0.1`, and changes the origin rewrite behaviour to only rewrite the origin when the proxy target and vite host are different (and vite host is set)

## Manual Test Plan
### Test Environment
Mine and @avatus machines

### Test Cases
- [x] HTML plugin works across multiple different Teleport proxies
- [x] Websocket connects work when vite host differs from proxy host
