### PR TITLE
Add `identity/key-agent` to MWI configuration reference

### DIFF
--- a/docs/pages/reference/machine-workload-identity/configuration.mdx
+++ b/docs/pages/reference/machine-workload-identity/configuration.mdx
@@ -271,7 +271,15 @@ It can be used to authenticate:
 - Management of Teleport resources using the Teleport Terraform provider.
 - Access to the Teleport API using the Teleport Go SDK.
 
-To use the key agent service with `tsh` or `tctl`, you must set the
+```yaml
+# type specifies the type of the output. For the key agent output, this will
+# always be `identity/key-agent`.
+type: identity/key-agent
+
+(!docs/pages/includes/machine-id/common-output-config.yaml!)
+```
+
+To use the `identity/key-agent` service with `tsh` or `tctl`, you must set the
 `TELEPORT_KEY_AGENT_DIR` environment variable to the configured destination
 directory path, and use the generated identity file.
 
@@ -281,13 +289,6 @@ Example:
 $ TELEPORT_KEY_AGENT_DIR=/opt/machine-id \
   TELEPORT_IDENTITY_FILE=/opt/machine-id/identity \
   tsh ssh user@host
-```
-
-```yaml
-# type specifies the type of the output. For the key agent output, this will
-# always be `identity/key-agent`.
-type: identity/key-agent
-(!docs/pages/includes/machine-id/common-output-config.yaml!)
 ```
 
 ### `application`

--- a/docs/pages/reference/machine-workload-identity/configuration.mdx
+++ b/docs/pages/reference/machine-workload-identity/configuration.mdx
@@ -271,6 +271,18 @@ It can be used to authenticate:
 - Management of Teleport resources using the Teleport Terraform provider.
 - Access to the Teleport API using the Teleport Go SDK.
 
+To use the key agent service with `tsh` or `tctl`, you must set the
+`TELEPORT_KEY_AGENT_DIR` environment variable to the configured destination
+directory path, and use the generated identity file.
+
+Example:
+
+```code
+$ TELEPORT_KEY_AGENT_DIR=/opt/machine-id \
+  TELEPORT_IDENTITY_FILE=/opt/machine-id/identity \
+  tsh ssh user@host
+```
+
 ```yaml
 # type specifies the type of the output. For the key agent output, this will
 # always be `identity/key-agent`.

--- a/docs/pages/reference/machine-workload-identity/configuration.mdx
+++ b/docs/pages/reference/machine-workload-identity/configuration.mdx
@@ -254,6 +254,30 @@ allow_reissue: false
 (!docs/pages/includes/machine-id/common-output-config.yaml!)
 ```
 
+### `identity/key-agent`
+
+The `identity/key-agent` service provides similar functionality to the
+`identity` output service, but makes it impossible to steal or exfiltrate the
+generated identity by keeping private key material entirely in-memory.
+
+It works similarly to the [Hardware Key Agent](https://github.com/gravitational/teleport/blob/master/rfd/0199-hardware-key-agent.md)
+in that it runs a gRPC service on a Unix socket, which the Teleport Client calls
+to perform cryptographic signing operations.
+
+It can be used to authenticate:
+
+- SSH access to your Teleport servers, using `tsh`.
+- Administrative actions against your cluster using tools like `tsh` or `tctl`.
+- Management of Teleport resources using the Teleport Terraform provider.
+- Access to the Teleport API using the Teleport Go SDK.
+
+```yaml
+# type specifies the type of the output. For the key agent output, this will
+# always be `identity/key-agent`.
+type: identity/key-agent
+(!docs/pages/includes/machine-id/common-output-config.yaml!)
+```
+
 ### `application`
 
 The `application` output service is used to generate credentials that can be

--- a/docs/pages/reference/machine-workload-identity/configuration.mdx
+++ b/docs/pages/reference/machine-workload-identity/configuration.mdx
@@ -258,7 +258,7 @@ allow_reissue: false
 
 The `identity/key-agent` service provides similar functionality to the
 `identity` output service, but makes it impossible to steal or exfiltrate the
-generated identity by keeping private key material entirely in-memory.
+generated identity by keeping private key material entirely in memory.
 
 It works similarly to the [Hardware Key Agent](https://github.com/gravitational/teleport/blob/master/rfd/0199-hardware-key-agent.md)
 in that it runs a gRPC service on a Unix socket, which the Teleport Client calls


### PR DESCRIPTION
Documents the `identity/key-agent` service added in https://github.com/gravitational/teleport/pull/66535.

Closes #66784.
