### PR TITLE
e2e: Add a dedicated login test, remove auth setup from report

### DIFF
--- a/e2e/global-setup.ts
+++ b/e2e/global-setup.ts
@@ -26,12 +26,17 @@ import { directLogin } from './helpers/login';
 const authDir = join(dirname(fileURLToPath(import.meta.url)), '.auth');
 
 export default async function globalSetup() {
+  const browser = process.env.E2E_BROWSER;
+  if (!browser) {
+    throw new Error('E2E_BROWSER must be set by the runner');
+  }
+
   mkdirSync(authDir, { recursive: true });
 
   for (const [username, creds] of Object.entries(users)) {
     const state = await directLogin(startUrl, username, creds.password);
     writeFileSync(
-      join(authDir, `${username}.json`),
+      join(authDir, `${browser}-${username}.json`),
       JSON.stringify(state, null, 2)
     );
   }

--- a/e2e/global-setup.ts
+++ b/e2e/global-setup.ts
@@ -20,25 +20,19 @@ import { mkdirSync, writeFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-import { startUrl, users } from '@gravitational/e2e/helpers/env';
-import { directLogin } from '@gravitational/e2e/helpers/login';
-// oxlint-disable-next-line no-restricted-imports
-import { test as setup } from '@playwright/test';
+import { startUrl, users } from './helpers/env';
+import { directLogin } from './helpers/login';
 
-const authDir = join(dirname(fileURLToPath(import.meta.url)), '../../.auth');
+const authDir = join(dirname(fileURLToPath(import.meta.url)), '.auth');
 
-mkdirSync(authDir, { recursive: true });
+export default async function globalSetup() {
+  mkdirSync(authDir, { recursive: true });
 
-for (const [username, creds] of Object.entries(users)) {
-  // oxlint-disable-next-line no-empty-pattern -- Playwright requires fixture argument to be destructured.
-  setup(`authenticate as ${username}`, async ({}, testInfo) => {
+  for (const [username, creds] of Object.entries(users)) {
     const state = await directLogin(startUrl, username, creds.password);
-
-    const browser = testInfo.project.name.split(':')[0];
-
     writeFileSync(
-      join(authDir, `${browser}-${username}.json`),
+      join(authDir, `${username}.json`),
       JSON.stringify(state, null, 2)
     );
-  });
+  }
 }

--- a/e2e/global-setup.ts
+++ b/e2e/global-setup.ts
@@ -25,7 +25,7 @@ import { directLogin } from './helpers/login';
 
 const authDir = join(dirname(fileURLToPath(import.meta.url)), '.auth');
 
-export default async function globalSetup() {
+async function globalSetup() {
   const browser = process.env.E2E_BROWSER;
   if (!browser) {
     throw new Error('E2E_BROWSER must be set by the runner');
@@ -41,3 +41,5 @@ export default async function globalSetup() {
     );
   }
 }
+
+export { globalSetup as default };

--- a/e2e/helpers/login.ts
+++ b/e2e/helpers/login.ts
@@ -22,10 +22,10 @@ import { Agent, fetch as undiciFetch } from 'undici';
 import { users } from './env';
 import { mockWebAuthn, signWebAuthnAssertion } from './webauthn';
 
-// directLogin runs during the auth setup project against a Teleport instance
-// the runner brings up with a freshly-generated self-signed cert, so the
-// global default verifier rejects the connection. Scope the bypass to these
-// two fetches via a dedicated dispatcher rather than disabling TLS globally.
+// directLogin runs during global setup against a Teleport instance the runner
+// brings up with a freshly-generated self-signed cert, so the global default
+// verifier rejects the connection. Scope the bypass to these two fetches via
+// a dedicated dispatcher rather than disabling TLS globally.
 const insecureDispatcher = new Agent({
   connect: { rejectUnauthorized: false },
 });

--- a/e2e/helpers/test.ts
+++ b/e2e/helpers/test.ts
@@ -198,9 +198,14 @@ export const test = base.extend<E2EFixtures>({
     await use(page);
   },
   storageState: async ({ username }, use, testInfo) => {
-    // Connect tests drive login through the Electron app and don't have a
-    // setup project that writes shared storage state files, so leave it unset.
-    if (!username || testInfo.project.name === 'connect') {
+    // Connect tests drive login through the Electron app, and unauthenticated
+    // tests intentionally start without a session, so neither has a storage
+    // state file to load even when the test declares a user.
+    if (
+      !username ||
+      testInfo.project.name === 'connect' ||
+      testInfo.project.name.endsWith(':unauthenticated')
+    ) {
       await use(undefined as unknown as string);
       return;
     }

--- a/e2e/helpers/test.ts
+++ b/e2e/helpers/test.ts
@@ -125,6 +125,8 @@ export const test = base.extend<E2EFixtures>({
       );
     }
 
+    const browser = testInfo.project.name.split(':')[0];
+
     await use(async (index: number): Promise<LoginAsResult> => {
       const definition = users[index];
       if (!definition) {
@@ -144,7 +146,7 @@ export const test = base.extend<E2EFixtures>({
       }
 
       const state: StorageState = JSON.parse(
-        readFileSync(join(authDir, `${name}.json`), 'utf-8')
+        readFileSync(join(authDir, `${browser}-${name}.json`), 'utf-8')
       );
 
       const ctx = page.context();
@@ -208,7 +210,9 @@ export const test = base.extend<E2EFixtures>({
       return;
     }
 
-    await use(join(authDir, `${username}.json`));
+    const browser = testInfo.project.name.split(':')[0];
+
+    await use(join(authDir, `${browser}-${username}.json`));
   },
   unifiedResourcesPage: async ({ page }, use) => {
     await use(new UnifiedResourcesPage(page));

--- a/e2e/helpers/test.ts
+++ b/e2e/helpers/test.ts
@@ -125,8 +125,6 @@ export const test = base.extend<E2EFixtures>({
       );
     }
 
-    const browser = testInfo.project.name.split(':')[0];
-
     await use(async (index: number): Promise<LoginAsResult> => {
       const definition = users[index];
       if (!definition) {
@@ -146,7 +144,7 @@ export const test = base.extend<E2EFixtures>({
       }
 
       const state: StorageState = JSON.parse(
-        readFileSync(join(authDir, `${browser}-${name}.json`), 'utf-8')
+        readFileSync(join(authDir, `${name}.json`), 'utf-8')
       );
 
       const ctx = page.context();
@@ -210,9 +208,7 @@ export const test = base.extend<E2EFixtures>({
       return;
     }
 
-    const browser = testInfo.project.name.split(':')[0];
-
-    await use(join(authDir, `${browser}-${username}.json`));
+    await use(join(authDir, `${username}.json`));
   },
   unifiedResourcesPage: async ({ page }, use) => {
     await use(new UnifiedResourcesPage(page));

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -36,6 +36,7 @@ export default defineConfig({
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 1 : 0,
   workers: process.env.CI ? 1 : undefined,
+  globalSetup: './global-setup.ts',
   reporter: [
     ['html', { open: 'never' }],
     ['json', { outputFile: 'test-results/results.json' }],
@@ -49,28 +50,18 @@ export default defineConfig({
   },
 
   projects: [
-    ...browserList.flatMap(browser => {
-      const setupName = `${browser}:setup`;
-      return [
-        {
-          name: setupName,
-          testDir: './tests/web',
-          testMatch: /.*\.setup\.ts/,
-          use: browserDevices[browser],
-        },
-        {
-          name: `${browser}:authenticated`,
-          testDir: './tests/web/authenticated',
-          use: { ...browserDevices[browser] },
-          dependencies: [setupName],
-        },
-        {
-          name: `${browser}:unauthenticated`,
-          testDir: './tests/web/unauthenticated',
-          use: { ...browserDevices[browser] },
-        },
-      ];
-    }),
+    ...browserList.flatMap(browser => [
+      {
+        name: `${browser}:authenticated`,
+        testDir: './tests/web/authenticated',
+        use: { ...browserDevices[browser] },
+      },
+      {
+        name: `${browser}:unauthenticated`,
+        testDir: './tests/web/unauthenticated',
+        use: { ...browserDevices[browser] },
+      },
+    ]),
 
     {
       name: 'connect',

--- a/e2e/runner/github.go
+++ b/e2e/runner/github.go
@@ -170,18 +170,20 @@ func writeJobSummary(report pwReport, failures, flaky []mergedFailure) error {
 }
 
 func renderMarkdownReport(w io.Writer, report pwReport, failures, flaky []mergedFailure) {
+	stats := reportableStats(report)
+
 	fmt.Fprint(w, "### E2E Test Results\n\n")
 
 	fmt.Fprint(w, "```diff\n")
-	fmt.Fprintf(w, "+ %d passed\n", report.Stats.Expected)
-	if report.Stats.Unexpected > 0 {
-		fmt.Fprintf(w, "- %d failed\n", report.Stats.Unexpected)
+	fmt.Fprintf(w, "+ %d passed\n", stats.expected)
+	if stats.unexpected > 0 {
+		fmt.Fprintf(w, "- %d failed\n", stats.unexpected)
 	}
-	if report.Stats.Flaky > 0 {
-		fmt.Fprintf(w, "! %d flaky\n", report.Stats.Flaky)
+	if stats.flaky > 0 {
+		fmt.Fprintf(w, "! %d flaky\n", stats.flaky)
 	}
-	if report.Stats.Skipped > 0 {
-		fmt.Fprintf(w, "# %d skipped\n", report.Stats.Skipped)
+	if stats.skipped > 0 {
+		fmt.Fprintf(w, "# %d skipped\n", stats.skipped)
 	}
 	fmt.Fprintf(w, "# %s\n", formatDuration(report.Stats.Duration))
 	fmt.Fprint(w, "```\n")
@@ -370,6 +372,58 @@ func writeFailureErrors(w io.Writer, results []pwResult) {
 		fmt.Fprint(w, "*Retried once and failed with the same error.*\n\n")
 	} else {
 		fmt.Fprintf(w, "*Retried %d times and failed with the same error.*\n\n", retries)
+	}
+}
+
+type reportStats struct {
+	expected   int
+	unexpected int
+	flaky      int
+	skipped    int
+}
+
+// reportableStats walks the suite tree and tallies tests excluding the setup
+// projects (e.g. `chromium:setup`). Playwright's top-level stats include those
+// auth-setup tests, which are infrastructure rather than test cases readers
+// care about.
+func reportableStats(report pwReport) reportStats {
+	var stats reportStats
+	walkSpecs(report.Suites, func(s pwSpec) {
+		// Treat the spec as flaky if any retry succeeded, matching how
+		// Playwright classifies flaky specs in its top-level stats.
+		flaky := false
+		var finalStatus string
+		for _, t := range s.Tests {
+			if strings.HasSuffix(t.ProjectName, ":setup") {
+				continue
+			}
+			finalStatus = t.Status
+			if len(t.Results) > 1 && t.Status == "expected" {
+				flaky = true
+			}
+		}
+		switch {
+		case finalStatus == "":
+			// All tests for this spec were filtered out (setup-only).
+		case flaky:
+			stats.flaky++
+		case finalStatus == "expected":
+			stats.expected++
+		case finalStatus == "unexpected":
+			stats.unexpected++
+		case finalStatus == "skipped":
+			stats.skipped++
+		}
+	})
+	return stats
+}
+
+func walkSpecs(suites []pwSuite, fn func(pwSpec)) {
+	for _, s := range suites {
+		for _, spec := range s.Specs {
+			fn(spec)
+		}
+		walkSpecs(s.Suites, fn)
 	}
 }
 

--- a/e2e/runner/playwright.go
+++ b/e2e/runner/playwright.go
@@ -301,6 +301,7 @@ func (p *playwrightRunner) startEnv(inst *testInstance) ([]string, error) {
 	env = append(env, "E2E_TCTL_BIN="+p.config.tctlBin)
 	env = append(env, "E2E_TELEPORT_CONFIG="+inst.teleportConfigPath)
 	env = append(env, "E2E_BROWSERS="+strings.Join(p.config.browsers, ","))
+	env = append(env, "E2E_BROWSER="+inst.browser)
 
 	env = append(env, "E2E_CONNECT_TSH_BIN="+p.config.connectTshBinPath)
 	env = append(env, "E2E_CONNECT_APP_DIR="+p.config.connectAppDir)

--- a/e2e/runner/playwright.go
+++ b/e2e/runner/playwright.go
@@ -121,6 +121,8 @@ func (p *playwrightRunner) test(ctx context.Context, debug bool) error {
 			args := []string{"exec", "playwright", "test", p.configFlag()}
 			args = append(args, extraArgs...)
 			args = append(args, "--reporter=blob,"+filepath.Join(p.config.sharedDir, "scripts", "dot-progress-reporter.ts"))
+			// Avoid `.playwright-artifacts-<n>` collisions across parallel pnpm runs.
+			args = append(args, "--output=test-results/"+inst.browser)
 
 			for _, proj := range baseProjects {
 				args = append(args, "--project="+inst.browser+":"+proj)
@@ -162,7 +164,7 @@ func (p *playwrightRunner) test(ctx context.Context, debug bool) error {
 
 			args := []string{"exec", "playwright", "test", p.configFlag()}
 			args = append(args, extraArgs...)
-			args = append(args, "--reporter=blob,"+filepath.Join(p.config.sharedDir, "scripts", "dot-progress-reporter.ts"), "--project=connect")
+			args = append(args, "--reporter=blob,"+filepath.Join(p.config.sharedDir, "scripts", "dot-progress-reporter.ts"), "--project=connect", "--output=test-results/connect")
 
 			if len(p.config.testFiles) > 0 {
 				args = append(args, p.config.testFiles...)

--- a/e2e/scripts/open-with-webauthn.ts
+++ b/e2e/scripts/open-with-webauthn.ts
@@ -66,7 +66,7 @@ const browserTypes = { chromium, firefox, webkit };
 const browserType =
   browserTypes[browserName as keyof typeof browserTypes] ?? chromium;
 const username = defaultUsername();
-const storageStatePath = join(e2eDir, `.auth/${username}.json`);
+const storageStatePath = join(e2eDir, `.auth/${browserName}-${username}.json`);
 
 info(`launching ${browserName} ${dim(`(mode: ${mode})`)}`);
 

--- a/e2e/scripts/open-with-webauthn.ts
+++ b/e2e/scripts/open-with-webauthn.ts
@@ -66,7 +66,7 @@ const browserTypes = { chromium, firefox, webkit };
 const browserType =
   browserTypes[browserName as keyof typeof browserTypes] ?? chromium;
 const username = defaultUsername();
-const storageStatePath = join(e2eDir, `.auth/${browserName}-${username}.json`);
+const storageStatePath = join(e2eDir, `.auth/${username}.json`);
 
 info(`launching ${browserName} ${dim(`(mode: ${mode})`)}`);
 

--- a/e2e/tests/web/authenticated/rbac.spec.ts
+++ b/e2e/tests/web/authenticated/rbac.spec.ts
@@ -114,9 +114,7 @@ test.describe('read-only access', () => {
     await test.step('User can see roles but cant create/delete/update', async () => {
       await rolesPage.goto();
 
-      await expect(
-        page.getByRole('heading', { name: 'Roles' })
-      ).toBeVisible();
+      await expect(page.getByRole('heading', { name: 'Roles' })).toBeVisible();
 
       await expect(rolesPage.createNewRoleButton).toBeDisabled();
 

--- a/e2e/tests/web/authenticated/rbac.spec.ts
+++ b/e2e/tests/web/authenticated/rbac.spec.ts
@@ -114,7 +114,9 @@ test.describe('read-only access', () => {
     await test.step('User can see roles but cant create/delete/update', async () => {
       await rolesPage.goto();
 
-      await expect(page.getByText('Roles').first()).toBeVisible();
+      await expect(
+        page.getByRole('heading', { name: 'Roles' })
+      ).toBeVisible();
 
       await expect(rolesPage.createNewRoleButton).toBeDisabled();
 

--- a/e2e/tests/web/unauthenticated/login.spec.ts
+++ b/e2e/tests/web/unauthenticated/login.spec.ts
@@ -1,0 +1,29 @@
+/**
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { login } from '@gravitational/e2e/helpers/login';
+import { test } from '@gravitational/e2e/helpers/test';
+
+test.use({ user: { roles: ['access', 'editor'] } });
+
+test('verify that a user can log in with username, password, and webauthn', async ({
+  page,
+  username,
+}) => {
+  await login(page, username);
+});


### PR DESCRIPTION
This exercises the `login` helper again in a dedicated test. We technically exercise this already in the signup test, but I thought it would be better to have an explicit login test.

To support this, unauthenticated tests can now define users - they're just not automatically logged in as that user.

Also updates the e2e reporter to not report on the auth setup tests as they add a lot of noise, and moves the authentication to global setup so it's not in the HTML report too.

Changes the `Role` assertion to check for a header as it seems to be flakey in firefox
