### PR TITLE
Okta: Remove OktaService.UpdateOktaAssignmentStatus

### DIFF
--- a/api/client/okta/okta.go
+++ b/api/client/okta/okta.go
@@ -16,10 +16,8 @@ package okta
 
 import (
 	"context"
-	"time"
 
 	"github.com/gravitational/trace"
-	"google.golang.org/protobuf/types/known/durationpb"
 
 	oktapb "github.com/gravitational/teleport/api/gen/proto/go/teleport/okta/v1"
 	"github.com/gravitational/teleport/api/types"
@@ -151,17 +149,6 @@ func (c *Client) UpdateOktaAssignment(ctx context.Context, assignment types.Okta
 		Assignment: assignmentV1,
 	})
 	return resp, trace.Wrap(err)
-}
-
-// UpdateOktaAssignmentStatus will update the status for an Okta assignment if the given time has passed
-// since the last transition.
-func (c *Client) UpdateOktaAssignmentStatus(ctx context.Context, name, status string, timeHasPassed time.Duration) error {
-	_, err := c.grpcClient.UpdateOktaAssignmentStatus(ctx, &oktapb.UpdateOktaAssignmentStatusRequest{
-		Name:          name,
-		Status:        types.OktaAssignmentStatusToProto(status),
-		TimeHasPassed: durationpb.New(timeHasPassed),
-	})
-	return trace.Wrap(err)
 }
 
 // DeleteOktaAssignment removes the specified Okta assignment resource.

--- a/api/gen/proto/go/teleport/okta/v1/okta_service_grpc.pb.go
+++ b/api/gen/proto/go/teleport/okta/v1/okta_service_grpc.pb.go
@@ -45,7 +45,6 @@ const (
 	OktaService_GetOktaAssignment_FullMethodName               = "/teleport.okta.v1.OktaService/GetOktaAssignment"
 	OktaService_CreateOktaAssignment_FullMethodName            = "/teleport.okta.v1.OktaService/CreateOktaAssignment"
 	OktaService_UpdateOktaAssignment_FullMethodName            = "/teleport.okta.v1.OktaService/UpdateOktaAssignment"
-	OktaService_UpdateOktaAssignmentStatus_FullMethodName      = "/teleport.okta.v1.OktaService/UpdateOktaAssignmentStatus"
 	OktaService_DeleteOktaAssignment_FullMethodName            = "/teleport.okta.v1.OktaService/DeleteOktaAssignment"
 	OktaService_DeleteAllOktaAssignments_FullMethodName        = "/teleport.okta.v1.OktaService/DeleteAllOktaAssignments"
 	OktaService_ConditionalUpdateOktaAssignment_FullMethodName = "/teleport.okta.v1.OktaService/ConditionalUpdateOktaAssignment"
@@ -83,8 +82,6 @@ type OktaServiceClient interface {
 	CreateOktaAssignment(ctx context.Context, in *CreateOktaAssignmentRequest, opts ...grpc.CallOption) (*types.OktaAssignmentV1, error)
 	// UpdateOktaAssignment updates an existing Okta assignment resource.
 	UpdateOktaAssignment(ctx context.Context, in *UpdateOktaAssignmentRequest, opts ...grpc.CallOption) (*types.OktaAssignmentV1, error)
-	// UpdateOktaAssignmentStatus will update the status for an Okta assignment.
-	UpdateOktaAssignmentStatus(ctx context.Context, in *UpdateOktaAssignmentStatusRequest, opts ...grpc.CallOption) (*emptypb.Empty, error)
 	// DeleteOktaAssignment removes the specified Okta assignment resource.
 	DeleteOktaAssignment(ctx context.Context, in *DeleteOktaAssignmentRequest, opts ...grpc.CallOption) (*emptypb.Empty, error)
 	// DeleteAllOktaAssignments removes all Okta assignments.
@@ -213,16 +210,6 @@ func (c *oktaServiceClient) UpdateOktaAssignment(ctx context.Context, in *Update
 	return out, nil
 }
 
-func (c *oktaServiceClient) UpdateOktaAssignmentStatus(ctx context.Context, in *UpdateOktaAssignmentStatusRequest, opts ...grpc.CallOption) (*emptypb.Empty, error) {
-	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
-	out := new(emptypb.Empty)
-	err := c.cc.Invoke(ctx, OktaService_UpdateOktaAssignmentStatus_FullMethodName, in, out, cOpts...)
-	if err != nil {
-		return nil, err
-	}
-	return out, nil
-}
-
 func (c *oktaServiceClient) DeleteOktaAssignment(ctx context.Context, in *DeleteOktaAssignmentRequest, opts ...grpc.CallOption) (*emptypb.Empty, error) {
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
 	out := new(emptypb.Empty)
@@ -339,8 +326,6 @@ type OktaServiceServer interface {
 	CreateOktaAssignment(context.Context, *CreateOktaAssignmentRequest) (*types.OktaAssignmentV1, error)
 	// UpdateOktaAssignment updates an existing Okta assignment resource.
 	UpdateOktaAssignment(context.Context, *UpdateOktaAssignmentRequest) (*types.OktaAssignmentV1, error)
-	// UpdateOktaAssignmentStatus will update the status for an Okta assignment.
-	UpdateOktaAssignmentStatus(context.Context, *UpdateOktaAssignmentStatusRequest) (*emptypb.Empty, error)
 	// DeleteOktaAssignment removes the specified Okta assignment resource.
 	DeleteOktaAssignment(context.Context, *DeleteOktaAssignmentRequest) (*emptypb.Empty, error)
 	// DeleteAllOktaAssignments removes all Okta assignments.
@@ -398,9 +383,6 @@ func (UnimplementedOktaServiceServer) CreateOktaAssignment(context.Context, *Cre
 }
 func (UnimplementedOktaServiceServer) UpdateOktaAssignment(context.Context, *UpdateOktaAssignmentRequest) (*types.OktaAssignmentV1, error) {
 	return nil, status.Error(codes.Unimplemented, "method UpdateOktaAssignment not implemented")
-}
-func (UnimplementedOktaServiceServer) UpdateOktaAssignmentStatus(context.Context, *UpdateOktaAssignmentStatusRequest) (*emptypb.Empty, error) {
-	return nil, status.Error(codes.Unimplemented, "method UpdateOktaAssignmentStatus not implemented")
 }
 func (UnimplementedOktaServiceServer) DeleteOktaAssignment(context.Context, *DeleteOktaAssignmentRequest) (*emptypb.Empty, error) {
 	return nil, status.Error(codes.Unimplemented, "method DeleteOktaAssignment not implemented")
@@ -630,24 +612,6 @@ func _OktaService_UpdateOktaAssignment_Handler(srv interface{}, ctx context.Cont
 	return interceptor(ctx, in, info, handler)
 }
 
-func _OktaService_UpdateOktaAssignmentStatus_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
-	in := new(UpdateOktaAssignmentStatusRequest)
-	if err := dec(in); err != nil {
-		return nil, err
-	}
-	if interceptor == nil {
-		return srv.(OktaServiceServer).UpdateOktaAssignmentStatus(ctx, in)
-	}
-	info := &grpc.UnaryServerInfo{
-		Server:     srv,
-		FullMethod: OktaService_UpdateOktaAssignmentStatus_FullMethodName,
-	}
-	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-		return srv.(OktaServiceServer).UpdateOktaAssignmentStatus(ctx, req.(*UpdateOktaAssignmentStatusRequest))
-	}
-	return interceptor(ctx, in, info, handler)
-}
-
 func _OktaService_DeleteOktaAssignment_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
 	in := new(DeleteOktaAssignmentRequest)
 	if err := dec(in); err != nil {
@@ -856,10 +820,6 @@ var OktaService_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "UpdateOktaAssignment",
 			Handler:    _OktaService_UpdateOktaAssignment_Handler,
-		},
-		{
-			MethodName: "UpdateOktaAssignmentStatus",
-			Handler:    _OktaService_UpdateOktaAssignmentStatus_Handler,
 		},
 		{
 			MethodName: "DeleteOktaAssignment",

--- a/api/gen/proto/go/teleport/okta/v1/okta_service_protohybrid.pb.go
+++ b/api/gen/proto/go/teleport/okta/v1/okta_service_protohybrid.pb.go
@@ -2703,111 +2703,6 @@ func (b0 UpdateOktaAssignmentRequest_builder) Build() *UpdateOktaAssignmentReque
 	return m0
 }
 
-// UpdateOktaAssignmentStatusRequest is a request for updating an Okta assignment status.
-type UpdateOktaAssignmentStatusRequest struct {
-	state protoimpl.MessageState `protogen:"hybrid.v1"`
-	// name is the name of the Okta assignment.
-	Name string `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
-	// status is the status to update the assignment to.
-	Status types.OktaAssignmentSpecV1_OktaAssignmentStatus `protobuf:"varint,2,opt,name=status,proto3,enum=types.OktaAssignmentSpecV1_OktaAssignmentStatus" json:"status,omitempty"`
-	// timeHasPassed is the amount of time that must have passed since the last transition
-	// in order to set the new transition.
-	TimeHasPassed *durationpb.Duration `protobuf:"bytes,3,opt,name=time_has_passed,json=timeHasPassed,proto3" json:"time_has_passed,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
-}
-
-func (x *UpdateOktaAssignmentStatusRequest) Reset() {
-	*x = UpdateOktaAssignmentStatusRequest{}
-	mi := &file_teleport_okta_v1_okta_service_proto_msgTypes[29]
-	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-	ms.StoreMessageInfo(mi)
-}
-
-func (x *UpdateOktaAssignmentStatusRequest) String() string {
-	return protoimpl.X.MessageStringOf(x)
-}
-
-func (*UpdateOktaAssignmentStatusRequest) ProtoMessage() {}
-
-func (x *UpdateOktaAssignmentStatusRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_okta_v1_okta_service_proto_msgTypes[29]
-	if x != nil {
-		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-		if ms.LoadMessageInfo() == nil {
-			ms.StoreMessageInfo(mi)
-		}
-		return ms
-	}
-	return mi.MessageOf(x)
-}
-
-func (x *UpdateOktaAssignmentStatusRequest) GetName() string {
-	if x != nil {
-		return x.Name
-	}
-	return ""
-}
-
-func (x *UpdateOktaAssignmentStatusRequest) GetStatus() types.OktaAssignmentSpecV1_OktaAssignmentStatus {
-	if x != nil {
-		return x.Status
-	}
-	return types.OktaAssignmentSpecV1_OktaAssignmentStatus(0)
-}
-
-func (x *UpdateOktaAssignmentStatusRequest) GetTimeHasPassed() *durationpb.Duration {
-	if x != nil {
-		return x.TimeHasPassed
-	}
-	return nil
-}
-
-func (x *UpdateOktaAssignmentStatusRequest) SetName(v string) {
-	x.Name = v
-}
-
-func (x *UpdateOktaAssignmentStatusRequest) SetStatus(v types.OktaAssignmentSpecV1_OktaAssignmentStatus) {
-	x.Status = v
-}
-
-func (x *UpdateOktaAssignmentStatusRequest) SetTimeHasPassed(v *durationpb.Duration) {
-	x.TimeHasPassed = v
-}
-
-func (x *UpdateOktaAssignmentStatusRequest) HasTimeHasPassed() bool {
-	if x == nil {
-		return false
-	}
-	return x.TimeHasPassed != nil
-}
-
-func (x *UpdateOktaAssignmentStatusRequest) ClearTimeHasPassed() {
-	x.TimeHasPassed = nil
-}
-
-type UpdateOktaAssignmentStatusRequest_builder struct {
-	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
-
-	// name is the name of the Okta assignment.
-	Name string
-	// status is the status to update the assignment to.
-	Status types.OktaAssignmentSpecV1_OktaAssignmentStatus
-	// timeHasPassed is the amount of time that must have passed since the last transition
-	// in order to set the new transition.
-	TimeHasPassed *durationpb.Duration
-}
-
-func (b0 UpdateOktaAssignmentStatusRequest_builder) Build() *UpdateOktaAssignmentStatusRequest {
-	m0 := &UpdateOktaAssignmentStatusRequest{}
-	b, x := &b0, m0
-	_, _ = b, x
-	x.Name = b.Name
-	x.Status = b.Status
-	x.TimeHasPassed = b.TimeHasPassed
-	return m0
-}
-
 // DeleteOktaAssignmentRequest is the request for deleting an Okta assignment.
 type DeleteOktaAssignmentRequest struct {
 	state protoimpl.MessageState `protogen:"hybrid.v1"`
@@ -2821,7 +2716,7 @@ type DeleteOktaAssignmentRequest struct {
 
 func (x *DeleteOktaAssignmentRequest) Reset() {
 	*x = DeleteOktaAssignmentRequest{}
-	mi := &file_teleport_okta_v1_okta_service_proto_msgTypes[30]
+	mi := &file_teleport_okta_v1_okta_service_proto_msgTypes[29]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2833,7 +2728,7 @@ func (x *DeleteOktaAssignmentRequest) String() string {
 func (*DeleteOktaAssignmentRequest) ProtoMessage() {}
 
 func (x *DeleteOktaAssignmentRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_okta_v1_okta_service_proto_msgTypes[30]
+	mi := &file_teleport_okta_v1_okta_service_proto_msgTypes[29]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2893,7 +2788,7 @@ type DeleteAllOktaAssignmentsRequest struct {
 
 func (x *DeleteAllOktaAssignmentsRequest) Reset() {
 	*x = DeleteAllOktaAssignmentsRequest{}
-	mi := &file_teleport_okta_v1_okta_service_proto_msgTypes[31]
+	mi := &file_teleport_okta_v1_okta_service_proto_msgTypes[30]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2905,7 +2800,7 @@ func (x *DeleteAllOktaAssignmentsRequest) String() string {
 func (*DeleteAllOktaAssignmentsRequest) ProtoMessage() {}
 
 func (x *DeleteAllOktaAssignmentsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_okta_v1_okta_service_proto_msgTypes[31]
+	mi := &file_teleport_okta_v1_okta_service_proto_msgTypes[30]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2941,7 +2836,7 @@ type GetAppsResponse_App struct {
 
 func (x *GetAppsResponse_App) Reset() {
 	*x = GetAppsResponse_App{}
-	mi := &file_teleport_okta_v1_okta_service_proto_msgTypes[32]
+	mi := &file_teleport_okta_v1_okta_service_proto_msgTypes[31]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2953,7 +2848,7 @@ func (x *GetAppsResponse_App) String() string {
 func (*GetAppsResponse_App) ProtoMessage() {}
 
 func (x *GetAppsResponse_App) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_okta_v1_okta_service_proto_msgTypes[32]
+	mi := &file_teleport_okta_v1_okta_service_proto_msgTypes[31]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3017,7 +2912,7 @@ type GetGroupsResponse_Group struct {
 
 func (x *GetGroupsResponse_Group) Reset() {
 	*x = GetGroupsResponse_Group{}
-	mi := &file_teleport_okta_v1_okta_service_proto_msgTypes[33]
+	mi := &file_teleport_okta_v1_okta_service_proto_msgTypes[32]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3029,7 +2924,7 @@ func (x *GetGroupsResponse_Group) String() string {
 func (*GetGroupsResponse_Group) ProtoMessage() {}
 
 func (x *GetGroupsResponse_Group) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_okta_v1_okta_service_proto_msgTypes[33]
+	mi := &file_teleport_okta_v1_okta_service_proto_msgTypes[32]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3207,15 +3102,11 @@ const file_teleport_okta_v1_okta_service_proto_rawDesc = "" +
 	"\x1bUpdateOktaAssignmentRequest\x127\n" +
 	"\n" +
 	"assignment\x18\x01 \x01(\v2\x17.types.OktaAssignmentV1R\n" +
-	"assignment\"\xc4\x01\n" +
-	"!UpdateOktaAssignmentStatusRequest\x12\x12\n" +
-	"\x04name\x18\x01 \x01(\tR\x04name\x12H\n" +
-	"\x06status\x18\x02 \x01(\x0e20.types.OktaAssignmentSpecV1.OktaAssignmentStatusR\x06status\x12A\n" +
-	"\x0ftime_has_passed\x18\x03 \x01(\v2\x19.google.protobuf.DurationR\rtimeHasPassed\"M\n" +
+	"assignment\"M\n" +
 	"\x1bDeleteOktaAssignmentRequest\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12\x1a\n" +
 	"\brevision\x18\x02 \x01(\tR\brevision\"!\n" +
-	"\x1fDeleteAllOktaAssignmentsRequest2\xb9\x10\n" +
+	"\x1fDeleteAllOktaAssignmentsRequest2\xce\x0f\n" +
 	"\vOktaService\x12r\n" +
 	"\x13ListOktaImportRules\x12,.teleport.okta.v1.ListOktaImportRulesRequest\x1a-.teleport.okta.v1.ListOktaImportRulesResponse\x12X\n" +
 	"\x11GetOktaImportRule\x12*.teleport.okta.v1.GetOktaImportRuleRequest\x1a\x17.types.OktaImportRuleV1\x12^\n" +
@@ -3226,8 +3117,7 @@ const file_teleport_okta_v1_okta_service_proto_rawDesc = "" +
 	"\x13ListOktaAssignments\x12,.teleport.okta.v1.ListOktaAssignmentsRequest\x1a-.teleport.okta.v1.ListOktaAssignmentsResponse\x12X\n" +
 	"\x11GetOktaAssignment\x12*.teleport.okta.v1.GetOktaAssignmentRequest\x1a\x17.types.OktaAssignmentV1\x12^\n" +
 	"\x14CreateOktaAssignment\x12-.teleport.okta.v1.CreateOktaAssignmentRequest\x1a\x17.types.OktaAssignmentV1\x12^\n" +
-	"\x14UpdateOktaAssignment\x12-.teleport.okta.v1.UpdateOktaAssignmentRequest\x1a\x17.types.OktaAssignmentV1\x12i\n" +
-	"\x1aUpdateOktaAssignmentStatus\x123.teleport.okta.v1.UpdateOktaAssignmentStatusRequest\x1a\x16.google.protobuf.Empty\x12]\n" +
+	"\x14UpdateOktaAssignment\x12-.teleport.okta.v1.UpdateOktaAssignmentRequest\x1a\x17.types.OktaAssignmentV1\x12]\n" +
 	"\x14DeleteOktaAssignment\x12-.teleport.okta.v1.DeleteOktaAssignmentRequest\x1a\x16.google.protobuf.Empty\x12e\n" +
 	"\x18DeleteAllOktaAssignments\x121.teleport.okta.v1.DeleteAllOktaAssignmentsRequest\x1a\x16.google.protobuf.Empty\x12\x96\x01\n" +
 	"\x1fConditionalUpdateOktaAssignment\x128.teleport.okta.v1.ConditionalUpdateOktaAssignmentRequest\x1a9.teleport.okta.v1.ConditionalUpdateOktaAssignmentResponse\x12u\n" +
@@ -3238,122 +3128,116 @@ const file_teleport_okta_v1_okta_service_proto_rawDesc = "" +
 	"\aGetApps\x12 .teleport.okta.v1.GetAppsRequest\x1a!.teleport.okta.v1.GetAppsResponse\x12T\n" +
 	"\tGetGroups\x12\".teleport.okta.v1.GetGroupsRequest\x1a#.teleport.okta.v1.GetGroupsResponseBLZJgithub.com/gravitational/teleport/api/gen/proto/go/teleport/okta/v1;oktav1b\x06proto3"
 
-var file_teleport_okta_v1_okta_service_proto_msgTypes = make([]protoimpl.MessageInfo, 34)
+var file_teleport_okta_v1_okta_service_proto_msgTypes = make([]protoimpl.MessageInfo, 33)
 var file_teleport_okta_v1_okta_service_proto_goTypes = []any{
-	(*ConditionalUpdateOktaAssignmentRequest)(nil),       // 0: teleport.okta.v1.ConditionalUpdateOktaAssignmentRequest
-	(*ConditionalUpdateOktaAssignmentResponse)(nil),      // 1: teleport.okta.v1.ConditionalUpdateOktaAssignmentResponse
-	(*UpsertOktaAssignmentResponse)(nil),                 // 2: teleport.okta.v1.UpsertOktaAssignmentResponse
-	(*UpsertOktaAssignmentRequest)(nil),                  // 3: teleport.okta.v1.UpsertOktaAssignmentRequest
-	(*GetAppsRequest)(nil),                               // 4: teleport.okta.v1.GetAppsRequest
-	(*GetAppsResponse)(nil),                              // 5: teleport.okta.v1.GetAppsResponse
-	(*GetGroupsRequest)(nil),                             // 6: teleport.okta.v1.GetGroupsRequest
-	(*GetGroupsResponse)(nil),                            // 7: teleport.okta.v1.GetGroupsResponse
-	(*CreateIntegrationRequest)(nil),                     // 8: teleport.okta.v1.CreateIntegrationRequest
-	(*UpdateIntegrationRequest)(nil),                     // 9: teleport.okta.v1.UpdateIntegrationRequest
-	(*AccessListSettings)(nil),                           // 10: teleport.okta.v1.AccessListSettings
-	(*OktaAPICredentials)(nil),                           // 11: teleport.okta.v1.OktaAPICredentials
-	(*CreateIntegrationResponse)(nil),                    // 12: teleport.okta.v1.CreateIntegrationResponse
-	(*UpdateIntegrationResponse)(nil),                    // 13: teleport.okta.v1.UpdateIntegrationResponse
-	(*ConnectorInfo)(nil),                                // 14: teleport.okta.v1.ConnectorInfo
-	(*ValidateClientCredentialsRequest)(nil),             // 15: teleport.okta.v1.ValidateClientCredentialsRequest
-	(*ValidateClientCredentialsResponse)(nil),            // 16: teleport.okta.v1.ValidateClientCredentialsResponse
-	(*ListOktaImportRulesRequest)(nil),                   // 17: teleport.okta.v1.ListOktaImportRulesRequest
-	(*ListOktaImportRulesResponse)(nil),                  // 18: teleport.okta.v1.ListOktaImportRulesResponse
-	(*GetOktaImportRuleRequest)(nil),                     // 19: teleport.okta.v1.GetOktaImportRuleRequest
-	(*CreateOktaImportRuleRequest)(nil),                  // 20: teleport.okta.v1.CreateOktaImportRuleRequest
-	(*UpdateOktaImportRuleRequest)(nil),                  // 21: teleport.okta.v1.UpdateOktaImportRuleRequest
-	(*DeleteOktaImportRuleRequest)(nil),                  // 22: teleport.okta.v1.DeleteOktaImportRuleRequest
-	(*DeleteAllOktaImportRulesRequest)(nil),              // 23: teleport.okta.v1.DeleteAllOktaImportRulesRequest
-	(*ListOktaAssignmentsRequest)(nil),                   // 24: teleport.okta.v1.ListOktaAssignmentsRequest
-	(*ListOktaAssignmentsResponse)(nil),                  // 25: teleport.okta.v1.ListOktaAssignmentsResponse
-	(*GetOktaAssignmentRequest)(nil),                     // 26: teleport.okta.v1.GetOktaAssignmentRequest
-	(*CreateOktaAssignmentRequest)(nil),                  // 27: teleport.okta.v1.CreateOktaAssignmentRequest
-	(*UpdateOktaAssignmentRequest)(nil),                  // 28: teleport.okta.v1.UpdateOktaAssignmentRequest
-	(*UpdateOktaAssignmentStatusRequest)(nil),            // 29: teleport.okta.v1.UpdateOktaAssignmentStatusRequest
-	(*DeleteOktaAssignmentRequest)(nil),                  // 30: teleport.okta.v1.DeleteOktaAssignmentRequest
-	(*DeleteAllOktaAssignmentsRequest)(nil),              // 31: teleport.okta.v1.DeleteAllOktaAssignmentsRequest
-	(*GetAppsResponse_App)(nil),                          // 32: teleport.okta.v1.GetAppsResponse.App
-	(*GetGroupsResponse_Group)(nil),                      // 33: teleport.okta.v1.GetGroupsResponse.Group
-	(*types.OktaAssignmentV1)(nil),                       // 34: types.OktaAssignmentV1
-	(*durationpb.Duration)(nil),                          // 35: google.protobuf.Duration
-	(*types.PluginV1)(nil),                               // 36: types.PluginV1
-	(*types.OktaImportRuleV1)(nil),                       // 37: types.OktaImportRuleV1
-	(types.OktaAssignmentSpecV1_OktaAssignmentStatus)(0), // 38: types.OktaAssignmentSpecV1.OktaAssignmentStatus
-	(*emptypb.Empty)(nil),                                // 39: google.protobuf.Empty
+	(*ConditionalUpdateOktaAssignmentRequest)(nil),  // 0: teleport.okta.v1.ConditionalUpdateOktaAssignmentRequest
+	(*ConditionalUpdateOktaAssignmentResponse)(nil), // 1: teleport.okta.v1.ConditionalUpdateOktaAssignmentResponse
+	(*UpsertOktaAssignmentResponse)(nil),            // 2: teleport.okta.v1.UpsertOktaAssignmentResponse
+	(*UpsertOktaAssignmentRequest)(nil),             // 3: teleport.okta.v1.UpsertOktaAssignmentRequest
+	(*GetAppsRequest)(nil),                          // 4: teleport.okta.v1.GetAppsRequest
+	(*GetAppsResponse)(nil),                         // 5: teleport.okta.v1.GetAppsResponse
+	(*GetGroupsRequest)(nil),                        // 6: teleport.okta.v1.GetGroupsRequest
+	(*GetGroupsResponse)(nil),                       // 7: teleport.okta.v1.GetGroupsResponse
+	(*CreateIntegrationRequest)(nil),                // 8: teleport.okta.v1.CreateIntegrationRequest
+	(*UpdateIntegrationRequest)(nil),                // 9: teleport.okta.v1.UpdateIntegrationRequest
+	(*AccessListSettings)(nil),                      // 10: teleport.okta.v1.AccessListSettings
+	(*OktaAPICredentials)(nil),                      // 11: teleport.okta.v1.OktaAPICredentials
+	(*CreateIntegrationResponse)(nil),               // 12: teleport.okta.v1.CreateIntegrationResponse
+	(*UpdateIntegrationResponse)(nil),               // 13: teleport.okta.v1.UpdateIntegrationResponse
+	(*ConnectorInfo)(nil),                           // 14: teleport.okta.v1.ConnectorInfo
+	(*ValidateClientCredentialsRequest)(nil),        // 15: teleport.okta.v1.ValidateClientCredentialsRequest
+	(*ValidateClientCredentialsResponse)(nil),       // 16: teleport.okta.v1.ValidateClientCredentialsResponse
+	(*ListOktaImportRulesRequest)(nil),              // 17: teleport.okta.v1.ListOktaImportRulesRequest
+	(*ListOktaImportRulesResponse)(nil),             // 18: teleport.okta.v1.ListOktaImportRulesResponse
+	(*GetOktaImportRuleRequest)(nil),                // 19: teleport.okta.v1.GetOktaImportRuleRequest
+	(*CreateOktaImportRuleRequest)(nil),             // 20: teleport.okta.v1.CreateOktaImportRuleRequest
+	(*UpdateOktaImportRuleRequest)(nil),             // 21: teleport.okta.v1.UpdateOktaImportRuleRequest
+	(*DeleteOktaImportRuleRequest)(nil),             // 22: teleport.okta.v1.DeleteOktaImportRuleRequest
+	(*DeleteAllOktaImportRulesRequest)(nil),         // 23: teleport.okta.v1.DeleteAllOktaImportRulesRequest
+	(*ListOktaAssignmentsRequest)(nil),              // 24: teleport.okta.v1.ListOktaAssignmentsRequest
+	(*ListOktaAssignmentsResponse)(nil),             // 25: teleport.okta.v1.ListOktaAssignmentsResponse
+	(*GetOktaAssignmentRequest)(nil),                // 26: teleport.okta.v1.GetOktaAssignmentRequest
+	(*CreateOktaAssignmentRequest)(nil),             // 27: teleport.okta.v1.CreateOktaAssignmentRequest
+	(*UpdateOktaAssignmentRequest)(nil),             // 28: teleport.okta.v1.UpdateOktaAssignmentRequest
+	(*DeleteOktaAssignmentRequest)(nil),             // 29: teleport.okta.v1.DeleteOktaAssignmentRequest
+	(*DeleteAllOktaAssignmentsRequest)(nil),         // 30: teleport.okta.v1.DeleteAllOktaAssignmentsRequest
+	(*GetAppsResponse_App)(nil),                     // 31: teleport.okta.v1.GetAppsResponse.App
+	(*GetGroupsResponse_Group)(nil),                 // 32: teleport.okta.v1.GetGroupsResponse.Group
+	(*types.OktaAssignmentV1)(nil),                  // 33: types.OktaAssignmentV1
+	(*durationpb.Duration)(nil),                     // 34: google.protobuf.Duration
+	(*types.PluginV1)(nil),                          // 35: types.PluginV1
+	(*types.OktaImportRuleV1)(nil),                  // 36: types.OktaImportRuleV1
+	(*emptypb.Empty)(nil),                           // 37: google.protobuf.Empty
 }
 var file_teleport_okta_v1_okta_service_proto_depIdxs = []int32{
-	34, // 0: teleport.okta.v1.ConditionalUpdateOktaAssignmentRequest.assignment:type_name -> types.OktaAssignmentV1
-	34, // 1: teleport.okta.v1.ConditionalUpdateOktaAssignmentResponse.assignment:type_name -> types.OktaAssignmentV1
-	34, // 2: teleport.okta.v1.UpsertOktaAssignmentResponse.assignment:type_name -> types.OktaAssignmentV1
-	34, // 3: teleport.okta.v1.UpsertOktaAssignmentRequest.assignment:type_name -> types.OktaAssignmentV1
+	33, // 0: teleport.okta.v1.ConditionalUpdateOktaAssignmentRequest.assignment:type_name -> types.OktaAssignmentV1
+	33, // 1: teleport.okta.v1.ConditionalUpdateOktaAssignmentResponse.assignment:type_name -> types.OktaAssignmentV1
+	33, // 2: teleport.okta.v1.UpsertOktaAssignmentResponse.assignment:type_name -> types.OktaAssignmentV1
+	33, // 3: teleport.okta.v1.UpsertOktaAssignmentRequest.assignment:type_name -> types.OktaAssignmentV1
 	11, // 4: teleport.okta.v1.GetAppsRequest.api_credentials:type_name -> teleport.okta.v1.OktaAPICredentials
-	32, // 5: teleport.okta.v1.GetAppsResponse.apps:type_name -> teleport.okta.v1.GetAppsResponse.App
+	31, // 5: teleport.okta.v1.GetAppsResponse.apps:type_name -> teleport.okta.v1.GetAppsResponse.App
 	11, // 6: teleport.okta.v1.GetGroupsRequest.api_credentials:type_name -> teleport.okta.v1.OktaAPICredentials
-	33, // 7: teleport.okta.v1.GetGroupsResponse.groups:type_name -> teleport.okta.v1.GetGroupsResponse.Group
+	32, // 7: teleport.okta.v1.GetGroupsResponse.groups:type_name -> teleport.okta.v1.GetGroupsResponse.Group
 	11, // 8: teleport.okta.v1.CreateIntegrationRequest.api_credentials:type_name -> teleport.okta.v1.OktaAPICredentials
 	10, // 9: teleport.okta.v1.CreateIntegrationRequest.access_list_settings:type_name -> teleport.okta.v1.AccessListSettings
-	35, // 10: teleport.okta.v1.CreateIntegrationRequest.time_between_imports:type_name -> google.protobuf.Duration
+	34, // 10: teleport.okta.v1.CreateIntegrationRequest.time_between_imports:type_name -> google.protobuf.Duration
 	11, // 11: teleport.okta.v1.UpdateIntegrationRequest.api_credentials:type_name -> teleport.okta.v1.OktaAPICredentials
 	10, // 12: teleport.okta.v1.UpdateIntegrationRequest.access_list_settings:type_name -> teleport.okta.v1.AccessListSettings
-	35, // 13: teleport.okta.v1.UpdateIntegrationRequest.time_between_imports:type_name -> google.protobuf.Duration
-	36, // 14: teleport.okta.v1.CreateIntegrationResponse.plugin:type_name -> types.PluginV1
+	34, // 13: teleport.okta.v1.UpdateIntegrationRequest.time_between_imports:type_name -> google.protobuf.Duration
+	35, // 14: teleport.okta.v1.CreateIntegrationResponse.plugin:type_name -> types.PluginV1
 	14, // 15: teleport.okta.v1.CreateIntegrationResponse.connector_info:type_name -> teleport.okta.v1.ConnectorInfo
-	36, // 16: teleport.okta.v1.UpdateIntegrationResponse.plugin:type_name -> types.PluginV1
+	35, // 16: teleport.okta.v1.UpdateIntegrationResponse.plugin:type_name -> types.PluginV1
 	14, // 17: teleport.okta.v1.UpdateIntegrationResponse.connector_info:type_name -> teleport.okta.v1.ConnectorInfo
 	11, // 18: teleport.okta.v1.ValidateClientCredentialsRequest.api_credentials:type_name -> teleport.okta.v1.OktaAPICredentials
-	37, // 19: teleport.okta.v1.ListOktaImportRulesResponse.import_rules:type_name -> types.OktaImportRuleV1
-	37, // 20: teleport.okta.v1.CreateOktaImportRuleRequest.import_rule:type_name -> types.OktaImportRuleV1
-	37, // 21: teleport.okta.v1.UpdateOktaImportRuleRequest.import_rule:type_name -> types.OktaImportRuleV1
-	34, // 22: teleport.okta.v1.ListOktaAssignmentsResponse.assignments:type_name -> types.OktaAssignmentV1
-	34, // 23: teleport.okta.v1.CreateOktaAssignmentRequest.assignment:type_name -> types.OktaAssignmentV1
-	34, // 24: teleport.okta.v1.UpdateOktaAssignmentRequest.assignment:type_name -> types.OktaAssignmentV1
-	38, // 25: teleport.okta.v1.UpdateOktaAssignmentStatusRequest.status:type_name -> types.OktaAssignmentSpecV1.OktaAssignmentStatus
-	35, // 26: teleport.okta.v1.UpdateOktaAssignmentStatusRequest.time_has_passed:type_name -> google.protobuf.Duration
-	17, // 27: teleport.okta.v1.OktaService.ListOktaImportRules:input_type -> teleport.okta.v1.ListOktaImportRulesRequest
-	19, // 28: teleport.okta.v1.OktaService.GetOktaImportRule:input_type -> teleport.okta.v1.GetOktaImportRuleRequest
-	20, // 29: teleport.okta.v1.OktaService.CreateOktaImportRule:input_type -> teleport.okta.v1.CreateOktaImportRuleRequest
-	21, // 30: teleport.okta.v1.OktaService.UpdateOktaImportRule:input_type -> teleport.okta.v1.UpdateOktaImportRuleRequest
-	22, // 31: teleport.okta.v1.OktaService.DeleteOktaImportRule:input_type -> teleport.okta.v1.DeleteOktaImportRuleRequest
-	23, // 32: teleport.okta.v1.OktaService.DeleteAllOktaImportRules:input_type -> teleport.okta.v1.DeleteAllOktaImportRulesRequest
-	24, // 33: teleport.okta.v1.OktaService.ListOktaAssignments:input_type -> teleport.okta.v1.ListOktaAssignmentsRequest
-	26, // 34: teleport.okta.v1.OktaService.GetOktaAssignment:input_type -> teleport.okta.v1.GetOktaAssignmentRequest
-	27, // 35: teleport.okta.v1.OktaService.CreateOktaAssignment:input_type -> teleport.okta.v1.CreateOktaAssignmentRequest
-	28, // 36: teleport.okta.v1.OktaService.UpdateOktaAssignment:input_type -> teleport.okta.v1.UpdateOktaAssignmentRequest
-	29, // 37: teleport.okta.v1.OktaService.UpdateOktaAssignmentStatus:input_type -> teleport.okta.v1.UpdateOktaAssignmentStatusRequest
-	30, // 38: teleport.okta.v1.OktaService.DeleteOktaAssignment:input_type -> teleport.okta.v1.DeleteOktaAssignmentRequest
-	31, // 39: teleport.okta.v1.OktaService.DeleteAllOktaAssignments:input_type -> teleport.okta.v1.DeleteAllOktaAssignmentsRequest
-	0,  // 40: teleport.okta.v1.OktaService.ConditionalUpdateOktaAssignment:input_type -> teleport.okta.v1.ConditionalUpdateOktaAssignmentRequest
-	3,  // 41: teleport.okta.v1.OktaService.UpsertOktaAssignment:input_type -> teleport.okta.v1.UpsertOktaAssignmentRequest
-	15, // 42: teleport.okta.v1.OktaService.ValidateClientCredentials:input_type -> teleport.okta.v1.ValidateClientCredentialsRequest
-	8,  // 43: teleport.okta.v1.OktaService.CreateIntegration:input_type -> teleport.okta.v1.CreateIntegrationRequest
-	9,  // 44: teleport.okta.v1.OktaService.UpdateIntegration:input_type -> teleport.okta.v1.UpdateIntegrationRequest
-	4,  // 45: teleport.okta.v1.OktaService.GetApps:input_type -> teleport.okta.v1.GetAppsRequest
-	6,  // 46: teleport.okta.v1.OktaService.GetGroups:input_type -> teleport.okta.v1.GetGroupsRequest
-	18, // 47: teleport.okta.v1.OktaService.ListOktaImportRules:output_type -> teleport.okta.v1.ListOktaImportRulesResponse
-	37, // 48: teleport.okta.v1.OktaService.GetOktaImportRule:output_type -> types.OktaImportRuleV1
-	37, // 49: teleport.okta.v1.OktaService.CreateOktaImportRule:output_type -> types.OktaImportRuleV1
-	37, // 50: teleport.okta.v1.OktaService.UpdateOktaImportRule:output_type -> types.OktaImportRuleV1
-	39, // 51: teleport.okta.v1.OktaService.DeleteOktaImportRule:output_type -> google.protobuf.Empty
-	39, // 52: teleport.okta.v1.OktaService.DeleteAllOktaImportRules:output_type -> google.protobuf.Empty
-	25, // 53: teleport.okta.v1.OktaService.ListOktaAssignments:output_type -> teleport.okta.v1.ListOktaAssignmentsResponse
-	34, // 54: teleport.okta.v1.OktaService.GetOktaAssignment:output_type -> types.OktaAssignmentV1
-	34, // 55: teleport.okta.v1.OktaService.CreateOktaAssignment:output_type -> types.OktaAssignmentV1
-	34, // 56: teleport.okta.v1.OktaService.UpdateOktaAssignment:output_type -> types.OktaAssignmentV1
-	39, // 57: teleport.okta.v1.OktaService.UpdateOktaAssignmentStatus:output_type -> google.protobuf.Empty
-	39, // 58: teleport.okta.v1.OktaService.DeleteOktaAssignment:output_type -> google.protobuf.Empty
-	39, // 59: teleport.okta.v1.OktaService.DeleteAllOktaAssignments:output_type -> google.protobuf.Empty
-	1,  // 60: teleport.okta.v1.OktaService.ConditionalUpdateOktaAssignment:output_type -> teleport.okta.v1.ConditionalUpdateOktaAssignmentResponse
-	2,  // 61: teleport.okta.v1.OktaService.UpsertOktaAssignment:output_type -> teleport.okta.v1.UpsertOktaAssignmentResponse
-	16, // 62: teleport.okta.v1.OktaService.ValidateClientCredentials:output_type -> teleport.okta.v1.ValidateClientCredentialsResponse
-	12, // 63: teleport.okta.v1.OktaService.CreateIntegration:output_type -> teleport.okta.v1.CreateIntegrationResponse
-	13, // 64: teleport.okta.v1.OktaService.UpdateIntegration:output_type -> teleport.okta.v1.UpdateIntegrationResponse
-	5,  // 65: teleport.okta.v1.OktaService.GetApps:output_type -> teleport.okta.v1.GetAppsResponse
-	7,  // 66: teleport.okta.v1.OktaService.GetGroups:output_type -> teleport.okta.v1.GetGroupsResponse
-	47, // [47:67] is the sub-list for method output_type
-	27, // [27:47] is the sub-list for method input_type
-	27, // [27:27] is the sub-list for extension type_name
-	27, // [27:27] is the sub-list for extension extendee
-	0,  // [0:27] is the sub-list for field type_name
+	36, // 19: teleport.okta.v1.ListOktaImportRulesResponse.import_rules:type_name -> types.OktaImportRuleV1
+	36, // 20: teleport.okta.v1.CreateOktaImportRuleRequest.import_rule:type_name -> types.OktaImportRuleV1
+	36, // 21: teleport.okta.v1.UpdateOktaImportRuleRequest.import_rule:type_name -> types.OktaImportRuleV1
+	33, // 22: teleport.okta.v1.ListOktaAssignmentsResponse.assignments:type_name -> types.OktaAssignmentV1
+	33, // 23: teleport.okta.v1.CreateOktaAssignmentRequest.assignment:type_name -> types.OktaAssignmentV1
+	33, // 24: teleport.okta.v1.UpdateOktaAssignmentRequest.assignment:type_name -> types.OktaAssignmentV1
+	17, // 25: teleport.okta.v1.OktaService.ListOktaImportRules:input_type -> teleport.okta.v1.ListOktaImportRulesRequest
+	19, // 26: teleport.okta.v1.OktaService.GetOktaImportRule:input_type -> teleport.okta.v1.GetOktaImportRuleRequest
+	20, // 27: teleport.okta.v1.OktaService.CreateOktaImportRule:input_type -> teleport.okta.v1.CreateOktaImportRuleRequest
+	21, // 28: teleport.okta.v1.OktaService.UpdateOktaImportRule:input_type -> teleport.okta.v1.UpdateOktaImportRuleRequest
+	22, // 29: teleport.okta.v1.OktaService.DeleteOktaImportRule:input_type -> teleport.okta.v1.DeleteOktaImportRuleRequest
+	23, // 30: teleport.okta.v1.OktaService.DeleteAllOktaImportRules:input_type -> teleport.okta.v1.DeleteAllOktaImportRulesRequest
+	24, // 31: teleport.okta.v1.OktaService.ListOktaAssignments:input_type -> teleport.okta.v1.ListOktaAssignmentsRequest
+	26, // 32: teleport.okta.v1.OktaService.GetOktaAssignment:input_type -> teleport.okta.v1.GetOktaAssignmentRequest
+	27, // 33: teleport.okta.v1.OktaService.CreateOktaAssignment:input_type -> teleport.okta.v1.CreateOktaAssignmentRequest
+	28, // 34: teleport.okta.v1.OktaService.UpdateOktaAssignment:input_type -> teleport.okta.v1.UpdateOktaAssignmentRequest
+	29, // 35: teleport.okta.v1.OktaService.DeleteOktaAssignment:input_type -> teleport.okta.v1.DeleteOktaAssignmentRequest
+	30, // 36: teleport.okta.v1.OktaService.DeleteAllOktaAssignments:input_type -> teleport.okta.v1.DeleteAllOktaAssignmentsRequest
+	0,  // 37: teleport.okta.v1.OktaService.ConditionalUpdateOktaAssignment:input_type -> teleport.okta.v1.ConditionalUpdateOktaAssignmentRequest
+	3,  // 38: teleport.okta.v1.OktaService.UpsertOktaAssignment:input_type -> teleport.okta.v1.UpsertOktaAssignmentRequest
+	15, // 39: teleport.okta.v1.OktaService.ValidateClientCredentials:input_type -> teleport.okta.v1.ValidateClientCredentialsRequest
+	8,  // 40: teleport.okta.v1.OktaService.CreateIntegration:input_type -> teleport.okta.v1.CreateIntegrationRequest
+	9,  // 41: teleport.okta.v1.OktaService.UpdateIntegration:input_type -> teleport.okta.v1.UpdateIntegrationRequest
+	4,  // 42: teleport.okta.v1.OktaService.GetApps:input_type -> teleport.okta.v1.GetAppsRequest
+	6,  // 43: teleport.okta.v1.OktaService.GetGroups:input_type -> teleport.okta.v1.GetGroupsRequest
+	18, // 44: teleport.okta.v1.OktaService.ListOktaImportRules:output_type -> teleport.okta.v1.ListOktaImportRulesResponse
+	36, // 45: teleport.okta.v1.OktaService.GetOktaImportRule:output_type -> types.OktaImportRuleV1
+	36, // 46: teleport.okta.v1.OktaService.CreateOktaImportRule:output_type -> types.OktaImportRuleV1
+	36, // 47: teleport.okta.v1.OktaService.UpdateOktaImportRule:output_type -> types.OktaImportRuleV1
+	37, // 48: teleport.okta.v1.OktaService.DeleteOktaImportRule:output_type -> google.protobuf.Empty
+	37, // 49: teleport.okta.v1.OktaService.DeleteAllOktaImportRules:output_type -> google.protobuf.Empty
+	25, // 50: teleport.okta.v1.OktaService.ListOktaAssignments:output_type -> teleport.okta.v1.ListOktaAssignmentsResponse
+	33, // 51: teleport.okta.v1.OktaService.GetOktaAssignment:output_type -> types.OktaAssignmentV1
+	33, // 52: teleport.okta.v1.OktaService.CreateOktaAssignment:output_type -> types.OktaAssignmentV1
+	33, // 53: teleport.okta.v1.OktaService.UpdateOktaAssignment:output_type -> types.OktaAssignmentV1
+	37, // 54: teleport.okta.v1.OktaService.DeleteOktaAssignment:output_type -> google.protobuf.Empty
+	37, // 55: teleport.okta.v1.OktaService.DeleteAllOktaAssignments:output_type -> google.protobuf.Empty
+	1,  // 56: teleport.okta.v1.OktaService.ConditionalUpdateOktaAssignment:output_type -> teleport.okta.v1.ConditionalUpdateOktaAssignmentResponse
+	2,  // 57: teleport.okta.v1.OktaService.UpsertOktaAssignment:output_type -> teleport.okta.v1.UpsertOktaAssignmentResponse
+	16, // 58: teleport.okta.v1.OktaService.ValidateClientCredentials:output_type -> teleport.okta.v1.ValidateClientCredentialsResponse
+	12, // 59: teleport.okta.v1.OktaService.CreateIntegration:output_type -> teleport.okta.v1.CreateIntegrationResponse
+	13, // 60: teleport.okta.v1.OktaService.UpdateIntegration:output_type -> teleport.okta.v1.UpdateIntegrationResponse
+	5,  // 61: teleport.okta.v1.OktaService.GetApps:output_type -> teleport.okta.v1.GetAppsResponse
+	7,  // 62: teleport.okta.v1.OktaService.GetGroups:output_type -> teleport.okta.v1.GetGroupsResponse
+	44, // [44:63] is the sub-list for method output_type
+	25, // [25:44] is the sub-list for method input_type
+	25, // [25:25] is the sub-list for extension type_name
+	25, // [25:25] is the sub-list for extension extendee
+	0,  // [0:25] is the sub-list for field type_name
 }
 
 func init() { file_teleport_okta_v1_okta_service_proto_init() }
@@ -3371,7 +3255,7 @@ func file_teleport_okta_v1_okta_service_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_teleport_okta_v1_okta_service_proto_rawDesc), len(file_teleport_okta_v1_okta_service_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   34,
+			NumMessages:   33,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/api/gen/proto/go/teleport/okta/v1/okta_service_protoopaque.pb.go
+++ b/api/gen/proto/go/teleport/okta/v1/okta_service_protoopaque.pb.go
@@ -2630,107 +2630,6 @@ func (b0 UpdateOktaAssignmentRequest_builder) Build() *UpdateOktaAssignmentReque
 	return m0
 }
 
-// UpdateOktaAssignmentStatusRequest is a request for updating an Okta assignment status.
-type UpdateOktaAssignmentStatusRequest struct {
-	state                    protoimpl.MessageState                          `protogen:"opaque.v1"`
-	xxx_hidden_Name          string                                          `protobuf:"bytes,1,opt,name=name,proto3"`
-	xxx_hidden_Status        types.OktaAssignmentSpecV1_OktaAssignmentStatus `protobuf:"varint,2,opt,name=status,proto3,enum=types.OktaAssignmentSpecV1_OktaAssignmentStatus"`
-	xxx_hidden_TimeHasPassed *durationpb.Duration                            `protobuf:"bytes,3,opt,name=time_has_passed,json=timeHasPassed,proto3"`
-	unknownFields            protoimpl.UnknownFields
-	sizeCache                protoimpl.SizeCache
-}
-
-func (x *UpdateOktaAssignmentStatusRequest) Reset() {
-	*x = UpdateOktaAssignmentStatusRequest{}
-	mi := &file_teleport_okta_v1_okta_service_proto_msgTypes[29]
-	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-	ms.StoreMessageInfo(mi)
-}
-
-func (x *UpdateOktaAssignmentStatusRequest) String() string {
-	return protoimpl.X.MessageStringOf(x)
-}
-
-func (*UpdateOktaAssignmentStatusRequest) ProtoMessage() {}
-
-func (x *UpdateOktaAssignmentStatusRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_okta_v1_okta_service_proto_msgTypes[29]
-	if x != nil {
-		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-		if ms.LoadMessageInfo() == nil {
-			ms.StoreMessageInfo(mi)
-		}
-		return ms
-	}
-	return mi.MessageOf(x)
-}
-
-func (x *UpdateOktaAssignmentStatusRequest) GetName() string {
-	if x != nil {
-		return x.xxx_hidden_Name
-	}
-	return ""
-}
-
-func (x *UpdateOktaAssignmentStatusRequest) GetStatus() types.OktaAssignmentSpecV1_OktaAssignmentStatus {
-	if x != nil {
-		return x.xxx_hidden_Status
-	}
-	return types.OktaAssignmentSpecV1_OktaAssignmentStatus(0)
-}
-
-func (x *UpdateOktaAssignmentStatusRequest) GetTimeHasPassed() *durationpb.Duration {
-	if x != nil {
-		return x.xxx_hidden_TimeHasPassed
-	}
-	return nil
-}
-
-func (x *UpdateOktaAssignmentStatusRequest) SetName(v string) {
-	x.xxx_hidden_Name = v
-}
-
-func (x *UpdateOktaAssignmentStatusRequest) SetStatus(v types.OktaAssignmentSpecV1_OktaAssignmentStatus) {
-	x.xxx_hidden_Status = v
-}
-
-func (x *UpdateOktaAssignmentStatusRequest) SetTimeHasPassed(v *durationpb.Duration) {
-	x.xxx_hidden_TimeHasPassed = v
-}
-
-func (x *UpdateOktaAssignmentStatusRequest) HasTimeHasPassed() bool {
-	if x == nil {
-		return false
-	}
-	return x.xxx_hidden_TimeHasPassed != nil
-}
-
-func (x *UpdateOktaAssignmentStatusRequest) ClearTimeHasPassed() {
-	x.xxx_hidden_TimeHasPassed = nil
-}
-
-type UpdateOktaAssignmentStatusRequest_builder struct {
-	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
-
-	// name is the name of the Okta assignment.
-	Name string
-	// status is the status to update the assignment to.
-	Status types.OktaAssignmentSpecV1_OktaAssignmentStatus
-	// timeHasPassed is the amount of time that must have passed since the last transition
-	// in order to set the new transition.
-	TimeHasPassed *durationpb.Duration
-}
-
-func (b0 UpdateOktaAssignmentStatusRequest_builder) Build() *UpdateOktaAssignmentStatusRequest {
-	m0 := &UpdateOktaAssignmentStatusRequest{}
-	b, x := &b0, m0
-	_, _ = b, x
-	x.xxx_hidden_Name = b.Name
-	x.xxx_hidden_Status = b.Status
-	x.xxx_hidden_TimeHasPassed = b.TimeHasPassed
-	return m0
-}
-
 // DeleteOktaAssignmentRequest is the request for deleting an Okta assignment.
 type DeleteOktaAssignmentRequest struct {
 	state               protoimpl.MessageState `protogen:"opaque.v1"`
@@ -2742,7 +2641,7 @@ type DeleteOktaAssignmentRequest struct {
 
 func (x *DeleteOktaAssignmentRequest) Reset() {
 	*x = DeleteOktaAssignmentRequest{}
-	mi := &file_teleport_okta_v1_okta_service_proto_msgTypes[30]
+	mi := &file_teleport_okta_v1_okta_service_proto_msgTypes[29]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2754,7 +2653,7 @@ func (x *DeleteOktaAssignmentRequest) String() string {
 func (*DeleteOktaAssignmentRequest) ProtoMessage() {}
 
 func (x *DeleteOktaAssignmentRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_okta_v1_okta_service_proto_msgTypes[30]
+	mi := &file_teleport_okta_v1_okta_service_proto_msgTypes[29]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2814,7 +2713,7 @@ type DeleteAllOktaAssignmentsRequest struct {
 
 func (x *DeleteAllOktaAssignmentsRequest) Reset() {
 	*x = DeleteAllOktaAssignmentsRequest{}
-	mi := &file_teleport_okta_v1_okta_service_proto_msgTypes[31]
+	mi := &file_teleport_okta_v1_okta_service_proto_msgTypes[30]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2826,7 +2725,7 @@ func (x *DeleteAllOktaAssignmentsRequest) String() string {
 func (*DeleteAllOktaAssignmentsRequest) ProtoMessage() {}
 
 func (x *DeleteAllOktaAssignmentsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_okta_v1_okta_service_proto_msgTypes[31]
+	mi := &file_teleport_okta_v1_okta_service_proto_msgTypes[30]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2860,7 +2759,7 @@ type GetAppsResponse_App struct {
 
 func (x *GetAppsResponse_App) Reset() {
 	*x = GetAppsResponse_App{}
-	mi := &file_teleport_okta_v1_okta_service_proto_msgTypes[32]
+	mi := &file_teleport_okta_v1_okta_service_proto_msgTypes[31]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2872,7 +2771,7 @@ func (x *GetAppsResponse_App) String() string {
 func (*GetAppsResponse_App) ProtoMessage() {}
 
 func (x *GetAppsResponse_App) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_okta_v1_okta_service_proto_msgTypes[32]
+	mi := &file_teleport_okta_v1_okta_service_proto_msgTypes[31]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2934,7 +2833,7 @@ type GetGroupsResponse_Group struct {
 
 func (x *GetGroupsResponse_Group) Reset() {
 	*x = GetGroupsResponse_Group{}
-	mi := &file_teleport_okta_v1_okta_service_proto_msgTypes[33]
+	mi := &file_teleport_okta_v1_okta_service_proto_msgTypes[32]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2946,7 +2845,7 @@ func (x *GetGroupsResponse_Group) String() string {
 func (*GetGroupsResponse_Group) ProtoMessage() {}
 
 func (x *GetGroupsResponse_Group) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_okta_v1_okta_service_proto_msgTypes[33]
+	mi := &file_teleport_okta_v1_okta_service_proto_msgTypes[32]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3124,15 +3023,11 @@ const file_teleport_okta_v1_okta_service_proto_rawDesc = "" +
 	"\x1bUpdateOktaAssignmentRequest\x127\n" +
 	"\n" +
 	"assignment\x18\x01 \x01(\v2\x17.types.OktaAssignmentV1R\n" +
-	"assignment\"\xc4\x01\n" +
-	"!UpdateOktaAssignmentStatusRequest\x12\x12\n" +
-	"\x04name\x18\x01 \x01(\tR\x04name\x12H\n" +
-	"\x06status\x18\x02 \x01(\x0e20.types.OktaAssignmentSpecV1.OktaAssignmentStatusR\x06status\x12A\n" +
-	"\x0ftime_has_passed\x18\x03 \x01(\v2\x19.google.protobuf.DurationR\rtimeHasPassed\"M\n" +
+	"assignment\"M\n" +
 	"\x1bDeleteOktaAssignmentRequest\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12\x1a\n" +
 	"\brevision\x18\x02 \x01(\tR\brevision\"!\n" +
-	"\x1fDeleteAllOktaAssignmentsRequest2\xb9\x10\n" +
+	"\x1fDeleteAllOktaAssignmentsRequest2\xce\x0f\n" +
 	"\vOktaService\x12r\n" +
 	"\x13ListOktaImportRules\x12,.teleport.okta.v1.ListOktaImportRulesRequest\x1a-.teleport.okta.v1.ListOktaImportRulesResponse\x12X\n" +
 	"\x11GetOktaImportRule\x12*.teleport.okta.v1.GetOktaImportRuleRequest\x1a\x17.types.OktaImportRuleV1\x12^\n" +
@@ -3143,8 +3038,7 @@ const file_teleport_okta_v1_okta_service_proto_rawDesc = "" +
 	"\x13ListOktaAssignments\x12,.teleport.okta.v1.ListOktaAssignmentsRequest\x1a-.teleport.okta.v1.ListOktaAssignmentsResponse\x12X\n" +
 	"\x11GetOktaAssignment\x12*.teleport.okta.v1.GetOktaAssignmentRequest\x1a\x17.types.OktaAssignmentV1\x12^\n" +
 	"\x14CreateOktaAssignment\x12-.teleport.okta.v1.CreateOktaAssignmentRequest\x1a\x17.types.OktaAssignmentV1\x12^\n" +
-	"\x14UpdateOktaAssignment\x12-.teleport.okta.v1.UpdateOktaAssignmentRequest\x1a\x17.types.OktaAssignmentV1\x12i\n" +
-	"\x1aUpdateOktaAssignmentStatus\x123.teleport.okta.v1.UpdateOktaAssignmentStatusRequest\x1a\x16.google.protobuf.Empty\x12]\n" +
+	"\x14UpdateOktaAssignment\x12-.teleport.okta.v1.UpdateOktaAssignmentRequest\x1a\x17.types.OktaAssignmentV1\x12]\n" +
 	"\x14DeleteOktaAssignment\x12-.teleport.okta.v1.DeleteOktaAssignmentRequest\x1a\x16.google.protobuf.Empty\x12e\n" +
 	"\x18DeleteAllOktaAssignments\x121.teleport.okta.v1.DeleteAllOktaAssignmentsRequest\x1a\x16.google.protobuf.Empty\x12\x96\x01\n" +
 	"\x1fConditionalUpdateOktaAssignment\x128.teleport.okta.v1.ConditionalUpdateOktaAssignmentRequest\x1a9.teleport.okta.v1.ConditionalUpdateOktaAssignmentResponse\x12u\n" +
@@ -3155,122 +3049,116 @@ const file_teleport_okta_v1_okta_service_proto_rawDesc = "" +
 	"\aGetApps\x12 .teleport.okta.v1.GetAppsRequest\x1a!.teleport.okta.v1.GetAppsResponse\x12T\n" +
 	"\tGetGroups\x12\".teleport.okta.v1.GetGroupsRequest\x1a#.teleport.okta.v1.GetGroupsResponseBLZJgithub.com/gravitational/teleport/api/gen/proto/go/teleport/okta/v1;oktav1b\x06proto3"
 
-var file_teleport_okta_v1_okta_service_proto_msgTypes = make([]protoimpl.MessageInfo, 34)
+var file_teleport_okta_v1_okta_service_proto_msgTypes = make([]protoimpl.MessageInfo, 33)
 var file_teleport_okta_v1_okta_service_proto_goTypes = []any{
-	(*ConditionalUpdateOktaAssignmentRequest)(nil),       // 0: teleport.okta.v1.ConditionalUpdateOktaAssignmentRequest
-	(*ConditionalUpdateOktaAssignmentResponse)(nil),      // 1: teleport.okta.v1.ConditionalUpdateOktaAssignmentResponse
-	(*UpsertOktaAssignmentResponse)(nil),                 // 2: teleport.okta.v1.UpsertOktaAssignmentResponse
-	(*UpsertOktaAssignmentRequest)(nil),                  // 3: teleport.okta.v1.UpsertOktaAssignmentRequest
-	(*GetAppsRequest)(nil),                               // 4: teleport.okta.v1.GetAppsRequest
-	(*GetAppsResponse)(nil),                              // 5: teleport.okta.v1.GetAppsResponse
-	(*GetGroupsRequest)(nil),                             // 6: teleport.okta.v1.GetGroupsRequest
-	(*GetGroupsResponse)(nil),                            // 7: teleport.okta.v1.GetGroupsResponse
-	(*CreateIntegrationRequest)(nil),                     // 8: teleport.okta.v1.CreateIntegrationRequest
-	(*UpdateIntegrationRequest)(nil),                     // 9: teleport.okta.v1.UpdateIntegrationRequest
-	(*AccessListSettings)(nil),                           // 10: teleport.okta.v1.AccessListSettings
-	(*OktaAPICredentials)(nil),                           // 11: teleport.okta.v1.OktaAPICredentials
-	(*CreateIntegrationResponse)(nil),                    // 12: teleport.okta.v1.CreateIntegrationResponse
-	(*UpdateIntegrationResponse)(nil),                    // 13: teleport.okta.v1.UpdateIntegrationResponse
-	(*ConnectorInfo)(nil),                                // 14: teleport.okta.v1.ConnectorInfo
-	(*ValidateClientCredentialsRequest)(nil),             // 15: teleport.okta.v1.ValidateClientCredentialsRequest
-	(*ValidateClientCredentialsResponse)(nil),            // 16: teleport.okta.v1.ValidateClientCredentialsResponse
-	(*ListOktaImportRulesRequest)(nil),                   // 17: teleport.okta.v1.ListOktaImportRulesRequest
-	(*ListOktaImportRulesResponse)(nil),                  // 18: teleport.okta.v1.ListOktaImportRulesResponse
-	(*GetOktaImportRuleRequest)(nil),                     // 19: teleport.okta.v1.GetOktaImportRuleRequest
-	(*CreateOktaImportRuleRequest)(nil),                  // 20: teleport.okta.v1.CreateOktaImportRuleRequest
-	(*UpdateOktaImportRuleRequest)(nil),                  // 21: teleport.okta.v1.UpdateOktaImportRuleRequest
-	(*DeleteOktaImportRuleRequest)(nil),                  // 22: teleport.okta.v1.DeleteOktaImportRuleRequest
-	(*DeleteAllOktaImportRulesRequest)(nil),              // 23: teleport.okta.v1.DeleteAllOktaImportRulesRequest
-	(*ListOktaAssignmentsRequest)(nil),                   // 24: teleport.okta.v1.ListOktaAssignmentsRequest
-	(*ListOktaAssignmentsResponse)(nil),                  // 25: teleport.okta.v1.ListOktaAssignmentsResponse
-	(*GetOktaAssignmentRequest)(nil),                     // 26: teleport.okta.v1.GetOktaAssignmentRequest
-	(*CreateOktaAssignmentRequest)(nil),                  // 27: teleport.okta.v1.CreateOktaAssignmentRequest
-	(*UpdateOktaAssignmentRequest)(nil),                  // 28: teleport.okta.v1.UpdateOktaAssignmentRequest
-	(*UpdateOktaAssignmentStatusRequest)(nil),            // 29: teleport.okta.v1.UpdateOktaAssignmentStatusRequest
-	(*DeleteOktaAssignmentRequest)(nil),                  // 30: teleport.okta.v1.DeleteOktaAssignmentRequest
-	(*DeleteAllOktaAssignmentsRequest)(nil),              // 31: teleport.okta.v1.DeleteAllOktaAssignmentsRequest
-	(*GetAppsResponse_App)(nil),                          // 32: teleport.okta.v1.GetAppsResponse.App
-	(*GetGroupsResponse_Group)(nil),                      // 33: teleport.okta.v1.GetGroupsResponse.Group
-	(*types.OktaAssignmentV1)(nil),                       // 34: types.OktaAssignmentV1
-	(*durationpb.Duration)(nil),                          // 35: google.protobuf.Duration
-	(*types.PluginV1)(nil),                               // 36: types.PluginV1
-	(*types.OktaImportRuleV1)(nil),                       // 37: types.OktaImportRuleV1
-	(types.OktaAssignmentSpecV1_OktaAssignmentStatus)(0), // 38: types.OktaAssignmentSpecV1.OktaAssignmentStatus
-	(*emptypb.Empty)(nil),                                // 39: google.protobuf.Empty
+	(*ConditionalUpdateOktaAssignmentRequest)(nil),  // 0: teleport.okta.v1.ConditionalUpdateOktaAssignmentRequest
+	(*ConditionalUpdateOktaAssignmentResponse)(nil), // 1: teleport.okta.v1.ConditionalUpdateOktaAssignmentResponse
+	(*UpsertOktaAssignmentResponse)(nil),            // 2: teleport.okta.v1.UpsertOktaAssignmentResponse
+	(*UpsertOktaAssignmentRequest)(nil),             // 3: teleport.okta.v1.UpsertOktaAssignmentRequest
+	(*GetAppsRequest)(nil),                          // 4: teleport.okta.v1.GetAppsRequest
+	(*GetAppsResponse)(nil),                         // 5: teleport.okta.v1.GetAppsResponse
+	(*GetGroupsRequest)(nil),                        // 6: teleport.okta.v1.GetGroupsRequest
+	(*GetGroupsResponse)(nil),                       // 7: teleport.okta.v1.GetGroupsResponse
+	(*CreateIntegrationRequest)(nil),                // 8: teleport.okta.v1.CreateIntegrationRequest
+	(*UpdateIntegrationRequest)(nil),                // 9: teleport.okta.v1.UpdateIntegrationRequest
+	(*AccessListSettings)(nil),                      // 10: teleport.okta.v1.AccessListSettings
+	(*OktaAPICredentials)(nil),                      // 11: teleport.okta.v1.OktaAPICredentials
+	(*CreateIntegrationResponse)(nil),               // 12: teleport.okta.v1.CreateIntegrationResponse
+	(*UpdateIntegrationResponse)(nil),               // 13: teleport.okta.v1.UpdateIntegrationResponse
+	(*ConnectorInfo)(nil),                           // 14: teleport.okta.v1.ConnectorInfo
+	(*ValidateClientCredentialsRequest)(nil),        // 15: teleport.okta.v1.ValidateClientCredentialsRequest
+	(*ValidateClientCredentialsResponse)(nil),       // 16: teleport.okta.v1.ValidateClientCredentialsResponse
+	(*ListOktaImportRulesRequest)(nil),              // 17: teleport.okta.v1.ListOktaImportRulesRequest
+	(*ListOktaImportRulesResponse)(nil),             // 18: teleport.okta.v1.ListOktaImportRulesResponse
+	(*GetOktaImportRuleRequest)(nil),                // 19: teleport.okta.v1.GetOktaImportRuleRequest
+	(*CreateOktaImportRuleRequest)(nil),             // 20: teleport.okta.v1.CreateOktaImportRuleRequest
+	(*UpdateOktaImportRuleRequest)(nil),             // 21: teleport.okta.v1.UpdateOktaImportRuleRequest
+	(*DeleteOktaImportRuleRequest)(nil),             // 22: teleport.okta.v1.DeleteOktaImportRuleRequest
+	(*DeleteAllOktaImportRulesRequest)(nil),         // 23: teleport.okta.v1.DeleteAllOktaImportRulesRequest
+	(*ListOktaAssignmentsRequest)(nil),              // 24: teleport.okta.v1.ListOktaAssignmentsRequest
+	(*ListOktaAssignmentsResponse)(nil),             // 25: teleport.okta.v1.ListOktaAssignmentsResponse
+	(*GetOktaAssignmentRequest)(nil),                // 26: teleport.okta.v1.GetOktaAssignmentRequest
+	(*CreateOktaAssignmentRequest)(nil),             // 27: teleport.okta.v1.CreateOktaAssignmentRequest
+	(*UpdateOktaAssignmentRequest)(nil),             // 28: teleport.okta.v1.UpdateOktaAssignmentRequest
+	(*DeleteOktaAssignmentRequest)(nil),             // 29: teleport.okta.v1.DeleteOktaAssignmentRequest
+	(*DeleteAllOktaAssignmentsRequest)(nil),         // 30: teleport.okta.v1.DeleteAllOktaAssignmentsRequest
+	(*GetAppsResponse_App)(nil),                     // 31: teleport.okta.v1.GetAppsResponse.App
+	(*GetGroupsResponse_Group)(nil),                 // 32: teleport.okta.v1.GetGroupsResponse.Group
+	(*types.OktaAssignmentV1)(nil),                  // 33: types.OktaAssignmentV1
+	(*durationpb.Duration)(nil),                     // 34: google.protobuf.Duration
+	(*types.PluginV1)(nil),                          // 35: types.PluginV1
+	(*types.OktaImportRuleV1)(nil),                  // 36: types.OktaImportRuleV1
+	(*emptypb.Empty)(nil),                           // 37: google.protobuf.Empty
 }
 var file_teleport_okta_v1_okta_service_proto_depIdxs = []int32{
-	34, // 0: teleport.okta.v1.ConditionalUpdateOktaAssignmentRequest.assignment:type_name -> types.OktaAssignmentV1
-	34, // 1: teleport.okta.v1.ConditionalUpdateOktaAssignmentResponse.assignment:type_name -> types.OktaAssignmentV1
-	34, // 2: teleport.okta.v1.UpsertOktaAssignmentResponse.assignment:type_name -> types.OktaAssignmentV1
-	34, // 3: teleport.okta.v1.UpsertOktaAssignmentRequest.assignment:type_name -> types.OktaAssignmentV1
+	33, // 0: teleport.okta.v1.ConditionalUpdateOktaAssignmentRequest.assignment:type_name -> types.OktaAssignmentV1
+	33, // 1: teleport.okta.v1.ConditionalUpdateOktaAssignmentResponse.assignment:type_name -> types.OktaAssignmentV1
+	33, // 2: teleport.okta.v1.UpsertOktaAssignmentResponse.assignment:type_name -> types.OktaAssignmentV1
+	33, // 3: teleport.okta.v1.UpsertOktaAssignmentRequest.assignment:type_name -> types.OktaAssignmentV1
 	11, // 4: teleport.okta.v1.GetAppsRequest.api_credentials:type_name -> teleport.okta.v1.OktaAPICredentials
-	32, // 5: teleport.okta.v1.GetAppsResponse.apps:type_name -> teleport.okta.v1.GetAppsResponse.App
+	31, // 5: teleport.okta.v1.GetAppsResponse.apps:type_name -> teleport.okta.v1.GetAppsResponse.App
 	11, // 6: teleport.okta.v1.GetGroupsRequest.api_credentials:type_name -> teleport.okta.v1.OktaAPICredentials
-	33, // 7: teleport.okta.v1.GetGroupsResponse.groups:type_name -> teleport.okta.v1.GetGroupsResponse.Group
+	32, // 7: teleport.okta.v1.GetGroupsResponse.groups:type_name -> teleport.okta.v1.GetGroupsResponse.Group
 	11, // 8: teleport.okta.v1.CreateIntegrationRequest.api_credentials:type_name -> teleport.okta.v1.OktaAPICredentials
 	10, // 9: teleport.okta.v1.CreateIntegrationRequest.access_list_settings:type_name -> teleport.okta.v1.AccessListSettings
-	35, // 10: teleport.okta.v1.CreateIntegrationRequest.time_between_imports:type_name -> google.protobuf.Duration
+	34, // 10: teleport.okta.v1.CreateIntegrationRequest.time_between_imports:type_name -> google.protobuf.Duration
 	11, // 11: teleport.okta.v1.UpdateIntegrationRequest.api_credentials:type_name -> teleport.okta.v1.OktaAPICredentials
 	10, // 12: teleport.okta.v1.UpdateIntegrationRequest.access_list_settings:type_name -> teleport.okta.v1.AccessListSettings
-	35, // 13: teleport.okta.v1.UpdateIntegrationRequest.time_between_imports:type_name -> google.protobuf.Duration
-	36, // 14: teleport.okta.v1.CreateIntegrationResponse.plugin:type_name -> types.PluginV1
+	34, // 13: teleport.okta.v1.UpdateIntegrationRequest.time_between_imports:type_name -> google.protobuf.Duration
+	35, // 14: teleport.okta.v1.CreateIntegrationResponse.plugin:type_name -> types.PluginV1
 	14, // 15: teleport.okta.v1.CreateIntegrationResponse.connector_info:type_name -> teleport.okta.v1.ConnectorInfo
-	36, // 16: teleport.okta.v1.UpdateIntegrationResponse.plugin:type_name -> types.PluginV1
+	35, // 16: teleport.okta.v1.UpdateIntegrationResponse.plugin:type_name -> types.PluginV1
 	14, // 17: teleport.okta.v1.UpdateIntegrationResponse.connector_info:type_name -> teleport.okta.v1.ConnectorInfo
 	11, // 18: teleport.okta.v1.ValidateClientCredentialsRequest.api_credentials:type_name -> teleport.okta.v1.OktaAPICredentials
-	37, // 19: teleport.okta.v1.ListOktaImportRulesResponse.import_rules:type_name -> types.OktaImportRuleV1
-	37, // 20: teleport.okta.v1.CreateOktaImportRuleRequest.import_rule:type_name -> types.OktaImportRuleV1
-	37, // 21: teleport.okta.v1.UpdateOktaImportRuleRequest.import_rule:type_name -> types.OktaImportRuleV1
-	34, // 22: teleport.okta.v1.ListOktaAssignmentsResponse.assignments:type_name -> types.OktaAssignmentV1
-	34, // 23: teleport.okta.v1.CreateOktaAssignmentRequest.assignment:type_name -> types.OktaAssignmentV1
-	34, // 24: teleport.okta.v1.UpdateOktaAssignmentRequest.assignment:type_name -> types.OktaAssignmentV1
-	38, // 25: teleport.okta.v1.UpdateOktaAssignmentStatusRequest.status:type_name -> types.OktaAssignmentSpecV1.OktaAssignmentStatus
-	35, // 26: teleport.okta.v1.UpdateOktaAssignmentStatusRequest.time_has_passed:type_name -> google.protobuf.Duration
-	17, // 27: teleport.okta.v1.OktaService.ListOktaImportRules:input_type -> teleport.okta.v1.ListOktaImportRulesRequest
-	19, // 28: teleport.okta.v1.OktaService.GetOktaImportRule:input_type -> teleport.okta.v1.GetOktaImportRuleRequest
-	20, // 29: teleport.okta.v1.OktaService.CreateOktaImportRule:input_type -> teleport.okta.v1.CreateOktaImportRuleRequest
-	21, // 30: teleport.okta.v1.OktaService.UpdateOktaImportRule:input_type -> teleport.okta.v1.UpdateOktaImportRuleRequest
-	22, // 31: teleport.okta.v1.OktaService.DeleteOktaImportRule:input_type -> teleport.okta.v1.DeleteOktaImportRuleRequest
-	23, // 32: teleport.okta.v1.OktaService.DeleteAllOktaImportRules:input_type -> teleport.okta.v1.DeleteAllOktaImportRulesRequest
-	24, // 33: teleport.okta.v1.OktaService.ListOktaAssignments:input_type -> teleport.okta.v1.ListOktaAssignmentsRequest
-	26, // 34: teleport.okta.v1.OktaService.GetOktaAssignment:input_type -> teleport.okta.v1.GetOktaAssignmentRequest
-	27, // 35: teleport.okta.v1.OktaService.CreateOktaAssignment:input_type -> teleport.okta.v1.CreateOktaAssignmentRequest
-	28, // 36: teleport.okta.v1.OktaService.UpdateOktaAssignment:input_type -> teleport.okta.v1.UpdateOktaAssignmentRequest
-	29, // 37: teleport.okta.v1.OktaService.UpdateOktaAssignmentStatus:input_type -> teleport.okta.v1.UpdateOktaAssignmentStatusRequest
-	30, // 38: teleport.okta.v1.OktaService.DeleteOktaAssignment:input_type -> teleport.okta.v1.DeleteOktaAssignmentRequest
-	31, // 39: teleport.okta.v1.OktaService.DeleteAllOktaAssignments:input_type -> teleport.okta.v1.DeleteAllOktaAssignmentsRequest
-	0,  // 40: teleport.okta.v1.OktaService.ConditionalUpdateOktaAssignment:input_type -> teleport.okta.v1.ConditionalUpdateOktaAssignmentRequest
-	3,  // 41: teleport.okta.v1.OktaService.UpsertOktaAssignment:input_type -> teleport.okta.v1.UpsertOktaAssignmentRequest
-	15, // 42: teleport.okta.v1.OktaService.ValidateClientCredentials:input_type -> teleport.okta.v1.ValidateClientCredentialsRequest
-	8,  // 43: teleport.okta.v1.OktaService.CreateIntegration:input_type -> teleport.okta.v1.CreateIntegrationRequest
-	9,  // 44: teleport.okta.v1.OktaService.UpdateIntegration:input_type -> teleport.okta.v1.UpdateIntegrationRequest
-	4,  // 45: teleport.okta.v1.OktaService.GetApps:input_type -> teleport.okta.v1.GetAppsRequest
-	6,  // 46: teleport.okta.v1.OktaService.GetGroups:input_type -> teleport.okta.v1.GetGroupsRequest
-	18, // 47: teleport.okta.v1.OktaService.ListOktaImportRules:output_type -> teleport.okta.v1.ListOktaImportRulesResponse
-	37, // 48: teleport.okta.v1.OktaService.GetOktaImportRule:output_type -> types.OktaImportRuleV1
-	37, // 49: teleport.okta.v1.OktaService.CreateOktaImportRule:output_type -> types.OktaImportRuleV1
-	37, // 50: teleport.okta.v1.OktaService.UpdateOktaImportRule:output_type -> types.OktaImportRuleV1
-	39, // 51: teleport.okta.v1.OktaService.DeleteOktaImportRule:output_type -> google.protobuf.Empty
-	39, // 52: teleport.okta.v1.OktaService.DeleteAllOktaImportRules:output_type -> google.protobuf.Empty
-	25, // 53: teleport.okta.v1.OktaService.ListOktaAssignments:output_type -> teleport.okta.v1.ListOktaAssignmentsResponse
-	34, // 54: teleport.okta.v1.OktaService.GetOktaAssignment:output_type -> types.OktaAssignmentV1
-	34, // 55: teleport.okta.v1.OktaService.CreateOktaAssignment:output_type -> types.OktaAssignmentV1
-	34, // 56: teleport.okta.v1.OktaService.UpdateOktaAssignment:output_type -> types.OktaAssignmentV1
-	39, // 57: teleport.okta.v1.OktaService.UpdateOktaAssignmentStatus:output_type -> google.protobuf.Empty
-	39, // 58: teleport.okta.v1.OktaService.DeleteOktaAssignment:output_type -> google.protobuf.Empty
-	39, // 59: teleport.okta.v1.OktaService.DeleteAllOktaAssignments:output_type -> google.protobuf.Empty
-	1,  // 60: teleport.okta.v1.OktaService.ConditionalUpdateOktaAssignment:output_type -> teleport.okta.v1.ConditionalUpdateOktaAssignmentResponse
-	2,  // 61: teleport.okta.v1.OktaService.UpsertOktaAssignment:output_type -> teleport.okta.v1.UpsertOktaAssignmentResponse
-	16, // 62: teleport.okta.v1.OktaService.ValidateClientCredentials:output_type -> teleport.okta.v1.ValidateClientCredentialsResponse
-	12, // 63: teleport.okta.v1.OktaService.CreateIntegration:output_type -> teleport.okta.v1.CreateIntegrationResponse
-	13, // 64: teleport.okta.v1.OktaService.UpdateIntegration:output_type -> teleport.okta.v1.UpdateIntegrationResponse
-	5,  // 65: teleport.okta.v1.OktaService.GetApps:output_type -> teleport.okta.v1.GetAppsResponse
-	7,  // 66: teleport.okta.v1.OktaService.GetGroups:output_type -> teleport.okta.v1.GetGroupsResponse
-	47, // [47:67] is the sub-list for method output_type
-	27, // [27:47] is the sub-list for method input_type
-	27, // [27:27] is the sub-list for extension type_name
-	27, // [27:27] is the sub-list for extension extendee
-	0,  // [0:27] is the sub-list for field type_name
+	36, // 19: teleport.okta.v1.ListOktaImportRulesResponse.import_rules:type_name -> types.OktaImportRuleV1
+	36, // 20: teleport.okta.v1.CreateOktaImportRuleRequest.import_rule:type_name -> types.OktaImportRuleV1
+	36, // 21: teleport.okta.v1.UpdateOktaImportRuleRequest.import_rule:type_name -> types.OktaImportRuleV1
+	33, // 22: teleport.okta.v1.ListOktaAssignmentsResponse.assignments:type_name -> types.OktaAssignmentV1
+	33, // 23: teleport.okta.v1.CreateOktaAssignmentRequest.assignment:type_name -> types.OktaAssignmentV1
+	33, // 24: teleport.okta.v1.UpdateOktaAssignmentRequest.assignment:type_name -> types.OktaAssignmentV1
+	17, // 25: teleport.okta.v1.OktaService.ListOktaImportRules:input_type -> teleport.okta.v1.ListOktaImportRulesRequest
+	19, // 26: teleport.okta.v1.OktaService.GetOktaImportRule:input_type -> teleport.okta.v1.GetOktaImportRuleRequest
+	20, // 27: teleport.okta.v1.OktaService.CreateOktaImportRule:input_type -> teleport.okta.v1.CreateOktaImportRuleRequest
+	21, // 28: teleport.okta.v1.OktaService.UpdateOktaImportRule:input_type -> teleport.okta.v1.UpdateOktaImportRuleRequest
+	22, // 29: teleport.okta.v1.OktaService.DeleteOktaImportRule:input_type -> teleport.okta.v1.DeleteOktaImportRuleRequest
+	23, // 30: teleport.okta.v1.OktaService.DeleteAllOktaImportRules:input_type -> teleport.okta.v1.DeleteAllOktaImportRulesRequest
+	24, // 31: teleport.okta.v1.OktaService.ListOktaAssignments:input_type -> teleport.okta.v1.ListOktaAssignmentsRequest
+	26, // 32: teleport.okta.v1.OktaService.GetOktaAssignment:input_type -> teleport.okta.v1.GetOktaAssignmentRequest
+	27, // 33: teleport.okta.v1.OktaService.CreateOktaAssignment:input_type -> teleport.okta.v1.CreateOktaAssignmentRequest
+	28, // 34: teleport.okta.v1.OktaService.UpdateOktaAssignment:input_type -> teleport.okta.v1.UpdateOktaAssignmentRequest
+	29, // 35: teleport.okta.v1.OktaService.DeleteOktaAssignment:input_type -> teleport.okta.v1.DeleteOktaAssignmentRequest
+	30, // 36: teleport.okta.v1.OktaService.DeleteAllOktaAssignments:input_type -> teleport.okta.v1.DeleteAllOktaAssignmentsRequest
+	0,  // 37: teleport.okta.v1.OktaService.ConditionalUpdateOktaAssignment:input_type -> teleport.okta.v1.ConditionalUpdateOktaAssignmentRequest
+	3,  // 38: teleport.okta.v1.OktaService.UpsertOktaAssignment:input_type -> teleport.okta.v1.UpsertOktaAssignmentRequest
+	15, // 39: teleport.okta.v1.OktaService.ValidateClientCredentials:input_type -> teleport.okta.v1.ValidateClientCredentialsRequest
+	8,  // 40: teleport.okta.v1.OktaService.CreateIntegration:input_type -> teleport.okta.v1.CreateIntegrationRequest
+	9,  // 41: teleport.okta.v1.OktaService.UpdateIntegration:input_type -> teleport.okta.v1.UpdateIntegrationRequest
+	4,  // 42: teleport.okta.v1.OktaService.GetApps:input_type -> teleport.okta.v1.GetAppsRequest
+	6,  // 43: teleport.okta.v1.OktaService.GetGroups:input_type -> teleport.okta.v1.GetGroupsRequest
+	18, // 44: teleport.okta.v1.OktaService.ListOktaImportRules:output_type -> teleport.okta.v1.ListOktaImportRulesResponse
+	36, // 45: teleport.okta.v1.OktaService.GetOktaImportRule:output_type -> types.OktaImportRuleV1
+	36, // 46: teleport.okta.v1.OktaService.CreateOktaImportRule:output_type -> types.OktaImportRuleV1
+	36, // 47: teleport.okta.v1.OktaService.UpdateOktaImportRule:output_type -> types.OktaImportRuleV1
+	37, // 48: teleport.okta.v1.OktaService.DeleteOktaImportRule:output_type -> google.protobuf.Empty
+	37, // 49: teleport.okta.v1.OktaService.DeleteAllOktaImportRules:output_type -> google.protobuf.Empty
+	25, // 50: teleport.okta.v1.OktaService.ListOktaAssignments:output_type -> teleport.okta.v1.ListOktaAssignmentsResponse
+	33, // 51: teleport.okta.v1.OktaService.GetOktaAssignment:output_type -> types.OktaAssignmentV1
+	33, // 52: teleport.okta.v1.OktaService.CreateOktaAssignment:output_type -> types.OktaAssignmentV1
+	33, // 53: teleport.okta.v1.OktaService.UpdateOktaAssignment:output_type -> types.OktaAssignmentV1
+	37, // 54: teleport.okta.v1.OktaService.DeleteOktaAssignment:output_type -> google.protobuf.Empty
+	37, // 55: teleport.okta.v1.OktaService.DeleteAllOktaAssignments:output_type -> google.protobuf.Empty
+	1,  // 56: teleport.okta.v1.OktaService.ConditionalUpdateOktaAssignment:output_type -> teleport.okta.v1.ConditionalUpdateOktaAssignmentResponse
+	2,  // 57: teleport.okta.v1.OktaService.UpsertOktaAssignment:output_type -> teleport.okta.v1.UpsertOktaAssignmentResponse
+	16, // 58: teleport.okta.v1.OktaService.ValidateClientCredentials:output_type -> teleport.okta.v1.ValidateClientCredentialsResponse
+	12, // 59: teleport.okta.v1.OktaService.CreateIntegration:output_type -> teleport.okta.v1.CreateIntegrationResponse
+	13, // 60: teleport.okta.v1.OktaService.UpdateIntegration:output_type -> teleport.okta.v1.UpdateIntegrationResponse
+	5,  // 61: teleport.okta.v1.OktaService.GetApps:output_type -> teleport.okta.v1.GetAppsResponse
+	7,  // 62: teleport.okta.v1.OktaService.GetGroups:output_type -> teleport.okta.v1.GetGroupsResponse
+	44, // [44:63] is the sub-list for method output_type
+	25, // [25:44] is the sub-list for method input_type
+	25, // [25:25] is the sub-list for extension type_name
+	25, // [25:25] is the sub-list for extension extendee
+	0,  // [0:25] is the sub-list for field type_name
 }
 
 func init() { file_teleport_okta_v1_okta_service_proto_init() }
@@ -3288,7 +3176,7 @@ func file_teleport_okta_v1_okta_service_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_teleport_okta_v1_okta_service_proto_rawDesc), len(file_teleport_okta_v1_okta_service_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   34,
+			NumMessages:   33,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/api/proto/teleport/okta/v1/okta_service.proto
+++ b/api/proto/teleport/okta/v1/okta_service.proto
@@ -45,8 +45,6 @@ service OktaService {
   rpc CreateOktaAssignment(CreateOktaAssignmentRequest) returns (types.OktaAssignmentV1);
   // UpdateOktaAssignment updates an existing Okta assignment resource.
   rpc UpdateOktaAssignment(UpdateOktaAssignmentRequest) returns (types.OktaAssignmentV1);
-  // UpdateOktaAssignmentStatus will update the status for an Okta assignment.
-  rpc UpdateOktaAssignmentStatus(UpdateOktaAssignmentStatusRequest) returns (google.protobuf.Empty);
   // DeleteOktaAssignment removes the specified Okta assignment resource.
   rpc DeleteOktaAssignment(DeleteOktaAssignmentRequest) returns (google.protobuf.Empty);
   // DeleteAllOktaAssignments removes all Okta assignments.
@@ -340,17 +338,6 @@ message CreateOktaAssignmentRequest {
 message UpdateOktaAssignmentRequest {
   // assignment is the Okta assignment to update.
   types.OktaAssignmentV1 assignment = 1;
-}
-
-// UpdateOktaAssignmentStatusRequest is a request for updating an Okta assignment status.
-message UpdateOktaAssignmentStatusRequest {
-  // name is the name of the Okta assignment.
-  string name = 1;
-  // status is the status to update the assignment to.
-  types.OktaAssignmentSpecV1.OktaAssignmentStatus status = 2;
-  // timeHasPassed is the amount of time that must have passed since the last transition
-  // in order to set the new transition.
-  google.protobuf.Duration time_has_passed = 3;
 }
 
 // DeleteOktaAssignmentRequest is the request for deleting an Okta assignment.

--- a/lib/auth/authclient/api.go
+++ b/lib/auth/authclient/api.go
@@ -22,7 +22,6 @@ import (
 	"context"
 	"io"
 	"iter"
-	"time"
 
 	"github.com/gravitational/trace"
 	"google.golang.org/grpc"
@@ -1111,10 +1110,6 @@ type OktaAccessPoint interface {
 	// UpdateOktaAssignment updates an existing Okta assignment resource.
 	UpdateOktaAssignment(context.Context, types.OktaAssignment) (types.OktaAssignment, error)
 
-	// UpdateOktaAssignmentStatus will update the status for an Okta assignment if the given time has passed
-	// since the last transition.
-	UpdateOktaAssignmentStatus(ctx context.Context, name, status string, timeHasPassed time.Duration) error
-
 	// DeleteOktaAssignment removes the specified Okta assignment resource.
 	DeleteOktaAssignment(ctx context.Context, name string) error
 
@@ -1989,12 +1984,6 @@ func (w *OktaWrapper) CreateOktaAssignment(ctx context.Context, assignment types
 // UpdateOktaAssignment updates an existing Okta assignment resource.
 func (w *OktaWrapper) UpdateOktaAssignment(ctx context.Context, assignment types.OktaAssignment) (types.OktaAssignment, error) {
 	return w.NoCache.UpdateOktaAssignment(ctx, assignment)
-}
-
-// UpdateOktaAssignmentStatus will update the status for an Okta assignment if the given time has passed
-// since the last transition.
-func (w *OktaWrapper) UpdateOktaAssignmentStatus(ctx context.Context, name, status string, timeHasPassed time.Duration) error {
-	return w.NoCache.UpdateOktaAssignmentStatus(ctx, name, status, timeHasPassed)
 }
 
 // DeleteOktaAssignment removes the specified Okta assignment resource.

--- a/lib/services/local/okta.go
+++ b/lib/services/local/okta.go
@@ -20,7 +20,6 @@ package local
 
 import (
 	"context"
-	"time"
 
 	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
@@ -175,30 +174,6 @@ func (o *OktaService) UpsertOktaAssignment(ctx context.Context, assignment types
 func (o *OktaService) ConditionalUpdateOktaAssignment(ctx context.Context, assignment types.OktaAssignment) (types.OktaAssignment, error) {
 	updated, err := o.assignmentSvc.ConditionalUpdateResource(ctx, assignment)
 	return updated, trace.Wrap(err)
-}
-
-// UpdateOktaAssignmentStatus will update the status for an Okta assignment if the given time has passed
-// since the last transition.
-func (o *OktaService) UpdateOktaAssignmentStatus(ctx context.Context, name, status string, timeHasPassed time.Duration) error {
-	_, err := o.assignmentSvc.UpdateAndSwapResource(ctx, name, func(currentAssignment types.OktaAssignment) error {
-		// Only update the status if the given duration has passed.
-		sinceLastTransition := o.clock.Since(currentAssignment.GetLastTransition())
-		if sinceLastTransition < timeHasPassed {
-			return trace.BadParameter("only %s has passed since last transition (want at least %s)", sinceLastTransition, timeHasPassed)
-		}
-
-		if err := currentAssignment.SetStatus(status); err != nil {
-			return trace.Wrap(err)
-		}
-		currentAssignment.SetLastTransition(o.clock.Now())
-
-		return nil
-	})
-	if err != nil {
-		return trace.Wrap(err)
-	}
-
-	return nil
 }
 
 // DeleteOktaAssignment removes the specified Okta assignment resource.

--- a/lib/services/local/okta_test.go
+++ b/lib/services/local/okta_test.go
@@ -397,25 +397,6 @@ func TestOktaAssignmentCRUD(t *testing.T) {
 		cmpopts.IgnoreFields(types.Metadata{}, "Revision"),
 	))
 
-	// Fail to update the status for an assignment due to a bad transition.
-	err = service.UpdateOktaAssignmentStatus(ctx, assignment1.GetName(), constants.OktaAssignmentStatusPending, 0)
-	require.ErrorIs(t, err, trace.BadParameter("invalid transition: processing -> pending"))
-
-	// Fail to update the status because not enough time has passed.
-	err = service.UpdateOktaAssignmentStatus(ctx, assignment1.GetName(), constants.OktaAssignmentStatusPending, time.Hour)
-	require.ErrorContains(t, err, "only 0s has passed since last transition")
-	require.True(t, trace.IsBadParameter(err))
-
-	// Successfully update the status for an assignment.
-	require.NoError(t, assignment1.SetStatus(constants.OktaAssignmentStatusSuccessful))
-	err = service.UpdateOktaAssignmentStatus(ctx, assignment1.GetName(), constants.OktaAssignmentStatusSuccessful, 0)
-	require.NoError(t, err)
-	assignment, err = service.GetOktaAssignment(ctx, assignment1.GetName())
-	require.NoError(t, err)
-	require.Empty(t, cmp.Diff(assignment1, assignment,
-		cmpopts.IgnoreFields(types.Metadata{}, "Revision"),
-	))
-
 	// Delete an assignment
 	err = service.DeleteOktaAssignment(ctx, assignment1.GetName())
 	require.NoError(t, err)

--- a/lib/services/okta.go
+++ b/lib/services/okta.go
@@ -20,7 +20,6 @@ package services
 
 import (
 	"context"
-	"time"
 
 	"github.com/gravitational/trace"
 
@@ -75,9 +74,6 @@ type OktaAssignments interface {
 	ConditionalUpdateOktaAssignment(context.Context, types.OktaAssignment) (types.OktaAssignment, error)
 	// UpsertOktaAssignment upsert an Okta assignment.
 	UpsertOktaAssignment(context.Context, types.OktaAssignment) (types.OktaAssignment, error)
-	// UpdateOktaAssignmentStatus will update the status for an Okta assignment if the given time has passed
-	// since the last transition.
-	UpdateOktaAssignmentStatus(ctx context.Context, name, status string, timeHasPassed time.Duration) error
 	// DeleteOktaAssignment removes the specified Okta assignment resource.
 	DeleteOktaAssignment(ctx context.Context, name string) error
 	// ConditionalDeleteOktaAssignment removes the specified Okta assignment resource, protected by optimistic locking.


### PR DESCRIPTION
Requires https://github.com/gravitational/teleport.e/pull/8785

No longer used after changes in https://github.com/gravitational/teleport.e/pull/8580.

## Backports

- https://github.com/gravitational/teleport/pull/69462