### PR TITLE
Add environment profile to Cloud Cluster Updates doc

### DIFF
--- a/docs/pages/upgrading/cloud-cluster-updates.mdx
+++ b/docs/pages/upgrading/cloud-cluster-updates.mdx
@@ -47,3 +47,12 @@ update types, including patches and agent upgrades. Updates will not begin befor
 Customers can change their maintenance window by navigating to the `Help & Support`
 section in the Teleport Web UI and clicking the edit button for `Window Start Time`
 in the `Scheduled Upgrades` section.
+
+## Environment profile
+
+The environment profile lets you define an environment (staging or production) for your
+tenant. During updates, tenants marked as staging will update before those marked as production.
+
+Customers can change their environment profile by navigating to the `Help & Support`
+section in the Teleport Web UI and clicking the edit button for `Environment Profile`
+in the `Scheduled Upgrades` section.


### PR DESCRIPTION
Adds docs section to Cloud Cluster Updates under Maintenance windows for the new Environment Profile selection
https://goteleport.com/docs/upgrading/cloud-cluster-updates/#maintenance-windows

<img width="625" height="335" alt="Screenshot 2026-05-27 at 8 54 46 AM" src="https://github.com/user-attachments/assets/87d5921f-1c0e-465e-90b3-9f0b788f10bd" />
