### PR TITLE
feat: added db vnet access to be embedded in tbot

### DIFF
--- a/lib/tbot/services/beams/vnet_service.go
+++ b/lib/tbot/services/beams/vnet_service.go
@@ -537,9 +537,6 @@ func (v *vnetApplicationService) GetDBCert(ctx context.Context, dbInfo *vnetv1.D
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	if id.TLSCert == nil || len(id.TLSCert.Certificate) == 0 {
-		return nil, trace.Errorf("identity generator returned no TLS certificate for database %q", dbInfo.GetDatabaseKey().GetName())
-	}
 	return id.TLSCert, nil
 }
 
@@ -547,12 +544,6 @@ func (v *vnetApplicationService) GetDBCert(ctx context.Context, dbInfo *vnetv1.D
 // across all VNet-issued database certificates in this service.
 func (v *vnetApplicationService) GetDBSigner(context.Context, *vnetv1.DatabaseKey) (crypto.Signer, error) {
 	return v.privateKey, nil
-}
-
-// OnNewDBConnection is invoked for each new VNet database connection. tbot
-// has no per-connection observability hook today, so this is a no-op.
-func (v *vnetApplicationService) OnNewDBConnection(context.Context, *vnetv1.DatabaseKey) error {
-	return nil
 }
 
 func isDescendantSubdomain(fqdn, zone string) bool {

--- a/lib/tbot/services/beams/vnet_service.go
+++ b/lib/tbot/services/beams/vnet_service.go
@@ -484,16 +484,13 @@ func (v *vnetApplicationService) resolveDatabaseFQDN(
 	}
 
 	log := v.logger.With("fqdn", fqdn, "identifier", identifier)
-	rsp, err := client.GetResourcePage[types.DatabaseServer](ctx, v.client, &proto.ListResourcesRequest{
-		ResourceType:        types.KindDatabaseServer,
-		PredicateExpression: db.MatchExpr(identifier),
-	})
+	servers, err := db.ListServers(ctx, v.client, identifier)
 	if err != nil {
 		log.ErrorContext(ctx, "Failed to list database servers", "error", err)
 		return nil, trace.Wrap(err, "listing database servers")
 	}
 
-	dbResource, ok := db.PickMatch(ctx, log, identifier, rsp.Resources)
+	dbResource, ok := db.PickMatch(ctx, log, identifier, servers)
 	if !ok {
 		return nil, errNoDBMatch
 	}

--- a/lib/tbot/services/beams/vnet_service.go
+++ b/lib/tbot/services/beams/vnet_service.go
@@ -492,10 +492,6 @@ func (v *vnetApplicationService) resolveDatabaseFQDN(
 		log.ErrorContext(ctx, "Failed to list database servers", "error", err)
 		return nil, trace.Wrap(err, "listing database servers")
 	}
-	if len(rsp.Resources) == 0 {
-		log.DebugContext(ctx, "No matching database servers for FQDN")
-		return nil, errNoDBMatch
-	}
 
 	dbResource, ok := db.PickMatch(ctx, log, identifier, rsp.Resources)
 	if !ok {

--- a/lib/tbot/services/beams/vnet_service.go
+++ b/lib/tbot/services/beams/vnet_service.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"crypto"
 	"crypto/tls"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net"
@@ -44,6 +45,7 @@ import (
 	"github.com/gravitational/teleport/lib/tbot/services/clientcredentials"
 	"github.com/gravitational/teleport/lib/utils"
 	"github.com/gravitational/teleport/lib/vnet"
+	"github.com/gravitational/teleport/lib/vnet/db"
 	"github.com/gravitational/teleport/lib/vnet/dns"
 )
 
@@ -283,6 +285,37 @@ type vnetOSConfiguration struct {
 	config *vnetv1.TargetOSConfiguration
 }
 
+// clusterAccess captures the per-cluster bits shared by AppInfo and
+// DatabaseInfo
+type clusterAccess struct {
+	profile     string
+	cluster     string
+	ipv4CIDR    string
+	dialOptions *vnetv1.DialOptions
+}
+
+func (v *vnetApplicationService) clusterAccess(osConfig *vnetOSConfiguration) (clusterAccess, error) {
+	cidrs := osConfig.config.GetIpv4CidrRanges()
+	if len(cidrs) == 0 {
+		return clusterAccess{}, trace.BadParameter("no ipv4 cidr ranges configured for VNet")
+	}
+	proxyAddr := osConfig.pong.GetProxyPublicAddr()
+	return clusterAccess{
+		profile:  proxyAddr,
+		cluster:  osConfig.pong.GetClusterName(),
+		ipv4CIDR: cidrs[0],
+		dialOptions: &vnetv1.DialOptions{
+			WebProxyAddr: proxyAddr,
+			// ALPN Upgrade is not required in Teleport Cloud. We might need
+			// to reevaluate this if we support Beams on-premise (or not? we
+			// could just draw a hard line and require sensible proxy
+			// configuration).
+			AlpnConnUpgradeRequired: false,
+			InsecureSkipVerify:      v.insecure,
+		},
+	}, nil
+}
+
 func (v *vnetApplicationService) ResolveFQDN(ctx context.Context, fqdn string) (*vnetv1.ResolveFQDNResponse, error) {
 	osConfig, err := v.getOSConfiguration(ctx)
 	if err != nil {
@@ -310,6 +343,17 @@ func (v *vnetApplicationService) ResolveFQDN(ctx context.Context, fqdn string) (
 			"dns_zones", osConfig.config.GetDnsZones(),
 		)
 		return &vnetv1.ResolveFQDNResponse{}, nil
+	}
+
+	// Try DB resolution first. The DB FQDN form (<identifier>.db.<zone>) is
+	// more specific than the app public_addr space. If the DB FQDN is not
+	// parseable, errNoDBMatch is returned and we fall through to app resolution below.
+	dbResp, err := v.resolveDatabaseFQDN(ctx, fqdn, osConfig)
+	switch {
+	case err == nil:
+		return dbResp, nil
+	case !errors.Is(err, errNoDBMatch):
+		return nil, trace.Wrap(err)
 	}
 
 	expr := fmt.Sprintf(
@@ -377,29 +421,25 @@ func (v *vnetApplicationService) ResolveFQDN(ctx context.Context, fqdn string) (
 	//
 	// TODO(boxofrad): Replace this with HTTPS-in-mTLS once RFD 0035e is approved
 	// and implemented.
-	proxyAddr := osConfig.pong.GetProxyPublicAddr()
+	ca, err := v.clusterAccess(osConfig)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	appInfo := &vnetv1.AppInfo{
+		AppKey: &vnetv1.AppKey{
+			Profile: ca.profile,
+			Name:    app.GetName(),
+		},
+		App:           app,
+		Ipv4CidrRange: ca.ipv4CIDR,
+		Cluster:       ca.cluster,
+		DialOptions:   ca.dialOptions,
+	}
+
 	return &vnetv1.ResolveFQDNResponse{
 		Match: &vnetv1.ResolveFQDNResponse_MatchedTcpApp{
 			MatchedTcpApp: &vnetv1.MatchedTCPApp{
-				AppInfo: &vnetv1.AppInfo{
-					AppKey: &vnetv1.AppKey{
-						Profile: proxyAddr,
-						Name:    app.GetName(),
-					},
-					App:           app,
-					Ipv4CidrRange: osConfig.config.GetIpv4CidrRanges()[0],
-					Cluster:       osConfig.pong.GetClusterName(),
-					DialOptions: &vnetv1.DialOptions{
-						WebProxyAddr: proxyAddr,
-
-						// ALPN Upgrade is not required in Teleport Cloud we
-						// might need to reevaluate this if we support Beams
-						// on-premise (or not? we could just draw a hard line
-						// and require sensible proxy configuration).
-						AlpnConnUpgradeRequired: false,
-						InsecureSkipVerify:      v.insecure,
-					},
-				},
+				AppInfo: appInfo,
 			},
 		},
 	}, nil
@@ -422,6 +462,97 @@ func (v *vnetApplicationService) GetAppCert(ctx context.Context, key *vnetv1.App
 // GetAppSigner returns the private key for the given application's TLS certificate.
 func (v *vnetApplicationService) GetAppSigner(context.Context, *vnetv1.AppKey, uint16) (crypto.Signer, error) {
 	return v.privateKey, nil
+}
+
+// errNoDBMatch signals that the DB sub-resolver did not match the queried
+// FQDN, and ResolveFQDN should fall through to app resolution.
+var errNoDBMatch = errors.New("no DB match for queried FQDN")
+
+// resolveDatabaseFQDN attempts to resolve fqdn as a VNet database FQDN of the
+// form <identifier>.db.<zone>. Returns errNoDBMatch when fqdn is not DB-shaped,
+// no databases match the parsed identifier, or the matched database's protocol
+// isn't supported by VNet — so the caller can fall through to app resolution.
+func (v *vnetApplicationService) resolveDatabaseFQDN(
+	ctx context.Context,
+	fqdn string,
+	osConfig *vnetOSConfiguration,
+) (*vnetv1.ResolveFQDNResponse, error) {
+	proxyHost := hostname(osConfig.pong.GetProxyPublicAddr())
+	identifier, ok := db.Parse(fqdn, proxyHost)
+	if !ok {
+		return nil, errNoDBMatch
+	}
+
+	log := v.logger.With("fqdn", fqdn, "identifier", identifier)
+	rsp, err := client.GetResourcePage[types.DatabaseServer](ctx, v.client, &proto.ListResourcesRequest{
+		ResourceType:        types.KindDatabaseServer,
+		PredicateExpression: db.MatchExpr(identifier),
+	})
+	if err != nil {
+		log.ErrorContext(ctx, "Failed to list database servers", "error", err)
+		return nil, trace.Wrap(err, "listing database servers")
+	}
+	if len(rsp.Resources) == 0 {
+		log.DebugContext(ctx, "No matching database servers for FQDN")
+		return nil, errNoDBMatch
+	}
+
+	dbResource, ok := db.PickMatch(ctx, log, identifier, rsp.Resources)
+	if !ok {
+		return nil, errNoDBMatch
+	}
+
+	ca, err := v.clusterAccess(osConfig)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return &vnetv1.ResolveFQDNResponse{
+		Match: &vnetv1.ResolveFQDNResponse_MatchedDatabase{
+			MatchedDatabase: &vnetv1.MatchedDatabase{
+				DatabaseInfo: &vnetv1.DatabaseInfo{
+					DatabaseKey: &vnetv1.DatabaseKey{
+						Profile: ca.profile,
+						Name:    dbResource.GetName(),
+					},
+					Cluster:       ca.cluster,
+					Protocol:      dbResource.GetProtocol(),
+					Ipv4CidrRange: ca.ipv4CIDR,
+					DialOptions:   ca.dialOptions,
+				},
+			},
+		},
+	}, nil
+}
+
+// GetDBCert issues a TLS certificate for the given database via tbot's
+// identity generator, using the bot-bound private key and the configured
+// delegation session.
+func (v *vnetApplicationService) GetDBCert(ctx context.Context, dbInfo *vnetv1.DatabaseInfo) (*tls.Certificate, error) {
+	id, err := v.identityGenerator.Generate(ctx,
+		identity.WithPrivateKey(v.privateKey),
+		identity.WithRouteToDatabase(*vnet.RouteToDatabase(dbInfo)),
+		identity.WithLifetime(v.credentialLifetime.TTL, v.credentialLifetime.RenewalInterval),
+		identity.WithDelegation(v.delegationSessionID),
+	)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	if id.TLSCert == nil || len(id.TLSCert.Certificate) == 0 {
+		return nil, trace.Errorf("identity generator returned no TLS certificate for database %q", dbInfo.GetDatabaseKey().GetName())
+	}
+	return id.TLSCert, nil
+}
+
+// GetDBSigner returns the bot-bound private key. The same key is shared
+// across all VNet-issued database certificates in this service.
+func (v *vnetApplicationService) GetDBSigner(context.Context, *vnetv1.DatabaseKey) (crypto.Signer, error) {
+	return v.privateKey, nil
+}
+
+// OnNewDBConnection is invoked for each new VNet database connection. tbot
+// has no per-connection observability hook today, so this is a no-op.
+func (v *vnetApplicationService) OnNewDBConnection(context.Context, *vnetv1.DatabaseKey) error {
+	return nil
 }
 
 func isDescendantSubdomain(fqdn, zone string) bool {

--- a/lib/tbot/services/beams/vnet_service_test.go
+++ b/lib/tbot/services/beams/vnet_service_test.go
@@ -19,6 +19,7 @@ package beams_test
 import (
 	"context"
 	"crypto/tls"
+	"fmt"
 	"io"
 	"log/slog"
 	"net"
@@ -30,6 +31,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/types/known/durationpb"
 
@@ -41,12 +43,15 @@ import (
 	vnetv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/vnet/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/utils/keys"
+	"github.com/gravitational/teleport/integration/helpers"
 	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/auth/storage"
 	"github.com/gravitational/teleport/lib/cryptosuites"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/service"
 	"github.com/gravitational/teleport/lib/service/servicecfg"
+	"github.com/gravitational/teleport/lib/srv/db/common"
+	"github.com/gravitational/teleport/lib/srv/db/postgres"
 	"github.com/gravitational/teleport/lib/tbot/bot"
 	"github.com/gravitational/teleport/lib/tbot/bot/connection"
 	"github.com/gravitational/teleport/lib/tbot/bot/onboarding"
@@ -156,24 +161,27 @@ func TestVNetService(t *testing.T) {
 	user, err = rootClient.CreateUser(t.Context(), user)
 	require.NoError(t, err)
 
-	// Register a db_server so VNet has something to resolve for DB FQDNs.
-	const dbName = "mypostgres"
-	dbServer, err := types.NewDatabaseServerV3(types.Metadata{
-		Name: dbName,
-	}, types.DatabaseServerSpecV3{
-		HostID:   "test-db-host",
-		Hostname: "test-db-host",
-		Database: &types.DatabaseV3{
-			Metadata: types.Metadata{Name: dbName},
-			Spec: types.DatabaseSpecV3{
-				Protocol: defaults.ProtocolPostgres,
-				URI:      "localhost:5432",
-			},
-		},
+	const (
+		dbName = "mypostgres"
+		dbUser = "testUser"
+		dbDB   = "mydb"
+	)
+	pts, err := postgres.NewTestServer(common.TestServerConfig{
+		AuthClient: rootClient,
+		Users:      []string{dbUser},
 	})
 	require.NoError(t, err)
-	_, err = rootClient.UpsertDatabaseServer(t.Context(), dbServer)
-	require.NoError(t, err)
+	go func() {
+		t.Logf("Postgres Fake server running at %s port", pts.Port())
+		require.NoError(t, pts.Serve())
+	}()
+	t.Cleanup(func() { pts.Close() })
+
+	helpers.MakeTestDatabaseServer(t, *proxyAddr, testenv.StaticToken, nil, servicecfg.Database{
+		Name:     dbName,
+		URI:      net.JoinHostPort("localhost", pts.Port()),
+		Protocol: "postgres",
+	})
 
 	// Create a delegation session for the user.
 	aliceClient := makeUserClient(t, process, rootClient, user.GetName())
@@ -262,6 +270,19 @@ func TestVNetService(t *testing.T) {
 	require.Len(t, ips, 1)
 	require.False(t, ips[0].Equal(upstreamResolvedIP),
 		"VNet should resolve %s to a synthetic IP, got upstream IP", dbFQDN)
+
+	pgCfg, err := pgconn.ParseConfig(fmt.Sprintf(
+		"postgres://%s@%s:5432/%s?sslmode=disable", dbUser, dbFQDN, dbDB,
+	))
+	require.NoError(t, err)
+	pgCfg.DialFunc = hostNetwork.ResolveAndDial
+	pgCfg.LookupFunc = hostNetwork.DNSResolver().LookupHost
+	pgConn, err := pgconn.ConnectConfig(t.Context(), pgCfg)
+	require.NoError(t, err)
+	defer pgConn.Close(t.Context())
+	result := pgConn.ExecParams(t.Context(), "SELECT 1", nil, nil, nil, nil).Read()
+	require.NoError(t, result.Err)
+	require.Len(t, result.Rows, 1)
 
 	cancel()
 	require.NoError(t, <-errCh)

--- a/lib/tbot/services/beams/vnet_service_test.go
+++ b/lib/tbot/services/beams/vnet_service_test.go
@@ -136,11 +136,16 @@ func TestVNetService(t *testing.T) {
 	user, err := types.NewUser("alice")
 	require.NoError(t, err)
 
-	role, err := types.NewRole("app-access", types.RoleSpecV6{
+	role, err := types.NewRole("vnet-access", types.RoleSpecV6{
 		Allow: types.RoleConditions{
 			AppLabels: types.Labels{
 				"*": {"*"},
 			},
+			DatabaseLabels: types.Labels{
+				"*": {"*"},
+			},
+			DatabaseUsers: []string{types.Wildcard},
+			DatabaseNames: []string{types.Wildcard},
 		},
 	})
 	require.NoError(t, err)
@@ -149,6 +154,25 @@ func TestVNetService(t *testing.T) {
 
 	user.AddRole(role.GetName())
 	user, err = rootClient.CreateUser(t.Context(), user)
+	require.NoError(t, err)
+
+	// Register a db_server so VNet has something to resolve for DB FQDNs.
+	const dbName = "mypostgres"
+	dbServer, err := types.NewDatabaseServerV3(types.Metadata{
+		Name: dbName,
+	}, types.DatabaseServerSpecV3{
+		HostID:   "test-db-host",
+		Hostname: "test-db-host",
+		Database: &types.DatabaseV3{
+			Metadata: types.Metadata{Name: dbName},
+			Spec: types.DatabaseSpecV3{
+				Protocol: defaults.ProtocolPostgres,
+				URI:      "localhost:5432",
+			},
+		},
+	})
+	require.NoError(t, err)
+	_, err = rootClient.UpsertDatabaseServer(t.Context(), dbServer)
 	require.NoError(t, err)
 
 	// Create a delegation session for the user.
@@ -230,6 +254,14 @@ func TestVNetService(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, ips, 1)
 	require.True(t, ips[0].Equal(upstreamResolvedIP))
+
+	// db_server should resolve to a VNet-assigned address from the configured CIDR range.
+	dbFQDN := dbName + ".db.localhost"
+	ips, err = hostNetwork.DNSResolver().LookupIP(t.Context(), "ip4", dbFQDN)
+	require.NoError(t, err)
+	require.Len(t, ips, 1)
+	require.False(t, ips[0].Equal(upstreamResolvedIP),
+		"VNet should resolve %s to a synthetic IP, got upstream IP", dbFQDN)
 
 	cancel()
 	require.NoError(t, <-errCh)

--- a/lib/vnet/db/db.go
+++ b/lib/vnet/db/db.go
@@ -22,6 +22,10 @@ import (
 	"log/slog"
 	"strings"
 
+	"github.com/gravitational/trace"
+
+	apiclient "github.com/gravitational/teleport/api/client"
+	"github.com/gravitational/teleport/api/client/proto"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/vnet/dns"
@@ -63,6 +67,19 @@ func MatchExpr(identifier string) string {
 	return fmt.Sprintf(`resource.status.vnet_dns_name == %q || name == %q`, identifier, identifier)
 }
 
+// ListServers queries clt for db_servers matching the given VNet identifier
+// (status.vnet_dns_name or metadata.name).
+func ListServers(ctx context.Context, clt apiclient.GetResourcesClient, identifier string) ([]types.DatabaseServer, error) {
+	rsp, err := apiclient.GetResourcePage[types.DatabaseServer](ctx, clt, &proto.ListResourcesRequest{
+		ResourceType:        types.KindDatabaseServer,
+		PredicateExpression: MatchExpr(identifier),
+	})
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return rsp.Resources, nil
+}
+
 // IsUserOptional reports whether the database protocol's db_service extracts
 // the database username from the wire protocol
 func IsUserOptional(protocol string) bool {
@@ -83,6 +100,9 @@ func IsUserOptional(protocol string) bool {
 // identifier, and gates the chosen database on IsUserOptional.
 func PickMatch(ctx context.Context, log *slog.Logger, identifier string, servers []types.DatabaseServer) (types.Database, bool) {
 	if len(servers) == 0 {
+		log.DebugContext(ctx, "No matching database servers for VNet identifier",
+			"identifier", identifier,
+		)
 		return nil, false
 	}
 	databases := types.DatabaseServers(servers).ToDatabases()

--- a/lib/vnet/db/db.go
+++ b/lib/vnet/db/db.go
@@ -17,8 +17,12 @@
 package db
 
 import (
+	"context"
+	"fmt"
+	"log/slog"
 	"strings"
 
+	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/vnet/dns"
 )
@@ -34,9 +38,8 @@ func HasZoneSuffix(fqdn, zone string) bool {
 
 // Parse attempts to parse fqdn as a VNet database FQDN of the form
 // <identifier>.db.<zone>. and returns the parsed identifier with ok = true on
-// success.
-// The identifier is either the DNS-safe vnet_dns_name or the literal database
-// resource name
+// success. The identifier is either the DNS-safe vnet_dns_name or the literal
+// database resource name.
 func Parse(fqdn, zone string) (identifier string, ok bool) {
 	if !HasZoneSuffix(fqdn, zone) {
 		return "", false
@@ -52,6 +55,14 @@ func Parse(fqdn, zone string) (identifier string, ok bool) {
 	return prefix, true
 }
 
+// MatchExpr returns a ListResources predicate expression that matches
+// db_servers whose database resource has either status.vnet_dns_name (the
+// DNS-safe hash) or metadata.name equal to identifier. Both forms are
+// accepted so users can type whichever is more convenient.
+func MatchExpr(identifier string) string {
+	return fmt.Sprintf(`resource.status.vnet_dns_name == %q || name == %q`, identifier, identifier)
+}
+
 // IsUserOptional reports whether the database protocol's db_service extracts
 // the database username from the wire protocol
 func IsUserOptional(protocol string) bool {
@@ -64,4 +75,34 @@ func IsUserOptional(protocol string) bool {
 	default:
 		return false
 	}
+}
+
+// PickMatch chooses a single database from a list of db_servers returned by a
+// VNet identifier query. It dedupes db_servers that advertise the same
+// database, warns when multiple distinct databases share the same
+// identifier, and gates the chosen database on IsUserOptional.
+func PickMatch(ctx context.Context, log *slog.Logger, identifier string, servers []types.DatabaseServer) (types.Database, bool) {
+	if len(servers) == 0 {
+		return nil, false
+	}
+	databases := types.DatabaseServers(servers).ToDatabases()
+	if len(databases) > 1 {
+		matchedNames := make([]string, 0, len(databases))
+		for _, d := range databases {
+			matchedNames = append(matchedNames, d.GetName())
+		}
+		log.WarnContext(ctx, "VNet identifier matched multiple databases; picking the first one",
+			"identifier", identifier,
+			"matched_db_names", matchedNames,
+		)
+	}
+	chosen := databases[0]
+	if !IsUserOptional(chosen.GetProtocol()) {
+		log.InfoContext(ctx, "Database protocol not currently supported by VNet",
+			"db_name", chosen.GetName(),
+			"protocol", chosen.GetProtocol(),
+		)
+		return nil, false
+	}
+	return chosen, true
 }

--- a/lib/vnet/db/db_test.go
+++ b/lib/vnet/db/db_test.go
@@ -17,10 +17,13 @@
 package db_test
 
 import (
+	"context"
+	"log/slog"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/defaults"
 	dbvnet "github.com/gravitational/teleport/lib/srv/db/vnet"
 	"github.com/gravitational/teleport/lib/vnet/db"
@@ -107,6 +110,71 @@ func TestParse(t *testing.T) {
 			require.Equal(t, tt.wantIdentifier, got)
 		})
 	}
+}
+
+func TestPickMatch(t *testing.T) {
+	t.Parallel()
+
+	silent := slog.New(slog.DiscardHandler)
+	ctx := context.Background()
+
+	t.Run("empty servers returns no match", func(t *testing.T) {
+		got, ok := db.PickMatch(ctx, silent, "foo", nil)
+		require.False(t, ok)
+		require.Nil(t, got)
+	})
+
+	t.Run("single server with supported protocol", func(t *testing.T) {
+		got, ok := db.PickMatch(ctx, silent, "my-pg",
+			[]types.DatabaseServer{newServer(t, "my-pg", "agent-1", defaults.ProtocolPostgres)})
+		require.True(t, ok)
+		require.Equal(t, "my-pg", got.GetName())
+	})
+
+	t.Run("unsupported protocol returns no match", func(t *testing.T) {
+		got, ok := db.PickMatch(ctx, silent, "my-mongo",
+			[]types.DatabaseServer{newServer(t, "my-mongo", "agent-1", defaults.ProtocolMongoDB)})
+		require.False(t, ok)
+		require.Nil(t, got)
+	})
+
+	t.Run("HA db_servers for same database dedupe to one", func(t *testing.T) {
+		got, ok := db.PickMatch(ctx, silent, "my-pg", []types.DatabaseServer{
+			newServer(t, "my-pg", "agent-1", defaults.ProtocolPostgres),
+			newServer(t, "my-pg", "agent-2", defaults.ProtocolPostgres),
+		})
+		require.True(t, ok)
+		require.Equal(t, "my-pg", got.GetName())
+	})
+
+	t.Run("distinct databases with same identifier picks the first", func(t *testing.T) {
+		got, ok := db.PickMatch(ctx, silent, "shared-id", []types.DatabaseServer{
+			newServer(t, "db-a", "agent-1", defaults.ProtocolPostgres),
+			newServer(t, "db-b", "agent-1", defaults.ProtocolPostgres),
+		})
+		require.True(t, ok)
+		require.Equal(t, "db-a", got.GetName())
+	})
+}
+
+// newServer builds a minimal DatabaseServer suitable for PickMatch tests.
+func newServer(t *testing.T, dbName, agentName, protocol string) types.DatabaseServer {
+	t.Helper()
+	srv, err := types.NewDatabaseServerV3(types.Metadata{
+		Name: dbName,
+	}, types.DatabaseServerSpecV3{
+		HostID:   agentName,
+		Hostname: agentName,
+		Database: &types.DatabaseV3{
+			Metadata: types.Metadata{Name: dbName},
+			Spec: types.DatabaseSpecV3{
+				Protocol: protocol,
+				URI:      "localhost:5432",
+			},
+		},
+	})
+	require.NoError(t, err)
+	return srv
 }
 
 func TestIsUserOptional(t *testing.T) {

--- a/lib/vnet/embedded.go
+++ b/lib/vnet/embedded.go
@@ -81,10 +81,6 @@ type EmbeddedApplicationService interface {
 
 	// GetDBSigner returns the private key for the database certificate
 	GetDBSigner(ctx context.Context, dbKey *vnetv1.DatabaseKey) (crypto.Signer, error)
-
-	// OnNewDBConnection is called whenever a new database connection is
-	// established through VNet.
-	OnNewDBConnection(ctx context.Context, dbKey *vnetv1.DatabaseKey) error
 }
 
 // EmbeddedVNetHostConfig is passed to EmbeddedVNetConfig.ConfigureHost to
@@ -325,10 +321,7 @@ func (e *embeddedApplicationServiceClient) SignForDB(ctx context.Context, req *v
 	return &vnetv1.SignForDBResponse{Signature: sig}, nil
 }
 
-func (e *embeddedApplicationServiceClient) OnNewDBConnection(ctx context.Context, req *vnetv1.OnNewDBConnectionRequest, _ ...grpc.CallOption) (*vnetv1.OnNewDBConnectionResponse, error) {
-	if err := e.service.OnNewDBConnection(ctx, req.GetDatabaseKey()); err != nil {
-		return nil, trace.Wrap(err)
-	}
+func (*embeddedApplicationServiceClient) OnNewDBConnection(context.Context, *vnetv1.OnNewDBConnectionRequest, ...grpc.CallOption) (*vnetv1.OnNewDBConnectionResponse, error) {
 	return &vnetv1.OnNewDBConnectionResponse{}, nil
 }
 

--- a/lib/vnet/embedded.go
+++ b/lib/vnet/embedded.go
@@ -75,6 +75,16 @@ type EmbeddedApplicationService interface {
 
 	// GetAppSigner returns the private key for the given application's TLS certificate.
 	GetAppSigner(ctx context.Context, key *vnetv1.AppKey, port uint16) (crypto.Signer, error)
+
+	// GetDBCert issues a TLS certificate for the given database.
+	GetDBCert(ctx context.Context, dbInfo *vnetv1.DatabaseInfo) (*tls.Certificate, error)
+
+	// GetDBSigner returns the private key for the database certificate
+	GetDBSigner(ctx context.Context, dbKey *vnetv1.DatabaseKey) (crypto.Signer, error)
+
+	// OnNewDBConnection is called whenever a new database connection is
+	// established through VNet.
+	OnNewDBConnection(ctx context.Context, dbKey *vnetv1.DatabaseKey) error
 }
 
 // EmbeddedVNetHostConfig is passed to EmbeddedVNetConfig.ConfigureHost to
@@ -275,18 +285,6 @@ func (*embeddedApplicationServiceClient) SignForSSHSession(context.Context, *vne
 	return nil, trace.NotImplemented("SSH not supported in embedded VNet")
 }
 
-func (*embeddedApplicationServiceClient) ReissueDBCert(ctx context.Context, in *vnetv1.ReissueDBCertRequest, opts ...grpc.CallOption) (*vnetv1.ReissueDBCertResponse, error) {
-	return nil, trace.NotImplemented("databases not supported in embedded VNet")
-}
-
-func (*embeddedApplicationServiceClient) SignForDB(context.Context, *vnetv1.SignForDBRequest, ...grpc.CallOption) (*vnetv1.SignForDBResponse, error) {
-	return nil, trace.NotImplemented("databases not supported in embedded VNet")
-}
-
-func (*embeddedApplicationServiceClient) OnNewDBConnection(context.Context, *vnetv1.OnNewDBConnectionRequest, ...grpc.CallOption) (*vnetv1.OnNewDBConnectionResponse, error) {
-	return nil, trace.NotImplemented("databases not supported in embedded VNet")
-}
-
 func (*embeddedApplicationServiceClient) ExchangeSSHKeys(context.Context, *vnetv1.ExchangeSSHKeysRequest, ...grpc.CallOption) (*vnetv1.ExchangeSSHKeysResponse, error) {
 	// EmbeddedVNet does not yet support SSH, but we must return a valid public
 	// key so that the SSH setup code doesn't return an error.
@@ -305,6 +303,33 @@ func (*embeddedApplicationServiceClient) ExchangeSSHKeys(context.Context, *vnetv
 
 func (*embeddedApplicationServiceClient) PerformSessionMFACeremony(context.Context, *vnetv1.PerformSessionMFACeremonyRequest, ...grpc.CallOption) (*vnetv1.PerformSessionMFACeremonyResponse, error) {
 	return nil, trace.NotImplemented("MFA ceremonies not supported in embedded VNet")
+}
+
+func (e *embeddedApplicationServiceClient) ReissueDBCert(ctx context.Context, req *vnetv1.ReissueDBCertRequest, _ ...grpc.CallOption) (*vnetv1.ReissueDBCertResponse, error) {
+	cert, err := e.service.GetDBCert(ctx, req.GetDatabaseInfo())
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return &vnetv1.ReissueDBCertResponse{Cert: cert.Certificate[0]}, nil
+}
+
+func (e *embeddedApplicationServiceClient) SignForDB(ctx context.Context, req *vnetv1.SignForDBRequest, _ ...grpc.CallOption) (*vnetv1.SignForDBResponse, error) {
+	signer, err := e.service.GetDBSigner(ctx, req.GetDatabaseKey())
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	sig, err := sign(signer, req.GetSign())
+	if err != nil {
+		return nil, trace.Wrap(err, "signing for db %v", req.GetDatabaseKey())
+	}
+	return &vnetv1.SignForDBResponse{Signature: sig}, nil
+}
+
+func (e *embeddedApplicationServiceClient) OnNewDBConnection(ctx context.Context, req *vnetv1.OnNewDBConnectionRequest, _ ...grpc.CallOption) (*vnetv1.OnNewDBConnectionResponse, error) {
+	if err := e.service.OnNewDBConnection(ctx, req.GetDatabaseKey()); err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return &vnetv1.OnNewDBConnectionResponse{}, nil
 }
 
 var _ vnetv1.ClientApplicationServiceClient = (*embeddedApplicationServiceClient)(nil)

--- a/lib/vnet/fqdn_resolver.go
+++ b/lib/vnet/fqdn_resolver.go
@@ -393,10 +393,7 @@ func (r *fqdnResolver) resolveDBInfoForCluster(
 		return nil, errNoMatch
 	}
 
-	resp, err := apiclient.GetResourcePage[types.DatabaseServer](ctx, candidate.client.CurrentCluster(), &proto.ListResourcesRequest{
-		ResourceType:        types.KindDatabaseServer,
-		PredicateExpression: db.MatchExpr(identifier),
-	})
+	servers, err := db.ListServers(ctx, candidate.client.CurrentCluster(), identifier)
 	if err != nil {
 		if ctx.Err() != nil {
 			return nil, trace.Wrap(err)
@@ -405,7 +402,7 @@ func (r *fqdnResolver) resolveDBInfoForCluster(
 		return nil, errNoMatch
 	}
 
-	dbResource, ok := db.PickMatch(ctx, log, identifier, resp.Resources)
+	dbResource, ok := db.PickMatch(ctx, log, identifier, servers)
 	if !ok {
 		return nil, errNoMatch
 	}

--- a/lib/vnet/fqdn_resolver.go
+++ b/lib/vnet/fqdn_resolver.go
@@ -393,16 +393,9 @@ func (r *fqdnResolver) resolveDBInfoForCluster(
 		return nil, errNoMatch
 	}
 
-	// Query the cluster for a database whose status.vnet_dns_name or metadata.name matches the parsed
-	// identifier. Matching either lets the user type the database name or the hash.
-	expr := fmt.Sprintf(
-		`resource.status.vnet_dns_name == %q || name == %q`,
-		identifier, identifier,
-	)
-
 	resp, err := apiclient.GetResourcePage[types.DatabaseServer](ctx, candidate.client.CurrentCluster(), &proto.ListResourcesRequest{
 		ResourceType:        types.KindDatabaseServer,
-		PredicateExpression: expr,
+		PredicateExpression: db.MatchExpr(identifier),
 	})
 	if err != nil {
 		if ctx.Err() != nil {
@@ -416,27 +409,12 @@ func (r *fqdnResolver) resolveDBInfoForCluster(
 		return nil, errNoMatch
 	}
 
-	databases := types.DatabaseServers(resp.Resources).ToDatabases()
-	if len(databases) > 1 {
-		matchedNames := make([]string, 0, len(databases))
-		for _, db := range databases {
-			matchedNames = append(matchedNames, db.GetName())
-		}
-		log.WarnContext(ctx, "VNet identifier matched multiple databases, picking the first one",
-			"identifier", identifier,
-			"matched_db_names", matchedNames,
-		)
-	}
-
-	dbResource := databases[0]
-	dbName := dbResource.GetName()
-	protocol := dbResource.GetProtocol()
-
-	if !db.IsUserOptional(protocol) {
-		log.InfoContext(ctx, "Database protocol not currently supported by VNet",
-			"protocol", protocol, "db_name", dbName)
+	dbResource, ok := db.PickMatch(ctx, log, identifier, resp.Resources)
+	if !ok {
 		return nil, errNoMatch
 	}
+	dbName := dbResource.GetName()
+	protocol := dbResource.GetProtocol()
 
 	dialOpts, err := r.cfg.clientApplication.GetDialOptions(ctx, candidate.profileName)
 	if err != nil {

--- a/lib/vnet/fqdn_resolver.go
+++ b/lib/vnet/fqdn_resolver.go
@@ -404,10 +404,6 @@ func (r *fqdnResolver) resolveDBInfoForCluster(
 		log.InfoContext(ctx, "Failed to list database servers", "error", err)
 		return nil, errNoMatch
 	}
-	if len(resp.Resources) == 0 {
-		log.DebugContext(ctx, "Found no matching database servers")
-		return nil, errNoMatch
-	}
 
 	dbResource, ok := db.PickMatch(ctx, log, identifier, resp.Resources)
 	if !ok {


### PR DESCRIPTION
## Changes
Wires database access through the embedded VNet in tbot's beams/vnet service, so workloads in Beams can reach Teleport-protected DBs by name (e.g. psql my-postgres.db.<proxy>:5432)

- Extends the beams/vnet service in tbot with database access support. Previously the service only routed traffic to Teleport-protected applications -  with this change, workloads in Beams can also connect to Teleport-protected databases by name (e.g. psql my-postgres.db.<proxy>:5432) without any Teleport CLI involvement, identity files, or long-lived secrets.

- The flow mirrors apps: VNet resolves the DB FQDN, intercepts the TCP connection on its TUN device, and proxies it through the Teleport proxy. tbot issues a short-lived DB cert scoped to the Delegation Session, so the workload inherits a subset of the user's permissions.


<!-- Provide a descriptive entry for the changelog of the next release. -->


<!-- Include manual testing efforts to verify the change. -->
<!-- Detail where the tests where run and what configurations were used. -->
<!-- Include all the test cases which were run to validate the change. -->

## Manual Test Plan
### Test Environment
Register a database:
```
db_service:
  databases:
    - name: my-postgres
      protocol: postgres
      uri: localhost:5432
      static_labels:
        env: dev
      tls:
        mode: insecure   # only if using a self-signed postgres
```
Create the bot:
```
$ tctl bots add vnet-test --roles=<role granting db access>
```
Start a delegation session:
```
$ tsh delegation create-session \
    --allow-all \
    --bot vnet-test \
    --session-ttl 1h
```
tbot configuration:
```
version: v2
join_uri: <join uri>
storage:
  type: directory
  path: /build/tbot-internal
services:
  - type: beams/vnet
    delegation_session_id: <delegation session id>
    upstream_nameservers: ["1.1.1.1:53"]
```
Start tbot container:
```
$ docker run \
    --name vnet-tbot \
    --rm -it \
    -e TELEPORT_BEAMS_RUNTIME=yes \
    -v $(pwd)/build:/build \
    --privileged \
    ubuntu \
    /bin/bash

# Inside the container
$ apt update && apt install -y ca-certificates
$ /build/tbot start -c /build/tbot.yaml --debug
```
Start user container:
```
$ docker run --rm -it --network=container:vnet-tbot ubuntu /bin/bash
# Inside the container
$ apt update && apt install -y postgresql-client iproute2 dnsutils
$ (sed '/^options single-request-reopen/d; s/^nameserver .*/nameserver 100.64.0.2/' /etc/resolv.conf; echo 'options single-request-reopen') > /tmp/resolv.conf && cp /tmp/resolv.conf /etc/resolv.conf
```

### Test Cases
- [x]  DNS resolution returns a synthetic IP for both FQDN forms:
dig +short my-postgres.db.<proxy> (literal database name)
dig +short <vnet_dns_name>.db.<proxy> (hash form from db_server.status.vnet_dns_name)
- [x] psql "postgres://<user>@my-postgres.db.<proxy>:5432/postgres?sslmode=disable" lands in a postgres=# prompt and round-trips a query (e.g. select now();).