### PR TITLE
Don't unmount Account Settings route components

### DIFF
--- a/web/packages/teleport/src/Account/Account.tsx
+++ b/web/packages/teleport/src/Account/Account.tsx
@@ -152,11 +152,11 @@ export function Account({
               <Route
                 exact
                 path={cfg.routes.account}
-                component={() => <Redirect to={cfg.routes.accountSecurity} />}
+                render={() => <Redirect to={cfg.routes.accountSecurity} />}
               />
               <Route
                 path={cfg.routes.accountSecurity}
-                component={() => (
+                render={() => (
                   <SecuritySettings
                     isSso={isSso}
                     canAddPasskeys={canAddPasskeys}
@@ -183,7 +183,7 @@ export function Account({
               />
               <Route
                 path={cfg.routes.accountPreferences}
-                component={() => (
+                render={() => (
                   <Preferences setErrorMessage={stableSetErrorMessage} />
                 )}
               />


### PR DESCRIPTION
Fixes https://github.com/gravitational/teleport/issues/66465

Changelog: Fixed unnecessary double MFA challenge when adding a MFA device using Web UI

This change prevents subcomponents tied to subroutes of the Account
Settings page from being unmounted whenever the `Account` component
state changes. Previous implementation effectively gave a different
component to the route each time `Account` was rendered.

Note: this PR is created against the v18 branch and v18 branch only, as the issue is specific to v18.

## Manual Test Plan
### Test Environment

A cloud cluster (necessary for testing the recovery scenario).

### Test Cases
- [x] Can CRUD passkeys (passwordless)
  - [x] Can login with added passkey
- [x] Can change passwords
  - [x] Can login with changed password
  - [x] Verify that account is locked after several unsuccessful change password attempts
- [x] Can CRUD MFA devices (test both otp + hardware key)
  - [x] Can login with added device
- Recovery codes
  - [x] Cloud only: can read and generate new recovery codes
- Windows Desktop Session Keyboard Layout
  - [x] Can change the keyboard layout
  - [x] Verify that the keyboard layout is saved upon relogin
