### PR TITLE
Update discovery terraform version requirement to 'next version' 18.8.0

### DIFF
--- a/docs/pages/reference/infrastructure-as-code/terraform-modules/teleport-discovery-aws/teleport-discovery-aws.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-modules/teleport-discovery-aws/teleport-discovery-aws.mdx
@@ -94,7 +94,7 @@ For bugs related to this code, please [open an issue](https://github.com/gravita
 | terraform | >= 1.5.7 |
 | aws | >= 5.0 |
 | http | >= 3.0 |
-| teleport | >= 18.7.4 |
+| teleport | >= 18.8.0 |
 | tls | >= 4.0 |
 
 ## Providers
@@ -103,7 +103,7 @@ For bugs related to this code, please [open an issue](https://github.com/gravita
 | ---- | ------- |
 | aws | >= 5.0 |
 | http | >= 3.0 |
-| teleport | >= 18.7.4 |
+| teleport | >= 18.8.0 |
 | tls | >= 4.0 |
 
 ## Modules

--- a/integrations/terraform-modules/teleport/discovery/aws/README.md
+++ b/integrations/terraform-modules/teleport/discovery/aws/README.md
@@ -80,7 +80,7 @@ For bugs related to this code, please [open an issue](https://github.com/gravita
 | terraform | >= 1.5.7 |
 | aws | >= 5.0 |
 | http | >= 3.0 |
-| teleport | >= 18.7.4 |
+| teleport | >= 18.8.0 |
 | tls | >= 4.0 |
 
 ## Providers
@@ -89,7 +89,7 @@ For bugs related to this code, please [open an issue](https://github.com/gravita
 | ---- | ------- |
 | aws | >= 5.0 |
 | http | >= 3.0 |
-| teleport | >= 18.7.4 |
+| teleport | >= 18.8.0 |
 | tls | >= 4.0 |
 
 ## Modules

--- a/integrations/terraform-modules/teleport/discovery/aws/versions.tf
+++ b/integrations/terraform-modules/teleport/discovery/aws/versions.tf
@@ -12,7 +12,7 @@ terraform {
     }
     teleport = {
       source  = "terraform.releases.teleport.dev/gravitational/teleport"
-      version = ">= 18.7.4"
+      version = ">= 18.8.0"
     }
     tls = {
       source  = "hashicorp/tls"


### PR DESCRIPTION
The EKS support in the discovery terraform module relies on a teleport provider update to avoid showing inconsistency errors after applying an EKS matcher. The version requirement needs to be at least the version the EKS changes are going out on.

