### PR TITLE
[v17] Fix lib/web feature watcher panic on nil cluster features.

### DIFF
--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -771,7 +771,7 @@ func NewHandler(cfg Config, opts ...HandlerOption) (*APIHandler, error) {
 		}
 	}
 
-	go h.startFeatureWatcher()
+	go h.startFeatureWatcher(h.cfg.Context)
 
 	return &APIHandler{
 		handler:    h,

--- a/lib/web/features.go
+++ b/lib/web/features.go
@@ -20,6 +20,7 @@ package web
 
 import (
 	"bytes"
+	"context"
 
 	"github.com/gravitational/teleport/api/client/proto"
 	"github.com/gravitational/teleport/entitlements"
@@ -53,10 +54,9 @@ func (h *Handler) GetClusterFeatures() proto.Features {
 // which will cause a panic.
 // The watcher doesn't ping the auth server immediately upon start because features are
 // already set by the config object in `NewHandler`.
-func (h *Handler) startFeatureWatcher() {
+func (h *Handler) startFeatureWatcher(ctx context.Context) {
 	ticker := h.clock.NewTicker(h.cfg.FeatureWatchInterval)
 	h.log.WithField("interval", h.cfg.FeatureWatchInterval).Info("Proxy handler features watcher has started")
-	ctx := h.cfg.Context
 
 	defer ticker.Stop()
 	for {
@@ -69,8 +69,11 @@ func (h *Handler) startFeatureWatcher() {
 				continue
 			}
 
-			h.SetClusterFeatures(*pingResponse.ServerFeatures)
-			h.log.WithField("features", pingResponse.ServerFeatures).Info("Done updating proxy features")
+			if pingResponse.ServerFeatures != nil {
+				h.SetClusterFeatures(*pingResponse.ServerFeatures)
+				h.log.WithField("features", pingResponse.ServerFeatures).Info("Done updating proxy features")
+			}
+
 		case <-ctx.Done():
 			h.log.Info("Feature service has stopped")
 			return

--- a/lib/web/features_test.go
+++ b/lib/web/features_test.go
@@ -23,6 +23,7 @@ import (
 	"log/slog"
 	"sync"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/google/go-cmp/cmp"
@@ -43,27 +44,27 @@ type mockedFeatureGetter struct {
 	authclient.ClientI
 
 	mu       sync.Mutex
-	features proto.Features
+	features *proto.Features
 }
 
 func (m *mockedFeatureGetter) Ping(ctx context.Context) (proto.PingResponse, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	return proto.PingResponse{
-		ServerFeatures: utils.CloneProtoMsg(&m.features),
+		ServerFeatures: utils.CloneProtoMsg(m.features),
 	}, nil
 }
 
 func (m *mockedFeatureGetter) setFeatures(f proto.Features) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	m.features = f
+	m.features = &f
 }
 
 func TestFeaturesWatcher(t *testing.T) {
 	clock := clockwork.NewFakeClock()
 
-	mockClient := &mockedFeatureGetter{features: proto.Features{
+	mockClient := &mockedFeatureGetter{features: &proto.Features{
 		Kubernetes:     true,
 		Entitlements:   map[string]*proto.EntitlementInfo{},
 		AccessRequests: &proto.AccessRequestsFeature{},
@@ -85,7 +86,7 @@ func TestFeaturesWatcher(t *testing.T) {
 	// before running the watcher, features should match the value passed to the handler
 	requireFeatures(t, clock, proto.Features{}, handler.GetClusterFeatures)
 
-	go handler.startFeatureWatcher()
+	go handler.startFeatureWatcher(ctx)
 	clock.BlockUntil(1)
 
 	// after starting the watcher, handler.GetClusterFeatures should return
@@ -180,4 +181,39 @@ func neverFeatures(t *testing.T, fakeClock *clockwork.FakeClock, doNotWant proto
 	require.Never(t, func() bool {
 		return cmp.Diff(doNotWant, getFeatures()) == ""
 	}, 1*time.Second, time.Millisecond*100)
+}
+
+func TestFeaturesWatcherDoesNotPanicOnNilFeatures(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		initialFeatures := proto.Features{
+			Entitlements: map[string]*proto.EntitlementInfo{
+				string(entitlements.App): {Enabled: true},
+			},
+		}
+
+		handler := &Handler{
+			cfg: Config{
+				FeatureWatchInterval: time.Nanosecond,
+				ProxyClient: &mockedFeatureGetter{
+					features: nil, // Simulate auth server returning nil features.
+				},
+			},
+			clock:           clockwork.NewRealClock(),
+			clusterFeatures: initialFeatures,
+			log:             newPackageLogger(),
+		}
+
+		go handler.startFeatureWatcher(t.Context())
+		synctest.Wait()
+
+		time.Sleep(handler.cfg.FeatureWatchInterval)
+		synctest.Wait()
+
+		require.Equal(
+			t,
+			initialFeatures,
+			handler.clusterFeatures,
+			"Cluster features must remain unchanged when auth server returns nil features",
+		)
+	})
 }

--- a/lib/web/features_test.go
+++ b/lib/web/features_test.go
@@ -26,9 +26,7 @@ import (
 	"testing/synctest"
 	"time"
 
-	"github.com/google/go-cmp/cmp"
 	"github.com/jonboulle/clockwork"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/gravitational/teleport"
@@ -38,7 +36,7 @@ import (
 	"github.com/gravitational/teleport/lib/auth/authclient"
 )
 
-// mockedPingTestProxy is a test proxy with a mocked Ping method
+// mockedFeatureGetter is a test proxy with a mocked Ping method
 // that returns the internal features
 type mockedFeatureGetter struct {
 	authclient.ClientI
@@ -62,125 +60,108 @@ func (m *mockedFeatureGetter) setFeatures(f proto.Features) {
 }
 
 func TestFeaturesWatcher(t *testing.T) {
-	clock := clockwork.NewFakeClock()
+	synctest.Test(t, func(t *testing.T) {
+		mockClient := &mockedFeatureGetter{features: &proto.Features{
+			Kubernetes:     true,
+			Entitlements:   map[string]*proto.EntitlementInfo{},
+			AccessRequests: &proto.AccessRequestsFeature{},
+		}}
 
-	mockClient := &mockedFeatureGetter{features: &proto.Features{
-		Kubernetes:     true,
-		Entitlements:   map[string]*proto.EntitlementInfo{},
-		AccessRequests: &proto.AccessRequestsFeature{},
-	}}
+		ctx, cancel := context.WithCancel(t.Context())
 
-	ctx, cancel := context.WithCancel(context.Background())
-	handler := &Handler{
-		cfg: Config{
-			FeatureWatchInterval: 100 * time.Millisecond,
-			ProxyClient:          mockClient,
-			Context:              ctx,
-		},
-		clock:           clock,
-		clusterFeatures: proto.Features{},
-		log:             newPackageLogger(),
-		logger:          slog.Default().With(teleport.ComponentKey, teleport.ComponentWeb),
-	}
+		handler := &Handler{
+			cfg: Config{
+				FeatureWatchInterval: 100 * time.Millisecond,
+				ProxyClient:          mockClient,
+			},
+			clock:           clockwork.NewRealClock(),
+			clusterFeatures: proto.Features{},
+			log:             newPackageLogger(),
+			logger:          slog.Default().With(teleport.ComponentKey, teleport.ComponentWeb),
+		}
 
-	// before running the watcher, features should match the value passed to the handler
-	requireFeatures(t, clock, proto.Features{}, handler.GetClusterFeatures)
+		go handler.startFeatureWatcher(ctx)
+		synctest.Wait()
 
-	go handler.startFeatureWatcher(ctx)
-	clock.BlockUntil(1)
+		// before running the watcher, features should match the value passed to the handler
+		require.Equal(t, proto.Features{}, handler.GetClusterFeatures())
 
-	// after starting the watcher, handler.GetClusterFeatures should return
-	// values matching the client's response
-	features := proto.Features{
-		Kubernetes:     true,
-		Entitlements:   map[string]*proto.EntitlementInfo{},
-		AccessRequests: &proto.AccessRequestsFeature{},
-	}
-	entitlements.BackfillFeatures(&features)
-	expected := utils.CloneProtoMsg(&features)
-	requireFeatures(t, clock, *expected, handler.GetClusterFeatures)
+		// advance and wait. once this returns the first feature update will have completed
+		// and the updater will be blocked prior to the second update.
+		time.Sleep(handler.cfg.FeatureWatchInterval)
+		synctest.Wait()
 
-	// update values once again and check if the features are properly updated
-	features = proto.Features{
-		Kubernetes:     false,
-		Entitlements:   map[string]*proto.EntitlementInfo{},
-		AccessRequests: &proto.AccessRequestsFeature{},
-	}
-	entitlements.BackfillFeatures(&features)
-	mockClient.setFeatures(features)
-	expected = utils.CloneProtoMsg(&features)
-	requireFeatures(t, clock, *expected, handler.GetClusterFeatures)
+		// after starting the watcher, handler.GetClusterFeatures should return
+		// values matching the client's response (with BackfillFeatures applied)
+		features := proto.Features{
+			Kubernetes:     true,
+			Entitlements:   map[string]*proto.EntitlementInfo{},
+			AccessRequests: &proto.AccessRequestsFeature{},
+		}
+		entitlements.BackfillFeatures(&features)
+		expected := utils.CloneProtoMsg(&features)
+		require.Equal(t, *expected, handler.GetClusterFeatures())
 
-	// test updating entitlements
-	features = proto.Features{
-		Kubernetes: true,
-		Entitlements: map[string]*proto.EntitlementInfo{
-			string(entitlements.ExternalAuditStorage):   {Enabled: true},
-			string(entitlements.AccessLists):            {Enabled: true},
-			string(entitlements.AccessMonitoring):       {Enabled: true},
-			string(entitlements.App):                    {Enabled: true},
-			string(entitlements.CloudAuditLogRetention): {Enabled: true},
-		},
-		AccessRequests: &proto.AccessRequestsFeature{},
-	}
-	entitlements.BackfillFeatures(&features)
-	mockClient.setFeatures(features)
+		// update values once again and check if the features are properly updated
+		features = proto.Features{
+			Kubernetes:     false,
+			Entitlements:   map[string]*proto.EntitlementInfo{},
+			AccessRequests: &proto.AccessRequestsFeature{},
+		}
+		mockClient.setFeatures(features)
 
-	expected = &proto.Features{
-		Kubernetes: true,
-		Entitlements: map[string]*proto.EntitlementInfo{
-			string(entitlements.ExternalAuditStorage):   {Enabled: true},
-			string(entitlements.AccessLists):            {Enabled: true},
-			string(entitlements.AccessMonitoring):       {Enabled: true},
-			string(entitlements.App):                    {Enabled: true},
-			string(entitlements.CloudAuditLogRetention): {Enabled: true},
-		},
-		AccessRequests: &proto.AccessRequestsFeature{},
-	}
-	entitlements.BackfillFeatures(expected)
-	requireFeatures(t, clock, *expected, handler.GetClusterFeatures)
+		time.Sleep(handler.cfg.FeatureWatchInterval)
+		synctest.Wait()
 
-	// stop watcher and ensure it stops updating features
-	cancel()
-	features = proto.Features{
-		Kubernetes:     !features.Kubernetes,
-		App:            !features.App,
-		DB:             true,
-		Entitlements:   map[string]*proto.EntitlementInfo{},
-		AccessRequests: &proto.AccessRequestsFeature{},
-	}
-	entitlements.BackfillFeatures(&features)
-	mockClient.setFeatures(features)
-	notExpected := utils.CloneProtoMsg(&features)
-	// assert the handler never get these last features as the watcher is stopped
-	neverFeatures(t, clock, *notExpected, handler.GetClusterFeatures)
-}
+		entitlements.BackfillFeatures(&features)
+		expected = utils.CloneProtoMsg(&features)
+		require.Equal(t, *expected, handler.GetClusterFeatures())
 
-// requireFeatures is a helper function that advances the clock, then
-// calls `getFeatures` every 100ms for up to 1 second, until it
-// returns the expected result (`want`).
-func requireFeatures(t *testing.T, fakeClock *clockwork.FakeClock, want proto.Features, getFeatures func() proto.Features) {
-	t.Helper()
+		// test updating entitlements
+		features = proto.Features{
+			Kubernetes: true,
+			Entitlements: map[string]*proto.EntitlementInfo{
+				string(entitlements.ExternalAuditStorage):   {Enabled: true},
+				string(entitlements.AccessLists):            {Enabled: true},
+				string(entitlements.AccessMonitoring):       {Enabled: true},
+				string(entitlements.App):                    {Enabled: true},
+				string(entitlements.CloudAuditLogRetention): {Enabled: true},
+			},
+			AccessRequests: &proto.AccessRequestsFeature{},
+		}
+		mockClient.setFeatures(features)
 
-	// Advance the clock so the service fetch and stores features
-	fakeClock.Advance(1 * time.Second)
+		time.Sleep(handler.cfg.FeatureWatchInterval)
+		synctest.Wait()
 
-	require.EventuallyWithT(t, func(t *assert.CollectT) {
-		diff := cmp.Diff(want, getFeatures())
-		assert.Empty(t, diff)
-	}, 5*time.Second, time.Millisecond*100)
-}
+		expectedFeatures := proto.Features{
+			Kubernetes: true,
+			Entitlements: map[string]*proto.EntitlementInfo{
+				string(entitlements.ExternalAuditStorage):   {Enabled: true},
+				string(entitlements.AccessLists):            {Enabled: true},
+				string(entitlements.AccessMonitoring):       {Enabled: true},
+				string(entitlements.App):                    {Enabled: true},
+				string(entitlements.CloudAuditLogRetention): {Enabled: true},
+			},
+			AccessRequests: &proto.AccessRequestsFeature{},
+		}
+		entitlements.BackfillFeatures(&expectedFeatures)
+		require.Equal(t, expectedFeatures, handler.GetClusterFeatures())
 
-// neverFeatures is a helper function that advances the clock, then
-// calls `getFeatures` every 100ms for up to 1 second. If at some point `getFeatures`
-// returns `doNotWant`, the test fails.
-func neverFeatures(t *testing.T, fakeClock *clockwork.FakeClock, doNotWant proto.Features, getFeatures func() proto.Features) {
-	t.Helper()
+		// stop watcher and ensure it stops updating features
+		cancel()
+		synctest.Wait()
 
-	fakeClock.Advance(1 * time.Second)
-	require.Never(t, func() bool {
-		return cmp.Diff(doNotWant, getFeatures()) == ""
-	}, 1*time.Second, time.Millisecond*100)
+		features = proto.Features{
+			Entitlements:   map[string]*proto.EntitlementInfo{},
+			AccessRequests: &proto.AccessRequestsFeature{},
+		}
+		mockClient.setFeatures(features)
+		notExpected := utils.CloneProtoMsg(&features)
+
+		// assert the handler never gets these last features as the watcher is stopped
+		require.NotEqual(t, *notExpected, handler.GetClusterFeatures())
+	})
 }
 
 func TestFeaturesWatcherDoesNotPanicOnNilFeatures(t *testing.T) {
@@ -201,6 +182,7 @@ func TestFeaturesWatcherDoesNotPanicOnNilFeatures(t *testing.T) {
 			clock:           clockwork.NewRealClock(),
 			clusterFeatures: initialFeatures,
 			log:             newPackageLogger(),
+			logger:          slog.Default().With(teleport.ComponentKey, teleport.ComponentWeb),
 		}
 
 		go handler.startFeatureWatcher(t.Context())


### PR DESCRIPTION
Backport https://github.com/gravitational/teleport/pull/66858 to branch/v17

`features_test.go` was [flaky](https://github.com/gravitational/teleport/actions/runs/26123578260/job/76831483071) after I applied the cherry-pick, so in addition to the cherry-picked change, I migrated `features_test.go` to use `synctest `just like `branch/v18` and `master` does. It was a copy-paste with some minor changes but no loss in coverage. Yay to deterministic tests 😎 
