### PR TITLE
fips: Switch to Go-native FIPS140 builds from boring crypto

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -85,8 +85,8 @@ ifneq ("$(FIPS)","")
 FIPS_TAG := fips
 FIPS_MESSAGE := with-FIPS-support
 RELEASE = teleport-$(GITTAG)-$(OS)-$(ARCH)-fips-bin
-GOEXPERIMENT = boringcrypto
-export GOEXPERIMENT
+GOFIPS140 = v1.0.0
+export GOFIPS140
 ifeq ($(BUILDBOX_MODE),cross)
 # We need to set CGO_ENABLED=0 when building rdpclient as the build of
 # boring-sys builds and runs a Go program as part of its integrity testing.
@@ -438,7 +438,7 @@ $(BUILDDIR)/tbot:
 
 .PHONY: $(BUILDDIR)/teleport-update
 $(BUILDDIR)/teleport-update:
-	GOOS=$(OS) GOARCH=$(ARCH) CGO_ENABLED=0 go build -tags "grpcnotrace" -o $(BUILDDIR)/teleport-update $(BUILDFLAGS_TELEPORT_UPDATE) $(TOOLS_LDFLAGS) ./tool/teleport-update
+	GOOS=$(OS) GOARCH=$(ARCH) CGO_ENABLED=0 go build -tags "grpcnotrace $(FIPS_TAG)" -o $(BUILDDIR)/teleport-update $(BUILDFLAGS_TELEPORT_UPDATE) $(TOOLS_LDFLAGS) ./tool/teleport-update
 
 TELEPORT_ARGS ?= start
 .PHONY: teleport-hot-reload

--- a/build.assets/Makefile
+++ b/build.assets/Makefile
@@ -104,8 +104,8 @@ build-enterprise-binaries: buildbox-centos7 webassets
 # This builds Enterprise binaries only.
 #
 .PHONY: build-binaries-fips
-build-binaries-fips: buildbox-centos7-fips webassets
-	docker run $(DOCKERFLAGS) $(NOROOT) $(BUILDBOX_CENTOS7_FIPS) \
+build-binaries-fips: buildbox-centos7 webassets
+	docker run $(DOCKERFLAGS) $(NOROOT) $(BUILDBOX_CENTOS7) \
 		make ADDFLAGS='$(ADDFLAGS)' PIV=$(PIV) FIPS=yes clean-ent full-ent
 
 #
@@ -668,8 +668,8 @@ release-ng: webassets buildbox-ng
 # CI should not use this target, it should use named Makefile targets like release-amd64-fips.
 #
 .PHONY: release-fips
-release-fips: buildbox-centos7-fips webassets
-	docker run $(DOCKERFLAGS) -i $(NOROOT) $(BUILDBOX_CENTOS7_FIPS) \
+release-fips: buildbox-centos7 webassets
+	docker run $(DOCKERFLAGS) -i $(NOROOT) $(BUILDBOX_CENTOS7) \
 		/usr/bin/make release-ent -e ADDFLAGS="$(ADDFLAGS)" OS=$(OS) ARCH=$(ARCH) RUNTIME=$(GOLANG_VERSION) FIDO2=$(FIDO2) PIV=$(PIV) FIPS=yes REPRODUCIBLE=yes
 
 #
@@ -699,9 +699,9 @@ release-centos7: buildbox-centos7 webassets
 # to call release-unix-preserving-webassets like we do for the non-fips release.
 #
 .PHONY: release-centos7-fips
-release-centos7-fips: buildbox-centos7-fips webassets
+release-centos7-fips: buildbox-centos7 webassets
 	$(call LOG_GROUP_START)
-	docker run $(DOCKERFLAGS) -i $(NOROOT) $(BUILDBOX_CENTOS7_FIPS) \
+	docker run $(DOCKERFLAGS) -i $(NOROOT) $(BUILDBOX_CENTOS7) \
 		/usr/bin/scl enable $(DEVTOOLSET) '/usr/bin/make release-ent -e ADDFLAGS="$(ADDFLAGS)" OS=$(OS) ARCH=$(ARCH) RUNTIME=$(GOLANG_VERSION) FIDO2=$(FIDO2) PIV=$(PIV) FIPS=yes REPRODUCIBLE=no'
 	$(call LOG_GROUP_END)
 

--- a/lib/fipscheck/disabled.go
+++ b/lib/fipscheck/disabled.go
@@ -1,3 +1,5 @@
+//go:build !fips
+
 // Teleport
 // Copyright (C) 2026 Gravitational, Inc.
 //
@@ -14,11 +16,22 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-package modules
+package fipscheck
 
-// IsBoringBinary checks if the binary was compiled in FIPS140 mode. It is
-// a compatibility shim that will be removed once the callers from other repos
-// have been removed.
-func IsBoringBinary() bool {
-	return IsFIPSBuild()
+import (
+	"crypto/fips140"
+	"fmt"
+	"os"
+)
+
+func init() {
+	// This guards against a user running teleport with `GODEBUG=fips140=on` set
+	// in their environment. They may be expecting this would enable FIPS140 mode
+	// with Teleport, but for that they need the fips build, as there is also a
+	// rust component that needs to have FIPS140 enabled.
+	if fips140.Enabled() {
+		fmt.Fprintln(os.Stderr, "FIPS140 mode is active in a non-FIPS build (GODEBUG=fips140=on).")
+		fmt.Fprintln(os.Stderr, "Install the Teleport Enterprise FIPS edition to use FIPS140 mode.")
+		os.Exit(1)
+	}
 }

--- a/lib/fipscheck/enabled.go
+++ b/lib/fipscheck/enabled.go
@@ -1,5 +1,7 @@
+//go:build fips
+
 // Teleport
-// Copyright (C) 2024 Gravitational, Inc.
+// Copyright (C) 2026 Gravitational, Inc.
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by
@@ -14,11 +16,22 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-//go:build !boringcrypto
+package fipscheck
 
-package modules
+import (
+	"crypto/fips140"
+	"fmt"
+	"os"
+)
 
-// IsFIPSBuild checks if the binary was compiled in FIPS140 mode.
-func IsFIPSBuild() bool {
-	return false
+func init() {
+	// This guards against a user running teleport with `GODEBUG=fips140=off` set
+	// in their environment. They may be expecting this would disable FIPS140 mode
+	// with Teleport, but for that they need the non-fips build, as there is also a
+	// rust component that will have FIPS140 enabled.
+	if !fips140.Enabled() {
+		fmt.Fprintln(os.Stderr, "FIPS140 mode is not active in a FIPS build (GODEBUG=fips140=off).")
+		fmt.Fprintln(os.Stderr, "Install the non-FIPS Teleport OSS/Enterprise edition to disable FIPS140 mode.")
+		os.Exit(1)
+	}
 }

--- a/lib/modules/fips.go
+++ b/lib/modules/fips.go
@@ -1,5 +1,5 @@
 // Teleport
-// Copyright (C) 2024 Gravitational, Inc.
+// Copyright (C) 2026 Gravitational, Inc.
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by
@@ -14,22 +14,10 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-//go:build boringcrypto
-
 package modules
 
-import (
-	"crypto/boring"
-	_ "crypto/tls/fipsonly"
-)
+import "crypto/fips140"
 
-// IsFIPSBuild checks if the binary was compiled in FIPS140 mode.
-//
-// It's possible to enable the boringcrypto GOEXPERIMENT (which will enable the
-// boringcrypto build tag) even on platforms that don't support the boringcrypto
-// module, which results in crypto packages being available and working, but not
-// actually using a certified cryptographic module, so we have to check
-// [boring.Enabled] even if this is compiled in.
 func IsFIPSBuild() bool {
-	return boring.Enabled()
+	return fips140.Enabled()
 }

--- a/tool/tbot/main.go
+++ b/tool/tbot/main.go
@@ -35,6 +35,7 @@ import (
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/types"
 	autoupdate "github.com/gravitational/teleport/lib/autoupdate/agent"
+	_ "github.com/gravitational/teleport/lib/fipscheck"
 	"github.com/gravitational/teleport/lib/modules"
 	"github.com/gravitational/teleport/lib/observability/tracing"
 	"github.com/gravitational/teleport/lib/tbot"

--- a/tool/tctl/main.go
+++ b/tool/tctl/main.go
@@ -21,6 +21,7 @@ package main
 import (
 	"context"
 
+	_ "github.com/gravitational/teleport/lib/fipscheck"
 	"github.com/gravitational/teleport/lib/utils/signal"
 	"github.com/gravitational/teleport/tool/tctl/common"
 )

--- a/tool/teleport-update/main.go
+++ b/tool/teleport-update/main.go
@@ -34,6 +34,7 @@ import (
 	"github.com/gravitational/teleport"
 	common "github.com/gravitational/teleport/lib/autoupdate"
 	autoupdate "github.com/gravitational/teleport/lib/autoupdate/agent"
+	_ "github.com/gravitational/teleport/lib/fipscheck"
 	"github.com/gravitational/teleport/lib/modules"
 	libutils "github.com/gravitational/teleport/lib/utils"
 	logutils "github.com/gravitational/teleport/lib/utils/log"

--- a/tool/teleport/main.go
+++ b/tool/teleport/main.go
@@ -21,6 +21,7 @@ package main
 import (
 	"os"
 
+	_ "github.com/gravitational/teleport/lib/fipscheck"
 	"github.com/gravitational/teleport/lib/observability/metrics"
 	"github.com/gravitational/teleport/session/reexec"
 	"github.com/gravitational/teleport/tool/teleport/common"

--- a/tool/tsh/main.go
+++ b/tool/tsh/main.go
@@ -19,6 +19,7 @@
 package main
 
 import (
+	_ "github.com/gravitational/teleport/lib/fipscheck"
 	tshcommon "github.com/gravitational/teleport/tool/tsh/common"
 )
 


### PR DESCRIPTION
Switch to using Go-native FIPS140 builds, using the GOFIPS140 build
environment variable, from the old boringcrypto FIPS140 build. The
latter is no longer supported now that Go supports FIPS140 builds
natively.

FIPS140 is enabled across the build when FIPS=1 is passed to `make` when
building. The main package of the binaries import the `lib/fipscheck`
package to ensure that a binary is not switched into or out of FIPS140
mode at launch time using the GODEBUG environment variable.

FIPS140 builds of OSS Teleport are not a supported configuration,
however the base of the Enterprise edition is the OSS repository, so
most of the changes are in this repository. Building OSS Teleport in
FIPS140 mode may not be complete.

Stop using the fips buildbox for fips release builds, and just use the
normal centos7 buildbox. The fips buildbox sets
`GOEXPERIMENT=boringcrypto` which should no longer be set when building
with Go-native FIPS140. The fips buildbox is otherwise identical to the
non-fips buildbox.

Companion: https://github.com/gravitational/teleport.e/pull/8758
Issue: https://github.com/gravitational/teleport.e/issues/8538
Test-run: https://github.com/gravitational/teleport.e/actions/runs/25717967974

## Manual Test Plan
### Test Environment

Create a dev build of the changes. The build should include an updated e
ref that incorporates the changes from the companion PR.

### Test Cases
- [x] Check that the build passes
- [x] Download the linux fips tarball and verify they start with --fips
