### PR TITLE
Fix TestDiscoveryServerEKS flaky test

### DIFF
--- a/lib/srv/discovery/kube_integration_watcher.go
+++ b/lib/srv/discovery/kube_integration_watcher.go
@@ -118,6 +118,8 @@ func (s *Server) startKubeIntegrationWatchers() error {
 			resourcesEnrolledByGroup := make(map[awsResourceGroup]int)
 			iterationDiscoveryConfigs := make(map[string]struct{})
 
+			inflightInstallations := sync.WaitGroup{}
+
 			select {
 			case resources := <-watcher.ResourcesC():
 				if len(resources) == 0 {
@@ -197,7 +199,9 @@ func (s *Server) startKubeIntegrationWatchers() error {
 
 				for key, val := range clustersByRegionAndIntegration {
 					key, val := key, val
-					go s.enrollEKSClusters(key.region, key.integration, key.discoveryConfigName, val, agentVersion, &mu, enrollingClusters)
+					inflightInstallations.Go(func() {
+						s.enrollEKSClusters(key.region, key.integration, key.discoveryConfigName, val, agentVersion, &mu, enrollingClusters)
+					})
 				}
 
 			case <-s.ctx.Done():
@@ -207,6 +211,8 @@ func (s *Server) startKubeIntegrationWatchers() error {
 			for group, count := range resourcesEnrolledByGroup {
 				s.awsEKSResourcesStatus.incrementEnrolled(group, count)
 			}
+
+			inflightInstallations.Wait()
 
 			s.updateDiscoveryConfigStatus(slices.Collect(maps.Keys(iterationDiscoveryConfigs))...)
 		}


### PR DESCRIPTION
The test that failed was validating that user tasks are created accordingly when the DiscoveryService tries to enroll an EKS cluster and it fails.

The issue was that the enrollment part of EKS clusters runs in a goroutine, and we can only create user task at the end of the installation attempt.

When we start a new iteration, which includes a backend write of the user tasks that were collected (in-memory) so far, the installation attempt might still be in-flight.

This means that a new iteration might clear in-memory user tasks.

The change ensures that we only start a new iteration after all the in-flight installation attempts have finished.

This could cause the process to stall if one EKS cluster takes too long, however that's not the case because the installation attempt has a timeout of 30 seconds.

### Demo
Running the following command
```
go test github.com/gravitational/teleport/lib/srv/discovery -c -race && stress -p 120 -count 2000 ./discovery.test -test.run '^TestDiscoveryServerEKS$'
```

Before:
`48s: 2000 runs total, 8 failures (0.40%)`

After:
`50s: 2000 runs total, 0 failures`

Error logs:
```
OUTPUT github.com/gravitational/teleport/lib/srv/discovery.TestDiscoveryServerEKS/multiple_EKS_clusters_with_different_KubeAppDiscovery_setting_failed_to_autoenroll_and_user_tasks_are_created
===================================================
=== RUN   TestDiscoveryServerEKS/multiple_EKS_clusters_with_different_KubeAppDiscovery_setting_failed_to_autoenroll_and_user_tasks_are_created
=== PAUSE TestDiscoveryServerEKS/multiple_EKS_clusters_with_different_KubeAppDiscovery_setting_failed_to_autoenroll_and_user_tasks_are_created
=== CONT  TestDiscoveryServerEKS/multiple_EKS_clusters_with_different_KubeAppDiscovery_setting_failed_to_autoenroll_and_user_tasks_are_created
    discovery_eks_test.go:238: 
        	Error Trace:	/__w/teleport.e/teleport.e/lib/srv/discovery/discovery_eks_test.go:238
        	            				/__w/teleport.e/teleport.e/lib/srv/discovery/discovery_eks_test.go:299
        	Error:      	map[string]*usertasksv1.DiscoverEKSCluster{"cluster02":(*usertasksv1.DiscoverEKSCluster)(0xc001ab1380)} does not contain "cluster01"
        	Test:       	TestDiscoveryServerEKS/multiple_EKS_clusters_with_different_KubeAppDiscovery_setting_failed_to_autoenroll_and_user_tasks_are_created
--- FAIL: TestDiscoveryServerEKS/multiple_EKS_clusters_with_different_KubeAppDiscovery_setting_failed_to_autoenroll_and_user_tasks_are_created (0.01s)
```