### PR TITLE
scope-aware authz for discovery configs

### DIFF
--- a/api/types/discoveryconfig/discoveryconfig.go
+++ b/api/types/discoveryconfig/discoveryconfig.go
@@ -267,3 +267,10 @@ func (a *DiscoveryConfig) CloneResource() types.ResourceWithLabels {
 	utils.StrictObjectToStruct(a, &copy)
 	return copy
 }
+
+// GetScope returns the scope this discovery config belongs to.
+func (a *DiscoveryConfig) GetScope() string {
+	// Discovery configs are currently always unscoped.
+	// TODO(nklaassen): scope discovery configs.
+	return ""
+}

--- a/lib/auth/discoveryconfig/discoveryconfigv1/service.go
+++ b/lib/auth/discoveryconfig/discoveryconfigv1/service.go
@@ -53,10 +53,11 @@ type ServiceConfig struct {
 	Logger *slog.Logger
 
 	// Authorizer is the authorizer to use.
-	Authorizer authz.Authorizer
+	Authorizer authz.ScopedAuthorizer
 
-	// Backend is the backend for storing DiscoveryConfigs.
-	Backend services.DiscoveryConfigs
+	// Backend is the backend for storing DiscoveryConfigs. This must be a local
+	// backend because list authorization requires server-side filtering.
+	Backend services.DiscoveryConfigsWithFilter
 
 	// Clock is the clock.
 	Clock clockwork.Clock
@@ -101,8 +102,8 @@ type Service struct {
 	discoveryconfigv1.UnimplementedDiscoveryConfigServiceServer
 
 	log           *slog.Logger
-	authorizer    authz.Authorizer
-	backend       services.DiscoveryConfigs
+	authorizer    authz.ScopedAuthorizer
+	backend       services.DiscoveryConfigsWithFilter
 	clock         clockwork.Clock
 	emitter       apievents.Emitter
 	usageReporter usagereporter.UsageReporter
@@ -126,16 +127,25 @@ func NewService(cfg ServiceConfig) (*Service, error) {
 
 // ListDiscoveryConfigs returns a paginated list of all DiscoveryConfig resources.
 func (s *Service) ListDiscoveryConfigs(ctx context.Context, req *discoveryconfigv1.ListDiscoveryConfigsRequest) (*discoveryconfigv1.ListDiscoveryConfigsResponse, error) {
-	authCtx, err := s.authorizer.Authorize(ctx)
+	authCtx, err := s.authorizer.AuthorizeScoped(ctx)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
-	if err := authCtx.CheckAccessToKind(types.KindDiscoveryConfig, types.VerbRead, types.VerbList); err != nil {
+	// Perform pre-authz check to break early if the caller definitely can't
+	// list discovery configs.
+	ruleCtx := authCtx.RuleContext()
+	if err := authCtx.CheckerContext.CheckMaybeHasAccessToRules(&ruleCtx, types.KindDiscoveryConfig, types.VerbRead, types.VerbList); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
-	results, nextKey, err := s.backend.ListDiscoveryConfigs(ctx, int(req.GetPageSize()), req.GetNextToken())
+	results, nextKey, err := s.backend.ListDiscoveryConfigsWithFilter(ctx, int(req.GetPageSize()), req.GetNextToken(), func(dc *discoveryconfig.DiscoveryConfig) bool {
+		ruleCtx.Resource = dc
+		err := authCtx.CheckerContext.Decision(ctx, dc.GetScope(), func(checker *services.ScopedAccessChecker) error {
+			return checker.CheckAccessToRules(&ruleCtx, types.KindDiscoveryConfig, types.VerbRead, types.VerbList)
+		})
+		return err == nil
+	})
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -157,17 +167,25 @@ func (s *Service) ListDiscoveryConfigs(ctx context.Context, req *discoveryconfig
 
 // GetDiscoveryConfig returns the specified DiscoveryConfig resource.
 func (s *Service) GetDiscoveryConfig(ctx context.Context, req *discoveryconfigv1.GetDiscoveryConfigRequest) (*discoveryconfigv1.DiscoveryConfig, error) {
-	authCtx, err := s.authorizer.Authorize(ctx)
+	authCtx, err := s.authorizer.AuthorizeScoped(ctx)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
-	if err := authCtx.CheckAccessToKind(types.KindDiscoveryConfig, types.VerbRead); err != nil {
+	ruleCtx := authCtx.RuleContext()
+	if err := authCtx.CheckerContext.CheckMaybeHasAccessToRules(&ruleCtx, types.KindDiscoveryConfig, types.VerbRead); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
 	dc, err := s.backend.GetDiscoveryConfig(ctx, req.Name)
 	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	ruleCtx.Resource = dc
+	if err := authCtx.CheckerContext.Decision(ctx, dc.GetScope(), func(checker *services.ScopedAccessChecker) error {
+		return checker.CheckAccessToRules(&ruleCtx, types.KindDiscoveryConfig, types.VerbRead)
+	}); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
@@ -181,17 +199,21 @@ func (s *Service) GetDiscoveryConfig(ctx context.Context, req *discoveryconfigv1
 
 // CreateDiscoveryConfig creates a new DiscoveryConfig resource.
 func (s *Service) CreateDiscoveryConfig(ctx context.Context, req *discoveryconfigv1.CreateDiscoveryConfigRequest) (*discoveryconfigv1.DiscoveryConfig, error) {
-	authCtx, err := s.authorizer.Authorize(ctx)
+	authCtx, err := s.authorizer.AuthorizeScoped(ctx)
 	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-
-	if err := authCtx.CheckAccessToKind(types.KindDiscoveryConfig, types.VerbCreate); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
 	dc, err := conv.FromProto(req.GetDiscoveryConfig())
 	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	ruleCtx := authCtx.RuleContext()
+	ruleCtx.Resource = dc
+	if err := authCtx.CheckerContext.Decision(ctx, dc.GetScope(), func(checker *services.ScopedAccessChecker) error {
+		return checker.CheckAccessToRules(&ruleCtx, types.KindDiscoveryConfig, types.VerbCreate)
+	}); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
@@ -209,7 +231,7 @@ func (s *Service) CreateDiscoveryConfig(ctx context.Context, req *discoveryconfi
 			Type: events.DiscoveryConfigCreateEvent,
 			Code: events.DiscoveryConfigCreateCode,
 		},
-		UserMetadata: authCtx.GetUserMetadata(),
+		UserMetadata: authCtx.Identity.GetIdentity().GetUserMetadata(),
 		ResourceMetadata: apievents.ResourceMetadata{
 			Name:    resp.GetName(),
 			Expires: resp.Expiry(),
@@ -226,17 +248,21 @@ func (s *Service) CreateDiscoveryConfig(ctx context.Context, req *discoveryconfi
 
 // UpdateDiscoveryConfig updates an existing DiscoveryConfig.
 func (s *Service) UpdateDiscoveryConfig(ctx context.Context, req *discoveryconfigv1.UpdateDiscoveryConfigRequest) (*discoveryconfigv1.DiscoveryConfig, error) {
-	authCtx, err := s.authorizer.Authorize(ctx)
+	authCtx, err := s.authorizer.AuthorizeScoped(ctx)
 	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-
-	if err := authCtx.CheckAccessToKind(types.KindDiscoveryConfig, types.VerbUpdate); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
 	dc, err := conv.FromProto(req.GetDiscoveryConfig())
 	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	ruleCtx := authCtx.RuleContext()
+	ruleCtx.Resource = dc
+	if err := authCtx.CheckerContext.Decision(ctx, dc.GetScope(), func(checker *services.ScopedAccessChecker) error {
+		return checker.CheckAccessToRules(&ruleCtx, types.KindDiscoveryConfig, types.VerbUpdate)
+	}); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
@@ -257,7 +283,7 @@ func (s *Service) UpdateDiscoveryConfig(ctx context.Context, req *discoveryconfi
 			Type: events.DiscoveryConfigUpdateEvent,
 			Code: events.DiscoveryConfigUpdateCode,
 		},
-		UserMetadata: authCtx.GetUserMetadata(),
+		UserMetadata: authCtx.Identity.GetIdentity().GetUserMetadata(),
 		ResourceMetadata: apievents.ResourceMetadata{
 			Name:    resp.GetName(),
 			Expires: resp.Expiry(),
@@ -274,17 +300,21 @@ func (s *Service) UpdateDiscoveryConfig(ctx context.Context, req *discoveryconfi
 
 // UpsertDiscoveryConfig creates or updates a DiscoveryConfig.
 func (s *Service) UpsertDiscoveryConfig(ctx context.Context, req *discoveryconfigv1.UpsertDiscoveryConfigRequest) (*discoveryconfigv1.DiscoveryConfig, error) {
-	authCtx, err := s.authorizer.Authorize(ctx)
+	authCtx, err := s.authorizer.AuthorizeScoped(ctx)
 	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-
-	if err := authCtx.CheckAccessToKind(types.KindDiscoveryConfig, types.VerbCreate, types.VerbUpdate); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
 	dc, err := conv.FromProto(req.GetDiscoveryConfig())
 	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	ruleCtx := authCtx.RuleContext()
+	ruleCtx.Resource = dc
+	if err := authCtx.CheckerContext.Decision(ctx, dc.GetScope(), func(checker *services.ScopedAccessChecker) error {
+		return checker.CheckAccessToRules(&ruleCtx, types.KindDiscoveryConfig, types.VerbCreate, types.VerbUpdate)
+	}); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
@@ -302,7 +332,7 @@ func (s *Service) UpsertDiscoveryConfig(ctx context.Context, req *discoveryconfi
 			Type: events.DiscoveryConfigCreateEvent,
 			Code: events.DiscoveryConfigCreateCode,
 		},
-		UserMetadata: authCtx.GetUserMetadata(),
+		UserMetadata: authCtx.Identity.GetIdentity().GetUserMetadata(),
 		ResourceMetadata: apievents.ResourceMetadata{
 			Name:    resp.GetName(),
 			Expires: resp.Expiry(),
@@ -319,21 +349,42 @@ func (s *Service) UpsertDiscoveryConfig(ctx context.Context, req *discoveryconfi
 
 // DeleteDiscoveryConfig removes the specified DiscoveryConfig resource.
 func (s *Service) DeleteDiscoveryConfig(ctx context.Context, req *discoveryconfigv1.DeleteDiscoveryConfigRequest) (*emptypb.Empty, error) {
-	authCtx, err := s.authorizer.Authorize(ctx)
+	authCtx, err := s.authorizer.AuthorizeScoped(ctx)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
+	ruleCtx := authCtx.RuleContext()
 
-	if err := authCtx.CheckAccessToKind(types.KindDiscoveryConfig, types.VerbDelete); err != nil {
-		return nil, trace.Wrap(err)
-	}
-
-	// Fetch the DiscoveryConfig before deletion to capture metadata for the usage event.
+	// Fetch the DiscoveryConfig before deletion to check access and capture
+	// metadata for the usage event.
 	dc, err := s.backend.GetDiscoveryConfig(ctx, req.GetName())
-	if err != nil && !trace.IsNotFound(err) {
-		s.log.WarnContext(ctx, "Skipping DiscoveryConfig delete usage event due to GetDiscoveryConfig failure.",
-			"discovery_config_name", req.GetName(),
-			"error", err)
+	if err != nil {
+		// If we can't fetch the current discovery config from the backend, the
+		// caller should be allowed to do an unconditional delete iff they
+		// are allowed to delete unscoped discovery configs.
+		//
+		// Unscoped identities that are allowed to delete discovery configs
+		// will be allowed here.
+		const emptyScope = ""
+		if err := authCtx.CheckerContext.Decision(ctx, emptyScope, func(checker *services.ScopedAccessChecker) error {
+			return checker.CheckAccessToRules(&ruleCtx, types.KindDiscoveryConfig, types.VerbDelete)
+		}); err != nil {
+			return nil, trace.Wrap(err)
+		}
+
+		if !trace.IsNotFound(err) {
+			s.log.WarnContext(ctx, "Skipping DiscoveryConfig delete usage event due to GetDiscoveryConfig failure.",
+				"discovery_config_name", req.GetName(),
+				"error", err)
+		}
+	} else {
+		// If we were able to fetch the current discovery config, check access at its real scope.
+		ruleCtx.Resource = dc
+		if err := authCtx.CheckerContext.Decision(ctx, dc.GetScope(), func(checker *services.ScopedAccessChecker) error {
+			return checker.CheckAccessToRules(&ruleCtx, types.KindDiscoveryConfig, types.VerbDelete)
+		}); err != nil {
+			return nil, trace.Wrap(err)
+		}
 	}
 
 	if err := s.backend.DeleteDiscoveryConfig(ctx, req.GetName()); err != nil {
@@ -345,7 +396,7 @@ func (s *Service) DeleteDiscoveryConfig(ctx context.Context, req *discoveryconfi
 			Type: events.DiscoveryConfigDeleteEvent,
 			Code: events.DiscoveryConfigDeleteCode,
 		},
-		UserMetadata: authCtx.GetUserMetadata(),
+		UserMetadata: authCtx.Identity.GetIdentity().GetUserMetadata(),
 		ResourceMetadata: apievents.ResourceMetadata{
 			Name: req.Name,
 		},
@@ -363,12 +414,18 @@ func (s *Service) DeleteDiscoveryConfig(ctx context.Context, req *discoveryconfi
 
 // DeleteAllDiscoveryConfigs removes all DiscoveryConfig resources.
 func (s *Service) DeleteAllDiscoveryConfigs(ctx context.Context, _ *discoveryconfigv1.DeleteAllDiscoveryConfigsRequest) (*emptypb.Empty, error) {
-	authCtx, err := s.authorizer.Authorize(ctx)
+	authCtx, err := s.authorizer.AuthorizeScoped(ctx)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
-	if err := authCtx.CheckAccessToKind(types.KindDiscoveryConfig, types.VerbDelete); err != nil {
+	// Deleting all discovery configs must only be allowed if the caller is
+	// allowed to delete unscoped discovery configs.
+	const emptyScope = ""
+	ruleCtx := authCtx.RuleContext()
+	if err := authCtx.CheckerContext.Decision(ctx, emptyScope, func(checker *services.ScopedAccessChecker) error {
+		return checker.CheckAccessToRules(&ruleCtx, types.KindDiscoveryConfig, types.VerbDelete)
+	}); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
@@ -381,7 +438,7 @@ func (s *Service) DeleteAllDiscoveryConfigs(ctx context.Context, _ *discoverycon
 			Type: events.DiscoveryConfigDeleteAllEvent,
 			Code: events.DiscoveryConfigDeleteAllCode,
 		},
-		UserMetadata:       authCtx.GetUserMetadata(),
+		UserMetadata:       authCtx.Identity.GetIdentity().GetUserMetadata(),
 		ConnectionMetadata: authz.ConnectionMetadata(ctx),
 	}); err != nil {
 		s.log.WarnContext(ctx, "Failed to emit discovery config delete all event.", "error", err)
@@ -392,12 +449,15 @@ func (s *Service) DeleteAllDiscoveryConfigs(ctx context.Context, _ *discoverycon
 
 // UpdateDiscoveryConfigStatus updates the status of a DiscoveryConfig.
 func (s *Service) UpdateDiscoveryConfigStatus(ctx context.Context, req *discoveryconfigv1.UpdateDiscoveryConfigStatusRequest) (*discoveryconfigv1.DiscoveryConfig, error) {
-	authCtx, err := s.authorizer.Authorize(ctx)
+	authCtx, err := s.authorizer.AuthorizeScoped(ctx)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
-	if !authz.HasBuiltinRole(*authCtx, string(types.RoleDiscovery)) {
+	// Currently only unscoped discovery services can call this API.
+	// TODO(nklaassen): support UpdateDiscoveryConfigStatus for scoped discovery service.
+	unscopedCtx, ok := authCtx.UnscopedContext()
+	if !ok || !authz.HasBuiltinRole(*unscopedCtx, string(types.RoleDiscovery)) {
 		return nil, trace.AccessDenied("UpdateDiscoveryConfigStatus request can be only executed by a Discovery Service")
 	}
 

--- a/lib/auth/discoveryconfig/discoveryconfigv1/service_test.go
+++ b/lib/auth/discoveryconfig/discoveryconfigv1/service_test.go
@@ -29,6 +29,9 @@ import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	discoveryconfigpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/discoveryconfig/v1"
+	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
+	scopedaccessv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/access/v1"
+	scopesv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/v1"
 	"github.com/gravitational/teleport/api/metadata"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/types/discoveryconfig"
@@ -37,6 +40,8 @@ import (
 	"github.com/gravitational/teleport/lib/authz"
 	"github.com/gravitational/teleport/lib/backend/memory"
 	"github.com/gravitational/teleport/lib/events"
+	scopedaccess "github.com/gravitational/teleport/lib/scopes/access"
+	"github.com/gravitational/teleport/lib/scopes/pinning"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/services/local"
 	"github.com/gravitational/teleport/lib/tlsca"
@@ -343,6 +348,54 @@ func TestDiscoveryConfigCRUD(t *testing.T) {
 	}
 }
 
+func TestScopePinnedIdentityCannotReadUnscopedDiscoveryConfig(t *testing.T) {
+	t.Setenv("TELEPORT_UNSTABLE_SCOPES", "yes")
+
+	ctx, localClient, resourceSvc := initSvc(t, "test-cluster")
+	dcName := uuid.NewString()
+	dc, err := discoveryconfig.NewDiscoveryConfig(
+		header.Metadata{Name: dcName},
+		discoveryconfig.Spec{DiscoveryGroup: "some-group"},
+	)
+	require.NoError(t, err)
+	_, err = localClient.CreateDiscoveryConfig(ctx, dc)
+	require.NoError(t, err)
+
+	localCtx := authorizerForScopePinnedDummyUser(t, ctx, localClient)
+
+	_, err = resourceSvc.GetDiscoveryConfig(localCtx, &discoveryconfigpb.GetDiscoveryConfigRequest{
+		Name: dcName,
+	})
+	require.ErrorAs(t, err, new(*trace.AccessDeniedError))
+
+	listResp, err := resourceSvc.ListDiscoveryConfigs(localCtx, &discoveryconfigpb.ListDiscoveryConfigsRequest{})
+	require.NoError(t, err)
+	require.Empty(t, listResp.GetDiscoveryConfigs())
+
+	_, err = resourceSvc.CreateDiscoveryConfig(localCtx, &discoveryconfigpb.CreateDiscoveryConfigRequest{
+		DiscoveryConfig: convert.ToProto(dc),
+	})
+	require.ErrorAs(t, err, new(*trace.AccessDeniedError))
+
+	_, err = resourceSvc.UpdateDiscoveryConfig(localCtx, &discoveryconfigpb.UpdateDiscoveryConfigRequest{
+		DiscoveryConfig: convert.ToProto(dc),
+	})
+	require.ErrorAs(t, err, new(*trace.AccessDeniedError))
+
+	_, err = resourceSvc.UpsertDiscoveryConfig(localCtx, &discoveryconfigpb.UpsertDiscoveryConfigRequest{
+		DiscoveryConfig: convert.ToProto(dc),
+	})
+	require.ErrorAs(t, err, new(*trace.AccessDeniedError))
+
+	_, err = resourceSvc.DeleteDiscoveryConfig(localCtx, &discoveryconfigpb.DeleteDiscoveryConfigRequest{
+		Name: dcName,
+	})
+	require.ErrorAs(t, err, new(*trace.AccessDeniedError))
+
+	_, err = resourceSvc.DeleteAllDiscoveryConfigs(localCtx, &discoveryconfigpb.DeleteAllDiscoveryConfigsRequest{})
+	require.ErrorAs(t, err, new(*trace.AccessDeniedError))
+}
+
 func TestUpdateDiscoveryConfigStatus(t *testing.T) {
 	clusterName := "test-cluster"
 
@@ -469,6 +522,48 @@ func authorizerForDummyUser(t *testing.T, ctx context.Context, roleSpec types.Ro
 	})
 }
 
+func authorizerForScopePinnedDummyUser(t *testing.T, ctx context.Context, localClient localClient) context.Context {
+	t.Helper()
+
+	user, err := types.NewUser("user-" + uuid.NewString())
+	require.NoError(t, err)
+	user, err = localClient.CreateUser(ctx, user)
+	require.NoError(t, err)
+
+	const testscope = "/testscope"
+
+	role := &scopedaccessv1.ScopedRole{
+		Kind:    scopedaccess.KindScopedRole,
+		Version: types.V1,
+		Metadata: &headerv1.Metadata{
+			Name: uuid.NewString(),
+		},
+		Scope: testscope,
+		Spec: &scopedaccessv1.ScopedRoleSpec{
+			AssignableScopes: []string{testscope},
+		},
+	}
+	_, err = localClient.CreateScopedRole(ctx, &scopedaccessv1.CreateScopedRoleRequest{
+		Role: role,
+	})
+	require.NoError(t, err)
+
+	return authz.ContextWithUser(ctx, authz.LocalUser{
+		Username: user.GetName(),
+		Identity: tlsca.Identity{
+			Username: user.GetName(),
+			ScopePin: &scopesv1.Pin{
+				Scope: testscope,
+				AssignmentTree: pinning.AssignmentTreeFromMap(map[string]map[string][]string{
+					testscope: {
+						testscope: {role.GetMetadata().GetName()},
+					},
+				}),
+			},
+		},
+	})
+}
+
 func authorizerForSystemRole(ctx context.Context, systemRole string) context.Context {
 	return authz.ContextWithUser(ctx, authz.BuiltinRole{
 		Username: uuid.NewString(),
@@ -484,6 +579,7 @@ type localClient interface {
 	CreateUser(ctx context.Context, user types.User) (types.User, error)
 	CreateRole(ctx context.Context, role types.Role) (types.Role, error)
 	CreateDiscoveryConfig(ctx context.Context, dc *discoveryconfig.DiscoveryConfig) (*discoveryconfig.DiscoveryConfig, error)
+	CreateScopedRole(ctx context.Context, req *scopedaccessv1.CreateScopedRoleRequest) (*scopedaccessv1.CreateScopedRoleResponse, error)
 }
 
 type testClient struct {
@@ -532,10 +628,12 @@ func initSvc(t *testing.T, clusterName string) (context.Context, localClient, *S
 	})
 	require.NoError(t, err)
 
-	authorizer, err := authz.NewAuthorizer(authz.AuthorizerOpts{
-		ClusterName: clusterName,
-		AccessPoint: accessPoint,
-		LockWatcher: lockWatcher,
+	scopedAccessSvc := local.NewScopedAccessService(backend)
+	authorizer, err := authz.NewScopedAuthorizer(authz.AuthorizerOpts{
+		ClusterName:      clusterName,
+		AccessPoint:      accessPoint,
+		ScopedRoleReader: scopedAccessSvc,
+		LockWatcher:      lockWatcher,
 	})
 	require.NoError(t, err)
 
@@ -556,10 +654,12 @@ func initSvc(t *testing.T, clusterName string) (context.Context, localClient, *S
 		*local.AccessService
 		*local.IdentityService
 		*local.DiscoveryConfigService
+		*local.ScopedAccessService
 	}{
 		AccessService:          roleSvc,
 		IdentityService:        userSvc,
 		DiscoveryConfigService: localResourceService,
+		ScopedAccessService:    scopedAccessSvc,
 	}, resourceSvc
 }
 

--- a/lib/auth/grpcserver.go
+++ b/lib/auth/grpcserver.go
@@ -6490,7 +6490,7 @@ func NewGRPCServer(cfg GRPCServerConfig) (*GRPCServer, error) {
 	usertaskv1pb.RegisterUserTaskServiceServer(server, userTask)
 
 	discoveryConfig, err := discoveryconfigv1.NewService(discoveryconfigv1.ServiceConfig{
-		Authorizer:    cfg.Authorizer,
+		Authorizer:    cfg.ScopedAuthorizer,
 		Backend:       cfg.AuthServer.Services,
 		Clock:         cfg.AuthServer.clock,
 		Emitter:       cfg.Emitter,


### PR DESCRIPTION
This PR adds scope-aware authorization for discovery config resources.

Discovery configs are currently unscoped and may only be accessed by unscoped identities. This change uses a scoped authorizer and does scope-aware access checks. This is a pre-req for:
- scoped discovery configs
- a scoped discovery service that needs to access scoped discovery configs
- the ability for scoped admins to access scoped discovery configs

## Manual Test Plan
### Test Environment

A teleport cluster with TELEPORT_UNSTABLE_SCOPES=yes and a scoped user

### Test Cases
- [x] local tctl can still read/write discovery configs
- [x] and unscoped user can still read/write discovery configs
- [x] a scoped user cannot read/write discovery configs (because they are not scoped yet)
