### PR TITLE
feat: add BeamsFeedback enum value to NavTitle

### DIFF
--- a/web/packages/teleport/src/types.ts
+++ b/web/packages/teleport/src/types.ts
@@ -118,6 +118,7 @@ export enum NavTitle {
 
   // Beams
   BeamsQuickstart = 'Quickstart',
+  BeamsFeedback = 'Feedback',
   BeamsList = 'Beams',
 }
 


### PR DESCRIPTION
## Change 
This PR adds`BeamsFeedback` to  NavTitle enum in preparation to support the new BeamsFeedback sub tab to link in our community slack channel for beam users to join.

Github Issue: https://github.com/gravitational/beams/issues/125


<!-- Provide a descriptive entry for the changelog of the next release. -->

Changelog:


<!-- Include manual testing efforts to verify the change. -->
<!-- Detail where the tests where run and what configurations were used. -->
<!-- Include all the test cases which were run to validate the change. -->

## Manual Test Plan
### Test Environment
N/A
### Test Cases
- [x] Nothing to validate here as this enum will be used in the follow up [PR](https://github.com/gravitational/teleport.e/pull/8755) in the enterprise repo 
