### PR TITLE
Upgrade to pnpm 11

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,5 +1,0 @@
-# The pnpm team releases new versions pretty often and we don't need to stay
-# at the freshest version at all times.
-update-notifier=false
-# ESLint editor integrations expect ESLint's binary to be in the root node_modules.
-public-hoist-pattern[]=eslint

--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
       "web/.storybook/public"
     ]
   },
-  "packageManager": "pnpm@10.32.1+sha512.a706938f0e89ac1456b6563eab4edf1d1faf3368d1191fc5c59790e96dc918e4456ab2e67d613de1043d2e8c81f87303e6b40d4ffeca9df15ef1ad567348f2be",
+  "packageManager": "pnpm@11.1.1+sha512.d1fdf5f73c617b64fa1a56a81c3c8dfe0e966e33a6010aa256b517ae77be21d93e05affc0de1a83b0e4f29d569f68b446ae8f068cd7247c0bb3df0fb4d7bdf9a",
   "engines": {
     "node": "^24"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,9 +10,7 @@ overrides:
 pnpmfileChecksum: sha256-TR6zTaL3sXZMyu+QoRdd27aSUTH6sH0gp+M2XjxgTUI=
 
 patchedDependencies:
-  jest-canvas-mock@2.5.2:
-    hash: 8329a68f6b8f930f6204c405a071859893962d4a6641b6c2c2bb33122c0441b1
-    path: web/patches/jest-canvas-mock@2.5.2.patch
+  jest-canvas-mock@2.5.2: 8329a68f6b8f930f6204c405a071859893962d4a6641b6c2c2bb33122c0441b1
 
 importers:
 
@@ -3444,6 +3442,7 @@ packages:
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
+    deprecated: Potential CWE-502 - Update to 1.3.1 or higher
 
   '@unrs/resolver-binding-android-arm-eabi@1.11.1':
     resolution: {integrity: sha512-ppLRUgHVaGRWUx0R0Ut06Mjo9gBaBkg3v/8AxusGLhsIotbBLuRk51rAzqLC8gq6NyyAojEXglNjzf6R948DNw==}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,18 +3,6 @@ packages:
   - e/web/*
   - e2e
   - e/e2e
-onlyBuiltDependencies:
-  - '@swc/core'
-  - cbor-extract
-  - electron
-  - esbuild
-  - msw
-  - node-pty
-  - protobufjs
-  - unrs-resolver
-ignoredBuiltDependencies:
-  # Imported by jsdom-testing-mocks but not needed by us.
-  - puppeteer
 # Without this, electron-builder will pull in electron-builder-squirrel-windows (which we don't need)
 # and that dep will in turn pull electron-winstaller (which we also don't need). pnpm will then
 # start complaining that electron-winstaller is not in onlyBuiltDependencies.
@@ -49,3 +37,16 @@ overrides:
   # csstype. Unfortunately, it looks like types from 3.1.3 are incompatible with 3.2.3. Since this
   # is a types-only package, we override it to 3.2.3 so that it matches the version from design.
   "styled-components@6.1.19>csstype@3.1.3": "^3.2.3"
+updateNotifier: false
+publicHoistPattern:
+  - eslint
+allowBuilds:
+  '@swc/core': true
+  cbor-extract: true
+  electron: true
+  esbuild: true
+  msw: true
+  node-pty: true
+  protobufjs: true
+  unrs-resolver: true
+  puppeteer: false


### PR DESCRIPTION
Ran the codemod from https://pnpm.io/migration

Will manually backport to v18 and v17

## Manual Test Plan
### Test Environment
Local

### Test Cases
- [x] `pnpm install` works
- [x] `pnpm build-ui` `pnpm format` `pnpm type-check` etc still work
- [x] All the previous configuration items are still here in their new places
