### PR TITLE
Fix DynamoDB DeleteRange unprocessed item handling

### DIFF
--- a/lib/backend/dynamo/dynamodbbk.go
+++ b/lib/backend/dynamo/dynamodbbk.go
@@ -45,6 +45,7 @@ import (
 
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/utils"
+	"github.com/gravitational/teleport/api/utils/retryutils"
 	"github.com/gravitational/teleport/lib/backend"
 	config "github.com/gravitational/teleport/lib/cloud/aws/config"
 	"github.com/gravitational/teleport/lib/defaults"
@@ -677,21 +678,75 @@ func (b *Backend) GetRange(ctx context.Context, startKey, endKey backend.Key, li
 	return &result, nil
 }
 
-const (
-	// batchOperationItemsLimit is the maximum number of items that can be put or deleted in a single batch operation.
-	// From https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Limits.html:
-	// A single call to BatchWriteItem can transmit up to 16MB of data over the network,
-	// consisting of up to 25 item put or delete operations.
-	batchOperationItemsLimit = 25
-)
+func (b *Backend) batchWriteItem(ctx context.Context, requests []types.WriteRequest) error {
+	if len(requests) == 0 {
+		return nil
+	}
+
+	requestItems := map[string][]types.WriteRequest{
+		b.TableName: requests,
+	}
+
+	var retry retryutils.Retry
+	previousOutstandingItems := len(requests)
+	for {
+		resp, err := b.svc.BatchWriteItem(ctx, &dynamodb.BatchWriteItemInput{
+			RequestItems: requestItems,
+		})
+		if err != nil {
+			return trace.Wrap(convertError(err))
+		}
+
+		if resp == nil || len(resp.UnprocessedItems) == 0 {
+			return nil
+		}
+
+		unprocessedItems := len(resp.UnprocessedItems[b.TableName])
+		if unprocessedItems >= previousOutstandingItems {
+			return trace.LimitExceeded("failed to delete all items, dynamodb returned an increased number of unprocessed items")
+		}
+
+		requestItems = resp.UnprocessedItems
+		previousOutstandingItems = unprocessedItems
+
+		if retry == nil {
+			firstRetry := b.RetryPeriod / 10
+			retry, err = retryutils.NewRetryV2(retryutils.RetryV2Config{
+				First:  firstRetry,
+				Driver: retryutils.NewExponentialDriver(firstRetry),
+				Max:    b.RetryPeriod,
+				Jitter: retryutils.FullJitter,
+				Clock:  b.clock,
+			})
+			if err != nil {
+				return trace.Errorf("failed to setup retry for dynamodb batch write: %v", err)
+			}
+		}
+
+		retry.Inc()
+		select {
+		case <-retry.After():
+		case <-ctx.Done():
+			return trace.Wrap(ctx.Err())
+		}
+	}
+}
 
 // DeleteRange deletes range of items with keys between startKey and endKey
 func (b *Backend) DeleteRange(ctx context.Context, startKey, endKey backend.Key) error {
+	const (
+		// batchOperationItemsLimit is the maximum number of items that can be put or deleted in a single batch operation.
+		// From https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Limits.html:
+		// A single call to BatchWriteItem can transmit up to 16MB of data over the network,
+		// consisting of up to 25 item put or delete operations.
+		batchOperationItemsLimit = 25
+		maxDeletionOperations    = backend.DefaultRangeLimit / 100 / batchOperationItemsLimit
+	)
+
 	// Attempt to pull all existing items and delete them in batches
 	// in accordance with the BatchWriteItem limits. There is a hard
 	// cap on the total number of items that can be deleted in a single
 	// DeleteRange call to avoid racing with additional records being added.
-	const maxDeletionOperations = backend.DefaultRangeLimit / 100 / batchOperationItemsLimit
 	requests := make([]types.WriteRequest, 0, batchOperationItemsLimit)
 	var deletions int
 	for item, err := range b.Items(ctx, backend.ItemsParams{StartKey: startKey, EndKey: endKey}) {
@@ -713,11 +768,7 @@ func (b *Backend) DeleteRange(ctx context.Context, startKey, endKey backend.Key)
 		})
 
 		if len(requests) == batchOperationItemsLimit {
-			if _, err := b.svc.BatchWriteItem(ctx, &dynamodb.BatchWriteItemInput{
-				RequestItems: map[string][]types.WriteRequest{
-					b.TableName: requests,
-				},
-			}); err != nil {
+			if err := b.batchWriteItem(ctx, requests); err != nil {
 				return trace.Wrap(err)
 			}
 
@@ -734,11 +785,7 @@ func (b *Backend) DeleteRange(ctx context.Context, startKey, endKey backend.Key)
 	}
 
 	if len(requests) > 0 {
-		if _, err := b.svc.BatchWriteItem(ctx, &dynamodb.BatchWriteItemInput{
-			RequestItems: map[string][]types.WriteRequest{
-				b.TableName: requests,
-			},
-		}); err != nil {
+		if err := b.batchWriteItem(ctx, requests); err != nil {
 			return trace.Wrap(err)
 		}
 	}

--- a/lib/backend/dynamo/dynamodbbk_test.go
+++ b/lib/backend/dynamo/dynamodbbk_test.go
@@ -20,14 +20,21 @@ package dynamo
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"log/slog"
+	"net"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/credentials"
+	"github.com/aws/aws-sdk-go-v2/feature/dynamodb/attributevalue"
 	"github.com/aws/aws-sdk-go-v2/service/applicationautoscaling"
 	autoscalingtypes "github.com/aws/aws-sdk-go-v2/service/applicationautoscaling/types"
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
@@ -39,12 +46,14 @@ import (
 	"github.com/jonboulle/clockwork"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/test/bufconn"
 
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/utils/retryutils"
 	"github.com/gravitational/teleport/lib/backend"
 	"github.com/gravitational/teleport/lib/backend/test"
 	"github.com/gravitational/teleport/lib/cloud/aws/config"
+	"github.com/gravitational/teleport/lib/utils"
 	"github.com/gravitational/teleport/lib/utils/clocki"
 	"github.com/gravitational/teleport/lib/utils/log/logtest"
 )
@@ -52,6 +61,315 @@ import (
 func TestMain(m *testing.M) {
 	logtest.InitLogger(testing.Verbose)
 	os.Exit(m.Run())
+}
+
+func newTestDynamoBackend(server *httptest.Server) *Backend {
+	return &Backend{
+		svc: dynamodb.New(dynamodb.Options{
+			Region:       "us-west-2",
+			Credentials:  credentials.NewStaticCredentialsProvider("access-key", "secret-key", ""),
+			BaseEndpoint: aws.String(server.URL),
+			HTTPClient:   server.Client(),
+		}),
+		clock:  clockwork.NewRealClock(),
+		logger: slog.Default(),
+		Config: Config{
+			TableName:   "table",
+			RetryPeriod: 10 * time.Second,
+		},
+	}
+}
+
+type listenerAddrOverride struct {
+	*bufconn.Listener
+}
+
+func (l listenerAddrOverride) Addr() net.Addr { return &utils.NetAddr{Addr: "example.com:80"} }
+
+func TestDeleteRangeRetriesUnprocessedItems(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		keys := []backend.Key{
+			backend.NewKey("testing", "fish"),
+			backend.NewKey("testing", "dumpling"),
+			backend.NewKey("testing", "color", "red"),
+		}
+
+		var batchWriteRequests [][]string
+		handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			switch r.Header.Get("X-Amz-Target") {
+			case "DynamoDB_20120810.Query":
+				items := make([]json.RawMessage, 0, len(keys))
+				for _, key := range keys {
+					item := map[string]types.AttributeValue{
+						hashKeyKey:  &types.AttributeValueMemberS{Value: hashKey},
+						fullPathKey: &types.AttributeValueMemberS{Value: prependPrefix(key)},
+						"Value":     &types.AttributeValueMemberB{Value: []byte("value")},
+					}
+
+					rawItem, err := attributevalue.MarshalMapJSON(item)
+					require.NoError(t, err)
+					items = append(items, rawItem)
+				}
+
+				w.Header().Set("Content-Type", "application/x-amz-json-1.0")
+				require.NoError(t, json.NewEncoder(w).Encode(map[string][]json.RawMessage{"Items": items}))
+			case "DynamoDB_20120810.BatchWriteItem":
+				var body map[string]map[string][]json.RawMessage
+				require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+
+				var requestedKeys []string
+				for _, requestedItems := range body["RequestItems"] {
+					for _, request := range requestedItems {
+						var raw map[string]json.RawMessage
+						require.NoError(t, json.Unmarshal(request, &raw))
+
+						if deleteRequest, ok := raw["DeleteRequest"]; ok {
+							var fields map[string]json.RawMessage
+							require.NoError(t, json.Unmarshal(deleteRequest, &fields))
+							key, err := attributevalue.UnmarshalMapJSON(fields["Key"])
+							require.NoError(t, err)
+
+							fullPath, ok := key[fullPathKey].(*types.AttributeValueMemberS)
+							require.True(t, ok)
+							requestedKeys = append(requestedKeys, fullPath.Value)
+						}
+					}
+				}
+
+				batchWriteRequests = append(batchWriteRequests, requestedKeys)
+
+				if len(batchWriteRequests) == 3 {
+					return
+				}
+
+				w.Header().Set("Content-Type", "application/x-amz-json-1.0")
+				switch len(batchWriteRequests) {
+				case 1:
+					rawKey1, err := attributevalue.MarshalMapJSON(map[string]types.AttributeValue{
+						hashKeyKey:  &types.AttributeValueMemberS{Value: hashKey},
+						fullPathKey: &types.AttributeValueMemberS{Value: prependPrefix(keys[1])},
+					})
+					require.NoError(t, err)
+
+					rawRequest1, err := json.Marshal(map[string]any{
+						"DeleteRequest": map[string]json.RawMessage{
+							"Key": rawKey1,
+						},
+					})
+					require.NoError(t, err)
+
+					rawKey2, err := attributevalue.MarshalMapJSON(map[string]types.AttributeValue{
+						hashKeyKey:  &types.AttributeValueMemberS{Value: hashKey},
+						fullPathKey: &types.AttributeValueMemberS{Value: prependPrefix(keys[2])},
+					})
+					require.NoError(t, err)
+
+					rawRequest2, err := json.Marshal(map[string]any{
+						"DeleteRequest": map[string]json.RawMessage{
+							"Key": rawKey2,
+						},
+					})
+					require.NoError(t, err)
+
+					require.NoError(t, json.NewEncoder(w).Encode(map[string]any{
+						"UnprocessedItems": map[string][]json.RawMessage{"table": {rawRequest1, rawRequest2}},
+					}))
+				case 2:
+					rawKey, err := attributevalue.MarshalMapJSON(map[string]types.AttributeValue{
+						hashKeyKey:  &types.AttributeValueMemberS{Value: hashKey},
+						fullPathKey: &types.AttributeValueMemberS{Value: prependPrefix(keys[2])},
+					})
+					require.NoError(t, err)
+
+					rawRequest, err := json.Marshal(map[string]any{
+						"DeleteRequest": map[string]json.RawMessage{
+							"Key": rawKey,
+						},
+					})
+					require.NoError(t, err)
+
+					require.NoError(t, json.NewEncoder(w).Encode(map[string]any{
+						"UnprocessedItems": map[string][]json.RawMessage{"table": {rawRequest}},
+					}))
+				}
+			default:
+				http.Error(w, "unexpected dynamodb operation", http.StatusBadRequest)
+			}
+		})
+
+		listener := bufconn.Listen(1024)
+		server := &httptest.Server{
+			Listener: listenerAddrOverride{Listener: listener},
+			Config:   &http.Server{Handler: handler},
+		}
+		server.StartTLS()
+		t.Cleanup(server.Close)
+
+		client := server.Client()
+		transport := client.Transport.(*http.Transport).Clone()
+		transport.DialContext = func(ctx context.Context, network, addr string) (net.Conn, error) {
+			return listener.DialContext(ctx)
+		}
+		client.Transport = transport
+
+		bk := newTestDynamoBackend(server)
+
+		err := bk.DeleteRange(t.Context(), backend.NewKey("foo"), backend.RangeEnd(backend.NewKey("zest")))
+		require.NoError(t, err)
+
+		expectedBatchWriteRequests := [][]string{
+			{prependPrefix(keys[0]), prependPrefix(keys[1]), prependPrefix(keys[2])},
+			{prependPrefix(keys[1]), prependPrefix(keys[2])},
+			{prependPrefix(keys[2])},
+		}
+		require.Equal(t, expectedBatchWriteRequests, batchWriteRequests)
+	})
+}
+
+func TestDeleteRangeReturnsErrorWhenUnprocessedItemsDoNotDecrease(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		key := backend.NewKey("testing", "test")
+		var batchWriteAttempts int
+		handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			switch r.Header.Get("X-Amz-Target") {
+			case "DynamoDB_20120810.Query":
+				item := map[string]types.AttributeValue{
+					hashKeyKey:  &types.AttributeValueMemberS{Value: hashKey},
+					fullPathKey: &types.AttributeValueMemberS{Value: prependPrefix(key)},
+					"Value":     &types.AttributeValueMemberB{Value: []byte("value")},
+				}
+
+				rawItem, err := attributevalue.MarshalMapJSON(item)
+				require.NoError(t, err)
+
+				w.Header().Set("Content-Type", "application/x-amz-json-1.0")
+				require.NoError(t, json.NewEncoder(w).Encode(map[string][]json.RawMessage{"Items": {rawItem}}))
+			case "DynamoDB_20120810.BatchWriteItem":
+				batchWriteAttempts++
+				rawKey, err := attributevalue.MarshalMapJSON(map[string]types.AttributeValue{
+					hashKeyKey:  &types.AttributeValueMemberS{Value: hashKey},
+					fullPathKey: &types.AttributeValueMemberS{Value: prependPrefix(key)},
+				})
+				require.NoError(t, err)
+
+				rawRequest, err := json.Marshal(map[string]any{
+					"DeleteRequest": map[string]json.RawMessage{
+						"Key": rawKey,
+					},
+				})
+				require.NoError(t, err)
+				w.Header().Set("Content-Type", "application/x-amz-json-1.0")
+				require.NoError(t, json.NewEncoder(w).Encode(map[string]any{
+					"UnprocessedItems": map[string][]json.RawMessage{"table": {rawRequest}},
+				}))
+			default:
+				http.Error(w, "unexpected dynamodb operation", http.StatusBadRequest)
+			}
+		})
+
+		listener := bufconn.Listen(1024)
+		server := &httptest.Server{
+			Listener: listenerAddrOverride{Listener: listener},
+			Config:   &http.Server{Handler: handler},
+		}
+		server.StartTLS()
+		t.Cleanup(server.Close)
+
+		client := server.Client()
+		transport := client.Transport.(*http.Transport).Clone()
+		transport.DialContext = func(ctx context.Context, network, addr string) (net.Conn, error) {
+			return listener.DialContext(ctx)
+		}
+		client.Transport = transport
+
+		bk := newTestDynamoBackend(server)
+
+		err := bk.DeleteRange(t.Context(), backend.NewKey("test"), backend.RangeEnd(backend.NewKey("zest")))
+		require.Error(t, err)
+		require.True(t, trace.IsLimitExceeded(err))
+		require.Equal(t, 1, batchWriteAttempts)
+	})
+}
+
+func TestDeleteRangeReturnsErrorWhenUnprocessedItemsIncrease(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		key := backend.NewKey("testing", "test")
+		extraKey := backend.NewKey("testing", "extra")
+		var batchWriteAttempts int
+		handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			switch r.Header.Get("X-Amz-Target") {
+			case "DynamoDB_20120810.Query":
+				item := map[string]types.AttributeValue{
+					hashKeyKey:  &types.AttributeValueMemberS{Value: hashKey},
+					fullPathKey: &types.AttributeValueMemberS{Value: prependPrefix(key)},
+					"Value":     &types.AttributeValueMemberB{Value: []byte("value")},
+				}
+
+				rawItem, err := attributevalue.MarshalMapJSON(item)
+				require.NoError(t, err)
+
+				w.Header().Set("Content-Type", "application/x-amz-json-1.0")
+				require.NoError(t, json.NewEncoder(w).Encode(map[string][]json.RawMessage{"Items": {rawItem}}))
+			case "DynamoDB_20120810.BatchWriteItem":
+				batchWriteAttempts++
+
+				rawKey, err := attributevalue.MarshalMapJSON(map[string]types.AttributeValue{
+					hashKeyKey:  &types.AttributeValueMemberS{Value: hashKey},
+					fullPathKey: &types.AttributeValueMemberS{Value: prependPrefix(key)},
+				})
+				require.NoError(t, err)
+
+				rawRequest, err := json.Marshal(map[string]any{
+					"DeleteRequest": map[string]json.RawMessage{
+						"Key": rawKey,
+					},
+				})
+				require.NoError(t, err)
+
+				rawExtraKey, err := attributevalue.MarshalMapJSON(map[string]types.AttributeValue{
+					hashKeyKey:  &types.AttributeValueMemberS{Value: hashKey},
+					fullPathKey: &types.AttributeValueMemberS{Value: prependPrefix(extraKey)},
+				})
+				require.NoError(t, err)
+
+				rawExtraRequest, err := json.Marshal(map[string]any{
+					"DeleteRequest": map[string]json.RawMessage{
+						"Key": rawExtraKey,
+					},
+				})
+				require.NoError(t, err)
+
+				w.Header().Set("Content-Type", "application/x-amz-json-1.0")
+				require.NoError(t, json.NewEncoder(w).Encode(map[string]any{
+					"UnprocessedItems": map[string][]json.RawMessage{"table": {rawRequest, rawExtraRequest}},
+				}))
+			default:
+				http.Error(w, "unexpected dynamodb operation", http.StatusBadRequest)
+			}
+		})
+
+		listener := bufconn.Listen(1024)
+		server := &httptest.Server{
+			Listener: listenerAddrOverride{Listener: listener},
+			Config:   &http.Server{Handler: handler},
+		}
+		server.StartTLS()
+		t.Cleanup(server.Close)
+
+		client := server.Client()
+		transport := client.Transport.(*http.Transport).Clone()
+		transport.DialContext = func(ctx context.Context, network, addr string) (net.Conn, error) {
+			return listener.DialContext(ctx)
+		}
+		client.Transport = transport
+
+		bk := newTestDynamoBackend(server)
+
+		err := bk.DeleteRange(t.Context(), backend.NewKey("test"), backend.RangeEnd(backend.NewKey("zest")))
+		require.Error(t, err)
+		require.True(t, trace.IsLimitExceeded(err))
+		require.Equal(t, 1, batchWriteAttempts)
+	})
 }
 
 func ensureTestsEnabled(t *testing.T) {


### PR DESCRIPTION
The BatchWriteItem API can return a response with items that failed to be written without returning an error. DeleteRange could silently allow items to never be removed under certain conditions because it never consumed the response.

A new batchWriteItem helper now manages interactions with the BatchWriteItem API. Any responses with UnprocessedItems are now retried with backoff. When the retry limit is exhausted a trace.LimitExceededError is returned.

Resolves https://github.com/gravitational/pressure-washing/issues/137.
