### PR TITLE
[v18] Add TLS options to app spec

### DIFF
--- a/api/proto/teleport/legacy/types/types.proto
+++ b/api/proto/teleport/legacy/types/types.proto
@@ -1196,6 +1196,8 @@ message AppSpecV3 {
   MCP MCP = 15 [(gogoproto.jsontag) = "mcp,omitempty"];
   // LLM contains LLM inference endpoint related configurations.
   LLM LLM = 16 [(gogoproto.jsontag) = "inference,omitempty"];
+  // TLS contains the app TLS configuration.
+  AppTLS TLS = 17 [(gogoproto.jsontag) = "tls,omitempty"];
 }
 
 // MCP contains MCP server-related configurations.
@@ -1263,6 +1265,35 @@ message LLM {
   // Defines a model that will be used if the model requested is not on the list.
   // The fallback model must be in the "models" list.
   string fallback_model = 4;
+}
+
+// AppTLS contains the app TLS configuration.
+message AppTLS {
+  // Mode defines the TLS verification.
+  // Supported values:
+  //   "verify-full" (performs certificate validation, and asserts server name and SPIFFE ID),
+  //   "verify-server-name" (performs certificate validation, and asserts server name),
+  //   "verify-spiffe-id": (performs certificate validation, and asserts SPIFFE ID. Requires `server_spiffe_id` option),
+  //   "insecure": (accepts any certificate provided by app)
+  string mode = 1;
+  // ServerName specifies a custom hostname used for TLS verification against
+  // the upstream certificate.
+  string server_name = 2;
+  // ServerSpiffeId specifies a SPIFFE ID that must be present on the server
+  // certificate.
+  string server_spiffe_id = 3;
+  // AllowedCas is the list of user provided CAs used for verifying upstream
+  // certificates. Accepted values are PEM-encoded CA certificates and
+  // Teleport CA aliases.
+  // Supported aliases:
+  //   "workload_identity" (workload Identity CA. Allows accepting certificates issued by `tbot`).
+  repeated string allowed_cas = 4;
+  // ClientCertMode specifies which client certificate mode to use for the
+  // upstream connection.
+  // Supported values:
+  //   "managed" (app service will issue client certificates to use in the app upstream connection, establishing mTLS connections),
+  //   "disabled" (app upstream connection won't use client certificates).
+  string client_cert_mode = 5;
 }
 
 // CommandLabelV2 is a label that has a value as a result of the

--- a/api/types/app.go
+++ b/api/types/app.go
@@ -112,6 +112,12 @@ type Application interface {
 	GetMCP() *MCP
 	// GetLLM fetches LLM specific configuration.
 	GetLLM() *LLM
+	// GetTLS fetches TLS configuration.
+	GetTLS() *AppTLS
+	// GetClientCertMode returns the client certificate mode used.
+	GetClientCertMode() AppClientCertMode
+	// GetTLSMode returns the TLS mode.
+	GetTLSMode() AppTLSMode
 	// IsEqual determines if two application resources are equivalent to one another.
 	IsEqual(Application) bool
 }
@@ -316,7 +322,7 @@ func (a *AppV3) IsLLM() bool {
 }
 
 func IsAppTCP(uri string) bool {
-	return strings.HasPrefix(uri, "tcp://")
+	return strings.HasPrefix(uri, "tcp://") || strings.HasPrefix(uri, SchemeTLS+"://")
 }
 
 // IsAppMCP returns true if provided uri is an MCP app.
@@ -642,6 +648,16 @@ func (a *AppV3) checkLLM() error {
 	return nil
 }
 
+// AppSupportsTLSConfig returns if app supports TLS config based on its URI.
+func AppSupportsTLSConfig(uri string) bool {
+	parsed, err := url.Parse(uri)
+	if err != nil {
+		return false
+	}
+
+	return slices.Contains(AppSchemesWithTLSSupport, parsed.Scheme)
+}
+
 // GetIdentityCenter returns the Identity Center information for the app, if any.
 // May be nil.
 func (a *AppV3) GetIdentityCenter() *AppIdentityCenter {
@@ -672,9 +688,40 @@ func (a *AppV3) GetMCP() *MCP {
 	return a.Spec.MCP
 }
 
-// GetMCP returns LLM specific configuration.
+// GetLLM returns LLM specific configuration.
 func (a *AppV3) GetLLM() *LLM {
 	return a.Spec.LLM
+}
+
+// GetTLS returns TLS configuration.
+func (a *AppV3) GetTLS() *AppTLS {
+	return a.Spec.TLS
+}
+
+// GetTLSMode returns the TLS mode.
+func (a *AppV3) GetTLSMode() AppTLSMode {
+	switch {
+	case a.Spec.InsecureSkipVerify:
+		return AppTLSModeInsecure
+	case a.Spec.TLS != nil && a.Spec.TLS.Mode != "":
+		// Rely on specified value when available.
+		return a.Spec.TLS.Mode
+	case AppSupportsTLSConfig(a.Spec.URI):
+		// Defaults to check only server name to keep backwards compatibility.
+		return AppTLSModeVerifyServerName
+	default:
+		// Unsupported app types should not return any valid mode.
+		return ""
+	}
+}
+
+// GetClientCertMode returns the client certificate mode used.
+func (a *AppV3) GetClientCertMode() AppClientCertMode {
+	if a.Spec.TLS == nil || a.Spec.TLS.ClientCertMode == "" {
+		return AppClientCertModeDisabled
+	}
+
+	return a.Spec.TLS.ClientCertMode
 }
 
 // DeduplicateApps deduplicates apps by combination of app name and public address.
@@ -828,4 +875,70 @@ var SupportedLLMProviders = []LLMProvider{
 	LLMProviderOpenAI,
 	LLMProviderAnthropic,
 	LLMProviderAWSBedrock,
+}
+
+// AppSchemesWithTLSSupport list of app schemas that support TLS configurations.
+var AppSchemesWithTLSSupport = []string{
+	"https",
+	SchemeTLS,
+	SchemeMCPHTTPS,
+	SchemeMCPSSEHTTPS,
+}
+
+// AppTLSMode defines TLS verification.
+//
+// Friendly reminder: When adding or modifying TLS mode value, also check the
+// AppTLS protobuf fields comments for updates. This will keep docs and IaC
+// reference up-to-date.
+type AppTLSMode = string
+
+const (
+	// AppTLSModeVerifyFull performs certificate verification with server name
+	// and spiffe ID check.
+	AppTLSModeVerifyFull AppTLSMode = "verify-full"
+	// AppTLSModeVerifyServerName performs certificate verification with server
+	// name check.
+	AppTLSModeVerifyServerName AppTLSMode = "verify-server-name"
+	// AppTLSModeVerifySpiffeID performs certificate verification with spiffe ID
+	// check.
+	AppTLSModeVerifySpiffeID AppTLSMode = "verify-spiffe-id"
+	// AppTLSModeInsecure disables app's TLS certificate verification.
+	AppTLSModeInsecure AppTLSMode = "insecure"
+)
+
+// AppClientCertMode specifies which client certificate mode to use for the
+// upstream connection.
+//
+// Friendly reminder: When adding or modifying a client cert mode, also check the
+// AppTLS protobuf fields comments for updates. This will keep docs and IaC
+// reference up-to-date.
+type AppClientCertMode = string
+
+const (
+	// AppClientCertModeManaged indicates app service will issue client
+	// certificates to use in the app upstream connection, establishing mTLS
+	// connections.
+	AppClientCertModeManaged AppClientCertMode = "managed"
+	// AppClientCertModeDisabled indicates the app upstream connection won't use
+	// client certificates.
+	AppClientCertModeDisabled AppClientCertMode = "disabled"
+)
+
+// AppTLSInternalCA represents a Teleport CA that the app service will accept
+// certificates from when establishing an app upstream connection.
+//
+// Friendly reminder: When adding or modifying a internal CA alias, also check
+// the AppTLS protobuf fields comments for updates. This will keep docs and IaC
+// reference up-to-date.
+type AppTLSInternalCA = string
+
+const (
+	// AppTLSInternalCAWorkloadIdentity represents the Workload Identity CA.
+	AppTLSInternalCAWorkloadIdentity AppTLSInternalCA = "workload_identity"
+)
+
+// AppSupportedInternalCAs returns the list of internal CAs that can be used
+// in the app TLS configuration.
+func AppSupportedInternalCAs() []string {
+	return []string{AppTLSInternalCAWorkloadIdentity}
 }

--- a/api/types/app_test.go
+++ b/api/types/app_test.go
@@ -1045,3 +1045,98 @@ func TestLLMConfiguration(t *testing.T) {
 		}
 	})
 }
+
+func TestAppTLSMode(t *testing.T) {
+	for name, tc := range map[string]struct {
+		spec         AppSpecV3
+		expectedMode AppTLSMode
+	}{
+		"unsupported protocol": {
+			spec:         AppSpecV3{URI: "tcp://0.0.0.0:8000"},
+			expectedMode: "",
+		},
+		"https insecure": {
+			spec: AppSpecV3{
+				URI: "https://localhost:443",
+				TLS: &AppTLS{
+					Mode: AppTLSModeInsecure,
+				},
+			},
+			expectedMode: AppTLSModeInsecure,
+		},
+		"insecure skip verify is respected": {
+			spec: AppSpecV3{
+				URI:                "https://localhost:80",
+				InsecureSkipVerify: true,
+			},
+			expectedMode: AppTLSModeInsecure,
+		},
+		"https default": {
+			spec:         AppSpecV3{URI: "https://localhost:443"},
+			expectedMode: AppTLSModeVerifyServerName,
+		},
+		"mcp https default": {
+			spec:         AppSpecV3{URI: "mcp+https://localhost:8080"},
+			expectedMode: AppTLSModeVerifyServerName,
+		},
+		"insecure skip verify with mode insecure": {
+			spec: AppSpecV3{
+				URI:                "https://localhost",
+				InsecureSkipVerify: true,
+				TLS:                &AppTLS{Mode: AppTLSModeInsecure},
+			},
+			expectedMode: AppTLSModeInsecure,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			app, err := NewAppV3(Metadata{Name: "myapp"}, tc.spec)
+			require.NoError(t, err)
+			require.Equal(t, tc.expectedMode, app.GetTLSMode())
+		})
+	}
+}
+
+func TestAppClientCertMode(t *testing.T) {
+	for name, tc := range map[string]struct {
+		spec         AppSpecV3
+		expectedMode AppClientCertMode
+	}{
+		"default disabled": {
+			spec:         AppSpecV3{URI: "https://0.0.0.0:8000"},
+			expectedMode: AppClientCertModeDisabled,
+		},
+		"empty tls block returns disabled": {
+			spec: AppSpecV3{
+				URI: "tls://0.0.0.0:8000",
+				TLS: &AppTLS{},
+			},
+			expectedMode: AppClientCertModeDisabled,
+		},
+		"explicit disable": {
+			spec: AppSpecV3{
+				URI: "tls://0.0.0.0:8000",
+				TLS: &AppTLS{
+					Mode:           AppTLSModeVerifyServerName,
+					ClientCertMode: AppClientCertModeDisabled,
+				},
+			},
+			expectedMode: AppClientCertModeDisabled,
+		},
+		"managed": {
+			spec: AppSpecV3{
+				URI: "tls://0.0.0.0:8000",
+				TLS: &AppTLS{
+					Mode:           AppTLSModeVerifyServerName,
+					ClientCertMode: AppClientCertModeManaged,
+				},
+			},
+			expectedMode: AppClientCertModeManaged,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			app, err := NewAppV3(Metadata{Name: "myapp"}, tc.spec)
+			require.NoError(t, err)
+			require.Equal(t, tc.expectedMode, app.GetClientCertMode())
+		})
+	}
+}

--- a/api/types/constants.go
+++ b/api/types/constants.go
@@ -1042,6 +1042,10 @@ const (
 	// SchemeLLMEndpoint is a URI scheme for LLM inference endpoints.
 	SchemeLLMEndpoint = "llm"
 
+	// SchemeTLS is a URI scheme for TCP apps that Teleport terminate TLS
+	// connections with upstream.
+	SchemeTLS = "tls"
+
 	// DiscoveredResourceNode identifies a discovered SSH node.
 	DiscoveredResourceNode = "node"
 	// DiscoveredResourceDatabase identifies a discovered database.

--- a/api/types/derived.gen.go
+++ b/api/types/derived.gen.go
@@ -236,7 +236,8 @@ func deriveTeleportEqual(this, that *AppSpecV3) bool {
 			deriveTeleportEqual_27(this.TCPPorts, that.TCPPorts) &&
 			this.UseAnyProxyPublicAddr == that.UseAnyProxyPublicAddr &&
 			deriveTeleportEqual_28(this.MCP, that.MCP) &&
-			deriveTeleportEqual_29(this.LLM, that.LLM)
+			deriveTeleportEqual_29(this.LLM, that.LLM) &&
+			deriveTeleportEqual_30(this.TLS, that.TLS)
 }
 
 // deriveTeleportEqual_ returns whether this and that are equal.
@@ -368,12 +369,12 @@ func deriveTeleportEqual_12(this, that *DatabaseSpecV3) bool {
 			deriveTeleportEqualAWS(&this.AWS, &that.AWS) &&
 			deriveTeleportEqualGCPCloudSQL(&this.GCP, &that.GCP) &&
 			deriveTeleportEqualAzure(&this.Azure, &that.Azure) &&
-			deriveTeleportEqual_30(&this.TLS, &that.TLS) &&
-			deriveTeleportEqual_31(&this.AD, &that.AD) &&
-			deriveTeleportEqual_32(&this.MySQL, &that.MySQL) &&
-			deriveTeleportEqual_33(this.AdminUser, that.AdminUser) &&
-			deriveTeleportEqual_34(&this.MongoAtlas, &that.MongoAtlas) &&
-			deriveTeleportEqual_35(&this.Oracle, &that.Oracle)
+			deriveTeleportEqual_31(&this.TLS, &that.TLS) &&
+			deriveTeleportEqual_32(&this.AD, &that.AD) &&
+			deriveTeleportEqual_33(&this.MySQL, &that.MySQL) &&
+			deriveTeleportEqual_34(this.AdminUser, that.AdminUser) &&
+			deriveTeleportEqual_35(&this.MongoAtlas, &that.MongoAtlas) &&
+			deriveTeleportEqual_36(&this.Oracle, &that.Oracle)
 }
 
 // deriveTeleportEqual_13 returns whether this and that are equal.
@@ -383,7 +384,7 @@ func deriveTeleportEqual_13(this, that *DynamicWindowsDesktopSpecV1) bool {
 			this.Addr == that.Addr &&
 			this.Domain == that.Domain &&
 			this.NonAD == that.NonAD &&
-			deriveTeleportEqual_36(this.ScreenSize, that.ScreenSize)
+			deriveTeleportEqual_37(this.ScreenSize, that.ScreenSize)
 }
 
 // deriveTeleportEqual_14 returns whether this and that are equal.
@@ -394,7 +395,7 @@ func deriveTeleportEqual_14(this, that *WindowsDesktopSpecV3) bool {
 			this.Domain == that.Domain &&
 			this.HostID == that.HostID &&
 			this.NonAD == that.NonAD &&
-			deriveTeleportEqual_36(this.ScreenSize, that.ScreenSize)
+			deriveTeleportEqual_37(this.ScreenSize, that.ScreenSize)
 }
 
 // deriveTeleportEqual_15 returns whether this and that are equal.
@@ -412,7 +413,7 @@ func deriveTeleportEqual_15(this, that *KubernetesClusterSpecV3) bool {
 func deriveTeleportEqual_16(this, that *KubernetesClusterDiscoveryStatus) bool {
 	return (this == nil && that == nil) ||
 		this != nil && that != nil &&
-			deriveTeleportEqual_37(this.Aws, that.Aws)
+			deriveTeleportEqual_38(this.Aws, that.Aws)
 }
 
 // deriveTeleportEqual_17 returns whether this and that are equal.
@@ -422,7 +423,7 @@ func deriveTeleportEqual_17(this, that *KubernetesServerSpecV3) bool {
 			this.Version == that.Version &&
 			this.Hostname == that.Hostname &&
 			this.HostID == that.HostID &&
-			deriveTeleportEqual_38(&this.Rotation, &that.Rotation) &&
+			deriveTeleportEqual_39(&this.Rotation, &that.Rotation) &&
 			deriveTeleportEqualKubernetesClusterV3(this.Cluster, that.Cluster) &&
 			deriveTeleportEqual_24(this.ProxyIDs, that.ProxyIDs) &&
 			this.RelayGroup == that.RelayGroup &&
@@ -442,7 +443,7 @@ func deriveTeleportEqual_19(this, that *OktaAssignmentSpecV1) bool {
 	return (this == nil && that == nil) ||
 		this != nil && that != nil &&
 			this.User == that.User &&
-			deriveTeleportEqual_39(this.Targets, that.Targets) &&
+			deriveTeleportEqual_40(this.Targets, that.Targets) &&
 			this.CleanupTime.Equal(that.CleanupTime) &&
 			this.Status == that.Status &&
 			this.LastTransition.Equal(that.LastTransition) &&
@@ -469,7 +470,7 @@ func deriveTeleportEqual_21(this, that map[string]CommandLabelV2) bool {
 		if !ok {
 			return false
 		}
-		if !(deriveTeleportEqual_40(&v, &thatv)) {
+		if !(deriveTeleportEqual_41(&v, &thatv)) {
 			return false
 		}
 	}
@@ -481,7 +482,7 @@ func deriveTeleportEqual_22(this, that *Rewrite) bool {
 	return (this == nil && that == nil) ||
 		this != nil && that != nil &&
 			deriveTeleportEqual_24(this.Redirect, that.Redirect) &&
-			deriveTeleportEqual_41(this.Headers, that.Headers) &&
+			deriveTeleportEqual_42(this.Headers, that.Headers) &&
 			this.JWTClaims == that.JWTClaims
 }
 
@@ -490,7 +491,7 @@ func deriveTeleportEqual_23(this, that *AppAWS) bool {
 	return (this == nil && that == nil) ||
 		this != nil && that != nil &&
 			this.ExternalID == that.ExternalID &&
-			deriveTeleportEqual_42(this.RolesAnywhereProfile, that.RolesAnywhereProfile)
+			deriveTeleportEqual_43(this.RolesAnywhereProfile, that.RolesAnywhereProfile)
 }
 
 // deriveTeleportEqual_24 returns whether this and that are equal.
@@ -526,7 +527,7 @@ func deriveTeleportEqual_26(this, that *AppIdentityCenter) bool {
 	return (this == nil && that == nil) ||
 		this != nil && that != nil &&
 			this.AccountID == that.AccountID &&
-			deriveTeleportEqual_43(this.PermissionSets, that.PermissionSets)
+			deriveTeleportEqual_44(this.PermissionSets, that.PermissionSets)
 }
 
 // deriveTeleportEqual_27 returns whether this and that are equal.
@@ -538,7 +539,7 @@ func deriveTeleportEqual_27(this, that []*PortRange) bool {
 		return false
 	}
 	for i := 0; i < len(this); i++ {
-		if !(deriveTeleportEqual_44(this[i], that[i])) {
+		if !(deriveTeleportEqual_45(this[i], that[i])) {
 			return false
 		}
 	}
@@ -560,12 +561,23 @@ func deriveTeleportEqual_29(this, that *LLM) bool {
 		this != nil && that != nil &&
 			this.Format == that.Format &&
 			this.Provider == that.Provider &&
-			deriveTeleportEqual_45(this.Models, that.Models) &&
+			deriveTeleportEqual_46(this.Models, that.Models) &&
 			this.FallbackModel == that.FallbackModel
 }
 
 // deriveTeleportEqual_30 returns whether this and that are equal.
-func deriveTeleportEqual_30(this, that *DatabaseTLS) bool {
+func deriveTeleportEqual_30(this, that *AppTLS) bool {
+	return (this == nil && that == nil) ||
+		this != nil && that != nil &&
+			this.Mode == that.Mode &&
+			this.ServerName == that.ServerName &&
+			this.ServerSpiffeId == that.ServerSpiffeId &&
+			deriveTeleportEqual_24(this.AllowedCas, that.AllowedCas) &&
+			this.ClientCertMode == that.ClientCertMode
+}
+
+// deriveTeleportEqual_31 returns whether this and that are equal.
+func deriveTeleportEqual_31(this, that *DatabaseTLS) bool {
 	return (this == nil && that == nil) ||
 		this != nil && that != nil &&
 			this.Mode == that.Mode &&
@@ -574,8 +586,8 @@ func deriveTeleportEqual_30(this, that *DatabaseTLS) bool {
 			this.TrustSystemCertPool == that.TrustSystemCertPool
 }
 
-// deriveTeleportEqual_31 returns whether this and that are equal.
-func deriveTeleportEqual_31(this, that *AD) bool {
+// deriveTeleportEqual_32 returns whether this and that are equal.
+func deriveTeleportEqual_32(this, that *AD) bool {
 	return (this == nil && that == nil) ||
 		this != nil && that != nil &&
 			this.KeytabFile == that.KeytabFile &&
@@ -588,30 +600,30 @@ func deriveTeleportEqual_31(this, that *AD) bool {
 			this.LDAPServiceAccountSID == that.LDAPServiceAccountSID
 }
 
-// deriveTeleportEqual_32 returns whether this and that are equal.
-func deriveTeleportEqual_32(this, that *MySQLOptions) bool {
+// deriveTeleportEqual_33 returns whether this and that are equal.
+func deriveTeleportEqual_33(this, that *MySQLOptions) bool {
 	return (this == nil && that == nil) ||
 		this != nil && that != nil &&
 			this.ServerVersion == that.ServerVersion
 }
 
-// deriveTeleportEqual_33 returns whether this and that are equal.
-func deriveTeleportEqual_33(this, that *DatabaseAdminUser) bool {
+// deriveTeleportEqual_34 returns whether this and that are equal.
+func deriveTeleportEqual_34(this, that *DatabaseAdminUser) bool {
 	return (this == nil && that == nil) ||
 		this != nil && that != nil &&
 			this.Name == that.Name &&
 			this.DefaultDatabase == that.DefaultDatabase
 }
 
-// deriveTeleportEqual_34 returns whether this and that are equal.
-func deriveTeleportEqual_34(this, that *MongoAtlas) bool {
+// deriveTeleportEqual_35 returns whether this and that are equal.
+func deriveTeleportEqual_35(this, that *MongoAtlas) bool {
 	return (this == nil && that == nil) ||
 		this != nil && that != nil &&
 			this.Name == that.Name
 }
 
-// deriveTeleportEqual_35 returns whether this and that are equal.
-func deriveTeleportEqual_35(this, that *OracleOptions) bool {
+// deriveTeleportEqual_36 returns whether this and that are equal.
+func deriveTeleportEqual_36(this, that *OracleOptions) bool {
 	return (this == nil && that == nil) ||
 		this != nil && that != nil &&
 			this.AuditUser == that.AuditUser &&
@@ -619,25 +631,25 @@ func deriveTeleportEqual_35(this, that *OracleOptions) bool {
 			this.ShuffleHostnames == that.ShuffleHostnames
 }
 
-// deriveTeleportEqual_36 returns whether this and that are equal.
-func deriveTeleportEqual_36(this, that *Resolution) bool {
+// deriveTeleportEqual_37 returns whether this and that are equal.
+func deriveTeleportEqual_37(this, that *Resolution) bool {
 	return (this == nil && that == nil) ||
 		this != nil && that != nil &&
 			this.Width == that.Width &&
 			this.Height == that.Height
 }
 
-// deriveTeleportEqual_37 returns whether this and that are equal.
-func deriveTeleportEqual_37(this, that *KubernetesClusterAWSStatus) bool {
+// deriveTeleportEqual_38 returns whether this and that are equal.
+func deriveTeleportEqual_38(this, that *KubernetesClusterAWSStatus) bool {
 	return (this == nil && that == nil) ||
 		this != nil && that != nil &&
 			this.SetupAccessForArn == that.SetupAccessForArn &&
 			this.Integration == that.Integration &&
-			deriveTeleportEqual_46(this.DiscoveryAssumedRole, that.DiscoveryAssumedRole)
+			deriveTeleportEqual_47(this.DiscoveryAssumedRole, that.DiscoveryAssumedRole)
 }
 
-// deriveTeleportEqual_38 returns whether this and that are equal.
-func deriveTeleportEqual_38(this, that *Rotation) bool {
+// deriveTeleportEqual_39 returns whether this and that are equal.
+func deriveTeleportEqual_39(this, that *Rotation) bool {
 	return (this == nil && that == nil) ||
 		this != nil && that != nil &&
 			this.State == that.State &&
@@ -647,36 +659,11 @@ func deriveTeleportEqual_38(this, that *Rotation) bool {
 			this.Started.Equal(that.Started) &&
 			this.GracePeriod == that.GracePeriod &&
 			this.LastRotated.Equal(that.LastRotated) &&
-			deriveTeleportEqual_47(&this.Schedule, &that.Schedule)
-}
-
-// deriveTeleportEqual_39 returns whether this and that are equal.
-func deriveTeleportEqual_39(this, that []*OktaAssignmentTargetV1) bool {
-	if this == nil || that == nil {
-		return this == nil && that == nil
-	}
-	if len(this) != len(that) {
-		return false
-	}
-	for i := 0; i < len(this); i++ {
-		if !(deriveTeleportEqual_48(this[i], that[i])) {
-			return false
-		}
-	}
-	return true
+			deriveTeleportEqual_48(&this.Schedule, &that.Schedule)
 }
 
 // deriveTeleportEqual_40 returns whether this and that are equal.
-func deriveTeleportEqual_40(this, that *CommandLabelV2) bool {
-	return (this == nil && that == nil) ||
-		this != nil && that != nil &&
-			this.Period == that.Period &&
-			deriveTeleportEqual_24(this.Command, that.Command) &&
-			this.Result == that.Result
-}
-
-// deriveTeleportEqual_41 returns whether this and that are equal.
-func deriveTeleportEqual_41(this, that []*Header) bool {
+func deriveTeleportEqual_40(this, that []*OktaAssignmentTargetV1) bool {
 	if this == nil || that == nil {
 		return this == nil && that == nil
 	}
@@ -691,16 +678,17 @@ func deriveTeleportEqual_41(this, that []*Header) bool {
 	return true
 }
 
-// deriveTeleportEqual_42 returns whether this and that are equal.
-func deriveTeleportEqual_42(this, that *AppAWSRolesAnywhereProfile) bool {
+// deriveTeleportEqual_41 returns whether this and that are equal.
+func deriveTeleportEqual_41(this, that *CommandLabelV2) bool {
 	return (this == nil && that == nil) ||
 		this != nil && that != nil &&
-			this.ProfileARN == that.ProfileARN &&
-			this.AcceptRoleSessionName == that.AcceptRoleSessionName
+			this.Period == that.Period &&
+			deriveTeleportEqual_24(this.Command, that.Command) &&
+			this.Result == that.Result
 }
 
-// deriveTeleportEqual_43 returns whether this and that are equal.
-func deriveTeleportEqual_43(this, that []*IdentityCenterPermissionSet) bool {
+// deriveTeleportEqual_42 returns whether this and that are equal.
+func deriveTeleportEqual_42(this, that []*Header) bool {
 	if this == nil || that == nil {
 		return this == nil && that == nil
 	}
@@ -715,16 +703,16 @@ func deriveTeleportEqual_43(this, that []*IdentityCenterPermissionSet) bool {
 	return true
 }
 
-// deriveTeleportEqual_44 returns whether this and that are equal.
-func deriveTeleportEqual_44(this, that *PortRange) bool {
+// deriveTeleportEqual_43 returns whether this and that are equal.
+func deriveTeleportEqual_43(this, that *AppAWSRolesAnywhereProfile) bool {
 	return (this == nil && that == nil) ||
 		this != nil && that != nil &&
-			this.Port == that.Port &&
-			this.EndPort == that.EndPort
+			this.ProfileARN == that.ProfileARN &&
+			this.AcceptRoleSessionName == that.AcceptRoleSessionName
 }
 
-// deriveTeleportEqual_45 returns whether this and that are equal.
-func deriveTeleportEqual_45(this, that []*LLM_Model) bool {
+// deriveTeleportEqual_44 returns whether this and that are equal.
+func deriveTeleportEqual_44(this, that []*IdentityCenterPermissionSet) bool {
 	if this == nil || that == nil {
 		return this == nil && that == nil
 	}
@@ -739,8 +727,32 @@ func deriveTeleportEqual_45(this, that []*LLM_Model) bool {
 	return true
 }
 
+// deriveTeleportEqual_45 returns whether this and that are equal.
+func deriveTeleportEqual_45(this, that *PortRange) bool {
+	return (this == nil && that == nil) ||
+		this != nil && that != nil &&
+			this.Port == that.Port &&
+			this.EndPort == that.EndPort
+}
+
 // deriveTeleportEqual_46 returns whether this and that are equal.
-func deriveTeleportEqual_46(this, that *AssumeRole) bool {
+func deriveTeleportEqual_46(this, that []*LLM_Model) bool {
+	if this == nil || that == nil {
+		return this == nil && that == nil
+	}
+	if len(this) != len(that) {
+		return false
+	}
+	for i := 0; i < len(this); i++ {
+		if !(deriveTeleportEqual_52(this[i], that[i])) {
+			return false
+		}
+	}
+	return true
+}
+
+// deriveTeleportEqual_47 returns whether this and that are equal.
+func deriveTeleportEqual_47(this, that *AssumeRole) bool {
 	return (this == nil && that == nil) ||
 		this != nil && that != nil &&
 			this.RoleARN == that.RoleARN &&
@@ -748,8 +760,8 @@ func deriveTeleportEqual_46(this, that *AssumeRole) bool {
 			this.RoleName == that.RoleName
 }
 
-// deriveTeleportEqual_47 returns whether this and that are equal.
-func deriveTeleportEqual_47(this, that *RotationSchedule) bool {
+// deriveTeleportEqual_48 returns whether this and that are equal.
+func deriveTeleportEqual_48(this, that *RotationSchedule) bool {
 	return (this == nil && that == nil) ||
 		this != nil && that != nil &&
 			this.UpdateClients.Equal(that.UpdateClients) &&
@@ -757,24 +769,24 @@ func deriveTeleportEqual_47(this, that *RotationSchedule) bool {
 			this.Standby.Equal(that.Standby)
 }
 
-// deriveTeleportEqual_48 returns whether this and that are equal.
-func deriveTeleportEqual_48(this, that *OktaAssignmentTargetV1) bool {
+// deriveTeleportEqual_49 returns whether this and that are equal.
+func deriveTeleportEqual_49(this, that *OktaAssignmentTargetV1) bool {
 	return (this == nil && that == nil) ||
 		this != nil && that != nil &&
 			this.Type == that.Type &&
 			this.Id == that.Id
 }
 
-// deriveTeleportEqual_49 returns whether this and that are equal.
-func deriveTeleportEqual_49(this, that *Header) bool {
+// deriveTeleportEqual_50 returns whether this and that are equal.
+func deriveTeleportEqual_50(this, that *Header) bool {
 	return (this == nil && that == nil) ||
 		this != nil && that != nil &&
 			this.Name == that.Name &&
 			this.Value == that.Value
 }
 
-// deriveTeleportEqual_50 returns whether this and that are equal.
-func deriveTeleportEqual_50(this, that *IdentityCenterPermissionSet) bool {
+// deriveTeleportEqual_51 returns whether this and that are equal.
+func deriveTeleportEqual_51(this, that *IdentityCenterPermissionSet) bool {
 	return (this == nil && that == nil) ||
 		this != nil && that != nil &&
 			this.ARN == that.ARN &&
@@ -782,8 +794,8 @@ func deriveTeleportEqual_50(this, that *IdentityCenterPermissionSet) bool {
 			this.AssignmentID == that.AssignmentID
 }
 
-// deriveTeleportEqual_51 returns whether this and that are equal.
-func deriveTeleportEqual_51(this, that *LLM_Model) bool {
+// deriveTeleportEqual_52 returns whether this and that are equal.
+func deriveTeleportEqual_52(this, that *LLM_Model) bool {
 	return (this == nil && that == nil) ||
 		this != nil && that != nil &&
 			this.Name == that.Name &&

--- a/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-appsv3.mdx
+++ b/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-appsv3.mdx
@@ -39,6 +39,7 @@ resource, which you can apply after installing the Teleport Kubernetes operator.
 |required_app_names|[]string|RequiredAppNames is a list of app names that are required for this app to function. Any app listed here will be part of the authentication redirect flow and authenticate alongside this app.|
 |rewrite|[object](#specrewrite)|Rewrite is a list of rewriting rules to apply to requests and responses.|
 |tcp_ports|[][object](#spectcp_ports-items)|TCPPorts is a list of ports and port ranges that an app agent can forward connections to. Only applicable to TCP App Access. If this field is not empty, URI is expected to contain no port number and start with the tcp protocol.|
+|tls|[object](#spectls)|TLS contains the app TLS configuration.|
 |uri|string|URI is the web app endpoint.|
 |use_any_proxy_public_addr|boolean|UseAnyProxyPublicAddr will rebuild this app's fqdn based on the proxy public addr that the request originated from. This should be true if your proxy has multiple proxy public addrs and you want the app to be accessible from any of them. If `public_addr` is explicitly set in the app spec, setting this value to true will overwrite that public address in the web UI.|
 
@@ -142,4 +143,14 @@ resource, which you can apply after installing the Teleport Kubernetes operator.
 |---|---|---|
 |end_port|integer|EndPort describes the end of the range, inclusive. If set, it must be between 2 and 65535 and be greater than Port when describing a port range. When omitted or set to zero, it signifies that the port range defines a single port.|
 |port|integer|Port describes the start of the range. It must be between 1 and 65535.|
+
+### spec.tls
+
+|Field|Type|Description|
+|---|---|---|
+|allowed_cas|[]string|AllowedCas is the list of user provided CAs used for verifying upstream certificates. Accepted values are PEM-encoded CA certificates and Teleport CA aliases. Supported aliases: "workload_identity" (workload Identity CA. Allows accepting certificates issued by `tbot`).|
+|client_cert_mode|string|ClientCertMode specifies which client certificate mode to use for the upstream connection. Supported values: "managed" (app service will issue client certificates to use in the app upstream connection, establishing mTLS connections), "disabled" (app upstream connection won't use client certificates).|
+|mode|string|Mode defines the TLS verification. Supported values: "verify-full" (performs certificate validation, and asserts server name and SPIFFE ID), "verify-server-name" (performs certificate validation, and asserts server name), "verify-spiffe-id": (performs certificate validation, and asserts SPIFFE ID. Requires `server_spiffe_id` option), "insecure": (accepts any certificate provided by app)|
+|server_name|string|ServerName specifies a custom hostname used for TLS verification against the upstream certificate.|
+|server_spiffe_id|string|ServerSpiffeId specifies a SPIFFE ID that must be present on the server certificate.|
 

--- a/docs/pages/reference/infrastructure-as-code/teleport-resources/app-server-v3.mdx
+++ b/docs/pages/reference/infrastructure-as-code/teleport-resources/app-server-v3.mdx
@@ -177,6 +177,7 @@ tcp_ports:
 use_any_proxy_public_addr: true
 mcp: # [...]
 inference: # [...]
+tls: # [...]
 ```
 
 |Field Name|Description|Type|
@@ -195,8 +196,35 @@ inference: # [...]
 |required_app_names|A list of app names that are required for this app to function. Any app listed here will be part of the authentication redirect flow and authenticate alongside this app.|[]string|
 |rewrite|A list of rewriting rules to apply to requests and responses.|[Rewrite](#rewrite)|
 |tcp_ports|A list of ports and port ranges that an app agent can forward connections to. Only applicable to TCP App Access. If this field is not empty, URI is expected to contain no port number and start with the tcp protocol.|[][Port Range](#port-range)|
+|tls|Contains the app TLS configuration.|[App TLS](#app-tls)|
 |uri|The web app endpoint.|string|
 |use_any_proxy_public_addr|Will rebuild this app's fqdn based on the proxy public addr that the request originated from. This should be true if your proxy has multiple proxy public addrs and you want the app to be accessible from any of them. If `public_addr` is explicitly set in the app spec, setting this value to true will overwrite that public address in the web UI.|Boolean|
+
+## App TLS
+
+Contains the app TLS configuration.
+
+
+Example:
+
+```yaml
+mode: "string"
+server_name: "string"
+server_spiffe_id: "string"
+allowed_cas: 
+  - "string"
+  - "string"
+  - "string"
+client_cert_mode: "string"
+```
+
+|Field Name|Description|Type|
+|---|---|---|
+|allowed_cas|The list of user provided CAs used for verifying upstream certificates. Accepted values are PEM-encoded CA certificates and Teleport CA aliases. Supported aliases:   "workload_identity" (workload Identity CA. Allows accepting certificates issued by `tbot`).|[]string|
+|client_cert_mode|Specifies which client certificate mode to use for the upstream connection. Supported values:   "managed" (app service will issue client certificates to use in the app upstream connection, establishing mTLS connections),   "disabled" (app upstream connection won't use client certificates).|string|
+|mode|Defines the TLS verification. Supported values:   "verify-full" (performs certificate validation, and asserts server name and SPIFFE ID),   "verify-server-name" (performs certificate validation, and asserts server name),   "verify-spiffe-id": (performs certificate validation, and asserts SPIFFE ID. Requires `server_spiffe_id` option),   "insecure": (accepts any certificate provided by app)|string|
+|server_name|Specifies a custom hostname used for TLS verification against the upstream certificate.|string|
+|server_spiffe_id|Specifies a SPIFFE ID that must be present on the server certificate.|string|
 
 ## App V3
 

--- a/docs/pages/reference/infrastructure-as-code/teleport-resources/app-v3.mdx
+++ b/docs/pages/reference/infrastructure-as-code/teleport-resources/app-v3.mdx
@@ -136,6 +136,7 @@ tcp_ports:
 use_any_proxy_public_addr: true
 mcp: # [...]
 inference: # [...]
+tls: # [...]
 ```
 
 |Field Name|Description|Type|
@@ -154,8 +155,35 @@ inference: # [...]
 |required_app_names|A list of app names that are required for this app to function. Any app listed here will be part of the authentication redirect flow and authenticate alongside this app.|[]string|
 |rewrite|A list of rewriting rules to apply to requests and responses.|[Rewrite](#rewrite)|
 |tcp_ports|A list of ports and port ranges that an app agent can forward connections to. Only applicable to TCP App Access. If this field is not empty, URI is expected to contain no port number and start with the tcp protocol.|[][Port Range](#port-range)|
+|tls|Contains the app TLS configuration.|[App TLS](#app-tls)|
 |uri|The web app endpoint.|string|
 |use_any_proxy_public_addr|Will rebuild this app's fqdn based on the proxy public addr that the request originated from. This should be true if your proxy has multiple proxy public addrs and you want the app to be accessible from any of them. If `public_addr` is explicitly set in the app spec, setting this value to true will overwrite that public address in the web UI.|Boolean|
+
+## App TLS
+
+Contains the app TLS configuration.
+
+
+Example:
+
+```yaml
+mode: "string"
+server_name: "string"
+server_spiffe_id: "string"
+allowed_cas: 
+  - "string"
+  - "string"
+  - "string"
+client_cert_mode: "string"
+```
+
+|Field Name|Description|Type|
+|---|---|---|
+|allowed_cas|The list of user provided CAs used for verifying upstream certificates. Accepted values are PEM-encoded CA certificates and Teleport CA aliases. Supported aliases:   "workload_identity" (workload Identity CA. Allows accepting certificates issued by `tbot`).|[]string|
+|client_cert_mode|Specifies which client certificate mode to use for the upstream connection. Supported values:   "managed" (app service will issue client certificates to use in the app upstream connection, establishing mTLS connections),   "disabled" (app upstream connection won't use client certificates).|string|
+|mode|Defines the TLS verification. Supported values:   "verify-full" (performs certificate validation, and asserts server name and SPIFFE ID),   "verify-server-name" (performs certificate validation, and asserts server name),   "verify-spiffe-id": (performs certificate validation, and asserts SPIFFE ID. Requires `server_spiffe_id` option),   "insecure": (accepts any certificate provided by app)|string|
+|server_name|Specifies a custom hostname used for TLS verification against the upstream certificate.|string|
+|server_spiffe_id|Specifies a SPIFFE ID that must be present on the server certificate.|string|
 
 ## CORS Policy
 

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/app.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/app.mdx
@@ -57,6 +57,7 @@ Optional:
 - `required_app_names` (List of String) RequiredAppNames is a list of app names that are required for this app to function. Any app listed here will be part of the authentication redirect flow and authenticate alongside this app.
 - `rewrite` (Attributes) Rewrite is a list of rewriting rules to apply to requests and responses. (see [below for nested schema](#nested-schema-for-specrewrite))
 - `tcp_ports` (Attributes List) TCPPorts is a list of ports and port ranges that an app agent can forward connections to. Only applicable to TCP App Access. If this field is not empty, URI is expected to contain no port number and start with the tcp protocol. (see [below for nested schema](#nested-schema-for-spectcp_ports))
+- `tls` (Attributes) TLS contains the app TLS configuration. (see [below for nested schema](#nested-schema-for-spectls))
 - `uri` (String) URI is the web app endpoint.
 - `use_any_proxy_public_addr` (Boolean) UseAnyProxyPublicAddr will rebuild this app's fqdn based on the proxy public addr that the request originated from. This should be true if your proxy has multiple proxy public addrs and you want the app to be accessible from any of them. If `public_addr` is explicitly set in the app spec, setting this value to true will overwrite that public address in the web UI.
 - `user_groups` (List of String) UserGroups are a list of user group IDs that this app is associated with.
@@ -165,4 +166,15 @@ Optional:
 
 - `end_port` (Number) EndPort describes the end of the range, inclusive. If set, it must be between 2 and 65535 and be greater than Port when describing a port range. When omitted or set to zero, it signifies that the port range defines a single port.
 - `port` (Number) Port describes the start of the range. It must be between 1 and 65535.
+
+
+### Nested Schema for `spec.tls`
+
+Optional:
+
+- `allowed_cas` (List of String) AllowedCas is the list of user provided CAs used for verifying upstream certificates. Accepted values are PEM-encoded CA certificates and Teleport CA aliases. Supported aliases: "workload_identity" (workload Identity CA. Allows accepting certificates issued by `tbot`).
+- `client_cert_mode` (String) ClientCertMode specifies which client certificate mode to use for the upstream connection. Supported values: "managed" (app service will issue client certificates to use in the app upstream connection, establishing mTLS connections), "disabled" (app upstream connection won't use client certificates).
+- `mode` (String) Mode defines the TLS verification. Supported values: "verify-full" (performs certificate validation, and asserts server name and SPIFFE ID), "verify-server-name" (performs certificate validation, and asserts server name), "verify-spiffe-id": (performs certificate validation, and asserts SPIFFE ID. Requires `server_spiffe_id` option), "insecure": (accepts any certificate provided by app)
+- `server_name` (String) ServerName specifies a custom hostname used for TLS verification against the upstream certificate.
+- `server_spiffe_id` (String) ServerSpiffeId specifies a SPIFFE ID that must be present on the server certificate.
 

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/app.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/app.mdx
@@ -76,6 +76,7 @@ Optional:
 - `required_app_names` (List of String) RequiredAppNames is a list of app names that are required for this app to function. Any app listed here will be part of the authentication redirect flow and authenticate alongside this app.
 - `rewrite` (Attributes) Rewrite is a list of rewriting rules to apply to requests and responses. (see [below for nested schema](#nested-schema-for-specrewrite))
 - `tcp_ports` (Attributes List) TCPPorts is a list of ports and port ranges that an app agent can forward connections to. Only applicable to TCP App Access. If this field is not empty, URI is expected to contain no port number and start with the tcp protocol. (see [below for nested schema](#nested-schema-for-spectcp_ports))
+- `tls` (Attributes) TLS contains the app TLS configuration. (see [below for nested schema](#nested-schema-for-spectls))
 - `uri` (String) URI is the web app endpoint.
 - `use_any_proxy_public_addr` (Boolean) UseAnyProxyPublicAddr will rebuild this app's fqdn based on the proxy public addr that the request originated from. This should be true if your proxy has multiple proxy public addrs and you want the app to be accessible from any of them. If `public_addr` is explicitly set in the app spec, setting this value to true will overwrite that public address in the web UI.
 - `user_groups` (List of String) UserGroups are a list of user group IDs that this app is associated with.
@@ -184,3 +185,14 @@ Optional:
 
 - `end_port` (Number) EndPort describes the end of the range, inclusive. If set, it must be between 2 and 65535 and be greater than Port when describing a port range. When omitted or set to zero, it signifies that the port range defines a single port.
 - `port` (Number) Port describes the start of the range. It must be between 1 and 65535.
+
+
+### Nested Schema for `spec.tls`
+
+Optional:
+
+- `allowed_cas` (List of String) AllowedCas is the list of user provided CAs used for verifying upstream certificates. Accepted values are PEM-encoded CA certificates and Teleport CA aliases. Supported aliases: "workload_identity" (workload Identity CA. Allows accepting certificates issued by `tbot`).
+- `client_cert_mode` (String) ClientCertMode specifies which client certificate mode to use for the upstream connection. Supported values: "managed" (app service will issue client certificates to use in the app upstream connection, establishing mTLS connections), "disabled" (app upstream connection won't use client certificates).
+- `mode` (String) Mode defines the TLS verification. Supported values: "verify-full" (performs certificate validation, and asserts server name and SPIFFE ID), "verify-server-name" (performs certificate validation, and asserts server name), "verify-spiffe-id": (performs certificate validation, and asserts SPIFFE ID. Requires `server_spiffe_id` option), "insecure": (accepts any certificate provided by app)
+- `server_name` (String) ServerName specifies a custom hostname used for TLS verification against the upstream certificate.
+- `server_spiffe_id` (String) ServerSpiffeId specifies a SPIFFE ID that must be present on the server certificate.

--- a/examples/chart/teleport-cluster/charts/teleport-operator/operator-crds/resources.teleport.dev_appsv3.yaml
+++ b/examples/chart/teleport-cluster/charts/teleport-operator/operator-crds/resources.teleport.dev_appsv3.yaml
@@ -288,6 +288,44 @@ spec:
                   type: object
                 nullable: true
                 type: array
+              tls:
+                description: TLS contains the app TLS configuration.
+                nullable: true
+                properties:
+                  allowed_cas:
+                    description: 'AllowedCas is the list of user provided CAs used
+                      for verifying upstream certificates. Accepted values are PEM-encoded
+                      CA certificates and Teleport CA aliases. Supported aliases:
+                      "workload_identity" (workload Identity CA. Allows accepting
+                      certificates issued by `tbot`).'
+                    items:
+                      type: string
+                    nullable: true
+                    type: array
+                  client_cert_mode:
+                    description: 'ClientCertMode specifies which client certificate
+                      mode to use for the upstream connection. Supported values: "managed"
+                      (app service will issue client certificates to use in the app
+                      upstream connection, establishing mTLS connections), "disabled"
+                      (app upstream connection won''t use client certificates).'
+                    type: string
+                  mode:
+                    description: 'Mode defines the TLS verification. Supported values:
+                      "verify-full" (performs certificate validation, and asserts
+                      server name and SPIFFE ID), "verify-server-name" (performs certificate
+                      validation, and asserts server name), "verify-spiffe-id": (performs
+                      certificate validation, and asserts SPIFFE ID. Requires `server_spiffe_id`
+                      option), "insecure": (accepts any certificate provided by app)'
+                    type: string
+                  server_name:
+                    description: ServerName specifies a custom hostname used for TLS
+                      verification against the upstream certificate.
+                    type: string
+                  server_spiffe_id:
+                    description: ServerSpiffeId specifies a SPIFFE ID that must be
+                      present on the server certificate.
+                    type: string
+                type: object
               uri:
                 description: URI is the web app endpoint.
                 type: string

--- a/integrations/operator/config/crd/bases/resources.teleport.dev_appsv3.yaml
+++ b/integrations/operator/config/crd/bases/resources.teleport.dev_appsv3.yaml
@@ -288,6 +288,44 @@ spec:
                   type: object
                 nullable: true
                 type: array
+              tls:
+                description: TLS contains the app TLS configuration.
+                nullable: true
+                properties:
+                  allowed_cas:
+                    description: 'AllowedCas is the list of user provided CAs used
+                      for verifying upstream certificates. Accepted values are PEM-encoded
+                      CA certificates and Teleport CA aliases. Supported aliases:
+                      "workload_identity" (workload Identity CA. Allows accepting
+                      certificates issued by `tbot`).'
+                    items:
+                      type: string
+                    nullable: true
+                    type: array
+                  client_cert_mode:
+                    description: 'ClientCertMode specifies which client certificate
+                      mode to use for the upstream connection. Supported values: "managed"
+                      (app service will issue client certificates to use in the app
+                      upstream connection, establishing mTLS connections), "disabled"
+                      (app upstream connection won''t use client certificates).'
+                    type: string
+                  mode:
+                    description: 'Mode defines the TLS verification. Supported values:
+                      "verify-full" (performs certificate validation, and asserts
+                      server name and SPIFFE ID), "verify-server-name" (performs certificate
+                      validation, and asserts server name), "verify-spiffe-id": (performs
+                      certificate validation, and asserts SPIFFE ID. Requires `server_spiffe_id`
+                      option), "insecure": (accepts any certificate provided by app)'
+                    type: string
+                  server_name:
+                    description: ServerName specifies a custom hostname used for TLS
+                      verification against the upstream certificate.
+                    type: string
+                  server_spiffe_id:
+                    description: ServerSpiffeId specifies a SPIFFE ID that must be
+                      present on the server certificate.
+                    type: string
+                type: object
               uri:
                 description: URI is the web app endpoint.
                 type: string

--- a/integrations/terraform/tfschema/types_terraform.go
+++ b/integrations/terraform/tfschema/types_terraform.go
@@ -1158,6 +1158,37 @@ func GenSchemaAppV3(ctx context.Context) (github_com_hashicorp_terraform_plugin_
 					Description: "TCPPorts is a list of ports and port ranges that an app agent can forward connections to. Only applicable to TCP App Access. If this field is not empty, URI is expected to contain no port number and start with the tcp protocol.",
 					Optional:    true,
 				},
+				"tls": {
+					Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.SingleNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
+						"allowed_cas": {
+							Description: "AllowedCas is the list of user provided CAs used for verifying upstream certificates. Accepted values are PEM-encoded CA certificates and Teleport CA aliases. Supported aliases: \"workload_identity\" (workload Identity CA. Allows accepting certificates issued by `tbot`).",
+							Optional:    true,
+							Type:        github_com_hashicorp_terraform_plugin_framework_types.ListType{ElemType: github_com_hashicorp_terraform_plugin_framework_types.StringType},
+						},
+						"client_cert_mode": {
+							Description: "ClientCertMode specifies which client certificate mode to use for the upstream connection. Supported values: \"managed\" (app service will issue client certificates to use in the app upstream connection, establishing mTLS connections), \"disabled\" (app upstream connection won't use client certificates).",
+							Optional:    true,
+							Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
+						},
+						"mode": {
+							Description: "Mode defines the TLS verification. Supported values: \"verify-full\" (performs certificate validation, and asserts server name and SPIFFE ID), \"verify-server-name\" (performs certificate validation, and asserts server name), \"verify-spiffe-id\": (performs certificate validation, and asserts SPIFFE ID. Requires `server_spiffe_id` option), \"insecure\": (accepts any certificate provided by app)",
+							Optional:    true,
+							Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
+						},
+						"server_name": {
+							Description: "ServerName specifies a custom hostname used for TLS verification against the upstream certificate.",
+							Optional:    true,
+							Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
+						},
+						"server_spiffe_id": {
+							Description: "ServerSpiffeId specifies a SPIFFE ID that must be present on the server certificate.",
+							Optional:    true,
+							Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
+						},
+					}),
+					Description: "TLS contains the app TLS configuration.",
+					Optional:    true,
+				},
 				"uri": {
 					Description: "URI is the web app endpoint.",
 					Optional:    true,
@@ -13765,6 +13796,119 @@ func CopyAppV3FromTerraform(_ context.Context, tf github_com_hashicorp_terraform
 							}
 						}
 					}
+					{
+						a, ok := tf.Attrs["tls"]
+						if !ok {
+							diags.Append(attrReadMissingDiag{"AppV3.Spec.TLS"})
+						} else {
+							v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.Object)
+							if !ok {
+								diags.Append(attrReadConversionFailureDiag{"AppV3.Spec.TLS", "github.com/hashicorp/terraform-plugin-framework/types.Object"})
+							} else {
+								obj.TLS = nil
+								if !v.Null && !v.Unknown {
+									tf := v
+									obj.TLS = &github_com_gravitational_teleport_api_types.AppTLS{}
+									obj := obj.TLS
+									{
+										a, ok := tf.Attrs["mode"]
+										if !ok {
+											diags.Append(attrReadMissingDiag{"AppV3.Spec.TLS.mode"})
+										} else {
+											v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.String)
+											if !ok {
+												diags.Append(attrReadConversionFailureDiag{"AppV3.Spec.TLS.mode", "github.com/hashicorp/terraform-plugin-framework/types.String"})
+											} else {
+												var t string
+												if !v.Null && !v.Unknown {
+													t = string(v.Value)
+												}
+												obj.Mode = t
+											}
+										}
+									}
+									{
+										a, ok := tf.Attrs["server_name"]
+										if !ok {
+											diags.Append(attrReadMissingDiag{"AppV3.Spec.TLS.server_name"})
+										} else {
+											v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.String)
+											if !ok {
+												diags.Append(attrReadConversionFailureDiag{"AppV3.Spec.TLS.server_name", "github.com/hashicorp/terraform-plugin-framework/types.String"})
+											} else {
+												var t string
+												if !v.Null && !v.Unknown {
+													t = string(v.Value)
+												}
+												obj.ServerName = t
+											}
+										}
+									}
+									{
+										a, ok := tf.Attrs["server_spiffe_id"]
+										if !ok {
+											diags.Append(attrReadMissingDiag{"AppV3.Spec.TLS.server_spiffe_id"})
+										} else {
+											v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.String)
+											if !ok {
+												diags.Append(attrReadConversionFailureDiag{"AppV3.Spec.TLS.server_spiffe_id", "github.com/hashicorp/terraform-plugin-framework/types.String"})
+											} else {
+												var t string
+												if !v.Null && !v.Unknown {
+													t = string(v.Value)
+												}
+												obj.ServerSpiffeId = t
+											}
+										}
+									}
+									{
+										a, ok := tf.Attrs["allowed_cas"]
+										if !ok {
+											diags.Append(attrReadMissingDiag{"AppV3.Spec.TLS.allowed_cas"})
+										} else {
+											v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.List)
+											if !ok {
+												diags.Append(attrReadConversionFailureDiag{"AppV3.Spec.TLS.allowed_cas", "github.com/hashicorp/terraform-plugin-framework/types.List"})
+											} else {
+												obj.AllowedCas = make([]string, len(v.Elems))
+												if !v.Null && !v.Unknown {
+													for k, a := range v.Elems {
+														v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.String)
+														if !ok {
+															diags.Append(attrReadConversionFailureDiag{"AppV3.Spec.TLS.allowed_cas", "github_com_hashicorp_terraform_plugin_framework_types.String"})
+														} else {
+															var t string
+															if !v.Null && !v.Unknown {
+																t = string(v.Value)
+															}
+															obj.AllowedCas[k] = t
+														}
+													}
+												}
+											}
+										}
+									}
+									{
+										a, ok := tf.Attrs["client_cert_mode"]
+										if !ok {
+											diags.Append(attrReadMissingDiag{"AppV3.Spec.TLS.client_cert_mode"})
+										} else {
+											v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.String)
+											if !ok {
+												diags.Append(attrReadConversionFailureDiag{"AppV3.Spec.TLS.client_cert_mode", "github.com/hashicorp/terraform-plugin-framework/types.String"})
+											} else {
+												var t string
+												if !v.Null && !v.Unknown {
+													t = string(v.Value)
+												}
+												obj.ClientCertMode = t
+											}
+										}
+									}
+								}
+							}
+						}
+					}
 				}
 			}
 		}
@@ -15686,6 +15830,179 @@ func CopyAppV3ToTerraform(ctx context.Context, obj *github_com_gravitational_tel
 								}
 								v.Unknown = false
 								tf.Attrs["inference"] = v
+							}
+						}
+					}
+					{
+						a, ok := tf.AttrTypes["tls"]
+						if !ok {
+							diags.Append(attrWriteMissingDiag{"AppV3.Spec.TLS"})
+						} else {
+							o, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.ObjectType)
+							if !ok {
+								diags.Append(attrWriteConversionFailureDiag{"AppV3.Spec.TLS", "github.com/hashicorp/terraform-plugin-framework/types.ObjectType"})
+							} else {
+								v, ok := tf.Attrs["tls"].(github_com_hashicorp_terraform_plugin_framework_types.Object)
+								if !ok {
+									v = github_com_hashicorp_terraform_plugin_framework_types.Object{
+
+										AttrTypes: o.AttrTypes,
+										Attrs:     make(map[string]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(o.AttrTypes)),
+									}
+								} else {
+									if v.Attrs == nil {
+										v.Attrs = make(map[string]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(tf.AttrTypes))
+									}
+								}
+								if obj.TLS == nil {
+									v.Null = true
+								} else {
+									obj := obj.TLS
+									tf := &v
+									{
+										t, ok := tf.AttrTypes["mode"]
+										if !ok {
+											diags.Append(attrWriteMissingDiag{"AppV3.Spec.TLS.mode"})
+										} else {
+											v, ok := tf.Attrs["mode"].(github_com_hashicorp_terraform_plugin_framework_types.String)
+											if !ok {
+												i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
+												if err != nil {
+													diags.Append(attrWriteGeneralError{"AppV3.Spec.TLS.mode", err})
+												}
+												v, ok = i.(github_com_hashicorp_terraform_plugin_framework_types.String)
+												if !ok {
+													diags.Append(attrWriteConversionFailureDiag{"AppV3.Spec.TLS.mode", "github.com/hashicorp/terraform-plugin-framework/types.String"})
+												}
+												v.Null = string(obj.Mode) == ""
+											}
+											v.Value = string(obj.Mode)
+											v.Unknown = false
+											tf.Attrs["mode"] = v
+										}
+									}
+									{
+										t, ok := tf.AttrTypes["server_name"]
+										if !ok {
+											diags.Append(attrWriteMissingDiag{"AppV3.Spec.TLS.server_name"})
+										} else {
+											v, ok := tf.Attrs["server_name"].(github_com_hashicorp_terraform_plugin_framework_types.String)
+											if !ok {
+												i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
+												if err != nil {
+													diags.Append(attrWriteGeneralError{"AppV3.Spec.TLS.server_name", err})
+												}
+												v, ok = i.(github_com_hashicorp_terraform_plugin_framework_types.String)
+												if !ok {
+													diags.Append(attrWriteConversionFailureDiag{"AppV3.Spec.TLS.server_name", "github.com/hashicorp/terraform-plugin-framework/types.String"})
+												}
+												v.Null = string(obj.ServerName) == ""
+											}
+											v.Value = string(obj.ServerName)
+											v.Unknown = false
+											tf.Attrs["server_name"] = v
+										}
+									}
+									{
+										t, ok := tf.AttrTypes["server_spiffe_id"]
+										if !ok {
+											diags.Append(attrWriteMissingDiag{"AppV3.Spec.TLS.server_spiffe_id"})
+										} else {
+											v, ok := tf.Attrs["server_spiffe_id"].(github_com_hashicorp_terraform_plugin_framework_types.String)
+											if !ok {
+												i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
+												if err != nil {
+													diags.Append(attrWriteGeneralError{"AppV3.Spec.TLS.server_spiffe_id", err})
+												}
+												v, ok = i.(github_com_hashicorp_terraform_plugin_framework_types.String)
+												if !ok {
+													diags.Append(attrWriteConversionFailureDiag{"AppV3.Spec.TLS.server_spiffe_id", "github.com/hashicorp/terraform-plugin-framework/types.String"})
+												}
+												v.Null = string(obj.ServerSpiffeId) == ""
+											}
+											v.Value = string(obj.ServerSpiffeId)
+											v.Unknown = false
+											tf.Attrs["server_spiffe_id"] = v
+										}
+									}
+									{
+										a, ok := tf.AttrTypes["allowed_cas"]
+										if !ok {
+											diags.Append(attrWriteMissingDiag{"AppV3.Spec.TLS.allowed_cas"})
+										} else {
+											o, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.ListType)
+											if !ok {
+												diags.Append(attrWriteConversionFailureDiag{"AppV3.Spec.TLS.allowed_cas", "github.com/hashicorp/terraform-plugin-framework/types.ListType"})
+											} else {
+												c, ok := tf.Attrs["allowed_cas"].(github_com_hashicorp_terraform_plugin_framework_types.List)
+												if !ok {
+													c = github_com_hashicorp_terraform_plugin_framework_types.List{
+
+														ElemType: o.ElemType,
+														Elems:    make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.AllowedCas)),
+														Null:     true,
+													}
+												} else {
+													if c.Elems == nil {
+														c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.AllowedCas))
+													}
+												}
+												if obj.AllowedCas != nil {
+													t := o.ElemType
+													if len(obj.AllowedCas) != len(c.Elems) {
+														c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.AllowedCas))
+													}
+													for k, a := range obj.AllowedCas {
+														v, ok := tf.Attrs["allowed_cas"].(github_com_hashicorp_terraform_plugin_framework_types.String)
+														if !ok {
+															i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
+															if err != nil {
+																diags.Append(attrWriteGeneralError{"AppV3.Spec.TLS.allowed_cas", err})
+															}
+															v, ok = i.(github_com_hashicorp_terraform_plugin_framework_types.String)
+															if !ok {
+																diags.Append(attrWriteConversionFailureDiag{"AppV3.Spec.TLS.allowed_cas", "github.com/hashicorp/terraform-plugin-framework/types.String"})
+															}
+															v.Null = string(a) == ""
+														}
+														v.Value = string(a)
+														v.Unknown = false
+														c.Elems[k] = v
+													}
+													if len(obj.AllowedCas) > 0 {
+														c.Null = false
+													}
+												}
+												c.Unknown = false
+												tf.Attrs["allowed_cas"] = c
+											}
+										}
+									}
+									{
+										t, ok := tf.AttrTypes["client_cert_mode"]
+										if !ok {
+											diags.Append(attrWriteMissingDiag{"AppV3.Spec.TLS.client_cert_mode"})
+										} else {
+											v, ok := tf.Attrs["client_cert_mode"].(github_com_hashicorp_terraform_plugin_framework_types.String)
+											if !ok {
+												i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
+												if err != nil {
+													diags.Append(attrWriteGeneralError{"AppV3.Spec.TLS.client_cert_mode", err})
+												}
+												v, ok = i.(github_com_hashicorp_terraform_plugin_framework_types.String)
+												if !ok {
+													diags.Append(attrWriteConversionFailureDiag{"AppV3.Spec.TLS.client_cert_mode", "github.com/hashicorp/terraform-plugin-framework/types.String"})
+												}
+												v.Null = string(obj.ClientCertMode) == ""
+											}
+											v.Value = string(obj.ClientCertMode)
+											v.Unknown = false
+											tf.Attrs["client_cert_mode"] = v
+										}
+									}
+								}
+								v.Unknown = false
+								tf.Attrs["tls"] = v
 							}
 						}
 					}

--- a/lib/config/configuration.go
+++ b/lib/config/configuration.go
@@ -2169,6 +2169,23 @@ func applyAppsConfig(fc *FileConfig, cfg *servicecfg.Config) error {
 			}
 		}
 
+		if application.TLS != nil {
+			app.TLS = &types.AppTLS{
+				Mode:           application.TLS.Mode,
+				ServerName:     application.TLS.ServerName,
+				ServerSpiffeId: application.TLS.ServerSpiffeId,
+				AllowedCas:     application.TLS.AllowedCas,
+				ClientCertMode: application.TLS.ClientCertMode,
+			}
+			for _, caCertPath := range application.TLS.AllowedCasFiles {
+				caCertContents, err := os.ReadFile(caCertPath)
+				if err != nil {
+					return trace.ConvertSystemError(err)
+				}
+				app.TLS.AllowedCas = append(app.TLS.AllowedCas, string(caCertContents))
+			}
+		}
+
 		if err := app.CheckAndSetDefaults(); err != nil {
 			return trace.Wrap(err)
 		}

--- a/lib/config/configuration_test.go
+++ b/lib/config/configuration_test.go
@@ -473,6 +473,18 @@ func TestConfigReading(t *testing.T) {
 						FallbackModel: "claude-opus-4-6",
 					},
 				},
+				{
+					Name:         "grpc-with-mtls",
+					StaticLabels: Labels,
+					URI:          "tcp://127.0.0.1:8080",
+					TLS: &AppTLS{
+						Mode:           types.AppTLSModeVerifyFull,
+						ServerName:     "example.com",
+						ServerSpiffeId: "spiffe://mycluster/svc/example",
+						AllowedCas:     []string{types.AppTLSInternalCAWorkloadIdentity},
+						ClientCertMode: types.AppClientCertModeManaged,
+					},
+				},
 			},
 			ResourceMatchers: []ResourceMatcher{
 				{
@@ -1696,6 +1708,18 @@ func makeConfigFixture() string {
 				FallbackModel: "claude-opus-4-6",
 			},
 		},
+		{
+			Name:         "grpc-with-mtls",
+			StaticLabels: Labels,
+			URI:          "tcp://127.0.0.1:8080",
+			TLS: &AppTLS{
+				Mode:           types.AppTLSModeVerifyFull,
+				ServerName:     "example.com",
+				ServerSpiffeId: "spiffe://mycluster/svc/example",
+				AllowedCas:     []string{types.AppTLSInternalCAWorkloadIdentity},
+				ClientCertMode: types.AppClientCertModeManaged,
+			},
+		},
 	}
 	conf.Apps.ResourceMatchers = []ResourceMatcher{
 		{
@@ -2685,6 +2709,35 @@ app_service:
 			name:   "LLM inference endpoint",
 			outErr: require.NoError,
 		},
+		{
+			inConfigString: `
+app_service:
+  enabled: true
+  apps:
+    - name: app-tls
+      uri: https://localhost:8080
+      tls:
+        mode: verify-full
+        client_cert_mode: managed
+`,
+			name:   "App TLS configuration",
+			outErr: require.NoError,
+		},
+		{
+			inConfigString: `
+app_service:
+  enabled: true
+  apps:
+    - name: app-tls
+      uri: https://localhost:8080
+      tls:
+        mode: verify-full
+        allowed_cas_files:
+        - _random-file.pem
+`,
+			name:   "App TLS configuration fails to read file",
+			outErr: require.Error,
+		},
 	}
 
 	for _, tt := range tests {
@@ -3336,6 +3389,76 @@ func TestTLSCert(t *testing.T) {
 
 			require.Len(t, cfg.Databases.Databases, 1)
 			require.Equal(t, fixtures.LocalhostCert, cfg.Databases.Databases[0].TLS.CACert)
+		})
+	}
+}
+
+func TestAppTLSCert(t *testing.T) {
+	tmpDir := t.TempDir()
+	tmpCA := filepath.Join(tmpDir, "ca.pem")
+
+	err := os.WriteFile(tmpCA, fixtures.LocalhostCert, 0o644)
+	require.NoError(t, err)
+
+	tests := []struct {
+		name               string
+		conf               *FileConfig
+		expectedAllowedCas []string
+	}{
+		{
+			"only files",
+			&FileConfig{
+				Apps: Apps{
+					Service: Service{
+						EnabledFlag: "true",
+					},
+					Apps: []*App{
+						{
+							Name: "test-app-1",
+							URI:  "https://localhost:1234",
+							TLS: &AppTLS{
+								Mode:            types.AppTLSModeVerifyFull,
+								AllowedCasFiles: []string{tmpCA},
+							},
+						},
+					},
+				},
+			},
+			[]string{string(fixtures.LocalhostCert)},
+		},
+		{
+			"mixed configuration",
+			&FileConfig{
+				Apps: Apps{
+					Service: Service{
+						EnabledFlag: "true",
+					},
+					Apps: []*App{
+						{
+							Name: "test-app-1",
+							URI:  "https://localhost:1234",
+							TLS: &AppTLS{
+								Mode:            types.AppTLSModeVerifyFull,
+								AllowedCas:      []string{types.AppTLSInternalCAWorkloadIdentity, string(fixtures.LocalhostCert)},
+								AllowedCasFiles: []string{tmpCA},
+							},
+						},
+					},
+				},
+			},
+			[]string{types.AppTLSInternalCAWorkloadIdentity, string(fixtures.LocalhostCert), string(fixtures.LocalhostCert)},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := servicecfg.MakeDefaultConfig()
+
+			err = ApplyFileConfig(tt.conf, cfg)
+			require.NoError(t, err)
+
+			require.Len(t, cfg.Apps.Apps, 1)
+			require.ElementsMatch(t, tt.expectedAllowedCas, cfg.Apps.Apps[0].TLS.AllowedCas)
 		})
 	}
 }

--- a/lib/config/fileconf.go
+++ b/lib/config/fileconf.go
@@ -2474,6 +2474,9 @@ type App struct {
 
 	// LLM contains LLM inference endpoint related configurations.
 	LLM *LLM `yaml:"inference,omitempty"`
+
+	// TLS contains the app TLS configuration.
+	TLS *AppTLS `yaml:"tls,omitempty"`
 }
 
 // CORS represents the configuration for Cross-Origin Resource Sharing (CORS)
@@ -2564,6 +2567,28 @@ type LLMModel struct {
 	Name string `yaml:"name"`
 	// ProviderName is the model name in the configured provider.
 	ProviderName string `yaml:"provider_name,omitempty"`
+}
+
+// AppTLS contains the app TLS configuration.
+type AppTLS struct {
+	// Mode defines the TLS verification.
+	Mode string `yaml:"mode,omitempty"`
+	// ServerName specifies a custom hostname used for TLS verification against
+	// the upstream certificate.
+	ServerName string `yaml:"server_name,omitempty"`
+	// ServerSpiffeId specifies a SPIFFE ID that must be present on the server
+	// certificate.
+	ServerSpiffeId string `yaml:"server_spiffe_id,omitempty"`
+	// AllowedCas is the list of user provided CAs used for verifying upstream
+	// certificates. Accepted values are PEM-encoded CA certificates and
+	// Teleport CA aliases.
+	AllowedCas []string `yaml:"allowed_cas,omitempty"`
+	// AllowedCasFiles list of CA certificates file paths that will be used for
+	// verifying upstream certificates.
+	AllowedCasFiles []string `yaml:"allowed_cas_files,omitempty"`
+	// ClientCertMode specifies which client certificate mode to use for the
+	// upstream connection.
+	ClientCertMode string `yaml:"client_cert_mode,omitempty"`
 }
 
 // Proxy is a `proxy_service` section of the config file:

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -6757,6 +6757,7 @@ func (process *TeleportProcess) initApps() {
 				TCPPorts:              makeApplicationTCPPorts(app.TCPPorts),
 				MCP:                   app.MCP,
 				LLM:                   app.LLM,
+				TLS:                   app.TLS,
 			})
 			if err != nil {
 				return trace.Wrap(err)

--- a/lib/service/service_test.go
+++ b/lib/service/service_test.go
@@ -2549,7 +2549,6 @@ func TestInitAppsFromConfig(t *testing.T) {
 
 	authDir := t.TempDir()
 	cfg := servicecfg.MakeDefaultConfig()
-	cfg.InsecureMode = true
 	cfg.Version = defaults.TeleportConfigVersionV3
 	cfg.DataDir = authDir
 	cfg.Auth.Enabled = true

--- a/lib/service/service_test.go
+++ b/lib/service/service_test.go
@@ -48,10 +48,12 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/protobuf/testing/protocmp"
 
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api"
 	"github.com/gravitational/teleport/api/breaker"
+	apidefaults "github.com/gravitational/teleport/api/defaults"
 	autoupdatepb "github.com/gravitational/teleport/api/gen/proto/go/teleport/autoupdate/v1"
 	"github.com/gravitational/teleport/api/types"
 	autoupdate "github.com/gravitational/teleport/api/types/autoupdate"
@@ -2538,4 +2540,133 @@ func TestInitKubernetesUnlicensed(t *testing.T) {
 	okEvent, err := process.WaitForEventTimeout(5*time.Second, TeleportOKEvent)
 	require.NoError(t, err)
 	require.Equal(t, teleport.ComponentKube, okEvent.Payload)
+}
+
+// TestInitAppsFromConfig given a list of static apps, ensure that they are
+// correctly registered.
+func TestInitAppsFromConfig(t *testing.T) {
+	t.Parallel()
+
+	authDir := t.TempDir()
+	cfg := servicecfg.MakeDefaultConfig()
+	cfg.InsecureMode = true
+	cfg.Version = defaults.TeleportConfigVersionV3
+	cfg.DataDir = authDir
+	cfg.Auth.Enabled = true
+	cfg.Auth.ListenAddr.Addr = newListener(t, ListenerAuth, &cfg.FileDescriptors)
+	cfg.SetAuthServerAddress(cfg.Auth.ListenAddr)
+	cfg.Auth.StorageConfig.Params = backend.Params{defaults.BackendPath: filepath.Join(authDir, defaults.BackendDir)}
+	var err error
+	cfg.Auth.ClusterName, err = services.NewClusterNameWithRandomID(types.ClusterNameSpecV2{
+		ClusterName: "auth-server",
+	})
+	require.NoError(t, err)
+	cfg.Auth.NetworkingConfig.SetProxyListenerMode(types.ProxyListenerMode_Multiplex)
+
+	cfg.Proxy.Enabled = true
+	cfg.Proxy.DisableWebInterface = true
+	cfg.Proxy.WebAddr.Addr = newListener(t, ListenerProxyWeb, &cfg.FileDescriptors)
+
+	cfg.SSH.Enabled = false
+	cfg.Apps.Enabled = true
+	cfg.Apps.Apps = []servicecfg.App{
+		{
+			Name: "example-http",
+			URI:  "http://localhost:8080",
+		},
+		{
+			Name: "example-mtls",
+			URI:  "https://localhost:8080",
+			TLS: &types.AppTLS{
+				Mode:           types.AppTLSModeVerifyFull,
+				ServerName:     "localhost",
+				ServerSpiffeId: "spiffe://mycluster/svc/local",
+				ClientCertMode: types.AppClientCertModeManaged,
+			},
+		},
+		{
+			Name: "example-llm",
+			URI:  "llm://",
+			LLM: &types.LLM{
+				Format:        types.LLMFormatAnthropic,
+				Provider:      types.LLMProviderAWSBedrock,
+				Models:        []*types.LLM_Model{{Name: "claude-opus-4-7", ProviderName: "global.claude-opus-4-7"}},
+				FallbackModel: "claude-opus-4-7",
+			},
+		},
+	}
+
+	process, err := NewTeleport(cfg)
+	require.NoError(t, err)
+
+	authC := process.GetAuthServer()
+	watchCtx, watchCancel := context.WithTimeout(t.Context(), 20*time.Second)
+	watcher, err := authC.NewWatcher(watchCtx, types.Watch{
+		Kinds: []types.WatchKind{{Kind: types.KindAppServer}},
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		watchCancel()
+		_ = watcher.Close()
+	})
+
+	require.NoError(t, process.Start())
+	t.Cleanup(func() {
+		_ = process.Close()
+		_ = process.Wait()
+	})
+
+	_, err = process.WaitForEventTimeout(5*time.Second, TeleportReadyEvent)
+	require.NoError(t, err)
+
+	// Ensure watcher starts correctly.
+	select {
+	case ev := <-watcher.Events():
+		require.Equal(t, types.OpInit, ev.Type)
+	case <-watcher.Done():
+		t.Fatalf("watcher closed before init: %v", watcher.Error())
+	case <-watchCtx.Done():
+		t.Fatal("timed out waiting for watcher init")
+	}
+
+	// Subscribe to backend writes for KindAppServer so we can assert their
+	// contents. This is required because the available process events don't
+	// guarantee that the heartbeat event is fired after the resource is
+	// persisted.
+	expected := make(map[string]struct{}, len(cfg.Apps.Apps))
+	for _, a := range cfg.Apps.Apps {
+		expected[a.Name] = struct{}{}
+	}
+	for len(expected) > 0 {
+		select {
+		case ev := <-watcher.Events():
+			if ev.Type != types.OpPut {
+				continue
+			}
+			srv, ok := ev.Resource.(types.AppServer)
+			if !ok {
+				continue
+			}
+			delete(expected, srv.GetApp().GetName())
+		case <-watcher.Done():
+			t.Fatalf("watcher closed before all apps were registered: %v", watcher.Error())
+		case <-watchCtx.Done():
+			t.Fatalf("timed out waiting for app servers, still expecting: %v", expected)
+		}
+	}
+
+	servers, err := authC.GetApplicationServers(t.Context(), apidefaults.Namespace)
+	require.NoError(t, err)
+
+	byName := make(map[string]types.Application, len(servers))
+	for _, s := range servers {
+		byName[s.GetApp().GetName()] = s.GetApp()
+	}
+	for _, appCfg := range cfg.Apps.Apps {
+		app, ok := byName[appCfg.Name]
+		require.True(t, ok, "expected app %q to be registered", appCfg.Name)
+		require.Equal(t, appCfg.URI, app.GetURI())
+		require.Empty(t, cmp.Diff(appCfg.TLS, app.GetTLS(), protocmp.Transform()))
+		require.Empty(t, cmp.Diff(appCfg.LLM, app.GetLLM(), protocmp.Transform()))
+	}
 }

--- a/lib/service/servicecfg/app.go
+++ b/lib/service/servicecfg/app.go
@@ -117,6 +117,9 @@ type App struct {
 
 	// LLM contains LLM inference endpoint related configurations.
 	LLM *types.LLM
+
+	// TLS contains the app TLS configuration.
+	TLS *types.AppTLS
 }
 
 // CORS represents the configuration for Cross-Origin Resource Sharing (CORS)

--- a/lib/services/app.go
+++ b/lib/services/app.go
@@ -21,16 +21,19 @@ package services
 import (
 	"cmp"
 	"context"
+	"crypto/x509"
 	"fmt"
 	"iter"
 	"log/slog"
 	"net/http"
 	"net/url"
 	"os"
+	"slices"
 	"strings"
 	"sync"
 
 	"github.com/gravitational/trace"
+	"github.com/spiffe/go-spiffe/v2/spiffeid"
 	"golang.org/x/net/idna"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/validation"
@@ -40,6 +43,7 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/types/wrappers"
 	"github.com/gravitational/teleport/api/utils/clientutils"
+	"github.com/gravitational/teleport/api/utils/tlsutils"
 	"github.com/gravitational/teleport/lib/utils"
 )
 
@@ -71,6 +75,12 @@ type Applications interface {
 
 // ValidateApp validates the Application resource.
 func ValidateApp(app types.Application, proxyGetter ProxyGetter) error {
+	if app.GetTLS() != nil {
+		if err := validateAppTLS(app); err != nil {
+			return trace.Wrap(err)
+		}
+	}
+
 	// If no public address is set, there's nothing to validate.
 	if app.GetPublicAddr() == "" {
 		return nil
@@ -126,6 +136,106 @@ func ValidateApp(app types.Application, proxyGetter ProxyGetter) error {
 					app.GetPublicAddr(),
 				)
 			}
+		}
+	}
+
+	return nil
+}
+
+// validateAppTLS validates application TLS options.
+func validateAppTLS(a types.Application) error {
+	if !types.AppSupportsTLSConfig(a.GetURI()) {
+		return trace.BadParameter(
+			"App %q can only specify 'tls' settings for URI schemes that use upstream TLS. Supported schemes are: %s",
+			a.GetName(),
+			quoteAndJoin(types.AppSchemesWithTLSSupport),
+		)
+	}
+
+	tls := a.GetTLS()
+	var mode types.AppTLSMode
+	switch tls.Mode {
+	case types.AppTLSModeInsecure,
+		types.AppTLSModeVerifyFull,
+		types.AppTLSModeVerifyServerName,
+		types.AppTLSModeVerifySpiffeID:
+		mode = tls.Mode
+	case "":
+		// When not specified, use the evaluated mode.
+		mode = a.GetTLSMode()
+	default:
+		return trace.BadParameter(
+			"App %q has invalid 'tls.mode' %q. Supported values are: %s",
+			a.GetName(),
+			tls.Mode,
+			quoteAndJoin([]string{
+				types.AppTLSModeInsecure,
+				types.AppTLSModeVerifyFull,
+				types.AppTLSModeVerifyServerName,
+				types.AppTLSModeVerifySpiffeID,
+			}),
+		)
+	}
+
+	if a.GetInsecureSkipVerify() && mode != types.AppTLSModeInsecure {
+		return trace.BadParameter(
+			"App %q cannot specify 'insecure_skip_verify: true' (deprecated) and 'tls.mode: %q'. Drop 'insecure_skip_verify', and if you want the app to use insecure connections set 'tls.mode: %q'",
+			a.GetName(),
+			mode,
+			types.AppTLSModeInsecure,
+		)
+	}
+
+	switch tls.ClientCertMode {
+	case types.AppClientCertModeManaged:
+		if mode == types.AppTLSModeInsecure {
+			return trace.BadParameter("App %q can only enable 'tls.client_cert_mode' when 'tls.mode' is %q", a.GetName(), types.AppTLSModeVerifyFull)
+		}
+	case types.AppClientCertModeDisabled, "":
+	default:
+		return trace.BadParameter(
+			"App %q has invalid 'tls.client_cert_mode'. Supported values are: %s",
+			a.GetName(),
+			quoteAndJoin([]string{"", types.AppClientCertModeDisabled, types.AppClientCertModeManaged}),
+		)
+	}
+
+	switch mode {
+	case types.AppTLSModeVerifyFull:
+		// Note: tls.ServerName is optional and doesn't require any specific validation.
+		if err := isValidSpiffeID(tls.ServerSpiffeId); err != nil {
+			return trace.BadParameter("App %q has invalid `tls.server_spiffe_id`. The SPIFFE ID must be complete (trust domain and path) and start with 'spiffe://': %v", a.GetName(), err)
+		}
+	case types.AppTLSModeVerifyServerName:
+		// Note: tls.ServerName is optional and doesn't require any specific validation.
+		if tls.ServerSpiffeId != "" {
+			return trace.BadParameter("App %q 'tls.server_spiffe_id' is not used when mode is set to %q. To perform both, server name and SPIFFE ID verifications use %q mode", a.GetName(), mode, types.AppTLSModeVerifyFull)
+		}
+	case types.AppTLSModeVerifySpiffeID:
+		if err := isValidSpiffeID(tls.ServerSpiffeId); err != nil {
+			return trace.BadParameter("App %q has invalid `tls.server_spiffe_id`. The SPIFFE ID must be complete (trust domain and path) and start with 'spiffe://': %v", a.GetName(), err)
+		}
+		if tls.ServerName != "" {
+			return trace.BadParameter("App %q 'tls.server_name' is not used when mode is set to %q. To perform both, server name and SPIFFE ID verifications use %q mode", a.GetName(), mode, types.AppTLSModeVerifyFull)
+		}
+	case types.AppTLSModeInsecure:
+		if tls.ServerName != "" || tls.ServerSpiffeId != "" || len(tls.AllowedCas) > 0 {
+			return trace.BadParameter("App %q 'tls' are not in use since mode is set to %q", a.GetName(), mode)
+		}
+	}
+
+	supportedCAs := types.AppSupportedInternalCAs()
+	for _, allowedCA := range tls.AllowedCas {
+		if slices.Contains(supportedCAs, allowedCA) {
+			continue
+		}
+		if err := isValidCACertificatePEM(allowedCA); err != nil {
+			return trace.BadParameter(
+				"App %q 'tls.allowed_cas' values must include valid PEM-encoded CA certificates or a Teleport CA alias (%s): %s",
+				a.GetName(),
+				quoteAndJoin(supportedCAs),
+				err,
+			)
 		}
 	}
 
@@ -408,4 +518,41 @@ func RewriteHeadersAndApplyValueTraits(r *http.Request, rewrites iter.Seq[*types
 			}
 		}
 	}
+}
+
+// isValidSpiffeID validates that s contains a valid SPIFFE ID.
+func isValidSpiffeID(s string) error {
+	_, err := spiffeid.FromString(s)
+	return err
+}
+
+// isValidCACertificatePEM validates that s contains valid PEM-encoded CA
+// certificate.
+func isValidCACertificatePEM(s string) error {
+	cert, err := tlsutils.ParseCertificatePEMStrict([]byte(s))
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	switch {
+	case !cert.BasicConstraintsValid || !cert.IsCA:
+		return trace.BadParameter("certificate %q is not a CA", cert.Subject.String())
+	case cert.KeyUsage != 0 && cert.KeyUsage&x509.KeyUsageCertSign == 0:
+		return trace.BadParameter("CA certificate %q does not allow certificate signing", cert.Subject.String())
+	}
+
+	return nil
+}
+
+// quoteAndJoin takes a slice of strings and returns them quoted and
+// comma-separated.
+func quoteAndJoin(items []string) string {
+	if len(items) == 0 {
+		return ""
+	}
+	quotedItems := make([]string, len(items))
+	for i, item := range items {
+		quotedItems[i] = `"` + item + `"`
+	}
+	return strings.Join(quotedItems, ", ")
 }

--- a/lib/services/app_test.go
+++ b/lib/services/app_test.go
@@ -19,12 +19,14 @@
 package services
 
 import (
+	"bytes"
 	"context"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"slices"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -32,6 +34,9 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/cryptosuites"
+	"github.com/gravitational/teleport/lib/tlsca"
+	"github.com/gravitational/teleport/lib/tlscatest"
 	"github.com/gravitational/teleport/lib/utils"
 )
 
@@ -229,6 +234,12 @@ func TestApplicationUnmarshal(t *testing.T) {
 		Labels:      map[string]string{"env": "dev"},
 	}, types.AppSpecV3{
 		URI: "http://localhost:8080",
+		TLS: &types.AppTLS{
+			Mode:           types.AppTLSModeVerifyFull,
+			ServerName:     "localhost",
+			ServerSpiffeId: "spiffe://mycluster/svc/localhost",
+			ClientCertMode: types.AppClientCertModeManaged,
+		},
 	})
 	require.NoError(t, err)
 	data, err := utils.ToJSON([]byte(appYAML))
@@ -245,7 +256,13 @@ func TestApplicationMarshal(t *testing.T) {
 		Description: "Test description",
 		Labels:      map[string]string{"env": "dev"},
 	}, types.AppSpecV3{
-		URI: "http://localhost:8080",
+		URI: "https://localhost:8080",
+		TLS: &types.AppTLS{
+			Mode:           types.AppTLSModeVerifyFull,
+			ServerName:     "localhost",
+			ServerSpiffeId: "spiffe://mycluster/svc/localhost",
+			ClientCertMode: types.AppClientCertModeManaged,
+		},
 	})
 	require.NoError(t, err)
 	data, err := MarshalApp(expected)
@@ -263,7 +280,12 @@ metadata:
   labels:
     env: dev
 spec:
-  uri: "http://localhost:8080"`
+  uri: "http://localhost:8080"
+  tls:
+    mode: verify-full
+    server_name: localhost
+    server_spiffe_id: spiffe://mycluster/svc/localhost
+    client_cert_mode: managed`
 
 func TestGetAppName(t *testing.T) {
 	tests := []struct {
@@ -588,4 +610,239 @@ func TestRewriteHeadersAndApplyValueTraits(t *testing.T) {
 	wantHeaders.Add("x-rewrite", "value2")
 	wantHeaders.Add("x-no-rewrite", "no-rewrite")
 	assert.Equal(t, wantHeaders, r.Header)
+}
+
+func TestValidateAppTLS(t *testing.T) {
+	for name, tc := range map[string]struct {
+		uri          string
+		tls          *types.AppTLS
+		insecureSkip bool
+		expectErr    require.ErrorAssertionFunc
+	}{
+		"full valid configuration": {
+			tls: &types.AppTLS{
+				Mode:           types.AppTLSModeVerifyFull,
+				ServerName:     "example.com",
+				ServerSpiffeId: "spiffe://mycluster/svc/example",
+				AllowedCas:     []string{types.AppTLSInternalCAWorkloadIdentity},
+				ClientCertMode: types.AppClientCertModeManaged,
+			},
+			expectErr: require.NoError,
+		},
+		"mcp https valid configuration": {
+			uri: "mcp+https://localhost",
+			tls: &types.AppTLS{
+				Mode:           types.AppTLSModeVerifyFull,
+				ServerSpiffeId: "spiffe://mycluster/svc/mcp",
+				ClientCertMode: types.AppClientCertModeManaged,
+			},
+			expectErr: require.NoError,
+		},
+		"minimal": {
+			tls: &types.AppTLS{
+				Mode: types.AppTLSModeVerifyServerName,
+			},
+			expectErr: require.NoError,
+		},
+		"insecure with client cert mode": {
+			tls: &types.AppTLS{
+				Mode:           types.AppTLSModeInsecure,
+				ClientCertMode: types.AppClientCertModeManaged,
+			},
+			expectErr: require.Error,
+		},
+		"conflicting insecure skip verify and tls mode": {
+			tls: &types.AppTLS{
+				Mode: types.AppTLSModeVerifyServerName,
+			},
+			insecureSkip: true,
+			expectErr:    require.Error,
+		},
+		"incomplete server spiffe id": {
+			tls: &types.AppTLS{
+				Mode:           types.AppTLSModeVerifySpiffeID,
+				ServerSpiffeId: "/svc/example",
+			},
+			expectErr: require.Error,
+		},
+		"verify spiffe id mode and with server name": {
+			tls: &types.AppTLS{
+				Mode:           types.AppTLSModeVerifySpiffeID,
+				ServerName:     "example.com",
+				ServerSpiffeId: "spiffe://mycluster/svc/example",
+			},
+			expectErr: require.Error,
+		},
+		"invalid mode": {
+			tls: &types.AppTLS{
+				Mode: "invalid",
+			},
+			expectErr: require.Error,
+		},
+		"invalid allowed CA": {
+			tls: &types.AppTLS{
+				Mode:       types.AppTLSModeVerifyFull,
+				AllowedCas: []string{"workload_identity", "malformed cert"},
+			},
+			expectErr: require.Error,
+		},
+		"server name with insecure mode": {
+			tls: &types.AppTLS{
+				Mode:       types.AppTLSModeInsecure,
+				ServerName: "example.com",
+			},
+			expectErr: require.Error,
+		},
+		"server spiffe id with insecure mode": {
+			tls: &types.AppTLS{
+				Mode:           types.AppTLSModeInsecure,
+				ServerSpiffeId: "spiffe://mycluster/svc/example",
+			},
+			expectErr: require.Error,
+		},
+		"verify spiffe missing server spiffe": {
+			tls: &types.AppTLS{
+				Mode: types.AppTLSModeVerifySpiffeID,
+			},
+			expectErr: require.Error,
+		},
+		"verify spiffe missing server spiffe trust domain": {
+			tls: &types.AppTLS{
+				Mode:           types.AppTLSModeVerifySpiffeID,
+				ServerSpiffeId: "spiffe:///svc/example",
+			},
+			expectErr: require.Error,
+		},
+		"invalid client cert mode value": {
+			tls: &types.AppTLS{
+				Mode:           types.AppTLSModeVerifyServerName,
+				ClientCertMode: "foo",
+			},
+			expectErr: require.Error,
+		},
+		"client cert mode with insecure": {
+			tls: &types.AppTLS{
+				Mode:           types.AppTLSModeInsecure,
+				ClientCertMode: types.AppClientCertModeManaged,
+			},
+			expectErr: require.Error,
+		},
+		"insecure skip verify compatible with mode insecure": {
+			tls:          &types.AppTLS{Mode: types.AppTLSModeInsecure},
+			insecureSkip: true,
+			expectErr:    require.NoError,
+		},
+		"insecure skip verify with empty mode defaults to insecure": {
+			tls:          &types.AppTLS{},
+			insecureSkip: true,
+			expectErr:    require.NoError,
+		},
+		"allowed cas with only internal alias": {
+			tls: &types.AppTLS{
+				Mode:       types.AppTLSModeVerifyServerName,
+				AllowedCas: []string{types.AppTLSInternalCAWorkloadIdentity},
+			},
+			expectErr: require.NoError,
+		},
+		"allowed cas with empty string entry": {
+			tls: &types.AppTLS{
+				Mode:       types.AppTLSModeVerifyServerName,
+				AllowedCas: []string{""},
+			},
+			expectErr: require.Error,
+		},
+		"insecure mode with allowed cas": {
+			tls: &types.AppTLS{
+				Mode:       types.AppTLSModeInsecure,
+				AllowedCas: []string{types.AppTLSInternalCAWorkloadIdentity},
+			},
+			expectErr: require.Error,
+		},
+		"cloud app with tls block": {
+			uri: "cloud://aws",
+			tls: &types.AppTLS{
+				Mode: types.AppTLSModeInsecure,
+			},
+			expectErr: require.Error,
+		},
+		"unsupported protocol with tls block": {
+			uri: "http://localhost",
+			tls: &types.AppTLS{
+				Mode: types.AppTLSModeInsecure,
+			},
+			expectErr: require.Error,
+		},
+		"unsupported protocol with empty tls config": {
+			uri:       "http://localhost",
+			tls:       &types.AppTLS{},
+			expectErr: require.Error,
+		},
+		"empty": {
+			tls:       &types.AppTLS{},
+			expectErr: require.NoError,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			uri := tc.uri
+			if uri == "" {
+				uri = "https://localhost"
+			}
+
+			app, err := types.NewAppV3(types.Metadata{Name: "myapp"}, types.AppSpecV3{
+				URI:                uri,
+				InsecureSkipVerify: tc.insecureSkip,
+				TLS:                tc.tls,
+			})
+			require.NoError(t, err)
+			tc.expectErr(t, validateAppTLS(app))
+		})
+	}
+}
+
+func TestValidateAppAllowedCAsContents(t *testing.T) {
+	caKeyPEM, caCertPEM, err := tlscatest.GenerateSelfSignedCA(tlscatest.GenerateCAConfig{ClusterName: "example.com"})
+	require.NoError(t, err)
+
+	identity := &tlsca.Identity{Username: "test-user"}
+	subj, err := identity.Subject()
+	require.NoError(t, err)
+
+	privateKey, err := cryptosuites.GenerateKeyWithAlgorithm(cryptosuites.ECDSAP256)
+	require.NoError(t, err)
+
+	ca, err := tlsca.FromKeys(caCertPEM, caKeyPEM)
+	require.NoError(t, err)
+	tlsCert, err := ca.GenerateCertificate(tlsca.CertificateRequest{
+		PublicKey: privateKey.Public(),
+		Subject:   subj,
+		NotAfter:  time.Now().Add(time.Hour),
+		DNSNames:  []string{"localhost", "*.localhost"},
+	})
+	require.NoError(t, err)
+
+	for name, tc := range map[string]struct {
+		contents  []byte
+		expectErr require.ErrorAssertionFunc
+	}{
+		"single valid ca": {
+			contents:  caCertPEM,
+			expectErr: require.NoError,
+		},
+		"only single ca allowed": {
+			contents:  bytes.Join([][]byte{caCertPEM, caCertPEM}, []byte("\n")),
+			expectErr: require.Error,
+		},
+		"no CA certificate": {
+			contents:  bytes.Join([][]byte{caCertPEM, tlsCert}, []byte("\n")),
+			expectErr: require.Error,
+		},
+		"no certificate contents": {
+			contents:  []byte("hello"),
+			expectErr: require.Error,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			tc.expectErr(t, isValidCACertificatePEM(string(tc.contents)))
+		})
+	}
 }


### PR DESCRIPTION
Backport #65995 to branch/v18.

## Manual Test Plan

### Test Environment

Locally hosted cluster with app service joined. Both are using binaries built from this branch.

### Test Cases
- [x] Static (start app service).
  - [x] Start app service with valid TLS configuration.
  - [x] Load CA certificates from path.
  - [x] Startup failures.
    - [x] Invalid CA certificates path.
    - [x] Invalid TLS configuration.

- [x] Dynamic app (start app service).
  - [x] `tctl create` app with TLS.
  - [x] `tctl edit` app with TLS.
  - [x] Validation errors (causes `tctl` command to fail)
    - [x] Invalid CA certificate contents.
    - [x] Invalid TLS configuration.