### PR TITLE
Desktop Session Playback - Improve Validation of Client Commands

### DIFF
--- a/lib/web/desktop/playback.go
+++ b/lib/web/desktop/playback.go
@@ -53,36 +53,25 @@ const (
 	actionSeek = playbackAction("seek")
 )
 
-// UnmarshalJSON implements custom json unmarshalling for playbackAction.
-// It ensures that actions conform to the expected set of values.
-func (a *playbackAction) UnmarshalJSON(data []byte) error {
-	var action string
-	if err := json.Unmarshal(data, &action); err != nil {
-		return err
-	}
-
-	switch action {
-	case string(actionPlayPause), string(actionSpeed), string(actionSeek):
-		*a = playbackAction(action)
+// Validate ensures that playback action matches one of the
+// playbackAction constants.
+func (a *playbackAction) Validate() error {
+	switch *a {
+	case actionPlayPause, actionSpeed, actionSeek:
 		return nil
 	default:
-		return trace.BadParameter("invalid desktop action")
+		return trace.BadParameter("invalid playback action")
 	}
 }
 
 type playbackSpeed float64
 
-// UnmarshalJSON implements custom json unmarshalling for playbackSpeed.
-// It coerces the received value into the range [minPlaybackSpeed, maxPlaybackSpeed].
-func (p *playbackSpeed) UnmarshalJSON(data []byte) error {
-	var speed float64
-	if err := json.Unmarshal(data, &speed); err != nil {
-		return err
-	}
-
-	speed = max(speed, minPlaybackSpeed)
-	speed = min(speed, maxPlaybackSpeed)
-	*p = playbackSpeed(speed)
+// Validate coerces playback speed into the acceptable
+// range [minPlaybackSpeed, maxPlaybackSpeed]. It will not
+// actually return an error.
+func (p *playbackSpeed) Validate() error {
+	*p = max(*p, minPlaybackSpeed)
+	*p = min(*p, maxPlaybackSpeed)
 	return nil
 }
 
@@ -93,6 +82,15 @@ type actionMessage struct {
 	Action        playbackAction `json:"action"`
 	PlaybackSpeed playbackSpeed  `json:"speed,omitempty"`
 	Pos           int64          `json:"pos"`
+}
+
+func (a *actionMessage) Validate() error {
+	for _, validate := range []func() error{a.Action.Validate, a.PlaybackSpeed.Validate} {
+		if err := validate(); err != nil {
+			return trace.Wrap(err)
+		}
+	}
+	return nil
 }
 
 // JSONReader is used to read JSON messages containing
@@ -126,6 +124,11 @@ func ReceivePlaybackActions(
 			return trace.Wrap(err)
 		}
 
+		err = action.Validate()
+		if err != nil {
+			return trace.Wrap(err)
+		}
+
 		switch action.Action {
 		case actionPlayPause:
 			if playing {
@@ -152,7 +155,7 @@ type RecordingPlayer interface {
 }
 
 // StreamRecording adapts the RecordingPlayer to a websocket by reading from C(),
-// marshalling events to JSON, and writing them to the connection. Automatically
+// marshaling events to JSON, and writing them to the connection. Automatically
 // writes a sentinel or error message to the websocket when the player exits.
 // It does *not* drain the player's event channel upon context cancellation.
 func StreamRecording(

--- a/lib/web/desktop/playback.go
+++ b/lib/web/desktop/playback.go
@@ -151,9 +151,11 @@ type RecordingPlayer interface {
 	Err() error
 }
 
-// PlayRecording feeds recorded events from a player
-// over a websocket.
-func PlayRecording(
+// StreamRecording adapts the RecordingPlayer to a websocket by reading from C(),
+// marshalling events to JSON, and writing them to the connection. Automatically
+// writes a sentinel or error message to the websocket when the player exits.
+// It does *not* drain the player's event channel upon context cancellation.
+func StreamRecording(
 	ctx context.Context,
 	log *slog.Logger,
 	ws *websocket.Conn,

--- a/lib/web/desktop/playback.go
+++ b/lib/web/desktop/playback.go
@@ -21,14 +21,15 @@ package desktop
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"time"
 
 	"github.com/gorilla/websocket"
+	"github.com/gravitational/trace"
 
 	"github.com/gravitational/teleport/api/types/events"
-	"github.com/gravitational/teleport/lib/player"
 	"github.com/gravitational/teleport/lib/utils"
 )
 
@@ -53,13 +54,60 @@ const (
 	actionSeek = playbackAction("seek")
 )
 
+// UnmarshalJSON implements custom json unmarshalling for playbackAction.
+// It ensures that actions conform to the expected set of values.
+func (a *playbackAction) UnmarshalJSON(data []byte) error {
+	var action string
+	if err := json.Unmarshal(data, &action); err != nil {
+		return err
+	}
+
+	switch action {
+	case string(actionPlayPause), string(actionSpeed), string(actionSeek):
+		*a = playbackAction(action)
+		return nil
+	default:
+		return errors.New("invalid desktop action")
+	}
+}
+
+type playbackSpeed float64
+
+// UnmarshalJSON implements custom json unmarshalling for playbackSpeed.
+// It coerces the received value into the range [minPlaybackSpeed, maxPlaybackSpeed].
+func (p *playbackSpeed) UnmarshalJSON(data []byte) error {
+	var speed float64
+	if err := json.Unmarshal(data, &speed); err != nil {
+		return err
+	}
+
+	speed = max(speed, minPlaybackSpeed)
+	speed = min(speed, maxPlaybackSpeed)
+	*p = playbackSpeed(speed)
+	return nil
+}
+
 // actionMessage is a message passed from the playback client
 // to the server over the websocket connection in order to
 // control playback.
 type actionMessage struct {
 	Action        playbackAction `json:"action"`
-	PlaybackSpeed float64        `json:"speed,omitempty"`
+	PlaybackSpeed playbackSpeed  `json:"speed,omitempty"`
 	Pos           int64          `json:"pos"`
+}
+
+// JSONReader is used to read JSON messages containing
+// commands for the session player.
+type JSONReader interface {
+	ReadJSON(v any) error
+}
+
+// PlayerController models the session player.
+type PlayerController interface {
+	SetPos(time.Duration) error
+	SetSpeed(float64) error
+	Pause() error
+	Play() error
 }
 
 // ReceivePlaybackActions handles logic for receiving playbackAction messages
@@ -67,21 +115,16 @@ type actionMessage struct {
 func ReceivePlaybackActions(
 	ctx context.Context,
 	logger *slog.Logger,
-	ws *websocket.Conn,
-	player *player.Player) {
+	reader JSONReader,
+	player PlayerController) error {
 	// playback always starts in a playing state
 	playing := true
 
 	for {
 		var action actionMessage
-
-		if err := ws.ReadJSON(&action); err != nil {
-			// Connection close errors are expected if the user closes the tab.
-			// Only log unexpected errors to avoid cluttering the logs.
-			if !utils.IsOKNetworkError(err) {
-				logger.WarnContext(ctx, "websocket read error", "error", err)
-			}
-			return
+		err := reader.ReadJSON(&action)
+		if err != nil {
+			return trace.Wrap(err)
 		}
 
 		switch action.Action {
@@ -93,16 +136,20 @@ func ReceivePlaybackActions(
 			}
 			playing = !playing
 		case actionSpeed:
-			action.PlaybackSpeed = max(action.PlaybackSpeed, minPlaybackSpeed)
-			action.PlaybackSpeed = min(action.PlaybackSpeed, maxPlaybackSpeed)
-			player.SetSpeed(action.PlaybackSpeed)
+			player.SetSpeed(float64(action.PlaybackSpeed))
 		case actionSeek:
 			player.SetPos(time.Duration(action.Pos) * time.Millisecond)
 		default:
 			slog.WarnContext(ctx, "invalid desktop playback action", "action", action.Action)
-			return
+			return errors.New("invalid desktop action")
 		}
 	}
+}
+
+// RecordingPlayer models the read actions of the session player.
+type RecordingPlayer interface {
+	C() <-chan events.AuditEvent
+	Err() error
 }
 
 // PlayRecording feeds recorded events from a player
@@ -111,8 +158,7 @@ func PlayRecording(
 	ctx context.Context,
 	log *slog.Logger,
 	ws *websocket.Conn,
-	player *player.Player) {
-	player.Play()
+	player RecordingPlayer) {
 	for {
 		select {
 		case <-ctx.Done():

--- a/lib/web/desktop/playback.go
+++ b/lib/web/desktop/playback.go
@@ -21,7 +21,6 @@ package desktop
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"log/slog"
 	"time"
@@ -67,7 +66,7 @@ func (a *playbackAction) UnmarshalJSON(data []byte) error {
 		*a = playbackAction(action)
 		return nil
 	default:
-		return errors.New("invalid desktop action")
+		return trace.BadParameter("invalid desktop action")
 	}
 }
 
@@ -141,7 +140,7 @@ func ReceivePlaybackActions(
 			player.SetPos(time.Duration(action.Pos) * time.Millisecond)
 		default:
 			slog.WarnContext(ctx, "invalid desktop playback action", "action", action.Action)
-			return errors.New("invalid desktop action")
+			return trace.BadParameter("invalid desktop action")
 		}
 	}
 }

--- a/lib/web/desktop/playback.go
+++ b/lib/web/desktop/playback.go
@@ -66,13 +66,11 @@ func (a *playbackAction) Validate() error {
 
 type playbackSpeed float64
 
-// Validate coerces playback speed into the acceptable
-// range [minPlaybackSpeed, maxPlaybackSpeed]. It will not
-// actually return an error.
-func (p *playbackSpeed) Validate() error {
+// Coerce coerces playback speed into the acceptable
+// range [minPlaybackSpeed, maxPlaybackSpeed].
+func (p *playbackSpeed) Coerce() {
 	*p = max(*p, minPlaybackSpeed)
 	*p = min(*p, maxPlaybackSpeed)
-	return nil
 }
 
 // actionMessage is a message passed from the playback client
@@ -82,15 +80,6 @@ type actionMessage struct {
 	Action        playbackAction `json:"action"`
 	PlaybackSpeed playbackSpeed  `json:"speed,omitempty"`
 	Pos           int64          `json:"pos"`
-}
-
-func (a *actionMessage) Validate() error {
-	for _, validate := range []func() error{a.Action.Validate, a.PlaybackSpeed.Validate} {
-		if err := validate(); err != nil {
-			return trace.Wrap(err)
-		}
-	}
-	return nil
 }
 
 // JSONReader is used to read JSON messages containing
@@ -124,7 +113,7 @@ func ReceivePlaybackActions(
 			return trace.Wrap(err)
 		}
 
-		err = action.Validate()
+		err = action.Action.Validate()
 		if err != nil {
 			return trace.Wrap(err)
 		}
@@ -138,6 +127,7 @@ func ReceivePlaybackActions(
 			}
 			playing = !playing
 		case actionSpeed:
+			action.PlaybackSpeed.Coerce()
 			player.SetSpeed(float64(action.PlaybackSpeed))
 		case actionSeek:
 			player.SetPos(time.Duration(action.Pos) * time.Millisecond)

--- a/lib/web/desktop/playback_test.go
+++ b/lib/web/desktop/playback_test.go
@@ -109,7 +109,7 @@ func newServer(t *testing.T, streamInterval time.Duration, events []apievents.Au
 		})
 		assert.NoError(t, err)
 		player.Play()
-		desktop.PlayRecording(r.Context(), log, ws, player)
+		desktop.StreamRecording(r.Context(), log, ws, player)
 	}))
 
 	t.Cleanup(s.Close)

--- a/lib/web/desktop/playback_test.go
+++ b/lib/web/desktop/playback_test.go
@@ -19,9 +19,15 @@
 package desktop_test
 
 import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -108,4 +114,168 @@ func newServer(t *testing.T, streamInterval time.Duration, events []apievents.Au
 
 	t.Cleanup(s.Close)
 	return s
+}
+
+type mockJSONReader struct {
+	json chan json.RawMessage
+	err  chan error
+	once sync.Once
+}
+
+func (m *mockJSONReader) Close() {
+	m.once.Do(func() {
+		close(m.json)
+	})
+}
+
+func (m *mockJSONReader) ReadJSON(v interface{}) error {
+	select {
+	case jsn, ok := <-m.json:
+		if !ok {
+			return io.EOF
+		}
+		return json.Unmarshal(jsn, v)
+	case e := <-m.err:
+		return e
+	}
+}
+
+type mockPlayer struct {
+	setPosCount   int
+	setSpeedCount int
+	speedSettings []float64
+	pauseCount    int
+	playCount     int
+}
+
+func (m *mockPlayer) SetPos(d time.Duration) error {
+	m.setPosCount++
+	return nil
+}
+
+func (m *mockPlayer) SetSpeed(s float64) error {
+	m.setSpeedCount++
+	m.speedSettings = append(m.speedSettings, s)
+	return nil
+}
+
+func (m *mockPlayer) Pause() error {
+	m.pauseCount++
+	return nil
+}
+
+func (m *mockPlayer) Play() error {
+	m.playCount++
+	return nil
+}
+
+func jsonActionMessage(action string, speed float64, pos int64) json.RawMessage {
+	if speed > 0 {
+		return fmt.Appendf(nil, `{"action": "%s", "speed": %f, "pos": %d}`, action, speed, pos)
+	}
+	return fmt.Appendf(nil, `{"action": "%s", "pos": %d}`, action, pos)
+
+}
+
+func sendWithDeadline[T any](ctx context.Context, c chan T, val T) {
+	select {
+	case c <- val:
+	case <-ctx.Done():
+	}
+}
+
+func TestPlaybackActions(t *testing.T) {
+	newFixture := func() (*mockJSONReader, *mockPlayer, chan error) {
+
+		mockReader := &mockJSONReader{
+			json: make(chan json.RawMessage),
+			err:  make(chan error),
+		}
+
+		mockPlayer := &mockPlayer{}
+
+		errCh := make(chan error)
+		go func() {
+			errCh <- desktop.ReceivePlaybackActions(t.Context(), slog.New(slog.DiscardHandler), mockReader, mockPlayer)
+		}()
+
+		return mockReader, mockPlayer, errCh
+	}
+
+	t.Run("invalid-action", func(t *testing.T) {
+		mockReader, mockPlayer, errCh := newFixture()
+		defer mockReader.Close()
+
+		ctx, cancel := context.WithTimeout(t.Context(), 2*time.Second)
+		defer cancel()
+
+		sendWithDeadline(ctx, mockReader.json, jsonActionMessage("invalid", 0, 0))
+		select {
+		case err := <-errCh:
+			require.Error(t, err)
+		case <-ctx.Done():
+			t.Fatalf("playback action reader did not exit before deadline")
+		}
+		assert.Zero(t, mockPlayer.playCount)
+		assert.Zero(t, mockPlayer.pauseCount)
+		assert.Zero(t, mockPlayer.setPosCount)
+		assert.Zero(t, mockPlayer.setSpeedCount)
+	})
+
+	t.Run("invalid-speeds", func(t *testing.T) {
+		mockReader, mockPlayer, errCh := newFixture()
+		defer mockReader.Close()
+
+		ctx, cancel := context.WithTimeout(t.Context(), 2*time.Second)
+		defer cancel()
+
+		// Too low
+		sendWithDeadline(ctx, mockReader.json, jsonActionMessage("speed", 0.01, 0))
+		// Too high
+		sendWithDeadline(ctx, mockReader.json, jsonActionMessage("speed", 17, 0))
+		mockReader.Close()
+		select {
+		case err := <-errCh:
+			require.Error(t, err)
+		case <-ctx.Done():
+			t.Fatalf("playback action reader did not exit before deadline")
+		}
+		assert.Zero(t, mockPlayer.playCount)
+		assert.Zero(t, mockPlayer.pauseCount)
+		assert.Zero(t, mockPlayer.setPosCount)
+		assert.Equal(t, 2, mockPlayer.setSpeedCount)
+		assert.Contains(t, mockPlayer.speedSettings, 0.25)
+		assert.Contains(t, mockPlayer.speedSettings, float64(16))
+	})
+
+	t.Run("happy-paths", func(t *testing.T) {
+		mockReader, mockPlayer, errCh := newFixture()
+		defer mockReader.Close()
+
+		ctx, cancel := context.WithTimeout(t.Context(), 1*time.Second)
+		defer cancel()
+
+		for _, action := range []json.RawMessage{
+			jsonActionMessage("speed", 0.25, 0),
+			jsonActionMessage("speed", 16, 0),
+			jsonActionMessage("play/pause", 16, 0),
+			jsonActionMessage("play/pause", 16, 0),
+			jsonActionMessage("seek", 0, 1000),
+		} {
+			sendWithDeadline(ctx, mockReader.json, action)
+		}
+		// Should return EOF on error
+		mockReader.Close()
+
+		select {
+		case err := <-errCh:
+			require.ErrorIs(t, err, io.EOF, "expected ReceivePlaybackActions to return an EOF but got %v", err)
+		case <-ctx.Done():
+			t.Fatalf("playback action reader did not exit before deadline")
+		}
+		assert.Equal(t, 1, mockPlayer.playCount)
+		assert.Equal(t, 1, mockPlayer.pauseCount)
+		assert.Equal(t, 1, mockPlayer.setPosCount)
+		assert.Equal(t, 2, mockPlayer.setSpeedCount)
+	})
 }

--- a/lib/web/desktop_playback.go
+++ b/lib/web/desktop_playback.go
@@ -85,7 +85,7 @@ func (h *Handler) desktopPlaybackHandle(
 		defer ws.Close()
 
 		player.Play()
-		desktop.PlayRecording(ctx, h.logger, ws, player)
+		desktop.StreamRecording(ctx, h.logger, ws, player)
 	}()
 
 	<-ctx.Done()

--- a/lib/web/desktop_playback.go
+++ b/lib/web/desktop_playback.go
@@ -29,6 +29,7 @@ import (
 	"github.com/gravitational/teleport/lib/player"
 	"github.com/gravitational/teleport/lib/reversetunnelclient"
 	"github.com/gravitational/teleport/lib/session"
+	"github.com/gravitational/teleport/lib/utils"
 	"github.com/gravitational/teleport/lib/web/desktop"
 )
 
@@ -71,12 +72,19 @@ func (h *Handler) desktopPlaybackHandle(
 
 	go func() {
 		defer cancel()
-		desktop.ReceivePlaybackActions(ctx, h.logger, ws, player)
+		err := desktop.ReceivePlaybackActions(ctx, h.logger, ws, player)
+		// Connection close errors are expected if the user closes the tab.
+		// Only log unexpected errors to avoid cluttering the logs.
+		if !utils.IsOKNetworkError(err) {
+			h.logger.WarnContext(ctx, "websocket read error", "error", err)
+		}
 	}()
 
 	go func() {
 		defer cancel()
 		defer ws.Close()
+
+		player.Play()
 		desktop.PlayRecording(ctx, h.logger, ws, player)
 	}()
 


### PR DESCRIPTION
This PR refactors and improves validation of client commands by the desktop session player. 


<!-- Include manual testing efforts to verify the change. -->
<!-- Detail where the tests where run and what configurations were used. -->
<!-- Include all the test cases which were run to validate the change. -->

## Manual Test Plan
### Test Environment
Local Cluster with saved desktop session recordings
### Test Cases
- [x] Session Recordings play from start to finish
- [x] Pause/Play button toggles between pause and play.
- [x] Speed settings take effect.
- [x] Seeking forward and backwards resumes playback at the desired position.
