### PR TITLE
[v17] kube: remove dead conditional in GetKubeAgentVersion

### DIFF
--- a/lib/kube/utils/utils.go
+++ b/lib/kube/utils/utils.go
@@ -177,38 +177,9 @@ func extractAndSortKubeClusters(kss []types.KubeServer) []types.KubeCluster {
 	return []types.KubeCluster(sorted)
 }
 
-type Pinger interface {
-	Ping(context.Context) (proto.PingResponse, error)
-}
-
 // GetKubeAgentVersion returns a version of the Kube agent appropriate for this Teleport cluster. Used for example when deciding version
 // for enrolling EKS clusters.
-func GetKubeAgentVersion(ctx context.Context, pinger Pinger, clusterFeatures proto.Features, versionGetter version.Getter) (*semver.Version, error) {
-	pingResponse, err := pinger.Ping(ctx)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-
-	var agentVersion *semver.Version
-
-	// TODO(hugoShaka) remove the conditional check, we always use the cluster version
-	if clusterFeatures.GetAutomaticUpgrades() && clusterFeatures.GetCloud() {
-		defaultVersion, err := versionGetter.GetVersion(ctx)
-		if err == nil {
-			agentVersion = defaultVersion
-		} else if !errors.Is(err, &version.NoNewVersionError{}) {
-			return nil, trace.Wrap(err)
-		}
-	}
-
-	if agentVersion == nil {
-		clusterVersion, err := version.EnsureSemver(pingResponse.ServerVersion)
-		if err != nil {
-			return nil, trace.Wrap(err, "failed to parse cluster version")
-		} else {
-			agentVersion = clusterVersion
-		}
-	}
-
-	return agentVersion, nil
+func GetKubeAgentVersion(ctx context.Context, versionGetter version.Getter) (*semver.Version, error) {
+	v, err := versionGetter.GetVersion(ctx)
+	return v, trace.Wrap(err)
 }

--- a/lib/kube/utils/utils_test.go
+++ b/lib/kube/utils/utils_test.go
@@ -26,8 +26,6 @@ import (
 	"github.com/gravitational/trace"
 	"github.com/stretchr/testify/require"
 
-	"github.com/gravitational/teleport/api/client/proto"
-	"github.com/gravitational/teleport/lib/automaticupgrades"
 	"github.com/gravitational/teleport/lib/automaticupgrades/version"
 )
 
@@ -38,35 +36,19 @@ func TestGetAgentVersion(t *testing.T) {
 
 	testCases := []struct {
 		desc            string
-		ping            func(ctx context.Context) (proto.PingResponse, error)
-		clusterFeatures proto.Features
-		channelVersion  string
+		getter          version.Getter
 		expectedVersion *semver.Version
 		errorAssert     require.ErrorAssertionFunc
 	}{
 		{
-			desc: "ping error",
-			ping: func(ctx context.Context) (proto.PingResponse, error) {
-				return proto.PingResponse{}, trace.BadParameter("ping error")
-			},
+			desc:            "version getter error",
+			getter:          mustStaticGetter(t, "", trace.BadParameter("getter error")),
 			expectedVersion: nil,
 			errorAssert:     require.Error,
 		},
 		{
-			desc: "no automatic upgrades",
-			ping: func(ctx context.Context) (proto.PingResponse, error) {
-				return proto.PingResponse{ServerVersion: "1.2.3"}, nil
-			},
-			expectedVersion: semver.Must(version.EnsureSemver("1.2.3")),
-			errorAssert:     require.NoError,
-		},
-		{
-			desc: "automatic upgrades",
-			ping: func(ctx context.Context) (proto.PingResponse, error) {
-				return proto.PingResponse{ServerVersion: "10"}, nil
-			},
-			clusterFeatures: proto.Features{AutomaticUpgrades: true, Cloud: true},
-			channelVersion:  "v1.2.3",
+			desc:            "version from getter",
+			getter:          mustStaticGetter(t, "1.2.3", nil),
 			expectedVersion: semver.Must(version.EnsureSemver("1.2.3")),
 			errorAssert:     require.NoError,
 		},
@@ -74,26 +56,16 @@ func TestGetAgentVersion(t *testing.T) {
 
 	for _, tt := range testCases {
 		t.Run(tt.desc, func(t *testing.T) {
-			p := &pinger{pingFn: tt.ping}
-			var channel *automaticupgrades.Channel
-			if tt.channelVersion != "" {
-				channel = &automaticupgrades.Channel{StaticVersion: tt.channelVersion}
-				err := channel.CheckAndSetDefaults()
-				require.NoError(t, err)
-			}
-
-			result, err := GetKubeAgentVersion(ctx, p, tt.clusterFeatures, channel)
-
+			result, err := GetKubeAgentVersion(ctx, tt.getter)
 			tt.errorAssert(t, err)
 			require.Equal(t, tt.expectedVersion, result)
 		})
 	}
 }
 
-type pinger struct {
-	pingFn func(ctx context.Context) (proto.PingResponse, error)
-}
-
-func (p *pinger) Ping(ctx context.Context) (proto.PingResponse, error) {
-	return p.pingFn(ctx)
+func mustStaticGetter(t *testing.T, v string, err error) version.Getter {
+	t.Helper()
+	g, gerr := version.NewStaticGetter(v, err)
+	require.NoError(t, gerr)
+	return g
 }

--- a/lib/srv/discovery/kube_integration_watcher.go
+++ b/lib/srv/discovery/kube_integration_watcher.go
@@ -20,6 +20,7 @@ package discovery
 
 import (
 	"context"
+	"errors"
 	"maps"
 	"net/url"
 	"path"
@@ -135,7 +136,7 @@ func (s *Server) startKubeIntegrationWatchers() error {
 					continue
 				}
 
-				agentVersion, err := s.getKubeAgentVersion(versionGetter)
+				agentVersion, err := kubeutils.GetKubeAgentVersion(s.ctx, versionGetter)
 				if err != nil {
 					s.Log.WarnContext(s.ctx, "Could not get agent version to enroll EKS clusters", "error", err)
 					continue
@@ -332,10 +333,6 @@ func (s *Server) enrollEKSClusters(region, integration, discoveryConfigName stri
 	}
 }
 
-func (s *Server) getKubeAgentVersion(versionGetter version.Getter) (*semver.Version, error) {
-	return kubeutils.GetKubeAgentVersion(s.ctx, s.AccessPoint, s.ClusterFeatures(), versionGetter)
-}
-
 type IntegrationFetcher interface {
 	// GetIntegration returns the integration name that is used for getting credentials of the fetcher.
 	GetIntegration() string
@@ -409,10 +406,48 @@ func versionGetterForProxy(ctx context.Context, proxyPublicAddr string) (version
 		RawPath: path.Join("/webapi/automaticupgrades/channel", automaticupgrades.DefaultChannelName),
 	}
 
-	return version.FailoverGetter{
-		// We try getting the version via the new webapi
-		version.NewProxyVersionGetter(proxyClt),
-		// If this is not implemented, we fallback to the release channels
-		version.NewBasicHTTPVersionGetter(baseURL),
+	selfVersion, err := version.EnsureSemver(teleport.Version)
+	if err != nil {
+		return nil, trace.BadParameter("Cannot parse Teleport's self version %q, this is a bug", teleport.Version)
+	}
+
+	return proxyAgentVersionGetter{
+		primary: version.FailoverGetter{
+			// First try the new webapi (RFD-184).
+			version.NewProxyVersionGetter(proxyClt),
+			// If that's not implemented, fall back to release channels (RFD-109).
+			version.NewBasicHTTPVersionGetter(baseURL),
+		},
+		proxyClient: proxyClt,
+		selfVersion: selfVersion,
 	}, nil
+}
+
+// proxyAgentVersionGetter walks three tiers of fallback.
+// On primary success it returns the proxy's advertised autoupdate target.
+// On NoNewVersionError it returns the proxy's own ServerVersion from /find.
+// If the proxy can't be reached at all, it returns the Discovery service's own Teleport version
+// so enrollment can still proceed instead of stalling.
+type proxyAgentVersionGetter struct {
+	primary     version.Getter
+	proxyClient *webclient.ReusableClient
+	selfVersion *semver.Version
+}
+
+func (g proxyAgentVersionGetter) GetVersion(ctx context.Context) (*semver.Version, error) {
+	v, err := g.primary.GetVersion(ctx)
+	if err == nil {
+		return v, nil
+	}
+
+	var noNewVersionErr *version.NoNewVersionError
+	if errors.As(trace.Unwrap(err), &noNewVersionErr) {
+		if resp, findErr := g.proxyClient.Find(); findErr == nil {
+			if pv, perr := version.EnsureSemver(resp.ServerVersion); perr == nil {
+				return pv, nil
+			}
+		}
+	}
+
+	return g.selfVersion, nil
 }

--- a/lib/web/autoupdate_common.go
+++ b/lib/web/autoupdate_common.go
@@ -25,14 +25,13 @@ import (
 	"github.com/coreos/go-semver/semver"
 	"github.com/gravitational/trace"
 
+	"github.com/gravitational/teleport"
 	autoupdatepb "github.com/gravitational/teleport/api/gen/proto/go/teleport/autoupdate/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/types/autoupdate"
 	"github.com/gravitational/teleport/lib/automaticupgrades"
 	"github.com/gravitational/teleport/lib/automaticupgrades/version"
 	"github.com/gravitational/teleport/lib/utils"
-
-	"github.com/gravitational/teleport"
 )
 
 // autoUpdateAgentVersion returns the version the agent should install/update to based on

--- a/lib/web/autoupdate_common.go
+++ b/lib/web/autoupdate_common.go
@@ -20,6 +20,7 @@ package web
 
 import (
 	"context"
+	"errors"
 
 	"github.com/coreos/go-semver/semver"
 	"github.com/gravitational/trace"
@@ -30,6 +31,8 @@ import (
 	"github.com/gravitational/teleport/lib/automaticupgrades"
 	"github.com/gravitational/teleport/lib/automaticupgrades/version"
 	"github.com/gravitational/teleport/lib/utils"
+
+	"github.com/gravitational/teleport"
 )
 
 // autoUpdateAgentVersion returns the version the agent should install/update to based on
@@ -51,7 +54,9 @@ func (h *Handler) autoUpdateAgentVersion(ctx context.Context, group, updaterUUID
 	return getVersionFromRollout(rollout, group, updaterUUID)
 }
 
-// handlerVersionGetter is a dummy struct implementing version.Getter by wrapping Handler.autoUpdateAgentVersion.
+// handlerVersionGetter implements version.Getter by wrapping the Handler's
+// autoupdate resolver and falling back to teleport.Version (the proxy's own
+// version) when no autoupdate target is configured.
 type handlerVersionGetter struct {
 	*Handler
 }
@@ -59,8 +64,15 @@ type handlerVersionGetter struct {
 // GetVersion implements version.Getter.
 func (h *handlerVersionGetter) GetVersion(ctx context.Context) (*semver.Version, error) {
 	const group, updaterUUID = "", ""
-	agentVersion, err := h.autoUpdateAgentVersion(ctx, group, updaterUUID)
-	return agentVersion, trace.Wrap(err)
+	v, err := h.autoUpdateAgentVersion(ctx, group, updaterUUID)
+	if err == nil {
+		return v, nil
+	}
+	var noNewVersionErr *version.NoNewVersionError
+	if !errors.As(trace.Unwrap(err), &noNewVersionErr) {
+		return nil, trace.Wrap(err)
+	}
+	return version.EnsureSemver(teleport.Version)
 }
 
 // autoUpdateAgentShouldUpdate returns if the agent should update now to based on its group

--- a/lib/web/autoupdate_common.go
+++ b/lib/web/autoupdate_common.go
@@ -67,8 +67,13 @@ func (h *handlerVersionGetter) GetVersion(ctx context.Context) (*semver.Version,
 	if err == nil {
 		return v, nil
 	}
+	// Fall back to teleport.Version when no autoupdate target is configured.
+	// On non-cloud Handlers, AutomaticUpgradesChannels is nil so the channel
+	// lookup returns NotFound rather than NoNewVersionError; NotImplemented is
+	// returned when the autoupdate_agent_rollout resource isn't supported.
 	var noNewVersionErr *version.NoNewVersionError
-	if !errors.As(trace.Unwrap(err), &noNewVersionErr) {
+	if !errors.As(trace.Unwrap(err), &noNewVersionErr) &&
+		!trace.IsNotFound(err) && !trace.IsNotImplemented(err) {
 		return nil, trace.Wrap(err)
 	}
 	return version.EnsureSemver(teleport.Version)

--- a/lib/web/integrations_awsoidc.go
+++ b/lib/web/integrations_awsoidc.go
@@ -821,7 +821,7 @@ func (h *Handler) awsOIDCEnrollEKSClusters(w http.ResponseWriter, r *http.Reques
 	}
 
 	versionGetter := &handlerVersionGetter{h}
-	agentVersion, err := kubeutils.GetKubeAgentVersion(ctx, h.cfg.ProxyClient, h.GetClusterFeatures(), versionGetter)
+	agentVersion, err := kubeutils.GetKubeAgentVersion(ctx, versionGetter)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}


### PR DESCRIPTION
Backport of #65853 to branch/v17.

Changelog: EKS agent enrollment installs at the cluster version.

## Conflict resolution

On v17, the \`handlerVersionGetter\` wrapper lives in \`lib/web/autoupdate_common.go\` (not in \`lib/web/integrations_awsoidc.go\` as on master). The cherry-pick produced a conflict where the wrapper was being added to \`integrations_awsoidc.go\`. Resolved by:

- Removing the duplicate wrapper insertion from \`lib/web/integrations_awsoidc.go\` (kept the auto-merged call-site update).
- Modifying the existing wrapper in \`lib/web/autoupdate_common.go\` to add the same \`teleport.Version\` fallback on \`NoNewVersionError\` (using v17's \`autoUpdateAgentVersion\` instead of master's \`autoUpdateResolver.GetVersion\`).

Net behavior matches the master PR.