### PR TITLE
Add updater support for `teleport-operator`

### DIFF
--- a/docs/pages/includes/helm-reference/zz_generated.teleport-operator.mdx
+++ b/docs/pages/includes/helm-reference/zz_generated.teleport-operator.mdx
@@ -134,6 +134,139 @@ pods run by the chart.
 You can override this to use your own Teleport Kubernetes Operator
 image rather than a Teleport-published image.
 
+## `updater`
+
+`updater` controls whether the Teleport Kube Updater should be deployed alongside
+the operator. The updater fetches the target version, validates the
+image signature, and updates the teleport operator.
+
+The updater fetches the update information using two protocols by querying the Teleport Proxy Service.
+
+All Kubernetes-specific fields such as `tolerations`, `affinity`, `nodeSelector`,
+... default to the updater values. However, they can be overridden from the
+`updater` object. For example:
+
+```yaml
+# the operator pod requests 1cpu and 2 GiB of memory. It also has a memory limit.
+resources:
+  requests:
+    cpu: "1"
+    memory: "2Gi"
+  limits:
+    memory: "2Gi"
+
+# the updater pod requests 0.5 cpu and 512MiB of memory. The memory limit has also been unset.
+updater:
+  resources:
+    requests:
+      cpu: "0.5"
+      memory: "512Mi"
+    limits: ~
+```
+
+Other updater-specific values that can be defined in `updater` are described
+below.
+
+### `updater.enabled`
+
+| Type | Default |
+|------|---------|
+| `bool` | `false` |
+
+`updater.enabled` Enables the Kube Agent Updater and deploys it alongside the Teleport Agent.
+
+### `updater.group`
+
+| Type | Default |
+|------|---------|
+| `string` | `""` |
+
+`updater.group` is the update group used when fetching the version using the webapi protocol.
+When unset, the group defaults to `default`.
+
+### `updater.image`
+
+| Type | Default |
+|------|---------|
+| `string` | `"public.ecr.aws/gravitational/teleport-kube-agent-updater"` |
+
+`updater.image` sets the container image used for Teleport updater
+pods run when `updater.enabled` is true.
+
+You can override this to use your own Teleport Kube Agent Updater image rather
+than a Teleport-published image.
+
+### `updater.serviceAccount`
+
+#### `updater.serviceAccount.name`
+
+| Type | Default |
+|------|---------|
+| `string` | `""` |
+
+`updater.serviceAccount.name` is the updater Kubernetes Service
+Account name. When unset, it defaults to `<kube agent sa name>-updater`
+
+### `updater.pullCredentials`
+
+| Type | Default |
+|------|---------|
+| `string` | `""` |
+
+`updater.pullCredentials` configures how the updater attempts to
+get the image pull credentials used to validate the image signature.
+
+This is not required when pulling images from official public Teleport
+registries (chart's default).
+
+Supported values are `aws`, `google`, `docker` and `none`.
+
+### `updater.extraArgs`
+
+| Type | Default |
+|------|---------|
+| `list` | `[]` |
+
+`updater.extraArgs` contains additional arguments to pass to the updater
+binary.
+
+### `updater.extraVolumes`
+
+| Type | Default |
+|------|---------|
+| `list` | `[]` |
+
+`updater.extraVolumes` contains extra volumes to mount into the Updater pods.
+See [the Kubernetes volume documentation](https://kubernetes.io/docs/concepts/storage/volumes/)
+for more details.
+
+For example:
+```yaml
+updater:
+  extraVolumes:
+  - name: myvolume
+    secret:
+      secretName: testSecret
+```
+
+### `updater.extraVolumeMounts`
+
+| Type | Default |
+|------|---------|
+| `list` | `[]` |
+
+`updater.extraVolumeMounts` contains extra volumes mounts for the updater.
+See [the Kubernetes volume documentation](https://kubernetes.io/docs/concepts/storage/volumes/)
+for more details.
+
+For example:
+```yaml
+updater:
+  extraVolumesMounts:
+  - name: myvolume
+    mountPath: /path/on/host
+```
+
 ## `annotations`
 
 ### `annotations.deployment`

--- a/examples/chart/teleport-cluster/charts/teleport-operator/.lint/all-kube-settings.yaml
+++ b/examples/chart/teleport-cluster/charts/teleport-operator/.lint/all-kube-settings.yaml
@@ -1,0 +1,45 @@
+teleportAddress: "example.teleport.sh:443"
+token: "my-operator-bot"
+teleportClusterName: "example.teleport.sh"
+updater:
+  enabled: true
+affinity:
+  nodeAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+      nodeSelectorTerms:
+        - matchExpressions:
+            - key: gravitational.io/dedicated
+              operator: In
+              values:
+                - teleport
+  podAntiAffinity:
+    preferredDuringSchedulingIgnoredDuringExecution:
+      - podAffinityTerm:
+          labelSelector:
+            matchExpressions:
+              - key: app
+                operator: In
+                values:
+                  - teleport
+          topologyKey: kubernetes.io/hostname
+        weight: 1
+nodeSelector:
+  gravitational.io/k8s-role: node
+imagePullSecrets:
+  - name: myRegistryKeySecretName
+tolerations:
+  - key: "dedicated"
+    operator: "Equal"
+    value: "teleport"
+    effect: "NoExecute"
+  - key: "dedicated"
+    operator: "Equal"
+    value: "teleport"
+    effect: "NoSchedule"
+imagePullPolicy: Always
+serviceAccount:
+  name: teleport-operator
+tls:
+  existingCASecretName: "helm-lint-existing-tls-secret-ca"
+  existingCASecretKeyName: "helm-lint-existing-tls-secret-key-name"
+priorityClassName: teleport-operator

--- a/examples/chart/teleport-cluster/charts/teleport-operator/.lint/updater-secret-docker.yaml
+++ b/examples/chart/teleport-cluster/charts/teleport-operator/.lint/updater-secret-docker.yaml
@@ -1,0 +1,22 @@
+teleportAddress: "example.teleport.sh:443"
+token: "my-operator-bot"
+teleportClusterName: "example.teleport.sh"
+updater:
+  enabled: true
+  pullCredentials: docker
+  extraEnv:
+    - name: DOCKER_CONFIG
+      value: /mnt/docker/
+  extraVolumes:
+    - name: docker-config
+      projected:
+        sources:
+          - secret:
+              name: my-pull-secret
+              items:
+                - key: .dockerconfigjson
+                  path: config.json
+  extraVolumeMounts:
+    - name: docker-config
+      mountPath: "/mnt/docker"
+      readOnly: true

--- a/examples/chart/teleport-cluster/charts/teleport-operator/.lint/updater.yaml
+++ b/examples/chart/teleport-cluster/charts/teleport-operator/.lint/updater.yaml
@@ -1,0 +1,5 @@
+teleportAddress: "example.teleport.sh:443"
+token: "my-operator-bot"
+teleportClusterName: "example.teleport.sh"
+updater:
+  enabled: true

--- a/examples/chart/teleport-cluster/charts/teleport-operator/Chart.yaml
+++ b/examples/chart/teleport-cluster/charts/teleport-operator/Chart.yaml
@@ -6,3 +6,7 @@ description: Teleport Operator provides management of select Teleport resources.
 icon: https://goteleport.com/static/teleport-symbol-bimi.svg
 keywords:
   - Teleport
+
+dependencies:
+  - name: teleport-kube-updater
+    version: *version

--- a/examples/chart/teleport-cluster/charts/teleport-operator/charts/teleport-kube-updater
+++ b/examples/chart/teleport-cluster/charts/teleport-operator/charts/teleport-kube-updater
@@ -1,0 +1,1 @@
+../../../../teleport-kube-updater/

--- a/examples/chart/teleport-cluster/charts/teleport-operator/templates/updater.yaml
+++ b/examples/chart/teleport-cluster/charts/teleport-operator/templates/updater.yaml
@@ -1,0 +1,26 @@
+{{- if .Values.updater.enabled -}}
+{{- $updater := mustMergeOverwrite (mustDeepCopy .Values) .Values.updater }}
+{{/* Pass additional value from outside of updater. */}}
+{{- $_ := set $updater "releaseName" .Release.Name }}
+{{- $_ = set $updater "releaseNamespace" .Release.Namespace }}
+
+{{/* Unset updater-specific values so we don't accidentally pick up teleport-specific things. */}}
+{{- if not .Values.updater.extraArgs }}
+  {{- $_ = unset $updater "extraArgs" }}
+{{- end }}
+{{- if not .Values.updater.extraVolumes }}
+  {{- $_ = unset $updater "extraVolumes" }}
+{{- end }}
+{{- if not .Values.updater.extraVolumeMounts }}
+  {{- $_ = unset $updater "extraVolumeMounts" }}
+{{- end }}
+{{/* Compute dynamic values (depending on other teleport-kube agent values). */}}
+{{- $_ = set $updater.serviceAccount "name" (coalesce .Values.updater.serviceAccount.name (include "teleport-cluster.operator.serviceAccountName" . | printf "%s-updater")) }}
+{{- $_ = set $updater "extraLabels" .Values.labels }}
+{{- $_ = set $updater "versionServer" "" }}
+{{- $_ = set $updater "version" (include "teleport-cluster.version" .)}}
+{{- $_ = set $updater "proxyAddr" .Values.teleportAddress }}
+{{- $_ = set $updater "baseImage" .Values.image }}
+{{- $_ = set $updater "containerName" "operator" }}
+{{ include "teleport-kube-updater.all" $updater }}
+{{- end -}}

--- a/examples/chart/teleport-cluster/charts/teleport-operator/templates/updater.yaml
+++ b/examples/chart/teleport-cluster/charts/teleport-operator/templates/updater.yaml
@@ -1,7 +1,7 @@
 {{- if .Values.updater.enabled -}}
 {{- $updater := mustMergeOverwrite (mustDeepCopy .Values) .Values.updater }}
 {{/* Pass additional value from outside of updater. */}}
-{{- $_ := set $updater "releaseName" .Release.Name }}
+{{- $_ := set $updater "releaseName" ( include "teleport-cluster.operator.fullname" . ) }}
 {{- $_ = set $updater "releaseNamespace" .Release.Namespace }}
 
 {{/* Unset updater-specific values so we don't accidentally pick up teleport-specific things. */}}

--- a/examples/chart/teleport-cluster/charts/teleport-operator/tests/__snapshot__/updater_deployment_test.yaml.snap
+++ b/examples/chart/teleport-cluster/charts/teleport-operator/tests/__snapshot__/updater_deployment_test.yaml.snap
@@ -1,0 +1,176 @@
+sets the affinity:
+  1: |
+    affinity:
+      nodeAffinity:
+        requiredDuringSchedulingIgnoredDuringExecution:
+          nodeSelectorTerms:
+          - matchExpressions:
+            - key: gravitational.io/dedicated
+              operator: In
+              values:
+              - teleport
+      podAntiAffinity:
+        preferredDuringSchedulingIgnoredDuringExecution:
+        - podAffinityTerm:
+            labelSelector:
+              matchExpressions:
+              - key: app
+                operator: In
+                values:
+                - teleport
+            topologyKey: kubernetes.io/hostname
+          weight: 1
+    containers:
+    - args:
+      - --agent-name=RELEASE-NAME
+      - --agent-namespace=NAMESPACE
+      - --base-image=public.ecr.aws/gravitational/teleport-operator
+      - --container-name=operator
+      - --proxy-address=example.teleport.sh:443
+      - --update-group=default
+      env:
+      - name: SSL_CERT_FILE
+        value: /etc/teleport-tls-ca/helm-lint-existing-tls-secret-key-name
+      image: public.ecr.aws/gravitational/teleport-kube-agent-updater:19.0.0-prealpha.2
+      imagePullPolicy: Always
+      livenessProbe:
+        failureThreshold: 6
+        httpGet:
+          path: /healthz
+          port: healthz
+        initialDelaySeconds: 5
+        periodSeconds: 5
+        timeoutSeconds: 5
+      name: kube-agent-updater
+      ports:
+      - containerPort: 8080
+        name: metrics
+        protocol: TCP
+      - containerPort: 8081
+        name: healthz
+        protocol: TCP
+      readinessProbe:
+        failureThreshold: 6
+        httpGet:
+          path: /readyz
+          port: healthz
+        initialDelaySeconds: 5
+        periodSeconds: 5
+        timeoutSeconds: 5
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop:
+          - ALL
+        readOnlyRootFilesystem: true
+      volumeMounts:
+      - mountPath: /etc/teleport-tls-ca
+        name: teleport-tls-ca
+        readOnly: true
+    imagePullSecrets:
+    - name: myRegistryKeySecretName
+    nodeSelector:
+      gravitational.io/k8s-role: node
+    priorityClassName: teleport-operator
+    serviceAccountName: teleport-operator-updater
+    tolerations:
+    - effect: NoExecute
+      key: dedicated
+      operator: Equal
+      value: teleport
+    - effect: NoSchedule
+      key: dedicated
+      operator: Equal
+      value: teleport
+    volumes:
+    - name: teleport-tls-ca
+      secret:
+        secretName: helm-lint-existing-tls-secret-ca
+sets the tolerations:
+  1: |
+    affinity:
+      nodeAffinity:
+        requiredDuringSchedulingIgnoredDuringExecution:
+          nodeSelectorTerms:
+          - matchExpressions:
+            - key: gravitational.io/dedicated
+              operator: In
+              values:
+              - teleport
+      podAntiAffinity:
+        preferredDuringSchedulingIgnoredDuringExecution:
+        - podAffinityTerm:
+            labelSelector:
+              matchExpressions:
+              - key: app
+                operator: In
+                values:
+                - teleport
+            topologyKey: kubernetes.io/hostname
+          weight: 1
+    containers:
+    - args:
+      - --agent-name=RELEASE-NAME
+      - --agent-namespace=NAMESPACE
+      - --base-image=public.ecr.aws/gravitational/teleport-operator
+      - --container-name=operator
+      - --proxy-address=example.teleport.sh:443
+      - --update-group=default
+      env:
+      - name: SSL_CERT_FILE
+        value: /etc/teleport-tls-ca/helm-lint-existing-tls-secret-key-name
+      image: public.ecr.aws/gravitational/teleport-kube-agent-updater:19.0.0-prealpha.2
+      imagePullPolicy: Always
+      livenessProbe:
+        failureThreshold: 6
+        httpGet:
+          path: /healthz
+          port: healthz
+        initialDelaySeconds: 5
+        periodSeconds: 5
+        timeoutSeconds: 5
+      name: kube-agent-updater
+      ports:
+      - containerPort: 8080
+        name: metrics
+        protocol: TCP
+      - containerPort: 8081
+        name: healthz
+        protocol: TCP
+      readinessProbe:
+        failureThreshold: 6
+        httpGet:
+          path: /readyz
+          port: healthz
+        initialDelaySeconds: 5
+        periodSeconds: 5
+        timeoutSeconds: 5
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop:
+          - ALL
+        readOnlyRootFilesystem: true
+      volumeMounts:
+      - mountPath: /etc/teleport-tls-ca
+        name: teleport-tls-ca
+        readOnly: true
+    imagePullSecrets:
+    - name: myRegistryKeySecretName
+    nodeSelector:
+      gravitational.io/k8s-role: node
+    priorityClassName: teleport-operator
+    serviceAccountName: teleport-operator-updater
+    tolerations:
+    - effect: NoExecute
+      key: dedicated
+      operator: Equal
+      value: teleport
+    - effect: NoSchedule
+      key: dedicated
+      operator: Equal
+      value: teleport
+    volumes:
+    - name: teleport-tls-ca
+      secret:
+        secretName: helm-lint-existing-tls-secret-ca

--- a/examples/chart/teleport-cluster/charts/teleport-operator/tests/__snapshot__/updater_deployment_test.yaml.snap
+++ b/examples/chart/teleport-cluster/charts/teleport-operator/tests/__snapshot__/updater_deployment_test.yaml.snap
@@ -22,7 +22,7 @@ sets the affinity:
           weight: 1
     containers:
     - args:
-      - --agent-name=RELEASE-NAME
+      - --agent-name=RELEASE-NAME-teleport-operator
       - --agent-namespace=NAMESPACE
       - --base-image=public.ecr.aws/gravitational/teleport-operator
       - --container-name=operator
@@ -72,6 +72,13 @@ sets the affinity:
     nodeSelector:
       gravitational.io/k8s-role: node
     priorityClassName: teleport-operator
+    securityContext:
+      fsGroup: 65532
+      runAsGroup: 65532
+      runAsNonRoot: true
+      runAsUser: 65532
+      seccompProfile:
+        type: RuntimeDefault
     serviceAccountName: teleport-operator-updater
     tolerations:
     - effect: NoExecute
@@ -110,7 +117,7 @@ sets the tolerations:
           weight: 1
     containers:
     - args:
-      - --agent-name=RELEASE-NAME
+      - --agent-name=RELEASE-NAME-teleport-operator
       - --agent-namespace=NAMESPACE
       - --base-image=public.ecr.aws/gravitational/teleport-operator
       - --container-name=operator
@@ -160,6 +167,13 @@ sets the tolerations:
     nodeSelector:
       gravitational.io/k8s-role: node
     priorityClassName: teleport-operator
+    securityContext:
+      fsGroup: 65532
+      runAsGroup: 65532
+      runAsNonRoot: true
+      runAsUser: 65532
+      seccompProfile:
+        type: RuntimeDefault
     serviceAccountName: teleport-operator-updater
     tolerations:
     - effect: NoExecute

--- a/examples/chart/teleport-cluster/charts/teleport-operator/tests/__snapshot__/updater_role_test.yaml.snap
+++ b/examples/chart/teleport-cluster/charts/teleport-operator/tests/__snapshot__/updater_role_test.yaml.snap
@@ -1,0 +1,93 @@
+sets the correct role rules:
+  1: |
+    - apiGroups:
+      - ""
+      resources:
+      - pods
+      verbs:
+      - get
+      - watch
+      - list
+      - delete
+    - apiGroups:
+      - ""
+      resources:
+      - pods/status
+      verbs:
+      - get
+      - watch
+      - list
+    - apiGroups:
+      - ""
+      resources:
+      - secrets
+      verbs:
+      - watch
+      - list
+    - apiGroups:
+      - ""
+      resourceNames:
+      - RELEASE-NAME-shared-state
+      resources:
+      - secrets
+      verbs:
+      - get
+    - apiGroups:
+      - ""
+      resources:
+      - events
+      verbs:
+      - create
+      - patch
+    - apiGroups:
+      - ""
+      resources:
+      - configmaps
+      verbs:
+      - create
+      - watch
+      - list
+    - apiGroups:
+      - ""
+      resourceNames:
+      - RELEASE-NAME-updater
+      resources:
+      - configmaps
+      verbs:
+      - get
+      - update
+    - apiGroups:
+      - apps
+      resources:
+      - deployments
+      - statefulsets
+      - deployments/status
+      - statefulsets/status
+      verbs:
+      - get
+      - watch
+      - list
+    - apiGroups:
+      - apps
+      resourceNames:
+      - RELEASE-NAME
+      resources:
+      - deployments
+      - statefulsets
+      verbs:
+      - update
+    - apiGroups:
+      - coordination.k8s.io
+      resources:
+      - leases
+      verbs:
+      - create
+    - apiGroups:
+      - coordination.k8s.io
+      resourceNames:
+      - RELEASE-NAME
+      resources:
+      - leases
+      verbs:
+      - get
+      - update

--- a/examples/chart/teleport-cluster/charts/teleport-operator/tests/__snapshot__/updater_role_test.yaml.snap
+++ b/examples/chart/teleport-cluster/charts/teleport-operator/tests/__snapshot__/updater_role_test.yaml.snap
@@ -27,7 +27,7 @@ sets the correct role rules:
     - apiGroups:
       - ""
       resourceNames:
-      - RELEASE-NAME-shared-state
+      - RELEASE-NAME-teleport-operator-shared-state
       resources:
       - secrets
       verbs:
@@ -50,7 +50,7 @@ sets the correct role rules:
     - apiGroups:
       - ""
       resourceNames:
-      - RELEASE-NAME-updater
+      - RELEASE-NAME-teleport-operator-updater
       resources:
       - configmaps
       verbs:
@@ -70,7 +70,7 @@ sets the correct role rules:
     - apiGroups:
       - apps
       resourceNames:
-      - RELEASE-NAME
+      - RELEASE-NAME-teleport-operator
       resources:
       - deployments
       - statefulsets
@@ -85,7 +85,7 @@ sets the correct role rules:
     - apiGroups:
       - coordination.k8s.io
       resourceNames:
-      - RELEASE-NAME
+      - RELEASE-NAME-teleport-operator
       resources:
       - leases
       verbs:

--- a/examples/chart/teleport-cluster/charts/teleport-operator/tests/updater_deployment_test.yaml
+++ b/examples/chart/teleport-cluster/charts/teleport-operator/tests/updater_deployment_test.yaml
@@ -1,0 +1,320 @@
+suite: Updater Deployment
+templates:
+  - updater.yaml
+tests:
+  #
+  # Basic tests
+  #
+  - it: does not create a Deployment when updater.enabled is false (default)
+    asserts:
+      - hasDocuments:
+          count: 0
+  - it: creates a Deployment when updater.enabled is true
+    values:
+      - ../.lint/updater.yaml
+    asserts:
+      - containsDocument:
+          kind: Deployment
+          apiVersion: apps/v1
+          name: RELEASE-NAME-updater
+          namespace: NAMESPACE
+  #
+  # Testing the agent configuration
+  #
+  - it: sets the updater base image
+    documentIndex: 0
+    values:
+      - ../.lint/updater.yaml
+    set:
+      image: repo.example.com/gravitational/teleport-distroless
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "--base-image=repo.example.com/gravitational/teleport-distroless"
+  - it: updater defaults to the operator image
+    documentIndex: 0
+    values:
+      - ../.lint/updater.yaml
+    set:
+      enterprise: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "--base-image=public.ecr.aws/gravitational/teleport-operator"
+  - it: sets the updater agent name
+    documentIndex: 0
+    values:
+      - ../.lint/updater.yaml
+    release:
+      name: my-release
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "--agent-name=my-release"
+  - it: sets the updater agent namespace
+    documentIndex: 0
+    values:
+      - ../.lint/updater.yaml
+    release:
+      namespace: my-namespace
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "--agent-namespace=my-namespace"
+  - it: defaults the updater proxy server to the proxy address
+    documentIndex: 0
+    set:
+      teleportAddress: proxy.teleport.example.com:443
+      updater:
+        enabled: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "--proxy-address=proxy.teleport.example.com:443"
+  - it: defaults the update group to the release channel when group is unset
+    documentIndex: 0
+    set:
+      teleportAddress: proxy.teleport.example.com:443
+      updater:
+        enabled: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "--update-group=default"
+  - it: uses the update group when set
+    documentIndex: 0
+    set:
+      teleportAddress: proxy.teleport.example.com:443
+      updater:
+        enabled: true
+        group: "foobar"
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "--update-group=foobar"
+  #
+  # Kubernetes-related tests
+  #
+  - it: sets the deployment annotations
+    documentIndex: 0
+    values:
+      - ../.lint/updater.yaml
+      - ../.lint/annotations.yaml
+    asserts:
+      - equal:
+          path: metadata.annotations.kubernetes\.io/deployment
+          value: test-annotation
+      - equal:
+          path: metadata.annotations.kubernetes\.io/deployment-different
+          value: 3
+  - it: sets the pod annotations
+    documentIndex: 0
+    values:
+      - ../.lint/updater.yaml
+      - ../.lint/annotations.yaml
+    asserts:
+      - equal:
+          path: spec.template.metadata.annotations.kubernetes\.io/pod
+          value: test-annotation
+      - equal:
+          path: spec.template.metadata.annotations.kubernetes\.io/pod-different
+          value: 4
+  - it: sets the affinity
+    documentIndex: 0
+    values:
+      - ../.lint/updater.yaml
+      - ../.lint/all-kube-settings.yaml
+    asserts:
+      - isNotNull:
+          path: spec.template.spec.affinity
+      - matchSnapshot:
+          path: spec.template.spec
+  - it: sets the tolerations
+    documentIndex: 0
+    values:
+      - ../.lint/updater.yaml
+      - ../.lint/all-kube-settings.yaml
+    asserts:
+      - isNotNull:
+          path: spec.template.spec.tolerations
+      - matchSnapshot:
+          path: spec.template.spec
+  - it: sets the imagePullSecrets
+    documentIndex: 0
+    values:
+      - ../.lint/updater.yaml
+      - ../.lint/all-kube-settings.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.imagePullSecrets[0].name
+          value: myRegistryKeySecretName
+  - it: sets the nodeSelector
+    documentIndex: 0
+    values:
+      - ../.lint/updater.yaml
+      - ../.lint/all-kube-settings.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.nodeSelector
+          value:
+            gravitational.io/k8s-role: node
+  - it: sets the updater container image and version
+    documentIndex: 0
+    values:
+      - ../.lint/updater.yaml
+    set:
+      teleportVersionOverride: 12.2.1
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: public.ecr.aws/gravitational/teleport-kube-agent-updater:12.2.1
+  - it: sets the updater container imagePullPolicy
+    documentIndex: 0
+    values:
+      - ../.lint/updater.yaml
+      - ../.lint/all-kube-settings.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].imagePullPolicy
+          value: Always
+  - it: mounts the tls CA if provided and set the env var
+    documentIndex: 0
+    values:
+      - ../.lint/updater.yaml
+      - ../.lint/all-kube-settings.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: teleport-tls-ca
+            secret:
+              secretName: helm-lint-existing-tls-secret-ca
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            mountPath: /etc/teleport-tls-ca
+            name: teleport-tls-ca
+            readOnly: true
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SSL_CERT_FILE
+            value: /etc/teleport-tls-ca/helm-lint-existing-tls-secret-key-name
+  - it: sets the updater container extraEnv
+    documentIndex: 0
+    values:
+      - ../.lint/updater.yaml
+    set:
+      updater:
+        extraEnv:
+          - name: HTTPS_PROXY
+            value: http://username:password@my.proxy.host:3128
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: HTTPS_PROXY
+            value: http://username:password@my.proxy.host:3128
+  - it: sets the pod resources
+    documentIndex: 0
+    values:
+      - ../.lint/updater.yaml
+      - ../.lint/resources.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].resources.limits.cpu
+          value: 2
+      - equal:
+          path: spec.template.spec.containers[0].resources.limits.memory
+          value: 4Gi
+      - equal:
+          path: spec.template.spec.containers[0].resources.requests.cpu
+          value: 1
+      - equal:
+          path: spec.template.spec.containers[0].resources.requests.memory
+          value: 2Gi
+  - it: sets the pod priorityClass
+    documentIndex: 0
+    values:
+      - ../.lint/updater.yaml
+      - ../.lint/all-kube-settings.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.priorityClassName
+          value: teleport-operator
+  - it: sets the pod service-account
+    documentIndex: 0
+    values:
+      - ../.lint/updater.yaml
+      - ../.lint/all-kube-settings.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.serviceAccountName
+          value: teleport-operator-updater
+  - it: sets the pod service-account (override)
+    documentIndex: 0
+    values:
+      - ../.lint/updater.yaml
+      - ../.lint/all-kube-settings.yaml
+    set:
+      updater:
+        serviceAccount:
+          name: distinct-updater-sa
+    asserts:
+      - equal:
+          path: spec.template.spec.serviceAccountName
+          value: distinct-updater-sa
+
+  - it: sets extraArgs when set
+    documentIndex: 0
+    values:
+      - ../.lint/updater.yaml
+    set:
+      updater:
+        extraArgs:
+          - "--foo=bar"
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "--foo=bar"
+
+  - it: sets the pull credentials when specified
+    documentIndex: 0
+    values:
+      - ../.lint/updater.yaml
+    set:
+      updater:
+        pullCredentials: "aws"
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "--pull-credentials=aws"
+
+  - it: sets extraVolumes when specified
+    documentIndex: 0
+    values:
+      - ../.lint/updater-secret-docker.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: docker-config
+            projected:
+              sources:
+                - secret:
+                    name: my-pull-secret
+                    items:
+                      - key: .dockerconfigjson
+                        path: config.json
+
+  - it: sets extraVolumeMounts when specified
+    documentIndex: 0
+    values:
+      - ../.lint/updater-secret-docker.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: docker-config
+            mountPath: "/mnt/docker"
+            readOnly: true

--- a/examples/chart/teleport-cluster/charts/teleport-operator/tests/updater_deployment_test.yaml
+++ b/examples/chart/teleport-cluster/charts/teleport-operator/tests/updater_deployment_test.yaml
@@ -16,7 +16,7 @@ tests:
       - containsDocument:
           kind: Deployment
           apiVersion: apps/v1
-          name: RELEASE-NAME-updater
+          name: RELEASE-NAME-teleport-operator-updater
           namespace: NAMESPACE
   #
   # Testing the agent configuration
@@ -50,7 +50,7 @@ tests:
     asserts:
       - contains:
           path: spec.template.spec.containers[0].args
-          content: "--agent-name=my-release"
+          content: "--agent-name=my-release-teleport-operator"
   - it: sets the updater agent namespace
     documentIndex: 0
     values:

--- a/examples/chart/teleport-cluster/charts/teleport-operator/tests/updater_role_test.yaml
+++ b/examples/chart/teleport-cluster/charts/teleport-operator/tests/updater_role_test.yaml
@@ -1,0 +1,30 @@
+suite: Updater Role
+templates:
+  - updater.yaml
+tests:
+  #
+  # Basic tests
+  #
+  - it: does not create a Role when updater.enabled is false (default)
+    asserts:
+      - hasDocuments:
+          count: 0
+  - it: creates a Role when updater.enabled is true
+    values:
+      - ../.lint/updater.yaml
+    asserts:
+      - containsDocument:
+          kind: Role
+          apiVersion: rbac.authorization.k8s.io/v1
+          name: RELEASE-NAME-updater
+          namespace: NAMESPACE
+  #
+  # Catch-all content test
+  #
+  - it: sets the correct role rules
+    documentIndex: 1
+    values:
+      - ../.lint/updater.yaml
+    asserts:
+      - matchSnapshot:
+          path: rules

--- a/examples/chart/teleport-cluster/charts/teleport-operator/tests/updater_role_test.yaml
+++ b/examples/chart/teleport-cluster/charts/teleport-operator/tests/updater_role_test.yaml
@@ -16,7 +16,7 @@ tests:
       - containsDocument:
           kind: Role
           apiVersion: rbac.authorization.k8s.io/v1
-          name: RELEASE-NAME-updater
+          name: RELEASE-NAME-teleport-operator-updater
           namespace: NAMESPACE
   #
   # Catch-all content test

--- a/examples/chart/teleport-cluster/charts/teleport-operator/tests/updater_rolebinding_test.yaml
+++ b/examples/chart/teleport-cluster/charts/teleport-operator/tests/updater_rolebinding_test.yaml
@@ -1,0 +1,41 @@
+suite: Updater RoleBinding
+templates:
+  - updater.yaml
+tests:
+  #
+  # Basic tests
+  #
+  - it: does not create a RoleBinding when updater.enabled is false (default)
+    asserts:
+      - hasDocuments:
+          count: 0
+  - it: creates a RoleBinding when updater.enabled is true
+    values:
+      - ../.lint/updater.yaml
+    asserts:
+      - containsDocument:
+          kind: RoleBinding
+          apiVersion: rbac.authorization.k8s.io/v1
+          name: RELEASE-NAME-updater
+          namespace: NAMESPACE
+
+  #
+  # Catch-all content test
+  #
+  - it: sets the correct rolebinding content
+    documentIndex: 2
+    values:
+      - ../.lint/updater.yaml
+    asserts:
+      - equal:
+          path: roleRef
+          value:
+            apiGroup: rbac.authorization.k8s.io
+            kind: Role
+            name: RELEASE-NAME-updater
+      - equal:
+          path: subjects
+          value:
+            - kind: ServiceAccount
+              name: RELEASE-NAME-teleport-operator-updater
+              namespace: NAMESPACE

--- a/examples/chart/teleport-cluster/charts/teleport-operator/tests/updater_rolebinding_test.yaml
+++ b/examples/chart/teleport-cluster/charts/teleport-operator/tests/updater_rolebinding_test.yaml
@@ -16,7 +16,7 @@ tests:
       - containsDocument:
           kind: RoleBinding
           apiVersion: rbac.authorization.k8s.io/v1
-          name: RELEASE-NAME-updater
+          name: RELEASE-NAME-teleport-operator-updater
           namespace: NAMESPACE
 
   #
@@ -32,7 +32,7 @@ tests:
           value:
             apiGroup: rbac.authorization.k8s.io
             kind: Role
-            name: RELEASE-NAME-updater
+            name: RELEASE-NAME-teleport-operator-updater
       - equal:
           path: subjects
           value:

--- a/examples/chart/teleport-cluster/charts/teleport-operator/values.yaml
+++ b/examples/chart/teleport-cluster/charts/teleport-operator/values.yaml
@@ -84,6 +84,97 @@ fullNameOverride: ""
 # image rather than a Teleport-published image.
 image: public.ecr.aws/gravitational/teleport-operator
 
+# updater -- controls whether the Teleport Kube Updater should be deployed alongside
+# the operator. The updater fetches the target version, validates the
+# image signature, and updates the teleport operator.
+#
+# The updater fetches the update information using two protocols by querying the Teleport Proxy Service.
+#
+# All Kubernetes-specific fields such as `tolerations`, `affinity`, `nodeSelector`,
+# ... default to the updater values. However, they can be overridden from the
+# `updater` object. For example:
+#
+# ```yaml
+# # the operator pod requests 1cpu and 2 GiB of memory. It also has a memory limit.
+# resources:
+#   requests:
+#     cpu: "1"
+#     memory: "2Gi"
+#   limits:
+#     memory: "2Gi"
+#
+# # the updater pod requests 0.5 cpu and 512MiB of memory. The memory limit has also been unset.
+# updater:
+#   resources:
+#     requests:
+#       cpu: "0.5"
+#       memory: "512Mi"
+#     limits: ~
+# ```
+#
+# Other updater-specific values that can be defined in `updater` are described
+# below.
+updater:
+  # updater.enabled(bool) -- Enables the Kube Agent Updater and deploys it alongside the Teleport Agent.
+  enabled: false
+
+  # updater.group(string) -- is the update group used when fetching the version using the webapi protocol.
+  # When unset, the group defaults to `default`.
+  group: ""
+
+  # updater.image(string) -- sets the container image used for Teleport updater
+  # pods run when `updater.enabled` is true.
+  #
+  # You can override this to use your own Teleport Kube Agent Updater image rather
+  # than a Teleport-published image.
+  image: public.ecr.aws/gravitational/teleport-kube-agent-updater
+
+  # updater.serviceAccount --
+  serviceAccount:
+    # updater.serviceAccount.name(string) -- is the updater Kubernetes Service
+    # Account name. When unset, it defaults to `<kube agent sa name>-updater`
+    name: ""
+
+  # updater.pullCredentials(string) -- configures how the updater attempts to
+  # get the image pull credentials used to validate the image signature.
+  #
+  # This is not required when pulling images from official public Teleport
+  # registries (chart's default).
+  #
+  # Supported values are `aws`, `google`, `docker` and `none`.
+  pullCredentials: ""
+
+  # updater.extraArgs(list) -- contains additional arguments to pass to the updater
+  # binary.
+  extraArgs: []
+
+  # updater.extraVolumes(list) -- contains extra volumes to mount into the Updater pods.
+  # See [the Kubernetes volume documentation](https://kubernetes.io/docs/concepts/storage/volumes/)
+  # for more details.
+  #
+  # For example:
+  # ```yaml
+  # updater:
+  #   extraVolumes:
+  #   - name: myvolume
+  #     secret:
+  #       secretName: testSecret
+  # ```
+  extraVolumes: []
+
+  # updater.extraVolumeMounts(list) -- contains extra volumes mounts for the updater.
+  # See [the Kubernetes volume documentation](https://kubernetes.io/docs/concepts/storage/volumes/)
+  # for more details.
+  #
+  # For example:
+  # ```yaml
+  # updater:
+  #   extraVolumesMounts:
+  #   - name: myvolume
+  #     mountPath: /path/on/host
+  # ```
+  extraVolumeMounts: []
+
 # annotations --
 annotations:
   # annotations.deployment(object) -- contains the Kubernetes annotations

--- a/examples/chart/teleport-kube-updater/templates/_deployment.tpl
+++ b/examples/chart/teleport-kube-updater/templates/_deployment.tpl
@@ -61,6 +61,9 @@ spec:
           - "--agent-name={{ .releaseName }}"
           - "--agent-namespace={{ .releaseNamespace }}"
           - "--base-image={{ .baseImage }}"
+  {{- if .containerName }}
+          - "--container-name={{.containerName}}"
+  {{- end}}
   {{- if .versionServer}}
           - "--version-server={{ .versionServer }}"
           - "--version-channel={{ .releaseChannel }}"

--- a/examples/chart/teleport-kube-updater/values.yaml
+++ b/examples/chart/teleport-kube-updater/values.yaml
@@ -1,10 +1,13 @@
-# Those 4 vars are not exposed to the user.
+# Those vars are not exposed to the user.
 releaseName: ""
 releaseNamespace: ""
 versionServerOverride: false
 version: ""
 baseImage: ""
+# when not set, the updater defaults to "teleport"
+containerName: ""
 
+# Those vars are user-facing
 versionServer: "https://{{ .Values.proxyAddr }}/v1/webapi/automaticupgrades/channel"
 releaseChannel: "stable/cloud"
 group: ""

--- a/integrations/kube-agent-updater/cmd/teleport-kube-agent-updater/main.go
+++ b/integrations/kube-agent-updater/cmd/teleport-kube-agent-updater/main.go
@@ -83,24 +83,28 @@ func main() {
 	logger := logr.FromSlogHandler(slogLogger.Handler())
 	ctrl.SetLogger(logger)
 
-	var agentName string
-	var agentNamespace string
-	var metricsAddr string
-	var probeAddr string
-	var syncPeriod time.Duration
-	var baseImageName string
-	var versionServer string
-	var versionChannel string
-	var insecureNoVerify bool
-	var insecureNoResolve bool
-	var disableLeaderElection bool
-	var credSource string
-	var logLevel string
-	var proxyAddress string
-	var updateGroup string
+	var (
+		agentName             string
+		agentNamespace        string
+		containerName         string
+		metricsAddr           string
+		probeAddr             string
+		syncPeriod            time.Duration
+		baseImageName         string
+		versionServer         string
+		versionChannel        string
+		insecureNoVerify      bool
+		insecureNoResolve     bool
+		disableLeaderElection bool
+		credSource            string
+		logLevel              string
+		proxyAddress          string
+		updateGroup           string
+	)
 
 	flag.StringVar(&agentName, "agent-name", "", "The name of the agent that should be updated. This is mandatory.")
 	flag.StringVar(&agentNamespace, "agent-namespace", "", "The namespace of the agent that should be updated. This is mandatory.")
+	flag.StringVar(&containerName, "container-name", "teleport", "The name of the container that should be updated.")
 	flag.StringVar(&metricsAddr, "metrics-addr", ":8080", "The address the metric endpoint binds to.")
 	flag.StringVar(&probeAddr, "healthz-addr", ":8081", "The address the probe endpoint binds to.")
 	flag.DurationVar(&syncPeriod, "sync-period", 10*time.Hour, "Operator sync period (format: https://pkg.go.dev/time#ParseDuration)")
@@ -315,6 +319,7 @@ func main() {
 		StatusWriter:   statusWriter,
 		Client:         mgr.GetClient(),
 		Scheme:         mgr.GetScheme(),
+		ContainerName:  containerName,
 	}
 
 	if err := deploymentController.SetupWithManager(mgr); err != nil {
@@ -327,6 +332,7 @@ func main() {
 		StatusWriter:   statusWriter,
 		Client:         mgr.GetClient(),
 		Scheme:         mgr.GetScheme(),
+		ContainerName:  containerName,
 	}
 
 	if err := statefulsetController.SetupWithManager(mgr); err != nil {

--- a/integrations/kube-agent-updater/pkg/controller/constants.go
+++ b/integrations/kube-agent-updater/pkg/controller/constants.go
@@ -26,7 +26,6 @@ import (
 
 const (
 	// Teleport container name in the `teleport-kube-agent` Helm chart
-	teleportContainerName = "teleport"
 	defaultRequeue        = 30 * time.Minute
 	reconciliationTimeout = 2 * time.Minute
 	kubeClientTimeout     = 1 * time.Minute

--- a/integrations/kube-agent-updater/pkg/controller/deployment.go
+++ b/integrations/kube-agent-updater/pkg/controller/deployment.go
@@ -35,6 +35,8 @@ import (
 
 // DeploymentVersionUpdater Reconciles a podSpec by changing its image
 type DeploymentVersionUpdater struct {
+	// ContainerName is the name of the container that will be updated.
+	ContainerName string
 	VersionUpdater
 	StatusWriter
 	kclient.Client
@@ -66,7 +68,7 @@ func (r *DeploymentVersionUpdater) Reconcile(ctx context.Context, req ctrl.Reque
 	}
 
 	// Get the current and past version
-	currentVersion, err := getWorkloadVersion(obj.Spec.Template.Spec)
+	currentVersion, err := getWorkloadVersion(obj.Spec.Template.Spec, r.ContainerName)
 	if err != nil {
 		var badParameterError *trace.BadParameterError
 		switch {
@@ -119,7 +121,7 @@ func (r *DeploymentVersionUpdater) Reconcile(ctx context.Context, req ctrl.Reque
 	}
 
 	log.Info("Updating podSpec with image", "image", image.String())
-	err = setContainerImageFromPodSpec(&obj.Spec.Template.Spec, teleportContainerName, image.String())
+	err = setContainerImageFromPodSpec(&obj.Spec.Template.Spec, r.ContainerName, image.String())
 	if err != nil {
 		log.Error(err, "Unexpected error, not updating.")
 		if err := r.writeStatus(ctx, &obj, currentVersion.String(), true); err != nil {

--- a/integrations/kube-agent-updater/pkg/controller/statefulset.go
+++ b/integrations/kube-agent-updater/pkg/controller/statefulset.go
@@ -38,6 +38,8 @@ import (
 )
 
 type StatefulSetVersionUpdater struct {
+	// ContainerName is the name of the container that will be updated.
+	ContainerName string
 	VersionUpdater
 	StatusWriter
 	kclient.Client
@@ -90,7 +92,7 @@ func (r *StatefulSetVersionUpdater) Reconcile(ctx context.Context, req ctrl.Requ
 	}
 
 	// Get the current and past version
-	currentVersion, err := getWorkloadVersion(obj.Spec.Template.Spec)
+	currentVersion, err := getWorkloadVersion(obj.Spec.Template.Spec, r.ContainerName)
 	if err != nil {
 		switch {
 		case trace.IsBadParameter(err):
@@ -154,7 +156,7 @@ func (r *StatefulSetVersionUpdater) Reconcile(ctx context.Context, req ctrl.Requ
 	}
 
 	log.Info("Updating podSpec with image", "image", image.String())
-	err = setContainerImageFromPodSpec(&obj.Spec.Template.Spec, teleportContainerName, image.String())
+	err = setContainerImageFromPodSpec(&obj.Spec.Template.Spec, r.ContainerName, image.String())
 	if err != nil {
 		log.Error(err, "Unexpected error, not updating.")
 		if err := r.writeStatus(ctx, &obj, currentVersion.String(), true); err != nil {

--- a/integrations/kube-agent-updater/pkg/controller/utils.go
+++ b/integrations/kube-agent-updater/pkg/controller/utils.go
@@ -30,8 +30,8 @@ import (
 	"github.com/gravitational/teleport/lib/automaticupgrades/version"
 )
 
-func getWorkloadVersion(podSpec v1.PodSpec) (*semver.Version, error) {
-	image, err := getContainerImageFromPodSpec(podSpec, teleportContainerName)
+func getWorkloadVersion(podSpec v1.PodSpec, container string) (*semver.Version, error) {
+	image, err := getContainerImageFromPodSpec(podSpec, container)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/integrations/kube-agent-updater/pkg/controller/utils_test.go
+++ b/integrations/kube-agent-updater/pkg/controller/utils_test.go
@@ -30,7 +30,8 @@ import (
 )
 
 const (
-	nonSemverTag = "my-custom-tag"
+	nonSemverTag          = "my-custom-tag"
+	teleportContainerName = "teleport"
 )
 
 func Test_getContainerImageFromPod(t *testing.T) {
@@ -347,7 +348,7 @@ func Test_getWorkloadVersion(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := getWorkloadVersion(tt.podSpec)
+			got, err := getWorkloadVersion(tt.podSpec, teleportContainerName)
 			tt.assertErr(t, err)
 			require.Equal(t, tt.expected, got)
 		})


### PR DESCRIPTION
This PR adds updater support to the operator.

While this technically works, this will break the first time we introduce a new CRD. I must add some logic that allows a newer operator to safely run against older CRDs. Will do in a separate PR. This must not be backported until the operator supports missing CRDs.

Changelog: Added automatic update to the `teleport-operator` Helm chart.

## Manual Test Plan
### Test Environment

Local k3d cluster with operator running against my staging cloud tenant

### Test Cases
- [x] No updater is deployed by default (both teleport-operator and teleport-cluster charts)
- [x] Updater is deployed when the value is set
- [ ] Updater updates the operator
- [ ] Updater honours the update group