### PR TITLE
Connect: attempt to fix `ETIMEDOUT` error on launch

### DIFF
--- a/web/packages/teleterm/src/preload.ts
+++ b/web/packages/teleterm/src/preload.ts
@@ -96,9 +96,17 @@ async function getElectronGlobals(): Promise<ElectronGlobals> {
   // All uses of tshClient must wait before updateTshdEventsServerAddress finishes to ensure that
   // the client is ready. Otherwise we run into a risk of causing panics in tshd due to a missing
   // tshd events client.
-  await tshClient.updateTshdEventsServerAddress({
-    address: tshdEventsServerAddress,
-  });
+  await tshClient.updateTshdEventsServerAddress(
+    {
+      address: tshdEventsServerAddress,
+    },
+    {
+      timeout: 15_000,
+      // On Windows, this first local gRPC call has been observed to fail fast
+      // with ETIMEDOUT even though the channel becomes ready shortly after.
+      metadataOptions: { waitForReady: true },
+    }
+  );
 
   return {
     mainProcessClient,

--- a/web/packages/teleterm/src/ui/boot.tsx
+++ b/web/packages/teleterm/src/ui/boot.tsx
@@ -19,6 +19,8 @@
 import React from 'react';
 import { createRoot } from 'react-dom/client';
 
+import { getErrorMessage } from 'shared/utils/error';
+
 import Logger from 'teleterm/logger';
 import { ElectronGlobals } from 'teleterm/types';
 import { App } from 'teleterm/ui/App';
@@ -51,7 +53,9 @@ async function boot(): Promise<void> {
   } catch (e) {
     logger.error('Failed to boot the React app', e);
     renderApp(
-      <FailedApp message={`Could not start the application: ${e.toString()}`} />
+      <FailedApp
+        message={`Could not start the application: ${getErrorMessage(e)}`}
+      />
     );
   }
 }


### PR DESCRIPTION
Some Windows users reported that Teleport Connect fails during startup.

The failure happens in the preload process while sending the first local gRPC request to the bundled tsh process:
`
[UI] error: Failed to boot the React app {"name":"TshdRpcError","message":"No connection established. Last error: Error: connect ETIMEDOUT 127.0.0.1:56365","stack":"RpcError: No connection established. Last error: Error: connect ETIMEDOUT 127.0.0.1:56365\n    at Object.callback (C:\\Program Files\\Teleport Connect\\resources\\app.asar\\build\\app\\preload\\index.js:3081:19)\n    at Object.onReceiveStatus (C:\\Program Files\\Teleport Connect\\resources\\app.asar\\node_modules\\@grpc\\grpc-js\\build\\src\\client.js:193:36)\n    at Object.onReceiveStatus (C:\\Program Files\\Teleport Connect\\resources\\app.asar\\node_modules\\@grpc\\grpc-js\\build\\src\\client-interceptors.js:361:141)\n    at Object.onReceiveStatus (C:\\Program Files\\Teleport Connect\\resources\\app.asar\\node_modules\\@grpc\\grpc-js\\build\\src\\client-interceptors.js:324:181)\n    at C:\\Program Files\\Teleport Connect\\resources\\app.asar\\node_modules\\@grpc\\grpc-js\\build\\src\\resolving-call.js:135:78\n    at process.processTicksAndRejections (node:internal/process/task_queues:84:11)","code":"UNAVAILABLE","isResolvableWithRelogin":false}
`

The grpc-js logs show the first connection attempt failing with `ETIMEDOUT`, which causes the RPC to fail fast. The channel then transitions to READY shortly afterward. In one captured trace, the channel became healthy roughly 700 ms after the RPC had already failed.

This PR sets `waitForReady` on `UpdateTshdEventsServerAddress` and adds a 15-second timeout. That lets grpc-js keep this startup RPC queued while the local channel transitions to READY, instead of failing the app startup on a transient local connection error.

Unfortunately, I was not able to reproduce the exact `ETIMEDOUT` error locally, so this change may not solve the bug. But if it does, we should consider applying the same handling to other local gRPC clients in Connect that could fail in the same way.

Changelog: Improved Teleport Connect startup reliability on Windows

<!-- Include manual testing efforts to verify the change. -->
<!-- Detail where the tests where run and what configurations were used. -->
<!-- Include all the test cases which were run to validate the change. -->

## Manual Test Plan
### Test Environment
Locally built app.

### Test Cases
- [x] The app starts as usual.
