### PR TITLE
Add Desktop Session Data to tlsca.Identity

### DIFF
--- a/lib/tlsca/ca.go
+++ b/lib/tlsca/ca.go
@@ -248,7 +248,7 @@ type Identity struct {
 	// WebSessionID is the session ID of the web session associated with this identity, if any.
 	WebSessionID string
 
-	// RouteToWindowsDesktop contains routing information for Windows or Linux desktop sessions.
+	// RouteToDesktop contains routing information for Windows or Linux desktop sessions.
 	RouteToDesktop RouteToDesktop
 }
 

--- a/lib/tlsca/ca.go
+++ b/lib/tlsca/ca.go
@@ -247,6 +247,20 @@ type Identity struct {
 
 	// WebSessionID is the session ID of the web session associated with this identity, if any.
 	WebSessionID string
+
+	// RouteToWindowsDesktop contains routing information for Windows or Linux desktop sessions.
+	RouteToDesktop RouteToDesktop
+}
+
+// RouteToDesktop holds routing information for Windows or Linux desktop sessions.
+type RouteToDesktop struct {
+	// DesktopName is the name of the target desktop.
+	DesktopName string
+	// Login is the username to authenticate as.
+	Login string
+	// SessionID is an ID used to identify desktop sessions created by
+	// this certificate.
+	SessionID string
 }
 
 // RouteToApp holds routing information for applications.
@@ -661,6 +675,20 @@ var (
 	// DelegationSessionIDASN1ExtensionOID is an extension OID that contains the
 	// identifier of the Delegation Session this certificate was created for.
 	DelegationSessionIDASN1ExtensionOID = asn1.ObjectIdentifier{1, 3, 9999, 2, 30}
+
+	// DesktopLoginASN1ExtensionOID is an extension OID that contains the
+	// login username for Windows or Linux desktop session this certificate
+	// was created for.
+	DesktopLoginASN1ExtensionOID = asn1.ObjectIdentifier{1, 3, 9999, 2, 31}
+
+	// DesktopNameASN1ExtensionOID is an extension OID that contains the name
+	// of the target desktop for the Windows or Linux desktop session this
+	// certificate was created for.
+	DesktopNameASN1ExtensionOID = asn1.ObjectIdentifier{1, 3, 9999, 2, 32}
+
+	// DesktopSessionIDASN1ExtensionOID is an extension ID used to encode the
+	// desktop session ID into a certificate.
+	DesktopSessionIDASN1ExtensionOID = asn1.ObjectIdentifier{1, 3, 9999, 2, 33}
 
 	// CAClusterNameExtensionOID records the cluster name in a Teleport CA
 	// certificate.
@@ -1150,6 +1178,30 @@ func (id *Identity) Subject() (pkix.Name, error) {
 			})
 	}
 
+	if id.RouteToDesktop.DesktopName != "" {
+		subject.ExtraNames = append(subject.ExtraNames,
+			pkix.AttributeTypeAndValue{
+				Type:  DesktopNameASN1ExtensionOID,
+				Value: id.RouteToDesktop.DesktopName,
+			})
+	}
+
+	if id.RouteToDesktop.Login != "" {
+		subject.ExtraNames = append(subject.ExtraNames,
+			pkix.AttributeTypeAndValue{
+				Type:  DesktopLoginASN1ExtensionOID,
+				Value: id.RouteToDesktop.Login,
+			})
+	}
+
+	if id.RouteToDesktop.SessionID != "" {
+		subject.ExtraNames = append(subject.ExtraNames,
+			pkix.AttributeTypeAndValue{
+				Type:  DesktopSessionIDASN1ExtensionOID,
+				Value: id.RouteToDesktop.SessionID,
+			})
+	}
+
 	return subject, nil
 }
 
@@ -1471,6 +1523,18 @@ func FromSubject(subject pkix.Name, expires time.Time) (*Identity, error) {
 		case attr.Type.Equal(WebSessionIDASN1ExtensionOID):
 			if val, ok := attr.Value.(string); ok {
 				id.WebSessionID = val
+			}
+		case attr.Type.Equal(DesktopLoginASN1ExtensionOID):
+			if val, ok := attr.Value.(string); ok {
+				id.RouteToDesktop.Login = val
+			}
+		case attr.Type.Equal(DesktopNameASN1ExtensionOID):
+			if val, ok := attr.Value.(string); ok {
+				id.RouteToDesktop.DesktopName = val
+			}
+		case attr.Type.Equal(DesktopSessionIDASN1ExtensionOID):
+			if val, ok := attr.Value.(string); ok {
+				id.RouteToDesktop.SessionID = val
 			}
 		}
 	}

--- a/lib/tlsca/ca_test.go
+++ b/lib/tlsca/ca_test.go
@@ -743,3 +743,45 @@ func TestDelegationSessionID(t *testing.T) {
 	require.False(t, out.Renewable)
 	require.Empty(t, cmp.Diff(out, &identity, cmpopts.EquateApproxTime(time.Second)))
 }
+
+func TestDesktopExtensions(t *testing.T) {
+	clock := clockwork.NewFakeClock()
+	ca, err := FromKeys([]byte(fixtures.TLSCACertPEM), []byte(fixtures.TLSCAKeyPEM))
+	require.NoError(t, err)
+
+	privateKey, err := cryptosuites.GenerateKeyWithAlgorithm(cryptosuites.ECDSAP256)
+	require.NoError(t, err)
+
+	expires := clock.Now().Add(time.Hour)
+	identity := Identity{
+		Username:     "alice@example.com",
+		Groups:       []string{"admin"},
+		Impersonator: "bob@example.com",
+		Usage:        []string{teleport.UsageAppsOnly},
+		RouteToDesktop: RouteToDesktop{
+			SessionID:   "43de4ffa8509aff3e3990e941400a403a12a6024d59897167b780ec0d03a1f15",
+			Login:       "Administrator@corp.local",
+			DesktopName: "dc1.corp.local",
+		},
+		TeleportCluster:   "tele-cluster",
+		OriginClusterName: "tele-cluster",
+		Expires:           expires,
+	}
+
+	subj, err := identity.Subject()
+	require.NoError(t, err)
+
+	certBytes, err := ca.GenerateCertificate(CertificateRequest{
+		Clock:     clock,
+		PublicKey: privateKey.Public(),
+		Subject:   subj,
+		NotAfter:  expires,
+	})
+	require.NoError(t, err)
+
+	cert, err := ParseCertificatePEM(certBytes)
+	require.NoError(t, err)
+	out, err := FromSubject(cert.Subject, cert.NotAfter)
+	require.NoError(t, err)
+	require.Empty(t, cmp.Diff(out, &identity, cmpopts.EquateApproxTime(time.Second)))
+}


### PR DESCRIPTION
Define new OIDs for desktop session data and update `FromSubject/Subject` implementations to read and write them.

<!-- Provide a descriptive entry for the changelog of the next release. -->


<!-- Include manual testing efforts to verify the change. -->
<!-- Detail where the tests where run and what configurations were used. -->
<!-- Include all the test cases which were run to validate the change. -->

## Manual Test Plan
### Test Environment
Unit tests
### Test Cases
- [x] Unit tests for desktop session details pass.
