### PR TITLE
[vnet] Add DNS routing diagnostic check

### DIFF
--- a/gen/proto/go/teleport/lib/vnet/diag/v1/diag.pb.go
+++ b/gen/proto/go/teleport/lib/vnet/diag/v1/diag.pb.go
@@ -1254,22 +1254,28 @@ func (b0 RouteConflict_builder) Build() *RouteConflict {
 // VNet's nameserver. It is the output of DNSDiag.
 //
 // The check uses a probe hostname of the form vnet-diag-<random>.<zone>. VNet's nameserver
-// short-circuits any query with this prefix and answers with an address derived from its IPv6
-// prefix, an address no other resolver can produce. The random label prevents DNS caches.
+// short-circuits any query with this prefix and answers with addresses derived from its IPv4 CIDR
+// range and IPv6 prefix, addresses no other resolver can produce. The random label prevents DNS
+// caches.
 //
-// The check first queries the probe directly against VNet's nameserver IP to confirm VNet's DNS
-// server is reachable and to capture the expected response. If that fails, vnet_dns_reachable is
-// false, vnet_dns_unreachable_error stores the error, and zone_results is empty. Otherwise, the
-// check runs the same probe query per zone through the system resolver and compares each answer to
-// the expected response. A mismatch means the per-zone OS resolver entry does not route to VNet.
+// The check first queries the probe directly against each VNet nameserver IPv4 and IPv6 addresses
+// asking for both A and AAAA records, to confirm VNet's DNS server is reachable and to capture the
+// expected responses per record type. If an IPv4 or IPv6 address is unreachable, the corresponding
+// reachability field still records the failure but the check continues with whatever was captured
+// from successful queries. If neither address produced a response for either record type,
+// zone_results is empty. Otherwise, the check runs the same probe per zone through the system
+// resolver, asking for A and AAAA independently, and compares each answer to the expected response.
+// A mismatch means the per-zone OS resolver entry does not route to VNet.
 type DNSReport struct {
 	state protoimpl.MessageState `protogen:"hybrid.v1"`
-	// vnet_dns_reachable is true if a direct DNS query to VNet's nameserver IP succeeded.
-	VnetDnsReachable bool `protobuf:"varint,1,opt,name=vnet_dns_reachable,json=vnetDnsReachable,proto3" json:"vnet_dns_reachable,omitempty"`
-	// vnet_dns_unreachable_error is set when vnet_dns_reachable is false.
-	VnetDnsUnreachableError string `protobuf:"bytes,2,opt,name=vnet_dns_unreachable_error,json=vnetDnsUnreachableError,proto3" json:"vnet_dns_unreachable_error,omitempty"`
-	// zone_results contains one entry per zone in NetworkStack.dns_zones. Empty if
-	// vnet_dns_reachable is false.
+	// ipv4_reachability is the outcome of probing VNet's IPv4 nameserver directly. Null if VNet is
+	// not serving DNS on IPv4.
+	Ipv4Reachability *VNetDNSReachability `protobuf:"bytes,1,opt,name=ipv4_reachability,json=ipv4Reachability,proto3" json:"ipv4_reachability,omitempty"`
+	// ipv6_reachability is the outcome of probing VNet's IPv6 nameserver directly. Null if VNet is
+	// not serving DNS on IPv6.
+	Ipv6Reachability *VNetDNSReachability `protobuf:"bytes,2,opt,name=ipv6_reachability,json=ipv6Reachability,proto3" json:"ipv6_reachability,omitempty"`
+	// zone_results contains one entry per zone in NetworkStack.dns_zones. Empty if neither
+	// reachability probe produced a response for either record type.
 	ZoneResults   []*DNSZoneResult `protobuf:"bytes,3,rep,name=zone_results,json=zoneResults,proto3" json:"zone_results,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
@@ -1300,18 +1306,18 @@ func (x *DNSReport) ProtoReflect() protoreflect.Message {
 	return mi.MessageOf(x)
 }
 
-func (x *DNSReport) GetVnetDnsReachable() bool {
+func (x *DNSReport) GetIpv4Reachability() *VNetDNSReachability {
 	if x != nil {
-		return x.VnetDnsReachable
+		return x.Ipv4Reachability
 	}
-	return false
+	return nil
 }
 
-func (x *DNSReport) GetVnetDnsUnreachableError() string {
+func (x *DNSReport) GetIpv6Reachability() *VNetDNSReachability {
 	if x != nil {
-		return x.VnetDnsUnreachableError
+		return x.Ipv6Reachability
 	}
-	return ""
+	return nil
 }
 
 func (x *DNSReport) GetZoneResults() []*DNSZoneResult {
@@ -1321,27 +1327,51 @@ func (x *DNSReport) GetZoneResults() []*DNSZoneResult {
 	return nil
 }
 
-func (x *DNSReport) SetVnetDnsReachable(v bool) {
-	x.VnetDnsReachable = v
+func (x *DNSReport) SetIpv4Reachability(v *VNetDNSReachability) {
+	x.Ipv4Reachability = v
 }
 
-func (x *DNSReport) SetVnetDnsUnreachableError(v string) {
-	x.VnetDnsUnreachableError = v
+func (x *DNSReport) SetIpv6Reachability(v *VNetDNSReachability) {
+	x.Ipv6Reachability = v
 }
 
 func (x *DNSReport) SetZoneResults(v []*DNSZoneResult) {
 	x.ZoneResults = v
 }
 
+func (x *DNSReport) HasIpv4Reachability() bool {
+	if x == nil {
+		return false
+	}
+	return x.Ipv4Reachability != nil
+}
+
+func (x *DNSReport) HasIpv6Reachability() bool {
+	if x == nil {
+		return false
+	}
+	return x.Ipv6Reachability != nil
+}
+
+func (x *DNSReport) ClearIpv4Reachability() {
+	x.Ipv4Reachability = nil
+}
+
+func (x *DNSReport) ClearIpv6Reachability() {
+	x.Ipv6Reachability = nil
+}
+
 type DNSReport_builder struct {
 	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
 
-	// vnet_dns_reachable is true if a direct DNS query to VNet's nameserver IP succeeded.
-	VnetDnsReachable bool
-	// vnet_dns_unreachable_error is set when vnet_dns_reachable is false.
-	VnetDnsUnreachableError string
-	// zone_results contains one entry per zone in NetworkStack.dns_zones. Empty if
-	// vnet_dns_reachable is false.
+	// ipv4_reachability is the outcome of probing VNet's IPv4 nameserver directly. Null if VNet is
+	// not serving DNS on IPv4.
+	Ipv4Reachability *VNetDNSReachability
+	// ipv6_reachability is the outcome of probing VNet's IPv6 nameserver directly. Null if VNet is
+	// not serving DNS on IPv6.
+	Ipv6Reachability *VNetDNSReachability
+	// zone_results contains one entry per zone in NetworkStack.dns_zones. Empty if neither
+	// reachability probe produced a response for either record type.
 	ZoneResults []*DNSZoneResult
 }
 
@@ -1349,35 +1379,156 @@ func (b0 DNSReport_builder) Build() *DNSReport {
 	m0 := &DNSReport{}
 	b, x := &b0, m0
 	_, _ = b, x
-	x.VnetDnsReachable = b.VnetDnsReachable
-	x.VnetDnsUnreachableError = b.VnetDnsUnreachableError
+	x.Ipv4Reachability = b.Ipv4Reachability
+	x.Ipv6Reachability = b.Ipv6Reachability
 	x.ZoneResults = b.ZoneResults
 	return m0
 }
 
+// VNetDNSReachability describes the outcome of probing one of VNet's DNS servers directly,
+// bypassing the system resolver.
+type VNetDNSReachability struct {
+	state protoimpl.MessageState `protogen:"hybrid.v1"`
+	// address is the server that was probed, e.g. "[fdec:1fed:139f::2]:53" or "100.64.0.2:53".
+	Address string `protobuf:"bytes,1,opt,name=address,proto3" json:"address,omitempty"`
+	// reachable is true if the server returned an answer for at least one record type.
+	Reachable bool `protobuf:"varint,2,opt,name=reachable,proto3" json:"reachable,omitempty"`
+	// responded_a is true if the server returned an A record for the probe.
+	RespondedA bool `protobuf:"varint,3,opt,name=responded_a,json=respondedA,proto3" json:"responded_a,omitempty"`
+	// responded_aaaa is true if the server returned an AAAA record for the probe.
+	RespondedAaaa bool `protobuf:"varint,4,opt,name=responded_aaaa,json=respondedAaaa,proto3" json:"responded_aaaa,omitempty"`
+	// error explains the failure when reachable is false.
+	Error         string `protobuf:"bytes,5,opt,name=error,proto3" json:"error,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *VNetDNSReachability) Reset() {
+	*x = VNetDNSReachability{}
+	mi := &file_teleport_lib_vnet_diag_v1_diag_proto_msgTypes[9]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *VNetDNSReachability) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*VNetDNSReachability) ProtoMessage() {}
+
+func (x *VNetDNSReachability) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_lib_vnet_diag_v1_diag_proto_msgTypes[9]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+func (x *VNetDNSReachability) GetAddress() string {
+	if x != nil {
+		return x.Address
+	}
+	return ""
+}
+
+func (x *VNetDNSReachability) GetReachable() bool {
+	if x != nil {
+		return x.Reachable
+	}
+	return false
+}
+
+func (x *VNetDNSReachability) GetRespondedA() bool {
+	if x != nil {
+		return x.RespondedA
+	}
+	return false
+}
+
+func (x *VNetDNSReachability) GetRespondedAaaa() bool {
+	if x != nil {
+		return x.RespondedAaaa
+	}
+	return false
+}
+
+func (x *VNetDNSReachability) GetError() string {
+	if x != nil {
+		return x.Error
+	}
+	return ""
+}
+
+func (x *VNetDNSReachability) SetAddress(v string) {
+	x.Address = v
+}
+
+func (x *VNetDNSReachability) SetReachable(v bool) {
+	x.Reachable = v
+}
+
+func (x *VNetDNSReachability) SetRespondedA(v bool) {
+	x.RespondedA = v
+}
+
+func (x *VNetDNSReachability) SetRespondedAaaa(v bool) {
+	x.RespondedAaaa = v
+}
+
+func (x *VNetDNSReachability) SetError(v string) {
+	x.Error = v
+}
+
+type VNetDNSReachability_builder struct {
+	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
+
+	// address is the server that was probed, e.g. "[fdec:1fed:139f::2]:53" or "100.64.0.2:53".
+	Address string
+	// reachable is true if the server returned an answer for at least one record type.
+	Reachable bool
+	// responded_a is true if the server returned an A record for the probe.
+	RespondedA bool
+	// responded_aaaa is true if the server returned an AAAA record for the probe.
+	RespondedAaaa bool
+	// error explains the failure when reachable is false.
+	Error string
+}
+
+func (b0 VNetDNSReachability_builder) Build() *VNetDNSReachability {
+	m0 := &VNetDNSReachability{}
+	b, x := &b0, m0
+	_, _ = b, x
+	x.Address = b.Address
+	x.Reachable = b.Reachable
+	x.RespondedA = b.RespondedA
+	x.RespondedAaaa = b.RespondedAaaa
+	x.Error = b.Error
+	return m0
+}
+
 // DNSZoneResult describes the outcome of querying a probe hostname under a single VNet-managed
-// DNS zone through the system resolver.
+// DNS zone through the system resolver. The query is made for both A and AAAA records.
 type DNSZoneResult struct {
 	state protoimpl.MessageState `protogen:"hybrid.v1"`
 	// zone is the DNS zone that was tested, e.g. "company.test".
 	Zone string `protobuf:"bytes,1,opt,name=zone,proto3" json:"zone,omitempty"`
-	// status describes the outcome of the query.
-	Status DNSZoneStatus `protobuf:"varint,2,opt,name=status,proto3,enum=teleport.lib.vnet.diag.v1.DNSZoneStatus" json:"status,omitempty"`
-	// observed_ip is the IP returned by the system resolver for the probe hostname. Empty on
-	// timeout or no answer.
-	ObservedIp string `protobuf:"bytes,3,opt,name=observed_ip,json=observedIp,proto3" json:"observed_ip,omitempty"`
-	// expected_ip is the IP that VNet's nameserver returned for the same probe hostname when
-	// queried directly.
-	ExpectedIp string `protobuf:"bytes,4,opt,name=expected_ip,json=expectedIp,proto3" json:"expected_ip,omitempty"`
-	// error is set on DNS_ZONE_STATUS_TIMEOUT and DNS_ZONE_STATUS_RESOLVER_ERROR.
-	Error         string `protobuf:"bytes,5,opt,name=error,proto3" json:"error,omitempty"`
+	// a_record is the outcome of the A-record part of the per-zone query. Null if no expected A was
+	// captured.
+	ARecord *RecordResult `protobuf:"bytes,2,opt,name=a_record,json=aRecord,proto3" json:"a_record,omitempty"`
+	// aaaa_record is the outcome of the AAAA-record part of the per-zone query. Null if no expected
+	// AAAA was captured.
+	AaaaRecord    *RecordResult `protobuf:"bytes,3,opt,name=aaaa_record,json=aaaaRecord,proto3" json:"aaaa_record,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
 
 func (x *DNSZoneResult) Reset() {
 	*x = DNSZoneResult{}
-	mi := &file_teleport_lib_vnet_diag_v1_diag_proto_msgTypes[9]
+	mi := &file_teleport_lib_vnet_diag_v1_diag_proto_msgTypes[10]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1389,7 +1540,7 @@ func (x *DNSZoneResult) String() string {
 func (*DNSZoneResult) ProtoMessage() {}
 
 func (x *DNSZoneResult) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_lib_vnet_diag_v1_diag_proto_msgTypes[9]
+	mi := &file_teleport_lib_vnet_diag_v1_diag_proto_msgTypes[10]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1407,52 +1558,52 @@ func (x *DNSZoneResult) GetZone() string {
 	return ""
 }
 
-func (x *DNSZoneResult) GetStatus() DNSZoneStatus {
+func (x *DNSZoneResult) GetARecord() *RecordResult {
 	if x != nil {
-		return x.Status
+		return x.ARecord
 	}
-	return DNSZoneStatus_DNS_ZONE_STATUS_UNSPECIFIED
+	return nil
 }
 
-func (x *DNSZoneResult) GetObservedIp() string {
+func (x *DNSZoneResult) GetAaaaRecord() *RecordResult {
 	if x != nil {
-		return x.ObservedIp
+		return x.AaaaRecord
 	}
-	return ""
-}
-
-func (x *DNSZoneResult) GetExpectedIp() string {
-	if x != nil {
-		return x.ExpectedIp
-	}
-	return ""
-}
-
-func (x *DNSZoneResult) GetError() string {
-	if x != nil {
-		return x.Error
-	}
-	return ""
+	return nil
 }
 
 func (x *DNSZoneResult) SetZone(v string) {
 	x.Zone = v
 }
 
-func (x *DNSZoneResult) SetStatus(v DNSZoneStatus) {
-	x.Status = v
+func (x *DNSZoneResult) SetARecord(v *RecordResult) {
+	x.ARecord = v
 }
 
-func (x *DNSZoneResult) SetObservedIp(v string) {
-	x.ObservedIp = v
+func (x *DNSZoneResult) SetAaaaRecord(v *RecordResult) {
+	x.AaaaRecord = v
 }
 
-func (x *DNSZoneResult) SetExpectedIp(v string) {
-	x.ExpectedIp = v
+func (x *DNSZoneResult) HasARecord() bool {
+	if x == nil {
+		return false
+	}
+	return x.ARecord != nil
 }
 
-func (x *DNSZoneResult) SetError(v string) {
-	x.Error = v
+func (x *DNSZoneResult) HasAaaaRecord() bool {
+	if x == nil {
+		return false
+	}
+	return x.AaaaRecord != nil
+}
+
+func (x *DNSZoneResult) ClearARecord() {
+	x.ARecord = nil
+}
+
+func (x *DNSZoneResult) ClearAaaaRecord() {
+	x.AaaaRecord = nil
 }
 
 type DNSZoneResult_builder struct {
@@ -1460,16 +1611,12 @@ type DNSZoneResult_builder struct {
 
 	// zone is the DNS zone that was tested, e.g. "company.test".
 	Zone string
-	// status describes the outcome of the query.
-	Status DNSZoneStatus
-	// observed_ip is the IP returned by the system resolver for the probe hostname. Empty on
-	// timeout or no answer.
-	ObservedIp string
-	// expected_ip is the IP that VNet's nameserver returned for the same probe hostname when
-	// queried directly.
-	ExpectedIp string
-	// error is set on DNS_ZONE_STATUS_TIMEOUT and DNS_ZONE_STATUS_RESOLVER_ERROR.
-	Error string
+	// a_record is the outcome of the A-record part of the per-zone query. Null if no expected A was
+	// captured.
+	ARecord *RecordResult
+	// aaaa_record is the outcome of the AAAA-record part of the per-zone query. Null if no expected
+	// AAAA was captured.
+	AaaaRecord *RecordResult
 }
 
 func (b0 DNSZoneResult_builder) Build() *DNSZoneResult {
@@ -1477,9 +1624,100 @@ func (b0 DNSZoneResult_builder) Build() *DNSZoneResult {
 	b, x := &b0, m0
 	_, _ = b, x
 	x.Zone = b.Zone
+	x.ARecord = b.ARecord
+	x.AaaaRecord = b.AaaaRecord
+	return m0
+}
+
+// RecordResult describes the outcome of querying a single record type for a single zone through
+// the system resolver.
+type RecordResult struct {
+	state protoimpl.MessageState `protogen:"hybrid.v1"`
+	// status describes the outcome of the query for this record type.
+	Status DNSZoneStatus `protobuf:"varint,1,opt,name=status,proto3,enum=teleport.lib.vnet.diag.v1.DNSZoneStatus" json:"status,omitempty"`
+	// observed_ip is the IP returned by the system resolver. Populated for DNS_ZONE_STATUS_HIJACKED.
+	ObservedIp string `protobuf:"bytes,2,opt,name=observed_ip,json=observedIp,proto3" json:"observed_ip,omitempty"`
+	// error is set on DNS_ZONE_STATUS_TIMEOUT and DNS_ZONE_STATUS_RESOLVER_ERROR.
+	Error         string `protobuf:"bytes,3,opt,name=error,proto3" json:"error,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *RecordResult) Reset() {
+	*x = RecordResult{}
+	mi := &file_teleport_lib_vnet_diag_v1_diag_proto_msgTypes[11]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *RecordResult) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*RecordResult) ProtoMessage() {}
+
+func (x *RecordResult) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_lib_vnet_diag_v1_diag_proto_msgTypes[11]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+func (x *RecordResult) GetStatus() DNSZoneStatus {
+	if x != nil {
+		return x.Status
+	}
+	return DNSZoneStatus_DNS_ZONE_STATUS_UNSPECIFIED
+}
+
+func (x *RecordResult) GetObservedIp() string {
+	if x != nil {
+		return x.ObservedIp
+	}
+	return ""
+}
+
+func (x *RecordResult) GetError() string {
+	if x != nil {
+		return x.Error
+	}
+	return ""
+}
+
+func (x *RecordResult) SetStatus(v DNSZoneStatus) {
+	x.Status = v
+}
+
+func (x *RecordResult) SetObservedIp(v string) {
+	x.ObservedIp = v
+}
+
+func (x *RecordResult) SetError(v string) {
+	x.Error = v
+}
+
+type RecordResult_builder struct {
+	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
+
+	// status describes the outcome of the query for this record type.
+	Status DNSZoneStatus
+	// observed_ip is the IP returned by the system resolver. Populated for DNS_ZONE_STATUS_HIJACKED.
+	ObservedIp string
+	// error is set on DNS_ZONE_STATUS_TIMEOUT and DNS_ZONE_STATUS_RESOLVER_ERROR.
+	Error string
+}
+
+func (b0 RecordResult_builder) Build() *RecordResult {
+	m0 := &RecordResult{}
+	b, x := &b0, m0
+	_, _ = b, x
 	x.Status = b.Status
 	x.ObservedIp = b.ObservedIp
-	x.ExpectedIp = b.ExpectedIp
 	x.Error = b.Error
 	return m0
 }
@@ -1508,7 +1746,7 @@ type SSHConfigurationReport struct {
 
 func (x *SSHConfigurationReport) Reset() {
 	*x = SSHConfigurationReport{}
-	mi := &file_teleport_lib_vnet_diag_v1_diag_proto_msgTypes[10]
+	mi := &file_teleport_lib_vnet_diag_v1_diag_proto_msgTypes[12]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1520,7 +1758,7 @@ func (x *SSHConfigurationReport) String() string {
 func (*SSHConfigurationReport) ProtoMessage() {}
 
 func (x *SSHConfigurationReport) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_lib_vnet_diag_v1_diag_proto_msgTypes[10]
+	mi := &file_teleport_lib_vnet_diag_v1_diag_proto_msgTypes[12]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1661,19 +1899,28 @@ const file_teleport_lib_vnet_diag_v1_diag_proto_rawDesc = "" +
 	"\x04dest\x18\x01 \x01(\tR\x04dest\x12\x1b\n" +
 	"\tvnet_dest\x18\x02 \x01(\tR\bvnetDest\x12%\n" +
 	"\x0einterface_name\x18\x03 \x01(\tR\rinterfaceName\x12#\n" +
-	"\rinterface_app\x18\x04 \x01(\tR\finterfaceApp\"\xc3\x01\n" +
-	"\tDNSReport\x12,\n" +
-	"\x12vnet_dns_reachable\x18\x01 \x01(\bR\x10vnetDnsReachable\x12;\n" +
-	"\x1avnet_dns_unreachable_error\x18\x02 \x01(\tR\x17vnetDnsUnreachableError\x12K\n" +
-	"\fzone_results\x18\x03 \x03(\v2(.teleport.lib.vnet.diag.v1.DNSZoneResultR\vzoneResults\"\xbd\x01\n" +
+	"\rinterface_app\x18\x04 \x01(\tR\finterfaceApp\"\x92\x02\n" +
+	"\tDNSReport\x12[\n" +
+	"\x11ipv4_reachability\x18\x01 \x01(\v2..teleport.lib.vnet.diag.v1.VNetDNSReachabilityR\x10ipv4Reachability\x12[\n" +
+	"\x11ipv6_reachability\x18\x02 \x01(\v2..teleport.lib.vnet.diag.v1.VNetDNSReachabilityR\x10ipv6Reachability\x12K\n" +
+	"\fzone_results\x18\x03 \x03(\v2(.teleport.lib.vnet.diag.v1.DNSZoneResultR\vzoneResults\"\xab\x01\n" +
+	"\x13VNetDNSReachability\x12\x18\n" +
+	"\aaddress\x18\x01 \x01(\tR\aaddress\x12\x1c\n" +
+	"\treachable\x18\x02 \x01(\bR\treachable\x12\x1f\n" +
+	"\vresponded_a\x18\x03 \x01(\bR\n" +
+	"respondedA\x12%\n" +
+	"\x0eresponded_aaaa\x18\x04 \x01(\bR\rrespondedAaaa\x12\x14\n" +
+	"\x05error\x18\x05 \x01(\tR\x05error\"\xb1\x01\n" +
 	"\rDNSZoneResult\x12\x12\n" +
-	"\x04zone\x18\x01 \x01(\tR\x04zone\x12@\n" +
-	"\x06status\x18\x02 \x01(\x0e2(.teleport.lib.vnet.diag.v1.DNSZoneStatusR\x06status\x12\x1f\n" +
-	"\vobserved_ip\x18\x03 \x01(\tR\n" +
-	"observedIp\x12\x1f\n" +
-	"\vexpected_ip\x18\x04 \x01(\tR\n" +
-	"expectedIp\x12\x14\n" +
-	"\x05error\x18\x05 \x01(\tR\x05error\"\xde\x02\n" +
+	"\x04zone\x18\x01 \x01(\tR\x04zone\x12B\n" +
+	"\ba_record\x18\x02 \x01(\v2'.teleport.lib.vnet.diag.v1.RecordResultR\aaRecord\x12H\n" +
+	"\vaaaa_record\x18\x03 \x01(\v2'.teleport.lib.vnet.diag.v1.RecordResultR\n" +
+	"aaaaRecord\"\x87\x01\n" +
+	"\fRecordResult\x12@\n" +
+	"\x06status\x18\x01 \x01(\x0e2(.teleport.lib.vnet.diag.v1.DNSZoneStatusR\x06status\x12\x1f\n" +
+	"\vobserved_ip\x18\x02 \x01(\tR\n" +
+	"observedIp\x12\x14\n" +
+	"\x05error\x18\x03 \x01(\tR\x05error\"\xde\x02\n" +
 	"\x16SSHConfigurationReport\x127\n" +
 	"\x18user_openssh_config_path\x18\x01 \x01(\tR\x15userOpensshConfigPath\x12/\n" +
 	"\x14vnet_ssh_config_path\x18\x02 \x01(\tR\x11vnetSshConfigPath\x12\\\n" +
@@ -1701,7 +1948,7 @@ const file_teleport_lib_vnet_diag_v1_diag_proto_rawDesc = "" +
 	"\x1eDNS_ZONE_STATUS_RESOLVER_ERROR\x10\x05BQZOgithub.com/gravitational/teleport/gen/proto/go/teleport/lib/vnet/diag/v1;diagv1b\x06proto3"
 
 var file_teleport_lib_vnet_diag_v1_diag_proto_enumTypes = make([]protoimpl.EnumInfo, 4)
-var file_teleport_lib_vnet_diag_v1_diag_proto_msgTypes = make([]protoimpl.MessageInfo, 11)
+var file_teleport_lib_vnet_diag_v1_diag_proto_msgTypes = make([]protoimpl.MessageInfo, 13)
 var file_teleport_lib_vnet_diag_v1_diag_proto_goTypes = []any{
 	(CheckAttemptStatus)(0),        // 0: teleport.lib.vnet.diag.v1.CheckAttemptStatus
 	(CheckReportStatus)(0),         // 1: teleport.lib.vnet.diag.v1.CheckReportStatus
@@ -1716,12 +1963,14 @@ var file_teleport_lib_vnet_diag_v1_diag_proto_goTypes = []any{
 	(*RouteConflictReport)(nil),    // 10: teleport.lib.vnet.diag.v1.RouteConflictReport
 	(*RouteConflict)(nil),          // 11: teleport.lib.vnet.diag.v1.RouteConflict
 	(*DNSReport)(nil),              // 12: teleport.lib.vnet.diag.v1.DNSReport
-	(*DNSZoneResult)(nil),          // 13: teleport.lib.vnet.diag.v1.DNSZoneResult
-	(*SSHConfigurationReport)(nil), // 14: teleport.lib.vnet.diag.v1.SSHConfigurationReport
-	(*timestamppb.Timestamp)(nil),  // 15: google.protobuf.Timestamp
+	(*VNetDNSReachability)(nil),    // 13: teleport.lib.vnet.diag.v1.VNetDNSReachability
+	(*DNSZoneResult)(nil),          // 14: teleport.lib.vnet.diag.v1.DNSZoneResult
+	(*RecordResult)(nil),           // 15: teleport.lib.vnet.diag.v1.RecordResult
+	(*SSHConfigurationReport)(nil), // 16: teleport.lib.vnet.diag.v1.SSHConfigurationReport
+	(*timestamppb.Timestamp)(nil),  // 17: google.protobuf.Timestamp
 }
 var file_teleport_lib_vnet_diag_v1_diag_proto_depIdxs = []int32{
-	15, // 0: teleport.lib.vnet.diag.v1.Report.created_at:type_name -> google.protobuf.Timestamp
+	17, // 0: teleport.lib.vnet.diag.v1.Report.created_at:type_name -> google.protobuf.Timestamp
 	5,  // 1: teleport.lib.vnet.diag.v1.Report.network_stack_attempt:type_name -> teleport.lib.vnet.diag.v1.NetworkStackAttempt
 	7,  // 2: teleport.lib.vnet.diag.v1.Report.checks:type_name -> teleport.lib.vnet.diag.v1.CheckAttempt
 	0,  // 3: teleport.lib.vnet.diag.v1.NetworkStackAttempt.status:type_name -> teleport.lib.vnet.diag.v1.CheckAttemptStatus
@@ -1731,17 +1980,21 @@ var file_teleport_lib_vnet_diag_v1_diag_proto_depIdxs = []int32{
 	9,  // 7: teleport.lib.vnet.diag.v1.CheckAttempt.commands:type_name -> teleport.lib.vnet.diag.v1.CommandAttempt
 	1,  // 8: teleport.lib.vnet.diag.v1.CheckReport.status:type_name -> teleport.lib.vnet.diag.v1.CheckReportStatus
 	10, // 9: teleport.lib.vnet.diag.v1.CheckReport.route_conflict_report:type_name -> teleport.lib.vnet.diag.v1.RouteConflictReport
-	14, // 10: teleport.lib.vnet.diag.v1.CheckReport.ssh_configuration_report:type_name -> teleport.lib.vnet.diag.v1.SSHConfigurationReport
+	16, // 10: teleport.lib.vnet.diag.v1.CheckReport.ssh_configuration_report:type_name -> teleport.lib.vnet.diag.v1.SSHConfigurationReport
 	12, // 11: teleport.lib.vnet.diag.v1.CheckReport.dns_report:type_name -> teleport.lib.vnet.diag.v1.DNSReport
 	2,  // 12: teleport.lib.vnet.diag.v1.CommandAttempt.status:type_name -> teleport.lib.vnet.diag.v1.CommandAttemptStatus
 	11, // 13: teleport.lib.vnet.diag.v1.RouteConflictReport.route_conflicts:type_name -> teleport.lib.vnet.diag.v1.RouteConflict
-	13, // 14: teleport.lib.vnet.diag.v1.DNSReport.zone_results:type_name -> teleport.lib.vnet.diag.v1.DNSZoneResult
-	3,  // 15: teleport.lib.vnet.diag.v1.DNSZoneResult.status:type_name -> teleport.lib.vnet.diag.v1.DNSZoneStatus
-	16, // [16:16] is the sub-list for method output_type
-	16, // [16:16] is the sub-list for method input_type
-	16, // [16:16] is the sub-list for extension type_name
-	16, // [16:16] is the sub-list for extension extendee
-	0,  // [0:16] is the sub-list for field type_name
+	13, // 14: teleport.lib.vnet.diag.v1.DNSReport.ipv4_reachability:type_name -> teleport.lib.vnet.diag.v1.VNetDNSReachability
+	13, // 15: teleport.lib.vnet.diag.v1.DNSReport.ipv6_reachability:type_name -> teleport.lib.vnet.diag.v1.VNetDNSReachability
+	14, // 16: teleport.lib.vnet.diag.v1.DNSReport.zone_results:type_name -> teleport.lib.vnet.diag.v1.DNSZoneResult
+	15, // 17: teleport.lib.vnet.diag.v1.DNSZoneResult.a_record:type_name -> teleport.lib.vnet.diag.v1.RecordResult
+	15, // 18: teleport.lib.vnet.diag.v1.DNSZoneResult.aaaa_record:type_name -> teleport.lib.vnet.diag.v1.RecordResult
+	3,  // 19: teleport.lib.vnet.diag.v1.RecordResult.status:type_name -> teleport.lib.vnet.diag.v1.DNSZoneStatus
+	20, // [20:20] is the sub-list for method output_type
+	20, // [20:20] is the sub-list for method input_type
+	20, // [20:20] is the sub-list for extension type_name
+	20, // [20:20] is the sub-list for extension extendee
+	0,  // [0:20] is the sub-list for field type_name
 }
 
 func init() { file_teleport_lib_vnet_diag_v1_diag_proto_init() }
@@ -1760,7 +2013,7 @@ func file_teleport_lib_vnet_diag_v1_diag_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_teleport_lib_vnet_diag_v1_diag_proto_rawDesc), len(file_teleport_lib_vnet_diag_v1_diag_proto_rawDesc)),
 			NumEnums:      4,
-			NumMessages:   11,
+			NumMessages:   13,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/gen/proto/go/teleport/lib/vnet/diag/v1/diag.pb.go
+++ b/gen/proto/go/teleport/lib/vnet/diag/v1/diag.pb.go
@@ -180,6 +180,68 @@ func (x CommandAttemptStatus) Number() protoreflect.EnumNumber {
 	return protoreflect.EnumNumber(x)
 }
 
+// DNSZoneStatus is the outcome of querying a probe hostname for a single DNS zone.
+type DNSZoneStatus int32
+
+const (
+	DNSZoneStatus_DNS_ZONE_STATUS_UNSPECIFIED DNSZoneStatus = 0
+	// DNS_ZONE_STATUS_OK indicates the system resolver returned the IP we expected from VNet's
+	// nameserver, so per-zone routing works.
+	DNSZoneStatus_DNS_ZONE_STATUS_OK DNSZoneStatus = 1
+	// DNS_ZONE_STATUS_HIJACKED indicates the system resolver returned an IP, but not the one VNet
+	// returned. Some other resolver answered for this zone.
+	DNSZoneStatus_DNS_ZONE_STATUS_HIJACKED DNSZoneStatus = 2
+	// DNS_ZONE_STATUS_NOT_REGISTERED indicates the system resolver returned NXDOMAIN or SERVFAIL.
+	DNSZoneStatus_DNS_ZONE_STATUS_NOT_REGISTERED DNSZoneStatus = 3
+	// DNS_ZONE_STATUS_TIMEOUT indicates the system resolver query timed out, likely because it
+	// was routed to a nameserver that is unreachable.
+	DNSZoneStatus_DNS_ZONE_STATUS_TIMEOUT DNSZoneStatus = 4
+	// DNS_ZONE_STATUS_RESOLVER_ERROR indicates an unexpected error from the system resolver.
+	DNSZoneStatus_DNS_ZONE_STATUS_RESOLVER_ERROR DNSZoneStatus = 5
+)
+
+// Enum value maps for DNSZoneStatus.
+var (
+	DNSZoneStatus_name = map[int32]string{
+		0: "DNS_ZONE_STATUS_UNSPECIFIED",
+		1: "DNS_ZONE_STATUS_OK",
+		2: "DNS_ZONE_STATUS_HIJACKED",
+		3: "DNS_ZONE_STATUS_NOT_REGISTERED",
+		4: "DNS_ZONE_STATUS_TIMEOUT",
+		5: "DNS_ZONE_STATUS_RESOLVER_ERROR",
+	}
+	DNSZoneStatus_value = map[string]int32{
+		"DNS_ZONE_STATUS_UNSPECIFIED":    0,
+		"DNS_ZONE_STATUS_OK":             1,
+		"DNS_ZONE_STATUS_HIJACKED":       2,
+		"DNS_ZONE_STATUS_NOT_REGISTERED": 3,
+		"DNS_ZONE_STATUS_TIMEOUT":        4,
+		"DNS_ZONE_STATUS_RESOLVER_ERROR": 5,
+	}
+)
+
+func (x DNSZoneStatus) Enum() *DNSZoneStatus {
+	p := new(DNSZoneStatus)
+	*p = x
+	return p
+}
+
+func (x DNSZoneStatus) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (DNSZoneStatus) Descriptor() protoreflect.EnumDescriptor {
+	return file_teleport_lib_vnet_diag_v1_diag_proto_enumTypes[3].Descriptor()
+}
+
+func (DNSZoneStatus) Type() protoreflect.EnumType {
+	return &file_teleport_lib_vnet_diag_v1_diag_proto_enumTypes[3]
+}
+
+func (x DNSZoneStatus) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
 // Report represents the attempts at running individual checks. It also includes general information
 // about the network stack managed by VNet. It assumes that each individual check as well as getting
 // info about the network stack can fail.
@@ -661,6 +723,7 @@ type CheckReport struct {
 	//
 	//	*CheckReport_RouteConflictReport
 	//	*CheckReport_SshConfigurationReport
+	//	*CheckReport_DnsReport
 	Report        isCheckReport_Report `protobuf_oneof:"report"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
@@ -723,6 +786,15 @@ func (x *CheckReport) GetSshConfigurationReport() *SSHConfigurationReport {
 	return nil
 }
 
+func (x *CheckReport) GetDnsReport() *DNSReport {
+	if x != nil {
+		if x, ok := x.Report.(*CheckReport_DnsReport); ok {
+			return x.DnsReport
+		}
+	}
+	return nil
+}
+
 func (x *CheckReport) SetStatus(v CheckReportStatus) {
 	x.Status = v
 }
@@ -741,6 +813,14 @@ func (x *CheckReport) SetSshConfigurationReport(v *SSHConfigurationReport) {
 		return
 	}
 	x.Report = &CheckReport_SshConfigurationReport{v}
+}
+
+func (x *CheckReport) SetDnsReport(v *DNSReport) {
+	if v == nil {
+		x.Report = nil
+		return
+	}
+	x.Report = &CheckReport_DnsReport{v}
 }
 
 func (x *CheckReport) HasReport() bool {
@@ -766,6 +846,14 @@ func (x *CheckReport) HasSshConfigurationReport() bool {
 	return ok
 }
 
+func (x *CheckReport) HasDnsReport() bool {
+	if x == nil {
+		return false
+	}
+	_, ok := x.Report.(*CheckReport_DnsReport)
+	return ok
+}
+
 func (x *CheckReport) ClearReport() {
 	x.Report = nil
 }
@@ -782,9 +870,16 @@ func (x *CheckReport) ClearSshConfigurationReport() {
 	}
 }
 
+func (x *CheckReport) ClearDnsReport() {
+	if _, ok := x.Report.(*CheckReport_DnsReport); ok {
+		x.Report = nil
+	}
+}
+
 const CheckReport_Report_not_set_case case_CheckReport_Report = 0
 const CheckReport_RouteConflictReport_case case_CheckReport_Report = 2
 const CheckReport_SshConfigurationReport_case case_CheckReport_Report = 3
+const CheckReport_DnsReport_case case_CheckReport_Report = 4
 
 func (x *CheckReport) WhichReport() case_CheckReport_Report {
 	if x == nil {
@@ -795,6 +890,8 @@ func (x *CheckReport) WhichReport() case_CheckReport_Report {
 		return CheckReport_RouteConflictReport_case
 	case *CheckReport_SshConfigurationReport:
 		return CheckReport_SshConfigurationReport_case
+	case *CheckReport_DnsReport:
+		return CheckReport_DnsReport_case
 	default:
 		return CheckReport_Report_not_set_case
 	}
@@ -813,6 +910,9 @@ type CheckReport_builder struct {
 	RouteConflictReport *RouteConflictReport
 	// ssh_configuration_report reports the status of the system's SSH configuration.
 	SshConfigurationReport *SSHConfigurationReport
+	// dns_report reports whether the system resolver routes queries for each VNet-managed DNS zone
+	// to VNet's nameserver.
+	DnsReport *DNSReport
 	// -- end of Report
 }
 
@@ -826,6 +926,9 @@ func (b0 CheckReport_builder) Build() *CheckReport {
 	}
 	if b.SshConfigurationReport != nil {
 		x.Report = &CheckReport_SshConfigurationReport{b.SshConfigurationReport}
+	}
+	if b.DnsReport != nil {
+		x.Report = &CheckReport_DnsReport{b.DnsReport}
 	}
 	return m0
 }
@@ -855,9 +958,17 @@ type CheckReport_SshConfigurationReport struct {
 	SshConfigurationReport *SSHConfigurationReport `protobuf:"bytes,3,opt,name=ssh_configuration_report,json=sshConfigurationReport,proto3,oneof"`
 }
 
+type CheckReport_DnsReport struct {
+	// dns_report reports whether the system resolver routes queries for each VNet-managed DNS zone
+	// to VNet's nameserver.
+	DnsReport *DNSReport `protobuf:"bytes,4,opt,name=dns_report,json=dnsReport,proto3,oneof"`
+}
+
 func (*CheckReport_RouteConflictReport) isCheckReport_Report() {}
 
 func (*CheckReport_SshConfigurationReport) isCheckReport_Report() {}
+
+func (*CheckReport_DnsReport) isCheckReport_Report() {}
 
 // CommandAttempt describes the attempt at running a particular command associated with a diagnostic
 // check.
@@ -1139,6 +1250,240 @@ func (b0 RouteConflict_builder) Build() *RouteConflict {
 	return m0
 }
 
+// DNSReport describes whether the system resolver routes DNS queries for VNet-managed zones to
+// VNet's nameserver. It is the output of DNSDiag.
+//
+// The check uses a probe hostname of the form vnet-diag-<random>.<zone>. VNet's nameserver
+// short-circuits any query with this prefix and answers with an address derived from its IPv6
+// prefix, an address no other resolver can produce. The random label prevents DNS caches.
+//
+// The check first queries the probe directly against VNet's nameserver IP to confirm VNet's DNS
+// server is reachable and to capture the expected response. If that fails, vnet_dns_reachable is
+// false, vnet_dns_unreachable_error stores the error, and zone_results is empty. Otherwise, the
+// check runs the same probe query per zone through the system resolver and compares each answer to
+// the expected response. A mismatch means the per-zone OS resolver entry does not route to VNet.
+type DNSReport struct {
+	state protoimpl.MessageState `protogen:"hybrid.v1"`
+	// vnet_dns_reachable is true if a direct DNS query to VNet's nameserver IP succeeded.
+	VnetDnsReachable bool `protobuf:"varint,1,opt,name=vnet_dns_reachable,json=vnetDnsReachable,proto3" json:"vnet_dns_reachable,omitempty"`
+	// vnet_dns_unreachable_error is set when vnet_dns_reachable is false.
+	VnetDnsUnreachableError string `protobuf:"bytes,2,opt,name=vnet_dns_unreachable_error,json=vnetDnsUnreachableError,proto3" json:"vnet_dns_unreachable_error,omitempty"`
+	// zone_results contains one entry per zone in NetworkStack.dns_zones. Empty if
+	// vnet_dns_reachable is false.
+	ZoneResults   []*DNSZoneResult `protobuf:"bytes,3,rep,name=zone_results,json=zoneResults,proto3" json:"zone_results,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *DNSReport) Reset() {
+	*x = DNSReport{}
+	mi := &file_teleport_lib_vnet_diag_v1_diag_proto_msgTypes[8]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *DNSReport) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*DNSReport) ProtoMessage() {}
+
+func (x *DNSReport) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_lib_vnet_diag_v1_diag_proto_msgTypes[8]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+func (x *DNSReport) GetVnetDnsReachable() bool {
+	if x != nil {
+		return x.VnetDnsReachable
+	}
+	return false
+}
+
+func (x *DNSReport) GetVnetDnsUnreachableError() string {
+	if x != nil {
+		return x.VnetDnsUnreachableError
+	}
+	return ""
+}
+
+func (x *DNSReport) GetZoneResults() []*DNSZoneResult {
+	if x != nil {
+		return x.ZoneResults
+	}
+	return nil
+}
+
+func (x *DNSReport) SetVnetDnsReachable(v bool) {
+	x.VnetDnsReachable = v
+}
+
+func (x *DNSReport) SetVnetDnsUnreachableError(v string) {
+	x.VnetDnsUnreachableError = v
+}
+
+func (x *DNSReport) SetZoneResults(v []*DNSZoneResult) {
+	x.ZoneResults = v
+}
+
+type DNSReport_builder struct {
+	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
+
+	// vnet_dns_reachable is true if a direct DNS query to VNet's nameserver IP succeeded.
+	VnetDnsReachable bool
+	// vnet_dns_unreachable_error is set when vnet_dns_reachable is false.
+	VnetDnsUnreachableError string
+	// zone_results contains one entry per zone in NetworkStack.dns_zones. Empty if
+	// vnet_dns_reachable is false.
+	ZoneResults []*DNSZoneResult
+}
+
+func (b0 DNSReport_builder) Build() *DNSReport {
+	m0 := &DNSReport{}
+	b, x := &b0, m0
+	_, _ = b, x
+	x.VnetDnsReachable = b.VnetDnsReachable
+	x.VnetDnsUnreachableError = b.VnetDnsUnreachableError
+	x.ZoneResults = b.ZoneResults
+	return m0
+}
+
+// DNSZoneResult describes the outcome of querying a probe hostname under a single VNet-managed
+// DNS zone through the system resolver.
+type DNSZoneResult struct {
+	state protoimpl.MessageState `protogen:"hybrid.v1"`
+	// zone is the DNS zone that was tested, e.g. "company.test".
+	Zone string `protobuf:"bytes,1,opt,name=zone,proto3" json:"zone,omitempty"`
+	// status describes the outcome of the query.
+	Status DNSZoneStatus `protobuf:"varint,2,opt,name=status,proto3,enum=teleport.lib.vnet.diag.v1.DNSZoneStatus" json:"status,omitempty"`
+	// observed_ip is the IP returned by the system resolver for the probe hostname. Empty on
+	// timeout or no answer.
+	ObservedIp string `protobuf:"bytes,3,opt,name=observed_ip,json=observedIp,proto3" json:"observed_ip,omitempty"`
+	// expected_ip is the IP that VNet's nameserver returned for the same probe hostname when
+	// queried directly.
+	ExpectedIp string `protobuf:"bytes,4,opt,name=expected_ip,json=expectedIp,proto3" json:"expected_ip,omitempty"`
+	// error is set on DNS_ZONE_STATUS_TIMEOUT and DNS_ZONE_STATUS_RESOLVER_ERROR.
+	Error         string `protobuf:"bytes,5,opt,name=error,proto3" json:"error,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *DNSZoneResult) Reset() {
+	*x = DNSZoneResult{}
+	mi := &file_teleport_lib_vnet_diag_v1_diag_proto_msgTypes[9]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *DNSZoneResult) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*DNSZoneResult) ProtoMessage() {}
+
+func (x *DNSZoneResult) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_lib_vnet_diag_v1_diag_proto_msgTypes[9]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+func (x *DNSZoneResult) GetZone() string {
+	if x != nil {
+		return x.Zone
+	}
+	return ""
+}
+
+func (x *DNSZoneResult) GetStatus() DNSZoneStatus {
+	if x != nil {
+		return x.Status
+	}
+	return DNSZoneStatus_DNS_ZONE_STATUS_UNSPECIFIED
+}
+
+func (x *DNSZoneResult) GetObservedIp() string {
+	if x != nil {
+		return x.ObservedIp
+	}
+	return ""
+}
+
+func (x *DNSZoneResult) GetExpectedIp() string {
+	if x != nil {
+		return x.ExpectedIp
+	}
+	return ""
+}
+
+func (x *DNSZoneResult) GetError() string {
+	if x != nil {
+		return x.Error
+	}
+	return ""
+}
+
+func (x *DNSZoneResult) SetZone(v string) {
+	x.Zone = v
+}
+
+func (x *DNSZoneResult) SetStatus(v DNSZoneStatus) {
+	x.Status = v
+}
+
+func (x *DNSZoneResult) SetObservedIp(v string) {
+	x.ObservedIp = v
+}
+
+func (x *DNSZoneResult) SetExpectedIp(v string) {
+	x.ExpectedIp = v
+}
+
+func (x *DNSZoneResult) SetError(v string) {
+	x.Error = v
+}
+
+type DNSZoneResult_builder struct {
+	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
+
+	// zone is the DNS zone that was tested, e.g. "company.test".
+	Zone string
+	// status describes the outcome of the query.
+	Status DNSZoneStatus
+	// observed_ip is the IP returned by the system resolver for the probe hostname. Empty on
+	// timeout or no answer.
+	ObservedIp string
+	// expected_ip is the IP that VNet's nameserver returned for the same probe hostname when
+	// queried directly.
+	ExpectedIp string
+	// error is set on DNS_ZONE_STATUS_TIMEOUT and DNS_ZONE_STATUS_RESOLVER_ERROR.
+	Error string
+}
+
+func (b0 DNSZoneResult_builder) Build() *DNSZoneResult {
+	m0 := &DNSZoneResult{}
+	b, x := &b0, m0
+	_, _ = b, x
+	x.Zone = b.Zone
+	x.Status = b.Status
+	x.ObservedIp = b.ObservedIp
+	x.ExpectedIp = b.ExpectedIp
+	x.Error = b.Error
+	return m0
+}
+
 // SSHConfigurationReport describes the state of the system's SSH configuration.
 type SSHConfigurationReport struct {
 	state protoimpl.MessageState `protogen:"hybrid.v1"`
@@ -1163,7 +1508,7 @@ type SSHConfigurationReport struct {
 
 func (x *SSHConfigurationReport) Reset() {
 	*x = SSHConfigurationReport{}
-	mi := &file_teleport_lib_vnet_diag_v1_diag_proto_msgTypes[8]
+	mi := &file_teleport_lib_vnet_diag_v1_diag_proto_msgTypes[10]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1175,7 +1520,7 @@ func (x *SSHConfigurationReport) String() string {
 func (*SSHConfigurationReport) ProtoMessage() {}
 
 func (x *SSHConfigurationReport) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_lib_vnet_diag_v1_diag_proto_msgTypes[8]
+	mi := &file_teleport_lib_vnet_diag_v1_diag_proto_msgTypes[10]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1297,11 +1642,13 @@ const file_teleport_lib_vnet_diag_v1_diag_proto_rawDesc = "" +
 	"\x06status\x18\x01 \x01(\x0e2-.teleport.lib.vnet.diag.v1.CheckAttemptStatusR\x06status\x12\x14\n" +
 	"\x05error\x18\x02 \x01(\tR\x05error\x12I\n" +
 	"\fcheck_report\x18\x03 \x01(\v2&.teleport.lib.vnet.diag.v1.CheckReportR\vcheckReport\x12E\n" +
-	"\bcommands\x18\x04 \x03(\v2).teleport.lib.vnet.diag.v1.CommandAttemptR\bcommands\"\xb2\x02\n" +
+	"\bcommands\x18\x04 \x03(\v2).teleport.lib.vnet.diag.v1.CommandAttemptR\bcommands\"\xf9\x02\n" +
 	"\vCheckReport\x12D\n" +
 	"\x06status\x18\x01 \x01(\x0e2,.teleport.lib.vnet.diag.v1.CheckReportStatusR\x06status\x12d\n" +
 	"\x15route_conflict_report\x18\x02 \x01(\v2..teleport.lib.vnet.diag.v1.RouteConflictReportH\x00R\x13routeConflictReport\x12m\n" +
-	"\x18ssh_configuration_report\x18\x03 \x01(\v21.teleport.lib.vnet.diag.v1.SSHConfigurationReportH\x00R\x16sshConfigurationReportB\b\n" +
+	"\x18ssh_configuration_report\x18\x03 \x01(\v21.teleport.lib.vnet.diag.v1.SSHConfigurationReportH\x00R\x16sshConfigurationReport\x12E\n" +
+	"\n" +
+	"dns_report\x18\x04 \x01(\v2$.teleport.lib.vnet.diag.v1.DNSReportH\x00R\tdnsReportB\b\n" +
 	"\x06report\"\xa1\x01\n" +
 	"\x0eCommandAttempt\x12G\n" +
 	"\x06status\x18\x01 \x01(\x0e2/.teleport.lib.vnet.diag.v1.CommandAttemptStatusR\x06status\x12\x14\n" +
@@ -1314,7 +1661,19 @@ const file_teleport_lib_vnet_diag_v1_diag_proto_rawDesc = "" +
 	"\x04dest\x18\x01 \x01(\tR\x04dest\x12\x1b\n" +
 	"\tvnet_dest\x18\x02 \x01(\tR\bvnetDest\x12%\n" +
 	"\x0einterface_name\x18\x03 \x01(\tR\rinterfaceName\x12#\n" +
-	"\rinterface_app\x18\x04 \x01(\tR\finterfaceApp\"\xde\x02\n" +
+	"\rinterface_app\x18\x04 \x01(\tR\finterfaceApp\"\xc3\x01\n" +
+	"\tDNSReport\x12,\n" +
+	"\x12vnet_dns_reachable\x18\x01 \x01(\bR\x10vnetDnsReachable\x12;\n" +
+	"\x1avnet_dns_unreachable_error\x18\x02 \x01(\tR\x17vnetDnsUnreachableError\x12K\n" +
+	"\fzone_results\x18\x03 \x03(\v2(.teleport.lib.vnet.diag.v1.DNSZoneResultR\vzoneResults\"\xbd\x01\n" +
+	"\rDNSZoneResult\x12\x12\n" +
+	"\x04zone\x18\x01 \x01(\tR\x04zone\x12@\n" +
+	"\x06status\x18\x02 \x01(\x0e2(.teleport.lib.vnet.diag.v1.DNSZoneStatusR\x06status\x12\x1f\n" +
+	"\vobserved_ip\x18\x03 \x01(\tR\n" +
+	"observedIp\x12\x1f\n" +
+	"\vexpected_ip\x18\x04 \x01(\tR\n" +
+	"expectedIp\x12\x14\n" +
+	"\x05error\x18\x05 \x01(\tR\x05error\"\xde\x02\n" +
 	"\x16SSHConfigurationReport\x127\n" +
 	"\x18user_openssh_config_path\x18\x01 \x01(\tR\x15userOpensshConfigPath\x12/\n" +
 	"\x14vnet_ssh_config_path\x18\x02 \x01(\tR\x11vnetSshConfigPath\x12\\\n" +
@@ -1332,44 +1691,57 @@ const file_teleport_lib_vnet_diag_v1_diag_proto_rawDesc = "" +
 	"\x14CommandAttemptStatus\x12&\n" +
 	"\"COMMAND_ATTEMPT_STATUS_UNSPECIFIED\x10\x00\x12\x1d\n" +
 	"\x19COMMAND_ATTEMPT_STATUS_OK\x10\x01\x12 \n" +
-	"\x1cCOMMAND_ATTEMPT_STATUS_ERROR\x10\x02BQZOgithub.com/gravitational/teleport/gen/proto/go/teleport/lib/vnet/diag/v1;diagv1b\x06proto3"
+	"\x1cCOMMAND_ATTEMPT_STATUS_ERROR\x10\x02*\xcb\x01\n" +
+	"\rDNSZoneStatus\x12\x1f\n" +
+	"\x1bDNS_ZONE_STATUS_UNSPECIFIED\x10\x00\x12\x16\n" +
+	"\x12DNS_ZONE_STATUS_OK\x10\x01\x12\x1c\n" +
+	"\x18DNS_ZONE_STATUS_HIJACKED\x10\x02\x12\"\n" +
+	"\x1eDNS_ZONE_STATUS_NOT_REGISTERED\x10\x03\x12\x1b\n" +
+	"\x17DNS_ZONE_STATUS_TIMEOUT\x10\x04\x12\"\n" +
+	"\x1eDNS_ZONE_STATUS_RESOLVER_ERROR\x10\x05BQZOgithub.com/gravitational/teleport/gen/proto/go/teleport/lib/vnet/diag/v1;diagv1b\x06proto3"
 
-var file_teleport_lib_vnet_diag_v1_diag_proto_enumTypes = make([]protoimpl.EnumInfo, 3)
-var file_teleport_lib_vnet_diag_v1_diag_proto_msgTypes = make([]protoimpl.MessageInfo, 9)
+var file_teleport_lib_vnet_diag_v1_diag_proto_enumTypes = make([]protoimpl.EnumInfo, 4)
+var file_teleport_lib_vnet_diag_v1_diag_proto_msgTypes = make([]protoimpl.MessageInfo, 11)
 var file_teleport_lib_vnet_diag_v1_diag_proto_goTypes = []any{
 	(CheckAttemptStatus)(0),        // 0: teleport.lib.vnet.diag.v1.CheckAttemptStatus
 	(CheckReportStatus)(0),         // 1: teleport.lib.vnet.diag.v1.CheckReportStatus
 	(CommandAttemptStatus)(0),      // 2: teleport.lib.vnet.diag.v1.CommandAttemptStatus
-	(*Report)(nil),                 // 3: teleport.lib.vnet.diag.v1.Report
-	(*NetworkStackAttempt)(nil),    // 4: teleport.lib.vnet.diag.v1.NetworkStackAttempt
-	(*NetworkStack)(nil),           // 5: teleport.lib.vnet.diag.v1.NetworkStack
-	(*CheckAttempt)(nil),           // 6: teleport.lib.vnet.diag.v1.CheckAttempt
-	(*CheckReport)(nil),            // 7: teleport.lib.vnet.diag.v1.CheckReport
-	(*CommandAttempt)(nil),         // 8: teleport.lib.vnet.diag.v1.CommandAttempt
-	(*RouteConflictReport)(nil),    // 9: teleport.lib.vnet.diag.v1.RouteConflictReport
-	(*RouteConflict)(nil),          // 10: teleport.lib.vnet.diag.v1.RouteConflict
-	(*SSHConfigurationReport)(nil), // 11: teleport.lib.vnet.diag.v1.SSHConfigurationReport
-	(*timestamppb.Timestamp)(nil),  // 12: google.protobuf.Timestamp
+	(DNSZoneStatus)(0),             // 3: teleport.lib.vnet.diag.v1.DNSZoneStatus
+	(*Report)(nil),                 // 4: teleport.lib.vnet.diag.v1.Report
+	(*NetworkStackAttempt)(nil),    // 5: teleport.lib.vnet.diag.v1.NetworkStackAttempt
+	(*NetworkStack)(nil),           // 6: teleport.lib.vnet.diag.v1.NetworkStack
+	(*CheckAttempt)(nil),           // 7: teleport.lib.vnet.diag.v1.CheckAttempt
+	(*CheckReport)(nil),            // 8: teleport.lib.vnet.diag.v1.CheckReport
+	(*CommandAttempt)(nil),         // 9: teleport.lib.vnet.diag.v1.CommandAttempt
+	(*RouteConflictReport)(nil),    // 10: teleport.lib.vnet.diag.v1.RouteConflictReport
+	(*RouteConflict)(nil),          // 11: teleport.lib.vnet.diag.v1.RouteConflict
+	(*DNSReport)(nil),              // 12: teleport.lib.vnet.diag.v1.DNSReport
+	(*DNSZoneResult)(nil),          // 13: teleport.lib.vnet.diag.v1.DNSZoneResult
+	(*SSHConfigurationReport)(nil), // 14: teleport.lib.vnet.diag.v1.SSHConfigurationReport
+	(*timestamppb.Timestamp)(nil),  // 15: google.protobuf.Timestamp
 }
 var file_teleport_lib_vnet_diag_v1_diag_proto_depIdxs = []int32{
-	12, // 0: teleport.lib.vnet.diag.v1.Report.created_at:type_name -> google.protobuf.Timestamp
-	4,  // 1: teleport.lib.vnet.diag.v1.Report.network_stack_attempt:type_name -> teleport.lib.vnet.diag.v1.NetworkStackAttempt
-	6,  // 2: teleport.lib.vnet.diag.v1.Report.checks:type_name -> teleport.lib.vnet.diag.v1.CheckAttempt
+	15, // 0: teleport.lib.vnet.diag.v1.Report.created_at:type_name -> google.protobuf.Timestamp
+	5,  // 1: teleport.lib.vnet.diag.v1.Report.network_stack_attempt:type_name -> teleport.lib.vnet.diag.v1.NetworkStackAttempt
+	7,  // 2: teleport.lib.vnet.diag.v1.Report.checks:type_name -> teleport.lib.vnet.diag.v1.CheckAttempt
 	0,  // 3: teleport.lib.vnet.diag.v1.NetworkStackAttempt.status:type_name -> teleport.lib.vnet.diag.v1.CheckAttemptStatus
-	5,  // 4: teleport.lib.vnet.diag.v1.NetworkStackAttempt.network_stack:type_name -> teleport.lib.vnet.diag.v1.NetworkStack
+	6,  // 4: teleport.lib.vnet.diag.v1.NetworkStackAttempt.network_stack:type_name -> teleport.lib.vnet.diag.v1.NetworkStack
 	0,  // 5: teleport.lib.vnet.diag.v1.CheckAttempt.status:type_name -> teleport.lib.vnet.diag.v1.CheckAttemptStatus
-	7,  // 6: teleport.lib.vnet.diag.v1.CheckAttempt.check_report:type_name -> teleport.lib.vnet.diag.v1.CheckReport
-	8,  // 7: teleport.lib.vnet.diag.v1.CheckAttempt.commands:type_name -> teleport.lib.vnet.diag.v1.CommandAttempt
+	8,  // 6: teleport.lib.vnet.diag.v1.CheckAttempt.check_report:type_name -> teleport.lib.vnet.diag.v1.CheckReport
+	9,  // 7: teleport.lib.vnet.diag.v1.CheckAttempt.commands:type_name -> teleport.lib.vnet.diag.v1.CommandAttempt
 	1,  // 8: teleport.lib.vnet.diag.v1.CheckReport.status:type_name -> teleport.lib.vnet.diag.v1.CheckReportStatus
-	9,  // 9: teleport.lib.vnet.diag.v1.CheckReport.route_conflict_report:type_name -> teleport.lib.vnet.diag.v1.RouteConflictReport
-	11, // 10: teleport.lib.vnet.diag.v1.CheckReport.ssh_configuration_report:type_name -> teleport.lib.vnet.diag.v1.SSHConfigurationReport
-	2,  // 11: teleport.lib.vnet.diag.v1.CommandAttempt.status:type_name -> teleport.lib.vnet.diag.v1.CommandAttemptStatus
-	10, // 12: teleport.lib.vnet.diag.v1.RouteConflictReport.route_conflicts:type_name -> teleport.lib.vnet.diag.v1.RouteConflict
-	13, // [13:13] is the sub-list for method output_type
-	13, // [13:13] is the sub-list for method input_type
-	13, // [13:13] is the sub-list for extension type_name
-	13, // [13:13] is the sub-list for extension extendee
-	0,  // [0:13] is the sub-list for field type_name
+	10, // 9: teleport.lib.vnet.diag.v1.CheckReport.route_conflict_report:type_name -> teleport.lib.vnet.diag.v1.RouteConflictReport
+	14, // 10: teleport.lib.vnet.diag.v1.CheckReport.ssh_configuration_report:type_name -> teleport.lib.vnet.diag.v1.SSHConfigurationReport
+	12, // 11: teleport.lib.vnet.diag.v1.CheckReport.dns_report:type_name -> teleport.lib.vnet.diag.v1.DNSReport
+	2,  // 12: teleport.lib.vnet.diag.v1.CommandAttempt.status:type_name -> teleport.lib.vnet.diag.v1.CommandAttemptStatus
+	11, // 13: teleport.lib.vnet.diag.v1.RouteConflictReport.route_conflicts:type_name -> teleport.lib.vnet.diag.v1.RouteConflict
+	13, // 14: teleport.lib.vnet.diag.v1.DNSReport.zone_results:type_name -> teleport.lib.vnet.diag.v1.DNSZoneResult
+	3,  // 15: teleport.lib.vnet.diag.v1.DNSZoneResult.status:type_name -> teleport.lib.vnet.diag.v1.DNSZoneStatus
+	16, // [16:16] is the sub-list for method output_type
+	16, // [16:16] is the sub-list for method input_type
+	16, // [16:16] is the sub-list for extension type_name
+	16, // [16:16] is the sub-list for extension extendee
+	0,  // [0:16] is the sub-list for field type_name
 }
 
 func init() { file_teleport_lib_vnet_diag_v1_diag_proto_init() }
@@ -1380,14 +1752,15 @@ func file_teleport_lib_vnet_diag_v1_diag_proto_init() {
 	file_teleport_lib_vnet_diag_v1_diag_proto_msgTypes[4].OneofWrappers = []any{
 		(*CheckReport_RouteConflictReport)(nil),
 		(*CheckReport_SshConfigurationReport)(nil),
+		(*CheckReport_DnsReport)(nil),
 	}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_teleport_lib_vnet_diag_v1_diag_proto_rawDesc), len(file_teleport_lib_vnet_diag_v1_diag_proto_rawDesc)),
-			NumEnums:      3,
-			NumMessages:   9,
+			NumEnums:      4,
+			NumMessages:   11,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/gen/proto/go/teleport/lib/vnet/diag/v1/diag.pb.go
+++ b/gen/proto/go/teleport/lib/vnet/diag/v1/diag.pb.go
@@ -1516,11 +1516,15 @@ type DNSZoneResult struct {
 	state protoimpl.MessageState `protogen:"hybrid.v1"`
 	// zone is the DNS zone that was tested, e.g. "company.test".
 	Zone string `protobuf:"bytes,1,opt,name=zone,proto3" json:"zone,omitempty"`
-	// a_record is the outcome of the A-record part of the per-zone query. Null if no expected A was
-	// captured.
+	// a_record is the outcome of the A-record query for this zone, compared to the
+	// A returned by VNet's DNS server on direct query. The check is skipped and
+	// this field is null when VNet's DNS server failed to return an A on direct
+	// query.
 	ARecord *RecordResult `protobuf:"bytes,2,opt,name=a_record,json=aRecord,proto3" json:"a_record,omitempty"`
-	// aaaa_record is the outcome of the AAAA-record part of the per-zone query. Null if no expected
-	// AAAA was captured.
+	// aaaa_record is the outcome of the AAAA-record query for this zone, compared
+	// to the AAAA returned by VNet's DNS server on direct query. The check is
+	// skipped and this field is null when VNet's DNS server failed to return an
+	// AAAA on direct query.
 	AaaaRecord    *RecordResult `protobuf:"bytes,3,opt,name=aaaa_record,json=aaaaRecord,proto3" json:"aaaa_record,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
@@ -1611,11 +1615,15 @@ type DNSZoneResult_builder struct {
 
 	// zone is the DNS zone that was tested, e.g. "company.test".
 	Zone string
-	// a_record is the outcome of the A-record part of the per-zone query. Null if no expected A was
-	// captured.
+	// a_record is the outcome of the A-record query for this zone, compared to the
+	// A returned by VNet's DNS server on direct query. The check is skipped and
+	// this field is null when VNet's DNS server failed to return an A on direct
+	// query.
 	ARecord *RecordResult
-	// aaaa_record is the outcome of the AAAA-record part of the per-zone query. Null if no expected
-	// AAAA was captured.
+	// aaaa_record is the outcome of the AAAA-record query for this zone, compared
+	// to the AAAA returned by VNet's DNS server on direct query. The check is
+	// skipped and this field is null when VNet's DNS server failed to return an
+	// AAAA on direct query.
 	AaaaRecord *RecordResult
 }
 

--- a/gen/proto/go/teleport/lib/vnet/diag/v1/diag_protoopaque.pb.go
+++ b/gen/proto/go/teleport/lib/vnet/diag/v1/diag_protoopaque.pb.go
@@ -180,6 +180,68 @@ func (x CommandAttemptStatus) Number() protoreflect.EnumNumber {
 	return protoreflect.EnumNumber(x)
 }
 
+// DNSZoneStatus is the outcome of querying a probe hostname for a single DNS zone.
+type DNSZoneStatus int32
+
+const (
+	DNSZoneStatus_DNS_ZONE_STATUS_UNSPECIFIED DNSZoneStatus = 0
+	// DNS_ZONE_STATUS_OK indicates the system resolver returned the IP we expected from VNet's
+	// nameserver, so per-zone routing works.
+	DNSZoneStatus_DNS_ZONE_STATUS_OK DNSZoneStatus = 1
+	// DNS_ZONE_STATUS_HIJACKED indicates the system resolver returned an IP, but not the one VNet
+	// returned. Some other resolver answered for this zone.
+	DNSZoneStatus_DNS_ZONE_STATUS_HIJACKED DNSZoneStatus = 2
+	// DNS_ZONE_STATUS_NOT_REGISTERED indicates the system resolver returned NXDOMAIN or SERVFAIL.
+	DNSZoneStatus_DNS_ZONE_STATUS_NOT_REGISTERED DNSZoneStatus = 3
+	// DNS_ZONE_STATUS_TIMEOUT indicates the system resolver query timed out, likely because it
+	// was routed to a nameserver that is unreachable.
+	DNSZoneStatus_DNS_ZONE_STATUS_TIMEOUT DNSZoneStatus = 4
+	// DNS_ZONE_STATUS_RESOLVER_ERROR indicates an unexpected error from the system resolver.
+	DNSZoneStatus_DNS_ZONE_STATUS_RESOLVER_ERROR DNSZoneStatus = 5
+)
+
+// Enum value maps for DNSZoneStatus.
+var (
+	DNSZoneStatus_name = map[int32]string{
+		0: "DNS_ZONE_STATUS_UNSPECIFIED",
+		1: "DNS_ZONE_STATUS_OK",
+		2: "DNS_ZONE_STATUS_HIJACKED",
+		3: "DNS_ZONE_STATUS_NOT_REGISTERED",
+		4: "DNS_ZONE_STATUS_TIMEOUT",
+		5: "DNS_ZONE_STATUS_RESOLVER_ERROR",
+	}
+	DNSZoneStatus_value = map[string]int32{
+		"DNS_ZONE_STATUS_UNSPECIFIED":    0,
+		"DNS_ZONE_STATUS_OK":             1,
+		"DNS_ZONE_STATUS_HIJACKED":       2,
+		"DNS_ZONE_STATUS_NOT_REGISTERED": 3,
+		"DNS_ZONE_STATUS_TIMEOUT":        4,
+		"DNS_ZONE_STATUS_RESOLVER_ERROR": 5,
+	}
+)
+
+func (x DNSZoneStatus) Enum() *DNSZoneStatus {
+	p := new(DNSZoneStatus)
+	*p = x
+	return p
+}
+
+func (x DNSZoneStatus) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (DNSZoneStatus) Descriptor() protoreflect.EnumDescriptor {
+	return file_teleport_lib_vnet_diag_v1_diag_proto_enumTypes[3].Descriptor()
+}
+
+func (DNSZoneStatus) Type() protoreflect.EnumType {
+	return &file_teleport_lib_vnet_diag_v1_diag_proto_enumTypes[3]
+}
+
+func (x DNSZoneStatus) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
 // Report represents the attempts at running individual checks. It also includes general information
 // about the network stack managed by VNet. It assumes that each individual check as well as getting
 // info about the network stack can fail.
@@ -691,6 +753,15 @@ func (x *CheckReport) GetSshConfigurationReport() *SSHConfigurationReport {
 	return nil
 }
 
+func (x *CheckReport) GetDnsReport() *DNSReport {
+	if x != nil {
+		if x, ok := x.xxx_hidden_Report.(*checkReport_DnsReport); ok {
+			return x.DnsReport
+		}
+	}
+	return nil
+}
+
 func (x *CheckReport) SetStatus(v CheckReportStatus) {
 	x.xxx_hidden_Status = v
 }
@@ -709,6 +780,14 @@ func (x *CheckReport) SetSshConfigurationReport(v *SSHConfigurationReport) {
 		return
 	}
 	x.xxx_hidden_Report = &checkReport_SshConfigurationReport{v}
+}
+
+func (x *CheckReport) SetDnsReport(v *DNSReport) {
+	if v == nil {
+		x.xxx_hidden_Report = nil
+		return
+	}
+	x.xxx_hidden_Report = &checkReport_DnsReport{v}
 }
 
 func (x *CheckReport) HasReport() bool {
@@ -734,6 +813,14 @@ func (x *CheckReport) HasSshConfigurationReport() bool {
 	return ok
 }
 
+func (x *CheckReport) HasDnsReport() bool {
+	if x == nil {
+		return false
+	}
+	_, ok := x.xxx_hidden_Report.(*checkReport_DnsReport)
+	return ok
+}
+
 func (x *CheckReport) ClearReport() {
 	x.xxx_hidden_Report = nil
 }
@@ -750,9 +837,16 @@ func (x *CheckReport) ClearSshConfigurationReport() {
 	}
 }
 
+func (x *CheckReport) ClearDnsReport() {
+	if _, ok := x.xxx_hidden_Report.(*checkReport_DnsReport); ok {
+		x.xxx_hidden_Report = nil
+	}
+}
+
 const CheckReport_Report_not_set_case case_CheckReport_Report = 0
 const CheckReport_RouteConflictReport_case case_CheckReport_Report = 2
 const CheckReport_SshConfigurationReport_case case_CheckReport_Report = 3
+const CheckReport_DnsReport_case case_CheckReport_Report = 4
 
 func (x *CheckReport) WhichReport() case_CheckReport_Report {
 	if x == nil {
@@ -763,6 +857,8 @@ func (x *CheckReport) WhichReport() case_CheckReport_Report {
 		return CheckReport_RouteConflictReport_case
 	case *checkReport_SshConfigurationReport:
 		return CheckReport_SshConfigurationReport_case
+	case *checkReport_DnsReport:
+		return CheckReport_DnsReport_case
 	default:
 		return CheckReport_Report_not_set_case
 	}
@@ -781,6 +877,9 @@ type CheckReport_builder struct {
 	RouteConflictReport *RouteConflictReport
 	// ssh_configuration_report reports the status of the system's SSH configuration.
 	SshConfigurationReport *SSHConfigurationReport
+	// dns_report reports whether the system resolver routes queries for each VNet-managed DNS zone
+	// to VNet's nameserver.
+	DnsReport *DNSReport
 	// -- end of xxx_hidden_Report
 }
 
@@ -794,6 +893,9 @@ func (b0 CheckReport_builder) Build() *CheckReport {
 	}
 	if b.SshConfigurationReport != nil {
 		x.xxx_hidden_Report = &checkReport_SshConfigurationReport{b.SshConfigurationReport}
+	}
+	if b.DnsReport != nil {
+		x.xxx_hidden_Report = &checkReport_DnsReport{b.DnsReport}
 	}
 	return m0
 }
@@ -823,9 +925,17 @@ type checkReport_SshConfigurationReport struct {
 	SshConfigurationReport *SSHConfigurationReport `protobuf:"bytes,3,opt,name=ssh_configuration_report,json=sshConfigurationReport,proto3,oneof"`
 }
 
+type checkReport_DnsReport struct {
+	// dns_report reports whether the system resolver routes queries for each VNet-managed DNS zone
+	// to VNet's nameserver.
+	DnsReport *DNSReport `protobuf:"bytes,4,opt,name=dns_report,json=dnsReport,proto3,oneof"`
+}
+
 func (*checkReport_RouteConflictReport) isCheckReport_Report() {}
 
 func (*checkReport_SshConfigurationReport) isCheckReport_Report() {}
+
+func (*checkReport_DnsReport) isCheckReport_Report() {}
 
 // CommandAttempt describes the attempt at running a particular command associated with a diagnostic
 // check.
@@ -1099,6 +1209,231 @@ func (b0 RouteConflict_builder) Build() *RouteConflict {
 	return m0
 }
 
+// DNSReport describes whether the system resolver routes DNS queries for VNet-managed zones to
+// VNet's nameserver. It is the output of DNSDiag.
+//
+// The check uses a probe hostname of the form vnet-diag-<random>.<zone>. VNet's nameserver
+// short-circuits any query with this prefix and answers with an address derived from its IPv6
+// prefix, an address no other resolver can produce. The random label prevents DNS caches.
+//
+// The check first queries the probe directly against VNet's nameserver IP to confirm VNet's DNS
+// server is reachable and to capture the expected response. If that fails, vnet_dns_reachable is
+// false, vnet_dns_unreachable_error stores the error, and zone_results is empty. Otherwise, the
+// check runs the same probe query per zone through the system resolver and compares each answer to
+// the expected response. A mismatch means the per-zone OS resolver entry does not route to VNet.
+type DNSReport struct {
+	state                              protoimpl.MessageState `protogen:"opaque.v1"`
+	xxx_hidden_VnetDnsReachable        bool                   `protobuf:"varint,1,opt,name=vnet_dns_reachable,json=vnetDnsReachable,proto3"`
+	xxx_hidden_VnetDnsUnreachableError string                 `protobuf:"bytes,2,opt,name=vnet_dns_unreachable_error,json=vnetDnsUnreachableError,proto3"`
+	xxx_hidden_ZoneResults             *[]*DNSZoneResult      `protobuf:"bytes,3,rep,name=zone_results,json=zoneResults,proto3"`
+	unknownFields                      protoimpl.UnknownFields
+	sizeCache                          protoimpl.SizeCache
+}
+
+func (x *DNSReport) Reset() {
+	*x = DNSReport{}
+	mi := &file_teleport_lib_vnet_diag_v1_diag_proto_msgTypes[8]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *DNSReport) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*DNSReport) ProtoMessage() {}
+
+func (x *DNSReport) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_lib_vnet_diag_v1_diag_proto_msgTypes[8]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+func (x *DNSReport) GetVnetDnsReachable() bool {
+	if x != nil {
+		return x.xxx_hidden_VnetDnsReachable
+	}
+	return false
+}
+
+func (x *DNSReport) GetVnetDnsUnreachableError() string {
+	if x != nil {
+		return x.xxx_hidden_VnetDnsUnreachableError
+	}
+	return ""
+}
+
+func (x *DNSReport) GetZoneResults() []*DNSZoneResult {
+	if x != nil {
+		if x.xxx_hidden_ZoneResults != nil {
+			return *x.xxx_hidden_ZoneResults
+		}
+	}
+	return nil
+}
+
+func (x *DNSReport) SetVnetDnsReachable(v bool) {
+	x.xxx_hidden_VnetDnsReachable = v
+}
+
+func (x *DNSReport) SetVnetDnsUnreachableError(v string) {
+	x.xxx_hidden_VnetDnsUnreachableError = v
+}
+
+func (x *DNSReport) SetZoneResults(v []*DNSZoneResult) {
+	x.xxx_hidden_ZoneResults = &v
+}
+
+type DNSReport_builder struct {
+	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
+
+	// vnet_dns_reachable is true if a direct DNS query to VNet's nameserver IP succeeded.
+	VnetDnsReachable bool
+	// vnet_dns_unreachable_error is set when vnet_dns_reachable is false.
+	VnetDnsUnreachableError string
+	// zone_results contains one entry per zone in NetworkStack.dns_zones. Empty if
+	// vnet_dns_reachable is false.
+	ZoneResults []*DNSZoneResult
+}
+
+func (b0 DNSReport_builder) Build() *DNSReport {
+	m0 := &DNSReport{}
+	b, x := &b0, m0
+	_, _ = b, x
+	x.xxx_hidden_VnetDnsReachable = b.VnetDnsReachable
+	x.xxx_hidden_VnetDnsUnreachableError = b.VnetDnsUnreachableError
+	x.xxx_hidden_ZoneResults = &b.ZoneResults
+	return m0
+}
+
+// DNSZoneResult describes the outcome of querying a probe hostname under a single VNet-managed
+// DNS zone through the system resolver.
+type DNSZoneResult struct {
+	state                 protoimpl.MessageState `protogen:"opaque.v1"`
+	xxx_hidden_Zone       string                 `protobuf:"bytes,1,opt,name=zone,proto3"`
+	xxx_hidden_Status     DNSZoneStatus          `protobuf:"varint,2,opt,name=status,proto3,enum=teleport.lib.vnet.diag.v1.DNSZoneStatus"`
+	xxx_hidden_ObservedIp string                 `protobuf:"bytes,3,opt,name=observed_ip,json=observedIp,proto3"`
+	xxx_hidden_ExpectedIp string                 `protobuf:"bytes,4,opt,name=expected_ip,json=expectedIp,proto3"`
+	xxx_hidden_Error      string                 `protobuf:"bytes,5,opt,name=error,proto3"`
+	unknownFields         protoimpl.UnknownFields
+	sizeCache             protoimpl.SizeCache
+}
+
+func (x *DNSZoneResult) Reset() {
+	*x = DNSZoneResult{}
+	mi := &file_teleport_lib_vnet_diag_v1_diag_proto_msgTypes[9]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *DNSZoneResult) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*DNSZoneResult) ProtoMessage() {}
+
+func (x *DNSZoneResult) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_lib_vnet_diag_v1_diag_proto_msgTypes[9]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+func (x *DNSZoneResult) GetZone() string {
+	if x != nil {
+		return x.xxx_hidden_Zone
+	}
+	return ""
+}
+
+func (x *DNSZoneResult) GetStatus() DNSZoneStatus {
+	if x != nil {
+		return x.xxx_hidden_Status
+	}
+	return DNSZoneStatus_DNS_ZONE_STATUS_UNSPECIFIED
+}
+
+func (x *DNSZoneResult) GetObservedIp() string {
+	if x != nil {
+		return x.xxx_hidden_ObservedIp
+	}
+	return ""
+}
+
+func (x *DNSZoneResult) GetExpectedIp() string {
+	if x != nil {
+		return x.xxx_hidden_ExpectedIp
+	}
+	return ""
+}
+
+func (x *DNSZoneResult) GetError() string {
+	if x != nil {
+		return x.xxx_hidden_Error
+	}
+	return ""
+}
+
+func (x *DNSZoneResult) SetZone(v string) {
+	x.xxx_hidden_Zone = v
+}
+
+func (x *DNSZoneResult) SetStatus(v DNSZoneStatus) {
+	x.xxx_hidden_Status = v
+}
+
+func (x *DNSZoneResult) SetObservedIp(v string) {
+	x.xxx_hidden_ObservedIp = v
+}
+
+func (x *DNSZoneResult) SetExpectedIp(v string) {
+	x.xxx_hidden_ExpectedIp = v
+}
+
+func (x *DNSZoneResult) SetError(v string) {
+	x.xxx_hidden_Error = v
+}
+
+type DNSZoneResult_builder struct {
+	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
+
+	// zone is the DNS zone that was tested, e.g. "company.test".
+	Zone string
+	// status describes the outcome of the query.
+	Status DNSZoneStatus
+	// observed_ip is the IP returned by the system resolver for the probe hostname. Empty on
+	// timeout or no answer.
+	ObservedIp string
+	// expected_ip is the IP that VNet's nameserver returned for the same probe hostname when
+	// queried directly.
+	ExpectedIp string
+	// error is set on DNS_ZONE_STATUS_TIMEOUT and DNS_ZONE_STATUS_RESOLVER_ERROR.
+	Error string
+}
+
+func (b0 DNSZoneResult_builder) Build() *DNSZoneResult {
+	m0 := &DNSZoneResult{}
+	b, x := &b0, m0
+	_, _ = b, x
+	x.xxx_hidden_Zone = b.Zone
+	x.xxx_hidden_Status = b.Status
+	x.xxx_hidden_ObservedIp = b.ObservedIp
+	x.xxx_hidden_ExpectedIp = b.ExpectedIp
+	x.xxx_hidden_Error = b.Error
+	return m0
+}
+
 // SSHConfigurationReport describes the state of the system's SSH configuration.
 type SSHConfigurationReport struct {
 	state                                             protoimpl.MessageState `protogen:"opaque.v1"`
@@ -1113,7 +1448,7 @@ type SSHConfigurationReport struct {
 
 func (x *SSHConfigurationReport) Reset() {
 	*x = SSHConfigurationReport{}
-	mi := &file_teleport_lib_vnet_diag_v1_diag_proto_msgTypes[8]
+	mi := &file_teleport_lib_vnet_diag_v1_diag_proto_msgTypes[10]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1125,7 +1460,7 @@ func (x *SSHConfigurationReport) String() string {
 func (*SSHConfigurationReport) ProtoMessage() {}
 
 func (x *SSHConfigurationReport) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_lib_vnet_diag_v1_diag_proto_msgTypes[8]
+	mi := &file_teleport_lib_vnet_diag_v1_diag_proto_msgTypes[10]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1247,11 +1582,13 @@ const file_teleport_lib_vnet_diag_v1_diag_proto_rawDesc = "" +
 	"\x06status\x18\x01 \x01(\x0e2-.teleport.lib.vnet.diag.v1.CheckAttemptStatusR\x06status\x12\x14\n" +
 	"\x05error\x18\x02 \x01(\tR\x05error\x12I\n" +
 	"\fcheck_report\x18\x03 \x01(\v2&.teleport.lib.vnet.diag.v1.CheckReportR\vcheckReport\x12E\n" +
-	"\bcommands\x18\x04 \x03(\v2).teleport.lib.vnet.diag.v1.CommandAttemptR\bcommands\"\xb2\x02\n" +
+	"\bcommands\x18\x04 \x03(\v2).teleport.lib.vnet.diag.v1.CommandAttemptR\bcommands\"\xf9\x02\n" +
 	"\vCheckReport\x12D\n" +
 	"\x06status\x18\x01 \x01(\x0e2,.teleport.lib.vnet.diag.v1.CheckReportStatusR\x06status\x12d\n" +
 	"\x15route_conflict_report\x18\x02 \x01(\v2..teleport.lib.vnet.diag.v1.RouteConflictReportH\x00R\x13routeConflictReport\x12m\n" +
-	"\x18ssh_configuration_report\x18\x03 \x01(\v21.teleport.lib.vnet.diag.v1.SSHConfigurationReportH\x00R\x16sshConfigurationReportB\b\n" +
+	"\x18ssh_configuration_report\x18\x03 \x01(\v21.teleport.lib.vnet.diag.v1.SSHConfigurationReportH\x00R\x16sshConfigurationReport\x12E\n" +
+	"\n" +
+	"dns_report\x18\x04 \x01(\v2$.teleport.lib.vnet.diag.v1.DNSReportH\x00R\tdnsReportB\b\n" +
 	"\x06report\"\xa1\x01\n" +
 	"\x0eCommandAttempt\x12G\n" +
 	"\x06status\x18\x01 \x01(\x0e2/.teleport.lib.vnet.diag.v1.CommandAttemptStatusR\x06status\x12\x14\n" +
@@ -1264,7 +1601,19 @@ const file_teleport_lib_vnet_diag_v1_diag_proto_rawDesc = "" +
 	"\x04dest\x18\x01 \x01(\tR\x04dest\x12\x1b\n" +
 	"\tvnet_dest\x18\x02 \x01(\tR\bvnetDest\x12%\n" +
 	"\x0einterface_name\x18\x03 \x01(\tR\rinterfaceName\x12#\n" +
-	"\rinterface_app\x18\x04 \x01(\tR\finterfaceApp\"\xde\x02\n" +
+	"\rinterface_app\x18\x04 \x01(\tR\finterfaceApp\"\xc3\x01\n" +
+	"\tDNSReport\x12,\n" +
+	"\x12vnet_dns_reachable\x18\x01 \x01(\bR\x10vnetDnsReachable\x12;\n" +
+	"\x1avnet_dns_unreachable_error\x18\x02 \x01(\tR\x17vnetDnsUnreachableError\x12K\n" +
+	"\fzone_results\x18\x03 \x03(\v2(.teleport.lib.vnet.diag.v1.DNSZoneResultR\vzoneResults\"\xbd\x01\n" +
+	"\rDNSZoneResult\x12\x12\n" +
+	"\x04zone\x18\x01 \x01(\tR\x04zone\x12@\n" +
+	"\x06status\x18\x02 \x01(\x0e2(.teleport.lib.vnet.diag.v1.DNSZoneStatusR\x06status\x12\x1f\n" +
+	"\vobserved_ip\x18\x03 \x01(\tR\n" +
+	"observedIp\x12\x1f\n" +
+	"\vexpected_ip\x18\x04 \x01(\tR\n" +
+	"expectedIp\x12\x14\n" +
+	"\x05error\x18\x05 \x01(\tR\x05error\"\xde\x02\n" +
 	"\x16SSHConfigurationReport\x127\n" +
 	"\x18user_openssh_config_path\x18\x01 \x01(\tR\x15userOpensshConfigPath\x12/\n" +
 	"\x14vnet_ssh_config_path\x18\x02 \x01(\tR\x11vnetSshConfigPath\x12\\\n" +
@@ -1282,44 +1631,57 @@ const file_teleport_lib_vnet_diag_v1_diag_proto_rawDesc = "" +
 	"\x14CommandAttemptStatus\x12&\n" +
 	"\"COMMAND_ATTEMPT_STATUS_UNSPECIFIED\x10\x00\x12\x1d\n" +
 	"\x19COMMAND_ATTEMPT_STATUS_OK\x10\x01\x12 \n" +
-	"\x1cCOMMAND_ATTEMPT_STATUS_ERROR\x10\x02BQZOgithub.com/gravitational/teleport/gen/proto/go/teleport/lib/vnet/diag/v1;diagv1b\x06proto3"
+	"\x1cCOMMAND_ATTEMPT_STATUS_ERROR\x10\x02*\xcb\x01\n" +
+	"\rDNSZoneStatus\x12\x1f\n" +
+	"\x1bDNS_ZONE_STATUS_UNSPECIFIED\x10\x00\x12\x16\n" +
+	"\x12DNS_ZONE_STATUS_OK\x10\x01\x12\x1c\n" +
+	"\x18DNS_ZONE_STATUS_HIJACKED\x10\x02\x12\"\n" +
+	"\x1eDNS_ZONE_STATUS_NOT_REGISTERED\x10\x03\x12\x1b\n" +
+	"\x17DNS_ZONE_STATUS_TIMEOUT\x10\x04\x12\"\n" +
+	"\x1eDNS_ZONE_STATUS_RESOLVER_ERROR\x10\x05BQZOgithub.com/gravitational/teleport/gen/proto/go/teleport/lib/vnet/diag/v1;diagv1b\x06proto3"
 
-var file_teleport_lib_vnet_diag_v1_diag_proto_enumTypes = make([]protoimpl.EnumInfo, 3)
-var file_teleport_lib_vnet_diag_v1_diag_proto_msgTypes = make([]protoimpl.MessageInfo, 9)
+var file_teleport_lib_vnet_diag_v1_diag_proto_enumTypes = make([]protoimpl.EnumInfo, 4)
+var file_teleport_lib_vnet_diag_v1_diag_proto_msgTypes = make([]protoimpl.MessageInfo, 11)
 var file_teleport_lib_vnet_diag_v1_diag_proto_goTypes = []any{
 	(CheckAttemptStatus)(0),        // 0: teleport.lib.vnet.diag.v1.CheckAttemptStatus
 	(CheckReportStatus)(0),         // 1: teleport.lib.vnet.diag.v1.CheckReportStatus
 	(CommandAttemptStatus)(0),      // 2: teleport.lib.vnet.diag.v1.CommandAttemptStatus
-	(*Report)(nil),                 // 3: teleport.lib.vnet.diag.v1.Report
-	(*NetworkStackAttempt)(nil),    // 4: teleport.lib.vnet.diag.v1.NetworkStackAttempt
-	(*NetworkStack)(nil),           // 5: teleport.lib.vnet.diag.v1.NetworkStack
-	(*CheckAttempt)(nil),           // 6: teleport.lib.vnet.diag.v1.CheckAttempt
-	(*CheckReport)(nil),            // 7: teleport.lib.vnet.diag.v1.CheckReport
-	(*CommandAttempt)(nil),         // 8: teleport.lib.vnet.diag.v1.CommandAttempt
-	(*RouteConflictReport)(nil),    // 9: teleport.lib.vnet.diag.v1.RouteConflictReport
-	(*RouteConflict)(nil),          // 10: teleport.lib.vnet.diag.v1.RouteConflict
-	(*SSHConfigurationReport)(nil), // 11: teleport.lib.vnet.diag.v1.SSHConfigurationReport
-	(*timestamppb.Timestamp)(nil),  // 12: google.protobuf.Timestamp
+	(DNSZoneStatus)(0),             // 3: teleport.lib.vnet.diag.v1.DNSZoneStatus
+	(*Report)(nil),                 // 4: teleport.lib.vnet.diag.v1.Report
+	(*NetworkStackAttempt)(nil),    // 5: teleport.lib.vnet.diag.v1.NetworkStackAttempt
+	(*NetworkStack)(nil),           // 6: teleport.lib.vnet.diag.v1.NetworkStack
+	(*CheckAttempt)(nil),           // 7: teleport.lib.vnet.diag.v1.CheckAttempt
+	(*CheckReport)(nil),            // 8: teleport.lib.vnet.diag.v1.CheckReport
+	(*CommandAttempt)(nil),         // 9: teleport.lib.vnet.diag.v1.CommandAttempt
+	(*RouteConflictReport)(nil),    // 10: teleport.lib.vnet.diag.v1.RouteConflictReport
+	(*RouteConflict)(nil),          // 11: teleport.lib.vnet.diag.v1.RouteConflict
+	(*DNSReport)(nil),              // 12: teleport.lib.vnet.diag.v1.DNSReport
+	(*DNSZoneResult)(nil),          // 13: teleport.lib.vnet.diag.v1.DNSZoneResult
+	(*SSHConfigurationReport)(nil), // 14: teleport.lib.vnet.diag.v1.SSHConfigurationReport
+	(*timestamppb.Timestamp)(nil),  // 15: google.protobuf.Timestamp
 }
 var file_teleport_lib_vnet_diag_v1_diag_proto_depIdxs = []int32{
-	12, // 0: teleport.lib.vnet.diag.v1.Report.created_at:type_name -> google.protobuf.Timestamp
-	4,  // 1: teleport.lib.vnet.diag.v1.Report.network_stack_attempt:type_name -> teleport.lib.vnet.diag.v1.NetworkStackAttempt
-	6,  // 2: teleport.lib.vnet.diag.v1.Report.checks:type_name -> teleport.lib.vnet.diag.v1.CheckAttempt
+	15, // 0: teleport.lib.vnet.diag.v1.Report.created_at:type_name -> google.protobuf.Timestamp
+	5,  // 1: teleport.lib.vnet.diag.v1.Report.network_stack_attempt:type_name -> teleport.lib.vnet.diag.v1.NetworkStackAttempt
+	7,  // 2: teleport.lib.vnet.diag.v1.Report.checks:type_name -> teleport.lib.vnet.diag.v1.CheckAttempt
 	0,  // 3: teleport.lib.vnet.diag.v1.NetworkStackAttempt.status:type_name -> teleport.lib.vnet.diag.v1.CheckAttemptStatus
-	5,  // 4: teleport.lib.vnet.diag.v1.NetworkStackAttempt.network_stack:type_name -> teleport.lib.vnet.diag.v1.NetworkStack
+	6,  // 4: teleport.lib.vnet.diag.v1.NetworkStackAttempt.network_stack:type_name -> teleport.lib.vnet.diag.v1.NetworkStack
 	0,  // 5: teleport.lib.vnet.diag.v1.CheckAttempt.status:type_name -> teleport.lib.vnet.diag.v1.CheckAttemptStatus
-	7,  // 6: teleport.lib.vnet.diag.v1.CheckAttempt.check_report:type_name -> teleport.lib.vnet.diag.v1.CheckReport
-	8,  // 7: teleport.lib.vnet.diag.v1.CheckAttempt.commands:type_name -> teleport.lib.vnet.diag.v1.CommandAttempt
+	8,  // 6: teleport.lib.vnet.diag.v1.CheckAttempt.check_report:type_name -> teleport.lib.vnet.diag.v1.CheckReport
+	9,  // 7: teleport.lib.vnet.diag.v1.CheckAttempt.commands:type_name -> teleport.lib.vnet.diag.v1.CommandAttempt
 	1,  // 8: teleport.lib.vnet.diag.v1.CheckReport.status:type_name -> teleport.lib.vnet.diag.v1.CheckReportStatus
-	9,  // 9: teleport.lib.vnet.diag.v1.CheckReport.route_conflict_report:type_name -> teleport.lib.vnet.diag.v1.RouteConflictReport
-	11, // 10: teleport.lib.vnet.diag.v1.CheckReport.ssh_configuration_report:type_name -> teleport.lib.vnet.diag.v1.SSHConfigurationReport
-	2,  // 11: teleport.lib.vnet.diag.v1.CommandAttempt.status:type_name -> teleport.lib.vnet.diag.v1.CommandAttemptStatus
-	10, // 12: teleport.lib.vnet.diag.v1.RouteConflictReport.route_conflicts:type_name -> teleport.lib.vnet.diag.v1.RouteConflict
-	13, // [13:13] is the sub-list for method output_type
-	13, // [13:13] is the sub-list for method input_type
-	13, // [13:13] is the sub-list for extension type_name
-	13, // [13:13] is the sub-list for extension extendee
-	0,  // [0:13] is the sub-list for field type_name
+	10, // 9: teleport.lib.vnet.diag.v1.CheckReport.route_conflict_report:type_name -> teleport.lib.vnet.diag.v1.RouteConflictReport
+	14, // 10: teleport.lib.vnet.diag.v1.CheckReport.ssh_configuration_report:type_name -> teleport.lib.vnet.diag.v1.SSHConfigurationReport
+	12, // 11: teleport.lib.vnet.diag.v1.CheckReport.dns_report:type_name -> teleport.lib.vnet.diag.v1.DNSReport
+	2,  // 12: teleport.lib.vnet.diag.v1.CommandAttempt.status:type_name -> teleport.lib.vnet.diag.v1.CommandAttemptStatus
+	11, // 13: teleport.lib.vnet.diag.v1.RouteConflictReport.route_conflicts:type_name -> teleport.lib.vnet.diag.v1.RouteConflict
+	13, // 14: teleport.lib.vnet.diag.v1.DNSReport.zone_results:type_name -> teleport.lib.vnet.diag.v1.DNSZoneResult
+	3,  // 15: teleport.lib.vnet.diag.v1.DNSZoneResult.status:type_name -> teleport.lib.vnet.diag.v1.DNSZoneStatus
+	16, // [16:16] is the sub-list for method output_type
+	16, // [16:16] is the sub-list for method input_type
+	16, // [16:16] is the sub-list for extension type_name
+	16, // [16:16] is the sub-list for extension extendee
+	0,  // [0:16] is the sub-list for field type_name
 }
 
 func init() { file_teleport_lib_vnet_diag_v1_diag_proto_init() }
@@ -1330,14 +1692,15 @@ func file_teleport_lib_vnet_diag_v1_diag_proto_init() {
 	file_teleport_lib_vnet_diag_v1_diag_proto_msgTypes[4].OneofWrappers = []any{
 		(*checkReport_RouteConflictReport)(nil),
 		(*checkReport_SshConfigurationReport)(nil),
+		(*checkReport_DnsReport)(nil),
 	}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_teleport_lib_vnet_diag_v1_diag_proto_rawDesc), len(file_teleport_lib_vnet_diag_v1_diag_proto_rawDesc)),
-			NumEnums:      3,
-			NumMessages:   9,
+			NumEnums:      4,
+			NumMessages:   11,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/gen/proto/go/teleport/lib/vnet/diag/v1/diag_protoopaque.pb.go
+++ b/gen/proto/go/teleport/lib/vnet/diag/v1/diag_protoopaque.pb.go
@@ -1556,11 +1556,15 @@ type DNSZoneResult_builder struct {
 
 	// zone is the DNS zone that was tested, e.g. "company.test".
 	Zone string
-	// a_record is the outcome of the A-record part of the per-zone query. Null if no expected A was
-	// captured.
+	// a_record is the outcome of the A-record query for this zone, compared to the
+	// A returned by VNet's DNS server on direct query. The check is skipped and
+	// this field is null when VNet's DNS server failed to return an A on direct
+	// query.
 	ARecord *RecordResult
-	// aaaa_record is the outcome of the AAAA-record part of the per-zone query. Null if no expected
-	// AAAA was captured.
+	// aaaa_record is the outcome of the AAAA-record query for this zone, compared
+	// to the AAAA returned by VNet's DNS server on direct query. The check is
+	// skipped and this field is null when VNet's DNS server failed to return an
+	// AAAA on direct query.
 	AaaaRecord *RecordResult
 }
 

--- a/gen/proto/go/teleport/lib/vnet/diag/v1/diag_protoopaque.pb.go
+++ b/gen/proto/go/teleport/lib/vnet/diag/v1/diag_protoopaque.pb.go
@@ -1213,21 +1213,25 @@ func (b0 RouteConflict_builder) Build() *RouteConflict {
 // VNet's nameserver. It is the output of DNSDiag.
 //
 // The check uses a probe hostname of the form vnet-diag-<random>.<zone>. VNet's nameserver
-// short-circuits any query with this prefix and answers with an address derived from its IPv6
-// prefix, an address no other resolver can produce. The random label prevents DNS caches.
+// short-circuits any query with this prefix and answers with addresses derived from its IPv4 CIDR
+// range and IPv6 prefix, addresses no other resolver can produce. The random label prevents DNS
+// caches.
 //
-// The check first queries the probe directly against VNet's nameserver IP to confirm VNet's DNS
-// server is reachable and to capture the expected response. If that fails, vnet_dns_reachable is
-// false, vnet_dns_unreachable_error stores the error, and zone_results is empty. Otherwise, the
-// check runs the same probe query per zone through the system resolver and compares each answer to
-// the expected response. A mismatch means the per-zone OS resolver entry does not route to VNet.
+// The check first queries the probe directly against each VNet nameserver IPv4 and IPv6 addresses
+// asking for both A and AAAA records, to confirm VNet's DNS server is reachable and to capture the
+// expected responses per record type. If an IPv4 or IPv6 address is unreachable, the corresponding
+// reachability field still records the failure but the check continues with whatever was captured
+// from successful queries. If neither address produced a response for either record type,
+// zone_results is empty. Otherwise, the check runs the same probe per zone through the system
+// resolver, asking for A and AAAA independently, and compares each answer to the expected response.
+// A mismatch means the per-zone OS resolver entry does not route to VNet.
 type DNSReport struct {
-	state                              protoimpl.MessageState `protogen:"opaque.v1"`
-	xxx_hidden_VnetDnsReachable        bool                   `protobuf:"varint,1,opt,name=vnet_dns_reachable,json=vnetDnsReachable,proto3"`
-	xxx_hidden_VnetDnsUnreachableError string                 `protobuf:"bytes,2,opt,name=vnet_dns_unreachable_error,json=vnetDnsUnreachableError,proto3"`
-	xxx_hidden_ZoneResults             *[]*DNSZoneResult      `protobuf:"bytes,3,rep,name=zone_results,json=zoneResults,proto3"`
-	unknownFields                      protoimpl.UnknownFields
-	sizeCache                          protoimpl.SizeCache
+	state                       protoimpl.MessageState `protogen:"opaque.v1"`
+	xxx_hidden_Ipv4Reachability *VNetDNSReachability   `protobuf:"bytes,1,opt,name=ipv4_reachability,json=ipv4Reachability,proto3"`
+	xxx_hidden_Ipv6Reachability *VNetDNSReachability   `protobuf:"bytes,2,opt,name=ipv6_reachability,json=ipv6Reachability,proto3"`
+	xxx_hidden_ZoneResults      *[]*DNSZoneResult      `protobuf:"bytes,3,rep,name=zone_results,json=zoneResults,proto3"`
+	unknownFields               protoimpl.UnknownFields
+	sizeCache                   protoimpl.SizeCache
 }
 
 func (x *DNSReport) Reset() {
@@ -1255,18 +1259,18 @@ func (x *DNSReport) ProtoReflect() protoreflect.Message {
 	return mi.MessageOf(x)
 }
 
-func (x *DNSReport) GetVnetDnsReachable() bool {
+func (x *DNSReport) GetIpv4Reachability() *VNetDNSReachability {
 	if x != nil {
-		return x.xxx_hidden_VnetDnsReachable
+		return x.xxx_hidden_Ipv4Reachability
 	}
-	return false
+	return nil
 }
 
-func (x *DNSReport) GetVnetDnsUnreachableError() string {
+func (x *DNSReport) GetIpv6Reachability() *VNetDNSReachability {
 	if x != nil {
-		return x.xxx_hidden_VnetDnsUnreachableError
+		return x.xxx_hidden_Ipv6Reachability
 	}
-	return ""
+	return nil
 }
 
 func (x *DNSReport) GetZoneResults() []*DNSZoneResult {
@@ -1278,27 +1282,51 @@ func (x *DNSReport) GetZoneResults() []*DNSZoneResult {
 	return nil
 }
 
-func (x *DNSReport) SetVnetDnsReachable(v bool) {
-	x.xxx_hidden_VnetDnsReachable = v
+func (x *DNSReport) SetIpv4Reachability(v *VNetDNSReachability) {
+	x.xxx_hidden_Ipv4Reachability = v
 }
 
-func (x *DNSReport) SetVnetDnsUnreachableError(v string) {
-	x.xxx_hidden_VnetDnsUnreachableError = v
+func (x *DNSReport) SetIpv6Reachability(v *VNetDNSReachability) {
+	x.xxx_hidden_Ipv6Reachability = v
 }
 
 func (x *DNSReport) SetZoneResults(v []*DNSZoneResult) {
 	x.xxx_hidden_ZoneResults = &v
 }
 
+func (x *DNSReport) HasIpv4Reachability() bool {
+	if x == nil {
+		return false
+	}
+	return x.xxx_hidden_Ipv4Reachability != nil
+}
+
+func (x *DNSReport) HasIpv6Reachability() bool {
+	if x == nil {
+		return false
+	}
+	return x.xxx_hidden_Ipv6Reachability != nil
+}
+
+func (x *DNSReport) ClearIpv4Reachability() {
+	x.xxx_hidden_Ipv4Reachability = nil
+}
+
+func (x *DNSReport) ClearIpv6Reachability() {
+	x.xxx_hidden_Ipv6Reachability = nil
+}
+
 type DNSReport_builder struct {
 	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
 
-	// vnet_dns_reachable is true if a direct DNS query to VNet's nameserver IP succeeded.
-	VnetDnsReachable bool
-	// vnet_dns_unreachable_error is set when vnet_dns_reachable is false.
-	VnetDnsUnreachableError string
-	// zone_results contains one entry per zone in NetworkStack.dns_zones. Empty if
-	// vnet_dns_reachable is false.
+	// ipv4_reachability is the outcome of probing VNet's IPv4 nameserver directly. Null if VNet is
+	// not serving DNS on IPv4.
+	Ipv4Reachability *VNetDNSReachability
+	// ipv6_reachability is the outcome of probing VNet's IPv6 nameserver directly. Null if VNet is
+	// not serving DNS on IPv6.
+	Ipv6Reachability *VNetDNSReachability
+	// zone_results contains one entry per zone in NetworkStack.dns_zones. Empty if neither
+	// reachability probe produced a response for either record type.
 	ZoneResults []*DNSZoneResult
 }
 
@@ -1306,28 +1334,146 @@ func (b0 DNSReport_builder) Build() *DNSReport {
 	m0 := &DNSReport{}
 	b, x := &b0, m0
 	_, _ = b, x
-	x.xxx_hidden_VnetDnsReachable = b.VnetDnsReachable
-	x.xxx_hidden_VnetDnsUnreachableError = b.VnetDnsUnreachableError
+	x.xxx_hidden_Ipv4Reachability = b.Ipv4Reachability
+	x.xxx_hidden_Ipv6Reachability = b.Ipv6Reachability
 	x.xxx_hidden_ZoneResults = &b.ZoneResults
 	return m0
 }
 
+// VNetDNSReachability describes the outcome of probing one of VNet's DNS servers directly,
+// bypassing the system resolver.
+type VNetDNSReachability struct {
+	state                    protoimpl.MessageState `protogen:"opaque.v1"`
+	xxx_hidden_Address       string                 `protobuf:"bytes,1,opt,name=address,proto3"`
+	xxx_hidden_Reachable     bool                   `protobuf:"varint,2,opt,name=reachable,proto3"`
+	xxx_hidden_RespondedA    bool                   `protobuf:"varint,3,opt,name=responded_a,json=respondedA,proto3"`
+	xxx_hidden_RespondedAaaa bool                   `protobuf:"varint,4,opt,name=responded_aaaa,json=respondedAaaa,proto3"`
+	xxx_hidden_Error         string                 `protobuf:"bytes,5,opt,name=error,proto3"`
+	unknownFields            protoimpl.UnknownFields
+	sizeCache                protoimpl.SizeCache
+}
+
+func (x *VNetDNSReachability) Reset() {
+	*x = VNetDNSReachability{}
+	mi := &file_teleport_lib_vnet_diag_v1_diag_proto_msgTypes[9]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *VNetDNSReachability) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*VNetDNSReachability) ProtoMessage() {}
+
+func (x *VNetDNSReachability) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_lib_vnet_diag_v1_diag_proto_msgTypes[9]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+func (x *VNetDNSReachability) GetAddress() string {
+	if x != nil {
+		return x.xxx_hidden_Address
+	}
+	return ""
+}
+
+func (x *VNetDNSReachability) GetReachable() bool {
+	if x != nil {
+		return x.xxx_hidden_Reachable
+	}
+	return false
+}
+
+func (x *VNetDNSReachability) GetRespondedA() bool {
+	if x != nil {
+		return x.xxx_hidden_RespondedA
+	}
+	return false
+}
+
+func (x *VNetDNSReachability) GetRespondedAaaa() bool {
+	if x != nil {
+		return x.xxx_hidden_RespondedAaaa
+	}
+	return false
+}
+
+func (x *VNetDNSReachability) GetError() string {
+	if x != nil {
+		return x.xxx_hidden_Error
+	}
+	return ""
+}
+
+func (x *VNetDNSReachability) SetAddress(v string) {
+	x.xxx_hidden_Address = v
+}
+
+func (x *VNetDNSReachability) SetReachable(v bool) {
+	x.xxx_hidden_Reachable = v
+}
+
+func (x *VNetDNSReachability) SetRespondedA(v bool) {
+	x.xxx_hidden_RespondedA = v
+}
+
+func (x *VNetDNSReachability) SetRespondedAaaa(v bool) {
+	x.xxx_hidden_RespondedAaaa = v
+}
+
+func (x *VNetDNSReachability) SetError(v string) {
+	x.xxx_hidden_Error = v
+}
+
+type VNetDNSReachability_builder struct {
+	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
+
+	// address is the server that was probed, e.g. "[fdec:1fed:139f::2]:53" or "100.64.0.2:53".
+	Address string
+	// reachable is true if the server returned an answer for at least one record type.
+	Reachable bool
+	// responded_a is true if the server returned an A record for the probe.
+	RespondedA bool
+	// responded_aaaa is true if the server returned an AAAA record for the probe.
+	RespondedAaaa bool
+	// error explains the failure when reachable is false.
+	Error string
+}
+
+func (b0 VNetDNSReachability_builder) Build() *VNetDNSReachability {
+	m0 := &VNetDNSReachability{}
+	b, x := &b0, m0
+	_, _ = b, x
+	x.xxx_hidden_Address = b.Address
+	x.xxx_hidden_Reachable = b.Reachable
+	x.xxx_hidden_RespondedA = b.RespondedA
+	x.xxx_hidden_RespondedAaaa = b.RespondedAaaa
+	x.xxx_hidden_Error = b.Error
+	return m0
+}
+
 // DNSZoneResult describes the outcome of querying a probe hostname under a single VNet-managed
-// DNS zone through the system resolver.
+// DNS zone through the system resolver. The query is made for both A and AAAA records.
 type DNSZoneResult struct {
 	state                 protoimpl.MessageState `protogen:"opaque.v1"`
 	xxx_hidden_Zone       string                 `protobuf:"bytes,1,opt,name=zone,proto3"`
-	xxx_hidden_Status     DNSZoneStatus          `protobuf:"varint,2,opt,name=status,proto3,enum=teleport.lib.vnet.diag.v1.DNSZoneStatus"`
-	xxx_hidden_ObservedIp string                 `protobuf:"bytes,3,opt,name=observed_ip,json=observedIp,proto3"`
-	xxx_hidden_ExpectedIp string                 `protobuf:"bytes,4,opt,name=expected_ip,json=expectedIp,proto3"`
-	xxx_hidden_Error      string                 `protobuf:"bytes,5,opt,name=error,proto3"`
+	xxx_hidden_ARecord    *RecordResult          `protobuf:"bytes,2,opt,name=a_record,json=aRecord,proto3"`
+	xxx_hidden_AaaaRecord *RecordResult          `protobuf:"bytes,3,opt,name=aaaa_record,json=aaaaRecord,proto3"`
 	unknownFields         protoimpl.UnknownFields
 	sizeCache             protoimpl.SizeCache
 }
 
 func (x *DNSZoneResult) Reset() {
 	*x = DNSZoneResult{}
-	mi := &file_teleport_lib_vnet_diag_v1_diag_proto_msgTypes[9]
+	mi := &file_teleport_lib_vnet_diag_v1_diag_proto_msgTypes[10]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1339,7 +1485,7 @@ func (x *DNSZoneResult) String() string {
 func (*DNSZoneResult) ProtoMessage() {}
 
 func (x *DNSZoneResult) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_lib_vnet_diag_v1_diag_proto_msgTypes[9]
+	mi := &file_teleport_lib_vnet_diag_v1_diag_proto_msgTypes[10]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1357,52 +1503,52 @@ func (x *DNSZoneResult) GetZone() string {
 	return ""
 }
 
-func (x *DNSZoneResult) GetStatus() DNSZoneStatus {
+func (x *DNSZoneResult) GetARecord() *RecordResult {
 	if x != nil {
-		return x.xxx_hidden_Status
+		return x.xxx_hidden_ARecord
 	}
-	return DNSZoneStatus_DNS_ZONE_STATUS_UNSPECIFIED
+	return nil
 }
 
-func (x *DNSZoneResult) GetObservedIp() string {
+func (x *DNSZoneResult) GetAaaaRecord() *RecordResult {
 	if x != nil {
-		return x.xxx_hidden_ObservedIp
+		return x.xxx_hidden_AaaaRecord
 	}
-	return ""
-}
-
-func (x *DNSZoneResult) GetExpectedIp() string {
-	if x != nil {
-		return x.xxx_hidden_ExpectedIp
-	}
-	return ""
-}
-
-func (x *DNSZoneResult) GetError() string {
-	if x != nil {
-		return x.xxx_hidden_Error
-	}
-	return ""
+	return nil
 }
 
 func (x *DNSZoneResult) SetZone(v string) {
 	x.xxx_hidden_Zone = v
 }
 
-func (x *DNSZoneResult) SetStatus(v DNSZoneStatus) {
-	x.xxx_hidden_Status = v
+func (x *DNSZoneResult) SetARecord(v *RecordResult) {
+	x.xxx_hidden_ARecord = v
 }
 
-func (x *DNSZoneResult) SetObservedIp(v string) {
-	x.xxx_hidden_ObservedIp = v
+func (x *DNSZoneResult) SetAaaaRecord(v *RecordResult) {
+	x.xxx_hidden_AaaaRecord = v
 }
 
-func (x *DNSZoneResult) SetExpectedIp(v string) {
-	x.xxx_hidden_ExpectedIp = v
+func (x *DNSZoneResult) HasARecord() bool {
+	if x == nil {
+		return false
+	}
+	return x.xxx_hidden_ARecord != nil
 }
 
-func (x *DNSZoneResult) SetError(v string) {
-	x.xxx_hidden_Error = v
+func (x *DNSZoneResult) HasAaaaRecord() bool {
+	if x == nil {
+		return false
+	}
+	return x.xxx_hidden_AaaaRecord != nil
+}
+
+func (x *DNSZoneResult) ClearARecord() {
+	x.xxx_hidden_ARecord = nil
+}
+
+func (x *DNSZoneResult) ClearAaaaRecord() {
+	x.xxx_hidden_AaaaRecord = nil
 }
 
 type DNSZoneResult_builder struct {
@@ -1410,16 +1556,12 @@ type DNSZoneResult_builder struct {
 
 	// zone is the DNS zone that was tested, e.g. "company.test".
 	Zone string
-	// status describes the outcome of the query.
-	Status DNSZoneStatus
-	// observed_ip is the IP returned by the system resolver for the probe hostname. Empty on
-	// timeout or no answer.
-	ObservedIp string
-	// expected_ip is the IP that VNet's nameserver returned for the same probe hostname when
-	// queried directly.
-	ExpectedIp string
-	// error is set on DNS_ZONE_STATUS_TIMEOUT and DNS_ZONE_STATUS_RESOLVER_ERROR.
-	Error string
+	// a_record is the outcome of the A-record part of the per-zone query. Null if no expected A was
+	// captured.
+	ARecord *RecordResult
+	// aaaa_record is the outcome of the AAAA-record part of the per-zone query. Null if no expected
+	// AAAA was captured.
+	AaaaRecord *RecordResult
 }
 
 func (b0 DNSZoneResult_builder) Build() *DNSZoneResult {
@@ -1427,9 +1569,97 @@ func (b0 DNSZoneResult_builder) Build() *DNSZoneResult {
 	b, x := &b0, m0
 	_, _ = b, x
 	x.xxx_hidden_Zone = b.Zone
+	x.xxx_hidden_ARecord = b.ARecord
+	x.xxx_hidden_AaaaRecord = b.AaaaRecord
+	return m0
+}
+
+// RecordResult describes the outcome of querying a single record type for a single zone through
+// the system resolver.
+type RecordResult struct {
+	state                 protoimpl.MessageState `protogen:"opaque.v1"`
+	xxx_hidden_Status     DNSZoneStatus          `protobuf:"varint,1,opt,name=status,proto3,enum=teleport.lib.vnet.diag.v1.DNSZoneStatus"`
+	xxx_hidden_ObservedIp string                 `protobuf:"bytes,2,opt,name=observed_ip,json=observedIp,proto3"`
+	xxx_hidden_Error      string                 `protobuf:"bytes,3,opt,name=error,proto3"`
+	unknownFields         protoimpl.UnknownFields
+	sizeCache             protoimpl.SizeCache
+}
+
+func (x *RecordResult) Reset() {
+	*x = RecordResult{}
+	mi := &file_teleport_lib_vnet_diag_v1_diag_proto_msgTypes[11]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *RecordResult) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*RecordResult) ProtoMessage() {}
+
+func (x *RecordResult) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_lib_vnet_diag_v1_diag_proto_msgTypes[11]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+func (x *RecordResult) GetStatus() DNSZoneStatus {
+	if x != nil {
+		return x.xxx_hidden_Status
+	}
+	return DNSZoneStatus_DNS_ZONE_STATUS_UNSPECIFIED
+}
+
+func (x *RecordResult) GetObservedIp() string {
+	if x != nil {
+		return x.xxx_hidden_ObservedIp
+	}
+	return ""
+}
+
+func (x *RecordResult) GetError() string {
+	if x != nil {
+		return x.xxx_hidden_Error
+	}
+	return ""
+}
+
+func (x *RecordResult) SetStatus(v DNSZoneStatus) {
+	x.xxx_hidden_Status = v
+}
+
+func (x *RecordResult) SetObservedIp(v string) {
+	x.xxx_hidden_ObservedIp = v
+}
+
+func (x *RecordResult) SetError(v string) {
+	x.xxx_hidden_Error = v
+}
+
+type RecordResult_builder struct {
+	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
+
+	// status describes the outcome of the query for this record type.
+	Status DNSZoneStatus
+	// observed_ip is the IP returned by the system resolver. Populated for DNS_ZONE_STATUS_HIJACKED.
+	ObservedIp string
+	// error is set on DNS_ZONE_STATUS_TIMEOUT and DNS_ZONE_STATUS_RESOLVER_ERROR.
+	Error string
+}
+
+func (b0 RecordResult_builder) Build() *RecordResult {
+	m0 := &RecordResult{}
+	b, x := &b0, m0
+	_, _ = b, x
 	x.xxx_hidden_Status = b.Status
 	x.xxx_hidden_ObservedIp = b.ObservedIp
-	x.xxx_hidden_ExpectedIp = b.ExpectedIp
 	x.xxx_hidden_Error = b.Error
 	return m0
 }
@@ -1448,7 +1678,7 @@ type SSHConfigurationReport struct {
 
 func (x *SSHConfigurationReport) Reset() {
 	*x = SSHConfigurationReport{}
-	mi := &file_teleport_lib_vnet_diag_v1_diag_proto_msgTypes[10]
+	mi := &file_teleport_lib_vnet_diag_v1_diag_proto_msgTypes[12]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1460,7 +1690,7 @@ func (x *SSHConfigurationReport) String() string {
 func (*SSHConfigurationReport) ProtoMessage() {}
 
 func (x *SSHConfigurationReport) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_lib_vnet_diag_v1_diag_proto_msgTypes[10]
+	mi := &file_teleport_lib_vnet_diag_v1_diag_proto_msgTypes[12]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1601,19 +1831,28 @@ const file_teleport_lib_vnet_diag_v1_diag_proto_rawDesc = "" +
 	"\x04dest\x18\x01 \x01(\tR\x04dest\x12\x1b\n" +
 	"\tvnet_dest\x18\x02 \x01(\tR\bvnetDest\x12%\n" +
 	"\x0einterface_name\x18\x03 \x01(\tR\rinterfaceName\x12#\n" +
-	"\rinterface_app\x18\x04 \x01(\tR\finterfaceApp\"\xc3\x01\n" +
-	"\tDNSReport\x12,\n" +
-	"\x12vnet_dns_reachable\x18\x01 \x01(\bR\x10vnetDnsReachable\x12;\n" +
-	"\x1avnet_dns_unreachable_error\x18\x02 \x01(\tR\x17vnetDnsUnreachableError\x12K\n" +
-	"\fzone_results\x18\x03 \x03(\v2(.teleport.lib.vnet.diag.v1.DNSZoneResultR\vzoneResults\"\xbd\x01\n" +
+	"\rinterface_app\x18\x04 \x01(\tR\finterfaceApp\"\x92\x02\n" +
+	"\tDNSReport\x12[\n" +
+	"\x11ipv4_reachability\x18\x01 \x01(\v2..teleport.lib.vnet.diag.v1.VNetDNSReachabilityR\x10ipv4Reachability\x12[\n" +
+	"\x11ipv6_reachability\x18\x02 \x01(\v2..teleport.lib.vnet.diag.v1.VNetDNSReachabilityR\x10ipv6Reachability\x12K\n" +
+	"\fzone_results\x18\x03 \x03(\v2(.teleport.lib.vnet.diag.v1.DNSZoneResultR\vzoneResults\"\xab\x01\n" +
+	"\x13VNetDNSReachability\x12\x18\n" +
+	"\aaddress\x18\x01 \x01(\tR\aaddress\x12\x1c\n" +
+	"\treachable\x18\x02 \x01(\bR\treachable\x12\x1f\n" +
+	"\vresponded_a\x18\x03 \x01(\bR\n" +
+	"respondedA\x12%\n" +
+	"\x0eresponded_aaaa\x18\x04 \x01(\bR\rrespondedAaaa\x12\x14\n" +
+	"\x05error\x18\x05 \x01(\tR\x05error\"\xb1\x01\n" +
 	"\rDNSZoneResult\x12\x12\n" +
-	"\x04zone\x18\x01 \x01(\tR\x04zone\x12@\n" +
-	"\x06status\x18\x02 \x01(\x0e2(.teleport.lib.vnet.diag.v1.DNSZoneStatusR\x06status\x12\x1f\n" +
-	"\vobserved_ip\x18\x03 \x01(\tR\n" +
-	"observedIp\x12\x1f\n" +
-	"\vexpected_ip\x18\x04 \x01(\tR\n" +
-	"expectedIp\x12\x14\n" +
-	"\x05error\x18\x05 \x01(\tR\x05error\"\xde\x02\n" +
+	"\x04zone\x18\x01 \x01(\tR\x04zone\x12B\n" +
+	"\ba_record\x18\x02 \x01(\v2'.teleport.lib.vnet.diag.v1.RecordResultR\aaRecord\x12H\n" +
+	"\vaaaa_record\x18\x03 \x01(\v2'.teleport.lib.vnet.diag.v1.RecordResultR\n" +
+	"aaaaRecord\"\x87\x01\n" +
+	"\fRecordResult\x12@\n" +
+	"\x06status\x18\x01 \x01(\x0e2(.teleport.lib.vnet.diag.v1.DNSZoneStatusR\x06status\x12\x1f\n" +
+	"\vobserved_ip\x18\x02 \x01(\tR\n" +
+	"observedIp\x12\x14\n" +
+	"\x05error\x18\x03 \x01(\tR\x05error\"\xde\x02\n" +
 	"\x16SSHConfigurationReport\x127\n" +
 	"\x18user_openssh_config_path\x18\x01 \x01(\tR\x15userOpensshConfigPath\x12/\n" +
 	"\x14vnet_ssh_config_path\x18\x02 \x01(\tR\x11vnetSshConfigPath\x12\\\n" +
@@ -1641,7 +1880,7 @@ const file_teleport_lib_vnet_diag_v1_diag_proto_rawDesc = "" +
 	"\x1eDNS_ZONE_STATUS_RESOLVER_ERROR\x10\x05BQZOgithub.com/gravitational/teleport/gen/proto/go/teleport/lib/vnet/diag/v1;diagv1b\x06proto3"
 
 var file_teleport_lib_vnet_diag_v1_diag_proto_enumTypes = make([]protoimpl.EnumInfo, 4)
-var file_teleport_lib_vnet_diag_v1_diag_proto_msgTypes = make([]protoimpl.MessageInfo, 11)
+var file_teleport_lib_vnet_diag_v1_diag_proto_msgTypes = make([]protoimpl.MessageInfo, 13)
 var file_teleport_lib_vnet_diag_v1_diag_proto_goTypes = []any{
 	(CheckAttemptStatus)(0),        // 0: teleport.lib.vnet.diag.v1.CheckAttemptStatus
 	(CheckReportStatus)(0),         // 1: teleport.lib.vnet.diag.v1.CheckReportStatus
@@ -1656,12 +1895,14 @@ var file_teleport_lib_vnet_diag_v1_diag_proto_goTypes = []any{
 	(*RouteConflictReport)(nil),    // 10: teleport.lib.vnet.diag.v1.RouteConflictReport
 	(*RouteConflict)(nil),          // 11: teleport.lib.vnet.diag.v1.RouteConflict
 	(*DNSReport)(nil),              // 12: teleport.lib.vnet.diag.v1.DNSReport
-	(*DNSZoneResult)(nil),          // 13: teleport.lib.vnet.diag.v1.DNSZoneResult
-	(*SSHConfigurationReport)(nil), // 14: teleport.lib.vnet.diag.v1.SSHConfigurationReport
-	(*timestamppb.Timestamp)(nil),  // 15: google.protobuf.Timestamp
+	(*VNetDNSReachability)(nil),    // 13: teleport.lib.vnet.diag.v1.VNetDNSReachability
+	(*DNSZoneResult)(nil),          // 14: teleport.lib.vnet.diag.v1.DNSZoneResult
+	(*RecordResult)(nil),           // 15: teleport.lib.vnet.diag.v1.RecordResult
+	(*SSHConfigurationReport)(nil), // 16: teleport.lib.vnet.diag.v1.SSHConfigurationReport
+	(*timestamppb.Timestamp)(nil),  // 17: google.protobuf.Timestamp
 }
 var file_teleport_lib_vnet_diag_v1_diag_proto_depIdxs = []int32{
-	15, // 0: teleport.lib.vnet.diag.v1.Report.created_at:type_name -> google.protobuf.Timestamp
+	17, // 0: teleport.lib.vnet.diag.v1.Report.created_at:type_name -> google.protobuf.Timestamp
 	5,  // 1: teleport.lib.vnet.diag.v1.Report.network_stack_attempt:type_name -> teleport.lib.vnet.diag.v1.NetworkStackAttempt
 	7,  // 2: teleport.lib.vnet.diag.v1.Report.checks:type_name -> teleport.lib.vnet.diag.v1.CheckAttempt
 	0,  // 3: teleport.lib.vnet.diag.v1.NetworkStackAttempt.status:type_name -> teleport.lib.vnet.diag.v1.CheckAttemptStatus
@@ -1671,17 +1912,21 @@ var file_teleport_lib_vnet_diag_v1_diag_proto_depIdxs = []int32{
 	9,  // 7: teleport.lib.vnet.diag.v1.CheckAttempt.commands:type_name -> teleport.lib.vnet.diag.v1.CommandAttempt
 	1,  // 8: teleport.lib.vnet.diag.v1.CheckReport.status:type_name -> teleport.lib.vnet.diag.v1.CheckReportStatus
 	10, // 9: teleport.lib.vnet.diag.v1.CheckReport.route_conflict_report:type_name -> teleport.lib.vnet.diag.v1.RouteConflictReport
-	14, // 10: teleport.lib.vnet.diag.v1.CheckReport.ssh_configuration_report:type_name -> teleport.lib.vnet.diag.v1.SSHConfigurationReport
+	16, // 10: teleport.lib.vnet.diag.v1.CheckReport.ssh_configuration_report:type_name -> teleport.lib.vnet.diag.v1.SSHConfigurationReport
 	12, // 11: teleport.lib.vnet.diag.v1.CheckReport.dns_report:type_name -> teleport.lib.vnet.diag.v1.DNSReport
 	2,  // 12: teleport.lib.vnet.diag.v1.CommandAttempt.status:type_name -> teleport.lib.vnet.diag.v1.CommandAttemptStatus
 	11, // 13: teleport.lib.vnet.diag.v1.RouteConflictReport.route_conflicts:type_name -> teleport.lib.vnet.diag.v1.RouteConflict
-	13, // 14: teleport.lib.vnet.diag.v1.DNSReport.zone_results:type_name -> teleport.lib.vnet.diag.v1.DNSZoneResult
-	3,  // 15: teleport.lib.vnet.diag.v1.DNSZoneResult.status:type_name -> teleport.lib.vnet.diag.v1.DNSZoneStatus
-	16, // [16:16] is the sub-list for method output_type
-	16, // [16:16] is the sub-list for method input_type
-	16, // [16:16] is the sub-list for extension type_name
-	16, // [16:16] is the sub-list for extension extendee
-	0,  // [0:16] is the sub-list for field type_name
+	13, // 14: teleport.lib.vnet.diag.v1.DNSReport.ipv4_reachability:type_name -> teleport.lib.vnet.diag.v1.VNetDNSReachability
+	13, // 15: teleport.lib.vnet.diag.v1.DNSReport.ipv6_reachability:type_name -> teleport.lib.vnet.diag.v1.VNetDNSReachability
+	14, // 16: teleport.lib.vnet.diag.v1.DNSReport.zone_results:type_name -> teleport.lib.vnet.diag.v1.DNSZoneResult
+	15, // 17: teleport.lib.vnet.diag.v1.DNSZoneResult.a_record:type_name -> teleport.lib.vnet.diag.v1.RecordResult
+	15, // 18: teleport.lib.vnet.diag.v1.DNSZoneResult.aaaa_record:type_name -> teleport.lib.vnet.diag.v1.RecordResult
+	3,  // 19: teleport.lib.vnet.diag.v1.RecordResult.status:type_name -> teleport.lib.vnet.diag.v1.DNSZoneStatus
+	20, // [20:20] is the sub-list for method output_type
+	20, // [20:20] is the sub-list for method input_type
+	20, // [20:20] is the sub-list for extension type_name
+	20, // [20:20] is the sub-list for extension extendee
+	0,  // [0:20] is the sub-list for field type_name
 }
 
 func init() { file_teleport_lib_vnet_diag_v1_diag_proto_init() }
@@ -1700,7 +1945,7 @@ func file_teleport_lib_vnet_diag_v1_diag_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_teleport_lib_vnet_diag_v1_diag_proto_rawDesc), len(file_teleport_lib_vnet_diag_v1_diag_proto_rawDesc)),
 			NumEnums:      4,
-			NumMessages:   11,
+			NumMessages:   13,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/gen/proto/ts/teleport/lib/vnet/diag/v1/diag_pb.ts
+++ b/gen/proto/ts/teleport/lib/vnet/diag/v1/diag_pb.ts
@@ -192,6 +192,15 @@ export interface CheckReport {
          */
         sshConfigurationReport: SSHConfigurationReport;
     } | {
+        oneofKind: "dnsReport";
+        /**
+         * dns_report reports whether the system resolver routes queries for each VNet-managed DNS zone
+         * to VNet's nameserver.
+         *
+         * @generated from protobuf field: teleport.lib.vnet.diag.v1.DNSReport dns_report = 4;
+         */
+        dnsReport: DNSReport;
+    } | {
         oneofKind: undefined;
     };
 }
@@ -270,6 +279,83 @@ export interface RouteConflict {
      * @generated from protobuf field: string interface_app = 4;
      */
     interfaceApp: string;
+}
+/**
+ * DNSReport describes whether the system resolver routes DNS queries for VNet-managed zones to
+ * VNet's nameserver. It is the output of DNSDiag.
+ *
+ * The check uses a probe hostname of the form vnet-diag-<random>.<zone>. VNet's nameserver
+ * short-circuits any query with this prefix and answers with an address derived from its IPv6
+ * prefix, an address no other resolver can produce. The random label prevents DNS caches.
+ *
+ * The check first queries the probe directly against VNet's nameserver IP to confirm VNet's DNS
+ * server is reachable and to capture the expected response. If that fails, vnet_dns_reachable is
+ * false, vnet_dns_unreachable_error stores the error, and zone_results is empty. Otherwise, the
+ * check runs the same probe query per zone through the system resolver and compares each answer to
+ * the expected response. A mismatch means the per-zone OS resolver entry does not route to VNet.
+ *
+ * @generated from protobuf message teleport.lib.vnet.diag.v1.DNSReport
+ */
+export interface DNSReport {
+    /**
+     * vnet_dns_reachable is true if a direct DNS query to VNet's nameserver IP succeeded.
+     *
+     * @generated from protobuf field: bool vnet_dns_reachable = 1;
+     */
+    vnetDnsReachable: boolean;
+    /**
+     * vnet_dns_unreachable_error is set when vnet_dns_reachable is false.
+     *
+     * @generated from protobuf field: string vnet_dns_unreachable_error = 2;
+     */
+    vnetDnsUnreachableError: string;
+    /**
+     * zone_results contains one entry per zone in NetworkStack.dns_zones. Empty if
+     * vnet_dns_reachable is false.
+     *
+     * @generated from protobuf field: repeated teleport.lib.vnet.diag.v1.DNSZoneResult zone_results = 3;
+     */
+    zoneResults: DNSZoneResult[];
+}
+/**
+ * DNSZoneResult describes the outcome of querying a probe hostname under a single VNet-managed
+ * DNS zone through the system resolver.
+ *
+ * @generated from protobuf message teleport.lib.vnet.diag.v1.DNSZoneResult
+ */
+export interface DNSZoneResult {
+    /**
+     * zone is the DNS zone that was tested, e.g. "company.test".
+     *
+     * @generated from protobuf field: string zone = 1;
+     */
+    zone: string;
+    /**
+     * status describes the outcome of the query.
+     *
+     * @generated from protobuf field: teleport.lib.vnet.diag.v1.DNSZoneStatus status = 2;
+     */
+    status: DNSZoneStatus;
+    /**
+     * observed_ip is the IP returned by the system resolver for the probe hostname. Empty on
+     * timeout or no answer.
+     *
+     * @generated from protobuf field: string observed_ip = 3;
+     */
+    observedIp: string;
+    /**
+     * expected_ip is the IP that VNet's nameserver returned for the same probe hostname when
+     * queried directly.
+     *
+     * @generated from protobuf field: string expected_ip = 4;
+     */
+    expectedIp: string;
+    /**
+     * error is set on DNS_ZONE_STATUS_TIMEOUT and DNS_ZONE_STATUS_RESOLVER_ERROR.
+     *
+     * @generated from protobuf field: string error = 5;
+     */
+    error: string;
 }
 /**
  * SSHConfigurationReport describes the state of the system's SSH configuration.
@@ -379,6 +465,50 @@ export enum CommandAttemptStatus {
      * @generated from protobuf enum value: COMMAND_ATTEMPT_STATUS_ERROR = 2;
      */
     ERROR = 2
+}
+/**
+ * DNSZoneStatus is the outcome of querying a probe hostname for a single DNS zone.
+ *
+ * @generated from protobuf enum teleport.lib.vnet.diag.v1.DNSZoneStatus
+ */
+export enum DNSZoneStatus {
+    /**
+     * @generated from protobuf enum value: DNS_ZONE_STATUS_UNSPECIFIED = 0;
+     */
+    DNS_ZONE_STATUS_UNSPECIFIED = 0,
+    /**
+     * DNS_ZONE_STATUS_OK indicates the system resolver returned the IP we expected from VNet's
+     * nameserver, so per-zone routing works.
+     *
+     * @generated from protobuf enum value: DNS_ZONE_STATUS_OK = 1;
+     */
+    DNS_ZONE_STATUS_OK = 1,
+    /**
+     * DNS_ZONE_STATUS_HIJACKED indicates the system resolver returned an IP, but not the one VNet
+     * returned. Some other resolver answered for this zone.
+     *
+     * @generated from protobuf enum value: DNS_ZONE_STATUS_HIJACKED = 2;
+     */
+    DNS_ZONE_STATUS_HIJACKED = 2,
+    /**
+     * DNS_ZONE_STATUS_NOT_REGISTERED indicates the system resolver returned NXDOMAIN or SERVFAIL.
+     *
+     * @generated from protobuf enum value: DNS_ZONE_STATUS_NOT_REGISTERED = 3;
+     */
+    DNS_ZONE_STATUS_NOT_REGISTERED = 3,
+    /**
+     * DNS_ZONE_STATUS_TIMEOUT indicates the system resolver query timed out, likely because it
+     * was routed to a nameserver that is unreachable.
+     *
+     * @generated from protobuf enum value: DNS_ZONE_STATUS_TIMEOUT = 4;
+     */
+    DNS_ZONE_STATUS_TIMEOUT = 4,
+    /**
+     * DNS_ZONE_STATUS_RESOLVER_ERROR indicates an unexpected error from the system resolver.
+     *
+     * @generated from protobuf enum value: DNS_ZONE_STATUS_RESOLVER_ERROR = 5;
+     */
+    DNS_ZONE_STATUS_RESOLVER_ERROR = 5
 }
 // @generated message type with reflection information, may provide speed optimized methods
 class Report$Type extends MessageType<Report> {
@@ -650,7 +780,8 @@ class CheckReport$Type extends MessageType<CheckReport> {
         super("teleport.lib.vnet.diag.v1.CheckReport", [
             { no: 1, name: "status", kind: "enum", T: () => ["teleport.lib.vnet.diag.v1.CheckReportStatus", CheckReportStatus, "CHECK_REPORT_STATUS_"] },
             { no: 2, name: "route_conflict_report", kind: "message", oneof: "report", T: () => RouteConflictReport },
-            { no: 3, name: "ssh_configuration_report", kind: "message", oneof: "report", T: () => SSHConfigurationReport }
+            { no: 3, name: "ssh_configuration_report", kind: "message", oneof: "report", T: () => SSHConfigurationReport },
+            { no: 4, name: "dns_report", kind: "message", oneof: "report", T: () => DNSReport }
         ]);
     }
     create(value?: PartialMessage<CheckReport>): CheckReport {
@@ -681,6 +812,12 @@ class CheckReport$Type extends MessageType<CheckReport> {
                         sshConfigurationReport: SSHConfigurationReport.internalBinaryRead(reader, reader.uint32(), options, (message.report as any).sshConfigurationReport)
                     };
                     break;
+                case /* teleport.lib.vnet.diag.v1.DNSReport dns_report */ 4:
+                    message.report = {
+                        oneofKind: "dnsReport",
+                        dnsReport: DNSReport.internalBinaryRead(reader, reader.uint32(), options, (message.report as any).dnsReport)
+                    };
+                    break;
                 default:
                     let u = options.readUnknownField;
                     if (u === "throw")
@@ -702,6 +839,9 @@ class CheckReport$Type extends MessageType<CheckReport> {
         /* teleport.lib.vnet.diag.v1.SSHConfigurationReport ssh_configuration_report = 3; */
         if (message.report.oneofKind === "sshConfigurationReport")
             SSHConfigurationReport.internalBinaryWrite(message.report.sshConfigurationReport, writer.tag(3, WireType.LengthDelimited).fork(), options).join();
+        /* teleport.lib.vnet.diag.v1.DNSReport dns_report = 4; */
+        if (message.report.oneofKind === "dnsReport")
+            DNSReport.internalBinaryWrite(message.report.dnsReport, writer.tag(4, WireType.LengthDelimited).fork(), options).join();
         let u = options.writeUnknownFields;
         if (u !== false)
             (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
@@ -901,6 +1041,148 @@ class RouteConflict$Type extends MessageType<RouteConflict> {
  * @generated MessageType for protobuf message teleport.lib.vnet.diag.v1.RouteConflict
  */
 export const RouteConflict = new RouteConflict$Type();
+// @generated message type with reflection information, may provide speed optimized methods
+class DNSReport$Type extends MessageType<DNSReport> {
+    constructor() {
+        super("teleport.lib.vnet.diag.v1.DNSReport", [
+            { no: 1, name: "vnet_dns_reachable", kind: "scalar", T: 8 /*ScalarType.BOOL*/ },
+            { no: 2, name: "vnet_dns_unreachable_error", kind: "scalar", T: 9 /*ScalarType.STRING*/ },
+            { no: 3, name: "zone_results", kind: "message", repeat: 1 /*RepeatType.PACKED*/, T: () => DNSZoneResult }
+        ]);
+    }
+    create(value?: PartialMessage<DNSReport>): DNSReport {
+        const message = globalThis.Object.create((this.messagePrototype!));
+        message.vnetDnsReachable = false;
+        message.vnetDnsUnreachableError = "";
+        message.zoneResults = [];
+        if (value !== undefined)
+            reflectionMergePartial<DNSReport>(this, message, value);
+        return message;
+    }
+    internalBinaryRead(reader: IBinaryReader, length: number, options: BinaryReadOptions, target?: DNSReport): DNSReport {
+        let message = target ?? this.create(), end = reader.pos + length;
+        while (reader.pos < end) {
+            let [fieldNo, wireType] = reader.tag();
+            switch (fieldNo) {
+                case /* bool vnet_dns_reachable */ 1:
+                    message.vnetDnsReachable = reader.bool();
+                    break;
+                case /* string vnet_dns_unreachable_error */ 2:
+                    message.vnetDnsUnreachableError = reader.string();
+                    break;
+                case /* repeated teleport.lib.vnet.diag.v1.DNSZoneResult zone_results */ 3:
+                    message.zoneResults.push(DNSZoneResult.internalBinaryRead(reader, reader.uint32(), options));
+                    break;
+                default:
+                    let u = options.readUnknownField;
+                    if (u === "throw")
+                        throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
+                    let d = reader.skip(wireType);
+                    if (u !== false)
+                        (u === true ? UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            }
+        }
+        return message;
+    }
+    internalBinaryWrite(message: DNSReport, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
+        /* bool vnet_dns_reachable = 1; */
+        if (message.vnetDnsReachable !== false)
+            writer.tag(1, WireType.Varint).bool(message.vnetDnsReachable);
+        /* string vnet_dns_unreachable_error = 2; */
+        if (message.vnetDnsUnreachableError !== "")
+            writer.tag(2, WireType.LengthDelimited).string(message.vnetDnsUnreachableError);
+        /* repeated teleport.lib.vnet.diag.v1.DNSZoneResult zone_results = 3; */
+        for (let i = 0; i < message.zoneResults.length; i++)
+            DNSZoneResult.internalBinaryWrite(message.zoneResults[i], writer.tag(3, WireType.LengthDelimited).fork(), options).join();
+        let u = options.writeUnknownFields;
+        if (u !== false)
+            (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+        return writer;
+    }
+}
+/**
+ * @generated MessageType for protobuf message teleport.lib.vnet.diag.v1.DNSReport
+ */
+export const DNSReport = new DNSReport$Type();
+// @generated message type with reflection information, may provide speed optimized methods
+class DNSZoneResult$Type extends MessageType<DNSZoneResult> {
+    constructor() {
+        super("teleport.lib.vnet.diag.v1.DNSZoneResult", [
+            { no: 1, name: "zone", kind: "scalar", T: 9 /*ScalarType.STRING*/ },
+            { no: 2, name: "status", kind: "enum", T: () => ["teleport.lib.vnet.diag.v1.DNSZoneStatus", DNSZoneStatus] },
+            { no: 3, name: "observed_ip", kind: "scalar", T: 9 /*ScalarType.STRING*/ },
+            { no: 4, name: "expected_ip", kind: "scalar", T: 9 /*ScalarType.STRING*/ },
+            { no: 5, name: "error", kind: "scalar", T: 9 /*ScalarType.STRING*/ }
+        ]);
+    }
+    create(value?: PartialMessage<DNSZoneResult>): DNSZoneResult {
+        const message = globalThis.Object.create((this.messagePrototype!));
+        message.zone = "";
+        message.status = 0;
+        message.observedIp = "";
+        message.expectedIp = "";
+        message.error = "";
+        if (value !== undefined)
+            reflectionMergePartial<DNSZoneResult>(this, message, value);
+        return message;
+    }
+    internalBinaryRead(reader: IBinaryReader, length: number, options: BinaryReadOptions, target?: DNSZoneResult): DNSZoneResult {
+        let message = target ?? this.create(), end = reader.pos + length;
+        while (reader.pos < end) {
+            let [fieldNo, wireType] = reader.tag();
+            switch (fieldNo) {
+                case /* string zone */ 1:
+                    message.zone = reader.string();
+                    break;
+                case /* teleport.lib.vnet.diag.v1.DNSZoneStatus status */ 2:
+                    message.status = reader.int32();
+                    break;
+                case /* string observed_ip */ 3:
+                    message.observedIp = reader.string();
+                    break;
+                case /* string expected_ip */ 4:
+                    message.expectedIp = reader.string();
+                    break;
+                case /* string error */ 5:
+                    message.error = reader.string();
+                    break;
+                default:
+                    let u = options.readUnknownField;
+                    if (u === "throw")
+                        throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
+                    let d = reader.skip(wireType);
+                    if (u !== false)
+                        (u === true ? UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            }
+        }
+        return message;
+    }
+    internalBinaryWrite(message: DNSZoneResult, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
+        /* string zone = 1; */
+        if (message.zone !== "")
+            writer.tag(1, WireType.LengthDelimited).string(message.zone);
+        /* teleport.lib.vnet.diag.v1.DNSZoneStatus status = 2; */
+        if (message.status !== 0)
+            writer.tag(2, WireType.Varint).int32(message.status);
+        /* string observed_ip = 3; */
+        if (message.observedIp !== "")
+            writer.tag(3, WireType.LengthDelimited).string(message.observedIp);
+        /* string expected_ip = 4; */
+        if (message.expectedIp !== "")
+            writer.tag(4, WireType.LengthDelimited).string(message.expectedIp);
+        /* string error = 5; */
+        if (message.error !== "")
+            writer.tag(5, WireType.LengthDelimited).string(message.error);
+        let u = options.writeUnknownFields;
+        if (u !== false)
+            (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+        return writer;
+    }
+}
+/**
+ * @generated MessageType for protobuf message teleport.lib.vnet.diag.v1.DNSZoneResult
+ */
+export const DNSZoneResult = new DNSZoneResult$Type();
 // @generated message type with reflection information, may provide speed optimized methods
 class SSHConfigurationReport$Type extends MessageType<SSHConfigurationReport> {
     constructor() {

--- a/gen/proto/ts/teleport/lib/vnet/diag/v1/diag_pb.ts
+++ b/gen/proto/ts/teleport/lib/vnet/diag/v1/diag_pb.ts
@@ -285,41 +285,85 @@ export interface RouteConflict {
  * VNet's nameserver. It is the output of DNSDiag.
  *
  * The check uses a probe hostname of the form vnet-diag-<random>.<zone>. VNet's nameserver
- * short-circuits any query with this prefix and answers with an address derived from its IPv6
- * prefix, an address no other resolver can produce. The random label prevents DNS caches.
+ * short-circuits any query with this prefix and answers with addresses derived from its IPv4 CIDR
+ * range and IPv6 prefix, addresses no other resolver can produce. The random label prevents DNS
+ * caches.
  *
- * The check first queries the probe directly against VNet's nameserver IP to confirm VNet's DNS
- * server is reachable and to capture the expected response. If that fails, vnet_dns_reachable is
- * false, vnet_dns_unreachable_error stores the error, and zone_results is empty. Otherwise, the
- * check runs the same probe query per zone through the system resolver and compares each answer to
- * the expected response. A mismatch means the per-zone OS resolver entry does not route to VNet.
+ * The check first queries the probe directly against each VNet nameserver IPv4 and IPv6 addresses
+ * asking for both A and AAAA records, to confirm VNet's DNS server is reachable and to capture the
+ * expected responses per record type. If an IPv4 or IPv6 address is unreachable, the corresponding
+ * reachability field still records the failure but the check continues with whatever was captured
+ * from successful queries. If neither address produced a response for either record type,
+ * zone_results is empty. Otherwise, the check runs the same probe per zone through the system
+ * resolver, asking for A and AAAA independently, and compares each answer to the expected response.
+ * A mismatch means the per-zone OS resolver entry does not route to VNet.
  *
  * @generated from protobuf message teleport.lib.vnet.diag.v1.DNSReport
  */
 export interface DNSReport {
     /**
-     * vnet_dns_reachable is true if a direct DNS query to VNet's nameserver IP succeeded.
+     * ipv4_reachability is the outcome of probing VNet's IPv4 nameserver directly. Null if VNet is
+     * not serving DNS on IPv4.
      *
-     * @generated from protobuf field: bool vnet_dns_reachable = 1;
+     * @generated from protobuf field: teleport.lib.vnet.diag.v1.VNetDNSReachability ipv4_reachability = 1;
      */
-    vnetDnsReachable: boolean;
+    ipv4Reachability?: VNetDNSReachability;
     /**
-     * vnet_dns_unreachable_error is set when vnet_dns_reachable is false.
+     * ipv6_reachability is the outcome of probing VNet's IPv6 nameserver directly. Null if VNet is
+     * not serving DNS on IPv6.
      *
-     * @generated from protobuf field: string vnet_dns_unreachable_error = 2;
+     * @generated from protobuf field: teleport.lib.vnet.diag.v1.VNetDNSReachability ipv6_reachability = 2;
      */
-    vnetDnsUnreachableError: string;
+    ipv6Reachability?: VNetDNSReachability;
     /**
-     * zone_results contains one entry per zone in NetworkStack.dns_zones. Empty if
-     * vnet_dns_reachable is false.
+     * zone_results contains one entry per zone in NetworkStack.dns_zones. Empty if neither
+     * reachability probe produced a response for either record type.
      *
      * @generated from protobuf field: repeated teleport.lib.vnet.diag.v1.DNSZoneResult zone_results = 3;
      */
     zoneResults: DNSZoneResult[];
 }
 /**
+ * VNetDNSReachability describes the outcome of probing one of VNet's DNS servers directly,
+ * bypassing the system resolver.
+ *
+ * @generated from protobuf message teleport.lib.vnet.diag.v1.VNetDNSReachability
+ */
+export interface VNetDNSReachability {
+    /**
+     * address is the server that was probed, e.g. "[fdec:1fed:139f::2]:53" or "100.64.0.2:53".
+     *
+     * @generated from protobuf field: string address = 1;
+     */
+    address: string;
+    /**
+     * reachable is true if the server returned an answer for at least one record type.
+     *
+     * @generated from protobuf field: bool reachable = 2;
+     */
+    reachable: boolean;
+    /**
+     * responded_a is true if the server returned an A record for the probe.
+     *
+     * @generated from protobuf field: bool responded_a = 3;
+     */
+    respondedA: boolean;
+    /**
+     * responded_aaaa is true if the server returned an AAAA record for the probe.
+     *
+     * @generated from protobuf field: bool responded_aaaa = 4;
+     */
+    respondedAaaa: boolean;
+    /**
+     * error explains the failure when reachable is false.
+     *
+     * @generated from protobuf field: string error = 5;
+     */
+    error: string;
+}
+/**
  * DNSZoneResult describes the outcome of querying a probe hostname under a single VNet-managed
- * DNS zone through the system resolver.
+ * DNS zone through the system resolver. The query is made for both A and AAAA records.
  *
  * @generated from protobuf message teleport.lib.vnet.diag.v1.DNSZoneResult
  */
@@ -331,29 +375,43 @@ export interface DNSZoneResult {
      */
     zone: string;
     /**
-     * status describes the outcome of the query.
+     * a_record is the outcome of the A-record part of the per-zone query. Null if no expected A was
+     * captured.
      *
-     * @generated from protobuf field: teleport.lib.vnet.diag.v1.DNSZoneStatus status = 2;
+     * @generated from protobuf field: teleport.lib.vnet.diag.v1.RecordResult a_record = 2;
+     */
+    aRecord?: RecordResult;
+    /**
+     * aaaa_record is the outcome of the AAAA-record part of the per-zone query. Null if no expected
+     * AAAA was captured.
+     *
+     * @generated from protobuf field: teleport.lib.vnet.diag.v1.RecordResult aaaa_record = 3;
+     */
+    aaaaRecord?: RecordResult;
+}
+/**
+ * RecordResult describes the outcome of querying a single record type for a single zone through
+ * the system resolver.
+ *
+ * @generated from protobuf message teleport.lib.vnet.diag.v1.RecordResult
+ */
+export interface RecordResult {
+    /**
+     * status describes the outcome of the query for this record type.
+     *
+     * @generated from protobuf field: teleport.lib.vnet.diag.v1.DNSZoneStatus status = 1;
      */
     status: DNSZoneStatus;
     /**
-     * observed_ip is the IP returned by the system resolver for the probe hostname. Empty on
-     * timeout or no answer.
+     * observed_ip is the IP returned by the system resolver. Populated for DNS_ZONE_STATUS_HIJACKED.
      *
-     * @generated from protobuf field: string observed_ip = 3;
+     * @generated from protobuf field: string observed_ip = 2;
      */
     observedIp: string;
     /**
-     * expected_ip is the IP that VNet's nameserver returned for the same probe hostname when
-     * queried directly.
-     *
-     * @generated from protobuf field: string expected_ip = 4;
-     */
-    expectedIp: string;
-    /**
      * error is set on DNS_ZONE_STATUS_TIMEOUT and DNS_ZONE_STATUS_RESOLVER_ERROR.
      *
-     * @generated from protobuf field: string error = 5;
+     * @generated from protobuf field: string error = 3;
      */
     error: string;
 }
@@ -1045,15 +1103,13 @@ export const RouteConflict = new RouteConflict$Type();
 class DNSReport$Type extends MessageType<DNSReport> {
     constructor() {
         super("teleport.lib.vnet.diag.v1.DNSReport", [
-            { no: 1, name: "vnet_dns_reachable", kind: "scalar", T: 8 /*ScalarType.BOOL*/ },
-            { no: 2, name: "vnet_dns_unreachable_error", kind: "scalar", T: 9 /*ScalarType.STRING*/ },
+            { no: 1, name: "ipv4_reachability", kind: "message", T: () => VNetDNSReachability },
+            { no: 2, name: "ipv6_reachability", kind: "message", T: () => VNetDNSReachability },
             { no: 3, name: "zone_results", kind: "message", repeat: 1 /*RepeatType.PACKED*/, T: () => DNSZoneResult }
         ]);
     }
     create(value?: PartialMessage<DNSReport>): DNSReport {
         const message = globalThis.Object.create((this.messagePrototype!));
-        message.vnetDnsReachable = false;
-        message.vnetDnsUnreachableError = "";
         message.zoneResults = [];
         if (value !== undefined)
             reflectionMergePartial<DNSReport>(this, message, value);
@@ -1064,11 +1120,11 @@ class DNSReport$Type extends MessageType<DNSReport> {
         while (reader.pos < end) {
             let [fieldNo, wireType] = reader.tag();
             switch (fieldNo) {
-                case /* bool vnet_dns_reachable */ 1:
-                    message.vnetDnsReachable = reader.bool();
+                case /* teleport.lib.vnet.diag.v1.VNetDNSReachability ipv4_reachability */ 1:
+                    message.ipv4Reachability = VNetDNSReachability.internalBinaryRead(reader, reader.uint32(), options, message.ipv4Reachability);
                     break;
-                case /* string vnet_dns_unreachable_error */ 2:
-                    message.vnetDnsUnreachableError = reader.string();
+                case /* teleport.lib.vnet.diag.v1.VNetDNSReachability ipv6_reachability */ 2:
+                    message.ipv6Reachability = VNetDNSReachability.internalBinaryRead(reader, reader.uint32(), options, message.ipv6Reachability);
                     break;
                 case /* repeated teleport.lib.vnet.diag.v1.DNSZoneResult zone_results */ 3:
                     message.zoneResults.push(DNSZoneResult.internalBinaryRead(reader, reader.uint32(), options));
@@ -1085,12 +1141,12 @@ class DNSReport$Type extends MessageType<DNSReport> {
         return message;
     }
     internalBinaryWrite(message: DNSReport, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
-        /* bool vnet_dns_reachable = 1; */
-        if (message.vnetDnsReachable !== false)
-            writer.tag(1, WireType.Varint).bool(message.vnetDnsReachable);
-        /* string vnet_dns_unreachable_error = 2; */
-        if (message.vnetDnsUnreachableError !== "")
-            writer.tag(2, WireType.LengthDelimited).string(message.vnetDnsUnreachableError);
+        /* teleport.lib.vnet.diag.v1.VNetDNSReachability ipv4_reachability = 1; */
+        if (message.ipv4Reachability)
+            VNetDNSReachability.internalBinaryWrite(message.ipv4Reachability, writer.tag(1, WireType.LengthDelimited).fork(), options).join();
+        /* teleport.lib.vnet.diag.v1.VNetDNSReachability ipv6_reachability = 2; */
+        if (message.ipv6Reachability)
+            VNetDNSReachability.internalBinaryWrite(message.ipv6Reachability, writer.tag(2, WireType.LengthDelimited).fork(), options).join();
         /* repeated teleport.lib.vnet.diag.v1.DNSZoneResult zone_results = 3; */
         for (let i = 0; i < message.zoneResults.length; i++)
             DNSZoneResult.internalBinaryWrite(message.zoneResults[i], writer.tag(3, WireType.LengthDelimited).fork(), options).join();
@@ -1105,23 +1161,96 @@ class DNSReport$Type extends MessageType<DNSReport> {
  */
 export const DNSReport = new DNSReport$Type();
 // @generated message type with reflection information, may provide speed optimized methods
+class VNetDNSReachability$Type extends MessageType<VNetDNSReachability> {
+    constructor() {
+        super("teleport.lib.vnet.diag.v1.VNetDNSReachability", [
+            { no: 1, name: "address", kind: "scalar", T: 9 /*ScalarType.STRING*/ },
+            { no: 2, name: "reachable", kind: "scalar", T: 8 /*ScalarType.BOOL*/ },
+            { no: 3, name: "responded_a", kind: "scalar", T: 8 /*ScalarType.BOOL*/ },
+            { no: 4, name: "responded_aaaa", kind: "scalar", T: 8 /*ScalarType.BOOL*/ },
+            { no: 5, name: "error", kind: "scalar", T: 9 /*ScalarType.STRING*/ }
+        ]);
+    }
+    create(value?: PartialMessage<VNetDNSReachability>): VNetDNSReachability {
+        const message = globalThis.Object.create((this.messagePrototype!));
+        message.address = "";
+        message.reachable = false;
+        message.respondedA = false;
+        message.respondedAaaa = false;
+        message.error = "";
+        if (value !== undefined)
+            reflectionMergePartial<VNetDNSReachability>(this, message, value);
+        return message;
+    }
+    internalBinaryRead(reader: IBinaryReader, length: number, options: BinaryReadOptions, target?: VNetDNSReachability): VNetDNSReachability {
+        let message = target ?? this.create(), end = reader.pos + length;
+        while (reader.pos < end) {
+            let [fieldNo, wireType] = reader.tag();
+            switch (fieldNo) {
+                case /* string address */ 1:
+                    message.address = reader.string();
+                    break;
+                case /* bool reachable */ 2:
+                    message.reachable = reader.bool();
+                    break;
+                case /* bool responded_a */ 3:
+                    message.respondedA = reader.bool();
+                    break;
+                case /* bool responded_aaaa */ 4:
+                    message.respondedAaaa = reader.bool();
+                    break;
+                case /* string error */ 5:
+                    message.error = reader.string();
+                    break;
+                default:
+                    let u = options.readUnknownField;
+                    if (u === "throw")
+                        throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
+                    let d = reader.skip(wireType);
+                    if (u !== false)
+                        (u === true ? UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            }
+        }
+        return message;
+    }
+    internalBinaryWrite(message: VNetDNSReachability, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
+        /* string address = 1; */
+        if (message.address !== "")
+            writer.tag(1, WireType.LengthDelimited).string(message.address);
+        /* bool reachable = 2; */
+        if (message.reachable !== false)
+            writer.tag(2, WireType.Varint).bool(message.reachable);
+        /* bool responded_a = 3; */
+        if (message.respondedA !== false)
+            writer.tag(3, WireType.Varint).bool(message.respondedA);
+        /* bool responded_aaaa = 4; */
+        if (message.respondedAaaa !== false)
+            writer.tag(4, WireType.Varint).bool(message.respondedAaaa);
+        /* string error = 5; */
+        if (message.error !== "")
+            writer.tag(5, WireType.LengthDelimited).string(message.error);
+        let u = options.writeUnknownFields;
+        if (u !== false)
+            (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+        return writer;
+    }
+}
+/**
+ * @generated MessageType for protobuf message teleport.lib.vnet.diag.v1.VNetDNSReachability
+ */
+export const VNetDNSReachability = new VNetDNSReachability$Type();
+// @generated message type with reflection information, may provide speed optimized methods
 class DNSZoneResult$Type extends MessageType<DNSZoneResult> {
     constructor() {
         super("teleport.lib.vnet.diag.v1.DNSZoneResult", [
             { no: 1, name: "zone", kind: "scalar", T: 9 /*ScalarType.STRING*/ },
-            { no: 2, name: "status", kind: "enum", T: () => ["teleport.lib.vnet.diag.v1.DNSZoneStatus", DNSZoneStatus] },
-            { no: 3, name: "observed_ip", kind: "scalar", T: 9 /*ScalarType.STRING*/ },
-            { no: 4, name: "expected_ip", kind: "scalar", T: 9 /*ScalarType.STRING*/ },
-            { no: 5, name: "error", kind: "scalar", T: 9 /*ScalarType.STRING*/ }
+            { no: 2, name: "a_record", kind: "message", T: () => RecordResult },
+            { no: 3, name: "aaaa_record", kind: "message", T: () => RecordResult }
         ]);
     }
     create(value?: PartialMessage<DNSZoneResult>): DNSZoneResult {
         const message = globalThis.Object.create((this.messagePrototype!));
         message.zone = "";
-        message.status = 0;
-        message.observedIp = "";
-        message.expectedIp = "";
-        message.error = "";
         if (value !== undefined)
             reflectionMergePartial<DNSZoneResult>(this, message, value);
         return message;
@@ -1134,17 +1263,11 @@ class DNSZoneResult$Type extends MessageType<DNSZoneResult> {
                 case /* string zone */ 1:
                     message.zone = reader.string();
                     break;
-                case /* teleport.lib.vnet.diag.v1.DNSZoneStatus status */ 2:
-                    message.status = reader.int32();
+                case /* teleport.lib.vnet.diag.v1.RecordResult a_record */ 2:
+                    message.aRecord = RecordResult.internalBinaryRead(reader, reader.uint32(), options, message.aRecord);
                     break;
-                case /* string observed_ip */ 3:
-                    message.observedIp = reader.string();
-                    break;
-                case /* string expected_ip */ 4:
-                    message.expectedIp = reader.string();
-                    break;
-                case /* string error */ 5:
-                    message.error = reader.string();
+                case /* teleport.lib.vnet.diag.v1.RecordResult aaaa_record */ 3:
+                    message.aaaaRecord = RecordResult.internalBinaryRead(reader, reader.uint32(), options, message.aaaaRecord);
                     break;
                 default:
                     let u = options.readUnknownField;
@@ -1161,18 +1284,12 @@ class DNSZoneResult$Type extends MessageType<DNSZoneResult> {
         /* string zone = 1; */
         if (message.zone !== "")
             writer.tag(1, WireType.LengthDelimited).string(message.zone);
-        /* teleport.lib.vnet.diag.v1.DNSZoneStatus status = 2; */
-        if (message.status !== 0)
-            writer.tag(2, WireType.Varint).int32(message.status);
-        /* string observed_ip = 3; */
-        if (message.observedIp !== "")
-            writer.tag(3, WireType.LengthDelimited).string(message.observedIp);
-        /* string expected_ip = 4; */
-        if (message.expectedIp !== "")
-            writer.tag(4, WireType.LengthDelimited).string(message.expectedIp);
-        /* string error = 5; */
-        if (message.error !== "")
-            writer.tag(5, WireType.LengthDelimited).string(message.error);
+        /* teleport.lib.vnet.diag.v1.RecordResult a_record = 2; */
+        if (message.aRecord)
+            RecordResult.internalBinaryWrite(message.aRecord, writer.tag(2, WireType.LengthDelimited).fork(), options).join();
+        /* teleport.lib.vnet.diag.v1.RecordResult aaaa_record = 3; */
+        if (message.aaaaRecord)
+            RecordResult.internalBinaryWrite(message.aaaaRecord, writer.tag(3, WireType.LengthDelimited).fork(), options).join();
         let u = options.writeUnknownFields;
         if (u !== false)
             (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
@@ -1183,6 +1300,69 @@ class DNSZoneResult$Type extends MessageType<DNSZoneResult> {
  * @generated MessageType for protobuf message teleport.lib.vnet.diag.v1.DNSZoneResult
  */
 export const DNSZoneResult = new DNSZoneResult$Type();
+// @generated message type with reflection information, may provide speed optimized methods
+class RecordResult$Type extends MessageType<RecordResult> {
+    constructor() {
+        super("teleport.lib.vnet.diag.v1.RecordResult", [
+            { no: 1, name: "status", kind: "enum", T: () => ["teleport.lib.vnet.diag.v1.DNSZoneStatus", DNSZoneStatus] },
+            { no: 2, name: "observed_ip", kind: "scalar", T: 9 /*ScalarType.STRING*/ },
+            { no: 3, name: "error", kind: "scalar", T: 9 /*ScalarType.STRING*/ }
+        ]);
+    }
+    create(value?: PartialMessage<RecordResult>): RecordResult {
+        const message = globalThis.Object.create((this.messagePrototype!));
+        message.status = 0;
+        message.observedIp = "";
+        message.error = "";
+        if (value !== undefined)
+            reflectionMergePartial<RecordResult>(this, message, value);
+        return message;
+    }
+    internalBinaryRead(reader: IBinaryReader, length: number, options: BinaryReadOptions, target?: RecordResult): RecordResult {
+        let message = target ?? this.create(), end = reader.pos + length;
+        while (reader.pos < end) {
+            let [fieldNo, wireType] = reader.tag();
+            switch (fieldNo) {
+                case /* teleport.lib.vnet.diag.v1.DNSZoneStatus status */ 1:
+                    message.status = reader.int32();
+                    break;
+                case /* string observed_ip */ 2:
+                    message.observedIp = reader.string();
+                    break;
+                case /* string error */ 3:
+                    message.error = reader.string();
+                    break;
+                default:
+                    let u = options.readUnknownField;
+                    if (u === "throw")
+                        throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
+                    let d = reader.skip(wireType);
+                    if (u !== false)
+                        (u === true ? UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            }
+        }
+        return message;
+    }
+    internalBinaryWrite(message: RecordResult, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
+        /* teleport.lib.vnet.diag.v1.DNSZoneStatus status = 1; */
+        if (message.status !== 0)
+            writer.tag(1, WireType.Varint).int32(message.status);
+        /* string observed_ip = 2; */
+        if (message.observedIp !== "")
+            writer.tag(2, WireType.LengthDelimited).string(message.observedIp);
+        /* string error = 3; */
+        if (message.error !== "")
+            writer.tag(3, WireType.LengthDelimited).string(message.error);
+        let u = options.writeUnknownFields;
+        if (u !== false)
+            (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+        return writer;
+    }
+}
+/**
+ * @generated MessageType for protobuf message teleport.lib.vnet.diag.v1.RecordResult
+ */
+export const RecordResult = new RecordResult$Type();
 // @generated message type with reflection information, may provide speed optimized methods
 class SSHConfigurationReport$Type extends MessageType<SSHConfigurationReport> {
     constructor() {

--- a/gen/proto/ts/teleport/lib/vnet/diag/v1/diag_pb.ts
+++ b/gen/proto/ts/teleport/lib/vnet/diag/v1/diag_pb.ts
@@ -375,15 +375,19 @@ export interface DNSZoneResult {
      */
     zone: string;
     /**
-     * a_record is the outcome of the A-record part of the per-zone query. Null if no expected A was
-     * captured.
+     * a_record is the outcome of the A-record query for this zone, compared to the
+     * A returned by VNet's DNS server on direct query. The check is skipped and
+     * this field is null when VNet's DNS server failed to return an A on direct
+     * query.
      *
      * @generated from protobuf field: teleport.lib.vnet.diag.v1.RecordResult a_record = 2;
      */
     aRecord?: RecordResult;
     /**
-     * aaaa_record is the outcome of the AAAA-record part of the per-zone query. Null if no expected
-     * AAAA was captured.
+     * aaaa_record is the outcome of the AAAA-record query for this zone, compared
+     * to the AAAA returned by VNet's DNS server on direct query. The check is
+     * skipped and this field is null when VNet's DNS server failed to return an
+     * AAAA on direct query.
      *
      * @generated from protobuf field: teleport.lib.vnet.diag.v1.RecordResult aaaa_record = 3;
      */

--- a/lib/teleterm/vnet/service.go
+++ b/lib/teleterm/vnet/service.go
@@ -283,30 +283,33 @@ func (s *Service) RunDiagnostics(ctx context.Context, req *api.RunDiagnosticsReq
 		nsa.SetNetworkStack(ns)
 	}
 
-	diagChecks, err := s.platformDiagChecks(ctx)
+	var diagChecks []diag.DiagCheck
+
+	//nolint:staticcheck // SA4023. routeConflictDiag may be nil on unsupported platforms (see service_other.go).
+	routeConflictDiag, err := s.platformRouteConflictDiag()
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
+	//nolint:staticcheck // SA4023.
+	if routeConflictDiag != nil {
+		diagChecks = append(diagChecks, routeConflictDiag)
+	}
 
-	// The DNS check is platform-agnostic, so it's added here rather than in
-	// platformDiagChecks. Skip it if NetworkStack is unavailable we need the
+	// Skip the DNS check if NetworkStack is unavailable we need the
 	// IPv6 prefix to derive VNet's DNS server address.
 	if ns := nsa.NetworkStack; ns != nil && ns.Ipv6Prefix != "" {
-		// TODO(tangyatsu): make NetworkStackInfo return DNS server addresses directly.
-		vnetDNSServer, err := diag.DNSServerForIPv6Prefix(ns.Ipv6Prefix)
+		dnsDiag, err := s.dnsDiag(ns)
 		if err != nil {
-			return nil, trace.Wrap(err, "computing VNet DNS server address for DNS diag check")
-		}
-
-		dnsDiag, err := diag.NewDNSDiag(&diag.DNSConfig{
-			DNSZones:      ns.DnsZones,
-			VNetDNSServer: vnetDNSServer,
-		})
-		if err != nil {
-			return nil, trace.Wrap(err, "constructing DNS diag check")
+			return nil, trace.Wrap(err)
 		}
 		diagChecks = append(diagChecks, dnsDiag)
 	}
+
+	sshDiag, err := s.sshDiag()
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	diagChecks = append(diagChecks, sshDiag)
 
 	report, err := diag.GenerateReport(ctx, diag.ReportPrerequisites{
 		Clock:               s.cfg.Clock,
@@ -320,6 +323,29 @@ func (s *Service) RunDiagnostics(ctx context.Context, req *api.RunDiagnosticsReq
 	return api.RunDiagnosticsResponse_builder{
 		Report: report,
 	}.Build(), nil
+}
+
+// sshDiag builds the SSH configuration diagnostic check. It is platform-agnostic.
+func (s *Service) sshDiag() (diag.DiagCheck, error) {
+	sshDiag, err := diag.NewSSHDiag(&diag.SSHConfig{
+		ProfilePath: s.cfg.profilePath,
+	})
+	return sshDiag, trace.Wrap(err)
+}
+
+// dnsDiag builds the DNS diagnostic check. It is platform-agnostic.
+func (s *Service) dnsDiag(ns *diagv1.NetworkStack) (diag.DiagCheck, error) {
+	// TODO(tangyatsu): make NetworkStackInfo return DNS server addresses directly.
+	vnetDNSServer, err := diag.DNSServerForIPv6Prefix(ns.Ipv6Prefix)
+	if err != nil {
+		return nil, trace.Wrap(err, "computing VNet DNS server address for DNS diag check")
+	}
+
+	dnsDiag, err := diag.NewDNSDiag(&diag.DNSConfig{
+		DNSZones:      ns.DnsZones,
+		VNetDNSServer: vnetDNSServer,
+	})
+	return dnsDiag, trace.Wrap(err, "constructing DNS diag check")
 }
 
 func (s *Service) getNetworkStack(ctx context.Context) (*diagv1.NetworkStack, error) {

--- a/lib/teleterm/vnet/service.go
+++ b/lib/teleterm/vnet/service.go
@@ -295,9 +295,9 @@ func (s *Service) RunDiagnostics(ctx context.Context, req *api.RunDiagnosticsReq
 		diagChecks = append(diagChecks, routeConflictDiag)
 	}
 
-	// Skip the DNS check if NetworkStack is unavailable we need the
-	// IPv6 prefix to derive VNet's DNS server address.
-	if ns := nsa.NetworkStack; ns != nil && ns.Ipv6Prefix != "" {
+	// Skip the DNS check if NetworkStack is unavailable we need at least one
+	// of Ipv6Prefix, Ipv4CidrRanges to derive a VNet DNS server address.
+	if ns := nsa.NetworkStack; ns != nil && (ns.Ipv6Prefix != "" || len(ns.Ipv4CidrRanges) > 0) {
 		dnsDiag, err := s.dnsDiag(ns)
 		if err != nil {
 			return nil, trace.Wrap(err)
@@ -336,15 +336,22 @@ func (s *Service) sshDiag() (diag.DiagCheck, error) {
 // dnsDiag builds the DNS diagnostic check. It is platform-agnostic.
 func (s *Service) dnsDiag(ns *diagv1.NetworkStack) (diag.DiagCheck, error) {
 	// TODO(tangyatsu): make NetworkStackInfo return DNS server addresses directly.
-	vnetDNSServer, err := diag.DNSServerForIPv6Prefix(ns.Ipv6Prefix)
-	if err != nil {
-		return nil, trace.Wrap(err, "computing VNet DNS server address for DNS diag check")
+	cfg := &diag.DNSConfig{DNSZones: ns.DnsZones}
+	if ns.Ipv6Prefix != "" {
+		s, err := diag.DNSServerForIPv6Prefix(ns.Ipv6Prefix)
+		if err != nil {
+			return nil, trace.Wrap(err, "computing VNet IPv6 DNS server address for DNS diag check")
+		}
+		cfg.VNetDNSIPv6 = s
 	}
-
-	dnsDiag, err := diag.NewDNSDiag(&diag.DNSConfig{
-		DNSZones:      ns.DnsZones,
-		VNetDNSServer: vnetDNSServer,
-	})
+	if len(ns.Ipv4CidrRanges) > 0 {
+		s, err := diag.DNSServerForIPv4CIDRRange(ns.Ipv4CidrRanges[0])
+		if err != nil {
+			return nil, trace.Wrap(err, "computing VNet IPv4 DNS server address for DNS diag check")
+		}
+		cfg.VNetDNSIPv4 = s
+	}
+	dnsDiag, err := diag.NewDNSDiag(cfg)
 	return dnsDiag, trace.Wrap(err, "constructing DNS diag check")
 }
 

--- a/lib/teleterm/vnet/service.go
+++ b/lib/teleterm/vnet/service.go
@@ -288,6 +288,26 @@ func (s *Service) RunDiagnostics(ctx context.Context, req *api.RunDiagnosticsReq
 		return nil, trace.Wrap(err)
 	}
 
+	// The DNS check is platform-agnostic, so it's added here rather than in
+	// platformDiagChecks. Skip it if NetworkStack is unavailable we need the
+	// IPv6 prefix to derive VNet's DNS server address.
+	if ns := nsa.NetworkStack; ns != nil && ns.Ipv6Prefix != "" {
+		// TODO(tangyatsu): make NetworkStackInfo return DNS server addresses directly.
+		vnetDNSServer, err := diag.DNSServerForIPv6Prefix(ns.Ipv6Prefix)
+		if err != nil {
+			return nil, trace.Wrap(err, "computing VNet DNS server address for DNS diag check")
+		}
+
+		dnsDiag, err := diag.NewDNSDiag(&diag.DNSConfig{
+			DNSZones:      ns.DnsZones,
+			VNetDNSServer: vnetDNSServer,
+		})
+		if err != nil {
+			return nil, trace.Wrap(err, "constructing DNS diag check")
+		}
+		diagChecks = append(diagChecks, dnsDiag)
+	}
+
 	report, err := diag.GenerateReport(ctx, diag.ReportPrerequisites{
 		Clock:               s.cfg.Clock,
 		NetworkStackAttempt: nsa,

--- a/lib/teleterm/vnet/service.go
+++ b/lib/teleterm/vnet/service.go
@@ -311,6 +311,7 @@ func (s *Service) RunDiagnostics(ctx context.Context, req *api.RunDiagnosticsReq
 	}
 	diagChecks = append(diagChecks, sshDiag)
 
+	// TODO(tangyatsu): release s.mu before diag checks and cancel them on Stop.
 	report, err := diag.GenerateReport(ctx, diag.ReportPrerequisites{
 		Clock:               s.cfg.Clock,
 		NetworkStackAttempt: nsa,

--- a/lib/teleterm/vnet/service_darwin.go
+++ b/lib/teleterm/vnet/service_darwin.go
@@ -17,32 +17,13 @@
 package vnet
 
 import (
-	"context"
-
-	"github.com/gravitational/trace"
-
 	"github.com/gravitational/teleport/lib/vnet/diag"
 )
 
-func (s *Service) platformDiagChecks(ctx context.Context) ([]diag.DiagCheck, error) {
-	routeConflictDiag, err := diag.NewRouteConflictDiag(&diag.RouteConflictConfig{
+func (s *Service) platformRouteConflictDiag() (diag.DiagCheck, error) {
+	return diag.NewRouteConflictDiag(&diag.RouteConflictConfig{
 		VnetIfaceName: s.networkStackInfo.GetInterfaceName(),
 		Routing:       &diag.DarwinRouting{},
 		Interfaces:    &diag.NetInterfaces{},
 	})
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-
-	sshDiag, err := diag.NewSSHDiag(&diag.SSHConfig{
-		ProfilePath: s.cfg.profilePath,
-	})
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-
-	return []diag.DiagCheck{
-		routeConflictDiag,
-		sshDiag,
-	}, nil
 }

--- a/lib/teleterm/vnet/service_linux.go
+++ b/lib/teleterm/vnet/service_linux.go
@@ -17,32 +17,13 @@
 package vnet
 
 import (
-	"context"
-
-	"github.com/gravitational/trace"
-
 	"github.com/gravitational/teleport/lib/vnet/diag"
 )
 
-func (s *Service) platformDiagChecks(ctx context.Context) ([]diag.DiagCheck, error) {
-	routeConflictDiag, err := diag.NewRouteConflictDiag(&diag.RouteConflictConfig{
-		VnetIfaceName: s.networkStackInfo.InterfaceName,
+func (s *Service) platformRouteConflictDiag() (diag.DiagCheck, error) {
+	return diag.NewRouteConflictDiag(&diag.RouteConflictConfig{
+		VnetIfaceName: s.networkStackInfo.GetInterfaceName(),
 		Routing:       &diag.LinuxRouting{},
 		Interfaces:    &diag.NetInterfaces{},
 	})
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-
-	sshDiag, err := diag.NewSSHDiag(&diag.SSHConfig{
-		ProfilePath: s.cfg.profilePath,
-	})
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-
-	return []diag.DiagCheck{
-		routeConflictDiag,
-		sshDiag,
-	}, nil
 }

--- a/lib/teleterm/vnet/service_other.go
+++ b/lib/teleterm/vnet/service_other.go
@@ -19,11 +19,9 @@
 package vnet
 
 import (
-	"context"
-
 	"github.com/gravitational/teleport/lib/vnet/diag"
 )
 
-func (s *Service) platformDiagChecks(ctx context.Context) ([]diag.DiagCheck, error) {
+func (s *Service) platformRouteConflictDiag() (diag.DiagCheck, error) {
 	return nil, nil
 }

--- a/lib/teleterm/vnet/service_windows.go
+++ b/lib/teleterm/vnet/service_windows.go
@@ -28,27 +28,12 @@ import (
 	"github.com/gravitational/teleport/lib/vnet/diag"
 )
 
-func (s *Service) platformDiagChecks(ctx context.Context) ([]diag.DiagCheck, error) {
-	routeConflictDiag, err := diag.NewRouteConflictDiag(&diag.RouteConflictConfig{
-		VnetIfaceName: s.networkStackInfo.InterfaceName,
+func (s *Service) platformRouteConflictDiag() (diag.DiagCheck, error) {
+	return diag.NewRouteConflictDiag(&diag.RouteConflictConfig{
+		VnetIfaceName: s.networkStackInfo.GetInterfaceName(),
 		Routing:       &diag.WindowsRouting{},
 		Interfaces:    &diag.NetInterfaces{},
 	})
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-
-	sshDiag, err := diag.NewSSHDiag(&diag.SSHConfig{
-		ProfilePath: s.cfg.profilePath,
-	})
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-
-	return []diag.DiagCheck{
-		routeConflictDiag,
-		sshDiag,
-	}, nil
 }
 
 // CheckInstallTimeRequirements verifies the existence of the VNet system service, which is installed only in per-machine setups.

--- a/lib/vnet/admin_process_common.go
+++ b/lib/vnet/admin_process_common.go
@@ -21,6 +21,8 @@ import (
 
 	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
+
+	"github.com/gravitational/teleport/lib/vnet/dns"
 )
 
 func newNetworkStackConfig(ctx context.Context, tun TUNDevice, clt *clientApplicationServiceClient) (*networkStackConfig, error) {
@@ -44,7 +46,7 @@ func newNetworkStackConfig(ctx context.Context, tun TUNDevice, clt *clientApplic
 	if err != nil {
 		return nil, trace.Wrap(err, "creating new IPv6 prefix")
 	}
-	dnsIPv6 := ipv6WithSuffix(ipv6Prefix, []byte{2})
+	dnsIPv6 := ipv6WithSuffix(ipv6Prefix, dns.DNSServerSuffix)
 	return &networkStackConfig{
 		tunDevice:          tun,
 		ipv6Prefix:         ipv6Prefix,

--- a/lib/vnet/diag/dns.go
+++ b/lib/vnet/diag/dns.go
@@ -215,7 +215,7 @@ func (d *DNSDiag) queryServerOnce(ctx context.Context, network string, server ne
 	ctx, cancel := context.WithTimeout(ctx, d.cfg.QueryTimeout)
 	defer cancel()
 
-	addrs, err := d.cfg.DirectQuerier.LookupDirect(ctx, network, probeFQDN(reachabilityProbeZone), server)
+	addrs, err := d.cfg.DirectQuerier.LookupDirect(ctx, network, probeName(reachabilityProbeZone), server)
 	if err != nil {
 		var dnsErr *net.DNSError
 		if errors.As(err, &dnsErr) && dnsErr.IsNotFound {
@@ -343,7 +343,7 @@ func (d *DNSDiag) queryZoneRecordOnce(ctx context.Context, zone, network string,
 	ctx, cancel := context.WithTimeout(ctx, d.cfg.QueryTimeout)
 	defer cancel()
 
-	addrs, err := d.cfg.Resolver.Lookup(ctx, network, probeFQDN(zone))
+	addrs, err := d.cfg.Resolver.Lookup(ctx, network, probeName(zone))
 	return classifyRecordResult(addrs, err, expected)
 }
 
@@ -405,19 +405,19 @@ func computeReportStatus(report *diagv1.DNSReport) diagv1.CheckReportStatus {
 	return diagv1.CheckReportStatus_CHECK_REPORT_STATUS_OK
 }
 
-// probeFQDN builds a probe hostname for a given zone with a fresh
+// probeName builds a probe hostname for a given zone with a fresh
 // random label, defeating any intermediate DNS caches. Format:
 //
-//	vnet-diag-<hex>.<zone>.
-func probeFQDN(zone string) string {
+//	vnet-diag-<hex>.<zone>
+func probeName(zone string) string {
 	const probeRandomBytes = 8
 	var b [probeRandomBytes]byte
 	if _, err := rand.Read(b[:]); err != nil {
 		// crypto/rand should never fail; if it does, return a deterministic
 		// fallback so the diag check at least produces a result.
-		return fmt.Sprintf("%sfallback.%s.", vnetdns.DiagProbePrefix, strings.TrimSuffix(zone, "."))
+		return fmt.Sprintf("%sfallback.%s", vnetdns.DiagProbePrefix, strings.TrimSuffix(zone, "."))
 	}
-	return fmt.Sprintf("%s%s.%s.", vnetdns.DiagProbePrefix, hex.EncodeToString(b[:]), strings.TrimSuffix(zone, "."))
+	return fmt.Sprintf("%s%s.%s", vnetdns.DiagProbePrefix, hex.EncodeToString(b[:]), strings.TrimSuffix(zone, "."))
 }
 
 // DNSServerForIPv6Prefix returns the address of VNet's IPv6 DNS server for a

--- a/lib/vnet/diag/dns.go
+++ b/lib/vnet/diag/dns.go
@@ -386,13 +386,12 @@ func classifyRecordResult(addrs []netip.Addr, err error, expected netip.Addr) *d
 	}
 }
 
-// computeReportStatus returns ISSUES_FOUND if any configured reachability check
-// failed, or if any per-zone record result is not OK; otherwise OK.
+// computeReportStatus returns ISSUES_FOUND if every configured nameserver is
+// unreachable, or if any per-zone record result is not OK, otherwise OK.
 func computeReportStatus(report *diagv1.DNSReport) diagv1.CheckReportStatus {
-	for _, r := range []*diagv1.VNetDNSReachability{report.Ipv4Reachability, report.Ipv6Reachability} {
-		if r != nil && !r.Reachable {
-			return diagv1.CheckReportStatus_CHECK_REPORT_STATUS_ISSUES_FOUND
-		}
+	if !report.GetIpv4Reachability().GetReachable() &&
+		!report.GetIpv6Reachability().GetReachable() {
+		return diagv1.CheckReportStatus_CHECK_REPORT_STATUS_ISSUES_FOUND
 	}
 	for _, zr := range report.ZoneResults {
 		if rr := zr.ARecord; rr != nil && rr.Status != diagv1.DNSZoneStatus_DNS_ZONE_STATUS_OK {

--- a/lib/vnet/diag/dns.go
+++ b/lib/vnet/diag/dns.go
@@ -25,6 +25,7 @@ import (
 	"net"
 	"net/netip"
 	"os/exec"
+	"slices"
 	"strings"
 	"sync"
 	"time"
@@ -52,8 +53,12 @@ type DNSConfig struct {
 	// check sends one query per zone through the OS resolver and verifies it
 	// reached VNet's nameserver.
 	DNSZones []string
-	// VNetDNSServer is the address of VNet's DNS server
-	VNetDNSServer netip.AddrPort
+	// VNetDNSIPv4 is the address of VNet's IPv4 DNS server. Zero if VNet is not
+	// serving DNS on IPv4.
+	VNetDNSIPv4 netip.AddrPort
+	// VNetDNSIPv6 is the address of VNet's IPv6 DNS server. Zero if VNet is not
+	// serving DNS on IPv6.
+	VNetDNSIPv6 netip.AddrPort
 	// Resolver does name resolution through the OS resolver.
 	Resolver Resolver
 	// DirectQuerier sends DNS queries directly to a specific nameserver, bypassing the OS resolver.
@@ -70,35 +75,45 @@ type DNSConfig struct {
 }
 
 // Resolver does name resolution through the OS resolver the same path real
-// applications use, so per-zone OS resolver routing is honored.
+// applications use, so per-zone OS resolver routing is honored. The network
+// argument is "ip4" or "ip6" so the caller can ask each record type
+// independently.
 type Resolver interface {
-	Lookup(ctx context.Context, host string) ([]netip.Addr, error)
+	Lookup(ctx context.Context, network, host string) ([]netip.Addr, error)
 }
 
 // DirectQuerier sends a DNS query directly to a specific server, bypassing the
 // OS resolver. Used by the reachability check to verify VNet's DNS process is
-// reachable independent of OS resolver configuration.
+// reachable independent of OS resolver configuration. The network argument is
+// "ip4" or "ip6" so the caller can ask each record type independently.
 type DirectQuerier interface {
-	LookupDirect(ctx context.Context, host string, server netip.AddrPort) ([]netip.Addr, error)
+	LookupDirect(ctx context.Context, network, host string, server netip.AddrPort) ([]netip.Addr, error)
+}
+
+// recordResult is the result of probing one server for one record type.
+type recordResult struct {
+	addr netip.Addr
+	err  error
 }
 
 // DNSDiag is the diagnostic check that verifies the OS resolver routes queries
 // for each VNet-managed DNS zone to VNet's nameserver. It runs two steps:
 //
-//  1. Reachability check: a direct DNS query to VNet's nameserver. If this
-//     fails, VNet's DNS is unreachable and the per-zone check is skipped.
-//  2. Per-zone check: one query per zone through the OS resolver. Each
-//     response is compared to the reachability response to determine whether
+//  1. Reachability check: direct DNS queries to VNet's IPv4 and IPv6 nameservers
+//     asking for both A and AAAA records. If neither nameserver returns a
+//     response for either record type, the per-zone check is skipped.
+//  2. Per-zone check: for each zone, A and AAAA queries through the OS resolver.
+//     Each response is compared to the reachability response to determine whether
 //     the OS resolver routed the query to VNet (OK), to some other resolver
-//     (HIJACKED), or not at all (NOT_REGISTERED / TIMEOUT).
+//     (HIJACKED), or not at all (NOT_REGISTERED / TIMEOUT / RESOLVER_ERROR).
 type DNSDiag struct {
 	cfg *DNSConfig
 }
 
 // NewDNSDiag returns a new DNSDiag.
 func NewDNSDiag(cfg *DNSConfig) (*DNSDiag, error) {
-	if !cfg.VNetDNSServer.IsValid() {
-		return nil, trace.BadParameter("missing VNet DNS server address")
+	if !cfg.VNetDNSIPv4.IsValid() && !cfg.VNetDNSIPv6.IsValid() {
+		return nil, trace.BadParameter("at least one of VNetDNSIPv4 or VNetDNSIPv6 must be set")
 	}
 	if cfg.Resolver == nil {
 		cfg.Resolver = NetResolver{}
@@ -134,88 +149,182 @@ func (d *DNSDiag) Commands(ctx context.Context) []*exec.Cmd {
 func (d *DNSDiag) Run(ctx context.Context) (*diagv1.CheckReport, error) {
 	report := &diagv1.DNSReport{}
 
-	// Reachability check
-	expectedIP, err := d.runReachabilityCheck(ctx)
-	if err != nil {
-		report.VnetDnsReachable = false
-		report.VnetDnsUnreachableError = err.Error()
-		return &diagv1.CheckReport{
-			Status: diagv1.CheckReportStatus_CHECK_REPORT_STATUS_ISSUES_FOUND,
-			Report: &diagv1.CheckReport_DnsReport{DnsReport: report},
-		}, nil
-	}
-	report.VnetDnsReachable = true
+	v4, v6 := d.runReachabilityCheck(ctx)
+	report.Ipv4Reachability = toReachabilityProto(v4)
+	report.Ipv6Reachability = toReachabilityProto(v6)
 
-	// Per-zone check
-	report.ZoneResults = d.runPerZoneCheck(ctx, expectedIP)
+	expectedA, expectedAAAA := mergeExpected(ctx, v6, v4)
 
-	status := diagv1.CheckReportStatus_CHECK_REPORT_STATUS_OK
-	for _, zr := range report.ZoneResults {
-		if zr.Status != diagv1.DNSZoneStatus_DNS_ZONE_STATUS_OK {
-			status = diagv1.CheckReportStatus_CHECK_REPORT_STATUS_ISSUES_FOUND
-			break
-		}
+	if expectedA.IsValid() || expectedAAAA.IsValid() {
+		report.ZoneResults = d.runPerZoneCheck(ctx, expectedA, expectedAAAA)
 	}
+
 	return &diagv1.CheckReport{
-		Status: status,
+		Status: computeReportStatus(report),
 		Report: &diagv1.CheckReport_DnsReport{DnsReport: report},
 	}, nil
 }
 
-// runReachabilityCheck queries VNet's nameserver directly and returns the response
-// IP, which becomes the expected_ip for every per-zone result.
-func (d *DNSDiag) runReachabilityCheck(ctx context.Context) (netip.Addr, error) {
+// reachabilityCheckResult captures the result of probing one VNet nameserver for both A and AAAA.
+type reachabilityCheckResult struct {
+	server netip.AddrPort
+	a      recordResult
+	aaaa   recordResult
+}
+
+// runReachabilityCheck probes each configured VNet nameserver for both A and AAAA records
+func (d *DNSDiag) runReachabilityCheck(ctx context.Context) (v4, v6 reachabilityCheckResult) {
+	v6.server = d.cfg.VNetDNSIPv6
+	v4.server = d.cfg.VNetDNSIPv4
+
+	var wg sync.WaitGroup
+	if v6.server.IsValid() {
+		wg.Go(func() { v6.a = d.queryServer(ctx, "ip4", v6.server) })
+		wg.Go(func() { v6.aaaa = d.queryServer(ctx, "ip6", v6.server) })
+	}
+	if v4.server.IsValid() {
+		wg.Go(func() { v4.a = d.queryServer(ctx, "ip4", v4.server) })
+		wg.Go(func() { v4.aaaa = d.queryServer(ctx, "ip6", v4.server) })
+	}
+	wg.Wait()
+	return
+}
+
+func (d *DNSDiag) queryServer(ctx context.Context, network string, server netip.AddrPort) recordResult {
 	var lastErr error
 	// Retries to skip the startup window where VNet's DNS isn't responding yet.
 	for attempt := 0; attempt < d.cfg.ReachabilityMaxAttempts; attempt++ {
 		if attempt > 0 {
 			select {
 			case <-ctx.Done():
-				return netip.Addr{}, trace.Wrap(ctx.Err(), "querying VNet DNS server at %s", d.cfg.VNetDNSServer)
+				return recordResult{err: trace.Wrap(ctx.Err(), "querying VNet DNS server at %s for %s", server, network)}
 			case <-time.After(d.cfg.ReachabilityRetryDelay):
 			}
 		}
-		addr, err := d.queryReachabilityOnce(ctx)
+		addr, err := d.queryServerOnce(ctx, network, server)
 		if err == nil {
-			return addr, nil
+			return recordResult{addr: addr}
 		}
 		lastErr = err
 	}
-	return netip.Addr{}, lastErr
+	return recordResult{err: lastErr}
 }
 
-func (d *DNSDiag) queryReachabilityOnce(ctx context.Context) (netip.Addr, error) {
+// queryServerOnce fires a single direct DNS query for one record type.
+func (d *DNSDiag) queryServerOnce(ctx context.Context, network string, server netip.AddrPort) (netip.Addr, error) {
 	ctx, cancel := context.WithTimeout(ctx, d.cfg.QueryTimeout)
 	defer cancel()
 
-	addrs, err := d.cfg.DirectQuerier.LookupDirect(ctx, probeFQDN(reachabilityProbeZone), d.cfg.VNetDNSServer)
+	addrs, err := d.cfg.DirectQuerier.LookupDirect(ctx, network, probeFQDN(reachabilityProbeZone), server)
 	if err != nil {
-		return netip.Addr{}, trace.Wrap(err, "querying VNet DNS server at %s", d.cfg.VNetDNSServer)
+		var dnsErr *net.DNSError
+		if errors.As(err, &dnsErr) && dnsErr.IsNotFound {
+			return netip.Addr{}, nil
+		}
+		return netip.Addr{}, trace.Wrap(err, "querying VNet DNS server at %s for %s", server, network)
 	}
 	if len(addrs) == 0 {
-		return netip.Addr{}, trace.Errorf("VNet DNS server at %s returned no answer", d.cfg.VNetDNSServer)
+		return netip.Addr{}, nil
 	}
 	return addrs[0], nil
 }
 
+func toReachabilityProto(o reachabilityCheckResult) *diagv1.VNetDNSReachability {
+	// At this point server may be either empty or valid. An empty server means
+	// VNet does not serve DNS on the address family this check was performed for
+	if !o.server.IsValid() {
+		return nil
+	}
+	m := &diagv1.VNetDNSReachability{
+		Address:       o.server.String(),
+		RespondedA:    o.a.addr.IsValid(),
+		RespondedAaaa: o.aaaa.addr.IsValid(),
+	}
+	m.Reachable = m.RespondedA || m.RespondedAaaa
+	if !m.Reachable {
+		var errs []string
+		if o.a.err != nil {
+			errs = append(errs, fmt.Sprintf("A: %s", o.a.err))
+		}
+		if o.aaaa.err != nil {
+			errs = append(errs, fmt.Sprintf("AAAA: %s", o.aaaa.err))
+		}
+		m.Error = strings.Join(errs, "; ")
+		if m.Error == "" {
+			m.Error = "server returned no records"
+		}
+	}
+	return m
+}
+
+// mergeExpected picks the expected A and AAAA from the reachability results.
+// Prefers IPv6 to match the order in which the OS resolver is most likely to
+// query.
+//
+// On macOS and Windows the OS prefers IPv6 over IPv4 per RFC 6724, on Linux
+// with systemd-resolved we register the IPv6 nameserver first and
+// systemd-resolved respects configuration order.
+func mergeExpected(ctx context.Context, v6, v4 reachabilityCheckResult) (expectedA, expectedAAAA netip.Addr) {
+	if v6.a.addr.IsValid() {
+		expectedA = v6.a.addr
+	} else {
+		expectedA = v4.a.addr
+	}
+	if v6.aaaa.addr.IsValid() {
+		expectedAAAA = v6.aaaa.addr
+	} else {
+		expectedAAAA = v4.aaaa.addr
+	}
+
+	// Log a warning when both nameservers returned a value for the same record and
+	// they disagree that should never happen and indicates a bug IN VNet
+	if v6.a.addr.IsValid() && v4.a.addr.IsValid() && v6.a.addr != v4.a.addr {
+		log.WarnContext(ctx, "VNet DNS returned different A records from IPv6 vs IPv4 nameservers",
+			"v6_response", v6.a.addr, "v4_response", v4.a.addr)
+	}
+	if v6.aaaa.addr.IsValid() && v4.aaaa.addr.IsValid() && v6.aaaa.addr != v4.aaaa.addr {
+		log.WarnContext(ctx, "VNet DNS returned different AAAA records from IPv6 vs IPv4 nameservers",
+			"v6_response", v6.aaaa.addr, "v4_response", v4.aaaa.addr)
+	}
+	return
+}
+
 // runPerZoneCheck queries the probe for each configured zone through the OS
-// resolver in parallel and returns a per-zone result.
-func (d *DNSDiag) runPerZoneCheck(ctx context.Context, expectedIP netip.Addr) []*diagv1.DNSZoneResult {
+// resolver in parallel, asking for each record type for which an expected IP
+// was captured.
+func (d *DNSDiag) runPerZoneCheck(ctx context.Context, expectedA, expectedAAAA netip.Addr) []*diagv1.DNSZoneResult {
 	results := make([]*diagv1.DNSZoneResult, len(d.cfg.DNSZones))
 	var wg sync.WaitGroup
 	for i, zone := range d.cfg.DNSZones {
 		wg.Go(func() {
-			results[i] = d.queryZone(ctx, zone, expectedIP)
+			results[i] = d.queryZone(ctx, zone, expectedA, expectedAAAA)
 		})
 	}
 	wg.Wait()
 	return results
 }
 
-// queryZone runs a single zone query with one retry on NOT_REGISTERED, to
-// skip a possible gap where the OS resolver hasn't yet picked up VNet's per-zone entry.
-func (d *DNSDiag) queryZone(ctx context.Context, zone string, expectedIP netip.Addr) *diagv1.DNSZoneResult {
-	result := d.queryZoneOnce(ctx, zone, expectedIP)
+// queryZone runs A and AAAA queries for a single zone in parallel.
+func (d *DNSDiag) queryZone(ctx context.Context, zone string, expectedA, expectedAAAA netip.Addr) *diagv1.DNSZoneResult {
+	result := &diagv1.DNSZoneResult{Zone: zone}
+	var wg sync.WaitGroup
+	if expectedA.IsValid() {
+		wg.Go(func() {
+			result.ARecord = d.queryZoneRecord(ctx, zone, "ip4", expectedA)
+		})
+	}
+	if expectedAAAA.IsValid() {
+		wg.Go(func() {
+			result.AaaaRecord = d.queryZoneRecord(ctx, zone, "ip6", expectedAAAA)
+		})
+	}
+	wg.Wait()
+	return result
+}
+
+// queryZoneRecord runs a single record-type query.
+func (d *DNSDiag) queryZoneRecord(ctx context.Context, zone, network string, expected netip.Addr) *diagv1.RecordResult {
+	result := d.queryZoneRecordOnce(ctx, zone, network, expected)
 	if result.Status != diagv1.DNSZoneStatus_DNS_ZONE_STATUS_NOT_REGISTERED {
 		return result
 	}
@@ -227,64 +336,73 @@ func (d *DNSDiag) queryZone(ctx context.Context, zone string, expectedIP netip.A
 		return result
 	case <-time.After(d.cfg.NotRegisteredRetryDelay):
 	}
-	return d.queryZoneOnce(ctx, zone, expectedIP)
+	return d.queryZoneRecordOnce(ctx, zone, network, expected)
 }
 
-func (d *DNSDiag) queryZoneOnce(ctx context.Context, zone string, expectedIP netip.Addr) *diagv1.DNSZoneResult {
+func (d *DNSDiag) queryZoneRecordOnce(ctx context.Context, zone, network string, expected netip.Addr) *diagv1.RecordResult {
 	ctx, cancel := context.WithTimeout(ctx, d.cfg.QueryTimeout)
 	defer cancel()
 
-	addrs, err := d.cfg.Resolver.Lookup(ctx, probeFQDN(zone))
-	status, observed, errStr := classifyDNSResult(addrs, err, expectedIP)
-
-	result := &diagv1.DNSZoneResult{
-		Zone:       zone,
-		Status:     status,
-		ExpectedIp: expectedIP.String(),
-		Error:      errStr,
-	}
-	if observed.IsValid() {
-		result.ObservedIp = observed.String()
-	}
-	return result
+	addrs, err := d.cfg.Resolver.Lookup(ctx, network, probeFQDN(zone))
+	return classifyRecordResult(addrs, err, expected)
 }
 
-// classifyDNSResult maps a resolver outcome to a [diagv1.DNSZoneStatus].
-func classifyDNSResult(addrs []netip.Addr, err error, expectedIP netip.Addr) (diagv1.DNSZoneStatus, netip.Addr, string) {
+// classifyRecordResult maps a resolver outcome for a single record type to a
+// [diagv1.RecordResult].
+func classifyRecordResult(addrs []netip.Addr, err error, expected netip.Addr) *diagv1.RecordResult {
 	if err != nil {
 		var dnsErr *net.DNSError
 		if errors.As(err, &dnsErr) {
 			switch {
 			case dnsErr.IsNotFound:
-				return diagv1.DNSZoneStatus_DNS_ZONE_STATUS_NOT_REGISTERED, netip.Addr{}, ""
+				return &diagv1.RecordResult{Status: diagv1.DNSZoneStatus_DNS_ZONE_STATUS_NOT_REGISTERED}
 			case dnsErr.IsTimeout:
-				return diagv1.DNSZoneStatus_DNS_ZONE_STATUS_TIMEOUT, netip.Addr{}, err.Error()
+				return &diagv1.RecordResult{
+					Status: diagv1.DNSZoneStatus_DNS_ZONE_STATUS_TIMEOUT,
+					Error:  err.Error(),
+				}
 			}
 		}
 		if errors.Is(err, context.DeadlineExceeded) {
-			return diagv1.DNSZoneStatus_DNS_ZONE_STATUS_TIMEOUT, netip.Addr{}, err.Error()
+			return &diagv1.RecordResult{
+				Status: diagv1.DNSZoneStatus_DNS_ZONE_STATUS_TIMEOUT,
+				Error:  err.Error(),
+			}
 		}
-		return diagv1.DNSZoneStatus_DNS_ZONE_STATUS_RESOLVER_ERROR, netip.Addr{}, err.Error()
+		return &diagv1.RecordResult{
+			Status: diagv1.DNSZoneStatus_DNS_ZONE_STATUS_RESOLVER_ERROR,
+			Error:  err.Error(),
+		}
 	}
-	// NOERROR with no answer is also classified as NOT_REGISTERED.
 	if len(addrs) == 0 {
-		return diagv1.DNSZoneStatus_DNS_ZONE_STATUS_NOT_REGISTERED, netip.Addr{}, ""
+		return &diagv1.RecordResult{Status: diagv1.DNSZoneStatus_DNS_ZONE_STATUS_NOT_REGISTERED}
 	}
-	if len(addrs) == 1 && addrs[0] == expectedIP {
-		return diagv1.DNSZoneStatus_DNS_ZONE_STATUS_OK, addrs[0], ""
+	if slices.Contains(addrs, expected) {
+		return &diagv1.RecordResult{Status: diagv1.DNSZoneStatus_DNS_ZONE_STATUS_OK}
 	}
-	// HIJACKED: surface the IPv6 if present, probes get AAAA only from VNet
-	// so a non-VNet IPv6 is the most direct evidence of interception.
-	//
-	// TODO(tangyatsu): proto carries a single observed_ip today. Consider
-	// widening to a repeated field so the UI can show multiple addresses for
-	// dual-stack hijackers or round-robin pools.
-	for _, a := range addrs {
-		if a.Is6() {
-			return diagv1.DNSZoneStatus_DNS_ZONE_STATUS_HIJACKED, a, ""
+	return &diagv1.RecordResult{
+		Status:     diagv1.DNSZoneStatus_DNS_ZONE_STATUS_HIJACKED,
+		ObservedIp: addrs[0].String(),
+	}
+}
+
+// computeReportStatus returns ISSUES_FOUND if any configured reachability check
+// failed, or if any per-zone record result is not OK; otherwise OK.
+func computeReportStatus(report *diagv1.DNSReport) diagv1.CheckReportStatus {
+	for _, r := range []*diagv1.VNetDNSReachability{report.Ipv4Reachability, report.Ipv6Reachability} {
+		if r != nil && !r.Reachable {
+			return diagv1.CheckReportStatus_CHECK_REPORT_STATUS_ISSUES_FOUND
 		}
 	}
-	return diagv1.DNSZoneStatus_DNS_ZONE_STATUS_HIJACKED, addrs[0], ""
+	for _, zr := range report.ZoneResults {
+		if rr := zr.ARecord; rr != nil && rr.Status != diagv1.DNSZoneStatus_DNS_ZONE_STATUS_OK {
+			return diagv1.CheckReportStatus_CHECK_REPORT_STATUS_ISSUES_FOUND
+		}
+		if rr := zr.AaaaRecord; rr != nil && rr.Status != diagv1.DNSZoneStatus_DNS_ZONE_STATUS_OK {
+			return diagv1.CheckReportStatus_CHECK_REPORT_STATUS_ISSUES_FOUND
+		}
+	}
+	return diagv1.CheckReportStatus_CHECK_REPORT_STATUS_OK
 }
 
 // probeFQDN builds a probe hostname for a given zone with a fresh
@@ -318,12 +436,25 @@ func DNSServerForIPv6Prefix(prefix string) (netip.AddrPort, error) {
 	return netip.AddrPortFrom(netip.AddrFrom16(b), vnetdns.DNSServerPort), nil
 }
 
+// DNSServerForIPv4CIDRRange returns the address of VNet's IPv4 DNS server for a given IPv4
+// CIDR range (e.g., 100.64.0.0/24 → 100.64.0.2:53). Matches lib/vnet/osconfig_provider.go.
+func DNSServerForIPv4CIDRRange(cidr string) (netip.AddrPort, error) {
+	_, ipNet, err := net.ParseCIDR(cidr)
+	if err != nil {
+		return netip.AddrPort{}, trace.Wrap(err, "parsing IPv4 CIDR %q", cidr)
+	}
+	ip := slices.Clone(ipNet.IP)
+	ip[len(ip)-1] += 2
+	addr, _ := netip.AddrFromSlice(ip)
+	return netip.AddrPortFrom(addr, vnetdns.DNSServerPort), nil
+}
+
 // NetResolver is the default [Resolver] implementation that uses [net.DefaultResolver].
 type NetResolver struct{}
 
 // Lookup implements [Resolver].
-func (NetResolver) Lookup(ctx context.Context, host string) ([]netip.Addr, error) {
-	addrs, err := net.DefaultResolver.LookupNetIP(ctx, "ip", host)
+func (NetResolver) Lookup(ctx context.Context, network, host string) ([]netip.Addr, error) {
+	addrs, err := net.DefaultResolver.LookupNetIP(ctx, network, host)
 	return addrs, trace.Wrap(err)
 }
 
@@ -333,14 +464,13 @@ func (NetResolver) Lookup(ctx context.Context, host string) ([]netip.Addr, error
 type NetDirectQuerier struct{}
 
 // LookupDirect implements [DirectQuerier].
-func (NetDirectQuerier) LookupDirect(ctx context.Context, host string, server netip.AddrPort) ([]netip.Addr, error) {
+func (NetDirectQuerier) LookupDirect(ctx context.Context, network, host string, server netip.AddrPort) ([]netip.Addr, error) {
 	r := &net.Resolver{
 		PreferGo: true,
-		Dial: func(ctx context.Context, network, _ string) (net.Conn, error) {
-			d := net.Dialer{}
-			return d.DialContext(ctx, network, server.String())
+		Dial: func(ctx context.Context, _, _ string) (net.Conn, error) {
+			return new(net.Dialer).DialContext(ctx, "udp", server.String())
 		},
 	}
-	addrs, err := r.LookupNetIP(ctx, "ip", host)
+	addrs, err := r.LookupNetIP(ctx, network, host)
 	return addrs, trace.Wrap(err)
 }

--- a/lib/vnet/diag/dns.go
+++ b/lib/vnet/diag/dns.go
@@ -197,7 +197,7 @@ func (d *DNSDiag) queryServer(ctx context.Context, network string, server netip.
 		if attempt > 0 {
 			select {
 			case <-ctx.Done():
-				return recordResult{err: trace.Wrap(ctx.Err(), "querying VNet DNS server at %s for %s", server, network)}
+				return recordResult{err: trace.Wrap(ctx.Err(), "querying VNet DNS server at %s for %s record", server, networkToRecordType(network))}
 			case <-time.After(d.cfg.ReachabilityRetryDelay):
 			}
 		}
@@ -208,6 +208,17 @@ func (d *DNSDiag) queryServer(ctx context.Context, network string, server netip.
 		lastErr = err
 	}
 	return recordResult{err: lastErr}
+}
+
+func networkToRecordType(network string) string {
+	switch network {
+	case "ip4":
+		return "A"
+	case "ip6":
+		return "AAAA"
+	default:
+		return "unknown"
+	}
 }
 
 // queryServerOnce fires a single direct DNS query for one record type.
@@ -221,7 +232,7 @@ func (d *DNSDiag) queryServerOnce(ctx context.Context, network string, server ne
 		if errors.As(err, &dnsErr) && dnsErr.IsNotFound {
 			return netip.Addr{}, nil
 		}
-		return netip.Addr{}, trace.Wrap(err, "querying VNet DNS server at %s for %s", server, network)
+		return netip.Addr{}, trace.Wrap(err, "querying VNet DNS server at %s for %s record", server, networkToRecordType(network))
 	}
 	if len(addrs) == 0 {
 		return netip.Addr{}, nil
@@ -244,12 +255,12 @@ func toReachabilityProto(o reachabilityCheckResult) *diagv1.VNetDNSReachability 
 	if !m.Reachable {
 		var errs []string
 		if o.a.err != nil {
-			errs = append(errs, fmt.Sprintf("A: %s", o.a.err))
+			errs = append(errs, o.a.err.Error())
 		}
 		if o.aaaa.err != nil {
-			errs = append(errs, fmt.Sprintf("AAAA: %s", o.aaaa.err))
+			errs = append(errs, o.aaaa.err.Error())
 		}
-		m.Error = strings.Join(errs, "; ")
+		m.Error = strings.Join(errs, "\n")
 		if m.Error == "" {
 			m.Error = "server returned no records"
 		}

--- a/lib/vnet/diag/dns.go
+++ b/lib/vnet/diag/dns.go
@@ -26,10 +26,10 @@ import (
 	"net/netip"
 	"os/exec"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/gravitational/trace"
-	"golang.org/x/sync/errgroup"
 
 	diagv1 "github.com/gravitational/teleport/gen/proto/go/teleport/lib/vnet/diag/v1"
 	vnetdns "github.com/gravitational/teleport/lib/vnet/dns"
@@ -40,7 +40,6 @@ const (
 	defaultNotRegisteredRetryDelay = 500 * time.Millisecond
 	defaultReachabilityMaxAttempts = 3
 	defaultReachabilityRetryDelay  = 500 * time.Millisecond
-	probeRandomBytes               = 8
 	// reachabilityProbeZone is the TLD used to build the reachability probe FQDN.
 	// VNet's probe handler matches on the "vnet-diag-" prefix only, so the zone
 	// is purely DNS-message filler. ".test" is RFC 2606 reserved.
@@ -57,11 +56,11 @@ type DNSConfig struct {
 	VNetDNSServer netip.AddrPort
 	// Resolver does name resolution through the OS resolver.
 	Resolver Resolver
-	// DirectQuerier sends DNS queries directly to a specific nameserver,bypassing the OS resolver.
+	// DirectQuerier sends DNS queries directly to a specific nameserver, bypassing the OS resolver.
 	DirectQuerier DirectQuerier
 	// QueryTimeout caps the duration of an individual DNS query.
 	QueryTimeout time.Duration
-	// NotRegisteredRetryDelay delays the retry of a per-zone query that returned NOT_REGISTERED .
+	// NotRegisteredRetryDelay delays the retry of a per-zone query that returned NOT_REGISTERED.
 	NotRegisteredRetryDelay time.Duration
 	// ReachabilityMaxAttempts caps reachability-check retries before reporting
 	// VNet's DNS as unreachable.
@@ -203,15 +202,13 @@ func (d *DNSDiag) queryReachabilityOnce(ctx context.Context) (netip.Addr, error)
 // resolver in parallel and returns a per-zone result.
 func (d *DNSDiag) runPerZoneCheck(ctx context.Context, expectedIP netip.Addr) []*diagv1.DNSZoneResult {
 	results := make([]*diagv1.DNSZoneResult, len(d.cfg.DNSZones))
-	var g errgroup.Group
+	var wg sync.WaitGroup
 	for i, zone := range d.cfg.DNSZones {
-		i, zone := i, zone
-		g.Go(func() error {
+		wg.Go(func() {
 			results[i] = d.queryZone(ctx, zone, expectedIP)
-			return nil
 		})
 	}
-	_ = g.Wait()
+	wg.Wait()
 	return results
 }
 
@@ -276,8 +273,8 @@ func classifyDNSResult(addrs []netip.Addr, err error, expectedIP netip.Addr) (di
 	if len(addrs) == 1 && addrs[0] == expectedIP {
 		return diagv1.DNSZoneStatus_DNS_ZONE_STATUS_OK, addrs[0], ""
 	}
-	// HIJACKED: surface the IPv6 if present — VNet answers AAAA only, so a
-	// non-VNet IPv6 is the most direct evidence of interception.
+	// HIJACKED: surface the IPv6 if present, probes get AAAA only from VNet
+	// so a non-VNet IPv6 is the most direct evidence of interception.
 	//
 	// TODO(tangyatsu): proto carries a single observed_ip today. Consider
 	// widening to a repeated field so the UI can show multiple addresses for
@@ -295,6 +292,7 @@ func classifyDNSResult(addrs []netip.Addr, err error, expectedIP netip.Addr) (di
 //
 //	vnet-diag-<hex>.<zone>.
 func probeFQDN(zone string) string {
+	const probeRandomBytes = 8
 	var b [probeRandomBytes]byte
 	if _, err := rand.Read(b[:]); err != nil {
 		// crypto/rand should never fail; if it does, return a deterministic

--- a/lib/vnet/diag/dns.go
+++ b/lib/vnet/diag/dns.go
@@ -1,0 +1,348 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package diag
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"net"
+	"net/netip"
+	"os/exec"
+	"strings"
+	"time"
+
+	"github.com/gravitational/trace"
+	"golang.org/x/sync/errgroup"
+
+	diagv1 "github.com/gravitational/teleport/gen/proto/go/teleport/lib/vnet/diag/v1"
+	vnetdns "github.com/gravitational/teleport/lib/vnet/dns"
+)
+
+const (
+	defaultDNSQueryTimeout         = 2 * time.Second
+	defaultNotRegisteredRetryDelay = 500 * time.Millisecond
+	defaultReachabilityMaxAttempts = 3
+	defaultReachabilityRetryDelay  = 500 * time.Millisecond
+	probeRandomBytes               = 8
+	// reachabilityProbeZone is the TLD used to build the reachability probe FQDN.
+	// VNet's probe handler matches on the "vnet-diag-" prefix only, so the zone
+	// is purely DNS-message filler. ".test" is RFC 2606 reserved.
+	reachabilityProbeZone = "test"
+)
+
+// DNSConfig is the configuration for DNSDiag.
+type DNSConfig struct {
+	// DNSZones is the list of DNS zones registered with the OS resolver. The
+	// check sends one query per zone through the OS resolver and verifies it
+	// reached VNet's nameserver.
+	DNSZones []string
+	// VNetDNSServer is the address of VNet's DNS server
+	VNetDNSServer netip.AddrPort
+	// Resolver does name resolution through the OS resolver.
+	Resolver Resolver
+	// DirectQuerier sends DNS queries directly to a specific nameserver,bypassing the OS resolver.
+	DirectQuerier DirectQuerier
+	// QueryTimeout caps the duration of an individual DNS query.
+	QueryTimeout time.Duration
+	// NotRegisteredRetryDelay delays the retry of a per-zone query that returned NOT_REGISTERED .
+	NotRegisteredRetryDelay time.Duration
+	// ReachabilityMaxAttempts caps reachability-check retries before reporting
+	// VNet's DNS as unreachable.
+	ReachabilityMaxAttempts int
+	// ReachabilityRetryDelay is the backoff between reachability attempts.
+	ReachabilityRetryDelay time.Duration
+}
+
+// Resolver does name resolution through the OS resolver the same path real
+// applications use, so per-zone OS resolver routing is honored.
+type Resolver interface {
+	Lookup(ctx context.Context, host string) ([]netip.Addr, error)
+}
+
+// DirectQuerier sends a DNS query directly to a specific server, bypassing the
+// OS resolver. Used by the reachability check to verify VNet's DNS process is
+// reachable independent of OS resolver configuration.
+type DirectQuerier interface {
+	LookupDirect(ctx context.Context, host string, server netip.AddrPort) ([]netip.Addr, error)
+}
+
+// DNSDiag is the diagnostic check that verifies the OS resolver routes queries
+// for each VNet-managed DNS zone to VNet's nameserver. It runs two steps:
+//
+//  1. Reachability check: a direct DNS query to VNet's nameserver. If this
+//     fails, VNet's DNS is unreachable and the per-zone check is skipped.
+//  2. Per-zone check: one query per zone through the OS resolver. Each
+//     response is compared to the reachability response to determine whether
+//     the OS resolver routed the query to VNet (OK), to some other resolver
+//     (HIJACKED), or not at all (NOT_REGISTERED / TIMEOUT).
+type DNSDiag struct {
+	cfg *DNSConfig
+}
+
+// NewDNSDiag returns a new DNSDiag.
+func NewDNSDiag(cfg *DNSConfig) (*DNSDiag, error) {
+	if !cfg.VNetDNSServer.IsValid() {
+		return nil, trace.BadParameter("missing VNet DNS server address")
+	}
+	if cfg.Resolver == nil {
+		cfg.Resolver = NetResolver{}
+	}
+	if cfg.DirectQuerier == nil {
+		cfg.DirectQuerier = NetDirectQuerier{}
+	}
+	if cfg.QueryTimeout == 0 {
+		cfg.QueryTimeout = defaultDNSQueryTimeout
+	}
+	if cfg.NotRegisteredRetryDelay == 0 {
+		cfg.NotRegisteredRetryDelay = defaultNotRegisteredRetryDelay
+	}
+	if cfg.ReachabilityMaxAttempts == 0 {
+		cfg.ReachabilityMaxAttempts = defaultReachabilityMaxAttempts
+	}
+	if cfg.ReachabilityRetryDelay == 0 {
+		cfg.ReachabilityRetryDelay = defaultReachabilityRetryDelay
+	}
+	return &DNSDiag{cfg: cfg}, nil
+}
+
+func (d *DNSDiag) EmptyCheckReport() *diagv1.CheckReport {
+	return &diagv1.CheckReport{Report: &diagv1.CheckReport_DnsReport{}}
+}
+
+// Commands returns platform-specific commands that capture additional DNS configuration state.
+func (d *DNSDiag) Commands(ctx context.Context) []*exec.Cmd {
+	return d.commands(ctx)
+}
+
+// Run executes the DNS check.
+func (d *DNSDiag) Run(ctx context.Context) (*diagv1.CheckReport, error) {
+	report := &diagv1.DNSReport{}
+
+	// Reachability check
+	expectedIP, err := d.runReachabilityCheck(ctx)
+	if err != nil {
+		report.VnetDnsReachable = false
+		report.VnetDnsUnreachableError = err.Error()
+		return &diagv1.CheckReport{
+			Status: diagv1.CheckReportStatus_CHECK_REPORT_STATUS_ISSUES_FOUND,
+			Report: &diagv1.CheckReport_DnsReport{DnsReport: report},
+		}, nil
+	}
+	report.VnetDnsReachable = true
+
+	// Per-zone check
+	report.ZoneResults = d.runPerZoneCheck(ctx, expectedIP)
+
+	status := diagv1.CheckReportStatus_CHECK_REPORT_STATUS_OK
+	for _, zr := range report.ZoneResults {
+		if zr.Status != diagv1.DNSZoneStatus_DNS_ZONE_STATUS_OK {
+			status = diagv1.CheckReportStatus_CHECK_REPORT_STATUS_ISSUES_FOUND
+			break
+		}
+	}
+	return &diagv1.CheckReport{
+		Status: status,
+		Report: &diagv1.CheckReport_DnsReport{DnsReport: report},
+	}, nil
+}
+
+// runReachabilityCheck queries VNet's nameserver directly and returns the response
+// IP, which becomes the expected_ip for every per-zone result.
+func (d *DNSDiag) runReachabilityCheck(ctx context.Context) (netip.Addr, error) {
+	var lastErr error
+	// Retries to skip the startup window where VNet's DNS isn't responding yet.
+	for attempt := 0; attempt < d.cfg.ReachabilityMaxAttempts; attempt++ {
+		if attempt > 0 {
+			select {
+			case <-ctx.Done():
+				return netip.Addr{}, trace.Wrap(ctx.Err(), "querying VNet DNS server at %s", d.cfg.VNetDNSServer)
+			case <-time.After(d.cfg.ReachabilityRetryDelay):
+			}
+		}
+		addr, err := d.queryReachabilityOnce(ctx)
+		if err == nil {
+			return addr, nil
+		}
+		lastErr = err
+	}
+	return netip.Addr{}, lastErr
+}
+
+func (d *DNSDiag) queryReachabilityOnce(ctx context.Context) (netip.Addr, error) {
+	ctx, cancel := context.WithTimeout(ctx, d.cfg.QueryTimeout)
+	defer cancel()
+
+	addrs, err := d.cfg.DirectQuerier.LookupDirect(ctx, probeFQDN(reachabilityProbeZone), d.cfg.VNetDNSServer)
+	if err != nil {
+		return netip.Addr{}, trace.Wrap(err, "querying VNet DNS server at %s", d.cfg.VNetDNSServer)
+	}
+	if len(addrs) == 0 {
+		return netip.Addr{}, trace.Errorf("VNet DNS server at %s returned no answer", d.cfg.VNetDNSServer)
+	}
+	return addrs[0], nil
+}
+
+// runPerZoneCheck queries the probe for each configured zone through the OS
+// resolver in parallel and returns a per-zone result.
+func (d *DNSDiag) runPerZoneCheck(ctx context.Context, expectedIP netip.Addr) []*diagv1.DNSZoneResult {
+	results := make([]*diagv1.DNSZoneResult, len(d.cfg.DNSZones))
+	var g errgroup.Group
+	for i, zone := range d.cfg.DNSZones {
+		i, zone := i, zone
+		g.Go(func() error {
+			results[i] = d.queryZone(ctx, zone, expectedIP)
+			return nil
+		})
+	}
+	_ = g.Wait()
+	return results
+}
+
+// queryZone runs a single zone query with one retry on NOT_REGISTERED, to
+// skip a possible gap where the OS resolver hasn't yet picked up VNet's per-zone entry.
+func (d *DNSDiag) queryZone(ctx context.Context, zone string, expectedIP netip.Addr) *diagv1.DNSZoneResult {
+	result := d.queryZoneOnce(ctx, zone, expectedIP)
+	if result.Status != diagv1.DNSZoneStatus_DNS_ZONE_STATUS_NOT_REGISTERED {
+		return result
+	}
+	if d.cfg.NotRegisteredRetryDelay <= 0 {
+		return result
+	}
+	select {
+	case <-ctx.Done():
+		return result
+	case <-time.After(d.cfg.NotRegisteredRetryDelay):
+	}
+	return d.queryZoneOnce(ctx, zone, expectedIP)
+}
+
+func (d *DNSDiag) queryZoneOnce(ctx context.Context, zone string, expectedIP netip.Addr) *diagv1.DNSZoneResult {
+	ctx, cancel := context.WithTimeout(ctx, d.cfg.QueryTimeout)
+	defer cancel()
+
+	addrs, err := d.cfg.Resolver.Lookup(ctx, probeFQDN(zone))
+	status, observed, errStr := classifyDNSResult(addrs, err, expectedIP)
+
+	result := &diagv1.DNSZoneResult{
+		Zone:       zone,
+		Status:     status,
+		ExpectedIp: expectedIP.String(),
+		Error:      errStr,
+	}
+	if observed.IsValid() {
+		result.ObservedIp = observed.String()
+	}
+	return result
+}
+
+// classifyDNSResult maps a resolver outcome to a [diagv1.DNSZoneStatus].
+func classifyDNSResult(addrs []netip.Addr, err error, expectedIP netip.Addr) (diagv1.DNSZoneStatus, netip.Addr, string) {
+	if err != nil {
+		var dnsErr *net.DNSError
+		if errors.As(err, &dnsErr) {
+			switch {
+			case dnsErr.IsNotFound:
+				return diagv1.DNSZoneStatus_DNS_ZONE_STATUS_NOT_REGISTERED, netip.Addr{}, ""
+			case dnsErr.IsTimeout:
+				return diagv1.DNSZoneStatus_DNS_ZONE_STATUS_TIMEOUT, netip.Addr{}, err.Error()
+			}
+		}
+		if errors.Is(err, context.DeadlineExceeded) {
+			return diagv1.DNSZoneStatus_DNS_ZONE_STATUS_TIMEOUT, netip.Addr{}, err.Error()
+		}
+		return diagv1.DNSZoneStatus_DNS_ZONE_STATUS_RESOLVER_ERROR, netip.Addr{}, err.Error()
+	}
+	// NOERROR with no answer is also classified as NOT_REGISTERED.
+	if len(addrs) == 0 {
+		return diagv1.DNSZoneStatus_DNS_ZONE_STATUS_NOT_REGISTERED, netip.Addr{}, ""
+	}
+	if len(addrs) == 1 && addrs[0] == expectedIP {
+		return diagv1.DNSZoneStatus_DNS_ZONE_STATUS_OK, addrs[0], ""
+	}
+	// HIJACKED: surface the IPv6 if present — VNet answers AAAA only, so a
+	// non-VNet IPv6 is the most direct evidence of interception.
+	//
+	// TODO(tangyatsu): proto carries a single observed_ip today. Consider
+	// widening to a repeated field so the UI can show multiple addresses for
+	// dual-stack hijackers or round-robin pools.
+	for _, a := range addrs {
+		if a.Is6() {
+			return diagv1.DNSZoneStatus_DNS_ZONE_STATUS_HIJACKED, a, ""
+		}
+	}
+	return diagv1.DNSZoneStatus_DNS_ZONE_STATUS_HIJACKED, addrs[0], ""
+}
+
+// probeFQDN builds a probe hostname for a given zone with a fresh
+// random label, defeating any intermediate DNS caches. Format:
+//
+//	vnet-diag-<hex>.<zone>.
+func probeFQDN(zone string) string {
+	var b [probeRandomBytes]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		// crypto/rand should never fail; if it does, return a deterministic
+		// fallback so the diag check at least produces a result.
+		return fmt.Sprintf("%sfallback.%s.", vnetdns.DiagProbePrefix, strings.TrimSuffix(zone, "."))
+	}
+	return fmt.Sprintf("%s%s.%s.", vnetdns.DiagProbePrefix, hex.EncodeToString(b[:]), strings.TrimSuffix(zone, "."))
+}
+
+// DNSServerForIPv6Prefix returns the address of VNet's IPv6 DNS server for a
+// given IPv6 ULA prefix (e.g., fdec:1fed:139f:: → [fdec:1fed:139f::2]:53).
+func DNSServerForIPv6Prefix(prefix string) (netip.AddrPort, error) {
+	addr, err := netip.ParseAddr(prefix)
+	if err != nil {
+		return netip.AddrPort{}, trace.Wrap(err, "parsing IPv6 prefix %q", prefix)
+	}
+	if !addr.Is6() {
+		return netip.AddrPort{}, trace.BadParameter("prefix %q is not IPv6", prefix)
+	}
+	// Same suffix VNet uses internally
+	b := addr.As16()
+	copy(b[16-len(vnetdns.DNSServerSuffix):], vnetdns.DNSServerSuffix)
+	return netip.AddrPortFrom(netip.AddrFrom16(b), vnetdns.DNSServerPort), nil
+}
+
+// NetResolver is the default [Resolver] implementation that uses [net.DefaultResolver].
+type NetResolver struct{}
+
+// Lookup implements [Resolver].
+func (NetResolver) Lookup(ctx context.Context, host string) ([]netip.Addr, error) {
+	addrs, err := net.DefaultResolver.LookupNetIP(ctx, "ip", host)
+	return addrs, trace.Wrap(err)
+}
+
+// NetDirectQuerier is the default [DirectQuerier] implementation. It uses a
+// custom [net.Resolver] whose Dial function forces every connection to the
+// configured target server, bypassing the OS resolver entirely.
+type NetDirectQuerier struct{}
+
+// LookupDirect implements [DirectQuerier].
+func (NetDirectQuerier) LookupDirect(ctx context.Context, host string, server netip.AddrPort) ([]netip.Addr, error) {
+	r := &net.Resolver{
+		PreferGo: true,
+		Dial: func(ctx context.Context, network, _ string) (net.Conn, error) {
+			d := net.Dialer{}
+			return d.DialContext(ctx, network, server.String())
+		},
+	}
+	addrs, err := r.LookupNetIP(ctx, "ip", host)
+	return addrs, trace.Wrap(err)
+}

--- a/lib/vnet/diag/dns_darwin.go
+++ b/lib/vnet/diag/dns_darwin.go
@@ -1,0 +1,28 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package diag
+
+import (
+	"context"
+	"os/exec"
+)
+
+func (d *DNSDiag) commands(ctx context.Context) []*exec.Cmd {
+	return []*exec.Cmd{
+		exec.CommandContext(ctx, "scutil", "--dns"),
+	}
+}

--- a/lib/vnet/diag/dns_linux.go
+++ b/lib/vnet/diag/dns_linux.go
@@ -1,0 +1,28 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package diag
+
+import (
+	"context"
+	"os/exec"
+)
+
+func (d *DNSDiag) commands(ctx context.Context) []*exec.Cmd {
+	return []*exec.Cmd{
+		exec.CommandContext(ctx, "resolvectl", "status"),
+	}
+}

--- a/lib/vnet/diag/dns_other.go
+++ b/lib/vnet/diag/dns_other.go
@@ -1,0 +1,28 @@
+//go:build !darwin && !linux && !windows
+
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package diag
+
+import (
+	"context"
+	"os/exec"
+)
+
+func (d *DNSDiag) commands(ctx context.Context) []*exec.Cmd {
+	return nil
+}

--- a/lib/vnet/diag/dns_test.go
+++ b/lib/vnet/diag/dns_test.go
@@ -227,8 +227,8 @@ func TestDNSDiagOnlyIPv6Reachable(t *testing.T) {
 	require.Equal(t, diagv1.DNSZoneStatus_DNS_ZONE_STATUS_OK, zr.ARecord.Status,
 		"A still verified because the IPv6 nameserver returned an expected A")
 	require.Equal(t, diagv1.DNSZoneStatus_DNS_ZONE_STATUS_OK, zr.AaaaRecord.Status)
-	// Overall ISSUES_FOUND because IPv4 nameserver was unreachable.
-	require.Equal(t, diagv1.CheckReportStatus_CHECK_REPORT_STATUS_ISSUES_FOUND, report.Status)
+	// One unreachable nameserver does not fail the overall check
+	require.Equal(t, diagv1.CheckReportStatus_CHECK_REPORT_STATUS_OK, report.Status)
 }
 
 func TestDNSDiagOnlyIPv6ServerNoAAnswer(t *testing.T) {

--- a/lib/vnet/diag/dns_test.go
+++ b/lib/vnet/diag/dns_test.go
@@ -35,32 +35,35 @@ import (
 
 // fakeResolver and fakeDirectQuerier inject lookup behavior per test.
 type fakeResolver struct {
-	lookup func(ctx context.Context, host string) ([]netip.Addr, error)
+	lookup func(ctx context.Context, network, host string) ([]netip.Addr, error)
 }
 
-func (f fakeResolver) Lookup(ctx context.Context, host string) ([]netip.Addr, error) {
-	return f.lookup(ctx, host)
+func (f fakeResolver) Lookup(ctx context.Context, network, host string) ([]netip.Addr, error) {
+	return f.lookup(ctx, network, host)
 }
 
 type fakeDirectQuerier struct {
-	lookup func(ctx context.Context, host string, server netip.AddrPort) ([]netip.Addr, error)
+	lookup func(ctx context.Context, network, host string, server netip.AddrPort) ([]netip.Addr, error)
 }
 
-func (f fakeDirectQuerier) LookupDirect(ctx context.Context, host string, server netip.AddrPort) ([]netip.Addr, error) {
-	return f.lookup(ctx, host, server)
+func (f fakeDirectQuerier) LookupDirect(ctx context.Context, network, host string, server netip.AddrPort) ([]netip.Addr, error) {
+	return f.lookup(ctx, network, host, server)
 }
 
 var (
-	testVNetDNS    = netip.MustParseAddrPort("[fdec:1fed:139f::2]:53")
-	testExpectedIP = netip.MustParseAddr("fdec:1fed:139f::2")
-	testOtherIP    = netip.MustParseAddr("2001:db8::1234")
-	testIPv4Hijack = netip.MustParseAddr("192.0.2.42")
+	testVNetDNSv6    = netip.MustParseAddrPort("[fdec:1fed:139f::2]:53")
+	testVNetDNSv4    = netip.MustParseAddrPort("100.64.0.2:53")
+	testExpectedAAAA = netip.MustParseAddr("fdec:1fed:139f::2")
+	testExpectedA    = netip.MustParseAddr("100.64.0.2")
+	testHijackAAAA   = netip.MustParseAddr("2001:db8::1234")
+	testHijackA      = netip.MustParseAddr("192.0.2.42")
 )
 
 func newTestDNSDiag(t *testing.T, cfg DNSConfig) *DNSDiag {
 	t.Helper()
-	if !cfg.VNetDNSServer.IsValid() {
-		cfg.VNetDNSServer = testVNetDNS
+	if !cfg.VNetDNSIPv4.IsValid() && !cfg.VNetDNSIPv6.IsValid() {
+		cfg.VNetDNSIPv4 = testVNetDNSv4
+		cfg.VNetDNSIPv6 = testVNetDNSv6
 	}
 	if cfg.QueryTimeout == 0 {
 		cfg.QueryTimeout = 100 * time.Millisecond
@@ -74,6 +77,56 @@ func newTestDNSDiag(t *testing.T, cfg DNSConfig) *DNSDiag {
 	d, err := NewDNSDiag(&cfg)
 	require.NoError(t, err)
 	return d
+}
+
+// goodDirectQuerier is a fakeDirectQuerier that returns the expected A and AAAA
+// for any server.
+var goodDirectQuerier = constantDirectQuerier(testExpectedA, testExpectedAAAA)
+
+// constantDirectQuerier returns a, aaaa for every query regardless of server.
+// Either argument may be a zero addr to fake a server that doesn't support
+// this record type.
+func constantDirectQuerier(a, aaaa netip.Addr) fakeDirectQuerier {
+	return fakeDirectQuerier{
+		lookup: func(_ context.Context, network, _ string, _ netip.AddrPort) ([]netip.Addr, error) {
+			switch network {
+			case "ip4":
+				if a.IsValid() {
+					return []netip.Addr{a}, nil
+				}
+			case "ip6":
+				if aaaa.IsValid() {
+					return []netip.Addr{aaaa}, nil
+				}
+			}
+			return nil, nil
+		},
+	}
+}
+
+// goodResolver is a fakeResolver that returns the expected A and AAAA for any
+// host.
+var goodResolver = constantResolver(testExpectedA, testExpectedAAAA)
+
+// constantResolver returns a, aaaa for every query regardless of host. Either
+// argument may be a zero addr to fake a resolver that doesn't return this
+// record type.
+func constantResolver(a, aaaa netip.Addr) fakeResolver {
+	return fakeResolver{
+		lookup: func(_ context.Context, network, _ string) ([]netip.Addr, error) {
+			switch network {
+			case "ip4":
+				if a.IsValid() {
+					return []netip.Addr{a}, nil
+				}
+			case "ip6":
+				if aaaa.IsValid() {
+					return []netip.Addr{aaaa}, nil
+				}
+			}
+			return nil, nil
+		},
+	}
 }
 
 // zoneOf extracts the zone from a probe FQDN
@@ -91,19 +144,47 @@ func zoneOf(fqdn string) string {
 	return strings.TrimSuffix(zone, ".")
 }
 
-func TestDNSDiagReachabilityFailureSkipsPerZone(t *testing.T) {
+func TestDNSDiagAllZonesOK(t *testing.T) {
+	d := newTestDNSDiag(t, DNSConfig{
+		DNSZones:      []string{"company.test", "example.test"},
+		DirectQuerier: goodDirectQuerier,
+		Resolver:      goodResolver,
+	})
+
+	report, err := d.Run(t.Context())
+	require.NoError(t, err)
+	require.Equal(t, diagv1.CheckReportStatus_CHECK_REPORT_STATUS_OK, report.Status)
+	dnsReport := report.GetDnsReport()
+	require.NotNil(t, dnsReport.Ipv4Reachability)
+	require.True(t, dnsReport.Ipv4Reachability.Reachable)
+	require.True(t, dnsReport.Ipv4Reachability.RespondedA)
+	require.True(t, dnsReport.Ipv4Reachability.RespondedAaaa)
+	require.NotNil(t, dnsReport.Ipv6Reachability)
+	require.True(t, dnsReport.Ipv6Reachability.Reachable)
+	require.True(t, dnsReport.Ipv6Reachability.RespondedA)
+	require.True(t, dnsReport.Ipv6Reachability.RespondedAaaa)
+	require.Len(t, dnsReport.ZoneResults, 2)
+	for _, zr := range dnsReport.ZoneResults {
+		require.NotNil(t, zr.ARecord, zr.Zone)
+		require.Equal(t, diagv1.DNSZoneStatus_DNS_ZONE_STATUS_OK, zr.ARecord.Status, zr.Zone)
+		require.NotNil(t, zr.AaaaRecord, zr.Zone)
+		require.Equal(t, diagv1.DNSZoneStatus_DNS_ZONE_STATUS_OK, zr.AaaaRecord.Status, zr.Zone)
+	}
+}
+
+func TestDNSDiagBothReachabilityFailureSkipsPerZone(t *testing.T) {
 	resolverCalled := false
 	d := newTestDNSDiag(t, DNSConfig{
 		DNSZones: []string{"company.test"},
 		DirectQuerier: fakeDirectQuerier{
-			lookup: func(context.Context, string, netip.AddrPort) ([]netip.Addr, error) {
+			lookup: func(context.Context, string, string, netip.AddrPort) ([]netip.Addr, error) {
 				return nil, errors.New("connection refused")
 			},
 		},
 		Resolver: fakeResolver{
-			lookup: func(context.Context, string) ([]netip.Addr, error) {
+			lookup: func(context.Context, string, string) ([]netip.Addr, error) {
 				resolverCalled = true
-				return []netip.Addr{testExpectedIP}, nil
+				return []netip.Addr{testExpectedAAAA}, nil
 			},
 		},
 	})
@@ -112,71 +193,116 @@ func TestDNSDiagReachabilityFailureSkipsPerZone(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, diagv1.CheckReportStatus_CHECK_REPORT_STATUS_ISSUES_FOUND, report.Status)
 	dnsReport := report.GetDnsReport()
-	require.False(t, dnsReport.VnetDnsReachable)
-	require.Contains(t, dnsReport.VnetDnsUnreachableError, "connection refused")
-	require.Empty(t, dnsReport.ZoneResults, "per-zone check must be skipped on reachability check failure")
-	require.False(t, resolverCalled, "OS resolver must not be called when VNet DNS is unreachable")
+	require.False(t, dnsReport.Ipv4Reachability.Reachable)
+	require.Contains(t, dnsReport.Ipv4Reachability.Error, "connection refused")
+	require.False(t, dnsReport.Ipv6Reachability.Reachable)
+	require.Contains(t, dnsReport.Ipv6Reachability.Error, "connection refused")
+	require.Empty(t, dnsReport.ZoneResults, "per-zone check must be skipped when no nameserver returned expected IPs")
+	require.False(t, resolverCalled, "OS resolver must not be called when both VNet DNS nameservers are unreachable")
 }
 
-func TestDNSDiagAllZonesOK(t *testing.T) {
+func TestDNSDiagOnlyIPv6Reachable(t *testing.T) {
+	// IPv4 server is unreachable; IPv6 server returns both records. Per-zone
+	// check should still run for both record types using IPv6's response.
 	d := newTestDNSDiag(t, DNSConfig{
-		DNSZones: []string{"company.test", "leaf.mirrors.link"},
+		DNSZones: []string{"company.test"},
 		DirectQuerier: fakeDirectQuerier{
-			lookup: func(context.Context, string, netip.AddrPort) ([]netip.Addr, error) {
-				return []netip.Addr{testExpectedIP}, nil
+			lookup: func(ctx context.Context, network, host string, server netip.AddrPort) ([]netip.Addr, error) {
+				if server != testVNetDNSv6 {
+					return nil, errors.New("network unreachable")
+				}
+				return goodDirectQuerier.lookup(ctx, network, host, server)
 			},
 		},
+		Resolver: goodResolver,
+	})
+
+	report, err := d.Run(t.Context())
+	require.NoError(t, err)
+	dnsReport := report.GetDnsReport()
+	require.False(t, dnsReport.Ipv4Reachability.Reachable)
+	require.True(t, dnsReport.Ipv6Reachability.Reachable)
+	require.Len(t, dnsReport.ZoneResults, 1)
+	zr := dnsReport.ZoneResults[0]
+	require.Equal(t, diagv1.DNSZoneStatus_DNS_ZONE_STATUS_OK, zr.ARecord.Status,
+		"A still verified because the IPv6 nameserver returned an expected A")
+	require.Equal(t, diagv1.DNSZoneStatus_DNS_ZONE_STATUS_OK, zr.AaaaRecord.Status)
+	// Overall ISSUES_FOUND because IPv4 nameserver was unreachable.
+	require.Equal(t, diagv1.CheckReportStatus_CHECK_REPORT_STATUS_ISSUES_FOUND, report.Status)
+}
+
+func TestDNSDiagOnlyIPv6ServerNoAAnswer(t *testing.T) {
+	// Only the IPv6 nameserver is configured, and it returns AAAA only.
+	d := newTestDNSDiag(t, DNSConfig{
+		VNetDNSIPv6:   testVNetDNSv6,
+		DNSZones:      []string{"company.test"},
+		DirectQuerier: constantDirectQuerier(netip.Addr{}, testExpectedAAAA),
 		Resolver: fakeResolver{
-			lookup: func(_ context.Context, host string) ([]netip.Addr, error) {
-				return []netip.Addr{testExpectedIP}, nil
+			lookup: func(_ context.Context, network, _ string) ([]netip.Addr, error) {
+				if network == "ip4" {
+					t.Fatalf("A lookup must not happen when no expected A was captured")
+				}
+				return []netip.Addr{testExpectedAAAA}, nil
 			},
 		},
 	})
 
 	report, err := d.Run(t.Context())
 	require.NoError(t, err)
-	require.Equal(t, diagv1.CheckReportStatus_CHECK_REPORT_STATUS_OK, report.Status)
 	dnsReport := report.GetDnsReport()
-	require.True(t, dnsReport.VnetDnsReachable)
-	require.Len(t, dnsReport.ZoneResults, 2)
-	for _, zr := range dnsReport.ZoneResults {
-		require.Equal(t, diagv1.DNSZoneStatus_DNS_ZONE_STATUS_OK, zr.Status, zr.Zone)
-		require.Equal(t, testExpectedIP.String(), zr.ObservedIp)
-		require.Equal(t, testExpectedIP.String(), zr.ExpectedIp)
-	}
+	require.Nil(t, dnsReport.Ipv4Reachability, "IPv4 reachability must be unset when IPv4 server is not configured")
+	require.NotNil(t, dnsReport.Ipv6Reachability)
+	require.True(t, dnsReport.Ipv6Reachability.Reachable)
+	require.True(t, dnsReport.Ipv6Reachability.RespondedAaaa)
+	require.False(t, dnsReport.Ipv6Reachability.RespondedA, "expected no A response")
+	require.Len(t, dnsReport.ZoneResults, 1)
+	zr := dnsReport.ZoneResults[0]
+	require.Nil(t, zr.ARecord, "A record result must be nil when no expected A was captured")
+	require.NotNil(t, zr.AaaaRecord)
+	require.Equal(t, diagv1.DNSZoneStatus_DNS_ZONE_STATUS_OK, zr.AaaaRecord.Status)
 }
 
-func TestDNSDiagPerZoneClassification(t *testing.T) {
+func TestDNSDiagPerRecordTypeClassification(t *testing.T) {
 	notFoundErr := &net.DNSError{Name: "x", IsNotFound: true}
 	timeoutErr := &net.DNSError{Name: "x", IsTimeout: true, Err: "i/o timeout"}
 	unexpectedErr := errors.New("upstream SERVFAIL")
 
+	zones := []string{
+		"ok.test",
+		"a-hijacked.test",
+		"aaaa-hijacked.test",
+		"mixed.test", // A TIMEOUT, AAAA HIJACKED
+		"missing.test",
+		"slow.test",
+		"borked.test",
+	}
+
 	d := newTestDNSDiag(t, DNSConfig{
-		DNSZones: []string{
-			"ok.test", "hijacked.test", "missing.test", "slow.test", "borked.test",
-			"hijacked-ipv4-only.test", "hijacked-extra-addr.test", "hijacked-mixed.test",
-		},
-		DirectQuerier: fakeDirectQuerier{
-			lookup: func(context.Context, string, netip.AddrPort) ([]netip.Addr, error) {
-				return []netip.Addr{testExpectedIP}, nil
-			},
-		},
+		DNSZones:      zones,
+		DirectQuerier: goodDirectQuerier,
 		Resolver: fakeResolver{
-			lookup: func(_ context.Context, host string) ([]netip.Addr, error) {
+			lookup: func(_ context.Context, network, host string) ([]netip.Addr, error) {
 				switch zoneOf(host) {
 				case "ok.test":
-					return []netip.Addr{testExpectedIP}, nil
-				case "hijacked.test":
-					return []netip.Addr{testOtherIP}, nil
-				case "hijacked-ipv4-only.test":
-					// VNet answers AAAA only, so any IPv4 came from a non-VNet resolver.
-					return []netip.Addr{testIPv4Hijack}, nil
-				case "hijacked-extra-addr.test":
-					// VNet returns exactly one address; an extra one means another resolver also answered.
-					return []netip.Addr{testExpectedIP, testOtherIP}, nil
-				case "hijacked-mixed.test":
-					// Exercises the IPv6-preferred surfacing path in the HIJACKED branch.
-					return []netip.Addr{testIPv4Hijack, testOtherIP}, nil
+					if network == "ip4" {
+						return []netip.Addr{testExpectedA}, nil
+					}
+					return []netip.Addr{testExpectedAAAA}, nil
+				case "a-hijacked.test":
+					if network == "ip4" {
+						return []netip.Addr{testHijackA}, nil
+					}
+					return []netip.Addr{testExpectedAAAA}, nil
+				case "aaaa-hijacked.test":
+					if network == "ip4" {
+						return []netip.Addr{testExpectedA}, nil
+					}
+					return []netip.Addr{testHijackAAAA}, nil
+				case "mixed.test":
+					if network == "ip4" {
+						return nil, timeoutErr
+					}
+					return []netip.Addr{testHijackAAAA}, nil
 				case "missing.test":
 					return nil, notFoundErr
 				case "slow.test":
@@ -199,42 +325,36 @@ func TestDNSDiagPerZoneClassification(t *testing.T) {
 		byZone[zr.Zone] = zr
 	}
 
-	assert.Equal(t, diagv1.DNSZoneStatus_DNS_ZONE_STATUS_OK, byZone["ok.test"].Status)
-	assert.Equal(t, testExpectedIP.String(), byZone["ok.test"].ObservedIp)
+	assert.Equal(t, diagv1.DNSZoneStatus_DNS_ZONE_STATUS_OK, byZone["ok.test"].ARecord.Status)
+	assert.Equal(t, diagv1.DNSZoneStatus_DNS_ZONE_STATUS_OK, byZone["ok.test"].AaaaRecord.Status)
 
-	assert.Equal(t, diagv1.DNSZoneStatus_DNS_ZONE_STATUS_HIJACKED, byZone["hijacked.test"].Status)
-	assert.Equal(t, testOtherIP.String(), byZone["hijacked.test"].ObservedIp)
+	assert.Equal(t, diagv1.DNSZoneStatus_DNS_ZONE_STATUS_HIJACKED, byZone["a-hijacked.test"].ARecord.Status)
+	assert.Equal(t, testHijackA.String(), byZone["a-hijacked.test"].ARecord.ObservedIp)
+	assert.Equal(t, diagv1.DNSZoneStatus_DNS_ZONE_STATUS_OK, byZone["a-hijacked.test"].AaaaRecord.Status)
 
-	assert.Equal(t, diagv1.DNSZoneStatus_DNS_ZONE_STATUS_HIJACKED, byZone["hijacked-ipv4-only.test"].Status)
-	assert.Equal(t, testIPv4Hijack.String(), byZone["hijacked-ipv4-only.test"].ObservedIp,
-		"IPv4-only hijack must surface the IPv4 as observed evidence")
+	assert.Equal(t, diagv1.DNSZoneStatus_DNS_ZONE_STATUS_OK, byZone["aaaa-hijacked.test"].ARecord.Status)
+	assert.Equal(t, diagv1.DNSZoneStatus_DNS_ZONE_STATUS_HIJACKED, byZone["aaaa-hijacked.test"].AaaaRecord.Status)
+	assert.Equal(t, testHijackAAAA.String(), byZone["aaaa-hijacked.test"].AaaaRecord.ObservedIp)
 
-	assert.Equal(t, diagv1.DNSZoneStatus_DNS_ZONE_STATUS_HIJACKED, byZone["hijacked-extra-addr.test"].Status,
-		"probe present but with extra addresses must classify as HIJACKED — VNet only ever returns one")
+	assert.Equal(t, diagv1.DNSZoneStatus_DNS_ZONE_STATUS_TIMEOUT, byZone["mixed.test"].ARecord.Status)
+	assert.Equal(t, diagv1.DNSZoneStatus_DNS_ZONE_STATUS_HIJACKED, byZone["mixed.test"].AaaaRecord.Status)
+	assert.Equal(t, testHijackAAAA.String(), byZone["mixed.test"].AaaaRecord.ObservedIp)
 
-	assert.Equal(t, diagv1.DNSZoneStatus_DNS_ZONE_STATUS_HIJACKED, byZone["hijacked-mixed.test"].Status)
-	assert.Equal(t, testOtherIP.String(), byZone["hijacked-mixed.test"].ObservedIp,
-		"with both IPv4 and IPv6 in a HIJACKED response, the IPv6 must be surfaced as it is the more direct evidence")
+	assert.Equal(t, diagv1.DNSZoneStatus_DNS_ZONE_STATUS_NOT_REGISTERED, byZone["missing.test"].ARecord.Status)
+	assert.Equal(t, diagv1.DNSZoneStatus_DNS_ZONE_STATUS_NOT_REGISTERED, byZone["missing.test"].AaaaRecord.Status)
 
-	assert.Equal(t, diagv1.DNSZoneStatus_DNS_ZONE_STATUS_NOT_REGISTERED, byZone["missing.test"].Status)
-	assert.Empty(t, byZone["missing.test"].ObservedIp)
+	assert.Equal(t, diagv1.DNSZoneStatus_DNS_ZONE_STATUS_TIMEOUT, byZone["slow.test"].ARecord.Status)
+	assert.NotEmpty(t, byZone["slow.test"].ARecord.Error)
 
-	assert.Equal(t, diagv1.DNSZoneStatus_DNS_ZONE_STATUS_TIMEOUT, byZone["slow.test"].Status)
-	assert.NotEmpty(t, byZone["slow.test"].Error)
-
-	assert.Equal(t, diagv1.DNSZoneStatus_DNS_ZONE_STATUS_RESOLVER_ERROR, byZone["borked.test"].Status)
-	assert.Contains(t, byZone["borked.test"].Error, "SERVFAIL")
+	assert.Equal(t, diagv1.DNSZoneStatus_DNS_ZONE_STATUS_RESOLVER_ERROR, byZone["borked.test"].ARecord.Status)
+	assert.Contains(t, byZone["borked.test"].ARecord.Error, "SERVFAIL")
 }
 
 func TestDNSDiagEmptyZonesOnlyReachability(t *testing.T) {
 	d := newTestDNSDiag(t, DNSConfig{
-		DirectQuerier: fakeDirectQuerier{
-			lookup: func(context.Context, string, netip.AddrPort) ([]netip.Addr, error) {
-				return []netip.Addr{testExpectedIP}, nil
-			},
-		},
+		DirectQuerier: goodDirectQuerier,
 		Resolver: fakeResolver{
-			lookup: func(context.Context, string) ([]netip.Addr, error) {
+			lookup: func(context.Context, string, string) ([]netip.Addr, error) {
 				t.Fatal("resolver should not be called when there are no zones")
 				return nil, nil
 			},
@@ -244,23 +364,19 @@ func TestDNSDiagEmptyZonesOnlyReachability(t *testing.T) {
 	report, err := d.Run(t.Context())
 	require.NoError(t, err)
 	require.Equal(t, diagv1.CheckReportStatus_CHECK_REPORT_STATUS_OK, report.Status)
-	require.True(t, report.GetDnsReport().VnetDnsReachable)
+	require.True(t, report.GetDnsReport().Ipv4Reachability.Reachable)
+	require.True(t, report.GetDnsReport().Ipv6Reachability.Reachable)
 	require.Empty(t, report.GetDnsReport().ZoneResults)
 }
 
 func TestDNSDiagReachabilityNoAnswer(t *testing.T) {
-	// VNet's DNS server responded but returned no records treated as
-	// unreachable, since per-zone has nothing to compare against.
+	// VNet's DNS server responded but returned no records.
 	d := newTestDNSDiag(t, DNSConfig{
-		DNSZones: []string{"company.test"},
-		DirectQuerier: fakeDirectQuerier{
-			lookup: func(context.Context, string, netip.AddrPort) ([]netip.Addr, error) {
-				return nil, nil
-			},
-		},
+		DNSZones:      []string{"company.test"},
+		DirectQuerier: constantDirectQuerier(netip.Addr{}, netip.Addr{}),
 		Resolver: fakeResolver{
-			lookup: func(context.Context, string) ([]netip.Addr, error) {
-				t.Fatal("per-zone check should be skipped when reachability check returns no answer")
+			lookup: func(context.Context, string, string) ([]netip.Addr, error) {
+				t.Fatal("per-zone check should be skipped when no expected IPs were captured")
 				return nil, nil
 			},
 		},
@@ -269,7 +385,52 @@ func TestDNSDiagReachabilityNoAnswer(t *testing.T) {
 	report, err := d.Run(t.Context())
 	require.NoError(t, err)
 	require.Equal(t, diagv1.CheckReportStatus_CHECK_REPORT_STATUS_ISSUES_FOUND, report.Status)
-	require.False(t, report.GetDnsReport().VnetDnsReachable)
+	require.False(t, report.GetDnsReport().Ipv4Reachability.Reachable)
+	require.Contains(t, report.GetDnsReport().Ipv4Reachability.Error, "server returned no records")
+	require.False(t, report.GetDnsReport().Ipv6Reachability.Reachable)
+	require.Contains(t, report.GetDnsReport().Ipv6Reachability.Error, "server returned no records")
+}
+
+func TestDNSDiagCrossTransportFallback(t *testing.T) {
+	d := newTestDNSDiag(t, DNSConfig{
+		DNSZones: []string{"company.test"},
+		DirectQuerier: fakeDirectQuerier{
+			lookup: func(_ context.Context, network, _ string, server netip.AddrPort) ([]netip.Addr, error) {
+				// IPv6 nameserver returns AAAA only, IPv4 nameserver returns both.
+				if server == testVNetDNSv6 && network == "ip4" {
+					return nil, nil
+				}
+				switch network {
+				case "ip4":
+					return []netip.Addr{testExpectedA}, nil
+				case "ip6":
+					return []netip.Addr{testExpectedAAAA}, nil
+				}
+				return nil, nil
+			},
+		},
+		Resolver: fakeResolver{
+			lookup: func(_ context.Context, network, _ string) ([]netip.Addr, error) {
+				if network == "ip4" {
+					return []netip.Addr{testExpectedA}, nil
+				}
+				return []netip.Addr{testExpectedAAAA}, nil
+			},
+		},
+	})
+
+	report, err := d.Run(t.Context())
+	require.NoError(t, err)
+	dnsReport := report.GetDnsReport()
+	require.True(t, dnsReport.Ipv6Reachability.RespondedAaaa)
+	require.False(t, dnsReport.Ipv6Reachability.RespondedA)
+	require.True(t, dnsReport.Ipv4Reachability.RespondedA)
+	require.True(t, dnsReport.Ipv4Reachability.RespondedAaaa)
+	require.Len(t, dnsReport.ZoneResults, 1)
+	zr := dnsReport.ZoneResults[0]
+	require.NotNil(t, zr.ARecord, "A check must still run using A captured from the IPv4 nameserver")
+	require.Equal(t, diagv1.DNSZoneStatus_DNS_ZONE_STATUS_OK, zr.ARecord.Status)
+	require.Equal(t, diagv1.DNSZoneStatus_DNS_ZONE_STATUS_OK, zr.AaaaRecord.Status)
 }
 
 func TestDNSDiagProbeFormat(t *testing.T) {
@@ -282,14 +443,14 @@ func TestDNSDiagProbeFormat(t *testing.T) {
 }
 
 func TestDNSDiagEmptyCheckReport(t *testing.T) {
-	d, err := NewDNSDiag(&DNSConfig{VNetDNSServer: testVNetDNS})
+	d, err := NewDNSDiag(&DNSConfig{VNetDNSIPv6: testVNetDNSv6})
 	require.NoError(t, err)
 	r := d.EmptyCheckReport()
 	_, ok := r.Report.(*diagv1.CheckReport_DnsReport)
 	require.True(t, ok, "EmptyCheckReport must return a DnsReport")
 }
 
-func TestNewDNSDiagRequiresVNetDNSServer(t *testing.T) {
+func TestNewDNSDiagRequiresAtLeastOneServer(t *testing.T) {
 	_, err := NewDNSDiag(&DNSConfig{})
 	require.Error(t, err)
 }
@@ -297,24 +458,24 @@ func TestNewDNSDiagRequiresVNetDNSServer(t *testing.T) {
 func TestDNSDiagNotRegisteredRetryRecovers(t *testing.T) {
 	notFoundErr := &net.DNSError{Name: "x", IsNotFound: true}
 
-	var callsPerZone sync.Map
+	type key struct{ zone, network string }
+	var callsPerKey sync.Map
 	d := newTestDNSDiag(t, DNSConfig{
-		DNSZones: []string{"company.test"},
-		DirectQuerier: fakeDirectQuerier{
-			lookup: func(context.Context, string, netip.AddrPort) ([]netip.Addr, error) {
-				return []netip.Addr{testExpectedIP}, nil
-			},
-		},
+		DNSZones:      []string{"company.test"},
+		DirectQuerier: goodDirectQuerier,
 		Resolver: fakeResolver{
-			lookup: func(_ context.Context, host string) ([]netip.Addr, error) {
-				zone := zoneOf(host)
-				n, _ := callsPerZone.LoadOrStore(zone, 0)
+			lookup: func(_ context.Context, network, host string) ([]netip.Addr, error) {
+				k := key{zoneOf(host), network}
+				n, _ := callsPerKey.LoadOrStore(k, 0)
 				count := n.(int) + 1
-				callsPerZone.Store(zone, count)
+				callsPerKey.Store(k, count)
 				if count == 1 {
 					return nil, notFoundErr
 				}
-				return []netip.Addr{testExpectedIP}, nil
+				if network == "ip4" {
+					return []netip.Addr{testExpectedA}, nil
+				}
+				return []netip.Addr{testExpectedAAAA}, nil
 			},
 		},
 	})
@@ -324,10 +485,13 @@ func TestDNSDiagNotRegisteredRetryRecovers(t *testing.T) {
 	require.Equal(t, diagv1.CheckReportStatus_CHECK_REPORT_STATUS_OK, report.Status,
 		"transient NOT_REGISTERED followed by OK on retry must result in overall OK")
 	zr := report.GetDnsReport().ZoneResults[0]
-	require.Equal(t, diagv1.DNSZoneStatus_DNS_ZONE_STATUS_OK, zr.Status)
+	require.Equal(t, diagv1.DNSZoneStatus_DNS_ZONE_STATUS_OK, zr.ARecord.Status)
+	require.Equal(t, diagv1.DNSZoneStatus_DNS_ZONE_STATUS_OK, zr.AaaaRecord.Status)
 
-	calls, _ := callsPerZone.Load("company.test")
-	require.Equal(t, 2, calls, "resolver must be called twice — once for the failed initial lookup and once for the retry")
+	for _, network := range []string{"ip4", "ip6"} {
+		calls, _ := callsPerKey.Load(key{"company.test", network})
+		require.Equal(t, 2, calls, "resolver must be called twice for %s, once for the failed initial lookup and once for the retry", network)
+	}
 }
 
 func TestDNSDiagNotRegisteredRetryPersistentFailure(t *testing.T) {
@@ -335,14 +499,10 @@ func TestDNSDiagNotRegisteredRetryPersistentFailure(t *testing.T) {
 
 	var calls atomic.Int32
 	d := newTestDNSDiag(t, DNSConfig{
-		DNSZones: []string{"company.test"},
-		DirectQuerier: fakeDirectQuerier{
-			lookup: func(context.Context, string, netip.AddrPort) ([]netip.Addr, error) {
-				return []netip.Addr{testExpectedIP}, nil
-			},
-		},
+		DNSZones:      []string{"company.test"},
+		DirectQuerier: goodDirectQuerier,
 		Resolver: fakeResolver{
-			lookup: func(context.Context, string) ([]netip.Addr, error) {
+			lookup: func(context.Context, string, string) ([]netip.Addr, error) {
 				calls.Add(1)
 				return nil, notFoundErr
 			},
@@ -352,49 +512,57 @@ func TestDNSDiagNotRegisteredRetryPersistentFailure(t *testing.T) {
 	report, err := d.Run(t.Context())
 	require.NoError(t, err)
 	zr := report.GetDnsReport().ZoneResults[0]
-	require.Equal(t, diagv1.DNSZoneStatus_DNS_ZONE_STATUS_NOT_REGISTERED, zr.Status,
+	require.Equal(t, diagv1.DNSZoneStatus_DNS_ZONE_STATUS_NOT_REGISTERED, zr.ARecord.Status,
 		"persistent NOT_REGISTERED must still report NOT_REGISTERED after the retry")
-	require.Equal(t, int32(2), calls.Load(), "resolver must be called exactly twice (initial + one retry)")
+	require.Equal(t, diagv1.DNSZoneStatus_DNS_ZONE_STATUS_NOT_REGISTERED, zr.AaaaRecord.Status)
+	require.Equal(t, int32(4), calls.Load(), "resolver must be called exactly 4 times (2 record types × 2 attempts each)")
 }
 
 func TestDNSDiagReachabilityRetryRecoversFromStartupGap(t *testing.T) {
-	var reachabilityCalls atomic.Int32
+	var attempts atomic.Int32
 	d := newTestDNSDiag(t, DNSConfig{
-		DNSZones: []string{"company.test"},
+		VNetDNSIPv6: testVNetDNSv6,
+		DNSZones:    []string{"company.test"},
 		DirectQuerier: fakeDirectQuerier{
-			lookup: func(context.Context, string, netip.AddrPort) ([]netip.Addr, error) {
-				if reachabilityCalls.Add(1) < 3 {
+			lookup: func(_ context.Context, network, _ string, _ netip.AddrPort) ([]netip.Addr, error) {
+				if network != "ip6" {
+					return nil, nil
+				}
+				if attempts.Add(1) < 3 {
 					return nil, &net.DNSError{Name: "x", IsTimeout: true, Err: "i/o timeout"}
 				}
-				return []netip.Addr{testExpectedIP}, nil
+				return []netip.Addr{testExpectedAAAA}, nil
 			},
 		},
 		Resolver: fakeResolver{
-			lookup: func(context.Context, string) ([]netip.Addr, error) {
-				return []netip.Addr{testExpectedIP}, nil
+			lookup: func(context.Context, string, string) ([]netip.Addr, error) {
+				return []netip.Addr{testExpectedAAAA}, nil
 			},
 		},
 	})
 
 	report, err := d.Run(t.Context())
 	require.NoError(t, err)
-	require.True(t, report.GetDnsReport().VnetDnsReachable,
+	require.True(t, report.GetDnsReport().Ipv6Reachability.Reachable,
 		"reachability check must succeed on the third attempt once VNet's DNS comes up")
-	require.Equal(t, int32(3), reachabilityCalls.Load(), "reachability check must be called 3 times (2 failures + 1 success)")
+	require.Equal(t, int32(3), attempts.Load(), "reachability check must be attempted 3 times (2 failures + 1 success)")
 }
 
 func TestDNSDiagReachabilityRetryPersistentFailure(t *testing.T) {
-	var reachabilityCalls atomic.Int32
+	var attempts atomic.Int32
 	d := newTestDNSDiag(t, DNSConfig{
-		DNSZones: []string{"company.test"},
+		VNetDNSIPv6: testVNetDNSv6,
+		DNSZones:    []string{"company.test"},
 		DirectQuerier: fakeDirectQuerier{
-			lookup: func(context.Context, string, netip.AddrPort) ([]netip.Addr, error) {
-				reachabilityCalls.Add(1)
+			lookup: func(_ context.Context, network, _ string, _ netip.AddrPort) ([]netip.Addr, error) {
+				if network == "ip6" {
+					attempts.Add(1)
+				}
 				return nil, &net.DNSError{Name: "x", IsTimeout: true, Err: "i/o timeout"}
 			},
 		},
 		Resolver: fakeResolver{
-			lookup: func(context.Context, string) ([]netip.Addr, error) {
+			lookup: func(context.Context, string, string) ([]netip.Addr, error) {
 				t.Fatal("per-zone check must be skipped when reachability check fails after all retries")
 				return nil, nil
 			},
@@ -404,9 +572,9 @@ func TestDNSDiagReachabilityRetryPersistentFailure(t *testing.T) {
 	report, err := d.Run(t.Context())
 	require.NoError(t, err)
 	dnsReport := report.GetDnsReport()
-	require.False(t, dnsReport.VnetDnsReachable)
-	require.Contains(t, dnsReport.VnetDnsUnreachableError, "i/o timeout")
-	require.Equal(t, int32(defaultReachabilityMaxAttempts), reachabilityCalls.Load(),
+	require.False(t, dnsReport.Ipv6Reachability.Reachable)
+	require.Contains(t, dnsReport.Ipv6Reachability.Error, "i/o timeout")
+	require.Equal(t, int32(defaultReachabilityMaxAttempts), attempts.Load(),
 		"reachability check must be retried up to ReachabilityMaxAttempts before giving up")
 }
 
@@ -416,7 +584,7 @@ func TestDNSDiagNotRegisteredRetryOnlyForNotRegistered(t *testing.T) {
 		respond func() ([]netip.Addr, error)
 	}{
 		{"HIJACKED", func() ([]netip.Addr, error) {
-			return []netip.Addr{testOtherIP}, nil
+			return []netip.Addr{testHijackAAAA}, nil
 		}},
 		{"TIMEOUT", func() ([]netip.Addr, error) {
 			return nil, &net.DNSError{Name: "x", IsTimeout: true}
@@ -425,21 +593,18 @@ func TestDNSDiagNotRegisteredRetryOnlyForNotRegistered(t *testing.T) {
 			return nil, errors.New("upstream SERVFAIL")
 		}},
 		{"OK", func() ([]netip.Addr, error) {
-			return []netip.Addr{testExpectedIP}, nil
+			return []netip.Addr{testExpectedAAAA}, nil
 		}},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			var calls atomic.Int32
 			d := newTestDNSDiag(t, DNSConfig{
-				DNSZones: []string{"company.test"},
-				DirectQuerier: fakeDirectQuerier{
-					lookup: func(context.Context, string, netip.AddrPort) ([]netip.Addr, error) {
-						return []netip.Addr{testExpectedIP}, nil
-					},
-				},
+				VNetDNSIPv6:   testVNetDNSv6,
+				DNSZones:      []string{"company.test"},
+				DirectQuerier: constantDirectQuerier(netip.Addr{}, testExpectedAAAA),
 				Resolver: fakeResolver{
-					lookup: func(context.Context, string) ([]netip.Addr, error) {
+					lookup: func(context.Context, string, string) ([]netip.Addr, error) {
 						calls.Add(1)
 						return tc.respond()
 					},
@@ -467,6 +632,30 @@ func TestDNSServerForIPv6Prefix(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.prefix, func(t *testing.T) {
 			got, err := DNSServerForIPv6Prefix(tc.prefix)
+			if tc.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tc.want, got.String())
+		})
+	}
+}
+
+func TestDNSServerForIPv4CIDRRange(t *testing.T) {
+	cases := []struct {
+		cidr    string
+		want    string
+		wantErr bool
+	}{
+		{cidr: "100.64.0.0/24", want: "100.64.0.2:53"},
+		{cidr: "172.16.0.0/16", want: "172.16.0.2:53"},
+		{cidr: "10.0.0.0/8", want: "10.0.0.2:53"},
+		{cidr: "not a cidr", wantErr: true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.cidr, func(t *testing.T) {
+			got, err := DNSServerForIPv4CIDRRange(tc.cidr)
 			if tc.wantErr {
 				require.Error(t, err)
 				return

--- a/lib/vnet/diag/dns_test.go
+++ b/lib/vnet/diag/dns_test.go
@@ -27,6 +27,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	diagv1 "github.com/gravitational/teleport/gen/proto/go/teleport/lib/vnet/diag/v1"
@@ -107,7 +108,7 @@ func TestDNSDiagReachabilityFailureSkipsPerZone(t *testing.T) {
 		},
 	})
 
-	report, err := d.Run(context.Background())
+	report, err := d.Run(t.Context())
 	require.NoError(t, err)
 	require.Equal(t, diagv1.CheckReportStatus_CHECK_REPORT_STATUS_ISSUES_FOUND, report.Status)
 	dnsReport := report.GetDnsReport()
@@ -132,7 +133,7 @@ func TestDNSDiagAllZonesOK(t *testing.T) {
 		},
 	})
 
-	report, err := d.Run(context.Background())
+	report, err := d.Run(t.Context())
 	require.NoError(t, err)
 	require.Equal(t, diagv1.CheckReportStatus_CHECK_REPORT_STATUS_OK, report.Status)
 	dnsReport := report.GetDnsReport()
@@ -189,7 +190,7 @@ func TestDNSDiagPerZoneClassification(t *testing.T) {
 		},
 	})
 
-	report, err := d.Run(context.Background())
+	report, err := d.Run(t.Context())
 	require.NoError(t, err)
 	require.Equal(t, diagv1.CheckReportStatus_CHECK_REPORT_STATUS_ISSUES_FOUND, report.Status)
 
@@ -198,31 +199,31 @@ func TestDNSDiagPerZoneClassification(t *testing.T) {
 		byZone[zr.Zone] = zr
 	}
 
-	require.Equal(t, diagv1.DNSZoneStatus_DNS_ZONE_STATUS_OK, byZone["ok.test"].Status)
-	require.Equal(t, testExpectedIP.String(), byZone["ok.test"].ObservedIp)
+	assert.Equal(t, diagv1.DNSZoneStatus_DNS_ZONE_STATUS_OK, byZone["ok.test"].Status)
+	assert.Equal(t, testExpectedIP.String(), byZone["ok.test"].ObservedIp)
 
-	require.Equal(t, diagv1.DNSZoneStatus_DNS_ZONE_STATUS_HIJACKED, byZone["hijacked.test"].Status)
-	require.Equal(t, testOtherIP.String(), byZone["hijacked.test"].ObservedIp)
+	assert.Equal(t, diagv1.DNSZoneStatus_DNS_ZONE_STATUS_HIJACKED, byZone["hijacked.test"].Status)
+	assert.Equal(t, testOtherIP.String(), byZone["hijacked.test"].ObservedIp)
 
-	require.Equal(t, diagv1.DNSZoneStatus_DNS_ZONE_STATUS_HIJACKED, byZone["hijacked-ipv4-only.test"].Status)
-	require.Equal(t, testIPv4Hijack.String(), byZone["hijacked-ipv4-only.test"].ObservedIp,
+	assert.Equal(t, diagv1.DNSZoneStatus_DNS_ZONE_STATUS_HIJACKED, byZone["hijacked-ipv4-only.test"].Status)
+	assert.Equal(t, testIPv4Hijack.String(), byZone["hijacked-ipv4-only.test"].ObservedIp,
 		"IPv4-only hijack must surface the IPv4 as observed evidence")
 
-	require.Equal(t, diagv1.DNSZoneStatus_DNS_ZONE_STATUS_HIJACKED, byZone["hijacked-extra-addr.test"].Status,
+	assert.Equal(t, diagv1.DNSZoneStatus_DNS_ZONE_STATUS_HIJACKED, byZone["hijacked-extra-addr.test"].Status,
 		"probe present but with extra addresses must classify as HIJACKED — VNet only ever returns one")
 
-	require.Equal(t, diagv1.DNSZoneStatus_DNS_ZONE_STATUS_HIJACKED, byZone["hijacked-mixed.test"].Status)
-	require.Equal(t, testOtherIP.String(), byZone["hijacked-mixed.test"].ObservedIp,
+	assert.Equal(t, diagv1.DNSZoneStatus_DNS_ZONE_STATUS_HIJACKED, byZone["hijacked-mixed.test"].Status)
+	assert.Equal(t, testOtherIP.String(), byZone["hijacked-mixed.test"].ObservedIp,
 		"with both IPv4 and IPv6 in a HIJACKED response, the IPv6 must be surfaced as it is the more direct evidence")
 
-	require.Equal(t, diagv1.DNSZoneStatus_DNS_ZONE_STATUS_NOT_REGISTERED, byZone["missing.test"].Status)
-	require.Empty(t, byZone["missing.test"].ObservedIp)
+	assert.Equal(t, diagv1.DNSZoneStatus_DNS_ZONE_STATUS_NOT_REGISTERED, byZone["missing.test"].Status)
+	assert.Empty(t, byZone["missing.test"].ObservedIp)
 
-	require.Equal(t, diagv1.DNSZoneStatus_DNS_ZONE_STATUS_TIMEOUT, byZone["slow.test"].Status)
-	require.NotEmpty(t, byZone["slow.test"].Error)
+	assert.Equal(t, diagv1.DNSZoneStatus_DNS_ZONE_STATUS_TIMEOUT, byZone["slow.test"].Status)
+	assert.NotEmpty(t, byZone["slow.test"].Error)
 
-	require.Equal(t, diagv1.DNSZoneStatus_DNS_ZONE_STATUS_RESOLVER_ERROR, byZone["borked.test"].Status)
-	require.Contains(t, byZone["borked.test"].Error, "SERVFAIL")
+	assert.Equal(t, diagv1.DNSZoneStatus_DNS_ZONE_STATUS_RESOLVER_ERROR, byZone["borked.test"].Status)
+	assert.Contains(t, byZone["borked.test"].Error, "SERVFAIL")
 }
 
 func TestDNSDiagEmptyZonesOnlyReachability(t *testing.T) {
@@ -240,7 +241,7 @@ func TestDNSDiagEmptyZonesOnlyReachability(t *testing.T) {
 		},
 	})
 
-	report, err := d.Run(context.Background())
+	report, err := d.Run(t.Context())
 	require.NoError(t, err)
 	require.Equal(t, diagv1.CheckReportStatus_CHECK_REPORT_STATUS_OK, report.Status)
 	require.True(t, report.GetDnsReport().VnetDnsReachable)
@@ -265,7 +266,7 @@ func TestDNSDiagReachabilityNoAnswer(t *testing.T) {
 		},
 	})
 
-	report, err := d.Run(context.Background())
+	report, err := d.Run(t.Context())
 	require.NoError(t, err)
 	require.Equal(t, diagv1.CheckReportStatus_CHECK_REPORT_STATUS_ISSUES_FOUND, report.Status)
 	require.False(t, report.GetDnsReport().VnetDnsReachable)
@@ -318,7 +319,7 @@ func TestDNSDiagNotRegisteredRetryRecovers(t *testing.T) {
 		},
 	})
 
-	report, err := d.Run(context.Background())
+	report, err := d.Run(t.Context())
 	require.NoError(t, err)
 	require.Equal(t, diagv1.CheckReportStatus_CHECK_REPORT_STATUS_OK, report.Status,
 		"transient NOT_REGISTERED followed by OK on retry must result in overall OK")
@@ -348,7 +349,7 @@ func TestDNSDiagNotRegisteredRetryPersistentFailure(t *testing.T) {
 		},
 	})
 
-	report, err := d.Run(context.Background())
+	report, err := d.Run(t.Context())
 	require.NoError(t, err)
 	zr := report.GetDnsReport().ZoneResults[0]
 	require.Equal(t, diagv1.DNSZoneStatus_DNS_ZONE_STATUS_NOT_REGISTERED, zr.Status,
@@ -375,7 +376,7 @@ func TestDNSDiagReachabilityRetryRecoversFromStartupGap(t *testing.T) {
 		},
 	})
 
-	report, err := d.Run(context.Background())
+	report, err := d.Run(t.Context())
 	require.NoError(t, err)
 	require.True(t, report.GetDnsReport().VnetDnsReachable,
 		"reachability check must succeed on the third attempt once VNet's DNS comes up")
@@ -400,7 +401,7 @@ func TestDNSDiagReachabilityRetryPersistentFailure(t *testing.T) {
 		},
 	})
 
-	report, err := d.Run(context.Background())
+	report, err := d.Run(t.Context())
 	require.NoError(t, err)
 	dnsReport := report.GetDnsReport()
 	require.False(t, dnsReport.VnetDnsReachable)
@@ -444,7 +445,7 @@ func TestDNSDiagNotRegisteredRetryOnlyForNotRegistered(t *testing.T) {
 					},
 				},
 			})
-			_, err := d.Run(context.Background())
+			_, err := d.Run(t.Context())
 			require.NoError(t, err)
 			require.Equal(t, int32(1), calls.Load(), "%s must not trigger a retry", tc.name)
 		})

--- a/lib/vnet/diag/dns_test.go
+++ b/lib/vnet/diag/dns_test.go
@@ -1,0 +1,477 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package diag
+
+import (
+	"context"
+	"errors"
+	"net"
+	"net/netip"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	diagv1 "github.com/gravitational/teleport/gen/proto/go/teleport/lib/vnet/diag/v1"
+)
+
+// fakeResolver and fakeDirectQuerier inject lookup behavior per test.
+type fakeResolver struct {
+	lookup func(ctx context.Context, host string) ([]netip.Addr, error)
+}
+
+func (f fakeResolver) Lookup(ctx context.Context, host string) ([]netip.Addr, error) {
+	return f.lookup(ctx, host)
+}
+
+type fakeDirectQuerier struct {
+	lookup func(ctx context.Context, host string, server netip.AddrPort) ([]netip.Addr, error)
+}
+
+func (f fakeDirectQuerier) LookupDirect(ctx context.Context, host string, server netip.AddrPort) ([]netip.Addr, error) {
+	return f.lookup(ctx, host, server)
+}
+
+var (
+	testVNetDNS    = netip.MustParseAddrPort("[fdec:1fed:139f::2]:53")
+	testExpectedIP = netip.MustParseAddr("fdec:1fed:139f::2")
+	testOtherIP    = netip.MustParseAddr("2001:db8::1234")
+	testIPv4Hijack = netip.MustParseAddr("192.0.2.42")
+)
+
+func newTestDNSDiag(t *testing.T, cfg DNSConfig) *DNSDiag {
+	t.Helper()
+	if !cfg.VNetDNSServer.IsValid() {
+		cfg.VNetDNSServer = testVNetDNS
+	}
+	if cfg.QueryTimeout == 0 {
+		cfg.QueryTimeout = 100 * time.Millisecond
+	}
+	if cfg.NotRegisteredRetryDelay == 0 {
+		cfg.NotRegisteredRetryDelay = time.Nanosecond
+	}
+	if cfg.ReachabilityRetryDelay == 0 {
+		cfg.ReachabilityRetryDelay = time.Nanosecond
+	}
+	d, err := NewDNSDiag(&cfg)
+	require.NoError(t, err)
+	return d
+}
+
+// zoneOf extracts the zone from a probe FQDN
+func zoneOf(fqdn string) string {
+	const prefix = "vnet-diag-"
+	rest, ok := strings.CutPrefix(fqdn, prefix)
+	if !ok {
+		return ""
+	}
+	// rest is "<hex>.<zone>."
+	_, zone, ok := strings.Cut(rest, ".")
+	if !ok {
+		return ""
+	}
+	return strings.TrimSuffix(zone, ".")
+}
+
+func TestDNSDiagReachabilityFailureSkipsPerZone(t *testing.T) {
+	resolverCalled := false
+	d := newTestDNSDiag(t, DNSConfig{
+		DNSZones: []string{"company.test"},
+		DirectQuerier: fakeDirectQuerier{
+			lookup: func(context.Context, string, netip.AddrPort) ([]netip.Addr, error) {
+				return nil, errors.New("connection refused")
+			},
+		},
+		Resolver: fakeResolver{
+			lookup: func(context.Context, string) ([]netip.Addr, error) {
+				resolverCalled = true
+				return []netip.Addr{testExpectedIP}, nil
+			},
+		},
+	})
+
+	report, err := d.Run(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, diagv1.CheckReportStatus_CHECK_REPORT_STATUS_ISSUES_FOUND, report.Status)
+	dnsReport := report.GetDnsReport()
+	require.False(t, dnsReport.VnetDnsReachable)
+	require.Contains(t, dnsReport.VnetDnsUnreachableError, "connection refused")
+	require.Empty(t, dnsReport.ZoneResults, "per-zone check must be skipped on reachability check failure")
+	require.False(t, resolverCalled, "OS resolver must not be called when VNet DNS is unreachable")
+}
+
+func TestDNSDiagAllZonesOK(t *testing.T) {
+	d := newTestDNSDiag(t, DNSConfig{
+		DNSZones: []string{"company.test", "leaf.mirrors.link"},
+		DirectQuerier: fakeDirectQuerier{
+			lookup: func(context.Context, string, netip.AddrPort) ([]netip.Addr, error) {
+				return []netip.Addr{testExpectedIP}, nil
+			},
+		},
+		Resolver: fakeResolver{
+			lookup: func(_ context.Context, host string) ([]netip.Addr, error) {
+				return []netip.Addr{testExpectedIP}, nil
+			},
+		},
+	})
+
+	report, err := d.Run(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, diagv1.CheckReportStatus_CHECK_REPORT_STATUS_OK, report.Status)
+	dnsReport := report.GetDnsReport()
+	require.True(t, dnsReport.VnetDnsReachable)
+	require.Len(t, dnsReport.ZoneResults, 2)
+	for _, zr := range dnsReport.ZoneResults {
+		require.Equal(t, diagv1.DNSZoneStatus_DNS_ZONE_STATUS_OK, zr.Status, zr.Zone)
+		require.Equal(t, testExpectedIP.String(), zr.ObservedIp)
+		require.Equal(t, testExpectedIP.String(), zr.ExpectedIp)
+	}
+}
+
+func TestDNSDiagPerZoneClassification(t *testing.T) {
+	notFoundErr := &net.DNSError{Name: "x", IsNotFound: true}
+	timeoutErr := &net.DNSError{Name: "x", IsTimeout: true, Err: "i/o timeout"}
+	unexpectedErr := errors.New("upstream SERVFAIL")
+
+	d := newTestDNSDiag(t, DNSConfig{
+		DNSZones: []string{
+			"ok.test", "hijacked.test", "missing.test", "slow.test", "borked.test",
+			"hijacked-ipv4-only.test", "hijacked-extra-addr.test", "hijacked-mixed.test",
+		},
+		DirectQuerier: fakeDirectQuerier{
+			lookup: func(context.Context, string, netip.AddrPort) ([]netip.Addr, error) {
+				return []netip.Addr{testExpectedIP}, nil
+			},
+		},
+		Resolver: fakeResolver{
+			lookup: func(_ context.Context, host string) ([]netip.Addr, error) {
+				switch zoneOf(host) {
+				case "ok.test":
+					return []netip.Addr{testExpectedIP}, nil
+				case "hijacked.test":
+					return []netip.Addr{testOtherIP}, nil
+				case "hijacked-ipv4-only.test":
+					// VNet answers AAAA only, so any IPv4 came from a non-VNet resolver.
+					return []netip.Addr{testIPv4Hijack}, nil
+				case "hijacked-extra-addr.test":
+					// VNet returns exactly one address; an extra one means another resolver also answered.
+					return []netip.Addr{testExpectedIP, testOtherIP}, nil
+				case "hijacked-mixed.test":
+					// Exercises the IPv6-preferred surfacing path in the HIJACKED branch.
+					return []netip.Addr{testIPv4Hijack, testOtherIP}, nil
+				case "missing.test":
+					return nil, notFoundErr
+				case "slow.test":
+					return nil, timeoutErr
+				case "borked.test":
+					return nil, unexpectedErr
+				}
+				t.Fatalf("unexpected host %q", host)
+				return nil, nil
+			},
+		},
+	})
+
+	report, err := d.Run(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, diagv1.CheckReportStatus_CHECK_REPORT_STATUS_ISSUES_FOUND, report.Status)
+
+	byZone := map[string]*diagv1.DNSZoneResult{}
+	for _, zr := range report.GetDnsReport().ZoneResults {
+		byZone[zr.Zone] = zr
+	}
+
+	require.Equal(t, diagv1.DNSZoneStatus_DNS_ZONE_STATUS_OK, byZone["ok.test"].Status)
+	require.Equal(t, testExpectedIP.String(), byZone["ok.test"].ObservedIp)
+
+	require.Equal(t, diagv1.DNSZoneStatus_DNS_ZONE_STATUS_HIJACKED, byZone["hijacked.test"].Status)
+	require.Equal(t, testOtherIP.String(), byZone["hijacked.test"].ObservedIp)
+
+	require.Equal(t, diagv1.DNSZoneStatus_DNS_ZONE_STATUS_HIJACKED, byZone["hijacked-ipv4-only.test"].Status)
+	require.Equal(t, testIPv4Hijack.String(), byZone["hijacked-ipv4-only.test"].ObservedIp,
+		"IPv4-only hijack must surface the IPv4 as observed evidence")
+
+	require.Equal(t, diagv1.DNSZoneStatus_DNS_ZONE_STATUS_HIJACKED, byZone["hijacked-extra-addr.test"].Status,
+		"probe present but with extra addresses must classify as HIJACKED — VNet only ever returns one")
+
+	require.Equal(t, diagv1.DNSZoneStatus_DNS_ZONE_STATUS_HIJACKED, byZone["hijacked-mixed.test"].Status)
+	require.Equal(t, testOtherIP.String(), byZone["hijacked-mixed.test"].ObservedIp,
+		"with both IPv4 and IPv6 in a HIJACKED response, the IPv6 must be surfaced as it is the more direct evidence")
+
+	require.Equal(t, diagv1.DNSZoneStatus_DNS_ZONE_STATUS_NOT_REGISTERED, byZone["missing.test"].Status)
+	require.Empty(t, byZone["missing.test"].ObservedIp)
+
+	require.Equal(t, diagv1.DNSZoneStatus_DNS_ZONE_STATUS_TIMEOUT, byZone["slow.test"].Status)
+	require.NotEmpty(t, byZone["slow.test"].Error)
+
+	require.Equal(t, diagv1.DNSZoneStatus_DNS_ZONE_STATUS_RESOLVER_ERROR, byZone["borked.test"].Status)
+	require.Contains(t, byZone["borked.test"].Error, "SERVFAIL")
+}
+
+func TestDNSDiagEmptyZonesOnlyReachability(t *testing.T) {
+	d := newTestDNSDiag(t, DNSConfig{
+		DirectQuerier: fakeDirectQuerier{
+			lookup: func(context.Context, string, netip.AddrPort) ([]netip.Addr, error) {
+				return []netip.Addr{testExpectedIP}, nil
+			},
+		},
+		Resolver: fakeResolver{
+			lookup: func(context.Context, string) ([]netip.Addr, error) {
+				t.Fatal("resolver should not be called when there are no zones")
+				return nil, nil
+			},
+		},
+	})
+
+	report, err := d.Run(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, diagv1.CheckReportStatus_CHECK_REPORT_STATUS_OK, report.Status)
+	require.True(t, report.GetDnsReport().VnetDnsReachable)
+	require.Empty(t, report.GetDnsReport().ZoneResults)
+}
+
+func TestDNSDiagReachabilityNoAnswer(t *testing.T) {
+	// VNet's DNS server responded but returned no records treated as
+	// unreachable, since per-zone has nothing to compare against.
+	d := newTestDNSDiag(t, DNSConfig{
+		DNSZones: []string{"company.test"},
+		DirectQuerier: fakeDirectQuerier{
+			lookup: func(context.Context, string, netip.AddrPort) ([]netip.Addr, error) {
+				return nil, nil
+			},
+		},
+		Resolver: fakeResolver{
+			lookup: func(context.Context, string) ([]netip.Addr, error) {
+				t.Fatal("per-zone check should be skipped when reachability check returns no answer")
+				return nil, nil
+			},
+		},
+	})
+
+	report, err := d.Run(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, diagv1.CheckReportStatus_CHECK_REPORT_STATUS_ISSUES_FOUND, report.Status)
+	require.False(t, report.GetDnsReport().VnetDnsReachable)
+}
+
+func TestDNSDiagProbeFormat(t *testing.T) {
+	a := probeFQDN("company.test")
+	b := probeFQDN("company.test")
+	require.NotEqual(t, a, b, "probe labels must be unique per call to defeat caches")
+	require.True(t, strings.HasPrefix(a, "vnet-diag-"), a)
+	require.True(t, strings.HasSuffix(a, ".company.test."), a)
+	require.Equal(t, "company.test", zoneOf(a))
+}
+
+func TestDNSDiagEmptyCheckReport(t *testing.T) {
+	d, err := NewDNSDiag(&DNSConfig{VNetDNSServer: testVNetDNS})
+	require.NoError(t, err)
+	r := d.EmptyCheckReport()
+	_, ok := r.Report.(*diagv1.CheckReport_DnsReport)
+	require.True(t, ok, "EmptyCheckReport must return a DnsReport")
+}
+
+func TestNewDNSDiagRequiresVNetDNSServer(t *testing.T) {
+	_, err := NewDNSDiag(&DNSConfig{})
+	require.Error(t, err)
+}
+
+func TestDNSDiagNotRegisteredRetryRecovers(t *testing.T) {
+	notFoundErr := &net.DNSError{Name: "x", IsNotFound: true}
+
+	var callsPerZone sync.Map
+	d := newTestDNSDiag(t, DNSConfig{
+		DNSZones: []string{"company.test"},
+		DirectQuerier: fakeDirectQuerier{
+			lookup: func(context.Context, string, netip.AddrPort) ([]netip.Addr, error) {
+				return []netip.Addr{testExpectedIP}, nil
+			},
+		},
+		Resolver: fakeResolver{
+			lookup: func(_ context.Context, host string) ([]netip.Addr, error) {
+				zone := zoneOf(host)
+				n, _ := callsPerZone.LoadOrStore(zone, 0)
+				count := n.(int) + 1
+				callsPerZone.Store(zone, count)
+				if count == 1 {
+					return nil, notFoundErr
+				}
+				return []netip.Addr{testExpectedIP}, nil
+			},
+		},
+	})
+
+	report, err := d.Run(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, diagv1.CheckReportStatus_CHECK_REPORT_STATUS_OK, report.Status,
+		"transient NOT_REGISTERED followed by OK on retry must result in overall OK")
+	zr := report.GetDnsReport().ZoneResults[0]
+	require.Equal(t, diagv1.DNSZoneStatus_DNS_ZONE_STATUS_OK, zr.Status)
+
+	calls, _ := callsPerZone.Load("company.test")
+	require.Equal(t, 2, calls, "resolver must be called twice — once for the failed initial lookup and once for the retry")
+}
+
+func TestDNSDiagNotRegisteredRetryPersistentFailure(t *testing.T) {
+	notFoundErr := &net.DNSError{Name: "x", IsNotFound: true}
+
+	var calls atomic.Int32
+	d := newTestDNSDiag(t, DNSConfig{
+		DNSZones: []string{"company.test"},
+		DirectQuerier: fakeDirectQuerier{
+			lookup: func(context.Context, string, netip.AddrPort) ([]netip.Addr, error) {
+				return []netip.Addr{testExpectedIP}, nil
+			},
+		},
+		Resolver: fakeResolver{
+			lookup: func(context.Context, string) ([]netip.Addr, error) {
+				calls.Add(1)
+				return nil, notFoundErr
+			},
+		},
+	})
+
+	report, err := d.Run(context.Background())
+	require.NoError(t, err)
+	zr := report.GetDnsReport().ZoneResults[0]
+	require.Equal(t, diagv1.DNSZoneStatus_DNS_ZONE_STATUS_NOT_REGISTERED, zr.Status,
+		"persistent NOT_REGISTERED must still report NOT_REGISTERED after the retry")
+	require.Equal(t, int32(2), calls.Load(), "resolver must be called exactly twice (initial + one retry)")
+}
+
+func TestDNSDiagReachabilityRetryRecoversFromStartupGap(t *testing.T) {
+	var reachabilityCalls atomic.Int32
+	d := newTestDNSDiag(t, DNSConfig{
+		DNSZones: []string{"company.test"},
+		DirectQuerier: fakeDirectQuerier{
+			lookup: func(context.Context, string, netip.AddrPort) ([]netip.Addr, error) {
+				if reachabilityCalls.Add(1) < 3 {
+					return nil, &net.DNSError{Name: "x", IsTimeout: true, Err: "i/o timeout"}
+				}
+				return []netip.Addr{testExpectedIP}, nil
+			},
+		},
+		Resolver: fakeResolver{
+			lookup: func(context.Context, string) ([]netip.Addr, error) {
+				return []netip.Addr{testExpectedIP}, nil
+			},
+		},
+	})
+
+	report, err := d.Run(context.Background())
+	require.NoError(t, err)
+	require.True(t, report.GetDnsReport().VnetDnsReachable,
+		"reachability check must succeed on the third attempt once VNet's DNS comes up")
+	require.Equal(t, int32(3), reachabilityCalls.Load(), "reachability check must be called 3 times (2 failures + 1 success)")
+}
+
+func TestDNSDiagReachabilityRetryPersistentFailure(t *testing.T) {
+	var reachabilityCalls atomic.Int32
+	d := newTestDNSDiag(t, DNSConfig{
+		DNSZones: []string{"company.test"},
+		DirectQuerier: fakeDirectQuerier{
+			lookup: func(context.Context, string, netip.AddrPort) ([]netip.Addr, error) {
+				reachabilityCalls.Add(1)
+				return nil, &net.DNSError{Name: "x", IsTimeout: true, Err: "i/o timeout"}
+			},
+		},
+		Resolver: fakeResolver{
+			lookup: func(context.Context, string) ([]netip.Addr, error) {
+				t.Fatal("per-zone check must be skipped when reachability check fails after all retries")
+				return nil, nil
+			},
+		},
+	})
+
+	report, err := d.Run(context.Background())
+	require.NoError(t, err)
+	dnsReport := report.GetDnsReport()
+	require.False(t, dnsReport.VnetDnsReachable)
+	require.Contains(t, dnsReport.VnetDnsUnreachableError, "i/o timeout")
+	require.Equal(t, int32(defaultReachabilityMaxAttempts), reachabilityCalls.Load(),
+		"reachability check must be retried up to ReachabilityMaxAttempts before giving up")
+}
+
+func TestDNSDiagNotRegisteredRetryOnlyForNotRegistered(t *testing.T) {
+	cases := []struct {
+		name    string
+		respond func() ([]netip.Addr, error)
+	}{
+		{"HIJACKED", func() ([]netip.Addr, error) {
+			return []netip.Addr{testOtherIP}, nil
+		}},
+		{"TIMEOUT", func() ([]netip.Addr, error) {
+			return nil, &net.DNSError{Name: "x", IsTimeout: true}
+		}},
+		{"RESOLVER_ERROR", func() ([]netip.Addr, error) {
+			return nil, errors.New("upstream SERVFAIL")
+		}},
+		{"OK", func() ([]netip.Addr, error) {
+			return []netip.Addr{testExpectedIP}, nil
+		}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var calls atomic.Int32
+			d := newTestDNSDiag(t, DNSConfig{
+				DNSZones: []string{"company.test"},
+				DirectQuerier: fakeDirectQuerier{
+					lookup: func(context.Context, string, netip.AddrPort) ([]netip.Addr, error) {
+						return []netip.Addr{testExpectedIP}, nil
+					},
+				},
+				Resolver: fakeResolver{
+					lookup: func(context.Context, string) ([]netip.Addr, error) {
+						calls.Add(1)
+						return tc.respond()
+					},
+				},
+			})
+			_, err := d.Run(context.Background())
+			require.NoError(t, err)
+			require.Equal(t, int32(1), calls.Load(), "%s must not trigger a retry", tc.name)
+		})
+	}
+}
+
+func TestDNSServerForIPv6Prefix(t *testing.T) {
+	cases := []struct {
+		prefix  string
+		want    string
+		wantErr bool
+	}{
+		{prefix: "fdec:1fed:139f::", want: "[fdec:1fed:139f::2]:53"},
+		{prefix: "fd00::", want: "[fd00::2]:53"},
+		{prefix: "fdec:1fed:139f::5", want: "[fdec:1fed:139f::2]:53"},
+		{prefix: "not an addr", wantErr: true},
+		{prefix: "172.20.0.0", wantErr: true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.prefix, func(t *testing.T) {
+			got, err := DNSServerForIPv6Prefix(tc.prefix)
+			if tc.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tc.want, got.String())
+		})
+	}
+}

--- a/lib/vnet/diag/dns_test.go
+++ b/lib/vnet/diag/dns_test.go
@@ -434,11 +434,12 @@ func TestDNSDiagCrossTransportFallback(t *testing.T) {
 }
 
 func TestDNSDiagProbeFormat(t *testing.T) {
-	a := probeFQDN("company.test")
-	b := probeFQDN("company.test")
+	a := probeName("company.test")
+	b := probeName("company.test")
 	require.NotEqual(t, a, b, "probe labels must be unique per call to defeat caches")
 	require.True(t, strings.HasPrefix(a, "vnet-diag-"), a)
-	require.True(t, strings.HasSuffix(a, ".company.test."), a)
+	require.True(t, strings.HasSuffix(a, ".company.test"), a)
+	require.False(t, strings.HasSuffix(a, "."), "probe name must not be FQDN")
 	require.Equal(t, "company.test", zoneOf(a))
 }
 

--- a/lib/vnet/diag/dns_windows.go
+++ b/lib/vnet/diag/dns_windows.go
@@ -1,0 +1,28 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package diag
+
+import (
+	"context"
+	"os/exec"
+)
+
+func (d *DNSDiag) commands(ctx context.Context) []*exec.Cmd {
+	return []*exec.Cmd{
+		exec.CommandContext(ctx, "netsh.exe", "namespace", "show", "effectivepolicy"),
+	}
+}

--- a/lib/vnet/diag/routeconflict_darwin.go
+++ b/lib/vnet/diag/routeconflict_darwin.go
@@ -129,6 +129,5 @@ func (n *NetInterfaces) interfaceApp(ctx context.Context, ifaceName string) (str
 func (c *RouteConflictDiag) commands(ctx context.Context) []*exec.Cmd {
 	return []*exec.Cmd{
 		exec.CommandContext(ctx, "netstat", "-rn", "-f", "inet"),
-		exec.CommandContext(ctx, "scutil", "--dns"),
 	}
 }

--- a/lib/vnet/diag/routeconflict_linux.go
+++ b/lib/vnet/diag/routeconflict_linux.go
@@ -107,6 +107,5 @@ func (n *NetInterfaces) interfaceApp(ctx context.Context, ifaceName string) (str
 func (c *RouteConflictDiag) commands(ctx context.Context) []*exec.Cmd {
 	return []*exec.Cmd{
 		exec.CommandContext(ctx, "ip", "route", "show"),
-		exec.CommandContext(ctx, "resolvectl", "status"),
 	}
 }

--- a/lib/vnet/diag/routeconflict_windows.go
+++ b/lib/vnet/diag/routeconflict_windows.go
@@ -74,6 +74,5 @@ func (c *RouteConflictDiag) commands(ctx context.Context) []*exec.Cmd {
 	return []*exec.Cmd{
 		exec.CommandContext(ctx, "netstat.exe", "-rn"),
 		exec.CommandContext(ctx, "ipconfig.exe", "/all"),
-		exec.CommandContext(ctx, "netsh.exe", "namespace", "show", "effectivepolicy"),
 	}
 }

--- a/lib/vnet/dns/diag_probe.go
+++ b/lib/vnet/dns/diag_probe.go
@@ -1,0 +1,33 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package dns
+
+import "strings"
+
+// DiagProbePrefix is the label prefix VNet reserves for diagnostic probe queries.
+// Full probe FQDNs have the form "vnet-diag-<random>.<zone>.".
+const DiagProbePrefix = "vnet-diag-"
+
+// HasDiagProbePrefix reports whether fqdn is a diagnostic probe query.
+// Matching is case-insensitive.
+func HasDiagProbePrefix(fqdn string) bool {
+	if len(fqdn) < len(DiagProbePrefix) {
+		return false
+	}
+	// Case-insensitive prefix match without allocations
+	return strings.EqualFold(fqdn[:len(DiagProbePrefix)], DiagProbePrefix)
+}

--- a/lib/vnet/dns/diag_probe_test.go
+++ b/lib/vnet/dns/diag_probe_test.go
@@ -1,0 +1,45 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package dns
+
+import "testing"
+
+func TestHasDiagProbePrefix(t *testing.T) {
+	cases := []struct {
+		name string
+		fqdn string
+		want bool
+	}{
+		{name: "lowercase match", fqdn: "vnet-diag-abc.company.test.", want: true},
+		{name: "uppercase match", fqdn: "VNET-DIAG-abc.company.test.", want: true},
+		{name: "mixed case match", fqdn: "Vnet-Diag-abc.company.test.", want: true},
+		{name: "exact prefix only", fqdn: "vnet-diag-", want: true},
+		{name: "no random suffix", fqdn: "vnet-diag-.company.test.", want: true},
+		{name: "regular app name", fqdn: "myapp.company.test.", want: false},
+		{name: "similar prefix", fqdn: "vnet-other.company.test.", want: false},
+		{name: "prefix in middle", fqdn: "x.vnet-diag-y.company.test.", want: false},
+		{name: "empty string", fqdn: "", want: false},
+		{name: "shorter than prefix", fqdn: "vnet-", want: false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := HasDiagProbePrefix(tc.fqdn); got != tc.want {
+				t.Errorf("HasDiagProbePrefix(%q) = %v, want %v", tc.fqdn, got, tc.want)
+			}
+		})
+	}
+}

--- a/lib/vnet/dns/dns.go
+++ b/lib/vnet/dns/dns.go
@@ -46,6 +46,13 @@ const (
 	forwardRequestTimeout = 5 * time.Second
 )
 
+// DNSServerSuffix is the byte appended to VNet's IPv6 prefix to form the DNS server
+// address, VNet's DNS server lives at <ipv6_prefix>::N where N is this value
+var DNSServerSuffix = []byte{2}
+
+// DNSServerPort is the port VNet's DNS server listens on.
+const DNSServerPort = 53
+
 // Resolver represents an entity that can resolve DNS requests.
 type Resolver interface {
 	// ResolveA should return a Result for an A record question. If an empty Result is returned with no error,

--- a/lib/vnet/dns/dns_test.go
+++ b/lib/vnet/dns/dns_test.go
@@ -45,7 +45,7 @@ func TestMain(m *testing.M) {
 // that net.Resolver can successfully use the stack to lookup hosts.
 func TestServer(t *testing.T) {
 	t.Parallel()
-	ctx := context.Background()
+	ctx := t.Context()
 
 	defaultIP4 := tcpip.AddrFrom4([4]byte{1, 2, 3, 4})
 	defaultIP6 := tcpip.AddrFrom16([16]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16})

--- a/lib/vnet/dns/osnameservers.go
+++ b/lib/vnet/dns/osnameservers.go
@@ -31,7 +31,7 @@ func NewOSUpstreamNameserverSource(logger *slog.Logger) (UpstreamNameserverSourc
 	)
 }
 
-// AddrWithDNSPort returns addr with DNS port 53.
+// AddrWithDNSPort returns addr with the DNS port (see DNSServerPort).
 func AddrWithDNSPort(addr netip.Addr) string {
-	return netip.AddrPortFrom(addr, 53).String()
+	return netip.AddrPortFrom(addr, DNSServerPort).String()
 }

--- a/lib/vnet/network_stack.go
+++ b/lib/vnet/network_stack.go
@@ -24,6 +24,7 @@ import (
 	"net/netip"
 	"os"
 	"sync"
+	"sync/atomic"
 
 	"github.com/gravitational/trace"
 	"golang.org/x/sync/errgroup"
@@ -166,6 +167,12 @@ type networkStack struct {
 	// diagProbeIPv6 is the IPv6 address (ipv6Prefix::2) returned to diagnostic probe queries.
 	// Set once in newNetworkStack.
 	diagProbeIPv6 [16]byte
+
+	// diagProbeIPv4 is the IPv4 address returned to diagnostic probe queries. Set on the
+	// first call of addDNSAddress, which happens after the first call of targetOSConfig
+	// and before DNS addresses are registered with any OS resolver, so ResolveA should
+	// not read nil in practice.
+	diagProbeIPv4 atomic.Pointer[[4]byte]
 
 	// dnsServer is the VNet's local DNS server that can handle UDP DNS
 	// requests.
@@ -636,6 +643,11 @@ func (ns *networkStack) addDNSAddress(ip net.IP) error {
 	if !ok {
 		return trace.Errorf("error parsing IPv4 DNS address %s", ip.String())
 	}
+	if v4 := ip.To4(); v4 != nil && ns.diagProbeIPv4.Load() == nil {
+		var b [4]byte
+		copy(b[:], v4)
+		ns.diagProbeIPv4.CompareAndSwap(nil, &b)
+	}
 	if ns.upstreamFilter != nil {
 		ns.upstreamFilter.AddExclude(dns.AddrWithDNSPort(addr))
 	}
@@ -648,6 +660,9 @@ func (ns *networkStack) ResolveA(ctx context.Context, fqdn string) (dns.Result, 
 	// Diagnostic probes short-circuit here. Without this, each probe's unique random label
 	// would allocate a fresh IPv4 from the CIDR pool, leaking the entry.
 	if dns.HasDiagProbePrefix(fqdn) {
+		if v4 := ns.diagProbeIPv4.Load(); v4 != nil {
+			return dns.Result{A: *v4}, nil
+		}
 		return dns.Result{NoRecord: true}, nil
 	}
 

--- a/lib/vnet/network_stack.go
+++ b/lib/vnet/network_stack.go
@@ -163,6 +163,10 @@ type networkStack struct {
 	// ipv6Prefix holds the 96-bit prefix that will be used for all IPv6 addresses assigned in the VNet.
 	ipv6Prefix tcpip.Address
 
+	// diagProbeIPv6 is the IPv6 address (ipv6Prefix::2) returned to diagnostic probe queries.
+	// Set once in newNetworkStack.
+	diagProbeIPv6 [16]byte
+
 	// dnsServer is the VNet's local DNS server that can handle UDP DNS
 	// requests.
 	dnsServer *dns.Server
@@ -323,10 +327,16 @@ func newNetworkStack(cfg *networkStackConfig) (*networkStack, error) {
 	ns.stack.SetTransportProtocolHandler(udp.ProtocolNumber, udpForwarder.HandlePacket)
 
 	if cfg.dnsIPv6 != (tcpip.Address{}) {
+		ns.diagProbeIPv6 = cfg.dnsIPv6.As16()
 		if err := ns.assignUDPHandler(cfg.dnsIPv6, dnsServer); err != nil {
 			return nil, trace.Wrap(err)
 		}
 		logger.DebugContext(context.Background(), "Serving DNS on IPv6.", "dns_addr", cfg.dnsIPv6)
+	} else {
+		// This branch shouldn't be reachable, every caller sets cfg.dnsIPv6.
+		// Added it so the probe handler can return a stable value if a future caller
+		// forgets to set it.
+		ns.diagProbeIPv6 = ipv6WithSuffix(cfg.ipv6Prefix, dns.DNSServerSuffix).As16()
 	}
 
 	return ns, nil
@@ -635,6 +645,12 @@ func (ns *networkStack) addDNSAddress(ip net.IP) error {
 
 // ResolveA implements [dns.Resolver.ResolveA].
 func (ns *networkStack) ResolveA(ctx context.Context, fqdn string) (dns.Result, error) {
+	// Diagnostic probes short-circuit here. Without this, each probe's unique random label
+	// would allocate a fresh IPv4 from the CIDR pool, leaking the entry.
+	if dns.HasDiagProbePrefix(fqdn) {
+		return dns.Result{NoRecord: true}, nil
+	}
+
 	// Do the actual resolution within a [singleflight.Group] keyed by [fqdn] to avoid concurrent requests to
 	// resolve an FQDN and then assign an address to it.
 	resultAny, err, _ := ns.resolveHandlerGroup.Do(fqdn, func() (any, error) {
@@ -675,6 +691,12 @@ func (ns *networkStack) ResolveA(ctx context.Context, fqdn string) (dns.Result, 
 
 // ResolveAAAA implements [dns.Resolver.ResolveAAAA].
 func (ns *networkStack) ResolveAAAA(ctx context.Context, fqdn string) (dns.Result, error) {
+	// Diagnostic probes return the stable IPv6 probe address — the value the diagnostic
+	// check compares against. No handler is allocated.
+	if dns.HasDiagProbePrefix(fqdn) {
+		return dns.Result{AAAA: ns.diagProbeIPv6}, nil
+	}
+
 	result, err := ns.ResolveA(ctx, fqdn)
 	if err != nil {
 		return dns.Result{}, trace.Wrap(err)

--- a/lib/vnet/network_stack_test.go
+++ b/lib/vnet/network_stack_test.go
@@ -17,7 +17,6 @@
 package vnet
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -40,7 +39,7 @@ func TestResolveADiagProbe(t *testing.T) {
 
 	const probeFQDN = "vnet-diag-abcdef.company.test."
 
-	result, err := ns.ResolveA(context.Background(), probeFQDN)
+	result, err := ns.ResolveA(t.Context(), probeFQDN)
 	require.NoError(t, err)
 	require.True(t, result.NoRecord, "A query for probe must return NoRecord (NODATA)")
 	require.Equal(t, [4]byte{}, result.A, "probe A query must not return any address")
@@ -57,7 +56,7 @@ func TestResolveAAAADiagProbe(t *testing.T) {
 
 	const probeFQDN = "vnet-diag-abcdef.company.test."
 
-	result, err := ns.ResolveAAAA(context.Background(), probeFQDN)
+	result, err := ns.ResolveAAAA(t.Context(), probeFQDN)
 	require.NoError(t, err)
 	require.Equal(t, testProbeIPv6, result.AAAA, "AAAA query for probe must return diagProbeIPv6")
 	require.Equal(t, [4]byte{}, result.A, "AAAA result must not include an A record")
@@ -77,7 +76,7 @@ func TestResolveAAAADiagProbeCaseInsensitive(t *testing.T) {
 		"Vnet-Diag-abc.company.test.",
 		"vNeT-dIaG-abc.company.test.",
 	} {
-		result, err := ns.ResolveAAAA(context.Background(), fqdn)
+		result, err := ns.ResolveAAAA(t.Context(), fqdn)
 		require.NoError(t, err, fqdn)
 		require.Equal(t, testProbeIPv6, result.AAAA, fqdn)
 	}

--- a/lib/vnet/network_stack_test.go
+++ b/lib/vnet/network_stack_test.go
@@ -29,8 +29,12 @@ var testIPv6Prefix = tcpip.AddrFrom16([16]byte{0xfd, 0xec, 0x1f, 0xed, 0x13, 0x9
 // testProbeIPv6 is the IPv6 probe address returned by ResolveAAAA for diagnostic queries
 var testProbeIPv6 = [16]byte{0xfd, 0xec, 0x1f, 0xed, 0x13, 0x9f, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2}
 
-// TestResolveADiagProbe verifies that A queries for probe names return NODATA
-func TestResolveADiagProbe(t *testing.T) {
+// testProbeIPv4 is the IPv4 probe address returned by ResolveA for diagnostic queries
+var testProbeIPv4 = [4]byte{100, 64, 0, 2}
+
+// TestResolveADiagProbeNoIPv4 verifies that A queries for probe names return NODATA
+// when diagProbeIPv4 has not been set yet.
+func TestResolveADiagProbeNoIPv4(t *testing.T) {
 	ns := &networkStack{
 		state:         newState(),
 		ipv6Prefix:    testIPv6Prefix,
@@ -43,6 +47,26 @@ func TestResolveADiagProbe(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, result.NoRecord, "A query for probe must return NoRecord (NODATA)")
 	require.Equal(t, [4]byte{}, result.A, "probe A query must not return any address")
+	require.Empty(t, ns.state.assignedIPs, "probe query must not mutate assignedIPs")
+	require.Empty(t, ns.state.tcpHandlers, "probe query must not create a TCP handler")
+}
+
+// TestResolveADiagProbeWithIPv4 verifies that A queries for probe names return the
+// stashed diagProbeIPv4 once it has been set.
+func TestResolveADiagProbeWithIPv4(t *testing.T) {
+	ns := &networkStack{
+		state:         newState(),
+		ipv6Prefix:    testIPv6Prefix,
+		diagProbeIPv6: testProbeIPv6,
+	}
+	ns.diagProbeIPv4.Store(&testProbeIPv4)
+
+	const probeFQDN = "vnet-diag-abcdef.company.test."
+
+	result, err := ns.ResolveA(t.Context(), probeFQDN)
+	require.NoError(t, err)
+	require.False(t, result.NoRecord, "A query for probe must return an answer when diagProbeIPv4 is set")
+	require.Equal(t, testProbeIPv4, result.A, "A query for probe must return diagProbeIPv4")
 	require.Empty(t, ns.state.assignedIPs, "probe query must not mutate assignedIPs")
 	require.Empty(t, ns.state.tcpHandlers, "probe query must not create a TCP handler")
 }

--- a/lib/vnet/network_stack_test.go
+++ b/lib/vnet/network_stack_test.go
@@ -1,0 +1,85 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package vnet
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"gvisor.dev/gvisor/pkg/tcpip"
+)
+
+// testIPv6Prefix is a fixed ULA prefix used in probe tests so the expected probe address is deterministic.
+var testIPv6Prefix = tcpip.AddrFrom16([16]byte{0xfd, 0xec, 0x1f, 0xed, 0x13, 0x9f})
+
+// testProbeIPv6 is the IPv6 probe address returned by ResolveAAAA for diagnostic queries
+var testProbeIPv6 = [16]byte{0xfd, 0xec, 0x1f, 0xed, 0x13, 0x9f, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2}
+
+// TestResolveADiagProbe verifies that A queries for probe names return NODATA
+func TestResolveADiagProbe(t *testing.T) {
+	ns := &networkStack{
+		state:         newState(),
+		ipv6Prefix:    testIPv6Prefix,
+		diagProbeIPv6: testProbeIPv6,
+	}
+
+	const probeFQDN = "vnet-diag-abcdef.company.test."
+
+	result, err := ns.ResolveA(context.Background(), probeFQDN)
+	require.NoError(t, err)
+	require.True(t, result.NoRecord, "A query for probe must return NoRecord (NODATA)")
+	require.Equal(t, [4]byte{}, result.A, "probe A query must not return any address")
+	require.Empty(t, ns.state.assignedIPs, "probe query must not mutate assignedIPs")
+	require.Empty(t, ns.state.tcpHandlers, "probe query must not create a TCP handler")
+}
+
+func TestResolveAAAADiagProbe(t *testing.T) {
+	ns := &networkStack{
+		state:         newState(),
+		ipv6Prefix:    testIPv6Prefix,
+		diagProbeIPv6: testProbeIPv6,
+	}
+
+	const probeFQDN = "vnet-diag-abcdef.company.test."
+
+	result, err := ns.ResolveAAAA(context.Background(), probeFQDN)
+	require.NoError(t, err)
+	require.Equal(t, testProbeIPv6, result.AAAA, "AAAA query for probe must return diagProbeIPv6")
+	require.Equal(t, [4]byte{}, result.A, "AAAA result must not include an A record")
+	require.Empty(t, ns.state.assignedIPs, "probe query must not mutate assignedIPs")
+	require.Empty(t, ns.state.tcpHandlers, "probe query must not create a TCP handler")
+}
+
+func TestResolveAAAADiagProbeCaseInsensitive(t *testing.T) {
+	ns := &networkStack{
+		state:         newState(),
+		ipv6Prefix:    testIPv6Prefix,
+		diagProbeIPv6: testProbeIPv6,
+	}
+
+	for _, fqdn := range []string{
+		"VNET-DIAG-abc.company.test.",
+		"Vnet-Diag-abc.company.test.",
+		"vNeT-dIaG-abc.company.test.",
+	} {
+		result, err := ns.ResolveAAAA(context.Background(), fqdn)
+		require.NoError(t, err, fqdn)
+		require.Equal(t, testProbeIPv6, result.AAAA, fqdn)
+	}
+	require.Empty(t, ns.state.assignedIPs)
+}

--- a/lib/vnet/vnet_test.go
+++ b/lib/vnet/vnet_test.go
@@ -67,6 +67,7 @@ import (
 	"github.com/gravitational/teleport/lib/tlsca"
 	"github.com/gravitational/teleport/lib/utils"
 	"github.com/gravitational/teleport/lib/utils/testutils"
+	"github.com/gravitational/teleport/lib/vnet/dns"
 )
 
 const (
@@ -100,7 +101,7 @@ func newTestPack(t *testing.T, ctx context.Context, cfg testPackConfig) *testPac
 
 	vnetIPv6Prefix, err := newIPv6Prefix()
 	require.NoError(t, err)
-	dnsIPv6 := ipv6WithSuffix(vnetIPv6Prefix, []byte{2})
+	dnsIPv6 := ipv6WithSuffix(vnetIPv6Prefix, dns.DNSServerSuffix)
 
 	// In reality the VNet networking stack runs in a separate process from the
 	// client application and communicates over gRPC. For the test, everything

--- a/proto/teleport/lib/vnet/diag/v1/diag.proto
+++ b/proto/teleport/lib/vnet/diag/v1/diag.proto
@@ -109,6 +109,9 @@ message CheckReport {
     RouteConflictReport route_conflict_report = 2;
     // ssh_configuration_report reports the status of the system's SSH configuration.
     SSHConfigurationReport ssh_configuration_report = 3;
+    // dns_report reports whether the system resolver routes queries for each VNet-managed DNS zone
+    // to VNet's nameserver.
+    DNSReport dns_report = 4;
   }
 }
 
@@ -159,6 +162,63 @@ message RouteConflict {
   // the output of `ifconfig -v <interface name>`. Not all VPN applications use this framework, so
   // it's likely to be empty.
   string interface_app = 4;
+}
+
+// DNSReport describes whether the system resolver routes DNS queries for VNet-managed zones to
+// VNet's nameserver. It is the output of DNSDiag.
+//
+// The check uses a probe hostname of the form vnet-diag-<random>.<zone>. VNet's nameserver
+// short-circuits any query with this prefix and answers with an address derived from its IPv6
+// prefix, an address no other resolver can produce. The random label prevents DNS caches.
+//
+// The check first queries the probe directly against VNet's nameserver IP to confirm VNet's DNS
+// server is reachable and to capture the expected response. If that fails, vnet_dns_reachable is
+// false, vnet_dns_unreachable_error stores the error, and zone_results is empty. Otherwise, the
+// check runs the same probe query per zone through the system resolver and compares each answer to
+// the expected response. A mismatch means the per-zone OS resolver entry does not route to VNet.
+message DNSReport {
+  // vnet_dns_reachable is true if a direct DNS query to VNet's nameserver IP succeeded.
+  bool vnet_dns_reachable = 1;
+  // vnet_dns_unreachable_error is set when vnet_dns_reachable is false.
+  string vnet_dns_unreachable_error = 2;
+  // zone_results contains one entry per zone in NetworkStack.dns_zones. Empty if
+  // vnet_dns_reachable is false.
+  repeated DNSZoneResult zone_results = 3;
+}
+
+// DNSZoneResult describes the outcome of querying a probe hostname under a single VNet-managed
+// DNS zone through the system resolver.
+message DNSZoneResult {
+  // zone is the DNS zone that was tested, e.g. "company.test".
+  string zone = 1;
+  // status describes the outcome of the query.
+  DNSZoneStatus status = 2;
+  // observed_ip is the IP returned by the system resolver for the probe hostname. Empty on
+  // timeout or no answer.
+  string observed_ip = 3;
+  // expected_ip is the IP that VNet's nameserver returned for the same probe hostname when
+  // queried directly.
+  string expected_ip = 4;
+  // error is set on DNS_ZONE_STATUS_TIMEOUT and DNS_ZONE_STATUS_RESOLVER_ERROR.
+  string error = 5;
+}
+
+// DNSZoneStatus is the outcome of querying a probe hostname for a single DNS zone.
+enum DNSZoneStatus {
+  DNS_ZONE_STATUS_UNSPECIFIED = 0;
+  // DNS_ZONE_STATUS_OK indicates the system resolver returned the IP we expected from VNet's
+  // nameserver, so per-zone routing works.
+  DNS_ZONE_STATUS_OK = 1;
+  // DNS_ZONE_STATUS_HIJACKED indicates the system resolver returned an IP, but not the one VNet
+  // returned. Some other resolver answered for this zone.
+  DNS_ZONE_STATUS_HIJACKED = 2;
+  // DNS_ZONE_STATUS_NOT_REGISTERED indicates the system resolver returned NXDOMAIN or SERVFAIL.
+  DNS_ZONE_STATUS_NOT_REGISTERED = 3;
+  // DNS_ZONE_STATUS_TIMEOUT indicates the system resolver query timed out, likely because it
+  // was routed to a nameserver that is unreachable.
+  DNS_ZONE_STATUS_TIMEOUT = 4;
+  // DNS_ZONE_STATUS_RESOLVER_ERROR indicates an unexpected error from the system resolver.
+  DNS_ZONE_STATUS_RESOLVER_ERROR = 5;
 }
 
 // SSHConfigurationReport describes the state of the system's SSH configuration.

--- a/proto/teleport/lib/vnet/diag/v1/diag.proto
+++ b/proto/teleport/lib/vnet/diag/v1/diag.proto
@@ -168,39 +168,67 @@ message RouteConflict {
 // VNet's nameserver. It is the output of DNSDiag.
 //
 // The check uses a probe hostname of the form vnet-diag-<random>.<zone>. VNet's nameserver
-// short-circuits any query with this prefix and answers with an address derived from its IPv6
-// prefix, an address no other resolver can produce. The random label prevents DNS caches.
+// short-circuits any query with this prefix and answers with addresses derived from its IPv4 CIDR
+// range and IPv6 prefix, addresses no other resolver can produce. The random label prevents DNS
+// caches.
 //
-// The check first queries the probe directly against VNet's nameserver IP to confirm VNet's DNS
-// server is reachable and to capture the expected response. If that fails, vnet_dns_reachable is
-// false, vnet_dns_unreachable_error stores the error, and zone_results is empty. Otherwise, the
-// check runs the same probe query per zone through the system resolver and compares each answer to
-// the expected response. A mismatch means the per-zone OS resolver entry does not route to VNet.
+// The check first queries the probe directly against each VNet nameserver IPv4 and IPv6 addresses
+// asking for both A and AAAA records, to confirm VNet's DNS server is reachable and to capture the
+// expected responses per record type. If an IPv4 or IPv6 address is unreachable, the corresponding
+// reachability field still records the failure but the check continues with whatever was captured
+// from successful queries. If neither address produced a response for either record type,
+// zone_results is empty. Otherwise, the check runs the same probe per zone through the system
+// resolver, asking for A and AAAA independently, and compares each answer to the expected response.
+// A mismatch means the per-zone OS resolver entry does not route to VNet.
 message DNSReport {
-  // vnet_dns_reachable is true if a direct DNS query to VNet's nameserver IP succeeded.
-  bool vnet_dns_reachable = 1;
-  // vnet_dns_unreachable_error is set when vnet_dns_reachable is false.
-  string vnet_dns_unreachable_error = 2;
-  // zone_results contains one entry per zone in NetworkStack.dns_zones. Empty if
-  // vnet_dns_reachable is false.
+  // ipv4_reachability is the outcome of probing VNet's IPv4 nameserver directly. Null if VNet is
+  // not serving DNS on IPv4.
+  VNetDNSReachability ipv4_reachability = 1;
+  // ipv6_reachability is the outcome of probing VNet's IPv6 nameserver directly. Null if VNet is
+  // not serving DNS on IPv6.
+  VNetDNSReachability ipv6_reachability = 2;
+  // zone_results contains one entry per zone in NetworkStack.dns_zones. Empty if neither
+  // reachability probe produced a response for either record type.
   repeated DNSZoneResult zone_results = 3;
 }
 
+// VNetDNSReachability describes the outcome of probing one of VNet's DNS servers directly,
+// bypassing the system resolver.
+message VNetDNSReachability {
+  // address is the server that was probed, e.g. "[fdec:1fed:139f::2]:53" or "100.64.0.2:53".
+  string address = 1;
+  // reachable is true if the server returned an answer for at least one record type.
+  bool reachable = 2;
+  // responded_a is true if the server returned an A record for the probe.
+  bool responded_a = 3;
+  // responded_aaaa is true if the server returned an AAAA record for the probe.
+  bool responded_aaaa = 4;
+  // error explains the failure when reachable is false.
+  string error = 5;
+}
+
 // DNSZoneResult describes the outcome of querying a probe hostname under a single VNet-managed
-// DNS zone through the system resolver.
+// DNS zone through the system resolver. The query is made for both A and AAAA records.
 message DNSZoneResult {
   // zone is the DNS zone that was tested, e.g. "company.test".
   string zone = 1;
-  // status describes the outcome of the query.
-  DNSZoneStatus status = 2;
-  // observed_ip is the IP returned by the system resolver for the probe hostname. Empty on
-  // timeout or no answer.
-  string observed_ip = 3;
-  // expected_ip is the IP that VNet's nameserver returned for the same probe hostname when
-  // queried directly.
-  string expected_ip = 4;
+  // a_record is the outcome of the A-record part of the per-zone query. Null if no expected A was
+  // captured.
+  RecordResult a_record = 2;
+  // aaaa_record is the outcome of the AAAA-record part of the per-zone query. Null if no expected
+  // AAAA was captured.
+  RecordResult aaaa_record = 3;
+}
+
+// RecordResult describes the outcome of querying a single record type for a single zone through
+// the system resolver.
+message RecordResult {
+  // status describes the outcome of the query for this record type.
+  DNSZoneStatus status = 1;
+  // observed_ip is the IP returned by the system resolver. Populated for DNS_ZONE_STATUS_HIJACKED.
+  string observed_ip = 2;
   // error is set on DNS_ZONE_STATUS_TIMEOUT and DNS_ZONE_STATUS_RESOLVER_ERROR.
-  string error = 5;
+  string error = 3;
 }
 
 // DNSZoneStatus is the outcome of querying a probe hostname for a single DNS zone.

--- a/proto/teleport/lib/vnet/diag/v1/diag.proto
+++ b/proto/teleport/lib/vnet/diag/v1/diag.proto
@@ -212,11 +212,15 @@ message VNetDNSReachability {
 message DNSZoneResult {
   // zone is the DNS zone that was tested, e.g. "company.test".
   string zone = 1;
-  // a_record is the outcome of the A-record part of the per-zone query. Null if no expected A was
-  // captured.
+  // a_record is the outcome of the A-record query for this zone, compared to the
+  // A returned by VNet's DNS server on direct query. The check is skipped and
+  // this field is null when VNet's DNS server failed to return an A on direct
+  // query.
   RecordResult a_record = 2;
-  // aaaa_record is the outcome of the AAAA-record part of the per-zone query. Null if no expected
-  // AAAA was captured.
+  // aaaa_record is the outcome of the AAAA-record query for this zone, compared
+  // to the AAAA returned by VNet's DNS server on direct query. The check is
+  // skipped and this field is null when VNet's DNS server failed to return an
+  // AAAA on direct query.
   RecordResult aaaa_record = 3;
 }
 

--- a/tool/tsh/common/vnet.go
+++ b/tool/tsh/common/vnet.go
@@ -166,7 +166,6 @@ func printDNSReport(r *diagv1.DNSReport) {
 		fmt.Printf("VNet DNS is unreachable: %s\n", r.VnetDnsUnreachableError)
 		return
 	}
-	// TODO(tangyatsu): make prettier
 	for _, zr := range r.ZoneResults {
 		switch zr.Status {
 		case diagv1.DNSZoneStatus_DNS_ZONE_STATUS_OK:

--- a/tool/tsh/common/vnet.go
+++ b/tool/tsh/common/vnet.go
@@ -24,7 +24,9 @@ import (
 	"github.com/gravitational/trace"
 
 	"github.com/gravitational/teleport/api/profile"
+	diagv1 "github.com/gravitational/teleport/gen/proto/go/teleport/lib/vnet/diag/v1"
 	"github.com/gravitational/teleport/lib/vnet"
+	"github.com/gravitational/teleport/lib/vnet/diag"
 )
 
 type vnetCLICommand interface {
@@ -66,7 +68,7 @@ func (c *vnetCommand) run(cf *CLIConf) error {
 		go func() {
 			fmt.Println("Running diagnostics.")
 			//nolint:staticcheck // SA4023. runVnetDiagnostics on unsupported platforms always returns err.
-			if err := runVnetDiagnostics(cf.Context, vnetProcess.NetworkStackInfo()); err != nil {
+			if err := runVnetDiagnostics(cf.Context, vnetProcess); err != nil {
 				logger.ErrorContext(cf.Context, "Ran into a problem while running diagnostics", "error", err)
 				return
 			}
@@ -124,4 +126,61 @@ func (vnetCommandNotSupported) FullCommand() string {
 
 func (vnetCommandNotSupported) run(*CLIConf) error {
 	panic("vnetCommandNotSupported.run should never be called, this is a bug")
+}
+
+// runDNSDiag runs the DNS check and prints any issues.
+func runDNSDiag(ctx context.Context, vnetProcess *vnet.UserProcess) error {
+	nsi := vnetProcess.NetworkStackInfo()
+	if nsi.Ipv6Prefix == "" {
+		return nil
+	}
+	cfg, err := vnetProcess.GetUnifiedClusterConfigProvider().GetUnifiedClusterConfig(ctx)
+	if err != nil {
+		return trace.Wrap(err, "getting unified cluster config for DNS diag")
+	}
+	vnetDNSServer, err := diag.DNSServerForIPv6Prefix(nsi.Ipv6Prefix)
+	if err != nil {
+		return trace.Wrap(err, "computing VNet DNS server address for DNS diag")
+	}
+	dnsDiag, err := diag.NewDNSDiag(&diag.DNSConfig{
+		DNSZones:      cfg.AllDNSZones(),
+		VNetDNSServer: vnetDNSServer,
+	})
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	report, err := dnsDiag.Run(ctx)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	printDNSReport(report.GetDnsReport())
+	return nil
+}
+
+// printDNSReport prints only zones that exhibit a problem.
+func printDNSReport(r *diagv1.DNSReport) {
+	if r == nil {
+		return
+	}
+	if !r.VnetDnsReachable {
+		fmt.Printf("VNet DNS is unreachable: %s\n", r.VnetDnsUnreachableError)
+		return
+	}
+	// TODO(tangyatsu): make prettier
+	for _, zr := range r.ZoneResults {
+		switch zr.Status {
+		case diagv1.DNSZoneStatus_DNS_ZONE_STATUS_OK:
+			// Working as expected; not printed.
+		case diagv1.DNSZoneStatus_DNS_ZONE_STATUS_HIJACKED:
+			fmt.Printf("DNS zone %q is hijacked: observed=%s, expected=%s\n", zr.Zone, zr.ObservedIp, zr.ExpectedIp)
+		case diagv1.DNSZoneStatus_DNS_ZONE_STATUS_NOT_REGISTERED:
+			fmt.Printf("DNS zone %q is not registered with the OS resolver\n", zr.Zone)
+		case diagv1.DNSZoneStatus_DNS_ZONE_STATUS_TIMEOUT:
+			fmt.Printf("DNS zone %q timed out: %s\n", zr.Zone, zr.Error)
+		case diagv1.DNSZoneStatus_DNS_ZONE_STATUS_RESOLVER_ERROR:
+			fmt.Printf("DNS zone %q resolver error: %s\n", zr.Zone, zr.Error)
+		default:
+			fmt.Printf("DNS zone %q has unexpected status %s\n", zr.Zone, zr.Status)
+		}
+	}
 }

--- a/tool/tsh/common/vnet.go
+++ b/tool/tsh/common/vnet.go
@@ -131,21 +131,30 @@ func (vnetCommandNotSupported) run(*CLIConf) error {
 // runDNSDiag runs the DNS check and prints any issues.
 func runDNSDiag(ctx context.Context, vnetProcess *vnet.UserProcess) error {
 	nsi := vnetProcess.NetworkStackInfo()
-	if nsi.Ipv6Prefix == "" {
-		return nil
-	}
 	cfg, err := vnetProcess.GetUnifiedClusterConfigProvider().GetUnifiedClusterConfig(ctx)
 	if err != nil {
 		return trace.Wrap(err, "getting unified cluster config for DNS diag")
 	}
-	vnetDNSServer, err := diag.DNSServerForIPv6Prefix(nsi.Ipv6Prefix)
-	if err != nil {
-		return trace.Wrap(err, "computing VNet DNS server address for DNS diag")
+	dnsCfg := &diag.DNSConfig{DNSZones: cfg.AllDNSZones()}
+	if nsi.Ipv6Prefix != "" {
+		s, err := diag.DNSServerForIPv6Prefix(nsi.Ipv6Prefix)
+		if err != nil {
+			return trace.Wrap(err, "computing VNet IPv6 DNS server address for DNS diag")
+		}
+		dnsCfg.VNetDNSIPv6 = s
 	}
-	dnsDiag, err := diag.NewDNSDiag(&diag.DNSConfig{
-		DNSZones:      cfg.AllDNSZones(),
-		VNetDNSServer: vnetDNSServer,
-	})
+	if len(cfg.IPv4CidrRanges) > 0 {
+		s, err := diag.DNSServerForIPv4CIDRRange(cfg.IPv4CidrRanges[0])
+		if err != nil {
+			return trace.Wrap(err, "computing VNet IPv4 DNS server address for DNS diag")
+		}
+		dnsCfg.VNetDNSIPv4 = s
+	}
+	if !dnsCfg.VNetDNSIPv4.IsValid() && !dnsCfg.VNetDNSIPv6.IsValid() {
+		return nil
+	}
+
+	dnsDiag, err := diag.NewDNSDiag(dnsCfg)
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -157,29 +166,63 @@ func runDNSDiag(ctx context.Context, vnetProcess *vnet.UserProcess) error {
 	return nil
 }
 
-// printDNSReport prints only zones that exhibit a problem.
+// printDNSReport prints reachability checks, and only zones that exhibit a problem.
 func printDNSReport(r *diagv1.DNSReport) {
 	if r == nil {
 		return
 	}
-	if !r.VnetDnsReachable {
-		fmt.Printf("VNet DNS is unreachable: %s\n", r.VnetDnsUnreachableError)
-		return
+	for _, f := range []struct {
+		family string
+		r      *diagv1.VNetDNSReachability
+	}{
+		{"IPv6", r.Ipv6Reachability},
+		{"IPv4", r.Ipv4Reachability},
+	} {
+		if f.r == nil {
+			continue
+		}
+		if !f.r.Reachable {
+			fmt.Printf("VNet %s DNS unreachable on %s: %s\n", f.family, f.r.Address, f.r.Error)
+			continue
+		}
+		fmt.Printf("VNet %s DNS reachable on %s (responds to %s)\n", f.family, f.r.Address, respondedRecordTypes(f.r))
 	}
 	for _, zr := range r.ZoneResults {
-		switch zr.Status {
-		case diagv1.DNSZoneStatus_DNS_ZONE_STATUS_OK:
-			// Working as expected; not printed.
-		case diagv1.DNSZoneStatus_DNS_ZONE_STATUS_HIJACKED:
-			fmt.Printf("DNS zone %q is hijacked: observed=%s, expected=%s\n", zr.Zone, zr.ObservedIp, zr.ExpectedIp)
-		case diagv1.DNSZoneStatus_DNS_ZONE_STATUS_NOT_REGISTERED:
-			fmt.Printf("DNS zone %q is not registered with the OS resolver\n", zr.Zone)
-		case diagv1.DNSZoneStatus_DNS_ZONE_STATUS_TIMEOUT:
-			fmt.Printf("DNS zone %q timed out: %s\n", zr.Zone, zr.Error)
-		case diagv1.DNSZoneStatus_DNS_ZONE_STATUS_RESOLVER_ERROR:
-			fmt.Printf("DNS zone %q resolver error: %s\n", zr.Zone, zr.Error)
-		default:
-			fmt.Printf("DNS zone %q has unexpected status %s\n", zr.Zone, zr.Status)
-		}
+		printZoneRecordResult(zr.Zone, "A", zr.ARecord)
+		printZoneRecordResult(zr.Zone, "AAAA", zr.AaaaRecord)
+	}
+}
+
+// respondedRecordTypes returns a human-readable list of record types the server responded to.
+func respondedRecordTypes(r *diagv1.VNetDNSReachability) string {
+	switch {
+	case r.RespondedA && r.RespondedAaaa:
+		return "A, AAAA"
+	case r.RespondedA:
+		return "A only"
+	case r.RespondedAaaa:
+		return "AAAA only"
+	default:
+		return "nothing"
+	}
+}
+
+func printZoneRecordResult(zone, recordType string, r *diagv1.RecordResult) {
+	if r == nil {
+		return
+	}
+	switch r.Status {
+	case diagv1.DNSZoneStatus_DNS_ZONE_STATUS_OK:
+		// Working as expected; not printed.
+	case diagv1.DNSZoneStatus_DNS_ZONE_STATUS_HIJACKED:
+		fmt.Printf("DNS zone %q %s record is hijacked: observed=%s\n", zone, recordType, r.ObservedIp)
+	case diagv1.DNSZoneStatus_DNS_ZONE_STATUS_NOT_REGISTERED:
+		fmt.Printf("DNS zone %q %s record is not registered with the OS resolver\n", zone, recordType)
+	case diagv1.DNSZoneStatus_DNS_ZONE_STATUS_TIMEOUT:
+		fmt.Printf("DNS zone %q %s record timed out: %s\n", zone, recordType, r.Error)
+	case diagv1.DNSZoneStatus_DNS_ZONE_STATUS_RESOLVER_ERROR:
+		fmt.Printf("DNS zone %q %s record resolver error: %s\n", zone, recordType, r.Error)
+	default:
+		fmt.Printf("DNS zone %q %s record has unexpected status %s\n", zone, recordType, r.Status)
 	}
 }

--- a/tool/tsh/common/vnet_darwin.go
+++ b/tool/tsh/common/vnet_darwin.go
@@ -24,7 +24,6 @@ import (
 	"github.com/gravitational/trace"
 
 	"github.com/gravitational/teleport"
-	vnetv1 "github.com/gravitational/teleport/gen/proto/go/teleport/lib/vnet/v1"
 	"github.com/gravitational/teleport/lib/vnet"
 	"github.com/gravitational/teleport/lib/vnet/daemon"
 	"github.com/gravitational/teleport/lib/vnet/diag"
@@ -76,7 +75,8 @@ func newPlatformVnetUninstallServiceCommand(app *kingpin.Application) vnetComman
 	return vnetCommandNotSupported{}
 }
 
-func runVnetDiagnostics(ctx context.Context, nsi *vnetv1.NetworkStackInfo) error {
+func runVnetDiagnostics(ctx context.Context, vnetProcess *vnet.UserProcess) error {
+	nsi := vnetProcess.NetworkStackInfo()
 	routeConflictDiag, err := diag.NewRouteConflictDiag(&diag.RouteConflictConfig{
 		VnetIfaceName: nsi.GetInterfaceName(),
 		Routing:       &diag.DarwinRouting{},
@@ -92,6 +92,10 @@ func runVnetDiagnostics(ctx context.Context, nsi *vnetv1.NetworkStackInfo) error
 
 	for _, rc := range rcs.GetRouteConflictReport().GetRouteConflicts() {
 		fmt.Printf("Found a conflicting route: %+v\n", rc)
+	}
+
+	if err := runDNSDiag(ctx, vnetProcess); err != nil {
+		return trace.Wrap(err)
 	}
 
 	return nil

--- a/tool/tsh/common/vnet_linux.go
+++ b/tool/tsh/common/vnet_linux.go
@@ -24,7 +24,6 @@ import (
 	"github.com/gravitational/trace"
 
 	"github.com/gravitational/teleport"
-	vnetv1 "github.com/gravitational/teleport/gen/proto/go/teleport/lib/vnet/v1"
 	"github.com/gravitational/teleport/lib/vnet"
 	"github.com/gravitational/teleport/lib/vnet/diag"
 )
@@ -63,7 +62,8 @@ func newPlatformVnetUninstallServiceCommand(app *kingpin.Application) vnetComman
 	return vnetCommandNotSupported{}
 }
 
-func runVnetDiagnostics(ctx context.Context, nsi *vnetv1.NetworkStackInfo) error {
+func runVnetDiagnostics(ctx context.Context, vnetProcess *vnet.UserProcess) error {
+	nsi := vnetProcess.NetworkStackInfo()
 	routeConflictDiag, err := diag.NewRouteConflictDiag(&diag.RouteConflictConfig{
 		VnetIfaceName: nsi.InterfaceName,
 		Routing:       &diag.LinuxRouting{},
@@ -79,6 +79,10 @@ func runVnetDiagnostics(ctx context.Context, nsi *vnetv1.NetworkStackInfo) error
 
 	for _, rc := range rcs.GetRouteConflictReport().RouteConflicts {
 		fmt.Printf("Found a conflicting route: %+v\n", rc)
+	}
+
+	if err := runDNSDiag(ctx, vnetProcess); err != nil {
+		return trace.Wrap(err)
 	}
 
 	return nil

--- a/tool/tsh/common/vnet_other.go
+++ b/tool/tsh/common/vnet_other.go
@@ -24,7 +24,7 @@ import (
 	"github.com/alecthomas/kingpin/v2"
 	"github.com/gravitational/trace"
 
-	vnetv1 "github.com/gravitational/teleport/gen/proto/go/teleport/lib/vnet/v1"
+	"github.com/gravitational/teleport/lib/vnet"
 )
 
 // Satisfy unused linter.
@@ -47,6 +47,6 @@ func newPlatformVnetUninstallServiceCommand(app *kingpin.Application) vnetComman
 }
 
 //nolint:staticcheck // SA4023. runVnetDiagnostics on unsupported platforms always returns err.
-func runVnetDiagnostics(ctx context.Context, nsi *vnetv1.NetworkStackInfo) error {
+func runVnetDiagnostics(ctx context.Context, vnetProcess *vnet.UserProcess) error {
 	return trace.NotImplemented("diagnostics are not implemented yet on this platform")
 }

--- a/tool/tsh/common/vnet_windows.go
+++ b/tool/tsh/common/vnet_windows.go
@@ -23,7 +23,6 @@ import (
 	"github.com/gravitational/trace"
 	"golang.org/x/sys/windows/svc"
 
-	vnetv1 "github.com/gravitational/teleport/gen/proto/go/teleport/lib/vnet/v1"
 	"github.com/gravitational/teleport/lib/vnet"
 )
 
@@ -88,6 +87,6 @@ func newPlatformVnetAdminSetupCommand(*kingpin.Application) vnetCommandNotSuppor
 	return vnetCommandNotSupported{}
 }
 
-func runVnetDiagnostics(ctx context.Context, nsi *vnetv1.NetworkStackInfo) error {
+func runVnetDiagnostics(ctx context.Context, vnetProcess *vnet.UserProcess) error {
 	return trace.NotImplemented("diagnostics are not implemented yet on Windows")
 }

--- a/web/packages/teleterm/src/helpers.ts
+++ b/web/packages/teleterm/src/helpers.ts
@@ -29,6 +29,7 @@ import {
 } from 'gen-proto-ts/teleport/lib/teleterm/vnet/v1/vnet_service_pb';
 import {
   CheckReport,
+  DNSReport,
   RouteConflictReport,
   SSHConfigurationReport,
 } from 'gen-proto-ts/teleport/lib/vnet/diag/v1/diag_pb';
@@ -207,6 +208,15 @@ export function reportOneOfIsSSHConfigurationReport(
   sshConfigurationReport: SSHConfigurationReport;
 } {
   return report.oneofKind === 'sshConfigurationReport';
+}
+
+export function reportOneOfIsDNSReport(
+  report: CheckReport['report']
+): report is {
+  oneofKind: 'dnsReport';
+  dnsReport: DNSReport;
+} {
+  return report.oneofKind === 'dnsReport';
 }
 
 export function statusOneOfIsWindowsServiceStatus(

--- a/web/packages/teleterm/src/services/vnet/__snapshots__/diag.test.ts.snap
+++ b/web/packages/teleterm/src/services/vnet/__snapshots__/diag.test.ts.snap
@@ -35,6 +35,21 @@ default            link#25            UCSIg               utun4
 \`\`\`
 
 ---
+✅ VNet IPv4 DNS reachable on 100.64.0.2:53 (responds to A, AAAA)
+⚠️ VNet IPv6 DNS unreachable on [fdff:fd74:46c0::2]:53: dial udp [fdff:fd74:46c0::2]:53: connect: network unreachable
+
+⚠️ 4 of 5 DNS zones are not routed through VNet.
+
+| Zone | A | AAAA |
+| --- | --- | --- |
+| hijack.zone.test | hijacked (1.2.3.4) | hijacked (2001:db8::1234) |
+| mixed.zone.test | OK | hijacked (2001:db8::1234) |
+| not-registered.zone.test | not registered | not registered |
+| staging.test | timeout | timeout |
+
+
+
+---
 ⚠️ VNet SSH is not configured.
 
   The user's default SSH configuration file does not include VNet's
@@ -47,6 +62,24 @@ default            link#25            UCSIg               utun4
 | VNet SSH config file     | /Users/user/Library/Application Support/Teleport Connect/tsh/vnet_ssh_config  |
 
 ~/.ssh/config does not exist
+
+
+"
+`;
+
+exports[`reportToText renders DNS report when both nameservers are unreachable 1`] = `
+"VNet Diagnostic Report
+
+Created at: 2024-11-23 13:27:48 (Sat, 23 Nov 2024 13:27:48 GMT)
+Network interface: utun4
+IPv4 CIDR ranges: 100.64.0.0/10
+IPv6 prefix: fdff:fd74:46c0::
+DNS zones: teleport.example.com, company.test
+
+---
+⚠️ VNet IPv4 DNS unreachable on 100.64.0.2:53: dial udp 100.64.0.2:53: connect: connection refused
+⚠️ VNet IPv6 DNS unreachable on [fdff:fd74:46c0::2]:53: dial udp [fdff:fd74:46c0::2]:53: connect: connection refused
+VNet's DNS is not responding. This might be caused by network routes set up by another program that capture traffic meant for VNet.
 
 
 "

--- a/web/packages/teleterm/src/services/vnet/diag.test.ts
+++ b/web/packages/teleterm/src/services/vnet/diag.test.ts
@@ -23,8 +23,12 @@ import {
   makeCheckAttempt,
   makeCheckReport,
   makeCommandAttempt,
+  makeDNSReport,
+  makeDNSZoneResult,
+  makeRecordResult,
   makeReport,
   makeRouteConflict,
+  makeVNetDNSReachability,
 } from './testHelpers';
 
 describe('reportToText', () => {
@@ -51,6 +55,64 @@ describe('reportToText', () => {
         ],
       },
     };
+    const dnsCheckReport = makeCheckReport({
+      status: diag.CheckReportStatus.ISSUES_FOUND,
+      report: {
+        oneofKind: 'dnsReport',
+        dnsReport: makeDNSReport({
+          ipv6Reachability: makeVNetDNSReachability({
+            address: '[fdff:fd74:46c0::2]:53',
+            reachable: false,
+            respondedA: false,
+            respondedAaaa: false,
+            error:
+              'dial udp [fdff:fd74:46c0::2]:53: connect: network unreachable',
+          }),
+          zoneResults: [
+            makeDNSZoneResult({ zone: 'company.test' }),
+            makeDNSZoneResult({
+              zone: 'hijack.zone.test',
+              aRecord: makeRecordResult({
+                status: diag.DNSZoneStatus.DNS_ZONE_STATUS_HIJACKED,
+                observedIp: '1.2.3.4',
+              }),
+              aaaaRecord: makeRecordResult({
+                status: diag.DNSZoneStatus.DNS_ZONE_STATUS_HIJACKED,
+                observedIp: '2001:db8::1234',
+              }),
+            }),
+            makeDNSZoneResult({
+              zone: 'mixed.zone.test',
+              aRecord: makeRecordResult(),
+              aaaaRecord: makeRecordResult({
+                status: diag.DNSZoneStatus.DNS_ZONE_STATUS_HIJACKED,
+                observedIp: '2001:db8::1234',
+              }),
+            }),
+            makeDNSZoneResult({
+              zone: 'not-registered.zone.test',
+              aRecord: makeRecordResult({
+                status: diag.DNSZoneStatus.DNS_ZONE_STATUS_NOT_REGISTERED,
+              }),
+              aaaaRecord: makeRecordResult({
+                status: diag.DNSZoneStatus.DNS_ZONE_STATUS_NOT_REGISTERED,
+              }),
+            }),
+            makeDNSZoneResult({
+              zone: 'staging.test',
+              aRecord: makeRecordResult({
+                status: diag.DNSZoneStatus.DNS_ZONE_STATUS_TIMEOUT,
+                error: 'i/o timeout',
+              }),
+              aaaaRecord: makeRecordResult({
+                status: diag.DNSZoneStatus.DNS_ZONE_STATUS_TIMEOUT,
+                error: 'i/o timeout',
+              }),
+            }),
+          ],
+        }),
+      },
+    });
     const sshConfigReport = makeCheckReport({
       status: diag.CheckReportStatus.OK,
     });
@@ -72,6 +134,9 @@ describe('reportToText', () => {
           commands: [makeCommandAttempt()],
         }),
         makeCheckAttempt({
+          checkReport: dnsCheckReport,
+        }),
+        makeCheckAttempt({
           checkReport: sshConfigReport,
         }),
       ],
@@ -80,6 +145,40 @@ describe('reportToText', () => {
     const actualText = reportToText(report);
     expect(actualText).toMatchSnapshot();
     // Verify that the text ends with a newline.
+    expect(actualText.endsWith('\n')).toBe(true);
+  });
+
+  it('renders DNS report when both nameservers are unreachable', () => {
+    const dnsCheckReport = makeCheckReport({
+      status: diag.CheckReportStatus.ISSUES_FOUND,
+      report: {
+        oneofKind: 'dnsReport',
+        dnsReport: makeDNSReport({
+          ipv4Reachability: makeVNetDNSReachability({
+            address: '100.64.0.2:53',
+            reachable: false,
+            respondedA: false,
+            respondedAaaa: false,
+            error: 'dial udp 100.64.0.2:53: connect: connection refused',
+          }),
+          ipv6Reachability: makeVNetDNSReachability({
+            address: '[fdff:fd74:46c0::2]:53',
+            reachable: false,
+            respondedA: false,
+            respondedAaaa: false,
+            error:
+              'dial udp [fdff:fd74:46c0::2]:53: connect: connection refused',
+          }),
+          zoneResults: [],
+        }),
+      },
+    });
+    const report = makeReport({
+      checks: [makeCheckAttempt({ checkReport: dnsCheckReport })],
+    });
+
+    const actualText = reportToText(report);
+    expect(actualText).toMatchSnapshot();
     expect(actualText.endsWith('\n')).toBe(true);
   });
 });

--- a/web/packages/teleterm/src/services/vnet/diag.ts
+++ b/web/packages/teleterm/src/services/vnet/diag.ts
@@ -202,33 +202,56 @@ ${pathsTable}
 ${currentContents}`;
 }
 
-function dnsReportToText({ report, status }: diag.CheckReport): string {
+function dnsReportToText({ report }: diag.CheckReport): string {
   if (!reportOneOfIsDNSReport(report)) {
     return '';
   }
-  const { vnetDnsReachable, vnetDnsUnreachableError, zoneResults } =
-    report.dnsReport;
+  const { ipv4Reachability, ipv6Reachability, zoneResults } = report.dnsReport;
 
-  if (!vnetDnsReachable) {
-    return `⚠️ VNet DNS server is unreachable.
+  const reachabilityLines = [
+    reachabilityToText('IPv4', ipv4Reachability),
+    reachabilityToText('IPv6', ipv6Reachability),
+  ].filter(Boolean);
 
-${vnetDnsUnreachableError}`;
+  const allUnreachable =
+    (ipv4Reachability || ipv6Reachability) &&
+    (!ipv4Reachability || !ipv4Reachability.reachable) &&
+    (!ipv6Reachability || !ipv6Reachability.reachable);
+  if (allUnreachable) {
+    reachabilityLines.push(
+      "VNet's DNS is not responding. This might be caused by network routes set up by another program that capture traffic meant for VNet."
+    );
   }
 
-  if (status === diag.CheckReportStatus.OK) {
-    return '✅ DNS queries for all VNet zones are routed through VNet.';
-  }
-
-  // Show only problem rows
+  // Show only zones that have at least one problem. A null aRecord
+  // or aaaaRecord means that record type wasn't queried because no
+  // expected IP was captured from the reachability step, so not a problem.
+  const okStatus = diag.DNSZoneStatus.DNS_ZONE_STATUS_OK;
   const problemRows = zoneResults.filter(
-    zr => zr.status !== diag.DNSZoneStatus.DNS_ZONE_STATUS_OK
+    zr =>
+      (zr.aRecord && zr.aRecord.status !== okStatus) ||
+      (zr.aaaaRecord && zr.aaaaRecord.status !== okStatus)
   );
 
+  if (problemRows.length === 0) {
+    return reachabilityLines.join('\n');
+  }
+
+  // Drop the record-type column if no row in the table has a result for it.
+  const showA = problemRows.some(zr => zr.aRecord);
+  const showAaaa = problemRows.some(zr => zr.aaaaRecord);
+  const headerCells = ['Zone'];
+  if (showA) headerCells.push('A');
+  if (showAaaa) headerCells.push('AAAA');
+  const headerRow = `| ${headerCells.join(' | ')} |`;
+  const separatorRow = `| ${headerCells.map(() => '---').join(' | ')} |`;
   const tableRows = problemRows
-    .map(
-      zoneResult =>
-        `| ${zoneResult.zone} | ${dnsZoneStatusToText(zoneResult.status)} | ${zoneResult.observedIp || '—'} | ${zoneResult.expectedIp || '—'} |`
-    )
+    .map(zr => {
+      const cells = [zr.zone];
+      if (showA) cells.push(recordResultToText(zr.aRecord));
+      if (showAaaa) cells.push(recordResultToText(zr.aaaaRecord));
+      return `| ${cells.join(' | ')} |`;
+    })
     .join('\n');
 
   const headerCount =
@@ -236,11 +259,45 @@ ${vnetDnsUnreachableError}`;
       ? `1 of ${zoneResults.length} DNS zones is not routed through VNet.`
       : `${problemRows.length} of ${zoneResults.length} DNS zones are not routed through VNet.`;
 
-  return `⚠️ ${headerCount}
+  return `${reachabilityLines.join('\n')}
 
-| Zone | Status | Observed | Expected |
-| ---- | ------ | -------- | -------- |
+⚠️ ${headerCount}
+
+${headerRow}
+${separatorRow}
 ${tableRows}`;
+}
+
+function reachabilityToText(
+  family: 'IPv4' | 'IPv6',
+  reach: diag.VNetDNSReachability | undefined
+): string {
+  if (!reach) {
+    return '';
+  }
+  if (!reach.reachable) {
+    return `⚠️ VNet ${family} DNS unreachable on ${reach.address}: ${reach.error}`;
+  }
+  const responded =
+    reach.respondedA && reach.respondedAaaa
+      ? 'A, AAAA'
+      : reach.respondedA
+        ? 'A only'
+        : reach.respondedAaaa
+          ? 'AAAA only'
+          : 'nothing';
+  return `✅ VNet ${family} DNS reachable on ${reach.address} (responds to ${responded})`;
+}
+
+function recordResultToText(rr: diag.RecordResult | undefined): string {
+  if (!rr) {
+    return '—';
+  }
+  const label = dnsZoneStatusToText(rr.status);
+  if (rr.observedIp) {
+    return `${label} (${rr.observedIp})`;
+  }
+  return label;
 }
 
 function dnsZoneStatusToText(status: diag.DNSZoneStatus): string {

--- a/web/packages/teleterm/src/services/vnet/diag.ts
+++ b/web/packages/teleterm/src/services/vnet/diag.ts
@@ -21,6 +21,7 @@ import { Timestamp } from 'gen-proto-ts/google/protobuf/timestamp_pb';
 import * as diag from 'gen-proto-ts/teleport/lib/vnet/diag/v1/diag_pb';
 
 import {
+  reportOneOfIsDNSReport,
   reportOneOfIsRouteConflictReport,
   reportOneOfIsSSHConfigurationReport,
 } from 'teleterm/helpers';
@@ -129,6 +130,10 @@ const reportOneofToDisplayDetails: Record<
     errorTitle: 'inspect SSH configuration',
     reportToText: sshConfigurationReportToText,
   },
+  dnsReport: {
+    errorTitle: 'inspect DNS configuration',
+    reportToText: dnsReportToText,
+  },
 };
 
 function routeConflictReportToText({
@@ -195,4 +200,62 @@ ${userOpensshConfigContents}
 ${pathsTable}
 
 ${currentContents}`;
+}
+
+function dnsReportToText({ report, status }: diag.CheckReport): string {
+  if (!reportOneOfIsDNSReport(report)) {
+    return '';
+  }
+  const { vnetDnsReachable, vnetDnsUnreachableError, zoneResults } =
+    report.dnsReport;
+
+  if (!vnetDnsReachable) {
+    return `⚠️ VNet DNS server is unreachable.
+
+${vnetDnsUnreachableError}`;
+  }
+
+  if (status === diag.CheckReportStatus.OK) {
+    return '✅ DNS queries for all VNet zones are routed through VNet.';
+  }
+
+  // Show only problem rows
+  const problemRows = zoneResults.filter(
+    zr => zr.status !== diag.DNSZoneStatus.DNS_ZONE_STATUS_OK
+  );
+
+  const tableRows = problemRows
+    .map(
+      zoneResult =>
+        `| ${zoneResult.zone} | ${dnsZoneStatusToText(zoneResult.status)} | ${zoneResult.observedIp || '—'} | ${zoneResult.expectedIp || '—'} |`
+    )
+    .join('\n');
+
+  const headerCount =
+    problemRows.length === 1
+      ? `1 of ${zoneResults.length} DNS zones is not routed through VNet.`
+      : `${problemRows.length} of ${zoneResults.length} DNS zones are not routed through VNet.`;
+
+  return `⚠️ ${headerCount}
+
+| Zone | Status | Observed | Expected |
+| ---- | ------ | -------- | -------- |
+${tableRows}`;
+}
+
+function dnsZoneStatusToText(status: diag.DNSZoneStatus): string {
+  switch (status) {
+    case diag.DNSZoneStatus.DNS_ZONE_STATUS_OK:
+      return 'OK';
+    case diag.DNSZoneStatus.DNS_ZONE_STATUS_HIJACKED:
+      return 'hijacked';
+    case diag.DNSZoneStatus.DNS_ZONE_STATUS_NOT_REGISTERED:
+      return 'not registered';
+    case diag.DNSZoneStatus.DNS_ZONE_STATUS_TIMEOUT:
+      return 'timeout';
+    case diag.DNSZoneStatus.DNS_ZONE_STATUS_RESOLVER_ERROR:
+      return 'resolver error';
+    default:
+      return `unknown (${status})`;
+  }
 }

--- a/web/packages/teleterm/src/services/vnet/testHelpers.ts
+++ b/web/packages/teleterm/src/services/vnet/testHelpers.ts
@@ -27,8 +27,10 @@ import {
   DNSReport,
   DNSZoneResult,
   DNSZoneStatus,
+  RecordResult,
   Report,
   RouteConflict,
+  VNetDNSReachability,
 } from 'gen-proto-ts/teleport/lib/vnet/diag/v1/diag_pb';
 
 export const makeReport = (props: Partial<Report> = {}): Report => ({
@@ -95,9 +97,31 @@ export const makeRouteConflict = (
 });
 
 export const makeDNSReport = (props: Partial<DNSReport> = {}): DNSReport => ({
-  vnetDnsReachable: true,
-  vnetDnsUnreachableError: '',
+  ipv4Reachability: makeVNetDNSReachability({ address: '100.64.0.2:53' }),
+  ipv6Reachability: makeVNetDNSReachability({
+    address: '[fdff:fd74:46c0::2]:53',
+  }),
   zoneResults: [],
+  ...props,
+});
+
+export const makeVNetDNSReachability = (
+  props: Partial<VNetDNSReachability> = {}
+): VNetDNSReachability => ({
+  address: '[fdff:fd74:46c0::2]:53',
+  reachable: true,
+  respondedA: true,
+  respondedAaaa: true,
+  error: '',
+  ...props,
+});
+
+export const makeRecordResult = (
+  props: Partial<RecordResult> = {}
+): RecordResult => ({
+  status: DNSZoneStatus.DNS_ZONE_STATUS_OK,
+  observedIp: '',
+  error: '',
   ...props,
 });
 
@@ -105,10 +129,8 @@ export const makeDNSZoneResult = (
   props: Partial<DNSZoneResult> = {}
 ): DNSZoneResult => ({
   zone: 'company.test',
-  status: DNSZoneStatus.DNS_ZONE_STATUS_OK,
-  observedIp: 'fdff:fd74:46c0::2',
-  expectedIp: 'fdff:fd74:46c0::2',
-  error: '',
+  aRecord: makeRecordResult(),
+  aaaaRecord: makeRecordResult(),
   ...props,
 });
 

--- a/web/packages/teleterm/src/services/vnet/testHelpers.ts
+++ b/web/packages/teleterm/src/services/vnet/testHelpers.ts
@@ -24,6 +24,9 @@ import {
   CheckReportStatus,
   CommandAttempt,
   CommandAttemptStatus,
+  DNSReport,
+  DNSZoneResult,
+  DNSZoneStatus,
   Report,
   RouteConflict,
 } from 'gen-proto-ts/teleport/lib/vnet/diag/v1/diag_pb';
@@ -88,6 +91,24 @@ export const makeRouteConflict = (
   vnetDest: '100.64.0.1',
   interfaceName: 'utun5',
   interfaceApp: '',
+  ...props,
+});
+
+export const makeDNSReport = (props: Partial<DNSReport> = {}): DNSReport => ({
+  vnetDnsReachable: true,
+  vnetDnsUnreachableError: '',
+  zoneResults: [],
+  ...props,
+});
+
+export const makeDNSZoneResult = (
+  props: Partial<DNSZoneResult> = {}
+): DNSZoneResult => ({
+  zone: 'company.test',
+  status: DNSZoneStatus.DNS_ZONE_STATUS_OK,
+  observedIp: 'fdff:fd74:46c0::2',
+  expectedIp: 'fdff:fd74:46c0::2',
+  error: '',
   ...props,
 });
 

--- a/web/packages/teleterm/src/ui/Vnet/DocumentVnetDiagReport.story.tsx
+++ b/web/packages/teleterm/src/ui/Vnet/DocumentVnetDiagReport.story.tsx
@@ -307,14 +307,22 @@ export function DocumentVnetDiagReport(props: StoryProps) {
         reachable: false,
         respondedA: false,
         respondedAaaa: false,
-        error: 'dial udp 100.64.0.2:53: connect: connection refused',
+        error:
+          'querying VNet DNS server at 100.64.0.2:53 for A record\n' +
+          '\tlookup vnet-diag-f4b49a465de45626.test: connect: connection refused\n' +
+          'querying VNet DNS server at 100.64.0.2:53 for AAAA record\n' +
+          '\tlookup vnet-diag-aa7634492d2eeb20.test: connect: connection refused',
       });
       dnsReport.ipv6Reachability = makeVNetDNSReachability({
         address: '[fdff:fd74:46c0::2]:53',
         reachable: false,
         respondedA: false,
         respondedAaaa: false,
-        error: 'dial udp [fdff:fd74:46c0::2]:53: connect: connection refused',
+        error:
+          'querying VNet DNS server at [fdff:fd74:46c0::2]:53 for A record\n' +
+          '\tlookup vnet-diag-f4b49a465de45626.test: connect: connection refused\n' +
+          'querying VNet DNS server at [fdff:fd74:46c0::2]:53 for AAAA record\n' +
+          '\tlookup vnet-diag-aa7634492d2eeb20.test: connect: connection refused',
       });
       dnsCheckAttempt.checkReport.status = CheckReportStatus.ISSUES_FOUND;
       break;
@@ -325,7 +333,11 @@ export function DocumentVnetDiagReport(props: StoryProps) {
         reachable: false,
         respondedA: false,
         respondedAaaa: false,
-        error: 'dial udp [fdff:fd74:46c0::2]:53: connect: network unreachable',
+        error:
+          'querying VNet DNS server at [fdff:fd74:46c0::2]:53 for A record\n' +
+          '\tlookup vnet-diag-e08c7ee8b534d6db.test: connect: network unreachable\n' +
+          'querying VNet DNS server at [fdff:fd74:46c0::2]:53 for AAAA record\n' +
+          '\tlookup vnet-diag-907e5ae789aea710.test: connect: network unreachable',
       });
       dnsReport.zoneResults = [
         ...props.dnsZones.map(zone => makeDNSZoneResult({ zone })),

--- a/web/packages/teleterm/src/ui/Vnet/DocumentVnetDiagReport.story.tsx
+++ b/web/packages/teleterm/src/ui/Vnet/DocumentVnetDiagReport.story.tsx
@@ -24,6 +24,8 @@ import {
   CheckAttemptStatus,
   CheckReportStatus,
   CommandAttemptStatus,
+  DNSReport,
+  DNSZoneStatus,
   RouteConflict,
   RouteConflictReport,
   SSHConfigurationReport,
@@ -36,6 +38,8 @@ import { reportToText } from 'teleterm/services/vnet/diag';
 import {
   makeCheckAttempt,
   makeCheckReport,
+  makeDNSReport,
+  makeDNSZoneResult,
   makeReport,
   makeRouteConflict,
 } from 'teleterm/services/vnet/testHelpers';
@@ -67,6 +71,7 @@ type StoryProps = {
   sshConfigured: boolean;
   userOpenSSHConfigExists: boolean;
   userOpenSSHConfigContents: string;
+  dnsAttempt: 'ok' | 'unreachable' | 'issues-found' | 'error';
   displayUnsupportedCheckAttempt: boolean;
   vnetRunning: boolean;
   reRunDiagnostics: 'success' | 'error' | 'processing';
@@ -111,6 +116,10 @@ const meta: Meta<StoryProps> = {
     sshConfigured: {
       control: { type: 'boolean' },
     },
+    dnsAttempt: {
+      control: { type: 'inline-radio' },
+      options: ['ok', 'unreachable', 'issues-found', 'error'],
+    },
     displayUnsupportedCheckAttempt: {
       description:
         "Simulate the component receiving a report with a check attempt that's not supported in the current version",
@@ -145,6 +154,7 @@ const meta: Meta<StoryProps> = {
     sshConfigured: false,
     userOpenSSHConfigExists: true,
     userOpenSSHConfigContents: defaultUserSSHConfigContents,
+    dnsAttempt: 'issues-found',
     displayUnsupportedCheckAttempt: false,
     vnetRunning: true,
     reRunDiagnostics: 'success',
@@ -256,6 +266,57 @@ export function DocumentVnetDiagReport(props: StoryProps) {
     }),
   });
   report.checks.push(sshConfigCheckAttempt);
+
+  const dnsReport: DNSReport = makeDNSReport();
+  const dnsCheckAttempt = makeCheckAttempt({
+    checkReport: makeCheckReport({
+      status: CheckReportStatus.OK,
+      report: { oneofKind: 'dnsReport', dnsReport },
+    }),
+  });
+  switch (props.dnsAttempt) {
+    case 'error':
+      dnsCheckAttempt.status = CheckAttemptStatus.ERROR;
+      dnsCheckAttempt.error = 'something went wrong';
+      break;
+    case 'ok':
+      // All zones routed correctly.
+      dnsReport.zoneResults = props.dnsZones.map(zone =>
+        makeDNSZoneResult({ zone })
+      );
+      break;
+    case 'unreachable':
+      // Reachability check failed, per-zone results are empty.
+      dnsReport.vnetDnsReachable = false;
+      dnsReport.vnetDnsUnreachableError =
+        'dial udp [fdff:fd74:46c0::2]:53: connect: connection refused';
+      dnsCheckAttempt.checkReport.status = CheckReportStatus.ISSUES_FOUND;
+      break;
+    case 'issues-found':
+      // Per-zone mixed results.
+      dnsReport.zoneResults = [
+        makeDNSZoneResult({ zone: 'company.test' }),
+        makeDNSZoneResult({
+          zone: 'leaf.mirrors.link',
+          status: DNSZoneStatus.DNS_ZONE_STATUS_HIJACKED,
+          observedIp: '100.64.0.123',
+        }),
+        makeDNSZoneResult({
+          zone: 'cluster.mirrors.link',
+          status: DNSZoneStatus.DNS_ZONE_STATUS_NOT_REGISTERED,
+          observedIp: '',
+        }),
+        makeDNSZoneResult({
+          zone: 'staging.test',
+          status: DNSZoneStatus.DNS_ZONE_STATUS_TIMEOUT,
+          observedIp: '',
+          error: 'i/o timeout',
+        }),
+      ];
+      dnsCheckAttempt.checkReport.status = CheckReportStatus.ISSUES_FOUND;
+      break;
+  }
+  report.checks.push(dnsCheckAttempt);
 
   if (props.displayUnsupportedCheckAttempt) {
     report.checks.push({

--- a/web/packages/teleterm/src/ui/Vnet/DocumentVnetDiagReport.story.tsx
+++ b/web/packages/teleterm/src/ui/Vnet/DocumentVnetDiagReport.story.tsx
@@ -297,12 +297,12 @@ export function DocumentVnetDiagReport(props: StoryProps) {
       dnsReport.zoneResults = [
         makeDNSZoneResult({ zone: 'company.test' }),
         makeDNSZoneResult({
-          zone: 'leaf.mirrors.link',
+          zone: 'hijacked.zone.test',
           status: DNSZoneStatus.DNS_ZONE_STATUS_HIJACKED,
           observedIp: '100.64.0.123',
         }),
         makeDNSZoneResult({
-          zone: 'cluster.mirrors.link',
+          zone: 'not-registered.zone.test',
           status: DNSZoneStatus.DNS_ZONE_STATUS_NOT_REGISTERED,
           observedIp: '',
         }),
@@ -316,6 +316,12 @@ export function DocumentVnetDiagReport(props: StoryProps) {
       dnsCheckAttempt.checkReport.status = CheckReportStatus.ISSUES_FOUND;
       break;
   }
+  dnsCheckAttempt.commands.push({
+    status: CommandAttemptStatus.OK,
+    error: '',
+    command: 'scutil --dns',
+    output: scutilOutput,
+  });
   report.checks.push(dnsCheckAttempt);
 
   if (props.displayUnsupportedCheckAttempt) {
@@ -368,6 +374,48 @@ export function DocumentVnetDiagReport(props: StoryProps) {
 
   return <Component visible doc={doc} />;
 }
+
+const scutilOutput = `DNS configuration
+
+resolver #1
+  nameserver[0] : 1.1.1.1
+  nameserver[1] : 192.168.1.1
+  if_index : 14 (en0)
+  flags    : Request A records
+  reach    : 0x00000002 (Reachable)
+  order    : 200000
+
+resolver #2
+  domain   : local
+  options  : mdns
+  timeout  : 5
+  flags    : Request A records
+  reach    : 0x00000000 (Not Reachable)
+  order    : 300000
+
+resolver #3
+  domain   : company.test
+  nameserver[0] : fdff:fd74:46c0::2
+  nameserver[1] : 100.64.0.2
+  flags    : Request A records
+  reach    : 0x00000002 (Reachable)
+
+resolver #4
+  domain   : other.test
+  nameserver[0] : fdff:fd74:46c0::2
+  nameserver[1] : 100.64.0.2
+  flags    : Request A records
+  reach    : 0x00000002 (Reachable)
+
+DNS configuration (for scoped queries)
+
+resolver #1
+  nameserver[0] : 1.1.1.1
+  nameserver[1] : 192.168.1.1
+  if_index : 14 (en0)
+  flags    : Scoped, Request A records
+  reach    : 0x00000002 (Reachable)
+`;
 
 const netstatOutput = `Routing tables
 

--- a/web/packages/teleterm/src/ui/Vnet/DocumentVnetDiagReport.story.tsx
+++ b/web/packages/teleterm/src/ui/Vnet/DocumentVnetDiagReport.story.tsx
@@ -40,8 +40,10 @@ import {
   makeCheckReport,
   makeDNSReport,
   makeDNSZoneResult,
+  makeRecordResult,
   makeReport,
   makeRouteConflict,
+  makeVNetDNSReachability,
 } from 'teleterm/services/vnet/testHelpers';
 import { useWorkspaceContext } from 'teleterm/ui/Documents';
 import { MockAppContextProvider } from 'teleterm/ui/fixtures/MockAppContextProvider';
@@ -67,11 +69,18 @@ type StoryProps = {
   routeConflictAttempt: 'ok' | 'issues-found' | 'error';
   routeConflicts: RouteConflict[];
   routeConflictCommandAttempt: 'ok' | 'error';
+  dnsAttempt:
+    | 'ok'
+    | 'unreachable'
+    | 'ipv6-unreachable'
+    | 'no-ipv6'
+    | 'mixed-zone-issues'
+    | 'both-aaaa-only'
+    | 'error';
   sshConfigAttempt: 'ok' | 'error';
   sshConfigured: boolean;
   userOpenSSHConfigExists: boolean;
   userOpenSSHConfigContents: string;
-  dnsAttempt: 'ok' | 'unreachable' | 'issues-found' | 'error';
   displayUnsupportedCheckAttempt: boolean;
   vnetRunning: boolean;
   reRunDiagnostics: 'success' | 'error' | 'processing';
@@ -107,6 +116,18 @@ const meta: Meta<StoryProps> = {
       control: { type: 'inline-radio' },
       options: ['ok', 'error'],
     },
+    dnsAttempt: {
+      control: { type: 'inline-radio' },
+      options: [
+        'ok',
+        'unreachable',
+        'ipv6-unreachable',
+        'no-ipv6',
+        'mixed-zone-issues',
+        'both-aaaa-only',
+        'error',
+      ],
+    },
     sshConfigAttempt: {
       control: { type: 'inline-radio' },
       options: ['ok', 'error'],
@@ -115,10 +136,6 @@ const meta: Meta<StoryProps> = {
     userOpenSSHConfigContents: {},
     sshConfigured: {
       control: { type: 'boolean' },
-    },
-    dnsAttempt: {
-      control: { type: 'inline-radio' },
-      options: ['ok', 'unreachable', 'issues-found', 'error'],
     },
     displayUnsupportedCheckAttempt: {
       description:
@@ -150,11 +167,11 @@ const meta: Meta<StoryProps> = {
       }),
     ],
     routeConflictCommandAttempt: 'ok',
+    dnsAttempt: 'mixed-zone-issues',
     sshConfigAttempt: 'ok',
     sshConfigured: false,
     userOpenSSHConfigExists: true,
     userOpenSSHConfigContents: defaultUserSSHConfigContents,
-    dnsAttempt: 'issues-found',
     displayUnsupportedCheckAttempt: false,
     vnetRunning: true,
     reRunDiagnostics: 'success',
@@ -265,8 +282,6 @@ export function DocumentVnetDiagReport(props: StoryProps) {
       },
     }),
   });
-  report.checks.push(sshConfigCheckAttempt);
-
   const dnsReport: DNSReport = makeDNSReport();
   const dnsCheckAttempt = makeCheckAttempt({
     checkReport: makeCheckReport({
@@ -280,37 +295,159 @@ export function DocumentVnetDiagReport(props: StoryProps) {
       dnsCheckAttempt.error = 'something went wrong';
       break;
     case 'ok':
-      // All zones routed correctly.
+      // Both nameservers reachable, all zones routed correctly.
       dnsReport.zoneResults = props.dnsZones.map(zone =>
         makeDNSZoneResult({ zone })
       );
       break;
     case 'unreachable':
-      // Reachability check failed, per-zone results are empty.
-      dnsReport.vnetDnsReachable = false;
-      dnsReport.vnetDnsUnreachableError =
-        'dial udp [fdff:fd74:46c0::2]:53: connect: connection refused';
+      // Both nameservers unreachable.
+      dnsReport.ipv4Reachability = makeVNetDNSReachability({
+        address: '100.64.0.2:53',
+        reachable: false,
+        respondedA: false,
+        respondedAaaa: false,
+        error: 'dial udp 100.64.0.2:53: connect: connection refused',
+      });
+      dnsReport.ipv6Reachability = makeVNetDNSReachability({
+        address: '[fdff:fd74:46c0::2]:53',
+        reachable: false,
+        respondedA: false,
+        respondedAaaa: false,
+        error: 'dial udp [fdff:fd74:46c0::2]:53: connect: connection refused',
+      });
       dnsCheckAttempt.checkReport.status = CheckReportStatus.ISSUES_FOUND;
       break;
-    case 'issues-found':
+    case 'ipv6-unreachable':
+      // IPv6 nameserver unreachable, IPv4 fine. Per-zone still runs.
+      dnsReport.ipv6Reachability = makeVNetDNSReachability({
+        address: '[fdff:fd74:46c0::2]:53',
+        reachable: false,
+        respondedA: false,
+        respondedAaaa: false,
+        error: 'dial udp [fdff:fd74:46c0::2]:53: connect: network unreachable',
+      });
+      dnsReport.zoneResults = [
+        ...props.dnsZones.map(zone => makeDNSZoneResult({ zone })),
+        makeDNSZoneResult({
+          zone: 'hijack.zone.test',
+          aRecord: makeRecordResult({
+            status: DNSZoneStatus.DNS_ZONE_STATUS_HIJACKED,
+            observedIp: '1.2.3.4',
+          }),
+          aaaaRecord: makeRecordResult({
+            status: DNSZoneStatus.DNS_ZONE_STATUS_HIJACKED,
+            observedIp: '2001:db8::1234',
+          }),
+        }),
+      ];
+      dnsCheckAttempt.checkReport.status = CheckReportStatus.ISSUES_FOUND;
+      break;
+    case 'no-ipv6':
+      // VNet does not serve DNS on IPv6.
+      dnsReport.ipv6Reachability = undefined;
+      dnsReport.ipv4Reachability = makeVNetDNSReachability({
+        address: '100.64.0.2:53',
+        respondedA: true,
+        respondedAaaa: false,
+      });
+      dnsReport.zoneResults = [
+        ...props.dnsZones.map(zone =>
+          makeDNSZoneResult({ zone, aaaaRecord: undefined })
+        ),
+        makeDNSZoneResult({
+          zone: 'hijack.zone.test',
+          aRecord: makeRecordResult({
+            status: DNSZoneStatus.DNS_ZONE_STATUS_HIJACKED,
+            observedIp: '1.2.3.4',
+          }),
+          aaaaRecord: undefined,
+        }),
+      ];
+      dnsCheckAttempt.checkReport.status = CheckReportStatus.ISSUES_FOUND;
+      break;
+    case 'mixed-zone-issues':
       // Per-zone mixed results.
       dnsReport.zoneResults = [
         makeDNSZoneResult({ zone: 'company.test' }),
         makeDNSZoneResult({
-          zone: 'hijacked.zone.test',
-          status: DNSZoneStatus.DNS_ZONE_STATUS_HIJACKED,
-          observedIp: '100.64.0.123',
+          zone: 'hijack.zone.test',
+          aRecord: makeRecordResult({
+            status: DNSZoneStatus.DNS_ZONE_STATUS_HIJACKED,
+            observedIp: '1.2.3.4',
+          }),
+          aaaaRecord: makeRecordResult({
+            status: DNSZoneStatus.DNS_ZONE_STATUS_HIJACKED,
+            observedIp: '2001:db8::1234',
+          }),
+        }),
+        makeDNSZoneResult({
+          zone: 'mixed.zone.test',
+          aRecord: makeRecordResult(),
+          aaaaRecord: makeRecordResult({
+            status: DNSZoneStatus.DNS_ZONE_STATUS_HIJACKED,
+            observedIp: '2001:db8::1234',
+          }),
         }),
         makeDNSZoneResult({
           zone: 'not-registered.zone.test',
-          status: DNSZoneStatus.DNS_ZONE_STATUS_NOT_REGISTERED,
-          observedIp: '',
+          aRecord: makeRecordResult({
+            status: DNSZoneStatus.DNS_ZONE_STATUS_NOT_REGISTERED,
+          }),
+          aaaaRecord: makeRecordResult({
+            status: DNSZoneStatus.DNS_ZONE_STATUS_NOT_REGISTERED,
+          }),
         }),
         makeDNSZoneResult({
           zone: 'staging.test',
-          status: DNSZoneStatus.DNS_ZONE_STATUS_TIMEOUT,
-          observedIp: '',
-          error: 'i/o timeout',
+          aRecord: makeRecordResult({
+            status: DNSZoneStatus.DNS_ZONE_STATUS_TIMEOUT,
+            error: 'i/o timeout',
+          }),
+          aaaaRecord: makeRecordResult({
+            status: DNSZoneStatus.DNS_ZONE_STATUS_TIMEOUT,
+            error: 'i/o timeout',
+          }),
+        }),
+      ];
+      dnsCheckAttempt.checkReport.status = CheckReportStatus.ISSUES_FOUND;
+      break;
+    case 'both-aaaa-only':
+      // Both nameservers reachable but respond to AAAA only.
+      dnsReport.ipv4Reachability = makeVNetDNSReachability({
+        address: '100.64.0.2:53',
+        respondedA: false,
+        respondedAaaa: true,
+      });
+      dnsReport.ipv6Reachability = makeVNetDNSReachability({
+        address: '[fdff:fd74:46c0::2]:53',
+        respondedA: false,
+        respondedAaaa: true,
+      });
+      dnsReport.zoneResults = [
+        makeDNSZoneResult({ zone: 'company.test', aRecord: undefined }),
+        makeDNSZoneResult({
+          zone: 'hijack.zone.test',
+          aRecord: undefined,
+          aaaaRecord: makeRecordResult({
+            status: DNSZoneStatus.DNS_ZONE_STATUS_HIJACKED,
+            observedIp: '2001:db8::1234',
+          }),
+        }),
+        makeDNSZoneResult({
+          zone: 'not-registered.zone.test',
+          aRecord: undefined,
+          aaaaRecord: makeRecordResult({
+            status: DNSZoneStatus.DNS_ZONE_STATUS_NOT_REGISTERED,
+          }),
+        }),
+        makeDNSZoneResult({
+          zone: 'staging.test',
+          aRecord: undefined,
+          aaaaRecord: makeRecordResult({
+            status: DNSZoneStatus.DNS_ZONE_STATUS_TIMEOUT,
+            error: 'i/o timeout',
+          }),
         }),
       ];
       dnsCheckAttempt.checkReport.status = CheckReportStatus.ISSUES_FOUND;
@@ -323,6 +460,7 @@ export function DocumentVnetDiagReport(props: StoryProps) {
     output: scutilOutput,
   });
   report.checks.push(dnsCheckAttempt);
+  report.checks.push(sshConfigCheckAttempt);
 
   if (props.displayUnsupportedCheckAttempt) {
     report.checks.push({

--- a/web/packages/teleterm/src/ui/Vnet/DocumentVnetDiagReport.tsx
+++ b/web/packages/teleterm/src/ui/Vnet/DocumentVnetDiagReport.tsx
@@ -492,7 +492,10 @@ function CheckReportDNS({
         <P1>
           <Warning /> VNet's DNS server is unreachable.
         </P1>
-        <P2 m={0}>VNet's DNS is not responding. Try restarting VNet.</P2>
+        <P2 m={0}>
+          This might be caused by network routes set up by another program that
+          capture traffic meant for VNet.
+        </P2>
         {vnetDnsUnreachableError ? <Pre>{vnetDnsUnreachableError}</Pre> : null}
       </Stack>
     );
@@ -521,7 +524,7 @@ function CheckReportDNS({
       </P1>
       <P2 m={0}>
         VNet's DNS server is reachable, but the OS resolver is not sending
-        queries for the zones below to VNet.
+        queries for the zones below to&nbsp VNet.
       </P2>
       <Table
         emptyText=""

--- a/web/packages/teleterm/src/ui/Vnet/DocumentVnetDiagReport.tsx
+++ b/web/packages/teleterm/src/ui/Vnet/DocumentVnetDiagReport.tsx
@@ -502,10 +502,8 @@ function CheckReportDNS({
 
   return (
     <Stack>
-      <Stack gap={0}>
-        <ReachabilityRow family="IPv4" reach={ipv4Reachability} />
-        <ReachabilityRow family="IPv6" reach={ipv6Reachability} />
-      </Stack>
+      <ReachabilityRow family="IPv4" reach={ipv4Reachability} />
+      <ReachabilityRow family="IPv6" reach={ipv6Reachability} />
 
       {allUnreachable && (
         <P2 m={0}>
@@ -578,7 +576,7 @@ function ReachabilityRow({
   }
   if (!reach.reachable) {
     return (
-      <P1>
+      <P1 m={0}>
         <Warning /> VNet {family} DNS unreachable on{' '}
         <code>{reach.address}</code>: {reach.error}
       </P1>
@@ -593,7 +591,7 @@ function ReachabilityRow({
           ? 'AAAA only'
           : 'nothing';
   return (
-    <P1>
+    <P1 m={0}>
       <Success /> VNet {family} DNS reachable on <code>{reach.address}</code>{' '}
       (responds to {responded})
     </P1>

--- a/web/packages/teleterm/src/ui/Vnet/DocumentVnetDiagReport.tsx
+++ b/web/packages/teleterm/src/ui/Vnet/DocumentVnetDiagReport.tsx
@@ -576,10 +576,13 @@ function ReachabilityRow({
   }
   if (!reach.reachable) {
     return (
-      <P1 m={0}>
-        <Warning /> VNet {family} DNS unreachable on{' '}
-        <code>{reach.address}</code>: {reach.error}
-      </P1>
+      <Stack gap={1}>
+        <P1 m={0}>
+          <Warning /> VNet {family} DNS unreachable on{' '}
+          <code>{reach.address}</code>. The error:
+        </P1>
+        <ErrorPre>{reach.error}</ErrorPre>
+      </Stack>
     );
   }
   const responded =
@@ -634,6 +637,17 @@ const Summary = styled.summary`
 
 const Pre = styled.pre`
   white-space: pre-wrap;
+`;
+
+const ErrorPre = styled(Pre)`
+  margin: 0;
+  align-self: stretch;
+  line-height: 1.6;
+  tab-size: 4;
+  padding: ${props => props.theme.space[2]}px;
+  background-color: ${props => props.theme.colors.levels.sunken};
+  border-radius: ${props => props.theme.radii[2]}px;
+  font-size: ${props => props.theme.fontSizes[1]}px;
 `;
 
 const Warning = styled(WarningIcon).attrs({

--- a/web/packages/teleterm/src/ui/Vnet/DocumentVnetDiagReport.tsx
+++ b/web/packages/teleterm/src/ui/Vnet/DocumentVnetDiagReport.tsx
@@ -39,6 +39,7 @@ import { CanceledError, useAsync } from 'shared/hooks/useAsync';
 import { pluralize } from 'shared/utils/text';
 
 import {
+  reportOneOfIsDNSReport,
   reportOneOfIsRouteConflictReport,
   reportOneOfIsSSHConfigurationReport,
 } from 'teleterm/helpers';
@@ -304,6 +305,10 @@ const reportOneofDisplayDetails: Record<
     errorTitle: 'inspect SSH configuration',
     Component: CheckReportSSHConfiguration,
   },
+  dnsReport: {
+    errorTitle: 'inspect DNS configuration',
+    Component: CheckReportDNS,
+  },
 };
 
 /**
@@ -465,6 +470,101 @@ function CheckReportSSHConfiguration({
       ) : null}
     </>
   );
+}
+
+/**
+ * CheckReportDNS displays the DNS check's per-zone outcomes
+ */
+function CheckReportDNS({
+  checkReport: { report, status },
+}: {
+  checkReport: diag.CheckReport;
+}) {
+  if (!reportOneOfIsDNSReport(report)) {
+    return null;
+  }
+  const { vnetDnsReachable, vnetDnsUnreachableError, zoneResults } =
+    report.dnsReport;
+
+  if (!vnetDnsReachable) {
+    return (
+      <Stack>
+        <P1>
+          <Warning /> VNet's DNS server is unreachable.
+        </P1>
+        <P2 m={0}>VNet's DNS is not responding. Try restarting VNet.</P2>
+        {vnetDnsUnreachableError ? <Pre>{vnetDnsUnreachableError}</Pre> : null}
+      </Stack>
+    );
+  }
+
+  if (status === diag.CheckReportStatus.OK) {
+    return (
+      <P1>
+        <Success /> DNS queries for all VNet zones are routed through VNet.
+      </P1>
+    );
+  }
+
+  // Show only problem rows.
+  const problemRows = zoneResults.filter(
+    zr => zr.status !== diag.DNSZoneStatus.DNS_ZONE_STATUS_OK
+  );
+
+  return (
+    <Stack>
+      <P1>
+        <Warning />{' '}
+        {problemRows.length === 1
+          ? `1 of ${zoneResults.length} DNS zones is not routed through VNet.`
+          : `${problemRows.length} of ${zoneResults.length} DNS zones are not routed through VNet.`}
+      </P1>
+      <P2 m={0}>
+        VNet's DNS server is reachable, but the OS resolver is not sending
+        queries for the zones below to VNet.
+      </P2>
+      <Table
+        emptyText=""
+        data={problemRows}
+        columns={[
+          { key: 'zone', headerText: 'Zone' },
+          {
+            key: 'status',
+            headerText: 'Status',
+            render: zr => <TextCell data={dnsZoneStatusLabel(zr.status)} />,
+          },
+          {
+            key: 'observedIp',
+            headerText: 'Observed',
+            render: zr => <TextCell data={zr.observedIp || '—'} />,
+          },
+          {
+            key: 'expectedIp',
+            headerText: 'Expected',
+            render: zr => <TextCell data={zr.expectedIp || '—'} />,
+          },
+        ]}
+        row={{ getStyle: () => ({ fontFamily: 'monospace' }) }}
+      />
+    </Stack>
+  );
+}
+
+function dnsZoneStatusLabel(status: diag.DNSZoneStatus): string {
+  switch (status) {
+    case diag.DNSZoneStatus.DNS_ZONE_STATUS_OK:
+      return 'OK';
+    case diag.DNSZoneStatus.DNS_ZONE_STATUS_HIJACKED:
+      return 'Hijacked';
+    case diag.DNSZoneStatus.DNS_ZONE_STATUS_NOT_REGISTERED:
+      return 'Not registered';
+    case diag.DNSZoneStatus.DNS_ZONE_STATUS_TIMEOUT:
+      return 'Timeout';
+    case diag.DNSZoneStatus.DNS_ZONE_STATUS_RESOLVER_ERROR:
+      return 'Resolver error';
+    default:
+      return `Unknown (${status})`;
+  }
 }
 
 const Summary = styled.summary`

--- a/web/packages/teleterm/src/ui/Vnet/DocumentVnetDiagReport.tsx
+++ b/web/packages/teleterm/src/ui/Vnet/DocumentVnetDiagReport.tsx
@@ -473,100 +473,160 @@ function CheckReportSSHConfiguration({
 }
 
 /**
- * CheckReportDNS displays the DNS check's per-zone outcomes
+ * CheckReportDNS displays per-family reachability and the per-zone, per-record-type outcomes.
  */
 function CheckReportDNS({
-  checkReport: { report, status },
+  checkReport: { report },
 }: {
   checkReport: diag.CheckReport;
 }) {
   if (!reportOneOfIsDNSReport(report)) {
     return null;
   }
-  const { vnetDnsReachable, vnetDnsUnreachableError, zoneResults } =
-    report.dnsReport;
+  const { ipv4Reachability, ipv6Reachability, zoneResults } = report.dnsReport;
 
-  if (!vnetDnsReachable) {
-    return (
-      <Stack>
-        <P1>
-          <Warning /> VNet's DNS server is unreachable.
-        </P1>
-        <P2 m={0}>
-          This might be caused by network routes set up by another program that
-          capture traffic meant for VNet.
-        </P2>
-        {vnetDnsUnreachableError ? <Pre>{vnetDnsUnreachableError}</Pre> : null}
-      </Stack>
-    );
-  }
-
-  if (status === diag.CheckReportStatus.OK) {
-    return (
-      <P1>
-        <Success /> DNS queries for all VNet zones are routed through VNet.
-      </P1>
-    );
-  }
-
-  // Show only problem rows.
+  // Show only zones that have at least one problem. A null aRecord
+  // or aaaaRecord means that record type wasn't queried because no
+  // expected IP was captured from the reachability step, so not a problem.
+  const okStatus = diag.DNSZoneStatus.DNS_ZONE_STATUS_OK;
   const problemRows = zoneResults.filter(
-    zr => zr.status !== diag.DNSZoneStatus.DNS_ZONE_STATUS_OK
+    zr =>
+      (zr.aRecord && zr.aRecord.status !== okStatus) ||
+      (zr.aaaaRecord && zr.aaaaRecord.status !== okStatus)
   );
+
+  const allUnreachable =
+    (ipv4Reachability || ipv6Reachability) &&
+    (!ipv4Reachability || !ipv4Reachability.reachable) &&
+    (!ipv6Reachability || !ipv6Reachability.reachable);
 
   return (
     <Stack>
-      <P1>
-        <Warning />{' '}
-        {problemRows.length === 1
-          ? `1 of ${zoneResults.length} DNS zones is not routed through VNet.`
-          : `${problemRows.length} of ${zoneResults.length} DNS zones are not routed through VNet.`}
-      </P1>
-      <P2 m={0}>
-        VNet's DNS server is reachable, but the OS resolver is not sending
-        queries for the zones below to&nbsp VNet.
-      </P2>
-      <Table
-        emptyText=""
-        data={problemRows}
-        columns={[
-          { key: 'zone', headerText: 'Zone' },
-          {
-            key: 'status',
-            headerText: 'Status',
-            render: zr => <TextCell data={dnsZoneStatusLabel(zr.status)} />,
-          },
-          {
-            key: 'observedIp',
-            headerText: 'Observed',
-            render: zr => <TextCell data={zr.observedIp || '—'} />,
-          },
-          {
-            key: 'expectedIp',
-            headerText: 'Expected',
-            render: zr => <TextCell data={zr.expectedIp || '—'} />,
-          },
-        ]}
-        row={{ getStyle: () => ({ fontFamily: 'monospace' }) }}
-      />
+      <Stack gap={0}>
+        <ReachabilityRow family="IPv4" reach={ipv4Reachability} />
+        <ReachabilityRow family="IPv6" reach={ipv6Reachability} />
+      </Stack>
+
+      {allUnreachable && (
+        <P2 m={0}>
+          VNet's DNS is not responding. This might be caused by network routes
+          set up by another program that capture traffic meant for VNet.
+        </P2>
+      )}
+
+      {problemRows.length > 0 && (
+        <>
+          <Stack>
+            <P1>
+              <Warning />{' '}
+              {problemRows.length === 1
+                ? `1 of ${zoneResults.length} DNS zones is not fully routed through VNet.`
+                : `${problemRows.length} of ${zoneResults.length} DNS zones are not fully routed through VNet.`}
+            </P1>
+            <P2 m={0}>
+              The OS resolver is not sending some queries for the zones below to
+              VNet.
+            </P2>
+          </Stack>
+          <Table
+            emptyText=""
+            data={problemRows}
+            // Drop the record-type column if no row in the table has a result for it.
+            columns={[
+              { key: 'zone' as const, headerText: 'Zone' },
+              ...(problemRows.some(zr => zr.aRecord)
+                ? [
+                    {
+                      key: 'aRecord' as const,
+                      headerText: 'A',
+                      render: (zr: diag.DNSZoneResult) => (
+                        <RecordResultCell rr={zr.aRecord} />
+                      ),
+                    },
+                  ]
+                : []),
+              ...(problemRows.some(zr => zr.aaaaRecord)
+                ? [
+                    {
+                      key: 'aaaaRecord' as const,
+                      headerText: 'AAAA',
+                      render: (zr: diag.DNSZoneResult) => (
+                        <RecordResultCell rr={zr.aaaaRecord} />
+                      ),
+                    },
+                  ]
+                : []),
+            ]}
+            row={{ getStyle: () => ({ fontFamily: 'monospace' }) }}
+          />
+        </>
+      )}
     </Stack>
   );
 }
 
-function dnsZoneStatusLabel(status: diag.DNSZoneStatus): string {
+function ReachabilityRow({
+  family,
+  reach,
+}: {
+  family: 'IPv4' | 'IPv6';
+  reach: diag.VNetDNSReachability | undefined;
+}) {
+  // Unset reachability means VNet doesn't serve DNS on this family. Skip the row.
+  if (!reach) {
+    return null;
+  }
+  if (!reach.reachable) {
+    return (
+      <P1>
+        <Warning /> VNet {family} DNS unreachable on{' '}
+        <code>{reach.address}</code>: {reach.error}
+      </P1>
+    );
+  }
+  const responded =
+    reach.respondedA && reach.respondedAaaa
+      ? 'A, AAAA'
+      : reach.respondedA
+        ? 'A only'
+        : reach.respondedAaaa
+          ? 'AAAA only'
+          : 'nothing';
+  return (
+    <P1>
+      <Success /> VNet {family} DNS reachable on <code>{reach.address}</code>{' '}
+      (responds to {responded})
+    </P1>
+  );
+}
+
+function RecordResultCell({ rr }: { rr: diag.RecordResult | undefined }) {
+  // No expected IP was captured for this record type, the cell is left empty.
+  if (!rr) {
+    return <TextCell data="" />;
+  }
+  return (
+    <Cell>
+      <DnsZoneStatusLabel status={rr.status} />
+      {rr.observedIp ? ` (${rr.observedIp})` : null}
+    </Cell>
+  );
+}
+
+function DnsZoneStatusLabel({ status }: { status: diag.DNSZoneStatus }) {
   switch (status) {
     case diag.DNSZoneStatus.DNS_ZONE_STATUS_OK:
-      return 'OK';
+      return <Success />;
     case diag.DNSZoneStatus.DNS_ZONE_STATUS_HIJACKED:
-      return 'Hijacked';
+      return <>Hijacked</>;
     case diag.DNSZoneStatus.DNS_ZONE_STATUS_NOT_REGISTERED:
-      return 'Not registered';
+      return <>Not registered</>;
     case diag.DNSZoneStatus.DNS_ZONE_STATUS_TIMEOUT:
-      return 'Timeout';
+      return <>Timeout</>;
     case diag.DNSZoneStatus.DNS_ZONE_STATUS_RESOLVER_ERROR:
-      return 'Resolver error';
+      return <>Resolver error</>;
     default:
-      return `Unknown (${status})`;
+      return <>Unknown ({status})</>;
   }
 }
 


### PR DESCRIPTION
Closes #52553

Changelog: Added a DNS routing diagnostic check that verifies the OS resolver routes queries for each VNet-managed DNS zone to VNet's nameservers.

This change adds a diagnostic check that verifies VNet-managed DNS zones are routed through VNet's nameservers, fetching the zone list from the cluster config and running the check against each zone for both A and AAAA records.

The check uses probe hostnames of the form `vnet-diag-<random>.<zone>`. VNet's nameservers match on the `vnet-diag-` prefix and short-circuit these queries, answering A and AAAA with known addresses derived from VNet's IPv4 CIDR range and IPv6 prefix (in most cases VNet's own DNS server addresses: `<cidr>.2` and `<prefix>::2`).

It runs in two steps:

1) Direct DNS queries for `vnet-diag-<random>.test` to each configured VNet IPv4 and IPv6 nameserver , asking for both A and AAAA. Confirms each nameserver is reachable and captures the responses as the expected answers for step 2. If no expected addresses were captured, step 2 is skipped.

2) For each zone, sends `vnet-diag-<random>.<zone>` through the OS resolver, separately for A and AAAA, and compares each answer to step 1's response.

The check fails if both nameservers are unreachable, or if at least one zone has an issue with either record type. A nameserver that returned no records during the reachability step is treated as unreachable.

Report samples:
<img width="676" height="358" alt="image" src="https://github.com/user-attachments/assets/b4282f16-1a26-4d42-969f-2cf42169dbe4" />
<img width="661" height="418" alt="image" src="https://github.com/user-attachments/assets/0ae25072-b7b9-44ba-8885-4fce4ed5cd72" />


## Manual Test Plan

### Test Environment

On macOS VNet's OS configuration loop wipes any file with VNet's comment and rewrites files for every managed zone. Locking a managed zone's resolver file with `chflags uchg` crashes VNet. To work around this, manual testing uses fake zone names that VNet doesn't manage, injected into the diag check's input via a temporary patch:

```go
// In tool/tsh/common/vnet.go:runDNSDiag and lib/teleterm/vnet/service.go:dnsDiag
zones := append(<real zones>,
    "vnet-diag-test-notreg.test",   // no /etc/resolver entry → NOT_REGISTERED
    "vnet-diag-test-timeout.test",  // points at 192.0.2.1 → TIMEOUT
    "vnet-diag-test-upstream.test", // points at 1.1.1.1 → NOT_REGISTERED (NXDOMAIN)
    "vnet-diag-test-hijack.test",   // points at local dnsmasq → HIJACKED
)
```

And a separate patch with the unreachable-DNS override:

```go
cfg.VNetDNSIPv6 = netip.MustParseAddrPort("[100::3]:53")
```

`/etc/resolver/` entries used:

```bash
sudo bash -c 'cat > /etc/resolver/vnet-diag-test-timeout.test <<EOF
nameserver 192.0.2.1
EOF'

sudo bash -c 'cat > /etc/resolver/vnet-diag-test-upstream.test <<EOF
nameserver 1.1.1.1
EOF'

sudo bash -c 'cat > /etc/resolver/vnet-diag-test-hijack.test <<EOF
nameserver 127.0.0.1
port 5354
EOF'
```

Local dnsmasq `dnsmasq.conf`:

```
port=5354
listen-address=127.0.0.1
address=/vnet-diag-test-hijack.test/2001:db8::1234
address=/vnet-diag-test-hijack.test/192.0.2.42
```

### Test Cases
- [x] Log into Teleport Connect, check diag report, see no issues.
- [x] Run `tsh vnet --diag`, see no DNS issues printed.
- [x] Make step 1 of the check fail, see diag report shows "VNet's DNS server is unreachable."
- [x] Configure four zones with the four failure statuses, check they are all detected and printed correctly.