### PR TITLE
Desktop Session Playback Hardening

### DIFF
--- a/lib/events/eventstest/streamer.go
+++ b/lib/events/eventstest/streamer.go
@@ -23,27 +23,32 @@ import (
 	"time"
 
 	apievents "github.com/gravitational/teleport/api/types/events"
-	"github.com/gravitational/teleport/lib/events"
 	"github.com/gravitational/teleport/lib/session"
 )
 
 // NewFakeStreamer returns a session streamer that streams the provided events, sending one
 // event per interval. An interval of 0 sends the events immediately, throttled only by the
 // ability of the receiver to keep up.
-func NewFakeStreamer(events []apievents.AuditEvent, interval time.Duration) events.SessionStreamer {
-	return fakeStreamer{
+func NewFakeStreamer(events []apievents.AuditEvent, interval time.Duration) *fakeStreamer {
+	return &fakeStreamer{
 		events:   events,
 		interval: interval,
+		errCh:    make(chan error),
 	}
+}
+
+func (e *fakeStreamer) WithErrors(errCh chan error) *fakeStreamer {
+	e.errCh = errCh
+	return e
 }
 
 type fakeStreamer struct {
 	events   []apievents.AuditEvent
 	interval time.Duration
+	errCh    chan error
 }
 
 func (f fakeStreamer) StreamSessionEvents(ctx context.Context, sessionID session.ID, startIndex int64) (chan apievents.AuditEvent, chan error) {
-	errors := make(chan error, 1)
 	events := make(chan apievents.AuditEvent)
 
 	go func() {
@@ -66,5 +71,5 @@ func (f fakeStreamer) StreamSessionEvents(ctx context.Context, sessionID session
 		}
 	}()
 
-	return events, errors
+	return events, f.errCh
 }

--- a/lib/events/eventstest/streamer.go
+++ b/lib/events/eventstest/streamer.go
@@ -29,26 +29,26 @@ import (
 // NewFakeStreamer returns a session streamer that streams the provided events, sending one
 // event per interval. An interval of 0 sends the events immediately, throttled only by the
 // ability of the receiver to keep up.
-func NewFakeStreamer(events []apievents.AuditEvent, interval time.Duration) *fakeStreamer {
-	return &fakeStreamer{
+func NewFakeStreamer(events []apievents.AuditEvent, interval time.Duration) *FakeStreamer {
+	return &FakeStreamer{
 		events:   events,
 		interval: interval,
 		errCh:    make(chan error),
 	}
 }
 
-func (e *fakeStreamer) WithErrors(errCh chan error) *fakeStreamer {
+func (e *FakeStreamer) WithErrors(errCh chan error) *FakeStreamer {
 	e.errCh = errCh
 	return e
 }
 
-type fakeStreamer struct {
+type FakeStreamer struct {
 	events   []apievents.AuditEvent
 	interval time.Duration
 	errCh    chan error
 }
 
-func (f fakeStreamer) StreamSessionEvents(ctx context.Context, sessionID session.ID, startIndex int64) (chan apievents.AuditEvent, chan error) {
+func (f FakeStreamer) StreamSessionEvents(ctx context.Context, sessionID session.ID, startIndex int64) (chan apievents.AuditEvent, chan error) {
 	events := make(chan apievents.AuditEvent)
 
 	go func() {

--- a/lib/player/player_test.go
+++ b/lib/player/player_test.go
@@ -20,7 +20,9 @@ package player_test
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"log/slog"
 	"strconv"
 	"testing"
 	"testing/synctest"
@@ -84,6 +86,30 @@ func TestPlayPause(t *testing.T) {
 	require.Equal(t, 3, count)
 }
 
+func TestPlayerError(t *testing.T) {
+	clk := clockwork.NewFakeClock()
+	errCh := make(chan error)
+	p, err := player.New(&player.Config{
+		Clock:     clk,
+		SessionID: "test-session",
+		Streamer:  &simpleStreamer{count: 1, errCh: errCh},
+		Log:       slog.New(slog.DiscardHandler),
+	})
+	require.NoError(t, err)
+
+	errCh <- errors.New("some error")
+
+	_ = p.Play()
+	_, ok := <-p.C()
+	require.False(t, ok)
+	playerErr := p.Err()
+	// Player.Err() should return the backend error that
+	// caused playback failure.
+	require.Error(t, playerErr)
+	assert.Contains(t, playerErr.Error(), "some error")
+
+}
+
 func TestAppliesTiming(t *testing.T) {
 	for _, test := range []struct {
 		desc    string
@@ -112,6 +138,7 @@ func TestAppliesTiming(t *testing.T) {
 				Clock:     clk,
 				SessionID: "test-session",
 				Streamer:  &simpleStreamer{count: 3, delay: 1000},
+				Log:       slog.New(slog.DiscardHandler),
 			})
 			require.NoError(t, err)
 
@@ -151,6 +178,7 @@ func TestClose(t *testing.T) {
 		Clock:     clk,
 		SessionID: "test-session",
 		Streamer:  &simpleStreamer{count: 2, delay: 1000},
+		Log:       slog.New(slog.DiscardHandler),
 	})
 	require.NoError(t, err)
 
@@ -180,6 +208,7 @@ func TestRewind(t *testing.T) {
 		Clock:     clk,
 		SessionID: "test-session",
 		Streamer:  &simpleStreamer{count: 10, delay: 1000},
+		Log:       slog.New(slog.DiscardHandler),
 	})
 	require.NoError(t, err)
 	require.NoError(t, p.Play())
@@ -221,6 +250,7 @@ func TestUseDatabaseTranslator(t *testing.T) {
 					Clock:     clk,
 					SessionID: "test-session",
 					Streamer:  &databaseStreamer{protocol: protocol, count: int64(queryEventCount)},
+					Log:       slog.New(slog.DiscardHandler),
 				})
 				require.NoError(t, err)
 				require.NoError(t, p.Play())
@@ -252,6 +282,7 @@ func TestUseDatabaseTranslator(t *testing.T) {
 			Clock:     clk,
 			SessionID: "test-session",
 			Streamer:  &databaseStreamer{protocol: "random-protocol", count: int64(queryEventCount)},
+			Log:       slog.New(slog.DiscardHandler),
 		})
 		require.NoError(t, err)
 		require.NoError(t, p.Play())
@@ -281,6 +312,7 @@ func TestSkipIdlePeriods(t *testing.T) {
 		SessionID:    "test-session",
 		SkipIdleTime: true,
 		Streamer:     &simpleStreamer{count: int64(eventCount), delay: int64(delayMilliseconds)},
+		Log:          slog.New(slog.DiscardHandler),
 	})
 	require.NoError(t, err)
 	require.NoError(t, p.Play())
@@ -305,10 +337,13 @@ func TestSkipIdlePeriods(t *testing.T) {
 type simpleStreamer struct {
 	count int64
 	delay int64 // milliseconds
+	errCh chan error
 }
 
 func (s *simpleStreamer) StreamSessionEvents(ctx context.Context, sessionID session.ID, startIndex int64) (chan apievents.AuditEvent, chan error) {
-	errors := make(chan error, 1)
+	if s.errCh == nil {
+		s.errCh = make(chan error)
+	}
 	evts := make(chan apievents.AuditEvent)
 
 	go func() {
@@ -336,7 +371,7 @@ func (s *simpleStreamer) StreamSessionEvents(ctx context.Context, sessionID sess
 		}
 	}()
 
-	return evts, errors
+	return evts, s.errCh
 }
 
 type databaseStreamer struct {
@@ -401,6 +436,7 @@ func TestInterruptsDelay(t *testing.T) {
 		p, err := player.New(&player.Config{
 			SessionID: "test-session",
 			Streamer:  &simpleStreamer{count: 3, delay: 5000},
+			Log:       slog.New(slog.DiscardHandler),
 		})
 		require.NoError(t, err)
 
@@ -439,6 +475,7 @@ func TestSeekForward(t *testing.T) {
 		p, err := player.New(&player.Config{
 			SessionID: "test-session",
 			Streamer:  &simpleStreamer{count: 1, delay: 6000},
+			Log:       slog.New(slog.DiscardHandler),
 		})
 		require.NoError(t, err)
 		t.Cleanup(func() { p.Close() })

--- a/lib/player/player_test.go
+++ b/lib/player/player_test.go
@@ -99,7 +99,6 @@ func TestPlayerError(t *testing.T) {
 
 	errCh <- errors.New("some error")
 
-	_ = p.Play()
 	_, ok := <-p.C()
 	require.False(t, ok)
 	playerErr := p.Err()

--- a/lib/web/desktop/playback.go
+++ b/lib/web/desktop/playback.go
@@ -179,7 +179,11 @@ func StreamRecording(
 			msg, err := utils.FastMarshal(evt)
 			if err != nil {
 				log.ErrorContext(ctx, "failed to marshal desktop event", "error", err)
-				ws.WriteMessage(websocket.BinaryMessage, []byte(`{"message":"error","errorText":"server error"}`))
+				if err := ws.WriteMessage(websocket.BinaryMessage, []byte(`{"message":"error","errorText":"server error"}`)); err != nil {
+					if !utils.IsOKNetworkError(err) {
+						log.WarnContext(ctx, "failed to write error message to client", "error", err)
+					}
+				}
 				return
 			}
 			if err := ws.WriteMessage(websocket.BinaryMessage, msg); err != nil {

--- a/lib/web/desktop/playback.go
+++ b/lib/web/desktop/playback.go
@@ -20,8 +20,6 @@ package desktop
 
 import (
 	"context"
-	"encoding/json"
-	"fmt"
 	"log/slog"
 	"time"
 
@@ -160,15 +158,9 @@ func StreamRecording(
 		case evt, ok := <-player.C():
 			if !ok {
 				if playerErr := player.Err(); playerErr != nil {
-					// Attempt to JSONify the error (escaping any quotes)
-					msg, err := json.Marshal(playerErr.Error())
-					if err != nil {
-						log.WarnContext(ctx, "failed to marshal player error message", "error", err)
-						msg = []byte(`"internal server error"`)
-					}
-					//lint:ignore QF1012 this write needs to happen in a single operation
-					bytes := fmt.Appendf(nil, `{"message":"error", "errorText":%s}`, string(msg))
-					if err := ws.WriteMessage(websocket.BinaryMessage, bytes); err != nil {
+					slog.ErrorContext(ctx, "stopping playback due to an error", "error", playerErr)
+
+					if err := ws.WriteMessage(websocket.BinaryMessage, []byte(`{"message":"error", "errorText": "internal server error"}`)); err != nil {
 						log.ErrorContext(ctx, "failed to write error message", "error", err)
 					}
 					return

--- a/lib/web/desktop/playback_test.go
+++ b/lib/web/desktop/playback_test.go
@@ -21,6 +21,7 @@ package desktop_test
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -53,7 +54,7 @@ func TestStreamsDesktopEvents(t *testing.T) {
 		&apievents.DesktopRecording{Message: []byte("ghi")},
 		&apievents.DesktopRecording{Message: []byte("jkl")},
 	}
-	s := newServer(t, 20*time.Millisecond, events)
+	s := newServer(t, 20*time.Millisecond, events, nil)
 
 	// connect to the server and verify that we receive
 	// all 4 JSON-encoded events
@@ -84,10 +85,38 @@ func TestStreamsDesktopEvents(t *testing.T) {
 	require.JSONEq(t, `{"message":"end"}`, string(b))
 }
 
-func newServer(t *testing.T, streamInterval time.Duration, events []apievents.AuditEvent) *httptest.Server {
+func TestStreamingError(t *testing.T) {
+	// set up a server that streams 4 events over websocket
+	events := []apievents.AuditEvent{
+		&apievents.DesktopRecording{Message: []byte("abc")},
+	}
+	errorCh := make(chan error, 1)
+	errorCh <- errors.New("some error")
+	s := newServer(t, 20*time.Millisecond, events, errorCh)
+
+	// connect to the server and verify that we receive
+	// all 4 JSON-encoded events
+	url := strings.Replace(s.URL, "http", "ws", 1)
+
+	// As per https://pkg.go.dev/github.com/gorilla/websocket#Dialer.DialContext:
+	// "The response body may not contain the entire response and does not need to be closed by the application."
+	//nolint:bodyclose // false positive
+	ws, _, err := websocket.DefaultDialer.Dial(url, nil)
+	require.NoError(t, err)
+
+	t.Cleanup(func() { ws.Close() })
+
+	typ, b, err := ws.ReadMessage()
+	require.NoError(t, err)
+	require.Equal(t, websocket.BinaryMessage, typ)
+	// error text should be generic and not leak backend details.
+	require.JSONEq(t, `{"message":"error", "errorText": "internal server error"}`, string(b))
+}
+
+func newServer(t *testing.T, streamInterval time.Duration, events []apievents.AuditEvent, errors chan error) *httptest.Server {
 	t.Helper()
 
-	fs := eventstest.NewFakeStreamer(events, streamInterval)
+	fs := eventstest.NewFakeStreamer(events, streamInterval).WithErrors(errors)
 	log := logtest.NewLogger()
 
 	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/lib/web/desktop/playback_test.go
+++ b/lib/web/desktop/playback_test.go
@@ -94,8 +94,6 @@ func TestStreamingError(t *testing.T) {
 	errorCh <- errors.New("some error")
 	s := newServer(t, 20*time.Millisecond, events, errorCh)
 
-	// connect to the server and verify that we receive
-	// all 4 JSON-encoded events
 	url := strings.Replace(s.URL, "http", "ws", 1)
 
 	// As per https://pkg.go.dev/github.com/gorilla/websocket#Dialer.DialContext:

--- a/lib/web/desktop_playback.go
+++ b/lib/web/desktop_playback.go
@@ -22,6 +22,7 @@ import (
 	"context"
 	"net/http"
 
+	"github.com/google/uuid"
 	"github.com/gorilla/websocket"
 	"github.com/gravitational/trace"
 	"github.com/julienschmidt/httprouter"
@@ -42,8 +43,14 @@ func (h *Handler) desktopPlaybackHandle(
 	ws *websocket.Conn,
 ) (any, error) {
 	sID := p.ByName("sid")
-	if sID == "" {
+
+	switch sID {
+	case "":
 		return nil, trace.BadParameter("missing session ID in request URL")
+	default:
+		if _, err := uuid.Parse(sID); err != nil {
+			return nil, trace.BadParameter("invalid session ID in request URL - %v", err)
+		}
 	}
 
 	clt, err := sctx.GetUserClient(r.Context(), cluster)

--- a/lib/web/desktop_playback.go
+++ b/lib/web/desktop_playback.go
@@ -22,7 +22,6 @@ import (
 	"context"
 	"net/http"
 
-	"github.com/google/uuid"
 	"github.com/gorilla/websocket"
 	"github.com/gravitational/trace"
 	"github.com/julienschmidt/httprouter"
@@ -47,12 +46,10 @@ func (h *Handler) desktopPlaybackHandle(
 		return nil, trace.BadParameter("missing session ID in request URL")
 	}
 
-	parsed, err := uuid.Parse(sID)
+	sessionID, err := session.ParseID(sID)
 	if err != nil {
 		return nil, trace.BadParameter("invalid session ID in request URL - %v", err)
 	}
-	// Ensure sID is in canonical form which is necessary for session lookup to succeed.
-	sID = parsed.String()
 
 	clt, err := sctx.GetUserClient(r.Context(), cluster)
 	if err != nil {
@@ -62,7 +59,7 @@ func (h *Handler) desktopPlaybackHandle(
 	player, err := player.New(&player.Config{
 		Clock:     h.clock,
 		Log:       h.logger,
-		SessionID: session.ID(sID),
+		SessionID: *sessionID,
 		Streamer:  clt,
 		Context:   r.Context(),
 	})

--- a/lib/web/desktop_playback.go
+++ b/lib/web/desktop_playback.go
@@ -43,15 +43,16 @@ func (h *Handler) desktopPlaybackHandle(
 	ws *websocket.Conn,
 ) (any, error) {
 	sID := p.ByName("sid")
-
-	switch sID {
-	case "":
+	if sID == "" {
 		return nil, trace.BadParameter("missing session ID in request URL")
-	default:
-		if _, err := uuid.Parse(sID); err != nil {
-			return nil, trace.BadParameter("invalid session ID in request URL - %v", err)
-		}
 	}
+
+	parsed, err := uuid.Parse(sID)
+	if err != nil {
+		return nil, trace.BadParameter("invalid session ID in request URL - %v", err)
+	}
+	// Ensure sID is in canonical form which is necessary for session lookup to succeed.
+	sID = parsed.String()
 
 	clt, err := sctx.GetUserClient(r.Context(), cluster)
 	if err != nil {


### PR DESCRIPTION
This PR adds two slight improvements to desktop session playback:
- Add proper validation that the sessionID is a UUID
- Prevent internal/backend errors from propagating to the client



<!-- Provide a descriptive entry for the changelog of the next release. -->


<!-- Include manual testing efforts to verify the change. -->
<!-- Detail where the tests where run and what configurations were used. -->
<!-- Include all the test cases which were run to validate the change. -->

## Manual Test Plan
### Test Environment
CI/CD
### Test Cases
- [x] Unit tests validate that backend error details are not leaked.
