### PR TITLE
Stop loading host AWS config in mock provider

### DIFF
--- a/lib/cloud/mocks/aws_config.go
+++ b/lib/cloud/mocks/aws_config.go
@@ -51,7 +51,7 @@ func (f *AWSConfigProvider) GetConfig(ctx context.Context, region string, optFns
 		stsClt = &STSClient{}
 	}
 
-	// Build a minimal aws.Config without loading the developer's local shared config (~/.aws/config).
+	// Build a minimal aws.Config without loading the local machines shared config (~/.aws/config).
 	// Apply the assume-role chain manually using the mock STS client so tests can verify which roles were assumed.
 	cfg := aws.Config{Region: region}
 	stsClientProvider := NewAssumeRoleClientProviderFunc(stsClt)

--- a/lib/cloud/mocks/aws_config.go
+++ b/lib/cloud/mocks/aws_config.go
@@ -22,6 +22,8 @@ import (
 	"context"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/credentials/stscreds"
+	ststypes "github.com/aws/aws-sdk-go-v2/service/sts/types"
 	"github.com/gravitational/trace"
 
 	"github.com/gravitational/teleport/api/types"
@@ -48,13 +50,36 @@ func (f *AWSConfigProvider) GetConfig(ctx context.Context, region string, optFns
 	if stsClt == nil {
 		stsClt = &STSClient{}
 	}
-	optFns = append([]awsconfig.OptionsFn{
-		awsconfig.WithOIDCIntegrationClient(f.OIDCIntegrationClient),
-		awsconfig.WithSTSClientProvider(
-			NewAssumeRoleClientProviderFunc(stsClt),
-		),
-	}, optFns...)
-	return awsconfig.GetConfig(ctx, region, optFns...)
+
+	// Build a minimal aws.Config without loading the developer's local shared config (~/.aws/config).
+	// Apply the assume-role chain manually using the mock STS client so tests can verify which roles were assumed.
+	cfg := aws.Config{Region: region}
+	stsClientProvider := NewAssumeRoleClientProviderFunc(stsClt)
+	roles := awsconfig.AssumedRoles(optFns...)
+	for _, r := range roles {
+		cfg.Credentials = stscreds.NewAssumeRoleProvider(stsClientProvider(cfg), r.RoleARN, func(aro *stscreds.AssumeRoleOptions) {
+			if r.ExternalID != "" {
+				aro.ExternalID = aws.String(r.ExternalID)
+			}
+			if r.SessionName != "" {
+				aro.RoleSessionName = r.SessionName
+			}
+			aro.Duration = r.Duration
+			for k, v := range r.Tags {
+				aro.Tags = append(aro.Tags, ststypes.Tag{
+					Key:   aws.String(k),
+					Value: aws.String(v),
+				})
+			}
+		})
+	}
+	if len(roles) > 0 {
+		cfg.Credentials = aws.NewCredentialsCache(cfg.Credentials)
+		if _, err := cfg.Credentials.Retrieve(ctx); err != nil {
+			return aws.Config{}, trace.Wrap(err)
+		}
+	}
+	return cfg, nil
 }
 
 type FakeOIDCIntegrationClient struct {


### PR DESCRIPTION
Fixes failing `Test_DynamicKubeCreds` (and related EKS/discovery tests) on machines with non-trivial local AWS profiles.

It was giving me error when my aws config is present at ~/.aws/config. CI doesn't hit this because the buildbox container has no shared config file.

## Test

- [x] `go test ./lib/kube/proxy/ -run Test_DynamicKubeCreds -count=1`
- [x] `go test ./lib/cloud/mocks/... ./lib/kube/proxy/... ./lib/srv/db/... ./lib/srv/discovery/... ./lib/srv/app/aws/... -count=1`
