### PR TITLE
[v18] [Web UI] Azure Discovery with Terraform

### DIFF
--- a/web/packages/shared/components/FieldMultiInput/FieldMultiInput.tsx
+++ b/web/packages/shared/components/FieldMultiInput/FieldMultiInput.tsx
@@ -24,6 +24,7 @@ import { ButtonSecondary } from 'design/Button';
 import ButtonIcon from 'design/ButtonIcon';
 import Flex from 'design/Flex';
 import * as Icon from 'design/Icon';
+import { inputGeometry } from 'design/Input/Input';
 import { LabelContent } from 'design/LabelInput/LabelInput';
 import { useRule } from 'shared/components/Validation';
 import {
@@ -47,6 +48,7 @@ type StringListValidationResult = ValidationResult & {
 
 export type FieldMultiInputProps = {
   label?: string;
+  placeholder?: string;
   value: string[];
   /**
    * Disables and mutes all controls and values.
@@ -75,6 +77,7 @@ export type FieldMultiInputProps = {
  */
 export function FieldMultiInput({
   label,
+  placeholder,
   value,
   disabled,
   readOnly,
@@ -160,10 +163,11 @@ export function FieldMultiInput({
             // difficult to use) or to keep the array with generated IDs as local
             // state (which would require us to write a prop/state reconciliation
             // procedure whose complexity would probably outweigh the benefits).
-            <Flex key={i} alignItems="center" gap={2}>
+            <Flex key={i} alignItems="start" gap={2}>
               <Box flex="1">
                 <FieldInput
                   value={val}
+                  placeholder={placeholder}
                   rule={precomputed(vr)}
                   ref={toFocus.current === i ? setFocus : null}
                   onChange={e =>
@@ -178,14 +182,21 @@ export function FieldMultiInput({
                 />
               </Box>
               {!readOnly && (
-                <ButtonIcon
-                  size={0}
-                  title="Remove Item"
-                  onClick={() => removeItem(i)}
-                  disabled={disabled}
+                // Match input height to keep 'X' icon centered
+                // when validation errors are present.
+                <Flex
+                  alignItems="center"
+                  height={inputGeometry['medium'].height}
                 >
-                  <Icon.Cross size="small" color={theme.colors.text.muted} />
-                </ButtonIcon>
+                  <ButtonIcon
+                    size={0}
+                    title="Remove Item"
+                    onClick={() => removeItem(i)}
+                    disabled={disabled}
+                  >
+                    <Icon.Cross size="small" color={theme.colors.text.muted} />
+                  </ButtonIcon>
+                </Flex>
               )}
             </Flex>
           );

--- a/web/packages/shared/components/Validation/rules.test.ts
+++ b/web/packages/shared/components/Validation/rules.test.ts
@@ -18,6 +18,7 @@
 
 import {
   arrayOf,
+  requiredAzureSubscriptionId,
   requiredConfirmedPassword,
   requiredEmailLike,
   requiredField,
@@ -249,4 +250,17 @@ test.each([
   },
 ])('arrayOf: $name', ({ items, expected }) => {
   expect(arrayOf(requiredField('required'))(items)()).toEqual(expected);
+});
+
+describe('requiredAzureSubscriptionId', () => {
+  test.each`
+    id                                        | valid
+    ${'550e8400-e29b-41d4-a716-446655440000'} | ${true}
+    ${'6ba7b810-9dad-11d1-80b4-00c04fd430c8'} | ${true}
+    ${'not-a-uuid'}                           | ${false}
+    ${'550e8400-e29b-41d4-a716'}              | ${false}
+    ${''}                                     | ${false}
+  `('id: "$id" → valid: $valid', ({ id, valid }) => {
+    expect(requiredAzureSubscriptionId(id)().valid).toBe(valid);
+  });
 });

--- a/web/packages/shared/components/Validation/rules.ts
+++ b/web/packages/shared/components/Validation/rules.ts
@@ -225,6 +225,24 @@ const validAwsRaResourceName = (name: string): ValidationResult => {
   };
 };
 
+const AZURE_SUBSCRIPTION_ID_REGEX =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+/**
+ * requiredAzureSubscriptionId checks that a value is non-empty and a valid
+ * Azure subscription UUID.
+ */
+const requiredAzureSubscriptionId: Rule = id => (): ValidationResult => {
+  if (!id) {
+    return { valid: false, message: 'Subscription ID is required' };
+  }
+  if (!AZURE_SUBSCRIPTION_ID_REGEX.test(id)) {
+    return { valid: false, message: 'Must be a valid Azure subscription ID' };
+  }
+
+  return { valid: true };
+};
+
 /**
  * requiredIntegrationName is a required field and checks for a
  * value which must also be a valid Integration name.
@@ -552,6 +570,7 @@ export {
   requiredIamRoleName,
   requiredIamTrustAnchorName,
   requiredIamProfileName,
+  requiredAzureSubscriptionId,
   requiredEmailLike,
   requiredMaxLength,
   requiredAll,

--- a/web/packages/teleport/src/Discover/Overview/Azure/SettingsTab.tsx
+++ b/web/packages/teleport/src/Discover/Overview/Azure/SettingsTab.tsx
@@ -1,6 +1,6 @@
 /**
  * Teleport
- * Copyright (C) 2025 Gravitational, Inc.
+ * Copyright (C) 2026 Gravitational, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by
@@ -20,55 +20,74 @@ import { useQuery } from '@tanstack/react-query';
 import { useState } from 'react';
 
 import { Box, Card, Flex, Indicator } from 'design';
-import { Danger } from 'design/Alert';
+import { Danger, Info } from 'design/Alert';
 import { copyToClipboard } from 'design/utils/copyToClipboard';
 import Validation from 'shared/components/Validation';
 
-import { DeploymentMethodSection } from 'teleport/Integrations/Enroll/Cloud/Aws/DeploymentMethodSection';
-import { IntegrationSection } from 'teleport/Integrations/Enroll/Cloud/Aws/EnrollAws';
-import { InfoGuideContent } from 'teleport/Integrations/Enroll/Cloud/Aws/InfoGuide';
-import { ResourcesSection } from 'teleport/Integrations/Enroll/Cloud/Aws/ResourcesSection';
-import { buildTerraformConfig } from 'teleport/Integrations/Enroll/Cloud/Aws/tf_module';
+import { ApplyTerraformSection } from 'teleport/Integrations/Enroll/Cloud/Azure/ApplyTerraformSection';
 import {
-  buildMatchers,
-  ServiceConfig,
-  ServiceConfigs,
-  ServiceType,
-} from 'teleport/Integrations/Enroll/Cloud/Aws/types';
+  ManagedIdentitySection,
+  IntegrationSection,
+} from 'teleport/Integrations/Enroll/Cloud/Azure/EnrollAzure';
+import { InfoGuideContent } from 'teleport/Integrations/Enroll/Cloud/Azure/InfoGuide';
+import { ResourcesSection } from 'teleport/Integrations/Enroll/Cloud/Azure/ResourcesSection';
+import { buildTerraformConfig } from 'teleport/Integrations/Enroll/Cloud/Azure/tf_module';
+import {
+  AzureManagedIdentity,
+  VmConfig,
+} from 'teleport/Integrations/Enroll/Cloud/Azure/types';
 import { Divider } from 'teleport/Integrations/Enroll/Cloud/Shared';
 import {
   InfoGuideTab,
   TerraformInfoGuide,
   TerraformInfoGuideSidePanel,
 } from 'teleport/Integrations/Enroll/Cloud/Shared/InfoGuide';
-import { AwsResource } from 'teleport/Integrations/status/AwsOidc/Cards/StatCard';
 import {
+  IntegrationAzureOidc,
   IntegrationDiscoveryRule,
-  integrationService,
   IntegrationWithSummary,
-  Regions,
+  integrationService,
+  AzureRegion,
+  AzureResource,
 } from 'teleport/services/integrations';
 import { useClusterVersion } from 'teleport/useClusterVersion';
 
 import { DeleteIntegrationSection } from '../DeleteIntegrationSection';
 
-const configFromRules = (rules: IntegrationDiscoveryRule[]): ServiceConfig => {
-  const regions = rules.map(r => r.region);
-  const isWildcard = regions.includes('*') || regions.includes('aws-global');
+const vmConfigFromRules = (rules?: IntegrationDiscoveryRule[]): VmConfig => {
+  const regions: (AzureRegion | '*')[] =
+    !rules?.length || rules.some(r => r.region === '*')
+      ? ['*']
+      : rules.map(r => r.region as AzureRegion);
+
+  const subscriptions = [
+    ...new Set((rules || []).flatMap(r => r.subscriptions || [])),
+  ];
+
+  const resourceGroups = [
+    ...new Set((rules || []).flatMap(r => r.resourceGroups || [])),
+  ].filter(g => g !== '*');
 
   return {
-    enabled: rules.length > 0,
-    regions: isWildcard || rules.length === 0 ? [] : (regions as Regions[]),
+    type: 'vm',
+    enabled: rules !== undefined && rules.length > 0,
+    regions,
+    subscriptions,
+    resourceGroups,
     tags:
-      rules.length > 0
-        ? rules[0].labelMatcher.map(l => ({
-            name: l.name,
-            value: l.value,
-          }))
+      rules && rules.length > 0
+        ? rules[0].labelMatcher.map(l => ({ name: l.name, value: l.value }))
         : [],
-    kubeAppDiscovery: rules[0]?.kubeAppDiscovery ?? false,
   };
 };
+
+const managedIdentityFromIntegration = (
+  integration?: IntegrationAzureOidc
+): AzureManagedIdentity => ({
+  resourceGroup: integration?.spec?.managedIdentity?.resourceGroup || '',
+  region: (integration?.spec?.managedIdentity?.region ||
+    'eastus') as AzureRegion,
+});
 
 export function SettingsTab({
   stats,
@@ -83,36 +102,35 @@ export function SettingsTab({
   const { clusterVersion } = useClusterVersion();
 
   const {
-    data: ec2Rules,
-    isLoading: isLoadingEc2,
-    isError: isEc2Error,
+    data: integration,
+    isLoading: isIntegrationLoading,
+    isError: isIntegrationError,
   } = useQuery({
-    queryKey: ['integrationRules', stats.name, AwsResource.ec2],
+    queryKey: ['integration', integrationName],
     queryFn: () =>
-      integrationService.fetchIntegrationRules(
-        integrationName,
-        AwsResource.ec2
+      integrationService.fetchIntegration<IntegrationAzureOidc>(
+        integrationName
       ),
   });
 
   const {
-    data: eksRules,
-    isLoading: isLoadingEks,
-    isError: isEksError,
+    data: vmRules,
+    isLoading: isRulesLoading,
+    isError: isRulesError,
   } = useQuery({
-    queryKey: ['integrationRules', stats.name, AwsResource.eks],
+    queryKey: ['integrationRules', stats.name, 'vm'],
     queryFn: () =>
       integrationService.fetchIntegrationRules(
         integrationName,
-        AwsResource.eks
+        AzureResource.vm
       ),
   });
 
-  const [updatedConfigs, setUpdatedConfigs] = useState<Partial<ServiceConfigs>>(
-    {}
-  );
+  const [updatedVmConfig, setVmConfig] = useState<VmConfig | null>(null);
+  const [updatedManagedIdentity, setManagedIdentity] =
+    useState<AzureManagedIdentity | null>(null);
 
-  if (isLoadingEc2 || isLoadingEks) {
+  if (isRulesLoading || isIntegrationLoading) {
     return (
       <Flex justifyContent="center" mt={6}>
         <Indicator />
@@ -120,25 +138,26 @@ export function SettingsTab({
     );
   }
 
-  if (isEc2Error || isEksError) {
+  if (isIntegrationError || isRulesError) {
     return <Danger>Failed to load the integration settings.</Danger>;
   }
 
-  const configs: ServiceConfigs = {
-    ec2: updatedConfigs.ec2 ?? configFromRules(ec2Rules.rules),
-    eks: updatedConfigs.eks ?? configFromRules(eksRules.rules),
-  };
+  const hasWildcardSubscription =
+    vmRules?.rules?.some(r => r.subscriptions?.includes('*')) ?? false;
 
-  const updateConfig = (type: ServiceType, patch: Partial<ServiceConfig>) => {
-    setUpdatedConfigs(prev => ({
-      ...prev,
-      [type]: { ...configs[type], ...patch },
-    }));
-  };
+  // relax uuid validation if wildcard subscription returned in rules
+  const allowWildcardSubscriptions = updatedVmConfig
+    ? false
+    : hasWildcardSubscription;
+
+  const vmConfig = updatedVmConfig ?? vmConfigFromRules(vmRules?.rules);
+  const managedIdentity =
+    updatedManagedIdentity ?? managedIdentityFromIntegration(integration);
 
   const terraformConfig = buildTerraformConfig({
     integrationName,
-    matchers: buildMatchers(configs),
+    vmConfig,
+    managedIdentity,
     version: clusterVersion,
   });
 
@@ -147,6 +166,13 @@ export function SettingsTab({
       {({ validator }) => (
         <Flex>
           <Box flex="1">
+            {hasWildcardSubscription && (
+              <Info mb={3}>
+                This integration was configured with a wildcard subscription
+                matcher in Terraform, which is currently unsupported by this
+                form. Please update your Terraform configuration directly.
+              </Info>
+            )}
             <Card p={4} mb={3}>
               <Box mb={4}>
                 <IntegrationSection
@@ -156,13 +182,21 @@ export function SettingsTab({
                 />
               </Box>
               <Divider />
+              <Box>
+                <ManagedIdentitySection
+                  managedIdentity={managedIdentity}
+                  onChange={setManagedIdentity}
+                  disabled={false}
+                />
+              </Box>
+              <Divider />
               <ResourcesSection
-                configs={configs}
-                onConfigChange={updateConfig}
+                vmConfig={vmConfig}
+                onVmChange={setVmConfig}
+                allowWildcardSubscriptions={allowWildcardSubscriptions}
               />
               <Divider />
-              <DeploymentMethodSection
-                terraformConfig={terraformConfig}
+              <ApplyTerraformSection
                 handleCopy={() => {
                   if (validator.validate() && terraformConfig) {
                     copyToClipboard(terraformConfig);

--- a/web/packages/teleport/src/Discover/Overview/IaCIntegrationOverview.story.tsx
+++ b/web/packages/teleport/src/Discover/Overview/IaCIntegrationOverview.story.tsx
@@ -33,12 +33,12 @@ export default {
 };
 
 const integrationName = 'my-terraform-integration';
-const initialEntries = [
-  cfg.getIaCIntegrationRoute(IntegrationKind.AwsOidc, integrationName),
-];
 const path = cfg.routes.integrationOverview;
 
-function Component() {
+function Component({
+  kind = IntegrationKind.AwsOidc,
+}: { kind?: IntegrationKind } = {}) {
+  const initialEntries = [cfg.getIaCIntegrationRoute(kind, integrationName)];
   return (
     <TeleportProviderBasic initialEntries={initialEntries}>
       <ToastNotifications />
@@ -263,6 +263,56 @@ Error.parameters = {
           { status: 500 }
         );
       }),
+    ],
+  },
+};
+
+export function AzureWithWildcardSubscription() {
+  return <Component kind={IntegrationKind.AzureOidc} />;
+}
+AzureWithWildcardSubscription.parameters = {
+  msw: {
+    handlers: [
+      http.get(cfg.getIntegrationStatsUrl(integrationName), () =>
+        HttpResponse.json({
+          name: integrationName,
+          subKind: IntegrationKind.AzureOidc,
+          unresolvedUserTasks: 0,
+          userTasks: [],
+          azurevm: {
+            resourcesFound: 3,
+            discoverLastSync: Date.now() - 2 * 60 * 1000,
+          },
+          isManagedByTerraform: true,
+        })
+      ),
+      http.get(`*/integrations/${integrationName}`, () =>
+        HttpResponse.json({
+          name: integrationName,
+          subKind: IntegrationKind.AzureOidc,
+          azureoidc: {
+            tenantId: 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
+            clientId: 'ffffffff-0000-1111-2222-333333333333',
+            managedIdentity: {
+              resourceGroup: 'my-resource-group',
+              region: 'eastus',
+            },
+          },
+        })
+      ),
+      http.get(`*/integrations/${integrationName}/discoveryrules`, () =>
+        HttpResponse.json({
+          rules: [
+            {
+              resourceType: 'vm',
+              region: 'eastus',
+              subscriptions: ['*'],
+              resourceGroups: [],
+              labelMatcher: [],
+            },
+          ],
+        })
+      ),
     ],
   },
 };

--- a/web/packages/teleport/src/Discover/Overview/IaCIntegrationOverview.tsx
+++ b/web/packages/teleport/src/Discover/Overview/IaCIntegrationOverview.tsx
@@ -45,7 +45,10 @@ import {
   InfoGuideSwitch,
   useTerraformInfoGuide,
 } from 'teleport/Integrations/Enroll/Cloud/Shared/InfoGuide';
-import { SummaryStatusLabel } from 'teleport/Integrations/shared/StatusLabel';
+import {
+  latestSyncDate,
+  SummaryStatusLabel,
+} from 'teleport/Integrations/shared/StatusLabel';
 import { useNoMinWidth } from 'teleport/Main';
 import {
   INTEGRATION_DISCOVERY_SCAN_INTERVAL_MS,
@@ -215,7 +218,7 @@ function IntegrationHealthCard({
   }, []);
 
   const hasIssues = stats.unresolvedUserTasks > 0;
-  const lastScanDate = getIntegrationLastScan(stats);
+  const lastScanDate = latestSyncDate(stats);
   const lastScanText = formatRelativeDate(lastScanDate);
   const nextScanText = formatTimeUntilNextScan(lastScanDate, nowMs);
   const configDetails = getIntegrationConfigDetails(stats);
@@ -376,19 +379,6 @@ function IssueItem(props: { text: string }) {
   );
 }
 
-function getIntegrationLastScan(
-  stats: IntegrationWithSummary
-): Date | undefined {
-  const lastScan = Math.max(
-    getTimestamp(stats.awsec2?.discoverLastSync),
-    getTimestamp(stats.awsrds?.discoverLastSync),
-    getTimestamp(stats.awseks?.discoverLastSync),
-    getTimestamp(stats.rolesAnywhereProfileSync?.syncEndTime)
-  );
-
-  return lastScan ? new Date(lastScan) : undefined;
-}
-
 function getIntegrationConfigDetails(
   stats: IntegrationWithSummary
 ): Array<{ label: string; value: string }> {
@@ -431,7 +421,8 @@ function formatResourceCounts(stats: IntegrationWithSummary): string {
   const ec2Count = stats.awsec2?.resourcesFound || 0;
   const rdsCount = stats.awsrds?.resourcesFound || 0;
   const eksCount = stats.awseks?.resourcesFound || 0;
-  const total = ec2Count + rdsCount + eksCount;
+  const azureVmCount = stats.azurevm?.resourcesFound || 0;
+  const total = ec2Count + rdsCount + eksCount + azureVmCount;
 
   if (total === 0) {
     return 'No resources discovered';
@@ -446,6 +437,9 @@ function formatResourceCounts(stats: IntegrationWithSummary): string {
   }
   if (eksCount > 0) {
     parts.push(`EKS: ${eksCount}`);
+  }
+  if (azureVmCount > 0) {
+    parts.push(`Azure VMs: ${azureVmCount}`);
   }
 
   return `${total} Discovered (${parts.join(', ')})`;
@@ -474,7 +468,7 @@ function formatTimeUntilNextScan(
 }
 
 function getStatsRefetchIntervalMs(stats: IntegrationWithSummary | undefined) {
-  const lastScanDate = stats ? getIntegrationLastScan(stats) : undefined;
+  const lastScanDate = stats ? latestSyncDate(stats) : undefined;
 
   if (!lastScanDate) {
     return OVERDUE_REFETCH_INTERVAL_MS;
@@ -486,21 +480,4 @@ function getStatsRefetchIntervalMs(stats: IntegrationWithSummary | undefined) {
     Date.now();
 
   return remainingMs <= 0 ? OVERDUE_REFETCH_INTERVAL_MS : remainingMs;
-}
-
-function getTimestamp(value: unknown): number {
-  if (!value) {
-    return 0;
-  }
-  if (value instanceof Date) {
-    return value.getTime();
-  }
-  if (typeof value === 'number') {
-    return value;
-  }
-  if (typeof value === 'string') {
-    const parsed = Date.parse(value);
-    return Number.isNaN(parsed) ? 0 : parsed;
-  }
-  return 0;
 }

--- a/web/packages/teleport/src/Discover/Overview/SettingsTab.tsx
+++ b/web/packages/teleport/src/Discover/Overview/SettingsTab.tsx
@@ -23,6 +23,7 @@ import {
 } from 'teleport/services/integrations';
 
 import { SettingsTab as AwsSettingsTab } from './Aws/SettingsTab';
+import { SettingsTab as AzureSettingsTab } from './Azure/SettingsTab';
 
 export function SettingsTab({
   stats,
@@ -37,6 +38,14 @@ export function SettingsTab({
     case IntegrationKind.AwsOidc:
       return (
         <AwsSettingsTab
+          stats={stats}
+          activeInfoGuideTab={activeInfoGuideTab}
+          onInfoGuideTabChange={onInfoGuideTabChange}
+        />
+      );
+    case IntegrationKind.AzureOidc:
+      return (
+        <AzureSettingsTab
           stats={stats}
           activeInfoGuideTab={activeInfoGuideTab}
           onInfoGuideTabChange={onInfoGuideTabChange}

--- a/web/packages/teleport/src/Discover/Overview/UserTaskDrawer.tsx
+++ b/web/packages/teleport/src/Discover/Overview/UserTaskDrawer.tsx
@@ -35,6 +35,7 @@ import { getErrorMessage } from 'shared/utils/error';
 
 import {
   integrationService,
+  type DiscoverAzureVmInstance,
   type DiscoverEc2Instance,
   type DiscoverEksCluster,
   type DiscoverRdsDatabase,
@@ -269,11 +270,21 @@ function getTaskInfo(task: UserTaskDetail): {
       account: task.discoverEks?.account_id,
     };
   }
-  return {
-    resourceType: 'RDS',
-    region: task.discoverRds?.region,
-    account: task.discoverRds?.account_id,
-  };
+  if (taskType.includes('rds')) {
+    return {
+      resourceType: 'RDS',
+      region: task.discoverRds?.region,
+      account: task.discoverRds?.account_id,
+    };
+  }
+  if (taskType.includes('azure-vm')) {
+    return {
+      resourceType: 'Azure VM',
+      region: task.discoverAzureVm?.region,
+      account: task.discoverAzureVm?.subscription_id,
+    };
+  }
+  return { resourceType: '', region: undefined, account: undefined };
 }
 
 type ImpactRow = {
@@ -281,7 +292,7 @@ type ImpactRow = {
   name?: string;
   resourceUrl?: string;
   invocationUrl?: string;
-  kind: 'ec2' | 'eks' | 'rds';
+  kind: 'ec2' | 'eks' | 'rds' | 'azure-vm';
 };
 
 function getImpacts(task: UserTaskDetail): {
@@ -319,17 +330,35 @@ function getImpacts(task: UserTaskDetail): {
     return { rows, count: rows.length };
   }
 
-  const databases = task.discoverRds?.databases ?? {};
-  const rows = Object.keys(databases).map(key => {
-    const d = databases[key] as DiscoverRdsDatabase;
-    return {
-      id: d?.name || key,
-      name: d?.name,
-      resourceUrl: d?.resourceUrl,
-      kind: 'rds' as const,
-    };
-  });
-  return { rows, count: rows.length };
+  if (taskType.includes('rds')) {
+    const databases = task.discoverRds?.databases ?? {};
+    const rows = Object.keys(databases).map(key => {
+      const d = databases[key] as DiscoverRdsDatabase;
+      return {
+        id: d?.name || key,
+        name: d?.name,
+        resourceUrl: d?.resourceUrl,
+        kind: 'rds' as const,
+      };
+    });
+    return { rows, count: rows.length };
+  }
+
+  if (taskType.includes('azure-vm')) {
+    const instances = task.discoverAzureVm?.instances ?? {};
+    const rows = Object.keys(instances).map(key => {
+      const vm = instances[key] as DiscoverAzureVmInstance;
+      return {
+        id: vm?.vm_id || vm?.resource_id || key,
+        name: vm?.name,
+        resourceUrl: vm?.resourceUrl,
+        kind: 'azure-vm' as const,
+      };
+    });
+    return { rows, count: rows.length };
+  }
+
+  return { rows: [], count: 0 };
 }
 
 function makeImpactsTable(impacted: { rows: ImpactRow[] }): {

--- a/web/packages/teleport/src/Integrations/Enroll/Cloud/Azure/ApplyTerraformSection.tsx
+++ b/web/packages/teleport/src/Integrations/Enroll/Cloud/Azure/ApplyTerraformSection.tsx
@@ -1,0 +1,224 @@
+/**
+ * Teleport
+ * Copyright (C) 2026 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import styled from 'styled-components';
+
+import { Alert, Box, Flex, Link as ExternalLink, Text } from 'design';
+import { ArrowSquareOut, Notification, Spinner } from 'design/Icon';
+import { rotate360 } from 'design/keyframes';
+import { TextSelectCopyMulti } from 'shared/components/TextSelectCopy';
+import { useValidation } from 'shared/components/Validation';
+
+import { TerraformCopyButton } from 'teleport/components/TerraformCopyButton';
+import cfg from 'teleport/config';
+import { IntegrationKind } from 'teleport/services/integrations';
+
+import { CircleNumber, Divider } from '../Shared';
+
+type ApplyTerraformSectionProps = {
+  handleCopy: () => void;
+  integrationExists?: boolean;
+  integrationName?: string;
+  handleCheckIntegration?: () => void;
+  handleCancelCheckIntegration?: () => void;
+  checkIntegrationError?: boolean;
+  isCheckingIntegration?: boolean;
+  showVerificationStep?: boolean;
+};
+
+export function ApplyTerraformSection({
+  handleCopy,
+  integrationExists,
+  integrationName,
+  handleCheckIntegration,
+  isCheckingIntegration,
+  checkIntegrationError,
+  handleCancelCheckIntegration,
+  showVerificationStep = true,
+}: ApplyTerraformSectionProps) {
+  const validator = useValidation();
+
+  return (
+    <>
+      <Flex alignItems="center" fontSize={4} fontWeight="medium" mb={2}>
+        <CircleNumber>4</CircleNumber>
+        Apply Terraform
+      </Flex>
+
+      <Box ml={4}>
+        <Flex flexDirection="column" mb={3}>
+          <Box mt={1} mb={4}>
+            <Text bold={true} fontSize="14px">
+              1. Add the module generated on the right to your Terraform
+              templates.
+            </Text>
+            <Box mt={2}>
+              <TerraformCopyButton
+                onClick={e => {
+                  const isValid = validator.validate();
+                  if (!isValid) {
+                    e.preventDefault();
+                  } else {
+                    handleCopy();
+                  }
+                }}
+              />
+              {validator.state.validating && !validator.state.valid && (
+                <Text color="error.main" mt={2} fontSize={1}>
+                  Please complete the required fields
+                </Text>
+              )}
+            </Box>
+          </Box>
+          <Box mb={4}>
+            <Text bold={true} fontSize="14px">
+              2. Configure Azure and Teleport providers
+            </Text>
+            <Text color="text.slightlyMuted" fontSize={1}>
+              If you need help configuring providers for your environment,
+              please reference <br />
+              <ExternalLink
+                href="https://goteleport.com/docs/zero-trust-access/infrastructure-as-code/terraform-provider/"
+                target="_blank"
+              >
+                <Flex inline alignItems="center">
+                  Teleport Terraform provider
+                  <ArrowSquareOut size={12} ml={1} />
+                </Flex>
+              </ExternalLink>{' '}
+              <ExternalLink
+                href="https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs"
+                target="_blank"
+              >
+                <Flex inline alignItems="center">
+                  Azure Terraform provider
+                  <ArrowSquareOut size={12} ml={1} />
+                </Flex>
+              </ExternalLink>
+            </Text>
+            <Text mt={1}>
+              Generate temporary bot Teleport credentials for Terraform.
+            </Text>
+            <TextSelectCopyMulti
+              lines={[
+                {
+                  comment: `tsh login --proxy=${cfg.proxyCluster}`,
+                  text: `eval "$(tctl terraform env)"`,
+                },
+              ]}
+            />
+          </Box>
+          <Box>
+            <Text bold={true} fontSize="14px" mb={2}>
+              3. Initialize and apply the configuration
+            </Text>
+            <TextSelectCopyMulti
+              lines={[{ text: `terraform init` }, { text: `terraform apply` }]}
+            />
+          </Box>
+        </Flex>
+      </Box>
+
+      {showVerificationStep && (
+        <>
+          <Divider />
+          <Flex alignItems="center" fontSize={4} fontWeight="medium" mb={2}>
+            <CircleNumber>5</CircleNumber>
+            Verify the Integration
+          </Flex>
+
+          <Box ml={4} mt={1}>
+            {integrationExists ? (
+              <Alert
+                kind="success"
+                mb={2}
+                primaryAction={{
+                  content: 'View Integration',
+                  linkTo: cfg.getIaCIntegrationRoute(
+                    IntegrationKind.AzureOidc,
+                    integrationName
+                  ),
+                }}
+              >
+                Integration Detected
+                <Text fontWeight="regular">Azure successfully added</Text>
+              </Alert>
+            ) : (
+              <Box mb={3}>
+                {isCheckingIntegration ? (
+                  <Alert
+                    kind="info"
+                    icon={AnimatedSpinner}
+                    primaryAction={{
+                      content: 'Cancel',
+                      onClick: handleCancelCheckIntegration,
+                    }}
+                    mb={0}
+                  >
+                    <Text fontWeight="regular" color="text.slightlyMuted">
+                      Checking for integration{' '}
+                      <Text as="span" fontWeight="bold">
+                        {integrationName}
+                      </Text>
+                      ...
+                    </Text>
+                  </Alert>
+                ) : checkIntegrationError ? (
+                  <Alert
+                    kind="danger"
+                    mb={0}
+                    primaryAction={{
+                      content: 'Check Integration',
+                      onClick: handleCheckIntegration,
+                    }}
+                  >
+                    Failed to detect integration
+                    <Text fontWeight="regular" color="text.slightlyMuted">
+                      Unable to detect the Azure integration "{integrationName}
+                      ". Please check your Terraform configuration and try
+                      again.
+                    </Text>
+                  </Alert>
+                ) : (
+                  <Alert
+                    kind="neutral"
+                    icon={Notification}
+                    mb={0}
+                    primaryAction={{
+                      content: 'Check Integration',
+                      onClick: handleCheckIntegration,
+                    }}
+                  >
+                    <Text fontWeight="regular" color="text.slightlyMuted">
+                      After applying your Terraform configuration, verify your
+                      integration was created successfully.
+                    </Text>
+                  </Alert>
+                )}
+              </Box>
+            )}
+          </Box>
+        </>
+      )}
+    </>
+  );
+}
+
+const AnimatedSpinner = styled(Spinner)`
+  animation: ${rotate360} 1.5s linear infinite;
+`;

--- a/web/packages/teleport/src/Integrations/Enroll/Cloud/Azure/EnrollAzure.story.tsx
+++ b/web/packages/teleport/src/Integrations/Enroll/Cloud/Azure/EnrollAzure.story.tsx
@@ -1,0 +1,41 @@
+/**
+ * Teleport
+ * Copyright (C) 2026 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import type { Meta } from '@storybook/react-vite';
+
+import { ContentMinWidth } from 'teleport/Main/Main';
+import { TeleportProviderBasic } from 'teleport/mocks/providers';
+
+import { EnrollAzure } from './EnrollAzure';
+
+export const WithTerraform = () => {
+  return (
+    <TeleportProviderBasic>
+      <ContentMinWidth>
+        <EnrollAzure />
+      </ContentMinWidth>
+    </TeleportProviderBasic>
+  );
+};
+
+const meta: Meta = {
+  title: 'Teleport/Integrations/Enroll/Cloud/Azure',
+  component: WithTerraform,
+};
+
+export default meta;

--- a/web/packages/teleport/src/Integrations/Enroll/Cloud/Azure/EnrollAzure.tsx
+++ b/web/packages/teleport/src/Integrations/Enroll/Cloud/Azure/EnrollAzure.tsx
@@ -1,0 +1,293 @@
+/**
+ * Teleport
+ * Copyright (C) 2026 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { useMemo, useState } from 'react';
+import { Link as InternalLink } from 'react-router';
+
+import { Box, ButtonSecondary, Flex, Subtitle1, Text } from 'design';
+import { copyToClipboard } from 'design/utils/copyToClipboard';
+import FieldInput from 'shared/components/FieldInput';
+import Validation from 'shared/components/Validation';
+import {
+  requiredField,
+  requiredIntegrationName,
+} from 'shared/components/Validation/rules';
+
+import cfg from 'teleport/config';
+import { Header } from 'teleport/Discover/Shared';
+import { useNoMinWidth } from 'teleport/Main';
+import { IntegrationKind } from 'teleport/services/integrations';
+import { IntegrationEnrollKind } from 'teleport/services/userEvent/types';
+import { useClusterVersion } from 'teleport/useClusterVersion';
+
+import {
+  CheckIntegrationButton,
+  CircleNumber,
+  Container,
+  Divider,
+  useEnrollCloudIntegration,
+} from '../Shared';
+import {
+  TerraformInfoGuideSidePanel,
+  InfoGuideSwitch,
+  useTerraformInfoGuide,
+  ContentWithSidePanel,
+  TerraformInfoGuide,
+} from '../Shared/InfoGuide';
+import { RegionSelect } from '../Shared/RegionSelect';
+import { ApplyTerraformSection } from './ApplyTerraformSection';
+import { InfoGuideContent } from './InfoGuide';
+import { azureRegionOptionGroups, azureRegionOptions } from './regions';
+import { ResourcesSection } from './ResourcesSection';
+import { buildTerraformConfig } from './tf_module';
+import { AzureManagedIdentity, VmConfig } from './types';
+
+export function EnrollAzure() {
+  useNoMinWidth();
+
+  const { clusterVersion } = useClusterVersion();
+
+  const {
+    integrationName,
+    setIntegrationName,
+    copyTerraformConfig,
+    integrationExists,
+    isFetching,
+    isError,
+    checkIntegration,
+    cancelCheckIntegration,
+  } = useEnrollCloudIntegration(IntegrationEnrollKind.AzureCloud);
+
+  const [vmConfig, setVmConfig] = useState<VmConfig>({
+    type: 'vm',
+    enabled: true,
+    regions: ['*'],
+    subscriptions: [],
+    resourceGroups: [],
+    tags: [],
+  });
+
+  const [managedIdentity, setManagedIdentity] = useState<AzureManagedIdentity>({
+    region: 'eastus',
+    resourceGroup: '',
+  });
+
+  const terraformConfig = useMemo(
+    () =>
+      buildTerraformConfig({
+        integrationName,
+        version: clusterVersion,
+        vmConfig: vmConfig,
+        managedIdentity: managedIdentity,
+      }),
+    [integrationName, clusterVersion, vmConfig, managedIdentity]
+  );
+
+  const {
+    isPanelOpen,
+    activeInfoGuideTab,
+    setActiveInfoGuideTab,
+    onInfoGuideClick,
+  } = useTerraformInfoGuide('info');
+
+  return (
+    <Validation>
+      {({ validator }) => (
+        <Box pt={3}>
+          <ContentWithSidePanel isPanelOpen={isPanelOpen}>
+            <Flex justifyContent="space-between" alignItems="start" mb={1}>
+              <Header>Connect Azure</Header>
+              <InfoGuideSwitch
+                isPanelOpen={isPanelOpen}
+                activeTab={activeInfoGuideTab}
+                onSwitch={onInfoGuideClick}
+              />
+            </Flex>
+            <Subtitle1 mb={3}>
+              Connect your Azure account to automatically discover and enroll
+              resources in your Teleport Cluster.
+            </Subtitle1>
+            <Container flexDirection="column" p={4} mb={3}>
+              <IntegrationSection
+                integrationName={integrationName}
+                onChange={setIntegrationName}
+                disabled={isFetching}
+              />
+              <Divider />
+              <ManagedIdentitySection
+                managedIdentity={managedIdentity}
+                onChange={setManagedIdentity}
+                disabled={isFetching}
+              />
+              <Divider />
+              <ResourcesSection vmConfig={vmConfig} onVmChange={setVmConfig} />
+              <Divider />
+              <ApplyTerraformSection
+                handleCopy={() => {
+                  if (validator.validate() && terraformConfig) {
+                    copyTerraformConfig(terraformConfig);
+                  }
+                }}
+                integrationExists={integrationExists}
+                integrationName={integrationName}
+                handleCheckIntegration={() => {
+                  if (validator.validate()) {
+                    checkIntegration();
+                  }
+                }}
+                handleCancelCheckIntegration={cancelCheckIntegration}
+                isCheckingIntegration={isFetching}
+                checkIntegrationError={isError}
+              />
+            </Container>
+            <Box mb={2}>
+              <CheckIntegrationButton
+                integrationExists={integrationExists}
+                integrationName={integrationName}
+                integrationKind={IntegrationKind.AzureOidc}
+              />
+              <ButtonSecondary
+                ml={3}
+                as={InternalLink}
+                to={cfg.getIntegrationEnrollRoute(null)}
+              >
+                Back
+              </ButtonSecondary>
+            </Box>
+          </ContentWithSidePanel>
+
+          <TerraformInfoGuideSidePanel
+            activeTab={activeInfoGuideTab}
+            onTabChange={setActiveInfoGuideTab}
+            InfoGuideContent={<InfoGuideContent />}
+            TerraformContent={
+              <TerraformInfoGuide
+                terraformConfig={terraformConfig}
+                handleCopy={() => {
+                  if (validator.validate() && terraformConfig) {
+                    copyToClipboard(terraformConfig);
+                  }
+                }}
+              />
+            }
+          />
+        </Box>
+      )}
+    </Validation>
+  );
+}
+
+type IntegrationSectionProps = {
+  integrationName: string;
+  onChange: (name: string) => void;
+  disabled: boolean;
+};
+
+export function IntegrationSection({
+  integrationName,
+  onChange,
+  disabled = false,
+}: IntegrationSectionProps) {
+  return (
+    <>
+      <Flex alignItems="center" fontSize={4} fontWeight="medium" mb={1}>
+        <CircleNumber>1</CircleNumber>
+        Integration Details
+      </Flex>
+      <Text ml={4} mb={3}>
+        Provide a name to identify this Azure integration in Teleport.
+      </Text>
+      <FieldInput
+        ml={4}
+        mb={0}
+        rule={requiredIntegrationName}
+        value={integrationName}
+        required={true}
+        label="Integration name"
+        placeholder="my-azure-integration"
+        maxWidth={360}
+        disabled={disabled}
+        onChange={e => onChange(e.target.value.trim())}
+      />
+    </>
+  );
+}
+
+type ManagedIdentitySectionProps = {
+  managedIdentity: AzureManagedIdentity;
+  onChange: (identity: AzureManagedIdentity) => void;
+  disabled?: boolean;
+};
+
+export function ManagedIdentitySection({
+  managedIdentity,
+  onChange,
+  disabled = false,
+}: ManagedIdentitySectionProps) {
+  return (
+    <>
+      <Flex alignItems="center" fontSize={4} fontWeight="medium" mb={3}>
+        <CircleNumber>2</CircleNumber>
+        Azure Managed Identity
+      </Flex>
+      <Box ml={4} mb={3} color="text.slightlyMuted" maxWidth={500}>
+        Configure the region and resource group for the Azure Managed Identity
+        used by the Teleport discovery service.
+      </Box>
+
+      <Box ml={4} mb={0} maxWidth={400}>
+        <RegionSelect
+          isMulti={false}
+          options={azureRegionOptionGroups}
+          value={azureRegionOptions.find(
+            opt => opt.value === managedIdentity.region
+          )}
+          onChange={option =>
+            option &&
+            onChange({
+              ...managedIdentity,
+              region: option.value,
+            })
+          }
+          label="Location"
+          placeholder="Select region..."
+          isDisabled={disabled}
+          required={true}
+          rule={requiredField('Managed identity location is required')}
+        />
+      </Box>
+      <FieldInput
+        ml={4}
+        mb={3}
+        rule={requiredField('Resource group name is required')}
+        value={managedIdentity.resourceGroup}
+        required={true}
+        label="Resource Group Name"
+        placeholder="my-resource-group"
+        maxWidth={400}
+        disabled={disabled}
+        onChange={e =>
+          onChange({
+            ...managedIdentity,
+            resourceGroup: e.target.value,
+          })
+        }
+      />
+    </>
+  );
+}

--- a/web/packages/teleport/src/Integrations/Enroll/Cloud/Azure/EnrollAzure.tsx
+++ b/web/packages/teleport/src/Integrations/Enroll/Cloud/Azure/EnrollAzure.tsx
@@ -17,7 +17,7 @@
  */
 
 import { useMemo, useState } from 'react';
-import { Link as InternalLink } from 'react-router';
+import { Link as InternalLink } from 'react-router-dom';
 
 import { Box, ButtonSecondary, Flex, Subtitle1, Text } from 'design';
 import { copyToClipboard } from 'design/utils/copyToClipboard';

--- a/web/packages/teleport/src/Integrations/Enroll/Cloud/Azure/InfoGuide.tsx
+++ b/web/packages/teleport/src/Integrations/Enroll/Cloud/Azure/InfoGuide.tsx
@@ -1,0 +1,101 @@
+/**
+ * Teleport
+ * Copyright (C) 2026 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import styled from 'styled-components';
+
+import { Box, Text, Flex, Link as ExternalLink } from 'design';
+import { NewTab } from 'design/Icon';
+import {
+  InfoParagraph,
+  InfoTitle,
+  InfoUl,
+  ReferenceLinks,
+  type ReferenceLink,
+} from 'shared/components/SlidingSidePanel/InfoGuide';
+
+const referenceLinks: ReferenceLink[] = [
+  {
+    title: 'Teleport Azure Discovery Documentation',
+    href: 'https://goteleport.com/docs/enroll-resources/auto-discovery/servers/azure-discovery/',
+  },
+];
+
+export function InfoGuideContent() {
+  return (
+    <Box>
+      <InfoTitle>Overview</InfoTitle>
+      <InfoParagraph>
+        Connect your Azure account to Teleport to automatically discover and
+        enroll resources in your cluster.
+      </InfoParagraph>
+
+      <InfoTitle>How It Works</InfoTitle>
+      <Box pl={2}>
+        <ol
+          css={`
+            padding: inherit;
+          `}
+        >
+          <li>
+            <strong>Configure what to discover.</strong> <br />
+            Specify resource types, subscriptions, regions, and tag filters to
+            control which resources are discovered.
+          </li>
+          <li>
+            <strong>Use the generated Terraform module.</strong> <br />
+            The generated Terraform module configuration will create an Azure
+            managed identity that grants Teleport read-only access and
+            configures Teleport discovery service to scan for your Azure
+            resources.
+          </li>
+          <li>
+            <strong>
+              Your cloud resources automatically appear in your Teleport
+              cluster.
+            </strong>
+            <br />
+            <Text as="span" color="text.slightlyMuted">
+              Teleport scans every 30 minutes to find matching resources.
+              Resources are enrolled in Teleport and ready for secure access.
+            </Text>
+          </li>
+        </ol>
+      </Box>
+      <InfoTitle>Prerequisites</InfoTitle>
+      <InfoParagraph>Before you begin, ensure you have:</InfoParagraph>
+      <InfoUl>
+        <InfoLinkLi>
+          <ExternalLink
+            href="https://goteleport.com/docs/enroll-resources/auto-discovery/servers/azure-discovery/#step-35-set-up-an-identity-for-discovered-nodes"
+            target="_blank"
+          >
+            <Flex>
+              Azure identity for VMs to be discovered
+              <NewTab size="small" ml={1} />
+            </Flex>
+          </ExternalLink>
+        </InfoLinkLi>
+      </InfoUl>
+      <ReferenceLinks links={referenceLinks} />
+    </Box>
+  );
+}
+
+const InfoLinkLi = styled.li`
+  color: ${({ theme }) => theme.colors.interactive.solid.accent.default};
+`;

--- a/web/packages/teleport/src/Integrations/Enroll/Cloud/Azure/ResourcesSection.tsx
+++ b/web/packages/teleport/src/Integrations/Enroll/Cloud/Azure/ResourcesSection.tsx
@@ -1,0 +1,180 @@
+/**
+ * Teleport
+ * Copyright (C) 2026 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { useMemo } from 'react';
+
+import { Box, Flex, Text } from 'design';
+import { FieldCheckbox } from 'shared/components/FieldCheckbox';
+import { FieldMultiInput } from 'shared/components/FieldMultiInput/FieldMultiInput';
+import { type Option } from 'shared/components/Select';
+import {
+  arrayOf,
+  requiredAzureSubscriptionId,
+  requiredField,
+} from 'shared/components/Validation/rules';
+
+import {
+  LabelsInput,
+  type Label,
+  type LabelsRule,
+} from 'teleport/components/LabelsInput/LabelsInput';
+import { AzureRegion } from 'teleport/services/integrations';
+
+import { CircleNumber } from '../Shared/common';
+import { RegionSelect } from '../Shared/RegionSelect';
+import { azureRegionOptions } from './regions';
+import { AzureTag, VmConfig } from './types';
+
+const subscriptionRule =
+  (allowWildcard: boolean) => (values: string[]) => () => {
+    if (values.length === 0) {
+      return {
+        valid: false,
+        results: [
+          { valid: false, message: 'At least one subscription is required' },
+        ],
+      };
+    }
+    const matchValues = allowWildcard ? values.filter(v => v !== '*') : values;
+    return arrayOf(requiredAzureSubscriptionId)(matchValues)();
+  };
+
+const nonEmptyTags: LabelsRule = (labels: Label[]) => () => {
+  const results = labels.map(label => ({
+    name: requiredField('Please enter a tag name')(label.name)(),
+    value: requiredField('Please enter a tag value')(label.value)(),
+  }));
+  return {
+    valid: results.every(r => r.name.valid && r.value.valid),
+    results: results,
+  };
+};
+
+type ResourcesSectionProps = {
+  vmConfig: VmConfig;
+  onVmChange: (config: VmConfig) => void;
+  allowWildcardSubscriptions?: boolean;
+};
+
+export function ResourcesSection({
+  vmConfig,
+  onVmChange,
+  allowWildcardSubscriptions = false,
+}: ResourcesSectionProps) {
+  return (
+    <>
+      <Flex alignItems="center" fontSize={4} fontWeight="medium" mb={1}>
+        <CircleNumber>3</CircleNumber>
+        Resource Types
+      </Flex>
+      <Text ml={4} mb={3}>
+        Select which Azure resource types to automatically discover and enroll.
+      </Text>
+
+      <AzureService
+        label="Virtual Machines"
+        config={vmConfig}
+        onUpdate={patch => onVmChange({ ...vmConfig, ...patch })}
+        allowWildcardSubscriptions={allowWildcardSubscriptions}
+      />
+    </>
+  );
+}
+
+function AzureService({
+  label,
+  config,
+  onUpdate,
+  allowWildcardSubscriptions,
+}: {
+  label: string;
+  config: VmConfig;
+  onUpdate: (patch: Partial<VmConfig>) => void;
+  allowWildcardSubscriptions: boolean;
+}) {
+  const isWildcardRegion = config.regions.some(r => r === '*');
+
+  const selectedOptions = useMemo<Option<AzureRegion>[]>(() => {
+    if (isWildcardRegion) return [];
+    return azureRegionOptions.filter(opt => config.regions.includes(opt.value));
+  }, [config.regions, isWildcardRegion]);
+
+  return (
+    <>
+      <FieldCheckbox
+        mb={2}
+        size="small"
+        label={label}
+        checked={config.enabled}
+      />
+      {config.enabled && (
+        <Box ml={4}>
+          <Box mb={3} maxWidth={432}>
+            <FieldMultiInput
+              label="Match subscriptions"
+              required
+              value={config.subscriptions}
+              placeholder="11111111-2222-3333-4444-555555555555"
+              onChange={subscriptions => onUpdate({ subscriptions })}
+              rule={subscriptionRule(allowWildcardSubscriptions)}
+            />
+          </Box>
+          <Box width={400} mb={3}>
+            <RegionSelect
+              isMulti={true}
+              label="Match regions"
+              options={azureRegionOptions}
+              value={selectedOptions}
+              placeholder={<Text color="text.main">All regions</Text>}
+              onChange={options =>
+                onUpdate({
+                  regions:
+                    options.length === 0
+                      ? ['*']
+                      : options.map((opt: Option<AzureRegion>) => opt.value),
+                })
+              }
+              isDisabled={false}
+            />
+          </Box>
+          <Box mb={3} maxWidth={432}>
+            <FieldMultiInput
+              label="Match resource groups"
+              value={config.resourceGroups}
+              placeholder="my-resource-group"
+              onChange={resourceGroups => onUpdate({ resourceGroups })}
+            />
+          </Box>
+          <Box mb={2} width={433}>
+            <LabelsInput
+              legend="Match tags"
+              adjective="tag"
+              labels={config.tags as Label[]}
+              labelKey={{ fieldName: 'Name', placeholder: 'Environment' }}
+              labelVal={{ fieldName: 'Value', placeholder: 'production' }}
+              setLabels={(tags: Label[]) =>
+                onUpdate({ tags: tags as AzureTag[] })
+              }
+              rule={nonEmptyTags}
+            />
+          </Box>
+        </Box>
+      )}
+    </>
+  );
+}

--- a/web/packages/teleport/src/Integrations/Enroll/Cloud/Azure/index.ts
+++ b/web/packages/teleport/src/Integrations/Enroll/Cloud/Azure/index.ts
@@ -1,0 +1,19 @@
+/**
+ * Teleport
+ * Copyright (C) 2026 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+export { EnrollAzure } from './EnrollAzure';

--- a/web/packages/teleport/src/Integrations/Enroll/Cloud/Azure/regions.ts
+++ b/web/packages/teleport/src/Integrations/Enroll/Cloud/Azure/regions.ts
@@ -95,7 +95,7 @@ const regions: { name: string; regions: AzureRegion[] }[] = [
   },
 ];
 
-export const azureRegionOptions = regions.map(({ name, regions }) => ({
+export const azureRegionOptionGroups = regions.map(({ name, regions }) => ({
   label: name,
   options: regions
     .filter(id => id in azureRegionMap)
@@ -104,3 +104,7 @@ export const azureRegionOptions = regions.map(({ name, regions }) => ({
       label: azureRegionMap[id],
     })),
 }));
+
+export const azureRegionOptions = azureRegionOptionGroups.flatMap(
+  group => group.options
+);

--- a/web/packages/teleport/src/Integrations/Enroll/Cloud/Azure/tf_module.test.ts
+++ b/web/packages/teleport/src/Integrations/Enroll/Cloud/Azure/tf_module.test.ts
@@ -1,0 +1,168 @@
+/**
+ * Teleport
+ * Copyright (C) 2026 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import {
+  AzureDiscoverTerraformModuleConfig,
+  buildTerraformConfig,
+} from './tf_module';
+
+describe('buildTerraformConfig', () => {
+  const baseConfig: AzureDiscoverTerraformModuleConfig = {
+    integrationName: 'my-integration',
+    version: '19.0.0',
+    vmConfig: {
+      type: 'vm',
+      enabled: true,
+      regions: ['eastus'],
+      subscriptions: [],
+      resourceGroups: [],
+      tags: [],
+    },
+    managedIdentity: {
+      resourceGroup: 'my-resource-group',
+      region: 'eastus',
+    },
+  };
+
+  test('uses production registry for release versions', () => {
+    const result = buildTerraformConfig(baseConfig);
+
+    expect(result).toContain(
+      'source  = "terraform.releases.teleport.dev/teleport/discovery/azure"'
+    );
+  });
+
+  test('uses staging registry for prerelease versions', () => {
+    const result = buildTerraformConfig({
+      ...baseConfig,
+      version: '19.0.0-rc.1',
+    });
+
+    expect(result).toContain(
+      'source  = "terraform-staging.releases.development.teleport.dev/teleport/discovery/azure"'
+    );
+  });
+
+  test('includes vm type in matcher', () => {
+    const result = buildTerraformConfig(baseConfig);
+
+    expect(result).toMatch(/types\s+=\s+\["vm"\]/);
+  });
+
+  test('omits azure_matchers when vm is disabled', () => {
+    const result = buildTerraformConfig({
+      ...baseConfig,
+      vmConfig: { ...baseConfig.vmConfig, enabled: false },
+    });
+
+    expect(result).not.toContain('azure_matchers');
+  });
+
+  test('includes specific regions sorted', () => {
+    const result = buildTerraformConfig({
+      ...baseConfig,
+      vmConfig: { ...baseConfig.vmConfig, regions: ['westus', 'eastus'] },
+    });
+
+    expect(result).toMatch(/regions\s+=\s+\["eastus",\s+"westus"\]/);
+  });
+
+  test('omits regions for wildcard', () => {
+    const result = buildTerraformConfig({
+      ...baseConfig,
+      vmConfig: { ...baseConfig.vmConfig, regions: ['*'] },
+    });
+
+    expect(result).not.toContain('regions');
+  });
+
+  test('includes subscriptions sorted', () => {
+    const result = buildTerraformConfig({
+      ...baseConfig,
+      vmConfig: { ...baseConfig.vmConfig, subscriptions: ['sub-b', 'sub-a'] },
+    });
+
+    expect(result).toContain('subscriptions = ["sub-a", "sub-b"]');
+  });
+
+  test('includes empty subscriptions array when none provided', () => {
+    const result = buildTerraformConfig(baseConfig);
+
+    expect(result).toContain('subscriptions = []');
+  });
+
+  test('includes resource_groups sorted', () => {
+    const result = buildTerraformConfig({
+      ...baseConfig,
+      vmConfig: { ...baseConfig.vmConfig, resourceGroups: ['rg-2', 'rg-1'] },
+    });
+
+    expect(result).toContain('resource_groups = ["rg-1", "rg-2"]');
+  });
+
+  test('omits resource_groups when empty', () => {
+    const result = buildTerraformConfig(baseConfig);
+
+    expect(result).not.toContain('resource_groups');
+  });
+
+  test('includes tags', () => {
+    const result = buildTerraformConfig({
+      ...baseConfig,
+      vmConfig: {
+        ...baseConfig.vmConfig,
+        tags: [{ name: 'env', value: 'prod' }],
+      },
+    });
+
+    expect(result).toContain('env = ["prod"]');
+  });
+
+  test('omits tags when empty', () => {
+    const result = buildTerraformConfig(baseConfig);
+
+    expect(result).not.toContain('tags');
+  });
+
+  test('omits tags for wildcard tag name', () => {
+    const result = buildTerraformConfig({
+      ...baseConfig,
+      vmConfig: {
+        ...baseConfig.vmConfig,
+        tags: [{ name: '*', value: '*' }],
+      },
+    });
+
+    expect(result).not.toContain('tags');
+  });
+
+  test('collects multiple values for the same tag key', () => {
+    const result = buildTerraformConfig({
+      ...baseConfig,
+      vmConfig: {
+        ...baseConfig.vmConfig,
+        tags: [
+          { name: 'env', value: 'prod' },
+          { name: 'env', value: 'staging' },
+        ],
+      },
+    });
+
+    expect(result).toContain('env = ["prod", "staging"]');
+  });
+});

--- a/web/packages/teleport/src/Integrations/Enroll/Cloud/Azure/tf_module.ts
+++ b/web/packages/teleport/src/Integrations/Enroll/Cloud/Azure/tf_module.ts
@@ -1,0 +1,132 @@
+/**
+ * Teleport
+ * Copyright (C) 2026 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { parse as parseVersion } from 'shared/utils/semVer';
+
+import cfg from 'teleport/config';
+
+import { hcl, type TFObject, type TFValue } from '../terraform';
+import {
+  AzureManagedIdentity,
+  AzureTag,
+  VmConfig,
+  ServiceConfig,
+} from './types';
+
+export type AzureDiscoverTerraformModuleConfig = {
+  integrationName: string;
+  version: string;
+  vmConfig: VmConfig;
+  managedIdentity: AzureManagedIdentity;
+};
+
+const TF_MODULE = '/teleport/discovery/azure';
+
+const isStaging = (version: string): boolean => {
+  const parsed = parseVersion(version);
+  if (!parsed) return false;
+
+  return parsed.prerelease.length > 0;
+};
+
+export const buildTerraformConfig = ({
+  integrationName,
+  version,
+  vmConfig,
+  managedIdentity,
+}: AzureDiscoverTerraformModuleConfig): string => {
+  const tfRegistry = isStaging(version)
+    ? cfg.terraform.stagingRegistry
+    : cfg.terraform.registry;
+
+  const moduleSrc = `${tfRegistry}${TF_MODULE}`;
+
+  const integrationNameOrNull = integrationName.trim() || null;
+
+  const matcher = buildMatcher(vmConfig);
+
+  const azureMatchers = matcher ? [matcher] : null;
+
+  const resourceGroup = managedIdentity.resourceGroup.trim();
+
+  const managedIdentityRegionOrNull = managedIdentity.region;
+
+  const tfModule = hcl`# Terraform Module
+module "azure_discovery" {
+  source  = ${moduleSrc}
+  version = ${version}
+
+  teleport_integration_use_name_prefix = ${integrationNameOrNull ? false : null}
+
+  teleport_proxy_public_addr    = ${cfg.proxyCluster + ':443'}
+  teleport_discovery_group_name = "cloud-discovery-group"
+  teleport_integration_name	    = ${integrationNameOrNull}
+
+  # Name of an existing Azure Resource Group where
+  # Azure resources will be created.
+  azure_resource_group_name = ${resourceGroup}
+
+  # Azure region (location) where the managed identity
+  # will be created (e.g., "eastus")
+  azure_managed_identity_location = ${managedIdentityRegionOrNull}
+
+  azure_matchers = ${azureMatchers}
+}
+`;
+
+  return tfModule;
+};
+
+const buildMatcher = (config: ServiceConfig): TFObject | null => {
+  if (!config.enabled) return null;
+
+  const matcher: { [key: string]: TFValue } = { types: [config.type] };
+
+  // required by azure discovery module
+  matcher.subscriptions = [...config.subscriptions].sort();
+
+  if (config.resourceGroups?.length > 0) {
+    matcher['resource_groups'] = [...config.resourceGroups].sort();
+  }
+
+  if (config.regions.length > 0 && !config.regions.some(r => r === '*')) {
+    matcher.regions = [...config.regions].sort();
+  }
+
+  const tags = buildTagMap(config.tags);
+  if (tags) {
+    matcher.tags = tags;
+  }
+
+  return matcher;
+};
+
+const buildTagMap = (tags: AzureTag[]) => {
+  const filtered = tags.filter(t => t.value && t.name);
+  if (filtered.length === 0) return null;
+  if (filtered.some(t => t.name === '*')) return null;
+
+  const tagMap: Record<string, string[]> = {};
+  filtered.forEach(tag => {
+    if (!tagMap[tag.name]) {
+      tagMap[tag.name] = [];
+    }
+    tagMap[tag.name].push(tag.value);
+  });
+  return tagMap;
+};

--- a/web/packages/teleport/src/Integrations/Enroll/Cloud/Azure/types.ts
+++ b/web/packages/teleport/src/Integrations/Enroll/Cloud/Azure/types.ts
@@ -1,0 +1,42 @@
+/**
+ * Teleport
+ * Copyright (C) 2026 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { AzureRegion } from 'teleport/services/integrations';
+
+export type ServiceType = 'vm';
+
+export type ServiceConfig = {
+  enabled: boolean;
+  regions: (AzureRegion | '*')[];
+  subscriptions: string[];
+  resourceGroups: string[];
+  tags: AzureTag[];
+  type: ServiceType;
+};
+
+export type VmConfig = ServiceConfig & { type: 'vm' };
+
+export type AzureTag = {
+  name: string;
+  value: string;
+};
+
+export type AzureManagedIdentity = {
+  region: AzureRegion;
+  resourceGroup: string;
+};

--- a/web/packages/teleport/src/Integrations/Enroll/Cloud/Shared/InfoGuide.tsx
+++ b/web/packages/teleport/src/Integrations/Enroll/Cloud/Shared/InfoGuide.tsx
@@ -49,10 +49,9 @@ export const ContentWithSidePanel = styled(Box)<{
   transition: ${p => (p.isPanelOpen ? 'margin 150ms' : 'margin 300ms')};
 `;
 
-export function useTerraformInfoGuide(defaultOpen = true) {
-  const [activeInfoGuideTab, setActiveInfoGuideTab] = useState<InfoGuideTab>(
-    defaultOpen ? 'info' : null
-  );
+export function useTerraformInfoGuide(defaultTab: InfoGuideTab = 'info') {
+  const [activeInfoGuideTab, setActiveInfoGuideTab] =
+    useState<InfoGuideTab>(defaultTab);
 
   const isPanelOpen = activeInfoGuideTab !== null;
 

--- a/web/packages/teleport/src/Integrations/Enroll/Cloud/terraform.ts
+++ b/web/packages/teleport/src/Integrations/Enroll/Cloud/terraform.ts
@@ -20,7 +20,7 @@ export interface TFObject {
   [key: string]: TFValue;
 }
 
-type TFValue = string | number | boolean | TFValue[] | TFObject | null;
+export type TFValue = string | number | boolean | TFValue[] | TFObject | null;
 
 /**
  * hcl is a tagged template function for generating Terraform HCL

--- a/web/packages/teleport/src/Integrations/Enroll/IntegrationRoute.tsx
+++ b/web/packages/teleport/src/Integrations/Enroll/IntegrationRoute.tsx
@@ -48,7 +48,7 @@ export function getRoutesToEnrollIntegrations() {
       key={IntegrationKind.AzureCloud}
       exact
       path={cfg.getIntegrationEnrollRoute(IntegrationKind.AzureCloud)}
-      element={<EnrollAzure />}
+      component={EnrollAzure}
     />,
   ];
 }

--- a/web/packages/teleport/src/Integrations/Enroll/IntegrationRoute.tsx
+++ b/web/packages/teleport/src/Integrations/Enroll/IntegrationRoute.tsx
@@ -23,6 +23,7 @@ import { IntegrationKind } from 'teleport/services/integrations';
 
 import { AwsOidc } from './AwsOidc';
 import { EnrollAws } from './Cloud/Aws';
+import { EnrollAzure } from './Cloud/Azure';
 
 export function getRoutesToEnrollIntegrations() {
   return [
@@ -42,6 +43,12 @@ export function getRoutesToEnrollIntegrations() {
       exact
       path={cfg.getIntegrationEnrollRoute(IntegrationKind.AwsCloud)}
       component={EnrollAws}
+    />,
+    <Route
+      key={IntegrationKind.AzureCloud}
+      exact
+      path={cfg.getIntegrationEnrollRoute(IntegrationKind.AzureCloud)}
+      element={<EnrollAzure />}
     />,
   ];
 }

--- a/web/packages/teleport/src/Integrations/Enroll/Shared/Tile.tsx
+++ b/web/packages/teleport/src/Integrations/Enroll/Shared/Tile.tsx
@@ -69,9 +69,7 @@ export function IntegrationTileWithSpec({
     );
   }
 
-  const isComingSoon =
-    spec.kind === IntegrationKind.AzureCloud ||
-    spec.kind === IntegrationKind.GoogleCloud;
+  const isComingSoon = spec.kind === IntegrationKind.GoogleCloud;
   if (isComingSoon) {
     Badge = <BadgeGuided>Coming Soon</BadgeGuided>;
     hasAccess = false;

--- a/web/packages/teleport/src/Integrations/IntegrationList.tsx
+++ b/web/packages/teleport/src/Integrations/IntegrationList.tsx
@@ -79,6 +79,7 @@ const statusKinds = [
   'entra-id',
   IntegrationKind.AwsOidc,
   IntegrationKind.AwsRa,
+  IntegrationKind.AzureOidc,
 ];
 
 type Filters = {
@@ -189,6 +190,7 @@ export function IntegrationList(props: Props) {
               if (
                 item.kind === IntegrationKind.AwsOidc ||
                 item.kind === IntegrationKind.AwsRa ||
+                item.kind === IntegrationKind.AzureOidc ||
                 item.kind === 'entra-id'
               ) {
                 // action menu for these integrations are available on the status page dashboard.
@@ -390,7 +392,7 @@ const NameCell = ({ item }: { item: IntegrationLike }) => {
         icon = <IconContainer name="awsidentityandaccessmanagementiam" />;
         break;
       case IntegrationKind.AzureOidc:
-        formattedText = 'Azure OIDC';
+        formattedText = item.name;
         icon = <IconContainer name="azure" />;
         break;
       case IntegrationKind.GitHub:

--- a/web/packages/teleport/src/Integrations/shared/StatusLabel.test.tsx
+++ b/web/packages/teleport/src/Integrations/shared/StatusLabel.test.tsx
@@ -139,6 +139,15 @@ function makeSummary(lastSyncMs: number): IntegrationWithSummary {
       ecsDatabaseServiceCount: 0,
       unresolvedUserTasks: 0,
     },
+    azurevm: {
+      rulesCount: 0,
+      resourcesFound: 0,
+      resourcesEnrollmentFailed: 0,
+      resourcesEnrollmentSuccess: 0,
+      discoverLastSync: 0,
+      ecsDatabaseServiceCount: 0,
+      unresolvedUserTasks: 0,
+    },
     rolesAnywhereProfileSync: undefined,
   };
 }

--- a/web/packages/teleport/src/Integrations/shared/StatusLabel.tsx
+++ b/web/packages/teleport/src/Integrations/shared/StatusLabel.tsx
@@ -230,21 +230,32 @@ const statusLabel = (status: Status, label: string) => {
   );
 };
 
-function isSummarySyncing(summary: IntegrationWithSummary): boolean {
-  const lastSync = Math.max(
-    getTimestamp(summary.awsec2?.discoverLastSync),
-    getTimestamp(summary.awsrds?.discoverLastSync),
-    getTimestamp(summary.awseks?.discoverLastSync),
-    getTimestamp(summary.rolesAnywhereProfileSync?.syncEndTime)
-  );
+export function latestSyncDate(
+  summary: IntegrationWithSummary
+): Date | undefined {
+  const lastSyncTimestamps = [
+    summary.awsec2?.discoverLastSync,
+    summary.awsrds?.discoverLastSync,
+    summary.awseks?.discoverLastSync,
+    summary.azurevm?.discoverLastSync,
+    summary.rolesAnywhereProfileSync?.syncEndTime,
+  ].map(toTimestamp);
 
+  const lastSync = Math.max(...lastSyncTimestamps);
+
+  return lastSync ? new Date(lastSync) : undefined;
+}
+
+function isSummarySyncing(summary: IntegrationWithSummary): boolean {
+  const lastScanDate = latestSyncDate(summary);
   return (
-    lastSync === 0 ||
-    Date.now() >= lastSync + INTEGRATION_DISCOVERY_SCAN_INTERVAL_MS
+    !lastScanDate ||
+    Date.now() >=
+      lastScanDate.getTime() + INTEGRATION_DISCOVERY_SCAN_INTERVAL_MS
   );
 }
 
-function getTimestamp(value: unknown): number {
+export function toTimestamp(value: unknown): number {
   if (!value) {
     return 0;
   }

--- a/web/packages/teleport/src/Integrations/status/AwsOidc/AwsOidcDashboard.test.tsx
+++ b/web/packages/teleport/src/Integrations/status/AwsOidc/AwsOidcDashboard.test.tsx
@@ -90,6 +90,15 @@ test('renders header and stats cards', async () => {
               ecsDatabaseServiceCount: 0, // irrelevant
               unresolvedUserTasks: 0,
             },
+            azurevm: {
+              rulesCount: 0,
+              resourcesFound: 0,
+              resourcesEnrollmentFailed: 0,
+              resourcesEnrollmentSuccess: 0,
+              discoverLastSync: 0,
+              ecsDatabaseServiceCount: 0,
+              unresolvedUserTasks: 0,
+            },
           }),
         }}
         path=""
@@ -197,6 +206,7 @@ test('renders enroll cards', () => {
             awsec2: zeroCount,
             awsrds: zeroCount,
             awseks: zeroCount,
+            azurevm: zeroCount,
           }),
         }}
         path=""

--- a/web/packages/teleport/src/config.ts
+++ b/web/packages/teleport/src/config.ts
@@ -37,6 +37,7 @@ import {
   IntegrationKind,
   PluginKind,
   Regions,
+  AzureResource,
 } from 'teleport/services/integrations';
 import type { KubeResourceKind } from 'teleport/services/kube/types';
 import type { GroupAction } from 'teleport/services/managedUpdates';
@@ -1489,7 +1490,7 @@ const cfg = {
 
   getIntegrationRulesUrl(
     name: string,
-    resourceType: AwsResource,
+    resourceType: AwsResource | AzureResource,
     regions?: string[]
   ) {
     const clusterId = cfg.proxyCluster;

--- a/web/packages/teleport/src/services/integrations/integrations.ts
+++ b/web/packages/teleport/src/services/integrations/integrations.ts
@@ -40,6 +40,7 @@ import {
   AwsOidcPingResponse,
   AwsRdsDatabase,
   AwsRolesAnywherePingResponse,
+  AzureResource,
   CreateAwsAppAccessRequest,
   EnrollEksClustersRequest,
   EnrollEksClustersResponse,
@@ -473,7 +474,7 @@ export const integrationService = {
 
   fetchIntegrationRules(
     name: string,
-    resourceType: AwsResource,
+    resourceType: AwsResource | AzureResource,
     regions?: string[]
   ): Promise<IntegrationDiscoveryRules> {
     return api
@@ -543,6 +544,12 @@ export const integrationService = {
           databases: resp.discoverRds?.databases || {},
           account_id: resp.discoverRds?.account_id,
           region: resp.discoverRds?.region,
+        },
+        discoverAzureVm: {
+          instances: resp.discoverAzureVm?.instances || {},
+          subscription_id: resp.discoverAzureVm?.subscription_id,
+          resource_group: resp.discoverAzureVm?.resource_group,
+          region: resp.discoverAzureVm?.region,
         },
       };
     });
@@ -640,10 +647,12 @@ function makeIntegration(json: any): Integration {
     name,
     subKind,
     awsoidc,
+    azureoidc,
     github,
     awsra,
     isManagedByTerraform,
     summary,
+    metadata,
   } = json;
 
   const commonFields = {
@@ -658,6 +667,7 @@ function makeIntegration(json: any): Integration {
     statusCode: IntegrationStatusCode.Running,
     isManagedByTerraform,
     summary,
+    labels: metadata?.labels,
   };
 
   if (subKind === IntegrationKind.AwsOidc) {
@@ -686,6 +696,18 @@ function makeIntegration(json: any): Integration {
           roleArn: awsra.profileSyncConfig.roleArn,
           filters: awsra.profileSyncConfig.filters,
         },
+      },
+    };
+  }
+
+  if (subKind === IntegrationKind.AzureOidc) {
+    return {
+      ...commonFields,
+      details: 'Enroll Azure resources into Teleport.',
+      spec: {
+        tenantId: azureoidc.tenantId,
+        clientId: azureoidc.clientId,
+        managedIdentity: azureoidc.managedIdentity,
       },
     };
   }

--- a/web/packages/teleport/src/services/integrations/types.ts
+++ b/web/packages/teleport/src/services/integrations/types.ts
@@ -112,9 +112,19 @@ export type IntegrationGitHub = IntegrationTemplate<
   IntegrationSpecGitHub
 >;
 
+export type IntegrationSpecAzureOidc = {
+  tenantId: string;
+  clientId: string;
+  managedIdentity?: {
+    region: string;
+    resourceGroup: string;
+  };
+};
+
 export type IntegrationAzureOidc = IntegrationTemplate<
   'integration',
-  IntegrationKind.AzureOidc
+  IntegrationKind.AzureOidc,
+  IntegrationSpecAzureOidc
 >;
 
 /**
@@ -612,6 +622,8 @@ export type IntegrationWithSummary = {
   awsrds: ResourceTypeSummary;
   // awseks contains the summary for the AWS EKS resources for this integration.
   awseks: ResourceTypeSummary;
+  // azurevm contains the summary for the Azure VM resources for this integration.
+  azurevm: ResourceTypeSummary;
   // rolesAnywhereProfileSync contains the summary for the AWS Roles Anywhere Profile Sync.
   rolesAnywhereProfileSync: RolesAnywhereProfileSync;
   isManagedByTerraform?: boolean;
@@ -659,11 +671,13 @@ export type UserTaskDetail = UserTask & {
   // description is a markdown document that explains the issue and how to fix it.
   description: string;
   // discoverEc2 contains the task details for the DiscoverEc2 tasks.
-  discoverEc2: DiscoverEc2;
+  discoverEc2?: DiscoverEc2;
   // discoverEKS contains the task details for the DiscoverEKS tasks.
-  discoverEks: DiscoverEks;
+  discoverEks?: DiscoverEks;
   // discoverRDS contains the task details for the DiscoverRDS tasks.
-  discoverRds: DiscoverRds;
+  discoverRds?: DiscoverRds;
+  // discoverAzureVm contains the task details for the DiscoverAzureVM tasks.
+  discoverAzureVm?: DiscoverAzureVm;
 };
 
 // DiscoverEc2 contains the instances that failed to auto-enroll into the cluster.
@@ -768,6 +782,38 @@ export type DiscoverRdsDatabase = {
   resourceUrl: string;
 };
 
+// DiscoverAzureVm contains the VMs that failed to auto-enroll into the cluster.
+export type DiscoverAzureVm = {
+  // instances maps a VM resource ID to the result of enrolling that VM into teleport.
+  instances: Record<string, DiscoverAzureVmInstance>;
+  // subscription_id is the Azure Subscription ID for the VMs.
+  subscription_id: string;
+  // resource_group is the Azure Resource Group where VMs are located.
+  resource_group: string;
+  // region is the Azure Region where Teleport failed to enroll VMs.
+  region: string;
+};
+
+// DiscoverAzureVmInstance contains the result of enrolling an Azure VM.
+export type DiscoverAzureVmInstance = {
+  // vm_id is the Azure VM ID that uniquely identifies the virtual machine.
+  vm_id: string;
+  // resource_id is the full Azure resource path for this VM.
+  resource_id: string;
+  // name is the VM name.
+  name: string;
+  // discovery_config is the discovery config name that originated this VM enrollment.
+  discovery_config: string;
+  // discovery_group is the DiscoveryGroup name that originated this task.
+  discovery_group: string;
+  // sync_time is the timestamp when the error was produced.
+  sync_time: number;
+  // resourceUrl is the Azure Portal URL to access this VM.
+  // Always present.
+  // Format: https://portal.azure.com/#resource/subscriptions/<subscription-id>/resourceGroups/<resource-group>/providers/Microsoft.Compute/virtualMachines/<vm-name>
+  resourceUrl: string;
+};
+
 // IntegrationDiscoveryRule describes a discovery rule associated with an integration.
 export type IntegrationDiscoveryRule = {
   // resourceType indicates the type of resource that this rule targets.
@@ -778,6 +824,10 @@ export type IntegrationDiscoveryRule = {
   region: string;
   // labelMatcher is the set of labels that are used to filter the resources before trying to auto-enroll them.
   labelMatcher: Label[];
+  // subscriptions is the set of Azure subscriptions that are used to filter Azure resources
+  subscriptions?: string[];
+  // resourceGroups is the set of Azure resource groups that are used to filter Azure resources
+  resourceGroups?: string[];
   // discoveryConfig is the name of the DiscoveryConfig that created this rule.
   discoveryConfig: string;
   // lastSync contains the time when this rule was used.
@@ -994,6 +1044,10 @@ export const azureRegionMap = {
 };
 
 export type AzureRegion = keyof typeof azureRegionMap;
+
+export enum AzureResource {
+  vm = 'vm',
+}
 
 // RdsEngine are the expected backend string values,
 // used when requesting lists of rds databases of the


### PR DESCRIPTION
Backport of https://github.com/gravitational/teleport/pull/64644 into branch/v18
Depends on https://github.com/gravitational/teleport/pull/66476 https://github.com/gravitational/teleport/pull/66439
 
- Adds Azure Discovery with Terraform enrollment flow
- Adds Azure integration overview settings tab
- Support for Azure VM User Tasks

This backport includes fixes to support react-router v5

## Manual Test Plan
### Test Environment
- Cloud

### Test Cases

#### Enroll
- [x] Add New > Integrations - Click `Azure Discovery With Terraform`
- [x] Click "Terraform" tab in Info Guide to see generated Terraform config
- [x] Configure the terraform discovery module, apply generated terraform configuration
- [x] Integration appears in Integrations list after applying configuration

#### Integration Overview
- [x] Integration Overview shows resources discovered, integration state, last scanned
- [x] Azure VM issues appear under Issues, when applicable
- [x] 'Settings' tab matches configuration from enrollment

changelog: Added Azure Discovery With Terraform integration guided flow in Web UI