### PR TITLE
Move less concrete instructions out of "Step"s

### DIFF
--- a/docs/pages/enroll-resources/application-access/protect-apps/openclaw.mdx
+++ b/docs/pages/enroll-resources/application-access/protect-apps/openclaw.mdx
@@ -27,18 +27,14 @@ Teleport can secure this setup by acting as a secure gateway. It provides:
 
 (!docs/pages/includes/edition-prereqs-tabs.mdx!)
 
-- A server to host OpenClaw (e.g., AWS EC2, Raspberry Pi, or mini PC).
 - An AI model provider account for the agent's backend.
+- A server to host OpenClaw (e.g., AWS EC2, Raspberry Pi, or mini PC). While you
+  can host OpenClaw on local hardware like a Raspberry Pi or Mac mini, this
+  guide uses an **AWS EC2 instance** as an example, running Ubuntu on a
+  `t3.small` instance. Make sure your network allows SSH access to the instance
+  so you can perform the initial installation.
 
-## Step 1/4. Set up the OpenClaw server
-
-While you can host OpenClaw on local hardware like a Raspberry Pi or Mac mini, this guide uses an **AWS EC2 instance** as an example.
-
-1. Log into the AWS Console and launch a new **Ubuntu** instance.
-2. Choose an instance type (e.g., `t3.small` for a balance of performance and free-tier).
-3. Ensure your Security Group allows SSH access so you can perform the initial installation.
-
-## Step 2/4. Install and configure OpenClaw
+## Step 1/3. Install and configure OpenClaw
 
 Once your server is running, connect via SSH to install the agent.
 
@@ -56,7 +52,7 @@ Once your server is running, connect via SSH to install the agent.
    $ source ~/.bashrc # or ~/.zshrc
    ```
 
-## Step 3/4. Enroll the server and application with Teleport
+## Step 2/3. Enroll the server and application with Teleport
 
 1. Generate a new join token that allows both the Node and App roles.
 
@@ -97,7 +93,7 @@ Once your server is running, connect via SSH to install the agent.
 
    ![OpenClaw Application Enrolled](https://website.goteleport.com/_uploads/openclaw_access_application_enrolled_5b7c996790.png)
 
-## Step 4/4. Pair OpenClaw with Teleport
+## Step 3/3. Pair OpenClaw with Teleport
 
 OpenClaw requires that any devices accessing it, outside of localhost, be explicitly paired. Pairing is OpenClaw's owner approval step that dictates which devices are allowed to join the gateway network.
 

--- a/docs/pages/enroll-resources/database-access/enrollment/aws/rds/mysql-postgres-mariadb.mdx
+++ b/docs/pages/enroll-resources/database-access/enrollment/aws/rds/mysql-postgres-mariadb.mdx
@@ -47,6 +47,7 @@ which supports IAM authentication.
 
 - AWS account with RDS and Aurora databases and permissions to create and attach
   IAM policies.
+
   <Admonition type="warning" title="IAM authentication">
   Your RDS and Aurora databases must have password and IAM authentication
   enabled.
@@ -55,11 +56,50 @@ which supports IAM authentication.
   the Database Service will attempt to enable IAM authentication by modifying
   them using respective APIs.
   </Admonition>
+
 - A Linux host or Amazon Elastic Kubernetes Service cluster where you will run
   the Teleport Database Service, which proxies connections to your RDS
   databases. 
+
 - (!docs/pages/includes/tctl.mdx!)
 
+- At least one user that allows IAM authentication on your databases. See
+  [Creating a database account using IAM
+  authentication](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/UsingWithRDS.IAMDBAuth.DBAccounts.html)
+  for more information. This guide assumes that your IAM user is called `alice`.
+
+  <details>
+  <summary>Examples of enabling an IAM user</summary>
+
+  See below how to enable IAM authentication for the user `alice` on your database engine:
+
+  <Tabs>
+    <TabItem label="PostgreSQL">
+    PostgreSQL users must have a `rds_iam` role:
+  
+    ```sql
+    CREATE USER alice;
+    GRANT rds_iam TO alice;
+    ```
+    </TabItem>
+    <TabItem label="MySQL/MariaDB">
+    MySQL and MariaDB users must have the RDS authentication plugin enabled:
+  
+    ```sql
+    CREATE USER alice IDENTIFIED WITH AWSAuthenticationPlugin AS 'RDS';
+    ```
+  
+    Created user may not have access to anything by default so let's grant it
+    some permissions:
+  
+    ```sql
+    GRANT ALL ON `%`.* TO 'alice'@'%';
+    ```
+    </TabItem>
+  </Tabs>
+
+  </details>
+  
 If you plan to run the Teleport Database Service on Kubernetes, you will need
 the following:
 
@@ -85,11 +125,11 @@ the following:
  - The [`jq` CLI tool](https://jqlang.github.io/jq/), which we use to process
    JSON data in this guide.
 
-## Step 1/6. Create a Teleport user
+## Step 1/5. Create a Teleport user
 
 (!docs/pages/includes/database-access/create-user.mdx!)
 
-## Step 2/6. Create a Database Service configuration
+## Step 2/5. Create a Database Service configuration
 
 In this section, you will configure the Teleport Database Service. To do so, you
 will:
@@ -170,7 +210,7 @@ place it at the `/etc/teleport.yaml` location.
 </TabItem>
 </Tabs>
 
-## Step 3/6. Create IAM policies for Teleport
+## Step 3/5. Create IAM policies for Teleport
 
 (!docs/pages/includes/database-access/create-iam-role-step-description.mdx accessFor="RDS instances and Aurora clusters" !)
 
@@ -184,7 +224,7 @@ Attach the following AWS IAM permissions to the Database Service IAM role:
 
 (!docs/pages/includes/database-access/reference/aws-iam/rds/access-policy.mdx!)
 
-## Step 4/6. Start the Database Service
+## Step 4/5. Start the Database Service
 
 Start the Teleport Database Service in your environment:
 
@@ -262,42 +302,7 @@ teleport-kube-agent-0   1/1     Running   0          32s
 </TabItem>
 </Tabs>
 
-## Step 5/6. Create a database IAM user
-
-Database users must allow IAM authentication in order to be used with Database
-Access for RDS. See below how to enable it for the user `alice` on your database
-engine. In the next step, we will authenticate to the database as the `alice`
-user via the user's Teleport account.
-
-<Tabs>
-  <TabItem label="PostgreSQL">
-  PostgreSQL users must have a `rds_iam` role:
-
-  ```sql
-  CREATE USER alice;
-  GRANT rds_iam TO alice;
-  ```
-  </TabItem>
-  <TabItem label="MySQL/MariaDB">
-  MySQL and MariaDB users must have the RDS authentication plugin enabled:
-
-  ```sql
-  CREATE USER alice IDENTIFIED WITH AWSAuthenticationPlugin AS 'RDS';
-  ```
-
-  Created user may not have access to anything by default so let's grant it
-  some permissions:
-
-  ```sql
-  GRANT ALL ON `%`.* TO 'alice'@'%';
-  ```
-  </TabItem>
-</Tabs>
-
-See [Creating a database account using IAM authentication](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/UsingWithRDS.IAMDBAuth.DBAccounts.html)
-for more information.
-
-## Step 6/6. Connect
+## Step 5/5. Connect
 
 Once the Database Service has started and joined the cluster, log in as the
 `alice` user you created earlier to see the registered databases:

--- a/docs/pages/enroll-resources/database-access/enrollment/aws/rds/sql-server-ad.mdx
+++ b/docs/pages/enroll-resources/database-access/enrollment/aws/rds/sql-server-ad.mdx
@@ -38,17 +38,31 @@ Database Service forwards user traffic to the database.
 (!docs/pages/includes/edition-prereqs-tabs.mdx!)
 
 - A SQL Server database with Active Directory authentication enabled.
+
 - A SQL Server network listener configured with a Certificate using Subject Alternative Names
+
 - A Windows machine joined to the same Active Directory domain as the database.
+
 - A Linux node joined to the same Active Directory domain as the database. This
   guide will walk you through the joining steps if you don't have one.
+
+- At least one login on your SQL Server instances that will use Active Directory
+  authentication.
+
+  For example, you can connect to your SQL Server as an administrative account
+  (e.g. `sa`) and create logins using the following command:
+  
+  ```sql
+  master> CREATE LOGIN [EXAMPLE\alice] FROM WINDOWS WITH DEFAULT_DATABASE = [master], DEFAULT_LANGUAGE = [us_english];
+  ```
+
 - (!docs/pages/includes/tctl.mdx!)
 
-## Step 1/7. Create a Teleport user
+## Step 1/6. Create a Teleport user
 
 (!docs/pages/includes/database-access/create-user.mdx!)
 
-## Step 2/7. Join the Linux node to Active Directory
+## Step 2/6. Join the Linux node to Active Directory
 
 <Admonition type="note">
   You can skip this step if you already have a Linux node joined to the same
@@ -123,7 +137,7 @@ example.com
   ...
 ```
 
-## Step 3/7. Create keytab file
+## Step 3/6. Create keytab file
 
 Teleport requires a keytab file to obtain Kerberos service tickets from your
 Active Directory for authentication with SQL Server. The easiest way to generate
@@ -223,7 +237,7 @@ KVNO Principal
   authentication failures.
 </Admonition>
 
-## Step 4/7. Set up the Teleport Database Service
+## Step 4/6. Set up the Teleport Database Service
 
 (!docs/pages/includes/tctl-token.mdx serviceName="Database" tokenType="db" tokenFile="/tmp/token"!)
 
@@ -318,25 +332,11 @@ object typically resides under the AWS Reserved / RDS path:
   toggle is enabled.
 </Admonition>
 
-## Step 5/7. Start the Database Service
+## Step 5/6. Start the Database Service
 
 (!docs/pages/includes/start-teleport.mdx service="the Teleport Database Service"!)
 
-## Step 6/7. Create SQL Server AD users
-
-<Admonition type="note">
-  You can skip this step if you already have Active Directory logins in your
-  SQL Server.
-</Admonition>
-
-Connect to your SQL Server as an administrative account (e.g. `sa`) and create
-logins that will use Active Directory authentication:
-
-```sql
-master> CREATE LOGIN [EXAMPLE\alice] FROM WINDOWS WITH DEFAULT_DATABASE = [master], DEFAULT_LANGUAGE = [us_english];
-```
-
-## Step 7/7. Connect
+## Step 6/6. Connect
 
 Log in to your Teleport cluster. Your SQL Server database should appear in the
 list of available databases:

--- a/docs/pages/identity-security/integrations/netiq.mdx
+++ b/docs/pages/identity-security/integrations/netiq.mdx
@@ -64,7 +64,7 @@ Check the [Identity Security page](../identity-security.mdx) for details on
 how to set up Access Graph.
   - The node running the Access Graph service must be reachable from the Teleport Auth Service.
 
-## Step 1/3. Create NetIQ IDM OAuth Client
+## Step 1/2. Create NetIQ IDM OAuth Client
 
 To register a new OAuth client with OSP (IDM Authorization Server), modify the OSP's
 `ism-configuration.properties` file.  
@@ -119,7 +119,7 @@ com.example.<Var name="client-id" />.clientPass = <Var name="client-secret" />
 
 Once the file is updated, restart OSP to apply the new settings.  
 
-## Step 2/3. Set up Access Graph NetIQ Sync
+## Step 2/2. Set up Access Graph NetIQ Sync
 
 To configure NetIQ Sync, run the following command:  
 
@@ -135,11 +135,12 @@ The wizard will prompt for:
 - **IDM User & Password** – A user with organization read access  
 
 After completing the setup, the wizard will create the necessary
-Teleport resources and start synchronization.  
+Teleport resources and start synchronization.
 
+## Next step: visualize NetIQ resources
 
-## Step 3/3. View NetIQ resources in Access Graph
+Once NetIQ resources are imported, you can navigate to the Access Graph page to visualize them.  
 
-Once NetIQ resources are imported, navigate to the Access Graph page to visualize them.  
+From the Teleport Web UI, visit **Identity Security** > **Graph Explorer**.
 
 The graph representation will display the relationships between users, groups, roles and resources within your organization.  

--- a/docs/pages/identity-security/integrations/ssh-keys-scan.mdx
+++ b/docs/pages/identity-security/integrations/ssh-keys-scan.mdx
@@ -83,7 +83,7 @@ Check the [Identity Security page](../identity-security.mdx) for details on
 how to set up Access Graph.
   - The node running the Access Graph service must be reachable from the Teleport Auth Service.
 
-## Step 1/3. Enable SSH Key Scanning
+## Step 1/2. Enable SSH Key Scanning
 
 To enable SSH Key Scanning, you need to configure the Teleport cluster to scan for SSH authorized keys.
 
@@ -110,7 +110,7 @@ SSH authorized keys. This process may take a few minutes to complete.
 After a few minutes, you can navigate to the Access Graph page in the Teleport UI to view the imported SSH authorized keys
 and local users.
 
-## Step 2/3. Scan for SSH private keys
+## Step 2/2. Scan for SSH private keys
 
 On devices enrolled in the Teleport, you can use the `tsh` CLI tool to scan for SSH private keys. Check [Device Trust](../../zero-trust-access/device-trust/device-trust.mdx)
 for details on how to enroll devices in Teleport, specially if you are using Jamf Pro.
@@ -136,10 +136,17 @@ fingerprints to the Teleport cluster. The Teleport cluster will then import the 
 Once the scan is complete, `tsh` will display the number of keys found, their fingerprints and their paths. The program
 output is the only place where the private key paths are displayed. The paths are not sent to the Teleport cluster.
 
+## Next steps
 
-## Step 3/3. View Access Graph
+Now that you have set up SSH key scanning, you can visualize the use of insecure
+SSH key patterns in your infrastructure and integrate with Jamf Pro.
+
+### View Access Graph
 
 Once the SSH authorized keys and private keys have been imported, you can view them on the Access Graph page.
+
+From the Teleport Web UI, visit **Identity Security** > **Graph Explorer**.
+
 Users whose devices have private keys will see direct paths to the servers they can access.
 
 The access paths shown include the following relationships:
@@ -154,7 +161,7 @@ Insecure paths are also visible in a user's access paths. To view them, click on
 from the context menu. This will show the Teleport permissions granted to the user, the resources they can access,
 and any detected insecure paths.
 
-### Access Graph: Dedicated `ssh_keys` SQL View
+### Use the `ssh_keys` SQL View
 
 Starting in version **v1.25.0**, Access Graph introduces a dedicated `ssh_keys` SQL view for managing SSH access paths.
 This view excludes access paths granted through Teleport and focuses on:
@@ -176,8 +183,7 @@ Below are a few example queries demonstrating how the `ssh_keys` view can be use
   SELECT * FROM ssh_keys WHERE resource_labels @> '{"env": "dev"}';
   ```
 
-
-## Jamf Pro Integration
+### Integrate Jamf Pro 
 
 If you are using Jamf Pro to manage your devices, you can integrate it with Teleport to automate the device enrollment
 process and periodically scan for SSH private keys. Check the [Jamf Pro Integration](../../zero-trust-access/device-trust/jamf-integration.mdx)

--- a/docs/pages/identity-security/session-summaries/session-summaries.mdx
+++ b/docs/pages/identity-security/session-summaries/session-summaries.mdx
@@ -104,13 +104,13 @@ Session Recording Summary Player and Timeline
 <Admonition type="tip" title="Teleport Enterprise Cloud Quick Start">
 Teleport Enterprise Cloud tenants include a pre-provisioned inference model
 (`teleport-cloud-default`). You can skip directly to
-[Step 3: Set up an inference policy](#step-35-set-up-an-inference-policy) to
+[Step 3: Set up an inference policy](#step-34-set-up-an-inference-policy) to
 start summarizing sessions.
 
 Note: Having the model pre-provisioned does not automatically enable session summarization.
 </Admonition>
 
-## Step 1/5: Configure access to inference configuration
+## Step 1/4: Configure access to inference configuration
 
 In order to manage the summary inference configuration, you need write access
 to `inference_model`, `inference_secret`, and `inference_policy` resources,
@@ -153,7 +153,7 @@ access to all necessary resources. To create a new role:
 
 1. (!docs/pages/includes/add-role-to-user.mdx role="summarizer-admin"!)
 
-## Step 2/5: Configure the inference model
+## Step 2/4: Configure the inference model
 
 In this step, you will create an `inference_model` resource. It tells Teleport
 how to summarize a session by pointing it to a large language model (LLM) API.
@@ -172,7 +172,7 @@ called `teleport-cloud-default`, powered by Amazon Bedrock. Teleport manages the
 underlying model and infrastructure.
 
 No additional configuration is needed for this step. Skip to
-[Step 3](#step-35-set-up-an-inference-policy) and reference
+[Step 3](#step-34-set-up-an-inference-policy) and reference
 `teleport-cloud-default` as the model in your inference policy.
 
 You can also add your own inference models using the **OpenAI** or **Amazon
@@ -370,7 +370,7 @@ modify the role specified in the **IAM Role** section of the instance summary.
 </TabItem>
 </Tabs>
 
-## Step 3/5: Set up an inference policy
+## Step 3/4: Set up an inference policy
 
 In this step, you will add an `inference_policy` resource that routes sessions
 to inference models using session kinds and optional custom filters. Only one
@@ -461,7 +461,7 @@ sections of [Teleport Resources Reference](../../reference/infrastructure-as-cod
 - [`inference_secret`](../../reference/infrastructure-as-code/teleport-resources/inference-secret.mdx) (only for OpenAI and compatible APIs)
 - [`inference_policy`](../../reference/infrastructure-as-code/teleport-resources/inference-policy.mdx)
 
-## Step 4/5: Configure access to session summaries
+## Step 4/4: Configure access to session summaries
 
 Every user who has access to
 [given session recording](../../reference/access-controls/roles.mdx#rbac-for-session-recordings)
@@ -498,14 +498,14 @@ access to all recordings. To create a new role:
 
 1. (!docs/pages/includes/add-role-to-user.mdx role="summary-auditor"!)
 
-## Step 5/5: Conduct a session and view its summary
+## Next steps
 
-That's it! We are ready to conduct a test session. Connect to any of your
-cluster resources using `tsh ssh`, `kubectl exec`, `tsh db connect`, or a web
-terminal. Start an interactive session and execute any command, quit the
-session, and go to **Audit -> Session Recordings**. You should see the
-corresponding recording tile with a summary button. Clicking the summary button
-will show the summary.
+Once you have completed the steps in this guide, you  are ready to conduct a
+test session. Connect to any of your cluster resources using `tsh ssh`, `kubectl
+exec`, `tsh db connect`, or a web terminal. Start an interactive session and
+execute any command, quit the session, and go to **Audit -> Session
+Recordings**. You should see the corresponding recording tile with a summary
+button. Clicking the summary button will show the summary.
 
 ### Session Recording Summary Dashboard
 
@@ -518,7 +518,7 @@ factors, including session size, model, and its temperature. Usually it should
 appear up to a minute after the session is uploaded to the Auth service.
 </Admonition>
 
-## Session Recording Search
+### Session Recording Search
 
 After summaries are enabled, you can configure
 [Session Recording Search](./session-search.mdx) to find summarized recordings

--- a/docs/pages/includes/helm-reference/zz_generated.teleport-kube-agent.mdx
+++ b/docs/pages/includes/helm-reference/zz_generated.teleport-kube-agent.mdx
@@ -251,7 +251,7 @@ to match your cluster domain if it is different from the default value `cluster.
 `awsDatabases` configures AWS database auto-discovery.
 
 <Admonition type="note" title="IAM roles">
-  For AWS database auto-discovery to work, your Database Service pods will need to use a role which has appropriate IAM permissions as per the [database documentation](../../enroll-resources/database-access/enrollment/aws/rds/mysql-postgres-mariadb.mdx#step-36-create-iam-policies-for-teleport).
+  For AWS database auto-discovery to work, your Database Service pods will need to use a role which has appropriate IAM permissions as per the [database documentation](../../enroll-resources/database-access/enrollment/aws/rds/mysql-postgres-mariadb.mdx#step-35-create-iam-policies-for-teleport).
   After configuring a role, you can use an `eks.amazonaws.com/role-arn` annotation with the `annotations.serviceAccount` value to associate it with the service account and grant permissions:
 
   ```yaml

--- a/docs/pages/installation/self-hosted/helm-deployments/digitalocean.mdx
+++ b/docs/pages/installation/self-hosted/helm-deployments/digitalocean.mdx
@@ -29,19 +29,9 @@ resources by deploying Teleport Agents.
 
 - DigitalOcean account.
 - Your workstation configured with [kubectl](https://kubernetes.io/docs/tasks/tools/), [Helm](https://helm.sh/docs/intro/install/), [doctl](https://docs.digitalocean.com/reference/doctl/how-to/install/), and the Teleport [tsh](../../../installation/single-machine/single-machine.mdx) client.
+- A DigitalOcean Kubernetes cluster. See the [DigitalOcean documentation](https://docs.digitalocean.com/products/kubernetes/how-to/create-clusters/) for how to get started.
 
-## Step 1/4. Create a DigitalOcean Kubernetes cluster
-
-Create a new [DigitalOcean Kubernetes Cluster](https://cloud.digitalocean.com/kubernetes/clusters/)
-
-![Create DigitalOcean Kubernetes cluster](../../../../img/helm/digitalocean/create-k8s.png)
-
-<br />
-While the Kubernetes cluster is being provisioned, follow the "Getting Started" guide as shown below:
-
-![Set up DigitalOcean Kubernetes client](../../../../img/helm/digitalocean/setup-k8s.png)
-
-## Step 2/4. Install Teleport
+## Step 1/3. Install Teleport
 
 (!docs/pages/includes/kubernetes-access/helm/helm-repo-add.mdx!)
 
@@ -129,7 +119,7 @@ Once you get the value for the external IP (it may take a few minutes for this f
 
 ![Configure DNS](../../../../img/helm/digitalocean/fqdn.png)
 
-## Step 3/4. Create and set up Teleport user
+## Step 2/3. Create and set up Teleport user
 Now we create a Teleport user by executing the `tctl` command with `kubectl`.
 
 <Tabs>
@@ -196,7 +186,7 @@ Second, update the **tadmin** user role to assign the **member** role:
 
 We've updated the user **tadmin** to have the **member** role, which is allowed to access a Kubernetes cluster with privilege `system:master`.
 
-## Step 4/4. Access your Kubernetes cluster using Teleport
+## Step 3/3. Access your Kubernetes cluster using Teleport
 
 The following steps show how to access the Kubernetes cluster using `tsh`.
 

--- a/docs/pages/zero-trust-access/export-audit-events/elastic-stack.mdx
+++ b/docs/pages/zero-trust-access/export-audit-events/elastic-stack.mdx
@@ -45,7 +45,7 @@ The instructions below demonstrate a local test of the Event Handler plugin on
 your workstation. You will need to adjust paths, ports, and domains for other
 environments.
 
-## Step 1/3. Configure a Logstash pipeline
+## Step 1/2. Configure a Logstash pipeline
 
 The Event Handler plugin forwards audit logs from Teleport by sending HTTP
 requests to a user-configured endpoint. We will define a Logstash pipeline that
@@ -334,7 +334,7 @@ Edit the file `/etc/elasticsearch/elasticsearch.yml` to set
 
 </details>
 
-## Step 2/3. Run the Event Handler plugin
+## Step 2/2. Run the Event Handler plugin
 
 In this section, you will modify the Event Handler configuration you generated
 and run the Event Handler to test your configuration.
@@ -358,10 +358,24 @@ your Logstash `http` input earlier, `https://localhost:9601`. Change
 
 (!docs/pages/includes/plugins/start-event-handler.mdx!)
 
-## Step 3/3. Create a data view in Kibana
+## Troubleshooting connection issues
 
-Make it possible to explore your Teleport audit events in Kibana by creating a
-data view. In the Elastic Stack UI, find the hamburger menu on the upper
+If the Teleport Event Handler is displaying error logs while connecting to your
+Teleport Cluster, ensure that:
+
+- The certificate the Teleport Event Handler is using to connect to your
+  Teleport cluster is not past its expiration date. This is the value of the
+  `--ttl` flag in the `tctl auth sign` command, which is 12 hours by default.
+- In your Teleport Event Handler configuration file, you have provided
+  the correct host *and* port for the Teleport Proxy Service.
+
+## Next step: set up a data view
+
+Now that you are exporting your audit events to the Elastic Stack, you can set
+up a data view in Kibana so that you can understand activity in your Teleport
+cluster.
+
+In the Elastic Stack UI, find the hamburger menu on the upper
 left of the screen, then click "Management" > "Data Views". Click "Create data
 view".
 
@@ -384,22 +398,13 @@ the event types for your Teleport audit events over time:
 
 ![Creating a visualization](../../../img/enterprise/plugins/elasticsearch/lens.png)
 
-## Troubleshooting connection issues
+Consult the [audit event
+reference](../../reference/deployment/monitoring/audit.mdx) so you can see the
+structures of the audit events you are interested in and plan visualizations and
+alerts.
 
-If the Teleport Event Handler is displaying error logs while connecting to your
-Teleport Cluster, ensure that:
+## Further reading
 
-- The certificate the Teleport Event Handler is using to connect to your
-  Teleport cluster is not past its expiration date. This is the value of the
-  `--ttl` flag in the `tctl auth sign` command, which is 12 hours by default.
-- In your Teleport Event Handler configuration file, you have provided
-  the correct host *and* port for the Teleport Proxy Service.
-
-## Next steps
-
-- Now that you are exporting your audit events to the Elastic Stack, consult our
-[audit event reference](../../reference/deployment/monitoring/audit.mdx) so you can plan
-visualizations and alerts.
-- To see all of the options you can set in the values file for the
+To see all of the options you can set in the values file for the
 `teleport-plugin-event-handler` Helm chart, consult our [reference
 guide](../../reference/helm-reference/teleport-plugin-event-handler.mdx).

--- a/examples/chart/teleport-kube-agent/values.yaml
+++ b/examples/chart/teleport-kube-agent/values.yaml
@@ -199,7 +199,7 @@ clusterDomain: "cluster.local"
 # awsDatabases(list) -- configures AWS database auto-discovery.
 #
 # <Admonition type="note" title="IAM roles">
-#   For AWS database auto-discovery to work, your Database Service pods will need to use a role which has appropriate IAM permissions as per the [database documentation](../../enroll-resources/database-access/enrollment/aws/rds/mysql-postgres-mariadb.mdx#step-36-create-iam-policies-for-teleport).
+#   For AWS database auto-discovery to work, your Database Service pods will need to use a role which has appropriate IAM permissions as per the [database documentation](../../enroll-resources/database-access/enrollment/aws/rds/mysql-postgres-mariadb.mdx#step-35-create-iam-policies-for-teleport).
 #   After configuring a role, you can use an `eks.amazonaws.com/role-arn` annotation with the `annotations.serviceAccount` value to associate it with the service account and grant permissions:
 #
 #   ```yaml


### PR DESCRIPTION
In how-to guides that include a "Step" section that consists entirely of setting up a non-Teleport product, or that does not include any concrete, achievable goals, move the content into either a Prerequisites item or a "Next steps" section. This way, we can focus the "Step" sections of our how-to guides on instructions that a user (humans and, ideally, AI agents) can complete quickly.

- **sql-server-ad.mdx, mysql-postgres-mariadb.mdx:** Move an external system setup step to the Prerequisites.

- **digitalocean.mdx:** Move cluster creation step to the Prerequisites, since it takes place entirely in an external system.

- **openclaw.mdx:** Move Step 1 into the Prerequisites, since it requires making open-ended choices about an external system (it's already there, but in a shorter form, so this is actually a consolidation).

- **netiq.mdx, ssh-keys-scan.mdx, session-summaries.mdx:** Move final step, which is not a step to complete but more of a general thing that's now possible once you complete the guide, out of the "Step" sections.

- **elastic-stack.mdx:** Move the data view discussion, which is open ended and requires a browser, to a Next steps section.
