### PR TITLE
[v18] Discover: do not prompt when leaving Connect My Computer

### DIFF
--- a/web/packages/teleport/src/Discover/ConnectMyComputer/index.ts
+++ b/web/packages/teleport/src/Discover/ConnectMyComputer/index.ts
@@ -26,6 +26,7 @@ import { TestConnection } from './TestConnection';
 
 export const ConnectMyComputerResource: ResourceViewConfig<ResourceSpec> = {
   kind: ResourceKind.ConnectMyComputer,
+  shouldPrompt: () => false,
   views: [
     {
       title: 'Set Up Teleport Connect',

--- a/web/packages/teleport/src/Discover/Discover.test.tsx
+++ b/web/packages/teleport/src/Discover/Discover.test.tsx
@@ -326,3 +326,19 @@ test('update flow: agentMeta is prepopulated based on agentMeta', () => {
 
   expect(screen.getByText('saml2')).toBeInTheDocument();
 });
+
+test('Connect My Computer does not prompt when leaving the flow', async () => {
+  renderUpdate({
+    resourceSpec: resourceSpecConnectMyComputer,
+    agentMeta: { resourceName: '' },
+  });
+
+  const text = await screen.findByText('Sign In & Connect My Computer');
+  expect(text).toBeInTheDocument();
+
+  // Simulate closing the tab / opening a deep link.
+  const event = new Event('beforeunload', { cancelable: true });
+  window.dispatchEvent(event);
+
+  expect(event.defaultPrevented).toBe(false);
+});


### PR DESCRIPTION
Backport #66418 to branch/v18

## Manual Test Plan
### Test Environment
`make build/teleport`.

### Test Cases
- [x] Navigating away from the Connect My Computer page doesn't trigger the prompt. 