### PR TITLE
Resolve LegacyKeyValueFormat warning for build container

### DIFF
--- a/build.assets/Dockerfile
+++ b/build.assets/Dockerfile
@@ -241,7 +241,7 @@ ENV GOPATH="/go" \
 # Install PAM module and policies for testing.
 COPY pam/ /opt/pam_teleport/
 RUN make -C /opt/pam_teleport install
-ENV SOFTHSM2_PATH "/usr/lib/softhsm/libsofthsm2.so"
+ENV SOFTHSM2_PATH="/usr/lib/softhsm/libsofthsm2.so"
 
 # Install bats.
 RUN git clone --depth=1 https://github.com/bats-core/bats-core.git -b v1.2.1 && \


### PR DESCRIPTION
Resolves LegacyKeyValueFormat in build.assets Dockerfile.

## Manual Test Plan
### Test Environment
- Local macOS dev machine

### Test Cases
- [x] `make enter` still works with no LegacyKeyValueFormat warnings emitted
