### PR TITLE
app: Reject duplicate effective public_addr in static config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,14 @@ change is backwards compatible apart from three cases:
 Rolling upgrades are supported: older-agent heartbeats are
 normalized so previously valid names still pass.
 
+Static configs with two apps that route to the same effective FQDN
+(either the same explicit `public_addr`, or one app's
+`<name>.<proxy_public_addr>` default colliding with another app's
+`public_addr`) are now rejected at startup. Previously Teleport
+accepted the config and routed non-deterministically. The check uses
+this agent's `proxy_service.public_addr`; apps served via another
+proxy's public address in a multi-proxy cluster are not checked.
+
 #### CLI --help Output Improvements
 
 In the past, Teleport CLI programs printed all subcommands, subcommands'

--- a/docs/pages/enroll-resources/application-access/protect-apps/connecting-apps.mdx
+++ b/docs/pages/enroll-resources/application-access/protect-apps/connecting-apps.mdx
@@ -222,6 +222,15 @@ is registered:
 `public_addr` (if set) must be a bare, lowercase DNS hostname. URI
 schemes, ports, IP addresses, and uppercase letters are rejected.
 
+In static config, two apps cannot share the same effective routing
+FQDN. The effective FQDN is `public_addr` if set, otherwise
+`<name>.<proxy_public_addr>`. When `proxy_service` is colocated in the
+same configuration, Teleport rejects collisions at startup, including
+the case where one app's `public_addr` matches another app's
+name-plus-proxy default. The check uses the colocated
+`proxy_service.public_addr`; apps that route via another proxy's
+public address in a multi-proxy cluster are not covered.
+
 After Teleport is running, users can access the app at `app-name.proxy_public_addr.com`
 e.g. `grafana.teleport.example.com`. You can also override `public_addr` e.g
 `grafana.acme.com` if you configure the appropriate DNS entry to point to the

--- a/docs/pages/enroll-resources/application-access/protect-apps/connecting-apps.mdx
+++ b/docs/pages/enroll-resources/application-access/protect-apps/connecting-apps.mdx
@@ -222,14 +222,10 @@ is registered:
 `public_addr` (if set) must be a bare, lowercase DNS hostname. URI
 schemes, ports, IP addresses, and uppercase letters are rejected.
 
-In static config, two apps cannot share the same effective routing
-FQDN. The effective FQDN is `public_addr` if set, otherwise
-`<name>.<proxy_public_addr>`. When `proxy_service` is colocated in the
-same configuration, Teleport rejects collisions at startup, including
-the case where one app's `public_addr` matches another app's
-name-plus-proxy default. The check uses the colocated
-`proxy_service.public_addr`; apps that route via another proxy's
-public address in a multi-proxy cluster are not covered.
+Two apps that route to the same FQDN create an ambiguous request, so
+Teleport does its best to reject such collisions. When `proxy_service`
+is colocated in the same static configuration, it rejects them at
+startup.
 
 After Teleport is running, users can access the app at `app-name.proxy_public_addr.com`
 e.g. `grafana.teleport.example.com`. You can also override `public_addr` e.g

--- a/lib/config/configuration.go
+++ b/lib/config/configuration.go
@@ -2269,9 +2269,7 @@ func applyAppsConfig(fc *FileConfig, cfg *servicecfg.Config) error {
 			}
 		}
 		// Map order is random; sort for a stable error message.
-		sortedFQDNs := slices.Collect(maps.Keys(appFQDNs))
-		slices.Sort(sortedFQDNs)
-		for _, fqdn := range sortedFQDNs {
+		for _, fqdn := range slices.Sorted(maps.Keys(appFQDNs)) {
 			if seenAppName, ok := seenFQDNs[fqdn]; ok {
 				return trace.BadParameter("apps %q and %q route to the same FQDN %q in static config", seenAppName, app.Name, fqdn)
 			}

--- a/lib/config/configuration.go
+++ b/lib/config/configuration.go
@@ -47,6 +47,7 @@ import (
 
 	"github.com/go-ldap/ldap/v3"
 	"github.com/gravitational/trace"
+	"golang.org/x/net/idna"
 	kyaml "k8s.io/apimachinery/pkg/util/yaml"
 
 	"github.com/gravitational/teleport"
@@ -2203,7 +2204,72 @@ func applyAppsConfig(fc *FileConfig, cfg *servicecfg.Config) error {
 		seenNames[app.Name] = struct{}{}
 	}
 
+	// Reject apps that share an effective routing FQDN; the dedupe key
+	// mirrors the runtime routing key, else duplicates route
+	// non-deterministically.
+	seenProxyHosts := map[string]struct{}{}
+	proxyHosts := make([]string, 0, len(cfg.Proxy.PublicAddrs))
+	for _, addr := range cfg.Proxy.PublicAddrs {
+		host, err := normalizeFQDN(addr.Host())
+		if err != nil {
+			return trace.Wrap(err, "proxy public_addr %q is an invalid IDN hostname", addr)
+		}
+		// Mirror proxyDNSNames(): skip IPs, fall back to cluster_name.
+		if net.ParseIP(host) != nil {
+			continue
+		}
+		if _, ok := seenProxyHosts[host]; ok {
+			continue
+		}
+		seenProxyHosts[host] = struct{}{}
+		proxyHosts = append(proxyHosts, host)
+	}
+	// No proxy public_addr: apps fall back to the cluster name.
+	if len(proxyHosts) == 0 && fc.Proxy.Enabled() && cfg.Auth.ClusterName != nil {
+		host, err := normalizeFQDN(cfg.Auth.ClusterName.GetClusterName())
+		if err != nil {
+			return trace.Wrap(err, "cluster_name %q is an invalid IDN hostname", cfg.Auth.ClusterName.GetClusterName())
+		}
+		if host != "" {
+			proxyHosts = append(proxyHosts, host)
+		}
+	}
+	// app.Name and app.PublicAddr are already normalized by
+	// CheckAndSetDefaults; only proxy public_addr and cluster_name need
+	// normalizeFQDN.
+	seenFQDNs := map[string]string{}
+	for _, app := range cfg.Apps.Apps {
+		// Dedupe per-app first: one app can contribute both public_addr
+		// and <name>.<proxy>, and that self-collision is not a conflict.
+		appFQDNs := map[string]struct{}{}
+		if app.PublicAddr != "" {
+			appFQDNs[app.PublicAddr] = struct{}{}
+		}
+		if app.PublicAddr == "" || app.UseAnyProxyPublicAddr {
+			for _, host := range proxyHosts {
+				appFQDNs[app.Name+"."+host] = struct{}{}
+			}
+		}
+		for fqdn := range appFQDNs {
+			if seenAppName, ok := seenFQDNs[fqdn]; ok {
+				return trace.BadParameter("apps %q and %q route to the same FQDN %q in static config", seenAppName, app.Name, fqdn)
+			}
+			seenFQDNs[fqdn] = app.Name
+		}
+	}
+
 	return nil
+}
+
+// normalizeFQDN returns host as ASCII, lowercase, with any trailing
+// dot stripped, so IDN, case, and trailing-dot variants collapse to
+// one dedupe key.
+func normalizeFQDN(host string) (string, error) {
+	asciiHost, err := idna.ToASCII(strings.TrimRight(host, "."))
+	if err != nil {
+		return "", trace.Wrap(err)
+	}
+	return strings.ToLower(asciiHost), nil
 }
 
 // applyMetricsConfig applies file configuration for the "metrics_service" section.

--- a/lib/config/configuration.go
+++ b/lib/config/configuration.go
@@ -2204,53 +2204,74 @@ func applyAppsConfig(fc *FileConfig, cfg *servicecfg.Config) error {
 		seenNames[app.Name] = struct{}{}
 	}
 
-	// Reject apps that share an effective routing FQDN; the dedupe key
-	// mirrors the runtime routing key, else duplicates route
-	// non-deterministically.
+	// Reject apps with the same effective routing FQDN; otherwise
+	// duplicates route non-deterministically. Mirror FindPublicAddr's
+	// fallback: use the proxy public_addr host as-is (IPs included),
+	// fall back to cluster_name when unset.
 	seenProxyHosts := map[string]struct{}{}
 	proxyHosts := make([]string, 0, len(cfg.Proxy.PublicAddrs))
-	for _, addr := range cfg.Proxy.PublicAddrs {
-		host, err := normalizeFQDN(addr.Host())
-		if err != nil {
-			return trace.Wrap(err, "proxy public_addr %q is an invalid IDN hostname", addr)
-		}
-		// Mirror proxyDNSNames(): skip IPs, fall back to cluster_name.
-		if net.ParseIP(host) != nil {
-			continue
-		}
-		if _, ok := seenProxyHosts[host]; ok {
-			continue
-		}
-		seenProxyHosts[host] = struct{}{}
-		proxyHosts = append(proxyHosts, host)
-	}
-	// No proxy public_addr: apps fall back to the cluster name.
-	if len(proxyHosts) == 0 && fc.Proxy.Enabled() && cfg.Auth.ClusterName != nil {
-		host, err := normalizeFQDN(cfg.Auth.ClusterName.GetClusterName())
-		if err != nil {
-			return trace.Wrap(err, "cluster_name %q is an invalid IDN hostname", cfg.Auth.ClusterName.GetClusterName())
-		}
-		if host != "" {
+	clusterNameFallback := ""
+	if fc.Proxy.Enabled() {
+		for _, addr := range cfg.Proxy.PublicAddrs {
+			host, err := normalizeFQDN(addr.Host())
+			if err != nil {
+				// A malformed proxy public_addr that no app
+				// depends on should not block app_service startup.
+				slog.WarnContext(context.Background(), "skipping malformed proxy public_addr in app FQDN dedupe",
+					"proxy_public_addr", addr.String(),
+					"error", err,
+				)
+				continue
+			}
+			if host == "" {
+				continue
+			}
+			if _, ok := seenProxyHosts[host]; ok {
+				continue
+			}
+			seenProxyHosts[host] = struct{}{}
 			proxyHosts = append(proxyHosts, host)
 		}
+		if cfg.Auth.ClusterName != nil {
+			host, err := normalizeFQDN(cfg.Auth.ClusterName.GetClusterName())
+			if err != nil {
+				// A malformed cluster_name that no app falls back
+				// to should not block app_service startup.
+				slog.WarnContext(context.Background(), "skipping malformed cluster_name in app FQDN dedupe",
+					"cluster_name", cfg.Auth.ClusterName.GetClusterName(),
+					"error", err,
+				)
+			} else {
+				clusterNameFallback = host
+			}
+		}
 	}
-	// app.Name and app.PublicAddr are already normalized by
-	// CheckAndSetDefaults; only proxy public_addr and cluster_name need
+	// CheckAndSetDefaults validates app.Name and app.PublicAddr as
+	// DNS-1123 forms, so they are already lowercase ASCII without a
+	// trailing dot; only proxy public_addr and cluster_name need
 	// normalizeFQDN.
 	seenFQDNs := map[string]string{}
 	for _, app := range cfg.Apps.Apps {
-		// Dedupe per-app first: one app can contribute both public_addr
-		// and <name>.<proxy>, and that self-collision is not a conflict.
+		// Dedupe per-app: one app contributing both public_addr and
+		// <name>.<proxy> is not a self-conflict.
 		appFQDNs := map[string]struct{}{}
 		if app.PublicAddr != "" {
 			appFQDNs[app.PublicAddr] = struct{}{}
 		}
 		if app.PublicAddr == "" || app.UseAnyProxyPublicAddr {
-			for _, host := range proxyHosts {
-				appFQDNs[app.Name+"."+host] = struct{}{}
+			switch {
+			case len(proxyHosts) > 0:
+				for _, host := range proxyHosts {
+					appFQDNs[utils.DefaultAppFQDN(app.Name, host, "")] = struct{}{}
+				}
+			case clusterNameFallback != "":
+				appFQDNs[utils.DefaultAppFQDN(app.Name, "", clusterNameFallback)] = struct{}{}
 			}
 		}
-		for fqdn := range appFQDNs {
+		// Map order is random; sort for a stable error message.
+		sortedFQDNs := slices.Collect(maps.Keys(appFQDNs))
+		slices.Sort(sortedFQDNs)
+		for _, fqdn := range sortedFQDNs {
 			if seenAppName, ok := seenFQDNs[fqdn]; ok {
 				return trace.BadParameter("apps %q and %q route to the same FQDN %q in static config", seenAppName, app.Name, fqdn)
 			}

--- a/lib/config/configuration_test.go
+++ b/lib/config/configuration_test.go
@@ -3058,13 +3058,33 @@ app_service:
       uri: "http://127.0.0.1:3000"
     - name: other
       uri: "http://127.0.0.1:3001"
-      public_addr: "app.cluster.example.com"
+      public_addr: "app.10.0.0.5"
 `,
-			name: "IP-only proxy public_addr falls back to cluster_name and detects collision",
+			name: "IP proxy public_addr collision rejected",
 			outErr: func(t require.TestingT, err error, _ ...any) {
 				require.ErrorContains(t, err, "route to the same FQDN")
-				require.ErrorContains(t, err, "app.cluster.example.com")
+				require.ErrorContains(t, err, "app.10.0.0.5")
 			},
+		},
+		{
+			inConfigString: `
+auth_service:
+  enabled: true
+  cluster_name: cluster.example.com
+proxy_service:
+  enabled: true
+  public_addr: 10.0.0.5
+app_service:
+  enabled: true
+  apps:
+    - name: app
+      uri: "http://127.0.0.1:3000"
+    - name: other
+      uri: "http://127.0.0.1:3001"
+      public_addr: "app.cluster.example.com"
+`,
+			name:   "IP proxy public_addr does not fall back to cluster_name",
+			outErr: require.NoError,
 		},
 		{
 			inConfigString: `
@@ -3085,10 +3105,83 @@ app_service:
       uri: "http://127.0.0.1:3001"
       public_addr: "app.teleport.test"
 `,
-			name: "mixed IP and hostname proxy public_addr uses only the hostname",
+			name: "collision on hostname among mixed IP and hostname proxy public_addr rejected",
 			outErr: func(t require.TestingT, err error, _ ...any) {
 				require.ErrorContains(t, err, "route to the same FQDN")
 				require.ErrorContains(t, err, "app.teleport.test")
+			},
+		},
+		{
+			inConfigString: `
+auth_service:
+  enabled: true
+  cluster_name: cluster.example.com
+proxy_service:
+  enabled: true
+  public_addr:
+    - 10.0.0.5
+    - teleport.test
+app_service:
+  enabled: true
+  apps:
+    - name: app
+      uri: "http://127.0.0.1:3000"
+    - name: other
+      uri: "http://127.0.0.1:3001"
+      public_addr: "app.10.0.0.5"
+`,
+			name: "collision on IP among mixed IP and hostname proxy public_addr rejected",
+			outErr: func(t require.TestingT, err error, _ ...any) {
+				require.ErrorContains(t, err, "route to the same FQDN")
+				require.ErrorContains(t, err, "app.10.0.0.5")
+			},
+		},
+		{
+			inConfigString: `
+proxy_service:
+  enabled: false
+  public_addr: teleport.test
+app_service:
+  enabled: true
+  apps:
+    - name: app
+      uri: "http://127.0.0.1:3000"
+    - name: other
+      uri: "http://127.0.0.1:3001"
+      public_addr: "app.teleport.test"
+`,
+			name:   "disabled local proxy_service public_addr is ignored",
+			outErr: require.NoError,
+		},
+		{
+			inConfigString: `
+proxy_service:
+  enabled: true
+  public_addr:
+    - proxy1.test
+    - proxy2.test
+app_service:
+  enabled: true
+  apps:
+    - name: app1
+      uri: "http://127.0.0.1:3000"
+      public_addr: "beta.proxy1.test"
+    - name: app2
+      uri: "http://127.0.0.1:3001"
+      public_addr: "beta.proxy2.test"
+    - name: beta
+      uri: "http://127.0.0.1:3002"
+`,
+			name: "multi-proxy collision reports the lower-sorted FQDN deterministically",
+			outErr: func(t require.TestingT, err error, _ ...any) {
+				// beta resolves to both beta.proxy1.test and
+				// beta.proxy2.test; both collide. The error must
+				// reference the lower-sorted one so the message is
+				// stable across runs (Go map iteration is random).
+				require.ErrorContains(t, err, "route to the same FQDN")
+				require.ErrorContains(t, err, "beta.proxy1.test")
+				require.ErrorContains(t, err, "app1")
+				require.ErrorContains(t, err, "beta")
 			},
 		},
 	}

--- a/lib/config/configuration_test.go
+++ b/lib/config/configuration_test.go
@@ -2791,6 +2791,306 @@ app_service:
 				require.ErrorContains(t, err, "duplicate application name")
 			},
 		},
+		{
+			inConfigString: `
+proxy_service:
+  enabled: true
+  public_addr: teleport.test
+app_service:
+  enabled: true
+  apps:
+    - name: app1
+      uri: "http://127.0.0.1:3001"
+      public_addr: "app.teleport.test"
+    - name: app2
+      uri: "http://127.0.0.1:3002"
+      public_addr: "app.teleport.test"
+`,
+			name: "duplicate explicit public_addr rejected",
+			outErr: func(t require.TestingT, err error, _ ...any) {
+				require.ErrorContains(t, err, "route to the same FQDN")
+				require.ErrorContains(t, err, "app1")
+				require.ErrorContains(t, err, "app2")
+				require.ErrorContains(t, err, "app.teleport.test")
+			},
+		},
+		{
+			inConfigString: `
+proxy_service:
+  enabled: true
+  public_addr: teleport.test
+app_service:
+  enabled: true
+  apps:
+    - name: app
+      uri: "http://127.0.0.1:3000"
+    - name: app1
+      uri: "http://127.0.0.1:3001"
+      public_addr: "app.teleport.test"
+`,
+			name: "name plus proxy collision rejected",
+			outErr: func(t require.TestingT, err error, _ ...any) {
+				require.ErrorContains(t, err, "route to the same FQDN")
+				require.ErrorContains(t, err, "app.teleport.test")
+			},
+		},
+		{
+			inConfigString: `
+app_service:
+  enabled: true
+  apps:
+    - name: app
+      uri: "http://127.0.0.1:3000"
+    - name: app1
+      uri: "http://127.0.0.1:3001"
+      public_addr: "app.teleport.test"
+`,
+			name:   "name plus proxy collision undetectable without proxy_service",
+			outErr: require.NoError,
+		},
+		{
+			inConfigString: `
+proxy_service:
+  enabled: true
+  public_addr:
+    - teleport.test
+    - alt.teleport.test
+app_service:
+  enabled: true
+  apps:
+    - name: app
+      uri: "http://127.0.0.1:3000"
+    - name: other
+      uri: "http://127.0.0.1:3001"
+      public_addr: "app.alt.teleport.test"
+`,
+			name: "collision on one of multiple proxy public_addrs rejected",
+			outErr: func(t require.TestingT, err error, _ ...any) {
+				require.ErrorContains(t, err, "route to the same FQDN")
+				require.ErrorContains(t, err, "app.alt.teleport.test")
+			},
+		},
+		{
+			inConfigString: `
+proxy_service:
+  enabled: true
+  public_addr:
+    - teleport.test
+    - alt.teleport.test
+app_service:
+  enabled: true
+  apps:
+    - name: app
+      uri: "http://127.0.0.1:3000"
+    - name: other
+      uri: "http://127.0.0.1:3001"
+`,
+			name:   "multiple proxy public_addrs without collision accepted",
+			outErr: require.NoError,
+		},
+		{
+			inConfigString: `
+proxy_service:
+  enabled: true
+  public_addr: teleport.test
+app_service:
+  enabled: true
+  apps:
+    - name: app
+      uri: "http://127.0.0.1:3000"
+    - name: other
+      uri: "http://127.0.0.1:3001"
+      public_addr: "app.teleport.test"
+      use_any_proxy_public_addr: true
+`,
+			name: "use_any_proxy_public_addr explicit public_addr collision rejected",
+			outErr: func(t require.TestingT, err error, _ ...any) {
+				require.ErrorContains(t, err, "route to the same FQDN")
+				require.ErrorContains(t, err, "app.teleport.test")
+			},
+		},
+		{
+			inConfigString: `
+proxy_service:
+  enabled: true
+  public_addr: teleport.test
+app_service:
+  enabled: true
+  apps:
+    - name: other
+      uri: "http://127.0.0.1:3000"
+    - name: app
+      uri: "http://127.0.0.1:3001"
+      public_addr: "somewhere.example.com"
+      use_any_proxy_public_addr: true
+`,
+			name:   "use_any_proxy_public_addr with non-colliding explicit public_addr accepted",
+			outErr: require.NoError,
+		},
+		{
+			inConfigString: `
+proxy_service:
+  enabled: true
+  public_addr: teleport.test
+app_service:
+  enabled: true
+  apps:
+    - name: app
+      uri: "http://127.0.0.1:3000"
+    - name: app1
+      uri: "http://127.0.0.1:3001"
+      public_addr: "app1.example.com"
+    - name: app2
+      uri: "http://127.0.0.1:3002"
+      public_addr: "app2.example.com"
+`,
+			name:   "distinct effective FQDNs accepted",
+			outErr: require.NoError,
+		},
+		{
+			inConfigString: `
+auth_service:
+  enabled: true
+  cluster_name: cluster.example.com
+proxy_service:
+  enabled: true
+app_service:
+  enabled: true
+  apps:
+    - name: app
+      uri: "http://127.0.0.1:3000"
+    - name: app1
+      uri: "http://127.0.0.1:3001"
+      public_addr: "app.cluster.example.com"
+`,
+			name: "cluster_name fallback collision rejected",
+			outErr: func(t require.TestingT, err error, _ ...any) {
+				require.ErrorContains(t, err, "route to the same FQDN")
+				require.ErrorContains(t, err, "app.cluster.example.com")
+			},
+		},
+		{
+			inConfigString: `
+proxy_service:
+  enabled: true
+  public_addr: Teleport.Test
+app_service:
+  enabled: true
+  apps:
+    - name: app
+      uri: "http://127.0.0.1:3000"
+    - name: app1
+      uri: "http://127.0.0.1:3001"
+      public_addr: "app.teleport.test"
+`,
+			name: "case insensitive proxy public_addr collision rejected",
+			outErr: func(t require.TestingT, err error, _ ...any) {
+				require.ErrorContains(t, err, "route to the same FQDN")
+				require.ErrorContains(t, err, "app.teleport.test")
+			},
+		},
+		{
+			inConfigString: `
+proxy_service:
+  enabled: true
+  public_addr: teleport.test.
+app_service:
+  enabled: true
+  apps:
+    - name: app
+      uri: "http://127.0.0.1:3000"
+    - name: app1
+      uri: "http://127.0.0.1:3001"
+      public_addr: "app.teleport.test"
+`,
+			name: "trailing dot proxy public_addr collision rejected",
+			outErr: func(t require.TestingT, err error, _ ...any) {
+				require.ErrorContains(t, err, "route to the same FQDN")
+				require.ErrorContains(t, err, "app.teleport.test")
+			},
+		},
+		{
+			inConfigString: `
+proxy_service:
+  enabled: true
+  public_addr:
+    - teleport.test:443
+    - teleport.test:3080
+app_service:
+  enabled: true
+  apps:
+    - name: app
+      uri: "http://127.0.0.1:3000"
+    - name: other
+      uri: "http://127.0.0.1:3001"
+`,
+			name:   "duplicate proxy public_addr hostnames do not self collide",
+			outErr: require.NoError,
+		},
+		{
+			inConfigString: `
+proxy_service:
+  enabled: true
+  public_addr: teleport.test
+app_service:
+  enabled: true
+  apps:
+    - name: app
+      uri: "http://127.0.0.1:3000"
+      public_addr: "app.teleport.test"
+      use_any_proxy_public_addr: true
+`,
+			name:   "app whose public_addr equals its name plus proxy form does not self collide",
+			outErr: require.NoError,
+		},
+		{
+			inConfigString: `
+auth_service:
+  enabled: true
+  cluster_name: cluster.example.com
+proxy_service:
+  enabled: true
+  public_addr: 10.0.0.5
+app_service:
+  enabled: true
+  apps:
+    - name: app
+      uri: "http://127.0.0.1:3000"
+    - name: other
+      uri: "http://127.0.0.1:3001"
+      public_addr: "app.cluster.example.com"
+`,
+			name: "IP-only proxy public_addr falls back to cluster_name and detects collision",
+			outErr: func(t require.TestingT, err error, _ ...any) {
+				require.ErrorContains(t, err, "route to the same FQDN")
+				require.ErrorContains(t, err, "app.cluster.example.com")
+			},
+		},
+		{
+			inConfigString: `
+auth_service:
+  enabled: true
+  cluster_name: cluster.example.com
+proxy_service:
+  enabled: true
+  public_addr:
+    - 10.0.0.5
+    - teleport.test
+app_service:
+  enabled: true
+  apps:
+    - name: app
+      uri: "http://127.0.0.1:3000"
+    - name: other
+      uri: "http://127.0.0.1:3001"
+      public_addr: "app.teleport.test"
+`,
+			name: "mixed IP and hostname proxy public_addr uses only the hostname",
+			outErr: func(t require.TestingT, err error, _ ...any) {
+				require.ErrorContains(t, err, "route to the same FQDN")
+				require.ErrorContains(t, err, "app.teleport.test")
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/lib/srv/app/watcher.go
+++ b/lib/srv/app/watcher.go
@@ -161,7 +161,7 @@ func FindPublicAddr(ctx context.Context, client FindPublicAddrClient, appPublicA
 		if err != nil {
 			return "", trace.Wrap(err)
 		}
-		return utils.DefaultAppPublicAddr(appName, addr.Host()), nil
+		return utils.DefaultAppFQDN(appName, addr.Host(), ""), nil
 	}
 
 	// Fall back to cluster name.
@@ -169,7 +169,7 @@ func FindPublicAddr(ctx context.Context, client FindPublicAddrClient, appPublicA
 	if err != nil {
 		return "", trace.Wrap(err)
 	}
-	return utils.DefaultAppPublicAddr(appName, cn.GetClusterName()), nil
+	return utils.DefaultAppFQDN(appName, "", cn.GetClusterName()), nil
 }
 
 func (s *Server) getResources() map[string]types.Application {

--- a/lib/utils/app.go
+++ b/lib/utils/app.go
@@ -17,6 +17,7 @@
 package utils
 
 import (
+	"cmp"
 	"fmt"
 	"net"
 	"strings"
@@ -48,4 +49,12 @@ func DefaultAppPublicAddr(appName, localProxyDNSName string) string {
 		localProxyDNSName = host
 	}
 	return fmt.Sprintf("%s.%s", appName, strings.ToLower(localProxyDNSName))
+}
+
+// DefaultAppFQDN returns the default routing FQDN for an app.
+// proxyPublicAddrHost takes precedence; clusterName is the fallback
+// when it is empty. An IP-valued proxy public_addr is used as-is,
+// not replaced by clusterName.
+func DefaultAppFQDN(appName, proxyPublicAddrHost, clusterName string) string {
+	return DefaultAppPublicAddr(appName, cmp.Or(proxyPublicAddrHost, clusterName))
 }

--- a/lib/utils/app_test.go
+++ b/lib/utils/app_test.go
@@ -1,0 +1,68 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package utils
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestDefaultAppFQDN(t *testing.T) {
+	tests := []struct {
+		name                string
+		appName             string
+		proxyPublicAddrHost string
+		clusterName         string
+		want                string
+	}{
+		{
+			name:                "proxy host used directly",
+			appName:             "app",
+			proxyPublicAddrHost: "teleport.test",
+			clusterName:         "cluster.example.com",
+			want:                "app.teleport.test",
+		},
+		{
+			name:                "proxy host wins over cluster name",
+			appName:             "app",
+			proxyPublicAddrHost: "10.0.0.5",
+			clusterName:         "cluster.example.com",
+			want:                "app.10.0.0.5",
+		},
+		{
+			name:                "cluster name used when proxy host is empty",
+			appName:             "app",
+			proxyPublicAddrHost: "",
+			clusterName:         "cluster.example.com",
+			want:                "app.cluster.example.com",
+		},
+		{
+			name:                "host is lowercased and port stripped",
+			appName:             "app",
+			proxyPublicAddrHost: "Teleport.Test:443",
+			clusterName:         "",
+			want:                "app.teleport.test",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := DefaultAppFQDN(tt.appName, tt.proxyPublicAddrHost, tt.clusterName)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}


### PR DESCRIPTION
Extend the existing duplicate-name check in `applyAppsConfig` to also reject static apps that resolve to the same effective routing FQDN. Fail fast at startup rather than dispatch non-deterministically via `servers[rand.N(len(servers))]` in `lib/web/app/match.go`.

Compute the effective FQDN per app as:

- `public_addr`, normalized through `idna.ToASCII` + trim trailing dot + lowercase to match `services.ValidateApp`'s proxy-collision compare,
- `<name>.<proxy_public_addr>` (one entry per proxy public addr) when `public_addr` is empty, or when `use_any_proxy_public_addr` is true (matching `utils.AssembleAppFQDN`),
- `<name>.<cluster_name>` as a fallback when `proxy_service` is enabled but `proxy_public_addr` is unset (matching `proxyDNSName` in `lib/web/apps.go`).

Limit the check to static `app_service.apps`. Skip dynamic apps (`tctl create`, `app_service.resources` selectors, Discovery, Roles Anywhere syncer): the effective FQDN depends on proxy config and cluster name, multi-auth HA admits concurrent colliding writes, and editing a proxy `public_addr` retroactively shifts every dynamic app's `<name>.<proxy>` form. Defer best-effort detection to a follow-up RFD.

Do not backport: older configs that previously routed non-deterministically would now fail to start.

Changelog: Reject duplicate effective public_addr in static app_service config.

## Manual Test Plan

### Test Environment

macOS, single-node Teleport (auth + proxy + app service), enterprise
build from the PR branch.

### Test Cases

#### Test 1: duplicate explicit public_addr rejected

```yaml
proxy_service:
  enabled: true
  public_addr: teleport.test
app_service:
  enabled: true
  apps:
    - name: app1
      uri: http://localhost:3001
      public_addr: app.teleport.test
    - name: app2
      uri: http://localhost:3002
      public_addr: app.teleport.test
```

- [x] Teleport refuses to start with an error containing
  `route to the same FQDN` and both app names.

#### Test 2: name+proxy collision rejected

```yaml
proxy_service:
  enabled: true
  public_addr: teleport.test
app_service:
  enabled: true
  apps:
    - name: app
      uri: http://localhost:3000
    - name: other
      uri: http://localhost:3001
      public_addr: app.teleport.test
```

- [x] Teleport refuses to start with an error referencing
  `app.teleport.test`.

#### Test 3: cluster_name fallback collision rejected

```yaml
auth_service:
  enabled: true
  cluster_name: cluster.example.com
proxy_service:
  enabled: true
app_service:
  enabled: true
  apps:
    - name: app
      uri: http://localhost:3000
    - name: other
      uri: http://localhost:3001
      public_addr: app.cluster.example.com
```

- [x] Teleport refuses to start with an error referencing
  `app.cluster.example.com`.

#### Test 4: distinct FQDNs accepted

```yaml
proxy_service:
  enabled: true
  public_addr: teleport.test
app_service:
  enabled: true
  apps:
    - name: app1
      uri: http://localhost:3001
      public_addr: app1.example.com
    - name: app2
      uri: http://localhost:3002
      public_addr: app2.example.com
```

- [x] Teleport starts and both apps appear in `tsh apps ls`.

#### Test 5: Regression baseline (parent branch, without this fix)

Build from the parent branch `julia/app-validation` (PR #65728) and
repeat Test 1. The parent already rejects duplicate `name` but not
duplicate `public_addr`.

- [x] Teleport starts without an error referencing
  `route to the same FQDN`.
- [x] `tctl get app_servers` lists both apps stored with the same `public_addr`,
  confirming the routing-ambiguity bug this PR fixes.


