### PR TITLE
Refactor teleterm directory sharing to use os.Root to prevent travers…

### DIFF
--- a/lib/teleterm/services/desktop/desktop_test.go
+++ b/lib/teleterm/services/desktop/desktop_test.go
@@ -58,5 +58,5 @@ func TestGetDirectory(t *testing.T) {
 	require.NoError(t, err)
 	resolvedPath, err := filepath.EvalSymlinks(path)
 	require.NoError(t, err)
-	require.Equal(t, resolvedPath, access.basePath)
+	require.Equal(t, resolvedPath, access.root.Name())
 }

--- a/lib/teleterm/services/desktop/directorysharing.go
+++ b/lib/teleterm/services/desktop/directorysharing.go
@@ -23,20 +23,24 @@ import (
 	"math"
 	"os"
 	"path/filepath"
-	"strings"
 
 	"github.com/gravitational/trace"
+)
+
+const (
+	// maxDirectoryRead is an upper bound on how many directory entries
+	// we will return for directory reads.
+	maxDirectoryRead = 4096
 )
 
 // DirectoryAccess enables file system operations for a given directory.
 // Should be kept in sync with web/packages/shared/libs/tdp/sharedDirectoryAccess.ts
 // where FS events are handled for Web UI.
 type DirectoryAccess struct {
-	// basePath is a shared directory path.
-	// Must not be used directly, but only through getSafePath.
-	// TODO(gzdunek): This code can be greatly simplified with os.OpenRoot.
-	// Switch to it when branch/v17 is updated to Go 1.24.
-	basePath string
+	// root is the root of the shared directory.
+	// os.Root provides protection against path traversal
+	// outside of the shared directory.
+	root *os.Root
 }
 
 // FileOrDirInfo contains metadata about a file or a directory.
@@ -64,60 +68,20 @@ func NewDirectoryAccess(baseDir string) (*DirectoryAccess, error) {
 		return nil, trace.ConvertSystemError(err)
 	}
 
-	stat, err := os.Stat(basePath)
+	root, err := os.OpenRoot(basePath)
 	if err != nil {
-		return nil, trace.ConvertSystemError(err)
-	}
-	if !stat.IsDir() {
-		return nil, trace.BadParameter("%q is not a directory", baseDir)
+		return nil, trace.BadParameter("could not open shared directory at %q - %v", basePath, err)
 	}
 
 	return &DirectoryAccess{
-		basePath: basePath,
+		root: root,
 	}, nil
 
 }
 
-// getSafePath allows building a safe path by joining the base path
-// and a relative path.
-// Returns an error if the resolved path escapes the basePath, preventing directory traversal attacks.
-func (d *DirectoryAccess) getSafePath(relativePath string) (string, error) {
-	full := filepath.Join(d.basePath, relativePath)
-	resolved, err := filepath.EvalSymlinks(full)
-	if err != nil {
-		// EvalSymlinks returns an error if the target file does not exist.
-		// In that case, attempt to resolve the symlinks of the parent directory instead.
-		if errors.Is(err, fs.ErrNotExist) {
-			parent := filepath.Dir(full)
-			resolvedParent, perr := filepath.EvalSymlinks(parent)
-			if perr != nil {
-				return "", trace.ConvertSystemError(perr)
-			}
-
-			// Reconstruct the full path by joining the resolved parent with the original file name.
-			resolved = filepath.Join(resolvedParent, filepath.Base(full))
-		} else {
-			return "", trace.ConvertSystemError(err)
-		}
-	}
-	if !isSubPath(d.basePath, resolved) {
-		return "", trace.BadParameter("path escapes from parent")
-	}
-	return resolved, nil
-}
-
-func isSubPath(parent, child string) bool {
-	return child == parent || strings.HasPrefix(child, parent+string(filepath.Separator))
-}
-
 // Stat retrieves metadata about a file or directory at the given path.
 func (d *DirectoryAccess) Stat(relativePath string) (*FileOrDirInfo, error) {
-	path, err := d.getSafePath(relativePath)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-
-	stat, err := os.Stat(path)
+	stat, err := d.root.Stat(sanitizeEmpty(relativePath))
 	if err != nil {
 		return nil, trace.ConvertSystemError(err)
 	}
@@ -128,12 +92,13 @@ func (d *DirectoryAccess) Stat(relativePath string) (*FileOrDirInfo, error) {
 
 // ReadDir lists files and directories within the given directory path, skips symlinks.
 func (d *DirectoryAccess) ReadDir(relativePath string) ([]*FileOrDirInfo, error) {
-	path, err := d.getSafePath(relativePath)
+	file, err := d.root.Open(sanitizeEmpty(relativePath))
 	if err != nil {
-		return nil, trace.Wrap(err)
+		return nil, trace.ConvertSystemError(err)
 	}
+	defer file.Close()
 
-	entries, err := os.ReadDir(path)
+	entries, err := file.ReadDir(maxDirectoryRead)
 	if err != nil {
 		return nil, trace.ConvertSystemError(err)
 	}
@@ -164,12 +129,7 @@ func (d *DirectoryAccess) ReadDir(relativePath string) ([]*FileOrDirInfo, error)
 
 // Read reads a slice of a file into buf. Returns the number of read bytes.
 func (d *DirectoryAccess) Read(relativePath string, offset int64, buf []byte) (n int, err error) {
-	path, err := d.getSafePath(relativePath)
-	if err != nil {
-		return 0, trace.Wrap(err)
-	}
-
-	file, err := os.Open(path)
+	file, err := d.root.Open(sanitizeEmpty(relativePath))
 	if err != nil {
 		return 0, trace.ConvertSystemError(err)
 	}
@@ -195,12 +155,7 @@ func (d *DirectoryAccess) Read(relativePath string, offset int64, buf []byte) (n
 
 // Write writes data to a file at a given offset.
 func (d *DirectoryAccess) Write(relativePath string, offset int64, data []byte) (n int, err error) {
-	path, err := d.getSafePath(relativePath)
-	if err != nil {
-		return 0, trace.Wrap(err)
-	}
-
-	file, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE, 0644)
+	file, err := d.root.OpenFile(sanitizeEmpty(relativePath), os.O_RDWR|os.O_CREATE, 0644)
 	if err != nil {
 		return 0, trace.ConvertSystemError(err)
 	}
@@ -224,28 +179,26 @@ func (d *DirectoryAccess) Write(relativePath string, offset int64, data []byte) 
 
 // Truncate truncates a file to the specified size.
 func (d *DirectoryAccess) Truncate(relativePath string, size uint64) error {
-	path, err := d.getSafePath(relativePath)
-	if err != nil {
-		return trace.Wrap(err)
-	}
-
 	if size > math.MaxInt64 {
 		size = math.MaxInt64
 	}
 
-	return trace.ConvertSystemError(os.Truncate(path, int64(size)))
+	// os.Root does not expose a "Truncate" method, so we must get
+	// a writable file handle to call truncate on.
+	file, err := d.root.OpenFile(sanitizeEmpty(relativePath), os.O_WRONLY, 0)
+	if err != nil {
+		return trace.ConvertSystemError(err)
+	}
+	defer file.Close()
+
+	return trace.ConvertSystemError(file.Truncate(int64(size)))
 }
 
 // Create creates a new file or directory at the given path.
 func (d *DirectoryAccess) Create(relativePath string, fileType FileType) error {
-	path, err := d.getSafePath(relativePath)
-	if err != nil {
-		return trace.Wrap(err)
-	}
-
 	switch fileType {
 	case FileTypeFile:
-		file, err := os.Create(path)
+		file, err := d.root.Create(sanitizeEmpty(relativePath))
 		if err != nil {
 			if errors.Is(err, fs.ErrExist) {
 				return nil // Ignore if file already exists
@@ -254,7 +207,7 @@ func (d *DirectoryAccess) Create(relativePath string, fileType FileType) error {
 		}
 		return trace.ConvertSystemError(file.Close())
 	case FileTypeDir:
-		err := os.Mkdir(path, 0700)
+		err := d.root.Mkdir(relativePath, 0700)
 		if errors.Is(err, fs.ErrExist) {
 			return nil // Ignore if directory already exists
 		}
@@ -266,21 +219,10 @@ func (d *DirectoryAccess) Create(relativePath string, fileType FileType) error {
 
 // Delete removes a file or directory at the given path.
 func (d *DirectoryAccess) Delete(relativePath string) error {
-	path, err := d.getSafePath(relativePath)
-	if err != nil {
-		return trace.Wrap(err)
-	}
-
-	err = os.RemoveAll(path)
-	return trace.ConvertSystemError(err)
+	return trace.ConvertSystemError(d.root.RemoveAll(sanitizeEmpty(relativePath)))
 }
 
 func (d *DirectoryAccess) readFileOrDirInfo(relativePath string, f os.FileInfo) (info *FileOrDirInfo, err error) {
-	path, err := d.getSafePath(relativePath)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-
 	info = &FileOrDirInfo{
 		Size:         f.Size(),
 		LastModified: f.ModTime().UnixMilli(),
@@ -293,7 +235,7 @@ func (d *DirectoryAccess) readFileOrDirInfo(relativePath string, f os.FileInfo) 
 		return info, nil
 	}
 
-	opened, err := os.Open(path)
+	opened, err := d.root.Open(sanitizeEmpty(relativePath))
 	if err != nil {
 		return nil, trace.ConvertSystemError(err)
 	}
@@ -315,4 +257,14 @@ func (d *DirectoryAccess) readFileOrDirInfo(relativePath string, f os.FileInfo) 
 		info.IsEmpty = true
 	}
 	return info, trace.ConvertSystemError(err)
+}
+
+// Consumers of DirectoryAccess expect to be able to pass empty path
+// strings to reference the root of the shared directory. Correct
+// these paths before passing them to os.Root methods.
+func sanitizeEmpty(path string) string {
+	if path == "" {
+		return "."
+	}
+	return path
 }

--- a/lib/teleterm/services/desktop/directorysharing_test.go
+++ b/lib/teleterm/services/desktop/directorysharing_test.go
@@ -17,6 +17,7 @@
 package desktop
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -26,14 +27,21 @@ import (
 )
 
 const (
-	testDirname         = "test_dir"
-	testFilename        = "test_file"
-	testSymlinkFilename = "test_symlink"
+	testDirname              = "accessible_root"
+	testInaccessibleFileName = "test_inaccessible_file"
+	testInaccessibleDirName  = "test_inaccessible_dir"
+
+	testSymlinkInaccessibleFileName = "test_inaccessible_symlink_file"
+	testSymlinkInaccessibleDirName  = "test_inaccessible_symlink_dir"
+	testSymlinkAccessibleFile       = "test_symlink_accessible_file"
+
+	testAccessibleFileName = "test_accessible_file"
+	testAccessibleDirName  = "test_accessible_dir"
 )
 
 func TestNewDirectoryAccess(t *testing.T) {
 	path := t.TempDir()
-	filePath := filepath.Join(path, testFilename)
+	filePath := filepath.Join(path, testInaccessibleFileName)
 	err := os.WriteFile(filePath, []byte("test"), 0600)
 	require.NoError(t, err)
 	_, err = NewDirectoryAccess(filePath)
@@ -42,42 +50,93 @@ func TestNewDirectoryAccess(t *testing.T) {
 
 func setUpSharedDir(t *testing.T) (*DirectoryAccess, string) {
 	t.Helper()
-	path := t.TempDir()
-	err := os.Mkdir(filepath.Join(path, testDirname), 0700)
+	testRoot := t.TempDir()
+	// Create a test folder like so:
+	//    <random_tmp_dir_name>
+	//    |-- test_inaccessible_dir/
+	//    |-- test_inaccessible_file
+	//    |-- accessible_root/ <- DirectoryAccess is rooted here
+	//    |   |-- test_inaccessible_symlink_dir/ -> ../test_inaccessible_dir/
+	//    |   |-- test_inaccessible_symlink_file -> ../test_inaccessible_file
+	//    |   |-- test_accessible_file
+	//    |   |-- test_accessible_dir/
+	//    |   |-- test_symlink_accessible_file -> ./accessible_file
+	//
+	// The access folder contains a single regular file and symlinks
+	// to a file and directory that should not be traversible, as well
+	// as a symlink to the regular file which *should be* accessible.
+	accessRoot := filepath.Join(testRoot, testDirname)
+	err := os.Mkdir(accessRoot, 0700)
 	require.NoError(t, err)
-	err = os.WriteFile(filepath.Join(path, testFilename), []byte("test"), 0600)
+	err = os.WriteFile(filepath.Join(accessRoot, testAccessibleFileName), []byte("test"), 0600)
 	require.NoError(t, err)
-	err = os.Symlink(filepath.Join(path, testFilename), filepath.Join(path, testSymlinkFilename))
+	err = os.WriteFile(filepath.Join(testRoot, testInaccessibleFileName), []byte("data"), 0600)
 	require.NoError(t, err)
-	access, err := NewDirectoryAccess(path)
+	err = os.Mkdir(filepath.Join(accessRoot, testAccessibleDirName), 0700)
 	require.NoError(t, err)
-	return access, path
+	err = os.Mkdir(filepath.Join(testRoot, testInaccessibleDirName), 0700)
+	require.NoError(t, err)
+	err = os.Symlink(filepath.Join(testRoot, testInaccessibleFileName), filepath.Join(accessRoot, testSymlinkInaccessibleFileName))
+	require.NoError(t, err)
+	err = os.Symlink(filepath.Join(accessRoot, testInaccessibleDirName), filepath.Join(accessRoot, testSymlinkInaccessibleDirName))
+	require.NoError(t, err)
+	// Symlink must use a relative path that remains within the shared directory.
+	err = os.Symlink(testAccessibleFileName, filepath.Join(accessRoot, testSymlinkAccessibleFile))
+	require.NoError(t, err)
+	access, err := NewDirectoryAccess(accessRoot)
+	require.NoError(t, err)
+	return access, accessRoot
 }
 
 func TestDirectoryAccessEscapingPaths(t *testing.T) {
-	outOfRootPath := filepath.Join(testDirname, "../..")
-	tests := []struct {
-		name string
-		call func(*DirectoryAccess) error
-	}{
-		{"Stat", func(a *DirectoryAccess) error { _, err := a.Stat(outOfRootPath); return err }},
-		{"ReadDir", func(a *DirectoryAccess) error { _, err := a.ReadDir(outOfRootPath); return err }},
-		{"Read", func(a *DirectoryAccess) error {
+	operations := map[string]func(a *DirectoryAccess, path string) error{
+		"Stat":    func(a *DirectoryAccess, path string) error { _, err := a.Stat(path); return err },
+		"ReadDir": func(a *DirectoryAccess, path string) error { _, err := a.ReadDir(path); return err },
+		"Read": func(a *DirectoryAccess, path string) error {
 			buf := make([]byte, 10)
-			_, err := a.Read(outOfRootPath, 0, buf)
+			_, err := a.Read(path, 0, buf)
 			return err
-		}},
-		{"Write", func(a *DirectoryAccess) error { _, err := a.Write(outOfRootPath, 0, []byte("test")); return err }},
-		{"Truncate", func(a *DirectoryAccess) error { err := a.Truncate(outOfRootPath, 100); return err }},
-		{"Create", func(a *DirectoryAccess) error { err := a.Create(outOfRootPath, FileTypeDir); return err }},
-		{"Delete", func(a *DirectoryAccess) error { err := a.Delete(outOfRootPath); return err }},
+		},
+		"Write":    func(a *DirectoryAccess, path string) error { _, err := a.Write(path, 0, []byte("test")); return err },
+		"Truncate": func(a *DirectoryAccess, path string) error { err := a.Truncate(path, 100); return err },
+		"Create":   func(a *DirectoryAccess, path string) error { err := a.Create(path, FileTypeDir); return err },
+		"Delete":   func(a *DirectoryAccess, path string) error { err := a.Delete(path); return err },
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.name+"_Escape", func(t *testing.T) {
+	// Try escape paths on all operations
+	paths := []string{"..", "../../"}
+	for opName, op := range operations {
+		for _, path := range paths {
+			t.Run(fmt.Sprintf("%s_Escape/%s", opName, path), func(t *testing.T) {
+				access, _ := setUpSharedDir(t)
+				err := op(access, path)
+				require.Error(t, err)
+				require.True(t, trace.IsAccessDenied(err))
+			})
+		}
+	}
+
+	// Try operations (except create/delete) on symlink to a file outside of the root.
+	symlinkOperations := []string{"Stat", "Read", "ReadDir", "Write", "Truncate"}
+	for _, symlinkOp := range symlinkOperations {
+		t.Run(fmt.Sprintf("symlink_traversal/%s", symlinkOp), func(t *testing.T) {
+			access, path := setUpSharedDir(t)
+			fmt.Println(path)
+			err := operations[symlinkOp](access, testSymlinkInaccessibleFileName)
+			require.Error(t, err)
+			require.True(t, trace.IsAccessDenied(err))
+		})
+	}
+
+	// Try create/delete operations following a symlink to a directory outside
+	// of the root.
+	symlinkDirOperations := []string{"Create", "Delete"}
+	for _, symlinkOp := range symlinkDirOperations {
+		t.Run(fmt.Sprintf("symlink_dir_traversal/%s", symlinkOp), func(t *testing.T) {
 			access, _ := setUpSharedDir(t)
-			err := tt.call(access)
-			require.ErrorContains(t, err, "path escapes from parent")
+			err := operations[symlinkOp](access, filepath.Join(testSymlinkInaccessibleDirName, "somefile"))
+			require.Error(t, err)
+			require.True(t, trace.IsAccessDenied(err))
 		})
 	}
 }
@@ -105,31 +164,47 @@ func TestDirectoryAccessSuccessOperations(t *testing.T) {
 		dir, err := access.ReadDir("")
 		require.NoError(t, err)
 
+		// Although there are 4 entries in the shared directory, our 'ReadDir'
+		// method only shows 2 because it skips symlinks.
 		require.Len(t, dir, 2)
-		osStat, err := os.Stat(filepath.Join(path, testDirname))
+		osStat, err := os.Stat(filepath.Join(path, testAccessibleDirName))
+		// Find the directory entry
 		require.NoError(t, err)
 		require.Contains(t, dir, &FileOrDirInfo{
 			Size:         4096,
 			LastModified: osStat.ModTime().UnixMilli(),
 			FileType:     FileTypeDir,
 			IsEmpty:      true,
-			Path:         testDirname,
+			Path:         testAccessibleDirName,
 		})
-		osStat, err = os.Stat(filepath.Join(path, testFilename))
+		osStat, err = os.Stat(filepath.Join(path, testAccessibleFileName))
 		require.NoError(t, err)
 		require.Contains(t, dir, &FileOrDirInfo{
 			Size:         osStat.Size(),
 			LastModified: osStat.ModTime().UnixMilli(),
 			FileType:     FileTypeFile,
 			IsEmpty:      false,
-			Path:         testFilename,
+			Path:         testAccessibleFileName,
 		})
 	})
 
 	t.Run("Read", func(t *testing.T) {
 		access, _ := setUpSharedDir(t)
 		buf := make([]byte, 4)
-		read, err := access.Read(testFilename, 0, buf)
+		read, err := access.Read(testAccessibleFileName, 0, buf)
+		require.NoError(t, err)
+		require.Equal(t, 4, read)
+		require.Equal(t, []byte("test"), buf)
+	})
+
+	// Although we hide symlinks during ReadDir operations,
+	// a tech savvy user could still attempt I/O operations against
+	// them. This "test" is more of a demonstration that relative
+	// symlinks that stay within the bounds of the root are permitted.
+	t.Run("Read Accessible Symlink", func(t *testing.T) {
+		access, _ := setUpSharedDir(t)
+		buf := make([]byte, 4)
+		read, err := access.Read(testSymlinkAccessibleFile, 0, buf)
 		require.NoError(t, err)
 		require.Equal(t, 4, read)
 		require.Equal(t, []byte("test"), buf)
@@ -137,22 +212,36 @@ func TestDirectoryAccessSuccessOperations(t *testing.T) {
 
 	t.Run("Write", func(t *testing.T) {
 		access, _ := setUpSharedDir(t)
-		written, err := access.Write(testFilename, 4, []byte("_new_content"))
+		written, err := access.Write(testAccessibleFileName, 4, []byte("_new_content"))
 		require.NoError(t, err)
 		require.Equal(t, 12, written)
 
 		buf := make([]byte, 16)
-		read, err := access.Read(testFilename, 0, buf)
+		read, err := access.Read(testAccessibleFileName, 0, buf)
 		require.NoError(t, err)
 		require.Equal(t, 16, read)
 		require.Equal(t, []byte("test_new_content"), buf)
 	})
 
+	t.Run("Write Accessible Symlink", func(t *testing.T) {
+		access, path := setUpSharedDir(t)
+		fmt.Println(path)
+		written, err := access.Write(testSymlinkAccessibleFile, 4, []byte("_symlink"))
+		require.NoError(t, err)
+		require.Equal(t, 8, written)
+
+		buf := make([]byte, 12)
+		read, err := access.Read(testSymlinkAccessibleFile, 0, buf)
+		require.NoError(t, err)
+		require.Equal(t, 12, read)
+		require.Equal(t, []byte("test_symlink"), buf)
+	})
+
 	t.Run("Truncate", func(t *testing.T) {
 		access, _ := setUpSharedDir(t)
-		err := access.Truncate(testFilename, 100)
+		err := access.Truncate(testAccessibleFileName, 100)
 		require.NoError(t, err)
-		stat, err := access.Stat(testFilename)
+		stat, err := access.Stat(testAccessibleFileName)
 		require.NoError(t, err)
 		require.Equal(t, int64(100), stat.Size)
 	})
@@ -175,8 +264,8 @@ func TestDirectoryAccessSuccessOperations(t *testing.T) {
 
 	t.Run("Delete", func(t *testing.T) {
 		access, _ := setUpSharedDir(t)
-		err := access.Delete(testFilename)
+		err := access.Delete(testInaccessibleFileName)
 		require.NoError(t, err)
-		require.NoFileExists(t, testFilename)
+		require.NoFileExists(t, testInaccessibleFileName)
 	})
 }


### PR DESCRIPTION
Go 1.24 introduced [os.Root](https://go.dev/blog/osroot) which allows users to easily build traversal-resistant APIs. As noted in a comment at the top of the current implementation, we should replace our homemade path traversal defense with one from the standard library.

<!-- Provide a descriptive entry for the changelog of the next release. -->

<!-- Include manual testing efforts to verify the change. -->
<!-- Detail where the tests where run and what configurations were used. -->
<!-- Include all the test cases which were run to validate the change. -->

## Manual Test Plan
### Test Environment
None
### Test Cases
- [x] Unit test coverage across all operations.
