### PR TITLE
lib/cache: avoid nested cache read lock in GetAccessListOwners

### DIFF
--- a/lib/cache/access_list.go
+++ b/lib/cache/access_list.go
@@ -358,9 +358,16 @@ func (c *Cache) GetAccessListOwners(ctx context.Context, accessListName string) 
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	defer rg.Release()
 
-	if !rg.ReadCache() {
+	upstreamRead := !rg.ReadCache()
+
+	// Release the read guard before performing nested cache reads.
+	// The read guard's sync.RWMutex blocks new readers while a writer
+	// is waiting, so holding this read lock across c.GetAccessList or
+	// accesslists.GetOwnersFor could result in a deadlock.
+	rg.Release()
+
+	if upstreamRead {
 		return c.Config.AccessLists.GetAccessListOwners(ctx, accessListName)
 	}
 


### PR DESCRIPTION
Prevent nested acquisition of the cache read guard in GetAccessListOwners by releasing the read guard prior to calling either of GetAccessList or accesslists.GetOwnerFor.

Resolves https://github.com/gravitational/pressure-washing/issues/146.