### PR TITLE
Fix sqlite backend KeepAlive revision mismatch

### DIFF
--- a/lib/backend/lite/lite.go
+++ b/lib/backend/lite/lite.go
@@ -781,7 +781,7 @@ func (l *Backend) KeepAlive(ctx context.Context, lease backend.Lease, expires ti
 		}
 		defer stmt.Close()
 
-		result, err := stmt.ExecContext(ctx, expires.UTC(), id(now), backend.CreateRevision(), lease.Key.String())
+		result, err := stmt.ExecContext(ctx, expires.UTC(), id(now), item.Revision, lease.Key.String())
 		if err != nil {
 			return trace.Wrap(err)
 		}

--- a/lib/backend/test/suite.go
+++ b/lib/backend/test/suite.go
@@ -760,6 +760,10 @@ func testKeepAlive(t *testing.T, newBackend Constructor) {
 	require.Equal(t, bigValue[:], event.Item.Value)
 	require.WithinDuration(t, expiresAt, event.Item.Expires, 2*time.Second)
 
+	storedItem, err := uut.Get(ctx, item.Key)
+	require.NoError(t, err)
+	require.Equal(t, storedItem.Revision, event.Item.Revision)
+
 	// move the current slightly forward, but still *before* the item's
 	// expiry time
 	clock.Advance(2 * time.Second)
@@ -775,6 +779,10 @@ func testKeepAlive(t *testing.T, newBackend Constructor) {
 	event = requireEvent(t, watcher, types.OpPut, prefix("key"), eventTimeout)
 	require.Equal(t, bigValue[:], event.Item.Value)
 	require.WithinDuration(t, updatedAt, event.Item.Expires, 2*time.Second)
+
+	storedItem, err = uut.Get(ctx, item.Key)
+	require.NoError(t, err)
+	require.Equal(t, storedItem.Revision, event.Item.Revision)
 
 	err = uut.Delete(t.Context(), item.Key)
 	require.NoError(t, err)


### PR DESCRIPTION
Ensures the backend table and events table use the same revision when updating items during KeepAlive operations. Previously a revision was generated for _both_ tables causing watchers and Get calls to observe different revisions.

The backend test suite was updated to validate revisions in the event stream match revisions in the backend.

Resolves https://github.com/gravitational/pressure-washing/issues/139.