### PR TITLE
Operator scope CRD column

### DIFF
--- a/examples/chart/teleport-cluster/charts/teleport-operator/operator-crds/resources.teleport.dev_scopedroleassignmentsv1.yaml
+++ b/examples/chart/teleport-cluster/charts/teleport-operator/operator-crds/resources.teleport.dev_scopedroleassignmentsv1.yaml
@@ -14,7 +14,12 @@ spec:
     singular: teleportscopedroleassignmentv1
   scope: Namespaced
   versions:
-  - name: v1
+  - additionalPrinterColumns:
+    - description: Resource's scope.
+      jsonPath: .scope
+      name: scope
+      type: string
+    name: v1
     schema:
       openAPIV3Schema:
         description: ScopedRoleAssignmentV1 is the Schema for the scopedroleassignmentsv1

--- a/examples/chart/teleport-cluster/charts/teleport-operator/operator-crds/resources.teleport.dev_scopedrolesv1.yaml
+++ b/examples/chart/teleport-cluster/charts/teleport-operator/operator-crds/resources.teleport.dev_scopedrolesv1.yaml
@@ -14,7 +14,12 @@ spec:
     singular: teleportscopedrolev1
   scope: Namespaced
   versions:
-  - name: v1
+  - additionalPrinterColumns:
+    - description: Resource's scope.
+      jsonPath: .scope
+      name: scope
+      type: string
+    name: v1
     schema:
       openAPIV3Schema:
         description: ScopedRoleV1 is the Schema for the scopedrolesv1 API

--- a/examples/chart/teleport-cluster/charts/teleport-operator/operator-crds/resources.teleport.dev_scopedtokensv1.yaml
+++ b/examples/chart/teleport-cluster/charts/teleport-operator/operator-crds/resources.teleport.dev_scopedtokensv1.yaml
@@ -14,7 +14,12 @@ spec:
     singular: teleportscopedtokenv1
   scope: Namespaced
   versions:
-  - name: v1
+  - additionalPrinterColumns:
+    - description: Resource's scope.
+      jsonPath: .scope
+      name: scope
+      type: string
+    name: v1
     schema:
       openAPIV3Schema:
         description: ScopedTokenV1 is the Schema for the scopedtokensv1 API

--- a/integrations/operator/config/crd/bases/resources.teleport.dev_scopedroleassignmentsv1.yaml
+++ b/integrations/operator/config/crd/bases/resources.teleport.dev_scopedroleassignmentsv1.yaml
@@ -14,7 +14,12 @@ spec:
     singular: teleportscopedroleassignmentv1
   scope: Namespaced
   versions:
-  - name: v1
+  - additionalPrinterColumns:
+    - description: Resource's scope.
+      jsonPath: .scope
+      name: scope
+      type: string
+    name: v1
     schema:
       openAPIV3Schema:
         description: ScopedRoleAssignmentV1 is the Schema for the scopedroleassignmentsv1

--- a/integrations/operator/config/crd/bases/resources.teleport.dev_scopedrolesv1.yaml
+++ b/integrations/operator/config/crd/bases/resources.teleport.dev_scopedrolesv1.yaml
@@ -14,7 +14,12 @@ spec:
     singular: teleportscopedrolev1
   scope: Namespaced
   versions:
-  - name: v1
+  - additionalPrinterColumns:
+    - description: Resource's scope.
+      jsonPath: .scope
+      name: scope
+      type: string
+    name: v1
     schema:
       openAPIV3Schema:
         description: ScopedRoleV1 is the Schema for the scopedrolesv1 API

--- a/integrations/operator/config/crd/bases/resources.teleport.dev_scopedtokensv1.yaml
+++ b/integrations/operator/config/crd/bases/resources.teleport.dev_scopedtokensv1.yaml
@@ -14,7 +14,12 @@ spec:
     singular: teleportscopedtokenv1
   scope: Namespaced
   versions:
-  - name: v1
+  - additionalPrinterColumns:
+    - description: Resource's scope.
+      jsonPath: .scope
+      name: scope
+      type: string
+    name: v1
     schema:
       openAPIV3Schema:
         description: ScopedTokenV1 is the Schema for the scopedtokensv1 API

--- a/integrations/operator/crdgen/handlerequest.go
+++ b/integrations/operator/crdgen/handlerequest.go
@@ -278,21 +278,21 @@ func generateSchema(file *File, groupName string, format crdFormatFunc, resp *go
 			name: "ScopedToken",
 			opts: []resourceSchemaOption{
 				withVersionOverride(types.V1),
-				withAdditionalRootFields([]string{"scope"}),
+				withScope(),
 			},
 		},
 		{
 			name: "ScopedRole",
 			opts: []resourceSchemaOption{
 				withVersionOverride(types.V1),
-				withAdditionalRootFields([]string{"scope"}),
+				withScope(),
 			},
 		},
 		{
 			name: "ScopedRoleAssignment",
 			opts: []resourceSchemaOption{
 				withVersionOverride(types.V1),
-				withAdditionalRootFields([]string{"scope"}),
+				withScope(),
 			},
 		},
 	}

--- a/integrations/operator/crdgen/schemagen.go
+++ b/integrations/operator/crdgen/schemagen.go
@@ -152,7 +152,7 @@ func withCustomSpecFields(customSpecFields []string) resourceSchemaOption {
 	}
 }
 
-// withScope says that the resource is scoped. A scope filed will be inserted at the CRD root.
+// withScope says that the resource is scoped. A scope field will be inserted at the CRD root.
 func withScope() resourceSchemaOption {
 	return func(cfg *resourceSchemaConfig) {
 		cfg.additionalRootFields = append(cfg.additionalRootFields, scopeFieldName)

--- a/integrations/operator/crdgen/schemagen.go
+++ b/integrations/operator/crdgen/schemagen.go
@@ -40,6 +40,7 @@ const (
 	statusPackageName = "teleportcr"
 	statusPackage     = statusPackagePath + "/" + statusPackageName
 	statusTypeName    = "Status"
+	scopeFieldName    = "scope"
 )
 
 // Add names to this array when adding support to new Teleport resources that could conflict with Kubernetes
@@ -151,11 +152,17 @@ func withCustomSpecFields(customSpecFields []string) resourceSchemaOption {
 	}
 }
 
-// withAdditionalRootFields adds fields from the root proto message as top-level
-// properties on the CRD.
-func withAdditionalRootFields(rootFields []string) resourceSchemaOption {
+// withScope says that the resource is scoped. A scope filed will be inserted at the CRD root.
+func withScope() resourceSchemaOption {
 	return func(cfg *resourceSchemaConfig) {
-		cfg.additionalRootFields = rootFields
+		cfg.additionalRootFields = append(cfg.additionalRootFields, scopeFieldName)
+		cfg.additionalColumns = append(cfg.additionalColumns, apiextv1.CustomResourceColumnDefinition{
+			Name:        scopeFieldName,
+			Type:        "string",
+			Description: "Resource's scope.",
+			Priority:    0,
+			JSONPath:    "." + scopeFieldName,
+		})
 	}
 }
 


### PR DESCRIPTION
This PR contains 2 minor changes:
- Quality of life: the scoped resources now exhibit a `scope` column when running `kubectl get`
- Developer experience: The `withAdditionalRootField([]string)` option is now `withScope()` as scopes were te only use case and the new name makes it more obvious when this should be set

## Manual Test Plan
### Test Environment

Operator deployed in a local k3d cluster against staging cluster

### Test Cases
- [x] Can get scoped roles
- [x] Can create scoped roles
