### PR TITLE
Re-generate tsh cli reference

### DIFF
--- a/docs/pages/reference/cli/tsh.mdx
+++ b/docs/pages/reference/cli/tsh.mdx
@@ -1865,6 +1865,27 @@ Usage:
 $ tsh vnet-ssh-autoconfig
 ```
 
+## tsh workload-identity issue-jwt
+
+Use Teleport Workload Identity to issue a JWT credential and write it to a local
+directory.
+
+Usage:
+
+```code
+$ tsh workload-identity issue-jwt --output=OUTPUT --audience=AUDIENCE [<flags>]
+```
+
+Flags:
+
+|Flag|Default|Description|
+|---|---|---|
+|`--audience`|*no default*|The audience to include in the JWT. Can be specified multiple times.|
+|`--credential-ttl`|`1h`|Sets the time to live for the credential.|
+|`--label-selector`|*no default*|A label-based selector for which workload identities to issue. Multiple labels can be provided using ','.|
+|`--name-selector`|*no default*|The name of the workload identity to issue.|
+|`--output`|*no default*|Path to the directory to write the SVID into.|
+
 ## tsh workload-identity issue-x509
 
 Use Teleport Workload Identity to issue an X509 credential and write it to a


### PR DESCRIPTION
`make cli-docs-tsh` to include the `tsh workload-identit issue-jwt` command.