### PR TITLE
Validate rate limiter to prevent integer division truncation to zero

### DIFF
--- a/lib/limiter/internal/ratelimit/ratelimit.go
+++ b/lib/limiter/internal/ratelimit/ratelimit.go
@@ -180,6 +180,13 @@ func (rs *RateSet) Add(period time.Duration, average int64, burst int64) error {
 	if burst <= 0 {
 		return trace.BadParameter("Invalid burst: %v", burst)
 	}
+	if int64(period) < average {
+		return trace.BadParameter(
+			"Invalid rate: period %v and average %d would require less than 1ns per token",
+			period, average,
+		)
+	}
+
 	rs.m[period] = &rate{period, average, burst}
 	return nil
 }

--- a/lib/limiter/internal/ratelimit/ratelimit_test.go
+++ b/lib/limiter/internal/ratelimit/ratelimit_test.go
@@ -126,3 +126,13 @@ func TestRateSetLenNilReceiver(t *testing.T) {
 	var rs *RateSet
 	require.Equal(t, 0, rs.Len())
 }
+
+func TestRateSetAdd_RejectsRatesBelowNanosecond(t *testing.T) {
+	rates := NewRateSet()
+
+	require.Error(t, rates.Add(100*time.Nanosecond, 101, 1))
+	require.Error(t, rates.Add(100*time.Nanosecond, 200, 1))
+
+	require.NoError(t, rates.Add(100*time.Nanosecond, 100, 1))
+	require.NoError(t, rates.Add(100*time.Nanosecond, 99, 1))
+}


### PR DESCRIPTION
Validate rate limiter to prevent integer division truncation to zero in cases like `lib/limiter/internal/ratelimit/tokenbucket.go` which could be configured by users in `teleport.yaml`:
```go
timePerToken:    time.Duration(int64(period) / rate.average),
```

Addresses https://github.com/gravitational/pressure-washing/issues/233