### PR TITLE
event-handler: fix ephemeral port exhaustion when sending to fluentd

### DIFF
--- a/integrations/event-handler/fluentd_client.go
+++ b/integrations/event-handler/fluentd_client.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"crypto/tls"
 	"crypto/x509"
+	"io"
 	"log/slog"
 	"net/http"
 	"os"
@@ -72,6 +73,7 @@ func NewFluentdClient(c *FluentdConfig, log *slog.Logger) (*FluentdClient, error
 			RootCAs:      ca,
 			Certificates: certs,
 		},
+		MaxConnsPerHost:     c.FluentdMaxConnections,
 		MaxIdleConnsPerHost: c.FluentdMaxConnections,
 		IdleConnTimeout:     httpTimeout,
 	}
@@ -128,7 +130,11 @@ func (f *FluentdClient) Send(ctx context.Context, url string, b []byte) error {
 
 		return trace.Wrap(err)
 	}
-	defer r.Body.Close()
+	// Drain and close the body to enable TCP connection reuse.
+	defer func() {
+		io.Copy(io.Discard, r.Body)
+		r.Body.Close()
+	}()
 
 	if r.StatusCode != http.StatusOK && r.StatusCode != http.StatusNoContent {
 		return trace.Errorf("Failed to send event to fluentd (HTTP %v)", r.StatusCode)

--- a/integrations/event-handler/session_events_job.go
+++ b/integrations/event-handler/session_events_job.go
@@ -268,9 +268,8 @@ func (j *SessionEventsJob) processMissingRecordings(ctx context.Context) error {
 			return nil
 		}
 
+		semaphore := make(chan struct{}, j.app.Config.Concurrency*2)
 		err := j.app.State.IterateMissingRecordings(func(sess session, attempts int) error {
-			semaphore := make(chan struct{}, j.app.Config.Concurrency*2)
-
 			return j.ingestSession(ctx, sess, attempts, semaphore)
 		})
 		if err != nil && !lib.IsCanceled(err) {


### PR DESCRIPTION
Three fixes to prevent "cannot assign requested address" errors caused by TCP connection exhaustion:

Fixes #42430

Changelog:
1. Drain HTTP response body before closing to enable connection reuse. Without draining, the transport cannot return connections to the pool, forcing a new TCP connection per request.

2. Set MaxConnsPerHost on the HTTP transport to match the configured max-connections, preventing unbounded outbound connections.

3. Move semaphore creation outside the IterateMissingRecordings callback so it is shared across all missing recordings. Previously each invocation created its own semaphore, providing no concurrency limit.


## Manual Test Plan
### Test Environment

### Test Cases
- [ ] 
