### PR TITLE
Move env var check to higher level

### DIFF
--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -6920,20 +6920,28 @@ func (process *TeleportProcess) initApps() {
 			return trace.Wrap(err)
 		}
 
+		// When the app_service itself is running on Teleport Cloud, then we reject any app
+		// with dynamic labels, which allow for code execution.
+		// This is primarily for the beams use case, where the only apps we expect
+		// to see are those created by `tsh beams publish`.
+		const teleportBeamsEnvVar = "TELEPORT_BEAMS_RUNTIME"
+		runningOnBeams, _ := apiutils.ParseBool(os.Getenv(teleportBeamsEnvVar))
+
 		appServer, err := app.New(process.ExitContext(), &app.Config{
-			Clock:                process.Config.Clock,
-			AuthClient:           conn.Client,
-			AccessPoint:          accessPoint,
-			HostID:               conn.HostUUID(),
-			Hostname:             process.Config.Hostname,
-			GetRotation:          process.GetRotation,
-			Apps:                 applications,
-			CloudLabels:          process.cloudLabels,
-			ResourceMatchers:     process.Config.Apps.ResourceMatchers,
-			OnHeartbeat:          process.OnHeartbeat(teleport.ComponentApp),
-			ConnectedProxyGetter: proxyGetter,
-			ConnectionsHandler:   connectionsHandler,
-			InventoryHandle:      process.inventoryHandle,
+			Clock:                       process.Config.Clock,
+			AuthClient:                  conn.Client,
+			AccessPoint:                 accessPoint,
+			HostID:                      conn.HostUUID(),
+			Hostname:                    process.Config.Hostname,
+			GetRotation:                 process.GetRotation,
+			Apps:                        applications,
+			CloudLabels:                 process.cloudLabels,
+			ResourceMatchers:            process.Config.Apps.ResourceMatchers,
+			OnHeartbeat:                 process.OnHeartbeat(teleport.ComponentApp),
+			ConnectedProxyGetter:        proxyGetter,
+			ConnectionsHandler:          connectionsHandler,
+			InventoryHandle:             process.inventoryHandle,
+			IgnoreAppsWithCommandLabels: runningOnBeams,
 		})
 		if err != nil {
 			return trace.Wrap(err)

--- a/lib/srv/app/server.go
+++ b/lib/srv/app/server.go
@@ -85,7 +85,7 @@ type Config struct {
 	// ResourceMatchers is a list of app resource matchers.
 	ResourceMatchers []services.ResourceMatcher
 
-	// OnReconcile is called after each database resource reconciliation.
+	// OnReconcile is called after each app resource reconciliation.
 	OnReconcile func(types.Apps)
 
 	// ConnectedProxyGetter gets the proxies teleport is connected to.
@@ -96,6 +96,10 @@ type Config struct {
 
 	// InventoryHandle is used to send app server heartbeats via the inventory control stream.
 	InventoryHandle inventory.DownstreamHandle
+
+	// IgnoreAppsWithCommandLabels configures the app server to reject app resources
+	// with dynamic/command labels even if the app's labels otherwise match.
+	IgnoreAppsWithCommandLabels bool
 }
 
 // CheckAndSetDefaults makes sure the configuration has the minimum required

--- a/lib/srv/app/watcher.go
+++ b/lib/srv/app/watcher.go
@@ -21,13 +21,11 @@ package app
 import (
 	"context"
 	"fmt"
-	"os"
 
 	"github.com/gravitational/trace"
 
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/types"
-	apiutils "github.com/gravitational/teleport/api/utils"
 	"github.com/gravitational/teleport/api/utils/clientutils"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/services/readonly"
@@ -191,20 +189,13 @@ func (s *Server) onDelete(ctx context.Context, app types.Application) error {
 	return s.unregisterAndRemoveApp(ctx, app.GetName())
 }
 
-const teleportBeamsEnvVar = "TELEPORT_BEAMS_RUNTIME"
-
 func (s *Server) matcher(app types.Application) bool {
 	matchesLabels := services.MatchResourceLabels(s.c.ResourceMatchers, app.GetAllLabels())
 	if !matchesLabels {
 		return false
 	}
 
-	// When the app_service itself is running on Teleport Cloud, then we reject any app
-	// with dynamic labels, which allow for code execution.
-	// This is primarily for the beams use case, where the only apps we expect
-	// to see are those created by `tsh beams publish`.
-	runningOnBeams, _ := apiutils.ParseBool(os.Getenv(teleportBeamsEnvVar))
-	if runningOnBeams {
+	if s.c.IgnoreAppsWithCommandLabels {
 		if len(app.GetDynamicLabels()) > 0 {
 			s.log.WarnContext(
 				context.Background(),

--- a/lib/srv/app/watcher_test.go
+++ b/lib/srv/app/watcher_test.go
@@ -34,7 +34,7 @@ import (
 )
 
 func TestCloudHostedAppServiceRejectsDynamicLabels(t *testing.T) {
-	t.Setenv(teleportBeamsEnvVar, "yes")
+	t.Parallel()
 
 	reconcileCh := make(chan types.Apps)
 
@@ -46,6 +46,8 @@ func TestCloudHostedAppServiceRejectsDynamicLabels(t *testing.T) {
 			reconcileCh <- a
 		},
 	})
+
+	s.appServer.c.IgnoreAppsWithCommandLabels = true
 
 	// Drain the initial event that fires when the watcher starts up
 	// (before we create any dynamic apps).


### PR DESCRIPTION
Minor change to address feedback on #66531 that came in after merge.

No backport or manual test plan as the change is included and manually tested in the v18 backport at #66560.