### PR TITLE
kube: forward watch BOOKMARK events unfiltered

### DIFF
--- a/lib/kube/proxy/resource_rbac_test.go
+++ b/lib/kube/proxy/resource_rbac_test.go
@@ -837,6 +837,112 @@ func TestWatcherResponseWriter(t *testing.T) {
 	}
 }
 
+// TestWatcherResponseWriter_BookmarkPassthrough reproduces the bug from
+// https://github.com/gravitational/teleport/issues/64188:
+// kubectl/client-go v0.35+ sends watch requests with sendInitialEvents=true and
+// expects a terminating BOOKMARK event annotated k8s.io/initial-events-end="true"
+// to mark the cache as synced. Teleport's kube agent runs every decoded event
+// (including BOOKMARK) through the resource filter; the BOOKMARK envelope is a
+// stripped Pod with empty Name and Namespace, so any restrictive name/namespace
+// rule rejects it and the bookmark is silently dropped. The client then waits
+// indefinitely for a bookmark that never arrives.
+func TestWatcherResponseWriter_BookmarkPassthrough(t *testing.T) {
+	t.Parallel()
+	const (
+		ns      = "default"
+		podName = "myPod"
+	)
+
+	// A restrictive allow rule: only "myPod" in "default". This is the shape
+	// that exposes the bug — the bookmark's empty name fails the name match.
+	allowed := []types.KubernetesResource{{
+		Kind:      "pods",
+		Namespace: ns,
+		Name:      podName,
+		Verbs:     []string{types.Wildcard},
+		APIGroup:  "",
+	}}
+
+	// The bookmark sent by kube-apiserver when sendInitialEvents=true completes:
+	// a near-empty Pod envelope with only resourceVersion + the
+	// k8s.io/initial-events-end annotation.
+	bookmarkPod := &corev1.Pod{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Pod",
+			APIVersion: "v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			ResourceVersion: "12345",
+			Annotations: map[string]string{
+				"k8s.io/initial-events-end": "true",
+			},
+		},
+	}
+
+	upstreamEvents := []*watch.Event{
+		{Type: watch.Added, Object: newFakePod(podName, ns)},
+		{Type: watch.Bookmark, Object: bookmarkPod},
+	}
+
+	userReader, userWriter := io.Pipe()
+	negotiator := newClientNegotiator(&globalKubeCodecs)
+	mr := metaResource{
+		requestedResource: apiResource{
+			resourceKind: "pods",
+			apiGroup:     "",
+			namespace:    ns,
+		},
+		resourceDefinition: &metav1.APIResource{Namespaced: true},
+		verb:               types.KubeVerbWatch,
+	}
+	filterWrapper := newResourceFilterer(
+		mr, &globalKubeCodecs,
+		newMatcher(mr, allowed, nil, logtest.NewLogger()),
+		logtest.NewLogger(),
+	)
+	watcher, err := responsewriters.NewWatcherResponseWriter(
+		newFakeResponseWriter(userWriter), negotiator, filterWrapper,
+	)
+	require.NoError(t, err)
+
+	watchEncoder, decoder := newWatchSerializers(
+		t, responsewriters.DefaultContentType, negotiator, watcher, userReader,
+	)
+	watcher.Header().Set(responsewriters.ContentTypeHeader, responsewriters.DefaultContentType)
+	watcher.WriteHeader(http.StatusOK)
+
+	var collected []*metav1.WatchEvent
+	var wg sync.WaitGroup
+	wg.Go(func() {
+		for {
+			event, err := decoder.decodeStreamingMessage()
+			if err != nil {
+				return
+			}
+			collected = append(collected, event)
+		}
+	})
+
+	for _, evt := range upstreamEvents {
+		require.NoError(t, watchEncoder.Encode(evt))
+	}
+
+	require.NoError(t, watcher.Close())
+	userReader.CloseWithError(io.EOF)
+	userWriter.CloseWithError(io.EOF)
+	wg.Wait()
+
+	gotTypes := make([]watch.EventType, 0, len(collected))
+	for _, e := range collected {
+		gotTypes = append(gotTypes, watch.EventType(e.Type))
+	}
+	require.Equal(t,
+		[]watch.EventType{watch.Added, watch.Bookmark},
+		gotTypes,
+		"BOOKMARK event was dropped by the kube agent filter — client-go WatchList informers will hang",
+	)
+}
+
 func newRawExtension(name, namespace string) runtime.RawExtension {
 	return runtime.RawExtension{
 		Object: newFakePod(name, namespace),

--- a/lib/kube/proxy/responsewriters/watcher.go
+++ b/lib/kube/proxy/responsewriters/watcher.go
@@ -313,6 +313,21 @@ func (w *WatcherResponseWriter) watchDecoder(contentType string, writer io.Write
 			)
 			return trace.Wrap(err)
 		default:
+			if eventType == watch.Bookmark {
+				// Bookmarks are protocol signals (KEP-956, KEP-3157), not resources.
+				// The envelope carries only resourceVersion and an optional
+				// k8s.io/initial-events-end annotation, with empty name and namespace.
+				// Resource RBAC would silently drop them for any non-wildcard rule,
+				// which causes client-go v0.35+ WatchList informers to hang forever
+				// waiting for the terminating bookmark.
+				if err := writeEventAndFlush(&watch.Event{
+					Type:   eventType,
+					Object: obj,
+				}); err != nil {
+					return trace.Wrap(err)
+				}
+				continue
+			}
 			if filter != nil {
 				// check if the event object matches the filtering criteria.
 				// If it does not match, ignore the event.

--- a/lib/kube/proxy/responsewriters/watcher.go
+++ b/lib/kube/proxy/responsewriters/watcher.go
@@ -313,22 +313,13 @@ func (w *WatcherResponseWriter) watchDecoder(contentType string, writer io.Write
 			)
 			return trace.Wrap(err)
 		default:
-			if eventType == watch.Bookmark {
-				// Bookmarks are protocol signals (KEP-956, KEP-3157), not resources.
-				// The envelope carries only resourceVersion and an optional
-				// k8s.io/initial-events-end annotation, with empty name and namespace.
-				// Resource RBAC would silently drop them for any non-wildcard rule,
-				// which causes client-go v0.35+ WatchList informers to hang forever
-				// waiting for the terminating bookmark.
-				if err := writeEventAndFlush(&watch.Event{
-					Type:   eventType,
-					Object: obj,
-				}); err != nil {
-					return trace.Wrap(err)
-				}
-				continue
-			}
-			if filter != nil {
+			// Bookmarks are protocol signals (KEP-956, KEP-3157), not resources.
+			// The envelope carries only resourceVersion and an optional
+			// k8s.io/initial-events-end annotation, with empty name and namespace.
+			// Resource RBAC would silently drop them for any non-wildcard rule,
+			// which causes client-go v0.35+ WatchList informers to hang forever
+			// waiting for the terminating bookmark.
+			if filter != nil && eventType != watch.Bookmark {
 				// check if the event object matches the filtering criteria.
 				// If it does not match, ignore the event.
 				publish, _, err := filter.FilterObj(obj)


### PR DESCRIPTION
Fixes #64188.

The kube agent's watch response filter ran every decoded event through `FilterObj`, including `watch.Bookmark`. A BOOKMARK envelope carries only a `resourceVersion` and an optional `k8s.io/initial-events-end` annotation, with empty `name` and `namespace`, so any non-wildcard rule rejected it and the bookmark was silently dropped. client-go v0.35+ (where `WatchListClient` is default-on) waits indefinitely for the terminating bookmark to mark its informer cache synced, so kubectl/k9s/Lens hang on watch operations through Teleport.

Bookmarks are protocol signals ([KEP-956 Watch Bookmarks](https://github.com/kubernetes/enhancements/tree/master/keps/sig-api-machinery/956-watch-bookmark), [KEP-3157 Watch List](https://github.com/kubernetes/enhancements/tree/master/keps/sig-api-machinery/3157-watch-list)), not resources. This change bypasses the resource filter for `watch.Bookmark` events, mirroring the existing bypass for `*metav1.Status`.

<!-- Include manual testing efforts to verify the change. -->
<!-- Detail where the tests where run and what configurations were used. -->
<!-- Include all the test cases which were run to validate the change. -->

## Manual Test Plan
### Test Environment

Kind cluster running Kubernetes v1.35.0. Teleport auth+proxy deployed in-cluster via the `teleport-cluster` Helm chart from a custom binary built from this branch. User bound to a single role whose `kubernetes_resources` rule was `kind: pods, namespace: default, name: mypod, verbs: ['*']` (deliberately non-wildcard so the filter path engages). Two pods in `default`: `mypod` (matches the rule) and `otherpod` (does not).

### Test Cases

- [x] **Pre-fix reproduction.** Built the branch with `watcher.go` reverted to the pre-fix version. Ran `kubectl get --raw '/api/v1/namespaces/default/pods?watch=true&sendInitialEvents=true&allowWatchBookmarks=true&resourceVersionMatch=NotOlderThan&resourceVersion=&timeoutSeconds=8'` through the Teleport proxy. Received **1 ADDED (`mypod`), 0 BOOKMARK** — the `k8s.io/initial-events-end` bookmark was dropped and the stream went silent until timeout. This is the symptom that hangs client-go v0.35+ informers.
- [x] **Post-fix.** Rebuilt with the fix and rolled out. Same kubectl command, same role. Received **1 ADDED (`mypod`), 2 BOOKMARK** — one carrying `k8s.io/initial-events-end: "true"`, one periodic bookmark before timeout. Informer would now mark its cache synced and proceed.
- [x] **RBAC still enforced.** In both runs `otherpod` was correctly filtered out — the fix only bypasses RBAC for protocol signals (BOOKMARK), not for resource events.