### PR TITLE
Add slack hosted plugin tctl support

### DIFF
--- a/tool/tctl/common/plugin/plugins_command.go
+++ b/tool/tctl/common/plugin/plugins_command.go
@@ -54,6 +54,7 @@ type pluginInstallArgs struct {
 	netIQ   netIQArgs
 	awsIC   awsICInstallArgs
 	github  githubArgs
+	slack   slackArgs
 }
 
 type pluginEditArgs struct {
@@ -66,6 +67,13 @@ type scimArgs struct {
 	connector     string
 	connectorType string
 	auth          string
+}
+
+type slackArgs struct {
+	cmd             *kingpin.CmdClause
+	appToken        string
+	fallbackChannel string
+	name            string
 }
 
 type pluginDeleteArgs struct {
@@ -127,6 +135,7 @@ func (p *PluginsCommand) initInstall(parent *kingpin.CmdClause, config *servicec
 	p.initInstallNetIQ(p.install.cmd)
 	p.initInstallAWSIC(p.install.cmd)
 	p.initInstallGithub(p.install.cmd)
+	p.initInstallSlack(p.install.cmd)
 }
 
 func (p *PluginsCommand) initDelete(parent *kingpin.CmdClause) {
@@ -254,6 +263,8 @@ func (p *PluginsCommand) TryRun(ctx context.Context, cmd string, clientFunc comm
 		commandFunc = p.InstallAWSIC
 	case p.install.github.cmd.FullCommand():
 		commandFunc = p.InstallGithub
+	case p.install.slack.cmd.FullCommand():
+		commandFunc = p.InstallSlack
 	case p.delete.cmd.FullCommand():
 		commandFunc = p.Delete
 	case p.edit.awsIC.cmd.FullCommand():

--- a/tool/tctl/common/plugin/slack.go
+++ b/tool/tctl/common/plugin/slack.go
@@ -1,0 +1,98 @@
+/*
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package plugin
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/alecthomas/kingpin/v2"
+	pluginspb "github.com/gravitational/teleport/api/gen/proto/go/teleport/plugins/v1"
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/trace"
+)
+
+func (p *PluginsCommand) initInstallSlack(parent *kingpin.CmdClause) {
+	p.install.slack.cmd = parent.Command("slack", "Install a Teleport Slack Access Request plugin.")
+	cmd := p.install.slack.cmd
+
+	cmd.Flag("app-token", "Slack app token used by the integration.").
+		Required().
+		StringVar(&p.install.slack.appToken)
+
+	cmd.Flag("fallback-channel", "Slack channel where unrouted alerts should be sent. For example #teleport-alerts.").
+		Required().
+		StringVar(&p.install.slack.fallbackChannel)
+
+	cmd.Flag("name", "Name of the Slack plugin instance.").
+		Default("slack-default").
+		StringVar(&p.install.slack.name)
+
+}
+
+// InstallSlack implements `tctl plugins install slack`, installing a Slack access
+// plugin into the teleport cluster
+func (p *PluginsCommand) InstallSlack(ctx context.Context, args pluginServices) error {
+	// Currently hardcoded plugin name, might relax the restriction in the future.
+	plugin := &types.PluginV1{
+		SubKind: types.PluginSubkindAccess,
+		Metadata: types.Metadata{
+			Labels: map[string]string{
+				types.HostedPluginLabel: "true",
+			},
+			Name: p.install.slack.name,
+		},
+		Spec: types.PluginSpecV1{
+			Settings: &types.PluginSpecV1_SlackAccessPlugin{
+				SlackAccessPlugin: &types.PluginSlackAccessSettings{
+					FallbackChannel: p.install.slack.fallbackChannel,
+				},
+			},
+		},
+	}
+
+	creds, err := types.NewPluginStaticCredentials(types.Metadata{
+		Name: p.install.slack.name,
+	},
+		types.PluginStaticCredentialsSpecV1{
+			Credentials: &types.PluginStaticCredentialsSpecV1_APIToken{
+				APIToken: p.install.slack.appToken,
+			},
+		},
+	)
+	if err != nil {
+		return trace.Wrap(err, "validating plugin static credentials")
+	}
+
+	credsv1, ok := creds.(*types.PluginStaticCredentialsV1)
+	if !ok {
+		return trace.BadParameter("expected type *types.PluginStaticCredentialsV1 (this is a bug)")
+	}
+
+	req := &pluginspb.CreatePluginRequest{
+		Plugin:                plugin,
+		StaticCredentialsList: []*types.PluginStaticCredentialsV1{credsv1},
+	}
+	if _, err := args.plugins.CreatePlugin(ctx, req); err != nil {
+		return trace.Wrap(err)
+	}
+
+	fmt.Printf("Successfully installed Slack access plugin %q\n", p.install.slack.name)
+	return nil
+}


### PR DESCRIPTION
Requires: https://github.com/gravitational/teleport.e/pull/8388

Note: this opens the possibility of having several Slack plugins with names different from `slack-default`. This is gracefully handled by the plugin itself as the PluginData is scoped with the plugin name. The web UI doesn't show the real plugin name in case of multiple Slack plugins so we might have to do a bit of cleanup there after.

Changelog: Added `tctl plugin slack` command to create Slack hosted plugins using a Slack Bot token.

## Manual Test Plan
### Test Environment

build in cloud staging with the `e` PR + custom tctl build with the current PR

### Test Cases
- [x] Can create a slack plugin with a bot token
- [x] Can create several plugins with different names
- [x] Fails if plugin already exists
