### PR TITLE
[v18] Fix JIT Access Request regression in mixed-version clusters

### DIFF
--- a/lib/componentfeatures/utils.go
+++ b/lib/componentfeatures/utils.go
@@ -21,6 +21,9 @@ package componentfeatures
 import (
 	"context"
 	"log/slog"
+	"slices"
+
+	"github.com/coreos/go-semver/semver"
 
 	componentfeaturesv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/componentfeatures/v1"
 	"github.com/gravitational/teleport/api/types"
@@ -172,7 +175,7 @@ func GetClusterAuthProxyServerFeatures(ctx context.Context, clt AuthProxyServers
 		features = append(features, nil)
 	} else {
 		for _, srv := range allProxies {
-			features = append(features, srv.GetComponentFeatures())
+			features = append(features, GetEffectiveServerFeatures(srv))
 		}
 	}
 
@@ -189,9 +192,43 @@ func GetClusterAuthProxyServerFeatures(ctx context.Context, clt AuthProxyServers
 		features = append(features, nil)
 	} else {
 		for _, srv := range allAuthServers {
-			features = append(features, srv.GetComponentFeatures())
+			features = append(features, GetEffectiveServerFeatures(srv))
 		}
 	}
 
 	return Intersect(features...)
+}
+
+// versionedComponent is implemented by any server type that advertises a
+// version and a set of component features.
+//
+// TODO(kiosion): DELETE in 20.0.0
+type versionedComponent interface {
+	GetTeleportVersion() string
+	GetComponentFeatures() *componentfeaturesv1.ComponentFeatures
+}
+
+// GetEffectiveServerFeatures computes a server's effective feature support.
+// Servers between v18.6.4 and v18.7.5 advertise FeatureResourceConstraintsV1
+// but predate the constraint parsing implementation; for those versions, the
+// advertisement should be stripped prior to intersection so clients don't show
+// constraints UI flows.
+//
+// TODO(kiosion): DELETE in 20.0.0
+func GetEffectiveServerFeatures(component versionedComponent) *componentfeaturesv1.ComponentFeatures {
+	f := component.GetComponentFeatures()
+	if f == nil {
+		return f
+	}
+	ver, err := semver.NewVersion(component.GetTeleportVersion())
+	if err != nil {
+		return f
+	}
+	if ver.LessThan(semver.Version{Major: 18, Minor: 7, Patch: 6}) {
+		features := slices.DeleteFunc(slices.Clone(f.GetFeatures()), func(id componentfeaturesv1.ComponentFeatureID) bool {
+			return id == FeatureResourceConstraintsV1.ToProto()
+		})
+		return &componentfeaturesv1.ComponentFeatures{Features: features}
+	}
+	return f
 }

--- a/lib/componentfeatures/utils_test.go
+++ b/lib/componentfeatures/utils_test.go
@@ -335,6 +335,37 @@ func TestGetClusterAuthProxyServerFeatures(t *testing.T) {
 	}
 }
 
+func TestGetEffectiveServerFeatures(t *testing.T) {
+	t.Parallel()
+	rcv1 := FeatureResourceConstraintsV1
+	otherFeature := FeatureID(9999)
+	makeAppServer := func(t *testing.T, version string, features *componentfeaturesv1.ComponentFeatures) types.AppServer {
+		app, err := types.NewAppV3(types.Metadata{Name: "aws-app"}, types.AppSpecV3{URI: "https://console.aws.amazon.com", Cloud: "AWS"})
+		require.NoError(t, err)
+		srv, err := types.NewAppServerV3FromApp(app, "localhost", "host-1")
+		require.NoError(t, err)
+		srv.Spec.Version = version
+		srv.SetComponentFeatures(features)
+		return srv
+	}
+
+	t.Run("old app server has ResourceConstraintsV1 stripped", func(t *testing.T) {
+		srv := makeAppServer(t, "18.7.5", New(rcv1, otherFeature))
+		result := GetEffectiveServerFeatures(srv)
+		require.ElementsMatch(t, New(otherFeature).GetFeatures(), result.GetFeatures())
+	})
+	t.Run("new app server keeps ResourceConstraintsV1", func(t *testing.T) {
+		srv := makeAppServer(t, "18.7.6", New(rcv1, otherFeature))
+		result := GetEffectiveServerFeatures(srv)
+		require.ElementsMatch(t, New(rcv1, otherFeature).GetFeatures(), result.GetFeatures())
+	})
+	t.Run("nil features on old app server returns empty", func(t *testing.T) {
+		srv := makeAppServer(t, "18.6.4", nil)
+		result := GetEffectiveServerFeatures(srv)
+		require.Empty(t, result.GetFeatures())
+	})
+}
+
 type fakeAuthProxyServersLister struct {
 	proxies       []types.Server
 	auths         []types.Server

--- a/lib/services/access_checker_test.go
+++ b/lib/services/access_checker_test.go
@@ -1145,6 +1145,22 @@ func TestAccessChecker_Constraints_AwsConsole(t *testing.T) {
 		NewAppAWSLoginMatcher("arn:aws:iam::123456789012:role/ReadOnly"),
 	)
 	require.NoError(t, err)
+
+	// 3) Should fail with AWSRoleARNMatcher: same constraint check as (1)
+	err = ac.CheckAccess(
+		&app,
+		AccessState{MFARequired: MFARequiredNever},
+		&AWSRoleARNMatcher{RoleARN: "arn:aws:iam::123456789012:role/Admin"},
+	)
+	require.Error(t, err)
+
+	// 4) Should pass with AWSRoleARNMatcher: same constraint check as (2)
+	err = ac.CheckAccess(
+		&app,
+		AccessState{MFARequired: MFARequiredNever},
+		&AWSRoleARNMatcher{RoleARN: "arn:aws:iam::123456789012:role/ReadOnly"},
+	)
+	require.NoError(t, err)
 }
 
 // TestUserSessionRoleNotFoundError ensures that role not found errors during user session access checks include UserSessionRoleNotFoundErrorMsg when appropriate,

--- a/lib/services/resource_constraints.go
+++ b/lib/services/resource_constraints.go
@@ -60,12 +60,17 @@ func WithConstraints(rc *types.ResourceConstraints) MatcherTransform {
 		}
 
 		return func(m RoleMatcher) RoleMatcher {
-			lm, ok := m.(*awsAppLoginMatcher)
-			if !ok {
+			var awsRole string
+			switch lm := m.(type) {
+			case *awsAppLoginMatcher:
+				awsRole = lm.awsRole
+			case *AWSRoleARNMatcher:
+				awsRole = lm.RoleARN
+			default:
 				return m
 			}
 			return RoleMatcherFunc(func(role types.Role, cond types.RoleConditionType) (bool, error) {
-				if _, ok := allowedSet[lm.awsRole]; !ok {
+				if _, ok := allowedSet[awsRole]; !ok {
 					return false, nil
 				}
 				return m.Match(role, cond)

--- a/lib/sshca/identity.go
+++ b/lib/sshca/identity.go
@@ -525,12 +525,19 @@ func DecodeIdentity(cert *ssh.Certificate) (*Identity, error) {
 		allowedResourceAccessIDs = resourceAccessIDs
 	}
 	if len(allowedResourceAccessIDs) > 0 {
-		// Prefer new extension when present, old extension is redundant
-		// (exists for backward-compat with older agents/proxies).
+		// Prefer new extension when present.
 		ident.AllowedResourceAccessIDs = allowedResourceAccessIDs
+		// Populate AllowedResourceIDs with any present unconstrained resources,
+		// so any path re-encoding this identity persists the resourceIDs
+		// to the legacy extension instead of adding a sentinel.
+		//
+		// TODO(kiosion): DELETE in 20.0.0
+		ident.AllowedResourceIDs, _ = types.UnwrapResourceAccessIDs(allowedResourceAccessIDs)
 	} else if len(allowedResourceIDs) > 0 {
-		// Fallback for certs from older auth servers that don't write the new extension.
+		// Fallback for certs from older Auths that don't write the new extension.
 		ident.AllowedResourceAccessIDs = types.CombineAsResourceAccessIDs(allowedResourceIDs, nil)
+		//nolint:staticcheck // TODO(kiosion): deprecated, to be removed in v20
+		ident.AllowedResourceIDs = allowedResourceIDs
 	}
 
 	ident.ConnectionDiagnosticID = takeValue(teleport.CertExtensionConnectionDiagnosticID)

--- a/lib/sshca/identity_test.go
+++ b/lib/sshca/identity_test.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/crypto/ssh"
 	"google.golang.org/protobuf/testing/protocmp"
@@ -157,4 +158,95 @@ func TestIdentityConversion(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Empty(t, cmp.Diff(ident, ident2, protocmp.Transform()))
+}
+
+// TestAllowedResources_SSHEncodeDecode verifies that AllowedResourceIDs and
+// AllowedResourceAccessIDs are populated correctly after an SSH cert's
+// encode-decode cycle across all resource mix permutations.
+func TestAllowedResources_SSHEncodeDecode(t *testing.T) {
+	plainNode := types.ResourceID{ClusterName: "cluster", Kind: types.KindNode, Name: "prod-node"}
+	plainDB := types.ResourceID{ClusterName: "cluster", Kind: types.KindDatabase, Name: "prod-db"}
+	constrainedApp := types.ResourceAccessID{
+		Id: types.ResourceID{ClusterName: "cluster", Kind: types.KindApp, Name: "aws-console"},
+		Constraints: &types.ResourceConstraints{
+			Version: types.V1,
+			Details: &types.ResourceConstraints_AwsConsole{
+				AwsConsole: &types.AWSConsoleResourceConstraints{
+					RoleArns: []string{"arn:aws:iam::123456789012:role/DevOps"},
+				},
+			},
+		},
+	}
+
+	tcs := []struct {
+		name                         string
+		allowedResourceIDs           []types.ResourceID
+		allowedResourceAccessIDs     []types.ResourceAccessID
+		wantAllowedResourceIDs       []types.ResourceID
+		wantAllowedResourceAccessIDs []types.ResourceAccessID
+	}{
+		{
+			name:                         "plain resources only (new auth cert)",
+			allowedResourceIDs:           []types.ResourceID{plainNode, plainDB},
+			allowedResourceAccessIDs:     types.ResourceIDsToResourceAccessIDs([]types.ResourceID{plainNode, plainDB}),
+			wantAllowedResourceIDs:       []types.ResourceID{plainNode, plainDB},
+			wantAllowedResourceAccessIDs: types.ResourceIDsToResourceAccessIDs([]types.ResourceID{plainNode, plainDB}),
+		},
+		{
+			name:                         "constrained resources only (new auth cert)",
+			allowedResourceIDs:           nil,
+			allowedResourceAccessIDs:     []types.ResourceAccessID{constrainedApp},
+			wantAllowedResourceIDs:       nil,
+			wantAllowedResourceAccessIDs: []types.ResourceAccessID{constrainedApp},
+		},
+		{
+			name:                     "mixed plain and constrained (new auth cert)",
+			allowedResourceIDs:       []types.ResourceID{plainNode},
+			allowedResourceAccessIDs: append(types.ResourceIDsToResourceAccessIDs([]types.ResourceID{plainNode}), constrainedApp),
+			wantAllowedResourceIDs:   []types.ResourceID{plainNode},
+			wantAllowedResourceAccessIDs: append(
+				types.ResourceIDsToResourceAccessIDs([]types.ResourceID{plainNode}),
+				constrainedApp,
+			),
+		},
+		{
+			name:                         "old auth cert (only old extension)",
+			allowedResourceIDs:           []types.ResourceID{plainNode, plainDB},
+			allowedResourceAccessIDs:     nil,
+			wantAllowedResourceIDs:       []types.ResourceID{plainNode, plainDB},
+			wantAllowedResourceAccessIDs: types.ResourceIDsToResourceAccessIDs([]types.ResourceID{plainNode, plainDB}),
+		},
+	}
+
+	for _, tt := range tcs {
+		t.Run(tt.name, func(t *testing.T) {
+			ident := &Identity{
+				ValidBefore: uint64(time.Now().Add(time.Hour).Unix()),
+				CertType:    ssh.UserCert,
+				Username:    "test-user",
+				Roles:       []string{"access"},
+				//nolint:staticcheck // testing deprecated field
+				AllowedResourceIDs:       tt.allowedResourceIDs,
+				AllowedResourceAccessIDs: tt.allowedResourceAccessIDs,
+			}
+
+			cert, err := ident.Encode(constants.CertificateFormatStandard)
+			require.NoError(t, err)
+
+			decoded, err := DecodeIdentity(cert)
+			require.NoError(t, err)
+
+			assert.ElementsMatch(t, tt.wantAllowedResourceAccessIDs, decoded.AllowedResourceAccessIDs,
+				"AllowedResourceAccessIDs mismatch")
+			//nolint:staticcheck // testing deprecated field
+			assert.ElementsMatch(t, tt.wantAllowedResourceIDs, decoded.AllowedResourceIDs,
+				"AllowedResourceIDs mismatch")
+
+			//nolint:staticcheck // testing deprecated field
+			for _, rid := range decoded.AllowedResourceIDs {
+				assert.False(t, types.IsSentinelResourceID(rid),
+					"sentinel value not expected in decoded AllowedResourceIDs")
+			}
+		})
+	}
 }

--- a/lib/tlsca/ca.go
+++ b/lib/tlsca/ca.go
@@ -1458,12 +1458,20 @@ func FromSubject(subject pkix.Name, expires time.Time) (*Identity, error) {
 	}
 
 	if len(allowedResourceAccessIDs) > 0 {
-		// Prefer new extension when present, old extension is redundant
-		// (exists for backward-compat with older agents/proxies).
+		// Prefer new extension when present.
 		id.AllowedResourceAccessIDs = allowedResourceAccessIDs
+		// Populate AllowedResourceIDs with any present unconstrained resources,
+		// so any path re-encoding this identity (e.g., database proxy CSR signing)
+		// persists the resourceIDs to the legacy extension, instead of adding a
+		// sentinel.
+		//
+		// TODO(kiosion): DELETE in 20.0.0
+		id.AllowedResourceIDs, _ = types.UnwrapResourceAccessIDs(allowedResourceAccessIDs)
 	} else if len(allowedResourceIDs) > 0 {
-		// Fallback for certs from older auth servers that don't write the new extension.
+		// Fallback for certs from older Auths that don't write the new extension.
 		id.AllowedResourceAccessIDs = types.CombineAsResourceAccessIDs(allowedResourceIDs, nil)
+		//nolint:staticcheck // TODO(kiosion): deprecated, to be removed in v20
+		id.AllowedResourceIDs = allowedResourceIDs
 	}
 
 	if err := id.CheckAndSetDefaults(); err != nil {

--- a/lib/tlsca/ca_test.go
+++ b/lib/tlsca/ca_test.go
@@ -497,7 +497,8 @@ func TestIdentity_ToFromSubject(t *testing.T) {
 
 // TestAllowedResources_EncodeDecodeCycle verifies that AllowedResourceIDs and
 // AllowedResourceAccessIDs survive encode-decode-re-encode cycles correctly
-// across all resource mix permutations.
+// across all resource mix permutations. The re-encode step simulates the
+// database proxy CSR signing path.
 func TestAllowedResources_EncodeDecodeCycle(t *testing.T) {
 	plainNode := types.ResourceID{ClusterName: "cluster", Kind: types.KindNode, Name: "prod-node"}
 	plainDB := types.ResourceID{ClusterName: "cluster", Kind: types.KindDatabase, Name: "prod-db"}
@@ -512,6 +513,7 @@ func TestAllowedResources_EncodeDecodeCycle(t *testing.T) {
 			},
 		},
 	}
+	sentinel := types.CreateSentinelResourceID()
 
 	tests := []struct {
 		name string
@@ -521,8 +523,8 @@ func TestAllowedResources_EncodeDecodeCycle(t *testing.T) {
 		// expected state after decode
 		wantAllowedResourceIDs       []types.ResourceID
 		wantAllowedResourceAccessIDs []types.ResourceAccessID
-		// expected state after decode-re-encode-decode roundtrip
-		wantRoundtripSameAsFirst bool
+		// expected contents of the legacy extension after re-encode
+		wantLegacyExtension []types.ResourceID
 	}{
 		{
 			name:                         "plain resources only (new auth cert)",
@@ -530,15 +532,15 @@ func TestAllowedResources_EncodeDecodeCycle(t *testing.T) {
 			allowedResourceAccessIDs:     types.ResourceIDsToResourceAccessIDs([]types.ResourceID{plainNode, plainDB}),
 			wantAllowedResourceIDs:       []types.ResourceID{plainNode, plainDB},
 			wantAllowedResourceAccessIDs: types.ResourceIDsToResourceAccessIDs([]types.ResourceID{plainNode, plainDB}),
-			wantRoundtripSameAsFirst:     true,
+			wantLegacyExtension:          []types.ResourceID{plainNode, plainDB},
 		},
 		{
 			name:                         "constrained resources only (new auth cert)",
-			allowedResourceIDs:           nil, // triggers sentinel in old extension
+			allowedResourceIDs:           nil,
 			allowedResourceAccessIDs:     []types.ResourceAccessID{constrainedApp},
-			wantAllowedResourceIDs:       nil, // no plain resources to unwrap
+			wantAllowedResourceIDs:       nil,
 			wantAllowedResourceAccessIDs: []types.ResourceAccessID{constrainedApp},
-			wantRoundtripSameAsFirst:     true,
+			wantLegacyExtension:          []types.ResourceID{sentinel},
 		},
 		{
 			name:                     "mixed plain and constrained (new auth cert)",
@@ -549,28 +551,29 @@ func TestAllowedResources_EncodeDecodeCycle(t *testing.T) {
 				types.ResourceIDsToResourceAccessIDs([]types.ResourceID{plainNode}),
 				constrainedApp,
 			),
-			wantRoundtripSameAsFirst: true,
+			wantLegacyExtension: []types.ResourceID{plainNode},
 		},
 		{
 			name:                         "old auth cert (only old extension, no new extension)",
 			allowedResourceIDs:           []types.ResourceID{plainNode, plainDB},
-			allowedResourceAccessIDs:     nil, // old auth doesn't write new extension
+			allowedResourceAccessIDs:     nil,
 			wantAllowedResourceIDs:       []types.ResourceID{plainNode, plainDB},
 			wantAllowedResourceAccessIDs: types.ResourceIDsToResourceAccessIDs([]types.ResourceID{plainNode, plainDB}),
-			wantRoundtripSameAsFirst:     true,
+			wantLegacyExtension:          []types.ResourceID{plainNode, plainDB},
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			identity := &Identity{
-				Username:                 "test-user",
-				Groups:                   []string{"access"},
+				Username: "test-user",
+				Groups:   []string{"access"},
+				//nolint:staticcheck // testing deprecated field
 				AllowedResourceIDs:       tt.allowedResourceIDs,
 				AllowedResourceAccessIDs: tt.allowedResourceAccessIDs,
 			}
 
-			// Encode → decode
+			// Encode then decode
 			subj, err := identity.Subject()
 			require.NoError(t, err)
 			subj.Names = append(subj.Names, subj.ExtraNames...)
@@ -579,38 +582,14 @@ func TestAllowedResources_EncodeDecodeCycle(t *testing.T) {
 			decoded, err := FromSubject(subj, time.Time{})
 			require.NoError(t, err)
 
-			require.ElementsMatch(t, tt.wantAllowedResourceAccessIDs, decoded.AllowedResourceAccessIDs,
-				"AllowedResourceAccessIDs mismatch after first decode")
+			assert.ElementsMatch(t, tt.wantAllowedResourceAccessIDs, decoded.AllowedResourceAccessIDs)
 			//nolint:staticcheck // testing deprecated field
-			require.ElementsMatch(t, tt.wantAllowedResourceIDs, decoded.AllowedResourceIDs,
-				"AllowedResourceIDs mismatch after first decode")
+			assert.ElementsMatch(t, tt.wantAllowedResourceIDs, decoded.AllowedResourceIDs)
 
-			if !tt.wantRoundtripSameAsFirst {
-				return
-			}
-
-			// re-encode then decode to simulate db csr signing path
+			// Re-encode, verify legacy extension, decode again
 			subj2, err := decoded.Subject()
 			require.NoError(t, err)
-
-			// verify the raw re-encoded subject's legacy extension directly.
-			// This is what an old agent would parse; if it contains
-			// the sentinel instead of real IDs, the agent denies access.
-			// Only check when plain resources are expected; for constrained-
-			// resources-only requests, the sentinel value is expected.
-			if len(tt.wantAllowedResourceIDs) > 0 {
-				for _, name := range subj2.ExtraNames {
-					if !name.Type.Equal(AllowedResourcesASN1ExtensionOID) {
-						continue
-					}
-					rawIDs, err := types.ResourceIDsFromString(name.Value.(string))
-					require.NoError(t, err)
-					for _, rid := range rawIDs {
-						require.False(t, types.IsSentinelResourceID(rid),
-							"sentinel value not appear expected in re-encoded legacy extension")
-					}
-				}
-			}
+			assert.ElementsMatch(t, tt.wantLegacyExtension, legacyExtensionIDs(t, subj2))
 
 			subj2.Names = append(subj2.Names, subj2.ExtraNames...)
 			subj2.ExtraNames = nil
@@ -618,13 +597,26 @@ func TestAllowedResources_EncodeDecodeCycle(t *testing.T) {
 			roundtripped, err := FromSubject(subj2, time.Time{})
 			require.NoError(t, err)
 
-			require.ElementsMatch(t, decoded.AllowedResourceAccessIDs, roundtripped.AllowedResourceAccessIDs,
-				"AllowedResourceAccessIDs changed after re-encode roundtrip")
+			assert.ElementsMatch(t, decoded.AllowedResourceAccessIDs, roundtripped.AllowedResourceAccessIDs)
 			//nolint:staticcheck // testing deprecated field
-			require.ElementsMatch(t, decoded.AllowedResourceIDs, roundtripped.AllowedResourceIDs,
-				"AllowedResourceIDs changed after re-encode roundtrip")
+			assert.ElementsMatch(t, decoded.AllowedResourceIDs, roundtripped.AllowedResourceIDs)
 		})
 	}
+}
+
+// legacyExtensionIDs extracts ResourceIDs from the legacy AllowedResources
+// extension (OID 1.3.9999.2.10) in a pkix.Name subject. This is what an
+// old agent would parse from the cert.
+func legacyExtensionIDs(t *testing.T, subj pkix.Name) []types.ResourceID {
+	t.Helper()
+	for _, name := range subj.ExtraNames {
+		if name.Type.Equal(AllowedResourcesASN1ExtensionOID) {
+			ids, err := types.ResourceIDsFromString(name.Value.(string))
+			require.NoError(t, err)
+			return ids
+		}
+	}
+	return nil
 }
 
 func TestGCPExtensions(t *testing.T) {

--- a/lib/tlsca/ca_test.go
+++ b/lib/tlsca/ca_test.go
@@ -495,6 +495,138 @@ func TestIdentity_ToFromSubject(t *testing.T) {
 	}
 }
 
+// TestAllowedResources_EncodeDecodeCycle verifies that AllowedResourceIDs and
+// AllowedResourceAccessIDs survive encode-decode-re-encode cycles correctly
+// across all resource mix permutations.
+func TestAllowedResources_EncodeDecodeCycle(t *testing.T) {
+	plainNode := types.ResourceID{ClusterName: "cluster", Kind: types.KindNode, Name: "prod-node"}
+	plainDB := types.ResourceID{ClusterName: "cluster", Kind: types.KindDatabase, Name: "prod-db"}
+	constrainedApp := types.ResourceAccessID{
+		Id: types.ResourceID{ClusterName: "cluster", Kind: types.KindApp, Name: "aws-console"},
+		Constraints: &types.ResourceConstraints{
+			Version: types.V1,
+			Details: &types.ResourceConstraints_AwsConsole{
+				AwsConsole: &types.AWSConsoleResourceConstraints{
+					RoleArns: []string{"arn:aws:iam::123456789012:role/DevOps"},
+				},
+			},
+		},
+	}
+
+	tests := []struct {
+		name string
+		// identity fields set before first encode
+		allowedResourceIDs       []types.ResourceID
+		allowedResourceAccessIDs []types.ResourceAccessID
+		// expected state after decode
+		wantAllowedResourceIDs       []types.ResourceID
+		wantAllowedResourceAccessIDs []types.ResourceAccessID
+		// expected state after decode-re-encode-decode roundtrip
+		wantRoundtripSameAsFirst bool
+	}{
+		{
+			name:                         "plain resources only (new auth cert)",
+			allowedResourceIDs:           []types.ResourceID{plainNode, plainDB},
+			allowedResourceAccessIDs:     types.ResourceIDsToResourceAccessIDs([]types.ResourceID{plainNode, plainDB}),
+			wantAllowedResourceIDs:       []types.ResourceID{plainNode, plainDB},
+			wantAllowedResourceAccessIDs: types.ResourceIDsToResourceAccessIDs([]types.ResourceID{plainNode, plainDB}),
+			wantRoundtripSameAsFirst:     true,
+		},
+		{
+			name:                         "constrained resources only (new auth cert)",
+			allowedResourceIDs:           nil, // triggers sentinel in old extension
+			allowedResourceAccessIDs:     []types.ResourceAccessID{constrainedApp},
+			wantAllowedResourceIDs:       nil, // no plain resources to unwrap
+			wantAllowedResourceAccessIDs: []types.ResourceAccessID{constrainedApp},
+			wantRoundtripSameAsFirst:     true,
+		},
+		{
+			name:                     "mixed plain and constrained (new auth cert)",
+			allowedResourceIDs:       []types.ResourceID{plainNode},
+			allowedResourceAccessIDs: append(types.ResourceIDsToResourceAccessIDs([]types.ResourceID{plainNode}), constrainedApp),
+			wantAllowedResourceIDs:   []types.ResourceID{plainNode},
+			wantAllowedResourceAccessIDs: append(
+				types.ResourceIDsToResourceAccessIDs([]types.ResourceID{plainNode}),
+				constrainedApp,
+			),
+			wantRoundtripSameAsFirst: true,
+		},
+		{
+			name:                         "old auth cert (only old extension, no new extension)",
+			allowedResourceIDs:           []types.ResourceID{plainNode, plainDB},
+			allowedResourceAccessIDs:     nil, // old auth doesn't write new extension
+			wantAllowedResourceIDs:       []types.ResourceID{plainNode, plainDB},
+			wantAllowedResourceAccessIDs: types.ResourceIDsToResourceAccessIDs([]types.ResourceID{plainNode, plainDB}),
+			wantRoundtripSameAsFirst:     true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			identity := &Identity{
+				Username:                 "test-user",
+				Groups:                   []string{"access"},
+				AllowedResourceIDs:       tt.allowedResourceIDs,
+				AllowedResourceAccessIDs: tt.allowedResourceAccessIDs,
+			}
+
+			// Encode → decode
+			subj, err := identity.Subject()
+			require.NoError(t, err)
+			subj.Names = append(subj.Names, subj.ExtraNames...)
+			subj.ExtraNames = nil
+
+			decoded, err := FromSubject(subj, time.Time{})
+			require.NoError(t, err)
+
+			require.ElementsMatch(t, tt.wantAllowedResourceAccessIDs, decoded.AllowedResourceAccessIDs,
+				"AllowedResourceAccessIDs mismatch after first decode")
+			//nolint:staticcheck // testing deprecated field
+			require.ElementsMatch(t, tt.wantAllowedResourceIDs, decoded.AllowedResourceIDs,
+				"AllowedResourceIDs mismatch after first decode")
+
+			if !tt.wantRoundtripSameAsFirst {
+				return
+			}
+
+			// re-encode then decode to simulate db csr signing path
+			subj2, err := decoded.Subject()
+			require.NoError(t, err)
+
+			// verify the raw re-encoded subject's legacy extension directly.
+			// This is what an old agent would parse; if it contains
+			// the sentinel instead of real IDs, the agent denies access.
+			// Only check when plain resources are expected; for constrained-
+			// resources-only requests, the sentinel value is expected.
+			if len(tt.wantAllowedResourceIDs) > 0 {
+				for _, name := range subj2.ExtraNames {
+					if !name.Type.Equal(AllowedResourcesASN1ExtensionOID) {
+						continue
+					}
+					rawIDs, err := types.ResourceIDsFromString(name.Value.(string))
+					require.NoError(t, err)
+					for _, rid := range rawIDs {
+						require.False(t, types.IsSentinelResourceID(rid),
+							"sentinel value not appear expected in re-encoded legacy extension")
+					}
+				}
+			}
+
+			subj2.Names = append(subj2.Names, subj2.ExtraNames...)
+			subj2.ExtraNames = nil
+
+			roundtripped, err := FromSubject(subj2, time.Time{})
+			require.NoError(t, err)
+
+			require.ElementsMatch(t, decoded.AllowedResourceAccessIDs, roundtripped.AllowedResourceAccessIDs,
+				"AllowedResourceAccessIDs changed after re-encode roundtrip")
+			//nolint:staticcheck // testing deprecated field
+			require.ElementsMatch(t, decoded.AllowedResourceIDs, roundtripped.AllowedResourceIDs,
+				"AllowedResourceIDs changed after re-encode roundtrip")
+		})
+	}
+}
+
 func TestGCPExtensions(t *testing.T) {
 	clock := clockwork.NewFakeClock()
 	ca, err := FromKeys([]byte(fixtures.TLSCACertPEM), []byte(fixtures.TLSCAKeyPEM))

--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -3550,16 +3550,15 @@ func (h *Handler) clusterUnifiedResourcesGet(w http.ResponseWriter, request *htt
 
 // appServerEffectiveFeatures computes the effective feature set for an app server,
 // intersected with cluster-wide auth/proxy features. App servers between v18.6.4 and
-// v18.7.2 advertise FeatureResourceConstraintsV1 but predate the constraint enforcement
+// v18.7.5 advertise FeatureResourceConstraintsV1 but predate the constraint enforcement
 // code; for those versions, the advertisement is stripped before intersection so the
 // frontend doesn't show the constraints UI.
 //
 // TODO(kiosion): DELETE in 20.0.0
 func appServerEffectiveFeatures(appServer types.AppServer, clusterFeatures *componentfeaturesv1.ComponentFeatures) *componentfeaturesv1.ComponentFeatures {
 	appFeatures := appServer.GetComponentFeatures()
-	minVer, minVerErr := semver.NewVersion("18.7.3")
 	ver, verErr := semver.NewVersion(appServer.GetTeleportVersion())
-	if verErr == nil && minVerErr == nil && ver.LessThan(*minVer) && appFeatures != nil {
+	if verErr == nil && ver.LessThan(semver.Version{Major: 18, Minor: 7, Patch: 6}) && appFeatures != nil {
 		features := slices.DeleteFunc(slices.Clone(appFeatures.GetFeatures()), func(f componentfeaturesv1.ComponentFeatureID) bool {
 			return f == componentfeatures.FeatureResourceConstraintsV1.ToProto()
 		})

--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -3499,7 +3499,7 @@ func (h *Handler) clusterUnifiedResourcesGet(w http.ResponseWriter, request *htt
 			// Compute end-to-end feature support for this app: only features that are supported by the AppServer *and*
 			// by all required cluster hops (Auth + Proxy), so clients can hide features that would fail somewhere
 			// along the request path.
-			appComponentFeatures := appServerEffectiveFeatures(r, clusterAuthProxyServerFeatures)
+			appComponentFeatures := componentfeatures.Intersect(componentfeatures.GetEffectiveServerFeatures(r), clusterAuthProxyServerFeatures)
 
 			app := ui.MakeApp(r.GetApp(), ui.MakeAppsConfig{
 				LocalClusterName:      h.auth.clusterName,
@@ -3546,25 +3546,6 @@ func (h *Handler) clusterUnifiedResourcesGet(w http.ResponseWriter, request *htt
 	}
 
 	return resp, nil
-}
-
-// appServerEffectiveFeatures computes the effective feature set for an app server,
-// intersected with cluster-wide auth/proxy features. App servers between v18.6.4 and
-// v18.7.5 advertise FeatureResourceConstraintsV1 but predate the constraint enforcement
-// code; for those versions, the advertisement is stripped before intersection so the
-// frontend doesn't show the constraints UI.
-//
-// TODO(kiosion): DELETE in 20.0.0
-func appServerEffectiveFeatures(appServer types.AppServer, clusterFeatures *componentfeaturesv1.ComponentFeatures) *componentfeaturesv1.ComponentFeatures {
-	appFeatures := appServer.GetComponentFeatures()
-	ver, verErr := semver.NewVersion(appServer.GetTeleportVersion())
-	if verErr == nil && ver.LessThan(semver.Version{Major: 18, Minor: 7, Patch: 6}) && appFeatures != nil {
-		features := slices.DeleteFunc(slices.Clone(appFeatures.GetFeatures()), func(f componentfeaturesv1.ComponentFeatureID) bool {
-			return f == componentfeatures.FeatureResourceConstraintsV1.ToProto()
-		})
-		appFeatures = &componentfeaturesv1.ComponentFeatures{Features: features}
-	}
-	return componentfeatures.Intersect(appFeatures, clusterFeatures)
 }
 
 // clusterNodesGet returns a list of nodes for a given cluster site.

--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -44,7 +44,6 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/coreos/go-semver/semver"
 	gogoproto "github.com/gogo/protobuf/proto"
 	"github.com/google/safetext/shsprintf"
 	"github.com/google/uuid"
@@ -66,7 +65,6 @@ import (
 	"github.com/gravitational/teleport/api/client/webclient"
 	"github.com/gravitational/teleport/api/constants"
 	apidefaults "github.com/gravitational/teleport/api/defaults"
-	componentfeaturesv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/componentfeatures/v1"
 	mfav1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/mfa/v1"
 	notificationsv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/notifications/v1"
 	summarizerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/summarizer/v1"

--- a/lib/web/apiserver_test.go
+++ b/lib/web/apiserver_test.go
@@ -85,7 +85,6 @@ import (
 	"github.com/gravitational/teleport/api/client/webclient"
 	"github.com/gravitational/teleport/api/constants"
 	apidefaults "github.com/gravitational/teleport/api/defaults"
-	componentfeaturesv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/componentfeatures/v1"
 	devicepb "github.com/gravitational/teleport/api/gen/proto/go/teleport/devicetrust/v1"
 	kubeproto "github.com/gravitational/teleport/api/gen/proto/go/teleport/kube/v1"
 	mfav1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/mfa/v1"

--- a/lib/web/apiserver_test.go
+++ b/lib/web/apiserver_test.go
@@ -1442,12 +1442,12 @@ func Test_appServerEffectiveFeatures(t *testing.T) {
 	}
 
 	t.Run("old app server has ResourceConstraintsV1 stripped", func(t *testing.T) {
-		srv := makeAppServer(t, "18.7.0", componentfeatures.New(rcv1, otherFeature))
+		srv := makeAppServer(t, "18.7.5", componentfeatures.New(rcv1, otherFeature))
 		result := appServerEffectiveFeatures(srv, clusterFeatures)
 		require.ElementsMatch(t, componentfeatures.New(otherFeature).GetFeatures(), result.GetFeatures())
 	})
 	t.Run("new app server keeps ResourceConstraintsV1", func(t *testing.T) {
-		srv := makeAppServer(t, "18.7.3", componentfeatures.New(rcv1, otherFeature))
+		srv := makeAppServer(t, "18.7.6", componentfeatures.New(rcv1, otherFeature))
 		result := appServerEffectiveFeatures(srv, clusterFeatures)
 		require.ElementsMatch(t, componentfeatures.New(rcv1, otherFeature).GetFeatures(), result.GetFeatures())
 	})

--- a/lib/web/apiserver_test.go
+++ b/lib/web/apiserver_test.go
@@ -1426,38 +1426,6 @@ func TestUnifiedResourcesGet_AppComponentFeatures(t *testing.T) {
 	require.ElementsMatch(t, []int{int(feature1)}, app.SupportedFeatureIDs)
 }
 
-func Test_appServerEffectiveFeatures(t *testing.T) {
-	t.Parallel()
-	rcv1 := componentfeatures.FeatureResourceConstraintsV1
-	otherFeature := componentfeatures.FeatureID(9999)
-	clusterFeatures := componentfeatures.New(rcv1, otherFeature)
-	makeAppServer := func(t *testing.T, version string, features *componentfeaturesv1.ComponentFeatures) types.AppServer {
-		app, err := types.NewAppV3(types.Metadata{Name: "aws-app"}, types.AppSpecV3{URI: "https://console.aws.amazon.com", Cloud: "AWS"})
-		require.NoError(t, err)
-		srv, err := types.NewAppServerV3FromApp(app, "localhost", "host-1")
-		require.NoError(t, err)
-		srv.Spec.Version = version
-		srv.SetComponentFeatures(features)
-		return srv
-	}
-
-	t.Run("old app server has ResourceConstraintsV1 stripped", func(t *testing.T) {
-		srv := makeAppServer(t, "18.7.5", componentfeatures.New(rcv1, otherFeature))
-		result := appServerEffectiveFeatures(srv, clusterFeatures)
-		require.ElementsMatch(t, componentfeatures.New(otherFeature).GetFeatures(), result.GetFeatures())
-	})
-	t.Run("new app server keeps ResourceConstraintsV1", func(t *testing.T) {
-		srv := makeAppServer(t, "18.7.6", componentfeatures.New(rcv1, otherFeature))
-		result := appServerEffectiveFeatures(srv, clusterFeatures)
-		require.ElementsMatch(t, componentfeatures.New(rcv1, otherFeature).GetFeatures(), result.GetFeatures())
-	})
-	t.Run("nil features on old app server returns empty", func(t *testing.T) {
-		srv := makeAppServer(t, "18.6.4", nil)
-		result := appServerEffectiveFeatures(srv, clusterFeatures)
-		require.Empty(t, result.GetFeatures())
-	})
-}
-
 func TestUnifiedResourcesGet(t *testing.T) {
 	t.Parallel()
 	env := newWebPack(t, 1)

--- a/lib/web/ui/app.go
+++ b/lib/web/ui/app.go
@@ -214,9 +214,13 @@ func MakeApp(app types.Application, c MakeAppsConfig) App {
 			grantedSet[gr.ARN] = struct{}{}
 		}
 
+		supportsResourceConstraints := componentfeatures.InAllSets(componentfeatures.FeatureResourceConstraintsV1, c.SupportedFeatures)
 		uiRoles := make([]aws.Role, 0, len(visibleRoles))
 		for _, r := range visibleRoles {
 			_, isGranted := grantedSet[r.ARN]
+			if !supportsResourceConstraints && !isGranted {
+				continue
+			}
 			uiRoles = append(uiRoles, aws.Role{
 				Name:            r.Name,
 				Display:         r.Display,

--- a/lib/web/ui/app_test.go
+++ b/lib/web/ui/app_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/componentfeatures"
 	"github.com/gravitational/teleport/lib/ui"
+	"github.com/gravitational/teleport/lib/utils/set"
 )
 
 func newApp(t *testing.T, name, publicAddr, description string, labels map[string]string) types.Application {
@@ -80,6 +81,54 @@ func TestMakeApp_SupportedFeatureIDs(t *testing.T) {
 		out := MakeApp(app, cfg)
 
 		require.ElementsMatch(t, []int{int(f1), int(f2)}, out.SupportedFeatureIDs)
+	})
+}
+
+func TestMakeApp_AWSRolesVisibility(t *testing.T) {
+	t.Parallel()
+
+	app, err := types.NewAppV3(
+		types.Metadata{
+			Name:   "aws-console",
+			Labels: map[string]string{"aws_account_id": "123456789012"},
+		},
+		types.AppSpecV3{
+			URI:   "https://console.aws.amazon.com",
+			Cloud: types.CloudAWS,
+		},
+	)
+	require.NoError(t, err)
+
+	grantedARN := "arn:aws:iam::123456789012:role/granted"
+	requestableARN := "arn:aws:iam::123456789012:role/requestable"
+	baseCfg := MakeAppsConfig{
+		LocalClusterName:  "root",
+		LocalProxyDNSName: "proxy.example.com",
+		AppClusterName:    "root",
+		UserGroupLookup:   map[string]types.UserGroup{},
+		AWSRoles: &PrincipalSet{
+			All:     set.New(grantedARN, requestableARN),
+			Granted: set.New(grantedARN),
+		},
+	}
+
+	t.Run("with constraint support returns granted and requestable", func(t *testing.T) {
+		t.Parallel()
+		cfg := baseCfg
+		cfg.SupportedFeatures = componentfeatures.New(componentfeatures.FeatureResourceConstraintsV1)
+
+		out := MakeApp(app, cfg)
+		require.Len(t, out.AWSRoles, 2)
+	})
+	t.Run("without constraint support returns only granted", func(t *testing.T) {
+		t.Parallel()
+		cfg := baseCfg
+		cfg.SupportedFeatures = nil
+
+		out := MakeApp(app, cfg)
+		require.Len(t, out.AWSRoles, 1)
+		require.Equal(t, grantedARN, out.AWSRoles[0].ARN)
+		require.False(t, out.AWSRoles[0].RequiresRequest)
 	})
 }
 

--- a/lib/web/ui/app_test.go
+++ b/lib/web/ui/app_test.go
@@ -27,7 +27,6 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/componentfeatures"
 	"github.com/gravitational/teleport/lib/ui"
-	"github.com/gravitational/teleport/lib/utils/set"
 )
 
 func newApp(t *testing.T, name, publicAddr, description string, labels map[string]string) types.Application {
@@ -102,14 +101,12 @@ func TestMakeApp_AWSRolesVisibility(t *testing.T) {
 	grantedARN := "arn:aws:iam::123456789012:role/granted"
 	requestableARN := "arn:aws:iam::123456789012:role/requestable"
 	baseCfg := MakeAppsConfig{
-		LocalClusterName:  "root",
-		LocalProxyDNSName: "proxy.example.com",
-		AppClusterName:    "root",
-		UserGroupLookup:   map[string]types.UserGroup{},
-		AWSRoles: &PrincipalSet{
-			All:     set.New(grantedARN, requestableARN),
-			Granted: set.New(grantedARN),
-		},
+		LocalClusterName:      "root",
+		LocalProxyDNSName:     "proxy.example.com",
+		AppClusterName:        "root",
+		UserGroupLookup:       map[string]types.UserGroup{},
+		GrantedAWSRolesLookup: map[string][]string{"aws-console": {grantedARN}},
+		AllowedAWSRolesLookup: map[string][]string{"aws-console": {grantedARN, requestableARN}},
 	}
 
 	t.Run("with constraint support returns granted and requestable", func(t *testing.T) {

--- a/web/packages/teleport/src/UnifiedResources/ResourceActionButton.tsx
+++ b/web/packages/teleport/src/UnifiedResources/ResourceActionButton.tsx
@@ -182,7 +182,9 @@ const AppLaunch = ({ app }: AppLaunchProps) => {
 
   const isAwsIdentityCenterApp = subKind === AppSubKind.AwsIcAccount;
   if (awsConsole || isAwsIdentityCenterApp) {
-    let awsConsoleOrIdentityCenterRoles: AwsRole[] = awsRoles;
+    let awsConsoleOrIdentityCenterRoles: AwsRole[] = awsRoles.filter(
+      ps => !ps.requiresRequest
+    );
     if (isAwsIdentityCenterApp) {
       awsConsoleOrIdentityCenterRoles = permissionSets.map(
         (ps): AwsRole => ({


### PR DESCRIPTION
### Context
Backport #66870, #66911 to v18. 

Changelog: Fixed a regression introduced in v18.7.6 affecting connectivity to resources via approved just-in-time resource access requests when the cluster is running agents older than v18.7.6.

## Manual Test Plan
### Test Environment
- Local cluster builds for this branch + v18.7.5 or older.
- Cloud cluster with AWS IC integration setup.

### Test Cases
- [x] Validate all cases from #66879's matrix pass for Web UI, Connect, and TSH clients.
