### PR TITLE
Add `cli-docs` target, fix generation, update references

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2022,12 +2022,15 @@ dump-preset-roles:
 	GOOS=$(OS) GOARCH=$(ARCH) $(CGOFLAG) go run ./build.assets/dump-preset-roles/main.go
 	pnpm test web/packages/teleport/src/Roles/RoleEditor/StandardEditor/standardmodel.test.ts
 
+.PHONY: cli-docs
+cli-docs: cli-docs-tsh cli-docs-tbot cli-docs-teleport cli-docs-tctl
+
 .PHONY: cli-docs-tsh
 cli-docs-tsh:
 # Executing go build instead of go run since we don't want to redirect
 # irrelevant output along with the docs page content.
 	go build -o $(BUILDDIR)/tshdocs -tags docs ./tool/tsh && \
-	$(BUILDDIR)/tshdocs help 2>docs/pages/reference/cli/tsh.mdx && \
+	$(BUILDDIR)/tshdocs help 1>docs/pages/reference/cli/tsh.mdx && \
 	rm $(BUILDDIR)/tshdocs
 
 .PHONY: cli-docs-tbot
@@ -2035,7 +2038,7 @@ cli-docs-tbot:
 # Executing go build instead of go run since we don't want to redirect
 # irrelevant output along with the docs page content.
 	go build -o $(BUILDDIR)/tbotdocs -tags docs ./tool/tbot && \
-	$(BUILDDIR)/tbotdocs help 2>docs/pages/reference/cli/tbot.mdx && \
+	$(BUILDDIR)/tbotdocs help 1>docs/pages/reference/cli/tbot.mdx && \
 	rm $(BUILDDIR)/tbotdocs
 
 .PHONY: cli-docs-teleport
@@ -2043,7 +2046,7 @@ cli-docs-teleport:
 # Executing go build instead of go run since we don't want to redirect
 # irrelevant output along with the docs page content.
 	go build -o $(BUILDDIR)/teleportdocs -tags docs ./tool/teleport && \
-	$(BUILDDIR)/teleportdocs help 2>docs/pages/reference/cli/teleport.mdx && \
+	$(BUILDDIR)/teleportdocs help 1>docs/pages/reference/cli/teleport.mdx && \
 	rm $(BUILDDIR)/teleportdocs
 
 .PHONY: cli-docs-tctl
@@ -2051,7 +2054,7 @@ cli-docs-tctl:
 # Executing go build instead of go run since we don't want to redirect
 # irrelevant output along with the docs page content.
 	go build -o $(BUILDDIR)/tctldocs -tags docs ./tool/tctl && \
-	$(BUILDDIR)/tctldocs help 2>docs/pages/reference/cli/tctl.mdx && \
+	$(BUILDDIR)/tctldocs help 1>docs/pages/reference/cli/tctl.mdx && \
 	rm $(BUILDDIR)/tctldocs
 
 # audit-event-reference generates audit event reference docs using the Web UI

--- a/docs/pages/reference/cli/tbot.mdx
+++ b/docs/pages/reference/cli/tbot.mdx
@@ -69,6 +69,7 @@ Flags:
 |`--join-method`|none|Method to use to join the cluster. (azure, azure_devops, bitbucket, circleci, gcp, github, gitlab, iam, kubernetes, spacelift, token, tpm, terraform_cloud, oracle, bound_keypair, env0)|
 |`--join-uri`|none|An optional URI with joining and authentication parameters. Individual flags for proxy, join method, token, etc may be used instead.|
 |`--[no-]oneshot`|`false`|If set, quit after the first renewal.|
+|`--[no-]scoped`|`false`|Indicates whether tbot should run in scoped mode. This is required when authenticating as a scoped Bot.|
 |`--[no-]specific-tls-extensions`|`false`|If set, includes additional `tls.crt`, `tls.key`, and `tls.cas` for apps that require these file extensions|
 |`--pid-file`|none|Full path to the PID file. By default no PID file will be created.|
 |`--proxy-server`|none|Address of the Teleport Proxy Server.|
@@ -111,6 +112,7 @@ Flags:
 |`--join-uri`|none|An optional URI with joining and authentication parameters. Individual flags for proxy, join method, token, etc may be used instead.|
 |`--listen`|none|The socket URI on which the local proxy should listen, such as `tcp://0.0.0.0:8080`.|
 |`--[no-]oneshot`|`false`|If set, quit after the first renewal.|
+|`--[no-]scoped`|`false`|Indicates whether tbot should run in scoped mode. This is required when authenticating as a scoped Bot.|
 |`--pid-file`|none|Full path to the PID file. By default no PID file will be created.|
 |`--proxy-server`|none|Address of the Teleport Proxy Server.|
 |`--registration-secret`|none|For bound keypair joining, specifies a registration secret for use at first join.|
@@ -151,6 +153,7 @@ Flags:
 |`--join-uri`|none|An optional URI with joining and authentication parameters. Individual flags for proxy, join method, token, etc may be used instead.|
 |`--listen`|none|The socket URI on which the tunnel should listen, such as `tcp://0.0.0.0:8080`.|
 |`--[no-]oneshot`|`false`|If set, quit after the first renewal.|
+|`--[no-]scoped`|`false`|Indicates whether tbot should run in scoped mode. This is required when authenticating as a scoped Bot.|
 |`--pid-file`|none|Full path to the PID file. By default no PID file will be created.|
 |`--proxy-server`|none|Address of the Teleport Proxy Server.|
 |`--registration-secret`|none|For bound keypair joining, specifies a registration secret for use at first join.|
@@ -192,6 +195,7 @@ Flags:
 |`--join-method`|none|Method to use to join the cluster. (azure, azure_devops, bitbucket, circleci, gcp, github, gitlab, iam, kubernetes, spacelift, token, tpm, terraform_cloud, oracle, bound_keypair, env0)|
 |`--join-uri`|none|An optional URI with joining and authentication parameters. Individual flags for proxy, join method, token, etc may be used instead.|
 |`--[no-]oneshot`|`false`|If set, quit after the first renewal.|
+|`--[no-]scoped`|`false`|Indicates whether tbot should run in scoped mode. This is required when authenticating as a scoped Bot.|
 |`--pid-file`|none|Full path to the PID file. By default no PID file will be created.|
 |`--proxy-server`|none|Address of the Teleport Proxy Server.|
 |`--reader-group`|none|An additional group name or GID that should be allowed by ACLs to read this destination. Only valid for file destinations on Linux.|
@@ -236,6 +240,7 @@ Flags:
 |`--join-uri`|none|An optional URI with joining and authentication parameters. Individual flags for proxy, join method, token, etc may be used instead.|
 |`--listen`|none|A socket URI to listen on, such as `tcp://0.0.0.0:3306`.|
 |`--[no-]oneshot`|`false`|If set, quit after the first renewal.|
+|`--[no-]scoped`|`false`|Indicates whether tbot should run in scoped mode. This is required when authenticating as a scoped Bot.|
 |`--pid-file`|none|Full path to the PID file. By default no PID file will be created.|
 |`--proxy-server`|none|Address of the Teleport Proxy Server.|
 |`--registration-secret`|none|For bound keypair joining, specifies a registration secret for use at first join.|
@@ -279,6 +284,7 @@ Flags:
 |`--join-uri`|none|An optional URI with joining and authentication parameters. Individual flags for proxy, join method, token, etc may be used instead.|
 |`--[no-]allow-reissue`|`false`|Allow the credentials output by this command to be reissued.|
 |`--[no-]oneshot`|`false`|If set, quit after the first renewal.|
+|`--[no-]scoped`|`false`|Indicates whether tbot should run in scoped mode. This is required when authenticating as a scoped Bot.|
 |`--pid-file`|none|Full path to the PID file. By default no PID file will be created.|
 |`--proxy-server`|none|Address of the Teleport Proxy Server.|
 |`--reader-group`|none|An additional group name or GID that should be allowed by ACLs to read this destination. Only valid for file destinations on Linux.|
@@ -322,6 +328,7 @@ Flags:
 |`--kubernetes-cluster`|none|The name of the Kubernetes cluster in Teleport for which to fetch credentials.|
 |`--[no-]disable-exec-plugin`|`false`|If set, disables the exec plugin. This allows credentials to be used without the `tbot` binary.|
 |`--[no-]oneshot`|`false`|If set, quit after the first renewal.|
+|`--[no-]scoped`|`false`|Indicates whether tbot should run in scoped mode. This is required when authenticating as a scoped Bot.|
 |`--pid-file`|none|Full path to the PID file. By default no PID file will be created.|
 |`--proxy-server`|none|Address of the Teleport Proxy Server.|
 |`--reader-group`|none|An additional group name or GID that should be allowed by ACLs to read this destination. Only valid for file destinations on Linux.|
@@ -366,6 +373,7 @@ Flags:
 |`--name-selector`|none|An explicit Kubernetes cluster name to include. Repeatable.|
 |`--[no-]disable-exec-plugin`|`false`|If set, disables the exec plugin. This allows credentials to be used without the `tbot` binary.|
 |`--[no-]oneshot`|`false`|If set, quit after the first renewal.|
+|`--[no-]scoped`|`false`|Indicates whether tbot should run in scoped mode. This is required when authenticating as a scoped Bot.|
 |`--pid-file`|none|Full path to the PID file. By default no PID file will be created.|
 |`--proxy-server`|none|Address of the Teleport Proxy Server.|
 |`--reader-group`|none|An additional group name or GID that should be allowed by ACLs to read this destination. Only valid for file destinations on Linux.|
@@ -407,6 +415,7 @@ Flags:
 |`--diag-addr`|none|If set and the bot is in debug mode, a diagnostics service will listen on specified address.|
 |`--join-method`|none|Method to use to join the cluster. (azure, azure_devops, bitbucket, circleci, gcp, github, gitlab, iam, kubernetes, spacelift, token, tpm, terraform_cloud, oracle, bound_keypair, env0)|
 |`--[no-]oneshot`|`false`|If set, quit after the first renewal.|
+|`--[no-]scoped`|`false`|Indicates whether tbot should run in scoped mode. This is required when authenticating as a scoped Bot.|
 |`--pid-file`|none|Full path to the PID file. By default no PID file will be created.|
 |`--proxy-server`|none|Address of the Teleport Proxy Server.|
 |`--renewal-interval`|none|Interval at which short-lived certificates are renewed; must be less than the certificate TTL.|
@@ -441,6 +450,7 @@ Flags:
 |`--join-method`|none|Method to use to join the cluster. (azure, azure_devops, bitbucket, circleci, gcp, github, gitlab, iam, kubernetes, spacelift, token, tpm, terraform_cloud, oracle, bound_keypair, env0)|
 |`--join-uri`|none|An optional URI with joining and authentication parameters. Individual flags for proxy, join method, token, etc may be used instead.|
 |`--[no-]oneshot`|`false`|If set, quit after the first renewal.|
+|`--[no-]scoped`|`false`|Indicates whether tbot should run in scoped mode. This is required when authenticating as a scoped Bot.|
 |`--pid-file`|none|Full path to the PID file. By default no PID file will be created.|
 |`--proxy-server`|none|Address of the Teleport Proxy Server.|
 |`--registration-secret`|none|For bound keypair joining, specifies a registration secret for use at first join.|
@@ -481,6 +491,7 @@ Flags:
 |`--join-uri`|none|An optional URI with joining and authentication parameters. Individual flags for proxy, join method, token, etc may be used instead.|
 |`--[no-]enable-resumption`|`false`|If set, disables SSH session resumption.|
 |`--[no-]oneshot`|`false`|If set, quit after the first renewal.|
+|`--[no-]scoped`|`false`|Indicates whether tbot should run in scoped mode. This is required when authenticating as a scoped Bot.|
 |`--pid-file`|none|Full path to the PID file. By default no PID file will be created.|
 |`--proxy-command`|none|The command to run as the SSH ProxyCommand, such as `fdpass-teleport`. Defaults to this tbot binary. Repeatable to add additional args.|
 |`--proxy-server`|none|Address of the Teleport Proxy Server.|
@@ -527,6 +538,7 @@ Flags:
 |`--listen`|none|The address on which the workload identity API should listen. This should either be prefixed with 'unix://' or 'tcp://'.|
 |`--name-selector`|none|The name of the workload identity to issue. Mutually exclusive with --label-selector.|
 |`--[no-]oneshot`|`false`|If set, quit after the first renewal.|
+|`--[no-]scoped`|`false`|Indicates whether tbot should run in scoped mode. This is required when authenticating as a scoped Bot.|
 |`--pid-file`|none|Full path to the PID file. By default no PID file will be created.|
 |`--proxy-server`|none|Address of the Teleport Proxy Server.|
 |`--registration-secret`|none|For bound keypair joining, specifies a registration secret for use at first join.|
@@ -569,6 +581,7 @@ Flags:
 |`--label-selector`|none|A label-based selector for which workload identities to issue. Multiple labels can be provided using ','. Mutually exclusive with --name-selector.|
 |`--name-selector`|none|The name of the workload identity to issue. Mutually exclusive with --label-selector.|
 |`--[no-]oneshot`|`false`|If set, quit after the first renewal.|
+|`--[no-]scoped`|`false`|Indicates whether tbot should run in scoped mode. This is required when authenticating as a scoped Bot.|
 |`--pid-file`|none|Full path to the PID file. By default no PID file will be created.|
 |`--profile-arn`|none|The ARN of the Roles Anywhere profile to use.|
 |`--proxy-server`|none|Address of the Teleport Proxy Server.|
@@ -619,6 +632,7 @@ Flags:
 |`--label-selector`|none|A label-based selector for which workload identities to issue. Multiple labels can be provided using ','. Mutually exclusive with --name-selector.|
 |`--name-selector`|none|The name of the workload identity to issue. Mutually exclusive with --label-selector.|
 |`--[no-]oneshot`|`false`|If set, quit after the first renewal.|
+|`--[no-]scoped`|`false`|Indicates whether tbot should run in scoped mode. This is required when authenticating as a scoped Bot.|
 |`--pid-file`|none|Full path to the PID file. By default no PID file will be created.|
 |`--proxy-server`|none|Address of the Teleport Proxy Server.|
 |`--reader-group`|none|An additional group name or GID that should be allowed by ACLs to read this destination. Only valid for file destinations on Linux.|
@@ -663,6 +677,7 @@ Flags:
 |`--name-selector`|none|The name of the workload identity to issue. Mutually exclusive with --label-selector.|
 |`--[no-]include-federated-trust-bundles`|`false`|If set, include federated trust bundles in the output.|
 |`--[no-]oneshot`|`false`|If set, quit after the first renewal.|
+|`--[no-]scoped`|`false`|Indicates whether tbot should run in scoped mode. This is required when authenticating as a scoped Bot.|
 |`--pid-file`|none|Full path to the PID file. By default no PID file will be created.|
 |`--proxy-server`|none|Address of the Teleport Proxy Server.|
 |`--reader-group`|none|An additional group name or GID that should be allowed by ACLs to read this destination. Only valid for file destinations on Linux.|
@@ -899,6 +914,7 @@ Flags:
 |`--join-method`|none|Method to use to join the cluster. (azure, azure_devops, bitbucket, circleci, gcp, github, gitlab, iam, kubernetes, spacelift, token, tpm, terraform_cloud, oracle, bound_keypair, env0)|
 |`--join-uri`|none|An optional URI with joining and authentication parameters. Individual flags for proxy, join method, token, etc may be used instead.|
 |`--[no-]oneshot`|`false`|If set, quit after the first renewal.|
+|`--[no-]scoped`|`false`|Indicates whether tbot should run in scoped mode. This is required when authenticating as a scoped Bot.|
 |`--[no-]specific-tls-extensions`|`false`|If set, includes additional `tls.crt`, `tls.key`, and `tls.cas` for apps that require these file extensions|
 |`--pid-file`|none|Full path to the PID file. By default no PID file will be created.|
 |`--proxy-server`|none|Address of the Teleport Proxy Server.|
@@ -941,6 +957,7 @@ Flags:
 |`--join-uri`|none|An optional URI with joining and authentication parameters. Individual flags for proxy, join method, token, etc may be used instead.|
 |`--listen`|none|The socket URI on which the local proxy should listen, such as `tcp://0.0.0.0:8080`.|
 |`--[no-]oneshot`|`false`|If set, quit after the first renewal.|
+|`--[no-]scoped`|`false`|Indicates whether tbot should run in scoped mode. This is required when authenticating as a scoped Bot.|
 |`--pid-file`|none|Full path to the PID file. By default no PID file will be created.|
 |`--proxy-server`|none|Address of the Teleport Proxy Server.|
 |`--registration-secret`|none|For bound keypair joining, specifies a registration secret for use at first join.|
@@ -981,6 +998,7 @@ Flags:
 |`--join-uri`|none|An optional URI with joining and authentication parameters. Individual flags for proxy, join method, token, etc may be used instead.|
 |`--listen`|none|The socket URI on which the tunnel should listen, such as `tcp://0.0.0.0:8080`.|
 |`--[no-]oneshot`|`false`|If set, quit after the first renewal.|
+|`--[no-]scoped`|`false`|Indicates whether tbot should run in scoped mode. This is required when authenticating as a scoped Bot.|
 |`--pid-file`|none|Full path to the PID file. By default no PID file will be created.|
 |`--proxy-server`|none|Address of the Teleport Proxy Server.|
 |`--registration-secret`|none|For bound keypair joining, specifies a registration secret for use at first join.|
@@ -1022,6 +1040,7 @@ Flags:
 |`--join-method`|none|Method to use to join the cluster. (azure, azure_devops, bitbucket, circleci, gcp, github, gitlab, iam, kubernetes, spacelift, token, tpm, terraform_cloud, oracle, bound_keypair, env0)|
 |`--join-uri`|none|An optional URI with joining and authentication parameters. Individual flags for proxy, join method, token, etc may be used instead.|
 |`--[no-]oneshot`|`false`|If set, quit after the first renewal.|
+|`--[no-]scoped`|`false`|Indicates whether tbot should run in scoped mode. This is required when authenticating as a scoped Bot.|
 |`--pid-file`|none|Full path to the PID file. By default no PID file will be created.|
 |`--proxy-server`|none|Address of the Teleport Proxy Server.|
 |`--reader-group`|none|An additional group name or GID that should be allowed by ACLs to read this destination. Only valid for file destinations on Linux.|
@@ -1066,6 +1085,7 @@ Flags:
 |`--join-uri`|none|An optional URI with joining and authentication parameters. Individual flags for proxy, join method, token, etc may be used instead.|
 |`--listen`|none|A socket URI to listen on, such as `tcp://0.0.0.0:3306`.|
 |`--[no-]oneshot`|`false`|If set, quit after the first renewal.|
+|`--[no-]scoped`|`false`|Indicates whether tbot should run in scoped mode. This is required when authenticating as a scoped Bot.|
 |`--pid-file`|none|Full path to the PID file. By default no PID file will be created.|
 |`--proxy-server`|none|Address of the Teleport Proxy Server.|
 |`--registration-secret`|none|For bound keypair joining, specifies a registration secret for use at first join.|
@@ -1109,6 +1129,7 @@ Flags:
 |`--join-uri`|none|An optional URI with joining and authentication parameters. Individual flags for proxy, join method, token, etc may be used instead.|
 |`--[no-]allow-reissue`|`false`|Allow the credentials output by this command to be reissued.|
 |`--[no-]oneshot`|`false`|If set, quit after the first renewal.|
+|`--[no-]scoped`|`false`|Indicates whether tbot should run in scoped mode. This is required when authenticating as a scoped Bot.|
 |`--pid-file`|none|Full path to the PID file. By default no PID file will be created.|
 |`--proxy-server`|none|Address of the Teleport Proxy Server.|
 |`--reader-group`|none|An additional group name or GID that should be allowed by ACLs to read this destination. Only valid for file destinations on Linux.|
@@ -1152,6 +1173,7 @@ Flags:
 |`--kubernetes-cluster`|none|The name of the Kubernetes cluster in Teleport for which to fetch credentials.|
 |`--[no-]disable-exec-plugin`|`false`|If set, disables the exec plugin. This allows credentials to be used without the `tbot` binary.|
 |`--[no-]oneshot`|`false`|If set, quit after the first renewal.|
+|`--[no-]scoped`|`false`|Indicates whether tbot should run in scoped mode. This is required when authenticating as a scoped Bot.|
 |`--pid-file`|none|Full path to the PID file. By default no PID file will be created.|
 |`--proxy-server`|none|Address of the Teleport Proxy Server.|
 |`--reader-group`|none|An additional group name or GID that should be allowed by ACLs to read this destination. Only valid for file destinations on Linux.|
@@ -1196,6 +1218,7 @@ Flags:
 |`--name-selector`|none|An explicit Kubernetes cluster name to include. Repeatable.|
 |`--[no-]disable-exec-plugin`|`false`|If set, disables the exec plugin. This allows credentials to be used without the `tbot` binary.|
 |`--[no-]oneshot`|`false`|If set, quit after the first renewal.|
+|`--[no-]scoped`|`false`|Indicates whether tbot should run in scoped mode. This is required when authenticating as a scoped Bot.|
 |`--pid-file`|none|Full path to the PID file. By default no PID file will be created.|
 |`--proxy-server`|none|Address of the Teleport Proxy Server.|
 |`--reader-group`|none|An additional group name or GID that should be allowed by ACLs to read this destination. Only valid for file destinations on Linux.|
@@ -1237,6 +1260,7 @@ Flags:
 |`--diag-addr`|none|If set and the bot is in debug mode, a diagnostics service will listen on specified address.|
 |`--join-method`|none|Method to use to join the cluster. (azure, azure_devops, bitbucket, circleci, gcp, github, gitlab, iam, kubernetes, spacelift, token, tpm, terraform_cloud, oracle, bound_keypair, env0)|
 |`--[no-]oneshot`|`false`|If set, quit after the first renewal.|
+|`--[no-]scoped`|`false`|Indicates whether tbot should run in scoped mode. This is required when authenticating as a scoped Bot.|
 |`--pid-file`|none|Full path to the PID file. By default no PID file will be created.|
 |`--proxy-server`|none|Address of the Teleport Proxy Server.|
 |`--renewal-interval`|none|Interval at which short-lived certificates are renewed; must be less than the certificate TTL.|
@@ -1271,6 +1295,7 @@ Flags:
 |`--join-method`|none|Method to use to join the cluster. (azure, azure_devops, bitbucket, circleci, gcp, github, gitlab, iam, kubernetes, spacelift, token, tpm, terraform_cloud, oracle, bound_keypair, env0)|
 |`--join-uri`|none|An optional URI with joining and authentication parameters. Individual flags for proxy, join method, token, etc may be used instead.|
 |`--[no-]oneshot`|`false`|If set, quit after the first renewal.|
+|`--[no-]scoped`|`false`|Indicates whether tbot should run in scoped mode. This is required when authenticating as a scoped Bot.|
 |`--pid-file`|none|Full path to the PID file. By default no PID file will be created.|
 |`--proxy-server`|none|Address of the Teleport Proxy Server.|
 |`--registration-secret`|none|For bound keypair joining, specifies a registration secret for use at first join.|
@@ -1311,6 +1336,7 @@ Flags:
 |`--join-uri`|none|An optional URI with joining and authentication parameters. Individual flags for proxy, join method, token, etc may be used instead.|
 |`--[no-]enable-resumption`|`false`|If set, disables SSH session resumption.|
 |`--[no-]oneshot`|`false`|If set, quit after the first renewal.|
+|`--[no-]scoped`|`false`|Indicates whether tbot should run in scoped mode. This is required when authenticating as a scoped Bot.|
 |`--pid-file`|none|Full path to the PID file. By default no PID file will be created.|
 |`--proxy-command`|none|The command to run as the SSH ProxyCommand, such as `fdpass-teleport`. Defaults to this tbot binary. Repeatable to add additional args.|
 |`--proxy-server`|none|Address of the Teleport Proxy Server.|
@@ -1357,6 +1383,7 @@ Flags:
 |`--listen`|none|The address on which the workload identity API should listen. This should either be prefixed with 'unix://' or 'tcp://'.|
 |`--name-selector`|none|The name of the workload identity to issue. Mutually exclusive with --label-selector.|
 |`--[no-]oneshot`|`false`|If set, quit after the first renewal.|
+|`--[no-]scoped`|`false`|Indicates whether tbot should run in scoped mode. This is required when authenticating as a scoped Bot.|
 |`--pid-file`|none|Full path to the PID file. By default no PID file will be created.|
 |`--proxy-server`|none|Address of the Teleport Proxy Server.|
 |`--registration-secret`|none|For bound keypair joining, specifies a registration secret for use at first join.|
@@ -1399,6 +1426,7 @@ Flags:
 |`--label-selector`|none|A label-based selector for which workload identities to issue. Multiple labels can be provided using ','. Mutually exclusive with --name-selector.|
 |`--name-selector`|none|The name of the workload identity to issue. Mutually exclusive with --label-selector.|
 |`--[no-]oneshot`|`false`|If set, quit after the first renewal.|
+|`--[no-]scoped`|`false`|Indicates whether tbot should run in scoped mode. This is required when authenticating as a scoped Bot.|
 |`--pid-file`|none|Full path to the PID file. By default no PID file will be created.|
 |`--profile-arn`|none|The ARN of the Roles Anywhere profile to use.|
 |`--proxy-server`|none|Address of the Teleport Proxy Server.|
@@ -1449,6 +1477,7 @@ Flags:
 |`--label-selector`|none|A label-based selector for which workload identities to issue. Multiple labels can be provided using ','. Mutually exclusive with --name-selector.|
 |`--name-selector`|none|The name of the workload identity to issue. Mutually exclusive with --label-selector.|
 |`--[no-]oneshot`|`false`|If set, quit after the first renewal.|
+|`--[no-]scoped`|`false`|Indicates whether tbot should run in scoped mode. This is required when authenticating as a scoped Bot.|
 |`--pid-file`|none|Full path to the PID file. By default no PID file will be created.|
 |`--proxy-server`|none|Address of the Teleport Proxy Server.|
 |`--reader-group`|none|An additional group name or GID that should be allowed by ACLs to read this destination. Only valid for file destinations on Linux.|
@@ -1493,6 +1522,7 @@ Flags:
 |`--name-selector`|none|The name of the workload identity to issue. Mutually exclusive with --label-selector.|
 |`--[no-]include-federated-trust-bundles`|`false`|If set, include federated trust bundles in the output.|
 |`--[no-]oneshot`|`false`|If set, quit after the first renewal.|
+|`--[no-]scoped`|`false`|Indicates whether tbot should run in scoped mode. This is required when authenticating as a scoped Bot.|
 |`--pid-file`|none|Full path to the PID file. By default no PID file will be created.|
 |`--proxy-server`|none|Address of the Teleport Proxy Server.|
 |`--reader-group`|none|An additional group name or GID that should be allowed by ACLs to read this destination. Only valid for file destinations on Linux.|
@@ -1540,5 +1570,5 @@ Flags:
 |---|---|---|
 |`--diag-addr`|none|The configured --diag-addr of a running bot, in host:port form.|
 |`--service`|none|An optional name. If set, waits for only the named service to become healthy. If unset, waits for all services.|
-|`--timeout`|none|An optional timeout. If set, returns an error if all specified services have reported healthy by the timeout.|
+|`--timeout`|none|An optional timeout. If set, returns an error if not all specified services have reported healthy by the timeout.|
 

--- a/docs/pages/reference/cli/tctl.mdx
+++ b/docs/pages/reference/cli/tctl.mdx
@@ -34,8 +34,8 @@ Global flags:
 |`-c`, `--config`|none|Path to a configuration file \[/etc/teleport.yaml\] for an Auth Service instance. Can also be set via the TELEPORT_CONFIG_FILE environment variable. Ignored if the auth_service is disabled.|
 |`-d`, `--[no-]debug`|`false`|Enable verbose logging to stderr|
 |`-i`, `--identity`|none|Path to an identity file. Must be provided to make remote connections to auth. An identity file can be exported with 'tctl auth sign'|
-|`--[no-]insecure`|`false`|When specifying a proxy address in --auth-server, do not verify its TLS certificate. Danger: any data you send can be intercepted or modified by an attacker.|
 |`--mfa-mode`|`auto`|Preferred mode for MFA assertions (auto, cross-platform, platform, sso, browser).|
+|`--[no-]insecure`|`false`|When specifying a proxy address in --auth-server, do not verify its TLS certificate. Danger: any data you send can be intercepted or modified by an attacker.|
 
 Global environment variables:
 
@@ -128,6 +128,30 @@ Arguments:
 |Argument|Default|Description|
 |---|---|---|
 |access-list-name|none (required)|The access list name to fetch review history for.|
+
+## tctl acl summary
+
+Show summary information for access lists, including their members and last
+review.
+
+Usage:
+
+```code
+$ tctl acl summary [<flags>] [<access-list-name>]
+```
+
+Flags:
+
+|Flag|Default|Description|
+|---|---|---|
+|`--format`|`yaml`|Output format 'yaml' or 'json'|
+|`--[no-]review-only`|`true`|Show only access lists that are due for review within the next 2 weeks or past due. Defaults to true.|
+
+Arguments:
+
+|Argument|Default|Description|
+|---|---|---|
+|access-list-name|none (optional)|The access list name to show summary for. If not provided, shows summary for all access lists.|
 
 ## tctl acl users add
 
@@ -496,7 +520,7 @@ Flags:
 |`--integration`|none|Name of the integration. Only applies to "github" CAs.|
 |`--[no-]keys`|`false`|if set, will print private keys|
 |`--out`|none|If set writes exported authorities to files with the given path prefix|
-|`--type`|none|export certificate type (user, host, tls-host, tls-user, tls-user-der, tls-spiffe, windows, db, db-der, db-client, db-client-der, openssh, saml-idp, github, awsra)|
+|`--type`|none|export certificate type (user, host, tls-host, tls-user, tls-user-der, tls-spiffe, windows, db, db-der, db-client, db-client-der, openssh, saml-idp, github, awsra, app-client)|
 
 ## tctl auth ls
 
@@ -533,7 +557,7 @@ Flags:
 |`--[no-]interactive`|`false`|Enable interactive mode|
 |`--[no-]manual`|`false`|Activate manual rotation, set rotation phases manually|
 |`--phase`|none|Target rotation phase to set, used in manual rotation, one of: init, standby, update_clients, update_servers, rollback|
-|`--type`|none|Certificate authority to rotate, one of: host, windows, user, db, db_client, openssh, jwt, saml_idp, oidc_idp, spiffe, okta, awsra, bound_keypair|
+|`--type`|none|Certificate authority to rotate, one of: host, windows, user, db, db_client, openssh, jwt, saml_idp, oidc_idp, spiffe, okta, awsra, bound_keypair, app_client|
 
 ## tctl auth sign
 
@@ -1048,6 +1072,26 @@ Flags:
 |`--device-id`|none|Device identifier|
 |`--[no-]current-device`|`false`|Removes the current device. Overrides --device-id and --asset-tag.|
 
+## tctl discovery nodes
+
+Report discovered server instances and their enrollment status using Teleport
+audit log and cluster state.
+
+Usage:
+
+```code
+$ tctl discovery nodes [<flags>]
+```
+
+Flags:
+
+|Flag|Default|Description|
+|---|---|---|
+|`--cloud`|``|Comma-separated list of cloud providers to include (allowed: aws, azure). Empty (default) returns all.|
+|`--format`|`text`|Output format.|
+|`--last`|`1h`|Time window to look back for failures in Teleport audit log (e.g. 1h, 24h, 30m).|
+|`--[no-]failures-only`|`false`|Only show instances with enrollment failures.|
+
 ## tctl edit
 
 Edit a Teleport resource.
@@ -1237,6 +1281,7 @@ Flags:
 |`--device`|none|UUID of a trusted device to disable.|
 |`--expires`|none|Time point (RFC3339) when the lock expires.|
 |`--join-token`|none|Bot join token name to disable|
+|`--linux-desktop`|none|Name of a Linux desktop to disable.|
 |`--login`|none|Name of a local UNIX user to disable.|
 |`--message`|none|Message to display to locked-out users.|
 |`--mfa-device`|none|UUID of a user MFA device to disable.|
@@ -1702,6 +1747,45 @@ Flags:
 |`--limit`|`50`|Maximum number of recordings to show. Default 50.|
 |`--to-utc`|none|End of time range in which recordings are listed. Format 2006-01-02. Defaults to current time.|
 
+## tctl recordings search
+
+Search session recordings using semantic and keyword queries.
+
+Usage:
+
+```code
+$ tctl recordings search [<flags>] [<query>...]
+```
+
+Flags:
+
+|Flag|Default|Description|
+|---|---|---|
+|`--access-request`|none|Filter by access request ID. Can be specified multiple times.|
+|`--database-name`|none|Filter database sessions by database name.|
+|`--format`|`text`|Format output (text, json, yaml).. Defaults to 'text'.|
+|`--from`|none|Start of time range. Format 2006-01-02. Defaults to 24 hours ago.|
+|`--kind`|none|Filter by session kind (ssh, db, k8s, desktop). Can be specified multiple times.|
+|`--label`|none|Filter by resource labels (key=value pairs), e.g. env/prod=true,db/type=postgres.|
+|`--limit`|`50`|Maximum number of results to return.|
+|`--pod-name`|none|Filter Kubernetes sessions by pod name.|
+|`--pod-namespace`|none|Filter Kubernetes sessions by pod namespace.|
+|`--resource-kind`|none|Filter by Teleport resource type (node, kube_cluster, db).|
+|`--resource-name`|none|Filter by resource name.|
+|`--role`|none|Filter by role held during the session. Can be specified multiple times.|
+|`--search-mode`|`hybrid`|Search strategy to use when search queries are provided.|
+|`--server-addr`|none|Filter SSH sessions by server address.|
+|`--server-hostname`|none|Filter SSH sessions by server hostname.|
+|`--severity`|none|Minimum severity level to include (low, medium, high, critical).|
+|`--to`|none|End of time range. Format 2006-01-02. Defaults to current time.|
+|`--username`|none|Filter by the Teleport username that initiated the session.|
+
+Arguments:
+
+|Argument|Default|Description|
+|---|---|---|
+|query|none (optional)|Natural language description of the sessions to find (e.g. "SSH sessions exfiltrating data to external endpoints").|
+
 ## tctl requests approve
 
 Approve pending Access Request.
@@ -1717,7 +1801,7 @@ Flags:
 |Flag|Default|Description|
 |---|---|---|
 |`--annotations`|none|Resolution attributes \<key\>=\<val\>\[,...\]|
-|`--assume-start-time`|none|Sets time roles can be assumed by requestor (RFC3339 e.g. 2023-12-12T23:20:50.52Z)|
+|`--assume-start-time`|none|Sets time roles can be assumed by requestor (RFC3339 e.g 2023-12-12T23:20:50.52Z)|
 |`--delegator`|none|Optional delegating identity|
 |`--reason`|none|Optional reason message|
 |`--roles`|none|Override requested roles \<role\>\[,...\]|
@@ -1894,6 +1978,24 @@ Arguments:
 |---|---|---|
 |connector_name|none (required)|name of the SAML connector to export the key from|
 
+## tctl scoped assignments list
+
+List scoped role assignments
+
+Usage:
+
+```code
+$ tctl scoped assignments list [<flags>]
+```
+
+Flags:
+
+|Flag|Default|Description|
+|---|---|---|
+|`-f`, `--format`|`text`|Format output (text, json, yaml).|
+|`--role`|none|Filter by assigned role.|
+|`--user`|none|Filter by user.|
+
 ## tctl scoped status
 
 Show the status of scoped resources.
@@ -1919,7 +2021,7 @@ Flags:
 |Flag|Default|Description|
 |---|---|---|
 |`--assign-scope`|none|Scope that should be applied to resources provisioned by this token|
-|`--format`|none|Output format, 'text', 'json', or 'yaml'|
+|`--format`|none|Format output (text, json, yaml).|
 |`--labels`|none|Set token labels, e.g. env=prod,region=us-west|
 |`--mode`|none|Usage mode of a token (default: unlimited, single_use)|
 |`--name`|none|Override the default, randomly generated token name with a specified name|
@@ -1942,7 +2044,7 @@ Flags:
 
 |Flag|Default|Description|
 |---|---|---|
-|`--format`|none|Output format, 'text', 'json' or 'yaml'|
+|`-f`, `--format`|none|Format output (text, json, yaml).|
 |`--[no-]with-secrets`|`false`|Do not redact join tokens|
 
 ## tctl scoped tokens rm
@@ -2103,7 +2205,7 @@ $ tctl status
 
 ## tctl terraform env
 
-Obtain certificates and load them into environments variables. This creates a
+Obtain certificates and load them into environment variables. This creates a
 temporary MachineID bot.
 
 Usage:
@@ -2165,7 +2267,7 @@ Flags:
 |`--context`|none|Kubernetes context to use. When not set, defaults to the active context.|
 |`-f`, `--[no-]force`|`false`|Force the token creation, even if the token already exists|
 |`-j`, `--join-with`|`auto`|Kubernetes joining type, possible values are 'oidc', 'jwks', and 'auto'. See https://goteleport.com/docs/reference/join-methods/#kubernetes-kubernetes for more details.|
-|`-n`, `--namespace`|`teleport`|Namespace of the Kubernetes Service Account using the token. For 'teleport-kube-agent' and 'tbot' Helm charts, this is release namespace.|
+|`-n`, `--namespace`|`teleport`|Namespace of the Kubernetes Service Account using the token. For 'teleport-kube-agent' and 'tbot' Helm charts, this is the release namespace.|
 |`-o`, `--out`|`./values.yaml`|Path of the output file.|
 |`-s`, `--service-account`|none|Name of the Kubernetes Service Account using the token. For 'teleport-kube-agent' and 'tbot' Helm charts, this is the release name.|
 |`--token-name`|none|Optional name of the created join token. When not set, default to '\<CLUSTER_NAME\>(-\<BOT_NAME\>)'|
@@ -2406,7 +2508,7 @@ Flags:
 
 |Flag|Default|Description|
 |---|---|---|
-|`--expires-at`|none|Time that the revocation should expire, usually this should match the expiry time of the credential. This should be specified using RFC3339 e.g. '2024-02-05T15:04:00Z'. If unspecified, the time 1 week from now is used.|
+|`--expires-at`|none|Time that the revocation should expire, usually this should match the expiry time of the credential. This should be specified using RFC3339 e.g '2024-02-05T15:04:00Z'. If unspecified, the time 1 week from now is used.|
 |`--reason`|none|Reason for revocation.|
 |`--serial`|none|Serial number of the certificate to revoke.|
 |`--type`|none|Type of credential to revoke (x509)|

--- a/docs/pages/reference/cli/teleport.mdx
+++ b/docs/pages/reference/cli/teleport.mdx
@@ -342,6 +342,16 @@ Flags:
 |`--token`|none|Invitation token or path to file with token value to register with an auth server \[none\].|
 |`--uri`|none|Address the proxied database is reachable at.|
 
+## teleport debug check-session-helper
+
+Checks if the embedded session helper is working, if available in this build.
+
+Usage:
+
+```code
+$ teleport debug check-session-helper
+```
+
 ## teleport debug get-log-level
 
 Fetches current log level.
@@ -383,7 +393,7 @@ Arguments:
 
 |Argument|Default|Description|
 |---|---|---|
-|PROFILES|none (optional)|Comma-separated profile names to be exported. Supported profiles: allocs,block,cmdline,profile,trace,goroutine,heap,mutex,threadcreate. Default: goroutine,heap,profile|
+|PROFILES|none (optional)|Comma-separated profile names to be exported. Supported profiles: goroutine,heap,mutex,threadcreate,trace,allocs,block,cmdline,profile. Default: goroutine,heap,profile|
 
 ## teleport debug readyz
 
@@ -393,6 +403,17 @@ Usage:
 
 ```code
 $ teleport debug readyz
+```
+
+## teleport debug require-session-helper
+
+Checks if the embedded session helper is working, failing if not available in
+this build.
+
+Usage:
+
+```code
+$ teleport debug require-session-helper
 ```
 
 ## teleport debug set-log-level
@@ -826,7 +847,7 @@ Flags:
 |Flag|Default|Description|
 |---|---|---|
 |`--advertise-ip`|none|IP to advertise to clients if running behind NAT|
-|`--apply-on-startup`|none|Path to a non-empty YAML file containing resources to apply on startup. Works on initialized clusters, unlike --bootstrap. Only supports the following kinds: \[user token cluster_networking_config cluster_auth_preference bot role, workload_identity\].|
+|`--apply-on-startup`|none|Path to a non-empty YAML file containing resources to apply on startup. Works on initialized clusters, unlike --bootstrap. Only supports the following kinds: \[cluster_auth_preference workload_identity bot role user token cluster_networking_config\].|
 |`--auth-server`|none|Address of the auth server \[127.0.0.1:3025\]|
 |`--bootstrap`|none|Path to a non-empty YAML file containing bootstrap resources (ignored if already initialized)|
 |`--ca-pin`|none|CA pin to validate the Auth Server (can be repeated for multiple pins)|

--- a/docs/pages/reference/cli/tsh.mdx
+++ b/docs/pages/reference/cli/tsh.mdx
@@ -222,6 +222,153 @@ Arguments:
 |---|---|---|
 |command|none (optional)|`az` command and subcommands arguments that are going to be forwarded to Azure CLI.|
 
+## tsh beams add
+
+Start a new beam, and optionally connect to it via SSH.
+
+Usage:
+
+```code
+$ tsh beams add [<flags>]
+```
+
+Flags:
+
+|Flag|Default|Description|
+|---|---|---|
+|`-f`, `--format`|`text`|Format output (text, json, yaml).|
+|`--[no-]console`|`true`|Connect to the beam via SSH after creation.|
+
+## tsh beams exec
+
+Run a command in a beam, via SSH.
+
+Usage:
+
+```code
+$ tsh beams exec <name> <command>...
+```
+
+Arguments:
+
+|Argument|Default|Description|
+|---|---|---|
+|command|none (required)|Command to execute in the instance.|
+|name|none (required)|ID (or UUID) of the beam to target.|
+
+## tsh beams ls
+
+List beam instances.
+
+Usage:
+
+```code
+$ tsh beams ls [<flags>]
+```
+
+Flags:
+
+|Flag|Default|Description|
+|---|---|---|
+|`-f`, `--format`|`text`|Format output (text, json, yaml).|
+|`--[no-]all`|`false`|List all beams. By default, filters to show only beams belonging to the current user.|
+
+## tsh beams publish
+
+Publish an HTTP or TCP service running in a beam.
+
+Usage:
+
+```code
+$ tsh beams publish [<flags>] <name>
+```
+
+Flags:
+
+|Flag|Default|Description|
+|---|---|---|
+|`-f`, `--format`|`text`|Format output (text, json, yaml).|
+|`--[no-]tcp`|`false`|Publish as a TCP app instead of an HTTP app.|
+
+Arguments:
+
+|Argument|Default|Description|
+|---|---|---|
+|name|none (required)|ID (or UUID) of the beam to target.|
+
+## tsh beams rm
+
+Delete a beam.
+
+Usage:
+
+```code
+$ tsh beams rm <name>
+```
+
+Arguments:
+
+|Argument|Default|Description|
+|---|---|---|
+|name|none (required)|ID (or UUID) of the beam to delete.|
+
+## tsh beams scp
+
+Copy files between a beam and the local filesystem.
+
+Usage:
+
+```code
+$ tsh beams scp [<flags>] <src> <dest>
+```
+
+Flags:
+
+|Flag|Default|Description|
+|---|---|---|
+|`-f`, `--format`|`text`|Format output (text, json, yaml).|
+|`-q`, `--[no-]quiet`|`false`|Quiet mode.|
+|`-r`, `--[no-]recursive`|`false`|Recursive copy of subdirectories.|
+
+Arguments:
+
+|Argument|Default|Description|
+|---|---|---|
+|dest|none (required)|Destination path to copy, in the form `BEAM_ID:PATH` or `LOCAL_PATH`.|
+|src|none (required)|Source path to copy, in the form `BEAM_ID:PATH` or `LOCAL_PATH`.|
+
+## tsh beams ssh
+
+Start an interactive shell in a beam, via SSH.
+
+Usage:
+
+```code
+$ tsh beams ssh <name>
+```
+
+Arguments:
+
+|Argument|Default|Description|
+|---|---|---|
+|name|none (required)|ID (or UUID) of the beam to connect to.|
+
+## tsh beams unpublish
+
+Unpublish a previously published service in a beam.
+
+Usage:
+
+```code
+$ tsh beams unpublish <name>
+```
+
+Arguments:
+
+|Argument|Default|Description|
+|---|---|---|
+|name|none (required)|ID (or UUID) of the beam to target.|
+
 ## tsh clusters
 
 List available Teleport clusters.
@@ -438,6 +585,31 @@ Arguments:
 |Argument|Default|Description|
 |---|---|---|
 |labels|none (optional)|List of comma separated labels to filter by labels (e.g. key1=value1,key2=value2).|
+
+## tsh delegation create-session
+
+Create a delegation session, allowing a bot or workload to temporarily act on
+your behalf.
+
+Usage:
+
+```code
+$ tsh delegation create-session [<flags>]
+```
+
+Flags:
+
+|Flag|Default|Description|
+|---|---|---|
+|`--allow-app`|none|Allow access to an application.|
+|`--allow-db`|none|Allow access to a database.|
+|`--allow-git-server`|none|Allow access to a Git server.|
+|`--allow-kube-cluster`|none|Allow access to a Kubernetes cluster.|
+|`--allow-node`|none|Allow access to an SSH node.|
+|`--allow-windows-desktop`|none|Allow access to a Windows desktop.|
+|`--bot`|none|Name of a bot allowed to use the delegation session. Repeat to allow multiple bots.|
+|`--[no-]allow-all`|`false`|Allow access to all resources, including destructive administrative actions. Mutually exclusive with the other --allow-* flags.|
+|`--session-ttl`|none|How long the delegation session should remain valid.|
 
 ## tsh device enroll
 
@@ -861,7 +1033,7 @@ Flags:
 |`--request-reason`|none|Reason for requesting additional roles.|
 |`--request-reviewers`|none|Suggested reviewers for role request.|
 |`--request-roles`|none|Request one or more extra roles.|
-|`--scope`|none|Scope pins credentials to a given scope.|
+|`--scope`|none|Scope pins credentials to a given scope. Use "" to explicitly remove scoping.|
 |`-v`, `--[no-]verbose`|`false`|Show extra status information.|
 
 Arguments:
@@ -1342,7 +1514,7 @@ Flags:
 
 |Flag|Default|Description|
 |---|---|---|
-|`--assume-start-time`|none|Sets time roles can be assumed by requestor (RFC3339 e.g. 2023-12-12T23:20:50.52Z).|
+|`--assume-start-time`|none|Sets time roles can be assumed by requestor (RFC3339 e.g 2023-12-12T23:20:50.52Z).|
 |`--max-duration`|none|How long the access should be granted for.|
 |`--[no-]nowait`|`false`|Finish without waiting for request resolution.|
 |`--reason`|none|Reason for requesting.|
@@ -1354,7 +1526,7 @@ Flags:
 
 ## tsh request drop
 
-Drop one more Access Requests from current identity.
+Drop one or more Access Requests from current identity.
 
 Usage:
 
@@ -1401,7 +1573,7 @@ Flags:
 
 |Flag|Default|Description|
 |---|---|---|
-|`--assume-start-time`|none|Sets time roles can be assumed by requestor (RFC3339 e.g. 2023-12-12T23:20:50.52Z).|
+|`--assume-start-time`|none|Sets time roles can be assumed by requestor (RFC3339 e.g 2023-12-12T23:20:50.52Z).|
 |`--[no-]approve`|`false`|Review proposes approval.|
 |`--[no-]deny`|`false`|Review proposes denial.|
 |`--reason`|none|Review reason message.|
@@ -1695,8 +1867,8 @@ $ tsh vnet-ssh-autoconfig
 
 ## tsh workload-identity issue-x509
 
-Use Teleport Workload Identity to issue an X509 credential write it to a local
-directory.
+Use Teleport Workload Identity to issue an X509 credential and write it to a
+local directory.
 
 Usage:
 


### PR DESCRIPTION
We have several `cli-docs-foo` commands that regenerate command references. These targets are currently removing all content from their respective files due to redirect from stderr; these days we print help to stdout, so the targets need updating.

It also adds a single `cli-docs` target that depends on all the individual ones.

Lastly, updated references are included.

We should consider adding CI target to ensure these files are up-to-date all the time, similar to the existing setup for other autogenerated files.