### PR TITLE
docs: adding agentic identity in feature matrix

### DIFF
--- a/docs/pages/feature-matrix.mdx
+++ b/docs/pages/feature-matrix.mdx
@@ -84,12 +84,12 @@ The **Teleport Agentic Identity Framework** combines Teleport identity, access, 
 | Identity-based access control for MCP traffic | ✔ | ✔ | ✔ |
 | Per-tool audit events for MCP requests | ✔ | ✔ | ✔ |
 |**Trusted runtimes ([Beams](https://www.beams.run/), beta).** Run agent sessions in isolated, ephemeral runtimes with built-in identity, controlled egress, and full audit:||||
-| Sandboxed agent runtime with ephemeral storage and short-lived injected identity | ✔ | ✖ | ✖ |
+| Sandboxed agent runtime (Firecracker microVM) with ephemeral storage and short-lived injected identity | ✔ | ✖ | ✖ |
 | Launch and manage beams via `tsh` and an MCP server | ✔ | ✖ | ✖ |
 | Built-in inference proxy with bundled providers (OpenAI, Anthropic) and bring-your-own option | ✔ | ✖ | ✖ |
 | Policy-controlled allowlist for external API egress | ✔ | ✖ | ✖ |
 | Per-user limits on concurrent beams and shared inference usage | ✔ | ✖ | ✖ |
-| Session-bound beam lifecycle with full audit trail | ✔ | ✖ | ✖ |
+| Session-bound beam lifecycle (~24-hour maximum) with full audit trail | ✔ | ✖ | ✖ |
 |**Agent enforcement.** Stop or constrain agent activity inline when policy is violated:||||
 | [Session and identity locks](identity-governance/locking.mdx) | Available in Teleport Identity Governance | Available in Teleport Identity Governance | ✖ |
 | [Device Trust](zero-trust-access/device-trust/guide.mdx) for the human operator behind an agent | ✔ | ✔ | ✖ |

--- a/docs/pages/feature-matrix.mdx
+++ b/docs/pages/feature-matrix.mdx
@@ -23,9 +23,9 @@ HTML tag until we can support these requirements some other way.*/}
   table:nth-of-type(1) tbody tr:nth-of-type(1),
   table:nth-of-type(1) tbody tr:nth-of-type(5),
   table:nth-of-type(1) tbody tr:nth-of-type(9),
-  table:nth-of-type(1) tbody tr:nth-of-type(18),
-  table:nth-of-type(1) tbody tr:nth-of-type(22),
-  table:nth-of-type(1) tbody tr:nth-of-type(26),
+  table:nth-of-type(1) tbody tr:nth-of-type(17),
+  table:nth-of-type(1) tbody tr:nth-of-type(21),
+  table:nth-of-type(1) tbody tr:nth-of-type(24),
   table:nth-of-type(2) tbody tr:nth-of-type(1),
   table:nth-of-type(2) tbody tr:nth-of-type(7),
   table:nth-of-type(2) tbody tr:nth-of-type(9),
@@ -71,11 +71,7 @@ include:
 
 ## Teleport Agentic Identity Framework
 
-The **Teleport Agentic Identity Framework** secures AI agents and the AI/ML
-infrastructure they access. It combines cryptographic agent identity, ephemeral
-runtime isolation through [Beams](https://www.beams.run/), Model Context
-Protocol (MCP) server protection, and behavioral monitoring across the Teleport
-platform.
+The **Teleport Agentic Identity Framework** combines Teleport identity, access, governance, and monitoring capabilities to secure AI agents and the infrastructure they access. It includes cryptographic agent identity, ephemeral runtime isolation through [Beams](https://www.beams.run/), Model Context Protocol (MCP) server protection, and behavioral monitoring across the Teleport platform.
 
 |  | **Enterprise (Cloud)** <div style={{ marginTop: 'var(--m-0-5)' }}><Button style={{ padding: '0 var(--m-1-5)', height: '2rem' }} as="link" href="https://goteleport.com/signup" target="_blank">Try for free</Button></div> | **Enterprise (Self-Hosted)** | **Community Edition** |
 |---|:---:|:---:|:---:|
@@ -83,28 +79,26 @@ platform.
 | Per-agent cryptographic certificates | ✔ | ✔ | ✖ |
 | Agent-to-owner identity linkage | ✔ | ✔ | ✖ |
 | Short-lived agent credentials with no standing privileges | ✔ | ✔ | ✖ |
-|**MCP server access.** Treat Model Context Protocol servers as first-class Teleport Protected Resources:||||
+|**MCP server access.** Treat Model Context Protocol servers as first-class protected resources in Teleport:||||
 | [MCP server enrollment and proxying](./enroll-resources/mcp-access/mcp-access.mdx) | ✔ | ✔ | ✔ |
 | Identity-based access control for MCP traffic | ✔ | ✔ | ✔ |
 | Per-tool audit events for MCP requests | ✔ | ✔ | ✔ |
-|**Trusted agent runtimes ([Beams](https://www.beams.run/), beta).** Run each agent session in an isolated Firecracker VM with built-in identity, no static secrets, and a full audit trail:||||
-| Ephemeral Firecracker VM per agent session, ~2-second startup | ✔ | ✖ | ✖ |
-| Short-lived identity certificate injected into the runtime at startup | ✔ | ✖ | ✖ |
-| VNet-tunneled egress with no static secrets in the runtime | ✔ | ✖ | ✖ |
+|**Trusted runtimes ([Beams](https://www.beams.run/), beta).** Run each agent session in an isolated Firecracker VM with built-in identity, no static secrets, and a full audit trail:||||
+| Ephemeral Firecracker per agent session, ~2-second startup | ✔ | ✖ | ✖ |
+| Short-lived identity certificates injected at startup with no static secrets | ✔ | ✖ | ✖ |
 | Ephemeral storage wiped on session end | ✔ | ✖ | ✖ |
-| Built-in inference endpoints (OpenAI, Anthropic) with bring-your-own option | ✔ | ✖ | ✖ |
-| Policy-controlled allowlist for external API egress | ✔ | ✖ | ✖ |
+| Built-in inference endpoints (OpenAI, Anthropic) with support for custom model providers | ✔ | ✖ | ✖ |
+| VNet-tunneled egress and policy-controlled allowlist for external API egress | ✔ | ✖ | ✖ |
 | Per-user caps on beam count and shared inference usage | ✔ | ✖ | ✖ |
-| Session-bound beam lifecycle (expires with user session, ~24 hours) | ✔ | ✖ | ✖ |
+| Beam lifecycle tied to the user session (~24-hour maximum) | ✔ | ✖ | ✖ |
 |**Agent enforcement.** Stop or constrain agent activity inline when policy is violated:||||
 | [Session and identity locks](identity-governance/locking.mdx) | Available in Teleport Identity Governance | Available in Teleport Identity Governance | ✖ |
 | [Device Trust](zero-trust-access/device-trust/guide.mdx) for the human operator behind an agent | ✔ | ✔ | ✖ |
 | [Per-Session MFA](zero-trust-access/authentication/per-session-mfa.mdx) for sensitive agent actions | ✔ | ✔ | ✔ |
 |**Agent behavior monitoring.** Detect anomalies in agent and human-plus-agent activity:||||
 | Identity threat patterns and anomaly surfacing | Available in Teleport Identity Security | Available in Teleport Identity Security | ✖ |
-| [Session recording and replay](./reference/architecture/session-recording.mdx) for agent sessions | ✔ | ✔ | ✔ |
-| [Session Recording Summaries](identity-security/session-summaries.mdx) | Available in Teleport Identity Security | Available in Teleport Identity Security | ✖ |
-|**AI/ML infrastructure protection.** Apply identity-based access control to systems agents and humans use to build, train, and serve models:||||
+| [Session recording](./reference/architecture/session-recording.mdx) for agent sessions | ✔ | ✔ | ✔ |
+|**AI infrastructure protection.** Apply identity-based access control to the systems that agents and humans use to build, train, and serve models:||||
 | Access control for model weights and training data stores ([applications](./enroll-resources/application-access/getting-started.mdx), [databases](./enroll-resources/database-access/getting-started.mdx)) | ✔ | ✔ | ✔ |
 | Access control for GPU clusters ([Linux servers](./enroll-resources/server-access/getting-started.mdx), [Kubernetes](./enroll-resources/kubernetes-access/getting-started.mdx)) | ✔ | ✔ | ✔ |
 | Access control for model registries and inference endpoints (applications, MCP servers) | ✔ | ✔ | ✔ |

--- a/docs/pages/feature-matrix.mdx
+++ b/docs/pages/feature-matrix.mdx
@@ -21,15 +21,21 @@ HTML tag until we can support these requirements some other way.*/}
     to update this list whenever we change the organization of the tables.
   */
   table:nth-of-type(1) tbody tr:nth-of-type(1),
-  table:nth-of-type(1) tbody tr:nth-of-type(7),
+  table:nth-of-type(1) tbody tr:nth-of-type(5),
   table:nth-of-type(1) tbody tr:nth-of-type(9),
-  table:nth-of-type(1) tbody tr:nth-of-type(16),
-  table:nth-of-type(1) tbody tr:nth-of-type(19),
-  table:nth-of-type(1) tbody tr:nth-of-type(27),
-  table:nth-of-type(1) tbody tr:nth-of-type(30),
-  table:nth-of-type(5) tbody tr:nth-of-type(1),
-  table:nth-of-type(5) tbody tr:nth-of-type(9),
-  table:nth-of-type(5) tbody tr:nth-of-type(19)
+  table:nth-of-type(1) tbody tr:nth-of-type(18),
+  table:nth-of-type(1) tbody tr:nth-of-type(22),
+  table:nth-of-type(1) tbody tr:nth-of-type(26),
+  table:nth-of-type(2) tbody tr:nth-of-type(1),
+  table:nth-of-type(2) tbody tr:nth-of-type(7),
+  table:nth-of-type(2) tbody tr:nth-of-type(9),
+  table:nth-of-type(2) tbody tr:nth-of-type(16),
+  table:nth-of-type(2) tbody tr:nth-of-type(19),
+  table:nth-of-type(2) tbody tr:nth-of-type(27),
+  table:nth-of-type(2) tbody tr:nth-of-type(30),
+  table:nth-of-type(6) tbody tr:nth-of-type(1),
+  table:nth-of-type(6) tbody tr:nth-of-type(9),
+  table:nth-of-type(6) tbody tr:nth-of-type(19)
   {
     background: #dddddd;
   }
@@ -57,10 +63,51 @@ The **Teleport Identity Infrastructure Platform** modernizes identity, access,
 and policy for infrastructure, for both human and non-human identities. Products
 include:
 
+- [Teleport Agentic Identity Framework](#teleport-agentic-identity-framework)
 - [Teleport Zero Trust Access](#teleport-zero-trust-access)
 - [Teleport Machine & Workload Identity](#teleport-machine--workload-identity)
 - [Teleport Identity Governance](#teleport-identity-governance)
 - [Teleport Identity Security](#teleport-identity-security)
+
+## Teleport Agentic Identity Framework
+
+The **Teleport Agentic Identity Framework** secures AI agents and the AI/ML
+infrastructure they access. It combines cryptographic agent identity, ephemeral
+runtime isolation through [Beams](https://www.beams.run/), Model Context
+Protocol (MCP) server protection, and behavioral monitoring across the Teleport
+platform.
+
+|  | **Enterprise (Cloud)** <div style={{ marginTop: 'var(--m-0-5)' }}><Button style={{ padding: '0 var(--m-1-5)', height: '2rem' }} as="link" href="https://goteleport.com/signup" target="_blank">Try for free</Button></div> | **Enterprise (Self-Hosted)** | **Community Edition** |
+|---|:---:|:---:|:---:|
+|**Agent identity.** Issue cryptographic identities to AI agents:||||
+| Per-agent cryptographic certificates | ✔ | ✔ | ✖ |
+| Agent-to-owner identity linkage | ✔ | ✔ | ✖ |
+| Short-lived agent credentials with no standing privileges | ✔ | ✔ | ✖ |
+|**MCP server access.** Treat Model Context Protocol servers as first-class Teleport Protected Resources:||||
+| [MCP server enrollment and proxying](./enroll-resources/mcp-access/mcp-access.mdx) | ✔ | ✔ | ✔ |
+| Identity-based access control for MCP traffic | ✔ | ✔ | ✔ |
+| Per-tool audit events for MCP requests | ✔ | ✔ | ✔ |
+|**Trusted agent runtimes ([Beams](https://www.beams.run/), beta).** Run each agent session in an isolated Firecracker VM with built-in identity, no static secrets, and a full audit trail:||||
+| Ephemeral Firecracker VM per agent session, ~2-second startup | ✔ | ✖ | ✖ |
+| Short-lived identity certificate injected into the runtime at startup | ✔ | ✖ | ✖ |
+| VNet-tunneled egress with no static secrets in the runtime | ✔ | ✖ | ✖ |
+| Ephemeral storage wiped on session end | ✔ | ✖ | ✖ |
+| Built-in inference endpoints (OpenAI, Anthropic) with bring-your-own option | ✔ | ✖ | ✖ |
+| Policy-controlled allowlist for external API egress | ✔ | ✖ | ✖ |
+| Per-user caps on beam count and shared inference usage | ✔ | ✖ | ✖ |
+| Session-bound beam lifecycle (expires with user session, ~24 hours) | ✔ | ✖ | ✖ |
+|**Agent enforcement.** Stop or constrain agent activity inline when policy is violated:||||
+| [Session and identity locks](identity-governance/locking.mdx) | Available in Teleport Identity Governance | Available in Teleport Identity Governance | ✖ |
+| [Device Trust](zero-trust-access/device-trust/guide.mdx) for the human operator behind an agent | ✔ | ✔ | ✖ |
+| [Per-Session MFA](zero-trust-access/authentication/per-session-mfa.mdx) for sensitive agent actions | ✔ | ✔ | ✔ |
+|**Agent behavior monitoring.** Detect anomalies in agent and human-plus-agent activity:||||
+| Identity threat patterns and anomaly surfacing | Available in Teleport Identity Security | Available in Teleport Identity Security | ✖ |
+| [Session recording and replay](./reference/architecture/session-recording.mdx) for agent sessions | ✔ | ✔ | ✔ |
+| [Session Recording Summaries](identity-security/session-summaries.mdx) | Available in Teleport Identity Security | Available in Teleport Identity Security | ✖ |
+|**AI/ML infrastructure protection.** Apply identity-based access control to systems agents and humans use to build, train, and serve models:||||
+| Access control for model weights and training data stores ([applications](./enroll-resources/application-access/getting-started.mdx), [databases](./enroll-resources/database-access/getting-started.mdx)) | ✔ | ✔ | ✔ |
+| Access control for GPU clusters ([Linux servers](./enroll-resources/server-access/getting-started.mdx), [Kubernetes](./enroll-resources/kubernetes-access/getting-started.mdx)) | ✔ | ✔ | ✔ |
+| Access control for model registries and inference endpoints (applications, MCP servers) | ✔ | ✔ | ✔ |
 
 ## Teleport Zero Trust Access
 
@@ -181,4 +228,3 @@ and non-human identities.
 | Self-hosted deployment| ✖ | ✔ | ✔ |
 | Multi-Region High Availability | ✔ (Teleport service) | ✔ (Customer-implemented, via a [supported blueprint](installation/self-hosted/deployments/multi-region-blueprint.mdx)) | ✖ |
 | FIPS-compliant binaries available for FedRAMP, including Low, Moderate & High | ✖ | ✔ | ✖ |
-

--- a/docs/pages/feature-matrix.mdx
+++ b/docs/pages/feature-matrix.mdx
@@ -23,9 +23,9 @@ HTML tag until we can support these requirements some other way.*/}
   table:nth-of-type(1) tbody tr:nth-of-type(1),
   table:nth-of-type(1) tbody tr:nth-of-type(5),
   table:nth-of-type(1) tbody tr:nth-of-type(9),
-  table:nth-of-type(1) tbody tr:nth-of-type(17),
-  table:nth-of-type(1) tbody tr:nth-of-type(21),
-  table:nth-of-type(1) tbody tr:nth-of-type(24),
+  table:nth-of-type(1) tbody tr:nth-of-type(16),
+  table:nth-of-type(1) tbody tr:nth-of-type(20),
+  table:nth-of-type(1) tbody tr:nth-of-type(23),
   table:nth-of-type(2) tbody tr:nth-of-type(1),
   table:nth-of-type(2) tbody tr:nth-of-type(7),
   table:nth-of-type(2) tbody tr:nth-of-type(9),
@@ -71,7 +71,7 @@ include:
 
 ## Teleport Agentic Identity Framework
 
-The **Teleport Agentic Identity Framework** combines Teleport identity, access, governance, and monitoring capabilities to secure AI agents and the infrastructure they access. It includes cryptographic agent identity, ephemeral runtime isolation through [Beams](https://www.beams.run/), Model Context Protocol (MCP) server protection, and behavioral monitoring across the Teleport platform.
+The **Teleport Agentic Identity Framework** combines Teleport identity, access, governance, and monitoring capabilities to secure AI agents and the infrastructure they access. It brings together cryptographic agent identity, ephemeral runtime isolation through [Beams](https://www.beams.run/), Model Context Protocol (MCP) server protection, and behavioral monitoring across the Teleport platform.
 
 |  | **Enterprise (Cloud)** <div style={{ marginTop: 'var(--m-0-5)' }}><Button style={{ padding: '0 var(--m-1-5)', height: '2rem' }} as="link" href="https://goteleport.com/signup" target="_blank">Try for free</Button></div> | **Enterprise (Self-Hosted)** | **Community Edition** |
 |---|:---:|:---:|:---:|
@@ -83,14 +83,13 @@ The **Teleport Agentic Identity Framework** combines Teleport identity, access, 
 | [MCP server enrollment and proxying](./enroll-resources/mcp-access/mcp-access.mdx) | ✔ | ✔ | ✔ |
 | Identity-based access control for MCP traffic | ✔ | ✔ | ✔ |
 | Per-tool audit events for MCP requests | ✔ | ✔ | ✔ |
-|**Trusted runtimes ([Beams](https://www.beams.run/), beta).** Run each agent session in an isolated Firecracker VM with built-in identity, no static secrets, and a full audit trail:||||
-| Ephemeral Firecracker per agent session, ~2-second startup | ✔ | ✖ | ✖ |
-| Short-lived identity certificates injected at startup with no static secrets | ✔ | ✖ | ✖ |
-| Ephemeral storage wiped on session end | ✔ | ✖ | ✖ |
-| Built-in inference endpoints (OpenAI, Anthropic) with support for custom model providers | ✔ | ✖ | ✖ |
-| VNet-tunneled egress and policy-controlled allowlist for external API egress | ✔ | ✖ | ✖ |
-| Per-user caps on beam count and shared inference usage | ✔ | ✖ | ✖ |
-| Beam lifecycle tied to the user session (~24-hour maximum) | ✔ | ✖ | ✖ |
+|**Trusted runtimes ([Beams](https://www.beams.run/), beta).** Run agent sessions in isolated, ephemeral runtimes with built-in identity, controlled egress, and full audit:||||
+| Sandboxed agent runtime with ephemeral storage and short-lived injected identity | ✔ | ✖ | ✖ |
+| Launch and manage beams via `tsh` and an MCP server | ✔ | ✖ | ✖ |
+| Built-in inference proxy with bundled providers (OpenAI, Anthropic) and bring-your-own option | ✔ | ✖ | ✖ |
+| Policy-controlled allowlist for external API egress | ✔ | ✖ | ✖ |
+| Per-user limits on concurrent beams and shared inference usage | ✔ | ✖ | ✖ |
+| Session-bound beam lifecycle with full audit trail | ✔ | ✖ | ✖ |
 |**Agent enforcement.** Stop or constrain agent activity inline when policy is violated:||||
 | [Session and identity locks](identity-governance/locking.mdx) | Available in Teleport Identity Governance | Available in Teleport Identity Governance | ✖ |
 | [Device Trust](zero-trust-access/device-trust/guide.mdx) for the human operator behind an agent | ✔ | ✔ | ✖ |


### PR DESCRIPTION
This resolves https://github.com/gravitational/teleport/issues/66501, adding a new  Agentic Identity Framework section to the feature matrix

[Worked with Marketing](https://docs.google.com/document/d/1ai4qb27dg5eWt5AiI6AcIUIkquA4RdWUQCa6TBHZMn8/) in GDocs; they've updated and signed off on the content- this PR is now ready for engineering/technical review.



