### PR TITLE
Inject build type into teleportassets.DistrolessImage

### DIFF
--- a/lib/auth/integration/integrationv1/awsoidc.go
+++ b/lib/auth/integration/integrationv1/awsoidc.go
@@ -602,6 +602,7 @@ func (s *AWSOIDCService) DeployDatabaseService(ctx context.Context, req *integra
 		Deployments:             deployments,
 		TeleportClusterName:     clusterName.GetClusterName(),
 		IntegrationName:         req.Integration,
+		TeleportBuildType:       s.modules.BuildType(),
 	})
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -764,6 +765,7 @@ func (s *AWSOIDCService) DeployService(ctx context.Context, req *integrationpb.D
 		TaskRoleARN:             req.TaskRoleArn,
 		TeleportClusterName:     clusterName.GetClusterName(),
 		TeleportVersionTag:      req.TeleportVersion,
+		TeleportBuildType:       s.modules.BuildType(),
 	})
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/integrations/awsoidc/deploydatabaseservice.go
+++ b/lib/integrations/awsoidc/deploydatabaseservice.go
@@ -47,6 +47,9 @@ type DeployDatabaseServiceRequest struct {
 	// Used to create names for Cluster and TaskDefinitions, and AWS resource tags.
 	TeleportClusterName string
 
+	// TeleportBuildType specifies the type of teleport build in use.
+	TeleportBuildType string
+
 	// IntegrationName is the integration name.
 	// Used for resource tagging when creating resources in AWS.
 	IntegrationName string
@@ -77,6 +80,10 @@ type DeployDatabaseServiceRequest struct {
 func (r *DeployDatabaseServiceRequest) CheckAndSetDefaults() error {
 	if r.Region == "" {
 		return trace.BadParameter("region is required")
+	}
+
+	if r.TeleportBuildType == "" {
+		return trace.BadParameter("build type is required")
 	}
 
 	if len(r.Deployments) == 0 {
@@ -239,6 +246,7 @@ func DeployDatabaseService(ctx context.Context, clt DeployServiceClient, req Dep
 			ResourceCreationTags: req.ResourceCreationTags,
 			Region:               req.Region,
 			TeleportConfigB64:    deployment.DeployServiceConfig,
+			TeleportBuildType:    req.TeleportBuildType,
 		}
 		logDeployment.DebugContext(ctx, "Upsert ECS TaskDefinition.")
 		taskDefinition, err := upsertTask(ctx, clt, upsertTaskReq)

--- a/lib/integrations/awsoidc/deploydatabaseservice_test.go
+++ b/lib/integrations/awsoidc/deploydatabaseservice_test.go
@@ -40,6 +40,7 @@ import (
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/cloud/aws/tags"
+	"github.com/gravitational/teleport/lib/modules"
 )
 
 func TestDeployDatabaseServiceRequest_CheckAndSetDefaults(t *testing.T) {
@@ -49,6 +50,7 @@ func TestDeployDatabaseServiceRequest_CheckAndSetDefaults(t *testing.T) {
 
 	baseReqFn := func() DeployDatabaseServiceRequest {
 		return DeployDatabaseServiceRequest{
+			TeleportBuildType:   modules.BuildOSS,
 			TeleportClusterName: "mycluster",
 			Region:              "r",
 			TaskRoleARN:         "arn",
@@ -81,6 +83,15 @@ func TestDeployDatabaseServiceRequest_CheckAndSetDefaults(t *testing.T) {
 			req: func() DeployDatabaseServiceRequest {
 				r := baseReqFn()
 				r.TeleportClusterName = ""
+				return r
+			},
+			errCheck: isBadParamErrFn,
+		},
+		{
+			name: "missing teleport build type",
+			req: func() DeployDatabaseServiceRequest {
+				r := baseReqFn()
+				r.TeleportBuildType = ""
 				return r
 			},
 			errCheck: isBadParamErrFn,
@@ -154,6 +165,7 @@ func TestDeployDatabaseServiceRequest_CheckAndSetDefaults(t *testing.T) {
 			errCheck: require.NoError,
 			expected: &DeployDatabaseServiceRequest{
 				TeleportClusterName: "mycluster",
+				TeleportBuildType:   modules.BuildOSS,
 				TeleportVersionTag:  teleport.Version,
 				Region:              "r",
 				TaskRoleARN:         "arn",
@@ -399,6 +411,7 @@ func TestDeployDatabaseService(t *testing.T) {
 	ctx := context.Background()
 	t.Run("fails to get account id", func(t *testing.T) {
 		_, err := DeployDatabaseService(ctx, &mockDeployServiceClient{}, DeployDatabaseServiceRequest{
+			TeleportBuildType:   modules.BuildOSS,
 			Region:              "us-east-1",
 			TaskRoleARN:         "my-role",
 			TeleportClusterName: "cluster-name",
@@ -424,6 +437,7 @@ func TestDeployDatabaseService(t *testing.T) {
 		resp, err := DeployDatabaseService(ctx,
 			mockClient,
 			DeployDatabaseServiceRequest{
+				TeleportBuildType:       modules.BuildOSS,
 				Region:                  "us-east-1",
 				TaskRoleARN:             "my-role",
 				TeleportClusterName:     "cluster-name",
@@ -457,6 +471,7 @@ func TestDeployDatabaseService(t *testing.T) {
 		resp, err := DeployDatabaseService(ctx,
 			mockClient,
 			DeployDatabaseServiceRequest{
+				TeleportBuildType:       modules.BuildOSS,
 				Region:                  "us-east-1",
 				TaskRoleARN:             "my-role",
 				TeleportClusterName:     "cluster-name",
@@ -535,6 +550,7 @@ func TestDeployDatabaseService(t *testing.T) {
 				iamTokenMissing: true,
 			},
 			DeployDatabaseServiceRequest{
+				TeleportBuildType:       modules.BuildOSS,
 				Region:                  "us-east-1",
 				TaskRoleARN:             "my-role",
 				TeleportClusterName:     "cluster-name",

--- a/lib/integrations/awsoidc/deployservice.go
+++ b/lib/integrations/awsoidc/deployservice.go
@@ -153,6 +153,9 @@ type DeployServiceRequest struct {
 	// TeleportConfigString is the `teleport.yaml` configuration for the service to be deployed.
 	// It should be base64 encoded as is expected by the `--config-string` param of `teleport start`.
 	TeleportConfigString string
+
+	// TeleportBuildType specifies the type of teleport build in use.
+	TeleportBuildType string
 }
 
 // normalizeECSResourceName converts a name into a valid ECS Resource Name.
@@ -221,6 +224,10 @@ func (r *DeployServiceRequest) CheckAndSetDefaults() error {
 
 	if len(r.SubnetIDs) == 0 {
 		return trace.BadParameter("at least one subnet id is required")
+	}
+
+	if r.TeleportBuildType == "" {
+		return trace.BadParameter("build type is required")
 	}
 
 	if r.TaskRoleARN == "" {
@@ -424,6 +431,7 @@ func DeployService(ctx context.Context, clt DeployServiceClient, req DeployServi
 		ResourceCreationTags: req.ResourceCreationTags,
 		Region:               req.Region,
 		TeleportConfigB64:    req.TeleportConfigString,
+		TeleportBuildType:    req.TeleportBuildType,
 	}
 	taskDefinition, err := upsertTask(ctx, clt, upsertTaskReq)
 	if err != nil {
@@ -475,11 +483,12 @@ type upsertTaskRequest struct {
 	ResourceCreationTags tags.AWSTags
 	Region               string
 	TeleportConfigB64    string
+	TeleportBuildType    string
 }
 
 // upsertTask ensures a TaskDefinition with TaskName exists
 func upsertTask(ctx context.Context, clt DeployServiceClient, req upsertTaskRequest) (*ecsTypes.TaskDefinition, error) {
-	taskAgentContainerImage, err := getDistrolessTeleportImage(req.TeleportVersionTag)
+	taskAgentContainerImage, err := getDistrolessTeleportImage(req.TeleportVersionTag, req.TeleportBuildType)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -770,11 +779,11 @@ func upsertService(ctx context.Context, clt DeployServiceClient, req upsertServi
 }
 
 // getDistrolessTeleportImage returns the distroless teleport image string
-func getDistrolessTeleportImage(version string) (string, error) {
+func getDistrolessTeleportImage(version string, buildType string) (string, error) {
 	semVer, err := semver.NewVersion(version)
 	if err != nil {
 		return "", trace.BadParameter("invalid version tag %s", version)
 	}
 
-	return teleportassets.DistrolessImage(*semVer), nil
+	return teleportassets.DistrolessImage(*semVer, buildType), nil
 }

--- a/lib/integrations/awsoidc/deployservice_test.go
+++ b/lib/integrations/awsoidc/deployservice_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/automaticupgrades"
 	"github.com/gravitational/teleport/lib/cloud/aws/tags"
+	"github.com/gravitational/teleport/lib/modules"
 )
 
 func TestDeployServiceRequest(t *testing.T) {
@@ -42,6 +43,7 @@ func TestDeployServiceRequest(t *testing.T) {
 
 	baseReqFn := func() DeployServiceRequest {
 		return DeployServiceRequest{
+			TeleportBuildType:       modules.BuildOSS,
 			TeleportClusterName:     "mycluster",
 			Region:                  "r",
 			SubnetIDs:               []string{"1"},
@@ -71,6 +73,15 @@ func TestDeployServiceRequest(t *testing.T) {
 			req: func() DeployServiceRequest {
 				r := baseReqFn()
 				r.TeleportClusterName = ""
+				return r
+			},
+			errCheck: isBadParamErrFn,
+		},
+		{
+			name: "missing teleport build type ",
+			req: func() DeployServiceRequest {
+				r := baseReqFn()
+				r.TeleportBuildType = ""
 				return r
 			},
 			errCheck: isBadParamErrFn,
@@ -143,6 +154,7 @@ func TestDeployServiceRequest(t *testing.T) {
 			req:      baseReqFn,
 			errCheck: require.NoError,
 			reqWithDefaults: DeployServiceRequest{
+				TeleportBuildType:       modules.BuildOSS,
 				TeleportClusterName:     "mycluster",
 				TeleportVersionTag:      teleport.Version,
 				Region:                  "r",
@@ -240,7 +252,10 @@ func TestUpsertTask(t *testing.T) {
 
 	semVer := teleport.SemVer()
 	semVer.PreRelease = ""
-	taskDefinition, err := upsertTask(ctx, mockClient, upsertTaskRequest{TeleportVersionTag: semVer.String()})
+	taskDefinition, err := upsertTask(ctx, mockClient, upsertTaskRequest{
+		TeleportVersionTag: semVer.String(),
+		TeleportBuildType:  modules.BuildOSS,
+	})
 	require.NoError(t, err)
 	require.Equal(t, expected, taskDefinition.ContainerDefinitions[0].Environment)
 }

--- a/lib/integrations/awsoidc/deployservice_update.go
+++ b/lib/integrations/awsoidc/deployservice_update.go
@@ -46,6 +46,8 @@ type UpdateServiceRequest struct {
 	TeleportVersionTag string
 	// OwnershipTags specifies ownership tags
 	OwnershipTags tags.AWSTags
+	// TeleportBuildType specifies the type of teleport build in use.
+	TeleportBuildType string
 }
 
 // CheckAndSetDefaults checks and sets default config values.
@@ -62,6 +64,10 @@ func (req *UpdateServiceRequest) CheckAndSetDefaults() error {
 		return trace.BadParameter("ownership tags required")
 	}
 
+	if req.TeleportBuildType == "" {
+		return trace.BadParameter("teleport build type required")
+	}
+
 	return nil
 }
 
@@ -71,7 +77,7 @@ func UpdateDeployService(ctx context.Context, clt DeployServiceClient, log *slog
 		return trace.Wrap(err)
 	}
 
-	teleportImage, err := getDistrolessTeleportImage(req.TeleportVersionTag)
+	teleportImage, err := getDistrolessTeleportImage(req.TeleportVersionTag, req.TeleportBuildType)
 	if err != nil {
 		return trace.Wrap(err)
 	}

--- a/lib/integrations/awsoidc/deployservice_update_test.go
+++ b/lib/integrations/awsoidc/deployservice_update_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/automaticupgrades"
+	"github.com/gravitational/teleport/lib/modules"
 	"github.com/gravitational/teleport/lib/utils/log/logtest"
 )
 
@@ -191,6 +192,7 @@ func TestUpdateDeployServices(t *testing.T) {
 		}
 
 		err := UpdateDeployService(ctx, m, log, UpdateServiceRequest{
+			TeleportBuildType:   modules.BuildOSS,
 			TeleportClusterName: clusterName,
 			TeleportVersionTag:  teleportVersion,
 			OwnershipTags:       ownershipTags,
@@ -227,6 +229,7 @@ func TestUpdateDeployServices(t *testing.T) {
 		}
 
 		err := UpdateDeployService(ctx, m, log, UpdateServiceRequest{
+			TeleportBuildType:   modules.BuildOSS,
 			TeleportClusterName: clusterName,
 			TeleportVersionTag:  teleportVersion,
 			OwnershipTags:       ownershipTags,
@@ -285,6 +288,7 @@ func TestUpdateDeployServices(t *testing.T) {
 		}
 
 		err := UpdateDeployService(ctx, m, log, UpdateServiceRequest{
+			TeleportBuildType:   modules.BuildOSS,
 			TeleportClusterName: clusterName,
 			TeleportVersionTag:  teleportVersion,
 			OwnershipTags:       ownershipTags,
@@ -355,6 +359,7 @@ func TestUpdateDeployServices(t *testing.T) {
 		}
 
 		err := UpdateDeployService(ctx, m, log, UpdateServiceRequest{
+			TeleportBuildType:   modules.BuildOSS,
 			TeleportClusterName: clusterName,
 			TeleportVersionTag:  teleportVersion,
 			OwnershipTags:       ownershipTags,
@@ -378,6 +383,7 @@ func TestUpdateDeployServices(t *testing.T) {
 		m := &mockDeployServiceClient{}
 
 		err := UpdateDeployService(ctx, m, log, UpdateServiceRequest{
+			TeleportBuildType:   modules.BuildOSS,
 			TeleportClusterName: clusterName,
 			TeleportVersionTag:  teleportVersion,
 			OwnershipTags:       ownershipTags,

--- a/lib/integrations/awsoidc/deployservice_vcr_test.go
+++ b/lib/integrations/awsoidc/deployservice_vcr_test.go
@@ -29,6 +29,7 @@ import (
 	"gopkg.in/dnaeon/go-vcr.v3/recorder"
 
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/modules"
 )
 
 func TestDeployDBService(t *testing.T) {
@@ -78,8 +79,9 @@ func TestDeployDBService(t *testing.T) {
 
 	deployServiceReqFunc := func(clusterName string) DeployServiceRequest {
 		return DeployServiceRequest{
-			Region:    awsRegion,
-			AccountID: awsAccountID,
+			Region:            awsRegion,
+			TeleportBuildType: modules.BuildOSS,
+			AccountID:         awsAccountID,
 			SubnetIDs: []string{
 				"subnet-0b7ab67161173748b",
 				"subnet-0dda93c8621eb2e99",

--- a/lib/service/awsoidc.go
+++ b/lib/service/awsoidc.go
@@ -87,6 +87,7 @@ func (process *TeleportProcess) initAWSOIDCDeployServiceUpdater(channels automat
 		TeleportClusterName:    clusterNameConfig.GetClusterName(),
 		TeleportClusterVersion: resp.GetServerVersion(),
 		UpgradeChannel:         upgradeChannel,
+		TeleportBuildType:      process.Config.Modules.BuildType(),
 	})
 	if err != nil {
 		return trace.Wrap(err)
@@ -136,6 +137,8 @@ type AWSOIDCDeployServiceUpdaterConfig struct {
 	TeleportClusterVersion string
 	// UpgradeChannel is the channel that serves the version used by the updater.
 	UpgradeChannel *automaticupgrades.Channel
+	// TeleportBuildType specifies the type of teleport build in use.
+	TeleportBuildType string
 }
 
 // CheckAndSetDefaults checks and sets default config values.
@@ -154,6 +157,10 @@ func (cfg *AWSOIDCDeployServiceUpdaterConfig) CheckAndSetDefaults() error {
 
 	if cfg.TeleportClusterVersion == "" {
 		return trace.BadParameter("teleport cluster version required")
+	}
+
+	if cfg.TeleportBuildType == "" {
+		return trace.BadParameter("teleport build type required")
 	}
 
 	if cfg.UpgradeChannel == nil {
@@ -349,6 +356,7 @@ func (updater *AWSOIDCDeployServiceUpdater) updateAWSOIDCDeployService(ctx conte
 		"new_version", teleportVersion,
 	)
 	if err := awsoidc.UpdateDeployService(ctx, awsOIDCDeployServiceClient, updater.Log, awsoidc.UpdateServiceRequest{
+		TeleportBuildType:   updater.TeleportBuildType,
 		TeleportClusterName: updater.TeleportClusterName,
 		TeleportVersionTag:  teleportVersion.String(),
 		OwnershipTags:       ownershipTags,

--- a/lib/utils/teleportassets/teleportassets.go
+++ b/lib/utils/teleportassets/teleportassets.go
@@ -100,9 +100,9 @@ const (
 )
 
 // DistrolessImage returns the distroless teleport image repo.
-func DistrolessImage(version semver.Version) string {
+func DistrolessImage(version semver.Version, buildType string) string {
 	repo := distrolessImageRepo(version)
-	name := distrolessImageName(modules.GetModules().BuildType())
+	name := distrolessImageName(buildType)
 	return fmt.Sprintf("%s/%s:%s", repo, name, version)
 }
 

--- a/lib/utils/teleportassets/teleportassets_test.go
+++ b/lib/utils/teleportassets/teleportassets_test.go
@@ -25,7 +25,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/gravitational/teleport/lib/modules"
-	"github.com/gravitational/teleport/lib/modules/modulestest"
 )
 
 func TestDistrolessTeleportImageRepo(t *testing.T) {
@@ -76,8 +75,7 @@ func TestDistrolessTeleportImageRepo(t *testing.T) {
 		t.Run(test.desc, func(t *testing.T) {
 			semVer, err := semver.NewVersion(test.version)
 			require.NoError(t, err)
-			modulestest.SetTestModules(t, modulestest.Modules{TestBuildType: test.buildType})
-			require.Equal(t, test.want, DistrolessImage(*semVer))
+			require.Equal(t, test.want, DistrolessImage(*semVer, test.buildType))
 		})
 	}
 }


### PR DESCRIPTION
This is purely mechanical change to inject the build type as a depency instead of relying on modules.GetModules().BuildType().

In addition to contributing to https://github.com/gravitational/teleport/issues/62799 this also serves as a prerequisite to future work that will provide a user supplied build type that is not based on the modules to retrieve the correct image.