### PR TITLE
[v18] Block symlinks and relative paths for moderated file transfers

### DIFF
--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -8005,32 +8005,17 @@ func testModeratedSFTP(t *testing.T, suite *integrationTestSuite) {
 		},
 	}
 	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			// Create and approve a file download request
-			tempDir := t.TempDir()
-			reqFile := filepath.Join(tempDir, "req-file")
-			err = os.WriteFile(reqFile, []byte("contents"), 0o666)
-			require.NoError(t, err)
-
-			err = tc.sess.RequestFileTransfer(ctx, tracessh.FileTransferReq{
-				Download: true,
-				Location: reqFile,
-			})
-			require.NoError(t, err)
-
-			sshReq = sshRquestIgnoringKeepalives(t, modSSHReqs)
+		createAndApproveTransferRequest := func(t *testing.T, req tracessh.FileTransferReq) {
+			require.NoError(t, tc.sess.RequestFileTransfer(ctx, req))
+			sshReq := sshRquestIgnoringKeepalives(t, modSSHReqs)
 			var fileReq apievents.FileTransferRequestEvent
-			err = json.Unmarshal(sshReq.Payload, &fileReq)
-			require.NoError(t, err)
-
-			err = modSess.ApproveFileTransferRequest(ctx, fileReq.RequestID)
-			require.NoError(t, err)
-
+			require.NoError(t, json.Unmarshal(sshReq.Payload, &fileReq))
+			require.NoError(t, modSess.ApproveFileTransferRequest(ctx, fileReq.RequestID))
 			// Ignore file transfer request approve event
 			sshRquestIgnoringKeepalives(t, modSSHReqs)
+		}
 
-			// Test that only operations needed to complete the download
-			// are allowed
+		openSFTPClient := func(t *testing.T) *sftp.Client {
 			transferSess, err := tc.sshClient.NewSession(ctx)
 			require.NoError(t, err)
 			t.Cleanup(func() {
@@ -8048,92 +8033,106 @@ func testModeratedSFTP(t *testing.T, suite *integrationTestSuite) {
 			require.NoError(t, err)
 			sftpClient, err := sftp.NewClientPipe(r, w)
 			require.NoError(t, err)
-
-			// A file not in the request shouldn't be allowed
-			badFile := filepath.Join(tempDir, "bad-file")
-			_, err = sftpClient.Open(badFile)
-			require.ErrorContains(t, err, fmt.Sprintf("operations are only allowed on %s, not %s", reqFile, badFile))
-			// Since this is a download no files should be allowed to be written to
-			_, err = sftpClient.OpenFile(reqFile, os.O_WRONLY)
-			require.ErrorContains(t, err, `writing is not allowed`)
-			// Only stats and reads should be allowed
-			err = sftpClient.Mkdir(reqFile)
-			require.ErrorContains(t, err, `method mkdir is not allowed on `+reqFile)
-			// Since this is a download no files should be allowed to have
-			// their permissions changed
-			err = sftpClient.Chmod(reqFile, 0o777)
-			require.ErrorContains(t, err, `writing is not allowed`)
-
-			// Only necessary operations should be allowed
-			_, err = sftpClient.Stat(reqFile)
-			require.NoError(t, err)
-			_, err = sftpClient.Lstat(reqFile)
-			require.NoError(t, err)
-			rf, err := sftpClient.Open(reqFile)
-			require.NoError(t, err)
-			require.NoError(t, rf.Close())
-
-			require.NoError(t, sftpClient.Close())
-
-			// Create and approve a file upload request
-			err = tc.sess.RequestFileTransfer(ctx, tracessh.FileTransferReq{
-				Download: false,
-				Filename: "upload-file",
-				Location: reqFile,
-			})
-			require.NoError(t, err)
-
-			sshReq = sshRquestIgnoringKeepalives(t, modSSHReqs)
-			err = json.Unmarshal(sshReq.Payload, &fileReq)
-			require.NoError(t, err)
-
-			err = modSess.ApproveFileTransferRequest(ctx, fileReq.RequestID)
-			require.NoError(t, err)
-
-			// Ignore file transfer request approve event
-			sshRquestIgnoringKeepalives(t, modSSHReqs)
-
-			isNilOrEOFErr(t, transferSess.Close())
-			transferSess, err = tc.sshClient.NewSession(ctx)
-			require.NoError(t, err)
 			t.Cleanup(func() {
-				require.NoError(t, transferSess.Close())
+				isNilOrEOFErr(t, sftpClient.Close())
 			})
-
 			err = transferSess.Setenv(ctx, string(telesftp.EnvModeratedSessionID), sessTracker.GetSessionID())
 			require.NoError(t, err)
+			return sftpClient
+		}
 
-			// Test that only operations needed to complete the download
-			// are allowed
-			err = transferSess.RequestSubsystem(ctx, teleport.SFTPSubsystem)
+		t.Run(tc.name, func(t *testing.T) {
+			tempDir := t.TempDir()
+			// Create needed files.
+			reqFile := filepath.Join(tempDir, "req-file")
+			err = os.WriteFile(reqFile, []byte("contents"), 0o666)
 			require.NoError(t, err)
-			w, err = transferSess.StdinPipe()
+			// On MacOS temp dirs are symlinked, we need the real path so the symlink
+			// check works.
+			reqFile, err := filepath.EvalSymlinks(reqFile)
 			require.NoError(t, err)
-			r, err = transferSess.StdoutPipe()
-			require.NoError(t, err)
-			sftpClient, err = sftp.NewClientPipe(r, w)
-			require.NoError(t, err)
+			symlinkFile := filepath.Join(tempDir, "symlink")
+			require.NoError(t, os.Symlink(reqFile, symlinkFile))
+			badFile := filepath.Join(tempDir, "bad-file")
 
-			// A file not in the request shouldn't be allowed
-			_, err = sftpClient.Open(badFile)
-			require.ErrorContains(t, err, fmt.Sprintf("operations are only allowed on %s, not %s", reqFile, badFile))
-			// Since this is an upload no files should be allowed to be read from
-			_, err = sftpClient.OpenFile(reqFile, os.O_RDONLY)
-			require.ErrorContains(t, err, `reading is not allowed`)
-			// Only stats, writes, and chmods should be allowed
-			err = sftpClient.Mkdir(reqFile)
-			require.ErrorContains(t, err, `method mkdir is not allowed on `+reqFile)
+			t.Run("download", func(t *testing.T) {
+				// Create and approve a file download request
+				createAndApproveTransferRequest(t, tracessh.FileTransferReq{
+					Download: true,
+					Location: reqFile,
+				})
 
-			// Only necessary operations should be allowed
-			_, err = sftpClient.Stat(reqFile)
-			require.NoError(t, err)
-			_, err = sftpClient.Lstat(reqFile)
-			require.NoError(t, err)
-			err = sftpClient.Chmod(reqFile, 0o777)
-			require.NoError(t, err)
-			wf, err := sftpClient.OpenFile(reqFile, os.O_WRONLY)
-			require.NoError(t, err)
-			require.NoError(t, wf.Close())
+				// Test that only operations needed to complete the download
+				// are allowed
+				sftpClient := openSFTPClient(t)
+
+				// A file not in the request shouldn't be allowed
+				_, err = sftpClient.Open(badFile)
+				require.ErrorContains(t, err, fmt.Sprintf("operations are only allowed on %s, not %s", reqFile, badFile))
+				// Since this is a download no files should be allowed to be written to
+				_, err = sftpClient.OpenFile(reqFile, os.O_WRONLY)
+				require.ErrorContains(t, err, `writing is not allowed`)
+				// Only stats and reads should be allowed
+				err = sftpClient.Mkdir(reqFile)
+				require.ErrorContains(t, err, `method mkdir is not allowed on `+reqFile)
+				// Since this is a download no files should be allowed to have
+				// their permissions changed
+				err = sftpClient.Chmod(reqFile, 0o777)
+				require.ErrorContains(t, err, `writing is not allowed`)
+
+				// Only necessary operations should be allowed
+				_, err = sftpClient.Stat(reqFile)
+				require.NoError(t, err)
+				_, err = sftpClient.Lstat(reqFile)
+				require.NoError(t, err)
+				rf, err := sftpClient.Open(reqFile)
+				require.NoError(t, err)
+				require.NoError(t, rf.Close())
+			})
+
+			t.Run("upload", func(t *testing.T) {
+				// Create and approve a file upload request
+				createAndApproveTransferRequest(t, tracessh.FileTransferReq{
+					Download: false,
+					Filename: "upload-file",
+					Location: reqFile,
+				})
+
+				sftpClient := openSFTPClient(t)
+
+				// A file not in the request shouldn't be allowed
+				_, err = sftpClient.Open(badFile)
+				require.ErrorContains(t, err, fmt.Sprintf("operations are only allowed on %s, not %s", reqFile, badFile))
+				// Since this is an upload no files should be allowed to be read from
+				_, err = sftpClient.OpenFile(reqFile, os.O_RDONLY)
+				require.ErrorContains(t, err, `reading is not allowed`)
+				// Only stats, writes, and chmods should be allowed
+				err = sftpClient.Mkdir(reqFile)
+				require.ErrorContains(t, err, `method mkdir is not allowed on `+reqFile)
+
+				// Only necessary operations should be allowed
+				_, err = sftpClient.Stat(reqFile)
+				require.NoError(t, err)
+				_, err = sftpClient.Lstat(reqFile)
+				require.NoError(t, err)
+				err = sftpClient.Chmod(reqFile, 0o777)
+				require.NoError(t, err)
+				wf, err := sftpClient.OpenFile(reqFile, os.O_WRONLY)
+				require.NoError(t, err)
+				require.NoError(t, wf.Close())
+
+				require.NoError(t, sftpClient.Close())
+			})
+
+			t.Run("don't evaluate symlinks", func(t *testing.T) {
+				createAndApproveTransferRequest(t, tracessh.FileTransferReq{
+					Download: true,
+					Location: symlinkFile,
+				})
+				sftpClient := openSFTPClient(t)
+				_, err = sftpClient.Open(symlinkFile)
+				require.ErrorContains(t, err, "following symlinks is not allowed")
+			})
 		})
 	}
 }

--- a/lib/srv/sess.go
+++ b/lib/srv/sess.go
@@ -26,6 +26,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"path/filepath"
 	"slices"
 	"strconv"
 	"sync"
@@ -1910,6 +1911,9 @@ func (s *session) addFileTransferRequest(params *rsession.FileTransferRequestPar
 	}
 	if !params.Download && params.Filename == "" {
 		return trace.BadParameter("no source file is set for the upload")
+	}
+	if !filepath.IsAbs(params.Location) {
+		return trace.BadParameter("request path must be absolute")
 	}
 
 	s.fileTransferReq = &fileTransferRequestWithApprovers{

--- a/lib/web/apiserver_test.go
+++ b/lib/web/apiserver_test.go
@@ -1883,7 +1883,7 @@ func TestFileTransferEvents(t *testing.T) {
 	// Create file transfer event
 	data, err := json.Marshal(events.EventFields{
 		"download": true,
-		"location": "~/myfile.txt",
+		"location": "/home/alice/myfile.txt",
 	})
 
 	require.NoError(t, err)

--- a/session/reexec/reexecsftp/sftp.go
+++ b/session/reexec/reexecsftp/sftp.go
@@ -28,8 +28,10 @@ import (
 	"os"
 	"os/user"
 	"path"
+	"path/filepath"
 	"strings"
 	"sync"
+	"syscall"
 	"time"
 
 	"github.com/gravitational/trace"
@@ -79,22 +81,12 @@ func newSFTPHandler(logger *slog.Logger, req *FileTransferRequest, events chan<-
 		allowed = &allowedOps{
 			write: !req.Download,
 		}
-		// TODO(capnspacehook): reject relative paths and symlinks
-		// make filepaths consistent by ensuring all separators use backslashes
-		allowedPath, err := sftputils.ExpandHomeDir(req.Location)
+		allowedPath, err := sftputils.ExpandHomeDir(filepath.ToSlash(req.Location))
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
 		if !path.IsAbs(allowedPath) {
-			currentUser, err := user.Current()
-			if err != nil {
-				return nil, trace.Wrap(err)
-			}
-			if currentUser.HomeDir != "" {
-				allowedPath = path.Join(currentUser.HomeDir, allowedPath)
-			} else {
-				allowedPath = path.Join(string(os.PathSeparator), allowedPath)
-			}
+			return nil, trace.BadParameter("allowed path must be absolute")
 		}
 		allowed.path = path.Clean(allowedPath)
 	}
@@ -114,7 +106,7 @@ func (s *sftpHandler) ensureReqIsAllowed(req *sftp.Request) error {
 		return nil
 	}
 
-	cleaned := path.Clean(req.Filepath)
+	cleaned := path.Clean(filepath.ToSlash(req.Filepath))
 	if s.allowed.path != cleaned {
 		return trace.Errorf("operations are only allowed on %s, not %s", s.allowed.path, cleaned)
 	}
@@ -185,11 +177,23 @@ func (s *sftpHandler) openFile(req *sftp.Request) (sftp.WriterAtReaderAt, error)
 	if err := s.ensureReqIsAllowed(req); err != nil {
 		return nil, err
 	}
-
-	f, err := os.OpenFile(req.Filepath, sftputils.ParseFlags(req), 0o644)
+	flags := sftputils.ParseFlags(req)
+	var f *os.File
+	var err error
+	if s.allowed != nil {
+		// Files in moderated sessions may not include symlinks.
+		f, err = openFileNoFollow(req.Filepath, flags, 0o644)
+	} else {
+		f, err = os.OpenFile(req.Filepath, flags, 0o644)
+	}
 	if err != nil {
+		// Symlink traversal is not allowed for moderated file transfers.
+		if s.allowed != nil && errors.Is(err, syscall.ELOOP) {
+			return nil, trace.Errorf("following symlinks is not allowed for moderated file transfers, request the resolved path instead")
+		}
 		return nil, err
 	}
+
 	trackFile := &sftputils.TrackedFile{File: f}
 	s.mtx.Lock()
 	s.files = append(s.files, trackFile)
@@ -212,6 +216,12 @@ func (s *sftpHandler) Filecmd(req *sftp.Request) (retErr error) {
 	}
 	if err := s.ensureReqIsAllowed(req); err != nil {
 		return err
+	}
+
+	if s.allowed != nil && req.Method == sftputils.MethodSetStat {
+		// Setstat can be called during moderated file transfers, don't follow
+		// symlinks if that's the case.
+		return setstatNoFollow(req.Filepath, req.AttrFlags(), req.Attributes())
 	}
 
 	return sftputils.HandleFilecmd(req, nil /* local filesystem */)
@@ -380,4 +390,132 @@ func openFD(fd uintptr, name string) (*os.File, error) {
 	}
 
 	return file, nil
+}
+
+// openAtAndClose opens a file under the parent directory without following
+// symlinks, then closes the parent file. The parent file will be
+// closed even if this function returns an error.
+func openAtAndClose(parent *os.File, name string, flags int, mode os.FileMode) (*os.File, error) {
+	defer parent.Close()
+	syscallConn, err := parent.SyscallConn()
+	if err != nil {
+		return nil, err
+	}
+	var childFd int
+	var openAtErr error
+	ctrlErr := syscallConn.Control(func(fd uintptr) {
+		for {
+			childFd, openAtErr = unix.Openat(int(fd), name, flags|unix.O_NOFOLLOW|unix.O_CLOEXEC, uint32(mode))
+			if !errors.Is(openAtErr, syscall.EINTR) {
+				return
+			}
+		}
+	})
+	if ctrlErr != nil {
+		return nil, ctrlErr
+	} else if openAtErr != nil {
+		return nil, openAtErr
+	}
+	return os.NewFile(uintptr(childFd), filepath.Join(parent.Name(), name)), nil
+}
+
+// openFileNoFollow opens a file without following symlinks in any part of the path.
+func openFileNoFollow(file string, flags int, mode os.FileMode) (*os.File, error) {
+	if !filepath.IsAbs(file) {
+		return nil, trace.BadParameter("file path must be absolute")
+	}
+	dir, filename := filepath.Split(file)
+	relDir, err := filepath.Rel(string(os.PathSeparator), dir)
+	if err != nil {
+		return nil, err
+	}
+	parent, err := os.OpenFile(string(os.PathSeparator), readOnlyPath, 0)
+	if err != nil {
+		return nil, err
+	}
+	// Open each directory one at a time to ensure no symlinks are followed.
+	for relDir != "" {
+		var part string
+		part, relDir, _ = strings.Cut(relDir, string(os.PathSeparator))
+		parent, err = openAtAndClose(parent, part, unix.O_DIRECTORY|readOnlyPath, 0)
+		if err != nil {
+			return nil, err
+		}
+	}
+	// Set nonblock so we don't hang in case file is a pipe.
+	f, err := openAtAndClose(parent, filename, flags|unix.O_NONBLOCK, mode)
+	if err != nil {
+		return nil, err
+	}
+	info, err := f.Stat()
+	if err != nil {
+		_ = f.Close()
+		return nil, err
+	}
+	if !info.Mode().IsRegular() {
+		_ = f.Close()
+		return nil, trace.BadParameter("path does not point to a regular file")
+	}
+	return f, nil
+}
+
+func chtimes(file *os.File, atime, mtime time.Time) error {
+	syscallConn, err := file.SyscallConn()
+	if err != nil {
+		return err
+	}
+	var modifyErr error
+	ctrlErr := syscallConn.Control(func(fd uintptr) {
+		for {
+			modifyErr = unix.Futimes(int(fd), []unix.Timeval{
+				unix.NsecToTimeval(atime.UnixNano()),
+				unix.NsecToTimeval(mtime.UnixNano()),
+			})
+			if !errors.Is(modifyErr, syscall.EINTR) {
+				return
+			}
+		}
+	})
+	if ctrlErr != nil {
+		return ctrlErr
+	}
+	return modifyErr
+}
+
+// setstatNoFollow sets file attributes on a file without following any symlinks.
+func setstatNoFollow(file string, attrFlags sftp.FileAttrFlags, attrs *sftp.FileStat) error {
+	if !attrFlags.Acmodtime && !attrFlags.Permissions && !attrFlags.Size && !attrFlags.UidGid {
+		return nil
+	}
+	mode := os.O_RDONLY
+	if attrFlags.Size {
+		// Only open in write mode if needed to truncate.
+		mode = os.O_WRONLY
+	}
+	f, err := openFileNoFollow(file, mode, 0)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	if attrFlags.Size {
+		if err := f.Truncate(int64(attrs.Size)); err != nil {
+			return err
+		}
+	}
+	if attrFlags.Acmodtime {
+		if err := chtimes(f, time.Unix(int64(attrs.Atime), 0), time.Unix(int64(attrs.Mtime), 0)); err != nil {
+			return err
+		}
+	}
+	if attrFlags.Permissions {
+		if err := f.Chmod(attrs.FileMode()); err != nil {
+			return err
+		}
+	}
+	if attrFlags.UidGid {
+		if err := f.Chown(int(attrs.UID), int(attrs.GID)); err != nil {
+			return err
+		}
+	}
+	return nil
 }

--- a/session/reexec/reexecsftp/sftp_darwin.go
+++ b/session/reexec/reexecsftp/sftp_darwin.go
@@ -1,0 +1,26 @@
+//go:build darwin
+
+/*
+ * Teleport
+ * Copyright (C) 2023  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package reexecsftp
+
+import "golang.org/x/sys/unix"
+
+// readOnlyPath holds platform-specific flags for opening a directory for openat().
+const readOnlyPath = unix.O_RDONLY

--- a/session/reexec/reexecsftp/sftp_linux.go
+++ b/session/reexec/reexecsftp/sftp_linux.go
@@ -1,0 +1,24 @@
+//go:build linux
+
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package reexecsftp
+
+import "golang.org/x/sys/unix"
+
+// readOnlyPath holds platform-specific flags for opening a directory for openat().
+const readOnlyPath = unix.O_PATH | unix.O_RDONLY

--- a/session/reexec/reexecsftp/sftp_test.go
+++ b/session/reexec/reexecsftp/sftp_test.go
@@ -1,0 +1,248 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package reexecsftp
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/pkg/sftp"
+	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport/session/sftputils"
+)
+
+func TestEnsureReqIsAllowed(t *testing.T) {
+	t.Parallel()
+	const filePath = "/foo/bar/baz.txt"
+	passTests := []struct {
+		name    string
+		allowed *allowedOps
+		req     *sftp.Request
+	}{
+		{
+			name: "no restrictions",
+			req: &sftp.Request{
+				Filepath: filePath,
+				Method:   sftputils.MethodGet,
+			},
+		},
+		{
+			name:    "read",
+			allowed: &allowedOps{path: filePath},
+			req: &sftp.Request{
+				Filepath: filePath,
+				Method:   sftputils.MethodGet,
+			},
+		},
+		{
+			name:    "write",
+			allowed: &allowedOps{path: filePath, write: true},
+			req: &sftp.Request{
+				Filepath: filePath,
+				Method:   sftputils.MethodPut,
+			},
+		},
+		{
+			name:    "chmod",
+			allowed: &allowedOps{path: filePath, write: true},
+			req: &sftp.Request{
+				Filepath: filePath,
+				Method:   sftputils.MethodSetStat,
+			},
+		},
+		{
+			name:    "stat in read mode",
+			allowed: &allowedOps{path: filePath},
+			req: &sftp.Request{
+				Filepath: filePath,
+				Method:   sftputils.MethodStat,
+			},
+		},
+		{
+			name:    "lstat in read mode",
+			allowed: &allowedOps{path: filePath},
+			req: &sftp.Request{
+				Filepath: filePath,
+				Method:   sftputils.MethodLstat,
+			},
+		},
+		{
+			name:    "stat in write mode",
+			allowed: &allowedOps{path: filePath, write: true},
+			req: &sftp.Request{
+				Filepath: filePath,
+				Method:   sftputils.MethodStat,
+			},
+		},
+		{
+			name:    "lstat in write mode",
+			allowed: &allowedOps{path: filePath, write: true},
+			req: &sftp.Request{
+				Filepath: filePath,
+				Method:   sftputils.MethodLstat,
+			},
+		},
+	}
+	for _, tc := range passTests {
+		t.Run("allow "+tc.name, func(t *testing.T) {
+			tc.req.Filepath = filePath
+			if tc.allowed != nil {
+				tc.allowed.path = filePath
+			}
+			handler := &sftpHandler{allowed: tc.allowed}
+			require.NoError(t, handler.ensureReqIsAllowed(tc.req))
+		})
+	}
+
+	const convolutedPath = "/foo/bar/../bar/baz.txt"
+	failTests := []struct {
+		name    string
+		allowed *allowedOps
+		req     *sftp.Request
+	}{
+		{
+			name:    "uncleaned path",
+			allowed: &allowedOps{path: convolutedPath},
+			req: &sftp.Request{
+				Filepath: convolutedPath,
+				Method:   sftputils.MethodGet,
+			},
+		},
+		{
+			name:    "get in write mode",
+			allowed: &allowedOps{path: filePath, write: true},
+			req: &sftp.Request{
+				Filepath: filePath,
+				Method:   sftputils.MethodGet,
+			},
+		},
+		{
+			name:    "write in read mode",
+			allowed: &allowedOps{path: filePath},
+			req: &sftp.Request{
+				Filepath: filePath,
+				Method:   sftputils.MethodPut,
+			},
+		},
+		{
+			name:    "chmod in read mode",
+			allowed: &allowedOps{path: filePath},
+			req: &sftp.Request{
+				Filepath: filePath,
+				Method:   sftputils.MethodSetStat,
+			},
+		},
+		{
+			name:    "unknown method",
+			allowed: &allowedOps{path: filePath},
+			req: &sftp.Request{
+				Filepath: filePath,
+				Method:   sftputils.MethodRename,
+			},
+		},
+	}
+	for _, tc := range failTests {
+		t.Run("deny "+tc.name, func(t *testing.T) {
+			handler := &sftpHandler{allowed: tc.allowed}
+			require.Error(t, handler.ensureReqIsAllowed(tc.req))
+		})
+	}
+}
+
+func newTempDir(t *testing.T) string {
+	tempDir := t.TempDir()
+	tempRoot, err := filepath.EvalSymlinks(tempDir)
+	require.NoError(t, err)
+	return tempRoot
+}
+
+func TestNoFollowFileOperations(t *testing.T) {
+	t.Parallel()
+
+	t.Run("successful on path with no symlinks", func(t *testing.T) {
+		targetFile := filepath.Join(newTempDir(t), "myfile.txt")
+
+		f, err := openFileNoFollow(targetFile, os.O_WRONLY|os.O_CREATE, 0o600)
+		require.NoError(t, err)
+		const fileData = "foo bar baz"
+		_, err = f.WriteString(fileData)
+		require.NoError(t, err)
+		require.NoError(t, f.Close())
+
+		info, err := os.Stat(targetFile)
+		require.NoError(t, err)
+		require.Equal(t, int64(len(fileData)), info.Size())
+		require.Equal(t, os.FileMode(0o600), info.Mode())
+
+		f, err = openFileNoFollow(targetFile, os.O_RDONLY, 0)
+		require.NoError(t, err)
+		data, err := io.ReadAll(f)
+		require.NoError(t, err)
+		require.NoError(t, f.Close())
+		require.Equal(t, []byte(fileData), data)
+
+		updatedTime := info.ModTime().Add(time.Hour).Truncate(time.Second)
+		err = setstatNoFollow(targetFile, sftp.FileAttrFlags{
+			Size:        true,
+			Permissions: true,
+			Acmodtime:   true,
+		}, &sftp.FileStat{
+			Size:  uint64(len(fileData) / 2),
+			Mode:  0o604,
+			Atime: uint32(updatedTime.Unix()),
+			Mtime: uint32(updatedTime.Unix()),
+		})
+		require.NoError(t, err)
+		newInfo, err := os.Stat(targetFile)
+		require.NoError(t, err)
+		require.Equal(t, int64(len(fileData)/2), newInfo.Size())
+		require.Equal(t, os.FileMode(0o604), newInfo.Mode())
+		require.Equal(t, updatedTime, newInfo.ModTime())
+	})
+
+	t.Run("block symlink in parent dir", func(t *testing.T) {
+		tempDir := newTempDir(t)
+		targetFile := filepath.Join(tempDir, "foo.txt")
+		require.NoError(t, os.WriteFile(targetFile, []byte("foo"), 0o644))
+		link := filepath.Join(tempDir, "link")
+		require.NoError(t, os.Symlink(tempDir, link))
+		linkTarget := filepath.Join(link, "foo.txt")
+
+		_, err := openFileNoFollow(linkTarget, os.O_WRONLY|os.O_CREATE, 0o644)
+		require.ErrorIs(t, err, syscall.ENOTDIR)
+		err = setstatNoFollow(linkTarget, sftp.FileAttrFlags{Permissions: true}, &sftp.FileStat{Mode: 0o600})
+		require.ErrorIs(t, err, syscall.ENOTDIR)
+	})
+
+	t.Run("block symlink at end of path", func(t *testing.T) {
+		tempDir := newTempDir(t)
+		targetFile := filepath.Join(tempDir, "foo.txt")
+		require.NoError(t, os.WriteFile(targetFile, []byte("foo"), 0o644))
+		link := filepath.Join(tempDir, "link")
+		require.NoError(t, os.Symlink(targetFile, link))
+
+		_, err := openFileNoFollow(link, os.O_WRONLY|os.O_CREATE, 0o644)
+		require.ErrorIs(t, err, syscall.ELOOP)
+		err = setstatNoFollow(link, sftp.FileAttrFlags{Permissions: true}, &sftp.FileStat{Mode: 0o600})
+		require.ErrorIs(t, err, syscall.ELOOP)
+	})
+}

--- a/session/sftputils/sftp.go
+++ b/session/sftputils/sftp.go
@@ -193,7 +193,6 @@ func (n *NonRecursiveDirectoryTransferError) Error() string {
 func setstat(req *sftp.Request, fs FileSystem) error {
 	attrFlags := req.AttrFlags()
 	attrs := req.Attributes()
-
 	if attrFlags.Acmodtime {
 		atime := time.Unix(int64(attrs.Atime), 0)
 		mtime := time.Unix(int64(attrs.Mtime), 0)


### PR DESCRIPTION
Backport #65674 to branch/v18

Changelog: Stopped traversing symlinks and allowing relative paths in moderated file transfers

## Manual Test Plan
### Test Environment
Enterprise cluster with two users, one that requires a moderator and one that can moderate sessions.
### Test Cases
- [x] Start a moderated session. As the peer, request to download a path that includes a symlink. As the moderator, approve the request. Verify that the peer sees an error message stating that symlinks are not allowed.
- [x] Start a moderated session. Verify that requesting a relative path returns an error.

