### PR TITLE
docs: spelling fix for managed updates

### DIFF
--- a/docs/pages/upgrading/agent-managed-updates/bootstrap-ec2-agent.mdx
+++ b/docs/pages/upgrading/agent-managed-updates/bootstrap-ec2-agent.mdx
@@ -10,7 +10,7 @@ and assigning them to an update group using `teleport-update` by defining the gr
 
 ## How it works
 
-It assumes you'll join the agent to your cluster during first boot wit delegated join method
+It assumes you'll join the agent to your cluster during first boot with delegated join method
 and that your cluster has Managed Updates v2 enabled.
 
 Delegated joins avoid shipping any secret token in user data. You create a named token resource that


### PR DESCRIPTION
This PR fixes a spelling error in the `/upgrading/agent-managed-updates/bootstrap-ec2-agent` page.