### PR TITLE
Add regression coverage for AWS endpoint suffix parsing

### DIFF
--- a/api/utils/aws/endpoint_test.go
+++ b/api/utils/aws/endpoint_test.go
@@ -738,6 +738,18 @@ func TestParseDynamoDBEndpoint(t *testing.T) {
 			desc:     "mismatched china region and non-china partition",
 			endpoint: "streams.dynamodb.cn-north-1.amazonaws.com",
 		},
+		{
+			desc:     "AWS suffix embedded in outer host",
+			endpoint: "dynamodb.us-east-1.amazonaws.com.example.com",
+		},
+		{
+			desc:     "AWS China suffix embedded in outer host",
+			endpoint: "dynamodb.cn-north-1.amazonaws.com.cn.example.com",
+		},
+		{
+			desc:     "AWS-looking service embedded in non-AWS outer host",
+			endpoint: "foo.dynamodb.us-east-1.amazonaws.com.example.com",
+		},
 	}
 	for _, tt := range tests {
 		tt := tt
@@ -847,6 +859,18 @@ func TestParseOpensearchEndpoint(t *testing.T) {
 		{
 			desc:     "mismatched china region and non-china partition",
 			endpoint: "streams.opensearch.cn-north-1.amazonaws.com",
+		},
+		{
+			desc:     "AWS suffix embedded in outer host",
+			endpoint: "opensearch-instance-foo.us-east-1.es.amazonaws.com.example.com",
+		},
+		{
+			desc:     "AWS China suffix embedded in outer host",
+			endpoint: "opensearch-instance-foo.cn-north-1.es.amazonaws.com.cn.example.com",
+		},
+		{
+			desc:     "AWS-looking service embedded in non-AWS outer host",
+			endpoint: "foo.opensearch.us-east-1.amazonaws.com.example.com",
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
### Summary

This adds parser-only regression coverage for AWS endpoint parsing helpers.

The added cases exercise hostnames where an AWS-looking endpoint appears inside a longer outer hostname, for example an endpoint-like suffix followed by another domain segment. These cases are useful regression fixtures because endpoint parsers should avoid treating embedded AWS-looking substrings as standalone AWS service endpoints.

The patch is limited to tests:

- DynamoDB endpoint parser coverage
- OpenSearch endpoint parser coverage
- no production code changes
- no network calls
- no credentialed AWS calls

### Motivation

Endpoint parsing logic is security-sensitive because the parsed service, region, partition, and instance values may be consumed by higher-level access-control or integration logic. Regression coverage for suffix-boundary handling helps preserve the expected parser contract.

This PR does not assert runtime impact. It adds narrow regression fixtures around suffix confusion cases so future parser changes have explicit guardrails.

### Test Plan

```bash
cd api
go test ./utils/aws -run TestParse(DynamoDB|Opensearch)Endpoint
```

Observed in the isolated branch worktree:

```text
ok   github.com/gravitational/teleport/api/utils/aws   (cached)
```