### PR TITLE
 Replace FileConfig.DebugDumpToYAML with YAMLString

### DIFF
--- a/lib/config/configuration_test.go
+++ b/lib/config/configuration_test.go
@@ -203,7 +203,9 @@ func TestSampleConfig(t *testing.T) {
 			require.NotNil(t, sfc)
 
 			fn := filepath.Join(t.TempDir(), "default-config.yaml")
-			err = os.WriteFile(fn, []byte(sfc.DebugDumpToYAML()), 0o660)
+			payload, err := sfc.YAMLString()
+			require.NoError(t, err)
+			err = os.WriteFile(fn, []byte(payload), 0o660)
 			require.NoError(t, err)
 
 			// make sure it could be parsed:
@@ -1850,7 +1852,12 @@ func makeConfigFixture() string {
 		},
 	}
 
-	return conf.DebugDumpToYAML()
+	payload, err := conf.YAMLString()
+	if err != nil {
+		panic(err)
+	}
+
+	return payload
 }
 
 func TestPermitUserEnvironment(t *testing.T) {

--- a/lib/config/fileconf.go
+++ b/lib/config/fileconf.go
@@ -461,13 +461,14 @@ func roleMapFromFlags(flags SampleFlags) map[string]bool {
 	return m
 }
 
-// DebugDumpToYAML allows for quick YAML dumping of the config
-func (conf *FileConfig) DebugDumpToYAML() string {
-	bytes, err := yaml.Marshal(&conf)
+// YAMLString returns the YAML representation of the config.
+func (conf *FileConfig) YAMLString() (string, error) {
+	raw, err := yaml.Marshal(&conf)
 	if err != nil {
-		panic(err)
+		return "", err
 	}
-	return string(bytes)
+
+	return string(raw), nil
 }
 
 // CheckAndSetDefaults sets defaults and ensures that the ciphers, kex

--- a/lib/service/servicecfg/config.go
+++ b/lib/service/servicecfg/config.go
@@ -32,7 +32,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/ghodss/yaml"
 	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
 	"golang.org/x/crypto/ssh"
@@ -689,20 +688,6 @@ func (cfg *Config) ApplyCAPins(caPins []string) error {
 		cfg.CAPins = filteredPins
 	}
 	return nil
-}
-
-// DebugDumpToYAML is useful for debugging: it dumps the Config structure into
-// a string
-func (cfg *Config) DebugDumpToYAML() string {
-	shallow := *cfg
-	// do not copy sensitive data to stdout
-	shallow.Identities = nil
-	shallow.Auth.Authorities = nil
-	out, err := yaml.Marshal(shallow)
-	if err != nil {
-		return err.Error()
-	}
-	return string(out)
 }
 
 // ApplyFIPSDefaults updates default configuration to be FedRAMP/FIPS

--- a/tool/teleport/common/teleport.go
+++ b/tool/teleport/common/teleport.go
@@ -1078,7 +1078,12 @@ func onConfigDump(flags dumpFlags) error {
 		return trace.Wrap(err)
 	}
 
-	configPath, err := dumpConfigFile(flags.output, sfc.DebugDumpToYAML(), sampleConfComment)
+	configYAML, err := sfc.YAMLString()
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	configPath, err := dumpConfigFile(flags.output, configYAML, sampleConfComment)
 	if err != nil {
 		return trace.Wrap(err)
 	}


### PR DESCRIPTION
Returns the marshal error to the caller instead of panicking, and removes the unused Config.DebugDumpToYAML method.


## Manual Test Plan
### Test Environment

Locally built teleport on dev machine.

### Test Cases
- [x] teleport configure output from this branch matches teleport 18.

tross/file_config_yaml:

```bash
./build/teleport configure
#
# A Sample Teleport configuration file.
#
# Things to update:
#  1. license.pem: Retrieve a license from your Teleport account https://teleport.sh
#     if you are an Enterprise customer.
#
version: v3
teleport:
  nodename: telebook
  data_dir: /var/lib/teleport
  join_params:
    token_name: ""
    method: token
  log:
    output: stderr
    severity: INFO
    format:
      output: text
  ca_pin: ""
  diag_addr: ""
auth_service:
  enabled: "yes"
  listen_addr: 0.0.0.0:3025
  license_file: /var/lib/teleport/license.pem
  proxy_listener_mode: multiplex
ssh_service:
  enabled: "yes"
proxy_service:
  enabled: "yes"
  https_keypairs: []
  https_keypairs_reload_interval: 0s
  acme: {}
```


teleport 18.8.0

```bash
./releases/18.8.0/teleport configure
#
# A Sample Teleport configuration file.
#
# Things to update:
#  1. license.pem: Retrieve a license from your Teleport account https://teleport.sh
#     if you are an Enterprise customer.
#
version: v3
teleport:
  nodename: telebook
  data_dir: /var/lib/teleport
  join_params:
    token_name: ""
    method: token
  log:
    output: stderr
    severity: INFO
    format:
      output: text
  ca_pin: ""
  diag_addr: ""
auth_service:
  enabled: "yes"
  listen_addr: 0.0.0.0:3025
  license_file: /var/lib/teleport/license.pem                                                                 proxy_listener_mode: multiplex
ssh_service:
  enabled: "yes"
proxy_service:
  enabled: "yes"
  https_keypairs: []                                                                                          https_keypairs_reload_interval: 0s
  acme: {}
```