### PR TITLE
cache: use common resource utils in the generic lister range

### DIFF
--- a/api/utils/clientutils/resources.go
+++ b/api/utils/clientutils/resources.go
@@ -145,6 +145,21 @@ func RangeResources[T any](ctx context.Context, start, end string,
 	})
 }
 
+// RangeResourcesWithPageSize is functionally the same as [RangeResources] but allows the caller to specify a page size for each request.
+func RangeResourcesWithPageSize[T any](ctx context.Context, start, end string,
+	pageFunc func(context.Context, int, string) ([]T, string, error),
+	keyFunc func(item T) string,
+	pageSize int) iter.Seq2[T, error] {
+
+	return rangeInternal(ctx, rangeParams[T]{
+		start:    start,
+		end:      end,
+		pageFunc: pageFunc,
+		keyFunc:  keyFunc,
+		pageSize: pageSize,
+	})
+}
+
 // CollectWithFallback collects all items in a collection using pageFunc, should the this be NotImplemented a fallbackFunc is attempted.
 // Example:
 //

--- a/lib/cache/generic_operations.go
+++ b/lib/cache/generic_operations.go
@@ -24,6 +24,7 @@ import (
 	"github.com/gravitational/trace"
 
 	"github.com/gravitational/teleport/api/defaults"
+	"github.com/gravitational/teleport/api/utils/clientutils"
 )
 
 // genericGetter is a helper to retrieve a single item from a cache collection.
@@ -180,39 +181,22 @@ func (l genericLister[T, I]) list(ctx context.Context, pageSize int, startToken 
 // Range retrieves a stream of items from the configured cache collection within the range [start, end).
 // If the cache is not healthy, then the items are retrieved from the upstream backend.
 func (l genericLister[T, I]) Range(ctx context.Context, start, end string) iter.Seq2[T, error] {
-	return func(yield func(T, error) bool) {
-		token := start
-		for {
-			items, next, err := l.listRange(ctx, l.defaultPageSize, token, end)
-			if err != nil {
-				yield(*new(T), err)
-				return
-			}
-
-			for _, item := range items {
-				if !yield(item, nil) {
-					return
-				}
-			}
-
-			if next == "" {
-				return
-			}
-
-			token = next
-		}
+	pageFunc := func(ctx context.Context, pageSize int, token string) ([]T, string, error) {
+		return l.listRange(ctx, pageSize, token, end)
 	}
+	return clientutils.RangeResourcesWithPageSize(ctx, start, end, pageFunc, l.nextToken, l.defaultPageSize)
 }
 
 // RangeWithFallback retrieves a stream of items from the configured cache collection within the range [start, end).
 // If the cache is not healthy, then the items are retrieved from the upstream backend. In addition, a fallback getter
 // is supported if the upstream does not implement a list operation, this is only checked on the first page.
 func (l genericLister[T, I]) RangeWithFallback(ctx context.Context, start, end string) iter.Seq2[T, error] {
+	pageFunc := func(ctx context.Context, pageSize int, token string) ([]T, string, error) {
+		return l.listRange(ctx, pageSize, token, end)
+	}
 	return func(yield func(T, error) bool) {
-		// Fallback is only allowed when configured and the entire range is requested.
 		fallbackAllowed := l.fallbackGetter != nil && start == "" && end == ""
-
-		for item, err := range l.Range(ctx, start, end) {
+		for item, err := range clientutils.RangeResourcesWithPageSize(ctx, start, end, pageFunc, l.nextToken, l.defaultPageSize) {
 			if err != nil {
 				if fallbackAllowed && trace.IsNotImplemented(err) {
 					items, err := l.fallbackGetter(ctx)
@@ -241,6 +225,5 @@ func (l genericLister[T, I]) RangeWithFallback(ctx context.Context, start, end s
 			// Disable the fallback once the first item is successfully yielded.
 			fallbackAllowed = false
 		}
-
 	}
 }

--- a/lib/cache/generic_operations.go
+++ b/lib/cache/generic_operations.go
@@ -125,6 +125,15 @@ func (g genericLister[T, I]) clipEnd(page []T, next, end string) ([]T, string) {
 // If the cache is not healthy, then the items are retrieved from the upstream backend.
 // The items returend are cloned and ownership is retained by the caller.
 func (l genericLister[T, I]) listRange(ctx context.Context, pageSize int, startToken, endToken string) ([]T, string, error) {
+	defaultPageSize := defaults.DefaultChunkSize
+	if l.defaultPageSize > 0 {
+		defaultPageSize = l.defaultPageSize
+	}
+
+	if pageSize <= 0 {
+		pageSize = defaultPageSize
+	}
+
 	rg, err := acquireReadGuard(l.cache, l.collection)
 	if err != nil {
 		return nil, "", trace.Wrap(err)
@@ -139,15 +148,6 @@ func (l genericLister[T, I]) listRange(ctx context.Context, pageSize int, startT
 
 		out, next = l.clipEnd(out, next, endToken)
 		return out, next, nil
-	}
-
-	defaultPageSize := defaults.DefaultChunkSize
-	if l.defaultPageSize > 0 {
-		defaultPageSize = l.defaultPageSize
-	}
-
-	if pageSize <= 0 {
-		pageSize = defaultPageSize
 	}
 
 	fetchFn := rg.store.cache.Ascend

--- a/lib/cache/generic_operations_test.go
+++ b/lib/cache/generic_operations_test.go
@@ -281,6 +281,53 @@ func TestGenericListerRangeWithFallback(t *testing.T) {
 			want:            expected[:2], // Collect yields first 2 items
 			wantErr:         "not implemented",
 		},
+		{
+			name: "explicit defaultPageSize is not overridden by auto adjustment",
+			upstreamList: func(ctx context.Context, pageSize int, token string) ([]types.Application, string, error) {
+				if pageSize != 3 {
+					return nil, "", trace.BadParameter(
+						"expected page size 3, got %d", pageSize,
+					)
+				}
+				return p.apps.ListApps(ctx, pageSize, token)
+			},
+			fallbackGetter:  p.apps.GetApps,
+			defaultPageSize: 3,
+			cacheOk:         false,
+			want:            expected,
+		},
+		{
+			name: "auto page size adjustment halves on limit exceeded then succeeds",
+			upstreamList: func() func(context.Context, int, string) ([]types.Application, string, error) {
+				callCount := 0 // cheeky trick to capture the callcount here.
+				return func(ctx context.Context, pageSize int, token string) ([]types.Application, string, error) {
+					callCount++
+					if callCount <= 2 {
+						return nil, "", trace.LimitExceeded("page too large")
+					}
+					if pageSize != 2 {
+						return nil, "", trace.BadParameter(
+							"expected halved page size 2, got %d after %d retries", pageSize, callCount-1,
+						)
+					}
+					return p.apps.ListApps(ctx, pageSize, token)
+				}
+			}(),
+			fallbackGetter:  p.apps.GetApps,
+			defaultPageSize: 8,
+			cacheOk:         false,
+			want:            expected,
+		},
+		{
+			name: "auto page size adjustment fails when halving reaches zero",
+			upstreamList: func(ctx context.Context, pageSize int, token string) ([]types.Application, string, error) {
+				return nil, "", trace.LimitExceeded("page too large")
+			},
+			fallbackGetter:  p.apps.GetApps,
+			defaultPageSize: 1,
+			cacheOk:         false,
+			wantErr:         "resource is too large to retrieve",
+		},
 	}
 
 	for _, tt := range tests {

--- a/lib/cache/generic_operations_test.go
+++ b/lib/cache/generic_operations_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/gravitational/teleport/api/defaults"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/types/header"
 	"github.com/gravitational/teleport/lib/itertools/stream"
@@ -328,6 +329,21 @@ func TestGenericListerRangeWithFallback(t *testing.T) {
 			cacheOk:         false,
 			wantErr:         "resource is too large to retrieve",
 		},
+		{
+			name: "zero defaultPageSize falls back to DefaultChunkSize",
+			upstreamList: func(ctx context.Context, pageSize int, token string) ([]types.Application, string, error) {
+				if pageSize != defaults.DefaultChunkSize {
+					return nil, "", trace.BadParameter(
+						"expected default chunk size %d, got %d", defaults.DefaultChunkSize, pageSize,
+					)
+				}
+				return p.apps.ListApps(ctx, pageSize, token)
+			},
+			fallbackGetter:  p.apps.GetApps,
+			defaultPageSize: 0,
+			cacheOk:         false,
+			want:            expected,
+		},
 	}
 
 	for _, tt := range tests {
@@ -344,7 +360,7 @@ func TestGenericListerRangeWithFallback(t *testing.T) {
 			}
 
 			p.cache.ok = tt.cacheOk
-			got, err := stream.Collect(l.RangeWithFallback(context.Background(), tt.start, tt.end))
+			got, err := stream.Collect(l.RangeWithFallback(t.Context(), tt.start, tt.end))
 
 			if tt.wantErr != "" {
 				require.ErrorContains(t, err, tt.wantErr)


### PR DESCRIPTION
This allows the generic lister to benefit from common page auto adjustment that is already used elsewhere in the cache. This path is only applicable when the cache is unhealthy.

The page size check is also moved in as a defensive measure, in theory the backend should handle this and default to its own sensible value as per RFD153.

