### PR TITLE
Revert wasm log level during desktop sessions

### DIFF
--- a/web/packages/shared/libs/tdp/client.ts
+++ b/web/packages/shared/libs/tdp/client.ts
@@ -351,7 +351,7 @@ export class TdpClient extends EventEmitter<EventMap> {
     // select the wasm log level
     let wasmLogLevel = LogType.OFF;
     if (import.meta.env.MODE === 'development') {
-      wasmLogLevel = LogType.WARN;
+      wasmLogLevel = LogType.TRACE;
     }
 
     // Convert the inlined (base64) WASM to a raw buffer. The init function will


### PR DESCRIPTION
Reverts the change from trace -> warn in #64160, turns out there's a verbose level in dev tools that filters the noise out