### PR TITLE
Add access graph client and response helpers to tctl

### DIFF
--- a/tool/tctl/common/accessgraph/client.go
+++ b/tool/tctl/common/accessgraph/client.go
@@ -23,14 +23,17 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"net"
 	"net/http"
 	"net/url"
 	"time"
 
 	"github.com/gravitational/trace"
 
+	tracehttp "github.com/gravitational/teleport/api/observability/tracing/http"
 	accessgraph "github.com/gravitational/teleport/lib/accessgraph/apiclient"
 	"github.com/gravitational/teleport/lib/client"
+	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/utils"
 )
 
@@ -64,12 +67,11 @@ type accessGraphResponse interface {
 // It propagates transport errors and turns any HTTP status >= 400 into
 // a non-nil error with a best-effort message extracted from the response body.
 func doRequest[T accessGraphResponse](resp T, err error) (T, error) {
-	var zero T
 	if err != nil {
-		return zero, trace.Wrap(err, "request failed")
+		return *new(T), trace.Wrap(err, "request failed")
 	}
 	if err := checkResponse(resp.StatusCode(), resp.Bytes()); err != nil {
-		return zero, err
+		return *new(T), err
 	}
 	return resp, nil
 }
@@ -78,7 +80,7 @@ func doRequest[T accessGraphResponse](resp T, err error) (T, error) {
 // a non-nil error if the status code indicates failure. It attempts to extract
 // a best-effort message from the response body.
 func checkResponse(statusCode int, body []byte) error {
-	if statusCode < 400 {
+	if 200 <= statusCode && statusCode < 400 {
 		return nil
 	}
 
@@ -137,14 +139,22 @@ func newAccessGraphHTTPClient(ctx context.Context, proxyAddr string, keyRing *cl
 		return nil, trace.Wrap(err)
 	}
 
+	// SNI follows the resolved proxy host
+	host, _, splitErr := net.SplitHostPort(proxyAddr)
+	if splitErr != nil {
+		host = proxyAddr
+	}
+	baseTLSConfig.ServerName = host
+
+	transport, err := defaults.Transport()
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	transport.TLSClientConfig = baseTLSConfig
+
 	httpClient := &http.Client{
-		// Honor HTTPS_PROXY / NO_PROXY, matching the webclient used by
-		// `tsh login` against this address; mTLS is end-to-end via CONNECT.
-		Transport: &http.Transport{
-			TLSClientConfig: baseTLSConfig,
-			Proxy:           http.ProxyFromEnvironment,
-		},
-		Timeout: accessGraphAPITimeout,
+		Transport: tracehttp.NewTransport(transport),
+		Timeout:   accessGraphAPITimeout,
 	}
 
 	slog.DebugContext(ctx, "Created Access Graph HTTP client",

--- a/tool/tctl/common/accessgraph/client.go
+++ b/tool/tctl/common/accessgraph/client.go
@@ -1,0 +1,155 @@
+/*
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package accessgraph
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"net/url"
+	"time"
+
+	"github.com/gravitational/trace"
+
+	accessgraph "github.com/gravitational/teleport/lib/accessgraph/apiclient"
+	"github.com/gravitational/teleport/lib/client"
+	"github.com/gravitational/teleport/lib/utils"
+)
+
+// accessGraphAPIPath is the proxy-side base path the proxy mounts the Access Graph API on.
+const accessGraphAPIPath = "/v1/enterprise/accessgraph/"
+
+// accessGraphAPITimeout timeout for Access Graph API calls.
+const accessGraphAPITimeout = 30 * time.Second
+
+// apiResponseError small wrapper to capture errors returned by in AG API responses,
+// which have the form of [accessgraph.BadRequest]
+type apiResponseError struct {
+	StatusCode int
+	Message    string
+}
+
+func (e *apiResponseError) Error() string {
+	return fmt.Sprintf("API request failed with status %d: %s", e.StatusCode, e.Message)
+}
+
+// accessGraphResponse is the common interface for generated client response types
+type accessGraphResponse interface {
+	StatusCode() int
+	Bytes() []byte
+}
+
+// doRequest is meant to wrap a generated client call directly:
+//
+//	resp, err := doRequest(client.GetFooWithResponse(ctx, ...))
+//
+// It propagates transport errors and turns any HTTP status >= 400 into
+// a non-nil error with a best-effort message extracted from the response body.
+func doRequest[T accessGraphResponse](resp T, err error) (T, error) {
+	var zero T
+	if err != nil {
+		return zero, trace.Wrap(err, "request failed")
+	}
+	if err := checkResponse(resp.StatusCode(), resp.Bytes()); err != nil {
+		return zero, err
+	}
+	return resp, nil
+}
+
+// checkResponse inspects the HTTP status code and body of an API response, returning
+// a non-nil error if the status code indicates failure. It attempts to extract
+// a best-effort message from the response body.
+func checkResponse(statusCode int, body []byte) error {
+	if statusCode < 400 {
+		return nil
+	}
+
+	var apiErr apiResponseError
+	if err := json.Unmarshal(body, &apiErr); err == nil && apiErr.Message != "" {
+		apiErr.StatusCode = statusCode
+		return &apiErr
+	}
+
+	// Fall back to trace.ReadError, which handles teleport's standard error envelope
+	return trace.ReadError(statusCode, body)
+}
+
+// newAccessGraphClient returns a generated Access Graph API client wired
+// to talk to proxyAddr over mTLS using keyRing's AG cert.
+func newAccessGraphClient(ctx context.Context, proxyAddr string, keyRing *client.KeyRing) (*accessgraph.ClientWithResponses, error) {
+	if proxyAddr == "" {
+		return nil, trace.BadParameter("missing proxy address")
+	}
+
+	// Normalize and validate  proxy address before using it to construct the client and HTTP transport.
+	addr, err := utils.ParseAddr(proxyAddr)
+	if err != nil {
+		return nil, trace.Wrap(err, "parsing proxy address %q", proxyAddr)
+	}
+
+	httpClient, err := newAccessGraphHTTPClient(ctx, addr.Addr, keyRing)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	baseURL := (&url.URL{Scheme: "https", Host: addr.Addr, Path: accessGraphAPIPath}).String()
+	accessGraphClient, err := accessgraph.NewClientWithResponses(
+		baseURL,
+		accessgraph.WithHTTPClient(httpClient),
+	)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	slog.DebugContext(ctx, "Initialized Access Graph API client",
+		"proxy_addr", addr.Addr,
+		"username", keyRing.Username,
+	)
+	return accessGraphClient, nil
+}
+
+// newAccessGraphHTTPClient returns an http.Client whose transpor presents keyRing's AG cert as mTLS to proxyAddr.
+func newAccessGraphHTTPClient(ctx context.Context, proxyAddr string, keyRing *client.KeyRing) (*http.Client, error) {
+	if keyRing == nil {
+		return nil, trace.BadParameter("missing key ring")
+	}
+
+	baseTLSConfig, err := keyRing.AccessGraphClientTLSConfig(nil)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	httpClient := &http.Client{
+		// Honor HTTPS_PROXY / NO_PROXY, matching the webclient used by
+		// `tsh login` against this address; mTLS is end-to-end via CONNECT.
+		Transport: &http.Transport{
+			TLSClientConfig: baseTLSConfig,
+			Proxy:           http.ProxyFromEnvironment,
+		},
+		Timeout: accessGraphAPITimeout,
+	}
+
+	slog.DebugContext(ctx, "Created Access Graph HTTP client",
+		"proxy_addr", proxyAddr,
+		"server_name", baseTLSConfig.ServerName,
+	)
+	return httpClient, nil
+}

--- a/tool/tctl/common/accessgraph/client.go
+++ b/tool/tctl/common/accessgraph/client.go
@@ -23,7 +23,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
-	"net"
 	"net/http"
 	"net/url"
 	"time"
@@ -80,14 +79,14 @@ func doRequest[T accessGraphResponse](resp T, err error) (T, error) {
 // a non-nil error if the status code indicates failure. It attempts to extract
 // a best-effort message from the response body.
 func checkResponse(statusCode int, body []byte) error {
-	if 200 <= statusCode && statusCode < 400 {
+	if http.StatusOK <= statusCode && statusCode < http.StatusBadRequest {
 		return nil
 	}
 
 	var apiErr apiResponseError
 	if err := json.Unmarshal(body, &apiErr); err == nil && apiErr.Message != "" {
 		apiErr.StatusCode = statusCode
-		return &apiErr
+		return trace.Wrap(&apiErr)
 	}
 
 	// Fall back to trace.ReadError, which handles teleport's standard error envelope
@@ -107,7 +106,7 @@ func newAccessGraphClient(ctx context.Context, proxyAddr string, keyRing *client
 		return nil, trace.Wrap(err, "parsing proxy address %q", proxyAddr)
 	}
 
-	httpClient, err := newAccessGraphHTTPClient(ctx, addr.Addr, keyRing)
+	httpClient, err := newAccessGraphHTTPClient(ctx, addr, keyRing)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -128,8 +127,8 @@ func newAccessGraphClient(ctx context.Context, proxyAddr string, keyRing *client
 	return accessGraphClient, nil
 }
 
-// newAccessGraphHTTPClient returns an http.Client whose transpor presents keyRing's AG cert as mTLS to proxyAddr.
-func newAccessGraphHTTPClient(ctx context.Context, proxyAddr string, keyRing *client.KeyRing) (*http.Client, error) {
+// newAccessGraphHTTPClient returns an http.Client whose transport presents keyRing's AG cert as mTLS to proxyAddr.
+func newAccessGraphHTTPClient(ctx context.Context, proxyAddr *utils.NetAddr, keyRing *client.KeyRing) (*http.Client, error) {
 	if keyRing == nil {
 		return nil, trace.BadParameter("missing key ring")
 	}
@@ -139,12 +138,7 @@ func newAccessGraphHTTPClient(ctx context.Context, proxyAddr string, keyRing *cl
 		return nil, trace.Wrap(err)
 	}
 
-	// SNI follows the resolved proxy host
-	host, _, splitErr := net.SplitHostPort(proxyAddr)
-	if splitErr != nil {
-		host = proxyAddr
-	}
-	baseTLSConfig.ServerName = host
+	baseTLSConfig.ServerName = proxyAddr.Host()
 
 	transport, err := defaults.Transport()
 	if err != nil {
@@ -159,7 +153,6 @@ func newAccessGraphHTTPClient(ctx context.Context, proxyAddr string, keyRing *cl
 
 	slog.DebugContext(ctx, "Created Access Graph HTTP client",
 		"proxy_addr", proxyAddr,
-		"server_name", baseTLSConfig.ServerName,
 	)
 	return httpClient, nil
 }

--- a/tool/tctl/common/accessgraph/client_test.go
+++ b/tool/tctl/common/accessgraph/client_test.go
@@ -1,0 +1,391 @@
+/*
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package accessgraph
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/gravitational/trace"
+	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport/api/utils/keys"
+	accessgraph "github.com/gravitational/teleport/lib/accessgraph/apiclient"
+	"github.com/gravitational/teleport/lib/client"
+	"github.com/gravitational/teleport/lib/utils/cert"
+)
+
+// newClientTestKeyRing builds a KeyRing with a self-signed cert for access graph client testing.
+func newClientTestKeyRing(t *testing.T, proxyHost string) *client.KeyRing {
+	t.Helper()
+	creds, err := cert.GenerateSelfSignedCert([]string{proxyHost}, nil, nil, nil)
+	require.NoError(t, err)
+	priv, err := keys.ParsePrivateKey(creds.PrivateKey)
+	require.NoError(t, err)
+	return &client.KeyRing{
+		KeyRingIndex:       client.KeyRingIndex{Username: "alice", ProxyHost: proxyHost},
+		TLSPrivateKey:      priv,
+		AccessGraphTLSCert: creds.Cert,
+	}
+}
+
+// TestCheckResponse_Success covers the no-error paths.
+func TestCheckResponse_Success(t *testing.T) {
+	t.Parallel()
+	require.NoError(t, checkResponse(200, []byte(`{"items":[]}`)))
+	require.NoError(t, checkResponse(399, nil))
+}
+
+// TestCheckResponse_AGBadRequest covers the AG-native error envelope —
+// the only branch we own. Anything else is delegated to [trace.ReadError].
+func TestCheckResponse_AGBadRequest(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		statusCode  int
+		body        string
+		wantStatus  int
+		wantMessage string
+	}{
+		{
+			name:        "400 with AG BadRequest envelope",
+			statusCode:  400,
+			body:        `{"message": "missing required field 'kind'"}`,
+			wantStatus:  400,
+			wantMessage: "missing required field 'kind'",
+		},
+		{
+			// Constructed body that satisfies both shapes; the AG
+			// envelope must take precedence
+			name:        "AG envelope wins over teleport envelope",
+			statusCode:  400,
+			body:        `{"message": "ag-native", "error": {"message": "teleport-envelope"}}`,
+			wantStatus:  400,
+			wantMessage: "ag-native",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			err := checkResponse(tt.statusCode, []byte(tt.body))
+			var agErr *apiResponseError
+			require.True(t, errors.As(err, &agErr), "want *apiResponseError, got %T", err)
+			require.Equal(t, tt.wantStatus, agErr.StatusCode)
+			require.Equal(t, tt.wantMessage, agErr.Message)
+		})
+	}
+}
+
+// TestCheckResponse_DelegatesToTraceReadError verifies that bodies the
+// AG envelope can't claim are passed through to [trace.ReadError]
+func TestCheckResponse_DelegatesToTraceReadError(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		statusCode int
+		body       string
+		wantCheck  func(error) bool
+	}{
+		{
+			name:       "403 → IsAccessDenied",
+			statusCode: 403,
+			body:       `{"error": {"message": "feature not enabled"}}`,
+			wantCheck:  trace.IsAccessDenied,
+		},
+		{
+			name:       "404 → IsNotFound",
+			statusCode: 404,
+			body:       `{"error": {"message": "no such resource"}}`,
+			wantCheck:  trace.IsNotFound,
+		},
+		{
+			name:       "400 → IsBadParameter",
+			statusCode: 400,
+			body:       `{"error": {"message": "bad input"}}`,
+			wantCheck:  trace.IsBadParameter,
+		},
+		{
+			// JSON that parses but matches neither the AG envelope
+			// (top-level "message") nor the Teleport envelope
+			// ("error.message"). Must delegate to trace.ReadError,
+			// not surface as *apiResponseError with an empty message.
+			name:       "JSON without message or error fields",
+			statusCode: 400,
+			body:       `{"foo":"bar"}`,
+			wantCheck:  trace.IsBadParameter,
+		},
+		{
+			name:       "non-JSON body still returns a non-nil error",
+			statusCode: 502,
+			body:       "upstream connection refused",
+			wantCheck:  func(err error) bool { return err != nil },
+		},
+		{
+			name:       "empty body still returns a non-nil error",
+			statusCode: 418,
+			body:       "",
+			wantCheck:  func(err error) bool { return err != nil },
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			err := checkResponse(tt.statusCode, []byte(tt.body))
+			require.True(t, tt.wantCheck(err), "wantCheck failed for err=%v", err)
+			// And specifically NOT *apiResponseError, which is
+			// reserved for the AG-native envelope.
+			var agErr *apiResponseError
+			require.False(t, errors.As(err, &agErr), "must not be *apiResponseError, got %v", err)
+		})
+	}
+}
+
+// fakeResponse is a minimal accessGraphResponse used to drive doRequest
+// without standing up a real HTTP exchange.
+type fakeResponse struct {
+	statusCode int
+	body       []byte
+}
+
+func (f fakeResponse) StatusCode() int { return f.statusCode }
+func (f fakeResponse) Bytes() []byte   { return f.body }
+
+func TestDoRequest(t *testing.T) {
+	t.Parallel()
+
+	t.Run("transport error is wrapped, response zeroed", func(t *testing.T) {
+		t.Parallel()
+		want := errors.New("dial tcp: connection refused")
+		got, err := doRequest(fakeResponse{statusCode: 200}, want)
+		require.ErrorIs(t, err, want)
+		require.Equal(t, fakeResponse{}, got, "response must be zero-valued on transport error")
+	})
+
+	t.Run("HTTP error becomes apiResponseError, response zeroed", func(t *testing.T) {
+		t.Parallel()
+		got, err := doRequest(
+			fakeResponse{statusCode: 500, body: []byte(`{"message":"boom"}`)},
+			nil,
+		)
+		var agErr *apiResponseError
+		require.True(t, errors.As(err, &agErr))
+		require.Equal(t, 500, agErr.StatusCode)
+		require.Equal(t, "boom", agErr.Message)
+		require.Equal(t, fakeResponse{}, got, "response must be zero-valued on HTTP error")
+	})
+
+	t.Run("success returns the original response unchanged", func(t *testing.T) {
+		t.Parallel()
+		in := fakeResponse{statusCode: 200, body: []byte(`{"items":[]}`)}
+		got, err := doRequest(in, nil)
+		require.NoError(t, err)
+		require.Equal(t, in, got)
+	})
+}
+
+// TestAccessGraphClient_AgainstMockServer exercises client and helpers using
+// an httptest server.
+func TestAccessGraphClient_AgainstMockServer(t *testing.T) {
+	t.Parallel()
+
+	// Use a non-IP ProxyHost so the TLS client actually sends SNI —
+	// per RFC 6066, IP literals don't get SNI. We use `example.com`
+	// the certs that httptest generate include `example.com` as a valid DNS name
+	const proxyHost = "example.com"
+	keyRing := newClientTestKeyRing(t, proxyHost)
+
+	const aliasesPath = "/v1/enterprise/accessgraph/graph/account-aliases"
+
+	type assertion func(t *testing.T, err error)
+	wantSuccess := func() assertion {
+		return func(t *testing.T, err error) { require.NoError(t, err) }
+	}
+	wantAGError := func(status int, msg string) assertion {
+		return func(t *testing.T, err error) {
+			var agErr *apiResponseError
+			require.True(t, errors.As(err, &agErr), "want *apiResponseError, got %T", err)
+			require.Equal(t, status, agErr.StatusCode)
+			require.Equal(t, msg, agErr.Message)
+		}
+	}
+	wantTraceCheck := func(check func(error) bool) assertion {
+		return func(t *testing.T, err error) {
+			require.True(t, check(err), "trace check failed for err=%v", err)
+			var agErr *apiResponseError
+			require.False(t, errors.As(err, &agErr),
+				"teleport-envelope errors must not surface as *apiResponseError")
+		}
+	}
+
+	tests := []struct {
+		name    string
+		handler http.HandlerFunc
+		assert  assertion
+	}{
+		{
+			name: "200 with empty alias list → no error",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(200)
+				_, _ = w.Write([]byte(`[]`))
+			},
+			assert: wantSuccess(),
+		},
+		{
+			name: "400 with AG BadRequest body",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(400)
+				_, _ = w.Write([]byte(`{"message":"invalid filter"}`))
+			},
+			assert: wantAGError(400, "invalid filter"),
+		},
+		{
+			// Simulates teleport proxy error returning a teleport [trace.Error]
+			name: "403 with teleport proxy envelope → typed trace error",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(403)
+				_, _ = w.Write([]byte(`{"error":{"message":"access graph is not enabled"}}`))
+			},
+			assert: wantTraceCheck(trace.IsAccessDenied),
+		},
+		{
+			name: "503 with empty body → non-nil trace error",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(503)
+			},
+			assert: wantTraceCheck(func(err error) bool { return err != nil }),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var (
+				gotPath string
+				gotSNI  string
+			)
+			srv := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				gotPath = r.URL.Path
+				tt.handler(w, r)
+			}))
+
+			// Observe the SNI the client sends, which must match the keyring's ProxyHost.
+			srv.TLS = &tls.Config{
+				GetCertificate: func(hello *tls.ClientHelloInfo) (*tls.Certificate, error) {
+					gotSNI = hello.ServerName
+					return nil, nil
+				},
+			}
+			srv.StartTLS()
+			t.Cleanup(srv.Close)
+
+			// Manually construct the http client so we can inject the RootCAs needed to verify the cert
+			httpClient, err := newAccessGraphHTTPClient(context.Background(), srv.Listener.Addr().String(), keyRing)
+			require.NoError(t, err)
+			tr := httpClient.Transport.(*http.Transport)
+			// httptest's cert is signed by a private CA, so we need to add it to the client's RootCAs
+			tr.TLSClientConfig.RootCAs = x509.NewCertPool()
+			tr.TLSClientConfig.RootCAs.AddCert(srv.Certificate())
+
+			// Construct the client with the test HTTP client, then do a request to verify the full stack,
+			baseURL := (&url.URL{
+				Scheme: "https",
+				Host:   srv.Listener.Addr().String(),
+				Path:   accessGraphAPIPath,
+			}).String()
+			ag, err := accessgraph.NewClientWithResponses(
+				baseURL,
+				accessgraph.WithHTTPClient(httpClient),
+			)
+			require.NoError(t, err)
+
+			_, err = doRequest(ag.GetAccountAliasesWithResponse(context.Background()))
+			tt.assert(t, err)
+			require.Equal(t, aliasesPath, gotPath, "client must hit the AG-mounted path")
+			require.Equal(t, proxyHost, gotSNI, "client must propagate keyring ProxyHost as SNI")
+		})
+	}
+}
+
+// TestNewAccessGraphClient_InputValidation covers the cheap up-front
+// guards that don't require a real keyring.
+func TestNewAccessGraphClient_InputValidation(t *testing.T) {
+	t.Parallel()
+
+	t.Run("empty proxy address", func(t *testing.T) {
+		t.Parallel()
+		_, err := newAccessGraphClient(context.Background(), "", &client.KeyRing{})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "proxy address")
+	})
+
+	t.Run("nil keyring", func(t *testing.T) {
+		t.Parallel()
+		_, err := newAccessGraphClient(context.Background(), "proxy.example.com:443", nil)
+		require.Error(t, err)
+		require.True(t, strings.Contains(err.Error(), "key ring"), "got %v", err)
+	})
+}
+
+// TestNewAccessGraphClient_Success covers the constructor happy path
+// and the proxy-address normalization performed by utils.ParseAddr.
+
+func TestNewAccessGraphClient_Success(t *testing.T) {
+	t.Parallel()
+
+	keyRing := newClientTestKeyRing(t, "proxy.example.com")
+
+	tests := []struct {
+		name      string
+		proxyAddr string
+		wantErr   string // empty → success
+	}{
+		{"bare host", "proxy.example.com", ""},
+		{"host:port", "proxy.example.com:443", ""},
+		{"normalizes scheme", "https://proxy.example.com:443", ""},
+		{"strips trailing path", "https://proxy.example.com/anything", ""},
+		{"unsupported scheme", "ftp://proxy.example.com", "unsupported scheme"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			c, err := newAccessGraphClient(context.Background(), tt.proxyAddr, keyRing)
+			if tt.wantErr != "" {
+				require.ErrorContains(t, err, tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			require.NotNil(t, c)
+		})
+	}
+}

--- a/tool/tctl/common/accessgraph/client_test.go
+++ b/tool/tctl/common/accessgraph/client_test.go
@@ -27,7 +27,6 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
-	"strings"
 	"testing"
 
 	"github.com/gravitational/trace"
@@ -36,6 +35,7 @@ import (
 	"github.com/gravitational/teleport/api/utils/keys"
 	accessgraph "github.com/gravitational/teleport/lib/accessgraph/apiclient"
 	"github.com/gravitational/teleport/lib/client"
+	"github.com/gravitational/teleport/lib/utils"
 	"github.com/gravitational/teleport/lib/utils/cert"
 )
 
@@ -53,119 +53,112 @@ func newClientTestKeyRing(t *testing.T, proxyHost string) *client.KeyRing {
 	}
 }
 
-// TestCheckResponse_Success covers the no-error paths.
-func TestCheckResponse_Success(t *testing.T) {
-	t.Parallel()
-	require.NoError(t, checkResponse(200, []byte(`{"items":[]}`)))
-	require.NoError(t, checkResponse(399, nil))
-}
+func TestCheckResponse(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		require.NoError(t, checkResponse(200, []byte(`{"items":[]}`)))
+		require.NoError(t, checkResponse(399, nil))
+	})
 
-// TestCheckResponse_AGBadRequest covers the AG-native error envelope —
-// the only branch we own. Anything else is delegated to [trace.ReadError].
-func TestCheckResponse_AGBadRequest(t *testing.T) {
-	t.Parallel()
+	// The AG-native error envelope is the only branch we own; anything
+	// else delegates to [trace.ReadError].
+	t.Run("AG bad request", func(t *testing.T) {
+		tests := []struct {
+			name        string
+			statusCode  int
+			body        string
+			wantStatus  int
+			wantMessage string
+		}{
+			{
+				name:        "400 with AG BadRequest envelope",
+				statusCode:  400,
+				body:        `{"message": "missing required field 'kind'"}`,
+				wantStatus:  400,
+				wantMessage: "missing required field 'kind'",
+			},
+			{
+				// Constructed body that satisfies both shapes; the AG
+				// envelope must take precedence
+				name:        "AG envelope wins over teleport envelope",
+				statusCode:  400,
+				body:        `{"message": "ag-native", "error": {"message": "teleport-envelope"}}`,
+				wantStatus:  400,
+				wantMessage: "ag-native",
+			},
+		}
 
-	tests := []struct {
-		name        string
-		statusCode  int
-		body        string
-		wantStatus  int
-		wantMessage string
-	}{
-		{
-			name:        "400 with AG BadRequest envelope",
-			statusCode:  400,
-			body:        `{"message": "missing required field 'kind'"}`,
-			wantStatus:  400,
-			wantMessage: "missing required field 'kind'",
-		},
-		{
-			// Constructed body that satisfies both shapes; the AG
-			// envelope must take precedence
-			name:        "AG envelope wins over teleport envelope",
-			statusCode:  400,
-			body:        `{"message": "ag-native", "error": {"message": "teleport-envelope"}}`,
-			wantStatus:  400,
-			wantMessage: "ag-native",
-		},
-	}
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				err := checkResponse(tt.statusCode, []byte(tt.body))
+				var agErr *apiResponseError
+				require.ErrorAs(t, err, &agErr, "want *apiResponseError, got %T", err)
+				require.Equal(t, tt.wantStatus, agErr.StatusCode)
+				require.Equal(t, tt.wantMessage, agErr.Message)
+			})
+		}
+	})
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-			err := checkResponse(tt.statusCode, []byte(tt.body))
-			var agErr *apiResponseError
-			require.ErrorAs(t, err, &agErr, "want *apiResponseError, got %T", err)
-			require.Equal(t, tt.wantStatus, agErr.StatusCode)
-			require.Equal(t, tt.wantMessage, agErr.Message)
-		})
-	}
-}
+	// Bodies the AG envelope can't claim are passed through to [trace.ReadError].
+	t.Run("delegates to trace.ReadError", func(t *testing.T) {
+		tests := []struct {
+			name       string
+			statusCode int
+			body       string
+			wantCheck  func(error) bool
+		}{
+			{
+				name:       "403 → IsAccessDenied",
+				statusCode: 403,
+				body:       `{"error": {"message": "feature not enabled"}}`,
+				wantCheck:  trace.IsAccessDenied,
+			},
+			{
+				name:       "404 → IsNotFound",
+				statusCode: 404,
+				body:       `{"error": {"message": "no such resource"}}`,
+				wantCheck:  trace.IsNotFound,
+			},
+			{
+				name:       "400 → IsBadParameter",
+				statusCode: 400,
+				body:       `{"error": {"message": "bad input"}}`,
+				wantCheck:  trace.IsBadParameter,
+			},
+			{
+				// JSON that parses but matches neither the AG envelope
+				// (top-level "message") nor the Teleport envelope
+				// ("error.message"). Must delegate to trace.ReadError,
+				// not surface as *apiResponseError with an empty message.
+				name:       "JSON without message or error fields",
+				statusCode: 400,
+				body:       `{"foo":"bar"}`,
+				wantCheck:  trace.IsBadParameter,
+			},
+			{
+				name:       "non-JSON body still returns a non-nil error",
+				statusCode: 502,
+				body:       "upstream connection refused",
+				wantCheck:  func(err error) bool { return err != nil },
+			},
+			{
+				name:       "empty body still returns a non-nil error",
+				statusCode: 418,
+				body:       "",
+				wantCheck:  func(err error) bool { return err != nil },
+			},
+		}
 
-// TestCheckResponse_DelegatesToTraceReadError verifies that bodies the
-// AG envelope can't claim are passed through to [trace.ReadError]
-func TestCheckResponse_DelegatesToTraceReadError(t *testing.T) {
-	t.Parallel()
-
-	tests := []struct {
-		name       string
-		statusCode int
-		body       string
-		wantCheck  func(error) bool
-	}{
-		{
-			name:       "403 → IsAccessDenied",
-			statusCode: 403,
-			body:       `{"error": {"message": "feature not enabled"}}`,
-			wantCheck:  trace.IsAccessDenied,
-		},
-		{
-			name:       "404 → IsNotFound",
-			statusCode: 404,
-			body:       `{"error": {"message": "no such resource"}}`,
-			wantCheck:  trace.IsNotFound,
-		},
-		{
-			name:       "400 → IsBadParameter",
-			statusCode: 400,
-			body:       `{"error": {"message": "bad input"}}`,
-			wantCheck:  trace.IsBadParameter,
-		},
-		{
-			// JSON that parses but matches neither the AG envelope
-			// (top-level "message") nor the Teleport envelope
-			// ("error.message"). Must delegate to trace.ReadError,
-			// not surface as *apiResponseError with an empty message.
-			name:       "JSON without message or error fields",
-			statusCode: 400,
-			body:       `{"foo":"bar"}`,
-			wantCheck:  trace.IsBadParameter,
-		},
-		{
-			name:       "non-JSON body still returns a non-nil error",
-			statusCode: 502,
-			body:       "upstream connection refused",
-			wantCheck:  func(err error) bool { return err != nil },
-		},
-		{
-			name:       "empty body still returns a non-nil error",
-			statusCode: 418,
-			body:       "",
-			wantCheck:  func(err error) bool { return err != nil },
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-			err := checkResponse(tt.statusCode, []byte(tt.body))
-			require.True(t, tt.wantCheck(err), "wantCheck failed for err=%v", err)
-			// And specifically NOT *apiResponseError, which is
-			// reserved for the AG-native envelope.
-			var agErr *apiResponseError
-			require.NotErrorAs(t, err, &agErr, "must not be *apiResponseError, got %v", err)
-		})
-	}
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				err := checkResponse(tt.statusCode, []byte(tt.body))
+				require.True(t, tt.wantCheck(err), "wantCheck failed for err=%v", err)
+				// And specifically NOT *apiResponseError, which is
+				// reserved for the AG-native envelope.
+				var agErr *apiResponseError
+				require.NotErrorAs(t, err, &agErr, "must not be *apiResponseError, got %v", err)
+			})
+		}
+	})
 }
 
 // fakeResponse is a minimal accessGraphResponse used to drive doRequest
@@ -179,10 +172,7 @@ func (f fakeResponse) StatusCode() int { return f.statusCode }
 func (f fakeResponse) Bytes() []byte   { return f.body }
 
 func TestDoRequest(t *testing.T) {
-	t.Parallel()
-
 	t.Run("transport error is wrapped, response zeroed", func(t *testing.T) {
-		t.Parallel()
 		want := errors.New("dial tcp: connection refused")
 		got, err := doRequest(fakeResponse{statusCode: 200}, want)
 		require.ErrorIs(t, err, want)
@@ -190,7 +180,6 @@ func TestDoRequest(t *testing.T) {
 	})
 
 	t.Run("HTTP error becomes apiResponseError, response zeroed", func(t *testing.T) {
-		t.Parallel()
 		got, err := doRequest(
 			fakeResponse{statusCode: 500, body: []byte(`{"message":"boom"}`)},
 			nil,
@@ -203,7 +192,6 @@ func TestDoRequest(t *testing.T) {
 	})
 
 	t.Run("success returns the original response unchanged", func(t *testing.T) {
-		t.Parallel()
 		in := fakeResponse{statusCode: 200, body: []byte(`{"items":[]}`)}
 		got, err := doRequest(in, nil)
 		require.NoError(t, err)
@@ -211,11 +199,8 @@ func TestDoRequest(t *testing.T) {
 	})
 }
 
-// TestAccessGraphClient_AgainstMockServer exercises client and helpers using
-// an httptest server.
-func TestAccessGraphClient_AgainstMockServer(t *testing.T) {
-	t.Parallel()
-
+// TestAccessGraphClient exercises client and helpers using an httptest server.
+func TestAccessGraphClient(t *testing.T) {
 	// dialHost and keyringProxyHost differ so SNI propagation can be
 	// distinguished from the keyring's ProxyHost.
 	const (
@@ -290,8 +275,6 @@ func TestAccessGraphClient_AgainstMockServer(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-
 			var (
 				gotPath string
 				gotSNI  string
@@ -315,7 +298,8 @@ func TestAccessGraphClient_AgainstMockServer(t *testing.T) {
 			// connection to the loopback listener.
 			_, port, err := net.SplitHostPort(srv.Listener.Addr().String())
 			require.NoError(t, err)
-			dialAddr := net.JoinHostPort(dialHost, port)
+			dialAddr, err := utils.ParseAddr(net.JoinHostPort(dialHost, port))
+			require.NoError(t, err)
 
 			httpClient, err := newAccessGraphHTTPClient(context.Background(), dialAddr, keyRing)
 			require.NoError(t, err)
@@ -331,7 +315,7 @@ func TestAccessGraphClient_AgainstMockServer(t *testing.T) {
 			// Construct the client with the test HTTP client, then do a request to verify the full stack,
 			baseURL := (&url.URL{
 				Scheme: "https",
-				Host:   dialAddr,
+				Host:   dialAddr.Addr,
 				Path:   accessGraphAPIPath,
 			}).String()
 			ag, err := accessgraph.NewClientWithResponses(
@@ -348,55 +332,48 @@ func TestAccessGraphClient_AgainstMockServer(t *testing.T) {
 	}
 }
 
-// TestNewAccessGraphClient_InputValidation covers the cheap up-front
-// guards that don't require a real keyring.
-func TestNewAccessGraphClient_InputValidation(t *testing.T) {
-	t.Parallel()
-
-	t.Run("empty proxy address", func(t *testing.T) {
-		t.Parallel()
-		_, err := newAccessGraphClient(context.Background(), "", &client.KeyRing{})
-		require.Error(t, err)
-		require.Contains(t, err.Error(), "proxy address")
-	})
-
-	t.Run("nil keyring", func(t *testing.T) {
-		t.Parallel()
-		_, err := newAccessGraphClient(context.Background(), "proxy.example.com:443", nil)
-		require.Error(t, err)
-		require.True(t, strings.Contains(err.Error(), "key ring"), "got %v", err)
-	})
-}
-
-// TestNewAccessGraphClient_Success covers the constructor happy path
-// and the proxy-address normalization performed by utils.ParseAddr.
-
-func TestNewAccessGraphClient_Success(t *testing.T) {
-	t.Parallel()
-
-	keyRing := newClientTestKeyRing(t, "proxy.example.com")
-
-	tests := []struct {
-		name      string
-		proxyAddr string
-		wantErr   string // empty → success
-	}{
-		{"bare host", "proxy.example.com", ""},
-		{"host:port", "proxy.example.com:443", ""},
-		{"normalizes scheme", "https://proxy.example.com:443", ""},
-		{"strips trailing path", "https://proxy.example.com/anything", ""},
-		{"unsupported scheme", "ftp://proxy.example.com", "unsupported scheme"},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-			c, err := newAccessGraphClient(context.Background(), tt.proxyAddr, keyRing)
-			if tt.wantErr != "" {
-				require.ErrorContains(t, err, tt.wantErr)
-				return
-			}
-			require.NoError(t, err)
-			require.NotNil(t, c)
+func TestNewAccessGraphClient(t *testing.T) {
+	// Cheap up-front guards that don't require a real keyring.
+	t.Run("input validation", func(t *testing.T) {
+		t.Run("empty proxy address", func(t *testing.T) {
+			_, err := newAccessGraphClient(context.Background(), "", &client.KeyRing{})
+			require.Error(t, err)
+			require.Contains(t, err.Error(), "proxy address")
 		})
-	}
+
+		t.Run("nil keyring", func(t *testing.T) {
+			_, err := newAccessGraphClient(context.Background(), "proxy.example.com:443", nil)
+			require.Error(t, err)
+			require.Contains(t, err.Error(), "key ring", "got %v", err)
+		})
+	})
+
+	// Constructor happy path and the proxy-address normalization
+	// performed by utils.ParseAddr.
+	t.Run("success", func(t *testing.T) {
+		keyRing := newClientTestKeyRing(t, "proxy.example.com")
+
+		tests := []struct {
+			name      string
+			proxyAddr string
+			wantErr   string // empty → success
+		}{
+			{"bare host", "proxy.example.com", ""},
+			{"host:port", "proxy.example.com:443", ""},
+			{"normalizes scheme", "https://proxy.example.com:443", ""},
+			{"strips trailing path", "https://proxy.example.com/anything", ""},
+			{"unsupported scheme", "ftp://proxy.example.com", "unsupported scheme"},
+		}
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				c, err := newAccessGraphClient(context.Background(), tt.proxyAddr, keyRing)
+				if tt.wantErr != "" {
+					require.ErrorContains(t, err, tt.wantErr)
+					return
+				}
+				require.NoError(t, err)
+				require.NotNil(t, c)
+			})
+		}
+	})
 }

--- a/tool/tctl/common/accessgraph/client_test.go
+++ b/tool/tctl/common/accessgraph/client_test.go
@@ -94,7 +94,7 @@ func TestCheckResponse_AGBadRequest(t *testing.T) {
 			t.Parallel()
 			err := checkResponse(tt.statusCode, []byte(tt.body))
 			var agErr *apiResponseError
-			require.True(t, errors.As(err, &agErr), "want *apiResponseError, got %T", err)
+			require.ErrorAs(t, err, &agErr, "want *apiResponseError, got %T", err)
 			require.Equal(t, tt.wantStatus, agErr.StatusCode)
 			require.Equal(t, tt.wantMessage, agErr.Message)
 		})
@@ -162,7 +162,7 @@ func TestCheckResponse_DelegatesToTraceReadError(t *testing.T) {
 			// And specifically NOT *apiResponseError, which is
 			// reserved for the AG-native envelope.
 			var agErr *apiResponseError
-			require.False(t, errors.As(err, &agErr), "must not be *apiResponseError, got %v", err)
+			require.NotErrorAs(t, err, &agErr, "must not be *apiResponseError, got %v", err)
 		})
 	}
 }
@@ -195,7 +195,7 @@ func TestDoRequest(t *testing.T) {
 			nil,
 		)
 		var agErr *apiResponseError
-		require.True(t, errors.As(err, &agErr))
+		require.ErrorAs(t, err, &agErr, "want *apiResponseError, got %T", err)
 		require.Equal(t, 500, agErr.StatusCode)
 		require.Equal(t, "boom", agErr.Message)
 		require.Equal(t, fakeResponse{}, got, "response must be zero-valued on HTTP error")
@@ -230,7 +230,7 @@ func TestAccessGraphClient_AgainstMockServer(t *testing.T) {
 	wantAGError := func(status int, msg string) assertion {
 		return func(t *testing.T, err error) {
 			var agErr *apiResponseError
-			require.True(t, errors.As(err, &agErr), "want *apiResponseError, got %T", err)
+			require.ErrorAs(t, err, &agErr, "want *apiResponseError, got %T", err)
 			require.Equal(t, status, agErr.StatusCode)
 			require.Equal(t, msg, agErr.Message)
 		}
@@ -239,8 +239,7 @@ func TestAccessGraphClient_AgainstMockServer(t *testing.T) {
 		return func(t *testing.T, err error) {
 			require.True(t, check(err), "trace check failed for err=%v", err)
 			var agErr *apiResponseError
-			require.False(t, errors.As(err, &agErr),
-				"teleport-envelope errors must not surface as *apiResponseError")
+			require.NotErrorAs(t, err, &agErr, "teleport-envelope errors must not surface as *apiResponseError")
 		}
 	}
 

--- a/tool/tctl/common/accessgraph/client_test.go
+++ b/tool/tctl/common/accessgraph/client_test.go
@@ -23,6 +23,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"errors"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -215,11 +216,13 @@ func TestDoRequest(t *testing.T) {
 func TestAccessGraphClient_AgainstMockServer(t *testing.T) {
 	t.Parallel()
 
-	// Use a non-IP ProxyHost so the TLS client actually sends SNI —
-	// per RFC 6066, IP literals don't get SNI. We use `example.com`
-	// the certs that httptest generate include `example.com` as a valid DNS name
-	const proxyHost = "example.com"
-	keyRing := newClientTestKeyRing(t, proxyHost)
+	// dialHost and keyringProxyHost differ so SNI propagation can be
+	// distinguished from the keyring's ProxyHost.
+	const (
+		dialHost         = "example.com"
+		keyringProxyHost = "stale.example.org"
+	)
+	keyRing := newClientTestKeyRing(t, keyringProxyHost)
 
 	const aliasesPath = "/v1/enterprise/accessgraph/graph/account-aliases"
 
@@ -308,10 +311,19 @@ func TestAccessGraphClient_AgainstMockServer(t *testing.T) {
 			srv.StartTLS()
 			t.Cleanup(srv.Close)
 
-			// Manually construct the http client so we can inject the RootCAs needed to verify the cert
-			httpClient, err := newAccessGraphHTTPClient(context.Background(), srv.Listener.Addr().String(), keyRing)
+			// Dial via dialHost (a hostname so SNI is sent) but redirect the
+			// connection to the loopback listener.
+			_, port, err := net.SplitHostPort(srv.Listener.Addr().String())
 			require.NoError(t, err)
-			tr := httpClient.Transport.(*http.Transport)
+			dialAddr := net.JoinHostPort(dialHost, port)
+
+			httpClient, err := newAccessGraphHTTPClient(context.Background(), dialAddr, keyRing)
+			require.NoError(t, err)
+			// Unwrap the tracehttp wrapper to reach the inner *http.Transport for test injection.
+			tr := httpClient.Transport.(interface{ Unwrap() http.RoundTripper }).Unwrap().(*http.Transport)
+			tr.DialContext = func(ctx context.Context, network, _ string) (net.Conn, error) {
+				return (&net.Dialer{}).DialContext(ctx, network, srv.Listener.Addr().String())
+			}
 			// httptest's cert is signed by a private CA, so we need to add it to the client's RootCAs
 			tr.TLSClientConfig.RootCAs = x509.NewCertPool()
 			tr.TLSClientConfig.RootCAs.AddCert(srv.Certificate())
@@ -319,7 +331,7 @@ func TestAccessGraphClient_AgainstMockServer(t *testing.T) {
 			// Construct the client with the test HTTP client, then do a request to verify the full stack,
 			baseURL := (&url.URL{
 				Scheme: "https",
-				Host:   srv.Listener.Addr().String(),
+				Host:   dialAddr,
 				Path:   accessGraphAPIPath,
 			}).String()
 			ag, err := accessgraph.NewClientWithResponses(
@@ -331,7 +343,7 @@ func TestAccessGraphClient_AgainstMockServer(t *testing.T) {
 			_, err = doRequest(ag.GetAccountAliasesWithResponse(context.Background()))
 			tt.assert(t, err)
 			require.Equal(t, aliasesPath, gotPath, "client must hit the AG-mounted path")
-			require.Equal(t, proxyHost, gotSNI, "client must propagate keyring ProxyHost as SNI")
+			require.Equal(t, dialHost, gotSNI, "client must propagate resolved proxy host as SNI, not keyring ProxyHost")
 		})
 	}
 }

--- a/tool/tctl/common/accessgraph/command.go
+++ b/tool/tctl/common/accessgraph/command.go
@@ -121,5 +121,10 @@ func (c *AccessGraphCommand) accessGraphCheck(ctx context.Context, clientFunc co
 	if err != nil {
 		return trace.Wrap(err, "failed to list Access Graph alerts")
 	}
+
+	if res.JSON200 == nil || res.JSON200.Data == nil {
+		return trace.BadParameter("unexpected response from Access Graph API: missing data")
+	}
+
 	return trace.Wrap(utils.WriteYAMLArray(c.stdout, res.JSON200.Data), "failed to write Access Graph alerts to output")
 }

--- a/tool/tctl/common/accessgraph/command.go
+++ b/tool/tctl/common/accessgraph/command.go
@@ -122,8 +122,8 @@ func (c *AccessGraphCommand) accessGraphCheck(ctx context.Context, clientFunc co
 		return trace.Wrap(err, "failed to list Access Graph alerts")
 	}
 
-	if res.JSON200 == nil || res.JSON200.Data == nil {
-		return trace.BadParameter("unexpected response from Access Graph API: missing data")
+	if res.JSON200 == nil {
+		return trace.BadParameter("unexpected response from Access Graph API: expected HTTP 200 with JSON body")
 	}
 
 	return trace.Wrap(utils.WriteYAMLArray(c.stdout, res.JSON200.Data), "failed to write Access Graph alerts to output")

--- a/tool/tctl/common/accessgraph/command.go
+++ b/tool/tctl/common/accessgraph/command.go
@@ -20,14 +20,15 @@ package accessgraph
 
 import (
 	"context"
-	"fmt"
 	"io"
 	"log/slog"
 	"os"
+	"time"
 
 	"github.com/alecthomas/kingpin/v2"
 	"github.com/gravitational/trace"
 
+	accessgraph "github.com/gravitational/teleport/lib/accessgraph/apiclient"
 	"github.com/gravitational/teleport/lib/service/servicecfg"
 	"github.com/gravitational/teleport/lib/utils"
 	commonclient "github.com/gravitational/teleport/tool/tctl/common/client"
@@ -49,10 +50,10 @@ type AccessGraphCommand struct {
 	// accessgraph is the parent command grouping AG subcommands.
 	// TODO(ghassan): remove when the real AG subcommands are implemented
 	accessgraph *kingpin.CmdClause
-	// credentials is a hidden diagnostic that exercises the credential
-	// resolve/re-issue path.
+	// check is a hidden diagnostic that exercises the credential
+	// and client issuance and response code paths for diagnostic purposes
 	// TODO(ghassan): remove when the real AG subcommands are implemented
-	credentials *kingpin.CmdClause
+	check *kingpin.CmdClause
 }
 
 // Initialize allows AccessGraphCommand to plug itself into the CLI parser.
@@ -64,7 +65,7 @@ func (c *AccessGraphCommand) Initialize(app *kingpin.Application, cliFlags *tctl
 	}
 
 	c.accessgraph = app.Command("accessgraph", "Manage Access Graph (experimental).").Hidden()
-	c.credentials = c.accessgraph.Command("credentials", "Validate and re-issue the Access Graph credential.").Hidden()
+	c.check = c.accessgraph.Command("check", "Validate Access Graph flows (experimental)").Hidden()
 }
 
 // TryRun takes the CLI command as an argument and executes it.
@@ -77,20 +78,20 @@ func (c *AccessGraphCommand) TryRun(ctx context.Context, cmd string, clientFunc 
 
 	var commandFunc func(context.Context, commonclient.InitFunc) error
 	switch cmd {
-	case c.credentials.FullCommand():
-		commandFunc = c.runCredentialsCheck
+	case c.check.FullCommand():
+		commandFunc = c.accessGraphCheck
 	default:
 		return false, nil
 	}
 	return true, trace.Wrap(commandFunc(ctx, clientFunc))
 }
 
-// runCredentialsCheck resolves the Access Graph credential and re-issues
-// it if missing or stale, then reports the outcome. It does not contact
-// the Access Graph service itself — only the auth path is exercised.
+// accessGraphCheck is a hidden diagnostic command that validates the Access Graph credential
+// loading and client issuance code paths, and exercises a simple AG API call to validate the client works.
+// This is intended for diagnostic and code exercises purposes
 //
 // TODO(ghassan): remove when the real AG subcommands are implemented
-func (c *AccessGraphCommand) runCredentialsCheck(ctx context.Context, clientFunc commonclient.InitFunc) error {
+func (c *AccessGraphCommand) accessGraphCheck(ctx context.Context, clientFunc commonclient.InitFunc) error {
 	creds, err := c.loadAccessGraphCredentials(ctx)
 	if err != nil {
 		return trace.Wrap(err)
@@ -98,6 +99,27 @@ func (c *AccessGraphCommand) runCredentialsCheck(ctx context.Context, clientFunc
 	if err := ensureAccessGraphCert(ctx, creds, clientFunc); err != nil {
 		return trace.Wrap(err)
 	}
-	fmt.Fprintf(c.stdout, "Access Graph credential is valid (proxy: %s).\n", creds.proxyAddr)
-	return nil
+
+	if creds.proxyAddr == "" {
+		return trace.BadParameter("missing proxy address in Access Graph credential")
+	}
+
+	// Exercise the client issuance code path to validate it works with the
+	client, err := newAccessGraphClient(ctx, creds.proxyAddr, creds.keyRing)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	// Exercise a client call to validate the client works.
+	end := time.Now()
+	start := end.Add(-time.Hour * 24)
+	res, err := doRequest(client.ListAlertsV1WithResponse(ctx, &accessgraph.ListAlertsV1Params{
+		StartTime: &start,
+		EndTime:   &end,
+	}))
+
+	if err != nil {
+		return trace.Wrap(err, "failed to list Access Graph alerts")
+	}
+	return trace.Wrap(utils.WriteYAMLArray(c.stdout, res.JSON200.Data), "failed to write Access Graph alerts to output")
 }


### PR DESCRIPTION
Issue: https://github.com/gravitational/access-graph/issues/1933

This PR adds the code to generate an access graph client that will be used by tctl access graph commands, as well as a couple of helpers for making requests and handling response errors.

In addition, it expands the previous `tctl accessgraph credentials` command (now: `tctl accessgraph check`) to exercise the client code paths and to check the implementation. For now this is a hidden diagnostic command, which will be removed once the actual tctl commands are introduced.

## What changed

The following files have been added/changed in this PR:

1. `tool/tctl/accessgraph/client.go`: Contains the code to generate a new client and exposes a couple of helpers for response handling.
2. `tool/tctl/accessgraph/client_test.go`: Test suite for the client generation and the helpers.
3. `tool/tctl/accessgraph/command.go`: Updated to exercise the client code paths.

## Why

This is part of the work related to [access-graph#1933](https://github.com/gravitational/access-graph/issues/1933), which is focused on adding some tctl commands that will communicate directly with access graph through the web proxy, allowing users to perform queries and actions that were previously only available on the web.

We've been working on introducing some of the plumbing required for these commands, and this PR adds the mechanism that will allow us to make requests against the Access Graph endpoint on the proxy.

## Manual Test Plan

### Test Environment

- Local macOS dev machine (current branch for `teleport` and main branch for `access-graph`).
- Cloud tenant (master branch for `teleport` + hosted access graph).

### Test Cases

- [x] `go build ./tool/tctl/common/accessgraph/...` exits 0 (local).
- [x] `go test ./tool/tctl/common/accessgraph/...` passes (local).
- [x] `make full` and `make full-ent` succeed — no import-cycle or compile fallout from the new package (local).
- [x] Exercise downstream `tctl` Access Graph subcommands (e.g. `tctl detections ls`) against the cloud tenant and confirm a successful response — proves the new client wiring works end-to-end.
- [x] Verify `HTTPS_PROXY` / `NO_PROXY` are honoured by routing `tctl-e` traffic through a local forward proxy: confirmed via a simple log line `CONNECT <proxy-host>:<port>` that is logged when running with `HTTPS_PROXY` set, and stays absent when `NO_PROXY` matches the host.