### PR TITLE
Add secondary index for database server lookup by database name

### DIFF
--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -8016,16 +8016,13 @@ func (a *Server) isMFARequired(ctx context.Context, scopedCtx *authz.ScopedConte
 		if t.Database.ServiceName == "" {
 			return nil, trace.BadParameter("missing ServiceName field in a database-only UserCertsRequest")
 		}
-		servers, err := a.GetDatabaseServers(ctx, apidefaults.Namespace)
-		if err != nil {
-			return nil, trace.Wrap(err)
-		}
 		var db types.Database
-		for _, server := range servers {
-			if server.GetDatabase().GetName() == t.Database.ServiceName {
-				db = server.GetDatabase()
-				break
+		for server, err := range a.RangeDatabaseServersWithName(ctx, t.Database.ServiceName) {
+			if err != nil {
+				return nil, trace.Wrap(err)
 			}
+			db = server.GetDatabase()
+			break
 		}
 		if db == nil {
 			return nil, trace.NotFound("database service %q not found", t.Database.ServiceName)

--- a/lib/auth/authclient/api.go
+++ b/lib/auth/authclient/api.go
@@ -1308,6 +1308,9 @@ type Cache interface {
 	// GetDatabaseServers returns all registered database proxy servers.
 	GetDatabaseServers(ctx context.Context, namespace string, opts ...services.MarshalOption) ([]types.DatabaseServer, error)
 
+	// RangeDatabaseServersWithName returns an iterator over database proxy servers for a given database name.
+	RangeDatabaseServersWithName(ctx context.Context, databaseName string) iter.Seq2[types.DatabaseServer, error]
+
 	// GetDatabases returns all database resources.
 	// Deprecated: Prefer paginated variant such as [ListDatabases] or [RangeDatabases]
 	GetDatabases(ctx context.Context) ([]types.Database, error)

--- a/lib/cache/cache_test.go
+++ b/lib/cache/cache_test.go
@@ -1382,7 +1382,7 @@ func TestRecovery(t *testing.T) {
 	require.Empty(t, cmp.Diff(ca2, out, cmpopts.IgnoreFields(types.Metadata{}, "Revision")))
 }
 
-func mustCreateDatabase(t *testing.T, name, protocol, uri string) *types.DatabaseV3 {
+func mustCreateDatabase(t testing.TB, name, protocol, uri string) *types.DatabaseV3 {
 	database, err := types.NewDatabaseV3(
 		types.Metadata{
 			Name: name,

--- a/lib/cache/database.go
+++ b/lib/cache/database.go
@@ -35,6 +35,7 @@ import (
 	"github.com/gravitational/teleport/lib/backend"
 	"github.com/gravitational/teleport/lib/itertools/stream"
 	"github.com/gravitational/teleport/lib/services"
+	logutils "github.com/gravitational/teleport/lib/utils/log"
 )
 
 type databaseIndex string
@@ -273,6 +274,7 @@ func (c *Cache) RangeDatabaseServersWithName(ctx context.Context, databaseName s
 			for _, r := range resp.Resources {
 				server, ok := r.(types.DatabaseServer)
 				if !ok {
+					c.Logger.WarnContext(ctx, "expected DatabaseServer but received unexpected type", "resource_type", logutils.TypeAttr(r))
 					continue
 				}
 				if server.GetDatabase().GetName() == databaseName {

--- a/lib/cache/database.go
+++ b/lib/cache/database.go
@@ -252,12 +252,17 @@ func (c *Cache) RangeDatabaseServersWithName(ctx context.Context, databaseName s
 		defer span.End()
 
 		upstreamListFn := func(ctx context.Context, pageSize int, startToken string) ([]types.DatabaseServer, string, error) {
-			// discard the database name prefix since it is always equal to the
-			// outer databaseName by construction. The start and next tokens
-			// both encode it from the same source.
-			rest, err := ordered.DecodePrefix([]byte(startToken), nil)
+			var tokenDatabaseName string
+			rest, err := ordered.DecodePrefix([]byte(startToken), &tokenDatabaseName)
 			if err != nil {
 				return nil, "", trace.Wrap(err)
+			}
+
+			// Verify that the token's database name matches the requested database name.
+			// This ensures that if the token is malformed or belongs to a different
+			// database, we don't return incorrect results.
+			if tokenDatabaseName != databaseName {
+				return nil, "", trace.BadParameter("pagination token does not match the requested database name")
 			}
 
 			backendKey := ""

--- a/lib/cache/database.go
+++ b/lib/cache/database.go
@@ -172,6 +172,9 @@ const databaseServerNameIndex databaseServerIndex = "name"
 const databaseServerDatabaseNameIndex databaseServerIndex = "database_name"
 
 func databaseServerByDatabaseNameKey(s types.DatabaseServer) string {
+	// Delete events deliver header only resources with a nil Database. This
+	// returns "" so the secondary index lookup is a no-op. The primary
+	// index deletion removes the entry from all indexes.
 	db := s.GetDatabase()
 	if db == nil {
 		return ""

--- a/lib/cache/database.go
+++ b/lib/cache/database.go
@@ -252,11 +252,20 @@ func (c *Cache) RangeDatabaseServersWithName(ctx context.Context, databaseName s
 		defer span.End()
 
 		upstreamListFn := func(ctx context.Context, pageSize int, startToken string) ([]types.DatabaseServer, string, error) {
-			// discard the databaseName, we don't need it to query the backend
-			var hostID, serverName string
-			_ = ordered.Decode([]byte(startToken), nil, &hostID, &serverName)
+			// discard the database name prefix since it is always equal to the
+			// outer databaseName by construction. The start and next tokens
+			// both encode it from the same source.
+			rest, err := ordered.DecodePrefix([]byte(startToken), nil)
+			if err != nil {
+				return nil, "", trace.Wrap(err)
+			}
+
 			backendKey := ""
-			if hostID != "" {
+			if len(rest) > 0 {
+				var hostID, serverName string
+				if err := ordered.Decode(rest, &hostID, &serverName); err != nil {
+					return nil, "", trace.Wrap(err)
+				}
 				backendKey = hostID + "/" + serverName
 			}
 

--- a/lib/cache/database.go
+++ b/lib/cache/database.go
@@ -293,7 +293,10 @@ func (c *Cache) RangeDatabaseServersWithName(ctx context.Context, databaseName s
 
 			next := ""
 			if resp.NextKey != "" {
-				hostID, serverName, _ := strings.Cut(resp.NextKey, backend.SeparatorString)
+				hostID, serverName, ok := strings.Cut(resp.NextKey, backend.SeparatorString)
+				if !ok {
+					return nil, "", trace.BadParameter("invalid pagination token: %q", resp.NextKey)
+				}
 				next = string(ordered.Encode(databaseName, hostID, serverName))
 			}
 			return page, next, nil

--- a/lib/cache/database.go
+++ b/lib/cache/database.go
@@ -239,14 +239,13 @@ func (c *Cache) GetDatabaseServers(ctx context.Context, namespace string, opts .
 
 // RangeDatabaseServersWithName returns an iterator over database proxy servers for a given database name.
 func (c *Cache) RangeDatabaseServersWithName(ctx context.Context, databaseName string) iter.Seq2[types.DatabaseServer, error] {
+	if databaseName == "" {
+		return stream.Fail[types.DatabaseServer](trace.BadParameter("missing database name"))
+	}
+
 	return func(yield func(types.DatabaseServer, error) bool) {
 		ctx, span := c.Tracer.Start(ctx, "cache/RangeDatabaseServersWithName")
 		defer span.End()
-
-		if databaseName == "" {
-			yield(nil, trace.BadParameter("missing database name"))
-			return
-		}
 
 		upstreamListFn := func(ctx context.Context, pageSize int, startToken string) ([]types.DatabaseServer, string, error) {
 			// discard the databaseName, we don't need it to query the backend

--- a/lib/cache/database.go
+++ b/lib/cache/database.go
@@ -19,9 +19,11 @@ package cache
 import (
 	"context"
 	"iter"
+	"strings"
 
 	"github.com/gravitational/trace"
 	"google.golang.org/protobuf/proto"
+	"rsc.io/ordered"
 
 	"github.com/gravitational/teleport/api/client"
 	clientproto "github.com/gravitational/teleport/api/client/proto"
@@ -30,6 +32,7 @@ import (
 	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/utils/clientutils"
+	"github.com/gravitational/teleport/lib/backend"
 	"github.com/gravitational/teleport/lib/itertools/stream"
 	"github.com/gravitational/teleport/lib/services"
 )
@@ -166,6 +169,15 @@ func (c *Cache) RangeDatabases(ctx context.Context, start, end string) iter.Seq2
 type databaseServerIndex string
 
 const databaseServerNameIndex databaseServerIndex = "name"
+const databaseServerDatabaseNameIndex databaseServerIndex = "database_name"
+
+func databaseServerByDatabaseNameKey(s types.DatabaseServer) string {
+	db := s.GetDatabase()
+	if db == nil {
+		return ""
+	}
+	return string(ordered.Encode(db.GetName(), s.GetHostID(), s.GetName()))
+}
 
 func newDatabaseServerCollection(p services.Presence, w types.WatchKind) (*collection[types.DatabaseServer, databaseServerIndex], error) {
 	if p == nil {
@@ -180,6 +192,7 @@ func newDatabaseServerCollection(p services.Presence, w types.WatchKind) (*colle
 				databaseServerNameIndex: func(u types.DatabaseServer) string {
 					return u.GetHostID() + "/" + u.GetName()
 				},
+				databaseServerDatabaseNameIndex: databaseServerByDatabaseNameKey,
 			}),
 		fetcher: func(ctx context.Context, loadSecrets bool) ([]types.DatabaseServer, error) {
 			return p.GetDatabaseServers(ctx, defaults.Namespace)
@@ -222,6 +235,74 @@ func (c *Cache) GetDatabaseServers(ctx context.Context, namespace string, opts .
 	}
 
 	return out, nil
+}
+
+// RangeDatabaseServersWithName returns an iterator over database proxy servers for a given database name.
+func (c *Cache) RangeDatabaseServersWithName(ctx context.Context, databaseName string) iter.Seq2[types.DatabaseServer, error] {
+	return func(yield func(types.DatabaseServer, error) bool) {
+		ctx, span := c.Tracer.Start(ctx, "cache/RangeDatabaseServersWithName")
+		defer span.End()
+
+		if databaseName == "" {
+			yield(nil, trace.BadParameter("missing database name"))
+			return
+		}
+
+		upstreamListFn := func(ctx context.Context, pageSize int, startToken string) ([]types.DatabaseServer, string, error) {
+			// discard the databaseName, we don't need it to query the backend
+			var hostID, serverName string
+			_ = ordered.Decode([]byte(startToken), nil, &hostID, &serverName)
+			backendKey := ""
+			if hostID != "" {
+				backendKey = hostID + "/" + serverName
+			}
+
+			resp, err := c.Config.Presence.ListResources(ctx, clientproto.ListResourcesRequest{
+				ResourceType: types.KindDatabaseServer,
+				Namespace:    defaults.Namespace,
+				Limit:        int32(pageSize),
+				StartKey:     backendKey,
+			})
+			if err != nil {
+				return nil, "", trace.Wrap(err)
+			}
+
+			var page []types.DatabaseServer
+			for _, r := range resp.Resources {
+				server, ok := r.(types.DatabaseServer)
+				if !ok {
+					continue
+				}
+				if server.GetDatabase().GetName() == databaseName {
+					page = append(page, server)
+				}
+			}
+
+			next := ""
+			if resp.NextKey != "" {
+				hostID, serverName, _ := strings.Cut(resp.NextKey, backend.SeparatorString)
+				next = string(ordered.Encode(databaseName, hostID, serverName))
+			}
+			return page, next, nil
+		}
+
+		lister := genericLister[types.DatabaseServer, databaseServerIndex]{
+			cache:           c,
+			collection:      c.collections.dbServers,
+			index:           databaseServerDatabaseNameIndex,
+			nextToken:       databaseServerByDatabaseNameKey,
+			defaultPageSize: defaults.DefaultChunkSize,
+			upstreamList:    upstreamListFn,
+		}
+
+		start := string(ordered.Encode(databaseName))
+		end := string(ordered.Encode(databaseName, ordered.Inf))
+		for item, err := range lister.Range(ctx, start, end) {
+			if !yield(item, err) {
+				return
+			}
+		}
+	}
 }
 
 type databaseServiceIndex string

--- a/lib/cache/database_test.go
+++ b/lib/cache/database_test.go
@@ -22,11 +22,13 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/gravitational/trace"
+	"github.com/stretchr/testify/require"
 
 	apidefaults "github.com/gravitational/teleport/api/defaults"
 	dbobjectv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/dbobject/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/defaults"
+	"github.com/gravitational/teleport/lib/services"
 )
 
 // TestDatabaseServices tests that CRUD operations on DatabaseServices are
@@ -221,4 +223,39 @@ func TestDatabaseObjects(t *testing.T) {
 			return nil
 		},
 	})
+}
+
+func mustCreateDatabaseServer(t testing.TB, hostID, dbName string) types.DatabaseServer {
+	t.Helper()
+
+	databaseServer, err := types.NewDatabaseServerV3(types.Metadata{
+		Name: dbName,
+	}, types.DatabaseServerSpecV3{
+		HostID:   hostID,
+		Hostname: "localhost",
+		Database: mustCreateDatabase(t, dbName, defaults.ProtocolPostgres, "localhost"),
+	})
+	require.NoError(t, err)
+	return databaseServer
+}
+
+var databaseServerRangeFuncs = rangeServersWithTargetNameFuncs[types.DatabaseServer]{
+	newResource: mustCreateDatabaseServer,
+	create: func(ctx context.Context, presence services.Presence, s types.DatabaseServer) error {
+		_, err := presence.UpsertDatabaseServer(ctx, s)
+		return err
+	},
+	delete: func(ctx context.Context, presence services.Presence, s types.DatabaseServer) error {
+		return presence.DeleteDatabaseServer(ctx, s.GetNamespace(), s.GetHostID(), s.GetName())
+	},
+	rangeByName: (*Cache).RangeDatabaseServersWithName,
+}
+
+func TestRangeDatabaseServersWithName(t *testing.T) {
+	t.Parallel()
+	testRangeServersWithTargetName(t, databaseServerRangeFuncs)
+}
+
+func BenchmarkRangeDatabaseServersWithName(b *testing.B) {
+	benchmarkRangeServersWithTargetName(b, databaseServerRangeFuncs)
 }

--- a/lib/cache/generic_server_range_test.go
+++ b/lib/cache/generic_server_range_test.go
@@ -23,6 +23,9 @@ import (
 	"testing"
 	"testing/synctest"
 
+	"github.com/gravitational/trace"
+	"github.com/stretchr/testify/require"
+
 	apidefaults "github.com/gravitational/teleport/api/defaults"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/backend/memory"
@@ -30,8 +33,6 @@ import (
 	"github.com/gravitational/teleport/lib/observability/tracing"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/services/local"
-	"github.com/gravitational/trace"
-	"github.com/stretchr/testify/require"
 )
 
 type hostIDGetterResource interface {

--- a/lib/cache/generic_server_range_test.go
+++ b/lib/cache/generic_server_range_test.go
@@ -1,0 +1,445 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package cache
+
+import (
+	"context"
+	"fmt"
+	"iter"
+	"testing"
+	"testing/synctest"
+
+	apidefaults "github.com/gravitational/teleport/api/defaults"
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/backend/memory"
+	"github.com/gravitational/teleport/lib/itertools/stream"
+	"github.com/gravitational/teleport/lib/observability/tracing"
+	"github.com/gravitational/teleport/lib/services"
+	"github.com/gravitational/teleport/lib/services/local"
+	"github.com/gravitational/trace"
+	"github.com/stretchr/testify/require"
+)
+
+type hostIDGetterResource interface {
+	types.Resource
+	GetHostID() string
+}
+
+type rangeServersWithTargetNameFuncs[T hostIDGetterResource] struct {
+	// newResource creates a new resource with the specified hostID and targetName.
+	newResource func(t testing.TB, hostID, targetName string) T
+	// create adds the resource to the backend.
+	create func(context.Context, services.Presence, T) error
+	// delete removes the resource from the backend.
+	delete func(context.Context, services.Presence, T) error
+	// rangeByName returns a stream of resources from the cache matching the target name filter.
+	rangeByName func(*Cache, context.Context, string) iter.Seq2[T, error]
+}
+
+type rangeServerSeed struct {
+	// hostID is the host ID to use for the seeded resource. If empty, a default will be generated.
+	hostID string
+	// targetName is the target name to use for the seeded resource (e.g. Database.ServiceName or App.Name).
+	targetName string
+	// want indicates whether this resource should be included in the test's expected results.
+	want bool
+}
+
+type rangeServersWithTargetNameTestCase[T hostIDGetterResource] struct {
+	// name is the test case name.
+	name string
+	// neverOK, if true, forces the cache to always be unhealthy, causing the
+	// rangeByName function to fallback to the backend for all pages.
+	neverOK bool
+	// filter is the target name filter to use when ranging resources.
+	filter string
+	// seeds defines the resources to seed in the backend before running the test.
+	seeds []rangeServerSeed
+	// onCollected is an optional callback that is called after each resource is collected
+	// from the rangeByName function, allowing the test to mutate cache state mid-iteration
+	onCollected func(n int, c *Cache)
+}
+
+func testRangeServersWithTargetName[T hostIDGetterResource](t *testing.T, funcs rangeServersWithTargetNameFuncs[T]) {
+	rangeServerSeeds := func(count int, targetName string, want bool, hostID func(int) string) []rangeServerSeed {
+		seeds := make([]rangeServerSeed, count)
+		for i := range count {
+			seeds[i].targetName = targetName
+			seeds[i].want = want
+			if hostID != nil {
+				seeds[i].hostID = hostID(i)
+			} else {
+				seeds[i].hostID = fmt.Sprintf("%06d", i)
+			}
+		}
+		return seeds
+	}
+
+	tests := []rangeServersWithTargetNameTestCase[T]{
+		{
+			name:   "HealthyCache_MultipleServersForSameTarget",
+			filter: "shared-target",
+			seeds: []rangeServerSeed{
+				{targetName: "shared-target", want: true},
+				{targetName: "shared-target", want: true},
+				{targetName: "other-target"},
+			},
+		},
+		{
+			name:   "HealthyCache_SingleServerForTarget",
+			filter: "other-target",
+			seeds: []rangeServerSeed{
+				{targetName: "shared-target"},
+				{targetName: "other-target", want: true},
+			},
+		},
+		{
+			name:   "HealthyCache_NonExistentTarget",
+			filter: "non-existent-target",
+			seeds: []rangeServerSeed{
+				{targetName: "shared-target"},
+			},
+		},
+		{
+			name:   "HealthyCache_FirstPagePartialMatchesContinues",
+			filter: "target",
+			seeds: append(
+				[]rangeServerSeed{
+					{hostID: "000000", targetName: "target", want: true},
+					{hostID: "000001", targetName: "target", want: true},
+				},
+				append(
+					rangeServerSeeds(apidefaults.DefaultChunkSize, "other-target", false, func(i int) string {
+						return fmt.Sprintf("%06d", i+2)
+					}),
+					rangeServerSeed{hostID: "zzzzzz", targetName: "target", want: true},
+				)...,
+			),
+		},
+		{
+			name:    "Fallback_MultipleServersForSameTarget",
+			neverOK: true,
+			filter:  "shared-target",
+			seeds: []rangeServerSeed{
+				{targetName: "shared-target", want: true},
+				{targetName: "shared-target", want: true},
+				{targetName: "other-target"},
+			},
+		},
+		{
+			name:    "Fallback_SingleServerForTarget",
+			neverOK: true,
+			filter:  "other-target",
+			seeds: []rangeServerSeed{
+				{targetName: "shared-target"},
+				{targetName: "other-target", want: true},
+			},
+		},
+		{
+			name:    "Fallback_NonExistentTarget",
+			neverOK: true,
+			filter:  "non-existent-target",
+			seeds: []rangeServerSeed{
+				{targetName: "shared-target"},
+			},
+		},
+		{
+			name:    "Fallback_PageWithNoMatchesContinuesToNextPage",
+			neverOK: true,
+			filter:  "zzz-target",
+			seeds: append(
+				// Fill a full page with "aaa-target" servers whose hostIDs sort
+				// before "zzzzzz", guaranteeing the first backend page has zero
+				// matches for "zzz-target".
+				rangeServerSeeds(apidefaults.DefaultChunkSize+1, "aaa-target", false, func(i int) string {
+					return fmt.Sprintf("%06d", i)
+				}),
+				rangeServerSeed{hostID: "zzzzzz", targetName: "zzz-target", want: true},
+			),
+		},
+		{
+			name:    "Fallback_FirstPagePartialMatchesContinues",
+			neverOK: true,
+			filter:  "target",
+			seeds: append(
+				[]rangeServerSeed{
+					{hostID: "000000", targetName: "target", want: true},
+					{hostID: "000001", targetName: "target", want: true},
+				},
+				append(
+					rangeServerSeeds(apidefaults.DefaultChunkSize, "other-target", false, func(i int) string {
+						return fmt.Sprintf("%06d", i+2)
+					}),
+					rangeServerSeed{hostID: "zzzzzz", targetName: "target", want: true},
+				)...,
+			),
+		},
+		{
+			name:   "TransientCacheHealth_ContinuesOnFallbackMidIteration",
+			filter: "shared-target",
+			seeds:  rangeServerSeeds(apidefaults.DefaultChunkSize+1, "shared-target", true, nil),
+			onCollected: func(n int, c *Cache) {
+				if n == apidefaults.DefaultChunkSize {
+					c.ok = false
+				}
+			},
+		},
+		{
+			name:   "TransientCacheHealth_CacheRecoversAfterFallbackPage",
+			filter: "shared-target",
+			seeds:  rangeServerSeeds(2*apidefaults.DefaultChunkSize+1, "shared-target", true, nil),
+			onCollected: func(n int, c *Cache) {
+				switch n {
+				case apidefaults.DefaultChunkSize:
+					c.ok = false
+				case 2 * apidefaults.DefaultChunkSize:
+					c.ok = true
+				}
+			},
+		},
+	}
+
+	t.Run("ParameterValidation", func(t *testing.T) {
+		t.Parallel()
+		ctx := t.Context()
+
+		c := &Cache{
+			Config: Config{
+				Tracer: tracing.NoopTracer("test"),
+			},
+		}
+
+		_, err := stream.Collect(funcs.rangeByName(c, ctx, ""))
+		require.ErrorAs(t, err, new(*trace.BadParameterError))
+	})
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			synctest.Test(t, func(t *testing.T) {
+				syncTestRangeServersWithTargetName(t, funcs, tt)
+			})
+		})
+	}
+
+	t.Run("DeletedResourceNotReturned", func(t *testing.T) {
+		t.Parallel()
+
+		tests := []struct {
+			name    string
+			neverOK bool
+		}{
+			{name: "HealthyCache", neverOK: false},
+			{name: "Fallback", neverOK: true},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				synctest.Test(t, func(t *testing.T) {
+					syncTestDeletedRangeServerWithTargetName(t, funcs, tt.neverOK)
+				})
+			})
+		}
+	})
+}
+
+// syncTestRangeServersWithTargetName must be run within [synctest.Test].
+func syncTestRangeServersWithTargetName[T hostIDGetterResource](
+	t *testing.T,
+	funcs rangeServersWithTargetNameFuncs[T],
+	tt rangeServersWithTargetNameTestCase[T],
+) {
+	ctx := t.Context()
+
+	p := newTestPack(t, func(cfg Config) Config {
+		cfg = ForAuth(cfg)
+		cfg.neverOK = tt.neverOK
+		return cfg
+	})
+	t.Cleanup(p.Close)
+
+	go func() {
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-p.eventsC:
+				// Discard events to avoid blocking the test.
+			}
+		}
+	}()
+
+	var expected []T
+	for i, seed := range tt.seeds {
+		hostID := seed.hostID
+		if hostID == "" {
+			hostID = fmt.Sprintf("%06d", i)
+		}
+		item := funcs.newResource(t, hostID, seed.targetName)
+		require.NoError(t, funcs.create(ctx, p.presenceS, item))
+		if seed.want {
+			expected = append(expected, item)
+		}
+	}
+
+	// Wait for cache to sync.
+	synctest.Wait()
+
+	var collected []T
+	for item, err := range funcs.rangeByName(p.cache, ctx, tt.filter) {
+		require.NoError(t, err)
+		collected = append(collected, item)
+		if tt.onCollected != nil {
+			tt.onCollected(len(collected), p.cache)
+		}
+	}
+
+	if len(expected) == 0 {
+		require.Empty(t, collected)
+		return
+	}
+	require.ElementsMatch(t, expected, collected)
+}
+
+// syncTestDeletedRangeServerWithTargetName must be run within [synctest.Test].
+func syncTestDeletedRangeServerWithTargetName[T hostIDGetterResource](
+	t *testing.T,
+	funcs rangeServersWithTargetNameFuncs[T],
+	neverOK bool,
+) {
+	ctx := t.Context()
+
+	p := newTestPack(t, func(cfg Config) Config {
+		cfg = ForAuth(cfg)
+		cfg.neverOK = neverOK
+		return cfg
+	})
+	t.Cleanup(p.Close)
+
+	item := funcs.newResource(t, "000000", "target")
+	require.NoError(t, funcs.create(ctx, p.presenceS, item))
+
+	// Wait for cache to sync.
+	synctest.Wait()
+
+	collected, err := stream.Collect(funcs.rangeByName(p.cache, ctx, "target"))
+	require.NoError(t, err)
+	require.Equal(t, []T{item}, collected)
+
+	require.NoError(t, funcs.delete(ctx, p.presenceS, item))
+
+	// Wait for cache to sync.
+	synctest.Wait()
+
+	collected, err = stream.Collect(funcs.rangeByName(p.cache, ctx, "target"))
+	require.NoError(t, err)
+	require.Empty(t, collected)
+}
+
+func benchmarkRangeServersWithTargetName[T hostIDGetterResource](b *testing.B, funcs rangeServersWithTargetNameFuncs[T]) {
+	b.Helper()
+	if testing.Short() {
+		b.Skip("skipping benchmark in short mode")
+	}
+
+	const count = 2 * apidefaults.DefaultChunkSize
+	const targetName = "shared-target"
+
+	tests := []struct {
+		name           string
+		neverOK        bool
+		firstMatchOnly bool
+	}{
+		{name: "RangeByName_FirstMatch", firstMatchOnly: true},
+		{name: "RangeByName_FirstMatch_Fallback", firstMatchOnly: true, neverOK: true},
+		{name: "RangeByName_AllMatches"},
+		{name: "RangeByName_AllMatches_Fallback", neverOK: true},
+	}
+
+	for _, tt := range tests {
+		b.Run(fmt.Sprintf("%s_%dServers", tt.name, count), func(b *testing.B) {
+			ctx := b.Context()
+			b.ReportAllocs()
+
+			bk, err := memory.New(memory.Config{Context: ctx, Mirror: true})
+			require.NoError(b, err)
+			b.Cleanup(func() { _ = bk.Close() })
+
+			// Populate the backend before creating the cache.
+			// New() will block until the cache is ready.
+			var kindName string
+			presenceS := local.NewPresenceService(bk)
+			firstMatchIndex := apidefaults.DefaultChunkSize - 1
+			firstMatchHostID := fmt.Sprintf("%06d", firstMatchIndex)
+			lastMatchIndex := count - 1
+			lastMatchHostID := fmt.Sprintf("%06d", lastMatchIndex)
+
+			// Add bulk resources with the first match near the end of the first
+			// backend page and the last match at the end of the second page to
+			// ensure the full range is processed.
+			for i := range count {
+				hostID := fmt.Sprintf("%06d", i)
+				name := fmt.Sprintf("target-%d", i+1)
+				if i == firstMatchIndex {
+					name = targetName
+				}
+				if i == lastMatchIndex {
+					name = targetName
+				}
+
+				s := funcs.newResource(b, hostID, name)
+				require.NoError(b, funcs.create(ctx, presenceS, s))
+				if kindName == "" {
+					kindName = s.GetKind()
+				}
+			}
+
+			require.NotEmpty(b, kindName)
+			watch := types.WatchKind{Kind: kindName}
+			c, err := New(Config{
+				Context:  ctx,
+				Presence: presenceS,
+				Events:   local.NewEventsService(bk),
+				Watches:  []types.WatchKind{watch},
+				neverOK:  tt.neverOK,
+			})
+			require.NoError(b, err)
+			b.Cleanup(func() { c.Close() })
+
+			for b.Loop() {
+				if tt.firstMatchOnly {
+					var matched bool
+					for server, err := range funcs.rangeByName(c, ctx, targetName) {
+						require.NoError(b, err)
+						require.Equal(b, firstMatchHostID, server.GetHostID())
+						matched = true
+						break
+					}
+					require.True(b, matched)
+					continue
+				}
+
+				servers, err := stream.Collect(funcs.rangeByName(c, ctx, targetName))
+				require.NoError(b, err)
+				require.Len(b, servers, 2)
+				require.ElementsMatch(b,
+					[]string{firstMatchHostID, lastMatchHostID},
+					[]string{servers[0].GetHostID(), servers[1].GetHostID()},
+				)
+			}
+		})
+	}
+}

--- a/lib/services/local/presence.go
+++ b/lib/services/local/presence.go
@@ -1061,6 +1061,10 @@ func (s *PresenceService) RangeDatabaseServersWithName(ctx context.Context, data
 		return stream.Fail[types.DatabaseServer](trace.BadParameter("missing database name"))
 	}
 
+	// TODO(wethreetrees): if Metadata.Name == Spec.Database.GetName() becomes a
+	// CheckAndSetDefaults invariant, this filter could check against the backend
+	// key's trailing component before unmarshalling. Currently no such invariant
+	// exists, so we unmarshal every item to read the embedded database name.
 	mapFn := func(item backend.Item) (types.DatabaseServer, bool) {
 		server, err := services.UnmarshalDatabaseServer(
 			item.Value,

--- a/lib/services/local/presence.go
+++ b/lib/services/local/presence.go
@@ -1055,6 +1055,33 @@ func (s *PresenceService) GetDatabaseServers(ctx context.Context, namespace stri
 	return servers, nil
 }
 
+// RangeDatabaseServersWithName returns an iterator over database proxy servers for a given database name.
+func (s *PresenceService) RangeDatabaseServersWithName(ctx context.Context, databaseName string) iter.Seq2[types.DatabaseServer, error] {
+	if databaseName == "" {
+		return func(yield func(types.DatabaseServer, error) bool) {
+			yield(nil, trace.BadParameter("missing database name"))
+		}
+	}
+
+	mapFn := func(item backend.Item) (types.DatabaseServer, bool) {
+		server, err := services.UnmarshalDatabaseServer(
+			item.Value,
+			services.WithExpires(item.Expires),
+			services.WithRevision(item.Revision),
+		)
+		if err != nil {
+			s.logger.WarnContext(ctx, "Failed to unmarshal database server", "key", item.Key, "error", err)
+			return nil, false
+		}
+		return server, server.GetDatabase().GetName() == databaseName
+	}
+
+	startKey := backend.ExactKey(dbServersPrefix, apidefaults.Namespace)
+	endKey := backend.RangeEnd(startKey)
+
+	return stream.FilterMap(s.Backend.Items(ctx, backend.ItemsParams{StartKey: startKey, EndKey: endKey}), mapFn)
+}
+
 // UpsertDatabaseServer registers new database proxy server.
 func (s *PresenceService) UpsertDatabaseServer(ctx context.Context, server types.DatabaseServer) (*types.KeepAlive, error) {
 	if err := services.CheckAndSetDefaults(server); err != nil {

--- a/lib/services/local/presence.go
+++ b/lib/services/local/presence.go
@@ -1058,9 +1058,7 @@ func (s *PresenceService) GetDatabaseServers(ctx context.Context, namespace stri
 // RangeDatabaseServersWithName returns an iterator over database proxy servers for a given database name.
 func (s *PresenceService) RangeDatabaseServersWithName(ctx context.Context, databaseName string) iter.Seq2[types.DatabaseServer, error] {
 	if databaseName == "" {
-		return func(yield func(types.DatabaseServer, error) bool) {
-			yield(nil, trace.BadParameter("missing database name"))
-		}
+		return stream.Fail[types.DatabaseServer](trace.BadParameter("missing database name"))
 	}
 
 	mapFn := func(item backend.Item) (types.DatabaseServer, bool) {

--- a/lib/services/local/presence_test.go
+++ b/lib/services/local/presence_test.go
@@ -48,6 +48,7 @@ import (
 	"github.com/gravitational/teleport/lib/backend"
 	"github.com/gravitational/teleport/lib/backend/memory"
 	"github.com/gravitational/teleport/lib/defaults"
+	iterstream "github.com/gravitational/teleport/lib/itertools/stream"
 )
 
 // TestApplicationServersCRUD verifies backend operations on app servers.
@@ -240,6 +241,76 @@ func TestDatabaseServersCRUD(t *testing.T) {
 	out, err = presence.GetDatabaseServers(ctx, apidefaults.Namespace)
 	require.NoError(t, err)
 	require.Empty(t, out)
+}
+
+func mustCreateDatabaseServer(t *testing.T, dbName string) types.DatabaseServer {
+	t.Helper()
+	server, err := types.NewDatabaseServerV3(types.Metadata{
+		Name: dbName,
+	}, types.DatabaseServerSpecV3{
+		HostID:   uuid.New().String(),
+		Hostname: "localhost",
+		Database: mustCreateDatabase(t, dbName, defaults.ProtocolPostgres, "localhost:5432"),
+	})
+	require.NoError(t, err)
+	return server
+}
+
+func TestRangeDatabaseServersWithName(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+
+	bk, err := memory.New(memory.Config{})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = bk.Close() })
+
+	presence := NewPresenceService(bk)
+
+	t.Run("ParameterValidation", func(t *testing.T) {
+		_, err = iterstream.Collect(presence.RangeDatabaseServersWithName(ctx, ""))
+		require.ErrorAs(t, err, new(*trace.BadParameterError))
+	})
+
+	server1 := mustCreateDatabaseServer(t, "shared-db")
+	server2 := mustCreateDatabaseServer(t, "shared-db")
+	server3 := mustCreateDatabaseServer(t, "standalone-db")
+
+	for _, s := range []types.DatabaseServer{server1, server2, server3} {
+		_, err := presence.UpsertDatabaseServer(ctx, s)
+		require.NoError(t, err)
+	}
+
+	t.Run("MultipleServersSameDatabase", func(t *testing.T) {
+		servers, err := iterstream.Collect(presence.RangeDatabaseServersWithName(ctx, "shared-db"))
+		require.NoError(t, err)
+		require.Len(t, servers, 2)
+		for _, s := range servers {
+			require.Equal(t, "shared-db", s.GetDatabase().GetName())
+		}
+	})
+
+	t.Run("SingleServerForDatabase", func(t *testing.T) {
+		servers, err := iterstream.Collect(presence.RangeDatabaseServersWithName(ctx, "standalone-db"))
+		require.NoError(t, err)
+		require.Len(t, servers, 1)
+		require.Equal(t, "standalone-db", servers[0].GetDatabase().GetName())
+	})
+
+	t.Run("NoServersForDatabase", func(t *testing.T) {
+		servers, err := iterstream.Collect(presence.RangeDatabaseServersWithName(ctx, "nonexistent-db"))
+		require.NoError(t, err)
+		require.Empty(t, servers)
+	})
+
+	t.Run("DeletedServersNotReturned", func(t *testing.T) {
+		err := presence.DeleteDatabaseServer(ctx, server1.GetNamespace(), server1.GetHostID(), server1.GetName())
+		require.NoError(t, err)
+
+		servers, err := iterstream.Collect(presence.RangeDatabaseServersWithName(ctx, "shared-db"))
+		require.NoError(t, err)
+		require.Len(t, servers, 1)
+		require.Equal(t, server2.GetHostID(), servers[0].GetHostID())
+	})
 }
 
 func TestNodeCRUD(t *testing.T) {

--- a/lib/services/presence.go
+++ b/lib/services/presence.go
@@ -20,6 +20,7 @@ package services
 
 import (
 	"context"
+	"iter"
 	"time"
 
 	"github.com/gravitational/teleport/api/client/proto"
@@ -232,4 +233,7 @@ type PresenceInternal interface {
 		name string,
 		condition backend.Condition,
 	) ([]backend.ConditionalAction, error)
+
+	// RangeDatabaseServersWithName returns an iterator over database proxy servers for a given database name.
+	RangeDatabaseServersWithName(ctx context.Context, databaseName string) iter.Seq2[types.DatabaseServer, error]
 }


### PR DESCRIPTION
Replaces the full scan in `IsMFARequiredRequest_Database`, which fetched all database servers and filtered in-memory, with a range scan over a secondary index keyed by database name. 

Adds a new function, `RangeDatabaseServersWithName`, to the cache and PresenceInternal interfaces that returns an iterator over database servers matching a given database name.

Also adds a generic test helper and benchmark to verify behavior of this change and the upcoming App and Kubernetes server changes.

<!-- Provide a descriptive entry for the changelog of the next release. -->

Changelog: Improved performance and reduced resource usage of the auth service for clusters with large numbers of registered databases with per-session MFA enabled.


<!-- Include manual testing efforts to verify the change. -->
<!-- Detail where the tests where run and what configurations were used. -->
<!-- Include all the test cases which were run to validate the change. -->

## Manual Test Plan
### Test Environment

Teleport Cloud tenant with at least one enrolled database and a role that requires per-session MFA for database access.

### Test Cases
- [x] Connect to a database where the role requires per-session MFA and confirm MFA prompt appears and connection succeeds after verification
- [x] Connect to a database where no per-session MFA is required and confirm connection succeeds without an MFA prompt
- [x] Unregister a previously registered database, attempt to connect, and confirm a not found error is returned
