### PR TITLE
Solidify role creation e2e test, stabilise DataTable's rows between renders

### DIFF
--- a/e2e/helpers/tctl.ts
+++ b/e2e/helpers/tctl.ts
@@ -51,6 +51,17 @@ export function deleteUser(username: string) {
   tctl('users', 'rm', username);
 }
 
+// Removes a resource (e.g. `role/test-role`) if it exists, swallowing the
+// error tctl returns when the resource is absent. Used by tests that need a
+// clean slate even if a previous attempt failed midway through cleanup.
+export function deleteResourceIfExists(resource: string) {
+  try {
+    tctl('rm', resource);
+  } catch {
+    // Resource doesn't exist; nothing to clean up.
+  }
+}
+
 function tctl(...args: string[]) {
   return execFileSync(tctlBin, [...args, '-c', teleportConfig], {
     encoding: 'utf-8',

--- a/e2e/helpers/tctl.ts
+++ b/e2e/helpers/tctl.ts
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { execFileSync } from 'child_process';
+import { execFileSync, type SpawnSyncReturns } from 'child_process';
 
 import { tctlBin, teleportConfig } from './env';
 
@@ -51,20 +51,30 @@ export function deleteUser(username: string) {
   tctl('users', 'rm', username);
 }
 
-// Removes a resource (e.g. `role/test-role`) if it exists, swallowing the
-// error tctl returns when the resource is absent. Used by tests that need a
-// clean slate even if a previous attempt failed midway through cleanup.
+// Removes a resource (e.g. `role/test-role`) if it exists. Swallows only the
+// "not found" error tctl returns when the resource is absent; any other
+// failure (auth, network, etc.) is re-thrown so it doesn't get masked.
 export function deleteResourceIfExists(resource: string) {
   try {
     tctl('rm', resource);
-  } catch {
-    // Resource doesn't exist; nothing to clean up.
+  } catch (err) {
+    if (!isNotFoundError(err)) {
+      throw err;
+    }
   }
+}
+
+function isNotFoundError(err: unknown) {
+  if (!err || typeof err !== 'object') {
+    return false;
+  }
+  const stderr = (err as SpawnSyncReturns<string>).stderr ?? '';
+  return /not found/i.test(stderr);
 }
 
 function tctl(...args: string[]) {
   return execFileSync(tctlBin, [...args, '-c', teleportConfig], {
     encoding: 'utf-8',
-    stdio: ['pipe', 'pipe', 'ignore'],
+    stdio: ['pipe', 'pipe', 'pipe'],
   });
 }

--- a/e2e/tests/web/authenticated/roles-crud.spec.ts
+++ b/e2e/tests/web/authenticated/roles-crud.spec.ts
@@ -16,7 +16,21 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+import { randomUUID } from 'node:crypto';
+
+import { deleteResourceIfExists } from '@gravitational/e2e/helpers/tctl';
 import { expect, test } from '@gravitational/e2e/helpers/test';
+
+// A unique role name per test ensures retries (and parallel workers) never
+// collide with leftover state from a previous attempt that failed before its
+// own cleanup ran.
+const roleName = `test-role-${randomUUID()}`;
+
+// Best-effort cleanup via tctl in case the test fails before the UI delete
+// step runs, so the role doesn't outlive the test run.
+test.afterEach(() => {
+  deleteResourceIfExists(`role/${roleName}`);
+});
 
 test('verify creating, editing, and deleting a role works', async ({
   page,
@@ -25,21 +39,21 @@ test('verify creating, editing, and deleting a role works', async ({
   await rolesPage.goto();
 
   await test.step('Create a new role', async () => {
-    await rolesPage.createRole('test-role');
+    await rolesPage.createRole(roleName);
 
-    await expect(page.getByRole('cell', { name: 'test-role' })).toBeVisible();
+    await expect(page.getByRole('cell', { name: roleName })).toBeVisible();
   });
 
   await test.step('Edit the role via YAML to add a description', async () => {
-    await rolesPage.editRole('test-role');
+    await rolesPage.editRole(roleName);
 
-    await expect(page.getByText('Edit Role test-role')).toBeVisible();
+    await expect(page.getByText(`Edit Role ${roleName}`)).toBeVisible();
 
     await rolesPage.switchToYamlEditor();
 
     await rolesPage.replaceYaml(
-      'name: test-role',
-      'name: test-role\n  description: test description'
+      `name: ${roleName}`,
+      `name: ${roleName}\n  description: test description`
     );
 
     await rolesPage.saveChangesButton.click();
@@ -50,11 +64,9 @@ test('verify creating, editing, and deleting a role works', async ({
   });
 
   await test.step('Delete the role', async () => {
-    await rolesPage.deleteRole('test-role');
+    await rolesPage.deleteRole(roleName);
 
-    await expect(
-      page.getByRole('cell', { name: 'test-role' })
-    ).not.toBeVisible();
+    await expect(page.getByRole('cell', { name: roleName })).not.toBeVisible();
   });
 });
 

--- a/web/packages/design/src/DataTable/Table.tsx
+++ b/web/packages/design/src/DataTable/Table.tsx
@@ -114,6 +114,7 @@ export default function Table<T>(props: TableProps<T>) {
     data.forEach((item, rowIdx) => {
       const customRow = row?.customRow?.(item);
       const renderAfter = row?.renderAfter?.(item);
+      const rowKey = row?.getKey?.(item) ?? rowIdx;
 
       const trContent = customRow
         ? customRow
@@ -129,7 +130,7 @@ export default function Table<T>(props: TableProps<T>) {
             );
 
             return (
-              <React.Fragment key={`${rowIdx} ${columnIdx}`}>
+              <React.Fragment key={`${rowKey} ${columnIdx}`}>
                 {$cell}
               </React.Fragment>
             );
@@ -137,7 +138,7 @@ export default function Table<T>(props: TableProps<T>) {
 
       rows.push(
         <tr
-          key={rowIdx}
+          key={rowKey}
           onClick={() => row?.onClick?.(item)}
           style={row?.getStyle?.(item)}
         >
@@ -147,7 +148,7 @@ export default function Table<T>(props: TableProps<T>) {
 
       if (renderAfter) {
         rows.push(
-          <React.Fragment key={`${rowIdx}-after`}>{renderAfter}</React.Fragment>
+          <React.Fragment key={`${rowKey}-after`}>{renderAfter}</React.Fragment>
         );
       }
     });

--- a/web/packages/design/src/DataTable/Table.tsx
+++ b/web/packages/design/src/DataTable/Table.tsx
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { PropsWithChildren, ReactNode, type JSX } from 'react';
+import React, { ReactNode, type JSX } from 'react';
 
 import { Box, Flex, Indicator, P1, Text } from 'design';
 import * as Icons from 'design/Icon';
@@ -112,41 +112,38 @@ export default function Table<T>(props: TableProps<T>) {
       return <LoadingIndicator colSpan={columns.length} />;
     }
     data.forEach((item, rowIdx) => {
-      const TableRow: React.FC<PropsWithChildren> = ({ children }) => (
+      const customRow = row?.customRow?.(item);
+      const renderAfter = row?.renderAfter?.(item);
+
+      const trContent = customRow
+        ? customRow
+        : columns.flatMap((column, columnIdx) => {
+            if (column.isNonRender) {
+              return []; // does not include this column.
+            }
+
+            const $cell = column.render ? (
+              column.render(item)
+            ) : (
+              <TextCell data={column.key ? item[column.key] : undefined} />
+            );
+
+            return (
+              <React.Fragment key={`${rowIdx} ${columnIdx}`}>
+                {$cell}
+              </React.Fragment>
+            );
+          });
+
+      rows.push(
         <tr
           key={rowIdx}
           onClick={() => row?.onClick?.(item)}
           style={row?.getStyle?.(item)}
         >
-          {children}
+          {trContent}
         </tr>
       );
-
-      const customRow = row?.customRow?.(item);
-      const renderAfter = row?.renderAfter?.(item);
-
-      if (customRow) {
-        rows.push(<TableRow key={rowIdx}>{customRow}</TableRow>);
-      } else {
-        const cells = columns.flatMap((column, columnIdx) => {
-          if (column.isNonRender) {
-            return []; // does not include this column.
-          }
-
-          const $cell = column.render ? (
-            column.render(item)
-          ) : (
-            <TextCell data={column.key ? item[column.key] : undefined} />
-          );
-
-          return (
-            <React.Fragment key={`${rowIdx} ${columnIdx}`}>
-              {$cell}
-            </React.Fragment>
-          );
-        });
-        rows.push(<TableRow key={rowIdx}>{cells}</TableRow>);
-      }
 
       if (renderAfter) {
         rows.push(

--- a/web/packages/design/src/DataTable/types.ts
+++ b/web/packages/design/src/DataTable/types.ts
@@ -98,6 +98,13 @@ export type TableProps<T> = {
      * the base table row.
      */
     renderAfter?(row: T): JSX.Element | null;
+    /**
+     * Returns a stable React key for the row. When the table can reorder
+     * (sort, filter, paginate, refetch), provide this so that stateful cells
+     * (e.g. open action menus) stay attached to their item rather than the
+     * row index. Falls back to the row index when not provided.
+     */
+    getKey?(row: T): React.Key;
   };
 };
 

--- a/web/packages/teleport/src/Bots/List/BotList.tsx
+++ b/web/packages/teleport/src/Bots/List/BotList.tsx
@@ -98,6 +98,7 @@ export function BotList({
         row={{
           onClick: onSelect,
           getStyle: () => ({ cursor: 'pointer' }),
+          getKey: bot => bot.name,
         }}
       />
       {selectedBot && interaction === Interaction.DELETE && (

--- a/web/packages/teleport/src/Clusters/ClusterList/ClusterList.tsx
+++ b/web/packages/teleport/src/Clusters/ClusterList/ClusterList.tsx
@@ -54,6 +54,9 @@ export default function ClustersList(props: Props) {
         clusters.find(c => c.clusterId === cfg.proxyCluster)
       }
       pagination={{ pageSize }}
+      row={{
+        getKey: cluster => cluster.clusterId,
+      }}
     />
   );
 }

--- a/web/packages/teleport/src/Discover/Overview/ActivityTab.tsx
+++ b/web/packages/teleport/src/Discover/Overview/ActivityTab.tsx
@@ -336,6 +336,7 @@ export function ActivityTab({
               }
               return { cursor: 'pointer' };
             },
+            getKey: row => row.name,
           }}
           columns={[
             {

--- a/web/packages/teleport/src/Integrations/IntegrationList.tsx
+++ b/web/packages/teleport/src/Integrations/IntegrationList.tsx
@@ -150,6 +150,7 @@ export function IntegrationList(props: Props) {
         row={{
           onClick: handleRowClick,
           getStyle: getRowStyle,
+          getKey: row => `${row.kind}:${row.name}`,
         }}
         columns={[
           {

--- a/web/packages/teleport/src/JoinTokens/JoinTokens.tsx
+++ b/web/packages/teleport/src/JoinTokens/JoinTokens.tsx
@@ -192,6 +192,7 @@ export const JoinTokens = () => {
               data={joinTokensAttempt.data.items}
               row={{
                 getStyle: getRowStyle,
+                getKey: token => token.id,
               }}
               columns={[
                 {

--- a/web/packages/teleport/src/ManagedUpdates/ManagedUpdates/GroupsTable.tsx
+++ b/web/packages/teleport/src/ManagedUpdates/ManagedUpdates/GroupsTable.tsx
@@ -347,6 +347,7 @@ export function GroupsTable({
             selectedGroupName === group.name
               ? { backgroundColor: theme.colors.interactive.tonal.neutral[1] }
               : undefined,
+          getKey: group => group.name,
         }}
       />
     </TableContainer>

--- a/web/packages/teleport/src/Roles/RoleList/RoleList.tsx
+++ b/web/packages/teleport/src/Roles/RoleList/RoleList.tsx
@@ -86,6 +86,9 @@ export function RoleList({
           ),
         },
       ]}
+      row={{
+        getKey: role => role.id,
+      }}
       emptyText="No Roles Found"
       isSearchable
     />

--- a/web/packages/teleport/src/Users/UserList/UserList.tsx
+++ b/web/packages/teleport/src/Users/UserList/UserList.tsx
@@ -71,6 +71,7 @@ export default function UserList({
           }
           return { cursor: 'pointer' };
         },
+        getKey: user => user.name,
       }}
       columns={[
         {


### PR DESCRIPTION
`TableRow` in `DataTable` was not stable between re-renders, causing every row (and therefore its menu) to be unmounted and remounted whenever the parent re-rendered. The success toast after saving a role would dismiss after 5 seconds, causing the table to re-render (`ToastNotificationProvider` -> `Roles` -> `RolesList` -> `table`), which would cause the menu to disappear and the e2e test to not be able to find the delete button. Changing `TableRow` from a function that's created every render to a `tr` should mitigate this.

Secondly, the retry of the e2e test would reuse the same role name, which had already been created but not deleted, so would cause the retry to fail for a different reason. I updated the test to delete the role it created after running (successful or not) and changed the test to use a random UUID at the end.
