### PR TITLE
Scope support in embedded tbot

### DIFF
--- a/integrations/lib/embeddedtbot/bot.go
+++ b/integrations/lib/embeddedtbot/bot.go
@@ -74,6 +74,7 @@ func New(botConfig *BotConfig, log *slog.Logger) (*EmbeddedBot, error) {
 				botConfig.CredentialLifetime,
 			),
 		},
+		Scoped: botConfig.Scoped,
 	}
 
 	err := cfg.CheckAndSetDefaults()

--- a/integrations/lib/embeddedtbot/bot_test.go
+++ b/integrations/lib/embeddedtbot/bot_test.go
@@ -19,19 +19,29 @@
 package embeddedtbot
 
 import (
-	"context"
 	"fmt"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
 	"github.com/google/uuid"
 	"github.com/gravitational/trace"
+	"github.com/jonboulle/clockwork"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
+	machineidv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/machineid/v1"
+	scopedaccessv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/access/v1"
+	scopedjoiningv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/joining/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/types/wrappers"
 	"github.com/gravitational/teleport/integration/helpers"
 	"github.com/gravitational/teleport/integrations/operator/controllers/resources/testlib"
+	"github.com/gravitational/teleport/lib/oidc/fakeissuer"
+	scopedaccess "github.com/gravitational/teleport/lib/scopes/access"
+	scopedjoining "github.com/gravitational/teleport/lib/scopes/joining"
 	"github.com/gravitational/teleport/lib/service/servicecfg"
 	"github.com/gravitational/teleport/lib/tbot/bot"
 	"github.com/gravitational/teleport/lib/tbot/bot/onboarding"
@@ -41,7 +51,7 @@ import (
 func TestBotJoinAuth(t *testing.T) {
 	// Configure and start Teleport server
 	clusterName := "root.example.com"
-	ctx := context.Background()
+	ctx := t.Context()
 	logger := logtest.NewLogger()
 	teleportServer := helpers.NewInstance(t, helpers.InstanceConfig{
 		ClusterName: clusterName,
@@ -163,7 +173,7 @@ func createBotRole(botName string, resourceName string, roleRequests []string) (
 	}
 
 	meta := role.GetMetadata()
-	meta.Description = fmt.Sprintf("Automatically generated role for bot %s", botName)
+	meta.Description = fmt.Sprintf("Role for bot %s", botName)
 	if meta.Labels == nil {
 		meta.Labels = map[string]string{}
 	}
@@ -194,4 +204,255 @@ func createBotUser(
 	user.SetMetadata(metadata)
 	user.SetTraits(traits)
 	return user, nil
+}
+
+func TestScopedBotJoinAuth(t *testing.T) {
+	// Test setup: Configure and start Teleport server
+	clusterName := "root.example.com"
+	logger := logtest.NewLogger()
+	ctx := t.Context()
+
+	// We lose test parallelism, but there's currently no other way to enable scope support.
+	t.Setenv("TELEPORT_UNSTABLE_SCOPES", "yes")
+
+	teleportServer := helpers.NewInstance(t, helpers.InstanceConfig{
+		ClusterName: clusterName,
+		HostID:      uuid.New().String(),
+		NodeName:    helpers.Loopback,
+		Logger:      logger,
+	})
+
+	// Test setup: building an admin user and role that will be used to create fixtures.
+	const adminUserName = "admin"
+	adminRole, err := types.NewRole("admin", types.RoleSpecV6{
+		Options: types.RoleOptions{},
+		Allow: types.RoleConditions{
+			Rules: []types.Rule{
+				{
+					Resources: []string{types.KindUser, types.KindRole, scopedaccess.KindScopedToken, scopedaccess.KindScopedRole, scopedaccess.KindScopedRoleAssignment, types.KindBot},
+					Verbs:     []string{types.VerbRead, types.VerbCreate, types.VerbDelete, types.VerbList, types.VerbUpdate},
+				},
+			},
+		},
+		Deny: types.RoleConditions{},
+	})
+	require.NoError(t, err)
+	teleportServer.AddUserWithRole(adminUserName, adminRole)
+
+	// Test setup: starting the Teleport instance
+	rcConf := servicecfg.MakeDefaultConfig()
+	rcConf.DataDir = t.TempDir()
+	rcConf.Auth.Enabled = true
+	rcConf.Proxy.Enabled = true
+	rcConf.Proxy.DisableWebInterface = true
+	rcConf.SSH.Enabled = false
+	rcConf.Version = "v3"
+
+	require.NoError(t, teleportServer.CreateEx(t, nil, rcConf))
+
+	require.NoError(t, teleportServer.Start())
+	t.Cleanup(func() { _ = teleportServer.StopAll() })
+
+	// Test setup: Building an admin client.
+	// Note: this is very convoluted but the bot service is not stored in the auth server struct and cannot be accessed
+	// without a rpc client.
+	adminCreds, err := helpers.GenerateUserCreds(helpers.UserCredsRequest{
+		Process:  teleportServer.Process,
+		Username: "admin",
+	})
+	require.NoError(t, err)
+	clt, err := teleportServer.NewClientWithCreds(
+		helpers.ClientConfig{
+			TeleportUser: adminUserName,
+			Login:        adminUserName,
+			Cluster:      clusterName,
+		},
+		*adminCreds,
+	)
+	require.NoError(t, err)
+
+	clusterClient, err := clt.ConnectToCluster(ctx)
+	require.NoError(t, err)
+	adminClient, err := clusterClient.ConnectToCluster(ctx, clusterName)
+	require.NoError(t, err)
+	// Validate that the admin client works.
+	adminPong, err := adminClient.Ping(ctx)
+	require.NoError(t, err)
+	require.Equal(t, clusterName, adminPong.ClusterName)
+
+	// Test setup: Create all the scoped resources describing a scoped bot, and its RBAC.
+	const (
+		testRootScope = "/my-scope"
+		testBotRole   = "scoped-role"
+		testBotName   = "test-bot"
+		testTokenName = "test-token"
+	)
+
+	// Role impersonated by the bot.
+	botRole := &scopedaccessv1.ScopedRole{
+		Kind:    scopedaccess.KindScopedRole,
+		Version: types.V1,
+		Metadata: &headerv1.Metadata{
+			Name: testBotRole,
+		},
+		Scope: testRootScope,
+		Spec: &scopedaccessv1.ScopedRoleSpec{
+			AssignableScopes: []string{testRootScope},
+			Rules: []*scopedaccessv1.ScopedRule{
+				// The role can read scoped roles. We will use this to validate its permissions later.
+				{
+					Resources: []string{scopedaccess.KindScopedRole},
+					Verbs:     []string{types.VerbReadNoSecrets},
+				},
+			},
+		},
+	}
+	require.NoError(t, scopedaccess.StrongValidateRole(botRole), "malformed role, this is a bug in the test fixture")
+	_, err = adminClient.ScopedAccessServiceClient().CreateScopedRole(ctx, &scopedaccessv1.CreateScopedRoleRequest{
+		Role: botRole,
+	})
+	require.NoError(t, err)
+
+	// Create the bot.
+	botResource := &machineidv1.Bot{
+		Kind:    types.KindBot,
+		Version: types.V1,
+		Metadata: &headerv1.Metadata{
+			Name: testBotName,
+		},
+		Spec:  &machineidv1.BotSpec{},
+		Scope: testRootScope,
+	}
+	_, err = adminClient.BotServiceClient().CreateBot(ctx, &machineidv1.CreateBotRequest{
+		Bot: botResource,
+	})
+	require.NoError(t, err)
+
+	// Assign role to bot
+	roleAssignment := &scopedaccessv1.ScopedRoleAssignment{
+		Kind:    scopedaccess.KindScopedRoleAssignment,
+		SubKind: scopedaccess.SubKindDynamic,
+		Version: types.V1,
+		Metadata: &headerv1.Metadata{
+			Name: testBotRole,
+		},
+		Scope: testRootScope,
+		Spec: &scopedaccessv1.ScopedRoleAssignmentSpec{
+			Assignments: []*scopedaccessv1.Assignment{
+				{
+					Role:  testBotRole,
+					Scope: testRootScope,
+				},
+			},
+			BotName:  testBotName,
+			BotScope: testRootScope,
+		},
+	}
+	_, err = adminClient.ScopedAccessServiceClient().CreateScopedRoleAssignment(
+		ctx,
+		&scopedaccessv1.CreateScopedRoleAssignmentRequest{
+			Assignment: roleAssignment,
+		})
+	require.NoError(t, err)
+
+	// Test setup: Wait for the role assignment to enter the auth server cache
+	// else the bot will race against the cache, joining will fail and the test wil be flaky.
+	require.EventuallyWithT(t, func(t *assert.CollectT) {
+		resp, err := adminClient.ScopedAccessServiceClient().GetScopedRoleAssignment(
+			ctx,
+			&scopedaccessv1.GetScopedRoleAssignmentRequest{
+				Name:    testBotRole,
+				SubKind: scopedaccess.SubKindDynamic,
+			},
+		)
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+		require.NotNil(t, resp.Assignment)
+	}, 5*time.Second, 100*time.Millisecond, "expected role assignment to enter the auth cache")
+
+	// Test setup: Create a fake Kubernetes JWKS signer that will be used by the bot to join the cluster.
+	const (
+		testPod            = "my-pod"
+		testNamespace      = "my-namespace"
+		testServiceAccount = "my-service-account"
+	)
+	signer, err := fakeissuer.NewKubernetesSigner(clockwork.NewRealClock())
+	require.NoError(t, err)
+	jwks, err := signer.GetMarshaledJWKS()
+	require.NoError(t, err)
+	jwt, err := signer.SignServiceAccountJWT(testPod, testNamespace, testServiceAccount, clusterName)
+	require.NoError(t, err)
+
+	tokenDir := t.TempDir()
+	tokenPath := filepath.Join(tokenDir, "token")
+	require.NoError(t, os.WriteFile(tokenPath, []byte(jwt), 0600))
+
+	// Test setup: Create the scoped token allowing the Bot to join with a JWT emitted by the Kube signer.
+	token := &scopedjoiningv1.ScopedToken{
+		Kind:     scopedaccess.KindScopedToken,
+		Version:  types.V1,
+		Metadata: &headerv1.Metadata{Name: testTokenName},
+		Scope:    testRootScope,
+		Spec: &scopedjoiningv1.ScopedTokenSpec{
+			JoinMethod: string(types.JoinMethodKubernetes),
+			UsageMode:  scopedjoining.TokenUsageModeBot,
+			Kubernetes: &scopedjoiningv1.Kubernetes{
+				Allow: []*scopedjoiningv1.Kubernetes_Rule{
+					{
+						ServiceAccount: testNamespace + ":" + testServiceAccount,
+					},
+				},
+				Type:       string(types.KubernetesJoinTypeStaticJWKS),
+				StaticJwks: &scopedjoiningv1.Kubernetes_StaticJWKSConfig{Jwks: jwks},
+			},
+			BotName:  testBotName,
+			BotScope: testRootScope,
+			Roles:    []string{string(types.RoleBot)},
+		},
+	}
+	// Somehow the admin client interface doesn't expose CreateScopedToken ¯\_(ツ)_/¯
+	// We use the auth server directly to create the scoped token.
+	_, err = teleportServer.Process.GetAuthServer().CreateScopedToken(ctx, &scopedjoiningv1.CreateScopedTokenRequest{
+		Token: token,
+	})
+	require.NoError(t, err)
+
+	// Test setup: Configure the bot to join the auth using the scoped join token and the JWT.
+	authAddr, err := teleportServer.Process.AuthAddr()
+	require.NoError(t, err)
+	botConfig := &BotConfig{
+		AuthServer: authAddr.Addr,
+		Onboarding: onboarding.Config{
+			TokenValue: testTokenName,
+			JoinMethod: types.JoinMethodKubernetes,
+			Kubernetes: onboarding.KubernetesOnboardingConfig{
+				TokenPath: tokenPath,
+			},
+		},
+		CredentialLifetime: bot.CredentialLifetime{
+			TTL:             defaultCertificateTTL,
+			RenewalInterval: defaultRenewalInterval,
+		},
+		Scoped: true,
+	}
+
+	// Test execution: Run the bot, make it join the cluster and yield credentials.
+	embeddedBot, err := New(botConfig, logger)
+	require.NoError(t, err)
+	pong, err := embeddedBot.Preflight(ctx)
+	require.NoError(t, err)
+	require.Equal(t, clusterName, pong.ClusterName)
+
+	botClient, err := embeddedBot.StartAndWaitForClient(ctx, 10*time.Second)
+	require.NoError(t, err)
+
+	// Test validation: check if the bot produced a valid client.
+	botPong, err := botClient.Ping(ctx)
+	require.NoError(t, err)
+	require.Equal(t, clusterName, botPong.ClusterName)
+
+	_, err = botClient.ScopedAccessServiceClient().GetScopedRole(ctx, &scopedaccessv1.GetScopedRoleRequest{
+		Name: testBotRole,
+	})
+	require.NoError(t, err)
 }

--- a/integrations/lib/embeddedtbot/config.go
+++ b/integrations/lib/embeddedtbot/config.go
@@ -42,6 +42,8 @@ type BotConfig struct {
 	Onboarding         onboarding.Config
 	CredentialLifetime bot.CredentialLifetime
 	Insecure           bool
+	// Scoped represents if the bot uses a scoped token to join (and gets a scoped identity).
+	Scoped bool
 }
 
 // BindFlags binds BotConfig fields to CLI flags.

--- a/lib/tbot/services/clientcredentials/config.go
+++ b/lib/tbot/services/clientcredentials/config.go
@@ -152,8 +152,8 @@ func (o *UnstableConfig) SetOrUpdateFacade(id *identity.Identity) {
 
 // CheckAndSetDefaults checks and sets default values for the configuration.
 func (o *UnstableConfig) CheckAndSetDefaults(scoped bool) error {
-	if scoped {
-		return trace.BadParameter("service type %q is not supported in scoped mode", ServiceType)
+	if scoped && o.DelegationSessionID != "" {
+		return trace.BadParameter("Delegation session ID is not supported in scoped mode")
 	}
 	return nil
 }

--- a/lib/tbot/services/clientcredentials/service.go
+++ b/lib/tbot/services/clientcredentials/service.go
@@ -51,6 +51,7 @@ func ServiceBuilder(cfg *UnstableConfig, credentialLifetime bot.CredentialLifeti
 			identityGenerator:  deps.IdentityGenerator,
 			log:                deps.Logger,
 			statusReporter:     deps.GetStatusReporter(),
+			scoped:             deps.Scoped,
 		}
 		return svc, nil
 	}
@@ -87,6 +88,7 @@ type Service struct {
 	statusReporter     readyz.Reporter
 	reloadCh           <-chan struct{}
 	identityGenerator  *identity.Generator
+	scoped             bool
 }
 
 func (s *Service) String() string {
@@ -97,14 +99,21 @@ func (s *Service) String() string {
 }
 
 func (s *Service) OneShot(ctx context.Context) error {
+	if s.scoped {
+		return s.generateScoped(ctx)
+	}
 	return s.generate(ctx)
 }
 
 func (s *Service) Run(ctx context.Context) error {
+	f := s.generate
+	if s.scoped {
+		f = s.generateScoped
+	}
 	err := internal.RunOnInterval(ctx, internal.RunOnIntervalConfig{
 		Service:         s.String(),
 		Name:            "output-renewal",
-		F:               s.generate,
+		F:               f,
 		Interval:        s.credentialLifetime.RenewalInterval,
 		RetryLimit:      internal.RenewalRetryLimit,
 		Log:             s.log,
@@ -133,6 +142,23 @@ func (s *Service) generate(ctx context.Context) error {
 	id, err := s.identityGenerator.Generate(ctx, opts...)
 	if err != nil {
 		return trace.Wrap(err, "generating identity")
+	}
+
+	s.cfg.SetOrUpdateFacade(id)
+	return nil
+}
+
+func (s *Service) generateScoped(ctx context.Context) error {
+	ctx, span := tracer.Start(
+		ctx,
+		"Service/generateScoped",
+	)
+	defer span.End()
+	s.log.InfoContext(ctx, "Generating scoped output")
+
+	id, err := s.identityGenerator.GenerateScoped(ctx, s.credentialLifetime.TTL, s.credentialLifetime.RenewalInterval)
+	if err != nil {
+		return trace.Wrap(err, "generating scoped identity")
 	}
 
 	s.cfg.SetOrUpdateFacade(id)


### PR DESCRIPTION
This PR is part of the scoped IaC (Terraform and kube operator) support for scopes. We already support creating scoped resources, but the bot backing the IaC are themselves running unscoped.

This PR contains 2 commits that can be reviewed separately.

### tbot creds service

This first commit allows the credentials service to run scoped. The change is pretty trivial, essentially `if scoped{generateScoped()}; else {generate()}`. If followed the pattern and naming convention from the existing scoped identity service.

### embedded tbot

The operator runs with an embedded tbot backed by the `embeddedtbot` lib. The second commit adds scope support for the embedded bot. This is also a straightforward change, but writing an integration test was more complex. Due to the size of the test I documented the steps the best I could.

## Manual Test Plan
### Test Environment

Local operator runnign againsts atging cluster (scoped operator code is not in this PR, will be sent separately)

### Test Cases
- [x] Operator runs on embedded tbopt scoped
- [x] Operator runs on embedded tbot unscoped
