### PR TITLE
[v18] app: Raise upstream response-header cap to 1h

### DIFF
--- a/lib/srv/app/transport.go
+++ b/lib/srv/app/transport.go
@@ -43,6 +43,11 @@ import (
 	"github.com/gravitational/teleport/lib/utils"
 )
 
+// responseHeaderTimeout caps how long to wait for an upstream to start
+// sending response headers, so a wedged upstream does not hold the
+// connection indefinitely.
+const responseHeaderTimeout = time.Hour
+
 // transportConfig is configuration for a rewriting transport.
 type transportConfig struct {
 	app           types.Application
@@ -103,10 +108,7 @@ func newTransport(ctx context.Context, c *transportConfig) (*transport, error) {
 		return nil, trace.Wrap(err)
 	}
 
-	// Add a timeout to control how long it takes to (start) getting a response
-	// from the target server. This allows Teleport to show the user a helpful
-	// error message when the target service is slow in responding.
-	tr.ResponseHeaderTimeout = requestTimeout
+	tr.ResponseHeaderTimeout = responseHeaderTimeout
 
 	tr.TLSClientConfig, err = configureTLS(c)
 	if err != nil {
@@ -323,10 +325,3 @@ func charWrap(message string) string {
 	}
 	return sb.String()
 }
-
-const (
-	// requestTimeout is the timeout to receive a response from the upstream
-	// server. Start it out large (not to break things) and slowly decrease it
-	// over time.
-	requestTimeout = 5 * time.Minute
-)

--- a/lib/srv/app/transport_test.go
+++ b/lib/srv/app/transport_test.go
@@ -19,13 +19,23 @@
 package app
 
 import (
+	"bufio"
+	"context"
+	"fmt"
+	"io"
+	"net"
 	"net/http"
 	"net/url"
 	"testing"
+	"testing/synctest"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
 	"github.com/gravitational/teleport/api/types"
+	apievents "github.com/gravitational/teleport/api/types/events"
+	"github.com/gravitational/teleport/lib/srv/app/common"
+	"github.com/gravitational/teleport/lib/tlsca"
 )
 
 func TestNeedsPathRedirect(t *testing.T) {
@@ -108,4 +118,151 @@ func TestNeedsPathRedirect(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestTransport_LongRunningUpstreamCompletes verifies a 10-minute
+// response-header delay completes under the 1-hour cap.
+func TestTransport_LongRunningUpstreamCompletes(t *testing.T) {
+	t.Parallel()
+	synctest.Test(t, func(t *testing.T) {
+		clientConn, serverConn := net.Pipe()
+		tr := newTestTransport(t, func(context.Context, string, string) (net.Conn, error) {
+			return clientConn, nil
+		})
+
+		ctx, cancel := context.WithCancel(t.Context())
+		defer cancel()
+		upstreamDone := make(chan struct{})
+		go func() {
+			defer close(upstreamDone)
+			fakeUpstream(ctx, serverConn, 10*time.Minute, "ok")
+		}()
+
+		req := newTestRequest(t)
+		resp, err := tr.RoundTrip(req)
+		require.NoError(t, err)
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+		body, err := io.ReadAll(resp.Body)
+		require.NoError(t, err)
+		require.NoError(t, resp.Body.Close())
+		require.Equal(t, "ok", string(body))
+
+		cancel()
+		<-upstreamDone
+	})
+}
+
+// TestTransport_SanityCapFiresDeadlineExceededDiagnostic verifies the
+// 1-hour cap fires and renders the Context Deadline Exceeded diagnostic
+// page for HTTP/1 ResponseHeaderTimeout. HTTP/2 coverage for the
+// net.Error.Timeout() case lives in errors_test.go.
+func TestTransport_SanityCapFiresDeadlineExceededDiagnostic(t *testing.T) {
+	t.Parallel()
+	synctest.Test(t, func(t *testing.T) {
+		clientConn, serverConn := net.Pipe()
+		tr := newTestTransport(t, func(context.Context, string, string) (net.Conn, error) {
+			return clientConn, nil
+		})
+
+		ctx, cancel := context.WithCancel(t.Context())
+		defer cancel()
+		upstreamDone := make(chan struct{})
+		go func() {
+			defer close(upstreamDone)
+			fakeUpstream(ctx, serverConn, 2*time.Hour, "should-not-be-read")
+		}()
+
+		req := newTestRequest(t)
+		resp, err := tr.RoundTrip(req)
+		require.NoError(t, err)
+		body, err := io.ReadAll(resp.Body)
+		require.NoError(t, err)
+		require.NoError(t, resp.Body.Close())
+		require.Contains(t, string(body), "Context Deadline Exceeded")
+
+		cancel()
+		<-upstreamDone
+	})
+}
+
+// newTestTransport builds a transport with the minimum config that
+// transportConfig.Check requires. The dial func is wired as the
+// underlying http.Transport.DialContext so callers can inject a
+// net.Pipe.
+func newTestTransport(t *testing.T, dial func(context.Context, string, string) (net.Conn, error)) *transport {
+	t.Helper()
+	app, err := types.NewAppV3(types.Metadata{Name: "test"}, types.AppSpecV3{
+		URI:        "http://upstream.invalid",
+		PublicAddr: "test.example.com",
+	})
+	require.NoError(t, err)
+	tr, err := newTransport(t.Context(), &transportConfig{
+		app:        app,
+		publicPort: "443",
+		jwt:        "test-jwt",
+	})
+	require.NoError(t, err)
+	tr.tr.(*http.Transport).DialContext = dial
+	return tr
+}
+
+// newTestRequest builds a request with the SessionContext that
+// transport.RoundTrip requires.
+func newTestRequest(t *testing.T) *http.Request {
+	t.Helper()
+	app, err := types.NewAppV3(types.Metadata{Name: "test"}, types.AppSpecV3{
+		URI: "http://upstream.invalid",
+	})
+	require.NoError(t, err)
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, "http://upstream.invalid/", nil)
+	require.NoError(t, err)
+	return common.WithSessionContext(req, &common.SessionContext{
+		App:   app,
+		Audit: noopAudit{},
+	})
+}
+
+// fakeUpstream reads one HTTP request, waits delay (or ctx cancel), then
+// writes a minimal 200. The ctx hook lets tests cancel the upstream so
+// synctest does not report a deadlock when delay exceeds the cap.
+func fakeUpstream(ctx context.Context, conn net.Conn, delay time.Duration, body string) {
+	defer conn.Close()
+	_, err := http.ReadRequest(bufio.NewReader(conn))
+	if err != nil {
+		return
+	}
+	select {
+	case <-time.After(delay):
+	case <-ctx.Done():
+		return
+	}
+	_, _ = fmt.Fprintf(conn, "HTTP/1.1 200 OK\r\nContent-Length: %d\r\n\r\n%s", len(body), body)
+}
+
+// noopAudit satisfies common.Audit so RoundTrip's audit emission does
+// not fail in tests.
+type noopAudit struct{}
+
+func (noopAudit) OnSessionStart(context.Context, string, *tlsca.Identity, types.Application) error {
+	return nil
+}
+
+func (noopAudit) OnSessionEnd(context.Context, string, *tlsca.Identity, types.Application) error {
+	return nil
+}
+
+func (noopAudit) OnSessionChunk(context.Context, string, string, *tlsca.Identity, types.Application) error {
+	return nil
+}
+
+func (noopAudit) OnRequest(context.Context, *common.SessionContext, *http.Request, uint32, *common.AWSResolvedEndpoint) error {
+	return nil
+}
+
+func (noopAudit) OnDynamoDBRequest(context.Context, *common.SessionContext, *http.Request, uint32, *common.AWSResolvedEndpoint) error {
+	return nil
+}
+
+func (noopAudit) EmitEvent(context.Context, apievents.AuditEvent) error {
+	return nil
 }

--- a/lib/utils/errors.go
+++ b/lib/utils/errors.go
@@ -97,7 +97,10 @@ func IsUntrustedCertErr(err error) bool {
 // CanExplainNetworkError returns a simple to understand error message that can
 // be used to debug common network and/or protocol errors.
 func CanExplainNetworkError(err error) (string, bool) {
-	var derr *net.DNSError
+	var (
+		derr *net.DNSError
+		nerr net.Error
+	)
 
 	switch {
 	// Connection refused errors can be reproduced by attempting to connect to a
@@ -134,11 +137,17 @@ Use "ping HOST" and "ip route get HOST" to help debug this issue.`, true
 Teleport could not complete the request because the server abruptly closed the connection before the response was received. To resolve this issue, ensure the server (or load balancer) does not have a timeout terminating the connection early and verify that the server is not crash looping.
 
 Use protocol-specific tools (e.g., curl, psql) to help debug this issue.`, true
-	// Slow responses can be reprodued by creating a HTTP server that does a
-	// time.Sleep before responding. The raw error typically looks like the following:
+	// Slow responses can be reproduced by creating a HTTP server that
+	// does a time.Sleep before responding. The raw error typically
+	// looks like the following:
 	//
 	// context deadline exceeded
-	case errors.Is(err, context.DeadlineExceeded):
+	//
+	// HTTP/1 wraps context.DeadlineExceeded via timeoutError.Is.
+	// HTTP/2's http2httpError does not wrap it; it implements
+	// net.Error with Timeout() returning true. Match both shapes
+	// here, plus syscall.ETIMEDOUT and other net.Error timeouts.
+	case errors.Is(err, context.DeadlineExceeded) || (errors.As(err, &nerr) && nerr.Timeout()):
 		return `Context Deadline Exceeded
 
 Teleport did not receive a response within the timeout period, likely due to the system being overloaded, network congestion, or a firewall blocking traffic. To resolve this issue, connect to the host directly and ensure it is responding promptly.

--- a/lib/utils/errors_test.go
+++ b/lib/utils/errors_test.go
@@ -1,0 +1,82 @@
+/*
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package utils
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// fakeTimeoutError mirrors http2httpError: net.Error with Timeout() ==
+// true and no Is method. Temporary() is required by the net.Error
+// interface (deprecated but not removed as of Go 1.25).
+type fakeTimeoutError struct{ msg string }
+
+func (e *fakeTimeoutError) Error() string   { return e.msg }
+func (e *fakeTimeoutError) Timeout() bool   { return true }
+func (e *fakeTimeoutError) Temporary() bool { return true }
+
+// fakeNonTimeoutError is a net.Error with Timeout() == false.
+type fakeNonTimeoutError struct{ msg string }
+
+func (e *fakeNonTimeoutError) Error() string   { return e.msg }
+func (e *fakeNonTimeoutError) Timeout() bool   { return false }
+func (e *fakeNonTimeoutError) Temporary() bool { return true }
+
+func TestCanExplainNetworkError_TimeoutFallthrough(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		err     error
+		wantOK  bool
+		wantSub string
+	}{
+		{
+			name:    "http2 response header timeout shape",
+			err:     &fakeTimeoutError{msg: "http2: timeout awaiting response headers"},
+			wantOK:  true,
+			wantSub: "Context Deadline Exceeded",
+		},
+		{
+			name:   "net error without Timeout returns no explanation",
+			err:    &fakeNonTimeoutError{msg: "some non-timeout net error"},
+			wantOK: false,
+		},
+		{
+			name:   "plain error returns no explanation",
+			err:    errors.New("not a net.Error"),
+			wantOK: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			msg, ok := CanExplainNetworkError(tt.err)
+			require.Equal(t, tt.wantOK, ok)
+			if tt.wantSub != "" {
+				require.Contains(t, msg, tt.wantSub)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Raise the app service upstream `ResponseHeaderTimeout` from 5 minutes to 1 hour. The 5-minute cap kills legitimate long-running HTTP requests through app access (slow POSTs, long-poll handshakes) with `net/http: timeout awaiting response headers`. Relax rather than remove: the app `http.Server` deliberately omits `ReadTimeout` and `WriteTimeout`, has no `MaxConnsPerHost`, and no listener limiter, so this cap is the only Teleport-side bound on per-request lifetime. The practical ceiling is already ~1 hour because session chunks force-close at `closeTimeout` in `lib/srv/app/session.go`.

Pick up a separate latent fix while in the area: HTTP/2 response-header timeouts previously fell through `utils.CanExplainNetworkError` to a raw Go error because `http2httpError` does not wrap `context.DeadlineExceeded`. Combine the HTTP/1 and HTTP/2 timeout shapes into one case so both surface the existing diagnostic page.

Issue: https://github.com/gravitational/teleport/issues/66646
Backport: https://github.com/gravitational/teleport/pull/66647
Changelog: Raise the app access upstream response-header cap from 5 minutes to 1 hour so long-running HTTP requests complete.

## Manual Test Plan

### Test Environment

- Local Teleport from this branch.
- An HTTP app whose upstream sleeps for 6 minutes before writing response headers.

### Test Cases

#### Test 1: Slow upstream completes past 5 minutes

Send `curl` to the slow app. The upstream sleeps for 6 minutes (past
the old 5-minute cap, within the new 1-hour cap) and then writes
response headers and a body.

- [x] `curl` against the slow app returns 200 with the upstream's body after ~6 minutes.

#### Test 2: Connection refused diagnostic

Send `curl` to an app whose upstream URI has nothing listening on the
configured port.

- [x] `curl` against an unreachable upstream returns the existing "Connection Refused" diagnostic page.

#### Test 3: DNS NXDOMAIN diagnostic

Send `curl` to an app whose upstream URI has a hostname that does not
resolve.

- [x] `curl` against an unresolvable upstream returns the existing "No Such Host" diagnostic page.

#### Test 4: Regression baseline (without fix)

Build from branch/v18 (before the fix) and repeat Test 1.

- [x] `curl` against the slow app fails at the 5-minute mark with the "Context Deadline Exceeded" diagnostic page, confirming the cap was previously 5 minutes.