### PR TITLE
Timeout Azure discovery install command

### DIFF
--- a/lib/cloud/azure/vm.go
+++ b/lib/cloud/azure/vm.go
@@ -20,6 +20,7 @@ package azure
 
 import (
 	"context"
+	"os"
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
@@ -333,6 +334,9 @@ func NewRunCommandClient(subscription string, cred azcore.TokenCredential, optio
 
 // Run runs Teleport installation command on a virtual machine.
 func (c *runCommandClient) Run(ctx context.Context, req RunCommandRequest) (*RunCommandResult, error) {
+	timeout := getRunCommandTimeout()
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
 	// TODO(Tener): make the run command name actual parameter.
 	const runCommandName = "teleport-install"
 
@@ -343,6 +347,7 @@ func (c *runCommandClient) Run(ctx context.Context, req RunCommandRequest) (*Run
 			Source: &armcompute.VirtualMachineRunCommandScriptSource{
 				Script: to.Ptr(req.Script),
 			},
+			TimeoutInSeconds: to.Ptr(int32(timeout.Seconds())),
 		},
 	}, nil)
 	if err != nil {
@@ -382,4 +387,17 @@ func fromPtr[T any](ptr *T) T {
 		out = *ptr
 	}
 	return out
+}
+
+func getRunCommandTimeout() time.Duration {
+	const timeoutEnv = "TELEPORT_UNSTABLE_AZURE_RUN_COMMAND_TIMEOUT"
+	if dur, err := time.ParseDuration(os.Getenv(timeoutEnv)); err == nil {
+		// clamp the timeout to a reasonable duration.
+		const (
+			minTimeout = time.Second * 10
+			maxTimeout = time.Minute * 90
+		)
+		return min(maxTimeout, max(minTimeout, dur))
+	}
+	return 5 * time.Minute // default to 5m
 }

--- a/lib/cloud/azure/vm.go
+++ b/lib/cloud/azure/vm.go
@@ -334,8 +334,9 @@ func NewRunCommandClient(subscription string, cred azcore.TokenCredential, optio
 
 // Run runs Teleport installation command on a virtual machine.
 func (c *runCommandClient) Run(ctx context.Context, req RunCommandRequest) (*RunCommandResult, error) {
-	timeout := getRunCommandTimeout()
-	ctx, cancel := context.WithTimeout(ctx, timeout)
+	runCommandTimeout := getRunCommandTimeout()
+	// pad the timeout so we can still attempt to collect output if it times out
+	ctx, cancel := context.WithTimeout(ctx, runCommandTimeout+time.Minute)
 	defer cancel()
 	// TODO(Tener): make the run command name actual parameter.
 	const runCommandName = "teleport-install"
@@ -347,7 +348,7 @@ func (c *runCommandClient) Run(ctx context.Context, req RunCommandRequest) (*Run
 			Source: &armcompute.VirtualMachineRunCommandScriptSource{
 				Script: to.Ptr(req.Script),
 			},
-			TimeoutInSeconds: to.Ptr(int32(timeout.Seconds())),
+			TimeoutInSeconds: to.Ptr(int32(runCommandTimeout.Seconds())),
 		},
 	}, nil)
 	if err != nil {


### PR DESCRIPTION
Changelog: Fixed an issue with Azure discovery where blocked installation attempts prevent discovery from making progress. Install attempts will now time out after 5 minutes, but this can be adjusted by setting an environment variable on the Teleport Discovery Service, e.g., `TELEPORT_UNSTABLE_AZURE_RUN_COMMAND_TIMEOUT=3m45s`.


<!-- Include manual testing efforts to verify the change. -->
<!-- Detail where the tests where run and what configurations were used. -->
<!-- Include all the test cases which were run to validate the change. -->

## Manual Test Plan
### Test Environment
- cloud staging tenant with discovery service configure to discover Azure VMs
- Azure VMs in multiple subscriptions
- custom installer script that sleeps forever for some VMs

### Test Cases
- [x] Verify that discovered VMs where the installer script sleeps indefinitely time out
  - [x] Verify that the timeout can be changed with the env var and that the installer attempt respects the timeout
- [x] Verify that discovery service is able to complete its discovery scan even when some VM installs timeout.
