### PR TITLE
[v18] kube: forward watch BOOKMARK events unfiltered

### DIFF
--- a/lib/kube/proxy/resource_rbac_test.go
+++ b/lib/kube/proxy/resource_rbac_test.go
@@ -837,6 +837,112 @@ func TestWatcherResponseWriter(t *testing.T) {
 	}
 }
 
+// TestWatcherResponseWriter_BookmarkPassthrough reproduces the bug from
+// https://github.com/gravitational/teleport/issues/64188:
+// kubectl/client-go v0.35+ sends watch requests with sendInitialEvents=true and
+// expects a terminating BOOKMARK event annotated k8s.io/initial-events-end="true"
+// to mark the cache as synced. Teleport's kube agent runs every decoded event
+// (including BOOKMARK) through the resource filter; the BOOKMARK envelope is a
+// stripped Pod with empty Name and Namespace, so any restrictive name/namespace
+// rule rejects it and the bookmark is silently dropped. The client then waits
+// indefinitely for a bookmark that never arrives.
+func TestWatcherResponseWriter_BookmarkPassthrough(t *testing.T) {
+	t.Parallel()
+	const (
+		ns      = "default"
+		podName = "myPod"
+	)
+
+	// A restrictive allow rule: only "myPod" in "default". This is the shape
+	// that exposes the bug — the bookmark's empty name fails the name match.
+	allowed := []types.KubernetesResource{{
+		Kind:      "pods",
+		Namespace: ns,
+		Name:      podName,
+		Verbs:     []string{types.Wildcard},
+		APIGroup:  "",
+	}}
+
+	// The bookmark sent by kube-apiserver when sendInitialEvents=true completes:
+	// a near-empty Pod envelope with only resourceVersion + the
+	// k8s.io/initial-events-end annotation.
+	bookmarkPod := &corev1.Pod{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Pod",
+			APIVersion: "v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			ResourceVersion: "12345",
+			Annotations: map[string]string{
+				"k8s.io/initial-events-end": "true",
+			},
+		},
+	}
+
+	upstreamEvents := []*watch.Event{
+		{Type: watch.Added, Object: newFakePod(podName, ns)},
+		{Type: watch.Bookmark, Object: bookmarkPod},
+	}
+
+	userReader, userWriter := io.Pipe()
+	negotiator := newClientNegotiator(&globalKubeCodecs)
+	mr := metaResource{
+		requestedResource: apiResource{
+			resourceKind: "pods",
+			apiGroup:     "",
+			namespace:    ns,
+		},
+		resourceDefinition: &metav1.APIResource{Namespaced: true},
+		verb:               types.KubeVerbWatch,
+	}
+	filterWrapper := newResourceFilterer(
+		mr, &globalKubeCodecs,
+		newMatcher(mr, allowed, nil, logtest.NewLogger()),
+		logtest.NewLogger(),
+	)
+	watcher, err := responsewriters.NewWatcherResponseWriter(
+		newFakeResponseWriter(userWriter), negotiator, filterWrapper,
+	)
+	require.NoError(t, err)
+
+	watchEncoder, decoder := newWatchSerializers(
+		t, responsewriters.DefaultContentType, negotiator, watcher, userReader,
+	)
+	watcher.Header().Set(responsewriters.ContentTypeHeader, responsewriters.DefaultContentType)
+	watcher.WriteHeader(http.StatusOK)
+
+	var collected []*metav1.WatchEvent
+	var wg sync.WaitGroup
+	wg.Go(func() {
+		for {
+			event, err := decoder.decodeStreamingMessage()
+			if err != nil {
+				return
+			}
+			collected = append(collected, event)
+		}
+	})
+
+	for _, evt := range upstreamEvents {
+		require.NoError(t, watchEncoder.Encode(evt))
+	}
+
+	require.NoError(t, watcher.Close())
+	userReader.CloseWithError(io.EOF)
+	userWriter.CloseWithError(io.EOF)
+	wg.Wait()
+
+	gotTypes := make([]watch.EventType, 0, len(collected))
+	for _, e := range collected {
+		gotTypes = append(gotTypes, watch.EventType(e.Type))
+	}
+	require.Equal(t,
+		[]watch.EventType{watch.Added, watch.Bookmark},
+		gotTypes,
+		"BOOKMARK event was dropped by the kube agent filter — client-go WatchList informers will hang",
+	)
+}
+
 func newRawExtension(name, namespace string) runtime.RawExtension {
 	return runtime.RawExtension{
 		Object: newFakePod(name, namespace),

--- a/lib/kube/proxy/responsewriters/watcher.go
+++ b/lib/kube/proxy/responsewriters/watcher.go
@@ -313,7 +313,13 @@ func (w *WatcherResponseWriter) watchDecoder(contentType string, writer io.Write
 			)
 			return trace.Wrap(err)
 		default:
-			if filter != nil {
+			// Bookmarks are protocol signals (KEP-956, KEP-3157), not resources.
+			// The envelope carries only resourceVersion and an optional
+			// k8s.io/initial-events-end annotation, with empty name and namespace.
+			// Resource RBAC would silently drop them for any non-wildcard rule,
+			// which causes client-go v0.35+ WatchList informers to hang forever
+			// waiting for the terminating bookmark.
+			if filter != nil && eventType != watch.Bookmark {
 				// check if the event object matches the filtering criteria.
 				// If it does not match, ignore the event.
 				publish, _, err := filter.FilterObj(obj)


### PR DESCRIPTION
Backport of #66939.

Clean cherry-pick of the 3 PR commits, squashed into one.