### PR TITLE
Add Scope support for proxy recording mode

### DIFF
--- a/lib/srv/authhandlers.go
+++ b/lib/srv/authhandlers.go
@@ -609,7 +609,7 @@ func (h *AuthHandlers) PublicKeyCallback(conn ssh.ConnMetadata, key ssh.PublicKe
 	case teleport.ComponentForwardingGit:
 		gitForwardingPermit, err = h.evaluateGitForwarding(ident, ca, clusterName.GetClusterName(), h.c.TargetServer)
 	case teleport.ComponentProxy:
-		proxyPermit, err = h.evaluateProxying(ident, ca, clusterName.GetClusterName())
+		proxyPermit, err = h.evaluateProxying(ident, ca, clusterName.GetClusterName(), h.c.TargetServer, conn.User())
 	case teleport.ComponentForwardingNode:
 		diagnosticTracing = true
 		if h.c.TargetServer != nil && h.c.TargetServer.IsOpenSSHNode() {
@@ -618,7 +618,7 @@ func (h *AuthHandlers) PublicKeyCallback(conn ssh.ConnMetadata, key ssh.PublicKe
 				accessPermit, err = h.evaluateScopedSSHAccess(ident, ca, clusterName.GetClusterName(), h.c.TargetServer, conn.User())
 			}
 		} else {
-			proxyPermit, err = h.evaluateProxying(ident, ca, clusterName.GetClusterName())
+			proxyPermit, err = h.evaluateProxying(ident, ca, clusterName.GetClusterName(), h.c.TargetServer, conn.User())
 		}
 	case teleport.ComponentNode:
 		diagnosticTracing = true
@@ -948,7 +948,7 @@ type scopedLoginChecker interface {
 type proxyingChecker interface {
 	// evaluateProxying evaluates the capabilities/constraints related to a user's
 	// attempt to access proxy forwarding.
-	evaluateProxying(ident *sshca.Identity, ca types.CertAuthority, clusterName string) (*proxyingPermit, error)
+	evaluateProxying(ident *sshca.Identity, ca types.CertAuthority, clusterName string, target types.Server, osUser string) (*proxyingPermit, error)
 }
 
 type gitForwardingChecker interface {
@@ -975,7 +975,7 @@ type proxyingPermit struct {
 	PinSourceIP           bool
 }
 
-func (a *ahLoginChecker) evaluateProxying(ident *sshca.Identity, ca types.CertAuthority, clusterName string) (*proxyingPermit, error) {
+func (a *ahLoginChecker) evaluateProxying(ident *sshca.Identity, ca types.CertAuthority, clusterName string, target types.Server, osUser string) (*proxyingPermit, error) {
 	// Use the server's shutdown context.
 	ctx := a.c.Server.Context()
 
@@ -986,9 +986,49 @@ func (a *ahLoginChecker) evaluateProxying(ident *sshca.Identity, ca types.CertAu
 		return nil, trace.Wrap(err)
 	}
 
-	accessChecker, err := services.NewAccessChecker(accessInfo, clusterName, a.c.AccessPoint)
+	// Build context — scoped or unscoped-wrapping.
+	var checkerContext *services.ScopedAccessCheckerContext
+	if accessInfo.ScopePin != nil {
+		checkerContext, err = services.NewScopedAccessCheckerContext(ctx, accessInfo, clusterName, a.c.AccessPoint.ScopedRoleReader())
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+	} else {
+		unscoped, err := services.NewAccessChecker(accessInfo, clusterName, a.c.AccessPoint)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		checkerContext = services.NewScopedAccessCheckerContextFromUnscoped(unscoped)
+	}
+
+	if accessInfo.ScopePin != nil && target == nil {
+		return nil, trace.AccessDenied("scoped proxying without a target is not supported")
+	}
+
+	agentScope := ""
+	if target != nil && target.GetScope() != "" {
+		agentScope = target.GetScope()
+	}
+
+	state, err := checkerContext.AccessStateFromSSHIdentity(ctx, ident, a.c.AccessPoint)
 	if err != nil {
 		return nil, trace.Wrap(err)
+	}
+
+	var checker *services.ScopedAccessChecker
+	if err := checkerContext.Decision(ctx, agentScope, func(c *services.ScopedAccessChecker) error {
+		// Clients are able to dial nodes as an SSH subsystem (ComponentProxy), and the target server is not known at this time.
+		// We do not support this mode for scopes right now.
+		if target != nil {
+			if err := c.SSH().CheckAccessToSSHServer(target, state, osUser); err != nil {
+				return trace.Wrap(err)
+			}
+		}
+		checker = c
+		return nil
+	}); err != nil {
+		return nil, trace.AccessDenied("user %s@%s is not authorized to login as %v@%s: %v",
+			ident.Username, ca.GetClusterName(), osUser, clusterName, err)
 	}
 
 	netConfig, err := a.c.AccessPoint.GetClusterNetworkingConfig(ctx)
@@ -1002,24 +1042,28 @@ func (a *ahLoginChecker) evaluateProxying(ident *sshca.Identity, ca types.CertAu
 		return nil, trace.Wrap(err)
 	}
 
-	privateKeyPolicy, err := accessChecker.PrivateKeyPolicy(authPref.GetPrivateKeyPolicy())
+	privateKeyPolicy, err := checker.PrivateKeyPolicy(authPref.GetPrivateKeyPolicy())
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
-	lockTargets := services.ProxyingLockTargets(clusterName, a.c.Server.HostUUID() /* id of underlying proxy */, accessInfo, ident)
+	clientIdleTimeout, err := checker.SSH().AdjustClientIdleTimeout(netConfig.GetClientIdleTimeout())
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
 
+	lockTargets := services.ProxyingLockTargets(clusterName, a.c.Server.HostUUID(), accessInfo, ident)
 	return &proxyingPermit{
-		ClientIdleTimeout:     accessChecker.AdjustClientIdleTimeout(netConfig.GetClientIdleTimeout()),
-		LockingMode:           accessChecker.LockingMode(authPref.GetLockingMode()),
+		ClientIdleTimeout:     clientIdleTimeout,
+		LockingMode:           checker.SSH().LockingMode(authPref.GetLockingMode()),
 		PrivateKeyPolicy:      privateKeyPolicy,
 		LockTargets:           lockTargets,
-		MaxConnections:        accessChecker.MaxConnections(),
-		SSHFileCopy:           accessChecker.CanCopyFiles(),
-		DisconnectExpiredCert: getDisconnectExpiredCertFromSSHIdentity(accessChecker, authPref, ident),
+		MaxConnections:        checker.SSH().MaxConnections(),
+		SSHFileCopy:           checker.SSH().CanCopyFiles(),
+		DisconnectExpiredCert: getDisconnectExpiredCertFromSSHIdentityScoped(checker.SSH(), authPref, ident),
 		MappedRoles:           accessInfo.Roles,
-		SessionRecordingMode:  accessChecker.SessionRecordingMode(constants.SessionRecordingServiceSSH),
-		PinSourceIP:           accessChecker.PinSourceIP(),
+		SessionRecordingMode:  checker.SSH().SessionRecordingMode(),
+		PinSourceIP:           checker.PinSourceIP(),
 	}, nil
 }
 

--- a/lib/srv/authhandlers_test.go
+++ b/lib/srv/authhandlers_test.go
@@ -107,11 +107,15 @@ func (m mockScopedRoleGetter) GetScopedRole(ctx context.Context, req *scopedacce
 }
 
 type mockLoginChecker struct {
-	rbacChecked bool
+	rbacChecked          bool
+	returnScopedIdentity bool
 }
 
 func (m *mockLoginChecker) evaluateSSHAccess(_ *sshca.Identity, _ types.CertAuthority, _ string, _ types.Server, _ string) (*decisionpb.SSHAccessPermit, error) {
 	m.rbacChecked = true
+	if m.returnScopedIdentity {
+		return nil, services.ErrScopedIdentity
+	}
 	return nil, nil
 }
 
@@ -163,17 +167,21 @@ func TestRBAC(t *testing.T) {
 
 	ctx := t.Context()
 
-	node, err := types.NewNode("testie_node", types.SubKindTeleportNode, types.ServerSpecV2{
+	const nodeScope = "/test/scope"
+
+	node, err := types.NewNode("testnode", types.SubKindTeleportNode, types.ServerSpecV2{
 		Addr:     "1.2.3.4:22",
 		Hostname: "testie",
-	}, nil)
+	}, map[string]string{"test": "node"})
 	require.NoError(t, err)
+	node.(*types.ServerV2).Scope = nodeScope
 
 	openSSHNode, err := types.NewNode("openssh", types.SubKindOpenSSHNode, types.ServerSpecV2{
 		Addr:     "1.2.3.4:22",
 		Hostname: "openssh",
-	}, nil)
+	}, map[string]string{"test": "node"})
 	require.NoError(t, err)
+	openSSHNode.(*types.ServerV2).Scope = nodeScope
 
 	gitServer, err := types.NewGitHubServer(types.GitHubServerMetadata{
 		Integration:  "org",
@@ -185,6 +193,7 @@ func TestRBAC(t *testing.T) {
 		name           string
 		component      string
 		targetServer   types.Server
+		scoped         bool
 		loginRBACCheck require.BoolAssertionFunc
 		gitRBACCheck   require.BoolAssertionFunc
 	}{
@@ -223,6 +232,31 @@ func TestRBAC(t *testing.T) {
 			loginRBACCheck: require.False,
 			gitRBACCheck:   require.True,
 		},
+		// Scope checking
+		{
+			name:           "scoped - teleport node, regular server",
+			component:      teleport.ComponentNode,
+			targetServer:   node,
+			scoped:         true,
+			loginRBACCheck: require.True,
+			gitRBACCheck:   require.False,
+		},
+		{
+			name:           "scoped - registered openssh node, forwarding server",
+			component:      teleport.ComponentForwardingNode,
+			targetServer:   openSSHNode,
+			scoped:         true,
+			loginRBACCheck: require.True,
+			gitRBACCheck:   require.False,
+		},
+		{
+			name:           "scoped - teleport node, forwarding server",
+			component:      teleport.ComponentForwardingNode,
+			targetServer:   node,
+			scoped:         true,
+			loginRBACCheck: require.False,
+			gitRBACCheck:   require.False,
+		},
 	}
 
 	// create User CA
@@ -245,6 +279,7 @@ func TestRBAC(t *testing.T) {
 
 	// create mock SSH server and add a cluster name
 	server := newMockServer(t)
+	server.setInfo(node)
 	clusterName, err := types.NewClusterName(types.ClusterNameSpecV2{
 		ClusterName: "localhost",
 		ClusterID:   "cluster_id",
@@ -256,12 +291,47 @@ func TestRBAC(t *testing.T) {
 	_, err = server.auth.CreateClusterNetworkingConfig(ctx, types.DefaultClusterNetworkingConfig())
 	require.NoError(t, err)
 
-	accessPoint := mockCAandAuthPrefGetter{
-		AccessPoint: server.auth,
-		authPref:    types.DefaultAuthPreference(),
-		cas: map[types.CertAuthType][]types.CertAuthority{
-			types.UserCA: {userCA},
+	nodeAccessRole, err := types.NewRole("node-access", types.RoleSpecV6{
+		Allow: types.RoleConditions{
+			Logins:     []string{"testuser"},
+			NodeLabels: types.Labels{types.Wildcard: []string{types.Wildcard}},
 		},
+	})
+	require.NoError(t, err)
+	_, err = server.auth.CreateRole(ctx, nodeAccessRole)
+	require.NoError(t, err)
+
+	scopedRole := &scopedaccessv1.ScopedRole{
+		Kind:     scopedaccess.KindScopedRole,
+		Metadata: &headerv1.Metadata{Name: "test"},
+		Scope:    nodeScope,
+		Spec: &scopedaccessv1.ScopedRoleSpec{
+			AssignableScopes: []string{nodeScope},
+			Ssh: &scopedaccessv1.ScopedRoleSSH{
+				Logins: []string{"testuser"},
+				Labels: []*labelv1.Label{
+					{Name: "test", Values: []string{"node"}},
+				},
+			},
+		},
+		Version: types.V1,
+	}
+	scopePin := &scopesv1.Pin{
+		Scope: "/test",
+		AssignmentTree: pinning.AssignmentTreeFromMap(map[string]map[string][]string{
+			nodeScope: {nodeScope: {scopedRole.Metadata.Name}},
+		}),
+	}
+
+	accessPoint := mockScopedRoleReaderGetter{
+		AccessPoint: mockCAandAuthPrefGetter{
+			AccessPoint: server.auth,
+			authPref:    types.DefaultAuthPreference(),
+			cas: map[types.CertAuthType][]types.CertAuthority{
+				types.UserCA: {userCA},
+			},
+		},
+		scopedRoles: []*scopedaccessv1.ScopedRole{scopedRole},
 	}
 
 	for _, tt := range tests {
@@ -277,7 +347,7 @@ func TestRBAC(t *testing.T) {
 			ah, err := NewAuthHandlers(config)
 			require.NoError(t, err)
 
-			lc := mockLoginChecker{}
+			lc := mockLoginChecker{returnScopedIdentity: tt.scoped}
 			ah.loginChecker = &lc
 
 			gc := mockGitForwardingChecker{}
@@ -289,13 +359,21 @@ func TestRBAC(t *testing.T) {
 			privateKey, err := cryptosuites.GeneratePrivateKeyWithAlgorithm(cryptosuites.ECDSAP256)
 			require.NoError(t, err)
 
+			ident := sshca.Identity{
+				Username:   "testuser",
+				Principals: []string{"testuser"},
+			}
+			if tt.scoped {
+				ident.ScopePin = scopePin
+			} else {
+				ident.Roles = []string{nodeAccessRole.GetName()}
+			}
+
 			c, err := testauthority.GenerateUserCert(sshca.UserCertificateRequest{
-				CASigner:      caSigner,
-				PublicUserKey: ssh.MarshalAuthorizedKey(privateKey.SSHPublicKey()),
-				Identity: sshca.Identity{
-					Username:   "testuser",
-					Principals: []string{"testuser"},
-				},
+				CASigner:          caSigner,
+				PublicUserKey:     ssh.MarshalAuthorizedKey(privateKey.SSHPublicKey()),
+				CertificateFormat: constants.CertificateFormatStandard,
+				Identity:          ident,
 			})
 			require.NoError(t, err)
 


### PR DESCRIPTION
SPecifying proxy mode in the `session_recording_config` would throw an error when trying to access a teleport ssh node as a scoped user.

<!-- Provide a descriptive entry for the changelog of the next release. -->

Changelog: Add proxy recording support for scoped roles


<!-- Include manual testing efforts to verify the change. -->
<!-- Detail where the tests where run and what configurations were used. -->
<!-- Include all the test cases which were run to validate the change. -->

## Manual Test Plan
### Test Environment

Local cluster

### Test Cases
- [x] Enabled the proxy recording mode and ssh into a node running teleport
- [x] Enabled the proxy recording mode and ssh into an openSSH node
- [x] scoped user cannot access other nodes that are unscoped or in a different scope
