### PR TITLE
Remove unused parameter from access plugin `NewApp`

### DIFF
--- a/integrations/access/accesslist/app.go
+++ b/integrations/access/accesslist/app.go
@@ -57,7 +57,7 @@ type App struct {
 }
 
 // NewApp will create a new access list application.
-func NewApp(bot MessagingBot) common.App {
+func NewApp() common.App {
 	app := &App{}
 	app.job = lib.NewServiceJob(app.run)
 	return app

--- a/integrations/access/accesslist/app_test.go
+++ b/integrations/access/accesslist/app_test.go
@@ -83,7 +83,7 @@ func (m *mockMessagingBot) FetchRecipient(ctx context.Context, recipient string)
 
 func (m *mockMessagingBot) SupportedApps() []common.App {
 	return []common.App{
-		NewApp(m),
+		NewApp(),
 	}
 }
 

--- a/integrations/access/accessrequest/app.go
+++ b/integrations/access/accessrequest/app.go
@@ -64,7 +64,7 @@ type App struct {
 }
 
 // NewApp will create a new access request application.
-func NewApp(bot MessagingBot) common.App {
+func NewApp() common.App {
 	app := &App{}
 	app.job = lib.NewServiceJob(app.run)
 	return app

--- a/integrations/access/datadog/bot.go
+++ b/integrations/access/datadog/bot.go
@@ -68,7 +68,7 @@ var resolutionNoteTemplate = template.Must(template.New("resolution note").Parse
 // SupportedApps are the apps supported by this bot.
 func (b Bot) SupportedApps() []common.App {
 	return []common.App{
-		accessrequest.NewApp(b),
+		accessrequest.NewApp(),
 	}
 }
 

--- a/integrations/access/discord/bot.go
+++ b/integrations/access/discord/bot.go
@@ -112,7 +112,7 @@ func (b DiscordBot) CheckHealth(ctx context.Context) error {
 // SupportedApps are the apps supported by this bot.
 func (b DiscordBot) SupportedApps() []common.App {
 	return []common.App{
-		accessrequest.NewApp(b),
+		accessrequest.NewApp(),
 	}
 }
 

--- a/integrations/access/mattermost/bot.go
+++ b/integrations/access/mattermost/bot.go
@@ -223,7 +223,7 @@ func NewBot(conf Config, clusterName, webProxyAddr string) (Bot, error) {
 // SupportedApps are the apps supported by this bot.
 func (b Bot) SupportedApps() []common.App {
 	return []common.App{
-		accessrequest.NewApp(b),
+		accessrequest.NewApp(),
 	}
 }
 

--- a/integrations/access/opsgenie/bot.go
+++ b/integrations/access/opsgenie/bot.go
@@ -45,7 +45,7 @@ type Bot struct {
 // SupportedApps are the apps supported by this bot.
 func (b *Bot) SupportedApps() []common.App {
 	return []common.App{
-		accessrequest.NewApp(b),
+		accessrequest.NewApp(),
 	}
 }
 

--- a/integrations/access/servicenow/bot.go
+++ b/integrations/access/servicenow/bot.go
@@ -44,7 +44,7 @@ type Bot struct {
 // SupportedApps are the apps supported by this bot.
 func (b *Bot) SupportedApps() []common.App {
 	return []common.App{
-		accessrequest.NewApp(b),
+		accessrequest.NewApp(),
 	}
 }
 

--- a/integrations/access/slack/bot.go
+++ b/integrations/access/slack/bot.go
@@ -98,8 +98,8 @@ func onAfterResponseSlack(sink common.StatusSink) func(_ *resty.Client, resp *re
 // SupportedApps are the apps supported by this bot.
 func (b Bot) SupportedApps() []common.App {
 	return []common.App{
-		accessrequest.NewApp(b),
-		appAccesslist.NewApp(b),
+		accessrequest.NewApp(),
+		appAccesslist.NewApp(),
 	}
 }
 


### PR DESCRIPTION
Remove the unused `bot` parameter in `NewApp()`. The bot field is set via `Init()` instead.

## Manual Test Plan
### Test Environment

Teleport Cloud, local Slack plugin.

### Test Cases
- [x] Verify Slack plugin behaves normally