### PR TITLE
Resolve the license file path for e2e tests

### DIFF
--- a/e2e/runner/flags.go
+++ b/e2e/runner/flags.go
@@ -97,7 +97,7 @@ func parseFlags(repoRoot string) (*e2eFlags, runMode, error) {
 
 	flag.Parse()
 
-	if err := resolveAbsPaths(&f.teleportBin, &f.tctlBin); err != nil {
+	if err := resolveAbsPaths(&f.teleportBin, &f.tctlBin, &f.licenseFile); err != nil {
 		return nil, 0, err
 	}
 


### PR DESCRIPTION
We need to resolve the abs path for the license file otherwise Teleport fails to start in enterprise e2e tests in CI