### PR TITLE
Fix lib/web feature watcher panic on nil cluster features.

### DIFF
--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -821,7 +821,7 @@ func NewHandler(cfg Config, opts ...HandlerOption) (*APIHandler, error) {
 		}
 	}
 
-	go h.startFeatureWatcher()
+	go h.startFeatureWatcher(h.cfg.Context)
 
 	return &APIHandler{
 		handler:    h,

--- a/lib/web/features.go
+++ b/lib/web/features.go
@@ -19,6 +19,8 @@
 package web
 
 import (
+	"context"
+
 	"github.com/gravitational/teleport/api/client/proto"
 )
 
@@ -45,8 +47,7 @@ func (h *Handler) GetClusterFeatures() proto.Features {
 // which will cause a panic.
 // The watcher doesn't ping the auth server immediately upon start because features are
 // already set by the config object in `NewHandler`.
-func (h *Handler) startFeatureWatcher() {
-	ctx := h.cfg.Context
+func (h *Handler) startFeatureWatcher(ctx context.Context) {
 	ticker := h.clock.NewTicker(h.cfg.FeatureWatchInterval)
 	h.logger.InfoContext(ctx, "Proxy handler features watcher has started", "interval", h.cfg.FeatureWatchInterval)
 

--- a/lib/web/features.go
+++ b/lib/web/features.go
@@ -61,8 +61,11 @@ func (h *Handler) startFeatureWatcher() {
 				continue
 			}
 
-			h.SetClusterFeatures(*pingResponse.ServerFeatures)
-			h.logger.InfoContext(ctx, "Done updating proxy features", "features", pingResponse.ServerFeatures)
+			if pingResponse.ServerFeatures != nil {
+				h.SetClusterFeatures(*pingResponse.ServerFeatures)
+				h.logger.InfoContext(ctx, "Done updating proxy features", "features", pingResponse.ServerFeatures)
+			}
+
 		case <-ctx.Done():
 			h.logger.InfoContext(ctx, "Feature service has stopped")
 			return

--- a/lib/web/features_test.go
+++ b/lib/web/features_test.go
@@ -42,26 +42,26 @@ type mockedFeatureGetter struct {
 	authclient.ClientI
 
 	mu       sync.Mutex
-	features proto.Features
+	features *proto.Features
 }
 
 func (m *mockedFeatureGetter) Ping(ctx context.Context) (proto.PingResponse, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	return proto.PingResponse{
-		ServerFeatures: utils.CloneProtoMsg(&m.features),
+		ServerFeatures: utils.CloneProtoMsg(m.features),
 	}, nil
 }
 
 func (m *mockedFeatureGetter) setFeatures(f proto.Features) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	m.features = f
+	m.features = &f
 }
 
 func TestFeaturesWatcher(t *testing.T) {
 	synctest.Test(t, func(t *testing.T) {
-		mockClient := &mockedFeatureGetter{features: proto.Features{
+		mockClient := &mockedFeatureGetter{features: &proto.Features{
 			Entitlements: map[string]*proto.EntitlementInfo{},
 		}}
 
@@ -147,5 +147,41 @@ func TestFeaturesWatcher(t *testing.T) {
 
 		// assert the handler never get these last features as the watcher is stopped
 		require.NotEqual(t, *notExpected, handler.GetClusterFeatures())
+	})
+}
+
+func TestFeaturesWatcherDoesNotPanicOnNilFeatures(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		initialFeatures := proto.Features{
+			Entitlements: map[string]*proto.EntitlementInfo{
+				string(entitlements.App): {Enabled: true},
+			},
+		}
+
+		handler := &Handler{
+			cfg: Config{
+				FeatureWatchInterval: time.Nanosecond,
+				ProxyClient: &mockedFeatureGetter{
+					features: nil, // Simulate auth server returning nil features.
+				},
+				Context: t.Context(),
+			},
+			clock:           clockwork.NewRealClock(),
+			clusterFeatures: initialFeatures,
+			logger:          slog.Default().With(teleport.ComponentKey, teleport.ComponentWeb),
+		}
+
+		go handler.startFeatureWatcher()
+		synctest.Wait()
+
+		time.Sleep(handler.cfg.FeatureWatchInterval)
+		synctest.Wait()
+
+		require.Equal(
+			t,
+			initialFeatures,
+			handler.clusterFeatures,
+			"Cluster features must remain unchanged when auth server returns nil features",
+		)
 	})
 }

--- a/lib/web/features_test.go
+++ b/lib/web/features_test.go
@@ -71,14 +71,13 @@ func TestFeaturesWatcher(t *testing.T) {
 			cfg: Config{
 				FeatureWatchInterval: 100 * time.Millisecond,
 				ProxyClient:          mockClient,
-				Context:              ctx,
 			},
 			clock:           clockwork.NewRealClock(),
 			clusterFeatures: proto.Features{},
 			logger:          slog.Default().With(teleport.ComponentKey, teleport.ComponentWeb),
 		}
 
-		go handler.startFeatureWatcher()
+		go handler.startFeatureWatcher(ctx)
 		synctest.Wait()
 
 		// before running the watcher, features should match the value passed to the handler
@@ -164,14 +163,13 @@ func TestFeaturesWatcherDoesNotPanicOnNilFeatures(t *testing.T) {
 				ProxyClient: &mockedFeatureGetter{
 					features: nil, // Simulate auth server returning nil features.
 				},
-				Context: t.Context(),
 			},
 			clock:           clockwork.NewRealClock(),
 			clusterFeatures: initialFeatures,
 			logger:          slog.Default().With(teleport.ComponentKey, teleport.ComponentWeb),
 		}
 
-		go handler.startFeatureWatcher()
+		go handler.startFeatureWatcher(t.Context())
 		synctest.Wait()
 
 		time.Sleep(handler.cfg.FeatureWatchInterval)


### PR DESCRIPTION
Saw this issue in a [CI run](https://github.com/gravitational/teleport/actions/runs/26070402424/job/76650405252?pr=66820) for one of my PRs. It should resolve the flaky tests and panics at runtime if Auth ever returns `nil` features in a ping response.