### PR TITLE
Tidy up Access Graph rewrite tool from post-merge feedback 

### DIFF
--- a/build.assets/tooling/cmd/accessgraph-rewrite-generated/main.go
+++ b/build.assets/tooling/cmd/accessgraph-rewrite-generated/main.go
@@ -31,6 +31,8 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+
+	"golang.org/x/mod/modfile"
 )
 
 const (
@@ -142,18 +144,12 @@ func findRepoRoot() (string, error) {
 		}
 	}
 }
-
 func isTeleportRootModule(data []byte) bool {
-	for _, line := range strings.Split(string(data), "\n") {
-		if strings.TrimSpace(line) == "module github.com/gravitational/teleport" {
-			return true
-		}
-	}
-	return false
+	return modfile.ModulePath(data) == "github.com/gravitational/teleport"
 }
 
 func rewriteImports(file *ast.File, mode rewriteMode) {
-	seen := make(map[string]struct{})
+	seen := make(map[importKey]struct{})
 	decls := file.Decls[:0]
 
 	for _, decl := range file.Decls {
@@ -193,7 +189,7 @@ func rewriteImports(file *ast.File, mode rewriteMode) {
 				continue
 			}
 
-			key := importKey(importSpec)
+			key := makeImportKey(importSpec)
 			if _, ok := seen[key]; ok {
 				continue
 			}
@@ -250,12 +246,17 @@ func setImportPath(spec *ast.ImportSpec, path string) {
 	spec.Path.Value = strconv.Quote(path)
 }
 
-func importKey(spec *ast.ImportSpec) string {
-	name := ""
+type importKey struct {
+	name string
+	path string
+}
+
+func makeImportKey(spec *ast.ImportSpec) importKey {
+	k := importKey{path: importPath(spec)}
 	if spec.Name != nil {
-		name = spec.Name.Name
+		k.name = spec.Name.Name
 	}
-	return name + "\x00" + importPath(spec)
+	return k
 }
 
 func rewriteUUIDSelectors(file *ast.File) {


### PR DESCRIPTION
#65949 vendored an OpenAPI-generated Access Graph REST client into Teleport so upcoming `tctl` Identity Security commands can talk to Access Graph under a strict API contract (tracked in gravitational/access-graph#1933). The `accessgraph-rewrite-generated` tool added in that PR post-processes the copied generated files to strip out the `oapi-codegen` runtime dependency, so vendoring the client adds no new runtime deps to Teleport.

This PR is a small follow-up addressing two post-merge suggestions from @espadolini on `build.assets/tooling/cmd/accessgraph-rewrite-generated`:

- **Use `modfile.ModulePath` to detect the teleport go.mod.** The previous line-by-line matcher could be fooled by a block-comment line that happened to read exactly `module github.com/gravitational/teleport`. `golang.org/x/mod` is already a direct dependency, so this is essentially free.
- **Replace the NUL-separated dedup key with a struct.** `importKey` is now a small `{name, path}` struct used directly as a `map[importKey]struct{}` key, instead of joining the two halves with `"\x00"`.

## Manual Test Plan
### Test Environment
- Local macOS dev machine, against a fresh copy of the access-graph generated assets.

### Test Cases
- [x] `go test ./cmd/accessgraph-rewrite-generated/` passes.
- [x] Ran `make -C lib/accessgraph/apiclient rewrite-generated` on a fresh copy of the access-graph generated files and diffed the output against the version currently checked in — 1:1 match.
- [x] `make full` and `make full-ent` still work
- [x] Tested the client on a prototype branch with tctl access graph commands hooked up. 