### PR TITLE
[v18] [Access Requests] Fix sentinel in legacy cert extension replacing actual resource IDs

### DIFF
--- a/lib/auth/access_request_test.go
+++ b/lib/auth/access_request_test.go
@@ -1840,6 +1840,9 @@ func createAccessRequestWithStartTime(t *testing.T) accessRequestWithStartTime {
 // When a mix of plain and constrained resources is requested, only the plain
 // resource IDs appear in the legacy extension (no sentinel).
 func testCertExtensionResourceIDs(t *testing.T, testPack *accessRequestTestPack) {
+	// TODO(kiosion): Unskip after https://github.com/gravitational/teleport/pull/66371 is merged.
+	t.Skipf("skipping until ssh certs constraints will be supported")
+
 	t.Parallel()
 
 	ctx := t.Context()

--- a/lib/auth/access_request_test.go
+++ b/lib/auth/access_request_test.go
@@ -197,6 +197,7 @@ func TestAccessRequest(t *testing.T) {
 	t.Run("role refresh with bogus request ID", func(t *testing.T) { testRoleRefreshWithBogusRequestID(t, testPack) })
 	t.Run("bot user approver", func(t *testing.T) { testBotAccessRequestReview(t, testPack) })
 	t.Run("deny", func(t *testing.T) { testAccessRequestDenyRules(t, testPack) })
+	t.Run("cert extension resource IDs", func(t *testing.T) { testCertExtensionResourceIDs(t, testPack) })
 }
 
 // waitForAccessRequests is a helper for writing access request tests that need to wait for access request CRUD. the supplied condition is
@@ -1825,4 +1826,148 @@ func createAccessRequestWithStartTime(t *testing.T) accessRequestWithStartTime {
 		requesterUserName:             requesterUserName,
 		createdRequest:                createdReq,
 	}
+}
+
+// testCertExtensionResourceIDs verifies that both the legacy AllowedResourceIDs
+// and the new AllowedResourceAccessIDs cert extensions are correctly populated
+// for access requests with constrained resources only, unconstrained resources
+// only, and a mix of both.
+//
+// Plain (unconstrained) resources should appear in both extensions.
+// Constrained resources appear only in the new extension. When all resources
+// are constrained, the legacy extension receives a sentinel value to prevent
+// older agents from interpreting an empty extension as "unrestricted access".
+// When a mix of plain and constrained resources is requested, only the plain
+// resource IDs appear in the legacy extension (no sentinel).
+func testCertExtensionResourceIDs(t *testing.T, testPack *accessRequestTestPack) {
+	t.Parallel()
+
+	ctx := t.Context()
+
+	username := "requester"
+
+	constrainedResourceIDs := []types.ResourceAccessID{{
+		Id: types.ResourceID{
+			ClusterName: testPack.clusterName,
+			Kind:        types.KindNode,
+			Name:        "staging",
+		},
+		Constraints: &types.ResourceConstraints{
+			Details: &types.ResourceConstraints_Ssh{
+				Ssh: &types.SSHResourceConstraints{Logins: []string{"root"}},
+			},
+		},
+	}}
+
+	plainResourceIDs := []types.ResourceAccessID{{
+		Id: types.ResourceID{
+			ClusterName: testPack.clusterName,
+			Kind:        types.KindNode,
+			Name:        "prod",
+		},
+	}}
+
+	mixedResourceIDs := append(plainResourceIDs, constrainedResourceIDs...)
+
+	constrainedRequest, err := services.NewAccessRequestWithResources(username, []string{"admins"}, constrainedResourceIDs)
+	require.NoError(t, err)
+	plainRequest, err := services.NewAccessRequestWithResources(username, []string{"admins"}, plainResourceIDs)
+	require.NoError(t, err)
+	mixedRequest, err := services.NewAccessRequestWithResources(username, []string{"admins"}, mixedResourceIDs)
+	require.NoError(t, err)
+
+	for _, req := range []types.AccessRequest{constrainedRequest, plainRequest, mixedRequest} {
+		req.SetState(types.RequestState_APPROVED)
+		req.SetAccessExpiry(time.Now().Add(time.Hour).UTC())
+		require.NoError(t, testPack.tlsServer.Auth().UpsertAccessRequest(ctx, req))
+	}
+
+	requester := authtest.TestUser(username)
+	requesterClient, err := testPack.tlsServer.NewClient(requester)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, requesterClient.Close()) })
+
+	generateCerts := func(t *testing.T, requestName string) *proto.Certs {
+		t.Helper()
+		certs, err := requesterClient.GenerateUserCerts(ctx, proto.UserCertsRequest{
+			SSHPublicKey:   testPack.sshPubKey,
+			TLSPublicKey:   testPack.tlsPubKey,
+			Username:       username,
+			Expires:        time.Now().Add(time.Hour).UTC(),
+			AccessRequests: []string{requestName},
+		})
+		require.NoError(t, err)
+		return certs
+	}
+
+	type certResources struct {
+		AllowedResourceIDs       []types.ResourceID
+		AllowedResourceAccessIDs []types.ResourceAccessID
+	}
+
+	parseCertResources := func(t *testing.T, certs *proto.Certs) (ssh, tls certResources) {
+		t.Helper()
+
+		sshCert, err := sshutils.ParseCertificate(certs.SSH)
+		require.NoError(t, err)
+		ssh.AllowedResourceIDs, err = types.ResourceIDsFromString(sshCert.Permissions.Extensions[teleport.CertExtensionAllowedResources])
+		require.NoError(t, err)
+		ssh.AllowedResourceAccessIDs, err = types.ResourceAccessIDsFromString(sshCert.Permissions.Extensions[teleport.CertExtensionAllowedResourceAccessIDs])
+		require.NoError(t, err)
+
+		tlsCert, err := tlsca.ParseCertificatePEM(certs.TLS)
+		require.NoError(t, err)
+		for _, attr := range tlsCert.Subject.Names {
+			switch {
+			case attr.Type.Equal(tlsca.AllowedResourcesASN1ExtensionOID):
+				tls.AllowedResourceIDs, err = types.ResourceIDsFromString(attr.Value.(string))
+				require.NoError(t, err)
+			case attr.Type.Equal(tlsca.AllowedResourceAccessIDsASN1ExtensionOID):
+				tls.AllowedResourceAccessIDs, err = types.ResourceAccessIDsFromString(attr.Value.(string))
+				require.NoError(t, err)
+			}
+		}
+
+		return ssh, tls
+	}
+
+	t.Run("constrained", func(t *testing.T) {
+		sshCert, tlsCert := parseCertResources(t, generateCerts(t, constrainedRequest.GetName()))
+
+		// All resources are constrained, so the legacy extension gets the
+		// sentinel and the new extension carries the full access IDs.
+		want := certResources{
+			AllowedResourceIDs:       []types.ResourceID{types.CreateSentinelResourceID()},
+			AllowedResourceAccessIDs: constrainedResourceIDs,
+		}
+		require.Equal(t, want, sshCert)
+		require.Equal(t, want, tlsCert)
+	})
+
+	t.Run("without constraints", func(t *testing.T) {
+		sshCert, tlsCert := parseCertResources(t, generateCerts(t, plainRequest.GetName()))
+
+		// No constraints, so the legacy extension carries the actual
+		// resource IDs and no sentinel is needed.
+		want := certResources{
+			AllowedResourceIDs:       []types.ResourceID{plainResourceIDs[0].Id},
+			AllowedResourceAccessIDs: plainResourceIDs,
+		}
+		require.Equal(t, want, sshCert)
+		require.Equal(t, want, tlsCert)
+	})
+
+	t.Run("mixed constrained and unconstrained", func(t *testing.T) {
+		sshCert, tlsCert := parseCertResources(t, generateCerts(t, mixedRequest.GetName()))
+
+		// The legacy extension should contain only the plain resource IDs
+		// (no sentinel) because older agents can still enforce those.
+		// The new extension carries all resources including constrained ones.
+		want := certResources{
+			AllowedResourceIDs:       []types.ResourceID{plainResourceIDs[0].Id},
+			AllowedResourceAccessIDs: mixedResourceIDs,
+		}
+		require.Equal(t, want, sshCert)
+		require.Equal(t, want, tlsCert)
+	})
 }

--- a/lib/auth/access_request_test.go
+++ b/lib/auth/access_request_test.go
@@ -1408,7 +1408,29 @@ func checkCerts(t *testing.T,
 	sshCertAllowedResources, err := types.ResourceAccessIDsFromString(sshCert.Permissions.Extensions[teleport.CertExtensionAllowedResourceAccessIDs])
 	require.NoError(t, err)
 	assert.ElementsMatch(t, resourceAccessIDs, sshCertAllowedResources)
+	assert.ElementsMatch(t, resourceAccessIDs, sshIdentity.AllowedResourceAccessIDs)
 	assert.ElementsMatch(t, resourceAccessIDs, tlsIdentity.AllowedResourceAccessIDs)
+
+	// Verify the legacy AllowedResourceIDs extension contains the expected values.
+	// Plain (unconstrained) resource IDs should appear in the old extension so that older
+	// agents/proxies that don't understand AllowedResourceAccessIDs can still enforce
+	// resource-level restrictions. The sentinel should only appear when all requested
+	// resources carry constraints that old agents can't enforce.
+	sshCertLegacyResources, err := types.ResourceIDsFromString(sshCert.Permissions.Extensions[teleport.CertExtensionAllowedResources])
+	require.NoError(t, err)
+	plainIDs, constrainedOnly := types.UnwrapResourceAccessIDs(resourceAccessIDs)
+	if len(plainIDs) > 0 {
+		// Plain resources should be in the old extension.
+		assert.ElementsMatch(t, plainIDs, sshCertLegacyResources, "SSH cert legacy extension should contain plain resource IDs")
+		// Sentinel should not be present.
+		for _, rid := range sshCertLegacyResources {
+			assert.False(t, types.IsSentinelResourceID(rid), "SSH cert legacy extension should not contain sentinel when plain resources are present")
+		}
+	} else if len(constrainedOnly) > 0 {
+		// Constraint-only requests should have the sentinel in the old extension.
+		require.Len(t, sshCertLegacyResources, 1, "SSH cert legacy extension should contain only sentinel")
+		assert.True(t, types.IsSentinelResourceID(sshCertLegacyResources[0]), "SSH cert legacy extension should be sentinel")
+	}
 }
 
 func TestCreateSuggestions(t *testing.T) {

--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -3831,6 +3831,7 @@ func generateCert(ctx context.Context, a *Server, req cert.Request, caType types
 	var (
 		scopePin                 *scopesv1.Pin
 		roleNames                []string
+		allowedResourceIDs       []types.ResourceID
 		allowedResourceAccessIDs []types.ResourceAccessID
 	)
 
@@ -3841,6 +3842,15 @@ func generateCert(ctx context.Context, a *Server, req cert.Request, caType types
 	if unscoped := certParams.UnscopedCertParams(); unscoped != nil {
 		roleNames = unscoped.RoleNames()
 		allowedResourceAccessIDs = unscoped.GetAllowedResourceAccessIDs()
+		// Separate out any plain ResourceIDs (those without constraints) so they
+		// can be written to the legacy AllowedResourceIDs cert extension. This
+		// ensures older agents/proxies that don't understand AllowedResourceAccessIDs
+		// still see the actual resource IDs instead of only the backwards-compat sentinel.
+		// ResourceAccessIDs are swallowed; we already have them
+		// and only want the plain (unconstrained) ResourceIDs.
+		//
+		// TODO(kiosion): DELETE in 21.0.0
+		allowedResourceIDs, _ = types.UnwrapResourceAccessIDs(allowedResourceAccessIDs)
 	}
 
 	var signedSSHCert []byte
@@ -3885,6 +3895,7 @@ func generateCert(ctx context.Context, a *Server, req cert.Request, caType types
 				DelegationSessionID:      req.DelegationSessionID,
 				JoinToken:                req.JoinToken,
 				CertificateExtensions:    certificateExtensions,
+				AllowedResourceIDs:       allowedResourceIDs,
 				AllowedResourceAccessIDs: allowedResourceAccessIDs,
 				ConnectionDiagnosticID:   req.ConnectionDiagnosticID,
 				PrivateKeyPolicy:         attestedKeyPolicy,
@@ -4028,6 +4039,7 @@ func generateCert(ctx context.Context, a *Server, req cert.Request, caType types
 		BotInternal:              req.BotInternal,
 		DelegationSessionID:      req.DelegationSessionID,
 		JoinToken:                req.JoinToken,
+		AllowedResourceIDs:       allowedResourceIDs,
 		AllowedResourceAccessIDs: allowedResourceAccessIDs,
 		PrivateKeyPolicy:         attestedKeyPolicy,
 		ConnectionDiagnosticID:   req.ConnectionDiagnosticID,

--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -3849,7 +3849,7 @@ func generateCert(ctx context.Context, a *Server, req cert.Request, caType types
 		// ResourceAccessIDs are swallowed; we already have them
 		// and only want the plain (unconstrained) ResourceIDs.
 		//
-		// TODO(kiosion): DELETE in 21.0.0
+		// TODO(kiosion): DELETE in 20.0.0
 		allowedResourceIDs, _ = types.UnwrapResourceAccessIDs(allowedResourceAccessIDs)
 	}
 

--- a/lib/sshca/identity.go
+++ b/lib/sshca/identity.go
@@ -524,8 +524,13 @@ func DecodeIdentity(cert *ssh.Certificate) (*Identity, error) {
 		}
 		allowedResourceAccessIDs = resourceAccessIDs
 	}
-	if len(allowedResourceIDs) > 0 || len(allowedResourceAccessIDs) > 0 {
-		ident.AllowedResourceAccessIDs = types.CombineAsResourceAccessIDs(allowedResourceIDs, allowedResourceAccessIDs)
+	if len(allowedResourceAccessIDs) > 0 {
+		// Prefer new extension when present, old extension is redundant
+		// (exists for backward-compat with older agents/proxies).
+		ident.AllowedResourceAccessIDs = allowedResourceAccessIDs
+	} else if len(allowedResourceIDs) > 0 {
+		// Fallback for certs from older auth servers that don't write the new extension.
+		ident.AllowedResourceAccessIDs = types.CombineAsResourceAccessIDs(allowedResourceIDs, nil)
 	}
 
 	ident.ConnectionDiagnosticID = takeValue(teleport.CertExtensionConnectionDiagnosticID)

--- a/lib/tlsca/ca.go
+++ b/lib/tlsca/ca.go
@@ -1457,8 +1457,13 @@ func FromSubject(subject pkix.Name, expires time.Time) (*Identity, error) {
 		}
 	}
 
-	if len(allowedResourceIDs) > 0 || len(allowedResourceAccessIDs) > 0 {
-		id.AllowedResourceAccessIDs = types.CombineAsResourceAccessIDs(allowedResourceIDs, allowedResourceAccessIDs)
+	if len(allowedResourceAccessIDs) > 0 {
+		// Prefer new extension when present, old extension is redundant
+		// (exists for backward-compat with older agents/proxies).
+		id.AllowedResourceAccessIDs = allowedResourceAccessIDs
+	} else if len(allowedResourceIDs) > 0 {
+		// Fallback for certs from older auth servers that don't write the new extension.
+		id.AllowedResourceAccessIDs = types.CombineAsResourceAccessIDs(allowedResourceIDs, nil)
 	}
 
 	if err := id.CheckAndSetDefaults(); err != nil {


### PR DESCRIPTION
Backport #66556 to branch/v18

changelog: Fixed resource-based access requests failing when node/ssh agents have not yet been updated to a version supporting Resource Constraints.


## Manual Test Plan
### Test Environment
-  Cluster with auth/proxy on latest v18 changes, and an SSH node agent on a pre-v18.7.3 binary (e.g. v18.7.0). 

### Test Cases
- Start auth and proxy from this branch build. Start an SSH node agent using a v18.7.0 binary. Create a role with search_as_roles granting access to the node. As a user with that role, create a resource-based access request: `tsh request create --resource /<cluster>/node/<node-uuid> --reason "test"`. Approve the request.
  - [x] Verify `tsh status` shows the actual resource under "Allowed Resources" (not __SENTINEL__).
  - [x]  Verify `tsh ssh <node-uuid>` succeeds against the old agent.
  - [x] **Test Backward compatibility** ( SSH  + TLS access path (ssh, app access))  - New(18.7.6+ fix)  Old (17.7.23) 
    - [x] New Auth + Old Proxy + Old Agent
    - [x] New Auth + New Proxy + Old Agent 
    - [x] New Auth + New Proxy + HA setup: New Agent, Old Agent 
    - [x] New Auth + New Proxy + HA setup: New Agent, New Agent -> Downgraded to  HA:  New Agent, Old Agent  (if this happens and the Access Request was created with constraints before downgrade the flow is not deterministic depending on the what agent will be picked, This seems to be acceptable since new Access Request will be issues with old semetics)  
    - [x] Test WebUI flow + TSH flow  for TLS and SSH cert
    - [x] After agent downgrade  the cert generated with constraints can't be use to connect to downgrade old agent. 