### PR TITLE
Docs: Add explicit Okta SP-initiated flow URL

### DIFF
--- a/docs/pages/identity-governance/integrations/okta/guided-sso.mdx
+++ b/docs/pages/identity-governance/integrations/okta/guided-sso.mdx
@@ -162,9 +162,17 @@ Okta Integration Network support is still in beta. If unsure please proceed with
 At this point, you have completed the guided flow for the Okta SSO integration. All users assigned
 to the Okta app are now able to log in to Teleport.
 
-To log in using the Okta connector, open the web UI and click the **Okta** button at the bottom of the page.
+To log in using the Okta connector, navigate to your Teleport cluster URL and click the **Okta** button at the bottom of the page to authenticate:
+
+```
+https://<Var name="example.teleport.sh" />
+```
 
 To log in using the `tsh` CLI:
+
+```
+tsh login --proxy=<Var name="example.teleport.sh" /> --auth=<Var name="okta" />
+```
 
 
 ## Supported features


### PR DESCRIPTION
Okta OIN team requested to state the URL explicitly for the SP-initiated SSO flow.

Render: [link](https://kopiczko-okta-oin-docs.d3pp5qlev8mo18.amplifyapp.com/docs/identity-governance/integrations/okta/guided-sso/#step-44-provide-your-okta-app-metadata-to-teleport)

## Backports

- https://github.com/gravitational/teleport/pull/67122
- https://github.com/gravitational/teleport/pull/67127