### PR TITLE
docs: update macOS tsh install to use teleport-tools pkg

### DIFF
--- a/docs/pages/includes/install-tsh.mdx
+++ b/docs/pages/includes/install-tsh.mdx
@@ -1,11 +1,11 @@
 <Tabs>
   <TabItem label="Mac">
 
-    Download the signed macOS .pkg installer for Teleport, which includes `tsh`.
+    Download the signed macOS .pkg installer for Teleport CLI Client Tools, which includes `tsh`.
     In Finder double-click the `pkg` file to begin installation:
 
     ```code
-    $ curl -O https://cdn.teleport.dev/teleport-(=teleport.version=).pkg
+    $ curl -O https://cdn.teleport.dev/teleport-tools-(=teleport.version=).pkg
     ```
 
     <Admonition type="danger">


### PR DESCRIPTION
not backporting this as some early 18.0, 18.1 versions do not have the tools package