### PR TITLE
Add `tctl detections ls` command that list Identity Activity Center alerts

### DIFF
--- a/docs/pages/reference/cli/tctl.mdx
+++ b/docs/pages/reference/cli/tctl.mdx
@@ -1012,6 +1012,27 @@ Flags:
 |`--format`|`text`|Output format, 'text', 'json' or 'yaml'|
 |`-v`, `--[no-]verbose`|`false`|Verbose table output, shows full label output|
 
+## tctl detections ls
+
+List Identity Security detections.
+
+Usage:
+
+```code
+$ tctl detections ls [<flags>]
+```
+
+Flags:
+
+|Flag|Default|Description|
+|---|---|---|
+|`--limit`|`100`|Maximum number of detections to return.|
+|`--[no-]detailed`|`false`|Include extra columns (Reported By, Type, Affected Entity, Tags, Description, Start Time, End Time, Updated) in text output.|
+|`--severity`|*no default* (any of (repeatable): `low`, `medium`, `high`, `critical`)|Filter detections by severity (Values: low, medium, high, critical).|
+|`--source`|*no default*|Filter detections by source.|
+|`--status`|`in_progress`,`triaged` (any of (repeatable): `in_progress`, `triaged`, `resolved`, `closed`)|Filter detections by status (Values: in_progress, triaged, resolved, closed). Default: in_progress, triaged.|
+|`--type`|*no default*|Filter detections by type.|
+
 ## tctl devices add
 
 Register managed devices.

--- a/tool/tctl/common/accessgraph/command.go
+++ b/tool/tctl/common/accessgraph/command.go
@@ -23,7 +23,6 @@ import (
 	"io"
 	"log/slog"
 	"os"
-	"time"
 
 	"github.com/alecthomas/kingpin/v2"
 	"github.com/gravitational/trace"
@@ -36,24 +35,12 @@ import (
 )
 
 // AccessGraphCommand implements experimental Access Graph commands.
-//
-// The user-facing surface is currently a single hidden diagnostic
-// (`tctl accessgraph credentials`) that validates / re-issues the
-// Access Graph credential without making any AG calls. It exists
-// primarily so the credential plumbing has a reachable entry point
-// ahead of the real `access`/`detections`/etc. subcommands.
 type AccessGraphCommand struct {
 	ccf    *tctlcfg.GlobalCLIFlags
 	config *servicecfg.Config
 	stdout io.Writer
 
-	// accessgraph is the parent command grouping AG subcommands.
-	// TODO(ghassan): remove when the real AG subcommands are implemented
-	accessgraph *kingpin.CmdClause
-	// check is a hidden diagnostic that exercises the credential
-	// and client issuance and response code paths for diagnostic purposes
-	// TODO(ghassan): remove when the real AG subcommands are implemented
-	check *kingpin.CmdClause
+	detections detectionsArgs
 }
 
 // Initialize allows AccessGraphCommand to plug itself into the CLI parser.
@@ -64,8 +51,8 @@ func (c *AccessGraphCommand) Initialize(app *kingpin.Application, cliFlags *tctl
 		c.stdout = os.Stdout
 	}
 
-	c.accessgraph = app.Command("accessgraph", "Manage Access Graph (experimental).").Hidden()
-	c.check = c.accessgraph.Command("check", "Validate Access Graph flows (experimental)").Hidden()
+	// Initialize AG subcommands.
+	c.initDetections(app)
 }
 
 // TryRun takes the CLI command as an argument and executes it.
@@ -76,55 +63,37 @@ func (c *AccessGraphCommand) TryRun(ctx context.Context, cmd string, clientFunc 
 		utils.InitLogger(utils.LoggingForCLI, slog.LevelDebug)
 	}
 
-	var commandFunc func(context.Context, commonclient.InitFunc) error
+	var commandFunc func(context.Context, *accessgraph.ClientWithResponses) error
+
 	switch cmd {
-	case c.check.FullCommand():
-		commandFunc = c.accessGraphCheck
+	case c.detections.ls.cmd.FullCommand():
+		commandFunc = c.DetectionsList
 	default:
 		return false, nil
 	}
-	return true, trace.Wrap(commandFunc(ctx, clientFunc))
-}
 
-// accessGraphCheck is a hidden diagnostic command that validates the Access Graph credential
-// loading and client issuance code paths, and exercises a simple AG API call to validate the client works.
-// This is intended for diagnostic and code exercises purposes
-//
-// TODO(ghassan): remove when the real AG subcommands are implemented
-func (c *AccessGraphCommand) accessGraphCheck(ctx context.Context, clientFunc commonclient.InitFunc) error {
+	// Load credentials and ensure the AG cert is valid.
 	creds, err := c.loadAccessGraphCredentials(ctx)
 	if err != nil {
-		return trace.Wrap(err)
+		return false, trace.Wrap(err)
 	}
+
+	// If the cert is not present or valid, ensureAccessGraphCert will fetch a new one,
+	// and load it into the keyring.
 	if err := ensureAccessGraphCert(ctx, creds, clientFunc); err != nil {
-		return trace.Wrap(err)
+		return true, trace.Wrap(err)
 	}
 
 	if creds.proxyAddr == "" {
-		return trace.BadParameter("missing proxy address in Access Graph credential")
+		return true, trace.BadParameter("missing proxy address in Access Graph credential")
 	}
 
-	// Exercise the client issuance code path to validate it works with the
-	client, err := newAccessGraphClient(ctx, creds.proxyAddr, creds.keyRing)
+	// Create an AG client using the resolved proxy address and credentials.
+	accessGraphClient, err := newAccessGraphClient(ctx, creds.proxyAddr, creds.keyRing)
 	if err != nil {
-		return trace.Wrap(err)
+		return true, trace.Wrap(err)
 	}
 
-	// Exercise a client call to validate the client works.
-	end := time.Now()
-	start := end.Add(-time.Hour * 24)
-	res, err := doRequest(client.ListAlertsV1WithResponse(ctx, &accessgraph.ListAlertsV1Params{
-		StartTime: &start,
-		EndTime:   &end,
-	}))
-
-	if err != nil {
-		return trace.Wrap(err, "failed to list Access Graph alerts")
-	}
-
-	if res.JSON200 == nil {
-		return trace.BadParameter("unexpected response from Access Graph API: expected HTTP 200 with JSON body")
-	}
-
-	return trace.Wrap(utils.WriteYAMLArray(c.stdout, res.JSON200.Data), "failed to write Access Graph alerts to output")
+	// Run the command.
+	return true, trace.Wrap(commandFunc(ctx, accessGraphClient))
 }

--- a/tool/tctl/common/accessgraph/detections_command.go
+++ b/tool/tctl/common/accessgraph/detections_command.go
@@ -1,0 +1,285 @@
+/*
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package accessgraph
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"log/slog"
+	"strings"
+	"time"
+
+	"github.com/alecthomas/kingpin/v2"
+	"github.com/gravitational/trace"
+
+	"github.com/gravitational/teleport"
+	accessgraph "github.com/gravitational/teleport/lib/accessgraph/apiclient"
+	"github.com/gravitational/teleport/lib/asciitable"
+)
+
+// descriptionTextMaxLen caps Description in the detailed text table so a long
+// write-up doesn't blow the row width out; JSON/YAML emit the full body.
+const descriptionTextMaxLen = 80
+
+type detectionsArgs struct {
+	cmd *kingpin.CmdClause
+	ls  detectionsListArgs
+
+	// Date filters
+	from time.Time
+	to   time.Time
+
+	// Output format
+	format string
+}
+
+type detectionsListArgs struct {
+	cmd *kingpin.CmdClause
+
+	// General filters
+	status   []string
+	source   []string
+	typ      []string
+	severity []string
+
+	// limit caps the total number of alerts returned across paginated calls.
+	limit int
+
+	// detailed expands the ls command to carry extra columns
+	detailed bool
+}
+
+func (c *AccessGraphCommand) initDetections(app *kingpin.Application) {
+	detectionsCmd := app.Command("detections", "Investigate security detections and anomalies.").Hidden()
+	detectionsCmd.Flag("from", fmt.Sprintf("Include activity at or after this time. (Examples: %s, %s, 24h, 7d; negative durations like -1h are future-relative. Default: 30d)", time.RFC3339, time.DateOnly)).
+		Default("30d").
+		SetValue(timeValue{target: &c.detections.from})
+	detectionsCmd.Flag("to", fmt.Sprintf("Include activity at or before this time. (Examples: %s, %s, 24h, 7d; negative durations like -1h are future-relative. Default: now)", time.RFC3339, time.DateOnly)).
+		Default("now").
+		SetValue(timeValue{target: &c.detections.to})
+	detectionsCmd.Flag("format", "Output format. (Values: text, json, yaml)").
+		Default(teleport.Text).
+		EnumVar(&c.detections.format, teleport.Text, teleport.JSON, teleport.YAML)
+	c.detections.cmd = detectionsCmd
+
+	c.initDetectionsList(c.detections.cmd)
+}
+
+func (c *AccessGraphCommand) initDetectionsList(parent *kingpin.CmdClause) {
+	lsCmd := parent.Command("ls", "List Identity Security detections.")
+
+	lsCmd.Flag("status", "Filter detections by status (Values: in_progress, triaged, resolved, closed). Default: in_progress, triaged.").
+		AllowDuplicate().
+		Default("in_progress", "triaged").
+		EnumsVar(&c.detections.ls.status, "in_progress", "triaged", "resolved", "closed")
+	lsCmd.Flag("source", "Filter detections by source.").
+		AllowDuplicate().
+		StringsVar(&c.detections.ls.source)
+	lsCmd.Flag("type", "Filter detections by type.").
+		AllowDuplicate().
+		StringsVar(&c.detections.ls.typ)
+	lsCmd.Flag("severity", "Filter detections by severity (Values: low, medium, high, critical).").
+		AllowDuplicate().
+		EnumsVar(&c.detections.ls.severity, "low", "medium", "high", "critical")
+	lsCmd.Flag("detailed", "Include extra columns (Reported By, Type, Affected Entity, Tags, Description, Start Time, End Time, Updated) in text output.").
+		BoolVar(&c.detections.ls.detailed)
+	lsCmd.Flag("limit", "Maximum number of detections to return.").
+		Default("100").
+		IntVar(&c.detections.ls.limit)
+	c.detections.ls.cmd = lsCmd
+}
+
+// DetectionsList executes `tctl detections ls`.
+func (c *AccessGraphCommand) DetectionsList(ctx context.Context, client *accessgraph.ClientWithResponses) error {
+	if err := validateTimeWindow(c.detections.from, c.detections.to); err != nil {
+		return trace.Wrap(err)
+	}
+	params := constructAlertsListQuery(c.detections)
+	alerts, err := fetchAlerts(ctx, client, params, c.detections.ls.limit)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	return displayDetections(c.stdout, alerts, c.detections.format, c.detections.ls.detailed)
+}
+
+// fetchAlerts paginates ListAlertsV1 until limit alerts have been collected or
+// the server signals no more pages. The final slice is trimmed to limit.
+func fetchAlerts(
+	ctx context.Context,
+	client *accessgraph.ClientWithResponses,
+	params accessgraph.ListAlertsV1Params,
+	limit int,
+) ([]accessgraph.SecurityAlert, error) {
+	var (
+		alerts []accessgraph.SecurityAlert
+		cursor *string
+	)
+	for {
+		params.NextCursor = cursor
+		resp, err := doRequest(client.ListAlertsV1WithResponse(ctx, &params))
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		if resp.JSON200 == nil {
+			return nil, trace.Errorf("received nil json response from Access Graph API")
+		}
+		alerts = append(alerts, resp.JSON200.Data...)
+		if limit > 0 && len(alerts) >= limit {
+			return alerts[:limit], nil
+		}
+		if resp.JSON200.NextCursor == nil {
+			return alerts, nil
+		}
+		// Guard against a backend that returns a non-advancing cursor, which would otherwise spin forever.
+		if cursor != nil && *resp.JSON200.NextCursor == *cursor {
+			slog.DebugContext(ctx, "Access Graph cursor did not advance; stopping pagination", "cursor", *cursor)
+			return alerts, nil
+		}
+		cursor = resp.JSON200.NextCursor
+	}
+}
+
+func constructAlertsListQuery(args detectionsArgs) accessgraph.ListAlertsV1Params {
+	var queryParts []string
+	for field, values := range map[string][]string{
+		"status":   args.ls.status,
+		"source":   args.ls.source,
+		"type":     args.ls.typ,
+		"severity": args.ls.severity,
+	} {
+		if clause := dslClause(field, values); clause != "" {
+			queryParts = append(queryParts, clause)
+		}
+	}
+	query := strings.Join(queryParts, " AND ")
+	return accessgraph.ListAlertsV1Params{
+		StartTime: &args.from,
+		EndTime:   &args.to,
+		Query:     &query,
+	}
+}
+
+func displayDetections(out io.Writer, alerts []accessgraph.SecurityAlert, format string, detailed bool) error {
+	if alerts == nil {
+		alerts = []accessgraph.SecurityAlert{}
+	}
+	return writeOutput(out, alerts, format, func(w io.Writer) error {
+		return displayDetectionsText(w, alerts, detailed)
+	})
+}
+
+// detectionRowHeaders returns the column titles for the text row schema.
+// Kept aligned with detectionRow so the two never drift out of step.
+func detectionRowHeaders(detailed bool) []string {
+	headers := []string{
+		"ID",
+		"Status",
+		"Date",
+		"Source",
+		"Alert",
+		"Severity",
+	}
+	if detailed {
+		headers = append(headers,
+			"Reported By",
+			"Type",
+			"Affected Entity",
+			"Tags",
+			"Description",
+			"Start Time",
+			"End Time",
+			"Updated",
+		)
+	}
+	return headers
+}
+
+// detectionRow renders a single SecurityAlert as a row matching detectionRowHeaders.
+func detectionRow(a accessgraph.SecurityAlert, detailed bool) []string {
+	row := []string{
+		a.Id.String(),
+		string(a.Status),
+		a.CreatedAt.Format(time.RFC3339),
+		string(a.Source),
+		a.Title,
+		string(a.Severity),
+	}
+	if !detailed {
+		return row
+	}
+
+	description := ""
+	if a.Description != nil {
+		description = truncateOneLine(*a.Description, descriptionTextMaxLen)
+	}
+	tags := ""
+	if a.Tags != nil {
+		tags = strings.Join(*a.Tags, ", ")
+	}
+	updated := ""
+	if a.UpdatedAt != nil {
+		updated = a.UpdatedAt.Format(time.RFC3339)
+	}
+	row = append(row,
+		strPtrToStr(a.ReportedBy),
+		a.Type,
+		formatAffectedEntity(a),
+		tags,
+		description,
+		a.StartTime.Format(time.RFC3339),
+		a.EndTime.Format(time.RFC3339),
+		updated,
+	)
+	return row
+}
+
+// formatAffectedEntity returns the AffectedEntity name, or an empty string
+// when no name is set.
+func formatAffectedEntity(a accessgraph.SecurityAlert) string {
+	if a.AffectedEntity == nil {
+		return ""
+	}
+	return strPtrToStr(a.AffectedEntity.Name)
+}
+
+// truncateOneLine collapses newlines to spaces and clips to max runes with an ellipsis suffix.
+func truncateOneLine(s string, max int) string {
+	s = strings.ReplaceAll(s, "\n", " ")
+	s = strings.ReplaceAll(s, "\r", " ")
+	runes := []rune(s)
+	if len(runes) <= max {
+		return s
+	}
+	if max <= 1 {
+		return "…"
+	}
+	return string(runes[:max-1]) + "…"
+}
+
+func displayDetectionsText(out io.Writer, alerts []accessgraph.SecurityAlert, detailed bool) error {
+	headers := detectionRowHeaders(detailed)
+	rows := make([][]string, 0, len(alerts))
+	for _, alert := range alerts {
+		rows = append(rows, detectionRow(alert, detailed))
+	}
+	table := asciitable.MakeTable(headers, rows...)
+	_, err := fmt.Fprintln(out, table.AsBuffer().String())
+	return trace.Wrap(err)
+}

--- a/tool/tctl/common/accessgraph/detections_command_test.go
+++ b/tool/tctl/common/accessgraph/detections_command_test.go
@@ -1,0 +1,444 @@
+/*
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package accessgraph
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/alecthomas/kingpin/v2"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+
+	"github.com/gravitational/teleport"
+	accessgraph "github.com/gravitational/teleport/lib/accessgraph/apiclient"
+	logmodels "github.com/gravitational/teleport/lib/accessgraph/apiclient/models/logs"
+)
+
+// AG-mounted paths the detection commands hit. Kept as constants so the test
+// fails loudly if the generated client's operation paths drift.
+const (
+	listAlertsPath = accessGraphAPIPath + "graph/alerts/v1"
+)
+
+// Fixed values shared across fixtures so handler assertions can pin the
+// exact UUID / log entries they expect.
+var (
+	fixtureAlertID  = uuid.MustParse("11111111-1111-1111-1111-111111111111")
+	fixtureLogUIDs  = []string{"22222222-2222-2222-2222-222222222222", "33333333-3333-3333-3333-333333333333"}
+	fixtureStart    = time.Date(2026, 4, 1, 12, 0, 0, 0, time.UTC)
+	fixtureEnd      = time.Date(2026, 4, 2, 12, 0, 0, 0, time.UTC)
+	fixtureCreated  = time.Date(2026, 4, 2, 12, 5, 0, 0, time.UTC)
+	fixtureUpdated  = time.Date(2026, 4, 3, 9, 0, 0, 0, time.UTC)
+	fixtureFromArg  = time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC)
+	fixtureToArg    = time.Date(2026, 4, 27, 0, 0, 0, 0, time.UTC)
+	fixtureLongDesc = strings.Repeat("very long detection write-up. ", 10) // >descriptionTextMaxLen runes
+)
+
+// alertFixture is a fully-populated SecurityAlert used as the default body for
+// list/get fixtures. Individual tests mutate a copy to exercise edge cases
+// (nil tags, missing AffectedEntity, empty LogEntries, etc.).
+func alertFixture(t *testing.T) accessgraph.SecurityAlert {
+	t.Helper()
+	reporter := "detection-engine"
+	desc := fixtureLongDesc
+	entName := "alice@example.com"
+	entType := "user"
+	tags := []string{"prod", "iam"}
+	mitigations := []string{"rotate-key", "notify-security"}
+	logEntries := append([]string{}, fixtureLogUIDs...)
+	updated := fixtureUpdated
+	return accessgraph.SecurityAlert{
+		Id:        fixtureAlertID,
+		Title:     "Unusual privilege escalation",
+		Type:      "privilege_escalation",
+		Severity:  accessgraph.SecurityAlertSeverity("high"),
+		Status:    accessgraph.AlertStatus("in_progress"),
+		Source:    logmodels.EventSource("aws"),
+		StartTime: fixtureStart,
+		EndTime:   fixtureEnd,
+		CreatedAt: fixtureCreated,
+		UpdatedAt: &updated,
+		AffectedEntity: &struct {
+			Name *string `json:"name,omitempty"`
+			Type *string `json:"type,omitempty"`
+		}{Name: &entName, Type: &entType},
+		Tags:            &tags,
+		Description:     &desc,
+		ReportedBy:      &reporter,
+		LogEntries:      &logEntries,
+		MitigationSteps: &mitigations,
+		StatusChangeLogs: []accessgraph.AlertStatusChangeLog{{
+			CreatedAt: fixtureCreated,
+			Status:    accessgraph.AlertStatus("in_progress"),
+			User:      "system",
+		}},
+	}
+}
+
+// listRequest captures what the list handler observed so tests can assert
+// on the request shaping (query DSL, start/end time) produced by
+// constructAlertsListQuery without re-parsing the wire format.
+type listRequest struct {
+	path  string
+	query url.Values
+}
+
+// newListAlertsHandler serves a ListAlertsV1 response and records the inbound
+// request into captured for assertion. Pass statusCode != 0 to drive the
+// error-propagation paths through the same helper.
+func newListAlertsHandler(t *testing.T, alerts []accessgraph.SecurityAlert, captured *listRequest, statusCode int, errBody string) http.Handler {
+	t.Helper()
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if captured != nil {
+			*captured = listRequest{path: r.URL.Path, query: r.URL.Query()}
+		}
+		require.Equal(t, listAlertsPath, r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		if statusCode != 0 && statusCode != http.StatusOK {
+			w.WriteHeader(statusCode)
+			_, _ = w.Write([]byte(errBody))
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(map[string]any{"data": alerts})
+	})
+}
+
+// fetchAlertsPage is a single page returned by newPaginatedAlertsHandler.
+type fetchAlertsPage struct {
+	data       []accessgraph.SecurityAlert
+	nextCursor *string
+}
+
+// newPaginatedAlertsHandler advances through pages on each request, asserting
+// the inbound next_cursor matches the previous page's signal.
+func newPaginatedAlertsHandler(t *testing.T, pages []fetchAlertsPage) http.Handler {
+	t.Helper()
+	var calls atomic.Int64
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		idx := int(calls.Add(1) - 1)
+		require.Less(t, idx, len(pages), "more page requests than configured")
+		if idx > 0 {
+			prev := pages[idx-1].nextCursor
+			require.NotNil(t, prev, "fetchAlerts continued past a nil cursor")
+			require.Equal(t, *prev, r.URL.Query().Get("next_cursor"))
+		}
+		page := pages[idx]
+		body := map[string]any{"data": page.data}
+		if page.nextCursor != nil {
+			body["next_cursor"] = *page.nextCursor
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(body)
+	})
+}
+
+// newDetectionsCommand wires an AccessGraphCommand with a captured stdout
+// buffer and the supplied defaults. Tests override fields on the returned
+// command before calling DetectionsList directly — TryRun is intentionally
+// bypassed because it owns credential loading, not behavior.
+func newDetectionsCommand(t *testing.T, format string) (*AccessGraphCommand, *bytes.Buffer) {
+	t.Helper()
+	var buf bytes.Buffer
+	c := &AccessGraphCommand{
+		stdout: &buf,
+		detections: detectionsArgs{
+			format: format,
+			from:   fixtureFromArg,
+			to:     fixtureToArg,
+		},
+	}
+	return c, &buf
+}
+
+// TestDetectionsList covers DetectionsList: request shaping into the AG list
+// endpoint, output rendering across formats, and error propagation.
+func TestDetectionsList(t *testing.T) {
+	t.Run("request shaping carries filters and window", func(t *testing.T) {
+		var got listRequest
+		ag := newAccessGraphTestClient(t, newListAlertsHandler(t,
+			[]accessgraph.SecurityAlert{alertFixture(t)}, &got, 0, ""))
+
+		c, _ := newDetectionsCommand(t, teleport.JSON)
+		c.detections.ls = detectionsListArgs{
+			status:   []string{"in_progress", "triaged"},
+			source:   []string{"aws"},
+			typ:      []string{"privilege_escalation"},
+			severity: []string{"high", "critical"},
+		}
+		require.NoError(t, c.DetectionsList(context.Background(), ag))
+
+		// The DSL is assembled by ranging over a map, so the AND-joined
+		// clauses come in non-deterministic order — assert membership.
+		clauses := strings.Split(got.query.Get("query"), " AND ")
+		require.ElementsMatch(t, []string{
+			`status:("in_progress" OR "triaged")`,
+			`source:"aws"`,
+			`type:"privilege_escalation"`,
+			`severity:("high" OR "critical")`,
+		}, clauses)
+
+		gotStart, err := time.Parse(time.RFC3339Nano, got.query.Get("start_time"))
+		require.NoError(t, err)
+		require.True(t, gotStart.Equal(fixtureFromArg), "got %v want %v", gotStart, fixtureFromArg)
+		gotEnd, err := time.Parse(time.RFC3339Nano, got.query.Get("end_time"))
+		require.NoError(t, err)
+		require.True(t, gotEnd.Equal(fixtureToArg), "got %v want %v", gotEnd, fixtureToArg)
+	})
+
+	t.Run("json format emits the alert list verbatim", func(t *testing.T) {
+		ag := newAccessGraphTestClient(t, newListAlertsHandler(t,
+			[]accessgraph.SecurityAlert{alertFixture(t)}, nil, 0, ""))
+
+		c, buf := newDetectionsCommand(t, teleport.JSON)
+		require.NoError(t, c.DetectionsList(context.Background(), ag))
+
+		var out []accessgraph.SecurityAlert
+		require.NoError(t, json.Unmarshal(buf.Bytes(), &out))
+		require.Len(t, out, 1)
+		require.Equal(t, fixtureAlertID, out[0].Id)
+		require.Equal(t, "Unusual privilege escalation", out[0].Title)
+	})
+
+	t.Run("yaml format emits the alert list", func(t *testing.T) {
+		ag := newAccessGraphTestClient(t, newListAlertsHandler(t,
+			[]accessgraph.SecurityAlert{alertFixture(t)}, nil, 0, ""))
+
+		c, buf := newDetectionsCommand(t, teleport.YAML)
+		require.NoError(t, c.DetectionsList(context.Background(), ag))
+
+		// utils.WriteYAML emits a slice of length 1 as the bare item (no list wrapper),
+		// so we unmarshal into a single alert. Multi-doc YAML would need yaml.Decoder.
+		var out accessgraph.SecurityAlert
+		require.NoError(t, yaml.Unmarshal(buf.Bytes(), &out))
+		require.Equal(t, fixtureAlertID, out.Id)
+	})
+
+	t.Run("text format renders the default column set", func(t *testing.T) {
+		ag := newAccessGraphTestClient(t, newListAlertsHandler(t,
+			[]accessgraph.SecurityAlert{alertFixture(t)}, nil, 0, ""))
+
+		c, buf := newDetectionsCommand(t, teleport.Text)
+		require.NoError(t, c.DetectionsList(context.Background(), ag))
+
+		out := buf.String()
+		for _, h := range detectionRowHeaders(false) {
+			require.Contains(t, out, h, "missing default column %q", h)
+		}
+		// Detailed-only columns must NOT appear in the default view.
+		for _, h := range []string{"Affected Entity", "Tags", "Description", "Reported By"} {
+			require.NotContains(t, out, h, "detailed column %q leaked into default view", h)
+		}
+		// ID and the Alert title both render in the default view (possibly clipped by the truncated-column helper).
+		require.Contains(t, out, "11111111", "alert ID prefix should appear")
+		require.Contains(t, out, "Unusual", "alert title prefix should appear under the Alert column")
+	})
+
+	t.Run("text format with --detailed adds detailed columns and avoids leaking full description", func(t *testing.T) {
+		ag := newAccessGraphTestClient(t, newListAlertsHandler(t,
+			[]accessgraph.SecurityAlert{alertFixture(t)}, nil, 0, ""))
+
+		c, buf := newDetectionsCommand(t, teleport.Text)
+		c.detections.ls.detailed = true
+		require.NoError(t, c.DetectionsList(context.Background(), ag))
+
+		out := buf.String()
+		for _, h := range detectionRowHeaders(true) {
+			require.Contains(t, out, h, "missing detailed column %q", h)
+		}
+		// Long description must not appear in full — table renderer / pre-truncation clips it.
+		require.NotContains(t, out, fixtureLongDesc, "untruncated description leaked into the table")
+	})
+
+	t.Run("text format on empty alert list renders only headers", func(t *testing.T) {
+		ag := newAccessGraphTestClient(t, newListAlertsHandler(t, []accessgraph.SecurityAlert{}, nil, 0, ""))
+
+		c, buf := newDetectionsCommand(t, teleport.Text)
+		require.NoError(t, c.DetectionsList(context.Background(), ag))
+		out := buf.String()
+		for _, h := range detectionRowHeaders(false) {
+			require.Contains(t, out, h, "header %q should still render for empty result", h)
+		}
+		require.NotContains(t, out, fixtureAlertID.String(), "no alert rows expected for empty result")
+	})
+
+	t.Run("nil alert list renders as empty", func(t *testing.T) {
+		// Handler returns {"data": null} — displayDetections normalizes
+		// this to an empty slice so JSON callers don't get a `null` body.
+		ag := newAccessGraphTestClient(t, newListAlertsHandler(t, nil, nil, 0, ""))
+
+		c, buf := newDetectionsCommand(t, teleport.JSON)
+		require.NoError(t, c.DetectionsList(context.Background(), ag))
+		require.Equal(t, "[]", strings.TrimSpace(buf.String()))
+	})
+
+	t.Run("HTTP 500 surfaces as APIResponseError", func(t *testing.T) {
+		ag := newAccessGraphTestClient(t, newListAlertsHandler(t, nil, nil,
+			http.StatusInternalServerError, `{"message":"alerts backend exploded"}`))
+
+		c, _ := newDetectionsCommand(t, teleport.JSON)
+		err := c.DetectionsList(context.Background(), ag)
+		var agErr *apiResponseError
+		require.ErrorAs(t, err, &agErr)
+		require.Equal(t, http.StatusInternalServerError, agErr.StatusCode)
+		require.Equal(t, "alerts backend exploded", agErr.Message)
+	})
+}
+
+// TestInitDetectionsFlags exercises the kingpin wiring (defaults, enum
+// validation, --from/--to via timeValue) without going through TryRun or
+// touching the network.
+func TestInitDetectionsFlags(t *testing.T) {
+	// parse builds a fresh app + command and parses argv, returning the
+	// populated detectionsArgs for assertion. Kept inline so each subtest
+	// gets an isolated parser state.
+	parse := func(t *testing.T, argv ...string) (detectionsArgs, error) {
+		t.Helper()
+		app := kingpin.New("tctl-test", "")
+		c := &AccessGraphCommand{}
+		c.initDetections(app)
+		_, err := app.Parse(argv)
+		return c.detections, err
+	}
+
+	t.Run("ls defaults", func(t *testing.T) {
+		before := time.Now()
+		got, err := parse(t, "detections", "ls")
+		after := time.Now()
+		require.NoError(t, err)
+
+		require.Equal(t, teleport.Text, got.format)
+		require.Equal(t, []string{"in_progress", "triaged"}, got.ls.status)
+		require.Empty(t, got.ls.severity, "no default severity filter — unset means all")
+		require.False(t, got.ls.detailed)
+		require.Equal(t, 100, got.ls.limit)
+
+		// --from defaults to "30d" → ~30d before parse time. Allow the
+		// parse window (before..after) to absorb any clock drift.
+		require.WithinRange(t, got.from, before.Add(-30*24*time.Hour-time.Second), after.Add(-30*24*time.Hour+time.Second))
+		require.WithinRange(t, got.to, before, after.Add(time.Second))
+	})
+
+	t.Run("ls rejects unknown status enum", func(t *testing.T) {
+		_, err := parse(t, "detections", "ls", "--status", "bogus")
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "enum value must be one of")
+		require.Contains(t, err.Error(), "triaged")
+	})
+
+	t.Run("ls rejects unknown severity enum", func(t *testing.T) {
+		_, err := parse(t, "detections", "ls", "--severity", "extreme")
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "enum value must be one of")
+		require.Contains(t, err.Error(), "critical")
+	})
+
+	t.Run("ls rejects unknown format enum", func(t *testing.T) {
+		_, err := parse(t, "detections", "ls", "--format", "xml")
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "enum value must be one of")
+	})
+
+	t.Run("ls accepts --detailed, --format, and --limit", func(t *testing.T) {
+		got, err := parse(t, "detections", "ls", "--detailed", "--format", teleport.JSON, "--limit", "250")
+		require.NoError(t, err)
+		require.True(t, got.ls.detailed)
+		require.Equal(t, teleport.JSON, got.format)
+		require.Equal(t, 250, got.ls.limit)
+	})
+}
+
+// TestFetchAlerts covers the pagination loop fetchAlerts wraps around
+// ListAlertsV1: cursor walk and the limit-based trim.
+func TestFetchAlerts(t *testing.T) {
+	t.Run("single page under limit returns all alerts", func(t *testing.T) {
+		ag := newAccessGraphTestClient(t, newPaginatedAlertsHandler(t, []fetchAlertsPage{
+			{data: []accessgraph.SecurityAlert{alertFixture(t)}},
+		}))
+		got, err := fetchAlerts(context.Background(), ag, accessgraph.ListAlertsV1Params{}, 100)
+		require.NoError(t, err)
+		require.Len(t, got, 1)
+		require.Equal(t, fixtureAlertID, got[0].Id)
+	})
+
+	t.Run("multi-page response walks the cursor", func(t *testing.T) {
+		cursor := "page2"
+		ag := newAccessGraphTestClient(t, newPaginatedAlertsHandler(t, []fetchAlertsPage{
+			{data: []accessgraph.SecurityAlert{alertFixture(t)}, nextCursor: &cursor},
+			{data: []accessgraph.SecurityAlert{alertFixture(t)}},
+		}))
+		got, err := fetchAlerts(context.Background(), ag, accessgraph.ListAlertsV1Params{}, 100)
+		require.NoError(t, err)
+		require.Len(t, got, 2)
+	})
+
+	t.Run("limit caps and trims across pages", func(t *testing.T) {
+		cursor := "page2"
+		// Two pages of 3 alerts each, limit=4 → fetch both pages, trim to 4.
+		page1 := []accessgraph.SecurityAlert{alertFixture(t), alertFixture(t), alertFixture(t)}
+		page2 := []accessgraph.SecurityAlert{alertFixture(t), alertFixture(t), alertFixture(t)}
+		ag := newAccessGraphTestClient(t, newPaginatedAlertsHandler(t, []fetchAlertsPage{
+			{data: page1, nextCursor: &cursor},
+			{data: page2},
+		}))
+		got, err := fetchAlerts(context.Background(), ag, accessgraph.ListAlertsV1Params{}, 4)
+		require.NoError(t, err)
+		require.Len(t, got, 4)
+	})
+
+	t.Run("limit zero disables the cap", func(t *testing.T) {
+		cursor := "page2"
+		ag := newAccessGraphTestClient(t, newPaginatedAlertsHandler(t, []fetchAlertsPage{
+			{data: []accessgraph.SecurityAlert{alertFixture(t), alertFixture(t)}, nextCursor: &cursor},
+			{data: []accessgraph.SecurityAlert{alertFixture(t)}},
+		}))
+		got, err := fetchAlerts(context.Background(), ag, accessgraph.ListAlertsV1Params{}, 0)
+		require.NoError(t, err)
+		require.Len(t, got, 3)
+	})
+
+	t.Run("non-advancing cursor breaks the loop", func(t *testing.T) {
+		var calls atomic.Int64
+		// Always returns the same non-nil cursor regardless of input, which
+		// would loop forever without the cursor-advance guard.
+		handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			calls.Add(1)
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"data":        []accessgraph.SecurityAlert{alertFixture(t)},
+				"next_cursor": "stuck",
+			})
+		})
+		ag := newAccessGraphTestClient(t, handler)
+		got, err := fetchAlerts(context.Background(), ag, accessgraph.ListAlertsV1Params{}, 0)
+		require.NoError(t, err)
+		require.Len(t, got, 2, "should return alerts collected before the loop broke")
+		require.EqualValues(t, 2, calls.Load(), "loop must stop on the first non-advancing cursor")
+	})
+}

--- a/tool/tctl/common/accessgraph/utils.go
+++ b/tool/tctl/common/accessgraph/utils.go
@@ -139,6 +139,9 @@ func fetchAllLogs(
 		if err != nil {
 			return nil, false, trace.Wrap(err)
 		}
+		if resp.JSON200 == nil {
+			return nil, false, trace.Errorf("received nil json response from Access Graph API")
+		}
 		pages++
 		slog.DebugContext(ctx, "logs page fetched", "page", pages, "page_size", len(resp.JSON200.Data))
 		events = append(events, resp.JSON200.Data...)


### PR DESCRIPTION
Issue: https://github.com/gravitational/access-graph/issues/1933

This PR adds `tctl detections ls`, the first user-facing consumer of the Access Graph (AG) `tctl` plumbing. It is the third of four stacked PRs delivering the foundation for those commands; the PRs can be reviewed independently and are split to keep each diff focused:

| #   | PR                                                             | What it does                                                                  |
| --- | -------------------------------------------------------------- | ----------------------------------------------------------------------------- |
| 1   | [Client](https://github.com/gravitational/teleport/pull/66724) | Hooks up the Access Graph client to `tctl`.                                   |
| 2   | [Utils](https://github.com/gravitational/teleport/pull/66863)  | Shared utilities used by a number of upcoming `tctl` AG-based commands.       |
| 3   | **Detections list (this PR)**                                  | `tctl detections ls` — list security detections with filters and time window. |
| 4   | Detections get (stacked on top)                                | `tctl detections get <id>` — fetch a single detection along with its events.  |

## Why

This is part of the work related to [access-graph#1933](https://github.com/gravitational/access-graph/issues/1933), which is focused on adding `tctl` commands that talk directly to Access Graph through the web proxy. Detections (`ls` and `get`) are the first real consumer surface for that plumbing; `ls` ships on its own so the command's flag/query/render contract can be reviewed before the `get` PR layers on event fetching.

**No pre-emptive feature check.** This command (and other IAC based commands coming later) don't probe whether Identity Activity Center is configured before issuing requests. The web UI does that against `features.json`, but replicating it in `tctl` meant either hitting `features.json` on every command, caching the result, or spinning up an Auth client just to check. After a quick chat with @tigrato , we opted to instead improve the error message from the server, the companion PR [access-graph#1998](https://github.com/gravitational/access-graph/pull/1998) does just that and improves the errors being returned by Access Graph (that PR does not block this one, it just enhances the errors).

A few small notes worth flagging:

- **Pagination is limit-based, not page-cap-based.** Alert lists are expected to be much smaller than the log queries in the utils PR, so a direct `--limit` (default 100, `0` for unbounded) gives users finer-grained control than the page-cap + `truncated` flag used by `fetchAllLogs`.
- **Default columns match the AG web UI** (`IStatus, Date, Source, Alert, Severity`), with `ID` kept so users can grab it easily for a `tctl detections get <id>` call
- **`--format` defaults to `text`** per `tctl X ls` convention; `--status` keeps the triage-focused default of `in_progress, triaged` (same as web), while `--severity` is unset by default (no filter).

Changelog: Added `tctl detections ls` to list Access Graph security detections.

## Manual Test Plan

### Test Environment

- Local dev cluster (current branch for `teleport` + local Access Graph).
- Cloud tenant (master branch for `teleport` + hosted Access Graph).

### Test Cases

- [x] `go build ./tool/tctl/common/accessgraph/...` exits 0.
- [x] `go test ./tool/tctl/common/accessgraph/...` passes.
- [x] `golangci-lint run ./tool/tctl/common/accessgraph/...` reports 0 issues.
- [x] `make full` and `make full-ent` succeed.
- [x] `tctl detections ls` returns the expected detections; text/JSON/YAML formats each render correctly.
- [x] Filter flags (`--status`, `--source`, `--type`, `--severity`, `--from`, `--to`) each narrow results as expected; unset `--severity` does not add a filter clause.
- [x] `--limit` caps results (default 100, explicit `0` returns all pages); cursor walk visits every page until exhausted or limit is hit.
- [x] `--detailed` adds the extended columns to the text output and `Description` is truncated.