### PR TITLE
Focus 8 how-to guides on commands/achievable steps

### DIFF
--- a/docs/pages/connect-your-client/model-context-protocol/database-access.mdx
+++ b/docs/pages/connect-your-client/model-context-protocol/database-access.mdx
@@ -49,7 +49,7 @@ provisioning](../../enroll-resources/database-access/auto-user-provisioning/post
 or [Database Access Controls](../../enroll-resources/database-access/rbac.mdx).
 </Admonition>
 
-## Step 1/2. Configure MCP clients
+## Step 1/2. List available MCP servers
 
 First, sign in into your Teleport cluster using `tsh login`:
 
@@ -67,6 +67,8 @@ $ tsh db ls
 # postgres-dev    Development database [* postgres]       env=dev
 # postgres-prod   Production database  [mcp_read_only]    env=prod
 ```
+
+## Step 2/2. Configure MCP clients
 
 Each database you want accessible through MCP must be configured with your MCP
 client individually. This is done using the `tsh mcp db config` command. Like
@@ -150,8 +152,6 @@ teleport://clusters/<Var name="teleport.example.com:443" />/databases/postgres-d
 ```
 </TabItem>
 </Tabs>
-
-## Step 2/2. Access Teleport-protected resources over MCP
 
 After configuring your MCP client, the following tools will be available:
 

--- a/docs/pages/connect-your-client/model-context-protocol/kube-access.mdx
+++ b/docs/pages/connect-your-client/model-context-protocol/kube-access.mdx
@@ -18,7 +18,7 @@ This guide explains how to connect to Teleport Kubernetes Clusters with MCP clie
 (!docs/pages/includes/edition-prereqs-tabs.mdx clients="\`tsh\` client"!)
 - Kubernetes Clusters enrolled with Teleport. See our [guides](../../enroll-resources/kubernetes-access/getting-started.mdx).
 
-## Step 1/2. Configure MCP clients
+## Step 1/2. List available MCP servers
 
 First, sign in into your Teleport cluster using `tsh login`:
 
@@ -41,7 +41,9 @@ Logged into Kubernetes cluster "minikube". Try 'kubectl version' to test the con
 ```
 This command also updates your default Kubernetes config.
 
-Next, configure your MCP clients to use the
+## Step 2/2. Configure MCP clients
+
+Configure your MCP clients to use the
 [`kubernetes-mcp-server`](https://github.com/containers/kubernetes-mcp-server)
 MCP server.
 
@@ -93,8 +95,6 @@ code-insiders --add-mcp '{"name":"kubernetes","command":"npx","args":["kubernete
 ```
 </TabItem>
 </Tabs>
-
-## Step 2/2. Access Teleport-protected resources over MCP
 
 After configuring your MCP client, you will find Kubernetes and Helm tools from
 `kubernetes-mcp-server`.

--- a/docs/pages/connect-your-client/model-context-protocol/mcp-access.mdx
+++ b/docs/pages/connect-your-client/model-context-protocol/mcp-access.mdx
@@ -28,7 +28,7 @@ Teleport.
   - [MCP Access with Stdio MCP Server](../../enroll-resources/mcp-access/enrolling-mcp-servers/stdio.mdx)
   </details>
   
-## Step 1/2. Configure MCP clients
+## Step 1/2. List available MCP servers
 
 First, sign in into your Teleport cluster using `tsh login`, assigning 
 <Var name="teleport.example.com" /> to the web address of the Teleport Proxy
@@ -47,6 +47,8 @@ Name           Description                                Type  Labels
 fs             Filesystem MCP Server                      stdio env=prod
 mcp-everything This MCP server attempts to exercise al... stdio env=dev,sandbox=true
 ```
+
+## Step 2/2. Configure MCP clients
 
 The MCP client configuration can be created using the `tsh mcp config` command.
 You can choose which servers to configure by using the `--labels` flag to filter
@@ -144,8 +146,6 @@ Here is a sample JSON configuration for launching Teleport MCP servers:
 ```
 </TabItem>
 </Tabs>
-
-## Step 2/2. Use Teleport-protected MCP servers
 
 After configuring your MCP client, the MCP tools and resources should be
 available.

--- a/docs/pages/machine-workload-identity/access-guides/ansible-awx.mdx
+++ b/docs/pages/machine-workload-identity/access-guides/ansible-awx.mdx
@@ -491,7 +491,7 @@ mode](../../reference/deployment/join-methods.mdx#kubernetes-jwks).
 Kubernetes clusters running on cloud providers like Amazon EKS, Azure AKS, and
 Google Kubernetes Engine frequently rotate their JWKS keys and should instead
 use Kubernetes OIDC joining. Refer to our [Kubernetes OIDC joining
-guide](../deployment/kubernetes-oidc.mdx#step-15-verify-support-for-service-account-issuer-discovery)
+guide](../deployment/kubernetes-oidc.mdx#step-14-verify-support-for-service-account-issuer-discovery)
 to learn how to configure the join token on these providers.
 
 The `tctl tokens configure-kube` helper described in [the standard

--- a/docs/pages/machine-workload-identity/access-guides/mcp.mdx
+++ b/docs/pages/machine-workload-identity/access-guides/mcp.mdx
@@ -193,7 +193,10 @@ MCP client you are using.
 
         You'll need to configure the MCP client to invoke the `tsh` binary with
         the following arguments:
-        `tsh mcp connect -i /opt/machine-id/identity --proxy example.teleport.sh:443 my-mcp-server`.
+
+        ```code
+        $ tsh mcp connect -i /opt/machine-id/identity --proxy example.teleport.sh:443 my-mcp-server
+        ```
 
         Modify the example values to match your environment:
         - `/opt/machine-id/identity` with the path to the identity file

--- a/docs/pages/machine-workload-identity/deployment/kubernetes-oidc.mdx
+++ b/docs/pages/machine-workload-identity/deployment/kubernetes-oidc.mdx
@@ -82,7 +82,7 @@ The examples in this guide will install a `tbot` deployment in the `default`
 Namespace of the Kubernetes cluster. Adjust references to `default` to the
 Namespace you wish to use.
 
-## Step 1/5. Verify support for Service Account Issuer Discovery
+## Step 1/4. Verify support for Service Account Issuer Discovery
 
 Before continuing, verify that your Kubernetes cluster can issue tokens that
 Teleport will be able to verify. To do so, we'll want to perform the following
@@ -160,11 +160,11 @@ JWKS joining](./kubernetes.mdx) or an [alternative Teleport join
 method](../../reference/deployment/join-methods.mdx) better suited to your cloud provider.
 </Admonition>
 
-## Step 2/5. Create a Bot
+## Step 2/4. Create a Bot
 
 (!docs/pages/includes/machine-id/create-a-bot.mdx!)
 
-## Step 3/5. Create a join token
+## Step 3/4. Create a join token
 
 Next, a join token needs to be configured. This will be used by `tbot` to join
 the cluster, and will require the issuer URL determined in Step 1.
@@ -203,7 +203,7 @@ Use `tctl` to apply this file:
 $ tctl create -f bot-token.yaml
 ```
 
-## Step 4/5. Create a `tbot` deployment
+## Step 4/4. Create a `tbot` deployment
 
 Now, you'll deploy `tbot` to your Kubernetes cluster using the Teleport `tbot`
 Helm chart. This will be configured using values provided to the Helm CLI tool.
@@ -254,7 +254,7 @@ $ kubectl logs deployment/tbot
 
 With this complete, `tbot` is now successfully deployed to your cluster.
 
-## Step 5/5. Configure services
+## Next step: configure infrastructure access
 
 By default, the `tbot` Helm chart is configured to write an identity file to a
 Kubernetes Secret called `tbot-out` in the namespace where `tbot` has been
@@ -297,11 +297,9 @@ type of service using the `services` value of the Helm chart and setting
 Follow one of the [access guides](../access-guides/access-guides.mdx) to find
 out more about how to configure `tbot` for your use case.
 
-## Next steps
+## Further reading
 
 - Explore the [Helm chart configuration reference](../../reference/helm-reference/tbot.mdx).
-- Follow the [access guides](../access-guides/access-guides.mdx) to finish
-  configuring `tbot` for your environment.
 - Read the [configuration reference](../../reference/machine-workload-identity/configuration.mdx) to explore
   all the available configuration options.
 - [More information about `TELEPORT_ANONYMOUS_TELEMETRY`.](../../reference/machine-workload-identity/telemetry.mdx)

--- a/docs/pages/machine-workload-identity/deployment/kubernetes.mdx
+++ b/docs/pages/machine-workload-identity/deployment/kubernetes.mdx
@@ -77,11 +77,11 @@ The examples in this guide will install a `tbot` deployment in the `default`
 Namespace of the Kubernetes cluster. Adjust references to `default` to the
 Namespace you wish to use.
 
-## Step 1/4. Create a Bot
+## Step 1/3. Create a Bot
 
 (!docs/pages/includes/machine-id/create-a-bot.mdx!)
 
-## Step 2/4. Create a join token
+## Step 2/3. Create a join token
 
 Next, a join token needs to be configured. This will be used by `tbot` to join
 the cluster. As the `kubernetes` join method will be used, the public key of the
@@ -131,7 +131,7 @@ Use `tctl` to apply this file:
 $ tctl create -f bot-token.yaml
 ```
 
-## Step 3/4. Create a `tbot` deployment
+## Step 3/3. Create a `tbot` deployment
 
 Now, you'll deploy `tbot` to your Kubernetes cluster using the Teleport `tbot`
 Helm chart. This will be configured using values provided to the Helm CLI tool.
@@ -182,7 +182,7 @@ $ kubectl logs deployment/tbot
 
 With this complete, `tbot` is now successfully deployed to your cluster.
 
-## Step 4/4. Using the output
+## Next step: configure infrastructure access
 
 By default, the `tbot` Helm chart is configured to write an identity file to a
 Kubernetes Secret called `tbot-out` in the namespace where `tbot` has been
@@ -225,11 +225,9 @@ type of output using the `services` value of the Helm chart and setting
 Follow one of the [access guides](../access-guides/access-guides.mdx) to find
 out more about how to configure `tbot` for your use case.
 
-## Next steps
+## Further reading
 
 - Explore the [Helm chart configuration reference](../../reference/helm-reference/tbot.mdx).
-- Follow the [access guides](../access-guides/access-guides.mdx) to finish
-  configuring `tbot` for your environment.
 - Read the [configuration reference](../../reference/machine-workload-identity/configuration.mdx) to explore
   all the available configuration options.
 - [More information about `TELEPORT_ANONYMOUS_TELEMETRY`.](../../reference/machine-workload-identity/telemetry.mdx)

--- a/docs/pages/machine-workload-identity/workload-identity/getting-started.mdx
+++ b/docs/pages/machine-workload-identity/workload-identity/getting-started.mdx
@@ -29,7 +29,7 @@ receive SPIFFE SVID-compatible workload identity credentials.
   workloads which need to access Teleport Workload Identity will run. For more
   information, see the [deployment guides](../deployment/deployment.mdx).
 
-## Step 1/4. Configure Workload Identity
+## Step 1/3. Configure Workload Identity
 
 First, you will need to create a Workload Identity resource.
 
@@ -136,7 +136,7 @@ spec:
 Use `tctl create -f ./workload-identity.yaml` to update the WorkloadIdentity
 resource with your changes.
 
-## Step 2/4. Configure `workload-identity-api` service in `tbot`
+## Step 2/3. Configure `workload-identity-api` service in `tbot`
 
 To set up a SPIFFE Workload API endpoint with `tbot`, we configure an instance
 of the `workload-identity-api` service.
@@ -222,7 +222,7 @@ spec:
     id: /svc/foo
 ```
 
-## Step 3/4. Testing the Workload API with `tbot spiffe-inspect`
+## Step 3/3. Testing the Workload API with `tbot spiffe-inspect`
 
 The `tbot` binary includes a `spiffe-inspect` command that can be used to
 test the configuration of the Workload API. This command will connect to the
@@ -246,7 +246,7 @@ Trust Bundles
 - example.teleport.sh
 ```
 
-## Step 4/4. Configuring your workload to use the Workload API
+## Next step: configure your workload to use the Workload API
 
 Now that you know that the Workload API is behaving as expected, you can
 configure your workload to use it. The exact steps will depend on the workload.
@@ -258,7 +258,7 @@ In cases where you have used the SPIFFE SDKs, you can configure the
 See the [Best Practices](./best-practices.mdx) guide for more information on
 integrating SPIFFE with your workloads.
 
-## Next steps
+## Further reading
 
 - [Workload Identity Overview](./introduction.mdx): Overview of Teleport
 Workload Identity.

--- a/docs/pages/reference/machine-workload-identity/bound-keypair/getting-started.mdx
+++ b/docs/pages/reference/machine-workload-identity/bound-keypair/getting-started.mdx
@@ -68,7 +68,7 @@ method works and how to use it in production.
   hosts (like CI runs), doing so will reduce security guarantees; see the
   [reference page][reference] for further information.
 
-## Step 1/5. Install `tbot`
+## Step 1/4. Install `tbot`
 
 **This step is completed on the bot host.**
 
@@ -79,13 +79,13 @@ Download and install the appropriate Teleport package for your platform:
 
 (!docs/pages/includes/install-linux.mdx!)
 
-## Step 2/5. Create a Bot
+## Step 2/4. Create a Bot
 
 **This step is completed on your local machine.**
 
 (!docs/pages/includes/machine-id/create-a-bot.mdx!)
 
-## Step 3/5. Create a join token
+## Step 3/4. Create a join token
 
 **This step is completed on your local machine.**
 
@@ -149,7 +149,7 @@ $ tctl get token/example --format=json | jq -r '.[0].status.bound_keypair.regist
 This assumes `jq` is installed. If not, run `tctl get token/example` and inspect
 the `.status.bound_keypair.registration_secret` field.
 
-## Step 4/5. Configure `tbot`
+## Step 4/4. Configure `tbot`
 
 **This step is completed on the bot host.**
 
@@ -184,7 +184,7 @@ Replace the following:
 
 (!docs/pages/includes/machine-id/daemon-or-oneshot.mdx!)
 
-## Step 5/5. Configure outputs
+## Next step: configure outputs
 
 (!docs/pages/includes/machine-id/configure-services.mdx!)
 
@@ -289,7 +289,7 @@ $ tbot start -c tbot.yaml
 For additional information on how onboarding a new bot works with Bound Keypair
 Joining, refer to the [onboarding reference](./concepts.mdx#onboarding).
 
-## Next steps
+## Further reading
 
 - Read the [Bound Keypair Joining Reference][reference]
   for more details about the join method and the available configuration options.


### PR DESCRIPTION
Ensure that in how-to guides, the actionable steps within each guide include CLI commands. Also standardize on including commands as block-level code fences instead of inline prose.

- **access-guides/mcp.mdx:** Extract an inline command into a code fence.
- **MWI guides:** Move open-ended final step, which cannot be achieved within the current guide, to a "Next step" section.
- **MCP client guides:** Distribute Step 1 and Step 2 so both contain commands and concrete, achievable steps.