### PR TITLE
Focus more how-to guide steps on commands

### DIFF
--- a/docs/pages/enroll-resources/application-access/protect-apps/connecting-apps.mdx
+++ b/docs/pages/enroll-resources/application-access/protect-apps/connecting-apps.mdx
@@ -22,6 +22,20 @@ the Teleport Proxy Service address. The Teleport Proxy Service routes browser
 traffic to the Teleport Application Service, which forwards HTTP requests to and
 from target applications.
 
+Once the Teleport Application Service is proxying traffic to your web
+application, the Teleport Proxy Service makes the application available at the
+following URL:
+
+```text
+https://<APPLICATION_NAME>.<TELEPORT_DOMAIN>
+```
+
+For example, if your Teleport domain name is `teleport.example.com`, the
+application named `my-app` would be available at
+`https://my-app.teleport.example.com`. The Proxy Service must present a TLS
+certificate for this domain name that browsers can verify against a certificate
+authority.
+
 ## Prerequisites
 
 (!docs/pages/includes/edition-prereqs-tabs.mdx!)
@@ -29,11 +43,43 @@ from target applications.
 - A web application that you want to protect with Teleport. The web application
   should be running in a private network. In this guide, we assume that the web
   application is available on `app.example.com:3000`.
+
 - A Linux server where you will run the Teleport Application Service. Your
   network must enable the server to connect to your web application.
+
 - (!docs/pages/includes/tctl.mdx!)
 
-## Step 1/3. Deploy the Teleport Application Service
+- **If you are self-hosting Teleport**, one of the following DNS records, which
+  allow users and API clients to reach Teleport-protected applications:
+  - A DNS A record that associates a wildcard subdomain of your Teleport Proxy
+    Service domain, e.g., `*.teleport.example.com`, with the IP address of the
+    Teleport Proxy Service.
+  - A DNS CNAME record that associates a wildcard subdomain of your Proxy
+    Service domain, e.g., `*.teleport.example.com`, with the domain name of the
+    Teleport Proxy Service.
+
+  If you are using Teleport Enterprise (Cloud), DNS records and TLS certificates
+  for this domain name are provisioned automatically.
+
+  <Admonition type="warning">
+
+   Do not create DNS records that map the Teleport cluster subdomain of a
+   registered application to the application's own host, as attempts to navigate
+   to the application will fail.
+
+  </Admonition>
+
+- **If you are self-hosting Teleport** Ensure that your system provisions TLS
+  certificates for Teleport-registered applications. The method to use depends
+  on how you originally set up TLS for your self-hosted Teleport deployment, and
+  is outside the scope of this guide. 
+
+  In general, the same system that provisions TLS certificates signed for the
+  web address of the Proxy Service (e.g., `teleport.example.com`) must also
+  provision certificates for the wildcard address used for applications (e.g.,
+  `*.teleport.example.com`).
+
+## Step 1/2. Deploy the Teleport Application Service
 
 In this step, you will configure the Teleport Application Service to proxy a
 target application, then deploy a Teleport Agent to run the service.
@@ -110,11 +156,7 @@ Application Service:
 
 (!docs/pages/includes/start-teleport.mdx service="the Teleport Application Service"!)
 
-## Step 2/3. [Optional] Configure TLS and DNS for your web applications
-
-(!docs/pages/includes/dns-app-access.mdx!)
-
-## Step 3/3. Configure RBAC and access the application
+## Step 2/2. Configure RBAC and access the application
 
 1. Create a role called `demo-app-access` that allows access to applications
    with the `env:demo` label that you assigned to the application that you

--- a/docs/pages/enroll-resources/application-access/vnet.mdx
+++ b/docs/pages/enroll-resources/application-access/vnet.mdx
@@ -74,7 +74,7 @@ and the suffix can be set to `bar.qux.test`.
 ## Step 2/3. Set `public_addr` of the app
 
 Set `public_addr` field of the application in the Application Service configuration file
-`/etc/teleport.yaml` and restart the `teleport` daemon.
+`/etc/teleport.yaml`:
 
 ```diff
 version: v3
@@ -85,6 +85,12 @@ app_service:
   - name: "tcp-app"
     uri: tcp://localhost:5432
 +   public_addr: "<Var name="public_addr" />"
+```
+
+Restart the `teleport` daemon:
+
+```code
+$ sudo systemctl reload teleport
 ```
 
 ## Step 3/3. Connect

--- a/docs/pages/installation/agents/add-service-to-agent.mdx
+++ b/docs/pages/installation/agents/add-service-to-agent.mdx
@@ -58,9 +58,10 @@ the `teleport-kube-agent` Helm chart:
 <Tabs>
 <TabItem label="tctl">
 
-Edit the `spec.roles` field in your token resource manifest. In this example, we
-are allowing this token to join the Teleport Application Service in addition to
-the Teleport Kubernetes Service:
+Edit the `spec.roles` field in your token resource manifest. In this example,
+which assumes the token manifest is at `token.yaml`, we are allowing this token
+to join the Teleport Application Service in addition to the Teleport Kubernetes
+Service:
 
 ```diff
 # ...
@@ -68,6 +69,12 @@ the Teleport Kubernetes Service:
     # use the minimal set of roles required (e.g. Node, Proxy, App, Kube, DB, WindowsDesktop)
 -   roles: [Kube]
 +   roles: [Kube,App]
+```
+
+Apply your changes:
+
+```code
+$ tctl create -f token.yaml
 ```
 
 </TabItem>
@@ -85,12 +92,19 @@ the Teleport Kubernetes Service:
 -     roles       = ["Kube"]
 +     roles       = ["Kube","App"]
 ```
+
+Reapply your changes:
+
+```code
+$ terraform apply
+```
+
 </TabItem>
 <TabItem label="Kubernetes">
 
-Edit the `spec.roles` field in your manifest. In this example, we are allowing
-this token to join the Teleport Application Service in addition to the Teleport
-Kubernetes Service:
+Edit the `spec.roles` field in your manifest, which we assume exists at
+`token.yaml`. In this example, we are allowing this token to join the Teleport
+Application Service in addition to the Teleport Kubernetes Service:
 
 ```diff
 # ...
@@ -99,6 +113,13 @@ Kubernetes Service:
 -   roles: [Kube]
 +   roles: [Kube,App]
 ```
+
+Apply your changes:
+
+```code
+$ kubectl apply -f token.yaml
+```
+
 </TabItem>
 <TabItem label="teleport-kube-agent">
 
@@ -111,13 +132,14 @@ Kubernetes Service:
 + roles: kube,app
 ```
 
+You will apply your changes when you redeploy the agent later in the guide.
+
 See the `teleport-kube-agent` [chart
 reference](../../reference/helm-reference/teleport-kube-agent.mdx#roles) for the
 roles and token types that the chart supports.
 
 </TabItem>
 </Tabs>
-
 
 ## Step 2/3. Edit your agent configuration
 

--- a/docs/pages/installation/agents/aws-iam.mdx
+++ b/docs/pages/installation/agents/aws-iam.mdx
@@ -50,7 +50,7 @@ joining token.
   installed.
 - (!docs/pages/includes/iac-clients.mdx!)
 
-## Step 1/5. Set up AWS IAM credentials
+## Step 1/3. Set up AWS IAM credentials
 
 Every Teleport process using the IAM method to join your Teleport cluster needs
 AWS IAM credentials in order to call the `sts:GetCallerIdentity` API. No
@@ -60,7 +60,7 @@ this API.
 If you are running Teleport on an EC2 instance, it is sufficient to attach any
 IAM role to the instance, using either the AWS Management Console or CLI. If the
 instance already has a role attached, you can skip to [Step
-2](#step-25-create-the-aws-joining-token).
+2](#step-23-create-the-aws-joining-token).
 
 <Tabs>
 <TabItem label="AWS Management Console">
@@ -115,7 +115,7 @@ policies.
 </TabItem>
 </Tabs>
 
-## Step 2/5. Create the AWS joining token
+## Step 2/3. Create the AWS joining token
 
 Create the following `token.yaml` with an `allow` rule specifying your AWS
 account and the ARN that the Teleport process's identity must match.
@@ -159,43 +159,39 @@ Add the following Kubernetes resource manifest, replacing values as indicated:
 </TabItem>
 </Tabs>
 
-## Step 3/5 Install Teleport
+## Step 3/3. Launch a Teleport Agent
 
-Install Teleport on your AWS EC2 instance.
+1. Install Teleport on your AWS EC2 instance:
 
-(!docs/pages/includes/install-linux.mdx!)
+   (!docs/pages/includes/install-linux.mdx!)
 
-## Step 4/5. Configure your services
+1. Configure your Teleport service with a custom `teleport.yaml` file. Use the
+   `join_params` section with `token_name` matching your token created in Step 2
+   and `method: iam` as shown in the following example config:
 
-Configure your Teleport service with a custom `teleport.yaml` file. Use the
-`join_params` section with `token_name` matching your token created in Step 2
-and `method: iam` as shown in the following example config:
+   ```yaml
+   # /etc/teleport.yaml
+   version: v3
+   teleport:
+     join_params:
+       token_name: iam-token
+       method: iam
+     proxy_server: teleport.example.com:443
+   ssh_service:
+     enabled: true
+   auth_service:
+     enabled: false
+   proxy_service:
+     enabled: false
+   ```
 
-```
-# /etc/teleport.yaml
-version: v3
-teleport:
-  join_params:
-    token_name: iam-token
-    method: iam
-  proxy_server: teleport.example.com:443
-ssh_service:
-  enabled: true
-auth_service:
-  enabled: false
-proxy_service:
-  enabled: false
-```
+   In the `teleport.proxy_server` field, replace the value with the host and web
+   port of your Teleport Proxy Service or Teleport Enterprise Cloud tenant,
+   e.g., `mytenant.teleport.sh:443`.
 
-In the `teleport.proxy_server` field, replace the value with the host and web
-port of your Teleport Proxy Service or Teleport Enterprise Cloud tenant, e.g.,
-`mytenant.teleport.sh:443`.
+1. (!docs/pages/includes/aws-credentials.mdx!)
 
-## Step 5/5. Launch your Teleport process
-
-(!docs/pages/includes/aws-credentials.mdx!)
-
-(!docs/pages/includes/start-teleport.mdx!)
+1. (!docs/pages/includes/start-teleport.mdx!)
 
 Once you have started Teleport, confirm that your service is able to connect to and
 join your cluster.

--- a/docs/pages/machine-workload-identity/deployment/github-actions.mdx
+++ b/docs/pages/machine-workload-identity/deployment/github-actions.mdx
@@ -185,18 +185,24 @@ to SSH. This example grants access to root on all nodes. In a production setup,
 it would be a good idea to restrict this to only the nodes that the bot would
 need.
 
-Use `tctl edit role/example-bot` to add the following to the role:
+1. Run the following command to open the `example-bot` role in your text editor:
 
-```yaml
-spec:
-  allow:
-    # Allow login to the Linux user 'root'.
-    logins: ['root']
-    # Allow connection to any node. Adjust these labels to match only nodes
-    # that needed to access.
-    node_labels:
-      '*': '*'
-```
+  ```code
+  $ tctl edit role/example-bot
+  ```
+
+1. Ensure the role includes the following:
+
+   ```yaml
+   spec:
+     allow:
+       # Allow login to the Linux user 'root'.
+       logins: ['root']
+       # Allow connection to any node. Adjust these labels to match only nodes
+       # that needed to access.
+       node_labels:
+         '*': '*'
+   ```
 
 With those privileges granted, you can now create the GitHub Actions workflow.
 Create `.github/workflows/example.yaml`:
@@ -309,20 +315,26 @@ to the Kubernetes cluster. This example will grant the bot access to all
 clusters with the group `editor`. For more detailed instructions on setting
 up Kubernetes RBAC, see the Kubernetes access guide.
 
-Use `tctl edit role/example-bot` to add the following rule to the Teleport role:
+1. Run the following command to open the `example-bot` role in your text editor:
 
-```yaml
-spec:
-  allow:
-    kubernetes_labels:
-      '*': '*'
-    kubernetes_resources:
-    - kind: pod
-      namespace: "*"
-      name: "*"
-    kubernetes_groups:
-    - editor
-```
+  ```code
+  $ tctl edit role/example-bot
+  ```
+
+1. Ensure the role includes the following:
+
+   ```yaml
+   spec:
+     allow:
+       kubernetes_labels:
+         '*': '*'
+       kubernetes_resources:
+       - kind: pod
+         namespace: "*"
+         name: "*"
+       kubernetes_groups:
+       - editor
+   ```
 
 <Admonition type="note">
 This example assumes the role is version `v6`. If you are using a `v7`+ role
@@ -413,19 +425,25 @@ Postgres database, but you may use any supported database type with any
 compatible client. Refer to our [generic database guide](../access-guides/databases.mdx)
 for more information on accessing databases protected by Teleport in your apps.
 
-Use `tctl edit role/example-bot` to add the following to the role:
+1. Run the following command to open the `example-bot` role in your text editor:
 
-```yaml
-spec:
-  allow:
-    db_labels:
-      '*': '*'
-    db_names: [demo-db]
-    db_users: [demo-user]
-    rules:
-      - resources: [db_server, db]
-        verbs: [read, list]
-```
+  ```code
+  $ tctl edit role/example-bot
+  ```
+
+1. Ensure the role includes the following:
+
+   ```yaml
+   spec:
+     allow:
+       db_labels:
+         '*': '*'
+       db_names: [demo-db]
+       db_users: [demo-user]
+       rules:
+         - resources: [db_server, db]
+           verbs: [read, list]
+   ```
 
 Make sure to adjust the labels, names, and users as necessary to match your
 desired databases.
@@ -522,15 +540,21 @@ The `teleport-actions/application-tunnel` action runs a background `tbot` client
 that provides a tunnel to an HTTP or TCP app protected by Teleport using Machine
 & Workload ID's [`application-tunnel` service](../../reference/machine-workload-identity/configuration.mdx#application-tunnel).
 
-Use `tctl edit role/example-bot` to add the following to the role:
+1. Run the following command to open the `example-bot` role in your text editor:
 
-```yaml
-spec:
-  allow:
-    # Grants access to apps with the `env=dev` label.
-    app_labels:
-      env: dev
-```
+  ```code
+  $ tctl edit role/example-bot
+  ```
+
+1. Ensure the role includes the following:
+
+   ```yaml
+   spec:
+     allow:
+       # Grants access to apps with the `env=dev` label.
+       app_labels:
+         env: dev
+   ```
 
 Make sure to adjust the label selector in the role to restrict which
 applications the bot will be allowed to access. For more information, refer to
@@ -617,15 +641,21 @@ so long as your bot has been granted appropriate RBAC permissions, so long as
 your client app can use HTTP proxies (e.g. the `$HTTP_PROXY` environment
 variable).
 
-Use `tctl edit role/example-bot` to add the following to the role:
+1. Run the following command to open the `example-bot` role in your text editor:
 
-```yaml
-spec:
-  allow:
-    # Grants access to apps with the `env=dev` label.
-    app_labels:
-      env: dev
-```
+  ```code
+  $ tctl edit role/example-bot
+  ```
+
+1. Ensure the role includes the following:
+
+   ```yaml
+   spec:
+     allow:
+       # Grants access to apps with the `env=dev` label.
+       app_labels:
+         env: dev
+   ```
 
 Make sure to adjust the label selector in the role to restrict which
 applications the bot will be allowed to access. For more information, refer to

--- a/docs/pages/machine-workload-identity/getting-started.mdx
+++ b/docs/pages/machine-workload-identity/getting-started.mdx
@@ -453,11 +453,28 @@ Commit and push this file to your repository.
 
 ### Run the workflow
 
-In your GitHub repository
+Execute the workflow you created:
+
+<Tabs>
+<TabItem label="Web UI">
+
+In your GitHub repository:
 - Go to the `Actions` tab
 - Select the Teleport workflow on the left
 - Click `Run workflow` on the right
 - Make sure the branch is `main` and click the `Run workflow` confirmation button
+
+</TabItem>
+<TabItem label="CLI">
+
+Execute the following command:
+
+```code
+$ gh workflow run teleport.yaml --ref main
+```
+
+</TabItem>
+</Tabs>
 
 After the workflow completes, you should see the job complete successfully, and the output of the command in the logs.
 

--- a/docs/pages/zero-trust-access/api/automatically-register-agents.mdx
+++ b/docs/pages/zero-trust-access/api/automatically-register-agents.mdx
@@ -62,7 +62,7 @@ services with your Teleport cluster.
 
 </Admonition>
 
-## Step 1/5. Set up your Go project
+## Step 1/4. Set up your Go project
 
 Download the source code for our minimal API client:
 
@@ -75,7 +75,7 @@ For the rest of this guide, we will show you how to set up this API client and
 explore the way it uses Teleport's API to synchronize Teleport Application
 Service instances with an external service discovery solution.
 
-## Step 2/5. Define RBAC resources
+## Step 2/4. Define RBAC resources
 
 Clients that communicate with Teleport's gRPC API assume the identity of a
 Teleport user and role in order to authenticate to the Auth Service, which
@@ -170,7 +170,7 @@ role 'register-apps-impersonator' has been created
 You will now be able to generate signed certificates for the `register-apps`
 role and user.
 
-## Step 3/5. Export an identity for the client application
+## Step 3/4. Export an identity for the client application
 
 Like all Teleport users, `register-apps` needs signed credentials in order to
 connect to your Teleport cluster. You will use the `tctl auth sign` command to
@@ -190,7 +190,74 @@ which establishes a reverse tunnel connection to the Auth Service. The plugin
 uses this reverse tunnel, along with your TLS credentials, to connect to the
 Auth Service's gRPC endpoint.
 
-## Step 4/5. Write the client application
+## Step 4/4. Test your client application
+
+Run the client application to see how Teleport can register and deregister
+resources in your infrastructure to synchronize with your service discovery
+solution.
+
+Make sure you have pulled the Teleport container image so the application can
+create containers based on it:
+
+```code
+$ docker image pull (=teleport.latest_oss_docker_image=)
+```
+
+In your project directory, run the following command:
+
+```code
+$ go run main.go
+Starting the application
+Connected to Teleport
+Connected to the Docker daemon
+```
+
+In a new terminal, run three new RabbitMQ containers:
+
+```code
+$ for i in {1..3}; do docker run -d rabbitmq:3-management; done;
+```
+
+The terminal where you ran the application should show output similar to the
+following:
+
+```text
+Created a new application token for URL: http://172.17.0.4:15672
+Started an Application Service container to proxy URL: http://172.17.0.4:15672
+Created a new application token for URL: http://172.17.0.3:15672
+Started an Application Service container to proxy URL: http://172.17.0.3:15672
+Created a new application token for URL: http://172.17.0.2:15672
+Started an Application Service container to proxy URL: http://172.17.0.2:15672
+```
+
+Verify that the RabbitMQ instances are registered with Teleport:
+
+```code
+$ tsh apps ls
+Application         Description Type Public Address           Labels
+------------------- ----------- ---- ------------------------ -------------------
+rabbitmq-172-17-0-2             HTTP rabbitmq-172-17-0-2.3... teleport.dev/origin
+rabbitmq-172-17-0-3             HTTP rabbitmq-172-17-0-3.3... teleport.dev/origin
+rabbitmq-172-17-0-4             HTTP rabbitmq-172-17-0-4.3... teleport.dev/origin
+```
+
+Next, stop one of your RabbitMQ containers:
+
+```code
+$ docker stop $(docker ps --filter "ancestor=rabbitmq:3-management" -q --last 1)
+```
+
+The terminal where you ran the application should show output similar to the
+following:
+
+```text
+Deleted unnecessary Application Service record: rabbitmq-172-17-0-4
+Deleted unnecessary Application Service container: 63facaa3033a
+```
+
+You should now see two registered applications when you run `tsh apps ls`.
+
+## How the application works
 
 In this step, we will walk you through the example client application.
 
@@ -886,73 +953,6 @@ manages communication between concurrent routines.
 After we create a ticker, the entrypoint receives from the ticker's channel
 (`k.C`) whenever the `updateInterval` elapses. It blocks until it receives from
 the channel, calling `app.reconcileApps` every interval.
-
-## Step 5/5. Test your client application
-
-Run the client application to see how Teleport can register and deregister
-resources in your infrastructure to synchronize with your service discovery
-solution.
-
-Make sure you have pulled the Teleport container image so the application can
-create containers based on it:
-
-```code
-$ docker image pull (=teleport.latest_oss_docker_image=)
-```
-
-In your project directory, run the following command:
-
-```code
-$ go run main.go
-Starting the application
-Connected to Teleport
-Connected to the Docker daemon
-```
-
-In a new terminal, run three new RabbitMQ containers:
-
-```code
-$ for i in {1..3}; do docker run -d rabbitmq:3-management; done;
-```
-
-The terminal where you ran the application should show output similar to the
-following:
-
-```text
-Created a new application token for URL: http://172.17.0.4:15672
-Started an Application Service container to proxy URL: http://172.17.0.4:15672
-Created a new application token for URL: http://172.17.0.3:15672
-Started an Application Service container to proxy URL: http://172.17.0.3:15672
-Created a new application token for URL: http://172.17.0.2:15672
-Started an Application Service container to proxy URL: http://172.17.0.2:15672
-```
-
-Verify that the RabbitMQ instances are registered with Teleport:
-
-```code
-$ tsh apps ls
-Application         Description Type Public Address           Labels
-------------------- ----------- ---- ------------------------ -------------------
-rabbitmq-172-17-0-2             HTTP rabbitmq-172-17-0-2.3... teleport.dev/origin
-rabbitmq-172-17-0-3             HTTP rabbitmq-172-17-0-3.3... teleport.dev/origin
-rabbitmq-172-17-0-4             HTTP rabbitmq-172-17-0-4.3... teleport.dev/origin
-```
-
-Next, stop one of your RabbitMQ containers:
-
-```code
-$ docker stop $(docker ps --filter "ancestor=rabbitmq:3-management" -q --last 1)
-```
-
-The terminal where you ran the application should show output similar to the
-following:
-
-```text
-Deleted unnecessary Application Service record: rabbitmq-172-17-0-4
-Deleted unnecessary Application Service container: 63facaa3033a
-```
-
-You should now see two registered applications when you run `tsh apps ls`.
 
 ## Next steps
 


### PR DESCRIPTION
Ensure that in how-to guides, the actionable steps within each guide include CLI commands. Standardize on including commands as block-level `code` snippets instead of inline prose.

- **Connecting Apps:** Move Step 2, the DNS/TLS step, into the Prerequisites. This is because the step is outside the scope of this guide and requires potentially new infrastructure choices.
- **VNet admin guide:** Use an example command for restarting Teleport instead of prose.
- **add-service-to-agent.mdx:**  Add example commands to apply the token configuration.
- **AWS IAM:** Combine related operations into a single step: configuring and starting Teleport. This isn't necessarily required, but improves readability and helps us roll out a standard in which we expect every "Step" to have at least one command.
- **automatically-register-agents.mdx:**  Fix misleading section heading: "Write the app" doesn't accurately represent the section, which is a walkthrough of an app that is already copied and started in other steps.
- **github-actions.mdx:** Extract inline commands into code fences.
- **MWI getting started:** Add a CLI alternative to the Web UI-based workflow run step.