### PR TITLE
Make Discovery Service partial cloud agnostic

### DIFF
--- a/docs/pages/enroll-resources/auto-discovery/databases/aws.mdx
+++ b/docs/pages/enroll-resources/auto-discovery/databases/aws.mdx
@@ -312,6 +312,6 @@ for information about database user provisioning and configuration.
 
 ## Troubleshooting
 
-(!docs/pages/includes/discovery/discovery-service-troubleshooting.mdx resourceKind="database" tctlResource="db" !)
+(!docs/pages/includes/discovery/discovery-service-troubleshooting.mdx resourceKind="database" tctlResource="db" cloud="AWS"!)
 
 (!docs/pages/includes/discovery/database-service-troubleshooting.mdx!)

--- a/docs/pages/enroll-resources/auto-discovery/kubernetes/aks-discovery.mdx
+++ b/docs/pages/enroll-resources/auto-discovery/kubernetes/aks-discovery.mdx
@@ -287,6 +287,6 @@ specified in the Azure section will be added to the Teleport cluster automatical
 
 ## Troubleshooting
 
-(!docs/pages/includes/discovery/discovery-service-troubleshooting.mdx resourceKind="Kubernetes cluster" tctlResource="kube_cluster" !)
+(!docs/pages/includes/discovery/discovery-service-troubleshooting.mdx resourceKind="Kubernetes cluster" tctlResource="kube_cluster" cloud="Azure"!)
 
 (!docs/pages/includes/discovery/kubernetes-service-troubleshooting.mdx!)

--- a/docs/pages/enroll-resources/auto-discovery/kubernetes/eks-discovery/eks-discovery-manual.mdx
+++ b/docs/pages/enroll-resources/auto-discovery/kubernetes/eks-discovery/eks-discovery-manual.mdx
@@ -347,6 +347,6 @@ automatically.
 
 ## Troubleshooting
 
-(!docs/pages/includes/discovery/discovery-service-troubleshooting.mdx resourceKind="Kubernetes cluster" tctlResource="kube_cluster" !)
+(!docs/pages/includes/discovery/discovery-service-troubleshooting.mdx resourceKind="Kubernetes cluster" tctlResource="kube_cluster" cloud="AWS"!)
 
 (!docs/pages/includes/discovery/kubernetes-service-troubleshooting.mdx!)

--- a/docs/pages/enroll-resources/auto-discovery/kubernetes/eks-discovery/eks-discovery-terraform.mdx
+++ b/docs/pages/enroll-resources/auto-discovery/kubernetes/eks-discovery/eks-discovery-terraform.mdx
@@ -349,7 +349,7 @@ in the newly-configured regions.
 
 ## Troubleshooting
 
-(!docs/pages/includes/discovery/discovery-service-troubleshooting.mdx resourceKind="Kubernetes cluster" tctlResource="kube_cluster" !)
+(!docs/pages/includes/discovery/discovery-service-troubleshooting.mdx resourceKind="Kubernetes cluster" tctlResource="kube_cluster" cloud="AWS"!)
 
 (!docs/pages/includes/discovery/kubernetes-service-troubleshooting.mdx!)
 

--- a/docs/pages/enroll-resources/auto-discovery/kubernetes/gke-discovery.mdx
+++ b/docs/pages/enroll-resources/auto-discovery/kubernetes/gke-discovery.mdx
@@ -658,6 +658,6 @@ will update its state to reflect the available clusters in your account.
 
 ## Troubleshooting
 
-(!docs/pages/includes/discovery/discovery-service-troubleshooting.mdx resourceKind="Kubernetes cluster" tctlResource="kube_cluster" !)
+(!docs/pages/includes/discovery/discovery-service-troubleshooting.mdx resourceKind="Kubernetes cluster" tctlResource="kube_cluster" cloud="Google Cloud"!)
 
 (!docs/pages/includes/discovery/kubernetes-service-troubleshooting.mdx!)

--- a/docs/pages/includes/discovery/discovery-service-troubleshooting.mdx
+++ b/docs/pages/includes/discovery/discovery-service-troubleshooting.mdx
@@ -1,3 +1,5 @@
+{{ cloud="cloud provider" }}
+
 ### Discovery Service troubleshooting
 
 First, check if any {{ resourceKind }}s have been discovered.
@@ -9,19 +11,20 @@ If some {{ resourceKind }}s do not appear in the list, check if the Discovery
 Service selector labels match the missing {{ resourceKind }} tags or look into
 the Discovery Service logs for permission errors.
 
-Check that the Discovery Service is running with credentials for the correct AWS
-account. It can discover resources in another AWS account, but it must be
-configured to assume a role in the other AWS account if that's the case.
+Check that the Discovery Service is running with credentials for the correct 
+{{ cloud }} account. It can discover resources in another {{ cloud }} account,
+but it must be configured to assume the correct principal in the other 
+{{ cloud }} account if that's the case.
 
-Check if there is more than one Discovery Services running:
+Check if there is more than one Discovery Service instance running:
 
 ```code
 $ tctl inventory status --connected
 ```
 
-If you are running multiple Discovery Services, you must ensure that each
-service is configured with the same `discovery_group` value if they are watching
-the same cloud {{ resourceKind }}s or a different value if they are watching different
-cloud {{ resourceKind }}s.
-If this is not configured correctly, a typical symptom is `{{ tctlResource }}`
-resources being intermittently deleted from your Teleport cluster's registry.
+If you are running multiple Discovery Service instances, you must ensure that
+each service is configured with the same `discovery_group` value if they are
+watching the same cloud {{ resourceKind }}s or a different value if they are
+watching different cloud {{ resourceKind }}s. If this is not configured
+correctly, a typical symptom is `{{ tctlResource }}` resources being
+intermittently deleted from your Teleport cluster's registry.


### PR DESCRIPTION
Fixes #66931

We use the `discovery-service-troubleshooting.mdx` partial in docs guides for multiple cloud providers, but it has some AWS-specific language. Use a parameter so it applies to other cloud providers.
