### PR TITLE
Calculate CA overrides on GenerateDatabaseCert

### DIFF
--- a/lib/auth/db.go
+++ b/lib/auth/db.go
@@ -43,6 +43,7 @@ import (
 	"github.com/gravitational/teleport/lib/auth/keystore"
 	"github.com/gravitational/teleport/lib/jwt"
 	"github.com/gravitational/teleport/lib/services"
+	"github.com/gravitational/teleport/lib/subca"
 	"github.com/gravitational/teleport/lib/tlsca"
 	"github.com/gravitational/teleport/lib/winpki"
 )
@@ -66,15 +67,6 @@ func (a *Server) generateDatabaseServerCert(ctx context.Context, req *proto.Data
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	// databases should be configured to trust the DatabaseClientCA when
-	// clients connect so return DatabaseClientCA in the response.
-	dbClientCA, err := a.GetCertAuthority(ctx, types.CertAuthID{
-		Type:       types.DatabaseClientCA,
-		DomainName: clusterName.GetClusterName(),
-	}, false)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
 	dbServerCA, err := a.GetCertAuthority(ctx, types.CertAuthID{
 		Type:       types.DatabaseCA,
 		DomainName: clusterName.GetClusterName(),
@@ -83,13 +75,25 @@ func (a *Server) generateDatabaseServerCert(ctx context.Context, req *proto.Data
 		return nil, trace.Wrap(err)
 	}
 
-	cert, err := a.generateDatabaseCert(ctx, req, dbServerCA)
+	resp, err := a.generateDatabaseCert(ctx, req, dbServerCA)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
+
+	// databases should be configured to trust the DatabaseClientCA when
+	// clients connect so return DatabaseClientCA in the response.
+	returnedCAID := types.CertAuthID{
+		Type:       types.DatabaseClientCA,
+		DomainName: clusterName.GetClusterName(),
+	}
+	caCerts, err := a.getDatabaseCACerts(ctx, returnedCAID)
+	if err != nil {
+		return nil, trace.Wrap(err, "response CACerts")
+	}
+
 	return &proto.DatabaseCertResponse{
-		Cert:    cert,
-		CACerts: services.GetTLSCerts(dbClientCA),
+		Cert:    resp.CertPEM,
+		CACerts: caCerts,
 	}, nil
 }
 
@@ -108,10 +112,11 @@ func (a *Server) generateDatabaseClientCert(ctx context.Context, req *proto.Data
 		return nil, trace.Wrap(err)
 	}
 
-	cert, err := a.generateDatabaseCert(ctx, req, dbClientCA)
+	resp, err := a.generateDatabaseCert(ctx, req, dbClientCA)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
+
 	// db clients should trust the Database Server CA when establishing
 	// connection to a database, so return that CA's certs in the response.
 	//
@@ -122,21 +127,32 @@ func (a *Server) generateDatabaseClientCert(ctx context.Context, req *proto.Data
 	if req.CertificateExtensions == proto.DatabaseCertRequest_WINDOWS_SMARTCARD {
 		returnedCAType = types.DatabaseClientCA
 	}
-
-	returnedCA, err := a.GetCertAuthority(ctx, types.CertAuthID{
+	returnedCAID := types.CertAuthID{
 		Type:       returnedCAType,
 		DomainName: clusterName.GetClusterName(),
-	}, false)
-	if err != nil {
-		return nil, trace.Wrap(err)
 	}
+	caCerts, err := a.getDatabaseCACerts(ctx, returnedCAID)
+	if err != nil {
+		return nil, trace.Wrap(err, "response CACerts")
+	}
+
 	return &proto.DatabaseCertResponse{
-		Cert:    cert,
-		CACerts: services.GetTLSCerts(returnedCA),
+		Cert:       resp.CertPEM,
+		CACerts:    caCerts,
+		TrustChain: resp.TrustChainPEM,
 	}, nil
 }
 
-func (a *Server) generateDatabaseCert(ctx context.Context, req *proto.DatabaseCertRequest, ca types.CertAuthority) ([]byte, error) {
+type generateDatabaseCertResponse struct {
+	CertPEM       []byte
+	TrustChainPEM [][]byte
+}
+
+func (a *Server) generateDatabaseCert(
+	ctx context.Context,
+	req *proto.DatabaseCertRequest,
+	ca types.CertAuthority,
+) (*generateDatabaseCertResponse, error) {
 	csr, err := tlsca.ParseCertificateRequestPEM(req.CSR)
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -145,6 +161,31 @@ func (a *Server) generateDatabaseCert(ctx context.Context, req *proto.DatabaseCe
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
+
+	var trustChain [][]byte
+	if ca.GetType() == types.DatabaseClientCA {
+		subCAResolver, err := subca.NewCAOverrideResolver(a.Cache, a.subCAEnabled)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		overrideResult, err := subCAResolver.CalculateOverride(ctx, types.CertAuthorityOverrideID{
+			ClusterName: ca.GetClusterName(),
+			CAType:      string(ca.GetType()),
+		}, subca.Certificate{PEM: caCert})
+		if err != nil {
+			return nil, trace.Wrap(err, "calculate CA override")
+		}
+
+		caCert = overrideResult.CACertificate.PEM
+
+		if len(overrideResult.CAChain) > 0 {
+			trustChain = make([][]byte, len(overrideResult.CAChain))
+			for i, cert := range overrideResult.CAChain {
+				trustChain[i] = cert.PEM
+			}
+		}
+	}
+
 	tlsCA, err := tlsca.FromCertAndSigner(caCert, signer)
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -199,7 +240,89 @@ func (a *Server) generateDatabaseCert(ctx context.Context, req *proto.DatabaseCe
 		}
 	}
 	cert, err := tlsCA.GenerateCertificate(certReq)
-	return cert, trace.Wrap(err)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return &generateDatabaseCertResponse{
+		CertPEM:       cert,
+		TrustChainPEM: trustChain,
+	}, nil
+}
+
+// getDatabaseCACerts returns the client root CAs for the specified CA
+// (ie, `resp.CACerts`).
+//
+// This method is aware of and correctly applies CA overrides.
+func (a *Server) getDatabaseCACerts(ctx context.Context, id types.CertAuthID) (certPEMs [][]byte, _ error) {
+	const loadKeys = false
+	ca, err := a.GetCertAuthority(ctx, id, loadKeys)
+	if err != nil {
+		return nil, trace.Wrap(err, "read CA")
+	}
+
+	if !a.subCAEnabled || id.Type != types.DatabaseClientCA {
+		return services.GetTLSCerts(ca), nil
+	}
+
+	// DBClientCA may be targeted by overrides. If that's the case we must use the
+	// override certificate (instead of the self-signed) whenever applicable.
+	caOverride, err := a.GetCertAuthorityOverride(ctx, types.CertAuthorityOverrideID{
+		ClusterName: id.DomainName,
+		CAType:      string(id.Type),
+	})
+	if trace.IsNotFound(err) {
+		// OK, overrides are not mandatory.
+		return services.GetTLSCerts(ca), nil
+	}
+	if err != nil {
+		return nil, trace.Wrap(err, "read CA override")
+	}
+
+	// Verify if active overrides exist, otherwise we don't need to bother with
+	// parsing.
+	hasActiveOverrides := false
+	for _, co := range caOverride.GetSpec().GetCertificateOverrides() {
+		if !co.GetDisabled() && len(co.GetCertificate()) > 0 {
+			hasActiveOverrides = true
+			break
+		}
+	}
+	if !hasActiveOverrides {
+		return services.GetTLSCerts(ca), nil
+	}
+
+	// At least one active override exists, so we'll need to parse the certs and
+	// prioritize the overrides over the self-signed.
+	publicKeyToPEM := make(map[string][]byte)
+	for i, kp := range ca.GetTrustedTLSKeyPairs() {
+		if len(kp.Cert) == 0 {
+			continue
+		}
+		cert, err := tlsca.ParseCertificatePEM(kp.Cert)
+		if err != nil {
+			return nil, trace.Wrap(err, "parse CA certificate (index %d)", i)
+		}
+		pkh := subca.HashCertificatePublicKey(cert)
+		publicKeyToPEM[pkh] = kp.Cert
+	}
+
+	parsedCAOverride, err := subca.ParseCAOverride(caOverride)
+	if err != nil {
+		return nil, trace.Wrap(err, "parse CA override")
+	}
+	for _, co := range parsedCAOverride.CertificateOverrides {
+		if co.CertificateOverride.GetDisabled() || co.Certificate == nil {
+			continue
+		}
+		publicKeyToPEM[co.PublicKey] = []byte(co.CertificateOverride.Certificate)
+	}
+
+	certPEMs = make([][]byte, 0, len(publicKeyToPEM))
+	for _, certPEM := range publicKeyToPEM {
+		certPEMs = append(certPEMs, certPEM)
+	}
+	return certPEMs, nil
 }
 
 // getCAandSigner returns correct signer and CA that should be used when generating database certificate.
@@ -237,14 +360,6 @@ func (a *Server) SignDatabaseCSR(ctx context.Context, req *proto.DatabaseCSRRequ
 	a.logger.DebugContext(ctx, "Signing database CSR for cluster", "cluster", req.ClusterName)
 
 	clusterName, err := a.GetClusterName(ctx)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-
-	hostCA, err := a.GetCertAuthority(ctx, types.CertAuthID{
-		Type:       types.HostCA,
-		DomainName: req.ClusterName,
-	}, false)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -313,9 +428,18 @@ func (a *Server) SignDatabaseCSR(ctx context.Context, req *proto.DatabaseCSRRequ
 		return nil, trace.Wrap(err)
 	}
 
+	returnedCAID := types.CertAuthID{
+		Type:       types.HostCA,
+		DomainName: req.ClusterName,
+	}
+	caCerts, err := a.getDatabaseCACerts(ctx, returnedCAID)
+	if err != nil {
+		return nil, trace.Wrap(err, "response CACerts")
+	}
+
 	return &proto.DatabaseCSRResponse{
 		Cert:    tlsCert,
-		CACerts: services.GetTLSCerts(hostCA),
+		CACerts: caCerts,
 	}, nil
 }
 

--- a/lib/auth/db.go
+++ b/lib/auth/db.go
@@ -94,6 +94,9 @@ func (a *Server) generateDatabaseServerCert(ctx context.Context, req *proto.Data
 	return &proto.DatabaseCertResponse{
 		Cert:    resp.CertPEM,
 		CACerts: caCerts,
+		// TrustChain and CAOverride not set on purpose.
+		// DatabaseCA certificates are not subject to CA overrides, only
+		// DatabaseClientCA is.
 	}, nil
 }
 

--- a/lib/auth/db.go
+++ b/lib/auth/db.go
@@ -88,7 +88,7 @@ func (a *Server) generateDatabaseServerCert(ctx context.Context, req *proto.Data
 	}
 	caCerts, err := a.getDatabaseCACerts(ctx, returnedCAID)
 	if err != nil {
-		return nil, trace.Wrap(err, "response CACerts")
+		return nil, trace.Wrap(err, "get database CA certs")
 	}
 
 	return &proto.DatabaseCertResponse{
@@ -133,7 +133,7 @@ func (a *Server) generateDatabaseClientCert(ctx context.Context, req *proto.Data
 	}
 	caCerts, err := a.getDatabaseCACerts(ctx, returnedCAID)
 	if err != nil {
-		return nil, trace.Wrap(err, "response CACerts")
+		return nil, trace.Wrap(err, "get database CA certs")
 	}
 
 	return &proto.DatabaseCertResponse{
@@ -443,7 +443,7 @@ func (a *Server) SignDatabaseCSR(ctx context.Context, req *proto.DatabaseCSRRequ
 	}
 	caCerts, err := a.getDatabaseCACerts(ctx, returnedCAID)
 	if err != nil {
-		return nil, trace.Wrap(err, "response CACerts")
+		return nil, trace.Wrap(err, "get database CA certs")
 	}
 
 	return &proto.DatabaseCSRResponse{

--- a/lib/auth/db.go
+++ b/lib/auth/db.go
@@ -320,6 +320,10 @@ func (a *Server) getDatabaseCACerts(ctx context.Context, id types.CertAuthID) (c
 		if co.CertificateOverride.GetDisabled() || co.Certificate == nil {
 			continue
 		}
+		if _, ok := publicKeyToPEM[co.PublicKey]; !ok {
+			// Ignore override, it targets an unknown/deleted CA certificate.
+			continue
+		}
 		publicKeyToPEM[co.PublicKey] = []byte(co.CertificateOverride.Certificate)
 	}
 

--- a/lib/auth/db.go
+++ b/lib/auth/db.go
@@ -170,7 +170,7 @@ func (a *Server) generateDatabaseCert(
 	var trustChain [][]byte
 	var caOverrideDetails *proto.CAOverrideCertificateDetails
 	if ca.GetType() == types.DatabaseClientCA {
-		subCAResolver, err := subca.NewCAOverrideResolver(a.Cache, a.subCAEnabled)
+		subCAResolver, err := subca.NewCAOverrideResolver(a.Cache, a.modules.IsEnterpriseBuild(), a.subCAEnabled)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}

--- a/lib/auth/db.go
+++ b/lib/auth/db.go
@@ -140,12 +140,14 @@ func (a *Server) generateDatabaseClientCert(ctx context.Context, req *proto.Data
 		Cert:       resp.CertPEM,
 		CACerts:    caCerts,
 		TrustChain: resp.TrustChainPEM,
+		CAOverride: resp.CAOverrideDetails,
 	}, nil
 }
 
 type generateDatabaseCertResponse struct {
-	CertPEM       []byte
-	TrustChainPEM [][]byte
+	CertPEM           []byte
+	TrustChainPEM     [][]byte
+	CAOverrideDetails *proto.CAOverrideCertificateDetails
 }
 
 func (a *Server) generateDatabaseCert(
@@ -163,6 +165,7 @@ func (a *Server) generateDatabaseCert(
 	}
 
 	var trustChain [][]byte
+	var caOverrideDetails *proto.CAOverrideCertificateDetails
 	if ca.GetType() == types.DatabaseClientCA {
 		subCAResolver, err := subca.NewCAOverrideResolver(a.Cache, a.subCAEnabled)
 		if err != nil {
@@ -177,6 +180,7 @@ func (a *Server) generateDatabaseCert(
 		}
 
 		caCert = overrideResult.CACertificate.PEM
+		caOverrideDetails = overrideResult.ToClientOverrideDetailsProto()
 
 		if len(overrideResult.CAChain) > 0 {
 			trustChain = make([][]byte, len(overrideResult.CAChain))
@@ -245,8 +249,9 @@ func (a *Server) generateDatabaseCert(
 	}
 
 	return &generateDatabaseCertResponse{
-		CertPEM:       cert,
-		TrustChainPEM: trustChain,
+		CertPEM:           cert,
+		TrustChainPEM:     trustChain,
+		CAOverrideDetails: caOverrideDetails,
 	}, nil
 }
 

--- a/lib/auth/db.go
+++ b/lib/auth/db.go
@@ -299,19 +299,7 @@ func (a *Server) getDatabaseCACerts(ctx context.Context, id types.CertAuthID) (c
 
 	// At least one active override exists, so we'll need to parse the certs and
 	// prioritize the overrides over the self-signed.
-	publicKeyToPEM := make(map[string][]byte)
-	for i, kp := range ca.GetTrustedTLSKeyPairs() {
-		if len(kp.Cert) == 0 {
-			continue
-		}
-		cert, err := tlsca.ParseCertificatePEM(kp.Cert)
-		if err != nil {
-			return nil, trace.Wrap(err, "parse CA certificate (index %d)", i)
-		}
-		pkh := subca.HashCertificatePublicKey(cert)
-		publicKeyToPEM[pkh] = kp.Cert
-	}
-
+	overridePublicKeyToPEM := make(map[string][]byte)
 	parsedCAOverride, err := subca.ParseCAOverride(caOverride)
 	if err != nil {
 		return nil, trace.Wrap(err, "parse CA override")
@@ -320,17 +308,29 @@ func (a *Server) getDatabaseCACerts(ctx context.Context, id types.CertAuthID) (c
 		if co.CertificateOverride.GetDisabled() || co.Certificate == nil {
 			continue
 		}
-		if _, ok := publicKeyToPEM[co.PublicKey]; !ok {
-			// Ignore override, it targets an unknown/deleted CA certificate.
-			continue
-		}
-		publicKeyToPEM[co.PublicKey] = []byte(co.CertificateOverride.Certificate)
+		overridePublicKeyToPEM[co.PublicKey] = []byte(co.CertificateOverride.Certificate)
 	}
 
-	certPEMs = make([][]byte, 0, len(publicKeyToPEM))
-	for _, certPEM := range publicKeyToPEM {
-		certPEMs = append(certPEMs, certPEM)
+	trustedKPs := ca.GetTrustedTLSKeyPairs()
+	certPEMs = make([][]byte, 0, len(overridePublicKeyToPEM))
+	for i, kp := range trustedKPs {
+		if len(kp.Cert) == 0 {
+			continue
+		}
+		cert, err := tlsca.ParseCertificatePEM(kp.Cert)
+		if err != nil {
+			return nil, trace.Wrap(err, "parse CA certificate (index %d)", i)
+		}
+		pkh := subca.HashCertificatePublicKey(cert)
+
+		// Use override certificate if applicable, otherwise use the CA.
+		if pem, ok := overridePublicKeyToPEM[pkh]; ok {
+			certPEMs = append(certPEMs, pem)
+			continue
+		}
+		certPEMs = append(certPEMs, kp.Cert)
 	}
+
 	return certPEMs, nil
 }
 

--- a/lib/auth/db_test.go
+++ b/lib/auth/db_test.go
@@ -24,17 +24,25 @@ import (
 	"crypto/x509/pkix"
 	"encoding/asn1"
 	"log/slog"
+	"slices"
+	"strings"
 	"testing"
 	"time"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/jonboulle/clockwork"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
 
-	"github.com/gravitational/teleport/api/client/proto"
+	clientpb "github.com/gravitational/teleport/api/client/proto"
+	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
+	subcav1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/subca/v1"
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/api/utils/tlsutils"
 	"github.com/gravitational/teleport/lib/auth"
 	"github.com/gravitational/teleport/lib/auth/authtest"
 	"github.com/gravitational/teleport/lib/cryptosuites"
+	subcaenv "github.com/gravitational/teleport/lib/subca/testenv"
 	"github.com/gravitational/teleport/lib/tlsca"
 )
 
@@ -105,15 +113,19 @@ func Test_getSnowflakeJWTParams(t *testing.T) {
 
 func TestDBCertSigning(t *testing.T) {
 	t.Parallel()
-	authServer, err := authtest.NewAuthServer(authtest.AuthServerConfig{
-		Clock:       clockwork.NewFakeClockAt(time.Now()),
-		ClusterName: "local.me",
+
+	clock := clockwork.NewFakeClockAt(time.Now())
+	const clusterName = "local.me"
+	testAuthServer, err := authtest.NewAuthServer(authtest.AuthServerConfig{
+		Clock:       clock,
+		ClusterName: clusterName,
 		Dir:         t.TempDir(),
 	})
 	require.NoError(t, err)
-	t.Cleanup(func() { require.NoError(t, authServer.Close()) })
+	t.Cleanup(func() { require.NoError(t, testAuthServer.Close()) })
 
-	ctx := context.Background()
+	authServer := testAuthServer.AuthServer
+	authServer.SetSubCAEnabled(true)
 
 	privateKey, err := cryptosuites.GenerateKeyWithAlgorithm(cryptosuites.RSA2048)
 	require.NoError(t, err)
@@ -126,20 +138,20 @@ func TestDBCertSigning(t *testing.T) {
 	// Set rotation to init phase. New CA will be generated.
 	// DB service should use active key to sign certificates.
 	// tctl should use new key to sign certificates.
-	err = authServer.AuthServer.RotateCertAuthority(ctx, types.RotateRequest{
+	err = authServer.RotateCertAuthority(t.Context(), types.RotateRequest{
 		Type:        types.DatabaseCA,
 		TargetPhase: types.RotationPhaseInit,
 		Mode:        types.RotationModeManual,
 	})
 	require.NoError(t, err)
-	err = authServer.AuthServer.RotateCertAuthority(ctx, types.RotateRequest{
+	err = authServer.RotateCertAuthority(t.Context(), types.RotateRequest{
 		Type:        types.DatabaseClientCA,
 		TargetPhase: types.RotationPhaseInit,
 		Mode:        types.RotationModeManual,
 	})
 	require.NoError(t, err)
 
-	dbCAs, err := authServer.AuthServer.GetCertAuthorities(ctx, types.DatabaseCA, false)
+	dbCAs, err := authServer.GetCertAuthorities(t.Context(), types.DatabaseCA, false)
 	require.NoError(t, err)
 	require.Len(t, dbCAs, 1)
 	require.Len(t, dbCAs[0].GetActiveKeys().TLS, 1)
@@ -147,7 +159,7 @@ func TestDBCertSigning(t *testing.T) {
 	activeDBCACert := dbCAs[0].GetActiveKeys().TLS[0].Cert
 	newDBCACert := dbCAs[0].GetAdditionalTrustedKeys().TLS[0].Cert
 
-	dbClientCAs, err := authServer.AuthServer.GetCertAuthorities(ctx, types.DatabaseClientCA, false)
+	dbClientCAs, err := authServer.GetCertAuthorities(t.Context(), types.DatabaseClientCA, false)
 	require.NoError(t, err)
 	require.Len(t, dbClientCAs, 1)
 	require.Len(t, dbClientCAs[0].GetActiveKeys().TLS, 1)
@@ -155,16 +167,92 @@ func TestDBCertSigning(t *testing.T) {
 	activeDBClientCACert := dbClientCAs[0].GetActiveKeys().TLS[0].Cert
 	newDBClientCACert := dbClientCAs[0].GetAdditionalTrustedKeys().TLS[0].Cert
 
-	tests := []struct {
+	// Prepare disabled CA overrides for activeDBClientCACert and
+	// newDBClientCACert, but do not create the overrides themselves yet.
+	var dbClientCAOverride *subcav1.CertAuthorityOverride
+	{
+		const chainLength = 2
+		externalChain, err := subcaenv.MakeCAChain(chainLength, &subcaenv.CAParams{
+			Clock: testAuthServer.Clock(),
+		})
+		require.NoError(t, err)
+		externalRoot := externalChain[chainLength-1]
+
+		subCAEnv := subcaenv.Env{
+			Clock:        clock,
+			ClusterName:  clusterName,
+			ExternalRoot: externalRoot,
+		}
+
+		parsedActiveDBClientCert, err := tlsutils.ParseCertificatePEM(activeDBClientCACert)
+		require.NoError(t, err)
+		parsedNewDBClientCert, err := tlsutils.ParseCertificatePEM(newDBClientCACert)
+		require.NoError(t, err)
+
+		dbClientCAOverride = &subcav1.CertAuthorityOverride{
+			Kind:    types.KindCertAuthorityOverride,
+			SubKind: string(types.DatabaseClientCA),
+			Version: types.V1,
+			Metadata: &headerv1.Metadata{
+				Name: clusterName,
+			},
+			Spec: &subcav1.CertAuthorityOverrideSpec{
+				CertificateOverrides: []*subcav1.CertificateOverride{
+					subCAEnv.NewDisabledCertificateOverride(t, parsedActiveDBClientCert, nil),
+					subCAEnv.NewDisabledCertificateOverride(t, parsedNewDBClientCert, nil),
+				},
+			},
+		}
+		// Include external root in the first override's chain.
+		dbClientCAOverride.Spec.CertificateOverrides[0].Chain = []string{string(externalRoot.CertPEM)}
+	}
+
+	// Map self-signed certificates to their overrides.
+	// Certificates absent from the map don't need to change.
+	caOverrideCertificateMap := map[string]*subcav1.CertificateOverride{
+		string(activeDBClientCACert): dbClientCAOverride.Spec.CertificateOverrides[0],
+		string(newDBClientCACert):    dbClientCAOverride.Spec.CertificateOverrides[1],
+	}
+	getOverrideAwareCertificates := func(selfSignedCert []byte, includeChain bool) (cert []byte, chain [][]byte) {
+		co, ok := caOverrideCertificateMap[string(selfSignedCert)]
+		if !ok {
+			return selfSignedCert, nil // No overrides.
+		}
+
+		if includeChain {
+			chain = make([][]byte, 0, len(co.Chain)+1)
+			chain = append(chain, []byte(co.Certificate))
+			for _, pem := range co.Chain {
+				chain = append(chain, []byte(pem))
+			}
+		}
+
+		return []byte(co.Certificate), chain
+	}
+
+	mustDeleteCAOverrides := func(t *testing.T) {
+		t.Helper()
+		err := authServer.DeleteCertAuthorityOverride(t.Context(), types.CertAuthorityOverrideID{
+			ClusterName: dbClientCAOverride.Metadata.Name,
+			CAType:      dbClientCAOverride.SubKind,
+		})
+		require.NoError(t, err, "DeleteCertAuthorityOverride errored")
+	}
+
+	type testCase struct {
 		name           string
-		requester      proto.DatabaseCertRequest_Requester
-		extensions     proto.DatabaseCertRequest_Extensions
+		requester      clientpb.DatabaseCertRequest_Requester
+		extensions     clientpb.DatabaseCertRequest_Extensions
 		crlDomain      string
 		wantCertSigner []byte
 		wantCACerts    [][]byte
 		wantKeyUsage   []x509.ExtKeyUsage
 		wantCDP        []string
-	}{
+
+		wantOverrideTrustChain [][]byte // Automatically set by CA override tests.
+	}
+
+	tests := []testCase{
 		{
 			name:           "DB service request is signed by active db client CA and trusts db CAs",
 			wantCertSigner: activeDBClientCACert,
@@ -173,30 +261,30 @@ func TestDBCertSigning(t *testing.T) {
 		},
 		{
 			name:           "tctl request is signed by new db CA and trusts db client CAs",
-			requester:      proto.DatabaseCertRequest_TCTL,
+			requester:      clientpb.DatabaseCertRequest_TCTL,
 			wantCertSigner: newDBCACert,
 			wantCACerts:    [][]byte{activeDBClientCACert, newDBClientCACert},
 			wantKeyUsage:   []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
 		},
 		{
 			name:           "DB service request for SQL Server databases is signed by active db client and trusts db client CAs",
-			extensions:     proto.DatabaseCertRequest_WINDOWS_SMARTCARD,
+			extensions:     clientpb.DatabaseCertRequest_WINDOWS_SMARTCARD,
 			wantCertSigner: activeDBClientCACert,
 			wantCACerts:    [][]byte{activeDBClientCACert, newDBClientCACert},
 			wantKeyUsage:   []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
 		},
 		{
 			name:           "tctl request for SQL Server databases is signed by new db CA and trusts db client CAs",
-			requester:      proto.DatabaseCertRequest_TCTL,
-			extensions:     proto.DatabaseCertRequest_WINDOWS_SMARTCARD,
+			requester:      clientpb.DatabaseCertRequest_TCTL,
+			extensions:     clientpb.DatabaseCertRequest_WINDOWS_SMARTCARD,
 			wantCertSigner: newDBCACert,
 			wantCACerts:    [][]byte{activeDBClientCACert, newDBClientCACert},
 			wantKeyUsage:   []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
 		},
 		{
 			name:           "tctl request for SQL Server database with CDPs",
-			requester:      proto.DatabaseCertRequest_TCTL,
-			extensions:     proto.DatabaseCertRequest_WINDOWS_SMARTCARD,
+			requester:      clientpb.DatabaseCertRequest_TCTL,
+			extensions:     clientpb.DatabaseCertRequest_WINDOWS_SMARTCARD,
 			crlDomain:      "example.com",
 			wantCertSigner: newDBCACert,
 			wantCACerts:    [][]byte{activeDBClientCACert, newDBClientCACert},
@@ -205,23 +293,77 @@ func TestDBCertSigning(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-			certResp, err := authServer.AuthServer.GenerateDatabaseCert(ctx, &proto.DatabaseCertRequest{
+		runTest := func(t *testing.T, tt *testCase) {
+			certResp, err := authServer.GenerateDatabaseCert(t.Context(), &clientpb.DatabaseCertRequest{
 				CSR:                   csr,
 				ServerName:            "localhost",
-				TTL:                   proto.Duration(time.Hour),
+				TTL:                   clientpb.Duration(time.Hour),
 				RequesterName:         tt.requester,
 				CertificateExtensions: tt.extensions,
 				CRLDomain:             tt.crlDomain,
 			})
 			require.NoError(t, err)
-			require.Equal(t, tt.wantCACerts, certResp.CACerts)
+
+			// Verify CA certs.
+			gotCAs := certResp.CACerts
+			wantCAs := slices.Clone(tt.wantCACerts)
+			slices.SortFunc(gotCAs, comparePEMs)
+			slices.SortFunc(wantCAs, comparePEMs)
+			if diff := cmp.Diff(wantCAs, gotCAs); diff != "" {
+				t.Errorf("resp.CACerts mismatch (-want +got)\n%s", diff)
+			}
+
+			// Verify trust chain.
+			if diff := cmp.Diff(tt.wantOverrideTrustChain, certResp.TrustChain); diff != "" {
+				t.Errorf("resp.TrustChain mismatch (-want +got)\n%s", diff)
+			}
 
 			// verify that the response cert is a DB CA cert.
 			mustVerifyCert(t, tt.wantCertSigner, certResp.Cert, tt.wantCDP, tt.wantKeyUsage...)
+		}
+
+		t.Run(tt.name, func(t *testing.T) {
+			// "Plain" test, no CA overrides.
+			t.Run("ok", func(t *testing.T) { runTest(t, &tt) })
+
+			t.Run("disabled_ca_overrides", func(t *testing.T) {
+				_, err := authServer.CreateCertAuthorityOverride(t.Context(), dbClientCAOverride)
+				require.NoError(t, err, "CreateCertAuthorityOverride errored")
+				t.Cleanup(func() { mustDeleteCAOverrides(t) })
+
+				// Disabled overrides have no effect on the outcome.
+				runTest(t, &tt)
+			})
+
+			t.Run("active_ca_overrides", func(t *testing.T) {
+				// Take a copy, then enable all overrides.
+				caOverride := proto.Clone(dbClientCAOverride).(*subcav1.CertAuthorityOverride)
+				for _, co := range caOverride.Spec.CertificateOverrides {
+					co.Disabled = false
+				}
+				_, err := authServer.CreateCertAuthorityOverride(t.Context(), caOverride)
+				require.NoError(t, err, "CreateCertAuthorityOverride errored")
+				t.Cleanup(func() { mustDeleteCAOverrides(t) })
+
+				// Adjust wanted cert/CAs to account for overrides.
+				wantCertSigner, wantChain := getOverrideAwareCertificates(tt.wantCertSigner, true)
+				wantCACerts := make([][]byte, len(tt.wantCACerts))
+				for i, cert := range tt.wantCACerts {
+					wantCACerts[i], _ = getOverrideAwareCertificates(cert, false)
+				}
+
+				tt := tt // Take a copy.
+				tt.wantCertSigner = wantCertSigner
+				tt.wantCACerts = wantCACerts
+				tt.wantOverrideTrustChain = wantChain
+				runTest(t, &tt)
+			})
 		})
 	}
+}
+
+func comparePEMs(a, b []byte) int {
+	return strings.Compare(string(a), string(b))
 }
 
 // mustVerifyCert is a helper func that verifies leaf cert with root cert.

--- a/lib/auth/db_test.go
+++ b/lib/auth/db_test.go
@@ -24,7 +24,6 @@ import (
 	"crypto/x509/pkix"
 	"encoding/asn1"
 	"log/slog"
-	"strings"
 	"testing"
 	"time"
 
@@ -386,10 +385,6 @@ func TestDBCertSigning(t *testing.T) {
 			})
 		})
 	}
-}
-
-func comparePEMs(a, b []byte) int {
-	return strings.Compare(string(a), string(b))
 }
 
 // mustVerifyCert is a helper func that verifies leaf cert with root cert.

--- a/lib/auth/db_test.go
+++ b/lib/auth/db_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/jonboulle/clockwork"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/testing/protocmp"
 
 	clientpb "github.com/gravitational/teleport/api/client/proto"
 	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
@@ -213,10 +214,13 @@ func TestDBCertSigning(t *testing.T) {
 		string(activeDBClientCACert): dbClientCAOverride.Spec.CertificateOverrides[0],
 		string(newDBClientCACert):    dbClientCAOverride.Spec.CertificateOverrides[1],
 	}
-	getOverrideAwareCertificates := func(selfSignedCert []byte, includeChain bool) (cert []byte, chain [][]byte) {
+	getOverrideAwareCertificates := func(
+		selfSignedCert []byte,
+		includeChain bool,
+	) (cert []byte, pubKeyHash string, chain [][]byte) {
 		co, ok := caOverrideCertificateMap[string(selfSignedCert)]
 		if !ok {
-			return selfSignedCert, nil // No overrides.
+			return selfSignedCert, "", nil // No overrides.
 		}
 
 		if includeChain {
@@ -227,7 +231,7 @@ func TestDBCertSigning(t *testing.T) {
 			}
 		}
 
-		return []byte(co.Certificate), chain
+		return []byte(co.Certificate), co.PublicKey, chain
 	}
 
 	mustDeleteCAOverrides := func(t *testing.T) {
@@ -249,7 +253,9 @@ func TestDBCertSigning(t *testing.T) {
 		wantKeyUsage   []x509.ExtKeyUsage
 		wantCDP        []string
 
-		wantOverrideTrustChain [][]byte // Automatically set by CA override tests.
+		// Automatically set by CA override tests.
+		wantOverrideTrustChain [][]byte
+		wantOverrideDetails    *clientpb.CAOverrideCertificateDetails
 	}
 
 	tests := []testCase{
@@ -318,6 +324,11 @@ func TestDBCertSigning(t *testing.T) {
 				t.Errorf("resp.TrustChain mismatch (-want +got)\n%s", diff)
 			}
 
+			// Verify override details.
+			if diff := cmp.Diff(tt.wantOverrideDetails, certResp.CAOverride, protocmp.Transform()); diff != "" {
+				t.Errorf("resp.CaOverride mismatch (-want +got)\n%s", diff)
+			}
+
 			// verify that the response cert is a DB CA cert.
 			mustVerifyCert(t, tt.wantCertSigner, certResp.Cert, tt.wantCDP, tt.wantKeyUsage...)
 		}
@@ -346,16 +357,21 @@ func TestDBCertSigning(t *testing.T) {
 				t.Cleanup(func() { mustDeleteCAOverrides(t) })
 
 				// Adjust wanted cert/CAs to account for overrides.
-				wantCertSigner, wantChain := getOverrideAwareCertificates(tt.wantCertSigner, true)
+				wantCertSigner, pubKeyHash, wantChain := getOverrideAwareCertificates(tt.wantCertSigner, true)
 				wantCACerts := make([][]byte, len(tt.wantCACerts))
 				for i, cert := range tt.wantCACerts {
-					wantCACerts[i], _ = getOverrideAwareCertificates(cert, false)
+					wantCACerts[i], _, _ = getOverrideAwareCertificates(cert, false)
 				}
 
 				tt := tt // Take a copy.
 				tt.wantCertSigner = wantCertSigner
 				tt.wantCACerts = wantCACerts
 				tt.wantOverrideTrustChain = wantChain
+				if pubKeyHash != "" {
+					tt.wantOverrideDetails = &clientpb.CAOverrideCertificateDetails{
+						PublicKeyHash: pubKeyHash,
+					}
+				}
 				runTest(t, &tt)
 			})
 		})

--- a/lib/auth/db_test.go
+++ b/lib/auth/db_test.go
@@ -41,6 +41,7 @@ import (
 	"github.com/gravitational/teleport/lib/auth"
 	"github.com/gravitational/teleport/lib/auth/authtest"
 	"github.com/gravitational/teleport/lib/cryptosuites"
+	"github.com/gravitational/teleport/lib/modules/modulestest"
 	subcaenv "github.com/gravitational/teleport/lib/subca/testenv"
 	"github.com/gravitational/teleport/lib/tlsca"
 	"github.com/gravitational/teleport/lib/tlscatest"
@@ -120,6 +121,8 @@ func TestDBCertSigning(t *testing.T) {
 		Clock:       clock,
 		ClusterName: clusterName,
 		Dir:         t.TempDir(),
+		// Required for CA override tests.
+		Modules: modulestest.EnterpriseModules(),
 	})
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, testAuthServer.Close()) })

--- a/lib/auth/db_test.go
+++ b/lib/auth/db_test.go
@@ -24,7 +24,6 @@ import (
 	"crypto/x509/pkix"
 	"encoding/asn1"
 	"log/slog"
-	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -326,11 +325,7 @@ func TestDBCertSigning(t *testing.T) {
 			require.NoError(t, err)
 
 			// Verify CA certs.
-			gotCAs := certResp.CACerts
-			wantCAs := slices.Clone(tt.wantCACerts)
-			slices.SortFunc(gotCAs, comparePEMs)
-			slices.SortFunc(wantCAs, comparePEMs)
-			if diff := cmp.Diff(wantCAs, gotCAs); diff != "" {
+			if diff := cmp.Diff(tt.wantCACerts, certResp.CACerts); diff != "" {
 				t.Errorf("resp.CACerts mismatch (-want +got)\n%s", diff)
 			}
 

--- a/lib/auth/db_test.go
+++ b/lib/auth/db_test.go
@@ -190,7 +190,7 @@ func TestDBCertSigning(t *testing.T) {
 		parsedNewDBClientCert, err := tlsutils.ParseCertificatePEM(newDBClientCACert)
 		require.NoError(t, err)
 
-		// Simulate na old, already rotated CA certificate.
+		// Simulate an old, already rotated CA certificate.
 		// It should not influence responses.
 		_, oldCertPEM, err := tlscatest.GenerateSelfSignedCA(tlscatest.GenerateCAConfig{
 			ClusterName: clusterName,

--- a/lib/auth/db_test.go
+++ b/lib/auth/db_test.go
@@ -45,6 +45,7 @@ import (
 	"github.com/gravitational/teleport/lib/cryptosuites"
 	subcaenv "github.com/gravitational/teleport/lib/subca/testenv"
 	"github.com/gravitational/teleport/lib/tlsca"
+	"github.com/gravitational/teleport/lib/tlscatest"
 )
 
 func Test_getSnowflakeJWTParams(t *testing.T) {
@@ -190,6 +191,17 @@ func TestDBCertSigning(t *testing.T) {
 		parsedNewDBClientCert, err := tlsutils.ParseCertificatePEM(newDBClientCACert)
 		require.NoError(t, err)
 
+		// Simulate na old, already rotated CA certificate.
+		// It should not influence responses.
+		_, oldCertPEM, err := tlscatest.GenerateSelfSignedCA(tlscatest.GenerateCAConfig{
+			ClusterName: clusterName,
+			NotBefore:   clock.Now().Add(-1 * time.Minute),
+			NotAfter:    clock.Now().Add(1 * time.Hour),
+		})
+		require.NoError(t, err)
+		oldCert, err := tlsutils.ParseCertificatePEM(oldCertPEM)
+		require.NoError(t, err)
+
 		dbClientCAOverride = &subcav1.CertAuthorityOverride{
 			Kind:    types.KindCertAuthorityOverride,
 			SubKind: string(types.DatabaseClientCA),
@@ -201,11 +213,14 @@ func TestDBCertSigning(t *testing.T) {
 				CertificateOverrides: []*subcav1.CertificateOverride{
 					subCAEnv.NewDisabledCertificateOverride(t, parsedActiveDBClientCert, nil),
 					subCAEnv.NewDisabledCertificateOverride(t, parsedNewDBClientCert, nil),
+					subCAEnv.NewDisabledCertificateOverride(t, oldCert, nil),
 				},
 			},
 		}
 		// Include external root in the first override's chain.
 		dbClientCAOverride.Spec.CertificateOverrides[0].Chain = []string{string(externalRoot.CertPEM)}
+		// Active the old override.
+		dbClientCAOverride.Spec.CertificateOverrides[2].Disabled = false
 	}
 
 	// Map self-signed certificates to their overrides.

--- a/lib/srv/db/auth_test.go
+++ b/lib/srv/db/auth_test.go
@@ -460,6 +460,10 @@ func (a *testAuth) WithLogger(getUpdatedLogger func(*slog.Logger) *slog.Logger) 
 	}
 }
 
+func (a *testAuth) WithSession(session *common.Session) common.Auth {
+	return a
+}
+
 func TestMongoDBAtlas(t *testing.T) {
 	t.Parallel()
 

--- a/lib/srv/db/common/audit.go
+++ b/lib/srv/db/common/audit.go
@@ -135,6 +135,14 @@ func NewAudit(config AuditConfig) (Audit, error) {
 
 // OnSessionStart emits an audit event when database session starts.
 func (a *audit) OnSessionStart(ctx context.Context, session *Session, sessionErr error) {
+	var caOverrideDetails *events.CAOverrideCertificateDetails
+	if session.caOverrideDetails != nil {
+		caOverrideDetails = &events.CAOverrideCertificateDetails{
+			Active:        true,
+			PublicKeyHash: session.caOverrideDetails.PublicKeyHash,
+		}
+	}
+
 	event := &events.DatabaseSessionStart{
 		Metadata: MakeEventMetadata(session,
 			libevents.DatabaseSessionStartEvent,
@@ -150,6 +158,7 @@ func (a *audit) OnSessionStart(ctx context.Context, session *Session, sessionErr
 		ClientMetadata: events.ClientMetadata{
 			UserAgent: session.UserAgent,
 		},
+		CAOverride: caOverrideDetails,
 	}
 	event.SetTime(session.StartTime)
 

--- a/lib/srv/db/common/auth.go
+++ b/lib/srv/db/common/auth.go
@@ -23,6 +23,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"crypto/x509/pkix"
+	"encoding/pem"
 	"fmt"
 	"log/slog"
 	"net/http"
@@ -1102,10 +1103,23 @@ func (a *dbAuth) getClientCert(ctx context.Context, expiry time.Time, databaseUs
 	if err != nil {
 		return nil, nil, trace.Wrap(err)
 	}
+
 	clientCert, err := privateKey.TLSCertificate(resp.Cert)
 	if err != nil {
 		return nil, nil, trace.Wrap(err)
 	}
+
+	for i, certPEM := range resp.TrustChain {
+		block, rest := pem.Decode(certPEM)
+		if block == nil {
+			return nil, nil, trace.BadParameter("failed to decode trust chain certificate PEM (index %d)", i)
+		}
+		if len(rest) != 0 {
+			return nil, nil, trace.BadParameter("trust chain certificate PEM has unexpected trailing data (index %d)", i)
+		}
+		clientCert.Certificate = append(clientCert.Certificate, block.Bytes)
+	}
+
 	return &clientCert, resp.CACerts, nil
 }
 

--- a/lib/srv/db/common/auth.go
+++ b/lib/srv/db/common/auth.go
@@ -290,6 +290,10 @@ func (a *dbAuth) WithLogger(getUpdatedLogger func(*slog.Logger) *slog.Logger) Au
 	return &cp
 }
 
+// WithSession returns a new instance of Auth with the given session.
+//
+// The session is automatically updated with authn data, like CA override
+// details, by the Auth instance.
 func (a *dbAuth) WithSession(session *Session) Auth {
 	cp := *a
 	cp.session = session

--- a/lib/srv/db/common/auth.go
+++ b/lib/srv/db/common/auth.go
@@ -114,6 +114,11 @@ type Auth interface {
 	// WithLogger returns a new instance of Auth with updated logger.
 	// The callback function receives the current logger and returns a new one.
 	WithLogger(getUpdatedLogger func(*slog.Logger) *slog.Logger) Auth
+	// WithSession returns a new instance of Auth with the given session.
+	//
+	// The session is automatically updated with authn data, like CA override
+	// details, by the Auth instance.
+	WithSession(session *Session) Auth
 }
 
 // AuthClient is an interface that defines a subset of libauth.Client's
@@ -239,6 +244,9 @@ type dbAuth struct {
 	// Avoiding the need to query the metadata server on every database
 	// connection.
 	azureVirtualMachineCache *utils.FnCache
+	// session is the current session being authenticated.
+	// nil in the base dbAuth instance, but set in its copies via WithSession.
+	session *Session
 }
 
 // NewAuth returns a new instance of database access authenticator.
@@ -261,23 +269,31 @@ func NewAuth(config AuthConfig) (Auth, error) {
 	}, nil
 }
 
-// NewAuthForSession returns a copy of Auth with session-specific logging.
+// NewAuthForSession returns a session-aware copy of Auth, which includes
+// session-specific logging and automatically recording CA override data.
 func NewAuthForSession(auth Auth, sessionCtx *Session) Auth {
-	return auth.WithLogger(func(logger *slog.Logger) *slog.Logger {
-		return logger.With(
-			"session_id", sessionCtx.ID,
-			"database", sessionCtx.Database.GetName(),
-		)
-	})
+	return auth.
+		WithLogger(func(logger *slog.Logger) *slog.Logger {
+			return logger.With(
+				"session_id", sessionCtx.ID,
+				"database", sessionCtx.Database.GetName(),
+			)
+		}).
+		WithSession(sessionCtx)
 }
 
 // WithLogger returns a new instance of Auth with updated logger.
 // The callback function receives the current logger and returns a new one.
 func (a *dbAuth) WithLogger(getUpdatedLogger func(*slog.Logger) *slog.Logger) Auth {
-	return &dbAuth{
-		cfg:                      a.cfg.withLogger(getUpdatedLogger),
-		azureVirtualMachineCache: a.azureVirtualMachineCache,
-	}
+	cp := *a
+	cp.cfg = a.cfg.withLogger(getUpdatedLogger)
+	return &cp
+}
+
+func (a *dbAuth) WithSession(session *Session) Auth {
+	cp := *a
+	cp.session = session
+	return &cp
 }
 
 // GetRDSAuthToken returns authorization token that will be used as a password
@@ -1102,6 +1118,10 @@ func (a *dbAuth) getClientCert(ctx context.Context, expiry time.Time, databaseUs
 	})
 	if err != nil {
 		return nil, nil, trace.Wrap(err)
+	}
+	// Save override details to the session so it appears in audit.
+	if a.session != nil {
+		a.session.caOverrideDetails = resp.CAOverride
 	}
 
 	clientCert, err := privateKey.TLSCertificate(resp.Cert)

--- a/lib/srv/db/common/auth_test.go
+++ b/lib/srv/db/common/auth_test.go
@@ -23,6 +23,7 @@ import (
 	"context"
 	"crypto/tls"
 	"crypto/x509"
+	"encoding/pem"
 	"errors"
 	"fmt"
 	"net/url"
@@ -49,6 +50,7 @@ import (
 	"github.com/gravitational/teleport/lib/cloud/mocks"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/fixtures"
+	subcaenv "github.com/gravitational/teleport/lib/subca/testenv"
 	"github.com/gravitational/teleport/lib/tlsca"
 	"github.com/gravitational/teleport/lib/utils/log/logtest"
 )
@@ -283,6 +285,84 @@ func TestAuthGetTLSConfig(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestAuthGetTLSConfig_caOverrides(t *testing.T) {
+	t.Parallel()
+
+	// Simulate an external CA chain, such as one that would be used by a CA
+	// override.
+	const chainLen = 3 // arbitrary
+	externalChain, err := subcaenv.MakeCAChain(chainLen, &subcaenv.CAParams{})
+	require.NoError(t, err)
+	ca0 := externalChain[0]
+	ca1 := externalChain[1]
+	ca2 := externalChain[2]
+
+	wantRootCAs := x509.NewCertPool()
+	require.True(t,
+		wantRootCAs.AppendCertsFromPEM(ca2.CertPEM),
+		"CertPool.AppendCertsFromPEM() errored")
+
+	// Leaf-to-root.
+	wantTrustChainDER := [][]byte{
+		ca2.Cert.Raw,
+		ca1.Cert.Raw,
+		ca0.Cert.Raw,
+	}
+
+	ca2KeyDER, err := x509.MarshalPKCS8PrivateKey(ca2.Key)
+	require.NoError(t, err)
+	ca2KeyPEM := pem.EncodeToMemory(&pem.Block{
+		Type:  "PRIVATE KEY",
+		Bytes: ca2KeyDER,
+	})
+
+	fakeAuth := &authClientMock{
+		caCertPEM: ca2.CertPEM,
+		caKeyPEM:  ca2KeyPEM,
+		trustChain: [][]byte{
+			// Leaf-to-root.
+			ca2.CertPEM,
+			ca1.CertPEM,
+			ca0.CertPEM,
+		},
+	}
+
+	auth, err := NewAuth(AuthConfig{
+		AuthClient:        fakeAuth,
+		AccessPoint:       &accessPointMock{},
+		AzureClients:      &azuretest.Clients{},
+		GCPClients:        &gcptest.Clients{},
+		AWSConfigProvider: &mocks.AWSConfigProvider{},
+	})
+	require.NoError(t, err)
+
+	db := newSelfHostedDatabase(t, "localhost:8888")
+	const user = "defaultUser"
+
+	t.Run("ok", func(t *testing.T) {
+		expiry := time.Now().Add(1 * time.Hour)
+
+		tlsConfig, err := auth.GetTLSConfig(t.Context(), expiry, db, user)
+		require.NoError(t, err)
+
+		// Verify roots.
+		assert.True(t,
+			wantRootCAs.Equal(tlsConfig.RootCAs),
+			"tlsConfig.RootCAs comparison failed, roots differ from wanted")
+
+		// Verify certificate+trust chain.
+		certs := tlsConfig.Certificates
+		require.Len(t, certs, 1, "tlsConfig.Certificates length mismatch")
+		gotChainDER := certs[0].Certificate
+		wantChainDER := make([][]byte, len(wantTrustChainDER)+1)
+		wantChainDER[0] = gotChainDER[0] // Take client cert as-is. This is the generated cert.
+		for i, der := range wantTrustChainDER {
+			wantChainDER[i+1] = der
+		}
+		assert.Equal(t, wantChainDER, gotChainDER, "tlsConfig.Certifices[0] mismatch")
+	})
 }
 
 func TestGetAzureIdentityResourceID(t *testing.T) {
@@ -1088,7 +1168,10 @@ func identityResourceID(t *testing.T, identityName string) string {
 }
 
 // authClientMock is a mock that implements AuthClient interface.
-type authClientMock struct{}
+type authClientMock struct {
+	caCertPEM, caKeyPEM []byte // defaults to fixtures.TLSCACertPEM / TLSCAKeyPEM.
+	trustChain          [][]byte
+}
 
 // GenerateDatabaseCert generates a cert using fixtures TLS CA.
 func (m *authClientMock) GenerateDatabaseCert(ctx context.Context, req *proto.DatabaseCertRequest) (*proto.DatabaseCertResponse, error) {
@@ -1099,7 +1182,16 @@ func (m *authClientMock) GenerateDatabaseCert(ctx context.Context, req *proto.Da
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	tlsCACert, err := tls.X509KeyPair([]byte(fixtures.TLSCACertPEM), []byte(fixtures.TLSCAKeyPEM))
+
+	caCert := m.caCertPEM
+	if caCert == nil {
+		caCert = []byte(fixtures.TLSCACertPEM)
+	}
+	caKey := m.caKeyPEM
+	if caKey == nil {
+		caKey = []byte(fixtures.TLSCAKeyPEM)
+	}
+	tlsCACert, err := tls.X509KeyPair(caCert, caKey)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -1121,8 +1213,9 @@ func (m *authClientMock) GenerateDatabaseCert(ctx context.Context, req *proto.Da
 	return &proto.DatabaseCertResponse{
 		Cert: cert,
 		CACerts: [][]byte{
-			[]byte(fixtures.TLSCACertPEM),
+			caCert,
 		},
+		TrustChain: m.trustChain,
 	}, nil
 }
 

--- a/lib/srv/db/common/auth_test.go
+++ b/lib/srv/db/common/auth_test.go
@@ -36,10 +36,12 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/redshift"
 	rss "github.com/aws/aws-sdk-go-v2/service/redshiftserverless"
 	"github.com/aws/aws-sdk-go-v2/service/sts"
+	googlecmp "github.com/google/go-cmp/cmp"
 	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/testing/protocmp"
 
 	"github.com/gravitational/teleport/api/client/proto"
 	"github.com/gravitational/teleport/api/types"
@@ -292,41 +294,44 @@ func TestAuthGetTLSConfig_caOverrides(t *testing.T) {
 
 	// Simulate an external CA chain, such as one that would be used by a CA
 	// override.
-	const chainLen = 3 // arbitrary
+	const chainLen = 2
 	externalChain, err := subcaenv.MakeCAChain(chainLen, &subcaenv.CAParams{})
 	require.NoError(t, err)
 	ca0 := externalChain[0]
 	ca1 := externalChain[1]
-	ca2 := externalChain[2]
 
 	wantRootCAs := x509.NewCertPool()
 	require.True(t,
-		wantRootCAs.AppendCertsFromPEM(ca2.CertPEM),
+		wantRootCAs.AppendCertsFromPEM(ca1.CertPEM),
 		"CertPool.AppendCertsFromPEM() errored")
 
 	// Leaf-to-root.
 	wantTrustChainDER := [][]byte{
-		ca2.Cert.Raw,
 		ca1.Cert.Raw,
 		ca0.Cert.Raw,
 	}
 
-	ca2KeyDER, err := x509.MarshalPKCS8PrivateKey(ca2.Key)
+	wantOverrideDetails := &proto.CAOverrideCertificateDetails{
+		// "Fake" hash.
+		PublicKeyHash: "9ce8baa9093e80846d30c4277a303b1c5d79f2432412382d1aaee3b1d05bcb21",
+	}
+
+	ca1KeyDER, err := x509.MarshalPKCS8PrivateKey(ca1.Key)
 	require.NoError(t, err)
-	ca2KeyPEM := pem.EncodeToMemory(&pem.Block{
+	ca1KeyPEM := pem.EncodeToMemory(&pem.Block{
 		Type:  "PRIVATE KEY",
-		Bytes: ca2KeyDER,
+		Bytes: ca1KeyDER,
 	})
 
 	fakeAuth := &authClientMock{
-		caCertPEM: ca2.CertPEM,
-		caKeyPEM:  ca2KeyPEM,
+		caCertPEM: ca1.CertPEM,
+		caKeyPEM:  ca1KeyPEM,
 		trustChain: [][]byte{
 			// Leaf-to-root.
-			ca2.CertPEM,
 			ca1.CertPEM,
 			ca0.CertPEM,
 		},
+		caOverride: wantOverrideDetails,
 	}
 
 	auth, err := NewAuth(AuthConfig{
@@ -343,6 +348,11 @@ func TestAuthGetTLSConfig_caOverrides(t *testing.T) {
 
 	t.Run("ok", func(t *testing.T) {
 		expiry := time.Now().Add(1 * time.Hour)
+
+		session := &Session{
+			Database: db,
+		}
+		auth := NewAuthForSession(auth, session)
 
 		tlsConfig, err := auth.GetTLSConfig(t.Context(), expiry, db, user)
 		require.NoError(t, err)
@@ -362,6 +372,12 @@ func TestAuthGetTLSConfig_caOverrides(t *testing.T) {
 			wantChainDER[i+1] = der
 		}
 		assert.Equal(t, wantChainDER, gotChainDER, "tlsConfig.Certifices[0] mismatch")
+
+		// Verify override details recorded in session.
+		wantOverrideDetails.PublicKeyHash = "banana"
+		if diff := googlecmp.Diff(wantOverrideDetails, session.caOverrideDetails, protocmp.Transform()); diff != "" {
+			t.Errorf("session.caOverrideDetails mismatch (-want +got)\n%s", diff)
+		}
 	})
 }
 
@@ -1171,6 +1187,7 @@ func identityResourceID(t *testing.T, identityName string) string {
 type authClientMock struct {
 	caCertPEM, caKeyPEM []byte // defaults to fixtures.TLSCACertPEM / TLSCAKeyPEM.
 	trustChain          [][]byte
+	caOverride          *proto.CAOverrideCertificateDetails
 }
 
 // GenerateDatabaseCert generates a cert using fixtures TLS CA.
@@ -1216,6 +1233,7 @@ func (m *authClientMock) GenerateDatabaseCert(ctx context.Context, req *proto.Da
 			caCert,
 		},
 		TrustChain: m.trustChain,
+		CAOverride: m.caOverride,
 	}, nil
 }
 

--- a/lib/srv/db/common/auth_test.go
+++ b/lib/srv/db/common/auth_test.go
@@ -331,7 +331,10 @@ func TestAuthGetTLSConfig_caOverrides(t *testing.T) {
 			ca1.CertPEM,
 			ca0.CertPEM,
 		},
-		caOverride: wantOverrideDetails,
+		// Take a defensive copy.
+		caOverride: &proto.CAOverrideCertificateDetails{
+			PublicKeyHash: wantOverrideDetails.PublicKeyHash,
+		},
 	}
 
 	auth, err := NewAuth(AuthConfig{
@@ -374,7 +377,6 @@ func TestAuthGetTLSConfig_caOverrides(t *testing.T) {
 		assert.Equal(t, wantChainDER, gotChainDER, "tlsConfig.Certifices[0] mismatch")
 
 		// Verify override details recorded in session.
-		wantOverrideDetails.PublicKeyHash = "banana"
 		if diff := googlecmp.Diff(wantOverrideDetails, session.caOverrideDetails, protocmp.Transform()); diff != "" {
 			t.Errorf("session.caOverrideDetails mismatch (-want +got)\n%s", diff)
 		}

--- a/lib/srv/db/common/session.go
+++ b/lib/srv/db/common/session.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/gravitational/trace"
 
+	"github.com/gravitational/teleport/api/client/proto"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/authz"
 	dtauthz "github.com/gravitational/teleport/lib/devicetrust/authz"
@@ -72,6 +73,10 @@ type Session struct {
 	UserAgent string
 	// ClientIP is the client IP address.
 	ClientIP string
+
+	// caOverrideDetails holds optional CA override details for the session.
+	// Assigned by the Auth implementation and used to augment audit events.
+	caOverrideDetails *proto.CAOverrideCertificateDetails
 }
 
 // String returns string representation of the session parameters.

--- a/lib/subca/ca_override_resolver.go
+++ b/lib/subca/ca_override_resolver.go
@@ -76,6 +76,7 @@ type CalculateOverrideResult struct {
 	// on the value of OverrideActive.
 	CACertificate Certificate
 	// CAChain is the certificate override trust chain, sorted leaf-to-root.
+	// Includes the override CA certificate if active.
 	CAChain []Certificate
 }
 
@@ -155,14 +156,14 @@ func calculateOverrides(
 			continue
 		}
 
-		var chain []Certificate
-		if len(co.CertificateOverride.Chain) > 0 {
-			chain = make([]Certificate, len(co.CertificateOverride.Chain))
-			for i, pem := range co.CertificateOverride.Chain {
-				chain[i] = Certificate{
-					PEM: []byte(pem),
-				}
-			}
+		chain := make([]Certificate, 0, len(co.CertificateOverride.Chain)+1)
+		chain = append(chain, Certificate{
+			PEM: []byte(co.CertificateOverride.Certificate),
+		})
+		for _, pem := range co.CertificateOverride.Chain {
+			chain = append(chain, Certificate{
+				PEM: []byte(pem),
+			})
 		}
 
 		*res = CalculateOverrideResult{

--- a/lib/subca/ca_override_resolver_test.go
+++ b/lib/subca/ca_override_resolver_test.go
@@ -229,6 +229,9 @@ func TestCAOverrideResolver_CalculateOverride(t *testing.T) {
 				OverrideActive: true,
 				PublicKeyHash:  o1.PublicKey,
 				CACertificate:  subca.Certificate{PEM: []byte(o1.Certificate)},
+				CAChain: []subca.Certificate{
+					{PEM: []byte(o1.Certificate)},
+				},
 			},
 		},
 		{
@@ -241,6 +244,7 @@ func TestCAOverrideResolver_CalculateOverride(t *testing.T) {
 				PublicKeyHash:  o4.PublicKey,
 				CACertificate:  subca.Certificate{PEM: []byte(o4.Certificate)},
 				CAChain: []subca.Certificate{
+					{PEM: []byte(o4.Certificate)},
 					{PEM: []byte(o4.Chain[0])},
 					{PEM: []byte(o4.Chain[1])},
 				},

--- a/lib/winpki/windows.go
+++ b/lib/winpki/windows.go
@@ -355,6 +355,11 @@ func generateDatabaseCredentials(ctx context.Context, auth AuthInterface, req *G
 	if err != nil {
 		return nil, nil, nil, trace.Wrap(err)
 	}
+
+	// NOTE: genResp.TrustChain is purposefully ignored here. CAs must be directly
+	// known by the NTAuth store, so there is no point in setting the trust chain.
+	// https://github.com/gravitational/teleport/blob/25f2d6c0b4e8fd6cebf5c9da014c0e344cd14fc2/rfd/0237-sub-ca-support.md?plain=1#L441-L447
+
 	certBlock, _ := pem.Decode(genResp.Cert)
 	if certBlock == nil {
 		return nil, nil, nil, trace.BadParameter("failed to decode certificate")


### PR DESCRIPTION
Calculate CA overrides when issuing DB Client CA certificates and propagate override details to audit (DatabaseSessionStart events).

https://github.com/gravitational/teleport.e/issues/7675

## Manual Test Plan
### Test Environment

Local environment build with `-tags=subca`. Redis is used as the downstream DB.

### Test Cases

DB connections are exercised on every applicable item.

- [x] DB Client CA certificates minted with self-signed CA if zero or disabled overrides
- [x] DB Client CA certificates minted with active override certificate
- [x] Active override with empty trust chain (presents only override certificate)
- [x] Active override with non-empty trust chain
- [x] Audit events include override details when appropriate