### PR TITLE
[v18] Desktop Access: Multi-Domain Sign-on (#64964)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -122,6 +122,7 @@ require (
 	github.com/fsouza/fake-gcs-server v1.52.2
 	github.com/fxamacker/cbor/v2 v2.9.0
 	github.com/ghodss/yaml v1.0.0
+	github.com/go-asn1-ber/asn1-ber v1.5.8-0.20250403174932-29230038a667
 	github.com/go-git/go-git/v5 v5.18.0
 	github.com/go-jose/go-jose/v3 v3.0.5
 	github.com/go-jose/go-jose/v4 v4.1.4
@@ -384,7 +385,6 @@ require (
 	github.com/fatih/color v1.18.0 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/gabriel-vasile/mimetype v1.4.13 // indirect
-	github.com/go-asn1-ber/asn1-ber v1.5.8-0.20250403174932-29230038a667 // indirect
 	github.com/go-chi/chi/v5 v5.2.5 // indirect
 	github.com/go-errors/errors v1.4.2 // indirect
 	github.com/go-faster/city v1.0.1 // indirect

--- a/lib/srv/db/common/kerberos/kinit/ldap.go
+++ b/lib/srv/db/common/kerberos/kinit/ldap.go
@@ -120,7 +120,8 @@ func (s *ldapConnector) GetActiveDirectorySID(ctx context.Context, username stri
 
 	defer client.Close()
 
-	return client.GetActiveDirectorySID(ctx, username)
+	sid, _, err = client.GetActiveDirectorySIDAndDN(ctx, username)
+	return sid, err
 }
 
 func (s *ldapConnector) tlsConfigForLDAP(ctx context.Context, clusterName string) (*tls.Config, error) {

--- a/lib/srv/desktop/discovery.go
+++ b/lib/srv/desktop/discovery.go
@@ -264,6 +264,7 @@ func (s *WindowsService) applyLabelsFromLDAP(entry *ldap.Entry, labels map[strin
 	if len(dn) > 0 && len(cn) > 0 {
 		ou := strings.TrimPrefix(dn, "CN="+cn+",")
 		labels[types.DiscoveryLabelWindowsOU] = ou
+		labels[types.DiscoveryLabelWindowsDomain] = dnToDomain(dn)
 	}
 
 	// label domain controllers
@@ -278,6 +279,28 @@ func (s *WindowsService) applyLabelsFromLDAP(entry *ldap.Entry, labels map[strin
 			labels[types.DiscoveryLabelLDAPPrefix+attr] = v
 		}
 	}
+}
+
+func dnToDomain(dn string) string {
+	// Leverage go-ldaps for parsing DNs.
+	parsed, err := ldap.ParseDN(dn)
+	if err != nil {
+		return ""
+	}
+
+	var b strings.Builder
+	for _, rdn := range parsed.RDNs {
+		// Domain Component RDNs will only ever have one attribute/value pair
+		// in practice (even though the grammar technically allows multiple).
+		if len(rdn.Attributes) == 1 && strings.EqualFold(rdn.Attributes[0].Type, "dc") {
+			if b.Len() > 0 {
+				b.WriteRune('.')
+			}
+			b.WriteString(rdn.Attributes[0].Value)
+		}
+	}
+
+	return b.String()
 }
 
 const dnsQueryTimeout = 5 * time.Second
@@ -398,7 +421,7 @@ func (s *WindowsService) ldapEntryToWindowsDesktop(
 		labels,
 		types.WindowsDesktopSpecV3{
 			Addr:   addr.String(),
-			Domain: s.cfg.Domain,
+			Domain: labels[types.DiscoveryLabelWindowsDomain],
 			HostID: s.cfg.Heartbeat.HostUUID,
 		},
 	)

--- a/lib/srv/desktop/discovery_test.go
+++ b/lib/srv/desktop/discovery_test.go
@@ -111,6 +111,22 @@ func TestAppliesLDAPLabels(t *testing.T) {
 	require.Empty(t, l["ldap/quux"])
 }
 
+func TestDNToDomain(t *testing.T) {
+	for _, test := range []struct {
+		dn, domain string
+	}{
+		{"CN=Computers,DC=child,DC=root,DC=zac,DC=local", "child.root.zac.local"},
+		{"CN=me,OU=Engineering,OU=Users,OU=DevGroup,DC=domain,DC=ad,DC=example,DC=com", "domain.ad.example.com"},
+		{"CN=me,OU=Engineering,OU=Users,OU=DevGroup,dC=domain,Dc=ad,dc=example,DC=com", "domain.ad.example.com"},
+		{"", ""},
+		{"CN=me,OU=Engineering,OU=Users,OU=DevGroup", ""},
+	} {
+		t.Run(test.dn, func(t *testing.T) {
+			require.Equal(t, test.domain, dnToDomain(test.dn))
+		})
+	}
+}
+
 func TestLabelsDomainControllers(t *testing.T) {
 	s := &WindowsService{}
 	for _, test := range []struct {

--- a/lib/srv/desktop/rdp/rdpclient/client.go
+++ b/lib/srv/desktop/rdp/rdpclient/client.go
@@ -1259,3 +1259,8 @@ func (c *Client) UpdateClientActivity() {
 	c.clientLastActive = time.Now().UTC()
 	c.clientActivityMu.Unlock()
 }
+
+// DisableNLA disables NLA in the client configuration.
+func (c *Client) DisableNLA() {
+	c.cfg.NLA = false
+}

--- a/lib/srv/desktop/rdp/rdpclient/client_nop.go
+++ b/lib/srv/desktop/rdp/rdpclient/client_nop.go
@@ -58,3 +58,6 @@ func (c *Client) GetClientLastActive() time.Time {
 
 // UpdateClientActivity updates the client activity timestamp.
 func (c *Client) UpdateClientActivity() {}
+
+// DisableNLA disables NLA in the client configuration.
+func (c *Client) DisableNLA() {}

--- a/lib/srv/desktop/windows_server.go
+++ b/lib/srv/desktop/windows_server.go
@@ -875,6 +875,22 @@ func (s *WindowsService) connectRDP(ctx context.Context, log *slog.Logger, tdpCo
 		return trace.Wrap(err)
 	}
 
+	if nla {
+		// Note: SplitN with a non-empty separator always returns a slice with length >= 1
+		// 'userParts' is guaranteed to have length of either 1 or 2.
+		userParts := strings.SplitN(windowsUser, "@", 2)
+		// NLA doesn't like mixing user with and without domain, so make sure we have one
+		if len(userParts) == 1 {
+			// windowsUser is missing a domain suffix. Add our default domain target.
+			windowsUser = windowsUser + "@" + s.cfg.Domain
+		} else if !strings.EqualFold(userParts[1], s.cfg.Domain) {
+			// windowsUser has a domain, but it doesn't match our configured default.
+			s.cfg.Logger.WarnContext(ctx, "NLA cannot be enabled for users from different domain, disabling")
+			rdpc.DisableNLA()
+			audit.enableNLA = false
+		}
+	}
+
 	// Generate client certificates to be used for the RDP connection.
 	certDER, keyDER, err := s.generateUserCert(ctx, windowsUser, windowsUserCertTTL, desktop, createUsers, groups)
 	if err != nil {
@@ -1222,43 +1238,56 @@ func timer() func() int64 {
 	}
 }
 
+type entry struct {
+	sid               string
+	distinguishedName string
+}
+
 // generateUserCert generates a keypair for the given Windows username,
 // optionally querying LDAP for the user's Security Identifier.
 func (s *WindowsService) generateUserCert(ctx context.Context, username string, ttl time.Duration, desktop types.WindowsDesktop, createUsers bool, groups []string) (certDER, keyDER []byte, err error) {
 	var activeDirectorySID string
+	var distinguishedName string
+
 	if !desktop.NonAD() {
-		// Use FnCache to fetch the SID, or load it from cache if we already have it
-		// The cache key is the username and domain combined to handle multi-domain setups
-		cacheKey := fmt.Sprintf("%s@%s", username, desktop.GetDomain())
-		sid, err := utils.FnCacheGet(ctx, s.sidCache, cacheKey, func(ctx context.Context) (string, error) {
+		cacheKey := username
+		if !strings.Contains(username, "@") {
+			cacheKey = fmt.Sprintf("%s@%s", username, desktop.GetDomain())
+		}
+		entry, err := utils.FnCacheGet(ctx, s.sidCache, cacheKey, func(ctx context.Context) (entry, error) {
 			tc, err := s.loadTLSConfigForLDAP()
 			if err != nil {
-				return "", trace.Wrap(err)
+				return entry{}, trace.Wrap(err)
 			}
 
 			ldapClient, err := winpki.DialLDAP(ctx, s.getLDAPConfig(), tc)
 			if err != nil {
-				return "", trace.Wrap(err)
+				return entry{}, trace.Wrap(err)
 			}
 			defer ldapClient.Close()
 
 			s.cfg.Logger.DebugContext(ctx, "querying LDAP for objectSid of Windows user", "username", username)
-			sid, err := ldapClient.GetActiveDirectorySID(ctx, username)
+			sid, dn, err := ldapClient.GetActiveDirectorySIDAndDN(ctx, username)
 			if err != nil {
-				return "", trace.Wrap(err)
+				return entry{}, trace.Wrap(err)
 			}
 
 			s.cfg.Logger.DebugContext(ctx, "Found objectSid for Windows user", "username", username)
-			return sid, nil
+			return entry{
+				sid:               sid,
+				distinguishedName: dn,
+			}, nil
 		})
 		if err != nil {
 			return nil, nil, trace.Wrap(err)
 		}
-		activeDirectorySID = sid
+		activeDirectorySID = entry.sid
+		distinguishedName = entry.distinguishedName
 	}
 	return s.generateCredentials(ctx, generateCredentialsRequest{
 		username:           username,
 		domain:             desktop.GetDomain(),
+		distinguishedName:  distinguishedName,
 		ad:                 !desktop.NonAD(),
 		ttl:                ttl,
 		activeDirectorySID: activeDirectorySID,
@@ -1271,6 +1300,8 @@ func (s *WindowsService) generateUserCert(ctx context.Context, username string, 
 type generateCredentialsRequest struct {
 	// username is the Windows username
 	username string
+	// distinguishedName is the distinguished name of user in AD
+	distinguishedName string
 	// domain is the Windows domain
 	domain string
 	// ad is true if we're connecting to a domain-joined desktop
@@ -1296,6 +1327,7 @@ type generateCredentialsRequest struct {
 func (s *WindowsService) generateCredentials(ctx context.Context, request generateCredentialsRequest) (certDER, keyDER []byte, err error) {
 	return winpki.GenerateWindowsDesktopCredentials(ctx, s.cfg.AuthClient, &winpki.GenerateCredentialsRequest{
 		Username:           request.username,
+		DistinguishedName:  request.distinguishedName,
 		Domain:             request.domain,
 		PKIDomain:          s.cfg.PKIDomain,
 		AD:                 request.ad,

--- a/lib/srv/desktop/windows_server_test.go
+++ b/lib/srv/desktop/windows_server_test.go
@@ -207,6 +207,7 @@ func TestGenerateCredentials(t *testing.T) {
 			defer cancel()
 
 			certb, keyb, err := winpki.GenerateWindowsDesktopCredentials(ctx, client, &winpki.GenerateCredentialsRequest{
+				AD:                                true,
 				Username:                          user,
 				Domain:                            domain,
 				TTL:                               5 * time.Minute,
@@ -223,7 +224,7 @@ func TestGenerateCredentials(t *testing.T) {
 			require.NotNil(t, cert)
 
 			require.Equal(t, test.wantSerialNumber, cert.Issuer.SerialNumber, "Issuer.SerialNumber")
-			require.Equal(t, user, cert.Subject.CommonName, "Subject.CommonName")
+			require.Equal(t, user+"@"+domain, cert.Subject.CommonName, "Subject.CommonName")
 			require.Contains(t,
 				cert.CRLDistributionPoints,
 				`ldap:///CN=`+test.wantCRLCommonName+`,CN=Teleport,CN=CDP,CN=Public Key Services,CN=Services,CN=Configuration,DC=test,DC=example,DC=com?certificateRevocationList?base?objectClass=cRLDistributionPoint`,

--- a/lib/tlsca/ca.go
+++ b/lib/tlsca/ca.go
@@ -1603,6 +1603,13 @@ func (ca *CertAuthority) GenerateCertificate(req CertificateRequest) ([]byte, er
 		"issuer_skid", base32.HexEncoding.EncodeToString(ca.Cert.SubjectKeyId),
 	)
 
+	// Go deserializes extra names into Names field, but it uses ExtraNames for serialization,
+	// if we have any then we have to copy them over, or they will get lost during another
+	// serialization in x509.CreateCertificate
+	if len(req.Subject.Names) > 0 {
+		req.Subject.ExtraNames = req.Subject.Names
+	}
+
 	template := &x509.Certificate{
 		SerialNumber: serialNumber,
 		Subject:      req.Subject,

--- a/lib/winpki/ldap.go
+++ b/lib/winpki/ldap.go
@@ -19,23 +19,30 @@
 package winpki
 
 import (
+	"cmp"
 	"context"
 	"crypto/tls"
 	"encoding/base32"
 	"errors"
 	"fmt"
+	"io"
 	"log/slog"
 	"net"
+	"net/url"
 	"os"
+	"slices"
 	"strings"
 	"time"
 
+	ber "github.com/go-asn1-ber/asn1-ber"
 	"github.com/go-ldap/ldap/v3"
 	"github.com/gravitational/trace"
 
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/tlsca"
 	"github.com/gravitational/teleport/lib/utils/dns"
+	libset "github.com/gravitational/teleport/lib/utils/set"
+	libslices "github.com/gravitational/teleport/lib/utils/slices"
 )
 
 const (
@@ -47,6 +54,18 @@ const (
 	// It is larger than the dial timeout because LDAP queries in large
 	// Active Directory environments may take longer to complete.
 	ldapRequestTimeout = 45 * time.Second
+
+	// maxReferralsCount is overall maximum number of referrals that
+	// we will attempt to follow when performing a recursive search.
+	maxReferralsCount = 10
+
+	// maxSearchDepth is the maximum number of referrals for a given referral
+	// chain that we will attempt to follow when performing a recursive search.
+	maxSearchDepth = 5
+
+	// maxSearchHosts is the maximum number of hosts we will attempt
+	// to contact for each referral when performing a recursive search.
+	maxSearchHosts = 5
 )
 
 // LocateServer contains parameters for locating LDAP servers
@@ -87,8 +106,9 @@ type LDAPConfig struct {
 // For this reason, callers are encouraged to create clients on-demand rather
 // than keeping them open for long periods of time.
 type LDAPClient struct {
-	cfg  *LDAPConfig
-	conn *ldap.Conn
+	cfg         *LDAPConfig
+	conn        *ldap.Conn
+	credentials *tls.Config
 }
 
 // DialLDAP creates a new LDAP client using the provided TLS config for client credentials.
@@ -99,8 +119,9 @@ func DialLDAP(ctx context.Context, cfg *LDAPConfig, credentials *tls.Config) (*L
 	}
 
 	return &LDAPClient{
-		cfg:  cfg,
-		conn: conn,
+		cfg:         cfg,
+		conn:        conn,
+		credentials: credentials,
 	}, nil
 }
 
@@ -137,6 +158,9 @@ const (
 
 	// AttrSAMAccountName is the SAM Account name of an LDAP object.
 	AttrSAMAccountName = "sAMAccountName"
+
+	// AttrUserPrincipalName is the User Principal Name of an LDAP object.
+	AttrUserPrincipalName = "userPrincipalName"
 )
 
 // searchPageSize is desired page size for LDAP search. In Active Directory the default search size limit is 1000 entries,
@@ -174,30 +198,522 @@ func convertLDAPError(err error) error {
 	return err
 }
 
-// GetActiveDirectorySID makes an LDAP query to retrieve the security identifier (SID)
-// for the specified Active Directory user.
-func (l *LDAPClient) GetActiveDirectorySID(ctx context.Context, username string) (string, error) {
-	filter := CombineLDAPFilters([]string{
-		fmt.Sprintf("(%s=%s)", AttrSAMAccountType, AccountTypeUser),
-		fmt.Sprintf("(%s=%s)", AttrSAMAccountName, ldap.EscapeFilter(username)),
-	})
+// GetActiveDirectorySIDAndDN makes an LDAP query to retrieve the security identifier (SID)
+// for the specified Active Directory user. It also returns their distinguished name.
+// The provided username can be a plain username "bob", or a full UPN like
+// "alice@example.com". In cases where the specified username's domain does not match the target
+// desktop's domain, this function will attempt to extract and chase referrals from search responses.
+func (l *LDAPClient) GetActiveDirectorySIDAndDN(ctx context.Context, username string) (string, string, error) {
+	fullUsername := username
+	username, domain, _ := strings.Cut(username, "@")
+	domain = cmp.Or(domain, l.cfg.Domain)
 
-	entries, err := l.ReadWithFilter(DomainDN(l.cfg.Domain), filter, []string{AttrObjectSid})
+	// By default, search for the user without following referrals
+	searchFn := l.ReadWithFilter
+	externalDomain := !strings.EqualFold(domain, l.cfg.Domain)
+	if externalDomain {
+		// The user does not belong to the Teleport configured domain. We may need
+		// to chase referrals to locate their SID.
+		searchFn = func(dn, filter string, attrs []string) ([]*ldap.Entry, error) {
+			return l.RecursiveReadWithFilter(ctx, dn, filter, attrs)
+		}
+	}
+
+	queries := []struct {
+		name  string
+		query func() ([]*ldap.Entry, error)
+	}{
+		{
+			name: "UPN and configured baseDN",
+			query: func() ([]*ldap.Entry, error) {
+				// User principal name and configured baseDN
+				filter := fmt.Sprintf("(%s=%s)", AttrUserPrincipalName, ldap.EscapeFilter(username+"@"+domain))
+				return searchFn(DomainDN(l.cfg.Domain), withSAMAccountFilter(filter), []string{AttrObjectSid})
+			},
+		},
+		{
+			name: "UPN and derived baseDN",
+			query: func() ([]*ldap.Entry, error) {
+				// User principal name and baseDN derived from username
+				filter := fmt.Sprintf("(%s=%s)", AttrUserPrincipalName, ldap.EscapeFilter(username+"@"+domain))
+				return searchFn(DomainDN(domain), withSAMAccountFilter(filter), []string{AttrObjectSid})
+			},
+		},
+		{
+			name: "sAMAccountName",
+			query: func() ([]*ldap.Entry, error) {
+				// sAMAccountName and baseDN derived from username
+				// Limited to 20 characters by AD schema
+				// https://learn.microsoft.com/en-us/windows/win32/adschema/a-samaccountname
+				if len(username) > 20 {
+					l.cfg.Logger.WarnContext(ctx, "username used for querying sAMAccountName is longer than 20 characters, results might be invalid", "username", username)
+					username = username[:20]
+				}
+				filter := fmt.Sprintf("(%s=%s)", AttrSAMAccountName, ldap.EscapeFilter(username))
+				return searchFn(DomainDN(domain), withSAMAccountFilter(filter), []string{AttrObjectSid})
+			},
+		},
+	}
+
+	var entries []*ldap.Entry
+	for _, query := range queries {
+		var err error
+		entries, err = query.query()
+		if err != nil {
+			l.cfg.Logger.DebugContext(ctx, "query failed", "query", query.name, "error", err)
+			continue
+		}
+
+		if len(entries) > 0 {
+			l.cfg.Logger.DebugContext(ctx, "query succeeded", "query", query.name, "results", len(entries))
+			break
+		}
+		l.cfg.Logger.DebugContext(ctx, "query succeeded but found no results", "query", query.name)
+	}
+
+	if len(entries) == 0 {
+		l.cfg.Logger.DebugContext(ctx, "all SID queries exhausted with no results found")
+		return "", "", trace.NotFound("could not find Windows account %q", fullUsername)
+	}
+	if len(entries) > 1 {
+		l.cfg.Logger.WarnContext(ctx, "found multiple entries for user, taking the first", "username", fullUsername)
+	}
+	activeDirectorySID, err := ADSIDStringFromLDAPEntry(entries[0])
+	if err != nil {
+		return "", "", trace.Wrap(err)
+	}
+	l.cfg.Logger.DebugContext(ctx, "Found objectSid Windows user", "username", fullUsername)
+	distinguishedName := entries[0].DN
+	return activeDirectorySID, distinguishedName, nil
+}
+
+func withSAMAccountFilter(filter string) string {
+	return CombineLDAPFilters([]string{
+		fmt.Sprintf("(%s=%s)", AttrSAMAccountType, AccountTypeUser),
+		filter,
+	})
+}
+
+// extractReferrals gathers referrals from the ldapErr.
+// If the LDAP server can't provide the information requested, but it has knowledge of another host or domain
+// that could fulfill the request, then it will return error like:
+// LDAP Result Code 10 "Referral": 0000202B: RefErr: DSID-0310084A
+// You then have to parse content of the ber-encoded error to extract the address for the referral
+func extractReferrals(ldapErr *ldap.Error) []string {
+	if ldapErr == nil {
+		return nil
+	}
+
+	if ldapErr.ResultCode != ldap.LDAPResultReferral {
+		return nil
+	}
+	searchResultIndex := slices.IndexFunc(ldapErr.Packet.Children, func(packet *ber.Packet) bool {
+		return packet.Description == "Search Result Done"
+	})
+	if searchResultIndex < 0 {
+		return nil
+	}
+	searchResult := ldapErr.Packet.Children[searchResultIndex]
+
+	referralsIndex := slices.IndexFunc(searchResult.Children, func(packet *ber.Packet) bool {
+		return packet.Description == "Referral"
+	})
+	if referralsIndex < 0 {
+		return nil
+	}
+	referrals := searchResult.Children[referralsIndex].Children
+
+	out := make([]string, 0, len(referrals))
+	for _, referral := range referrals {
+		referralValue, ok := referral.Value.(string)
+		// we only support LDAPS connections
+		if ok && strings.HasPrefix(referralValue, "ldaps://") {
+			out = append(out, referralValue)
+		}
+	}
+
+	return out
+}
+
+// searchResult attempts to emulate the behavior of
+// a tagged union. The 'search' function returns a
+// list of ldap entries XOR a list of referral strings
+// in the success path.
+type searchResult interface {
+	isSearchResult()
+}
+
+type searchResultEntry struct{ entries []*ldap.Entry }
+type searchResultReferral struct{ referrals []string }
+
+func (searchResultEntry) isSearchResult()    {}
+func (searchResultReferral) isSearchResult() {}
+
+func (l *LDAPClient) search(ctx context.Context, client ldap.Client, searchRequest *ldap.SearchRequest) (searchResult, error) {
+	l.cfg.Logger.DebugContext(ctx, "Executing paged query", "filter", searchRequest.Filter, "baseDN", searchRequest.BaseDN)
+	res, err := client.SearchWithPaging(searchRequest, searchPageSize)
+
 	switch {
 	case err != nil:
-		return "", trace.Wrap(err)
-	case len(entries) == 0:
-		return "", trace.NotFound("could not find Windows account %q", username)
-	case len(entries) > 1:
-		l.cfg.Logger.WarnContext(ctx, "found multiple entries for user, taking the first", "user", username)
+		var ldapErr *ldap.Error
+		if errors.As(err, &ldapErr) && ldapErr.ResultCode == ldap.LDAPResultReferral {
+			referrals := extractReferrals(ldapErr)
+			if len(referrals) == 0 {
+				return nil, trace.Errorf("Failed to extract referrals from ldap error: %v", err)
+			}
+			l.cfg.Logger.DebugContext(ctx, "Got referrals from paged query error", "referrals", referrals)
+			return searchResultReferral{
+				referrals: referrals,
+			}, nil
+		}
+		return nil, trace.Wrap(err)
+	case len(res.Entries) > 0:
+		l.cfg.Logger.DebugContext(ctx, "Got results from paged query", "count", len(res.Entries))
+		return searchResultEntry{
+			entries: res.Entries,
+		}, nil
+	case len(res.Referrals) > 0:
+		l.cfg.Logger.DebugContext(ctx, "Got referrals from paged query", "referrals", res.Referrals)
+		return searchResultReferral{
+			referrals: res.Referrals,
+		}, nil
+	default:
+		return nil, trace.NotFound("no results found for LDAP query")
+	}
+}
+
+type ldapReferral struct {
+	// URL scheme (ldaps:// or ldap://)
+	scheme string
+	// The raw referral received from LDAP server.
+	raw string
+	// (optional) host is the add:port (port optional) hostname
+	host string
+	// (optional) base distinguished name specified by the referral.
+	baseDN string
+	// (optional) scope specified by the referral.
+	scope string
+	// (optional) comma separated list of attributes specified by the referral.
+	attributes string
+	// (optional) filter specified by the referral.
+	filter string
+	// (optional) comma separated list of extensions specified by the referral.
+	extensions string
+}
+
+// Referral grammar:
+// https://datatracker.ietf.org/doc/html/rfc4516#section-2
+//
+// parses an LDAP referral URL
+func parseLDAPReferral(raw string) (ldapReferral, error) {
+	const ldapsPrefix = "ldaps://"
+	const ldapPrefix = "ldap://"
+	var ref string
+	var scheme string
+	switch {
+	case strings.HasPrefix(raw, ldapsPrefix):
+		ref = strings.TrimPrefix(raw, ldapsPrefix)
+		scheme = ldapsPrefix
+	case strings.HasPrefix(raw, ldapPrefix):
+		ref = strings.TrimPrefix(raw, ldapPrefix)
+		scheme = ldapPrefix
+	default:
+		return ldapReferral{}, trace.BadParameter("LDAP referral does not have ldaps scheme")
 	}
 
-	sid, err := ADSIDStringFromLDAPEntry(entries[0])
+	if len(ref) == 0 {
+		// I guess it's technically a valid URL, but useless.
+		return ldapReferral{scheme: scheme, raw: raw}, trace.BadParameter("empty referral")
+	}
+
+	isValidHostPort := func(host string) error {
+		const subDelims = "!$&'()*+,;=:"
+		for _, r := range host {
+			switch {
+			case r >= 'A' && r <= 'Z':
+			case r >= 'a' && r <= 'z':
+			case r >= '0' && r <= '9':
+			case r == '-' || r == '.' || r == '_' || r == '~':
+			case strings.ContainsRune(subDelims, r):
+			case r == '%':
+			default:
+				return trace.BadParameter("malformed LDAP URL - host portion contains invalid character %c", r)
+			}
+		}
+		return nil
+	}
+
+	hostPort, remainder, found := strings.Cut(ref, "/")
+	if err := isValidHostPort(hostPort); err != nil {
+		return ldapReferral{}, err
+	}
+
+	if !found || remainder == "" {
+		return ldapReferral{scheme: scheme, raw: raw, host: hostPort}, nil
+	}
+
+	// invariant: remainder is non-empty
+	// Since we 'found' the forward slash above, the remainder should contain
+	// at least the DN component. Optionally, up to 4 parameters (each prefixed
+	// by a '?') may follow the DN. So we'll split 'remainder' on "?"
+	// for a maximum of 5 substrings.
+	parts := strings.SplitN(remainder, "?", 5)
+	// therefore len(parts) > 0 holds
+	dn, params := parts[0], parts[1:]
+	var err error
+	if dn, err = url.QueryUnescape(dn); err != nil {
+		return ldapReferral{}, trace.BadParameter("LDAP URL contains malformed DN component")
+	}
+
+	referral := ldapReferral{
+		scheme: scheme,
+		raw:    raw,
+		host:   hostPort,
+		baseDN: dn,
+	}
+
+	assign := []*string{
+		&referral.attributes,
+		&referral.scope,
+		&referral.filter,
+		&referral.extensions,
+	}
+
+	for idx, param := range params {
+		// Params may be percent encoded
+		*assign[idx], err = url.QueryUnescape(param)
+		if err != nil {
+			return ldapReferral{}, trace.Wrap(err)
+		}
+	}
+	return referral, nil
+}
+
+// A referral may be a hostname, or a *domain referral* which needs to be
+// resolved to a set of hosts. This function attempts an SRV lookup on the url.
+// Returns either a slice of the resolved hosts, or upon failure, a slice
+// containing only parsed hostname of the raw referral.
+func (r *ldapReferral) resolve(ctx context.Context, rslv resolver) []string {
+	// The host portion of an LDAP URL is actually optional.
+	// Avoid looking up or returning empty hosts
+	if r.host == "" {
+		return []string{}
+	}
+
+	_, port, _ := net.SplitHostPort(r.host)
+	if port != "" {
+		// Skip the SRV lookup. If the referral URL has
+		// an exact port then this isn't a domain referral
+		return []string{r.host}
+	}
+
+	_, records, err := rslv.LookupSRV(ctx, "ldap", "tcp", r.host)
+	if err == nil && len(records) > 0 {
+		return libslices.Map(records, func(srv *net.SRV) string {
+			return srv.Target
+		})
+	}
+	// No records found or SRV lookup failed. Fall
+	// back to trying the host as-is.
+	return []string{r.host}
+}
+
+type searcher interface {
+	search(ctx context.Context, searchRequest *ldap.SearchRequest) (searchResult, error)
+	io.Closer
+}
+
+type ldapSearcher struct {
+	*LDAPClient
+}
+
+func (l *ldapSearcher) search(ctx context.Context, searchRequest *ldap.SearchRequest) (searchResult, error) {
+	return l.LDAPClient.search(ctx, l.conn, searchRequest)
+}
+
+type resolver interface {
+	LookupSRV(ctx context.Context, service, proto, name string) (string, []*net.SRV, error)
+}
+
+// Clones 'originalRequest' and overrides the attributes, filter, and scope
+// parameters if the 'referral' contains a non-empty replacement.
+func newRequestFromReferral(originalRequest *ldap.SearchRequest, referral ldapReferral) *ldap.SearchRequest {
+	getScope := func(scope string) int {
+		switch scope {
+		case "base":
+			return ldap.ScopeBaseObject
+		case "one":
+			return ldap.ScopeSingleLevel
+		case "sub":
+			return ldap.ScopeWholeSubtree
+		default:
+			return originalRequest.Scope
+		}
+	}
+
+	attributes := originalRequest.Attributes
+	if referral.attributes != "" {
+		attributes = strings.Split(referral.attributes, ",")
+	}
+
+	return ldap.NewSearchRequest(
+		cmp.Or(referral.baseDN, originalRequest.BaseDN),
+		getScope(referral.scope),
+		originalRequest.DerefAliases,
+		originalRequest.SizeLimit,
+		originalRequest.TimeLimit,
+		originalRequest.TypesOnly,
+		cmp.Or(referral.filter, originalRequest.Filter),
+		attributes,
+		originalRequest.Controls,
+	)
+}
+
+// recursiveSearch maintains context for an LDAP
+// query that chases referrals.
+type recursiveSearch struct {
+	// Tracks raw referral strings that the search has encountered.
+	referrals libset.Set[string]
+	// Limits how far down a given referral chain the search will go.
+	maxDepth uint
+	// Limits the how many referrals will be attempted overall.
+	maxReferrals uint
+	// Maximum number of hosts to try per referral.
+	maxHosts uint
+	// constructor for new searcher (wrapped LDAP client) and associated close function
+	// to be called when the searcher is no longer needed.
+	newSearcher func(context.Context, string) (searcher, error)
+	// A resolver to use for SRV lookups when resolving domain referrals.
+	resolver resolver
+	logger   *slog.Logger
+}
+
+func (r *recursiveSearch) start(ctx context.Context, client searcher, request *ldap.SearchRequest) ([]*ldap.Entry, error) {
+	return r.run(ctx, client, request, 0)
+}
+
+func (r *recursiveSearch) run(ctx context.Context, client searcher, request *ldap.SearchRequest, depth uint) ([]*ldap.Entry, error) {
+	res, err := client.search(ctx, request)
 	if err != nil {
-		return "", trace.Wrap(err)
+		return nil, trace.Wrap(err)
 	}
 
-	return sid, nil
+	if entryResult, ok := res.(searchResultEntry); ok {
+		return entryResult.entries, nil
+	}
+
+	referralResult, ok := res.(searchResultReferral)
+	if !ok {
+		return nil, trace.Errorf("unexpected search result type")
+	}
+
+	if depth >= r.maxDepth {
+		return nil, trace.LimitExceeded("cannot chase LDAP referral chains beyond the maximum allowed length (%d)", r.maxDepth)
+	}
+
+	// Parse LDAP referrals, filter out those that have already been encountered,
+	// and add new ones to the referrals set.
+	parsedReferrals := libslices.FilterMapUnique(referralResult.referrals, func(ref string) (ldapReferral, bool) {
+		defer r.referrals.Add(ref)
+		referral, err := parseLDAPReferral(ref)
+		if err != nil {
+			r.logger.WarnContext(ctx, "Could not parse referral as URL", "referral", ref, "error", err)
+			return ldapReferral{}, false
+		}
+
+		if !strings.Contains(referral.scheme, "ldaps") {
+			r.logger.InfoContext(ctx, "Ignoring referral URL with unexpected scheme", "referral", ref, "scheme", referral.scheme)
+			return ldapReferral{}, false
+		}
+
+		// Avoid following the same referral twice or exceeding the maximum referral limit
+		alreadySeen := r.referrals.Contains(ref)
+		maxReferralsReached := len(r.referrals) >= int(r.maxReferrals)
+		return referral, !alreadySeen && !maxReferralsReached
+	})
+
+referralLoop:
+	for _, ref := range parsedReferrals {
+		// The referral *may* resolve to multiple hosts
+		hosts := ref.resolve(ctx, r.resolver)
+		r.logger.InfoContext(ctx, "Chasing referral", "referral", ref.raw, "hosts", hosts)
+		for _, host := range hosts[:min(uint(len(hosts)), r.maxHosts)] {
+			entries, err := func() ([]*ldap.Entry, error) {
+				newClient, err := r.newSearcher(ctx, host)
+				if err != nil {
+					r.logger.ErrorContext(ctx, "Failed to dial LDAPS server while chasing referral", "error", err, "hostname", host)
+					return nil, err
+				}
+				defer newClient.Close()
+
+				entries, err := r.run(ctx, newClient, newRequestFromReferral(request, ref), depth+1)
+				if err != nil && !trace.IsNotFound(err) {
+					r.logger.WarnContext(ctx, "Failed to execute LDAPS query while chasing referral", "error", err, "hostname", host)
+					return nil, err
+				}
+				return entries, nil
+			}()
+
+			if err != nil {
+				if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+					return nil, err
+				}
+				continue
+			}
+
+			if len(entries) > 0 {
+				r.logger.InfoContext(ctx, "Terminating referral chase after successfully finding entries", "referral", ref.raw, "host", host)
+				return entries, nil
+			}
+
+			// We successfully contacted the referred domain, but it simply didn't
+			// have the data we're looking for. We don't need to continue contacting
+			// other hosts belonging to the same referral/domain.
+			continue referralLoop
+		}
+	}
+	// Referral chasing complete, but no relevant entries found.
+	return nil, nil
+}
+
+// RecursiveReadWithFilter follows referrals and executes the query/read recursively by
+// following referrals to other domains where the search request should be repeated.
+func (l *LDAPClient) RecursiveReadWithFilter(ctx context.Context, dn string, filter string, attrs []string) ([]*ldap.Entry, error) {
+	search := recursiveSearch{
+		referrals:    libset.New[string](),
+		maxDepth:     maxSearchDepth,
+		maxHosts:     maxSearchHosts,
+		maxReferrals: maxReferralsCount,
+		newSearcher: func(ctx context.Context, host string) (searcher, error) {
+			serverName, _, err := net.SplitHostPort(host)
+			if err != nil {
+				serverName = host
+			}
+
+			// Clone the existing credentials, so that we can change the 'ServerName' to
+			// match the hostname of the new LDAP server that we're about to dial.
+			referralCreds := l.credentials.Clone()
+			referralCreds.ServerName = serverName
+			client, err := DialLDAP(ctx, &LDAPConfig{
+				Addr:   host,
+				Logger: l.cfg.Logger,
+			}, referralCreds)
+			return &ldapSearcher{LDAPClient: client}, err
+		},
+		resolver: net.DefaultResolver,
+		logger:   l.cfg.Logger,
+	}
+	return search.start(ctx, &ldapSearcher{LDAPClient: l}, ldap.NewSearchRequest(
+		dn,
+		ldap.ScopeWholeSubtree,
+		ldap.DerefAlways,
+		0,     // no SizeLimit
+		0,     // no TimeLimit
+		false, // TypesOnly == false, we want attribute values
+		filter,
+		attrs,
+		nil, // no Controls)
+	))
 }
 
 // ReadWithFilter searches the specified DN (and its children) using the specified LDAP filter.

--- a/lib/winpki/ldap.go
+++ b/lib/winpki/ldap.go
@@ -427,13 +427,20 @@ func parseLDAPReferral(raw string) (ldapReferral, error) {
 	}
 
 	isValidHostPort := func(host string) error {
+		// As a first pass, run it through the standard URL parser.
+		if _, err := url.Parse(scheme + host); err != nil {
+			return trace.BadParameter("malformed LDAP URL - invalid address or hostname: %v", err)
+		}
+
+		// url.Parse misses invalid characters in hostnames. ex, "host_name:8080" contains
+		// an illegal underscore, but passes validation above. We'll be a little more strict.
 		const subDelims = "!$&'()*+,;=:"
 		for _, r := range host {
 			switch {
 			case r >= 'A' && r <= 'Z':
 			case r >= 'a' && r <= 'z':
 			case r >= '0' && r <= '9':
-			case r == '-' || r == '.' || r == '_' || r == '~':
+			case r == '-' || r == '.' || r == '_' || r == '~' || r == '[' || r == ']':
 			case strings.ContainsRune(subDelims, r):
 			case r == '%':
 			default:

--- a/lib/winpki/ldap_test.go
+++ b/lib/winpki/ldap_test.go
@@ -1,0 +1,474 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package winpki
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"math"
+	"net"
+	"testing"
+
+	"github.com/go-ldap/ldap/v3"
+	"github.com/russellhaering/gosaml2/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	libSet "github.com/gravitational/teleport/lib/utils/set"
+	libslices "github.com/gravitational/teleport/lib/utils/slices"
+)
+
+// referrals tracks fake LDAP referrals which can be
+// resolved to some number of hosts with the accompanied
+// LookupSRV method. This allows us to mock SRV lookups.
+type referrals struct {
+	refs     map[string][]string
+	resolves map[string]int
+}
+
+func (r referrals) LookupSRV(ctx context.Context, _, _, name string) (string, []*net.SRV, error) {
+	r.resolves[name] += 1
+	if len(r.refs[name]) == 0 {
+		return "", nil, errors.New("not found")
+	}
+
+	return "", libslices.Map(r.refs[name], func(s string) *net.SRV {
+		return &net.SRV{
+			Target: s,
+		}
+	}), ctx.Err()
+}
+
+func (r *referrals) clear() {
+	clear(r.resolves)
+}
+
+// topology represents an LDAP server topology,
+// wherein a given host, when searched, returns either
+// LDAP entries or referrals.
+type topology struct {
+	servers     map[string]searchResult
+	searches    map[string]int
+	openClients map[string]struct{}
+}
+
+func (t *topology) clear() {
+	clear(t.searches)
+	clear(t.openClients)
+}
+
+type funcSearcher struct {
+	searchFunc func(ctx context.Context, searchRequest *ldap.SearchRequest) (res searchResult, err error)
+	onClose    func() error
+}
+
+func (f funcSearcher) search(ctx context.Context, searchRequest *ldap.SearchRequest) (res searchResult, err error) {
+	return f.searchFunc(ctx, searchRequest)
+}
+
+func (f funcSearcher) Close() error {
+	return f.onClose()
+}
+
+func (t topology) newSearcher(_ context.Context, name string) (searcher, error) {
+	id := uuid.NewV4().String()
+	t.openClients[id] = struct{}{}
+	return funcSearcher{searchFunc: func(ctx context.Context, searchRequest *ldap.SearchRequest) (res searchResult, err error) {
+		res, ok := t.servers[name]
+		t.searches[name] += 1
+		if !ok {
+			return nil, errors.New("search failed for this host")
+		}
+
+		return res, ctx.Err()
+	}, onClose: func() error { delete(t.openClients, id); return nil }}, nil
+}
+
+func TestRecursiveSearch(t *testing.T) {
+	t.Parallel()
+
+	discardLogger := slog.New(slog.DiscardHandler)
+
+	// Define a mapping of referrals to resolved hostnames to use for testing.
+	refs := referrals{
+		resolves: map[string]int{},
+		refs: map[string][]string{
+			"a.lab.local": []string{"hosta1", "hosta2", "hosta3", "hosta4"},
+			"b.lab.local": []string{"hostb1", "hostb2", "hostb3"},
+			"c.lab.local": []string{"hostc1", "hostc2"},
+			"d.lab.local": []string{"hostd1"},
+			// Test fallback behavior where a failed SRV lookup
+			// falls back to the parsed url.
+			"noresolve.com": nil,
+		},
+	}
+
+	// Define a topology for this test. If started from root and search
+	// limits allow, the recursive search would exhaustively query each "server",
+	// visiting every host, until it finds the single valid LDAP entry held by
+	// "noresolve.com".
+	top := topology{
+		servers: map[string]searchResult{
+			"root": searchResultReferral{
+				referrals: []string{"ldaps://a.lab.local"},
+			},
+			"hosta4": searchResultReferral{
+				referrals: []string{"ldaps://b.lab.local"},
+			},
+			"hostb3": searchResultReferral{
+				referrals: []string{"ldaps://c.lab.local"},
+			},
+			"hostc2": searchResultReferral{
+				referrals: []string{"ldaps://d.lab.local"},
+			},
+			"hostd1": searchResultReferral{
+				referrals: []string{"ldaps://noresolve.com"},
+			},
+			"noresolve.com": searchResultEntry{
+				entries: []*ldap.Entry{&ldap.Entry{
+					DN: "somedn",
+				}},
+			},
+		},
+		searches:    map[string]int{},
+		openClients: map[string]struct{}{},
+	}
+
+	t.Run("successful search", func(t *testing.T) {
+		testSearch := recursiveSearch{
+			maxDepth:     100,
+			maxHosts:     100,
+			maxReferrals: 100,
+			referrals:    make(libSet.Set[string]),
+			newSearcher:  top.newSearcher,
+			resolver:     refs,
+			logger:       discardLogger,
+		}
+
+		// Start the search from the "root" mock LDAPS server
+		root, _ := top.newSearcher(t.Context(), "root")
+		root.Close()
+		entries, err := testSearch.start(t.Context(), root, &ldap.SearchRequest{})
+		require.NoError(t, err)
+		assert.Len(t, entries, 1)
+		// Should have followed all 5 referrals
+		assert.Len(t, testSearch.referrals, 5)
+		// All client handles closed
+		assert.Empty(t, top.openClients)
+	})
+
+	t.Run("max referrals exceeded", func(t *testing.T) {
+		refs.clear()
+		top.clear()
+
+		// Should fail after trying two referrals
+		testSearch := recursiveSearch{
+			maxDepth:     100,
+			maxHosts:     100,
+			maxReferrals: 2,
+			referrals:    make(libSet.Set[string]),
+			newSearcher:  top.newSearcher,
+			resolver:     refs,
+			logger:       discardLogger,
+		}
+
+		// Start the search from the "root" mock LDAPS server
+		root, _ := top.newSearcher(t.Context(), "root")
+		root.Close()
+		entries, err := testSearch.start(t.Context(), root, &ldap.SearchRequest{})
+		assert.NoError(t, err)
+		assert.Empty(t, entries)
+		// As a quirk, the third referral ends up on the referral list (since we *did* see it),
+		// but is not actually visited
+		for _, key := range []string{"ldaps://a.lab.local", "ldaps://b.lab.local", "ldaps://c.lab.local"} {
+			assert.Contains(t, testSearch.referrals, key)
+		}
+		// Validates that c.lab.local was never resolved
+		assert.NotContains(t, refs.resolves, "c.lab.local")
+		// All client handles closed
+		assert.Empty(t, top.openClients)
+	})
+
+	t.Run("max hosts exceeded", func(t *testing.T) {
+		refs.clear()
+		top.clear()
+
+		// Should fail on the first referral since only the last host
+		// "hosta4" contains the next referral
+		testSearch := recursiveSearch{
+			maxDepth:     100,
+			maxHosts:     3,
+			maxReferrals: 100,
+			referrals:    make(libSet.Set[string]),
+			newSearcher:  top.newSearcher,
+			resolver:     refs,
+			logger:       discardLogger,
+		}
+
+		// Start the search from the "root" mock LDAPS server
+		root, _ := top.newSearcher(t.Context(), "root")
+		root.Close()
+		entries, err := testSearch.start(t.Context(), root, &ldap.SearchRequest{})
+		assert.NoError(t, err)
+		assert.Empty(t, entries)
+		for _, key := range []string{"ldaps://a.lab.local"} {
+			assert.Contains(t, testSearch.referrals, key)
+		}
+		// Validates that b.lab.local was never resolved because the search failed
+		// before this referral was discovered.
+		assert.NotContains(t, refs.resolves, "b.lab.local")
+		// All client handles closed
+		assert.Empty(t, top.openClients)
+	})
+
+	t.Run("max depth exceeded", func(t *testing.T) {
+		refs.clear()
+		top.clear()
+
+		// Should fail just before reaching the end
+		testSearch := recursiveSearch{
+			maxDepth:     4,
+			maxHosts:     100,
+			maxReferrals: 100,
+			referrals:    make(libSet.Set[string]),
+			newSearcher:  top.newSearcher,
+			resolver:     refs,
+			logger:       discardLogger,
+		}
+
+		// Start the search from the "root" mock LDAPS server
+		root, _ := top.newSearcher(t.Context(), "root")
+		root.Close()
+		entries, err := testSearch.start(t.Context(), root, &ldap.SearchRequest{})
+		assert.NoError(t, err)
+		assert.Empty(t, entries)
+		for _, key := range []string{"ldaps://a.lab.local", "ldaps://b.lab.local", "ldaps://c.lab.local", "ldaps://d.lab.local"} {
+			assert.Contains(t, testSearch.referrals, key)
+		}
+		assert.NotContains(t, refs.resolves, "noresolve.com")
+		// All client handles closed
+		assert.Empty(t, top.openClients)
+	})
+
+	t.Run("context cancellation returns error", func(t *testing.T) {
+		refs.clear()
+		top.clear()
+
+		subCtx, cancel := context.WithCancel(t.Context())
+		testSearch := recursiveSearch{
+			maxDepth:     100,
+			maxHosts:     100,
+			maxReferrals: 100,
+			referrals:    make(libSet.Set[string]),
+			newSearcher:  top.newSearcher,
+			resolver:     refs,
+			logger:       discardLogger,
+		}
+
+		cancel()
+		// Start the search from the "root" mock LDAPS server
+		root, _ := top.newSearcher(t.Context(), "root")
+		root.Close()
+		entries, err := testSearch.start(subCtx, root, &ldap.SearchRequest{})
+		assert.Error(t, err)
+		assert.Empty(t, entries)
+		// All client handles closed
+		assert.Empty(t, top.openClients)
+	})
+
+	t.Run("cycles skipped", func(t *testing.T) {
+		cycleRefs := referrals{
+			resolves: map[string]int{},
+			refs: map[string][]string{
+				"a.lab.local": []string{"hosta1"},
+				"b.lab.local": []string{"hostb1"},
+			},
+		}
+
+		cycleTopology := topology{
+			searches:    map[string]int{},
+			openClients: map[string]struct{}{},
+			servers: map[string]searchResult{
+				"root":   searchResultReferral{referrals: []string{"ldaps://a.lab.local"}},
+				"hosta1": searchResultReferral{referrals: []string{"ldaps://b.lab.local"}},
+				// points back to a previous referral
+				"hostb1": searchResultReferral{referrals: []string{"ldaps://a.lab.local"}},
+			},
+		}
+
+		// Should fail just before reaching the end
+		testSearch := recursiveSearch{
+			maxDepth:     math.MaxInt32,
+			maxHosts:     100,
+			maxReferrals: math.MaxInt32,
+			referrals:    make(libSet.Set[string]),
+			newSearcher:  cycleTopology.newSearcher,
+			resolver:     cycleRefs,
+			logger:       slog.Default(),
+		}
+
+		// Start the search from the "root" mock LDAPS server
+		root, _ := top.newSearcher(t.Context(), "root")
+		root.Close()
+		entries, err := testSearch.start(t.Context(), root, &ldap.SearchRequest{})
+		require.NoError(t, err)
+		assert.Empty(t, entries)
+		// Referral and associated host are only resolved/searched once
+		assert.Equal(t, 1, cycleRefs.resolves["a.lab.local"])
+		assert.Equal(t, 1, cycleTopology.searches["hosta1"])
+		// All client handles closed
+		assert.Empty(t, top.openClients)
+	})
+}
+
+func TestReferralParsing(t *testing.T) {
+	t.Run("full url", func(t *testing.T) {
+		ref, err := parseLDAPReferral("ldaps://somehost:123/DC=example,DC=com?cn,mail?sub?filter")
+		require.NoError(t, err)
+		assert.Equal(t, "ldaps://", ref.scheme)
+		assert.Equal(t, "somehost:123", ref.host)
+		assert.Equal(t, "DC=example,DC=com", ref.baseDN)
+		assert.Equal(t, "cn,mail", ref.attributes)
+		assert.Equal(t, "filter", ref.filter)
+		assert.Equal(t, "sub", ref.scope)
+	})
+
+	t.Run("attributes only", func(t *testing.T) {
+		ref, err := parseLDAPReferral("ldaps://somehost:123/dn?cn,mail")
+		require.NoError(t, err)
+		assert.Equal(t, "ldaps://", ref.scheme)
+		assert.Equal(t, "somehost:123", ref.host)
+		assert.Equal(t, "dn", ref.baseDN)
+		assert.Equal(t, "cn,mail", ref.attributes)
+		assert.Empty(t, ref.filter)
+		assert.Empty(t, ref.scope)
+	})
+
+	t.Run("scope only", func(t *testing.T) {
+		ref, err := parseLDAPReferral("ldaps://somehost:123/DC=example,DC=com??one")
+		require.NoError(t, err)
+		assert.Equal(t, "ldaps://", ref.scheme)
+		assert.Equal(t, "somehost:123", ref.host)
+		assert.Equal(t, "DC=example,DC=com", ref.baseDN)
+		assert.Empty(t, ref.attributes)
+		assert.Empty(t, ref.filter)
+		assert.Equal(t, "one", ref.scope)
+	})
+
+	t.Run("filter only", func(t *testing.T) {
+		ref, err := parseLDAPReferral("ldaps://somehost:123/DC=example,DC=com???filter")
+		require.NoError(t, err)
+		assert.Equal(t, "ldaps://", ref.scheme)
+		assert.Equal(t, "somehost:123", ref.host)
+		assert.Equal(t, "DC=example,DC=com", ref.baseDN)
+		assert.Empty(t, ref.attributes)
+		assert.Equal(t, "filter", ref.filter)
+		assert.Empty(t, ref.scope)
+	})
+
+	t.Run("attributes and filter only", func(t *testing.T) {
+		ref, err := parseLDAPReferral("ldaps://somehost:123/DC=example,DC=com?cn,mail??filter")
+		require.NoError(t, err)
+		assert.Equal(t, "ldaps://", ref.scheme)
+		assert.Equal(t, "somehost:123", ref.host)
+		assert.Equal(t, "DC=example,DC=com", ref.baseDN)
+		assert.Equal(t, "cn,mail", ref.attributes)
+		assert.Equal(t, "filter", ref.filter)
+		assert.Empty(t, ref.scope)
+	})
+
+	t.Run("extensions only - with dn", func(t *testing.T) {
+		ref, err := parseLDAPReferral("ldaps://somehost:123/DC=example,DC=com????extensions")
+		require.NoError(t, err)
+		assert.Equal(t, "ldaps://", ref.scheme)
+		assert.Equal(t, "somehost:123", ref.host)
+		assert.Equal(t, "DC=example,DC=com", ref.baseDN)
+		assert.Empty(t, ref.attributes)
+		assert.Empty(t, ref.filter)
+		assert.Empty(t, ref.scope)
+	})
+
+	t.Run("extensions only", func(t *testing.T) {
+		ref, err := parseLDAPReferral("ldaps://somehost:123/dn??????extensions")
+		require.NoError(t, err)
+		assert.Equal(t, "ldaps://", ref.scheme)
+		assert.Equal(t, "somehost:123", ref.host)
+		assert.Equal(t, "dn", ref.baseDN)
+		assert.Empty(t, ref.attributes)
+		assert.Empty(t, ref.filter)
+		assert.Empty(t, ref.scope)
+		// Excess '?'s end up in extensions
+		assert.Equal(t, "??extensions", ref.extensions)
+	})
+
+	t.Run("dn only", func(t *testing.T) {
+		ref, err := parseLDAPReferral("ldap:///dn")
+		require.NoError(t, err)
+		assert.Equal(t, "ldap://", ref.scheme)
+		assert.Equal(t, "dn", ref.baseDN)
+		assert.Empty(t, ref.host)
+		assert.Empty(t, ref.attributes)
+		assert.Empty(t, ref.filter)
+		assert.Empty(t, ref.scope)
+		assert.Empty(t, ref.extensions)
+	})
+
+	t.Run("sparse but valid", func(t *testing.T) {
+		ref, err := parseLDAPReferral("ldap:///dn????")
+		require.NoError(t, err)
+		assert.Equal(t, "ldap://", ref.scheme)
+		assert.Equal(t, "dn", ref.baseDN)
+		assert.Empty(t, ref.host)
+		assert.Empty(t, ref.attributes)
+		assert.Empty(t, ref.filter)
+		assert.Empty(t, ref.scope)
+		assert.Empty(t, ref.extensions)
+	})
+
+	t.Run("scheme only", func(t *testing.T) {
+		_, err := parseLDAPReferral("ldap://")
+		// We expect an error on empty referral URLs
+		require.Error(t, err)
+	})
+
+	t.Run("percent encoded params", func(t *testing.T) {
+		ref, err := parseLDAPReferral("ldap://host.example.com:1234/dc=example%3F,dc=com?cn,o%3Dname?sub?(cn=John%20Smith)?1.2.3.4=foo%2Cbar")
+		require.NoError(t, err)
+		assert.Equal(t, "ldap://", ref.scheme)
+		assert.Equal(t, "dc=example?,dc=com", ref.baseDN)
+		assert.Equal(t, "host.example.com:1234", ref.host)
+		assert.Equal(t, "cn,o=name", ref.attributes)
+		assert.Equal(t, "(cn=John Smith)", ref.filter)
+		assert.Equal(t, "sub", ref.scope)
+		assert.Equal(t, "1.2.3.4=foo,bar", ref.extensions)
+	})
+
+	t.Run("malformed urls", func(t *testing.T) {
+		for _, url := range []string{
+			"ldap://host name.example.com/dc=example,dc=com", // space in host
+			"ldap://host@example.com/dc=example,dc=com",      // @ in host
+			"ldap://host#example.com/dc=example,dc=com",      // fragment in host
+			"ldap://[::1/dc=example,dc=com",                  // unclosed IP-literal bracket
+			"ldap://host?",                                   // ? in host
+		} {
+			_, err := parseLDAPReferral(url)
+			require.Error(t, err)
+		}
+
+	})
+}

--- a/lib/winpki/ldap_test.go
+++ b/lib/winpki/ldap_test.go
@@ -416,6 +416,18 @@ func TestReferralParsing(t *testing.T) {
 		assert.Equal(t, "??extensions", ref.extensions)
 	})
 
+	t.Run("ipv6", func(t *testing.T) {
+		ref, err := parseLDAPReferral("ldaps://[2001:db8::1]:80/dn")
+		require.NoError(t, err)
+		assert.Equal(t, "ldaps://", ref.scheme)
+		assert.Equal(t, "[2001:db8::1]:80", ref.host)
+		assert.Equal(t, "dn", ref.baseDN)
+		assert.Empty(t, ref.attributes)
+		assert.Empty(t, ref.filter)
+		assert.Empty(t, ref.scope)
+		assert.Empty(t, ref.extensions)
+	})
+
 	t.Run("dn only", func(t *testing.T) {
 		ref, err := parseLDAPReferral("ldap:///dn")
 		require.NoError(t, err)

--- a/lib/winpki/windows.go
+++ b/lib/winpki/windows.go
@@ -29,8 +29,11 @@ import (
 	"encoding/json"
 	"encoding/pem"
 	"fmt"
+	"slices"
+	"strings"
 	"time"
 
+	"github.com/go-ldap/ldap/v3"
 	"github.com/gravitational/trace"
 
 	"github.com/gravitational/teleport/api/client/proto"
@@ -62,6 +65,55 @@ func createUsersExtension(groups []string) (pkix.Extension, error) {
 	}, nil
 }
 
+// oids is mapping from distinguished name parts to asn1 object identifiers.
+// It's used for conversion between string representation obtained from LDAP
+// and pkix.Name.ExtraNames list
+var oids = map[string]asn1.ObjectIdentifier{
+	"businesscategory":           {2, 5, 4, 15},
+	"c":                          {2, 5, 4, 6},
+	"cn":                         {2, 5, 4, 3},
+	"dc":                         {0, 9, 2342, 19200300, 100, 1, 25},
+	"description":                {2, 5, 4, 13},
+	"destinationindicator":       {2, 5, 4, 27},
+	"distinguishedName":          {2, 5, 4, 49},
+	"dnqualifier":                {2, 5, 4, 46},
+	"emailaddress":               {1, 2, 840, 113549, 1, 9, 1},
+	"enhancedsearchguide":        {2, 5, 4, 47},
+	"facsimiletelephonenumber":   {2, 5, 4, 23},
+	"generationqualifier":        {2, 5, 4, 44},
+	"givenname":                  {2, 5, 4, 42},
+	"houseidentifier":            {2, 5, 4, 51},
+	"initials":                   {2, 5, 4, 43},
+	"internationalisdnnumber":    {2, 5, 4, 25},
+	"l":                          {2, 5, 4, 7},
+	"member":                     {2, 5, 4, 31},
+	"name":                       {2, 5, 4, 41},
+	"o":                          {2, 5, 4, 10},
+	"ou":                         {2, 5, 4, 11},
+	"owner":                      {2, 5, 4, 32},
+	"physicaldeliveryofficename": {2, 5, 4, 19},
+	"postaladdress":              {2, 5, 4, 16},
+	"postalcode":                 {2, 5, 4, 17},
+	"postOfficebox":              {2, 5, 4, 18},
+	"preferreddeliverymethod":    {2, 5, 4, 28},
+	"registeredaddress":          {2, 5, 4, 26},
+	"roleoccupant":               {2, 5, 4, 33},
+	"searchguide":                {2, 5, 4, 14},
+	"seealso":                    {2, 5, 4, 34},
+	"serialnumber":               {2, 5, 4, 5},
+	"sn":                         {2, 5, 4, 4},
+	"st":                         {2, 5, 4, 8},
+	"street":                     {2, 5, 4, 9},
+	"telephonenumber":            {2, 5, 4, 20},
+	"teletexterminalidentifier":  {2, 5, 4, 22},
+	"telexnumber":                {2, 5, 4, 21},
+	"title":                      {2, 5, 4, 12},
+	"uid":                        {0, 9, 2342, 19200300, 100, 1, 1},
+	"uniquemember":               {2, 5, 4, 50},
+	"userpassword":               {2, 5, 4, 35},
+	"x121address":                {2, 5, 4, 24},
+}
+
 func getCertRequest(req *GenerateCredentialsRequest) (*certRequest, error) {
 	// Important: rdpclient currently only supports 2048-bit RSA keys.
 	// If you switch the key type here, update handle_general_authentication in
@@ -73,15 +125,35 @@ func getCertRequest(req *GenerateCredentialsRequest) (*certRequest, error) {
 	// Also important: rdpclient expects the private key to be in PKCS1 format.
 	keyDER := x509.MarshalPKCS1PrivateKey(rsaKey.(*rsa.PrivateKey))
 
+	// Assume the AD user belongs to req.Domain, unless the
+	// username provided is a full UPN (user@domain)
+	upn := req.Username
+	if !strings.Contains(upn, "@") {
+		upn = fmt.Sprintf("%v@%v", upn, req.Domain)
+	}
+
 	// Generate the Windows-compatible certificate, see
 	// https://docs.microsoft.com/en-us/troubleshoot/windows-server/windows-security/enabling-smart-card-logon-third-party-certification-authorities
 	// for requirements.
-	san, err := SubjectAltNameExtension(req.Username, req.Domain)
+	san, err := subjectAltNameExtension(upn)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
+
+	name := pkix.Name{CommonName: req.Username}
+	if req.AD {
+		name = pkix.Name{CommonName: upn}
+	}
+	distinguishedName := req.DistinguishedName
+	if distinguishedName != "" {
+		name, err = convertDistinguishedName(distinguishedName)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+	}
+
 	csr := &x509.CertificateRequest{
-		Subject: pkix.Name{CommonName: req.Username},
+		Subject: name,
 		// We have to pass SAN and ExtKeyUsage as raw extensions because
 		// crypto/x509 doesn't support what we need:
 		// - x509.ExtKeyUsage doesn't have the Smartcard Logon variant
@@ -143,6 +215,29 @@ func getCertRequest(req *GenerateCredentialsRequest) (*certRequest, error) {
 	return cr, nil
 }
 
+func convertDistinguishedName(distinguishedName string) (pkix.Name, error) {
+	dn, err := ldap.ParseDN(distinguishedName)
+	if err != nil {
+		return pkix.Name{}, trace.Wrap(err)
+	}
+	name := pkix.Name{}
+	for _, rdn := range dn.RDNs {
+		for _, attr := range rdn.Attributes {
+			oid, ok := oids[strings.ToLower(attr.Type)]
+			if !ok {
+				continue
+			}
+			name.ExtraNames = append(name.ExtraNames, pkix.AttributeTypeAndValue{
+				Type:  oid,
+				Value: attr.Value,
+			})
+		}
+	}
+	// list have to be reversed for Windows to recognize the name's parts in the correct order
+	slices.Reverse(name.ExtraNames)
+	return name, nil
+}
+
 // AuthInterface is a subset of auth.ClientI
 type AuthInterface interface {
 	// GenerateDatabaseCert generates a database certificate for windows SQL Server
@@ -158,6 +253,8 @@ type AuthInterface interface {
 type GenerateCredentialsRequest struct {
 	// Username is the Windows username
 	Username string
+	// DistinguishedName is distinguished name of the user in AD
+	DistinguishedName string
 	// Domain is the Active Directory domain of the user.
 	Domain string
 	// PKIDomain is the Active Directory domain where CRLs are published.
@@ -318,8 +415,8 @@ var EnhancedKeyUsageExtension = pkix.Extension{
 	}(),
 }
 
-// SubjectAltNameExtension fills in the SAN for a Windows certificate
-func SubjectAltNameExtension(user, domain string) (pkix.Extension, error) {
+// subjectAltNameExtension fills in the SAN for a Windows certificate
+func subjectAltNameExtension(userPrincipalName string) (pkix.Extension, error) {
 	// Setting otherName SAN according to
 	// https://samfira.com/2020/05/16/golang-x-509-certificates-and-othername/
 	//
@@ -332,7 +429,7 @@ func SubjectAltNameExtension(user, domain string) (pkix.Extension, error) {
 			OtherName: otherName[UPN]{
 				OID: UPNOtherNameOID,
 				Value: UPN{
-					Value: fmt.Sprintf("%s@%s", user, domain), // TODO(zmb3): sanitize username to avoid domain spoofing
+					Value: userPrincipalName,
 				},
 			},
 		},

--- a/lib/winpki/windows_test.go
+++ b/lib/winpki/windows_test.go
@@ -19,7 +19,10 @@
 package winpki
 
 import (
+	"crypto/x509/pkix"
+	"encoding/asn1"
 	"os"
+	"reflect"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -98,6 +101,45 @@ func TestCRLDN(t *testing.T) {
 			got, err := CRLDN(test.clusterName, test.issuerSKID, "test.goteleport.com", test.caType)
 			require.NoError(t, err)
 			require.Equal(t, test.crlDN, got)
+		})
+	}
+}
+
+func TestConvertDistinguishedName(t *testing.T) {
+	tests := []struct {
+		dn   string
+		want pkix.Name
+	}{
+		{
+			"CN=a,DC=b,DC=c,DC=d", pkix.Name{ExtraNames: []pkix.AttributeTypeAndValue{
+				{Type: asn1.ObjectIdentifier{0, 9, 2342, 19200300, 100, 1, 25}, Value: "d"},
+				{Type: asn1.ObjectIdentifier{0, 9, 2342, 19200300, 100, 1, 25}, Value: "c"},
+				{Type: asn1.ObjectIdentifier{0, 9, 2342, 19200300, 100, 1, 25}, Value: "b"},
+				{Type: asn1.ObjectIdentifier{2, 5, 4, 3}, Value: "a"},
+			}},
+		},
+		{
+			"CN=a,OU=b,DC=c", pkix.Name{ExtraNames: []pkix.AttributeTypeAndValue{
+				{Type: asn1.ObjectIdentifier{0, 9, 2342, 19200300, 100, 1, 25}, Value: "c"},
+				{Type: asn1.ObjectIdentifier{2, 5, 4, 11}, Value: "b"},
+				{Type: asn1.ObjectIdentifier{2, 5, 4, 3}, Value: "a"}},
+			}},
+		{
+			"CN=a,CN=b,OU=c,C=d,DC=e,WRONG=wrong", pkix.Name{ExtraNames: []pkix.AttributeTypeAndValue{
+				{Type: asn1.ObjectIdentifier{0, 9, 2342, 19200300, 100, 1, 25}, Value: "e"},
+				{Type: asn1.ObjectIdentifier{2, 5, 4, 6}, Value: "d"},
+				{Type: asn1.ObjectIdentifier{2, 5, 4, 11}, Value: "c"},
+				{Type: asn1.ObjectIdentifier{2, 5, 4, 3}, Value: "b"},
+				{Type: asn1.ObjectIdentifier{2, 5, 4, 3}, Value: "a"}},
+			}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.dn, func(t *testing.T) {
+			got, err := convertDistinguishedName(tt.dn)
+			require.NoError(t, err)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("convertDistinguishedName() got = %v, want %v", got, tt.want)
+			}
 		})
 	}
 }


### PR DESCRIPTION
Backports #64964






<!-- Provide a descriptive entry for the changelog of the next release. -->

Changelog: Added support for multi-domain sign-on to Windows Desktop Service


<!-- Include manual testing efforts to verify the change. -->
<!-- Detail where the tests where run and what configurations were used. -->
<!-- Include all the test cases which were run to validate the change. -->

## Manual Test Plan
### Test Environment
Test Lab in AWS that has 4 separate AD domains each with a single domain controller: 
- `lab.local`
- `child.lab.local`
- `grand.child.lab.local`
- `other.local`

This models an AD forest where `lab.local` has two nested child domains as well as an outgoing trust relationship with `other.local`.

Additionally, a Teleport cluster with a single Windows Desktop Service instance is configured in the same VPC as the AD forest and is configured primarily against `lab.local` The EC2 instance hosting Teleport is configured to use the domain controller for `lab.local` as its primary DNS server.

### Test Cases
- Multi-Domain sign on
  - [x] Verify that the domain controller for `lab.local` (`dc1.lab.local`) is discovered as Windows Desktop resource (
  - [x] Sign into `dc1.lab.local` as `Administrator@child.lab.local`
  - [x] Sign into `dc1.lab.local` as `Administrator@grand.child.lab.local`
  - [x] Sign into `dc1.lab.local` as `Administrator@other.local`
- Regular, local domain sign on
  - [x] Sign into `dc1.lab.local` as  local`Administrator`
  - [x] Sign into a non-AD, statically configured Windows Desktop as a local user
