### PR TITLE
docs: Desktop fixes

### DIFF
--- a/docs/pages/enroll-resources/desktop-access/active-directory.mdx
+++ b/docs/pages/enroll-resources/desktop-access/active-directory.mdx
@@ -238,7 +238,7 @@ To export the Teleport CA certificate:
 
    (!docs/pages/includes/desktop-access/windows-ca-note.mdx!)
 
-1. Take note of the path to file you just downloaded for use in a later step.
+1. Take note of the path to the file you just downloaded for use in a later step.
 
 #### Create the GPO for the Teleport certificate
 
@@ -676,7 +676,7 @@ To create a role for accessing Windows desktops:
      allow:
        windows_desktop_labels:
          "*": "*"
-       windows_desktop_logins: ["jsmith"]
+       windows_desktop_logins: ["Administrator"]
    ```
 
 1. Create the role:

--- a/docs/pages/enroll-resources/desktop-access/directory-sharing.mdx
+++ b/docs/pages/enroll-resources/desktop-access/directory-sharing.mdx
@@ -7,7 +7,7 @@ tags:
  - infrastructure-identity
 ---
 
-Directory Sharing is a Teleport feature of that makes it easy to move files
+Directory Sharing is a Teleport feature that makes it easy to move files
 between a local machine and a remote desktop—and apply changes to those
 files—without compromising security.
 
@@ -55,7 +55,7 @@ find the desktop, and click 'Connect' to start a session.
 Once the session starts, click the three-dot menu on the top-right of the screen
 and click "Share Directory":
 
-![The "Share Desktop" button](../../../img/desktop-access/share.png)
+![The "Share Directory" button](../../../img/desktop-access/share.png)
 
 ### Limitations on directories you can share
 
@@ -237,7 +237,7 @@ a remote Windows desktop.
 On the remote side, Directory Sharing takes advantage of [file system-related
 messaging](https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpefs/)
 within the Remote Desktop Protocol (RDP). On the local side, Teleport Connect uses Go's
-native file system API to read from and write to the user-selected directory
+native file system API to read from and write to the user-selected directory.
 
 Teleport Connect establishes a secure mTLS connection to the Teleport Proxy Service,
 which forwards traffic to and from the relevant Teleport Desktop Service instance.

--- a/docs/pages/enroll-resources/desktop-access/dynamic-registration.mdx
+++ b/docs/pages/enroll-resources/desktop-access/dynamic-registration.mdx
@@ -74,7 +74,7 @@ metadata:
     env: test
 spec:
   addr: host1.example.com:3089
-  # non_ad should be true for logging with local Windows user and false for Active Directory users
+  # non_ad should be true for logging in with local Windows user and false for Active Directory users
   non_ad: true
   # domain specifies domain used for AD-joined machines
   domain: ""

--- a/docs/pages/enroll-resources/desktop-access/troubleshooting.mdx
+++ b/docs/pages/enroll-resources/desktop-access/troubleshooting.mdx
@@ -223,7 +223,7 @@ the new CA.
 
 You click **Connect** on a Windows host from the Teleport Web UI, and a new tab
 opens, but nothing is displayed other than the top bar. After a while, an error
-is displayed about a failed connection. In most case, this error occurs when the
+is displayed about a failed connection. In most cases, this error occurs when the
 `windows_desktop_service` can't reach the target Windows host.
 
 #### Solution: Modify firewall rules to allow inbound RDP traffic


### PR DESCRIPTION
docs/pages/enroll-resources/desktop-access/active-directory.mdx:
- grammar fix
- correct user for role. This specified to create an example with the `Administrator` user

docs/pages/enroll-resources/desktop-access/directory-sharing.mdx:
- grammar fixes
- image alt fix

docs/pages/enroll-resources/desktop-access/dynamic-registration.mdx:
- grammar fix

docs/pages/enroll-resources/desktop-access/troubleshooting.mdx:
- grammar fix

