### PR TITLE
docs: Update cluster mgmt and audit records

### DIFF
--- a/docs/pages/reference/audit-events.mdx
+++ b/docs/pages/reference/audit-events.mdx
@@ -6991,7 +6991,7 @@ Example:
 
 ```json
 {
-  "account_id": "278576220453",
+  "account_id": "(=aws.account_id=)",
   "cluster_name": "localhost",
   "code": "TDS00I",
   "command_id": "e8a5f3ba-e9e5-4cbd-979b-18fd1e7ad00f",
@@ -7017,7 +7017,7 @@ Example:
 
 ```json
 {
-  "account_id": "278576220453",
+  "account_id": "(=aws.account_id=)",
   "cluster_name": "localhost",
   "code": "TDS00W",
   "command_id": "c2936d68-fc0c-4c16-a860-916a97f57644",

--- a/docs/pages/reference/audit-events.mdx
+++ b/docs/pages/reference/audit-events.mdx
@@ -6991,7 +6991,7 @@ Example:
 
 ```json
 {
-  "account_id": "(=aws.account_id=)",
+  "account_id": "123456789012",
   "cluster_name": "localhost",
   "code": "TDS00I",
   "command_id": "e8a5f3ba-e9e5-4cbd-979b-18fd1e7ad00f",
@@ -7017,7 +7017,7 @@ Example:
 
 ```json
 {
-  "account_id": "(=aws.account_id=)",
+  "account_id": "123456789012",
   "cluster_name": "localhost",
   "code": "TDS00W",
   "command_id": "c2936d68-fc0c-4c16-a860-916a97f57644",

--- a/docs/pages/zero-trust-access/management/external-audit-storage.mdx
+++ b/docs/pages/zero-trust-access/management/external-audit-storage.mdx
@@ -128,7 +128,7 @@ support your AWS environment:
                 "athena:GetQueryResults",
                 "athena:GetQueryExecution"
             ],
-            "Resource": "arn:aws:athena:us-west-2:(=aws.account_id=):workgroup/teleport_events_<unique_id>",
+            "Resource": "arn:aws:athena:us-west-2:123456789012:workgroup/teleport_events_<unique_id>",
             "Sid": "AllowAthenaQuery"
         },
         {
@@ -140,9 +140,9 @@ support your AWS environment:
                 "glue:UpdateTable"
             ],
             "Resource": [
-                "arn:aws:glue:us-west-2:(=aws.account_id=):catalog",
-                "arn:aws:glue:us-west-2:(=aws.account_id=):database/teleport_events_<unique_id>",
-                "arn:aws:glue:us-west-2:(=aws.account_id=):table/teleport_events_<unique_id>/teleport_events"
+                "arn:aws:glue:us-west-2:123456789012:catalog",
+                "arn:aws:glue:us-west-2:123456789012:database/teleport_events_<unique_id>",
+                "arn:aws:glue:us-west-2:123456789012:table/teleport_events_<unique_id>/teleport_events"
             ],
             "Sid": "FullAccessOnGlueTable"
         }

--- a/docs/pages/zero-trust-access/management/external-audit-storage.mdx
+++ b/docs/pages/zero-trust-access/management/external-audit-storage.mdx
@@ -128,7 +128,7 @@ support your AWS environment:
                 "athena:GetQueryResults",
                 "athena:GetQueryExecution"
             ],
-            "Resource": "arn:aws:athena:us-west-2:278576220453:workgroup/teleport_events_<unique_id>",
+            "Resource": "arn:aws:athena:us-west-2:(=aws.account_id=):workgroup/teleport_events_<unique_id>",
             "Sid": "AllowAthenaQuery"
         },
         {
@@ -140,9 +140,9 @@ support your AWS environment:
                 "glue:UpdateTable"
             ],
             "Resource": [
-                "arn:aws:glue:us-west-2:278576220453:catalog",
-                "arn:aws:glue:us-west-2:278576220453:database/teleport_events_<unique_id>",
-                "arn:aws:glue:us-west-2:278576220453:table/teleport_events_<unique_id>/teleport_events"
+                "arn:aws:glue:us-west-2:(=aws.account_id=):catalog",
+                "arn:aws:glue:us-west-2:(=aws.account_id=):database/teleport_events_<unique_id>",
+                "arn:aws:glue:us-west-2:(=aws.account_id=):table/teleport_events_<unique_id>/teleport_events"
             ],
             "Sid": "FullAccessOnGlueTable"
         }

--- a/docs/pages/zero-trust-access/management/trustedclusters.mdx
+++ b/docs/pages/zero-trust-access/management/trustedclusters.mdx
@@ -912,7 +912,7 @@ both the root and leaf clusters. Usually, this can be done by adding the `--debu
 command to start the teleport service:
 
 ```code
-teleport start --debug`
+teleport start --debug
 ```
 
 You can also enable verbose output by updating the configuration file for both


### PR DESCRIPTION
docs/pages/reference/audit-events.mdx:
- update to use sample AWS account id

docs/pages/zero-trust-access/management/external-audit-storage.mdx:
- update to use sample AWS account id

docs/pages/zero-trust-access/management/trustedclusters.mdx:
- correct `teleport start --debug` command