### PR TITLE
Fix tctl mistake in Helm Access Graph guide

### DIFF
--- a/docs/pages/identity-security/access-graph/self-hosted-helm.mdx
+++ b/docs/pages/identity-security/access-graph/self-hosted-helm.mdx
@@ -254,7 +254,7 @@ spec:
 Apply your changes:
 
 ```code
-$ tctl apply -f access-graph-reader.yaml
+$ tctl create -f access-graph-reader.yaml
 ```
 
 ## Next steps


### PR DESCRIPTION
Replace `tctl apply` with `tctl create`.