### PR TITLE
Fix memory backend value aliasing

### DIFF
--- a/lib/backend/memory/memory.go
+++ b/lib/backend/memory/memory.go
@@ -170,6 +170,7 @@ func (m *Memory) Create(ctx context.Context, i backend.Item) (*backend.Lease, er
 		Type: types.OpPut,
 		Item: i,
 	}
+	event.Item.Value = bytes.Clone(i.Value)
 	m.processEvent(event)
 	if !m.EventsOff {
 		m.buf.Emit(event)
@@ -189,7 +190,10 @@ func (m *Memory) Get(ctx context.Context, key backend.Key) (*backend.Item, error
 	if !found {
 		return nil, trace.NotFound("key %q is not found", key.String())
 	}
-	return &i.Item, nil
+
+	out := i.Item
+	out.Value = bytes.Clone(i.Value)
+	return &out, nil
 }
 
 // Update updates item if it exists, or returns NotFound error
@@ -210,6 +214,7 @@ func (m *Memory) Update(ctx context.Context, i backend.Item) (*backend.Lease, er
 		Type: types.OpPut,
 		Item: i,
 	}
+	event.Item.Value = bytes.Clone(i.Value)
 	m.processEvent(event)
 	if !m.EventsOff {
 		m.buf.Emit(event)
@@ -233,6 +238,7 @@ func (m *Memory) Put(ctx context.Context, i backend.Item) (*backend.Lease, error
 		Type: types.OpPut,
 		Item: i,
 	}
+	event.Item.Value = bytes.Clone(i.Value)
 	m.processEvent(event)
 	if !m.EventsOff {
 		m.buf.Emit(event)
@@ -294,6 +300,7 @@ func (m *Memory) DeleteRange(ctx context.Context, startKey, endKey backend.Key) 
 			Type: types.OpDelete,
 			Item: item,
 		}
+		event.Item.Value = bytes.Clone(item.Value)
 		m.processEvent(event)
 		if !m.EventsOff {
 			m.buf.Emit(event)
@@ -375,7 +382,9 @@ func (m *Memory) Items(ctx context.Context, params backend.ItemsParams) iter.Seq
 			}
 
 			for _, item := range items {
-				if !yield(item, nil) {
+				out := item
+				out.Value = bytes.Clone(item.Value)
+				if !yield(out, nil) {
 					return
 				}
 
@@ -426,6 +435,7 @@ func (m *Memory) KeepAlive(ctx context.Context, lease backend.Lease, expires tim
 		Type: types.OpPut,
 		Item: item,
 	}
+	event.Item.Value = bytes.Clone(item.Value)
 	m.processEvent(event)
 	if !m.EventsOff {
 		m.buf.Emit(event)
@@ -462,6 +472,7 @@ func (m *Memory) CompareAndSwap(ctx context.Context, expected backend.Item, repl
 		Type: types.OpPut,
 		Item: replaceWith,
 	}
+	event.Item.Value = bytes.Clone(replaceWith.Value)
 	m.processEvent(event)
 	if !m.EventsOff {
 		m.buf.Emit(event)
@@ -517,6 +528,7 @@ func (m *Memory) ConditionalUpdate(ctx context.Context, i backend.Item) (*backen
 		Type: types.OpPut,
 		Item: i,
 	}
+	event.Item.Value = bytes.Clone(i.Value)
 	m.processEvent(event)
 	if !m.EventsOff {
 		m.buf.Emit(event)
@@ -573,6 +585,7 @@ func (m *Memory) processEvent(event backend.Event) {
 	switch event.Type {
 	case types.OpPut:
 		item := &btreeItem{Item: event.Item, index: -1}
+		item.Value = bytes.Clone(event.Item.Value)
 		treeItem, found := m.tree.Get(item)
 		var existingItem *btreeItem
 		if found {

--- a/lib/backend/memory/memory_test.go
+++ b/lib/backend/memory/memory_test.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
+	"github.com/stretchr/testify/require"
 
 	"github.com/gravitational/teleport/lib/backend"
 	"github.com/gravitational/teleport/lib/backend/test"
@@ -63,4 +64,56 @@ func TestMemory(t *testing.T) {
 	}
 
 	test.RunBackendComplianceSuite(t, newBackend)
+}
+
+func TestMemoryItemOwnership(t *testing.T) {
+	mem, err := New(Config{})
+	require.NoError(t, err)
+
+	key := backend.NewKey("testing")
+	value := []byte{0, 1, 2, 3}
+	lease, err := mem.Put(t.Context(), backend.Item{
+		Key:   key,
+		Value: value,
+	})
+	require.NoError(t, err)
+
+	// Mutating the caller-owned write buffer must not mutate the stored item.
+	copy(value, []byte{9, 8, 7, 6})
+
+	got, err := mem.Get(t.Context(), key)
+	require.NoError(t, err)
+	require.Equal(t, lease.Revision, got.Revision)
+	require.Equal(t, []byte{0, 1, 2, 3}, got.Value)
+
+	// Mutating the item returned by Get must not mutate the stored item.
+	got.Revision = "tampered"
+	got.Value[0] = 9
+
+	got, err = mem.Get(t.Context(), key)
+	require.NoError(t, err)
+	require.Equal(t, lease.Revision, got.Revision)
+	require.Equal(t, []byte{0, 1, 2, 3}, got.Value)
+
+	var itemsFound bool
+	for item, err := range mem.Items(t.Context(), backend.ItemsParams{
+		StartKey: key,
+		EndKey:   backend.NewKey("zzzz"),
+		Limit:    1,
+	}) {
+		itemsFound = true
+		require.NoError(t, err)
+		require.Equal(t, lease.Revision, item.Revision)
+		require.Equal(t, []byte{0, 1, 2, 3}, item.Value)
+
+		// Mutating the item returned by Items must not mutate the stored item.
+		item.Revision = "tampered"
+		item.Value[0] = 8
+	}
+	require.True(t, itemsFound)
+
+	got, err = mem.Get(t.Context(), key)
+	require.NoError(t, err)
+	require.Equal(t, lease.Revision, got.Revision)
+	require.Equal(t, []byte{0, 1, 2, 3}, got.Value)
 }


### PR DESCRIPTION
Ensures the memory backend does not expose or retain caller owned values by cloning them prior to storing, on gets, and replicating to watchers.

Resolves https://github.com/gravitational/pressure-washing/issues/143.