### PR TITLE
[v18] Use `ptybuffer` in `lib/srv` tests

### DIFF
--- a/lib/srv/sess_test.go
+++ b/lib/srv/sess_test.go
@@ -844,6 +844,78 @@ func TestSessionRecordingModes(t *testing.T) {
 	}
 }
 
+func TestStopSessionWithoutClientDisconnect(t *testing.T) {
+	t.Parallel()
+
+	for _, tt := range []struct {
+		name      string
+		component string
+		setTerm   func(*testing.T, *ServerContext)
+	}{
+		{
+			name:      "local terminal",
+			component: teleport.ComponentNode,
+			setTerm: func(t *testing.T, scx *ServerContext) {
+				term, err := newLocalTerminal(scx)
+				require.NoError(t, err)
+				scx.term = term
+			},
+		},
+		{
+			name:      "remote terminal",
+			component: teleport.ComponentForwardingNode,
+			setTerm: func(t *testing.T, scx *ServerContext) {
+				term, err := newRemoteTerminal(scx)
+				require.NoError(t, err)
+				scx.term = term
+			},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			srv := newMockServer(t)
+			srv.component = tt.component
+
+			reg, err := NewSessionRegistry(SessionRegistryConfig{
+				Srv:                   srv,
+				SessionTrackerService: srv.auth,
+			})
+			require.NoError(t, err)
+			t.Cleanup(func() { reg.Close() })
+
+			scx := newTestServerContext(t, reg.Srv, nil, &decisionpb.SSHAccessPermit{})
+			if tt.setTerm != nil {
+				tt.setTerm(t, scx)
+			}
+
+			// Unlike real SSH clients, the mock SSH channel does not automatically close
+			// when the session ends, which is the misbehavior this test is meant to ensure
+			// is handled.
+			sshChanOpen := newMockSSHChannel()
+			t.Cleanup(func() { require.NoError(t, sshChanOpen.Close()) })
+			go func() {
+				_, _ = io.ReadAll(sshChanOpen)
+			}()
+
+			require.NoError(t, reg.OpenSession(t.Context(), sshChanOpen, scx))
+			require.NotNil(t, scx.session)
+
+			stopDone := make(chan struct{})
+			go func() {
+				scx.session.Stop()
+				close(stopDone)
+			}()
+
+			select {
+			case <-stopDone:
+			case <-time.After(5 * time.Second):
+				require.Fail(t, "session Stop blocked while client channel remained open")
+			}
+		})
+	}
+}
+
 func testOpenSession(t *testing.T, reg *SessionRegistry, sessionJoiningRoleSet services.RoleSet, accessPermit *decisionpb.SSHAccessPermit) (*session, ssh.Channel) {
 	scx := newTestServerContext(t, reg.Srv, sessionJoiningRoleSet, accessPermit)
 

--- a/lib/srv/term.go
+++ b/lib/srv/term.go
@@ -495,7 +495,6 @@ func (t *terminal) setOwner() error {
 }
 
 type remoteTerminal struct {
-	wg sync.WaitGroup
 	mu sync.Mutex
 
 	log *slog.Logger
@@ -524,9 +523,7 @@ func newRemoteTerminal(ctx *ServerContext) (*remoteTerminal, error) {
 	return t, nil
 }
 
-func (t *remoteTerminal) AddParty(delta int) {
-	t.wg.Add(delta)
-}
+func (t *remoteTerminal) AddParty(delta int) {}
 
 type ptyBuffer struct {
 	r io.Reader
@@ -660,11 +657,6 @@ func (t *remoteTerminal) Close() error {
 	if err != nil {
 		return trace.Wrap(err)
 	}
-
-	// Wait for parties to be relased after closing the remote session. This
-	// avoid cases where the parties are blocked, reading from the remote
-	// session.
-	t.wg.Wait()
 
 	t.log.DebugContext(t.ctx.CancelContext(), "Closed remote terminal and underlying SSH session")
 	return nil

--- a/lib/srv/term.go
+++ b/lib/srv/term.go
@@ -115,6 +115,12 @@ type Terminal interface {
 // NewTerminal returns a new terminal. Terminal can be local or remote
 // depending on cluster configuration.
 func NewTerminal(ctx *ServerContext) (Terminal, error) {
+	// In tests, use a remote terminal (ptybuffer) rather than allocating a real PTY
+	// for higher throughput, especially under high CPU load.
+	if ctx.IsTestStub {
+		return newRemoteTerminal(ctx)
+	}
+
 	// It doesn't matter what mode the cluster is in, if this is a Teleport node
 	// return a local terminal.
 	if ctx.srv.Component() == teleport.ComponentNode {


### PR DESCRIPTION
Backport #66673 and https://github.com/gravitational/teleport/pull/66728 to branch/v18