### PR TITLE
app: Fix stale comment in initApps

### DIFF
--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -6695,11 +6695,10 @@ var appDependEvents = []string{
 }
 
 func (process *TeleportProcess) initApps() {
-	// If no applications are specified, broadcast AppsReady so the
-	// process readiness gate is not blocked, then return. This is due
-	// to the strange behavior in reading file configuration. If the
-	// user does not specify an "app_service" section, that is
-	// considered enabling "app_service".
+	// If app_service is enabled but no apps, debug app, MCP demo
+	// server, or resource matchers are configured, there is nothing
+	// to proxy. Broadcast AppsReady so the process readiness gate is
+	// not blocked, then return.
 	if len(process.Config.Apps.Apps) == 0 &&
 		!process.Config.Apps.DebugApp &&
 		!process.Config.Apps.MCPDemoServer &&


### PR DESCRIPTION
Rewrite the early-return comment in `initApps`. The previous prose claimed that omitting an `app_service` section enables `app_service`. The call site is already gated by `cfg.Apps.Enabled`, which only flips to `true` inside `applyAppsConfig` when the file config explicitly opts in. `Apps` has no `defaultEnabled` override, unlike `Auth`, `Proxy`, `SSH`, and `Debug`.

Rewrite the comment to describe what the early return actually guards: return when `app_service` is enabled but has no apps, debug app, MCP demo server, or resource matchers configured.