### PR TITLE
Enterprise e2e linting and export types

### DIFF
--- a/.oxlintrc.jsonc
+++ b/.oxlintrc.jsonc
@@ -423,7 +423,7 @@
      * E2E tests
      */
     {
-      "files": ["e2e/**/*.ts"],
+      "files": ["e2e/**/*.ts", "e/e2e/**/*.ts"],
       "rules": {
         "react-hooks/rules-of-hooks": "off"
       }
@@ -456,6 +456,40 @@
                 "name": "@playwright/test",
                 "importNames": ["test", "expect"],
                 "message": "Import 'test' and 'expect' from '@gravitational/e2e/helpers/connect' instead."
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "files": ["e/e2e/tests/web/**/*.ts"],
+      "rules": {
+        "no-restricted-imports": [
+          "error",
+          {
+            "paths": [
+              {
+                "name": "@playwright/test",
+                "importNames": ["test", "expect"],
+                "message": "Import 'test' and 'expect' from '@gravitational/e-e2e/helpers/test' instead."
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "files": ["e/e2e/tests/connect/**/*.ts"],
+      "rules": {
+        "no-restricted-imports": [
+          "error",
+          {
+            "paths": [
+              {
+                "name": "@playwright/test",
+                "importNames": ["test", "expect"],
+                "message": "Import 'test' and 'expect' from '@gravitational/e-e2e/helpers/connect' instead."
               }
             ]
           }

--- a/e2e/helpers/test.ts
+++ b/e2e/helpers/test.ts
@@ -231,6 +231,7 @@ export const test = base.extend<E2EFixtures>({
 });
 
 export { expect } from '@playwright/test';
+export type { Locator, Page } from '@playwright/test';
 
 function pickLoginDefinition(
   user: UserDefinition | undefined,


### PR DESCRIPTION
Exports a couple of types for enterprise to use (as enterprise doesn't have playwright as a dependency) and add linting rules that mirror OSS, but for enterprise