### PR TITLE
docs: add video to agentic identity framework docs page

### DIFF
--- a/docs/pages/agentic-identity-framework.mdx
+++ b/docs/pages/agentic-identity-framework.mdx
@@ -13,7 +13,6 @@ import EnrollmentMethods, { Method } from '@site/src/components/Pages/Landing/En
 import Resources from '@site/src/components/Pages/Homepage/Resources';
 import Integrations from "@site/src/components/Pages/Homepage/Integrations";
 
-import agenticAiImg from '@version/docs/img/agentic-ai/agentic-ai-hero.png';
 import shieldCheckSvg from "@site/src/components/Icon/svg/shield-check2.svg";
 import keySvg from "@site/src/components/Icon/svg/key.svg";
 import gaugeSvg from "@site/src/components/Icon/svg/gauge.svg";
@@ -38,7 +37,7 @@ import elasticsearchSvg from "@site/src/components/Icon/svg/elastic-stack.svg";
 <LandingHero
   title="Teleport Agentic Identity Framework"
   subTitle="Design and reference implementation for the secure deployment of agents on infrastructure."
-  image={agenticAiImg}
+  youtubeVideoId="fjP5c3Y77BY"
   links={[
     {
       title: "Deploy agents safely across infrastructure",


### PR DESCRIPTION
This commit swaps the LandingHero image on the Agentic Identity Framework docs page, with a YouTube video instead. Unused import removed.