### PR TITLE
[vnet] Fix VNet systemd service file to use Teleport Connect bundled tsh

### DIFF
--- a/examples/systemd/vnet/README.md
+++ b/examples/systemd/vnet/README.md
@@ -3,6 +3,8 @@
 This directory contains files needed for VNet to work on Linux.
 Teleport Connect ships these files in its package.
 
+The `teleport-vnet.service` unit is Teleport Connect-specific: its `ExecStart` points at the tsh binary bundled with Connect at `/opt/Teleport Connect/resources/bin/tsh`. To use a different tsh (such as `/usr/local/bin/tsh`), edit the `ExecStart` line.
+
 ## Files
 
 - `teleport-vnet.service`: systemd unit for the privileged VNet daemon.

--- a/examples/systemd/vnet/teleport-vnet.service
+++ b/examples/systemd/vnet/teleport-vnet.service
@@ -7,6 +7,6 @@ Requires=dbus.service
 Type=dbus
 BusName=org.teleport.vnet1
 Environment=TELEPORT_TOOLS_VERSION=off
-ExecStart=/usr/local/bin/tsh vnet-daemon
+ExecStart=/opt/Teleport\x20Connect/resources/bin/tsh vnet-daemon
 User=root
 Group=root


### PR DESCRIPTION
Resolves a version conflict when both teleport and teleport-connect packages are installed, by pointing `ExecStart` directly at the tsh bundled with Teleport Connect

The original issue was: if `teleport` without `vnet-daemon` is installed first and `teleport-connect` is installed on top, the post-install script skips creating the `/usr/local/bin/tsh` symlink, so `teleport-vnet.service` ends up calling the older `tsh`, which doesn't support the `vnet-daemon` subcommand. The systemd unit fails to start.


<!-- Provide a descriptive entry for the changelog of the next release. -->

Changelog: Fix Teleport Connect's VNet failing to start on Linux when an older `tsh` is present at `/usr/local/bin/tsh`.


## Manual Test Plan
### Test Environment
any Linux distro with systemd, D-Bus and polkit

### Test Cases
- [x] Install `teleport` package older than v18.8.0, then install rebuilt `teleport-connect` on top, and verify VNet starts

