### PR TITLE
Always populate AllowedResourceIDs on decoded Identity

### DIFF
--- a/lib/sshca/identity.go
+++ b/lib/sshca/identity.go
@@ -531,12 +531,19 @@ func DecodeIdentity(cert *ssh.Certificate) (*Identity, error) {
 		allowedResourceAccessIDs = resourceAccessIDs
 	}
 	if len(allowedResourceAccessIDs) > 0 {
-		// Prefer new extension when present, old extension is redundant
-		// (exists for backward-compat with older agents/proxies).
+		// Prefer new extension when present.
 		ident.AllowedResourceAccessIDs = allowedResourceAccessIDs
+		// Populate AllowedResourceIDs with any present unconstrained resources,
+		// so any path re-encoding this identity persists the resourceIDs
+		// to the legacy extension instead of adding a sentinel.
+		//
+		// TODO(kiosion): DELETE in 20.0.0
+		ident.AllowedResourceIDs, _ = types.UnwrapResourceAccessIDs(allowedResourceAccessIDs)
 	} else if len(allowedResourceIDs) > 0 {
-		// Fallback for certs from older auth servers that don't write the new extension.
+		// Fallback for certs from older Auths that don't write the new extension.
 		ident.AllowedResourceAccessIDs = types.CombineAsResourceAccessIDs(allowedResourceIDs, nil)
+		//nolint:staticcheck // TODO(kiosion): deprecated, to be removed in v20
+		ident.AllowedResourceIDs = allowedResourceIDs
 	}
 
 	ident.ConnectionDiagnosticID = takeValue(teleport.CertExtensionConnectionDiagnosticID)

--- a/lib/sshca/identity_test.go
+++ b/lib/sshca/identity_test.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/crypto/ssh"
 	"google.golang.org/protobuf/testing/protocmp"
@@ -158,4 +159,95 @@ func TestIdentityConversion(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Empty(t, cmp.Diff(ident, ident2, protocmp.Transform()))
+}
+
+// TestAllowedResources_SSHEncodeDecode verifies that AllowedResourceIDs and
+// AllowedResourceAccessIDs are populated correctly after an SSH cert's
+// encode-decode cycle across all resource mix permutations.
+func TestAllowedResources_SSHEncodeDecode(t *testing.T) {
+	plainNode := types.ResourceID{ClusterName: "cluster", Kind: types.KindNode, Name: "prod-node"}
+	plainDB := types.ResourceID{ClusterName: "cluster", Kind: types.KindDatabase, Name: "prod-db"}
+	constrainedApp := types.ResourceAccessID{
+		Id: types.ResourceID{ClusterName: "cluster", Kind: types.KindApp, Name: "aws-console"},
+		Constraints: &types.ResourceConstraints{
+			Version: types.V1,
+			Details: &types.ResourceConstraints_AwsConsole{
+				AwsConsole: &types.AWSConsoleResourceConstraints{
+					RoleArns: []string{"arn:aws:iam::123456789012:role/DevOps"},
+				},
+			},
+		},
+	}
+
+	tcs := []struct {
+		name                         string
+		allowedResourceIDs           []types.ResourceID
+		allowedResourceAccessIDs     []types.ResourceAccessID
+		wantAllowedResourceIDs       []types.ResourceID
+		wantAllowedResourceAccessIDs []types.ResourceAccessID
+	}{
+		{
+			name:                         "plain resources only (new auth cert)",
+			allowedResourceIDs:           []types.ResourceID{plainNode, plainDB},
+			allowedResourceAccessIDs:     types.ResourceIDsToResourceAccessIDs([]types.ResourceID{plainNode, plainDB}),
+			wantAllowedResourceIDs:       []types.ResourceID{plainNode, plainDB},
+			wantAllowedResourceAccessIDs: types.ResourceIDsToResourceAccessIDs([]types.ResourceID{plainNode, plainDB}),
+		},
+		{
+			name:                         "constrained resources only (new auth cert)",
+			allowedResourceIDs:           nil,
+			allowedResourceAccessIDs:     []types.ResourceAccessID{constrainedApp},
+			wantAllowedResourceIDs:       nil,
+			wantAllowedResourceAccessIDs: []types.ResourceAccessID{constrainedApp},
+		},
+		{
+			name:                     "mixed plain and constrained (new auth cert)",
+			allowedResourceIDs:       []types.ResourceID{plainNode},
+			allowedResourceAccessIDs: append(types.ResourceIDsToResourceAccessIDs([]types.ResourceID{plainNode}), constrainedApp),
+			wantAllowedResourceIDs:   []types.ResourceID{plainNode},
+			wantAllowedResourceAccessIDs: append(
+				types.ResourceIDsToResourceAccessIDs([]types.ResourceID{plainNode}),
+				constrainedApp,
+			),
+		},
+		{
+			name:                         "old auth cert (only old extension)",
+			allowedResourceIDs:           []types.ResourceID{plainNode, plainDB},
+			allowedResourceAccessIDs:     nil,
+			wantAllowedResourceIDs:       []types.ResourceID{plainNode, plainDB},
+			wantAllowedResourceAccessIDs: types.ResourceIDsToResourceAccessIDs([]types.ResourceID{plainNode, plainDB}),
+		},
+	}
+
+	for _, tt := range tcs {
+		t.Run(tt.name, func(t *testing.T) {
+			ident := &Identity{
+				ValidBefore: uint64(time.Now().Add(time.Hour).Unix()),
+				CertType:    ssh.UserCert,
+				Username:    "test-user",
+				Roles:       []string{"access"},
+				//nolint:staticcheck // testing deprecated field
+				AllowedResourceIDs:       tt.allowedResourceIDs,
+				AllowedResourceAccessIDs: tt.allowedResourceAccessIDs,
+			}
+
+			cert, err := ident.Encode(constants.CertificateFormatStandard)
+			require.NoError(t, err)
+
+			decoded, err := DecodeIdentity(cert)
+			require.NoError(t, err)
+
+			assert.ElementsMatch(t, tt.wantAllowedResourceAccessIDs, decoded.AllowedResourceAccessIDs,
+				"AllowedResourceAccessIDs mismatch")
+			//nolint:staticcheck // testing deprecated field
+			assert.ElementsMatch(t, tt.wantAllowedResourceIDs, decoded.AllowedResourceIDs,
+				"AllowedResourceIDs mismatch")
+
+			//nolint:staticcheck // testing deprecated field
+			for _, rid := range decoded.AllowedResourceIDs {
+				assert.False(t, types.IsSentinelResourceID(rid),
+					"sentinel value not expected in decoded AllowedResourceIDs")
+			}
+		})
+	}
 }

--- a/lib/tlsca/ca.go
+++ b/lib/tlsca/ca.go
@@ -1476,12 +1476,20 @@ func FromSubject(subject pkix.Name, expires time.Time) (*Identity, error) {
 	}
 
 	if len(allowedResourceAccessIDs) > 0 {
-		// Prefer new extension when present, old extension is redundant
-		// (exists for backward-compat with older agents/proxies).
+		// Prefer new extension when present.
 		id.AllowedResourceAccessIDs = allowedResourceAccessIDs
+		// Populate AllowedResourceIDs with any present unconstrained resources,
+		// so any path re-encoding this identity (e.g., database proxy CSR signing)
+		// persists the resourceIDs to the legacy extension, instead of adding a
+		// sentinel.
+		//
+		// TODO(kiosion): DELETE in 20.0.0
+		id.AllowedResourceIDs, _ = types.UnwrapResourceAccessIDs(allowedResourceAccessIDs)
 	} else if len(allowedResourceIDs) > 0 {
-		// Fallback for certs from older auth servers that don't write the new extension.
+		// Fallback for certs from older Auths that don't write the new extension.
 		id.AllowedResourceAccessIDs = types.CombineAsResourceAccessIDs(allowedResourceIDs, nil)
+		//nolint:staticcheck // TODO(kiosion): deprecated, to be removed in v20
+		id.AllowedResourceIDs = allowedResourceIDs
 	}
 
 	if err := id.CheckAndSetDefaults(); err != nil {

--- a/lib/tlsca/ca_test.go
+++ b/lib/tlsca/ca_test.go
@@ -496,7 +496,8 @@ func TestIdentity_ToFromSubject(t *testing.T) {
 
 // TestAllowedResources_EncodeDecodeCycle verifies that AllowedResourceIDs and
 // AllowedResourceAccessIDs survive encode-decode-re-encode cycles correctly
-// across all resource mix permutations.
+// across all resource mix permutations. The re-encode step simulates the
+// database proxy CSR signing path.
 func TestAllowedResources_EncodeDecodeCycle(t *testing.T) {
 	plainNode := types.ResourceID{ClusterName: "cluster", Kind: types.KindNode, Name: "prod-node"}
 	plainDB := types.ResourceID{ClusterName: "cluster", Kind: types.KindDatabase, Name: "prod-db"}
@@ -511,6 +512,7 @@ func TestAllowedResources_EncodeDecodeCycle(t *testing.T) {
 			},
 		},
 	}
+	sentinel := types.CreateSentinelResourceID()
 
 	tests := []struct {
 		name string
@@ -520,8 +522,8 @@ func TestAllowedResources_EncodeDecodeCycle(t *testing.T) {
 		// expected state after decode
 		wantAllowedResourceIDs       []types.ResourceID
 		wantAllowedResourceAccessIDs []types.ResourceAccessID
-		// expected state after decode-re-encode-decode roundtrip
-		wantRoundtripSameAsFirst bool
+		// expected contents of the legacy extension after re-encode
+		wantLegacyExtension []types.ResourceID
 	}{
 		{
 			name:                         "plain resources only (new auth cert)",
@@ -529,15 +531,15 @@ func TestAllowedResources_EncodeDecodeCycle(t *testing.T) {
 			allowedResourceAccessIDs:     types.ResourceIDsToResourceAccessIDs([]types.ResourceID{plainNode, plainDB}),
 			wantAllowedResourceIDs:       []types.ResourceID{plainNode, plainDB},
 			wantAllowedResourceAccessIDs: types.ResourceIDsToResourceAccessIDs([]types.ResourceID{plainNode, plainDB}),
-			wantRoundtripSameAsFirst:     true,
+			wantLegacyExtension:          []types.ResourceID{plainNode, plainDB},
 		},
 		{
 			name:                         "constrained resources only (new auth cert)",
-			allowedResourceIDs:           nil, // triggers sentinel in old extension
+			allowedResourceIDs:           nil,
 			allowedResourceAccessIDs:     []types.ResourceAccessID{constrainedApp},
-			wantAllowedResourceIDs:       nil, // no plain resources to unwrap
+			wantAllowedResourceIDs:       nil,
 			wantAllowedResourceAccessIDs: []types.ResourceAccessID{constrainedApp},
-			wantRoundtripSameAsFirst:     true,
+			wantLegacyExtension:          []types.ResourceID{sentinel},
 		},
 		{
 			name:                     "mixed plain and constrained (new auth cert)",
@@ -548,28 +550,29 @@ func TestAllowedResources_EncodeDecodeCycle(t *testing.T) {
 				types.ResourceIDsToResourceAccessIDs([]types.ResourceID{plainNode}),
 				constrainedApp,
 			),
-			wantRoundtripSameAsFirst: true,
+			wantLegacyExtension: []types.ResourceID{plainNode},
 		},
 		{
 			name:                         "old auth cert (only old extension, no new extension)",
 			allowedResourceIDs:           []types.ResourceID{plainNode, plainDB},
-			allowedResourceAccessIDs:     nil, // old auth doesn't write new extension
+			allowedResourceAccessIDs:     nil,
 			wantAllowedResourceIDs:       []types.ResourceID{plainNode, plainDB},
 			wantAllowedResourceAccessIDs: types.ResourceIDsToResourceAccessIDs([]types.ResourceID{plainNode, plainDB}),
-			wantRoundtripSameAsFirst:     true,
+			wantLegacyExtension:          []types.ResourceID{plainNode, plainDB},
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			identity := &Identity{
-				Username:                 "test-user",
-				Groups:                   []string{"access"},
+				Username: "test-user",
+				Groups:   []string{"access"},
+				//nolint:staticcheck // testing deprecated field
 				AllowedResourceIDs:       tt.allowedResourceIDs,
 				AllowedResourceAccessIDs: tt.allowedResourceAccessIDs,
 			}
 
-			// Encode → decode
+			// Encode then decode
 			subj, err := identity.Subject()
 			require.NoError(t, err)
 			subj.Names = append(subj.Names, subj.ExtraNames...)
@@ -578,38 +581,14 @@ func TestAllowedResources_EncodeDecodeCycle(t *testing.T) {
 			decoded, err := FromSubject(subj, time.Time{})
 			require.NoError(t, err)
 
-			require.ElementsMatch(t, tt.wantAllowedResourceAccessIDs, decoded.AllowedResourceAccessIDs,
-				"AllowedResourceAccessIDs mismatch after first decode")
+			assert.ElementsMatch(t, tt.wantAllowedResourceAccessIDs, decoded.AllowedResourceAccessIDs)
 			//nolint:staticcheck // testing deprecated field
-			require.ElementsMatch(t, tt.wantAllowedResourceIDs, decoded.AllowedResourceIDs,
-				"AllowedResourceIDs mismatch after first decode")
+			assert.ElementsMatch(t, tt.wantAllowedResourceIDs, decoded.AllowedResourceIDs)
 
-			if !tt.wantRoundtripSameAsFirst {
-				return
-			}
-
-			// re-encode then decode to simulate db csr signing path
+			// Re-encode, verify legacy extension, decode again
 			subj2, err := decoded.Subject()
 			require.NoError(t, err)
-
-			// verify the raw re-encoded subject's legacy extension directly.
-			// This is what an old agent would parse; if it contains
-			// the sentinel instead of real IDs, the agent denies access.
-			// Only check when plain resources are expected; for constrained-
-			// resources-only requests, the sentinel value is expected.
-			if len(tt.wantAllowedResourceIDs) > 0 {
-				for _, name := range subj2.ExtraNames {
-					if !name.Type.Equal(AllowedResourcesASN1ExtensionOID) {
-						continue
-					}
-					rawIDs, err := types.ResourceIDsFromString(name.Value.(string))
-					require.NoError(t, err)
-					for _, rid := range rawIDs {
-						require.False(t, types.IsSentinelResourceID(rid),
-							"sentinel value not appear expected in re-encoded legacy extension")
-					}
-				}
-			}
+			assert.ElementsMatch(t, tt.wantLegacyExtension, legacyExtensionIDs(t, subj2))
 
 			subj2.Names = append(subj2.Names, subj2.ExtraNames...)
 			subj2.ExtraNames = nil
@@ -617,13 +596,26 @@ func TestAllowedResources_EncodeDecodeCycle(t *testing.T) {
 			roundtripped, err := FromSubject(subj2, time.Time{})
 			require.NoError(t, err)
 
-			require.ElementsMatch(t, decoded.AllowedResourceAccessIDs, roundtripped.AllowedResourceAccessIDs,
-				"AllowedResourceAccessIDs changed after re-encode roundtrip")
+			assert.ElementsMatch(t, decoded.AllowedResourceAccessIDs, roundtripped.AllowedResourceAccessIDs)
 			//nolint:staticcheck // testing deprecated field
-			require.ElementsMatch(t, decoded.AllowedResourceIDs, roundtripped.AllowedResourceIDs,
-				"AllowedResourceIDs changed after re-encode roundtrip")
+			assert.ElementsMatch(t, decoded.AllowedResourceIDs, roundtripped.AllowedResourceIDs)
 		})
 	}
+}
+
+// legacyExtensionIDs extracts ResourceIDs from the legacy AllowedResources
+// extension (OID 1.3.9999.2.10) in a pkix.Name subject. This is what an
+// old agent would parse from the cert.
+func legacyExtensionIDs(t *testing.T, subj pkix.Name) []types.ResourceID {
+	t.Helper()
+	for _, name := range subj.ExtraNames {
+		if name.Type.Equal(AllowedResourcesASN1ExtensionOID) {
+			ids, err := types.ResourceIDsFromString(name.Value.(string))
+			require.NoError(t, err)
+			return ids
+		}
+	}
+	return nil
 }
 
 func TestGCPExtensions(t *testing.T) {

--- a/lib/tlsca/ca_test.go
+++ b/lib/tlsca/ca_test.go
@@ -494,6 +494,138 @@ func TestIdentity_ToFromSubject(t *testing.T) {
 	}
 }
 
+// TestAllowedResources_EncodeDecodeCycle verifies that AllowedResourceIDs and
+// AllowedResourceAccessIDs survive encode-decode-re-encode cycles correctly
+// across all resource mix permutations.
+func TestAllowedResources_EncodeDecodeCycle(t *testing.T) {
+	plainNode := types.ResourceID{ClusterName: "cluster", Kind: types.KindNode, Name: "prod-node"}
+	plainDB := types.ResourceID{ClusterName: "cluster", Kind: types.KindDatabase, Name: "prod-db"}
+	constrainedApp := types.ResourceAccessID{
+		Id: types.ResourceID{ClusterName: "cluster", Kind: types.KindApp, Name: "aws-console"},
+		Constraints: &types.ResourceConstraints{
+			Version: types.V1,
+			Details: &types.ResourceConstraints_AwsConsole{
+				AwsConsole: &types.AWSConsoleResourceConstraints{
+					RoleArns: []string{"arn:aws:iam::123456789012:role/DevOps"},
+				},
+			},
+		},
+	}
+
+	tests := []struct {
+		name string
+		// identity fields set before first encode
+		allowedResourceIDs       []types.ResourceID
+		allowedResourceAccessIDs []types.ResourceAccessID
+		// expected state after decode
+		wantAllowedResourceIDs       []types.ResourceID
+		wantAllowedResourceAccessIDs []types.ResourceAccessID
+		// expected state after decode-re-encode-decode roundtrip
+		wantRoundtripSameAsFirst bool
+	}{
+		{
+			name:                         "plain resources only (new auth cert)",
+			allowedResourceIDs:           []types.ResourceID{plainNode, plainDB},
+			allowedResourceAccessIDs:     types.ResourceIDsToResourceAccessIDs([]types.ResourceID{plainNode, plainDB}),
+			wantAllowedResourceIDs:       []types.ResourceID{plainNode, plainDB},
+			wantAllowedResourceAccessIDs: types.ResourceIDsToResourceAccessIDs([]types.ResourceID{plainNode, plainDB}),
+			wantRoundtripSameAsFirst:     true,
+		},
+		{
+			name:                         "constrained resources only (new auth cert)",
+			allowedResourceIDs:           nil, // triggers sentinel in old extension
+			allowedResourceAccessIDs:     []types.ResourceAccessID{constrainedApp},
+			wantAllowedResourceIDs:       nil, // no plain resources to unwrap
+			wantAllowedResourceAccessIDs: []types.ResourceAccessID{constrainedApp},
+			wantRoundtripSameAsFirst:     true,
+		},
+		{
+			name:                     "mixed plain and constrained (new auth cert)",
+			allowedResourceIDs:       []types.ResourceID{plainNode},
+			allowedResourceAccessIDs: append(types.ResourceIDsToResourceAccessIDs([]types.ResourceID{plainNode}), constrainedApp),
+			wantAllowedResourceIDs:   []types.ResourceID{plainNode},
+			wantAllowedResourceAccessIDs: append(
+				types.ResourceIDsToResourceAccessIDs([]types.ResourceID{plainNode}),
+				constrainedApp,
+			),
+			wantRoundtripSameAsFirst: true,
+		},
+		{
+			name:                         "old auth cert (only old extension, no new extension)",
+			allowedResourceIDs:           []types.ResourceID{plainNode, plainDB},
+			allowedResourceAccessIDs:     nil, // old auth doesn't write new extension
+			wantAllowedResourceIDs:       []types.ResourceID{plainNode, plainDB},
+			wantAllowedResourceAccessIDs: types.ResourceIDsToResourceAccessIDs([]types.ResourceID{plainNode, plainDB}),
+			wantRoundtripSameAsFirst:     true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			identity := &Identity{
+				Username:                 "test-user",
+				Groups:                   []string{"access"},
+				AllowedResourceIDs:       tt.allowedResourceIDs,
+				AllowedResourceAccessIDs: tt.allowedResourceAccessIDs,
+			}
+
+			// Encode → decode
+			subj, err := identity.Subject()
+			require.NoError(t, err)
+			subj.Names = append(subj.Names, subj.ExtraNames...)
+			subj.ExtraNames = nil
+
+			decoded, err := FromSubject(subj, time.Time{})
+			require.NoError(t, err)
+
+			require.ElementsMatch(t, tt.wantAllowedResourceAccessIDs, decoded.AllowedResourceAccessIDs,
+				"AllowedResourceAccessIDs mismatch after first decode")
+			//nolint:staticcheck // testing deprecated field
+			require.ElementsMatch(t, tt.wantAllowedResourceIDs, decoded.AllowedResourceIDs,
+				"AllowedResourceIDs mismatch after first decode")
+
+			if !tt.wantRoundtripSameAsFirst {
+				return
+			}
+
+			// re-encode then decode to simulate db csr signing path
+			subj2, err := decoded.Subject()
+			require.NoError(t, err)
+
+			// verify the raw re-encoded subject's legacy extension directly.
+			// This is what an old agent would parse; if it contains
+			// the sentinel instead of real IDs, the agent denies access.
+			// Only check when plain resources are expected; for constrained-
+			// resources-only requests, the sentinel value is expected.
+			if len(tt.wantAllowedResourceIDs) > 0 {
+				for _, name := range subj2.ExtraNames {
+					if !name.Type.Equal(AllowedResourcesASN1ExtensionOID) {
+						continue
+					}
+					rawIDs, err := types.ResourceIDsFromString(name.Value.(string))
+					require.NoError(t, err)
+					for _, rid := range rawIDs {
+						require.False(t, types.IsSentinelResourceID(rid),
+							"sentinel value not appear expected in re-encoded legacy extension")
+					}
+				}
+			}
+
+			subj2.Names = append(subj2.Names, subj2.ExtraNames...)
+			subj2.ExtraNames = nil
+
+			roundtripped, err := FromSubject(subj2, time.Time{})
+			require.NoError(t, err)
+
+			require.ElementsMatch(t, decoded.AllowedResourceAccessIDs, roundtripped.AllowedResourceAccessIDs,
+				"AllowedResourceAccessIDs changed after re-encode roundtrip")
+			//nolint:staticcheck // testing deprecated field
+			require.ElementsMatch(t, decoded.AllowedResourceIDs, roundtripped.AllowedResourceIDs,
+				"AllowedResourceIDs changed after re-encode roundtrip")
+		})
+	}
+}
+
 func TestGCPExtensions(t *testing.T) {
 	clock := clockwork.NewFakeClock()
 	ca, err := FromKeys([]byte(fixtures.TLSCACertPEM), []byte(fixtures.TLSCAKeyPEM))


### PR DESCRIPTION
## Context
Follow-up to #66556. That fix correctly populated AllowedResourceIDs on the Identity during initial cert generation ensuring the legacy cert extension contained any unconstrained ResourceIDs rather than a sentinel value. However, TLS and SSH cert decoders populated AllowedResourceAccessIDs but left AllowedResourceIDs nil. Any path decoding an identity and re-encoding via Subject() would result in the encoder adding a sentinel value into the legacy field and storing all resources under the new AllowedResourceAccessIDs field only.

This uniquely affected database access in mixed-version clusters, where the database server was older than auth and proxy. Unlike SSH nodes, apps, desktops, and Kube, which either receive the original cert directly or generate a fresh one via GenerateUserCerts, Database connections go through a CSR re-signing step between Proxy and the db agent. Proxy would decode user cert, build a CSR (Subject()), send it to Auth for signing (FromSubject() then Subject() again). This dropped AllowedResourceIDs, storing all under the new extension, so older database agents received the cert with only the sentinel in the legacy extension and, unaware of the new extension, denied access.

Fix by populating AllowedResourceIDs at decode time in both decoders via UnwrapResourceAccessIDs, ensuring and unconstrained resources persist across decode-re-encode cycles.

## Manual Test Plan
### Test Environment

| Scenario | Auth + Proxy version | Agent version     |
|----------|----------------------|-------------------|
| A        | This branch          | v18.7.0           |
| B        | This branch          | This branch       |

- Start Auth and Proxy built from this branch.
- Start each relevant resource agent from the version indicated.
- Create a user with `search_as_roles` granting access to request the target resource.
- For each resource test case, create a resource-based access request, approve it, assume it, then connect.

### Test Cases
- [x] SSH node: `tsh request create --resource /<cluster>/node/<uuid>`
  - [x] Scenario A: verify `tsh ssh user@host` succeeds for old agent
  - [x] Scenario B: verify `tsh ssh user@host` succeeds for new agent
- [x] Database: `tsh request create --resource /<cluster>/db/<name>`
  - [x] Scenario A: verify `tsh db connect <name> --db-user <uiser> --db-name <dbname>` succeeds for old agent
  - [x] Scenario B: verify `tsh db connect <name> --db-user <uiser> --db-name <dbname>` succeeds for new agent
- [x] App (non-AWS console): create resource request via web UI
  - [x] Scenario A: verify app launches
  - [x] Scenario B: verify app launches
- [x] App (MCP demo): create resource request via web UI
  - [x] Scenario A: verify connection succeeds via client
  - [x] Scenario B: verify connection succeeds via client
- [x] App (AWS console): create resource request for via web UI
  - [x] Scenario A: verify app launches
  - [x] Scenario B: verify app launches
- [x] Windows Desktop: create resource request via web UI
  - [x] Scenario A: verify connection succeeds
  - [x] Scenario B: verify connection succeeds
- [x] Kubernetes: `tsh request create --resource /<cluster>/kube_cluster/<name>`
  - [x] Scenario A: verify `tsh kube login` succeeds
  - [x] Scenario B: verify `tsh kube login` succeeds
- [x] For all scenarios, after assuming each request, verify `tsh status` shows the expected resource ID under "Allowed Resources".
- [x] Git: ~~verify connection succeeds when using Auth built from this branch, and v18.7.0 Proxy~~ not supported in Access Requests yet.

