### PR TITLE
[v18] Use `clipboardchange` when available for clipboard sync

### DIFF
--- a/web/packages/shared/components/DesktopSession/DesktopSession.tsx
+++ b/web/packages/shared/components/DesktopSession/DesktopSession.tsx
@@ -111,7 +111,7 @@ export function DesktopSession({
   const {
     directorySharingState,
     onClipboardData,
-    sendLocalClipboardToRemote,
+    onTransientUserActivation,
     clipboardSharingState,
     clearSharing,
     onShareDirectory,
@@ -272,7 +272,7 @@ export function DesktopSession({
       // Opportunistically sync local clipboard to remote while
       // transient user activation is in effect.
       // https://developer.mozilla.org/en-US/docs/Web/API/Clipboard/readText#security
-      sendLocalClipboardToRemote();
+      onTransientUserActivation();
     }
   }
 
@@ -336,7 +336,7 @@ export function DesktopSession({
     // Opportunistically sync local clipboard to remote while
     // transient user activation is in effect.
     // https://developer.mozilla.org/en-US/docs/Web/API/Clipboard/readText#security
-    sendLocalClipboardToRemote();
+    onTransientUserActivation();
   }
 
   function handleMouseUp(e: React.MouseEvent<HTMLCanvasElement>) {

--- a/web/packages/shared/components/DesktopSession/useDesktopSession.tsx
+++ b/web/packages/shared/components/DesktopSession/useDesktopSession.tsx
@@ -38,7 +38,8 @@ declare global {
   }
 }
 
-const supportsClipboardChangeEvent = 'onclipboardchange' in navigator.clipboard;
+const supportsClipboardChangeEvent =
+  navigator.clipboard && 'onclipboardchange' in navigator.clipboard;
 
 const logger = new Logger('DesktopSession');
 

--- a/web/packages/shared/components/DesktopSession/useDesktopSession.tsx
+++ b/web/packages/shared/components/DesktopSession/useDesktopSession.tsx
@@ -21,10 +21,12 @@ import {
   SetStateAction,
   useCallback,
   useEffect,
+  useEffectEvent,
   useRef,
   useState,
 } from 'react';
 
+import { Logger } from 'design/logger';
 import type { ToastNotificationItem } from 'shared/components/ToastNotification';
 import { Attempt } from 'shared/hooks/useAsync';
 import { ClipboardData, TdpClient } from 'shared/libs/tdp';
@@ -36,6 +38,10 @@ declare global {
   }
 }
 
+const supportsClipboardChangeEvent = 'onclipboardchange' in navigator.clipboard;
+
+const logger = new Logger('DesktopSession');
+
 export default function useDesktopSession(
   tdpClient: TdpClient,
   aclAttempt: Attempt<{
@@ -46,6 +52,7 @@ export default function useDesktopSession(
 ) {
   const encoder = useRef(new TextEncoder());
   const latestClipboardDigest = useRef('');
+  const triggeredClipboardPermissionsCheck = useRef(false);
   const [directorySharingState, setDirectorySharingState] = useState<{
     directorySelected: boolean;
   }>({ directorySelected: false });
@@ -80,11 +87,24 @@ export default function useDesktopSession(
       setClipboardSharingState
     );
 
+    if (supportsClipboardChangeEvent) {
+      navigator.clipboard.addEventListener(
+        'clipboardchange',
+        handleNativeClipboardChange
+      );
+    }
+
     return () => {
       clearReadListenerPromise.then(clearReadListener => clearReadListener());
       clearWriteListenerPromise.then(clearWriteListener =>
         clearWriteListener()
       );
+      if (supportsClipboardChangeEvent) {
+        navigator.clipboard.removeEventListener(
+          'clipboardchange',
+          handleNativeClipboardChange
+        );
+      }
     };
   }, []);
 
@@ -99,8 +119,34 @@ export default function useDesktopSession(
     ]);
   }, []);
 
+  const handleNativeClipboardChange = useEffectEvent(() => {
+    logger.info('Native clipboardchange event received, syncing clipboard');
+    void sendLocalClipboardToRemote();
+  });
+
+  function onTransientUserActivation() {
+    // Fallback for Chromium versions without the native clipboardchange event.
+    // In browsers with native support, still trigger one read on the first user
+    // action so the browser shows the clipboard prompt before remote-to-local
+    // clipboard writes.
+    if (!supportsClipboardChangeEvent) {
+      void sendLocalClipboardToRemote();
+      return;
+    }
+
+    if (triggeredClipboardPermissionsCheck.current) {
+      return;
+    }
+
+    triggeredClipboardPermissionsCheck.current = true;
+    void sendLocalClipboardToRemote();
+  }
+
   async function sendLocalClipboardToRemote() {
     if (!(await sysClipboardGuard(clipboardSharing, 'read'))) {
+      logger.warn(
+        'Skipping clipboard sync: local clipboard read is not allowed'
+      );
       return;
     }
     const text = await navigator.clipboard.readText();
@@ -114,16 +160,20 @@ export default function useDesktopSession(
   }
 
   async function onClipboardData(clipboardData: ClipboardData) {
-    if (
-      clipboardData.data &&
-      (await sysClipboardGuard(clipboardSharing, 'write'))
-    ) {
-      await navigator.clipboard.writeText(clipboardData.data);
-      latestClipboardDigest.current = await sha256Digest(
-        clipboardData.data,
-        encoder.current
-      );
+    if (!clipboardData.data) {
+      return;
     }
+    if (!(await sysClipboardGuard(clipboardSharing, 'write'))) {
+      logger.warn(
+        'Skipping clipboard sync: local clipboard write is not allowed'
+      );
+      return;
+    }
+    await navigator.clipboard.writeText(clipboardData.data);
+    latestClipboardDigest.current = await sha256Digest(
+      clipboardData.data,
+      encoder.current
+    );
   }
 
   const onShareDirectory = useCallback(async () => {
@@ -164,7 +214,7 @@ export default function useDesktopSession(
     alerts,
     onRemoveAlert,
     addAlert,
-    sendLocalClipboardToRemote,
+    onTransientUserActivation,
     onClipboardData,
   };
 }


### PR DESCRIPTION
Backport #66747 to branch/v18

changelog: Improved the reliability of clipboard sharing for remote desktop sessions in both Teleport Connect and browsers running Chrome 144+.

## Manual Test Plan

### Test Environment

Local cluster connecting to non-AD host running WS2019.

### Test Cases

Web UI
- [x] Copy from local machine and paste to remote works
- [x] Copy from remote machine and paste local works

Connect
- [x] Copy from local machine and paste to remote works
- [x] Copy from remote machine and paste local works
