### PR TITLE
Add Prometheus metrics to the ResetUser call

### DIFF
--- a/lib/auth/users/usersv1/metrics.go
+++ b/lib/auth/users/usersv1/metrics.go
@@ -1,0 +1,34 @@
+package usersv1
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/gravitational/teleport"
+	"github.com/gravitational/teleport/lib/observability/metrics"
+)
+
+const (
+	LabelUserKind = "user_kind"
+	LabelGRPCCode = "grpc_code"
+)
+
+type UserKindLabelValue string
+
+const (
+	UserKindLocal   UserKindLabelValue = "local"
+	UserKindSSO     UserKindLabelValue = "sso"
+	UserKindBot     UserKindLabelValue = "bot"
+	UserKindUnknown UserKindLabelValue = "unknown"
+)
+
+var ResetUserCounter = prometheus.NewCounterVec(prometheus.CounterOpts{
+	Namespace: teleport.MetricNamespace,
+	Subsystem: "users",
+	Name:      "reset_user",
+	Help:      "Total number of user reset operations",
+}, []string{LabelUserKind, LabelGRPCCode})
+
+func init() {
+	println("=========== init()")
+	metrics.RegisterPrometheusCollectors(ResetUserCounter)
+}

--- a/lib/auth/users/usersv1/service.go
+++ b/lib/auth/users/usersv1/service.go
@@ -24,12 +24,15 @@ import (
 
 	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
+	"github.com/prometheus/client_golang/prometheus"
+	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/emptypb"
 
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/constants"
 	apidefaults "github.com/gravitational/teleport/api/defaults"
 	userspb "github.com/gravitational/teleport/api/gen/proto/go/teleport/users/v1"
+	"github.com/gravitational/teleport/api/trail"
 	"github.com/gravitational/teleport/api/types"
 	apievents "github.com/gravitational/teleport/api/types/events"
 	"github.com/gravitational/teleport/lib/auth/authclient"
@@ -616,16 +619,29 @@ func (s *Service) ListUsers(ctx context.Context, req *userspb.ListUsersRequest) 
 }
 
 func (s *Service) ResetUser(ctx context.Context, req *userspb.ResetUserRequest) (*userspb.ResetUserResponse, error) {
+	res, userKind, err := s.authorizeAndResetUser(ctx, req)
+	ResetUserCounter.With(prometheus.Labels{
+		LabelUserKind: string(userKind),
+		LabelGRPCCode: status.Code(trail.ToGRPC(err)).String(),
+	}).Inc()
+	return res, trace.Wrap(err)
+}
+
+// authorizeAndResetUser authenticates a reset request and resets user's
+// credentials It returns a response and user kind (for metrics).
+func (s *Service) authorizeAndResetUser(
+	ctx context.Context, req *userspb.ResetUserRequest,
+) (*userspb.ResetUserResponse, UserKindLabelValue, error) {
 	authCtx, err := s.authorizer.Authorize(ctx)
 	if err != nil {
 		s.emitUserResetEvent(ctx, req.Name, events.UserResetFailureEvent, events.UserResetFailureCode)
-		return nil, trace.Wrap(err)
+		return nil, "", trace.Wrap(err)
 	}
 
 	// Allow reused MFA responses to allow creating a reset token after creating a user.
 	if err := authCtx.AuthorizeAdminActionAllowReusedMFA(); err != nil {
 		// Don't emit an event; this is a normal part of the admin action MFA flow.
-		return nil, trace.Wrap(err)
+		return nil, "", trace.Wrap(err)
 	}
 
 	if err := authCtx.CheckAccessToRule(
@@ -634,26 +650,26 @@ func (s *Service) ResetUser(ctx context.Context, req *userspb.ResetUserRequest) 
 		types.VerbUpdate,
 	); err != nil {
 		s.emitUserResetEvent(ctx, req.Name, events.UserResetFailureEvent, events.UserResetFailureCode)
-		return nil, trace.Wrap(err)
+		return nil, "", trace.Wrap(err)
 	}
 
 	if authz.HasBuiltinRole(*authCtx, string(types.RoleOkta)) {
 		s.emitUserResetEvent(ctx, req.Name, events.UserResetFailureEvent, events.UserResetFailureCode)
-		return nil, trace.AccessDenied("access denied")
+		return nil, "", trace.AccessDenied("access denied")
 	}
 
 	setResetUserRequestDefaults(req)
 	if err = validateResetUserRequest(req); err != nil {
-		return nil, trace.Wrap(err)
+		return nil, "", trace.Wrap(err)
 	}
 
-	res, err := s.resetUser(ctx, req)
+	res, userKind, err := s.resetUser(ctx, req)
 	if err != nil {
-		return nil, trace.Wrap(err)
+		return nil, userKind, trace.Wrap(err)
 	}
 
 	s.emitUserResetEvent(ctx, req.Name, events.UserResetEvent, events.UserResetCode)
-	return res, nil
+	return res, userKind, nil
 }
 
 func (s *Service) emitUserResetEvent(
@@ -673,20 +689,31 @@ func (s *Service) emitUserResetEvent(
 	}
 }
 
-func (s *Service) resetUser(ctx context.Context, req *userspb.ResetUserRequest) (*userspb.ResetUserResponse, error) {
+// resetUser resets user's credentials and returns a response and user kind
+// (for metrics). The response contents, as well as procedure used, depends on
+// the user kind.
+func (s *Service) resetUser(
+	ctx context.Context, req *userspb.ResetUserRequest,
+) (*userspb.ResetUserResponse, UserKindLabelValue, error) {
 	switch user, err := s.cache.GetUser(ctx, req.Name, false /* withSecrets */); {
 	case trace.IsNotFound(err):
-		return s.resetUnknownUser(ctx, req)
+		res, err := s.resetUnknownUser(ctx, req)
+		if err != nil {
+			return nil, "", trace.Wrap(err)
+		}
+		return res, UserKindUnknown, nil
 	case err != nil:
-		return nil, trace.Wrap(err)
+		return nil, "", trace.Wrap(err)
 	case user.IsBot():
-		return nil, trace.BadParameter("cannot reset a bot user")
+		return nil, UserKindBot, trace.BadParameter("cannot reset a bot user")
 	case user.GetUserType() == types.UserTypeLocal:
-		return s.resetLocalUser(ctx, req)
+		res, err := s.resetLocalUser(ctx, req)
+		return res, UserKindLocal, trace.Wrap(err)
 	case user.GetUserType() == types.UserTypeSSO:
-		return s.resetSSOUser(ctx, req)
+		res, err := s.resetSSOUser(ctx, req)
+		return res, UserKindSSO, trace.Wrap(err)
 	default:
-		return nil, trace.BadParameter("unknown user type: %q", user.GetUserType())
+		return nil, "", trace.BadParameter("unknown user type: %q", user.GetUserType())
 	}
 }
 

--- a/lib/auth/users/usersv1/service_test.go
+++ b/lib/auth/users/usersv1/service_test.go
@@ -33,9 +33,12 @@ import (
 	"github.com/google/uuid"
 	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
+	"github.com/prometheus/client_golang/prometheus"
+	io_prometheus_client "github.com/prometheus/client_model/go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/crypto/bcrypt"
+	"google.golang.org/grpc/codes"
 
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/constants"
@@ -978,14 +981,6 @@ func TestRBAC(t *testing.T) {
 				_, err := env.ResetUser(ctx, &userspb.ResetUserRequest{Name: llama.GetName()})
 				assert.Error(t, err, "eexpected RBAC to prevent resetting user")
 				assert.True(t, trace.IsAccessDenied(err), "expected access denied, got %T %v", err, err)
-
-				evts := getAllEvents(env.emitter.C())
-				require.GreaterOrEqual(t, len(evts), 1)
-
-				e, ok := evts[len(evts)-1].(*apievents.UserReset)
-				require.True(t, ok)
-				assert.Equal(t, events.UserResetFailureEvent, e.GetType())
-				assert.Equal(t, events.UserResetFailureCode, e.Code)
 			},
 			checker: &fakeChecker{
 				rules: []types.Rule{
@@ -1046,7 +1041,7 @@ func TestRBAC(t *testing.T) {
 }
 
 func TestResetUser(t *testing.T) {
-	t.Parallel()
+	// Can't go parallel because of using global metrics state.
 	ctx := t.Context()
 
 	assertUserResetEvent := func(t *testing.T, e apievents.AuditEvent, username string) {
@@ -1067,6 +1062,7 @@ func TestResetUser(t *testing.T) {
 		userType          types.UserType
 		expectToken       bool
 		assert            func(t *testing.T, env *env, user types.User, res *userspb.ResetUserResponse)
+		userKindLabel     usersv1.UserKindLabelValue
 	}{
 		{
 			name: "local user",
@@ -1100,6 +1096,7 @@ func TestResetUser(t *testing.T) {
 
 				assertUserResetEvent(t, evts[1], user.GetName())
 			},
+			userKindLabel: usersv1.UserKindLocal,
 		},
 		{
 			name: "SSO user, active",
@@ -1119,6 +1116,7 @@ func TestResetUser(t *testing.T) {
 				require.GreaterOrEqual(t, len(evts), 1)
 				assertUserResetEvent(t, evts[len(evts)-1], user.GetName())
 			},
+			userKindLabel: usersv1.UserKindSSO,
 		},
 		{
 			name: "SSO user, active, with SSO MFA",
@@ -1173,6 +1171,7 @@ func TestResetUser(t *testing.T) {
 				require.GreaterOrEqual(t, len(evts), 1)
 				assertUserResetEvent(t, evts[len(evts)-1], user.GetName())
 			},
+			userKindLabel: usersv1.UserKindSSO,
 		},
 		{
 			name: "SSO user, expired",
@@ -1202,11 +1201,14 @@ func TestResetUser(t *testing.T) {
 				require.GreaterOrEqual(t, len(evts), 1)
 				assertUserResetEvent(t, evts[len(evts)-1], user.GetName())
 			},
+			userKindLabel: usersv1.UserKindUnknown,
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+			usersv1.ResetUserCounter.Reset()
+
 			env, err := newTestEnv()
 			require.NoError(t, err, "creating test service")
 
@@ -1281,12 +1283,24 @@ func TestResetUser(t *testing.T) {
 			// verify that password was reset
 			_, err = env.backend.GetPasswordHash(user.GetName())
 			require.True(t, trace.IsNotFound(err), "expected trace.NotFound, got %T %v", err, err)
+
+			var m io_prometheus_client.Metric
+			counter := usersv1.ResetUserCounter.With(prometheus.Labels{
+				usersv1.LabelUserKind: string(tc.userKindLabel),
+				usersv1.LabelGRPCCode: codes.OK.String(),
+			})
+			require.NoError(t, counter.Write(&m))
+			// Comparing floating point values, use assert.InDelta instead of
+			// assert.Equal
+			assert.InDelta(t, 1.0, m.Counter.GetValue(), 0.001)
 		})
 	}
 }
 
 func TestResetUser_NotFound(t *testing.T) {
-	t.Parallel()
+	// Can't go parallel because using global Prometheus metrics state
+
+	usersv1.ResetUserCounter.Reset()
 	ctx := t.Context()
 	env, err := newTestEnv()
 	require.NoError(t, err, "creating test service")
@@ -1296,10 +1310,22 @@ func TestResetUser_NotFound(t *testing.T) {
 		Type: authclient.UserTokenTypeResetPassword,
 	})
 	assert.True(t, trace.IsNotFound(err), "expected trace.NotFound, got %T %v", err, err)
+
+	var m io_prometheus_client.Metric
+	counter := usersv1.ResetUserCounter.With(prometheus.Labels{
+		usersv1.LabelUserKind: "",
+		usersv1.LabelGRPCCode: codes.NotFound.String(),
+	})
+	require.NoError(t, counter.Write(&m))
+	// Comparing floating point values, use assert.InDelta instead of
+	// assert.Equal
+	assert.InDelta(t, 1.0, m.Counter.GetValue(), 0.001)
 }
 
 func TestResetUser_Bot(t *testing.T) {
-	t.Parallel()
+	// Can't go parallel because using global Prometheus metrics state
+
+	usersv1.ResetUserCounter.Reset()
 	ctx := t.Context()
 	env, err := newTestEnv()
 	require.NoError(t, err, "creating test service")
@@ -1325,6 +1351,16 @@ func TestResetUser_Bot(t *testing.T) {
 		Type: authclient.UserTokenTypeResetPassword,
 	})
 	assert.True(t, trace.IsBadParameter(err), "expected trace.BadParameter, got %T %v", err, err)
+
+	var m io_prometheus_client.Metric
+	counter := usersv1.ResetUserCounter.With(prometheus.Labels{
+		usersv1.LabelUserKind: string(usersv1.UserKindBot),
+		usersv1.LabelGRPCCode: codes.InvalidArgument.String(),
+	})
+	require.NoError(t, counter.Write(&m))
+	// Comparing floating point values, use assert.InDelta instead of
+	// assert.Equal
+	assert.InDelta(t, 1.0, m.Counter.GetValue(), 0.001)
 }
 
 func TestResetUser_AdminMFARequired(t *testing.T) {


### PR DESCRIPTION
RFD: https://github.com/gravitational/rfd/blob/main/rfd/0251-resetting-mfa-devices-for-sso-users.md

This PR builds on top of PR #66842 and adds Prometheus metrics.
Fixes https://github.com/gravitational/teleport/issues/41741

<!-- Include manual testing efforts to verify the change. -->
<!-- Detail where the tests where run and what configurations were used. -->
<!-- Include all the test cases which were run to validate the change. -->

## Manual Test Plan
### Test Environment
Any Teleport cluster.

### Test Cases
- [ ] Reset a local user, observe metrics.
- [ ] Reset an SSO user, observe metrics.
- [ ] Reset an inexistent user, observe metrics.
- [ ] Attempt to reset user without necessary privileges, observe metrics.
