### PR TITLE
[v18][scopes] scope-aware authz in vnetconfig service

### DIFF
--- a/lib/auth/grpcserver.go
+++ b/lib/auth/grpcserver.go
@@ -6565,9 +6565,9 @@ func NewGRPCServer(cfg GRPCServerConfig) (*GRPCServer, error) {
 	notificationsv1pb.RegisterNotificationServiceServer(server, notificationsServer)
 
 	vnetConfigServiceServer, err := vnetconfigv1.NewService(vnetconfigv1.ServiceConfig{
-		Authorizer: cfg.Authorizer,
-		Storage:    cfg.AuthServer.VnetConfigService,
-		Emitter:    cfg.Emitter,
+		ScopedAuthorizer: cfg.ScopedAuthorizer,
+		Storage:          cfg.AuthServer.VnetConfigService,
+		Emitter:          cfg.Emitter,
 	})
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/auth/vnetconfig/vnetconfigv1/service.go
+++ b/lib/auth/vnetconfig/vnetconfigv1/service.go
@@ -31,13 +31,14 @@ import (
 	apievents "github.com/gravitational/teleport/api/types/events"
 	typesvnet "github.com/gravitational/teleport/api/types/vnet"
 	"github.com/gravitational/teleport/lib/authz"
+	"github.com/gravitational/teleport/lib/scopes"
 	"github.com/gravitational/teleport/lib/services"
 )
 
 // ServiceConfig holds configuration options for VNet service.
 type ServiceConfig struct {
-	// Authorizer is the authorizer used to check access to resources.
-	Authorizer authz.Authorizer
+	// ScopedAuthorizer is the scoped authorizer used to check access to resources.
+	ScopedAuthorizer authz.ScopedAuthorizer
 	// Emitter is used to send audit events in response to processing requests.
 	Emitter apievents.Emitter
 	// Storage is used to store VNet configs.
@@ -51,16 +52,16 @@ type Service struct {
 	// Opting out of forward compatibility, this service must implement all service methods.
 	vnet.UnsafeVnetConfigServiceServer
 
-	storage    services.VnetConfigService
-	authorizer authz.Authorizer
-	emitter    apievents.Emitter
-	logger     *slog.Logger
+	storage          services.VnetConfigService
+	scopedAuthorizer authz.ScopedAuthorizer
+	emitter          apievents.Emitter
+	logger           *slog.Logger
 }
 
 // NewService returns a new VnetConfig API service.
 func NewService(cfg ServiceConfig) (*Service, error) {
-	if cfg.Authorizer == nil {
-		return nil, trace.BadParameter("authorizer is required for vnet config service")
+	if cfg.ScopedAuthorizer == nil {
+		return nil, trace.BadParameter("scoped authorizer is required for vnet config service")
 	}
 	if cfg.Storage == nil {
 		return nil, trace.BadParameter("storage is required for vnet config service")
@@ -69,21 +70,22 @@ func NewService(cfg ServiceConfig) (*Service, error) {
 		return nil, trace.BadParameter("emitter is required for vnet config service")
 	}
 	return &Service{
-		authorizer: cfg.Authorizer,
-		storage:    cfg.Storage,
-		emitter:    cfg.Emitter,
-		logger:     cmp.Or(cfg.Logger, slog.Default()),
+		scopedAuthorizer: cfg.ScopedAuthorizer,
+		storage:          cfg.Storage,
+		emitter:          cfg.Emitter,
+		logger:           cmp.Or(cfg.Logger, slog.Default()),
 	}, nil
 }
 
 // GetVnetConfig returns the singleton VnetConfig resource.
 func (s *Service) GetVnetConfig(ctx context.Context, _ *vnet.GetVnetConfigRequest) (*vnet.VnetConfig, error) {
-	authCtx, err := s.authorizer.Authorize(ctx)
+	authCtx, err := s.scopedAuthorizer.AuthorizeScoped(ctx)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
-	if err := authCtx.CheckAccessToKind(types.KindVnetConfig, types.VerbRead); err != nil {
+	ruleCtx := authCtx.RuleContext()
+	if err := authCtx.CheckerContext.RiskyAuthorizeUnpinnedRead(ctx, services.UnpinnedReadVnetConfig, &ruleCtx); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
@@ -98,16 +100,7 @@ func (s *Service) GetVnetConfig(ctx context.Context, _ *vnet.GetVnetConfigReques
 
 // CreateVnetConfig creates a VnetConfig resource.
 func (s *Service) CreateVnetConfig(ctx context.Context, req *vnet.CreateVnetConfigRequest) (*vnet.VnetConfig, error) {
-	authCtx, err := s.authorizer.Authorize(ctx)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-
-	if err := authCtx.CheckAccessToKind(types.KindVnetConfig, types.VerbCreate); err != nil {
-		return nil, trace.Wrap(err)
-	}
-
-	if err := authCtx.AuthorizeAdminActionAllowReusedMFA(); err != nil {
+	if err := s.authorizeWrite(ctx, types.VerbCreate); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
@@ -126,16 +119,7 @@ func (s *Service) CreateVnetConfig(ctx context.Context, req *vnet.CreateVnetConf
 
 // UpdateVnetConfig updates a VnetConfig resource.
 func (s *Service) UpdateVnetConfig(ctx context.Context, req *vnet.UpdateVnetConfigRequest) (*vnet.VnetConfig, error) {
-	authCtx, err := s.authorizer.Authorize(ctx)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-
-	if err := authCtx.CheckAccessToKind(types.KindVnetConfig, types.VerbUpdate); err != nil {
-		return nil, trace.Wrap(err)
-	}
-
-	if err := authCtx.AuthorizeAdminActionAllowReusedMFA(); err != nil {
+	if err := s.authorizeWrite(ctx, types.VerbUpdate); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
@@ -154,17 +138,7 @@ func (s *Service) UpdateVnetConfig(ctx context.Context, req *vnet.UpdateVnetConf
 
 // UpsertVnetConfig does basic validation and upserts a VnetConfig resource.
 func (s *Service) UpsertVnetConfig(ctx context.Context, req *vnet.UpsertVnetConfigRequest) (*vnet.VnetConfig, error) {
-	authCtx, err := s.authorizer.Authorize(ctx)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-
-	if err := authCtx.CheckAccessToKind(types.KindVnetConfig, types.VerbCreate, types.VerbUpdate); err != nil {
-		return nil, trace.Wrap(err)
-	}
-
-	// Support reused MFA for bulk tctl create requests.
-	if err := authCtx.AuthorizeAdminActionAllowReusedMFA(); err != nil {
+	if err := s.authorizeWrite(ctx, types.VerbCreate, types.VerbUpdate); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
@@ -183,24 +157,37 @@ func (s *Service) UpsertVnetConfig(ctx context.Context, req *vnet.UpsertVnetConf
 
 // DeleteVnetConfig deletes the singleton VnetConfig resource.
 func (s *Service) DeleteVnetConfig(ctx context.Context, _ *vnet.DeleteVnetConfigRequest) (*emptypb.Empty, error) {
-	authCtx, err := s.authorizer.Authorize(ctx)
-	if err != nil {
+	if err := s.authorizeWrite(ctx, types.VerbDelete); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
-	if err := authCtx.CheckAccessToKind(types.KindVnetConfig, types.VerbDelete); err != nil {
-		return nil, trace.Wrap(err)
-	}
-
-	if err := authCtx.AuthorizeAdminActionAllowReusedMFA(); err != nil {
-		return nil, trace.Wrap(err)
-	}
-
-	err = s.storage.DeleteVnetConfig(ctx)
+	err := s.storage.DeleteVnetConfig(ctx)
 	status := eventStatus(err)
 	s.emitAuditEvent(ctx, newDeleteAuditEvent(ctx, status))
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 	return &emptypb.Empty{}, nil
+}
+
+func (s *Service) authorizeWrite(ctx context.Context, verbs ...string) error {
+	authCtx, err := s.scopedAuthorizer.AuthorizeScoped(ctx)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	// VnetConfig is unscoped, which is effectively equivalent to the root scope for authz checks.
+	const resourceScope = scopes.Root
+
+	ruleCtx := authCtx.RuleContext()
+	if err := authCtx.CheckerContext.Decision(ctx, resourceScope, func(checker *services.ScopedAccessChecker) error {
+		return checker.CheckAccessToRules(&ruleCtx, types.KindVnetConfig, verbs...)
+	}); err != nil {
+		return trace.Wrap(err)
+	}
+
+	if unscopedAuthCtx, isUnscoped := authCtx.UnscopedContext(); isUnscoped {
+		return unscopedAuthCtx.AuthorizeAdminActionAllowReusedMFA()
+	}
+	return trace.AccessDenied("cannot perform admin action as scoped identity")
 }

--- a/lib/auth/vnetconfig/vnetconfigv1/service_test.go
+++ b/lib/auth/vnetconfig/vnetconfigv1/service_test.go
@@ -30,6 +30,8 @@ import (
 	"github.com/stretchr/testify/require"
 
 	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
+	scopedaccessv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/access/v1"
+	scopesv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/v1"
 	"github.com/gravitational/teleport/api/gen/proto/go/teleport/vnet/v1"
 	"github.com/gravitational/teleport/api/types"
 	apievents "github.com/gravitational/teleport/api/types/events"
@@ -226,6 +228,50 @@ func TestServiceAccess(t *testing.T) {
 	})
 }
 
+func TestServiceScopedAccess(t *testing.T) {
+	t.Parallel()
+
+	vnetConfig := &vnet.VnetConfig{
+		Kind:    types.KindVnetConfig,
+		Version: types.V1,
+		Metadata: &headerv1.Metadata{
+			Name: types.MetaNameVnetConfig,
+		},
+	}
+
+	t.Run("read allowed despite scope pin", func(t *testing.T) {
+		service, _ := newServiceWithScopedAuthorizer(t, newFakeScopedAuthorizer(t))
+
+		// First create a VnetConfig at the storage later so the next step can read it.
+		_, err := service.storage.CreateVnetConfig(t.Context(), vnetConfig)
+		require.NoError(t, err)
+
+		// The read should be allowed.
+		_, err = service.GetVnetConfig(t.Context(), &vnet.GetVnetConfigRequest{})
+		require.NoError(t, err)
+	})
+
+	t.Run("write denied for scoped identity", func(t *testing.T) {
+		service, emitter := newServiceWithScopedAuthorizer(t, newFakeScopedAuthorizer(t))
+
+		_, err := service.CreateVnetConfig(t.Context(), &vnet.CreateVnetConfigRequest{VnetConfig: vnetConfig})
+		require.ErrorAs(t, err, new(*trace.AccessDeniedError))
+		require.Empty(t, emitter.Events(), "expected no audit events on access denied")
+
+		_, err = service.UpdateVnetConfig(t.Context(), &vnet.UpdateVnetConfigRequest{VnetConfig: vnetConfig})
+		require.ErrorAs(t, err, new(*trace.AccessDeniedError))
+		require.Empty(t, emitter.Events(), "expected no audit events on access denied")
+
+		_, err = service.UpsertVnetConfig(t.Context(), &vnet.UpsertVnetConfigRequest{VnetConfig: vnetConfig})
+		require.ErrorAs(t, err, new(*trace.AccessDeniedError))
+		require.Empty(t, emitter.Events(), "expected no audit events on access denied")
+
+		_, err = service.DeleteVnetConfig(t.Context(), &vnet.DeleteVnetConfigRequest{})
+		require.ErrorAs(t, err, new(*trace.AccessDeniedError))
+		require.Empty(t, emitter.Events(), "expected no audit events on access denied")
+	})
+}
+
 func eventStatusSuccess(t *testing.T, evt apievents.AuditEvent) bool {
 	t.Helper()
 
@@ -284,6 +330,81 @@ func (f fakeChecker) CheckAccessToRule(_ services.RuleContext, _ string, resourc
 	return trace.AccessDenied("access denied to rule=%v/verb=%v", resource, verb)
 }
 
+type fakeAuthorizer struct {
+	authState authz.AdminActionAuthState
+	checker   services.AccessChecker
+}
+
+func (f *fakeAuthorizer) Authorize(ctx context.Context) (*authz.Context, error) {
+	user, err := types.NewUser("alice")
+	if err != nil {
+		return nil, err
+	}
+
+	return &authz.Context{
+		User:                 user,
+		Checker:              f.checker,
+		AdminActionAuthState: f.authState,
+	}, nil
+}
+
+func (f *fakeAuthorizer) AuthorizeScoped(ctx context.Context) (*authz.ScopedContext, error) {
+	authzCtx, err := f.Authorize(ctx)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return authz.ScopedContextFromUnscopedContext(authzCtx), nil
+}
+
+type fakeScopedAuthorizer struct {
+	ctx *authz.ScopedContext
+}
+
+func (f fakeScopedAuthorizer) AuthorizeScoped(context.Context) (*authz.ScopedContext, error) {
+	return f.ctx, nil
+}
+
+type fakeScopedRoleReader struct {
+	roles map[string]*scopedaccessv1.ScopedRole
+}
+
+func (f fakeScopedRoleReader) GetScopedRole(_ context.Context, req *scopedaccessv1.GetScopedRoleRequest) (*scopedaccessv1.GetScopedRoleResponse, error) {
+	role := f.roles[req.GetName()]
+	if role == nil {
+		return nil, trace.NotFound("scoped role %q not found", req.GetName())
+	}
+	return &scopedaccessv1.GetScopedRoleResponse{Role: role}, nil
+}
+
+func (f fakeScopedRoleReader) ListScopedRoles(context.Context, *scopedaccessv1.ListScopedRolesRequest) (*scopedaccessv1.ListScopedRolesResponse, error) {
+	roles := make([]*scopedaccessv1.ScopedRole, 0, len(f.roles))
+	for _, role := range f.roles {
+		roles = append(roles, role)
+	}
+	return &scopedaccessv1.ListScopedRolesResponse{Roles: roles}, nil
+}
+
+func newFakeScopedAuthorizer(t *testing.T) fakeScopedAuthorizer {
+	t.Helper()
+
+	checkerContext, err := services.NewScopedAccessCheckerContext(t.Context(), &services.AccessInfo{
+		Username: "alice",
+		ScopePin: &scopesv1.Pin{
+			Scope: "/test",
+		},
+	}, "test-cluster", fakeScopedRoleReader{})
+	require.NoError(t, err)
+
+	return fakeScopedAuthorizer{
+		ctx: &authz.ScopedContext{
+			User: &types.UserV2{
+				Metadata: types.Metadata{Name: "alice"},
+			},
+			CheckerContext: checkerContext,
+		},
+	}
+}
+
 func newService(t *testing.T, authState authz.AdminActionAuthState, checker services.AccessChecker) (*Service, *eventstest.MockRecorderEmitter) {
 	t.Helper()
 
@@ -300,22 +421,35 @@ func newServiceWithStorage(t *testing.T, authState authz.AdminActionAuthState, c
 	t.Helper()
 
 	emitter := &eventstest.MockRecorderEmitter{}
-	authorizer := authz.AuthorizerFunc(func(ctx context.Context) (*authz.Context, error) {
-		user, err := types.NewUser("alice")
-		if err != nil {
-			return nil, err
-		}
-		return &authz.Context{
-			User:                 user,
-			Checker:              checker,
-			AdminActionAuthState: authState,
-		}, nil
-	})
+
+	authorizer := &fakeAuthorizer{
+		authState: authState,
+		checker:   checker,
+	}
 
 	service, err := NewService(ServiceConfig{
-		Authorizer: authorizer,
-		Storage:    storage,
-		Emitter:    emitter,
+		ScopedAuthorizer: authorizer,
+		Storage:          storage,
+		Emitter:          emitter,
+	})
+	require.NoError(t, err)
+	return service, emitter
+}
+
+func newServiceWithScopedAuthorizer(t *testing.T, authorizer authz.ScopedAuthorizer) (*Service, *eventstest.MockRecorderEmitter) {
+	t.Helper()
+
+	bk, err := memory.New(memory.Config{})
+	require.NoError(t, err)
+
+	storage, err := local.NewVnetConfigService(bk)
+	require.NoError(t, err)
+
+	emitter := &eventstest.MockRecorderEmitter{}
+	service, err := NewService(ServiceConfig{
+		ScopedAuthorizer: authorizer,
+		Storage:          storage,
+		Emitter:          emitter,
 	})
 	require.NoError(t, err)
 	return service, emitter


### PR DESCRIPTION
Backport #66268 to branch/v18

## Manual Test Plan
### Test Environment

running cluster with `TELEPORT_UNSTABLE_SCOPES=yes`
some user granted a scoped role in some scope
unscoped admin user

### Test Cases
- [x] unscoped user with editor role can still read and upsert vnet config (with admin mfa for upsert)
- [x] log in with a scope pin `tsh login --scope=/test`
- [x] `tctl get vnet_config` works
- [x] `tsh vnet` works and VNet SSH access works (scopes don't yet support app access) 