### PR TITLE
build: Add tool to verify Go build settings

### DIFF
--- a/build.assets/tooling/cmd/gobuildverify/main.go
+++ b/build.assets/tooling/cmd/gobuildverify/main.go
@@ -1,0 +1,220 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+// Command gobuildverify verifies that a Go binary has required build
+// settings. See spec.md for details.
+package main
+
+import (
+	"debug/buildinfo"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"regexp"
+	"strings"
+)
+
+var usageText = `usage: gobuildverify [-h] <binary> <expressions...>
+
+Verify that a Go binary has required build settings.
+
+Each expression has the form A[=B] where:
+  A          Check that setting A is present
+  A=B        Check that setting A has exact value B
+  A=/B/      Check that setting A matches regexp B
+  A=(B)      Check that setting A (comma-separated list) contains
+             an element matching B, where B uses the rules above
+
+A -- argument terminates parsing of flags. All subsequent arguments are
+treated as non-flags, allowing them to start with a hyphen.`
+
+func main() {
+	binaryPath, exprs := parseArgs(os.Args)
+
+	info, err := buildinfo.ReadFile(binaryPath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error reading build info from %s: %v\n", binaryPath, err)
+		os.Exit(3)
+	}
+
+	errs := verify(info, exprs)
+	for _, e := range errs {
+		fmt.Fprintln(os.Stderr, e)
+	}
+	if len(errs) > 0 {
+		os.Exit(1)
+	}
+}
+
+func parseArgs(clargs []string) (string, []string) {
+	flag.CommandLine.Init(clargs[0], flag.ContinueOnError)
+	flag.CommandLine.SetOutput(io.Discard)
+	if err := flag.CommandLine.Parse(clargs[1:]); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			fmt.Println(usageText)
+			os.Exit(0)
+		}
+		fmt.Fprintln(os.Stderr, err)
+		fmt.Fprintln(os.Stderr, usageText)
+		os.Exit(2)
+	}
+
+	args := flag.Args()
+	if len(args) < 2 {
+		fmt.Fprintln(os.Stderr, usageText)
+		os.Exit(2)
+	}
+	return args[0], args[1:]
+}
+
+// verify parses the expression strings and checks them against the build
+// info, returning an error for each expression that does not match.
+func verify(info *buildinfo.BuildInfo, exprStrs []string) []error {
+	settings := make(map[string]string)
+	for _, s := range info.Settings {
+		settings[s.Key] = s.Value
+	}
+
+	var errs []error
+	for _, s := range exprStrs {
+		expr, err := parseExpr(s)
+		if err != nil {
+			errs = append(errs, err)
+			continue
+		}
+
+		value, ok := settings[expr.key]
+		if !ok {
+			errs = append(errs, &matchError{key: expr.key})
+			continue
+		}
+		if expr.matcher != nil && !expr.matcher.match(value) {
+			err := &matchError{key: expr.key, actual: value, matcher: expr.matcher}
+			errs = append(errs, err)
+		}
+	}
+	return errs
+}
+
+// matchError is returned when a build setting does not satisfy an expression.
+type matchError struct {
+	key     string
+	actual  string
+	matcher matcher
+}
+
+func (e *matchError) Error() string {
+	switch m := e.matcher.(type) {
+	case nil:
+		return fmt.Sprintf("Build setting not present: %s", e.key)
+	case *listMatcher:
+		return fmt.Sprintf("Build setting does not contain value: %s: %s not in %s", e.key, m.inner, e.actual)
+	default:
+		return fmt.Sprintf("Build setting value does not match: %s: %s != %s", e.key, e.actual, e.matcher)
+	}
+}
+
+// expression represents a parsed check expression.
+type expression struct {
+	key     string
+	matcher matcher // nil means presence check only
+}
+
+// matcher defines how a build setting value is checked.
+type matcher interface {
+	match(value string) bool
+	String() string
+}
+
+type exactMatcher struct {
+	want string
+}
+
+func (m *exactMatcher) match(value string) bool {
+	return value == m.want
+}
+
+func (m *exactMatcher) String() string {
+	return m.want
+}
+
+type regexpMatcher struct {
+	re   *regexp.Regexp
+	expr string
+}
+
+func (m *regexpMatcher) match(value string) bool {
+	return m.re.MatchString(value)
+}
+
+func (m *regexpMatcher) String() string {
+	return "/" + m.expr + "/"
+}
+
+type listMatcher struct {
+	inner matcher
+}
+
+func (m *listMatcher) match(value string) bool {
+	for _, elem := range strings.Split(value, ",") {
+		if m.inner.match(elem) {
+			return true
+		}
+	}
+	return false
+}
+
+func (m *listMatcher) String() string {
+	return "(" + m.inner.String() + ")"
+}
+
+// parseExpr parses an expression string of the form "A" or "A=B".
+func parseExpr(s string) (expression, error) {
+	key, value, hasValue := strings.Cut(s, "=")
+	if key == "" {
+		return expression{}, fmt.Errorf("no setting name in expression: %q", s)
+	}
+	if !hasValue {
+		return expression{key: key}, nil
+	}
+	m, err := parseMatch(value)
+	if err != nil {
+		return expression{}, err
+	}
+	return expression{key: key, matcher: m}, nil
+}
+
+// parseMatch parses a match value: a bare string, /regexp/, or (list).
+func parseMatch(s string) (matcher, error) {
+	if strings.HasPrefix(s, "/") && strings.HasSuffix(s, "/") && len(s) > 1 {
+		pattern := s[1 : len(s)-1]
+		re, err := regexp.Compile(pattern)
+		if err != nil {
+			return nil, fmt.Errorf("invalid regexp %s: %w", s, err)
+		}
+		return &regexpMatcher{re: re, expr: pattern}, nil
+	}
+	if strings.HasPrefix(s, "(") && strings.HasSuffix(s, ")") && len(s) > 1 {
+		inner, err := parseMatch(s[1 : len(s)-1])
+		if err != nil {
+			return nil, err
+		}
+		return &listMatcher{inner: inner}, nil
+	}
+	return &exactMatcher{want: s}, nil
+}

--- a/build.assets/tooling/cmd/gobuildverify/main_test.go
+++ b/build.assets/tooling/cmd/gobuildverify/main_test.go
@@ -1,0 +1,303 @@
+// Teleport
+// Copyright (C) 2025 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package main
+
+import (
+	"debug/buildinfo"
+	"runtime/debug"
+	"testing"
+)
+
+func TestParseExpr(t *testing.T) {
+	tests := []struct {
+		name        string
+		input       string
+		wantKey     string
+		wantMatcher string // "" means presence check (nil matcher)
+		wantErr     bool
+	}{
+		{
+			name:    "presence only",
+			input:   "GOARCH",
+			wantKey: "GOARCH",
+		},
+		{
+			name:        "exact match",
+			input:       "GOARCH=amd64",
+			wantKey:     "GOARCH",
+			wantMatcher: "amd64",
+		},
+		{
+			name:        "regexp match",
+			input:       "GOARCH=/^amd64$/",
+			wantKey:     "GOARCH",
+			wantMatcher: "/^amd64$/",
+		},
+		{
+			name:        "list match with exact inner",
+			input:       "-tags=(fips)",
+			wantKey:     "-tags",
+			wantMatcher: "(fips)",
+		},
+		{
+			name:        "list match with regexp inner",
+			input:       "-tags=(/^fips$/)",
+			wantKey:     "-tags",
+			wantMatcher: "(/^fips$/)",
+		},
+		{
+			name:        "value containing equals",
+			input:       "DefaultGODEBUG=fips140=on",
+			wantKey:     "DefaultGODEBUG",
+			wantMatcher: "fips140=on",
+		},
+		{
+			name:        "single slash is exact match",
+			input:       "A=/",
+			wantKey:     "A",
+			wantMatcher: "/",
+		},
+		{
+			name:        "empty parens is list match",
+			input:       "A=()",
+			wantKey:     "A",
+			wantMatcher: "()",
+		},
+		{
+			name:    "invalid regexp",
+			input:   "GOARCH=/[invalid/",
+			wantKey: "GOARCH",
+			wantErr: true,
+		},
+		{
+			name:    "invalid regexp in list",
+			input:   "-tags=(/[invalid/)",
+			wantKey: "-tags",
+			wantErr: true,
+		},
+		{
+			name:    "missing setting name",
+			input:   "=value",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			expr, err := parseExpr(tt.input)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if expr.key != tt.wantKey {
+				t.Errorf("key = %q, want %q", expr.key, tt.wantKey)
+			}
+			if tt.wantMatcher == "" && expr.matcher != nil {
+				t.Errorf("expected nil matcher for presence check, got %s", expr.matcher)
+			}
+			if tt.wantMatcher != "" && expr.matcher == nil {
+				t.Fatalf("expected matcher %q, got nil", tt.wantMatcher)
+			}
+			if tt.wantMatcher != "" && expr.matcher.String() != tt.wantMatcher {
+				t.Errorf("matcher = %q, want %q", expr.matcher.String(), tt.wantMatcher)
+			}
+		})
+	}
+}
+
+func TestExactMatcher(t *testing.T) {
+	tests := []struct {
+		name  string
+		want  string
+		value string
+		match bool
+	}{
+		{"equal", "amd64", "amd64", true},
+		{"not equal", "amd64", "arm64", false},
+		{"empty value", "amd64", "", false},
+		{"empty want", "", "", true},
+		{"substring not exact", "amd", "amd64", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := &exactMatcher{want: tt.want}
+			if got := m.match(tt.value); got != tt.match {
+				t.Errorf("match(%q) = %v, want %v", tt.value, got, tt.match)
+			}
+		})
+	}
+}
+
+func TestRegexpMatcher(t *testing.T) {
+	tests := []struct {
+		name    string
+		pattern string
+		value   string
+		match   bool
+	}{
+		{"full match", "^amd64$", "amd64", true},
+		{"no match", "^amd64$", "arm64", false},
+		{"partial match", "amd", "amd64", true},
+		{"alternation", "^(amd|arm)64$", "arm64", true},
+		{"complex pattern", "fips140=on(ly)?", "fips140=on", true},
+		{"complex pattern only", "fips140=on(ly)?", "fips140=only", true},
+		{"complex pattern no match", "fips140=on(ly)?", "fips140=off", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m, err := parseMatch("/" + tt.pattern + "/")
+			if err != nil {
+				t.Fatalf("parseMatch: %v", err)
+			}
+			if got := m.match(tt.value); got != tt.match {
+				t.Errorf("match(%q) = %v, want %v", tt.value, got, tt.match)
+			}
+		})
+	}
+}
+
+func TestListMatcher(t *testing.T) {
+	tests := []struct {
+		name  string
+		expr  string
+		value string
+		match bool
+	}{
+		{"exact element match", "(fips)", "fips", true},
+		{"exact in comma list", "(fips)", "boringcrypto,fips", true},
+		{"exact not in list", "(fips)", "boringcrypto,other", false},
+		{"regexp element match", "(/^fips$/)", "fips", true},
+		{"regexp in comma list", "(/fips/)", "boringcrypto,fips,other", true},
+		{"regexp no match", "(/^fips$/)", "boringcrypto,other", false},
+		{"single element list", "(foo)", "foo", true},
+		{"single element no match", "(foo)", "bar", false},
+		{"empty value", "(foo)", "", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m, err := parseMatch(tt.expr)
+			if err != nil {
+				t.Fatalf("parseMatch: %v", err)
+			}
+			if got := m.match(tt.value); got != tt.match {
+				t.Errorf("match(%q) = %v, want %v", tt.value, got, tt.match)
+			}
+		})
+	}
+}
+
+func TestVerify(t *testing.T) {
+	info := &buildinfo.BuildInfo{
+		Settings: []debug.BuildSetting{
+			{Key: "GOARCH", Value: "amd64"},
+			{Key: "CGO_ENABLED", Value: "1"},
+			{Key: "-tags", Value: "fips,boringcrypto"},
+			{Key: "GOFIPS140", Value: "v1.0.0-c2097c7c"},
+		},
+	}
+
+	tests := []struct {
+		name     string
+		exprs    []string
+		wantErrs []string
+	}{
+		{
+			name:  "all pass",
+			exprs: []string{"GOARCH=amd64", "CGO_ENABLED"},
+		},
+		{
+			name:  "setting not present",
+			exprs: []string{"MISSING"},
+			wantErrs: []string{
+				"Build setting not present: MISSING",
+			},
+		},
+		{
+			name:  "setting not present for matcher",
+			exprs: []string{"MISSING=value"},
+			wantErrs: []string{
+				"Build setting not present: MISSING",
+			},
+		},
+		{
+			name:  "exact mismatch",
+			exprs: []string{"GOARCH=arm64"},
+			wantErrs: []string{
+				"Build setting value does not match: GOARCH: amd64 != arm64",
+			},
+		},
+		{
+			name:  "regexp mismatch",
+			exprs: []string{"GOARCH=/^arm/"},
+			wantErrs: []string{
+				"Build setting value does not match: GOARCH: amd64 != /^arm/",
+			},
+		},
+		{
+			name:  "list match",
+			exprs: []string{"-tags=(fips)"},
+		},
+		{
+			name:  "list no match",
+			exprs: []string{"-tags=(nothere)"},
+			wantErrs: []string{
+				"Build setting does not contain value: -tags: nothere not in fips,boringcrypto",
+			},
+		},
+		{
+			name:  "multiple errors",
+			exprs: []string{"MISSING", "GOARCH=arm64"},
+			wantErrs: []string{
+				"Build setting not present: MISSING",
+				"Build setting value does not match: GOARCH: amd64 != arm64",
+			},
+		},
+		{
+			name:  "presence only passes",
+			exprs: []string{"GOARCH"},
+		},
+		{
+			name:  "invalid expression",
+			exprs: []string{"GOARCH=/[bad/"},
+			wantErrs: []string{
+				"invalid regexp /[bad/: error parsing regexp: missing closing ]: `[bad`",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			errs := verify(info, tt.exprs)
+			if len(errs) != len(tt.wantErrs) {
+				t.Fatalf("got %d errors, want %d:\n  got:  %v\n  want: %v", len(errs), len(tt.wantErrs), errs, tt.wantErrs)
+			}
+			for i := range errs {
+				if errs[i].Error() != tt.wantErrs[i] {
+					t.Errorf("error[%d] = %q, want %q", i, errs[i].Error(), tt.wantErrs[i])
+				}
+			}
+		})
+	}
+}

--- a/build.assets/tooling/cmd/gobuildverify/spec.md
+++ b/build.assets/tooling/cmd/gobuildverify/spec.md
@@ -1,0 +1,59 @@
+# gobuildverify
+
+gobuildverify is a tool that verifies that a Go binary has required build
+settings. The output of `go version -m -json` has a section named `Settings`
+that lists all the build settings that were set for a binary. These are
+available programmatically via the `debug/buildinfo` package.
+
+The build setting values embedded in a Go binary are strings. In some cases,
+the strings are comma-separated lists. `gobuildverify` expressions can match
+against individual strings or against individual elements of a comma-separated
+list. A match may be an exact string match or a RE2 regular expression match.
+
+For example:
+```
+gobuildverify binary '-tags=(fips)' 'DefaultGODEBUG=(/fips140=on(ly)?/)' 'GOFIPS140=/^v1\.0\.0/'
+```
+
+This will verify that `binary` has:
+* a build setting named `-tags` that is a comma-separated list and one of the elements
+  has the value `fips`,
+* a build setting named `DefaultGODEBUG` that is a comma-separated list and one
+  of the elements matches the regular expression `fips140=on(ly)?`,
+* a build setting named `GOFIPS140` that is a string that matches the regular
+  expression `^v1\.0\.0`.
+
+If all three expressions match, then `gobuildverify` will exit with success (0).
+Otherwise it will print an appropriate error message saying what did not match
+and exit with failure (1).
+
+Each argument is an expression of the form `A[=B]`. `B` can be absent, a
+string, a string surrounded by slashes, or a string surrounded by parentheses.
+These four forms are interpreted as follows:
+* Presence: Of the form `A`, checks for the presence of the build setting `A`,
+* Exact match: Of the form `A=B`, checks that the setting `A` has the exact
+  value `B`,
+* Regexp match: Of the form `A=/B/`, treats `B` as a regular expression (RE2)
+  and checks that the setting `A` has a value that matches the regexp `B` with
+  `regexp.MatchString` (which is an unanchored match),
+* List contains match: Of the form `A=(B)`, treats the value of the `A` setting
+  as a comma-separated list and matches `B` against each element. The contents
+  inside the parens is itself a match expression evaluated by the rules above.
+  For example, `A=(/B/)` does a regexp match of `B` against each list element
+  of the `A` setting. `A=(B)` does an exact match against each of the list
+  elements.
+
+If a setting is not present, the error message will say:
+
+    Build setting not present: <setting>
+
+If the expression has a match value that is a string or a regex and it does not
+match the build setting in the binary, the error message will say:
+
+    Build setting value does not match: <setting>: <actual> != <want>
+
+If the expression is a list match and none of the elements match, the error
+message will say:
+
+    Build setting does not contain value: <setting>: <want> not in <list>
+


### PR DESCRIPTION
Add a tool - `gobuildverify` - that verifies that the required build
settings are set in a binary. The primary use case for this is verifying
the FIPS140 build to ensure the binaries have been built with the `fips`
tag and that FIPS is enabled at run time, as well as the correct version
of the certified FIPS modules is being used.

Issue: https://github.com/gravitational/teleport.e/issues/8538
