### PR TITLE
Trim Azure matcher selectors before dedup

### DIFF
--- a/lib/services/matchers.go
+++ b/lib/services/matchers.go
@@ -31,6 +31,7 @@ import (
 	apiutils "github.com/gravitational/teleport/api/utils"
 	azureutils "github.com/gravitational/teleport/api/utils/azure"
 	"github.com/gravitational/teleport/lib/scopes"
+	"github.com/gravitational/teleport/lib/utils"
 	libslices "github.com/gravitational/teleport/lib/utils/slices"
 	"github.com/gravitational/teleport/lib/utils/typical"
 )
@@ -77,13 +78,18 @@ func AssumeRoleFromAWSMetadata(meta *types.AWS) types.AssumeRole {
 }
 
 // SimplifyAzureMatchers returns simplified Azure Matchers.
-// Selectors are deduplicated, wildcard in a selector reduces the selector
-// to just the wildcard, and defaults are applied.
+// Selectors are trimmed of whitespace, deduplicated, wildcard in a selector
+// reduces the selector to just the wildcard, and defaults are applied.
+//
+// Trim runs BEFORE dedupe so whitespace variants like " sub-1" and "sub-1"
+// collapse instead of surviving byte-equality dedup as distinct entries.
+// Empty-after-trim entries are dropped silently; an entry list that is
+// empty (or all-empty) collapses to the wildcard.
 func SimplifyAzureMatchers(matchers []types.AzureMatcher) []types.AzureMatcher {
 	result := make([]types.AzureMatcher, 0, len(matchers))
 	for _, m := range matchers {
-		subs := apiutils.Deduplicate(m.Subscriptions)
-		groups := apiutils.Deduplicate(m.ResourceGroups)
+		subs := libslices.FilterMapUnique(m.Subscriptions, utils.TrimNonEmpty)
+		groups := libslices.FilterMapUnique(m.ResourceGroups, utils.TrimNonEmpty)
 		ts := apiutils.Deduplicate(m.Types)
 		if len(subs) == 0 || slices.Contains(subs, types.Wildcard) {
 			subs = []string{types.Wildcard}

--- a/lib/services/matchers.go
+++ b/lib/services/matchers.go
@@ -77,19 +77,11 @@ func AssumeRoleFromAWSMetadata(meta *types.AWS) types.AssumeRole {
 	}
 }
 
-// SimplifyAzureMatchers returns simplified Azure Matchers.
-// Selectors are trimmed of whitespace, deduplicated, and wildcard in a
-// selector reduces the selector to just the wildcard. Defaults are applied.
-//
-// Trim runs BEFORE dedup so whitespace variants like " sub-1" and "sub-1"
-// collapse instead of surviving byte-equality dedup as distinct entries.
-// Truly empty selector lists (len(input) == 0) collapse to the wildcard
-// per existing convention.
-//
-// The malformed-but-non-empty case (e.g. [" "], ["", "  "]) does NOT widen
-// to wildcard. Widening would silently turn a config typo into a
-// match-everything scope. The original input is preserved instead so the
-// downstream Azure SDK call surfaces the typo as an invalid-scope error.
+// SimplifyAzureMatchers returns simplified Azure matchers. Each selector list
+// is trimmed, deduplicated, and collapsed to the wildcard if any entry is the
+// wildcard or the list is empty. Lists where every entry is whitespace-only are
+// preserved verbatim rather than widened to wildcard, so invalid hand-edited
+// scopes fail closed downstream instead of matching all.
 func SimplifyAzureMatchers(matchers []types.AzureMatcher) []types.AzureMatcher {
 	result := make([]types.AzureMatcher, 0, len(matchers))
 	for _, m := range matchers {

--- a/lib/services/matchers.go
+++ b/lib/services/matchers.go
@@ -78,25 +78,24 @@ func AssumeRoleFromAWSMetadata(meta *types.AWS) types.AssumeRole {
 }
 
 // SimplifyAzureMatchers returns simplified Azure Matchers.
-// Selectors are trimmed of whitespace, deduplicated, wildcard in a selector
-// reduces the selector to just the wildcard, and defaults are applied.
+// Selectors are trimmed of whitespace, deduplicated, and wildcard in a
+// selector reduces the selector to just the wildcard. Defaults are applied.
 //
-// Trim runs BEFORE dedupe so whitespace variants like " sub-1" and "sub-1"
+// Trim runs BEFORE dedup so whitespace variants like " sub-1" and "sub-1"
 // collapse instead of surviving byte-equality dedup as distinct entries.
-// Empty-after-trim entries are dropped silently; an entry list that is
-// empty (or all-empty) collapses to the wildcard.
+// Truly empty selector lists (len(input) == 0) collapse to the wildcard
+// per existing convention.
+//
+// The malformed-but-non-empty case (e.g. [" "], ["", "  "]) does NOT widen
+// to wildcard. Widening would silently turn a config typo into a
+// match-everything scope. The original input is preserved instead so the
+// downstream Azure SDK call surfaces the typo as an invalid-scope error.
 func SimplifyAzureMatchers(matchers []types.AzureMatcher) []types.AzureMatcher {
 	result := make([]types.AzureMatcher, 0, len(matchers))
 	for _, m := range matchers {
-		subs := libslices.FilterMapUnique(m.Subscriptions, utils.TrimNonEmpty)
-		groups := libslices.FilterMapUnique(m.ResourceGroups, utils.TrimNonEmpty)
+		subs := simplifySelector(m.Subscriptions)
+		groups := simplifySelector(m.ResourceGroups)
 		ts := apiutils.Deduplicate(m.Types)
-		if len(subs) == 0 || slices.Contains(subs, types.Wildcard) {
-			subs = []string{types.Wildcard}
-		}
-		if len(groups) == 0 || slices.Contains(groups, types.Wildcard) {
-			groups = []string{types.Wildcard}
-		}
 		var regions []string
 		if len(m.Regions) == 0 || slices.Contains(m.Regions, types.Wildcard) {
 			regions = []string{types.Wildcard}
@@ -114,6 +113,37 @@ func SimplifyAzureMatchers(matchers []types.AzureMatcher) []types.AzureMatcher {
 		result = append(result, elem)
 	}
 	return result
+}
+
+// simplifySelector applies the SimplifyAzureMatchers normalization rules to a
+// single selector list (Subscriptions or ResourceGroups). The four input
+// shapes are handled distinctly to avoid silently widening malformed config
+// to the wildcard:
+//
+//   - empty input (len == 0)                -> wildcard (existing convention)
+//   - any wildcard among trimmed entries    -> wildcard (existing convention)
+//   - non-empty input with at least one
+//     non-empty trimmed entry               -> trimmed, deduped entries
+//   - non-empty input that ALL trim to empty
+//     (e.g. [" "], ["", "  "])              -> original input preserved verbatim
+//     (do NOT widen to wildcard; the Azure
+//     SDK call surfaces the typo)
+func simplifySelector(input []string) []string {
+	if len(input) == 0 {
+		return []string{types.Wildcard}
+	}
+	trimmed := libslices.FilterMapUnique(input, utils.TrimNonEmpty)
+	if slices.Contains(trimmed, types.Wildcard) {
+		return []string{types.Wildcard}
+	}
+	if len(trimmed) == 0 {
+		// User supplied selectors but every entry was whitespace-only.
+		// This is a config typo, not a "match everything" signal.
+		// Preserve the original input so the Azure SDK rejects it as an
+		// invalid scope rather than silently broadening discovery.
+		return input
+	}
+	return trimmed
 }
 
 // MatchResourceLabels returns true if any of the provided selectors matches the provided database.

--- a/lib/services/matchers_test.go
+++ b/lib/services/matchers_test.go
@@ -318,13 +318,18 @@ func TestSimplifyAzureMatchersTrimmedWildcardCollapses(t *testing.T) {
 		"trimmed wildcard alongside concrete entries must collapse to a single wildcard")
 }
 
-// TestSimplifyAzureMatchersAllEmptyEntriesCollapseToWildcard guards against a
-// regression where a slice that is all whitespace-only entries (e.g.
-// ["", "  ", "\t"]) failed to fall through to the empty-list branch and
-// reached downstream as garbage scope. After trim+drop-empty, no explicit
-// scope remains, so the normal empty-list behavior must canonicalize the
-// matcher back to wildcard.
-func TestSimplifyAzureMatchersAllEmptyEntriesCollapseToWildcard(t *testing.T) {
+// TestSimplifyAzureMatchersAllEmptyEntriesDoNotWidenToWildcard guards
+// against the silent escalation pathology: a malformed selector list where
+// every entry trims to empty (e.g. [" "], ["", "\t"]) MUST NOT widen to the
+// wildcard. Widening would turn a config typo (`subscriptions: [" "]`) into
+// "discover every subscription in the tenant", which is the opposite of the
+// operator's intent. The original input is preserved instead so the
+// downstream Azure SDK call surfaces the malformed scope as an invalid-scope
+// error.
+//
+// The truly empty case (len(input) == 0) still collapses to wildcard, since
+// that is the documented "discover everything" convention.
+func TestSimplifyAzureMatchersAllEmptyEntriesDoNotWidenToWildcard(t *testing.T) {
 	t.Parallel()
 	matchers := []types.AzureMatcher{
 		{
@@ -338,10 +343,39 @@ func TestSimplifyAzureMatchersAllEmptyEntriesCollapseToWildcard(t *testing.T) {
 	simplified := SimplifyAzureMatchers(matchers)
 	require.Len(t, simplified, 1)
 
+	require.Equal(t, []string{"", "  ", "\t"}, simplified[0].Subscriptions,
+		"all-whitespace subscriptions must NOT widen to wildcard; "+
+			"preserve the malformed input so the SDK rejects it instead of "+
+			"silently discovering every subscription in the tenant")
+	require.Equal(t, []string{" "}, simplified[0].ResourceGroups,
+		"all-whitespace resource groups must NOT widen to wildcard; "+
+			"preserve the malformed input so the SDK rejects it instead of "+
+			"silently discovering every resource group")
+}
+
+// TestSimplifyAzureMatchersTrulyEmptyCollapsesToWildcard pins the documented
+// convention for the truly empty case (len == 0): match everything. This is
+// the opposite of the all-whitespace case and must remain distinct.
+func TestSimplifyAzureMatchersTrulyEmptyCollapsesToWildcard(t *testing.T) {
+	t.Parallel()
+	matchers := []types.AzureMatcher{
+		{
+			Subscriptions:  nil,
+			ResourceGroups: []string{},
+			Regions:        []string{"eu-west-1"},
+			Types:          []string{"vm"},
+		},
+	}
+
+	simplified := SimplifyAzureMatchers(matchers)
+	require.Len(t, simplified, 1)
+
 	require.Equal(t, []string{types.Wildcard}, simplified[0].Subscriptions,
-		"all-empty subscriptions must collapse to wildcard, not survive as garbage")
+		"truly empty subscription list (len == 0) collapses to wildcard "+
+			"per documented 'discover everything' convention")
 	require.Equal(t, []string{types.Wildcard}, simplified[0].ResourceGroups,
-		"all-empty resource groups must collapse to wildcard, not survive as garbage")
+		"truly empty resource group list (len == 0) collapses to wildcard "+
+			"per documented 'discover everything' convention")
 }
 
 func TestMatchResourceByFilters_Helper(t *testing.T) {

--- a/lib/services/matchers_test.go
+++ b/lib/services/matchers_test.go
@@ -267,6 +267,83 @@ func TestSimplifyAzureMatchersCollapsesRegionsWildcard(t *testing.T) {
 		"any wildcard in regions must collapse the slice to a single wildcard")
 }
 
+// TestSimplifyAzureMatchersTrimsBeforeDedupe guards against a regression where
+// Subscriptions and ResourceGroups deduped without first trimming whitespace,
+// letting hand-edited config like " sub-1" survive byte-equality dedup as a
+// distinct entry from "sub-1" and reach downstream as duplicate scopes.
+func TestSimplifyAzureMatchersTrimsBeforeDedupe(t *testing.T) {
+	t.Parallel()
+	matchers := []types.AzureMatcher{
+		{
+			Subscriptions:  []string{" sub-1", "sub-1", "sub-2  ", "  ", "sub-2"},
+			ResourceGroups: []string{"rg-a", "  rg-a", "rg-b ", "", "\t"},
+			Regions:        []string{"eu-west-1"},
+			Types:          []string{"vm"},
+		},
+	}
+
+	simplified := SimplifyAzureMatchers(matchers)
+	require.Len(t, simplified, 1)
+
+	require.Equal(t, []string{"sub-1", "sub-2"}, simplified[0].Subscriptions,
+		"whitespace variants must collapse to a single trimmed entry, "+
+			"first-occurrence order preserved")
+	require.Equal(t, []string{"rg-a", "rg-b"}, simplified[0].ResourceGroups,
+		"resource group whitespace variants must collapse to a single trimmed entry")
+	require.Equal(t, []string{"eu-west-1"}, simplified[0].Regions)
+	require.Equal(t, []string{"vm"}, simplified[0].Types)
+}
+
+// TestSimplifyAzureMatchersTrimmedWildcardCollapses guards against a
+// regression where a hand-edited wildcard with stray whitespace (" * ")
+// failed to trigger the wildcard collapse because the slices.Contains check
+// ran against untrimmed inputs.
+func TestSimplifyAzureMatchersTrimmedWildcardCollapses(t *testing.T) {
+	t.Parallel()
+	matchers := []types.AzureMatcher{
+		{
+			Subscriptions:  []string{" * ", "sub-1"},
+			ResourceGroups: []string{"\t*\n", "rg-a"},
+			Regions:        []string{"eu-west-1"},
+			Types:          []string{"vm"},
+		},
+	}
+
+	simplified := SimplifyAzureMatchers(matchers)
+	require.Len(t, simplified, 1)
+
+	require.Equal(t, []string{types.Wildcard}, simplified[0].Subscriptions,
+		"trimmed wildcard alongside concrete entries must collapse to a single wildcard")
+	require.Equal(t, []string{types.Wildcard}, simplified[0].ResourceGroups,
+		"trimmed wildcard alongside concrete entries must collapse to a single wildcard")
+}
+
+// TestSimplifyAzureMatchersAllEmptyEntriesCollapseToWildcard guards against a
+// regression where a slice that is all whitespace-only entries (e.g.
+// ["", "  ", "\t"]) failed to fall through to the empty-list branch and
+// reached downstream as garbage scope. After trim+drop-empty, no explicit
+// scope remains, so the normal empty-list behavior must canonicalize the
+// matcher back to wildcard.
+func TestSimplifyAzureMatchersAllEmptyEntriesCollapseToWildcard(t *testing.T) {
+	t.Parallel()
+	matchers := []types.AzureMatcher{
+		{
+			Subscriptions:  []string{"", "  ", "\t"},
+			ResourceGroups: []string{" "},
+			Regions:        []string{"eu-west-1"},
+			Types:          []string{"vm"},
+		},
+	}
+
+	simplified := SimplifyAzureMatchers(matchers)
+	require.Len(t, simplified, 1)
+
+	require.Equal(t, []string{types.Wildcard}, simplified[0].Subscriptions,
+		"all-empty subscriptions must collapse to wildcard, not survive as garbage")
+	require.Equal(t, []string{types.Wildcard}, simplified[0].ResourceGroups,
+		"all-empty resource groups must collapse to wildcard, not survive as garbage")
+}
+
 func TestMatchResourceByFilters_Helper(t *testing.T) {
 	t.Parallel()
 

--- a/lib/utils/strings.go
+++ b/lib/utils/strings.go
@@ -1,6 +1,6 @@
 /*
  * Teleport
- * Copyright (C) 2025  Gravitational, Inc.
+ * Copyright (C) 2026  Gravitational, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/lib/utils/strings.go
+++ b/lib/utils/strings.go
@@ -1,0 +1,34 @@
+/*
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package utils
+
+import "strings"
+
+// TrimNonEmpty trims leading and trailing whitespace from s and reports whether
+// the trimmed value is non-empty. It is shaped to be a drop-in callback for
+// filter-and-transform helpers such as lib/utils/slices.FilterMapUnique, where
+// the boolean return decides whether the transformed value is kept.
+//
+// Typical use is normalizing user-edited string lists (matcher selectors,
+// config arrays) where stray whitespace and empty entries should both be
+// dropped before downstream processing.
+func TrimNonEmpty(s string) (string, bool) {
+	s = strings.TrimSpace(s)
+	return s, s != ""
+}

--- a/lib/utils/strings_test.go
+++ b/lib/utils/strings_test.go
@@ -1,6 +1,6 @@
 /*
  * Teleport
- * Copyright (C) 2025  Gravitational, Inc.
+ * Copyright (C) 2026  Gravitational, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/lib/utils/strings_test.go
+++ b/lib/utils/strings_test.go
@@ -1,0 +1,52 @@
+/*
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package utils
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTrimNonEmpty(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name      string
+		in        string
+		wantValue string
+		wantKeep  bool
+	}{
+		{name: "empty input is dropped", in: "", wantValue: "", wantKeep: false},
+		{name: "whitespace-only input is dropped", in: "  \t\n", wantValue: "", wantKeep: false},
+		{name: "leading whitespace trimmed and kept", in: "  hello", wantValue: "hello", wantKeep: true},
+		{name: "trailing whitespace trimmed and kept", in: "hello  ", wantValue: "hello", wantKeep: true},
+		{name: "surrounding whitespace trimmed and kept", in: " \tx\n ", wantValue: "x", wantKeep: true},
+		{name: "unicode whitespace trimmed and kept", in: "\u00a0hello\u00a0", wantValue: "hello", wantKeep: true},
+		{name: "internal whitespace preserved", in: "a b", wantValue: "a b", wantKeep: true},
+		{name: "no whitespace passes through", in: "plain", wantValue: "plain", wantKeep: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, keep := TrimNonEmpty(tt.in)
+			assert.Equal(t, tt.wantValue, got)
+			assert.Equal(t, tt.wantKeep, keep)
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Trim Azure matcher Subscriptions and ResourceGroups before dedup, closing the order pathology where `apiutils.Deduplicate` ran on raw inputs and let whitespace variants like `[" sub-1", "sub-1"]` survive as distinct strings. 