### PR TITLE
service: stop reconnect loop on graceful exit

### DIFF
--- a/lib/service/connect.go
+++ b/lib/service/connect.go
@@ -118,7 +118,7 @@ func (process *TeleportProcess) reconnectToAuthService(role types.SystemRole) (*
 		case t := <-retry.After():
 			process.logger.DebugContext(process.ExitContext(), "Retrying connection to auth server.", "identity", role, "backoff", t.Sub(startedWait))
 			retry.Inc()
-		case <-process.ExitContext().Done():
+		case <-process.GracefulExitContext().Done():
 			process.logger.InfoContext(process.ExitContext(), "Stopping connection attempts, teleport is shutting down.", "identity", role)
 			return nil, ErrTeleportExited
 		}


### PR DESCRIPTION
During a graceful restart (SIGQUIT), the shutdown context passed to StartShutdown has a very long timeout (MaxCertDuration). This means ExitContext does not close until that timeout elapses, while GracefulExitContext closes immediately when graceful shutdown begins.

reconnectToAuthService was selecting on ExitContext().Done(), so the retry loop kept firing (with growing backoff) even after graceful shutdown started, because ExitContext stays open throughout. Meanwhile, connectToAuthService uses GracefulExitContext internally and returns "context canceled" on every attempt. The net effect: register.discovery and discovery.init never exited, Supervisor.Wait blocked indefinitely, and the pod was stuck for the full 5m terminationGracePeriodSeconds before Kubernetes sent SIGKILL.

`reconnectToAuthService` is only invoked when a service starts and never when the service is already operating for some time and loses connection.

Switching the select to GracefulExitContext().Done() makes the retry loop exit as soon as graceful shutdown is initiated, unblocking the supervisor and allowing the pod to terminate cleanly.






<!-- Provide a descriptive entry for the changelog of the next release. -->

Changelog:


<!-- Include manual testing efforts to verify the change. -->
<!-- Detail where the tests where run and what configurations were used. -->
<!-- Include all the test cases which were run to validate the change. -->

## Manual Test Plan
### Test Environment

### Test Cases
- [ ] 
