### PR TITLE
Fix username matchers for identifier-first login

### DIFF
--- a/lib/auth/moderation/session_access.go
+++ b/lib/auth/moderation/session_access.go
@@ -166,7 +166,7 @@ func (e *SessionAccessEvaluator) matchesJoin(allow *types.SessionJoinPolicy) boo
 
 	for _, allowRole := range allow.Roles {
 		// GlobToRegexp makes sure this is always a valid regexp.
-		expr := regexp.MustCompile("^" + utils.GlobToRegexp(allowRole) + "$")
+		expr := regexp.MustCompile(utils.GlobToRegexp(allowRole))
 
 		for _, policySet := range e.policySets {
 			if expr.MatchString(policySet.Name) {

--- a/lib/join/joinutils/utils.go
+++ b/lib/join/joinutils/utils.go
@@ -36,6 +36,7 @@ import (
 func GlobMatch(pattern, str string) (bool, error) {
 	pattern = regexp.QuoteMeta(pattern)
 	pattern = strings.ReplaceAll(pattern, `\*`, ".*")
+	// note: unlike utils.GlobToRegexp, we also support `?` here
 	pattern = strings.ReplaceAll(pattern, `\?`, ".")
 	pattern = "^" + pattern + "$"
 	matched, err := regexp.MatchString(pattern, str)

--- a/lib/utils/parse/parse.go
+++ b/lib/utils/parse/parse.go
@@ -420,7 +420,7 @@ func newRegexp(raw string, escape bool) (*regexp.Regexp, error) {
 			// replace glob-style wildcards with regexp wildcards
 			// for plain strings, and quote all characters that could
 			// be interpreted in regular expression
-			raw = "^" + utils.GlobToRegexp(raw) + "$"
+			raw = utils.GlobToRegexp(raw)
 		}
 	}
 

--- a/lib/utils/replace.go
+++ b/lib/utils/replace.go
@@ -40,7 +40,7 @@ func ContainsExpansion(val string) bool {
 // with real .* regexp-friendly values, does not modify regexp-compatible values,
 // quotes non-wildcard values
 func GlobToRegexp(in string) string {
-	return replaceWildcard.ReplaceAllString(regexp.QuoteMeta(in), "(.*)")
+	return "^" + replaceWildcard.ReplaceAllString(regexp.QuoteMeta(in), "(.*)") + "$"
 }
 
 // ErrReplaceRegexNotFound is a marker error returned by
@@ -427,7 +427,7 @@ func expressionToRegexp(expression string) string {
 	// replace glob-style wildcards with regexp wildcards
 	// for plain strings, and quote all characters that could
 	// be interpreted in regular expression
-	return "^" + GlobToRegexp(expression) + "$"
+	return GlobToRegexp(expression)
 }
 
 // CompileExpression compiles the given regex expression with Teleport's custom globbing

--- a/lib/utils/utils_test.go
+++ b/lib/utils/utils_test.go
@@ -208,22 +208,22 @@ func TestGlobToRegexp(t *testing.T) {
 		{
 			comment: "simple values are not replaced",
 			in:      "value-value",
-			out:     "value-value",
+			out:     "^value-value$",
 		},
 		{
 			comment: "wildcard and start of string is replaced with regexp wildcard expression",
 			in:      "*",
-			out:     "(.*)",
+			out:     "^(.*)$",
 		},
 		{
 			comment: "wildcard is replaced with regexp wildcard expression",
 			in:      "a-*-b-*",
-			out:     "a-(.*)-b-(.*)",
+			out:     "^a-(.*)-b-(.*)$",
 		},
 		{
 			comment: "special chars are quoted",
 			in:      "a-.*-b-*$",
-			out:     `a-\.(.*)-b-(.*)\$`,
+			out:     `^a-\.(.*)-b-(.*)\$$`,
 		},
 	}
 	for _, testCase := range testCases {

--- a/lib/web/apiserver_test.go
+++ b/lib/web/apiserver_test.go
@@ -11955,3 +11955,21 @@ func TestIPPinning(t *testing.T) {
 	_, err = pack.clt.Get(t.Context(), endpoint, url.Values{})
 	require.NoError(t, err)
 }
+
+func TestGlobMatch(t *testing.T) {
+	for _, test := range []struct {
+		pattern, input string
+		wantGlobMatch  bool
+	}{
+		{"alice", "malice", false},
+		{"alice", "alice-bob", false},
+		{"*@example.com", "foo@example.com.attacker.com", false},
+
+		{"alice", "alice", true},
+		{"*@example.com", "bob@example.com", true},
+	} {
+		got, err := globMatch(test.pattern, test.input)
+		require.NoError(t, err)
+		require.Equal(t, test.wantGlobMatch, got, "pattern=%q input=%q", test.pattern, test.input)
+	}
+}


### PR DESCRIPTION
utils.GlobToRegexp has a gotcha - the regexp it returns isn't anchored with ^ and $ characters (these are typically added by the caller).

The only place in Teleport where the caller failed to add anchors is in the username matchers. As a result, we may end up matching partial strings and presenting more connectors than expected to the user.

In addition to fixing the direct issue, also update GlobToRegexp to add the anchors itself, reducing the chance of similar mistakes in the future.

Closes gravitational/pressure-washing#30

## Manual Test Plan
### Test Environment

### Test Cases
- [ ] 
