### PR TITLE
Update kube agent updater pull credentials

### DIFF
--- a/docs/pages/includes/helm-reference/zz_generated.teleport-kube-agent.mdx
+++ b/docs/pages/includes/helm-reference/zz_generated.teleport-kube-agent.mdx
@@ -857,7 +857,7 @@ get the image pull credentials used to validate the image signature.
 This is not required when pulling images from official public Teleport
 registries (chart's default).
 
-Supported values are `amazon`, `google`, `docker` and `none`.
+Supported values are `aws`, `google`, `docker` and `none`.
 
 ### `updater.extraArgs`
 

--- a/examples/chart/teleport-kube-agent/tests/updater_deployment_test.yaml
+++ b/examples/chart/teleport-kube-agent/tests/updater_deployment_test.yaml
@@ -344,11 +344,11 @@ tests:
       - ../.lint/updater.yaml
     set:
       updater:
-        pullCredentials: "amazon"
+        pullCredentials: "aws"
     asserts:
       - contains:
           path: spec.template.spec.containers[0].args
-          content: "--pull-credentials=amazon"
+          content: "--pull-credentials=aws"
 
   - it: sets extraVolumes when specified
     documentIndex: 0

--- a/examples/chart/teleport-kube-agent/values.yaml
+++ b/examples/chart/teleport-kube-agent/values.yaml
@@ -698,7 +698,7 @@ updater:
   # This is not required when pulling images from official public Teleport
   # registries (chart's default).
   #
-  # Supported values are `amazon`, `google`, `docker` and `none`.
+  # Supported values are `aws`, `google`, `docker` and `none`.
   pullCredentials: ""
 
   # updater.extraArgs(list) -- contains additional arguments to pass to the updater


### PR DESCRIPTION
Fixes https://github.com/gravitational/teleport/issues/66613

The valid value is `aws`, not `amazon`.


## Manual Test Plan
### Test Environment
  Dev env
### Test Cases
- [x] Confirmed tests on aws type vs previous amazon 
