### PR TITLE
Fix Enhanced Session Recording in proxy recording mode

### DIFF
--- a/lib/srv/ctx.go
+++ b/lib/srv/ctx.go
@@ -921,6 +921,24 @@ func (c *ServerContext) ShouldHandleSessionRecording() bool {
 	return c.srv.Component() != teleport.ComponentNode || !services.IsRecordAtProxy(c.SessionRecordingConfig.GetMode())
 }
 
+// AuditEmitter returns the emitter to use for session-level audit events.
+// On a Teleport Node in proxy recording mode it returns a discard emitter
+// so the node does not duplicate events the proxy forwarding node already emits.
+func (c *ServerContext) AuditEmitter() apievents.Emitter {
+	if c.ShouldHandleSessionRecording() {
+		return c.srv
+	}
+	return events.NewDiscardAuditLog()
+}
+
+// BPFEmitter returns the emitter to use for Enhanced Session Recording
+// (BPF) events. BPF programs only run on the Teleport Node where the
+// session executes, so these events must always reach the audit log
+// regardless of cluster recording mode.
+func (c *ServerContext) BPFEmitter() apievents.Emitter {
+	return c.srv
+}
+
 func (c *ServerContext) Close() error {
 	// If the underlying connection is holding tracking information, report that
 	// to the audit log at close.

--- a/lib/srv/sess.go
+++ b/lib/srv/sess.go
@@ -870,7 +870,7 @@ func newSession(ctx context.Context, r *SessionRegistry, scx *ServerContext, ch 
 		login:           scx.Identity.Login,
 		stopC:           make(chan struct{}),
 		startTime:       startTime,
-		emitter:         scx.srv,
+		emitter:         scx.AuditEmitter(),
 		serverCtx:       scx.srv.Context(),
 		access:          &access,
 		scx:             scx,
@@ -886,11 +886,6 @@ func newSession(ctx context.Context, r *SessionRegistry, scx *ServerContext, ch 
 	}
 
 	sess.io.OnWriteError = sess.onWriteErrorCallback(sessionRecordingMode)
-
-	// Nodes discard events in cases when proxies are already recording them.
-	if !sess.shouldHandleRecording() {
-		sess.emitter = events.NewDiscardAuditLog()
-	}
 
 	go func() {
 		if _, open := <-sess.io.TerminateNotifier(); open {
@@ -1477,7 +1472,7 @@ func (s *session) startInteractive(ctx context.Context, scx *ServerContext, p *p
 		sessionContext := &bpf.SessionContext{
 			Context:               scx.srv.Context(),
 			AuditSessionID:        auditSessID,
-			Emitter:               s.emitter,
+			Emitter:               scx.BPFEmitter(),
 			Namespace:             scx.srv.GetNamespace(),
 			SessionID:             s.id.String(),
 			ServerID:              scx.srv.ID(),
@@ -1663,7 +1658,7 @@ func (s *session) startExec(ctx context.Context, channel ssh.Channel, scx *Serve
 	sessionContext := &bpf.SessionContext{
 		Context:               scx.srv.Context(),
 		AuditSessionID:        auditSessID,
-		Emitter:               s.emitter,
+		Emitter:               scx.BPFEmitter(),
 		Namespace:             scx.srv.GetNamespace(),
 		SessionID:             string(s.id),
 		ServerID:              scx.srv.ID(),

--- a/lib/srv/sess_test.go
+++ b/lib/srv/sess_test.go
@@ -1751,3 +1751,64 @@ func (f *fakeSudoersBackend) RemoveSudoers(name string) error {
 	delete(f.sudoers, name)
 	return f.err
 }
+
+func TestServerContext_emitters(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		component     string
+		recordingMode string
+		wantDiscard   bool
+	}{
+		{
+			name:          "node component, node recording",
+			component:     teleport.ComponentNode,
+			recordingMode: types.RecordAtNode,
+			wantDiscard:   false,
+		},
+		{
+			name:          "node component, proxy recording",
+			component:     teleport.ComponentNode,
+			recordingMode: types.RecordAtProxy,
+			wantDiscard:   true,
+		},
+		{
+			name:          "node component, proxy-sync recording",
+			component:     teleport.ComponentNode,
+			recordingMode: types.RecordAtProxySync,
+			wantDiscard:   true,
+		},
+		{
+			name:          "forwarding node component, proxy recording",
+			component:     teleport.ComponentForwardingNode,
+			recordingMode: types.RecordAtProxy,
+			wantDiscard:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			recConfig, err := types.NewSessionRecordingConfigFromConfigFile(types.SessionRecordingConfigSpecV2{
+				Mode: tt.recordingMode,
+			})
+			require.NoError(t, err)
+
+			srv := &mockServer{component: tt.component}
+			scx := &ServerContext{
+				SessionRecordingConfig: recConfig,
+				srv:                    srv,
+			}
+
+			// BPFEmitter must always be the underlying server so ESR events
+			// reach the audit log regardless of cluster recording mode.
+			require.Same(t, srv, scx.BPFEmitter())
+
+			if tt.wantDiscard {
+				require.IsType(t, (*events.DiscardAuditLog)(nil), scx.AuditEmitter())
+			} else {
+				require.Same(t, srv, scx.AuditEmitter())
+			}
+		})
+	}
+}

--- a/lib/srv/sess_test.go
+++ b/lib/srv/sess_test.go
@@ -1752,7 +1752,7 @@ func (f *fakeSudoersBackend) RemoveSudoers(name string) error {
 	return f.err
 }
 
-func TestServerContext_emitters(t *testing.T) {
+func TestServerContextEmitters(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {


### PR DESCRIPTION
Changelog: Fix a Enhanced Session Recording bug in proxy recording mode that caused Teleport Nodes to stop emitting BPF events.

Closes https://github.com/gravitational/teleport/issues/66853

## Manual Test Plan
### Test Environment

Enable ESR on a Teleport Node (must be linux) and require ESR for a role by following [the docs](https://goteleport.com/docs/enroll-resources/server-access/guides/bpf-session-recording). Set `auth_service.session_recording: proxy` in the auth service.

### Test Cases
- The node emits BPF audit events while the proxy emits non-BPF audit events.
  - [x] recording mode: proxy
  - [x] recording mode: proxy-sync
  - [x] recording mode: node
  - [x] recording mode: node-sync
