### PR TITLE
[v18] Connect: attempt to fix `ETIMEDOUT` error on launch

### DIFF
--- a/web/packages/teleterm/src/preload.ts
+++ b/web/packages/teleterm/src/preload.ts
@@ -96,9 +96,17 @@ async function getElectronGlobals(): Promise<ElectronGlobals> {
   // All uses of tshClient must wait before updateTshdEventsServerAddress finishes to ensure that
   // the client is ready. Otherwise we run into a risk of causing panics in tshd due to a missing
   // tshd events client.
-  await tshClient.updateTshdEventsServerAddress({
-    address: tshdEventsServerAddress,
-  });
+  await tshClient.updateTshdEventsServerAddress(
+    {
+      address: tshdEventsServerAddress,
+    },
+    {
+      timeout: 15_000,
+      // On Windows, this first local gRPC call has been observed to fail fast
+      // with ETIMEDOUT even though the channel becomes ready shortly after.
+      metadataOptions: { waitForReady: true },
+    }
+  );
 
   return {
     mainProcessClient,

--- a/web/packages/teleterm/src/ui/boot.tsx
+++ b/web/packages/teleterm/src/ui/boot.tsx
@@ -19,6 +19,8 @@
 import React from 'react';
 import { createRoot } from 'react-dom/client';
 
+import { getErrorMessage } from 'shared/utils/error';
+
 import Logger from 'teleterm/logger';
 import { ElectronGlobals } from 'teleterm/types';
 import { App } from 'teleterm/ui/App';
@@ -51,7 +53,9 @@ async function boot(): Promise<void> {
   } catch (e) {
     logger.error('Failed to boot the React app', e);
     renderApp(
-      <FailedApp message={`Could not start the application: ${e.toString()}`} />
+      <FailedApp
+        message={`Could not start the application: ${getErrorMessage(e)}`}
+      />
     );
   }
 }


### PR DESCRIPTION
Backport #66477 to branch/v18

changelog: Improved Teleport Connect startup reliability on Windows

## Manual Test Plan
### Test Environment
Locally built app.

### Test Cases
- [x] The app starts as usual.
