### PR TITLE
[reversetunnel] respect KeepAliveCountMax in agent pool

### DIFF
--- a/lib/reversetunnel/agent_test.go
+++ b/lib/reversetunnel/agent_test.go
@@ -52,6 +52,7 @@ type mockSSHClient struct {
 	MockPrincipals        []string
 	MockGlobalRequests    chan *ssh.Request
 	MockHandleChannelOpen chan ssh.NewChannel
+	MockEnableWatchdog    func(time.Duration)
 }
 
 func (m *mockSSHClient) User() string { return "" }
@@ -112,6 +113,9 @@ func (m *mockSSHClient) GlobalRequests() <-chan *ssh.Request {
 }
 
 func (m *mockSSHClient) EnableWatchdog(timeout time.Duration) {
+	if m.MockEnableWatchdog != nil {
+		m.MockEnableWatchdog(timeout)
+	}
 }
 
 type fakeReaderWriter struct{}

--- a/lib/reversetunnel/agentpool.go
+++ b/lib/reversetunnel/agentpool.go
@@ -820,6 +820,9 @@ func (c *agentPoolRuntimeConfig) update(ctx context.Context, netConfig types.Clu
 
 	oldProxyListenerMode := c.proxyListenerMode
 	c.keepAliveInterval = netConfig.GetKeepAliveInterval()
+	if v := int(netConfig.GetKeepAliveCountMax()); v > 0 {
+		c.keepAliveCount = v
+	}
 	c.proxyListenerMode = netConfig.GetProxyListenerMode()
 
 	// Fallback to agent mesh strategy if there is an error.

--- a/lib/reversetunnel/agentpool_test.go
+++ b/lib/reversetunnel/agentpool_test.go
@@ -20,13 +20,18 @@ package reversetunnel
 
 import (
 	"context"
+	"fmt"
+	"sync"
+	"sync/atomic"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/gravitational/trace"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/crypto/ssh"
 
+	tracessh "github.com/gravitational/teleport/api/observability/tracing/ssh"
 	apissh "github.com/gravitational/teleport/api/ssh"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/utils/retryutils"
@@ -172,4 +177,187 @@ func TestAgentPoolConnectionCount(t *testing.T) {
 
 type mockSigner struct {
 	ssh.Signer
+}
+
+func TestAgentKeepAliveCountTimeout(t *testing.T) {
+	cases := []struct {
+		name           string
+		keepAliveCount int
+		expectTimeout  time.Duration
+	}{
+		{
+			name:           "count=3 produces 300ms watchdog timeout",
+			keepAliveCount: 3,
+			expectTimeout:  300 * time.Millisecond,
+		},
+		{
+			name:           "count=7 produces 700ms watchdog timeout",
+			keepAliveCount: 7,
+			expectTimeout:  700 * time.Millisecond,
+		},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			synctest.Test(t, func(t *testing.T) {
+				var (
+					watchdogOnce    sync.Once
+					watchdogTimeout time.Duration
+				)
+
+				requests := make(chan *ssh.Request)
+
+				agent, client := testAgent(t, agentConfig{
+					keepAlive:      100 * time.Millisecond,
+					keepAliveCount: tt.keepAliveCount,
+				})
+
+				client.MockEnableWatchdog = func(timeout time.Duration) {
+					watchdogOnce.Do(func() {
+						watchdogTimeout = timeout
+					})
+				}
+
+				client.MockSendRequest = func(ctx context.Context, name string, wantReply bool, payload []byte) (bool, []byte, error) {
+					return true, nil, nil
+				}
+
+				client.MockOpenChannel = func(ctx context.Context, name string, data []byte) (*tracessh.Channel, <-chan *ssh.Request, error) {
+					return tracessh.NewTraceChannel(
+						&mockSSHChannel{
+							MockSendRequest: func(name string, wantReply bool, payload []byte) (bool, error) {
+								return true, nil
+							},
+						},
+					), requests, nil
+				}
+
+				ctx, cancel := context.WithCancel(t.Context())
+				defer cancel()
+
+				require.NoError(t, agent.Start(ctx))
+
+				// Wait for all goroutines in the bubble to block, at which
+				// point sendKeepalives has fired its timer(0) and called
+				// EnableWatchdog.
+				synctest.Wait()
+
+				// Stop the agent and drain the requests channel so
+				// DiscardRequests can exit, leaving no blocked goroutines.
+				agent.Stop()
+				close(requests)
+
+				require.Equal(t, tt.expectTimeout, watchdogTimeout,
+					"watchdog timeout should equal keepAlive * keepAliveCount")
+			})
+		})
+	}
+}
+
+func TestAgentPoolKeepAliveCountUpdatesAgent(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		watchdogTimeouts := make(chan time.Duration, 2)
+
+		var mu sync.Mutex
+		currentRequests := make(chan *ssh.Request)
+
+		pool, client := setupTestAgentPool(t)
+
+		// Use a fresh tracker with no pre-tracked proxies so lease.Claim
+		// always succeeds regardless of principal name.
+		var err error
+		pool.tracker, err = track.New(track.Config{ClusterName: "test-cluster"})
+		require.NoError(t, err)
+		pool.tracker.TrackExpected(track.Proxy{Name: "proxy-1"})
+
+		agentCount := 0
+		var keepAliveCountMax atomic.Int64 // starting at 0 will default to apidefaults.KeepAliveCountMax
+
+		pool.newAgentFunc = func(ctx context.Context, tracker *track.Tracker, lease *track.Lease) (Agent, error) {
+			agentCount++
+			// Each agent gets a unique principal so it never collides with a
+			// previously claimed proxy.
+			principal := fmt.Sprintf("proxy-%d", agentCount)
+
+			mu.Lock()
+			reqs := currentRequests
+			mu.Unlock()
+
+			mockClient := &mockSSHClient{
+				MockPrincipals:        []string{principal},
+				MockGlobalRequests:    make(chan *ssh.Request),
+				MockHandleChannelOpen: make(chan ssh.NewChannel),
+				MockSendRequest: func(ctx context.Context, name string, wantReply bool, payload []byte) (bool, []byte, error) {
+					return true, nil, nil
+				},
+				MockOpenChannel: func(ctx context.Context, name string, data []byte) (*tracessh.Channel, <-chan *ssh.Request, error) {
+					return tracessh.NewTraceChannel(
+						&mockSSHChannel{
+							MockSendRequest: func(name string, wantReply bool, payload []byte) (bool, error) {
+								return true, nil
+							},
+						},
+					), reqs, nil
+				},
+			}
+			mockClient.MockEnableWatchdog = func(timeout time.Duration) {
+				select {
+				case watchdogTimeouts <- timeout:
+				default:
+				}
+			}
+
+			inject := &mockAgentInjection{client: mockClient}
+			a, err := newAgent(agentConfig{
+				addr:             utils.NetAddr{Addr: "test-proxy-addr"},
+				keepAlive:        pool.runtimeConfig.keepAliveInterval,
+				keepAliveCount:   pool.runtimeConfig.keepAliveCount,
+				sshDialer:        inject,
+				transportHandler: inject,
+				versionGetter:    inject,
+				tracker:          tracker,
+				lease:            lease,
+			})
+			if err != nil {
+				return nil, trace.Wrap(err)
+			}
+			a.stateCallback = pool.getStateCallback(a)
+			return a, nil
+		}
+
+		client.mockGetClusterNetworkingConfig = func(ctx context.Context) (types.ClusterNetworkingConfig, error) {
+			config := types.DefaultClusterNetworkingConfig()
+			config.SetKeepAliveInterval(100 * time.Millisecond)
+			config.SetKeepAliveCountMax(keepAliveCountMax.Load())
+			return config, nil
+		}
+
+		require.NoError(t, pool.Start())
+		defer pool.Stop()
+
+		synctest.Wait()
+
+		require.Equal(t, 300*time.Millisecond, <-watchdogTimeouts,
+			"first agent: watchdog timeout should be keepAlive(100ms) * keepAliveCount(3)")
+
+		keepAliveCountMax.Store(7)
+
+		newReqs := make(chan *ssh.Request)
+		mu.Lock()
+		oldReqs := currentRequests
+		currentRequests = newReqs
+		mu.Unlock()
+
+		// Closing oldReqs unblocks the first agent's DiscardRequests goroutine,
+		// which causes the agent to close and the pool to reconnect with the
+		// updated keepAliveCount.
+		close(oldReqs)
+
+		synctest.Wait()
+
+		require.Equal(t, 700*time.Millisecond, <-watchdogTimeouts,
+			"second agent: watchdog timeout should be keepAlive(100ms) * keepAliveCount(7)")
+
+		close(newReqs)
+	})
 }


### PR DESCRIPTION
<!-- Provide a descriptive entry for the changelog of the next release. -->

<!-- Include manual testing efforts to verify the change. -->
<!-- Detail where the tests where run and what configurations were used. -->
<!-- Include all the test cases which were run to validate the change. -->

## Manual Test Plan
### Test Environment
Local VM with auth and proxy with a SSH node and a separate client.

### Test Cases
- [x] Inject a timeout and ensure a custom config in the auth is picked up in the node. 
