### PR TITLE
Fix device trust for remote users connecting to a trusted cluster

### DIFF
--- a/lib/authz/permissions.go
+++ b/lib/authz/permissions.go
@@ -813,6 +813,7 @@ func (a *authorizer) authorizeRemoteUser(ctx context.Context, u RemoteUser) (*Co
 		PrivateKeyPolicy:  u.Identity.PrivateKeyPolicy,
 		UserType:          u.Identity.UserType,
 		OriginClusterName: u.Identity.TeleportCluster,
+		DeviceExtensions:  u.Identity.DeviceExtensions,
 	}
 	if checker.PinSourceIP() && identity.PinnedIP == "" {
 		return nil, trace.Wrap(ErrIPPinningMissing)

--- a/lib/authz/permissions_test.go
+++ b/lib/authz/permissions_test.go
@@ -45,6 +45,7 @@ import (
 	"github.com/gravitational/teleport/lib/auth/authtest"
 	"github.com/gravitational/teleport/lib/authz"
 	"github.com/gravitational/teleport/lib/backend/memory"
+	"github.com/gravitational/teleport/lib/fixtures"
 	"github.com/gravitational/teleport/lib/modules"
 	"github.com/gravitational/teleport/lib/modules/modulestest"
 	"github.com/gravitational/teleport/lib/services"
@@ -544,6 +545,74 @@ func TestAuthorizer_Authorize_deviceTrust(t *testing.T) {
 				"auth.Context.disableDeviceAuthorization not inherited from Authorizer")
 		})
 	}
+}
+
+// TestAuthorizer_Authorize_remoteUserDeviceTrust verifies that device trust
+// extensions are propagated through the authorizeRemoteUser path. A remote user
+// whose original identity carries DeviceExtensions should have DeviceVerified=true
+// in the resulting auth context.
+func TestAuthorizer_Authorize_remoteUserDeviceTrust(t *testing.T) {
+	t.Parallel()
+	client, watcher, _ := newTestResources(t)
+	_, localRole, err := authtest.CreateUserAndRole(client, "local-llama", []string{"local-llama"}, nil)
+	require.NoError(t, err, "CreateUserAndRole")
+
+	remoteClusterName := "remote-cluster"
+	ca, err := types.NewCertAuthority(types.CertAuthoritySpecV2{
+		Type:        types.UserCA,
+		ClusterName: remoteClusterName,
+		ActiveKeys: types.CAKeySet{
+			SSH: []*types.SSHKeyPair{{
+				PrivateKey: []byte(fixtures.SSHCAPrivateKey),
+				PublicKey:  []byte(fixtures.SSHCAPublicKey),
+			}},
+			TLS: []*types.TLSKeyPair{{
+				Cert: []byte(fixtures.TLSCACertPEM),
+				Key:  []byte(fixtures.TLSCAKeyPEM),
+			}},
+		},
+		RoleMap: types.RoleMap{{
+			Remote: localRole.GetName(),
+			Local:  []string{localRole.GetName()},
+		}},
+	})
+	require.NoError(t, err, "NewCertAuthority failed")
+	require.NoError(t, client.UpsertCertAuthority(t.Context(), ca), "UpsertCertAuthority failed")
+
+	deviceExt := tlsca.DeviceExtensions{
+		DeviceID:     "deviceid1",
+		AssetTag:     "assettag1",
+		CredentialID: "credentialid1",
+	}
+
+	remoteUser := authz.RemoteUser{
+		Username:    "llama",
+		ClusterName: remoteClusterName,
+		RemoteRoles: []string{localRole.GetName()},
+		Principals:  []string{"llama"},
+		Identity: tlsca.Identity{
+			Username:         "llama",
+			Groups:           []string{localRole.GetName()},
+			DeviceExtensions: deviceExt,
+		},
+	}
+
+	authorizer, err := authz.NewAuthorizer(authz.AuthorizerOpts{
+		ClusterName: clusterName,
+		AccessPoint: client,
+		LockWatcher: watcher,
+	})
+	require.NoError(t, err, "NewAuthorizer failed")
+
+	userCtx := authz.ContextWithUser(t.Context(), remoteUser)
+	authCtx, err := authorizer.Authorize(userCtx)
+	require.NoError(t, err, "Authorize failed")
+
+	authPref, err := client.GetAuthPreference(t.Context())
+	require.NoError(t, err, "GetAuthPreference failed")
+	state := authCtx.GetAccessState(authPref)
+	assert.True(t, state.DeviceVerified,
+		"DeviceVerified should be true for remote user whose identity has device extensions")
 }
 
 // hostFQDN consists of host UUID and cluster name joined via .
@@ -1532,6 +1601,7 @@ func newTestResources(t *testing.T) (*testClient, *services.LockWatcher, authz.A
 		LockGetter: lockSvc,
 	})
 	require.NoError(t, err)
+	t.Cleanup(lockWatcher.Close)
 
 	authorizer, err := authz.NewAuthorizer(authz.AuthorizerOpts{
 		ClusterName: clusterName,


### PR DESCRIPTION
## Context
`authorizeRemoteUser()` constructs a remapped `tlsca.Identity` for federated users connecting to a leaf cluster. This remapped identity intentionally copies routing and attestation fields from the unmapped identity (e.g., MFAVerified, PinnedIP, PrivateKeyPolicy), but DeviceExtensions was not included. `GetAccessState()` reads DeviceExtensions from `Context.Identity` to set `state.DeviceVerified`. Without it propagated through, DeviceVerified is always false for remote users, causing any role with `device_trust_mode=required/optional` to deny access, even when the user's original cert carries valid device attestation.

> [!note]
> This only seems to affect TLS connections; SSH connections to leaf cluster resources requiring device trust succeed as expected.

Changelog: Fix device trust for remote users connecting to a trusted cluster.

## Manual Test Plan
### Test Environment
- Root cluster A with a trusted leaf cluster B
- A role on cluster B with device_trust_mode: required
- A user in cluster A with a device-trust-enrolled device
- An app, kube, or DB resource on cluster B protected by this role

### Test Cases
- [x] User logs into root cluster A with `tsh login` from an enrolled device (cert should contain DeviceExtensions)
- [x] When leaf cluster is built from this branch, user accessing resource on leaf cluster B protected by `device_trust_mode: required` results in access being granted
- [x] When leaf cluster is built from `master`, user accessing resource on leaf cluster B protected by `device_trust_mode: required` results in access denied
- [x] In both version cases, user accessing the same resource from a non-enrolled device (or with DeviceExtensions stripped) results in access being denied with a trusted device error
