### PR TITLE
ui: allows identifier first login to resize

### DIFF
--- a/web/packages/teleport/src/components/FormLogin/FormIdentifierFirst.tsx
+++ b/web/packages/teleport/src/components/FormLogin/FormIdentifierFirst.tsx
@@ -123,7 +123,7 @@ export function FormIdentifierFirst({
   };
 
   return (
-    <Card my="5" mx="auto" width={650} p={4}>
+    <Card my="5" mx="auto" maxWidth={650} minWidth={300} p={4}>
       <Flex flexDirection="column" alignItems="center">
         <Text typography="h1" textAlign="center">
           {rememberedUsername ? title : ssoTitle}


### PR DESCRIPTION
Fixes #66479

From mobile 
<img width="468" height="491" alt="image" src="https://github.com/user-attachments/assets/68f0893c-a736-4a53-bd09-317456e19f33" />

to 

<img width="457" height="469" alt="image" src="https://github.com/user-attachments/assets/95255830-5c45-44b2-8cbe-07b088adc5f5" />



Changelog: Fixed identifier-first login form overflowing on mobile viewports.

## Manual Test Plan
### Test Environment
    Dev environment
### Test Cases
- [x] Confirmed login for identifier first is not cut off on mobile sizes such as iphone 17
- [x] Confirmed no impact to desktop identifier first login screen
