### PR TITLE
refactor: return sentinel ErrDeniedAccessListDeletion for acl deletion error

### DIFF
--- a/lib/accesslists/validate.go
+++ b/lib/accesslists/validate.go
@@ -28,6 +28,10 @@ import (
 	scopedaccess "github.com/gravitational/teleport/lib/scopes/access"
 )
 
+// ErrDeniedAccessListDeletion is returned when an Access List which also also a
+// member of another Access List is attempted for deletion.
+var ErrDeniedAccessListDeletion = &trace.AccessDeniedError{Message: "Access List with nested Access List membership cannot be deleted without first removing the membership"}
+
 // ValidateAccessListWithMembers makes sure the given AccessList and it's members is valid before
 // storing it. If the existingAccessList is non-nil it also checks if this is a valid update
 // transition. It takes into account validation of the nested access lists membership.

--- a/lib/services/local/access_list.go
+++ b/lib/services/local/access_list.go
@@ -20,6 +20,7 @@ package local
 
 import (
 	"context"
+	"fmt"
 	"iter"
 	"maps"
 	"slices"
@@ -1449,8 +1450,9 @@ func (a *AccessListService) checkDeletionBlockingMemberRelationships(ctx context
 	}
 
 	if len(memberOfTitles) > 0 {
-		return trace.AccessDenied(`Cannot delete "%s", as it is a member of Access Lists: %s`,
+		errMsg := fmt.Sprintf(`Cannot delete "%s", as it is a member of Access Lists: %s`,
 			accessList.Spec.Title, quoteAndJoin(memberOfTitles))
+		return trace.Wrap(accesslists.ErrDeniedAccessListDeletion, errMsg)
 	}
 
 	return nil


### PR DESCRIPTION
Access List service does not allow deletion of an Access List which is also a member of another Access List. 
In such case, `trace.AccessDenied` error is returned. 
This PR updates the error returned type to be of a new `ErrDeniedAccessListDeletion` sentinel error so that this error 
can be compared without conflicting with Access Denied error returned by RBAC.  
