### PR TITLE
Add preset role "access-plugin-with-review"

### DIFF
--- a/constants.go
+++ b/constants.go
@@ -757,6 +757,10 @@ const (
 	// permissions required by self-hosted access request plugin.
 	PresetAccessPluginRoleName = "access-plugin"
 
+	// PresetAccessPluginWithReviewRoleName is a name of a preset role that includes
+	// permissions required by self-hosted access request plugin that permits review.
+	PresetAccessPluginWithReviewRoleName = "access-plugin-with-review"
+
 	// PresetListAccessRequestResourcesRoleName is a name of a preset role that
 	// includes permissions to read access request resources.
 	PresetListAccessRequestResourcesRoleName = "list-access-request-resources"

--- a/constants.go
+++ b/constants.go
@@ -757,8 +757,8 @@ const (
 	// permissions required by self-hosted access request plugin.
 	PresetAccessPluginRoleName = "access-plugin"
 
-	// PresetAccessPluginWithReviewRoleName is a name of a preset role that includes
-	// permissions required by self-hosted access request plugin that permits review.
+	// PresetAccessPluginWithReviewRoleName names the preset role that includes
+	// permissions required by self-hosted access request plugins that permit native reviews.
 	PresetAccessPluginWithReviewRoleName = "access-plugin-with-review"
 
 	// PresetListAccessRequestResourcesRoleName is a name of a preset role that

--- a/lib/auth/init.go
+++ b/lib/auth/init.go
@@ -1430,6 +1430,7 @@ func GetPresetRoles(buildType string) []types.Role {
 		services.NewSystemIdentityCenterAccessRole(buildType),
 		services.NewPresetWildcardWorkloadIdentityIssuerRole(),
 		services.NewPresetAccessPluginRole(),
+		services.NewPresetAccessPluginWithReviewRole(),
 		services.NewPresetListAccessRequestResourcesRole(),
 		services.NewPresetMCPUserRole(),
 	}

--- a/lib/auth/init_test.go
+++ b/lib/auth/init_test.go
@@ -965,6 +965,7 @@ func TestPresets(t *testing.T) {
 		teleport.PresetTerraformProviderRoleName,
 		teleport.PresetWildcardWorkloadIdentityIssuerRoleName,
 		teleport.PresetAccessPluginRoleName,
+		teleport.PresetAccessPluginWithReviewRoleName,
 		teleport.PresetListAccessRequestResourcesRoleName,
 		teleport.PresetMCPUserRoleName,
 	}

--- a/lib/services/presets.go
+++ b/lib/services/presets.go
@@ -642,6 +642,43 @@ func NewPresetAccessPluginRole() types.Role {
 	return role
 }
 
+// NewPresetAccessPluginWithReviewRole returns a new pre-defined role for self-hosted
+// access request plugins that permits review.
+func NewPresetAccessPluginWithReviewRole() types.Role {
+	role := &types.RoleV6{
+		Kind:    types.KindRole,
+		Version: types.V8,
+		Metadata: types.Metadata{
+			Name:        teleport.PresetAccessPluginWithReviewRoleName,
+			Namespace:   apidefaults.Namespace,
+			Description: "Default access plugin with review role",
+			Labels: map[string]string{
+				types.TeleportInternalResourceType: types.PresetResource,
+			},
+		},
+		Spec: types.RoleSpecV6{
+			Allow: types.RoleConditions{
+				Rules: []types.Rule{
+					types.NewRule(types.KindAccessRequest, RO()),
+					types.NewRule(types.KindAccessPluginData, RW()),
+					types.NewRule(types.KindAccessMonitoringRule, RO()),
+					types.NewRule(types.KindAccessList, RO()),
+					types.NewRule(types.KindRole, RO()),
+					types.NewRule(types.KindUser, RO()),
+					types.NewRule(types.KindUserLoginState, RO()),
+				},
+				ReviewRequests: &types.AccessReviewConditions{
+					PreviewAsRoles: []string{
+						teleport.PresetListAccessRequestResourcesRoleName,
+					},
+					SubmitForUsers: []string{"*"},
+				},
+			},
+		},
+	}
+	return role
+}
+
 // NewPresetListAccessRequestResourcesRole returns a new pre-defined role that
 // allows reading access request resources.
 func NewPresetListAccessRequestResourcesRole() types.Role {
@@ -968,6 +1005,7 @@ var defaultAllowRulesMap = map[string][]types.Rule{
 	teleport.PresetAccessRoleName:                     NewPresetAccessRole().GetRules(types.Allow),
 	teleport.PresetTerraformProviderRoleName:          NewPresetTerraformProviderRole().GetRules(types.Allow),
 	teleport.PresetAccessPluginRoleName:               NewPresetAccessPluginRole().GetRules(types.Allow),
+	teleport.PresetAccessPluginWithReviewRoleName:     NewPresetAccessPluginWithReviewRole().GetRules(types.Allow),
 	teleport.PresetListAccessRequestResourcesRoleName: NewPresetListAccessRequestResourcesRole().GetRules(types.Allow),
 }
 

--- a/lib/services/presets_test.go
+++ b/lib/services/presets_test.go
@@ -842,34 +842,20 @@ func TestAddRoleDefaults(t *testing.T) {
 						types.TeleportInternalResourceType: types.PresetResource,
 					},
 				},
-			},
-			expectedErr: require.NoError,
-			expected: &types.RoleV6{
-				Kind:    types.KindRole,
-				Version: types.V8,
-				Metadata: types.Metadata{
-					Name:        teleport.PresetAccessPluginWithReviewRoleName,
-					Namespace:   apidefaults.Namespace,
-					Description: "Default access plugin with review role",
-					Labels: map[string]string{
-						types.TeleportInternalResourceType: types.PresetResource,
-					},
-				},
 				Spec: types.RoleSpecV6{
 					Allow: types.RoleConditions{
-						Rules: []types.Rule{
-							// The missing resources got added as individual rules
-							types.NewRule(types.KindAccessRequest, RO()),
-							types.NewRule(types.KindAccessPluginData, RW()),
-							types.NewRule(types.KindAccessMonitoringRule, RO()),
-							types.NewRule(types.KindAccessList, RO()),
-							types.NewRule(types.KindRole, RO()),
-							types.NewRule(types.KindUser, RO()),
-							types.NewRule(types.KindUserLoginState, RO()),
+						ReviewRequests: &types.AccessReviewConditions{
+							PreviewAsRoles: []string{
+								teleport.PresetListAccessRequestResourcesRoleName,
+							},
+							SubmitForUsers: []string{"*"},
 						},
 					},
 				},
 			},
+			expectedErr:    require.NoError,
+			reviewNotEmpty: true,
+			expected:       NewPresetAccessPluginWithReviewRole(),
 		},
 		{
 			name: "list-access-request-resources (default roles match preset rules)",

--- a/lib/services/presets_test.go
+++ b/lib/services/presets_test.go
@@ -830,6 +830,48 @@ func TestAddRoleDefaults(t *testing.T) {
 			},
 		},
 		{
+			name: "access-plugin-with-review (default roles match preset rules)",
+			role: &types.RoleV6{
+				Kind:    types.KindRole,
+				Version: types.V8,
+				Metadata: types.Metadata{
+					Name:        teleport.PresetAccessPluginWithReviewRoleName,
+					Namespace:   apidefaults.Namespace,
+					Description: "Default access plugin with review role",
+					Labels: map[string]string{
+						types.TeleportInternalResourceType: types.PresetResource,
+					},
+				},
+			},
+			expectedErr: require.NoError,
+			expected: &types.RoleV6{
+				Kind:    types.KindRole,
+				Version: types.V8,
+				Metadata: types.Metadata{
+					Name:        teleport.PresetAccessPluginWithReviewRoleName,
+					Namespace:   apidefaults.Namespace,
+					Description: "Default access plugin with review role",
+					Labels: map[string]string{
+						types.TeleportInternalResourceType: types.PresetResource,
+					},
+				},
+				Spec: types.RoleSpecV6{
+					Allow: types.RoleConditions{
+						Rules: []types.Rule{
+							// The missing resources got added as individual rules
+							types.NewRule(types.KindAccessRequest, RO()),
+							types.NewRule(types.KindAccessPluginData, RW()),
+							types.NewRule(types.KindAccessMonitoringRule, RO()),
+							types.NewRule(types.KindAccessList, RO()),
+							types.NewRule(types.KindRole, RO()),
+							types.NewRule(types.KindUser, RO()),
+							types.NewRule(types.KindUserLoginState, RO()),
+						},
+					},
+				},
+			},
+		},
+		{
 			name: "list-access-request-resources (default roles match preset rules)",
 			role: &types.RoleV6{
 				Kind:    types.KindRole,


### PR DESCRIPTION
Depends on #66254

Adds a new preset role `access-plugin-with-review` that extends the existing preset role `access-plugin` with new Access Review condition: `review_requests.submit_for_users`. This allows access plugins to submit reviews on behalf of Slack users. The new role otherwise holds the same ruleset as the existing `access-plugin` role.

Context for reviewers: This supports the upcoming feature for native reviews in slack. An access plugin would then require this preset role in order to perform native reviews. Changelog will be saved for final PR.

## Manual Test Plan
### Test Environment

Teleport Cloud

### Test Cases
- [x] Verify the preset role `access-plugin-with-review` is created with rule for `review_requests.submit_for_users = ["*"]`
