### PR TITLE
[v18] app access: reject dynamic labels for beams

### DIFF
--- a/docs/pages/enroll-resources/application-access/reference.mdx
+++ b/docs/pages/enroll-resources/application-access/reference.mdx
@@ -121,9 +121,12 @@ spec:
       value: "{{external.env}}"
   # Optional dynamic labels.
   dynamic_labels:
-  - name: "hostname"
-    command: ["hostname"]
-    period: 1m0s
+    hostname:
+      command: ["hostname"]
+      period: 1m0s
+    uname:
+      command: ["uname", "-a"]
+      period: 5m0s
 ```
 
 You can create a new `app` resource by running the following commands, which
@@ -235,4 +238,3 @@ To run this command, one of the user's roles must include the
 Application Service. To learn how to set up secure access to Azure via Teleport,
 read [Protect the Azure CLI with Teleport Application
 Access](../../enroll-resources/application-access/cloud-apis/azure.mdx).
-

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -6853,20 +6853,28 @@ func (process *TeleportProcess) initApps() {
 			return trace.Wrap(err)
 		}
 
+		// When the app_service itself is running on Teleport Cloud, then we reject any app
+		// with dynamic labels, which allow for code execution.
+		// This is primarily for the beams use case, where the only apps we expect
+		// to see are those created by `tsh beams publish`.
+		const teleportBeamsEnvVar = "TELEPORT_BEAMS_RUNTIME"
+		runningOnBeams, _ := apiutils.ParseBool(os.Getenv(teleportBeamsEnvVar))
+
 		appServer, err := app.New(process.ExitContext(), &app.Config{
-			Clock:                process.Config.Clock,
-			AuthClient:           conn.Client,
-			AccessPoint:          accessPoint,
-			HostID:               conn.HostUUID(),
-			Hostname:             process.Config.Hostname,
-			GetRotation:          process.GetRotation,
-			Apps:                 applications,
-			CloudLabels:          process.cloudLabels,
-			ResourceMatchers:     process.Config.Apps.ResourceMatchers,
-			OnHeartbeat:          process.OnHeartbeat(teleport.ComponentApp),
-			ConnectedProxyGetter: proxyGetter,
-			ConnectionsHandler:   connectionsHandler,
-			InventoryHandle:      process.inventoryHandle,
+			Clock:                       process.Config.Clock,
+			AuthClient:                  conn.Client,
+			AccessPoint:                 accessPoint,
+			HostID:                      conn.HostUUID(),
+			Hostname:                    process.Config.Hostname,
+			GetRotation:                 process.GetRotation,
+			Apps:                        applications,
+			CloudLabels:                 process.cloudLabels,
+			ResourceMatchers:            process.Config.Apps.ResourceMatchers,
+			OnHeartbeat:                 process.OnHeartbeat(teleport.ComponentApp),
+			ConnectedProxyGetter:        proxyGetter,
+			ConnectionsHandler:          connectionsHandler,
+			InventoryHandle:             process.inventoryHandle,
+			IgnoreAppsWithCommandLabels: runningOnBeams,
 		})
 		if err != nil {
 			return trace.Wrap(err)

--- a/lib/srv/app/server.go
+++ b/lib/srv/app/server.go
@@ -85,7 +85,7 @@ type Config struct {
 	// ResourceMatchers is a list of app resource matchers.
 	ResourceMatchers []services.ResourceMatcher
 
-	// OnReconcile is called after each database resource reconciliation.
+	// OnReconcile is called after each app resource reconciliation.
 	OnReconcile func(types.Apps)
 
 	// ConnectedProxyGetter gets the proxies teleport is connected to.
@@ -96,6 +96,10 @@ type Config struct {
 
 	// InventoryHandle is used to send app server heartbeats via the inventory control stream.
 	InventoryHandle inventory.DownstreamHandle
+
+	// IgnoreAppsWithCommandLabels configures the app server to reject app resources
+	// with dynamic/command labels even if the app's labels otherwise match.
+	IgnoreAppsWithCommandLabels bool
 }
 
 // CheckAndSetDefaults makes sure the configuration has the minimum required

--- a/lib/srv/app/watcher.go
+++ b/lib/srv/app/watcher.go
@@ -21,13 +21,11 @@ package app
 import (
 	"context"
 	"fmt"
-	"os"
 
 	"github.com/gravitational/trace"
 
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/types"
-	apiutils "github.com/gravitational/teleport/api/utils"
 	"github.com/gravitational/teleport/api/utils/clientutils"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/services/readonly"
@@ -188,20 +186,13 @@ func (s *Server) onDelete(ctx context.Context, app types.Application) error {
 	return s.unregisterAndRemoveApp(ctx, app.GetName())
 }
 
-const teleportBeamsEnvVar = "TELEPORT_BEAMS_RUNTIME"
-
 func (s *Server) matcher(app types.Application) bool {
 	matchesLabels := services.MatchResourceLabels(s.c.ResourceMatchers, app.GetAllLabels())
 	if !matchesLabels {
 		return false
 	}
 
-	// When the app_service itself is running on Teleport Cloud, then we reject any app
-	// with dynamic labels, which allow for code execution.
-	// This is primarily for the beams use case, where the only apps we expect
-	// to see are those created by `tsh beams publish`.
-	runningOnBeams, _ := apiutils.ParseBool(os.Getenv(teleportBeamsEnvVar))
-	if runningOnBeams {
+	if s.c.IgnoreAppsWithCommandLabels {
 		if len(app.GetDynamicLabels()) > 0 {
 			s.log.WarnContext(
 				context.Background(),

--- a/lib/srv/app/watcher.go
+++ b/lib/srv/app/watcher.go
@@ -21,11 +21,13 @@ package app
 import (
 	"context"
 	"fmt"
+	"os"
 
 	"github.com/gravitational/trace"
 
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/types"
+	apiutils "github.com/gravitational/teleport/api/utils"
 	"github.com/gravitational/teleport/api/utils/clientutils"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/services/readonly"
@@ -186,6 +188,29 @@ func (s *Server) onDelete(ctx context.Context, app types.Application) error {
 	return s.unregisterAndRemoveApp(ctx, app.GetName())
 }
 
+const teleportBeamsEnvVar = "TELEPORT_BEAMS_RUNTIME"
+
 func (s *Server) matcher(app types.Application) bool {
-	return services.MatchResourceLabels(s.c.ResourceMatchers, app.GetAllLabels())
+	matchesLabels := services.MatchResourceLabels(s.c.ResourceMatchers, app.GetAllLabels())
+	if !matchesLabels {
+		return false
+	}
+
+	// When the app_service itself is running on Teleport Cloud, then we reject any app
+	// with dynamic labels, which allow for code execution.
+	// This is primarily for the beams use case, where the only apps we expect
+	// to see are those created by `tsh beams publish`.
+	runningOnBeams, _ := apiutils.ParseBool(os.Getenv(teleportBeamsEnvVar))
+	if runningOnBeams {
+		if len(app.GetDynamicLabels()) > 0 {
+			s.log.WarnContext(
+				context.Background(),
+				"refusing to register app with dynamic labels",
+				"app_name", app.GetName(),
+			)
+			return false
+		}
+	}
+
+	return true
 }

--- a/lib/srv/app/watcher_test.go
+++ b/lib/srv/app/watcher_test.go
@@ -33,6 +33,62 @@ import (
 	"github.com/gravitational/teleport/lib/services"
 )
 
+func TestCloudHostedAppServiceRejectsDynamicLabels(t *testing.T) {
+	t.Setenv(teleportBeamsEnvVar, "yes")
+
+	reconcileCh := make(chan types.Apps)
+
+	s := SetUpSuiteWithConfig(t, suiteConfig{
+		ResourceMatchers: []services.ResourceMatcher{
+			{Labels: types.Labels{"group": []string{"a"}}},
+		},
+		OnReconcile: func(a types.Apps) {
+			reconcileCh <- a
+		},
+	})
+
+	// Drain the initial event that fires when the watcher starts up
+	// (before we create any dynamic apps).
+	select {
+	case <-reconcileCh:
+	case <-time.After(time.Second):
+		t.Fatal("Didn't receive initial reconcile event after 1s.")
+	}
+
+	// Create app with label group=a and dynamic labels.
+	app, err := makeDynamicApp("app_with_dynamic_labels", map[string]string{"group": "a"})
+	require.NoError(t, err)
+	app.SetDynamicLabels(map[string]types.CommandLabel{
+		"foo": &types.CommandLabelV2{
+			Period:  types.Duration(5 * time.Second),
+			Command: []string{"echo", "bar"},
+		},
+	})
+	err = s.authServer.AuthServer.CreateApp(t.Context(), app)
+	require.NoError(t, err)
+
+	// It should not have been registered.
+	select {
+	case apps := <-reconcileCh:
+		require.Nil(t, apps.Find(app.GetName()), "app with dynamic labels should not have been registered")
+	case <-time.After(time.Second):
+		t.Fatal("Didn't receive reconcile event after 1s.")
+	}
+
+	// Remove the dynamic labels
+	app.SetDynamicLabels(make(map[string]types.CommandLabel))
+	err = s.authServer.AuthServer.UpdateApp(t.Context(), app)
+	require.NoError(t, err)
+
+	// It should now be registered.
+	select {
+	case apps := <-reconcileCh:
+		require.NotNil(t, apps.Find(app.GetName()))
+	case <-time.After(time.Second):
+		t.Fatal("Didn't receive reconcile event after 1s.")
+	}
+}
+
 // TestWatcher verifies that app agent properly detects and applies
 // changes to application resources.
 func TestWatcher(t *testing.T) {

--- a/lib/srv/app/watcher_test.go
+++ b/lib/srv/app/watcher_test.go
@@ -34,7 +34,7 @@ import (
 )
 
 func TestCloudHostedAppServiceRejectsDynamicLabels(t *testing.T) {
-	t.Setenv(teleportBeamsEnvVar, "yes")
+	t.Parallel()
 
 	reconcileCh := make(chan types.Apps)
 
@@ -46,6 +46,8 @@ func TestCloudHostedAppServiceRejectsDynamicLabels(t *testing.T) {
 			reconcileCh <- a
 		},
 	})
+
+	s.appServer.c.IgnoreAppsWithCommandLabels = true
 
 	// Drain the initial event that fires when the watcher starts up
 	// (before we create any dynamic apps).


### PR DESCRIPTION
Backport #66531 to branch/v18

## Manual Test Plan

### Test Environment

- Run app service locally with `TELEPORT_BEAMS_RUNTIME=yes`.
- Configure resource matchers to match `foo: '*'`.

### Test Cases 

- [x] Register an `app` resource with label `foo: bar` and no command labels. Verify that app_server resource is created.
- [x] `tctl edit` the app resource and add at least one dynamic label. Verify that the app_server resource goes away.