### PR TITLE
Fix flaky `vnetContext.test.tsx`

### DIFF
--- a/web/packages/teleterm/src/ui/Vnet/vnetContext.test.tsx
+++ b/web/packages/teleterm/src/ui/Vnet/vnetContext.test.tsx
@@ -341,38 +341,43 @@ describe('diag notification', () => {
       mockAppContext: appContext => {
         jest
           .spyOn(appContext.vnet, 'runDiagnostics')
-          .mockResolvedValueOnce(
-            new MockedUnaryCall({ report: issuesFoundReport })
-          )
-          .mockResolvedValueOnce(
-            new MockedUnaryCall({ report: noIssuesFoundReport })
-          )
-          .mockResolvedValueOnce(
-            new MockedUnaryCall({ report: issuesFoundReport })
-          )
-          .mockResolvedValue(
-            new MockedUnaryCall({}, new Error('something went wrong'))
-          );
+          .mockReturnValue(new MockedUnaryCall({ report: issuesFoundReport }));
       },
       verify: async ({ notificationsService, vnet }, result) => {
-        // Open the diag report and verify that it removes the notification.
+        // Wait for the first run to create a notification.
         await waitFor(
-          () =>
-            expect(result.current.diagnosticsAttempt.status).toEqual('success'),
+          () => expect(notificationsService.getNotifications()).toHaveLength(1),
           { interval }
         );
+
+        // Open the diag report and verify that it removes the notification.
         await act(async () => {
           result.current.openReport(result.current.diagnosticsAttempt.data);
         });
-        expect(notificationsService.notifyWarning).toHaveBeenCalledTimes(1);
         expect(notificationsService.getNotifications()).toHaveLength(0);
 
         jest.clearAllMocks();
 
-        // Wait for the third report to be processed and verify that it does not result in another
-        // notification being created.
+        // Wait for at least one no-issues run…
+        await act(async () => {
+          jest
+            .spyOn(vnet, 'runDiagnostics')
+            .mockReturnValue(
+              new MockedUnaryCall({ report: noIssuesFoundReport })
+            );
+        });
         await waitFor(
-          () => expect(vnet.runDiagnostics).toHaveBeenCalledTimes(3),
+          () => expect(vnet.runDiagnostics).toHaveBeenCalledTimes(1),
+          { interval }
+        );
+
+        // …then flip back to returning issues and wait for one more run. Verify that the cycle
+        // did not create another notification.
+        jest
+          .spyOn(vnet, 'runDiagnostics')
+          .mockReturnValue(new MockedUnaryCall({ report: issuesFoundReport }));
+        await waitFor(
+          () => expect(vnet.runDiagnostics).toHaveBeenCalledTimes(2),
           { interval }
         );
         expect(notificationsService.notifyWarning).toHaveBeenCalledTimes(0);
@@ -416,10 +421,9 @@ describe('diag notification', () => {
       mockAppContext: appContext => {
         jest
           .spyOn(appContext.vnet, 'runDiagnostics')
-          .mockResolvedValueOnce(
+          .mockReturnValue(
             new MockedUnaryCall({ report: noIssuesFoundReport })
-          )
-          .mockReturnValue(new MockedUnaryCall({ report: issuesFoundReport }));
+          );
       },
       verify: async (
         { vnet, notificationsService },
@@ -431,15 +435,22 @@ describe('diag notification', () => {
             expect(result.current.diagnosticsAttempt.status).toEqual('success'),
           { interval }
         );
-        expect(notificationsService.notifyWarning).not.toHaveBeenCalled();
+        expect(notificationsService.getNotifications()).toHaveLength(0);
 
-        // Close the panel and wait for the next run, verify that the notification was sent.
-        await act(async () => controlConnectionsRef.current.close());
+        // Close the panel and start returning report with issues, then wait for the next run to
+        // produce a notification.
+        await act(async () => {
+          jest
+            .spyOn(vnet, 'runDiagnostics')
+            .mockReturnValue(
+              new MockedUnaryCall({ report: issuesFoundReport })
+            );
+          controlConnectionsRef.current.close();
+        });
         await waitFor(
-          () => expect(vnet.runDiagnostics).toHaveBeenCalledTimes(2),
+          () => expect(notificationsService.getNotifications()).toHaveLength(1),
           { interval }
         );
-        expect(notificationsService.getNotifications().length).toEqual(1);
       },
     },
     {

--- a/web/packages/teleterm/src/ui/Vnet/vnetContext.test.tsx
+++ b/web/packages/teleterm/src/ui/Vnet/vnetContext.test.tsx
@@ -359,13 +359,11 @@ describe('diag notification', () => {
         jest.clearAllMocks();
 
         // Wait for at least one no-issues run…
-        await act(async () => {
-          jest
-            .spyOn(vnet, 'runDiagnostics')
-            .mockReturnValue(
-              new MockedUnaryCall({ report: noIssuesFoundReport })
-            );
-        });
+        jest
+          .spyOn(vnet, 'runDiagnostics')
+          .mockReturnValue(
+            new MockedUnaryCall({ report: noIssuesFoundReport })
+          );
         await waitFor(
           () => expect(vnet.runDiagnostics).toHaveBeenCalledTimes(1),
           { interval }
@@ -439,14 +437,10 @@ describe('diag notification', () => {
 
         // Close the panel and start returning report with issues, then wait for the next run to
         // produce a notification.
-        await act(async () => {
-          jest
-            .spyOn(vnet, 'runDiagnostics')
-            .mockReturnValue(
-              new MockedUnaryCall({ report: issuesFoundReport })
-            );
-          controlConnectionsRef.current.close();
-        });
+        await act(async () => controlConnectionsRef.current.close());
+        jest
+          .spyOn(vnet, 'runDiagnostics')
+          .mockReturnValue(new MockedUnaryCall({ report: issuesFoundReport }));
         await waitFor(
           () => expect(notificationsService.getNotifications()).toHaveLength(1),
           { interval }

--- a/web/packages/teleterm/src/ui/Vnet/vnetContext.tsx
+++ b/web/packages/teleterm/src/ui/Vnet/vnetContext.tsx
@@ -420,6 +420,8 @@ export const VnetContextProvider: FC<
         !notificationsService.hasNotification(previousNotificationId);
       notificationsService.removeNotification(previousNotificationId);
 
+      // Once a user acknowledged or dismissed a VNet warning during a session, we don't want to
+      // notify them about it again unless they manually re-run diagnostics.
       if (
         hasActedOnPreviousNotification ||
         hasDismissedDiagnosticsAlertRef.current


### PR DESCRIPTION
Closes #64192.

VNet diagnostics run on a configurable interval. When the `RunDiagnostics` RPC returns a report which says that the diagnostics found some issues, `VnetContext` shows a warning notification in the app (see #52462).

In tests, that interval is set to a very low value so the tests don't take forever to run. The setup of two tests:

* `is not shown after opening a report, receiving another report with no issues and then issues reoccuring`
* `is not shown when the VNet panel is opened and no issues are found, but appears after the panel is closed and issues are found`

depended on the number of calls to the mocked version of a VNet service client. This was prone to failure on CI where under heavy load `waitFor` could take more time to resolve than the diagnostics interval, making the tests run against wrong state of the mocked `vnet.runDiagnostics`.

To fix this, this PR makes it so that we directly mutate the mock in tests when we need the RPC to start returning a different report, instead of depending on the number of calls to `vnet.runDiagnostics`.