### PR TITLE
Shared helpers for tctl Access Graph commands

### DIFF
--- a/tool/tctl/common/accessgraph/credentials_test.go
+++ b/tool/tctl/common/accessgraph/credentials_test.go
@@ -563,11 +563,12 @@ func TestShouldPersistAccessGraphCert(t *testing.T) {
 			want: false,
 		},
 		{
-			name: "just outside threshold (5m1s)",
+			// 30s slack absorbs the wall-clock gap between signing and the time.Now() check under CI load.
+			name: "just outside threshold (5m30s)",
 			creds: func(t *testing.T) *accessGraphCredentials {
 				return &accessGraphCredentials{
 					clientStore: client.NewMemClientStore(),
-					keyRing:     withCert(t, 5*time.Minute+time.Second),
+					keyRing:     withCert(t, 5*time.Minute+30*time.Second),
 				}
 			},
 			want: true,

--- a/tool/tctl/common/accessgraph/utils.go
+++ b/tool/tctl/common/accessgraph/utils.go
@@ -1,0 +1,195 @@
+/*
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package accessgraph
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"log/slog"
+	"strings"
+	"time"
+
+	"github.com/gravitational/trace"
+
+	"github.com/gravitational/teleport"
+	accessgraph "github.com/gravitational/teleport/lib/accessgraph/apiclient"
+	logmodels "github.com/gravitational/teleport/lib/accessgraph/apiclient/models/logs"
+	"github.com/gravitational/teleport/lib/utils"
+)
+
+type timeValue struct {
+	target *time.Time
+}
+
+func (v timeValue) Set(s string) error {
+	parsed, err := parseTimeFilterValue(s, time.Now())
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	*v.target = parsed
+	return nil
+}
+
+func (v timeValue) String() string {
+	if v.target == nil || v.target.IsZero() {
+		return ""
+	}
+
+	return v.target.Format(time.RFC3339)
+}
+
+func parseTimeFilterValue(s string, now time.Time) (time.Time, error) {
+	if s == "" {
+		return time.Time{}, nil
+	}
+
+	if s == "now" {
+		return now, nil
+	}
+
+	if ts, err := time.Parse(time.RFC3339, s); err == nil {
+		return ts, nil
+	}
+
+	// Date-only inputs are interpreted as local-midnight so a user writing
+	// `--from 2026-05-06` gets the start of that day in their own timezone.
+	if ts, err := time.ParseInLocation(time.DateOnly, s, time.Local); err == nil {
+		return ts, nil
+	}
+
+	duration, err := parseRelativeDuration(s)
+	if err != nil {
+		return time.Time{}, trace.BadParameter("invalid time %q, expected RFC3339 (2026-05-06T15:04:05Z), date (2026-05-06), or relative duration like 24h or 7d", s)
+	}
+
+	return now.Add(-duration), nil
+}
+
+// validateTimeWindow rejects inverted `--from`/`--to` windows; zero values on
+// either side are skipped so callers with optional bounds still work.
+func validateTimeWindow(from, to time.Time) error {
+	if from.IsZero() || to.IsZero() {
+		return nil
+	}
+	if !from.Before(to) {
+		return trace.BadParameter("invalid time window: --from (%s) must be before --to (%s)", from.Format(time.RFC3339), to.Format(time.RFC3339))
+	}
+	return nil
+}
+
+// parseRelativeDuration extends time.ParseDuration with a "d" suffix meaning days.
+func parseRelativeDuration(s string) (time.Duration, error) {
+	if before, ok := strings.CutSuffix(s, "d"); ok {
+		hours, err := time.ParseDuration(before + "h")
+		if err != nil {
+			return 0, trace.Wrap(err)
+		}
+		return hours * 24, nil
+	}
+
+	duration, err := time.ParseDuration(s)
+	if err != nil {
+		return 0, trace.Wrap(err)
+	}
+	return duration, nil
+}
+
+// fetchAllLogs paginates ExecuteLogsQueryV1 up to maxResults events
+// (<=0 means unbounded); truncated is true if more results remained.
+func fetchAllLogs(
+	ctx context.Context,
+	client *accessgraph.ClientWithResponses,
+	params accessgraph.ExecuteLogsQueryV1Params,
+	maxResults int,
+) (events []logmodels.AccessgraphStorageV1alphaEvent, truncated bool, err error) {
+	var from, to string
+	if params.StartTime != nil {
+		from = params.StartTime.Format(time.RFC3339)
+	}
+	if params.EndTime != nil {
+		to = params.EndTime.Format(time.RFC3339)
+	}
+	slog.DebugContext(ctx, "logs query", "query", strPtrToStr(params.Query), "from", from, "to", to, "max_results", maxResults)
+
+	var (
+		cursor *string
+		pages  int
+	)
+	for {
+		params.Iterator = cursor
+		resp, err := doRequest(client.ExecuteLogsQueryV1WithResponse(ctx, &params))
+		if err != nil {
+			return nil, false, trace.Wrap(err)
+		}
+		pages++
+		slog.DebugContext(ctx, "logs page fetched", "page", pages, "page_size", len(resp.JSON200.Data))
+		events = append(events, resp.JSON200.Data...)
+		if maxResults > 0 && len(events) >= maxResults {
+			truncated = len(events) > maxResults || resp.JSON200.NextCursor != nil
+			events = events[:maxResults]
+			break
+		}
+		if resp.JSON200.NextCursor == nil {
+			break
+		}
+		cursor = resp.JSON200.NextCursor
+	}
+	slog.DebugContext(ctx, "logs fetch complete", "pages", pages, "events", len(events), "truncated", truncated)
+	return events, truncated, nil
+}
+
+// strPtrToStr returns *s or "" if s is nil.
+func strPtrToStr(s *string) string {
+	if s == nil {
+		return ""
+	}
+	return *s
+}
+
+// dslClause returns `field:value` or `field:(v1 OR v2 ...)`; values are %q-quoted.
+func dslClause(field string, values []string) string {
+	switch len(values) {
+	case 0:
+		return ""
+	case 1:
+		return fmt.Sprintf("%s:%q", field, values[0])
+	default:
+		parts := make([]string, len(values))
+		for i, v := range values {
+			parts[i] = fmt.Sprintf("%q", v)
+		}
+		return fmt.Sprintf("%s:(%s)", field, strings.Join(parts, " OR "))
+	}
+}
+
+// writeOutput dispatches payload rendering: text invokes renderText; json/yaml marshal payload directly.
+func writeOutput(w io.Writer, payload any, format string, renderText func(io.Writer) error) error {
+	switch format {
+	case teleport.Text:
+		return trace.Wrap(renderText(w))
+	case teleport.JSON:
+		return trace.Wrap(utils.WriteJSON(w, payload))
+	case teleport.YAML:
+		return trace.Wrap(utils.WriteYAML(w, payload))
+	default:
+		return trace.BadParameter("unknown format %q", format)
+	}
+}

--- a/tool/tctl/common/accessgraph/utils_test.go
+++ b/tool/tctl/common/accessgraph/utils_test.go
@@ -1,0 +1,456 @@
+/*
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package accessgraph
+
+import (
+	"context"
+	"crypto/tls"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/gravitational/trace"
+	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport"
+	accessgraph "github.com/gravitational/teleport/lib/accessgraph/apiclient"
+)
+
+func TestParseRelativeDuration(t *testing.T) {
+	tests := []struct {
+		name    string
+		in      string
+		want    time.Duration
+		wantErr bool
+	}{
+		{name: "hours", in: "24h", want: 24 * time.Hour},
+		{name: "minutes", in: "30m", want: 30 * time.Minute},
+		{name: "compound", in: "1h30m", want: 90 * time.Minute},
+		{name: "days", in: "7d", want: 7 * 24 * time.Hour},
+		{name: "single day", in: "1d", want: 24 * time.Hour},
+		{name: "fractional days", in: "0.5d", want: 12 * time.Hour},
+		{name: "zero seconds", in: "0s", want: 0},
+		{name: "empty string", in: "", wantErr: true},
+		{name: "garbage", in: "abc", wantErr: true},
+		{name: "lone d", in: "d", wantErr: true},
+		{name: "no unit", in: "5", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseRelativeDuration(tt.in)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestParseTimeFilterValue(t *testing.T) {
+	// Pinned "now" so the relative-duration cases are deterministic.
+	now := time.Date(2026, 4, 27, 12, 0, 0, 0, time.UTC)
+
+	t.Run("empty string returns zero time", func(t *testing.T) {
+		got, err := parseTimeFilterValue("", now)
+		require.NoError(t, err)
+		require.True(t, got.IsZero())
+	})
+
+	t.Run("RFC3339 timestamp parses as-is", func(t *testing.T) {
+		want := time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC)
+		got, err := parseTimeFilterValue("2026-01-02T03:04:05Z", now)
+		require.NoError(t, err)
+		require.True(t, got.Equal(want), "got %v want %v", got, want)
+	})
+
+	t.Run("date-only input parses as local midnight", func(t *testing.T) {
+		want := time.Date(2026, 5, 6, 0, 0, 0, 0, time.Local)
+		got, err := parseTimeFilterValue("2026-05-06", now)
+		require.NoError(t, err)
+		require.True(t, got.Equal(want), "got %v want %v", got, want)
+	})
+
+	t.Run("\"now\" sentinel returns parse-time now", func(t *testing.T) {
+		got, err := parseTimeFilterValue("now", now)
+		require.NoError(t, err)
+		require.Equal(t, now, got)
+	})
+
+	t.Run("relative duration is subtracted from now", func(t *testing.T) {
+		got, err := parseTimeFilterValue("24h", now)
+		require.NoError(t, err)
+		require.Equal(t, now.Add(-24*time.Hour), got)
+	})
+
+	t.Run("negative duration is future-relative", func(t *testing.T) {
+		// Documented behavior: a negative offset flips the subtraction
+		// and produces a future timestamp. Used by callers that want to
+		// query forward from now.
+		got, err := parseTimeFilterValue("-2h", now)
+		require.NoError(t, err)
+		require.Equal(t, now.Add(2*time.Hour), got)
+	})
+
+	t.Run("relative day suffix", func(t *testing.T) {
+		got, err := parseTimeFilterValue("7d", now)
+		require.NoError(t, err)
+		require.Equal(t, now.Add(-7*24*time.Hour), got)
+	})
+
+	t.Run("invalid input returns BadParameter", func(t *testing.T) {
+		_, err := parseTimeFilterValue("not a time", now)
+		require.Error(t, err)
+		require.True(t, trace.IsBadParameter(err), "want BadParameter, got %v", err)
+		require.Contains(t, err.Error(), "RFC3339")
+	})
+}
+
+func TestTimeValue(t *testing.T) {
+	t.Run("Set parses RFC3339 and String round-trips", func(t *testing.T) {
+		var target time.Time
+		v := timeValue{target: &target}
+		require.NoError(t, v.Set("2026-01-02T03:04:05Z"))
+		require.Equal(t, "2026-01-02T03:04:05Z", v.String())
+	})
+
+	t.Run("zero target prints empty", func(t *testing.T) {
+		var target time.Time
+		require.Empty(t, timeValue{target: &target}.String())
+	})
+
+	t.Run("nil target prints empty", func(t *testing.T) {
+		require.Empty(t, timeValue{}.String())
+	})
+
+	t.Run("Set propagates parse errors", func(t *testing.T) {
+		var target time.Time
+		require.Error(t, timeValue{target: &target}.Set("garbage"))
+	})
+}
+
+func TestValidateTimeWindow(t *testing.T) {
+	earlier := time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC)
+	later := time.Date(2026, 5, 10, 0, 0, 0, 0, time.UTC)
+
+	t.Run("from before to is valid", func(t *testing.T) {
+		require.NoError(t, validateTimeWindow(earlier, later))
+	})
+
+	t.Run("from equal to is rejected", func(t *testing.T) {
+		err := validateTimeWindow(earlier, earlier)
+		require.Error(t, err)
+		require.True(t, trace.IsBadParameter(err), "want BadParameter, got %v", err)
+	})
+
+	t.Run("from after to is rejected", func(t *testing.T) {
+		err := validateTimeWindow(later, earlier)
+		require.Error(t, err)
+		require.True(t, trace.IsBadParameter(err), "want BadParameter, got %v", err)
+	})
+
+	t.Run("zero from is skipped", func(t *testing.T) {
+		require.NoError(t, validateTimeWindow(time.Time{}, later))
+	})
+
+	t.Run("zero to is skipped", func(t *testing.T) {
+		require.NoError(t, validateTimeWindow(earlier, time.Time{}))
+	})
+}
+
+func TestStrPtrToStr(t *testing.T) {
+	require.Empty(t, strPtrToStr(nil))
+	empty := ""
+	require.Empty(t, strPtrToStr(&empty))
+	val := "hello"
+	require.Equal(t, "hello", strPtrToStr(&val))
+}
+
+func TestDslClause(t *testing.T) {
+	require.Empty(t, dslClause("user", nil))
+	require.Empty(t, dslClause("user", []string{}))
+	require.Equal(t, `user:"alice"`, dslClause("user", []string{"alice"}))
+	require.Equal(t,
+		`user:("alice" OR "bob")`,
+		dslClause("user", []string{"alice", "bob"}),
+	)
+	// Embedded quote → \" (important: would otherwise break the DSL).
+	require.Equal(t, `f:"a\"b"`, dslClause("f", []string{`a"b`}))
+	// Backslash → \\.
+	require.Equal(t, `f:"a\\b"`, dslClause("f", []string{`a\b`}))
+	// Newline → \n escape sequence.
+	require.Equal(t, `f:"a\nb"`, dslClause("f", []string{"a\nb"}))
+	// Valid non-ASCII passes through unchanged (printable runes).
+	require.Equal(t, `f:"café"`, dslClause("f", []string{"café"}))
+}
+
+type fetchAllLogsPage struct {
+	data       []map[string]any
+	nextCursor *string
+}
+
+// fetchAllLogsHandler returns an http.Handler that serves a fixed sequence
+// of paginated responses. It records each request so tests can assert on
+// the cursor flow.
+func fetchAllLogsHandler(t *testing.T, pages []fetchAllLogsPage) (http.Handler, *atomic.Int64, *[]string) {
+	t.Helper()
+	var calls atomic.Int64
+	cursors := []string{}
+	cursorsRef := &cursors
+
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		idx := int(calls.Add(1) - 1)
+		// Record the iterator the client sent on this call.
+		*cursorsRef = append(*cursorsRef, r.URL.Query().Get("iterator"))
+
+		require.Less(t, idx, len(pages), "client requested more pages than configured")
+		page := pages[idx]
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(200)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"data":        page.data,
+			"next_cursor": page.nextCursor,
+		})
+	})
+	return handler, &calls, cursorsRef
+}
+
+func newAccessGraphTestClient(t *testing.T, h http.Handler) *accessgraph.ClientWithResponses {
+	t.Helper()
+	srv := httptest.NewTLSServer(h)
+	t.Cleanup(srv.Close)
+
+	httpClient := srv.Client()
+	if tr, ok := httpClient.Transport.(*http.Transport); ok {
+		tr.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
+	}
+	c, err := accessgraph.NewClientWithResponses(
+		srv.URL+accessGraphAPIPath,
+		accessgraph.WithHTTPClient(httpClient),
+	)
+	require.NoError(t, err)
+	return c
+}
+
+func TestFetchAllLogs(t *testing.T) {
+	t.Run("single page, no cursor → no pagination", func(t *testing.T) {
+		h, calls, cursors := fetchAllLogsHandler(t, []fetchAllLogsPage{
+			{data: []map[string]any{{"id": "a"}, {"id": "b"}}, nextCursor: nil},
+		})
+		c := newAccessGraphTestClient(t, h)
+
+		got, truncated, err := fetchAllLogs(context.Background(), c, accessgraph.ExecuteLogsQueryV1Params{}, 10)
+		require.NoError(t, err)
+		require.False(t, truncated)
+		require.Len(t, got, 2)
+		require.EqualValues(t, 1, calls.Load())
+		require.Equal(t, []string{""}, *cursors, "first call must omit the iterator")
+	})
+
+	t.Run("multiple pages walk the cursor", func(t *testing.T) {
+		c1 := "cursor-1"
+		c2 := "cursor-2"
+		h, calls, cursors := fetchAllLogsHandler(t, []fetchAllLogsPage{
+			{data: []map[string]any{{"id": "a"}}, nextCursor: &c1},
+			{data: []map[string]any{{"id": "b"}}, nextCursor: &c2},
+			{data: []map[string]any{{"id": "c"}}, nextCursor: nil},
+		})
+		c := newAccessGraphTestClient(t, h)
+
+		got, truncated, err := fetchAllLogs(context.Background(), c, accessgraph.ExecuteLogsQueryV1Params{}, 10)
+		require.NoError(t, err)
+		require.False(t, truncated)
+		require.Len(t, got, 3)
+		require.EqualValues(t, 3, calls.Load())
+		// Each subsequent call sends the previous response's
+		// next_cursor as `iterator` — that's the contract.
+		require.Equal(t, []string{"", "cursor-1", "cursor-2"}, *cursors)
+	})
+
+	t.Run("HTTP error short-circuits", func(t *testing.T) {
+		var calls atomic.Int64
+		h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			calls.Add(1)
+			w.WriteHeader(500)
+			_, _ = w.Write([]byte(`{"message":"server is sad"}`))
+		})
+		c := newAccessGraphTestClient(t, h)
+
+		_, _, err := fetchAllLogs(context.Background(), c, accessgraph.ExecuteLogsQueryV1Params{}, 10)
+		require.Error(t, err)
+		var agErr *apiResponseError
+		require.ErrorAs(t, err, &agErr)
+		require.Equal(t, 500, agErr.StatusCode)
+		require.Equal(t, "server is sad", agErr.Message)
+		require.EqualValues(t, 1, calls.Load(), "must not retry past the first failure")
+	})
+
+	t.Run("maxResults limit returns partial results with truncated=true", func(t *testing.T) {
+		stuck := "stuck"
+		var calls atomic.Int64
+		h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			calls.Add(1)
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(200)
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"data":        []map[string]any{{"id": "x"}},
+				"next_cursor": &stuck,
+			})
+		})
+		c := newAccessGraphTestClient(t, h)
+
+		got, truncated, err := fetchAllLogs(context.Background(), c, accessgraph.ExecuteLogsQueryV1Params{}, 5)
+		require.NoError(t, err)
+		require.True(t, truncated, "more pages remained when maxResults was hit")
+		require.Len(t, got, 5, "should return up to maxResults events")
+		require.EqualValues(t, 5, calls.Load())
+	})
+
+	t.Run("page overshoot trims and flags truncated", func(t *testing.T) {
+		h, calls, _ := fetchAllLogsHandler(t, []fetchAllLogsPage{
+			{data: []map[string]any{{"id": "a"}, {"id": "b"}, {"id": "c"}, {"id": "d"}, {"id": "e"}}, nextCursor: nil},
+		})
+		c := newAccessGraphTestClient(t, h)
+
+		got, truncated, err := fetchAllLogs(context.Background(), c, accessgraph.ExecuteLogsQueryV1Params{}, 3)
+		require.NoError(t, err)
+		require.True(t, truncated, "single-page overshoot must flag truncated")
+		require.Len(t, got, 3)
+		require.EqualValues(t, 1, calls.Load())
+	})
+
+	t.Run("maxResults zero means unbounded", func(t *testing.T) {
+		c1 := "cursor-1"
+		h, calls, _ := fetchAllLogsHandler(t, []fetchAllLogsPage{
+			{data: []map[string]any{{"id": "a"}, {"id": "b"}}, nextCursor: &c1},
+			{data: []map[string]any{{"id": "c"}}, nextCursor: nil},
+		})
+		c := newAccessGraphTestClient(t, h)
+
+		got, truncated, err := fetchAllLogs(context.Background(), c, accessgraph.ExecuteLogsQueryV1Params{}, 0)
+		require.NoError(t, err)
+		require.False(t, truncated, "unbounded fetch must never report truncation")
+		require.Len(t, got, 3)
+		require.EqualValues(t, 2, calls.Load())
+	})
+
+	t.Run("maxResults equal to total — exhaustion, not truncation", func(t *testing.T) {
+		c1 := "cursor-1"
+		h, _, _ := fetchAllLogsHandler(t, []fetchAllLogsPage{
+			{data: []map[string]any{{"id": "a"}, {"id": "b"}}, nextCursor: &c1},
+			{data: []map[string]any{{"id": "c"}}, nextCursor: nil},
+		})
+		c := newAccessGraphTestClient(t, h)
+
+		got, truncated, err := fetchAllLogs(context.Background(), c, accessgraph.ExecuteLogsQueryV1Params{}, 3)
+		require.NoError(t, err)
+		require.False(t, truncated, "natural exhaustion at the limit must not flag truncated")
+		require.Len(t, got, 3)
+	})
+
+	t.Run("query and time params reach the server", func(t *testing.T) {
+		var got url.Values
+		h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			got = r.URL.Query()
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(200)
+			_, _ = w.Write([]byte(`{"data":[]}`))
+		})
+		c := newAccessGraphTestClient(t, h)
+
+		query := "user:alice"
+		start := time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC)
+		end := time.Date(2026, 4, 27, 0, 0, 0, 0, time.UTC)
+		_, _, err := fetchAllLogs(context.Background(), c, accessgraph.ExecuteLogsQueryV1Params{
+			Query:     &query,
+			StartTime: &start,
+			EndTime:   &end,
+		}, 10)
+		require.NoError(t, err)
+		require.Equal(t, "user:alice", got.Get("query"))
+		require.NotEmpty(t, got.Get("start_time"))
+		require.NotEmpty(t, got.Get("end_time"))
+	})
+}
+
+// TestWriteOutput covers the format dispatch for the writeOutput helper used
+// by every AG consumer command.
+func TestWriteOutput(t *testing.T) {
+	payload := map[string]any{"id": "abc", "title": "hello"}
+	textRender := func(out string) func(io.Writer) error {
+		return func(w io.Writer) error {
+			_, err := io.WriteString(w, out)
+			return err
+		}
+	}
+
+	t.Run("text invokes renderText and skips marshaling", func(t *testing.T) {
+		var buf strings.Builder
+		err := writeOutput(&buf, payload, teleport.Text, textRender("rendered text"))
+		require.NoError(t, err)
+		require.Equal(t, "rendered text", buf.String())
+	})
+
+	t.Run("json marshals payload and ignores renderText", func(t *testing.T) {
+		var buf strings.Builder
+		err := writeOutput(&buf, payload, teleport.JSON, func(io.Writer) error {
+			t.Fatal("renderText must not be called for json")
+			return nil
+		})
+		require.NoError(t, err)
+
+		var got map[string]any
+		require.NoError(t, json.Unmarshal([]byte(buf.String()), &got))
+		require.Equal(t, payload, got)
+	})
+
+	t.Run("yaml marshals payload and ignores renderText", func(t *testing.T) {
+		var buf strings.Builder
+		err := writeOutput(&buf, payload, teleport.YAML, func(io.Writer) error {
+			t.Fatal("renderText must not be called for yaml")
+			return nil
+		})
+		require.NoError(t, err)
+		require.Contains(t, buf.String(), "id: abc")
+		require.Contains(t, buf.String(), "title: hello")
+	})
+
+	t.Run("unknown format returns BadParameter", func(t *testing.T) {
+		var buf strings.Builder
+		err := writeOutput(&buf, payload, "xml", textRender("unused"))
+		require.True(t, trace.IsBadParameter(err), "want BadParameter, got %v", err)
+		require.Empty(t, buf.String())
+	})
+
+	t.Run("text propagates renderText error", func(t *testing.T) {
+		want := trace.BadParameter("render failed")
+		err := writeOutput(io.Discard, payload, teleport.Text, func(io.Writer) error {
+			return want
+		})
+		require.ErrorIs(t, err, want)
+	})
+}


### PR DESCRIPTION
Issue: https://github.com/gravitational/access-graph/issues/1933

This PR adds `tool/tctl/common/accessgraph/utils.go` — a small file of shared helpers — and its unit tests, in support of the upcoming `tctl` Access Graph (AG) commands. It is the second of four stacked PRs delivering the foundation for those commands; the PRs can be reviewed independently and are split to keep each diff focused:

| #   | PR                                                             | What it does                                                                  |
| --- | -------------------------------------------------------------- | ----------------------------------------------------------------------------- |
| 1   | [Client](https://github.com/gravitational/teleport/pull/66724) | Hooks up the Access Graph client to `tctl`.                                   |
| 2   | **Utils (this PR)**                                            | Shared utilities used by a number of upcoming `tctl` AG-based commands.       |
| 3   | [Detections list](https://github.com/gravitational/teleport/pull/66885)                              | `tctl detections ls` — list security detections with filters and time window. |
| 4   | Detections get (coming soon)                                | `tctl detections get <id>` — fetch a single detection along with its events.  |

## What changed

The following files have been added in this PR:

1. `tool/tctl/common/accessgraph/utils.go`: a kingpin `Value` and parsers for `--from`/`--to` time-range flags (`timeValue`, `parseTimeFilterValue`, `parseRelativeDuration`); a paginating log fetcher (`fetchAllLogs`) with a configurable page cap (`fetchAllLogsMaxPages`); and small DSL/string helpers (`dslClause`, `strPtrToStr`).
2. `tool/tctl/common/accessgraph/utils_test.go`: unit-test coverage for each helper, including an `httptest` server pass that exercises `fetchAllLogs`'s cursor walk, error short-circuit, and page-cap truncation behaviour.

## Why

This is part of the work related to [access-graph#1933](https://github.com/gravitational/access-graph/issues/1933), which is focused on adding some tctl commands that talk directly to Access Graph through the web proxy. This PR adds the small pieces that several of the upcoming commands will share, so each consumer PR can stay focused on its own command wiring rather than re-deriving the same parsing/pagination/quoting code.

A few notes on the helpers worth flagging:

- **`fetchAllLogs`.** Used by some commands (eg: `detections`, `access review`, `investigate`, ...) to walk the cursor returned by `ExecuteLogsQueryV1`. Centralising it here keeps the pagination contract — including the configurable page cap and the `truncated bool` signal on cap-hit — in one place.
- **`dslClause`.** Used by the same upcoming commands to build `field:value` clauses for the logs query. Centralising it ensures every command quotes values the same way. The DSL parser itself lives in the access-graph repo (separate from this one).

Changelog: None.

## Manual Test Plan

### Test Environment

- Local dev cluster (current branch for `teleport` + local Access Graph).
- Cloud tenant (master branch for `teleport` + hosted Access Graph) reached via the consumer-commands tip of this stack.

### Test Cases

- [x] `go build ./tool/tctl/common/accessgraph/...` exits 0.
- [x] `go test ./tool/tctl/common/accessgraph/...` passes.
- [x] `golangci-lint run ./tool/tctl/common/accessgraph/...` reports 0 issues.
- [x] `make full` and `make full-ent` succeed.
- [x] Exercise downstream `tctl` Access Graph subcommands (e.g. `tctl detections ls`) and confirm a successful response / expected errors.