### PR TITLE
Bring back single Dependabot group for UI updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -342,31 +342,14 @@ updates:
           - 'electron*'
           - node-gyp
           - node-pty
-      ui-tooling:
-        dependency-type: development
+      ui:
         update-types:
           - 'minor'
           - 'patch'
         # Contrary to what the docs say, if a dependency matches more than one rule, it is _not_
         # included in the first group that it matches. Other groups must be explicitly excluded,
-        # otherwise Dependabot is going to perform minor Electron updates in ui groups.
+        # otherwise Dependabot is going to perform minor Electron updates in the UI group.
         # https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#groups--
-        exclude-patterns:
-          - 'electron*'
-          - node-gyp
-          - node-pty
-          # Exclude type packages; they need to be updated together with the corresponding app deps.
-          - '@types/*'
-          # Exclude teleterm dev deps that are really just regular deps that we don't want
-          # electron-builder to externalize (see https://github.com/gravitational/teleport/pull/65213).
-          - '@protobuf-ts/grpc-transport'
-          - '@xterm/*'
-          - events
-          - 'react-dnd*'
-      ui:
-        update-types:
-          - 'minor'
-          - 'patch'
         exclude-patterns:
           - 'electron*'
           - node-gyp


### PR DESCRIPTION
This effectively reverts #65213.

[In a thread on Slack](https://gravitational.slack.com/archives/C02DQ1C2BMW/p1778775087687499?thread_ts=1778774692.241769&cid=C02DQ1C2BMW), Ryan suggested that we should backport dep updates to all release branches and improve tests if they don't catch breaking changes.

I feel like with the long running versions now it's a sensible thing to do since otherwise we just don't have a plan in place to update old deps, other than cutting a new major version every year.

First though we have to align UI deps on release branches (#66431). Before that, this PR reverts the previous change that added a separate ui-tooling group. It'll no longer be necessary if we get into the habit of updating deps on all release branches.

I added the do-not-merge label because I want to merge this closer to June 1st.