### PR TITLE
Add build container config dir to git ignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,6 +78,7 @@ ssh.config
 
 # Build cache and tooling
 /build.assets/.cache
+/build.assets/.config
 /build.assets/tooling/bin/**
 
 # Teleport binaries


### PR DESCRIPTION
Adds `build.assets/.config` as used in the build container to `.gitignore` to prevent accidental commits and diff noise.

<!-- Include manual testing efforts to verify the change. -->
<!-- Detail where the tests where run and what configurations were used. -->
<!-- Include all the test cases which were run to validate the change. -->

## Manual Test Plan
### Test Environment
- Local macOS dev machine

### Test Cases
- [x] Run `make enter` to create a build container then `make all` from within. Observe that the generated `.config` directory is ignored.
