### PR TITLE
[v18] [Web] Check app srv ver for constraint feature advertisement

### DIFF
--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -44,6 +44,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/coreos/go-semver/semver"
 	gogoproto "github.com/gogo/protobuf/proto"
 	"github.com/google/safetext/shsprintf"
 	"github.com/google/uuid"
@@ -65,6 +66,7 @@ import (
 	"github.com/gravitational/teleport/api/client/webclient"
 	"github.com/gravitational/teleport/api/constants"
 	apidefaults "github.com/gravitational/teleport/api/defaults"
+	componentfeaturesv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/componentfeatures/v1"
 	mfav1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/mfa/v1"
 	notificationsv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/notifications/v1"
 	summarizerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/summarizer/v1"
@@ -3497,7 +3499,7 @@ func (h *Handler) clusterUnifiedResourcesGet(w http.ResponseWriter, request *htt
 			// Compute end-to-end feature support for this app: only features that are supported by the AppServer *and*
 			// by all required cluster hops (Auth + Proxy), so clients can hide features that would fail somewhere
 			// along the request path.
-			appComponentFeatures := componentfeatures.Intersect(r.GetComponentFeatures(), clusterAuthProxyServerFeatures)
+			appComponentFeatures := appServerEffectiveFeatures(r, clusterAuthProxyServerFeatures)
 
 			app := ui.MakeApp(r.GetApp(), ui.MakeAppsConfig{
 				LocalClusterName:      h.auth.clusterName,
@@ -3544,6 +3546,26 @@ func (h *Handler) clusterUnifiedResourcesGet(w http.ResponseWriter, request *htt
 	}
 
 	return resp, nil
+}
+
+// appServerEffectiveFeatures computes the effective feature set for an app server,
+// intersected with cluster-wide auth/proxy features. App servers between v18.6.4 and
+// v18.7.2 advertise FeatureResourceConstraintsV1 but predate the constraint enforcement
+// code; for those versions, the advertisement is stripped before intersection so the
+// frontend doesn't show the constraints UI.
+//
+// TODO(kiosion): DELETE in 20.0.0
+func appServerEffectiveFeatures(appServer types.AppServer, clusterFeatures *componentfeaturesv1.ComponentFeatures) *componentfeaturesv1.ComponentFeatures {
+	appFeatures := appServer.GetComponentFeatures()
+	minVer, minVerErr := semver.NewVersion("18.7.3")
+	ver, verErr := semver.NewVersion(appServer.GetTeleportVersion())
+	if verErr == nil && minVerErr == nil && ver.LessThan(*minVer) && appFeatures != nil {
+		features := slices.DeleteFunc(slices.Clone(appFeatures.GetFeatures()), func(f componentfeaturesv1.ComponentFeatureID) bool {
+			return f == componentfeatures.FeatureResourceConstraintsV1.ToProto()
+		})
+		appFeatures = &componentfeaturesv1.ComponentFeatures{Features: features}
+	}
+	return componentfeatures.Intersect(appFeatures, clusterFeatures)
 }
 
 // clusterNodesGet returns a list of nodes for a given cluster site.

--- a/lib/web/apiserver_test.go
+++ b/lib/web/apiserver_test.go
@@ -85,6 +85,7 @@ import (
 	"github.com/gravitational/teleport/api/client/webclient"
 	"github.com/gravitational/teleport/api/constants"
 	apidefaults "github.com/gravitational/teleport/api/defaults"
+	componentfeaturesv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/componentfeatures/v1"
 	devicepb "github.com/gravitational/teleport/api/gen/proto/go/teleport/devicetrust/v1"
 	kubeproto "github.com/gravitational/teleport/api/gen/proto/go/teleport/kube/v1"
 	mfav1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/mfa/v1"
@@ -1423,6 +1424,38 @@ func TestUnifiedResourcesGet_AppComponentFeatures(t *testing.T) {
 	require.True(t, app.AWSConsole)
 
 	require.ElementsMatch(t, []int{int(feature1)}, app.SupportedFeatureIDs)
+}
+
+func Test_appServerEffectiveFeatures(t *testing.T) {
+	t.Parallel()
+	rcv1 := componentfeatures.FeatureResourceConstraintsV1
+	otherFeature := componentfeatures.FeatureID(9999)
+	clusterFeatures := componentfeatures.New(rcv1, otherFeature)
+	makeAppServer := func(t *testing.T, version string, features *componentfeaturesv1.ComponentFeatures) types.AppServer {
+		app, err := types.NewAppV3(types.Metadata{Name: "aws-app"}, types.AppSpecV3{URI: "https://console.aws.amazon.com", Cloud: "AWS"})
+		require.NoError(t, err)
+		srv, err := types.NewAppServerV3FromApp(app, "localhost", "host-1")
+		require.NoError(t, err)
+		srv.Spec.Version = version
+		srv.SetComponentFeatures(features)
+		return srv
+	}
+
+	t.Run("old app server has ResourceConstraintsV1 stripped", func(t *testing.T) {
+		srv := makeAppServer(t, "18.7.0", componentfeatures.New(rcv1, otherFeature))
+		result := appServerEffectiveFeatures(srv, clusterFeatures)
+		require.ElementsMatch(t, componentfeatures.New(otherFeature).GetFeatures(), result.GetFeatures())
+	})
+	t.Run("new app server keeps ResourceConstraintsV1", func(t *testing.T) {
+		srv := makeAppServer(t, "18.7.3", componentfeatures.New(rcv1, otherFeature))
+		result := appServerEffectiveFeatures(srv, clusterFeatures)
+		require.ElementsMatch(t, componentfeatures.New(rcv1, otherFeature).GetFeatures(), result.GetFeatures())
+	})
+	t.Run("nil features on old app server returns empty", func(t *testing.T) {
+		srv := makeAppServer(t, "18.6.4", nil)
+		result := appServerEffectiveFeatures(srv, clusterFeatures)
+		require.Empty(t, result.GetFeatures())
+	})
 }
 
 func TestUnifiedResourcesGet(t *testing.T) {


### PR DESCRIPTION
Backport #66849 to v18.

## Manual Test Plan
### Test Environment
- Auth and Proxy on this branch build.
- App server on v18.7.0 (pre-constraint parsing), serving an AWS Console app resource.

### Test Cases
- [x] In Web UI, validate that the constraints picker (role ARN selection) is not shown for the app served by the older app server when creating an access request.
- [x] Upgrade the app server to this branch build, and verify the constraint picker is shown when creating an access request.
