### PR TITLE
feat: Allow sort menu items to be hidden

### DIFF
--- a/web/packages/shared/components/Controls/SortMenu.story.tsx
+++ b/web/packages/shared/components/Controls/SortMenu.story.tsx
@@ -59,6 +59,15 @@ export default {
         disableSort: true,
         defaultOrder: 'DESC',
       },
+      {
+        key: 'no-label-key',
+        label: '',
+      },
+      {
+        key: 'hidden',
+        label: 'Should be invisible',
+        hidden: true,
+      },
     ],
     selectedKey: 'name',
     selectedOrder: 'ASC',

--- a/web/packages/shared/components/Controls/SortMenu.test.tsx
+++ b/web/packages/shared/components/Controls/SortMenu.test.tsx
@@ -230,28 +230,28 @@ describe('SortMenu', () => {
     expect(onChange).toHaveBeenCalledTimes(1);
     expect(onChange).toHaveBeenLastCalledWith('test-2', 'DESC');
   });
-});
 
-it('shows the item key if the label is empty', async () => {
-  const { user, onChange } = renderComponent({
-    props: {
-      items: [
-        {
-          key: 'test1',
-          label: '',
-        },
-      ],
-      selectedKey: 'test1',
-      selectedOrder: 'ASC',
-    },
+  it('shows the item key if the label is empty', async () => {
+    const { user, onChange } = renderComponent({
+      props: {
+        items: [
+          {
+            key: 'test1',
+            label: '',
+          },
+        ],
+        selectedKey: 'test1',
+        selectedOrder: 'ASC',
+      },
+    });
+    await openMenu(user, 'test1');
+    const menu = screen.getByRole('menu');
+    const t1 = within(menu).getByRole('menuitem', { name: 'test1' });
+    expect(t1).toBeInTheDocument();
+    await user.click(t1);
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange).toHaveBeenLastCalledWith('test1', 'ASC');
   });
-  await openMenu(user, 'test1');
-  const menu = screen.getByRole('menu');
-  const t1 = within(menu).getByRole('menuitem', { name: 'test1' });
-  expect(t1).toBeInTheDocument();
-  await user.click(t1);
-  expect(onChange).toHaveBeenCalledTimes(1);
-  expect(onChange).toHaveBeenLastCalledWith('test1', 'ASC');
 });
 
 async function openMenu(user: UserEvent, label = 'Name') {

--- a/web/packages/shared/components/Controls/SortMenu.test.tsx
+++ b/web/packages/shared/components/Controls/SortMenu.test.tsx
@@ -31,7 +31,7 @@ describe('SortMenu', () => {
     expect(screen.getByText('Name')).toBeInTheDocument();
   });
 
-  describe('shows the selected item sort-specific in the button', () => {
+  describe('shows the selected item sort-specific label in the button', () => {
     it('ascending', async () => {
       renderComponent({
         props: {
@@ -155,6 +155,33 @@ describe('SortMenu', () => {
     expect(onChange).not.toHaveBeenCalled();
   });
 
+  it('hidden options are invisible unless already selected', async () => {
+    const { user } = renderComponent({
+      props: {
+        items: [
+          {
+            key: 'test1',
+            label: 'Test1',
+            hidden: true,
+          },
+          {
+            key: 'test2',
+            label: 'Test2',
+            hidden: true,
+          },
+        ],
+        selectedKey: 'test1',
+        selectedOrder: 'DESC',
+      },
+    });
+    await openMenu(user, 'Test1');
+    const menu = screen.getByRole('menu');
+    const t1 = within(menu).queryByRole('menuitem', { name: 'Test1' });
+    const t2 = within(menu).queryByRole('menuitem', { name: 'Test2' });
+    expect(t1).toBeInTheDocument();
+    expect(t2).not.toBeInTheDocument();
+  });
+
   it('allows an item to be selected', async () => {
     const { user, onChange } = renderComponent();
     await openMenu(user);
@@ -203,6 +230,28 @@ describe('SortMenu', () => {
     expect(onChange).toHaveBeenCalledTimes(1);
     expect(onChange).toHaveBeenLastCalledWith('test-2', 'DESC');
   });
+});
+
+it('shows the item key if the label is empty', async () => {
+  const { user, onChange } = renderComponent({
+    props: {
+      items: [
+        {
+          key: 'test1',
+          label: '',
+        },
+      ],
+      selectedKey: 'test1',
+      selectedOrder: 'ASC',
+    },
+  });
+  await openMenu(user, 'test1');
+  const menu = screen.getByRole('menu');
+  const t1 = within(menu).getByRole('menuitem', { name: 'test1' });
+  expect(t1).toBeInTheDocument();
+  await user.click(t1);
+  expect(onChange).toHaveBeenCalledTimes(1);
+  expect(onChange).toHaveBeenLastCalledWith('test1', 'ASC');
 });
 
 async function openMenu(user: UserEvent, label = 'Name') {

--- a/web/packages/shared/components/Controls/SortMenu.tsx
+++ b/web/packages/shared/components/Controls/SortMenu.tsx
@@ -145,22 +145,20 @@ export function SortMenu(props: {
         menuListCss={() => `padding-bottom: 8px;`}
       >
         <MenuTitle>Sort by</MenuTitle>
-        {items.map(({ key, label: optionLabel, hidden }) => {
-          const checked = selectedKey === key;
-          if (hidden && !checked) {
-            return null;
-          }
-          return (
-            <StyledMenuItem key={key} onClick={() => handleItemSelected(key)}>
-              <Tick
-                size={'small'}
-                checked={checked}
-                color={theme.colors.text.muted}
-              />
-              {optionLabel || key}
-            </StyledMenuItem>
-          );
-        })}
+        {items
+          .filter(({ key, hidden }) => !hidden || selectedKey === key)
+          .map(({ key, label: optionLabel }) => {
+            return (
+              <StyledMenuItem key={key} onClick={() => handleItemSelected(key)}>
+                <Tick
+                  size={'small'}
+                  checked={selectedKey === key}
+                  color={theme.colors.text.muted}
+                />
+                {optionLabel || key}
+              </StyledMenuItem>
+            );
+          })}
         <MenuTitle>Order</MenuTitle>
         <StyledMenuItem
           onClick={() => handleOrderSelected('ASC')}

--- a/web/packages/shared/components/Controls/SortMenu.tsx
+++ b/web/packages/shared/components/Controls/SortMenu.tsx
@@ -47,6 +47,8 @@ export type SortItem = {
   defaultOrder?: SortOrder;
   /** Disable the sort options when this item is selected. The default sort order is still honored when the item is selected. */
   disableSort?: boolean;
+  /** Hide this item from the sort menu options. Useful if some sorting fields are conditional. */
+  hidden?: boolean;
 };
 
 export function SortMenu(props: {
@@ -66,8 +68,7 @@ export function SortMenu(props: {
   const theme = useTheme();
 
   const {
-    key,
-    label = key ?? 'No label',
+    label,
     ascendingLabel,
     descendingLabel,
     ascendingOptionLabel = 'Ascending',
@@ -80,11 +81,11 @@ export function SortMenu(props: {
 
   const handleClose = () => setAnchorEl(null);
 
-  const handleItemSelected = (key: string) => {
+  const handleItemSelected = (newKey: string) => {
     handleClose();
     onChange(
-      key,
-      items.find(f => f.key === key)?.defaultOrder ?? selectedOrder ?? 'ASC'
+      newKey,
+      items.find(f => f.key === newKey)?.defaultOrder ?? selectedOrder ?? 'ASC'
     );
   };
 
@@ -123,8 +124,8 @@ export function SortMenu(props: {
         )}
 
         {selectedOrder === 'ASC'
-          ? (ascendingLabel ?? label)
-          : (descendingLabel ?? label)}
+          ? (ascendingLabel ?? (label || selectedKey))
+          : (descendingLabel ?? (label || selectedKey))}
 
         <ChevronDown size={'small'} />
       </StyledButtonBorder>
@@ -144,16 +145,22 @@ export function SortMenu(props: {
         menuListCss={() => `padding-bottom: 8px;`}
       >
         <MenuTitle>Sort by</MenuTitle>
-        {items.map(({ key, label: optionLabel }) => (
-          <StyledMenuItem key={key} onClick={() => handleItemSelected(key)}>
-            <Tick
-              size={'small'}
-              checked={selectedKey == key}
-              color={theme.colors.text.muted}
-            />
-            {optionLabel}
-          </StyledMenuItem>
-        ))}
+        {items.map(({ key, label: optionLabel, hidden }) => {
+          const checked = selectedKey === key;
+          if (hidden && !checked) {
+            return null;
+          }
+          return (
+            <StyledMenuItem key={key} onClick={() => handleItemSelected(key)}>
+              <Tick
+                size={'small'}
+                checked={checked}
+                color={theme.colors.text.muted}
+              />
+              {optionLabel || key}
+            </StyledMenuItem>
+          );
+        })}
         <MenuTitle>Order</MenuTitle>
         <StyledMenuItem
           onClick={() => handleOrderSelected('ASC')}


### PR DESCRIPTION
## Summary

This change allows `SortMenu` options to be individually hidden. This is useful if an option is conditional - perhaps the field it applies to is sometimes unavailable (such as an owner field when filtering for only the current user's records).

## Changes

- Add `hidden` to `SortItem`
- Renames uses of item keys to better explain which item they refer to (selected vs. new vs. item key)
- Fix defaulting labels to use item keys if label is empty
- Update tests
- Update stories

## Manual Test Plan

<!-- Include manual testing efforts to verify the change. -->
<!-- Detail where the tests where run and what configurations were used. -->
<!-- Include all the test cases which were run to validate the change. -->

### Test Environment

Tested with a locally running cluster with some data mocked.

### Test Cases
- [x] Regression test access lists sorting
- [x] Regression test unified resources sorting
- [x] Regression test bot instances sorting
- [x] Regression test instance inventory sorting
- [x] Regression test integrations sorting
- [x] Regression test session recordings sorting (local sorting, not api)
