### PR TITLE
[v17] events/athena: use per-publisher direct message size limit

### DIFF
--- a/lib/events/athena/athena.go
+++ b/lib/events/athena/athena.go
@@ -500,7 +500,7 @@ func New(ctx context.Context, cfg Config) (*Log, error) {
 	}
 
 	l := &Log{
-		publisher: newPublisherFromAthenaConfig(cfg),
+		publisher: newPublisherFromAthenaConfig(ctx, cfg),
 		querier:   querier,
 	}
 

--- a/lib/events/athena/athena_test.go
+++ b/lib/events/athena/athena_test.go
@@ -339,7 +339,7 @@ func TestPublisherConsumer(t *testing.T) {
 			ID:   uuid.NewString(),
 			Time: time.Now().UTC(),
 			Type: events.AppCreateEvent,
-			Code: strings.Repeat("d", 2*maxDirectMessageSize),
+			Code: strings.Repeat("d", 2*maxSNSDirectMessageSize),
 		},
 		AppMetadata: apievents.AppMetadata{
 			AppName: "app-large",
@@ -420,12 +420,10 @@ func TestPublisherConsumer(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			fS3 := newFakeS3manager()
 			fq := newFakeQueue()
-			p := &publisher{
-				PublisherConfig: PublisherConfig{
-					MessagePublisher: fq,
-					Uploader:         fS3,
-				},
-			}
+			p := NewPublisher(PublisherConfig{
+				MessagePublisher: fq,
+				Uploader:         fS3,
+			})
 			cfg := validCollectCfgForTests(t)
 			cfg.sqsReceiver = fq
 			cfg.payloadDownloader = fS3

--- a/lib/events/athena/integration_test.go
+++ b/lib/events/athena/integration_test.go
@@ -23,6 +23,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log/slog"
 	"os"
 	"strconv"
 	"strings"
@@ -191,12 +192,16 @@ func testIntegrationAthenaLargeEvents(t *testing.T, bypassSNS bool) {
 		MaxBatchSize: 1,
 		BypassSNS:    bypassSNS,
 	})
+	size := 200000
+	if bypassSNS {
+		size = 1024 * 1024
+	}
 	in := &apievents.SessionStart{
 		Metadata: apievents.Metadata{
 			Index: 2,
 			Type:  events.SessionStartEvent,
 			ID:    uuid.NewString(),
-			Code:  strings.Repeat("d", 200000),
+			Code:  strings.Repeat("d", size),
 			Time:  ac.clock.Now().UTC(),
 		},
 	}
@@ -651,4 +656,33 @@ func (ac *AthenaContext) setupInfraWithCleanup(t *testing.T, ctx context.Context
 		QueueURL: aws.ToString(queueCreated.QueueUrl),
 		Region:   awsCfg.Region,
 	}
+}
+
+func TestIntegration_sqsMaxDirectMessageSize(t *testing.T) {
+	if ok, _ := strconv.ParseBool(os.Getenv(teleport.AWSRunTests)); !ok {
+		t.Skip("Skipping AWS integration test. Set TEST_AWS=true to run.")
+	}
+
+	ctx := t.Context()
+	awsCfg, err := awsconfig.LoadDefaultConfig(ctx)
+	require.NoError(t, err)
+
+	sqsClient := sqs.NewFromConfig(awsCfg)
+
+	queueName := fmt.Sprintf("sqsMaxDirectMessageSize-test-%s", uuid.New().String())
+	created, err := sqsClient.CreateQueue(ctx, &sqs.CreateQueueInput{
+		QueueName: aws.String(queueName),
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_, err := sqsClient.DeleteQueue(context.Background(), &sqs.DeleteQueueInput{
+			QueueUrl: created.QueueUrl,
+		})
+		assert.NoError(t, err)
+	})
+
+	got := sqsMaxDirectMessageSize(ctx, sqsClient, *created.QueueUrl, slog.Default())
+
+	// SQS default MaximumMessageSize is 1 MiB; expect value minus overhead.
+	require.Equal(t, (1024-10)*1024, got)
 }

--- a/lib/events/athena/publisher.go
+++ b/lib/events/athena/publisher.go
@@ -22,8 +22,10 @@ import (
 	"bytes"
 	"context"
 	"encoding/base64"
+	"log/slog"
 	"net/http"
 	"path"
+	"strconv"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -49,10 +51,10 @@ const (
 	payloadTypeRawProtoEvent = "raw_proto_event"
 	payloadTypeS3Based       = "s3_event"
 
-	// maxDirectMessageSize defines maximum size of SNS/SQS message. AWS allows
+	// maxSNSDirectMessageSize defines maximum size of SNS message. AWS allows
 	// 256KB however it counts also headers. We round it to 250KB, just to be
 	// sure.
-	maxDirectMessageSize = 250 * 1024
+	maxSNSDirectMessageSize = 250 * 1024
 )
 
 // maxS3BasedSize defines some resonable threshold for S3 based messages
@@ -148,22 +150,65 @@ type s3uploader interface {
 }
 
 type PublisherConfig struct {
-	MessagePublisher messagePublisher
-	Uploader         s3uploader
-	PayloadBucket    string
-	PayloadPrefix    string
+	MessagePublisher     messagePublisher
+	Uploader             s3uploader
+	PayloadBucket        string
+	PayloadPrefix        string
+	MaxDirectMessageSize int
 }
 
 // NewPublisher returns new instance of publisher.
 func NewPublisher(cfg PublisherConfig) *publisher {
+	if cfg.MaxDirectMessageSize <= 0 {
+		cfg.MaxDirectMessageSize = maxSNSDirectMessageSize
+	}
 	return &publisher{
 		PublisherConfig: cfg,
 	}
 }
 
+// sqsGetQueueAttributer is the subset of the SQS API used by sqsMaxDirectMessageSize.
+type sqsGetQueueAttributer interface {
+	GetQueueAttributes(ctx context.Context, params *sqs.GetQueueAttributesInput, optFns ...func(*sqs.Options)) (*sqs.GetQueueAttributesOutput, error)
+}
+
+// sqsMaxDirectMessageSize queries the queue's MaximumMessageSize attribute and
+// returns a safe direct-send limit (attribute value minus sqsMessageAttributeOverhead).
+// Falls back to maxSNSDirectMessageSize and logs a warning if the attribute
+// cannot be retrieved or parsed.
+func sqsMaxDirectMessageSize(ctx context.Context, client sqsGetQueueAttributer, queueURL string, logger *slog.Logger) int {
+	// sqsMessageAttributeOverhead is the amount subtracted from a queue's
+	// MaximumMessageSize when deriving the usable direct-send limit, to leave
+	// room for SQS message attributes.
+	const sqsMessageAttributeOverhead = 10 * 1024
+
+	reqCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+
+	attrs, err := client.GetQueueAttributes(reqCtx, &sqs.GetQueueAttributesInput{
+		QueueUrl:       &queueURL,
+		AttributeNames: []sqstypes.QueueAttributeName{sqstypes.QueueAttributeNameMaximumMessageSize},
+	})
+	if err != nil {
+		logger.WarnContext(ctx, "Failed to query SQS MaximumMessageSize, using conservative SNS limit as fallback", "error", err)
+		return maxSNSDirectMessageSize
+	}
+	raw, ok := attrs.Attributes[string(sqstypes.QueueAttributeNameMaximumMessageSize)]
+	if !ok {
+		logger.WarnContext(ctx, "SQS queue did not return MaximumMessageSize, using conservative SNS limit as fallback")
+		return maxSNSDirectMessageSize
+	}
+	v, err := strconv.Atoi(raw)
+	if err != nil || v <= sqsMessageAttributeOverhead {
+		logger.WarnContext(ctx, "SQS MaximumMessageSize value is invalid, using conservative SNS limit as fallback", "value", raw)
+		return maxSNSDirectMessageSize
+	}
+	return v - sqsMessageAttributeOverhead
+}
+
 // newPublisherFromAthenaConfig returns new instance of publisher from athena
 // config.
-func newPublisherFromAthenaConfig(cfg Config) *publisher {
+func newPublisherFromAthenaConfig(ctx context.Context, cfg Config) *publisher {
 	r := awsretry.NewStandard(func(so *awsretry.StandardOptions) {
 		so.MaxAttempts = 20
 		so.MaxBackoff = 1 * time.Minute
@@ -179,24 +224,31 @@ func newPublisherFromAthenaConfig(cfg Config) *publisher {
 		t.MaxIdleConnsPerHost = defaults.HTTPMaxIdleConnsPerHost
 	})
 	var messagePublisher messagePublisherFunc
+	var maxDirectMessageSize int
 	if cfg.TopicARN == topicARNBypass {
-		messagePublisher = SQSPublisherFunc(cfg.QueueURL, sqs.NewFromConfig(*cfg.PublisherConsumerAWSConfig, func(o *sqs.Options) {
+		sqsClient := sqs.NewFromConfig(*cfg.PublisherConsumerAWSConfig, func(o *sqs.Options) {
 			o.Retryer = r
 			o.HTTPClient = hc
-		}))
+
+		})
+
+		messagePublisher = SQSPublisherFunc(cfg.QueueURL, sqsClient)
+		maxDirectMessageSize = sqsMaxDirectMessageSize(ctx, sqsClient, cfg.QueueURL, cfg.Logger)
 	} else {
 		messagePublisher = SNSPublisherFunc(cfg.TopicARN, sns.NewFromConfig(*cfg.PublisherConsumerAWSConfig, func(o *sns.Options) {
 			o.Retryer = r
 			o.HTTPClient = hc
 		}))
+		maxDirectMessageSize = maxSNSDirectMessageSize // SNS allows messages up to 256KB, but we use a smaller limit to be safe
 	}
 
 	return NewPublisher(PublisherConfig{
 		MessagePublisher: messagePublisher,
 		// TODO(tobiaszheller): consider reworking lib/observability to work also on s3 sdk-v2.
-		Uploader:      s3manager.NewUploader(s3.NewFromConfig(*cfg.PublisherConsumerAWSConfig)),
-		PayloadBucket: cfg.largeEventsBucket,
-		PayloadPrefix: cfg.largeEventsPrefix,
+		Uploader:             s3manager.NewUploader(s3.NewFromConfig(*cfg.PublisherConsumerAWSConfig)),
+		PayloadBucket:        cfg.largeEventsBucket,
+		PayloadPrefix:        cfg.largeEventsPrefix,
+		MaxDirectMessageSize: maxDirectMessageSize,
 	})
 }
 
@@ -243,7 +295,7 @@ func (p *publisher) EmitAuditEvent(ctx context.Context, in apievents.AuditEvent)
 	}
 
 	base64Len := base64.StdEncoding.EncodedLen(len(marshaledProto))
-	if base64Len > maxDirectMessageSize {
+	if base64Len > p.MaxDirectMessageSize {
 		if base64Len > maxS3BasedSize {
 			return trace.BadParameter("message too large to publish, size %d", base64Len)
 		}

--- a/lib/events/athena/publisher_test.go
+++ b/lib/events/athena/publisher_test.go
@@ -21,22 +21,39 @@ package athena
 import (
 	"context"
 	"errors"
+	"log/slog"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/feature/s3/manager"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/aws/aws-sdk-go-v2/service/sqs"
+	sqstypes "github.com/aws/aws-sdk-go-v2/service/sqs/types"
 	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	apievents "github.com/gravitational/teleport/api/types/events"
 )
 
+type mockSQSGetQueueAttributer struct {
+	attrs map[string]string
+	err   error
+}
+
+func (m *mockSQSGetQueueAttributer) GetQueueAttributes(_ context.Context, _ *sqs.GetQueueAttributesInput, _ ...func(*sqs.Options)) (*sqs.GetQueueAttributesOutput, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
+	return &sqs.GetQueueAttributesOutput{Attributes: m.attrs}, nil
+}
+
 func init() {
 	// Override maxS3BasedSize so we don't have to allocate 2GiB to test it.
 	// Do this in init to avoid any race.
-	maxS3BasedSize = maxDirectMessageSize * 4
+	maxS3BasedSize = (1024 - 10) * 1024 * 4
 }
 
 // TODO(tobiaszheller): Those UT just cover basic stuff. When we will have consumer
@@ -44,12 +61,13 @@ func init() {
 func Test_EmitAuditEvent(t *testing.T) {
 	veryLongString := strings.Repeat("t", maxS3BasedSize+1)
 	tests := []struct {
-		name          string
-		in            apievents.AuditEvent
-		publishErrors []error
-		uploader      s3uploader
-		wantCheck     func(t *testing.T, out []fakeQueueMessage)
-		wantErrorMsg  string
+		name                 string
+		in                   apievents.AuditEvent
+		publishErrors        []error
+		uploader             s3uploader
+		maxDirectMessageSize int
+		wantCheck            func(t *testing.T, out []fakeQueueMessage)
+		wantErrorMsg         string
 	}{
 		{
 			name: "valid publish",
@@ -86,10 +104,47 @@ func Test_EmitAuditEvent(t *testing.T) {
 				Metadata: apievents.Metadata{
 					ID:   uuid.NewString(),
 					Time: time.Now().UTC(),
-					Code: strings.Repeat("d", 2*maxDirectMessageSize),
+					Code: strings.Repeat("d", 2*maxSNSDirectMessageSize),
 				},
 			},
 			uploader: mockUploader{},
+			wantCheck: func(t *testing.T, out []fakeQueueMessage) {
+				require.Len(t, out, 1)
+				require.True(t, out[0].s3Based)
+			},
+		},
+		{
+			// A message between the SNS and SQS direct-send limits should go
+			// directly to the queue (no S3 hop) when MaxDirectMessageSize is
+			// the larger SQS threshold.
+			name: "medium message sent directly with SQS limit",
+			in: &apievents.AppCreate{
+				Metadata: apievents.Metadata{
+					ID:   uuid.NewString(),
+					Time: time.Now().UTC(),
+					Code: strings.Repeat("d", 2*maxSNSDirectMessageSize),
+				},
+			},
+			maxDirectMessageSize: (1024 - 10) * 1024,
+			uploader:             mockUploader{},
+			wantCheck: func(t *testing.T, out []fakeQueueMessage) {
+				require.Len(t, out, 1)
+				require.False(t, out[0].s3Based)
+			},
+		},
+		{
+			// A message larger than the SQS direct-send limit but smaller than
+			// maxS3BasedSize must fall back to S3.
+			name: "large message exceeds SQS limit falls back to S3",
+			in: &apievents.AppCreate{
+				Metadata: apievents.Metadata{
+					ID:   uuid.NewString(),
+					Time: time.Now().UTC(),
+					Code: strings.Repeat("d", 2*(1024-10)*1024),
+				},
+			},
+			maxDirectMessageSize: (1024 - 10) * 1024,
+			uploader:             mockUploader{},
 			wantCheck: func(t *testing.T, out []fakeQueueMessage) {
 				require.Len(t, out, 1)
 				require.True(t, out[0].s3Based)
@@ -126,12 +181,11 @@ func Test_EmitAuditEvent(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			fq := newFakeQueue()
-			p := &publisher{
-				PublisherConfig: PublisherConfig{
-					MessagePublisher: fq,
-					Uploader:         tt.uploader,
-				},
-			}
+			p := NewPublisher(PublisherConfig{
+				MessagePublisher:     fq,
+				Uploader:             tt.uploader,
+				MaxDirectMessageSize: tt.maxDirectMessageSize,
+			})
 			err := p.EmitAuditEvent(context.Background(), tt.in)
 			if tt.wantErrorMsg != "" {
 				require.ErrorContains(t, err, tt.wantErrorMsg)
@@ -148,4 +202,52 @@ type mockUploader struct{}
 
 func (m mockUploader) Upload(ctx context.Context, input *s3.PutObjectInput, opts ...func(*manager.Uploader)) (*manager.UploadOutput, error) {
 	return &manager.UploadOutput{}, nil
+}
+
+func Test_sqsMaxDirectMessageSize(t *testing.T) {
+	const overhead = 10 * 1024
+	const queueURL = "https://sqs.us-east-1.amazonaws.com/123456789/test-queue"
+
+	maxSizeAttr := func(v int) map[string]string {
+		return map[string]string{string(sqstypes.QueueAttributeNameMaximumMessageSize): strconv.Itoa(v)}
+	}
+
+	tests := []struct {
+		name     string
+		mock     *mockSQSGetQueueAttributer
+		wantSize int
+	}{
+		{
+			name:     "returns attribute value minus overhead",
+			mock:     &mockSQSGetQueueAttributer{attrs: maxSizeAttr(262144)},
+			wantSize: 262144 - overhead,
+		},
+		{
+			name:     "falls back to SNS limit when API call fails",
+			mock:     &mockSQSGetQueueAttributer{err: errors.New("connection refused")},
+			wantSize: maxSNSDirectMessageSize,
+		},
+		{
+			name:     "falls back to SNS limit when attribute is missing",
+			mock:     &mockSQSGetQueueAttributer{attrs: map[string]string{}},
+			wantSize: maxSNSDirectMessageSize,
+		},
+		{
+			name:     "falls back to SNS limit when value is not a number",
+			mock:     &mockSQSGetQueueAttributer{attrs: map[string]string{string(sqstypes.QueueAttributeNameMaximumMessageSize): "not-a-number"}},
+			wantSize: maxSNSDirectMessageSize,
+		},
+		{
+			name:     "falls back to SNS limit when value is too small to subtract overhead",
+			mock:     &mockSQSGetQueueAttributer{attrs: maxSizeAttr(overhead)},
+			wantSize: maxSNSDirectMessageSize,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := sqsMaxDirectMessageSize(context.Background(), tt.mock, queueURL, slog.Default())
+			assert.Equal(t, tt.wantSize, got)
+		})
+	}
 }


### PR DESCRIPTION
Backport of #66469 to branch/v17



<!-- Provide a descriptive entry for the changelog of the next release. -->

Changelog: Reduced unnecessary S3 uploads for Athena audit log deployments that publish directly to SQS by applying the correct SQS message size limit when the client has `sqs:GetQueueAttributes` permission, instead of always using the 256 KB SNS limit.


## Manual Test Plan
### Test Environment

local

### Test Cases
- [x] Athena passes integration tests