### PR TITLE
[v18] app access: Serve HTML page for browsers on `ErrTrustedDeviceRequired`

### DIFF
--- a/docs/pages/includes/device-trust/troubleshooting.mdx
+++ b/docs/pages/includes/device-trust/troubleshooting.mdx
@@ -45,6 +45,12 @@ device/<asset_tag>` and changing the "enroll_status" field to "not_enrolled".
 
 ### App access and "access to this app requires a trusted device"
 
+{/*
+    NOTE: This section is linked in the product.
+    Make sure the link stays updated, or better yet, do not change the name of this section.
+    https://github.com/gravitational/teleport/blob/9bc227823d914122663ea62ad5957e4ccfeba82a/lib/srv/app/connections_handler.go#L803
+*/}
+
 Follow the instructions in the [Web UI troubleshooting section](
 #web-ui-fails-to-authenticate-trusted-device) below (Teleport v16 or later).
 
@@ -64,6 +70,12 @@ Follow the instructions in the [Web UI troubleshooting section](
 #web-ui-fails-to-authenticate-trusted-device) below.
 
 ### Web UI fails to authenticate trusted device
+
+{/*
+    NOTE: This section is linked in the product.
+    Make sure the link stays updated, or better yet, do not change the name of this section.
+    https://github.com/gravitational/teleport/blob/9bc227823d914122663ea62ad5957e4ccfeba82a/lib/srv/app/connections_handler.go#L802
+*/}
 
 The Web UI attempts to authenticate your device using Teleport Connect during
 login. If you are not asked to authenticate your device immediately after login,

--- a/docs/pages/zero-trust-access/device-trust/device-management.mdx
+++ b/docs/pages/zero-trust-access/device-trust/device-management.mdx
@@ -270,6 +270,12 @@ Save and close your editor to apply your changes.
 
 ## Troubleshooting
 
+{/*
+    NOTE: This section is linked in the product.
+    Make sure the link stays updated, or better yet, do not change the name of this section.
+    https://github.com/gravitational/teleport/blob/9bc227823d914122663ea62ad5957e4ccfeba82a/lib/srv/app/connections_handler.go#L801
+*/}
+
 (!docs/pages/includes/device-trust/troubleshooting.mdx!)
 
 ## Next steps

--- a/lib/srv/app/connections_handler.go
+++ b/lib/srv/app/connections_handler.go
@@ -31,6 +31,7 @@ import (
 	"net"
 	"net/http"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -738,24 +739,62 @@ func (c *ConnectionsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		// Convert trace error type to HTTP and write response, make sure we close the
 		// connection afterwards so that the monitor is recreated if needed.
 		code := trace.ErrorToCode(err)
+		w.Header().Set("Connection", "close")
 
-		var text string
 		switch {
 		case errors.Is(err, services.ErrTrustedDeviceRequired):
-			text = `A trusted device is required to access this resource but this device has not been registered as a trusted device; use 'tsh device enroll' to register as a trusted device.
-
-See https://goteleport.com/docs/admin-guides/access-controls/device-trust/device-management/#troubleshooting for help.
-`
+			writeTrustedDeviceRequired(w, r, code)
 		case errors.Is(err, services.ErrSessionMFARequired):
-			text = authclient.ErrNoMFADevices.Error()
-
+			http.Error(w, authclient.ErrNoMFADevices.Error(), code)
 		default:
-			text = http.StatusText(code)
+			http.Error(w, http.StatusText(code), code)
 		}
-
-		w.Header().Set("Connection", "close")
-		http.Error(w, text, code)
 	}
+}
+
+const (
+	trustedDeviceRequiredDocsURL          = "https://goteleport.com/docs/zero-trust-access/device-trust/device-management/#troubleshooting"
+	trustedDeviceRequiredWebUIDocsURL     = "https://goteleport.com/docs/zero-trust-access/device-trust/device-management/#web-ui-fails-to-authenticate-trusted-device"
+	trustedDeviceRequiredAppAccessDocsURL = "https://goteleport.com/docs/zero-trust-access/device-trust/device-management/#app-access-and-access-to-this-app-requires-a-trusted-device"
+)
+
+// writeTrustedDeviceRequired writes the response body for a request that failed
+// with [services.ErrTrustedDeviceRequired]. Browsers receive a small HTML page
+// with clickable links to the docs; every other client gets plain text.
+func writeTrustedDeviceRequired(w http.ResponseWriter, r *http.Request, code int) {
+	if isBrowserUserAgent(r.UserAgent()) {
+		const body = `<!DOCTYPE html>
+<html lang="en">
+<head><meta charset="utf-8"><title>Trusted device required</title></head>
+<body>
+<p>A trusted device is required to access this resource, but this session has not been authorized with Device Trust. Follow <a href="` + trustedDeviceRequiredWebUIDocsURL + `" target="_blank">the Web UI troubleshooting guide</a> to authorize the session with Device Trust.</p>
+<p>If accessing the resource through VNet or a local proxy, make sure the device running Teleport Connect or tsh is registered and enrolled. See <a href="` + trustedDeviceRequiredAppAccessDocsURL + `" target="_blank">the app access troubleshooting guide</a> for help.</p>
+</body>
+</html>
+`
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		w.Header().Set("X-Content-Type-Options", "nosniff")
+		w.WriteHeader(code)
+		_, _ = w.Write([]byte(body))
+		return
+	}
+
+	http.Error(w, `A trusted device is required to access this resource but this device has not been registered as a trusted device; use 'tsh device enroll' to register as a trusted device.
+
+See `+trustedDeviceRequiredDocsURL+` for help.
+`, code)
+}
+
+// isBrowserUserAgent reports whether ua plausibly comes from a web browser, as
+// opposed to a CLI (tsh, curl) or some SDK client. It relies on the historical
+// quirk that essentially every browser UA begins with "Mozilla/" and contains
+// a known engine token. Modern browsers (Chrome, Safari, Edge, Opera, mobile
+// browsers) are all WebKit- or Blink-based and carry "AppleWebKit"; the Firefox
+// family carries "Gecko/".
+func isBrowserUserAgent(ua string) bool {
+	lower := strings.ToLower(ua)
+	return strings.HasPrefix(lower, "mozilla/") &&
+		(strings.Contains(lower, "applewebkit") || strings.Contains(lower, "gecko/"))
 }
 
 // getConnectionInfo extracts identity information from the provided

--- a/lib/srv/app/connections_handler_test.go
+++ b/lib/srv/app/connections_handler_test.go
@@ -1,0 +1,168 @@
+/*
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package app
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsBrowserUserAgent(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		ua   string
+		want bool
+	}{
+		{
+			name: "empty",
+			ua:   "",
+			want: false,
+		},
+		{
+			name: "tsh",
+			ua:   "tsh/17.0.0",
+			want: false,
+		},
+		{
+			name: "curl",
+			ua:   "curl/8.4.0",
+			want: false,
+		},
+		{
+			name: "Go http client",
+			ua:   "Go-http-client/1.1",
+			want: false,
+		},
+		{
+			name: "Mozilla prefix without engine token",
+			ua:   "Mozilla/5.0 compatible",
+			want: false,
+		},
+		{
+			name: "Chrome on macOS",
+			ua:   "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36",
+			want: true,
+		},
+		{
+			name: "Safari on macOS",
+			ua:   "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Safari/605.1.1",
+			want: true,
+		},
+		{
+			name: "Safari on iPhone",
+			ua:   "Mozilla/5.0 (iPhone; CPU iPhone OS 8_4 like Mac OS X) AppleWebKit/600.1.4 (KHTML, like Gecko) Version/8.0 Mobile/12H143 Safari/600.1.4",
+			want: true,
+		},
+		{
+			name: "Firefox on Linux",
+			ua:   "Mozilla/5.0 (Linux; U; Linux 2.6; en-US; rv:1.9.9.2) Gecko/20100722 Firefox/3.6.8",
+			want: true,
+		},
+		{
+			name: "Firefox on iOS",
+			ua:   "Mozilla/5.0 (iPhone; CPU iPhone OS 12_0_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) FxiOS/7.0.4 Mobile/16A404 Safari/605.1.15",
+			want: true,
+		},
+		{
+			name: "Chrome on iOS",
+			ua:   "Mozilla/5.0 (iPhone; CPU iPhone OS 8_2 like Mac OS X) AppleWebKit/600.1.4 (KHTML, like Gecko) CriOS/44.0.2403.67 Mobile/12D508 Safari/600.1.4",
+			want: true,
+		},
+		{
+			name: "Edge on Windows",
+			ua:   "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/147.0.0.0 Safari/537.36 Edg/147.0.3912.72",
+			want: true,
+		},
+		{
+			name: "Opera on macOS",
+			ua:   "Mozilla/5.0 (Macintosh; Intel Mac OS X 14_3_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36 OPR/108.0.0.0",
+			want: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, isBrowserUserAgent(tc.ua))
+		})
+	}
+}
+
+func TestWriteTrustedDeviceRequired(t *testing.T) {
+	t.Parallel()
+
+	const browserUA = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36"
+
+	tests := []struct {
+		name            string
+		userAgent       string
+		wantContentType string
+		wantBodyParts   []string
+		wantNoBodyPart  string
+	}{
+		{
+			name:            "browser gets HTML with clickable links to Web UI and app access guides",
+			userAgent:       browserUA,
+			wantContentType: "text/html; charset=utf-8",
+			wantBodyParts: []string{
+				`<a href="` + trustedDeviceRequiredWebUIDocsURL + `"`,
+				`<a href="` + trustedDeviceRequiredAppAccessDocsURL + `"`,
+			},
+		},
+		{
+			name:            "non-browser gets plain text with URL but no HTML link",
+			userAgent:       "tsh/17.0.0",
+			wantContentType: "text/plain; charset=utf-8",
+			wantBodyParts:   []string{trustedDeviceRequiredDocsURL},
+			wantNoBodyPart:  "<a ",
+		},
+		{
+			name:            "empty UA gets plain text with URL but no HTML link",
+			userAgent:       "",
+			wantContentType: "text/plain; charset=utf-8",
+			wantBodyParts:   []string{trustedDeviceRequiredDocsURL},
+			wantNoBodyPart:  "<a ",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest("GET", "/", nil)
+			if tc.userAgent != "" {
+				req.Header.Set("User-Agent", tc.userAgent)
+			}
+			rec := httptest.NewRecorder()
+
+			writeTrustedDeviceRequired(rec, req, http.StatusForbidden)
+
+			require.Equal(t, http.StatusForbidden, rec.Code)
+			require.Equal(t, tc.wantContentType, rec.Header().Get("Content-Type"))
+			for _, want := range tc.wantBodyParts {
+				require.Contains(t, rec.Body.String(), want)
+			}
+			if tc.wantNoBodyPart != "" {
+				require.NotContains(t, rec.Body.String(), tc.wantNoBodyPart)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Backport #65878

Changelog: When attempting to access a web app protected by Device Trust from an untrusted device, browsers now see a simple HTML page instead of a plain text response

## Manual Test Plan
### Test Environment

A local Teleport cluster where a user has [an appropriate role](https://goteleport.com/docs/zero-trust-access/device-trust/enforcing-device-trust/#web-application-support) that enforces Device Trust for web apps. Then it's a matter of skipping the Device Trust prompt on login for the Web UI and on tsh it's enough to log in through a locally built tsh which has no Device Trust support built in.

### Test Cases
- [x] Verify that the error page shows an HTML response for browsers.
- [x] Verify that the error page shows a plain text response for curl through a local proxy.
