### PR TITLE
Desktop Access: Always Warn when 'InsecureSkipVerify' is set.

### DIFF
--- a/lib/srv/desktop/windows_server.go
+++ b/lib/srv/desktop/windows_server.go
@@ -307,7 +307,33 @@ func (cfg *WindowsServiceConfig) CheckAndSetDefaults() error {
 		cfg.Logger.WarnContext(context.Background(), "site is set, but locate_server is false. site will be ignored.")
 	}
 
+	cfg.insecureSkipVerifyWarning()
+
 	return nil
+}
+
+func (w *WindowsServiceConfig) insecureSkipVerifyWarning() {
+	if !w.LDAPConfig.InsecureSkipVerify || w.Logger == nil {
+		return
+	}
+
+	const withCAs = "LDAP configuration specifies both a CA certificate and insecure_skip_verify. " +
+		"TLS connections to the LDAP server will not be verified. If this is intentional, disregard this warning."
+
+	const withoutCAs = "LDAP configuration specifies insecure_skip_verify. " +
+		"TLS connections to the LDAP server will not be verified. If this is intentional, disregard this warning."
+
+	// It's possible to provide a CA certificate for the LDAP server
+	// and to skip TLS validation, though this may be an error, so try
+	// to warn the user.
+	// (You may need this configuration in order to use certificates to
+	// authenticate with LDAP when the LDAP server name is not correct
+	// in the certificate).
+	if len(w.LDAPConfig.CAs) > 0 {
+		w.Logger.WarnContext(context.Background(), withCAs)
+	} else {
+		w.Logger.WarnContext(context.Background(), withoutCAs)
+	}
 }
 
 func (cfg *HeartbeatConfig) CheckAndSetDefaults() error {
@@ -334,9 +360,6 @@ func (s *WindowsService) getLDAPConfig() *winpki.LDAPConfig {
 	}
 }
 
-const insecureSkipVerifyWarning = "LDAP configuration specifies both a CA certificate and insecure_skip_verify. " +
-	"TLS connections to the LDAP server will not be verified. If this is intentional, disregard this warning."
-
 // NewWindowsService initializes a new WindowsService.
 //
 // To start serving connections, call Serve.
@@ -344,16 +367,6 @@ const insecureSkipVerifyWarning = "LDAP configuration specifies both a CA certif
 func NewWindowsService(cfg WindowsServiceConfig) (*WindowsService, error) {
 	if err := cfg.CheckAndSetDefaults(); err != nil {
 		return nil, trace.Wrap(err)
-	}
-
-	// It's possible to provide a CA certificate for the LDAP server
-	// and to skip TLS valdiation, though this may be an error, so try
-	// to warn the user.
-	// (You may need this configuration in order to use certificates to
-	// authenticate with LDAP when the LDAP server name is not correct
-	// in the certificate).
-	if len(cfg.LDAPConfig.CAs) > 0 && cfg.LDAPConfig.InsecureSkipVerify {
-		cfg.Logger.WarnContext(context.Background(), insecureSkipVerifyWarning)
 	}
 
 	clusterName, err := cfg.AccessPoint.GetClusterName(context.TODO())


### PR DESCRIPTION
This PR just ensures that we always emit a warning in the logs when `InsecureSkipVerify` is set in the LDAP config. At the moment, we only warn if `InsecureSkipVerify` is set _and_ one or more CAs are configured.


<!-- Provide a descriptive entry for the changelog of the next release. -->



<!-- Include manual testing efforts to verify the change. -->
<!-- Detail where the tests where run and what configurations were used. -->
<!-- Include all the test cases which were run to validate the change. -->

## Manual Test Plan
### Test Environment
Local Cluster
### Test Cases
- [x] Start WDS with InsecureSkipVerify set and no CAs configured. Observe warning in logs.
- [x] Start WDS with InsecureSkipVerify set and at least on CA configured. Observe a different warning in logs.
- [x] Start WDS with InsecureSkipVerify unset. Observe that no warning is logged.
