### PR TITLE
Fix minor inaccuracies in two plugin guides

### DIFF
--- a/docs/pages/identity-governance/access-requests/plugins/discord.mdx
+++ b/docs/pages/identity-governance/access-requests/plugins/discord.mdx
@@ -60,8 +60,7 @@ targeted by the Access Request.
   create an app and add it to your Discord servers. Make sure the bot is only
   available to your Discord servers and is not a public bot.
 
-  The app must grant the following OAuth2 scopes:
-  - bot
+  The app must grant the OAuth2 scope `bot` and the following bot permissions:
   - View Channels
   - Send Messages
 

--- a/docs/pages/identity-governance/access-requests/plugins/jira.mdx
+++ b/docs/pages/identity-governance/access-requests/plugins/jira.mdx
@@ -75,7 +75,7 @@ webhook run by the plugin, which modifies the Access Request in Teleport.
   plugin on a Linux server) or `<plugin-domain>:443` (if using Kubernetes). The
   webhook needs to be notified only when an issue is created, updated, or
   deleted. Follow the [Atlassian webhook
-  docs](https://developer.atlassian.com/server/jira/platform/webhooks/) to
+  docs](https://developer.atlassian.com/cloud/jira/software/webhooks/) to
   create it.
 
 - A means of providing TLS credentials for the Jira webhook run by the plugin.


### PR DESCRIPTION
Fix issues on `master` that Codex discovered only when we backported changes introduced by #66540 to v18 (see #66758):

- Jira Access Request plugin: Use a Jira Cloud docs link for the webhook requirement in the Prerequisites.
- Discord Access Request plugin: separate OAuth scopes from bot permissions.