### PR TITLE
Azure discovery TF module - random_id and http data source respect var.create

### DIFF
--- a/integrations/terraform-modules/teleport/discovery/azure/main.tf
+++ b/integrations/terraform-modules/teleport/discovery/azure/main.tf
@@ -15,13 +15,14 @@ locals {
     "teleport.dev/azure-managed-identity-resource-group" = var.azure_resource_group_name
   })
 
-  teleport_cluster_name         = local.teleport_ping.cluster_name
-  teleport_ping                 = jsondecode(data.http.teleport_ping.response_body)
+  teleport_cluster_name         = try(local.teleport_ping.cluster_name, "")
+  teleport_ping                 = local.create ? jsondecode(one(data.http.teleport_ping[*].response_body)) : null
   teleport_proxy_public_url     = "https://${var.teleport_proxy_public_addr}"
-  teleport_resource_name_suffix = random_id.suffix.hex
+  teleport_resource_name_suffix = one(random_id.suffix[*].hex)
 }
 
 resource "random_id" "suffix" {
+  count       = local.create ? 1 : 0
   byte_length = 4
 }
 
@@ -30,6 +31,7 @@ data "azurerm_client_config" "this" {
 }
 
 data "http" "teleport_ping" {
+  count           = local.create ? 1 : 0
   request_headers = { Accept = "application/json" }
   url             = "${local.teleport_proxy_public_url}/webapi/find"
 }

--- a/integrations/terraform-modules/teleport/discovery/azure/tests/main.tftest.hcl
+++ b/integrations/terraform-modules/teleport/discovery/azure/tests/main.tftest.hcl
@@ -83,6 +83,53 @@ run "create" {
   }
 }
 
+run "create_false" {
+  variables {
+    create = false
+  }
+
+  assert {
+    condition     = length(random_id.suffix) == 0
+    error_message = "random_id suffix should not be created"
+  }
+  assert {
+    condition     = length(data.http.teleport_ping) == 0
+    error_message = "data.http.teleport_ping should not be fetched"
+  }
+  assert {
+    condition     = length(data.azurerm_client_config.this) == 0
+    error_message = "data.azurerm_client_config should not be fetched"
+  }
+  assert {
+    condition     = length(azurerm_user_assigned_identity.teleport_discovery_service) == 0
+    error_message = "azurerm_user_assigned_identity should not be created"
+  }
+  assert {
+    condition     = length(azurerm_federated_identity_credential.teleport_discovery_service) == 0
+    error_message = "azurerm_federated_identity_credential should not be created"
+  }
+  assert {
+    condition     = length(azurerm_role_definition.teleport_discovery) == 0
+    error_message = "azurerm_role_definition should not be created"
+  }
+  assert {
+    condition     = length(azurerm_role_assignment.teleport_discovery) == 0
+    error_message = "azurerm_role_assignment should not be created"
+  }
+  assert {
+    condition     = length(teleport_integration.azure_oidc) == 0
+    error_message = "teleport_integration should not be created"
+  }
+  assert {
+    condition     = length(teleport_provision_token.azure) == 0
+    error_message = "teleport_provision_token should not be created"
+  }
+  assert {
+    condition     = length(teleport_discovery_config.azure) == 0
+    error_message = "teleport_discovery_config should not be created"
+  }
+}
+
 run "use_oidc_integration_false" {
   variables {
     use_oidc_integration = false


### PR DESCRIPTION
adds `count = 0` when var.create = false for remaining data sources, resources

<!-- Include manual testing efforts to verify the change. -->
<!-- Detail where the tests where run and what configurations were used. -->
<!-- Include all the test cases which were run to validate the change. -->

## Manual Test Plan
### Test Environment
- local
### Test Cases
- [x] Nothing created when module set to var.create
- [x] Module working when var.create omitted / true
