### PR TITLE
[v18] kube: handle goaway test fixture conns concurrently

### DIFF
--- a/lib/kube/proxy/forwarder_test.go
+++ b/lib/kube/proxy/forwarder_test.go
@@ -2054,9 +2054,10 @@ type goawayServer struct {
 	listener  net.Listener
 	tlsConfig *tls.Config
 
-	mu       sync.Mutex
-	conns    []net.Conn
-	wg       sync.WaitGroup
+	mu     sync.Mutex
+	closed bool
+	conns  []net.Conn
+	wg     sync.WaitGroup
 }
 
 // URL returns the address clients should use to connect to the server.
@@ -2079,6 +2080,11 @@ func (g *goawayServer) Serve() error {
 		}
 
 		g.mu.Lock()
+		if g.closed {
+			g.mu.Unlock()
+			_ = conn.Close()
+			continue
+		}
 		g.conns = append(g.conns, conn)
 		g.wg.Go(func() { _ = g.handleConn(conn) })
 		g.mu.Unlock()
@@ -2091,6 +2097,7 @@ func (g *goawayServer) Serve() error {
 func (g *goawayServer) Close() error {
 	err := g.listener.Close()
 	g.mu.Lock()
+	g.closed = true
 	for _, c := range g.conns {
 		_ = c.Close()
 	}

--- a/lib/kube/proxy/forwarder_test.go
+++ b/lib/kube/proxy/forwarder_test.go
@@ -2074,9 +2074,7 @@ func (g *goawayServer) Serve() error {
 			return err
 		}
 
-		if err := g.handleConn(conn); err != nil {
-			return err
-		}
+		go func() { _ = g.handleConn(conn) }()
 	}
 }
 

--- a/lib/kube/proxy/forwarder_test.go
+++ b/lib/kube/proxy/forwarder_test.go
@@ -2053,6 +2053,10 @@ func TestGOAWAYHandling_Concurrent(t *testing.T) {
 type goawayServer struct {
 	listener  net.Listener
 	tlsConfig *tls.Config
+
+	mu       sync.Mutex
+	conns    []net.Conn
+	wg       sync.WaitGroup
 }
 
 // URL returns the address clients should use to connect to the server.
@@ -2074,13 +2078,25 @@ func (g *goawayServer) Serve() error {
 			return err
 		}
 
-		go func() { _ = g.handleConn(conn) }()
+		g.mu.Lock()
+		g.conns = append(g.conns, conn)
+		g.wg.Go(func() { _ = g.handleConn(conn) })
+		g.mu.Unlock()
 	}
 }
 
-// Close terminates the server and unblocks any calls to [Serve].
+// Close terminates the server and unblocks any calls to [Serve], then
+// closes all in-flight connections and waits for their handler goroutines
+// to exit.
 func (g *goawayServer) Close() error {
-	return g.listener.Close()
+	err := g.listener.Close()
+	g.mu.Lock()
+	for _, c := range g.conns {
+		_ = c.Close()
+	}
+	g.mu.Unlock()
+	g.wg.Wait()
+	return err
 }
 
 // handleConn performs the initial HTTP/2 message exchange and then


### PR DESCRIPTION
Backport of #66934 to branch/v18.

Clean cherry-pick (auto-merge only, no conflicts).