### PR TITLE
[v18] Connect: improve profile watcher and awaitable sender logging

### DIFF
--- a/web/packages/teleterm/src/mainProcess/awaitableSender/awaitableSender.ts
+++ b/web/packages/teleterm/src/mainProcess/awaitableSender/awaitableSender.ts
@@ -168,6 +168,7 @@ export class AwaitableSender<T> implements IAwaitableSender<T> {
       this.logger.error('Renderer failed to process message', {
         messageId: message.id,
         messageType: message.type,
+        error: message.error,
       });
       item.reject(message.error);
       return;

--- a/web/packages/teleterm/src/mainProcess/awaitableSender/awaitableSender.ts
+++ b/web/packages/teleterm/src/mainProcess/awaitableSender/awaitableSender.ts
@@ -77,14 +77,14 @@ export class AwaitableSender<T> implements IAwaitableSender<T> {
    * This method returns a promise that resolves once the other side
    * acknowledges receiving and processing the message.
    * If the acknowledgment is not received within the specified timeout
-   * (default 10 seconds), the promise rejects with a `MessageAcknowledgementError`.
+   * (default 20 seconds), the promise rejects with a `MessageAcknowledgementError`.
    *
    * If the renderer received the message, but failed to process it, the promise
    * is also rejected.
    */
   send(
     payload: T,
-    { signal = AbortSignal.timeout(10_000) }: { signal?: AbortSignal } = {}
+    { signal = AbortSignal.timeout(20_000) }: { signal?: AbortSignal } = {}
   ): Promise<void> {
     const id = crypto.randomUUID();
 

--- a/web/packages/teleterm/src/mainProcess/awaitableSender/awaitableSender.ts
+++ b/web/packages/teleterm/src/mainProcess/awaitableSender/awaitableSender.ts
@@ -18,6 +18,8 @@
 
 import { MessageEvent, MessagePortMain } from 'electron';
 
+import Logger from 'teleterm/logger';
+
 export type Message = MessageData | MessageAck;
 
 export interface MessageData {
@@ -41,6 +43,7 @@ function isMessageAck(v: unknown): v is MessageAck {
 }
 
 export interface IAwaitableSender<T> {
+  readonly id: string;
   send(payload: T, options?: { signal?: AbortSignal }): Promise<void>;
   whenDisposed(): Promise<void>;
 }
@@ -54,6 +57,8 @@ export interface IAwaitableSender<T> {
  * to receive messages.
  */
 export class AwaitableSender<T> implements IAwaitableSender<T> {
+  public readonly id = crypto.randomUUID().slice(0, 8);
+  private readonly logger = new Logger(`AwaitableSender ${this.id}`);
   private messages = new Map<
     string,
     { resolve(): void; reject(reason: unknown): void }
@@ -91,6 +96,10 @@ export class AwaitableSender<T> implements IAwaitableSender<T> {
 
       const abort = () => {
         cleanup();
+        this.logger.warn('Message acknowledgement aborted', {
+          messageId: id,
+          reason: signal.reason,
+        });
         reject(new MessageAcknowledgementError(signal.reason));
       };
 
@@ -112,7 +121,24 @@ export class AwaitableSender<T> implements IAwaitableSender<T> {
       });
 
       const message: MessageData = { type: 'data', id, payload };
-      this.port.postMessage(message);
+      this.logger.info('Sending message to renderer', {
+        messageId: message.id,
+        messageType: message.type,
+      });
+      try {
+        this.port.postMessage(message);
+      } catch (error) {
+        cleanup();
+        this.logger.error(
+          'Failed to post message to renderer',
+          {
+            messageId: id,
+            messageType: message.type,
+          },
+          error
+        );
+        reject(error);
+      }
     });
   }
 
@@ -123,19 +149,33 @@ export class AwaitableSender<T> implements IAwaitableSender<T> {
 
   private processMessage = (event: MessageEvent): void => {
     const message = event.data;
-    // Only to satisfy TypeScript.
     // We don't expect non-ack messages to be received on this port.
     if (!isMessageAck(message)) {
+      this.logger.warn('Received non-ack message on awaitable sender port', {
+        message,
+      });
       return;
     }
     const item = this.messages.get(message.id);
     if (!item) {
+      this.logger.warn('Received ack for unknown message id', {
+        messageId: message.id,
+        messageType: message.type,
+      });
       return;
     }
     if (message.error) {
+      this.logger.error('Renderer failed to process message', {
+        messageId: message.id,
+        messageType: message.type,
+      });
       item.reject(message.error);
       return;
     }
+    this.logger.info('Message acknowledged by renderer', {
+      messageId: message.id,
+      messageType: message.type,
+    });
     item.resolve();
   };
 

--- a/web/packages/teleterm/src/mainProcess/clusterLifecycleManager/clusterLifecycleManager.test.ts
+++ b/web/packages/teleterm/src/mainProcess/clusterLifecycleManager/clusterLifecycleManager.test.ts
@@ -341,6 +341,7 @@ test.each(tests)('$name', async ({ setup, expect: testExpect }) => {
     consumer
   );
   const mockRendererHandler = {
+    id: 'test-renderer-handler',
     send: throwInRendererHandler
       ? jest.fn().mockRejectedValue(new Error('Error in renderer'))
       : jest.fn().mockResolvedValue(undefined),

--- a/web/packages/teleterm/src/mainProcess/clusterLifecycleManager/clusterLifecycleManager.ts
+++ b/web/packages/teleterm/src/mainProcess/clusterLifecycleManager/clusterLifecycleManager.ts
@@ -186,7 +186,6 @@ export class ClusterLifecycleManager {
         void this.watchProfileChanges();
         return;
       }
-      this.logger.info('Profile watcher already started');
     } catch (error) {
       this.logger.error('Failed to sync root clusters', error);
       throw error;

--- a/web/packages/teleterm/src/mainProcess/clusterLifecycleManager/clusterLifecycleManager.ts
+++ b/web/packages/teleterm/src/mainProcess/clusterLifecycleManager/clusterLifecycleManager.ts
@@ -35,7 +35,7 @@ import { mergeClusterProfileWithDetails } from 'teleterm/services/tshd/cluster';
 import { RootClusterUri } from 'teleterm/ui/uri';
 
 import { ClusterStore } from '../clusterStore';
-import { ProfileChangeSet } from '../profileWatcher';
+import { ProfileChange, ProfileChangeSet } from '../profileWatcher';
 
 /** Describes a lifecycle event related to a cluster. */
 export interface ClusterLifecycleEvent {
@@ -114,46 +114,82 @@ export class ClusterLifecycleManager {
       return;
     }
 
-    this.logger.info('Renderer lifecycle event handler registered');
+    this.logger.info('Renderer lifecycle event handler registered', {
+      senderId: handler.id,
+    });
     this.rendererEventHandler = handler;
     this.rendererEventHandler.whenDisposed().then(() => {
-      this.logger.info('Renderer lifecycle event handler unregistered');
+      this.logger.info('Renderer lifecycle event handler unregistered', {
+        senderId: handler.id,
+      });
       this.rendererEventHandler = undefined;
     });
   }
 
   async addCluster(proxyAddress: string): Promise<Cluster> {
-    const cluster = await this.clusterStore.add(proxyAddress);
-    await this.rendererEventHandler.send({
-      op: 'did-add-cluster',
-      uri: cluster.uri,
-    });
-    return cluster;
+    this.logger.info('Adding cluster', { proxyAddress });
+    try {
+      const cluster = await this.clusterStore.add(proxyAddress);
+      await this.sendRendererEvent({
+        op: 'did-add-cluster',
+        uri: cluster.uri,
+      });
+      this.logger.info('Cluster added', { uri: cluster.uri });
+      return cluster;
+    } catch (error) {
+      this.logger.error('Failed to add cluster', { proxyAddress }, error);
+      throw error;
+    }
   }
 
   async logoutAndRemoveCluster(uri: RootClusterUri): Promise<void> {
-    await this.rendererEventHandler.send({ op: 'will-logout-and-remove', uri });
-    this.onBeforeRemove(uri);
-    await this.clusterStore.logoutAndRemove(uri);
+    this.logger.info('Logging out and removing cluster', { uri });
+    try {
+      await this.sendRendererEvent({ op: 'will-logout-and-remove', uri });
+      this.onBeforeRemove(uri);
+      await this.clusterStore.logoutAndRemove(uri);
+      this.logger.info('Logged out and removed cluster', { uri });
+    } catch (error) {
+      this.logger.error('Failed to log out and remove cluster', { uri }, error);
+      throw error;
+    }
   }
 
   async syncCluster(uri: RootClusterUri): Promise<void> {
-    const { previous, next } = await this.clusterStore.sync(uri);
-    if (!hasAccessChanged(previous.loggedInUser, next.loggedInUser)) {
-      return;
+    this.logger.info('Syncing cluster', { uri });
+    try {
+      const { previous, next } = await this.clusterStore.sync(uri);
+      const accessChanged = hasAccessChanged(
+        previous.loggedInUser,
+        next.loggedInUser
+      );
+      if (accessChanged) {
+        await this.sendRendererEvent({
+          op: 'did-change-access',
+          uri: next.uri,
+        });
+      }
+      this.logger.info('Cluster synced', { uri: next.uri, accessChanged });
+    } catch (error) {
+      this.logger.error('Failed to sync cluster', { uri }, error);
+      throw error;
     }
-
-    await this.rendererEventHandler.send({
-      op: 'did-change-access',
-      uri: next.uri,
-    });
   }
 
   async syncRootClustersAndStartProfileWatcher(): Promise<void> {
-    await this.clusterStore.syncRootClusters();
-    if (!this.watcherStarted) {
-      this.watcherStarted = true;
-      void this.watchProfileChanges();
+    this.logger.info('Syncing root clusters');
+    try {
+      await this.clusterStore.syncRootClusters();
+      if (!this.watcherStarted) {
+        this.logger.info('Starting profile watcher');
+        this.watcherStarted = true;
+        void this.watchProfileChanges();
+        return;
+      }
+      this.logger.info('Profile watcher already started');
+    } catch (error) {
+      this.logger.error('Failed to sync root clusters', error);
+      throw error;
     }
   }
 
@@ -161,7 +197,7 @@ export class ClusterLifecycleManager {
     // Do not wait for this promise to finish as we don't want to block logout
     // on checking app updates.
     this.appUpdater.maybeRemoveManagingCluster(uri).catch(error => {
-      this.logger.error('Failed to remove managing cluster', error);
+      this.logger.error('Failed to remove managing cluster', { uri }, error);
     });
   }
 
@@ -215,21 +251,33 @@ export class ClusterLifecycleManager {
                 await this.handleClusterRemoved(change.cluster);
                 break;
             }
+            this.logger.info('Processed profile change', {
+              op: change.op,
+              uri: getChangeUri(change),
+            });
           } catch (error) {
-            this.logger.error('Error while processing cluster event', error);
+            this.logger.error(
+              'Error while processing profile change',
+              {
+                op: change.op,
+                uri: getChangeUri(change),
+              },
+              error
+            );
             this.handleWatcherError({ error, reason: 'processing-error' });
           }
         }
       }
+      this.logger.info('Profile watcher stopped');
     } catch (error) {
-      this.logger.error('Profile watcher exited with error', error);
+      this.logger.error('Profile watcher exited with error', { error });
       this.handleWatcherError({ error, reason: 'exited' });
     }
   }
 
   private async handleClusterAdded(cluster: Cluster): Promise<void> {
     await this.syncOrUpdateCluster(cluster);
-    await this.rendererEventHandler.send({
+    await this.sendRendererEvent({
       op: 'did-add-cluster',
       uri: cluster.uri,
     });
@@ -244,6 +292,9 @@ export class ClusterLifecycleManager {
     const hasLoggedOut = wasLoggedIn && !isLoggedIn;
 
     if (hasLoggedOut) {
+      this.logger.info('Detected cluster logout from profile change', {
+        uri: next.uri,
+      });
       await this.handleClusterLogout(next);
       return;
     }
@@ -260,16 +311,19 @@ export class ClusterLifecycleManager {
     await this.syncOrUpdateCluster(next);
 
     if (!hasAccessChanged(previous.loggedInUser, next.loggedInUser)) {
+      this.logger.info('Cluster profile changed without access changes', {
+        uri: next.uri,
+      });
       return;
     }
-    await this.rendererEventHandler.send({
+    await this.sendRendererEvent({
       op: 'did-change-access',
       uri: next.uri,
     });
   }
 
   private async handleClusterRemoved(cluster: Cluster): Promise<void> {
-    await this.rendererEventHandler.send({
+    await this.sendRendererEvent({
       op: 'will-logout-and-remove',
       uri: cluster.uri,
     });
@@ -278,7 +332,7 @@ export class ClusterLifecycleManager {
   }
 
   private async handleClusterLogout(cluster: Cluster): Promise<void> {
-    await this.rendererEventHandler.send({
+    await this.sendRendererEvent({
       op: 'will-logout',
       uri: cluster.uri,
     });
@@ -288,6 +342,13 @@ export class ClusterLifecycleManager {
   }
 
   private handleWatcherError(watcherError: ProfileWatcherError): void {
+    this.logger.info(
+      'Reporting profile watcher error to renderer',
+      {
+        reason: watcherError.reason,
+      },
+      watcherError.error
+    );
     const serialized: ProfileWatcherError = {
       reason: watcherError.reason,
       error: serializeError(ensureError(watcherError.error)),
@@ -295,6 +356,24 @@ export class ClusterLifecycleManager {
     this.windowsManager
       .getWindow()
       .webContents.send(RendererIpc.ProfileWatcherError, serialized);
+  }
+
+  private async sendRendererEvent(event: ClusterLifecycleEvent): Promise<void> {
+    if (!this.rendererEventHandler) {
+      this.logger.error(
+        'Skipped renderer lifecycle event because handler is not registered',
+        {
+          op: event.op,
+          uri: event.uri,
+        }
+      );
+    }
+
+    this.logger.info('Sending renderer lifecycle event', {
+      op: event.op,
+      uri: event.uri,
+    });
+    await this.rendererEventHandler.send(event);
   }
 }
 
@@ -325,4 +404,11 @@ function areArraysEqual(a: string[], b: string[]): boolean {
   const aSet = new Set(a);
   const bSet = new Set(b);
   return aSet.size === bSet.size && aSet.isSubsetOf(bSet);
+}
+
+function getChangeUri(change: ProfileChange): RootClusterUri {
+  if (change.op === 'changed') {
+    return change.next.uri;
+  }
+  return change.cluster.uri;
 }

--- a/web/packages/teleterm/src/mainProcess/clusterLifecycleManager/clusterLifecycleManager.ts
+++ b/web/packages/teleterm/src/mainProcess/clusterLifecycleManager/clusterLifecycleManager.ts
@@ -236,9 +236,11 @@ export class ClusterLifecycleManager {
   private async watchProfileChanges(): Promise<void> {
     try {
       for await (const changes of this.profileWatcher) {
-        this.logger.info('Detected profile changes', changes);
-
         for (const change of changes) {
+          this.logger.info('Processing profile change', {
+            op: change.op,
+            uri: getChangeUri(change),
+          });
           try {
             switch (change.op) {
               case 'added':

--- a/web/packages/teleterm/src/mainProcess/clusterStore/clusterStore.ts
+++ b/web/packages/teleterm/src/mainProcess/clusterStore/clusterStore.ts
@@ -170,7 +170,7 @@ export class ClusterStore {
    * message to the sender.
    */
   registerSender(sender: AwaitableSender<ClusterStoreUpdate>): void {
-    this.logger.info('Sender registered');
+    this.logger.info('Sender registered', { senderId: sender.id });
     this.senders.add(sender);
     const send = this.withErrorHandling(update => sender.send(update));
     void send({
@@ -179,7 +179,7 @@ export class ClusterStore {
     });
     sender.whenDisposed().then(() => {
       this.senders.delete(sender);
-      this.logger.info('Sender unregistered');
+      this.logger.info('Sender unregistered', { senderId: sender.id });
     });
   }
 

--- a/web/packages/teleterm/src/mainProcess/mainProcessClient.ts
+++ b/web/packages/teleterm/src/mainProcess/mainProcessClient.ts
@@ -18,9 +18,12 @@
 
 import { ipcRenderer } from 'electron';
 
+import { ensureError } from 'shared/utils/error';
+
 import Logger from 'teleterm/logger';
 import type { Message, MessageAck } from 'teleterm/mainProcess/awaitableSender';
 import { CreateAgentConfigFileArgs } from 'teleterm/mainProcess/createAgentConfigFile';
+import { serializeError } from 'teleterm/mainProcess/ipcSerializer';
 import { AppUpdateEvent } from 'teleterm/services/appUpdater';
 import { createFileStorageClient } from 'teleterm/services/fileStorage';
 import { RootClusterUri } from 'teleterm/ui/uri';
@@ -303,18 +306,37 @@ function startAwaitableSenderListener<T>(
 
   localPort.onmessage = async (event: MessageEvent<Message>) => {
     const msg = event.data;
-    if (msg.type !== 'data') {
+    if (msg?.type !== 'data') {
+      logger.warn('Received non-data message on awaitable sender listener', {
+        message: msg,
+      });
       return;
     }
+    logger.info('Received message on awaitable sender listener', {
+      messageId: msg.id,
+      messageType: msg.type,
+    });
     const ack: MessageAck = { type: 'ack', id: msg.id };
 
     try {
       await listener(msg.payload as T);
     } catch (e) {
-      ack.error = e;
+      ack.error = serializeError(ensureError(e));
     }
 
-    localPort.postMessage(ack);
+    try {
+      localPort.postMessage(ack);
+      logger.info('Sent awaitable sender ack', {
+        messageId: msg.id,
+        ackError: ack.error,
+      });
+    } catch (e) {
+      logger.error('Failed to send awaitable sender ack', {
+        messageId: msg.id,
+        ackError: ack.error,
+        sendError: e,
+      });
+    }
   };
 
   localPort.start();

--- a/web/packages/teleterm/src/mainProcess/profileWatcher/profileWatcher.test.ts
+++ b/web/packages/teleterm/src/mainProcess/profileWatcher/profileWatcher.test.ts
@@ -17,6 +17,7 @@
  */
 
 import { EventEmitter } from 'node:events';
+import type { WatchEventType } from 'node:fs';
 import fs from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
@@ -24,6 +25,7 @@ import path from 'node:path';
 import { Cluster } from 'gen-proto-ts/teleport/lib/teleterm/v1/cluster_pb';
 import { wait } from 'shared/utils/wait';
 
+import Logger, { NullService } from 'teleterm/logger';
 import { makeRootCluster } from 'teleterm/services/tshd/testHelpers';
 import { RootClusterUri, routing } from 'teleterm/ui/uri';
 
@@ -32,6 +34,7 @@ import { CreateFsWatcher, FsWatcher, watchProfiles } from './profileWatcher';
 let tempDir: string;
 
 beforeAll(async () => {
+  Logger.init(new NullService());
   tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'profile-watcher-test'));
 });
 
@@ -140,7 +143,10 @@ function mockClusterStore(initial: { clusters: Cluster[] }) {
 class VirtualWatcher extends EventEmitter implements FsWatcher {
   private closed = false;
   constructor(
-    private readonly onEvent: () => void,
+    private readonly onEvent: (
+      event: WatchEventType,
+      filename: string | null
+    ) => void,
     signal?: AbortSignal
   ) {
     super();
@@ -149,7 +155,7 @@ class VirtualWatcher extends EventEmitter implements FsWatcher {
 
   emitFileSystemEvent(): void {
     if (!this.closed) {
-      this.onEvent();
+      this.onEvent('change', 'profile');
     }
   }
 

--- a/web/packages/teleterm/src/mainProcess/profileWatcher/profileWatcher.ts
+++ b/web/packages/teleterm/src/mainProcess/profileWatcher/profileWatcher.ts
@@ -118,7 +118,7 @@ export async function* watchProfiles({
         }
       }
     } catch (error) {
-      logger.warn('Profile watcher received an error', error);
+      logger.warn('Debounced watch received an error', error);
       // Check if the error is caused by removing the watched directory.
       // Removing that directory emits different events, depending on a platform:
       // - On macOS/Linux, it emits a 'rename' event.
@@ -223,10 +223,13 @@ async function* debounceWatch(
   let eventsToDebounce = 0;
   let uniqueFiles = new Set<string | null>();
   const scheduleYield = debounce(() => {
-    logger.info('Received debounced file system events', {
+    const toLog: { eventCount: number; files?: (string | null)[] } = {
       eventCount: eventsToDebounce,
-      files: Array.from(uniqueFiles.values()),
-    });
+    };
+    if (uniqueFiles.size > 0) {
+      toLog.files = Array.from(uniqueFiles.values());
+    }
+    logger.info('Received debounced file system events', toLog);
     uniqueFiles.clear();
     eventsToDebounce = 0;
     signal.resolve();

--- a/web/packages/teleterm/src/mainProcess/profileWatcher/profileWatcher.ts
+++ b/web/packages/teleterm/src/mainProcess/profileWatcher/profileWatcher.ts
@@ -237,11 +237,6 @@ async function* debounceWatch(
   const queueFileSystemEvent = () => {
     ++eventsToDebounce;
     if (eventsToDebounce > maxFileSystemEvents) {
-      logger.error('File system event limit exceeded', {
-        eventsToDebounce,
-        maxFileSystemEvents,
-        debounceMs,
-      });
       signal.reject(
         new FileSystemEventsOverflowError(maxFileSystemEvents, debounceMs)
       );

--- a/web/packages/teleterm/src/mainProcess/profileWatcher/profileWatcher.ts
+++ b/web/packages/teleterm/src/mainProcess/profileWatcher/profileWatcher.ts
@@ -221,7 +221,13 @@ async function* debounceWatch(
   let signal = Promise.withResolvers<void>();
   let closed = false;
   let eventsToDebounce = 0;
+  let uniqueFiles = new Set<string | null>();
   const scheduleYield = debounce(() => {
+    logger.info('Received debounced file system events', {
+      eventCount: eventsToDebounce,
+      files: Array.from(uniqueFiles.values()),
+    });
+    uniqueFiles.clear();
     eventsToDebounce = 0;
     signal.resolve();
   }, debounceMs);
@@ -245,10 +251,7 @@ async function* debounceWatch(
     path,
     signal: abortSignal,
     onEvent: (event: WatchEventType, filename: string | null) => {
-      logger.info('Received file system event', {
-        event,
-        filename,
-      });
+      uniqueFiles.add(filename);
       queueFileSystemEvent();
     },
   });

--- a/web/packages/teleterm/src/mainProcess/profileWatcher/profileWatcher.ts
+++ b/web/packages/teleterm/src/mainProcess/profileWatcher/profileWatcher.ts
@@ -16,13 +16,14 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { watch } from 'node:fs';
+import { watch, type WatchEventType } from 'node:fs';
 import { access } from 'node:fs/promises';
 
 import { Cluster } from 'gen-proto-ts/teleport/lib/teleterm/v1/cluster_pb';
 import { debounce } from 'shared/utils/highbar';
 import { wait } from 'shared/utils/wait';
 
+import Logger from 'teleterm/logger';
 import { isTshdRpcError } from 'teleterm/services/tshd';
 import { mergeClusterProfileWithDetails } from 'teleterm/services/tshd/cluster';
 import { RootClusterUri } from 'teleterm/ui/uri';
@@ -46,12 +47,13 @@ export interface FsWatcher {
 export type CreateFsWatcher = (options: {
   path: string;
   signal?: AbortSignal;
-  onEvent(): void;
+  onEvent(event: WatchEventType, filename: string | null): void;
 }) => FsWatcher;
 
 const createNodeFsWatcher: CreateFsWatcher = ({ path, signal, onEvent }) =>
   watch(path, { signal, recursive: true }, onEvent);
 
+const logger = new Logger('ProfileWatcher');
 /**
  * Watches the specified `tshDirectory` for profile changes.
  * File system events are debounced with a default 200 ms delay.
@@ -86,6 +88,12 @@ export async function* watchProfiles({
   signal?: AbortSignal;
   createFsWatcher?: CreateFsWatcher;
 }): AsyncGenerator<ProfileChangeSet, void, void> {
+  logger.info('Starting profile watcher', {
+    tshDirectory,
+    debounceMs,
+    maxFileSystemEvents,
+  });
+
   while (!signal?.aborted) {
     try {
       for await (const _ of debounceWatch(
@@ -103,10 +111,14 @@ export async function* watchProfiles({
 
         const changes = detectChanges(oldClusters, newClusters);
         if (changes.length > 0) {
+          logger.info('Detected profile changes', changes);
           yield changes;
+        } else {
+          logger.info('No profile changes detected');
         }
       }
     } catch (error) {
+      logger.warn('Profile watcher received an error', error);
       // Check if the error is caused by removing the watched directory.
       // Removing that directory emits different events, depending on a platform:
       // - On macOS/Linux, it emits a 'rename' event.
@@ -121,10 +133,13 @@ export async function* watchProfiles({
       ) {
         const ok = await pathExists(tshDirectory);
         if (!ok) {
+          logger.info('Watched directory was removed');
           yield clusterStore
             .getRootClusters()
             .map(cluster => ({ op: 'removed', cluster }));
+          logger.info('Waiting for watched directory to reappear');
           await waitForPath(tshDirectory, signal);
+          logger.info('Watched directory reappeared');
           continue;
         }
       }
@@ -210,9 +225,14 @@ async function* debounceWatch(
     eventsToDebounce = 0;
     signal.resolve();
   }, debounceMs);
-  const onEvent = () => {
+  const queueFileSystemEvent = () => {
     ++eventsToDebounce;
     if (eventsToDebounce > maxFileSystemEvents) {
+      logger.error('File system event limit exceeded', {
+        eventsToDebounce,
+        maxFileSystemEvents,
+        debounceMs,
+      });
       signal.reject(
         new FileSystemEventsOverflowError(maxFileSystemEvents, debounceMs)
       );
@@ -224,7 +244,13 @@ async function* debounceWatch(
   const watcher = createFsWatcher({
     path,
     signal: abortSignal,
-    onEvent,
+    onEvent: (event: WatchEventType, filename: string | null) => {
+      logger.info('Received file system event', {
+        event,
+        filename,
+      });
+      queueFileSystemEvent();
+    },
   });
 
   const closeHandler = () => {
@@ -237,7 +263,8 @@ async function* debounceWatch(
 
   // The watcher might be restarted if the path disappears and then reappears.
   // Begin by checking for any changes immediately.
-  onEvent();
+  logger.info('Scheduling initial profile scan');
+  queueFileSystemEvent();
 
   try {
     while (true) {

--- a/web/packages/teleterm/src/services/logger/loggerService.ts
+++ b/web/packages/teleterm/src/services/logger/loggerService.ts
@@ -72,9 +72,7 @@ export function createFileLoggerService(
     level: 'info',
     exitOnError: false,
     format: format.combine(
-      format.timestamp({
-        format: 'DD-MM-YY HH:mm:ss',
-      }),
+      format.timestamp(),
       format.printf(({ level, message, timestamp, context }) => {
         // `message` is an array because the functions in createLoggerFromWinston
         // collect all the arguments into an array.

--- a/web/packages/teleterm/src/ui/appContext.ts
+++ b/web/packages/teleterm/src/ui/appContext.ts
@@ -231,7 +231,7 @@ export default class AppContext implements IAppContext {
           case 'did-add-cluster':
             return this.workspacesService.addWorkspace(uri);
           case 'did-change-access':
-            if (!this.clustersService.findCluster(uri).connected) {
+            if (!this.clustersService.findCluster(uri)?.connected) {
               // Only refresh resources when the cluster is connected.
               return;
             }


### PR DESCRIPTION
Backport #66529 to branch/v18

## Manual Test Plan
### Test Environment
`pnpm start-term`

### Test Cases
- [x] Profile changes, such as `tsh logout` are detected and logged. 