### PR TITLE
fix: MemoryRouter duplication in stories

### DIFF
--- a/web/packages/teleport/src/BotInstances/BotInstances.story.tsx
+++ b/web/packages/teleport/src/BotInstances/BotInstances.story.tsx
@@ -18,7 +18,7 @@
 
 import { Meta, StoryObj } from '@storybook/react-vite';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { MemoryRouter, Route, Routes } from 'react-router';
+import { Route, Routes } from 'react-router';
 
 import Box from 'design/Box/Box';
 
@@ -195,20 +195,21 @@ function Wrapper(props?: {
 
   return (
     <QueryClientProvider client={queryClient}>
-      <MemoryRouter initialEntries={['/web/bots/instances']}>
-        <TeleportProviderBasic teleportCtx={ctx}>
-          <Routes>
-            <Route
-              path={cfg.routes.botInstances}
-              element={
-                <Box height={820}>
-                  <BotInstances />
-                </Box>
-              }
-            />
-          </Routes>
-        </TeleportProviderBasic>
-      </MemoryRouter>
+      <TeleportProviderBasic
+        teleportCtx={ctx}
+        initialEntries={['/web/bots/instances']}
+      >
+        <Routes>
+          <Route
+            path={cfg.routes.botInstances}
+            element={
+              <Box height={820}>
+                <BotInstances />
+              </Box>
+            }
+          />
+        </Routes>
+      </TeleportProviderBasic>
     </QueryClientProvider>
   );
 }

--- a/web/packages/teleport/src/Bots/Details/BotDetails.story.tsx
+++ b/web/packages/teleport/src/Bots/Details/BotDetails.story.tsx
@@ -18,7 +18,7 @@
 
 import { Meta, StoryObj } from '@storybook/react-vite';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { MemoryRouter, Route, Routes } from 'react-router';
+import { Route, Routes } from 'react-router';
 
 import Box from 'design/Box';
 
@@ -621,20 +621,21 @@ function Wrapper(props?: {
 
   return (
     <QueryClientProvider client={queryClient}>
-      <MemoryRouter initialEntries={['/web/bot/ansible-worker']}>
-        <TeleportProviderBasic teleportCtx={ctx}>
-          <Routes>
-            <Route
-              path={cfg.routes.bot}
-              element={
-                <Box height={820} overflow={'auto'}>
-                  <BotDetails />
-                </Box>
-              }
-            />
-          </Routes>
-        </TeleportProviderBasic>
-      </MemoryRouter>
+      <TeleportProviderBasic
+        teleportCtx={ctx}
+        initialEntries={['/web/bot/ansible-worker']}
+      >
+        <Routes>
+          <Route
+            path={cfg.routes.bot}
+            element={
+              <Box height={820} overflow={'auto'}>
+                <BotDetails />
+              </Box>
+            }
+          />
+        </Routes>
+      </TeleportProviderBasic>
     </QueryClientProvider>
   );
 }

--- a/web/packages/teleport/src/Bots/Edit/EditDialog.story.tsx
+++ b/web/packages/teleport/src/Bots/Edit/EditDialog.story.tsx
@@ -18,6 +18,7 @@
 
 import { Meta, StoryObj } from '@storybook/react-vite';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
 import { createTeleportContext } from 'teleport/mocks/contexts';
 import { TeleportProviderBasic } from 'teleport/mocks/providers';
 import { defaultAccess, makeAcl } from 'teleport/services/user/makeAcl';

--- a/web/packages/teleport/src/Bots/Edit/EditDialog.story.tsx
+++ b/web/packages/teleport/src/Bots/Edit/EditDialog.story.tsx
@@ -18,8 +18,6 @@
 
 import { Meta, StoryObj } from '@storybook/react-vite';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { MemoryRouter } from 'react-router';
-
 import { createTeleportContext } from 'teleport/mocks/contexts';
 import { TeleportProviderBasic } from 'teleport/mocks/providers';
 import { defaultAccess, makeAcl } from 'teleport/services/user/makeAcl';
@@ -255,15 +253,13 @@ function Wrapper(props?: { hasBotsRead?: boolean; hasBotsEdit?: boolean }) {
 
   return (
     <QueryClientProvider client={queryClient}>
-      <MemoryRouter>
-        <TeleportProviderBasic teleportCtx={ctx}>
-          <EditDialog
-            botName="ansible-worker"
-            onCancel={() => {}}
-            onSuccess={() => {}}
-          />
-        </TeleportProviderBasic>
-      </MemoryRouter>
+      <TeleportProviderBasic teleportCtx={ctx}>
+        <EditDialog
+          botName="ansible-worker"
+          onCancel={() => {}}
+          onSuccess={() => {}}
+        />
+      </TeleportProviderBasic>
     </QueryClientProvider>
   );
 }

--- a/web/packages/teleport/src/Bots/List/Bots.story.tsx
+++ b/web/packages/teleport/src/Bots/List/Bots.story.tsx
@@ -16,8 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { MemoryRouter } from 'react-router';
-
 import { botsFixture } from 'teleport/Bots/fixtures';
 import { BotList } from 'teleport/Bots/List/BotList';
 import { TeleportProviderBasic } from 'teleport/mocks/providers';
@@ -30,11 +28,9 @@ export default {
 
 export const Empty = () => {
   return (
-    <MemoryRouter>
-      <TeleportProviderBasic>
-        <EmptyState />
-      </TeleportProviderBasic>
-    </MemoryRouter>
+    <TeleportProviderBasic>
+      <EmptyState />
+    </TeleportProviderBasic>
   );
 };
 

--- a/web/packages/teleport/src/Instances/Instances.story.tsx
+++ b/web/packages/teleport/src/Instances/Instances.story.tsx
@@ -18,7 +18,7 @@
 
 import { Meta, StoryObj } from '@storybook/react-vite';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { MemoryRouter, Route, Routes } from 'react-router';
+import { Route, Routes } from 'react-router';
 
 import cfg from 'teleport/config';
 import { createTeleportContext } from 'teleport/mocks/contexts';
@@ -164,13 +164,14 @@ function Wrapper(props?: {
 
   return (
     <QueryClientProvider client={queryClient}>
-      <MemoryRouter initialEntries={[cfg.routes.instances]}>
-        <TeleportProviderBasic teleportCtx={ctx}>
-          <Routes>
-            <Route path={cfg.routes.instances} element={<Instances />} />
-          </Routes>
-        </TeleportProviderBasic>
-      </MemoryRouter>
+      <TeleportProviderBasic
+        teleportCtx={ctx}
+        initialEntries={[cfg.routes.instances]}
+      >
+        <Routes>
+          <Route path={cfg.routes.instances} element={<Instances />} />
+        </Routes>
+      </TeleportProviderBasic>
     </QueryClientProvider>
   );
 }

--- a/web/packages/teleport/src/WorkloadIdentity/WorkloadIdentities.story.tsx
+++ b/web/packages/teleport/src/WorkloadIdentity/WorkloadIdentities.story.tsx
@@ -18,7 +18,7 @@
 
 import { Meta, StoryObj } from '@storybook/react-vite';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { MemoryRouter, Route, Routes } from 'react-router';
+import { Route, Routes } from 'react-router';
 
 import cfg from 'teleport/config';
 import { createTeleportContext } from 'teleport/mocks/contexts';
@@ -148,16 +148,17 @@ function Wrapper(props?: { hasListPermission?: boolean }) {
 
   return (
     <QueryClientProvider client={queryClient}>
-      <MemoryRouter initialEntries={[cfg.routes.workloadIdentities]}>
-        <TeleportProviderBasic teleportCtx={ctx}>
-          <Routes>
-            <Route
-              path={cfg.routes.workloadIdentities}
-              element={<WorkloadIdentities />}
-            />
-          </Routes>
-        </TeleportProviderBasic>
-      </MemoryRouter>
+      <TeleportProviderBasic
+        teleportCtx={ctx}
+        initialEntries={[cfg.routes.workloadIdentities]}
+      >
+        <Routes>
+          <Route
+            path={cfg.routes.workloadIdentities}
+            element={<WorkloadIdentities />}
+          />
+        </Routes>
+      </TeleportProviderBasic>
     </QueryClientProvider>
   );
 }


### PR DESCRIPTION
## Summary

Some stories were not working presumably after the react-router upgrade. This change removes the duplication of `MemoryRouter`s given `TeleportProviderBasic` now provides one itself.

## Changes
- Remove duplicated `MemoryRouter`
- Set `initialEntries` prop on `TeleportProviderBasic` instead
