### PR TITLE
cache: remove singletonListAdapter helper from cache test

### DIFF
--- a/lib/cache/auto_update_test.go
+++ b/lib/cache/auto_update_test.go
@@ -17,10 +17,8 @@
 package cache
 
 import (
-	"context"
 	"testing"
-
-	"github.com/gravitational/trace"
+	"testing/synctest"
 
 	autoupdatev1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/autoupdate/v1"
 )
@@ -28,103 +26,59 @@ import (
 // TestAutoUpdateConfig tests that CRUD operations on AutoUpdateConfig resources are
 // replicated from the backend to the cache.
 func TestAutoUpdateConfig(t *testing.T) {
-	t.Parallel()
+	synctest.Test(t, func(t *testing.T) {
+		p := newTestPack(t, ForAuth)
+		t.Cleanup(p.Close)
 
-	p := newTestPack(t, ForAuth)
-	t.Cleanup(p.Close)
-
-	testResources153(t, p, testFuncs[*autoupdatev1.AutoUpdateConfig]{
-		newResource: func(name string) (*autoupdatev1.AutoUpdateConfig, error) {
-			return newAutoUpdateConfig(t), nil
-		},
-		create: func(ctx context.Context, item *autoupdatev1.AutoUpdateConfig) error {
-			_, err := p.autoUpdateService.UpsertAutoUpdateConfig(ctx, item)
-			return trace.Wrap(err)
-		},
-		list: getAllAdapter(func(ctx context.Context) ([]*autoupdatev1.AutoUpdateConfig, error) {
-			item, err := p.autoUpdateService.GetAutoUpdateConfig(ctx)
-			if trace.IsNotFound(err) {
-				return []*autoupdatev1.AutoUpdateConfig{}, nil
-			}
-			return []*autoupdatev1.AutoUpdateConfig{item}, trace.Wrap(err)
-		}),
-		cacheList: getAllAdapter(func(ctx context.Context) ([]*autoupdatev1.AutoUpdateConfig, error) {
-			item, err := p.cache.GetAutoUpdateConfig(ctx)
-			if trace.IsNotFound(err) {
-				return []*autoupdatev1.AutoUpdateConfig{}, nil
-			}
-			return []*autoupdatev1.AutoUpdateConfig{item}, trace.Wrap(err)
-		}),
-		deleteAll: func(ctx context.Context) error {
-			return trace.Wrap(p.autoUpdateService.DeleteAutoUpdateConfig(ctx))
-		},
-	}, withSkipPaginationTest())
+		testSingleton153(t, p, testSingletonFuncs153[*autoupdatev1.AutoUpdateConfig]{
+			newResource: func() *autoupdatev1.AutoUpdateConfig {
+				return newAutoUpdateConfig(t)
+			},
+			create:   p.autoUpdateService.CreateAutoUpdateConfig,
+			update:   p.autoUpdateService.UpdateAutoUpdateConfig,
+			get:      p.autoUpdateService.GetAutoUpdateConfig,
+			cacheGet: p.cache.GetAutoUpdateConfig,
+			delete:   p.autoUpdateService.DeleteAutoUpdateConfig,
+		})
+	})
 }
 
 // TestAutoUpdateVersion tests that CRUD operations on AutoUpdateVersion resource are
 // replicated from the backend to the cache.
 func TestAutoUpdateVersion(t *testing.T) {
-	t.Parallel()
+	synctest.Test(t, func(t *testing.T) {
+		p := newTestPack(t, ForAuth)
+		t.Cleanup(p.Close)
 
-	p := newTestPack(t, ForAuth)
-	t.Cleanup(p.Close)
-
-	testResources153(t, p, testFuncs[*autoupdatev1.AutoUpdateVersion]{
-		newResource: func(name string) (*autoupdatev1.AutoUpdateVersion, error) {
-			return newAutoUpdateVersion(t), nil
-		},
-		create: func(ctx context.Context, item *autoupdatev1.AutoUpdateVersion) error {
-			_, err := p.autoUpdateService.UpsertAutoUpdateVersion(ctx, item)
-			return trace.Wrap(err)
-		},
-		list: getAllAdapter(func(ctx context.Context) ([]*autoupdatev1.AutoUpdateVersion, error) {
-			item, err := p.autoUpdateService.GetAutoUpdateVersion(ctx)
-			if trace.IsNotFound(err) {
-				return []*autoupdatev1.AutoUpdateVersion{}, nil
-			}
-			return []*autoupdatev1.AutoUpdateVersion{item}, trace.Wrap(err)
-		}),
-		cacheList: getAllAdapter(func(ctx context.Context) ([]*autoupdatev1.AutoUpdateVersion, error) {
-			item, err := p.cache.GetAutoUpdateVersion(ctx)
-			if trace.IsNotFound(err) {
-				return []*autoupdatev1.AutoUpdateVersion{}, nil
-			}
-			return []*autoupdatev1.AutoUpdateVersion{item}, trace.Wrap(err)
-		}),
-		deleteAll: p.autoUpdateService.DeleteAutoUpdateVersion,
-	}, withSkipPaginationTest())
+		testSingleton153(t, p, testSingletonFuncs153[*autoupdatev1.AutoUpdateVersion]{
+			newResource: func() *autoupdatev1.AutoUpdateVersion {
+				return newAutoUpdateVersion(t)
+			},
+			create:   p.autoUpdateService.CreateAutoUpdateVersion,
+			update:   p.autoUpdateService.UpdateAutoUpdateVersion,
+			get:      p.autoUpdateService.GetAutoUpdateVersion,
+			cacheGet: p.cache.GetAutoUpdateVersion,
+			delete:   p.autoUpdateService.DeleteAutoUpdateVersion,
+		})
+	})
 }
 
 // TestAutoUpdateAgentRollout tests that CRUD operations on AutoUpdateAgentRollout resource are
 // replicated from the backend to the cache.
 func TestAutoUpdateAgentRollout(t *testing.T) {
-	t.Parallel()
+	synctest.Test(t, func(t *testing.T) {
+		p := newTestPack(t, ForAuth)
+		t.Cleanup(p.Close)
 
-	p := newTestPack(t, ForAuth)
-	t.Cleanup(p.Close)
-
-	testResources153(t, p, testFuncs[*autoupdatev1.AutoUpdateAgentRollout]{
-		newResource: func(name string) (*autoupdatev1.AutoUpdateAgentRollout, error) {
-			return newAutoUpdateAgentRollout(t), nil
-		},
-		create: func(ctx context.Context, item *autoupdatev1.AutoUpdateAgentRollout) error {
-			_, err := p.autoUpdateService.UpsertAutoUpdateAgentRollout(ctx, item)
-			return trace.Wrap(err)
-		},
-		list: getAllAdapter(func(ctx context.Context) ([]*autoupdatev1.AutoUpdateAgentRollout, error) {
-			item, err := p.autoUpdateService.GetAutoUpdateAgentRollout(ctx)
-			if trace.IsNotFound(err) {
-				return []*autoupdatev1.AutoUpdateAgentRollout{}, nil
-			}
-			return []*autoupdatev1.AutoUpdateAgentRollout{item}, trace.Wrap(err)
-		}),
-		cacheList: getAllAdapter(func(ctx context.Context) ([]*autoupdatev1.AutoUpdateAgentRollout, error) {
-			item, err := p.cache.GetAutoUpdateAgentRollout(ctx)
-			if trace.IsNotFound(err) {
-				return []*autoupdatev1.AutoUpdateAgentRollout{}, nil
-			}
-			return []*autoupdatev1.AutoUpdateAgentRollout{item}, trace.Wrap(err)
-		}),
-		deleteAll: p.autoUpdateService.DeleteAutoUpdateAgentRollout,
-	}, withSkipPaginationTest())
+		testSingleton153(t, p, testSingletonFuncs153[*autoupdatev1.AutoUpdateAgentRollout]{
+			newResource: func() *autoupdatev1.AutoUpdateAgentRollout {
+				return newAutoUpdateAgentRollout(t)
+			},
+			create:   p.autoUpdateService.CreateAutoUpdateAgentRollout,
+			update:   p.autoUpdateService.UpdateAutoUpdateAgentRollout,
+			get:      p.autoUpdateService.GetAutoUpdateAgentRollout,
+			cacheGet: p.cache.GetAutoUpdateAgentRollout,
+			delete:   p.autoUpdateService.DeleteAutoUpdateAgentRollout,
+		})
+	})
 }

--- a/lib/cache/cache_singleton_test.go
+++ b/lib/cache/cache_singleton_test.go
@@ -1,0 +1,272 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package cache
+
+import (
+	"context"
+	"testing"
+	"testing/synctest"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/gravitational/trace"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/testing/protocmp"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/api/types/header"
+)
+
+type testSingletonFuncs153[T types.Resource153] struct {
+	newResource func() T
+	create      func(context.Context, T) (T, error)
+	get         func(context.Context) (T, error)
+	cacheGet    func(context.Context) (T, error)
+	update      func(context.Context, T) (T, error)
+	delete      func(context.Context) error
+	setup       func(T)
+	modify      func(T)
+	cmpOpts     []cmp.Option
+}
+
+func (f *testSingletonFuncs153[T]) CheckAndSetDefaults(t *testing.T) {
+	if f.setup == nil {
+		f.setup = func(t T) {
+			metadata := t.GetMetadata()
+			if metadata.Expires == nil {
+				metadata.Expires = timestamppb.New(time.Now().Add(30 * time.Minute))
+			} else {
+				expiry := metadata.Expires.AsTime()
+				metadata.Expires = timestamppb.New(expiry.Add(30 * time.Minute))
+			}
+			metadata.Labels = map[string]string{"label": "value1"}
+		}
+	}
+	if f.modify == nil {
+		f.modify = func(t T) {
+			metadata := t.GetMetadata()
+			if metadata.Expires == nil {
+				metadata.Expires = timestamppb.New(time.Now().Add(30 * time.Minute))
+			} else {
+				expiry := metadata.Expires.AsTime()
+				metadata.Expires = timestamppb.New(expiry.Add(30 * time.Minute))
+			}
+			metadata.Labels["label"] = "value2"
+		}
+	}
+	if f.cmpOpts == nil {
+		f.cmpOpts = []cmp.Option{
+			protocmp.IgnoreFields(&headerv1.Metadata{}, "revision"),
+			protocmp.Transform(),
+			cmpopts.EquateEmpty(),
+		}
+	}
+
+	require.NotNil(t, f.newResource, "newResource function must be provided")
+	require.NotNil(t, f.create, "create function must be provided")
+	require.NotNil(t, f.get, "get function must be provided")
+	require.NotNil(t, f.cacheGet, "cacheGet function must be provided")
+	require.NotNil(t, f.update, "update function must be provided")
+	require.NotNil(t, f.delete, "delete function must be provided")
+}
+
+// testSingleton153 is a wrapper for testing singleton resources conforming to [types.Resource153]
+// Must be ran within [synctest.Test].
+func testSingleton153[T types.Resource153](t *testing.T, p *testPack, funcs testSingletonFuncs153[T]) {
+	funcs.CheckAndSetDefaults(t)
+	ctx := t.Context()
+
+	// Ensure the cache is healthy before proceeding to
+	// prevent running the tests falling back to upstream reads.
+	require.True(t, p.cache.ok)
+
+	// Ensure the singleton doesn't already exist.
+	_, err := funcs.get(ctx)
+	require.True(t, trace.IsNotFound(err))
+
+	_, err = funcs.cacheGet(ctx)
+	require.True(t, trace.IsNotFound(err))
+
+	// Create a resource.
+	res := funcs.newResource()
+	funcs.setup(res)
+	cmpOpts := funcs.cmpOpts
+
+	created, err := funcs.create(ctx, res)
+	require.NoError(t, err)
+	require.Empty(t, cmp.Diff(res, created, cmpOpts...))
+
+	// Check that the resource is now in the backend.
+	backendRes, err := funcs.get(ctx)
+	require.NoError(t, err)
+	require.Empty(t, cmp.Diff(res, backendRes, cmpOpts...))
+
+	// Wait until the information has been replicated to the cache.
+	synctest.Wait()
+
+	// Make sure a single cache get works.
+	cachedRes, err := funcs.cacheGet(ctx)
+	require.NoError(t, err)
+	require.Empty(t, cmp.Diff(res, cachedRes, cmpOpts...))
+
+	funcs.modify(res)
+	updated, err := funcs.update(ctx, res)
+	require.NoError(t, err)
+	require.Empty(t, cmp.Diff(updated, res, cmpOpts...))
+
+	updatedBackendRes, err := funcs.get(ctx)
+	require.NoError(t, err)
+	require.Empty(t, cmp.Diff(updatedBackendRes, res, cmpOpts...))
+	require.NotEmpty(t, cmp.Diff(backendRes, updatedBackendRes, cmpOpts...), "update did not change the resource")
+
+	p.cache.ok = false
+	// Ensure fallback works when cache is unhealthy.
+	fallbackRes, err := funcs.cacheGet(ctx)
+	require.NoError(t, err)
+	require.Empty(t, cmp.Diff(res, fallbackRes, cmpOpts...))
+	p.cache.ok = true
+
+	err = funcs.delete(ctx)
+	require.NoError(t, err)
+
+	_, err = funcs.get(ctx)
+	require.True(t, trace.IsNotFound(err))
+
+	// Wait until the delete event hits the cache.
+	synctest.Wait()
+
+	// Ensure the resource is deleted from the cache.
+	_, err = funcs.cacheGet(ctx)
+	require.True(t, trace.IsNotFound(err))
+}
+
+type testLegacySingletonFuncs[T types.Resource] struct {
+	newResource func() T
+	create      func(context.Context, T) error
+	get         func(context.Context) (T, error)
+	cacheGet    func(context.Context) (T, error)
+	update      func(context.Context, T) error
+	delete      func(context.Context) error
+	setup       func(T)
+	modify      func(T)
+	cmpOpts     []cmp.Option
+}
+
+func (f *testLegacySingletonFuncs[T]) CheckAndSetDefaults(t *testing.T) {
+	if f.setup == nil {
+		f.setup = func(t T) {
+			if t.Expiry().IsZero() {
+				t.SetExpiry(time.Now().Add(30 * time.Minute))
+			} else {
+				t.SetExpiry(t.Expiry().Add(30 * time.Minute))
+			}
+		}
+	}
+	if f.modify == nil {
+		f.modify = func(t T) {
+			if t.Expiry().IsZero() {
+				t.SetExpiry(time.Now().Add(30 * time.Minute))
+			} else {
+				t.SetExpiry(t.Expiry().Add(30 * time.Minute))
+			}
+		}
+	}
+	if f.cmpOpts == nil {
+		f.cmpOpts = []cmp.Option{
+			cmpopts.IgnoreFields(types.Metadata{}, "Revision"),
+			cmpopts.IgnoreFields(header.Metadata{}, "Revision"),
+		}
+	}
+
+	require.NotNil(t, f.newResource, "newResource function must be provided")
+	require.NotNil(t, f.create, "create function must be provided")
+	require.NotNil(t, f.get, "get function must be provided")
+	require.NotNil(t, f.cacheGet, "cacheGet function must be provided")
+	require.NotNil(t, f.update, "update function must be provided")
+	require.NotNil(t, f.delete, "delete function must be provided")
+}
+
+// testLegacySingleton is a wrapper for testing resources conforming to [types.Resource]
+// Must be ran within [synctest.Test].
+func testLegacySingleton[T types.Resource](t *testing.T, p *testPack, funcs testLegacySingletonFuncs[T]) {
+	funcs.CheckAndSetDefaults(t)
+	ctx := t.Context()
+
+	// Ensure the cache is healthy before proceeding to
+	// prevent running the tests falling back to upstream reads.
+	require.True(t, p.cache.ok)
+
+	// Ensure the singleton doesn't already exist.
+	_, err := funcs.get(ctx)
+	require.True(t, trace.IsNotFound(err))
+
+	_, err = funcs.cacheGet(ctx)
+	require.True(t, trace.IsNotFound(err))
+
+	res := funcs.newResource()
+	funcs.setup(res)
+	cmpOpts := funcs.cmpOpts
+
+	// Create a resource.
+	err = funcs.create(ctx, res)
+	require.NoError(t, err)
+
+	// Check that the resource is now in the backend.
+	backendRes, err := funcs.get(ctx)
+	require.NoError(t, err)
+	require.Empty(t, cmp.Diff(res, backendRes, cmpOpts...))
+
+	// Wait until the information has been replicated to the cache.
+	synctest.Wait()
+
+	// Make sure a single cache get works.
+	cachedRes, err := funcs.cacheGet(ctx)
+	require.NoError(t, err)
+	require.Empty(t, cmp.Diff(res, cachedRes, cmpOpts...))
+
+	funcs.modify(res)
+	err = funcs.update(ctx, res)
+	require.NoError(t, err)
+
+	updatedBackendRes, err := funcs.get(ctx)
+	require.NoError(t, err)
+	require.Empty(t, cmp.Diff(updatedBackendRes, res, cmpOpts...))
+	require.NotEmpty(t, cmp.Diff(backendRes, updatedBackendRes, cmpOpts...), "update did not change the resource")
+
+	p.cache.ok = false
+	// Ensure fallback works when cache is unhealthy.
+	fallbackRes, err := funcs.cacheGet(ctx)
+	require.NoError(t, err)
+	require.Empty(t, cmp.Diff(res, fallbackRes, cmpOpts...))
+	p.cache.ok = true
+
+	err = funcs.delete(ctx)
+	require.NoError(t, err)
+
+	_, err = funcs.get(ctx)
+	require.True(t, trace.IsNotFound(err))
+
+	// Wait until the delete event hits the cache.
+	synctest.Wait()
+
+	// Ensure the resource is deleted from the cache.
+	_, err = funcs.cacheGet(ctx)
+	require.True(t, trace.IsNotFound(err))
+}

--- a/lib/cache/cache_test.go
+++ b/lib/cache/cache_test.go
@@ -256,20 +256,6 @@ func getAllAdapter[T any](fn func(context.Context) ([]T, error)) func(context.Co
 	}
 }
 
-// singletonListAdapter adapts a singleton getter to conform to [testFuncs] interface
-func singletonListAdapter[T any](fn func(context.Context) (T, error)) func(context.Context, int, string) ([]T, string, error) {
-	return func(ctx context.Context, _ int, _ string) ([]T, string, error) {
-		out, err := fn(ctx)
-		if err != nil {
-			if trace.IsNotFound(err) {
-				return nil, "", nil
-			}
-			return nil, "", trace.Wrap(err)
-		}
-		return []T{out}, "", nil
-	}
-}
-
 // testFuncs are functions to support testing an object in a cache.
 type testFuncs[T any] struct {
 	newResource func(string) (T, error)

--- a/lib/cache/cluster_config_test.go
+++ b/lib/cache/cluster_config_test.go
@@ -19,11 +19,11 @@ package cache
 import (
 	"context"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/gravitational/trace"
 	"github.com/stretchr/testify/require"
 
 	clusterconfigv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/clusterconfig/v1"
@@ -175,21 +175,20 @@ func TestAuthPreference(t *testing.T) {
 }
 
 func TestAccessGraphSettings(t *testing.T) {
-	t.Parallel()
+	synctest.Test(t, func(t *testing.T) {
+		p := newTestPack(t, ForAuth)
+		t.Cleanup(p.Close)
 
-	p := newTestPack(t, ForAuth)
-	t.Cleanup(p.Close)
+		testSingleton153(t, p, testSingletonFuncs153[*clusterconfigv1.AccessGraphSettings]{
+			newResource: func() *clusterconfigv1.AccessGraphSettings {
+				return newAccessGraphSettings(t)
+			},
+			create:   p.clusterConfigS.CreateAccessGraphSettings,
+			update:   p.clusterConfigS.UpdateAccessGraphSettings,
+			get:      p.clusterConfigS.GetAccessGraphSettings,
+			cacheGet: p.cache.GetAccessGraphSettings,
+			delete:   p.clusterConfigS.DeleteAccessGraphSettings,
+		})
+	})
 
-	testResources153(t, p, testFuncs[*clusterconfigv1.AccessGraphSettings]{
-		newResource: func(name string) (*clusterconfigv1.AccessGraphSettings, error) {
-			return newAccessGraphSettings(t), nil
-		},
-		create: func(ctx context.Context, item *clusterconfigv1.AccessGraphSettings) error {
-			_, err := p.clusterConfigS.UpsertAccessGraphSettings(ctx, item)
-			return trace.Wrap(err)
-		},
-		list:      singletonListAdapter(p.clusterConfigS.GetAccessGraphSettings),
-		cacheList: singletonListAdapter(p.cache.GetAccessGraphSettings),
-		deleteAll: p.clusterConfigS.DeleteAccessGraphSettings,
-	}, withSkipPaginationTest())
 }

--- a/lib/cache/networking_restrictions_test.go
+++ b/lib/cache/networking_restrictions_test.go
@@ -18,23 +18,22 @@ package cache
 
 import (
 	"testing"
+	"testing/synctest"
 
 	"github.com/gravitational/teleport/api/types"
 )
 
 func TestNetworkRestrictions(t *testing.T) {
-	t.Parallel()
-
-	p := newTestPack(t, ForAuth)
-	t.Cleanup(p.Close)
-
-	testResources(t, p, testFuncs[types.NetworkRestrictions]{
-		newResource: func(name string) (types.NetworkRestrictions, error) {
-			return types.NewNetworkRestrictions(), nil
-		},
-		create:    p.restrictions.SetNetworkRestrictions,
-		list:      singletonListAdapter(p.restrictions.GetNetworkRestrictions),
-		cacheList: singletonListAdapter(p.cache.GetNetworkRestrictions),
-		deleteAll: p.restrictions.DeleteNetworkRestrictions,
-	}, withSkipPaginationTest()) // skip pagination test because NetworkRestrictions is a singleton resource
+	synctest.Test(t, func(t *testing.T) {
+		p := newTestPack(t, ForAuth)
+		t.Cleanup(p.Close)
+		testLegacySingleton(t, p, testLegacySingletonFuncs[types.NetworkRestrictions]{
+			newResource: types.NewNetworkRestrictions,
+			create:      p.restrictions.SetNetworkRestrictions,
+			update:      p.restrictions.SetNetworkRestrictions,
+			get:         p.restrictions.GetNetworkRestrictions,
+			cacheGet:    p.cache.GetNetworkRestrictions,
+			delete:      p.restrictions.DeleteNetworkRestrictions,
+		})
+	})
 }

--- a/lib/cache/recording_encryption_test.go
+++ b/lib/cache/recording_encryption_test.go
@@ -17,10 +17,8 @@
 package cache
 
 import (
-	"context"
 	"testing"
-
-	"github.com/gravitational/trace"
+	"testing/synctest"
 
 	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
 	recordingencryptionv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/recordingencryption/v1"
@@ -43,25 +41,17 @@ func newRecordingEncryption() *recordingencryptionv1.RecordingEncryption {
 // TestRecordingEncryption tests that CRUD operations on the RecordingEncryption resource are
 // replicated from the backend to the cache.
 func TestRecordingEncryption(t *testing.T) {
-	t.Parallel()
+	synctest.Test(t, func(t *testing.T) {
+		p := newTestPack(t, ForAuth)
+		t.Cleanup(p.Close)
+		testSingleton153(t, p, testSingletonFuncs153[*recordingencryptionv1.RecordingEncryption]{
+			newResource: newRecordingEncryption,
+			create:      p.recordingEncryption.CreateRecordingEncryption,
+			update:      p.recordingEncryption.UpdateRecordingEncryption,
+			get:         p.recordingEncryption.GetRecordingEncryption,
+			cacheGet:    p.cache.GetRecordingEncryption,
+			delete:      p.recordingEncryption.DeleteRecordingEncryption,
+		})
+	})
 
-	p := newTestPack(t, ForAuth)
-	t.Cleanup(p.Close)
-
-	testResources153(t, p, testFuncs[*recordingencryptionv1.RecordingEncryption]{
-		newResource: func(name string) (*recordingencryptionv1.RecordingEncryption, error) {
-			return newRecordingEncryption(), nil
-		},
-		create: func(ctx context.Context, item *recordingencryptionv1.RecordingEncryption) error {
-			_, err := p.recordingEncryption.CreateRecordingEncryption(ctx, item)
-			return trace.Wrap(err)
-		},
-		update: func(ctx context.Context, item *recordingencryptionv1.RecordingEncryption) error {
-			_, err := p.recordingEncryption.UpdateRecordingEncryption(ctx, item)
-			return trace.Wrap(err)
-		},
-		list:      singletonListAdapter(p.recordingEncryption.GetRecordingEncryption),
-		cacheList: singletonListAdapter(p.cache.GetRecordingEncryption),
-		deleteAll: p.recordingEncryption.DeleteRecordingEncryption,
-	}, withSkipPaginationTest())
 }

--- a/lib/cache/static_scoped_tokens_test.go
+++ b/lib/cache/static_scoped_tokens_test.go
@@ -19,9 +19,9 @@ package cache
 import (
 	"context"
 	"testing"
+	"testing/synctest"
 	"time"
 
-	"github.com/gravitational/trace"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
@@ -61,23 +61,22 @@ func newStaticScopedTokens() *joiningv1.StaticScopedTokens {
 // TestStaticScopedTokens tests that CRUD operations on the StaticScopedTokens resource are
 // replicated from the backend to the cache.
 func TestStaticScopedTokens(t *testing.T) {
-	t.Parallel()
-
-	p := newTestPack(t, ForAuth)
-	t.Cleanup(p.Close)
-
-	testResources153(t, p, testFuncs[*joiningv1.StaticScopedTokens]{
-		newResource: func(name string) (*joiningv1.StaticScopedTokens, error) {
-			return newStaticScopedTokens(), nil
-		},
-		create: func(ctx context.Context, item *joiningv1.StaticScopedTokens) error {
-			return trace.Wrap(p.clusterConfigS.SetStaticScopedTokens(ctx, item))
-		},
-		update: func(ctx context.Context, item *joiningv1.StaticScopedTokens) error {
-			return trace.Wrap(p.clusterConfigS.SetStaticScopedTokens(ctx, item))
-		},
-		list:      singletonListAdapter(p.clusterConfigS.GetStaticScopedTokens),
-		cacheList: singletonListAdapter(p.cache.GetStaticScopedTokens),
-		deleteAll: p.clusterConfigS.DeleteStaticScopedTokens,
-	}, withSkipPaginationTest())
+	synctest.Test(t, func(t *testing.T) {
+		p := newTestPack(t, ForAuth)
+		t.Cleanup(p.Close)
+		testSingleton153(t, p, testSingletonFuncs153[*joiningv1.StaticScopedTokens]{
+			newResource: newStaticScopedTokens,
+			create: func(ctx context.Context, sst *joiningv1.StaticScopedTokens) (*joiningv1.StaticScopedTokens, error) {
+				// Does not obey 153 semantics.
+				return sst, p.clusterConfigS.SetStaticScopedTokens(ctx, sst)
+			},
+			update: func(ctx context.Context, sst *joiningv1.StaticScopedTokens) (*joiningv1.StaticScopedTokens, error) {
+				// Does not obey 153 semantics.
+				return sst, p.clusterConfigS.SetStaticScopedTokens(ctx, sst)
+			},
+			get:      p.clusterConfigS.GetStaticScopedTokens,
+			cacheGet: p.cache.GetStaticScopedTokens,
+			delete:   p.clusterConfigS.DeleteStaticScopedTokens,
+		})
+	})
 }

--- a/lib/cache/summarizer_test.go
+++ b/lib/cache/summarizer_test.go
@@ -19,8 +19,7 @@ package cache
 import (
 	"context"
 	"testing"
-
-	"github.com/gravitational/trace"
+	"testing/synctest"
 
 	summarizerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/summarizer/v1"
 	"github.com/gravitational/teleport/api/types"
@@ -99,33 +98,27 @@ func TestInferencePolicyCache(t *testing.T) {
 }
 
 func TestRetrievalModelCache(t *testing.T) {
-	t.Parallel()
+	synctest.Test(t, func(t *testing.T) {
+		p := newTestPack(t, ForAuth)
+		t.Cleanup(p.Close)
 
-	p := newTestPack(t, ForAuth)
-	t.Cleanup(p.Close)
-
-	testResources153(t, p, testFuncs[*summarizerv1.RetrievalModel]{
-		newResource: func(name string) (*summarizerv1.RetrievalModel, error) {
-			return summarizer.NewRetrievalModel(&summarizerv1.RetrievalModelSpec{
-				EmbeddingsProvider: &summarizerv1.RetrievalModelSpec_Openai{
-					Openai: &summarizerv1.OpenAIProvider{
-						OpenaiModelId:   "text-embedding-3-small",
-						ApiKeySecretRef: "some",
+		testSingleton153(t, p, testSingletonFuncs153[*summarizerv1.RetrievalModel]{
+			newResource: func() *summarizerv1.RetrievalModel {
+				return summarizer.NewRetrievalModel(&summarizerv1.RetrievalModelSpec{
+					EmbeddingsProvider: &summarizerv1.RetrievalModelSpec_Openai{
+						Openai: &summarizerv1.OpenAIProvider{
+							OpenaiModelId:   "text-embedding-3-small",
+							ApiKeySecretRef: "some",
+						},
 					},
-				},
-				InferenceModelName: "some",
-			}), nil
-		},
-		create: func(ctx context.Context, item *summarizerv1.RetrievalModel) error {
-			_, err := p.summarizer.CreateRetrievalModel(ctx, item)
-			return err
-		},
-		update: func(ctx context.Context, item *summarizerv1.RetrievalModel) error {
-			_, err := p.summarizer.UpdateRetrievalModel(ctx, item)
-			return trace.Wrap(err)
-		},
-		list:      singletonListAdapter(p.summarizer.GetRetrievalModel),
-		cacheList: singletonListAdapter(p.cache.GetRetrievalModel),
-		deleteAll: p.summarizer.DeleteRetrievalModel,
-	}, withSkipPaginationTest()) // skip pagination test because RetrievalModel is a singleton resource
+					InferenceModelName: "some",
+				})
+			},
+			create:   p.summarizer.CreateRetrievalModel,
+			update:   p.summarizer.UpdateRetrievalModel,
+			get:      p.summarizer.GetRetrievalModel,
+			cacheGet: p.cache.GetRetrievalModel,
+			delete:   p.summarizer.DeleteRetrievalModel,
+		})
+	})
 }

--- a/lib/cache/web_ui_config_test.go
+++ b/lib/cache/web_ui_config_test.go
@@ -18,30 +18,31 @@ package cache
 
 import (
 	"testing"
+	"testing/synctest"
 
 	"github.com/gravitational/teleport/api/types"
 )
 
 func TestWebUIConfig(t *testing.T) {
-	t.Parallel()
-
-	p := newTestPack(t, ForProxy)
-	t.Cleanup(p.Close)
-
-	testResources(t, p, testFuncs[types.UIConfig]{
-		newResource: func(name string) (types.UIConfig, error) {
-			return &types.UIConfigV1{
-				ResourceHeader: types.ResourceHeader{
-					Kind: types.KindUIConfig,
-					Metadata: types.Metadata{
-						Name: types.MetaNameUIConfig,
+	synctest.Test(t, func(t *testing.T) {
+		p := newTestPack(t, ForAuth)
+		t.Cleanup(p.Close)
+		testLegacySingleton(t, p, testLegacySingletonFuncs[types.UIConfig]{
+			newResource: func() types.UIConfig {
+				return &types.UIConfigV1{
+					ResourceHeader: types.ResourceHeader{
+						Kind: types.KindUIConfig,
+						Metadata: types.Metadata{
+							Name: types.MetaNameUIConfig,
+						},
 					},
-				},
-			}, nil
-		},
-		create:    p.clusterConfigS.SetUIConfig,
-		list:      singletonListAdapter(p.clusterConfigS.GetUIConfig),
-		cacheList: singletonListAdapter(p.cache.GetUIConfig),
-		deleteAll: p.clusterConfigS.DeleteUIConfig,
-	}, withSkipPaginationTest()) // UIConfig is a singleton resource, so pagination is not applicable.
+				}
+			},
+			create:   p.clusterConfigS.SetUIConfig,
+			update:   p.clusterConfigS.SetUIConfig,
+			get:      p.clusterConfigS.GetUIConfig,
+			cacheGet: p.cache.GetUIConfig,
+			delete:   p.clusterConfigS.DeleteUIConfig,
+		})
+	})
 }

--- a/lib/services/local/restrictions.go
+++ b/lib/services/local/restrictions.go
@@ -64,7 +64,7 @@ func (s *RestrictionsService) SetNetworkRestrictions(ctx context.Context, nr typ
 }
 
 func (s *RestrictionsService) GetNetworkRestrictions(ctx context.Context) (types.NetworkRestrictions, error) {
-	item, err := s.Get(context.TODO(), backend.NewKey(restrictionsPrefix, network))
+	item, err := s.Get(ctx, backend.NewKey(restrictionsPrefix, network))
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}


### PR DESCRIPTION
Instead dedicated helpers were added to test singleton like resources in the cache. This is a step towards removing `withSkipPaginationTest` which is a potential footgun.

Also fixes context not being passed to `GetNetworkRestrictions`

Since the tests make use of the in memory backend the new helpers are ran within synctest bubble.