### PR TITLE
[v18] Add LLM inference endpoint configuration

### DIFF
--- a/api/proto/teleport/legacy/types/types.proto
+++ b/api/proto/teleport/legacy/types/types.proto
@@ -1194,6 +1194,8 @@ message AppSpecV3 {
   bool UseAnyProxyPublicAddr = 14 [(gogoproto.jsontag) = "use_any_proxy_public_addr,omitempty"];
   // MCP contains MCP server related configurations.
   MCP MCP = 15 [(gogoproto.jsontag) = "mcp,omitempty"];
+  // LLM contains LLM inference endpoint related configurations.
+  LLM LLM = 16 [(gogoproto.jsontag) = "inference,omitempty"];
 }
 
 // MCP contains MCP server-related configurations.
@@ -1239,6 +1241,28 @@ message PortRange {
   // be greater than Port when describing a port range. When omitted or set to zero, it signifies
   // that the port range defines a single port.
   uint32 EndPort = 2 [(gogoproto.jsontag) = "end_port,omitempty"];
+}
+
+// LLM contains LLM inference endpoint related configurations.
+message LLM {
+  // Model is a provider model definition.
+  message Model {
+    // Name defines the model name. This is the requested value.
+    string name = 1;
+    // Represents the model name in the configured provider.
+    string provider_name = 2;
+  }
+
+  // Defines the LLM inference API format.
+  string format = 1;
+  // Defines which inference provider will be used to serve the requests.
+  string provider = 2;
+  // Defines the list of supported models, and optionally their name on the
+  // inference provider.
+  repeated Model models = 3;
+  // Defines a model that will be used if the model requested is not on the list.
+  // The fallback model must be in the "models" list.
+  string fallback_model = 4;
 }
 
 // CommandLabelV2 is a label that has a value as a result of the

--- a/api/types/app.go
+++ b/api/types/app.go
@@ -75,6 +75,8 @@ type Application interface {
 	IsTCP() bool
 	// IsMCP returns true if this app represents a MCP server.
 	IsMCP() bool
+	// IsLLM returns true if this app represents an LLM inference endpoint.
+	IsLLM() bool
 	// GetProtocol returns the application protocol.
 	GetProtocol() string
 	// GetAWSAccountID returns value of label containing AWS account ID on this app.
@@ -108,6 +110,8 @@ type Application interface {
 	GetIdentityCenter() *AppIdentityCenter
 	// GetMCP fetches MCP specific configuration.
 	GetMCP() *MCP
+	// GetLLM fetches LLM specific configuration.
+	GetLLM() *LLM
 	// IsEqual determines if two application resources are equivalent to one another.
 	IsEqual(Application) bool
 }
@@ -306,6 +310,11 @@ func (a *AppV3) IsMCP() bool {
 	return IsAppMCP(a.Spec.URI)
 }
 
+// IsLLM returns true if app is an LLM inference endpoint.
+func (a *AppV3) IsLLM() bool {
+	return strings.HasPrefix(a.Spec.URI, SchemeLLMEndpoint+"://")
+}
+
 func IsAppTCP(uri string) bool {
 	return strings.HasPrefix(uri, "tcp://")
 }
@@ -322,6 +331,9 @@ func (a *AppV3) GetProtocol() string {
 	}
 	if a.IsMCP() {
 		return "MCP"
+	}
+	if a.IsLLM() {
+		return "LLM"
 	}
 	return "HTTP"
 }
@@ -435,6 +447,8 @@ func (a *AppV3) CheckAndSetDefaults() error {
 			a.Spec.URI = fmt.Sprintf("cloud://%v", a.Spec.Cloud)
 		case a.Spec.MCP != nil && a.Spec.MCP.Command != "":
 			a.Spec.URI = SchemeMCPStdio + "://"
+		case a.Spec.LLM != nil:
+			a.Spec.URI = SchemeLLMEndpoint + "://"
 		default:
 			return trace.BadParameter("app %q URI is empty", a.GetName())
 		}
@@ -479,15 +493,19 @@ func (a *AppV3) CheckAndSetDefaults() error {
 		}
 	}
 
-	if len(a.Spec.TCPPorts) != 0 {
-		if err := a.checkTCPPorts(); err != nil {
-			return trace.Wrap(err)
-		}
-	}
-
-	if a.IsMCP() {
+	switch {
+	case a.IsMCP():
 		a.SetSubKind(SubKindMCP)
 		if err := a.checkMCP(); err != nil {
+			return trace.Wrap(err)
+		}
+	case a.IsLLM():
+		a.SetSubKind(SubKindLLM)
+		if err := a.checkLLM(); err != nil {
+			return trace.Wrap(err)
+		}
+	case len(a.Spec.TCPPorts) != 0:
+		if err := a.checkTCPPorts(); err != nil {
 			return trace.Wrap(err)
 		}
 	}
@@ -510,16 +528,19 @@ func (a *AppV3) checkTCPPorts() error {
 		return trace.BadParameter("invalid app URI format: %v", err)
 	}
 
+	switch {
 	// The scheme of URI is enforced to be "tcp" on purpose. This way in the future we can add
 	// multi-port support to web apps without throwing hard errors when a cluster with a multi-port
 	// web app gets downgraded to a version which supports multi-port only for TCP apps.
 	//
 	// For now, we simply ignore the Ports field set on non-TCP apps.
-	if uri.Scheme != "tcp" {
+	case uri.Scheme != "tcp":
 		return nil
-	}
-
-	if uri.Port() != "" {
+	case a.Spec.MCP != nil:
+		return trace.BadParameter("TCP app %q cannot specify 'mcp' configuration", a.GetName())
+	case a.Spec.LLM != nil:
+		return trace.BadParameter("TCP app %q cannot specify 'inference' configuration", a.GetName())
+	case uri.Port() != "":
 		return trace.BadParameter("TCP app URI %q must not include a port number when the app spec defines a list of ports", a.Spec.URI)
 	}
 
@@ -533,6 +554,13 @@ func (a *AppV3) checkTCPPorts() error {
 }
 
 func (a *AppV3) checkMCP() error {
+	switch {
+	case a.Spec.LLM != nil:
+		return trace.BadParameter("MCP server %q cannot specify 'inference' configuration", a.GetName())
+	case len(a.Spec.TCPPorts) != 0:
+		return trace.BadParameter("MCP server %q cannot specify 'tcp_ports' configuration", a.GetName())
+	}
+
 	switch GetMCPServerTransportType(a.Spec.URI) {
 	case MCPTransportStdio:
 		return trace.Wrap(a.checkMCPStdio())
@@ -558,6 +586,59 @@ func (a *AppV3) checkMCPStdio() error {
 	if a.Spec.MCP.RunAsHostUser == "" {
 		return trace.BadParameter("MCP server %q is missing 'run_as_host_user' which specifies a valid host user to execute the command", a.GetName())
 	}
+	return nil
+}
+
+// supportedFormatInferenceProviders determines which provider can serve an API
+// format.
+var supportedFormatInferenceProviders = map[LLMFormat][]LLMProvider{
+	LLMFormatAnthropic: {LLMProviderAnthropic, LLMProviderAWSBedrock},
+	LLMFormatOpenAI:    {LLMProviderOpenAI},
+}
+
+func (a *AppV3) checkLLM() error {
+	switch {
+	case a.Spec.URI != SchemeLLMEndpoint+"://":
+		return trace.BadParameter("Inference endpoint %q cannot specify 'uri' configuration", a.GetName())
+	case a.Spec.LLM == nil:
+		return trace.BadParameter("Inference endpoint %q must specify 'inference' configuration", a.GetName())
+	case a.Spec.Cloud != "":
+		return trace.BadParameter("Inference endpoint %q cannot specify 'cloud' configuration", a.GetName())
+	case a.Spec.MCP != nil:
+		return trace.BadParameter("Inference endpoint %q cannot specify 'mcp' configuration", a.GetName())
+	case len(a.Spec.TCPPorts) != 0:
+		return trace.BadParameter("Inference endpoint %q cannot specify 'tcp_ports' configuration", a.GetName())
+	case a.Spec.Rewrite != nil:
+		return trace.BadParameter("Inference endpoint %q cannot specify 'rewrite' configuration", a.GetName())
+	case a.Spec.AWS != nil:
+		return trace.BadParameter("Inference endpoint %q cannot specify 'aws' configuration", a.GetName())
+	}
+
+	llm := a.Spec.LLM
+	// Ensure the combination between Format and Provider is supported.
+	// This also covers the requirement of supported format and provider values.
+	providers, ok := supportedFormatInferenceProviders[llm.Format]
+	if !ok {
+		return trace.BadParameter("Inference endpoint %q format %q doesn't have any valid 'provider'. Supported formats are: %s", a.GetName(), llm.Format, strings.Join(SupportedLLMFormats, ", "))
+	}
+
+	if !slices.Contains(providers, llm.Provider) {
+		return trace.BadParameter("Inference endpoint %q must set one of the providers supported by %q format: %s", a.GetName(), llm.Format, strings.Join(providers, ", "))
+	}
+
+	for _, model := range llm.Models {
+		if model == nil || model.Name == "" {
+			return trace.BadParameter("Inference endpoint %q 'models' elements must include the 'name' property", a.GetName())
+		}
+	}
+
+	// Ensure fallback model is present on the models list.
+	if llm.FallbackModel != "" {
+		if !slices.ContainsFunc(llm.Models, func(model *LLM_Model) bool { return model.Name == llm.FallbackModel }) {
+			return trace.BadParameter("Inference endpoint %q doesn't specify the model used in 'fallback_model'. Update the 'models' list to include the missing model or update the 'fallback_model' to one item of the list", a.GetName())
+		}
+	}
+
 	return nil
 }
 
@@ -589,6 +670,11 @@ func (a *AppV3) IsEqual(i Application) bool {
 // GetMCP returns MCP specific configuration.
 func (a *AppV3) GetMCP() *MCP {
 	return a.Spec.MCP
+}
+
+// GetMCP returns LLM specific configuration.
+func (a *AppV3) GetLLM() *LLM {
+	return a.Spec.LLM
 }
 
 // DeduplicateApps deduplicates apps by combination of app name and public address.
@@ -705,4 +791,41 @@ func GetMCPServerTransportType(uri string) string {
 	default:
 		return ""
 	}
+}
+
+// LLMFormat indicates the API format used by clients to use an inference
+// endpoint.
+type LLMFormat = string
+
+const (
+	// LLMFormatUnspecified represents an empty LLM API format.
+	LLMFormatUnspecified LLMProvider = ""
+	// LLMFormatOpenAI represents the OpenAI LLM API format.
+	LLMFormatOpenAI LLMFormat = "openai"
+	// LLMFormatAnthropic represents the Anthropic LLM API format.
+	LLMFormatAnthropic LLMFormat = "anthropic"
+)
+
+// SupportedLLMFormats is the list of supported LLM API formats.
+var SupportedLLMFormats = []LLMFormat{LLMFormatOpenAI, LLMFormatAnthropic}
+
+// LLMProvider determines which service serves the LLM inference endpoint.
+type LLMProvider = string
+
+const (
+	// LLMProviderUnspecified represents an empty inference provider.
+	LLMProviderUnspecified LLMProvider = ""
+	// LLMProviderOpenAI represents the OpenAI LLM inference provider.
+	LLMProviderOpenAI LLMProvider = "openai"
+	// LLMProviderAnthropic represents the Anthropic LLM inference provider.
+	LLMProviderAnthropic LLMProvider = "anthropic"
+	// LLMProviderAWSBedrock represents the AWS Bedrock LLM inference provider.
+	LLMProviderAWSBedrock LLMProvider = "bedrock"
+)
+
+// SupportedLLMProviders is the list of supported LLM inference providers.
+var SupportedLLMProviders = []LLMProvider{
+	LLMProviderOpenAI,
+	LLMProviderAnthropic,
+	LLMProviderAWSBedrock,
 }

--- a/api/types/app_test.go
+++ b/api/types/app_test.go
@@ -734,6 +734,39 @@ func TestNewAppV3(t *testing.T) {
 			},
 			wantErr: require.NoError,
 		},
+		{
+			name: "mcp with tcp_ports",
+			meta: Metadata{
+				Name: "teleport-mcp-demo",
+				Labels: map[string]string{
+					TeleportInternalResourceType: DemoResource,
+				},
+			},
+			spec: AppSpecV3{
+				URI: "mcp+stdio://teleport-mcp-demo",
+				TCPPorts: []*PortRange{
+					{Port: 1000, EndPort: 5000},
+				},
+			},
+			wantErr: require.Error,
+		},
+		{
+			name: "mcp with inference",
+			meta: Metadata{
+				Name: "teleport-mcp-demo",
+				Labels: map[string]string{
+					TeleportInternalResourceType: DemoResource,
+				},
+			},
+			spec: AppSpecV3{
+				URI: "mcp+stdio://teleport-mcp-demo",
+				LLM: &LLM{
+					Format:   LLMFormatAnthropic,
+					Provider: LLMProviderAnthropic,
+				},
+			},
+			wantErr: require.Error,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -838,4 +871,177 @@ func TestDeduplicateApps(t *testing.T) {
 
 	deduped := DeduplicateApps(apps)
 	require.Equal(t, []string{"a", "b", "c", "d"}, slices.Collect(ResourceNames(deduped)))
+}
+
+func TestLLMSubKind(t *testing.T) {
+	app, err := NewAppV3(Metadata{
+		Name: "my-app",
+	}, AppSpecV3{
+		LLM: &LLM{
+			Format:   LLMFormatAnthropic,
+			Provider: LLMProviderAnthropic,
+		},
+	})
+	require.NoError(t, err)
+	require.True(t, app.IsLLM())
+	require.Equal(t, SubKindLLM, app.SubKind)
+}
+
+func TestLLMConfiguration(t *testing.T) {
+	// Given an inference endpoint configuration, ensure the selected values for
+	// 'format' and 'provider' are compatible.
+	t.Run("format and provider combination", func(t *testing.T) {
+		for _, format := range SupportedLLMFormats {
+			supportedProviders := supportedFormatInferenceProviders[format]
+			for _, provider := range SupportedLLMProviders {
+				t.Run(format+" "+provider, func(t *testing.T) {
+					_, err := NewAppV3(Metadata{
+						Name: "my-app",
+					}, AppSpecV3{
+						LLM: &LLM{
+							Format:   format,
+							Provider: provider,
+						},
+					})
+					// If it is supported, we don't expect errors.
+					if slices.Contains(supportedProviders, provider) {
+						require.NoError(t, err)
+						return
+					}
+					require.Error(t, err)
+				})
+			}
+		}
+	})
+
+	// Given an inference endpoint configuration, ensure the models list elements
+	// contain at least the model name.
+	t.Run("models element", func(t *testing.T) {
+		for name, tc := range map[string]struct {
+			models    []*LLM_Model
+			expectErr require.ErrorAssertionFunc
+		}{
+			"valid": {
+				models: []*LLM_Model{
+					{Name: "claude-opus-4-6", ProviderName: "opus-4.6"},
+					{Name: "claude-sonnet-4-6"},
+					{Name: "claude-haiku-4-5", ProviderName: "haiku-4.5"},
+				},
+				expectErr: require.NoError,
+			},
+			"invalid": {
+				models: []*LLM_Model{
+					{ProviderName: "opus-4.6"},
+					{Name: "claude-sonnet-4-6"},
+					{Name: "claude-haiku-4-5"},
+				},
+				expectErr: require.Error,
+			},
+		} {
+			t.Run(name, func(t *testing.T) {
+				_, err := NewAppV3(Metadata{
+					Name: "my-app",
+				}, AppSpecV3{
+					LLM: &LLM{
+						Format:   LLMFormatAnthropic,
+						Provider: LLMProviderAnthropic,
+						Models:   tc.models,
+					},
+				})
+				tc.expectErr(t, err)
+			})
+		}
+	})
+
+	// Given an inference endpoint configuration, ensure the fallback model is
+	// present on the models list.
+	t.Run("fallback model", func(t *testing.T) {
+		t.Run("valid", func(t *testing.T) {
+			_, err := NewAppV3(Metadata{
+				Name: "my-app",
+			}, AppSpecV3{
+				LLM: &LLM{
+					Format:   LLMFormatAnthropic,
+					Provider: LLMProviderAnthropic,
+					Models: []*LLM_Model{
+						{Name: "claude-opus-4-6"},
+					},
+					FallbackModel: "claude-opus-4-6",
+				},
+			})
+			require.NoError(t, err)
+		})
+
+		t.Run("invalid", func(t *testing.T) {
+			for name, models := range map[string][]*LLM_Model{
+				"missing": {{Name: "claude-opus-4-6"}},
+				"empty":   nil,
+			} {
+				t.Run(name, func(t *testing.T) {
+					_, err := NewAppV3(Metadata{
+						Name: "my-app",
+					}, AppSpecV3{
+						LLM: &LLM{
+							Format:        LLMFormatAnthropic,
+							Provider:      LLMProviderAnthropic,
+							Models:        models,
+							FallbackModel: "claude-sonnet-4-6",
+						},
+					})
+					require.Error(t, err)
+				})
+			}
+		})
+	})
+
+	t.Run("invalid configurations", func(t *testing.T) {
+		for name, modifySpec := range map[string]func(AppSpecV3) AppSpecV3{
+			"mcp": func(spec AppSpecV3) AppSpecV3 {
+				spec.MCP = &MCP{
+					Command: "docker",
+					Args:    []string{"run", "-i", "--rm", "mcp/everything"},
+				}
+				return spec
+			},
+			"tcp_ports": func(spec AppSpecV3) AppSpecV3 {
+				spec.TCPPorts = []*PortRange{
+					{Port: 1000, EndPort: 5000},
+				}
+				return spec
+			},
+			"rewrite": func(spec AppSpecV3) AppSpecV3 {
+				spec.Rewrite = &Rewrite{
+					Redirect: []string{"localhost"},
+				}
+				return spec
+			},
+			"custom uri": func(spec AppSpecV3) AppSpecV3 {
+				spec.URI = SchemeLLMEndpoint + "://my-inference-endpoint"
+				return spec
+			},
+			"aws": func(spec AppSpecV3) AppSpecV3 {
+				spec.AWS = &AppAWS{ExternalID: "default-external-id"}
+				return spec
+			},
+			"llm provider": func(spec AppSpecV3) AppSpecV3 {
+				spec.LLM.Provider = "random"
+				return spec
+			},
+			"llm format": func(spec AppSpecV3) AppSpecV3 {
+				spec.LLM.Format = "random"
+				return spec
+			},
+		} {
+			t.Run(name, func(t *testing.T) {
+				spec := modifySpec(AppSpecV3{
+					LLM: &LLM{
+						Format:   LLMFormatAnthropic,
+						Provider: LLMFormatAnthropic,
+					},
+				})
+				_, err := NewAppV3(Metadata{Name: "my-app"}, spec)
+				require.Error(t, err)
+			})
+		}
+	})
 }

--- a/api/types/constants.go
+++ b/api/types/constants.go
@@ -184,10 +184,18 @@ const (
 	// SubKindMCP represents an MCP server as a subkind of app.
 	SubKindMCP = KindMCP
 
+	// SubKindLLM represents an LLM inference endpoint as a subkind of app.
+	SubKindLLM = KindLLM
+
 	// KindMCP is an MCP server resource.
 	// Currently, MCP servers are accessed through apps.
 	// In the future, they may become a standalone resource kind.
 	KindMCP = "mcp"
+
+	// KindLLM is an LLM inference endpoint server resource.
+	// Currently, inference endpoints are accessed through apps.
+	// In the future, they may become a standalone resource kind.
+	KindLLM = "llm"
 
 	// KindDatabaseServer is a database proxy server resource.
 	KindDatabaseServer = "db_server"
@@ -1030,6 +1038,9 @@ const (
 	SchemeMCPHTTPS = "mcp+https"
 	// MCPTransportHTTP indicates the MCP server uses SSE transport.
 	MCPTransportHTTP = "Streamable HTTP"
+
+	// SchemeLLMEndpoint is a URI scheme for LLM inference endpoints.
+	SchemeLLMEndpoint = "llm"
 
 	// DiscoveredResourceNode identifies a discovered SSH node.
 	DiscoveredResourceNode = "node"

--- a/api/types/derived.gen.go
+++ b/api/types/derived.gen.go
@@ -235,7 +235,8 @@ func deriveTeleportEqual(this, that *AppSpecV3) bool {
 			deriveTeleportEqual_26(this.IdentityCenter, that.IdentityCenter) &&
 			deriveTeleportEqual_27(this.TCPPorts, that.TCPPorts) &&
 			this.UseAnyProxyPublicAddr == that.UseAnyProxyPublicAddr &&
-			deriveTeleportEqual_28(this.MCP, that.MCP)
+			deriveTeleportEqual_28(this.MCP, that.MCP) &&
+			deriveTeleportEqual_29(this.LLM, that.LLM)
 }
 
 // deriveTeleportEqual_ returns whether this and that are equal.
@@ -367,12 +368,12 @@ func deriveTeleportEqual_12(this, that *DatabaseSpecV3) bool {
 			deriveTeleportEqualAWS(&this.AWS, &that.AWS) &&
 			deriveTeleportEqualGCPCloudSQL(&this.GCP, &that.GCP) &&
 			deriveTeleportEqualAzure(&this.Azure, &that.Azure) &&
-			deriveTeleportEqual_29(&this.TLS, &that.TLS) &&
-			deriveTeleportEqual_30(&this.AD, &that.AD) &&
-			deriveTeleportEqual_31(&this.MySQL, &that.MySQL) &&
-			deriveTeleportEqual_32(this.AdminUser, that.AdminUser) &&
-			deriveTeleportEqual_33(&this.MongoAtlas, &that.MongoAtlas) &&
-			deriveTeleportEqual_34(&this.Oracle, &that.Oracle)
+			deriveTeleportEqual_30(&this.TLS, &that.TLS) &&
+			deriveTeleportEqual_31(&this.AD, &that.AD) &&
+			deriveTeleportEqual_32(&this.MySQL, &that.MySQL) &&
+			deriveTeleportEqual_33(this.AdminUser, that.AdminUser) &&
+			deriveTeleportEqual_34(&this.MongoAtlas, &that.MongoAtlas) &&
+			deriveTeleportEqual_35(&this.Oracle, &that.Oracle)
 }
 
 // deriveTeleportEqual_13 returns whether this and that are equal.
@@ -382,7 +383,7 @@ func deriveTeleportEqual_13(this, that *DynamicWindowsDesktopSpecV1) bool {
 			this.Addr == that.Addr &&
 			this.Domain == that.Domain &&
 			this.NonAD == that.NonAD &&
-			deriveTeleportEqual_35(this.ScreenSize, that.ScreenSize)
+			deriveTeleportEqual_36(this.ScreenSize, that.ScreenSize)
 }
 
 // deriveTeleportEqual_14 returns whether this and that are equal.
@@ -393,7 +394,7 @@ func deriveTeleportEqual_14(this, that *WindowsDesktopSpecV3) bool {
 			this.Domain == that.Domain &&
 			this.HostID == that.HostID &&
 			this.NonAD == that.NonAD &&
-			deriveTeleportEqual_35(this.ScreenSize, that.ScreenSize)
+			deriveTeleportEqual_36(this.ScreenSize, that.ScreenSize)
 }
 
 // deriveTeleportEqual_15 returns whether this and that are equal.
@@ -411,7 +412,7 @@ func deriveTeleportEqual_15(this, that *KubernetesClusterSpecV3) bool {
 func deriveTeleportEqual_16(this, that *KubernetesClusterDiscoveryStatus) bool {
 	return (this == nil && that == nil) ||
 		this != nil && that != nil &&
-			deriveTeleportEqual_36(this.Aws, that.Aws)
+			deriveTeleportEqual_37(this.Aws, that.Aws)
 }
 
 // deriveTeleportEqual_17 returns whether this and that are equal.
@@ -421,7 +422,7 @@ func deriveTeleportEqual_17(this, that *KubernetesServerSpecV3) bool {
 			this.Version == that.Version &&
 			this.Hostname == that.Hostname &&
 			this.HostID == that.HostID &&
-			deriveTeleportEqual_37(&this.Rotation, &that.Rotation) &&
+			deriveTeleportEqual_38(&this.Rotation, &that.Rotation) &&
 			deriveTeleportEqualKubernetesClusterV3(this.Cluster, that.Cluster) &&
 			deriveTeleportEqual_24(this.ProxyIDs, that.ProxyIDs) &&
 			this.RelayGroup == that.RelayGroup &&
@@ -441,7 +442,7 @@ func deriveTeleportEqual_19(this, that *OktaAssignmentSpecV1) bool {
 	return (this == nil && that == nil) ||
 		this != nil && that != nil &&
 			this.User == that.User &&
-			deriveTeleportEqual_38(this.Targets, that.Targets) &&
+			deriveTeleportEqual_39(this.Targets, that.Targets) &&
 			this.CleanupTime.Equal(that.CleanupTime) &&
 			this.Status == that.Status &&
 			this.LastTransition.Equal(that.LastTransition) &&
@@ -468,7 +469,7 @@ func deriveTeleportEqual_21(this, that map[string]CommandLabelV2) bool {
 		if !ok {
 			return false
 		}
-		if !(deriveTeleportEqual_39(&v, &thatv)) {
+		if !(deriveTeleportEqual_40(&v, &thatv)) {
 			return false
 		}
 	}
@@ -480,7 +481,7 @@ func deriveTeleportEqual_22(this, that *Rewrite) bool {
 	return (this == nil && that == nil) ||
 		this != nil && that != nil &&
 			deriveTeleportEqual_24(this.Redirect, that.Redirect) &&
-			deriveTeleportEqual_40(this.Headers, that.Headers) &&
+			deriveTeleportEqual_41(this.Headers, that.Headers) &&
 			this.JWTClaims == that.JWTClaims
 }
 
@@ -489,7 +490,7 @@ func deriveTeleportEqual_23(this, that *AppAWS) bool {
 	return (this == nil && that == nil) ||
 		this != nil && that != nil &&
 			this.ExternalID == that.ExternalID &&
-			deriveTeleportEqual_41(this.RolesAnywhereProfile, that.RolesAnywhereProfile)
+			deriveTeleportEqual_42(this.RolesAnywhereProfile, that.RolesAnywhereProfile)
 }
 
 // deriveTeleportEqual_24 returns whether this and that are equal.
@@ -525,7 +526,7 @@ func deriveTeleportEqual_26(this, that *AppIdentityCenter) bool {
 	return (this == nil && that == nil) ||
 		this != nil && that != nil &&
 			this.AccountID == that.AccountID &&
-			deriveTeleportEqual_42(this.PermissionSets, that.PermissionSets)
+			deriveTeleportEqual_43(this.PermissionSets, that.PermissionSets)
 }
 
 // deriveTeleportEqual_27 returns whether this and that are equal.
@@ -537,7 +538,7 @@ func deriveTeleportEqual_27(this, that []*PortRange) bool {
 		return false
 	}
 	for i := 0; i < len(this); i++ {
-		if !(deriveTeleportEqual_43(this[i], that[i])) {
+		if !(deriveTeleportEqual_44(this[i], that[i])) {
 			return false
 		}
 	}
@@ -554,7 +555,17 @@ func deriveTeleportEqual_28(this, that *MCP) bool {
 }
 
 // deriveTeleportEqual_29 returns whether this and that are equal.
-func deriveTeleportEqual_29(this, that *DatabaseTLS) bool {
+func deriveTeleportEqual_29(this, that *LLM) bool {
+	return (this == nil && that == nil) ||
+		this != nil && that != nil &&
+			this.Format == that.Format &&
+			this.Provider == that.Provider &&
+			deriveTeleportEqual_45(this.Models, that.Models) &&
+			this.FallbackModel == that.FallbackModel
+}
+
+// deriveTeleportEqual_30 returns whether this and that are equal.
+func deriveTeleportEqual_30(this, that *DatabaseTLS) bool {
 	return (this == nil && that == nil) ||
 		this != nil && that != nil &&
 			this.Mode == that.Mode &&
@@ -563,8 +574,8 @@ func deriveTeleportEqual_29(this, that *DatabaseTLS) bool {
 			this.TrustSystemCertPool == that.TrustSystemCertPool
 }
 
-// deriveTeleportEqual_30 returns whether this and that are equal.
-func deriveTeleportEqual_30(this, that *AD) bool {
+// deriveTeleportEqual_31 returns whether this and that are equal.
+func deriveTeleportEqual_31(this, that *AD) bool {
 	return (this == nil && that == nil) ||
 		this != nil && that != nil &&
 			this.KeytabFile == that.KeytabFile &&
@@ -577,30 +588,30 @@ func deriveTeleportEqual_30(this, that *AD) bool {
 			this.LDAPServiceAccountSID == that.LDAPServiceAccountSID
 }
 
-// deriveTeleportEqual_31 returns whether this and that are equal.
-func deriveTeleportEqual_31(this, that *MySQLOptions) bool {
+// deriveTeleportEqual_32 returns whether this and that are equal.
+func deriveTeleportEqual_32(this, that *MySQLOptions) bool {
 	return (this == nil && that == nil) ||
 		this != nil && that != nil &&
 			this.ServerVersion == that.ServerVersion
 }
 
-// deriveTeleportEqual_32 returns whether this and that are equal.
-func deriveTeleportEqual_32(this, that *DatabaseAdminUser) bool {
+// deriveTeleportEqual_33 returns whether this and that are equal.
+func deriveTeleportEqual_33(this, that *DatabaseAdminUser) bool {
 	return (this == nil && that == nil) ||
 		this != nil && that != nil &&
 			this.Name == that.Name &&
 			this.DefaultDatabase == that.DefaultDatabase
 }
 
-// deriveTeleportEqual_33 returns whether this and that are equal.
-func deriveTeleportEqual_33(this, that *MongoAtlas) bool {
+// deriveTeleportEqual_34 returns whether this and that are equal.
+func deriveTeleportEqual_34(this, that *MongoAtlas) bool {
 	return (this == nil && that == nil) ||
 		this != nil && that != nil &&
 			this.Name == that.Name
 }
 
-// deriveTeleportEqual_34 returns whether this and that are equal.
-func deriveTeleportEqual_34(this, that *OracleOptions) bool {
+// deriveTeleportEqual_35 returns whether this and that are equal.
+func deriveTeleportEqual_35(this, that *OracleOptions) bool {
 	return (this == nil && that == nil) ||
 		this != nil && that != nil &&
 			this.AuditUser == that.AuditUser &&
@@ -608,25 +619,25 @@ func deriveTeleportEqual_34(this, that *OracleOptions) bool {
 			this.ShuffleHostnames == that.ShuffleHostnames
 }
 
-// deriveTeleportEqual_35 returns whether this and that are equal.
-func deriveTeleportEqual_35(this, that *Resolution) bool {
+// deriveTeleportEqual_36 returns whether this and that are equal.
+func deriveTeleportEqual_36(this, that *Resolution) bool {
 	return (this == nil && that == nil) ||
 		this != nil && that != nil &&
 			this.Width == that.Width &&
 			this.Height == that.Height
 }
 
-// deriveTeleportEqual_36 returns whether this and that are equal.
-func deriveTeleportEqual_36(this, that *KubernetesClusterAWSStatus) bool {
+// deriveTeleportEqual_37 returns whether this and that are equal.
+func deriveTeleportEqual_37(this, that *KubernetesClusterAWSStatus) bool {
 	return (this == nil && that == nil) ||
 		this != nil && that != nil &&
 			this.SetupAccessForArn == that.SetupAccessForArn &&
 			this.Integration == that.Integration &&
-			deriveTeleportEqual_44(this.DiscoveryAssumedRole, that.DiscoveryAssumedRole)
+			deriveTeleportEqual_46(this.DiscoveryAssumedRole, that.DiscoveryAssumedRole)
 }
 
-// deriveTeleportEqual_37 returns whether this and that are equal.
-func deriveTeleportEqual_37(this, that *Rotation) bool {
+// deriveTeleportEqual_38 returns whether this and that are equal.
+func deriveTeleportEqual_38(this, that *Rotation) bool {
 	return (this == nil && that == nil) ||
 		this != nil && that != nil &&
 			this.State == that.State &&
@@ -636,60 +647,11 @@ func deriveTeleportEqual_37(this, that *Rotation) bool {
 			this.Started.Equal(that.Started) &&
 			this.GracePeriod == that.GracePeriod &&
 			this.LastRotated.Equal(that.LastRotated) &&
-			deriveTeleportEqual_45(&this.Schedule, &that.Schedule)
-}
-
-// deriveTeleportEqual_38 returns whether this and that are equal.
-func deriveTeleportEqual_38(this, that []*OktaAssignmentTargetV1) bool {
-	if this == nil || that == nil {
-		return this == nil && that == nil
-	}
-	if len(this) != len(that) {
-		return false
-	}
-	for i := 0; i < len(this); i++ {
-		if !(deriveTeleportEqual_46(this[i], that[i])) {
-			return false
-		}
-	}
-	return true
+			deriveTeleportEqual_47(&this.Schedule, &that.Schedule)
 }
 
 // deriveTeleportEqual_39 returns whether this and that are equal.
-func deriveTeleportEqual_39(this, that *CommandLabelV2) bool {
-	return (this == nil && that == nil) ||
-		this != nil && that != nil &&
-			this.Period == that.Period &&
-			deriveTeleportEqual_24(this.Command, that.Command) &&
-			this.Result == that.Result
-}
-
-// deriveTeleportEqual_40 returns whether this and that are equal.
-func deriveTeleportEqual_40(this, that []*Header) bool {
-	if this == nil || that == nil {
-		return this == nil && that == nil
-	}
-	if len(this) != len(that) {
-		return false
-	}
-	for i := 0; i < len(this); i++ {
-		if !(deriveTeleportEqual_47(this[i], that[i])) {
-			return false
-		}
-	}
-	return true
-}
-
-// deriveTeleportEqual_41 returns whether this and that are equal.
-func deriveTeleportEqual_41(this, that *AppAWSRolesAnywhereProfile) bool {
-	return (this == nil && that == nil) ||
-		this != nil && that != nil &&
-			this.ProfileARN == that.ProfileARN &&
-			this.AcceptRoleSessionName == that.AcceptRoleSessionName
-}
-
-// deriveTeleportEqual_42 returns whether this and that are equal.
-func deriveTeleportEqual_42(this, that []*IdentityCenterPermissionSet) bool {
+func deriveTeleportEqual_39(this, that []*OktaAssignmentTargetV1) bool {
 	if this == nil || that == nil {
 		return this == nil && that == nil
 	}
@@ -704,16 +666,81 @@ func deriveTeleportEqual_42(this, that []*IdentityCenterPermissionSet) bool {
 	return true
 }
 
+// deriveTeleportEqual_40 returns whether this and that are equal.
+func deriveTeleportEqual_40(this, that *CommandLabelV2) bool {
+	return (this == nil && that == nil) ||
+		this != nil && that != nil &&
+			this.Period == that.Period &&
+			deriveTeleportEqual_24(this.Command, that.Command) &&
+			this.Result == that.Result
+}
+
+// deriveTeleportEqual_41 returns whether this and that are equal.
+func deriveTeleportEqual_41(this, that []*Header) bool {
+	if this == nil || that == nil {
+		return this == nil && that == nil
+	}
+	if len(this) != len(that) {
+		return false
+	}
+	for i := 0; i < len(this); i++ {
+		if !(deriveTeleportEqual_49(this[i], that[i])) {
+			return false
+		}
+	}
+	return true
+}
+
+// deriveTeleportEqual_42 returns whether this and that are equal.
+func deriveTeleportEqual_42(this, that *AppAWSRolesAnywhereProfile) bool {
+	return (this == nil && that == nil) ||
+		this != nil && that != nil &&
+			this.ProfileARN == that.ProfileARN &&
+			this.AcceptRoleSessionName == that.AcceptRoleSessionName
+}
+
 // deriveTeleportEqual_43 returns whether this and that are equal.
-func deriveTeleportEqual_43(this, that *PortRange) bool {
+func deriveTeleportEqual_43(this, that []*IdentityCenterPermissionSet) bool {
+	if this == nil || that == nil {
+		return this == nil && that == nil
+	}
+	if len(this) != len(that) {
+		return false
+	}
+	for i := 0; i < len(this); i++ {
+		if !(deriveTeleportEqual_50(this[i], that[i])) {
+			return false
+		}
+	}
+	return true
+}
+
+// deriveTeleportEqual_44 returns whether this and that are equal.
+func deriveTeleportEqual_44(this, that *PortRange) bool {
 	return (this == nil && that == nil) ||
 		this != nil && that != nil &&
 			this.Port == that.Port &&
 			this.EndPort == that.EndPort
 }
 
-// deriveTeleportEqual_44 returns whether this and that are equal.
-func deriveTeleportEqual_44(this, that *AssumeRole) bool {
+// deriveTeleportEqual_45 returns whether this and that are equal.
+func deriveTeleportEqual_45(this, that []*LLM_Model) bool {
+	if this == nil || that == nil {
+		return this == nil && that == nil
+	}
+	if len(this) != len(that) {
+		return false
+	}
+	for i := 0; i < len(this); i++ {
+		if !(deriveTeleportEqual_51(this[i], that[i])) {
+			return false
+		}
+	}
+	return true
+}
+
+// deriveTeleportEqual_46 returns whether this and that are equal.
+func deriveTeleportEqual_46(this, that *AssumeRole) bool {
 	return (this == nil && that == nil) ||
 		this != nil && that != nil &&
 			this.RoleARN == that.RoleARN &&
@@ -721,8 +748,8 @@ func deriveTeleportEqual_44(this, that *AssumeRole) bool {
 			this.RoleName == that.RoleName
 }
 
-// deriveTeleportEqual_45 returns whether this and that are equal.
-func deriveTeleportEqual_45(this, that *RotationSchedule) bool {
+// deriveTeleportEqual_47 returns whether this and that are equal.
+func deriveTeleportEqual_47(this, that *RotationSchedule) bool {
 	return (this == nil && that == nil) ||
 		this != nil && that != nil &&
 			this.UpdateClients.Equal(that.UpdateClients) &&
@@ -730,27 +757,35 @@ func deriveTeleportEqual_45(this, that *RotationSchedule) bool {
 			this.Standby.Equal(that.Standby)
 }
 
-// deriveTeleportEqual_46 returns whether this and that are equal.
-func deriveTeleportEqual_46(this, that *OktaAssignmentTargetV1) bool {
+// deriveTeleportEqual_48 returns whether this and that are equal.
+func deriveTeleportEqual_48(this, that *OktaAssignmentTargetV1) bool {
 	return (this == nil && that == nil) ||
 		this != nil && that != nil &&
 			this.Type == that.Type &&
 			this.Id == that.Id
 }
 
-// deriveTeleportEqual_47 returns whether this and that are equal.
-func deriveTeleportEqual_47(this, that *Header) bool {
+// deriveTeleportEqual_49 returns whether this and that are equal.
+func deriveTeleportEqual_49(this, that *Header) bool {
 	return (this == nil && that == nil) ||
 		this != nil && that != nil &&
 			this.Name == that.Name &&
 			this.Value == that.Value
 }
 
-// deriveTeleportEqual_48 returns whether this and that are equal.
-func deriveTeleportEqual_48(this, that *IdentityCenterPermissionSet) bool {
+// deriveTeleportEqual_50 returns whether this and that are equal.
+func deriveTeleportEqual_50(this, that *IdentityCenterPermissionSet) bool {
 	return (this == nil && that == nil) ||
 		this != nil && that != nil &&
 			this.ARN == that.ARN &&
 			this.Name == that.Name &&
 			this.AssignmentID == that.AssignmentID
+}
+
+// deriveTeleportEqual_51 returns whether this and that are equal.
+func deriveTeleportEqual_51(this, that *LLM_Model) bool {
+	return (this == nil && that == nil) ||
+		this != nil && that != nil &&
+			this.Name == that.Name &&
+			this.ProviderName == that.ProviderName
 }

--- a/api/types/resource.go
+++ b/api/types/resource.go
@@ -550,6 +550,8 @@ func MatchKinds(resource ResourceWithLabels, kinds []string) bool {
 		// MCP server resources are subkinds of app resources, but it is
 		// possible for certain APIs like ListUnifiedResources to use KindMCP as
 		// a kind filter.
+		//
+		// TODO(gabrielcorado): support LLM subkind.
 		return resource.GetSubKind() == SubKindMCP && slices.Contains(kinds, KindMCP)
 	case KindSAMLIdPServiceProvider, KindIdentityCenterAccount:
 		return slices.Contains(kinds, KindApp)

--- a/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-appsv3.mdx
+++ b/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-appsv3.mdx
@@ -31,6 +31,7 @@ resource, which you can apply after installing the Teleport Kubernetes operator.
 |cors|[object](#speccors)|CORSPolicy defines the Cross-Origin Resource Sharing settings for the app.|
 |dynamic_labels|[object](#specdynamic_labels)|DynamicLabels are the app's command labels.|
 |identity_center|[object](#specidentity_center)|IdentityCenter encapsulates information specific to AWS IAM Identity Center. Only valid for Identity Center account apps.|
+|inference|[object](#specinference)|LLM contains LLM inference endpoint related configurations.|
 |insecure_skip_verify|boolean|InsecureSkipVerify disables app's TLS certificate verification.|
 |integration|string|Integration is the integration name that must be used to access this Application. Only applicable to AWS App Access. If present, the Application must use the Integration's credentials instead of ambient credentials to access Cloud APIs.|
 |mcp|[object](#specmcp)|MCP contains MCP server related configurations.|
@@ -95,6 +96,22 @@ resource, which you can apply after installing the Teleport Kubernetes operator.
 |arn|string|ARN is the fully-formed ARN of the Permission Set.|
 |assignment_name|string|AssignmentID is the ID of the Teleport Account Assignment resource that represents this permission being assigned on the enclosing Account.|
 |name|string|Name is the human-readable name of the Permission Set.|
+
+### spec.inference
+
+|Field|Type|Description|
+|---|---|---|
+|fallback_model|string|Defines a model that will be used if the model requested is not on the list. The fallback model must be in the "models" list.|
+|format|string|Defines the LLM inference API format.|
+|models|[][object](#specinferencemodels-items)|Defines the list of supported models, and optionally their name on the inference provider.|
+|provider|string|Defines which inference provider will be used to serve the requests.|
+
+### spec.inference.models items
+
+|Field|Type|Description|
+|---|---|---|
+|name|string||
+|provider_name|string||
 
 ### spec.mcp
 

--- a/docs/pages/reference/infrastructure-as-code/teleport-resources/app-server-v3.mdx
+++ b/docs/pages/reference/infrastructure-as-code/teleport-resources/app-server-v3.mdx
@@ -176,6 +176,7 @@ tcp_ports:
   - # [...]
 use_any_proxy_public_addr: true
 mcp: # [...]
+inference: # [...]
 ```
 
 |Field Name|Description|Type|
@@ -186,6 +187,7 @@ mcp: # [...]
 |cors|Policy defines the Cross-Origin Resource Sharing settings for the app.|[CORS Policy](#cors-policy)|
 |dynamic_labels|The app's command labels.|map[string][Command Label V2](#command-label-v2)|
 |identity_center|Encapsulates information specific to AWS IAM Identity Center. Only valid for Identity Center account apps.|[App Identity Center](#app-identity-center)|
+|inference|Contains LLM inference endpoint related configurations.|[LLM](#llm)|
 |insecure_skip_verify|Disables app's TLS certificate verification.|Boolean|
 |integration|The integration name that must be used to access this Application. Only applicable to AWS App Access. If present, the Application must use the Integration's credentials instead of ambient credentials to access Cloud APIs.|string|
 |mcp|Contains MCP server related configurations.|[MCP](#mcp)|
@@ -341,6 +343,47 @@ assignment_name: "string"
 |arn|The fully-formed ARN of the Permission Set.|string|
 |assignment_name|The ID of the Teleport Account Assignment resource that represents this permission being assigned on the enclosing Account.|string|
 |name|The human-readable name of the Permission Set.|string|
+
+## LLM
+
+Contains LLM inference endpoint related configurations.
+
+
+Example:
+
+```yaml
+format: "string"
+provider: "string"
+models: 
+  - # [...]
+  - # [...]
+  - # [...]
+fallback_model: "string"
+```
+
+|Field Name|Description|Type|
+|---|---|---|
+|fallback_model|Defines a model that will be used if the model requested is not on the list. The fallback model must be in the "models" list.|string|
+|format|Defines the LLM inference API format.|string|
+|models|Defines the list of supported models, and optionally their name on the inference provider.|[][LLM_Model](#llm_model)|
+|provider|Defines which inference provider will be used to serve the requests.|string|
+
+## LLM_Model
+
+Model is a provider model definition.
+
+
+Example:
+
+```yaml
+name: "string"
+provider_name: "string"
+```
+
+|Field Name|Description|Type|
+|---|---|---|
+|name|Defines the model name. This is the requested value.|string|
+|provider_name|Represents the model name in the configured provider.|string|
 
 ## MCP
 

--- a/docs/pages/reference/infrastructure-as-code/teleport-resources/app-v3.mdx
+++ b/docs/pages/reference/infrastructure-as-code/teleport-resources/app-v3.mdx
@@ -135,6 +135,7 @@ tcp_ports:
   - # [...]
 use_any_proxy_public_addr: true
 mcp: # [...]
+inference: # [...]
 ```
 
 |Field Name|Description|Type|
@@ -145,6 +146,7 @@ mcp: # [...]
 |cors|Policy defines the Cross-Origin Resource Sharing settings for the app.|[CORS Policy](#cors-policy)|
 |dynamic_labels|The app's command labels.|map[string][Command Label V2](#command-label-v2)|
 |identity_center|Encapsulates information specific to AWS IAM Identity Center. Only valid for Identity Center account apps.|[App Identity Center](#app-identity-center)|
+|inference|Contains LLM inference endpoint related configurations.|[LLM](#llm)|
 |insecure_skip_verify|Disables app's TLS certificate verification.|Boolean|
 |integration|The integration name that must be used to access this Application. Only applicable to AWS App Access. If present, the Application must use the Integration's credentials instead of ambient credentials to access Cloud APIs.|string|
 |mcp|Contains MCP server related configurations.|[MCP](#mcp)|
@@ -254,6 +256,47 @@ assignment_name: "string"
 |arn|The fully-formed ARN of the Permission Set.|string|
 |assignment_name|The ID of the Teleport Account Assignment resource that represents this permission being assigned on the enclosing Account.|string|
 |name|The human-readable name of the Permission Set.|string|
+
+## LLM
+
+Contains LLM inference endpoint related configurations.
+
+
+Example:
+
+```yaml
+format: "string"
+provider: "string"
+models: 
+  - # [...]
+  - # [...]
+  - # [...]
+fallback_model: "string"
+```
+
+|Field Name|Description|Type|
+|---|---|---|
+|fallback_model|Defines a model that will be used if the model requested is not on the list. The fallback model must be in the "models" list.|string|
+|format|Defines the LLM inference API format.|string|
+|models|Defines the list of supported models, and optionally their name on the inference provider.|[][LLM_Model](#llm_model)|
+|provider|Defines which inference provider will be used to serve the requests.|string|
+
+## LLM_Model
+
+Model is a provider model definition.
+
+
+Example:
+
+```yaml
+name: "string"
+provider_name: "string"
+```
+
+|Field Name|Description|Type|
+|---|---|---|
+|name|Defines the model name. This is the requested value.|string|
+|provider_name|Represents the model name in the configured provider.|string|
 
 ## MCP
 

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/app.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/app.mdx
@@ -49,6 +49,7 @@ Optional:
 - `cors` (Attributes) CORSPolicy defines the Cross-Origin Resource Sharing settings for the app. (see [below for nested schema](#nested-schema-for-speccors))
 - `dynamic_labels` (Attributes Map) DynamicLabels are the app's command labels. (see [below for nested schema](#nested-schema-for-specdynamic_labels))
 - `identity_center` (Attributes) IdentityCenter encapsulates information specific to AWS IAM Identity Center. Only valid for Identity Center account apps. (see [below for nested schema](#nested-schema-for-specidentity_center))
+- `inference` (Attributes) LLM contains LLM inference endpoint related configurations. (see [below for nested schema](#nested-schema-for-specinference))
 - `insecure_skip_verify` (Boolean) InsecureSkipVerify disables app's TLS certificate verification.
 - `integration` (String) Integration is the integration name that must be used to access this Application. Only applicable to AWS App Access. If present, the Application must use the Integration's credentials instead of ambient credentials to access Cloud APIs.
 - `mcp` (Attributes) MCP contains MCP server related configurations. (see [below for nested schema](#nested-schema-for-specmcp))
@@ -111,6 +112,24 @@ Optional:
 - `arn` (String) ARN is the fully-formed ARN of the Permission Set.
 - `assignment_name` (String) AssignmentID is the ID of the Teleport Account Assignment resource that represents this permission being assigned on the enclosing Account.
 - `name` (String) Name is the human-readable name of the Permission Set.
+
+
+
+### Nested Schema for `spec.inference`
+
+Optional:
+
+- `fallback_model` (String) Defines a model that will be used if the model requested is not on the list. The fallback model must be in the "models" list.
+- `format` (String) Defines the LLM inference API format.
+- `models` (Attributes List) Defines the list of supported models, and optionally their name on the inference provider. (see [below for nested schema](#nested-schema-for-specinferencemodels))
+- `provider` (String) Defines which inference provider will be used to serve the requests.
+
+### Nested Schema for `spec.inference.models`
+
+Optional:
+
+- `name` (String) Name defines the model name. This is the requested value.
+- `provider_name` (String) Represents the model name in the configured provider.
 
 
 

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/app.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/app.mdx
@@ -68,6 +68,7 @@ Optional:
 - `cors` (Attributes) CORSPolicy defines the Cross-Origin Resource Sharing settings for the app. (see [below for nested schema](#nested-schema-for-speccors))
 - `dynamic_labels` (Attributes Map) DynamicLabels are the app's command labels. (see [below for nested schema](#nested-schema-for-specdynamic_labels))
 - `identity_center` (Attributes) IdentityCenter encapsulates information specific to AWS IAM Identity Center. Only valid for Identity Center account apps. (see [below for nested schema](#nested-schema-for-specidentity_center))
+- `inference` (Attributes) LLM contains LLM inference endpoint related configurations. (see [below for nested schema](#nested-schema-for-specinference))
 - `insecure_skip_verify` (Boolean) InsecureSkipVerify disables app's TLS certificate verification.
 - `integration` (String) Integration is the integration name that must be used to access this Application. Only applicable to AWS App Access. If present, the Application must use the Integration's credentials instead of ambient credentials to access Cloud APIs.
 - `mcp` (Attributes) MCP contains MCP server related configurations. (see [below for nested schema](#nested-schema-for-specmcp))
@@ -130,6 +131,24 @@ Optional:
 - `arn` (String) ARN is the fully-formed ARN of the Permission Set.
 - `assignment_name` (String) AssignmentID is the ID of the Teleport Account Assignment resource that represents this permission being assigned on the enclosing Account.
 - `name` (String) Name is the human-readable name of the Permission Set.
+
+
+
+### Nested Schema for `spec.inference`
+
+Optional:
+
+- `fallback_model` (String) Defines a model that will be used if the model requested is not on the list. The fallback model must be in the "models" list.
+- `format` (String) Defines the LLM inference API format.
+- `models` (Attributes List) Defines the list of supported models, and optionally their name on the inference provider. (see [below for nested schema](#nested-schema-for-specinferencemodels))
+- `provider` (String) Defines which inference provider will be used to serve the requests.
+
+### Nested Schema for `spec.inference.models`
+
+Optional:
+
+- `name` (String) Name defines the model name. This is the requested value.
+- `provider_name` (String) Represents the model name in the configured provider.
 
 
 

--- a/examples/chart/teleport-cluster/charts/teleport-operator/operator-crds/resources.teleport.dev_appsv3.yaml
+++ b/examples/chart/teleport-cluster/charts/teleport-operator/operator-crds/resources.teleport.dev_appsv3.yaml
@@ -166,6 +166,35 @@ spec:
                     nullable: true
                     type: array
                 type: object
+              inference:
+                description: LLM contains LLM inference endpoint related configurations.
+                nullable: true
+                properties:
+                  fallback_model:
+                    description: Defines a model that will be used if the model requested
+                      is not on the list. The fallback model must be in the "models"
+                      list.
+                    type: string
+                  format:
+                    description: Defines the LLM inference API format.
+                    type: string
+                  models:
+                    description: Defines the list of supported models, and optionally
+                      their name on the inference provider.
+                    items:
+                      properties:
+                        name:
+                          type: string
+                        provider_name:
+                          type: string
+                      type: object
+                    nullable: true
+                    type: array
+                  provider:
+                    description: Defines which inference provider will be used to
+                      serve the requests.
+                    type: string
+                type: object
               insecure_skip_verify:
                 description: InsecureSkipVerify disables app's TLS certificate verification.
                 type: boolean

--- a/integrations/operator/config/crd/bases/resources.teleport.dev_appsv3.yaml
+++ b/integrations/operator/config/crd/bases/resources.teleport.dev_appsv3.yaml
@@ -166,6 +166,35 @@ spec:
                     nullable: true
                     type: array
                 type: object
+              inference:
+                description: LLM contains LLM inference endpoint related configurations.
+                nullable: true
+                properties:
+                  fallback_model:
+                    description: Defines a model that will be used if the model requested
+                      is not on the list. The fallback model must be in the "models"
+                      list.
+                    type: string
+                  format:
+                    description: Defines the LLM inference API format.
+                    type: string
+                  models:
+                    description: Defines the list of supported models, and optionally
+                      their name on the inference provider.
+                    items:
+                      properties:
+                        name:
+                          type: string
+                        provider_name:
+                          type: string
+                      type: object
+                    nullable: true
+                    type: array
+                  provider:
+                    description: Defines which inference provider will be used to
+                      serve the requests.
+                    type: string
+                type: object
               insecure_skip_verify:
                 description: InsecureSkipVerify disables app's TLS certificate verification.
                 type: boolean

--- a/integrations/terraform/tfschema/types_terraform.go
+++ b/integrations/terraform/tfschema/types_terraform.go
@@ -1032,6 +1032,43 @@ func GenSchemaAppV3(ctx context.Context) (github_com_hashicorp_terraform_plugin_
 					Description: "IdentityCenter encapsulates information specific to AWS IAM Identity Center. Only valid for Identity Center account apps.",
 					Optional:    true,
 				},
+				"inference": {
+					Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.SingleNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
+						"fallback_model": {
+							Description: "Defines a model that will be used if the model requested is not on the list. The fallback model must be in the \"models\" list.",
+							Optional:    true,
+							Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
+						},
+						"format": {
+							Description: "Defines the LLM inference API format.",
+							Optional:    true,
+							Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
+						},
+						"models": {
+							Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.ListNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
+								"name": {
+									Description: "Name defines the model name. This is the requested value.",
+									Optional:    true,
+									Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
+								},
+								"provider_name": {
+									Description: "Represents the model name in the configured provider.",
+									Optional:    true,
+									Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
+								},
+							}),
+							Description: "Defines the list of supported models, and optionally their name on the inference provider.",
+							Optional:    true,
+						},
+						"provider": {
+							Description: "Defines which inference provider will be used to serve the requests.",
+							Optional:    true,
+							Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
+						},
+					}),
+					Description: "LLM contains LLM inference endpoint related configurations.",
+					Optional:    true,
+				},
 				"insecure_skip_verify": {
 					Description: "InsecureSkipVerify disables app's TLS certificate verification.",
 					Optional:    true,
@@ -13596,6 +13633,138 @@ func CopyAppV3FromTerraform(_ context.Context, tf github_com_hashicorp_terraform
 							}
 						}
 					}
+					{
+						a, ok := tf.Attrs["inference"]
+						if !ok {
+							diags.Append(attrReadMissingDiag{"AppV3.Spec.LLM"})
+						} else {
+							v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.Object)
+							if !ok {
+								diags.Append(attrReadConversionFailureDiag{"AppV3.Spec.LLM", "github.com/hashicorp/terraform-plugin-framework/types.Object"})
+							} else {
+								obj.LLM = nil
+								if !v.Null && !v.Unknown {
+									tf := v
+									obj.LLM = &github_com_gravitational_teleport_api_types.LLM{}
+									obj := obj.LLM
+									{
+										a, ok := tf.Attrs["format"]
+										if !ok {
+											diags.Append(attrReadMissingDiag{"AppV3.Spec.LLM.format"})
+										} else {
+											v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.String)
+											if !ok {
+												diags.Append(attrReadConversionFailureDiag{"AppV3.Spec.LLM.format", "github.com/hashicorp/terraform-plugin-framework/types.String"})
+											} else {
+												var t string
+												if !v.Null && !v.Unknown {
+													t = string(v.Value)
+												}
+												obj.Format = t
+											}
+										}
+									}
+									{
+										a, ok := tf.Attrs["provider"]
+										if !ok {
+											diags.Append(attrReadMissingDiag{"AppV3.Spec.LLM.provider"})
+										} else {
+											v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.String)
+											if !ok {
+												diags.Append(attrReadConversionFailureDiag{"AppV3.Spec.LLM.provider", "github.com/hashicorp/terraform-plugin-framework/types.String"})
+											} else {
+												var t string
+												if !v.Null && !v.Unknown {
+													t = string(v.Value)
+												}
+												obj.Provider = t
+											}
+										}
+									}
+									{
+										a, ok := tf.Attrs["models"]
+										if !ok {
+											diags.Append(attrReadMissingDiag{"AppV3.Spec.LLM.models"})
+										} else {
+											v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.List)
+											if !ok {
+												diags.Append(attrReadConversionFailureDiag{"AppV3.Spec.LLM.models", "github.com/hashicorp/terraform-plugin-framework/types.List"})
+											} else {
+												obj.Models = make([]*github_com_gravitational_teleport_api_types.LLM_Model, len(v.Elems))
+												if !v.Null && !v.Unknown {
+													for k, a := range v.Elems {
+														v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.Object)
+														if !ok {
+															diags.Append(attrReadConversionFailureDiag{"AppV3.Spec.LLM.models", "github_com_hashicorp_terraform_plugin_framework_types.Object"})
+														} else {
+															var t *github_com_gravitational_teleport_api_types.LLM_Model
+															if !v.Null && !v.Unknown {
+																tf := v
+																t = &github_com_gravitational_teleport_api_types.LLM_Model{}
+																obj := t
+																{
+																	a, ok := tf.Attrs["name"]
+																	if !ok {
+																		diags.Append(attrReadMissingDiag{"AppV3.Spec.LLM.models.name"})
+																	} else {
+																		v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.String)
+																		if !ok {
+																			diags.Append(attrReadConversionFailureDiag{"AppV3.Spec.LLM.models.name", "github.com/hashicorp/terraform-plugin-framework/types.String"})
+																		} else {
+																			var t string
+																			if !v.Null && !v.Unknown {
+																				t = string(v.Value)
+																			}
+																			obj.Name = t
+																		}
+																	}
+																}
+																{
+																	a, ok := tf.Attrs["provider_name"]
+																	if !ok {
+																		diags.Append(attrReadMissingDiag{"AppV3.Spec.LLM.models.provider_name"})
+																	} else {
+																		v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.String)
+																		if !ok {
+																			diags.Append(attrReadConversionFailureDiag{"AppV3.Spec.LLM.models.provider_name", "github.com/hashicorp/terraform-plugin-framework/types.String"})
+																		} else {
+																			var t string
+																			if !v.Null && !v.Unknown {
+																				t = string(v.Value)
+																			}
+																			obj.ProviderName = t
+																		}
+																	}
+																}
+															}
+															obj.Models[k] = t
+														}
+													}
+												}
+											}
+										}
+									}
+									{
+										a, ok := tf.Attrs["fallback_model"]
+										if !ok {
+											diags.Append(attrReadMissingDiag{"AppV3.Spec.LLM.fallback_model"})
+										} else {
+											v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.String)
+											if !ok {
+												diags.Append(attrReadConversionFailureDiag{"AppV3.Spec.LLM.fallback_model", "github.com/hashicorp/terraform-plugin-framework/types.String"})
+											} else {
+												var t string
+												if !v.Null && !v.Unknown {
+													t = string(v.Value)
+												}
+												obj.FallbackModel = t
+											}
+										}
+									}
+								}
+							}
+						}
+					}
 				}
 			}
 		}
@@ -15317,6 +15486,206 @@ func CopyAppV3ToTerraform(ctx context.Context, obj *github_com_gravitational_tel
 								}
 								v.Unknown = false
 								tf.Attrs["mcp"] = v
+							}
+						}
+					}
+					{
+						a, ok := tf.AttrTypes["inference"]
+						if !ok {
+							diags.Append(attrWriteMissingDiag{"AppV3.Spec.LLM"})
+						} else {
+							o, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.ObjectType)
+							if !ok {
+								diags.Append(attrWriteConversionFailureDiag{"AppV3.Spec.LLM", "github.com/hashicorp/terraform-plugin-framework/types.ObjectType"})
+							} else {
+								v, ok := tf.Attrs["inference"].(github_com_hashicorp_terraform_plugin_framework_types.Object)
+								if !ok {
+									v = github_com_hashicorp_terraform_plugin_framework_types.Object{
+
+										AttrTypes: o.AttrTypes,
+										Attrs:     make(map[string]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(o.AttrTypes)),
+									}
+								} else {
+									if v.Attrs == nil {
+										v.Attrs = make(map[string]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(tf.AttrTypes))
+									}
+								}
+								if obj.LLM == nil {
+									v.Null = true
+								} else {
+									obj := obj.LLM
+									tf := &v
+									{
+										t, ok := tf.AttrTypes["format"]
+										if !ok {
+											diags.Append(attrWriteMissingDiag{"AppV3.Spec.LLM.format"})
+										} else {
+											v, ok := tf.Attrs["format"].(github_com_hashicorp_terraform_plugin_framework_types.String)
+											if !ok {
+												i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
+												if err != nil {
+													diags.Append(attrWriteGeneralError{"AppV3.Spec.LLM.format", err})
+												}
+												v, ok = i.(github_com_hashicorp_terraform_plugin_framework_types.String)
+												if !ok {
+													diags.Append(attrWriteConversionFailureDiag{"AppV3.Spec.LLM.format", "github.com/hashicorp/terraform-plugin-framework/types.String"})
+												}
+												v.Null = string(obj.Format) == ""
+											}
+											v.Value = string(obj.Format)
+											v.Unknown = false
+											tf.Attrs["format"] = v
+										}
+									}
+									{
+										t, ok := tf.AttrTypes["provider"]
+										if !ok {
+											diags.Append(attrWriteMissingDiag{"AppV3.Spec.LLM.provider"})
+										} else {
+											v, ok := tf.Attrs["provider"].(github_com_hashicorp_terraform_plugin_framework_types.String)
+											if !ok {
+												i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
+												if err != nil {
+													diags.Append(attrWriteGeneralError{"AppV3.Spec.LLM.provider", err})
+												}
+												v, ok = i.(github_com_hashicorp_terraform_plugin_framework_types.String)
+												if !ok {
+													diags.Append(attrWriteConversionFailureDiag{"AppV3.Spec.LLM.provider", "github.com/hashicorp/terraform-plugin-framework/types.String"})
+												}
+												v.Null = string(obj.Provider) == ""
+											}
+											v.Value = string(obj.Provider)
+											v.Unknown = false
+											tf.Attrs["provider"] = v
+										}
+									}
+									{
+										a, ok := tf.AttrTypes["models"]
+										if !ok {
+											diags.Append(attrWriteMissingDiag{"AppV3.Spec.LLM.models"})
+										} else {
+											o, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.ListType)
+											if !ok {
+												diags.Append(attrWriteConversionFailureDiag{"AppV3.Spec.LLM.models", "github.com/hashicorp/terraform-plugin-framework/types.ListType"})
+											} else {
+												c, ok := tf.Attrs["models"].(github_com_hashicorp_terraform_plugin_framework_types.List)
+												if !ok {
+													c = github_com_hashicorp_terraform_plugin_framework_types.List{
+
+														ElemType: o.ElemType,
+														Elems:    make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.Models)),
+														Null:     true,
+													}
+												} else {
+													if c.Elems == nil {
+														c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.Models))
+													}
+												}
+												if obj.Models != nil {
+													o := o.ElemType.(github_com_hashicorp_terraform_plugin_framework_types.ObjectType)
+													if len(obj.Models) != len(c.Elems) {
+														c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.Models))
+													}
+													for k, a := range obj.Models {
+														v, ok := tf.Attrs["models"].(github_com_hashicorp_terraform_plugin_framework_types.Object)
+														if !ok {
+															v = github_com_hashicorp_terraform_plugin_framework_types.Object{
+
+																AttrTypes: o.AttrTypes,
+																Attrs:     make(map[string]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(o.AttrTypes)),
+															}
+														} else {
+															if v.Attrs == nil {
+																v.Attrs = make(map[string]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(tf.AttrTypes))
+															}
+														}
+														if a == nil {
+															v.Null = true
+														} else {
+															obj := a
+															tf := &v
+															{
+																t, ok := tf.AttrTypes["name"]
+																if !ok {
+																	diags.Append(attrWriteMissingDiag{"AppV3.Spec.LLM.models.name"})
+																} else {
+																	v, ok := tf.Attrs["name"].(github_com_hashicorp_terraform_plugin_framework_types.String)
+																	if !ok {
+																		i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
+																		if err != nil {
+																			diags.Append(attrWriteGeneralError{"AppV3.Spec.LLM.models.name", err})
+																		}
+																		v, ok = i.(github_com_hashicorp_terraform_plugin_framework_types.String)
+																		if !ok {
+																			diags.Append(attrWriteConversionFailureDiag{"AppV3.Spec.LLM.models.name", "github.com/hashicorp/terraform-plugin-framework/types.String"})
+																		}
+																		v.Null = string(obj.Name) == ""
+																	}
+																	v.Value = string(obj.Name)
+																	v.Unknown = false
+																	tf.Attrs["name"] = v
+																}
+															}
+															{
+																t, ok := tf.AttrTypes["provider_name"]
+																if !ok {
+																	diags.Append(attrWriteMissingDiag{"AppV3.Spec.LLM.models.provider_name"})
+																} else {
+																	v, ok := tf.Attrs["provider_name"].(github_com_hashicorp_terraform_plugin_framework_types.String)
+																	if !ok {
+																		i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
+																		if err != nil {
+																			diags.Append(attrWriteGeneralError{"AppV3.Spec.LLM.models.provider_name", err})
+																		}
+																		v, ok = i.(github_com_hashicorp_terraform_plugin_framework_types.String)
+																		if !ok {
+																			diags.Append(attrWriteConversionFailureDiag{"AppV3.Spec.LLM.models.provider_name", "github.com/hashicorp/terraform-plugin-framework/types.String"})
+																		}
+																		v.Null = string(obj.ProviderName) == ""
+																	}
+																	v.Value = string(obj.ProviderName)
+																	v.Unknown = false
+																	tf.Attrs["provider_name"] = v
+																}
+															}
+														}
+														v.Unknown = false
+														c.Elems[k] = v
+													}
+													if len(obj.Models) > 0 {
+														c.Null = false
+													}
+												}
+												c.Unknown = false
+												tf.Attrs["models"] = c
+											}
+										}
+									}
+									{
+										t, ok := tf.AttrTypes["fallback_model"]
+										if !ok {
+											diags.Append(attrWriteMissingDiag{"AppV3.Spec.LLM.fallback_model"})
+										} else {
+											v, ok := tf.Attrs["fallback_model"].(github_com_hashicorp_terraform_plugin_framework_types.String)
+											if !ok {
+												i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
+												if err != nil {
+													diags.Append(attrWriteGeneralError{"AppV3.Spec.LLM.fallback_model", err})
+												}
+												v, ok = i.(github_com_hashicorp_terraform_plugin_framework_types.String)
+												if !ok {
+													diags.Append(attrWriteConversionFailureDiag{"AppV3.Spec.LLM.fallback_model", "github.com/hashicorp/terraform-plugin-framework/types.String"})
+												}
+												v.Null = string(obj.FallbackModel) == ""
+											}
+											v.Value = string(obj.FallbackModel)
+											v.Unknown = false
+											tf.Attrs["fallback_model"] = v
+										}
+									}
+								}
+								v.Unknown = false
+								tf.Attrs["inference"] = v
 							}
 						}
 					}

--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -1393,6 +1393,7 @@ func (a *ServerWithRoles) checkAction(namespace, resourceKind string, verb strin
 var (
 	// supportedUnifiedResourceKinds is the set of kinds that
 	// may be requested via ListUnifiedResources.
+	// TODO(gabrielcorado): add LLM app subkind.
 	supportedUnifiedResourceKinds = map[string]struct{}{
 		types.KindApp:                    {},
 		types.KindDatabase:               {},
@@ -1409,6 +1410,7 @@ var (
 
 func (a *ServerWithRoles) checkKindAccess(kind string) error {
 	// MCP are apps internally atm.
+	// TODO(gabrielcorado): add support for LLM subkind.
 	if kind == types.KindMCP {
 		kind = types.KindApp
 	}

--- a/lib/config/configuration.go
+++ b/lib/config/configuration.go
@@ -2154,6 +2154,21 @@ func applyAppsConfig(fc *FileConfig, cfg *servicecfg.Config) error {
 			}
 		}
 
+		if application.LLM != nil {
+			app.LLM = &types.LLM{
+				Format:        application.LLM.Format,
+				Provider:      application.LLM.Provider,
+				FallbackModel: application.LLM.FallbackModel,
+			}
+			app.LLM.Models = make([]*types.LLM_Model, 0, len(application.LLM.Models))
+			for _, model := range application.LLM.Models {
+				app.LLM.Models = append(app.LLM.Models, &types.LLM_Model{
+					Name:         model.Name,
+					ProviderName: model.ProviderName,
+				})
+			}
+		}
+
 		if err := app.CheckAndSetDefaults(); err != nil {
 			return trace.Wrap(err)
 		}

--- a/lib/config/configuration_test.go
+++ b/lib/config/configuration_test.go
@@ -458,6 +458,21 @@ func TestConfigReading(t *testing.T) {
 						Args:          []string{"run", "-i", "--rm", "mcp/everything"},
 					},
 				},
+				{
+					Name:         "anthropic",
+					StaticLabels: Labels,
+					LLM: &LLM{
+						Format:   "anthropic",
+						Provider: "bedrock",
+						Models: []LLMModel{
+							{
+								Name:         "claude-opus-4-6",
+								ProviderName: "arn:bedrock:inference-profile",
+							},
+						},
+						FallbackModel: "claude-opus-4-6",
+					},
+				},
 			},
 			ResourceMatchers: []ResourceMatcher{
 				{
@@ -1666,6 +1681,21 @@ func makeConfigFixture() string {
 				RunAsHostUser: "docker",
 			},
 		},
+		{
+			Name:         "anthropic",
+			StaticLabels: Labels,
+			LLM: &LLM{
+				Format:   "anthropic",
+				Provider: "bedrock",
+				Models: []LLMModel{
+					{
+						Name:         "claude-opus-4-6",
+						ProviderName: "arn:bedrock:inference-profile",
+					},
+				},
+				FallbackModel: "claude-opus-4-6",
+			},
+		},
 	}
 	conf.Apps.ResourceMatchers = []ResourceMatcher{
 		{
@@ -2641,6 +2671,19 @@ app_service:
 `,
 			name:   "TCP app with port bigger than 65535",
 			outErr: require.Error,
+		},
+		{
+			inConfigString: `
+app_service:
+  enabled: true
+  apps:
+    - name: anthropic
+      inference:
+        format: anthropic
+        provider: anthropic
+`,
+			name:   "LLM inference endpoint",
+			outErr: require.NoError,
 		},
 	}
 

--- a/lib/config/fileconf.go
+++ b/lib/config/fileconf.go
@@ -2471,6 +2471,9 @@ type App struct {
 
 	// MCP contains MCP server-related configurations.
 	MCP *MCP `yaml:"mcp,omitempty"`
+
+	// LLM contains LLM inference endpoint related configurations.
+	LLM *LLM `yaml:"inference,omitempty"`
 }
 
 // CORS represents the configuration for Cross-Origin Resource Sharing (CORS)
@@ -2538,6 +2541,29 @@ type MCP struct {
 	// RunAsHostUser is the host user account under which the command will be
 	// executed. Required for stdio-based MCP servers.
 	RunAsHostUser string `yaml:"run_as_host_user,omitempty"`
+}
+
+// LLM contains LLM inference endpoint related configurations.
+type LLM struct {
+	// Format is the LLM inference API format.
+	Format string `yaml:"format"`
+	// Provider is the inference provider that will be used to serve the
+	// requests.
+	Provider string `yaml:"provider"`
+	// Models is the list of supported models, and optionally their name on the
+	// inference provider.
+	Models []LLMModel `yaml:"models,omitempty"`
+	// FallbackModel is a model that will be used if the model requested is not
+	// on the list.
+	FallbackModel string `yaml:"fallback_model,omitempty"`
+}
+
+// LLMModel is a provider model definition.
+type LLMModel struct {
+	// Name defines the model name.
+	Name string `yaml:"name"`
+	// ProviderName is the model name in the configured provider.
+	ProviderName string `yaml:"provider_name,omitempty"`
 }
 
 // Proxy is a `proxy_service` section of the config file:

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -6756,6 +6756,7 @@ func (process *TeleportProcess) initApps() {
 				CORS:                  makeApplicationCORS(app.CORS),
 				TCPPorts:              makeApplicationTCPPorts(app.TCPPorts),
 				MCP:                   app.MCP,
+				LLM:                   app.LLM,
 			})
 			if err != nil {
 				return trace.Wrap(err)

--- a/lib/service/servicecfg/app.go
+++ b/lib/service/servicecfg/app.go
@@ -114,6 +114,9 @@ type App struct {
 
 	// MCP contains MCP server-related configurations.
 	MCP *types.MCP
+
+	// LLM contains LLM inference endpoint related configurations.
+	LLM *types.LLM
 }
 
 // CORS represents the configuration for Cross-Origin Resource Sharing (CORS)
@@ -157,6 +160,9 @@ type PortRange struct {
 }
 
 // CheckAndSetDefaults validates an application.
+//
+// Note: full app validation happens after conversion to `types.AppV3` so static
+// and dynamic registration share the same validation rules.
 func (a *App) CheckAndSetDefaults() error {
 	if a.Name == "" {
 		return trace.BadParameter("missing application name")
@@ -167,6 +173,8 @@ func (a *App) CheckAndSetDefaults() error {
 			a.URI = fmt.Sprintf("cloud://%v", a.Cloud)
 		case a.MCP != nil && a.MCP.Command != "":
 			a.URI = types.SchemeMCPStdio + "://"
+		case a.LLM != nil:
+			a.URI = types.SchemeLLMEndpoint + "://"
 		default:
 			return trace.BadParameter("missing application %q URI", a.Name)
 		}

--- a/lib/services/unified_resource.go
+++ b/lib/services/unified_resource.go
@@ -421,6 +421,8 @@ func (c *UnifiedResourceCache) itemKindMatches(r resource, kinds map[string]stru
 			return true
 		}
 
+		// TODO(gabrielcorado): support LLM subkind.
+
 		_, ok := kinds[types.KindIdentityCenterAccount]
 		return ok
 	case types.KindKubeServer:
@@ -463,6 +465,8 @@ func (c *UnifiedResourceCache) itemKindMatches(r resource, kinds map[string]stru
 				return true
 			}
 		}
+
+		// TODO(gabrielcorado): support LLM subkind.
 		return false
 	default:
 		return false

--- a/lib/srv/app/connections_handler.go
+++ b/lib/srv/app/connections_handler.go
@@ -463,6 +463,10 @@ func (c *ConnectionsHandler) serveHTTP(w http.ResponseWriter, r *http.Request) e
 	case app.IsGCP():
 		return c.serveSession(w, r, &identity, app, c.withGCPHandler)
 
+	// TODO(gabrielcorado): implement inference endpoint handler.
+	case app.IsLLM():
+		return trace.NotImplemented("LLM access is not implemented")
+
 	default:
 		return c.serveSession(w, r, &identity, app, c.withJWTTokenForwarder)
 	}
@@ -623,6 +627,9 @@ func (c *ConnectionsHandler) handleConnection(ctx context.Context, cancel contex
 	// 3. If the application is an HTTP application, store the error and let the HTTP handler
 	//    serve the error directly so that it's properly converted to an HTTP status code.
 	//    This will ensure users will get a 403 when authorization fails.
+	//
+	// Note: LLM doesn't require a special handling. It must work like other
+	// HTTP applications.
 	if err != nil {
 		switch {
 		case app.IsTCP():

--- a/lib/teleterm/services/unifiedresources/unifiedresources.go
+++ b/lib/teleterm/services/unifiedresources/unifiedresources.go
@@ -31,6 +31,7 @@ import (
 	"github.com/gravitational/teleport/lib/teleterm/clusters"
 )
 
+// TODO(gabrielcorado): add support to LLM.
 var supportedResourceKinds = []string{
 	types.KindNode,
 	types.KindDatabase,


### PR DESCRIPTION
Backport https://github.com/gravitational/teleport/pull/65688 to branch/v18

## Manual Test Plan
### Test Environment

Locally hosted cluster with app service joined. Both are using binaries built from this branch.

### Test Cases

- [x] `tctl` CRUD LLM.
- [x] WebUI presents LLM apps as a regular app.
- [x] `tctl` create/update validation errors return correctly.
- [x] `tsh` lists LLM apps.
- [x] Accessing LLM apps is rejected (not implemented error).
  - [x] Public addr
  - [x] Local proxy (`tsh proxy app`)
  - [x] Certificates (`tsh app login`) 
- [x] RBAC for LLM apps follows `app_labels`.