### PR TITLE
[v17] Handle empty session ID/value in event handler

### DIFF
--- a/integrations/event-handler/state.go
+++ b/integrations/event-handler/state.go
@@ -296,9 +296,19 @@ func (s *State) GetSessions() (map[string]int64, error) {
 	r := make(map[string]int64)
 
 	for key := range s.dv.KeysPrefix(sessionPrefix, nil) {
+		// skip if the key is exactly the sessionPrefix
+		if string(key) == sessionPrefix {
+			continue
+		}
+
 		b, err := s.dv.Read(key)
 		if err != nil {
 			return nil, trace.Wrap(err)
+		}
+
+		// Assume 0 if empty/unset
+		if len(b) == 0 {
+			b = make([]byte, 8)
 		}
 
 		id := key[len(sessionPrefix):]
@@ -310,6 +320,11 @@ func (s *State) GetSessions() (map[string]int64, error) {
 
 // SetSessionIndex writes current session index into state
 func (s *State) SetSessionIndex(id string, index int64) error {
+	// refuse to set empty session ID
+	if id == "" {
+		return trace.Wrap(errors.New("session ID cannot be empty"))
+	}
+
 	var b = make([]byte, 8)
 
 	binary.BigEndian.PutUint64(b, uint64(index))

--- a/integrations/event-handler/state.go
+++ b/integrations/event-handler/state.go
@@ -113,7 +113,7 @@ func NewState(c *StartCmdConfig, log *slog.Logger) (*State, error) {
 	return &s, nil
 }
 
-// createStorageDir is used to calculate storage dir path and create dir if it does not exits
+// createStorageDir is used to calculate storage dir path and create dir if it does not exist
 func createStorageDir(c *StartCmdConfig, log *slog.Logger) (string, error) {
 	host, port, err := net.SplitHostPort(c.TeleportAddr)
 	if err != nil {
@@ -306,9 +306,10 @@ func (s *State) GetSessions() (map[string]int64, error) {
 			return nil, trace.Wrap(err)
 		}
 
-		// Assume 0 if empty/unset
-		if len(b) == 0 {
+		// Assume 0 if byte count is incorrect
+		if len(b) != 8 {
 			b = make([]byte, 8)
+			binary.BigEndian.PutUint64(b, uint64(0))
 		}
 
 		id := key[len(sessionPrefix):]
@@ -322,7 +323,7 @@ func (s *State) GetSessions() (map[string]int64, error) {
 func (s *State) SetSessionIndex(id string, index int64) error {
 	// refuse to set empty session ID
 	if id == "" {
-		return trace.Wrap(errors.New("session ID cannot be empty"))
+		return trace.BadParameter("session ID cannot be empty")
 	}
 
 	var b = make([]byte, 8)

--- a/integrations/event-handler/state.go
+++ b/integrations/event-handler/state.go
@@ -297,7 +297,7 @@ func (s *State) GetSessions() (map[string]int64, error) {
 
 	for key := range s.dv.KeysPrefix(sessionPrefix, nil) {
 		// skip if the key is exactly the sessionPrefix
-		if string(key) == sessionPrefix {
+		if key == sessionPrefix {
 			continue
 		}
 

--- a/integrations/event-handler/state.go
+++ b/integrations/event-handler/state.go
@@ -308,6 +308,10 @@ func (s *State) GetSessions() (map[string]int64, error) {
 
 		// Assume 0 if byte count is incorrect
 		if len(b) != 8 {
+			s.log.WarnContext(
+				context.TODO(),
+				"Malformed session state key found in storage. Starting over at index 0.", "session", key,
+			)
 			b = make([]byte, 8)
 			binary.BigEndian.PutUint64(b, uint64(0))
 		}

--- a/integrations/event-handler/state.go
+++ b/integrations/event-handler/state.go
@@ -307,7 +307,7 @@ func (s *State) GetSessions() (map[string]int64, error) {
 		}
 
 		// Assume 0 if byte count is incorrect
-		if len(b) != 8 {
+		if len(b) != binary.Size(uint64(0)) {
 			s.log.WarnContext(
 				context.TODO(),
 				"Malformed session state key found in storage. Starting over at index 0.", "session", key,

--- a/integrations/event-handler/state_test.go
+++ b/integrations/event-handler/state_test.go
@@ -155,7 +155,6 @@ func TestGetSessions(t *testing.T) {
 	state, err := NewState(config, slog.Default())
 	require.NoError(t, err)
 
-	expected := make([]session, 0, 10)
 	expectedMap := make(map[string]int64, 10)
 	for i := 0; i < 10; i++ {
 		s := session{
@@ -164,7 +163,6 @@ func TestGetSessions(t *testing.T) {
 			UploadTime: time.Now().UTC(),
 		}
 		err := state.SetSessionIndex(s.ID, 0)
-		expected = append(expected, s)
 		expectedMap[s.ID] = 0
 		assert.NoError(t, err)
 	}

--- a/integrations/event-handler/state_test.go
+++ b/integrations/event-handler/state_test.go
@@ -149,3 +149,69 @@ func TestStateMissingRecordings(t *testing.T) {
 	require.NoError(t, err)
 
 }
+
+func TestGetSessions(t *testing.T) {
+	config := newStartCmdConfig(t)
+	state, err := NewState(config, slog.Default())
+	require.NoError(t, err)
+
+	expected := make([]session, 0, 10)
+	expectedmap := make(map[string]int64, 10)
+	for i := 0; i < 10; i++ {
+		s := session{
+			ID:         strconv.Itoa(i),
+			Index:      int64(i),
+			UploadTime: time.Now().UTC(),
+		}
+		err := state.SetSessionIndex(s.ID, 0)
+		expected = append(expected, s)
+		expectedmap[s.ID] = 0
+		assert.NoError(t, err)
+	}
+
+	// List with GetSessions should work
+	// Iterating find all stored records and validate they match
+	// the original sessions.
+	sessions, err := state.GetSessions()
+	require.NoError(t, err)
+	assert.Equal(t, expectedmap, sessions)
+
+	// add bogus entry by writing a file called `session` to the directory
+	var b = make([]byte, 8)
+	err = state.dv.Write(sessionPrefix, b)
+	require.NoError(t, err)
+
+	// break real entry by writing a zero-byte file
+	b = make([]byte, 0)
+	p := sessionPrefix + strconv.Itoa(2)
+	err = state.dv.Write(p, b)
+	require.NoError(t, err)
+
+	// now with bogus empty file, try GetSessions again
+	sessions, err = state.GetSessions()
+	require.NoError(t, err)
+	assert.Equal(t, expectedmap, sessions)
+
+}
+
+func TestSetSessionIndex(t *testing.T) {
+	config := newStartCmdConfig(t)
+	state, err := NewState(config, slog.Default())
+	require.NoError(t, err)
+
+	s1 := session{
+		ID:         "61ab9b21-172e-40af-bf94-d95da60c94f1",
+		Index:      int64(0),
+		UploadTime: time.Now().UTC(),
+	}
+	err = state.SetSessionIndex(s1.ID, 0)
+	require.NoError(t, err)
+
+	s2 := session{
+		ID:         "",
+		Index:      int64(0),
+		UploadTime: time.Now().UTC(),
+	}
+	err = state.SetSessionIndex(s2.ID, 0)
+	require.Error(t, err, "Should refuse to set an empty Session ID")
+}

--- a/integrations/event-handler/state_test.go
+++ b/integrations/event-handler/state_test.go
@@ -156,7 +156,7 @@ func TestGetSessions(t *testing.T) {
 	require.NoError(t, err)
 
 	expected := make([]session, 0, 10)
-	expectedmap := make(map[string]int64, 10)
+	expectedMap := make(map[string]int64, 10)
 	for i := 0; i < 10; i++ {
 		s := session{
 			ID:         strconv.Itoa(i),
@@ -165,7 +165,7 @@ func TestGetSessions(t *testing.T) {
 		}
 		err := state.SetSessionIndex(s.ID, 0)
 		expected = append(expected, s)
-		expectedmap[s.ID] = 0
+		expectedMap[s.ID] = 0
 		assert.NoError(t, err)
 	}
 
@@ -174,7 +174,7 @@ func TestGetSessions(t *testing.T) {
 	// the original sessions.
 	sessions, err := state.GetSessions()
 	require.NoError(t, err)
-	assert.Equal(t, expectedmap, sessions)
+	assert.Equal(t, expectedMap, sessions)
 
 	// add bogus entry by writing a file called `session` to the directory
 	var b = make([]byte, 8)
@@ -190,7 +190,7 @@ func TestGetSessions(t *testing.T) {
 	// now with bogus empty file, try GetSessions again
 	sessions, err = state.GetSessions()
 	require.NoError(t, err)
-	assert.Equal(t, expectedmap, sessions)
+	assert.Equal(t, expectedMap, sessions)
 
 }
 


### PR DESCRIPTION
Backport #64342 to branch/v17

## Manual Test Plan

### Test Environment
A self hosted v18 cluster using the XXX backend.

### Test Cases
- [x] Event handler runs
- [x] New SSH sessions are ingested
- [x] Event handler can be restarted
- [x] Event handler recovers from a corrupted state directory

changelog: Hardened event handler so it recovers in case of malformed session ID or corrupted data directory