### PR TITLE
cli: Fix bash autocomplete output

### DIFF
--- a/lib/utils/cli.go
+++ b/lib/utils/cli.go
@@ -353,6 +353,9 @@ func InitCLIParser(appName, appHelp string) (app *kingpin.Application) {
 func InitHiddenCLIParser() (app *kingpin.Application) {
 	app = kingpin.New("", "")
 	app.UsageWriter(io.Discard)
+	// HiddenHelpWriter suppresses flags like --completion-script-bash that override UsageWriter before writing.
+	// This prevents an unnecessary autocomplete from outputting.
+	app.HiddenHelpWriter(io.Discard)
 	app.Terminate(func(i int) {})
 
 	return app


### PR DESCRIPTION
Fixes #57701

This fixes the `bash` autocomplate from outputting the below in addition to the proper parts like `_tsh_bash_autocomplete`. This prevents the error output of `complete: usage: complete [-abcdefgjksuv] [-pr]...` when running `eval "$(tsh --completion-script-bash)"` and `eval "$(tctl --completion-script-bash)"`.

```bash
__bash_autocomplete() {
    local cur prev opts base
    COMPREPLY=()
    cur="${COMP_WORDS[COMP_CWORD]}"
    opts=$( ${COMP_WORDS[0]} --completion-bash "${COMP_WORDS[@]:1:$COMP_CWORD}" )
    COMPREPLY=( $(compgen -W "${opts}" -- ${cur}) )
    return 0
}
complete -F __bash_autocomplete -o default 
```

## Manual Test Plan
### Test Environment
   Dev environment
### Test Cases
- [x] Confirm `usage: complete` message no longer occurring with `tsh` and `tctl`
- [x] Validate autocomplete working as expected for `tsh` 
- [x] Validate autocomplete working as expected for `tctl` 
