### PR TITLE
Write AWS config files with stricter permissions

### DIFF
--- a/lib/aws/awsconfigfile/awsconfigfile.go
+++ b/lib/aws/awsconfigfile/awsconfigfile.go
@@ -17,6 +17,7 @@
 package awsconfigfile
 
 import (
+	"bytes"
 	"io"
 	"os"
 	"path/filepath"
@@ -167,12 +168,7 @@ func writeSSOConfig(configFilePath string, profiles []SSOProfile, sessions []SSO
 		return trace.Wrap(err)
 	}
 
-	// Create the directory if it does not exist.
-	if err := os.MkdirAll(filepath.Dir(configFilePath), 0o700); err != nil {
-		return trace.Wrap(err)
-	}
-
-	return trace.Wrap(iniFile.SaveTo(configFilePath))
+	return trace.Wrap(writeINIFile(iniFile, configFilePath))
 }
 
 func getOrCreateManagedSection(iniFile *ini.File, sectionName, expectedComment string) (*ini.Section, error) {
@@ -209,7 +205,7 @@ func UpsertProfileCredentialProcess(configFilePath, profileName, credentialProce
 func addCredentialProcessToSection(configFilePath, sectionName, credentialProcessCommand string) error {
 	iniFile, err := ini.LoadSources(ini.LoadOptions{
 		AllowNestedValues: true, // Allow AWS-like nested values. Docs: http://docs.aws.amazon.com/cli/latest/topic/config-vars.html#nested-values
-		Loose:             true, // Allow non-existing files. ini.SaveTo will create the file if it does not exist.
+		Loose:             true, // Allow non-existing files. writeConfigFile will create the file if it does not exist.
 	}, configFilePath)
 	if err != nil {
 		return trace.Wrap(err)
@@ -242,12 +238,28 @@ func addCredentialProcessToSection(configFilePath, sectionName, credentialProces
 		return trace.BadParameter("%s: section %q contains other keys, remove the section and try again", configFilePath, sectionName)
 	}
 
-	// Create the directory if it does not exist, otherwise ini.SaveTo will fail.
-	if err := os.MkdirAll(filepath.Dir(configFilePath), 0o700); err != nil {
+	return trace.Wrap(writeINIFile(iniFile, configFilePath))
+}
+
+// writeINIFile writes the given ini file path with u+rw permissions.
+func writeINIFile(iniFile *ini.File, iniFilePath string) error {
+	// Serialize content first; no point in creating output directories for
+	// a file that will never exist
+	var content bytes.Buffer
+	if _, err := iniFile.WriteTo(&content); err != nil {
 		return trace.Wrap(err)
 	}
 
-	return trace.Wrap(iniFile.SaveTo(configFilePath))
+	// Create the destination directory if it does not exist, os.WriteFile will
+	// fail if the target directory doesn't exist
+	if err := os.MkdirAll(filepath.Dir(iniFilePath), 0o700); err != nil {
+		return trace.Wrap(err)
+	}
+
+	// We're avoiding [*ini.File.SaveTo] here because SaveTo creates the file as
+	// globally read+write (i.e. with FileMode 0o666), and we want tighter
+	// permissions (user-only rw) on it.
+	return trace.Wrap(os.WriteFile(iniFilePath, content.Bytes(), 0o600))
 }
 
 // RemoveTeleportManagedProfile removes the credential_process key on sections that have a specific section comment.
@@ -285,7 +297,7 @@ func RemoveTeleportManagedProfile(configFilePath, profile string) error {
 		return nil
 	}
 
-	return trace.Wrap(iniFile.SaveTo(configFilePath))
+	return trace.Wrap(writeINIFile(iniFile, configFilePath))
 }
 
 // RemoveAllTeleportManagedProfiles removes all the profiles managed by Teleport.
@@ -316,5 +328,5 @@ func RemoveAllTeleportManagedProfiles(configFilePath string) error {
 		return nil
 	}
 
-	return trace.Wrap(iniFile.SaveTo(configFilePath))
+	return trace.Wrap(writeINIFile(iniFile, configFilePath))
 }

--- a/lib/aws/awsconfigfile/awsconfigfile_test.go
+++ b/lib/aws/awsconfigfile/awsconfigfile_test.go
@@ -246,9 +246,10 @@ credential_process = credential_process
 
 		dir := filepath.Join(tmpDir, "dir")
 		require.DirExists(t, dir)
-		info, err := os.Stat(dir)
-		require.NoError(t, err)
-		require.Equal(t, os.FileMode(0700), info.Mode().Perm())
+		requireUnixPermissions(t, dir, 0o700)
+
+		require.FileExists(t, configFilePath)
+		requireUnixPermissions(t, configFilePath, 0o600)
 
 		bs, err := os.ReadFile(configFilePath)
 		require.NoError(t, err)
@@ -477,6 +478,13 @@ func TestSSORemovalGuard(t *testing.T) {
 	require.Contains(t, s, "[profile sso-profile]", "SSO profile should persist after logout")
 }
 
+func requireUnixPermissions(t *testing.T, target string, expected os.FileMode) {
+	t.Helper()
+	info, err := os.Stat(target)
+	require.NoError(t, err)
+	require.Equal(t, expected, info.Mode().Perm())
+}
+
 func TestUpdateRemoveCycle(t *testing.T) {
 	initialContents := "[profile baz]\nregion = us-east-1\n\n[default]\nregion = us-west-2\n"
 	configFilePath := filepath.Join(t.TempDir(), "config")
@@ -515,9 +523,7 @@ func TestSSOConfig(t *testing.T) {
 
 		dir := filepath.Join(tmpDir, "dir")
 		require.DirExists(t, dir)
-		info, err := os.Stat(dir)
-		require.NoError(t, err)
-		require.Equal(t, os.FileMode(0700), info.Mode().Perm())
+		requireUnixPermissions(t, dir, 0o700)
 
 		bs, err := os.ReadFile(configFilePath)
 		require.NoError(t, err)


### PR DESCRIPTION
Prior to this patch `tctl` would create new AWS config files with filemode `0666`
(globally readable). In most cases this is not a security issue as Teleport would
create the file's destination directory with `0700` (only readable by the owner).

This becomes an issue in the rare case where the destination directory already
exists AND has weak permissions; in this case the AWS config files may be read
by other users on the owner's machine.

This change bypasses the ini file library's `SaveTo` method and writes the file
with known permissions.

## Manual Test Plan

### Test Environment
- Teleport Staging cluster with Identity Center integration 
- Teleport user with Identity Center account assignments
- Target user is logged into Teleport via `tsh login`

### Test Cases
- [x] Fresh install
  - [x] Set the `AWS_CONFIG_FILE` environment variable to point to filesystem location that would be valid to write to, but does not exist 
  - [x] Run `tsh aws-profile`
  - [x] Verify that an AWS config file has been created at the location specified in `AWS_CONFIG_FILE`
  - [x] Verify that all new parent directories created have permissions `0o700`
  - [x] Verify that the created file itself only has owner read & write permissions (`0o600`)
  - [x] Verify that the file content matches the expected content as described by #63032

- [x] New file
  - [x] Create a new local directory with fully open permissions (`0o777`)
  - [x] Set the `AWS_CONFIG_FILE` environment variable to point to a file under that directory
  - [x] Run `tsh aws-profile`
  - [x] Verify that an AWS config file has been created at the location specified in `AWS_CONFIG_FILE`
  - [x] Verify that the parent directory's file permissions have not changed
  - [x] Verify that the created file only has owner read & write permissions (`0o600`)
  - [x] Verify that the file content matches the expected content as described by #63032

- [x]  Existing file
  - [x] Create a new local directory with fully open permissions (`0o777`)
  - [x] In that directory, create a file with fully open permissions (`0o666`)
  - [x] Set the `AWS_CONFIG_FILE` environment variable to point to a the target file
  - [x] Run `tsh aws-profile`
  - [x] Verify that Teleport has replaced the content of the target file
  - [x] Verify that the parent directory's file permissions have not changed (`0o777`)
  - [x] Verify that the created file only has owner read & write permissions (`0o666`)
  - [x] Verify that the file content matches the expected content as described by #63032

---
Changelog: Tightened default permission when creating AWS configuration files
