### PR TITLE
[v18] Fix GenerateCertificate overriding Subject.ExtraNames

### DIFF
--- a/lib/auth/desktop.go
+++ b/lib/auth/desktop.go
@@ -94,6 +94,20 @@ func (a *Server) GenerateWindowsDesktopCert(ctx context.Context, req *proto.Wind
 		return nil, trace.Wrap(err)
 	}
 
+	// Our CSR may contains non-standard subject OIDs that
+	// we need to preserve, but de-serializing the CSR puts those fields
+	// in csr.Subject.Names which is ignored when re-serializing
+	// (See documentation on Names and ExtraNames fields of [pkix.Name])
+	// Copy the Names -> ExtraNames but be warned - The values in `ExtraNames`
+	// take precedence over standard Subject values (CommonName, Country, Organization, etc.)
+	// in the pkix.Name struct. If you modified any of these values after parsing the CSR,
+	// those modifications will be LOST upon cert generation.
+	// If you need to modify the original CSR's subject in this function, then we must
+	// take care to prune standard OIDs for these fields from csr.Subject.Names first.
+	if len(csr.Subject.Names) > 0 {
+		csr.Subject.ExtraNames = csr.Subject.Names
+	}
+
 	// See https://docs.microsoft.com/en-us/troubleshoot/windows-server/windows-security/enabling-smart-card-logon-third-party-certification-authorities
 	// for cert requirements for Windows authn.
 	certReq := tlsca.CertificateRequest{

--- a/lib/tlsca/ca.go
+++ b/lib/tlsca/ca.go
@@ -1608,13 +1608,6 @@ func (ca *CertAuthority) GenerateCertificate(req CertificateRequest) ([]byte, er
 		"issuer_skid", base32.HexEncoding.EncodeToString(ca.Cert.SubjectKeyId),
 	)
 
-	// Go deserializes extra names into Names field, but it uses ExtraNames for serialization,
-	// if we have any then we have to copy them over, or they will get lost during another
-	// serialization in x509.CreateCertificate
-	if len(req.Subject.Names) > 0 {
-		req.Subject.ExtraNames = req.Subject.Names
-	}
-
 	template := &x509.Certificate{
 		SerialNumber: serialNumber,
 		Subject:      req.Subject,

--- a/lib/tlsca/ca_test.go
+++ b/lib/tlsca/ca_test.go
@@ -745,7 +745,7 @@ func TestDelegationSessionID(t *testing.T) {
 	require.Empty(t, cmp.Diff(out, &identity, cmpopts.EquateApproxTime(time.Second)))
 }
 
-func TestGenerateCertificate_ExtraNamesPreserved(t *testing.T) {
+func TestGenerateCertificate_SubjectModifcationsPreserved(t *testing.T) {
 	ca, err := FromKeys([]byte(fixtures.TLSCACertPEM), []byte(fixtures.TLSCAKeyPEM))
 	require.NoError(t, err)
 	key, err := cryptosuites.GenerateKeyWithAlgorithm(cryptosuites.ECDSAP256)
@@ -795,10 +795,10 @@ func TestGenerateCertificate_ExtraNamesPreserved(t *testing.T) {
 	require.NoError(t, err)
 
 	// Subject modifications are preserved.
-	assert.Equal(t, parsedRoundTripped.Subject.CommonName, "bob")
-	assert.Equal(t, parsedRoundTripped.Subject.Organization, []string{"marketing"})
+	assert.Equal(t, "bob", parsedRoundTripped.Subject.CommonName)
+	assert.Equal(t, []string{"marketing"}, parsedRoundTripped.Subject.Organization)
 	// DNS modification preserved.
-	assert.Equal(t, parsedRoundTripped.DNSNames, []string{"overridden-dns"})
+	assert.Equal(t, []string{"overridden-dns"}, parsedRoundTripped.DNSNames)
 
 	// The extra name that we added should be present in the roundtripped cert.
 	assert.Len(t, parsedRoundTripped.Subject.Names, len(parsed.Subject.Names)+1)

--- a/lib/tlsca/ca_test.go
+++ b/lib/tlsca/ca_test.go
@@ -744,3 +744,58 @@ func TestDelegationSessionID(t *testing.T) {
 	require.False(t, out.Renewable)
 	require.Empty(t, cmp.Diff(out, &identity, cmpopts.EquateApproxTime(time.Second)))
 }
+
+func TestGenerateCertificate_ExtraNamesPreserved(t *testing.T) {
+	ca, err := FromKeys([]byte(fixtures.TLSCACertPEM), []byte(fixtures.TLSCAKeyPEM))
+	require.NoError(t, err)
+	key, err := cryptosuites.GenerateKeyWithAlgorithm(cryptosuites.ECDSAP256)
+	require.NoError(t, err)
+	generated, err := ca.GenerateCertificate(CertificateRequest{
+		Subject: pkix.Name{
+			CommonName:         "alice",
+			Organization:       []string{"org"},
+			OrganizationalUnit: []string{"engineering"},
+			Locality:           []string{"Somewhere"},
+			Province:           []string{"N/A"},
+			StreetAddress:      []string{"123 Cherry Street"},
+			PostalCode:         []string{"99999"},
+			Country:            []string{"US"},
+			SerialNumber:       "12345",
+		},
+		PublicKey: key.Public(),
+		DNSNames:  []string{"overridden-cn"},
+		NotAfter:  time.Now().Add(10 * time.Second),
+	})
+	require.NoError(t, err)
+
+	parsed, err := ParseCertificatePEM(generated)
+	require.NoError(t, err)
+
+	// Let's re-use the original subject, but add an extra value.
+	parsed.Subject.ExtraNames = []pkix.AttributeTypeAndValue{
+		{
+			Type:  []int{1, 2, 3},
+			Value: "somevalue",
+		},
+	}
+
+	roundTripped, err := ca.GenerateCertificate(CertificateRequest{
+		Subject:   parsed.Subject,
+		PublicKey: key.Public(),
+		DNSNames:  []string{"overridden-cn"},
+		NotAfter:  time.Now().Add(10 * time.Second),
+	})
+	require.NoError(t, err)
+
+	parsedRoundTripped, err := ParseCertificatePEM(roundTripped)
+	require.NoError(t, err)
+
+	// Names should contain exactly one more entry than the original
+	require.Len(t, parsedRoundTripped.Subject.Names, len(parsed.Subject.Names)+1)
+	for _, item := range parsed.Subject.Names {
+		// All standard subject fields are preserved.
+		require.Contains(t, parsedRoundTripped.Subject.Names, item)
+	}
+	// The extra name that we added should be present in the roundtripped cert.
+	require.Contains(t, parsedRoundTripped.Subject.Names, parsed.Subject.ExtraNames[0])
+}

--- a/lib/tlsca/ca_test.go
+++ b/lib/tlsca/ca_test.go
@@ -763,7 +763,7 @@ func TestGenerateCertificate_ExtraNamesPreserved(t *testing.T) {
 			SerialNumber:       "12345",
 		},
 		PublicKey: key.Public(),
-		DNSNames:  []string{"overridden-cn"},
+		DNSNames:  []string{"dns"},
 		NotAfter:  time.Now().Add(10 * time.Second),
 	})
 	require.NoError(t, err)
@@ -771,31 +771,36 @@ func TestGenerateCertificate_ExtraNamesPreserved(t *testing.T) {
 	parsed, err := ParseCertificatePEM(generated)
 	require.NoError(t, err)
 
-	// Let's re-use the original subject, but add an extra value.
+	// Let's modify the subject a bit from the original.
+	// Add some new OIDs, modify the CN, etc.
 	parsed.Subject.ExtraNames = []pkix.AttributeTypeAndValue{
 		{
 			Type:  []int{1, 2, 3},
 			Value: "somevalue",
 		},
 	}
+	parsed.Subject.CommonName = "bob"
+	parsed.Subject.Organization = []string{"marketing"}
 
 	roundTripped, err := ca.GenerateCertificate(CertificateRequest{
 		Subject:   parsed.Subject,
 		PublicKey: key.Public(),
-		DNSNames:  []string{"overridden-cn"},
-		NotAfter:  time.Now().Add(10 * time.Second),
+		// Override DNSNames as well
+		DNSNames: []string{"overridden-dns"},
+		NotAfter: time.Now().Add(10 * time.Second),
 	})
 	require.NoError(t, err)
 
 	parsedRoundTripped, err := ParseCertificatePEM(roundTripped)
 	require.NoError(t, err)
 
-	// Names should contain exactly one more entry than the original
-	require.Len(t, parsedRoundTripped.Subject.Names, len(parsed.Subject.Names)+1)
-	for _, item := range parsed.Subject.Names {
-		// All standard subject fields are preserved.
-		require.Contains(t, parsedRoundTripped.Subject.Names, item)
-	}
+	// Subject modifications are preserved.
+	assert.Equal(t, parsedRoundTripped.Subject.CommonName, "bob")
+	assert.Equal(t, parsedRoundTripped.Subject.Organization, []string{"marketing"})
+	// DNS modification preserved.
+	assert.Equal(t, parsedRoundTripped.DNSNames, []string{"overridden-dns"})
+
 	// The extra name that we added should be present in the roundtripped cert.
-	require.Contains(t, parsedRoundTripped.Subject.Names, parsed.Subject.ExtraNames[0])
+	assert.Len(t, parsedRoundTripped.Subject.Names, len(parsed.Subject.Names)+1)
+	assert.Contains(t, parsedRoundTripped.Subject.Names, parsed.Subject.ExtraNames[0])
 }


### PR DESCRIPTION
Backport #66915 to branch/v18

changelog: Fixed tsh aws, tsh gcp, tsh azure, and tsh proxy app failing from certificate errors.

## Manual Test Plan
### Test Environment
Test Cluster in AWS with multiple Windows desktops belonging to separate AD domains.
### Test Cases
- [x] Validate that multi-domain sign in into the root domain works for users in a child domain
- [x] Validate that multi-domain sign in into the root domain works for users in domain belonging to an external forest.