### PR TITLE
Watch and publish CA override CRLs to LDAP

### DIFF
--- a/lib/auth/authclient/api.go
+++ b/lib/auth/authclient/api.go
@@ -765,6 +765,8 @@ type DatabaseAccessPoint interface {
 type ReadWindowsDesktopAccessPoint interface {
 	// Closer closes all the resources
 	io.Closer
+	// SubCAServiceGetter reads CA override resources.
+	services.SubCAServiceGetter
 
 	// NewWatcher returns a new event watcher.
 	NewWatcher(ctx context.Context, watch types.Watch) (types.Watcher, error)

--- a/lib/authz/permissions.go
+++ b/lib/authz/permissions.go
@@ -1354,6 +1354,7 @@ func unscopedDefinitionForBuiltinRole(clusterName string, recConfig readonly.Ses
 					Rules: []types.Rule{
 						types.NewRule(types.KindEvent, services.WO()),
 						types.NewRule(types.KindCertAuthority, services.ReadNoSecrets()),
+						types.NewRule(types.KindCertAuthorityOverride, services.RO()),
 						types.NewRule(types.KindClusterName, services.RO()),
 						types.NewRule(types.KindClusterAuditConfig, services.RO()),
 						types.NewRule(types.KindClusterNetworkingConfig, services.RO()),

--- a/lib/cache/cache.go
+++ b/lib/cache/cache.go
@@ -434,6 +434,7 @@ func ForWindowsDesktop(cfg Config) Config {
 	cfg.target = "windows_desktop"
 	cfg.Watches = []types.WatchKind{
 		{Kind: types.KindCertAuthority, LoadSecrets: false, Filter: makeAllKnownCAsFilter().IntoMap()},
+		{Kind: types.KindCertAuthorityOverride},
 		{Kind: types.KindClusterName},
 		{Kind: types.KindClusterAuditConfig},
 		{Kind: types.KindClusterNetworkingConfig},

--- a/lib/srv/desktop/windows_server.go
+++ b/lib/srv/desktop/windows_server.go
@@ -43,6 +43,7 @@ import (
 	"github.com/gravitational/teleport/api/constants"
 	apidefaults "github.com/gravitational/teleport/api/defaults"
 	tdpbv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/desktop/v1"
+	subcav1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/subca/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/types/events"
 	"github.com/gravitational/teleport/api/utils/clientutils"
@@ -1478,8 +1479,9 @@ func (s *WindowsService) runCRLUpdateLoop() {
 	}
 }
 
-// watchCAEvents watches for WindowsCA updates, signaling those in the received
-// channel.
+// watchCAEvents watches for WindowsCA updates, for both CA and CA override
+// resources, signaling those in the received channel.
+//
 // watchCAEvents runs until ctx is closed.
 func (s *WindowsService) watchCAEvents(
 	ctx context.Context,
@@ -1513,6 +1515,10 @@ func (s *WindowsService) watchCAEvents(
 					Filter: map[string]string{
 						string(types.WindowsCA): types.Wildcard,
 					},
+				},
+				{
+					Kind: types.KindCertAuthorityOverride,
+					// Filters not supported for KindCertAuthorityOverride.
 				},
 			},
 		})
@@ -1580,7 +1586,7 @@ func runCAWatcherLoop(
 				continue // OK, expected.
 
 			case isFirstEvent:
-				logger.WarnContext(ctx,
+				eLog.WarnContext(ctx,
 					"Received non-init event as the first event. Will attempt to re-create the watcher.",
 					"op", e.Type,
 				)
@@ -1590,10 +1596,29 @@ func runCAWatcherLoop(
 				continue // OK, we only care about mutating events.
 			}
 
-			logger.InfoContext(ctx,
-				"Received mutating WindowsCA event, signaling CRL update",
-				"op", e.Type,
-			)
+			if e.Resource.GetKind() == types.KindCertAuthorityOverride {
+				if e.Resource.GetSubKind() != string(types.WindowsCA) {
+					eLog.DebugContext(ctx, "Skipping CA override update for unrelated CA type")
+					continue
+				}
+
+				uw, ok := e.Resource.(types.Resource153UnwrapperT[*subcav1.CertAuthorityOverride])
+				if !ok {
+					eLog.WarnContext(ctx,
+						"Skipping CA override resource with unexpected underlying type",
+						"resource_type", logutils.TypeAttr(e.Resource),
+					)
+					continue
+				}
+
+				caOverride := uw.UnwrapT()
+				if len(caOverride.GetStatus().GetPublicKeyHashToCrl()) == 0 {
+					eLog.DebugContext(ctx, "Skipping CA override resource without CRLs")
+					continue
+				}
+			}
+
+			eLog.InfoContext(ctx, "Received mutating Windows CA event, signaling CRL update")
 			select {
 			case signalCAEvent <- struct{}{}:
 			default:

--- a/lib/srv/desktop/windows_server_test.go
+++ b/lib/srv/desktop/windows_server_test.go
@@ -42,6 +42,7 @@ import (
 
 	"github.com/gravitational/teleport/api/constants"
 	tdpbv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/desktop/v1"
+	subcav1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/subca/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/types/events"
 	"github.com/gravitational/teleport/lib/auth/authclient"
@@ -51,7 +52,7 @@ import (
 	"github.com/gravitational/teleport/lib/modules"
 	"github.com/gravitational/teleport/lib/service/servicecfg"
 	"github.com/gravitational/teleport/lib/srv/desktop/tdp/protocol/tdpb"
-	"github.com/gravitational/teleport/lib/subca/testenv"
+	subcaenv "github.com/gravitational/teleport/lib/subca/testenv"
 	"github.com/gravitational/teleport/lib/tlsca"
 	logutils "github.com/gravitational/teleport/lib/utils/log"
 	"github.com/gravitational/teleport/lib/utils/log/logtest"
@@ -476,7 +477,7 @@ func TestLoadTLSConfigForLDAP(t *testing.T) {
 	})
 
 	mustSelfSignedCA := func() *x509.Certificate {
-		ca, err := testenv.NewSelfSignedCA(&testenv.CAParams{})
+		ca, err := subcaenv.NewSelfSignedCA(&subcaenv.CAParams{})
 		if err != nil {
 			panic(err)
 		}
@@ -656,6 +657,12 @@ func TestCRLUpdateSchedule(t *testing.T) {
 		waitForNextCRLUpdate(t)
 	})
 
+	caID := types.CertAuthID{
+		Type:       types.WindowsCA,
+		DomainName: clusterName,
+	}
+	const loadKeys = true
+
 	t.Run("update by CA event", func(t *testing.T) {
 		// Don't t.Parallel().
 
@@ -663,11 +670,7 @@ func TestCRLUpdateSchedule(t *testing.T) {
 		authServer := testAuth.AuthServer
 
 		// Fetch current WindowsCA.
-		id := types.CertAuthID{
-			Type:       types.WindowsCA,
-			DomainName: clusterName,
-		}
-		ca, err := authServer.GetCertAuthority(ctx, id, true /* loadKeys */)
+		ca, err := authServer.GetCertAuthority(ctx, caID, loadKeys)
 		require.NoError(t, err)
 
 		// Simulate a rotation by addding an entry to AdditionalTrustedKeys.
@@ -691,6 +694,94 @@ func TestCRLUpdateSchedule(t *testing.T) {
 
 		waitForNextCRLUpdate(t)
 	})
+
+	upsertOverrideForCA := func(
+		t *testing.T,
+		caID types.CertAuthID,
+		modifyOverride func(caOverride *subcav1.CertAuthorityOverride),
+	) {
+		ctx := t.Context()
+		authServer := testAuth.AuthServer
+
+		// Fetch CA to override.
+		ca, err := authServer.GetCertAuthority(ctx, caID, loadKeys)
+		require.NoError(t, err)
+
+		// Prepare CA override env.
+		externalCA, err := subcaenv.NewSelfSignedCA(&subcaenv.CAParams{
+			Clock: clock,
+		})
+		require.NoError(t, err)
+		env := subcaenv.Env{
+			Clock:       clock,
+			ClusterName: clusterName,
+		}
+
+		// Prepare an override with CRLs.
+		// If targeting the Windows CA, without modifications, this should trigger
+		// a CRL update.
+		caOverride := env.NewOverrideForCA(t, ca, externalCA)
+		caOverride.Status = &subcav1.CertAuthorityOverrideStatus{
+			PublicKeyHashToCrl: make(map[string]*subcav1.CertificateRevocationList),
+		}
+		for _, co := range caOverride.Spec.CertificateOverrides {
+			caOverride.Status.PublicKeyHashToCrl[co.PublicKey] = &subcav1.CertificateRevocationList{
+				Pem: "<insert PEM here>",
+			}
+		}
+
+		if modifyOverride != nil {
+			modifyOverride(caOverride)
+		}
+
+		_, err = authServer.UpsertCertAuthorityOverride(ctx, caOverride)
+		require.NoError(t, err, "UpsertCertAuthorityOverride errored")
+	}
+
+	t.Run("update by CA override event", func(t *testing.T) {
+		// Don't t.Parallel().
+
+		upsertOverrideForCA(t, caID, nil)
+		waitForNextCRLUpdate(t)
+	})
+
+	waitForEvent := func(t *testing.T) {
+		t.Helper()
+		select {
+		case <-accessPoint.EventReceived():
+			// OK.
+		case <-t.Context().Done():
+			t.Fatal("Test timed out")
+		case <-time.After(2 * time.Second):
+			t.Fatal("Timed out waiting for next event")
+		}
+	}
+
+	t.Run("skips unrelated CA override events", func(t *testing.T) {
+		// Don't t.Parallel().
+
+		// Drain events channel.
+		waitForEvent(t)
+
+		// Create an empty Windows CA override.
+		// It should not trigger a CRL update, as the resource itself lacks CRLs.
+		upsertOverrideForCA(t, caID, func(caOverride *subcav1.CertAuthorityOverride) {
+			caOverride.Spec.CertificateOverrides = nil
+			caOverride.Status = nil
+		})
+		waitForEvent(t)
+
+		// Create an unrelated override.
+		// It should not trigger an update.
+		upsertOverrideForCA(t, types.CertAuthID{
+			Type:       types.DatabaseClientCA,
+			DomainName: clusterName,
+		}, nil)
+		waitForEvent(t)
+
+		// Verify no updates.
+		caClient.WaitForUpdate(t, wantUpdates)
+	})
 }
 
 // watcherAwareAccessPoint is a WindowsDesktopAccessPoint wrapper that
@@ -703,6 +794,7 @@ type watcherAwareAccessPoint struct {
 
 	initReceived      chan struct{}
 	initReceivedClose func()
+	eventReceived     chan struct{}
 
 	done <-chan struct{} // signals end of test
 	wg   sync.WaitGroup
@@ -714,6 +806,7 @@ func newWatcherAwareAccessPoint(t *testing.T, ap authclient.WindowsDesktopAccess
 	watcherAP := &watcherAwareAccessPoint{
 		WindowsDesktopAccessPoint: ap,
 		initReceived:              make(chan struct{}),
+		eventReceived:             make(chan struct{}, 1),
 		done:                      ctx.Done(),
 	}
 	watcherAP.initReceivedClose = sync.OnceFunc(func() { close(watcherAP.initReceived) })
@@ -735,6 +828,7 @@ func (a *watcherAwareAccessPoint) NewWatcher(ctx context.Context, watch types.Wa
 	ww := &watcherInitWrapper{
 		Watcher:          w,
 		markInitReceived: a.initReceivedClose,
+		eventReceived:    a.eventReceived,
 		done:             a.done,
 		events:           make(chan types.Event),
 	}
@@ -751,6 +845,13 @@ func (a *watcherAwareAccessPoint) InitReceived() <-chan struct{} {
 	return a.initReceived
 }
 
+// EventReceived signals that a new event was received.
+// The channel has a buffer of 1 so it must be drained before new events can
+// truly be distinguished. Includes the OpInit event.
+func (a *watcherAwareAccessPoint) EventReceived() <-chan struct{} {
+	return a.eventReceived
+}
+
 // watcherInitWrapper wraps a types.Watcher so it can wait for its first init
 // event.
 //
@@ -759,6 +860,7 @@ type watcherInitWrapper struct {
 	types.Watcher
 
 	markInitReceived func()
+	eventReceived    chan struct{}
 
 	done   <-chan struct{} // signals end of test
 	events chan types.Event
@@ -778,9 +880,17 @@ func (w *watcherInitWrapper) forwardEvents(ctx context.Context, other types.Watc
 		case <-other.Done():
 			return
 		case e := <-other.Events():
+			// Optimistically signal a new event.
+			select {
+			case w.eventReceived <- struct{}{}:
+			default:
+			}
+
+			// Record OpInit.
 			if e.Type == types.OpInit {
 				w.markInitReceived()
 			}
+
 			// Forward event.
 			select {
 			case <-w.done:

--- a/lib/winpki/certificate_authority.go
+++ b/lib/winpki/certificate_authority.go
@@ -133,7 +133,7 @@ func (c *CertificateStoreClient) Update(ctx context.Context, tc *tls.Config) err
 					"subject", cert.Subject,
 				)
 
-				if err := c.updateCRL(ctx, c.cfg.ClusterName, cert.SubjectKeyId, keyPair.CRL, ca.GetType(), tc); err != nil {
+				if err := c.updateCRL(ctx, cert.Subject.CommonName, cert.SubjectKeyId, keyPair.CRL, ca.GetType(), tc); err != nil {
 					return trace.Wrap(err)
 				}
 			}

--- a/lib/winpki/certificate_authority.go
+++ b/lib/winpki/certificate_authority.go
@@ -21,11 +21,15 @@ package winpki
 import (
 	"context"
 	"crypto/tls"
+	"encoding/pem"
 	"log/slog"
 
 	"github.com/gravitational/trace"
 
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/api/utils/tlsutils"
+	"github.com/gravitational/teleport/lib/services"
+	"github.com/gravitational/teleport/lib/subca"
 	"github.com/gravitational/teleport/lib/tlsca"
 )
 
@@ -43,6 +47,8 @@ type CertificateStoreClient struct {
 // Teleport has its own locking concept that is used for revocation, so the CRLS generated here
 // are always empty and exist only to satisfy the Windows requirements for CRL checking.
 type CRLGenerator interface {
+	// SubCAServiceGetter reads CA override resources.
+	services.SubCAServiceGetter
 	// GenerateCertAuthorityCRL returns an empty CRL for a CA.
 	GenerateCertAuthorityCRL(ctx context.Context, caType types.CertAuthType) ([]byte, error)
 	// GetCertAuthorities returns a list of cert authorities
@@ -62,9 +68,25 @@ type CertificateStoreConfig struct {
 	ClusterName string
 	// LC is the LDAPConfig
 	LC *LDAPConfig
+	// DialLDAPForTesting allows callers to provide an alternative implementation
+	// of the DialLDAP function.
+	// Used for testing.
+	DialLDAPForTesting func(ctx context.Context, cfg *LDAPConfig, credentials *tls.Config) (LDAPClientForCRLUpdate, error)
 }
 
-// Update publishes an empty certificate revocation list to LDAP.
+// LDAPClientForCRLUpdate defines the subset of [LDAPClient] necessary for CRL
+// updates.
+//
+// See [LDAPClient].
+type LDAPClientForCRLUpdate interface {
+	Close() error
+	CreateContainer(ctx context.Context, dn string) error
+	Create(dn string, class string, attrs map[string][]string) error
+	Update(ctx context.Context, dn string, replaceAttrs map[string][]string) error
+}
+
+// Update publishes an empty CRLs (Certificate Revocation Lists) to LDAP.
+// Both CA and CA override resources are queried for CRLs to publish.
 func (c *CertificateStoreClient) Update(ctx context.Context, tc *tls.Config) error {
 	caType := types.WindowsCA
 
@@ -118,7 +140,86 @@ func (c *CertificateStoreClient) Update(ctx context.Context, tc *tls.Config) err
 		}
 	}
 
+	if err := c.updateCAOverrideCRLs(ctx, tc); err != nil {
+		return trace.Wrap(err, "update CA override CRLs")
+	}
+
 	return nil
+}
+
+func (c *CertificateStoreClient) updateCAOverrideCRLs(ctx context.Context, tc *tls.Config) error {
+	const caType = types.WindowsCA
+	clusterName := c.cfg.ClusterName
+
+	caOverride, err := c.cfg.AccessPoint.GetCertAuthorityOverride(ctx, types.CertAuthorityOverrideID{
+		ClusterName: clusterName,
+		CAType:      string(caType),
+	})
+	if trace.IsNotFound(err) {
+		return nil // OK, overrides are optional.
+	}
+	if err != nil {
+		return trace.Wrap(err, "read CA overrides")
+	}
+
+	crlMap := caOverride.GetStatus().GetPublicKeyHashToCrl()
+
+	var errs []error
+	for _, co := range caOverride.GetSpec().GetCertificateOverrides() {
+		// Find a candidate override.
+		if co.GetCertificate() == "" {
+			continue
+		}
+
+		// Parse certificate.
+		cert, err := tlsutils.ParseCertificatePEM([]byte(co.GetCertificate()))
+		if err != nil {
+			c.cfg.Logger.WarnContext(ctx, "Failed to parse CA override certificate, skipping",
+				"ca_type", caType,
+				"cluster_name", clusterName,
+				"public_key_hash", co.GetPublicKey(), // Note, may be empty.
+			)
+			continue
+		}
+
+		// Produce PKH.
+		pkh := subca.HashCertificatePublicKey(cert)
+
+		logger := c.cfg.Logger.With(
+			"ca_type", caType,
+			"cluster_name", clusterName,
+			"public_key_hash", pkh,
+		)
+
+		// Find and parse CRL.
+		crlPB, ok := crlMap[pkh]
+		if !ok || crlPB == nil {
+			logger.WarnContext(ctx, "CA override lacks CRL for certificate, skipping",
+				"ca_type", caType,
+				"cluster_name", clusterName,
+				"public_key_hash", pkh,
+			)
+			continue
+		}
+		block, _ := pem.Decode([]byte(crlPB.Pem))
+		if block == nil {
+			logger.WarnContext(ctx, "Failed to decode CA override CRL PEM")
+			continue
+		}
+		crlDER := block.Bytes
+		if len(crlDER) == 0 {
+			logger.WarnContext(ctx, "CA override has empty CRL DER")
+			continue
+		}
+		logger.DebugContext(ctx, "Updating CA override CRL")
+
+		// Update CRL. Record errors from this step.
+		if err := c.updateCRL(ctx, cert.Subject.CommonName, cert.SubjectKeyId, crlDER, caType, tc); err != nil {
+			errs = append(errs, err)
+		}
+	}
+
+	return trace.NewAggregate(errs...)
 }
 
 func (c *CertificateStoreClient) updateCRL(ctx context.Context, issuerCN string, issuerSKID []byte, crlDER []byte, caType types.CertAuthType, tc *tls.Config) error {
@@ -144,7 +245,12 @@ func (c *CertificateStoreClient) updateCRL(ctx context.Context, issuerCN string,
 		return trace.Wrap(err)
 	}
 
-	ldapClient, err := DialLDAP(ctx, c.cfg.LC, tc)
+	var ldapClient LDAPClientForCRLUpdate
+	if c.cfg.DialLDAPForTesting != nil {
+		ldapClient, err = c.cfg.DialLDAPForTesting(ctx, c.cfg.LC, tc)
+	} else {
+		ldapClient, err = DialLDAP(ctx, c.cfg.LC, tc)
+	}
 	if err != nil {
 		return trace.Wrap(err, "dialing LDAP server")
 	}

--- a/lib/winpki/certificate_authority_test.go
+++ b/lib/winpki/certificate_authority_test.go
@@ -1,0 +1,296 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package winpki
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/gravitational/trace"
+	"github.com/stretchr/testify/require"
+
+	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
+	subcav1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/subca/v1"
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/api/utils/tlsutils"
+	"github.com/gravitational/teleport/lib/subca"
+	subcaenv "github.com/gravitational/teleport/lib/subca/testenv"
+	"github.com/gravitational/teleport/lib/tlscatest"
+	"github.com/gravitational/teleport/lib/utils/log/logtest"
+)
+
+func TestCertificateStoreClient_Update(t *testing.T) {
+	t.Parallel()
+
+	const clusterName = "zarquon"
+	const domain = "LLAMA"
+	const caCRL = "<insert CA CRL here>"
+	const overrideCRL = "<insert override CRL here>"
+
+	// Prepare a CA. (Only the relevant bits.)
+	caKeyPEM, caCertPEM, err := tlscatest.GenerateSelfSignedCA(tlscatest.GenerateCAConfig{
+		ClusterName: clusterName,
+	})
+	require.NoError(t, err)
+	caCert, err := tlsutils.ParseCertificatePEM(caCertPEM)
+	require.NoError(t, err)
+	ca, err := types.NewCertAuthority(types.CertAuthoritySpecV2{
+		Type:        types.WindowsCA,
+		ClusterName: clusterName,
+		ActiveKeys: types.CAKeySet{
+			TLS: []*types.TLSKeyPair{
+				{
+					Cert:    caCertPEM,
+					Key:     caKeyPEM,
+					KeyType: types.PrivateKeyType_RAW,
+					CRL:     []byte(caCRL),
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	// Prepare a CA override. (Only the relevant bits.)
+	overrideRoot, err := subcaenv.NewSelfSignedCA(nil /* params */)
+	require.NoError(t, err)
+	overrideCA, err := overrideRoot.NewIntermediateCA(&subcaenv.CAParams{
+		Pub: caCert.PublicKey,
+		Template: &x509.Certificate{
+			Subject: pkix.Name{
+				Organization: caCert.Subject.Organization,
+				CommonName:   "Llama Windows CA", // customized CN.
+			},
+			NotAfter: caCert.NotAfter,
+		},
+	})
+	require.NoError(t, err)
+	overrideCert, overrideCertPEM := overrideCA.Cert, overrideCA.CertPEM
+	publicKeyHash := subca.HashCertificatePublicKey(overrideCert)
+	caOverride := &subcav1.CertAuthorityOverride{
+		Kind:    types.KindCertAuthorityOverride,
+		SubKind: string(types.WindowsCA),
+		Version: types.V1,
+		Metadata: &headerv1.Metadata{
+			Name: clusterName,
+		},
+		Spec: &subcav1.CertAuthorityOverrideSpec{
+			CertificateOverrides: []*subcav1.CertificateOverride{
+				{
+					PublicKey:   publicKeyHash,
+					Certificate: string(overrideCertPEM),
+					Disabled:    true, // We'll push the CRL even if it's disabled.
+				},
+			},
+		},
+		Status: &subcav1.CertAuthorityOverrideStatus{
+			PublicKeyHashToCrl: map[string]*subcav1.CertificateRevocationList{
+				publicKeyHash: {
+					Pem: string(pem.EncodeToMemory(&pem.Block{
+						Type:  "X509 CRL",
+						Bytes: []byte(overrideCRL),
+					})),
+				},
+			},
+		},
+	}
+
+	ldap := newFakeLDAP()
+	csc := NewCertificateStoreClient(CertificateStoreConfig{
+		AccessPoint: &fakeAccessPoint{
+			cas: []types.CertAuthority{
+				ca,
+			},
+			caOverrides: []*subcav1.CertAuthorityOverride{
+				caOverride,
+			},
+		},
+		Domain:      domain,
+		Logger:      logtest.NewLogger(),
+		ClusterName: clusterName,
+		LC:          &LDAPConfig{}, // Unused, LDAP is faked.
+		DialLDAPForTesting: func(context.Context, *LDAPConfig, *tls.Config) (LDAPClientForCRLUpdate, error) {
+			return ldap.newClient(), nil
+		},
+	})
+
+	tc := &tls.Config{} // Unused, LDAP is faked.
+	require.NoError(t,
+		csc.Update(t.Context(), tc),
+		"Update errored",
+	)
+
+	// Prepare wanted state.
+	containerDN, err := crlContainerDN(domain, types.WindowsCA)
+	require.NoError(t, err)
+	caCRLDN, err := CRLDN(caCert.Subject.CommonName, caCert.SubjectKeyId, domain, types.WindowsCA)
+	require.NoError(t, err)
+	overrideCRLDN, err := CRLDN(overrideCert.Subject.CommonName, overrideCert.SubjectKeyId, domain, types.WindowsCA)
+	require.NoError(t, err)
+	want := map[string]*ldapEntry{
+		containerDN: {
+			ObjectClass: "container",
+		},
+		caCRLDN: {
+			ObjectClass: "cRLDistributionPoint",
+			Attrs: map[string][]string{
+				"certificateRevocationList": {caCRL},
+			},
+		},
+		overrideCRLDN: {
+			ObjectClass: "cRLDistributionPoint",
+			Attrs: map[string][]string{
+				"certificateRevocationList": {overrideCRL},
+			},
+		},
+	}
+
+	// Assert LDAP state.
+	if diff := cmp.Diff(want, ldap.entries); diff != "" {
+		t.Fatalf("LDAP entries mismatch (-want +got)\n%s", diff)
+	}
+
+	// Exercise entry update flow.
+	t.Run("update", func(t *testing.T) {
+		require.NoError(t,
+			csc.Update(t.Context(), tc),
+			"Update errored",
+		)
+
+		// Assert LDAP state.
+		if diff := cmp.Diff(want, ldap.entries); diff != "" {
+			t.Fatalf("LDAP entries mismatch (-want +got)\n%s", diff)
+		}
+	})
+}
+
+type fakeAccessPoint struct {
+	CRLGenerator
+
+	cas         []types.CertAuthority
+	caOverrides []*subcav1.CertAuthorityOverride
+}
+
+func (f *fakeAccessPoint) GetCertAuthorities(ctx context.Context, caType types.CertAuthType, loadKeys bool) ([]types.CertAuthority, error) {
+	var resp []types.CertAuthority
+	for _, ca := range f.cas {
+		if ca.GetType() != caType {
+			continue
+		}
+		if !loadKeys {
+			ca = ca.WithoutSecrets().(types.CertAuthority)
+		}
+		resp = append(resp, ca)
+	}
+	return resp, nil
+}
+
+func (f *fakeAccessPoint) GetCertAuthorityOverride(ctx context.Context, id types.CertAuthorityOverrideID) (*subcav1.CertAuthorityOverride, error) {
+	for _, caOverride := range f.caOverrides {
+		if caOverride.Metadata.Name == id.ClusterName && caOverride.SubKind == id.CAType {
+			return caOverride, nil
+		}
+	}
+	return nil, trace.NotFound("not found")
+}
+
+type ldapEntry struct {
+	ObjectClass string
+	Attrs       map[string][]string
+}
+
+type fakeLDAP struct {
+	entries map[string]*ldapEntry // dn -> entry
+}
+
+func newFakeLDAP() *fakeLDAP {
+	return &fakeLDAP{
+		entries: make(map[string]*ldapEntry),
+	}
+}
+
+func (l *fakeLDAP) newClient() *fakeLDAPClient {
+	return &fakeLDAPClient{ldap: l}
+}
+
+func (l *fakeLDAP) CreateContainer(ctx context.Context, dn string) error {
+	if _, ok := l.entries[dn]; ok {
+		return nil
+	}
+	l.entries[dn] = &ldapEntry{
+		ObjectClass: "container",
+	}
+	return nil
+}
+
+func (l *fakeLDAP) Create(dn string, class string, attrs map[string][]string) error {
+	if _, ok := l.entries[dn]; ok {
+		// AlreadyExists triggers the update flow on CertificateStoreClient.
+		return trace.AlreadyExists("entry %q already exists", dn)
+	}
+	l.entries[dn] = &ldapEntry{
+		ObjectClass: class,
+		Attrs:       attrs,
+	}
+	return nil
+}
+
+func (l *fakeLDAP) Update(ctx context.Context, dn string, replaceAttrs map[string][]string) error {
+	e, ok := l.entries[dn]
+	if !ok {
+		return fmt.Errorf("entry %q not found", dn)
+	}
+	e.Attrs = replaceAttrs
+	return nil
+}
+
+type fakeLDAPClient struct {
+	ldap   *fakeLDAP
+	closed bool
+}
+
+func (c *fakeLDAPClient) Close() error {
+	c.closed = true
+	return nil
+}
+
+func (c *fakeLDAPClient) CreateContainer(ctx context.Context, dn string) error {
+	if c.closed {
+		return errors.New("ldap client closed")
+	}
+	return c.ldap.CreateContainer(ctx, dn)
+}
+
+func (c *fakeLDAPClient) Create(dn string, class string, attrs map[string][]string) error {
+	if c.closed {
+		return errors.New("ldap client closed")
+	}
+	return c.ldap.Create(dn, class, attrs)
+}
+
+func (c *fakeLDAPClient) Update(ctx context.Context, dn string, replaceAttrs map[string][]string) error {
+	if c.closed {
+		return errors.New("ldap client closed")
+	}
+	return c.ldap.Update(ctx, dn, replaceAttrs)
+}

--- a/lib/winpki/ldap.go
+++ b/lib/winpki/ldap.go
@@ -350,7 +350,7 @@ func (searchResultEntry) isSearchResult()    {}
 func (searchResultReferral) isSearchResult() {}
 
 func (l *LDAPClient) search(ctx context.Context, client ldap.Client, searchRequest *ldap.SearchRequest) (searchResult, error) {
-	l.cfg.Logger.DebugContext(ctx, "Executing paged query", "filter", searchRequest.Filter, "baseDN", searchRequest.BaseDN)
+	l.cfg.Logger.DebugContext(ctx, "Executing paged query", "filter", searchRequest.Filter, "base_dn", searchRequest.BaseDN)
 	res, err := client.SearchWithPaging(searchRequest, searchPageSize)
 
 	switch {


### PR DESCRIPTION
Publish CA override CRLs to LDAP, which allows for AD (Active Directory) / LDAP-based Desktop Access sessions to work with CA overrides.

CA override CRLs are both published on a timer (as are CA CRLs), as well actively watched for and published on resource updates.

https://github.com/gravitational/teleport.e/issues/7675

## Manual Test Plan
### Test Environment

Local environment built using `-tags=subca`. These need to be patched-in for a proper E2E test:

* #66411
* https://github.com/gravitational/teleport.e/pull/8651

### Test Cases
- [x] Override CRLs are published on startup and on timer
- [x] Override CRLs are published as a result of updates
- [x] Desktop Access works (override active, AD/LDAP-based)
- [x] Desktop Access works (override active, AD/LDAP-based, customized override Subject CN)
