### PR TITLE
Fix `staticcheck` error from `ConfigureACL`

### DIFF
--- a/lib/tbot/services/identity/key_agent_service.go
+++ b/lib/tbot/services/identity/key_agent_service.go
@@ -152,6 +152,7 @@ func (s *KeyAgentService) Run(ctx context.Context) error {
 	// 	   and permissions to restrict access to it - this is the same as the
 	// 	   internal.CreateListener method's behavior.
 	if dir.ACLsEnabled() {
+		//nolint:staticcheck // staticcheck doesn't like nop implementations in fs_other.go
 		if err := botfs.ConfigureACL(filepath.Join(dir.Path, libhwk.CertFileName), dir.Readers); err != nil {
 			return trace.Wrap(err)
 		}


### PR DESCRIPTION
When running `staticcheck` on non-Linux hosts, it incorrectly thinks `ConfigureACL` always returns an error.

```
lib/tbot/services/identity/key_agent_service.go:155:13: SA4023(related information): the lhs of the comparison is the 1st return value of this function call (staticcheck)
                if err := botfs.ConfigureACL(filepath.Join(dir.Path, libhwk.CertFileName), dir.Readers); err != nil {
                          ^
lib/tbot/services/identity/key_agent_service.go:155:92: SA4023: this comparison is always true (staticcheck)
                if err := botfs.ConfigureACL(filepath.Join(dir.Path, libhwk.CertFileName), dir.Readers); err != nil {
                                                                                                         ^
lib/tbot/services/identity/key_agent_service.go:155:92: SA4023(related information): github.com/gravitational/teleport/lib/tbot/botfs.ConfigureACL never returns a nil interface value (staticcheck)
                if err := botfs.ConfigureACL(filepath.Join(dir.Path, libhwk.CertFileName), dir.Readers); err != nil {
                                                                                                         ^
```
