### PR TITLE
Filter desktop logins to granted-only in clusterUnifiedResourcesGet

### DIFF
--- a/lib/teleterm/services/unifiedresources/unifiedresources.go
+++ b/lib/teleterm/services/unifiedresources/unifiedresources.go
@@ -178,11 +178,19 @@ func List(ctx context.Context, cluster *clusters.Cluster, authClient AuthClient,
 			}
 			response.Resources = append(response.Resources, ur)
 		case types.WindowsDesktop:
+			logins := enrichedResource.Logins
+			if req.IncludeRequestable || req.UseSearchAsRoles {
+				var err error
+				logins, err = accessChecker.GetAllowedLoginsForResource(r)
+				if err != nil {
+					return nil, trace.Wrap(err)
+				}
+			}
 			response.Resources = append(response.Resources, UnifiedResource{
 				WindowsDesktop: &clusters.WindowsDesktop{
 					URI:            cluster.URI.AppendWindowsDesktop(r.GetName()),
 					WindowsDesktop: r,
-					Logins:         enrichedResource.Logins,
+					Logins:         logins,
 				},
 				RequiresRequest: requiresRequest,
 			})

--- a/lib/teleterm/services/unifiedresources/unifiedresources_test.go
+++ b/lib/teleterm/services/unifiedresources/unifiedresources_test.go
@@ -262,6 +262,51 @@ func TestUnifiedResourcesListWildcardDatabaseUsers(t *testing.T) {
 	require.True(t, db.WildcardUserAllowed)
 }
 
+// TestUnifiedResourcesGet_DesktopLoginFiltering verifies that the logins
+// returned for Windows/Linux Desktop resources in the unified resources endpoint
+// only include logins from the user's currently-granted roles, not logins
+// from roles reachable via search_as_roles when includedResourceMode=all.
+func TestUnifiedResourcesList_DesktopLoginFiltering(t *testing.T) {
+	ctx := t.Context()
+	cluster := &clusters.Cluster{URI: uri.NewClusterURI("foo"), ProfileName: "foo"}
+
+	desktop, err := types.NewWindowsDesktopV3("test-desktop", nil,
+		types.WindowsDesktopSpecV3{Addr: "1.2.3.4:3389", HostID: "host-1"})
+	require.NoError(t, err)
+
+	// The assigned role grants "granted-login" for desktops.
+	assignedRole, err := types.NewRole("assigned-role", types.RoleSpecV6{
+		Allow: types.RoleConditions{
+			WindowsDesktopLabels: types.Labels{types.Wildcard: {types.Wildcard}},
+			WindowsDesktopLogins: []string{"granted-login"},
+		},
+	})
+	require.NoError(t, err)
+
+	// Simulate what the auth layer returns when IncludeRequestable is set:
+	// enriched logins contain the union of granted + requestable logins.
+	mockedResources := []*proto.PaginatedResource{
+		{
+			Resource: &proto.PaginatedResource_WindowsDesktop{WindowsDesktop: desktop},
+			Logins:   []string{"granted-login", "requestable-login"},
+		},
+	}
+
+	response, err := List(ctx, cluster, &mockClient{
+		paginatedResources: mockedResources,
+		// Only the assigned role. the requestable role is not held by the user.
+		roles: []types.Role{assignedRole},
+	}, &proto.ListUnifiedResourcesRequest{
+		IncludeRequestable: true,
+	})
+	require.NoError(t, err)
+	require.Len(t, response.Resources, 1)
+
+	require.ElementsMatch(t, []string{"granted-login"},
+		response.Resources[0].WindowsDesktop.Logins,
+		"desktop logins should only contain granted logins, not requestable ones")
+}
+
 type mockClient struct {
 	paginatedResources []*proto.PaginatedResource
 	nextKey            string

--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -3589,9 +3589,25 @@ func (h *Handler) clusterUnifiedResourcesGet(w http.ResponseWriter, request *htt
 			})
 			unifiedResources = append(unifiedResources, app)
 		case types.WindowsDesktop:
-			unifiedResources = append(unifiedResources, ui.MakeWindowsDesktop(r, enriched.Logins, enriched.RequiresRequest))
+			logins := enriched.Logins
+			if req.IncludeRequestable || req.UseSearchAsRoles {
+				var err error
+				logins, err = accessChecker.GetAllowedLoginsForResource(r)
+				if err != nil {
+					return nil, trace.Wrap(err)
+				}
+			}
+			unifiedResources = append(unifiedResources, ui.MakeWindowsDesktop(r, logins, enriched.RequiresRequest))
 		case types.Resource153UnwrapperT[*linuxdesktopv1.LinuxDesktop]:
-			unifiedResources = append(unifiedResources, ui.MakeLinuxDesktop(r.UnwrapT(), enriched.Logins, enriched.RequiresRequest))
+			logins := enriched.Logins
+			if req.IncludeRequestable || req.UseSearchAsRoles {
+				var err error
+				logins, err = accessChecker.GetAllowedLoginsForResource(enriched)
+				if err != nil {
+					return nil, trace.Wrap(err)
+				}
+			}
+			unifiedResources = append(unifiedResources, ui.MakeLinuxDesktop(r.UnwrapT(), logins, enriched.RequiresRequest))
 		case types.KubeCluster:
 			kube := ui.MakeKubeCluster(r, accessChecker, enriched.RequiresRequest)
 			unifiedResources = append(unifiedResources, kube)

--- a/lib/web/apiserver_test.go
+++ b/lib/web/apiserver_test.go
@@ -1737,6 +1737,83 @@ func TestUnifiedResourcesGet(t *testing.T) {
 	})
 }
 
+// TestUnifiedResourcesGet_DesktopLoginFiltering verifies that the logins
+// returned for Windows/Linux Desktop resources in the unified resources endpoint
+// only include logins from the user's currently-granted roles, not logins
+// from roles reachable via search_as_roles when includedResourceMode=all.
+func TestUnifiedResourcesGet_DesktopLoginFiltering(t *testing.T) {
+	t.Parallel()
+	env := newWebPack(t, 1)
+	proxy := env.proxies[0]
+
+	const username = "desktop-login-test@example.com"
+
+	// requestableRole has desktop logins the user can only get via access request.
+	requestableRole, err := types.NewRole("emg-access", types.RoleSpecV6{
+		Allow: types.RoleConditions{
+			WindowsDesktopLabels: types.Labels{types.Wildcard: {types.Wildcard}},
+			WindowsDesktopLogins: []string{"requestable-login"},
+		},
+	})
+	require.NoError(t, err)
+
+	// assignedRole is the user's default role with search_as_roles pointing
+	// at requestableRole so the user can discover resources for access requests.
+	assignedRole, err := types.NewRole("assigned-role", types.RoleSpecV6{
+		Allow: types.RoleConditions{
+			// Give wildcard node/desktop access so the resource is visible.
+			NodeLabels:           types.Labels{types.Wildcard: {types.Wildcard}},
+			WindowsDesktopLabels: types.Labels{types.Wildcard: {types.Wildcard}},
+			WindowsDesktopLogins: []string{"granted-login"},
+			Logins:               []string{"granted-login"},
+			Request: &types.AccessRequestConditions{
+				Roles:         []string{requestableRole.GetName()},
+				SearchAsRoles: []string{requestableRole.GetName()},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	_, err = env.server.Auth().UpsertRole(context.Background(), requestableRole)
+	require.NoError(t, err)
+
+	pack := proxy.authPack(t, username, []types.Role{assignedRole})
+
+	// Create a Windows Desktop resource.
+	desktop, err := types.NewWindowsDesktopV3("test-desktop", nil, types.WindowsDesktopSpecV3{
+		Addr:   "1.2.3.4:3389",
+		HostID: "host-1",
+	})
+	require.NoError(t, err)
+	require.NoError(t, env.server.Auth().UpsertWindowsDesktop(context.Background(), desktop))
+
+	clusterName := env.server.ClusterName()
+	endpoint := pack.clt.Endpoint("webapi", "sites", clusterName, "resources")
+
+	type desktopResponse struct {
+		Items []webui.Desktop `json:"items"`
+	}
+
+	// Fetch with includedResourceMode=all, which enables IncludeRequestable on
+	// the backend and causes the auth layer to use search_as_roles when
+	// computing logins.
+	query := url.Values{
+		"kinds":                []string{types.KindWindowsDesktop},
+		"includedResourceMode": []string{"all"},
+	}
+	re, err := pack.clt.Get(context.Background(), endpoint, query)
+	require.NoError(t, err)
+
+	var resp desktopResponse
+	require.NoError(t, json.Unmarshal(re.Bytes(), &resp))
+	require.Len(t, resp.Items, 1, "expected exactly one desktop")
+
+	// The logins present should only be ones the user currently can access,
+	// not ones from requestable roles.
+	require.ElementsMatch(t, []string{"granted-login"}, resp.Items[0].Logins,
+		"desktop logins should only contain granted logins, not requestable ones")
+}
+
 type clusterAlertsGetResponse struct {
 	Alerts []types.ClusterAlert `json:"alerts"`
 }


### PR DESCRIPTION
## Context
When the unified resources endpoint is called with `includedResourceMode=all` or `searchAsRoles=yes`, Auth extends the user's roleset with `search_as_roles` and computes logins using this extended set. This means `enriched.Logins` contains the union of granted and requestable logins for every resource type.

SSH node and app handlers already account for this by recomputing the granted subset separately using the base access checker without `search_as_roles`. Desktop handlers (Windows, Linux) in both the web UI and Connect did not, passing the unfiltered union directly to the response. This caused logins from roles reachable only via `search_as_roles` to appear in the desktop Connect dropdown, even though the user hasn't requested those roles and cannot use them.

This has been present since `IncludeRequestable` was combined with desktop login enrichment in the unified resources endpoint ~mid 2024. Auth intentionally returns the union, and SSH and app handlers use it to populate `PrincipalSet.All` when Resource Constraints are supported and we want to provide all possible requestable logins in addition to currently-granted. 

Resolves #67018 

Changelog: Fixed Windows and Linux desktop Connect dropdowns showing logins from roles the user can request but hasn't been granted.

## Manual Test Plan
### Test Environment
- Teleport cluster built from this branch
- Two roles: an assigned role with `search_as_roles` pointing at a requestable role, each with distinct `windows_desktop_logins`
- A Windows Desktop resource registered in the cluster
- A user assigned only the first role

### Test Cases
- [x] Web UI: Log in as test user, navigate to Resources, toggle the resource availability filter to include requestable resources, click "Connect" on the Windows Desktop. Validate logins are only ones currently granted by the first role.
- [x] Web UI: With the same setup, add `logins` and `node_labels` to both roles, register an SSH node, and validate SSH logins remain unaffected.
- [x] Web UI: Create and approve an Access Request for the second role as test user. Validate that when assumed, clicking "Connect" on the Windows Desktop shows only logins granted by the second role.
- [x] Teleport Connect: Validate above steps within Connect.
