### PR TITLE
Update Proxy heartbeats to heartbeat with Kind=Proxy

### DIFF
--- a/lib/auth/apiserver.go
+++ b/lib/auth/apiserver.go
@@ -265,6 +265,12 @@ func (s *APIServer) upsertServer(auth presenceForAPIServer, role types.SystemRol
 	default:
 		return nil, trace.BadParameter("upsertServer with unknown role: %q", role)
 	}
+	// UnmarshalServer forces s.Kind = kind, ignoring the Kind in the payload.
+	// This is retained for backwards compatibility: prior to v19, proxy
+	// heartbeats sent the resource with Kind=KindNode over the wire (see
+	// https://github.com/gravitational/teleport/issues/66997). v19+ proxies
+	// send the correct kind; the override remains so older proxies in mixed
+	// clusters continue to work.
 	server, err := services.UnmarshalServer(req.Server, kind)
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/auth/presence/presencev1/service.go
+++ b/lib/auth/presence/presencev1/service.go
@@ -490,10 +490,18 @@ func (s *Service) UpsertProxyServer(
 	if srv == nil {
 		return nil, trace.BadParameter("server: must be specified")
 	}
-	// nb(noah): This forced overwrite of kind is load-bearing. You will be
-	// surprised to learn that in its current state the Proxy heartbeater will
-	// upsert the Server with Kind=Node.
-	// See https://github.com/gravitational/teleport/issues/66997
+	// Prior to v19, proxy heartbeats sent the resource with Kind=KindNode
+	// (see https://github.com/gravitational/teleport/issues/66997). v19+
+	// proxies send Kind=KindProxy; this override is retained so older proxies
+	// in mixed clusters continue to upsert correctly.
+	if srv.GetKind() != types.KindProxy {
+		s.logger.WarnContext(ctx,
+			"received proxy heartbeat with unexpected kind; overriding to KindProxy",
+			"received_kind", srv.GetKind(),
+			"server_name", srv.GetName(),
+			"server_version", srv.GetTeleportVersion(),
+		)
+	}
 	srv.Kind = types.KindProxy
 	if err := srv.CheckAndSetDefaults(); err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/auth/presence/presencev1/service.go
+++ b/lib/auth/presence/presencev1/service.go
@@ -494,7 +494,7 @@ func (s *Service) UpsertProxyServer(
 	// (see https://github.com/gravitational/teleport/issues/66997). v19+
 	// proxies send Kind=KindProxy; this override is retained so older proxies
 	// in mixed clusters continue to upsert correctly.
-	// TODO(strideynet): In V21.0.0, we should consider changing the behaviour
+	// TODO(strideynet): In V21.0.0, we should consider changing the behavior
 	// to reject or warn on incorrect Kind.
 	srv.Kind = types.KindProxy
 	if err := srv.CheckAndSetDefaults(); err != nil {

--- a/lib/auth/presence/presencev1/service.go
+++ b/lib/auth/presence/presencev1/service.go
@@ -494,14 +494,6 @@ func (s *Service) UpsertProxyServer(
 	// (see https://github.com/gravitational/teleport/issues/66997). v19+
 	// proxies send Kind=KindProxy; this override is retained so older proxies
 	// in mixed clusters continue to upsert correctly.
-	if srv.GetKind() != types.KindProxy {
-		s.logger.WarnContext(ctx,
-			"received proxy heartbeat with unexpected kind; overriding to KindProxy",
-			"received_kind", srv.GetKind(),
-			"server_name", srv.GetName(),
-			"server_version", srv.GetTeleportVersion(),
-		)
-	}
 	srv.Kind = types.KindProxy
 	if err := srv.CheckAndSetDefaults(); err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/auth/presence/presencev1/service.go
+++ b/lib/auth/presence/presencev1/service.go
@@ -494,6 +494,8 @@ func (s *Service) UpsertProxyServer(
 	// (see https://github.com/gravitational/teleport/issues/66997). v19+
 	// proxies send Kind=KindProxy; this override is retained so older proxies
 	// in mixed clusters continue to upsert correctly.
+	// TODO(strideynet): In V21.0.0, we should consider changing the behaviour
+	// to reject or warn on incorrect Kind.
 	srv.Kind = types.KindProxy
 	if err := srv.CheckAndSetDefaults(); err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/srv/regular/sshserver.go
+++ b/lib/srv/regular/sshserver.go
@@ -1195,8 +1195,12 @@ func (s *Server) getBasicInfo() *types.ServerV2 {
 		// protobuf message
 		relayGroup, relayIDs = s.relayInfoGetter()
 	}
+	kind := types.KindNode
+	if s.proxyMode {
+		kind = types.KindProxy
+	}
 	srv := &types.ServerV2{
-		Kind:    types.KindNode,
+		Kind:    kind,
 		Version: types.V2,
 		Scope:   s.scope,
 		Metadata: types.Metadata{

--- a/lib/srv/regular/sshserver_test.go
+++ b/lib/srv/regular/sshserver_test.go
@@ -49,6 +49,7 @@ import (
 	"golang.org/x/crypto/ssh"
 	"golang.org/x/crypto/ssh/agent"
 	"google.golang.org/grpc"
+	"google.golang.org/protobuf/testing/protocmp"
 
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/breaker"
@@ -67,6 +68,7 @@ import (
 	"github.com/gravitational/teleport/lib/auth/testauthority"
 	"github.com/gravitational/teleport/lib/authz"
 	"github.com/gravitational/teleport/lib/bpf"
+	"github.com/gravitational/teleport/lib/componentfeatures"
 	"github.com/gravitational/teleport/lib/cryptosuites"
 	"github.com/gravitational/teleport/lib/events"
 	"github.com/gravitational/teleport/lib/events/eventstest"
@@ -3887,4 +3889,145 @@ func TestServerInfo(t *testing.T) {
 	info, err := f.ssh.srv.getServerInfo(t.Context())
 	require.NoError(t, err)
 	require.Equal(t, scope, info.Scope)
+}
+
+func TestGetServerInfoHeartbeat(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	clock := clockwork.NewFakeClock()
+	expiry := clock.Now().UTC().Add(apidefaults.ServerAnnounceTTL)
+	sshFeatures := componentfeatures.ForSSHServer()
+
+	testServer, err := authtest.NewTestServer(authtest.ServerConfig{
+		Auth: authtest.AuthServerConfig{
+			ClusterName: "localhost",
+			Dir:         t.TempDir(),
+			Clock:       clock,
+		},
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, testServer.Close()) })
+
+	hostSigner := newSigner(t, ctx, testServer)
+
+	// newServer constructs a Server via the public constructor using the same
+	// option shape that real Proxies/Nodes use. role determines the identity
+	// of the client used for the AccessPoint, and extraOpts plug in
+	// role-specific behaviour like SetProxyMode. The returned Server has not
+	// been Started — getServerInfo can be called directly on it.
+	newServer := func(t *testing.T, role types.SystemRole, hostname, serverID string, extraOpts ...ServerOption) *Server {
+		t.Helper()
+		client, err := testServer.NewClient(authtest.TestIdentity{
+			I: authz.BuiltinRole{Role: role, Username: serverID},
+		})
+		require.NoError(t, err)
+		t.Cleanup(func() { require.NoError(t, client.Close()) })
+
+		lockWatcher := newLockWatcher(ctx, t, client)
+		sessionController, err := srv.NewSessionController(srv.SessionControllerConfig{
+			Semaphores:   client,
+			AccessPoint:  client,
+			LockEnforcer: lockWatcher,
+			Emitter:      client,
+			Component:    teleport.ComponentNode,
+			ServerID:     serverID,
+		})
+		require.NoError(t, err)
+
+		opts := []ServerOption{
+			SetUUID(serverID),
+			SetNamespace(apidefaults.Namespace),
+			SetEmitter(client),
+			SetClock(clock),
+			SetLockWatcher(lockWatcher),
+			SetSessionController(sessionController),
+			SetConnectedProxyGetter(reversetunnel.NewConnectedProxyGetter()),
+		}
+		opts = append(opts, extraOpts...)
+
+		s, err := New(
+			ctx,
+			utils.NetAddr{AddrNetwork: "tcp", Addr: "127.0.0.1:0"},
+			hostname,
+			sshutils.StaticHostSigners(hostSigner),
+			client,
+			t.TempDir(),
+			"",
+			utils.NetAddr{},
+			client,
+			opts...,
+		)
+		require.NoError(t, err)
+		t.Cleanup(func() { require.NoError(t, s.Close()) })
+		return s
+	}
+
+	tests := []struct {
+		name     string
+		buildSrv func(t *testing.T) *Server
+		want     *types.ServerV2
+	}{
+		{
+			name: "node mode",
+			buildSrv: func(t *testing.T) *Server {
+				return newServer(t, types.RoleNode, "node-host", "node-uuid",
+					SetLabels(map[string]string{"static-label": "static-value"}, nil, nil),
+					SetScope("/scope"),
+				)
+			},
+			want: &types.ServerV2{
+				Kind:    types.KindNode,
+				Version: types.V2,
+				Scope:   "/scope",
+				Metadata: types.Metadata{
+					Name:      "node-uuid",
+					Namespace: apidefaults.Namespace,
+					Labels:    map[string]string{"static-label": "static-value"},
+					Expires:   &expiry,
+				},
+				Spec: types.ServerSpecV2{
+					CmdLabels:         map[string]types.CommandLabelV2{},
+					Hostname:          "node-host",
+					Version:           teleport.Version,
+					ComponentFeatures: sshFeatures,
+				},
+			},
+		},
+		{
+			name: "proxy mode",
+			buildSrv: func(t *testing.T) *Server {
+				return newServer(t, types.RoleProxy, "proxy-host", "proxy-uuid",
+					SetProxyMode("10.0.0.1:1234", nil, nil, nil),
+				)
+			},
+			want: &types.ServerV2{
+				Kind:    types.KindProxy,
+				Version: types.V2,
+				Metadata: types.Metadata{
+					Name:      "proxy-uuid",
+					Namespace: apidefaults.Namespace,
+					Expires:   &expiry,
+				},
+				Spec: types.ServerSpecV2{
+					CmdLabels:         map[string]types.CommandLabelV2{},
+					Hostname:          "proxy-host",
+					Version:           teleport.Version,
+					PeerAddr:          "10.0.0.1:1234",
+					ComponentFeatures: sshFeatures,
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := tt.buildSrv(t)
+			info, err := s.getServerInfo(t.Context())
+			require.NoError(t, err)
+			// listener addr is bound dynamically on instantiation, so we fetch
+			// as we won't know ahead of time.
+			tt.want.Spec.Addr = s.AdvertiseAddr()
+			require.Empty(t, cmp.Diff(tt.want, info, protocmp.Transform()))
+		})
+	}
 }

--- a/lib/srv/regular/sshserver_test.go
+++ b/lib/srv/regular/sshserver_test.go
@@ -3910,12 +3910,6 @@ func TestGetServerInfoHeartbeat(t *testing.T) {
 	t.Cleanup(func() { require.NoError(t, testServer.Close()) })
 
 	hostSigner := newSigner(t, ctx, testServer)
-
-	// newServer constructs a Server via the public constructor using the same
-	// option shape that real Proxies/Nodes use. role determines the identity
-	// of the client used for the AccessPoint, and extraOpts plug in
-	// role-specific behaviour like SetProxyMode. The returned Server has not
-	// been Started — getServerInfo can be called directly on it.
 	newServer := func(t *testing.T, role types.SystemRole, hostname, serverID string, extraOpts ...ServerOption) *Server {
 		t.Helper()
 		client, err := testServer.NewClient(authtest.TestIdentity{


### PR DESCRIPTION
Closes https://github.com/gravitational/teleport/issues/66997

Today, the Proxy's heartbeat reports a ServerV2 with Kind = types.KindNode instead of Kind = types.KindProxy. The auth server's UpsertProxyServer HTTP and gRPC handlers paper over this by force-overriding Kind to types.KindProxy before the resource is persisted. This is confusing and introduces the risk of foot-guns in the future. I discovered this whilst working on migrating the UpsertProxyServer RPC from HTTP to gRPC.

This PR modifies the code responsible for generating the proxies ServerV2 to set the Kind correctly. This section of code is already aware of whether it is serving a Node or Proxy - so this was fairly trivial. At a later date, we may wish to consider removing the over-ride behaviour.

## Manual Test Plan
### Test Environment

Local cluster with additional Proxy.

### Test Cases

- [x] Upon starting, the additional Proxy heartbeats correctly and shows under `tctl get proxies`.
  - [x] Insert break-point to view the received heartbeat object - ensure Kind is set correctly. 
- [x] Upon shutting down the additional Proxy, it unregisters itself and no longer shows under `tctl get proxies`.
