### PR TITLE
fix: avoid dns lookups in TestDiscoveryDatabase

### DIFF
--- a/lib/srv/discovery/discovery.go
+++ b/lib/srv/discovery/discovery.go
@@ -54,6 +54,7 @@ import (
 	"github.com/gravitational/teleport/api/types/usertasks"
 	"github.com/gravitational/teleport/api/utils/retryutils"
 	"github.com/gravitational/teleport/lib/auth/authclient"
+	"github.com/gravitational/teleport/lib/automaticupgrades/version"
 	awsregions "github.com/gravitational/teleport/lib/cloud/aws/regions"
 	"github.com/gravitational/teleport/lib/cloud/awsconfig"
 	"github.com/gravitational/teleport/lib/cloud/azure"
@@ -179,6 +180,11 @@ type Config struct {
 	// ClusterFeatures returns flags for supported/unsupported features.
 	// Used as a function because cluster features might change on Auth restarts.
 	ClusterFeatures func() proto.Features
+
+	// kubeAgentVersionGetter overrides the proxy-backed kube agent version getter.
+	// It is used by tests that run discovery watchers under synctest, where real
+	// HTTP/DNS calls are not allowed.
+	kubeAgentVersionGetter version.Getter
 
 	// TriggerFetchC is a list of channels that must be notified when a off-band poll must be performed.
 	// This is used to start a polling iteration when a new DiscoveryConfig change is received.

--- a/lib/srv/discovery/discovery_test.go
+++ b/lib/srv/discovery/discovery_test.go
@@ -2829,6 +2829,7 @@ func TestDiscoveryDatabase(t *testing.T) {
 							return azureClients, nil
 						},
 						ClusterFeatures:           func() proto.Features { return proto.Features{} },
+						kubeAgentVersionGetter:    staticKubeAgentVersionGetter(t),
 						KubernetesClient:          fake.NewClientset(),
 						AccessPoint:               getDiscoveryAccessPointWithEKSEnroller(tlsServer.Auth(), authClient, noopEKSEnroller),
 						AWSDatabaseFetcherFactory: dbFetcherFactory,

--- a/lib/srv/discovery/kube_integration_watcher.go
+++ b/lib/srv/discovery/kube_integration_watcher.go
@@ -67,8 +67,8 @@ func (s *Server) startKubeIntegrationWatchers() error {
 	}
 	proxyPublicAddr := pingResponse.GetProxyPublicAddr()
 
-	var versionGetter version.Getter
-	if proxyPublicAddr == "" {
+	versionGetter := s.kubeAgentVersionGetter
+	if versionGetter == nil && proxyPublicAddr == "" {
 		// If there are no proxy services running, we might fail to get the proxy URL and build a client.
 		// In this case we "gracefully" fallback to our own version.
 		// This is not supposed to happen outside of tests as the discovery service must join via a proxy.
@@ -79,7 +79,7 @@ func (s *Server) startKubeIntegrationWatchers() error {
 		if err != nil {
 			return trace.BadParameter("Cannot parse Teleport's self version %q, this is a bug", teleport.Version)
 		}
-	} else {
+	} else if versionGetter == nil {
 		versionGetter, err = versionGetterForProxy(s.ctx, proxyPublicAddr)
 		if err != nil {
 			s.Log.WarnContext(s.ctx,

--- a/lib/srv/discovery/kube_integration_watcher_test.go
+++ b/lib/srv/discovery/kube_integration_watcher_test.go
@@ -46,6 +46,7 @@ import (
 	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/auth/authtest"
 	"github.com/gravitational/teleport/lib/authz"
+	"github.com/gravitational/teleport/lib/automaticupgrades/version"
 	"github.com/gravitational/teleport/lib/cloud/mocks"
 	"github.com/gravitational/teleport/lib/integrations/awsoidc"
 	"github.com/gravitational/teleport/lib/srv/discovery/common"
@@ -135,6 +136,12 @@ func TestServer_getKubeFetchers(t *testing.T) {
 		require.ElementsMatch(t, tc.expectedIntegrationFetchers, s.getKubeFetchers(true))
 		require.ElementsMatch(t, tc.expectedNonIntegrationFetchers, s.getKubeFetchers(false))
 	}
+}
+
+func staticKubeAgentVersionGetter(t *testing.T) version.Getter {
+	getter, err := version.NewStaticGetter("1.2.3", nil)
+	require.NoError(t, err)
+	return getter
 }
 
 func TestDiscoveryKubeIntegrationEKS(t *testing.T) {
@@ -422,9 +429,10 @@ func TestDiscoveryKubeIntegrationEKS(t *testing.T) {
 							AWSConfigProvider: fakeConfigProvider,
 							eksClusters:       eksMockClusters[:2],
 						},
-						ClusterFeatures:  func() proto.Features { return proto.Features{} },
-						KubernetesClient: fake.NewClientset(),
-						AccessPoint:      tc.accessPoint(t, tlsServer.Auth(), authClient),
+						ClusterFeatures:        func() proto.Features { return proto.Features{} },
+						kubeAgentVersionGetter: staticKubeAgentVersionGetter(t),
+						KubernetesClient:       fake.NewClientset(),
+						AccessPoint:            tc.accessPoint(t, tlsServer.Auth(), authClient),
 						Matchers: Matchers{
 							AWS: tc.awsMatchers,
 						},


### PR DESCRIPTION
I can't seem to get TestDiscoveryDatabase past the flaky test detector. The issue is a DNS lookup using a goroutine outside the synctest bubble writing to a channel created inside the bubble. It appears to be due to some global singleflight group:

```
fatal error: send on synctest channel from outside bubble

goroutine 8180 [running, synctest bubble 49]:
net.(*resolverConfig).tryAcquireSema(...)
	/opt/go/src/net/dnsclient_unix.go:430
net.(*resolverConfig).tryUpdate(0x1dad4f40, {0x16270f4a, 0x10})
	/opt/go/src/net/dnsclient_unix.go:396 +0x105
net.getSystemDNSConfig()
	/opt/go/src/net/dnsclient_unix.go:369 +0x30
net.(*conf).lookupOrder(0x1d8059c0, 0x1dad1a80, {0xc0069711d0, 0x14})
	/opt/go/src/net/conf.go:285 +0x21a
net.(*conf).hostLookupOrder(0x1d8059c0, 0x1dad1a80, {0xc0069711d0, 0x14})
	/opt/go/src/net/conf.go:238 +0x11e
net.(*Resolver).lookupIP(0x1dad1a80, {0x174b6028, 0xc003368b40}, {0x16232f04, 0x3}, {0xc0069711d0, 0x14})
	/opt/go/src/net/lookup_unix.go:62 +0xa9
net.init.func1({0x174b6028, 0xc003368b40}, 0xc0025775b0, {0x16232f04, 0x3}, {0xc0069711d0, 0x14})
	/opt/go/src/net/hook.go:21 +0x83
net.(*Resolver).lookupIPAddr.func1()
	/opt/go/src/net/lookup.go:335 +0xa5
internal/singleflight.(*Group).doCall(0x1dad1a90, 0xc003368b90, {0xc0069711e8, 0x18}, 0xc001ae3600)
	/opt/go/src/internal/singleflight/singleflight.go:93 +0x5c
created by internal/singleflight.(*Group).DoChan in goroutine 8179
	/opt/go/src/internal/singleflight/singleflight.go:86 +0x55d
```

This change avoids the DNS lookup in the test.

Fixes https://github.com/gravitational/teleport/issues/67026