### PR TITLE
policy-poc: Per-request authorization for App Access

### DIFF
--- a/lib/config/configuration.go
+++ b/lib/config/configuration.go
@@ -66,6 +66,7 @@ import (
 	"github.com/gravitational/teleport/lib/multiplexer"
 	"github.com/gravitational/teleport/lib/service/servicecfg"
 	"github.com/gravitational/teleport/lib/services"
+	"github.com/gravitational/teleport/lib/srv/app/policy"
 	"github.com/gravitational/teleport/lib/tlsca"
 	"github.com/gravitational/teleport/lib/utils"
 	awsregion "github.com/gravitational/teleport/lib/utils/aws/region"
@@ -2046,6 +2047,21 @@ func applyAppsConfig(fc *FileConfig, cfg *servicecfg.Config) error {
 	// Apps are enabled.
 	cfg.Apps.Enabled = true
 
+	// Compile the file-local named policies first so app entries can
+	// resolve string references against them.
+	var library []policy.Policy
+	if len(fc.Apps.Policies) > 0 {
+		specs := make([]policy.Spec, 0, len(fc.Apps.Policies))
+		for _, p := range fc.Apps.Policies {
+			specs = append(specs, convertPolicySpec(p))
+		}
+		var err error
+		library, err = policy.CompileAll(specs)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+	}
+
 	// Log when proxy_service is enabled in the same config but has no
 	// public_addr. The proxy falls back to the cluster name for the
 	// auth redirect. Per-app public_addr controls the app's FQDN but
@@ -2189,10 +2205,76 @@ func applyAppsConfig(fc *FileConfig, cfg *servicecfg.Config) error {
 		if err := app.CheckAndSetDefaults(); err != nil {
 			return trace.Wrap(err)
 		}
+
+		if len(application.Policies) > 0 {
+			// Policies enforce per-HTTP-request authorization. TCP, MCP,
+			// and LLM apps reach the agent through non-HTTP paths and
+			// would silently bypass the gate.
+			if len(application.TCPPorts) > 0 {
+				return trace.BadParameter("app %q: policies are not supported on TCP apps", application.Name)
+			}
+			if application.MCP != nil {
+				return trace.BadParameter("app %q: policies are not supported on MCP apps", application.Name)
+			}
+			if application.LLM != nil {
+				return trace.BadParameter("app %q: policies are not supported on LLM apps", application.Name)
+			}
+			// public_addr is the lookup key the connections handler uses
+			// to find this app's policies at request time. If it is left
+			// empty Teleport resolves it later from app.Name + proxy
+			// host, but that happens after the policy map is built,
+			// which would silently skip enforcement.
+			if application.PublicAddr == "" {
+				return trace.BadParameter("app %q: policies require an explicit public_addr", application.Name)
+			}
+			refs := convertPolicyRefs(application.Policies)
+			resolved, err := policy.Resolve(library, refs)
+			if err != nil {
+				return trace.Wrap(err, "resolving policies for app %q", application.Name)
+			}
+			app.Policies = resolved
+		}
+
 		cfg.Apps.Apps = append(cfg.Apps.Apps, app)
 	}
 
 	return nil
+}
+
+func convertPolicySpec(p AppAccessPolicy) policy.Spec {
+	out := policy.Spec{Name: p.Name}
+	for _, r := range p.Allow {
+		out.Allow = append(out.Allow, policy.RuleSpec{
+			Paths:      r.Paths,
+			Methods:    r.Methods,
+			Where:      r.Where,
+			ReasonCode: r.ReasonCode,
+			Reason:     r.Reason,
+		})
+	}
+	for _, r := range p.Deny {
+		out.Deny = append(out.Deny, policy.RuleSpec{
+			Paths:      r.Paths,
+			Methods:    r.Methods,
+			Where:      r.Where,
+			ReasonCode: r.ReasonCode,
+			Reason:     r.Reason,
+		})
+	}
+	return out
+}
+
+func convertPolicyRefs(refs []AppAccessPolicyRef) []policy.Ref {
+	out := make([]policy.Ref, 0, len(refs))
+	for _, r := range refs {
+		if r.Inline != nil {
+			spec := convertPolicySpec(*r.Inline)
+			out = append(out, policy.Ref{Inline: &spec})
+			continue
+		}
+		out = append(out, policy.Ref{Name: r.Name})
+	}
+	return out
 }
 
 // applyMetricsConfig applies file configuration for the "metrics_service" section.

--- a/lib/config/fileconf.go
+++ b/lib/config/fileconf.go
@@ -2406,6 +2406,74 @@ type Apps struct {
 
 	// ResourceMatchers match cluster application resources.
 	ResourceMatchers []ResourceMatcher `yaml:"resources,omitempty"`
+
+	// Policies are file-local named policies referenced by name from
+	// apps[].policies. See the RFD on policy-based App Access.
+	Policies []AppAccessPolicy `yaml:"policies,omitempty"`
+}
+
+// AppAccessPolicy is the YAML shape of a named policy attached to one
+// or more apps. A policy may hold any combination of allow and deny
+// rules; at least one of the two must be set.
+type AppAccessPolicy struct {
+	// Name is the policy identifier, unique within its scope.
+	Name string `yaml:"name"`
+	// Allow is the list of allow rules.
+	Allow []AppAccessPolicyRule `yaml:"allow,omitempty"`
+	// Deny is the list of deny rules.
+	Deny []AppAccessPolicyRule `yaml:"deny,omitempty"`
+}
+
+// AppAccessPolicyRule is one match clause inside a policy.
+type AppAccessPolicyRule struct {
+	// Paths is the list of path patterns to match.
+	Paths []string `yaml:"paths,omitempty"`
+	// Methods is the list of HTTP methods to match. Empty or "*" means any.
+	Methods []string `yaml:"methods,omitempty"`
+	// Where is an optional Teleport predicate expression.
+	Where string `yaml:"where,omitempty"`
+	// ReasonCode is the machine-readable identifier surfaced in audit and
+	// 403 responses. Defaults to the policy name on allow rules and to
+	// teleport_explicit_deny on deny rules.
+	ReasonCode string `yaml:"reason_code,omitempty"`
+	// Reason is the human-readable string returned to the user.
+	Reason string `yaml:"reason,omitempty"`
+}
+
+// AppAccessPolicyRef is one entry in an app's policies list. It is
+// either a string (referencing a name in app_service.policies) or an
+// inline AppAccessPolicy.
+type AppAccessPolicyRef struct {
+	// Name is set when the entry is a bare string referencing a
+	// file-local policy by name.
+	Name string `yaml:"-"`
+	// Inline is set when the entry is an inline policy spec.
+	Inline *AppAccessPolicy `yaml:"-"`
+}
+
+// UnmarshalYAML implements yaml.Unmarshaler. Accepts either a bare
+// string or a map.
+func (r *AppAccessPolicyRef) UnmarshalYAML(unmarshal func(any) error) error {
+	var s string
+	if err := unmarshal(&s); err == nil {
+		r.Name = s
+		return nil
+	}
+	var inline AppAccessPolicy
+	if err := unmarshal(&inline); err != nil {
+		return err
+	}
+	r.Inline = &inline
+	return nil
+}
+
+// MarshalYAML implements yaml.Marshaler. Emits a bare string when only
+// Name is set; otherwise emits the inline policy.
+func (r AppAccessPolicyRef) MarshalYAML() (any, error) {
+	if r.Inline == nil {
+		return r.Name, nil
+	}
+	return r.Inline, nil
 }
 
 // App is the specific application that will be proxied by the application
@@ -2471,6 +2539,10 @@ type App struct {
 
 	// TLS contains the app TLS configuration.
 	TLS *AppTLS `yaml:"tls,omitempty"`
+
+	// Policies attaches the named or inline app-access policies to this
+	// app. See RFD on policy-based App Access.
+	Policies []AppAccessPolicyRef `yaml:"policies,omitempty"`
 }
 
 // CORS represents the configuration for Cross-Origin Resource Sharing (CORS)

--- a/lib/config/policy_test.go
+++ b/lib/config/policy_test.go
@@ -1,0 +1,362 @@
+/*
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package config
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport/lib/service/servicecfg"
+)
+
+const policyYAML = `
+version: v3
+teleport:
+  data_dir: /tmp/data
+  nodename: test
+  auth_server: "127.0.0.1:3025"
+auth_service:
+  enabled: false
+proxy_service:
+  enabled: false
+ssh_service:
+  enabled: false
+app_service:
+  enabled: true
+  policies:
+    - name: read-only
+      allow:
+        - paths: ["/api/public/**"]
+          methods: [GET, HEAD]
+    - name: own-subtree
+      allow:
+        - paths: ["/api/users/{username}/**"]
+          where: 'path.username == user.name'
+    - name: no-admin
+      deny:
+        - paths: ["/admin/**"]
+          reason_code: admin_blocked
+          reason: "Admin endpoints are not exposed via Teleport."
+  apps:
+    - name: app-with-named-policies
+      uri: "http://localhost:18080"
+      public_addr: "app.t.tp"
+      policies: [read-only, own-subtree, no-admin]
+    - name: app-with-inline-policy
+      uri: "http://localhost:18081"
+      public_addr: "app2.t.tp"
+      policies:
+        - name: inline-read
+          allow:
+            - paths: ["/health"]
+              methods: [GET]
+    - name: app-without-policies
+      uri: "http://localhost:18082"
+      public_addr: "app3.t.tp"
+`
+
+func TestApplyAppsConfig_Policies(t *testing.T) {
+	conf, err := ReadConfig(bytes.NewBufferString(policyYAML))
+	require.NoError(t, err)
+
+	cfg := servicecfg.MakeDefaultConfig()
+	require.NoError(t, ApplyFileConfig(conf, cfg))
+
+	require.True(t, cfg.Apps.Enabled)
+	require.Len(t, cfg.Apps.Apps, 3)
+
+	named := cfg.Apps.Apps[0]
+	require.Equal(t, "app-with-named-policies", named.Name)
+	require.Len(t, named.Policies, 3)
+	require.Equal(t, "read-only", named.Policies[0].Name)
+	require.Equal(t, "own-subtree", named.Policies[1].Name)
+	require.Equal(t, "no-admin", named.Policies[2].Name)
+	require.Len(t, named.Policies[2].Deny, 1)
+	require.Equal(t, "admin_blocked", named.Policies[2].Deny[0].ReasonCode)
+
+	inline := cfg.Apps.Apps[1]
+	require.Equal(t, "app-with-inline-policy", inline.Name)
+	require.Len(t, inline.Policies, 1)
+	require.Equal(t, "inline-read", inline.Policies[0].Name)
+
+	without := cfg.Apps.Apps[2]
+	require.Equal(t, "app-without-policies", without.Name)
+	require.Empty(t, without.Policies)
+}
+
+const badYAMLReserved = `
+version: v3
+teleport:
+  data_dir: /tmp/data
+  nodename: test
+  auth_server: "127.0.0.1:3025"
+auth_service:
+  enabled: false
+proxy_service:
+  enabled: false
+ssh_service:
+  enabled: false
+app_service:
+  enabled: true
+  policies:
+    - name: bad
+      allow:
+        - paths: ["/foo"]
+          reason_code: teleport_custom
+  apps:
+    - name: a
+      uri: "http://localhost:18080"
+      public_addr: "a.t.tp"
+      policies: [bad]
+`
+
+func TestApplyAppsConfig_RejectsReservedPrefix(t *testing.T) {
+	conf, err := ReadConfig(bytes.NewBufferString(badYAMLReserved))
+	require.NoError(t, err)
+
+	cfg := servicecfg.MakeDefaultConfig()
+	err = ApplyFileConfig(conf, cfg)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "teleport_")
+}
+
+const mixedYAML = `
+version: v3
+teleport:
+  data_dir: /tmp/data
+  nodename: test
+  auth_server: "127.0.0.1:3025"
+auth_service:
+  enabled: false
+proxy_service:
+  enabled: false
+ssh_service:
+  enabled: false
+app_service:
+  enabled: true
+  policies:
+    - name: mixed
+      allow:
+        - paths: ["/foo"]
+      deny:
+        - paths: ["/bar"]
+  apps:
+    - name: a
+      uri: "http://localhost:18080"
+      public_addr: "a.t.tp"
+      policies: [mixed]
+`
+
+func TestApplyAppsConfig_AcceptsMixedKinds(t *testing.T) {
+	conf, err := ReadConfig(bytes.NewBufferString(mixedYAML))
+	require.NoError(t, err)
+
+	cfg := servicecfg.MakeDefaultConfig()
+	require.NoError(t, ApplyFileConfig(conf, cfg))
+	require.Len(t, cfg.Apps.Apps, 1)
+	pols := cfg.Apps.Apps[0].Policies
+	require.Len(t, pols, 1)
+	require.Len(t, pols[0].Allow, 1)
+	require.Len(t, pols[0].Deny, 1)
+}
+
+const badYAMLUnknownRef = `
+version: v3
+teleport:
+  data_dir: /tmp/data
+  nodename: test
+  auth_server: "127.0.0.1:3025"
+auth_service:
+  enabled: false
+proxy_service:
+  enabled: false
+ssh_service:
+  enabled: false
+app_service:
+  enabled: true
+  apps:
+    - name: a
+      uri: "http://localhost:18080"
+      public_addr: "a.t.tp"
+      policies: [missing]
+`
+
+func TestApplyAppsConfig_RejectsUnknownPolicyRef(t *testing.T) {
+	conf, err := ReadConfig(bytes.NewBufferString(badYAMLUnknownRef))
+	require.NoError(t, err)
+
+	cfg := servicecfg.MakeDefaultConfig()
+	err = ApplyFileConfig(conf, cfg)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "unknown policy")
+}
+
+const tcpAppYAML = `
+version: v3
+teleport:
+  data_dir: /tmp/data
+  nodename: test
+  auth_server: "127.0.0.1:3025"
+auth_service:
+  enabled: false
+proxy_service:
+  enabled: false
+ssh_service:
+  enabled: false
+app_service:
+  enabled: true
+  policies:
+    - name: p
+      allow:
+        - paths: ["/foo"]
+  apps:
+    - name: a
+      uri: "tcp://localhost"
+      public_addr: "a.t.tp"
+      tcp_ports:
+        - port: 5432
+      policies: [p]
+`
+
+func TestApplyAppsConfig_RejectsPoliciesOnTCPApp(t *testing.T) {
+	conf, err := ReadConfig(bytes.NewBufferString(tcpAppYAML))
+	require.NoError(t, err)
+
+	cfg := servicecfg.MakeDefaultConfig()
+	err = ApplyFileConfig(conf, cfg)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "TCP apps")
+}
+
+const mcpAppYAML = `
+version: v3
+teleport:
+  data_dir: /tmp/data
+  nodename: test
+  auth_server: "127.0.0.1:3025"
+auth_service:
+  enabled: false
+proxy_service:
+  enabled: false
+ssh_service:
+  enabled: false
+app_service:
+  enabled: true
+  policies:
+    - name: p
+      allow:
+        - paths: ["/foo"]
+  apps:
+    - name: a
+      uri: "mcp+stdio://"
+      public_addr: "a.t.tp"
+      mcp:
+        command: "/usr/bin/true"
+        run_as_host_user: nobody
+      policies: [p]
+`
+
+func TestApplyAppsConfig_RejectsPoliciesOnMCPApp(t *testing.T) {
+	conf, err := ReadConfig(bytes.NewBufferString(mcpAppYAML))
+	require.NoError(t, err)
+
+	cfg := servicecfg.MakeDefaultConfig()
+	err = ApplyFileConfig(conf, cfg)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "MCP apps")
+}
+
+const llmAppYAML = `
+version: v3
+teleport:
+  data_dir: /tmp/data
+  nodename: test
+  auth_server: "127.0.0.1:3025"
+auth_service:
+  enabled: false
+proxy_service:
+  enabled: false
+ssh_service:
+  enabled: false
+app_service:
+  enabled: true
+  policies:
+    - name: p
+      allow:
+        - paths: ["/foo"]
+  apps:
+    - name: a
+      uri: "https://api.openai.com"
+      public_addr: "a.t.tp"
+      inference:
+        provider: openai
+        format: openai
+      policies: [p]
+`
+
+func TestApplyAppsConfig_RejectsPoliciesOnLLMApp(t *testing.T) {
+	conf, err := ReadConfig(bytes.NewBufferString(llmAppYAML))
+	require.NoError(t, err)
+
+	cfg := servicecfg.MakeDefaultConfig()
+	err = ApplyFileConfig(conf, cfg)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "LLM apps")
+}
+
+const noPublicAddrYAML = `
+version: v3
+teleport:
+  data_dir: /tmp/data
+  nodename: test
+  auth_server: "127.0.0.1:3025"
+auth_service:
+  enabled: false
+proxy_service:
+  enabled: false
+ssh_service:
+  enabled: false
+app_service:
+  enabled: true
+  policies:
+    - name: p
+      allow:
+        - paths: ["/foo"]
+  apps:
+    - name: a
+      uri: "http://localhost:8080"
+      policies: [p]
+`
+
+// TestApplyAppsConfig_RejectsPoliciesWithoutPublicAddr locks in the
+// fix for the bot-flagged bypass: public_addr is the lookup key the
+// connections handler uses at request time. If it is empty here,
+// resolution happens later on the agent side and the policy map
+// keyed on `app.PublicAddr` silently misses, skipping the gate.
+func TestApplyAppsConfig_RejectsPoliciesWithoutPublicAddr(t *testing.T) {
+	conf, err := ReadConfig(bytes.NewBufferString(noPublicAddrYAML))
+	require.NoError(t, err)
+
+	cfg := servicecfg.MakeDefaultConfig()
+	err = ApplyFileConfig(conf, cfg)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "public_addr")
+}

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -172,6 +172,7 @@ import (
 	alpnproxyauth "github.com/gravitational/teleport/lib/srv/alpnproxy/auth"
 	alpncommon "github.com/gravitational/teleport/lib/srv/alpnproxy/common"
 	"github.com/gravitational/teleport/lib/srv/app"
+	"github.com/gravitational/teleport/lib/srv/app/policy"
 	"github.com/gravitational/teleport/lib/srv/db"
 	"github.com/gravitational/teleport/lib/srv/desktop"
 	"github.com/gravitational/teleport/lib/srv/ingress"
@@ -6898,6 +6899,17 @@ func (process *TeleportProcess) initApps() {
 			return trace.Wrap(err)
 		}
 
+		// Key by public_addr (not name) so a dynamic app or
+		// trusted-cluster app with a colliding name cannot inherit or
+		// bypass another app's policies; the connections handler
+		// looks up by app.GetPublicAddr().
+		policiesByApp := map[string][]policy.Policy{}
+		for _, app := range process.Config.Apps.Apps {
+			if len(app.Policies) > 0 {
+				policiesByApp[app.PublicAddr] = app.Policies
+			}
+		}
+
 		connectionsHandler, err := app.NewConnectionsHandler(process.ExitContext(), &app.ConnectionsHandlerConfig{
 			InsecureMode:      process.Config.InsecureMode,
 			Clock:             process.Config.Clock,
@@ -6914,6 +6926,7 @@ func (process *TeleportProcess) initApps() {
 			Logger:            logger,
 			LimiterConfig:     process.Config.Apps.Limiter,
 			MCPDemoServer:     process.Config.Apps.MCPDemoServer,
+			Policies:          policiesByApp,
 		})
 		if err != nil {
 			return trace.Wrap(err)

--- a/lib/service/servicecfg/app.go
+++ b/lib/service/servicecfg/app.go
@@ -34,6 +34,7 @@ import (
 	"github.com/gravitational/teleport/lib/limiter"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/srv/app/common"
+	"github.com/gravitational/teleport/lib/srv/app/policy"
 )
 
 // AppsConfig configures application proxy service.
@@ -124,6 +125,10 @@ type App struct {
 
 	// TLS contains the app TLS configuration.
 	TLS *types.AppTLS
+
+	// Policies are the compiled policy-based App Access rules attached
+	// to this app. Empty means no per-request filtering.
+	Policies []policy.Policy
 }
 
 // CORS represents the configuration for Cross-Origin Resource Sharing (CORS)

--- a/lib/srv/app/connections_handler.go
+++ b/lib/srv/app/connections_handler.go
@@ -25,12 +25,14 @@ import (
 	"context"
 	"crypto/tls"
 	"crypto/x509"
+	"encoding/json"
 	"errors"
 	"log"
 	"log/slog"
 	"net"
 	"net/http"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -40,13 +42,14 @@ import (
 	"github.com/gravitational/teleport"
 	apidefaults "github.com/gravitational/teleport/api/defaults"
 	"github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/teleport/api/types/events"
+	apievents "github.com/gravitational/teleport/api/types/events"
 	apiutils "github.com/gravitational/teleport/api/utils"
 	"github.com/gravitational/teleport/api/utils/clientutils"
 	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/authz"
 	"github.com/gravitational/teleport/lib/cloud/awsconfig"
 	"github.com/gravitational/teleport/lib/defaults"
+	"github.com/gravitational/teleport/lib/events"
 	"github.com/gravitational/teleport/lib/httplib"
 	"github.com/gravitational/teleport/lib/limiter"
 	"github.com/gravitational/teleport/lib/services"
@@ -55,6 +58,7 @@ import (
 	appazure "github.com/gravitational/teleport/lib/srv/app/azure"
 	"github.com/gravitational/teleport/lib/srv/app/common"
 	appgcp "github.com/gravitational/teleport/lib/srv/app/gcp"
+	"github.com/gravitational/teleport/lib/srv/app/policy"
 	"github.com/gravitational/teleport/lib/srv/mcp"
 	"github.com/gravitational/teleport/lib/tlsca"
 	"github.com/gravitational/teleport/lib/utils"
@@ -76,7 +80,7 @@ type ConnectionsHandlerConfig struct {
 	DataDir string
 
 	// Emitter is an event emitter.
-	Emitter events.Emitter
+	Emitter apievents.Emitter
 
 	// Authorizer is used to authorize requests.
 	Authorizer authz.Authorizer
@@ -124,6 +128,10 @@ type ConnectionsHandlerConfig struct {
 
 	// InsecureMode defines whether insecure connections are allowed.
 	InsecureMode bool
+
+	// Policies maps app name to the compiled policy set for that app.
+	// Apps with no entry skip the policy engine entirely.
+	Policies map[string][]policy.Policy
 }
 
 // CheckAndSetDefaults validates the config values and sets defaults.
@@ -401,9 +409,109 @@ func (c *ConnectionsHandler) serveSession(w http.ResponseWriter, r *http.Request
 		Audit:    session.audit,
 	}
 
-	// Forward request to the target application.
 	session.handler.ServeHTTP(w, common.WithSessionContext(r, sessionCtx))
 	return nil
+}
+
+// applyPolicies runs the attached policies for app against the request.
+// Returns true if the request was answered (deny served, no further
+// forwarding). Returns false if the engine allowed the request or no
+// policies are attached.
+func (c *ConnectionsHandler) applyPolicies(w http.ResponseWriter, r *http.Request, identity *tlsca.Identity, app types.Application) bool {
+	// Key by public_addr because that is what the agent routes by:
+	// keying by name alone would let a dynamic app or trusted-cluster
+	// app inherit (or bypass) a static app's policies if names collide.
+	policies := c.cfg.Policies[app.GetPublicAddr()]
+	if len(policies) == 0 {
+		return false
+	}
+
+	normPath, normErr := policy.Normalize(r.URL.RequestURI())
+	req := policy.Request{
+		Method:    strings.ToUpper(r.Method),
+		Path:      normPath,
+		UserName:  identity.Username,
+		UserRoles: identity.Groups,
+	}
+	if normErr != nil {
+		code, _ := policy.IsNormalizeError(normErr)
+		req.NormalizeCode = code
+		req.NormalizeErr = normErr.Error()
+	}
+
+	decision := policy.Evaluate(policies, req)
+	c.logPolicyDecision(r.Context(), identity, app, req, decision)
+	if decision.Allow {
+		return false
+	}
+	c.emitPolicyDenyAuditEvent(r.Context(), identity, app, r, decision)
+
+	w.Header().Set("Teleport-Decision-Reason", decision.ReasonCode)
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusForbidden)
+	reason := decision.Reason
+	if reason == "" {
+		reason = decision.ReasonCode
+	}
+	body, err := json.Marshal(struct {
+		ReasonCode string `json:"reason_code"`
+		Reason     string `json:"reason"`
+	}{decision.ReasonCode, reason})
+	if err != nil {
+		// Marshaling two strings cannot fail in practice; fall back to
+		// the bare reason code so the client still sees something
+		// machine-readable.
+		body = []byte(decision.ReasonCode)
+	}
+	_, _ = w.Write(body)
+	return true
+}
+
+func (c *ConnectionsHandler) logPolicyDecision(ctx context.Context, identity *tlsca.Identity, app types.Application, req policy.Request, d policy.Decision) {
+	verdict := "allow"
+	if !d.Allow {
+		verdict = "deny"
+	}
+	c.log.LogAttrs(ctx, slog.LevelDebug, "app.session.policy",
+		slog.String("user", identity.Username),
+		slog.String("app", app.GetName()),
+		slog.String("session_id", identity.RouteToApp.SessionID),
+		slog.String("method", req.Method),
+		slog.String("path", req.Path),
+		slog.String("decision", verdict),
+		slog.String("reason_code", d.ReasonCode),
+		slog.String("reason", d.Reason),
+		slog.String("policy_ref", d.PolicyRef),
+		slog.Any("bound_vars", d.BoundVars),
+		slog.Any("policies_evaluated", d.EvalSummary.PoliciesEvaluated),
+	)
+}
+
+// emitPolicyDenyAuditEvent emits a 403 AppSessionRequest event for a
+// policy-denied request. audit.EmitEvent routes this event type only
+// to session recording for the forwarded path; deny never creates a
+// session chunk, so we go through the cluster audit emitter directly
+// to ensure denies land in tctl events and any SIEM ingesting the
+// audit log.
+func (c *ConnectionsHandler) emitPolicyDenyAuditEvent(ctx context.Context, identity *tlsca.Identity, app types.Application, r *http.Request, d policy.Decision) {
+	event := &apievents.AppSessionRequest{
+		Metadata: apievents.Metadata{
+			Type: events.AppSessionRequestEvent,
+			Code: events.AppSessionRequestCode,
+		},
+		AppMetadata: apievents.AppMetadata{
+			AppURI:        app.GetURI(),
+			AppPublicAddr: app.GetPublicAddr(),
+			AppName:       app.GetName(),
+		},
+		Method:     r.Method,
+		Path:       r.URL.Path,
+		RawQuery:   r.URL.RawQuery,
+		StatusCode: http.StatusForbidden,
+	}
+	if err := c.cfg.Emitter.EmitAuditEvent(ctx, event); err != nil {
+		c.log.WarnContext(ctx, "Failed to emit policy deny audit event.", "error", err)
+	}
 }
 
 // sessionStartTime fetches the session start time based on the certificate
@@ -453,6 +561,11 @@ func (c *ConnectionsHandler) serveHTTP(w http.ResponseWriter, r *http.Request) e
 	}
 
 	identity := authCtx.Identity.GetIdentity()
+	// Apply policy-based access ahead of dispatch so every HTTP path,
+	// including the AWS console redirect, runs through the same gate.
+	if c.applyPolicies(w, r, &identity, app) {
+		return nil
+	}
 	switch {
 	case app.IsAWSConsole():
 		// Requests from AWS applications are signed by AWS Signature Version 4

--- a/lib/srv/app/connections_handler_policy_test.go
+++ b/lib/srv/app/connections_handler_policy_test.go
@@ -1,0 +1,239 @@
+/*
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package app
+
+import (
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport/api/types"
+	apievents "github.com/gravitational/teleport/api/types/events"
+	"github.com/gravitational/teleport/lib/events/eventstest"
+	"github.com/gravitational/teleport/lib/srv/app/policy"
+	"github.com/gravitational/teleport/lib/tlsca"
+)
+
+func TestApplyPolicies(t *testing.T) {
+	gitlab := mustCompilePolicies(t, []policy.Spec{
+		{
+			Name: "no-admin",
+			Deny: []policy.RuleSpec{{
+				Paths:      []string{"/admin/**"},
+				ReasonCode: "admin_blocked",
+				Reason:     "Admin endpoints are platform-team only.",
+			}},
+		},
+		{
+			Name: "read-only",
+			Allow: []policy.RuleSpec{{
+				Paths:   []string{"/api/**"},
+				Methods: []string{"GET", "HEAD"},
+			}},
+		},
+	})
+
+	tests := []struct {
+		name        string
+		policiesFor string // app name in c.cfg.Policies
+		app         string // app name on the request
+		method      string
+		path        string
+		wantAnswer  bool   // applyPolicies return value
+		wantStatus  int    // response status when wantAnswer
+		wantReason  string // Teleport-Decision-Reason header
+		wantAudit   bool   // expect an AppSessionRequest event emitted
+	}{
+		{
+			name:        "no policies short-circuits",
+			policiesFor: "",
+			app:         "unrelated",
+			method:      "GET",
+			path:        "/anything",
+			wantAnswer:  false,
+		},
+		{
+			name:        "deny via path rule",
+			policiesFor: "gitlab",
+			app:         "gitlab",
+			method:      "POST",
+			path:        "/admin/users",
+			wantAnswer:  true,
+			wantStatus:  http.StatusForbidden,
+			wantReason:  "admin_blocked",
+			wantAudit:   true,
+		},
+		{
+			name:        "allow via path rule",
+			policiesFor: "gitlab",
+			app:         "gitlab",
+			method:      "GET",
+			path:        "/api/v4/projects/1",
+			wantAnswer:  false,
+		},
+		{
+			name:        "no allow matched",
+			policiesFor: "gitlab",
+			app:         "gitlab",
+			method:      "POST",
+			path:        "/api/v4/projects/1",
+			wantAnswer:  true,
+			wantStatus:  http.StatusForbidden,
+			wantReason:  policy.ReasonNoMatchingAllow,
+			wantAudit:   true,
+		},
+		{
+			name:        "leading double slash bypass blocked",
+			policiesFor: "gitlab",
+			app:         "gitlab",
+			method:      "GET",
+			path:        "//admin/users",
+			wantAnswer:  true,
+			wantStatus:  http.StatusForbidden,
+			wantReason:  policy.ReasonPathDecodeFailed,
+			wantAudit:   true,
+		},
+		{
+			name:        "method is upper-cased",
+			policiesFor: "gitlab",
+			app:         "gitlab",
+			method:      "get",
+			path:        "/api/v4/projects/1",
+			wantAnswer:  false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			emitter := &eventstest.MockRecorderEmitter{}
+			c := &ConnectionsHandler{
+				cfg: &ConnectionsHandlerConfig{
+					Emitter: emitter,
+				},
+				log: slog.Default(),
+			}
+			app := newTestApp(t, tc.app)
+			if tc.policiesFor != "" {
+				// policiesFor stores the test-case "key" we want to use;
+				// the handler looks up by public_addr, so build the map
+				// using the test app's public_addr to keep the table
+				// driven by short app names while exercising the real
+				// keying contract.
+				c.cfg.Policies = map[string][]policy.Policy{app.GetPublicAddr(): gitlab}
+			}
+			req := httptest.NewRequest(tc.method, tc.path, nil)
+			rec := httptest.NewRecorder()
+			identity := &tlsca.Identity{Username: "alice"}
+
+			got := c.applyPolicies(rec, req, identity, app)
+			require.Equal(t, tc.wantAnswer, got)
+			if tc.wantAnswer {
+				require.Equal(t, tc.wantStatus, rec.Code)
+				require.Equal(t, tc.wantReason, rec.Header().Get("Teleport-Decision-Reason"))
+				require.Equal(t, "application/json", rec.Header().Get("Content-Type"))
+				var body struct {
+					ReasonCode string `json:"reason_code"`
+					Reason     string `json:"reason"`
+				}
+				require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+				require.Equal(t, tc.wantReason, body.ReasonCode)
+				require.NotEmpty(t, body.Reason)
+			}
+			if tc.wantAudit {
+				require.Len(t, emitter.Events(), 1)
+				evt, ok := emitter.Events()[0].(*apievents.AppSessionRequest)
+				require.True(t, ok, "expected AppSessionRequest, got %T", emitter.Events()[0])
+				require.Equal(t, uint32(http.StatusForbidden), evt.StatusCode)
+				require.Equal(t, tc.app, evt.AppName)
+			} else {
+				require.Empty(t, emitter.Events())
+			}
+		})
+	}
+}
+
+func mustCompilePolicies(t *testing.T, specs []policy.Spec) []policy.Policy {
+	t.Helper()
+	p, err := policy.CompileAll(specs)
+	require.NoError(t, err)
+	return p
+}
+
+func newTestApp(t *testing.T, name string) types.Application {
+	t.Helper()
+	app, err := types.NewAppV3(
+		types.Metadata{Name: name},
+		types.AppSpecV3{URI: "http://localhost", PublicAddr: name + ".t.tp"},
+	)
+	require.NoError(t, err)
+	return app
+}
+
+// TestApplyPolicies_KeyByPublicAddrPreventsNameCollision locks in the
+// fix for the bot-flagged name-collision bug: two apps that share a
+// name but differ in public_addr must not share policies.
+func TestApplyPolicies_KeyByPublicAddrPreventsNameCollision(t *testing.T) {
+	policies, err := policy.CompileAll([]policy.Spec{{
+		Name: "block-admin",
+		Deny: []policy.RuleSpec{{
+			Paths:      []string{"/admin/**"},
+			ReasonCode: "admin_blocked",
+		}},
+	}})
+	require.NoError(t, err)
+
+	gated, err := types.NewAppV3(
+		types.Metadata{Name: "shared"},
+		types.AppSpecV3{URI: "http://a", PublicAddr: "gated.t.tp"},
+	)
+	require.NoError(t, err)
+
+	ungated, err := types.NewAppV3(
+		types.Metadata{Name: "shared"},
+		types.AppSpecV3{URI: "http://b", PublicAddr: "ungated.t.tp"},
+	)
+	require.NoError(t, err)
+
+	c := &ConnectionsHandler{
+		cfg: &ConnectionsHandlerConfig{
+			Emitter: &eventstest.MockRecorderEmitter{},
+			Policies: map[string][]policy.Policy{
+				"gated.t.tp": policies,
+			},
+		},
+		log: slog.Default(),
+	}
+	identity := &tlsca.Identity{Username: "alice"}
+
+	// gated app must enforce the policy
+	rec := httptest.NewRecorder()
+	got := c.applyPolicies(rec, httptest.NewRequest("GET", "/admin/x", nil), identity, gated)
+	require.True(t, got)
+	require.Equal(t, http.StatusForbidden, rec.Code)
+
+	// ungated app shares the name but the lookup keyed by public_addr
+	// finds no policies for it, so the gate passes through.
+	rec = httptest.NewRecorder()
+	got = c.applyPolicies(rec, httptest.NewRequest("GET", "/admin/x", nil), identity, ungated)
+	require.False(t, got)
+}

--- a/lib/srv/app/policy/engine.go
+++ b/lib/srv/app/policy/engine.go
@@ -1,0 +1,166 @@
+/*
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package policy
+
+import (
+	"fmt"
+)
+
+// Decision is the result of evaluating a request against a policy set.
+type Decision struct {
+	Allow      bool
+	ReasonCode string
+	Reason     string
+	PolicyRef  string
+	BoundVars  map[string]string
+
+	EvalSummary EvalSummary
+}
+
+// EvalSummary captures which policies were considered, for audit.
+type EvalSummary struct {
+	PoliciesEvaluated []string
+}
+
+// Request is the per-request input to Evaluate.
+type Request struct {
+	Method        string
+	Path          string
+	NormalizeCode string // teleport_* code if normalization failed
+	NormalizeErr  string // message if normalization failed
+	UserName      string
+	UserRoles     []string
+}
+
+// Evaluate applies the deny-first / allow-second decision model. If
+// policies is empty the request is allowed (backwards-compatibility
+// contract). A normalization failure short-circuits to a synthetic deny.
+func Evaluate(policies []Policy, req Request) Decision {
+	summary := EvalSummary{}
+	for _, p := range policies {
+		summary.PoliciesEvaluated = append(summary.PoliciesEvaluated, p.Name)
+	}
+
+	if req.NormalizeCode != "" {
+		return Decision{
+			ReasonCode:  req.NormalizeCode,
+			Reason:      req.NormalizeErr,
+			EvalSummary: summary,
+		}
+	}
+
+	if len(policies) == 0 {
+		return Decision{Allow: true, EvalSummary: summary}
+	}
+
+	for _, p := range policies {
+		for _, rule := range p.Deny {
+			match, caps, err := matchRule(rule, req)
+			if err != nil {
+				return Decision{
+					ReasonCode:  ReasonPredicateError,
+					Reason:      err.Error(),
+					PolicyRef:   policyRef(p.Name, rule.ReasonCode),
+					BoundVars:   caps,
+					EvalSummary: summary,
+				}
+			}
+			if !match {
+				continue
+			}
+			return Decision{
+				ReasonCode:  rule.ReasonCode,
+				Reason:      rule.Reason,
+				PolicyRef:   policyRef(p.Name, rule.ReasonCode),
+				BoundVars:   caps,
+				EvalSummary: summary,
+			}
+		}
+	}
+
+	hasAllowRules := false
+	for _, p := range policies {
+		if len(p.Allow) > 0 {
+			hasAllowRules = true
+			break
+		}
+	}
+	if !hasAllowRules {
+		return Decision{Allow: true, EvalSummary: summary}
+	}
+
+	for _, p := range policies {
+		for _, rule := range p.Allow {
+			// Predicate errors on allow rules are treated as no-match.
+			match, caps, err := matchRule(rule, req)
+			if err != nil || !match {
+				continue
+			}
+			return Decision{
+				Allow:       true,
+				ReasonCode:  rule.ReasonCode,
+				Reason:      rule.Reason,
+				PolicyRef:   policyRef(p.Name, rule.ReasonCode),
+				BoundVars:   caps,
+				EvalSummary: summary,
+			}
+		}
+	}
+
+	return Decision{
+		ReasonCode:  ReasonNoMatchingAllow,
+		Reason:      "no allow rule matched the request",
+		EvalSummary: summary,
+	}
+}
+
+// matchRule reports whether rule matches the request and returns any
+// captured path variables. A non-nil error means the where: clause
+// evaluation failed.
+func matchRule(rule Rule, req Request) (bool, map[string]string, error) {
+	if !rule.MatchesMethod(req.Method) {
+		return false, nil, nil
+	}
+	caps, ok := rule.MatchesPath(req.Path)
+	if !ok {
+		return false, nil, nil
+	}
+	if rule.Where == nil {
+		return true, caps, nil
+	}
+	env := Env{
+		UserName:      req.UserName,
+		UserRoles:     req.UserRoles,
+		Path:          caps,
+		RequestMethod: req.Method,
+		RequestPath:   req.Path,
+	}
+	v, err := rule.Where.Evaluate(env)
+	if err != nil {
+		return false, caps, err
+	}
+	return v, caps, nil
+}
+
+func policyRef(policyName, reasonCode string) string {
+	if reasonCode == "" {
+		return policyName
+	}
+	return fmt.Sprintf("%s/%s", policyName, reasonCode)
+}

--- a/lib/srv/app/policy/engine_test.go
+++ b/lib/srv/app/policy/engine_test.go
@@ -1,0 +1,272 @@
+/*
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package policy
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func allowPolicy(name, path string, methods ...string) Policy {
+	rule := Rule{Paths: []*PathMatcher{MustCompilePath(path)}, Methods: methods, ReasonCode: name, Reason: name}
+	return Policy{Name: name, Allow: []Rule{rule}}
+}
+
+func denyPolicy(name, path string, methods ...string) Policy {
+	rule := Rule{Paths: []*PathMatcher{MustCompilePath(path)}, Methods: methods, ReasonCode: name, Reason: name}
+	return Policy{Name: name, Deny: []Rule{rule}}
+}
+
+func defaultDenyPolicy(name, path string) Policy {
+	p, err := Compile(Spec{
+		Name: name,
+		Deny: []RuleSpec{{Paths: []string{path}}},
+	})
+	if err != nil {
+		panic(err)
+	}
+	return p
+}
+
+func TestEvaluate_TruthTable(t *testing.T) {
+	allow := allowPolicy("allow-foo", "/foo")
+	deny := denyPolicy("deny-foo", "/foo")
+	tests := []struct {
+		name       string
+		policies   []Policy
+		path       string
+		wantAllow  bool
+		wantReason string
+	}{
+		{name: "none", policies: nil, path: "/foo", wantAllow: true},
+		{name: "only deny, match", policies: []Policy{deny}, path: "/foo", wantAllow: false, wantReason: "deny-foo"},
+		{name: "only deny, no match", policies: []Policy{deny}, path: "/bar", wantAllow: true},
+		{name: "only allow, match", policies: []Policy{allow}, path: "/foo", wantAllow: true, wantReason: "allow-foo"},
+		{name: "only allow, no match", policies: []Policy{allow}, path: "/bar", wantAllow: false, wantReason: ReasonNoMatchingAllow},
+		{name: "deny first, both match", policies: []Policy{deny, allow}, path: "/foo", wantAllow: false, wantReason: "deny-foo"},
+		// Deny wins even when placed after a matching allow.
+		{name: "allow first, both match", policies: []Policy{allow, deny}, path: "/foo", wantAllow: false, wantReason: "deny-foo"},
+		{
+			name: "deny no match, allow match",
+			policies: []Policy{
+				denyPolicy("deny-bar", "/bar"),
+				allow,
+			},
+			path: "/foo", wantAllow: true, wantReason: "allow-foo",
+		},
+		{
+			name: "deny no match, allow no match",
+			policies: []Policy{
+				denyPolicy("deny-bar", "/bar"),
+				allow,
+			},
+			path: "/baz", wantAllow: false, wantReason: ReasonNoMatchingAllow,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			d := Evaluate(tc.policies, Request{Method: "GET", Path: tc.path})
+			require.Equal(t, tc.wantAllow, d.Allow, "decision: %+v", d)
+			if tc.wantReason != "" {
+				require.Equal(t, tc.wantReason, d.ReasonCode)
+			}
+		})
+	}
+}
+
+func TestEvaluate_MixedPolicyAllowAndDeny(t *testing.T) {
+	p, err := Compile(Spec{
+		Name: "mixed",
+		Allow: []RuleSpec{{
+			Paths: []string{"/api/**"},
+		}},
+		Deny: []RuleSpec{{
+			Paths: []string{"/api/admin/**"},
+		}},
+	})
+	require.NoError(t, err)
+
+	t.Run("allow path matches", func(t *testing.T) {
+		d := Evaluate([]Policy{p}, Request{Method: "GET", Path: "/api/users"})
+		require.True(t, d.Allow)
+	})
+	t.Run("deny wins over allow", func(t *testing.T) {
+		d := Evaluate([]Policy{p}, Request{Method: "GET", Path: "/api/admin/users"})
+		require.False(t, d.Allow)
+		require.Equal(t, ReasonExplicitDeny, d.ReasonCode)
+	})
+}
+
+func TestEvaluate_DefaultDenyReason(t *testing.T) {
+	deny := defaultDenyPolicy("no-admin", "/admin")
+	d := Evaluate([]Policy{deny}, Request{Method: "GET", Path: "/admin"})
+	require.False(t, d.Allow)
+	require.Equal(t, ReasonExplicitDeny, d.ReasonCode)
+}
+
+func TestEvaluate_PoliciesEvaluatedOrder(t *testing.T) {
+	policies := []Policy{
+		denyPolicy("z-deny", "/never"),
+		allowPolicy("a-allow", "/yes"),
+	}
+	d := Evaluate(policies, Request{Method: "GET", Path: "/yes"})
+	require.Equal(t, []string{"z-deny", "a-allow"}, d.EvalSummary.PoliciesEvaluated)
+}
+
+func TestEvaluate_WorkedExample(t *testing.T) {
+	gitlabNoAdmin := Policy{
+		Name: "gitlab-no-project-admin",
+		Deny: []Rule{{
+			Paths: []*PathMatcher{
+				MustCompilePath("/api/v4/projects/*/variables/**"),
+				MustCompilePath("/api/v4/projects/*/hooks/**"),
+			},
+			ReasonCode: "project_admin_blocked",
+			Reason:     "Project admin endpoints are platform-team only.",
+		}},
+	}
+	gitlabRepoRead := Policy{
+		Name: "gitlab-repo-read",
+		Allow: []Rule{{
+			Paths:      []*PathMatcher{MustCompilePath("/api/v4/projects/*/repository/**")},
+			Methods:    []string{"GET", "HEAD"},
+			ReasonCode: "gitlab-repo-read",
+			Reason:     "gitlab-repo-read",
+		}},
+	}
+	gitlabMR := Policy{
+		Name: "gitlab-mr-collaborate",
+		Allow: []Rule{{
+			Paths:      []*PathMatcher{MustCompilePath("/api/v4/projects/*/merge_requests/**")},
+			Methods:    []string{"GET", "HEAD", "POST", "PUT"},
+			ReasonCode: "gitlab-mr-collaborate",
+			Reason:     "gitlab-mr-collaborate",
+		}},
+	}
+	policies := []Policy{gitlabNoAdmin, gitlabRepoRead, gitlabMR}
+
+	t.Run("encoded slash deny", func(t *testing.T) {
+		_, err := Normalize("/api/v4/projects/org%2Fapi/repository/files/README.md")
+		require.Error(t, err)
+		code, ok := IsNormalizeError(err)
+		require.True(t, ok)
+		require.Equal(t, ReasonEncodedSlashInSegment, code)
+	})
+	t.Run("allow via repo-read", func(t *testing.T) {
+		path, err := Normalize("/api/v4/projects/123/repository/files/README.md")
+		require.NoError(t, err)
+		d := Evaluate(policies, Request{Method: "GET", Path: path})
+		require.True(t, d.Allow)
+		require.Equal(t, "gitlab-repo-read", d.ReasonCode)
+	})
+	t.Run("deny via project-admin", func(t *testing.T) {
+		path, err := Normalize("/api/v4/projects/123/hooks/4")
+		require.NoError(t, err)
+		d := Evaluate(policies, Request{Method: "DELETE", Path: path})
+		require.False(t, d.Allow)
+		require.Equal(t, "project_admin_blocked", d.ReasonCode)
+	})
+	t.Run("deny via no allow match", func(t *testing.T) {
+		path, err := Normalize("/api/v4/projects/789/repository/files/README.md")
+		require.NoError(t, err)
+		d := Evaluate(policies, Request{Method: "POST", Path: path})
+		require.False(t, d.Allow)
+		require.Equal(t, ReasonNoMatchingAllow, d.ReasonCode)
+	})
+}
+
+func TestEvaluate_Where(t *testing.T) {
+	pred, err := CompilePredicate(`path.username == user.name`)
+	require.NoError(t, err)
+	p := Policy{
+		Name: "own-subtree",
+		Allow: []Rule{{
+			Paths:      []*PathMatcher{MustCompilePath("/api/users/{username}/**")},
+			Where:      pred,
+			ReasonCode: "own-subtree",
+			Reason:     "own-subtree",
+		}},
+	}
+	d := Evaluate([]Policy{p}, Request{
+		Method:   "GET",
+		Path:     "/api/users/alice/profile",
+		UserName: "alice",
+	})
+	require.True(t, d.Allow)
+	require.Equal(t, "alice", d.BoundVars["username"])
+
+	// Path captures bob but user is alice; the allow rule must not match.
+	d = Evaluate([]Policy{p}, Request{
+		Method:   "POST",
+		Path:     "/api/users/bob/data",
+		UserName: "alice",
+	})
+	require.False(t, d.Allow)
+	require.Equal(t, ReasonNoMatchingAllow, d.ReasonCode)
+}
+
+func TestEvaluate_DenyPredicateError(t *testing.T) {
+	deny := Policy{
+		Name: "errs",
+		Deny: []Rule{{
+			Paths: []*PathMatcher{MustCompilePath("/x/**")},
+			Where: errPredicate{},
+		}},
+	}
+	d := Evaluate([]Policy{deny}, Request{Method: "GET", Path: "/x/1"})
+	require.False(t, d.Allow)
+	require.Equal(t, ReasonPredicateError, d.ReasonCode)
+}
+
+func TestEvaluate_AllowPredicateError(t *testing.T) {
+	allow := Policy{
+		Name: "errs",
+		Allow: []Rule{{
+			Paths: []*PathMatcher{MustCompilePath("/x/**")},
+			Where: errPredicate{},
+		}},
+	}
+	d := Evaluate([]Policy{allow}, Request{Method: "GET", Path: "/x/1"})
+	require.False(t, d.Allow)
+	require.Equal(t, ReasonNoMatchingAllow, d.ReasonCode)
+}
+
+func TestEvaluate_NormalizeFailureSurfaces(t *testing.T) {
+	d := Evaluate(nil, Request{
+		Method:        "GET",
+		Path:          "",
+		NormalizeCode: ReasonEncodedSlashInSegment,
+		NormalizeErr:  "encoded path separator decoded into a new segment",
+	})
+	require.False(t, d.Allow)
+	require.Equal(t, ReasonEncodedSlashInSegment, d.ReasonCode)
+}
+
+type errPredicate struct{}
+
+func (errPredicate) Evaluate(Env) (bool, error) {
+	return false, errBoom
+}
+
+var errBoom = stringErr("boom")
+
+type stringErr string
+
+func (s stringErr) Error() string { return string(s) }

--- a/lib/srv/app/policy/loader.go
+++ b/lib/srv/app/policy/loader.go
@@ -1,0 +1,150 @@
+/*
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package policy
+
+import (
+	"strings"
+
+	"github.com/gravitational/trace"
+)
+
+// Spec is the raw, pre-compile shape of a policy, as parsed from a YAML
+// config or constructed by callers. Strings are unparsed.
+type Spec struct {
+	Name  string
+	Allow []RuleSpec
+	Deny  []RuleSpec
+}
+
+// RuleSpec is the raw, pre-compile shape of a rule.
+type RuleSpec struct {
+	Paths      []string
+	Methods    []string
+	Where      string
+	ReasonCode string
+	Reason     string
+}
+
+// Ref is one entry in an app's policies list: either a name reference or
+// an inline policy spec.
+type Ref struct {
+	Name   string
+	Inline *Spec
+}
+
+// Compile produces a Policy from a Spec, compiling path patterns and the
+// where: expression. Invariants are enforced via ValidatePolicy.
+func Compile(s Spec) (Policy, error) {
+	p := Policy{Name: s.Name}
+	for i, r := range s.Allow {
+		compiled, err := compileRule(r)
+		if err != nil {
+			return Policy{}, trace.Wrap(err, "policy %q allow rule %d", s.Name, i)
+		}
+		p.Allow = append(p.Allow, compiled)
+	}
+	for i, r := range s.Deny {
+		compiled, err := compileRule(r)
+		if err != nil {
+			return Policy{}, trace.Wrap(err, "policy %q deny rule %d", s.Name, i)
+		}
+		p.Deny = append(p.Deny, compiled)
+	}
+	if err := ValidatePolicy(p); err != nil {
+		return Policy{}, trace.Wrap(err)
+	}
+	FillDefaults(&p)
+	return p, nil
+}
+
+func compileRule(r RuleSpec) (Rule, error) {
+	methods := make([]string, len(r.Methods))
+	for i, m := range r.Methods {
+		methods[i] = strings.ToUpper(m)
+	}
+	out := Rule{
+		Methods:    methods,
+		ReasonCode: r.ReasonCode,
+		Reason:     r.Reason,
+	}
+	for _, pat := range r.Paths {
+		m, err := CompilePath(pat)
+		if err != nil {
+			return Rule{}, trace.Wrap(err)
+		}
+		out.Paths = append(out.Paths, m)
+	}
+	if r.Where != "" {
+		pred, err := CompilePredicate(r.Where)
+		if err != nil {
+			return Rule{}, trace.Wrap(err)
+		}
+		out.Where = pred
+	}
+	return out, nil
+}
+
+// CompileAll compiles a slice of Specs in order. Duplicate names are
+// rejected via ValidatePolicies after compilation.
+func CompileAll(specs []Spec) ([]Policy, error) {
+	out := make([]Policy, 0, len(specs))
+	for _, s := range specs {
+		p, err := Compile(s)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		out = append(out, p)
+	}
+	if err := ValidatePolicies(out); err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return out, nil
+}
+
+// Resolve maps a list of policy refs against the named library and
+// returns the compiled set for one app. Names not found in library are
+// an error.
+func Resolve(library []Policy, refs []Ref) ([]Policy, error) {
+	byName := map[string]Policy{}
+	for _, p := range library {
+		byName[p.Name] = p
+	}
+	out := make([]Policy, 0, len(refs))
+	for _, r := range refs {
+		switch {
+		case r.Name != "" && r.Inline != nil:
+			return nil, trace.BadParameter("policy ref %q has both name and inline spec", r.Name)
+		case r.Name != "":
+			p, ok := byName[r.Name]
+			if !ok {
+				return nil, trace.NotFound("unknown policy %q", r.Name)
+			}
+			out = append(out, p)
+		case r.Inline != nil:
+			p, err := Compile(*r.Inline)
+			if err != nil {
+				return nil, trace.Wrap(err)
+			}
+			out = append(out, p)
+		default:
+			return nil, trace.BadParameter("policy ref must set either name or inline")
+		}
+	}
+	return out, nil
+}

--- a/lib/srv/app/policy/loader_test.go
+++ b/lib/srv/app/policy/loader_test.go
@@ -1,0 +1,173 @@
+/*
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package policy
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCompile_AcceptsBothAllowAndDeny(t *testing.T) {
+	p, err := Compile(Spec{
+		Name:  "mixed",
+		Allow: []RuleSpec{{Paths: []string{"/foo"}}},
+		Deny:  []RuleSpec{{Paths: []string{"/bar"}}},
+	})
+	require.NoError(t, err)
+	require.Len(t, p.Allow, 1)
+	require.Len(t, p.Deny, 1)
+	require.Equal(t, "mixed", p.Allow[0].ReasonCode)
+	require.Equal(t, ReasonExplicitDeny, p.Deny[0].ReasonCode)
+}
+
+func TestCompile_RejectsEmpty(t *testing.T) {
+	_, err := Compile(Spec{Name: "empty"})
+	require.Error(t, err)
+}
+
+func TestCompile_AcceptsMultipleDeniesWithDefaultCode(t *testing.T) {
+	p, err := Compile(Spec{
+		Name: "many-denies",
+		Deny: []RuleSpec{
+			{Paths: []string{"/a"}},
+			{Paths: []string{"/b"}},
+		},
+	})
+	require.NoError(t, err)
+	require.Equal(t, ReasonExplicitDeny, p.Deny[0].ReasonCode)
+	require.Equal(t, ReasonExplicitDeny, p.Deny[1].ReasonCode)
+}
+
+func TestCompile_RejectsAllowWithoutPaths(t *testing.T) {
+	_, err := Compile(Spec{
+		Name:  "where-only",
+		Allow: []RuleSpec{{Where: `user.name == "alice"`}},
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "allow rule must set paths")
+}
+
+func TestCompile_RejectsReservedReasonCodePrefix(t *testing.T) {
+	_, err := Compile(Spec{
+		Name:  "blocked",
+		Allow: []RuleSpec{{Paths: []string{"/foo"}, ReasonCode: "teleport_custom"}},
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "teleport_")
+}
+
+func TestCompile_RejectsReservedNamePrefix(t *testing.T) {
+	_, err := Compile(Spec{
+		Name:  "teleport_custom",
+		Allow: []RuleSpec{{Paths: []string{"/foo"}}},
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "teleport_")
+}
+
+func TestCompile_RejectsDuplicateReasonCodes(t *testing.T) {
+	_, err := Compile(Spec{
+		Name: "dup",
+		Allow: []RuleSpec{
+			{Paths: []string{"/a"}, ReasonCode: "same"},
+			{Paths: []string{"/b"}, ReasonCode: "same"},
+		},
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "duplicate")
+}
+
+// TestCompile_UpperCasesMethods locks in compile-time normalization
+// of HTTP methods. The matcher uppercases the request method but
+// compares against the stored Methods slice as-is, so a config of
+// `methods: [post]` would silently fail to match POST requests
+// without this normalization.
+func TestCompile_UpperCasesMethods(t *testing.T) {
+	p, err := Compile(Spec{
+		Name: "deny-post",
+		Deny: []RuleSpec{{
+			Paths:   []string{"/admin"},
+			Methods: []string{"post", "Delete"},
+		}},
+	})
+	require.NoError(t, err)
+	require.Equal(t, []string{"POST", "DELETE"}, p.Deny[0].Methods)
+	require.True(t, p.Deny[0].MatchesMethod("POST"))
+	require.True(t, p.Deny[0].MatchesMethod("DELETE"))
+}
+
+func TestCompile_FillsDefaults(t *testing.T) {
+	p, err := Compile(Spec{
+		Name:  "default",
+		Allow: []RuleSpec{{Paths: []string{"/foo"}}},
+	})
+	require.NoError(t, err)
+	require.Equal(t, "default", p.Allow[0].ReasonCode)
+	require.Equal(t, "default", p.Allow[0].Reason)
+}
+
+func TestCompileAll_RejectsDuplicateNames(t *testing.T) {
+	_, err := CompileAll([]Spec{
+		{Name: "p", Allow: []RuleSpec{{Paths: []string{"/a"}}}},
+		{Name: "p", Allow: []RuleSpec{{Paths: []string{"/b"}}}},
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "duplicate policy name")
+}
+
+func TestResolve_ByName(t *testing.T) {
+	lib, err := CompileAll([]Spec{
+		{Name: "read-only", Allow: []RuleSpec{{Paths: []string{"/**"}, Methods: []string{"GET"}}}},
+	})
+	require.NoError(t, err)
+
+	out, err := Resolve(lib, []Ref{{Name: "read-only"}})
+	require.NoError(t, err)
+	require.Len(t, out, 1)
+	require.Equal(t, "read-only", out[0].Name)
+}
+
+func TestResolve_UnknownName(t *testing.T) {
+	_, err := Resolve(nil, []Ref{{Name: "missing"}})
+	require.Error(t, err)
+}
+
+func TestResolve_Inline(t *testing.T) {
+	out, err := Resolve(nil, []Ref{{Inline: &Spec{
+		Name:  "inline",
+		Allow: []RuleSpec{{Paths: []string{"/foo"}}},
+	}}})
+	require.NoError(t, err)
+	require.Len(t, out, 1)
+	require.Equal(t, "inline", out[0].Name)
+}
+
+func TestResolve_EmptyRef(t *testing.T) {
+	_, err := Resolve(nil, []Ref{{}})
+	require.Error(t, err)
+}
+
+func TestResolve_BothNameAndInline(t *testing.T) {
+	_, err := Resolve(nil, []Ref{{
+		Name:   "x",
+		Inline: &Spec{Name: "x"},
+	}})
+	require.Error(t, err)
+}

--- a/lib/srv/app/policy/matcher.go
+++ b/lib/srv/app/policy/matcher.go
@@ -1,0 +1,166 @@
+/*
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package policy
+
+import (
+	"strings"
+
+	"github.com/gravitational/trace"
+)
+
+// PathMatcher is a compiled path pattern.
+type PathMatcher struct {
+	pattern string
+	segs    []segment
+	tail    bool // pattern ends with **
+}
+
+// segment is one component of a compiled pattern.
+type segment struct {
+	kind segmentKind
+	text string
+}
+
+type segmentKind int
+
+const (
+	segLiteral segmentKind = iota // exact "/foo"
+	segStar                       // "*" - exactly one segment
+	segCapture                    // "{name}" - capture one segment
+)
+
+// CompilePath compiles a pattern into a PathMatcher.
+//
+//   - "*" matches exactly one non-empty path segment.
+//   - "**" matches zero or more segments, only allowed as the last
+//     component.
+//   - "{name}" captures one non-empty path segment to path.<name>.
+//
+// Any other use of "*" or "{" returns an error.
+func CompilePath(pattern string) (*PathMatcher, error) {
+	if pattern == "" {
+		return nil, trace.BadParameter("empty path pattern")
+	}
+	if !strings.HasPrefix(pattern, "/") {
+		return nil, trace.BadParameter("path pattern must start with '/': %q", pattern)
+	}
+	trimmed := strings.TrimPrefix(pattern, "/")
+	// Trailing slash is normalized away in Match, but the pattern itself
+	// rejects an explicit trailing slash to keep authors honest.
+	if strings.HasSuffix(pattern, "/") && pattern != "/" {
+		return nil, trace.BadParameter("path pattern must not end with '/': %q", pattern)
+	}
+
+	m := &PathMatcher{pattern: pattern}
+	if pattern == "/" {
+		return m, nil
+	}
+	parts := strings.Split(trimmed, "/")
+	for i, p := range parts {
+		switch {
+		case p == "":
+			return nil, trace.BadParameter("path pattern has empty segment: %q", pattern)
+		case p == "**":
+			if i != len(parts)-1 {
+				return nil, trace.BadParameter("path pattern: '**' may only appear as the last segment: %q", pattern)
+			}
+			m.tail = true
+		case p == "*":
+			m.segs = append(m.segs, segment{kind: segStar})
+		case strings.HasPrefix(p, "{") && strings.HasSuffix(p, "}"):
+			name := p[1 : len(p)-1]
+			if name == "" || strings.ContainsAny(name, "{}*/") {
+				return nil, trace.BadParameter("path pattern: invalid capture name in %q", pattern)
+			}
+			m.segs = append(m.segs, segment{kind: segCapture, text: name})
+		default:
+			if strings.ContainsAny(p, "*{}") {
+				return nil, trace.BadParameter("path pattern: stray metacharacter in segment %q (pattern %q)", p, pattern)
+			}
+			m.segs = append(m.segs, segment{kind: segLiteral, text: p})
+		}
+	}
+	return m, nil
+}
+
+// MustCompilePath compiles a pattern or panics. Intended for tests and
+// for callers that supply hand-written patterns at init time.
+func MustCompilePath(pattern string) *PathMatcher {
+	m, err := CompilePath(pattern)
+	if err != nil {
+		panic(err)
+	}
+	return m
+}
+
+// Match reports whether path matches m and returns any captures.
+// path must be normalized (starts with "/", no trailing "/" except root).
+func (m *PathMatcher) Match(path string) (map[string]string, bool) {
+	if m.pattern == "/" {
+		if path == "/" {
+			return nil, true
+		}
+		return nil, false
+	}
+	if path == "" {
+		return nil, false
+	}
+	if path == "/" {
+		// Only a tail-glob with no fixed prefix segments matches root
+		// (e.g. "/**"). Concrete-segment patterns like "/foo" or
+		// "/foo/**" do not.
+		if m.tail && len(m.segs) == 0 {
+			return nil, true
+		}
+		return nil, false
+	}
+	parts := strings.Split(strings.TrimPrefix(path, "/"), "/")
+	switch {
+	case m.tail:
+		// "**" matches zero or more trailing segments. The path must
+		// supply at least the prefix segments preceding the "**".
+		if len(parts) < len(m.segs) {
+			return nil, false
+		}
+	default:
+		if len(parts) != len(m.segs) {
+			return nil, false
+		}
+	}
+	var caps map[string]string
+	for i, seg := range m.segs {
+		p := parts[i]
+		if p == "" {
+			return nil, false
+		}
+		switch seg.kind {
+		case segLiteral:
+			if p != seg.text {
+				return nil, false
+			}
+		case segStar:
+		case segCapture:
+			if caps == nil {
+				caps = map[string]string{}
+			}
+			caps[seg.text] = p
+		}
+	}
+	return caps, true
+}

--- a/lib/srv/app/policy/matcher_test.go
+++ b/lib/srv/app/policy/matcher_test.go
@@ -1,0 +1,100 @@
+/*
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package policy
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCompilePath_Errors(t *testing.T) {
+	bad := []string{
+		"",
+		"foo",            // missing leading slash
+		"/foo/**/bar",    // ** not last
+		"/foo/{}/bar",    // empty capture name
+		"/foo/{a/b}/bar", // bad character in capture
+		"/foo/",          // trailing slash
+		"/foo//bar",      // empty segment
+		"/foo*bar",       // stray *
+		"/foo{x}",        // stray {
+	}
+	for _, p := range bad {
+		t.Run(p, func(t *testing.T) {
+			_, err := CompilePath(p)
+			require.Error(t, err, "wanted err for %q", p)
+		})
+	}
+}
+
+func TestPathMatch(t *testing.T) {
+	tests := []struct {
+		pattern string
+		path    string
+		match   bool
+		caps    map[string]string
+	}{
+		{pattern: "/foo", path: "/foo", match: true},
+		{pattern: "/foo", path: "/foo/bar", match: false},
+		{pattern: "/foo/*", path: "/foo/bar", match: true},
+		{pattern: "/foo/*", path: "/foo/bar/baz", match: false},
+		{pattern: "/foo/**", path: "/foo", match: true},
+		{pattern: "/foo/**", path: "/foo/bar", match: true},
+		{pattern: "/foo/**", path: "/foo/bar/baz", match: true},
+		{pattern: "/foo/{x}", path: "/foo/bar", match: true, caps: map[string]string{"x": "bar"}},
+		{pattern: "/foo/{x}", path: "/foo/", match: false},
+		{
+			pattern: "/api/v4/projects/{project}/merge_requests/{mr}/notes",
+			path:    "/api/v4/projects/123/merge_requests/4/notes",
+			match:   true,
+			caps:    map[string]string{"project": "123", "mr": "4"},
+		},
+		{pattern: "/", path: "/", match: true},
+		{pattern: "/", path: "/foo", match: false},
+		// `**` is documented as matching zero or more segments, so a
+		// root-glob `/**` must include the root path itself; an empty
+		// allow set against `/**` should not have a deny-by-default
+		// hole at "/".
+		{pattern: "/**", path: "/", match: true},
+		{pattern: "/**", path: "/foo", match: true},
+		{pattern: "/**", path: "/foo/bar", match: true},
+		{pattern: "/foo/**", path: "/", match: false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.pattern+"_vs_"+tc.path, func(t *testing.T) {
+			m, err := CompilePath(tc.pattern)
+			require.NoError(t, err)
+			caps, ok := m.Match(tc.path)
+			require.Equal(t, tc.match, ok)
+			if tc.match && len(tc.caps) > 0 {
+				require.Equal(t, tc.caps, caps)
+			}
+		})
+	}
+}
+
+func TestPathMatch_TrailingSlashNormalizesAway(t *testing.T) {
+	m := MustCompilePath("/foo")
+	norm, err := Normalize("/foo/")
+	require.NoError(t, err)
+	_, ok := m.Match(norm)
+	require.True(t, ok)
+}

--- a/lib/srv/app/policy/normalize.go
+++ b/lib/srv/app/policy/normalize.go
@@ -1,0 +1,155 @@
+/*
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package policy
+
+import (
+	"errors"
+	"net/url"
+	"path"
+	"strings"
+	"unicode"
+
+	"golang.org/x/text/unicode/norm"
+)
+
+// NormalizeError is returned by Normalize for inputs that fail one of the
+// path security rules. The Code is one of the teleport_* reasons.
+type NormalizeError struct {
+	Code    string
+	Message string
+}
+
+func (e *NormalizeError) Error() string { return e.Message }
+
+// IsNormalizeError reports whether err is a NormalizeError. If so it
+// returns the embedded reason code.
+func IsNormalizeError(err error) (string, bool) {
+	var ne *NormalizeError
+	if errors.As(err, &ne) {
+		return ne.Code, true
+	}
+	return "", false
+}
+
+// Normalize parses and normalizes a request URL path.
+//
+// Returns the normalized path on success, or a *NormalizeError on a
+// security-rule failure. Normalize never returns a non-NormalizeError
+// error.
+func Normalize(rawPath string) (string, error) {
+	// A leading "//" causes net/url.Parse to read the next segment as
+	// Host. The upstream router collapses "//x" to "/x", so feeding the
+	// parser's empty Path to the engine would let "//admin" bypass an
+	// "/admin" deny rule.
+	if strings.HasPrefix(rawPath, "//") {
+		return "", &NormalizeError{
+			Code:    ReasonPathDecodeFailed,
+			Message: "path must not start with multiple slashes",
+		}
+	}
+	u, err := url.Parse(rawPath)
+	if err != nil {
+		return "", &NormalizeError{Code: ReasonPathDecodeFailed, Message: "invalid request path"}
+	}
+	raw := u.EscapedPath()
+	if raw == "" {
+		raw = u.Path
+	}
+
+	current := raw
+	// Three rounds catches single, double, and triple percent encoding.
+	// Anything still encoded after that is rejected by the post-loop
+	// check rather than decoded further.
+	for range 3 {
+		decoded, err := url.PathUnescape(current)
+		if err != nil {
+			return "", &NormalizeError{Code: ReasonPathDecodeFailed, Message: "invalid request path"}
+		}
+		if decoded != current {
+			encodedSlashes := strings.Count(current, "%2F") + strings.Count(current, "%2f")
+			rawSlashes := strings.Count(current, "/")
+			decodedSlashes := strings.Count(decoded, "/")
+			if encodedSlashes > 0 && decodedSlashes > rawSlashes {
+				return "", &NormalizeError{
+					Code:    ReasonEncodedSlashInSegment,
+					Message: "encoded path separator decoded into a new segment",
+				}
+			}
+		}
+		if decoded == current {
+			break
+		}
+		current = decoded
+	}
+	if strings.Contains(current, "%2F") || strings.Contains(current, "%2f") {
+		return "", &NormalizeError{
+			Code:    ReasonDoubleEncodedSlash,
+			Message: "path contains encoded slash after 3 decode rounds",
+		}
+	}
+	// Windows-style backends interpret "\" as a path separator. The Go
+	// path package does not, so an engine-side "\admin" would not match
+	// an "/admin" deny rule while the upstream still routes there.
+	// Check after decoding so "%5c" cannot smuggle a backslash past
+	// the gate.
+	if strings.ContainsRune(current, '\\') {
+		return "", &NormalizeError{
+			Code:    ReasonPathDecodeFailed,
+			Message: "path must not contain backslashes",
+		}
+	}
+	// Java servlet containers and some other stacks treat ";" as a
+	// matrix-parameter separator: a request to "/admin;foo/users"
+	// routes to the "/admin/users" handler upstream, so feeding the
+	// "admin;foo" segment to the engine would skip an "/admin/**"
+	// deny rule.
+	if strings.ContainsRune(current, ';') {
+		return "", &NormalizeError{
+			Code:    ReasonPathDecodeFailed,
+			Message: "path must not contain semicolons",
+		}
+	}
+
+	current = norm.NFC.String(current)
+
+	if !strings.HasPrefix(current, "/") {
+		current = "/" + current
+	}
+	// path.Clean collapses repeated slashes and resolves dot-segments.
+	current = path.Clean(current)
+
+	// IIS, ASP.NET, and some Java backends strip trailing dots and
+	// trailing whitespace from each path segment before routing, so
+	// "/admin." or "/admin. " would reach the "/admin" handler upstream
+	// while skipping an "/admin" deny rule. Reject rather than strip so
+	// the operator sees the bypass attempt.
+	for _, seg := range strings.Split(strings.TrimPrefix(current, "/"), "/") {
+		if seg == "" {
+			continue
+		}
+		trimmed := strings.TrimRightFunc(seg, unicode.IsSpace)
+		if strings.HasSuffix(trimmed, ".") || trimmed != seg {
+			return "", &NormalizeError{
+				Code:    ReasonPathDecodeFailed,
+				Message: "path segment must not end with a dot or whitespace",
+			}
+		}
+	}
+	return current, nil
+}

--- a/lib/srv/app/policy/normalize_test.go
+++ b/lib/srv/app/policy/normalize_test.go
@@ -1,0 +1,98 @@
+/*
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package policy
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNormalize(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+		code string // expected NormalizeError code, empty on success
+	}{
+		{name: "plain", in: "/foo/bar", want: "/foo/bar"},
+		{name: "trailing slash", in: "/foo/bar/", want: "/foo/bar"},
+		{name: "root", in: "/", want: "/"},
+		{name: "dot segments", in: "/foo/./bar/../baz", want: "/foo/baz"},
+		{name: "query stripped", in: "/foo?x=1", want: "/foo"},
+		{name: "fragment stripped", in: "/foo#anchor", want: "/foo"},
+		{name: "single percent decode", in: "/foo/%62ar", want: "/foo/bar"},
+		{
+			name: "encoded slash in segment",
+			in:   "/api/foo%2Fbar",
+			code: ReasonEncodedSlashInSegment,
+		},
+		{
+			name: "double-encoded slash decodes to slash",
+			in:   "/api/projects/org%252Frepo/files",
+			code: ReasonEncodedSlashInSegment,
+		},
+		{
+			name: "triple-encoded slash decodes on the 3rd round",
+			in:   "/api/projects/org%25252Frepo/files",
+			code: ReasonEncodedSlashInSegment,
+		},
+		{
+			name: "quad-encoded slash still has %2F after 3 rounds",
+			in:   "/api/projects/org%2525252Frepo/files",
+			code: ReasonDoubleEncodedSlash,
+		},
+		{
+			name: "mixed case encoded slash",
+			in:   "/api/foo%2fbar",
+			code: ReasonEncodedSlashInSegment,
+		},
+		{name: "nfc unicode", in: "/café", want: "/café"},
+
+		// Bypass variants the engine must reject. Each of these reaches
+		// the upstream as a different effective path, so feeding the
+		// stripped form to the engine would defeat path-based deny rules.
+		{name: "leading double slash", in: "//admin", code: ReasonPathDecodeFailed},
+		{name: "leading triple slash", in: "///admin", code: ReasonPathDecodeFailed},
+		{name: "leading slash plus host", in: "//evil.com/admin", code: ReasonPathDecodeFailed},
+		{name: "internal double slash collapses", in: "/foo//bar", want: "/foo/bar"},
+		{name: "trailing dot segment", in: "/admin.", code: ReasonPathDecodeFailed},
+		{name: "trailing dot via percent encoded dot", in: "/admin%2e", code: ReasonPathDecodeFailed},
+		{name: "middle segment ending in dot", in: "/admin./inner", code: ReasonPathDecodeFailed},
+		{name: "percent-encoded backslash", in: "/admin%5cusers", code: ReasonPathDecodeFailed},
+		{name: "percent-encoded backslash upper hex", in: "/admin%5Cusers", code: ReasonPathDecodeFailed},
+		{name: "double percent-encoded backslash", in: "/admin%255cusers", code: ReasonPathDecodeFailed},
+		{name: "semicolon matrix param", in: "/admin;foo/users", code: ReasonPathDecodeFailed},
+		{name: "percent-encoded semicolon", in: "/admin%3bfoo/users", code: ReasonPathDecodeFailed},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := Normalize(tc.in)
+			if tc.code != "" {
+				require.Error(t, err)
+				code, ok := IsNormalizeError(err)
+				require.True(t, ok, "expected NormalizeError, got %T: %v", err, err)
+				require.Equal(t, tc.code, code)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tc.want, got)
+		})
+	}
+}

--- a/lib/srv/app/policy/policy.go
+++ b/lib/srv/app/policy/policy.go
@@ -1,0 +1,206 @@
+/*
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+// Package policy implements policy-based per-request authorization for
+// Teleport App Access. See RFD on policy-based App Access for the design.
+package policy
+
+import (
+	"strings"
+
+	"github.com/gravitational/trace"
+)
+
+// Reserved Teleport-emitted reason codes and policy-name prefix.
+const (
+	ReservedPrefix = "teleport_"
+
+	ReasonExplicitDeny          = "teleport_explicit_deny"
+	ReasonNoMatchingAllow       = "teleport_no_matching_allow"
+	ReasonDoubleEncodedSlash    = "teleport_double_encoded_slash"
+	ReasonEncodedSlashInSegment = "teleport_encoded_slash_in_segment"
+	ReasonPathDecodeFailed      = "teleport_path_decode_failed"
+	ReasonPredicateError        = "teleport_predicate_error"
+)
+
+const methodAny = "*"
+
+// Policy is a named bundle of rules. A policy may hold any combination
+// of allow and deny rules; at least one of the two must be set.
+type Policy struct {
+	Name  string
+	Allow []Rule
+	Deny  []Rule
+}
+
+// Rule is a single match clause inside a policy.
+type Rule struct {
+	// Paths are the compiled path patterns. Required on allow rules;
+	// optional on deny rules.
+	Paths []*PathMatcher
+
+	// Methods is the list of HTTP methods, upper-case. Empty or
+	// containing "*" means any method.
+	Methods []string
+
+	// Where is the optional compiled predicate. May be nil.
+	Where Predicate
+
+	// ReasonCode is the machine-readable identifier surfaced in
+	// audit and 403 responses. Defaults to the policy name on allow
+	// rules and to ReasonExplicitDeny on deny rules.
+	ReasonCode string
+
+	// Reason is the human-readable string returned to the user.
+	// Defaults to ReasonCode.
+	Reason string
+}
+
+// Predicate is a compiled where: expression. Returns the boolean result,
+// or an error to be surfaced as teleport_predicate_error.
+type Predicate interface {
+	Evaluate(env Env) (bool, error)
+}
+
+// MatchesMethod reports whether r matches the given method.
+func (r *Rule) MatchesMethod(method string) bool {
+	if len(r.Methods) == 0 {
+		return true
+	}
+	method = strings.ToUpper(method)
+	for _, m := range r.Methods {
+		if m == methodAny || m == method {
+			return true
+		}
+	}
+	return false
+}
+
+// MatchesPath returns the captured variables if any path in r matches the
+// given normalized path. The second return is false if no path matches.
+// A rule with no paths set matches any path with no captures.
+func (r *Rule) MatchesPath(path string) (map[string]string, bool) {
+	if len(r.Paths) == 0 {
+		return nil, true
+	}
+	for _, p := range r.Paths {
+		if caps, ok := p.Match(path); ok {
+			return caps, true
+		}
+	}
+	return nil, false
+}
+
+// ValidatePolicy enforces the name, reserved-prefix, and reason-code
+// uniqueness invariants. Run before FillDefaults: uniqueness applies
+// only to operator-set codes because multiple deny rules legitimately
+// share the synthetic default.
+func ValidatePolicy(p Policy) error {
+	if p.Name == "" {
+		return trace.BadParameter("policy name is required")
+	}
+	if strings.HasPrefix(p.Name, ReservedPrefix) {
+		return trace.BadParameter("policy %q: name must not start with %q", p.Name, ReservedPrefix)
+	}
+	if len(p.Allow) == 0 && len(p.Deny) == 0 {
+		return trace.BadParameter("policy %q: must hold at least one allow or deny rule", p.Name)
+	}
+	seen := map[string]bool{}
+	for i, r := range p.Allow {
+		if err := validateAllowRule(r); err != nil {
+			return trace.Wrap(err, "policy %q allow rule %d", p.Name, i)
+		}
+		if err := checkOperatorReasonCode(r.ReasonCode, p.Name, seen, "allow", i); err != nil {
+			return err
+		}
+	}
+	for i, r := range p.Deny {
+		if err := validateDenyRule(r); err != nil {
+			return trace.Wrap(err, "policy %q deny rule %d", p.Name, i)
+		}
+		if err := checkOperatorReasonCode(r.ReasonCode, p.Name, seen, "deny", i); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func checkOperatorReasonCode(code, policyName string, seen map[string]bool, kind string, idx int) error {
+	if code == "" {
+		return nil
+	}
+	if strings.HasPrefix(code, ReservedPrefix) {
+		return trace.BadParameter("policy %q %s rule %d: reason_code %q must not start with %q", policyName, kind, idx, code, ReservedPrefix)
+	}
+	if seen[code] {
+		return trace.BadParameter("policy %q %s rule %d: duplicate reason_code %q", policyName, kind, idx, code)
+	}
+	seen[code] = true
+	return nil
+}
+
+func validateAllowRule(r Rule) error {
+	if len(r.Paths) == 0 {
+		// A where-only allow rule matches every request and decides on
+		// the predicate alone. A typo there fail-opens the app.
+		return trace.BadParameter("allow rule must set paths")
+	}
+	return nil
+}
+
+func validateDenyRule(r Rule) error {
+	if len(r.Paths) == 0 && len(r.Methods) == 0 && r.Where == nil {
+		return trace.BadParameter("deny rule must set at least one of paths, methods, or where")
+	}
+	return nil
+}
+
+// FillDefaults populates ReasonCode and Reason on each rule. Allow
+// rules default to the policy name; deny rules default to the
+// synthetic ReasonExplicitDeny code. Run after ValidatePolicy.
+func FillDefaults(p *Policy) {
+	for i := range p.Allow {
+		fillRuleDefaults(&p.Allow[i], p.Name)
+	}
+	for i := range p.Deny {
+		fillRuleDefaults(&p.Deny[i], ReasonExplicitDeny)
+	}
+}
+
+func fillRuleDefaults(r *Rule, defaultCode string) {
+	if r.ReasonCode == "" {
+		r.ReasonCode = defaultCode
+	}
+	if r.Reason == "" {
+		r.Reason = r.ReasonCode
+	}
+}
+
+// ValidatePolicies rejects duplicate names. Per-policy invariants are
+// checked in Compile; ValidatePolicies expects already-compiled inputs
+// (post-FillDefaults), so it does not re-run ValidatePolicy.
+func ValidatePolicies(policies []Policy) error {
+	seen := map[string]bool{}
+	for _, p := range policies {
+		if seen[p.Name] {
+			return trace.BadParameter("duplicate policy name %q", p.Name)
+		}
+		seen[p.Name] = true
+	}
+	return nil
+}

--- a/lib/srv/app/policy/predicate.go
+++ b/lib/srv/app/policy/predicate.go
@@ -1,0 +1,201 @@
+/*
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package policy
+
+import (
+	"regexp"
+	"slices"
+	"strconv"
+	"strings"
+	"sync"
+	"unicode"
+
+	"github.com/gravitational/trace"
+
+	"github.com/gravitational/teleport/lib/utils/typical"
+)
+
+// Env holds the runtime bindings exposed to where: expressions.
+type Env struct {
+	UserName      string
+	UserRoles     []string
+	Path          map[string]string
+	RequestMethod string
+	RequestPath   string
+}
+
+// CompilePredicate parses a where: expression at policy-load time.
+func CompilePredicate(expression string) (Predicate, error) {
+	if err := validateRegexpMatchCalls(expression); err != nil {
+		return nil, trace.Wrap(err)
+	}
+	p, err := getParser()
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return p.Parse(expression)
+}
+
+// regexpMatchCall matches the start of a regexp.match invocation.
+var regexpMatchCall = regexp.MustCompile(`regexp\.match\s*\(`)
+
+// validateRegexpMatchCalls forces the first argument to regexp.match to
+// be a string literal and pre-compiles the pattern so syntax errors
+// surface at policy load instead of at first request. Without this an
+// operator could accidentally hand attackers control of the compile via
+// a path capture.
+func validateRegexpMatchCalls(expression string) error {
+	for _, idx := range regexpMatchCall.FindAllStringIndex(expression, -1) {
+		rest := strings.TrimLeftFunc(expression[idx[1]:], unicode.IsSpace)
+		if rest == "" {
+			return trace.BadParameter("regexp.match: missing first argument")
+		}
+		quote := rune(rest[0])
+		if quote != '"' && quote != '\'' && quote != '`' {
+			return trace.BadParameter("regexp.match: first argument must be a string literal, got %q...", firstToken(rest))
+		}
+		pattern, err := parseGoStringLiteral(rest)
+		if err != nil {
+			return trace.Wrap(err, "regexp.match: parsing first argument")
+		}
+		re, err := regexp.Compile(pattern)
+		if err != nil {
+			return trace.Wrap(err, "regexp.match: compiling pattern %q", pattern)
+		}
+		regexCache.Store(pattern, re)
+	}
+	return nil
+}
+
+// parseGoStringLiteral parses a leading Go-style string literal at the
+// start of s and returns its unquoted value. Supports the same three
+// quoting forms strconv.Unquote accepts.
+func parseGoStringLiteral(s string) (string, error) {
+	quote := s[0]
+	if quote == '`' {
+		end := strings.IndexByte(s[1:], '`')
+		if end < 0 {
+			return "", trace.BadParameter("unterminated raw string literal")
+		}
+		return s[1 : 1+end], nil
+	}
+	// Walk the literal honoring escape sequences so embedded quotes do
+	// not terminate it early.
+	for i := 1; i < len(s); i++ {
+		switch s[i] {
+		case '\\':
+			i++ // skip the escaped byte
+		case quote:
+			return strconv.Unquote(s[:i+1])
+		}
+	}
+	return "", trace.BadParameter("unterminated string literal")
+}
+
+func firstToken(s string) string {
+	end := strings.IndexAny(s, " \t\n,)")
+	if end < 0 {
+		end = len(s)
+	}
+	if end > 16 {
+		end = 16
+	}
+	return s[:end]
+}
+
+var (
+	parserOnce sync.Once
+	parser     *typical.Parser[Env, bool]
+	parserErr  error
+	regexCache sync.Map // map[string]*regexp.Regexp
+)
+
+func getParser() (*typical.Parser[Env, bool], error) {
+	parserOnce.Do(func() {
+		parser, parserErr = newParser()
+	})
+	return parser, parserErr
+}
+
+func newParser() (*typical.Parser[Env, bool], error) {
+	spec := typical.ParserSpec[Env]{
+		Variables: map[string]typical.Variable{
+			"user.name": typical.DynamicVariable(func(e Env) (string, error) {
+				return e.UserName, nil
+			}),
+			"user.roles": typical.DynamicVariable(func(e Env) ([]string, error) {
+				return e.UserRoles, nil
+			}),
+			"path": typical.DynamicMapFunction(func(e Env, key string) (string, error) {
+				return e.Path[key], nil
+			}),
+			"request.method": typical.DynamicVariable(func(e Env) (string, error) {
+				return e.RequestMethod, nil
+			}),
+			"request.path": typical.DynamicVariable(func(e Env) (string, error) {
+				return e.RequestPath, nil
+			}),
+		},
+		Functions: map[string]typical.Function{
+			"contains": typical.BinaryFunction[Env](func(list []string, item string) (bool, error) {
+				return slices.Contains(list, item), nil
+			}),
+			"contains_any": typical.BinaryFunction[Env](func(list []string, items []string) (bool, error) {
+				for _, it := range items {
+					if slices.Contains(list, it) {
+						return true, nil
+					}
+				}
+				return false, nil
+			}),
+			"contains_all": typical.BinaryFunction[Env](func(list []string, items []string) (bool, error) {
+				for _, it := range items {
+					if !slices.Contains(list, it) {
+						return false, nil
+					}
+				}
+				return true, nil
+			}),
+			"regexp.match": typical.BinaryFunction[Env](regexpMatch),
+			"strings.upper": typical.UnaryFunction[Env](func(s string) (string, error) {
+				return strings.ToUpper(s), nil
+			}),
+			"strings.lower": typical.UnaryFunction[Env](func(s string) (string, error) {
+				return strings.ToLower(s), nil
+			}),
+		},
+	}
+	return typical.NewParser[Env, bool](spec)
+}
+
+// regexpMatch compiles each unique pattern once via regexCache and
+// reuses it for subsequent requests. validateRegexpMatchCalls has
+// already rejected non-literal patterns at load time, so the cache key
+// space is bounded by the policy library.
+func regexpMatch(pattern, s string) (bool, error) {
+	if cached, ok := regexCache.Load(pattern); ok {
+		return cached.(*regexp.Regexp).MatchString(s), nil
+	}
+	re, err := regexp.Compile(pattern)
+	if err != nil {
+		return false, trace.Wrap(err)
+	}
+	actual, _ := regexCache.LoadOrStore(pattern, re)
+	return actual.(*regexp.Regexp).MatchString(s), nil
+}

--- a/lib/srv/app/policy/predicate_test.go
+++ b/lib/srv/app/policy/predicate_test.go
@@ -1,0 +1,136 @@
+/*
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package policy
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCompilePredicate(t *testing.T) {
+	tests := []struct {
+		name string
+		expr string
+		env  Env
+		want bool
+		err  bool
+	}{
+		{
+			name: "path equality",
+			expr: `path.username == user.name`,
+			env:  Env{UserName: "alice", Path: map[string]string{"username": "alice"}},
+			want: true,
+		},
+		{
+			name: "path inequality",
+			expr: `path.username == user.name`,
+			env:  Env{UserName: "alice", Path: map[string]string{"username": "bob"}},
+			want: false,
+		},
+		{
+			name: "contains role",
+			expr: `contains(user.roles, "admin")`,
+			env:  Env{UserRoles: []string{"admin", "user"}},
+			want: true,
+		},
+		{
+			name: "request method check",
+			expr: `request.method == "GET"`,
+			env:  Env{RequestMethod: "GET"},
+			want: true,
+		},
+		{
+			name: "compound expression",
+			expr: `path.username == user.name && contains(user.roles, "engineer")`,
+			env: Env{
+				UserName:  "alice",
+				UserRoles: []string{"engineer"},
+				Path:      map[string]string{"username": "alice"},
+			},
+			want: true,
+		},
+		{
+			name: "rejects unknown variable",
+			expr: `path.username == user.naem`,
+			err:  true,
+		},
+		{
+			name: "regexp.match literal pattern",
+			expr: `regexp.match("^GET$", request.method)`,
+			env:  Env{RequestMethod: "GET"},
+			want: true,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			p, err := CompilePredicate(tc.expr)
+			if tc.err {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			got, err := p.Evaluate(tc.env)
+			require.NoError(t, err)
+			require.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestRegexpMatch_RejectsRuntimePattern(t *testing.T) {
+	_, err := CompilePredicate(`regexp.match(path.x, "anything")`)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "string literal")
+}
+
+func TestRegexpMatch_RejectsInvalidPattern(t *testing.T) {
+	_, err := CompilePredicate(`regexp.match("[", request.method)`)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "compiling pattern")
+}
+
+func TestValidateRegexpMatchCalls_NoPanic(t *testing.T) {
+	cases := []string{
+		`regexp.match(", user.name)`,
+		`regexp.match(  , user.name)`,
+		`regexp.match()`,
+		`regexp.match("`,
+	}
+	for _, expr := range cases {
+		t.Run(expr, func(t *testing.T) {
+			_, err := CompilePredicate(expr)
+			require.Error(t, err)
+		})
+	}
+}
+
+func TestRegexpMatch_LiteralWithCommasAndParens(t *testing.T) {
+	for _, expr := range []string{
+		`regexp.match("a,b", request.method)`,
+		`regexp.match("a(b|c)d", request.method)`,
+		`regexp.match("escaped \"quote\"", request.method)`,
+	} {
+		t.Run(expr, func(t *testing.T) {
+			p, err := CompilePredicate(expr)
+			require.NoError(t, err)
+			_, err = p.Evaluate(Env{RequestMethod: "x"})
+			require.NoError(t, err)
+		})
+	}
+}


### PR DESCRIPTION
End-to-end PoC for the in-flight RFD on policy-based App Access.

App admins define named `policies` and attach them to apps. A policy
must hold at least one `allow` or `deny` rule, and the two kinds may
coexist in the same policy. Each rule matches on path, method, and an
optional predicate over the request and the caller's identity. The
agent evaluates the rules per request and emits a structured audit
event on deny.

The gate runs inside the **app agent** HTTP dispatch in `lib/srv/app`,
hoisted into `serveHTTP` ahead of the per-protocol switch so every
HTTP flow (including the AWS console redirect) runs through it. The
proxy is untouched. TCP, MCP, and LLM apps cannot carry policies and
are rejected at config-validate time, since those flows do not reach
the HTTP dispatch.

The package at `lib/srv/app/policy/` holds the URL normalizer, path
matcher, decision engine, and predicate-parser environment. The
normalizer rejects path shapes that defeat path-based denies
(leading `//`, trailing-dot or trailing-whitespace segments,
backslash-containing paths, multi-round percent-encoded slashes).

`regexp.match` predicate patterns must be string literals and are
compiled once at policy load so an operator-supplied expression
cannot hand attackers control of the regex compile.

Policy denies return a JSON 403 body with `reason_code` and `reason`, plus a `Teleport-Decision-Reason` header that carries the reason code. They also emit an `AppSessionRequest` audit event via the cluster
audit emitter so denied requests appear in `tctl events` and any
SIEM-shipped audit pipeline. The 403 response body carries only the
JSON body with `reason_code` and `reason`. Operator-set `reason:` text is reflected to the client; for synthetic codes the message is a static description (e.g. "no allow rule matched the request"). Raw predicate error
text) goes to the agent's structured debug log, not to the audit
event, : the `AppSessionRequest` proto has no reason field, and emitting one with full evaluation detail (predicate inputs, captured vars) is a
dedicated proto event with a reason field is RFD-level follow-up.

This is a PoC. Policy authoring is scoped to file-local config under
`app_service.policies` and per-app `policies:` lists. Dynamic-resource
apps cannot carry policies, hot reload is not wired, and frames after
a WebSocket upgrade are not gated. These remain RFD-level follow-up.

## Manual Test Plan

### Test Environment

- [ ] Local Teleport agent built from this branch on macOS
- [ ] Local `t.tp` proxy reachable on port 443
- [ ] App service running with two HTTP test apps behind the agent:
  one with policies attached and one without

### Test Cases

- [ ] An app with no `policies:` attached behaves as before: every
  authorized HTTP request reaches the upstream.
- [ ] An app with an `allow` rule for `/api/public/**` and a deny
  rule for `/admin/**`:
  - `GET /api/public/health` is allowed and forwarded.
  - `GET /admin/users` returns 403, body is `teleport_explicit_deny`,
    upstream is not reached.
  - `POST /private/x` returns 403 with `teleport_no_matching_allow`.
- [ ] A policy with both `allow:` and `deny:` rules: deny wins even
  when an `allow` rule would match.
- [ ] Path normalization bypass attempts return 403 without reaching
  the upstream: `GET //admin`, `GET /admin.`, `GET /admin%2e`,
  `GET /admin\users`.
- [ ] `regexp.match` with a path-capture pattern is rejected at
  policy load (agent fails to start with a clear error).
- [ ] Attaching `policies:` to a TCP, MCP, or LLM app is rejected at
  config-validate time.
- [ ] Each deny response writes an `AppSessionRequest` audit event
  visible via `tctl events`.
