### PR TITLE
SCIM: Add rate limit proto settings

### DIFF
--- a/api/proto/teleport/legacy/types/types.proto
+++ b/api/proto/teleport/legacy/types/types.proto
@@ -7865,6 +7865,25 @@ message PluginSCIMSettings {
   // by the SCIM plugin. It enables matching a SAML/OIDC external user
   // with a SCIM-persisted user, allowing the ephemeral user entry to be updated to SCIM user.
   ConnectorInfo connector_info = 3 [(gogoproto.jsontag) = "connector_info"];
+
+  // RateLimit configures scim integration rate limiting.
+  PluginSCIMRateLimit rate_limit = 4 [(gogoproto.jsontag) = "rate_limit,omitempty"];
+}
+
+// PluginSCIMRateLimit configures per request rate limiting for a SCIM plugin.
+// If unset, server defaults are applied.
+message PluginSCIMRateLimit {
+  option (gogoproto.equal) = true;
+  // Average is the maximum average number of requests per period.
+  int64 average = 1 [(gogoproto.jsontag) = "average"];
+  // Burst is the maximum number of requests allowed in a burst above the average.
+  int64 burst = 2 [(gogoproto.jsontag) = "burst"];
+  // PeriodSeconds is the rate limiting window duration in seconds.
+  int64 period_seconds = 3 [(gogoproto.jsontag) = "period_seconds"];
+  // MaxConcurrentMutations limits the number of simultaneous mutating operations
+  // (Create, Update, Delete, Patch) allowed for this integration. Zero means no limit.
+  // Note that List and Read operations are not affected by this limit.
+  int64 max_concurrent_operations = 5 [(gogoproto.jsontag) = "max_concurrent_operations"];
 }
 
 // PluginDatadogAccessSettings defines the settings for a Datadog Incident Management plugin


### PR DESCRIPTION
### What


Add SCIM plugin settings for server rate limiting. 

Related: https://github.com/gravitational/teleport/issues/61932

### Why

Teleport SCIM Server needs separate rate limiting configuration that can be aligned depending on the SCIM clients behavior  and the cluster scale. 

##### Why not use the `WithLimiterHandlerFunc` or `WithHighLimiterHandlerFunc` ? 

- This limits are hardcoded and also works per IP as token where in SCIM flow we need to limit all  API calls no matters of the IP.
-  we want to limit number of ongoing request where if limit is reach the retry-after mechanism will be used to notify the client. 
- We want to make it fully configurable 





