### PR TITLE
Add Azure Resource Graph VM discovery client

### DIFF
--- a/build.assets/tooling/go.sum
+++ b/build.assets/tooling/go.sum
@@ -78,6 +78,8 @@ github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/redis/armredis/v3 v3.3.0 h
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/redis/armredis/v3 v3.3.0/go.mod h1:DiazWkJHUUKUZGpIdV7JhDTjebBxdfsJ386dE5w7G3o=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/redisenterprise/armredisenterprise v1.2.0 h1:hTmVmyvriwO+ymGLEsH7HZokVwinC2MZl8F0LjvPdHU=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/redisenterprise/armredisenterprise v1.2.0/go.mod h1:uHEpZj4TWSZEp35rIByJ8RX7hQBm3bxfPxS4tiz+x+g=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resourcegraph/armresourcegraph v0.9.0 h1:zLzoX5+W2l95UJoVwiyNS4dX8vHyQ6x2xRLoBBL9wMk=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resourcegraph/armresourcegraph v0.9.0/go.mod h1:wVEOJfGTj0oPAUGA1JuRAvz/lxXQsWW16axmHPP47Bk=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/sql/armsql v1.2.0 h1:S087deZ0kP1RUg4pU7w9U9xpUedTCbOtz+mnd0+hrkQ=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/sql/armsql v1.2.0/go.mod h1:B4cEyXrWBmbfMDAPnpJ1di7MAt5DKP57jPEObAvZChg=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/subscription/armsubscription v1.2.0 h1:UrGzkHueDwAWDdjQxC+QaXHd4tVCkISYE9j7fSSXF8k=

--- a/e2e/runner/go.sum
+++ b/e2e/runner/go.sum
@@ -64,6 +64,8 @@ github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/redis/armredis/v3 v3.3.0 h
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/redis/armredis/v3 v3.3.0/go.mod h1:DiazWkJHUUKUZGpIdV7JhDTjebBxdfsJ386dE5w7G3o=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/redisenterprise/armredisenterprise v1.2.0 h1:hTmVmyvriwO+ymGLEsH7HZokVwinC2MZl8F0LjvPdHU=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/redisenterprise/armredisenterprise v1.2.0/go.mod h1:uHEpZj4TWSZEp35rIByJ8RX7hQBm3bxfPxS4tiz+x+g=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resourcegraph/armresourcegraph v0.9.0 h1:zLzoX5+W2l95UJoVwiyNS4dX8vHyQ6x2xRLoBBL9wMk=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resourcegraph/armresourcegraph v0.9.0/go.mod h1:wVEOJfGTj0oPAUGA1JuRAvz/lxXQsWW16axmHPP47Bk=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/sql/armsql v1.2.0 h1:S087deZ0kP1RUg4pU7w9U9xpUedTCbOtz+mnd0+hrkQ=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/sql/armsql v1.2.0/go.mod h1:B4cEyXrWBmbfMDAPnpJ1di7MAt5DKP57jPEObAvZChg=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/subscription/armsubscription v1.2.0 h1:UrGzkHueDwAWDdjQxC+QaXHd4tVCkISYE9j7fSSXF8k=

--- a/go.mod
+++ b/go.mod
@@ -39,6 +39,7 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/postgresql/armpostgresqlflexibleservers v1.1.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/redis/armredis/v3 v3.3.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/redisenterprise/armredisenterprise v1.2.0
+	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resourcegraph/armresourcegraph v0.9.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/sql/armsql v1.2.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/subscription/armsubscription v1.2.0
 	github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v1.6.3

--- a/go.sum
+++ b/go.sum
@@ -97,6 +97,8 @@ github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/redis/armredis/v3 v3.3.0 h
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/redis/armredis/v3 v3.3.0/go.mod h1:DiazWkJHUUKUZGpIdV7JhDTjebBxdfsJ386dE5w7G3o=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/redisenterprise/armredisenterprise v1.2.0 h1:hTmVmyvriwO+ymGLEsH7HZokVwinC2MZl8F0LjvPdHU=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/redisenterprise/armredisenterprise v1.2.0/go.mod h1:uHEpZj4TWSZEp35rIByJ8RX7hQBm3bxfPxS4tiz+x+g=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resourcegraph/armresourcegraph v0.9.0 h1:zLzoX5+W2l95UJoVwiyNS4dX8vHyQ6x2xRLoBBL9wMk=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resourcegraph/armresourcegraph v0.9.0/go.mod h1:wVEOJfGTj0oPAUGA1JuRAvz/lxXQsWW16axmHPP47Bk=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources v1.2.0 h1:Dd+RhdJn0OTtVGaeDLZpcumkIVCtA/3/Fo42+eoYvVM=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources v1.2.0/go.mod h1:5kakwfW5CjC9KK+Q4wjXAg+ShuIm2mBMua0ZFj2C8PE=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/sql/armsql v1.2.0 h1:S087deZ0kP1RUg4pU7w9U9xpUedTCbOtz+mnd0+hrkQ=

--- a/integrations/event-handler/go.mod
+++ b/integrations/event-handler/go.mod
@@ -48,6 +48,7 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/postgresql/armpostgresqlflexibleservers v1.1.0 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/redis/armredis/v3 v3.3.0 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/redisenterprise/armredisenterprise v1.2.0 // indirect
+	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resourcegraph/armresourcegraph v0.9.0 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/sql/armsql v1.2.0 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/subscription/armsubscription v1.2.0 // indirect
 	github.com/Azure/go-ansiterm v0.0.0-20250102033503-faa5f7b0171c // indirect

--- a/integrations/event-handler/go.sum
+++ b/integrations/event-handler/go.sum
@@ -71,6 +71,8 @@ github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/redis/armredis/v3 v3.3.0 h
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/redis/armredis/v3 v3.3.0/go.mod h1:DiazWkJHUUKUZGpIdV7JhDTjebBxdfsJ386dE5w7G3o=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/redisenterprise/armredisenterprise v1.2.0 h1:hTmVmyvriwO+ymGLEsH7HZokVwinC2MZl8F0LjvPdHU=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/redisenterprise/armredisenterprise v1.2.0/go.mod h1:uHEpZj4TWSZEp35rIByJ8RX7hQBm3bxfPxS4tiz+x+g=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resourcegraph/armresourcegraph v0.9.0 h1:zLzoX5+W2l95UJoVwiyNS4dX8vHyQ6x2xRLoBBL9wMk=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resourcegraph/armresourcegraph v0.9.0/go.mod h1:wVEOJfGTj0oPAUGA1JuRAvz/lxXQsWW16axmHPP47Bk=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources v1.2.0 h1:Dd+RhdJn0OTtVGaeDLZpcumkIVCtA/3/Fo42+eoYvVM=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources v1.2.0/go.mod h1:5kakwfW5CjC9KK+Q4wjXAg+ShuIm2mBMua0ZFj2C8PE=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/sql/armsql v1.2.0 h1:S087deZ0kP1RUg4pU7w9U9xpUedTCbOtz+mnd0+hrkQ=

--- a/integrations/terraform-mwi/go.mod
+++ b/integrations/terraform-mwi/go.mod
@@ -51,6 +51,7 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/postgresql/armpostgresqlflexibleservers v1.1.0 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/redis/armredis/v3 v3.3.0 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/redisenterprise/armredisenterprise v1.2.0 // indirect
+	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resourcegraph/armresourcegraph v0.9.0 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/sql/armsql v1.2.0 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/subscription/armsubscription v1.2.0 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v1.6.3 // indirect

--- a/integrations/terraform-mwi/go.sum
+++ b/integrations/terraform-mwi/go.sum
@@ -97,6 +97,8 @@ github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/redis/armredis/v3 v3.3.0 h
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/redis/armredis/v3 v3.3.0/go.mod h1:DiazWkJHUUKUZGpIdV7JhDTjebBxdfsJ386dE5w7G3o=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/redisenterprise/armredisenterprise v1.2.0 h1:hTmVmyvriwO+ymGLEsH7HZokVwinC2MZl8F0LjvPdHU=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/redisenterprise/armredisenterprise v1.2.0/go.mod h1:uHEpZj4TWSZEp35rIByJ8RX7hQBm3bxfPxS4tiz+x+g=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resourcegraph/armresourcegraph v0.9.0 h1:zLzoX5+W2l95UJoVwiyNS4dX8vHyQ6x2xRLoBBL9wMk=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resourcegraph/armresourcegraph v0.9.0/go.mod h1:wVEOJfGTj0oPAUGA1JuRAvz/lxXQsWW16axmHPP47Bk=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources v1.2.0 h1:Dd+RhdJn0OTtVGaeDLZpcumkIVCtA/3/Fo42+eoYvVM=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources v1.2.0/go.mod h1:5kakwfW5CjC9KK+Q4wjXAg+ShuIm2mBMua0ZFj2C8PE=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/sql/armsql v1.2.0 h1:S087deZ0kP1RUg4pU7w9U9xpUedTCbOtz+mnd0+hrkQ=

--- a/integrations/terraform/go.mod
+++ b/integrations/terraform/go.mod
@@ -63,6 +63,7 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/postgresql/armpostgresqlflexibleservers v1.1.0 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/redis/armredis/v3 v3.3.0 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/redisenterprise/armredisenterprise v1.2.0 // indirect
+	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resourcegraph/armresourcegraph v0.9.0 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/sql/armsql v1.2.0 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/subscription/armsubscription v1.2.0 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v1.6.3 // indirect

--- a/integrations/terraform/go.sum
+++ b/integrations/terraform/go.sum
@@ -128,6 +128,8 @@ github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/redis/armredis/v3 v3.3.0 h
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/redis/armredis/v3 v3.3.0/go.mod h1:DiazWkJHUUKUZGpIdV7JhDTjebBxdfsJ386dE5w7G3o=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/redisenterprise/armredisenterprise v1.2.0 h1:hTmVmyvriwO+ymGLEsH7HZokVwinC2MZl8F0LjvPdHU=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/redisenterprise/armredisenterprise v1.2.0/go.mod h1:uHEpZj4TWSZEp35rIByJ8RX7hQBm3bxfPxS4tiz+x+g=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resourcegraph/armresourcegraph v0.9.0 h1:zLzoX5+W2l95UJoVwiyNS4dX8vHyQ6x2xRLoBBL9wMk=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resourcegraph/armresourcegraph v0.9.0/go.mod h1:wVEOJfGTj0oPAUGA1JuRAvz/lxXQsWW16axmHPP47Bk=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources v1.2.0 h1:Dd+RhdJn0OTtVGaeDLZpcumkIVCtA/3/Fo42+eoYvVM=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources v1.2.0/go.mod h1:5kakwfW5CjC9KK+Q4wjXAg+ShuIm2mBMua0ZFj2C8PE=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/sql/armsql v1.2.0 h1:S087deZ0kP1RUg4pU7w9U9xpUedTCbOtz+mnd0+hrkQ=

--- a/lib/cloud/azure/azuretest/azure.go
+++ b/lib/cloud/azure/azuretest/azure.go
@@ -36,6 +36,7 @@ type Clients struct {
 	AzureAKSClientPerSub    map[string]azure.AKSClient
 	AzureAKSClient          azure.AKSClient
 	AzureVirtualMachines    azure.VirtualMachinesClient
+	AzureResourceGraph      azure.ResourceGraphClient
 	AzureSQLServer          azure.SQLServerClient
 	AzureManagedSQLServer   azure.ManagedSQLServerClient
 	AzureMySQLFlex          azure.MySQLFlexServersClient
@@ -93,6 +94,11 @@ func (c *Clients) GetRedisEnterpriseClient(ctx context.Context, subscription str
 // the given subscription.
 func (c *Clients) GetVirtualMachinesClient(ctx context.Context, subscription string) (azure.VirtualMachinesClient, error) {
 	return c.AzureVirtualMachines, nil
+}
+
+// GetResourceGraphClient returns the configured Resource Graph client.
+func (c *Clients) GetResourceGraphClient(ctx context.Context) (azure.ResourceGraphClient, error) {
+	return c.AzureResourceGraph, nil
 }
 
 // GetSQLServerClient returns an Azure client for listing SQL servers.

--- a/lib/cloud/azure/clients.go
+++ b/lib/cloud/azure/clients.go
@@ -52,6 +52,8 @@ type Clients interface {
 	GetKubernetesClient(ctx context.Context, subscription string) (AKSClient, error)
 	// GetVirtualMachinesClient returns an Azure Virtual Machines client for the given subscription.
 	GetVirtualMachinesClient(ctx context.Context, subscription string) (VirtualMachinesClient, error)
+	// GetResourceGraphClient returns an Azure Resource Graph client.
+	GetResourceGraphClient(ctx context.Context) (ResourceGraphClient, error)
 	// GetSQLServerClient returns an Azure SQL Server client for the
 	// specified subscription.
 	GetSQLServerClient(ctx context.Context, subscription string) (SQLServerClient, error)
@@ -169,6 +171,7 @@ type clients struct {
 	redisEnterpriseClients     ClientMap[RedisEnterpriseClient]
 	kubernetesClient           map[string]AKSClient
 	virtualMachinesClients     ClientMap[VirtualMachinesClient]
+	resourceGraphClient        ResourceGraphClient
 	sqlServerClients           ClientMap[SQLServerClient]
 	managedSQLServerClients    ClientMap[ManagedSQLServerClient]
 	mySQLFlexServersClients    ClientMap[MySQLFlexServersClient]
@@ -245,6 +248,38 @@ func (c *clients) GetKubernetesClient(ctx context.Context, subscription string) 
 // the given subscription.
 func (c *clients) GetVirtualMachinesClient(ctx context.Context, subscription string) (VirtualMachinesClient, error) {
 	return c.virtualMachinesClients.Get(ctx, subscription, c.GetCredential)
+}
+
+// GetResourceGraphClient returns an Azure Resource Graph client.
+func (c *clients) GetResourceGraphClient(ctx context.Context) (ResourceGraphClient, error) {
+	c.mtx.RLock()
+	client := c.resourceGraphClient
+	c.mtx.RUnlock()
+	if client != nil {
+		return client, nil
+	}
+	return c.initResourceGraphClient(ctx)
+}
+
+func (c *clients) initResourceGraphClient(ctx context.Context) (ResourceGraphClient, error) {
+	cred, err := c.GetCredential(ctx)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	c.mtx.Lock()
+	defer c.mtx.Unlock()
+	if c.resourceGraphClient != nil { // If some other thread already got here first.
+		return c.resourceGraphClient, nil
+	}
+	// TODO(gavin): if/when we support AzureChina/AzureGovernment, we will
+	// need to specify the cloud in these options.
+	client, err := NewResourceGraphClient(cred, &arm.ClientOptions{})
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	c.resourceGraphClient = client
+	return client, nil
 }
 
 // GetSQLServerClient returns an Azure client for listing SQL servers.

--- a/lib/cloud/azure/discoveredvm.go
+++ b/lib/cloud/azure/discoveredvm.go
@@ -34,7 +34,7 @@ type DiscoveredVM struct {
 	ResourceGroup string
 	// OSType is the VM's OS family from osDisk.osType, e.g. OSTypeLinux or OSTypeWindows.
 	// Empty when ARG omits the field; non-string drift skips the row at parse time.
-	OSType string
+	OSType OSType
 	// Tags are the VM tags, e.g. {"env": "prod"}. Empty map (not nil) when the VM has no tags.
 	Tags map[string]string
 }

--- a/lib/cloud/azure/discoveredvm.go
+++ b/lib/cloud/azure/discoveredvm.go
@@ -1,0 +1,40 @@
+/*
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package azure
+
+// DiscoveredVM describes an Azure virtual machine returned by discovery.
+type DiscoveredVM struct {
+	// ID is the ARM resource ID, e.g. "/subscriptions/.../virtualMachines/foo".
+	ID string
+	// SubscriptionID is the Azure subscription containing the VM, e.g. "11111111-1111-1111-1111-111111111111".
+	SubscriptionID string
+	// Name is the VM's display name, e.g. "teleport-agent-01".
+	Name string
+	// VMID is Azure's unique identifier for the VM, e.g. "22222222-2222-2222-2222-222222222222".
+	VMID string
+	// Location is the Azure region containing the VM, e.g. "eastus".
+	Location string
+	// ResourceGroup is the Azure resource group containing the VM, e.g. "teleport-rg".
+	ResourceGroup string
+	// OSType is the VM's OS family from osDisk.osType, e.g. OSTypeLinux or OSTypeWindows.
+	// Empty when ARG omits the field; non-string drift skips the row at parse time.
+	OSType string
+	// Tags are the VM tags, e.g. {"env": "prod"}. Empty map (not nil) when the VM has no tags.
+	Tags map[string]string
+}

--- a/lib/cloud/azure/errors.go
+++ b/lib/cloud/azure/errors.go
@@ -46,6 +46,8 @@ func ConvertResponseError(err error) error {
 			return trace.AlreadyExists("%s", responseErr)
 		case http.StatusNotFound:
 			return trace.NotFound("%s", responseErr)
+		case http.StatusTooManyRequests:
+			return trace.LimitExceeded("%s", responseErr)
 		}
 	case errors.As(err, &authenticationFailedErr):
 		return trace.AccessDenied("%s", authenticationFailedErr)

--- a/lib/cloud/azure/kqlsafety.go
+++ b/lib/cloud/azure/kqlsafety.go
@@ -1,0 +1,242 @@
+/*
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+// KQL (Kusto Query Language) injection safety for Azure Resource Graph (ARG) queries.
+//
+// This file is the single source of truth for protecting the KQL query string
+// from injection by caller-supplied filter values. Three layers, in order of
+// strength:
+//
+//  1. Allowlist (primary). sanitizeQueryVMsParams rejects any non-wildcard
+//     Region/ResourceGroup outside its per-field regex (azureRegionPattern,
+//     azureResourceGroupPattern), and rejects any OSType outside the closed
+//     set of canonical OSType constants -- all before any KQL is built.
+//     Empty and untrimmed values are rejected too. Subscription IDs are
+//     also validated here for non-empty, trimmed, canonical hyphenated UUID form.
+//  2. Parameterization. SubscriptionIDs flow through the typed SDK field
+//     (armresourcegraph.QueryRequest.Subscriptions in queryChunk), never the
+//     KQL string. Zero KQL injection surface for subscription IDs.
+//  3. Defense-in-depth. quoteKQL/escapeKQL double single quotes inside KQL
+//     string literals. FuzzEscapeKQL pins the no-breakout invariant (every
+//     single quote in the output is part of a doubled pair); FuzzQuoteKQL
+//     pins semantic parity with an in-test port of Azure/azure-kusto-go's
+//     QuoteString. Belt-and-suspenders on top of the allowlist.
+//
+// Contract for adding new KQL-bound inputs: every value that flows into KQL
+// MUST pass through sanitizeQueryVMsParams (or an equivalent allowlist
+// validator), and every value interpolated as a string literal MUST go
+// through quoteKQL.
+//
+// No existing Teleport code or third-party dependency provides this; the
+// hand-rolled escape is justified by (a) the strict allowlist excludes every
+// escapable byte, and (b) FuzzQuoteKQL parity against an in-test port of the
+// canonical Azure/azure-kusto-go QuoteString. Vendoring the full Kusto SDK
+// for one ReplaceAll would add dependency surface for zero behavior change.
+
+package azure
+
+import (
+	"regexp"
+	"slices"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/gravitational/trace"
+
+	"github.com/gravitational/teleport/api/types"
+)
+
+// sanitizedParams is QueryVMsParams after passing every check in sanitizeQueryVMsParams.
+// The only intended constructor of this type is sanitizeQueryVMsParams. Outside the
+// azure package, sanitizedParams cannot be manufactured at all (the type is unexported);
+// inside the package, literal construction is technically possible but is the kind of
+// thing code review must catch -- the type's role is to make the safe form the only
+// form that compiles for any caller that doesn't already live alongside this file.
+//
+// Field order intentionally differs from QueryVMsParams so the underlying types are
+// not identical: that prevents sanitizedParams(rawParams) direct conversion from
+// compiling, which would otherwise be a one-line back door around sanitizeQueryVMsParams.
+// Do not "fix" the order to match QueryVMsParams; the divergence is load-bearing.
+type sanitizedParams struct {
+	// KQL-bound fields come first. Regions and ResourceGroups are regex-allowlisted
+	// via sanitizeKQLValues; OSTypes is closed-set validated via sanitizeOSTypes.
+	Regions        []string
+	ResourceGroups []string
+	OSTypes        []OSType
+	// SubscriptionIDs uses typed SDK parameterization, not KQL interpolation.
+	SubscriptionIDs []string
+}
+
+// Defense-in-depth regex allowlists for caller-supplied string values that flow into KQL
+// string literals. Each is a Teleport-supported safe subset of Azure's naming surface,
+// narrow enough to reject any character that could break out of a single-quoted KQL string
+// (quote, backslash, newline, null, etc.). OSType is validated separately by sanitizeOSTypes
+// against the closed set of OSType constants and so has no regex here.
+//
+// types.Wildcard ("*") is whitelisted by sanitizeKQLValues; the predicate
+// helpers absorb wildcards before any KQL is generated.
+var (
+	// azureRegionPattern is an injection-safety allowlist for region values: alphanumeric only,
+	// matching the canonical form ARG stores in the `location` column (e.g. "eastus", "westeurope").
+	// Display names like "East US" or "(US) East US" appear in Azure UI and sample responses
+	// but ARG normalizes location to canonical for filtering.
+	//
+	// See ARG property normalization (the page documents that some properties are lowercased;
+	// sample responses on the same page show `location` in canonical form like "eastus"):
+	// https://learn.microsoft.com/en-us/azure/governance/resource-graph/concepts/explore-resources
+	azureRegionPattern = regexp.MustCompile(`^[A-Za-z0-9]+$`)
+
+	// azureResourceGroupPattern is a Teleport-defined ASCII subset of Azure's resource group
+	// naming surface: letters, digits, underscore, hyphen, period, and parenthesis. Azure's
+	// canonical pattern (^[-\w\._\(\)]+$) uses `\w` which includes Unicode word chars;
+	// we narrow to ASCII for a well-bounded allowlist. Length (1-90) is enforced by Azure.
+	//
+	// See the Microsoft.Resources TypeSpec source. The `NamePattern` argument to `ResourceNameParameter`
+	// on the ResourceGroup model declares the regex once at the source level; the generated swagger
+	// `pattern` fields on every `resourceGroupName` parameter (Get, Create, Update, Delete, etc.) all
+	// come from this one declaration:
+	// https://github.com/Azure/azure-rest-api-specs/blob/d2765895f8a8ddf6c540fbf1ebfdf2ea7bfe490f/specification/resources/resource-manager/Microsoft.Resources/resources/ResourceGroup.tsp#L19-L24
+	//
+	// The trailing character class excludes period to match Azure's "cannot end with
+	// period" rule for resource group names.
+	azureResourceGroupPattern = regexp.MustCompile(`^[A-Za-z0-9_.()-]*[A-Za-z0-9_()-]$`)
+)
+
+// azureSubscriptionIDLen is the length of a canonical Azure subscription ID:
+// the 36-char hyphenated UUID form (8-4-4-4-12) that the Azure SDK and Teleport
+// elsewhere (e.g. lib/join/azurejoin generates them with uuid.NewString) treat
+// as the subscription's identity. uuid.Validate accepts looser variants --
+// urn:uuid:..., {...}, and unhyphenated 32-char hex -- that real Azure
+// subscriptions never use; pairing the length check with uuid.Validate keeps
+// this validator's accepted set identical to the prior regex
+// (^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$)
+// and surfaces malformed input as a clear caller-side BadParameter rather than
+// pushing it downstream.
+const azureSubscriptionIDLen = 36
+
+// sanitizeQueryVMsParams enforces the input contract shared by QueryVMs and the ARMResourceGraphMock:
+// a non-empty subscription list with no empty, untrimmed, or non-canonical-UUID entries, and per-field
+// allowlist validation for the filter slices. Returns sanitizedParams: the only path to a value
+// buildVMDiscoveryKQL accepts. Centralized so the mock cannot drift from production behavior.
+func sanitizeQueryVMsParams(params QueryVMsParams) (sanitizedParams, error) {
+	if len(params.SubscriptionIDs) == 0 {
+		return sanitizedParams{}, trace.BadParameter("at least one subscription ID is required")
+	}
+
+	for _, id := range params.SubscriptionIDs {
+		switch {
+		case id == "":
+			return sanitizedParams{}, trace.BadParameter("subscription ID must not be empty")
+		case strings.TrimSpace(id) != id:
+			return sanitizedParams{}, trace.BadParameter("subscription ID %q must not have leading or trailing whitespace", id)
+		case len(id) != azureSubscriptionIDLen || uuid.Validate(id) != nil:
+			return sanitizedParams{}, trace.BadParameter("subscription ID %q must be a canonical UUID (e.g. \"11111111-1111-1111-1111-111111111111\")", id)
+		}
+	}
+
+	if err := sanitizeKQLValues(params.Regions, azureRegionPattern, "region"); err != nil {
+		return sanitizedParams{}, trace.Wrap(err)
+	}
+	if err := sanitizeKQLValues(params.ResourceGroups, azureResourceGroupPattern, "resource group"); err != nil {
+		return sanitizedParams{}, trace.Wrap(err)
+	}
+	if err := sanitizeOSTypes(params.OSTypes); err != nil {
+		return sanitizedParams{}, trace.Wrap(err)
+	}
+
+	// Clone every slice so the validated value cannot be mutated by the caller after
+	// validation. Without this, params.Regions[0] = "evil" after sanitize would silently
+	// alias into the sanitized result, undermining the "validated once, safe thereafter"
+	// invariant.
+	return sanitizedParams{
+		SubscriptionIDs: slices.Clone(params.SubscriptionIDs),
+		Regions:         slices.Clone(params.Regions),
+		ResourceGroups:  slices.Clone(params.ResourceGroups),
+		OSTypes:         slices.Clone(params.OSTypes),
+	}, nil
+}
+
+// sanitizeKQLValues rejects any non-wildcard entry that is empty, untrimmed, or doesn't
+// match the supplied pattern. kind is a human-readable label used in error messages.
+// types.Wildcard is whitelisted because predicate helpers absorb it before KQL is built.
+func sanitizeKQLValues(values []string, pattern *regexp.Regexp, kind string) error {
+	for _, v := range values {
+		switch {
+		case v == types.Wildcard:
+			continue
+		case v == "":
+			return trace.BadParameter("%s must not be empty", kind)
+		case strings.TrimSpace(v) != v:
+			return trace.BadParameter("%s %q must not have leading or trailing whitespace", kind, v)
+		case !pattern.MatchString(v):
+			return trace.BadParameter("%s %q contains invalid characters; allowed pattern: %s", kind, v, pattern.String())
+		}
+	}
+
+	return nil
+}
+
+// sanitizeOSTypes validates the closed set of canonical Azure VM OS type values
+// against the OSType* constants. The OSType named type guides callers through
+// the constants at compile time; this runtime check rejects values that bypass
+// the type (e.g. literal OSType("linux") conversions, zero values, or untrimmed
+// entries from caller-side config parsing). Strict canonical case per Azure's
+// documented enum -- no whitespace tolerance, no case folding.
+//
+// Branches are ordered to give the caller the most actionable error for their
+// specific mistake (empty, untrimmed, unknown value) rather than a single
+// catch-all "must be Linux or Windows" for every failure mode.
+//
+// types.Wildcard is whitelisted because predicate helpers absorb it before KQL is built.
+func sanitizeOSTypes(values []OSType) error {
+	for _, v := range values {
+		switch {
+		case string(v) == types.Wildcard:
+			continue
+		case v == "":
+			return trace.BadParameter("OS type must not be empty")
+		case strings.TrimSpace(string(v)) != string(v):
+			return trace.BadParameter("OS type %q must not have leading or trailing whitespace", v)
+		case v != OSTypeLinux && v != OSTypeWindows:
+			return trace.BadParameter("OS type %q must be %q or %q", v, OSTypeLinux, OSTypeWindows)
+		}
+	}
+
+	return nil
+}
+
+// quoteKQL escapes single quotes in s and wraps the result in single quotes to produce a KQL string literal.
+//
+// PRECONDITION: s must have already passed sanitizeKQLValues, sanitizeOSTypes,
+// or an equivalent per-field allowlist. quoteKQL is not a general-purpose
+// arbitrary-string KQL encoder; it is the defense-in-depth layer that runs
+// only after the allowlist has excluded every escapable byte except single quotes.
+func quoteKQL(s string) string {
+	return "'" + escapeKQL(s) + "'"
+}
+
+// escapeKQL escapes single quotes in a KQL string literal by doubling them.
+//
+// This is the minimum subset of Azure Kusto's string quoting behavior that suffices
+// for single-quoted literals; allowlisted input (sanitizeKQLValues) guarantees no other
+// escapable byte ever reaches this function. FuzzQuoteKQL compares its output against an
+// in-test port of Azure/azure-kusto-go's QuoteString to keep that invariant honest. Vendoring
+// the full SDK escape lib would add dependency surface for behavior the allowlist already excludes.
+func escapeKQL(s string) string {
+	return strings.ReplaceAll(s, "'", "''")
+}

--- a/lib/cloud/azure/kqlsafety_test.go
+++ b/lib/cloud/azure/kqlsafety_test.go
@@ -1,0 +1,783 @@
+/*
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+// Unit tests for kqlsafety.go: the KQL injection safety layer.
+//
+// White-box tests of sanitizeQueryVMsParams, sanitizeKQLValues, quoteKQL, and
+// escapeKQL live here. Integration tests that exercise the same code through
+// the QueryVMs entry point live in resourcegraph_test.go alongside the rest
+// of the QueryVMs behavior coverage.
+
+package azure
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+	"testing"
+	"unicode"
+	"unicode/utf8"
+
+	"github.com/gravitational/trace"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport/api/types"
+)
+
+// TestSanitizeQueryVMsParams is a white-box test of the package's KQL safety
+// entry point. Integration coverage through QueryVMs lives in
+// resourcegraph_test.go::TestQueryVMsValidatesInputs.
+func TestSanitizeQueryVMsParams(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name        string
+		params      QueryVMsParams
+		wantErr     bool
+		errContains string // only consulted when wantErr is true
+	}{
+		// Valid inputs: sanitize succeeds and the returned sanitizedParams
+		// echoes every input slice. Equality checks below pin the no-mutation
+		// contract; slice-cloning is exercised separately by
+		// TestSanitizeQueryVMsParamsCopiesInputSlices.
+		{
+			name:   "minimal subscription only",
+			params: QueryVMsParams{SubscriptionIDs: []string{"11111111-1111-1111-1111-111111111111"}},
+		},
+		{
+			name: "resource group with underscore",
+			params: QueryVMsParams{
+				SubscriptionIDs: []string{"11111111-1111-1111-1111-111111111111"},
+				ResourceGroups:  []string{"my_resource_group"},
+			},
+		},
+		{
+			name: "resource group full char-class",
+			params: QueryVMsParams{
+				SubscriptionIDs: []string{"11111111-1111-1111-1111-111111111111"},
+				ResourceGroups:  []string{"My-RG_v1.0(test)"},
+			},
+		},
+		{
+			name: "region canonical and with digits",
+			params: QueryVMsParams{
+				SubscriptionIDs: []string{"11111111-1111-1111-1111-111111111111"},
+				Regions:         []string{"eastus", "eastus2"},
+			},
+		},
+		{
+			name: "OS type canonical values",
+			params: QueryVMsParams{
+				SubscriptionIDs: []string{"11111111-1111-1111-1111-111111111111"},
+				OSTypes:         []OSType{OSTypeLinux, OSTypeWindows},
+			},
+		},
+		{
+			name: "all wildcards",
+			params: QueryVMsParams{
+				SubscriptionIDs: []string{"11111111-1111-1111-1111-111111111111"},
+				Regions:         []string{types.Wildcard},
+				ResourceGroups:  []string{types.Wildcard},
+				OSTypes:         []OSType{types.Wildcard},
+			},
+		},
+		{
+			name: "uppercase UUID subscription ID accepted",
+			params: QueryVMsParams{
+				SubscriptionIDs: []string{"AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA"},
+			},
+		},
+		{
+			name: "lowercase UUID subscription ID accepted",
+			params: QueryVMsParams{
+				SubscriptionIDs: []string{"aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"},
+			},
+		},
+		{
+			name: "single-character resource group name",
+			params: QueryVMsParams{
+				SubscriptionIDs: []string{"11111111-1111-1111-1111-111111111111"},
+				ResourceGroups:  []string{"a"},
+			},
+		},
+		{
+			// Pins that the validator's per-entry checks treat wildcard
+			// independently and accept mixed shape. The query meaning of
+			// "wildcard absorbs concrete" (resulting predicate omits the
+			// whole `| where` clause) is enforced by predicate generation
+			// and covered in TestBuildVMDiscoveryKQL; this case covers
+			// only the validation surface.
+			name: "wildcard mixed with concrete values across every field",
+			params: QueryVMsParams{
+				SubscriptionIDs: []string{"11111111-1111-1111-1111-111111111111"},
+				Regions:         []string{types.Wildcard, "eastus"},
+				ResourceGroups:  []string{"rg", types.Wildcard},
+				OSTypes:         []OSType{OSTypeLinux, types.Wildcard},
+			},
+		},
+
+		// Invalid inputs: sanitize returns BadParameter; errContains pins
+		// the actionable substring so a regression that collapses the
+		// per-branch diagnostics surfaces here.
+		{
+			name:        "empty subscription list",
+			params:      QueryVMsParams{},
+			wantErr:     true,
+			errContains: "at least one subscription ID is required",
+		},
+		{
+			name:        "empty subscription ID",
+			params:      QueryVMsParams{SubscriptionIDs: []string{""}},
+			wantErr:     true,
+			errContains: "subscription ID must not be empty",
+		},
+		{
+			name:        "untrimmed subscription ID",
+			params:      QueryVMsParams{SubscriptionIDs: []string{" sub "}},
+			wantErr:     true,
+			errContains: "must not have leading or trailing whitespace",
+		},
+		{
+			name: "region display form with space",
+			params: QueryVMsParams{
+				SubscriptionIDs: []string{"00000000-0000-0000-0000-000000000000"},
+				Regions:         []string{"east us"},
+			},
+			wantErr:     true,
+			errContains: "region",
+		},
+		{
+			name: "resource group with single quote",
+			params: QueryVMsParams{
+				SubscriptionIDs: []string{"00000000-0000-0000-0000-000000000000"},
+				ResourceGroups:  []string{"rg'name"},
+			},
+			wantErr:     true,
+			errContains: "resource group",
+		},
+		{
+			name: "OS type with digit",
+			params: QueryVMsParams{
+				SubscriptionIDs: []string{"00000000-0000-0000-0000-000000000000"},
+				OSTypes:         []OSType{"Linux1"},
+			},
+			wantErr:     true,
+			errContains: `OS type "Linux1" must be "Linux" or "Windows"`,
+		},
+		{
+			name: "OS type unknown letter-only value rejected",
+			params: QueryVMsParams{
+				SubscriptionIDs: []string{"00000000-0000-0000-0000-000000000000"},
+				OSTypes:         []OSType{"Solaris"},
+			},
+			wantErr:     true,
+			errContains: `OS type "Solaris" must be "Linux" or "Windows"`,
+		},
+		{
+			name: "OS type lowercase rejected (strict canonical case)",
+			params: QueryVMsParams{
+				SubscriptionIDs: []string{"00000000-0000-0000-0000-000000000000"},
+				OSTypes:         []OSType{"linux"},
+			},
+			wantErr:     true,
+			errContains: `OS type "linux" must be "Linux" or "Windows"`,
+		},
+		{
+			name: "OS type uppercase rejected (strict canonical case)",
+			params: QueryVMsParams{
+				SubscriptionIDs: []string{"00000000-0000-0000-0000-000000000000"},
+				OSTypes:         []OSType{"WINDOWS"},
+			},
+			wantErr:     true,
+			errContains: `OS type "WINDOWS" must be "Linux" or "Windows"`,
+		},
+		{
+			name:        "non-UUID subscription ID rejected",
+			params:      QueryVMsParams{SubscriptionIDs: []string{"my-subscription"}},
+			wantErr:     true,
+			errContains: "must be a canonical UUID",
+		},
+		{
+			name:        "short UUID (missing hex digit) rejected",
+			params:      QueryVMsParams{SubscriptionIDs: []string{"00000000-0000-0000-0000-00000000000"}},
+			wantErr:     true,
+			errContains: "must be a canonical UUID",
+		},
+		{
+			name:        "UUID with wrong separators rejected",
+			params:      QueryVMsParams{SubscriptionIDs: []string{"00000000_0000_0000_0000_000000000000"}},
+			wantErr:     true,
+			errContains: "must be a canonical UUID",
+		},
+		{
+			name: "resource group ending with period rejected",
+			params: QueryVMsParams{
+				SubscriptionIDs: []string{"00000000-0000-0000-0000-000000000000"},
+				ResourceGroups:  []string{"rg-name."},
+			},
+			wantErr:     true,
+			errContains: "resource group",
+		},
+		{
+			name: "empty region rejected",
+			params: QueryVMsParams{
+				SubscriptionIDs: []string{"00000000-0000-0000-0000-000000000000"},
+				Regions:         []string{""},
+			},
+			wantErr:     true,
+			errContains: "region must not be empty",
+		},
+		{
+			name: "untrimmed region rejected",
+			params: QueryVMsParams{
+				SubscriptionIDs: []string{"00000000-0000-0000-0000-000000000000"},
+				Regions:         []string{" eastus"},
+			},
+			wantErr:     true,
+			errContains: "must not have leading or trailing whitespace",
+		},
+		{
+			name: "empty resource group rejected",
+			params: QueryVMsParams{
+				SubscriptionIDs: []string{"00000000-0000-0000-0000-000000000000"},
+				ResourceGroups:  []string{""},
+			},
+			wantErr:     true,
+			errContains: "resource group must not be empty",
+		},
+		{
+			name: "untrimmed resource group rejected",
+			params: QueryVMsParams{
+				SubscriptionIDs: []string{"00000000-0000-0000-0000-000000000000"},
+				ResourceGroups:  []string{" rg"},
+			},
+			wantErr:     true,
+			errContains: "must not have leading or trailing whitespace",
+		},
+		{
+			name: "empty OS type rejected",
+			params: QueryVMsParams{
+				SubscriptionIDs: []string{"00000000-0000-0000-0000-000000000000"},
+				OSTypes:         []OSType{""},
+			},
+			wantErr:     true,
+			errContains: "OS type must not be empty",
+		},
+		{
+			name: "untrimmed OS type rejected",
+			params: QueryVMsParams{
+				SubscriptionIDs: []string{"00000000-0000-0000-0000-000000000000"},
+				OSTypes:         []OSType{" Linux"},
+			},
+			wantErr:     true,
+			errContains: `OS type " Linux" must not have leading or trailing whitespace`,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := sanitizeQueryVMsParams(tc.params)
+			if tc.wantErr {
+				require.Error(t, err)
+				assert.True(t, trace.IsBadParameter(err),
+					"validation must surface as BadParameter, got %T: %v", err, err)
+				assert.Contains(t, err.Error(), tc.errContains)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tc.params.SubscriptionIDs, got.SubscriptionIDs)
+			assert.Equal(t, tc.params.Regions, got.Regions)
+			assert.Equal(t, tc.params.ResourceGroups, got.ResourceGroups)
+			assert.Equal(t, tc.params.OSTypes, got.OSTypes)
+		})
+	}
+}
+
+// TestSanitizeKQLValues is a direct white-box test of the per-field allowlist
+// validator. TestSanitizeQueryVMsParams exercises it through the entry point;
+// this test pins its main branches (wildcard pass-through, empty, untrimmed,
+// regex rejection) in isolation so a future change to either layer surfaces here.
+func TestSanitizeKQLValues(t *testing.T) {
+	t.Parallel()
+	pattern := regexp.MustCompile(`^[a-z]+$`)
+
+	t.Run("valid plus wildcard passes", func(t *testing.T) {
+		require.NoError(t, sanitizeKQLValues([]string{"ok", types.Wildcard}, pattern, "test"))
+	})
+
+	t.Run("empty rejected", func(t *testing.T) {
+		err := sanitizeKQLValues([]string{""}, pattern, "test")
+		require.Error(t, err)
+		assert.True(t, trace.IsBadParameter(err))
+		assert.Contains(t, err.Error(), "must not be empty")
+	})
+
+	t.Run("untrimmed rejected", func(t *testing.T) {
+		err := sanitizeKQLValues([]string{" ok"}, pattern, "test")
+		require.Error(t, err)
+		assert.True(t, trace.IsBadParameter(err))
+		assert.Contains(t, err.Error(), "leading or trailing whitespace")
+	})
+
+	t.Run("regex mismatch rejected", func(t *testing.T) {
+		err := sanitizeKQLValues([]string{"bad!"}, pattern, "test")
+		require.Error(t, err)
+		assert.True(t, trace.IsBadParameter(err))
+		assert.Contains(t, err.Error(), "invalid characters")
+	})
+}
+
+// TestSanitizeQueryVMsParamsCopiesInputSlices pins the "validated once, safe
+// thereafter" invariant: caller mutations to the input slices after sanitize
+// returns must not leak into the sanitized value. Without slice cloning, a
+// caller could pass a benign slice, get a sanitizedParams back, then mutate
+// the original slice and have the mutation reach buildVMDiscoveryKQL.
+func TestSanitizeQueryVMsParamsCopiesInputSlices(t *testing.T) {
+	t.Parallel()
+	params := QueryVMsParams{
+		SubscriptionIDs: []string{"00000000-0000-0000-0000-000000000000"},
+		Regions:         []string{"eastus"},
+		ResourceGroups:  []string{"rg"},
+		OSTypes:         []OSType{OSTypeLinux},
+	}
+
+	sanitized, err := sanitizeQueryVMsParams(params)
+	require.NoError(t, err)
+
+	// Mutate every input slice after sanitize returns.
+	params.SubscriptionIDs[0] = "11111111-1111-1111-1111-111111111111"
+	params.Regions[0] = "' or 1 == 1 or '"
+	params.ResourceGroups[0] = "' or 1 == 1 or '"
+	params.OSTypes[0] = "' or 1 == 1 or '"
+
+	assert.Equal(t, []string{"00000000-0000-0000-0000-000000000000"}, sanitized.SubscriptionIDs,
+		"sanitizedParams must hold a copy of SubscriptionIDs, not share the caller's backing array")
+	assert.Equal(t, []string{"eastus"}, sanitized.Regions,
+		"sanitizedParams must hold a copy of Regions; otherwise post-validation mutation could inject KQL")
+	assert.Equal(t, []string{"rg"}, sanitized.ResourceGroups,
+		"sanitizedParams must hold a copy of ResourceGroups; otherwise post-validation mutation could inject KQL")
+	assert.Equal(t, []OSType{OSTypeLinux}, sanitized.OSTypes,
+		"sanitizedParams must hold a copy of OSTypes; otherwise post-validation mutation could inject KQL")
+}
+
+// TestQuoteKQL pins the production single-quoted KQL literal form. FuzzQuoteKQL
+// covers round-trip correctness across arbitrary inputs; this test pins
+// specific outputs for the most common shapes.
+func TestQuoteKQL(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"empty", "", `''`},
+		{"plain", "plain", `'plain'`},
+		{"single quote doubled", "it's", `'it''s'`},
+		{"leading and trailing quote", "'both'", `'''both'''`},
+		{"all quotes tripled", "'''", `''''''''`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, quoteKQL(tc.in))
+		})
+	}
+}
+
+func TestEscapeKQL(t *testing.T) {
+	t.Parallel()
+	assert.Empty(t, escapeKQL(""))
+	assert.Equal(t, "plain", escapeKQL("plain"))
+	assert.Equal(t, "it''s", escapeKQL("it's"))
+	assert.Equal(t, "''both''", escapeKQL("'both'"))
+}
+
+// TestDecodeKQLSingleQuoted exercises the quoteKQL inverse directly so a bug in
+// the test decoder cannot silently make FuzzEscapeKQL pass for the wrong reasons.
+func TestDecodeKQLSingleQuoted(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"empty", `''`, ""},
+		{"plain", `'plain'`, "plain"},
+		{"doubled quote", `'with''quote'`, "with'quote"},
+		{"two doubled quotes", `'two''''quotes'`, "two''quotes"},
+		{"leading quote", `'''leading'`, "'leading"},
+		{"trailing quote", `'trailing'''`, "trailing'"},
+		{"backslash literal", `'back\slash'`, `back\slash`},
+		{"newline literal", "'line\nbreak'", "line\nbreak"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := decodeKQLSingleQuoted(tt.in)
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+
+	bad := []struct {
+		name string
+		in   string
+	}{
+		{"unwrapped", `plain`},
+		{"missing closing quote", `'plain`},
+		{"missing opening quote", `plain'`},
+		{"isolated quote in body", `'east'us'`},
+		{"single byte", `'`},
+	}
+	for _, tt := range bad {
+		t.Run("rejects "+tt.name, func(t *testing.T) {
+			_, err := decodeKQLSingleQuoted(tt.in)
+			require.Error(t, err)
+		})
+	}
+}
+
+// TestDecodeKQLDoubleQuoted exercises the double-quoted KQL decoder directly so
+// a decoder bug cannot mask reference-encoder disagreement in FuzzQuoteKQL.
+func TestDecodeKQLDoubleQuoted(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"empty", `""`, ""},
+		{"plain", `"plain"`, "plain"},
+		{"escaped double quote", `"with\"quote"`, `with"quote`},
+		{"escaped single quote", `"with\'quote"`, `with'quote`},
+		{"escaped backslash", `"with\\slash"`, `with\slash`},
+		{"null", `"with\0null"`, "with\x00null"},
+		{"control chars", `"a\bb\fc\nd\re\tf\vg"`, "a\bb\fc\nd\re\tf\vg"},
+		{"unicode bmp", `"é"`, "é"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := decodeKQLDoubleQuoted(tt.in)
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+
+	bad := []struct {
+		name string
+		in   string
+	}{
+		{"unwrapped", `plain`},
+		{"missing closing quote", `"plain`},
+		{"unknown escape", `"\q"`},
+		{"truncated unicode", `"\u12"`},
+		{"non-hex unicode", `"\uzzzz"`},
+		{"single byte", `"`},
+	}
+	for _, tt := range bad {
+		t.Run("rejects "+tt.name, func(t *testing.T) {
+			_, err := decodeKQLDoubleQuoted(tt.in)
+			require.Error(t, err)
+		})
+	}
+}
+
+// FuzzEscapeKQL is the second half of the C73 defense-in-depth: even if a
+// dangerous value ever bypasses sanitizeKQLValues, escapeKQL must produce
+// output that cannot break out of the surrounding single-quoted KQL literal.
+// Two invariants:
+//  1. Round-trip: undoing the quote-doubling recovers the original input.
+//  2. No isolated single quote remains in the output.
+func FuzzEscapeKQL(f *testing.F) {
+	seeds := []string{
+		"",
+		"plain",
+		"with'quote",
+		"two''quotes",
+		"'leading",
+		"trailing'",
+		`back\slash`,
+		"new\nline",
+		"null\x00byte",
+		"tab\there",
+		"unicode-é",
+		"emoji-🎉",
+		"' OR 1=1 --",
+		"'; drop table; --",
+	}
+	for _, s := range seeds {
+		f.Add(s)
+	}
+	f.Fuzz(func(t *testing.T, s string) {
+		escaped := escapeKQL(s)
+		quoted := quoteKQL(s)
+
+		// Invariant 1: round-trip via the production helpers recovers the
+		// input. Using quoteKQL (which wraps escapeKQL) makes the relationship
+		// between the two production helpers explicit, and uses the same
+		// decoder FuzzQuoteKQL uses so the two fuzzers share a decoding model.
+		recovered, err := decodeKQLSingleQuoted(quoted)
+		if err != nil {
+			t.Fatalf("quoteKQL output cannot be decoded: input %q quoted %q err %v",
+				s, quoted, err)
+		}
+		if recovered != s {
+			t.Fatalf("quoteKQL round-trip failed: input %q -> quoted %q -> recovered %q",
+				s, quoted, recovered)
+		}
+
+		// Invariant 2: every single quote in the output is part of a
+		// doubled pair. An isolated quote would close the surrounding
+		// KQL literal and let the rest of the input be parsed as KQL.
+		for i := 0; i < len(escaped); i++ {
+			if escaped[i] != '\'' {
+				continue
+			}
+			if i+1 >= len(escaped) || escaped[i+1] != '\'' {
+				t.Fatalf("escapeKQL left an isolated single quote at index %d in %q (input %q)",
+					i, escaped, s)
+			}
+			i++
+		}
+	})
+}
+
+// FuzzQuoteKQL checks quoteKQL against an independent local double-quoted KQL
+// reference. The two encoders produce different forms by design: production
+// uses single-quoted literals and encodes each interior single quote as two
+// consecutive U+0027 bytes; the reference uses double-quoted literals with
+// backslash escapes.
+//
+// String equality between the two outputs is meaningless; we compare by
+// decoding both back to the original input and asserting they match.
+func FuzzQuoteKQL(f *testing.F) {
+	// Seeds intentionally omit astral-plane runes (e.g., "emoji-🎉"): the
+	// reference encoder's \uNNNN form skips runes above 0xFFFF, so they would
+	// always Skip in the fuzz body. Coverage for emoji etc. lives in
+	// FuzzEscapeKQL where the encoder is byte-preserving.
+	seeds := []string{
+		"",
+		"plain",
+		"with'quote",
+		"two''quotes",
+		`back\slash`,
+		`mixed'and\both`,
+		"new\nline",
+		"null\x00byte",
+		"tab\there",
+		"unicode-é",
+		"' OR 1=1 --",
+		"'; drop table; --",
+	}
+	for _, s := range seeds {
+		f.Add(s)
+	}
+	f.Fuzz(func(t *testing.T, s string) {
+		// The dependency-free reference below mirrors Azure Kusto's string quoting
+		// behavior, which ranges over runes. Skip inputs where that behavior is
+		// intentionally lossy or ambiguous compared to production's byte-preserving
+		// single-quote escape.
+		if !utf8.ValidString(s) {
+			t.Skip()
+		}
+		for _, r := range s {
+			// Azure Kusto's QuoteString emits fmt.Sprintf("\\u%04x", r), which
+			// produces 5+ hex digits for astral-plane runes. KQL \u escapes are
+			// four hex digits, so skip these rather than make the local decoder
+			// accept ambiguous nonstandard output.
+			if r > 0xFFFF {
+				t.Skip()
+			}
+		}
+
+		ours := quoteKQL(s)
+		theirs := quoteKQLDoubleQuotedReference(s)
+
+		oursDecoded, err := decodeKQLSingleQuoted(ours)
+		if err != nil {
+			t.Fatalf("quoteKQL produced an undecodable string: input=%q ours=%q err=%v", s, ours, err)
+		}
+		if oursDecoded != s {
+			t.Fatalf("quoteKQL did not faithfully encode input: input=%q ours=%q decoded=%q",
+				s, ours, oursDecoded)
+		}
+
+		theirsDecoded, err := decodeKQLDoubleQuoted(theirs)
+		if err != nil {
+			t.Fatalf("double-quoted reference produced an undecodable string: input=%q theirs=%q err=%v",
+				s, theirs, err)
+		}
+		if theirsDecoded != s {
+			t.Fatalf("double-quoted reference did not faithfully encode input: input=%q theirs=%q decoded=%q",
+				s, theirs, theirsDecoded)
+		}
+
+		// Parity: both encoders agreed on the original value.
+		if oursDecoded != theirsDecoded {
+			t.Fatalf("parity failed: input=%q ours=%q->%q theirs=%q->%q",
+				s, ours, oursDecoded, theirs, theirsDecoded)
+		}
+	})
+}
+
+// quoteKQLDoubleQuotedReference is a test-only, dependency-free port of Azure
+// Kusto's QuoteString(value, false) string escaping behavior. It intentionally
+// uses a different representation than production quoteKQL, which makes
+// FuzzQuoteKQL compare semantics rather than output form.
+func quoteKQLDoubleQuotedReference(s string) string {
+	var out strings.Builder
+	out.Grow(len(s) + 2)
+	out.WriteByte('"')
+	for _, r := range s {
+		switch r {
+		case '\\':
+			out.WriteString(`\\`)
+		case '\'':
+			out.WriteString(`\'`)
+		case '"':
+			out.WriteString(`\"`)
+		case '\x00':
+			out.WriteString(`\0`)
+		case '\a':
+			out.WriteString(`\a`)
+		case '\b':
+			out.WriteString(`\b`)
+		case '\f':
+			out.WriteString(`\f`)
+		case '\n':
+			out.WriteString(`\n`)
+		case '\r':
+			out.WriteString(`\r`)
+		case '\t':
+			out.WriteString(`\t`)
+		case '\v':
+			out.WriteString(`\v`)
+		default:
+			if !shouldEscapeKQLRune(r) {
+				out.WriteRune(r)
+			} else {
+				fmt.Fprintf(&out, `\u%04x`, r)
+			}
+		}
+	}
+	out.WriteByte('"')
+	return out.String()
+}
+
+func shouldEscapeKQLRune(r rune) bool {
+	if r <= unicode.MaxLatin1 {
+		return unicode.IsControl(r)
+	}
+	return true
+}
+
+// decodeKQLSingleQuoted strips the surrounding single quotes and undoes the
+// doubled-interior-single-quote encoding. Errors if the input is not a
+// well-formed single-quoted KQL string literal.
+//
+// Byte-preserving by design, matching production escapeKQL. Future readers:
+// do not "fix" this to range over runes; that would silently change the test
+// semantics and let escape-related regressions slip through.
+func decodeKQLSingleQuoted(s string) (string, error) {
+	if len(s) < 2 || s[0] != '\'' || s[len(s)-1] != '\'' {
+		return "", fmt.Errorf("not a single-quoted literal: %q", s)
+	}
+	inner := s[1 : len(s)-1]
+	// Walk the body to ensure every interior single quote is doubled.
+	var out strings.Builder
+	for i := 0; i < len(inner); i++ {
+		if inner[i] != '\'' {
+			out.WriteByte(inner[i])
+			continue
+		}
+		if i+1 >= len(inner) || inner[i+1] != '\'' {
+			return "", fmt.Errorf("isolated single quote at index %d in %q", i, inner)
+		}
+		out.WriteByte('\'')
+		i++
+	}
+	return out.String(), nil
+}
+
+// decodeKQLDoubleQuoted is the inverse of quoteKQLDoubleQuotedReference: strip
+// the surrounding double quotes and undo backslash escapes. Mirrors the escape
+// set in quoteKQLDoubleQuotedReference plus \uNNNN so decoder tests can catch
+// malformed unicode escapes.
+func decodeKQLDoubleQuoted(s string) (string, error) {
+	if len(s) < 2 || s[0] != '"' || s[len(s)-1] != '"' {
+		return "", fmt.Errorf("not a double-quoted literal: %q", s)
+	}
+	inner := s[1 : len(s)-1]
+	var out strings.Builder
+	for i := 0; i < len(inner); i++ {
+		if inner[i] != '\\' {
+			out.WriteByte(inner[i])
+			continue
+		}
+		if i+1 >= len(inner) {
+			return "", fmt.Errorf("trailing backslash in %q", inner)
+		}
+		switch inner[i+1] {
+		case '\\':
+			out.WriteByte('\\')
+		case '\'':
+			out.WriteByte('\'')
+		case '"':
+			out.WriteByte('"')
+		case '0':
+			out.WriteByte('\x00')
+		case 'a':
+			out.WriteByte('\a')
+		case 'b':
+			out.WriteByte('\b')
+		case 'f':
+			out.WriteByte('\f')
+		case 'n':
+			out.WriteByte('\n')
+		case 'r':
+			out.WriteByte('\r')
+		case 't':
+			out.WriteByte('\t')
+		case 'v':
+			out.WriteByte('\v')
+		case 'u':
+			if i+5 >= len(inner) {
+				return "", fmt.Errorf("truncated \\uNNNN at index %d in %q", i, inner)
+			}
+			var r rune
+			for j := 2; j < 6; j++ {
+				c := inner[i+j]
+				var d rune
+				switch {
+				case '0' <= c && c <= '9':
+					d = rune(c - '0')
+				case 'a' <= c && c <= 'f':
+					d = rune(c-'a') + 10
+				case 'A' <= c && c <= 'F':
+					d = rune(c-'A') + 10
+				default:
+					return "", fmt.Errorf("non-hex digit %q in \\uNNNN at index %d in %q", c, i, inner)
+				}
+				r = r*16 + d
+			}
+			out.WriteRune(r)
+			i += 4
+		default:
+			return "", fmt.Errorf("unknown escape \\%c at index %d in %q", inner[i+1], i, inner)
+		}
+		i++
+	}
+	return out.String(), nil
+}

--- a/lib/cloud/azure/mocks.go
+++ b/lib/cloud/azure/mocks.go
@@ -22,6 +22,10 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"maps"
+	"slices"
+	"strings"
+	"sync"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
@@ -448,6 +452,9 @@ func (m *ARMKubernetesMock) NewListByResourceGroupPager(group string, _ *armcont
 }
 
 func (m *ARMKubernetesMock) GetCommandResult(ctx context.Context, resourceGroupName string, resourceName string, commandID string, options *armcontainerservice.ManagedClustersClientGetCommandResultOptions) (armcontainerservice.ManagedClustersClientGetCommandResultResponse, error) {
+	if m.NoAuth {
+		return armcontainerservice.ManagedClustersClientGetCommandResultResponse{}, trace.AccessDenied("unauthorized")
+	}
 	return armcontainerservice.ManagedClustersClientGetCommandResultResponse{
 		RunCommandResult: armcontainerservice.RunCommandResult{
 			ID: to.Ptr(commandID),
@@ -500,8 +507,10 @@ func (m *ARMComputeMock) NewListPager(resourceGroup string, _ *armcompute.Virtua
 		vms = []*armcompute.VirtualMachine{}
 	}
 	return runtime.NewPager(runtime.PagingHandler[armcompute.VirtualMachinesClientListResponse]{
-		More: func(page armcompute.VirtualMachinesClientListResponse) bool {
-			return page.NextLink != nil && len(*page.NextLink) > 0
+		More: func(_ armcompute.VirtualMachinesClientListResponse) bool {
+			// Single-page mock: never advertise additional pages. The Fetcher
+			// returns its full payload on the first call and never sets NextLink.
+			return false
 		},
 		Fetcher: func(ctx context.Context, page *armcompute.VirtualMachinesClientListResponse) (armcompute.VirtualMachinesClientListResponse, error) {
 			return armcompute.VirtualMachinesClientListResponse{
@@ -519,8 +528,10 @@ func (m *ARMComputeMock) NewListAllPager(_ *armcompute.VirtualMachinesClientList
 		vms = append(vms, resourceGroupVMs...)
 	}
 	return runtime.NewPager(runtime.PagingHandler[armcompute.VirtualMachinesClientListAllResponse]{
-		More: func(page armcompute.VirtualMachinesClientListAllResponse) bool {
-			return page.NextLink != nil && len(*page.NextLink) > 0
+		More: func(_ armcompute.VirtualMachinesClientListAllResponse) bool {
+			// Single-page mock: never advertise additional pages. The Fetcher
+			// returns its full payload on the first call and never sets NextLink.
+			return false
 		},
 		Fetcher: func(ctx context.Context, page *armcompute.VirtualMachinesClientListAllResponse) (armcompute.VirtualMachinesClientListAllResponse, error) {
 			return armcompute.VirtualMachinesClientListAllResponse{
@@ -725,4 +736,164 @@ func NewUserAssignedIdentity(subscription, resourceGroupName, resourceName, clie
 			ClientID: &clientID,
 		},
 	}
+}
+
+// ARMResourceGraphMock implements ResourceGraphClient for tests.
+//
+// Set VMs, VMsBySubscription, and Err before calling QueryVMs. Query metadata
+// is exposed through Calls and LastParams.
+type ARMResourceGraphMock struct {
+	// VMs is the response returned when VMsBySubscription is nil.
+	VMs []DiscoveredVM
+	// VMsBySubscription routes responses by subscription ID. VM rows must still
+	// populate required ARG fields, including SubscriptionID. When set, VMs is ignored.
+	VMsBySubscription map[string][]DiscoveredVM
+	// Err is returned verbatim from QueryVMs when non-nil.
+	Err error
+
+	mu         sync.RWMutex
+	calls      int
+	lastParams QueryVMsParams
+}
+
+// QueryVMs implements ResourceGraphClient.
+func (m *ARMResourceGraphMock) QueryVMs(_ context.Context, params QueryVMsParams) ([]DiscoveredVM, error) {
+	// Validate before touching call state: production rejects these inputs
+	// before any SDK round trip, so the mock's calls counter must not move
+	// on validation failure.
+	if err := validateQueryVMsParams(params); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	m.mu.Lock()
+	m.calls++
+	m.lastParams = cloneQueryVMsParams(params)
+	err := m.Err
+	var vmsBySubscription map[string][]DiscoveredVM
+	var vms []DiscoveredVM
+	if err == nil {
+		vmsBySubscription = cloneDiscoveredVMsBySubscription(m.VMsBySubscription)
+		vms = cloneDiscoveredVMs(m.VMs)
+	}
+	m.mu.Unlock()
+
+	if err != nil {
+		return nil, err
+	}
+	var src []DiscoveredVM
+	if vmsBySubscription != nil {
+		for _, sub := range params.SubscriptionIDs {
+			src = append(src, vmsBySubscription[sub]...)
+		}
+	} else {
+		src = vms
+	}
+	return mockARGServerFilter(src, params)
+}
+
+// Calls returns the number of QueryVMs invocations.
+func (m *ARMResourceGraphMock) Calls() int {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return m.calls
+}
+
+// LastParams returns a snapshot of the most recent QueryVMs params.
+func (m *ARMResourceGraphMock) LastParams() QueryVMsParams {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return cloneQueryVMsParams(m.lastParams)
+}
+
+// cloneQueryVMsParams copies params without sharing slice backing arrays.
+func cloneQueryVMsParams(params QueryVMsParams) QueryVMsParams {
+	params.SubscriptionIDs = slices.Clone(params.SubscriptionIDs)
+	params.Regions = slices.Clone(params.Regions)
+	params.ResourceGroups = slices.Clone(params.ResourceGroups)
+	params.OSTypes = slices.Clone(params.OSTypes)
+	return params
+}
+
+func cloneDiscoveredVMsBySubscription(vms map[string][]DiscoveredVM) map[string][]DiscoveredVM {
+	if vms == nil {
+		return nil
+	}
+	clone := make(map[string][]DiscoveredVM, len(vms))
+	for subscription, subscriptionVMs := range vms {
+		clone[subscription] = cloneDiscoveredVMs(subscriptionVMs)
+	}
+	return clone
+}
+
+func cloneDiscoveredVMs(vms []DiscoveredVM) []DiscoveredVM {
+	clone := slices.Clone(vms)
+	for i := range clone {
+		clone[i].Tags = maps.Clone(clone[i].Tags)
+		if clone[i].Tags == nil {
+			// Production guarantees Tags is a non-nil empty map even when ARG
+			// returns no tags; preserve that contract for fixtures with nil Tags.
+			clone[i].Tags = map[string]string{}
+		}
+	}
+	return clone
+}
+
+// mockARGServerFilter mirrors the caller-controlled ARG predicates against
+// DiscoveredVM fixtures: subscription, region, resource group, and OS type.
+// It does not model the fixed type and power-state filters.
+func mockARGServerFilter(vms []DiscoveredVM, params QueryVMsParams) ([]DiscoveredVM, error) {
+	allowAllRegions := isMatchAll(params.Regions)
+	allowAllRGs := isMatchAll(params.ResourceGroups)
+	allowAllOSTypes := isMatchAll(params.OSTypes)
+	allowedSubs := make(map[string]struct{}, len(params.SubscriptionIDs))
+	for _, s := range params.SubscriptionIDs {
+		allowedSubs[s] = struct{}{}
+	}
+
+	out := make([]DiscoveredVM, 0, len(vms))
+	for _, vm := range vms {
+		if err := validateMockARGVM(vm); err != nil {
+			return nil, trace.Wrap(err)
+		}
+		if _, ok := allowedSubs[vm.SubscriptionID]; !ok {
+			continue
+		}
+		if !allowAllRegions && !equalFoldAny(vm.Location, params.Regions) {
+			continue
+		}
+		if !allowAllRGs && !equalFoldAny(vm.ResourceGroup, params.ResourceGroups) {
+			continue
+		}
+		if !allowAllOSTypes && !equalFoldAny(vm.OSType, params.OSTypes) {
+			continue
+		}
+		out = append(out, vm)
+	}
+	return out, nil
+}
+
+func validateMockARGVM(vm DiscoveredVM) error {
+	for _, field := range []struct {
+		key   string
+		value string
+	}{
+		{key: "id", value: vm.ID},
+		{key: "subscriptionId", value: vm.SubscriptionID},
+		{key: "name", value: vm.Name},
+		{key: "vmId", value: vm.VMID},
+		{key: "location", value: vm.Location},
+		{key: "resourceGroup", value: vm.ResourceGroup},
+	} {
+		if field.value == "" {
+			return trace.BadParameter("ARMResourceGraphMock fixture missing or empty required field %q", field.key)
+		}
+	}
+	return nil
+}
+
+// equalFoldAny reports whether s case-insensitively matches any candidate.
+func equalFoldAny(s string, candidates []string) bool {
+	return slices.ContainsFunc(candidates, func(candidate string) bool {
+		return strings.EqualFold(s, candidate)
+	})
 }

--- a/lib/cloud/azure/mocks.go
+++ b/lib/cloud/azure/mocks.go
@@ -751,7 +751,7 @@ type ARMResourceGraphMock struct {
 	// Err is returned verbatim from QueryVMs when non-nil.
 	Err error
 
-	mu         sync.RWMutex
+	mu         sync.Mutex
 	calls      int
 	lastParams QueryVMsParams
 }
@@ -761,7 +761,7 @@ func (m *ARMResourceGraphMock) QueryVMs(_ context.Context, params QueryVMsParams
 	// Validate before touching call state: production rejects these inputs
 	// before any SDK round trip, so the mock's calls counter must not move
 	// on validation failure.
-	if err := validateQueryVMsParams(params); err != nil {
+	if _, err := sanitizeQueryVMsParams(params); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
@@ -793,25 +793,26 @@ func (m *ARMResourceGraphMock) QueryVMs(_ context.Context, params QueryVMsParams
 
 // Calls returns the number of QueryVMs invocations.
 func (m *ARMResourceGraphMock) Calls() int {
-	m.mu.RLock()
-	defer m.mu.RUnlock()
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	return m.calls
 }
 
 // LastParams returns a snapshot of the most recent QueryVMs params.
 func (m *ARMResourceGraphMock) LastParams() QueryVMsParams {
-	m.mu.RLock()
-	defer m.mu.RUnlock()
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	return cloneQueryVMsParams(m.lastParams)
 }
 
 // cloneQueryVMsParams copies params without sharing slice backing arrays.
 func cloneQueryVMsParams(params QueryVMsParams) QueryVMsParams {
-	params.SubscriptionIDs = slices.Clone(params.SubscriptionIDs)
-	params.Regions = slices.Clone(params.Regions)
-	params.ResourceGroups = slices.Clone(params.ResourceGroups)
-	params.OSTypes = slices.Clone(params.OSTypes)
-	return params
+	return QueryVMsParams{
+		SubscriptionIDs: slices.Clone(params.SubscriptionIDs),
+		Regions:         slices.Clone(params.Regions),
+		ResourceGroups:  slices.Clone(params.ResourceGroups),
+		OSTypes:         slices.Clone(params.OSTypes),
+	}
 }
 
 func cloneDiscoveredVMsBySubscription(vms map[string][]DiscoveredVM) map[string][]DiscoveredVM {
@@ -892,8 +893,10 @@ func validateMockARGVM(vm DiscoveredVM) error {
 }
 
 // equalFoldAny reports whether s case-insensitively matches any candidate.
-func equalFoldAny(s string, candidates []string) bool {
-	return slices.ContainsFunc(candidates, func(candidate string) bool {
-		return strings.EqualFold(s, candidate)
+// Generic over ~string so Location/ResourceGroup ([]string) and OSTypes ([]OSType)
+// share one helper.
+func equalFoldAny[S ~string](s S, candidates []S) bool {
+	return slices.ContainsFunc(candidates, func(candidate S) bool {
+		return strings.EqualFold(string(s), string(candidate))
 	})
 }

--- a/lib/cloud/azure/resourcegraph.go
+++ b/lib/cloud/azure/resourcegraph.go
@@ -1,0 +1,574 @@
+/*
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package azure
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"regexp"
+	"slices"
+	"strings"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resourcegraph/armresourcegraph"
+	"github.com/gravitational/trace"
+
+	"github.com/gravitational/teleport/api/types"
+	libslices "github.com/gravitational/teleport/lib/utils/slices"
+)
+
+// ResourceGraphClient is a client for Azure Resource Graph (ARG) VM discovery.
+type ResourceGraphClient interface {
+	// QueryVMs returns running VMs matching the supplied scope and filters.
+	QueryVMs(ctx context.Context, params QueryVMsParams) ([]DiscoveredVM, error)
+}
+
+// QueryVMsParams scopes a Resource Graph VM query to a set of subscriptions
+// and an optional set of regions, resource groups, and OS types.
+//
+// QueryVMs does not deduplicate the region, resource-group, or OS-type lists; callers are expected to
+// simplify them by trimming, deduping, and collapsing wildcards. Any types.Wildcard anywhere in a list
+// subsumes all other entries in that list and causes that filter to match every value even when the
+// list also contains entries that would narrow it.
+type QueryVMsParams struct {
+	// SubscriptionIDs is the set of Azure subscriptions to query. QueryVMs requires at least one entry.
+	// Empty is an error, not a wildcard: this is the query scope, not a filter.
+	// QueryVMs rejects empty or untrimmed entries; duplicates pass through (caller's job).
+	SubscriptionIDs []string
+	// Regions filters VMs by location. An empty slice or any occurrence of types.Wildcard matches every region.
+	Regions []string
+	// ResourceGroups filters VMs by resource group. An empty slice or any
+	// occurrence of types.Wildcard matches every resource group.
+	ResourceGroups []string
+	// OSTypes filters VMs by osDisk.osType, e.g. []string{OSTypeLinux, OSTypeWindows}.
+	// An empty slice or any occurrence of types.Wildcard matches every OS type.
+	OSTypes []string
+}
+
+// OS-type values accepted by QueryVMsParams.OSTypes. ARG records osDisk.osType in
+// canonical case; matching is case-insensitive so callers may pass any casing, but
+// these constants give a single source of truth and catch typos at compile time.
+const (
+	OSTypeLinux   = "Linux"
+	OSTypeWindows = "Windows"
+)
+
+// argResourcesAPI is the slice of armresourcegraph.Client we depend on, extracted as an interface
+// so unit tests can fake the SDK without spinning up a real ARG client.
+type argResourcesAPI interface {
+	Resources(ctx context.Context, query armresourcegraph.QueryRequest, options *armresourcegraph.ClientResourcesOptions) (armresourcegraph.ClientResourcesResponse, error)
+}
+
+type resourceGraphClient struct {
+	api argResourcesAPI
+}
+
+// NewResourceGraphClient returns a ResourceGraphClient backed by the official
+// Azure SDK's armresourcegraph.Client.
+func NewResourceGraphClient(cred azcore.TokenCredential, options *arm.ClientOptions) (ResourceGraphClient, error) {
+	client, err := armresourcegraph.NewClient(cred, options)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return &resourceGraphClient{api: client}, nil
+}
+
+// argMaxSubscriptionsPerQuery caps the subscription scope of a single Resource Graph request.
+// Keep this comfortably below Microsoft's recommended grouping size and tenant subscription limits.
+//
+// Source: https://learn.microsoft.com/en-us/azure/governance/resource-graph/concepts/guidance-for-throttled-requests
+const argMaxSubscriptionsPerQuery = 200
+
+// argPageSize is the per-page row limit passed to Resource Graph as QueryRequestOptions.Top.
+// The SDK names the field "Top" after the underlying REST parameter; we alias it here to make
+// the call site read as a page size and to give argMaxPagesPerChunk a real symbol to reference.
+const argPageSize int32 = 1000
+
+// argMaxPagesPerChunk bounds the SkipToken pagination loop in a single chunk's worth of Resource Graph results.
+// QueryVMs asks for argPageSize rows per page, so this allows up to argPageSize x argMaxPagesPerChunk rows
+// (about one million) per chunk before treating pagination as runaway.
+//
+// Source: https://learn.microsoft.com/en-us/azure/governance/resource-graph/concepts/guidance-for-throttled-requests#pagination
+const argMaxPagesPerChunk = 1000
+
+// Resource Graph query vocabulary used by buildVMDiscoveryKQL. Named so the query's external
+// dependencies are explicit and a future Microsoft schema rename has one greppable place to update.
+//
+// Semantic-intent values (type, running power state) define what "discoverable VM" means for this query.
+// Path values are schema dependencies on the shape of the Microsoft.Compute/virtualMachines projection returned by ARG.
+const (
+	argVMType            = "Microsoft.Compute/virtualMachines"
+	argRunningPowerState = "PowerState/running"
+
+	argPowerStatePath = "properties.extended.instanceView.powerState.code"
+	argOSTypePath     = "properties.storageProfile.osDisk.osType"
+	argVMIDPath       = "properties.vmId"
+)
+
+// QueryVMs runs the discovery query against Resource Graph and translates the rows to []DiscoveredVM.
+//
+// Callers are expected to pass simplified inputs satisfying the QueryVMsParams documented contract:
+// trimmed, deduped, with wildcards collapsed to []string{types.Wildcard}. QueryVMs defensively rejects
+// empty or untrimmed subscription IDs and filter values; deduplication remains the caller's job.
+func (c *resourceGraphClient) QueryVMs(ctx context.Context, params QueryVMsParams) ([]DiscoveredVM, error) {
+	if err := validateQueryVMsParams(params); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	query := buildVMDiscoveryKQL(params.Regions, params.ResourceGroups, params.OSTypes)
+
+	var (
+		all          []DiscoveredVM
+		rawRowsTotal int
+	)
+	for chunk := range slices.Chunk(params.SubscriptionIDs, argMaxSubscriptionsPerQuery) {
+		result, err := c.queryChunk(ctx, query, chunk)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		all = append(all, result.vms...)
+		rawRowsTotal += result.rawRowsTotal
+	}
+	if rawRowsTotal > 0 && len(all) == 0 {
+		// Systemic drift: ARG returned rows across the query but none parsed.
+		// Evaluated at query level (not per page or per chunk) so one bad page
+		// or subscription chunk cannot discard valid VMs found elsewhere.
+		return nil, trace.Errorf(
+			"resource graph query returned %d rows but none could be parsed; "+
+				"likely contract drift (renamed field or shifted type)", rawRowsTotal)
+	}
+
+	return all, nil
+}
+
+type queryVMsResult struct {
+	vms          []DiscoveredVM
+	rawRowsTotal int
+}
+
+// queryChunk runs a single ARG query against one chunk of subscription IDs and follows SkipToken pagination internally.
+// The pagination loop is bounded by argMaxPagesPerChunk, a defense against runaway loops a buggy server or mock could
+// otherwise drive. AccessDenied errors are wrapped with ARG-specific remediation guidance.
+func (c *resourceGraphClient) queryChunk(ctx context.Context, query string, subscriptionIDs []string) (queryVMsResult, error) {
+	subs := libslices.Map(subscriptionIDs, to.Ptr[string])
+
+	var (
+		all          []DiscoveredVM
+		lastResp     armresourcegraph.ClientResourcesResponse
+		skipToken    *string
+		rawRowsTotal int
+	)
+
+	for range argMaxPagesPerChunk {
+		req := armresourcegraph.QueryRequest{
+			Query:         to.Ptr(query),
+			Subscriptions: subs,
+			Options: &armresourcegraph.QueryRequestOptions{
+				ResultFormat: to.Ptr(armresourcegraph.ResultFormatObjectArray),
+				Top:          to.Ptr(argPageSize),
+				SkipToken:    skipToken,
+			},
+		}
+
+		resp, err := c.api.Resources(ctx, req, nil)
+		if err != nil {
+			converted := ConvertResponseError(err)
+			if trace.IsAccessDenied(converted) {
+				// Resource Graph has no separate authorization gate: ARG derives access from the
+				// caller's read permissions on the queried resources. A 403 here means the credential
+				// has no read access to any subscription in the chunk. See:
+				// https://learn.microsoft.com/en-us/azure/governance/resource-graph/overview#permissions-in-azure-resource-graph
+				return queryVMsResult{}, trace.Wrap(converted,
+					"resource graph query was denied; ensure the credential has "+
+						"Microsoft.Compute/virtualMachines/read (e.g. via the Reader role) "+
+						"on the queried subscription(s) or a containing management group scope")
+			}
+			return queryVMsResult{}, trace.Wrap(converted)
+		}
+		lastResp = resp
+
+		rows, err := parseDiscoveredVMs(ctx, resp.Data)
+		if err != nil {
+			return queryVMsResult{}, trace.Wrap(err)
+		}
+		// parseDiscoveredVMs returned no error → Data was nil or []any. Track raw row count
+		// across pages so QueryVMs can distinguish "no rows ever returned" (empty tenant)
+		// from "rows returned but none parsed" (systemic schema drift) across the whole query.
+		if data, ok := resp.Data.([]any); ok {
+			rawRowsTotal += len(data)
+		}
+
+		all = append(all, rows...)
+		if resp.SkipToken == nil || *resp.SkipToken == "" {
+			if resp.ResultTruncated != nil && *resp.ResultTruncated == armresourcegraph.ResultTruncatedTrue {
+				return queryVMsResult{}, trace.Errorf(
+					"resource graph response was truncated but did not include a skip token; "+
+						"results are incomplete (%s)",
+					resourceGraphResponseSummary(resp))
+			}
+			return queryVMsResult{vms: all, rawRowsTotal: rawRowsTotal}, nil
+		}
+		skipToken = resp.SkipToken
+	}
+
+	return queryVMsResult{}, trace.Errorf(
+		"resource graph pagination exceeded the %d-page safety cap; aborting (suspected runaway loop; %s)",
+		argMaxPagesPerChunk, resourceGraphResponseSummary(lastResp))
+}
+
+func resourceGraphResponseSummary(resp armresourcegraph.ClientResourcesResponse) string {
+	var parts []string
+	if resp.SkipToken != nil && *resp.SkipToken != "" {
+		parts = append(parts, fmt.Sprintf("skip_token=%q", *resp.SkipToken))
+	}
+	if resp.Count != nil {
+		parts = append(parts, fmt.Sprintf("count=%d", *resp.Count))
+	}
+	if resp.TotalRecords != nil {
+		parts = append(parts, fmt.Sprintf("total_records=%d", *resp.TotalRecords))
+	}
+	if resp.ResultTruncated != nil {
+		parts = append(parts, fmt.Sprintf("result_truncated=%v", *resp.ResultTruncated))
+	}
+	if len(parts) == 0 {
+		return "response metadata unavailable"
+	}
+	return strings.Join(parts, ", ")
+}
+
+// buildVMDiscoveryKQL composes the KQL query used by QueryVMs. The shape is intentionally fixed: type and
+// power-state predicates are baked in; OS, region, and resource-group predicates are caller-controllable.
+//
+// Single quotes in inputs are doubled according to KQL's escape rule.
+func buildVMDiscoveryKQL(regions []string, resourceGroups []string, osTypes []string) string {
+	var sb strings.Builder
+	sb.WriteString("Resources")
+	sb.WriteString("\n| where type =~ " + quoteKQL(argVMType))
+	if pred := osTypesPredicate(osTypes); pred != "" {
+		sb.WriteString("\n")
+		sb.WriteString(pred)
+	}
+	sb.WriteString("\n| where tostring(" + argPowerStatePath + ") =~ " + quoteKQL(argRunningPowerState))
+	if pred := regionPredicate(regions); pred != "" {
+		sb.WriteString("\n")
+		sb.WriteString(pred)
+	}
+	if pred := resourceGroupsPredicate(resourceGroups); pred != "" {
+		sb.WriteString("\n")
+		sb.WriteString(pred)
+	}
+	sb.WriteString("\n| project id, name, subscriptionId, resourceGroup, location, tags," +
+		"\n          vmId = tostring(" + argVMIDPath + ")," +
+		"\n          osType = tostring(" + argOSTypePath + ")")
+	return sb.String()
+}
+
+// regionPredicate returns a KQL `| where location in~ (...)` clause, or empty string when the
+// filter is effectively unset. Uses case-insensitive set membership (in~) because ARG normalizes
+// the `location` column to canonical lowercase, but callers may pass region names in their
+// display-case form like "EastUS".
+//
+// Any occurrence of types.Wildcard is treated as "match everything" to avoid
+// interpreting unsimplified wildcard-containing input as a region name.
+func regionPredicate(regions []string) string {
+	if isMatchAll(regions) {
+		return ""
+	}
+	return "| where location in~ (" + strings.Join(libslices.Map(regions, quoteKQL), ", ") + ")"
+}
+
+// resourceGroupsPredicate returns a KQL `| where resourceGroup in~ (...)` clause, or empty string
+// when the filter is effectively unset. Uses case-insensitive set membership (in~) because ARM
+// resource path segments are case-insensitive.
+//
+// Any occurrence of types.Wildcard is treated as "match everything" to avoid
+// interpreting unsimplified wildcard-containing input as a resource group name.
+func resourceGroupsPredicate(rgs []string) string {
+	if isMatchAll(rgs) {
+		return ""
+	}
+	return "| where resourceGroup in~ (" + strings.Join(libslices.Map(rgs, quoteKQL), ", ") + ")"
+}
+
+// osTypesPredicate returns a KQL clause filtering VMs by osDisk.osType, or empty string when the
+// filter is effectively unset. Uses case-insensitive set membership (in~) because ARG records
+// osType in canonical form ("Linux", "Windows") but callers may pass any casing.
+//
+// Any occurrence of types.Wildcard is treated as "match everything" to avoid
+// interpreting unsimplified wildcard-containing input as an OS-type name.
+func osTypesPredicate(osTypes []string) string {
+	if isMatchAll(osTypes) {
+		return ""
+	}
+	return "| where tostring(" + argOSTypePath + ") in~ (" + strings.Join(libslices.Map(osTypes, quoteKQL), ", ") + ")"
+}
+
+// isMatchAll reports whether values is an unset filter or contains an explicit wildcard. Callers
+// normally pass values trimmed, deduped, and with wildcards collapsed, but treating wildcard as absorbing
+// here prevents unsimplified inputs from silently narrowing results by treating "*" as a value to match.
+func isMatchAll(values []string) bool {
+	return len(values) == 0 || slices.Contains(values, types.Wildcard)
+}
+
+// quoteKQL escapes single quotes in s and wraps the result in single quotes to produce a KQL string literal.
+func quoteKQL(s string) string {
+	return "'" + escapeKQL(s) + "'"
+}
+
+// escapeKQL escapes single quotes in a KQL string literal by doubling them.
+func escapeKQL(s string) string {
+	return strings.ReplaceAll(s, "'", "''")
+}
+
+// Defense-in-depth allowlists for caller-supplied values that flow into KQL string literals.
+// Each is a Teleport-supported safe subset of Azure's naming surface, narrow enough to reject any
+// character that could break out of a single-quoted KQL string (quote, backslash, newline, null, etc.).
+//
+// types.Wildcard ("*") is whitelisted by validateKQLValues; the predicate
+// helpers absorb wildcards before any KQL is generated.
+var (
+	// azureRegionPattern is an injection-safety allowlist for region values:
+	// alphanumeric only, matching Azure's display and canonical forms.
+	azureRegionPattern = regexp.MustCompile(`^[A-Za-z0-9]+$`)
+	// azureResourceGroupPattern is our safe subset of Azure resource group
+	// names: letters, digits, underscore, hyphen, period, and parenthesis.
+	// Length is enforced by Azure; this pattern only blocks unsafe chars.
+	azureResourceGroupPattern = regexp.MustCompile(`^[A-Za-z0-9._()\-]+$`)
+	// azureOSTypePattern matches Azure VM OS type names. With OSTypeLinux and
+	// OSTypeWindows as canonical values, only letter-only inputs are valid;
+	// any future single-word OS name will fit.
+	azureOSTypePattern = regexp.MustCompile(`^[A-Za-z]+$`)
+)
+
+// validateQueryVMsParams enforces the input contract shared by QueryVMs and the ARMResourceGraphMock:
+// a non-empty subscription list with no empty or untrimmed entries, and per-field allowlist validation
+// for the filter slices. Centralized so the mock cannot drift from production behavior.
+func validateQueryVMsParams(params QueryVMsParams) error {
+	if len(params.SubscriptionIDs) == 0 {
+		return trace.BadParameter("at least one subscription ID is required")
+	}
+
+	for _, id := range params.SubscriptionIDs {
+		if strings.TrimSpace(id) == "" {
+			return trace.BadParameter("subscription ID must not be empty")
+		}
+		if strings.TrimSpace(id) != id {
+			return trace.BadParameter("subscription ID %q must not have leading or trailing whitespace", id)
+		}
+	}
+
+	if err := validateKQLValues(params.Regions, azureRegionPattern, "region"); err != nil {
+		return err
+	}
+	if err := validateKQLValues(params.ResourceGroups, azureResourceGroupPattern, "resource group"); err != nil {
+		return err
+	}
+	if err := validateKQLValues(params.OSTypes, azureOSTypePattern, "OS type"); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// validateKQLValues rejects any non-wildcard entry that is empty, untrimmed, or doesn't
+// match the supplied pattern. kind is a human-readable label used in error messages.
+// types.Wildcard is whitelisted because predicate helpers absorb it before KQL is built.
+func validateKQLValues(values []string, pattern *regexp.Regexp, kind string) error {
+	for _, v := range values {
+		if v == types.Wildcard {
+			continue
+		}
+		if strings.TrimSpace(v) == "" {
+			return trace.BadParameter("%s must not be empty", kind)
+		}
+		if strings.TrimSpace(v) != v {
+			return trace.BadParameter("%s %q must not have leading or trailing whitespace", kind, v)
+		}
+		if !pattern.MatchString(v) {
+			return trace.BadParameter("%s %q contains invalid characters; allowed pattern: %s", kind, v, pattern.String())
+		}
+	}
+
+	return nil
+}
+
+// parseDiscoveredVMs parses Resource Graph QueryResponse.Data into VMs.
+// Malformed rows are skipped; outer-shape drift returns an error.
+func parseDiscoveredVMs(ctx context.Context, data any) ([]DiscoveredVM, error) {
+	if data == nil {
+		return nil, nil
+	}
+
+	rows, ok := data.([]any)
+	if !ok {
+		return nil, trace.BadParameter("resource graph response Data has unexpected type %T (expected []any)", data)
+	}
+
+	out := make([]DiscoveredVM, 0, len(rows))
+	skipped := 0
+	for i, row := range rows {
+		m, ok := row.(map[string]any)
+		if !ok {
+			// Per-row at debug so a persistently malformed VM doesn't flood logs
+			// every poll cycle. The summary warn below fires once per call.
+			slog.DebugContext(ctx, "Skipping Resource Graph row with unexpected type",
+				"row", i, "got_type", fmt.Sprintf("%T", row))
+			skipped++
+			continue
+		}
+		vm, err := parseDiscoveredVMRow(ctx, m)
+		if err != nil {
+			slog.DebugContext(ctx, "Skipping malformed Resource Graph row",
+				"row", i, "error", err)
+			skipped++
+			continue
+		}
+		out = append(out, vm)
+	}
+
+	if skipped > 0 {
+		// One warn per affected response, regardless of how many rows were bad.
+		// Row-level detail is at debug above for operators investigating.
+		// Systemic drift (every row failing across the query) is detected in
+		// QueryVMs after all chunks complete, not per-page here, so that
+		// isolated malformed pages/chunks don't discard valid VMs found elsewhere.
+		slog.WarnContext(ctx, "Resource Graph returned malformed rows",
+			"skipped", skipped, "kept", len(out))
+	}
+
+	return out, nil
+}
+
+// parseDiscoveredVMRow extracts a DiscoveredVM from a single ARG response row.
+// Identity-field drift errors; tag drift is best-effort: malformed outer tags
+// yield an empty map, and malformed inner entries are dropped.
+func parseDiscoveredVMRow(ctx context.Context, m map[string]any) (DiscoveredVM, error) {
+	id, err := getRequiredARGString(m, "id")
+	if err != nil {
+		return DiscoveredVM{}, err
+	}
+	subID, err := getRequiredARGString(m, "subscriptionId")
+	if err != nil {
+		return DiscoveredVM{}, err
+	}
+	name, err := getRequiredARGString(m, "name")
+	if err != nil {
+		return DiscoveredVM{}, err
+	}
+	vmID, err := getRequiredARGString(m, "vmId")
+	if err != nil {
+		return DiscoveredVM{}, err
+	}
+	location, err := getRequiredARGString(m, "location")
+	if err != nil {
+		return DiscoveredVM{}, err
+	}
+	rg, err := getRequiredARGString(m, "resourceGroup")
+	if err != nil {
+		return DiscoveredVM{}, err
+	}
+	// OS type is not identity: empty when ARG omits the field is fine. Non-string
+	// drift propagates to parseDiscoveredVMs's per-row skip path.
+	osType, err := getStringIfPresent(m, "osType")
+	if err != nil {
+		return DiscoveredVM{}, err
+	}
+	tags := getStringMap(ctx, m, "tags")
+
+	return DiscoveredVM{
+		ID:             id,
+		SubscriptionID: subID,
+		Name:           name,
+		VMID:           vmID,
+		Location:       location,
+		ResourceGroup:  rg,
+		OSType:         osType,
+		Tags:           tags,
+	}, nil
+}
+
+// getRequiredARGString returns a required string field from an ARG row.
+func getRequiredARGString(m map[string]any, key string) (string, error) {
+	value, err := getStringIfPresent(m, key)
+	if err != nil {
+		return "", err
+	}
+	if value == "" {
+		return "", trace.BadParameter("resource graph response row missing or empty required field %q", key)
+	}
+
+	return value, nil
+}
+
+// getStringIfPresent returns the string value at key in an ARG row. Missing or
+// nil values return "", nil. Non-string values return BadParameter.
+func getStringIfPresent(m map[string]any, key string) (string, error) {
+	v, ok := m[key]
+	if !ok || v == nil {
+		return "", nil
+	}
+	s, ok := v.(string)
+	if !ok {
+		return "", trace.BadParameter("field %q has unexpected type %T (expected string)", key, v)
+	}
+
+	return s, nil
+}
+
+// getStringMap extracts a map[string]string from an ARG row's nested object
+// field. It is best-effort: malformed shape (missing, nil, or wrong-type outer;
+// nil or non-string inner values) is logged at debug and the affected entries
+// are dropped, rather than failing the parent row.
+//
+// This policy is shaped by how Azure VM tags flow into Teleport's discovery
+// label matchers (lib/srv/server/azure_watcher.go calls services.MatchLabels
+// on vm.Tags): fabricating selector values via fmt.Sprint of arbitrary
+// Go-typed data could let drifted ARG output present unintended selector
+// matches. Dropping enforces the rule "selectors only see literal string
+// values that Azure actually returned."
+func getStringMap(ctx context.Context, m map[string]any, key string) map[string]string {
+	raw, ok := m[key]
+	if !ok || raw == nil {
+		return map[string]string{}
+	}
+	asMap, ok := raw.(map[string]any)
+	if !ok {
+		slog.DebugContext(ctx, "Resource Graph row has malformed tags; using empty map",
+			"key", key, "got_type", fmt.Sprintf("%T", raw))
+		return map[string]string{}
+	}
+	out := make(map[string]string, len(asMap))
+	for k, v := range asMap {
+		if v == nil {
+			continue
+		}
+		s, ok := v.(string)
+		if !ok {
+			slog.DebugContext(ctx, "Dropping non-string Resource Graph tag value",
+				"key", key, "tag_key", k, "got_type", fmt.Sprintf("%T", v))
+			continue
+		}
+		out[k] = s
+	}
+
+	return out
+}

--- a/lib/cloud/azure/resourcegraph.go
+++ b/lib/cloud/azure/resourcegraph.go
@@ -22,7 +22,6 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
-	"regexp"
 	"slices"
 	"strings"
 
@@ -50,7 +49,8 @@ type ResourceGraphClient interface {
 // subsumes all other entries in that list and causes that filter to match every value even when the
 // list also contains entries that would narrow it.
 type QueryVMsParams struct {
-	// SubscriptionIDs is the set of Azure subscriptions to query. QueryVMs requires at least one entry.
+	// SubscriptionIDs is the set of Azure subscriptions to query, e.g.
+	// "11111111-1111-1111-1111-111111111111". QueryVMs requires at least one entry.
 	// Empty is an error, not a wildcard: this is the query scope, not a filter.
 	// QueryVMs rejects empty or untrimmed entries; duplicates pass through (caller's job).
 	SubscriptionIDs []string
@@ -59,17 +59,22 @@ type QueryVMsParams struct {
 	// ResourceGroups filters VMs by resource group. An empty slice or any
 	// occurrence of types.Wildcard matches every resource group.
 	ResourceGroups []string
-	// OSTypes filters VMs by osDisk.osType, e.g. []string{OSTypeLinux, OSTypeWindows}.
+	// OSTypes filters VMs by osDisk.osType, e.g. []OSType{OSTypeLinux, OSTypeWindows}.
 	// An empty slice or any occurrence of types.Wildcard matches every OS type.
-	OSTypes []string
+	OSTypes []OSType
 }
 
-// OS-type values accepted by QueryVMsParams.OSTypes. ARG records osDisk.osType in
-// canonical case; matching is case-insensitive so callers may pass any casing, but
-// these constants give a single source of truth and catch typos at compile time.
+// OSType is the closed enum of OS family values that QueryVMsParams.OSTypes accepts
+// and that DiscoveredVM.OSType reports. Microsoft documents the full set as exactly
+// Linux and Windows; callers must use the constants below rather than constructing
+// OSType values directly. ARG records osDisk.osType in this canonical case.
+type OSType string
+
+// OS-type values accepted by QueryVMsParams.OSTypes and reported by DiscoveredVM.OSType.
+// Strict canonical case: validation rejects any other casing or whitespace.
 const (
-	OSTypeLinux   = "Linux"
-	OSTypeWindows = "Windows"
+	OSTypeLinux   OSType = "Linux"
+	OSTypeWindows OSType = "Windows"
 )
 
 // argResourcesAPI is the slice of armresourcegraph.Client we depend on, extracted as an interface
@@ -130,17 +135,18 @@ const (
 // trimmed, deduped, with wildcards collapsed to []string{types.Wildcard}. QueryVMs defensively rejects
 // empty or untrimmed subscription IDs and filter values; deduplication remains the caller's job.
 func (c *resourceGraphClient) QueryVMs(ctx context.Context, params QueryVMsParams) ([]DiscoveredVM, error) {
-	if err := validateQueryVMsParams(params); err != nil {
+	sanitized, err := sanitizeQueryVMsParams(params)
+	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
-	query := buildVMDiscoveryKQL(params.Regions, params.ResourceGroups, params.OSTypes)
+	query := buildVMDiscoveryKQL(sanitized)
 
 	var (
 		all          []DiscoveredVM
 		rawRowsTotal int
 	)
-	for chunk := range slices.Chunk(params.SubscriptionIDs, argMaxSubscriptionsPerQuery) {
+	for chunk := range slices.Chunk(sanitized.SubscriptionIDs, argMaxSubscriptionsPerQuery) {
 		result, err := c.queryChunk(ctx, query, chunk)
 		if err != nil {
 			return nil, trace.Wrap(err)
@@ -178,7 +184,15 @@ func (c *resourceGraphClient) queryChunk(ctx context.Context, query string, subs
 		rawRowsTotal int
 	)
 
-	for range argMaxPagesPerChunk {
+	// Logged once per chunk: the KQL text and scope do not change across the
+	// SkipToken loop. Per-page diagnostic (page index, response summary) is
+	// emitted inside the loop after each Resources call; the chunk-complete
+	// log fires on the success return below with aggregate counts.
+	slog.DebugContext(ctx, "Resource Graph query starting",
+		"subscription_count", len(subscriptionIDs),
+		"query", query)
+
+	for page := range argMaxPagesPerChunk {
 		req := armresourcegraph.QueryRequest{
 			Query:         to.Ptr(query),
 			Subscriptions: subs,
@@ -206,11 +220,15 @@ func (c *resourceGraphClient) queryChunk(ctx context.Context, query string, subs
 		}
 		lastResp = resp
 
+		slog.DebugContext(ctx, "Resource Graph page returned",
+			"page", page,
+			"summary", resourceGraphResponseSummary(resp))
+
 		rows, err := parseDiscoveredVMs(ctx, resp.Data)
 		if err != nil {
 			return queryVMsResult{}, trace.Wrap(err)
 		}
-		// parseDiscoveredVMs returned no error → Data was nil or []any. Track raw row count
+		// parseDiscoveredVMs returned no error: Data was nil or []any. Track raw row count
 		// across pages so QueryVMs can distinguish "no rows ever returned" (empty tenant)
 		// from "rows returned but none parsed" (systemic schema drift) across the whole query.
 		if data, ok := resp.Data.([]any); ok {
@@ -225,6 +243,10 @@ func (c *resourceGraphClient) queryChunk(ctx context.Context, query string, subs
 						"results are incomplete (%s)",
 					resourceGraphResponseSummary(resp))
 			}
+			slog.DebugContext(ctx, "Resource Graph chunk complete",
+				"pages", page+1,
+				"rows_kept", len(all),
+				"raw_rows_total", rawRowsTotal)
 			return queryVMsResult{vms: all, rawRowsTotal: rawRowsTotal}, nil
 		}
 		skipToken = resp.SkipToken
@@ -255,24 +277,37 @@ func resourceGraphResponseSummary(resp armresourcegraph.ClientResourcesResponse)
 	return strings.Join(parts, ", ")
 }
 
-// buildVMDiscoveryKQL composes the KQL query used by QueryVMs. The shape is intentionally fixed: type and
-// power-state predicates are baked in; OS, region, and resource-group predicates are caller-controllable.
+// buildVMDiscoveryKQL composes the KQL (Kusto Query Language) query used by QueryVMs.
+// The shape is intentionally fixed: type and power-state predicates are baked in;
+// OS, region, and resource-group predicates are caller-controllable.
 //
 // Single quotes in inputs are doubled according to KQL's escape rule.
-func buildVMDiscoveryKQL(regions []string, resourceGroups []string, osTypes []string) string {
+//
+// The sanitizedParams type is constructed only by sanitizeQueryVMsParams (in
+// kqlsafety.go), which allowlists every interpolated literal. Injection safety
+// is therefore a compile-time invariant: an unsanitized input cannot reach this
+// function. quoteKQL is defense-in-depth on top of that guarantee.
+//
+// All comparisons use case-insensitive KQL operators (`=~` for equality, `in~` for
+// set membership), not `==` or `in`. ARG normalizes some columns to lowercase
+// (e.g. `resourceGroup`) and preserves portal casing on others, so case-insensitive
+// comparison matches uniformly without the caller needing to know which is which.
+//
+// Note: when adding a new `| where` clause here, use `=~` / `in~`, not `==` / `in`.
+func buildVMDiscoveryKQL(params sanitizedParams) string {
 	var sb strings.Builder
 	sb.WriteString("Resources")
 	sb.WriteString("\n| where type =~ " + quoteKQL(argVMType))
-	if pred := osTypesPredicate(osTypes); pred != "" {
+	if pred := osTypesPredicate(params.OSTypes); pred != "" {
 		sb.WriteString("\n")
 		sb.WriteString(pred)
 	}
 	sb.WriteString("\n| where tostring(" + argPowerStatePath + ") =~ " + quoteKQL(argRunningPowerState))
-	if pred := regionPredicate(regions); pred != "" {
+	if pred := regionPredicate(params.Regions); pred != "" {
 		sb.WriteString("\n")
 		sb.WriteString(pred)
 	}
-	if pred := resourceGroupsPredicate(resourceGroups); pred != "" {
+	if pred := resourceGroupsPredicate(params.ResourceGroups); pred != "" {
 		sb.WriteString("\n")
 		sb.WriteString(pred)
 	}
@@ -298,7 +333,7 @@ func regionPredicate(regions []string) string {
 
 // resourceGroupsPredicate returns a KQL `| where resourceGroup in~ (...)` clause, or empty string
 // when the filter is effectively unset. Uses case-insensitive set membership (in~) because ARM
-// resource path segments are case-insensitive.
+// (Azure Resource Manager) resource path segments are case-insensitive.
 //
 // Any occurrence of types.Wildcard is treated as "match everything" to avoid
 // interpreting unsimplified wildcard-containing input as a resource group name.
@@ -310,105 +345,26 @@ func resourceGroupsPredicate(rgs []string) string {
 }
 
 // osTypesPredicate returns a KQL clause filtering VMs by osDisk.osType, or empty string when the
-// filter is effectively unset. Uses case-insensitive set membership (in~) because ARG records
-// osType in canonical form ("Linux", "Windows") but callers may pass any casing.
+// filter is effectively unset. Uses case-insensitive set membership (in~) for symmetry with
+// regionPredicate and resourceGroupsPredicate; the file-wide rationale for case-insensitive
+// operators is documented on buildVMDiscoveryKQL.
 //
 // Any occurrence of types.Wildcard is treated as "match everything" to avoid
 // interpreting unsimplified wildcard-containing input as an OS-type name.
-func osTypesPredicate(osTypes []string) string {
+func osTypesPredicate(osTypes []OSType) string {
 	if isMatchAll(osTypes) {
 		return ""
 	}
-	return "| where tostring(" + argOSTypePath + ") in~ (" + strings.Join(libslices.Map(osTypes, quoteKQL), ", ") + ")"
+	quoted := libslices.Map(osTypes, func(t OSType) string { return quoteKQL(string(t)) })
+	return "| where tostring(" + argOSTypePath + ") in~ (" + strings.Join(quoted, ", ") + ")"
 }
 
 // isMatchAll reports whether values is an unset filter or contains an explicit wildcard. Callers
 // normally pass values trimmed, deduped, and with wildcards collapsed, but treating wildcard as absorbing
 // here prevents unsimplified inputs from silently narrowing results by treating "*" as a value to match.
-func isMatchAll(values []string) bool {
-	return len(values) == 0 || slices.Contains(values, types.Wildcard)
-}
-
-// quoteKQL escapes single quotes in s and wraps the result in single quotes to produce a KQL string literal.
-func quoteKQL(s string) string {
-	return "'" + escapeKQL(s) + "'"
-}
-
-// escapeKQL escapes single quotes in a KQL string literal by doubling them.
-func escapeKQL(s string) string {
-	return strings.ReplaceAll(s, "'", "''")
-}
-
-// Defense-in-depth allowlists for caller-supplied values that flow into KQL string literals.
-// Each is a Teleport-supported safe subset of Azure's naming surface, narrow enough to reject any
-// character that could break out of a single-quoted KQL string (quote, backslash, newline, null, etc.).
-//
-// types.Wildcard ("*") is whitelisted by validateKQLValues; the predicate
-// helpers absorb wildcards before any KQL is generated.
-var (
-	// azureRegionPattern is an injection-safety allowlist for region values:
-	// alphanumeric only, matching Azure's display and canonical forms.
-	azureRegionPattern = regexp.MustCompile(`^[A-Za-z0-9]+$`)
-	// azureResourceGroupPattern is our safe subset of Azure resource group
-	// names: letters, digits, underscore, hyphen, period, and parenthesis.
-	// Length is enforced by Azure; this pattern only blocks unsafe chars.
-	azureResourceGroupPattern = regexp.MustCompile(`^[A-Za-z0-9._()\-]+$`)
-	// azureOSTypePattern matches Azure VM OS type names. With OSTypeLinux and
-	// OSTypeWindows as canonical values, only letter-only inputs are valid;
-	// any future single-word OS name will fit.
-	azureOSTypePattern = regexp.MustCompile(`^[A-Za-z]+$`)
-)
-
-// validateQueryVMsParams enforces the input contract shared by QueryVMs and the ARMResourceGraphMock:
-// a non-empty subscription list with no empty or untrimmed entries, and per-field allowlist validation
-// for the filter slices. Centralized so the mock cannot drift from production behavior.
-func validateQueryVMsParams(params QueryVMsParams) error {
-	if len(params.SubscriptionIDs) == 0 {
-		return trace.BadParameter("at least one subscription ID is required")
-	}
-
-	for _, id := range params.SubscriptionIDs {
-		if strings.TrimSpace(id) == "" {
-			return trace.BadParameter("subscription ID must not be empty")
-		}
-		if strings.TrimSpace(id) != id {
-			return trace.BadParameter("subscription ID %q must not have leading or trailing whitespace", id)
-		}
-	}
-
-	if err := validateKQLValues(params.Regions, azureRegionPattern, "region"); err != nil {
-		return err
-	}
-	if err := validateKQLValues(params.ResourceGroups, azureResourceGroupPattern, "resource group"); err != nil {
-		return err
-	}
-	if err := validateKQLValues(params.OSTypes, azureOSTypePattern, "OS type"); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-// validateKQLValues rejects any non-wildcard entry that is empty, untrimmed, or doesn't
-// match the supplied pattern. kind is a human-readable label used in error messages.
-// types.Wildcard is whitelisted because predicate helpers absorb it before KQL is built.
-func validateKQLValues(values []string, pattern *regexp.Regexp, kind string) error {
-	for _, v := range values {
-		if v == types.Wildcard {
-			continue
-		}
-		if strings.TrimSpace(v) == "" {
-			return trace.BadParameter("%s must not be empty", kind)
-		}
-		if strings.TrimSpace(v) != v {
-			return trace.BadParameter("%s %q must not have leading or trailing whitespace", kind, v)
-		}
-		if !pattern.MatchString(v) {
-			return trace.BadParameter("%s %q contains invalid characters; allowed pattern: %s", kind, v, pattern.String())
-		}
-	}
-
-	return nil
+// Generic over ~string so the same predicate covers []string (Regions, ResourceGroups) and []OSType.
+func isMatchAll[S ~string](values []S) bool {
+	return len(values) == 0 || slices.Contains(values, S(types.Wildcard))
 }
 
 // parseDiscoveredVMs parses Resource Graph QueryResponse.Data into VMs.
@@ -487,7 +443,10 @@ func parseDiscoveredVMRow(ctx context.Context, m map[string]any) (DiscoveredVM, 
 		return DiscoveredVM{}, err
 	}
 	// OS type is not identity: empty when ARG omits the field is fine. Non-string
-	// drift propagates to parseDiscoveredVMs's per-row skip path.
+	// drift propagates to parseDiscoveredVMs's per-row skip path. ARG returns this
+	// in canonical case ("Linux" / "Windows") per the documented Azure enum; if a
+	// future ARG response drifts to lowercase or an unknown value, it surfaces as
+	// OSType(<raw>) for the consumer to see rather than being silently rejected here.
 	osType, err := getStringIfPresent(m, "osType")
 	if err != nil {
 		return DiscoveredVM{}, err
@@ -501,7 +460,7 @@ func parseDiscoveredVMRow(ctx context.Context, m map[string]any) (DiscoveredVM, 
 		VMID:           vmID,
 		Location:       location,
 		ResourceGroup:  rg,
-		OSType:         osType,
+		OSType:         OSType(osType),
 		Tags:           tags,
 	}, nil
 }
@@ -539,12 +498,14 @@ func getStringIfPresent(m map[string]any, key string) (string, error) {
 // nil or non-string inner values) is logged at debug and the affected entries
 // are dropped, rather than failing the parent row.
 //
-// This policy is shaped by how Azure VM tags flow into Teleport's discovery
-// label matchers (lib/srv/server/azure_watcher.go calls services.MatchLabels
-// on vm.Tags): fabricating selector values via fmt.Sprint of arbitrary
-// Go-typed data could let drifted ARG output present unintended selector
-// matches. Dropping enforces the rule "selectors only see literal string
-// values that Azure actually returned."
+// Non-string values are dropped, not stringified. The general rule is that
+// callers may use tag values as inputs to identity, authorization, or selector
+// logic, where a fmt.Sprint'd Go literal (e.g. "map[k:v]") could be
+// misinterpreted as a value Azure actually returned. The live caller making
+// this concrete today is lib/srv/server/azure_watcher.go, which feeds vm.Tags
+// into services.MatchLabels for discovery label matching; dropping non-string
+// values enforces "selectors only see literal string values Azure returned" so
+// drifted ARG output cannot present unintended selector matches.
 func getStringMap(ctx context.Context, m map[string]any, key string) map[string]string {
 	raw, ok := m[key]
 	if !ok || raw == nil {

--- a/lib/cloud/azure/resourcegraph_test.go
+++ b/lib/cloud/azure/resourcegraph_test.go
@@ -1856,7 +1856,7 @@ func quoteKQLDoubleQuotedReference(s string) string {
 			if !shouldEscapeKQLRune(r) {
 				out.WriteRune(r)
 			} else {
-				out.WriteString(fmt.Sprintf(`\u%04x`, r))
+				fmt.Fprintf(&out, `\u%04x`, r)
 			}
 		}
 	}

--- a/lib/cloud/azure/resourcegraph_test.go
+++ b/lib/cloud/azure/resourcegraph_test.go
@@ -1,0 +1,1967 @@
+/*
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package azure
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"reflect"
+	"strings"
+	"sync"
+	"testing"
+	"unicode"
+	"unicode/utf8"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resourcegraph/armresourcegraph"
+	"github.com/google/go-cmp/cmp"
+	"github.com/gravitational/trace"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport/api/types"
+)
+
+func TestBuildVMDiscoveryKQL(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name            string
+		regions         []string
+		resourceGroups  []string
+		osTypes         []string
+		wantContains    []string
+		wantNotContains []string
+	}{
+		{
+			name:           "no filters",
+			regions:        nil,
+			resourceGroups: nil,
+			osTypes:        nil,
+			wantContains: []string{
+				"Resources",
+				"Microsoft.Compute/virtualMachines",
+				"powerState.code) =~ 'PowerState/running'",
+				"| project id, name, subscriptionId, resourceGroup",
+				"vmId = tostring(properties.vmId)",
+				"osType = tostring(properties.storageProfile.osDisk.osType)",
+			},
+			wantNotContains: []string{
+				"| where location in~",
+				"| where resourceGroup in~",
+				"| where tostring(properties.storageProfile.osDisk.osType)",
+			},
+		},
+		{
+			name:           "wildcard region, rg, and os types",
+			regions:        []string{types.Wildcard},
+			resourceGroups: []string{types.Wildcard},
+			osTypes:        []string{types.Wildcard},
+			wantNotContains: []string{
+				"| where location in~",
+				"| where resourceGroup in~",
+				"| where tostring(properties.storageProfile.osDisk.osType)",
+			},
+		},
+		{
+			name:           "wildcard mixed with concrete filters matches all",
+			regions:        []string{types.Wildcard, "eastus"},
+			resourceGroups: []string{types.Wildcard, "rg1"},
+			osTypes:        []string{types.Wildcard, OSTypeLinux},
+			wantNotContains: []string{
+				"| where location in~",
+				"| where resourceGroup in~",
+				"| where tostring(properties.storageProfile.osDisk.osType)",
+			},
+		},
+		{
+			name:    "single region uses case-insensitive set membership",
+			regions: []string{"eastus"},
+			wantContains: []string{
+				"| where location in~ ('eastus')",
+			},
+		},
+		{
+			name:           "single resource group uses case-insensitive set membership",
+			resourceGroups: []string{"discover-rg"},
+			wantContains: []string{
+				"| where resourceGroup in~ ('discover-rg')",
+			},
+		},
+		{
+			name:    "single os type uses case-insensitive set membership",
+			osTypes: []string{OSTypeLinux},
+			wantContains: []string{
+				"| where tostring(properties.storageProfile.osDisk.osType) in~ ('Linux')",
+			},
+		},
+		{
+			name:    "multiple os types render as a set",
+			osTypes: []string{OSTypeLinux, OSTypeWindows},
+			wantContains: []string{
+				"| where tostring(properties.storageProfile.osDisk.osType) in~ ('Linux', 'Windows')",
+			},
+		},
+		// The next three cases exercise buildVMDiscoveryKQL directly with values
+		// QueryVMs would reject at validation time. They verify the lower-level
+		// quote-escape behavior as a defense-in-depth contract on the helper,
+		// not as input the public API accepts.
+		{
+			name:           "defense-in-depth: single quote in resource group is escaped",
+			resourceGroups: []string{"rg'name"},
+			wantContains: []string{
+				"| where resourceGroup in~ ('rg''name')",
+			},
+		},
+		{
+			name:    "defense-in-depth: single quote in region is escaped",
+			regions: []string{"east'us"},
+			wantContains: []string{
+				"| where location in~ ('east''us')",
+			},
+		},
+		{
+			name:    "defense-in-depth: single quote in os type is escaped",
+			osTypes: []string{"odd'os"},
+			wantContains: []string{
+				"| where tostring(properties.storageProfile.osDisk.osType) in~ ('odd''os')",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := buildVMDiscoveryKQL(tt.regions, tt.resourceGroups, tt.osTypes)
+			for _, want := range tt.wantContains {
+				assert.Contains(t, got, want, "missing expected fragment %q in:\n%s", want, got)
+			}
+			for _, unwanted := range tt.wantNotContains {
+				assert.NotContains(t, got, unwanted, "unexpected fragment %q in:\n%s", unwanted, got)
+			}
+		})
+	}
+}
+
+func TestQueryVMsParamsFieldsStayInSyncWithARGMock(t *testing.T) {
+	t.Parallel()
+
+	typ := reflect.TypeOf(QueryVMsParams{})
+	fields := make([]string, 0, typ.NumField())
+	for i := range typ.NumField() {
+		fields = append(fields, typ.Field(i).Name)
+	}
+
+	assert.ElementsMatch(t, []string{"SubscriptionIDs", "Regions", "ResourceGroups", "OSTypes"}, fields,
+		"QueryVMsParams fields define the caller-controllable ARG filters. "+
+			"If a field is added, update buildVMDiscoveryKQL and mockARGServerFilter together, "+
+			"or document why the new parameter is not part of ARG filtering.")
+}
+
+func TestEscapeKQL(t *testing.T) {
+	t.Parallel()
+	assert.Empty(t, escapeKQL(""))
+	assert.Equal(t, "plain", escapeKQL("plain"))
+	assert.Equal(t, "it''s", escapeKQL("it's"))
+	assert.Equal(t, "''both''", escapeKQL("'both'"))
+}
+
+func makeARGVMRow(id, name string) map[string]any {
+	return map[string]any{
+		"id":             id,
+		"subscriptionId": "sub",
+		"name":           name,
+		"vmId":           name + "-vmid",
+		"location":       "eastus",
+		"resourceGroup":  "rg",
+		"osType":         OSTypeLinux,
+	}
+}
+
+func TestParseDiscoveredVMs(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		data    any
+		wantErr bool
+		verify  func(t *testing.T, got []DiscoveredVM)
+	}{
+		{
+			name: "nil data returns nil slice",
+			data: nil,
+			verify: func(t *testing.T, got []DiscoveredVM) {
+				assert.Nil(t, got)
+			},
+		},
+		{
+			name:    "unexpected top-level type returns error",
+			data:    "not a slice",
+			wantErr: true,
+		},
+		{
+			// Bad row alongside a good one: bad is skipped, good is kept.
+			// Single-row all-bad would now trip the query-level drift guard; that
+			// path is covered by TestQueryVMsContractDriftOnAllQueryRowsFail.
+			name: "unexpected row type is skipped, sibling good row kept",
+			data: []any{
+				makeARGVMRow("/subscriptions/sub/.../good", "good-row-type"),
+				"not a map",
+			},
+			verify: func(t *testing.T, got []DiscoveredVM) {
+				require.Len(t, got, 1)
+				assert.Equal(t, "good-row-type", got[0].Name)
+			},
+		},
+		{
+			name: "happy path projects all fields",
+			data: []any{map[string]any{
+				"id":             "/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Compute/virtualMachines/vm1",
+				"subscriptionId": "sub",
+				"name":           "vm1",
+				"vmId":           "abc-123",
+				"location":       "eastus",
+				"resourceGroup":  "rg",
+				"osType":         OSTypeLinux,
+				"tags": map[string]any{
+					"env":   "prod",
+					"owner": "alice",
+				},
+			}},
+			verify: func(t *testing.T, got []DiscoveredVM) {
+				want := []DiscoveredVM{{
+					ID:             "/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Compute/virtualMachines/vm1",
+					SubscriptionID: "sub",
+					Name:           "vm1",
+					VMID:           "abc-123",
+					Location:       "eastus",
+					ResourceGroup:  "rg",
+					OSType:         OSTypeLinux,
+					Tags:           map[string]string{"env": "prod", "owner": "alice"},
+				}}
+				assert.Empty(t, cmp.Diff(want, got))
+			},
+		},
+		{
+			// osType absent on input: parser tolerates it (empty string in output).
+			// VMs without an osType in ARG can still flow through; downstream
+			// matchers using OSTypes will not match this VM.
+			name: "missing osType yields empty OSType, VM kept",
+			data: []any{func() map[string]any {
+				row := makeARGVMRow("/subscriptions/sub/.../no-os", "no-os-vm")
+				delete(row, "osType")
+				return row
+			}()},
+			verify: func(t *testing.T, got []DiscoveredVM) {
+				require.Len(t, got, 1)
+				assert.Empty(t, got[0].OSType,
+					"missing osType in the ARG row must produce empty OSType, not drop the VM")
+			},
+		},
+		{
+			// osType is optional, but if ARG returns it with a shifted type the row
+			// is malformed. Keep the sibling good row so this pins row-level skip
+			// behavior without tripping the query-level all-rows-failed drift guard.
+			name: "non-string osType is skipped, sibling good row kept",
+			data: []any{
+				makeARGVMRow("/subscriptions/sub/.../good", "good-nonstring-os"),
+				func() map[string]any {
+					row := makeARGVMRow("/subscriptions/sub/.../bad-os", "bad-os-vm")
+					row["osType"] = 42
+					return row
+				}(),
+			},
+			verify: func(t *testing.T, got []DiscoveredVM) {
+				require.Len(t, got, 1)
+				assert.Equal(t, "good-nonstring-os", got[0].Name)
+			},
+		},
+		{
+			// Empty required field on the bad row: that row is skipped, the
+			// sibling good row is kept. (All-bad input would trip the query-level
+			// drift guard; that's covered by TestQueryVMsContractDriftOnAllQueryRowsFail.)
+			name: "empty id field is skipped, sibling good row kept",
+			data: []any{
+				makeARGVMRow("/subscriptions/sub/.../good", "good-empty-id"),
+				map[string]any{
+					"id":             "",
+					"subscriptionId": "sub",
+					"name":           "drop-empty-id",
+					"vmId":           "vm-1",
+					"location":       "eastus",
+					"resourceGroup":  "rg",
+				},
+			},
+			verify: func(t *testing.T, got []DiscoveredVM) {
+				require.Len(t, got, 1)
+				assert.Equal(t, "good-empty-id", got[0].Name)
+			},
+		},
+		{
+			name: "missing id field is skipped, sibling good row kept",
+			data: []any{
+				makeARGVMRow("/subscriptions/sub/.../good", "good-missing-id"),
+				map[string]any{
+					"subscriptionId": "sub",
+					"name":           "drop-missing-id",
+					"vmId":           "vm-2",
+					"location":       "eastus",
+					"resourceGroup":  "rg",
+				},
+			},
+			verify: func(t *testing.T, got []DiscoveredVM) {
+				require.Len(t, got, 1)
+				assert.Equal(t, "good-missing-id", got[0].Name)
+			},
+		},
+		{
+			// Nil required fields are treated like missing required fields.
+			name: "nil required string field is skipped, sibling good row kept",
+			data: []any{
+				makeARGVMRow("/subscriptions/sub/.../good", "good-nil-name"),
+				map[string]any{
+					"id":             "/subscriptions/sub/.../vm",
+					"subscriptionId": "sub",
+					"name":           nil,
+					"vmId":           "vm-vmid",
+					"location":       "westeurope",
+					"resourceGroup":  "rg",
+				},
+			},
+			verify: func(t *testing.T, got []DiscoveredVM) {
+				require.Len(t, got, 1)
+				assert.Equal(t, "good-nil-name", got[0].Name)
+			},
+		},
+		{
+			name: "missing subscriptionId field is skipped, sibling good row kept",
+			data: []any{
+				makeARGVMRow("/subscriptions/sub/.../good", "good-missing-sub"),
+				map[string]any{
+					"id":            "/subscriptions/sub/.../vm",
+					"name":          "vm",
+					"vmId":          "vm-vmid",
+					"location":      "eastus",
+					"resourceGroup": "rg",
+				},
+			},
+			verify: func(t *testing.T, got []DiscoveredVM) {
+				require.Len(t, got, 1)
+				assert.Equal(t, "good-missing-sub", got[0].Name)
+			},
+		},
+		{
+			// Type drift in a required field: bad row dropped, good row kept.
+			name: "non-string scalar field is skipped, sibling good row kept",
+			data: []any{
+				makeARGVMRow("/subscriptions/sub/.../good", "good-nonstring-scalar"),
+				map[string]any{
+					"id":             "/subscriptions/sub/.../vm",
+					"subscriptionId": "sub",
+					"name":           "vm",
+					"vmId":           42, // wrong type
+					"location":       "westeurope",
+					"resourceGroup":  "rg",
+				},
+			},
+			verify: func(t *testing.T, got []DiscoveredVM) {
+				require.Len(t, got, 1)
+				assert.Equal(t, "good-nonstring-scalar", got[0].Name)
+			},
+		},
+		{
+			// Tag values flow into services.MatchLabels in the discovery layer.
+			// Non-string drift is dropped, not coerced via fmt.Sprint, so
+			// selectors never match fabricated Go-formatted values.
+			name: "non-string and nil tag values are dropped, string values kept",
+			data: []any{func() map[string]any {
+				row := makeARGVMRow("/subscriptions/sub/.../vm", "vm")
+				row["tags"] = map[string]any{
+					"strKey": "value",
+					"intKey": 42,
+					"nilKey": nil,
+				}
+				return row
+			}()},
+			verify: func(t *testing.T, got []DiscoveredVM) {
+				require.Len(t, got, 1)
+				assert.Equal(t, "value", got[0].Tags["strKey"])
+				_, hasInt := got[0].Tags["intKey"]
+				assert.False(t, hasInt,
+					"non-string tag values must be dropped, not stringified; "+
+						"tag values feed Teleport label matchers in discovery")
+				_, hasNil := got[0].Tags["nilKey"]
+				assert.False(t, hasNil, "nil tag values are dropped")
+			},
+		},
+		{
+			// Tags are metadata, not identity: shape drift in tags must not
+			// lose the VM. The row is kept with an empty (but non-nil) Tags map.
+			name: "tags wrong type yields empty tags, VM kept",
+			data: []any{map[string]any{
+				"id":             "/subscriptions/sub/.../vm",
+				"subscriptionId": "sub",
+				"name":           "vm",
+				"vmId":           "vm-vmid",
+				"location":       "eastus",
+				"resourceGroup":  "rg",
+				"tags":           "not a map",
+			}},
+			verify: func(t *testing.T, got []DiscoveredVM) {
+				require.Len(t, got, 1, "tag-shape drift must not drop the VM; tags are metadata")
+				require.NotNil(t, got[0].Tags, "Tags must always be a non-nil map")
+				assert.Empty(t, got[0].Tags)
+			},
+		},
+		{
+			// One bad row in a batch must not poison the rest.
+			name: "mixed good and bad rows keeps the good one",
+			data: []any{
+				makeARGVMRow("/subscriptions/sub/.../good-vm", "good-vm"),
+				map[string]any{
+					"id":             "",
+					"subscriptionId": "sub",
+					"name":           "bad-vm",
+					"vmId":           "vm-bad",
+					"location":       "eastus",
+					"resourceGroup":  "rg",
+				},
+				"not a map",
+			},
+			verify: func(t *testing.T, got []DiscoveredVM) {
+				require.Len(t, got, 1, "the good row must be kept even when other rows are malformed")
+				assert.Equal(t, "good-vm", got[0].Name)
+			},
+		},
+		{
+			// Missing/nil tags must still produce a non-nil empty map.
+			name: "missing tags yields non-nil empty map",
+			data: []any{
+				makeARGVMRow("/subscriptions/sub/.../no-tags", "no-tags"),
+				func() map[string]any {
+					row := makeARGVMRow("/subscriptions/sub/.../nil-tags", "nil-tags")
+					row["tags"] = nil
+					return row
+				}(),
+			},
+			verify: func(t *testing.T, got []DiscoveredVM) {
+				require.Len(t, got, 2)
+				for _, vm := range got {
+					assert.NotNil(t, vm.Tags, "tags must be non-nil for %q", vm.ID)
+					assert.Empty(t, vm.Tags)
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := parseDiscoveredVMs(t.Context(), tt.data)
+			if tt.wantErr {
+				assert.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			if tt.verify != nil {
+				tt.verify(t, got)
+			}
+		})
+	}
+}
+
+// TestQueryVMsContractDriftOnAllQueryRowsFail pins the failure-loud behavior
+// when every row returned by a whole query fails to parse. This is the failure
+// mode where a renamed field or shifted type would otherwise produce
+// ([]DiscoveredVM{}, nil) - indistinguishable from a healthy empty result
+// and visible only as "discovery silently stopped finding VMs."
+//
+// The guard lives at the query level, not per page or per subscription chunk,
+// so isolated malformed pages/chunks cannot drop valid VMs found elsewhere.
+func TestQueryVMsContractDriftOnAllQueryRowsFail(t *testing.T) {
+	t.Parallel()
+	// Mix several per-row failure shapes; every one must fail to parse for
+	// the query-level drift guard to fire.
+	api := &fakeARGAPI{
+		pages: []argPage{{
+			data: []any{
+				"not a map",
+				map[string]any{
+					// missing id
+					"subscriptionId": "sub",
+					"name":           "vm-a",
+					"vmId":           "vm-a-id",
+					"location":       "eastus",
+					"resourceGroup":  "rg",
+				},
+				map[string]any{
+					"id":             "/sub/.../vm-b",
+					"subscriptionId": "sub",
+					"name":           "vm-b",
+					"vmId":           42, // wrong type
+					"location":       "eastus",
+					"resourceGroup":  "rg",
+				},
+			},
+		}},
+	}
+	c := &resourceGraphClient{api: api}
+
+	got, err := c.QueryVMs(t.Context(), QueryVMsParams{SubscriptionIDs: []string{"sub"}})
+	require.Error(t, err,
+		"all rows failing to parse must surface as drift, not silent empty result")
+	assert.Empty(t, got, "drift error must not return partial results")
+	assert.Contains(t, err.Error(), "contract drift",
+		"error must name the failure mode so operators don't read this as an empty tenant")
+	assert.Contains(t, err.Error(), "3 rows",
+		"error must name how many rows ARG returned for context")
+}
+
+// TestQueryVMsContractDriftIsQueryScopedNotPageScoped pins the bug-fix:
+// a single bad row on a small trailing page must NOT discard earlier pages'
+// valid VMs. The drift guard fires only when the entire query produced zero
+// parsed VMs, not when one page happens to be all-bad.
+func TestQueryVMsContractDriftIsQueryScopedNotPageScoped(t *testing.T) {
+	t.Parallel()
+	api := &fakeARGAPI{
+		pages: []argPage{
+			{
+				// Page 1: a valid row.
+				data:      []any{makeARGVMRow("/sub/.../valid-vm", "valid-vm")},
+				skipToken: to.Ptr("page-2"),
+			},
+			{
+				// Page 2: a single row that fails to parse (missing id).
+				// Old per-page guard would fire here and drop page 1's results.
+				// Query-level guard sees rawRowsTotal=2, kept=1, so no drift.
+				data: []any{
+					map[string]any{
+						"subscriptionId": "sub",
+						"name":           "bad-trailing-vm",
+						"vmId":           "bad-id",
+						"location":       "eastus",
+						"resourceGroup":  "rg",
+					},
+				},
+			},
+		},
+	}
+	c := &resourceGraphClient{api: api}
+
+	got, err := c.QueryVMs(t.Context(), QueryVMsParams{SubscriptionIDs: []string{"sub"}})
+	require.NoError(t, err,
+		"a single bad row on a trailing page must not tank the chunk; "+
+			"page-scoped drift detection would lose page 1's valid VMs")
+	require.Len(t, got, 1,
+		"page 1's valid VM must be returned; only the single bad row from page 2 is dropped")
+	assert.Equal(t, "valid-vm", got[0].Name)
+}
+
+// TestQueryVMsContractDriftIsQueryScopedNotChunkScoped pins the same policy at subscription-chunk
+// boundaries: an all-bad later chunk must not discard valid VMs found in an earlier chunk.
+func TestQueryVMsContractDriftIsQueryScopedNotChunkScoped(t *testing.T) {
+	t.Parallel()
+	api := &fakeARGAPI{
+		pages: []argPage{
+			{
+				// Chunk 1: a valid row.
+				data: []any{makeARGVMRow("/sub/.../valid-vm", "valid-vm")},
+			},
+			{
+				// Chunk 2: a single row that fails to parse (missing id).
+				data: []any{
+					map[string]any{
+						"subscriptionId": "sub",
+						"name":           "bad-chunk-vm",
+						"vmId":           "bad-id",
+						"location":       "eastus",
+						"resourceGroup":  "rg",
+					},
+				},
+			},
+		},
+	}
+	c := &resourceGraphClient{api: api}
+
+	got, err := c.QueryVMs(t.Context(), QueryVMsParams{
+		SubscriptionIDs: makeSubscriptionIDs(argMaxSubscriptionsPerQuery + 1),
+	})
+	require.NoError(t, err,
+		"an all-bad later chunk must not tank the query when earlier chunks produced valid VMs")
+	require.Len(t, got, 1,
+		"chunk 1's valid VM must be returned; only the bad row from chunk 2 is dropped")
+	assert.Equal(t, "valid-vm", got[0].Name)
+}
+
+// fakeARGAPI records Resource Graph calls and replays pre-built pages.
+type fakeARGAPI struct {
+	pages       []argPage
+	calls       int
+	gotRequests []armresourcegraph.QueryRequest
+	err         error
+}
+
+type argPage struct {
+	data            any
+	skipToken       *string
+	count           *int64
+	totalRecords    *int64
+	resultTruncated *armresourcegraph.ResultTruncated
+}
+
+func makeRunawayARGPages(n int) []argPage {
+	pages := make([]argPage, n)
+	for i := range n {
+		pages[i] = argPage{
+			data:            []any{},
+			count:           to.Ptr[int64](0),
+			totalRecords:    to.Ptr(int64(n)),
+			resultTruncated: to.Ptr(armresourcegraph.ResultTruncatedTrue),
+			skipToken:       to.Ptr(fmt.Sprintf("page-%d", i+1)),
+		}
+	}
+	return pages
+}
+
+func (f *fakeARGAPI) Resources(_ context.Context, query armresourcegraph.QueryRequest, _ *armresourcegraph.ClientResourcesOptions) (armresourcegraph.ClientResourcesResponse, error) {
+	f.calls++
+	f.gotRequests = append(f.gotRequests, query)
+	if f.err != nil {
+		return armresourcegraph.ClientResourcesResponse{}, f.err
+	}
+	if f.calls > len(f.pages) {
+		return armresourcegraph.ClientResourcesResponse{}, errors.New("fakeARGAPI: more pages requested than configured")
+	}
+	page := f.pages[f.calls-1]
+	return armresourcegraph.ClientResourcesResponse{
+		QueryResponse: armresourcegraph.QueryResponse{
+			Count:           page.count,
+			Data:            page.data,
+			ResultTruncated: page.resultTruncated,
+			TotalRecords:    page.totalRecords,
+			SkipToken:       page.skipToken,
+		},
+	}, nil
+}
+
+func TestQueryVMs(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name   string
+		api    *fakeARGAPI
+		params QueryVMsParams
+		verify func(t *testing.T, got []DiscoveredVM, api *fakeARGAPI, err error)
+	}{
+		{
+			name:   "missing subscriptions is rejected",
+			api:    &fakeARGAPI{},
+			params: QueryVMsParams{},
+			verify: func(t *testing.T, got []DiscoveredVM, api *fakeARGAPI, err error) {
+				assert.Error(t, err)
+				assert.True(t, trace.IsBadParameter(err),
+					"empty subscription list must be BadParameter, got %T: %v", err, err)
+				assert.Equal(t, 0, api.calls,
+					"validation must run before any ARG round trip")
+			},
+		},
+		{
+			name: "single page returns parsed VMs and forwards multi-sub / multi-rg params",
+			api: &fakeARGAPI{
+				pages: []argPage{{
+					data: []any{
+						makeARGVMRow("/sub/.../vm1", "vm1"),
+						makeARGVMRow("/sub/.../vm2", "vm2"),
+					},
+				}},
+			},
+			params: QueryVMsParams{
+				SubscriptionIDs: []string{"sub-1", "sub-2"},
+				Regions:         []string{"eastus"},
+				ResourceGroups:  []string{"rg-1", "rg-2"},
+			},
+			verify: func(t *testing.T, got []DiscoveredVM, api *fakeARGAPI, err error) {
+				require.NoError(t, err)
+				require.Len(t, got, 2)
+				assert.Equal(t, 1, api.calls)
+				req := api.gotRequests[0]
+				require.NotNil(t, req.Query)
+				assert.Contains(t, *req.Query, "| where location in~ ('eastus')")
+				assert.Contains(t, *req.Query, "| where resourceGroup in~ ('rg-1', 'rg-2')")
+				require.Len(t, req.Subscriptions, 2)
+				require.NotNil(t, req.Subscriptions[0])
+				assert.Equal(t, "sub-1", *req.Subscriptions[0])
+				assert.Equal(t, "sub-2", *req.Subscriptions[1])
+				require.NotNil(t, req.Options)
+				require.NotNil(t, req.Options.ResultFormat)
+				assert.Equal(t, armresourcegraph.ResultFormatObjectArray, *req.Options.ResultFormat)
+				require.NotNil(t, req.Options.Top)
+				assert.Equal(t, argPageSize, *req.Options.Top)
+				assert.Nil(t, req.Options.SkipToken)
+			},
+		},
+		{
+			name: "paginates across SkipToken",
+			api: &fakeARGAPI{
+				pages: []argPage{
+					{
+						data: []any{
+							makeARGVMRow("/sub/.../vm1", "vm1"),
+						},
+						skipToken: to.Ptr("page-2-token"),
+					},
+					{
+						data: []any{
+							makeARGVMRow("/sub/.../vm2", "vm2"),
+						},
+						skipToken: to.Ptr(""), // empty string also terminates
+					},
+				},
+			},
+			params: QueryVMsParams{SubscriptionIDs: []string{"sub"}},
+			verify: func(t *testing.T, got []DiscoveredVM, api *fakeARGAPI, err error) {
+				require.NoError(t, err)
+				require.Len(t, got, 2)
+				assert.Equal(t, 2, api.calls)
+				require.NotNil(t, api.gotRequests[1].Options)
+				require.NotNil(t, api.gotRequests[1].Options.SkipToken)
+				assert.Equal(t, "page-2-token", *api.gotRequests[1].Options.SkipToken)
+			},
+		},
+		{
+			name:   "propagates SDK errors",
+			api:    &fakeARGAPI{err: errors.New("boom")},
+			params: QueryVMsParams{SubscriptionIDs: []string{"sub"}},
+			verify: func(t *testing.T, got []DiscoveredVM, api *fakeARGAPI, err error) {
+				require.Error(t, err)
+				assert.True(t, strings.Contains(err.Error(), "boom"), "expected wrapped error, got %v", err)
+			},
+		},
+		{
+			name: "403 surfaces AccessDenied with remediation message",
+			// Build an *azcore.ResponseError so ConvertResponseError maps it to AccessDenied.
+			api:    &fakeARGAPI{err: &azcore.ResponseError{StatusCode: http.StatusForbidden}},
+			params: QueryVMsParams{SubscriptionIDs: []string{"sub"}},
+			verify: func(t *testing.T, got []DiscoveredVM, api *fakeARGAPI, err error) {
+				require.Error(t, err)
+				assert.True(t, trace.IsAccessDenied(err), "expected AccessDenied, got %T: %v", err, err)
+				// Surface the RBAC action commonly missing when ARG returns 403.
+				assert.Contains(t, err.Error(), "Microsoft.Compute/virtualMachines/read",
+					"error must name the missing permission so operators know which RBAC action to grant")
+			},
+		},
+		{
+			// ARG throttles per-user quotas with 429 plus x-ms-user-quota-resets-after.
+			// ConvertResponseError must classify this as LimitExceeded so callers can
+			// detect throttling (vs auth failure, transient breakage) and back off.
+			name:   "429 surfaces LimitExceeded so callers can back off",
+			api:    &fakeARGAPI{err: &azcore.ResponseError{StatusCode: http.StatusTooManyRequests}},
+			params: QueryVMsParams{SubscriptionIDs: []string{"sub"}},
+			verify: func(t *testing.T, got []DiscoveredVM, api *fakeARGAPI, err error) {
+				require.Error(t, err)
+				assert.True(t, trace.IsLimitExceeded(err),
+					"429 must classify as LimitExceeded so the discovery loop can distinguish "+
+						"throttling from other errors and reduce poll frequency; got %T: %v", err, err)
+			},
+		},
+		{
+			// Runaway pagination must hit the explicit page cap.
+			name: "pagination safety cap aborts runaway paging",
+			api: &fakeARGAPI{
+				pages: makeRunawayARGPages(argMaxPagesPerChunk),
+			},
+			params: QueryVMsParams{SubscriptionIDs: []string{"sub"}},
+			verify: func(t *testing.T, got []DiscoveredVM, api *fakeARGAPI, err error) {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), "pagination exceeded")
+				assert.Contains(t, err.Error(), fmt.Sprintf("%d-page safety cap", argMaxPagesPerChunk),
+					"error must include the configured cap so operators can identify this boundary")
+				assert.Contains(t, err.Error(), fmt.Sprintf(`skip_token="page-%d"`, argMaxPagesPerChunk))
+				assert.Contains(t, err.Error(), "count=0")
+				assert.Contains(t, err.Error(), fmt.Sprintf("total_records=%d", argMaxPagesPerChunk))
+				assert.Contains(t, err.Error(), "result_truncated=true")
+				assert.Equal(t, argMaxPagesPerChunk, api.calls,
+					"the safety cap should allow exactly argMaxPagesPerChunk page attempts before aborting")
+			},
+		},
+		{
+			name: "subscription list at argMaxSubscriptionsPerQuery uses one chunk",
+			api: &fakeARGAPI{
+				pages: []argPage{{data: []any{makeARGVMRow("/sub/.../chunk-vm", "chunk-vm")}}},
+			},
+			params: QueryVMsParams{
+				SubscriptionIDs: makeSubscriptionIDs(argMaxSubscriptionsPerQuery),
+			},
+			verify: func(t *testing.T, got []DiscoveredVM, api *fakeARGAPI, err error) {
+				require.NoError(t, err)
+				require.Len(t, got, 1)
+				assert.Equal(t, 1, api.calls,
+					"exactly argMaxSubscriptionsPerQuery subscriptions must fit in one ARG request")
+				require.Len(t, api.gotRequests, 1)
+				assert.Len(t, api.gotRequests[0].Subscriptions, argMaxSubscriptionsPerQuery)
+			},
+		},
+		{
+			// 2N+1 subscription IDs split into chunks of N, N, and 1.
+			name: "chunks subscription list when over argMaxSubscriptionsPerQuery",
+			api: &fakeARGAPI{
+				pages: []argPage{
+					{data: []any{makeARGVMRow("/sub/.../chunk1-vm", "chunk1-vm")}},
+					{data: []any{makeARGVMRow("/sub/.../chunk2-vm", "chunk2-vm")}},
+					{data: []any{makeARGVMRow("/sub/.../chunk3-vm", "chunk3-vm")}},
+				},
+			},
+			params: QueryVMsParams{
+				SubscriptionIDs: makeSubscriptionIDs(2*argMaxSubscriptionsPerQuery + 1),
+			},
+			verify: func(t *testing.T, got []DiscoveredVM, api *fakeARGAPI, err error) {
+				require.NoError(t, err)
+				assert.Equal(t, 3, api.calls,
+					"expected one ARG call per chunk for 2N+1 subscriptions")
+				require.Len(t, got, 3, "result must be the union of per-chunk responses")
+				ids := []string{got[0].ID, got[1].ID, got[2].ID}
+				assert.ElementsMatch(t, []string{
+					"/sub/.../chunk1-vm",
+					"/sub/.../chunk2-vm",
+					"/sub/.../chunk3-vm",
+				}, ids)
+				require.Len(t, api.gotRequests, 3)
+				assert.Len(t, api.gotRequests[0].Subscriptions, argMaxSubscriptionsPerQuery)
+				assert.Len(t, api.gotRequests[1].Subscriptions, argMaxSubscriptionsPerQuery)
+				assert.Len(t, api.gotRequests[2].Subscriptions, 1,
+					"final chunk holds the remainder")
+			},
+		},
+		{
+			// SkipToken state must not carry from one subscription chunk to the next.
+			name: "pagination state does not leak across chunks",
+			api: &fakeARGAPI{
+				pages: []argPage{
+					{
+						data:      []any{makeARGVMRow("/sub/.../chunk1-page1", "chunk1-page1")},
+						skipToken: to.Ptr("chunk1-page2"),
+					},
+					{
+						data: []any{makeARGVMRow("/sub/.../chunk1-page2", "chunk1-page2")},
+					},
+					{
+						data: []any{makeARGVMRow("/sub/.../chunk2-page1", "chunk2-page1")},
+					},
+				},
+			},
+			params: QueryVMsParams{
+				SubscriptionIDs: makeSubscriptionIDs(argMaxSubscriptionsPerQuery + 1),
+			},
+			verify: func(t *testing.T, got []DiscoveredVM, api *fakeARGAPI, err error) {
+				require.NoError(t, err)
+				require.Len(t, got, 3, "every page across both chunks must be returned")
+				require.Len(t, api.gotRequests, 3)
+				require.NotNil(t, api.gotRequests[0].Options)
+				assert.Nil(t, api.gotRequests[0].Options.SkipToken,
+					"chunk 1 page 1 must start with a nil SkipToken")
+				require.NotNil(t, api.gotRequests[1].Options)
+				require.NotNil(t, api.gotRequests[1].Options.SkipToken,
+					"chunk 1 page 2 must carry the page-1 token")
+				assert.Equal(t, "chunk1-page2", *api.gotRequests[1].Options.SkipToken)
+				require.NotNil(t, api.gotRequests[2].Options)
+				assert.Nil(t, api.gotRequests[2].Options.SkipToken,
+					"chunk 2 page 1 must start fresh; a non-nil token here means "+
+						"chunk-1 pagination state leaked into chunk 2")
+			},
+		},
+		{
+			// Outer-shape drift on a later page must surface fatally; earlier pages' success
+			// must not mask it.
+			name: "outer-shape drift on a paginated page surfaces the error",
+			api: &fakeARGAPI{
+				pages: []argPage{
+					{
+						data:      []any{makeARGVMRow("/sub/.../vm1", "vm1")},
+						skipToken: to.Ptr("page-2"),
+					},
+					{
+						// Outer-shape drift: Data must be []any, not a string.
+						data: "not a slice",
+					},
+				},
+			},
+			params: QueryVMsParams{SubscriptionIDs: []string{"sub"}},
+			verify: func(t *testing.T, got []DiscoveredVM, api *fakeARGAPI, err error) {
+				require.Error(t, err)
+				assert.True(t, trace.IsBadParameter(err),
+					"outer-shape drift must surface as BadParameter; got %T: %v", err, err)
+				assert.Contains(t, err.Error(), "resource graph response Data",
+					"the outer-shape error from parseDiscoveredVMs must surface, not be swallowed")
+				assert.Equal(t, 2, api.calls,
+					"the parse error must come from page 2; page 1 had to succeed first")
+			},
+		},
+		{
+			// Per-row malformed entries on a later page must be skipped, not fatal: the
+			// good page 1 row plus the good entry on page 2 should be returned.
+			name: "row-level drift on a paginated page is skipped, chunk still succeeds",
+			api: &fakeARGAPI{
+				pages: []argPage{
+					{
+						data:      []any{makeARGVMRow("/sub/.../vm1", "vm1")},
+						skipToken: to.Ptr("page-2"),
+					},
+					{
+						data: []any{
+							"not a map",
+							makeARGVMRow("/sub/.../vm2", "vm2"),
+						},
+					},
+				},
+			},
+			params: QueryVMsParams{SubscriptionIDs: []string{"sub"}},
+			verify: func(t *testing.T, got []DiscoveredVM, api *fakeARGAPI, err error) {
+				require.NoError(t, err,
+					"per-row drift must skip the row, not abort the chunk")
+				require.Len(t, got, 2,
+					"page 1's good row plus page 2's good row must both be kept; only the malformed row is dropped")
+				assert.Equal(t, "vm1", got[0].Name)
+				assert.Equal(t, "vm2", got[1].Name)
+				assert.Equal(t, 2, api.calls)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			c := &resourceGraphClient{api: tt.api}
+			got, err := c.QueryVMs(t.Context(), tt.params)
+			tt.verify(t, got, tt.api, err)
+		})
+	}
+}
+
+// makeSubscriptionIDs returns n synthetic subscription IDs for chunking tests.
+func makeSubscriptionIDs(n int) []string {
+	out := make([]string, n)
+	for i := range n {
+		out[i] = fmt.Sprintf("sub-%d", i)
+	}
+
+	return out
+}
+
+func makeMockARGVM(sub, rg, location, name string) DiscoveredVM {
+	return DiscoveredVM{
+		ID:             fmt.Sprintf("/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Compute/virtualMachines/%s", sub, rg, name),
+		SubscriptionID: sub,
+		Name:           name,
+		VMID:           name + "-vmid",
+		Location:       location,
+		ResourceGroup:  rg,
+		OSType:         OSTypeLinux,
+		Tags:           map[string]string{},
+	}
+}
+
+// TestARMResourceGraphMock_caseInsensitiveFilters keeps mock filtering aligned
+// with KQL `in~` semantics.
+func TestARMResourceGraphMock_caseInsensitiveFilters(t *testing.T) {
+	t.Parallel()
+	mock := &ARMResourceGraphMock{
+		VMs: []DiscoveredVM{
+			makeMockARGVM("sub-1", "rg-a", "eastus", "vm1"), // ARG canonical lowercase; RG names are case-insensitive in ARM.
+			makeMockARGVM("sub-1", "rg-b", "westus2", "vm2"),
+		},
+	}
+
+	got, err := mock.QueryVMs(t.Context(), QueryVMsParams{
+		SubscriptionIDs: []string{"sub-1"},
+		Regions:         []string{"EastUS"}, // display-cased
+		ResourceGroups:  []string{"RG-A"},   // mixed-case
+	})
+
+	require.NoError(t, err)
+	require.Len(t, got, 1,
+		"mock must apply case-insensitive matching to mirror KQL `in~`; "+
+			"otherwise display-cased operator config silently returns zero VMs")
+	assert.Equal(t, "/subscriptions/sub-1/resourceGroups/rg-a/providers/Microsoft.Compute/virtualMachines/vm1", got[0].ID)
+}
+
+// TestARMResourceGraphMock_OSTypesFiltering proves the mock enforces OSTypes
+// against the fixture's OSType field. Without this, a regression that swaps
+// the production KQL operator (e.g. in~ to ==) would still pass mock-based
+// tests despite breaking against real ARG.
+func TestARMResourceGraphMock_OSTypesFiltering(t *testing.T) {
+	t.Parallel()
+	linuxVM := makeMockARGVM("sub-1", "rg-a", "eastus", "linux-vm")
+	windowsVM := makeMockARGVM("sub-1", "rg-a", "eastus", "windows-vm")
+	windowsVM.OSType = OSTypeWindows
+	mock := &ARMResourceGraphMock{
+		VMs: []DiscoveredVM{linuxVM, windowsVM},
+	}
+
+	t.Run("Linux-only filter returns only Linux VMs", func(t *testing.T) {
+		t.Parallel()
+		got, err := mock.QueryVMs(t.Context(), QueryVMsParams{
+			SubscriptionIDs: []string{"sub-1"},
+			OSTypes:         []string{OSTypeLinux},
+		})
+		require.NoError(t, err)
+		require.Len(t, got, 1)
+		assert.Equal(t, "linux-vm", got[0].Name)
+	})
+
+	t.Run("Windows-only filter returns only Windows VMs", func(t *testing.T) {
+		t.Parallel()
+		got, err := mock.QueryVMs(t.Context(), QueryVMsParams{
+			SubscriptionIDs: []string{"sub-1"},
+			OSTypes:         []string{OSTypeWindows},
+		})
+		require.NoError(t, err)
+		require.Len(t, got, 1)
+		assert.Equal(t, "windows-vm", got[0].Name)
+	})
+
+	t.Run("wildcard OSTypes returns all OS types", func(t *testing.T) {
+		t.Parallel()
+		got, err := mock.QueryVMs(t.Context(), QueryVMsParams{
+			SubscriptionIDs: []string{"sub-1"},
+			OSTypes:         []string{types.Wildcard},
+		})
+		require.NoError(t, err)
+		assert.Len(t, got, 2)
+	})
+
+	t.Run("OSTypes uses case-insensitive matching like KQL in~", func(t *testing.T) {
+		t.Parallel()
+		got, err := mock.QueryVMs(t.Context(), QueryVMsParams{
+			SubscriptionIDs: []string{"sub-1"},
+			OSTypes:         []string{"linux"}, // canonical lowercase; fixture has "Linux"
+		})
+		require.NoError(t, err)
+		require.Len(t, got, 1)
+		assert.Equal(t, "linux-vm", got[0].Name)
+	})
+}
+
+func TestARMResourceGraphMock_wildcardMixedWithConcreteFiltersMatchesAll(t *testing.T) {
+	t.Parallel()
+	mock := &ARMResourceGraphMock{
+		VMs: []DiscoveredVM{
+			makeMockARGVM("sub-1", "rg-a", "eastus", "vm1"),
+			makeMockARGVM("sub-1", "rg-b", "westus2", "vm2"),
+		},
+	}
+
+	got, err := mock.QueryVMs(t.Context(), QueryVMsParams{
+		SubscriptionIDs: []string{"sub-1"},
+		Regions:         []string{types.Wildcard, "eastus"},
+		ResourceGroups:  []string{types.Wildcard, "rg-a"},
+	})
+
+	require.NoError(t, err)
+	require.Len(t, got, 2,
+		"wildcard must be absorbing even when mixed with concrete filters; "+
+			"otherwise unsimplified input silently narrows discovery")
+}
+
+func TestARMResourceGraphMock_rejectsInvalidFixtures(t *testing.T) {
+	t.Parallel()
+	mock := &ARMResourceGraphMock{
+		VMs: []DiscoveredVM{
+			{
+				ID:             "/subscriptions/sub-1/resourceGroups/rg-a/providers/Microsoft.Compute/virtualMachines/vm1",
+				SubscriptionID: "sub-1",
+				Name:           "vm1",
+				Location:       "eastus",
+				ResourceGroup:  "rg-a",
+				// VMID intentionally omitted.
+			},
+		},
+	}
+
+	_, err := mock.QueryVMs(t.Context(), QueryVMsParams{SubscriptionIDs: []string{"sub-1"}})
+	require.Error(t, err)
+	assert.True(t, trace.IsBadParameter(err), "invalid fixtures should fail like production row parsing, got %T: %v", err, err)
+	assert.Contains(t, err.Error(), "ARMResourceGraphMock fixture missing or empty required field")
+}
+
+// TestARMResourceGraphMock_LastParamsClones verifies LastParams cloning.
+func TestARMResourceGraphMock_LastParamsClones(t *testing.T) {
+	t.Parallel()
+	mock := &ARMResourceGraphMock{}
+
+	subs := []string{"sub-1"}
+	regions := []string{"eastus"}
+	rgs := []string{"rg-a"}
+	osTypes := []string{OSTypeLinux}
+	_, err := mock.QueryVMs(t.Context(), QueryVMsParams{
+		SubscriptionIDs: subs,
+		Regions:         regions,
+		ResourceGroups:  rgs,
+		OSTypes:         osTypes,
+	})
+	require.NoError(t, err)
+
+	// Mutate the caller's slices in place after the call.
+	subs[0] = "MUTATED"
+	regions[0] = "MUTATED"
+	rgs[0] = "MUTATED"
+	osTypes[0] = "MUTATED"
+
+	got := mock.LastParams()
+	assert.Equal(t, []string{"sub-1"}, got.SubscriptionIDs,
+		"LastParams must snapshot SubscriptionIDs, not alias the caller's slice")
+	assert.Equal(t, []string{"eastus"}, got.Regions,
+		"LastParams must snapshot Regions, not alias the caller's slice")
+	assert.Equal(t, []string{"rg-a"}, got.ResourceGroups,
+		"LastParams must snapshot ResourceGroups, not alias the caller's slice")
+	assert.Equal(t, []string{OSTypeLinux}, got.OSTypes,
+		"LastParams must snapshot OSTypes, not alias the caller's slice")
+
+	first := mock.LastParams()
+	require.Len(t, first.SubscriptionIDs, 1)
+	require.Len(t, first.Regions, 1)
+	require.Len(t, first.ResourceGroups, 1)
+	require.Len(t, first.OSTypes, 1)
+	first.SubscriptionIDs[0] = "MUTATED"
+	first.Regions[0] = "MUTATED"
+	first.ResourceGroups[0] = "MUTATED"
+	first.OSTypes[0] = "MUTATED"
+
+	second := mock.LastParams()
+	assert.Equal(t, []string{"sub-1"}, second.SubscriptionIDs,
+		"LastParams must clone on read so prior callers cannot mutate the snapshot")
+	assert.Equal(t, []string{"eastus"}, second.Regions)
+	assert.Equal(t, []string{"rg-a"}, second.ResourceGroups)
+	assert.Equal(t, []string{OSTypeLinux}, second.OSTypes)
+}
+
+// TestARMResourceGraphMock_ValidationFailureDoesNotBumpCalls pins the mock's
+// agreement with production: production rejects invalid params before any SDK
+// round trip, so the mock's calls counter must not increment on validation
+// failure. Otherwise mock-based tests would over-count calls relative to the
+// real client.
+func TestARMResourceGraphMock_ValidationFailureDoesNotBumpCalls(t *testing.T) {
+	t.Parallel()
+	mock := &ARMResourceGraphMock{}
+
+	_, err := mock.QueryVMs(t.Context(), QueryVMsParams{})
+	require.Error(t, err)
+	assert.True(t, trace.IsBadParameter(err))
+	assert.Equal(t, 0, mock.Calls(),
+		"validation failure must not register as a call; production never reaches the SDK either")
+
+	_, err = mock.QueryVMs(t.Context(), QueryVMsParams{
+		SubscriptionIDs: []string{"sub"},
+		Regions:         []string{"east'us"}, // invalid char
+	})
+	require.Error(t, err)
+	assert.Equal(t, 0, mock.Calls(),
+		"filter validation failure must not register as a call either")
+
+	// Sanity: a valid call increments.
+	_, err = mock.QueryVMs(t.Context(), QueryVMsParams{SubscriptionIDs: []string{"sub"}})
+	require.NoError(t, err)
+	assert.Equal(t, 1, mock.Calls())
+}
+
+// TestARMResourceGraphMock_PreservesNonNilTags pins the production contract that
+// DiscoveredVM.Tags is always non-nil (empty map for "no tags"). cloneDiscoveredVMs
+// must not regress this when a fixture omits Tags.
+func TestARMResourceGraphMock_PreservesNonNilTags(t *testing.T) {
+	t.Parallel()
+	mock := &ARMResourceGraphMock{
+		VMs: []DiscoveredVM{
+			{
+				ID:             "/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Compute/virtualMachines/vm1",
+				SubscriptionID: "sub",
+				Name:           "vm1",
+				VMID:           "vm1-vmid",
+				Location:       "eastus",
+				ResourceGroup:  "rg",
+				// Tags intentionally nil.
+			},
+		},
+	}
+
+	got, err := mock.QueryVMs(t.Context(), QueryVMsParams{SubscriptionIDs: []string{"sub"}})
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	require.NotNil(t, got[0].Tags,
+		"Tags must be non-nil to match production's parseDiscoveredVMs contract; "+
+			"callers should be able to index Tags without a nil check")
+	assert.Empty(t, got[0].Tags)
+}
+
+// TestARMResourceGraphMock_AccessorsAreRaceFree exercises concurrent accessors
+// under -race.
+func TestARMResourceGraphMock_AccessorsAreRaceFree(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+	mock := &ARMResourceGraphMock{
+		VMsBySubscription: map[string][]DiscoveredVM{
+			"sub-0": {makeMockARGVM("sub-0", "rg-a", "eastus", "vm-0")},
+			"sub-1": {makeMockARGVM("sub-1", "rg-a", "eastus", "vm-1")},
+			"sub-2": {makeMockARGVM("sub-2", "rg-a", "eastus", "vm-2")},
+			"sub-3": {makeMockARGVM("sub-3", "rg-a", "eastus", "vm-3")},
+		},
+	}
+
+	const writers = 4
+	const readers = 4
+	const callsPerWriter = 50
+
+	var wg sync.WaitGroup
+	wg.Add(writers + readers)
+	errCh := make(chan error, writers*callsPerWriter)
+
+	for i := range writers {
+		go func(i int) {
+			defer wg.Done()
+			params := QueryVMsParams{
+				SubscriptionIDs: []string{fmt.Sprintf("sub-%d", i)},
+				Regions:         []string{"eastus"},
+				ResourceGroups:  []string{"rg-a"},
+			}
+			for range callsPerWriter {
+				_, err := mock.QueryVMs(ctx, params)
+				if err != nil {
+					errCh <- err
+				}
+			}
+		}(i)
+	}
+	for range readers {
+		go func() {
+			defer wg.Done()
+			for range callsPerWriter {
+				_ = mock.Calls()
+				_ = mock.LastParams()
+			}
+		}()
+	}
+	wg.Wait()
+	close(errCh)
+	for err := range errCh {
+		require.NoError(t, err)
+	}
+
+	assert.Equal(t, writers*callsPerWriter, mock.Calls(),
+		"every QueryVMs invocation across all writers must be counted exactly once")
+}
+
+func TestGetStringIfPresent(t *testing.T) {
+	t.Parallel()
+
+	m := map[string]any{
+		"name": "vincent",
+		"nil":  nil,
+		"int":  42,
+	}
+
+	got, err := getStringIfPresent(m, "name")
+	require.NoError(t, err)
+	require.Equal(t, "vincent", got)
+
+	got, err = getStringIfPresent(m, "missing")
+	require.NoError(t, err)
+	require.Empty(t, got)
+
+	got, err = getStringIfPresent(m, "nil")
+	require.NoError(t, err)
+	require.Empty(t, got)
+
+	_, err = getStringIfPresent(m, "int")
+	require.Error(t, err)
+	require.True(t, trace.IsBadParameter(err), "type drift must surface as BadParameter, got %T", err)
+}
+
+func TestGetStringMap(t *testing.T) {
+	t.Parallel()
+
+	m := map[string]any{
+		"happy":  map[string]any{"strKey": "value", "intKey": 42, "nilKey": nil},
+		"wrong":  "not a map",
+		"nested": map[string]any{"deepKey": map[string]any{"k": "v"}},
+	}
+
+	t.Run("missing key yields empty non-nil map", func(t *testing.T) {
+		got := getStringMap(t.Context(), m, "missing")
+		require.NotNil(t, got)
+		assert.Empty(t, got)
+	})
+
+	t.Run("non-string and nil values are dropped, string values kept", func(t *testing.T) {
+		got := getStringMap(t.Context(), m, "happy")
+		assert.Equal(t, map[string]string{"strKey": "value"}, got,
+			"non-string tag values must be dropped, not coerced via fmt.Sprint, "+
+				"since tag values feed services.MatchLabels in discovery enrollment decisions")
+	})
+
+	t.Run("outer shape drift yields empty map, not error", func(t *testing.T) {
+		got := getStringMap(t.Context(), m, "wrong")
+		require.NotNil(t, got)
+		assert.Empty(t, got,
+			"wrong outer type is logged at debug and degrades to empty tags; "+
+				"the parent row is not lost")
+	})
+
+	t.Run("structured inner values are dropped, not Go-formatted", func(t *testing.T) {
+		got := getStringMap(t.Context(), m, "nested")
+		assert.Empty(t, got,
+			"nested object tag values are schema drift; dropping them is safer "+
+				"than fmt.Sprint producing Go-syntax strings selectors would never see")
+	})
+}
+
+// TestQueryVMsValidatesInputs is the restriction half of the C73 defense-in-depth.
+// It pairs with FuzzEscapeKQL: the regex rejects any input that contains KQL
+// metacharacters, escapeKQL is the safety net if validation is ever bypassed.
+func TestQueryVMsValidatesInputs(t *testing.T) {
+	t.Parallel()
+	// Dangerous characters and substrings that must never reach escapeKQL.
+	// Each is tried against every list field (Regions, ResourceGroups, OSTypes)
+	// so a future loosened regex on any one field is caught by these tests.
+	dangerous := []struct {
+		name  string
+		value string
+	}{
+		{"single quote", "east'us"},
+		{"double quote", `east"us`},
+		{"backslash", `east\us`},
+		{"newline", "east\nus"},
+		{"carriage return", "east\rus"},
+		{"tab", "east\tus"},
+		{"null byte", "east\x00us"},
+		{"pipe", "east|us"},
+		{"semicolon", "east;us"},
+		{"space", "east us"},
+		{"unicode letter", "eastusé"},
+		{"emoji", "eastus🎉"},
+		{"comment fragment", "eastus // x"},
+		{"slash star", "eastus/*"},
+	}
+	type field int
+	const (
+		fieldRegion field = iota
+		fieldRG
+		fieldOSType
+	)
+	fields := []struct {
+		f    field
+		kind string
+	}{
+		{fieldRegion, "region"},
+		{fieldRG, "resource group"},
+		{fieldOSType, "OS type"},
+	}
+
+	for _, fld := range fields {
+		for _, d := range dangerous {
+			t.Run(fld.kind+"/"+d.name, func(t *testing.T) {
+				t.Parallel()
+				params := QueryVMsParams{SubscriptionIDs: []string{"sub"}}
+				switch fld.f {
+				case fieldRegion:
+					params.Regions = []string{d.value}
+				case fieldRG:
+					params.ResourceGroups = []string{d.value}
+				case fieldOSType:
+					params.OSTypes = []string{d.value}
+				}
+
+				c := &resourceGraphClient{api: &fakeARGAPI{}}
+				_, err := c.QueryVMs(t.Context(), params)
+				require.Error(t, err)
+				assert.True(t, trace.IsBadParameter(err),
+					"validation must surface as BadParameter, got %T: %v", err, err)
+				assert.Contains(t, err.Error(), fld.kind,
+					"error must name the offending field kind")
+				assert.Contains(t, err.Error(), fmt.Sprintf("%q", d.value),
+					"error must include the offending value so operators can find their config")
+			})
+		}
+	}
+
+	// emptyPage is a single empty Resource Graph page the fake replays when
+	// validation must pass and the call must proceed to the SDK; the test
+	// then asserts no error was returned, regardless of the (empty) result.
+	emptyPage := func() *fakeARGAPI {
+		return &fakeARGAPI{pages: []argPage{{data: []any{}}}}
+	}
+
+	// Wildcards must still pass for every field; the validator should not
+	// treat "*" as an invalid character.
+	t.Run("wildcard passes for all fields", func(t *testing.T) {
+		t.Parallel()
+		c := &resourceGraphClient{api: emptyPage()}
+		_, err := c.QueryVMs(t.Context(), QueryVMsParams{
+			SubscriptionIDs: []string{"sub"},
+			Regions:         []string{types.Wildcard},
+			ResourceGroups:  []string{types.Wildcard},
+			OSTypes:         []string{types.Wildcard},
+		})
+		require.NoError(t, err)
+	})
+
+	// Wildcard mixed with concrete (still valid) entries also passes; the
+	// validator must check each entry independently and skip wildcards.
+	t.Run("wildcard mixed with valid concrete passes", func(t *testing.T) {
+		t.Parallel()
+		c := &resourceGraphClient{api: emptyPage()}
+		_, err := c.QueryVMs(t.Context(), QueryVMsParams{
+			SubscriptionIDs: []string{"sub"},
+			Regions:         []string{types.Wildcard, "eastus"},
+			ResourceGroups:  []string{types.Wildcard, "rg-1"},
+			OSTypes:         []string{types.Wildcard, OSTypeLinux},
+		})
+		require.NoError(t, err)
+	})
+
+	// Empty filter values produce a clear "must not be empty" message, not
+	// the generic "contains invalid characters" the regex would emit.
+	t.Run("empty region rejected with clear message", func(t *testing.T) {
+		t.Parallel()
+		c := &resourceGraphClient{api: &fakeARGAPI{}}
+		_, err := c.QueryVMs(t.Context(), QueryVMsParams{
+			SubscriptionIDs: []string{"sub"},
+			Regions:         []string{""},
+		})
+		require.Error(t, err)
+		assert.True(t, trace.IsBadParameter(err))
+		assert.Contains(t, err.Error(), "region must not be empty",
+			"empty values get a dedicated error rather than a confusing 'invalid characters'")
+	})
+
+	// Untrimmed values produce a "must not have leading or trailing whitespace"
+	// message, distinguishing input-hygiene errors from character-class errors.
+	// Each field has its own kind label, so check all three.
+	untrimmed := []struct {
+		name   string
+		params QueryVMsParams
+		kind   string
+		value  string
+	}{
+		{
+			name: "untrimmed region rejected with clear message",
+			params: QueryVMsParams{
+				SubscriptionIDs: []string{"sub"},
+				Regions:         []string{" eastus "},
+			},
+			kind:  "region",
+			value: " eastus ",
+		},
+		{
+			name: "untrimmed resource group rejected with clear message",
+			params: QueryVMsParams{
+				SubscriptionIDs: []string{"sub"},
+				ResourceGroups:  []string{" rg-1 "},
+			},
+			kind:  "resource group",
+			value: " rg-1 ",
+		},
+		{
+			name: "untrimmed OS type rejected with clear message",
+			params: QueryVMsParams{
+				SubscriptionIDs: []string{"sub"},
+				OSTypes:         []string{" Linux "},
+			},
+			kind:  "OS type",
+			value: " Linux ",
+		},
+	}
+	for _, tt := range untrimmed {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			c := &resourceGraphClient{api: &fakeARGAPI{}}
+			_, err := c.QueryVMs(t.Context(), tt.params)
+			require.Error(t, err)
+			assert.True(t, trace.IsBadParameter(err))
+			assert.Contains(t, err.Error(), tt.kind,
+				"error must name the offending field kind")
+			assert.Contains(t, err.Error(), "leading or trailing whitespace")
+			assert.Contains(t, err.Error(), fmt.Sprintf("%q", tt.value),
+				"error must include the offending value")
+		})
+	}
+
+	// Empty subscription IDs are caught as a query-scope error before any
+	// filter validation runs.
+	t.Run("empty subscription ID rejected", func(t *testing.T) {
+		t.Parallel()
+		c := &resourceGraphClient{api: &fakeARGAPI{}}
+		_, err := c.QueryVMs(t.Context(), QueryVMsParams{
+			SubscriptionIDs: []string{""},
+		})
+		require.Error(t, err)
+		assert.True(t, trace.IsBadParameter(err))
+		assert.Contains(t, err.Error(), "subscription ID must not be empty")
+	})
+
+	t.Run("whitespace-only subscription ID rejected", func(t *testing.T) {
+		t.Parallel()
+		c := &resourceGraphClient{api: &fakeARGAPI{}}
+		_, err := c.QueryVMs(t.Context(), QueryVMsParams{
+			SubscriptionIDs: []string{"   "},
+		})
+		require.Error(t, err)
+		assert.True(t, trace.IsBadParameter(err))
+		assert.Contains(t, err.Error(), "subscription ID must not be empty")
+	})
+
+	t.Run("untrimmed subscription ID rejected", func(t *testing.T) {
+		t.Parallel()
+		c := &resourceGraphClient{api: &fakeARGAPI{}}
+		_, err := c.QueryVMs(t.Context(), QueryVMsParams{
+			SubscriptionIDs: []string{" sub-1 "},
+		})
+		require.Error(t, err)
+		assert.True(t, trace.IsBadParameter(err))
+		assert.Contains(t, err.Error(), "must not have leading or trailing whitespace")
+	})
+}
+
+// TestQueryVMsTruncatedWithoutSkipToken pins the behavior where ARG marks the
+// response truncated but omits a SkipToken: results would otherwise be silently
+// incomplete, so QueryVMs must surface this as an error instead.
+func TestQueryVMsTruncatedWithoutSkipToken(t *testing.T) {
+	t.Parallel()
+	api := &fakeARGAPI{
+		pages: []argPage{
+			{
+				data:            []any{makeARGVMRow("/sub/.../vm1", "vm1")},
+				resultTruncated: to.Ptr(armresourcegraph.ResultTruncatedTrue),
+				// No skipToken -- the pathology this test targets.
+			},
+		},
+	}
+	c := &resourceGraphClient{api: api}
+	_, err := c.QueryVMs(t.Context(), QueryVMsParams{SubscriptionIDs: []string{"sub"}})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "truncated",
+		"truncation without a skip token must surface; silently returning partial results would be worse")
+	assert.Contains(t, err.Error(), "result_truncated=true",
+		"the response summary should name the failure mode")
+}
+
+// TestQueryVMsNotTruncatedWithoutSkipTokenReturnsResults pins the partner of
+// TestQueryVMsTruncatedWithoutSkipToken: a clean final page (ResultTruncated=false,
+// no SkipToken) must return its rows, not be misread as a truncation error.
+func TestQueryVMsNotTruncatedWithoutSkipTokenReturnsResults(t *testing.T) {
+	t.Parallel()
+	api := &fakeARGAPI{
+		pages: []argPage{
+			{
+				data:            []any{makeARGVMRow("/sub/.../vm1", "vm1")},
+				resultTruncated: to.Ptr(armresourcegraph.ResultTruncatedFalse),
+			},
+		},
+	}
+	c := &resourceGraphClient{api: api}
+	got, err := c.QueryVMs(t.Context(), QueryVMsParams{SubscriptionIDs: []string{"sub"}})
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	assert.Equal(t, "vm1", got[0].Name)
+}
+
+// TestQueryVMsForwardsDuplicateSubscriptions pins the documented no-dedup
+// contract on SubscriptionIDs: duplicate entries flow through to ARG as-is,
+// which may produce duplicate VMs. Deduplication is the caller's job.
+func TestQueryVMsForwardsDuplicateSubscriptions(t *testing.T) {
+	t.Parallel()
+	api := &fakeARGAPI{
+		pages: []argPage{{data: []any{}}},
+	}
+	c := &resourceGraphClient{api: api}
+	_, err := c.QueryVMs(t.Context(), QueryVMsParams{
+		SubscriptionIDs: []string{"sub-1", "sub-1", "sub-2"},
+	})
+	require.NoError(t, err)
+	require.Len(t, api.gotRequests, 1, "all entries fit in one chunk")
+	require.Len(t, api.gotRequests[0].Subscriptions, 3,
+		"duplicates must pass through unchanged; deduplication is the caller's contract")
+	for i, want := range []string{"sub-1", "sub-1", "sub-2"} {
+		require.NotNil(t, api.gotRequests[0].Subscriptions[i])
+		assert.Equal(t, want, *api.gotRequests[0].Subscriptions[i],
+			"subscription order must be preserved across the dedup-skipping path")
+	}
+}
+
+// TestDecodeKQLSingleQuoted exercises the quoteKQL inverse directly so a bug in
+// the test decoder cannot silently make FuzzEscapeKQL pass for the wrong reasons.
+func TestDecodeKQLSingleQuoted(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"empty", `''`, ""},
+		{"plain", `'plain'`, "plain"},
+		{"doubled quote", `'with''quote'`, "with'quote"},
+		{"two doubled quotes", `'two''''quotes'`, "two''quotes"},
+		{"leading quote", `'''leading'`, "'leading"},
+		{"trailing quote", `'trailing'''`, "trailing'"},
+		{"backslash literal", `'back\slash'`, `back\slash`},
+		{"newline literal", "'line\nbreak'", "line\nbreak"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := decodeKQLSingleQuoted(tt.in)
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+
+	bad := []struct {
+		name string
+		in   string
+	}{
+		{"unwrapped", `plain`},
+		{"missing closing quote", `'plain`},
+		{"missing opening quote", `plain'`},
+		{"isolated quote in body", `'east'us'`},
+		{"single byte", `'`},
+	}
+	for _, tt := range bad {
+		t.Run("rejects "+tt.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := decodeKQLSingleQuoted(tt.in)
+			require.Error(t, err)
+		})
+	}
+}
+
+// TestDecodeKQLDoubleQuoted exercises the double-quoted KQL decoder directly so
+// a decoder bug cannot mask reference-encoder disagreement in FuzzQuoteKQL.
+func TestDecodeKQLDoubleQuoted(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"empty", `""`, ""},
+		{"plain", `"plain"`, "plain"},
+		{"escaped double quote", `"with\"quote"`, `with"quote`},
+		{"escaped single quote", `"with\'quote"`, `with'quote`},
+		{"escaped backslash", `"with\\slash"`, `with\slash`},
+		{"null", `"with\0null"`, "with\x00null"},
+		{"control chars", `"a\bb\fc\nd\re\tf\vg"`, "a\bb\fc\nd\re\tf\vg"},
+		{"unicode bmp", `"é"`, "é"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := decodeKQLDoubleQuoted(tt.in)
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+
+	bad := []struct {
+		name string
+		in   string
+	}{
+		{"unwrapped", `plain`},
+		{"missing closing quote", `"plain`},
+		{"unknown escape", `"\q"`},
+		{"truncated unicode", `"\u12"`},
+		{"non-hex unicode", `"\uzzzz"`},
+		{"single byte", `"`},
+	}
+	for _, tt := range bad {
+		t.Run("rejects "+tt.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := decodeKQLDoubleQuoted(tt.in)
+			require.Error(t, err)
+		})
+	}
+}
+
+// FuzzEscapeKQL is the second half of the C73 defense-in-depth: even if a
+// dangerous value ever bypasses validateKQLValues, escapeKQL must produce
+// output that cannot break out of the surrounding single-quoted KQL literal.
+// Two invariants:
+//  1. Round-trip: undoing the quote-doubling recovers the original input.
+//  2. No isolated single quote remains in the output.
+func FuzzEscapeKQL(f *testing.F) {
+	seeds := []string{
+		"",
+		"plain",
+		"with'quote",
+		"two''quotes",
+		"'leading",
+		"trailing'",
+		`back\slash`,
+		"new\nline",
+		"null\x00byte",
+		"tab\there",
+		"unicode-é",
+		"emoji-🎉",
+		"' OR 1=1 --",
+		"'; drop table; --",
+	}
+	for _, s := range seeds {
+		f.Add(s)
+	}
+	f.Fuzz(func(t *testing.T, s string) {
+		escaped := escapeKQL(s)
+
+		// Invariant 1: round-trip recovers the input exactly.
+		recovered := strings.ReplaceAll(escaped, "''", "'")
+		if recovered != s {
+			t.Fatalf("escapeKQL round-trip failed: input %q -> escaped %q -> recovered %q",
+				s, escaped, recovered)
+		}
+
+		// Invariant 2: every single quote in the output is part of a
+		// doubled pair. An isolated quote would close the surrounding
+		// KQL literal and let the rest of the input be parsed as KQL.
+		for i := 0; i < len(escaped); i++ {
+			if escaped[i] != '\'' {
+				continue
+			}
+			if i+1 >= len(escaped) || escaped[i+1] != '\'' {
+				t.Fatalf("escapeKQL left an isolated single quote at index %d in %q (input %q)",
+					i, escaped, s)
+			}
+			i++
+		}
+	})
+}
+
+// FuzzQuoteKQL checks quoteKQL against an independent local double-quoted KQL
+// reference. The two encoders produce different forms by design:
+//   - ours: single-quoted with ” doubling, e.g. 'east”us'
+//   - reference: double-quoted with backslash escapes, e.g. "east\'us"
+//
+// String equality between the two outputs is meaningless; we compare by
+// decoding both back to the original input and asserting they match.
+func FuzzQuoteKQL(f *testing.F) {
+	seeds := []string{
+		"",
+		"plain",
+		"with'quote",
+		"two''quotes",
+		`back\slash`,
+		`mixed'and\both`,
+		"new\nline",
+		"null\x00byte",
+		"tab\there",
+		"unicode-é",
+		"emoji-🎉",
+		"' OR 1=1 --",
+		"'; drop table; --",
+	}
+	for _, s := range seeds {
+		f.Add(s)
+	}
+	f.Fuzz(func(t *testing.T, s string) {
+		// The dependency-free reference below mirrors Azure Kusto's string quoting
+		// behavior, which ranges over runes. Skip inputs where that behavior is
+		// intentionally lossy or ambiguous compared to production's byte-preserving
+		// single-quote escape.
+		if !utf8.ValidString(s) {
+			t.Skip()
+		}
+		for _, r := range s {
+			// Azure Kusto's QuoteString emits fmt.Sprintf("\\u%04x", r), which
+			// produces 5+ hex digits for astral-plane runes. KQL \u escapes are
+			// four hex digits, so skip these rather than make the local decoder
+			// accept ambiguous nonstandard output.
+			if r > 0xFFFF {
+				t.Skip()
+			}
+		}
+
+		ours := quoteKQL(s)
+		theirs := quoteKQLDoubleQuotedReference(s)
+
+		oursDecoded, err := decodeKQLSingleQuoted(ours)
+		if err != nil {
+			t.Fatalf("quoteKQL produced an undecodable string: input=%q ours=%q err=%v", s, ours, err)
+		}
+		if oursDecoded != s {
+			t.Fatalf("quoteKQL did not faithfully encode input: input=%q ours=%q decoded=%q",
+				s, ours, oursDecoded)
+		}
+
+		theirsDecoded, err := decodeKQLDoubleQuoted(theirs)
+		if err != nil {
+			t.Fatalf("double-quoted reference produced an undecodable string: input=%q theirs=%q err=%v",
+				s, theirs, err)
+		}
+		if theirsDecoded != s {
+			t.Fatalf("double-quoted reference did not faithfully encode input: input=%q theirs=%q decoded=%q",
+				s, theirs, theirsDecoded)
+		}
+
+		// Parity: both encoders agreed on the original value.
+		if oursDecoded != theirsDecoded {
+			t.Fatalf("parity failed: input=%q ours=%q→%q theirs=%q→%q",
+				s, ours, oursDecoded, theirs, theirsDecoded)
+		}
+	})
+}
+
+// quoteKQLDoubleQuotedReference is a test-only, dependency-free port of Azure
+// Kusto's QuoteString(value, false) string escaping behavior. It intentionally
+// uses a different representation than production quoteKQL, which makes
+// FuzzQuoteKQL compare semantics rather than output form.
+func quoteKQLDoubleQuotedReference(s string) string {
+	var out strings.Builder
+	out.Grow(len(s) + 2)
+	out.WriteByte('"')
+	for _, r := range s {
+		switch r {
+		case '\\':
+			out.WriteString(`\\`)
+		case '\'':
+			out.WriteString(`\'`)
+		case '"':
+			out.WriteString(`\"`)
+		case '\x00':
+			out.WriteString(`\0`)
+		case '\a':
+			out.WriteString(`\a`)
+		case '\b':
+			out.WriteString(`\b`)
+		case '\f':
+			out.WriteString(`\f`)
+		case '\n':
+			out.WriteString(`\n`)
+		case '\r':
+			out.WriteString(`\r`)
+		case '\t':
+			out.WriteString(`\t`)
+		case '\v':
+			out.WriteString(`\v`)
+		default:
+			if !shouldEscapeKQLRune(r) {
+				out.WriteRune(r)
+			} else {
+				out.WriteString(fmt.Sprintf(`\u%04x`, r))
+			}
+		}
+	}
+	out.WriteByte('"')
+	return out.String()
+}
+
+func shouldEscapeKQLRune(r rune) bool {
+	if r <= unicode.MaxLatin1 {
+		return unicode.IsControl(r)
+	}
+	return true
+}
+
+// decodeKQLSingleQuoted is the inverse of quoteKQL: strip the surrounding
+// single quotes and undo the ” doubling. Errors if the input is not a
+// well-formed single-quoted KQL string literal.
+func decodeKQLSingleQuoted(s string) (string, error) {
+	if len(s) < 2 || s[0] != '\'' || s[len(s)-1] != '\'' {
+		return "", fmt.Errorf("not a single-quoted literal: %q", s)
+	}
+	inner := s[1 : len(s)-1]
+	// Walk the body to ensure every ' is doubled (no isolated quote).
+	var out strings.Builder
+	for i := 0; i < len(inner); i++ {
+		if inner[i] != '\'' {
+			out.WriteByte(inner[i])
+			continue
+		}
+		if i+1 >= len(inner) || inner[i+1] != '\'' {
+			return "", fmt.Errorf("isolated single quote at index %d in %q", i, inner)
+		}
+		out.WriteByte('\'')
+		i++
+	}
+	return out.String(), nil
+}
+
+// decodeKQLDoubleQuoted is the inverse of quoteKQLDoubleQuotedReference: strip
+// the surrounding double quotes and undo backslash escapes. Mirrors the escape
+// set in quoteKQLDoubleQuotedReference plus \uNNNN so decoder tests can catch
+// malformed unicode escapes.
+func decodeKQLDoubleQuoted(s string) (string, error) {
+	if len(s) < 2 || s[0] != '"' || s[len(s)-1] != '"' {
+		return "", fmt.Errorf("not a double-quoted literal: %q", s)
+	}
+	inner := s[1 : len(s)-1]
+	var out strings.Builder
+	for i := 0; i < len(inner); i++ {
+		if inner[i] != '\\' {
+			out.WriteByte(inner[i])
+			continue
+		}
+		if i+1 >= len(inner) {
+			return "", fmt.Errorf("trailing backslash in %q", inner)
+		}
+		switch inner[i+1] {
+		case '\\':
+			out.WriteByte('\\')
+		case '\'':
+			out.WriteByte('\'')
+		case '"':
+			out.WriteByte('"')
+		case '0':
+			out.WriteByte('\x00')
+		case 'a':
+			out.WriteByte('\a')
+		case 'b':
+			out.WriteByte('\b')
+		case 'f':
+			out.WriteByte('\f')
+		case 'n':
+			out.WriteByte('\n')
+		case 'r':
+			out.WriteByte('\r')
+		case 't':
+			out.WriteByte('\t')
+		case 'v':
+			out.WriteByte('\v')
+		case 'u':
+			if i+5 >= len(inner) {
+				return "", fmt.Errorf("truncated \\uNNNN at index %d in %q", i, inner)
+			}
+			var r rune
+			for j := 2; j < 6; j++ {
+				c := inner[i+j]
+				var d rune
+				switch {
+				case '0' <= c && c <= '9':
+					d = rune(c - '0')
+				case 'a' <= c && c <= 'f':
+					d = rune(c-'a') + 10
+				case 'A' <= c && c <= 'F':
+					d = rune(c-'A') + 10
+				default:
+					return "", fmt.Errorf("non-hex digit %q in \\uNNNN at index %d in %q", c, i, inner)
+				}
+				r = r*16 + d
+			}
+			out.WriteRune(r)
+			i += 4
+		default:
+			return "", fmt.Errorf("unknown escape \\%c at index %d in %q", inner[i+1], i, inner)
+		}
+		i++
+	}
+	return out.String(), nil
+}

--- a/lib/cloud/azure/resourcegraph_test.go
+++ b/lib/cloud/azure/resourcegraph_test.go
@@ -27,8 +27,6 @@ import (
 	"strings"
 	"sync"
 	"testing"
-	"unicode"
-	"unicode/utf8"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
@@ -47,7 +45,7 @@ func TestBuildVMDiscoveryKQL(t *testing.T) {
 		name            string
 		regions         []string
 		resourceGroups  []string
-		osTypes         []string
+		osTypes         []OSType
 		wantContains    []string
 		wantNotContains []string
 	}{
@@ -74,7 +72,7 @@ func TestBuildVMDiscoveryKQL(t *testing.T) {
 			name:           "wildcard region, rg, and os types",
 			regions:        []string{types.Wildcard},
 			resourceGroups: []string{types.Wildcard},
-			osTypes:        []string{types.Wildcard},
+			osTypes:        []OSType{types.Wildcard},
 			wantNotContains: []string{
 				"| where location in~",
 				"| where resourceGroup in~",
@@ -85,7 +83,7 @@ func TestBuildVMDiscoveryKQL(t *testing.T) {
 			name:           "wildcard mixed with concrete filters matches all",
 			regions:        []string{types.Wildcard, "eastus"},
 			resourceGroups: []string{types.Wildcard, "rg1"},
-			osTypes:        []string{types.Wildcard, OSTypeLinux},
+			osTypes:        []OSType{types.Wildcard, OSTypeLinux},
 			wantNotContains: []string{
 				"| where location in~",
 				"| where resourceGroup in~",
@@ -108,14 +106,14 @@ func TestBuildVMDiscoveryKQL(t *testing.T) {
 		},
 		{
 			name:    "single os type uses case-insensitive set membership",
-			osTypes: []string{OSTypeLinux},
+			osTypes: []OSType{OSTypeLinux},
 			wantContains: []string{
 				"| where tostring(properties.storageProfile.osDisk.osType) in~ ('Linux')",
 			},
 		},
 		{
 			name:    "multiple os types render as a set",
-			osTypes: []string{OSTypeLinux, OSTypeWindows},
+			osTypes: []OSType{OSTypeLinux, OSTypeWindows},
 			wantContains: []string{
 				"| where tostring(properties.storageProfile.osDisk.osType) in~ ('Linux', 'Windows')",
 			},
@@ -140,7 +138,7 @@ func TestBuildVMDiscoveryKQL(t *testing.T) {
 		},
 		{
 			name:    "defense-in-depth: single quote in os type is escaped",
-			osTypes: []string{"odd'os"},
+			osTypes: []OSType{"odd'os"},
 			wantContains: []string{
 				"| where tostring(properties.storageProfile.osDisk.osType) in~ ('odd''os')",
 			},
@@ -150,7 +148,11 @@ func TestBuildVMDiscoveryKQL(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			got := buildVMDiscoveryKQL(tt.regions, tt.resourceGroups, tt.osTypes)
+			got := buildVMDiscoveryKQL(sanitizedParams{
+				Regions:        tt.regions,
+				ResourceGroups: tt.resourceGroups,
+				OSTypes:        tt.osTypes,
+			})
 			for _, want := range tt.wantContains {
 				assert.Contains(t, got, want, "missing expected fragment %q in:\n%s", want, got)
 			}
@@ -176,23 +178,15 @@ func TestQueryVMsParamsFieldsStayInSyncWithARGMock(t *testing.T) {
 			"or document why the new parameter is not part of ARG filtering.")
 }
 
-func TestEscapeKQL(t *testing.T) {
-	t.Parallel()
-	assert.Empty(t, escapeKQL(""))
-	assert.Equal(t, "plain", escapeKQL("plain"))
-	assert.Equal(t, "it''s", escapeKQL("it's"))
-	assert.Equal(t, "''both''", escapeKQL("'both'"))
-}
-
 func makeARGVMRow(id, name string) map[string]any {
 	return map[string]any{
 		"id":             id,
-		"subscriptionId": "sub",
+		"subscriptionId": "00000000-0000-0000-0000-000000000000",
 		"name":           name,
 		"vmId":           name + "-vmid",
 		"location":       "eastus",
 		"resourceGroup":  "rg",
-		"osType":         OSTypeLinux,
+		"osType":         string(OSTypeLinux),
 	}
 }
 
@@ -234,12 +228,12 @@ func TestParseDiscoveredVMs(t *testing.T) {
 			name: "happy path projects all fields",
 			data: []any{map[string]any{
 				"id":             "/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Compute/virtualMachines/vm1",
-				"subscriptionId": "sub",
+				"subscriptionId": "00000000-0000-0000-0000-000000000000",
 				"name":           "vm1",
 				"vmId":           "abc-123",
 				"location":       "eastus",
 				"resourceGroup":  "rg",
-				"osType":         OSTypeLinux,
+				"osType":         string(OSTypeLinux),
 				"tags": map[string]any{
 					"env":   "prod",
 					"owner": "alice",
@@ -248,7 +242,7 @@ func TestParseDiscoveredVMs(t *testing.T) {
 			verify: func(t *testing.T, got []DiscoveredVM) {
 				want := []DiscoveredVM{{
 					ID:             "/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Compute/virtualMachines/vm1",
-					SubscriptionID: "sub",
+					SubscriptionID: "00000000-0000-0000-0000-000000000000",
 					Name:           "vm1",
 					VMID:           "abc-123",
 					Location:       "eastus",
@@ -302,7 +296,7 @@ func TestParseDiscoveredVMs(t *testing.T) {
 				makeARGVMRow("/subscriptions/sub/.../good", "good-empty-id"),
 				map[string]any{
 					"id":             "",
-					"subscriptionId": "sub",
+					"subscriptionId": "00000000-0000-0000-0000-000000000000",
 					"name":           "drop-empty-id",
 					"vmId":           "vm-1",
 					"location":       "eastus",
@@ -319,7 +313,7 @@ func TestParseDiscoveredVMs(t *testing.T) {
 			data: []any{
 				makeARGVMRow("/subscriptions/sub/.../good", "good-missing-id"),
 				map[string]any{
-					"subscriptionId": "sub",
+					"subscriptionId": "00000000-0000-0000-0000-000000000000",
 					"name":           "drop-missing-id",
 					"vmId":           "vm-2",
 					"location":       "eastus",
@@ -338,7 +332,7 @@ func TestParseDiscoveredVMs(t *testing.T) {
 				makeARGVMRow("/subscriptions/sub/.../good", "good-nil-name"),
 				map[string]any{
 					"id":             "/subscriptions/sub/.../vm",
-					"subscriptionId": "sub",
+					"subscriptionId": "00000000-0000-0000-0000-000000000000",
 					"name":           nil,
 					"vmId":           "vm-vmid",
 					"location":       "westeurope",
@@ -374,7 +368,7 @@ func TestParseDiscoveredVMs(t *testing.T) {
 				makeARGVMRow("/subscriptions/sub/.../good", "good-nonstring-scalar"),
 				map[string]any{
 					"id":             "/subscriptions/sub/.../vm",
-					"subscriptionId": "sub",
+					"subscriptionId": "00000000-0000-0000-0000-000000000000",
 					"name":           "vm",
 					"vmId":           42, // wrong type
 					"location":       "westeurope",
@@ -417,7 +411,7 @@ func TestParseDiscoveredVMs(t *testing.T) {
 			name: "tags wrong type yields empty tags, VM kept",
 			data: []any{map[string]any{
 				"id":             "/subscriptions/sub/.../vm",
-				"subscriptionId": "sub",
+				"subscriptionId": "00000000-0000-0000-0000-000000000000",
 				"name":           "vm",
 				"vmId":           "vm-vmid",
 				"location":       "eastus",
@@ -437,7 +431,7 @@ func TestParseDiscoveredVMs(t *testing.T) {
 				makeARGVMRow("/subscriptions/sub/.../good-vm", "good-vm"),
 				map[string]any{
 					"id":             "",
-					"subscriptionId": "sub",
+					"subscriptionId": "00000000-0000-0000-0000-000000000000",
 					"name":           "bad-vm",
 					"vmId":           "vm-bad",
 					"location":       "eastus",
@@ -505,7 +499,7 @@ func TestQueryVMsContractDriftOnAllQueryRowsFail(t *testing.T) {
 				"not a map",
 				map[string]any{
 					// missing id
-					"subscriptionId": "sub",
+					"subscriptionId": "00000000-0000-0000-0000-000000000000",
 					"name":           "vm-a",
 					"vmId":           "vm-a-id",
 					"location":       "eastus",
@@ -513,7 +507,7 @@ func TestQueryVMsContractDriftOnAllQueryRowsFail(t *testing.T) {
 				},
 				map[string]any{
 					"id":             "/sub/.../vm-b",
-					"subscriptionId": "sub",
+					"subscriptionId": "00000000-0000-0000-0000-000000000000",
 					"name":           "vm-b",
 					"vmId":           42, // wrong type
 					"location":       "eastus",
@@ -524,7 +518,7 @@ func TestQueryVMsContractDriftOnAllQueryRowsFail(t *testing.T) {
 	}
 	c := &resourceGraphClient{api: api}
 
-	got, err := c.QueryVMs(t.Context(), QueryVMsParams{SubscriptionIDs: []string{"sub"}})
+	got, err := c.QueryVMs(t.Context(), QueryVMsParams{SubscriptionIDs: []string{"00000000-0000-0000-0000-000000000000"}})
 	require.Error(t, err,
 		"all rows failing to parse must surface as drift, not silent empty result")
 	assert.Empty(t, got, "drift error must not return partial results")
@@ -553,7 +547,7 @@ func TestQueryVMsContractDriftIsQueryScopedNotPageScoped(t *testing.T) {
 				// Query-level guard sees rawRowsTotal=2, kept=1, so no drift.
 				data: []any{
 					map[string]any{
-						"subscriptionId": "sub",
+						"subscriptionId": "00000000-0000-0000-0000-000000000000",
 						"name":           "bad-trailing-vm",
 						"vmId":           "bad-id",
 						"location":       "eastus",
@@ -565,7 +559,7 @@ func TestQueryVMsContractDriftIsQueryScopedNotPageScoped(t *testing.T) {
 	}
 	c := &resourceGraphClient{api: api}
 
-	got, err := c.QueryVMs(t.Context(), QueryVMsParams{SubscriptionIDs: []string{"sub"}})
+	got, err := c.QueryVMs(t.Context(), QueryVMsParams{SubscriptionIDs: []string{"00000000-0000-0000-0000-000000000000"}})
 	require.NoError(t, err,
 		"a single bad row on a trailing page must not tank the chunk; "+
 			"page-scoped drift detection would lose page 1's valid VMs")
@@ -588,7 +582,7 @@ func TestQueryVMsContractDriftIsQueryScopedNotChunkScoped(t *testing.T) {
 				// Chunk 2: a single row that fails to parse (missing id).
 				data: []any{
 					map[string]any{
-						"subscriptionId": "sub",
+						"subscriptionId": "00000000-0000-0000-0000-000000000000",
 						"name":           "bad-chunk-vm",
 						"vmId":           "bad-id",
 						"location":       "eastus",
@@ -692,7 +686,7 @@ func TestQueryVMs(t *testing.T) {
 				}},
 			},
 			params: QueryVMsParams{
-				SubscriptionIDs: []string{"sub-1", "sub-2"},
+				SubscriptionIDs: []string{"11111111-1111-1111-1111-111111111111", "22222222-2222-2222-2222-222222222222"},
 				Regions:         []string{"eastus"},
 				ResourceGroups:  []string{"rg-1", "rg-2"},
 			},
@@ -706,8 +700,8 @@ func TestQueryVMs(t *testing.T) {
 				assert.Contains(t, *req.Query, "| where resourceGroup in~ ('rg-1', 'rg-2')")
 				require.Len(t, req.Subscriptions, 2)
 				require.NotNil(t, req.Subscriptions[0])
-				assert.Equal(t, "sub-1", *req.Subscriptions[0])
-				assert.Equal(t, "sub-2", *req.Subscriptions[1])
+				assert.Equal(t, "11111111-1111-1111-1111-111111111111", *req.Subscriptions[0])
+				assert.Equal(t, "22222222-2222-2222-2222-222222222222", *req.Subscriptions[1])
 				require.NotNil(t, req.Options)
 				require.NotNil(t, req.Options.ResultFormat)
 				assert.Equal(t, armresourcegraph.ResultFormatObjectArray, *req.Options.ResultFormat)
@@ -734,7 +728,7 @@ func TestQueryVMs(t *testing.T) {
 					},
 				},
 			},
-			params: QueryVMsParams{SubscriptionIDs: []string{"sub"}},
+			params: QueryVMsParams{SubscriptionIDs: []string{"00000000-0000-0000-0000-000000000000"}},
 			verify: func(t *testing.T, got []DiscoveredVM, api *fakeARGAPI, err error) {
 				require.NoError(t, err)
 				require.Len(t, got, 2)
@@ -747,7 +741,7 @@ func TestQueryVMs(t *testing.T) {
 		{
 			name:   "propagates SDK errors",
 			api:    &fakeARGAPI{err: errors.New("boom")},
-			params: QueryVMsParams{SubscriptionIDs: []string{"sub"}},
+			params: QueryVMsParams{SubscriptionIDs: []string{"00000000-0000-0000-0000-000000000000"}},
 			verify: func(t *testing.T, got []DiscoveredVM, api *fakeARGAPI, err error) {
 				require.Error(t, err)
 				assert.True(t, strings.Contains(err.Error(), "boom"), "expected wrapped error, got %v", err)
@@ -757,7 +751,7 @@ func TestQueryVMs(t *testing.T) {
 			name: "403 surfaces AccessDenied with remediation message",
 			// Build an *azcore.ResponseError so ConvertResponseError maps it to AccessDenied.
 			api:    &fakeARGAPI{err: &azcore.ResponseError{StatusCode: http.StatusForbidden}},
-			params: QueryVMsParams{SubscriptionIDs: []string{"sub"}},
+			params: QueryVMsParams{SubscriptionIDs: []string{"00000000-0000-0000-0000-000000000000"}},
 			verify: func(t *testing.T, got []DiscoveredVM, api *fakeARGAPI, err error) {
 				require.Error(t, err)
 				assert.True(t, trace.IsAccessDenied(err), "expected AccessDenied, got %T: %v", err, err)
@@ -772,7 +766,7 @@ func TestQueryVMs(t *testing.T) {
 			// detect throttling (vs auth failure, transient breakage) and back off.
 			name:   "429 surfaces LimitExceeded so callers can back off",
 			api:    &fakeARGAPI{err: &azcore.ResponseError{StatusCode: http.StatusTooManyRequests}},
-			params: QueryVMsParams{SubscriptionIDs: []string{"sub"}},
+			params: QueryVMsParams{SubscriptionIDs: []string{"00000000-0000-0000-0000-000000000000"}},
 			verify: func(t *testing.T, got []DiscoveredVM, api *fakeARGAPI, err error) {
 				require.Error(t, err)
 				assert.True(t, trace.IsLimitExceeded(err),
@@ -786,7 +780,7 @@ func TestQueryVMs(t *testing.T) {
 			api: &fakeARGAPI{
 				pages: makeRunawayARGPages(argMaxPagesPerChunk),
 			},
-			params: QueryVMsParams{SubscriptionIDs: []string{"sub"}},
+			params: QueryVMsParams{SubscriptionIDs: []string{"00000000-0000-0000-0000-000000000000"}},
 			verify: func(t *testing.T, got []DiscoveredVM, api *fakeARGAPI, err error) {
 				require.Error(t, err)
 				assert.Contains(t, err.Error(), "pagination exceeded")
@@ -901,7 +895,7 @@ func TestQueryVMs(t *testing.T) {
 					},
 				},
 			},
-			params: QueryVMsParams{SubscriptionIDs: []string{"sub"}},
+			params: QueryVMsParams{SubscriptionIDs: []string{"00000000-0000-0000-0000-000000000000"}},
 			verify: func(t *testing.T, got []DiscoveredVM, api *fakeARGAPI, err error) {
 				require.Error(t, err)
 				assert.True(t, trace.IsBadParameter(err),
@@ -930,7 +924,7 @@ func TestQueryVMs(t *testing.T) {
 					},
 				},
 			},
-			params: QueryVMsParams{SubscriptionIDs: []string{"sub"}},
+			params: QueryVMsParams{SubscriptionIDs: []string{"00000000-0000-0000-0000-000000000000"}},
 			verify: func(t *testing.T, got []DiscoveredVM, api *fakeARGAPI, err error) {
 				require.NoError(t, err,
 					"per-row drift must skip the row, not abort the chunk")
@@ -957,7 +951,7 @@ func TestQueryVMs(t *testing.T) {
 func makeSubscriptionIDs(n int) []string {
 	out := make([]string, n)
 	for i := range n {
-		out[i] = fmt.Sprintf("sub-%d", i)
+		out[i] = fmt.Sprintf("00000000-0000-0000-0000-%012d", i)
 	}
 
 	return out
@@ -982,13 +976,13 @@ func TestARMResourceGraphMock_caseInsensitiveFilters(t *testing.T) {
 	t.Parallel()
 	mock := &ARMResourceGraphMock{
 		VMs: []DiscoveredVM{
-			makeMockARGVM("sub-1", "rg-a", "eastus", "vm1"), // ARG canonical lowercase; RG names are case-insensitive in ARM.
-			makeMockARGVM("sub-1", "rg-b", "westus2", "vm2"),
+			makeMockARGVM("11111111-1111-1111-1111-111111111111", "rg-a", "eastus", "vm1"), // ARG canonical lowercase; RG names are case-insensitive in ARM.
+			makeMockARGVM("11111111-1111-1111-1111-111111111111", "rg-b", "westus2", "vm2"),
 		},
 	}
 
 	got, err := mock.QueryVMs(t.Context(), QueryVMsParams{
-		SubscriptionIDs: []string{"sub-1"},
+		SubscriptionIDs: []string{"11111111-1111-1111-1111-111111111111"},
 		Regions:         []string{"EastUS"}, // display-cased
 		ResourceGroups:  []string{"RG-A"},   // mixed-case
 	})
@@ -997,7 +991,7 @@ func TestARMResourceGraphMock_caseInsensitiveFilters(t *testing.T) {
 	require.Len(t, got, 1,
 		"mock must apply case-insensitive matching to mirror KQL `in~`; "+
 			"otherwise display-cased operator config silently returns zero VMs")
-	assert.Equal(t, "/subscriptions/sub-1/resourceGroups/rg-a/providers/Microsoft.Compute/virtualMachines/vm1", got[0].ID)
+	assert.Equal(t, "/subscriptions/11111111-1111-1111-1111-111111111111/resourceGroups/rg-a/providers/Microsoft.Compute/virtualMachines/vm1", got[0].ID)
 }
 
 // TestARMResourceGraphMock_OSTypesFiltering proves the mock enforces OSTypes
@@ -1006,8 +1000,8 @@ func TestARMResourceGraphMock_caseInsensitiveFilters(t *testing.T) {
 // tests despite breaking against real ARG.
 func TestARMResourceGraphMock_OSTypesFiltering(t *testing.T) {
 	t.Parallel()
-	linuxVM := makeMockARGVM("sub-1", "rg-a", "eastus", "linux-vm")
-	windowsVM := makeMockARGVM("sub-1", "rg-a", "eastus", "windows-vm")
+	linuxVM := makeMockARGVM("11111111-1111-1111-1111-111111111111", "rg-a", "eastus", "linux-vm")
+	windowsVM := makeMockARGVM("11111111-1111-1111-1111-111111111111", "rg-a", "eastus", "windows-vm")
 	windowsVM.OSType = OSTypeWindows
 	mock := &ARMResourceGraphMock{
 		VMs: []DiscoveredVM{linuxVM, windowsVM},
@@ -1016,8 +1010,8 @@ func TestARMResourceGraphMock_OSTypesFiltering(t *testing.T) {
 	t.Run("Linux-only filter returns only Linux VMs", func(t *testing.T) {
 		t.Parallel()
 		got, err := mock.QueryVMs(t.Context(), QueryVMsParams{
-			SubscriptionIDs: []string{"sub-1"},
-			OSTypes:         []string{OSTypeLinux},
+			SubscriptionIDs: []string{"11111111-1111-1111-1111-111111111111"},
+			OSTypes:         []OSType{OSTypeLinux},
 		})
 		require.NoError(t, err)
 		require.Len(t, got, 1)
@@ -1027,8 +1021,8 @@ func TestARMResourceGraphMock_OSTypesFiltering(t *testing.T) {
 	t.Run("Windows-only filter returns only Windows VMs", func(t *testing.T) {
 		t.Parallel()
 		got, err := mock.QueryVMs(t.Context(), QueryVMsParams{
-			SubscriptionIDs: []string{"sub-1"},
-			OSTypes:         []string{OSTypeWindows},
+			SubscriptionIDs: []string{"11111111-1111-1111-1111-111111111111"},
+			OSTypes:         []OSType{OSTypeWindows},
 		})
 		require.NoError(t, err)
 		require.Len(t, got, 1)
@@ -1038,22 +1032,22 @@ func TestARMResourceGraphMock_OSTypesFiltering(t *testing.T) {
 	t.Run("wildcard OSTypes returns all OS types", func(t *testing.T) {
 		t.Parallel()
 		got, err := mock.QueryVMs(t.Context(), QueryVMsParams{
-			SubscriptionIDs: []string{"sub-1"},
-			OSTypes:         []string{types.Wildcard},
+			SubscriptionIDs: []string{"11111111-1111-1111-1111-111111111111"},
+			OSTypes:         []OSType{types.Wildcard},
 		})
 		require.NoError(t, err)
 		assert.Len(t, got, 2)
 	})
 
-	t.Run("OSTypes uses case-insensitive matching like KQL in~", func(t *testing.T) {
+	t.Run("non-canonical case rejected at validation", func(t *testing.T) {
 		t.Parallel()
-		got, err := mock.QueryVMs(t.Context(), QueryVMsParams{
-			SubscriptionIDs: []string{"sub-1"},
-			OSTypes:         []string{"linux"}, // canonical lowercase; fixture has "Linux"
+		_, err := mock.QueryVMs(t.Context(), QueryVMsParams{
+			SubscriptionIDs: []string{"11111111-1111-1111-1111-111111111111"},
+			OSTypes:         []OSType{"linux"},
 		})
-		require.NoError(t, err)
-		require.Len(t, got, 1)
-		assert.Equal(t, "linux-vm", got[0].Name)
+		require.Error(t, err)
+		assert.True(t, trace.IsBadParameter(err),
+			"strict canonical-case enforcement must surface as BadParameter, got %T: %v", err, err)
 	})
 }
 
@@ -1061,13 +1055,13 @@ func TestARMResourceGraphMock_wildcardMixedWithConcreteFiltersMatchesAll(t *test
 	t.Parallel()
 	mock := &ARMResourceGraphMock{
 		VMs: []DiscoveredVM{
-			makeMockARGVM("sub-1", "rg-a", "eastus", "vm1"),
-			makeMockARGVM("sub-1", "rg-b", "westus2", "vm2"),
+			makeMockARGVM("11111111-1111-1111-1111-111111111111", "rg-a", "eastus", "vm1"),
+			makeMockARGVM("11111111-1111-1111-1111-111111111111", "rg-b", "westus2", "vm2"),
 		},
 	}
 
 	got, err := mock.QueryVMs(t.Context(), QueryVMsParams{
-		SubscriptionIDs: []string{"sub-1"},
+		SubscriptionIDs: []string{"11111111-1111-1111-1111-111111111111"},
 		Regions:         []string{types.Wildcard, "eastus"},
 		ResourceGroups:  []string{types.Wildcard, "rg-a"},
 	})
@@ -1084,7 +1078,7 @@ func TestARMResourceGraphMock_rejectsInvalidFixtures(t *testing.T) {
 		VMs: []DiscoveredVM{
 			{
 				ID:             "/subscriptions/sub-1/resourceGroups/rg-a/providers/Microsoft.Compute/virtualMachines/vm1",
-				SubscriptionID: "sub-1",
+				SubscriptionID: "11111111-1111-1111-1111-111111111111",
 				Name:           "vm1",
 				Location:       "eastus",
 				ResourceGroup:  "rg-a",
@@ -1093,7 +1087,7 @@ func TestARMResourceGraphMock_rejectsInvalidFixtures(t *testing.T) {
 		},
 	}
 
-	_, err := mock.QueryVMs(t.Context(), QueryVMsParams{SubscriptionIDs: []string{"sub-1"}})
+	_, err := mock.QueryVMs(t.Context(), QueryVMsParams{SubscriptionIDs: []string{"11111111-1111-1111-1111-111111111111"}})
 	require.Error(t, err)
 	assert.True(t, trace.IsBadParameter(err), "invalid fixtures should fail like production row parsing, got %T: %v", err, err)
 	assert.Contains(t, err.Error(), "ARMResourceGraphMock fixture missing or empty required field")
@@ -1104,10 +1098,10 @@ func TestARMResourceGraphMock_LastParamsClones(t *testing.T) {
 	t.Parallel()
 	mock := &ARMResourceGraphMock{}
 
-	subs := []string{"sub-1"}
+	subs := []string{"11111111-1111-1111-1111-111111111111"}
 	regions := []string{"eastus"}
 	rgs := []string{"rg-a"}
-	osTypes := []string{OSTypeLinux}
+	osTypes := []OSType{OSTypeLinux}
 	_, err := mock.QueryVMs(t.Context(), QueryVMsParams{
 		SubscriptionIDs: subs,
 		Regions:         regions,
@@ -1123,13 +1117,13 @@ func TestARMResourceGraphMock_LastParamsClones(t *testing.T) {
 	osTypes[0] = "MUTATED"
 
 	got := mock.LastParams()
-	assert.Equal(t, []string{"sub-1"}, got.SubscriptionIDs,
+	assert.Equal(t, []string{"11111111-1111-1111-1111-111111111111"}, got.SubscriptionIDs,
 		"LastParams must snapshot SubscriptionIDs, not alias the caller's slice")
 	assert.Equal(t, []string{"eastus"}, got.Regions,
 		"LastParams must snapshot Regions, not alias the caller's slice")
 	assert.Equal(t, []string{"rg-a"}, got.ResourceGroups,
 		"LastParams must snapshot ResourceGroups, not alias the caller's slice")
-	assert.Equal(t, []string{OSTypeLinux}, got.OSTypes,
+	assert.Equal(t, []OSType{OSTypeLinux}, got.OSTypes,
 		"LastParams must snapshot OSTypes, not alias the caller's slice")
 
 	first := mock.LastParams()
@@ -1143,11 +1137,11 @@ func TestARMResourceGraphMock_LastParamsClones(t *testing.T) {
 	first.OSTypes[0] = "MUTATED"
 
 	second := mock.LastParams()
-	assert.Equal(t, []string{"sub-1"}, second.SubscriptionIDs,
+	assert.Equal(t, []string{"11111111-1111-1111-1111-111111111111"}, second.SubscriptionIDs,
 		"LastParams must clone on read so prior callers cannot mutate the snapshot")
 	assert.Equal(t, []string{"eastus"}, second.Regions)
 	assert.Equal(t, []string{"rg-a"}, second.ResourceGroups)
-	assert.Equal(t, []string{OSTypeLinux}, second.OSTypes)
+	assert.Equal(t, []OSType{OSTypeLinux}, second.OSTypes)
 }
 
 // TestARMResourceGraphMock_ValidationFailureDoesNotBumpCalls pins the mock's
@@ -1166,7 +1160,7 @@ func TestARMResourceGraphMock_ValidationFailureDoesNotBumpCalls(t *testing.T) {
 		"validation failure must not register as a call; production never reaches the SDK either")
 
 	_, err = mock.QueryVMs(t.Context(), QueryVMsParams{
-		SubscriptionIDs: []string{"sub"},
+		SubscriptionIDs: []string{"00000000-0000-0000-0000-000000000000"},
 		Regions:         []string{"east'us"}, // invalid char
 	})
 	require.Error(t, err)
@@ -1174,7 +1168,7 @@ func TestARMResourceGraphMock_ValidationFailureDoesNotBumpCalls(t *testing.T) {
 		"filter validation failure must not register as a call either")
 
 	// Sanity: a valid call increments.
-	_, err = mock.QueryVMs(t.Context(), QueryVMsParams{SubscriptionIDs: []string{"sub"}})
+	_, err = mock.QueryVMs(t.Context(), QueryVMsParams{SubscriptionIDs: []string{"00000000-0000-0000-0000-000000000000"}})
 	require.NoError(t, err)
 	assert.Equal(t, 1, mock.Calls())
 }
@@ -1188,7 +1182,7 @@ func TestARMResourceGraphMock_PreservesNonNilTags(t *testing.T) {
 		VMs: []DiscoveredVM{
 			{
 				ID:             "/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Compute/virtualMachines/vm1",
-				SubscriptionID: "sub",
+				SubscriptionID: "00000000-0000-0000-0000-000000000000",
 				Name:           "vm1",
 				VMID:           "vm1-vmid",
 				Location:       "eastus",
@@ -1198,7 +1192,7 @@ func TestARMResourceGraphMock_PreservesNonNilTags(t *testing.T) {
 		},
 	}
 
-	got, err := mock.QueryVMs(t.Context(), QueryVMsParams{SubscriptionIDs: []string{"sub"}})
+	got, err := mock.QueryVMs(t.Context(), QueryVMsParams{SubscriptionIDs: []string{"00000000-0000-0000-0000-000000000000"}})
 	require.NoError(t, err)
 	require.Len(t, got, 1)
 	require.NotNil(t, got[0].Tags,
@@ -1214,10 +1208,10 @@ func TestARMResourceGraphMock_AccessorsAreRaceFree(t *testing.T) {
 	ctx := t.Context()
 	mock := &ARMResourceGraphMock{
 		VMsBySubscription: map[string][]DiscoveredVM{
-			"sub-0": {makeMockARGVM("sub-0", "rg-a", "eastus", "vm-0")},
-			"sub-1": {makeMockARGVM("sub-1", "rg-a", "eastus", "vm-1")},
-			"sub-2": {makeMockARGVM("sub-2", "rg-a", "eastus", "vm-2")},
-			"sub-3": {makeMockARGVM("sub-3", "rg-a", "eastus", "vm-3")},
+			"00000000-0000-0000-0000-000000000000": {makeMockARGVM("00000000-0000-0000-0000-000000000000", "rg-a", "eastus", "vm-0")},
+			"00000000-0000-0000-0000-000000000001": {makeMockARGVM("00000000-0000-0000-0000-000000000001", "rg-a", "eastus", "vm-1")},
+			"00000000-0000-0000-0000-000000000002": {makeMockARGVM("00000000-0000-0000-0000-000000000002", "rg-a", "eastus", "vm-2")},
+			"00000000-0000-0000-0000-000000000003": {makeMockARGVM("00000000-0000-0000-0000-000000000003", "rg-a", "eastus", "vm-3")},
 		},
 	}
 
@@ -1233,7 +1227,7 @@ func TestARMResourceGraphMock_AccessorsAreRaceFree(t *testing.T) {
 		go func(i int) {
 			defer wg.Done()
 			params := QueryVMsParams{
-				SubscriptionIDs: []string{fmt.Sprintf("sub-%d", i)},
+				SubscriptionIDs: []string{fmt.Sprintf("00000000-0000-0000-0000-%012d", i)},
 				Regions:         []string{"eastus"},
 				ResourceGroups:  []string{"rg-a"},
 			}
@@ -1374,14 +1368,14 @@ func TestQueryVMsValidatesInputs(t *testing.T) {
 		for _, d := range dangerous {
 			t.Run(fld.kind+"/"+d.name, func(t *testing.T) {
 				t.Parallel()
-				params := QueryVMsParams{SubscriptionIDs: []string{"sub"}}
+				params := QueryVMsParams{SubscriptionIDs: []string{"00000000-0000-0000-0000-000000000000"}}
 				switch fld.f {
 				case fieldRegion:
 					params.Regions = []string{d.value}
 				case fieldRG:
 					params.ResourceGroups = []string{d.value}
 				case fieldOSType:
-					params.OSTypes = []string{d.value}
+					params.OSTypes = []OSType{OSType(d.value)}
 				}
 
 				c := &resourceGraphClient{api: &fakeARGAPI{}}
@@ -1410,10 +1404,10 @@ func TestQueryVMsValidatesInputs(t *testing.T) {
 		t.Parallel()
 		c := &resourceGraphClient{api: emptyPage()}
 		_, err := c.QueryVMs(t.Context(), QueryVMsParams{
-			SubscriptionIDs: []string{"sub"},
+			SubscriptionIDs: []string{"00000000-0000-0000-0000-000000000000"},
 			Regions:         []string{types.Wildcard},
 			ResourceGroups:  []string{types.Wildcard},
-			OSTypes:         []string{types.Wildcard},
+			OSTypes:         []OSType{types.Wildcard},
 		})
 		require.NoError(t, err)
 	})
@@ -1424,10 +1418,37 @@ func TestQueryVMsValidatesInputs(t *testing.T) {
 		t.Parallel()
 		c := &resourceGraphClient{api: emptyPage()}
 		_, err := c.QueryVMs(t.Context(), QueryVMsParams{
-			SubscriptionIDs: []string{"sub"},
+			SubscriptionIDs: []string{"00000000-0000-0000-0000-000000000000"},
 			Regions:         []string{types.Wildcard, "eastus"},
 			ResourceGroups:  []string{types.Wildcard, "rg-1"},
-			OSTypes:         []string{types.Wildcard, OSTypeLinux},
+			OSTypes:         []OSType{types.Wildcard, OSTypeLinux},
+		})
+		require.NoError(t, err)
+	})
+
+	// Resource group names commonly contain underscores (e.g. "my_resource_group").
+	// An earlier revision of azureResourceGroupPattern omitted `_` from the
+	// allowlist, silently rejecting valid Azure RG names. This case pins that
+	// underscore-bearing values are accepted.
+	t.Run("underscore in resource group passes", func(t *testing.T) {
+		t.Parallel()
+		c := &resourceGraphClient{api: emptyPage()}
+		_, err := c.QueryVMs(t.Context(), QueryVMsParams{
+			SubscriptionIDs: []string{"00000000-0000-0000-0000-000000000000"},
+			ResourceGroups:  []string{"my_resource_group"},
+		})
+		require.NoError(t, err)
+	})
+
+	// Resource group allowlist accepts the full character class: letters,
+	// digits, underscore, hyphen, period, and parenthesis. A single value
+	// exercises every char class at once.
+	t.Run("full char-class resource group passes", func(t *testing.T) {
+		t.Parallel()
+		c := &resourceGraphClient{api: emptyPage()}
+		_, err := c.QueryVMs(t.Context(), QueryVMsParams{
+			SubscriptionIDs: []string{"00000000-0000-0000-0000-000000000000"},
+			ResourceGroups:  []string{"My-RG_v1.0(test)"},
 		})
 		require.NoError(t, err)
 	})
@@ -1438,7 +1459,7 @@ func TestQueryVMsValidatesInputs(t *testing.T) {
 		t.Parallel()
 		c := &resourceGraphClient{api: &fakeARGAPI{}}
 		_, err := c.QueryVMs(t.Context(), QueryVMsParams{
-			SubscriptionIDs: []string{"sub"},
+			SubscriptionIDs: []string{"00000000-0000-0000-0000-000000000000"},
 			Regions:         []string{""},
 		})
 		require.Error(t, err)
@@ -1459,7 +1480,7 @@ func TestQueryVMsValidatesInputs(t *testing.T) {
 		{
 			name: "untrimmed region rejected with clear message",
 			params: QueryVMsParams{
-				SubscriptionIDs: []string{"sub"},
+				SubscriptionIDs: []string{"00000000-0000-0000-0000-000000000000"},
 				Regions:         []string{" eastus "},
 			},
 			kind:  "region",
@@ -1468,7 +1489,7 @@ func TestQueryVMsValidatesInputs(t *testing.T) {
 		{
 			name: "untrimmed resource group rejected with clear message",
 			params: QueryVMsParams{
-				SubscriptionIDs: []string{"sub"},
+				SubscriptionIDs: []string{"00000000-0000-0000-0000-000000000000"},
 				ResourceGroups:  []string{" rg-1 "},
 			},
 			kind:  "resource group",
@@ -1477,8 +1498,8 @@ func TestQueryVMsValidatesInputs(t *testing.T) {
 		{
 			name: "untrimmed OS type rejected with clear message",
 			params: QueryVMsParams{
-				SubscriptionIDs: []string{"sub"},
-				OSTypes:         []string{" Linux "},
+				SubscriptionIDs: []string{"00000000-0000-0000-0000-000000000000"},
+				OSTypes:         []OSType{" Linux "},
 			},
 			kind:  "OS type",
 			value: " Linux ",
@@ -1520,7 +1541,9 @@ func TestQueryVMsValidatesInputs(t *testing.T) {
 		})
 		require.Error(t, err)
 		assert.True(t, trace.IsBadParameter(err))
-		assert.Contains(t, err.Error(), "subscription ID must not be empty")
+		// Whitespace-only falls into the trim-whitespace branch (not the empty branch),
+		// which yields a more accurate message: the input is not empty, it is whitespace.
+		assert.Contains(t, err.Error(), "must not have leading or trailing whitespace")
 	})
 
 	t.Run("untrimmed subscription ID rejected", func(t *testing.T) {
@@ -1550,7 +1573,7 @@ func TestQueryVMsTruncatedWithoutSkipToken(t *testing.T) {
 		},
 	}
 	c := &resourceGraphClient{api: api}
-	_, err := c.QueryVMs(t.Context(), QueryVMsParams{SubscriptionIDs: []string{"sub"}})
+	_, err := c.QueryVMs(t.Context(), QueryVMsParams{SubscriptionIDs: []string{"00000000-0000-0000-0000-000000000000"}})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "truncated",
 		"truncation without a skip token must surface; silently returning partial results would be worse")
@@ -1572,7 +1595,7 @@ func TestQueryVMsNotTruncatedWithoutSkipTokenReturnsResults(t *testing.T) {
 		},
 	}
 	c := &resourceGraphClient{api: api}
-	got, err := c.QueryVMs(t.Context(), QueryVMsParams{SubscriptionIDs: []string{"sub"}})
+	got, err := c.QueryVMs(t.Context(), QueryVMsParams{SubscriptionIDs: []string{"00000000-0000-0000-0000-000000000000"}})
 	require.NoError(t, err)
 	require.Len(t, got, 1)
 	assert.Equal(t, "vm1", got[0].Name)
@@ -1588,380 +1611,15 @@ func TestQueryVMsForwardsDuplicateSubscriptions(t *testing.T) {
 	}
 	c := &resourceGraphClient{api: api}
 	_, err := c.QueryVMs(t.Context(), QueryVMsParams{
-		SubscriptionIDs: []string{"sub-1", "sub-1", "sub-2"},
+		SubscriptionIDs: []string{"11111111-1111-1111-1111-111111111111", "11111111-1111-1111-1111-111111111111", "22222222-2222-2222-2222-222222222222"},
 	})
 	require.NoError(t, err)
 	require.Len(t, api.gotRequests, 1, "all entries fit in one chunk")
 	require.Len(t, api.gotRequests[0].Subscriptions, 3,
 		"duplicates must pass through unchanged; deduplication is the caller's contract")
-	for i, want := range []string{"sub-1", "sub-1", "sub-2"} {
+	for i, want := range []string{"11111111-1111-1111-1111-111111111111", "11111111-1111-1111-1111-111111111111", "22222222-2222-2222-2222-222222222222"} {
 		require.NotNil(t, api.gotRequests[0].Subscriptions[i])
 		assert.Equal(t, want, *api.gotRequests[0].Subscriptions[i],
 			"subscription order must be preserved across the dedup-skipping path")
 	}
-}
-
-// TestDecodeKQLSingleQuoted exercises the quoteKQL inverse directly so a bug in
-// the test decoder cannot silently make FuzzEscapeKQL pass for the wrong reasons.
-func TestDecodeKQLSingleQuoted(t *testing.T) {
-	t.Parallel()
-	tests := []struct {
-		name string
-		in   string
-		want string
-	}{
-		{"empty", `''`, ""},
-		{"plain", `'plain'`, "plain"},
-		{"doubled quote", `'with''quote'`, "with'quote"},
-		{"two doubled quotes", `'two''''quotes'`, "two''quotes"},
-		{"leading quote", `'''leading'`, "'leading"},
-		{"trailing quote", `'trailing'''`, "trailing'"},
-		{"backslash literal", `'back\slash'`, `back\slash`},
-		{"newline literal", "'line\nbreak'", "line\nbreak"},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-			got, err := decodeKQLSingleQuoted(tt.in)
-			require.NoError(t, err)
-			assert.Equal(t, tt.want, got)
-		})
-	}
-
-	bad := []struct {
-		name string
-		in   string
-	}{
-		{"unwrapped", `plain`},
-		{"missing closing quote", `'plain`},
-		{"missing opening quote", `plain'`},
-		{"isolated quote in body", `'east'us'`},
-		{"single byte", `'`},
-	}
-	for _, tt := range bad {
-		t.Run("rejects "+tt.name, func(t *testing.T) {
-			t.Parallel()
-			_, err := decodeKQLSingleQuoted(tt.in)
-			require.Error(t, err)
-		})
-	}
-}
-
-// TestDecodeKQLDoubleQuoted exercises the double-quoted KQL decoder directly so
-// a decoder bug cannot mask reference-encoder disagreement in FuzzQuoteKQL.
-func TestDecodeKQLDoubleQuoted(t *testing.T) {
-	t.Parallel()
-	tests := []struct {
-		name string
-		in   string
-		want string
-	}{
-		{"empty", `""`, ""},
-		{"plain", `"plain"`, "plain"},
-		{"escaped double quote", `"with\"quote"`, `with"quote`},
-		{"escaped single quote", `"with\'quote"`, `with'quote`},
-		{"escaped backslash", `"with\\slash"`, `with\slash`},
-		{"null", `"with\0null"`, "with\x00null"},
-		{"control chars", `"a\bb\fc\nd\re\tf\vg"`, "a\bb\fc\nd\re\tf\vg"},
-		{"unicode bmp", `"é"`, "é"},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-			got, err := decodeKQLDoubleQuoted(tt.in)
-			require.NoError(t, err)
-			assert.Equal(t, tt.want, got)
-		})
-	}
-
-	bad := []struct {
-		name string
-		in   string
-	}{
-		{"unwrapped", `plain`},
-		{"missing closing quote", `"plain`},
-		{"unknown escape", `"\q"`},
-		{"truncated unicode", `"\u12"`},
-		{"non-hex unicode", `"\uzzzz"`},
-		{"single byte", `"`},
-	}
-	for _, tt := range bad {
-		t.Run("rejects "+tt.name, func(t *testing.T) {
-			t.Parallel()
-			_, err := decodeKQLDoubleQuoted(tt.in)
-			require.Error(t, err)
-		})
-	}
-}
-
-// FuzzEscapeKQL is the second half of the C73 defense-in-depth: even if a
-// dangerous value ever bypasses validateKQLValues, escapeKQL must produce
-// output that cannot break out of the surrounding single-quoted KQL literal.
-// Two invariants:
-//  1. Round-trip: undoing the quote-doubling recovers the original input.
-//  2. No isolated single quote remains in the output.
-func FuzzEscapeKQL(f *testing.F) {
-	seeds := []string{
-		"",
-		"plain",
-		"with'quote",
-		"two''quotes",
-		"'leading",
-		"trailing'",
-		`back\slash`,
-		"new\nline",
-		"null\x00byte",
-		"tab\there",
-		"unicode-é",
-		"emoji-🎉",
-		"' OR 1=1 --",
-		"'; drop table; --",
-	}
-	for _, s := range seeds {
-		f.Add(s)
-	}
-	f.Fuzz(func(t *testing.T, s string) {
-		escaped := escapeKQL(s)
-
-		// Invariant 1: round-trip recovers the input exactly.
-		recovered := strings.ReplaceAll(escaped, "''", "'")
-		if recovered != s {
-			t.Fatalf("escapeKQL round-trip failed: input %q -> escaped %q -> recovered %q",
-				s, escaped, recovered)
-		}
-
-		// Invariant 2: every single quote in the output is part of a
-		// doubled pair. An isolated quote would close the surrounding
-		// KQL literal and let the rest of the input be parsed as KQL.
-		for i := 0; i < len(escaped); i++ {
-			if escaped[i] != '\'' {
-				continue
-			}
-			if i+1 >= len(escaped) || escaped[i+1] != '\'' {
-				t.Fatalf("escapeKQL left an isolated single quote at index %d in %q (input %q)",
-					i, escaped, s)
-			}
-			i++
-		}
-	})
-}
-
-// FuzzQuoteKQL checks quoteKQL against an independent local double-quoted KQL
-// reference. The two encoders produce different forms by design:
-//   - ours: single-quoted with ” doubling, e.g. 'east”us'
-//   - reference: double-quoted with backslash escapes, e.g. "east\'us"
-//
-// String equality between the two outputs is meaningless; we compare by
-// decoding both back to the original input and asserting they match.
-func FuzzQuoteKQL(f *testing.F) {
-	seeds := []string{
-		"",
-		"plain",
-		"with'quote",
-		"two''quotes",
-		`back\slash`,
-		`mixed'and\both`,
-		"new\nline",
-		"null\x00byte",
-		"tab\there",
-		"unicode-é",
-		"emoji-🎉",
-		"' OR 1=1 --",
-		"'; drop table; --",
-	}
-	for _, s := range seeds {
-		f.Add(s)
-	}
-	f.Fuzz(func(t *testing.T, s string) {
-		// The dependency-free reference below mirrors Azure Kusto's string quoting
-		// behavior, which ranges over runes. Skip inputs where that behavior is
-		// intentionally lossy or ambiguous compared to production's byte-preserving
-		// single-quote escape.
-		if !utf8.ValidString(s) {
-			t.Skip()
-		}
-		for _, r := range s {
-			// Azure Kusto's QuoteString emits fmt.Sprintf("\\u%04x", r), which
-			// produces 5+ hex digits for astral-plane runes. KQL \u escapes are
-			// four hex digits, so skip these rather than make the local decoder
-			// accept ambiguous nonstandard output.
-			if r > 0xFFFF {
-				t.Skip()
-			}
-		}
-
-		ours := quoteKQL(s)
-		theirs := quoteKQLDoubleQuotedReference(s)
-
-		oursDecoded, err := decodeKQLSingleQuoted(ours)
-		if err != nil {
-			t.Fatalf("quoteKQL produced an undecodable string: input=%q ours=%q err=%v", s, ours, err)
-		}
-		if oursDecoded != s {
-			t.Fatalf("quoteKQL did not faithfully encode input: input=%q ours=%q decoded=%q",
-				s, ours, oursDecoded)
-		}
-
-		theirsDecoded, err := decodeKQLDoubleQuoted(theirs)
-		if err != nil {
-			t.Fatalf("double-quoted reference produced an undecodable string: input=%q theirs=%q err=%v",
-				s, theirs, err)
-		}
-		if theirsDecoded != s {
-			t.Fatalf("double-quoted reference did not faithfully encode input: input=%q theirs=%q decoded=%q",
-				s, theirs, theirsDecoded)
-		}
-
-		// Parity: both encoders agreed on the original value.
-		if oursDecoded != theirsDecoded {
-			t.Fatalf("parity failed: input=%q ours=%q→%q theirs=%q→%q",
-				s, ours, oursDecoded, theirs, theirsDecoded)
-		}
-	})
-}
-
-// quoteKQLDoubleQuotedReference is a test-only, dependency-free port of Azure
-// Kusto's QuoteString(value, false) string escaping behavior. It intentionally
-// uses a different representation than production quoteKQL, which makes
-// FuzzQuoteKQL compare semantics rather than output form.
-func quoteKQLDoubleQuotedReference(s string) string {
-	var out strings.Builder
-	out.Grow(len(s) + 2)
-	out.WriteByte('"')
-	for _, r := range s {
-		switch r {
-		case '\\':
-			out.WriteString(`\\`)
-		case '\'':
-			out.WriteString(`\'`)
-		case '"':
-			out.WriteString(`\"`)
-		case '\x00':
-			out.WriteString(`\0`)
-		case '\a':
-			out.WriteString(`\a`)
-		case '\b':
-			out.WriteString(`\b`)
-		case '\f':
-			out.WriteString(`\f`)
-		case '\n':
-			out.WriteString(`\n`)
-		case '\r':
-			out.WriteString(`\r`)
-		case '\t':
-			out.WriteString(`\t`)
-		case '\v':
-			out.WriteString(`\v`)
-		default:
-			if !shouldEscapeKQLRune(r) {
-				out.WriteRune(r)
-			} else {
-				fmt.Fprintf(&out, `\u%04x`, r)
-			}
-		}
-	}
-	out.WriteByte('"')
-	return out.String()
-}
-
-func shouldEscapeKQLRune(r rune) bool {
-	if r <= unicode.MaxLatin1 {
-		return unicode.IsControl(r)
-	}
-	return true
-}
-
-// decodeKQLSingleQuoted is the inverse of quoteKQL: strip the surrounding
-// single quotes and undo the ” doubling. Errors if the input is not a
-// well-formed single-quoted KQL string literal.
-func decodeKQLSingleQuoted(s string) (string, error) {
-	if len(s) < 2 || s[0] != '\'' || s[len(s)-1] != '\'' {
-		return "", fmt.Errorf("not a single-quoted literal: %q", s)
-	}
-	inner := s[1 : len(s)-1]
-	// Walk the body to ensure every ' is doubled (no isolated quote).
-	var out strings.Builder
-	for i := 0; i < len(inner); i++ {
-		if inner[i] != '\'' {
-			out.WriteByte(inner[i])
-			continue
-		}
-		if i+1 >= len(inner) || inner[i+1] != '\'' {
-			return "", fmt.Errorf("isolated single quote at index %d in %q", i, inner)
-		}
-		out.WriteByte('\'')
-		i++
-	}
-	return out.String(), nil
-}
-
-// decodeKQLDoubleQuoted is the inverse of quoteKQLDoubleQuotedReference: strip
-// the surrounding double quotes and undo backslash escapes. Mirrors the escape
-// set in quoteKQLDoubleQuotedReference plus \uNNNN so decoder tests can catch
-// malformed unicode escapes.
-func decodeKQLDoubleQuoted(s string) (string, error) {
-	if len(s) < 2 || s[0] != '"' || s[len(s)-1] != '"' {
-		return "", fmt.Errorf("not a double-quoted literal: %q", s)
-	}
-	inner := s[1 : len(s)-1]
-	var out strings.Builder
-	for i := 0; i < len(inner); i++ {
-		if inner[i] != '\\' {
-			out.WriteByte(inner[i])
-			continue
-		}
-		if i+1 >= len(inner) {
-			return "", fmt.Errorf("trailing backslash in %q", inner)
-		}
-		switch inner[i+1] {
-		case '\\':
-			out.WriteByte('\\')
-		case '\'':
-			out.WriteByte('\'')
-		case '"':
-			out.WriteByte('"')
-		case '0':
-			out.WriteByte('\x00')
-		case 'a':
-			out.WriteByte('\a')
-		case 'b':
-			out.WriteByte('\b')
-		case 'f':
-			out.WriteByte('\f')
-		case 'n':
-			out.WriteByte('\n')
-		case 'r':
-			out.WriteByte('\r')
-		case 't':
-			out.WriteByte('\t')
-		case 'v':
-			out.WriteByte('\v')
-		case 'u':
-			if i+5 >= len(inner) {
-				return "", fmt.Errorf("truncated \\uNNNN at index %d in %q", i, inner)
-			}
-			var r rune
-			for j := 2; j < 6; j++ {
-				c := inner[i+j]
-				var d rune
-				switch {
-				case '0' <= c && c <= '9':
-					d = rune(c - '0')
-				case 'a' <= c && c <= 'f':
-					d = rune(c-'a') + 10
-				case 'A' <= c && c <= 'F':
-					d = rune(c-'A') + 10
-				default:
-					return "", fmt.Errorf("non-hex digit %q in \\uNNNN at index %d in %q", c, i, inner)
-				}
-				r = r*16 + d
-			}
-			out.WriteRune(r)
-			i += 4
-		default:
-			return "", fmt.Errorf("unknown escape \\%c at index %d in %q", inner[i+1], i, inner)
-		}
-		i++
-	}
-	return out.String(), nil
 }

--- a/lib/cloud/azure/vm.go
+++ b/lib/cloud/azure/vm.go
@@ -53,6 +53,14 @@ type scaleSet interface {
 	Get(ctx context.Context, resourceGroupName string, vmScaleSetName string, instanceID string, options *armcompute.VirtualMachineScaleSetVMsClientGetOptions) (armcompute.VirtualMachineScaleSetVMsClientGetResponse, error)
 }
 
+// VMID extracts the VM ID from a VM.
+func VMID(vm *armcompute.VirtualMachine) string {
+	if vm == nil || vm.Properties == nil || vm.Properties.VMID == nil {
+		return ""
+	}
+	return *vm.Properties.VMID
+}
+
 // VirtualMachinesClient is a client for Azure virtual machines.
 type VirtualMachinesClient interface {
 	// Get returns the virtual machine (including scale set VMs) for the given
@@ -203,6 +211,9 @@ func (c *vmClient) Get(ctx context.Context, resourceID string) (*VirtualMachine,
 
 // GetByVMID returns the virtual machine for a given VM ID.
 func (c *vmClient) GetByVMID(ctx context.Context, vmID string) (*VirtualMachine, error) {
+	if vmID == "" {
+		return nil, trace.BadParameter("vmID is required")
+	}
 	pager := newListAllPager(c.api.NewListAllPager(&armcompute.VirtualMachinesClientListAllOptions{}))
 	for pager.more() {
 		res, err := pager.nextPage(ctx)
@@ -211,7 +222,7 @@ func (c *vmClient) GetByVMID(ctx context.Context, vmID string) (*VirtualMachine,
 		}
 
 		for _, vm := range res {
-			if vm.Properties != nil && *vm.Properties.VMID == vmID {
+			if VMID(vm) == vmID {
 				result, err := parseVirtualMachine(vm)
 				return result, trace.Wrap(err)
 			}

--- a/lib/cloud/azure/vm_test.go
+++ b/lib/cloud/azure/vm_test.go
@@ -346,7 +346,6 @@ func TestVMIDNilGuards(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
 			require.Equal(t, tt.want, VMID(tt.vm))
 		})
 	}

--- a/lib/cloud/azure/vm_test.go
+++ b/lib/cloud/azure/vm_test.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v6"
+	"github.com/gravitational/trace"
 	"github.com/stretchr/testify/require"
 
 	"github.com/gravitational/teleport/api/types"
@@ -280,7 +281,7 @@ func TestListVirtualMachines(t *testing.T) {
 			wantIDs:       []string{"vm1", "vm2"},
 		},
 		{
-			name:          "nonexistant resource group",
+			name:          "nonexistent resource group",
 			resourceGroup: "rgfake",
 			wantIDs:       []string{},
 		},
@@ -304,4 +305,66 @@ func TestListVirtualMachines(t *testing.T) {
 			require.ElementsMatch(t, tc.wantIDs, vmIDs)
 		})
 	}
+}
+
+// TestVMIDNilGuards pins the nil-traversal behavior of the VMID accessor.
+// VMID is called from GetByVMID's pager loop, where SDK pages can include
+// VMs missing Properties or VMID; without these guards, the loop would panic.
+func TestVMIDNilGuards(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		vm   *armcompute.VirtualMachine
+		want string
+	}{
+		{
+			name: "nil VM",
+			vm:   nil,
+			want: "",
+		},
+		{
+			name: "VM with nil Properties",
+			vm:   &armcompute.VirtualMachine{},
+			want: "",
+		},
+		{
+			name: "VM with non-nil Properties but nil VMID",
+			vm: &armcompute.VirtualMachine{
+				Properties: &armcompute.VirtualMachineProperties{},
+			},
+			want: "",
+		},
+		{
+			name: "VM with VMID populated",
+			vm: &armcompute.VirtualMachine{
+				Properties: &armcompute.VirtualMachineProperties{
+					VMID: to.Ptr("00000000-0000-0000-0000-000000000000"),
+				},
+			},
+			want: "00000000-0000-0000-0000-000000000000",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tt.want, VMID(tt.vm))
+		})
+	}
+}
+
+// TestGetByVMIDRejectsEmptyID pins the entry-point guard that prevents a full
+// subscription-wide pager walk when the caller passes "". Without this, the
+// loop would scan every VM in the subscription comparing against "" for VMs
+// where VMID returns "" (nil-Properties or nil-VMID), potentially matching
+// the wrong VM.
+func TestGetByVMIDRejectsEmptyID(t *testing.T) {
+	t.Parallel()
+	vmClient := NewVirtualMachinesClientByAPI(&ARMComputeMock{}, nil /* scaleSetAPI */)
+
+	got, err := vmClient.GetByVMID(t.Context(), "")
+	require.Error(t, err)
+	require.True(t, trace.IsBadParameter(err),
+		"empty vmID must surface as BadParameter, not as a NotFound after walking every VM; got %T: %v",
+		err, err)
+	require.Nil(t, got)
 }


### PR DESCRIPTION
Partially updates https://github.com/gravitational/teleport/issues/65605.

1/2 split from: https://github.com/gravitational/teleport/pull/65720.

- Azure Resource Graph VM query construction.
- KQL input validation and escaping behavior.
- Resource Graph pagination, subscription chunking, and truncation handling.
- ARG response parsing, schema-drift handling, and tag parsing semantics.

---

- Missing/nil tags produce an empty non-nil map.
- Malformed outer `tags` shape keeps the VM with empty tags.
- Non-string/nil tag values are dropped rather than coerced with `fmt.Sprint`.
- Rationale: tags feed label matching, so the parser should not fabricate selector values.

If ARG returns data in an unexpected top-level shape, or if it returns rows but none can be parsed, QueryVMs returns an error instead of reporting an empty result. Individual malformed rows are skipped so valid VMs from the same query are still returned.