### PR TITLE
[v18] Add support for enrolling uniform Azure VM Scale Set

### DIFF
--- a/lib/cloud/azure/mocks.go
+++ b/lib/cloud/azure/mocks.go
@@ -538,16 +538,53 @@ func (m *ARMComputeMock) Get(_ context.Context, _ string, _ string, _ *armcomput
 	}, m.GetErr
 }
 
-// ARMComputeScaleSetMock mocks armcompute.VirtualMachineScaleSetVMsClient.
-type ARMScaleSetMock struct {
+// ARMScaleSetVMsMock mocks armcompute.VirtualMachineScaleSetVMsClient.
+type ARMScaleSetVMsMock struct {
 	GetResult armcompute.VirtualMachineScaleSetVM
 	GetErr    error
+	ListErr   error
 }
 
-func (m *ARMScaleSetMock) Get(ctx context.Context, resourceGroupName string, vmScaleSetName string, instanceID string, options *armcompute.VirtualMachineScaleSetVMsClientGetOptions) (armcompute.VirtualMachineScaleSetVMsClientGetResponse, error) {
+func (m *ARMScaleSetVMsMock) Get(ctx context.Context, resourceGroupName string, vmScaleSetName string, instanceID string, options *armcompute.VirtualMachineScaleSetVMsClientGetOptions) (armcompute.VirtualMachineScaleSetVMsClientGetResponse, error) {
 	return armcompute.VirtualMachineScaleSetVMsClientGetResponse{
 		VirtualMachineScaleSetVM: m.GetResult,
 	}, m.GetErr
+}
+
+func (m *ARMScaleSetVMsMock) NewListPager(resourceGroupName string, virtualMachineScaleSetName string, options *armcompute.VirtualMachineScaleSetVMsClientListOptions) *runtime.Pager[armcompute.VirtualMachineScaleSetVMsClientListResponse] {
+	return newPagerHelper(m.ListErr != nil, func() (armcompute.VirtualMachineScaleSetVMsClientListResponse, error) {
+		return armcompute.VirtualMachineScaleSetVMsClientListResponse{
+			VirtualMachineScaleSetVMListResult: armcompute.VirtualMachineScaleSetVMListResult{
+				Value: []*armcompute.VirtualMachineScaleSetVM{&m.GetResult},
+			},
+		}, m.ListErr
+	})
+}
+
+// ARMScaleSetsMock mocks armcompute.VirtualMachineScaleSetsClient.
+type ARMScaleSetsMock struct {
+	ScaleSetRecords []*armcompute.VirtualMachineScaleSet
+	ListErr         error
+}
+
+func (m *ARMScaleSetsMock) NewListPager(resourceGroupName string, options *armcompute.VirtualMachineScaleSetsClientListOptions) *runtime.Pager[armcompute.VirtualMachineScaleSetsClientListResponse] {
+	return newPagerHelper(m.ListErr != nil, func() (armcompute.VirtualMachineScaleSetsClientListResponse, error) {
+		return armcompute.VirtualMachineScaleSetsClientListResponse{
+			VirtualMachineScaleSetListResult: armcompute.VirtualMachineScaleSetListResult{
+				Value: m.ScaleSetRecords,
+			},
+		}, m.ListErr
+	})
+}
+
+func (m *ARMScaleSetsMock) NewListAllPager(options *armcompute.VirtualMachineScaleSetsClientListAllOptions) *runtime.Pager[armcompute.VirtualMachineScaleSetsClientListAllResponse] {
+	return newPagerHelper(m.ListErr != nil, func() (armcompute.VirtualMachineScaleSetsClientListAllResponse, error) {
+		return armcompute.VirtualMachineScaleSetsClientListAllResponse{
+			VirtualMachineScaleSetListWithLinkResult: armcompute.VirtualMachineScaleSetListWithLinkResult{
+				Value: m.ScaleSetRecords,
+			},
+		}, m.ListErr
+	})
 }
 
 // ARMSQLServerMock mocks armSQLServerClient

--- a/lib/cloud/azure/vm.go
+++ b/lib/cloud/azure/vm.go
@@ -20,6 +20,7 @@ package azure
 
 import (
 	"context"
+	"log/slog"
 	"os"
 	"time"
 
@@ -30,6 +31,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v6"
 	"github.com/gravitational/trace"
 
+	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/types"
 )
 
@@ -37,8 +39,8 @@ import (
 // virtual scale set VMs.
 const virtualScaleSetUniformVMResourceType = "virtualMachineScaleSets/virtualMachines"
 
-// armCompute provides an interface for an Azure virtual machine client.
-type armCompute interface {
+// virtualMachinesLister provides an interface for an Azure virtual machine client.
+type virtualMachinesLister interface {
 	// Get retrieves information about an Azure virtual machine.
 	Get(ctx context.Context, resourceGroupName string, vmName string, options *armcompute.VirtualMachinesClientGetOptions) (armcompute.VirtualMachinesClientGetResponse, error)
 	// NewListPager lists Azure virtual Machines.
@@ -47,10 +49,20 @@ type armCompute interface {
 	NewListAllPager(opts *armcompute.VirtualMachinesClientListAllOptions) *runtime.Pager[armcompute.VirtualMachinesClientListAllResponse]
 }
 
-// scaleSet provides an interfaces for an Azure VM scale set client.
-type scaleSet interface {
+// scaleSetsLister provides an interface for an Azure VM scale set client.
+type scaleSetsLister interface {
+	// NewListAllPager gets a list of all VM Scale Sets in the subscription, regardless of the associated resource group.
+	NewListAllPager(options *armcompute.VirtualMachineScaleSetsClientListAllOptions) *runtime.Pager[armcompute.VirtualMachineScaleSetsClientListAllResponse]
+	// NewListPager gets a list of all VM scale sets under a resource group.
+	NewListPager(resourceGroupName string, options *armcompute.VirtualMachineScaleSetsClientListOptions) *runtime.Pager[armcompute.VirtualMachineScaleSetsClientListResponse]
+}
+
+// scaleSetVMsLister provides an interface for an Azure VM scale set VMs client.
+type scaleSetVMsLister interface {
 	// Get retrieves a virtual machine from a VM scale set.
 	Get(ctx context.Context, resourceGroupName string, vmScaleSetName string, instanceID string, options *armcompute.VirtualMachineScaleSetVMsClientGetOptions) (armcompute.VirtualMachineScaleSetVMsClientGetResponse, error)
+	// NewListPager gets a list of all virtual machines in a VM scale set.
+	NewListPager(resourceGroupName string, virtualMachineScaleSetName string, options *armcompute.VirtualMachineScaleSetVMsClientListOptions) *runtime.Pager[armcompute.VirtualMachineScaleSetVMsClientListResponse]
 }
 
 // VirtualMachinesClient is a client for Azure virtual machines.
@@ -61,7 +73,7 @@ type VirtualMachinesClient interface {
 	// GetByVMID returns the virtual machine for a given VM ID.
 	GetByVMID(ctx context.Context, vmID string) (*VirtualMachine, error)
 	// ListVirtualMachines gets all of the virtual machines in the given resource group.
-	ListVirtualMachines(ctx context.Context, resourceGroup string) ([]*armcompute.VirtualMachine, error)
+	ListVirtualMachines(ctx context.Context, resourceGroup string) ([]*VirtualMachine, error)
 }
 
 // VirtualMachine represents an Azure virtual machine.
@@ -74,10 +86,19 @@ type VirtualMachine struct {
 	Subscription string
 	// ResourceGroup is the resource group the VM is in.
 	ResourceGroup string
+	// Location is the Azure region containing the VM, e.g. "eastus".
+	Location string
 	// VMID is the VM's ID.
 	VMID string
+	// UniformScaleSetName is the name of the Virtual Machine Scale Set. Empty string if the VM is not part of a uniform Scale Set.
+	UniformScaleSetName string
+	// UniformScaleSetVMInstanceID is the instance ID of the Virtual Machine Scale Set VM. Empty string if the VM is not part of a uniform Scale Set.
+	// This is a unique identifier for the VM within its Scale Set, e.g. "0", "1".
+	UniformScaleSetVMInstanceID string
 	// Identities are the identities associated with the resource.
 	Identities []Identity
+	// Tags are the VM tags, e.g. {"env": "prod"}. Empty map (not nil) when the VM has no tags.
+	Tags map[string]string
 }
 
 // Identity represents an Azure virtual machine identity.
@@ -87,10 +108,14 @@ type Identity struct {
 }
 
 type vmClient struct {
-	// api is the Azure virtual machine client.
-	api armCompute
-	// scaleSetAPI is the Azure VM scale set client.
-	scaleSetAPI scaleSet
+	// virtualMachinesLister is the Azure virtual machine client.
+	virtualMachinesLister virtualMachinesLister
+	// scaleSetVMsLister is the Azure VM scale set VMs client.
+	scaleSetVMsLister scaleSetVMsLister
+	// scaleSetsLister is the Azure VM scale set client.
+	scaleSetsLister scaleSetsLister
+
+	logger *slog.Logger
 }
 
 // NewVirtualMachinesClient creates a new Azure virtual machines client by
@@ -100,77 +125,45 @@ func NewVirtualMachinesClient(subscription string, cred azcore.TokenCredential, 
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	scaleSetAPI, err := armcompute.NewVirtualMachineScaleSetVMsClient(subscription, cred, options)
+	scaleSetVMsLister, err := armcompute.NewVirtualMachineScaleSetVMsClient(subscription, cred, options)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	scaleSetAPI, err := armcompute.NewVirtualMachineScaleSetsClient(subscription, cred, options)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
-	return NewVirtualMachinesClientByAPI(computeAPI, scaleSetAPI), nil
+	config := VirtualMachinesClientConfig{
+		VirtualMachineAPI: computeAPI,
+		ScaleSetsAPI:      scaleSetAPI,
+		ScaleSetVMsAPI:    scaleSetVMsLister,
+	}
+	return NewVirtualMachinesClientByAPI(config), nil
+}
+
+// VirtualMachinesClientConfig combines dependencies for creating a VirtualMachinesClient.
+type VirtualMachinesClientConfig struct {
+	VirtualMachineAPI virtualMachinesLister
+	ScaleSetsAPI      scaleSetsLister
+	ScaleSetVMsAPI    scaleSetVMsLister
+	Logger            *slog.Logger
 }
 
 // NewVirtualMachinesClientByAPI creates a new Azure virtual machines client by
 // ARM API client.
-func NewVirtualMachinesClientByAPI(api armCompute, scaleSetAPI scaleSet) VirtualMachinesClient {
+func NewVirtualMachinesClientByAPI(config VirtualMachinesClientConfig) VirtualMachinesClient {
+	logger := config.Logger
+	if logger == nil {
+		logger = slog.Default().With(teleport.ComponentKey, "azure_virtualmachines_client")
+	}
+
 	return &vmClient{
-		api:         api,
-		scaleSetAPI: scaleSetAPI,
+		virtualMachinesLister: config.VirtualMachineAPI,
+		scaleSetsLister:       config.ScaleSetsAPI,
+		scaleSetVMsLister:     config.ScaleSetVMsAPI,
+		logger:                logger,
 	}
-}
-
-type vmTypes interface {
-	*armcompute.VirtualMachine | *armcompute.VirtualMachineScaleSetVM
-}
-
-func parseVirtualMachine[T vmTypes](vm T) (*VirtualMachine, error) {
-	var (
-		id       string
-		name     string
-		identity *armcompute.VirtualMachineIdentity
-		vmID     *string
-	)
-
-	switch v := any(vm).(type) {
-	case *armcompute.VirtualMachine:
-		id = *v.ID
-		name = *v.Name
-		identity = v.Identity
-		if v.Properties != nil {
-			vmID = v.Properties.VMID
-		}
-
-	case *armcompute.VirtualMachineScaleSetVM:
-		id = *v.ID
-		name = *v.Name
-		identity = v.Identity
-		if v.Properties != nil {
-			vmID = v.Properties.VMID
-		}
-	}
-
-	resourceID, err := arm.ParseResourceID(id)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-
-	var identities []Identity
-	if identity != nil {
-		if systemAssigned := StringVal(identity.PrincipalID); systemAssigned != "" {
-			identities = append(identities, Identity{ResourceID: systemAssigned})
-		}
-
-		for identityID := range identity.UserAssignedIdentities {
-			identities = append(identities, Identity{ResourceID: identityID})
-		}
-	}
-
-	return &VirtualMachine{
-		ID:            id,
-		Name:          name,
-		Subscription:  resourceID.SubscriptionID,
-		ResourceGroup: resourceID.ResourceGroupName,
-		VMID:          StringVal(vmID),
-		Identities:    identities,
-	}, nil
 }
 
 // Get returns the virtual machine (including scale set VMs) for the given
@@ -192,18 +185,23 @@ func (c *vmClient) Get(ctx context.Context, resourceID string) (*VirtualMachine,
 		return c.getScaleSetVM(ctx, parsedResourceID)
 	}
 
-	resp, err := c.api.Get(ctx, parsedResourceID.ResourceGroupName, parsedResourceID.Name, nil)
+	resp, err := c.virtualMachinesLister.Get(ctx, parsedResourceID.ResourceGroupName, parsedResourceID.Name, nil)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
-	vm, err := parseVirtualMachine(&resp.VirtualMachine)
+	vm, err := virtualMachineFromARMComputeVirtualMachine(&resp.VirtualMachine)
 	return vm, trace.Wrap(err)
 }
 
 // GetByVMID returns the virtual machine for a given VM ID.
 func (c *vmClient) GetByVMID(ctx context.Context, vmID string) (*VirtualMachine, error) {
-	pager := newListAllPager(c.api.NewListAllPager(&armcompute.VirtualMachinesClientListAllOptions{}))
+	pager := newAPIPager(
+		c.virtualMachinesLister.NewListAllPager(&armcompute.VirtualMachinesClientListAllOptions{}),
+		func(resp armcompute.VirtualMachinesClientListAllResponse) []*armcompute.VirtualMachine {
+			return resp.Value
+		},
+	)
 	for pager.more() {
 		res, err := pager.nextPage(ctx)
 		if err != nil {
@@ -212,7 +210,7 @@ func (c *vmClient) GetByVMID(ctx context.Context, vmID string) (*VirtualMachine,
 
 		for _, vm := range res {
 			if vm.Properties != nil && *vm.Properties.VMID == vmID {
-				result, err := parseVirtualMachine(vm)
+				result, err := virtualMachineFromARMComputeVirtualMachine(vm)
 				return result, trace.Wrap(err)
 			}
 		}
@@ -225,36 +223,36 @@ func (c *vmClient) getScaleSetVM(ctx context.Context, resourceID *arm.ResourceID
 		return nil, trace.BadParameter("expected resource ID to include scale set as parent resource")
 	}
 
-	resp, err := c.scaleSetAPI.Get(ctx, resourceID.ResourceGroupName, resourceID.Parent.Name, resourceID.Name, nil)
+	resp, err := c.scaleSetVMsLister.Get(ctx, resourceID.ResourceGroupName, resourceID.Parent.Name, resourceID.Name, nil)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
-	result, err := parseVirtualMachine(&resp.VirtualMachineScaleSetVM)
+	scaleSetName := resourceID.Parent.Name
+	resourceGroup := resourceID.ResourceGroupName
+	subscriptionID := resourceID.SubscriptionID
+
+	result, err := virtualMachineFromARMComputeVirtualMachineScaleSetVM(&resp.VirtualMachineScaleSetVM, subscriptionID, resourceGroup, scaleSetName)
 	return result, trace.Wrap(err)
 }
 
-type vmPager struct {
+type apiPager[T any] struct {
 	more     func() bool
-	nextPage func(context.Context) ([]*armcompute.VirtualMachine, error)
+	nextPage func(context.Context) ([]*T, error)
 }
 
-func newListPager(azurePager *runtime.Pager[armcompute.VirtualMachinesClientListResponse]) vmPager {
-	return vmPager{
-		more: azurePager.More,
-		nextPage: func(ctx context.Context) ([]*armcompute.VirtualMachine, error) {
-			res, err := azurePager.NextPage(ctx)
-			return res.Value, trace.Wrap(err)
-		},
-	}
-}
-
-func newListAllPager(azurePager *runtime.Pager[armcompute.VirtualMachinesClientListAllResponse]) vmPager {
-	return vmPager{
-		more: azurePager.More,
-		nextPage: func(ctx context.Context) ([]*armcompute.VirtualMachine, error) {
-			res, err := azurePager.NextPage(ctx)
-			return res.Value, trace.Wrap(err)
+// newAPIPager wraps an Azure SDK pager into a apiPager. The values function
+// extracts the slice of *T from each response page; this keeps the wrapper
+// generic over the response type R while remaining type-safe at compile time.
+func newAPIPager[T, R any](p *runtime.Pager[R], values func(R) []*T) apiPager[T] {
+	return apiPager[T]{
+		more: p.More,
+		nextPage: func(ctx context.Context) ([]*T, error) {
+			res, err := p.NextPage(ctx)
+			if err != nil {
+				return nil, trace.Wrap(err)
+			}
+			return values(res), nil
 		},
 	}
 }
@@ -262,22 +260,143 @@ func newListAllPager(azurePager *runtime.Pager[armcompute.VirtualMachinesClientL
 // ListVirtualMachines lists all virtual machines in a given resource group
 // using the Azure virtual machines API. If resourceGroup is "*", it lists
 // all virtual machines in any resource group.
-func (c *vmClient) ListVirtualMachines(ctx context.Context, resourceGroup string) ([]*armcompute.VirtualMachine, error) {
-	var pager vmPager
-	if resourceGroup == types.Wildcard {
-		pager = newListAllPager(c.api.NewListAllPager(&armcompute.VirtualMachinesClientListAllOptions{}))
-	} else {
-		pager = newListPager(c.api.NewListPager(resourceGroup, &armcompute.VirtualMachinesClientListOptions{}))
+// It includes regular VMs and VMs from VM Scale Sets.
+func (c *vmClient) ListVirtualMachines(ctx context.Context, resourceGroup string) ([]*VirtualMachine, error) {
+	regularVMs, listVMsErr := c.listARMVirtualMachinesAsVirtualMachines(ctx, resourceGroup)
+
+	uniformScaleSetVirtualMachines, uniformVMSSListVMsErr := c.listVirtualMachinesFromUniformVMSS(ctx, resourceGroup)
+
+	switch {
+	case listVMsErr != nil && uniformVMSSListVMsErr != nil:
+		return nil, trace.NewAggregate(listVMsErr, uniformVMSSListVMsErr)
+
+	case listVMsErr != nil:
+		c.logger.WarnContext(ctx, "failed to call ListVirtualMachines API, continuing with uniform VMSS VMs", "error", listVMsErr)
+		return uniformScaleSetVirtualMachines, nil
+
+	case uniformVMSSListVMsErr != nil:
+		c.logger.WarnContext(ctx, "failed to list VMs from uniform VMSS, continuing with regular VMs", "error", uniformVMSSListVMsErr)
+		return regularVMs, nil
+
+	default:
+		return append(regularVMs, uniformScaleSetVirtualMachines...), nil
 	}
-	var virtualMachines []*armcompute.VirtualMachine
+}
+
+// vmScaleSetIsFlexible reports whether the Scale Set was created with flexible orchestration mode.
+func vmScaleSetIsFlexible(vmScaleSetProperties *armcompute.VirtualMachineScaleSetProperties) bool {
+	return vmScaleSetProperties != nil && StringVal(vmScaleSetProperties.OrchestrationMode) == string(armcompute.OrchestrationModeFlexible)
+}
+
+func (c *vmClient) listARMVirtualMachinesAsVirtualMachines(ctx context.Context, resourceGroup string) ([]*VirtualMachine, error) {
+	var allVMs []*VirtualMachine
+
+	var pager apiPager[armcompute.VirtualMachine]
+	if resourceGroup == types.Wildcard {
+		pager = newAPIPager(
+			c.virtualMachinesLister.NewListAllPager(&armcompute.VirtualMachinesClientListAllOptions{}),
+			func(resp armcompute.VirtualMachinesClientListAllResponse) []*armcompute.VirtualMachine {
+				return resp.Value
+			},
+		)
+	} else {
+		pager = newAPIPager(
+			c.virtualMachinesLister.NewListPager(resourceGroup, &armcompute.VirtualMachinesClientListOptions{}),
+			func(resp armcompute.VirtualMachinesClientListResponse) []*armcompute.VirtualMachine {
+				return resp.Value
+			},
+		)
+	}
+
 	for pager.more() {
 		res, err := pager.nextPage(ctx)
 		if err != nil {
 			return nil, trace.Wrap(ConvertResponseError(err))
 		}
-		virtualMachines = append(virtualMachines, res...)
+		for _, rawVM := range res {
+			vm, err := virtualMachineFromARMComputeVirtualMachine(rawVM)
+			if err != nil {
+				c.logger.DebugContext(ctx, "skipping Azure VM", "resource_id", StringVal(rawVM.ID), "error", err)
+				continue
+			}
+			allVMs = append(allVMs, vm)
+		}
 	}
 
+	return allVMs, nil
+}
+
+func (c *vmClient) listVirtualMachinesFromUniformVMSS(ctx context.Context, resourceGroupFilter string) ([]*VirtualMachine, error) {
+	var pager apiPager[armcompute.VirtualMachineScaleSet]
+	if resourceGroupFilter == types.Wildcard {
+		pager = newAPIPager(
+			c.scaleSetsLister.NewListAllPager(&armcompute.VirtualMachineScaleSetsClientListAllOptions{}),
+			func(resp armcompute.VirtualMachineScaleSetsClientListAllResponse) []*armcompute.VirtualMachineScaleSet {
+				return resp.Value
+			},
+		)
+	} else {
+		pager = newAPIPager(
+			c.scaleSetsLister.NewListPager(resourceGroupFilter, &armcompute.VirtualMachineScaleSetsClientListOptions{}),
+			func(resp armcompute.VirtualMachineScaleSetsClientListResponse) []*armcompute.VirtualMachineScaleSet {
+				return resp.Value
+			},
+		)
+	}
+
+	var virtualMachines []*VirtualMachine
+	for pager.more() {
+		scaleSetsPage, err := pager.nextPage(ctx)
+		if err != nil {
+			return nil, trace.Wrap(ConvertResponseError(err))
+		}
+
+		for _, scaleSet := range scaleSetsPage {
+			// Skip VM Scale Sets whose orchestration mode is Flexible, because those are returned in the regular List Virtual Machines API.
+			if vmScaleSetIsFlexible(scaleSet.Properties) {
+				continue
+			}
+
+			scaleSetName := StringVal(scaleSet.Name)
+
+			scaleSetResourceID, err := arm.ParseResourceID(StringVal(scaleSet.ID))
+			if err != nil {
+				c.logger.DebugContext(ctx, "skipping entire Azure VM Scale Set", "scale_set_name", scaleSetName, "resource_id", StringVal(scaleSet.ID), "error", err)
+				continue
+			}
+			resourceGroup := scaleSetResourceID.ResourceGroupName
+			subscriptionID := scaleSetResourceID.SubscriptionID
+
+			scaleSetVMsPager := newAPIPager(
+				c.scaleSetVMsLister.NewListPager(resourceGroup, scaleSetName, &armcompute.VirtualMachineScaleSetVMsClientListOptions{}),
+				func(resp armcompute.VirtualMachineScaleSetVMsClientListResponse) []*armcompute.VirtualMachineScaleSetVM {
+					return resp.Value
+				},
+			)
+			pageCount := 0
+			vmsCounter := 0
+			for scaleSetVMsPager.more() {
+				pageCount++
+				scaleSetVMsPage, err := scaleSetVMsPager.nextPage(ctx)
+				if err != nil {
+					c.logger.DebugContext(ctx, "error when fetching Azure VM Scale Set VMs page", "scale_set_name", scaleSetName, "resource_id", StringVal(scaleSet.ID), "page", pageCount, "error", err)
+					break
+				}
+
+				vmsCounter += len(scaleSetVMsPage)
+				for _, vm := range scaleSetVMsPage {
+					discoveredVM, err := virtualMachineFromARMComputeVirtualMachineScaleSetVM(vm, subscriptionID, resourceGroup, scaleSetName)
+					if err != nil {
+						c.logger.DebugContext(ctx, "skipping Azure VM Scale Set VM", "scale_set_name", scaleSetName, "resource_id", StringVal(vm.ID), "error", err)
+						continue
+					}
+					virtualMachines = append(virtualMachines, discoveredVM)
+				}
+			}
+
+			c.logger.DebugContext(ctx, "fetched all VMs from Azure VM Scale Set", "scale_set_name", scaleSetName, "resource_id", StringVal(scaleSet.ID), "pages_listed", pageCount, "vms_listed", vmsCounter)
+		}
+	}
 	return virtualMachines, nil
 }
 
@@ -289,8 +408,20 @@ type RunCommandRequest struct {
 	ResourceGroup string
 	// VMName is the name of the VM.
 	VMName string
+	// UniformScaleSetName is the name of the Scale Set this VM belongs to.
+	// Only used when the VM is part of a uniform VM Scale Set.
+	// Regular VMs and VMs from flexible VM Scale Sets should leave this field empty.
+	UniformScaleSetName string
+	// UniformScaleSetVMInstanceID is the instance ID of this VM within the uniform Scale Set.
+	// Only used when the VM is part of a uniform VM Scale Set.
+	// Regular VMs and VMs from flexible VM Scale Sets should leave this field empty.
+	UniformScaleSetVMInstanceID string
 	// Script is the shell script to be executed in the virtual machine.
 	Script string
+}
+
+func (r RunCommandRequest) isUniformVMSS() bool {
+	return r.UniformScaleSetName != "" && r.UniformScaleSetVMInstanceID != ""
 }
 
 // RunCommandResult contains the result of executing a command on an Azure VM.
@@ -317,7 +448,8 @@ type RunCommandClient interface {
 }
 
 type runCommandClient struct {
-	api *armcompute.VirtualMachineRunCommandsClient
+	virtualMachineRunCommandsAPI *armcompute.VirtualMachineRunCommandsClient
+	scaleSetVMRunCommandsAPI     *armcompute.VirtualMachineScaleSetVMRunCommandsClient
 }
 
 // NewRunCommandClient creates a new Azure Run Command client by subscription
@@ -327,10 +459,20 @@ func NewRunCommandClient(subscription string, cred azcore.TokenCredential, optio
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
+
+	scaleSetVMRunCommandsAPI, err := armcompute.NewVirtualMachineScaleSetVMRunCommandsClient(subscription, cred, options)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
 	return &runCommandClient{
-		api: runCommandAPI,
+		virtualMachineRunCommandsAPI: runCommandAPI,
+		scaleSetVMRunCommandsAPI:     scaleSetVMRunCommandsAPI,
 	}, nil
 }
+
+// TODO(Tener): make the run command name actual parameter.
+const runCommandName = "teleport-install"
 
 // Run runs Teleport installation command on a virtual machine.
 func (c *runCommandClient) Run(ctx context.Context, req RunCommandRequest) (*RunCommandResult, error) {
@@ -338,10 +480,8 @@ func (c *runCommandClient) Run(ctx context.Context, req RunCommandRequest) (*Run
 	// pad the timeout so we can still attempt to collect output if it times out
 	ctx, cancel := context.WithTimeout(ctx, runCommandTimeout+time.Minute)
 	defer cancel()
-	// TODO(Tener): make the run command name actual parameter.
-	const runCommandName = "teleport-install"
 
-	poller, err := c.api.BeginCreateOrUpdate(ctx, req.ResourceGroup, req.VMName, runCommandName, armcompute.VirtualMachineRunCommand{
+	runCommand := armcompute.VirtualMachineRunCommand{
 		Location: to.Ptr(req.Region),
 		Properties: &armcompute.VirtualMachineRunCommandProperties{
 			AsyncExecution: to.Ptr(false),
@@ -350,36 +490,87 @@ func (c *runCommandClient) Run(ctx context.Context, req RunCommandRequest) (*Run
 			},
 			TimeoutInSeconds: to.Ptr(int32(runCommandTimeout.Seconds())),
 		},
-	}, nil)
+	}
+
+	var runCommandProperties *armcompute.VirtualMachineRunCommandProperties
+	var err error
+
+	if req.isUniformVMSS() {
+		runCommandProperties, err = c.uniformScaleSetVirtualMachineRunCommand(ctx, req, runCommand)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+	} else {
+		runCommandProperties, err = c.regularVirtualMachineRunCommand(ctx, req, runCommand)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+	}
+
+	commandResult, err := commandResultFromInstanceView(runCommandProperties)
 	if err != nil {
 		return nil, trace.Wrap(err)
+	}
+
+	return commandResult, nil
+}
+
+func (c *runCommandClient) regularVirtualMachineRunCommand(ctx context.Context, req RunCommandRequest, runCommand armcompute.VirtualMachineRunCommand) (*armcompute.VirtualMachineRunCommandProperties, error) {
+	poller, err := c.virtualMachineRunCommandsAPI.BeginCreateOrUpdate(ctx, req.ResourceGroup, req.VMName, runCommandName, runCommand, nil)
+	if err != nil {
+		return nil, trace.Wrap(ConvertResponseError(err))
 	}
 
 	_, err = poller.PollUntilDone(ctx, &runtime.PollUntilDoneOptions{Frequency: 10 * time.Second})
 	if err != nil {
-		return nil, trace.Wrap(err)
+		return nil, trace.Wrap(ConvertResponseError(err))
 	}
 
 	// note: we are not guaranteed to receive the output of the command above if the req.Name is not unique.
 	// in particular, two discovery services may race, causing the output to be empty: our attempt can be shadowed by a newer one.
-	resp, err := c.api.GetByVirtualMachine(ctx, req.ResourceGroup, req.VMName, runCommandName, &armcompute.VirtualMachineRunCommandsClientGetByVirtualMachineOptions{
+	resp, err := c.virtualMachineRunCommandsAPI.GetByVirtualMachine(ctx, req.ResourceGroup, req.VMName, runCommandName, &armcompute.VirtualMachineRunCommandsClientGetByVirtualMachineOptions{
 		Expand: to.Ptr("instanceView"),
 	})
 	if err != nil {
-		return nil, trace.Wrap(err)
+		return nil, trace.Wrap(ConvertResponseError(err))
 	}
 
-	if resp.Properties == nil || resp.Properties.InstanceView == nil {
-		return nil, trace.BadParameter("unable to query command execution state, failure assumed")
+	return resp.Properties, nil
+}
+
+func (c *runCommandClient) uniformScaleSetVirtualMachineRunCommand(ctx context.Context, req RunCommandRequest, runCommand armcompute.VirtualMachineRunCommand) (*armcompute.VirtualMachineRunCommandProperties, error) {
+	poller, err := c.scaleSetVMRunCommandsAPI.BeginCreateOrUpdate(ctx, req.ResourceGroup, req.UniformScaleSetName, req.UniformScaleSetVMInstanceID, runCommandName, runCommand, nil)
+	if err != nil {
+		return nil, trace.Wrap(ConvertResponseError(err))
 	}
-	iv := resp.Properties.InstanceView
-	result := &RunCommandResult{
-		ExecutionState: string(fromPtr(iv.ExecutionState)),
-		ExitCode:       fromPtr(iv.ExitCode),
-		StdOut:         fromPtr(iv.Output),
-		StdErr:         fromPtr(iv.Error),
+
+	_, err = poller.PollUntilDone(ctx, &runtime.PollUntilDoneOptions{Frequency: 10 * time.Second})
+	if err != nil {
+		return nil, trace.Wrap(ConvertResponseError(err))
 	}
-	return result, nil
+
+	// note: we are not guaranteed to receive the output of the command above if the req.Name is not unique.
+	// in particular, two discovery services may race, causing the output to be empty: our attempt can be shadowed by a newer one.
+	resp, err := c.scaleSetVMRunCommandsAPI.Get(ctx, req.ResourceGroup, req.UniformScaleSetName, req.UniformScaleSetVMInstanceID, runCommandName, &armcompute.VirtualMachineScaleSetVMRunCommandsClientGetOptions{
+		Expand: to.Ptr("instanceView"),
+	})
+	if err != nil {
+		return nil, trace.Wrap(ConvertResponseError(err))
+	}
+
+	return resp.Properties, nil
+}
+
+func commandResultFromInstanceView(properties *armcompute.VirtualMachineRunCommandProperties) (*RunCommandResult, error) {
+	if properties == nil || properties.InstanceView == nil {
+		return nil, trace.BadParameter("unable to query command execution state")
+	}
+	return &RunCommandResult{
+		ExecutionState: string(fromPtr(properties.InstanceView.ExecutionState)),
+		ExitCode:       fromPtr(properties.InstanceView.ExitCode),
+		StdOut:         fromPtr(properties.InstanceView.Output),
+		StdErr:         fromPtr(properties.InstanceView.Error),
+	}, nil
 }
 
 func fromPtr[T any](ptr *T) T {
@@ -401,4 +592,73 @@ func getRunCommandTimeout() time.Duration {
 		return min(maxTimeout, max(minTimeout, dur))
 	}
 	return 5 * time.Minute // default to 5m
+}
+
+func virtualMachineFromARMComputeVirtualMachine(vm *armcompute.VirtualMachine) (*VirtualMachine, error) {
+	if vm == nil {
+		return nil, trace.BadParameter("vm cannot be nil")
+	}
+
+	var vmid string
+	if vm.Properties != nil {
+		vmid = StringVal(vm.Properties.VMID)
+	}
+
+	// The ARM resource ID should never fail to parse, unless Azure changes the contract.
+	resourceMetadata, err := arm.ParseResourceID(StringVal(vm.ID))
+	if err != nil {
+		return nil, trace.BadParameter("failed to parse Virtual Machine resource ID %q: %v", StringVal(vm.ID), err)
+	}
+
+	return &VirtualMachine{
+		ID:            StringVal(vm.ID),
+		VMID:          vmid,
+		Name:          StringVal(vm.Name),
+		Location:      StringVal(vm.Location),
+		Subscription:  resourceMetadata.SubscriptionID,
+		ResourceGroup: resourceMetadata.ResourceGroupName,
+		Identities:    parseVMIdentities(vm.Identity),
+		Tags:          ConvertTags(vm.Tags),
+	}, nil
+}
+
+func virtualMachineFromARMComputeVirtualMachineScaleSetVM(vm *armcompute.VirtualMachineScaleSetVM, subscriptionID, resourceGroup, scaleSetName string) (*VirtualMachine, error) {
+	if vm == nil {
+		return nil, trace.BadParameter("vm cannot be nil")
+	}
+
+	var vmid string
+	if vm.Properties != nil {
+		vmid = StringVal(vm.Properties.VMID)
+	}
+
+	return &VirtualMachine{
+		ID:                          StringVal(vm.ID),
+		VMID:                        vmid,
+		Name:                        StringVal(vm.Name),
+		Location:                    StringVal(vm.Location),
+		Subscription:                subscriptionID,
+		ResourceGroup:               resourceGroup,
+		Identities:                  parseVMIdentities(vm.Identity),
+		Tags:                        ConvertTags(vm.Tags),
+		UniformScaleSetName:         scaleSetName,
+		UniformScaleSetVMInstanceID: StringVal(vm.InstanceID),
+	}, nil
+}
+
+func parseVMIdentities(identity *armcompute.VirtualMachineIdentity) []Identity {
+	if identity == nil {
+		return nil
+	}
+
+	var identities []Identity
+	if systemAssigned := StringVal(identity.PrincipalID); systemAssigned != "" {
+		identities = append(identities, Identity{ResourceID: systemAssigned})
+	}
+
+	for identityID := range identity.UserAssignedIdentities {
+		identities = append(identities, Identity{ResourceID: identityID})
+	}
+
+	return identities
 }

--- a/lib/cloud/azure/vm_test.go
+++ b/lib/cloud/azure/vm_test.go
@@ -25,9 +25,20 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v6"
+	"github.com/gravitational/trace"
 	"github.com/stretchr/testify/require"
 
 	"github.com/gravitational/teleport/api/types"
+)
+
+const (
+	testSubID = "11111111-1111-1111-1111-111111111111"
+	rgName    = "rg1"
+
+	vmResourceID = "/subscriptions/11111111-1111-1111-1111-111111111111/resourceGroups/rg1/providers/Microsoft.Compute/virtualMachines/vm1"
+
+	vmssResourceID   = "/subscriptions/11111111-1111-1111-1111-111111111111/resourceGroups/rg1/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1"
+	vmssVMResourceID = "/subscriptions/11111111-1111-1111-1111-111111111111/resourceGroups/rg1/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1/virtualMachines/0"
 )
 
 func TestGetVirtualMachine(t *testing.T) {
@@ -137,7 +148,9 @@ func TestGetVirtualMachine(t *testing.T) {
 		},
 	} {
 		t.Run(tc.desc, func(t *testing.T) {
-			vmClient := NewVirtualMachinesClientByAPI(tc.client, nil /* scaleSetAPI */)
+			vmClient := NewVirtualMachinesClientByAPI(VirtualMachinesClientConfig{
+				VirtualMachineAPI: tc.client,
+			})
 
 			vm, err := vmClient.Get(ctx, tc.resourceID)
 			tc.assertError(t, err)
@@ -153,14 +166,14 @@ func TestGetScaleSetVirtualMachine(t *testing.T) {
 	for _, tc := range []struct {
 		desc        string
 		resourceID  string
-		client      *ARMScaleSetMock
+		client      *ARMScaleSetVMsMock
 		assertError require.ErrorAssertionFunc
 		assertVM    require.ValueAssertionFunc
 	}{
 		{
 			desc:       "vm with valid user identities",
 			resourceID: validResourceID,
-			client: &ARMScaleSetMock{
+			client: &ARMScaleSetVMsMock{
 				GetResult: armcompute.VirtualMachineScaleSetVM{
 					ID:   to.Ptr(validResourceID),
 					Name: to.Ptr("name"),
@@ -191,7 +204,7 @@ func TestGetScaleSetVirtualMachine(t *testing.T) {
 		{
 			desc:       "vm without identity",
 			resourceID: validResourceID,
-			client: &ARMScaleSetMock{
+			client: &ARMScaleSetVMsMock{
 				GetResult: armcompute.VirtualMachineScaleSetVM{
 					ID:   to.Ptr(validResourceID),
 					Name: to.Ptr("name"),
@@ -210,7 +223,7 @@ func TestGetScaleSetVirtualMachine(t *testing.T) {
 		{
 			desc:       "vm with only user managed identities",
 			resourceID: validResourceID,
-			client: &ARMScaleSetMock{
+			client: &ARMScaleSetVMsMock{
 				GetResult: armcompute.VirtualMachineScaleSetVM{
 					ID:   to.Ptr(validResourceID),
 					Name: to.Ptr("name"),
@@ -238,7 +251,7 @@ func TestGetScaleSetVirtualMachine(t *testing.T) {
 		{
 			desc:       "client error",
 			resourceID: validResourceID,
-			client: &ARMScaleSetMock{
+			client: &ARMScaleSetVMsMock{
 				GetErr: fmt.Errorf("client error"),
 			},
 			assertError: require.Error,
@@ -246,7 +259,9 @@ func TestGetScaleSetVirtualMachine(t *testing.T) {
 		},
 	} {
 		t.Run(tc.desc, func(t *testing.T) {
-			vmClient := NewVirtualMachinesClientByAPI(nil /* api */, tc.client)
+			vmClient := NewVirtualMachinesClientByAPI(VirtualMachinesClientConfig{
+				ScaleSetVMsAPI: tc.client,
+			})
 
 			vm, err := vmClient.Get(ctx, tc.resourceID)
 			tc.assertError(t, err)
@@ -255,53 +270,711 @@ func TestGetScaleSetVirtualMachine(t *testing.T) {
 	}
 }
 
+// collectVMIDs returns the VMID field from each VirtualMachine.
+// VMID is the Azure-assigned UUID for the VM (e.g. "22222222-..."), distinct from
+// the ARM resource ID. It is used throughout the tests as a stable identifier
+// to verify which VMs were returned.
+func collectVMIDs(vms []*VirtualMachine) []string {
+	ids := make([]string, 0, len(vms))
+	for _, vm := range vms {
+		ids = append(ids, vm.VMID)
+	}
+	return ids
+}
+
 func TestListVirtualMachines(t *testing.T) {
 	t.Parallel()
-	mockAPI := &ARMComputeMock{
-		VirtualMachines: map[string][]*armcompute.VirtualMachine{
-			"rg1": {
-				{ID: to.Ptr("vm1")},
-				{ID: to.Ptr("vm2")},
-			},
-			"rg2": {
-				{ID: to.Ptr("vm3")},
-				{ID: to.Ptr("vm4")},
-			},
+
+	// A well-formed regular VM whose ARM ID is parseable.
+	regularVM := &armcompute.VirtualMachine{
+		ID:       to.Ptr(vmResourceID),
+		Name:     to.Ptr("vm1"),
+		Location: to.Ptr("eastus"),
+		Properties: &armcompute.VirtualMachineProperties{
+			VMID: to.Ptr("vm-uuid-1"),
 		},
 	}
-	tests := []struct {
-		name          string
-		resourceGroup string
-		wantIDs       []string
+
+	buildVMWithVMID := func(vmID string) *armcompute.VirtualMachine {
+		return &armcompute.VirtualMachine{
+			ID:       to.Ptr(vmResourceID),
+			Name:     to.Ptr("vm1"),
+			Location: to.Ptr("eastus"),
+			Properties: &armcompute.VirtualMachineProperties{
+				VMID: to.Ptr(vmID),
+			},
+		}
+	}
+
+	// A well-formed uniform scale set with a parseable ARM ID.
+	uniformScaleSet := &armcompute.VirtualMachineScaleSet{
+		ID:   to.Ptr(vmssResourceID),
+		Name: to.Ptr("vmss1"),
+	}
+
+	// A VM belonging to the scale set above.
+	scaleSetVM := armcompute.VirtualMachineScaleSetVM{
+		ID:         to.Ptr(vmssVMResourceID),
+		Name:       to.Ptr("vmss1_0"),
+		Location:   to.Ptr("eastus"),
+		InstanceID: to.Ptr("0"),
+		Properties: &armcompute.VirtualMachineScaleSetVMProperties{
+			VMID: to.Ptr("vmss-vm-uuid-1"),
+		},
+	}
+
+	for _, tc := range []struct {
+		desc           string
+		vmAPI          *ARMComputeMock
+		scaleSetsAPI   *ARMScaleSetsMock
+		scaleSetVMsAPI *ARMScaleSetVMsMock
+		resourceGroup  string
+		wantVMIDs      []string
 	}{
 		{
-			name:          "existing resource group",
-			resourceGroup: "rg1",
-			wantIDs:       []string{"vm1", "vm2"},
+			desc: "regular VMs only, no scale sets",
+			vmAPI: &ARMComputeMock{
+				VirtualMachines: map[string][]*armcompute.VirtualMachine{
+					rgName: {regularVM},
+				},
+			},
+			scaleSetsAPI:   &ARMScaleSetsMock{},
+			scaleSetVMsAPI: &ARMScaleSetVMsMock{},
+			resourceGroup:  rgName,
+			wantVMIDs:      []string{"vm-uuid-1"},
 		},
 		{
-			name:          "nonexistant resource group",
-			resourceGroup: "rgfake",
-			wantIDs:       []string{},
+			desc:  "uniform VMSS VMs only, no regular VMs",
+			vmAPI: &ARMComputeMock{VirtualMachines: map[string][]*armcompute.VirtualMachine{}},
+			scaleSetsAPI: &ARMScaleSetsMock{
+				ScaleSetRecords: []*armcompute.VirtualMachineScaleSet{uniformScaleSet},
+			},
+			scaleSetVMsAPI: &ARMScaleSetVMsMock{GetResult: scaleSetVM},
+			resourceGroup:  rgName,
+			wantVMIDs:      []string{"vmss-vm-uuid-1"},
 		},
 		{
-			name:          "all resource groups",
-			resourceGroup: types.Wildcard,
-			wantIDs:       []string{"vm1", "vm2", "vm3", "vm4"},
+			desc: "combines regular VMs and uniform VMSS VMs",
+			vmAPI: &ARMComputeMock{
+				VirtualMachines: map[string][]*armcompute.VirtualMachine{
+					rgName: {regularVM},
+				},
+			},
+			scaleSetsAPI: &ARMScaleSetsMock{
+				ScaleSetRecords: []*armcompute.VirtualMachineScaleSet{uniformScaleSet},
+			},
+			scaleSetVMsAPI: &ARMScaleSetVMsMock{GetResult: scaleSetVM},
+			resourceGroup:  rgName,
+			wantVMIDs:      []string{"vm-uuid-1", "vmss-vm-uuid-1"},
+		},
+		{
+			desc: "flexible scale set is skipped by the VMSS lister",
+			vmAPI: &ARMComputeMock{
+				VirtualMachines: map[string][]*armcompute.VirtualMachine{
+					rgName: {regularVM},
+				},
+			},
+			scaleSetsAPI: &ARMScaleSetsMock{
+				ScaleSetRecords: []*armcompute.VirtualMachineScaleSet{
+					{
+						ID:   to.Ptr(vmssResourceID),
+						Name: to.Ptr("vmss1"),
+						Properties: &armcompute.VirtualMachineScaleSetProperties{
+							OrchestrationMode: to.Ptr(armcompute.OrchestrationModeFlexible),
+						},
+					},
+				},
+			},
+			// scaleSetVMsAPI would return a VM, but it must never be called for
+			// a flexible scale set.
+			scaleSetVMsAPI: &ARMScaleSetVMsMock{GetResult: scaleSetVM},
+			resourceGroup:  rgName,
+			wantVMIDs:      []string{"vm-uuid-1"},
+		},
+		{
+			// When listing VMs within a scale set fails, the scale set is skipped
+			// (inner loop breaks) but processing continues. Regular VMs are unaffected.
+			desc:  "scale set VM listing error skips that scale set gracefully",
+			vmAPI: &ARMComputeMock{VirtualMachines: map[string][]*armcompute.VirtualMachine{}},
+			scaleSetsAPI: &ARMScaleSetsMock{
+				ScaleSetRecords: []*armcompute.VirtualMachineScaleSet{uniformScaleSet},
+			},
+			scaleSetVMsAPI: &ARMScaleSetVMsMock{ListErr: trace.NotFound("vms not found")},
+			resourceGroup:  rgName,
+			wantVMIDs:      []string{},
+		},
+		{
+			desc:  "scale set with invalid ARM ID is skipped, valid scale sets still processed",
+			vmAPI: &ARMComputeMock{VirtualMachines: map[string][]*armcompute.VirtualMachine{}},
+			scaleSetsAPI: &ARMScaleSetsMock{
+				ScaleSetRecords: []*armcompute.VirtualMachineScaleSet{
+					{ID: to.Ptr("not-a-valid-arm-id"), Name: to.Ptr("bad")},
+					uniformScaleSet,
+				},
+			},
+			scaleSetVMsAPI: &ARMScaleSetVMsMock{GetResult: scaleSetVM},
+			resourceGroup:  rgName,
+			wantVMIDs:      []string{"vmss-vm-uuid-1"},
+		},
+		{
+			desc: "wildcard resource group returns VMs across all resource groups",
+			vmAPI: &ARMComputeMock{
+				VirtualMachines: map[string][]*armcompute.VirtualMachine{
+					"rg1": {
+						{
+							ID:   to.Ptr("/subscriptions/11111111-1111-1111-1111-111111111111/resourceGroups/rg1/providers/Microsoft.Compute/virtualMachines/vm1"),
+							Name: to.Ptr("vm1"),
+							Properties: &armcompute.VirtualMachineProperties{
+								VMID: to.Ptr("uuid-1"),
+							},
+						},
+					},
+					"rg2": {
+						{
+							ID:   to.Ptr("/subscriptions/11111111-1111-1111-1111-111111111111/resourceGroups/rg2/providers/Microsoft.Compute/virtualMachines/vm2"),
+							Name: to.Ptr("vm2"),
+							Properties: &armcompute.VirtualMachineProperties{
+								VMID: to.Ptr("uuid-2"),
+							},
+						},
+					},
+				},
+			},
+			scaleSetsAPI:   &ARMScaleSetsMock{},
+			scaleSetVMsAPI: &ARMScaleSetVMsMock{},
+			resourceGroup:  types.Wildcard,
+			wantVMIDs:      []string{"uuid-1", "uuid-2"},
+		},
+		{
+			desc: "existing resource group",
+			vmAPI: &ARMComputeMock{
+				VirtualMachines: map[string][]*armcompute.VirtualMachine{
+					"rg1": {
+						buildVMWithVMID("vm1"),
+						buildVMWithVMID("vm2"),
+					},
+					"rg2": {
+						buildVMWithVMID("vm3"),
+						buildVMWithVMID("vm4"),
+					},
+				},
+			},
+			scaleSetsAPI:   &ARMScaleSetsMock{},
+			scaleSetVMsAPI: &ARMScaleSetVMsMock{},
+			resourceGroup:  "rg1",
+			wantVMIDs:      []string{"vm1", "vm2"},
+		},
+		{
+			desc: "nonexistent resource group",
+			vmAPI: &ARMComputeMock{
+				VirtualMachines: map[string][]*armcompute.VirtualMachine{
+					"rg1": {
+						buildVMWithVMID("vm1"),
+						buildVMWithVMID("vm2"),
+					},
+					"rg2": {
+						buildVMWithVMID("vm3"),
+						buildVMWithVMID("vm4"),
+					},
+				},
+			},
+			scaleSetsAPI:   &ARMScaleSetsMock{},
+			scaleSetVMsAPI: &ARMScaleSetVMsMock{},
+			resourceGroup:  "rgfake",
+			wantVMIDs:      []string{},
+		},
+		{
+			desc: "all resource groups",
+			vmAPI: &ARMComputeMock{
+				VirtualMachines: map[string][]*armcompute.VirtualMachine{
+					"rg1": {
+						buildVMWithVMID("vm1"),
+						buildVMWithVMID("vm2"),
+					},
+					"rg2": {
+						buildVMWithVMID("vm3"),
+						buildVMWithVMID("vm4"),
+					},
+				},
+			},
+			scaleSetsAPI:   &ARMScaleSetsMock{},
+			scaleSetVMsAPI: &ARMScaleSetVMsMock{},
+			resourceGroup:  types.Wildcard,
+			wantVMIDs:      []string{"vm1", "vm2", "vm3", "vm4"},
+		},
+	} {
+		t.Run(tc.desc, func(t *testing.T) {
+			t.Parallel()
+			client := NewVirtualMachinesClientByAPI(VirtualMachinesClientConfig{
+				VirtualMachineAPI: tc.vmAPI,
+				ScaleSetsAPI:      tc.scaleSetsAPI,
+				ScaleSetVMsAPI:    tc.scaleSetVMsAPI,
+			})
+
+			vms, err := client.ListVirtualMachines(t.Context(), tc.resourceGroup)
+			require.NoError(t, err)
+			require.ElementsMatch(t, tc.wantVMIDs, collectVMIDs(vms))
+		})
+	}
+}
+
+// TestListVirtualMachines_VMSSFields verifies that VirtualMachines returned for
+// uniform scale set VMs are populated with the correct scale set metadata.
+func TestListVirtualMachines_VMSSFields(t *testing.T) {
+	t.Parallel()
+
+	scaleSetVM := armcompute.VirtualMachineScaleSetVM{
+		ID:         to.Ptr(vmssVMResourceID),
+		Name:       to.Ptr("vmss1_0"),
+		Location:   to.Ptr("eastus"),
+		InstanceID: to.Ptr("0"),
+		Properties: &armcompute.VirtualMachineScaleSetVMProperties{
+			VMID: to.Ptr("vmss-vm-uuid-1"),
 		},
 	}
 
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			client := NewVirtualMachinesClientByAPI(mockAPI, nil /* scaleSetAPI */)
+	client := NewVirtualMachinesClientByAPI(VirtualMachinesClientConfig{
+		VirtualMachineAPI: &ARMComputeMock{VirtualMachines: map[string][]*armcompute.VirtualMachine{}},
+		ScaleSetsAPI: &ARMScaleSetsMock{
+			ScaleSetRecords: []*armcompute.VirtualMachineScaleSet{
+				{ID: to.Ptr(vmssResourceID), Name: to.Ptr("vmss1")},
+			},
+		},
+		ScaleSetVMsAPI: &ARMScaleSetVMsMock{GetResult: scaleSetVM},
+	})
 
-			vms, err := client.ListVirtualMachines(context.Background(), tc.resourceGroup)
-			require.NoError(t, err)
-			var vmIDs []string
-			for _, vm := range vms {
-				vmIDs = append(vmIDs, *vm.ID)
+	vms, err := client.ListVirtualMachines(t.Context(), rgName)
+	require.NoError(t, err)
+	require.Len(t, vms, 1)
+
+	vm := vms[0]
+	require.Equal(t, "vmss1", vm.UniformScaleSetName)
+	require.Equal(t, "0", vm.UniformScaleSetVMInstanceID)
+	require.Equal(t, testSubID, vm.Subscription)
+	require.Equal(t, rgName, vm.ResourceGroup)
+	require.Equal(t, "vmss-vm-uuid-1", vm.VMID)
+	require.Equal(t, "eastus", vm.Location)
+}
+
+func TestVmScaleSetIsFlexible(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		desc       string
+		properties *armcompute.VirtualMachineScaleSetProperties
+		want       bool
+	}{
+		{
+			desc:       "nil properties is not flexible (treated as Uniform)",
+			properties: nil,
+			want:       false,
+		},
+		{
+			desc: "flexible orchestration mode",
+			properties: &armcompute.VirtualMachineScaleSetProperties{
+				OrchestrationMode: to.Ptr(armcompute.OrchestrationModeFlexible),
+			},
+			want: true,
+		},
+		{
+			desc: "uniform orchestration mode",
+			properties: &armcompute.VirtualMachineScaleSetProperties{
+				OrchestrationMode: to.Ptr(armcompute.OrchestrationModeUniform),
+			},
+			want: false,
+		},
+		{
+			desc:       "properties without orchestration mode is not flexible",
+			properties: &armcompute.VirtualMachineScaleSetProperties{},
+			want:       false,
+		},
+	} {
+		t.Run(tc.desc, func(t *testing.T) {
+			require.Equal(t, tc.want, vmScaleSetIsFlexible(tc.properties))
+		})
+	}
+}
+
+func TestRunCommandRequestIsUniformVMSS(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		desc string
+		req  RunCommandRequest
+		want bool
+	}{
+		{
+			desc: "regular VM, no scale set fields",
+			req:  RunCommandRequest{VMName: "vm1", ResourceGroup: "rg1"},
+			want: false,
+		},
+		{
+			desc: "both ScaleSetName and InstanceID set",
+			req:  RunCommandRequest{VMName: "vmss1_0", UniformScaleSetName: "vmss1", UniformScaleSetVMInstanceID: "0"},
+			want: true,
+		},
+		{
+			desc: "only ScaleSetName, no InstanceID",
+			req:  RunCommandRequest{VMName: "vmss1_0", UniformScaleSetName: "vmss1"},
+			want: false,
+		},
+		{
+			desc: "only InstanceID, no ScaleSetName",
+			req:  RunCommandRequest{VMName: "vmss1_0", UniformScaleSetVMInstanceID: "0"},
+			want: false,
+		},
+	} {
+		t.Run(tc.desc, func(t *testing.T) {
+			require.Equal(t, tc.want, tc.req.isUniformVMSS())
+		})
+	}
+}
+
+func TestCommandResultFromInstanceView(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		desc         string
+		properties   *armcompute.VirtualMachineRunCommandProperties
+		wantErr      bool
+		wantState    string
+		wantExitCode int32
+		wantStdOut   string
+		wantStdErr   string
+		wantFailure  bool
+	}{
+		{
+			desc:    "nil properties returns error",
+			wantErr: true,
+		},
+		{
+			desc:       "nil InstanceView returns error",
+			properties: &armcompute.VirtualMachineRunCommandProperties{},
+			wantErr:    true,
+		},
+		{
+			desc: "succeeded command with zero exit code",
+			properties: &armcompute.VirtualMachineRunCommandProperties{
+				InstanceView: &armcompute.VirtualMachineRunCommandInstanceView{
+					ExecutionState: to.Ptr(armcompute.ExecutionStateSucceeded),
+					ExitCode:       to.Ptr(int32(0)),
+					Output:         to.Ptr("install ok"),
+					Error:          to.Ptr(""),
+				},
+			},
+			wantState:    string(armcompute.ExecutionStateSucceeded),
+			wantExitCode: 0,
+			wantStdOut:   "install ok",
+			wantStdErr:   "",
+			wantFailure:  false,
+		},
+		{
+			desc: "failed state with non-zero exit code",
+			properties: &armcompute.VirtualMachineRunCommandProperties{
+				InstanceView: &armcompute.VirtualMachineRunCommandInstanceView{
+					ExecutionState: to.Ptr(armcompute.ExecutionStateFailed),
+					ExitCode:       to.Ptr(int32(1)),
+					Output:         to.Ptr(""),
+					Error:          to.Ptr("command not found"),
+				},
+			},
+			wantState:    string(armcompute.ExecutionStateFailed),
+			wantExitCode: 1,
+			wantStdErr:   "command not found",
+			wantFailure:  true,
+		},
+		{
+			desc: "succeeded state with non-zero exit code is still a failure",
+			properties: &armcompute.VirtualMachineRunCommandProperties{
+				InstanceView: &armcompute.VirtualMachineRunCommandInstanceView{
+					ExecutionState: to.Ptr(armcompute.ExecutionStateSucceeded),
+					ExitCode:       to.Ptr(int32(127)),
+					Output:         to.Ptr(""),
+					Error:          to.Ptr("script exited with code 127"),
+				},
+			},
+			wantState:    string(armcompute.ExecutionStateSucceeded),
+			wantExitCode: 127,
+			wantStdErr:   "script exited with code 127",
+			wantFailure:  true,
+		},
+		{
+			desc: "nil pointer fields in InstanceView default to zero values",
+			properties: &armcompute.VirtualMachineRunCommandProperties{
+				InstanceView: &armcompute.VirtualMachineRunCommandInstanceView{},
+			},
+			wantState:    "",
+			wantExitCode: 0,
+			wantFailure:  true,
+		},
+	} {
+		t.Run(tc.desc, func(t *testing.T) {
+			result, err := commandResultFromInstanceView(tc.properties)
+			if tc.wantErr {
+				require.Error(t, err)
+				require.Nil(t, result)
+				return
 			}
-			require.ElementsMatch(t, tc.wantIDs, vmIDs)
+			require.NoError(t, err)
+			require.NotNil(t, result)
+			require.Equal(t, tc.wantState, result.ExecutionState)
+			require.Equal(t, tc.wantExitCode, result.ExitCode)
+			require.Equal(t, tc.wantStdOut, result.StdOut)
+			require.Equal(t, tc.wantStdErr, result.StdErr)
+			require.Equal(t, tc.wantFailure, result.Failure())
+		})
+	}
+}
+
+func TestVirtualMachineFromVirtualMachine(t *testing.T) {
+	const (
+		validResourceID = "/subscriptions/11111111-1111-1111-1111-111111111111/resourceGroups/rg/providers/Microsoft.Compute/virtualMachines/vm-name"
+		subscriptionID  = "11111111-1111-1111-1111-111111111111"
+		resourceGroup   = "rg"
+	)
+
+	for _, tc := range []struct {
+		desc        string
+		vm          *armcompute.VirtualMachine
+		assertError require.ErrorAssertionFunc
+		assertVM    require.ValueAssertionFunc
+	}{
+		{
+			desc: "vm with all fields populated",
+			vm: &armcompute.VirtualMachine{
+				ID:       to.Ptr(validResourceID),
+				Name:     to.Ptr("vm-name"),
+				Location: to.Ptr("eastus"),
+				Properties: &armcompute.VirtualMachineProperties{
+					VMID: to.Ptr("22222222-2222-2222-2222-222222222222"),
+				},
+				Tags: map[string]*string{
+					"env":  to.Ptr("prod"),
+					"team": to.Ptr("infra"),
+				},
+			},
+			assertError: require.NoError,
+			assertVM: func(t require.TestingT, val any, _ ...any) {
+				require.NotNil(t, val)
+				vm, ok := val.(*VirtualMachine)
+				require.Truef(t, ok, "expected *VirtualMachine, got %T", val)
+				require.Equal(t, &VirtualMachine{
+					ID:            validResourceID,
+					VMID:          "22222222-2222-2222-2222-222222222222",
+					Name:          "vm-name",
+					Location:      "eastus",
+					Subscription:  subscriptionID,
+					ResourceGroup: resourceGroup,
+					Tags: map[string]string{
+						"env":  "prod",
+						"team": "infra",
+					},
+				}, vm)
+			},
+		},
+		{
+			desc: "vm with nil Properties does not panic and has empty VMID",
+			vm: &armcompute.VirtualMachine{
+				ID:       to.Ptr(validResourceID),
+				Name:     to.Ptr("vm-name"),
+				Location: to.Ptr("eastus"),
+			},
+			assertError: require.NoError,
+			assertVM: func(t require.TestingT, val any, _ ...any) {
+				require.NotNil(t, val)
+				vm, ok := val.(*VirtualMachine)
+				require.Truef(t, ok, "expected *VirtualMachine, got %T", val)
+				require.Empty(t, vm.VMID)
+				require.Equal(t, validResourceID, vm.ID)
+				require.Equal(t, subscriptionID, vm.Subscription)
+				require.Equal(t, resourceGroup, vm.ResourceGroup)
+			},
+		},
+		{
+			desc: "vm without tags returns empty (not nil) map",
+			vm: &armcompute.VirtualMachine{
+				ID:   to.Ptr(validResourceID),
+				Name: to.Ptr("vm-name"),
+			},
+			assertError: require.NoError,
+			assertVM: func(t require.TestingT, val any, _ ...any) {
+				require.NotNil(t, val)
+				vm, ok := val.(*VirtualMachine)
+				require.Truef(t, ok, "expected *VirtualMachine, got %T", val)
+				require.NotNil(t, vm.Tags)
+				require.Empty(t, vm.Tags)
+			},
+		},
+		{
+			desc: "vm not part of a Scale Set has empty Scale Set fields",
+			vm: &armcompute.VirtualMachine{
+				ID:   to.Ptr(validResourceID),
+				Name: to.Ptr("vm-name"),
+			},
+			assertError: require.NoError,
+			assertVM: func(t require.TestingT, val any, _ ...any) {
+				require.NotNil(t, val)
+				vm, ok := val.(*VirtualMachine)
+				require.Truef(t, ok, "expected *VirtualMachine, got %T", val)
+				require.Empty(t, vm.UniformScaleSetName)
+				require.Empty(t, vm.UniformScaleSetVMInstanceID)
+			},
+		},
+		{
+			desc:        "nil vm returns error",
+			vm:          nil,
+			assertError: require.Error,
+			assertVM:    require.Nil,
+		},
+		{
+			desc: "invalid resource ID returns error",
+			vm: &armcompute.VirtualMachine{
+				ID:   to.Ptr("not-a-valid-arm-id"),
+				Name: to.Ptr("vm-name"),
+			},
+			assertError: require.Error,
+			assertVM:    require.Nil,
+		},
+	} {
+		t.Run(tc.desc, func(t *testing.T) {
+			vm, err := virtualMachineFromARMComputeVirtualMachine(tc.vm)
+			tc.assertError(t, err)
+			tc.assertVM(t, vm)
+		})
+	}
+}
+
+func TestVirtualMachineFromVirtualMachineScaleSetVM(t *testing.T) {
+	const (
+		validResourceID = "/subscriptions/11111111-1111-1111-1111-111111111111/resourceGroups/rg/providers/Microsoft.Compute/virtualMachineScaleSets/vmss/virtualMachines/0"
+		subscriptionID  = "11111111-1111-1111-1111-111111111111"
+		resourceGroup   = "rg"
+		scaleSetName    = "vmss"
+	)
+
+	for _, tc := range []struct {
+		desc           string
+		vm             *armcompute.VirtualMachineScaleSetVM
+		scaleSetName   string
+		resourceGroup  string
+		subscriptionID string
+		assertError    require.ErrorAssertionFunc
+		assertVM       require.ValueAssertionFunc
+	}{
+		{
+			desc: "scale set vm with all fields populated",
+			vm: &armcompute.VirtualMachineScaleSetVM{
+				ID:         to.Ptr(validResourceID),
+				Name:       to.Ptr("vmss_0"),
+				Location:   to.Ptr("eastus"),
+				InstanceID: to.Ptr("0"),
+				Properties: &armcompute.VirtualMachineScaleSetVMProperties{
+					VMID: to.Ptr("22222222-2222-2222-2222-222222222222"),
+				},
+				Tags: map[string]*string{
+					"env":  to.Ptr("prod"),
+					"team": to.Ptr("infra"),
+				},
+			},
+			scaleSetName:   scaleSetName,
+			resourceGroup:  resourceGroup,
+			subscriptionID: subscriptionID,
+			assertError:    require.NoError,
+			assertVM: func(t require.TestingT, val any, _ ...any) {
+				require.NotNil(t, val)
+				vm, ok := val.(*VirtualMachine)
+				require.Truef(t, ok, "expected *VirtualMachine, got %T", val)
+				require.Equal(t, &VirtualMachine{
+					ID:                          validResourceID,
+					VMID:                        "22222222-2222-2222-2222-222222222222",
+					Name:                        "vmss_0",
+					Location:                    "eastus",
+					Subscription:                subscriptionID,
+					ResourceGroup:               resourceGroup,
+					UniformScaleSetName:         scaleSetName,
+					UniformScaleSetVMInstanceID: "0",
+					Tags: map[string]string{
+						"env":  "prod",
+						"team": "infra",
+					},
+				}, vm)
+			},
+		},
+		{
+			desc: "scale set vm with nil Properties does not panic and has empty VMID",
+			vm: &armcompute.VirtualMachineScaleSetVM{
+				ID:         to.Ptr(validResourceID),
+				Name:       to.Ptr("vmss_0"),
+				Location:   to.Ptr("eastus"),
+				InstanceID: to.Ptr("0"),
+			},
+			scaleSetName:   scaleSetName,
+			resourceGroup:  resourceGroup,
+			subscriptionID: subscriptionID,
+			assertError:    require.NoError,
+			assertVM: func(t require.TestingT, val any, _ ...any) {
+				require.NotNil(t, val)
+				vm, ok := val.(*VirtualMachine)
+				require.Truef(t, ok, "expected *VirtualMachine, got %T", val)
+				require.Empty(t, vm.VMID)
+				require.Equal(t, validResourceID, vm.ID)
+				require.Equal(t, scaleSetName, vm.UniformScaleSetName)
+				require.Equal(t, "0", vm.UniformScaleSetVMInstanceID)
+			},
+		},
+		{
+			desc: "scale set vm without tags returns empty (not nil) map",
+			vm: &armcompute.VirtualMachineScaleSetVM{
+				ID:         to.Ptr(validResourceID),
+				Name:       to.Ptr("vmss_0"),
+				InstanceID: to.Ptr("0"),
+			},
+			scaleSetName:   scaleSetName,
+			resourceGroup:  resourceGroup,
+			subscriptionID: subscriptionID,
+			assertError:    require.NoError,
+			assertVM: func(t require.TestingT, val any, _ ...any) {
+				require.NotNil(t, val)
+				vm, ok := val.(*VirtualMachine)
+				require.Truef(t, ok, "expected *VirtualMachine, got %T", val)
+				require.NotNil(t, vm.Tags)
+				require.Empty(t, vm.Tags)
+			},
+		},
+		{
+			desc: "uses caller-provided subscription, resource group, and scale set name without parsing ID",
+			vm: &armcompute.VirtualMachineScaleSetVM{
+				ID:         to.Ptr("not-a-valid-arm-id"),
+				Name:       to.Ptr("vmss_0"),
+				InstanceID: to.Ptr("0"),
+			},
+			scaleSetName:   scaleSetName,
+			resourceGroup:  resourceGroup,
+			subscriptionID: subscriptionID,
+			assertError:    require.NoError,
+			assertVM: func(t require.TestingT, val any, _ ...any) {
+				require.NotNil(t, val)
+				vm, ok := val.(*VirtualMachine)
+				require.Truef(t, ok, "expected *VirtualMachine, got %T", val)
+				require.Equal(t, subscriptionID, vm.Subscription)
+				require.Equal(t, resourceGroup, vm.ResourceGroup)
+				require.Equal(t, scaleSetName, vm.UniformScaleSetName)
+			},
+		},
+		{
+			desc:           "nil vm returns error",
+			vm:             nil,
+			scaleSetName:   scaleSetName,
+			resourceGroup:  resourceGroup,
+			subscriptionID: subscriptionID,
+			assertError:    require.Error,
+			assertVM:       require.Nil,
+		},
+	} {
+		t.Run(tc.desc, func(t *testing.T) {
+			vm, err := virtualMachineFromARMComputeVirtualMachineScaleSetVM(tc.vm, tc.subscriptionID, tc.resourceGroup, tc.scaleSetName)
+			tc.assertError(t, err)
+			tc.assertVM(t, vm)
 		})
 	}
 }

--- a/lib/srv/db/common/auth_test.go
+++ b/lib/srv/db/common/auth_test.go
@@ -302,9 +302,11 @@ func TestGetAzureIdentityResourceID(t *testing.T) {
 				instanceType: types.InstanceMetadataTypeAzure,
 			},
 			cloud: &azuretest.Clients{
-				AzureVirtualMachines: azure.NewVirtualMachinesClientByAPI(&azure.ARMComputeMock{
-					GetResult: mocks.AzureVM([]string{identityResourceID(t, "identity")}),
-				}, nil /* scaleSetAPI */),
+				AzureVirtualMachines: azure.NewVirtualMachinesClientByAPI(azure.VirtualMachinesClientConfig{
+					VirtualMachineAPI: &azure.ARMComputeMock{
+						GetResult: mocks.AzureVM([]string{identityResourceID(t, "identity")}),
+					},
+				}),
 			},
 			errAssertion: require.NoError,
 			resourceIDAssertion: func(requireT require.TestingT, value interface{}, _ ...interface{}) {
@@ -319,9 +321,11 @@ func TestGetAzureIdentityResourceID(t *testing.T) {
 				instanceType: types.InstanceMetadataTypeAzure,
 			},
 			cloud: &azuretest.Clients{
-				AzureVirtualMachines: azure.NewVirtualMachinesClientByAPI(&azure.ARMComputeMock{
-					GetResult: mocks.AzureVM([]string{identityResourceID(t, "identity")}),
-				}, nil /* scaleSetAPI */),
+				AzureVirtualMachines: azure.NewVirtualMachinesClientByAPI(azure.VirtualMachinesClientConfig{
+					VirtualMachineAPI: &azure.ARMComputeMock{
+						GetResult: mocks.AzureVM([]string{identityResourceID(t, "identity")}),
+					},
+				}),
 			},
 			errAssertion:        require.Error,
 			resourceIDAssertion: require.Empty,
@@ -334,9 +338,11 @@ func TestGetAzureIdentityResourceID(t *testing.T) {
 				instanceType: types.InstanceMetadataTypeAzure,
 			},
 			cloud: &azuretest.Clients{
-				AzureVirtualMachines: azure.NewVirtualMachinesClientByAPI(&azure.ARMComputeMock{
-					GetResult: mocks.AzureVM([]string{"identity"}),
-				}, nil /* scaleSetAPI */),
+				AzureVirtualMachines: azure.NewVirtualMachinesClientByAPI(azure.VirtualMachinesClientConfig{
+					VirtualMachineAPI: &azure.ARMComputeMock{
+						GetResult: mocks.AzureVM([]string{"identity"}),
+					},
+				}),
 			},
 			errAssertion:        require.Error,
 			resourceIDAssertion: require.Empty,
@@ -359,9 +365,11 @@ func TestGetAzureIdentityResourceID(t *testing.T) {
 				instanceType: types.InstanceMetadataTypeAzure,
 			},
 			cloud: &azuretest.Clients{
-				AzureVirtualMachines: azure.NewVirtualMachinesClientByAPI(&azure.ARMComputeMock{
-					GetErr: errors.New("failed to get VM"),
-				}, nil /* scaleSetAPI */),
+				AzureVirtualMachines: azure.NewVirtualMachinesClientByAPI(azure.VirtualMachinesClientConfig{
+					VirtualMachineAPI: &azure.ARMComputeMock{
+						GetErr: errors.New("failed to get VM"),
+					},
+				}),
 			},
 			errAssertion:        require.Error,
 			resourceIDAssertion: require.Empty,
@@ -374,12 +382,11 @@ func TestGetAzureIdentityResourceID(t *testing.T) {
 				instanceType: types.InstanceMetadataTypeAzure,
 			},
 			cloud: &azuretest.Clients{
-				AzureVirtualMachines: azure.NewVirtualMachinesClientByAPI(
-					nil, /* api */
-					&azure.ARMScaleSetMock{
+				AzureVirtualMachines: azure.NewVirtualMachinesClientByAPI(azure.VirtualMachinesClientConfig{
+					ScaleSetVMsAPI: &azure.ARMScaleSetVMsMock{
 						GetResult: mocks.AzureScaleSetVM([]string{identityResourceID(t, "identity")}),
 					},
-				),
+				}),
 			},
 			errAssertion: require.NoError,
 			resourceIDAssertion: func(requireT require.TestingT, value interface{}, _ ...interface{}) {
@@ -394,12 +401,11 @@ func TestGetAzureIdentityResourceID(t *testing.T) {
 				instanceType: types.InstanceMetadataTypeAzure,
 			},
 			cloud: &azuretest.Clients{
-				AzureVirtualMachines: azure.NewVirtualMachinesClientByAPI(
-					nil, /* api */
-					&azure.ARMScaleSetMock{
+				AzureVirtualMachines: azure.NewVirtualMachinesClientByAPI(azure.VirtualMachinesClientConfig{
+					ScaleSetVMsAPI: &azure.ARMScaleSetVMsMock{
 						GetResult: mocks.AzureScaleSetVM([]string{identityResourceID(t, "identity")}),
 					},
-				),
+				}),
 			},
 			errAssertion:        require.Error,
 			resourceIDAssertion: require.Empty,
@@ -412,12 +418,11 @@ func TestGetAzureIdentityResourceID(t *testing.T) {
 				instanceType: types.InstanceMetadataTypeAzure,
 			},
 			cloud: &azuretest.Clients{
-				AzureVirtualMachines: azure.NewVirtualMachinesClientByAPI(
-					nil, /* api */
-					&azure.ARMScaleSetMock{
+				AzureVirtualMachines: azure.NewVirtualMachinesClientByAPI(azure.VirtualMachinesClientConfig{
+					ScaleSetVMsAPI: &azure.ARMScaleSetVMsMock{
 						GetResult: mocks.AzureScaleSetVM([]string{"identity"}),
 					},
-				),
+				}),
 			},
 			errAssertion:        require.Error,
 			resourceIDAssertion: require.Empty,
@@ -430,12 +435,11 @@ func TestGetAzureIdentityResourceID(t *testing.T) {
 				instanceType: types.InstanceMetadataTypeAzure,
 			},
 			cloud: &azuretest.Clients{
-				AzureVirtualMachines: azure.NewVirtualMachinesClientByAPI(
-					nil, /* api */
-					&azure.ARMScaleSetMock{
+				AzureVirtualMachines: azure.NewVirtualMachinesClientByAPI(azure.VirtualMachinesClientConfig{
+					ScaleSetVMsAPI: &azure.ARMScaleSetVMsMock{
 						GetErr: trace.NotFound("vm not found"),
 					},
-				),
+				}),
 			},
 			errAssertion:        require.Error,
 			resourceIDAssertion: require.Empty,
@@ -474,7 +478,9 @@ func TestGetAzureIdentityResourceIDCache(t *testing.T) {
 		AuthClient:  new(authClientMock),
 		AccessPoint: new(accessPointMock),
 		AzureClients: &azuretest.Clients{
-			AzureVirtualMachines: azure.NewVirtualMachinesClientByAPI(virtualMachinesMock, nil /* scaleSetAPI */),
+			AzureVirtualMachines: azure.NewVirtualMachinesClientByAPI(azure.VirtualMachinesClientConfig{
+				VirtualMachineAPI: virtualMachinesMock,
+			}),
 		},
 		azureIMDSClient: &imdsMock{
 			id:           "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rg/providers/microsoft.compute/virtualmachines/vm",

--- a/lib/srv/discovery/discovery.go
+++ b/lib/srv/discovery/discovery.go
@@ -30,7 +30,6 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v6"
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/account"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
@@ -1120,9 +1119,12 @@ func genEC2InstancesLogStr(instances []server.EC2Instance) string {
 	})
 }
 
-func genAzureInstancesLogStr(instances []*armcompute.VirtualMachine) string {
-	return genInstancesLogStr(instances, func(i *armcompute.VirtualMachine) string {
-		return aws.ToString(i.Name)
+func genAzureInstancesLogStr(instances []*azure.VirtualMachine) string {
+	return genInstancesLogStr(instances, func(i *azure.VirtualMachine) string {
+		if i.UniformScaleSetName != "" {
+			return "vmss:" + i.UniformScaleSetName + "/" + i.Name
+		}
+		return i.Name
 	})
 }
 
@@ -1487,15 +1489,10 @@ func (e *limitedErrorReporter) report(ctx context.Context, result server.AzureIn
 	instance := result.Instance
 	commandResult := result.CommandResult
 
-	var vmID string
-	if instance.Properties != nil {
-		vmID = azure.StringVal(instance.Properties.VMID)
-	}
-
 	if commandResult != nil {
 		e.logger.WarnContext(ctx, "Teleport installation script failed",
-			"vm_id", vmID,
-			"resource_id", azure.StringVal(instance.ID),
+			"vm_id", instance.VMID,
+			"resource_id", instance.ID,
 			"state", commandResult.ExecutionState,
 			"exit_code", commandResult.ExitCode,
 			"stdout", commandResult.StdOut,
@@ -1503,8 +1500,8 @@ func (e *limitedErrorReporter) report(ctx context.Context, result server.AzureIn
 		)
 	} else {
 		e.logger.WarnContext(ctx, "Failed to execute Teleport installation script",
-			"vm_id", vmID,
-			"resource_id", azure.StringVal(instance.ID),
+			"vm_id", instance.VMID,
+			"resource_id", instance.ID,
 			"api_error", result.APIError,
 		)
 	}
@@ -1702,7 +1699,7 @@ func (s *Server) installAzureServers(instances *server.AzureInstances, vmTasks *
 		return
 	}
 
-	addFailedEnrollment := func(vm *armcompute.VirtualMachine, issueType string) {
+	addFailedEnrollment := func(vm *azure.VirtualMachine, issueType string) {
 		// Static matchers don't have a discovery config resource, so skip creating user tasks
 		// because validation requires a discovery config name.
 		if instances.DiscoveryConfigName == noDiscoveryConfig {
@@ -1721,9 +1718,9 @@ func (s *Server) installAzureServers(instances *server.AzureInstances, vmTasks *
 				region:         instances.Region,
 			},
 			&usertasksv1.DiscoverAzureVMInstance{
-				VmId:            azure.StringVal(vm.Properties.VMID),
-				ResourceId:      azure.StringVal(vm.ID),
-				Name:            azure.StringVal(vm.Name),
+				VmId:            vm.VMID,
+				ResourceId:      vm.ID,
+				Name:            vm.Name,
 				DiscoveryConfig: instances.DiscoveryConfigName,
 				DiscoveryGroup:  s.DiscoveryGroup,
 				SyncTime:        timestamppb.New(s.clock.Now()),

--- a/lib/srv/discovery/discovery_test.go
+++ b/lib/srv/discovery/discovery_test.go
@@ -3204,8 +3204,29 @@ func (m *mockAzureClient) GetByVMID(_ context.Context, _ string) (*azure.Virtual
 	return nil, nil
 }
 
-func (m *mockAzureClient) ListVirtualMachines(_ context.Context, _ string) ([]*armcompute.VirtualMachine, error) {
-	return m.vms, nil
+func (m *mockAzureClient) ListVirtualMachines(_ context.Context, _ string) ([]*azure.VirtualMachine, error) {
+	discoveredVMs := make([]*azure.VirtualMachine, 0, len(m.vms))
+	for _, vm := range m.vms {
+		var vmID string
+		if vm.Properties != nil {
+			vmID = azure.StringVal(vm.Properties.VMID)
+		}
+		resourceMetadata, err := arm.ParseResourceID(azure.StringVal(vm.ID))
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+
+		discoveredVMs = append(discoveredVMs, &azure.VirtualMachine{
+			ID:            azure.StringVal(vm.ID),
+			Name:          azure.StringVal(vm.Name),
+			VMID:          vmID,
+			Location:      azure.StringVal(vm.Location),
+			Tags:          azure.ConvertTags(vm.Tags),
+			ResourceGroup: resourceMetadata.ResourceGroupName,
+		})
+	}
+
+	return discoveredVMs, nil
 }
 
 func TestAzureVMDiscovery(t *testing.T) {
@@ -3267,12 +3288,9 @@ func TestAzureVMDiscovery(t *testing.T) {
 		if integration {
 			label = integrationLabel
 		}
+		resourceID := "/subscriptions/testsub/resourceGroups/testrg/providers/Microsoft.Compute/virtualMachines/" + name
 		return &armcompute.VirtualMachine{
-			ID: aws.String((&arm.ResourceID{
-				SubscriptionID:    "testsub",
-				ResourceGroupName: "rg",
-				Name:              name,
-			}).String()),
+			ID:       aws.String(resourceID),
 			Name:     aws.String(name),
 			Location: aws.String("westcentralus"),
 			Tags: map[string]*string{
@@ -3333,12 +3351,12 @@ func TestAzureVMDiscovery(t *testing.T) {
 		userTasksCheck           func(*testing.T, UserTaskLister)
 	}{
 		{
-			name:           "no nodes present, 1 found",
+			name:           "no nodes present, 2 found",
 			presentVMs:     []types.Server{},
 			staticMatchers: vmMatcherFn(),
 			foundVMS:       foundAzureVMs(),
 			wantInstances:  []string{testVMName, testVMNameIntegration},
-			wantResources:  1,
+			wantResources:  2,
 		},
 		{
 			name:           "nodes present, instance filtered",
@@ -3354,7 +3372,7 @@ func TestAzureVMDiscovery(t *testing.T) {
 			staticMatchers: vmMatcherFn(),
 			foundVMS:       foundAzureVMs(),
 			wantInstances:  []string{testVMName, testVMNameIntegration},
-			wantResources:  1,
+			wantResources:  2,
 		},
 		{
 			name:            "no nodes present, 1 found using dynamic matchers",
@@ -3363,7 +3381,7 @@ func TestAzureVMDiscovery(t *testing.T) {
 			staticMatchers:  Matchers{},
 			foundVMS:        foundAzureVMs(),
 			wantInstances:   []string{testVMName, testVMNameIntegration},
-			wantResources:   1,
+			wantResources:   2,
 		},
 		{
 			name:            "multiple failures",
@@ -3409,6 +3427,7 @@ func TestAzureVMDiscovery(t *testing.T) {
 						DiscoverAzureVm: &usertasksv1.DiscoverAzureVM{
 							Instances: map[string]*usertasksv1.DiscoverAzureVMInstance{
 								"bad-api0-vmid": {
+									ResourceId:      "/subscriptions/testsub/resourceGroups/testrg/providers/Microsoft.Compute/virtualMachines/bad-api0",
 									VmId:            "bad-api0-vmid",
 									Name:            "bad-api0",
 									DiscoveryConfig: defaultDiscoveryConfig().GetName(),

--- a/lib/srv/discovery/fetchers/azuresync/azure-sync_test.go
+++ b/lib/srv/discovery/fetchers/azuresync/azure-sync_test.go
@@ -24,12 +24,12 @@ import (
 	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/authorization/armauthorization/v2"
-	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v6"
 	"github.com/gravitational/trace"
 	"github.com/stretchr/testify/require"
 
 	"github.com/gravitational/teleport/api/defaults"
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/cloud/azure"
 )
 
 type testRoleDefCli struct {
@@ -58,10 +58,10 @@ func (t testRoleAssignCli) ListRoleAssignments(ctx context.Context, scope string
 
 type testVmCli struct {
 	returnErr bool
-	vms       []*armcompute.VirtualMachine
+	vms       []*azure.VirtualMachine
 }
 
-func (t testVmCli) ListVirtualMachines(ctx context.Context, resourceGroup string) ([]*armcompute.VirtualMachine, error) {
+func (t testVmCli) ListVirtualMachines(ctx context.Context, resourceGroup string) ([]*azure.VirtualMachine, error) {
 	if t.returnErr {
 		return nil, fmt.Errorf("error")
 	}
@@ -105,10 +105,10 @@ func newRoleAssign(id string, name string) *armauthorization.RoleAssignment {
 	}
 }
 
-func newVm(id string, name string) *armcompute.VirtualMachine {
-	return &armcompute.VirtualMachine{
-		ID:   &id,
-		Name: &name,
+func newVm(id string, name string) *azure.VirtualMachine {
+	return &azure.VirtualMachine{
+		ID:   id,
+		Name: name,
 	}
 }
 
@@ -221,7 +221,7 @@ func TestPoll(t *testing.T) {
 	roleAssigns := []*armauthorization.RoleAssignment{
 		newRoleAssign("id1", "name1"),
 	}
-	vms := []*armcompute.VirtualMachine{
+	vms := []*azure.VirtualMachine{
 		newVm("id1", "name2"),
 	}
 	roleDefClient := testRoleDefCli{}
@@ -248,7 +248,7 @@ func TestPoll(t *testing.T) {
 		returnErr   bool
 		roleDefs    []*armauthorization.RoleDefinition
 		roleAssigns []*armauthorization.RoleAssignment
-		vms         []*armcompute.VirtualMachine
+		vms         []*azure.VirtualMachine
 		feats       Features
 	}{
 		// Process no results from clients
@@ -257,7 +257,7 @@ func TestPoll(t *testing.T) {
 			returnErr:   false,
 			roleDefs:    []*armauthorization.RoleDefinition{},
 			roleAssigns: []*armauthorization.RoleAssignment{},
-			vms:         []*armcompute.VirtualMachine{},
+			vms:         []*azure.VirtualMachine{},
 			feats:       allFeats,
 		},
 		// Process test results from clients
@@ -331,9 +331,9 @@ func TestPoll(t *testing.T) {
 			require.Equal(t, tt.feats.VirtualMachines == false || len(tt.vms) == 0, len(resources.VirtualMachines) == 0)
 			for idx, resource := range resources.VirtualMachines {
 				vm := tt.vms[idx]
-				require.Equal(t, *vm.ID, resource.Id)
+				require.Equal(t, vm.ID, resource.Id)
 				require.Equal(t, fetcher.SubscriptionID, resource.SubscriptionId)
-				require.Equal(t, *vm.Name, resource.Name)
+				require.Equal(t, vm.Name, resource.Name)
 			}
 		})
 	}

--- a/lib/srv/discovery/fetchers/azuresync/virtualmachines.go
+++ b/lib/srv/discovery/fetchers/azuresync/virtualmachines.go
@@ -21,17 +21,17 @@ package azuresync
 import (
 	"context"
 
-	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v6"
 	"github.com/gravitational/trace"
 
 	accessgraphv1alpha "github.com/gravitational/teleport/gen/proto/go/accessgraph/v1alpha"
+	"github.com/gravitational/teleport/lib/cloud/azure"
 )
 
 const allResourceGroups = "*" //nolint:unused // invoked in a dependent PR
 
 // VirtualMachinesClient specifies the methods used to fetch virtual machines from Azure
 type VirtualMachinesClient interface {
-	ListVirtualMachines(ctx context.Context, resourceGroup string) ([]*armcompute.VirtualMachine, error)
+	ListVirtualMachines(ctx context.Context, resourceGroup string) ([]*azure.VirtualMachine, error)
 }
 
 func fetchVirtualMachines(ctx context.Context, subscriptionID string, cli VirtualMachinesClient) ([]*accessgraphv1alpha.AzureVirtualMachine, error) { //nolint:unused // invoked in a dependent PR
@@ -44,14 +44,14 @@ func fetchVirtualMachines(ctx context.Context, subscriptionID string, cli Virtua
 	pbVms := make([]*accessgraphv1alpha.AzureVirtualMachine, 0, len(vms))
 	var fetchErrs []error
 	for _, vm := range vms {
-		if vm.ID == nil || vm.Name == nil {
-			fetchErrs = append(fetchErrs, trace.BadParameter("nil values on AzureVirtualMachine object: %v", vm))
+		if vm.ID == "" || vm.Name == "" {
+			fetchErrs = append(fetchErrs, trace.BadParameter("empty values on AzureVirtualMachine object: %v", vm))
 			continue
 		}
 		pbVm := accessgraphv1alpha.AzureVirtualMachine{
-			Id:             *vm.ID,
+			Id:             vm.ID,
 			SubscriptionId: subscriptionID,
-			Name:           *vm.Name,
+			Name:           vm.Name,
 		}
 		pbVms = append(pbVms, &pbVm)
 	}

--- a/lib/srv/server/azure_installer.go
+++ b/lib/srv/server/azure_installer.go
@@ -21,7 +21,6 @@ package server
 import (
 	"context"
 
-	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v6"
 	"github.com/gravitational/trace"
 	"golang.org/x/sync/errgroup"
 
@@ -32,7 +31,7 @@ import (
 // AzureInstallRequest combines parameters for running commands on a set of Azure
 // virtual machines.
 type AzureInstallRequest struct {
-	Instances            []*armcompute.VirtualMachine
+	Instances            []*azure.VirtualMachine
 	InstallerParams      *types.InstallerParams
 	ProxyAddrGetter      func(context.Context) (string, error)
 	Region               string
@@ -42,8 +41,8 @@ type AzureInstallRequest struct {
 
 // AzureInstallResult stores installation results for particular VM instance.
 type AzureInstallResult struct {
-	// Instance is VM instance.
-	Instance *armcompute.VirtualMachine
+	// Instance is the Azure Virtual Machine the installation was attempted on.
+	Instance *azure.VirtualMachine
 	// APIError is potential API error encountered.
 	APIError error
 	// CommandResult is the result of run command: execution status, exit code, stdout, stderr.
@@ -84,10 +83,12 @@ func (req *AzureInstallRequest) Run(ctx context.Context, client azure.RunCommand
 			}
 
 			runRequest := azure.RunCommandRequest{
-				Region:        req.Region,
-				ResourceGroup: req.ResourceGroup,
-				VMName:        azure.StringVal(inst.Name),
-				Script:        script,
+				Region:                      req.Region,
+				ResourceGroup:               req.ResourceGroup,
+				VMName:                      inst.Name,
+				Script:                      script,
+				UniformScaleSetName:         inst.UniformScaleSetName,
+				UniformScaleSetVMInstanceID: inst.UniformScaleSetVMInstanceID,
 			}
 
 			commandResult, apiError := client.Run(ctx, runRequest)

--- a/lib/srv/server/azure_installer_test.go
+++ b/lib/srv/server/azure_installer_test.go
@@ -49,15 +49,15 @@ func (m *mockRunCommandClient) Run(ctx context.Context, req azure.RunCommandRequ
 }
 
 func TestAzureInstallRequestRun(t *testing.T) {
-	makeVM := func(name string) *armcompute.VirtualMachine {
-		return &armcompute.VirtualMachine{
-			ID:   &name,
-			Name: &name,
+	makeVM := func(name string) *azure.VirtualMachine {
+		return &azure.VirtualMachine{
+			ID:   name,
+			Name: name,
 		}
 	}
 
-	makeVMs := func(names ...string) []*armcompute.VirtualMachine {
-		var vms []*armcompute.VirtualMachine
+	makeVMs := func(names ...string) []*azure.VirtualMachine {
+		var vms []*azure.VirtualMachine
 		for _, name := range names {
 			vms = append(vms, makeVM(name))
 		}
@@ -70,7 +70,7 @@ func TestAzureInstallRequestRun(t *testing.T) {
 
 	tests := []struct {
 		name            string
-		instances       []*armcompute.VirtualMachine
+		instances       []*azure.VirtualMachine
 		proxyAddrGetter func(context.Context) (string, error)
 
 		wantErr string
@@ -127,9 +127,9 @@ func TestAzureInstallRequestRun(t *testing.T) {
 					mu.Lock()
 					defer mu.Unlock()
 					if result.Failure() {
-						failed = append(failed, *result.Instance.ID)
+						failed = append(failed, result.Instance.ID)
 					} else {
-						good = append(good, *result.Instance.ID)
+						good = append(good, result.Instance.ID)
 					}
 				},
 			}

--- a/lib/srv/server/azure_watcher.go
+++ b/lib/srv/server/azure_watcher.go
@@ -23,8 +23,6 @@ import (
 	"log/slog"
 	"slices"
 
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
-	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v6"
 	"github.com/gravitational/trace"
 
 	usageeventsv1 "github.com/gravitational/teleport/api/gen/proto/go/usageevents/v1"
@@ -57,7 +55,7 @@ type AzureInstances struct {
 	// InstallerParams are the installer parameters used for installation.
 	InstallerParams *types.InstallerParams
 	// Instances is a list of discovered Azure virtual machines.
-	Instances []*armcompute.VirtualMachine
+	Instances []*azure.VirtualMachine
 }
 
 func (instances *AzureInstances) LogValue() slog.Value {
@@ -82,8 +80,8 @@ func (instances *AzureInstances) resourceType() string {
 }
 
 // MakeUsageEvent builds usage event for a single installation result.
-func (instances *AzureInstances) MakeUsageEvent(instance *armcompute.VirtualMachine) (string, *usageeventsv1.ResourceCreateEvent) {
-	return azureEventPrefix + azure.StringVal(instance.ID), &usageeventsv1.ResourceCreateEvent{
+func (instances *AzureInstances) MakeUsageEvent(instance *azure.VirtualMachine) (string, *usageeventsv1.ResourceCreateEvent) {
+	return azureEventPrefix + instance.ID, &usageeventsv1.ResourceCreateEvent{
 		ResourceType:        instances.resourceType(),
 		ResourceOrigin:      types.OriginCloud,
 		CloudProvider:       types.CloudAzure,
@@ -101,11 +99,9 @@ func (instances *AzureInstances) MakeRunEvent(result AzureInstallResult) *apieve
 
 	var vmID, vmName, resourceID string
 	if result.Instance != nil {
-		vmName = azure.StringVal(result.Instance.Name)
-		resourceID = azure.StringVal(result.Instance.ID)
-		if result.Instance.Properties != nil {
-			vmID = azure.StringVal(result.Instance.Properties.VMID)
-		}
+		vmName = result.Instance.Name
+		resourceID = result.Instance.ID
+		vmID = result.Instance.VMID
 	}
 
 	evt := &apievents.AzureRun{
@@ -162,12 +158,8 @@ func (instances *AzureInstances) FilterExistingNodes(existingNodes []types.Serve
 		}
 	}
 
-	instances.Instances = slices.DeleteFunc(instances.Instances, func(instance *armcompute.VirtualMachine) bool {
-		var vmID string
-		if instance.Properties != nil && instance.Properties.VMID != nil {
-			vmID = *instance.Properties.VMID
-		}
-		_, found := vmIDs[vmID]
+	instances.Instances = slices.DeleteFunc(instances.Instances, func(instance *azure.VirtualMachine) bool {
+		_, found := vmIDs[instance.VMID]
 		return found
 	})
 }
@@ -305,54 +297,28 @@ func (f *azureInstanceFetcher) GetInstances(ctx context.Context, _ bool) ([]*Azu
 		return nil, trace.Wrap(err)
 	}
 
-	instancesByRegionAndResourceGroup := make(map[resourceGroupLocation][]*armcompute.VirtualMachine)
+	instanceGroups := make(map[resourceGroupLocation][]*azure.VirtualMachine)
 
 	allowAllLocations := slices.Contains(f.Regions, types.Wildcard)
-	allowAllResourceGroups := f.ResourceGroup == types.Wildcard
 
 	for _, vm := range vms {
-		location := azure.StringVal(vm.Location)
-		if !slices.Contains(f.Regions, location) && !allowAllLocations {
+		if !slices.Contains(f.Regions, vm.Location) && !allowAllLocations {
 			continue
 		}
-
-		vmTags := make(map[string]string, len(vm.Tags))
-		for key, value := range vm.Tags {
-			vmTags[key] = azure.StringVal(value)
-		}
-		if match, _, _ := services.MatchLabels(f.Labels, vmTags); !match {
+		if match, _, _ := services.MatchLabels(f.Labels, vm.Tags); !match {
 			continue
-		}
-
-		resourceGroup := f.ResourceGroup
-		if allowAllResourceGroups {
-			resourceMetadata, err := arm.ParseResourceID(azure.StringVal(vm.ID))
-			if err != nil {
-				f.Logger.WarnContext(ctx, "Skipping Teleport installation on Azure VM - failed to infer resource group from vm id",
-					"subscription_id", f.Subscription,
-					"vm_id", azure.StringVal(vm.Properties.VMID),
-					"resource_id", azure.StringVal(vm.ID),
-					"error", err,
-				)
-				continue
-			}
-			resourceGroup = resourceMetadata.ResourceGroupName
 		}
 
 		batchGroup := resourceGroupLocation{
-			resourceGroup: resourceGroup,
-			location:      location,
+			resourceGroup: vm.ResourceGroup,
+			location:      vm.Location,
 		}
 
-		if _, ok := instancesByRegionAndResourceGroup[batchGroup]; !ok {
-			instancesByRegionAndResourceGroup[batchGroup] = make([]*armcompute.VirtualMachine, 0)
-		}
-
-		instancesByRegionAndResourceGroup[batchGroup] = append(instancesByRegionAndResourceGroup[batchGroup], vm)
+		instanceGroups[batchGroup] = append(instanceGroups[batchGroup], vm)
 	}
 
 	var instances []*AzureInstances
-	for batchGroup, vms := range instancesByRegionAndResourceGroup {
+	for batchGroup, vms := range instanceGroups {
 		instances = append(instances, &AzureInstances{
 			SubscriptionID:      f.Subscription,
 			Region:              batchGroup.location,

--- a/lib/srv/server/azure_watcher_test.go
+++ b/lib/srv/server/azure_watcher_test.go
@@ -62,82 +62,91 @@ func TestAzureWatcher(t *testing.T) {
 	)
 	clients := mockClients{
 		vmClients: map[string]azure.VirtualMachinesClient{
-			sub1: azure.NewVirtualMachinesClientByAPI(&azure.ARMComputeMock{
-				VirtualMachines: map[string][]*armcompute.VirtualMachine{
-					"rg1": {
-						{
-							ID:       to.Ptr(makeAzureVMID(sub1, "rg1", "vm1")),
-							Location: to.Ptr("location1"),
-						},
-						{
-							ID:       to.Ptr(makeAzureVMID(sub1, "rg1", "vm2")),
-							Location: to.Ptr("location1"),
-							Tags: map[string]*string{
-								"teleport": to.Ptr("yes"),
+			sub1: azure.NewVirtualMachinesClientByAPI(azure.VirtualMachinesClientConfig{
+				VirtualMachineAPI: &azure.ARMComputeMock{
+					VirtualMachines: map[string][]*armcompute.VirtualMachine{
+						"rg1": {
+							{
+								ID:       to.Ptr(makeAzureVMID(sub1, "rg1", "vm1")),
+								Location: to.Ptr("location1"),
+							},
+							{
+								ID:       to.Ptr(makeAzureVMID(sub1, "rg1", "vm2")),
+								Location: to.Ptr("location1"),
+								Tags: map[string]*string{
+									"teleport": to.Ptr("yes"),
+								},
+							},
+							{
+								ID:       to.Ptr(makeAzureVMID(sub1, "rg1", "vm5")),
+								Location: to.Ptr("location2"),
 							},
 						},
-						{
-							ID:       to.Ptr(makeAzureVMID(sub1, "rg1", "vm5")),
-							Location: to.Ptr("location2"),
-						},
-					},
-					"rg2": {
-						{
-							ID:       to.Ptr(makeAzureVMID(sub1, "rg2", "vm3")),
-							Location: to.Ptr("location1"),
-						},
-						{
-							ID:       to.Ptr(makeAzureVMID(sub1, "rg2", "vm4")),
-							Location: to.Ptr("location1"),
-							Tags: map[string]*string{
-								"teleport": to.Ptr("yes"),
+						"rg2": {
+							{
+								ID:       to.Ptr(makeAzureVMID(sub1, "rg2", "vm3")),
+								Location: to.Ptr("location1"),
 							},
-						},
-						{
-							ID:       to.Ptr(makeAzureVMID(sub1, "rg2", "vm6")),
-							Location: to.Ptr("location2"),
-						},
-					},
-				},
-			}, nil /* scaleSetAPI */),
-			sub2: azure.NewVirtualMachinesClientByAPI(&azure.ARMComputeMock{
-				VirtualMachines: map[string][]*armcompute.VirtualMachine{
-					"rg3": {
-						{
-							ID:       to.Ptr(makeAzureVMID(sub2, "rg3", "vm7")),
-							Location: to.Ptr("location1"),
-						},
-						{
-							ID:       to.Ptr(makeAzureVMID(sub2, "rg3", "vm8")),
-							Location: to.Ptr("location1"),
-							Tags: map[string]*string{
-								"teleport": to.Ptr("yes"),
+							{
+								ID:       to.Ptr(makeAzureVMID(sub1, "rg2", "vm4")),
+								Location: to.Ptr("location1"),
+								Tags: map[string]*string{
+									"teleport": to.Ptr("yes"),
+								},
 							},
-						},
-						{
-							ID:       to.Ptr(makeAzureVMID(sub2, "rg3", "vm9")),
-							Location: to.Ptr("location2"),
-						},
-					},
-					"rg4": {
-						{
-							ID:       to.Ptr(makeAzureVMID(sub2, "rg4", "vm10")),
-							Location: to.Ptr("location1"),
-						},
-						{
-							ID:       to.Ptr(makeAzureVMID(sub2, "rg4", "vm11")),
-							Location: to.Ptr("location1"),
-							Tags: map[string]*string{
-								"teleport": to.Ptr("yes"),
+							{
+								ID:       to.Ptr(makeAzureVMID(sub1, "rg2", "vm6")),
+								Location: to.Ptr("location2"),
 							},
-						},
-						{
-							ID:       to.Ptr(makeAzureVMID(sub2, "rg4", "vm12")),
-							Location: to.Ptr("location2"),
 						},
 					},
 				},
-			}, nil /* scaleSetAPI */),
+				ScaleSetVMsAPI: &azure.ARMScaleSetVMsMock{},
+				ScaleSetsAPI:   &azure.ARMScaleSetsMock{},
+			},
+			),
+			sub2: azure.NewVirtualMachinesClientByAPI(azure.VirtualMachinesClientConfig{
+				ScaleSetVMsAPI: &azure.ARMScaleSetVMsMock{},
+				ScaleSetsAPI:   &azure.ARMScaleSetsMock{},
+				VirtualMachineAPI: &azure.ARMComputeMock{
+					VirtualMachines: map[string][]*armcompute.VirtualMachine{
+						"rg3": {
+							{
+								ID:       to.Ptr(makeAzureVMID(sub2, "rg3", "vm7")),
+								Location: to.Ptr("location1"),
+							},
+							{
+								ID:       to.Ptr(makeAzureVMID(sub2, "rg3", "vm8")),
+								Location: to.Ptr("location1"),
+								Tags: map[string]*string{
+									"teleport": to.Ptr("yes"),
+								},
+							},
+							{
+								ID:       to.Ptr(makeAzureVMID(sub2, "rg3", "vm9")),
+								Location: to.Ptr("location2"),
+							},
+						},
+						"rg4": {
+							{
+								ID:       to.Ptr(makeAzureVMID(sub2, "rg4", "vm10")),
+								Location: to.Ptr("location1"),
+							},
+							{
+								ID:       to.Ptr(makeAzureVMID(sub2, "rg4", "vm11")),
+								Location: to.Ptr("location1"),
+								Tags: map[string]*string{
+									"teleport": to.Ptr("yes"),
+								},
+							},
+							{
+								ID:       to.Ptr(makeAzureVMID(sub2, "rg4", "vm12")),
+								Location: to.Ptr("location2"),
+							},
+						},
+					},
+				},
+			}),
 		},
 	}
 
@@ -262,7 +271,7 @@ func TestAzureWatcher(t *testing.T) {
 				select {
 				case results := <-watcher.InstancesC:
 					for _, vm := range results.Instances {
-						parsedResource, err := arm.ParseResourceID(*vm.ID)
+						parsedResource, err := arm.ParseResourceID(vm.ID)
 						require.NoError(t, err)
 						vmID := parsedResource.Name
 						vmIDs = append(vmIDs, vmID)
@@ -292,18 +301,14 @@ func TestAzureInstances_FilterExistingNodes(t *testing.T) {
 			name: "no existing nodes",
 			instances: &AzureInstances{
 				SubscriptionID: "sub-1",
-				Instances: []*armcompute.VirtualMachine{
+				Instances: []*azure.VirtualMachine{
 					{
-						ID: to.Ptr("/subscriptions/sub-1/resourceGroups/rg1/providers/Microsoft.Compute/virtualMachines/vm1"),
-						Properties: &armcompute.VirtualMachineProperties{
-							VMID: to.Ptr("vm-id-1"),
-						},
+						ID:   "/subscriptions/sub-1/resourceGroups/rg1/providers/Microsoft.Compute/virtualMachines/vm1",
+						VMID: "vm-id-1",
 					},
 					{
-						ID: to.Ptr("/subscriptions/sub-1/resourceGroups/rg1/providers/Microsoft.Compute/virtualMachines/vm2"),
-						Properties: &armcompute.VirtualMachineProperties{
-							VMID: to.Ptr("vm-id-2"),
-						},
+						ID:   "/subscriptions/sub-1/resourceGroups/rg1/providers/Microsoft.Compute/virtualMachines/vm2",
+						VMID: "vm-id-2",
 					},
 				},
 			},
@@ -314,18 +319,14 @@ func TestAzureInstances_FilterExistingNodes(t *testing.T) {
 			name: "filter out matching node",
 			instances: &AzureInstances{
 				SubscriptionID: "sub-1",
-				Instances: []*armcompute.VirtualMachine{
+				Instances: []*azure.VirtualMachine{
 					{
-						ID: to.Ptr("/subscriptions/sub-1/resourceGroups/rg1/providers/Microsoft.Compute/virtualMachines/vm1"),
-						Properties: &armcompute.VirtualMachineProperties{
-							VMID: to.Ptr("vm-id-1"),
-						},
+						ID:   "/subscriptions/sub-1/resourceGroups/rg1/providers/Microsoft.Compute/virtualMachines/vm1",
+						VMID: "vm-id-1",
 					},
 					{
-						ID: to.Ptr("/subscriptions/sub-1/resourceGroups/rg1/providers/Microsoft.Compute/virtualMachines/vm2"),
-						Properties: &armcompute.VirtualMachineProperties{
-							VMID: to.Ptr("vm-id-2"),
-						},
+						ID:   "/subscriptions/sub-1/resourceGroups/rg1/providers/Microsoft.Compute/virtualMachines/vm2",
+						VMID: "vm-id-2",
 					},
 				},
 			},
@@ -338,18 +339,14 @@ func TestAzureInstances_FilterExistingNodes(t *testing.T) {
 			name: "filter out all matching nodes",
 			instances: &AzureInstances{
 				SubscriptionID: "sub-1",
-				Instances: []*armcompute.VirtualMachine{
+				Instances: []*azure.VirtualMachine{
 					{
-						ID: to.Ptr("/subscriptions/sub-1/resourceGroups/rg1/providers/Microsoft.Compute/virtualMachines/vm1"),
-						Properties: &armcompute.VirtualMachineProperties{
-							VMID: to.Ptr("vm-id-1"),
-						},
+						ID:   "/subscriptions/sub-1/resourceGroups/rg1/providers/Microsoft.Compute/virtualMachines/vm1",
+						VMID: "vm-id-1",
 					},
 					{
-						ID: to.Ptr("/subscriptions/sub-1/resourceGroups/rg1/providers/Microsoft.Compute/virtualMachines/vm2"),
-						Properties: &armcompute.VirtualMachineProperties{
-							VMID: to.Ptr("vm-id-2"),
-						},
+						ID:   "/subscriptions/sub-1/resourceGroups/rg1/providers/Microsoft.Compute/virtualMachines/vm2",
+						VMID: "vm-id-2",
 					},
 				},
 			},
@@ -363,12 +360,10 @@ func TestAzureInstances_FilterExistingNodes(t *testing.T) {
 			name: "different subscription is not filtered",
 			instances: &AzureInstances{
 				SubscriptionID: "sub-1",
-				Instances: []*armcompute.VirtualMachine{
+				Instances: []*azure.VirtualMachine{
 					{
-						ID: to.Ptr("/subscriptions/sub-1/resourceGroups/rg1/providers/Microsoft.Compute/virtualMachines/vm1"),
-						Properties: &armcompute.VirtualMachineProperties{
-							VMID: to.Ptr("vm-id-1"),
-						},
+						ID:   "/subscriptions/sub-1/resourceGroups/rg1/providers/Microsoft.Compute/virtualMachines/vm1",
+						VMID: "vm-id-1",
 					},
 				},
 			},
@@ -381,12 +376,10 @@ func TestAzureInstances_FilterExistingNodes(t *testing.T) {
 			name: "node without vm id is not used for filtering",
 			instances: &AzureInstances{
 				SubscriptionID: "sub-1",
-				Instances: []*armcompute.VirtualMachine{
+				Instances: []*azure.VirtualMachine{
 					{
-						ID: to.Ptr("/subscriptions/sub-1/resourceGroups/rg1/providers/Microsoft.Compute/virtualMachines/vm1"),
-						Properties: &armcompute.VirtualMachineProperties{
-							VMID: to.Ptr("vm-id-1"),
-						},
+						ID:   "/subscriptions/sub-1/resourceGroups/rg1/providers/Microsoft.Compute/virtualMachines/vm1",
+						VMID: "vm-id-1",
 					},
 				},
 			},
@@ -399,10 +392,9 @@ func TestAzureInstances_FilterExistingNodes(t *testing.T) {
 			name: "instance without properties is not filtered",
 			instances: &AzureInstances{
 				SubscriptionID: "sub-1",
-				Instances: []*armcompute.VirtualMachine{
+				Instances: []*azure.VirtualMachine{
 					{
-						ID:         to.Ptr("/subscriptions/sub-1/resourceGroups/rg1/providers/Microsoft.Compute/virtualMachines/vm1"),
-						Properties: nil,
+						ID: "/subscriptions/sub-1/resourceGroups/rg1/providers/Microsoft.Compute/virtualMachines/vm1",
 					},
 				},
 			},
@@ -419,11 +411,7 @@ func TestAzureInstances_FilterExistingNodes(t *testing.T) {
 
 			var gotVMIDs []string
 			for _, vm := range tc.instances.Instances {
-				var vmID string
-				if vm.Properties != nil {
-					vmID = *vm.Properties.VMID
-				}
-				gotVMIDs = append(gotVMIDs, vmID)
+				gotVMIDs = append(gotVMIDs, vm.VMID)
 			}
 
 			require.ElementsMatch(t, tc.expectedVMIDs, gotVMIDs)
@@ -464,12 +452,10 @@ func TestMakeRunEvent(t *testing.T) {
 		resourceID     = "/subscriptions/sub-1/resourceGroups/rg1/providers/Microsoft.Compute/virtualMachines/vm1"
 	)
 
-	vm := &armcompute.VirtualMachine{
-		ID:   to.Ptr(resourceID),
-		Name: to.Ptr(vmName),
-		Properties: &armcompute.VirtualMachineProperties{
-			VMID: to.Ptr(vmID),
-		},
+	vm := &azure.VirtualMachine{
+		ID:   resourceID,
+		Name: vmName,
+		VMID: vmID,
 	}
 
 	tests := []struct {
@@ -600,9 +586,9 @@ func TestMakeRunEvent(t *testing.T) {
 		{
 			name: "instance without properties",
 			result: AzureInstallResult{
-				Instance: &armcompute.VirtualMachine{
-					ID:   to.Ptr(resourceID),
-					Name: to.Ptr(vmName),
+				Instance: &azure.VirtualMachine{
+					ID:   resourceID,
+					Name: vmName,
 				},
 				APIError: trace.AccessDenied("forbidden"),
 			},
@@ -644,8 +630,8 @@ func TestMakeUsageEvent(t *testing.T) {
 		resourceID      = "/subscriptions/sub-1/resourceGroups/rg1/providers/Microsoft.Compute/virtualMachines/vm1"
 	)
 
-	vm := &armcompute.VirtualMachine{
-		ID: to.Ptr(resourceID),
+	vm := &azure.VirtualMachine{
+		ID: resourceID,
 	}
 
 	tests := []struct {

--- a/lib/usertasks/descriptions/azure-vm-missing-run-commands-permission.md
+++ b/lib/usertasks/descriptions/azure-vm-missing-run-commands-permission.md
@@ -8,4 +8,12 @@ To fix this, grant the identity a role that includes the following permissions:
 - `Microsoft.Compute/virtualMachines/runCommands/write`
 - `Microsoft.Compute/virtualMachines/runCommands/delete`
 
+When enrolling Virtual Machine Scale Sets using uniform orchestration mode, ensure you also add the following permissions:
+- `Microsoft.Compute/virtualMachineScaleSets/read`
+- `Microsoft.Compute/virtualMachineScaleSets/virtualMachines/read`
+- `Microsoft.Compute/virtualMachineScaleSets/virtualMachines/runCommand/action`
+- `Microsoft.Compute/virtualMachineScaleSets/virtualMachines/runCommands/write`
+- `Microsoft.Compute/virtualMachineScaleSets/virtualMachines/runCommands/read`
+- `Microsoft.Compute/virtualMachineScaleSets/virtualMachines/runCommands/delete`
+
 You can assign these permissions at the Subscription level for broad access, or limit the scope to the Resource Group.


### PR DESCRIPTION
Backport #66631 to branch/v18

changelog: Added support for auto enrolling Azure Virtual Machine Scale Sets deployed as Uniform orchestration mode (flexible is already supported).


## Manual Test Plan
### Test Environment

- Local env with app registration credentials

### Test Cases
- [x] Auto enroll regular VMs
- [x] Auto enroll orchestration:flexible VMSS VMs
- [x] Auto enroll orchestration:uniform VMSS VMs

### Demo
<img width="611" height="612" alt="image" src="https://github.com/user-attachments/assets/bda5b26a-e392-4fad-ab31-26f835e45593" />
