### PR TITLE
Add vulnerability management page to docs

### DIFF
--- a/docs/cspell.json
+++ b/docs/cspell.json
@@ -585,6 +585,7 @@
     "goteleport",
     "gotemplate",
     "gots",
+    "govulncheck",
     "goxmldsig",
     "gpgkey",
     "gpupdate",

--- a/docs/pages/reference/vulnerability-management.mdx
+++ b/docs/pages/reference/vulnerability-management.mdx
@@ -1,6 +1,10 @@
 ---
 title: "Vulnerability Management"
 description: "Explains how vulnerabilities in Teleport's products are managed."
+tags:
+ - reference
+ - resiliency
+ - platform-wide
 ---
 
 This page explains the processes and tools that Teleport uses to manage vulnerabilities in our products and supply chain.
@@ -15,25 +19,25 @@ Teleport uses the following methods to discover vulnerabilities in the code we w
 * Bug bounty program
 * LLM review of changes and existing code
 
-## Vulnerabilities in Teleport's Supply Chain
+## Vulnerabilities in Teleport's supply chain
 
 Teleport employs several software composition analysis tools to surface known vulnerabilities in the open source packages we use within the product.
 
-### Container Images
+### Container images
 
 Our container images are rebuilt nightly to pull in security updates from upstream base images.
 
-### Software Libraries
+### Software libraries
 
-We use GitHub Dependabot, Socket, and govulncheck to inventory known vulnerabilities in our software library dependencies.
+We use GitHub Dependabot and govulncheck to inventory known vulnerabilities in our software library dependencies.
 
-On a nightly basis, we run govulncheck to evaluate known CVEs impacting our product. Vulnerabilities which are not reachable from our code are not raised by govulncheck.
+On a nightly basis, we run govulncheck on the master branch and the release branches for supported Teleport versions to identify known CVEs impacting our product. Vulnerabilities which are not reachable from our code are not raised by govulncheck.
 
-Socket is used to scan across multiple ecosystems with similar reachability analysis.
+Dependabot runs continuously on the master branch to identify a broader set of software libraries with known vulnerabilities regardless of whether they impact Teleport.
 
-When a vulnerability in a software library is flagged by these tools as potentially reachable in our application, we prioritize fixing it promptly.
+When known vulnerabilities are flagged by these tools, we prioritize updating them promptly. Even when the issue does not impact Teleport, we address them in order to reduce the noise customers experience from their own scanners.
 
-GitHub Dependabot is used to track all CVEs in software libraries we use regardless of reachability. Our standard procedure is to patch known vulnerabilities in software libraries on a monthly basis.
+These updates are backported to supported release branches of Teleport as well.
 
 ## SLAs
 

--- a/docs/pages/reference/vulnerability-management.mdx
+++ b/docs/pages/reference/vulnerability-management.mdx
@@ -1,0 +1,60 @@
+---
+title: "Vulnerability Management in Teleport"
+description: "Explains how vulnerabilities in Teleport's products are managed."
+---
+
+This page explains the processes and tools that Teleport uses to manage vulnerabilities in our products and supply chain.
+
+## Vulnerabilities in Teleport
+
+Teleport uses the following methods to discover vulnerabilities in the code we write:
+
+* Multiple peer reviews on all production code changes
+* Several penetration tests per year
+* Annual red team engagements
+* Bug bounty program
+* LLM review of changes and existing code
+
+## Vulnerabilities in Teleport's Supply Chain
+
+Teleport employs several software composition analysis tools to surface known vulnerabilities in the open source packages we use within the product.
+
+### Container Images
+
+Our container images are rebuilt nightly to pull in security updates from upstream base images.
+
+### Software Libraries
+
+We use GitHub Dependabot, Socket, and govulncheck to inventory known vulnerabilities in our software library dependencies.
+
+On a nightly basis, we run govulncheck to evaluate known CVEs impacting our product. Vulnerabilities which are not reachable from our code are not raised by govulncheck.
+
+Socket is used to scan across multiple ecosystems with similar reachability analysis.
+
+When a vulnerability in a software library is flagged by these tools as potentially reachable in our application, we prioritize fixing it quickly, and typically merge the patch in within 1 week.
+
+GitHub Dependabot is used to track all CVEs in software libraries we use regardless of reachability. Our standard procedure is to patch known vulnerabilities in software libraries within on a monthly basis.
+
+## SLAs
+
+The timelines above reflect our typical procedures. We also maintain the following-policy level SLA commitments to patch vulnerabilities in both our code and our dependencies.
+
+These timelines are based on the severity of the vulnerability as determined by our team based on its impact to our product.
+
+| Severity        | Service Level Agreement |
+| --------------- | ----------------------- |
+| Critical        | 30 days                 |
+| High            | 60 days                 |
+| Medium and Low  | At our discretion       |
+
+## Exceptions
+
+In some cases, vulnerabilities cannot be patched within our typical update cadence. Some recent examples include:
+
+* Fixes were not yet available
+* Upstream maintainers determined the CVE was not a valid issue
+* The fix broke important functionality
+
+If Teleport's product is not impacted by the vulnerability, we will wait until the fix can be made safely.
+
+If Teleport's product is impacted by the vulnerability, we will seek an alternative mitigation strategy, and may require additional time to implement it safely.

--- a/docs/pages/reference/vulnerability-management.mdx
+++ b/docs/pages/reference/vulnerability-management.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Vulnerability Management in Teleport"
+title: "Vulnerability Management"
 description: "Explains how vulnerabilities in Teleport's products are managed."
 ---
 
@@ -31,13 +31,13 @@ On a nightly basis, we run govulncheck to evaluate known CVEs impacting our prod
 
 Socket is used to scan across multiple ecosystems with similar reachability analysis.
 
-When a vulnerability in a software library is flagged by these tools as potentially reachable in our application, we prioritize fixing it quickly, and typically merge the patch in within 1 week.
+When a vulnerability in a software library is flagged by these tools as potentially reachable in our application, we prioritize fixing it promptly.
 
-GitHub Dependabot is used to track all CVEs in software libraries we use regardless of reachability. Our standard procedure is to patch known vulnerabilities in software libraries within on a monthly basis.
+GitHub Dependabot is used to track all CVEs in software libraries we use regardless of reachability. Our standard procedure is to patch known vulnerabilities in software libraries on a monthly basis.
 
 ## SLAs
 
-The timelines above reflect our typical procedures. We also maintain the following-policy level SLA commitments to patch vulnerabilities in both our code and our dependencies.
+The timelines above reflect our typical procedures. We also maintain the following policy level SLA commitments to patch vulnerabilities in both our code and our dependencies.
 
 These timelines are based on the severity of the vulnerability as determined by our team based on its impact to our product.
 
@@ -49,12 +49,8 @@ These timelines are based on the severity of the vulnerability as determined by 
 
 ## Exceptions
 
-In some cases, vulnerabilities cannot be patched within our typical update cadence. Some recent examples include:
+In some cases, vulnerabilities cannot be patched within our typical update cadence. This may be because fixes are not yet available, upstream maintainers determined the CVE was not valid, or the fix breaks important functionality.
 
-* Fixes were not yet available
-* Upstream maintainers determined the CVE was not a valid issue
-* The fix broke important functionality
-
-If Teleport's product is not impacted by the vulnerability, we will wait until the fix can be made safely.
+If Teleport's product is not impacted by the vulnerability, we will wait until an official patch can be applied safely.
 
 If Teleport's product is impacted by the vulnerability, we will seek an alternative mitigation strategy, and may require additional time to implement it safely.


### PR DESCRIPTION
The goal is to clearly communicate our strategy for discovering and managing vulnerabilities in our code and supply chain.
