### PR TITLE
fix: Use pointer types for generated protobuf messages

### DIFF
--- a/lib/usagereporter/teleport/audit_test.go
+++ b/lib/usagereporter/teleport/audit_test.go
@@ -319,7 +319,7 @@ func TestConvertAuditEvent(t *testing.T) {
 			actual := ConvertAuditEvent(tt.event)
 			assert.Equal(t, tt.expected, actual)
 			actualAnonymized := actual.Anonymize(anonymizer)
-			assert.Equal(t, tt.expectedAnonymized, &actualAnonymized)
+			assert.Equal(t, tt.expectedAnonymized, actualAnonymized)
 		})
 	}
 }

--- a/lib/usagereporter/teleport/types.go
+++ b/lib/usagereporter/teleport/types.go
@@ -35,19 +35,19 @@ import (
 type Anonymizable interface {
 	// Anonymize uses the given anonymizer to anonymize the event and converts
 	// it into a partially filled SubmitEventRequest.
-	Anonymize(utils.Anonymizer) prehogv1a.SubmitEventRequest
+	Anonymize(utils.Anonymizer) *prehogv1a.SubmitEventRequest
 }
 
 // UserLoginEvent is an event emitted when a user logs into Teleport,
 // potentially via SSO.
 type UserLoginEvent prehogv1a.UserLoginEvent
 
-func (u *UserLoginEvent) Anonymize(a utils.Anonymizer) prehogv1a.SubmitEventRequest {
+func (u *UserLoginEvent) Anonymize(a utils.Anonymizer) *prehogv1a.SubmitEventRequest {
 	var deviceID string
 	if u.DeviceId != "" {
 		deviceID = a.AnonymizeString(u.DeviceId)
 	}
-	return prehogv1a.SubmitEventRequest{
+	return &prehogv1a.SubmitEventRequest{
 		Event: &prehogv1a.SubmitEventRequest_UserLogin{
 			UserLogin: &prehogv1a.UserLoginEvent{
 				UserName:                 a.AnonymizeString(u.UserName),
@@ -63,8 +63,8 @@ func (u *UserLoginEvent) Anonymize(a utils.Anonymizer) prehogv1a.SubmitEventRequ
 // AccessRequestCreateEvent is emitted when Access Request is created.
 type AccessRequestCreateEvent prehogv1a.AccessRequestCreateEvent
 
-func (e *AccessRequestCreateEvent) Anonymize(a utils.Anonymizer) prehogv1a.SubmitEventRequest {
-	return prehogv1a.SubmitEventRequest{
+func (e *AccessRequestCreateEvent) Anonymize(a utils.Anonymizer) *prehogv1a.SubmitEventRequest {
+	return &prehogv1a.SubmitEventRequest{
 		Event: &prehogv1a.SubmitEventRequest_AccessRequestCreate{
 			AccessRequestCreate: &prehogv1a.AccessRequestCreateEvent{
 				UserName:      a.AnonymizeString(e.UserName),
@@ -77,8 +77,8 @@ func (e *AccessRequestCreateEvent) Anonymize(a utils.Anonymizer) prehogv1a.Submi
 // AccessRequestCreateEvent is emitted when Access Request is reviewed.
 type AccessRequestReviewEvent prehogv1a.AccessRequestReviewEvent
 
-func (e *AccessRequestReviewEvent) Anonymize(a utils.Anonymizer) prehogv1a.SubmitEventRequest {
-	return prehogv1a.SubmitEventRequest{
+func (e *AccessRequestReviewEvent) Anonymize(a utils.Anonymizer) *prehogv1a.SubmitEventRequest {
+	return &prehogv1a.SubmitEventRequest{
 		Event: &prehogv1a.SubmitEventRequest_AccessRequestReview{
 			AccessRequestReview: &prehogv1a.AccessRequestReviewEvent{
 				UserName:      a.AnonymizeString(e.UserName),
@@ -94,8 +94,8 @@ func (e *AccessRequestReviewEvent) Anonymize(a utils.Anonymizer) prehogv1a.Submi
 // potentially via SSO.
 type BotJoinEvent prehogv1a.BotJoinEvent
 
-func (u *BotJoinEvent) Anonymize(a utils.Anonymizer) prehogv1a.SubmitEventRequest {
-	return prehogv1a.SubmitEventRequest{
+func (u *BotJoinEvent) Anonymize(a utils.Anonymizer) *prehogv1a.SubmitEventRequest {
+	return &prehogv1a.SubmitEventRequest{
 		Event: &prehogv1a.SubmitEventRequest_BotJoin{
 			BotJoin: &prehogv1a.BotJoinEvent{
 				BotName:       a.AnonymizeString(u.BotName),
@@ -111,8 +111,8 @@ func (u *BotJoinEvent) Anonymize(a utils.Anonymizer) prehogv1a.SubmitEventReques
 // SSOCreateEvent is emitted when an SSO connector has been created.
 type SSOCreateEvent prehogv1a.SSOCreateEvent
 
-func (u *SSOCreateEvent) Anonymize(a utils.Anonymizer) prehogv1a.SubmitEventRequest {
-	return prehogv1a.SubmitEventRequest{
+func (u *SSOCreateEvent) Anonymize(a utils.Anonymizer) *prehogv1a.SubmitEventRequest {
+	return &prehogv1a.SubmitEventRequest{
 		Event: &prehogv1a.SubmitEventRequest_SsoCreate{
 			SsoCreate: &prehogv1a.SSOCreateEvent{
 				ConnectorType: u.ConnectorType,
@@ -125,7 +125,7 @@ func (u *SSOCreateEvent) Anonymize(a utils.Anonymizer) prehogv1a.SubmitEventRequ
 // (ssh, etc).
 type SessionStartEvent prehogv1a.SessionStartEvent
 
-func (u *SessionStartEvent) Anonymize(a utils.Anonymizer) prehogv1a.SubmitEventRequest {
+func (u *SessionStartEvent) Anonymize(a utils.Anonymizer) *prehogv1a.SubmitEventRequest {
 	sessionStart := &prehogv1a.SessionStartEvent{
 		UserName:    a.AnonymizeString(u.UserName),
 		SessionType: u.SessionType,
@@ -159,7 +159,7 @@ func (u *SessionStartEvent) Anonymize(a utils.Anonymizer) prehogv1a.SubmitEventR
 			GitService: u.Git.GitService,
 		}
 	}
-	return prehogv1a.SubmitEventRequest{
+	return &prehogv1a.SubmitEventRequest{
 		Event: &prehogv1a.SubmitEventRequest_SessionStartV2{
 			SessionStartV2: sessionStart,
 		},
@@ -170,7 +170,7 @@ func (u *SessionStartEvent) Anonymize(a utils.Anonymizer) prehogv1a.SubmitEventR
 // created.
 type ResourceCreateEvent prehogv1a.ResourceCreateEvent
 
-func (u *ResourceCreateEvent) Anonymize(a utils.Anonymizer) prehogv1a.SubmitEventRequest {
+func (u *ResourceCreateEvent) Anonymize(a utils.Anonymizer) *prehogv1a.SubmitEventRequest {
 	var discoveryConfigName string
 	if u.DiscoveryConfigName != "" {
 		discoveryConfigName = a.AnonymizeString(u.DiscoveryConfigName)
@@ -187,7 +187,7 @@ func (u *ResourceCreateEvent) Anonymize(a utils.Anonymizer) prehogv1a.SubmitEven
 			DbProtocol: db.DbProtocol,
 		}
 	}
-	return prehogv1a.SubmitEventRequest{
+	return &prehogv1a.SubmitEventRequest{
 		Event: &prehogv1a.SubmitEventRequest_ResourceCreate{
 			ResourceCreate: event,
 		},
@@ -255,8 +255,8 @@ func (u *UIIntegrationEnrollStartEvent) CheckAndSetDefaults() error {
 	return trace.Wrap(validateIntegrationEnrollMetadata(u.Metadata))
 }
 
-func (u *UIIntegrationEnrollStartEvent) Anonymize(a utils.Anonymizer) prehogv1a.SubmitEventRequest {
-	return prehogv1a.SubmitEventRequest{
+func (u *UIIntegrationEnrollStartEvent) Anonymize(a utils.Anonymizer) *prehogv1a.SubmitEventRequest {
+	return &prehogv1a.SubmitEventRequest{
 		Event: &prehogv1a.SubmitEventRequest_UiIntegrationEnrollStartEvent{
 			UiIntegrationEnrollStartEvent: &prehogv1a.UIIntegrationEnrollStartEvent{
 				Metadata: &prehogv1a.IntegrationEnrollMetadata{
@@ -276,8 +276,8 @@ func (u *UIIntegrationEnrollCompleteEvent) CheckAndSetDefaults() error {
 	return trace.Wrap(validateIntegrationEnrollMetadata(u.Metadata))
 }
 
-func (u *UIIntegrationEnrollCompleteEvent) Anonymize(a utils.Anonymizer) prehogv1a.SubmitEventRequest {
-	return prehogv1a.SubmitEventRequest{
+func (u *UIIntegrationEnrollCompleteEvent) Anonymize(a utils.Anonymizer) *prehogv1a.SubmitEventRequest {
+	return &prehogv1a.SubmitEventRequest{
 		Event: &prehogv1a.SubmitEventRequest_UiIntegrationEnrollCompleteEvent{
 			UiIntegrationEnrollCompleteEvent: &prehogv1a.UIIntegrationEnrollCompleteEvent{
 				Metadata: &prehogv1a.IntegrationEnrollMetadata{
@@ -298,8 +298,8 @@ func (u *UIIntegrationEnrollStepEvent) CheckAndSetDefaults() error {
 	return trace.Wrap(validateIntegrationEnrollMetadata(u.Metadata))
 }
 
-func (u *UIIntegrationEnrollStepEvent) Anonymize(a utils.Anonymizer) prehogv1a.SubmitEventRequest {
-	return prehogv1a.SubmitEventRequest{
+func (u *UIIntegrationEnrollStepEvent) Anonymize(a utils.Anonymizer) *prehogv1a.SubmitEventRequest {
+	return &prehogv1a.SubmitEventRequest{
 		Event: &prehogv1a.SubmitEventRequest_UiIntegrationEnrollStepEvent{
 			UiIntegrationEnrollStepEvent: &prehogv1a.UIIntegrationEnrollStepEvent{
 				Metadata: &prehogv1a.IntegrationEnrollMetadata{
@@ -325,8 +325,8 @@ func (u *UIIntegrationEnrollSectionOpenEvent) CheckAndSetDefaults() error {
 	return trace.Wrap(validateIntegrationEnrollMetadata(u.Metadata))
 }
 
-func (u *UIIntegrationEnrollSectionOpenEvent) Anonymize(a utils.Anonymizer) prehogv1a.SubmitEventRequest {
-	return prehogv1a.SubmitEventRequest{
+func (u *UIIntegrationEnrollSectionOpenEvent) Anonymize(a utils.Anonymizer) *prehogv1a.SubmitEventRequest {
+	return &prehogv1a.SubmitEventRequest{
 		Event: &prehogv1a.SubmitEventRequest_UiIntegrationEnrollSectionOpenEvent{
 			UiIntegrationEnrollSectionOpenEvent: &prehogv1a.UIIntegrationEnrollSectionOpenEvent{
 				Metadata: &prehogv1a.IntegrationEnrollMetadata{
@@ -349,8 +349,8 @@ func (u *UIIntegrationEnrollFieldCompleteEvent) CheckAndSetDefaults() error {
 	return trace.Wrap(validateIntegrationEnrollMetadata(u.Metadata))
 }
 
-func (u *UIIntegrationEnrollFieldCompleteEvent) Anonymize(a utils.Anonymizer) prehogv1a.SubmitEventRequest {
-	return prehogv1a.SubmitEventRequest{
+func (u *UIIntegrationEnrollFieldCompleteEvent) Anonymize(a utils.Anonymizer) *prehogv1a.SubmitEventRequest {
+	return &prehogv1a.SubmitEventRequest{
 		Event: &prehogv1a.SubmitEventRequest_UiIntegrationEnrollFieldCompleteEvent{
 			UiIntegrationEnrollFieldCompleteEvent: &prehogv1a.UIIntegrationEnrollFieldCompleteEvent{
 				Metadata: &prehogv1a.IntegrationEnrollMetadata{
@@ -373,8 +373,8 @@ func (u *UIIntegrationEnrollCodeCopyEvent) CheckAndSetDefaults() error {
 	return trace.Wrap(validateIntegrationEnrollMetadata(u.Metadata))
 }
 
-func (u *UIIntegrationEnrollCodeCopyEvent) Anonymize(a utils.Anonymizer) prehogv1a.SubmitEventRequest {
-	return prehogv1a.SubmitEventRequest{
+func (u *UIIntegrationEnrollCodeCopyEvent) Anonymize(a utils.Anonymizer) *prehogv1a.SubmitEventRequest {
+	return &prehogv1a.SubmitEventRequest{
 		Event: &prehogv1a.SubmitEventRequest_UiIntegrationEnrollCodeCopyEvent{
 			UiIntegrationEnrollCodeCopyEvent: &prehogv1a.UIIntegrationEnrollCodeCopyEvent{
 				Metadata: &prehogv1a.IntegrationEnrollMetadata{
@@ -397,8 +397,8 @@ func (u *UIIntegrationEnrollLinkClickEvent) CheckAndSetDefaults() error {
 	return trace.Wrap(validateIntegrationEnrollMetadata(u.Metadata))
 }
 
-func (u *UIIntegrationEnrollLinkClickEvent) Anonymize(a utils.Anonymizer) prehogv1a.SubmitEventRequest {
-	return prehogv1a.SubmitEventRequest{
+func (u *UIIntegrationEnrollLinkClickEvent) Anonymize(a utils.Anonymizer) *prehogv1a.SubmitEventRequest {
+	return &prehogv1a.SubmitEventRequest{
 		Event: &prehogv1a.SubmitEventRequest_UiIntegrationEnrollLinkClickEvent{
 			UiIntegrationEnrollLinkClickEvent: &prehogv1a.UIIntegrationEnrollLinkClickEvent{
 				Metadata: &prehogv1a.IntegrationEnrollMetadata{
@@ -416,8 +416,8 @@ func (u *UIIntegrationEnrollLinkClickEvent) Anonymize(a utils.Anonymizer) prehog
 // UIBannerClickEvent is a UI event sent when a banner is clicked.
 type UIBannerClickEvent prehogv1a.UIBannerClickEvent
 
-func (u *UIBannerClickEvent) Anonymize(a utils.Anonymizer) prehogv1a.SubmitEventRequest {
-	return prehogv1a.SubmitEventRequest{
+func (u *UIBannerClickEvent) Anonymize(a utils.Anonymizer) *prehogv1a.SubmitEventRequest {
+	return &prehogv1a.SubmitEventRequest{
 		Event: &prehogv1a.SubmitEventRequest_UiBannerClick{
 			UiBannerClick: &prehogv1a.UIBannerClickEvent{
 				UserName: a.AnonymizeString(u.UserName),
@@ -431,8 +431,8 @@ func (u *UIBannerClickEvent) Anonymize(a utils.Anonymizer) prehogv1a.SubmitEvent
 // onboarding is complete.
 type UIOnboardCompleteGoToDashboardClickEvent prehogv1a.UIOnboardCompleteGoToDashboardClickEvent
 
-func (u *UIOnboardCompleteGoToDashboardClickEvent) Anonymize(a utils.Anonymizer) prehogv1a.SubmitEventRequest {
-	return prehogv1a.SubmitEventRequest{
+func (u *UIOnboardCompleteGoToDashboardClickEvent) Anonymize(a utils.Anonymizer) *prehogv1a.SubmitEventRequest {
+	return &prehogv1a.SubmitEventRequest{
 		Event: &prehogv1a.SubmitEventRequest_UiOnboardCompleteGoToDashboardClick{
 			UiOnboardCompleteGoToDashboardClick: &prehogv1a.UIOnboardCompleteGoToDashboardClickEvent{
 				UserName: a.AnonymizeString(u.UserName),
@@ -445,8 +445,8 @@ func (u *UIOnboardCompleteGoToDashboardClickEvent) Anonymize(a utils.Anonymizer)
 // clicks the "add first resource" button.
 type UIOnboardAddFirstResourceClickEvent prehogv1a.UIOnboardAddFirstResourceClickEvent
 
-func (u *UIOnboardAddFirstResourceClickEvent) Anonymize(a utils.Anonymizer) prehogv1a.SubmitEventRequest {
-	return prehogv1a.SubmitEventRequest{
+func (u *UIOnboardAddFirstResourceClickEvent) Anonymize(a utils.Anonymizer) *prehogv1a.SubmitEventRequest {
+	return &prehogv1a.SubmitEventRequest{
 		Event: &prehogv1a.SubmitEventRequest_UiOnboardAddFirstResourceClick{
 			UiOnboardAddFirstResourceClick: &prehogv1a.UIOnboardAddFirstResourceClickEvent{
 				UserName: a.AnonymizeString(u.UserName),
@@ -459,8 +459,8 @@ func (u *UIOnboardAddFirstResourceClickEvent) Anonymize(a utils.Anonymizer) preh
 // clicks the "add first resource later" button.
 type UIOnboardAddFirstResourceLaterClickEvent prehogv1a.UIOnboardAddFirstResourceLaterClickEvent
 
-func (u *UIOnboardAddFirstResourceLaterClickEvent) Anonymize(a utils.Anonymizer) prehogv1a.SubmitEventRequest {
-	return prehogv1a.SubmitEventRequest{
+func (u *UIOnboardAddFirstResourceLaterClickEvent) Anonymize(a utils.Anonymizer) *prehogv1a.SubmitEventRequest {
+	return &prehogv1a.SubmitEventRequest{
 		Event: &prehogv1a.SubmitEventRequest_UiOnboardAddFirstResourceLaterClick{
 			UiOnboardAddFirstResourceLaterClick: &prehogv1a.UIOnboardAddFirstResourceLaterClickEvent{
 				UserName: a.AnonymizeString(u.UserName),
@@ -473,8 +473,8 @@ func (u *UIOnboardAddFirstResourceLaterClickEvent) Anonymize(a utils.Anonymizer)
 // when the user configures login credentials.
 type UIOnboardSetCredentialSubmitEvent prehogv1a.UIOnboardSetCredentialSubmitEvent
 
-func (u *UIOnboardSetCredentialSubmitEvent) Anonymize(a utils.Anonymizer) prehogv1a.SubmitEventRequest {
-	return prehogv1a.SubmitEventRequest{
+func (u *UIOnboardSetCredentialSubmitEvent) Anonymize(a utils.Anonymizer) *prehogv1a.SubmitEventRequest {
+	return &prehogv1a.SubmitEventRequest{
 		Event: &prehogv1a.SubmitEventRequest_UiOnboardSetCredentialSubmit{
 			UiOnboardSetCredentialSubmit: &prehogv1a.UIOnboardSetCredentialSubmitEvent{
 				UserName: a.AnonymizeString(u.UserName),
@@ -487,8 +487,8 @@ func (u *UIOnboardSetCredentialSubmitEvent) Anonymize(a utils.Anonymizer) prehog
 // user submit their onboarding questionnaire.
 type UIOnboardQuestionnaireSubmitEvent prehogv1a.UIOnboardQuestionnaireSubmitEvent
 
-func (u *UIOnboardQuestionnaireSubmitEvent) Anonymize(a utils.Anonymizer) prehogv1a.SubmitEventRequest {
-	return prehogv1a.SubmitEventRequest{
+func (u *UIOnboardQuestionnaireSubmitEvent) Anonymize(a utils.Anonymizer) *prehogv1a.SubmitEventRequest {
+	return &prehogv1a.SubmitEventRequest{
 		Event: &prehogv1a.SubmitEventRequest_UiOnboardQuestionnaireSubmit{
 			UiOnboardQuestionnaireSubmit: &prehogv1a.UIOnboardQuestionnaireSubmitEvent{
 				UserName: a.AnonymizeString(u.UserName),
@@ -501,8 +501,8 @@ func (u *UIOnboardQuestionnaireSubmitEvent) Anonymize(a utils.Anonymizer) prehog
 // when the MFA challenge is completed.
 type UIOnboardRegisterChallengeSubmitEvent prehogv1a.UIOnboardRegisterChallengeSubmitEvent
 
-func (u *UIOnboardRegisterChallengeSubmitEvent) Anonymize(a utils.Anonymizer) prehogv1a.SubmitEventRequest {
-	return prehogv1a.SubmitEventRequest{
+func (u *UIOnboardRegisterChallengeSubmitEvent) Anonymize(a utils.Anonymizer) *prehogv1a.SubmitEventRequest {
+	return &prehogv1a.SubmitEventRequest{
 		Event: &prehogv1a.SubmitEventRequest_UiOnboardRegisterChallengeSubmit{
 			UiOnboardRegisterChallengeSubmit: &prehogv1a.UIOnboardRegisterChallengeSubmitEvent{
 				UserName:  a.AnonymizeString(u.UserName),
@@ -516,8 +516,8 @@ func (u *UIOnboardRegisterChallengeSubmitEvent) Anonymize(a utils.Anonymizer) pr
 // UIRecoveryCodesContinueClickEvent is a UI event sent when a user configures recovery codes.
 type UIRecoveryCodesContinueClickEvent prehogv1a.UIRecoveryCodesContinueClickEvent
 
-func (u *UIRecoveryCodesContinueClickEvent) Anonymize(a utils.Anonymizer) prehogv1a.SubmitEventRequest {
-	return prehogv1a.SubmitEventRequest{
+func (u *UIRecoveryCodesContinueClickEvent) Anonymize(a utils.Anonymizer) *prehogv1a.SubmitEventRequest {
+	return &prehogv1a.SubmitEventRequest{
 		Event: &prehogv1a.SubmitEventRequest_UiRecoveryCodesContinueClick{
 			UiRecoveryCodesContinueClick: &prehogv1a.UIRecoveryCodesContinueClickEvent{
 				UserName: a.AnonymizeString(u.UserName),
@@ -529,8 +529,8 @@ func (u *UIRecoveryCodesContinueClickEvent) Anonymize(a utils.Anonymizer) prehog
 // UIRecoveryCodesCopyClickEvent is a UI event sent when a user copies recovery codes.
 type UIRecoveryCodesCopyClickEvent prehogv1a.UIRecoveryCodesCopyClickEvent
 
-func (u *UIRecoveryCodesCopyClickEvent) Anonymize(a utils.Anonymizer) prehogv1a.SubmitEventRequest {
-	return prehogv1a.SubmitEventRequest{
+func (u *UIRecoveryCodesCopyClickEvent) Anonymize(a utils.Anonymizer) *prehogv1a.SubmitEventRequest {
+	return &prehogv1a.SubmitEventRequest{
 		Event: &prehogv1a.SubmitEventRequest_UiRecoveryCodesCopyClick{
 			UiRecoveryCodesCopyClick: &prehogv1a.UIRecoveryCodesCopyClickEvent{
 				UserName: a.AnonymizeString(u.UserName),
@@ -542,8 +542,8 @@ func (u *UIRecoveryCodesCopyClickEvent) Anonymize(a utils.Anonymizer) prehogv1a.
 // UsageUIRecoveryCodesPrintClick is a UI event sent when a user prints recovery codes.
 type UsageUIRecoveryCodesPrintClick prehogv1a.UIRecoveryCodesPrintClickEvent
 
-func (u *UsageUIRecoveryCodesPrintClick) Anonymize(a utils.Anonymizer) prehogv1a.SubmitEventRequest {
-	return prehogv1a.SubmitEventRequest{
+func (u *UsageUIRecoveryCodesPrintClick) Anonymize(a utils.Anonymizer) *prehogv1a.SubmitEventRequest {
+	return &prehogv1a.SubmitEventRequest{
 		Event: &prehogv1a.SubmitEventRequest_UiRecoveryCodesPrintClick{
 			UiRecoveryCodesPrintClick: &prehogv1a.UIRecoveryCodesPrintClickEvent{
 				UserName: a.AnonymizeString(u.UserName),
@@ -555,13 +555,13 @@ func (u *UsageUIRecoveryCodesPrintClick) Anonymize(a utils.Anonymizer) prehogv1a
 // RoleCreateEvent is an event emitted when a custom role is created.
 type RoleCreateEvent prehogv1a.RoleCreateEvent
 
-func (u *RoleCreateEvent) Anonymize(a utils.Anonymizer) prehogv1a.SubmitEventRequest {
+func (u *RoleCreateEvent) Anonymize(a utils.Anonymizer) *prehogv1a.SubmitEventRequest {
 	role := u.RoleName
 	if !slices.Contains(teleport.PresetRoles, u.RoleName) {
 		role = a.AnonymizeString(u.RoleName)
 	}
 
-	return prehogv1a.SubmitEventRequest{
+	return &prehogv1a.SubmitEventRequest{
 		Event: &prehogv1a.SubmitEventRequest_RoleCreate{
 			RoleCreate: &prehogv1a.RoleCreateEvent{
 				UserName: a.AnonymizeString(u.UserName),
@@ -574,8 +574,8 @@ func (u *RoleCreateEvent) Anonymize(a utils.Anonymizer) prehogv1a.SubmitEventReq
 // BotCreateEvent is an event emitted when a Machine ID bot is created.
 type BotCreateEvent prehogv1a.BotCreateEvent
 
-func (u *BotCreateEvent) Anonymize(a utils.Anonymizer) prehogv1a.SubmitEventRequest {
-	return prehogv1a.SubmitEventRequest{
+func (u *BotCreateEvent) Anonymize(a utils.Anonymizer) *prehogv1a.SubmitEventRequest {
+	return &prehogv1a.SubmitEventRequest{
 		Event: &prehogv1a.SubmitEventRequest_BotCreate{
 			BotCreate: &prehogv1a.BotCreateEvent{
 				UserName:    a.AnonymizeString(u.UserName),
@@ -592,8 +592,8 @@ func (u *BotCreateEvent) Anonymize(a utils.Anonymizer) prehogv1a.SubmitEventRequ
 // UICreateNewRoleClickEvent is a UI event sent when a user prints recovery codes.
 type UICreateNewRoleClickEvent prehogv1a.UICreateNewRoleClickEvent
 
-func (u *UICreateNewRoleClickEvent) Anonymize(a utils.Anonymizer) prehogv1a.SubmitEventRequest {
-	return prehogv1a.SubmitEventRequest{
+func (u *UICreateNewRoleClickEvent) Anonymize(a utils.Anonymizer) *prehogv1a.SubmitEventRequest {
+	return &prehogv1a.SubmitEventRequest{
 		Event: &prehogv1a.SubmitEventRequest_UiCreateNewRoleClick{
 			UiCreateNewRoleClick: &prehogv1a.UICreateNewRoleClickEvent{
 				UserName: a.AnonymizeString(u.UserName),
@@ -605,8 +605,8 @@ func (u *UICreateNewRoleClickEvent) Anonymize(a utils.Anonymizer) prehogv1a.Subm
 // UICreateNewRoleSaveClickEvent is a UI event sent when a user prints recovery codes.
 type UICreateNewRoleSaveClickEvent prehogv1a.UICreateNewRoleSaveClickEvent
 
-func (u *UICreateNewRoleSaveClickEvent) Anonymize(a utils.Anonymizer) prehogv1a.SubmitEventRequest {
-	return prehogv1a.SubmitEventRequest{
+func (u *UICreateNewRoleSaveClickEvent) Anonymize(a utils.Anonymizer) *prehogv1a.SubmitEventRequest {
+	return &prehogv1a.SubmitEventRequest{
 		Event: &prehogv1a.SubmitEventRequest_UiCreateNewRoleSaveClick{
 			UiCreateNewRoleSaveClick: &prehogv1a.UICreateNewRoleSaveClickEvent{
 				UserName:                   a.AnonymizeString(u.UserName),
@@ -622,8 +622,8 @@ func (u *UICreateNewRoleSaveClickEvent) Anonymize(a utils.Anonymizer) prehogv1a.
 // UICreateNewRoleCancelClickEvent is a UI event sent when a user prints recovery codes.
 type UICreateNewRoleCancelClickEvent prehogv1a.UICreateNewRoleCancelClickEvent
 
-func (u *UICreateNewRoleCancelClickEvent) Anonymize(a utils.Anonymizer) prehogv1a.SubmitEventRequest {
-	return prehogv1a.SubmitEventRequest{
+func (u *UICreateNewRoleCancelClickEvent) Anonymize(a utils.Anonymizer) *prehogv1a.SubmitEventRequest {
+	return &prehogv1a.SubmitEventRequest{
 		Event: &prehogv1a.SubmitEventRequest_UiCreateNewRoleCancelClick{
 			UiCreateNewRoleCancelClick: &prehogv1a.UICreateNewRoleCancelClickEvent{
 				UserName: a.AnonymizeString(u.UserName),
@@ -635,8 +635,8 @@ func (u *UICreateNewRoleCancelClickEvent) Anonymize(a utils.Anonymizer) prehogv1
 // UICreateNewRoleViewDocumentationClickEvent is a UI event sent when a user prints recovery codes.
 type UICreateNewRoleViewDocumentationClickEvent prehogv1a.UICreateNewRoleViewDocumentationClickEvent
 
-func (u *UICreateNewRoleViewDocumentationClickEvent) Anonymize(a utils.Anonymizer) prehogv1a.SubmitEventRequest {
-	return prehogv1a.SubmitEventRequest{
+func (u *UICreateNewRoleViewDocumentationClickEvent) Anonymize(a utils.Anonymizer) *prehogv1a.SubmitEventRequest {
+	return &prehogv1a.SubmitEventRequest{
 		Event: &prehogv1a.SubmitEventRequest_UiCreateNewRoleViewDocumentationClick{
 			UiCreateNewRoleViewDocumentationClick: &prehogv1a.UICreateNewRoleViewDocumentationClickEvent{
 				UserName: a.AnonymizeString(u.UserName),
@@ -648,8 +648,8 @@ func (u *UICreateNewRoleViewDocumentationClickEvent) Anonymize(a utils.Anonymize
 // UICallToActionClickEvent is a UI event sent when a user prints recovery codes.
 type UICallToActionClickEvent prehogv1a.UICallToActionClickEvent
 
-func (u *UICallToActionClickEvent) Anonymize(a utils.Anonymizer) prehogv1a.SubmitEventRequest {
-	return prehogv1a.SubmitEventRequest{
+func (u *UICallToActionClickEvent) Anonymize(a utils.Anonymizer) *prehogv1a.SubmitEventRequest {
+	return &prehogv1a.SubmitEventRequest{
 		Event: &prehogv1a.SubmitEventRequest_UiCallToActionClickEvent{
 			UiCallToActionClickEvent: &prehogv1a.UICallToActionClickEvent{
 				Cta:      u.Cta,
@@ -662,8 +662,8 @@ func (u *UICallToActionClickEvent) Anonymize(a utils.Anonymizer) prehogv1a.Submi
 // UIPageViewEvent is a UI event emitted when a user views a page.
 type UIPageViewEvent prehogv1a.UIPageViewEvent
 
-func (u *UIPageViewEvent) Anonymize(a utils.Anonymizer) prehogv1a.SubmitEventRequest {
-	return prehogv1a.SubmitEventRequest{
+func (u *UIPageViewEvent) Anonymize(a utils.Anonymizer) *prehogv1a.SubmitEventRequest {
+	return &prehogv1a.SubmitEventRequest{
 		Event: &prehogv1a.SubmitEventRequest_UiPageView{
 			UiPageView: &prehogv1a.UIPageViewEvent{
 				UserName:    a.AnonymizeString(u.UserName),
@@ -679,8 +679,8 @@ func (u *UIPageViewEvent) Anonymize(a utils.Anonymizer) prehogv1a.SubmitEventReq
 // button in a usage reporting alert.
 type UIUsageReportingAlertCtaClickEvent prehogv1a.UIUsageReportingAlertCtaClickEvent
 
-func (u *UIUsageReportingAlertCtaClickEvent) Anonymize(a utils.Anonymizer) prehogv1a.SubmitEventRequest {
-	return prehogv1a.SubmitEventRequest{
+func (u *UIUsageReportingAlertCtaClickEvent) Anonymize(a utils.Anonymizer) *prehogv1a.SubmitEventRequest {
+	return &prehogv1a.SubmitEventRequest{
 		Event: &prehogv1a.SubmitEventRequest_UiUsageReportingAlertCtaClick{
 			UiUsageReportingAlertCtaClick: &prehogv1a.UIUsageReportingAlertCtaClickEvent{
 				UserName:    a.AnonymizeString(u.UserName),
@@ -696,7 +696,7 @@ func (u *UIUsageReportingAlertCtaClickEvent) Anonymize(a utils.Anonymizer) preho
 // issued, used to track the duration and restriction.
 type UserCertificateIssuedEvent prehogv1a.UserCertificateIssuedEvent
 
-func (u *UserCertificateIssuedEvent) Anonymize(a utils.Anonymizer) prehogv1a.SubmitEventRequest {
+func (u *UserCertificateIssuedEvent) Anonymize(a utils.Anonymizer) *prehogv1a.SubmitEventRequest {
 	e := &prehogv1a.UserCertificateIssuedEvent{
 		UserName:         a.AnonymizeString(u.UserName),
 		Ttl:              u.Ttl,
@@ -710,7 +710,7 @@ func (u *UserCertificateIssuedEvent) Anonymize(a utils.Anonymizer) prehogv1a.Sub
 	if u.BotInstanceId != "" {
 		e.BotInstanceId = a.AnonymizeString(u.BotInstanceId)
 	}
-	return prehogv1a.SubmitEventRequest{
+	return &prehogv1a.SubmitEventRequest{
 		Event: &prehogv1a.SubmitEventRequest_UserCertificateIssuedEvent{
 			UserCertificateIssuedEvent: e,
 		},
@@ -721,8 +721,8 @@ func (u *UserCertificateIssuedEvent) Anonymize(a utils.Anonymizer) prehogv1a.Sub
 // handled.
 type KubeRequestEvent prehogv1a.KubeRequestEvent
 
-func (u *KubeRequestEvent) Anonymize(a utils.Anonymizer) prehogv1a.SubmitEventRequest {
-	return prehogv1a.SubmitEventRequest{
+func (u *KubeRequestEvent) Anonymize(a utils.Anonymizer) *prehogv1a.SubmitEventRequest {
+	return &prehogv1a.SubmitEventRequest{
 		Event: &prehogv1a.SubmitEventRequest_KubeRequest{
 			KubeRequest: &prehogv1a.KubeRequestEvent{
 				UserName: a.AnonymizeString(u.UserName),
@@ -735,8 +735,8 @@ func (u *KubeRequestEvent) Anonymize(a utils.Anonymizer) prehogv1a.SubmitEventRe
 // SFTPEvent is an event emitted for each file operation in a SFTP connection.
 type SFTPEvent prehogv1a.SFTPEvent
 
-func (u *SFTPEvent) Anonymize(a utils.Anonymizer) prehogv1a.SubmitEventRequest {
-	return prehogv1a.SubmitEventRequest{
+func (u *SFTPEvent) Anonymize(a utils.Anonymizer) *prehogv1a.SubmitEventRequest {
+	return &prehogv1a.SubmitEventRequest{
 		Event: &prehogv1a.SubmitEventRequest_Sftp{
 			Sftp: &prehogv1a.SFTPEvent{
 				UserName: a.AnonymizeString(u.UserName),
@@ -750,8 +750,8 @@ func (u *SFTPEvent) Anonymize(a utils.Anonymizer) prehogv1a.SubmitEventRequest {
 // AgentMetadataEvent is an event emitted after an agent first connects to the auth server.
 type AgentMetadataEvent prehogv1a.AgentMetadataEvent
 
-func (u *AgentMetadataEvent) Anonymize(a utils.Anonymizer) prehogv1a.SubmitEventRequest {
-	return prehogv1a.SubmitEventRequest{
+func (u *AgentMetadataEvent) Anonymize(a utils.Anonymizer) *prehogv1a.SubmitEventRequest {
+	return &prehogv1a.SubmitEventRequest{
 		Event: &prehogv1a.SubmitEventRequest_AgentMetadataEvent{
 			AgentMetadataEvent: &prehogv1a.AgentMetadataEvent{
 				Version:               u.Version,
@@ -804,8 +804,8 @@ type ResourceHeartbeatEvent struct {
 	Static bool
 }
 
-func (u *ResourceHeartbeatEvent) Anonymize(a utils.Anonymizer) prehogv1a.SubmitEventRequest {
-	return prehogv1a.SubmitEventRequest{
+func (u *ResourceHeartbeatEvent) Anonymize(a utils.Anonymizer) *prehogv1a.SubmitEventRequest {
+	return &prehogv1a.SubmitEventRequest{
 		Event: &prehogv1a.SubmitEventRequest_ResourceHeartbeat{
 			ResourceHeartbeat: &prehogv1a.ResourceHeartbeatEvent{
 				ResourceName: a.AnonymizeNonEmpty(u.Name),
@@ -819,8 +819,8 @@ func (u *ResourceHeartbeatEvent) Anonymize(a utils.Anonymizer) prehogv1a.SubmitE
 // AssistCompletionEvent is an event emitted after each completion by the Assistant
 type AssistCompletionEvent prehogv1a.AssistCompletionEvent
 
-func (e *AssistCompletionEvent) Anonymize(a utils.Anonymizer) prehogv1a.SubmitEventRequest {
-	return prehogv1a.SubmitEventRequest{
+func (e *AssistCompletionEvent) Anonymize(a utils.Anonymizer) *prehogv1a.SubmitEventRequest {
+	return &prehogv1a.SubmitEventRequest{
 		Event: &prehogv1a.SubmitEventRequest_AssistCompletion{
 			AssistCompletion: &prehogv1a.AssistCompletionEvent{
 				UserName:         a.AnonymizeString(e.UserName),
@@ -836,8 +836,8 @@ func (e *AssistCompletionEvent) Anonymize(a utils.Anonymizer) prehogv1a.SubmitEv
 // EditorChangeEvent is an event emitted when the default editor is added or removed to an user
 type EditorChangeEvent prehogv1a.EditorChangeEvent
 
-func (e *EditorChangeEvent) Anonymize(a utils.Anonymizer) prehogv1a.SubmitEventRequest {
-	return prehogv1a.SubmitEventRequest{
+func (e *EditorChangeEvent) Anonymize(a utils.Anonymizer) *prehogv1a.SubmitEventRequest {
+	return &prehogv1a.SubmitEventRequest{
 		Event: &prehogv1a.SubmitEventRequest_EditorChangeEvent{
 			EditorChangeEvent: &prehogv1a.EditorChangeEvent{
 				UserName: a.AnonymizeString(e.UserName),
@@ -849,8 +849,8 @@ func (e *EditorChangeEvent) Anonymize(a utils.Anonymizer) prehogv1a.SubmitEventR
 
 type AssistExecutionEvent prehogv1a.AssistExecutionEvent
 
-func (e *AssistExecutionEvent) Anonymize(a utils.Anonymizer) prehogv1a.SubmitEventRequest {
-	return prehogv1a.SubmitEventRequest{
+func (e *AssistExecutionEvent) Anonymize(a utils.Anonymizer) *prehogv1a.SubmitEventRequest {
+	return &prehogv1a.SubmitEventRequest{
 		Event: &prehogv1a.SubmitEventRequest_AssistExecution{
 			AssistExecution: &prehogv1a.AssistExecutionEvent{
 				UserName:         a.AnonymizeString(e.UserName),
@@ -866,8 +866,8 @@ func (e *AssistExecutionEvent) Anonymize(a utils.Anonymizer) prehogv1a.SubmitEve
 
 type AssistNewConversationEvent prehogv1a.AssistNewConversationEvent
 
-func (e *AssistNewConversationEvent) Anonymize(a utils.Anonymizer) prehogv1a.SubmitEventRequest {
-	return prehogv1a.SubmitEventRequest{
+func (e *AssistNewConversationEvent) Anonymize(a utils.Anonymizer) *prehogv1a.SubmitEventRequest {
+	return &prehogv1a.SubmitEventRequest{
 		Event: &prehogv1a.SubmitEventRequest_AssistNewConversation{
 			AssistNewConversation: &prehogv1a.AssistNewConversationEvent{
 				UserName: a.AnonymizeString(e.UserName),
@@ -880,8 +880,8 @@ func (e *AssistNewConversationEvent) Anonymize(a utils.Anonymizer) prehogv1a.Sub
 type AssistAccessRequestEvent prehogv1a.AssistAccessRequestEvent
 
 // Anonymize anonymizes the event.
-func (e *AssistAccessRequestEvent) Anonymize(a utils.Anonymizer) prehogv1a.SubmitEventRequest {
-	return prehogv1a.SubmitEventRequest{
+func (e *AssistAccessRequestEvent) Anonymize(a utils.Anonymizer) *prehogv1a.SubmitEventRequest {
+	return &prehogv1a.SubmitEventRequest{
 		Event: &prehogv1a.SubmitEventRequest_AssistAccessRequest{
 			AssistAccessRequest: &prehogv1a.AssistAccessRequestEvent{
 				UserName:         a.AnonymizeString(e.UserName),
@@ -897,8 +897,8 @@ func (e *AssistAccessRequestEvent) Anonymize(a utils.Anonymizer) prehogv1a.Submi
 type AssistActionEvent prehogv1a.AssistActionEvent
 
 // Anonymize anonymizes the event.
-func (e *AssistActionEvent) Anonymize(a utils.Anonymizer) prehogv1a.SubmitEventRequest {
-	return prehogv1a.SubmitEventRequest{
+func (e *AssistActionEvent) Anonymize(a utils.Anonymizer) *prehogv1a.SubmitEventRequest {
+	return &prehogv1a.SubmitEventRequest{
 		Event: &prehogv1a.SubmitEventRequest_AssistAction{
 			AssistAction: &prehogv1a.AssistActionEvent{
 				UserName:         a.AnonymizeString(e.UserName),
@@ -914,8 +914,8 @@ func (e *AssistActionEvent) Anonymize(a utils.Anonymizer) prehogv1a.SubmitEventR
 type AccessListCreateEvent prehogv1a.AccessListCreateEvent
 
 // Anonymize anonymizes the event.
-func (e *AccessListCreateEvent) Anonymize(a utils.Anonymizer) prehogv1a.SubmitEventRequest {
-	return prehogv1a.SubmitEventRequest{
+func (e *AccessListCreateEvent) Anonymize(a utils.Anonymizer) *prehogv1a.SubmitEventRequest {
+	return &prehogv1a.SubmitEventRequest{
 		Event: &prehogv1a.SubmitEventRequest_AccessListCreate{
 			AccessListCreate: &prehogv1a.AccessListCreateEvent{
 				UserName: a.AnonymizeString(e.UserName),
@@ -930,8 +930,8 @@ func (e *AccessListCreateEvent) Anonymize(a utils.Anonymizer) prehogv1a.SubmitEv
 type AccessListUpdateEvent prehogv1a.AccessListUpdateEvent
 
 // Anonymize anonymizes the event.
-func (e *AccessListUpdateEvent) Anonymize(a utils.Anonymizer) prehogv1a.SubmitEventRequest {
-	return prehogv1a.SubmitEventRequest{
+func (e *AccessListUpdateEvent) Anonymize(a utils.Anonymizer) *prehogv1a.SubmitEventRequest {
+	return &prehogv1a.SubmitEventRequest{
 		Event: &prehogv1a.SubmitEventRequest_AccessListUpdate{
 			AccessListUpdate: &prehogv1a.AccessListUpdateEvent{
 				UserName: a.AnonymizeString(e.UserName),
@@ -946,8 +946,8 @@ func (e *AccessListUpdateEvent) Anonymize(a utils.Anonymizer) prehogv1a.SubmitEv
 type AccessListDeleteEvent prehogv1a.AccessListDeleteEvent
 
 // Anonymize anonymizes the event.
-func (e *AccessListDeleteEvent) Anonymize(a utils.Anonymizer) prehogv1a.SubmitEventRequest {
-	return prehogv1a.SubmitEventRequest{
+func (e *AccessListDeleteEvent) Anonymize(a utils.Anonymizer) *prehogv1a.SubmitEventRequest {
+	return &prehogv1a.SubmitEventRequest{
 		Event: &prehogv1a.SubmitEventRequest_AccessListDelete{
 			AccessListDelete: &prehogv1a.AccessListDeleteEvent{
 				UserName: a.AnonymizeString(e.UserName),
@@ -962,8 +962,8 @@ func (e *AccessListDeleteEvent) Anonymize(a utils.Anonymizer) prehogv1a.SubmitEv
 type AccessListMemberCreateEvent prehogv1a.AccessListMemberCreateEvent
 
 // Anonymize anonymizes the event.
-func (e *AccessListMemberCreateEvent) Anonymize(a utils.Anonymizer) prehogv1a.SubmitEventRequest {
-	return prehogv1a.SubmitEventRequest{
+func (e *AccessListMemberCreateEvent) Anonymize(a utils.Anonymizer) *prehogv1a.SubmitEventRequest {
+	return &prehogv1a.SubmitEventRequest{
 		Event: &prehogv1a.SubmitEventRequest_AccessListMemberCreate{
 			AccessListMemberCreate: &prehogv1a.AccessListMemberCreateEvent{
 				UserName:   a.AnonymizeString(e.UserName),
@@ -979,8 +979,8 @@ func (e *AccessListMemberCreateEvent) Anonymize(a utils.Anonymizer) prehogv1a.Su
 type AccessListMemberUpdateEvent prehogv1a.AccessListMemberUpdateEvent
 
 // Anonymize anonymizes the event.
-func (e *AccessListMemberUpdateEvent) Anonymize(a utils.Anonymizer) prehogv1a.SubmitEventRequest {
-	return prehogv1a.SubmitEventRequest{
+func (e *AccessListMemberUpdateEvent) Anonymize(a utils.Anonymizer) *prehogv1a.SubmitEventRequest {
+	return &prehogv1a.SubmitEventRequest{
 		Event: &prehogv1a.SubmitEventRequest_AccessListMemberUpdate{
 			AccessListMemberUpdate: &prehogv1a.AccessListMemberUpdateEvent{
 				UserName:   a.AnonymizeString(e.UserName),
@@ -996,8 +996,8 @@ func (e *AccessListMemberUpdateEvent) Anonymize(a utils.Anonymizer) prehogv1a.Su
 type AccessListMemberDeleteEvent prehogv1a.AccessListMemberDeleteEvent
 
 // Anonymize anonymizes the event.
-func (e *AccessListMemberDeleteEvent) Anonymize(a utils.Anonymizer) prehogv1a.SubmitEventRequest {
-	return prehogv1a.SubmitEventRequest{
+func (e *AccessListMemberDeleteEvent) Anonymize(a utils.Anonymizer) *prehogv1a.SubmitEventRequest {
+	return &prehogv1a.SubmitEventRequest{
 		Event: &prehogv1a.SubmitEventRequest_AccessListMemberDelete{
 			AccessListMemberDelete: &prehogv1a.AccessListMemberDeleteEvent{
 				UserName:   a.AnonymizeString(e.UserName),
@@ -1013,8 +1013,8 @@ func (e *AccessListMemberDeleteEvent) Anonymize(a utils.Anonymizer) prehogv1a.Su
 type AccessListGrantsToUserEvent prehogv1a.AccessListGrantsToUserEvent
 
 // Anonymize anonymizes the event.
-func (e *AccessListGrantsToUserEvent) Anonymize(a utils.Anonymizer) prehogv1a.SubmitEventRequest {
-	return prehogv1a.SubmitEventRequest{
+func (e *AccessListGrantsToUserEvent) Anonymize(a utils.Anonymizer) *prehogv1a.SubmitEventRequest {
+	return &prehogv1a.SubmitEventRequest{
 		Event: &prehogv1a.SubmitEventRequest_AccessListGrantsToUser{
 			AccessListGrantsToUser: &prehogv1a.AccessListGrantsToUserEvent{
 				UserName:                    a.AnonymizeString(e.UserName),
@@ -1030,8 +1030,8 @@ func (e *AccessListGrantsToUserEvent) Anonymize(a utils.Anonymizer) prehogv1a.Su
 type AccessListReviewCreateEvent prehogv1a.AccessListReviewCreateEvent
 
 // Anonymize anonymizes the event.
-func (e *AccessListReviewCreateEvent) Anonymize(a utils.Anonymizer) prehogv1a.SubmitEventRequest {
-	return prehogv1a.SubmitEventRequest{
+func (e *AccessListReviewCreateEvent) Anonymize(a utils.Anonymizer) *prehogv1a.SubmitEventRequest {
+	return &prehogv1a.SubmitEventRequest{
 		Event: &prehogv1a.SubmitEventRequest_AccessListReviewCreate{
 			AccessListReviewCreate: &prehogv1a.AccessListReviewCreateEvent{
 				UserName: a.AnonymizeString(e.UserName),
@@ -1051,8 +1051,8 @@ func (e *AccessListReviewCreateEvent) Anonymize(a utils.Anonymizer) prehogv1a.Su
 type AccessListReviewDeleteEvent prehogv1a.AccessListReviewDeleteEvent
 
 // Anonymize anonymizes the event.
-func (e *AccessListReviewDeleteEvent) Anonymize(a utils.Anonymizer) prehogv1a.SubmitEventRequest {
-	return prehogv1a.SubmitEventRequest{
+func (e *AccessListReviewDeleteEvent) Anonymize(a utils.Anonymizer) *prehogv1a.SubmitEventRequest {
+	return &prehogv1a.SubmitEventRequest{
 		Event: &prehogv1a.SubmitEventRequest_AccessListReviewDelete{
 			AccessListReviewDelete: &prehogv1a.AccessListReviewDeleteEvent{
 				UserName: a.AnonymizeString(e.UserName),
@@ -1067,8 +1067,8 @@ func (e *AccessListReviewDeleteEvent) Anonymize(a utils.Anonymizer) prehogv1a.Su
 type AccessListReviewComplianceEvent prehogv1a.AccessListReviewComplianceEvent
 
 // Anonymize anonymizes the event.
-func (e *AccessListReviewComplianceEvent) Anonymize(a utils.Anonymizer) prehogv1a.SubmitEventRequest {
-	return prehogv1a.SubmitEventRequest{
+func (e *AccessListReviewComplianceEvent) Anonymize(a utils.Anonymizer) *prehogv1a.SubmitEventRequest {
+	return &prehogv1a.SubmitEventRequest{
 		Event: &prehogv1a.SubmitEventRequest_AccessListReviewCompliance{
 			AccessListReviewCompliance: &prehogv1a.AccessListReviewComplianceEvent{
 				TotalAccessLists:      e.TotalAccessLists,
@@ -1089,8 +1089,8 @@ type UserMetadata struct {
 // DeviceAuthenticateEvent event is emitted after a successful device authentication ceremony.
 type DeviceAuthenticateEvent prehogv1a.DeviceAuthenticateEvent
 
-func (d *DeviceAuthenticateEvent) Anonymize(a utils.Anonymizer) prehogv1a.SubmitEventRequest {
-	return prehogv1a.SubmitEventRequest{
+func (d *DeviceAuthenticateEvent) Anonymize(a utils.Anonymizer) *prehogv1a.SubmitEventRequest {
+	return &prehogv1a.SubmitEventRequest{
 		Event: &prehogv1a.SubmitEventRequest_DeviceAuthenticateEvent{
 			DeviceAuthenticateEvent: &prehogv1a.DeviceAuthenticateEvent{
 				DeviceId:     a.AnonymizeString(d.DeviceId),
@@ -1104,8 +1104,8 @@ func (d *DeviceAuthenticateEvent) Anonymize(a utils.Anonymizer) prehogv1a.Submit
 // DeviceEnrollEvent event is emitted after a successful device enrollment.
 type DeviceEnrollEvent prehogv1a.DeviceEnrollEvent
 
-func (d *DeviceEnrollEvent) Anonymize(a utils.Anonymizer) prehogv1a.SubmitEventRequest {
-	return prehogv1a.SubmitEventRequest{
+func (d *DeviceEnrollEvent) Anonymize(a utils.Anonymizer) *prehogv1a.SubmitEventRequest {
+	return &prehogv1a.SubmitEventRequest{
 		Event: &prehogv1a.SubmitEventRequest_DeviceEnrollEvent{
 			DeviceEnrollEvent: &prehogv1a.DeviceEnrollEvent{
 				DeviceId:     a.AnonymizeString(d.DeviceId),
@@ -1121,8 +1121,8 @@ func (d *DeviceEnrollEvent) Anonymize(a utils.Anonymizer) prehogv1a.SubmitEventR
 // when user completes the desired CTA for the feature.
 type FeatureRecommendationEvent prehogv1a.FeatureRecommendationEvent
 
-func (e *FeatureRecommendationEvent) Anonymize(a utils.Anonymizer) prehogv1a.SubmitEventRequest {
-	return prehogv1a.SubmitEventRequest{
+func (e *FeatureRecommendationEvent) Anonymize(a utils.Anonymizer) *prehogv1a.SubmitEventRequest {
+	return &prehogv1a.SubmitEventRequest{
 		Event: &prehogv1a.SubmitEventRequest_FeatureRecommendationEvent{
 			FeatureRecommendationEvent: &prehogv1a.FeatureRecommendationEvent{
 				UserName:                    a.AnonymizeString(e.UserName),
@@ -1137,8 +1137,8 @@ func (e *FeatureRecommendationEvent) Anonymize(a utils.Anonymizer) prehogv1a.Sub
 // enterprise license.
 type LicenseLimitEvent prehogv1a.LicenseLimitEvent
 
-func (e *LicenseLimitEvent) Anonymize(a utils.Anonymizer) prehogv1a.SubmitEventRequest {
-	return prehogv1a.SubmitEventRequest{
+func (e *LicenseLimitEvent) Anonymize(a utils.Anonymizer) *prehogv1a.SubmitEventRequest {
+	return &prehogv1a.SubmitEventRequest{
 		Event: &prehogv1a.SubmitEventRequest_LicenseLimitEvent{
 			LicenseLimitEvent: &prehogv1a.LicenseLimitEvent{
 				LicenseLimit: e.LicenseLimit,
@@ -1151,8 +1151,8 @@ func (e *LicenseLimitEvent) Anonymize(a utils.Anonymizer) prehogv1a.SubmitEventR
 // in a Windows desktop session.
 type DesktopDirectoryShareEvent prehogv1a.DesktopDirectoryShareEvent
 
-func (e *DesktopDirectoryShareEvent) Anonymize(a utils.Anonymizer) prehogv1a.SubmitEventRequest {
-	return prehogv1a.SubmitEventRequest{
+func (e *DesktopDirectoryShareEvent) Anonymize(a utils.Anonymizer) *prehogv1a.SubmitEventRequest {
+	return &prehogv1a.SubmitEventRequest{
 		Event: &prehogv1a.SubmitEventRequest_DesktopDirectoryShare{
 			DesktopDirectoryShare: &prehogv1a.DesktopDirectoryShareEvent{
 				Desktop:       a.AnonymizeString(e.Desktop),
@@ -1168,8 +1168,8 @@ func (e *DesktopDirectoryShareEvent) Anonymize(a utils.Anonymizer) prehogv1a.Sub
 // desktop.
 type DesktopClipboardEvent prehogv1a.DesktopClipboardEvent
 
-func (e *DesktopClipboardEvent) Anonymize(a utils.Anonymizer) prehogv1a.SubmitEventRequest {
-	return prehogv1a.SubmitEventRequest{
+func (e *DesktopClipboardEvent) Anonymize(a utils.Anonymizer) *prehogv1a.SubmitEventRequest {
+	return &prehogv1a.SubmitEventRequest{
 		Event: &prehogv1a.SubmitEventRequest_DesktopClipboardTransfer{
 			DesktopClipboardTransfer: &prehogv1a.DesktopClipboardEvent{
 				Desktop:  a.AnonymizeString(e.Desktop),
@@ -1182,8 +1182,8 @@ func (e *DesktopClipboardEvent) Anonymize(a utils.Anonymizer) prehogv1a.SubmitEv
 type TagExecuteQueryEvent prehogv1a.TAGExecuteQueryEvent
 
 // Anonymize anonymizes the event.
-func (e *TagExecuteQueryEvent) Anonymize(a utils.Anonymizer) prehogv1a.SubmitEventRequest {
-	return prehogv1a.SubmitEventRequest{
+func (e *TagExecuteQueryEvent) Anonymize(a utils.Anonymizer) *prehogv1a.SubmitEventRequest {
+	return &prehogv1a.SubmitEventRequest{
 		Event: &prehogv1a.SubmitEventRequest_TagExecuteQuery{
 			TagExecuteQuery: &prehogv1a.TAGExecuteQueryEvent{
 				UserName:   a.AnonymizeString(e.UserName),
@@ -1199,8 +1199,8 @@ func (e *TagExecuteQueryEvent) Anonymize(a utils.Anonymizer) prehogv1a.SubmitEve
 type AccessGraphGitlabScanEvent prehogv1a.AccessGraphGitlabScanEvent
 
 // Anonymize anonymizes the event.
-func (e *AccessGraphGitlabScanEvent) Anonymize(_ utils.Anonymizer) prehogv1a.SubmitEventRequest {
-	return prehogv1a.SubmitEventRequest{
+func (e *AccessGraphGitlabScanEvent) Anonymize(_ utils.Anonymizer) *prehogv1a.SubmitEventRequest {
+	return &prehogv1a.SubmitEventRequest{
 		Event: &prehogv1a.SubmitEventRequest_AccessGraphGitlabScan{
 			AccessGraphGitlabScan: &prehogv1a.AccessGraphGitlabScanEvent{
 				TotalProjects: e.TotalProjects,
@@ -1217,8 +1217,8 @@ func (e *AccessGraphGitlabScanEvent) Anonymize(_ utils.Anonymizer) prehogv1a.Sub
 type AccessGraphSecretsScanAuthorizedKeysEvent prehogv1a.AccessGraphSecretsScanAuthorizedKeysEvent
 
 // Anonymize anonymizes the event.
-func (e *AccessGraphSecretsScanAuthorizedKeysEvent) Anonymize(a utils.Anonymizer) prehogv1a.SubmitEventRequest {
-	return prehogv1a.SubmitEventRequest{
+func (e *AccessGraphSecretsScanAuthorizedKeysEvent) Anonymize(a utils.Anonymizer) *prehogv1a.SubmitEventRequest {
+	return &prehogv1a.SubmitEventRequest{
 		Event: &prehogv1a.SubmitEventRequest_AccessGraphSecretsScanAuthorizedKeys{
 			AccessGraphSecretsScanAuthorizedKeys: &prehogv1a.AccessGraphSecretsScanAuthorizedKeysEvent{
 				HostId:    a.AnonymizeString(e.HostId),
@@ -1232,8 +1232,8 @@ func (e *AccessGraphSecretsScanAuthorizedKeysEvent) Anonymize(a utils.Anonymizer
 type AccessGraphSecretsScanSSHPrivateKeysEvent prehogv1a.AccessGraphSecretsScanSSHPrivateKeysEvent
 
 // Anonymize anonymizes the event.
-func (e *AccessGraphSecretsScanSSHPrivateKeysEvent) Anonymize(a utils.Anonymizer) prehogv1a.SubmitEventRequest {
-	return prehogv1a.SubmitEventRequest{
+func (e *AccessGraphSecretsScanSSHPrivateKeysEvent) Anonymize(a utils.Anonymizer) *prehogv1a.SubmitEventRequest {
+	return &prehogv1a.SubmitEventRequest{
 		Event: &prehogv1a.SubmitEventRequest_AccessGraphSecretsScanSshPrivateKeys{
 			AccessGraphSecretsScanSshPrivateKeys: &prehogv1a.AccessGraphSecretsScanSSHPrivateKeysEvent{
 				DeviceId:     a.AnonymizeString(e.DeviceId),
@@ -1248,8 +1248,8 @@ func (e *AccessGraphSecretsScanSSHPrivateKeysEvent) Anonymize(a utils.Anonymizer
 type AccessGraphAWSScanEvent prehogv1a.AccessGraphAWSScanEvent
 
 // Anonymize anonymizes the event.
-func (e *AccessGraphAWSScanEvent) Anonymize(_ utils.Anonymizer) prehogv1a.SubmitEventRequest {
-	return prehogv1a.SubmitEventRequest{
+func (e *AccessGraphAWSScanEvent) Anonymize(_ utils.Anonymizer) *prehogv1a.SubmitEventRequest {
+	return &prehogv1a.SubmitEventRequest{
 		Event: &prehogv1a.SubmitEventRequest_AccessGraphAwsScan{
 			AccessGraphAwsScan: &prehogv1a.AccessGraphAWSScanEvent{
 				TotalEc2Instances:  e.TotalEc2Instances,
@@ -1272,8 +1272,8 @@ func (e *AccessGraphAWSScanEvent) Anonymize(_ utils.Anonymizer) prehogv1a.Submit
 type UIAccessGraphCrownJewelDiffViewEvent prehogv1a.UIAccessGraphCrownJewelDiffViewEvent
 
 // Anonymize anonymizes the event.
-func (e *UIAccessGraphCrownJewelDiffViewEvent) Anonymize(_ utils.Anonymizer) prehogv1a.SubmitEventRequest {
-	return prehogv1a.SubmitEventRequest{
+func (e *UIAccessGraphCrownJewelDiffViewEvent) Anonymize(_ utils.Anonymizer) *prehogv1a.SubmitEventRequest {
+	return &prehogv1a.SubmitEventRequest{
 		Event: &prehogv1a.SubmitEventRequest_UiAccessGraphCrownJewelDiffView{
 			UiAccessGraphCrownJewelDiffView: &prehogv1a.UIAccessGraphCrownJewelDiffViewEvent{
 				AffectedResourceSource: e.AffectedResourceSource,
@@ -1287,8 +1287,8 @@ func (e *UIAccessGraphCrownJewelDiffViewEvent) Anonymize(_ utils.Anonymizer) pre
 type AccessGraphAccessPathChangedEvent prehogv1a.AccessGraphAccessPathChangedEvent
 
 // Anonymize anonymizes the event.
-func (e *AccessGraphAccessPathChangedEvent) Anonymize(_ utils.Anonymizer) prehogv1a.SubmitEventRequest {
-	return prehogv1a.SubmitEventRequest{
+func (e *AccessGraphAccessPathChangedEvent) Anonymize(_ utils.Anonymizer) *prehogv1a.SubmitEventRequest {
+	return &prehogv1a.SubmitEventRequest{
 		Event: &prehogv1a.SubmitEventRequest_AccessGraphAccessPathChanged{
 			AccessGraphAccessPathChanged: &prehogv1a.AccessGraphAccessPathChangedEvent{
 				AffectedResourceType:   strings.ToLower(e.AffectedResourceType),
@@ -1302,8 +1302,8 @@ func (e *AccessGraphAccessPathChangedEvent) Anonymize(_ utils.Anonymizer) prehog
 type AccessGraphCrownJewelCreateEvent prehogv1a.AccessGraphCrownJewelCreateEvent
 
 // Anonymize anonymizes the event.
-func (e *AccessGraphCrownJewelCreateEvent) Anonymize(_ utils.Anonymizer) prehogv1a.SubmitEventRequest {
-	return prehogv1a.SubmitEventRequest{
+func (e *AccessGraphCrownJewelCreateEvent) Anonymize(_ utils.Anonymizer) *prehogv1a.SubmitEventRequest {
+	return &prehogv1a.SubmitEventRequest{
 		Event: &prehogv1a.SubmitEventRequest_AccessGraphCrownJewelCreate{
 			AccessGraphCrownJewelCreate: &prehogv1a.AccessGraphCrownJewelCreateEvent{},
 		},
@@ -1318,8 +1318,8 @@ type ExternalAuditStorageAuthenticateEvent prehogv1a.ExternalAuditStorageAuthent
 
 // Anonymize anonymizes the event. Since there is nothing to anonymize, it
 // really just wraps itself in a [prehogv1a.SubmitEventRequest].
-func (e *ExternalAuditStorageAuthenticateEvent) Anonymize(a utils.Anonymizer) prehogv1a.SubmitEventRequest {
-	return prehogv1a.SubmitEventRequest{
+func (e *ExternalAuditStorageAuthenticateEvent) Anonymize(a utils.Anonymizer) *prehogv1a.SubmitEventRequest {
+	return &prehogv1a.SubmitEventRequest{
 		Event: &prehogv1a.SubmitEventRequest_ExternalAuditStorageAuthenticate{
 			ExternalAuditStorageAuthenticate: &prehogv1a.ExternalAuditStorageAuthenticateEvent{},
 		},
@@ -1331,8 +1331,8 @@ type SecurityReportGetResultEvent prehogv1a.SecurityReportGetResultEvent
 
 // Anonymize anonymizes the event. Since there is nothing to anonymize, it
 // really just wraps itself in a [prehogv1a.SubmitEventRequest].
-func (e *SecurityReportGetResultEvent) Anonymize(a utils.Anonymizer) prehogv1a.SubmitEventRequest {
-	return prehogv1a.SubmitEventRequest{
+func (e *SecurityReportGetResultEvent) Anonymize(a utils.Anonymizer) *prehogv1a.SubmitEventRequest {
+	return &prehogv1a.SubmitEventRequest{
 		Event: &prehogv1a.SubmitEventRequest_SecurityReportGetResult{
 			SecurityReportGetResult: &prehogv1a.SecurityReportGetResultEvent{
 				UserName: a.AnonymizeString(e.UserName),
@@ -1348,8 +1348,8 @@ type AuditQueryRunEvent prehogv1a.AuditQueryRunEvent
 
 // Anonymize anonymizes the event. Since there is nothing to anonymize, it
 // really just wraps itself in a [prehogv1a.SubmitEventRequest].
-func (e *AuditQueryRunEvent) Anonymize(a utils.Anonymizer) prehogv1a.SubmitEventRequest {
-	return prehogv1a.SubmitEventRequest{
+func (e *AuditQueryRunEvent) Anonymize(a utils.Anonymizer) *prehogv1a.SubmitEventRequest {
+	return &prehogv1a.SubmitEventRequest{
 		Event: &prehogv1a.SubmitEventRequest_AuditQueryRun{
 			AuditQueryRun: &prehogv1a.AuditQueryRunEvent{
 				UserName:  a.AnonymizeString(e.UserName),
@@ -1364,8 +1364,8 @@ func (e *AuditQueryRunEvent) Anonymize(a utils.Anonymizer) prehogv1a.SubmitEvent
 type DiscoveryFetchEvent prehogv1a.DiscoveryFetchEvent
 
 // Anonymize anonymizes the event.
-func (e *DiscoveryFetchEvent) Anonymize(a utils.Anonymizer) prehogv1a.SubmitEventRequest {
-	return prehogv1a.SubmitEventRequest{
+func (e *DiscoveryFetchEvent) Anonymize(a utils.Anonymizer) *prehogv1a.SubmitEventRequest {
+	return &prehogv1a.SubmitEventRequest{
 		Event: &prehogv1a.SubmitEventRequest_DiscoveryFetchEvent{
 			DiscoveryFetchEvent: &prehogv1a.DiscoveryFetchEvent{
 				CloudProvider: e.CloudProvider,
@@ -1379,8 +1379,8 @@ func (e *DiscoveryFetchEvent) Anonymize(a utils.Anonymizer) prehogv1a.SubmitEven
 type MFAAuthenticationEvent prehogv1a.MFAAuthenticationEvent
 
 // Anonymize anonymizes the event.
-func (e *MFAAuthenticationEvent) Anonymize(a utils.Anonymizer) prehogv1a.SubmitEventRequest {
-	return prehogv1a.SubmitEventRequest{
+func (e *MFAAuthenticationEvent) Anonymize(a utils.Anonymizer) *prehogv1a.SubmitEventRequest {
+	return &prehogv1a.SubmitEventRequest{
 		Event: &prehogv1a.SubmitEventRequest_MfaAuthenticationEvent{
 			MfaAuthenticationEvent: &prehogv1a.MFAAuthenticationEvent{
 				UserName:          a.AnonymizeString(e.UserName),
@@ -1396,8 +1396,8 @@ func (e *MFAAuthenticationEvent) Anonymize(a utils.Anonymizer) prehogv1a.SubmitE
 type OktaAccessListSyncEvent prehogv1a.OktaAccessListSyncEvent
 
 // Anonymize anonymizes the event.
-func (u *OktaAccessListSyncEvent) Anonymize(a utils.Anonymizer) prehogv1a.SubmitEventRequest {
-	return prehogv1a.SubmitEventRequest{
+func (u *OktaAccessListSyncEvent) Anonymize(a utils.Anonymizer) *prehogv1a.SubmitEventRequest {
+	return &prehogv1a.SubmitEventRequest{
 		Event: &prehogv1a.SubmitEventRequest_OktaAccessListSync{
 			OktaAccessListSync: &prehogv1a.OktaAccessListSyncEvent{
 				NumAppFilters:        u.NumAppFilters,
@@ -1416,7 +1416,7 @@ func (u *OktaAccessListSyncEvent) Anonymize(a utils.Anonymizer) prehogv1a.Submit
 type DatabaseUserCreatedEvent prehogv1a.DatabaseUserCreatedEvent
 
 // Anonymize anonymizes the event.
-func (u *DatabaseUserCreatedEvent) Anonymize(a utils.Anonymizer) prehogv1a.SubmitEventRequest {
+func (u *DatabaseUserCreatedEvent) Anonymize(a utils.Anonymizer) *prehogv1a.SubmitEventRequest {
 	event := &prehogv1a.DatabaseUserCreatedEvent{
 		UserName: a.AnonymizeString(u.UserName),
 		NumRoles: u.NumRoles,
@@ -1430,7 +1430,7 @@ func (u *DatabaseUserCreatedEvent) Anonymize(a utils.Anonymizer) prehogv1a.Submi
 		}
 	}
 
-	return prehogv1a.SubmitEventRequest{
+	return &prehogv1a.SubmitEventRequest{
 		Event: &prehogv1a.SubmitEventRequest_DatabaseUserCreated{
 			DatabaseUserCreated: event,
 		},
@@ -1441,8 +1441,8 @@ func (u *DatabaseUserCreatedEvent) Anonymize(a utils.Anonymizer) prehogv1a.Submi
 type DatabaseUserPermissionsUpdateEvent prehogv1a.DatabaseUserPermissionsUpdateEvent
 
 // Anonymize anonymizes the event.
-func (u *DatabaseUserPermissionsUpdateEvent) Anonymize(a utils.Anonymizer) prehogv1a.SubmitEventRequest {
-	return prehogv1a.SubmitEventRequest{
+func (u *DatabaseUserPermissionsUpdateEvent) Anonymize(a utils.Anonymizer) *prehogv1a.SubmitEventRequest {
+	return &prehogv1a.SubmitEventRequest{
 		Event: &prehogv1a.SubmitEventRequest_DatabaseUserPermissionsUpdated{
 			DatabaseUserPermissionsUpdated: &prehogv1a.DatabaseUserPermissionsUpdateEvent{
 				UserName:             a.AnonymizeString(u.UserName),
@@ -1458,7 +1458,7 @@ func (u *DatabaseUserPermissionsUpdateEvent) Anonymize(a utils.Anonymizer) preho
 // issued.
 type SPIFFESVIDIssuedEvent prehogv1a.SPIFFESVIDIssuedEvent
 
-func (u *SPIFFESVIDIssuedEvent) Anonymize(a utils.Anonymizer) prehogv1a.SubmitEventRequest {
+func (u *SPIFFESVIDIssuedEvent) Anonymize(a utils.Anonymizer) *prehogv1a.SubmitEventRequest {
 	e := &prehogv1a.SPIFFESVIDIssuedEvent{
 		UserName:     a.AnonymizeString(u.UserName),
 		UserKind:     u.UserKind,
@@ -1470,7 +1470,7 @@ func (u *SPIFFESVIDIssuedEvent) Anonymize(a utils.Anonymizer) prehogv1a.SubmitEv
 	if u.BotInstanceId != "" {
 		e.BotInstanceId = a.AnonymizeString(u.BotInstanceId)
 	}
-	return prehogv1a.SubmitEventRequest{
+	return &prehogv1a.SubmitEventRequest{
 		Event: &prehogv1a.SubmitEventRequest_SpiffeSvidIssued{
 			SpiffeSvidIssued: e,
 		},
@@ -1480,12 +1480,12 @@ func (u *SPIFFESVIDIssuedEvent) Anonymize(a utils.Anonymizer) prehogv1a.SubmitEv
 // UserTaskStateEvent is an event emitted when the state of a User Task changes.
 type UserTaskStateEvent prehogv1a.UserTaskStateEvent
 
-func (u *UserTaskStateEvent) Anonymize(a utils.Anonymizer) prehogv1a.SubmitEventRequest {
+func (u *UserTaskStateEvent) Anonymize(a utils.Anonymizer) *prehogv1a.SubmitEventRequest {
 	var discoveryConfigName string
 	if u.DiscoveryConfigName != "" {
 		discoveryConfigName = a.AnonymizeString(u.DiscoveryConfigName)
 	}
-	return prehogv1a.SubmitEventRequest{
+	return &prehogv1a.SubmitEventRequest{
 		Event: &prehogv1a.SubmitEventRequest_UserTaskState{
 			UserTaskState: &prehogv1a.UserTaskStateEvent{
 				TaskType:            u.TaskType,
@@ -1502,8 +1502,8 @@ func (u *UserTaskStateEvent) Anonymize(a utils.Anonymizer) prehogv1a.SubmitEvent
 // a session recording.
 type SessionRecordingAccessEvent prehogv1a.SessionRecordingAccessEvent
 
-func (s *SessionRecordingAccessEvent) Anonymize(a utils.Anonymizer) prehogv1a.SubmitEventRequest {
-	return prehogv1a.SubmitEventRequest{
+func (s *SessionRecordingAccessEvent) Anonymize(a utils.Anonymizer) *prehogv1a.SubmitEventRequest {
+	return &prehogv1a.SubmitEventRequest{
 		Event: &prehogv1a.SubmitEventRequest_SessionRecordingAccess{
 			SessionRecordingAccess: &prehogv1a.SessionRecordingAccessEvent{
 				SessionType: s.SessionType,
@@ -2218,8 +2218,8 @@ func ConvertUsageEvent(event *usageeventsv1.UsageEventOneOf, userMD UserMetadata
 type SessionSummaryAccessEvent prehogv1a.SessionSummaryAccessEvent
 
 // Anonymize anonymizes the event.
-func (e *SessionSummaryAccessEvent) Anonymize(a utils.Anonymizer) prehogv1a.SubmitEventRequest {
-	return prehogv1a.SubmitEventRequest{
+func (e *SessionSummaryAccessEvent) Anonymize(a utils.Anonymizer) *prehogv1a.SubmitEventRequest {
+	return &prehogv1a.SubmitEventRequest{
 		Event: &prehogv1a.SubmitEventRequest_SessionSummaryAccessEvent{
 			SessionSummaryAccessEvent: &prehogv1a.SessionSummaryAccessEvent{
 				UserName:     a.AnonymizeString(e.UserName),
@@ -2235,8 +2235,8 @@ func (e *SessionSummaryAccessEvent) Anonymize(a utils.Anonymizer) prehogv1a.Subm
 type SessionSummaryCreateEvent prehogv1a.SessionSummaryCreateEvent
 
 // Anonymize anonymizes the event.
-func (e *SessionSummaryCreateEvent) Anonymize(a utils.Anonymizer) prehogv1a.SubmitEventRequest {
-	return prehogv1a.SubmitEventRequest{
+func (e *SessionSummaryCreateEvent) Anonymize(a utils.Anonymizer) *prehogv1a.SubmitEventRequest {
+	return &prehogv1a.SubmitEventRequest{
 		Event: &prehogv1a.SubmitEventRequest_SessionSummaryCreateEvent{
 			SessionSummaryCreateEvent: &prehogv1a.SessionSummaryCreateEvent{
 				SessionType:         e.SessionType,
@@ -2256,8 +2256,8 @@ func (e *SessionSummaryCreateEvent) Anonymize(a utils.Anonymizer) prehogv1a.Subm
 type SessionSummarySearchEvent prehogv1a.SessionSummarySearchEvent
 
 // Anonymize anonymizes the event.
-func (e *SessionSummarySearchEvent) Anonymize(a utils.Anonymizer) prehogv1a.SubmitEventRequest {
-	return prehogv1a.SubmitEventRequest{
+func (e *SessionSummarySearchEvent) Anonymize(a utils.Anonymizer) *prehogv1a.SubmitEventRequest {
+	return &prehogv1a.SubmitEventRequest{
 		Event: &prehogv1a.SubmitEventRequest_SessionSummarySearchEvent{
 			SessionSummarySearchEvent: &prehogv1a.SessionSummarySearchEvent{
 				UserName:   a.AnonymizeString(e.UserName),
@@ -2273,8 +2273,8 @@ func (e *SessionSummarySearchEvent) Anonymize(a utils.Anonymizer) prehogv1a.Subm
 type DiscoveryConfigEvent prehogv1a.DiscoveryConfigEvent
 
 // Anonymize anonymizes the event.
-func (e *DiscoveryConfigEvent) Anonymize(a utils.Anonymizer) prehogv1a.SubmitEventRequest {
-	return prehogv1a.SubmitEventRequest{
+func (e *DiscoveryConfigEvent) Anonymize(a utils.Anonymizer) *prehogv1a.SubmitEventRequest {
+	return &prehogv1a.SubmitEventRequest{
 		Event: &prehogv1a.SubmitEventRequest_DiscoveryConfig{
 			DiscoveryConfig: &prehogv1a.DiscoveryConfigEvent{
 				Action:              e.Action,
@@ -2291,8 +2291,8 @@ func (e *DiscoveryConfigEvent) Anonymize(a utils.Anonymizer) prehogv1a.SubmitEve
 type IdentitySecurityGraphSizeEvent prehogv1a.IdentitySecurityGraphSizeEvent
 
 // Anonymize anonymizes the event.
-func (e *IdentitySecurityGraphSizeEvent) Anonymize(a utils.Anonymizer) prehogv1a.SubmitEventRequest {
-	return prehogv1a.SubmitEventRequest{
+func (e *IdentitySecurityGraphSizeEvent) Anonymize(a utils.Anonymizer) *prehogv1a.SubmitEventRequest {
+	return &prehogv1a.SubmitEventRequest{
 		Event: &prehogv1a.SubmitEventRequest_IdentitySecurityGraphSizeEvent{
 			IdentitySecurityGraphSizeEvent: &prehogv1a.IdentitySecurityGraphSizeEvent{
 				Provider:        e.Provider,
@@ -2307,8 +2307,8 @@ func (e *IdentitySecurityGraphSizeEvent) Anonymize(a utils.Anonymizer) prehogv1a
 type IdentitySecurityAuditLogsIngestedEvent prehogv1a.IdentitySecurityAuditLogsIngestedEvent
 
 // Anonymize anonymizes the event.
-func (e *IdentitySecurityAuditLogsIngestedEvent) Anonymize(a utils.Anonymizer) prehogv1a.SubmitEventRequest {
-	return prehogv1a.SubmitEventRequest{
+func (e *IdentitySecurityAuditLogsIngestedEvent) Anonymize(a utils.Anonymizer) *prehogv1a.SubmitEventRequest {
+	return &prehogv1a.SubmitEventRequest{
 		Event: &prehogv1a.SubmitEventRequest_IdentitySecurityAuditLogsIngestedEvent{
 			IdentitySecurityAuditLogsIngestedEvent: &prehogv1a.IdentitySecurityAuditLogsIngestedEvent{
 				Provider:     e.Provider,

--- a/lib/usagereporter/teleport/types_discover.go
+++ b/lib/usagereporter/teleport/types_discover.go
@@ -117,8 +117,8 @@ func (u *UIDiscoverStartedEvent) CheckAndSetDefaults() error {
 	return nil
 }
 
-func (u *UIDiscoverStartedEvent) Anonymize(a utils.Anonymizer) prehogv1a.SubmitEventRequest {
-	return prehogv1a.SubmitEventRequest{
+func (u *UIDiscoverStartedEvent) Anonymize(a utils.Anonymizer) *prehogv1a.SubmitEventRequest {
+	return &prehogv1a.SubmitEventRequest{
 		Event: &prehogv1a.SubmitEventRequest_UiDiscoverStartedEvent{
 			UiDiscoverStartedEvent: &prehogv1a.UIDiscoverStartedEvent{
 				Metadata: &prehogv1a.DiscoverMetadata{
@@ -139,8 +139,8 @@ func (u *UIDiscoverResourceSelectionEvent) CheckAndSetDefaults() error {
 	return trace.Wrap(validateDiscoverBaseEventFields(u.Metadata, u.Resource, u.Status))
 }
 
-func (u *UIDiscoverResourceSelectionEvent) Anonymize(a utils.Anonymizer) prehogv1a.SubmitEventRequest {
-	return prehogv1a.SubmitEventRequest{
+func (u *UIDiscoverResourceSelectionEvent) Anonymize(a utils.Anonymizer) *prehogv1a.SubmitEventRequest {
+	return &prehogv1a.SubmitEventRequest{
 		Event: &prehogv1a.SubmitEventRequest_UiDiscoverResourceSelectionEvent{
 			UiDiscoverResourceSelectionEvent: &prehogv1a.UIDiscoverResourceSelectionEvent{
 				Metadata: &prehogv1a.DiscoverMetadata{
@@ -163,8 +163,8 @@ func (u *UIDiscoverIntegrationAWSOIDCConnectEvent) CheckAndSetDefaults() error {
 	return trace.Wrap(validateDiscoverBaseEventFields(u.Metadata, u.Resource, u.Status))
 }
 
-func (u *UIDiscoverIntegrationAWSOIDCConnectEvent) Anonymize(a utils.Anonymizer) prehogv1a.SubmitEventRequest {
-	return prehogv1a.SubmitEventRequest{
+func (u *UIDiscoverIntegrationAWSOIDCConnectEvent) Anonymize(a utils.Anonymizer) *prehogv1a.SubmitEventRequest {
+	return &prehogv1a.SubmitEventRequest{
 		Event: &prehogv1a.SubmitEventRequest_UiDiscoverIntegrationAwsOidcConnectEvent{
 			UiDiscoverIntegrationAwsOidcConnectEvent: &prehogv1a.UIDiscoverIntegrationAWSOIDCConnectEvent{
 				Metadata: &prehogv1a.DiscoverMetadata{
@@ -189,8 +189,8 @@ func (u *UIDiscoverDatabaseRDSEnrollEvent) CheckAndSetDefaults() error {
 	return trace.Wrap(validateDiscoverBaseEventFields(u.Metadata, u.Resource, u.Status))
 }
 
-func (u *UIDiscoverDatabaseRDSEnrollEvent) Anonymize(a utils.Anonymizer) prehogv1a.SubmitEventRequest {
-	return prehogv1a.SubmitEventRequest{
+func (u *UIDiscoverDatabaseRDSEnrollEvent) Anonymize(a utils.Anonymizer) *prehogv1a.SubmitEventRequest {
+	return &prehogv1a.SubmitEventRequest{
 		Event: &prehogv1a.SubmitEventRequest_UiDiscoverDatabaseRdsEnrollEvent{
 			UiDiscoverDatabaseRdsEnrollEvent: &prehogv1a.UIDiscoverDatabaseRDSEnrollEvent{
 				Metadata: &prehogv1a.DiscoverMetadata{
@@ -213,8 +213,8 @@ func (u *UIDiscoverKubeEKSEnrollEvent) CheckAndSetDefaults() error {
 	return trace.Wrap(validateDiscoverBaseEventFields(u.Metadata, u.Resource, u.Status))
 }
 
-func (u *UIDiscoverKubeEKSEnrollEvent) Anonymize(a utils.Anonymizer) prehogv1a.SubmitEventRequest {
-	return prehogv1a.SubmitEventRequest{
+func (u *UIDiscoverKubeEKSEnrollEvent) Anonymize(a utils.Anonymizer) *prehogv1a.SubmitEventRequest {
+	return &prehogv1a.SubmitEventRequest{
 		Event: &prehogv1a.SubmitEventRequest_UiDiscoverKubeEksEnrollEvent{
 			UiDiscoverKubeEksEnrollEvent: &prehogv1a.UIDiscoverKubeEKSEnrollEvent{
 				Metadata: &prehogv1a.DiscoverMetadata{
@@ -241,8 +241,8 @@ func (u *UIDiscoverDeployServiceEvent) CheckAndSetDefaults() error {
 	return trace.Wrap(validateDiscoverBaseEventFields(u.Metadata, u.Resource, u.Status))
 }
 
-func (u *UIDiscoverDeployServiceEvent) Anonymize(a utils.Anonymizer) prehogv1a.SubmitEventRequest {
-	return prehogv1a.SubmitEventRequest{
+func (u *UIDiscoverDeployServiceEvent) Anonymize(a utils.Anonymizer) *prehogv1a.SubmitEventRequest {
+	return &prehogv1a.SubmitEventRequest{
 		Event: &prehogv1a.SubmitEventRequest_UiDiscoverDeployServiceEvent{
 			UiDiscoverDeployServiceEvent: &prehogv1a.UIDiscoverDeployServiceEvent{
 				Metadata: &prehogv1a.DiscoverMetadata{
@@ -265,8 +265,8 @@ func (u *UIDiscoverCreateDiscoveryConfigEvent) CheckAndSetDefaults() error {
 	return trace.Wrap(validateDiscoverBaseEventFields(u.Metadata, u.Resource, u.Status))
 }
 
-func (u *UIDiscoverCreateDiscoveryConfigEvent) Anonymize(a utils.Anonymizer) prehogv1a.SubmitEventRequest {
-	return prehogv1a.SubmitEventRequest{
+func (u *UIDiscoverCreateDiscoveryConfigEvent) Anonymize(a utils.Anonymizer) *prehogv1a.SubmitEventRequest {
+	return &prehogv1a.SubmitEventRequest{
 		Event: &prehogv1a.SubmitEventRequest_UiDiscoverCreateDiscoveryConfig{
 			UiDiscoverCreateDiscoveryConfig: &prehogv1a.UIDiscoverCreateDiscoveryConfigEvent{
 				Metadata: &prehogv1a.DiscoverMetadata{
@@ -289,8 +289,8 @@ func (u *UIDiscoverDatabaseRegisterEvent) CheckAndSetDefaults() error {
 	return trace.Wrap(validateDiscoverBaseEventFields(u.Metadata, u.Resource, u.Status))
 }
 
-func (u *UIDiscoverDatabaseRegisterEvent) Anonymize(a utils.Anonymizer) prehogv1a.SubmitEventRequest {
-	return prehogv1a.SubmitEventRequest{
+func (u *UIDiscoverDatabaseRegisterEvent) Anonymize(a utils.Anonymizer) *prehogv1a.SubmitEventRequest {
+	return &prehogv1a.SubmitEventRequest{
 		Event: &prehogv1a.SubmitEventRequest_UiDiscoverDatabaseRegisterEvent{
 			UiDiscoverDatabaseRegisterEvent: &prehogv1a.UIDiscoverDatabaseRegisterEvent{
 				Metadata: &prehogv1a.DiscoverMetadata{
@@ -312,8 +312,8 @@ func (u *UIDiscoverDatabaseConfigureMTLSEvent) CheckAndSetDefaults() error {
 	return trace.Wrap(validateDiscoverBaseEventFields(u.Metadata, u.Resource, u.Status))
 }
 
-func (u *UIDiscoverDatabaseConfigureMTLSEvent) Anonymize(a utils.Anonymizer) prehogv1a.SubmitEventRequest {
-	return prehogv1a.SubmitEventRequest{
+func (u *UIDiscoverDatabaseConfigureMTLSEvent) Anonymize(a utils.Anonymizer) *prehogv1a.SubmitEventRequest {
+	return &prehogv1a.SubmitEventRequest{
 		Event: &prehogv1a.SubmitEventRequest_UiDiscoverDatabaseConfigureMtlsEvent{
 			UiDiscoverDatabaseConfigureMtlsEvent: &prehogv1a.UIDiscoverDatabaseConfigureMTLSEvent{
 				Metadata: &prehogv1a.DiscoverMetadata{
@@ -335,8 +335,8 @@ func (u *UIDiscoverDesktopActiveDirectoryToolsInstallEvent) CheckAndSetDefaults(
 	return trace.Wrap(validateDiscoverBaseEventFields(u.Metadata, u.Resource, u.Status))
 }
 
-func (u *UIDiscoverDesktopActiveDirectoryToolsInstallEvent) Anonymize(a utils.Anonymizer) prehogv1a.SubmitEventRequest {
-	return prehogv1a.SubmitEventRequest{
+func (u *UIDiscoverDesktopActiveDirectoryToolsInstallEvent) Anonymize(a utils.Anonymizer) *prehogv1a.SubmitEventRequest {
+	return &prehogv1a.SubmitEventRequest{
 		Event: &prehogv1a.SubmitEventRequest_UiDiscoverDesktopActiveDirectoryToolsInstallEvent{
 			UiDiscoverDesktopActiveDirectoryToolsInstallEvent: &prehogv1a.UIDiscoverDesktopActiveDirectoryToolsInstallEvent{
 				Metadata: &prehogv1a.DiscoverMetadata{
@@ -358,8 +358,8 @@ func (u *UIDiscoverDesktopActiveDirectoryConfigureEvent) CheckAndSetDefaults() e
 	return trace.Wrap(validateDiscoverBaseEventFields(u.Metadata, u.Resource, u.Status))
 }
 
-func (u *UIDiscoverDesktopActiveDirectoryConfigureEvent) Anonymize(a utils.Anonymizer) prehogv1a.SubmitEventRequest {
-	return prehogv1a.SubmitEventRequest{
+func (u *UIDiscoverDesktopActiveDirectoryConfigureEvent) Anonymize(a utils.Anonymizer) *prehogv1a.SubmitEventRequest {
+	return &prehogv1a.SubmitEventRequest{
 		Event: &prehogv1a.SubmitEventRequest_UiDiscoverDesktopActiveDirectoryConfigureEvent{
 			UiDiscoverDesktopActiveDirectoryConfigureEvent: &prehogv1a.UIDiscoverDesktopActiveDirectoryConfigureEvent{
 				Metadata: &prehogv1a.DiscoverMetadata{
@@ -384,8 +384,8 @@ func (u *UIDiscoverAutoDiscoveredResourcesEvent) CheckAndSetDefaults() error {
 	return trace.Wrap(validateDiscoverBaseEventFields(u.Metadata, u.Resource, u.Status))
 }
 
-func (u *UIDiscoverAutoDiscoveredResourcesEvent) Anonymize(a utils.Anonymizer) prehogv1a.SubmitEventRequest {
-	return prehogv1a.SubmitEventRequest{
+func (u *UIDiscoverAutoDiscoveredResourcesEvent) Anonymize(a utils.Anonymizer) *prehogv1a.SubmitEventRequest {
+	return &prehogv1a.SubmitEventRequest{
 		Event: &prehogv1a.SubmitEventRequest_UiDiscoverAutoDiscoveredResourcesEvent{
 			UiDiscoverAutoDiscoveredResourcesEvent: &prehogv1a.UIDiscoverAutoDiscoveredResourcesEvent{
 				Metadata: &prehogv1a.DiscoverMetadata{
@@ -407,8 +407,8 @@ func (u *UIDiscoverEC2InstanceSelectionEvent) CheckAndSetDefaults() error {
 	return trace.Wrap(validateDiscoverBaseEventFields(u.Metadata, u.Resource, u.Status))
 }
 
-func (u *UIDiscoverEC2InstanceSelectionEvent) Anonymize(a utils.Anonymizer) prehogv1a.SubmitEventRequest {
-	return prehogv1a.SubmitEventRequest{
+func (u *UIDiscoverEC2InstanceSelectionEvent) Anonymize(a utils.Anonymizer) *prehogv1a.SubmitEventRequest {
+	return &prehogv1a.SubmitEventRequest{
 		Event: &prehogv1a.SubmitEventRequest_UiDiscoverEc2InstanceSelection{
 			UiDiscoverEc2InstanceSelection: &prehogv1a.UIDiscoverEC2InstanceSelectionEvent{
 				Metadata: &prehogv1a.DiscoverMetadata{
@@ -429,8 +429,8 @@ func (u *UIDiscoverDeployEICEEvent) CheckAndSetDefaults() error {
 	return trace.Wrap(validateDiscoverBaseEventFields(u.Metadata, u.Resource, u.Status))
 }
 
-func (u *UIDiscoverDeployEICEEvent) Anonymize(a utils.Anonymizer) prehogv1a.SubmitEventRequest {
-	return prehogv1a.SubmitEventRequest{
+func (u *UIDiscoverDeployEICEEvent) Anonymize(a utils.Anonymizer) *prehogv1a.SubmitEventRequest {
+	return &prehogv1a.SubmitEventRequest{
 		Event: &prehogv1a.SubmitEventRequest_UiDiscoverDeployEice{
 			UiDiscoverDeployEice: &prehogv1a.UIDiscoverDeployEICEEvent{
 				Metadata: &prehogv1a.DiscoverMetadata{
@@ -451,8 +451,8 @@ func (u *UIDiscoverCreateNodeEvent) CheckAndSetDefaults() error {
 	return trace.Wrap(validateDiscoverBaseEventFields(u.Metadata, u.Resource, u.Status))
 }
 
-func (u *UIDiscoverCreateNodeEvent) Anonymize(a utils.Anonymizer) prehogv1a.SubmitEventRequest {
-	return prehogv1a.SubmitEventRequest{
+func (u *UIDiscoverCreateNodeEvent) Anonymize(a utils.Anonymizer) *prehogv1a.SubmitEventRequest {
+	return &prehogv1a.SubmitEventRequest{
 		Event: &prehogv1a.SubmitEventRequest_UiDiscoverCreateNode{
 			UiDiscoverCreateNode: &prehogv1a.UIDiscoverCreateNodeEvent{
 				Metadata: &prehogv1a.DiscoverMetadata{
@@ -473,8 +473,8 @@ func (u *UIDiscoverCreateAppServerEvent) CheckAndSetDefaults() error {
 	return trace.Wrap(validateDiscoverBaseEventFields(u.Metadata, u.Resource, u.Status))
 }
 
-func (u *UIDiscoverCreateAppServerEvent) Anonymize(a utils.Anonymizer) prehogv1a.SubmitEventRequest {
-	return prehogv1a.SubmitEventRequest{
+func (u *UIDiscoverCreateAppServerEvent) Anonymize(a utils.Anonymizer) *prehogv1a.SubmitEventRequest {
+	return &prehogv1a.SubmitEventRequest{
 		Event: &prehogv1a.SubmitEventRequest_UiDiscoverCreateAppServerEvent{
 			UiDiscoverCreateAppServerEvent: &prehogv1a.UIDiscoverCreateAppServerEvent{
 				Metadata: &prehogv1a.DiscoverMetadata{
@@ -496,8 +496,8 @@ func (u *UIDiscoverDatabaseConfigureIAMPolicyEvent) CheckAndSetDefaults() error 
 	return trace.Wrap(validateDiscoverBaseEventFields(u.Metadata, u.Resource, u.Status))
 }
 
-func (u *UIDiscoverDatabaseConfigureIAMPolicyEvent) Anonymize(a utils.Anonymizer) prehogv1a.SubmitEventRequest {
-	return prehogv1a.SubmitEventRequest{
+func (u *UIDiscoverDatabaseConfigureIAMPolicyEvent) Anonymize(a utils.Anonymizer) *prehogv1a.SubmitEventRequest {
+	return &prehogv1a.SubmitEventRequest{
 		Event: &prehogv1a.SubmitEventRequest_UiDiscoverDatabaseConfigureIamPolicyEvent{
 			UiDiscoverDatabaseConfigureIamPolicyEvent: &prehogv1a.UIDiscoverDatabaseConfigureIAMPolicyEvent{
 				Metadata: &prehogv1a.DiscoverMetadata{
@@ -519,8 +519,8 @@ func (u *UIDiscoverPrincipalsConfigureEvent) CheckAndSetDefaults() error {
 	return trace.Wrap(validateDiscoverBaseEventFields(u.Metadata, u.Resource, u.Status))
 }
 
-func (u *UIDiscoverPrincipalsConfigureEvent) Anonymize(a utils.Anonymizer) prehogv1a.SubmitEventRequest {
-	return prehogv1a.SubmitEventRequest{
+func (u *UIDiscoverPrincipalsConfigureEvent) Anonymize(a utils.Anonymizer) *prehogv1a.SubmitEventRequest {
+	return &prehogv1a.SubmitEventRequest{
 		Event: &prehogv1a.SubmitEventRequest_UiDiscoverPrincipalsConfigureEvent{
 			UiDiscoverPrincipalsConfigureEvent: &prehogv1a.UIDiscoverPrincipalsConfigureEvent{
 				Metadata: &prehogv1a.DiscoverMetadata{
@@ -542,8 +542,8 @@ func (u *UIDiscoverTestConnectionEvent) CheckAndSetDefaults() error {
 	return trace.Wrap(validateDiscoverBaseEventFields(u.Metadata, u.Resource, u.Status))
 }
 
-func (u *UIDiscoverTestConnectionEvent) Anonymize(a utils.Anonymizer) prehogv1a.SubmitEventRequest {
-	return prehogv1a.SubmitEventRequest{
+func (u *UIDiscoverTestConnectionEvent) Anonymize(a utils.Anonymizer) *prehogv1a.SubmitEventRequest {
+	return &prehogv1a.SubmitEventRequest{
 		Event: &prehogv1a.SubmitEventRequest_UiDiscoverTestConnectionEvent{
 			UiDiscoverTestConnectionEvent: &prehogv1a.UIDiscoverTestConnectionEvent{
 				Metadata: &prehogv1a.DiscoverMetadata{
@@ -564,8 +564,8 @@ func (u *UIDiscoverCompletedEvent) CheckAndSetDefaults() error {
 	return trace.Wrap(validateDiscoverBaseEventFields(u.Metadata, u.Resource, u.Status))
 }
 
-func (u *UIDiscoverCompletedEvent) Anonymize(a utils.Anonymizer) prehogv1a.SubmitEventRequest {
-	return prehogv1a.SubmitEventRequest{
+func (u *UIDiscoverCompletedEvent) Anonymize(a utils.Anonymizer) *prehogv1a.SubmitEventRequest {
+	return &prehogv1a.SubmitEventRequest{
 		Event: &prehogv1a.SubmitEventRequest_UiDiscoverCompletedEvent{
 			UiDiscoverCompletedEvent: &prehogv1a.UIDiscoverCompletedEvent{
 				Metadata: &prehogv1a.DiscoverMetadata{

--- a/lib/usagereporter/teleport/types_ui_accesslist.go
+++ b/lib/usagereporter/teleport/types_ui_accesslist.go
@@ -81,8 +81,8 @@ func (u *UIAccessListDefineAccessEvent) CheckAndSetDefaults() error {
 	return trace.Wrap(validateAccessListBaseEventFields(u.Metadata, u.Status))
 }
 
-func (u *UIAccessListDefineAccessEvent) Anonymize(a utils.Anonymizer) prehogv1a.SubmitEventRequest {
-	return prehogv1a.SubmitEventRequest{
+func (u *UIAccessListDefineAccessEvent) Anonymize(a utils.Anonymizer) *prehogv1a.SubmitEventRequest {
+	return &prehogv1a.SubmitEventRequest{
 		Event: &prehogv1a.SubmitEventRequest_UiAccessListDefineAccessEvent{
 			UiAccessListDefineAccessEvent: &prehogv1a.UIAccessListDefineAccessEvent{
 				Metadata: &prehogv1a.AccessListMetadata{
@@ -102,8 +102,8 @@ func (u *UIAccessListDefineIdentitiesEvent) CheckAndSetDefaults() error {
 	return trace.Wrap(validateAccessListBaseEventFields(u.Metadata, u.Status))
 }
 
-func (u *UIAccessListDefineIdentitiesEvent) Anonymize(a utils.Anonymizer) prehogv1a.SubmitEventRequest {
-	return prehogv1a.SubmitEventRequest{
+func (u *UIAccessListDefineIdentitiesEvent) Anonymize(a utils.Anonymizer) *prehogv1a.SubmitEventRequest {
+	return &prehogv1a.SubmitEventRequest{
 		Event: &prehogv1a.SubmitEventRequest_UiAccessListDefineIdentitiesEvent{
 			UiAccessListDefineIdentitiesEvent: &prehogv1a.UIAccessListDefineIdentitiesEvent{
 				Metadata: &prehogv1a.AccessListMetadata{
@@ -123,8 +123,8 @@ func (u *UIAccessListBasicInfoEvent) CheckAndSetDefaults() error {
 	return trace.Wrap(validateAccessListBaseEventFields(u.Metadata, u.Status))
 }
 
-func (u *UIAccessListBasicInfoEvent) Anonymize(a utils.Anonymizer) prehogv1a.SubmitEventRequest {
-	return prehogv1a.SubmitEventRequest{
+func (u *UIAccessListBasicInfoEvent) Anonymize(a utils.Anonymizer) *prehogv1a.SubmitEventRequest {
+	return &prehogv1a.SubmitEventRequest{
 		Event: &prehogv1a.SubmitEventRequest_UiAccessListDefineBasicInfoEvent{
 			UiAccessListDefineBasicInfoEvent: &prehogv1a.UIAccessListDefineBasicInfoEvent{
 				Metadata: &prehogv1a.AccessListMetadata{
@@ -144,8 +144,8 @@ func (u *UIAccessListDefineMembersEvent) CheckAndSetDefaults() error {
 	return trace.Wrap(validateAccessListBaseEventFields(u.Metadata, u.Status))
 }
 
-func (u *UIAccessListDefineMembersEvent) Anonymize(a utils.Anonymizer) prehogv1a.SubmitEventRequest {
-	return prehogv1a.SubmitEventRequest{
+func (u *UIAccessListDefineMembersEvent) Anonymize(a utils.Anonymizer) *prehogv1a.SubmitEventRequest {
+	return &prehogv1a.SubmitEventRequest{
 		Event: &prehogv1a.SubmitEventRequest_UiAccessListDefineMembersEvent{
 			UiAccessListDefineMembersEvent: &prehogv1a.UIAccessListDefineMembersEvent{
 				Metadata: &prehogv1a.AccessListMetadata{
@@ -165,8 +165,8 @@ func (u *UIAccessListDefineOwnersEvent) CheckAndSetDefaults() error {
 	return trace.Wrap(validateAccessListBaseEventFields(u.Metadata, u.Status))
 }
 
-func (u *UIAccessListDefineOwnersEvent) Anonymize(a utils.Anonymizer) prehogv1a.SubmitEventRequest {
-	return prehogv1a.SubmitEventRequest{
+func (u *UIAccessListDefineOwnersEvent) Anonymize(a utils.Anonymizer) *prehogv1a.SubmitEventRequest {
+	return &prehogv1a.SubmitEventRequest{
 		Event: &prehogv1a.SubmitEventRequest_UiAccessListDefineOwnersEvent{
 			UiAccessListDefineOwnersEvent: &prehogv1a.UIAccessListDefineOwnersEvent{
 				Metadata: &prehogv1a.AccessListMetadata{
@@ -186,8 +186,8 @@ func (u *UIAccessListStartedEvent) CheckAndSetDefaults() error {
 	return trace.Wrap(validateAccessListBaseEventFields(u.Metadata, u.Status))
 }
 
-func (u *UIAccessListStartedEvent) Anonymize(a utils.Anonymizer) prehogv1a.SubmitEventRequest {
-	return prehogv1a.SubmitEventRequest{
+func (u *UIAccessListStartedEvent) Anonymize(a utils.Anonymizer) *prehogv1a.SubmitEventRequest {
+	return &prehogv1a.SubmitEventRequest{
 		Event: &prehogv1a.SubmitEventRequest_UiAccessListStartEvent{
 			UiAccessListStartEvent: &prehogv1a.UIAccessListStartEvent{
 				Metadata: &prehogv1a.AccessListMetadata{
@@ -207,8 +207,8 @@ func (u *UIAccessListCompletedEvent) CheckAndSetDefaults() error {
 	return trace.Wrap(validateAccessListBaseEventFields(u.Metadata, u.Status))
 }
 
-func (u *UIAccessListCompletedEvent) Anonymize(a utils.Anonymizer) prehogv1a.SubmitEventRequest {
-	return prehogv1a.SubmitEventRequest{
+func (u *UIAccessListCompletedEvent) Anonymize(a utils.Anonymizer) *prehogv1a.SubmitEventRequest {
+	return &prehogv1a.SubmitEventRequest{
 		Event: &prehogv1a.SubmitEventRequest_UiAccessListCompleteEvent{
 			UiAccessListCompleteEvent: &prehogv1a.UIAccessListCompleteEvent{
 				Metadata: &prehogv1a.AccessListMetadata{
@@ -229,8 +229,8 @@ func (u *UIAccessListCustomEvent) CheckAndSetDefaults() error {
 	return trace.Wrap(validateAccessListBaseEventFields(u.Metadata, u.Status))
 }
 
-func (u *UIAccessListCustomEvent) Anonymize(a utils.Anonymizer) prehogv1a.SubmitEventRequest {
-	return prehogv1a.SubmitEventRequest{
+func (u *UIAccessListCustomEvent) Anonymize(a utils.Anonymizer) *prehogv1a.SubmitEventRequest {
+	return &prehogv1a.SubmitEventRequest{
 		Event: &prehogv1a.SubmitEventRequest_UiAccessListCustomEvent{
 			UiAccessListCustomEvent: &prehogv1a.UIAccessListCustomEvent{
 				Metadata: &prehogv1a.AccessListMetadata{
@@ -249,8 +249,8 @@ func (u *UIAccessListIntegrateEvent) CheckAndSetDefaults() error {
 	return trace.Wrap(validateAccessListMetadata(u.Metadata))
 }
 
-func (u *UIAccessListIntegrateEvent) Anonymize(a utils.Anonymizer) prehogv1a.SubmitEventRequest {
-	return prehogv1a.SubmitEventRequest{
+func (u *UIAccessListIntegrateEvent) Anonymize(a utils.Anonymizer) *prehogv1a.SubmitEventRequest {
+	return &prehogv1a.SubmitEventRequest{
 		Event: &prehogv1a.SubmitEventRequest_UiAccessListIntegrateEvent{
 			UiAccessListIntegrateEvent: &prehogv1a.UIAccessListIntegrateEvent{
 				Metadata: &prehogv1a.AccessListMetadata{

--- a/lib/usagereporter/teleport/usagereporter.go
+++ b/lib/usagereporter/teleport/usagereporter.go
@@ -113,7 +113,7 @@ func (t *StreamingUsageReporter) AnonymizeAndSubmit(events ...Anonymizable) {
 		req.Timestamp = timestamppb.New(t.clock.Now())
 		req.ClusterName = t.anonymizer.AnonymizeString(t.clusterName.GetClusterName())
 		req.TeleportVersion = teleport.Version
-		t.usageReporter.AddEventsToQueue(&req)
+		t.usageReporter.AddEventsToQueue(req)
 	}
 }
 

--- a/lib/usagereporter/teleport/usagereporter_test.go
+++ b/lib/usagereporter/teleport/usagereporter_test.go
@@ -811,7 +811,7 @@ func TestConvertUsageEvent(t *testing.T) {
 
 			got := usageEvent.Anonymize(anonymizer)
 
-			require.Equal(t, tt.expected, &got)
+			require.Equal(t, tt.expected, got)
 		})
 	}
 }

--- a/tool/tctl/common/scoped_token_command_test.go
+++ b/tool/tctl/common/scoped_token_command_test.go
@@ -39,7 +39,7 @@ type listedScopedToken struct {
 	Version  string
 	Metadata struct {
 		Name    string
-		Expires timestamppb.Timestamp
+		Expires *timestamppb.Timestamp
 		ID      uint
 	}
 	Spec struct {


### PR DESCRIPTION
Converts non-pointer protobuf generated Go types to pointers via `open2opaque rewrite -levels=red ./...`. This contributes to https://github.com/gravitational/teleport/issues/66776 and was done separately to isolate per proto file migrations in the future.

