### PR TITLE
Add `tctl detections get` command that gets an Identity Activity Center alert

### DIFF
--- a/docs/pages/reference/cli/tctl.mdx
+++ b/docs/pages/reference/cli/tctl.mdx
@@ -1012,6 +1012,22 @@ Flags:
 |`--format`|`text`|Output format, 'text', 'json' or 'yaml'|
 |`-v`, `--[no-]verbose`|`false`|Verbose table output, shows full label output|
 
+## tctl detections get
+
+Get Identity Security detection details.
+
+Usage:
+
+```code
+$ tctl detections get <id>
+```
+
+Arguments:
+
+|Argument|Default|Description|
+|---|---|---|
+|id|*no default* (required)|The detection ID to retrieve.|
+
 ## tctl detections ls
 
 List Identity Security detections.

--- a/tool/tctl/common/accessgraph/command.go
+++ b/tool/tctl/common/accessgraph/command.go
@@ -68,6 +68,8 @@ func (c *AccessGraphCommand) TryRun(ctx context.Context, cmd string, clientFunc 
 	switch cmd {
 	case c.detections.ls.cmd.FullCommand():
 		commandFunc = c.DetectionsList
+	case c.detections.get.cmd.FullCommand():
+		commandFunc = c.DetectionsGet
 	default:
 		return false, nil
 	}

--- a/tool/tctl/common/accessgraph/detections_command.go
+++ b/tool/tctl/common/accessgraph/detections_command.go
@@ -27,10 +27,13 @@ import (
 	"time"
 
 	"github.com/alecthomas/kingpin/v2"
+	"github.com/charmbracelet/lipgloss"
+	"github.com/google/uuid"
 	"github.com/gravitational/trace"
 
 	"github.com/gravitational/teleport"
 	accessgraph "github.com/gravitational/teleport/lib/accessgraph/apiclient"
+	logmodels "github.com/gravitational/teleport/lib/accessgraph/apiclient/models/logs"
 	"github.com/gravitational/teleport/lib/asciitable"
 )
 
@@ -41,6 +44,7 @@ const descriptionTextMaxLen = 80
 type detectionsArgs struct {
 	cmd *kingpin.CmdClause
 	ls  detectionsListArgs
+	get detectionsGetArgs
 
 	// Date filters
 	from time.Time
@@ -80,6 +84,7 @@ func (c *AccessGraphCommand) initDetections(app *kingpin.Application) {
 	c.detections.cmd = detectionsCmd
 
 	c.initDetectionsList(c.detections.cmd)
+	c.initDetectionsGet(c.detections.cmd)
 }
 
 func (c *AccessGraphCommand) initDetectionsList(parent *kingpin.CmdClause) {
@@ -140,16 +145,16 @@ func fetchAlerts(
 		if resp.JSON200 == nil {
 			return nil, trace.Errorf("received nil json response from Access Graph API")
 		}
+		// Guard against a backend that returns a non-advancing cursor, which would otherwise spin forever.
+		if cursor != nil && resp.JSON200.NextCursor != nil && *resp.JSON200.NextCursor == *cursor {
+			slog.DebugContext(ctx, "Access Graph cursor did not advance; stopping pagination", "cursor", *cursor)
+			return alerts, nil
+		}
 		alerts = append(alerts, resp.JSON200.Data...)
 		if limit > 0 && len(alerts) >= limit {
 			return alerts[:limit], nil
 		}
 		if resp.JSON200.NextCursor == nil {
-			return alerts, nil
-		}
-		// Guard against a backend that returns a non-advancing cursor, which would otherwise spin forever.
-		if cursor != nil && *resp.JSON200.NextCursor == *cursor {
-			slog.DebugContext(ctx, "Access Graph cursor did not advance; stopping pagination", "cursor", *cursor)
 			return alerts, nil
 		}
 		cursor = resp.JSON200.NextCursor
@@ -280,6 +285,134 @@ func displayDetectionsText(out io.Writer, alerts []accessgraph.SecurityAlert, de
 		rows = append(rows, detectionRow(alert, detailed))
 	}
 	table := asciitable.MakeTable(headers, rows...)
-	_, err := fmt.Fprintln(out, table.AsBuffer().String())
+	_, err := fmt.Fprintln(out, table.String())
 	return trace.Wrap(err)
+}
+
+type detectionsGetArgs struct {
+	cmd *kingpin.CmdClause
+	id  string
+}
+
+func (c *AccessGraphCommand) initDetectionsGet(parent *kingpin.CmdClause) {
+	getCmd := parent.Command("get", "Get Identity Security detection details.")
+	getCmd.Arg("id", "The detection ID to retrieve.").Required().StringVar(&c.detections.get.id)
+	c.detections.get.cmd = getCmd
+}
+
+// detectionGetOutput is the payload for `detections get`.
+type detectionGetOutput struct {
+	Alert       accessgraph.SecurityAlert                  `json:"alert" yaml:"alert"`
+	Events      []logmodels.AccessgraphStorageV1alphaEvent `json:"events" yaml:"events"`
+	EventsError string                                     `json:"events_error,omitempty" yaml:"events_error,omitempty"`
+}
+
+// DetectionsGet executes `tctl detections get <id>`.
+func (c *AccessGraphCommand) DetectionsGet(ctx context.Context, client *accessgraph.ClientWithResponses) error {
+	id, err := uuid.Parse(c.detections.get.id)
+	if err != nil {
+		return trace.BadParameter("invalid detection id %q: %v", c.detections.get.id, err)
+	}
+	resp, err := doRequest(client.GetAlertV1WithResponse(ctx, id))
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	if resp.JSON200 == nil {
+		return trace.Errorf("received nil json response from Access Graph API")
+	}
+
+	alert := resp.JSON200.Data
+
+	// Non-fatal: alert detail is still useful; error surfaces in Log Entries.
+	events, eventsErr := fetchAlertEvents(ctx, client, alert)
+
+	out := detectionGetOutput{Alert: alert, Events: events}
+	if eventsErr != nil {
+		out.EventsError = eventsErr.Error()
+	}
+	return writeOutput(c.stdout, out, c.detections.format, func(w io.Writer) error {
+		return displayDetectionText(w, alert, events, eventsErr)
+	})
+}
+
+// eventsFetchErrorStyle paints the events-fetch warning yellow + bold.
+var eventsFetchErrorStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("11")).Bold(true)
+
+// fetchAlertEvents fetches the logs referenced by the alert's LogEntries.
+func fetchAlertEvents(ctx context.Context, client *accessgraph.ClientWithResponses, a accessgraph.SecurityAlert) ([]logmodels.AccessgraphStorageV1alphaEvent, error) {
+	if a.LogEntries == nil || len(*a.LogEntries) == 0 {
+		return nil, nil
+	}
+	query := dslClause("uid", *a.LogEntries)
+	order := accessgraph.Asc
+	events, _, err := fetchAllLogs(ctx, client, accessgraph.ExecuteLogsQueryV1Params{
+		Query:     &query,
+		Order:     &order,
+		StartTime: &a.StartTime,
+		EndTime:   &a.EndTime,
+	}, len(*a.LogEntries))
+	return events, trace.Wrap(err)
+}
+
+// displayDetectionText renders the human-readable detail view for one alert.
+func displayDetectionText(out io.Writer, a accessgraph.SecurityAlert, events []logmodels.AccessgraphStorageV1alphaEvent, eventsErr error) error {
+	field := func(label, value string) {
+		fmt.Fprintf(out, "%-19s%s\n", label+":", value)
+	}
+	field("ID", a.Id.String())
+	field("Title", a.Title)
+	field("Severity", string(a.Severity))
+	field("Status", string(a.Status))
+	if a.AffectedEntity != nil && a.AffectedEntity.Name != nil && *a.AffectedEntity.Name != "" {
+		field("Affected Entity", *a.AffectedEntity.Name)
+	}
+	field("Type", a.Type)
+	field("Source", string(a.Source))
+	if a.ReportedBy != nil {
+		field("Reported By", *a.ReportedBy)
+	}
+	if a.Tags != nil && len(*a.Tags) > 0 {
+		field("Tags", strings.Join(*a.Tags, ", "))
+	}
+	field("Period", fmt.Sprintf("%s → %s", a.StartTime.Format(time.RFC3339), a.EndTime.Format(time.RFC3339)))
+	field("Created", a.CreatedAt.Format(time.RFC3339))
+	if a.UpdatedAt != nil {
+		field("Updated", a.UpdatedAt.Format(time.RFC3339))
+	}
+	if a.Description != nil && *a.Description != "" {
+		fmt.Fprintf(out, "\nDescription:\n%s\n", *a.Description)
+	}
+	if a.MitigationSteps != nil && len(*a.MitigationSteps) > 0 {
+		fmt.Fprintln(out, "\nMitigation Steps:")
+		for _, step := range *a.MitigationSteps {
+			fmt.Fprintf(out, "  - %s\n", step)
+		}
+	}
+	if eventsErr != nil || len(events) > 0 || (a.LogEntries != nil && len(*a.LogEntries) > 0) {
+		fmt.Fprintln(out, "\nLog Entries:")
+		switch {
+		case eventsErr != nil:
+			fmt.Fprintln(out, eventsFetchErrorStyle.Render(eventsErr.Error()))
+		case len(events) == 0:
+			fmt.Fprintln(out, "Not found.")
+		default:
+			if err := displayEventsText(out, events); err != nil {
+				return trace.Wrap(err)
+			}
+		}
+	}
+	if len(a.StatusChangeLogs) > 0 {
+		fmt.Fprintln(out, "\nStatus Changes:")
+		changes := asciitable.MakeTable([]string{"Time", "Status", "User", "Reason"})
+		for _, log := range a.StatusChangeLogs {
+			reason := ""
+			if log.Reason != nil {
+				reason = *log.Reason
+			}
+			changes.AddRow([]string{log.CreatedAt.Format(time.RFC3339), string(log.Status), log.User, reason})
+		}
+		fmt.Fprintln(out, changes.String())
+	}
+	return nil
 }

--- a/tool/tctl/common/accessgraph/detections_command_test.go
+++ b/tool/tctl/common/accessgraph/detections_command_test.go
@@ -31,6 +31,7 @@ import (
 
 	"github.com/alecthomas/kingpin/v2"
 	"github.com/google/uuid"
+	"github.com/gravitational/trace"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v3"
 
@@ -43,6 +44,8 @@ import (
 // fails loudly if the generated client's operation paths drift.
 const (
 	listAlertsPath = accessGraphAPIPath + "graph/alerts/v1"
+	getAlertPath   = accessGraphAPIPath + "graph/alerts/v1/" // + <uuid>
+	logsQueryPath  = accessGraphAPIPath + "graph/logs/v1"
 )
 
 // Fixed values shared across fixtures so handler assertions can pin the
@@ -97,6 +100,20 @@ func alertFixture(t *testing.T) accessgraph.SecurityAlert {
 			Status:    accessgraph.AlertStatus("in_progress"),
 			User:      "system",
 		}},
+	}
+}
+
+// eventFixture builds a minimal event with a deterministic timestamp.
+func eventFixture(uid string, offset time.Duration) logmodels.AccessgraphStorageV1alphaEvent {
+	return logmodels.AccessgraphStorageV1alphaEvent{
+		Uuid:        uid,
+		Time:        fixtureStart.Add(offset),
+		Action:      "LOGIN",
+		EventType:   "authentication",
+		EventSource: logmodels.EventSource("aws"),
+		Status:      "success",
+		Identity:    logmodels.AccessgraphStorageV1alphaIdentity{Name: "alice", Id: "alice@example.com"},
+		Target:      logmodels.AccessgraphStorageV1alphaTarget{Resource: "prod-db"},
 	}
 }
 
@@ -156,6 +173,57 @@ func newPaginatedAlertsHandler(t *testing.T, pages []fetchAlertsPage) http.Handl
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 		_ = json.NewEncoder(w).Encode(body)
+	})
+}
+
+// getAlertRequests records the wire-level traffic DetectionsGet drove.
+type getAlertRequests struct {
+	alertPath    string
+	logCalls     atomic.Int64
+	logIterators []string
+	logQuery     string
+	logStart     string
+	logEnd       string
+}
+
+// newGetAlertHandler serves the alert and (paginated) logs routes. Pass
+// nil/empty logPages to assert the logs route is never hit.
+func newGetAlertHandler(t *testing.T, alert accessgraph.SecurityAlert, logPages []fetchAllLogsPage, captured *getAlertRequests, alertStatus int, alertErrBody string) http.Handler {
+	t.Helper()
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.URL.Path == getAlertPath+alert.Id.String():
+			if captured != nil {
+				captured.alertPath = r.URL.Path
+			}
+			if alertStatus != 0 && alertStatus != http.StatusOK {
+				w.WriteHeader(alertStatus)
+				_, _ = w.Write([]byte(alertErrBody))
+				return
+			}
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(map[string]any{"data": alert})
+		case r.URL.Path == logsQueryPath:
+			idx := int(captured.logCalls.Add(1) - 1)
+			captured.logIterators = append(captured.logIterators, r.URL.Query().Get("iterator"))
+			// Query + window are constant across pages so first-call values are sufficient.
+			if idx == 0 {
+				captured.logQuery = r.URL.Query().Get("query")
+				captured.logStart = r.URL.Query().Get("start_time")
+				captured.logEnd = r.URL.Query().Get("end_time")
+			}
+			require.Less(t, idx, len(logPages), "client requested more log pages than configured")
+			page := logPages[idx]
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"data":        page.data,
+				"next_cursor": page.nextCursor,
+			})
+		default:
+			t.Errorf("unexpected request to %s", r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		}
 	})
 }
 
@@ -298,7 +366,7 @@ func TestDetectionsList(t *testing.T) {
 		require.Equal(t, "[]", strings.TrimSpace(buf.String()))
 	})
 
-	t.Run("HTTP 500 surfaces as APIResponseError", func(t *testing.T) {
+	t.Run("HTTP 500 surfaces as apiResponseError", func(t *testing.T) {
 		ag := newAccessGraphTestClient(t, newListAlertsHandler(t, nil, nil,
 			http.StatusInternalServerError, `{"message":"alerts backend exploded"}`))
 
@@ -309,6 +377,192 @@ func TestDetectionsList(t *testing.T) {
 		require.Equal(t, http.StatusInternalServerError, agErr.StatusCode)
 		require.Equal(t, "alerts backend exploded", agErr.Message)
 	})
+}
+
+func TestDetectionsGet(t *testing.T) {
+	t.Run("invalid uuid returns BadParameter without hitting the server", func(t *testing.T) {
+		// Handler fails on any request — the uuid guard must trip first.
+		var called atomic.Int64
+		ag := newAccessGraphTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			called.Add(1)
+			t.Errorf("server reached despite invalid uuid: %s", r.URL.Path)
+		}))
+
+		c, _ := newDetectionsCommand(t, teleport.JSON)
+		c.detections.get.id = "not-a-uuid"
+		err := c.DetectionsGet(context.Background(), ag)
+		require.True(t, trace.IsBadParameter(err), "want BadParameter, got %v", err)
+		require.EqualValues(t, 0, called.Load())
+	})
+
+	t.Run("alert with log entries walks the logs cursor across pages", func(t *testing.T) {
+		alert := alertFixture(t)
+		cursor := "page-2"
+		page1 := []logmodels.AccessgraphStorageV1alphaEvent{eventFixture(fixtureLogUIDs[0], time.Minute)}
+		page2 := []logmodels.AccessgraphStorageV1alphaEvent{eventFixture(fixtureLogUIDs[1], 2*time.Minute)}
+		var got getAlertRequests
+		ag := newAccessGraphTestClient(t, newGetAlertHandler(t, alert, []fetchAllLogsPage{
+			{data: eventsAsMaps(t, page1), nextCursor: &cursor},
+			{data: eventsAsMaps(t, page2)},
+		}, &got, 0, ""))
+
+		c, buf := newDetectionsCommand(t, teleport.JSON)
+		c.detections.get.id = alert.Id.String()
+		require.NoError(t, c.DetectionsGet(context.Background(), ag))
+
+		require.Equal(t, getAlertPath+alert.Id.String(), got.alertPath)
+		require.EqualValues(t, 2, got.logCalls.Load(), "should walk both pages")
+		require.Equal(t, []string{"", "page-2"}, got.logIterators, "second call must send the prior next_cursor")
+		require.Equal(t, `uid:("22222222-2222-2222-2222-222222222222" OR "33333333-3333-3333-3333-333333333333")`, got.logQuery)
+		require.Equal(t, fixtureStart.Format(time.RFC3339), got.logStart, "fetchAlertEvents must send the alert's StartTime")
+		require.Equal(t, fixtureEnd.Format(time.RFC3339), got.logEnd, "fetchAlertEvents must send the alert's EndTime")
+
+		var out detectionGetOutput
+		require.NoError(t, json.Unmarshal(buf.Bytes(), &out))
+		require.Len(t, out.Events, 2, "events from both pages should appear in the payload")
+	})
+
+	t.Run("alert without log entries skips the logs fetch", func(t *testing.T) {
+		alert := alertFixture(t)
+		empty := []string{}
+		alert.LogEntries = &empty
+
+		var got getAlertRequests
+		ag := newAccessGraphTestClient(t, newGetAlertHandler(t, alert, nil, &got, 0, ""))
+
+		c, _ := newDetectionsCommand(t, teleport.JSON)
+		c.detections.get.id = alert.Id.String()
+		require.NoError(t, c.DetectionsGet(context.Background(), ag))
+		require.EqualValues(t, 0, got.logCalls.Load(), "logs endpoint must not be called when LogEntries is empty")
+	})
+
+	t.Run("json output contains alert and events", func(t *testing.T) {
+		alert := alertFixture(t)
+		events := []logmodels.AccessgraphStorageV1alphaEvent{
+			eventFixture(fixtureLogUIDs[0], time.Minute),
+			eventFixture(fixtureLogUIDs[1], 2*time.Minute),
+		}
+		ag := newAccessGraphTestClient(t, newGetAlertHandler(t, alert, []fetchAllLogsPage{{
+			data: eventsAsMaps(t, events),
+		}}, &getAlertRequests{}, 0, ""))
+
+		c, buf := newDetectionsCommand(t, teleport.JSON)
+		c.detections.get.id = alert.Id.String()
+		require.NoError(t, c.DetectionsGet(context.Background(), ag))
+
+		var out detectionGetOutput
+		require.NoError(t, json.Unmarshal(buf.Bytes(), &out))
+		require.Equal(t, fixtureAlertID, out.Alert.Id)
+		require.Len(t, out.Events, 2)
+		require.Equal(t, fixtureLogUIDs[0], out.Events[0].Uuid)
+	})
+
+	t.Run("text output renders alert detail and events table", func(t *testing.T) {
+		alert := alertFixture(t)
+		events := []logmodels.AccessgraphStorageV1alphaEvent{
+			eventFixture(fixtureLogUIDs[0], time.Minute),
+		}
+		ag := newAccessGraphTestClient(t, newGetAlertHandler(t, alert, []fetchAllLogsPage{{
+			data: eventsAsMaps(t, events),
+		}}, &getAlertRequests{}, 0, ""))
+
+		c, buf := newDetectionsCommand(t, teleport.Text)
+		c.detections.get.id = alert.Id.String()
+		require.NoError(t, c.DetectionsGet(context.Background(), ag))
+
+		out := buf.String()
+		// Header lines from displayDetectionText.
+		require.Contains(t, out, "ID:                "+fixtureAlertID.String())
+		require.Contains(t, out, "Title:             Unusual privilege escalation")
+		require.Contains(t, out, "Severity:          high")
+		require.Contains(t, out, "Period:            "+fixtureStart.Format(time.RFC3339)+" → "+fixtureEnd.Format(time.RFC3339))
+		require.Contains(t, out, "Affected Entity:   alice@example.com")
+		// Events table.
+		require.Contains(t, out, "Log Entries:")
+		require.Contains(t, out, "alice")
+		require.Contains(t, out, "prod-db")
+		// Status-change table.
+		require.Contains(t, out, "Status Changes:")
+	})
+
+	t.Run("text output omits optional headers when fields are nil", func(t *testing.T) {
+		alert := accessgraph.SecurityAlert{
+			Id:        fixtureAlertID,
+			Title:     "Bare alert",
+			Type:      "anomaly",
+			Severity:  accessgraph.SecurityAlertSeverity("low"),
+			Status:    accessgraph.AlertStatus("open"),
+			Source:    logmodels.EventSource("aws"),
+			StartTime: fixtureStart,
+			EndTime:   fixtureEnd,
+			CreatedAt: fixtureCreated,
+		}
+		ag := newAccessGraphTestClient(t, newGetAlertHandler(t, alert, nil, &getAlertRequests{}, 0, ""))
+
+		c, buf := newDetectionsCommand(t, teleport.Text)
+		c.detections.get.id = alert.Id.String()
+		require.NoError(t, c.DetectionsGet(context.Background(), ag))
+
+		out := buf.String()
+		require.Contains(t, out, "ID:                "+fixtureAlertID.String())
+		require.Contains(t, out, "Title:             Bare alert")
+		for _, header := range []string{
+			"Reported By:", "Updated:", "Affected Entity:", "Tags:",
+			"Description:", "Mitigation Steps:", "Log Entries:", "Status Changes:",
+		} {
+			require.NotContains(t, out, header, "optional section %q must not render for a minimal alert", header)
+		}
+	})
+
+	t.Run("HTTP 404 from get surfaces as apiResponseError", func(t *testing.T) {
+		alert := alertFixture(t)
+		ag := newAccessGraphTestClient(t, newGetAlertHandler(t, alert, nil, &getAlertRequests{},
+			http.StatusNotFound, `{"message":"no such alert"}`))
+
+		c, _ := newDetectionsCommand(t, teleport.JSON)
+		c.detections.get.id = alert.Id.String()
+		err := c.DetectionsGet(context.Background(), ag)
+		var agErr *apiResponseError
+		require.ErrorAs(t, err, &agErr)
+		require.Equal(t, http.StatusNotFound, agErr.StatusCode)
+		require.Equal(t, "no such alert", agErr.Message)
+	})
+}
+
+func TestDisplayDetectionTextAffectedEntity(t *testing.T) {
+	strPtr := func(s string) *string { return &s }
+
+	cases := []struct {
+		name     string
+		entName  *string
+		wantLine string // empty = no Affected line
+	}{
+		{"name set", strPtr("alice@example.com"), "Affected Entity:   alice@example.com"},
+		{"name nil", nil, ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			alert := accessgraph.SecurityAlert{
+				Id: fixtureAlertID, Title: "x", Type: "x",
+				Severity:  accessgraph.SecurityAlertSeverity("low"),
+				Status:    accessgraph.AlertStatus("open"),
+				Source:    logmodels.EventSource("aws"),
+				StartTime: fixtureStart, EndTime: fixtureEnd, CreatedAt: fixtureCreated,
+				AffectedEntity: &struct {
+					Name *string `json:"name,omitempty"`
+					Type *string `json:"type,omitempty"`
+				}{Name: tc.entName},
+			}
+			var buf bytes.Buffer
+			require.NoError(t, displayDetectionText(&buf, alert, nil, nil))
+			out := buf.String()
+			if tc.wantLine == "" {
+				require.NotContains(t, out, "Affected Entity:")
+				return
+			}
+			require.Contains(t, out, tc.wantLine)
+		})
+	}
 }
 
 // TestInitDetectionsFlags exercises the kingpin wiring (defaults, enum
@@ -371,6 +625,17 @@ func TestInitDetectionsFlags(t *testing.T) {
 		require.True(t, got.ls.detailed)
 		require.Equal(t, teleport.JSON, got.format)
 		require.Equal(t, 250, got.ls.limit)
+	})
+
+	t.Run("get requires id argument", func(t *testing.T) {
+		_, err := parse(t, "detections", "get")
+		require.Error(t, err)
+	})
+
+	t.Run("get captures id positional", func(t *testing.T) {
+		got, err := parse(t, "detections", "get", fixtureAlertID.String())
+		require.NoError(t, err)
+		require.Equal(t, fixtureAlertID.String(), got.get.id)
 	})
 }
 
@@ -438,7 +703,23 @@ func TestFetchAlerts(t *testing.T) {
 		ag := newAccessGraphTestClient(t, handler)
 		got, err := fetchAlerts(context.Background(), ag, accessgraph.ListAlertsV1Params{}, 0)
 		require.NoError(t, err)
-		require.Len(t, got, 2, "should return alerts collected before the loop broke")
+		require.Len(t, got, 1, "guard fires before appending the duplicate page")
 		require.EqualValues(t, 2, calls.Load(), "loop must stop on the first non-advancing cursor")
 	})
+}
+
+// eventsAsMaps re-marshals events through JSON so the handler's
+// fetchAllLogsPage (which carries []map[string]any) can serialize them with
+// the exact field shape the AG schema expects.
+func eventsAsMaps(t *testing.T, events []logmodels.AccessgraphStorageV1alphaEvent) []map[string]any {
+	t.Helper()
+	out := make([]map[string]any, 0, len(events))
+	for _, ev := range events {
+		b, err := json.Marshal(ev)
+		require.NoError(t, err)
+		var m map[string]any
+		require.NoError(t, json.Unmarshal(b, &m))
+		out = append(out, m)
+	}
+	return out
 }

--- a/tool/tctl/common/accessgraph/utils.go
+++ b/tool/tctl/common/accessgraph/utils.go
@@ -31,6 +31,7 @@ import (
 	"github.com/gravitational/teleport"
 	accessgraph "github.com/gravitational/teleport/lib/accessgraph/apiclient"
 	logmodels "github.com/gravitational/teleport/lib/accessgraph/apiclient/models/logs"
+	"github.com/gravitational/teleport/lib/asciitable"
 	"github.com/gravitational/teleport/lib/utils"
 )
 
@@ -142,6 +143,14 @@ func fetchAllLogs(
 		if resp.JSON200 == nil {
 			return nil, false, trace.Errorf("received nil json response from Access Graph API")
 		}
+
+		// Guard against a backend that returns a non-advancing cursor, which would otherwise spin forever.
+		if cursor != nil && resp.JSON200.NextCursor != nil && *resp.JSON200.NextCursor == *cursor {
+			slog.DebugContext(ctx, "Access Graph cursor did not advance; stopping pagination", "cursor", *cursor)
+			truncated = true
+			break
+		}
+
 		pages++
 		slog.DebugContext(ctx, "logs page fetched", "page", pages, "page_size", len(resp.JSON200.Data))
 		events = append(events, resp.JSON200.Data...)
@@ -195,4 +204,43 @@ func writeOutput(w io.Writer, payload any, format string, renderText func(io.Wri
 	default:
 		return trace.BadParameter("unknown format %q", format)
 	}
+}
+
+// displayEventsText renders access-graph log events as a compact table.
+func displayEventsText(out io.Writer, events []logmodels.AccessgraphStorageV1alphaEvent) error {
+	if len(events) == 0 {
+		_, err := fmt.Fprintln(out, "No events found.")
+		return trace.Wrap(err)
+	}
+
+	table := asciitable.MakeTable([]string{
+		"Time",
+		"Identity",
+		"Event Type",
+		"Action",
+		"Status",
+		"Resource",
+		"Source",
+	})
+	for _, ev := range events {
+		identity := ev.Identity.Name
+		if identity == "" {
+			identity = ev.Identity.Id
+		}
+		resource := ev.Target.Resource
+		if resource == "" && ev.Target.Id != "" {
+			resource = ev.Target.Id
+		}
+		table.AddRow([]string{
+			ev.Time.Format(time.RFC3339),
+			identity,
+			ev.EventType,
+			ev.Action,
+			ev.Status,
+			resource,
+			strings.TrimSpace(string(ev.EventSource)),
+		})
+	}
+	_, err := fmt.Fprintln(out, table.AsBuffer().String())
+	return trace.Wrap(err)
 }

--- a/tool/tctl/common/accessgraph/utils_test.go
+++ b/tool/tctl/common/accessgraph/utils_test.go
@@ -310,15 +310,18 @@ func TestFetchAllLogs(t *testing.T) {
 	})
 
 	t.Run("maxResults limit returns partial results with truncated=true", func(t *testing.T) {
-		stuck := "stuck"
+		// Advancing cursors per page so the non-advancing guard doesn't fire;
+		// the cap must be the thing that stops the loop.
+		cursors := []string{"c1", "c2", "c3", "c4", "c5"}
 		var calls atomic.Int64
 		h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			calls.Add(1)
+			n := calls.Add(1)
+			next := cursors[n-1]
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(200)
 			_ = json.NewEncoder(w).Encode(map[string]any{
 				"data":        []map[string]any{{"id": "x"}},
-				"next_cursor": &stuck,
+				"next_cursor": &next,
 			})
 		})
 		c := newAccessGraphTestClient(t, h)
@@ -341,6 +344,29 @@ func TestFetchAllLogs(t *testing.T) {
 		require.True(t, truncated, "single-page overshoot must flag truncated")
 		require.Len(t, got, 3)
 		require.EqualValues(t, 1, calls.Load())
+	})
+
+	t.Run("non-advancing cursor breaks the unbounded loop", func(t *testing.T) {
+		stuck := "stuck"
+		var calls atomic.Int64
+		// Always returns the same non-nil cursor, which without the guard
+		// would loop forever when maxResults is unbounded.
+		h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			calls.Add(1)
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(200)
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"data":        []map[string]any{{"id": "x"}},
+				"next_cursor": &stuck,
+			})
+		})
+		c := newAccessGraphTestClient(t, h)
+
+		got, truncated, err := fetchAllLogs(context.Background(), c, accessgraph.ExecuteLogsQueryV1Params{}, 0)
+		require.NoError(t, err)
+		require.True(t, truncated, "non-advancing cursor must signal truncation")
+		require.Len(t, got, 1, "guard fires before appending the duplicate page")
+		require.EqualValues(t, 2, calls.Load(), "loop must stop on the first non-advancing cursor")
 	})
 
 	t.Run("maxResults zero means unbounded", func(t *testing.T) {


### PR DESCRIPTION
Issue: https://github.com/gravitational/access-graph/issues/1933

This PR adds `tctl detections get <id>`, the second user-facing consumer of the Access Graph (AG) `tctl` plumbing. It is the fourth of four stacked PRs delivering the foundation for those commands; the PRs can be reviewed independently and are split to keep each diff focused:

| #   | PR                                                                      | What it does                                                                  |
| --- | ----------------------------------------------------------------------- | ----------------------------------------------------------------------------- |
| 1   | [Client](https://github.com/gravitational/teleport/pull/66724)          | Hooks up the Access Graph client to `tctl`.                                   |
| 2   | [Utils](https://github.com/gravitational/teleport/pull/66863)           | Shared utilities used by a number of upcoming `tctl` AG-based commands.       |
| 3   | [Detections list](https://github.com/gravitational/teleport/pull/66885) | `tctl detections ls` — list security detections with filters and time window. |
| 4   | **Detections get (this PR)**                                            | `tctl detections get <id>` — fetch a single detection along with its events.  |

## Why

This is part of the work related to [access-graph#1933](https://github.com/gravitational/access-graph/issues/1933), which is focused on adding `tctl` commands that talk directly to Access Graph through the web proxy. `get` is the natural follow-up to `ls`: the path operators take when triaging a specific detection.

**No pre-emptive feature check.** Same approach as `ls` — see the [detections list PR](https://github.com/gravitational/teleport/pull/66885) and [access-graph#1998](https://github.com/gravitational/access-graph/pull/1998) for the full rationale. Short version: the CLI doesn't probe `features.json` before the call; the backend now returns better errors and `tctl` surfaces them.

A few notes worth flagging:

- **Events fetch is non-fatal.** The alert detail is useful on its own, so a failed events fetch does not abort the command — the error is surfaced via `detectionGetOutput.EventsError` (JSON/YAML) and the AG-returned message renders inline under `Log Entries:` (text).
- **`displayEventsText` lives in `utils.go`** so future AG consumers (`access review`, `investigate`) can share the events-table layout.

Open question for reviewers: should `get` expose a `--log-limit` flag? Today the events query is `uid:(...)` built from the alert's `LogEntries`, so it is naturally bounded by `len(LogEntries)` and the fetcher runs unbounded. If alerts in production carry large `LogEntries` sets we may want a default cap (e.g. 10) — happy to add it here or in a follow-up.

Changelog: Added `tctl detections get <id>` to fetch a single Access Graph security detection along with its events.

## Manual Test Plan

### Test Environment

- Local dev cluster (current branch for `teleport` + local Access Graph).
- Cloud tenant (master branch for `teleport` + hosted Access Graph).

### Test Cases

- [x] `go build ./tool/tctl/common/accessgraph/...` exits 0.
- [x] `go test ./tool/tctl/common/accessgraph/...` passes.
- [x] `golangci-lint run ./tool/tctl/common/accessgraph/...` reports 0 issues.
- [x] `make full` and `make full-ent` succeed.
- [x] `tctl detections get <id>` returns the expected detection; text/JSON/YAML formats each render correctly.
- [x] A malformed `<id>` (non-UUID) is rejected before the network call with a clear error.
- [x] An unknown but well-formed `<id>` surfaces the AG HTTP error (e.g. 404) rather than crashing.
- [x] Alerts with `LogEntries` but a failing events fetch still render the alert detail; the JSON `events_error` field is populated and the text `Log Entries:` section shows the AG-returned error message.
- [x] Text output omits each optional section (`Reported`, `Updated`, `Affected`, `Tags`, `Description`, `Mitigation Steps`, `Log Entries`, `Status Changes`) when the underlying field is nil/empty.
- [x] `Affected:` renders the entity name when set and is omitted otherwise.