### PR TITLE
Fix flaky TestNewIdPIAMConfigureClient when AWS_PROFILE is set

### DIFF
--- a/lib/integrations/awsoidc/idp_iam_config_test.go
+++ b/lib/integrations/awsoidc/idp_iam_config_test.go
@@ -559,6 +559,7 @@ func TestNewIdPIAMConfigureClient(t *testing.T) {
 		// Prevent the AWS SDK from loading user configuration files which may set the region.
 		t.Setenv("AWS_SHARED_CREDENTIALS_FILE", "/dev/null/does-not-exist")
 		t.Setenv("AWS_CONFIG_FILE", "/dev/null/does-not-exist")
+		t.Setenv("AWS_PROFILE", "")
 		t.Setenv("AWS_REGION", "")
 		t.Setenv("AWS_DEFAULT_REGION", "")
 		_, err := NewIdPIAMConfigureClient(context.Background())


### PR DESCRIPTION
`TestNewIdPIAMConfigureClient` fails when `AWS_PROFILE` is set in the test environment (e.g., `AWS_PROFILE=teleport-dev-foo`). 

```
$ go test -race -tags "desktop_access_rdp libfido2 pivtest" github.com/gravitational/teleport/lib/integrations/awsoidc -run TestNewIdPIAMConfigureClient

=== RUN   TestNewIdPIAMConfigureClient
=== RUN   TestNewIdPIAMConfigureClient/no_aws_region_env_var,_returns_an_error
    idp_iam_config_test.go:565: 
        	Error Trace:	/Users/christhach/projects/teleport/lib/integrations/awsoidc/idp_iam_config_test.go:565
        	Error:      	Error "failed to get shared config profile, teleport-dev-foo" does not contain "please set the AWS_REGION environment variable"
        	Test:       	TestNewIdPIAMConfigureClient/no_aws_region_env_var,_returns_an_error
=== RUN   TestNewIdPIAMConfigureClient/aws_region_env_var_was_set,_success
--- FAIL: TestNewIdPIAMConfigureClient (0.00s)
    --- FAIL: TestNewIdPIAMConfigureClient/no_aws_region_env_var,_returns_an_error (0.00s)
    --- PASS: TestNewIdPIAMConfigureClient/aws_region_env_var_was_set,_success (0.00s)
FAIL
FAIL	github.com/gravitational/teleport/lib/integrations/awsoidc	1.227s
FAIL
```

The test clears `AWS_REGION`, `AWS_DEFAULT_REGION`, and points `AWS_CONFIG_FILE` to a non-existent path, but does not clear `AWS_PROFILE`. The AWS SDK attempts to load the named profile from the non-existent config file and returns `"failed to get shared config profile"` before the region check is ever reached, causing the assertion for `"please set the AWS_REGION environment variable"` to fail.

The fix adds `t.Setenv("AWS_PROFILE", "")` to the test ensuring the AWS SDK does not attempt to load a named profile.

## Manual Test Plan
### Test Environment

Mac local development environment with `AWS_PROFILE=teleport-dev-foo` set in shell environment

### Test Cases
- [x] Run `go test -race github.com/gravitational/teleport/lib/integrations/awsoidc -run TestNewIdPIAMConfigureClient` with `AWS_PROFILE` set passes
- [x] Run `go test -race github.com/gravitational/teleport/lib/integrations/awsoidc -run TestNewIdPIAMConfigureClient` without `AWS_PROFILE` set passes
- [x] Run `go test -race github.com/gravitational/teleport/lib/integrations/awsoidc` passes