### PR TITLE
[v18] Focus how-to guides on objectives and CLI steps

### DIFF
--- a/docs/pages/machine-workload-identity/deployment/aws.mdx
+++ b/docs/pages/machine-workload-identity/deployment/aws.mdx
@@ -41,7 +41,7 @@ guidance on deploying `tbot` as a workload on Kubernetes.
 - An AWS EC2 virtual machine that you wish to install `tbot` onto configured
   with the IAM role attached.
 
-## Step 1/5. Install `tbot`
+## Step 1/4. Install `tbot`
 
 **This step is completed on the AWS EC2 instance.**
 
@@ -52,13 +52,13 @@ Download and install the appropriate Teleport package for your platform:
 
 (!docs/pages/includes/install-linux.mdx!)
 
-## Step 2/5. Create a Bot
+## Step 2/4. Create a Bot
 
 **This step is completed on your local machine.**
 
 (!docs/pages/includes/machine-id/create-a-bot.mdx!)
 
-## Step 3/5. Create a join token
+## Step 3/4. Create a join token
 
 **This step is completed on your local machine.**
 
@@ -99,7 +99,7 @@ Use `tctl` to apply this file:
 $ tctl create -f bot-token.yaml
 ```
 
-## Step 4/5. Configure `tbot`
+## Step 4/4. Configure `tbot`
 
 **This step is completed on the AWS EC2 instance.**
 
@@ -125,11 +125,11 @@ Replace:
 
 (!docs/pages/includes/machine-id/daemon-or-oneshot.mdx!)
 
-## Step 5/5. Configure services
-
-(!docs/pages/includes/machine-id/configure-services.mdx!)
-
 ## Next steps
+
+You have now prepared the base configuration for `tbot`. At this point, it
+identifies itself to the Teleport cluster and renews its own credentials but
+does not output any credentials for other applications to use.
 
 - Follow the [access guides](../access-guides/access-guides.mdx) to finish configuring `tbot` for
   your environment.

--- a/docs/pages/machine-workload-identity/deployment/azure-devops.mdx
+++ b/docs/pages/machine-workload-identity/deployment/azure-devops.mdx
@@ -36,7 +36,7 @@ control.
 
 - (!docs/pages/includes/tctl.mdx!)
 
-## Step 1/5. Determine your Azure DevOps organization ID
+## Step 1/4. Determine your Azure DevOps organization ID
 
 Before we can grant access to a `tbot` running within an Azure DevOps pipeline,
 we must determine the ID of the Azure DevOps organization that the pipeline
@@ -70,11 +70,11 @@ Organization ID: 0ca3ddd9-0000-1111-2222-example58665
 
 Record this organization ID as you will need it later: <Var name="organization-id" />
 
-## Step 2/5. Create a Bot
+## Step 2/4. Create a Bot
 
 (!docs/pages/includes/machine-id/create-a-bot.mdx!)
 
-## Step 3/5. Create a join token
+## Step 3/4. Create a join token
 
 To allow the Azure DevOps pipeline to authenticate to your Teleport cluster,
 you'll first need to create a join token. An Azure DevOps join token contains
@@ -119,7 +119,7 @@ Apply this to your Teleport cluster using `tctl`:
 $ tctl create -f bot-token.yaml
 ```
 
-## Step 4/5. Configure an Azure DevOps pipeline
+## Step 4/4. Configure an Azure DevOps pipeline
 
 With the bot and join token created, you can now configure an Azure DevOps
 pipeline that sets up `tbot` to use these.
@@ -190,11 +190,11 @@ Check the status of your Azure DevOps pipeline run. If everything is configured
 correctly, you should see `tbot` successfully start, join the cluster, and then
 exit.
 
-## Step 5/5. Configure services
-
-(!docs/pages/includes/machine-id/configure-services.mdx!)
-
 ## Further steps
+
+You have now prepared the base configuration for `tbot`. At this point, it
+identifies itself to the Teleport cluster and renews its own credentials but
+does not output any credentials for other applications to use.
 
 - For more information about the Azure DevOps join method, read the
   [join method reference page.](../../reference/deployment/join-methods.mdx#azure-devops-azure_devops)

--- a/docs/pages/machine-workload-identity/deployment/azure.mdx
+++ b/docs/pages/machine-workload-identity/deployment/azure.mdx
@@ -37,7 +37,7 @@ occur without the use of a long-lived secret.
 - An Azure VM you wish to install Machine & Workload Identity onto with the
   managed identity configured as a user-assigned managed identity.
 
-## Step 1/5. Install `tbot`
+## Step 1/4. Install `tbot`
 
 **This step is completed on the Azure VM.**
 
@@ -48,13 +48,13 @@ Download and install the appropriate Teleport package for your platform:
 
 (!docs/pages/includes/install-linux.mdx!)
 
-## Step 2/5. Create a Bot
+## Step 2/4. Create a Bot
 
 **This step is completed on your local machine.**
 
 (!docs/pages/includes/machine-id/create-a-bot.mdx!)
 
-## Step 3/5. Create a join token
+## Step 3/4. Create a join token
 
 **This step is completed on your local machine.**
 
@@ -95,7 +95,7 @@ Use `tctl` to apply this file:
 $ tctl create -f bot-token.yaml
 ```
 
-## Step 4/5. Configure `tbot`
+## Step 4/4. Configure `tbot`
 
 **This step is completed on the Azure VM.**
 
@@ -125,11 +125,11 @@ Replace:
 
 (!docs/pages/includes/machine-id/daemon-or-oneshot.mdx!)
 
-## Step 5/5. Configure services
-
-(!docs/pages/includes/machine-id/configure-services.mdx!)
-
 ## Next steps
+
+You have now prepared the base configuration for `tbot`. At this point, it
+identifies itself to the Teleport cluster and renews its own credentials but
+does not output any credentials for other applications to use.
 
 - Follow the [access guides](../access-guides/access-guides.mdx) to finish configuring `tbot` for
   your environment.

--- a/docs/pages/machine-workload-identity/deployment/circleci.mdx
+++ b/docs/pages/machine-workload-identity/deployment/circleci.mdx
@@ -22,7 +22,7 @@ to run within a CircleCI workflow. The bot will be configured to use the
 - (!docs/pages/includes/tctl.mdx!)
 - A CircleCI project connected to a Git repository you can push to.
 
-## Step 1/5. Configure CircleCI
+## Step 1/4. Configure CircleCI
 
 In order to configure the rules for which CircleCI workflows will be allowed to
 connect to your Teleport cluster, you must determine the ID of your CircleCI
@@ -71,11 +71,11 @@ Note this value down and substitute <Var name="context-id" /> in configuration e
 with it.
 
 
-## Step 2/5. Create a Bot
+## Step 2/4. Create a Bot
 
 (!docs/pages/includes/machine-id/create-a-bot.mdx!)
 
-## Step 3/5. Create the join token for CircleCI
+## Step 3/4. Create the join token for CircleCI
 
 In order to allow your CircleCI workflow to authenticate with your Teleport
 cluster, you'll first need to create a join token. These tokens set out criteria
@@ -122,7 +122,7 @@ Apply this to your Teleport cluster using `tctl`:
 $ tctl create -f bot-token.yaml
 ```
 
-## Step 4/5. Configure a CircleCI workflow
+## Step 4/4. Configure a CircleCI workflow
 
 With the bot and join token created, you can now configure a CircleCI
 workflow that can connect to your Teleport cluster.
@@ -208,11 +208,11 @@ to these credentials.
 Ensure that the role you assign to your CircleCI bot has access to only the
 resources in your Teleport cluster that your CI/CD needs to interact with.
 
-## Step 5/5. Configure services
-
-(!docs/pages/includes/machine-id/configure-services.mdx!)
-
 ## Further steps
+
+You have now prepared the base configuration for `tbot`. At this point, it
+identifies itself to the Teleport cluster and renews its own credentials but
+does not output any credentials for other applications to use.
 
 - Follow the [access guides](../access-guides/access-guides.mdx) to finish configuring `tbot` for
   your environment.

--- a/docs/pages/machine-workload-identity/deployment/gitlab.mdx
+++ b/docs/pages/machine-workload-identity/deployment/gitlab.mdx
@@ -35,11 +35,11 @@ using a self-hosted GitLab instance, your Teleport Auth Service must be able to
 connect to your GitLab instance and your GitLab instance must be configured with
 a valid TLS certificate.**
 
-## Step 1/4. Create a Bot
+## Step 1/3. Create a Bot
 
 (!docs/pages/includes/machine-id/create-a-bot.mdx!)
 
-## Step 2/4. Create a join token
+## Step 2/3. Create a join token
 
 To allow GitLab CI to authenticate to your Teleport cluster, you'll first need
 to create a join token. A GitLab join token contains allow rules that describe
@@ -91,7 +91,7 @@ Apply this to your Teleport cluster using `tctl`:
 $ tctl create -f bot-token.yaml
 ```
 
-## Step 3/4. Configure a GitLab Pipeline
+## Step 3/3. Configure a GitLab Pipeline
 
 With the bot and join token created, you can now configure a GitLab pipeline
 that sets up `tbot` to use these.
@@ -170,11 +170,11 @@ Commit and push these two files to the repository.
 Check your GitLab CI status, and examine the log results from the commit for
 failure.
 
-## Step 4/4. Configure services
-
-(!docs/pages/includes/machine-id/configure-services.mdx!)
-
 ## Further steps
+
+You have now prepared the base configuration for `tbot`. At this point, it
+identifies itself to the Teleport cluster and renews its own credentials but
+does not output any credentials for other applications to use.
 
 - For more information about GitLab joining, read the
   [join method reference page.](../../reference/deployment/join-methods.mdx#gitlab-gitlab)

--- a/docs/pages/machine-workload-identity/deployment/linux-tpm.mdx
+++ b/docs/pages/machine-workload-identity/deployment/linux-tpm.mdx
@@ -30,7 +30,7 @@ installed on the cluster's Auth Service.
 - A Linux user on that host that you wish `tbot` to run as. In the guide,
 we will use `teleport` for this.
 
-## Step 1/5. Install `tbot`
+## Step 1/4. Install `tbot`
 
 **This step is completed on the Linux host.**
 
@@ -52,11 +52,11 @@ for a different solution, we recommend creating udev rules similar to the ones
 shipped by the [TPM2 Software Stack](
 https://github.com/tpm2-software/tpm2-tss/blob/ede63dd1ac1f0a46029d457304edcac2162bfab8/dist/tpm-udev.rules#L4).
 
-## Step 2/5. Create a Bot
+## Step 2/4. Create a Bot
 
 (!docs/pages/includes/machine-id/create-a-bot.mdx!)
 
-## Step 3/5. Create a `tpm` join token
+## Step 3/4. Create a `tpm` join token
 
 With the Bot created, we now need to create a token. The token will be used by
 `tbot` to authenticate as the Bot to the Teleport cluster.
@@ -154,7 +154,7 @@ Apply this to your Teleport cluster using `tctl`:
 $ tctl create -f bot-token.yaml
 ```
 
-## Step 4/5. Configure `tbot`
+## Step 4/4. Configure `tbot`
 
 Create `/etc/tbot.yaml`:
 
@@ -199,11 +199,11 @@ $ sudo chown teleport:teleport /var/lib/teleport/bot
 
 (!docs/pages/includes/machine-id/daemon.mdx!)
 
-## Step 5/5. Configure services
-
-(!docs/pages/includes/machine-id/configure-services.mdx!)
-
 ## Next steps
+
+You have now prepared the base configuration for `tbot`. At this point, it
+identifies itself to the Teleport cluster and renews its own credentials but
+does not output any credentials for other applications to use.
 
 - Follow the [access guides](../access-guides/access-guides.mdx) to finish configuring `tbot` for
 your environment.

--- a/docs/pages/machine-workload-identity/deployment/linux.mdx
+++ b/docs/pages/machine-workload-identity/deployment/linux.mdx
@@ -32,7 +32,7 @@ is not possible to use the same token multiple times.
 - A Linux user on that host that you wish `tbot` to run as. In the guide, we
   will use `teleport` for this.
 
-## Step 1/4. Install `tbot`
+## Step 1/3. Install `tbot`
 
 **This step is completed on the Linux host.**
 
@@ -43,7 +43,7 @@ Install Teleport as appropriate for your platform:
 
 (!docs/pages/includes/install-linux.mdx!)
 
-## Step 2/4. Create a bot user
+## Step 2/3. Create a bot user
 
 **This step is completed on your local machine.**
 
@@ -56,7 +56,7 @@ $ tctl bots add example
 A join token will be included in the results of `tctl bots add`, record this
 value as it will be needed when configuring `tbot`.
 
-## Step 3/4. Configure `tbot`
+## Step 3/3. Configure `tbot`
 
 **This step is completed on the Linux host.**
 
@@ -96,11 +96,11 @@ run has completed, but there is no tangible security benefit to doing so.
 
 (!docs/pages/includes/machine-id/daemon.mdx!)
 
-## Step 4/4. Configure services
-
-(!docs/pages/includes/machine-id/configure-services.mdx!)
-
 ## Next steps
+
+You have now prepared the base configuration for `tbot`. At this point, it
+identifies itself to the Teleport cluster and renews its own credentials but
+does not output any credentials for other applications to use.
 
 - Follow the [access guides](../access-guides/access-guides.mdx) to finish configuring `tbot` for
   your environment.

--- a/docs/pages/machine-workload-identity/workload-identity/aws-oidc-federation.mdx
+++ b/docs/pages/machine-workload-identity/workload-identity/aws-oidc-federation.mdx
@@ -408,8 +408,10 @@ Replace:
 - example-workload-identity with the name of the Workload Identity you have
   created.
 
-Restart your `tbot` service to apply the new configuration. You should see a
-file created at `/opt/workload-identity/jwt_svid` containing the JWT.
+(!docs/pages/includes/machine-id/reload-tbot.mdx!)
+
+You should see a file created at `/opt/workload-identity/jwt_svid` containing
+the JWT.
 
 ## Step 4/4. Configure AWS CLIs and SDKs
 

--- a/docs/pages/machine-workload-identity/workload-identity/gcp-workload-identity-federation-jwt.mdx
+++ b/docs/pages/machine-workload-identity/workload-identity/gcp-workload-identity-federation-jwt.mdx
@@ -340,8 +340,10 @@ Replace:
 - `example-workload-identity` with the name of the Workload Identity you have
   created.
 
-Restart your `tbot` service to apply the new configuration. You should see a
-file created at `/opt/workload-identity/jwt_svid` containing the JWT.
+(!docs/pages/includes/machine-id/reload-tbot.mdx!)
+
+You should see a file created at `/opt/workload-identity/jwt_svid` containing
+the JWT.
 
 ## Step 4/4. Configure GCP CLIs and SDKs
 

--- a/docs/pages/machine-workload-identity/workload-identity/mwi-tbot-aws-guide.mdx
+++ b/docs/pages/machine-workload-identity/workload-identity/mwi-tbot-aws-guide.mdx
@@ -27,7 +27,7 @@ By the end, you'll have a working `tbot` service that issues SPIFFE-compatible c
   be named `teleport-bot-role`.
 - An AWS EC2 instance with the IAM role attached that you'll install the MWI agent, `tbot`, onto.
 
-## Step 1/7. Install `tbot`
+## Step 1/6. Install `tbot`
 
 **This step is completed on the AWS EC2 instance.**
 
@@ -37,13 +37,13 @@ Download and install the appropriate Teleport package for your platform:
 
 (!docs/pages/includes/install-linux.mdx!)
 
-## Step 2/7. Create a Bot
+## Step 2/6. Create a Bot
 
 **This step is completed on your local machine.**
 
 (!docs/pages/includes/machine-id/create-a-bot.mdx!)
 
-## Step 3/7. Create a join token
+## Step 3/6. Create a join token
 
 **This step is completed on your local machine.**
 
@@ -84,7 +84,7 @@ Use `tctl` to apply this file:
 $ tctl create bot-token.yaml
 ```
 
-## Step 4/7. Configure `tbot`
+## Step 4/6. Configure `tbot`
 
 **This step is completed on the AWS EC2 instance.** Configure `workload-identity-api` service in `tbot`. 
 To issue SPIFFE credentials to workloads, `tbot` must expose a Workload API endpoint.
@@ -129,7 +129,7 @@ Replace:
 
 Restart your `tbot` instance to apply the new configuration.
 
-## Step 5/7. Configure Workload Identity
+## Step 5/6. Configure Workload Identity
 
 Next, we'll configure Workload Identity on the target resource you just created. 
 With your bot configured and connected to Teleport, you can now use it to issue SPIFFE-compatible 
@@ -164,7 +164,11 @@ Replace:
 - `example-workload-identity` with a name that describes your use-case.
 - `/svc/foo` with the SPIFFE ID path you have decided on issuing.
 
-Use `tctl create ./workload-identity.yaml` to create the Workload Identity.
+Create the Workload Identity:
+
+```code
+$ tctl create ./workload-identity.yaml
+```
 
 ### Using workload attestation
 
@@ -202,7 +206,7 @@ spec:
 With this configuration, the SPIFFE ID automatically 
 includes the systemd service name, such as `/svc/my-app` for a service named `my-app`.
 
-## Step 6/7. Testing the Workload API with `tbot spiffe-inspect`
+## Step 6/6. Testing the Workload API with `tbot spiffe-inspect`
 
 Use `tbot spiffe-inspect` to verify that the Workload API endpoint is issuing SPIFFE credentials correctly.
 This command connects to the endpoint, requests SVIDs, and prints detailed debug information.
@@ -225,8 +229,6 @@ Trust Bundles
 - teleport.example.com
 ```
 This confirms that workloads can successfully connect to the Workload API and receive SPIFFE-compatible credentials issued by Teleport.
-
-## Step 7/7. Configuring your workload to use the Workload API
 
 Now that you know that the Workload API is behaving as expected, you can configure your workload to use it. 
 The exact steps will depend on the workload. In cases where you have used the SPIFFE SDKs, you can configure the `SPIFFE_ENDPOINT_SOCKET` 

--- a/docs/pages/zero-trust-access/infrastructure-as-code/managing-resources/kubernetes-oidc-join-token.mdx
+++ b/docs/pages/zero-trust-access/infrastructure-as-code/managing-resources/kubernetes-oidc-join-token.mdx
@@ -77,7 +77,7 @@ A functional Teleport Terraform provider by following [the Terraform provider gu
 </TabItem>
 </Tabs>
 
-## Step 1/4. Detect the OIDC provider URL
+## Step 1/3. Detect the OIDC provider URL
 
 In this step we will connect to the cluster and recover the OIDC provider URL.
 If you already have the cluster's OIDC provider URL (e.g. as an output from the
@@ -130,7 +130,7 @@ $ curl <Var name="https://oidc.example.com/path/to/issuer/"/>.well-known/openid-
 }
 ```
 
-## Step 2/4. Create the Join Token
+## Step 2/3. Create the Join Token
 
 In this step we will configure Teleport to trust tokens signed by the Kubernetes OIDC provider.
 This will allow agents running in this Kubernetes cluster to join the Teleport cluster.
@@ -273,60 +273,57 @@ Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
 </TabItem>
 </Tabs>
 
-## Step 3/4. Configure the agent
+## Step 3/3. Configure and deploy the agent
 
 In this step we will write the `teleport-kube-agent` Helm chart configuration
-so that the agent uses the previously created token to join.
+so that the agent uses the previously created token to join, then deploy the
+agent.
 
 You must have the following information:
 - The Teleport cluster address: <Var name="teleport.example.com:443"/>
 - The Teleport cluster name: <Var name="teleport.example.com"/>
 - The name of the kubernetes cluster you are connecting: <Var name="kube-cluster-name"/>
 
-Write the following `values.yaml` YAML manifest.
+1. Write the following `values.yaml` YAML manifest.
 
-```yaml
-roles: "kube"
-proxyAddr: <Var name="teleport.example.com:443"/>
-# If you use Teleport Community Edition or AGPL, set to false
-enterprise: true
-updater:
-  enabled: true
-joinParams:
-  method: "kubernetes"
-  tokenName: <Var name="kube-cluster-name"/>-oidc
-kubeClusterName: <Var name="kube-cluster-name"/>
-teleportClusterName: <Var name="teleport.example.com"/>
-```
+   ```yaml
+   roles: "kube"
+   proxyAddr: <Var name="teleport.example.com:443"/>
+   # If you use Teleport Community Edition or AGPL, set to false
+   enterprise: true
+   updater:
+     enabled: true
+   joinParams:
+     method: "kubernetes"
+     tokenName: <Var name="kube-cluster-name"/>-oidc
+   kubeClusterName: <Var name="kube-cluster-name"/>
+   teleportClusterName: <Var name="teleport.example.com"/>
+   ```
 
-## Step 4/4. Deploy the agent
+1. (!docs/pages/includes/kubernetes-access/helm/helm-repo-add.mdx!)
 
-In this step we will deploy a release of the `teleport-kube-agent` chart using
-the values we wrote previously.
+1. Deploy the Teleport Kubernetes Agent using the values we previously set in
+   the provision token:
+   - The namespace in which you will deploy the agent: <Var name="teleport"/>
+   - The name of the Teleport Agent release: <Var name="teleport-agent"/>
 
-(!docs/pages/includes/kubernetes-access/helm/helm-repo-add.mdx!)
+   ```code
+   $ helm upgrade --install <Var name="teleport-agent"/> teleport/teleport-kube-agent \
+     --namespace <Var name="teleport"/> --create-namespace \
+     --version (=teleport.version=) \
+     --values values.yaml
+   ```
 
-Finally deploy the Teleport Kubernetes Agent using the values we previously set in the provision token:
-- The namespace in which you will deploy the agent: <Var name="teleport"/>
-- The name of the Teleport agent release: <Var name="teleport-agent"/>
+1. Validate that the agent successfully joined the cluster by checking its pod
+   readiness (this can take a couple of minutes):
 
-```code
-$ helm upgrade --install <Var name="teleport-agent"/> teleport/teleport-kube-agent \
-  --namespace <Var name="teleport"/> --create-namespace \
-  --version (=teleport.version=) \
-  --values values.yaml
-```
-
-Validate that the agent successfully joined the cluster by checking its pod readiness
-(this can take a couple of minutes):
-
-```code
-$ kubectl get pods -n <Var name="teleport"/>
-
-NAME                                     READY   STATUS    RESTARTS   AGE
-<Var name="teleport-agent"/>-0                         1/1     Running   0          9s
-<Var name="teleport-agent"/>-updater-6b8b74996-jz4qg   1/1     Running   0          15s
-```
+   ```code
+   $ kubectl get pods -n <Var name="teleport"/>
+   
+   NAME                                     READY   STATUS    RESTARTS   AGE
+   <Var name="teleport-agent"/>-0                         1/1     Running   0          9s
+   <Var name="teleport-agent"/>-updater-6b8b74996-jz4qg   1/1     Running   0          15s
+   ```
 
 ## Next steps
 

--- a/docs/pages/zero-trust-access/infrastructure-as-code/terraform-provider/dedicated-server.mdx
+++ b/docs/pages/zero-trust-access/infrastructure-as-code/terraform-provider/dedicated-server.mdx
@@ -43,13 +43,11 @@ Terraform provider. The daemon stores its identity on the disk and refresh the t
 
 - A Linux user on that host that you wish Terraform and `tbot` to run as.
 
-## Step 1/4. Install `tbot` on your server
+- `tbot` installed on your server and joined to your Teleport cluster. Follow
+  [the `tbot` deployment guide for
+  Linux](../../../machine-workload-identity/deployment/linux.mdx).
 
-You must install `tbot` and make it join the Teleport cluster.
-To do so, follow [the `tbot` deployment guide for Linux](../../../machine-workload-identity/deployment/linux.mdx)
-until step 3. 
-
-## Step 2/4. Configure RBAC
+## Step 1/3. Configure RBAC
 
 At this point, `tbot` is installed and configured on the machine that will run Terraform.
 
@@ -62,7 +60,7 @@ with the name of the Bot you created in the deployment guide.
 $ tctl bots update example --add-roles terraform-provider
 ```
 
-## Step 3/4. Configure `tbot` output
+## Step 2/3. Configure `tbot` output
 
 Now, `tbot` needs to be configured with an output that will produce the
 credentials needed by the Terraform provider. As the Terraform provider will be
@@ -86,16 +84,13 @@ services:
     path: /opt/machine-id
 ```
 
-If operating `tbot` as a background service, restart it. If running `tbot` in
-one-shot mode (which creates credentials and ends the process, rather than running
-a background process), it must be executed before you attempt to execute the
-Terraform plan later.
+(!docs/pages/includes/machine-id/reload-tbot.mdx!)
 
 You should now see an `identity` file under `/opt/machine-id`. This contains
 the private key and signed certificates needed by the Terraform provider to
 authenticate with the Teleport Auth Service.
 
-## Step 4/4. Run Terraform
+## Step 3/3. Run Terraform
 
 Start by creating a new Terraform working directory:
 


### PR DESCRIPTION
Backport #66441 to branch/v18

Move towards a standard in which each top-level "Step" section of a how-to guide includes at least one command, emphasizing concrete, followable steps. This change implements the more minor variants of this work; once this is done, we'll focus on guides that more heavily feature UI-only flows or other instructions that could use more concrete examples.

This change edits Machine Identity deployment guides to remove a final "Step" section that instructs the user to follow a guide to accessing resources. Instead, this change moves these instructions into the "Next steps" section of each guide. This helps ensure that each "Step" section focuses on concrete, verifiable outcomes.

Also add `tbot` restart command examples to guides that tell the user to restart `tbot`, continuing the work started in #66354 to roll out a `reload-tbot.mdx` partial.

In `kubernetes-oidc-join-token.mdx`, consolidate configuration and deployment steps so each config file is close to the command to apply it.

In `dedicated-server.mdx`, move Step 1 into the prerequisites, since it requires following another guide. Edit `linux.mdx` to move post-completion instructions to the "Next steps" section, which allows us to move this guide into the prerequisites of dedicated-server.mdx more cleanly.
