### PR TITLE
Move some third-party setup steps to Prerequisites

### DIFF
--- a/docs/pages/enroll-resources/mcp-access/integration-guides/github.mdx
+++ b/docs/pages/enroll-resources/mcp-access/integration-guides/github.mdx
@@ -22,24 +22,29 @@ interacts with GitHub using the permissions granted to the service account.
 ## Prerequisites
 
 (!docs/pages/includes/edition-prereqs-tabs.mdx edition="Teleport (v18.3.0 or higher)" clients="\`tsh\` client"!)
+
 - Access to a service account to your GitHub organization.
+
 - A host to run the MCP server that is reachable by the Teleport Application Service.
+
 - A running Teleport Application Service. If you have not yet done this, follow
   the [Getting Started guide](../getting-started.mdx).
+
 - A Teleport user with sufficient permissions (e.g. role `mcp-user`) to access
   MCP servers.
 
-## Step 1/3. Create a personal access token
+- A GitHub personal access token, which requires manual preparation in the
+  GitHub Web UI. To create a token, follow the [GitHub
+  documentation](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens#creating-a-fine-grained-personal-access-token).
 
-Log in to GitHub using your service account. Navigate to Settings > Developer
-Settings > Personal access tokens, then click **Generate new token**.
+  <Admonition type="danger">
 
-When creating the token, grant only the minimal permissions needed. Avoid broad
-scopes such as write or admin access unless absolutely required.
+  When creating the token, grant only the minimal permissions needed. Avoid
+  broad scopes such as write or admin access unless absolutely required.
 
-Once the token is created, save it for use in the next step.
+  </Admonition>
 
-## Step 2/3. Run the GitHub MCP server
+## Step 1/2. Run the GitHub MCP server
 
 First, install `mcp-proxy` on the host that will run the MCP server:
 ```code
@@ -66,7 +71,7 @@ Service.
 After starting, `mcp-proxy` exposes a streamable-HTTP endpoint at `http://<Var
 name="MCP_HOST" initial="localhost" />:8000/mcp`.
 
-## Step 3/3. Connect via Teleport
+## Step 2/2. Connect via Teleport
 
 (!docs/pages/includes/mcp-access/integration-teleport-app.mdx service="github" serviceName="GitHub" port="8000"!)
 
@@ -90,7 +95,7 @@ spec:
 
 ![GitHub Claude](../../../../img/mcp-access/github-claude.png)
 
-## Connect to GitHub without service account
+## Connect to GitHub without a service account
 
 Instead of using a service account's personal access token, you can require each
 Teleport user to supply their own token from the client side. This removes the

--- a/docs/pages/enroll-resources/mcp-access/integration-guides/grafana.mdx
+++ b/docs/pages/enroll-resources/mcp-access/integration-guides/grafana.mdx
@@ -21,18 +21,26 @@ mapped by [JWT authentication](https://grafana.com/docs/grafana/latest/setup-gra
 ## Prerequisites
 
 (!docs/pages/includes/edition-prereqs-tabs.mdx edition="Teleport (v18.3.0 or higher)" clients="\`tsh\` client"!)
-- Ability to configure your Grafana instance.
+
 - A host to run the MCP server that is reachable by the Teleport Application Service.
+
 - A running Teleport Application Service. If you have not yet done this, follow
   the [Getting Started guide](../getting-started.mdx).
+
 - A Teleport user with sufficient permissions (e.g. role `mcp-user`) to access
   MCP servers.
 
-## Step 1/3. Configure JWT authentication in Grafana
+- A Grafana instance configured for JWT authentication. Setting this up depends
+  on your infrastructure and is outside the scope of this guide.
 
-(!docs/pages/includes/application-access/jwt-grafana-config.mdx!)
+  <details>
+  <summary>Configuring JWT authentication in Grafana</summary>
 
-## Step 2/3. Run the Grafana MCP server
+  (!docs/pages/includes/application-access/jwt-grafana-config.mdx!)
+
+  </details>
+
+## Step 1/2. Run the Grafana MCP server
 
 The Grafana MCP Server can be run either as a compiled binary or via the
 official Docker image:
@@ -63,7 +71,7 @@ $ docker run -d -p 8000:8000 \
 
 The Grafana MCP Server now exposes a streamable-HTTP endpoint at `http://<Var name="MCP_HOST"/>:8000/mcp`.
 
-## Step 3/3. Connect via Teleport
+## Step 2/2. Connect via Teleport
 
 (!docs/pages/includes/mcp-access/integration-teleport-app-rewrite.mdx service="grafana" serviceName="Grafana" port="8000" headerName="X-Grafana-API-Key" headerValue="&#123;&#123;internal.jwt&#125;&#125;" !)
 

--- a/docs/pages/enroll-resources/mcp-access/integration-guides/notion.mdx
+++ b/docs/pages/enroll-resources/mcp-access/integration-guides/notion.mdx
@@ -21,32 +21,42 @@ granted to the integration.
 ## Prerequisites
 
 (!docs/pages/includes/edition-prereqs-tabs.mdx edition="Teleport (v18.3.0 or higher)" clients="\`tsh\` client"!)
+
 - Access to your Notion workspace and sufficient privileges to manage integrations.
+
 - A host to run the MCP server that is reachable by the Teleport Application Service.
+
 - A running Teleport Application Service. If you have not yet done this, follow
   the [Getting Started guide](../getting-started.mdx).
+
 - A Teleport user with sufficient permissions (e.g. role `mcp-user`) to access
   MCP servers.
 
-## Step 1/3. Create an integration in Notion
+- A Notion integration with permissions to read content. This requires manually
+  setting up the integration in the Notion Web UI.
 
-Go to https://www.notion.so/profile/integrations and create a new **internal
-integration**.
+  <details>
+  <summary>Setting up a Notion integration</summary>
 
-![Notion integration](../../../../img/mcp-access/notion-integration.png)
+  1. Go to https://www.notion.so/profile/integrations and create a new **internal
+     integration**.
+  
+     ![Notion integration](../../../../img/mcp-access/notion-integration.png)
+  
+  1. Limit the scope available to LLMs: disable all permissions except "Read
+     Content" in the "Capabilities" section.
+  
+  1. Open the "Access" tab and select the pages you want the integration to be
+     able to access.
+  
+     ![Notion access](../../../../img/mcp-access/notion-access.png)
+  
+  1. Return to the "Configuration" tab, copy the "Internal Integration Secret" for
+     use in the next step.
 
-To limit the scope available to LLMs, disable all permissions except "Read
-Content" in the "Capabilities" section.
+  </details>
 
-Next, open "Access" tab and select the pages you want the integration to be able
-to access.
-
-![Notion access](../../../../img/mcp-access/notion-access.png)
-
-Finally, return to the "Configuration" tab, copy the "Internal Integration
-Secret" for use in the next step.
-
-## Step 2/3. Run the Notion MCP server
+## Step 1/2. Run the Notion MCP server
 
 Start the Notion MCP server using your Notion integration token <Var
 name="ntn_your_internal_integration_secret" />:
@@ -63,7 +73,7 @@ The `--auth-token` value is the shared secret Teleport uses to authenticate to
 the MCP server. Since the MCP server is not publicly accessible, using a fixed
 value is acceptable.
 
-## Step 3/3. Connect via Teleport
+## Step 2/2. Connect via Teleport
 
 (!docs/pages/includes/mcp-access/integration-teleport-app.mdx service="notion" serviceName="Notion" port="8000" !)
 

--- a/docs/pages/identity-governance/access-requests/plugins/discord.mdx
+++ b/docs/pages/identity-governance/access-requests/plugins/discord.mdx
@@ -46,17 +46,41 @@ targeted by the Access Request.
 
 - Admin account on your Discord server. Installing a bot requires at least the
   "manager server" permission.
+
 - Either a Linux host or Kubernetes cluster where you will run the Discord plugin.
+
 - (!docs/pages/includes/tctl.mdx!)
 
-## Step 1/8. Define RBAC resources
+- An app registered with Discord to represent the Access Request plugin. This
+  requires manually creating the app in the Discord Web UI. 
+
+  Follow the [Discord Getting Started
+  guide](https://docs.discord.com/developers/quick-start/getting-started) to
+  create an app and add it to your Discord servers. Make sure the bot is only
+  available to your Discord servers and is not a public bot.
+
+  The app must grant the following OAuth2 scopes:
+  - bot
+  - View Channels
+  - Send Messages
+
+  <Admonition type="tip">
+
+  Copy the token for use later in this guide.
+
+  </Admonition>
+
+  When registering the app, you can use the <a href={AppIcon} download>Teleport
+  icon</a> as well as our <a href={BotLogo} download>Teleport avatar</a>.
+
+## Step 1/7. Define RBAC resources
 
 Before you set up the Discord plugin, you will need to enable Role Access Requests
 in your Teleport cluster.
 
 (!/docs/pages/includes/plugins/editor-request-rbac.mdx!)
 
-## Step 2/8. Define a Teleport Discord plugin user
+## Step 2/7. Define a Teleport Discord plugin user
 
 The required permissions for the plugin are configured in the preset `access-plugin`
 role. To generate credentials for the plugin, define either a Machine ID bot user
@@ -71,7 +95,7 @@ or a regular Teleport user.
 </TabItem>
 </Tabs>
 
-## Step 3/8. Export the access plugin identity
+## Step 3/7. Export the access plugin identity
 
 Give the plugin access to a Teleport identity file. We recommend using Machine
 ID for this in order to produce short-lived identity files that are less
@@ -87,56 +111,11 @@ longer-lived identity files with `tctl`:
 </TabItem>
 </Tabs>
 
-## Step 4/8. Install the Teleport Discord plugin
+## Step 4/7. Install the Teleport Discord plugin
 
 (!docs/pages/includes/plugins/install-access-request.mdx name="discord"!)
 
-## Step 5/8. Register a Discord app
-
-The Access Request plugin for Discord receives Access Request events from the
-Teleport Auth Service, formats them into Discord messages, and sends them to the
-Discord API to post them in your guild (Discord server). For this to work,
-you must register a new app with the Discord API.
-
-### Create your application
-
-1. Visit
-   [https://discord.com/developers/applications](https://discord.com/developers/applications)
-   to create a new Discord application. Click "New Application" and name the
-   application "Teleport".
-1. <a href={AppIcon} download>Download the application icon.</a>
-1. Set the application icon.
-
-### Create the application bot
-
-Go to the "Bot" tab and choose "Add Bot". You can <a href={BotLogo}
-download>download</a> our avatar to set as your Bot icon. Un-check the "Public
-Bot" toggle as this bot should only be used within your Discord servers.
-Finally, press "Reset Token", copy and save the new token into a safe place.
-This token will be used by the Teleport plugin to authenticate against the
-Discord API.
-
-### Install and authorize the application in your Discord server
-
-Go to the "OAuth2" tab, open the "URL Generator" and check the following
-permissions:
-
-- bot
-- View Channels
-- Send Messages
-
-Copy and access the generated URL. Choose to install the application into the
-desired Discord server. If the server is not available in the
-dropdown list, it means you don't have sufficient rights. Ask a server
-administrator to grant you a role with the "manage server" permission.
-
-<Admonition type="note">
-The same application can be installed into multiple Discord servers. To
-do so, access the OAuth URL multiple times and choose different servers. You
-have to be admin on a Discord server to install the app into it.
-</Admonition>
-
-## Step 6/8. Configure the Teleport Discord plugin
+## Step 5/7. Configure the Teleport Discord plugin
 
 At this point, the Teleport Discord plugin has the credentials it needs to
 communicate with your Teleport cluster and the Discord API. In this step, you will
@@ -295,7 +274,7 @@ The final configuration file should resemble the following:
 </TabItem>
 </Tabs>
 
-## Step 7/8. Test your Discord app
+## Step 6/7. Test your Discord app
 
 Once Teleport is running, you've created the Discord app, and the plugin is
 configured, you can now run the plugin and test the workflow.
@@ -377,7 +356,7 @@ Request Reviewed` in the Teleport Web UI.
 
 </Admonition>
 
-## Step 8/8. Set up systemd
+## Step 7/7. Set up systemd
 
 This section is only relevant if you are running the Teleport Discord plugin on a
 Linux host.

--- a/docs/pages/identity-governance/access-requests/plugins/jira.mdx
+++ b/docs/pages/identity-governance/access-requests/plugins/jira.mdx
@@ -49,6 +49,35 @@ webhook run by the plugin, which modifies the Access Request in Teleport.
     to allow traffic to the Jira plugin via a `LoadBalancer` service, so your
     environment must support services of this type.
 
+- A Jira Kanban project with exactly four columns named `Pending`, `Approved`,
+  `Denied`, and `Expired`, and no other columns or statuses. This requires
+  manual preparation using the Jira Web UI. In this guide, we assume that your
+  project is called "Teleport Access Requests", which receives the key `TAR` by
+  default. 
+
+  <Admonition type="warning">
+
+  If your project board does not contain these (and only these) columns, each
+  with a status of the same name, the Jira Access Request plugin will behave in
+  unexpected ways.
+
+  </Admonition>
+
+- A Jira API token for the plugin to authenticate with, which requires the
+  Atlassian Web UI. Follow the [Atlassian
+  documentation](https://support.atlassian.com/atlassian-account/docs/manage-api-tokens-for-your-atlassian-account/)
+  for instructions on creating a token.
+
+- The public domain name (including any DNS records) for the Teleport Jira
+  plugin. Jira must be able to reach your webhook on this domain name.
+
+- A Jira webhook pointing to `<plugin-domain>:8081` (if you are deploying the
+  plugin on a Linux server) or `<plugin-domain>:443` (if using Kubernetes). The
+  webhook needs to be notified only when an issue is created, updated, or
+  deleted. Follow the [Atlassian webhook
+  docs](https://developer.atlassian.com/server/jira/platform/webhooks/) to
+  create it.
+
 - A means of providing TLS credentials for the Jira webhook run by the plugin.
   **TLS certificates must not be self signed.** For example, you can obtain TLS
   credentials for the webhook with Let's Encrypt by using an [ACME
@@ -62,14 +91,14 @@ webhook run by the plugin, which modifies the Access Request in Teleport.
 
 - (!docs/pages/includes/tctl.mdx!)
 
-## Step 1/8. Define RBAC resources
+## Step 1/7. Define RBAC resources
 
 Before you set up the Jira plugin, you need to enable Role Access Requests in
 your Teleport cluster.
 
 (!docs/pages/includes/plugins/editor-request-rbac.mdx!)
 
-## Step 2/8. Define a Teleport Jira plugin user
+## Step 2/7. Define a Teleport Jira plugin user
 
 The required permissions for the plugin are configured in the preset
 `access-plugin-update` role. To generate credentials for the plugin, define
@@ -126,7 +155,7 @@ $ tctl bots update my-bot --add-roles access-plugin-update
 </TabItem>
 </Tabs>
 
-## Step 3/8. Export the access plugin identity
+## Step 3/7. Export the access plugin identity
 
 Give the plugin access to a Teleport identity file. We recommend using Machine
 ID for this in order to produce short-lived identity files that are less
@@ -142,7 +171,7 @@ longer-lived identity files with `tctl`:
 </TabItem>
 </Tabs>
 
-## Step 4/8. Install the Teleport Jira plugin
+## Step 4/7. Install the Teleport Jira plugin
 
 Install the Teleport Jira plugin following the instructions below, which depend
 on whether you are deploying the plugin on a host (e.g., an EC2 instance) or a
@@ -154,91 +183,7 @@ tenant).
 
 (!docs/pages/includes/plugins/install-access-request.mdx name="jira"!)
 
-## Step 5/8. Set up a Jira project
-
-In this section, you will create a Jira a project that the Teleport plugin can
-modify when a Teleport user creates or updates an Access Request. The plugin
-then uses the Jira webhook to monitor the state of the board and respond to any
-changes in the tickets it creates.
-
-### Create a project for managing Access Requests
-
-In Jira, find the top navigation bar and click **Projects** -> **Create
-project**. Select **Kanban** for the template, then **Use template**. Click
-**Select a company-managed project**.
-
-You'll see a screen where you can enter a name for your project. In this guide,
-we assume that your project is called "Teleport Access Requests", which
-receives the key `TAR` by default. 
-
-Make sure "Connect repositories, documents, and more" is unset, then click
-**Create project**.
-
-In the three-dots menu on the upper right of your new board, click **Board
-settings**, then click **Columns**. Edit the statuses in your board so it
-contains the following four:
-
-1. Pending
-1. Approved
-1. Denied
-1. Expired
-
-Create a column with the same name as each status. The result should be the
-following:
-
-![Jira board setup](../../../../img/enterprise/plugins/jira/board-setup.png)
-
-<Admonition type="warning">
-
-If your project board does not contain these (and only these) columns, each with
-a status of the same name, the Jira Access Request plugin will behave in
-unexpected ways. Remove all other columns and statuses.
-
-</Admonition>
-
-Click **Back to board** to review your changes.
-
-### Retrieve your Jira API token
-
-Obtain an API token that the Access Request plugin uses to make
-changes to your Jira project. Click the gear menu at the upper right of the
-screen, then click **Atlassian account settings**. Click **Security** >
-**Create and manage API tokens** > **Create API token**. 
-
-Choose any label and click **Copy**. Paste the API token into a convenient
-location (e.g., a password manager or local text document) so you can use it
-later in this guide when you configure the Jira plugin.
-
-### Set up a Jira webhook
-
-Now that you have generated an API key that the Teleport Jira plugin uses to
-manage your project, enable Jira to notify the Teleport Jira plugin when your
-project is updated by creating a webhook.
-
-Return to Jira. Click the gear menu on the upper right of the screen. Click
-**System** > **WebHooks** > **Create a WebHook**. 
-
-<Tabs>
-<TabItem label="Executable">
-
-Enter "Teleport Access Request Plugin" in the "Name" field. In the "URL" field,
-enter the domain name you created for the plugin earlier, plus port `8081`.
-
-</TabItem>
-<TabItem label="Helm Chart">
-
-Enter "Teleport Access Request Plugin" in the "Name" field. In the "URL" field,
-enter the domain name you created for the plugin earlier, plus port `443`.
-
-</TabItem>
-</Tabs>
-
-The webhook needs to be notified only when an issue is created, updated, or
-deleted. You can leave all the other boxes empty.
-
-Click **Create**.
-
-## Step 6/8. Configure the Jira Access Request plugin
+## Step 5/7. Configure the Jira Access Request plugin
 
 Earlier, you retrieved credentials that the Jira plugin uses to connect to
 Teleport and the Jira API. You will now configure the plugin to use these
@@ -363,7 +308,7 @@ for the webhook. Use `teleport-plugin-jira-tls`.
 </TabItem>
 </Tabs>
 
-## Step 7/8. Run the Jira plugin
+## Step 6/7. Run the Jira plugin
 
 After finishing your configuration, you can now run the plugin and test your
 Jira-based Access Request flow:
@@ -467,7 +412,7 @@ Request Reviewed` in the Teleport Web UI.
 
 </Admonition>
 
-## Step 8/8. Set up systemd
+## Step 7/7. Set up systemd
 
 <Admonition type="tip">
 

--- a/docs/pages/identity-governance/access-requests/plugins/mattermost.mdx
+++ b/docs/pages/identity-governance/access-requests/plugins/mattermost.mdx
@@ -39,17 +39,31 @@ productivity.
 
 - A Mattermost account with admin privileges. This plugin has been tested with
   Mattermost v7.0.1.
+
 - Either a Linux host or Kubernetes cluster where you will run the Teleport Mattermost plugin.
+
+- A Mattermost bot for the plugin to use. This requires manual preparation in
+  the Mattermost Web UI. Follow the [Mattermost documentation](
+  https://developers.mattermost.com/integrate/reference/bot-accounts/) to create
+  a bot.
+
+  You can <a href={BotLogo} download>download</a> our avatar to set as your Bot
+  Icon.
+
+  Set "post:all" to "Enabled".
+
+  Save the resulting OAuth 2.0 token for use later in this guide.
+
 - (!docs/pages/includes/tctl.mdx!)
 
-## Step 1/8. Define RBAC resources
+## Step 1/7. Define RBAC resources
 
 Before you set up the Mattermost plugin, you will need to enable Role Access Requests
 in your Teleport cluster.
 
 (!/docs/pages/includes/plugins/editor-request-rbac.mdx!)
 
-## Step 2/8. Define a Teleport Mattermost plugin user
+## Step 2/7. Define a Teleport Mattermost plugin user
 
 The required permissions for the plugin are configured in the preset `access-plugin`
 role. To generate credentials for the plugin, define either a Machine ID bot user
@@ -64,7 +78,7 @@ or a regular Teleport user.
 </TabItem>
 </Tabs>
 
-## Step 3/8. Export the access plugin identity
+## Step 3/7. Export the access plugin identity
 
 Give the plugin access to a Teleport identity file. We recommend using Machine
 ID for this in order to produce short-lived identity files that are less
@@ -80,7 +94,7 @@ longer-lived identity files with `tctl`:
 </TabItem>
 </Tabs>
 
-## Step 4/8. Install the Teleport Mattermost plugin
+## Step 4/7. Install the Teleport Mattermost plugin
 
 <Tabs>
 <TabItem scope={["enterprise", "oss"]} label="Self-Hosted">
@@ -102,40 +116,7 @@ Teleport Proxy Service and your Mattermost deployment.
 
 (!docs/pages/includes/plugins/install-access-request.mdx name="mattermost"!)
 
-## Step 5/8. Register a Mattermost bot
-
-Now that you have generated the credentials your plugin needs to connect to your
-Teleport cluster, register your plugin with Mattermost so it can send Access
-Request messages to your workspace.
-
-In Mattermost, click the menu button in the upper left of the UI, then click
-System Console → Integrations → Bot Accounts.
-
-Set "Enable Bot Account Creation" to "true".
-
-![Enable Mattermost bots](../../../../img/enterprise/plugins/mattermost/mattermost_admin_console_integrations_bot_accounts.png)
-
-This will allow you to create a new bot account for the Mattermost plugin.
-
-Go back to your team. In the menu on the upper left of the UI, click
-Integrations → Bot Accounts → Add Bot Account.
-
-Set the "Username", "Display Name", and "Description" fields according to how
-you would like the Mattermost plugin bot to appear in your workspace. Set "Role"
-to "Member".
-
-{/* lint ignore absolute-docs-links */}
-You can <a href={BotLogo} download>download</a> our avatar to set as your Bot
-Icon.
-
-Set "post:all" to "Enabled".
-
-![Enable Mattermost Bots](../../../../img/enterprise/plugins/mattermost/mattermost_bot.png)
-
-Click "Create Bot Account". We will use the resulting OAuth 2.0 token when we
-configure the Mattermost plugin.
-
-## Step 6/8. Configure the Mattermost plugin
+## Step 5/7. Configure the Mattermost plugin
 
 At this point, you have generated credentials that the Mattermost plugin will use
 to connect to Teleport and Mattermost. You will now configure the Mattermost
@@ -276,7 +257,7 @@ severity = "INFO" # Logger severity. Could be "INFO", "ERROR", "DEBUG" or "WARN"
 </TabItem>
 </Tabs>
 
-## Step 7/8. Test your Mattermost bot
+## Step 6/7. Test your Mattermost bot
 
 <Tabs>
 <TabItem label="Executable">
@@ -355,7 +336,7 @@ Request Reviewed` in the Teleport Web UI.
 
 </Admonition>
 
-## Step 8/8. Set up systemd
+## Step 7/7. Set up systemd
 
 This section is only relevant if you are running the Teleport Mattermost plugin
 on a Linux host.

--- a/docs/pages/identity-governance/access-requests/plugins/slack.mdx
+++ b/docs/pages/identity-governance/access-requests/plugins/slack.mdx
@@ -57,18 +57,35 @@ Here is an example of sending an Access Request via Teleport's Slack plugin:
 - Slack admin privileges to create an app and install it to your workspace. Your
   Slack profile must have the "Workspace Owner" or "Workspace Admin" banner
   below your profile picture.
+
 - Either a Linux host or Kubernetes cluster where you will run the Slack plugin.
+
+- A Slack application and OAuth token to use for the plugin. These require
+  manual preparation in the Slack Web UI. Follow the [Slack
+  documentation](https://docs.slack.dev/tools/node-slack-sdk/getting-started) to
+  set up the application.
+
+  The application's name should be "Teleport".
+
+  The application requires the following scopes:
+  - `chat:write`
+  - `incoming-webhook`
+  - `users:read`
+  - `users:read.email`
+
+  Choose "Slackbot" as the default channel the plugin will post to. The plugin
+  will post here when sending direct messages.
 
 (!/docs/pages/includes/tctl.mdx!)
 
-## Step 1/8. Define RBAC resources
+## Step 1/7. Define RBAC resources
 
 Before you set up the Slack plugin, you will need to enable Role Access Requests
 in your Teleport cluster.
 
 (!/docs/pages/includes/plugins/editor-request-rbac.mdx!)
 
-## Step 2/8. Define a Teleport Slack plugin user
+## Step 2/7. Define a Teleport Slack plugin user
 
 The required permissions for the plugin are configured in the preset `access-plugin`
 role. To generate credentials for the plugin, define either a Machine ID bot user
@@ -83,7 +100,7 @@ or a regular Teleport user.
 </TabItem>
 </Tabs>
 
-## Step 3/8. Export the access plugin identity
+## Step 3/7. Export the access plugin identity
 
 Give the plugin access to a Teleport identity file. We recommend using Machine
 ID for this in order to produce short-lived identity files that are less
@@ -99,73 +116,11 @@ longer-lived identity files with `tctl`:
 </TabItem>
 </Tabs>
 
-## Step 4/8. Install the Teleport Slack plugin
+## Step 4/7. Install the Teleport Slack plugin
 
 (!docs/pages/includes/plugins/install-access-request.mdx name="slack"!)
 
-## Step 5/8. Register a Slack app
-
-The Access Request plugin for Slack receives Access Request events from the
-Teleport Auth Service, formats them into Slack messages, and sends them to the
-Slack API to post them in your workspace. For this to work, you must register a
-new app with the Slack API.
-
-### Create your app
-
-Visit [https://api.slack.com/apps](https://api.slack.com/apps) to create a new
-Slack app. Click "Create an App", then "From scratch". Fill in the form as shown
-below:
-
-![Create Slack App](../../../../img/enterprise/plugins/slack/Create-a-Slack-App.png)
-
-The "App Name" should be "Teleport". Click the "Development Slack Workspace"
-dropdown and choose the workspace where you would like to see Access Request
-messages.
-
-### Generate an OAuth token with scopes
-
-Next, configure your application to authenticate to the Slack API. We will do
-this by generating an OAuth token that the plugin will present to the Slack API.
-
-We will restrict the plugin to the narrowest possible permissions by using OAuth
-scopes. The Slack plugin needs to post messages to your workspace. It also needs
-to read usernames and email addresses in order to direct Access Request
-notifications from the Auth Service to the appropriate Teleport users in Slack.
-
-After creating your app, the Slack website will open a console where you can
-specify configuration options. On the sidebar menu under "Features", click
-"OAuth & Permissions".
-
-Scroll to the "Scopes" section and click "Add an OAuth Scope" for each of the
-following scopes:
-
-- `chat:write`
-- `incoming-webhook`
-- `users:read`
-- `users:read.email`
-
-The result should look like this:
-
-![API Scopes](../../../../img/enterprise/plugins/slack/api-scopes.png)
-
-After you have configured scopes for your plugin, scroll back to the top of the
-OAuth & Permissions page, find the "OAuth Tokens for Your Workspace" section,
-and click "Install to Workspace". You will see a summary of the permission you
-configured for the Slack plugin earlier.
-
-In "Where should Teleport post?", choose "Slackbot" as the default channel the
-plugin will post to. The plugin will post here when sending direct messages.
-Later in this guide, we will configure the plugin to post in other channels as
-well.
-
-After submitting this form, you will see an OAuth token in the "OAuth &
-Permissions" tab under "Tokens for Your Workspace":
-
-![OAuth Tokens](../../../../img/enterprise/plugins/slack/OAuth.png)
-
-You will use this token later when configuring the Slack plugin.
-
-## Step 6/8. Configure the Teleport Slack plugin
+## Step 5/7. Configure the Teleport Slack plugin
 
 At this point, the Teleport Slack plugin has the credentials it needs to
 communicate with your Teleport cluster and the Slack API. In this step, you will
@@ -319,7 +274,7 @@ any other channel you mention in your `role_to_recipients` map, you will need
 to invite the plugin to that channel. Navigate to each channel and enter `/invite
 @teleport` in the message box.
 
-## Step 7/8. Test your Slack app
+## Step 6/7. Test your Slack app
 
 Once Teleport is running, you've created the Slack app, and the plugin is
 configured, you can now run the plugin and test the workflow.
@@ -402,7 +357,7 @@ Request Reviewed` in the Teleport Web UI.
 
 </Admonition>
 
-## Step 8/8. Set up systemd
+## Step 7/7. Set up systemd
 
 This section is only relevant if you are running the Teleport Slack plugin on a
 Linux host.


### PR DESCRIPTION
In some how-to guides that require configuring a third-party system, move the "Step..." section involving that system into the Prerequisites. In these guides, setting up the third-party system does not depend on information obtained by following the guide. As a result, we can make it clearer at the start of the guide that it depends on setting up an external system. The advantages are:

- Potentially, AI agents can determine before beginning the flow that they cannot achieve the objectives of the guide themselves unless a human user has configured the external system.
- All of the objectives to complete within the guide are related to Teleport itself. In other words, these are not guides to completing tasks in a third-party system along with Teleport. This is more maintainable, since we only need to link to the instructions within the third-party system's docs.
- It lets a human user estimate at the start of each guide how much work they'll need to perform to, for example, get permissions to manage their organization's workspace.