### PR TITLE
[v18] Refactor and fix `Service[T].Resources` handling malformed items incorectly

### DIFF
--- a/lib/services/local/generic/generic.go
+++ b/lib/services/local/generic/generic.go
@@ -255,6 +255,11 @@ func (s *Service[T]) Resources(ctx context.Context, startKey, endKey string) ite
 	return stream.TakeWhile(
 		stream.FilterMap(s.backend.Items(ctx, params), mapFn),
 		func(r T) bool {
+			// We promise the consumers of this function that the returned
+			// results an exclusive of the endkey but the underlying Items
+			// method returns us a stream that's inclusive of the end key - so
+			// if the user has provided us an end-key, we manually filter them
+			// out to convert from inclusive to exclusive.
 			return endKey == "" || r.GetName() < endKey
 		},
 	)

--- a/lib/services/local/generic/generic.go
+++ b/lib/services/local/generic/generic.go
@@ -30,6 +30,7 @@ import (
 	"github.com/gravitational/teleport/api/defaults"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/backend"
+	"github.com/gravitational/teleport/lib/itertools/stream"
 	"github.com/gravitational/teleport/lib/services"
 	logutils "github.com/gravitational/teleport/lib/utils/log"
 )
@@ -224,39 +225,39 @@ func (s *Service[T]) GetResources(ctx context.Context) ([]T, error) {
 	return out, nil
 }
 
-// Resources returns a stream of resources within the range [startKey, endKey].
-// If both keys are empty, then the entire range is returned.
+// Resources returns a stream of resources within the range [startKey, endKey).
+// If endKey is empty, iteration continues to the end of the prefix range.
+//
+// This method can be used to implement RangeFoo.
 func (s *Service[T]) Resources(ctx context.Context, startKey, endKey string) iter.Seq2[T, error] {
 	params := backend.ItemsParams{
 		StartKey: s.backendPrefix.AppendKey(backend.KeyFromString(startKey)),
+		// Defaults to end of range if not specified.
+		EndKey: backend.RangeEnd(s.backendPrefix.ExactKey()),
 	}
-	if endKey == "" {
-		params.EndKey = backend.RangeEnd(s.backendPrefix.ExactKey())
-	} else {
-		params.EndKey = s.backendPrefix.AppendKey(backend.KeyFromString(endKey))
+	if endKey != "" {
+		params.EndKey = s.backendPrefix.AppendKey(backend.KeyFromString(endKey)).ExactKey()
 	}
-	return func(yield func(T, error) bool) {
-		for item, err := range s.backend.Items(ctx, params) {
-			if err != nil {
-				var t T
-				yield(t, trace.Wrap(err))
-				return
-			}
 
-			resource, err := s.unmarshalFunc(item.Value,
-				services.WithExpires(item.Expires),
-				services.WithRevision(item.Revision))
-			if err != nil {
-				// unmarshal errors are logged and skipped
-				slog.WarnContext(ctx, "skipping resource due to unmarshal error", "error", err, "key", logutils.StringerAttr(item.Key))
-				return
-			}
-
-			if !yield(resource, nil) {
-				return
-			}
+	mapFn := func(item backend.Item) (T, bool) {
+		resource, err := s.unmarshalFunc(item.Value,
+			services.WithExpires(item.Expires),
+			services.WithRevision(item.Revision))
+		if err != nil {
+			// unmarshal errors are logged and skipped
+			slog.WarnContext(ctx, "skipping resource due to unmarshal error", "error", err, "key", logutils.StringerAttr(item.Key))
+			var zero T
+			return zero, false
 		}
+		return resource, true
 	}
+
+	return stream.TakeWhile(
+		stream.FilterMap(s.backend.Items(ctx, params), mapFn),
+		func(r T) bool {
+			return endKey == "" || r.GetName() < endKey
+		},
+	)
 }
 
 // ListResources returns a paginated list of resources.

--- a/lib/services/local/generic/generic.go
+++ b/lib/services/local/generic/generic.go
@@ -246,8 +246,7 @@ func (s *Service[T]) Resources(ctx context.Context, startKey, endKey string) ite
 		if err != nil {
 			// unmarshal errors are logged and skipped
 			slog.WarnContext(ctx, "skipping resource due to unmarshal error", "error", err, "key", logutils.StringerAttr(item.Key))
-			var zero T
-			return zero, false
+			return *new(T), false
 		}
 		return resource, true
 	}

--- a/lib/services/local/generic/generic.go
+++ b/lib/services/local/generic/generic.go
@@ -232,11 +232,12 @@ func (s *Service[T]) GetResources(ctx context.Context) ([]T, error) {
 func (s *Service[T]) Resources(ctx context.Context, startKey, endKey string) iter.Seq2[T, error] {
 	params := backend.ItemsParams{
 		StartKey: s.backendPrefix.AppendKey(backend.KeyFromString(startKey)),
-		// Defaults to end of range if not specified.
-		EndKey: backend.RangeEnd(s.backendPrefix.ExactKey()),
 	}
 	if endKey != "" {
 		params.EndKey = s.backendPrefix.AppendKey(backend.KeyFromString(endKey)).ExactKey()
+	} else {
+		// Defaults to end of range if not specified.
+		params.EndKey = backend.RangeEnd(s.backendPrefix.ExactKey())
 	}
 
 	mapFn := func(item backend.Item) (T, bool) {

--- a/lib/services/local/generic/generic_test.go
+++ b/lib/services/local/generic/generic_test.go
@@ -226,13 +226,13 @@ func TestGenericCRUD(t *testing.T) {
 		cmpopts.IgnoreFields(types.Metadata{}, "Revision"),
 	))
 
-	// Retrieve all resources from the stream
+	// Retrieve resources within an exclusive end range from the stream.
 	streamedResources = nil
 	for r, err := range service.Resources(ctx, r1.GetName(), r2.GetName()) {
 		require.NoError(t, err)
 		streamedResources = append(streamedResources, r)
 	}
-	require.Empty(t, cmp.Diff(paginatedOut, streamedResources,
+	require.Empty(t, cmp.Diff([]*testResource{r1}, streamedResources,
 		cmpopts.IgnoreFields(types.Metadata{}, "Revision"),
 	))
 
@@ -246,15 +246,13 @@ func TestGenericCRUD(t *testing.T) {
 		cmpopts.IgnoreFields(types.Metadata{}, "Revision"),
 	))
 
-	// Retrieve a single resource from the stream
+	// An exclusive end equal to the first resource yields nothing.
 	streamedResources = nil
 	for r, err := range service.Resources(ctx, "", r1.GetName()) {
 		require.NoError(t, err)
 		streamedResources = append(streamedResources, r)
 	}
-	require.Empty(t, cmp.Diff([]*testResource{r1}, streamedResources,
-		cmpopts.IgnoreFields(types.Metadata{}, "Revision"),
-	))
+	require.Empty(t, streamedResources)
 
 	// Fetch a specific service provider.
 	r, err := service.GetResource(ctx, r2.GetName())
@@ -371,6 +369,56 @@ func TestGenericCRUD(t *testing.T) {
 	count, err = service.CountResources(ctx)
 	require.NoError(t, err)
 	require.Equal(t, uint(0), count)
+}
+
+// TestResourcesSkipsUnmarshalErrors guards against a regression where a single
+// malformed backend item would terminate iteration over Resources rather than
+// being skipped.
+func TestResourcesSkipsUnmarshalErrors(t *testing.T) {
+	ctx := t.Context()
+
+	memBackend, err := memory.New(memory.Config{
+		Context: ctx,
+		Clock:   clockwork.NewFakeClock(),
+	})
+	require.NoError(t, err)
+
+	service, err := NewService(&ServiceConfig[*testResource]{
+		Backend:       memBackend,
+		ResourceKind:  "generic resource",
+		PageLimit:     200,
+		BackendPrefix: backend.NewKey("generic_prefix"),
+		UnmarshalFunc: unmarshalResource,
+		MarshalFunc:   marshalResource,
+	})
+	require.NoError(t, err)
+
+	// Insert valid resources at "r1" and "r3".
+	r1 := newTestResource("r1")
+	_, err = service.CreateResource(ctx, r1)
+	require.NoError(t, err)
+	r3 := newTestResource("r3")
+	_, err = service.CreateResource(ctx, r3)
+	require.NoError(t, err)
+
+	// Insert a malformed item at "r2", bypassing marshal so the unmarshal
+	// path will fail when iterating.
+	_, err = memBackend.Put(ctx, backend.Item{
+		Key:   service.MakeKey(backend.NewKey("r2")),
+		Value: []byte("not-valid-json"),
+	})
+	require.NoError(t, err)
+
+	// Resources must skip the malformed item and continue past it.
+	var got []*testResource
+	for r, err := range service.Resources(ctx, "", "") {
+		require.NoError(t, err)
+		got = append(got, r)
+	}
+	require.Empty(t, cmp.Diff(
+		[]*testResource{r1, r3}, got,
+		cmpopts.IgnoreFields(types.Metadata{}, "Revision"),
+	))
 }
 
 func TestGenericListResourcesReturnNextResource(t *testing.T) {

--- a/lib/services/local/generic/generic_wrapper.go
+++ b/lib/services/local/generic/generic_wrapper.go
@@ -158,8 +158,10 @@ func (s ServiceWrapper[T]) ListResourcesWithFilter(ctx context.Context, pageSize
 	return out, nextToken, trace.Wrap(err)
 }
 
-// Resources returns a stream of resources within the range [startKey, endKey].
-// If both keys are empty, then the entire range is returned.
+// Resources returns a stream of resources within the range [startKey, endKey).
+// If endKey is empty, iteration continues to the end of the prefix range.
+//
+// This method may be used to implement RangeFoo.
 func (s *ServiceWrapper[T]) Resources(ctx context.Context, startKey, endKey string) iter.Seq2[T, error] {
 	return func(yield func(T, error) bool) {
 		for adapter, err := range s.service.Resources(ctx, startKey, endKey) {

--- a/lib/services/local/generic/generic_wrapper_test.go
+++ b/lib/services/local/generic/generic_wrapper_test.go
@@ -174,13 +174,13 @@ func TestGenericWrapperCRUD(t *testing.T) {
 	}
 	require.Empty(t, cmp.Diff(paginatedOut, streamedResources, protocmp.Transform()))
 
-	// Retrieve all resources from the stream
+	// Retrieve resources within an exclusive end range from the stream.
 	streamedResources = nil
 	for r, err := range service.Resources(ctx, r1.GetMetadata().GetName(), r2.GetMetadata().GetName()) {
 		require.NoError(t, err)
 		streamedResources = append(streamedResources, r)
 	}
-	require.Empty(t, cmp.Diff(paginatedOut, streamedResources, protocmp.Transform()))
+	require.Empty(t, cmp.Diff([]*testResource153{r1}, streamedResources, protocmp.Transform()))
 
 	// Retrieve a single resource from the stream
 	streamedResources = nil
@@ -190,13 +190,13 @@ func TestGenericWrapperCRUD(t *testing.T) {
 	}
 	require.Empty(t, cmp.Diff([]*testResource153{r2}, streamedResources, protocmp.Transform()))
 
-	// Retrieve a single resource from the stream
+	// An exclusive end equal to the first resource yields nothing.
 	streamedResources = nil
 	for r, err := range service.Resources(ctx, "", r1.GetMetadata().GetName()) {
 		require.NoError(t, err)
 		streamedResources = append(streamedResources, r)
 	}
-	require.Empty(t, cmp.Diff([]*testResource153{r1}, streamedResources, protocmp.Transform()))
+	require.Empty(t, streamedResources)
 
 	// Fetch a specific service provider.
 	r, err := service.GetResource(ctx, r2.GetMetadata().GetName())


### PR DESCRIPTION
Backport #66580 to branch/v18