### PR TITLE
Troubleshoot synctest race condition/flake in `lib/srv/discovery`

### DIFF
--- a/lib/srv/discovery/discovery_test.go
+++ b/lib/srv/discovery/discovery_test.go
@@ -259,6 +259,7 @@ func (m *mockSSMInstaller) GetInstalledInstances() []string {
 }
 
 func TestDiscoveryServer(t *testing.T) {
+	t.Log("Trigger")
 	t.Parallel()
 
 	defaultDiscoveryGroup := "dc001"
@@ -2348,6 +2349,7 @@ type UserTaskLister interface {
 }
 
 func TestDiscoveryDatabase(t *testing.T) {
+	t.Log("Trigger")
 	const (
 		mainDiscoveryGroup  = "main"
 		integrationName     = "my-integration"
@@ -3233,6 +3235,7 @@ func (m *mockAzureClient) ListVirtualMachines(_ context.Context, _ string) ([]*a
 }
 
 func TestAzureVMDiscovery(t *testing.T) {
+	t.Log("Trigger")
 	t.Parallel()
 
 	const defaultDiscoveryGroup = "dc001"

--- a/lib/srv/discovery/kube_integration_watcher_test.go
+++ b/lib/srv/discovery/kube_integration_watcher_test.go
@@ -138,6 +138,7 @@ func TestServer_getKubeFetchers(t *testing.T) {
 }
 
 func TestDiscoveryKubeIntegrationEKS(t *testing.T) {
+	t.Log("Trigger")
 	const (
 		mainDiscoveryGroup = "main"
 		awsAccountID       = "880713328506"


### PR DESCRIPTION
Possibly introduced by https://github.com/gravitational/teleport/pull/65853/