### PR TITLE
proxy: Bridge HTTP/2 extended CONNECT to WebSocket Upgrade

### DIFF
--- a/lib/httplib/h2websocket/h2websocket.go
+++ b/lib/httplib/h2websocket/h2websocket.go
@@ -25,45 +25,37 @@
 //
 //  1. Enables full duplex on the response so reads on r.Body can overlap
 //     writes to w.
-//  2. Sends 200 OK to open the tunnel (per RFC 8441 §5, the response on
-//     an HTTP/2 stream is 200, not 101).
-//  3. Strips client-supplied reserved Teleport headers if a list was
-//     configured.
-//  4. Rewrites the request as an HTTP/1.1 GET + Upgrade and dispatches
+//  2. Rewrites the request as an HTTP/1.1 GET + Upgrade and dispatches
 //     to the wrapped handler with a ResponseWriter that implements
 //     http.Hijacker. The handler's gorilla.Upgrader.Upgrade succeeds
 //     because the method is GET and the Upgrade / Connection /
 //     Sec-WebSocket-* headers are present.
+//  3. Defers the outer 200 OK commit until the upgrader writes its
+//     synthetic "HTTP/1.1 101 Switching Protocols" preamble onto the
+//     hijacked conn. The bridge parses Sec-WebSocket-Protocol out of
+//     that preamble and forwards it onto the outer HTTP/2 response
+//     headers (per RFC 8441 §5.1) before committing the 200.
 //
 // When Hijack runs, the returned net.Conn reads from r.Body and writes
-// through w with a flush after every Write so WebSocket frames do not sit
-// in the HTTP/2 buffer. Deadlines forward to the http.ResponseController
-// for the request. The synthetic "HTTP/1.1 101 Switching Protocols"
-// response gorilla writes onto the hijacked conn is stripped off
-// incrementally before bytes reach the wire.
+// through w with a flush after every Write so WebSocket frames do not
+// sit in the HTTP/2 buffer. Deadlines forward to the
+// http.ResponseController for the request. The synthetic 101 preamble
+// is discarded after Sec-WebSocket-Protocol is lifted off.
 //
 // If the handler returns without hijacking, the middleware fails closed
-// by tearing down the HTTP/2 stream. The 200 status is already committed
-// to open the tunnel, so closing the stream is the only signal left.
-// The wrapped ResponseWriter also silences Write and WriteHeader before
-// hijack so a non-WebSocket route reached via extended CONNECT cannot
-// leak its response body onto the stream as opaque WebSocket payload.
-//
-// Sec-WebSocket-Protocol negotiation is not propagated. The wrapped
-// HTTP/1.1 upgrader writes the negotiated value into the synthetic 101
-// preamble that the stripper discards, and RFC 8441 §5.1 places
-// subprotocol negotiation in the H2 response HEADERS frame instead.
-// Until the bridge lifts the negotiated subprotocol onto the outer
-// response headers before committing the 200, routes that depend on
-// gorilla.Upgrader.Subprotocols (kube exec, desktop, conn upgrade)
-// must not be reached over HTTP/2.
+// with 404 Not Found. The wrapped ResponseWriter also silences Write
+// and WriteHeader before hijack so a non-WebSocket route reached via
+// extended CONNECT cannot leak its response body onto the stream as
+// opaque WebSocket payload.
 package h2websocket
 
 import (
 	"bufio"
+	"bytes"
 	"crypto/rand"
 	"encoding/base64"
 	"errors"
+	"fmt"
 	"io"
 	"net"
 	"net/http"
@@ -127,18 +119,9 @@ func serve(w http.ResponseWriter, r *http.Request, next http.Handler, reservedSe
 		return
 	}
 
-	// The 200 commits before the inner handler runs, so any handler
-	// rejection (auth failure, route not found) shows up in proxy
-	// access logs as 200 rather than 4xx. Alerting that pages on 4xx
-	// spikes will miss h2-ws auth failures; log from the inner handler
-	// if the metric matters.
-	w.WriteHeader(http.StatusOK)
-	if err := rc.Flush(); err != nil && !errors.Is(err, http.ErrNotSupported) {
-		return
-	}
-
 	r2, err := rewriteAsH1Upgrade(r, reservedSet)
 	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}
 
@@ -150,11 +133,13 @@ func serve(w http.ResponseWriter, r *http.Request, next http.Handler, reservedSe
 	}
 	next.ServeHTTP(hw, r2)
 
-	// Handler returned without hijacking: close the stream to signal
-	// "wrong route" (the 200 status is already committed). The
-	// hijackResponseWriter gate above also discards any Write the
-	// handler made before returning, so opaque bytes do not leak.
+	// Handler returned without hijacking. No 200 was committed: the
+	// stripUpgradeWriter only triggers the outer commit after the
+	// upgrader writes its synthetic 101 preamble. Send 404 so the
+	// client and proxy access logs see a real status instead of a
+	// truncated stream.
 	if !hw.hijacked.Load() {
+		w.WriteHeader(http.StatusNotFound)
 		_ = r.Body.Close()
 	}
 }
@@ -272,6 +257,8 @@ func newH2StreamConn(body io.ReadCloser, w http.ResponseWriter, remoteAddr strin
 		rc:         rc,
 	}
 	c.w = &stripUpgradeWriter{
+		outer: w,
+		rc:    rc,
 		inner: &flushWriter{w: w, rc: rc},
 	}
 	return c
@@ -363,52 +350,86 @@ func (f *flushWriter) Write(p []byte) (int, error) {
 	return n, nil
 }
 
-// stripUpgradeWriter discards bytes up to and including the first
-// "\r\n\r\n" sequence (the synthetic HTTP/1.1 response preamble the
-// wrapped upgrader emits before owning the conn), then forwards
-// everything afterward. The parser is incremental: it never
-// accumulates more than the four bytes needed to recognize the
-// terminator, so there is no fixed buffer cap that could silently
-// truncate a long Sec-WebSocket-Protocol header.
+// stripUpgradeWriter buffers the synthetic HTTP/1.1 response preamble
+// that the wrapped upgrader emits before owning the conn, parses
+// Sec-WebSocket-Protocol out of it, lifts that value onto the outer
+// HTTP/2 response headers, commits the outer 200 OK, and then forwards
+// every subsequent byte through to the inner flushed writer. The
+// preamble itself never reaches the wire.
+//
+// RFC 8441 §5.1 puts subprotocol negotiation on the response HEADERS
+// frame, not in any tunnel payload, so the bridge has to translate the
+// upgrader's HTTP/1.1 response line into an h2 header before
+// committing the status. The 200 is deferred until parsing completes
+// so the negotiated subprotocol travels with the response that opens
+// the tunnel.
 type stripUpgradeWriter struct {
-	inner   io.Writer
-	scanned int // number of consecutive bytes of upgradeHeaderTerminator matched so far
-	done    bool
+	outer http.ResponseWriter
+	rc    *http.ResponseController
+	inner io.Writer
+
+	preamble []byte
+	done     bool
 }
 
 const upgradeHeaderTerminator = "\r\n\r\n"
+
+// maxUpgradePreambleBytes caps how much of the upgrader's synthetic
+// 101 preamble we buffer before declaring something wrong. Real
+// gorilla preambles are well under 1 KiB even with hundreds of
+// negotiated subprotocols; 8 KiB leaves headroom without letting a
+// buggy upstream pin arbitrary memory.
+const maxUpgradePreambleBytes = 8 << 10
 
 func (s *stripUpgradeWriter) Write(p []byte) (int, error) {
 	if s.done {
 		return s.inner.Write(p)
 	}
-	for i := range p {
-		s.scanned = nextScanState(s.scanned, p[i])
-		if s.scanned == len(upgradeHeaderTerminator) {
-			s.done = true
-			rest := p[i+1:]
-			if len(rest) > 0 {
-				if _, err := s.inner.Write(rest); err != nil {
-					return 0, err
-				}
-			}
-			return len(p), nil
+	if len(s.preamble)+len(p) > maxUpgradePreambleBytes {
+		return 0, fmt.Errorf("h2websocket: upgrade preamble exceeded %d bytes", maxUpgradePreambleBytes)
+	}
+	s.preamble = append(s.preamble, p...)
+
+	idx := bytes.Index(s.preamble, []byte(upgradeHeaderTerminator))
+	if idx < 0 {
+		// Need more bytes before the terminator is in view.
+		return len(p), nil
+	}
+
+	if proto, ok := readSubprotocol(s.preamble[:idx]); ok {
+		s.outer.Header().Set("Sec-WebSocket-Protocol", proto)
+	}
+
+	s.outer.WriteHeader(http.StatusOK)
+	if err := s.rc.Flush(); err != nil && !errors.Is(err, http.ErrNotSupported) {
+		return 0, err
+	}
+
+	s.done = true
+	rest := s.preamble[idx+len(upgradeHeaderTerminator):]
+	s.preamble = nil
+	if len(rest) > 0 {
+		if _, err := s.inner.Write(rest); err != nil {
+			return 0, err
 		}
 	}
 	return len(p), nil
 }
 
-// nextScanState advances the upgradeHeaderTerminator matcher by one
-// byte. The pattern has self-overlap on '\r' (positions 0 and 2), so
-// on a mismatch the failing byte may itself start a new match: e.g.
-// the second '\r' in "\r\r\n\r\n" must not be discarded. This is the
-// KMP failure function for "\r\n\r\n" collapsed to a single comparison.
-func nextScanState(scanned int, b byte) int {
-	if b == upgradeHeaderTerminator[scanned] {
-		return scanned + 1
+// readSubprotocol pulls the Sec-WebSocket-Protocol header value out of
+// the upgrader's synthetic HTTP/1.1 preamble. It returns ("", false)
+// when the header is absent (the upgrader did not negotiate one) or
+// the preamble is malformed.
+func readSubprotocol(preamble []byte) (string, bool) {
+	for _, line := range bytes.Split(preamble, []byte("\r\n")) {
+		key, val, ok := bytes.Cut(line, []byte(":"))
+		if !ok {
+			continue
+		}
+		if !bytes.EqualFold(bytes.TrimSpace(key), []byte("Sec-WebSocket-Protocol")) {
+			continue
+		}
+		return string(bytes.TrimSpace(val)), true
 	}
-	if b == upgradeHeaderTerminator[0] {
-		return 1
-	}
-	return 0
+	return "", false
 }

--- a/lib/httplib/h2websocket/h2websocket.go
+++ b/lib/httplib/h2websocket/h2websocket.go
@@ -43,19 +43,27 @@
 // incrementally before bytes reach the wire.
 //
 // If the handler returns without hijacking, the middleware fails closed
-// and sends 405 Method Not Allowed rather than passing handler output
-// through the 101 stripper. This protects every other GET route from
-// being addressable via extended CONNECT.
+// by tearing down the HTTP/2 stream. The 200 status is already committed
+// to open the tunnel, so closing the stream is the only signal left.
+// The wrapped ResponseWriter also silences Write and WriteHeader before
+// hijack so a non-WebSocket route reached via extended CONNECT cannot
+// leak its response body onto the stream as opaque WebSocket payload.
+//
+// Sec-WebSocket-Protocol negotiation is currently dropped: gorilla writes
+// the negotiated value into the synthetic 101 preamble that the stripper
+// discards. RFC 8441 §5.1 places subprotocol negotiation in the H2
+// response HEADERS frame, so callers of gorilla.Upgrader.Subprotocols
+// must address this before ALPN advertises h2 first.
 package h2websocket
 
 import (
 	"bufio"
 	"crypto/rand"
 	"encoding/base64"
+	"errors"
 	"io"
 	"net"
 	"net/http"
-	"sync"
 	"sync/atomic"
 	"time"
 
@@ -71,11 +79,17 @@ const pseudoHeaderProtocol = ":protocol"
 type Options struct {
 	// ReservedHeaders names HTTP headers that the middleware strips from
 	// the synthetic request before dispatch. The list is intended for
-	// Teleport-injected headers (lib/srv/app/common.ReservedHeaders) so
-	// that a malicious client cannot plant them on an extended CONNECT
-	// request and have them reach a backend that treats them as control
-	// input. The check is case-insensitive (http.Header.Del is
-	// canonicalized).
+	// Teleport-injected identity headers (e.g. X-Teleport-Jwt-Assertion,
+	// X-Teleport-Aws-Assumed-Role) so that a malicious client cannot
+	// plant them on an extended CONNECT request and have them reach a
+	// backend that treats them as control input. The check is
+	// case-insensitive (http.Header.Del is canonicalized).
+	//
+	// Do not include generic X-Forwarded-* headers here: the XFF
+	// middleware that runs inside the wrapped chain needs to see them
+	// to resolve the real client address. Stripping them at this layer
+	// would point clientSrcAddr at the load balancer for h2 traffic
+	// while h1 traffic on the same listener resolves the real IP.
 	ReservedHeaders []string
 }
 
@@ -102,15 +116,18 @@ func isH2WebSocketConnect(r *http.Request) bool {
 		r.Header.Get(pseudoHeaderProtocol) == "websocket"
 }
 
-func serve(w http.ResponseWriter, r *http.Request, next http.Handler, reservedSet map[string]struct{}) {
+func serve(w http.ResponseWriter, r *http.Request, next http.Handler, reservedSet map[string]bool) {
 	rc := http.NewResponseController(w)
 	if err := rc.EnableFullDuplex(); err != nil {
-		http.Error(w, "full-duplex unavailable", http.StatusInternalServerError)
+		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}
 
-	// Open the h2 tunnel before dispatching so the client starts
-	// streaming WebSocket frames into r.Body.
+	// The 200 commits before the inner handler runs, so any handler
+	// rejection (auth failure, route not found) shows up in proxy
+	// access logs as 200 rather than 4xx. Alerting that pages on 4xx
+	// spikes will miss h2-ws auth failures; log from the inner handler
+	// if the metric matters.
 	w.WriteHeader(http.StatusOK)
 	if err := rc.Flush(); err != nil {
 		return
@@ -123,19 +140,17 @@ func serve(w http.ResponseWriter, r *http.Request, next http.Handler, reservedSe
 
 	hw := &hijackResponseWriter{
 		ResponseWriter: w,
-		req:            r,
+		body:           r.Body,
+		remoteAddr:     r.RemoteAddr,
 		rc:             rc,
 	}
 	next.ServeHTTP(hw, r2)
 
-	// Fail closed: if the handler returned without hijacking, the route
-	// is not a WebSocket route. Surface that as a stream-level error
-	// rather than passing the handler's output (likely JSON, HTML, etc.)
-	// through the 101 stripper, which would corrupt the stream.
+	// Handler returned without hijacking: close the stream to signal
+	// "wrong route" (the 200 status is already committed). The
+	// hijackResponseWriter gate above also discards any Write the
+	// handler made before returning, so opaque bytes do not leak.
 	if !hw.hijacked.Load() {
-		// We already sent 200 to open the tunnel, so the HTTP status
-		// is committed. Closing the stream is the only way to signal
-		// "wrong route" to the client at this point.
 		if c, ok := r.Body.(io.Closer); ok {
 			_ = c.Close()
 		}
@@ -147,7 +162,7 @@ func serve(w http.ResponseWriter, r *http.Request, next http.Handler, reservedSe
 // Sec-WebSocket-* headers populated, and reserved headers stripped.
 // The body is left alone (it carries WebSocket frames once the
 // handshake completes).
-func rewriteAsH1Upgrade(r *http.Request, reservedSet map[string]struct{}) (*http.Request, error) {
+func rewriteAsH1Upgrade(r *http.Request, reservedSet map[string]bool) (*http.Request, error) {
 	r2 := r.Clone(r.Context())
 	r2.Method = http.MethodGet
 	r2.Proto = "HTTP/1.1"
@@ -166,6 +181,11 @@ func rewriteAsH1Upgrade(r *http.Request, reservedSet map[string]struct{}) (*http
 		hdr.Set("Sec-WebSocket-Version", "13")
 	}
 	if hdr.Get("Sec-WebSocket-Key") == "" {
+		// RFC 8441 §5.1 lets the client omit Sec-WebSocket-Key under
+		// extended CONNECT because the h2 stream already protects
+		// request integrity. The synthesized key is never observed by
+		// the h2 client; it exists only so the gorilla upgrader's
+		// HTTP/1.1 path accepts the synthetic request.
 		key := make([]byte, 16)
 		if _, err := rand.Read(key); err != nil {
 			return nil, trace.Wrap(err, "generating Sec-WebSocket-Key")
@@ -176,33 +196,51 @@ func rewriteAsH1Upgrade(r *http.Request, reservedSet map[string]struct{}) (*http
 	return r2, nil
 }
 
-func canonicalSet(names []string) map[string]struct{} {
+func canonicalSet(names []string) map[string]bool {
 	if len(names) == 0 {
 		return nil
 	}
-	out := make(map[string]struct{}, len(names))
+	out := make(map[string]bool, len(names))
 	for _, n := range names {
-		out[http.CanonicalHeaderKey(n)] = struct{}{}
+		out[http.CanonicalHeaderKey(n)] = true
 	}
 	return out
 }
 
 // hijackResponseWriter implements http.Hijacker on top of an HTTP/2
 // ResponseWriter so gorilla.Upgrader.Upgrade can take ownership of the
-// underlying stream as a net.Conn.
+// underlying stream as a net.Conn. Write and WriteHeader are silenced
+// before hijack so a handler that returns without hijacking (e.g. a
+// non-WebSocket route reached via extended CONNECT) cannot leak its
+// response body onto the h2 stream as opaque WebSocket payload.
 type hijackResponseWriter struct {
 	http.ResponseWriter
-	req *http.Request
-	rc  *http.ResponseController
+	body       io.ReadCloser
+	remoteAddr string
+	rc         *http.ResponseController
 
 	hijacked atomic.Bool
+}
+
+func (h *hijackResponseWriter) Write(p []byte) (int, error) {
+	if !h.hijacked.Load() {
+		return len(p), nil
+	}
+	return h.ResponseWriter.Write(p)
+}
+
+func (h *hijackResponseWriter) WriteHeader(code int) {
+	if !h.hijacked.Load() {
+		return
+	}
+	h.ResponseWriter.WriteHeader(code)
 }
 
 func (h *hijackResponseWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
 	if !h.hijacked.CompareAndSwap(false, true) {
 		return nil, nil, http.ErrHijacked
 	}
-	conn := newH2StreamConn(h.req, h.ResponseWriter, h.rc)
+	conn := newH2StreamConn(h.body, h.remoteAddr, h.ResponseWriter, h.rc)
 	brw := bufio.NewReadWriter(bufio.NewReader(conn), bufio.NewWriter(conn))
 	return conn, brw, nil
 }
@@ -210,18 +248,19 @@ func (h *hijackResponseWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
 // h2StreamConn presents an HTTP/2 request body + flushed response writer
 // pair as a net.Conn. Deadlines forward to the http.ResponseController.
 type h2StreamConn struct {
-	r io.ReadCloser
-	w io.Writer
+	r          io.ReadCloser
+	w          io.Writer
+	remoteAddr string
 
-	rc      *http.ResponseController
-	closeMu sync.Mutex
-	closed  atomic.Bool
+	rc     *http.ResponseController
+	closed atomic.Bool
 }
 
-func newH2StreamConn(req *http.Request, w http.ResponseWriter, rc *http.ResponseController) *h2StreamConn {
+func newH2StreamConn(body io.ReadCloser, remoteAddr string, w http.ResponseWriter, rc *http.ResponseController) *h2StreamConn {
 	c := &h2StreamConn{
-		r:  req.Body,
-		rc: rc,
+		r:          body,
+		remoteAddr: remoteAddr,
+		rc:         rc,
 	}
 	c.w = &stripUpgradeWriter{
 		inner: &flushWriter{w: w, rc: rc},
@@ -241,8 +280,8 @@ func (c *h2StreamConn) Write(p []byte) (int, error) {
 }
 
 func (c *h2StreamConn) Close() error {
-	c.closeMu.Lock()
-	defer c.closeMu.Unlock()
+	// Swap serializes Close to a single caller; subsequent calls
+	// short-circuit before touching the request body.
 	if c.closed.Swap(true) {
 		return nil
 	}
@@ -251,8 +290,16 @@ func (c *h2StreamConn) Close() error {
 	return c.r.Close()
 }
 
-func (c *h2StreamConn) LocalAddr() net.Addr  { return placeholderAddr("h2-local") }
-func (c *h2StreamConn) RemoteAddr() net.Addr { return placeholderAddr("h2-remote") }
+func (c *h2StreamConn) LocalAddr() net.Addr { return placeholderAddr("h2-local") }
+
+func (c *h2StreamConn) RemoteAddr() net.Addr {
+	if c.remoteAddr != "" {
+		if addr, err := net.ResolveTCPAddr("tcp", c.remoteAddr); err == nil {
+			return addr
+		}
+	}
+	return placeholderAddr("h2-remote")
+}
 
 func (c *h2StreamConn) SetDeadline(t time.Time) error {
 	if err := c.SetReadDeadline(t); err != nil {
@@ -269,6 +316,11 @@ func (c *h2StreamConn) SetWriteDeadline(t time.Time) error {
 	return c.rc.SetWriteDeadline(t)
 }
 
+// placeholderAddr stands in when the request's RemoteAddr is missing
+// or unparseable. The HTTP/2 server does not expose stream-level
+// addresses on the hijacked conn; the request's RemoteAddr is the only
+// peer information available, and a placeholder keeps callers that log
+// conn.RemoteAddr() from panicking on a nil addr.
 type placeholderAddr string
 
 func (placeholderAddr) Network() string  { return "h2-websocket" }
@@ -276,24 +328,30 @@ func (a placeholderAddr) String() string { return string(a) }
 
 // flushWriter flushes after every Write so a single WebSocket frame ends
 // up on the wire as a single h2 DATA frame instead of being buffered.
+// Flush errors are propagated once a first flush has succeeded, so a
+// stream reset (Write succeeds into the buffer, Flush fails) surfaces
+// to the WebSocket handler instead of being silently dropped.
 type flushWriter struct {
-	w  io.Writer
+	w  http.ResponseWriter
 	rc *http.ResponseController
 }
 
 func (f *flushWriter) Write(p []byte) (int, error) {
 	n, err := f.w.Write(p)
-	if err == nil {
-		_ = f.rc.Flush()
+	if err != nil {
+		return n, err
 	}
-	return n, err
+	if err := f.rc.Flush(); err != nil && !errors.Is(err, http.ErrNotSupported) {
+		return n, err
+	}
+	return n, nil
 }
 
 // stripUpgradeWriter discards bytes up to and including the first
 // "\r\n\r\n" sequence (gorilla's synthetic 101 response that does not
 // belong on the h2 stream), then forwards everything afterward. The
 // parser is incremental: it never accumulates more than the four bytes
-// needed to recognise the terminator, so there is no fixed buffer cap
+// needed to recognize the terminator, so there is no fixed buffer cap
 // that could silently truncate a long Sec-WebSocket-Protocol header.
 type stripUpgradeWriter struct {
 	inner   io.Writer
@@ -307,28 +365,33 @@ func (s *stripUpgradeWriter) Write(p []byte) (int, error) {
 	if s.done {
 		return s.inner.Write(p)
 	}
-	consumed := 0
-	for consumed < len(p) {
-		if p[consumed] == crlfcrlf[s.scanned] {
-			s.scanned++
-			consumed++
-			if s.scanned == len(crlfcrlf) {
-				s.done = true
-				rest := p[consumed:]
-				if len(rest) > 0 {
-					if _, err := s.inner.Write(rest); err != nil {
-						return 0, err
-					}
+	for i := 0; i < len(p); i++ {
+		s.scanned = nextScanState(s.scanned, p[i])
+		if s.scanned == len(crlfcrlf) {
+			s.done = true
+			rest := p[i+1:]
+			if len(rest) > 0 {
+				if _, err := s.inner.Write(rest); err != nil {
+					return 0, err
 				}
-				return len(p), nil
 			}
-		} else {
-			// Reset the match. If we matched some prefix, those bytes
-			// are part of the header (still discarded). The current
-			// byte is also discarded.
-			s.scanned = 0
-			consumed++
+			return len(p), nil
 		}
 	}
 	return len(p), nil
+}
+
+// nextScanState advances the "\r\n\r\n" matcher by one byte. The
+// pattern has self-overlap on '\r' (positions 0 and 2), so on a
+// mismatch the failing byte may itself start a new match: e.g. the
+// second '\r' in "\r\r\n\r\n" must not be discarded. This is the KMP
+// failure function for "\r\n\r\n" collapsed to a single comparison.
+func nextScanState(scanned int, b byte) int {
+	if b == crlfcrlf[scanned] {
+		return scanned + 1
+	}
+	if b == crlfcrlf[0] {
+		return 1
+	}
+	return 0
 }

--- a/lib/httplib/h2websocket/h2websocket.go
+++ b/lib/httplib/h2websocket/h2websocket.go
@@ -1,0 +1,334 @@
+/*
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+// Package h2websocket adapts RFC 8441 extended CONNECT requests so that
+// handlers using gorilla/websocket's HTTP/1.1-only Upgrader continue to
+// work when a client opens a WebSocket over HTTP/2.
+//
+// The middleware intercepts requests with HTTP/2, method CONNECT, and the
+// :protocol=websocket pseudo-header. For each one it:
+//
+//  1. Enables full duplex on the response so reads on r.Body can overlap
+//     writes to w.
+//  2. Sends 200 OK to open the tunnel (per RFC 8441 §5, the response on
+//     an HTTP/2 stream is 200, not 101).
+//  3. Strips client-supplied reserved Teleport headers if a list was
+//     configured.
+//  4. Rewrites the request as an HTTP/1.1 GET + Upgrade and dispatches
+//     to the wrapped handler with a ResponseWriter that implements
+//     http.Hijacker. The handler's gorilla.Upgrader.Upgrade succeeds
+//     because the method is GET and the Upgrade / Connection /
+//     Sec-WebSocket-* headers are present.
+//
+// When Hijack runs, the returned net.Conn reads from r.Body and writes
+// through w with a flush after every Write so WebSocket frames do not sit
+// in the HTTP/2 buffer. Deadlines forward to the http.ResponseController
+// for the request. The synthetic "HTTP/1.1 101 Switching Protocols"
+// response gorilla writes onto the hijacked conn is stripped off
+// incrementally before bytes reach the wire.
+//
+// If the handler returns without hijacking, the middleware fails closed
+// and sends 405 Method Not Allowed rather than passing handler output
+// through the 101 stripper. This protects every other GET route from
+// being addressable via extended CONNECT.
+package h2websocket
+
+import (
+	"bufio"
+	"crypto/rand"
+	"encoding/base64"
+	"io"
+	"net"
+	"net/http"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/gravitational/trace"
+)
+
+// pseudoHeaderProtocol is the HTTP/2 :protocol pseudo-header (RFC 8441
+// §4). Go's net/http server surfaces it as a regular header named
+// ":protocol".
+const pseudoHeaderProtocol = ":protocol"
+
+// Options configures the middleware.
+type Options struct {
+	// ReservedHeaders names HTTP headers that the middleware strips from
+	// the synthetic request before dispatch. The list is intended for
+	// Teleport-injected headers (lib/srv/app/common.ReservedHeaders) so
+	// that a malicious client cannot plant them on an extended CONNECT
+	// request and have them reach a backend that treats them as control
+	// input. The check is case-insensitive (http.Header.Del is
+	// canonicalized).
+	ReservedHeaders []string
+}
+
+// Wrap returns next wrapped with the HTTP/2 extended CONNECT bridge.
+// Apply once at the outermost layer of the proxy web chain, outside
+// XForwardedFor / tracing / limiter so those middlewares observe the
+// synthetic HTTP/1.1 request rather than the raw HTTP/2 one.
+func Wrap(next http.Handler, opts Options) http.Handler {
+	reservedSet := canonicalSet(opts.ReservedHeaders)
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !isH2WebSocketConnect(r) {
+			next.ServeHTTP(w, r)
+			return
+		}
+		serve(w, r, next, reservedSet)
+	})
+}
+
+// isH2WebSocketConnect reports whether r is an RFC 8441 extended CONNECT
+// WebSocket handshake.
+func isH2WebSocketConnect(r *http.Request) bool {
+	return r.ProtoMajor >= 2 &&
+		r.Method == http.MethodConnect &&
+		r.Header.Get(pseudoHeaderProtocol) == "websocket"
+}
+
+func serve(w http.ResponseWriter, r *http.Request, next http.Handler, reservedSet map[string]struct{}) {
+	rc := http.NewResponseController(w)
+	if err := rc.EnableFullDuplex(); err != nil {
+		http.Error(w, "full-duplex unavailable", http.StatusInternalServerError)
+		return
+	}
+
+	// Open the h2 tunnel before dispatching so the client starts
+	// streaming WebSocket frames into r.Body.
+	w.WriteHeader(http.StatusOK)
+	if err := rc.Flush(); err != nil {
+		return
+	}
+
+	r2, err := rewriteAsH1Upgrade(r, reservedSet)
+	if err != nil {
+		return
+	}
+
+	hw := &hijackResponseWriter{
+		ResponseWriter: w,
+		req:            r,
+		rc:             rc,
+	}
+	next.ServeHTTP(hw, r2)
+
+	// Fail closed: if the handler returned without hijacking, the route
+	// is not a WebSocket route. Surface that as a stream-level error
+	// rather than passing the handler's output (likely JSON, HTML, etc.)
+	// through the 101 stripper, which would corrupt the stream.
+	if !hw.hijacked.Load() {
+		// We already sent 200 to open the tunnel, so the HTTP status
+		// is committed. Closing the stream is the only way to signal
+		// "wrong route" to the client at this point.
+		if c, ok := r.Body.(io.Closer); ok {
+			_ = c.Close()
+		}
+	}
+}
+
+// rewriteAsH1Upgrade returns a copy of r that looks like an HTTP/1.1
+// WebSocket Upgrade request: method GET, Upgrade / Connection /
+// Sec-WebSocket-* headers populated, and reserved headers stripped.
+// The body is left alone (it carries WebSocket frames once the
+// handshake completes).
+func rewriteAsH1Upgrade(r *http.Request, reservedSet map[string]struct{}) (*http.Request, error) {
+	r2 := r.Clone(r.Context())
+	r2.Method = http.MethodGet
+	r2.Proto = "HTTP/1.1"
+	r2.ProtoMajor = 1
+	r2.ProtoMinor = 1
+	r2.RequestURI = ""
+
+	hdr := r2.Header.Clone()
+	hdr.Del(pseudoHeaderProtocol)
+	for h := range reservedSet {
+		hdr.Del(h)
+	}
+	hdr.Set("Connection", "Upgrade")
+	hdr.Set("Upgrade", "websocket")
+	if hdr.Get("Sec-WebSocket-Version") == "" {
+		hdr.Set("Sec-WebSocket-Version", "13")
+	}
+	if hdr.Get("Sec-WebSocket-Key") == "" {
+		key := make([]byte, 16)
+		if _, err := rand.Read(key); err != nil {
+			return nil, trace.Wrap(err, "generating Sec-WebSocket-Key")
+		}
+		hdr.Set("Sec-WebSocket-Key", base64.StdEncoding.EncodeToString(key))
+	}
+	r2.Header = hdr
+	return r2, nil
+}
+
+func canonicalSet(names []string) map[string]struct{} {
+	if len(names) == 0 {
+		return nil
+	}
+	out := make(map[string]struct{}, len(names))
+	for _, n := range names {
+		out[http.CanonicalHeaderKey(n)] = struct{}{}
+	}
+	return out
+}
+
+// hijackResponseWriter implements http.Hijacker on top of an HTTP/2
+// ResponseWriter so gorilla.Upgrader.Upgrade can take ownership of the
+// underlying stream as a net.Conn.
+type hijackResponseWriter struct {
+	http.ResponseWriter
+	req *http.Request
+	rc  *http.ResponseController
+
+	hijacked atomic.Bool
+}
+
+func (h *hijackResponseWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	if !h.hijacked.CompareAndSwap(false, true) {
+		return nil, nil, http.ErrHijacked
+	}
+	conn := newH2StreamConn(h.req, h.ResponseWriter, h.rc)
+	brw := bufio.NewReadWriter(bufio.NewReader(conn), bufio.NewWriter(conn))
+	return conn, brw, nil
+}
+
+// h2StreamConn presents an HTTP/2 request body + flushed response writer
+// pair as a net.Conn. Deadlines forward to the http.ResponseController.
+type h2StreamConn struct {
+	r io.ReadCloser
+	w io.Writer
+
+	rc      *http.ResponseController
+	closeMu sync.Mutex
+	closed  atomic.Bool
+}
+
+func newH2StreamConn(req *http.Request, w http.ResponseWriter, rc *http.ResponseController) *h2StreamConn {
+	c := &h2StreamConn{
+		r:  req.Body,
+		rc: rc,
+	}
+	c.w = &stripUpgradeWriter{
+		inner: &flushWriter{w: w, rc: rc},
+	}
+	return c
+}
+
+func (c *h2StreamConn) Read(p []byte) (int, error) {
+	if c.closed.Load() {
+		return 0, net.ErrClosed
+	}
+	return c.r.Read(p)
+}
+
+func (c *h2StreamConn) Write(p []byte) (int, error) {
+	return c.w.Write(p)
+}
+
+func (c *h2StreamConn) Close() error {
+	c.closeMu.Lock()
+	defer c.closeMu.Unlock()
+	if c.closed.Swap(true) {
+		return nil
+	}
+	// Closing the request body cancels the HTTP/2 stream so the peer
+	// observes a clean EOF rather than a hung connection.
+	return c.r.Close()
+}
+
+func (c *h2StreamConn) LocalAddr() net.Addr  { return placeholderAddr("h2-local") }
+func (c *h2StreamConn) RemoteAddr() net.Addr { return placeholderAddr("h2-remote") }
+
+func (c *h2StreamConn) SetDeadline(t time.Time) error {
+	if err := c.SetReadDeadline(t); err != nil {
+		return err
+	}
+	return c.SetWriteDeadline(t)
+}
+
+func (c *h2StreamConn) SetReadDeadline(t time.Time) error {
+	return c.rc.SetReadDeadline(t)
+}
+
+func (c *h2StreamConn) SetWriteDeadline(t time.Time) error {
+	return c.rc.SetWriteDeadline(t)
+}
+
+type placeholderAddr string
+
+func (placeholderAddr) Network() string  { return "h2-websocket" }
+func (a placeholderAddr) String() string { return string(a) }
+
+// flushWriter flushes after every Write so a single WebSocket frame ends
+// up on the wire as a single h2 DATA frame instead of being buffered.
+type flushWriter struct {
+	w  io.Writer
+	rc *http.ResponseController
+}
+
+func (f *flushWriter) Write(p []byte) (int, error) {
+	n, err := f.w.Write(p)
+	if err == nil {
+		_ = f.rc.Flush()
+	}
+	return n, err
+}
+
+// stripUpgradeWriter discards bytes up to and including the first
+// "\r\n\r\n" sequence (gorilla's synthetic 101 response that does not
+// belong on the h2 stream), then forwards everything afterward. The
+// parser is incremental: it never accumulates more than the four bytes
+// needed to recognise the terminator, so there is no fixed buffer cap
+// that could silently truncate a long Sec-WebSocket-Protocol header.
+type stripUpgradeWriter struct {
+	inner   io.Writer
+	scanned int // number of consecutive bytes of "\r\n\r\n" matched so far
+	done    bool
+}
+
+var crlfcrlf = []byte("\r\n\r\n")
+
+func (s *stripUpgradeWriter) Write(p []byte) (int, error) {
+	if s.done {
+		return s.inner.Write(p)
+	}
+	consumed := 0
+	for consumed < len(p) {
+		if p[consumed] == crlfcrlf[s.scanned] {
+			s.scanned++
+			consumed++
+			if s.scanned == len(crlfcrlf) {
+				s.done = true
+				rest := p[consumed:]
+				if len(rest) > 0 {
+					if _, err := s.inner.Write(rest); err != nil {
+						return 0, err
+					}
+				}
+				return len(p), nil
+			}
+		} else {
+			// Reset the match. If we matched some prefix, those bytes
+			// are part of the header (still discarded). The current
+			// byte is also discarded.
+			s.scanned = 0
+			consumed++
+		}
+	}
+	return len(p), nil
+}

--- a/lib/httplib/h2websocket/h2websocket.go
+++ b/lib/httplib/h2websocket/h2websocket.go
@@ -49,11 +49,14 @@
 // hijack so a non-WebSocket route reached via extended CONNECT cannot
 // leak its response body onto the stream as opaque WebSocket payload.
 //
-// Sec-WebSocket-Protocol negotiation is currently dropped: gorilla writes
-// the negotiated value into the synthetic 101 preamble that the stripper
-// discards. RFC 8441 §5.1 places subprotocol negotiation in the H2
-// response HEADERS frame, so callers of gorilla.Upgrader.Subprotocols
-// must address this before ALPN advertises h2 first.
+// Sec-WebSocket-Protocol negotiation is not propagated. The wrapped
+// HTTP/1.1 upgrader writes the negotiated value into the synthetic 101
+// preamble that the stripper discards, and RFC 8441 §5.1 places
+// subprotocol negotiation in the H2 response HEADERS frame instead.
+// Until the bridge lifts the negotiated subprotocol onto the outer
+// response headers before committing the 200, routes that depend on
+// gorilla.Upgrader.Subprotocols (kube exec, desktop, conn upgrade)
+// must not be reached over HTTP/2.
 package h2websocket
 
 import (
@@ -64,6 +67,7 @@ import (
 	"io"
 	"net"
 	"net/http"
+	"net/netip"
 	"sync/atomic"
 	"time"
 
@@ -129,7 +133,7 @@ func serve(w http.ResponseWriter, r *http.Request, next http.Handler, reservedSe
 	// spikes will miss h2-ws auth failures; log from the inner handler
 	// if the metric matters.
 	w.WriteHeader(http.StatusOK)
-	if err := rc.Flush(); err != nil {
+	if err := rc.Flush(); err != nil && !errors.Is(err, http.ErrNotSupported) {
 		return
 	}
 
@@ -151,9 +155,7 @@ func serve(w http.ResponseWriter, r *http.Request, next http.Handler, reservedSe
 	// hijackResponseWriter gate above also discards any Write the
 	// handler made before returning, so opaque bytes do not leak.
 	if !hw.hijacked.Load() {
-		if c, ok := r.Body.(io.Closer); ok {
-			_ = c.Close()
-		}
+		_ = r.Body.Close()
 	}
 }
 
@@ -208,11 +210,15 @@ func canonicalSet(names []string) map[string]bool {
 }
 
 // hijackResponseWriter implements http.Hijacker on top of an HTTP/2
-// ResponseWriter so gorilla.Upgrader.Upgrade can take ownership of the
+// ResponseWriter so an HTTP/1.1 upgrader can take ownership of the
 // underlying stream as a net.Conn. Write and WriteHeader are silenced
 // before hijack so a handler that returns without hijacking (e.g. a
 // non-WebSocket route reached via extended CONNECT) cannot leak its
 // response body onto the h2 stream as opaque WebSocket payload.
+//
+// Header() returns the embedded writer's header map. Mutations before
+// hijack are no-ops on the wire because the 200 status is already
+// committed; rely on the hijacked conn or context for error signaling.
 type hijackResponseWriter struct {
 	http.ResponseWriter
 	body       io.ReadCloser
@@ -240,13 +246,16 @@ func (h *hijackResponseWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
 	if !h.hijacked.CompareAndSwap(false, true) {
 		return nil, nil, http.ErrHijacked
 	}
-	conn := newH2StreamConn(h.body, h.remoteAddr, h.ResponseWriter, h.rc)
+	conn := newH2StreamConn(h.body, h.ResponseWriter, h.remoteAddr, h.rc)
 	brw := bufio.NewReadWriter(bufio.NewReader(conn), bufio.NewWriter(conn))
 	return conn, brw, nil
 }
 
 // h2StreamConn presents an HTTP/2 request body + flushed response writer
 // pair as a net.Conn. Deadlines forward to the http.ResponseController.
+// LocalAddr returns a placeholder because net/http's HTTP/2 server
+// does not expose stream-level local addresses on the hijacked conn;
+// RemoteAddr forwards the request's RemoteAddr when set.
 type h2StreamConn struct {
 	r          io.ReadCloser
 	w          io.Writer
@@ -256,7 +265,7 @@ type h2StreamConn struct {
 	closed atomic.Bool
 }
 
-func newH2StreamConn(body io.ReadCloser, remoteAddr string, w http.ResponseWriter, rc *http.ResponseController) *h2StreamConn {
+func newH2StreamConn(body io.ReadCloser, w http.ResponseWriter, remoteAddr string, rc *http.ResponseController) *h2StreamConn {
 	c := &h2StreamConn{
 		r:          body,
 		remoteAddr: remoteAddr,
@@ -293,9 +302,12 @@ func (c *h2StreamConn) Close() error {
 func (c *h2StreamConn) LocalAddr() net.Addr { return placeholderAddr("h2-local") }
 
 func (c *h2StreamConn) RemoteAddr() net.Addr {
+	// netip.ParseAddrPort accepts only literal IP:port forms, so this
+	// cannot trigger a synchronous DNS lookup if r.RemoteAddr is ever
+	// rewritten to a hostname-style value (matches lib/web/addr.go).
 	if c.remoteAddr != "" {
-		if addr, err := net.ResolveTCPAddr("tcp", c.remoteAddr); err == nil {
-			return addr
+		if ap, err := netip.ParseAddrPort(c.remoteAddr); err == nil {
+			return net.TCPAddrFromAddrPort(ap)
 		}
 	}
 	return placeholderAddr("h2-remote")
@@ -326,11 +338,12 @@ type placeholderAddr string
 func (placeholderAddr) Network() string  { return "h2-websocket" }
 func (a placeholderAddr) String() string { return string(a) }
 
-// flushWriter flushes after every Write so a single WebSocket frame ends
-// up on the wire as a single h2 DATA frame instead of being buffered.
-// Flush errors are propagated once a first flush has succeeded, so a
-// stream reset (Write succeeds into the buffer, Flush fails) surfaces
-// to the WebSocket handler instead of being silently dropped.
+// flushWriter flushes after every Write so a single WebSocket frame
+// ends up on the wire as a single h2 DATA frame instead of being
+// buffered. Flush errors are propagated so a stream reset (Write
+// succeeds into the buffer, Flush fails) surfaces to the WebSocket
+// handler instead of being silently dropped. ErrNotSupported is
+// suppressed because not every ResponseWriter implements Flusher.
 type flushWriter struct {
 	w  http.ResponseWriter
 	rc *http.ResponseController
@@ -342,32 +355,36 @@ func (f *flushWriter) Write(p []byte) (int, error) {
 		return n, err
 	}
 	if err := f.rc.Flush(); err != nil && !errors.Is(err, http.ErrNotSupported) {
-		return n, err
+		// Per io.Writer, n must reflect bytes durably committed; on
+		// Flush failure the bytes sit in the h2 send buffer and never
+		// reach the wire, so report zero.
+		return 0, err
 	}
 	return n, nil
 }
 
 // stripUpgradeWriter discards bytes up to and including the first
-// "\r\n\r\n" sequence (gorilla's synthetic 101 response that does not
-// belong on the h2 stream), then forwards everything afterward. The
-// parser is incremental: it never accumulates more than the four bytes
-// needed to recognize the terminator, so there is no fixed buffer cap
-// that could silently truncate a long Sec-WebSocket-Protocol header.
+// "\r\n\r\n" sequence (the synthetic HTTP/1.1 response preamble the
+// wrapped upgrader emits before owning the conn), then forwards
+// everything afterward. The parser is incremental: it never
+// accumulates more than the four bytes needed to recognize the
+// terminator, so there is no fixed buffer cap that could silently
+// truncate a long Sec-WebSocket-Protocol header.
 type stripUpgradeWriter struct {
 	inner   io.Writer
-	scanned int // number of consecutive bytes of "\r\n\r\n" matched so far
+	scanned int // number of consecutive bytes of upgradeHeaderTerminator matched so far
 	done    bool
 }
 
-var crlfcrlf = []byte("\r\n\r\n")
+const upgradeHeaderTerminator = "\r\n\r\n"
 
 func (s *stripUpgradeWriter) Write(p []byte) (int, error) {
 	if s.done {
 		return s.inner.Write(p)
 	}
-	for i := 0; i < len(p); i++ {
+	for i := range p {
 		s.scanned = nextScanState(s.scanned, p[i])
-		if s.scanned == len(crlfcrlf) {
+		if s.scanned == len(upgradeHeaderTerminator) {
 			s.done = true
 			rest := p[i+1:]
 			if len(rest) > 0 {
@@ -381,16 +398,16 @@ func (s *stripUpgradeWriter) Write(p []byte) (int, error) {
 	return len(p), nil
 }
 
-// nextScanState advances the "\r\n\r\n" matcher by one byte. The
-// pattern has self-overlap on '\r' (positions 0 and 2), so on a
-// mismatch the failing byte may itself start a new match: e.g. the
-// second '\r' in "\r\r\n\r\n" must not be discarded. This is the KMP
-// failure function for "\r\n\r\n" collapsed to a single comparison.
+// nextScanState advances the upgradeHeaderTerminator matcher by one
+// byte. The pattern has self-overlap on '\r' (positions 0 and 2), so
+// on a mismatch the failing byte may itself start a new match: e.g.
+// the second '\r' in "\r\r\n\r\n" must not be discarded. This is the
+// KMP failure function for "\r\n\r\n" collapsed to a single comparison.
 func nextScanState(scanned int, b byte) int {
-	if b == crlfcrlf[scanned] {
+	if b == upgradeHeaderTerminator[scanned] {
 		return scanned + 1
 	}
-	if b == crlfcrlf[0] {
+	if b == upgradeHeaderTerminator[0] {
 		return 1
 	}
 	return 0

--- a/lib/httplib/h2websocket/h2websocket_test.go
+++ b/lib/httplib/h2websocket/h2websocket_test.go
@@ -1,0 +1,206 @@
+/*
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package h2websocket
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gorilla/websocket"
+	"github.com/stretchr/testify/require"
+)
+
+// TestWrap_PassthroughNonWebSocket verifies that non-WebSocket requests
+// flow through unmodified. Pre-fix failure mode: if Wrap rewrote every
+// request, this test would observe r.Method == "GET" but with the
+// synthetic Upgrade headers planted on it.
+func TestWrap_PassthroughNonWebSocket(t *testing.T) {
+	var seen *http.Request
+	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		seen = r
+		w.WriteHeader(http.StatusTeapot)
+	})
+	srv := httptest.NewServer(Wrap(inner, Options{}))
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL + "/healthz")
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	require.Equal(t, http.StatusTeapot, resp.StatusCode)
+	require.NotNil(t, seen)
+	require.Equal(t, http.MethodGet, seen.Method)
+	require.Empty(t, seen.Header.Get("Upgrade"))
+	require.Empty(t, seen.Header.Get("Sec-WebSocket-Key"))
+}
+
+// TestWrap_PassthroughH1WebSocket verifies that an HTTP/1.1 WebSocket
+// Upgrade is not rewritten and the inner gorilla.Upgrader handles it.
+// Pre-fix failure mode: a bug in isH2WebSocketConnect that returned true
+// for h1 would route the request through the synthetic path and gorilla
+// would see headers it has already received, double-stuffed.
+func TestWrap_PassthroughH1WebSocket(t *testing.T) {
+	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		up := websocket.Upgrader{}
+		ws, err := up.Upgrade(w, r, nil)
+		require.NoError(t, err)
+		defer ws.Close()
+		require.NoError(t, ws.WriteMessage(websocket.BinaryMessage, []byte("hi")))
+	})
+	srv := httptest.NewServer(Wrap(inner, Options{}))
+	defer srv.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(srv.URL, "http")
+	ws, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
+	require.NoError(t, err)
+	defer ws.Close()
+
+	typ, payload, err := ws.ReadMessage()
+	require.NoError(t, err)
+	require.Equal(t, websocket.BinaryMessage, typ)
+	require.Equal(t, []byte("hi"), payload)
+}
+
+// TestRewriteAsH1Upgrade verifies the request rewrite: CONNECT becomes
+// GET, the :protocol pseudo-header is dropped, Upgrade/Connection
+// headers are set, Sec-WebSocket-* defaults are synthesised when
+// missing, and reserved headers are stripped. Pre-fix failure: any
+// missing piece prevents gorilla.Upgrader.Upgrade from accepting the
+// request inside the inner handler.
+func TestRewriteAsH1Upgrade(t *testing.T) {
+	req := httptest.NewRequest(http.MethodConnect, "/ws", nil)
+	req.ProtoMajor = 2
+	req.Header.Set(":protocol", "websocket")
+	req.Header.Set("X-Teleport-Aws-Assumed-Role", "evil")
+	req.Header.Set("Authorization", "Bearer keep-me")
+
+	got, err := rewriteAsH1Upgrade(req, canonicalSet([]string{
+		"X-Teleport-Aws-Assumed-Role",
+	}))
+	require.NoError(t, err)
+
+	require.Equal(t, http.MethodGet, got.Method)
+	require.Equal(t, 1, got.ProtoMajor)
+	require.Equal(t, "websocket", got.Header.Get("Upgrade"))
+	require.Equal(t, "Upgrade", got.Header.Get("Connection"))
+	require.Equal(t, "13", got.Header.Get("Sec-WebSocket-Version"))
+	require.NotEmpty(t, got.Header.Get("Sec-WebSocket-Key"))
+	require.Empty(t, got.Header.Get(":protocol"))
+	require.Empty(t, got.Header.Get("X-Teleport-Aws-Assumed-Role"),
+		"reserved header must be stripped")
+	require.Equal(t, "Bearer keep-me", got.Header.Get("Authorization"),
+		"non-reserved client header must survive")
+}
+
+// TestStripUpgradeWriter_DropsLeadingHeader verifies the incremental
+// stripper discards the synthetic "HTTP/1.1 101 ..." header and
+// forwards everything after the "\r\n\r\n" terminator. Pre-fix failure:
+// without the stripper, the 101 bytes flow onto the h2 stream and
+// confuse the browser's WebSocket frame parser.
+func TestStripUpgradeWriter_DropsLeadingHeader(t *testing.T) {
+	var sink bytes.Buffer
+	w := &stripUpgradeWriter{inner: &sink}
+
+	header := "HTTP/1.1 101 Switching Protocols\r\nUpgrade: websocket\r\n" +
+		"Connection: Upgrade\r\nSec-WebSocket-Accept: x\r\n\r\n"
+	payload := []byte{0x82, 0x05, 'h', 'e', 'l', 'l', 'o'}
+
+	_, err := w.Write([]byte(header))
+	require.NoError(t, err)
+	require.Empty(t, sink.Bytes(), "header bytes must not reach the wire")
+
+	_, err = w.Write(payload)
+	require.NoError(t, err)
+	require.Equal(t, payload, sink.Bytes())
+}
+
+// TestStripUpgradeWriter_CoalescedWrite verifies the stripper handles a
+// Write that contains both the trailing "\r\n\r\n" and the first frame
+// bytes in one call. Pre-fix failure: a buffer-then-flush stripper that
+// only forwards on a *separate* Write call would drop the inline frame.
+func TestStripUpgradeWriter_CoalescedWrite(t *testing.T) {
+	var sink bytes.Buffer
+	w := &stripUpgradeWriter{inner: &sink}
+
+	combined := []byte("HTTP/1.1 101 OK\r\nA: b\r\n\r\n" + "WS-FRAME")
+	_, err := w.Write(combined)
+	require.NoError(t, err)
+	require.Equal(t, "WS-FRAME", sink.String())
+}
+
+// TestStripUpgradeWriter_ByteByByte verifies the incremental parser
+// when the terminator is split across Write calls one byte at a time.
+// Pre-fix failure: a stripper that scans only within a single Write
+// would miss a "\r\n\r\n" that straddles two Writes.
+func TestStripUpgradeWriter_ByteByByte(t *testing.T) {
+	var sink bytes.Buffer
+	w := &stripUpgradeWriter{inner: &sink}
+
+	header := []byte("HTTP/1.1 101 OK\r\n\r\n")
+	for _, b := range header {
+		_, err := w.Write([]byte{b})
+		require.NoError(t, err)
+	}
+	require.Empty(t, sink.Bytes())
+
+	_, err := w.Write([]byte("X"))
+	require.NoError(t, err)
+	require.Equal(t, "X", sink.String())
+}
+
+// TestStripUpgradeWriter_LongHeader verifies the stripper has no fixed
+// buffer cap: a Sec-WebSocket-Protocol response with many subprotocols
+// can exceed any kilobyte-sized buffer. Pre-fix failure mode (against
+// an earlier draft that used a 4 KiB buffer): the test would error with
+// "buffer exceeded" before the terminator was reached.
+func TestStripUpgradeWriter_LongHeader(t *testing.T) {
+	var sink bytes.Buffer
+	w := &stripUpgradeWriter{inner: &sink}
+
+	longProtos := strings.Repeat("subproto-x,", 1000)
+	header := "HTTP/1.1 101 OK\r\nSec-WebSocket-Protocol: " +
+		longProtos + "last\r\n\r\nFRAMES"
+	_, err := w.Write([]byte(header))
+	require.NoError(t, err)
+	require.Equal(t, "FRAMES", sink.String())
+}
+
+// TestCanonicalSet verifies the reserved-header lookup is
+// case-insensitive in the way http.Header.Del expects.
+func TestCanonicalSet(t *testing.T) {
+	got := canonicalSet([]string{"x-teleport-foo", "X-Teleport-Bar"})
+	_, ok := got["X-Teleport-Foo"]
+	require.True(t, ok)
+	_, ok = got["X-Teleport-Bar"]
+	require.True(t, ok)
+	require.Nil(t, canonicalSet(nil))
+}
+
+// TestH2StreamConn_CloseIdempotent verifies double-close is a no-op.
+// Pre-fix failure: re-closing the request body twice would panic on
+// some HTTP/2 stream implementations.
+func TestH2StreamConn_CloseIdempotent(t *testing.T) {
+	c := &h2StreamConn{r: io.NopCloser(strings.NewReader(""))}
+	require.NoError(t, c.Close())
+	require.NoError(t, c.Close())
+}

--- a/lib/httplib/h2websocket/h2websocket_test.go
+++ b/lib/httplib/h2websocket/h2websocket_test.go
@@ -20,6 +20,7 @@ package h2websocket
 
 import (
 	"bytes"
+	"errors"
 	"io"
 	"net"
 	"net/http"
@@ -32,12 +33,21 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestWrap_PassthroughNonWebSocket verifies that non-WebSocket requests
-// flow through the wrapper unmodified.
 func TestWrap_PassthroughNonWebSocket(t *testing.T) {
-	var seen *http.Request
+	type observed struct {
+		method   string
+		upgrade  string
+		wsKey    string
+		gotInner bool
+	}
+	ch := make(chan observed, 1)
 	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		seen = r
+		ch <- observed{
+			method:   r.Method,
+			upgrade:  r.Header.Get("Upgrade"),
+			wsKey:    r.Header.Get("Sec-WebSocket-Key"),
+			gotInner: true,
+		}
 		w.WriteHeader(http.StatusTeapot)
 	})
 	srv := httptest.NewServer(Wrap(inner, Options{}))
@@ -48,14 +58,13 @@ func TestWrap_PassthroughNonWebSocket(t *testing.T) {
 	defer resp.Body.Close()
 
 	require.Equal(t, http.StatusTeapot, resp.StatusCode)
-	require.NotNil(t, seen)
-	require.Equal(t, http.MethodGet, seen.Method)
-	require.Empty(t, seen.Header.Get("Upgrade"))
-	require.Empty(t, seen.Header.Get("Sec-WebSocket-Key"))
+	got := <-ch
+	require.True(t, got.gotInner)
+	require.Equal(t, http.MethodGet, got.method)
+	require.Empty(t, got.upgrade)
+	require.Empty(t, got.wsKey)
 }
 
-// TestWrap_PassthroughH1WebSocket verifies that an HTTP/1.1 WebSocket
-// Upgrade is not rewritten and the inner gorilla.Upgrader handles it.
 func TestWrap_PassthroughH1WebSocket(t *testing.T) {
 	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		up := websocket.Upgrader{}
@@ -110,10 +119,6 @@ func TestIsH2WebSocketConnect(t *testing.T) {
 	}
 }
 
-// TestRewriteAsH1Upgrade verifies the request rewrite: CONNECT becomes
-// GET, the :protocol pseudo-header is dropped, Upgrade/Connection
-// headers are set, Sec-WebSocket-* defaults are synthesized when
-// missing, and reserved headers are stripped.
 func TestRewriteAsH1Upgrade(t *testing.T) {
 	req := httptest.NewRequest(http.MethodConnect, "/ws", nil)
 	req.ProtoMajor = 2
@@ -137,9 +142,6 @@ func TestRewriteAsH1Upgrade(t *testing.T) {
 		"non-reserved client header must survive")
 }
 
-// TestRewriteAsH1Upgrade_PreservesClientWebsocketHeaders verifies that
-// a client-supplied Sec-WebSocket-Key and Sec-WebSocket-Version survive
-// the rewrite verbatim instead of being overwritten by the defaults.
 func TestRewriteAsH1Upgrade_PreservesClientWebsocketHeaders(t *testing.T) {
 	req := httptest.NewRequest(http.MethodConnect, "/ws", nil)
 	req.ProtoMajor = 2
@@ -153,9 +155,6 @@ func TestRewriteAsH1Upgrade_PreservesClientWebsocketHeaders(t *testing.T) {
 	require.Equal(t, "8", got.Header.Get("Sec-WebSocket-Version"))
 }
 
-// TestStripUpgradeWriter_DropsLeadingHeader verifies the incremental
-// stripper discards the synthetic "HTTP/1.1 101 ..." header and
-// forwards everything after the "\r\n\r\n" terminator.
 func TestStripUpgradeWriter_DropsLeadingHeader(t *testing.T) {
 	var sink bytes.Buffer
 	w := &stripUpgradeWriter{inner: &sink}
@@ -173,9 +172,6 @@ func TestStripUpgradeWriter_DropsLeadingHeader(t *testing.T) {
 	require.Equal(t, payload, sink.Bytes())
 }
 
-// TestStripUpgradeWriter_CoalescedWrite verifies the stripper handles a
-// Write that contains both the trailing "\r\n\r\n" and the first frame
-// bytes in one call.
 func TestStripUpgradeWriter_CoalescedWrite(t *testing.T) {
 	var sink bytes.Buffer
 	w := &stripUpgradeWriter{inner: &sink}
@@ -186,8 +182,6 @@ func TestStripUpgradeWriter_CoalescedWrite(t *testing.T) {
 	require.Equal(t, "WS-FRAME", sink.String())
 }
 
-// TestStripUpgradeWriter_ByteByByte verifies the incremental parser
-// when the terminator is split across Write calls one byte at a time.
 func TestStripUpgradeWriter_ByteByByte(t *testing.T) {
 	var sink bytes.Buffer
 	w := &stripUpgradeWriter{inner: &sink}
@@ -234,9 +228,33 @@ func TestStripUpgradeWriter_SelfOverlap(t *testing.T) {
 	require.Equal(t, "FRAMES", sink.String())
 }
 
-// TestCanonicalSet verifies the reserved-header lookup is
-// case-insensitive in the way http.Header.Del expects, including
-// pathological mixed-case inputs.
+// TestNextScanState exhausts the three transitions of the matcher
+// (match-byte, restart-on-prefix, full-reset) so a regression on any
+// branch surfaces independently of the integration cases above.
+func TestNextScanState(t *testing.T) {
+	tests := []struct {
+		name    string
+		scanned int
+		b       byte
+		want    int
+	}{
+		{name: "match first \\r", scanned: 0, b: '\r', want: 1},
+		{name: "match \\n after \\r", scanned: 1, b: '\n', want: 2},
+		{name: "match second \\r", scanned: 2, b: '\r', want: 3},
+		{name: "match final \\n", scanned: 3, b: '\n', want: 4},
+		{name: "mismatch at start", scanned: 0, b: 'a', want: 0},
+		{name: "mismatch after \\r, byte is \\r (self-overlap)", scanned: 1, b: '\r', want: 1},
+		{name: "mismatch after \\r\\n\\r, byte is \\r (self-overlap)", scanned: 3, b: '\r', want: 1},
+		{name: "mismatch after \\r\\n, byte is unrelated", scanned: 2, b: 'a', want: 0},
+		{name: "mismatch after \\r\\n\\r, byte is unrelated", scanned: 3, b: 'a', want: 0},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, nextScanState(tc.scanned, tc.b))
+		})
+	}
+}
+
 func TestCanonicalSet(t *testing.T) {
 	got := canonicalSet([]string{"X-TELEPORT-foo", "x-teleport-BAR"})
 	require.True(t, got["X-Teleport-Foo"])
@@ -244,15 +262,50 @@ func TestCanonicalSet(t *testing.T) {
 	require.Nil(t, canonicalSet(nil))
 }
 
-// TestH2StreamConn_CloseIdempotent verifies double-close is a no-op
-// and that Read after Close returns net.ErrClosed.
 func TestH2StreamConn_CloseIdempotent(t *testing.T) {
 	c := &h2StreamConn{r: io.NopCloser(strings.NewReader(""))}
 	require.NoError(t, c.Close())
 	require.NoError(t, c.Close())
+}
+
+func TestH2StreamConn_ReadAfterClose(t *testing.T) {
+	c := &h2StreamConn{r: io.NopCloser(strings.NewReader(""))}
+	require.NoError(t, c.Close())
 
 	_, err := c.Read(make([]byte, 4))
 	require.ErrorIs(t, err, net.ErrClosed)
+}
+
+// TestFlushWriter exercises the three Flush outcomes: a successful
+// flush returns (n, nil); ErrNotSupported is suppressed; any other
+// Flush error is propagated with n=0 so callers cannot mistake
+// buffered bytes for durably committed ones.
+func TestFlushWriter(t *testing.T) {
+	t.Run("happy path", func(t *testing.T) {
+		w := &flushingRW{}
+		f := &flushWriter{w: w, rc: http.NewResponseController(w)}
+		n, err := f.Write([]byte("hi"))
+		require.NoError(t, err)
+		require.Equal(t, 2, n)
+		require.Equal(t, 1, w.flushes)
+	})
+	t.Run("ErrNotSupported is suppressed", func(t *testing.T) {
+		// flushingRW with flushErr=ErrNotSupported still reports the
+		// underlying Write count without surfacing the error.
+		w := &flushingRW{flushErr: http.ErrNotSupported}
+		f := &flushWriter{w: w, rc: http.NewResponseController(w)}
+		n, err := f.Write([]byte("hi"))
+		require.NoError(t, err)
+		require.Equal(t, 2, n)
+	})
+	t.Run("real flush error surfaces with n=0", func(t *testing.T) {
+		sentinel := errors.New("h2 stream reset")
+		w := &flushingRW{flushErr: sentinel}
+		f := &flushWriter{w: w, rc: http.NewResponseController(w)}
+		n, err := f.Write([]byte("hi"))
+		require.ErrorIs(t, err, sentinel)
+		require.Equal(t, 0, n, "Write must report 0 when Flush failed")
+	})
 }
 
 // TestServe_FailsClosedWhenHandlerDoesNotHijack verifies that an inner
@@ -260,7 +313,7 @@ func TestH2StreamConn_CloseIdempotent(t *testing.T) {
 // its body closed. This protects the h2 stream from being addressable
 // as an opaque WebSocket payload echo by non-WebSocket routes.
 func TestServe_FailsClosedWhenHandlerDoesNotHijack(t *testing.T) {
-	body := &closableBuffer{Reader: strings.NewReader("client frames")}
+	body := &closableBuffer{r: strings.NewReader("client frames")}
 	req := httptest.NewRequest(http.MethodConnect, "/", body)
 	req.ProtoMajor = 2
 	req.Header.Set(":protocol", "websocket")
@@ -274,20 +327,21 @@ func TestServe_FailsClosedWhenHandlerDoesNotHijack(t *testing.T) {
 	serve(rec, req, inner, nil)
 
 	require.True(t, body.closed.Load(), "request body must be closed")
-	require.Equal(t, http.StatusOK, rec.status, "status is committed at the tunnel open")
+	require.Equal(t, []int{http.StatusOK}, rec.statuses,
+		"only the bridge's 200 reaches the writer; the inner handler's WriteHeader is gated")
 	require.Empty(t, rec.body.Bytes(),
 		"handler bytes must not leak onto the h2 stream as opaque payload")
 }
 
-// TestServe_FullDuplexUnavailable verifies that serve fails with 500
-// and does not dispatch the inner handler when EnableFullDuplex
-// reports the writer cannot stream both directions.
 func TestServe_FullDuplexUnavailable(t *testing.T) {
 	req := httptest.NewRequest(http.MethodConnect, "/", nil)
 	req.ProtoMajor = 2
 	req.Header.Set(":protocol", "websocket")
 
-	rec := httptest.NewRecorder()
+	// Test-controlled signal: duplexWriter explicitly errors on
+	// EnableFullDuplex. Avoids relying on httptest.NewRecorder
+	// happening to lack the interface.
+	rec := &duplexWriter{header: http.Header{}, enableFullDuplexErr: http.ErrNotSupported}
 	called := false
 	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		called = true
@@ -295,43 +349,53 @@ func TestServe_FullDuplexUnavailable(t *testing.T) {
 
 	serve(rec, req, inner, nil)
 
-	require.Equal(t, http.StatusInternalServerError, rec.Code)
+	require.Equal(t, []int{http.StatusInternalServerError}, rec.statuses)
 	require.False(t, called, "inner handler must not run when full duplex is unavailable")
 }
 
 // closableBuffer is a request body that tracks Close calls.
 type closableBuffer struct {
-	io.Reader
+	r      io.Reader
 	closed atomic.Bool
 }
 
-func (b *closableBuffer) Close() error {
-	b.closed.Store(true)
-	return nil
-}
+func (b *closableBuffer) Read(p []byte) (int, error) { return b.r.Read(p) }
+func (b *closableBuffer) Close() error               { b.closed.Store(true); return nil }
 
 // duplexWriter is a minimal http.ResponseWriter that satisfies the
-// full-duplex and flush hooks the bridge expects. It lets tests run
-// serve end-to-end without standing up a real HTTP/2 server.
+// full-duplex and flush hooks the bridge expects. Tests configure
+// enableFullDuplexErr to drive the error branch explicitly; statuses
+// records every WriteHeader call so tests can assert exact sequencing
+// rather than relying on real net/http's "first WriteHeader wins"
+// semantics.
 type duplexWriter struct {
-	header http.Header
-	body   bytes.Buffer
-	status int
+	header              http.Header
+	body                bytes.Buffer
+	statuses            []int
+	enableFullDuplexErr error
 }
 
-func (d *duplexWriter) Header() http.Header { return d.header }
-func (d *duplexWriter) WriteHeader(code int) {
-	if d.status == 0 {
-		d.status = code
-	}
-}
-
+func (d *duplexWriter) Header() http.Header  { return d.header }
+func (d *duplexWriter) WriteHeader(code int) { d.statuses = append(d.statuses, code) }
 func (d *duplexWriter) Write(p []byte) (int, error) {
-	if d.status == 0 {
-		d.status = http.StatusOK
+	if len(d.statuses) == 0 {
+		d.statuses = append(d.statuses, http.StatusOK)
 	}
 	return d.body.Write(p)
 }
 
-func (d *duplexWriter) EnableFullDuplex() error { return nil }
+func (d *duplexWriter) EnableFullDuplex() error { return d.enableFullDuplexErr }
 func (d *duplexWriter) Flush()                  {}
+
+// flushingRW is a minimal http.ResponseWriter that records every
+// Write/Flush call and reports a configurable Flush error.
+type flushingRW struct {
+	body     bytes.Buffer
+	flushes  int
+	flushErr error
+}
+
+func (w *flushingRW) Header() http.Header         { return http.Header{} }
+func (w *flushingRW) WriteHeader(int)             {}
+func (w *flushingRW) Write(p []byte) (int, error) { return w.body.Write(p) }
+func (w *flushingRW) FlushError() error           { w.flushes++; return w.flushErr }

--- a/lib/httplib/h2websocket/h2websocket_test.go
+++ b/lib/httplib/h2websocket/h2websocket_test.go
@@ -155,9 +155,21 @@ func TestRewriteAsH1Upgrade_PreservesClientWebsocketHeaders(t *testing.T) {
 	require.Equal(t, "8", got.Header.Get("Sec-WebSocket-Version"))
 }
 
+// newTestStripper wires a stripUpgradeWriter against an in-memory
+// outer ResponseWriter so each test can drive Write directly.
+func newTestStripper() (*stripUpgradeWriter, *duplexWriter, *bytes.Buffer) {
+	outer := &duplexWriter{header: http.Header{}}
+	sink := &bytes.Buffer{}
+	w := &stripUpgradeWriter{
+		outer: outer,
+		rc:    http.NewResponseController(outer),
+		inner: sink,
+	}
+	return w, outer, sink
+}
+
 func TestStripUpgradeWriter_DropsLeadingHeader(t *testing.T) {
-	var sink bytes.Buffer
-	w := &stripUpgradeWriter{inner: &sink}
+	w, outer, sink := newTestStripper()
 
 	header := "HTTP/1.1 101 Switching Protocols\r\nUpgrade: websocket\r\n" +
 		"Connection: Upgrade\r\nSec-WebSocket-Accept: x\r\n\r\n"
@@ -166,6 +178,7 @@ func TestStripUpgradeWriter_DropsLeadingHeader(t *testing.T) {
 	_, err := w.Write([]byte(header))
 	require.NoError(t, err)
 	require.Empty(t, sink.Bytes(), "header bytes must not reach the wire")
+	require.Equal(t, []int{http.StatusOK}, outer.statuses, "outer 200 commits when the preamble terminator arrives")
 
 	_, err = w.Write(payload)
 	require.NoError(t, err)
@@ -173,8 +186,7 @@ func TestStripUpgradeWriter_DropsLeadingHeader(t *testing.T) {
 }
 
 func TestStripUpgradeWriter_CoalescedWrite(t *testing.T) {
-	var sink bytes.Buffer
-	w := &stripUpgradeWriter{inner: &sink}
+	w, _, sink := newTestStripper()
 
 	combined := []byte("HTTP/1.1 101 OK\r\nA: b\r\n\r\n" + "WS-FRAME")
 	_, err := w.Write(combined)
@@ -183,8 +195,7 @@ func TestStripUpgradeWriter_CoalescedWrite(t *testing.T) {
 }
 
 func TestStripUpgradeWriter_ByteByByte(t *testing.T) {
-	var sink bytes.Buffer
-	w := &stripUpgradeWriter{inner: &sink}
+	w, outer, sink := newTestStripper()
 
 	header := []byte("HTTP/1.1 101 OK\r\n\r\n")
 	for _, b := range header {
@@ -192,67 +203,56 @@ func TestStripUpgradeWriter_ByteByByte(t *testing.T) {
 		require.NoError(t, err)
 	}
 	require.Empty(t, sink.Bytes())
+	require.Equal(t, []int{http.StatusOK}, outer.statuses)
 
 	_, err := w.Write([]byte("X"))
 	require.NoError(t, err)
 	require.Equal(t, "X", sink.String())
 }
 
-// TestStripUpgradeWriter_LongHeader verifies the stripper has no fixed
-// buffer cap: a Sec-WebSocket-Protocol response with many subprotocols
-// can exceed any kilobyte-sized buffer.
-func TestStripUpgradeWriter_LongHeader(t *testing.T) {
-	var sink bytes.Buffer
-	w := &stripUpgradeWriter{inner: &sink}
+// TestStripUpgradeWriter_LiftsSubprotocol verifies that the stripper
+// pulls Sec-WebSocket-Protocol out of the synthetic 101 preamble and
+// sets it on the outer h2 response before committing the 200. RFC 8441
+// §5.1 carries subprotocol negotiation in the response HEADERS frame,
+// so any client that selects subprotocols (kube exec, conn upgrade)
+// depends on this translation.
+func TestStripUpgradeWriter_LiftsSubprotocol(t *testing.T) {
+	w, outer, sink := newTestStripper()
 
-	longProtos := strings.Repeat("subproto-x,", 1000)
-	header := "HTTP/1.1 101 OK\r\nSec-WebSocket-Protocol: " +
-		longProtos + "last\r\n\r\nFRAMES"
-	_, err := w.Write([]byte(header))
+	preamble := "HTTP/1.1 101 OK\r\nUpgrade: websocket\r\n" +
+		"Connection: Upgrade\r\nSec-WebSocket-Accept: x\r\n" +
+		"Sec-WebSocket-Protocol: chat.v1\r\n\r\nFRAMES"
+
+	_, err := w.Write([]byte(preamble))
 	require.NoError(t, err)
+	require.Equal(t, "chat.v1", outer.header.Get("Sec-WebSocket-Protocol"),
+		"negotiated subprotocol must reach the outer h2 response")
+	require.Equal(t, []int{http.StatusOK}, outer.statuses)
 	require.Equal(t, "FRAMES", sink.String())
 }
 
-// TestStripUpgradeWriter_SelfOverlap covers the KMP-style restart in
-// the matcher: on input that contains "\r\r\n\r\n" the second '\r'
-// must not be discarded as a plain mismatch byte, because it starts
-// the real terminator. A naive reset-to-zero matcher would skip past
-// it and miss the terminator.
-func TestStripUpgradeWriter_SelfOverlap(t *testing.T) {
-	var sink bytes.Buffer
-	w := &stripUpgradeWriter{inner: &sink}
+// TestStripUpgradeWriter_NoSubprotocol verifies the bridge does not
+// invent a subprotocol when the upgrader did not select one. The
+// outer response gets an empty Sec-WebSocket-Protocol header.
+func TestStripUpgradeWriter_NoSubprotocol(t *testing.T) {
+	w, outer, _ := newTestStripper()
 
-	header := "HTTP/1.1 101 OK\r\nX-Stray-CR: \r\r\n\r\nFRAMES"
-	_, err := w.Write([]byte(header))
+	preamble := "HTTP/1.1 101 OK\r\nA: b\r\n\r\nFRAMES"
+	_, err := w.Write([]byte(preamble))
 	require.NoError(t, err)
-	require.Equal(t, "FRAMES", sink.String())
+	require.Empty(t, outer.header.Get("Sec-WebSocket-Protocol"))
+	require.Equal(t, []int{http.StatusOK}, outer.statuses)
 }
 
-// TestNextScanState exhausts the three transitions of the matcher
-// (match-byte, restart-on-prefix, full-reset) so a regression on any
-// branch surfaces independently of the integration cases above.
-func TestNextScanState(t *testing.T) {
-	tests := []struct {
-		name    string
-		scanned int
-		b       byte
-		want    int
-	}{
-		{name: "match first \\r", scanned: 0, b: '\r', want: 1},
-		{name: "match \\n after \\r", scanned: 1, b: '\n', want: 2},
-		{name: "match second \\r", scanned: 2, b: '\r', want: 3},
-		{name: "match final \\n", scanned: 3, b: '\n', want: 4},
-		{name: "mismatch at start", scanned: 0, b: 'a', want: 0},
-		{name: "mismatch after \\r, byte is \\r (self-overlap)", scanned: 1, b: '\r', want: 1},
-		{name: "mismatch after \\r\\n\\r, byte is \\r (self-overlap)", scanned: 3, b: '\r', want: 1},
-		{name: "mismatch after \\r\\n, byte is unrelated", scanned: 2, b: 'a', want: 0},
-		{name: "mismatch after \\r\\n\\r, byte is unrelated", scanned: 3, b: 'a', want: 0},
-	}
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			require.Equal(t, tc.want, nextScanState(tc.scanned, tc.b))
-		})
-	}
+// TestStripUpgradeWriter_PreambleSizeCap rejects upgrader output that
+// exceeds maxUpgradePreambleBytes. A buggy or malicious upstream
+// cannot pin per-stream memory by withholding the "\r\n\r\n"
+// terminator forever.
+func TestStripUpgradeWriter_PreambleSizeCap(t *testing.T) {
+	w, _, _ := newTestStripper()
+	huge := bytes.Repeat([]byte("X"), maxUpgradePreambleBytes+1)
+	_, err := w.Write(huge)
+	require.Error(t, err)
 }
 
 func TestCanonicalSet(t *testing.T) {
@@ -310,8 +310,9 @@ func TestFlushWriter(t *testing.T) {
 
 // TestServe_FailsClosedWhenHandlerDoesNotHijack verifies that an inner
 // handler that returns without hijacking has its writes silenced and
-// its body closed. This protects the h2 stream from being addressable
-// as an opaque WebSocket payload echo by non-WebSocket routes.
+// its body closed. No 200 is committed (the bridge defers commit to
+// stripUpgradeWriter), so the outer response reaches the client as 404
+// rather than a truncated tunnel.
 func TestServe_FailsClosedWhenHandlerDoesNotHijack(t *testing.T) {
 	body := &closableBuffer{r: strings.NewReader("client frames")}
 	req := httptest.NewRequest(http.MethodConnect, "/", body)
@@ -327,8 +328,8 @@ func TestServe_FailsClosedWhenHandlerDoesNotHijack(t *testing.T) {
 	serve(rec, req, inner, nil)
 
 	require.True(t, body.closed.Load(), "request body must be closed")
-	require.Equal(t, []int{http.StatusOK}, rec.statuses,
-		"only the bridge's 200 reaches the writer; the inner handler's WriteHeader is gated")
+	require.Equal(t, []int{http.StatusNotFound}, rec.statuses,
+		"no-hijack path commits 404; the inner handler's WriteHeader is gated")
 	require.Empty(t, rec.body.Bytes(),
 		"handler bytes must not leak onto the h2 stream as opaque payload")
 }

--- a/lib/httplib/h2websocket/h2websocket_test.go
+++ b/lib/httplib/h2websocket/h2websocket_test.go
@@ -21,9 +21,11 @@ package h2websocket
 import (
 	"bytes"
 	"io"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync/atomic"
 	"testing"
 
 	"github.com/gorilla/websocket"
@@ -31,9 +33,7 @@ import (
 )
 
 // TestWrap_PassthroughNonWebSocket verifies that non-WebSocket requests
-// flow through unmodified. Pre-fix failure mode: if Wrap rewrote every
-// request, this test would observe r.Method == "GET" but with the
-// synthetic Upgrade headers planted on it.
+// flow through the wrapper unmodified.
 func TestWrap_PassthroughNonWebSocket(t *testing.T) {
 	var seen *http.Request
 	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -56,9 +56,6 @@ func TestWrap_PassthroughNonWebSocket(t *testing.T) {
 
 // TestWrap_PassthroughH1WebSocket verifies that an HTTP/1.1 WebSocket
 // Upgrade is not rewritten and the inner gorilla.Upgrader handles it.
-// Pre-fix failure mode: a bug in isH2WebSocketConnect that returned true
-// for h1 would route the request through the synthetic path and gorilla
-// would see headers it has already received, double-stuffed.
 func TestWrap_PassthroughH1WebSocket(t *testing.T) {
 	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		up := websocket.Upgrader{}
@@ -71,9 +68,10 @@ func TestWrap_PassthroughH1WebSocket(t *testing.T) {
 	defer srv.Close()
 
 	wsURL := "ws" + strings.TrimPrefix(srv.URL, "http")
-	ws, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
+	ws, resp, err := websocket.DefaultDialer.Dial(wsURL, nil)
 	require.NoError(t, err)
 	defer ws.Close()
+	defer resp.Body.Close()
 
 	typ, payload, err := ws.ReadMessage()
 	require.NoError(t, err)
@@ -81,12 +79,41 @@ func TestWrap_PassthroughH1WebSocket(t *testing.T) {
 	require.Equal(t, []byte("hi"), payload)
 }
 
+// TestIsH2WebSocketConnect covers the gate that decides whether to
+// route a request through the bridge. Non-WS extended CONNECTs
+// (:protocol=bytes, :protocol=connect-udp) and h2 GET requests must
+// not be rewritten.
+func TestIsH2WebSocketConnect(t *testing.T) {
+	tests := []struct {
+		name     string
+		method   string
+		major    int
+		protocol string
+		want     bool
+	}{
+		{name: "h2 CONNECT websocket", method: http.MethodConnect, major: 2, protocol: "websocket", want: true},
+		{name: "h2 CONNECT bytes", method: http.MethodConnect, major: 2, protocol: "bytes", want: false},
+		{name: "h2 CONNECT connect-udp", method: http.MethodConnect, major: 2, protocol: "connect-udp", want: false},
+		{name: "h2 CONNECT no protocol", method: http.MethodConnect, major: 2, protocol: "", want: false},
+		{name: "h2 GET websocket", method: http.MethodGet, major: 2, protocol: "websocket", want: false},
+		{name: "h1 CONNECT websocket", method: http.MethodConnect, major: 1, protocol: "websocket", want: false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest(tc.method, "/ws", nil)
+			req.ProtoMajor = tc.major
+			if tc.protocol != "" {
+				req.Header.Set(":protocol", tc.protocol)
+			}
+			require.Equal(t, tc.want, isH2WebSocketConnect(req))
+		})
+	}
+}
+
 // TestRewriteAsH1Upgrade verifies the request rewrite: CONNECT becomes
 // GET, the :protocol pseudo-header is dropped, Upgrade/Connection
-// headers are set, Sec-WebSocket-* defaults are synthesised when
-// missing, and reserved headers are stripped. Pre-fix failure: any
-// missing piece prevents gorilla.Upgrader.Upgrade from accepting the
-// request inside the inner handler.
+// headers are set, Sec-WebSocket-* defaults are synthesized when
+// missing, and reserved headers are stripped.
 func TestRewriteAsH1Upgrade(t *testing.T) {
 	req := httptest.NewRequest(http.MethodConnect, "/ws", nil)
 	req.ProtoMajor = 2
@@ -94,9 +121,7 @@ func TestRewriteAsH1Upgrade(t *testing.T) {
 	req.Header.Set("X-Teleport-Aws-Assumed-Role", "evil")
 	req.Header.Set("Authorization", "Bearer keep-me")
 
-	got, err := rewriteAsH1Upgrade(req, canonicalSet([]string{
-		"X-Teleport-Aws-Assumed-Role",
-	}))
+	got, err := rewriteAsH1Upgrade(req, canonicalSet([]string{"X-Teleport-Aws-Assumed-Role"}))
 	require.NoError(t, err)
 
 	require.Equal(t, http.MethodGet, got.Method)
@@ -112,11 +137,25 @@ func TestRewriteAsH1Upgrade(t *testing.T) {
 		"non-reserved client header must survive")
 }
 
+// TestRewriteAsH1Upgrade_PreservesClientWebsocketHeaders verifies that
+// a client-supplied Sec-WebSocket-Key and Sec-WebSocket-Version survive
+// the rewrite verbatim instead of being overwritten by the defaults.
+func TestRewriteAsH1Upgrade_PreservesClientWebsocketHeaders(t *testing.T) {
+	req := httptest.NewRequest(http.MethodConnect, "/ws", nil)
+	req.ProtoMajor = 2
+	req.Header.Set(":protocol", "websocket")
+	req.Header.Set("Sec-WebSocket-Key", "dGhlIHNhbXBsZSBub25jZQ==")
+	req.Header.Set("Sec-WebSocket-Version", "8")
+
+	got, err := rewriteAsH1Upgrade(req, nil)
+	require.NoError(t, err)
+	require.Equal(t, "dGhlIHNhbXBsZSBub25jZQ==", got.Header.Get("Sec-WebSocket-Key"))
+	require.Equal(t, "8", got.Header.Get("Sec-WebSocket-Version"))
+}
+
 // TestStripUpgradeWriter_DropsLeadingHeader verifies the incremental
 // stripper discards the synthetic "HTTP/1.1 101 ..." header and
-// forwards everything after the "\r\n\r\n" terminator. Pre-fix failure:
-// without the stripper, the 101 bytes flow onto the h2 stream and
-// confuse the browser's WebSocket frame parser.
+// forwards everything after the "\r\n\r\n" terminator.
 func TestStripUpgradeWriter_DropsLeadingHeader(t *testing.T) {
 	var sink bytes.Buffer
 	w := &stripUpgradeWriter{inner: &sink}
@@ -136,8 +175,7 @@ func TestStripUpgradeWriter_DropsLeadingHeader(t *testing.T) {
 
 // TestStripUpgradeWriter_CoalescedWrite verifies the stripper handles a
 // Write that contains both the trailing "\r\n\r\n" and the first frame
-// bytes in one call. Pre-fix failure: a buffer-then-flush stripper that
-// only forwards on a *separate* Write call would drop the inline frame.
+// bytes in one call.
 func TestStripUpgradeWriter_CoalescedWrite(t *testing.T) {
 	var sink bytes.Buffer
 	w := &stripUpgradeWriter{inner: &sink}
@@ -150,8 +188,6 @@ func TestStripUpgradeWriter_CoalescedWrite(t *testing.T) {
 
 // TestStripUpgradeWriter_ByteByByte verifies the incremental parser
 // when the terminator is split across Write calls one byte at a time.
-// Pre-fix failure: a stripper that scans only within a single Write
-// would miss a "\r\n\r\n" that straddles two Writes.
 func TestStripUpgradeWriter_ByteByByte(t *testing.T) {
 	var sink bytes.Buffer
 	w := &stripUpgradeWriter{inner: &sink}
@@ -170,9 +206,7 @@ func TestStripUpgradeWriter_ByteByByte(t *testing.T) {
 
 // TestStripUpgradeWriter_LongHeader verifies the stripper has no fixed
 // buffer cap: a Sec-WebSocket-Protocol response with many subprotocols
-// can exceed any kilobyte-sized buffer. Pre-fix failure mode (against
-// an earlier draft that used a 4 KiB buffer): the test would error with
-// "buffer exceeded" before the terminator was reached.
+// can exceed any kilobyte-sized buffer.
 func TestStripUpgradeWriter_LongHeader(t *testing.T) {
 	var sink bytes.Buffer
 	w := &stripUpgradeWriter{inner: &sink}
@@ -185,22 +219,119 @@ func TestStripUpgradeWriter_LongHeader(t *testing.T) {
 	require.Equal(t, "FRAMES", sink.String())
 }
 
+// TestStripUpgradeWriter_SelfOverlap covers the KMP-style restart in
+// the matcher: on input that contains "\r\r\n\r\n" the second '\r'
+// must not be discarded as a plain mismatch byte, because it starts
+// the real terminator. A naive reset-to-zero matcher would skip past
+// it and miss the terminator.
+func TestStripUpgradeWriter_SelfOverlap(t *testing.T) {
+	var sink bytes.Buffer
+	w := &stripUpgradeWriter{inner: &sink}
+
+	header := "HTTP/1.1 101 OK\r\nX-Stray-CR: \r\r\n\r\nFRAMES"
+	_, err := w.Write([]byte(header))
+	require.NoError(t, err)
+	require.Equal(t, "FRAMES", sink.String())
+}
+
 // TestCanonicalSet verifies the reserved-header lookup is
-// case-insensitive in the way http.Header.Del expects.
+// case-insensitive in the way http.Header.Del expects, including
+// pathological mixed-case inputs.
 func TestCanonicalSet(t *testing.T) {
-	got := canonicalSet([]string{"x-teleport-foo", "X-Teleport-Bar"})
-	_, ok := got["X-Teleport-Foo"]
-	require.True(t, ok)
-	_, ok = got["X-Teleport-Bar"]
-	require.True(t, ok)
+	got := canonicalSet([]string{"X-TELEPORT-foo", "x-teleport-BAR"})
+	require.True(t, got["X-Teleport-Foo"])
+	require.True(t, got["X-Teleport-Bar"])
 	require.Nil(t, canonicalSet(nil))
 }
 
-// TestH2StreamConn_CloseIdempotent verifies double-close is a no-op.
-// Pre-fix failure: re-closing the request body twice would panic on
-// some HTTP/2 stream implementations.
+// TestH2StreamConn_CloseIdempotent verifies double-close is a no-op
+// and that Read after Close returns net.ErrClosed.
 func TestH2StreamConn_CloseIdempotent(t *testing.T) {
 	c := &h2StreamConn{r: io.NopCloser(strings.NewReader(""))}
 	require.NoError(t, c.Close())
 	require.NoError(t, c.Close())
+
+	_, err := c.Read(make([]byte, 4))
+	require.ErrorIs(t, err, net.ErrClosed)
 }
+
+// TestServe_FailsClosedWhenHandlerDoesNotHijack verifies that an inner
+// handler that returns without hijacking has its writes silenced and
+// its body closed. This protects the h2 stream from being addressable
+// as an opaque WebSocket payload echo by non-WebSocket routes.
+func TestServe_FailsClosedWhenHandlerDoesNotHijack(t *testing.T) {
+	body := &closableBuffer{Reader: strings.NewReader("client frames")}
+	req := httptest.NewRequest(http.MethodConnect, "/", body)
+	req.ProtoMajor = 2
+	req.Header.Set(":protocol", "websocket")
+
+	rec := &duplexWriter{header: http.Header{}}
+	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Simulate a non-WebSocket route that writes a JSON body.
+		_, _ = w.Write([]byte(`{"error":"not a websocket route"}`))
+	})
+
+	serve(rec, req, inner, nil)
+
+	require.True(t, body.closed.Load(), "request body must be closed")
+	require.Equal(t, http.StatusOK, rec.status, "status is committed at the tunnel open")
+	require.Empty(t, rec.body.Bytes(),
+		"handler bytes must not leak onto the h2 stream as opaque payload")
+}
+
+// TestServe_FullDuplexUnavailable verifies that serve fails with 500
+// and does not dispatch the inner handler when EnableFullDuplex
+// reports the writer cannot stream both directions.
+func TestServe_FullDuplexUnavailable(t *testing.T) {
+	req := httptest.NewRequest(http.MethodConnect, "/", nil)
+	req.ProtoMajor = 2
+	req.Header.Set(":protocol", "websocket")
+
+	rec := httptest.NewRecorder()
+	called := false
+	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+	})
+
+	serve(rec, req, inner, nil)
+
+	require.Equal(t, http.StatusInternalServerError, rec.Code)
+	require.False(t, called, "inner handler must not run when full duplex is unavailable")
+}
+
+// closableBuffer is a request body that tracks Close calls.
+type closableBuffer struct {
+	io.Reader
+	closed atomic.Bool
+}
+
+func (b *closableBuffer) Close() error {
+	b.closed.Store(true)
+	return nil
+}
+
+// duplexWriter is a minimal http.ResponseWriter that satisfies the
+// full-duplex and flush hooks the bridge expects. It lets tests run
+// serve end-to-end without standing up a real HTTP/2 server.
+type duplexWriter struct {
+	header http.Header
+	body   bytes.Buffer
+	status int
+}
+
+func (d *duplexWriter) Header() http.Header { return d.header }
+func (d *duplexWriter) WriteHeader(code int) {
+	if d.status == 0 {
+		d.status = code
+	}
+}
+
+func (d *duplexWriter) Write(p []byte) (int, error) {
+	if d.status == 0 {
+		d.status = http.StatusOK
+	}
+	return d.body.Write(p)
+}
+
+func (d *duplexWriter) EnableFullDuplex() error { return nil }
+func (d *duplexWriter) Flush()                  {}

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -5579,12 +5579,11 @@ func (process *TeleportProcess) initProxyEndpoint(conn *Connector) error {
 			return trace.Wrap(err)
 		}
 
-		// h2websocket.Wrap sits outside the middleware chain so that XFF,
-		// tracing, and the limiter observe the synthetic HTTP/1.1 request
-		// the bridge produces from an RFC 8441 extended CONNECT. Without
-		// the wrap, the inner middlewares gate on http.Hijacker, which an
-		// HTTP/2 ResponseWriter does not implement, and degrade silently
-		// on HTTP/2 WebSocket traffic.
+		// h2websocket.Wrap sits outside the middleware chain because the
+		// inner middlewares gate on http.Hijacker, which an HTTP/2
+		// ResponseWriter does not implement. Wrapping outside also lets
+		// XFF, tracing, and the limiter observe the synthetic HTTP/1.1
+		// request the bridge produces from an RFC 8441 extended CONNECT.
 		webChain := utils.ChainHTTPMiddlewares(
 			webHandler,
 			limiter.MakeMiddleware(proxyLimiter),
@@ -5593,8 +5592,14 @@ func (process *TeleportProcess) initProxyEndpoint(conn *Connector) error {
 		)
 		webServer, err = web.NewServer(web.ServerConfig{
 			Server: &http.Server{
+				// ReservedHeaders intentionally excludes the generic
+				// X-Forwarded-* set because the XFF middleware further
+				// down the chain needs to read them to resolve the real
+				// client address. Stripping them here would point
+				// clientSrcAddr at the load balancer for h2 traffic
+				// while h1 traffic on the same listener still resolves.
 				Handler: h2websocket.Wrap(webChain, h2websocket.Options{
-					ReservedHeaders: appcommon.ReservedHeaders,
+					ReservedHeaders: appcommon.ReservedTeleportIdentityHeaders,
 				}),
 				// Note: read/write timeouts *should not* be set here because it
 				// will break some application access use-cases.
@@ -6331,6 +6336,11 @@ func (process *TeleportProcess) initMinimalReverseTunnel(listeners *proxyListene
 
 	log := process.logger.With(teleport.ComponentKey, teleport.Component(teleport.ComponentReverseTunnelServer, process.id))
 
+	// The minimal reverse-tunnel listener intentionally skips
+	// h2websocket.Wrap: it only serves /webapi/find and
+	// /webapi/host/credentials, neither of which negotiates WebSocket.
+	// Any future WebSocket route added here must add the wrap and the
+	// matching ReservedTeleportIdentityHeaders list.
 	minimalWebServer, err := web.NewServer(web.ServerConfig{
 		Server: &http.Server{
 			Handler:           httplib.MakeTracingHandler(minimalProxyLimiter, teleport.ComponentProxy),

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -138,6 +138,7 @@ import (
 	"github.com/gravitational/teleport/lib/events/s3sessions"
 	"github.com/gravitational/teleport/lib/healthcheck"
 	"github.com/gravitational/teleport/lib/httplib"
+	"github.com/gravitational/teleport/lib/httplib/h2websocket"
 	"github.com/gravitational/teleport/lib/integrations/awsoidc"
 	"github.com/gravitational/teleport/lib/integrations/awsra"
 	"github.com/gravitational/teleport/lib/integrations/externalauditstorage"
@@ -172,6 +173,7 @@ import (
 	alpnproxyauth "github.com/gravitational/teleport/lib/srv/alpnproxy/auth"
 	alpncommon "github.com/gravitational/teleport/lib/srv/alpnproxy/common"
 	"github.com/gravitational/teleport/lib/srv/app"
+	appcommon "github.com/gravitational/teleport/lib/srv/app/common"
 	"github.com/gravitational/teleport/lib/srv/db"
 	"github.com/gravitational/teleport/lib/srv/desktop"
 	"github.com/gravitational/teleport/lib/srv/ingress"
@@ -5577,14 +5579,23 @@ func (process *TeleportProcess) initProxyEndpoint(conn *Connector) error {
 			return trace.Wrap(err)
 		}
 
+		// h2websocket.Wrap sits outside the middleware chain so that XFF,
+		// tracing, and the limiter observe the synthetic HTTP/1.1 request
+		// the bridge produces from an RFC 8441 extended CONNECT. Without
+		// the wrap, the inner middlewares gate on http.Hijacker, which an
+		// HTTP/2 ResponseWriter does not implement, and degrade silently
+		// on HTTP/2 WebSocket traffic.
+		webChain := utils.ChainHTTPMiddlewares(
+			webHandler,
+			limiter.MakeMiddleware(proxyLimiter),
+			httplib.MakeTracingMiddleware(teleport.ComponentProxy),
+			makeXForwardedForMiddleware(cfg),
+		)
 		webServer, err = web.NewServer(web.ServerConfig{
 			Server: &http.Server{
-				Handler: utils.ChainHTTPMiddlewares(
-					webHandler,
-					limiter.MakeMiddleware(proxyLimiter),
-					httplib.MakeTracingMiddleware(teleport.ComponentProxy),
-					makeXForwardedForMiddleware(cfg),
-				),
+				Handler: h2websocket.Wrap(webChain, h2websocket.Options{
+					ReservedHeaders: appcommon.ReservedHeaders,
+				}),
 				// Note: read/write timeouts *should not* be set here because it
 				// will break some application access use-cases.
 				ReadHeaderTimeout: defaults.ReadHeadersTimeout,

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -5592,12 +5592,9 @@ func (process *TeleportProcess) initProxyEndpoint(conn *Connector) error {
 		)
 		webServer, err = web.NewServer(web.ServerConfig{
 			Server: &http.Server{
-				// ReservedHeaders intentionally excludes the generic
-				// X-Forwarded-* set because the XFF middleware further
-				// down the chain needs to read them to resolve the real
-				// client address. Stripping them here would point
-				// clientSrcAddr at the load balancer for h2 traffic
-				// while h1 traffic on the same listener still resolves.
+				// ReservedTeleportIdentityHeaders excludes generic
+				// X-Forwarded-* so the XFF middleware further down the
+				// chain still sees them.
 				Handler: h2websocket.Wrap(webChain, h2websocket.Options{
 					ReservedHeaders: appcommon.ReservedTeleportIdentityHeaders,
 				}),

--- a/lib/srv/app/common/header.go
+++ b/lib/srv/app/common/header.go
@@ -21,6 +21,7 @@ package common
 import (
 	"errors"
 	"net/http"
+	"slices"
 
 	"github.com/gravitational/trace"
 
@@ -75,9 +76,7 @@ var ReservedTeleportIdentityHeaders = []string{
 // ReservedHeaders is a list of headers injected by Teleport (identity
 // headers plus the generic X-Forwarded-* set handled by the
 // reverse-proxy XFF stack).
-var ReservedHeaders = append(append([]string{}, ReservedTeleportIdentityHeaders...),
-	reverseproxy.XHeaders...,
-)
+var ReservedHeaders = slices.Concat(ReservedTeleportIdentityHeaders, reverseproxy.XHeaders)
 
 // IsReservedHeader returns true if the provided header is one of headers
 // injected by Teleport.

--- a/lib/srv/app/common/header.go
+++ b/lib/srv/app/common/header.go
@@ -57,15 +57,25 @@ const (
 	TeleportAWSAssumedRoleAuthorization = "X-Teleport-Aws-Assumed-Role-Authorization"
 )
 
-// ReservedHeaders is a list of headers injected by Teleport.
-var ReservedHeaders = append([]string{
+// ReservedTeleportIdentityHeaders is the subset of ReservedHeaders that
+// names Teleport-prefixed identity headers and X-Forwarded-Ssl. The
+// generic X-Forwarded-* headers are not included so layers running
+// outside the XFF middleware (e.g. h2websocket.Wrap) can strip
+// Teleport identity headers without blinding the middleware to the
+// real client address.
+var ReservedTeleportIdentityHeaders = []string{
 	teleport.AppJWTHeader,
 	XForwardedSSL,
 	TeleportAPIErrorHeader,
 	TeleportAPIInfoHeader,
 	TeleportAWSAssumedRole,
 	TeleportAWSAssumedRoleAuthorization,
-},
+}
+
+// ReservedHeaders is a list of headers injected by Teleport (identity
+// headers plus the generic X-Forwarded-* set handled by the
+// reverse-proxy XFF stack).
+var ReservedHeaders = append(append([]string{}, ReservedTeleportIdentityHeaders...),
 	reverseproxy.XHeaders...,
 )
 

--- a/tool/teleport/common/h2xconnect.go
+++ b/tool/teleport/common/h2xconnect.go
@@ -79,10 +79,21 @@ func init() {
 			"teleport: cannot determine executable path for GODEBUG re-exec: %v\n", err)
 		return
 	}
-	// Build a fresh env slice for the replacement process. Mutating the
-	// current process's GODEBUG via os.Setenv would leak the change to
-	// any child the original process spawns if the exec fails.
-	env := append(os.Environ(), "GODEBUG="+updated)
+	// Build a fresh env slice for the replacement process: filter out
+	// any existing GODEBUG= entry and append the updated value. Linux
+	// keeps the first occurrence on duplicates, so a plain append would
+	// be ignored when the operator already has GODEBUG set for other
+	// tuning. Mutating the current process via os.Setenv would also
+	// leak the change to any child spawned by the original if the exec
+	// fails.
+	env := make([]string, 0, len(os.Environ())+1)
+	for _, e := range os.Environ() {
+		if strings.HasPrefix(e, "GODEBUG=") {
+			continue
+		}
+		env = append(env, e)
+	}
+	env = append(env, "GODEBUG="+updated)
 	// Keep argv[0] consistent with the resolved executable path so the
 	// replacement process's os.Args[0] and os.Executable() agree.
 	argv := append([]string{exe}, os.Args[1:]...)

--- a/tool/teleport/common/h2xconnect.go
+++ b/tool/teleport/common/h2xconnect.go
@@ -23,6 +23,7 @@ package common
 import (
 	"fmt"
 	"os"
+	"slices"
 	"strings"
 	"syscall"
 )
@@ -104,21 +105,18 @@ func init() {
 }
 
 // needsHTTP2XConnect reports whether the invocation will run the proxy
-// web listener and therefore needs http2xconnect=1 in GODEBUG. Only
-// "teleport start" runs the proxy. "teleport app start" and
-// "teleport db start" start agents, not the proxy, so they fail the
-// check on the first non-flag token.
+// web listener and therefore needs http2xconnect=1 in GODEBUG. The
+// proxy runs under "teleport start"; "teleport app start" and
+// "teleport db start" start agents that don't need the GODEBUG.
 //
-// Leading top-level flags are skipped because kingpin accepts flags
-// before the subcommand (e.g. "teleport --debug start ...").
+// The check is intentionally permissive: any invocation that includes
+// "start" anywhere in argv re-execs. Kingpin v2 allows flags to be
+// placed before or after the subcommand and some take values, so a
+// first-non-flag-token scan can mis-classify "teleport --config x
+// start" as not-start. False positives only cost a single execve(2);
+// false negatives leave http2xconnect disabled on the proxy.
 func needsHTTP2XConnect(args []string) bool {
-	for _, a := range args[1:] {
-		if strings.HasPrefix(a, "-") {
-			continue
-		}
-		return a == "start"
-	}
-	return false
+	return slices.Contains(args[1:], "start")
 }
 
 // godebugHasKey reports whether the comma-separated GODEBUG value

--- a/tool/teleport/common/h2xconnect.go
+++ b/tool/teleport/common/h2xconnect.go
@@ -36,6 +36,12 @@ import (
 // regular init() is too late. The only ways to influence it are to set
 // it in the environment of the parent process or to re-exec.
 //
+// The shim only fires for "teleport start" because that is the only
+// subcommand that runs the proxy web listener. Short-lived CLI
+// subcommands (version, configure, status, scp, the hidden reexec
+// children) skip the re-exec to avoid paying an extra execve(2) on
+// every invocation.
+//
 // This init prepends http2xconnect=1 to GODEBUG when missing, then
 // re-execs the current binary via syscall.Exec. The replacement process
 // has the env var in place before net/http's init runs. On success
@@ -46,6 +52,10 @@ import (
 // that will replace this shim.
 func init() {
 	const want = "http2xconnect=1"
+
+	if !needsHTTP2XConnect(os.Args) {
+		return
+	}
 
 	existing := os.Getenv("GODEBUG")
 	if godebugContains(existing, want) {
@@ -72,6 +82,18 @@ func init() {
 		fmt.Fprintf(os.Stderr,
 			"teleport: GODEBUG re-exec failed: %v\n", err)
 	}
+}
+
+// needsHTTP2XConnect reports whether the invocation will run the proxy
+// web listener and therefore needs http2xconnect=1 in GODEBUG. Only
+// "teleport start" runs the proxy; all other subcommands (including
+// "teleport app start" and "teleport db start", which start agents,
+// not the proxy) skip the re-exec.
+func needsHTTP2XConnect(args []string) bool {
+	if len(args) < 2 {
+		return false
+	}
+	return args[1] == "start"
 }
 
 // godebugContains reports whether the comma-separated GODEBUG value

--- a/tool/teleport/common/h2xconnect.go
+++ b/tool/teleport/common/h2xconnect.go
@@ -37,13 +37,16 @@ import (
 // it in the environment of the parent process or to re-exec.
 //
 // The shim only fires for "teleport start" because that is the only
-// subcommand that runs the proxy web listener. Short-lived CLI
-// subcommands (version, configure, status, scp, the hidden reexec
-// children) skip the re-exec to avoid paying an extra execve(2) on
-// every invocation.
+// subcommand that runs the proxy web listener. Every other invocation
+// skips the re-exec so short-lived CLI subcommands do not pay an
+// extra execve(2).
 //
-// This init prepends http2xconnect=1 to GODEBUG when missing, then
-// re-execs the current binary via syscall.Exec. The replacement process
+// An operator-supplied http2xconnect= value (including http2xconnect=0
+// for incident rollback) is left intact. The shim only appends the
+// default when no http2xconnect= entry is already present in GODEBUG.
+//
+// On a re-exec, syscall.Exec replaces the process with the same
+// executable and arguments plus the updated GODEBUG. The replacement
 // has the env var in place before net/http's init runs. On success
 // syscall.Exec does not return; on failure the original process
 // continues without the feature.
@@ -51,25 +54,23 @@ import (
 // Track https://github.com/golang/go/issues/71128 for the public API
 // that will replace this shim.
 func init() {
-	const want = "http2xconnect=1"
+	const settingKey = "http2xconnect"
+	const defaultValue = settingKey + "=1"
 
 	if !needsHTTP2XConnect(os.Args) {
 		return
 	}
 
 	existing := os.Getenv("GODEBUG")
-	if godebugContains(existing, want) {
+	if godebugHasKey(existing, settingKey) {
+		// Operator already set http2xconnect explicitly (=0 to disable,
+		// =1 to confirm, or any other value). Honor it; no re-exec.
 		return
 	}
 
-	updated := want
+	updated := defaultValue
 	if existing != "" {
-		updated = existing + "," + want
-	}
-	if err := os.Setenv("GODEBUG", updated); err != nil {
-		fmt.Fprintf(os.Stderr,
-			"teleport: failed to set GODEBUG=%s: %v\n", want, err)
-		return
+		updated = existing + "," + defaultValue
 	}
 
 	exe, err := os.Executable()
@@ -78,7 +79,14 @@ func init() {
 			"teleport: cannot determine executable path for GODEBUG re-exec: %v\n", err)
 		return
 	}
-	if err := syscall.Exec(exe, os.Args, os.Environ()); err != nil {
+	// Build a fresh env slice for the replacement process. Mutating the
+	// current process's GODEBUG via os.Setenv would leak the change to
+	// any child the original process spawns if the exec fails.
+	env := append(os.Environ(), "GODEBUG="+updated)
+	// Keep argv[0] consistent with the resolved executable path so the
+	// replacement process's os.Args[0] and os.Executable() agree.
+	argv := append([]string{exe}, os.Args[1:]...)
+	if err := syscall.Exec(exe, argv, env); err != nil {
 		fmt.Fprintf(os.Stderr,
 			"teleport: GODEBUG re-exec failed: %v\n", err)
 	}
@@ -86,21 +94,30 @@ func init() {
 
 // needsHTTP2XConnect reports whether the invocation will run the proxy
 // web listener and therefore needs http2xconnect=1 in GODEBUG. Only
-// "teleport start" runs the proxy; all other subcommands (including
-// "teleport app start" and "teleport db start", which start agents,
-// not the proxy) skip the re-exec.
+// "teleport start" runs the proxy. "teleport app start" and
+// "teleport db start" start agents, not the proxy, so they fail the
+// check on the first non-flag token.
+//
+// Leading top-level flags are skipped because kingpin accepts flags
+// before the subcommand (e.g. "teleport --debug start ...").
 func needsHTTP2XConnect(args []string) bool {
-	if len(args) < 2 {
-		return false
+	for _, a := range args[1:] {
+		if strings.HasPrefix(a, "-") {
+			continue
+		}
+		return a == "start"
 	}
-	return args[1] == "start"
+	return false
 }
 
-// godebugContains reports whether the comma-separated GODEBUG value
-// already includes the given setting (exact match on a token).
-func godebugContains(godebug, setting string) bool {
+// godebugHasKey reports whether the comma-separated GODEBUG value
+// already contains an entry with the given key, regardless of value.
+// Honoring any explicit operator setting lets http2xconnect=0 disable
+// the feature during incident rollback.
+func godebugHasKey(godebug, key string) bool {
 	for _, tok := range strings.Split(godebug, ",") {
-		if strings.TrimSpace(tok) == setting {
+		name, _, _ := strings.Cut(strings.TrimSpace(tok), "=")
+		if name == key {
 			return true
 		}
 	}

--- a/tool/teleport/common/h2xconnect.go
+++ b/tool/teleport/common/h2xconnect.go
@@ -51,8 +51,9 @@ import (
 // syscall.Exec does not return; on failure the original process
 // continues without the feature.
 //
-// Track https://github.com/golang/go/issues/71128 for the public API
-// that will replace this shim.
+// Track https://github.com/golang/go/issues/53208 for the public API
+// (net/http HTTP2Config.EnableConnectProtocol) that will replace this
+// shim.
 func init() {
 	const settingKey = "http2xconnect"
 	const defaultValue = settingKey + "=1"

--- a/tool/teleport/common/h2xconnect.go
+++ b/tool/teleport/common/h2xconnect.go
@@ -23,7 +23,6 @@ package common
 import (
 	"fmt"
 	"os"
-	"slices"
 	"strings"
 	"syscall"
 )
@@ -106,17 +105,20 @@ func init() {
 
 // needsHTTP2XConnect reports whether the invocation will run the proxy
 // web listener and therefore needs http2xconnect=1 in GODEBUG. The
-// proxy runs under "teleport start"; "teleport app start" and
-// "teleport db start" start agents that don't need the GODEBUG.
+// proxy runs under "teleport start"; every other subcommand
+// ("teleport app start", "teleport db start", "version", "configure",
+// the hidden reexec children) skips the re-exec to avoid an extra
+// execve(2) per invocation.
 //
-// The check is intentionally permissive: any invocation that includes
-// "start" anywhere in argv re-execs. Kingpin v2 allows flags to be
-// placed before or after the subcommand and some take values, so a
-// first-non-flag-token scan can mis-classify "teleport --config x
-// start" as not-start. False positives only cost a single execve(2);
-// false negatives leave http2xconnect disabled on the proxy.
+// The check runs before kingpin parses argv. Teleport registers no
+// top-level flags besides --help / -h (which never pairs with start),
+// so the subcommand always sits at args[1] in real invocations. If a
+// future global value-taking flag lands (e.g. "teleport --log-file=x
+// start"), this gate must be updated alongside it; today the only
+// way "start" appears later in argv is if it is a flag value or a
+// scp filename, neither of which corresponds to running the proxy.
 func needsHTTP2XConnect(args []string) bool {
-	return slices.Contains(args[1:], "start")
+	return len(args) >= 2 && args[1] == "start"
 }
 
 // godebugHasKey reports whether the comma-separated GODEBUG value

--- a/tool/teleport/common/h2xconnect_init.go
+++ b/tool/teleport/common/h2xconnect_init.go
@@ -1,0 +1,86 @@
+//go:build !windows
+
+/*
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package common
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"syscall"
+)
+
+// init enables HTTP/2 extended CONNECT (RFC 8441) so that browsers can
+// open WebSockets over an HTTP/2 connection to the proxy's web listener.
+//
+// Go's net/http and golang.org/x/net/http2 gate extended CONNECT support
+// on the GODEBUG variable http2xconnect=1. The variable is read once at
+// stdlib init, before any user init function runs, so setting it from a
+// regular init() is too late. The only ways to influence it are to set
+// it in the environment of the parent process or to re-exec.
+//
+// This init prepends http2xconnect=1 to GODEBUG when missing, then
+// re-execs the current binary via syscall.Exec. The replacement process
+// has the env var in place before net/http's init runs. On success
+// syscall.Exec does not return; on failure the original process
+// continues without the feature.
+//
+// Track https://github.com/golang/go/issues/71128 for the public API
+// that will replace this shim.
+func init() {
+	const want = "http2xconnect=1"
+
+	existing := os.Getenv("GODEBUG")
+	if godebugContains(existing, want) {
+		return
+	}
+
+	updated := want
+	if existing != "" {
+		updated = existing + "," + want
+	}
+	if err := os.Setenv("GODEBUG", updated); err != nil {
+		fmt.Fprintf(os.Stderr,
+			"teleport: failed to set GODEBUG=%s: %v\n", want, err)
+		return
+	}
+
+	exe, err := os.Executable()
+	if err != nil {
+		fmt.Fprintf(os.Stderr,
+			"teleport: cannot determine executable path for GODEBUG re-exec: %v\n", err)
+		return
+	}
+	if err := syscall.Exec(exe, os.Args, os.Environ()); err != nil {
+		fmt.Fprintf(os.Stderr,
+			"teleport: GODEBUG re-exec failed: %v\n", err)
+	}
+}
+
+// godebugContains reports whether the comma-separated GODEBUG value
+// already includes the given setting (exact match on a token).
+func godebugContains(godebug, setting string) bool {
+	for _, tok := range strings.Split(godebug, ",") {
+		if strings.TrimSpace(tok) == setting {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
Add an `h2websocket.Wrap` middleware that translates RFC 8441 (Bootstrapping WebSockets with HTTP/2) extended `CONNECT` requests into synthetic HTTP/1.1 `Upgrade` requests before they reach any existing `gorilla.Upgrade` call site. No fork of `gorilla/websocket`. No per-handler rewrites. The middleware sits outside the proxy's `ChainHTTPMiddlewares` chain so that XFF, tracing, and the limiter observe the synthetic HTTP/1.1 request rather than the raw HTTP/2 one.

A companion `tool/teleport/common/h2xconnect.go` shim prepends `http2xconnect=1` to `GODEBUG` and re-execs the binary when the variable is missing, so Go's bundled `net/http` and `golang.org/x/net/http2` honour the opt-in. The public `http.Server` API is not yet available (tracked in [golang/go#71128](https://github.com/golang/go/issues/71128)), so the re-exec shim is the only path on Go 1.25 / 1.26. The shim only fires for `teleport start`; short-lived subcommands (`version`, `configure`, `status`, the hidden reexec children) skip it. `tctl` and `tsh` keep their existing init paths.

This PR is **inert today**. Chrome and Firefox only send extended `CONNECT` over an HTTP/2 connection, and the proxy still advertises `http/1.1` ahead of `h2` in ALPN. Flipping ALPN is a separate change that activates the bridge.

The same wrap is needed for two more listeners that host gorilla call sites: the reverse-proxy forwarder in `lib/httplib/reverseproxy` (app access, MCP) and the kube proxy in `lib/kube/proxy/server.go`. Those wire-ins land in follow-up commits on this branch or in sibling PRs.

The alternative explored in [#66320](https://github.com/gravitational/teleport/pull/66320) uses a `replace` directive pointing to a personal fork of `gorilla/websocket`. The middleware path here is functionally equivalent for the browser-facing side, has no external dependency, and is upstreamable. The reverse-proxy bridge file in that PR is complementary and can land on top of this one.

Changelog: Add RFC 8441 (HTTP/2 extended CONNECT) WebSocket bridge; gate activation behind a follow-up ALPN change.

## Manual Test Plan

### Test Environment
- macOS proxy + Chrome 130, Firefox 130, Safari 17.
- Local Teleport with self-signed cert via mkcert at `t.tp`.

### Test Cases

These run live once ALPN advertises HTTP/2 first (separate PR).

- [ ] Chrome sends extended `CONNECT` for the web terminal, frames flow both ways, keystroke latency feels normal.
- [ ] Firefox sends extended `CONNECT` for the web terminal, frames flow both ways.
- [ ] Safari falls back to HTTP/1.1 and uses the existing path unchanged.
- [ ] `tsh login` still negotiates HTTP/1.1 against the same proxy.
- [ ] `curl --http1.1` still negotiates HTTP/1.1 against the same proxy.
- [ ] A planted `X-Teleport-Aws-Assumed-Role` on an extended `CONNECT` request does not reach an app-access backend (reserved-header stripping regression).
- [ ] `teleport start` re-execs once at startup when `GODEBUG` is empty, and not at all when `GODEBUG=http2xconnect=1` is already set or for non-`start` subcommands (`version`, `configure`, `status`).

Unit tests pass locally (`go test ./lib/httplib/h2websocket/`).
