### PR TITLE
Support IPv6 addresses in LDAPS URLs

### DIFF
--- a/lib/winpki/ldap.go
+++ b/lib/winpki/ldap.go
@@ -427,13 +427,20 @@ func parseLDAPReferral(raw string) (ldapReferral, error) {
 	}
 
 	isValidHostPort := func(host string) error {
+		// As a first pass, run it through the standard URL parser.
+		if _, err := url.Parse(scheme + host); err != nil {
+			return trace.BadParameter("malformed LDAP URL - invalid address or hostname: %v", err)
+		}
+
+		// url.Parse misses invalid characters in hostnames. ex, "host_name:8080" contains
+		// an illegal underscore, but passes validation above. We'll be a little more strict.
 		const subDelims = "!$&'()*+,;=:"
 		for _, r := range host {
 			switch {
 			case r >= 'A' && r <= 'Z':
 			case r >= 'a' && r <= 'z':
 			case r >= '0' && r <= '9':
-			case r == '-' || r == '.' || r == '_' || r == '~':
+			case r == '-' || r == '.' || r == '_' || r == '~' || r == '[' || r == ']':
 			case strings.ContainsRune(subDelims, r):
 			case r == '%':
 			default:

--- a/lib/winpki/ldap_test.go
+++ b/lib/winpki/ldap_test.go
@@ -416,6 +416,18 @@ func TestReferralParsing(t *testing.T) {
 		assert.Equal(t, "??extensions", ref.extensions)
 	})
 
+	t.Run("ipv6", func(t *testing.T) {
+		ref, err := parseLDAPReferral("ldaps://[2001:db8::1]:80/dn")
+		require.NoError(t, err)
+		assert.Equal(t, "ldaps://", ref.scheme)
+		assert.Equal(t, "[2001:db8::1]:80", ref.host)
+		assert.Equal(t, "dn", ref.baseDN)
+		assert.Empty(t, ref.attributes)
+		assert.Empty(t, ref.filter)
+		assert.Empty(t, ref.scope)
+		assert.Empty(t, ref.extensions)
+	})
+
 	t.Run("dn only", func(t *testing.T) {
 		ref, err := parseLDAPReferral("ldap:///dn")
 		require.NoError(t, err)


### PR DESCRIPTION
Codex found this bug in the v18 backport for multi-domain logon support (#66471). This PR ports the fix up to master.


<!-- Provide a descriptive entry for the changelog of the next release. -->


<!-- Include manual testing efforts to verify the change. -->
<!-- Detail where the tests where run and what configurations were used. -->
<!-- Include all the test cases which were run to validate the change. -->

## Manual Test Plan
### Test Environment
Unit tests
### Test Cases
- [x] Unit test for ipv6 succeeds
