### PR TITLE
fix moderated file transfer uploads when Location is a directory

### DIFF
--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -7972,136 +7972,135 @@ func testModeratedSFTP(t *testing.T, suite *integrationTestSuite) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			// Create and approve a file download request
 			tempDir := t.TempDir()
-			reqFile := filepath.Join(tempDir, "req-file")
+			filename := "req-file"
+			reqFile := filepath.Join(tempDir, filename)
 			err = os.WriteFile(reqFile, []byte("contents"), 0o666)
 			require.NoError(t, err)
-
-			err = tc.sess.RequestFileTransfer(ctx, tracessh.FileTransferReq{
-				Download: true,
-				Location: reqFile,
-			})
-			require.NoError(t, err)
-
-			sshReq = sshRquestIgnoringKeepalives(t, modSSHReqs)
-			var fileReq apievents.FileTransferRequestEvent
-			err = json.Unmarshal(sshReq.Payload, &fileReq)
-			require.NoError(t, err)
-
-			err = modSess.ApproveFileTransferRequest(ctx, fileReq.RequestID)
-			require.NoError(t, err)
-
-			// Ignore file transfer request approve event
-			sshRquestIgnoringKeepalives(t, modSSHReqs)
-
-			// Test that only operations needed to complete the download
-			// are allowed
-			transferSess, err := tc.sshClient.NewSession(ctx)
-			require.NoError(t, err)
-			t.Cleanup(func() {
-				isNilOrEOFErr(t, transferSess.Close())
-			})
-
-			err = transferSess.Setenv(ctx, telesftp.EnvModeratedSessionID, sessTracker.GetSessionID())
-			require.NoError(t, err)
-
-			err = transferSess.RequestSubsystem(ctx, teleport.SFTPSubsystem)
-			require.NoError(t, err)
-			w, err := transferSess.StdinPipe()
-			require.NoError(t, err)
-			r, err := transferSess.StdoutPipe()
-			require.NoError(t, err)
-			sftpClient, err := sftp.NewClientPipe(r, w)
-			require.NoError(t, err)
-
-			// A file not in the request shouldn't be allowed
 			badFile := filepath.Join(tempDir, "bad-file")
-			_, err = sftpClient.Open(badFile)
-			require.ErrorContains(t, err, fmt.Sprintf("operations are only allowed on %s, not %s", reqFile, badFile))
-			// Since this is a download no files should be allowed to be written to
-			_, err = sftpClient.OpenFile(reqFile, os.O_WRONLY)
-			require.ErrorContains(t, err, `writing is not allowed`)
-			// Only stats and reads should be allowed
-			err = sftpClient.Mkdir(reqFile)
-			require.ErrorContains(t, err, `method mkdir is not allowed on `+reqFile)
-			// Since this is a download no files should be allowed to have
-			// their permissions changed
-			err = sftpClient.Chmod(reqFile, 0o777)
-			require.ErrorContains(t, err, `writing is not allowed`)
 
-			// Only necessary operations should be allowed
-			_, err = sftpClient.Stat(reqFile)
-			require.NoError(t, err)
-			_, err = sftpClient.Lstat(reqFile)
-			require.NoError(t, err)
-			rf, err := sftpClient.Open(reqFile)
-			require.NoError(t, err)
-			require.NoError(t, rf.Close())
+			t.Run("download", func(t *testing.T) {
+				// Create and approve a file download request
+				err = tc.sess.RequestFileTransfer(ctx, tracessh.FileTransferReq{
+					Download: true,
+					Location: reqFile,
+				})
+				require.NoError(t, err)
 
-			require.NoError(t, sftpClient.Close())
+				sftpClient := handleModeratedFileTransfer(t, ctx, modSess, modSSHReqs, tc.sshClient, sessTracker)
 
-			// Create and approve a file upload request
-			err = tc.sess.RequestFileTransfer(ctx, tracessh.FileTransferReq{
-				Download: false,
-				Filename: "upload-file",
-				Location: reqFile,
-			})
-			require.NoError(t, err)
+				// A file not in the request shouldn't be allowed
+				_, err = sftpClient.Open(badFile)
+				require.ErrorContains(t, err, fmt.Sprintf("operations are only allowed on %s, not %s", reqFile, badFile))
+				// Since this is a download no files should be allowed to be written to
+				_, err = sftpClient.OpenFile(reqFile, os.O_WRONLY)
+				require.ErrorContains(t, err, "writing is not allowed")
+				// Only stats and reads should be allowed
+				err = sftpClient.Mkdir(reqFile)
+				require.ErrorContains(t, err, "method mkdir is not allowed on "+reqFile)
+				// Since this is a download no files should be allowed to have
+				// their permissions changed
+				err = sftpClient.Chmod(reqFile, 0o777)
+				require.ErrorContains(t, err, "writing is not allowed")
 
-			sshReq = sshRquestIgnoringKeepalives(t, modSSHReqs)
-			err = json.Unmarshal(sshReq.Payload, &fileReq)
-			require.NoError(t, err)
+				// Only necessary operations should be allowed
+				_, err = sftpClient.Stat(reqFile)
+				require.NoError(t, err)
+				_, err = sftpClient.Lstat(reqFile)
+				require.NoError(t, err)
+				rf, err := sftpClient.Open(reqFile)
+				require.NoError(t, err)
+				require.NoError(t, rf.Close())
 
-			err = modSess.ApproveFileTransferRequest(ctx, fileReq.RequestID)
-			require.NoError(t, err)
-
-			// Ignore file transfer request approve event
-			sshRquestIgnoringKeepalives(t, modSSHReqs)
-
-			isNilOrEOFErr(t, transferSess.Close())
-			transferSess, err = tc.sshClient.NewSession(ctx)
-			require.NoError(t, err)
-			t.Cleanup(func() {
-				require.NoError(t, transferSess.Close())
+				require.NoError(t, sftpClient.Close())
 			})
 
-			err = transferSess.Setenv(ctx, telesftp.EnvModeratedSessionID, sessTracker.GetSessionID())
-			require.NoError(t, err)
+			t.Run("upload", func(t *testing.T) {
+				// Create and approve a file upload request
+				err = tc.sess.RequestFileTransfer(ctx, tracessh.FileTransferReq{
+					Download: false,
+					Location: tempDir,
+					Filename: filename,
+				})
+				require.NoError(t, err)
 
-			// Test that only operations needed to complete the download
-			// are allowed
-			err = transferSess.RequestSubsystem(ctx, teleport.SFTPSubsystem)
-			require.NoError(t, err)
-			w, err = transferSess.StdinPipe()
-			require.NoError(t, err)
-			r, err = transferSess.StdoutPipe()
-			require.NoError(t, err)
-			sftpClient, err = sftp.NewClientPipe(r, w)
-			require.NoError(t, err)
+				sftpClient := handleModeratedFileTransfer(t, ctx, modSess, modSSHReqs, tc.sshClient, sessTracker)
 
-			// A file not in the request shouldn't be allowed
-			_, err = sftpClient.Open(badFile)
-			require.ErrorContains(t, err, fmt.Sprintf("operations are only allowed on %s, not %s", reqFile, badFile))
-			// Since this is an upload no files should be allowed to be read from
-			_, err = sftpClient.OpenFile(reqFile, os.O_RDONLY)
-			require.ErrorContains(t, err, `reading is not allowed`)
-			// Only stats, writes, and chmods should be allowed
-			err = sftpClient.Mkdir(reqFile)
-			require.ErrorContains(t, err, `method mkdir is not allowed on `+reqFile)
+				// A file not in the request shouldn't be allowed
+				_, err = sftpClient.Open(badFile)
+				require.ErrorContains(t, err, fmt.Sprintf("operations are only allowed on %s, not %s", tempDir, badFile))
+				// Since this is an upload no files should be allowed to be read from
+				_, err = sftpClient.OpenFile(reqFile, os.O_RDONLY)
+				require.ErrorContains(t, err, "reading is not allowed")
+				// Only stats, writes, and chmods should be allowed
+				err = sftpClient.Mkdir(reqFile)
+				require.ErrorContains(t, err, "method mkdir is not allowed on "+reqFile)
 
-			// Only necessary operations should be allowed
-			_, err = sftpClient.Stat(reqFile)
-			require.NoError(t, err)
-			_, err = sftpClient.Lstat(reqFile)
-			require.NoError(t, err)
-			err = sftpClient.Chmod(reqFile, 0o777)
-			require.NoError(t, err)
-			wf, err := sftpClient.OpenFile(reqFile, os.O_WRONLY)
-			require.NoError(t, err)
-			require.NoError(t, wf.Close())
+				// Only necessary operations should be allowed
+				_, err = sftpClient.Stat(reqFile)
+				require.NoError(t, err)
+				_, err = sftpClient.Lstat(reqFile)
+				require.NoError(t, err)
+				err = sftpClient.Chmod(reqFile, 0o777)
+				require.NoError(t, err)
+				wf, err := sftpClient.OpenFile(reqFile, os.O_WRONLY)
+				require.NoError(t, err)
+				require.NoError(t, wf.Close())
+			})
+
+			t.Run("attempt upload to non-allowed path", func(t *testing.T) {
+				// Create and approve a file upload request
+				err = tc.sess.RequestFileTransfer(ctx, tracessh.FileTransferReq{
+					Download: false,
+					Location: reqFile,
+					Filename: filename,
+				})
+				require.NoError(t, err)
+
+				sftpClient := handleModeratedFileTransfer(t, ctx, modSess, modSSHReqs, tc.sshClient, sessTracker)
+
+				// Location and Filepath joined are also allowed for uploads, but
+				newFile := filepath.Join(reqFile, filename)
+				_, err = sftpClient.OpenFile(newFile, os.O_WRONLY)
+				require.ErrorContains(t, err, fmt.Sprintf("operations are only allowed on %s, not %s", reqFile, newFile))
+			})
 		})
 	}
+}
+
+func handleModeratedFileTransfer(t *testing.T, ctx context.Context, modSess *tracessh.Session, modSSHReqs <-chan *ssh.Request, sshClient *tracessh.Client, sessTracker types.SessionTracker) *sftp.Client {
+	t.Helper()
+
+	sshReq := sshRquestIgnoringKeepalives(t, modSSHReqs)
+	var fileReq apievents.FileTransferRequestEvent
+	err := json.Unmarshal(sshReq.Payload, &fileReq)
+	require.NoError(t, err)
+
+	err = modSess.ApproveFileTransferRequest(ctx, fileReq.RequestID)
+	require.NoError(t, err)
+
+	// Ignore file transfer request approve event
+	sshRquestIgnoringKeepalives(t, modSSHReqs)
+
+	transferSess, err := sshClient.NewSession(ctx)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		isNilOrEOFErr(t, transferSess.Close())
+	})
+
+	err = transferSess.Setenv(ctx, telesftp.EnvModeratedSessionID, sessTracker.GetSessionID())
+	require.NoError(t, err)
+
+	err = transferSess.RequestSubsystem(ctx, teleport.SFTPSubsystem)
+	require.NoError(t, err)
+	w, err := transferSess.StdinPipe()
+	require.NoError(t, err)
+	r, err := transferSess.StdoutPipe()
+	require.NoError(t, err)
+	sftpClient, err := sftp.NewClientPipe(r, w)
+	require.NoError(t, err)
+
+	return sftpClient
 }
 
 func sshRquestIgnoringKeepalives(t *testing.T, ch <-chan *ssh.Request) *ssh.Request {

--- a/session/reexec/reexecsftp/sftp.go
+++ b/session/reexec/reexecsftp/sftp.go
@@ -57,8 +57,15 @@ func (c compositeCh) Close() error {
 }
 
 type allowedOps struct {
+	// write is true if the request is an upload and writes should be
+	// allowed.
 	write bool
-	path  string
+	// path is the path of the file being downloaded or uploaded.
+	path string
+	// fullPath is the full path of the file being uploaded. For uploads
+	// with a non-empty approved Filename, it holds path.Join(path, Filename)
+	// so that the actual file write can be checked against and allowed.
+	fullPath string
 }
 
 // sftpHandler provides handlers for a SFTP server.
@@ -97,6 +104,25 @@ func newSFTPHandler(logger *slog.Logger, req *FileTransferRequest, events chan<-
 			}
 		}
 		allowed.path = path.Clean(allowedPath)
+
+		// For upload requests, Location is the destination which may
+		// or may not be a directory, and Filename is the name of the
+		// file being uploaded. We want to allow Location/Filename to
+		// be written to, but only if Location is a directory. Otherwise
+		// if Location is a file and the basename of Location is equal to
+		// Filename then Location/Filename/Filename will be allowed to be
+		// written to.
+		if !req.Download && req.Filename != "" {
+			// Ensure Filename is simply a base filename, and isn't a
+			// relative or absolute path, otherwise it could be used to
+			// allow writes outside of Location.
+			if path.Base(req.Filename) != req.Filename {
+				return nil, trace.BadParameter("filename %s must be a filename only, not a path", req.Filename)
+			}
+			if fi, err := os.Lstat(allowed.path); err == nil && fi.IsDir() {
+				allowed.fullPath = path.Join(allowed.path, req.Filename)
+			}
+		}
 	}
 
 	return &sftpHandler{
@@ -115,7 +141,7 @@ func (s *sftpHandler) ensureReqIsAllowed(req *sftp.Request) error {
 	}
 
 	cleaned := path.Clean(req.Filepath)
-	if s.allowed.path != cleaned {
+	if cleaned != s.allowed.path && cleaned != s.allowed.fullPath {
 		return trace.Errorf("operations are only allowed on %s, not %s", s.allowed.path, cleaned)
 	}
 


### PR DESCRIPTION
I will have to change the integration tests to fix a merge conflict once https://github.com/gravitational/teleport/pull/65674 is merged; I didn't realize @atburke was already doing a similar cleanup on the same integration test there.

Fixes https://github.com/gravitational/teleport/issues/64844.

<!-- Provide a descriptive entry for the changelog of the next release. -->

Changelog: fix file uploads in a moderated SSH session when the remote destination is a directory

<!-- Include manual testing efforts to verify the change. -->
<!-- Detail where the tests where run and what configurations were used. -->
<!-- Include all the test cases which were run to validate the change. -->

## Manual Test Plan
### Test Environment

### Test Cases
- [x] Start an SSH session as a user that needs moderation
- [x] Join the session as another user that is allowed to join as a moderator
- [x] Request a file upload when the dest is a directory and the file to upload doesn't exist
- [x] Request a file upload when the dest is a directory and the file to upload does exist
- [x] Request a file upload when the dest is a file and the file to upload shares the same name as dest's basename
