### PR TITLE
Fix password recovery

### DIFF
--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -4507,15 +4507,21 @@ func (a *Server) CreateAuthenticateChallenge(ctx context.Context, req *proto.Cre
 	}
 
 	// When completing a Browser MFA flow, only a WebAuthn challenge is needed, so
-	// clear the redirect URL so SSO and Browser MFA challenges are not generated.
-	clientRedirectURL := ""
+	// clear the redirect URLs so SSO and Browser MFA challenges are not generated.
+	ssoClientRedirectURL := ""
+	browserMFATSHRedirectURL := ""
 	if req.BrowserMFARequestID == "" {
-		// Both SSO and Browser MFA redirect URLs point to the same callback server on tsh.
-		// So we can take either one and generate an auth challenge with it.
-		clientRedirectURL = cmp.Or(req.SSOClientRedirectURL, req.BrowserMFATSHRedirectURL)
+		ssoClientRedirectURL = req.SSOClientRedirectURL
+		browserMFATSHRedirectURL = req.BrowserMFATSHRedirectURL
 	}
 
-	challenges, err := a.mfaAuthChallenge(ctx, username, clientRedirectURL, req.ProxyAddress, challengeExtensions)
+	challenges, err := a.mfaAuthChallenge(ctx, mfaAuthChallengeParams{
+		user:                     username,
+		ssoClientRedirectURL:     ssoClientRedirectURL,
+		browserMFATSHRedirectURL: browserMFATSHRedirectURL,
+		proxyAddress:             req.ProxyAddress,
+		challengeExtensions:      challengeExtensions,
+	})
 	if err != nil {
 		// Do not obfuscate config-related errors.
 		if errors.Is(err, types.ErrPasswordlessRequiresWebauthn) || errors.Is(err, types.ErrPasswordlessDisabledBySettings) {
@@ -8077,10 +8083,18 @@ func (a *Server) isMFARequired(ctx context.Context, scopedCtx *authz.ScopedConte
 	}, nil
 }
 
+type mfaAuthChallengeParams struct {
+	user                     string
+	ssoClientRedirectURL     string
+	browserMFATSHRedirectURL string
+	proxyAddress             string
+	challengeExtensions      *mfav1.ChallengeExtensions
+}
+
 // mfaAuthChallenge constructs an MFAAuthenticateChallenge for all MFA devices
 // registered by the user.
-func (a *Server) mfaAuthChallenge(ctx context.Context, user, clientRedirectURL, proxyAddress string, challengeExtensions *mfav1.ChallengeExtensions) (*proto.MFAAuthenticateChallenge, error) {
-	isPasswordless := challengeExtensions.Scope == mfav1.ChallengeScope_CHALLENGE_SCOPE_PASSWORDLESS_LOGIN
+func (a *Server) mfaAuthChallenge(ctx context.Context, p mfaAuthChallengeParams) (*proto.MFAAuthenticateChallenge, error) {
+	isPasswordless := p.challengeExtensions.Scope == mfav1.ChallengeScope_CHALLENGE_SCOPE_PASSWORDLESS_LOGIN
 
 	// Check what kind of MFA is enabled.
 	apref, err := a.GetAuthPreference(ctx)
@@ -8140,9 +8154,9 @@ func (a *Server) mfaAuthChallenge(ctx context.Context, user, clientRedirectURL, 
 				Code:        events.CreateMFAAuthChallengeCode,
 				ClusterName: clusterName.GetClusterName(),
 			},
-			UserMetadata:        authz.ClientUserMetadataWithUser(ctx, user),
-			ChallengeScope:      challengeExtensions.Scope.String(),
-			ChallengeAllowReuse: challengeExtensions.AllowReuse == mfav1.ChallengeAllowReuse_CHALLENGE_ALLOW_REUSE_YES,
+			UserMetadata:        authz.ClientUserMetadataWithUser(ctx, p.user),
+			ChallengeScope:      p.challengeExtensions.Scope.String(),
+			ChallengeAllowReuse: p.challengeExtensions.AllowReuse == mfav1.ChallengeAllowReuse_CHALLENGE_ALLOW_REUSE_YES,
 			FlowType:            apievents.MFAFlowType_MFA_FLOW_TYPE_PER_SESSION_CERTIFICATE,
 		}); err != nil {
 			a.logger.WarnContext(ctx, "Failed to emit CreateMFAAuthChallenge event", "error", err)
@@ -8154,11 +8168,11 @@ func (a *Server) mfaAuthChallenge(ctx context.Context, user, clientRedirectURL, 
 	}
 
 	// User required for non-passwordless.
-	if user == "" {
+	if p.user == "" {
 		return nil, trace.BadParameter("user required")
 	}
 
-	devs, err := a.Services.GetMFADevices(ctx, user, true /* withSecrets */)
+	devs, err := a.Services.GetMFADevices(ctx, p.user, true /* withSecrets */)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -8177,7 +8191,7 @@ func (a *Server) mfaAuthChallenge(ctx context.Context, user, clientRedirectURL, 
 			Webauthn: webConfig,
 			Identity: wanlib.WithDevices(a.Services, groupedDevs.Webauthn),
 		}
-		assertion, err := webLogin.Begin(ctx, wanlib.BeginParams{User: user, ChallengeExtensions: challengeExtensions})
+		assertion, err := webLogin.Begin(ctx, wanlib.BeginParams{User: p.user, ChallengeExtensions: p.challengeExtensions})
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
@@ -8186,15 +8200,15 @@ func (a *Server) mfaAuthChallenge(ctx context.Context, user, clientRedirectURL, 
 
 	// If the user has an SSO device and the client provided a redirect URL to handle
 	// the MFA SSO flow, create an SSO challenge.
-	if enableSSO && groupedDevs.SSO != nil && clientRedirectURL != "" {
+	if enableSSO && groupedDevs.SSO != nil && p.ssoClientRedirectURL != "" {
 		if challenge.SSOChallenge, err = a.BeginSSOMFAChallenge(
 			ctx,
 			mfatypes.BeginSSOMFAChallengeParams{
-				User:                 user,
+				User:                 p.user,
 				SSO:                  groupedDevs.SSO.GetSso(),
-				SSOClientRedirectURL: clientRedirectURL,
-				ProxyAddress:         proxyAddress,
-				Ext:                  challengeExtensions,
+				SSOClientRedirectURL: p.ssoClientRedirectURL,
+				ProxyAddress:         p.proxyAddress,
+				Ext:                  p.challengeExtensions,
 			},
 		); err != nil {
 			return nil, trace.Wrap(err)
@@ -8204,13 +8218,13 @@ func (a *Server) mfaAuthChallenge(ctx context.Context, user, clientRedirectURL, 
 	// If the user has a WebAuthn device, return a Browser MFA challenge. This
 	// challenge is useful in cases where a user only has a browser-associated
 	// WebAuthn device, but is trying to MFA via a CLI tool (tsh, tctl etc.)
-	if enableBrowserMFA && groupedDevs.Browser != nil && clientRedirectURL != "" {
+	if enableBrowserMFA && groupedDevs.Browser != nil && p.browserMFATSHRedirectURL != "" {
 		if challenge.BrowserMFAChallenge, err = a.BeginBrowserMFAChallenge(
 			ctx,
 			mfatypes.BeginBrowserMFAChallengeParams{
-				User:                     user,
-				BrowserMFATSHRedirectURL: clientRedirectURL,
-				Ext:                      challengeExtensions,
+				User:                     p.user,
+				BrowserMFATSHRedirectURL: p.browserMFATSHRedirectURL,
+				Ext:                      p.challengeExtensions,
 			},
 		); err != nil {
 			return nil, trace.Wrap(err)
@@ -8228,9 +8242,9 @@ func (a *Server) mfaAuthChallenge(ctx context.Context, user, clientRedirectURL, 
 			Code:        events.CreateMFAAuthChallengeCode,
 			ClusterName: clusterName.GetClusterName(),
 		},
-		UserMetadata:        authz.ClientUserMetadataWithUser(ctx, user),
-		ChallengeScope:      challengeExtensions.Scope.String(),
-		ChallengeAllowReuse: challengeExtensions.AllowReuse == mfav1.ChallengeAllowReuse_CHALLENGE_ALLOW_REUSE_YES,
+		UserMetadata:        authz.ClientUserMetadataWithUser(ctx, p.user),
+		ChallengeScope:      p.challengeExtensions.Scope.String(),
+		ChallengeAllowReuse: p.challengeExtensions.AllowReuse == mfav1.ChallengeAllowReuse_CHALLENGE_ALLOW_REUSE_YES,
 		FlowType:            apievents.MFAFlowType_MFA_FLOW_TYPE_PER_SESSION_CERTIFICATE,
 	}); err != nil {
 		a.logger.WarnContext(ctx, "Failed to emit CreateMFAAuthChallenge event", "error", err)

--- a/lib/auth/browser_mfa_test.go
+++ b/lib/auth/browser_mfa_test.go
@@ -771,6 +771,20 @@ func TestBrowserMFAChallengeCreation(t *testing.T) {
 				assert.Equal(t, mfav1.ChallengeAllowReuse_CHALLENGE_ALLOW_REUSE_YES, sd.ChallengeExtensions.AllowReuse)
 			},
 		},
+		{
+			name: "NOK SSO redirect URL must not fall back to Browser MFA redirect URL",
+			// Use a user with webauthn to ensure Browser MFA would be triggered if
+			// SSO redirect URL was incorrectly used for the Browser MFA flow.
+			username: env.webauthnUser.GetName(),
+			challengeRequest: &proto.CreateAuthenticateChallengeRequest{
+				ChallengeExtensions:  loginExt,
+				SSOClientRedirectURL: "/web/sso_confirm?channel_id=test-channel",
+				// BrowserMFATSHRedirectURL not set.
+			},
+			assertChallenge: func(t *testing.T, chal *proto.MFAAuthenticateChallenge) {
+				assert.Nil(t, chal.BrowserMFAChallenge, "Browser MFA challenge must not be created when only SSOClientRedirectURL is set")
+			},
+		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			userClient, err := env.server.NewClient(authtest.TestUser(tt.username))

--- a/lib/auth/grpcserver.go
+++ b/lib/auth/grpcserver.go
@@ -19,7 +19,6 @@
 package auth
 
 import (
-	"cmp"
 	"context"
 	"crypto/tls"
 	"errors"
@@ -2684,23 +2683,27 @@ func doMFAPresenceChallenge(ctx context.Context, actx *grpcContext, stream authp
 	chalExt := &mfav1pb.ChallengeExtensions{Scope: mfav1pb.ChallengeScope_CHALLENGE_SCOPE_USER_SESSION}
 
 	// When completing a Browser MFA flow, only a WebAuthn challenge is needed, so
-	// clear the redirect URL so SSO and Browser MFA challenges are not generated.
-	clientRedirectURL := ""
+	// clear the redirect URLs so SSO and Browser MFA challenges are not generated.
+	ssoClientRedirectURL := ""
+	browserMFATSHRedirectURL := ""
 	if challengeReq.BrowserMfaRequestId == "" {
-		// Both SSO and Browser MFA redirect URLs point to the same callback server on tsh.
-		// So we can take either one and generate an auth challenge with it.
-		ssoURL := challengeReq.SSOClientRedirectURL
-		browserURL := challengeReq.BrowserMFATSHRedirectURL
-		clientRedirectURL = cmp.Or(ssoURL, browserURL)
-		if ssoURL != "" && browserURL != "" && ssoURL != browserURL {
+		ssoClientRedirectURL = challengeReq.SSOClientRedirectURL
+		browserMFATSHRedirectURL = challengeReq.BrowserMFATSHRedirectURL
+		if ssoClientRedirectURL != "" && browserMFATSHRedirectURL != "" && ssoClientRedirectURL != browserMFATSHRedirectURL {
 			slog.WarnContext(ctx, "SSO and Browser MFA redirect URLs do not match, this is a bug.",
 				// Strip out the sensitive query params before printing
-				"sso_url", strings.Split(ssoURL, "?")[0],
-				"browser_url", strings.Split(browserURL, "?")[0],
+				"sso_url", strings.Split(ssoClientRedirectURL, "?")[0],
+				"browser_url", strings.Split(browserMFATSHRedirectURL, "?")[0],
 			)
 		}
 	}
-	authChallenge, err := actx.authServer.mfaAuthChallenge(ctx, user, clientRedirectURL, challengeReq.ProxyAddress, chalExt)
+	authChallenge, err := actx.authServer.mfaAuthChallenge(ctx, mfaAuthChallengeParams{
+		user:                     user,
+		ssoClientRedirectURL:     ssoClientRedirectURL,
+		browserMFATSHRedirectURL: browserMFATSHRedirectURL,
+		proxyAddress:             challengeReq.ProxyAddress,
+		challengeExtensions:      chalExt,
+	})
 	if err != nil {
 		return trace.Wrap(err)
 	}


### PR DESCRIPTION
Browser MFA introduced a bug when a user went through the "Forgot password" flow. It would attempt to start a Browser MFA flow, which isn't supported in the browser, only from CLI tools and Connect.

The issue occurred because `clientRedirectURL` for both the SSO and Browser MFA flows are the same, so I kept it as one parameter passed to `mfaAuthChallenge`. In this case that meant that when the password recovery flow was started and `mfaAuthChallenge` was called, it would attempt to generate a Browser MFA challenge, which failed because it was given an SSO-only URL.

## Manual Test Plan
### Test Environment
Deployed to staging tenant for testing.
### Test Cases
- [x] Logging in
  - [x] On the web UI using webauthn
  - [x] On Connect using webauthn
  - [x] On Connect using Browser MFA
  - [x] On tsh using webauthn
  - [x] On tsh using Browser MFA
- [x] Per-session MFA
  - [x] Using webauthn
  - [x] Using Browser MFA
- [x] Password recovery doesn't error when MFA verifying
- [x] Moderated sessions
  - [x] work with webauthn
  - [x] work with Browser MFA
