### PR TITLE
Fix GenerateCertificate overriding CommonName on parsed subjects

### DIFF
--- a/lib/tlsca/ca.go
+++ b/lib/tlsca/ca.go
@@ -446,11 +446,18 @@ func (id *Identity) CheckAndSetDefaults() error {
 	return nil
 }
 
-// Custom ranges are taken from this article
-//
-// https://serverfault.com/questions/551477/is-there-reserved-oid-space-for-internal-enterprise-cas
-//
-// http://oid-info.com/get/1.3.9999
+// Custom OID arc used for Teleport-specific certificate attributes.
+var teleportOIDPrefix = asn1.ObjectIdentifier{1, 3, 9999}
+
+// isTeleportOID returns whether the given OID falls under the Teleport-custom
+// arc (1.3.9999).
+func isTeleportOID(oid asn1.ObjectIdentifier) bool {
+	return len(oid) >= len(teleportOIDPrefix) &&
+		oid[0] == teleportOIDPrefix[0] &&
+		oid[1] == teleportOIDPrefix[1] &&
+		oid[2] == teleportOIDPrefix[2]
+}
+
 var (
 	// KubeUsersASN1ExtensionOID is an extension ID used when encoding/decoding
 	// license payload into certificates
@@ -1628,9 +1635,17 @@ func (ca *CertAuthority) GenerateCertificate(req CertificateRequest) ([]byte, er
 
 	// Go deserializes extra names into Names field, but it uses ExtraNames for serialization,
 	// if we have any then we have to copy them over, or they will get lost during another
-	// serialization in x509.CreateCertificate
-	if len(req.Subject.Names) > 0 {
-		req.Subject.ExtraNames = req.Subject.Names
+	// serialization in x509.CreateCertificate.
+	//
+	// However, we must only copy non-standard OIDs (Teleport-custom attributes under 1.3.9999.*).
+	// Standard PKIX attributes (CN, O, OU, etc. under 2.5.4.*) are already handled by
+	// pkix.Name's typed fields and should not be duplicated into ExtraNames; ExtraNames
+	// values take precedence over typed fields during marshaling. This would override the
+	// caller's intended CommonName/Organization values.
+	for _, name := range req.Subject.Names {
+		if isTeleportOID(name.Type) {
+			req.Subject.ExtraNames = append(req.Subject.ExtraNames, name)
+		}
 	}
 
 	template := &x509.Certificate{

--- a/lib/tlsca/ca_test.go
+++ b/lib/tlsca/ca_test.go
@@ -120,7 +120,111 @@ func TestPrincipals(t *testing.T) {
 	}
 }
 
-// TestScopePin verifies the encoding/decoding of the scope pin field.
+// TestGenerateCertificate_ParsedSubject tests that GenerateCertificate
+// correctly handles subjects parsed from existing certificates, where Go
+// populates Names (from deserialization) but not ExtraNames.
+func TestGenerateCertificate_ParsedSubject(t *testing.T) {
+	t.Parallel()
+
+	clock := clockwork.NewFakeClock()
+
+	genKey := func(t *testing.T) crypto.Signer {
+		t.Helper()
+		key, err := cryptosuites.GenerateKeyWithAlgorithm(cryptosuites.ECDSAP256)
+		require.NoError(t, err)
+		return key
+	}
+
+	generateAndParse := func(t *testing.T, ca *CertAuthority, subject pkix.Name, dnsNames ...string) *x509.Certificate {
+		t.Helper()
+		certPEM, err := ca.GenerateCertificate(CertificateRequest{
+			Clock:     clock,
+			PublicKey: genKey(t).Public(),
+			Subject:   subject,
+			NotAfter:  clock.Now().Add(time.Hour),
+			DNSNames:  dnsNames,
+		})
+		require.NoError(t, err)
+		cert, err := ParseCertificatePEM(certPEM)
+		require.NoError(t, err)
+		return cert
+	}
+
+	newSelfSignedCA := func(t *testing.T) *CertAuthority {
+		t.Helper()
+		key := genKey(t)
+		certPEM, err := GenerateSelfSignedCAWithConfig(GenerateCAConfig{
+			Entity: pkix.Name{
+				CommonName:   "localhost",
+				Organization: []string{"Teleport"},
+			},
+			Signer:   key,
+			DNSNames: []string{"localhost"},
+			TTL:      time.Hour,
+		})
+		require.NoError(t, err)
+		keyPEM, err := keys.MarshalPrivateKey(key)
+		require.NoError(t, err)
+		tlsCert, err := tls.X509KeyPair(certPEM, keyPEM)
+		require.NoError(t, err)
+		ca, err := FromTLSCertificate(tlsCert)
+		require.NoError(t, err)
+		return ca
+	}
+
+	// Regression test for GenerateCertificate's blanket Names to ExtraNames copying
+	// caused CA's parsed CN (e.g., "localhost") to override the caller's intended CN,
+	// making child cert's Subject == the CA's Subject.
+	t.Run("parsed subject does not override caller CommonName", func(t *testing.T) {
+		t.Parallel()
+
+		localCA := newSelfSignedCA(t)
+
+		// Use the CA's parsed Subject with an overridden CommonName;
+		// same pattern used by LocalCertGenerator.generateCert and alpnproxy listener.
+		sniHost := "sts.amazonaws.com"
+		subject := localCA.Cert.Subject
+		subject.CommonName = sniHost
+
+		childCert := generateAndParse(t, localCA, subject, sniHost)
+
+		assert.Equal(t, sniHost, childCert.Subject.CommonName,
+			"child cert CN should be the SNI host, not the CA's CN")
+		assert.NotEqual(t, childCert.Subject.String(), childCert.Issuer.String(),
+			"child cert Subject must not equal Issuer (would look self-signed)")
+	})
+
+	// Desktop Access multi-domain needs custom Teleport OIDs to
+	// survive a parse and re-encode cycle through GenerateCertificate.
+	t.Run("custom Teleport OIDs survive parsed-subject re-encoding", func(t *testing.T) {
+		t.Parallel()
+
+		ca, err := FromKeys([]byte(fixtures.TLSCACertPEM), []byte(fixtures.TLSCAKeyPEM))
+		require.NoError(t, err)
+
+		identity := Identity{
+			Username:        "alice",
+			Groups:          []string{"devs"},
+			KubernetesUsers: []string{"admin"},
+			Expires:         clock.Now().Add(time.Hour),
+		}
+		identitySubj, err := identity.Subject()
+		require.NoError(t, err)
+
+		// Generate a cert then parse it and re-encode using the parsed subject.
+		firstCert := generateAndParse(t, ca, identitySubj)
+		secondCert := generateAndParse(t, ca, firstCert.Subject)
+
+		firstID, err := FromSubject(firstCert.Subject, firstCert.NotAfter)
+		require.NoError(t, err)
+		secondID, err := FromSubject(secondCert.Subject, secondCert.NotAfter)
+		require.NoError(t, err)
+
+		assert.Equal(t, firstID.Username, secondID.Username)
+		assert.Equal(t, firstID.KubernetesUsers, secondID.KubernetesUsers)
+	})
+}
+
 func TestScopePin(t *testing.T) {
 	clock := clockwork.NewFakeClock()
 	expires := clock.Now().Add(1 * time.Hour)


### PR DESCRIPTION
### Context
GenerateCertificate was changed to copy req.Subject.Names into ExtraNames to preserve Teleport-custom OIDs when a cert subject is decoded and re-encoded. However, this also copies standard PKIX attributes (CN, O, etc.). Go's marshaling gives ExtraNames priority, so any caller that passes an existing cert's subject and then overrides CommonName for example has that override silently reverted.

This affects LocalCertGenerator in local_proxy_middleware.go which generates per-hostname TLS certs for the local ALPN proxy used by `tsh aws`, `tsh gcp`, `tsh azure`, and `tsh proxy app`. Child certs end up with the CA's CN instead of the requested hostname, resulting in clients interpreting them as self-signed and rejecting them.

### Changes
Fix by filtering the copy to only include Teleport-custom OIDs (under 1.3.9999) anbd leaving standard attrs to pkix.Name's typed fields.

Changelog: Fixed `tsh aws`, `tsh gcp`, `tsh azure`, and `tsh proxy app` failing from certificate errors.

## Manual Test Plan
### Test Environment
- Local Teleport cluster ~v18 with an AWS Console, GCP, or Azure resource configured.
- TSH built from this branch.

### Test Cases
- [ ] 
