### PR TITLE
chore: gate db vnet access only to beams

### DIFF
--- a/lib/vnet/fqdn_resolver.go
+++ b/lib/vnet/fqdn_resolver.go
@@ -45,6 +45,10 @@ type fqdnResolverConfig struct {
 	clientApplication  ClientApplication
 	clusterConfigCache *ClusterConfigCache
 	leafClusterCache   *leafClusterCache
+	// allowDatabaseAccess gates VNet database FQDN resolution. Database access
+	// via VNet is currently intended for use only within Teleport Beams, when
+	// false, DB resolution is skipped and the dispatcher falls through to SSH.
+	allowDatabaseAccess bool
 }
 
 func newFQDNResolver(cfg *fqdnResolverConfig) *fqdnResolver {
@@ -374,6 +378,13 @@ func (r *fqdnResolver) resolveDBInfoForCluster(
 	candidate clusterResolutionCandidate,
 	fqdn string,
 ) (*vnetv1.ResolveFQDNResponse, error) {
+	// VNet database resolution is currently intended for use only within
+	// Teleport Beams. When disabled, skip DB resolution so the dispatcher
+	// falls through to SSH resolution unchanged.
+	if !r.cfg.allowDatabaseAccess {
+		return nil, errNoMatch
+	}
+
 	log := log.With("profile", candidate.profileName, "leaf_cluster", candidate.leafClusterName, "fqdn", fqdn)
 
 	// Try to parse the FQDN as a database FQDN against each possible zone.

--- a/lib/vnet/fqdn_resolver.go
+++ b/lib/vnet/fqdn_resolver.go
@@ -45,9 +45,7 @@ type fqdnResolverConfig struct {
 	clientApplication  ClientApplication
 	clusterConfigCache *ClusterConfigCache
 	leafClusterCache   *leafClusterCache
-	// allowDatabaseAccess gates VNet database FQDN resolution. Database access
-	// via VNet is currently intended for use only within Teleport Beams, when
-	// false, DB resolution is skipped and the dispatcher falls through to SSH.
+	// allowDatabaseAccess gates VNet database FQDN resolution for tsh/Connect.
 	allowDatabaseAccess bool
 }
 
@@ -378,9 +376,6 @@ func (r *fqdnResolver) resolveDBInfoForCluster(
 	candidate clusterResolutionCandidate,
 	fqdn string,
 ) (*vnetv1.ResolveFQDNResponse, error) {
-	// VNet database resolution is currently intended for use only within
-	// Teleport Beams. When disabled, skip DB resolution so the dispatcher
-	// falls through to SSH resolution unchanged.
 	if !r.cfg.allowDatabaseAccess {
 		return nil, errNoMatch
 	}

--- a/lib/vnet/user_process.go
+++ b/lib/vnet/user_process.go
@@ -19,7 +19,6 @@ package vnet
 import (
 	"context"
 	"crypto/tls"
-	"os"
 
 	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
@@ -109,18 +108,14 @@ func RunUserProcess(ctx context.Context, clientApplication ClientApplication) (*
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	// VNet database access is currently intended for use only within Teleport
-	// Beams. The beams runtime sets TELEPORT_BEAMS_RUNTIME=yes, which is the
-	// same signal used by the beams tbot VNet service.
-	allowDatabaseAccess := os.Getenv("TELEPORT_BEAMS_RUNTIME") == "yes"
-	if allowDatabaseAccess {
-		log.InfoContext(ctx, "Detected beams runtime, VNet database access is enabled")
-	}
 	fqdnResolver := newFQDNResolver(&fqdnResolverConfig{
-		clientApplication:   clientApplication,
-		clusterConfigCache:  clusterConfigCache,
-		leafClusterCache:    leafClusterCache,
-		allowDatabaseAccess: allowDatabaseAccess,
+		clientApplication:  clientApplication,
+		clusterConfigCache: clusterConfigCache,
+		leafClusterCache:   leafClusterCache,
+		// DB access via VNet is currently only supported by the tbot beams, but
+		// disabled for tsh/Connect by default. flip to true to enable DB access via VNet
+		// for tsh/Connect to validate locally.
+		allowDatabaseAccess: false,
 	})
 	unifiedClusterConfigProvider := NewUnifiedClusterConfigProvider(&UnifiedClusterConfigProviderConfig{
 		clientApplication:  clientApplication,

--- a/lib/vnet/user_process.go
+++ b/lib/vnet/user_process.go
@@ -19,6 +19,7 @@ package vnet
 import (
 	"context"
 	"crypto/tls"
+	"os"
 
 	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
@@ -108,10 +109,18 @@ func RunUserProcess(ctx context.Context, clientApplication ClientApplication) (*
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
+	// VNet database access is currently intended for use only within Teleport
+	// Beams. The beams runtime sets TELEPORT_BEAMS_RUNTIME=yes, which is the
+	// same signal used by the beams tbot VNet service.
+	allowDatabaseAccess := os.Getenv("TELEPORT_BEAMS_RUNTIME") == "yes"
+	if allowDatabaseAccess {
+		log.InfoContext(ctx, "Detected beams runtime, VNet database access is enabled")
+	}
 	fqdnResolver := newFQDNResolver(&fqdnResolverConfig{
-		clientApplication:  clientApplication,
-		clusterConfigCache: clusterConfigCache,
-		leafClusterCache:   leafClusterCache,
+		clientApplication:   clientApplication,
+		clusterConfigCache:  clusterConfigCache,
+		leafClusterCache:    leafClusterCache,
+		allowDatabaseAccess: allowDatabaseAccess,
 	})
 	unifiedClusterConfigProvider := NewUnifiedClusterConfigProvider(&UnifiedClusterConfigProviderConfig{
 		clientApplication:  clientApplication,

--- a/lib/vnet/vnet_test.go
+++ b/lib/vnet/vnet_test.go
@@ -196,9 +196,10 @@ func runTestClientApplicationService(t *testing.T, ctx context.Context, cfg test
 	leafClusterCache, err := newLeafClusterCache(cfg.clock)
 	require.NoError(t, err)
 	fqdnResolver := newFQDNResolver(&fqdnResolverConfig{
-		clientApplication:  cfg.fakeClientApp,
-		clusterConfigCache: clusterConfigCache,
-		leafClusterCache:   leafClusterCache,
+		clientApplication:   cfg.fakeClientApp,
+		clusterConfigCache:  clusterConfigCache,
+		leafClusterCache:    leafClusterCache,
+		allowDatabaseAccess: true,
 	})
 	clientApplicationService, err := newClientApplicationService(&clientApplicationServiceConfig{
 		clientApplication: cfg.fakeClientApp,


### PR DESCRIPTION

## Changes
We do not want to support db access via vnet for everyone today, would like it to be limited to beams only until we can revisit and implement in a better way. So this PR guards against that using `allowDatabaseAccess` flag which defaults to false, to validate locally we can set it to true to test using tsh vnet but ensure this is scoped to beams only in prod.

RFD: https://github.com/gravitational/teleport.e/pull/8432

<!-- Provide a descriptive entry for the changelog of the next release. -->



<!-- Include manual testing efforts to verify the change. -->
<!-- Detail where the tests where run and what configurations were used. -->
<!-- Include all the test cases which were run to validate the change. -->

## Manual Test Plan
### Test Environment
- Any v18+ cluster with a registered database resource
- Build of tsh from this branch (make build/tsh).
- A beam: any tenant where you've run tsh beams add. Beam containers export TELEPORT_BEAMS_RUNTIME=yes automatically.

### Test Cases
- [x]  Inside a beam (`tsh beams add` → console in), run `psql "postgresql://postgres@postgres.db.teleport.localhost/postgres"` and confirm it connects via VNet.
- [x] Locally with `tsh vnet` running (no beam, `allowDatabaseAccess` value unchanged) and a local Postgres listening on `:5432`, run `psql "postgresql://postgres@postgres.db.teleport.localhost/postgres"` and confirm it fails to resolve/connect -  proving VNet doesn't claim the hostname.
