### PR TITLE
Docs: Add support for enrolling uniform Azure VM Scale Sets

### DIFF
--- a/docs/pages/enroll-resources/auto-discovery/servers/azure-vm-discovery/azure-vm-discovery-manual.mdx
+++ b/docs/pages/enroll-resources/auto-discovery/servers/azure-vm-discovery/azure-vm-discovery-manual.mdx
@@ -151,10 +151,12 @@ resources:
 Teleport requires the following permissions to discover and enroll Azure VMs:
 
 - `Microsoft.Compute/virtualMachines/read`
-- `Microsoft.Compute/virtualMachines/runCommand/action`
 - `Microsoft.Compute/virtualMachines/runCommands/write`
 - `Microsoft.Compute/virtualMachines/runCommands/read`
-- `Microsoft.Compute/virtualMachines/runCommands/delete`
+- `Microsoft.Compute/virtualMachineScaleSets/read`
+- `Microsoft.Compute/virtualMachineScaleSets/virtualMachines/read`
+- `Microsoft.Compute/virtualMachineScaleSets/virtualMachines/runCommands/read`
+- `Microsoft.Compute/virtualMachineScaleSets/virtualMachines/runCommands/write`
 
 Here is a sample role definition allowing Teleport to read and run commands on Azure
 virtual machines:
@@ -170,10 +172,12 @@ virtual machines:
             {
                 "actions": [
                     "Microsoft.Compute/virtualMachines/read",
-                    "Microsoft.Compute/virtualMachines/runCommand/action",
                     "Microsoft.Compute/virtualMachines/runCommands/write",
                     "Microsoft.Compute/virtualMachines/runCommands/read",
-                    "Microsoft.Compute/virtualMachines/runCommands/delete"
+                    "Microsoft.Compute/virtualMachineScaleSets/read",
+                    "Microsoft.Compute/virtualMachineScaleSets/virtualMachines/read",
+                    "Microsoft.Compute/virtualMachineScaleSets/virtualMachines/runCommands/write",
+                    "Microsoft.Compute/virtualMachineScaleSets/virtualMachines/runCommands/read"
                 ],
                 "notActions": [],
                 "dataActions": [],
@@ -183,6 +187,16 @@ virtual machines:
     }
 }
 ```
+
+<Admonition type="tip">
+Using the role definition above grants Teleport access to enroll VMs and VMs from Virtual Machine Scale Sets (VMSSs).
+
+VMSSs have two orchestration modes: Uniform and, the recommended, [Flexible](https://learn.microsoft.com/en-us/azure/virtual-machine-scale-sets/virtual-machine-scale-sets-orchestration-modes#scale-sets-with-flexible-orchestration-recommended).
+If you are not using or don't want to enroll VMSSs with Uniform orchestration mode, you can further limit the permissions granted to Teleport by removing the `Microsoft.Compute/virtualMachineScaleSets/*` permissions.
+
+Navigate to the [Azure portal](https://portal.azure.com/#view/Microsoft_Azure_ComputeHub/ComputeHubMenuBlade/~/virtualMachineScaleSetsBrowse) and look for the Orchestration mode column to check the orchestration mode of your VMSSs and make sure to adjust the role permissions accordingly.
+</Admonition>
+
 The `assignableScopes` field above includes a subscription
 `/subscriptions/<subscription>`, allowing the role to be assigned at any
 resource scope within that subscription or the subscription scope itself. If


### PR DESCRIPTION
Continuation of https://github.com/gravitational/teleport/pull/66631

Besides adding the required permissions, this PR also removes permissions that were not required for auto enrolling regular VMs.

https://marco-docs-azure-uniform-vmss-discovery.d3pp5qlev8mo18.amplifyapp.com/docs/enroll-resources/auto-discovery/servers/azure-vm-discovery/azure-vm-discovery-manual/ (might become unavailable)
<img width="1071" height="379" alt="image" src="https://github.com/user-attachments/assets/2f55e593-74ce-4fe4-84b3-0b9a46e09661" />

