### PR TITLE
docs: Update ldap username references

### DIFF
--- a/docs/pages/includes/config-reference/database-config.yaml
+++ b/docs/pages/includes/config-reference/database-config.yaml
@@ -224,7 +224,7 @@ db_service:
       # Optional path to Kerberos configuration file. Defaults to /etc/krb5.conf.
       krb5_file: /etc/krb5.conf
       # Name of the service account Teleport uses to perform LDAP queries for retrieving user SIDs.
-      ldap_service_account_name: "svc-teleport"
+      ldap_service_account_name: 'svc-teleport'
       # SID of the above service account. Teleport uses this to authenticate LDAP queries.
       # Also required for PKINIT if the user SID must be included in the certificate.
       ldap_service_account_sid: "S-1-5-21-1111111111-2222222222-3333333333-4444"

--- a/docs/pages/includes/config-reference/database-config.yaml
+++ b/docs/pages/includes/config-reference/database-config.yaml
@@ -224,7 +224,7 @@ db_service:
       # Optional path to Kerberos configuration file. Defaults to /etc/krb5.conf.
       krb5_file: /etc/krb5.conf
       # Name of the service account Teleport uses to perform LDAP queries for retrieving user SIDs.
-      ldap_service_account_name: 'svc-teleport'
+      ldap_service_account_name: 'EXAMPLE\svc-teleport'
       # SID of the above service account. Teleport uses this to authenticate LDAP queries.
       # Also required for PKINIT if the user SID must be included in the certificate.
       ldap_service_account_sid: "S-1-5-21-1111111111-2222222222-3333333333-4444"

--- a/docs/pages/includes/config-reference/desktop-config.yaml
+++ b/docs/pages/includes/config-reference/desktop-config.yaml
@@ -51,9 +51,9 @@ windows_desktop_service:
     # avoid the need to escape the backslash (\) character.
     #
     # For example, if your domain is "example.com", the NetBIOS name for it is
-    # likely "EXAMPLE". When connecting as the "svc-teleport" user, you should
-    # use the format: "EXAMPLE\svc-teleport".
-    username: "$LDAP_USERNAME"
+    # likely "EXAMPLE". When connecting as the 'svc-teleport' user, you should
+    # use the format: 'EXAMPLE\svc-teleport'.
+    username: '$LDAP_USERNAME'
     # The security identifier of the service account specified by the username
     # field above. This looks like a string starting with "S-".
     #


### PR DESCRIPTION
Updated ldap username to use `'` instead of `"`. Without a additional `\` that will result in a error. 

The database config reference was missing the domain for the username.
