### PR TITLE
[v18] docs: corrected aws ec2 tag link

### DIFF
--- a/docs/pages/enroll-resources/automatic-labels/ec2-tags.mdx
+++ b/docs/pages/enroll-resources/automatic-labels/ec2-tags.mdx
@@ -38,7 +38,7 @@ fakehost.example.com 127.0.0.1:3022 env=example,hostname=ip-172-31-53-70,aws/Nam
 ## Enable tags in instance metadata
 
 To allow Teleport to import EC2 tags, tags must be enabled in the instance metadata. This can be done
-via the AWS console or the AWS CLI. See the [AWS documentation](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Tags.html#allow-access-to-tags-in-IMDS)
+via the AWS console or the AWS CLI. See the [AWS documentation](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/work-with-tags-in-IMDS.html#allow-access-to-tags-in-IMDS)
 for more details.
 
 <Admonition type="note" title="Note">


### PR DESCRIPTION
This PR fixes a dead AWS documentation link on the automatic-labels/ec2-tags page.

The existing link pointed to the deprecated AWS page:
using_tags.html#allow-access-to-tags-in-imds

AWS has since moved this content to:
work-with-tags-in-IMDS.html#allow-access-to-tags-in-IMDS

This update replaces the outdated reference with the current AWS documentation URL:
https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/work-with-tags-in-IMDS.html#allow-access-to-tags-in-IMDS

Note, sometimes the old link will redirect to the main Tags page (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Tags.html). AWS has redirect/canonicalization rules for some paths; CDN caching sometimes catches the lowercase path and rewrites it; this is especially common in older AWS docs where filenames were generated from mixed-case source content years ago, so sometimes it works, other times it misses and returns a 404.