### PR TITLE
docs: Update sql server self-hosted

### DIFF
--- a/docs/pages/enroll-resources/database-access/enrollment/self-hosted/sql-server-ad-pkinit.mdx
+++ b/docs/pages/enroll-resources/database-access/enrollment/self-hosted/sql-server-ad-pkinit.mdx
@@ -248,6 +248,8 @@ database section below as appropriate:
   Teleport needs access to `objectSid`, `sAMAccountName` and `sAMAccountType` attributes.
 </Admonition>
 
+Configure a Teleport configuration file at `/etc/teleport.yaml`:
+
 ```yaml
 version: v3
 teleport:

--- a/docs/pages/enroll-resources/database-access/enrollment/self-hosted/sql-server-ad-pkinit.mdx
+++ b/docs/pages/enroll-resources/database-access/enrollment/self-hosted/sql-server-ad-pkinit.mdx
@@ -251,7 +251,7 @@ database section below as appropriate:
 ```yaml
 version: v3
 teleport:
-  auth_token: abcd123-insecure-do-not-use-this
+  auth_token: /tmp/token
   proxy_server: teleport.example.com:443
 
 auth_service:
@@ -275,7 +275,7 @@ db_service:
           -----BEGIN CERTIFICATE-----
           ...
           -----END CERTIFICATE-----
-        ldap_service_account_name: "DEV\svc-teleport"
+        ldap_service_account_name: 'DEV\svc-teleport'
         ldap_service_account_sid: "S-1-5-21-1111111111-2222222222-3333333333-4444"
 ```
 


### PR DESCRIPTION
Updates:
- Uses file based token which matches to earlier instructions to store in `/tmp/token`
- Uses `'` instead of `"` for username. Otherwise the username will not go through correctly without an extra `\`.
- Instruct to store configuration file
