### PR TITLE
kube: handle goaway test fixture conns concurrently

### DIFF
--- a/lib/kube/proxy/forwarder_test.go
+++ b/lib/kube/proxy/forwarder_test.go
@@ -2426,6 +2426,10 @@ func TestGOAWAYHandling_Concurrent(t *testing.T) {
 type goawayServer struct {
 	listener  net.Listener
 	tlsConfig *tls.Config
+
+	mu       sync.Mutex
+	conns    []net.Conn
+	wg       sync.WaitGroup
 }
 
 // URL returns the address clients should use to connect to the server.
@@ -2447,13 +2451,25 @@ func (g *goawayServer) Serve() error {
 			return err
 		}
 
-		go func() { _ = g.handleConn(conn) }()
+		g.mu.Lock()
+		g.conns = append(g.conns, conn)
+		g.wg.Go(func() { _ = g.handleConn(conn) })
+		g.mu.Unlock()
 	}
 }
 
-// Close terminates the server and unblocks any calls to [Serve].
+// Close terminates the server and unblocks any calls to [Serve], then
+// closes all in-flight connections and waits for their handler goroutines
+// to exit.
 func (g *goawayServer) Close() error {
-	return g.listener.Close()
+	err := g.listener.Close()
+	g.mu.Lock()
+	for _, c := range g.conns {
+		_ = c.Close()
+	}
+	g.mu.Unlock()
+	g.wg.Wait()
+	return err
 }
 
 // handleConn performs the initial HTTP/2 message exchange and then

--- a/lib/kube/proxy/forwarder_test.go
+++ b/lib/kube/proxy/forwarder_test.go
@@ -2447,9 +2447,7 @@ func (g *goawayServer) Serve() error {
 			return err
 		}
 
-		if err := g.handleConn(conn); err != nil {
-			return err
-		}
+		go func() { _ = g.handleConn(conn) }()
 	}
 }
 

--- a/lib/kube/proxy/forwarder_test.go
+++ b/lib/kube/proxy/forwarder_test.go
@@ -2427,9 +2427,10 @@ type goawayServer struct {
 	listener  net.Listener
 	tlsConfig *tls.Config
 
-	mu       sync.Mutex
-	conns    []net.Conn
-	wg       sync.WaitGroup
+	mu     sync.Mutex
+	closed bool
+	conns  []net.Conn
+	wg     sync.WaitGroup
 }
 
 // URL returns the address clients should use to connect to the server.
@@ -2452,6 +2453,11 @@ func (g *goawayServer) Serve() error {
 		}
 
 		g.mu.Lock()
+		if g.closed {
+			g.mu.Unlock()
+			_ = conn.Close()
+			continue
+		}
 		g.conns = append(g.conns, conn)
 		g.wg.Go(func() { _ = g.handleConn(conn) })
 		g.mu.Unlock()
@@ -2464,6 +2470,7 @@ func (g *goawayServer) Serve() error {
 func (g *goawayServer) Close() error {
 	err := g.listener.Close()
 	g.mu.Lock()
+	g.closed = true
 	for _, c := range g.conns {
 		_ = c.Close()
 	}


### PR DESCRIPTION
Follow-up to #66672. The fake `goawayServer` in `forwarder_test.go` calls `handleConn` inline, so concurrent clients in `TestGOAWAYHandling_Concurrent` are serialized. Under `-race` + slow CI, the 50-deep backlog can outlast the per-request 10s context, leaving the `httptest` handler stuck in TLS handshake and `forwarderServer.Close()` waiting on it until Go's 10-minute test timeout fires.

Example: https://github.com/gravitational/teleport/actions/runs/26193145084/job/77066278419?pr=66930

Fix: spawn a goroutine per accepted conn. No production code touched.

Stress: `stress -p 8 -test.cpu=1 -race` for ~4 min — 1,317 runs, 0 failures.