### PR TITLE
Optimize contains(split()) in resource expression parser

### DIFF
--- a/build.assets/tooling/go.mod
+++ b/build.assets/tooling/go.mod
@@ -313,5 +313,5 @@ replace (
 	github.com/microsoft/go-mssqldb => github.com/gravitational/go-mssqldb v1.8.1-teleport.2
 	github.com/opencontainers/selinux => github.com/gravitational/selinux v1.13.0-teleport
 	github.com/redis/go-redis/v9 => github.com/gravitational/redis/v9 v9.6.1-teleport.1
-	github.com/vulcand/predicate => github.com/gravitational/predicate v1.3.4
+	github.com/vulcand/predicate => github.com/gravitational/predicate v1.3.5-0.20260511125330-ddfb710e0084
 )

--- a/build.assets/tooling/go.mod
+++ b/build.assets/tooling/go.mod
@@ -299,7 +299,7 @@ require (
 )
 
 replace (
-	github.com/alecthomas/kingpin/v2 => github.com/gravitational/kingpin/v2 v2.1.11-0.20260417152838-9efcbe7e5d61
+	github.com/alecthomas/kingpin/v2 => github.com/gravitational/kingpin/v2 v2.1.11-0.20260507144047-1f18894764f5
 	github.com/crewjam/saml => github.com/gravitational/saml v0.4.15-teleport.2
 	github.com/datastax/go-cassandra-native-protocol => github.com/gravitational/go-cassandra-native-protocol v0.0.0-teleport.3
 	github.com/go-mysql-org/go-mysql => github.com/gravitational/go-mysql v1.9.1-teleport.4
@@ -313,5 +313,5 @@ replace (
 	github.com/microsoft/go-mssqldb => github.com/gravitational/go-mssqldb v1.8.1-teleport.2
 	github.com/opencontainers/selinux => github.com/gravitational/selinux v1.13.0-teleport
 	github.com/redis/go-redis/v9 => github.com/gravitational/redis/v9 v9.6.1-teleport.1
-	github.com/vulcand/predicate => github.com/gravitational/predicate v1.3.5-0.20260511125330-ddfb710e0084
+	github.com/vulcand/predicate => github.com/gravitational/predicate v1.4.0
 )

--- a/build.assets/tooling/go.sum
+++ b/build.assets/tooling/go.sum
@@ -484,12 +484,12 @@ github.com/gravitational/go-libfido2 v1.5.3-teleport.1 h1:nPfxiTH2Sr3J6zan280fbH
 github.com/gravitational/go-libfido2 v1.5.3-teleport.1/go.mod h1:92J9LtSBl0UyUWljElJpTbMMNhC6VeY8dshsu40qjjo=
 github.com/gravitational/httprouter v1.3.1-0.20220408074523-c876c5e705a5 h1:qg8FcGwRACSHortU1UxCSo9nF0t34rPWjk9Nef3j2Ic=
 github.com/gravitational/httprouter v1.3.1-0.20220408074523-c876c5e705a5/go.mod h1:JR6WtHb+2LUe8TCKY3cZOxFyyO8IZAc4RVcycCCAKdM=
-github.com/gravitational/kingpin/v2 v2.1.11-0.20260417152838-9efcbe7e5d61 h1:cgG/o1SAL2WK9AtryT/esiuXqCN47f15EwppKgeom60=
-github.com/gravitational/kingpin/v2 v2.1.11-0.20260417152838-9efcbe7e5d61/go.mod h1:usbNrkVhUGh5+Pqd4u5tYKszWmq6YSCApkePRMmJFP8=
+github.com/gravitational/kingpin/v2 v2.1.11-0.20260507144047-1f18894764f5 h1:E7lyOeBLDh+3N3cAKT+dC343tAP5uJxyUJDGFxi+q5Y=
+github.com/gravitational/kingpin/v2 v2.1.11-0.20260507144047-1f18894764f5/go.mod h1:usbNrkVhUGh5+Pqd4u5tYKszWmq6YSCApkePRMmJFP8=
 github.com/gravitational/license v0.0.0-20250329001817-070456fa8ec1 h1:Kt7aT9N7vbZmcMejGXnSAGap8TUwH3fMoHE8cQm14wc=
 github.com/gravitational/license v0.0.0-20250329001817-070456fa8ec1/go.mod h1:n4RXV6T3SJ/vrJqmc4vBeHpaBspxWENDD67ssQlXXkg=
-github.com/gravitational/predicate v1.3.5-0.20260511125330-ddfb710e0084 h1:BRWNqpuSl2EETF4k059dNa0UnDcEfKJFs4DPVHPRU/E=
-github.com/gravitational/predicate v1.3.5-0.20260511125330-ddfb710e0084/go.mod h1:cTQkp40X3YejTcWsZGvzAtfa28VXfBxT10H/Grt0Fzs=
+github.com/gravitational/predicate v1.4.0 h1:vyaPQ04DQq083k6CAcM0fyGYoSUt8ZsIdn1gSkDRE+g=
+github.com/gravitational/predicate v1.4.0/go.mod h1:cTQkp40X3YejTcWsZGvzAtfa28VXfBxT10H/Grt0Fzs=
 github.com/gravitational/protobuf v1.3.2-teleport.2 h1:MO5eFXfGfDiAbBA7X8tDW2EMLfRWQVJMmK+MA6gV8AI=
 github.com/gravitational/protobuf v1.3.2-teleport.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
 github.com/gravitational/roundtrip v1.0.3 h1:n5JLvJVs8XrnJxXGYOzb8I9zGMEr5WVhSA1qGuxzwnU=

--- a/build.assets/tooling/go.sum
+++ b/build.assets/tooling/go.sum
@@ -488,8 +488,8 @@ github.com/gravitational/kingpin/v2 v2.1.11-0.20260417152838-9efcbe7e5d61 h1:cgG
 github.com/gravitational/kingpin/v2 v2.1.11-0.20260417152838-9efcbe7e5d61/go.mod h1:usbNrkVhUGh5+Pqd4u5tYKszWmq6YSCApkePRMmJFP8=
 github.com/gravitational/license v0.0.0-20250329001817-070456fa8ec1 h1:Kt7aT9N7vbZmcMejGXnSAGap8TUwH3fMoHE8cQm14wc=
 github.com/gravitational/license v0.0.0-20250329001817-070456fa8ec1/go.mod h1:n4RXV6T3SJ/vrJqmc4vBeHpaBspxWENDD67ssQlXXkg=
-github.com/gravitational/predicate v1.3.4 h1:9N3JhBXNPcUh0w8DdlpnVmfnH9Z3xxbw43sD3E19VBE=
-github.com/gravitational/predicate v1.3.4/go.mod h1:cTQkp40X3YejTcWsZGvzAtfa28VXfBxT10H/Grt0Fzs=
+github.com/gravitational/predicate v1.3.5-0.20260511125330-ddfb710e0084 h1:BRWNqpuSl2EETF4k059dNa0UnDcEfKJFs4DPVHPRU/E=
+github.com/gravitational/predicate v1.3.5-0.20260511125330-ddfb710e0084/go.mod h1:cTQkp40X3YejTcWsZGvzAtfa28VXfBxT10H/Grt0Fzs=
 github.com/gravitational/protobuf v1.3.2-teleport.2 h1:MO5eFXfGfDiAbBA7X8tDW2EMLfRWQVJMmK+MA6gV8AI=
 github.com/gravitational/protobuf v1.3.2-teleport.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
 github.com/gravitational/roundtrip v1.0.3 h1:n5JLvJVs8XrnJxXGYOzb8I9zGMEr5WVhSA1qGuxzwnU=

--- a/e2e/runner/go.mod
+++ b/e2e/runner/go.mod
@@ -307,5 +307,5 @@ replace (
 	github.com/microsoft/go-mssqldb => github.com/gravitational/go-mssqldb v1.8.1-teleport.2
 	github.com/opencontainers/selinux => github.com/gravitational/selinux v1.13.0-teleport
 	github.com/redis/go-redis/v9 => github.com/gravitational/redis/v9 v9.6.1-teleport.1
-	github.com/vulcand/predicate => github.com/gravitational/predicate v1.3.4
+	github.com/vulcand/predicate => github.com/gravitational/predicate v1.3.5-0.20260511125330-ddfb710e0084
 )

--- a/e2e/runner/go.mod
+++ b/e2e/runner/go.mod
@@ -294,7 +294,7 @@ require (
 )
 
 replace (
-	github.com/alecthomas/kingpin/v2 => github.com/gravitational/kingpin/v2 v2.1.11-0.20260417152838-9efcbe7e5d61
+	github.com/alecthomas/kingpin/v2 => github.com/gravitational/kingpin/v2 v2.1.11-0.20260507144047-1f18894764f5
 	github.com/crewjam/saml => github.com/gravitational/saml v0.4.15-teleport.2
 	github.com/datastax/go-cassandra-native-protocol => github.com/gravitational/go-cassandra-native-protocol v0.0.0-teleport.3
 	github.com/go-mysql-org/go-mysql => github.com/gravitational/go-mysql v1.9.1-teleport.4
@@ -308,5 +308,5 @@ replace (
 	github.com/microsoft/go-mssqldb => github.com/gravitational/go-mssqldb v1.8.1-teleport.2
 	github.com/opencontainers/selinux => github.com/gravitational/selinux v1.13.0-teleport
 	github.com/redis/go-redis/v9 => github.com/gravitational/redis/v9 v9.6.1-teleport.1
-	github.com/vulcand/predicate => github.com/gravitational/predicate v1.3.5-0.20260511125330-ddfb710e0084
+	github.com/vulcand/predicate => github.com/gravitational/predicate v1.4.0
 )

--- a/e2e/runner/go.mod
+++ b/e2e/runner/go.mod
@@ -270,6 +270,7 @@ require (
 	golang.org/x/term v0.42.0 // indirect
 	golang.org/x/text v0.36.0 // indirect
 	golang.org/x/time v0.15.0 // indirect
+	golang.org/x/tools v0.44.0 // indirect
 	google.golang.org/api v0.272.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260401024825-9d38bb4040a9 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260406210006-6f92a3bedf2d // indirect

--- a/e2e/runner/go.sum
+++ b/e2e/runner/go.sum
@@ -478,12 +478,12 @@ github.com/gravitational/go-libfido2 v1.5.3-teleport.1 h1:nPfxiTH2Sr3J6zan280fbH
 github.com/gravitational/go-libfido2 v1.5.3-teleport.1/go.mod h1:92J9LtSBl0UyUWljElJpTbMMNhC6VeY8dshsu40qjjo=
 github.com/gravitational/httprouter v1.3.1-0.20220408074523-c876c5e705a5 h1:qg8FcGwRACSHortU1UxCSo9nF0t34rPWjk9Nef3j2Ic=
 github.com/gravitational/httprouter v1.3.1-0.20220408074523-c876c5e705a5/go.mod h1:JR6WtHb+2LUe8TCKY3cZOxFyyO8IZAc4RVcycCCAKdM=
-github.com/gravitational/kingpin/v2 v2.1.11-0.20260417152838-9efcbe7e5d61 h1:cgG/o1SAL2WK9AtryT/esiuXqCN47f15EwppKgeom60=
-github.com/gravitational/kingpin/v2 v2.1.11-0.20260417152838-9efcbe7e5d61/go.mod h1:usbNrkVhUGh5+Pqd4u5tYKszWmq6YSCApkePRMmJFP8=
+github.com/gravitational/kingpin/v2 v2.1.11-0.20260507144047-1f18894764f5 h1:E7lyOeBLDh+3N3cAKT+dC343tAP5uJxyUJDGFxi+q5Y=
+github.com/gravitational/kingpin/v2 v2.1.11-0.20260507144047-1f18894764f5/go.mod h1:usbNrkVhUGh5+Pqd4u5tYKszWmq6YSCApkePRMmJFP8=
 github.com/gravitational/license v0.0.0-20250329001817-070456fa8ec1 h1:Kt7aT9N7vbZmcMejGXnSAGap8TUwH3fMoHE8cQm14wc=
 github.com/gravitational/license v0.0.0-20250329001817-070456fa8ec1/go.mod h1:n4RXV6T3SJ/vrJqmc4vBeHpaBspxWENDD67ssQlXXkg=
-github.com/gravitational/predicate v1.3.5-0.20260511125330-ddfb710e0084 h1:BRWNqpuSl2EETF4k059dNa0UnDcEfKJFs4DPVHPRU/E=
-github.com/gravitational/predicate v1.3.5-0.20260511125330-ddfb710e0084/go.mod h1:cTQkp40X3YejTcWsZGvzAtfa28VXfBxT10H/Grt0Fzs=
+github.com/gravitational/predicate v1.4.0 h1:vyaPQ04DQq083k6CAcM0fyGYoSUt8ZsIdn1gSkDRE+g=
+github.com/gravitational/predicate v1.4.0/go.mod h1:cTQkp40X3YejTcWsZGvzAtfa28VXfBxT10H/Grt0Fzs=
 github.com/gravitational/protobuf v1.3.2-teleport.2 h1:MO5eFXfGfDiAbBA7X8tDW2EMLfRWQVJMmK+MA6gV8AI=
 github.com/gravitational/protobuf v1.3.2-teleport.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
 github.com/gravitational/roundtrip v1.0.3 h1:n5JLvJVs8XrnJxXGYOzb8I9zGMEr5WVhSA1qGuxzwnU=

--- a/e2e/runner/go.sum
+++ b/e2e/runner/go.sum
@@ -482,8 +482,8 @@ github.com/gravitational/kingpin/v2 v2.1.11-0.20260417152838-9efcbe7e5d61 h1:cgG
 github.com/gravitational/kingpin/v2 v2.1.11-0.20260417152838-9efcbe7e5d61/go.mod h1:usbNrkVhUGh5+Pqd4u5tYKszWmq6YSCApkePRMmJFP8=
 github.com/gravitational/license v0.0.0-20250329001817-070456fa8ec1 h1:Kt7aT9N7vbZmcMejGXnSAGap8TUwH3fMoHE8cQm14wc=
 github.com/gravitational/license v0.0.0-20250329001817-070456fa8ec1/go.mod h1:n4RXV6T3SJ/vrJqmc4vBeHpaBspxWENDD67ssQlXXkg=
-github.com/gravitational/predicate v1.3.4 h1:9N3JhBXNPcUh0w8DdlpnVmfnH9Z3xxbw43sD3E19VBE=
-github.com/gravitational/predicate v1.3.4/go.mod h1:cTQkp40X3YejTcWsZGvzAtfa28VXfBxT10H/Grt0Fzs=
+github.com/gravitational/predicate v1.3.5-0.20260511125330-ddfb710e0084 h1:BRWNqpuSl2EETF4k059dNa0UnDcEfKJFs4DPVHPRU/E=
+github.com/gravitational/predicate v1.3.5-0.20260511125330-ddfb710e0084/go.mod h1:cTQkp40X3YejTcWsZGvzAtfa28VXfBxT10H/Grt0Fzs=
 github.com/gravitational/protobuf v1.3.2-teleport.2 h1:MO5eFXfGfDiAbBA7X8tDW2EMLfRWQVJMmK+MA6gV8AI=
 github.com/gravitational/protobuf v1.3.2-teleport.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
 github.com/gravitational/roundtrip v1.0.3 h1:n5JLvJVs8XrnJxXGYOzb8I9zGMEr5WVhSA1qGuxzwnU=

--- a/go.mod
+++ b/go.mod
@@ -256,6 +256,7 @@ require (
 	golang.org/x/term v0.42.0
 	golang.org/x/text v0.36.0
 	golang.org/x/time v0.15.0
+	golang.org/x/tools v0.44.0
 	golang.zx2c4.com/wireguard v0.0.0-20231211153847-12269c276173
 	golang.zx2c4.com/wireguard/windows v0.5.3
 	google.golang.org/api v0.272.0
@@ -597,7 +598,6 @@ require (
 	go.yaml.in/yaml/v2 v2.4.3 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/telemetry v0.0.0-20260409153401-be6f6cb8b1fa // indirect
-	golang.org/x/tools v0.44.0 // indirect
 	golang.org/x/xerrors v0.0.0-20240903120638-7835f813f4da // indirect
 	golang.zx2c4.com/wintun v0.0.0-20230126152724-0fa3db229ce2 // indirect
 	gomodules.xyz/jsonpatch/v2 v2.4.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -639,5 +639,5 @@ replace (
 	github.com/microsoft/go-mssqldb => github.com/gravitational/go-mssqldb v1.8.1-teleport.2
 	github.com/opencontainers/selinux => github.com/gravitational/selinux v1.13.0-teleport
 	github.com/redis/go-redis/v9 => github.com/gravitational/redis/v9 v9.6.1-teleport.1
-	github.com/vulcand/predicate => github.com/gravitational/predicate v1.3.5-0.20260511125330-ddfb710e0084
+	github.com/vulcand/predicate => github.com/gravitational/predicate v1.4.0
 )

--- a/go.mod
+++ b/go.mod
@@ -639,5 +639,5 @@ replace (
 	github.com/microsoft/go-mssqldb => github.com/gravitational/go-mssqldb v1.8.1-teleport.2
 	github.com/opencontainers/selinux => github.com/gravitational/selinux v1.13.0-teleport
 	github.com/redis/go-redis/v9 => github.com/gravitational/redis/v9 v9.6.1-teleport.1
-	github.com/vulcand/predicate => github.com/gravitational/predicate v1.3.4
+	github.com/vulcand/predicate => github.com/gravitational/predicate v1.3.5-0.20260511125330-ddfb710e0084
 )

--- a/go.sum
+++ b/go.sum
@@ -793,8 +793,8 @@ github.com/gravitational/kingpin/v2 v2.1.11-0.20260507144047-1f18894764f5 h1:E7l
 github.com/gravitational/kingpin/v2 v2.1.11-0.20260507144047-1f18894764f5/go.mod h1:usbNrkVhUGh5+Pqd4u5tYKszWmq6YSCApkePRMmJFP8=
 github.com/gravitational/license v0.0.0-20250329001817-070456fa8ec1 h1:Kt7aT9N7vbZmcMejGXnSAGap8TUwH3fMoHE8cQm14wc=
 github.com/gravitational/license v0.0.0-20250329001817-070456fa8ec1/go.mod h1:n4RXV6T3SJ/vrJqmc4vBeHpaBspxWENDD67ssQlXXkg=
-github.com/gravitational/predicate v1.3.4 h1:9N3JhBXNPcUh0w8DdlpnVmfnH9Z3xxbw43sD3E19VBE=
-github.com/gravitational/predicate v1.3.4/go.mod h1:cTQkp40X3YejTcWsZGvzAtfa28VXfBxT10H/Grt0Fzs=
+github.com/gravitational/predicate v1.3.5-0.20260511125330-ddfb710e0084 h1:BRWNqpuSl2EETF4k059dNa0UnDcEfKJFs4DPVHPRU/E=
+github.com/gravitational/predicate v1.3.5-0.20260511125330-ddfb710e0084/go.mod h1:cTQkp40X3YejTcWsZGvzAtfa28VXfBxT10H/Grt0Fzs=
 github.com/gravitational/protobuf v1.3.2-teleport.2 h1:MO5eFXfGfDiAbBA7X8tDW2EMLfRWQVJMmK+MA6gV8AI=
 github.com/gravitational/protobuf v1.3.2-teleport.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
 github.com/gravitational/redis/v9 v9.6.1-teleport.1 h1:gPirfPKArN2nPhTKR3h9fnEg5YuYU933+CjlDJMo4H0=

--- a/go.sum
+++ b/go.sum
@@ -793,8 +793,8 @@ github.com/gravitational/kingpin/v2 v2.1.11-0.20260507144047-1f18894764f5 h1:E7l
 github.com/gravitational/kingpin/v2 v2.1.11-0.20260507144047-1f18894764f5/go.mod h1:usbNrkVhUGh5+Pqd4u5tYKszWmq6YSCApkePRMmJFP8=
 github.com/gravitational/license v0.0.0-20250329001817-070456fa8ec1 h1:Kt7aT9N7vbZmcMejGXnSAGap8TUwH3fMoHE8cQm14wc=
 github.com/gravitational/license v0.0.0-20250329001817-070456fa8ec1/go.mod h1:n4RXV6T3SJ/vrJqmc4vBeHpaBspxWENDD67ssQlXXkg=
-github.com/gravitational/predicate v1.3.5-0.20260511125330-ddfb710e0084 h1:BRWNqpuSl2EETF4k059dNa0UnDcEfKJFs4DPVHPRU/E=
-github.com/gravitational/predicate v1.3.5-0.20260511125330-ddfb710e0084/go.mod h1:cTQkp40X3YejTcWsZGvzAtfa28VXfBxT10H/Grt0Fzs=
+github.com/gravitational/predicate v1.4.0 h1:vyaPQ04DQq083k6CAcM0fyGYoSUt8ZsIdn1gSkDRE+g=
+github.com/gravitational/predicate v1.4.0/go.mod h1:cTQkp40X3YejTcWsZGvzAtfa28VXfBxT10H/Grt0Fzs=
 github.com/gravitational/protobuf v1.3.2-teleport.2 h1:MO5eFXfGfDiAbBA7X8tDW2EMLfRWQVJMmK+MA6gV8AI=
 github.com/gravitational/protobuf v1.3.2-teleport.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
 github.com/gravitational/redis/v9 v9.6.1-teleport.1 h1:gPirfPKArN2nPhTKR3h9fnEg5YuYU933+CjlDJMo4H0=

--- a/integrations/event-handler/go.mod
+++ b/integrations/event-handler/go.mod
@@ -410,5 +410,5 @@ replace (
 	github.com/microsoft/go-mssqldb => github.com/gravitational/go-mssqldb v1.8.1-teleport.2
 	github.com/opencontainers/selinux => github.com/gravitational/selinux v1.13.0-teleport
 	github.com/redis/go-redis/v9 => github.com/gravitational/redis/v9 v9.6.1-teleport.1
-	github.com/vulcand/predicate => github.com/gravitational/predicate v1.3.4
+	github.com/vulcand/predicate => github.com/gravitational/predicate v1.3.5-0.20260511125330-ddfb710e0084
 )

--- a/integrations/event-handler/go.mod
+++ b/integrations/event-handler/go.mod
@@ -397,7 +397,7 @@ require (
 )
 
 replace (
-	github.com/alecthomas/kingpin/v2 => github.com/gravitational/kingpin/v2 v2.1.11-0.20260417152838-9efcbe7e5d61
+	github.com/alecthomas/kingpin/v2 => github.com/gravitational/kingpin/v2 v2.1.11-0.20260507144047-1f18894764f5
 	github.com/crewjam/saml => github.com/gravitational/saml v0.4.15-teleport.2
 	github.com/datastax/go-cassandra-native-protocol => github.com/gravitational/go-cassandra-native-protocol v0.0.0-teleport.3
 	github.com/go-mysql-org/go-mysql => github.com/gravitational/go-mysql v1.9.1-teleport.4
@@ -411,5 +411,5 @@ replace (
 	github.com/microsoft/go-mssqldb => github.com/gravitational/go-mssqldb v1.8.1-teleport.2
 	github.com/opencontainers/selinux => github.com/gravitational/selinux v1.13.0-teleport
 	github.com/redis/go-redis/v9 => github.com/gravitational/redis/v9 v9.6.1-teleport.1
-	github.com/vulcand/predicate => github.com/gravitational/predicate v1.3.5-0.20260511125330-ddfb710e0084
+	github.com/vulcand/predicate => github.com/gravitational/predicate v1.4.0
 )

--- a/integrations/event-handler/go.mod
+++ b/integrations/event-handler/go.mod
@@ -357,6 +357,7 @@ require (
 	golang.org/x/sys v0.43.0 // indirect
 	golang.org/x/term v0.42.0 // indirect
 	golang.org/x/text v0.36.0 // indirect
+	golang.org/x/tools v0.44.0 // indirect
 	google.golang.org/api v0.272.0 // indirect
 	google.golang.org/genproto v0.0.0-20260316180232-0b37fe3546d5 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260401024825-9d38bb4040a9 // indirect

--- a/integrations/event-handler/go.sum
+++ b/integrations/event-handler/go.sum
@@ -531,12 +531,12 @@ github.com/gravitational/go-mysql v1.9.1-teleport.4 h1:2Lt2fcEMrco6apu8jme0mj6OS
 github.com/gravitational/go-mysql v1.9.1-teleport.4/go.mod h1:pkllauQtJgHr2mTonYYysOznctozxiWgwpKAez0s+2U=
 github.com/gravitational/httprouter v1.3.1-0.20220408074523-c876c5e705a5 h1:qg8FcGwRACSHortU1UxCSo9nF0t34rPWjk9Nef3j2Ic=
 github.com/gravitational/httprouter v1.3.1-0.20220408074523-c876c5e705a5/go.mod h1:JR6WtHb+2LUe8TCKY3cZOxFyyO8IZAc4RVcycCCAKdM=
-github.com/gravitational/kingpin/v2 v2.1.11-0.20260417152838-9efcbe7e5d61 h1:cgG/o1SAL2WK9AtryT/esiuXqCN47f15EwppKgeom60=
-github.com/gravitational/kingpin/v2 v2.1.11-0.20260417152838-9efcbe7e5d61/go.mod h1:usbNrkVhUGh5+Pqd4u5tYKszWmq6YSCApkePRMmJFP8=
+github.com/gravitational/kingpin/v2 v2.1.11-0.20260507144047-1f18894764f5 h1:E7lyOeBLDh+3N3cAKT+dC343tAP5uJxyUJDGFxi+q5Y=
+github.com/gravitational/kingpin/v2 v2.1.11-0.20260507144047-1f18894764f5/go.mod h1:usbNrkVhUGh5+Pqd4u5tYKszWmq6YSCApkePRMmJFP8=
 github.com/gravitational/license v0.0.0-20250329001817-070456fa8ec1 h1:Kt7aT9N7vbZmcMejGXnSAGap8TUwH3fMoHE8cQm14wc=
 github.com/gravitational/license v0.0.0-20250329001817-070456fa8ec1/go.mod h1:n4RXV6T3SJ/vrJqmc4vBeHpaBspxWENDD67ssQlXXkg=
-github.com/gravitational/predicate v1.3.5-0.20260511125330-ddfb710e0084 h1:BRWNqpuSl2EETF4k059dNa0UnDcEfKJFs4DPVHPRU/E=
-github.com/gravitational/predicate v1.3.5-0.20260511125330-ddfb710e0084/go.mod h1:cTQkp40X3YejTcWsZGvzAtfa28VXfBxT10H/Grt0Fzs=
+github.com/gravitational/predicate v1.4.0 h1:vyaPQ04DQq083k6CAcM0fyGYoSUt8ZsIdn1gSkDRE+g=
+github.com/gravitational/predicate v1.4.0/go.mod h1:cTQkp40X3YejTcWsZGvzAtfa28VXfBxT10H/Grt0Fzs=
 github.com/gravitational/protobuf v1.3.2-teleport.2 h1:MO5eFXfGfDiAbBA7X8tDW2EMLfRWQVJMmK+MA6gV8AI=
 github.com/gravitational/protobuf v1.3.2-teleport.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
 github.com/gravitational/redis/v9 v9.6.1-teleport.1 h1:gPirfPKArN2nPhTKR3h9fnEg5YuYU933+CjlDJMo4H0=

--- a/integrations/event-handler/go.sum
+++ b/integrations/event-handler/go.sum
@@ -535,8 +535,8 @@ github.com/gravitational/kingpin/v2 v2.1.11-0.20260417152838-9efcbe7e5d61 h1:cgG
 github.com/gravitational/kingpin/v2 v2.1.11-0.20260417152838-9efcbe7e5d61/go.mod h1:usbNrkVhUGh5+Pqd4u5tYKszWmq6YSCApkePRMmJFP8=
 github.com/gravitational/license v0.0.0-20250329001817-070456fa8ec1 h1:Kt7aT9N7vbZmcMejGXnSAGap8TUwH3fMoHE8cQm14wc=
 github.com/gravitational/license v0.0.0-20250329001817-070456fa8ec1/go.mod h1:n4RXV6T3SJ/vrJqmc4vBeHpaBspxWENDD67ssQlXXkg=
-github.com/gravitational/predicate v1.3.4 h1:9N3JhBXNPcUh0w8DdlpnVmfnH9Z3xxbw43sD3E19VBE=
-github.com/gravitational/predicate v1.3.4/go.mod h1:cTQkp40X3YejTcWsZGvzAtfa28VXfBxT10H/Grt0Fzs=
+github.com/gravitational/predicate v1.3.5-0.20260511125330-ddfb710e0084 h1:BRWNqpuSl2EETF4k059dNa0UnDcEfKJFs4DPVHPRU/E=
+github.com/gravitational/predicate v1.3.5-0.20260511125330-ddfb710e0084/go.mod h1:cTQkp40X3YejTcWsZGvzAtfa28VXfBxT10H/Grt0Fzs=
 github.com/gravitational/protobuf v1.3.2-teleport.2 h1:MO5eFXfGfDiAbBA7X8tDW2EMLfRWQVJMmK+MA6gV8AI=
 github.com/gravitational/protobuf v1.3.2-teleport.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
 github.com/gravitational/redis/v9 v9.6.1-teleport.1 h1:gPirfPKArN2nPhTKR3h9fnEg5YuYU933+CjlDJMo4H0=

--- a/integrations/terraform-mwi/go.mod
+++ b/integrations/terraform-mwi/go.mod
@@ -528,7 +528,7 @@ require (
 )
 
 replace (
-	github.com/alecthomas/kingpin/v2 => github.com/gravitational/kingpin/v2 v2.1.11-0.20260417152838-9efcbe7e5d61
+	github.com/alecthomas/kingpin/v2 => github.com/gravitational/kingpin/v2 v2.1.11-0.20260507144047-1f18894764f5
 	github.com/crewjam/saml => github.com/gravitational/saml v0.4.15-teleport.2
 	github.com/datastax/go-cassandra-native-protocol => github.com/gravitational/go-cassandra-native-protocol v0.0.0-teleport.3
 	github.com/go-mysql-org/go-mysql => github.com/gravitational/go-mysql v1.9.1-teleport.4
@@ -542,7 +542,7 @@ replace (
 	github.com/microsoft/go-mssqldb => github.com/gravitational/go-mssqldb v1.8.1-teleport.2
 	github.com/opencontainers/selinux => github.com/gravitational/selinux v1.13.0-teleport
 	github.com/redis/go-redis/v9 => github.com/gravitational/redis/v9 v9.6.1-teleport.1
-	github.com/vulcand/predicate => github.com/gravitational/predicate v1.3.5-0.20260511125330-ddfb710e0084
+	github.com/vulcand/predicate => github.com/gravitational/predicate v1.4.0
 )
 
 // Doc generation tooling.

--- a/integrations/terraform-mwi/go.mod
+++ b/integrations/terraform-mwi/go.mod
@@ -542,7 +542,7 @@ replace (
 	github.com/microsoft/go-mssqldb => github.com/gravitational/go-mssqldb v1.8.1-teleport.2
 	github.com/opencontainers/selinux => github.com/gravitational/selinux v1.13.0-teleport
 	github.com/redis/go-redis/v9 => github.com/gravitational/redis/v9 v9.6.1-teleport.1
-	github.com/vulcand/predicate => github.com/gravitational/predicate v1.3.4
+	github.com/vulcand/predicate => github.com/gravitational/predicate v1.3.5-0.20260511125330-ddfb710e0084
 )
 
 // Doc generation tooling.

--- a/integrations/terraform-mwi/go.sum
+++ b/integrations/terraform-mwi/go.sum
@@ -735,8 +735,8 @@ github.com/gravitational/kingpin/v2 v2.1.11-0.20260417152838-9efcbe7e5d61 h1:cgG
 github.com/gravitational/kingpin/v2 v2.1.11-0.20260417152838-9efcbe7e5d61/go.mod h1:usbNrkVhUGh5+Pqd4u5tYKszWmq6YSCApkePRMmJFP8=
 github.com/gravitational/license v0.0.0-20250329001817-070456fa8ec1 h1:Kt7aT9N7vbZmcMejGXnSAGap8TUwH3fMoHE8cQm14wc=
 github.com/gravitational/license v0.0.0-20250329001817-070456fa8ec1/go.mod h1:n4RXV6T3SJ/vrJqmc4vBeHpaBspxWENDD67ssQlXXkg=
-github.com/gravitational/predicate v1.3.4 h1:9N3JhBXNPcUh0w8DdlpnVmfnH9Z3xxbw43sD3E19VBE=
-github.com/gravitational/predicate v1.3.4/go.mod h1:cTQkp40X3YejTcWsZGvzAtfa28VXfBxT10H/Grt0Fzs=
+github.com/gravitational/predicate v1.3.5-0.20260511125330-ddfb710e0084 h1:BRWNqpuSl2EETF4k059dNa0UnDcEfKJFs4DPVHPRU/E=
+github.com/gravitational/predicate v1.3.5-0.20260511125330-ddfb710e0084/go.mod h1:cTQkp40X3YejTcWsZGvzAtfa28VXfBxT10H/Grt0Fzs=
 github.com/gravitational/protobuf v1.3.2-teleport.2 h1:MO5eFXfGfDiAbBA7X8tDW2EMLfRWQVJMmK+MA6gV8AI=
 github.com/gravitational/protobuf v1.3.2-teleport.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
 github.com/gravitational/redis/v9 v9.6.1-teleport.1 h1:gPirfPKArN2nPhTKR3h9fnEg5YuYU933+CjlDJMo4H0=

--- a/integrations/terraform-mwi/go.sum
+++ b/integrations/terraform-mwi/go.sum
@@ -731,12 +731,12 @@ github.com/gravitational/go-mysql v1.9.1-teleport.4 h1:2Lt2fcEMrco6apu8jme0mj6OS
 github.com/gravitational/go-mysql v1.9.1-teleport.4/go.mod h1:pkllauQtJgHr2mTonYYysOznctozxiWgwpKAez0s+2U=
 github.com/gravitational/httprouter v1.3.1-0.20220408074523-c876c5e705a5 h1:qg8FcGwRACSHortU1UxCSo9nF0t34rPWjk9Nef3j2Ic=
 github.com/gravitational/httprouter v1.3.1-0.20220408074523-c876c5e705a5/go.mod h1:JR6WtHb+2LUe8TCKY3cZOxFyyO8IZAc4RVcycCCAKdM=
-github.com/gravitational/kingpin/v2 v2.1.11-0.20260417152838-9efcbe7e5d61 h1:cgG/o1SAL2WK9AtryT/esiuXqCN47f15EwppKgeom60=
-github.com/gravitational/kingpin/v2 v2.1.11-0.20260417152838-9efcbe7e5d61/go.mod h1:usbNrkVhUGh5+Pqd4u5tYKszWmq6YSCApkePRMmJFP8=
+github.com/gravitational/kingpin/v2 v2.1.11-0.20260507144047-1f18894764f5 h1:E7lyOeBLDh+3N3cAKT+dC343tAP5uJxyUJDGFxi+q5Y=
+github.com/gravitational/kingpin/v2 v2.1.11-0.20260507144047-1f18894764f5/go.mod h1:usbNrkVhUGh5+Pqd4u5tYKszWmq6YSCApkePRMmJFP8=
 github.com/gravitational/license v0.0.0-20250329001817-070456fa8ec1 h1:Kt7aT9N7vbZmcMejGXnSAGap8TUwH3fMoHE8cQm14wc=
 github.com/gravitational/license v0.0.0-20250329001817-070456fa8ec1/go.mod h1:n4RXV6T3SJ/vrJqmc4vBeHpaBspxWENDD67ssQlXXkg=
-github.com/gravitational/predicate v1.3.5-0.20260511125330-ddfb710e0084 h1:BRWNqpuSl2EETF4k059dNa0UnDcEfKJFs4DPVHPRU/E=
-github.com/gravitational/predicate v1.3.5-0.20260511125330-ddfb710e0084/go.mod h1:cTQkp40X3YejTcWsZGvzAtfa28VXfBxT10H/Grt0Fzs=
+github.com/gravitational/predicate v1.4.0 h1:vyaPQ04DQq083k6CAcM0fyGYoSUt8ZsIdn1gSkDRE+g=
+github.com/gravitational/predicate v1.4.0/go.mod h1:cTQkp40X3YejTcWsZGvzAtfa28VXfBxT10H/Grt0Fzs=
 github.com/gravitational/protobuf v1.3.2-teleport.2 h1:MO5eFXfGfDiAbBA7X8tDW2EMLfRWQVJMmK+MA6gV8AI=
 github.com/gravitational/protobuf v1.3.2-teleport.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
 github.com/gravitational/redis/v9 v9.6.1-teleport.1 h1:gPirfPKArN2nPhTKR3h9fnEg5YuYU933+CjlDJMo4H0=

--- a/integrations/terraform/go.mod
+++ b/integrations/terraform/go.mod
@@ -533,7 +533,7 @@ require (
 )
 
 replace (
-	github.com/alecthomas/kingpin/v2 => github.com/gravitational/kingpin/v2 v2.1.11-0.20260417152838-9efcbe7e5d61
+	github.com/alecthomas/kingpin/v2 => github.com/gravitational/kingpin/v2 v2.1.11-0.20260507144047-1f18894764f5
 	github.com/crewjam/saml => github.com/gravitational/saml v0.4.15-teleport.2
 	github.com/datastax/go-cassandra-native-protocol => github.com/gravitational/go-cassandra-native-protocol v0.0.0-teleport.3
 	github.com/go-mysql-org/go-mysql => github.com/gravitational/go-mysql v1.9.1-teleport.4
@@ -547,7 +547,7 @@ replace (
 	github.com/microsoft/go-mssqldb => github.com/gravitational/go-mssqldb v1.8.1-teleport.2
 	github.com/opencontainers/selinux => github.com/gravitational/selinux v1.13.0-teleport
 	github.com/redis/go-redis/v9 => github.com/gravitational/redis/v9 v9.6.1-teleport.1
-	github.com/vulcand/predicate => github.com/gravitational/predicate v1.3.5-0.20260511125330-ddfb710e0084
+	github.com/vulcand/predicate => github.com/gravitational/predicate v1.4.0
 )
 
 // Doc generation tooling.

--- a/integrations/terraform/go.mod
+++ b/integrations/terraform/go.mod
@@ -547,7 +547,7 @@ replace (
 	github.com/microsoft/go-mssqldb => github.com/gravitational/go-mssqldb v1.8.1-teleport.2
 	github.com/opencontainers/selinux => github.com/gravitational/selinux v1.13.0-teleport
 	github.com/redis/go-redis/v9 => github.com/gravitational/redis/v9 v9.6.1-teleport.1
-	github.com/vulcand/predicate => github.com/gravitational/predicate v1.3.4
+	github.com/vulcand/predicate => github.com/gravitational/predicate v1.3.5-0.20260511125330-ddfb710e0084
 )
 
 // Doc generation tooling.

--- a/integrations/terraform/go.sum
+++ b/integrations/terraform/go.sum
@@ -830,12 +830,12 @@ github.com/gravitational/go-mysql v1.9.1-teleport.4 h1:2Lt2fcEMrco6apu8jme0mj6OS
 github.com/gravitational/go-mysql v1.9.1-teleport.4/go.mod h1:pkllauQtJgHr2mTonYYysOznctozxiWgwpKAez0s+2U=
 github.com/gravitational/httprouter v1.3.1-0.20220408074523-c876c5e705a5 h1:qg8FcGwRACSHortU1UxCSo9nF0t34rPWjk9Nef3j2Ic=
 github.com/gravitational/httprouter v1.3.1-0.20220408074523-c876c5e705a5/go.mod h1:JR6WtHb+2LUe8TCKY3cZOxFyyO8IZAc4RVcycCCAKdM=
-github.com/gravitational/kingpin/v2 v2.1.11-0.20260417152838-9efcbe7e5d61 h1:cgG/o1SAL2WK9AtryT/esiuXqCN47f15EwppKgeom60=
-github.com/gravitational/kingpin/v2 v2.1.11-0.20260417152838-9efcbe7e5d61/go.mod h1:usbNrkVhUGh5+Pqd4u5tYKszWmq6YSCApkePRMmJFP8=
+github.com/gravitational/kingpin/v2 v2.1.11-0.20260507144047-1f18894764f5 h1:E7lyOeBLDh+3N3cAKT+dC343tAP5uJxyUJDGFxi+q5Y=
+github.com/gravitational/kingpin/v2 v2.1.11-0.20260507144047-1f18894764f5/go.mod h1:usbNrkVhUGh5+Pqd4u5tYKszWmq6YSCApkePRMmJFP8=
 github.com/gravitational/license v0.0.0-20250329001817-070456fa8ec1 h1:Kt7aT9N7vbZmcMejGXnSAGap8TUwH3fMoHE8cQm14wc=
 github.com/gravitational/license v0.0.0-20250329001817-070456fa8ec1/go.mod h1:n4RXV6T3SJ/vrJqmc4vBeHpaBspxWENDD67ssQlXXkg=
-github.com/gravitational/predicate v1.3.5-0.20260511125330-ddfb710e0084 h1:BRWNqpuSl2EETF4k059dNa0UnDcEfKJFs4DPVHPRU/E=
-github.com/gravitational/predicate v1.3.5-0.20260511125330-ddfb710e0084/go.mod h1:cTQkp40X3YejTcWsZGvzAtfa28VXfBxT10H/Grt0Fzs=
+github.com/gravitational/predicate v1.4.0 h1:vyaPQ04DQq083k6CAcM0fyGYoSUt8ZsIdn1gSkDRE+g=
+github.com/gravitational/predicate v1.4.0/go.mod h1:cTQkp40X3YejTcWsZGvzAtfa28VXfBxT10H/Grt0Fzs=
 github.com/gravitational/protobuf v1.3.2-teleport.2 h1:MO5eFXfGfDiAbBA7X8tDW2EMLfRWQVJMmK+MA6gV8AI=
 github.com/gravitational/protobuf v1.3.2-teleport.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
 github.com/gravitational/redis/v9 v9.6.1-teleport.1 h1:gPirfPKArN2nPhTKR3h9fnEg5YuYU933+CjlDJMo4H0=

--- a/integrations/terraform/go.sum
+++ b/integrations/terraform/go.sum
@@ -834,8 +834,8 @@ github.com/gravitational/kingpin/v2 v2.1.11-0.20260417152838-9efcbe7e5d61 h1:cgG
 github.com/gravitational/kingpin/v2 v2.1.11-0.20260417152838-9efcbe7e5d61/go.mod h1:usbNrkVhUGh5+Pqd4u5tYKszWmq6YSCApkePRMmJFP8=
 github.com/gravitational/license v0.0.0-20250329001817-070456fa8ec1 h1:Kt7aT9N7vbZmcMejGXnSAGap8TUwH3fMoHE8cQm14wc=
 github.com/gravitational/license v0.0.0-20250329001817-070456fa8ec1/go.mod h1:n4RXV6T3SJ/vrJqmc4vBeHpaBspxWENDD67ssQlXXkg=
-github.com/gravitational/predicate v1.3.4 h1:9N3JhBXNPcUh0w8DdlpnVmfnH9Z3xxbw43sD3E19VBE=
-github.com/gravitational/predicate v1.3.4/go.mod h1:cTQkp40X3YejTcWsZGvzAtfa28VXfBxT10H/Grt0Fzs=
+github.com/gravitational/predicate v1.3.5-0.20260511125330-ddfb710e0084 h1:BRWNqpuSl2EETF4k059dNa0UnDcEfKJFs4DPVHPRU/E=
+github.com/gravitational/predicate v1.3.5-0.20260511125330-ddfb710e0084/go.mod h1:cTQkp40X3YejTcWsZGvzAtfa28VXfBxT10H/Grt0Fzs=
 github.com/gravitational/protobuf v1.3.2-teleport.2 h1:MO5eFXfGfDiAbBA7X8tDW2EMLfRWQVJMmK+MA6gV8AI=
 github.com/gravitational/protobuf v1.3.2-teleport.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
 github.com/gravitational/redis/v9 v9.6.1-teleport.1 h1:gPirfPKArN2nPhTKR3h9fnEg5YuYU933+CjlDJMo4H0=

--- a/lib/services/parser.go
+++ b/lib/services/parser.go
@@ -1227,10 +1227,10 @@ func combineSplitContains(cursor *astutil.Cursor) (cont bool) {
 }
 
 // optimizeSplitContains is an [astutil.ApplyFunc] that replaces calls to
-// __split_contains where the delimiter is a one byte literal and the target is
-// a literal into calls to __split_contains_singlebyte_affix, by combining the
-// delimiter and literal strings into a new literal string that can be more
-// efficiently matched.
+// __split_contains where the delimiter is a nonempty literal string and the
+// target is a literal string into calls to __split_contains_singlebyte_affix,
+// by combining the delimiter and literal strings into a new literal string that
+// can be more efficiently matched.
 func optimizeSplitContains(cursor *astutil.Cursor) (cont bool) {
 	cont = true
 

--- a/lib/services/parser.go
+++ b/lib/services/parser.go
@@ -964,10 +964,12 @@ type lazyStringSplit struct {
 	value, delimiter string
 }
 
+// Slice implements [typical.StringSlice].
 func (s *lazyStringSplit) Slice() []string {
 	return strings.Split(s.value, s.delimiter)
 }
 
+// Contains implements [typical.StringSlice].
 func (s *lazyStringSplit) Contains(target string) bool {
 	return splitContains(s.value, s.delimiter, target)
 }

--- a/lib/services/parser.go
+++ b/lib/services/parser.go
@@ -1030,24 +1030,25 @@ func splitContains(value, delimiter, target string) bool {
 	return false
 }
 
-func splitContainsSinglebyteAffix(value, delimTargetDelim string) bool {
-	// the delimiter is one byte and it's at the head and tail of
-	// delimTargetDelim, so if we don't have two bytes we can't do some of the
-	// slicing; this is an internal-use function so we're not really concerned
-	// with sanity checks - if called incorrectly, this function will return a
-	// useless value but it will not crash
-	if len(delimTargetDelim) < 2 {
+func splitContainsAffix(value, delimTargetDelim string, delimLength int) bool {
+	if delimLength <= 0 {
+		// special case, used by the optimizer
 		return false
 	}
-	if value == delimTargetDelim[1:len(delimTargetDelim)-1] {
+	if len(delimTargetDelim) < 2*delimLength {
+		// this function is only for internal use, so if given nonsensical data
+		// we can return whatever we want
+		return false
+	}
+	if value == delimTargetDelim[delimLength:len(delimTargetDelim)-delimLength] {
 		// ("foo", ",foo,")
 		return true
 	}
-	if strings.HasPrefix(value, delimTargetDelim[1:]) {
+	if strings.HasPrefix(value, delimTargetDelim[delimLength:]) {
 		// ("foo,bar", ",foo,")
 		return true
 	}
-	if strings.HasSuffix(value, delimTargetDelim[:len(delimTargetDelim)-1]) {
+	if strings.HasSuffix(value, delimTargetDelim[:len(delimTargetDelim)-delimLength]) {
 		// ("bar,foo", ",foo,")
 		return true
 	}
@@ -1107,8 +1108,8 @@ func newResourceExpressionParser(opts ...func(*typical.ParserSpec[types.Resource
 			"__split_contains": typical.TernaryFunction[types.ResourceWithLabels](func(value string, delimiter string, target string) (bool, error) {
 				return splitContains(value, delimiter, target), nil
 			}),
-			"__split_contains_singlebyte_affix": typical.BinaryFunction[types.ResourceWithLabels](func(value string, delimTargetDelim string) (bool, error) {
-				return splitContainsSinglebyteAffix(value, delimTargetDelim), nil
+			"__split_contains_affix": typical.TernaryFunction[types.ResourceWithLabels](func(value string, delimTargetDelim string, delimLength int) (bool, error) {
+				return splitContainsAffix(value, delimTargetDelim, delimLength), nil
 			}),
 		},
 		GetUnknownIdentifier: func(env types.ResourceWithLabels, fields []string) (any, error) {
@@ -1243,49 +1244,48 @@ func optimizeSplitContains(cursor *astutil.Cursor) (cont bool) {
 
 	delimiter := getLiteralString(ast.Unparen(splitContainsCall.Args[1]))
 	target := getLiteralString(ast.Unparen(splitContainsCall.Args[2]))
-	if delimiter == nil || target == nil {
+	if delimiter == nil || target == nil || *delimiter == "" {
 		return
 	}
 
-	if *delimiter != "" && strings.Contains(*target, *delimiter) {
+	if strings.Contains(*target, *delimiter) {
 		// impossible match, turn it into a function call that unconditionally
 		// returns false very quickly
 
 		// TODO(espadolini): figure out if adding a "false" or "__false"
 		// variable has the potential to break things
 
-		// __split_contains(value, ",", "contains,delimiter") -> __split_contains_singlebyte_affix(value, "")
+		// __split_contains(value, ",", "contains,delimiter") -> __split_contains_affix(value, "", 0)
 		cursor.Replace(&ast.CallExpr{
-			Fun: &ast.Ident{Name: "__split_contains_singlebyte_affix"},
+			Fun: &ast.Ident{Name: "__split_contains_affix"},
 			Args: []ast.Expr{
 				ast.Unparen(splitContainsCall.Args[0]),
 				&ast.BasicLit{Kind: token.STRING, Value: `""`},
+				&ast.BasicLit{Kind: token.INT, Value: "0"},
 			},
 		})
 		return
 	}
 
-	if len(*delimiter) != 1 {
-		return
-	}
+	// we affix the delimiter to the head and tail of the target string so we
+	// can just call [strings.Contains] which is almost surely much more
+	// efficient than anything else we could do; we have to pass the length of
+	// the delimiter since checking whether the target is at the beginning or
+	// end of the value (or if the value is exactly equal to the target)
+	// requires knowing how much to skip
 
-	// the delimiter is a one byte literal string and the target is a literal
-	// string, so we affix the delimiter to the head and tail of the target
-	// string so we can just call [strings.Contains] which is almost surely much
-	// more efficient than anything else we could do; the delimiter has to be
-	// single byte because __split_contains_singlebyte_affix must be able to
-	// skip it when checking for the target being at the very beginning or the
-	// very end of the string, and we don't want to copy every string in the
-	// slice just to add the delimiter at the beginning and end for that
-
-	// __split_contains(sliceExpr, ",", "literal") -> __split_contains_singlebyte_affix(sliceExpr, ",literal,")
+	// __split_contains(sliceExpr, ",", "literal") -> __split_contains_affix(sliceExpr, ",literal,", len(","))
 	cursor.Replace(&ast.CallExpr{
-		Fun: &ast.Ident{Name: "__split_contains_singlebyte_affix"},
+		Fun: &ast.Ident{Name: "__split_contains_affix"},
 		Args: []ast.Expr{
 			ast.Unparen(splitContainsCall.Args[0]),
 			&ast.BasicLit{
 				Kind:  token.STRING,
 				Value: strconv.Quote(*delimiter + *target + *delimiter),
+			},
+			&ast.BasicLit{
+				Kind:  token.INT,
+				Value: strconv.FormatInt(int64(len(*delimiter)), 10),
 			},
 		},
 	})

--- a/lib/services/parser.go
+++ b/lib/services/parser.go
@@ -1130,8 +1130,16 @@ func newResourceExpression(expression string, parser *typical.Parser[types.Resou
 		return nil, trace.Wrap(err)
 	}
 
-	astExpr = astutil.Apply(astExpr, nil, combineSplitContains).(ast.Expr)
-	astExpr = astutil.Apply(astExpr, nil, optimizeSplitContains).(ast.Expr)
+	for _, postFunc := range []astutil.ApplyFunc{
+		combineSplitContains,
+		optimizeSplitContains,
+	} {
+		newNode := astutil.Apply(astExpr, nil, postFunc)
+		astExpr, _ = newNode.(ast.Expr)
+		if astExpr == nil {
+			return nil, trace.Errorf("expected ast.Expr from AST optimization step, got %T (this is a bug)", newNode)
+		}
+	}
 
 	expr, err := parser.ParseAST(astExpr)
 	return expr, trace.Wrap(err)

--- a/lib/services/parser.go
+++ b/lib/services/parser.go
@@ -1094,10 +1094,10 @@ func newResourceExpressionParser(opts ...func(*typical.ParserSpec[types.Resource
 			"exists": typical.UnaryFunction[types.ResourceWithLabels](func(value string) (bool, error) {
 				return value != "", nil
 			}),
-			"split": typical.BinaryFunction[types.ResourceWithLabels](func(value string, delimiter string) (typical.LazyStringSlice, error) {
+			"split": typical.BinaryFunction[types.ResourceWithLabels](func(value string, delimiter string) (typical.StringSlice, error) {
 				return &lazyStringSplit{value: value, delimiter: delimiter}, nil
 			}),
-			"contains": typical.BinaryFunction[types.ResourceWithLabels](func(list typical.LazyStringSlice, value string) (bool, error) {
+			"contains": typical.BinaryFunction[types.ResourceWithLabels](func(list typical.StringSlice, value string) (bool, error) {
 				return list.Contains(value), nil
 			}),
 			"__split_contains": typical.TernaryFunction[types.ResourceWithLabels](func(value string, delimiter string, target string) (bool, error) {

--- a/lib/services/parser.go
+++ b/lib/services/parser.go
@@ -1010,7 +1010,11 @@ func splitContains(value, delimiter, target string) bool {
 	} else if strings.Contains(target, delimiter) || !strings.Contains(value, target) {
 		// delimiter is nonempty, so SplitSeq works bytewise, and there's no way
 		// we'll ever get a match if the target contains the delimiter or if the
-		// target is not contained in the value
+		// target is not contained in the value; note that this check is
+		// wasteful in case of a successful match, but erring on the side of
+		// excluding matches will hopefully result in overall faster behavior,
+		// especially when resource expressions are used as a predicate to
+		// select one or few resources
 		return false
 	}
 

--- a/lib/services/parser.go
+++ b/lib/services/parser.go
@@ -1226,6 +1226,10 @@ func combineSplitContains(cursor *astutil.Cursor) (cont bool) {
 	return
 }
 
+func isImpossibleSplitContainsMatch(target, delimiter string) bool {
+	return delimiter != "" && strings.Contains(target, delimiter)
+}
+
 // optimizeSplitContains is an [astutil.ApplyFunc] that replaces calls to
 // __split_contains where the delimiter is a nonempty literal string and the
 // target is a literal string into calls to __split_contains_singlebyte_affix,
@@ -1249,7 +1253,7 @@ func optimizeSplitContains(cursor *astutil.Cursor) (cont bool) {
 		return
 	}
 
-	if *delimiter != "" && strings.Contains(*target, *delimiter) {
+	if isImpossibleSplitContainsMatch(*target, *delimiter) {
 		// impossible match, turn it into a function call that unconditionally
 		// returns false very quickly
 

--- a/lib/services/parser.go
+++ b/lib/services/parser.go
@@ -975,12 +975,6 @@ func (s *lazyStringSplit) Contains(target string) bool {
 }
 
 func splitContains(value, delimiter, target string) bool {
-	if value == "" {
-		// empty slice no matter what the delimiter is, so the target can't ever
-		// be in there
-		return false
-	}
-
 	if delimiter == "" {
 		// an empty delimiter was unfortunately not preemptively disallowed, so
 		// we have to match the behavior of [strings.Split] with an empty
@@ -990,6 +984,10 @@ func splitContains(value, delimiter, target string) bool {
 			// exploding a string into utf8 sequences never yields an empty
 			// string, so we can't ever match an empty target if the delimiter
 			// is empty
+			return false
+		}
+		if value == "" {
+			// exploding the empty string into utf8 sequences yields nothing
 			return false
 		}
 		r, s := utf8.DecodeRuneInString(target)
@@ -1009,6 +1007,10 @@ func splitContains(value, delimiter, target string) bool {
 		// go escaping for strings, so we can't rely on the well-formedness of
 		// strings either; if we hit this case we just fall back to the slower
 		// case using SplitSeq
+	} else if value == "" {
+		// the empty value splits into a single empty string since the delimiter
+		// is nonempty
+		return target == ""
 	} else if strings.Contains(target, delimiter) || !strings.Contains(value, target) {
 		// delimiter is nonempty, so SplitSeq works bytewise, and there's no way
 		// we'll ever get a match if the target contains the delimiter or if the

--- a/lib/services/parser.go
+++ b/lib/services/parser.go
@@ -21,14 +21,19 @@ package services
 import (
 	"context"
 	"fmt"
+	"go/ast"
+	goparser "go/parser"
+	"go/token"
 	"log/slog"
-	"slices"
+	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/gravitational/trace"
 	"github.com/vulcand/predicate"
 	"github.com/vulcand/predicate/builder"
+	"golang.org/x/tools/go/ast/astutil"
 
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/types"
@@ -954,18 +959,58 @@ func predicateContainsAny(a, b any) predicate.BoolPredicate {
 	}
 }
 
-// NewResourceExpression returns a [typical.Expression] that is to be evaluated against a
-// [types.ResourceWithLabels]. It is customized to allow short identifiers common in all
-// resources:
-//   - shorthand `name` refers to `resource.spec.hostname` for node resources, or it refers
-//     to `resource.metadata.name` for all other resources eg: `name == "app-name-jenkins"`
-//   - shorthand `labels` refers to resource `resource.metadata.labels + resource.spec.dynamic_labels`
-//     eg: `labels.env == "prod"`
-//
-// All other fields can be referenced by starting expression with identifier `resource`
-// followed by the names of the json fields ie: `resource.spec.public_addr`.
-func NewResourceExpression(expression string) (typical.Expression[types.ResourceWithLabels, bool], error) {
-	parser, err := typical.NewParser[types.ResourceWithLabels, bool](typical.ParserSpec[types.ResourceWithLabels]{
+type lazyStringSplit struct {
+	value, delimiter string
+}
+
+func (s *lazyStringSplit) Slice() []string {
+	return strings.Split(s.value, s.delimiter)
+}
+
+func (s *lazyStringSplit) Contains(target string) bool {
+	return splitContains(s.value, s.delimiter, target)
+}
+
+func splitContains(value, delimiter, target string) bool {
+	if strings.Contains(target, delimiter) || !strings.Contains(value, target) {
+		return false
+	}
+
+	for v := range strings.SplitSeq(value, delimiter) {
+		if target == v {
+			return true
+		}
+	}
+	return false
+}
+
+func splitContainsSinglebyteAffix(value, delimTargetDelim string) bool {
+	// the delimiter is one byte and it's at the head and tail of
+	// delimTargetDelim, so if we don't have two bytes we can't do some of the
+	// slicing; this is an internal-use function so we're not really concerned
+	// with sanity checks - if called incorrectly, this function will return a
+	// useless value but it will not crash
+	if len(delimTargetDelim) < 2 {
+		return false
+	}
+	if value == delimTargetDelim[1:len(delimTargetDelim)-1] {
+		// ("foo", ",foo,")
+		return true
+	}
+	if strings.HasPrefix(value, delimTargetDelim[1:]) {
+		// ("foo,bar", ",foo,")
+		return true
+	}
+	if strings.HasSuffix(value, delimTargetDelim[:len(delimTargetDelim)-1]) {
+		// ("bar,foo", ",foo,")
+		return true
+	}
+	// ("bar,qux,foo,baz", ",foo,")
+	return strings.Contains(value, delimTargetDelim)
+}
+
+func newResourceExpressionParser(opts ...func(*typical.ParserSpec[types.ResourceWithLabels])) (*typical.Parser[types.ResourceWithLabels, bool], error) {
+	spec := typical.ParserSpec[types.ResourceWithLabels]{
 		Variables: map[string]typical.Variable{
 			"resource.metadata.labels": typical.DynamicVariable(func(r types.ResourceWithLabels) (map[string]string, error) {
 				return r.GetStaticLabels(), nil
@@ -1007,11 +1052,17 @@ func NewResourceExpression(expression string) (typical.Expression[types.Resource
 			"exists": typical.UnaryFunction[types.ResourceWithLabels](func(value string) (bool, error) {
 				return value != "", nil
 			}),
-			"split": typical.BinaryFunction[types.ResourceWithLabels](func(value string, delimiter string) ([]string, error) {
-				return strings.Split(value, delimiter), nil
+			"split": typical.BinaryFunction[types.ResourceWithLabels](func(value string, delimiter string) (typical.LazyStringSlice, error) {
+				return &lazyStringSplit{value: value, delimiter: delimiter}, nil
 			}),
-			"contains": typical.BinaryFunction[types.ResourceWithLabels](func(list []string, value string) (bool, error) {
-				return slices.Contains(list, value), nil
+			"contains": typical.BinaryFunction[types.ResourceWithLabels](func(list typical.LazyStringSlice, value string) (bool, error) {
+				return list.Contains(value), nil
+			}),
+			"__split_contains": typical.TernaryFunction[types.ResourceWithLabels](func(value string, delimiter string, target string) (bool, error) {
+				return splitContains(value, delimiter, target), nil
+			}),
+			"__split_contains_singlebyte_affix": typical.BinaryFunction[types.ResourceWithLabels](func(value string, delimTargetDelim string) (bool, error) {
+				return splitContainsSinglebyteAffix(value, delimTargetDelim), nil
 			}),
 		},
 		GetUnknownIdentifier: func(env types.ResourceWithLabels, fields []string) (any, error) {
@@ -1024,11 +1075,195 @@ func NewResourceExpression(expression string) (typical.Expression[types.Resource
 			identifier := strings.Join(fields, ".")
 			return nil, trace.BadParameter("identifier %s is not defined", identifier)
 		},
+	}
+	for _, opt := range opts {
+		opt(&spec)
+	}
+	parser, err := typical.NewParser[types.ResourceWithLabels, bool](spec)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return parser, nil
+}
+
+var resourceExpressionParserOnce sync.Once
+var resourceExpressionParser *typical.Parser[types.ResourceWithLabels, bool]
+
+func getResourceExpressionParser() (*typical.Parser[types.ResourceWithLabels, bool], error) {
+	resourceExpressionParserOnce.Do(func() {
+		p, err := newResourceExpressionParser()
+		if err != nil {
+			return
+		}
+		resourceExpressionParser = p
 	})
+	if resourceExpressionParser != nil {
+		return resourceExpressionParser, nil
+	}
+	// if there was an error creating the parser, which is impossible at the
+	// time of writing, just try again on every call so we can forward the error
+	// to the caller
+	return newResourceExpressionParser()
+}
+
+// NewResourceExpression returns a [typical.Expression] that is to be evaluated against a
+// [types.ResourceWithLabels]. It is customized to allow short identifiers common in all
+// resources:
+//   - shorthand `name` refers to `resource.spec.hostname` for node resources, or it refers
+//     to `resource.metadata.name` for all other resources eg: `name == "app-name-jenkins"`
+//   - shorthand `labels` refers to resource `resource.metadata.labels + resource.spec.dynamic_labels`
+//     eg: `labels.env == "prod"`
+//
+// All other fields can be referenced by starting expression with identifier `resource`
+// followed by the names of the json fields ie: `resource.spec.public_addr`.
+func NewResourceExpression(expression string) (typical.Expression[types.ResourceWithLabels, bool], error) {
+	parser, err := getResourceExpressionParser()
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return newResourceExpression(expression, parser)
+}
+
+func newResourceExpression(expression string, parser *typical.Parser[types.ResourceWithLabels, bool]) (typical.Expression[types.ResourceWithLabels, bool], error) {
+	astExpr, err := goparser.ParseExpr(expression)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
-	expr, err := parser.Parse(expression)
+	astExpr = astutil.Apply(astExpr, nil, combineSplitContains).(ast.Expr)
+	astExpr = astutil.Apply(astExpr, nil, optimizeSplitContains).(ast.Expr)
+
+	expr, err := parser.ParseAST(astExpr)
 	return expr, trace.Wrap(err)
+}
+
+// combineSplitContains is an [astutil.ApplyFunc] that replaces the combination
+// of calls of "contains(split(value, delimiter), target)" into a single call to
+// "__split_contains(value, delimiter, target)".
+func combineSplitContains(cursor *astutil.Cursor) (cont bool) {
+	cont = true
+
+	containsCall := getIdentCall(cursor.Node(), "contains")
+	if containsCall == nil {
+		return
+	}
+	if len(containsCall.Args) != 2 {
+		return
+	}
+
+	splitCall := getIdentCall(ast.Unparen(containsCall.Args[0]), "split")
+	if splitCall == nil {
+		return
+	}
+	if len(splitCall.Args) != 2 {
+		return
+	}
+
+	// contains(split(value, delim), target) -> __split_contains(slice, delim, target)
+	cursor.Replace(&ast.CallExpr{
+		Fun: &ast.Ident{Name: "__split_contains"},
+		Args: []ast.Expr{
+			ast.Unparen(splitCall.Args[0]),
+			ast.Unparen(splitCall.Args[1]),
+			ast.Unparen(containsCall.Args[1]),
+		},
+	})
+	return
+}
+
+// optimizeSplitContains is an [astutil.ApplyFunc] that replaces calls to
+// __split_contains where the delimiter is a one byte literal and the target is
+// a literal into calls to __split_contains_singlebyte_affix, by combining the
+// delimiter and literal strings into a new literal string that can be more
+// efficiently matched.
+func optimizeSplitContains(cursor *astutil.Cursor) (cont bool) {
+	cont = true
+
+	splitContainsCall := getIdentCall(cursor.Node(), "__split_contains")
+	if splitContainsCall == nil {
+		return
+	}
+	if len(splitContainsCall.Args) != 3 {
+		return
+	}
+
+	delimiter := getLiteralString(ast.Unparen(splitContainsCall.Args[1]))
+	target := getLiteralString(ast.Unparen(splitContainsCall.Args[2]))
+	if delimiter == nil || target == nil {
+		return
+	}
+
+	if strings.Contains(*target, *delimiter) {
+		// impossible match, turn it into a function call that unconditionally
+		// returns false very quickly
+
+		// TODO(espadolini): figure out if adding a "false" or "__false"
+		// variable has the potential to break things
+
+		// __split_contains(sliceExpr, ",", "contains,delimiter") -> __split_contains_singlebyte_affix("", "")
+		cursor.Replace(&ast.CallExpr{
+			Fun: &ast.Ident{Name: "__split_contains_singlebyte_affix"},
+			Args: []ast.Expr{
+				&ast.BasicLit{Kind: token.STRING, Value: `""`},
+				&ast.BasicLit{Kind: token.STRING, Value: `""`},
+			},
+		})
+		return
+	}
+
+	if len(*delimiter) != 1 {
+		return
+	}
+
+	// the delimiter is a one byte literal string and the target is a literal
+	// string, so we affix the delimiter to the head and tail of the target
+	// string so we can just call [strings.Contains] which is almost surely much
+	// more efficient than anything else we could do; the delimiter has to be
+	// single byte because __split_contains_singlebyte_affix must be able to
+	// skip it when checking for the target being at the very beginning or the
+	// very end of the string, and we don't want to copy every string in the
+	// slice just to add the delimiter at the beginning and end for that
+
+	// __split_contains(sliceExpr, ",", "literal") -> __split_contains_singlebyte_affix(sliceExpr, ",literal,")
+	cursor.Replace(&ast.CallExpr{
+		Fun: &ast.Ident{Name: "__split_contains_singlebyte_affix"},
+		Args: []ast.Expr{
+			ast.Unparen(splitContainsCall.Args[0]),
+			&ast.BasicLit{
+				Kind:  token.STRING,
+				Value: strconv.Quote(*delimiter + *target + *delimiter),
+			},
+		},
+	})
+
+	return
+}
+
+func getIdentCall(n ast.Node, ident string) *ast.CallExpr {
+	c, _ := n.(*ast.CallExpr)
+	if c == nil {
+		return nil
+	}
+	// predicate doesn't handle function expressions, not even to unparen them,
+	// so `(foo)(1, 2, 3)` is not valid and we only need to check for
+	// [*ast.Ident]
+	if i, _ := c.Fun.(*ast.Ident); i == nil || i.Name != ident {
+		return nil
+	}
+	return c
+}
+
+func getLiteralString(n ast.Node) *string {
+	l, _ := n.(*ast.BasicLit)
+	if l == nil {
+		return nil
+	}
+	if l.Kind != token.STRING {
+		return nil
+	}
+	s, err := strconv.Unquote(l.Value)
+	if err != nil {
+		return nil
+	}
+	return &s
 }

--- a/lib/services/parser.go
+++ b/lib/services/parser.go
@@ -1030,26 +1030,24 @@ func splitContains(value, delimiter, target string) bool {
 	return false
 }
 
-func splitContainsAffix(value, delimTargetDelim string, delimLength int) bool {
-	if delimLength <= 0 {
-		// special case, used by the optimizer
+func splitContainsSinglebyteAffix(value, delimTargetDelim string) bool {
+	// the delimiter is one byte and it's at the head and tail of
+	// delimTargetDelim, so if we don't have two bytes we can't do some of the
+	// slicing; this is an internal-use function so we're not really concerned
+	// with sanity checks - if called incorrectly, this function will return a
+	// useless value but it will not crash
+	if len(delimTargetDelim) < 2 {
 		return false
 	}
-	if len(delimTargetDelim) < 2*delimLength {
-		// this function is only for internal use, so if given nonsensical data
-		// we can return whatever we want
-		return false
-	}
-
-	if target := delimTargetDelim[delimLength : len(delimTargetDelim)-delimLength]; value == target {
+	if target := delimTargetDelim[1 : len(delimTargetDelim)-1]; value == target {
 		// ("foo", ",foo,")
 		return true
 	}
-	if targetDelim := delimTargetDelim[delimLength:]; strings.HasPrefix(value, targetDelim) {
+	if targetDelim := delimTargetDelim[1:]; strings.HasPrefix(value, targetDelim) {
 		// ("foo,bar", ",foo,")
 		return true
 	}
-	if delimTarget := delimTargetDelim[:len(delimTargetDelim)-delimLength]; strings.HasSuffix(value, delimTarget) {
+	if delimTarget := delimTargetDelim[:len(delimTargetDelim)-1]; strings.HasSuffix(value, delimTarget) {
 		// ("bar,foo", ",foo,")
 		return true
 	}
@@ -1109,8 +1107,8 @@ func newResourceExpressionParser(opts ...func(*typical.ParserSpec[types.Resource
 			"__split_contains": typical.TernaryFunction[types.ResourceWithLabels](func(value string, delimiter string, target string) (bool, error) {
 				return splitContains(value, delimiter, target), nil
 			}),
-			"__split_contains_affix": typical.TernaryFunction[types.ResourceWithLabels](func(value string, delimTargetDelim string, delimLength int) (bool, error) {
-				return splitContainsAffix(value, delimTargetDelim, delimLength), nil
+			"__split_contains_singlebyte_affix": typical.BinaryFunction[types.ResourceWithLabels](func(value string, delimTargetDelim string) (bool, error) {
+				return splitContainsSinglebyteAffix(value, delimTargetDelim), nil
 			}),
 		},
 		GetUnknownIdentifier: func(env types.ResourceWithLabels, fields []string) (any, error) {
@@ -1245,48 +1243,49 @@ func optimizeSplitContains(cursor *astutil.Cursor) (cont bool) {
 
 	delimiter := getLiteralString(ast.Unparen(splitContainsCall.Args[1]))
 	target := getLiteralString(ast.Unparen(splitContainsCall.Args[2]))
-	if delimiter == nil || target == nil || *delimiter == "" {
+	if delimiter == nil || target == nil {
 		return
 	}
 
-	if strings.Contains(*target, *delimiter) {
+	if *delimiter != "" && strings.Contains(*target, *delimiter) {
 		// impossible match, turn it into a function call that unconditionally
 		// returns false very quickly
 
 		// TODO(espadolini): figure out if adding a "false" or "__false"
 		// variable has the potential to break things
 
-		// __split_contains(value, ",", "contains,delimiter") -> __split_contains_affix(value, "", 0)
+		// __split_contains(value, ",", "contains,delimiter") -> __split_contains_singlebyte_affix(value, "")
 		cursor.Replace(&ast.CallExpr{
-			Fun: &ast.Ident{Name: "__split_contains_affix"},
+			Fun: &ast.Ident{Name: "__split_contains_singlebyte_affix"},
 			Args: []ast.Expr{
 				ast.Unparen(splitContainsCall.Args[0]),
 				&ast.BasicLit{Kind: token.STRING, Value: `""`},
-				&ast.BasicLit{Kind: token.INT, Value: "0"},
 			},
 		})
 		return
 	}
 
-	// we affix the delimiter to the head and tail of the target string so we
-	// can just call [strings.Contains] which is almost surely much more
-	// efficient than anything else we could do; we have to pass the length of
-	// the delimiter since checking whether the target is at the beginning or
-	// end of the value (or if the value is exactly equal to the target)
-	// requires knowing how much to skip
+	if len(*delimiter) != 1 {
+		return
+	}
 
-	// __split_contains(sliceExpr, ",", "literal") -> __split_contains_affix(sliceExpr, ",literal,", len(","))
+	// the delimiter is a one byte literal string and the target is a literal
+	// string, so we affix the delimiter to the head and tail of the target
+	// string so we can just call [strings.Contains] which is almost surely much
+	// more efficient than anything else we could do; the delimiter has to be
+	// single byte because __split_contains_singlebyte_affix must be able to
+	// skip it when checking for the target being at the very beginning or the
+	// very end of the string, and we don't want to copy every string in the
+	// slice just to add the delimiter at the beginning and end for that
+
+	// __split_contains(sliceExpr, ",", "literal") -> __split_contains_singlebyte_affix(sliceExpr, ",literal,")
 	cursor.Replace(&ast.CallExpr{
-		Fun: &ast.Ident{Name: "__split_contains_affix"},
+		Fun: &ast.Ident{Name: "__split_contains_singlebyte_affix"},
 		Args: []ast.Expr{
 			ast.Unparen(splitContainsCall.Args[0]),
 			&ast.BasicLit{
 				Kind:  token.STRING,
 				Value: strconv.Quote(*delimiter + *target + *delimiter),
-			},
-			&ast.BasicLit{
-				Kind:  token.INT,
-				Value: strconv.FormatInt(int64(len(*delimiter)), 10),
 			},
 		},
 	})

--- a/lib/services/parser.go
+++ b/lib/services/parser.go
@@ -29,6 +29,7 @@ import (
 	"strings"
 	"sync"
 	"time"
+	"unicode/utf8"
 
 	"github.com/gravitational/trace"
 	"github.com/vulcand/predicate"
@@ -972,7 +973,44 @@ func (s *lazyStringSplit) Contains(target string) bool {
 }
 
 func splitContains(value, delimiter, target string) bool {
-	if strings.Contains(target, delimiter) || !strings.Contains(value, target) {
+	if value == "" {
+		// empty slice no matter what the delimiter is, so the target can't ever
+		// be in there
+		return false
+	}
+
+	if delimiter == "" {
+		// an empty delimiter was unfortunately not preemptively disallowed, so
+		// we have to match the behavior of [strings.Split] with an empty
+		// delimiter, i.e. splitting up the string in individual utf8 sequences
+		// or single bytes of non-well-formed utf8
+		if target == "" {
+			// exploding a string into utf8 sequences never yields an empty
+			// string, so we can't ever match an empty target if the delimiter
+			// is empty
+			return false
+		}
+		r, s := utf8.DecodeRuneInString(target)
+		if len(target) != s {
+			// target is more than one rune or invalid non-utf8 byte, so it will
+			// never match anything yielded by SplitSeq(value, "")
+			return false
+		}
+		if s != 1 || r != utf8.RuneError {
+			// target is a well formed utf8 sequence, so we can check if it's in
+			// value by means of Contains
+			return strings.Contains(value, target)
+		}
+		// target is a single byte that's not a valid utf8 sequence but it might
+		// appear in value as part of a valid utf8 sequence, so we can't use a
+		// bytewise contains, unfortunately, and the predicate language supports
+		// go escaping for strings, so we can't rely on the well-formedness of
+		// strings either; if we hit this case we just fall back to the slower
+		// case using SplitSeq
+	} else if strings.Contains(target, delimiter) || !strings.Contains(value, target) {
+		// delimiter is nonempty, so SplitSeq works bytewise, and there's no way
+		// we'll ever get a match if the target contains the delimiter or if the
+		// target is not contained in the value
 		return false
 	}
 
@@ -1201,7 +1239,7 @@ func optimizeSplitContains(cursor *astutil.Cursor) (cont bool) {
 		return
 	}
 
-	if strings.Contains(*target, *delimiter) {
+	if *delimiter != "" && strings.Contains(*target, *delimiter) {
 		// impossible match, turn it into a function call that unconditionally
 		// returns false very quickly
 

--- a/lib/services/parser.go
+++ b/lib/services/parser.go
@@ -1040,15 +1040,16 @@ func splitContainsAffix(value, delimTargetDelim string, delimLength int) bool {
 		// we can return whatever we want
 		return false
 	}
-	if value == delimTargetDelim[delimLength:len(delimTargetDelim)-delimLength] {
+
+	if target := delimTargetDelim[delimLength : len(delimTargetDelim)-delimLength]; value == target {
 		// ("foo", ",foo,")
 		return true
 	}
-	if strings.HasPrefix(value, delimTargetDelim[delimLength:]) {
+	if targetDelim := delimTargetDelim[delimLength:]; strings.HasPrefix(value, targetDelim) {
 		// ("foo,bar", ",foo,")
 		return true
 	}
-	if strings.HasSuffix(value, delimTargetDelim[:len(delimTargetDelim)-delimLength]) {
+	if delimTarget := delimTargetDelim[:len(delimTargetDelim)-delimLength]; strings.HasSuffix(value, delimTarget) {
 		// ("bar,foo", ",foo,")
 		return true
 	}

--- a/lib/services/parser.go
+++ b/lib/services/parser.go
@@ -1195,6 +1195,7 @@ func newResourceExpression(expression string, parser *typical.Parser[types.Resou
 // of calls of "contains(split(value, delimiter), target)" into a single call to
 // "__split_contains(value, delimiter, target)".
 func combineSplitContains(cursor *astutil.Cursor) (cont bool) {
+	// we don't terminate the AST visit early so we always return true
 	cont = true
 
 	containsCall := getIdentCall(cursor.Node(), "contains")
@@ -1231,6 +1232,7 @@ func combineSplitContains(cursor *astutil.Cursor) (cont bool) {
 // by combining the delimiter and literal strings into a new literal string that
 // can be more efficiently matched.
 func optimizeSplitContains(cursor *astutil.Cursor) (cont bool) {
+	// we don't terminate the AST visit early so we always return true
 	cont = true
 
 	splitContainsCall := getIdentCall(cursor.Node(), "__split_contains")

--- a/lib/services/parser.go
+++ b/lib/services/parser.go
@@ -1167,7 +1167,7 @@ func combineSplitContains(cursor *astutil.Cursor) (cont bool) {
 		return
 	}
 
-	// contains(split(value, delim), target) -> __split_contains(slice, delim, target)
+	// contains(split(value, delim), target) -> __split_contains(value, delim, target)
 	cursor.Replace(&ast.CallExpr{
 		Fun: &ast.Ident{Name: "__split_contains"},
 		Args: []ast.Expr{
@@ -1208,11 +1208,11 @@ func optimizeSplitContains(cursor *astutil.Cursor) (cont bool) {
 		// TODO(espadolini): figure out if adding a "false" or "__false"
 		// variable has the potential to break things
 
-		// __split_contains(sliceExpr, ",", "contains,delimiter") -> __split_contains_singlebyte_affix("", "")
+		// __split_contains(value, ",", "contains,delimiter") -> __split_contains_singlebyte_affix(value, "")
 		cursor.Replace(&ast.CallExpr{
 			Fun: &ast.Ident{Name: "__split_contains_singlebyte_affix"},
 			Args: []ast.Expr{
-				&ast.BasicLit{Kind: token.STRING, Value: `""`},
+				ast.Unparen(splitContainsCall.Args[0]),
 				&ast.BasicLit{Kind: token.STRING, Value: `""`},
 			},
 		})

--- a/lib/services/parser_test.go
+++ b/lib/services/parser_test.go
@@ -227,6 +227,12 @@ func TestNewResourceExpression(t *testing.T) {
 			// Test operator precedence
 			`exists(labels.env) || (exists(labels.os) && labels.os != "mac")`,
 			`exists(labels.env) || exists(labels.os) && labels.os != "mac"`,
+			// split/contain combinations
+			`contains(split("a,b", ","), "a")`,
+			`contains(split("a,b", ","), "b")`,
+			`contains(split("", ","), "")`,
+			`contains(split(",,,", ",,"), ",")`,
+			`contains(split(",,,", ",,"), "")`,
 		}
 		for _, expr := range exprs {
 			t.Run(expr, func(t *testing.T) {
@@ -256,6 +262,9 @@ func TestNewResourceExpression(t *testing.T) {
 			`equals(resource.spec.hostname, "wrong-value")`,
 			`search("mac", "not-found")`,
 			`hasPrefix(name, "x")`,
+			`contains(split(",,,", ","), ",")`,
+			`contains(split(",,,", ","), ",,")`,
+			`contains(split(",,,,", ",,"), ",")`,
 		}
 		for _, expr := range exprs {
 			t.Run(expr, func(t *testing.T) {

--- a/lib/services/parser_test.go
+++ b/lib/services/parser_test.go
@@ -444,20 +444,20 @@ func BenchmarkSplitContains(b *testing.B) {
 	})
 	require.NoError(b, err)
 
-	for name, exprFmt := range map[string]string{
+	for name, expr := range map[string]string{
 		// the happiest path
-		"optimized": `contains(split(labels["ip"], %q), "1.2.3.6")`,
+		"optimized": `contains(split(labels["ip"], "|"), "1.2.3.6")`,
 		// these two should be equivalent after AST transformations, not as fast
 		// as the happy path when matching against a literal but still zero
 		// allocations
-		"auto_combined":   `contains(split(labels["ip"], %q), labels.target_ip)`,
-		"manual_combined": `__split_contains(labels["ip"], %q, labels.target_ip)`,
+		"auto_combined":   `contains(split(labels["ip"], "|"), labels.target_ip)`,
+		"manual_combined": `__split_contains(labels["ip"], "|", labels.target_ip)`,
 		// this uses lazy evaluation of slices so it should be about as fast as
 		// the combined version but with some object passing involved
-		"unoptimized": `contains_unoptimized(split(labels["ip"], %q), "1.2.3.6")`,
+		"unoptimized": `contains_unoptimized(split(labels["ip"], "|"), "1.2.3.6")`,
 		// this will eagerly split the string into a slice and then checks items
 		// in the slice one by one, mimicking the legacy behavior
-		"legacy_naive": `contains_naive(split(labels["ip"], %q), "1.2.3.6")`,
+		"legacy_naive": `contains_naive(split(labels["ip"], "|"), "1.2.3.6")`,
 	} {
 		b.Run("impl="+name, func(b *testing.B) {
 			for _, repetitions := range []int{0, 1, 3, 5, 20, 100} {
@@ -494,7 +494,7 @@ func BenchmarkSplitContains(b *testing.B) {
 						})
 						require.NoError(b, err)
 
-						expression, err := newResourceExpression(fmt.Sprintf(exprFmt, delim), parser)
+						expression, err := newResourceExpression(expr, parser)
 						require.NoError(b, err)
 
 						for b.Loop() {

--- a/lib/services/parser_test.go
+++ b/lib/services/parser_test.go
@@ -409,6 +409,10 @@ func TestResourceParserLabelExpansion(t *testing.T) {
 }
 
 func BenchmarkSplitContains(b *testing.B) {
+	if testing.Short() {
+		b.Skip("skipping heavy benchmark")
+	}
+
 	parser, err := newResourceExpressionParser(func(ps *typical.ParserSpec[types.ResourceWithLabels]) {
 		// this avoids the AST optimizations on the exact function name of
 		// contains but otherwise has the same behavior
@@ -417,22 +421,6 @@ func BenchmarkSplitContains(b *testing.B) {
 		ps.Functions["contains_naive"] = typical.BinaryFunction[types.ResourceWithLabels](func(list []string, value string) (bool, error) {
 			return slices.Contains(list, value), nil
 		})
-	})
-	require.NoError(b, err)
-
-	server, err := types.NewServerWithLabels("server-name", types.KindNode, types.ServerSpecV2{
-		Hostname: "server-hostname",
-	}, map[string]string{
-		"ip":        "1.2.3.11|1.2.3.101|1.2.3.1" + strings.Repeat("|2.3.4.5", 200) + "|1.2.3.6" + strings.Repeat("|2.3.4.5", 200),
-		"target_ip": "1.2.3.6",
-	})
-	require.NoError(b, err)
-
-	server2, err := types.NewServerWithLabels("server-name", types.KindNode, types.ServerSpecV2{
-		Hostname: "server-hostname",
-	}, map[string]string{
-		"ip":        "1.2.3.11|1.2.3.101|1.2.3.1" + strings.Repeat("|2.3.4.5", 200) + "|1.2.3.5" + strings.Repeat("|2.3.4.5", 200),
-		"target_ip": "1.2.3.6",
 	})
 	require.NoError(b, err)
 
@@ -451,17 +439,39 @@ func BenchmarkSplitContains(b *testing.B) {
 		// in the slice one by one, mimicking the legacy behavior
 		"legacy_naive": `contains_naive(split(labels["ip"], "|"), "1.2.3.6")`,
 	} {
-		b.Run(name, func(b *testing.B) {
-			expression, err := newResourceExpression(expr, parser)
-			require.NoError(b, err)
+		b.Run("impl="+name, func(b *testing.B) {
+			for _, repetitions := range []int{0, 1, 3, 5, 200} {
+				ipLabel := "1.2.3.11|1.2.3.101|1.2.3.1" + strings.Repeat("|2.3.4.5", repetitions) + "|1.2.3.6" + strings.Repeat("|2.3.4.5", repetitions)
+				ipLabel2 := "1.2.3.11|1.2.3.101|1.2.3.1" + strings.Repeat("|2.3.4.5", repetitions) + "|1.2.3.5" + strings.Repeat("|2.3.4.5", repetitions)
+				b.Run(fmt.Sprintf("label_length=%d", len(ipLabel)), func(b *testing.B) {
+					server, err := types.NewServerWithLabels("server-name", types.KindNode, types.ServerSpecV2{
+						Hostname: "server-hostname",
+					}, map[string]string{
+						"ip":        ipLabel,
+						"target_ip": "1.2.3.6",
+					})
+					require.NoError(b, err)
 
-			for b.Loop() {
-				match, err := expression.Evaluate(server)
-				require.NoError(b, err)
-				require.True(b, match)
-				match, err = expression.Evaluate(server2)
-				require.NoError(b, err)
-				require.False(b, match)
+					server2, err := types.NewServerWithLabels("server-name", types.KindNode, types.ServerSpecV2{
+						Hostname: "server-hostname",
+					}, map[string]string{
+						"ip":        ipLabel2,
+						"target_ip": "1.2.3.6",
+					})
+					require.NoError(b, err)
+
+					expression, err := newResourceExpression(expr, parser)
+					require.NoError(b, err)
+
+					for b.Loop() {
+						match, err := expression.Evaluate(server)
+						require.NoError(b, err)
+						require.True(b, match)
+						match, err = expression.Evaluate(server2)
+						require.NoError(b, err)
+						require.False(b, match)
+					}
+				})
 			}
 		})
 	}
@@ -471,21 +481,21 @@ func TestSplitContainsZeroAlloc(t *testing.T) {
 	server, err := types.NewServerWithLabels("server-name", types.KindNode, types.ServerSpecV2{
 		Hostname: "server-hostname",
 	}, map[string]string{
-		"ip":        "1.2.3.11|1.2.3.101|1.2.3.1" + strings.Repeat("|2.3.4.5", 200) + "|1.2.3.6" + strings.Repeat("|2.3.4.5", 200),
-		"target_ip": "1.2.3.6",
+		"ip":        "1.2.3.11|1.2.3.101|1.2.3.1",
+		"target_ip": "1.2.3.101",
 	})
 	require.NoError(t, err)
 
 	server2, err := types.NewServerWithLabels("server-name", types.KindNode, types.ServerSpecV2{
 		Hostname: "server-hostname",
 	}, map[string]string{
-		"ip":        "1.2.3.11|1.2.3.101|1.2.3.1" + strings.Repeat("|2.3.4.5", 200) + "|1.2.3.5" + strings.Repeat("|2.3.4.5", 200),
-		"target_ip": "1.2.3.6",
+		"ip":        "1.2.3.11|1.2.3.101|1.2.3.1",
+		"target_ip": "1.2.3.102",
 	})
 	require.NoError(t, err)
 
 	for name, expr := range map[string]string{
-		"optimized":       `contains(split(labels["ip"], "|"), "1.2.3.6")`,
+		"optimized":       `contains(split(labels["ip"], "|"), "1.2.3.101")`,
 		"auto_combined":   `contains(split(labels["ip"], "|"), labels.target_ip)`,
 		"manual_combined": `__split_contains(labels["ip"], "|", labels.target_ip)`,
 	} {

--- a/lib/services/parser_test.go
+++ b/lib/services/parser_test.go
@@ -489,8 +489,8 @@ func TestSplitContainsZeroAlloc(t *testing.T) {
 	server2, err := types.NewServerWithLabels("server-name", types.KindNode, types.ServerSpecV2{
 		Hostname: "server-hostname",
 	}, map[string]string{
-		"ip":        "1.2.3.11|1.2.3.101|1.2.3.1",
-		"target_ip": "1.2.3.102",
+		"ip":        "1.2.3.11|1.2.3.102|1.2.3.1",
+		"target_ip": "1.2.3.101",
 	})
 	require.NoError(t, err)
 

--- a/lib/services/parser_test.go
+++ b/lib/services/parser_test.go
@@ -444,20 +444,20 @@ func BenchmarkSplitContains(b *testing.B) {
 	})
 	require.NoError(b, err)
 
-	for name, expr := range map[string]string{
+	for name, exprFmt := range map[string]string{
 		// the happiest path
-		"optimized": `contains(split(labels["ip"], "|"), "1.2.3.6")`,
+		"optimized": `contains(split(labels["ip"], %q), "1.2.3.6")`,
 		// these two should be equivalent after AST transformations, not as fast
 		// as the happy path when matching against a literal but still zero
 		// allocations
-		"auto_combined":   `contains(split(labels["ip"], "|"), labels.target_ip)`,
-		"manual_combined": `__split_contains(labels["ip"], "|", labels.target_ip)`,
+		"auto_combined":   `contains(split(labels["ip"], %q), labels.target_ip)`,
+		"manual_combined": `__split_contains(labels["ip"], %q, labels.target_ip)`,
 		// this uses lazy evaluation of slices so it should be about as fast as
 		// the combined version but with some object passing involved
-		"unoptimized": `contains_unoptimized(split(labels["ip"], "|"), "1.2.3.6")`,
+		"unoptimized": `contains_unoptimized(split(labels["ip"], %q), "1.2.3.6")`,
 		// this will eagerly split the string into a slice and then checks items
 		// in the slice one by one, mimicking the legacy behavior
-		"legacy_naive": `contains_naive(split(labels["ip"], "|"), "1.2.3.6")`,
+		"legacy_naive": `contains_naive(split(labels["ip"], %q), "1.2.3.6")`,
 	} {
 		b.Run("impl="+name, func(b *testing.B) {
 			for _, repetitions := range []int{0, 1, 3, 5, 20, 100} {
@@ -494,7 +494,7 @@ func BenchmarkSplitContains(b *testing.B) {
 						})
 						require.NoError(b, err)
 
-						expression, err := newResourceExpression(expr, parser)
+						expression, err := newResourceExpression(fmt.Sprintf(exprFmt, delim), parser)
 						require.NoError(b, err)
 
 						for b.Loop() {

--- a/lib/services/parser_test.go
+++ b/lib/services/parser_test.go
@@ -460,38 +460,53 @@ func BenchmarkSplitContains(b *testing.B) {
 		"legacy_naive": `contains_naive(split(labels["ip"], "|"), "1.2.3.6")`,
 	} {
 		b.Run("impl="+name, func(b *testing.B) {
-			for _, repetitions := range []int{0, 1, 3, 5, 200} {
-				ipLabel := "1.2.3.11|1.2.3.101|1.2.3.1" + strings.Repeat("|2.3.4.5", repetitions) + "|1.2.3.6" + strings.Repeat("|2.3.4.5", repetitions)
-				ipLabel2 := "1.2.3.11|1.2.3.101|1.2.3.1" + strings.Repeat("|2.3.4.5", repetitions) + "|1.2.3.5" + strings.Repeat("|2.3.4.5", repetitions)
-				b.Run(fmt.Sprintf("label_length=%d", len(ipLabel)), func(b *testing.B) {
-					server, err := types.NewServerWithLabels("server-name", types.KindNode, types.ServerSpecV2{
-						Hostname: "server-hostname",
-					}, map[string]string{
-						"ip":        ipLabel,
-						"target_ip": "1.2.3.6",
-					})
-					require.NoError(b, err)
-
-					server2, err := types.NewServerWithLabels("server-name", types.KindNode, types.ServerSpecV2{
-						Hostname: "server-hostname",
-					}, map[string]string{
-						"ip":        ipLabel2,
-						"target_ip": "1.2.3.6",
-					})
-					require.NoError(b, err)
-
-					expression, err := newResourceExpression(expr, parser)
-					require.NoError(b, err)
-
-					for b.Loop() {
-						match, err := expression.Evaluate(server)
+			for _, repetitions := range []int{0, 1, 3, 5, 20, 100} {
+				addresses := slices.Concat(
+					[]string{"1.2.3.11", "1.2.3.101", "1.2.3.1"},
+					slices.Repeat([]string{"1.3.4.5"}, repetitions),
+					[]string{"1.2.3.6"},
+					slices.Repeat([]string{"1.3.4.7"}, repetitions),
+				)
+				addresses2 := slices.Concat(
+					[]string{"1.2.3.11", "1.2.3.101", "1.2.3.1"},
+					slices.Repeat([]string{"1.3.4.5"}, repetitions),
+					[]string{"1.2.3.5"},
+					slices.Repeat([]string{"1.3.4.7"}, repetitions),
+				)
+				for _, delimLength := range []int{1, 2} {
+					delim := strings.Repeat("|", delimLength)
+					ipLabel := strings.Join(addresses, delim)
+					ipLabel2 := strings.Join(addresses2, delim)
+					b.Run(fmt.Sprintf("label=%d/delim=%d", len(ipLabel), delimLength), func(b *testing.B) {
+						server, err := types.NewServerWithLabels("server-name", types.KindNode, types.ServerSpecV2{
+							Hostname: "server-hostname",
+						}, map[string]string{
+							"ip":        ipLabel,
+							"target_ip": "1.2.3.6",
+						})
 						require.NoError(b, err)
-						require.True(b, match)
-						match, err = expression.Evaluate(server2)
+
+						server2, err := types.NewServerWithLabels("server-name", types.KindNode, types.ServerSpecV2{
+							Hostname: "server-hostname",
+						}, map[string]string{
+							"ip":        ipLabel2,
+							"target_ip": "1.2.3.6",
+						})
 						require.NoError(b, err)
-						require.False(b, match)
-					}
-				})
+
+						expression, err := newResourceExpression(expr, parser)
+						require.NoError(b, err)
+
+						for b.Loop() {
+							match, err := expression.Evaluate(server)
+							require.NoError(b, err)
+							require.True(b, match)
+							match, err = expression.Evaluate(server2)
+							require.NoError(b, err)
+							require.False(b, match)
+						}
+					})
+				}
 			}
 		})
 	}
@@ -515,9 +530,10 @@ func TestSplitContainsZeroAlloc(t *testing.T) {
 	require.NoError(t, err)
 
 	for name, expr := range map[string]string{
-		"optimized":       `contains(split(labels["ip"], "|"), "1.2.3.101")`,
-		"auto_combined":   `contains(split(labels["ip"], "|"), labels.target_ip)`,
-		"manual_combined": `__split_contains(labels["ip"], "|", labels.target_ip)`,
+		"optimized":           `contains(split(labels["ip"], "|"), "1.2.3.101")`,
+		"optimized_multibyte": `contains(split(labels["ip"], "1|"), "1.2.3.10")`,
+		"auto_combined":       `contains(split(labels["ip"], "|"), labels.target_ip)`,
+		"manual_combined":     `__split_contains(labels["ip"], "|", labels.target_ip)`,
 	} {
 		t.Run(name, func(t *testing.T) {
 			expression, err := NewResourceExpression(expr)
@@ -537,15 +553,15 @@ func TestSplitContainsZeroAlloc(t *testing.T) {
 }
 
 func TestSplitContainsOptimizations(t *testing.T) {
-	var splitContainsCalled, splitContainsSinglebyteAffixCalled bool
+	var splitContainsCalled, splitContainsAffixCalled bool
 	parser, err := newResourceExpressionParser(func(ps *typical.ParserSpec[types.ResourceWithLabels]) {
 		ps.Functions["__split_contains"] = typical.TernaryFunction[types.ResourceWithLabels](func(value string, delimiter string, target string) (bool, error) {
 			splitContainsCalled = true
 			return splitContains(value, delimiter, target), nil
 		})
-		ps.Functions["__split_contains_singlebyte_affix"] = typical.BinaryFunction[types.ResourceWithLabels](func(value string, delimTargetDelim string) (bool, error) {
-			splitContainsSinglebyteAffixCalled = true
-			return splitContainsSinglebyteAffix(value, delimTargetDelim), nil
+		ps.Functions["__split_contains_affix"] = typical.TernaryFunction[types.ResourceWithLabels](func(value string, delimTargetDelim string, delimLength int) (bool, error) {
+			splitContainsAffixCalled = true
+			return splitContainsAffix(value, delimTargetDelim, delimLength), nil
 		})
 	})
 	require.NoError(t, err)
@@ -564,8 +580,26 @@ func TestSplitContainsOptimizations(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, match)
 	require.False(t, splitContainsCalled)
-	require.True(t, splitContainsSinglebyteAffixCalled)
-	splitContainsSinglebyteAffixCalled = false
+	require.True(t, splitContainsAffixCalled)
+	splitContainsAffixCalled = false
+
+	expr, err = newResourceExpression(`contains(split(labels["ip"], "1|1"), ".2.3.10")`, parser)
+	require.NoError(t, err)
+	match, err = expr.Evaluate(server)
+	require.NoError(t, err)
+	require.True(t, match)
+	require.False(t, splitContainsCalled)
+	require.True(t, splitContainsAffixCalled)
+	splitContainsAffixCalled = false
+
+	expr, err = newResourceExpression(`contains(split(labels["ip"], "xx"), "1.2.3.6")`, parser)
+	require.NoError(t, err)
+	match, err = expr.Evaluate(server)
+	require.NoError(t, err)
+	require.False(t, match)
+	require.False(t, splitContainsCalled)
+	require.True(t, splitContainsAffixCalled)
+	splitContainsAffixCalled = false
 
 	expr, err = newResourceExpression(`contains(split(labels["ip"], "|"), labels.target_ip)`, parser)
 	require.NoError(t, err)
@@ -573,7 +607,7 @@ func TestSplitContainsOptimizations(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, match)
 	require.True(t, splitContainsCalled)
-	require.False(t, splitContainsSinglebyteAffixCalled)
+	require.False(t, splitContainsAffixCalled)
 }
 
 // TestParserHostCertContext tests set functions with a custom host cert

--- a/lib/services/parser_test.go
+++ b/lib/services/parser_test.go
@@ -20,6 +20,8 @@ package services
 
 import (
 	"fmt"
+	"slices"
+	"strings"
 	"testing"
 	"time"
 
@@ -32,6 +34,7 @@ import (
 	"github.com/gravitational/teleport/api/constants"
 	apidefaults "github.com/gravitational/teleport/api/defaults"
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/utils/typical"
 )
 
 func TestParserForIdentifierSubcondition(t *testing.T) {
@@ -405,20 +408,142 @@ func TestResourceParserLabelExpansion(t *testing.T) {
 	}
 }
 
-func BenchmarkContains(b *testing.B) {
+func BenchmarkSplitContains(b *testing.B) {
+	parser, err := newResourceExpressionParser(func(ps *typical.ParserSpec[types.ResourceWithLabels]) {
+		// this avoids the AST optimizations on the exact function name of
+		// contains but otherwise has the same behavior
+		ps.Functions["contains_unoptimized"] = ps.Functions["contains"]
+		// this forces the slice to be created eagerly in memory
+		ps.Functions["contains_naive"] = typical.BinaryFunction[types.ResourceWithLabels](func(list []string, value string) (bool, error) {
+			return slices.Contains(list, value), nil
+		})
+	})
+	require.NoError(b, err)
+
 	server, err := types.NewServerWithLabels("server-name", types.KindNode, types.ServerSpecV2{
 		Hostname: "server-hostname",
-	}, map[string]string{"ip": "1.2.3.11|1.2.3.101|1.2.3.1"})
+	}, map[string]string{
+		"ip":        "1.2.3.11|1.2.3.101|1.2.3.1" + strings.Repeat("|2.3.4.5", 200) + "|1.2.3.6" + strings.Repeat("|2.3.4.5", 200),
+		"target_ip": "1.2.3.6",
+	})
 	require.NoError(b, err)
 
-	expression, err := NewResourceExpression(`contains(split(labels["ip"], "|"), "1.2.3.1")`)
+	server2, err := types.NewServerWithLabels("server-name", types.KindNode, types.ServerSpecV2{
+		Hostname: "server-hostname",
+	}, map[string]string{
+		"ip":        "1.2.3.11|1.2.3.101|1.2.3.1" + strings.Repeat("|2.3.4.5", 200) + "|1.2.3.5" + strings.Repeat("|2.3.4.5", 200),
+		"target_ip": "1.2.3.6",
+	})
 	require.NoError(b, err)
 
-	for b.Loop() {
-		match, err := expression.Evaluate(server)
-		require.NoError(b, err)
-		require.True(b, match)
+	for name, expr := range map[string]string{
+		// the happiest path
+		"optimized": `contains(split(labels["ip"], "|"), "1.2.3.6")`,
+		// these two should be equivalent after AST transformations, not as fast
+		// as the happy path when matching against a literal but still zero
+		// allocations
+		"auto_combined":   `contains(split(labels["ip"], "|"), labels.target_ip)`,
+		"manual_combined": `__split_contains(labels["ip"], "|", labels.target_ip)`,
+		// this uses lazy evaluation of slices so it should be about as fast as
+		// the combined version but with some object passing involved
+		"unoptimized": `contains_unoptimized(split(labels["ip"], "|"), "1.2.3.6")`,
+		// this will eagerly split the string into a slice and then checks items
+		// in the slice one by one, mimicking the legacy behavior
+		"legacy_naive": `contains_naive(split(labels["ip"], "|"), "1.2.3.6")`,
+	} {
+		b.Run(name, func(b *testing.B) {
+			expression, err := newResourceExpression(expr, parser)
+			require.NoError(b, err)
+
+			for b.Loop() {
+				match, err := expression.Evaluate(server)
+				require.NoError(b, err)
+				require.True(b, match)
+				match, err = expression.Evaluate(server2)
+				require.NoError(b, err)
+				require.False(b, match)
+			}
+		})
 	}
+}
+
+func TestSplitContainsZeroAlloc(t *testing.T) {
+	server, err := types.NewServerWithLabels("server-name", types.KindNode, types.ServerSpecV2{
+		Hostname: "server-hostname",
+	}, map[string]string{
+		"ip":        "1.2.3.11|1.2.3.101|1.2.3.1" + strings.Repeat("|2.3.4.5", 200) + "|1.2.3.6" + strings.Repeat("|2.3.4.5", 200),
+		"target_ip": "1.2.3.6",
+	})
+	require.NoError(t, err)
+
+	server2, err := types.NewServerWithLabels("server-name", types.KindNode, types.ServerSpecV2{
+		Hostname: "server-hostname",
+	}, map[string]string{
+		"ip":        "1.2.3.11|1.2.3.101|1.2.3.1" + strings.Repeat("|2.3.4.5", 200) + "|1.2.3.5" + strings.Repeat("|2.3.4.5", 200),
+		"target_ip": "1.2.3.6",
+	})
+	require.NoError(t, err)
+
+	for name, expr := range map[string]string{
+		"optimized":       `contains(split(labels["ip"], "|"), "1.2.3.6")`,
+		"auto_combined":   `contains(split(labels["ip"], "|"), labels.target_ip)`,
+		"manual_combined": `__split_contains(labels["ip"], "|", labels.target_ip)`,
+	} {
+		t.Run(name, func(t *testing.T) {
+			expression, err := NewResourceExpression(expr)
+			require.NoError(t, err)
+
+			allocs := testing.AllocsPerRun(1000, func() {
+				match, err := expression.Evaluate(server)
+				require.NoError(t, err)
+				require.True(t, match)
+				match, err = expression.Evaluate(server2)
+				require.NoError(t, err)
+				require.False(t, match)
+			})
+			require.Zero(t, allocs)
+		})
+	}
+}
+
+func TestSplitContainsOptimizations(t *testing.T) {
+	var splitContainsCalled, splitContainsSinglebyteAffixCalled bool
+	parser, err := newResourceExpressionParser(func(ps *typical.ParserSpec[types.ResourceWithLabels]) {
+		ps.Functions["__split_contains"] = typical.TernaryFunction[types.ResourceWithLabels](func(value string, delimiter string, target string) (bool, error) {
+			splitContainsCalled = true
+			return splitContains(value, delimiter, target), nil
+		})
+		ps.Functions["__split_contains_singlebyte_affix"] = typical.BinaryFunction[types.ResourceWithLabels](func(value string, delimTargetDelim string) (bool, error) {
+			splitContainsSinglebyteAffixCalled = true
+			return splitContainsSinglebyteAffix(value, delimTargetDelim), nil
+		})
+	})
+	require.NoError(t, err)
+
+	server, err := types.NewServerWithLabels("server-name", types.KindNode, types.ServerSpecV2{
+		Hostname: "server-hostname",
+	}, map[string]string{
+		"ip":        "1.2.3.11|1.2.3.101|1.2.3.1" + strings.Repeat("|2.3.4.5", 200) + "|1.2.3.6" + strings.Repeat("|2.3.4.5", 200),
+		"target_ip": "1.2.3.6",
+	})
+	require.NoError(t, err)
+
+	expr, err := newResourceExpression(`contains(split(labels["ip"], "|"), "1.2.3.6")`, parser)
+	require.NoError(t, err)
+	match, err := expr.Evaluate(server)
+	require.NoError(t, err)
+	require.True(t, match)
+	require.False(t, splitContainsCalled)
+	require.True(t, splitContainsSinglebyteAffixCalled)
+	splitContainsSinglebyteAffixCalled = false
+
+	expr, err = newResourceExpression(`contains(split(labels["ip"], "|"), labels.target_ip)`, parser)
+	require.NoError(t, err)
+	match, err = expr.Evaluate(server)
+	require.NoError(t, err)
+	require.True(t, match)
+	require.True(t, splitContainsCalled)
+	require.False(t, splitContainsSinglebyteAffixCalled)
 }
 
 // TestParserHostCertContext tests set functions with a custom host cert

--- a/lib/services/parser_test.go
+++ b/lib/services/parser_test.go
@@ -506,6 +506,86 @@ func BenchmarkSplitContains(b *testing.B) {
 	}
 }
 
+func TestSplitContainsFunctionality(t *testing.T) {
+	type testCase struct{ value, delimiter, target string }
+	testCases := []testCase{
+		{"", "", ""},
+		{"abc", "", ""},
+		{"abc", "", "a"},
+		{
+			"\u00e8", // LATIN SMALL LETTER E WITH GRAVE
+			"",
+			"\u00e8",
+		},
+		{
+			"\u00e8", // LATIN SMALL LETTER E WITH GRAVE
+			"",
+			"\xc3", // half of the encoding of U+00E8
+		},
+		{
+			"\u00e8", // LATIN SMALL LETTER E WITH GRAVE
+			"\xc3",   // half of the encoding of U+00E8
+			"\xa8",   // the other half
+		},
+		{"", ",", "a"},
+		{"a,b,c", ",", "a"},
+		{"a,b,c", ",", "d"},
+		{"a,b,c", ",", ""},
+		{"a,,b,,c", ",", ""},
+		{"a,,b,,c", ",", ",b"},
+		{"a,,,b,,,c", ",,", ",b"},
+		{"a,,,b,,,c", ",,", "b,"},
+		{"aaaa", "a", "a"},
+		{"aaaa", "aa", "a"},
+		{"aaaa", "aa", ""},
+		{"aaaa", "aa", "aa"},
+		{"aaa", "aa", "a"},
+	}
+	t.Run("lazyStringSplit", func(t *testing.T) {
+		for _, tc := range testCases {
+			lss := &lazyStringSplit{
+				value:     tc.value,
+				delimiter: tc.delimiter,
+			}
+			require.Equal(t,
+				strings.Split(tc.value, tc.delimiter),
+				lss.Slice(),
+			)
+			require.Equal(t,
+				slices.Contains(strings.Split(tc.value, tc.delimiter), tc.target),
+				lss.Contains(tc.target),
+			)
+		}
+	})
+	t.Run("splitContains", func(t *testing.T) {
+		for _, tc := range testCases {
+			require.Equal(t,
+				slices.Contains(strings.Split(tc.value, tc.delimiter), tc.target),
+				splitContains(tc.value, tc.delimiter, tc.target),
+			)
+		}
+	})
+	t.Run("splitContainsSinglebyteAffix", func(t *testing.T) {
+		for _, tc := range testCases {
+			if isImpossibleSplitContainsMatch(tc.target, tc.delimiter) {
+				require.Equal(t,
+					slices.Contains(strings.Split(tc.value, tc.delimiter), tc.target),
+					splitContainsSinglebyteAffix(tc.value, ""),
+				)
+				continue
+			}
+			if len(tc.delimiter) != 1 {
+				continue
+			}
+			require.Equal(t,
+				slices.Contains(strings.Split(tc.value, tc.delimiter), tc.target),
+				splitContainsSinglebyteAffix(tc.value, tc.delimiter+tc.target+tc.delimiter),
+			)
+		}
+	})
+
+}
+
 func TestSplitContainsZeroAlloc(t *testing.T) {
 	server, err := types.NewServerWithLabels("server-name", types.KindNode, types.ServerSpecV2{
 		Hostname: "server-hostname",

--- a/lib/services/parser_test.go
+++ b/lib/services/parser_test.go
@@ -527,6 +527,16 @@ func TestSplitContainsFunctionality(t *testing.T) {
 			"\xc3",   // half of the encoding of U+00E8
 			"\xa8",   // the other half
 		},
+		{
+			"\u00e8\xc3", // some broken utf-8
+			"",
+			"\xc3",
+		},
+		{
+			"\u00e8\xc3", // some broken utf-8
+			"a",
+			"\xc3",
+		},
 		{"", ",", "a"},
 		{"a,b,c", ",", "a"},
 		{"a,b,c", ",", "d"},

--- a/lib/services/parser_test.go
+++ b/lib/services/parser_test.go
@@ -460,53 +460,38 @@ func BenchmarkSplitContains(b *testing.B) {
 		"legacy_naive": `contains_naive(split(labels["ip"], "|"), "1.2.3.6")`,
 	} {
 		b.Run("impl="+name, func(b *testing.B) {
-			for _, repetitions := range []int{0, 1, 3, 5, 20, 100} {
-				addresses := slices.Concat(
-					[]string{"1.2.3.11", "1.2.3.101", "1.2.3.1"},
-					slices.Repeat([]string{"1.3.4.5"}, repetitions),
-					[]string{"1.2.3.6"},
-					slices.Repeat([]string{"1.3.4.7"}, repetitions),
-				)
-				addresses2 := slices.Concat(
-					[]string{"1.2.3.11", "1.2.3.101", "1.2.3.1"},
-					slices.Repeat([]string{"1.3.4.5"}, repetitions),
-					[]string{"1.2.3.5"},
-					slices.Repeat([]string{"1.3.4.7"}, repetitions),
-				)
-				for _, delimLength := range []int{1, 2} {
-					delim := strings.Repeat("|", delimLength)
-					ipLabel := strings.Join(addresses, delim)
-					ipLabel2 := strings.Join(addresses2, delim)
-					b.Run(fmt.Sprintf("label=%d/delim=%d", len(ipLabel), delimLength), func(b *testing.B) {
-						server, err := types.NewServerWithLabels("server-name", types.KindNode, types.ServerSpecV2{
-							Hostname: "server-hostname",
-						}, map[string]string{
-							"ip":        ipLabel,
-							"target_ip": "1.2.3.6",
-						})
-						require.NoError(b, err)
-
-						server2, err := types.NewServerWithLabels("server-name", types.KindNode, types.ServerSpecV2{
-							Hostname: "server-hostname",
-						}, map[string]string{
-							"ip":        ipLabel2,
-							"target_ip": "1.2.3.6",
-						})
-						require.NoError(b, err)
-
-						expression, err := newResourceExpression(expr, parser)
-						require.NoError(b, err)
-
-						for b.Loop() {
-							match, err := expression.Evaluate(server)
-							require.NoError(b, err)
-							require.True(b, match)
-							match, err = expression.Evaluate(server2)
-							require.NoError(b, err)
-							require.False(b, match)
-						}
+			for _, repetitions := range []int{0, 1, 3, 5, 200} {
+				ipLabel := "1.2.3.11|1.2.3.101|1.2.3.1" + strings.Repeat("|2.3.4.5", repetitions) + "|1.2.3.6" + strings.Repeat("|2.3.4.5", repetitions)
+				ipLabel2 := "1.2.3.11|1.2.3.101|1.2.3.1" + strings.Repeat("|2.3.4.5", repetitions) + "|1.2.3.5" + strings.Repeat("|2.3.4.5", repetitions)
+				b.Run(fmt.Sprintf("label_length=%d", len(ipLabel)), func(b *testing.B) {
+					server, err := types.NewServerWithLabels("server-name", types.KindNode, types.ServerSpecV2{
+						Hostname: "server-hostname",
+					}, map[string]string{
+						"ip":        ipLabel,
+						"target_ip": "1.2.3.6",
 					})
-				}
+					require.NoError(b, err)
+
+					server2, err := types.NewServerWithLabels("server-name", types.KindNode, types.ServerSpecV2{
+						Hostname: "server-hostname",
+					}, map[string]string{
+						"ip":        ipLabel2,
+						"target_ip": "1.2.3.6",
+					})
+					require.NoError(b, err)
+
+					expression, err := newResourceExpression(expr, parser)
+					require.NoError(b, err)
+
+					for b.Loop() {
+						match, err := expression.Evaluate(server)
+						require.NoError(b, err)
+						require.True(b, match)
+						match, err = expression.Evaluate(server2)
+						require.NoError(b, err)
+						require.False(b, match)
+					}
+				})
 			}
 		})
 	}
@@ -530,10 +515,9 @@ func TestSplitContainsZeroAlloc(t *testing.T) {
 	require.NoError(t, err)
 
 	for name, expr := range map[string]string{
-		"optimized":           `contains(split(labels["ip"], "|"), "1.2.3.101")`,
-		"optimized_multibyte": `contains(split(labels["ip"], "1|"), "1.2.3.10")`,
-		"auto_combined":       `contains(split(labels["ip"], "|"), labels.target_ip)`,
-		"manual_combined":     `__split_contains(labels["ip"], "|", labels.target_ip)`,
+		"optimized":       `contains(split(labels["ip"], "|"), "1.2.3.101")`,
+		"auto_combined":   `contains(split(labels["ip"], "|"), labels.target_ip)`,
+		"manual_combined": `__split_contains(labels["ip"], "|", labels.target_ip)`,
 	} {
 		t.Run(name, func(t *testing.T) {
 			expression, err := NewResourceExpression(expr)
@@ -553,15 +537,15 @@ func TestSplitContainsZeroAlloc(t *testing.T) {
 }
 
 func TestSplitContainsOptimizations(t *testing.T) {
-	var splitContainsCalled, splitContainsAffixCalled bool
+	var splitContainsCalled, splitContainsSinglebyteAffixCalled bool
 	parser, err := newResourceExpressionParser(func(ps *typical.ParserSpec[types.ResourceWithLabels]) {
 		ps.Functions["__split_contains"] = typical.TernaryFunction[types.ResourceWithLabels](func(value string, delimiter string, target string) (bool, error) {
 			splitContainsCalled = true
 			return splitContains(value, delimiter, target), nil
 		})
-		ps.Functions["__split_contains_affix"] = typical.TernaryFunction[types.ResourceWithLabels](func(value string, delimTargetDelim string, delimLength int) (bool, error) {
-			splitContainsAffixCalled = true
-			return splitContainsAffix(value, delimTargetDelim, delimLength), nil
+		ps.Functions["__split_contains_singlebyte_affix"] = typical.BinaryFunction[types.ResourceWithLabels](func(value string, delimTargetDelim string) (bool, error) {
+			splitContainsSinglebyteAffixCalled = true
+			return splitContainsSinglebyteAffix(value, delimTargetDelim), nil
 		})
 	})
 	require.NoError(t, err)
@@ -580,26 +564,8 @@ func TestSplitContainsOptimizations(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, match)
 	require.False(t, splitContainsCalled)
-	require.True(t, splitContainsAffixCalled)
-	splitContainsAffixCalled = false
-
-	expr, err = newResourceExpression(`contains(split(labels["ip"], "1|1"), ".2.3.10")`, parser)
-	require.NoError(t, err)
-	match, err = expr.Evaluate(server)
-	require.NoError(t, err)
-	require.True(t, match)
-	require.False(t, splitContainsCalled)
-	require.True(t, splitContainsAffixCalled)
-	splitContainsAffixCalled = false
-
-	expr, err = newResourceExpression(`contains(split(labels["ip"], "xx"), "1.2.3.6")`, parser)
-	require.NoError(t, err)
-	match, err = expr.Evaluate(server)
-	require.NoError(t, err)
-	require.False(t, match)
-	require.False(t, splitContainsCalled)
-	require.True(t, splitContainsAffixCalled)
-	splitContainsAffixCalled = false
+	require.True(t, splitContainsSinglebyteAffixCalled)
+	splitContainsSinglebyteAffixCalled = false
 
 	expr, err = newResourceExpression(`contains(split(labels["ip"], "|"), labels.target_ip)`, parser)
 	require.NoError(t, err)
@@ -607,7 +573,7 @@ func TestSplitContainsOptimizations(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, match)
 	require.True(t, splitContainsCalled)
-	require.False(t, splitContainsAffixCalled)
+	require.False(t, splitContainsSinglebyteAffixCalled)
 }
 
 // TestParserHostCertContext tests set functions with a custom host cert

--- a/lib/services/parser_test.go
+++ b/lib/services/parser_test.go
@@ -363,7 +363,7 @@ func TestResourceParserLabelExpansion(t *testing.T) {
 	// Server resource should use hostname when using name identifier.
 	server, err := types.NewServerWithLabels("server-name", types.KindNode, types.ServerSpecV2{
 		Hostname: "server-hostname",
-	}, map[string]string{"ip": "1.2.3.11,1.2.3.101,1.2.3.1", "foo": "bar"})
+	}, map[string]string{"ip": "1.2.3.11,1.2.3.101,1.2.3.1", "present_ip": "1.2.3.1", "absent_ip": "1.2.3.5", "foo": "bar"})
 	require.NoError(t, err)
 
 	tests := []struct {
@@ -384,6 +384,26 @@ func TestResourceParserLabelExpansion(t *testing.T) {
 		},
 		{
 			expression: `contains(split(labels.llama, ","),  "1.2.3.2")`,
+			assertion:  require.False,
+		},
+		{
+			expression: `contains(split(labels.llama, ","), "")`,
+			assertion:  require.True,
+		},
+		{
+			expression: `contains(split(labels.llama, ","), labels.llama)`,
+			assertion:  require.True,
+		},
+		{
+			expression: `contains(split(labels.ip, ","), "1.2.3.2")`,
+			assertion:  require.False,
+		},
+		{
+			expression: `contains(split(labels.ip, ","), labels.present_ip)`,
+			assertion:  require.True,
+		},
+		{
+			expression: `contains(split(labels.ip, ","), labels.absent_ip)`,
 			assertion:  require.False,
 		},
 		{

--- a/lib/utils/typical/parser.go
+++ b/lib/utils/typical/parser.go
@@ -1046,28 +1046,28 @@ func (l LiteralExpr[TEnv, T]) Evaluate(TEnv) (T, error) {
 	return l.Value, nil
 }
 
-type LazyStringSlice interface {
+type StringSlice interface {
 	Slice() []string
 	Contains(target string) bool
 }
 
-type stringSliceAsLazyStringSlice []string
+type actualStringSlice []string
 
-func (s stringSliceAsLazyStringSlice) Slice() []string {
+func (s actualStringSlice) Slice() []string {
 	return s
 }
 
-func (s stringSliceAsLazyStringSlice) Contains(target string) bool {
+func (s actualStringSlice) Contains(target string) bool {
 	return slices.Contains(s, target)
 }
 
-type stringAsLazyStringSlice string
+type stringAsStringSlice string
 
-func (s stringAsLazyStringSlice) Slice() []string {
+func (s stringAsStringSlice) Slice() []string {
 	return []string{string(s)}
 }
 
-func (s stringAsLazyStringSlice) Contains(target string) bool {
+func (s stringAsStringSlice) Contains(target string) bool {
 	return string(s) == target
 }
 
@@ -1084,21 +1084,24 @@ func coerce[TEnv, TArg any](arg any) (Expression[TEnv, TArg], error) {
 
 	{
 		var expr Expression[TEnv, TArg]
+		// this is a runtime check to know if TArg is []string; if it is, we can
+		// write an Expression[TEnv, []string] through typedExpr and then expr
+		// will be the Expression[TEnv, TArg] to return, without having to do a
+		// second type assertion
 		typedExpr, ok := any(&expr).(*Expression[TEnv, []string])
 		if ok {
-			// If we are expecting a []string and given a string, wrap it in a slice.
-			// This happens at parse time without reflection during evaluation.
-			// It's probably possible to do this for any slice type with heavy use
-			// of reflect, but for now []string is sufficient.
+			switch arg := arg.(type) {
+			// If we are expecting a []string and given a string or an
+			// expression returning a string, we wrap it in a slice. This
+			// happens at parse time without reflection during evaluation. It's
+			// probably possible to do this for any slice type with heavy use of
+			// reflect, but for now []string is sufficient.
 			//
 			// This enables functions like strings.upper(str) to accept lists or
-			// single strings, which is common in existing predicate expressions.
-			switch arg := arg.(type) {
+			// single strings, which is common in existing predicate
+			// expressions.
 			case string:
 				*typedExpr = LiteralExpr[TEnv, []string]{[]string{arg}}
-			case []string:
-				// This case will be necessary if we caught a slice literal.
-				*typedExpr = LiteralExpr[TEnv, []string]{arg}
 			case Expression[TEnv, string]:
 				*typedExpr = dynamicVariable[TEnv, []string]{
 					func(env TEnv) ([]string, error) {
@@ -1109,7 +1112,13 @@ func coerce[TEnv, TArg any](arg any) (Expression[TEnv, TArg], error) {
 						return []string{str}, nil
 					},
 				}
-			case Expression[TEnv, LazyStringSlice]:
+			// This case will be necessary if we caught a slice literal.
+			case []string:
+				*typedExpr = LiteralExpr[TEnv, []string]{arg}
+			// This case is if we have an expression returning a [StringSlice]
+			// but we're expecting a []string. There's no way to get a
+			// StringSlice literal, so we don't have to deal with that.
+			case Expression[TEnv, StringSlice]:
 				*typedExpr = dynamicVariable[TEnv, []string]{
 					accessor: func(env TEnv) ([]string, error) {
 						lss, err := arg.Evaluate(env)
@@ -1129,31 +1138,37 @@ func coerce[TEnv, TArg any](arg any) (Expression[TEnv, TArg], error) {
 
 	{
 		var expr Expression[TEnv, TArg]
-		typedExpr, ok := any(&expr).(*Expression[TEnv, LazyStringSlice])
+		// same type check as above, if this passes we know that TArg is StringSlice
+		typedExpr, ok := any(&expr).(*Expression[TEnv, StringSlice])
 		if ok {
 			switch arg := arg.(type) {
+			// Like what we do above when expecting a []string, we wrap string
+			// literals and string expressions into singleton [StringSlice]
+			// objects with the appropriate adapter.
 			case string:
-				*typedExpr = LiteralExpr[TEnv, LazyStringSlice]{stringAsLazyStringSlice(arg)}
-			case []string:
-				*typedExpr = LiteralExpr[TEnv, LazyStringSlice]{stringSliceAsLazyStringSlice(arg)}
+				*typedExpr = LiteralExpr[TEnv, StringSlice]{stringAsStringSlice(arg)}
 			case Expression[TEnv, string]:
-				*typedExpr = dynamicVariable[TEnv, LazyStringSlice]{
-					accessor: func(env TEnv) (LazyStringSlice, error) {
+				*typedExpr = dynamicVariable[TEnv, StringSlice]{
+					accessor: func(env TEnv) (StringSlice, error) {
 						str, err := arg.Evaluate(env)
 						if err != nil {
 							return nil, trace.Wrap(err)
 						}
-						return stringAsLazyStringSlice(str), nil
+						return stringAsStringSlice(str), nil
 					},
 				}
+			// These cases convert from []string literals or expressions into
+			// StringSlice.
+			case []string:
+				*typedExpr = LiteralExpr[TEnv, StringSlice]{actualStringSlice(arg)}
 			case Expression[TEnv, []string]:
-				*typedExpr = dynamicVariable[TEnv, LazyStringSlice]{
-					accessor: func(env TEnv) (LazyStringSlice, error) {
+				*typedExpr = dynamicVariable[TEnv, StringSlice]{
+					accessor: func(env TEnv) (StringSlice, error) {
 						ss, err := arg.Evaluate(env)
 						if err != nil {
 							return nil, trace.Wrap(err)
 						}
-						return stringSliceAsLazyStringSlice(ss), nil
+						return actualStringSlice(ss), nil
 					},
 				}
 			default:

--- a/lib/utils/typical/parser.go
+++ b/lib/utils/typical/parser.go
@@ -40,7 +40,9 @@ package typical
 
 import (
 	"fmt"
+	"go/ast"
 	"reflect"
+	"slices"
 
 	"github.com/gravitational/trace"
 	"github.com/vulcand/predicate"
@@ -98,7 +100,7 @@ type Function interface {
 // specific expression language.
 type Parser[TEnv, TResult any] struct {
 	spec    ParserSpec[TEnv]
-	pred    predicate.Parser
+	pred    predicate.ASTParser
 	options parserOptions
 }
 
@@ -157,7 +159,7 @@ func NewParser[TEnv, TResult any](spec ParserSpec[TEnv], opts ...ParserOption) (
 		}
 	}
 
-	pred, err := predicate.NewParser(def)
+	pred, err := predicate.NewASTParser(def)
 	if err != nil {
 		return nil, trace.Wrap(err, "creating predicate parser")
 	}
@@ -173,6 +175,21 @@ func (p *Parser[TEnv, TResult]) Parse(expression string) (Expression[TEnv, TResu
 		return nil, trace.BadParameter("empty expression")
 	}
 	result, err := p.pred.Parse(expression)
+	if err != nil {
+		return nil, trace.Wrap(err, "parsing expression")
+	}
+	expr, err := coerce[TEnv, TResult](result)
+	if err != nil {
+		return nil, trace.Wrap(err, "expression evaluated to unexpected type")
+	}
+	return expr, nil
+}
+
+func (p *Parser[TEnv, TResult]) ParseAST(expression ast.Expr) (Expression[TEnv, TResult], error) {
+	if expression == nil {
+		return nil, trace.BadParameter("nil expression")
+	}
+	result, err := p.pred.ParseAST(expression)
 	if err != nil {
 		return nil, trace.Wrap(err, "parsing expression")
 	}
@@ -1029,6 +1046,31 @@ func (l LiteralExpr[TEnv, T]) Evaluate(TEnv) (T, error) {
 	return l.Value, nil
 }
 
+type LazyStringSlice interface {
+	Slice() []string
+	Contains(target string) bool
+}
+
+type stringSliceAsLazyStringSlice []string
+
+func (s stringSliceAsLazyStringSlice) Slice() []string {
+	return s
+}
+
+func (s stringSliceAsLazyStringSlice) Contains(target string) bool {
+	return slices.Contains(s, target)
+}
+
+type stringAsLazyStringSlice string
+
+func (s stringAsLazyStringSlice) Slice() []string {
+	return []string{string(s)}
+}
+
+func (s stringAsLazyStringSlice) Contains(target string) bool {
+	return string(s) == target
+}
+
 // coerce is called at parse time to attempt to convert arg to an
 // Expression[TEnv, TArg]. In most cases (for valid expressions) we can convert
 // all arguments to known types at parse time so that reflection is not
@@ -1040,38 +1082,86 @@ func coerce[TEnv, TArg any](arg any) (Expression[TEnv, TArg], error) {
 		return typedArgExpr, nil
 	}
 
-	// any(*new(TArg)) is a trick to create an interface wrapping an instance of
-	// the generic type TArg so that we can do a type assertion on TArg.
-	if _, ok := any(*new(TArg)).([]string); ok {
-		// If we are expecting a []string and given a string, wrap it in a slice.
-		// This happens at parse time without reflection during evaluation.
-		// It's probably possible to do this for any slice type with heavy use
-		// of reflect, but for now []string is sufficient.
-		//
-		// This enables functions like strings.upper(str) to accept lists or
-		// single strings, which is common in existing predicate expressions.
-		var sliceExpr Expression[TEnv, []string]
-		switch typedArg := arg.(type) {
-		case string:
-			sliceExpr = LiteralExpr[TEnv, []string]{[]string{typedArg}}
-		case []string:
-			// This case will be necessary if we caught a slice literal.
-			sliceExpr = LiteralExpr[TEnv, []string]{typedArg}
-		case Expression[TEnv, string]:
-			sliceExpr = dynamicVariable[TEnv, []string]{
-				func(env TEnv) ([]string, error) {
-					str, err := typedArg.Evaluate(env)
-					if err != nil {
-						return nil, trace.Wrap(err)
-					}
-					return []string{str}, nil
-				},
+	{
+		var expr Expression[TEnv, TArg]
+		typedExpr, ok := any(&expr).(*Expression[TEnv, []string])
+		if ok {
+			// If we are expecting a []string and given a string, wrap it in a slice.
+			// This happens at parse time without reflection during evaluation.
+			// It's probably possible to do this for any slice type with heavy use
+			// of reflect, but for now []string is sufficient.
+			//
+			// This enables functions like strings.upper(str) to accept lists or
+			// single strings, which is common in existing predicate expressions.
+			switch arg := arg.(type) {
+			case string:
+				*typedExpr = LiteralExpr[TEnv, []string]{[]string{arg}}
+			case []string:
+				// This case will be necessary if we caught a slice literal.
+				*typedExpr = LiteralExpr[TEnv, []string]{arg}
+			case Expression[TEnv, string]:
+				*typedExpr = dynamicVariable[TEnv, []string]{
+					func(env TEnv) ([]string, error) {
+						str, err := arg.Evaluate(env)
+						if err != nil {
+							return nil, trace.Wrap(err)
+						}
+						return []string{str}, nil
+					},
+				}
+			case Expression[TEnv, LazyStringSlice]:
+				*typedExpr = dynamicVariable[TEnv, []string]{
+					accessor: func(env TEnv) ([]string, error) {
+						lss, err := arg.Evaluate(env)
+						if err != nil {
+							return nil, trace.Wrap(err)
+						}
+						return lss.Slice(), nil
+					},
+				}
+			default:
+				return nil, unexpectedTypeError[TArg](arg)
 			}
-		default:
-			return nil, unexpectedTypeError[TArg](arg)
+
+			return expr, nil
 		}
-		// We know TArg is []string so this assertion is safe.
-		return sliceExpr.(Expression[TEnv, TArg]), nil
+	}
+
+	{
+		var expr Expression[TEnv, TArg]
+		typedExpr, ok := any(&expr).(*Expression[TEnv, LazyStringSlice])
+		if ok {
+			switch arg := arg.(type) {
+			case string:
+				*typedExpr = LiteralExpr[TEnv, LazyStringSlice]{stringAsLazyStringSlice(arg)}
+			case []string:
+				*typedExpr = LiteralExpr[TEnv, LazyStringSlice]{stringSliceAsLazyStringSlice(arg)}
+			case Expression[TEnv, string]:
+				*typedExpr = dynamicVariable[TEnv, LazyStringSlice]{
+					accessor: func(env TEnv) (LazyStringSlice, error) {
+						str, err := arg.Evaluate(env)
+						if err != nil {
+							return nil, trace.Wrap(err)
+						}
+						return stringAsLazyStringSlice(str), nil
+					},
+				}
+			case Expression[TEnv, []string]:
+				*typedExpr = dynamicVariable[TEnv, LazyStringSlice]{
+					accessor: func(env TEnv) (LazyStringSlice, error) {
+						ss, err := arg.Evaluate(env)
+						if err != nil {
+							return nil, trace.Wrap(err)
+						}
+						return stringSliceAsLazyStringSlice(ss), nil
+					},
+				}
+			default:
+				return nil, unexpectedTypeError[TArg](arg)
+			}
+
+			return expr, nil
+		}
 	}
 
 	if anyExpr, ok := arg.(Expression[TEnv, any]); ok {

--- a/lib/utils/typical/parser.go
+++ b/lib/utils/typical/parser.go
@@ -373,22 +373,32 @@ func (d dynamicMap[TEnv, TValues, TMap]) buildIndexExpression(keyExpr Expression
 	}}
 }
 
-type funcGetter[TValues any] func(key string) (TValues, error)
-
-func (f funcGetter[TValues]) Get(key string) (TValues, error) {
-	return f(key)
-}
-
 // DynamicMapFunction returns a definition for a variable that can be indexed
 // with map[key] or map.key syntax to get a TValues. Each time the
 // variable is indexed in an expression, [getFunc] will be called to retrieve
 // the value.
 func DynamicMapFunction[TEnv, TValues any](getFunc func(env TEnv, key string) (TValues, error)) Variable {
-	return DynamicMap[TEnv, TValues](func(env TEnv) (funcGetter[TValues], error) {
-		return funcGetter[TValues](func(key string) (TValues, error) {
-			return getFunc(env, key)
-		}), nil
-	})
+	return dynamicMapFunction[TEnv, TValues]{getFunc: getFunc}
+}
+
+type dynamicMapFunction[TEnv, TValues any] struct {
+	getFunc func(env TEnv, key string) (TValues, error)
+}
+
+//nolint:unused // https://github.com/dominikh/go-tools/issues/1294
+func (d dynamicMapFunction[TEnv, TValues]) buildIndexExpression(keyExpr Expression[TEnv, string]) any {
+	return dynamicVariable[TEnv, TValues]{func(env TEnv) (TValues, error) {
+		var nul TValues
+		key, err := keyExpr.Evaluate(env)
+		if err != nil {
+			return nul, trace.Wrap(err, "evaluating key of index expression")
+		}
+		result, err := d.getFunc(env, key)
+		if err != nil {
+			return nul, trace.Wrap(err, "getting value from dynamic map")
+		}
+		return result, nil
+	}}
 }
 
 type dynamicVariable[TEnv, TVar any] struct {

--- a/lib/utils/typical/parser.go
+++ b/lib/utils/typical/parser.go
@@ -1046,27 +1046,44 @@ func (l LiteralExpr[TEnv, T]) Evaluate(TEnv) (T, error) {
 	return l.Value, nil
 }
 
+// StringSlice is an interface to represent operations that one might want to do
+// on a string slice, but without necessarily having to evaluate the slice
+// eagerly.
 type StringSlice interface {
+	// Slice converts the StringSlice into a regular []string. The return value
+	// might be shared between callers, so it shouldn't be modified, but
+	// implementations might have to create a new slice at every call.
 	Slice() []string
+	// Contains returns true if the target string is in the slice. Calling
+	// Contains should be equivalent (but can be faster) to calling
+	// [slices.Contains] on the result of Slice().
 	Contains(target string) bool
 }
 
+// actualStringSlice is an adapter type to treat an actual []string as a
+// [StringSlice].
 type actualStringSlice []string
 
+// Slice implements [StringSlice].
 func (s actualStringSlice) Slice() []string {
 	return s
 }
 
+// Contains implements [StringSlice].
 func (s actualStringSlice) Contains(target string) bool {
 	return slices.Contains(s, target)
 }
 
+// stringAsStringSlice is an adapter to regard a single string as a singleton
+// [StringSlice].
 type stringAsStringSlice string
 
+// Slice implements [StringSlice].
 func (s stringAsStringSlice) Slice() []string {
 	return []string{string(s)}
 }
 
+// Contains implements [StringSlice].
 func (s stringAsStringSlice) Contains(target string) bool {
 	return string(s) == target
 }


### PR DESCRIPTION
This PR improves the performance of predicate resource expressions in a number of ways:
- gets rid of allocations during evaluation caused by `typical.DynamicMapFunction`, avoiding the extra "accessor" step of `typical.DynamicMap` used to return a map-like object that, in the case of `DynamicMapFunction`, would just end up being an unusable `funcGetter` object anyway;
- adds an AST-level optimization to replace the function composition of `contains(split(value, delimiter), target)` with a single call to an internal-use function `__split_contains(value, delimiter, target)` that iterates over the string with `strings.SplitSeq` and does a pre-check with `strings.Contains` (it's common to use resource expressions to match exactly one resource, so most resources can be excluded with a faster check like this);
- adds a second AST-level optimization to turn calls to `__split_contains` that use literal expressions for delimiter and target into a more optimized internal-use function that can take full advantage of `strings.Contains` by manipulating string literals at parse time; this is shown by benchmarks to be over twice as fast as the already faster implementation that skips the slicing;
- as an additional safeguard against more complicated expressions that we somehow fail to optimize, adds the ability for users of the `lib/utils/typical` parser to deal with `StringSlice` objects that can be converted into regular string slices but can also directly check for string membership, and uses this in the resource expression parser so that if the return value of `split` is passed to an invocation of `contains` we still avoid the full string split.


Benchmark as ran on work laptop, the "optimized" variant has the full set of optimizations, the "combined" variants don't take advantage of the second optimization and the "unoptimized" variant only uses the more performant lazy implementation (and thus has some memory allocation in the hot loop), the "legacy_naive" variant is essentially the implementation as it currently stands, before this PR.

<details>
<summary>Benchmark</summary>

```
goos: darwin
goarch: arm64
pkg: github.com/gravitational/teleport/lib/services
cpu: Apple M4 Pro
BenchmarkSplitContains/impl=optimized/label_length=34-14         	 3318758	       356.9 ns/op	       0 B/op	       0 allocs/op
BenchmarkSplitContains/impl=optimized/label_length=50-14         	 3009904	       398.4 ns/op	       0 B/op	       0 allocs/op
BenchmarkSplitContains/impl=optimized/label_length=82-14         	 2694086	       445.1 ns/op	       0 B/op	       0 allocs/op
BenchmarkSplitContains/impl=optimized/label_length=114-14        	 2476327	       481.6 ns/op	       0 B/op	       0 allocs/op
BenchmarkSplitContains/impl=optimized/label_length=3234-14       	  759519	      1550 ns/op	       0 B/op	       0 allocs/op
BenchmarkSplitContains/impl=auto_combined/label_length=34-14     	 2589672	       459.6 ns/op	       0 B/op	       0 allocs/op
BenchmarkSplitContains/impl=auto_combined/label_length=50-14     	 2386660	       503.7 ns/op	       0 B/op	       0 allocs/op
BenchmarkSplitContains/impl=auto_combined/label_length=82-14     	 2236590	       535.2 ns/op	       0 B/op	       0 allocs/op
BenchmarkSplitContains/impl=auto_combined/label_length=114-14    	 2144386	       559.2 ns/op	       0 B/op	       0 allocs/op
BenchmarkSplitContains/impl=auto_combined/label_length=3234-14   	  319545	      3522 ns/op	       0 B/op	       0 allocs/op
BenchmarkSplitContains/impl=manual_combined/label_length=34-14   	 2562504	       469.2 ns/op	       0 B/op	       0 allocs/op
BenchmarkSplitContains/impl=manual_combined/label_length=50-14   	 2398839	       501.5 ns/op	       0 B/op	       0 allocs/op
BenchmarkSplitContains/impl=manual_combined/label_length=82-14   	 2251044	       533.4 ns/op	       0 B/op	       0 allocs/op
BenchmarkSplitContains/impl=manual_combined/label_length=114-14  	 2119479	       564.6 ns/op	       0 B/op	       0 allocs/op
BenchmarkSplitContains/impl=manual_combined/label_length=3234-14 	  318231	      3501 ns/op	       0 B/op	       0 allocs/op
BenchmarkSplitContains/impl=unoptimized/label_length=34-14       	 2597746	       462.2 ns/op	      64 B/op	       2 allocs/op
BenchmarkSplitContains/impl=unoptimized/label_length=50-14       	 2346944	       510.3 ns/op	      64 B/op	       2 allocs/op
BenchmarkSplitContains/impl=unoptimized/label_length=82-14       	 2206498	       541.7 ns/op	      64 B/op	       2 allocs/op
BenchmarkSplitContains/impl=unoptimized/label_length=114-14      	 2103183	       570.2 ns/op	      64 B/op	       2 allocs/op
BenchmarkSplitContains/impl=unoptimized/label_length=3234-14     	  316538	      3461 ns/op	      64 B/op	       2 allocs/op
BenchmarkSplitContains/impl=legacy_naive/label_length=34-14      	 2604980	       460.9 ns/op	     192 B/op	       4 allocs/op
BenchmarkSplitContains/impl=legacy_naive/label_length=50-14      	 2351200	       512.8 ns/op	     256 B/op	       4 allocs/op
BenchmarkSplitContains/impl=legacy_naive/label_length=82-14      	 2023129	       594.0 ns/op	     384 B/op	       4 allocs/op
BenchmarkSplitContains/impl=legacy_naive/label_length=114-14     	 1773704	       675.0 ns/op	     512 B/op	       4 allocs/op
BenchmarkSplitContains/impl=legacy_naive/label_length=3234-14    	  142918	      8123 ns/op	   13120 B/op	       4 allocs/op
PASS
ok  	github.com/gravitational/teleport/lib/services	30.468s
```

</details>

This PR bumps gravitational/predicate to include gravitational/predicate#23.

Changelog: Improved the performance of certain predicate expressions used to select SSH servers

## Manual Test Plan
### Test Environment

Custom build on a cloud staging tenant on a dedicated node with one auth, 100k synthetic node entries with a comma-separated "ip" label containing 20 random ip addresses, one real agent (latest Teleport release), custom client to load test `ResolveSSHTarget` running on an EC2 instance in the same region as the auth, `tsh` on local laptop (latest Teleport release)

### Test Cases
- [x] Predicate-based SSH (i.e. `tsh` with proxy templates) works
- [x] Load testing `ResolveSSHTarget` at scale shows the appropriate improvement in throughput and GC pressure compared to a build without this PR
