### PR TITLE
crdgen: address scope-related bugs

### DIFF
--- a/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-botsv1.mdx
+++ b/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-botsv1.mdx
@@ -23,6 +23,7 @@ resource, which you can apply after installing the Teleport Kubernetes operator.
 |apiVersion|string|APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources|
 |kind|string|Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds|
 |metadata|object||
+|scope|string|The scope of the Bot. If unset, the Bot is unscoped (classic behavior) and if set, the Bot is scoped. When the Bot is scoped, the `spec.roles`, `spec.traits` and `spec.max_session_ttl` fields must not be set.|
 |spec|[object](#spec)|Bot resource definition v1 from Teleport|
 
 ### spec

--- a/examples/chart/teleport-cluster/charts/teleport-operator/operator-crds/resources.teleport.dev_botsv1.yaml
+++ b/examples/chart/teleport-cluster/charts/teleport-operator/operator-crds/resources.teleport.dev_botsv1.yaml
@@ -14,7 +14,16 @@ spec:
     singular: teleportbotv1
   scope: Namespaced
   versions:
-  - name: v1
+  - additionalPrinterColumns:
+    - description: Resource's scope.
+      jsonPath: .scope
+      name: scope
+      type: string
+    - description: The age of this resource
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1
     schema:
       openAPIV3Schema:
         description: BotV1 is the Schema for the botsv1 API
@@ -31,6 +40,16 @@ spec:
             type: string
           metadata:
             type: object
+          scope:
+            description: The scope of the Bot. If unset, the Bot is unscoped (classic
+              behavior) and if set, the Bot is scoped. When the Bot is scoped, the
+              `spec.roles`, `spec.traits` and `spec.max_session_ttl` fields must not
+              be set.
+            type: string
+            x-kubernetes-validations:
+            - message: Scope is immutable. To create the resource in a different scope
+                you must delete it first.
+              rule: self == oldSelf
           spec:
             description: Bot resource definition v1 from Teleport
             properties:
@@ -135,6 +154,10 @@ spec:
                 type: integer
             type: object
         type: object
+        x-kubernetes-validations:
+        - message: Scope is immutable. To create the resource in a different scope
+            you must delete it first.
+          rule: has(self.scope) == has(oldSelf.scope)
     served: true
     storage: true
     subresources:

--- a/examples/chart/teleport-cluster/charts/teleport-operator/operator-crds/resources.teleport.dev_scopedroleassignmentsv1.yaml
+++ b/examples/chart/teleport-cluster/charts/teleport-operator/operator-crds/resources.teleport.dev_scopedroleassignmentsv1.yaml
@@ -44,6 +44,10 @@ spec:
           scope:
             description: Scope is the scope of the role assignment resource.
             type: string
+            x-kubernetes-validations:
+            - message: Scope is immutable. To create the resource in a different scope
+                you must delete it first.
+              rule: self == oldSelf
           spec:
             description: ScopedRoleAssignment resource definition v1 from Teleport
             properties:

--- a/examples/chart/teleport-cluster/charts/teleport-operator/operator-crds/resources.teleport.dev_scopedroleassignmentsv1.yaml
+++ b/examples/chart/teleport-cluster/charts/teleport-operator/operator-crds/resources.teleport.dev_scopedroleassignmentsv1.yaml
@@ -19,6 +19,10 @@ spec:
       jsonPath: .scope
       name: scope
       type: string
+    - description: The age of this resource
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
     name: v1
     schema:
       openAPIV3Schema:

--- a/examples/chart/teleport-cluster/charts/teleport-operator/operator-crds/resources.teleport.dev_scopedroleassignmentsv1.yaml
+++ b/examples/chart/teleport-cluster/charts/teleport-operator/operator-crds/resources.teleport.dev_scopedroleassignmentsv1.yaml
@@ -147,6 +147,10 @@ spec:
                 type: integer
             type: object
         type: object
+        x-kubernetes-validations:
+        - message: Scope is immutable. To create the resource in a different scope
+            you must delete it first.
+          rule: has(self.scope) == has(oldSelf.scope)
     served: true
     storage: true
     subresources:

--- a/examples/chart/teleport-cluster/charts/teleport-operator/operator-crds/resources.teleport.dev_scopedrolesv1.yaml
+++ b/examples/chart/teleport-cluster/charts/teleport-operator/operator-crds/resources.teleport.dev_scopedrolesv1.yaml
@@ -379,6 +379,10 @@ spec:
                 type: integer
             type: object
         type: object
+        x-kubernetes-validations:
+        - message: Scope is immutable. To create the resource in a different scope
+            you must delete it first.
+          rule: has(self.scope) == has(oldSelf.scope)
     served: true
     storage: true
     subresources:

--- a/examples/chart/teleport-cluster/charts/teleport-operator/operator-crds/resources.teleport.dev_scopedrolesv1.yaml
+++ b/examples/chart/teleport-cluster/charts/teleport-operator/operator-crds/resources.teleport.dev_scopedrolesv1.yaml
@@ -43,6 +43,10 @@ spec:
           scope:
             description: Scope is the scope of the role resource.
             type: string
+            x-kubernetes-validations:
+            - message: Scope is immutable. To create the resource in a different scope
+                you must delete it first.
+              rule: self == oldSelf
           spec:
             description: ScopedRole resource definition v1 from Teleport
             properties:

--- a/examples/chart/teleport-cluster/charts/teleport-operator/operator-crds/resources.teleport.dev_scopedrolesv1.yaml
+++ b/examples/chart/teleport-cluster/charts/teleport-operator/operator-crds/resources.teleport.dev_scopedrolesv1.yaml
@@ -19,6 +19,10 @@ spec:
       jsonPath: .scope
       name: scope
       type: string
+    - description: The age of this resource
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
     name: v1
     schema:
       openAPIV3Schema:

--- a/examples/chart/teleport-cluster/charts/teleport-operator/operator-crds/resources.teleport.dev_scopedtokensv1.yaml
+++ b/examples/chart/teleport-cluster/charts/teleport-operator/operator-crds/resources.teleport.dev_scopedtokensv1.yaml
@@ -19,6 +19,10 @@ spec:
       jsonPath: .scope
       name: scope
       type: string
+    - description: The age of this resource
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
     name: v1
     schema:
       openAPIV3Schema:

--- a/examples/chart/teleport-cluster/charts/teleport-operator/operator-crds/resources.teleport.dev_scopedtokensv1.yaml
+++ b/examples/chart/teleport-cluster/charts/teleport-operator/operator-crds/resources.teleport.dev_scopedtokensv1.yaml
@@ -43,6 +43,10 @@ spec:
           scope:
             description: Scope is the scope of the token resource.
             type: string
+            x-kubernetes-validations:
+            - message: Scope is immutable. To create the resource in a different scope
+                you must delete it first.
+              rule: self == oldSelf
           spec:
             description: ScopedToken resource definition v1 from Teleport
             properties:

--- a/examples/chart/teleport-cluster/charts/teleport-operator/operator-crds/resources.teleport.dev_scopedtokensv1.yaml
+++ b/examples/chart/teleport-cluster/charts/teleport-operator/operator-crds/resources.teleport.dev_scopedtokensv1.yaml
@@ -399,6 +399,10 @@ spec:
                 type: integer
             type: object
         type: object
+        x-kubernetes-validations:
+        - message: Scope is immutable. To create the resource in a different scope
+            you must delete it first.
+          rule: has(self.scope) == has(oldSelf.scope)
     served: true
     storage: true
     subresources:

--- a/integrations/operator/Makefile
+++ b/integrations/operator/Makefile
@@ -158,12 +158,12 @@ crd-manifests-diff: crdgen
 
 # This is a helper to dump a request sent to crdgen.
 # See crdgen/DEBUG.md for instruction on how to use this target to replay crdgen with a debugger attached.
-.PHONY: crdgen-debug-dump-request
+.PHONY: debug-dump-request
 debug-dump-request:
 	$(eval PROTOBUF_MOD_PATH := $(shell go mod download --json github.com/gogo/protobuf | awk -F: '/"Dir"/ { print $$2 }' | tr -d ' ",'))
 	for proto in $(PROTOS); do \
 		protoc \
-			-I=../../../api/proto/ \
+			-I=../../api/proto/ \
 			-I=$(PROTOBUF_MOD_PATH) \
 			--plugin=./crdgen/hack/protoc-gen-dump \
 			--dump_out="." \

--- a/integrations/operator/Makefile
+++ b/integrations/operator/Makefile
@@ -241,7 +241,7 @@ TIMESTAMP := $(shell date +%Y%m%d%H%M%S)
 TELEPORT_VERSION ?= 19.0.0-dev
 TELEPORT_IMAGE_DEFAULT := public.ecr.aws/gravitational/teleport-distroless
 TELEPORT_IMAGE ?= $(TELEPORT_IMAGE_DEFAULT)
-TELEPORT_IMAGE_VERSION ?= 18.6.4
+TELEPORT_IMAGE_VERSION ?= 18.8.1
 LOCAL_BUILD := $(if $(filter-out $(TELEPORT_IMAGE_DEFAULT),$(TELEPORT_IMAGE)),1,)
 ARCH ?= $(shell go env GOARCH)
 
@@ -271,6 +271,8 @@ endif
 		--set "teleportVersionOverride=$(TELEPORT_IMAGE_VERSION)" \
 		--set "operator.teleportVersionOverride=$(VERSION)" \
 		--set "operator.image=$(subst :$(VERSION),,$(IMG))" \
+		--set "extraEnv[0].name=TELEPORT_UNSTABLE_SCOPES" \
+		--set "extraEnv[0].value=yes" \
 		$(if $(LOCAL_BUILD),--set "image=$(TELEPORT_IMAGE)") \
 		$(if $(ENTERPRISE),--set "enterprise=true") \
 		$(if $(ENTERPRISE),--set "enterpriseImage=$(TELEPORT_IMAGE)")

--- a/integrations/operator/apis/resources/v1/botv1_types.go
+++ b/integrations/operator/apis/resources/v1/botv1_types.go
@@ -41,6 +41,7 @@ type TeleportBotV1 struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata"`
 
+	Scope  string             `json:"scope,omitempty"`
 	Spec   *TeleportBotV1Spec `json:"spec,omitempty"`
 	Status teleportcr.Status  `json:"status"`
 }
@@ -69,7 +70,8 @@ func (l *TeleportBotV1) ToTeleport() *machineidv1.Bot {
 			Description: l.Annotations[teleportcr.DescriptionKey],
 			Labels:      l.Labels,
 		},
-		Spec: (*machineidv1.BotSpec)(l.Spec),
+		Spec:  (*machineidv1.BotSpec)(l.Spec),
+		Scope: l.Scope,
 	}
 	return resource
 }

--- a/integrations/operator/config/crd/bases/resources.teleport.dev_botsv1.yaml
+++ b/integrations/operator/config/crd/bases/resources.teleport.dev_botsv1.yaml
@@ -14,7 +14,16 @@ spec:
     singular: teleportbotv1
   scope: Namespaced
   versions:
-  - name: v1
+  - additionalPrinterColumns:
+    - description: Resource's scope.
+      jsonPath: .scope
+      name: scope
+      type: string
+    - description: The age of this resource
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1
     schema:
       openAPIV3Schema:
         description: BotV1 is the Schema for the botsv1 API
@@ -31,6 +40,16 @@ spec:
             type: string
           metadata:
             type: object
+          scope:
+            description: The scope of the Bot. If unset, the Bot is unscoped (classic
+              behavior) and if set, the Bot is scoped. When the Bot is scoped, the
+              `spec.roles`, `spec.traits` and `spec.max_session_ttl` fields must not
+              be set.
+            type: string
+            x-kubernetes-validations:
+            - message: Scope is immutable. To create the resource in a different scope
+                you must delete it first.
+              rule: self == oldSelf
           spec:
             description: Bot resource definition v1 from Teleport
             properties:
@@ -135,6 +154,10 @@ spec:
                 type: integer
             type: object
         type: object
+        x-kubernetes-validations:
+        - message: Scope is immutable. To create the resource in a different scope
+            you must delete it first.
+          rule: has(self.scope) == has(oldSelf.scope)
     served: true
     storage: true
     subresources:

--- a/integrations/operator/config/crd/bases/resources.teleport.dev_scopedroleassignmentsv1.yaml
+++ b/integrations/operator/config/crd/bases/resources.teleport.dev_scopedroleassignmentsv1.yaml
@@ -44,6 +44,10 @@ spec:
           scope:
             description: Scope is the scope of the role assignment resource.
             type: string
+            x-kubernetes-validations:
+            - message: Scope is immutable. To create the resource in a different scope
+                you must delete it first.
+              rule: self == oldSelf
           spec:
             description: ScopedRoleAssignment resource definition v1 from Teleport
             properties:

--- a/integrations/operator/config/crd/bases/resources.teleport.dev_scopedroleassignmentsv1.yaml
+++ b/integrations/operator/config/crd/bases/resources.teleport.dev_scopedroleassignmentsv1.yaml
@@ -19,6 +19,10 @@ spec:
       jsonPath: .scope
       name: scope
       type: string
+    - description: The age of this resource
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
     name: v1
     schema:
       openAPIV3Schema:

--- a/integrations/operator/config/crd/bases/resources.teleport.dev_scopedroleassignmentsv1.yaml
+++ b/integrations/operator/config/crd/bases/resources.teleport.dev_scopedroleassignmentsv1.yaml
@@ -147,6 +147,10 @@ spec:
                 type: integer
             type: object
         type: object
+        x-kubernetes-validations:
+        - message: Scope is immutable. To create the resource in a different scope
+            you must delete it first.
+          rule: has(self.scope) == has(oldSelf.scope)
     served: true
     storage: true
     subresources:

--- a/integrations/operator/config/crd/bases/resources.teleport.dev_scopedrolesv1.yaml
+++ b/integrations/operator/config/crd/bases/resources.teleport.dev_scopedrolesv1.yaml
@@ -379,6 +379,10 @@ spec:
                 type: integer
             type: object
         type: object
+        x-kubernetes-validations:
+        - message: Scope is immutable. To create the resource in a different scope
+            you must delete it first.
+          rule: has(self.scope) == has(oldSelf.scope)
     served: true
     storage: true
     subresources:

--- a/integrations/operator/config/crd/bases/resources.teleport.dev_scopedrolesv1.yaml
+++ b/integrations/operator/config/crd/bases/resources.teleport.dev_scopedrolesv1.yaml
@@ -43,6 +43,10 @@ spec:
           scope:
             description: Scope is the scope of the role resource.
             type: string
+            x-kubernetes-validations:
+            - message: Scope is immutable. To create the resource in a different scope
+                you must delete it first.
+              rule: self == oldSelf
           spec:
             description: ScopedRole resource definition v1 from Teleport
             properties:

--- a/integrations/operator/config/crd/bases/resources.teleport.dev_scopedrolesv1.yaml
+++ b/integrations/operator/config/crd/bases/resources.teleport.dev_scopedrolesv1.yaml
@@ -19,6 +19,10 @@ spec:
       jsonPath: .scope
       name: scope
       type: string
+    - description: The age of this resource
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
     name: v1
     schema:
       openAPIV3Schema:

--- a/integrations/operator/config/crd/bases/resources.teleport.dev_scopedtokensv1.yaml
+++ b/integrations/operator/config/crd/bases/resources.teleport.dev_scopedtokensv1.yaml
@@ -19,6 +19,10 @@ spec:
       jsonPath: .scope
       name: scope
       type: string
+    - description: The age of this resource
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
     name: v1
     schema:
       openAPIV3Schema:

--- a/integrations/operator/config/crd/bases/resources.teleport.dev_scopedtokensv1.yaml
+++ b/integrations/operator/config/crd/bases/resources.teleport.dev_scopedtokensv1.yaml
@@ -43,6 +43,10 @@ spec:
           scope:
             description: Scope is the scope of the token resource.
             type: string
+            x-kubernetes-validations:
+            - message: Scope is immutable. To create the resource in a different scope
+                you must delete it first.
+              rule: self == oldSelf
           spec:
             description: ScopedToken resource definition v1 from Teleport
             properties:

--- a/integrations/operator/config/crd/bases/resources.teleport.dev_scopedtokensv1.yaml
+++ b/integrations/operator/config/crd/bases/resources.teleport.dev_scopedtokensv1.yaml
@@ -399,6 +399,10 @@ spec:
                 type: integer
             type: object
         type: object
+        x-kubernetes-validations:
+        - message: Scope is immutable. To create the resource in a different scope
+            you must delete it first.
+          rule: has(self.scope) == has(oldSelf.scope)
     served: true
     storage: true
     subresources:

--- a/integrations/operator/crdgen/handlerequest.go
+++ b/integrations/operator/crdgen/handlerequest.go
@@ -219,7 +219,13 @@ func generateSchema(file *File, groupName string, format crdFormatFunc, resp *go
 			},
 		},
 		{name: "TrustedClusterV2"},
-		{name: "Bot", opts: []resourceSchemaOption{withVersionOverride(types.V1)}},
+		{
+			name: "Bot",
+			opts: []resourceSchemaOption{
+				withVersionOverride(types.V1),
+				withScope(),
+			},
+		},
 		{
 			name: "WorkloadIdentity",
 			opts: []resourceSchemaOption{

--- a/integrations/operator/crdgen/schemagen.go
+++ b/integrations/operator/crdgen/schemagen.go
@@ -113,13 +113,13 @@ func NewSchema() *Schema {
 }
 
 type resourceSchemaConfig struct {
-	nameOverride         string
-	versionOverride      string
-	customSpecFields     []string
-	additionalRootFields []string
-	kindWithoutVersion   bool
-	additionalColumns    []apiextv1.CustomResourceColumnDefinition
-	validationRules      apiextv1.ValidationRules
+	nameOverride       string
+	versionOverride    string
+	customSpecFields   []string
+	withScopeRootField bool
+	kindWithoutVersion bool
+	additionalColumns  []apiextv1.CustomResourceColumnDefinition
+	validationRules    apiextv1.ValidationRules
 }
 
 type resourceSchemaOption func(*resourceSchemaConfig)
@@ -155,7 +155,7 @@ func withCustomSpecFields(customSpecFields []string) resourceSchemaOption {
 // withScope says that the resource is scoped. A scope field will be inserted at the CRD root.
 func withScope() resourceSchemaOption {
 	return func(cfg *resourceSchemaConfig) {
-		cfg.additionalRootFields = append(cfg.additionalRootFields, scopeFieldName)
+		cfg.withScopeRootField = true
 		cfg.additionalColumns = append(cfg.additionalColumns, apiextv1.CustomResourceColumnDefinition{
 			Name:        scopeFieldName,
 			Type:        "string",
@@ -274,19 +274,25 @@ func (generator *SchemaGenerator) addResource(file *File, name string, opts ...r
 	}
 
 	var rootFields map[string]apiextv1.JSONSchemaProps
-	if len(cfg.additionalRootFields) > 0 {
-		rootFields = make(map[string]apiextv1.JSONSchemaProps, len(cfg.additionalRootFields))
-		for _, fieldName := range cfg.additionalRootFields {
-			field, ok := rootMsg.GetField(fieldName)
-			if !ok {
-				return trace.NotFound("root field %q not found", fieldName)
-			}
-			prop, err := generator.prop(field)
-			if err != nil {
-				return trace.Wrap(err)
-			}
-			rootFields[fieldName] = prop
+	if cfg.withScopeRootField {
+		rootFields = make(map[string]apiextv1.JSONSchemaProps)
+		field, ok := rootMsg.GetField(scopeFieldName)
+		if !ok {
+			return trace.NotFound("root field %q not found", scopeFieldName)
 		}
+		prop, err := generator.prop(field)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+		// Scopes are immutable. We force the user to delete and re-create the CRD.
+		// This prevents leaving dangling resources in Teleport.
+		prop.XValidations = apiextv1.ValidationRules{
+			{
+				Rule:    "self == oldSelf",
+				Message: fmt.Sprintf("Scope is immutable. To create the resource in a different scope you must delete it first."),
+			},
+		}
+		rootFields[scopeFieldName] = prop
 	}
 
 	root.versions = append(root.versions, SchemaVersion{

--- a/integrations/operator/crdgen/schemagen.go
+++ b/integrations/operator/crdgen/schemagen.go
@@ -35,12 +35,13 @@ import (
 )
 
 const (
-	k8sKindPrefix     = "Teleport"
-	statusPackagePath = "github.com/gravitational/teleport/integrations/operator/apis/resources"
-	statusPackageName = "teleportcr"
-	statusPackage     = statusPackagePath + "/" + statusPackageName
-	statusTypeName    = "Status"
-	scopeFieldName    = "scope"
+	k8sKindPrefix         = "Teleport"
+	statusPackagePath     = "github.com/gravitational/teleport/integrations/operator/apis/resources"
+	statusPackageName     = "teleportcr"
+	statusPackage         = statusPackagePath + "/" + statusPackageName
+	statusTypeName        = "Status"
+	scopeFieldName        = "scope"
+	immutableScopeMessage = "Scope is immutable. To create the resource in a different scope you must delete it first."
 )
 
 // Add names to this array when adding support to new Teleport resources that could conflict with Kubernetes
@@ -273,6 +274,8 @@ func (generator *SchemaGenerator) addResource(file *File, name string, opts ...r
 		kubernetesVersion = "v1"
 	}
 
+	validationRules := cfg.validationRules
+
 	var rootFields map[string]apiextv1.JSONSchemaProps
 	if cfg.withScopeRootField {
 		rootFields = make(map[string]apiextv1.JSONSchemaProps)
@@ -289,10 +292,16 @@ func (generator *SchemaGenerator) addResource(file *File, name string, opts ...r
 		prop.XValidations = apiextv1.ValidationRules{
 			{
 				Rule:    "self == oldSelf",
-				Message: fmt.Sprintf("Scope is immutable. To create the resource in a different scope you must delete it first."),
+				Message: immutableScopeMessage,
 			},
 		}
 		rootFields[scopeFieldName] = prop
+		// The validation rule only triggers if the field is set.
+		// To make sure a resource doesn't go from scoped to unscoped we must also make sure that `scope` is not set/unset.
+		validationRules = append(validationRules, apiextv1.ValidationRule{
+			Rule:    "has(self.scope) == has(oldSelf.scope)",
+			Message: immutableScopeMessage,
+		})
 	}
 
 	root.versions = append(root.versions, SchemaVersion{
@@ -300,7 +309,7 @@ func (generator *SchemaGenerator) addResource(file *File, name string, opts ...r
 		Schema:               schema,
 		additionalColumns:    cfg.additionalColumns,
 		additionalRootFields: rootFields,
-		validationRules:      cfg.validationRules,
+		validationRules:      validationRules,
 	})
 
 	return nil

--- a/integrations/operator/crdgen/schemagen.go
+++ b/integrations/operator/crdgen/schemagen.go
@@ -166,22 +166,9 @@ func withScope() resourceSchemaOption {
 	}
 }
 
-var ageColumn = apiextv1.CustomResourceColumnDefinition{
-	Name:        "Age",
-	Type:        "date",
-	Description: "The age of this resource",
-	JSONPath:    ".metadata.creationTimestamp",
-}
-
 func withAdditionalColumns(additionalColumns []apiextv1.CustomResourceColumnDefinition) resourceSchemaOption {
-	// We add the age column back (it's removed if we set additional columns for the CRD).
-	// See https://github.com/kubernetes/kubectl/issues/903#issuecomment-669244656.
-	columns := make([]apiextv1.CustomResourceColumnDefinition, len(additionalColumns)+1)
-	copy(columns, additionalColumns)
-	columns[len(additionalColumns)] = ageColumn
-
 	return func(cfg *resourceSchemaConfig) {
-		cfg.additionalColumns = columns
+		cfg.additionalColumns = append(cfg.additionalColumns, additionalColumns...)
 	}
 }
 
@@ -543,6 +530,13 @@ func (generator *SchemaGenerator) singularProp(field *Field, prop *apiextv1.JSON
 	return nil
 }
 
+var ageColumn = apiextv1.CustomResourceColumnDefinition{
+	Name:        "Age",
+	Type:        "date",
+	Description: "The age of this resource",
+	JSONPath:    ".metadata.creationTimestamp",
+}
+
 func (root RootSchema) CustomResourceDefinition() (apiextv1.CustomResourceDefinition, error) {
 	crd := apiextv1.CustomResourceDefinition{
 		TypeMeta: metav1.TypeMeta{
@@ -595,6 +589,11 @@ func (root RootSchema) CustomResourceDefinition() (apiextv1.CustomResourceDefini
 	}
 
 	for i, schemaVersion := range root.versions {
+		// Restore the age column if some additional columns were set.
+		columns := schemaVersion.additionalColumns
+		if len(columns) > 0 {
+			columns = append(columns, ageColumn)
+		}
 
 		schema := schemaVersion.Schema
 		version := apiextv1.CustomResourceDefinitionVersion{
@@ -624,7 +623,7 @@ func (root RootSchema) CustomResourceDefinition() (apiextv1.CustomResourceDefini
 					},
 				},
 			},
-			AdditionalPrinterColumns: schemaVersion.additionalColumns,
+			AdditionalPrinterColumns: columns,
 		}
 
 		// Add any additional root-level fields as siblings to spec/metadata/status.


### PR DESCRIPTION
This PR does 3 changes:

- Fixes a bug that happened when both `withAdditionalColumns()` and `withScope()` were set. Now the `age` column is always present, and `withAdditionalColumns()` does not clear the `scope` column anymore
- Makes the `TeleportBot` CR scoped, scope support was added to the resource 
- Adds a transition rule to the CRD `scope` field to prevent changes

The scope must not change, Teleport doesn't support scope changes. A scope change might cause dangling resource as the finalizer doesn't run properly/runs on the wrong resource.

Changelog: Added early failing when a Teleport Kube Operator resource changes scope.

## Manual Test Plan
### Test Environment

Local cluster + staging

### Test Cases

- [x] scope change is blocked
- [x] scope removal is blocked
- [x] operator can create scoped bots
- [x] operator can create unscoped bots
- [x] bot CR has a scope column
