### PR TITLE
[v18] teleterm: remove top bar for desktop sessions

### DIFF
--- a/web/packages/shared/components/DesktopSession/ActionMenu.tsx
+++ b/web/packages/shared/components/DesktopSession/ActionMenu.tsx
@@ -20,18 +20,23 @@ import * as Icons from 'design/Icon';
 import { MenuIcon, MenuItem, MenuItemIcon } from 'shared/components/MenuAction';
 
 export default function ActionMenu(props: Props) {
-  const { showShareDirectory, onShareDirectory, onDisconnect, onCtrlAltDel } =
-    props;
+  const {
+    showShareDirectory,
+    onShareDirectory,
+    onDisconnect,
+    onCtrlAltDel,
+    openUpward,
+    buttonIconColor = 'text.slightlyMuted',
+  } = props;
 
   return (
     <MenuIcon
       buttonIconProps={{
-        size: 0,
-        color: 'text.slightlyMuted',
-        style: { fontSize: '20px' },
+        color: buttonIconColor,
+        style: { fontSize: '20px', borderRadius: '8px' },
         title: 'More actions',
       }}
-      menuProps={menuProps}
+      menuProps={openUpward ? upwardMenuProps : menuProps}
     >
       {showShareDirectory && (
         <MenuItem onClick={onShareDirectory}>
@@ -56,6 +61,8 @@ type Props = {
   onShareDirectory: VoidFunction;
   onDisconnect: VoidFunction;
   onCtrlAltDel: VoidFunction;
+  openUpward?: boolean;
+  buttonIconColor?: string;
 };
 
 const menuListCss = () => `
@@ -64,4 +71,16 @@ const menuListCss = () => `
 
 const menuProps = {
   menuListCss,
+} as const;
+
+const upwardMenuProps = {
+  menuListCss,
+  anchorOrigin: {
+    vertical: 'top' as const,
+    horizontal: 'center' as const,
+  },
+  transformOrigin: {
+    vertical: 'bottom' as const,
+    horizontal: 'center' as const,
+  },
 } as const;

--- a/web/packages/shared/components/DesktopSession/AlertDropdown.tsx
+++ b/web/packages/shared/components/DesktopSession/AlertDropdown.tsx
@@ -20,14 +20,23 @@ import { useRef, useState } from 'react';
 import styled, { useTheme } from 'styled-components';
 
 import { Button, ButtonIcon, Card, Flex, H3 } from 'design';
+import { BoxProps } from 'design/Box';
 import { Cross, Warning } from 'design/Icon';
+import { HoverTooltip } from 'design/Tooltip';
 import {
   ToastNotification,
   type ToastNotificationItem,
 } from 'shared/components/ToastNotification';
 import { useClickOutside } from 'shared/hooks/useClickOutside';
+import { pluralize } from 'shared/utils/text';
 
-export function AlertDropdown({ alerts, onRemoveAlert }: Props) {
+export function AlertDropdown(
+  props: {
+    alerts: ToastNotificationItem[];
+    onRemoveAlert: (id: string) => void;
+  } & BoxProps
+) {
+  const { alerts, onRemoveAlert, ...boxProps } = props;
   const [showDropdown, setShowDropdown] = useState(false);
   const ref = useRef(null);
   const theme = useTheme();
@@ -52,22 +61,20 @@ export function AlertDropdown({ alerts, onRemoveAlert }: Props) {
 
   return (
     <>
-      <StyledButton
-        title={'Alerts'}
-        hasAlerts={alerts.length > 0}
-        px={2}
-        onClick={toggleDropdown}
+      <HoverTooltip
+        tipContent={`${alerts.length} ${pluralize(alerts.length, 'alert')}`}
+        placement="top"
       >
-        <Flex
-          alignItems="center"
-          justifyContent="space-between"
-          color={
-            alerts.length ? theme.colors.text.main : theme.colors.text.disabled
-          }
-        >
-          <Warning size={20} mr={2} /> {alerts.length}
-        </Flex>
-      </StyledButton>
+        <StyledButton px={2} onClick={toggleDropdown}>
+          <Flex
+            alignItems="center"
+            justifyContent="space-between"
+            color={theme.colors.text.main}
+          >
+            <Warning size={20} mr={2} /> {alerts.length}
+          </Flex>
+        </StyledButton>
+      </HoverTooltip>
       {showDropdown && (
         <StyledCard
           mt={3}
@@ -75,6 +82,7 @@ export function AlertDropdown({ alerts, onRemoveAlert }: Props) {
           style={{
             maxHeight: window.innerHeight / 3,
           }}
+          {...boxProps}
         >
           <Flex alignItems="center" justifyContent="space-between">
             <H3 px={3} style={{ overflow: 'visible' }}>
@@ -104,25 +112,21 @@ const StyledButton = styled(Button)`
   color: ${({ theme }) => theme.colors.light};
   min-height: 0;
   height: ${({ theme }) => theme.fontSizes[7] + 'px'};
-  background-color: ${props =>
-    props.hasAlerts
-      ? props.theme.colors.warning.main
-      : props.theme.colors.spotBackground[1]};
+  background-color: ${props => props.theme.colors.warning.main};
   &:hover,
   &:focus {
-    background-color: ${props =>
-      props.hasAlerts
-        ? props.theme.colors.warning.hover
-        : props.theme.colors.spotBackground[2]};
+    background-color: ${props => props.theme.colors.warning.hover};
   }
 `;
 
-const StyledCard = styled(Card)`
+const StyledCard = styled(Card).attrs(props => ({
+  right: 0,
+  top: `${props.theme.fontSizes[7]}px`,
+  ...props,
+}))`
   display: flex;
   flex-direction: column;
   position: absolute;
-  right: 0;
-  top: ${({ theme }) => theme.fontSizes[7] + 'px'};
   background-color: ${({ theme }) => theme.colors.levels.elevated};
 `;
 
@@ -137,8 +141,3 @@ const StyledOverflow = styled(Flex)`
   overflow-y: auto;
   overflow-x: hidden;
 `;
-
-type Props = {
-  alerts: ToastNotificationItem[];
-  onRemoveAlert: (id: string) => void;
-};

--- a/web/packages/shared/components/DesktopSession/DesktopSession.story.tsx
+++ b/web/packages/shared/components/DesktopSession/DesktopSession.story.tsx
@@ -33,7 +33,10 @@ import {
 } from 'shared/libs/tdp';
 import { TdpError as RemoteTdpError } from 'shared/libs/tdp/client';
 
-import { DesktopSession, DesktopSessionProps } from './DesktopSession';
+import {
+  DesktopSessionWithSharing,
+  DesktopSessionWithSharingProps,
+} from './DesktopSessionWithSharing';
 
 const meta: Meta = {
   title: 'Shared/DesktopSession',
@@ -63,7 +66,7 @@ const fakeClient = () => {
   return client;
 };
 
-const props: DesktopSessionProps = {
+const props: DesktopSessionWithSharingProps = {
   aclAttempt: makeSuccessAttempt({
     clipboardSharingEnabled: true,
     directorySharingEnabled: true,
@@ -76,11 +79,11 @@ const props: DesktopSessionProps = {
 };
 
 export const Processing = () => (
-  <DesktopSession {...props} aclAttempt={makeProcessingAttempt()} />
+  <DesktopSessionWithSharing {...props} aclAttempt={makeProcessingAttempt()} />
 );
 
 export const FetchError = () => (
-  <DesktopSession
+  <DesktopSessionWithSharing
     {...props}
     aclAttempt={makeErrorAttempt(new Error('Network Error'))}
   />
@@ -100,11 +103,11 @@ export const TdpError = () => {
     );
   };
 
-  return <DesktopSession {...props} client={client} />;
+  return <DesktopSessionWithSharing {...props} client={client} />;
 };
 
 export const Connected = () => {
-  return <DesktopSession {...props} />;
+  return <DesktopSessionWithSharing {...props} />;
 };
 
 export const DisconnectedWithNoMessage = () => {
@@ -113,11 +116,11 @@ export const DisconnectedWithNoMessage = () => {
     client.emit(TdpClientEvent.TRANSPORT_CLOSE, undefined);
   };
 
-  return <DesktopSession {...props} client={client} />;
+  return <DesktopSessionWithSharing {...props} client={client} />;
 };
 
 export const MfaPrompt = () => (
-  <DesktopSession
+  <DesktopSessionWithSharing
     {...props}
     customConnectionState={() => {
       return (
@@ -133,11 +136,14 @@ export const MfaPrompt = () => (
 );
 
 export const AnotherSessionActive = () => (
-  <DesktopSession {...props} hasAnotherSession={() => Promise.resolve(true)} />
+  <DesktopSessionWithSharing
+    {...props}
+    hasAnotherSession={() => Promise.resolve(true)}
+  />
 );
 
 export const SharingDisabledRbac = () => (
-  <DesktopSession
+  <DesktopSessionWithSharing
     {...props}
     aclAttempt={makeSuccessAttempt({
       clipboardSharingEnabled: false,
@@ -184,7 +190,7 @@ export const Alerts = () => {
     );
   };
 
-  return <DesktopSession {...props} client={client} />;
+  return <DesktopSessionWithSharing {...props} client={client} />;
 };
 
 function emitFrame(client: TdpClient, spec: ClientScreenSpec) {

--- a/web/packages/shared/components/DesktopSession/DesktopSession.test.tsx
+++ b/web/packages/shared/components/DesktopSession/DesktopSession.test.tsx
@@ -34,7 +34,7 @@ import 'jest-canvas-mock';
 
 import { TdpTransport } from 'shared/libs/tdp/client';
 
-import { DesktopSession } from './DesktopSession';
+import { DesktopSessionWithSharing } from './DesktopSessionWithSharing';
 
 // Disable WASM in tests.
 jest.mock('shared/libs/ironrdp/pkg/ironrdp');
@@ -110,7 +110,7 @@ test('reconnect button reinitializes the connection', async () => {
   jest.spyOn(tpdClient, 'connect');
   jest.spyOn(tpdClient, 'shutdown');
   const { unmount } = render(
-    <DesktopSession
+    <DesktopSessionWithSharing
       client={tpdClient}
       username="admin"
       desktop="win-lab"
@@ -154,7 +154,7 @@ test('ensure sharing remains enabled if the initial desktop connection attempt f
     selectDirectoryInBrowser
   );
   render(
-    <DesktopSession
+    <DesktopSessionWithSharing
       client={tpdClient}
       username="admin"
       desktop="win-lab"
@@ -189,7 +189,7 @@ test('re-sharing directory is possible after a reconnect', async () => {
   const mockFsSpy = jest.fn(async () => mockDirectoryAccess());
   const tpdClient = new TdpClient(transport.getTransport, mockFsSpy);
   render(
-    <DesktopSession
+    <DesktopSessionWithSharing
       client={tpdClient}
       username="admin"
       desktop="win-lab"
@@ -228,7 +228,6 @@ async function testSharingDirectory() {
   expect(await screen.findByTitle('More actions')).toBeVisible();
   await userEvent.click(screen.getByTitle('More actions'));
   await userEvent.click(await screen.findByText('Share Directory'));
-  expect(await screen.findByTitle('Alerts')).toHaveTextContent('0');
 }
 
 function mockDirectoryAccess(): SharedDirectoryAccess {

--- a/web/packages/shared/components/DesktopSession/DesktopSession.tsx
+++ b/web/packages/shared/components/DesktopSession/DesktopSession.tsx
@@ -17,6 +17,7 @@
  */
 
 import React, { useCallback, useEffect, useRef, useState } from 'react';
+import { ReactNode } from 'react';
 
 import {
   Alert,
@@ -35,6 +36,7 @@ import {
   CanvasRendererRef,
 } from 'shared/components/CanvasRenderer';
 import { Latency } from 'shared/components/LatencyDiagnostic';
+import type { ToastNotificationItem } from 'shared/components/ToastNotification';
 import {
   Attempt,
   makeEmptyAttempt,
@@ -50,7 +52,6 @@ import {
 import { TdpError } from 'shared/libs/tdp/client';
 
 import { InputHandler } from './InputHandler';
-import TopBar from './TopBar';
 import useDesktopSession, {
   clipboardSharingMessage,
   directorySharingPossible,
@@ -60,8 +61,6 @@ import useDesktopSession, {
 
 export interface DesktopSessionProps {
   client: TdpClient;
-  /** Username for display purposes. */
-  username: string;
   /** Desktop name for display purposes. */
   desktop: string;
   aclAttempt: Attempt<{
@@ -82,16 +81,31 @@ export interface DesktopSessionProps {
    * Spec can be found here: https://learn.microsoft.com/en-us/globalization/windows-keyboard-layouts
    */
   keyboardLayout?: number;
+  renderControls(props: DesktopSessionControlsRenderProps): ReactNode;
+}
+
+export interface DesktopSessionControlsRenderProps {
+  canShareDirectory: boolean;
+  isSharingDirectory: boolean;
+  isSharingClipboard: boolean;
+  clipboardSharingMessage: string;
+  onShareDirectory: VoidFunction;
+  onCtrlAltDel: VoidFunction;
+  onDisconnect: VoidFunction;
+  alerts: ToastNotificationItem[];
+  onRemoveAlert(id: string): void;
+  isConnected: boolean;
+  latencyStats: Latency;
 }
 
 export function DesktopSession({
   client,
-  aclAttempt,
-  username,
   desktop,
+  aclAttempt,
   hasAnotherSession,
   customConnectionState,
   keyboardLayout = 0,
+  renderControls,
   browserSupportsSharing,
 }: DesktopSessionProps) {
   const {
@@ -105,7 +119,6 @@ export function DesktopSession({
     onRemoveAlert,
     addAlert,
   } = useDesktopSession(client, aclAttempt, browserSupportsSharing);
-
   const [tdpConnectionStatus, setTdpConnectionStatus] =
     useState<TdpConnectionStatus>({ status: '' });
 
@@ -375,6 +388,19 @@ export function DesktopSession({
     customConnectionState?.({ retry: onRetry })
   );
 
+  const controlsProps: DesktopSessionControlsRenderProps = {
+    canShareDirectory: directorySharingPossible(directorySharingState),
+    isSharingDirectory: isSharingDirectory(directorySharingState),
+    isSharingClipboard: isSharingClipboard(clipboardSharingState),
+    clipboardSharingMessage: clipboardSharingMessage(clipboardSharingState),
+    onShareDirectory,
+    onCtrlAltDel: handleCtrlAltDel,
+    onDisconnect: () => client.shutdown(),
+    alerts,
+    onRemoveAlert,
+    isConnected: screenState.state === 'canvas-visible',
+    latencyStats,
+  };
   return (
     <Flex
       flexDirection="column"
@@ -385,22 +411,7 @@ export function DesktopSession({
         height: 100%;
       `}
     >
-      <TopBar
-        isConnected={screenState.state === 'canvas-visible'}
-        onDisconnect={() => {
-          client.shutdown();
-        }}
-        userHost={`${username} on ${desktop}`}
-        canShareDirectory={directorySharingPossible(directorySharingState)}
-        isSharingDirectory={isSharingDirectory(directorySharingState)}
-        isSharingClipboard={isSharingClipboard(clipboardSharingState)}
-        clipboardSharingMessage={clipboardSharingMessage(clipboardSharingState)}
-        onShareDirectory={onShareDirectory}
-        onCtrlAltDel={handleCtrlAltDel}
-        alerts={alerts}
-        onRemoveAlert={onRemoveAlert}
-        latency={latencyStats}
-      />
+      {renderControls(controlsProps)}
 
       {/* The UI states below (except the loading indicator) take up space.*/}
       {/* They're hidden while the canvas is visible, so when `connect()` reads the screen size, */}

--- a/web/packages/shared/components/DesktopSession/DesktopSessionWithSharing.tsx
+++ b/web/packages/shared/components/DesktopSession/DesktopSessionWithSharing.tsx
@@ -1,0 +1,74 @@
+/**
+ * Teleport
+ * Copyright (C) 2026 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import React from 'react';
+
+import { Attempt } from 'shared/hooks/useAsync';
+import { TdpClient } from 'shared/libs/tdp';
+
+import {
+  DesktopSession,
+  DesktopSessionControlsRenderProps,
+} from './DesktopSession';
+import TopBar from './TopBar';
+
+export type DesktopSessionWithSharingProps = {
+  client: TdpClient;
+  username: string;
+  desktop: string;
+  aclAttempt: Attempt<{
+    clipboardSharingEnabled: boolean;
+    directorySharingEnabled: boolean;
+  }>;
+  /** Determines if the browser client support directory and clipboard sharing. */
+  browserSupportsSharing: boolean;
+  customConnectionState?(args: { retry(): void }): React.ReactElement;
+  hasAnotherSession(): Promise<boolean>;
+  keyboardLayout?: number;
+};
+
+/**
+ * Composes DesktopSession with useDesktopSession for use in the web UI.
+ * Teleport Connect calls useDesktopSession directly in DocumentDesktopSession
+ * so it can publish session state to the status bar.
+ */
+export function DesktopSessionWithSharing(
+  props: DesktopSessionWithSharingProps
+) {
+  return (
+    <DesktopSession
+      {...props}
+      renderControls={(controls: DesktopSessionControlsRenderProps) => (
+        <TopBar
+          isConnected={controls.isConnected}
+          onDisconnect={controls.onDisconnect}
+          userHost={`${props.username} on ${props.desktop}`}
+          canShareDirectory={controls.canShareDirectory}
+          isSharingDirectory={controls.isSharingDirectory}
+          isSharingClipboard={controls.isSharingClipboard}
+          clipboardSharingMessage={controls.clipboardSharingMessage}
+          onShareDirectory={controls.onShareDirectory}
+          onCtrlAltDel={controls.onCtrlAltDel}
+          alerts={controls.alerts}
+          onRemoveAlert={controls.onRemoveAlert}
+          latency={controls.latencyStats}
+        />
+      )}
+    />
+  );
+}

--- a/web/packages/shared/components/DesktopSession/TopBar.tsx
+++ b/web/packages/shared/components/DesktopSession/TopBar.tsx
@@ -75,7 +75,9 @@ export default function TopBar(props: Props) {
           <HoverTooltip tipContent={clipboardSharingMessage} placement="bottom">
             <Clipboard style={primaryOnTrue(isSharingClipboard)} />
           </HoverTooltip>
-          <AlertDropdown alerts={alerts} onRemoveAlert={onRemoveAlert} />
+          {!!alerts?.length && (
+            <AlertDropdown alerts={alerts} onRemoveAlert={onRemoveAlert} />
+          )}
           <ActionMenu
             onDisconnect={onDisconnect}
             showShareDirectory={canShareDirectory && !isSharingDirectory}

--- a/web/packages/shared/components/DesktopSession/index.ts
+++ b/web/packages/shared/components/DesktopSession/index.ts
@@ -17,3 +17,4 @@
  */
 
 export { DesktopSession, DisconnectedState } from './DesktopSession';
+export { DesktopSessionWithSharing } from './DesktopSessionWithSharing';

--- a/web/packages/shared/components/DesktopSession/useDesktopSession.tsx
+++ b/web/packages/shared/components/DesktopSession/useDesktopSession.tsx
@@ -89,9 +89,9 @@ export default function useDesktopSession(
   }, []);
 
   const [alerts, setAlerts] = useState<ToastNotificationItem[]>([]);
-  const onRemoveAlert = (id: string) => {
+  const onRemoveAlert = useCallback((id: string) => {
     setAlerts(prevState => prevState.filter(alert => alert.id !== id));
-  };
+  }, []);
   const addAlert = useCallback((alert: Omit<ToastNotificationItem, 'id'>) => {
     setAlerts(prevState => [
       ...prevState,
@@ -126,7 +126,7 @@ export default function useDesktopSession(
     }
   }
 
-  const onShareDirectory = async () => {
+  const onShareDirectory = useCallback(async () => {
     try {
       await tdpClient.shareDirectory();
       setDirectorySharingState({
@@ -147,7 +147,7 @@ export default function useDesktopSession(
         },
       });
     }
-  };
+  }, [tdpClient, addAlert]);
 
   /** Clears sharing state. */
   const clearSharing = useCallback(() => {

--- a/web/packages/teleport/src/DesktopSession/DesktopSession.tsx
+++ b/web/packages/teleport/src/DesktopSession/DesktopSession.tsx
@@ -21,7 +21,7 @@ import { useParams } from 'react-router';
 
 import {
   DisconnectedState,
-  DesktopSession as SharedDesktopSession,
+  DesktopSessionWithSharing as SharedDesktopSession,
 } from 'shared/components/DesktopSession';
 import { useAsync } from 'shared/hooks/useAsync';
 import { selectDirectoryInBrowser, TdpClient } from 'shared/libs/tdp';

--- a/web/packages/teleterm/src/ui/DocumentCluster/InfoGuideSidePanel.story.tsx
+++ b/web/packages/teleterm/src/ui/DocumentCluster/InfoGuideSidePanel.story.tsx
@@ -57,6 +57,7 @@ const rootClusterDoc = makeDocumentCluster({
 export function InfoGuideSidePanel() {
   const topBarConnectMyComputerRef = useRef<HTMLDivElement>(null);
   const topBarAccessRequestRef = useRef<HTMLDivElement>(null);
+  const desktopSessionControlsRef = useRef<HTMLDivElement>(null);
 
   const appContext = new MockAppContext();
   const cluster = makeRootCluster({
@@ -88,7 +89,10 @@ export function InfoGuideSidePanel() {
                           </StyledTabs>
                           <Example />
                         </Flex>
-                        <StatusBar onAssumedRolesClick={() => null} />
+                        <StatusBar
+                          onAssumedRolesClick={() => null}
+                          desktopSessionControlsRef={desktopSessionControlsRef}
+                        />
                       </Flex>
                     </InfoGuidePanelProvider>
                   </Wrapper>

--- a/web/packages/teleterm/src/ui/DocumentDesktopSession/DocumentDesktopSession.tsx
+++ b/web/packages/teleterm/src/ui/DocumentDesktopSession/DocumentDesktopSession.tsx
@@ -16,7 +16,8 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { useCallback, useMemo, useState } from 'react';
+import { MutableRefObject, useCallback, useMemo, useState } from 'react';
+import { createPortal } from 'react-dom';
 
 import { Text } from 'design';
 import { ACL } from 'gen-proto-ts/teleport/lib/teleterm/v1/cluster_pb';
@@ -38,6 +39,7 @@ import { useWorkspaceContext } from 'teleterm/ui/Documents';
 import { useWorkspaceLoggedInUser } from 'teleterm/ui/hooks/useLoggedInUser';
 import { useLogger } from 'teleterm/ui/hooks/useLogger';
 import * as types from 'teleterm/ui/services/workspacesService';
+import { DesktopSessionControls } from 'teleterm/ui/StatusBar/DesktopSessionControls';
 import { DesktopUri, isWindowsDesktopUri, routing } from 'teleterm/ui/uri';
 
 // The check for another active session is disabled in Connect:
@@ -51,13 +53,18 @@ const noOtherSession = () => Promise.resolve(false);
 export function DocumentDesktopSession(props: {
   visible: boolean;
   doc: types.DocumentDesktopSession;
+  desktopSessionControlsRef: MutableRefObject<HTMLDivElement>;
 }) {
   return (
     <ForegroundSession
       visible={props.visible}
       connected={props.doc.status === 'connected'}
     >
-      <DesktopSessionComponent visible={props.visible} doc={props.doc} />
+      <DesktopSessionComponent
+        visible={props.visible}
+        doc={props.doc}
+        desktopSessionControlsRef={props.desktopSessionControlsRef}
+      />
     </ForegroundSession>
   );
 }
@@ -65,12 +72,14 @@ export function DocumentDesktopSession(props: {
 function DesktopSessionComponent(props: {
   visible: boolean;
   doc: types.DocumentDesktopSession;
+  desktopSessionControlsRef: MutableRefObject<HTMLDivElement>;
 }) {
   const logger = useLogger('DocumentDesktopSession');
   const { desktopUri, login, origin, uri } = props.doc;
   const appCtx = useAppContext();
   const { documentsService } = useWorkspaceContext();
   const loggedInUser = useWorkspaceLoggedInUser();
+
   const acl = useMemo<Attempt<ACL>>(() => {
     if (!loggedInUser?.acl) {
       return makeProcessingAttempt();
@@ -143,9 +152,18 @@ function DesktopSessionComponent(props: {
           routing.parseWindowsDesktopUri(desktopUri).params?.windowsDesktopId
         }
         client={client}
-        username={login}
         aclAttempt={acl}
         browserSupportsSharing
+        renderControls={controls => {
+          if (!(props.visible && controls.isConnected)) {
+            return;
+          }
+
+          return createPortal(
+            <DesktopSessionControls controls={controls} />,
+            props.desktopSessionControlsRef.current
+          );
+        }}
       />
     );
   }

--- a/web/packages/teleterm/src/ui/Documents/DocumentsRenderer.tsx
+++ b/web/packages/teleterm/src/ui/Documents/DocumentsRenderer.tsx
@@ -57,13 +57,21 @@ import { WorkspaceContextProvider } from './workspaceContext';
 export function DocumentsRenderer(props: {
   topBarConnectMyComputerRef: MutableRefObject<HTMLDivElement>;
   topBarAccessRequestRef: MutableRefObject<HTMLDivElement>;
+  desktopSessionControlsRef: MutableRefObject<HTMLDivElement>;
 }) {
   const { workspacesService } = useAppContext();
 
   function renderDocuments(documentsService: DocumentsService) {
     return documentsService.getDocuments().map(doc => {
       const isActiveDoc = workspacesService.isDocumentActive(doc.uri);
-      return <MemoizedDocument doc={doc} visible={isActiveDoc} key={doc.uri} />;
+      return (
+        <MemoizedDocument
+          doc={doc}
+          visible={isActiveDoc}
+          key={doc.uri}
+          desktopSessionControlsRef={props.desktopSessionControlsRef}
+        />
+      );
     });
   }
 
@@ -131,8 +139,12 @@ const DocumentsContainer = styled.div<{ isVisible?: boolean }>`
   display: ${props => (props.isVisible ? 'contents' : 'none')};
 `;
 
-function MemoizedDocument(props: { doc: types.Document; visible: boolean }) {
-  const { doc, visible } = props;
+function MemoizedDocument(props: {
+  doc: types.Document;
+  visible: boolean;
+  desktopSessionControlsRef: MutableRefObject<HTMLDivElement>;
+}) {
+  const { doc, visible, desktopSessionControlsRef } = props;
 
   return useMemo(() => {
     switch (doc.kind) {
@@ -176,7 +188,13 @@ function MemoizedDocument(props: { doc: types.Document; visible: boolean }) {
       case 'doc.vnet_info':
         return <DocumentVnetInfo doc={doc} visible={visible} />;
       case 'doc.desktop_session':
-        return <DocumentDesktopSession doc={doc} visible={visible} />;
+        return (
+          <DocumentDesktopSession
+            doc={doc}
+            visible={visible}
+            desktopSessionControlsRef={desktopSessionControlsRef}
+          />
+        );
       default:
         doc satisfies types.DocumentBlank;
         return (
@@ -187,5 +205,5 @@ function MemoizedDocument(props: { doc: types.Document; visible: boolean }) {
           </Document>
         );
     }
-  }, [visible, doc]);
+  }, [visible, doc, desktopSessionControlsRef]);
 }

--- a/web/packages/teleterm/src/ui/LayoutManager.tsx
+++ b/web/packages/teleterm/src/ui/LayoutManager.tsx
@@ -29,6 +29,7 @@ import { TopBar } from 'teleterm/ui/TopBar';
 export function LayoutManager() {
   const topBarConnectMyComputerRef = useRef<HTMLDivElement>(null);
   const topBarAccessRequestRef = useRef<HTMLDivElement>(null);
+  const desktopSessionControlsRef = useRef<HTMLDivElement>(null);
 
   return (
     <Flex flex="1" flexDirection="column" minHeight={0}>
@@ -46,11 +47,13 @@ export function LayoutManager() {
         <TabHostContainer
           topBarConnectMyComputerRef={topBarConnectMyComputerRef}
           topBarAccessRequestRef={topBarAccessRequestRef}
+          desktopSessionControlsRef={desktopSessionControlsRef}
         />
         <NotificationsHost />
       </Flex>
       <AccessRequestCheckout />
       <StatusBar
+        desktopSessionControlsRef={desktopSessionControlsRef}
         onAssumedRolesClick={() => {
           // This is a little hacky, but has one advantage:
           // we don't need to expose a way to open/close the popover.

--- a/web/packages/teleterm/src/ui/StatusBar/DesktopSessionControls.story.tsx
+++ b/web/packages/teleterm/src/ui/StatusBar/DesktopSessionControls.story.tsx
@@ -1,0 +1,59 @@
+/**
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { DesktopSessionControlsRenderProps } from 'shared/components/DesktopSession/DesktopSession';
+import { ToastNotificationItem } from 'shared/components/ToastNotification/types';
+
+import { DesktopSessionControls } from './DesktopSessionControls';
+
+export default {
+  title: 'Teleterm/StatusBar/DesktopSessionControls',
+  parameters: {
+    layout: 'centered',
+  },
+};
+
+const controls: DesktopSessionControlsRenderProps = {
+  canShareDirectory: true,
+  isSharingDirectory: false,
+  isSharingClipboard: false,
+  clipboardSharingMessage: 'Clipboard sharing inactive.',
+  onShareDirectory: () => {},
+  onCtrlAltDel: () => {},
+  onDisconnect: () => {},
+  onRemoveAlert: () => {},
+  alerts: [],
+  isConnected: false,
+  latencyStats: undefined,
+};
+
+export function NoAlerts() {
+  return <DesktopSessionControls controls={controls} />;
+}
+
+export function WithAlert() {
+  const alerts = [
+    {
+      severity: 'warn',
+      content: 'This is a warning message.',
+      id: 'warning-1',
+    },
+  ] as ToastNotificationItem[];
+  const alertControls = { ...controls, alerts };
+  return <DesktopSessionControls controls={alertControls} />;
+}

--- a/web/packages/teleterm/src/ui/StatusBar/DesktopSessionControls.tsx
+++ b/web/packages/teleterm/src/ui/StatusBar/DesktopSessionControls.tsx
@@ -1,0 +1,125 @@
+/**
+ * Teleport
+ * Copyright (C) 2026 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import styled, { useTheme } from 'styled-components';
+
+import { Box, Flex, ResourceIcon } from 'design';
+import { Clipboard, FolderShared } from 'design/Icon';
+import { HoverTooltip } from 'design/Tooltip';
+import ActionMenu from 'shared/components/DesktopSession/ActionMenu';
+import { AlertDropdown } from 'shared/components/DesktopSession/AlertDropdown';
+import type { DesktopSessionControlsRenderProps } from 'shared/components/DesktopSession/DesktopSession';
+import { LatencyDiagnostic } from 'shared/components/LatencyDiagnostic';
+
+import { statusBarHeight } from './constants';
+
+export function DesktopSessionControls({
+  controls,
+}: {
+  controls: DesktopSessionControlsRenderProps;
+}) {
+  const theme = useTheme();
+
+  const iconColor = (active: boolean) =>
+    active ? theme.colors.text.main : theme.colors.text.muted;
+
+  return (
+    <Inset>
+      <Box mx={2}>
+        <ResourceIcon name="windows" size="large" />
+      </Box>
+      {controls.latencyStats && (
+        <LatencyDiagnostic latency={controls.latencyStats} />
+      )}
+      <HoverTooltip
+        tipContent={directorySharingTooltip(
+          controls.canShareDirectory,
+          controls.isSharingDirectory
+        )}
+        placement="top"
+      >
+        <FolderShared
+          size="small"
+          padding="8px"
+          color={iconColor(controls.isSharingDirectory)}
+        />
+      </HoverTooltip>
+      <HoverTooltip
+        tipContent={controls.clipboardSharingMessage}
+        placement="top"
+      >
+        <Clipboard
+          size="small"
+          padding="8px"
+          color={iconColor(controls.isSharingClipboard)}
+        />
+      </HoverTooltip>
+      {!!controls?.alerts?.length && (
+        <AlertDropdown
+          alerts={controls.alerts}
+          onRemoveAlert={controls.onRemoveAlert}
+          top="unset"
+          bottom={statusBarHeight + theme.space[2]}
+          right={2}
+        />
+      )}
+      <Divider />
+      <ActionMenu
+        showShareDirectory={
+          controls.canShareDirectory && !controls.isSharingDirectory
+        }
+        onShareDirectory={controls.onShareDirectory}
+        onCtrlAltDel={controls.onCtrlAltDel}
+        onDisconnect={controls.onDisconnect}
+        openUpward
+        buttonIconColor="text.slightlyMuted"
+      />
+    </Inset>
+  );
+}
+
+const Inset = styled(Flex).attrs({ alignSelf: 'center', alignItems: 'center' })`
+  background: ${({ theme }) => theme.colors.levels.sunken};
+  box-shadow:
+    0 2px 1px -1px rgba(0, 0, 0, 0.2) inset,
+    0 1px 1px 0 rgba(0, 0, 0, 0.14) inset,
+    0 1px 3px 0 rgba(0, 0, 0, 0.12) inset;
+  border-radius: ${({ theme }) => theme.radii[3]}px;
+  height: 32px;
+  margin: 4px auto;
+  gap: 2px;
+`;
+
+const Divider = styled.div`
+  width: 1px;
+  height: 20px;
+  background: ${({ theme }) => theme.colors.interactive.tonal.neutral[1]};
+`;
+
+function directorySharingTooltip(
+  canShare: boolean,
+  isSharing: boolean
+): string {
+  if (!canShare) {
+    return 'Directory Sharing Disabled';
+  }
+  if (!isSharing) {
+    return 'Directory Sharing Inactive';
+  }
+  return 'Directory Sharing Enabled';
+}

--- a/web/packages/teleterm/src/ui/StatusBar/StatusBar.tsx
+++ b/web/packages/teleterm/src/ui/StatusBar/StatusBar.tsx
@@ -17,7 +17,7 @@
  */
 
 import { UseQueryResult } from '@tanstack/react-query';
-import { Fragment, useCallback } from 'react';
+import { Fragment, MutableRefObject, useCallback } from 'react';
 import { useTheme } from 'styled-components';
 
 import { ButtonPrimary, Flex, Text } from 'design';
@@ -33,7 +33,10 @@ import { statusBarHeight } from './constants';
 import { ShareFeedback } from './ShareFeedback';
 import { useActiveDocumentClusterBreadcrumbs } from './useActiveDocumentClusterBreadcrumbs';
 
-export function StatusBar(props: { onAssumedRolesClick(): void }) {
+export function StatusBar(props: {
+  onAssumedRolesClick(): void;
+  desktopSessionControlsRef: MutableRefObject<HTMLDivElement>;
+}) {
   const breadcrumbs = useActiveDocumentClusterBreadcrumbs();
   const theme = useTheme();
   const rootClusterUri = useStoreSelector(
@@ -48,6 +51,7 @@ export function StatusBar(props: { onAssumedRolesClick(): void }) {
     <Flex
       width="100%"
       height={`${statusBarHeight}px`}
+      background={theme.colors.levels.surface}
       css={`
         border-top: 1px solid ${props => props.theme.colors.spotBackground[1]};
       `}
@@ -126,6 +130,7 @@ export function StatusBar(props: { onAssumedRolesClick(): void }) {
             </Text>
           </ButtonPrimary>
         )}
+        <Flex ref={props.desktopSessionControlsRef} height="100%" />
         <AccessRequestCheckoutButton />
         <ShareFeedback />
       </Flex>

--- a/web/packages/teleterm/src/ui/StatusBar/constants.ts
+++ b/web/packages/teleterm/src/ui/StatusBar/constants.ts
@@ -16,4 +16,4 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-export const statusBarHeight = 28;
+export const statusBarHeight = 36;

--- a/web/packages/teleterm/src/ui/TabHost/TabHost.story.tsx
+++ b/web/packages/teleterm/src/ui/TabHost/TabHost.story.tsx
@@ -79,6 +79,7 @@ export function Story() {
             <TabHostContainer
               topBarConnectMyComputerRef={createRef()}
               topBarAccessRequestRef={createRef()}
+              desktopSessionControlsRef={createRef()}
             />
           </VnetContextProvider>
         </ConnectionsContextProvider>

--- a/web/packages/teleterm/src/ui/TabHost/TabHost.test.tsx
+++ b/web/packages/teleterm/src/ui/TabHost/TabHost.test.tsx
@@ -73,6 +73,7 @@ async function getTestSetup({ documents }: { documents: Document[] }) {
           ctx={appContext}
           topBarConnectMyComputerRef={createRef()}
           topBarAccessRequestRef={createRef()}
+          desktopSessionControlsRef={createRef()}
         />
       </ResourcesContextProvider>
     </MockAppContextProvider>

--- a/web/packages/teleterm/src/ui/TabHost/TabHost.tsx
+++ b/web/packages/teleterm/src/ui/TabHost/TabHost.tsx
@@ -39,6 +39,7 @@ import { useTabShortcuts } from './useTabShortcuts';
 export function TabHostContainer(props: {
   topBarConnectMyComputerRef: MutableRefObject<HTMLDivElement>;
   topBarAccessRequestRef: MutableRefObject<HTMLDivElement>;
+  desktopSessionControlsRef: MutableRefObject<HTMLDivElement>;
 }) {
   const ctx = useAppContext();
   const isRootClusterSelected = useStoreSelector(
@@ -52,6 +53,7 @@ export function TabHostContainer(props: {
         ctx={ctx}
         topBarConnectMyComputerRef={props.topBarConnectMyComputerRef}
         topBarAccessRequestRef={props.topBarAccessRequestRef}
+        desktopSessionControlsRef={props.desktopSessionControlsRef}
       />
     );
   }
@@ -62,10 +64,12 @@ export function TabHost({
   ctx,
   topBarConnectMyComputerRef,
   topBarAccessRequestRef,
+  desktopSessionControlsRef,
 }: {
   ctx: IAppContext;
   topBarConnectMyComputerRef: MutableRefObject<HTMLDivElement>;
   topBarAccessRequestRef: MutableRefObject<HTMLDivElement>;
+  desktopSessionControlsRef: MutableRefObject<HTMLDivElement>;
 }) {
   useWorkspaceServiceState();
   const documentsService =
@@ -146,6 +150,7 @@ export function TabHost({
       <DocumentsRenderer
         topBarConnectMyComputerRef={topBarConnectMyComputerRef}
         topBarAccessRequestRef={topBarAccessRequestRef}
+        desktopSessionControlsRef={desktopSessionControlsRef}
       />
     </StyledTabHost>
   );

--- a/web/packages/teleterm/src/ui/services/connectionTracker/connectionTrackerService.test.tsx
+++ b/web/packages/teleterm/src/ui/services/connectionTracker/connectionTrackerService.test.tsx
@@ -243,6 +243,7 @@ function setupTests(): {
 
   const topBarConnectMyComputerRef = createRef<HTMLDivElement>();
   const topBarAccessRequestRef = createRef<HTMLDivElement>();
+  const desktopSessionControlsRef = createRef<HTMLDivElement>();
   const Component = () => (
     <MockAppContextProvider appContext={ctx}>
       <ResourcesContextProvider>
@@ -250,6 +251,7 @@ function setupTests(): {
           ctx={ctx}
           topBarConnectMyComputerRef={topBarConnectMyComputerRef}
           topBarAccessRequestRef={topBarAccessRequestRef}
+          desktopSessionControlsRef={desktopSessionControlsRef}
         />
       </ResourcesContextProvider>
     </MockAppContextProvider>


### PR DESCRIPTION
Backports #65993 

Changelog: Windows desktop controls in Teleport Connect now reside in the status bar in order to allocate more screen real estate to the RDP session.

## Manual Test Plan

### Test Environment

Local cluster.

### Test Cases

Web UI
- [x] Top bar is still present.
- [x] Top bar functionality still works.

Connect
- [x] Top bar is not present in Teleport Connect sessions.
- [x] Status bar controls show up when a desktop session tab is focused.
- [x] Status bar controls disappear when a non-desktop tab is focused.
