### PR TITLE
[v18] webclient: Check Content-Type before parsing non-200 ping response

### DIFF
--- a/api/client/webclient/webclient.go
+++ b/api/client/webclient/webclient.go
@@ -26,6 +26,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"mime"
 	"net"
 	"net/http"
 	"net/url"
@@ -284,10 +285,27 @@ func pingWithClient(cfg *Config, clt *http.Client) (*PingResponse, error) {
 			return nil, trace.Wrap(err, "could not read ping response body; check the network connection")
 		}
 
+		helpQuestion := "is proxy reachable?"
+		if resp.StatusCode == http.StatusNotFound {
+			// More often than not, a 404 from /webapi/ping is going to indicate
+			// that cfg.ProxyAddr is not a Teleport server in the first place.
+			helpQuestion = fmt.Sprintf("is %q a Teleport server?", "https://"+cfg.ProxyAddr)
+		}
+
+		// A non-200 response is not necessarily from the proxy. Something in front
+		// of it (a load balancer, a tunnel like Cloudflare, etc.) can return its
+		// own non-JSON error page.
+		// Only attempt to parse the body as JSON when the Content-Type says so.
+		if contentType, _, err := mime.ParseMediaType(resp.Header.Get("Content-Type")); contentType != "application/json" {
+			slog.DebugContext(req.Context(), "Ping response is not JSON", "content_type", contentType, "body", string(bodyBytes), "error", err)
+
+			return nil, trace.Errorf("/webapi/ping returned a %d response; %s", resp.StatusCode, helpQuestion)
+		}
+
 		errResp := &PingErrorResponse{}
 		if err := json.Unmarshal(bodyBytes, errResp); err != nil {
-			slog.DebugContext(req.Context(), "Could not parse ping response body", "body", string(bodyBytes))
-			return nil, trace.Wrap(err, "cannot parse ping response; is proxy reachable?")
+			slog.DebugContext(req.Context(), "Could not parse ping response body", "body", string(bodyBytes), "error", err)
+			return nil, trace.Errorf("/webapi/ping returned a %d JSON response; %s", resp.StatusCode, helpQuestion)
 		}
 
 		return nil, trace.Wrap(errors.New(errResp.Error.Message), "proxy service returned unsuccessful ping response; Teleport cluster auth may be misconfigured")
@@ -295,7 +313,7 @@ func pingWithClient(cfg *Config, clt *http.Client) (*PingResponse, error) {
 
 	pr := &PingResponse{}
 	if err := json.NewDecoder(resp.Body).Decode(pr); err != nil {
-		return nil, trace.Wrap(err, "cannot parse server response; is %q a Teleport server?", "https://"+cfg.ProxyAddr)
+		return nil, trace.Wrap(err, "cannot parse server ping response; is %q a Teleport server?", "https://"+cfg.ProxyAddr)
 	}
 
 	return pr, nil

--- a/api/client/webclient/webclient_test.go
+++ b/api/client/webclient/webclient_test.go
@@ -115,11 +115,15 @@ func TestPingError(t *testing.T) {
 
 	testCases := []struct {
 		desc        string
+		statusCode  int
+		contentType string
 		writeBody   func(t *testing.T, w http.ResponseWriter)
 		errContains string
 	}{
 		{
-			desc: "unsuccessful response",
+			desc:        "unsuccessful response",
+			statusCode:  http.StatusInternalServerError,
+			contentType: "application/json",
 			writeBody: func(t *testing.T, w http.ResponseWriter) {
 				err := json.NewEncoder(w).Encode(PingErrorResponse{Error: PingError{Message: "lorem ipsum"}})
 				require.NoError(t, err)
@@ -127,12 +131,65 @@ func TestPingError(t *testing.T) {
 			errContains: "lorem ipsum",
 		},
 		{
-			desc: "mangled response",
+			desc:        "mangled response",
+			statusCode:  http.StatusInternalServerError,
+			contentType: "application/json",
 			writeBody: func(t *testing.T, w http.ResponseWriter) {
 				_, err := w.Write([]byte("mangled lorem ipsum"))
 				require.NoError(t, err)
 			},
-			errContains: "invalid character",
+			errContains: "/webapi/ping returned a 500 JSON response; is proxy reachable?",
+		},
+		{
+			// Something in front of the proxy responded with its own non-JSON error
+			// page.
+			desc:        "non-JSON content type",
+			statusCode:  http.StatusInternalServerError,
+			contentType: "text/html; charset=utf-8",
+			writeBody: func(t *testing.T, w http.ResponseWriter) {
+				_, err := w.Write([]byte("<html><body>error 502</body></html>"))
+				require.NoError(t, err)
+			},
+			errContains: "/webapi/ping returned a 500 response; is proxy reachable?",
+		},
+		{
+			// A 404 on /webapi/ping suggests the address isn't a Teleport server at
+			// all rather than the proxy being unreachable.
+			desc:        "non-JSON 404 response",
+			statusCode:  http.StatusNotFound,
+			contentType: "text/html; charset=utf-8",
+			writeBody: func(t *testing.T, w http.ResponseWriter) {
+				_, err := w.Write([]byte("<html><body>not found</body></html>"))
+				require.NoError(t, err)
+			},
+			errContains: `/webapi/ping returned a 404 response; is "https://`,
+		},
+		{
+			// 404 + application/json but the body isn't parseable. The help text
+			// should still reflect that the address probably isn't a Teleport server.
+			desc:        "mangled 404 response",
+			statusCode:  http.StatusNotFound,
+			contentType: "application/json",
+			writeBody: func(t *testing.T, w http.ResponseWriter) {
+				_, err := w.Write([]byte("mangled lorem ipsum"))
+				require.NoError(t, err)
+			},
+			errContains: `/webapi/ping returned a 404 JSON response; is "https://`,
+		},
+		{
+			// 200 but a body that doesn't decode into PingResponse.
+			// In theory, we could check Content-Type on success too, but what if
+			// there's a deployment behind something that mangles Content-Type?
+			// Checking Content-Type on success would introduce a regression and make
+			// it impossible for users to log in.
+			desc:        "mangled 200 response",
+			statusCode:  http.StatusOK,
+			contentType: "application/json",
+			writeBody: func(t *testing.T, w http.ResponseWriter) {
+				_, err := w.Write([]byte("mangled lorem ipsum"))
+				require.NoError(t, err)
+			},
+			errContains: `cannot parse server ping response; is "https://`,
 		},
 	}
 
@@ -144,8 +201,8 @@ func TestPingError(t *testing.T) {
 					return
 				}
 
-				w.Header().Set("Content-Type", "application/json")
-				w.WriteHeader(http.StatusInternalServerError)
+				w.Header().Set("Content-Type", testCase.contentType)
+				w.WriteHeader(testCase.statusCode)
 				testCase.writeBody(t, w)
 			})
 			httpSvr := httptest.NewServer(handler)

--- a/web/packages/teleterm/src/ui/ClusterConnect/ClusterLogin/ClusterLogin.tsx
+++ b/web/packages/teleterm/src/ui/ClusterConnect/ClusterLogin/ClusterLogin.tsx
@@ -85,7 +85,7 @@ export const ClusterLoginPresentation = (
             margin={0}
             width="100%"
           >
-            Unable to retrieve cluster auth preferences
+            Unable to retrieve authentication methods
           </Alerts.Danger>
           <ButtonPrimary autoFocus={true} size="large" onClick={props.init}>
             Retry


### PR DESCRIPTION
Backport #66706 to branch/v18

changelog: Improved the error message on login in tsh and Teleport Connect when `/webapi/ping` returns a non-200 response

## Manual Test Plan
### Test Environment

A local build of tsh and Connect.

### Test Cases
- [x] Trying to add `example.com` as a cluster in Connect returns "/webapi/ping returned a 404 response; is "https://example.com" a Teleport server?" rather than "cannot parse ping response; is proxy reachable? invalid character '<' looking for beginning of value".