### PR TITLE
Add `tsh workload-identity issue-jwt`

### DIFF
--- a/lib/tbot/workloadidentity/issue.go
+++ b/lib/tbot/workloadidentity/issue.go
@@ -176,18 +176,12 @@ func labelsToSelectors(in map[string][]string) []*workloadidentityv1pb.LabelSele
 	return selectors
 }
 
-// jwtAuthClient is the minimal client interface required to issue JWT workload
-// identity credentials.
-type jwtAuthClient interface {
-	WorkloadIdentityIssuanceClient() workloadidentityv1pb.WorkloadIdentityIssuanceServiceClient
-}
-
 // IssueJWTWorkloadIdentity uses a given client and selector to issue a single
 // or multiple JWT-SVID workload identity credentials.
 func IssueJWTWorkloadIdentity(
 	ctx context.Context,
 	log *slog.Logger,
-	clt jwtAuthClient,
+	clt authClient,
 	workloadIdentity bot.WorkloadIdentitySelector,
 	audiences []string,
 	ttl time.Duration,

--- a/lib/tbot/workloadidentity/issue.go
+++ b/lib/tbot/workloadidentity/issue.go
@@ -26,7 +26,6 @@ import (
 	"github.com/gravitational/trace"
 	"google.golang.org/protobuf/types/known/durationpb"
 
-	apiclient "github.com/gravitational/teleport/api/client"
 	workloadidentityv1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/workloadidentity/v1"
 	"github.com/gravitational/teleport/lib/cryptosuites"
 	"github.com/gravitational/teleport/lib/tbot/bot"
@@ -177,12 +176,18 @@ func labelsToSelectors(in map[string][]string) []*workloadidentityv1pb.LabelSele
 	return selectors
 }
 
+// jwtAuthClient is the minimal client interface required to issue JWT workload
+// identity credentials.
+type jwtAuthClient interface {
+	WorkloadIdentityIssuanceClient() workloadidentityv1pb.WorkloadIdentityIssuanceServiceClient
+}
+
 // IssueJWTWorkloadIdentity uses a given client and selector to issue a single
 // or multiple JWT-SVID workload identity credentials.
 func IssueJWTWorkloadIdentity(
 	ctx context.Context,
 	log *slog.Logger,
-	clt *apiclient.Client,
+	clt jwtAuthClient,
 	workloadIdentity bot.WorkloadIdentitySelector,
 	audiences []string,
 	ttl time.Duration,

--- a/tool/tsh/common/tsh.go
+++ b/tool/tsh/common/tsh.go
@@ -1989,6 +1989,8 @@ func Run(ctx context.Context, args []string, opts ...CliOption) error {
 		err = onHeadlessApprove(&cf)
 	case workloadIdentityCmd.issueX509.FullCommand():
 		err = workloadIdentityCmd.issueX509.run(&cf)
+	case workloadIdentityCmd.issueJWT.FullCommand():
+		err = workloadIdentityCmd.issueJWT.run(&cf)
 	case vnetCommand.FullCommand():
 		err = vnetCommand.run(&cf)
 	case vnetSSHAutoConfigCommand.FullCommand():

--- a/tool/tsh/common/workload_identity.go
+++ b/tool/tsh/common/workload_identity.go
@@ -45,10 +45,12 @@ const (
 	svidPEMPath            = "svid.pem"
 	svidKeyPEMPath         = "svid_key.pem"
 	svidTrustBundlePEMPath = "svid_bundle.pem"
+	jwtSVIDPath            = "jwt_svid"
 )
 
 type workloadIdentityCommands struct {
 	issueX509 *issueX509Command
+	issueJWT  *issueJWTCommand
 }
 
 func newWorkloadIdentityCommands(
@@ -57,6 +59,7 @@ func newWorkloadIdentityCommands(
 	cmd := app.Command("workload-identity", "Issue Workload Identity credentials.")
 	cmds := workloadIdentityCommands{
 		issueX509: newIssueX509Command(cmd),
+		issueJWT:  newIssueJWTCommand(cmd),
 	}
 	return cmds
 }
@@ -240,6 +243,137 @@ func (c *issueX509Command) run(cf *CLIConf) error {
 			keyPath,
 			svidPath,
 			trustBundlePath,
+		)
+
+		return nil
+	})
+}
+
+type issueJWTCommand struct {
+	*kingpin.CmdClause
+	nameSelector    string
+	labelSelector   string
+	ttl             time.Duration
+	outputDirectory string
+	audiences       []string
+}
+
+func newIssueJWTCommand(parent *kingpin.CmdClause) *issueJWTCommand {
+	cmd := &issueJWTCommand{
+		CmdClause: parent.Command("issue-jwt", "Use Teleport Workload Identity to issue a JWT credential and write it to a local directory."),
+	}
+
+	cmd.Flag(
+		"name-selector",
+		"The name of the workload identity to issue.",
+	).StringVar(&cmd.nameSelector)
+	cmd.Flag(
+		"label-selector",
+		"A label-based selector for which workload identities to issue. Multiple labels can be provided using ','.",
+	).StringVar(&cmd.labelSelector)
+	cmd.Flag("credential-ttl", "Sets the time to live for the credential.").
+		Default("1h").
+		DurationVar(&cmd.ttl)
+	cmd.Flag("output", "Path to the directory to write the SVID into.").
+		Required().
+		StringVar(&cmd.outputDirectory)
+	cmd.Flag("audience", "The audience to include in the JWT. Can be specified multiple times.").
+		Required().
+		StringsVar(&cmd.audiences)
+
+	return cmd
+}
+
+func (c *issueJWTCommand) run(cf *CLIConf) error {
+	ctx := cf.Context
+
+	tc, err := makeClient(cf)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	tc.AllowHeadless = true
+
+	selector := bot.WorkloadIdentitySelector{}
+	switch {
+	case c.nameSelector != "" && c.labelSelector != "":
+		return trace.BadParameter("cannot specify both name and label selectors")
+	case c.nameSelector != "":
+		selector.Name = c.nameSelector
+	case c.labelSelector != "":
+		labels, err := client.ParseLabelSpec(c.labelSelector)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+		selector.Labels = map[string][]string{}
+		for k, v := range labels {
+			selector.Labels[k] = []string{v}
+		}
+	default:
+		return trace.BadParameter("name-selector or label-selector must be specified")
+	}
+
+	return client.RetryWithRelogin(ctx, tc, func() error {
+		clusterClient, err := tc.ConnectToCluster(ctx)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+		defer clusterClient.Close()
+
+		credentials, err := workloadidentity.IssueJWTWorkloadIdentity(
+			ctx,
+			logger,
+			clusterClient.AuthClient,
+			selector,
+			c.audiences,
+			c.ttl,
+			nil,
+		)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+		var jwtCredential *workloadidentityv1pb.Credential
+		switch len(credentials) {
+		case 0:
+			return trace.BadParameter("no JWT SVIDs returned")
+		case 1:
+			jwtCredential = credentials[0]
+		default:
+			// We could eventually implement some kind of hint selection mechanism
+			// to pick the "right" one.
+			received := make([]string, 0, len(credentials))
+			for _, cred := range credentials {
+				received = append(received,
+					fmt.Sprintf(
+						"%s:%s",
+						cred.WorkloadIdentityName,
+						cred.SpiffeId,
+					),
+				)
+			}
+			return trace.BadParameter(
+				"multiple JWT SVIDs received: %v", received,
+			)
+		}
+
+		// Create directory if it does not exist.
+		if err := os.MkdirAll(c.outputDirectory, teleport.PrivateDirMode); err != nil {
+			return trace.Wrap(err, "creating output directory")
+		}
+
+		jwtPath := filepath.Join(c.outputDirectory, jwtSVIDPath)
+		if err := os.WriteFile(
+			jwtPath,
+			[]byte(jwtCredential.GetJwtSvid().GetJwt()),
+			teleport.FileMaskOwnerOnly,
+		); err != nil {
+			return trace.Wrap(err)
+		}
+
+		fmt.Fprintf(
+			cf.Stdout(),
+			"SVID %q issued. File written to: \n - %s\n",
+			jwtCredential.SpiffeId,
+			jwtPath,
 		)
 
 		return nil

--- a/tool/tsh/common/workload_identity_test.go
+++ b/tool/tsh/common/workload_identity_test.go
@@ -24,11 +24,14 @@ import (
 	"crypto/ecdsa"
 	"crypto/x509"
 	"encoding/pem"
+	"net"
 	"os"
 	"path/filepath"
+	"strconv"
 	"testing"
 	"time"
 
+	"github.com/spiffe/go-spiffe/v2/svid/jwtsvid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -39,6 +42,7 @@ import (
 	"github.com/gravitational/teleport/lib/service/servicecfg"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/tlsca"
+	"github.com/gravitational/teleport/lib/utils"
 )
 
 func TestWorkloadIdentityIssueX509(t *testing.T) {
@@ -129,6 +133,84 @@ func TestWorkloadIdentityIssueX509(t *testing.T) {
 	bundleBlock, _ := pem.Decode(bundlePEM)
 	_, err = x509.ParseCertificate(bundleBlock.Bytes)
 	require.NoError(t, err)
+}
+
+func TestWorkloadIdentityIssueJWT(t *testing.T) {
+	ctx := t.Context()
+
+	role, err := types.NewRole("workload-identity-issuer", types.RoleSpecV6{
+		Allow: types.RoleConditions{
+			WorkloadIdentityLabels: types.Labels{
+				types.Wildcard: []string{types.Wildcard},
+			},
+			Rules: []types.Rule{
+				types.NewRule(types.KindWorkloadIdentity, services.RO()),
+			},
+		},
+	})
+	require.NoError(t, err)
+	s := newTestSuite(t, withRootConfigFunc(func(cfg *servicecfg.Config) {
+		// reconfig the user to use the new role instead of the default ones
+		// User is the second bootstrap resource.
+		user, ok := cfg.Auth.BootstrapResources[1].(types.User)
+		require.True(t, ok)
+		user.AddRole(role.GetName())
+		cfg.Auth.BootstrapResources[1] = user
+		cfg.Auth.BootstrapResources = append(cfg.Auth.BootstrapResources, role)
+		cfg.SSH.Enabled = false
+		// JWT issuance needs the proxy's public address to construct the
+		// issuer URI.
+		cfg.Proxy.PublicAddrs = []utils.NetAddr{
+			{AddrNetwork: "tcp", Addr: net.JoinHostPort("localhost", strconv.Itoa(cfg.Proxy.WebAddr.Port(0)))},
+		}
+	}))
+
+	_, err = s.root.GetAuthServer().Services.UpsertWorkloadIdentity(
+		ctx,
+		&workloadidentityv1pb.WorkloadIdentity{
+			Kind:    types.KindWorkloadIdentity,
+			Version: types.V1,
+			Metadata: &headerv1.Metadata{
+				Name:   "my-workload-identity",
+				Labels: map[string]string{},
+			},
+			Spec: &workloadidentityv1pb.WorkloadIdentitySpec{
+				Spiffe: &workloadidentityv1pb.WorkloadIdentitySPIFFE{
+					Id: "/test",
+				},
+			},
+		},
+	)
+	require.NoError(t, err)
+	require.EventuallyWithT(t, func(t *assert.CollectT) {
+		_, err := s.root.GetAuthServer().Cache.GetWorkloadIdentity(ctx, "my-workload-identity")
+		require.NoError(t, err)
+	}, time.Second*5, 100*time.Millisecond)
+
+	homeDir, _ := mustLoginLegacy(t, s)
+	outDir := filepath.Join(t.TempDir(), "out")
+	err = Run(
+		ctx,
+		[]string{
+			"workload-identity",
+			"issue-jwt",
+			"--insecure",
+			"--output", outDir,
+			"--credential-ttl", "10m",
+			"--name-selector", "my-workload-identity",
+			"--audience", "example",
+			"--audience", "foo",
+		},
+		setHomePath(homeDir),
+	)
+	require.NoError(t, err)
+
+	jwtBytes, err := os.ReadFile(filepath.Join(outDir, "jwt_svid"))
+	require.NoError(t, err)
+	jwt, err := jwtsvid.ParseInsecure(string(jwtBytes), []string{"example"})
+	require.NoError(t, err)
+	require.Equal(t, "spiffe://root/test", jwt.ID.String())
+	require.Equal(t, []string{"example", "foo"}, jwt.Audience)
 }
 
 func setWorkloadIdentityX509CAOverride(ctx context.Context, t *testing.T, process *service.TeleportProcess) {


### PR DESCRIPTION
Closes https://github.com/gravitational/teleport/issues/66311



<!-- Provide a descriptive entry for the changelog of the next release. -->

Changelog: Introduces `tsh workload-identity issue-jwt` command for human issuance of JWT-SVIDs


<!-- Include manual testing efforts to verify the change. -->
<!-- Detail where the tests where run and what configurations were used. -->
<!-- Include all the test cases which were run to validate the change. -->

## Manual Test Plan
### Test Environment

Local cluster with following Workload Identity spec:

```yaml
kind: workload_identity
version: v1
metadata:
  name: human
  labels:
    env: human
spec:
  rules:
    allow:
      - conditions:
          - attribute: user.is_bot
            eq:
              value: "false"
  spiffe:
    id: /human/{{ user.name }}
```

### Test Cases
- [x] Issuance using name selector
- [x] Issuance using label selector
- [x] Issuance with multiple audiences
- [x] Issuance of workload identity that does not exist/user does not have privileges for fails sensibly
- [x] Directory is created if does not exist
