### PR TITLE
docs: adding Agentic Identity Framework callouts

### DIFF
--- a/docs/pages/connect-your-client/model-context-protocol/database-access.mdx
+++ b/docs/pages/connect-your-client/model-context-protocol/database-access.mdx
@@ -9,6 +9,17 @@ tags:
  - how-to
 ---
 
+<Callout
+  variant="tip"
+  title="Did you know? MCP access is part of a broader Agentic Identity Framework."
+  description="The Agentic Identity Framework is a standards-driven set of designs, SDKs, and reference implementations for deploying AI agents securely."
+  icon="gearStack"
+  link={{
+    title: "Explore framework",
+    href: "../../../agentic-identity-framework",
+  }}
+/>
+
 This guide explains how to connect to your **PostgreSQL** Teleport databases with MCP clients.
 
 {/* lint ignore page-structure remark-lint */}

--- a/docs/pages/connect-your-client/model-context-protocol/kube-access.mdx
+++ b/docs/pages/connect-your-client/model-context-protocol/kube-access.mdx
@@ -9,6 +9,17 @@ tags:
  - how-to
 ---
 
+<Callout
+  variant="tip"
+  title="Did you know? MCP access is part of a broader Agentic Identity Framework."
+  description="The Agentic Identity Framework is a standards-driven set of designs, SDKs, and reference implementations for deploying AI agents securely."
+  icon="gearStack"
+  link={{
+    title: "Explore framework",
+    href: "../../../agentic-identity-framework",
+  }}
+/>
+
 This guide explains how to connect to Teleport Kubernetes Clusters with MCP clients.
 
 {/* lint ignore page-structure remark-lint */}

--- a/docs/pages/connect-your-client/model-context-protocol/mcp-access.mdx
+++ b/docs/pages/connect-your-client/model-context-protocol/mcp-access.mdx
@@ -10,6 +10,17 @@ tags:
  - infrastructure-identity
 ---
 
+<Callout
+  variant="tip"
+  title="Did you know? MCP access is part of a broader Agentic Identity Framework."
+  description="The Agentic Identity Framework is a standards-driven set of designs, SDKs, and reference implementations for deploying AI agents securely."
+  icon="gearStack"
+  link={{
+    title: "Explore framework",
+    href: "../../../agentic-identity-framework",
+  }}
+/>
+
 This guide explains how to configure MCP clients to access MCP servers served by
 Teleport.
 

--- a/docs/pages/enroll-resources/mcp-access/dynamic-registration.mdx
+++ b/docs/pages/enroll-resources/mcp-access/dynamic-registration.mdx
@@ -9,6 +9,17 @@ tags:
 - mcp
 ---
 
+<Callout
+  variant="tip"
+  title="Did you know? Dynamic MCP server registration is part of a broader Agentic Identity Framework."
+  description="The Agentic Identity Framework is a standards-driven set of designs, SDKs, and reference implementations for deploying AI agents securely."
+  icon="gearStack"
+  link={{
+    title: "Explore framework",
+    href: "../../../agentic-identity-framework",
+  }}
+/>
+
 Dynamic MCP server registration allows Teleport administrators to register new
 MCP servers (or update/unregister existing ones) without having to update the
 static configuration files read by Teleport Application Service instances.

--- a/docs/pages/enroll-resources/mcp-access/jwt.mdx
+++ b/docs/pages/enroll-resources/mcp-access/jwt.mdx
@@ -9,6 +9,17 @@ tags:
 - zero-trust
 ---
 
+<Callout
+  variant="tip"
+  title="Did you know? MCP access is part of a broader Agentic Identity Framework."
+  description="The Agentic Identity Framework is a standards-driven set of designs, SDKs, and reference implementations for deploying AI agents securely."
+  icon="gearStack"
+  link={{
+    title: "Explore framework",
+    href: "../../../agentic-identity-framework",
+  }}
+/>
+
 (!docs/pages/includes/application-access/jwt-intro.mdx appType="MCP server" !)
 
 ## Classic JWTs

--- a/docs/pages/enroll-resources/mcp-access/rbac.mdx
+++ b/docs/pages/enroll-resources/mcp-access/rbac.mdx
@@ -9,6 +9,17 @@ tags:
 - zero-trust
 ---
 
+<Callout
+  variant="tip"
+  title="Did you know? MCP Access Controls are part of a broader Agentic Identity Framework."
+  description="The Agentic Identity Framework is a standards-driven set of designs, SDKs, and reference implementations for deploying AI agents securely."
+  icon="gearStack"
+  link={{
+    title: "Explore framework",
+    href: "../../../agentic-identity-framework",
+  }}
+/>
+
 You can use Teleport's role-based access control (RBAC) system to set up
 granular permissions for authenticating to MCP servers connected to Teleport.
 

--- a/docs/pages/identity-security/usage/usage.mdx
+++ b/docs/pages/identity-security/usage/usage.mdx
@@ -8,6 +8,17 @@ tags:
 enterprise: Identity Security
 ---
 
+<Callout
+  variant="tip"
+  title="Did you know? Agent access paths and activity is part of a broader Agentic Identity Framework."
+  description="The Agentic Identity Framework is a standards-driven set of designs, SDKs, and reference implementations for deploying AI agents securely."
+  icon="gearStack"
+  link={{
+    title: "Explore framework",
+    href: "../../agentic-identity-framework",
+  }}
+/>
+
 Teleport Identity Security helps teams expose and eliminate hidden risk in their infrastructure. 
 
 These are some use cases for Teleport Identity Security:  
@@ -22,4 +33,3 @@ These are some use cases for Teleport Identity Security:
 ## Guides
 
 <DocCardList />
-

--- a/docs/pages/machine-workload-identity/workload-identity/introduction.mdx
+++ b/docs/pages/machine-workload-identity/workload-identity/introduction.mdx
@@ -8,6 +8,17 @@ tags:
  - infrastructure-identity
 ---
 
+<Callout
+  variant="tip"
+  title="Did you know? Workload Identity is part of a broader Agentic Identity Framework."
+  description="The Agentic Identity Framework is a standards-driven set of designs, SDKs, and reference implementations for deploying AI agents securely."
+  icon="gearStack"
+  link={{
+    title: "Explore framework",
+    href: "../../../agentic-identity-framework",
+  }}
+/>
+
 Teleport Workload Identity securely issues short-lived cryptographic identities
 to workloads. It is a flexible foundation for workload identity across your 
 infrastructure, creating a uniform way for your workloads to authenticate 

--- a/docs/pages/reference/machine-workload-identity/workload-identity/revocations.mdx
+++ b/docs/pages/reference/machine-workload-identity/workload-identity/revocations.mdx
@@ -8,6 +8,17 @@ tags:
  - resiliency
 ---
 
+<Callout
+  variant="tip"
+  title="Did you know? Workload Identity is part of a broader Agentic Identity Framework."
+  description="The Agentic Identity Framework is a standards-driven set of designs, SDKs, and reference implementations for deploying AI agents securely."
+  icon="gearStack"
+  link={{
+    title: "Explore framework",
+    href: "../../../../agentic-identity-framework",
+  }}
+/>
+
 The revocations mechanism provides a way to mark an issued X509 workload
 identity credential as revoked - indicating to workloads that this credential
 should no longer be considered valid.

--- a/docs/pages/reference/machine-workload-identity/workload-identity/workload-identity-api-and-workload-attestation.mdx
+++ b/docs/pages/reference/machine-workload-identity/workload-identity/workload-identity-api-and-workload-attestation.mdx
@@ -8,6 +8,17 @@ tags:
  - infrastructure-identity
 ---
 
+<Callout
+  variant="tip"
+  title="Did you know? Workload Identity is part of a broader Agentic Identity Framework."
+  description="The Agentic Identity Framework is a standards-driven set of designs, SDKs, and reference implementations for deploying AI agents securely."
+  icon="gearStack"
+  link={{
+    title: "Explore framework",
+    href: "../../../../agentic-identity-framework",
+  }}
+/>
+
 The Workload Identity API service (`workload-identity-api`) is a configurable
 `tbot` service that allows workloads to request JWT and X509 workload identity
 credentials on-the-fly.


### PR DESCRIPTION
This PR adds the `Callout` component to Agentic Identity Framework related pages like MCP, Workload Identity, etc. that point them to the main AIF page.