### PR TITLE
[AWSIC] Add `iam:CreateSAMLProvider` to Identity Center Policy

### DIFF
--- a/docs/pages/identity-governance/integrations/aws-iam-identity-center/guide.mdx
+++ b/docs/pages/identity-governance/integrations/aws-iam-identity-center/guide.mdx
@@ -86,7 +86,8 @@ iam:ListAttachedRolePolicies
 iam:ListRolePolicies
 
 // AllowAccountAssignmentOnOwner
-iam:GetSAMLProvider
+iam:GetSAMLProvider 
+iam:CreateSAMLProvider
 
 // ListProvisionedRoles
 iam:ListRoles

--- a/lib/cloud/aws/policy_statements.go
+++ b/lib/cloud/aws/policy_statements.go
@@ -560,6 +560,7 @@ func StatementForAWSIdentityCenterAccess() *Statement {
 
 			// AllowAccountAssignmentOnOwner
 			"iam:GetSAMLProvider",
+			"iam:CreateSAMLProvider",
 
 			// ListProvisionedRoles
 			"iam:ListRoles",

--- a/lib/integrations/awsoidc/testdata/TestConfigureIdPIAMWithPolicyPresetOutput.golden
+++ b/lib/integrations/awsoidc/testdata/TestConfigureIdPIAMWithPolicyPresetOutput.golden
@@ -90,6 +90,7 @@ AssignPolicy: {
             "iam:ListAttachedRolePolicies",
             "iam:ListRolePolicies",
             "iam:GetSAMLProvider",
+            "iam:CreateSAMLProvider",
             "iam:ListRoles"
         ],
         "Resource": "*",


### PR DESCRIPTION
Adds the required `iam:CreateSAMLProvider` permission to the Teleport-generated
Identity Center policy statement. This permission is required when provisioning
the first Account Assignment to a new AWS Account in order to create a SAML provider
that ties the AWS Account into the Identity Center instance's auth system.
