### PR TITLE
[vnet] Disable client tool auto-updates in VNet systemd service

### DIFF
--- a/examples/systemd/vnet/teleport-vnet.service
+++ b/examples/systemd/vnet/teleport-vnet.service
@@ -6,6 +6,7 @@ Requires=dbus.service
 [Service]
 Type=dbus
 BusName=org.teleport.vnet1
+Environment=TELEPORT_TOOLS_VERSION=off
 ExecStart=/usr/local/bin/tsh vnet-daemon
 User=root
 Group=root


### PR DESCRIPTION
Already in v18 https://github.com/gravitational/teleport/pull/64737/changes/82973fb63bd02954bdd362fdc3759b4fd18b902a

Explicitly set `TELEPORT_TOOLS_VERSION=off` in the systemd unit to prevent undesired client tool auto-updates in the VNet daemon. It was already safe in practice because root has no `~/.tsh`, but if `HOME` or `TELEPORT_HOME` gets redirected the daemon could initiate an auto-update on the next start.


## Manual Test Plan
### Test Environment
any Linux distro with systemd, D-Bus and polkit

### Test Cases
- [x] can start VNet with `tsh vnet`
- [x] can connect to TCP app over VNet
- [x]  can connect to SSH node over VNet