### PR TITLE
Switch to net.SplitHostPort to extract host from remote address

### DIFF
--- a/lib/limiter/internal/ratelimit/http.go
+++ b/lib/limiter/internal/ratelimit/http.go
@@ -20,7 +20,6 @@ import (
 	"net"
 	"net/http"
 	"strconv"
-	"strings"
 )
 
 func ServeHTTPError(w http.ResponseWriter, r *http.Request, err error) {
@@ -50,11 +49,10 @@ func ServeHTTPError(w http.ResponseWriter, r *http.Request, err error) {
 }
 
 func ExtractClientIP(r *http.Request) (string, error) {
-	// TODO: use net.SplitHostPort to be compatible with IPv6
-	token, _, _ := strings.Cut(r.RemoteAddr, ":")
-	if token == "" {
+	host, _, err := net.SplitHostPort(r.RemoteAddr)
+	if err != nil || host == "" {
 		return "", errors.New("failed to extract source IP")
 	}
 
-	return token, nil
+	return host, nil
 }

--- a/lib/limiter/internal/ratelimit/http_test.go
+++ b/lib/limiter/internal/ratelimit/http_test.go
@@ -1,0 +1,52 @@
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ratelimit
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestExtractClientIP(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		remoteAddr string
+		want       string
+	}{
+		{
+			name:       "IPv4",
+			remoteAddr: "127.0.0.1:1234",
+			want:       "127.0.0.1",
+		},
+		{
+			name:       "IPv6",
+			remoteAddr: "[::1]:1234",
+			want:       "::1",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ExtractClientIP(&http.Request{RemoteAddr: tt.remoteAddr})
+
+			assert.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}


### PR DESCRIPTION
Fixed limiter IP extraction for IPv6 remote addresses.
Addresses: https://github.com/gravitational/pressure-washing/issues/51