### PR TITLE
[v18] Fix lib/web feature watcher panic on nil cluster features.

### DIFF
--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -760,7 +760,7 @@ func NewHandler(cfg Config, opts ...HandlerOption) (*APIHandler, error) {
 		}
 	}
 
-	go h.startFeatureWatcher()
+	go h.startFeatureWatcher(h.cfg.Context)
 
 	return &APIHandler{
 		handler:    h,

--- a/lib/web/features.go
+++ b/lib/web/features.go
@@ -19,6 +19,8 @@
 package web
 
 import (
+	"context"
+
 	"github.com/gravitational/teleport/api/client/proto"
 	"github.com/gravitational/teleport/entitlements"
 )
@@ -47,8 +49,7 @@ func (h *Handler) GetClusterFeatures() proto.Features {
 // which will cause a panic.
 // The watcher doesn't ping the auth server immediately upon start because features are
 // already set by the config object in `NewHandler`.
-func (h *Handler) startFeatureWatcher() {
-	ctx := h.cfg.Context
+func (h *Handler) startFeatureWatcher(ctx context.Context) {
 	ticker := h.clock.NewTicker(h.cfg.FeatureWatchInterval)
 	h.logger.InfoContext(ctx, "Proxy handler features watcher has started", "interval", h.cfg.FeatureWatchInterval)
 
@@ -63,8 +64,11 @@ func (h *Handler) startFeatureWatcher() {
 				continue
 			}
 
-			h.SetClusterFeatures(*pingResponse.ServerFeatures)
-			h.logger.InfoContext(ctx, "Done updating proxy features", "features", pingResponse.ServerFeatures)
+			if pingResponse.ServerFeatures != nil {
+				h.SetClusterFeatures(*pingResponse.ServerFeatures)
+				h.logger.InfoContext(ctx, "Done updating proxy features", "features", pingResponse.ServerFeatures)
+			}
+
 		case <-ctx.Done():
 			h.logger.InfoContext(ctx, "Feature service has stopped")
 			return

--- a/lib/web/features_test.go
+++ b/lib/web/features_test.go
@@ -42,26 +42,26 @@ type mockedFeatureGetter struct {
 	authclient.ClientI
 
 	mu       sync.Mutex
-	features proto.Features
+	features *proto.Features
 }
 
 func (m *mockedFeatureGetter) Ping(ctx context.Context) (proto.PingResponse, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	return proto.PingResponse{
-		ServerFeatures: utils.CloneProtoMsg(&m.features),
+		ServerFeatures: utils.CloneProtoMsg(m.features),
 	}, nil
 }
 
 func (m *mockedFeatureGetter) setFeatures(f proto.Features) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	m.features = f
+	m.features = &f
 }
 
 func TestFeaturesWatcher(t *testing.T) {
 	synctest.Test(t, func(t *testing.T) {
-		mockClient := &mockedFeatureGetter{features: proto.Features{
+		mockClient := &mockedFeatureGetter{features: &proto.Features{
 			Kubernetes:     true,
 			Entitlements:   map[string]*proto.EntitlementInfo{},
 			AccessRequests: &proto.AccessRequestsFeature{},
@@ -73,14 +73,13 @@ func TestFeaturesWatcher(t *testing.T) {
 			cfg: Config{
 				FeatureWatchInterval: 100 * time.Millisecond,
 				ProxyClient:          mockClient,
-				Context:              ctx,
 			},
 			clock:           clockwork.NewRealClock(),
 			clusterFeatures: proto.Features{},
 			logger:          slog.Default().With(teleport.ComponentKey, teleport.ComponentWeb),
 		}
 
-		go handler.startFeatureWatcher()
+		go handler.startFeatureWatcher(ctx)
 		synctest.Wait()
 
 		// before running the watcher, features should match the value passed to the handler
@@ -166,5 +165,40 @@ func TestFeaturesWatcher(t *testing.T) {
 
 		// assert the handler never get these last features as the watcher is stopped
 		require.NotEqual(t, *notExpected, handler.GetClusterFeatures())
+	})
+}
+
+func TestFeaturesWatcherDoesNotPanicOnNilFeatures(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		initialFeatures := proto.Features{
+			Entitlements: map[string]*proto.EntitlementInfo{
+				string(entitlements.App): {Enabled: true},
+			},
+		}
+
+		handler := &Handler{
+			cfg: Config{
+				FeatureWatchInterval: time.Nanosecond,
+				ProxyClient: &mockedFeatureGetter{
+					features: nil, // Simulate auth server returning nil features.
+				},
+			},
+			clock:           clockwork.NewRealClock(),
+			clusterFeatures: initialFeatures,
+			logger:          slog.Default().With(teleport.ComponentKey, teleport.ComponentWeb),
+		}
+
+		go handler.startFeatureWatcher(t.Context())
+		synctest.Wait()
+
+		time.Sleep(handler.cfg.FeatureWatchInterval)
+		synctest.Wait()
+
+		require.Equal(
+			t,
+			initialFeatures,
+			handler.clusterFeatures,
+			"Cluster features must remain unchanged when auth server returns nil features",
+		)
 	})
 }


### PR DESCRIPTION
Backport https://github.com/gravitational/teleport/pull/66858 to branch/v18