### PR TITLE
 cache: fix pagination test harness leaving cache in an unhealthy state

### DIFF
--- a/lib/cache/cache_test.go
+++ b/lib/cache/cache_test.go
@@ -1472,6 +1472,10 @@ func testResourcesInternal[T any](t *testing.T, p *testPack, funcs testFuncs[T],
 		testResourcePagination(t, p, funcs)
 	}
 
+	// Ensure the cache is healthy before proceeding to
+	// prevent running the tests falling back to upstream reads.
+	require.True(t, p.cache.ok)
+
 	// Create a resource.
 	r, err := funcs.newResource("test-resource-1")
 	require.NoError(t, err)
@@ -2887,6 +2891,7 @@ func testResourcePagination[T any](t *testing.T, p *testPack, funcs testFuncs[T]
 	require.NoError(t, funcs.deleteAll(ctx))
 
 	// Wait for the cache to be empty.
+	p.cache.ok = true
 	require.EventuallyWithT(t, func(t *assert.CollectT) {
 		items, err := funcs.cacheListAll(ctx)
 		assert.NoError(t, err)


### PR DESCRIPTION
The testResourcePagination helper exercised fallback upstream reads by setting the cache in an unhealthy state, but never restored the cache to a healthy state before completing. This resulted in all tests that supported pagination being exercised against the upstream backend instead of the cache.
