### PR TITLE
Make rejected accepts retryable in lib/limiter

### DIFF
--- a/lib/limiter/connlimiter.go
+++ b/lib/limiter/connlimiter.go
@@ -148,7 +148,7 @@ func (l *ConnectionsLimiter) GetNumConnection(token string) (int64, error) {
 
 	numberOfConnections, exists := l.connections[token]
 	if !exists {
-		return -1, trace.BadParameter("unable to get connections of a nonexistent token: %q", token)
+		return 0, nil
 	}
 
 	return numberOfConnections, nil

--- a/lib/limiter/connlimiter_test.go
+++ b/lib/limiter/connlimiter_test.go
@@ -68,3 +68,21 @@ func TestConnectionsLimiter(t *testing.T) {
 		require.NoError(t, l.AcquireConnection("token2"))
 	}
 }
+
+func TestConnectionsLimiter_GetNumConnection(t *testing.T) {
+	l := limiter.NewConnectionsLimiter(2)
+
+	numConnections, err := l.GetNumConnection("conn1")
+	require.NoError(t, err)
+	require.Zero(t, numConnections)
+
+	require.NoError(t, l.AcquireConnection("conn1"))
+	numConnections, err = l.GetNumConnection("conn1")
+	require.NoError(t, err)
+	require.Equal(t, int64(1), numConnections)
+
+	l.ReleaseConnection("conn1")
+	numConnections, err = l.GetNumConnection("conn1")
+	require.NoError(t, err)
+	require.Zero(t, numConnections)
+}

--- a/lib/limiter/limiter.go
+++ b/lib/limiter/limiter.go
@@ -161,8 +161,8 @@ func (l *Limiter) StreamServerInterceptor(srv any, serverStream grpc.ServerStrea
 
 // WrapListener returns a [Listener] that wraps the provided listener
 // with one that limits connections
-func (l *Limiter) WrapListener(ln net.Listener) (*Listener, error) {
-	return NewListener(ln, l.connectionLimiter)
+func (l *Limiter) WrapListener(ln net.Listener, opts ...ListenerOption) (*Listener, error) {
+	return NewListener(ln, l.connectionLimiter, opts...)
 }
 
 type handlerWrapper interface {

--- a/lib/limiter/limiter_test.go
+++ b/lib/limiter/limiter_test.go
@@ -356,6 +356,39 @@ func (f *fakeConn) Close() error {
 	return nil
 }
 
+// wrappedListener wraps accepted connections so tests can observe when a
+// rejected connection is closed.
+type wrappedListener struct {
+	net.Listener
+	closed chan struct{}
+}
+
+func (l *wrappedListener) Accept() (net.Conn, error) {
+	conn, err := l.Listener.Accept()
+	if err != nil {
+		return nil, err
+	}
+	return &wrappedListenerConn{
+		Conn:   conn,
+		closed: l.closed,
+	}, nil
+}
+
+// wrappedListenerConn lets the caller know when the connection is closed by sending on a channel.
+type wrappedListenerConn struct {
+	net.Conn
+	closed chan struct{}
+}
+
+func (c *wrappedListenerConn) Close() error {
+	err := c.Conn.Close()
+	select {
+	case c.closed <- struct{}{}:
+	default:
+	}
+	return err
+}
+
 func TestMakeMiddleware(t *testing.T) {
 	t.Parallel()
 
@@ -617,31 +650,88 @@ func TestIndependentLimiters(t *testing.T) {
 	require.Error(t, defaultLimiter.RegisterRequest("127.0.0.1"))
 }
 
-func TestListenerLimitExceededErrorRetryable(t *testing.T) {
-	limiter := NewConnectionsLimiter(1)
-	ln, err := NewListener(&fakeListener{
-		acceptConn: &fakeConn{addr: mockAddr{}},
-	}, limiter)
-	require.NoError(t, err)
+func TestListener_LimitExceededDoesNotTerminateServe(t *testing.T) {
+	tests := []struct {
+		name      string
+		serve     func(t *testing.T, ln net.Listener) (stop func(), done <-chan error)
+		assertErr func(t *testing.T, err error)
+	}{
+		{
+			name: "grpc",
+			serve: func(t *testing.T, ln net.Listener) (func(), <-chan error) {
+				srv := grpc.NewServer()
+				done := make(chan error, 1)
+				go func() { done <- srv.Serve(ln) }()
+				return srv.Stop, done
+			},
+			assertErr: func(t *testing.T, err error) {
+				require.NoError(t, err)
+			},
+		},
+		{
+			name: "http",
+			serve: func(t *testing.T, ln net.Listener) (func(), <-chan error) {
+				srv := &http.Server{
+					Handler: http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+						w.WriteHeader(http.StatusNoContent)
+					}),
+				}
+				done := make(chan error, 1)
+				go func() { done <- srv.Serve(ln) }()
+				return func() {
+					require.NoError(t, srv.Close())
+				}, done
+			},
+			assertErr: func(t *testing.T, err error) {
+				require.ErrorIs(t, err, http.ErrServerClosed)
+			},
+		},
+	}
 
-	// First connection is accepted and kept open
-	conn, err := ln.Accept()
-	require.NoError(t, err)
-	require.NotNil(t, conn)
-	defer conn.Close()
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			base, err := net.Listen("tcp", "127.0.0.1:0")
+			require.NoError(t, err)
+			defer base.Close()
 
-	// Second connection from the same IP exceeds the limit
-	conn, err = ln.Accept()
-	require.Nil(t, conn)
-	require.Error(t, err)
+			closed := make(chan struct{}, 1)
+			cl := NewConnectionsLimiter(1)
+			ln, err := NewListener(&wrappedListener{
+				Listener: base,
+				closed:   closed,
+			}, cl)
+			require.NoError(t, err)
 
-	require.True(t, trace.IsLimitExceeded(err))
+			// Saturate the limit so the next accepted connection is rejected.
+			require.NoError(t, cl.AcquireConnection("127.0.0.1"))
+			defer cl.ReleaseConnection("127.0.0.1")
 
-	// grpc.Server.Serve uses Temporary() to decide
-	// whether an Accept error should stop the server
-	temporary, ok := err.(interface {
-		Temporary() bool
-	})
-	require.True(t, ok)
-	require.True(t, temporary.Temporary())
+			stop, done := tt.serve(t, ln)
+
+			// Listener.Accept limit exceeds with a tcp connection.
+			c, err := net.Dial("tcp", base.Addr().String())
+			require.NoError(t, err)
+			defer c.Close()
+
+			// Wait until the rejected connection is closed by Listener.Accept.
+			select {
+			case <-closed:
+			case <-time.After(2 * time.Second):
+				t.Fatal("timed out waiting for rejected connection to close")
+			}
+
+			// Check if server is still running after rejecting connection.
+			select {
+			case err := <-done:
+				require.True(t, trace.IsLimitExceeded(err),
+					"expected limit exceeded error, got %v", err)
+				t.Fatalf("%s Server.Serve exited on per-IP limit hit: %v", tt.name, err)
+			case <-time.After(100 * time.Millisecond):
+				// Serve kept running after the rejected connection.
+			}
+
+			stop()
+			tt.assertErr(t, <-done)
+		})
+	}
 }

--- a/lib/limiter/limiter_test.go
+++ b/lib/limiter/limiter_test.go
@@ -616,3 +616,32 @@ func TestIndependentLimiters(t *testing.T) {
 	}
 	require.Error(t, defaultLimiter.RegisterRequest("127.0.0.1"))
 }
+
+func TestListenerLimitExceededErrorRetryable(t *testing.T) {
+	limiter := NewConnectionsLimiter(1)
+	ln, err := NewListener(&fakeListener{
+		acceptConn: &fakeConn{addr: mockAddr{}},
+	}, limiter)
+	require.NoError(t, err)
+
+	// First connection is accepted and kept open
+	conn, err := ln.Accept()
+	require.NoError(t, err)
+	require.NotNil(t, conn)
+	defer conn.Close()
+
+	// Second connection from the same IP exceeds the limit
+	conn, err = ln.Accept()
+	require.Nil(t, conn)
+	require.Error(t, err)
+
+	require.True(t, trace.IsLimitExceeded(err))
+
+	// grpc.Server.Serve uses Temporary() to decide
+	// whether an Accept error should stop the server
+	temporary, ok := err.(interface {
+		Temporary() bool
+	})
+	require.True(t, ok)
+	require.True(t, temporary.Temporary())
+}

--- a/lib/limiter/limiter_test.go
+++ b/lib/limiter/limiter_test.go
@@ -188,164 +188,148 @@ func TestLimiter_StreamServerInterceptor(t *testing.T) {
 	require.Error(t, err)
 }
 
-// TestListener verifies that a [Listener] only accepts
-// connections if the connection limit has not been exceeded.
 func TestListener(t *testing.T) {
-	const connLimit = 5
 	failedAcceptErr := errors.New("failed accept")
-	tooManyConnectionsErr := trace.LimitExceeded("too many connections from 127.0.0.1: 2, max is 2")
 
-	tests := []struct {
-		name             string
-		config           Config
-		listener         *fakeListener
-		acceptAssertion  func(t *testing.T, iteration int, conn net.Conn, err error)
-		numConnAssertion func(t *testing.T, num int64)
-	}{
-		{
-			name:   "all connections allowed",
-			config: Config{MaxConnections: 0},
-			listener: &fakeListener{
-				acceptConn: &fakeConn{
-					addr: mockAddr{},
-				},
+	t.Run("allows and releases connections", func(t *testing.T) {
+		limiter := NewConnectionsLimiter(2)
+		ln, err := NewListener(&fakeListener{
+			acceptConns: []net.Conn{
+				&fakeConn{addr: mockAddr{}},
+				&fakeConn{addr: mockAddr{}},
+				&fakeConn{addr: mockAddr{}},
 			},
-			acceptAssertion: func(t *testing.T, _ int, conn net.Conn, err error) {
-				require.NoError(t, err)
-				require.NotNil(t, conn)
+		}, limiter)
+		require.NoError(t, err)
+		defer ln.Close()
+
+		conn1, err := ln.Accept()
+		require.NoError(t, err)
+		conn2, err := ln.Accept()
+		require.NoError(t, err)
+
+		n, err := limiter.GetNumConnection("127.0.0.1")
+		require.NoError(t, err)
+		require.Equal(t, int64(2), n)
+
+		require.NoError(t, conn1.Close())
+		require.NoError(t, conn2.Close())
+
+		n, err = limiter.GetNumConnection("127.0.0.1")
+		require.NoError(t, err)
+		require.Zero(t, n)
+
+		conn3, err := ln.Accept()
+		require.NoError(t, err)
+		require.NoError(t, conn3.Close())
+	})
+
+	t.Run("returns listener accept errors", func(t *testing.T) {
+		limiter := NewConnectionsLimiter(0)
+		ln, err := NewListener(&fakeListener{acceptError: failedAcceptErr}, limiter)
+		require.NoError(t, err)
+		defer ln.Close()
+
+		conn, err := ln.Accept()
+		require.ErrorIs(t, err, failedAcceptErr)
+		require.Nil(t, conn)
+	})
+
+	t.Run("closes invalid remote address and keeps accepting", func(t *testing.T) {
+		// 0 means no connection limit per cient IP
+		limiter := NewConnectionsLimiter(0)
+		invalidConn := &fakeConn{
+			addr: &utils.NetAddr{
+				Addr:        "abcd",
+				AddrNetwork: "tcp",
 			},
-			numConnAssertion: func(t *testing.T, num int64) {
-				// MaxConnections == 0 prevents any connections from being accumulated
-				require.Zero(t, num)
-			},
-		},
-		{
-			name:   "accept failure",
-			config: Config{MaxConnections: 0},
-			listener: &fakeListener{
-				acceptError: failedAcceptErr,
-			},
-			acceptAssertion: func(t *testing.T, _ int, conn net.Conn, err error) {
-				require.ErrorIs(t, err, failedAcceptErr)
-				require.Nil(t, conn)
-			},
-			numConnAssertion: func(t *testing.T, num int64) {
-				require.Zero(t, num)
-			},
-		},
-		{
-			name:   "invalid remote address",
-			config: Config{MaxConnections: 0},
-			listener: &fakeListener{
-				acceptConn: &fakeConn{
-					addr: &utils.NetAddr{
-						Addr:        "abcd",
-						AddrNetwork: "tcp",
-					},
-				},
-			},
-			acceptAssertion: func(t *testing.T, _ int, conn net.Conn, err error) {
-				require.Error(t, err)
-				require.Nil(t, conn)
-			},
-			numConnAssertion: func(t *testing.T, num int64) {
-				require.Zero(t, num)
-			},
-		},
-		{
-			name:   "max connections exceeded",
-			config: Config{MaxConnections: 2},
-			listener: &fakeListener{
-				acceptConn: &fakeConn{
-					addr: mockAddr{},
-				},
-			},
-			acceptAssertion: func(t *testing.T, i int, conn net.Conn, err error) {
-				if i < 2 {
-					require.NoError(t, err)
-					require.NotNil(t, conn)
-					return
-				}
-				require.Error(t, err)
-				require.ErrorIs(t, err, tooManyConnectionsErr)
-				require.True(t, trace.IsLimitExceeded(err))
-				require.Nil(t, conn)
-			},
-			numConnAssertion: func(t *testing.T, num int64) {
-				require.Equal(t, int64(2), num)
-			},
+		}
+		validConn := &fakeConn{addr: mockAddr{}}
+
+		ln, err := NewListener(&fakeListener{
+			acceptConns: []net.Conn{invalidConn, validConn},
+		}, limiter)
+		require.NoError(t, err)
+		defer ln.Close()
+
+		conn, err := ln.Accept()
+		require.NoError(t, err)
+		wrapped, ok := conn.(*wrappedConn)
+		require.True(t, ok)
+		require.Same(t, validConn, wrapped.NetConn())
+		require.True(t, invalidConn.closed)
+	})
+}
+
+func TestListener_LimitExceeded(t *testing.T) {
+	limiter := NewConnectionsLimiter(1)
+	require.NoError(t, limiter.AcquireConnection("127.0.0.1"))
+	defer limiter.ReleaseConnection("127.0.0.1")
+
+	rejectedConn := &fakeConn{addr: mockAddr{}}
+	allowedConn := &fakeConn{
+		addr: &utils.NetAddr{
+			Addr:        "127.0.0.2:1234",
+			AddrNetwork: "tcp",
 		},
 	}
 
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			limiter := NewConnectionsLimiter(test.config.MaxConnections)
+	var callbackRemoteAddr string
+	var callbackErr error
+	ln, err := NewListener(
+		&fakeListener{acceptConns: []net.Conn{rejectedConn, allowedConn}},
+		limiter,
+		WithLimitExceededCallback(func(remoteAddr string, err error) {
+			callbackRemoteAddr = remoteAddr
+			callbackErr = err
+		}),
+	)
+	require.NoError(t, err)
+	defer ln.Close()
 
-			ln, err := NewListener(test.listener, limiter)
-			require.NoError(t, err)
+	conn, err := ln.Accept()
+	require.NoError(t, err)
+	wrapped, ok := conn.(*wrappedConn)
+	require.True(t, ok)
+	require.Same(t, allowedConn, wrapped.NetConn())
 
-			// open connections without closing to enforce limits
-			conns := make([]net.Conn, 0, connLimit)
-			for i := range connLimit {
-				conn, err := ln.Accept()
-				test.acceptAssertion(t, i, conn, err)
+	// The rejected connection should be closed, the callback should be called
+	// and the listener should still accept the allowed connection.
+	require.True(t, rejectedConn.closed)
+	require.Equal(t, "127.0.0.1", callbackRemoteAddr)
+	require.True(t, trace.IsLimitExceeded(callbackErr))
 
-				if conn != nil {
-					conns = append(conns, conn)
-				}
-			}
-
-			// validate limits were enforced
-			n, err := limiter.GetNumConnection("127.0.0.1")
-			require.NoError(t, err)
-			test.numConnAssertion(t, n)
-
-			// close connections to reset limits
-			for _, conn := range conns {
-				require.NoError(t, conn.Close())
-			}
-
-			// ensure closing connections resets count
-			n, err = limiter.GetNumConnection("127.0.0.1")
-			if test.config.MaxConnections == 0 {
-				require.NoError(t, err)
-				require.Zero(t, n)
-			} else {
-				require.True(t, trace.IsBadParameter(err))
-				require.Equal(t, int64(-1), n)
-			}
-
-			// open connections again after closing to
-			// ensure that closing reset limits
-			for i := range 5 {
-				conn, err := ln.Accept()
-				test.acceptAssertion(t, i, conn, err)
-
-				if conn != nil {
-					t.Cleanup(func() {
-						require.NoError(t, err)
-					})
-				}
-			}
-		})
-	}
+	require.NoError(t, conn.Close())
 }
 
 type fakeListener struct {
 	net.Listener
 
-	acceptConn  net.Conn
+	acceptConns []net.Conn
 	acceptError error
 }
 
 func (f *fakeListener) Accept() (net.Conn, error) {
-	return f.acceptConn, f.acceptError
+	if f.acceptError != nil {
+		return nil, f.acceptError
+	}
+	if len(f.acceptConns) == 0 {
+		return nil, errors.New("fake listener exhausted")
+	}
+	conn := f.acceptConns[0]
+	f.acceptConns = f.acceptConns[1:]
+	return conn, nil
+}
+
+func (f *fakeListener) Close() error {
+	return nil
 }
 
 type fakeConn struct {
 	net.Conn
 
-	addr net.Addr
+	addr   net.Addr
+	closed bool
 }
 
 func (f *fakeConn) RemoteAddr() net.Addr {
@@ -353,6 +337,7 @@ func (f *fakeConn) RemoteAddr() net.Addr {
 }
 
 func (f *fakeConn) Close() error {
+	f.closed = true
 	return nil
 }
 
@@ -710,6 +695,7 @@ func TestListener_LimitExceededDoesNotTerminateServe(t *testing.T) {
 				closed:   closed,
 			}, cl)
 			require.NoError(t, err)
+			defer ln.Close()
 
 			// Saturate the limit so the next accepted connection is rejected.
 			require.NoError(t, cl.AcquireConnection("127.0.0.1"))
@@ -741,9 +727,7 @@ func TestListener_LimitExceededDoesNotTerminateServe(t *testing.T) {
 			case <-accepts:
 				// Serve kept running after the rejected connection.
 			case err := <-done:
-				require.True(t, trace.IsLimitExceeded(err),
-					"expected limit exceeded error, got %v", err)
-				t.Fatalf("%s Server.Serve exited on per-IP limit hit: %v", tt.name, err)
+				t.Fatalf("%s Server.Serve exited after rejecting one connection: %v", tt.name, err)
 			case <-time.After(timeout):
 				t.Fatal("timed out waiting for Serve to re-Accept after rejected connection")
 			}

--- a/lib/limiter/limiter_test.go
+++ b/lib/limiter/limiter_test.go
@@ -356,14 +356,20 @@ func (f *fakeConn) Close() error {
 	return nil
 }
 
-// wrappedListener wraps accepted connections so tests can observe when a
-// rejected connection is closed.
+// wrappedListener signals every Accept call so tests can observe that the
+// server's accept loop kept running, and wraps accepted connections so tests
+// can observe when a rejected connection is closed.
 type wrappedListener struct {
 	net.Listener
-	closed chan struct{}
+	closed  chan struct{}
+	accepts chan struct{}
 }
 
 func (l *wrappedListener) Accept() (net.Conn, error) {
+	select {
+	case l.accepts <- struct{}{}:
+	default:
+	}
 	conn, err := l.Listener.Accept()
 	if err != nil {
 		return nil, err
@@ -690,14 +696,17 @@ func TestListener_LimitExceededDoesNotTerminateServe(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			const timeout = 5 * time.Second
 			base, err := net.Listen("tcp", "127.0.0.1:0")
 			require.NoError(t, err)
 			defer base.Close()
 
+			accepts := make(chan struct{}, 1)
 			closed := make(chan struct{}, 1)
 			cl := NewConnectionsLimiter(1)
 			ln, err := NewListener(&wrappedListener{
 				Listener: base,
+				accepts:  accepts,
 				closed:   closed,
 			}, cl)
 			require.NoError(t, err)
@@ -708,7 +717,14 @@ func TestListener_LimitExceededDoesNotTerminateServe(t *testing.T) {
 
 			stop, done := tt.serve(t, ln)
 
-			// Listener.Accept limit exceeds with a tcp connection.
+			// Drain the Accept call Serve makes on startup.
+			select {
+			case <-accepts:
+			case <-time.After(timeout):
+				t.Fatal("timed out waiting for Serve to call Accept")
+			}
+
+			// Force a rejected Accept by dialing into the saturated limiter.
 			c, err := net.Dial("tcp", base.Addr().String())
 			require.NoError(t, err)
 			defer c.Close()
@@ -716,18 +732,20 @@ func TestListener_LimitExceededDoesNotTerminateServe(t *testing.T) {
 			// Wait until the rejected connection is closed by Listener.Accept.
 			select {
 			case <-closed:
-			case <-time.After(2 * time.Second):
+			case <-time.After(timeout):
 				t.Fatal("timed out waiting for rejected connection to close")
 			}
 
 			// Check if server is still running after rejecting connection.
 			select {
+			case <-accepts:
+				// Serve kept running after the rejected connection.
 			case err := <-done:
 				require.True(t, trace.IsLimitExceeded(err),
 					"expected limit exceeded error, got %v", err)
 				t.Fatalf("%s Server.Serve exited on per-IP limit hit: %v", tt.name, err)
-			case <-time.After(100 * time.Millisecond):
-				// Serve kept running after the rejected connection.
+			case <-time.After(timeout):
+				t.Fatal("timed out waiting for Serve to re-Accept after rejected connection")
 			}
 
 			stop()

--- a/lib/limiter/listener.go
+++ b/lib/limiter/listener.go
@@ -32,6 +32,15 @@ type Listener struct {
 	limiter *ConnectionsLimiter
 }
 
+// retryableAcceptError wraps expected per-connection listener errors so the
+// server accept loops keep serving after a single connection is rejected.
+type retryableAcceptError struct {
+	error
+}
+
+func (e retryableAcceptError) Unwrap() error   { return e.error }
+func (e retryableAcceptError) Temporary() bool { return true }
+
 // NewListener creates a [Listener] that enforces the limits of
 // the provided [ConnectionsLimiter] on the all connections accepted
 // by the provided [net.Listener].
@@ -66,7 +75,7 @@ func (l *Listener) Accept() (net.Conn, error) {
 		// return false, which poses problems for consumers relying
 		// on that to determine if the connection was prevented.
 		_ = conn.Close()
-		return nil, trace.Wrap(err)
+		return nil, retryableAcceptError{trace.Wrap(err)}
 	}
 
 	return &wrappedConn{

--- a/lib/limiter/listener.go
+++ b/lib/limiter/listener.go
@@ -25,66 +25,78 @@ import (
 	"github.com/gravitational/trace"
 )
 
+// LimitExceededCallback is called when a connection accepted by Listener is
+// rejected because the per-client connection limit was exceeded.
+type LimitExceededCallback func(remoteAddr string, err error)
+
+// ListenerOption configures Listener.
+type ListenerOption func(*Listener)
+
+// WithLimitExceededCallback configures a callback for rejected connections.
+func WithLimitExceededCallback(fn LimitExceededCallback) ListenerOption {
+	return func(l *Listener) {
+		l.onLimitExceeded = fn
+	}
+}
+
 // Listener wraps a [net.Listener] and applies connection limiting
 // per client to all connections that are accepted.
 type Listener struct {
 	net.Listener
-	limiter *ConnectionsLimiter
+	limiter         *ConnectionsLimiter
+	onLimitExceeded LimitExceededCallback
 }
-
-// retryableAcceptError wraps expected per-connection listener errors so generic
-// server accept loops keep serving after a single connection is rejected.
-type retryableAcceptError struct {
-	error
-}
-
-func (e retryableAcceptError) Unwrap() error   { return e.error }
-func (e retryableAcceptError) Temporary() bool { return true }
-func (e retryableAcceptError) Timeout() bool   { return false }
 
 // NewListener creates a [Listener] that enforces the limits of
 // the provided [ConnectionsLimiter] on the all connections accepted
 // by the provided [net.Listener].
-func NewListener(ln net.Listener, limiter *ConnectionsLimiter) (*Listener, error) {
+func NewListener(ln net.Listener, limiter *ConnectionsLimiter, opts ...ListenerOption) (*Listener, error) {
 	if ln == nil {
 		return nil, trace.BadParameter("listener cannot be nil")
 	}
 
-	return &Listener{
+	l := &Listener{
 		Listener: ln,
 		limiter:  limiter,
-	}, nil
+	}
+	for _, opt := range opts {
+		opt(l)
+	}
+	return l, nil
 }
 
 // Accept waits for and returns the next connection to the listener
-// if the limiter is able to acquire a connection. If not, and the max number
-// of connections has been exceeded then a [trace.LimitExceeded] error
-// is returned.
+// if the limiter is able to acquire a connection. Connections that
+// exceed the per-client limit are closed and do not surface as
+// listener-level accept errors.
 func (l *Listener) Accept() (net.Conn, error) {
-	conn, err := l.Listener.Accept()
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
+	for {
+		conn, err := l.Listener.Accept()
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
 
-	remoteAddr, _, err := net.SplitHostPort(conn.RemoteAddr().String())
-	if err != nil {
-		return nil, trace.NewAggregate(err, conn.Close())
-	}
+		remoteAddr, _, err := net.SplitHostPort(conn.RemoteAddr().String())
+		if err != nil {
+			_ = conn.Close()
+			continue
+		}
 
-	if err := l.limiter.AcquireConnection(remoteAddr); err != nil {
-		// Aggregating the error here makes trace.IsLimitExceeded
-		// return false, which poses problems for consumers relying
-		// on that to determine if the connection was prevented.
-		_ = conn.Close()
-		return nil, retryableAcceptError{trace.Wrap(err)}
-	}
+		if err := l.limiter.AcquireConnection(remoteAddr); err != nil {
+			if l.onLimitExceeded != nil {
+				l.onLimitExceeded(remoteAddr, err)
+			}
+			_ = conn.Close()
+			continue
+		}
 
-	return &wrappedConn{
-		Conn: conn,
-		release: func() {
-			l.limiter.ReleaseConnection(remoteAddr)
-		},
-	}, nil
+		return &wrappedConn{
+			Conn: conn,
+			release: func() {
+				l.limiter.ReleaseConnection(remoteAddr)
+			},
+		}, nil
+	}
 
 }
 

--- a/lib/limiter/listener.go
+++ b/lib/limiter/listener.go
@@ -32,7 +32,7 @@ type Listener struct {
 	limiter *ConnectionsLimiter
 }
 
-// retryableAcceptError wraps expected per-connection listener errors so the
+// retryableAcceptError wraps expected per-connection listener errors so generic
 // server accept loops keep serving after a single connection is rejected.
 type retryableAcceptError struct {
 	error
@@ -40,6 +40,7 @@ type retryableAcceptError struct {
 
 func (e retryableAcceptError) Unwrap() error   { return e.error }
 func (e retryableAcceptError) Temporary() bool { return true }
+func (e retryableAcceptError) Timeout() bool   { return false }
 
 // NewListener creates a [Listener] that enforces the limits of
 // the provided [ConnectionsLimiter] on the all connections accepted

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -3750,7 +3750,10 @@ func (process *TeleportProcess) initSSH() error {
 			}()
 			defer mux.Close()
 
-			listener, err = limiter.WrapListener(mux.SSH())
+			listener, err = limiter.WrapListener(
+				mux.SSH(),
+				sshutils.ConnectionLimitExceededCallback(process.ExitContext(), logger),
+			)
 			if err != nil {
 				return trace.Wrap(err)
 			}
@@ -5383,7 +5386,10 @@ func (process *TeleportProcess) initProxyEndpoint(conn *Connector) error {
 			}
 		}
 
-		rtListener, err := reverseTunnelLimiter.WrapListener(listeners.reverseTunnel)
+		rtListener, err := reverseTunnelLimiter.WrapListener(
+			listeners.reverseTunnel,
+			sshutils.ConnectionLimitExceededCallback(process.ExitContext(), logger),
+		)
 		if err != nil {
 			return trace.Wrap(err)
 		}
@@ -5984,7 +5990,10 @@ func (process *TeleportProcess) initProxyEndpoint(conn *Connector) error {
 
 		// start ssh server
 		go func() {
-			listener, err := proxyLimiter.WrapListener(listeners.ssh)
+			listener, err := proxyLimiter.WrapListener(
+				listeners.ssh,
+				sshutils.ConnectionLimitExceededCallback(process.ExitContext(), logger),
+			)
 			if err != nil {
 				logger.ErrorContext(process.ExitContext(), "Failed to set up SSH proxy server", "error", err)
 				return
@@ -5996,7 +6005,10 @@ func (process *TeleportProcess) initProxyEndpoint(conn *Connector) error {
 
 		// start grpc server
 		go func() {
-			listener, err := proxyLimiter.WrapListener(listeners.sshGRPC)
+			listener, err := proxyLimiter.WrapListener(
+				listeners.sshGRPC,
+				sshutils.ConnectionLimitExceededCallback(process.ExitContext(), logger),
+			)
 			if err != nil {
 				logger.ErrorContext(process.ExitContext(), "Failed to set up SSH proxy server", "error", err)
 				return

--- a/lib/sshutils/server.go
+++ b/lib/sshutils/server.go
@@ -150,6 +150,15 @@ func SetLimiter(limiter *limiter.Limiter) ServerOption {
 	}
 }
 
+// ConnectionLimitExceededCallback records connection limit hits rejected by a
+// limiter.Listener before they reach this server's accept loop.
+func ConnectionLimitExceededCallback(ctx context.Context, logger *slog.Logger) limiter.ListenerOption {
+	return limiter.WithLimitExceededCallback(func(remoteAddr string, err error) {
+		proxyConnectionLimitHitCount.Inc()
+		logger.ErrorContext(ctx, "connection limit exceeded", "client_ip", remoteAddr, "error", err)
+	})
+}
+
 // SetShutdownPollPeriod sets a polling period for graceful shutdowns of SSH servers
 func SetShutdownPollPeriod(period time.Duration) ServerOption {
 	return func(s *Server) error {
@@ -336,7 +345,10 @@ func (s *Server) Start() error {
 			return trace.ConvertSystemError(err)
 		}
 
-		listener, err = s.limiter.WrapListener(listener)
+		listener, err = s.limiter.WrapListener(listener, ConnectionLimitExceededCallback(
+			s.closeContext,
+			s.logger.With("listen_addr", listener.Addr().String()),
+		))
 		if err != nil {
 			return trace.Wrap(err)
 		}


### PR DESCRIPTION
Update limiter.Listener.Accept so per-client connection rejections are handled inside the listener instead of being returned as listener Accept errors.

When an accepted connection exceeds the per-IP connection limit (or has an invalid remote address), the listener now closes that connection and continues accepting. This prevents server accept loops, including `grpc.Server.Serve`, from treating rejected client connections as a fatal listener error and having the server exit.

Also added an optional limit-exceeded callback so callers can preserve logging for rejected connections.

Fixes: https://github.com/gravitational/pressure-washing/issues/223

