### PR TITLE
cache: expand pagination coverage for Resource153

### DIFF
--- a/lib/cache/cache_test.go
+++ b/lib/cache/cache_test.go
@@ -1396,11 +1396,11 @@ func mustCreateDatabase(t *testing.T, name, protocol, uri string) *types.Databas
 	return database
 }
 
-func newUserTasks(t *testing.T) *usertasksv1.UserTask {
+func newUserTasks(t *testing.T, name string) *usertasksv1.UserTask {
 	t.Helper()
 
 	ut, err := usertasks.NewDiscoverEC2UserTask(&usertasksv1.UserTaskSpec{
-		Integration: "my-integration",
+		Integration: "my-integration-" + name,
 		TaskType:    usertasks.TaskTypeDiscoverEC2,
 		IssueType:   "ec2-ssm-agent-not-registered",
 		State:       "OPEN",
@@ -1443,11 +1443,6 @@ func testResources[T types.Resource](t *testing.T, p *testPack, funcs testFuncs[
 
 // testResources153 is a wrapper for testing resources conforming to types.Resource153
 func testResources153[T types.Resource153](t *testing.T, p *testPack, funcs testFuncs[T], opts ...optionsFunc) {
-	// TODO(rana): Add broader support for virtual resources in list operations.
-	// Virtual resources change the total count returned by list operations,
-	// and is unexpected for the current test. When updated, we can remove virtual
-	// resource filtering and paging from lib/cache/health_check_config_test.go.
-	opts = append(opts, withSkipPaginationTest())
 	funcs.resource = defaultResource153Ops[T]()
 	testResourcesInternal(t, p, funcs, opts...)
 }
@@ -2011,7 +2006,7 @@ func TestCacheWatchKindExistsInEvents(t *testing.T) {
 		types.KindAutoUpdateAgentRollout:            types.Resource153ToLegacy(newAutoUpdateAgentRollout(t)),
 		types.KindAutoUpdateAgentReport:             types.Resource153ToLegacy(newAutoUpdateAgentReport(t, "test")),
 		types.KindAutoUpdateBotInstanceReport:       types.Resource153ToLegacy(newAutoUpdateBotInstanceReport(t)),
-		types.KindUserTask:                          types.Resource153ToLegacy(newUserTasks(t)),
+		types.KindUserTask:                          types.Resource153ToLegacy(newUserTasks(t, "test")),
 		types.KindProvisioningPrincipalState:        types.Resource153ToLegacy(newProvisioningPrincipalState("u-alice@example.com")),
 		types.KindIdentityCenterAccount:             types.Resource153ToLegacy(newIdentityCenterAccount("some_account")),
 		types.KindIdentityCenterAccountAssignment:   types.Resource153ToLegacy(newIdentityCenterAccountAssignment("some_account_assignment")),
@@ -2843,10 +2838,7 @@ func testResourcePagination[T any](t *testing.T, p *testPack, funcs testFuncs[T]
 	assert.Len(t, page3, 1)
 	assert.Empty(t, end)
 
-	var listed []T
-	listed = append(listed, page1...)
-	listed = append(listed, page2...)
-	listed = append(listed, page3...)
+	listed := slices.Concat(page1, page2, page3)
 
 	// All items have been returned as expected
 	assert.Empty(t, cmp.Diff(expected, listed, cmpOpts...))
@@ -2856,6 +2848,31 @@ func testResourcePagination[T any](t *testing.T, p *testPack, funcs testFuncs[T]
 	require.NoError(t, err)
 	assert.Len(t, pageSmall, 1)
 	assert.NotEmpty(t, pageSmallNext)
+
+	// Verify pagination behaves correctly through the upstream-fallback path
+	// when the cache is not healthy.
+	p.cache.ok = false
+
+	upstreamPage1, upstreamNext1, err := funcs.cacheList(ctx, defaultTestPageSize, "")
+	require.NoError(t, err)
+	assert.Len(t, upstreamPage1, defaultTestPageSize)
+	assert.NotEmpty(t, upstreamNext1)
+
+	upstreamPage2, upstreamNext2, err := funcs.cacheList(ctx, defaultTestPageSize, upstreamNext1)
+	require.NoError(t, err)
+	assert.Len(t, upstreamPage2, defaultTestPageSize)
+	assert.NotEmpty(t, upstreamNext2)
+	assert.NotEqual(t, upstreamPage1, upstreamPage2)
+
+	upstreamPage3, end, err := funcs.cacheList(ctx, defaultTestPageSize, upstreamNext2)
+	require.NoError(t, err)
+	assert.Len(t, upstreamPage3, 1)
+	assert.Empty(t, end)
+
+	upstreamListed := slices.Concat(upstreamPage1, upstreamPage2, upstreamPage3)
+	assert.Empty(t, cmp.Diff(expected, upstreamListed, cmpOpts...))
+
+	p.cache.ok = true
 
 	if funcs.Range != nil && funcs.cacheRange != nil {
 		out, err := stream.Collect(funcs.cacheRange(ctx, "", page2Start))

--- a/lib/cache/health_check_config_test.go
+++ b/lib/cache/health_check_config_test.go
@@ -51,23 +51,26 @@ func TestHealthCheckConfig(t *testing.T) {
 	require.NoError(t, err)
 	t.Cleanup(p.Close)
 
-	testResources153(t, p, testFuncs[*healthcheckconfigv1.HealthCheckConfig]{
-		newResource: func(name string) (*healthcheckconfigv1.HealthCheckConfig, error) {
-			return newHealthCheckConfig(t, name), nil
+	testResources153(t, p,
+		testFuncs[*healthcheckconfigv1.HealthCheckConfig]{
+			newResource: func(name string) (*healthcheckconfigv1.HealthCheckConfig, error) {
+				return newHealthCheckConfig(t, name), nil
+			},
+			create: func(ctx context.Context, cfg *healthcheckconfigv1.HealthCheckConfig) error {
+				_, err := p.healthCheckConfig.CreateHealthCheckConfig(ctx, cfg)
+				return trace.Wrap(err)
+			},
+			list: filterHealthCfgNonVirtual(p.healthCheckConfig.ListHealthCheckConfigs),
+			update: func(ctx context.Context, cfg *healthcheckconfigv1.HealthCheckConfig) error {
+				_, err := p.healthCheckConfig.UpdateHealthCheckConfig(ctx, cfg)
+				return trace.Wrap(err)
+			},
+			deleteAll: p.healthCheckConfig.DeleteAllHealthCheckConfigs,
+			cacheList: filterHealthCfgNonVirtual(p.cache.ListHealthCheckConfigs),
+			cacheGet:  p.cache.GetHealthCheckConfig,
 		},
-		create: func(ctx context.Context, cfg *healthcheckconfigv1.HealthCheckConfig) error {
-			_, err := p.healthCheckConfig.CreateHealthCheckConfig(ctx, cfg)
-			return trace.Wrap(err)
-		},
-		list: filterHealthCfgNonVirtual(p.healthCheckConfig.ListHealthCheckConfigs),
-		update: func(ctx context.Context, cfg *healthcheckconfigv1.HealthCheckConfig) error {
-			_, err := p.healthCheckConfig.UpdateHealthCheckConfig(ctx, cfg)
-			return trace.Wrap(err)
-		},
-		deleteAll: p.healthCheckConfig.DeleteAllHealthCheckConfigs,
-		cacheList: filterHealthCfgNonVirtual(p.cache.ListHealthCheckConfigs),
-		cacheGet:  p.cache.GetHealthCheckConfig,
-	})
+		withSkipPaginationTest(),
+	)
 }
 
 type listHealthCfgFunc func(ctx context.Context, pageSize int, pageToken string) ([]*healthcheckconfigv1.HealthCheckConfig, string, error)

--- a/lib/cache/summarizer_test.go
+++ b/lib/cache/summarizer_test.go
@@ -127,5 +127,5 @@ func TestRetrievalModelCache(t *testing.T) {
 		list:      singletonListAdapter(p.summarizer.GetRetrievalModel),
 		cacheList: singletonListAdapter(p.cache.GetRetrievalModel),
 		deleteAll: p.summarizer.DeleteRetrievalModel,
-	}, withSkipPaginationTest()) // skip pagination test because NetworkRestrictions is a singleton resource
+	}, withSkipPaginationTest()) // skip pagination test because RetrievalModel is a singleton resource
 }

--- a/lib/cache/user_task.go
+++ b/lib/cache/user_task.go
@@ -76,8 +76,8 @@ func (c *Cache) ListUserTasks(ctx context.Context, pageSize int64, pageToken str
 		cache:      c,
 		collection: c.collections.userTasks,
 		index:      userTaskNameIndex,
-		upstreamList: func(ctx context.Context, i int, s string) ([]*usertasksv1.UserTask, string, error) {
-			out, next, err := c.Config.UserTasks.ListUserTasks(ctx, pageSize, pageToken, filters)
+		upstreamList: func(ctx context.Context, pageSize int, pageToken string) ([]*usertasksv1.UserTask, string, error) {
+			out, next, err := c.Config.UserTasks.ListUserTasks(ctx, int64(pageSize), pageToken, filters)
 			return out, next, trace.Wrap(err)
 		},
 		nextToken: func(t *usertasksv1.UserTask) string {

--- a/lib/cache/user_task_test.go
+++ b/lib/cache/user_task_test.go
@@ -35,7 +35,7 @@ func TestUserTasks(t *testing.T) {
 
 	testResources153(t, p, testFuncs[*usertasksv1.UserTask]{
 		newResource: func(name string) (*usertasksv1.UserTask, error) {
-			return newUserTasks(t), nil
+			return newUserTasks(t, name), nil
 		},
 		create: func(ctx context.Context, item *usertasksv1.UserTask) error {
 			_, err := p.userTasks.CreateUserTask(ctx, item)
@@ -48,5 +48,5 @@ func TestUserTasks(t *testing.T) {
 			return p.cache.ListUserTasks(ctx, int64(pageLimit), pageToken, &usertasksv1.ListUserTasksFilters{})
 		},
 		deleteAll: p.userTasks.DeleteAllUserTasks,
-	}, withSkipPaginationTest())
+	})
 }

--- a/lib/cache/workload_identity_test.go
+++ b/lib/cache/workload_identity_test.go
@@ -67,12 +67,11 @@ func TestWorkloadIdentity(t *testing.T) {
 		deleteAll: func(ctx context.Context) error {
 			return p.workloadIdentity.DeleteAllWorkloadIdentities(ctx)
 		},
-
 		cacheList: func(ctx context.Context, pageSize int, pageToken string) ([]*workloadidentityv1pb.WorkloadIdentity, string, error) {
-			return p.cache.ListWorkloadIdentities(ctx, 0, "", nil)
+			return p.cache.ListWorkloadIdentities(ctx, pageSize, pageToken, nil)
 		},
 		cacheGet: p.cache.GetWorkloadIdentity,
-	}, withSkipPaginationTest())
+	})
 }
 
 // TestWorkloadIdentityCacheSorting tests that cache items are sorted.


### PR DESCRIPTION
Enable pagination tests for Resource153 cache resources by default and fix resource-specific test setup that previously skipped or bypassed pagination.

This also fixes two issues found:

UserTask upstream fallback listing honors the requested page size and token.

WorkloadIdentity cache listing forwards the page size and token instead of infinitely loading the first page.