### PR TITLE
Restore single log out partial

### DIFF
--- a/docs/pages/includes/sso/saml-slo.mdx
+++ b/docs/pages/includes/sso/saml-slo.mdx
@@ -1,0 +1,10 @@
+<details>
+<summary>SAML Single Logout</summary>
+    Setting the `spec.single_logout_url` endpoint in SAML connectors enables SAML SLO (Single Logout).
+    If enabled, upon logging out of Teleport, users will also be logged out of the SAML provider session, which 
+    may also log them out of any other non-Teleport applications which they are currently logged into using the same SAML provider.
+
+    For optimal user experience, we recommend keeping this disabled unless necessary.
+
+    Refer to your SAML provider's documentation for instructions on where to obtain this URL.
+</details>

--- a/docs/pages/zero-trust-access/sso/integrate-idp/entra-id.mdx
+++ b/docs/pages/zero-trust-access/sso/integrate-idp/entra-id.mdx
@@ -228,6 +228,8 @@ version: v2
 
 (!docs/pages/includes/sso/idp-initiated.mdx!)
 
+(!docs/pages/includes/sso/saml-slo.mdx!)
+
 ### Test the connector
 
 With the connector in place on the cluster, you can test it with `tctl`:

--- a/docs/pages/zero-trust-access/sso/integrate-idp/okta.mdx
+++ b/docs/pages/zero-trust-access/sso/integrate-idp/okta.mdx
@@ -221,6 +221,8 @@ version: v2
 
 (!docs/pages/includes/sso/idp-initiated.mdx!)
 
+(!docs/pages/includes/sso/saml-slo.mdx!)
+
 ### Test the connector
 
 You can test the connector before applying it to your cluster. This is strongly


### PR DESCRIPTION
Fixes #64890

Before #61492, the SSO index page briefly documented single log out (SLO) for SAML. #61492 refactored our SSO authentication connector guides to remove the duplication between the landing page and individual IdP guides, but inadvertently removed the reference to the partial that documented SLO. This change restores the partial to the closest location available to its original one: below the `idp-initiated.mdx` partial in our SAML guidance.