### PR TITLE
[v18] Support `rds` matcher in `teleport/discovery/aws`

### DIFF
--- a/docs/pages/reference/infrastructure-as-code/terraform-modules/teleport-discovery-aws/teleport-discovery-aws.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-modules/teleport-discovery-aws/teleport-discovery-aws.mdx
@@ -139,7 +139,7 @@ No modules.
 | aws\_iam\_policy\_use\_name\_prefix | Determines whether the name of the AWS IAM policy (`aws_iam_policy_name`) is used as a prefix. | `bool` | `true` | no |
 | aws\_iam\_role\_name | Name for the AWS IAM role for discovery. | `string` | `"teleport-discovery"` | no |
 | aws\_iam\_role\_use\_name\_prefix | Determines whether the name of the AWS IAM role (`aws_iam_role_name`) is used as a prefix. | `bool` | `true` | no |
-| aws\_matchers | AWS resource discovery matchers. Valid values for aws\_matchers.types are: ec2, eks. | ```list(object({ types = list(string) regions = optional(list(string), ["*"]) tags = optional(map(list(string)), { "*" : ["*"] }) setup_access_for_arn = optional(string, "") kube_app_discovery = optional(bool) }))``` | `[]` | no |
+| aws\_matchers | AWS resource discovery matchers. Valid values for aws\_matchers.types are: ec2, eks, rds. | ```list(object({ types = list(string) regions = optional(list(string), ["*"]) tags = optional(map(list(string)), { "*" : ["*"] }) setup_access_for_arn = optional(string, "") kube_app_discovery = optional(bool) }))``` | `[]` | no |
 | create | Toggle creation of all resources. | `bool` | `true` | no |
 | create\_aws\_iam\_openid\_connect\_provider | Toggle AWS IAM OIDC provider creation. If false and using OIDC, then the AWS IAM OIDC provider must already exist. | `bool` | `true` | no |
 | discovery\_service\_iam\_credential\_source | Configure the AWS credential source for Teleport Discovery Service instances. The default uses AWS OIDC integration. | ```object({ use_oidc_integration = optional(bool, true) trust_role = optional(object({ role_arn = string external_id = optional(string, "") })) })``` | ```{ "trust_role": null, "use_oidc_integration": true }``` | no |

--- a/integrations/terraform-modules/teleport/discovery/aws/README.md
+++ b/integrations/terraform-modules/teleport/discovery/aws/README.md
@@ -125,7 +125,7 @@ No modules.
 | aws\_iam\_policy\_use\_name\_prefix | Determines whether the name of the AWS IAM policy (`aws_iam_policy_name`) is used as a prefix. | `bool` | `true` | no |
 | aws\_iam\_role\_name | Name for the AWS IAM role for discovery. | `string` | `"teleport-discovery"` | no |
 | aws\_iam\_role\_use\_name\_prefix | Determines whether the name of the AWS IAM role (`aws_iam_role_name`) is used as a prefix. | `bool` | `true` | no |
-| aws\_matchers | AWS resource discovery matchers. Valid values for aws\_matchers.types are: ec2, eks. | ```list(object({ types = list(string) regions = optional(list(string), ["*"]) tags = optional(map(list(string)), { "*" : ["*"] }) setup_access_for_arn = optional(string, "") kube_app_discovery = optional(bool) }))``` | `[]` | no |
+| aws\_matchers | AWS resource discovery matchers. Valid values for aws\_matchers.types are: ec2, eks, rds. | ```list(object({ types = list(string) regions = optional(list(string), ["*"]) tags = optional(map(list(string)), { "*" : ["*"] }) setup_access_for_arn = optional(string, "") kube_app_discovery = optional(bool) }))``` | `[]` | no |
 | create | Toggle creation of all resources. | `bool` | `true` | no |
 | create\_aws\_iam\_openid\_connect\_provider | Toggle AWS IAM OIDC provider creation. If false and using OIDC, then the AWS IAM OIDC provider must already exist. | `bool` | `true` | no |
 | discovery\_service\_iam\_credential\_source | Configure the AWS credential source for Teleport Discovery Service instances. The default uses AWS OIDC integration. | ```object({ use_oidc_integration = optional(bool, true) trust_role = optional(object({ role_arn = string external_id = optional(string, "") })) })``` | ```{ "trust_role": null, "use_oidc_integration": true }``` | no |

--- a/integrations/terraform-modules/teleport/discovery/aws/aws_iam_policy.tf
+++ b/integrations/terraform-modules/teleport/discovery/aws/aws_iam_policy.tf
@@ -16,6 +16,7 @@ locals {
 
   uses_ec2             = contains(local.aws_matcher_types, "ec2")
   uses_eks             = contains(local.aws_matcher_types, "eks")
+  uses_rds             = contains(local.aws_matcher_types, "rds")
   uses_wildcard_region = contains(local.aws_matcher_regions, "*")
 
   ec2_actions = [
@@ -38,10 +39,16 @@ locals {
     "eks:UpdateAccessEntry",
   ]
 
+  rds_actions = [
+    "rds:DescribeDBClusters",
+    "rds:DescribeDBInstances",
+  ]
+
   policy_actions = concat(
     local.uses_wildcard_region ? ["account:ListRegions"] : [],
     local.uses_ec2 ? local.ec2_actions : [],
     local.uses_eks ? local.eks_actions : [],
+    local.uses_rds ? local.rds_actions : [],
   )
 }
 

--- a/integrations/terraform-modules/teleport/discovery/aws/variables.tf
+++ b/integrations/terraform-modules/teleport/discovery/aws/variables.tf
@@ -42,7 +42,7 @@ variable "match_aws_resource_types" {
 }
 
 variable "aws_matchers" {
-  description = "AWS resource discovery matchers. Valid values for aws_matchers.types are: ec2, eks."
+  description = "AWS resource discovery matchers. Valid values for aws_matchers.types are: ec2, eks, rds."
   type = list(object({
     types                = list(string)
     regions              = optional(list(string), ["*"])
@@ -65,10 +65,14 @@ variable "aws_matchers" {
     condition = alltrue(flatten([
       for matcher in var.aws_matchers : [
         for rt in matcher.types :
-        contains(["ec2", "eks"], rt)
+        contains([
+          "ec2",
+          "eks",
+          "rds",
+        ], rt)
       ]
     ]))
-    error_message = "Allowed values for aws_matchers.types are: ec2, eks."
+    error_message = "Allowed values for aws_matchers.types are: ec2, eks, rds."
   }
 
   validation {


### PR DESCRIPTION
Backport #66600 to branch/v18

changelog: Added support for AWS RDS discovery in the `teleport/discovery/aws` Terraform module.

### Test Cases
- [x] Add `rds` to the module's matcher types input
  - [x] Verify that the AWS IAM policy is updated to include RDS discovery permissions
  - [x] Verify that the AWS RDS databases are discovered and `db` objects are created
