### PR TITLE
Force resource replacement on scope change

### DIFF
--- a/integrations/terraform/protoc-gen-terraform-scopedrole.yaml
+++ b/integrations/terraform/protoc-gen-terraform-scopedrole.yaml
@@ -54,6 +54,8 @@ plan_modifiers:
   # Force to recreate resource if its name changes
   Metadata.name:
     - "github.com/hashicorp/terraform-plugin-framework/tfsdk.RequiresReplace()"
+  ScopedRole.scope:
+    - "github.com/hashicorp/terraform-plugin-framework/tfsdk.RequiresReplace()"
 
 # This must be defined for the generator to be happy, but in reality all time
 # fields are overridden (because the protobuf timestamps contain locks and the

--- a/integrations/terraform/protoc-gen-terraform-scopedroleassignment.yaml
+++ b/integrations/terraform/protoc-gen-terraform-scopedroleassignment.yaml
@@ -55,6 +55,8 @@ plan_modifiers:
   # Force to recreate resource if its name changes
   Metadata.name:
     - "github.com/hashicorp/terraform-plugin-framework/tfsdk.RequiresReplace()"
+  ScopedRoleAssignment.scope:
+    - "github.com/hashicorp/terraform-plugin-framework/tfsdk.RequiresReplace()"
 
 # This must be defined for the generator to be happy, but in reality all time
 # fields are overridden (because the protobuf timestamps contain locks and the

--- a/integrations/terraform/protoc-gen-terraform-scopedtoken.yaml
+++ b/integrations/terraform/protoc-gen-terraform-scopedtoken.yaml
@@ -59,6 +59,8 @@ plan_modifiers:
   # Force to recreate resource if its name changes
   Metadata.name:
     - "github.com/hashicorp/terraform-plugin-framework/tfsdk.RequiresReplace()"
+  ScopedToken.scope:
+    - "github.com/hashicorp/terraform-plugin-framework/tfsdk.RequiresReplace()"
 
 # This must be defined for the generator to be happy, but in reality all time
 # fields are overridden (because the protobuf timestamps contain locks and the

--- a/integrations/terraform/tfschema/scopes/access/assignment/v1/assignment_terraform.go
+++ b/integrations/terraform/tfschema/scopes/access/assignment/v1/assignment_terraform.go
@@ -101,9 +101,10 @@ func GenSchemaScopedRoleAssignment(ctx context.Context) (github_com_hashicorp_te
 			Required:    true,
 		},
 		"scope": {
-			Description: "Scope is the scope of the role assignment resource.",
-			Required:    true,
-			Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
+			Description:   "Scope is the scope of the role assignment resource.",
+			PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributePlanModifier{github_com_hashicorp_terraform_plugin_framework_tfsdk.RequiresReplace()},
+			Required:      true,
+			Type:          github_com_hashicorp_terraform_plugin_framework_types.StringType,
 		},
 		"spec": {
 			Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.SingleNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{

--- a/integrations/terraform/tfschema/scopes/access/v1/role_terraform.go
+++ b/integrations/terraform/tfschema/scopes/access/v1/role_terraform.go
@@ -103,9 +103,10 @@ func GenSchemaScopedRole(ctx context.Context) (github_com_hashicorp_terraform_pl
 			Required:    true,
 		},
 		"scope": {
-			Description: "Scope is the scope of the role resource.",
-			Required:    true,
-			Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
+			Description:   "Scope is the scope of the role resource.",
+			PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributePlanModifier{github_com_hashicorp_terraform_plugin_framework_tfsdk.RequiresReplace()},
+			Required:      true,
+			Type:          github_com_hashicorp_terraform_plugin_framework_types.StringType,
 		},
 		"spec": {
 			Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.SingleNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{

--- a/integrations/terraform/tfschema/scopes/joining/v1/token_terraform.go
+++ b/integrations/terraform/tfschema/scopes/joining/v1/token_terraform.go
@@ -102,9 +102,10 @@ func GenSchemaScopedToken(ctx context.Context) (github_com_hashicorp_terraform_p
 			Required:    true,
 		},
 		"scope": {
-			Description: "Scope is the scope of the token resource.",
-			Required:    true,
-			Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
+			Description:   "Scope is the scope of the token resource.",
+			PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributePlanModifier{github_com_hashicorp_terraform_plugin_framework_tfsdk.RequiresReplace()},
+			Required:      true,
+			Type:          github_com_hashicorp_terraform_plugin_framework_types.StringType,
 		},
 		"spec": {
 			Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.SingleNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{


### PR DESCRIPTION
This PR makes the Terraform provider delete and re-create a scoped resource if its scope changes.

This is required as Teleport doesn't support scope changes in-place.

Note for test coverage: this is covered by another PR that I'll open soon that adds scope support for bots.

Changelog: Fixed a bug in Terraform when scoped resources change scope.

## Manual Test Plan
### Test Environment

Local build + staging cluster

### Test Cases
- [x] Can create scoped resources
- [x] TF replaces resource on scope change
