### PR TITLE
Fix mistakes in Jira Access Request plugin guide

### DIFF
--- a/docs/pages/identity-governance/access-requests/plugins/jira.mdx
+++ b/docs/pages/identity-governance/access-requests/plugins/jira.mdx
@@ -100,9 +100,8 @@ your Teleport cluster.
 
 ## Step 2/7. Define a Teleport Jira plugin user
 
-The required permissions for the plugin are configured in the preset
-`access-plugin-update` role. To generate credentials for the plugin, define
-either a Machine ID bot user or a regular Teleport user.
+To generate credentials for the plugin, define either a Machine ID bot user or a
+regular Teleport user.
 
 <Tabs>
 <TabItem label="Machine & Workload Identity">
@@ -126,7 +125,7 @@ spec:
       - resources: ['access_request']
         verbs: ['list', 'read', 'update']
       - resources: ['access_plugin_data']
-        verbs: ['update']
+        verbs: ['list', 'read', 'update']
 ```
 
 Create the role:


### PR DESCRIPTION
In #65190, we inadvertently introduced two small issues, which this change fixes:

- Remove a reference to a nonexistent role. This was a mistake due to a find/replace operation.
- Add full permissions to the access-plugin-update role. The Jira Access Request plugin needs to list and read `access_plugin_data`, not just create it.