### PR TITLE
Clarify Grafana MCP guide prerequisite

### DIFF
--- a/docs/pages/enroll-resources/mcp-access/integration-guides/grafana.mdx
+++ b/docs/pages/enroll-resources/mcp-access/integration-guides/grafana.mdx
@@ -30,15 +30,9 @@ mapped by [JWT authentication](https://grafana.com/docs/grafana/latest/setup-gra
 - A Teleport user with sufficient permissions (e.g. role `mcp-user`) to access
   MCP servers.
 
-- A Grafana instance configured for JWT authentication. Setting this up depends
-  on your infrastructure and is outside the scope of this guide.
-
-  <details>
-  <summary>Configuring JWT authentication in Grafana</summary>
+- A Grafana instance configured for JWT authentication with Teleport.
 
   (!docs/pages/includes/application-access/jwt-grafana-config.mdx!)
-
-  </details>
 
 ## Step 1/2. Run the Grafana MCP server
 


### PR DESCRIPTION
In #66540, we changed a number of guides in the docs to roll out a standard in which the body of a how-to guide contains concrete steps that the user can complete in their Teleport cluster, while any steps that depend on a user's infrastructure and cannot include command examples belong in the "Prerequisites" or "Next steps" sections.

The Grafana MCP guide is an edge case, since there is a Grafana-specific configuration step that cannot include an example command, since it depends on how the user has deployed Grafana, but also requires a change from all users. Edit the guide to make this change clearer, removing a `details` box, while still keeping it in the Prerequisites.