### PR TITLE
app: Match public_addr case-insensitively

### DIFF
--- a/docs/pages/reference/access-controls/predicate-language.mdx
+++ b/docs/pages/reference/access-controls/predicate-language.mdx
@@ -69,6 +69,7 @@ The language also supports the following functions:
 | Functions (with examples)                    | Description                                                |
 |----------------------------------------------|------------------------------------------------------------|
 | `equals(labels["env"], "prod")`              | resources with label key `env` equal to label value `prod` |
+| `equalsFold(resource.spec.public_addr, "myapp.example.com")` | case-insensitive equality; for hostnames or other case-insensitive identifiers |
 | `exists(labels["env"])`                      | resources with a label key `env`; label value unchecked    |
 | `!exists(labels["env"])`                     | resources without a label key `env`; label value unchecked |
 | `search("foo", "bar", "some phrase")`        | fuzzy match against common resource fields                 |

--- a/lib/services/parser.go
+++ b/lib/services/parser.go
@@ -1001,6 +1001,9 @@ func NewResourceExpression(expression string) (typical.Expression[types.Resource
 			"equals": typical.BinaryFunction[types.ResourceWithLabels](func(a, b string) (bool, error) {
 				return strings.Compare(a, b) == 0, nil
 			}),
+			"equalsFold": typical.BinaryFunction[types.ResourceWithLabels](func(a, b string) (bool, error) {
+				return strings.EqualFold(a, b), nil
+			}),
 			"search": typical.UnaryVariadicFunctionWithEnv(func(r types.ResourceWithLabels, v ...string) (bool, error) {
 				return r.MatchSearch(v), nil
 			}),

--- a/lib/services/parser_test.go
+++ b/lib/services/parser_test.go
@@ -195,6 +195,10 @@ func TestNewResourceExpression(t *testing.T) {
 			`!equals(labels.undefined, "prod")`,
 			`equals(resource.spec.hostname, "test-hostname")`,
 			`equals(health.status, "")`,
+			// Test equalsFold.
+			`equalsFold(resource.spec.hostname, "TEST-HOSTNAME")`,
+			`equalsFold(resource.metadata.name, "Test-Name")`,
+			`!equalsFold(resource.spec.hostname, "different")`,
 			// Test search.
 			`search("mac")`,
 			`search("os", "mac", "prod")`,
@@ -253,6 +257,7 @@ func TestNewResourceExpression(t *testing.T) {
 			`equals(resource.spec.hostname, "wrong-value")`,
 			`search("mac", "not-found")`,
 			`hasPrefix(name, "x")`,
+			`equalsFold(resource.spec.hostname, "different")`,
 		}
 		for _, expr := range exprs {
 			t.Run(expr, func(t *testing.T) {

--- a/lib/srv/app/server.go
+++ b/lib/srv/app/server.go
@@ -665,9 +665,7 @@ func (s *Server) GetAppByPublicAddress(ctx context.Context, publicAddr string) (
 	defer s.mu.RUnlock()
 	// don't call s.getApps() as this will call RLock and potentially deadlock.
 	for _, a := range s.apps {
-		// DNS hostnames are case-insensitive; the Host-header path
-		// in lib/web/app/match.go uses the same comparison.
-		if strings.EqualFold(publicAddr, a.GetPublicAddr()) {
+		if strings.EqualFold(a.GetPublicAddr(), publicAddr) {
 			return s.appWithUpdatedLabelsLocked(a), nil
 		}
 	}

--- a/lib/srv/app/server.go
+++ b/lib/srv/app/server.go
@@ -25,6 +25,7 @@ import (
 	"context"
 	"log/slog"
 	"net"
+	"strings"
 	"sync"
 	"time"
 
@@ -664,7 +665,9 @@ func (s *Server) GetAppByPublicAddress(ctx context.Context, publicAddr string) (
 	defer s.mu.RUnlock()
 	// don't call s.getApps() as this will call RLock and potentially deadlock.
 	for _, a := range s.apps {
-		if publicAddr == a.GetPublicAddr() {
+		// DNS hostnames are case-insensitive; the Host-header path
+		// in lib/web/app/match.go uses the same comparison.
+		if strings.EqualFold(publicAddr, a.GetPublicAddr()) {
 			return s.appWithUpdatedLabelsLocked(a), nil
 		}
 	}

--- a/lib/srv/app/server_test.go
+++ b/lib/srv/app/server_test.go
@@ -1457,6 +1457,44 @@ func TestCleanupOrphanedAppServers(t *testing.T) {
 	}
 }
 
+// TestGetAppByPublicAddressCaseInsensitive guards the case-insensitive
+// hostname comparison in GetAppByPublicAddress. The Web app router
+// upstream passes the request Host header, which browsers lowercase
+// before sending, so a mixed-case stored public_addr that compared
+// by `==` would silently miss every routing lookup.
+func TestGetAppByPublicAddressCaseInsensitive(t *testing.T) {
+	app, err := types.NewAppV3(
+		types.Metadata{Name: "myapp"},
+		types.AppSpecV3{URI: "http://localhost", PublicAddr: "MyApp.Example.Com"},
+	)
+	require.NoError(t, err)
+	s := &Server{
+		c:    &Config{},
+		apps: map[string]types.Application{app.GetName(): app},
+	}
+
+	tests := []struct {
+		query   string
+		wantHit bool
+	}{
+		{query: "myapp.example.com", wantHit: true},
+		{query: "MYAPP.EXAMPLE.COM", wantHit: true},
+		{query: "MyApp.Example.Com", wantHit: true},
+		{query: "other.example.com", wantHit: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.query, func(t *testing.T) {
+			got, err := s.GetAppByPublicAddress(context.Background(), tt.query)
+			if tt.wantHit {
+				require.NoError(t, err)
+				require.Equal(t, "myapp", got.GetName())
+			} else {
+				require.Error(t, err)
+			}
+		})
+	}
+}
+
 var (
 	staticLabels = map[string]string{
 		"bar": "baz",

--- a/lib/tbot/services/beams/vnet_service.go
+++ b/lib/tbot/services/beams/vnet_service.go
@@ -356,8 +356,11 @@ func (v *vnetApplicationService) ResolveFQDN(ctx context.Context, fqdn string) (
 		return nil, trace.Wrap(err)
 	}
 
+	// equalsFold because public_addr may be stored with mixed case
+	// but DNS hostnames are case-insensitive, so a browser-issued
+	// fqdn arrives lowercased.
 	expr := fmt.Sprintf(
-		`resource.spec.public_addr == %+q || resource.spec.public_addr == %+q`,
+		`equalsFold(resource.spec.public_addr, %+q) || equalsFold(resource.spec.public_addr, %+q)`,
 		fqdn,
 		strings.TrimSuffix(fqdn, "."),
 	)

--- a/lib/vnet/fqdn_resolver.go
+++ b/lib/vnet/fqdn_resolver.go
@@ -254,7 +254,9 @@ func (r *fqdnResolver) resolveAppInfoForCluster(
 	log := log.With("profile", candidate.profileName, "leaf_cluster", candidate.leafClusterName, "fqdn", fqdn)
 
 	// An app public_addr could technically be fully-qualified or not, match either way.
-	expr := fmt.Sprintf(`resource.spec.public_addr == "%s" || resource.spec.public_addr == "%s"`,
+	// equalsFold is needed because public_addr may be stored with mixed case but DNS
+	// hostnames are case-insensitive, so a browser-issued fqdn arrives lowercased.
+	expr := fmt.Sprintf(`equalsFold(resource.spec.public_addr, "%s") || equalsFold(resource.spec.public_addr, "%s")`,
 		strings.TrimSuffix(fqdn, "."), fqdn)
 
 	// If candidate is a leaf cluster and fqdn possibly points to a leaf
@@ -295,7 +297,9 @@ func (r *fqdnResolver) resolveAppInfoForCluster(
 			if !ok {
 				return nil, trace.BadParameter("expected *types.AppV3, got %T", resource.GetApp())
 			}
-			matchedByPublicAddr := dns.FullyQualify(app.GetPublicAddr()) == fqdn
+			// DNS hostnames are case-insensitive; the backend predicate
+			// above uses equalsFold, so this local check must too.
+			matchedByPublicAddr := strings.EqualFold(dns.FullyQualify(app.GetPublicAddr()), fqdn)
 			matchedByName := app.GetName() == potentialAppName
 			if !matchedByName && !matchedByPublicAddr {
 				// This shouldn't happen if the backend query worked correctly.

--- a/lib/vnet/fqdn_resolver.go
+++ b/lib/vnet/fqdn_resolver.go
@@ -297,8 +297,7 @@ func (r *fqdnResolver) resolveAppInfoForCluster(
 			if !ok {
 				return nil, trace.BadParameter("expected *types.AppV3, got %T", resource.GetApp())
 			}
-			// DNS hostnames are case-insensitive; the backend predicate
-			// above uses equalsFold, so this local check must too.
+			// Match the backend equalsFold predicate above.
 			matchedByPublicAddr := strings.EqualFold(dns.FullyQualify(app.GetPublicAddr()), fqdn)
 			matchedByName := app.GetName() == potentialAppName
 			if !matchedByName && !matchedByPublicAddr {

--- a/lib/vnet/fqdn_resolver.go
+++ b/lib/vnet/fqdn_resolver.go
@@ -256,7 +256,7 @@ func (r *fqdnResolver) resolveAppInfoForCluster(
 	// An app public_addr could technically be fully-qualified or not, match either way.
 	// equalsFold is needed because public_addr may be stored with mixed case but DNS
 	// hostnames are case-insensitive, so a browser-issued fqdn arrives lowercased.
-	expr := fmt.Sprintf(`equalsFold(resource.spec.public_addr, "%s") || equalsFold(resource.spec.public_addr, "%s")`,
+	expr := fmt.Sprintf(`equalsFold(resource.spec.public_addr, %+q) || equalsFold(resource.spec.public_addr, %+q)`,
 		strings.TrimSuffix(fqdn, "."), fqdn)
 
 	// If candidate is a leaf cluster and fqdn possibly points to a leaf
@@ -270,7 +270,7 @@ func (r *fqdnResolver) resolveAppInfoForCluster(
 	var potentialAppName string
 	if candidate.leafClusterName != "" && isDirectSubdomain(fqdn, candidate.profileName) {
 		potentialAppName = strings.TrimSuffix(fqdn, "."+dns.FullyQualify(candidate.profileName))
-		expr += fmt.Sprintf(` || name == "%s"`, potentialAppName)
+		expr += fmt.Sprintf(` || name == %+q`, potentialAppName)
 	}
 
 	resp, err := apiclient.GetResourcePage[types.AppServer](ctx, candidate.client.CurrentCluster(), &proto.ListResourcesRequest{

--- a/lib/web/app/handler.go
+++ b/lib/web/app/handler.go
@@ -565,7 +565,7 @@ func (h *Handler) checkForDualCredentialMismatch(outerIdentity *tlsca.Identity, 
 	if outerIdentity.RouteToApp.ClusterName != innerIdentity.RouteToApp.ClusterName {
 		return trace.AccessDenied("cluster name %q does not match session cluster name %q", outerIdentity.RouteToApp.ClusterName, innerIdentity.RouteToApp.ClusterName)
 	}
-	if innerIdentity.RouteToApp.PublicAddr != "" && outerIdentity.RouteToApp.PublicAddr != innerIdentity.RouteToApp.PublicAddr {
+	if innerIdentity.RouteToApp.PublicAddr != "" && !strings.EqualFold(outerIdentity.RouteToApp.PublicAddr, innerIdentity.RouteToApp.PublicAddr) {
 		return trace.AccessDenied("app public address %q does not match session public app address %q", outerIdentity.RouteToApp.PublicAddr, innerIdentity.RouteToApp.PublicAddr)
 	}
 	// RouteToApp.Name may not be set in web cookie flows.

--- a/lib/web/app/handler.go
+++ b/lib/web/app/handler.go
@@ -645,7 +645,7 @@ func HasName(r *http.Request, proxyPublicAddrs []utils.NetAddr) (string, bool) {
 		if net.ParseIP(raddr.Host()) != nil {
 			return "", false
 		}
-		if raddr.Host() == paddr.Host() {
+		if strings.EqualFold(raddr.Host(), paddr.Host()) {
 			return "", false
 		}
 	}

--- a/lib/web/app/handler_test.go
+++ b/lib/web/app/handler_test.go
@@ -1447,6 +1447,17 @@ func Test_checkForDualCredentialMismatch(t *testing.T) {
 			outerIdentity: *appSessionIdentity,
 		},
 		{
+			// DNS hostnames are case-insensitive, so an outer cookie with
+			// a mixed-case PublicAddr must still match the inner session.
+			name:         "public addr case-insensitive match",
+			innerSession: appSession,
+			outerIdentity: func() tlsca.Identity {
+				id := *appSessionIdentity
+				id.RouteToApp.PublicAddr = "APP.EXAMPLE.COM"
+				return id
+			}(),
+		},
+		{
 			// Session has no RouteToApp.Name; public addr mismatch should still fail.
 			name:         "no app name in session, public addr mismatch",
 			innerSession: appSessionNoName,

--- a/lib/web/app/match.go
+++ b/lib/web/app/match.go
@@ -49,9 +49,12 @@ func MatchUnshuffled(ctx context.Context, cluster reversetunnelclient.Cluster, f
 type Matcher func(readonly.AppServer) bool
 
 // MatchPublicAddr matches on the public address of an application.
+// Comparison is case-insensitive because DNS names are
+// case-insensitive and browsers lowercase the Host header before
+// sending it.
 func MatchPublicAddr(publicAddr string) Matcher {
 	return func(appServer readonly.AppServer) bool {
-		return appServer.GetApp().GetPublicAddr() == publicAddr
+		return strings.EqualFold(appServer.GetApp().GetPublicAddr(), publicAddr)
 	}
 }
 

--- a/lib/web/app/match_test.go
+++ b/lib/web/app/match_test.go
@@ -87,3 +87,22 @@ type mockDialConn struct {
 func (c *mockDialConn) Close() error {
 	return nil
 }
+
+// TestMatchPublicAddrCaseInsensitive guards the case-insensitive
+// hostname comparison in MatchPublicAddr. Browsers lowercase the
+// Host header, so a mixed-case stored public_addr that compared by
+// == would silently miss every preflight and routing lookup.
+func TestMatchPublicAddrCaseInsensitive(t *testing.T) {
+	app, err := types.NewAppV3(
+		types.Metadata{Name: "test-app", Namespace: defaults.Namespace},
+		types.AppSpecV3{URI: "https://app.localhost", PublicAddr: "MyApp.Example.Com"},
+	)
+	require.NoError(t, err)
+	appServer, err := types.NewAppServerV3FromApp(app, "localhost", "123")
+	require.NoError(t, err)
+
+	require.True(t, MatchPublicAddr("myapp.example.com")(appServer))
+	require.True(t, MatchPublicAddr("MYAPP.EXAMPLE.COM")(appServer))
+	require.True(t, MatchPublicAddr("MyApp.Example.Com")(appServer))
+	require.False(t, MatchPublicAddr("other.example.com")(appServer))
+}

--- a/lib/web/app/match_test.go
+++ b/lib/web/app/match_test.go
@@ -90,8 +90,8 @@ func (c *mockDialConn) Close() error {
 
 // TestMatchPublicAddrCaseInsensitive guards the case-insensitive
 // hostname comparison in MatchPublicAddr. Browsers lowercase the
-// Host header, so a mixed-case stored public_addr that compared by
-// == would silently miss every preflight and routing lookup.
+// Host header, so a mixed-case stored public_addr must still match
+// when the request hostname is folded to a different case.
 func TestMatchPublicAddrCaseInsensitive(t *testing.T) {
 	app, err := types.NewAppV3(
 		types.Metadata{Name: "test-app", Namespace: defaults.Namespace},

--- a/lib/web/app/middleware.go
+++ b/lib/web/app/middleware.go
@@ -23,6 +23,7 @@ import (
 	"net"
 	"net/http"
 	"strconv"
+	"strings"
 
 	"github.com/gravitational/trace"
 	"github.com/julienschmidt/httprouter"
@@ -110,9 +111,11 @@ func (h *Handler) redirectToLauncher(w http.ResponseWriter, r *http.Request, p l
 }
 
 // validateAppAddr checks that appAddr does not match proxyHost
-// and returns an error on conflict.
+// and returns an error on conflict. DNS hostnames are
+// case-insensitive, so a mixed-case app public_addr must not be
+// treated as distinct from a lowercase proxy host.
 func (h *Handler) validateAppAddr(ctx context.Context, appAddr, proxyHost string) error {
-	if appAddr != proxyHost {
+	if !strings.EqualFold(appAddr, proxyHost) {
 		return nil
 	}
 	const errMsg = "Application public address conflicts with the " +

--- a/lib/web/app/transport.go
+++ b/lib/web/app/transport.go
@@ -213,7 +213,6 @@ func (t *transport) rewriteRedirect(resp *http.Response) error {
 
 	// If this is a redirect to a public addr of a leaf cluster, rewrite it.
 	// We want the rewrite to happen using our own public address.
-	// DNS hostnames are case-insensitive, so compare with EqualFold.
 	if strings.EqualFold(host, t.c.identity.RouteToApp.PublicAddr) {
 		// drop scheme and host, leaving only the relative path.
 		u.Host = ""

--- a/lib/web/app/transport.go
+++ b/lib/web/app/transport.go
@@ -213,7 +213,8 @@ func (t *transport) rewriteRedirect(resp *http.Response) error {
 
 	// If this is a redirect to a public addr of a leaf cluster, rewrite it.
 	// We want the rewrite to happen using our own public address.
-	if host == t.c.identity.RouteToApp.PublicAddr {
+	// DNS hostnames are case-insensitive, so compare with EqualFold.
+	if strings.EqualFold(host, t.c.identity.RouteToApp.PublicAddr) {
 		// drop scheme and host, leaving only the relative path.
 		u.Host = ""
 		u.Scheme = ""


### PR DESCRIPTION
Match `public_addr` case-insensitively in every Go call site and in the resource expression predicate language. DNS hostnames are case-insensitive per RFC 1035 and browsers lowercase the Host header before sending, so a mixed-case stored `public_addr` is invisible to routing today.

Switch four Go call sites to `strings.EqualFold`: `GetAppByPublicAddress` in the app server, `MatchPublicAddr` in the web app router, `checkForDualCredentialMismatch` in the web app handler, and `rewriteRedirect` in the web app transport.

Add an `equalsFold` function to the resource expression language so the predicate string passed to `ListResources` also case-folds. Without it the VNet FQDN resolver and the tbot Beams VNet service miss mixed-case stored values at the backend filter step, before any Go-side comparison runs. The new function mirrors `equals` and matches `strings.EqualFold`.

The companion PR https://github.com/gravitational/teleport/pull/65728 makes app `metadata.name` strictly lowercase; `public_addr` stays case-preserving and this PR closes the gap so routing matches across the case boundary.

Changelog: Fix application routing when `public_addr` is stored with mixed case.

## Manual Test Plan

### Test Environment

- Local Teleport built from this branch at `tp/app-validation-eqfold/build/teleport`
- Local instance on alt ports (web `13443`, auth `13025`, tunnel `13024`, listen `13023`) using the cluster name `eqfold.t.tp`
- Static `app_service` registers one app with `name: myapp` and `public_addr: MyApp.t.tp` (mixed case)
- Admin identity exported via `tctl auth sign --user=testuser --out=/tmp/eqfold-testuser`
- A no-op HTTP backend listening on `127.0.0.1:18876`

### Test Cases

- [x] `tctl get app_servers` shows the app stored as `public_addr: MyApp.t.tp` (case preserved, no auto-lowercase)
- [x] `tsh apps ls --query='equalsFold(resource.spec.public_addr, "myapp.t.tp")'` returns the app, proving the new predicate function is recognised and evaluated server-side and that a lowercase query matches a mixed-case stored value
- [x] `tsh apps ls --query='resource.spec.public_addr == "myapp.t.tp"'` returns nothing, confirming the old `==` predicate misses the same value and that `equalsFold` is doing real work
- [x] `tsh apps ls --query='resource.spec.public_addr == "MyApp.t.tp"'` returns the app, sanity check that the backend really holds the mixed-case form
