### PR TITLE
Fix predicate expression construction via fmt.Sprintf

### DIFF
--- a/lib/benchmark/db/db.go
+++ b/lib/benchmark/db/db.go
@@ -64,7 +64,7 @@ func getDatabase(ctx context.Context, tc *client.TeleportClient, serviceName str
 	databases, err := tc.ListDatabases(ctx, &proto.ListResourcesRequest{
 		Namespace:           defaults.Namespace,
 		ResourceType:        types.KindDatabaseServer,
-		PredicateExpression: fmt.Sprintf(`name == "%s" && resource.spec.protocol == "%s"`, serviceName, protocol),
+		PredicateExpression: fmt.Sprintf(`name == %q && resource.spec.protocol == %q`, serviceName, protocol),
 	})
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/client/conntest/database.go
+++ b/lib/client/conntest/database.go
@@ -232,7 +232,7 @@ func (s *DatabaseConnectionTester) runALPNTunnel(ctx context.Context, req TestCo
 func (s *DatabaseConnectionTester) getDatabaseServers(ctx context.Context, databaseName string) ([]types.DatabaseServer, error) {
 	// Lookup the Database Server that's proxying the requested Database.
 	page, err := apiclient.GetResourcePage[types.DatabaseServer](ctx, s.cfg.UserClient, &proto.ListResourcesRequest{
-		PredicateExpression: fmt.Sprintf(`name == "%s"`, databaseName),
+		PredicateExpression: fmt.Sprintf(`name == %q`, databaseName),
 		ResourceType:        types.KindDatabaseServer,
 		Limit:               defaults.MaxIterationLimit,
 	})

--- a/lib/tbot/services/application/output_service.go
+++ b/lib/tbot/services/application/output_service.go
@@ -251,7 +251,7 @@ func getApp(ctx context.Context, clt *apiclient.Client, appName string) (types.A
 	servers, err := apiclient.GetAllResources[types.AppServer](ctx, clt, &proto.ListResourcesRequest{
 		Namespace:           defaults.Namespace,
 		ResourceType:        types.KindAppServer,
-		PredicateExpression: fmt.Sprintf(`name == "%s"`, appName),
+		PredicateExpression: fmt.Sprintf(`name == %q`, appName),
 		Limit:               1,
 	})
 	if err != nil {

--- a/lib/teleterm/clusters/cluster_apps.go
+++ b/lib/teleterm/clusters/cluster_apps.go
@@ -62,7 +62,7 @@ func GetApp(ctx context.Context, authClient authclient.ClientI, appName string) 
 		apps, err := apiclient.GetAllResources[types.AppServer](ctx, authClient, &proto.ListResourcesRequest{
 			Namespace:           apidefaults.Namespace,
 			ResourceType:        types.KindAppServer,
-			PredicateExpression: fmt.Sprintf(`name == "%s"`, appName),
+			PredicateExpression: fmt.Sprintf(`name == %q`, appName),
 		})
 		if err != nil {
 			return trace.Wrap(err)

--- a/lib/teleterm/clusters/cluster_databases.go
+++ b/lib/teleterm/clusters/cluster_databases.go
@@ -77,7 +77,7 @@ func (c *Cluster) GetDatabase(ctx context.Context, authClient authclient.ClientI
 		databases, err := apiclient.GetAllResources[types.DatabaseServer](ctx, authClient, &proto.ListResourcesRequest{
 			Namespace:           defaults.Namespace,
 			ResourceType:        types.KindDatabaseServer,
-			PredicateExpression: fmt.Sprintf(`name == "%s"`, dbName),
+			PredicateExpression: fmt.Sprintf(`name == %q`, dbName),
 		})
 		if err != nil {
 			return trace.Wrap(err)

--- a/lib/vnet/fqdn_resolver.go
+++ b/lib/vnet/fqdn_resolver.go
@@ -256,7 +256,7 @@ func (r *fqdnResolver) resolveAppInfoForCluster(
 	log := log.With("profile", candidate.profileName, "leaf_cluster", candidate.leafClusterName, "fqdn", fqdn)
 
 	// An app public_addr could technically be fully-qualified or not, match either way.
-	expr := fmt.Sprintf(`resource.spec.public_addr == "%s" || resource.spec.public_addr == "%s"`,
+	expr := fmt.Sprintf(`resource.spec.public_addr == %q || resource.spec.public_addr == %q`,
 		strings.TrimSuffix(fqdn, "."), fqdn)
 
 	// If candidate is a leaf cluster and fqdn possibly points to a leaf
@@ -270,7 +270,7 @@ func (r *fqdnResolver) resolveAppInfoForCluster(
 	var potentialAppName string
 	if candidate.leafClusterName != "" && isDirectSubdomain(fqdn, candidate.profileName) {
 		potentialAppName = strings.TrimSuffix(fqdn, "."+dns.FullyQualify(candidate.profileName))
-		expr += fmt.Sprintf(` || name == "%s"`, potentialAppName)
+		expr += fmt.Sprintf(` || name == %q`, potentialAppName)
 	}
 
 	resp, err := apiclient.GetResourcePage[types.AppServer](ctx, candidate.client.CurrentCluster(), &proto.ListResourcesRequest{

--- a/lib/web/databases.go
+++ b/lib/web/databases.go
@@ -498,7 +498,7 @@ func (h *Handler) dbConnect(
 	databases, err := apiclient.GetAllResources[types.DatabaseServer](ctx, clt, &proto.ListResourcesRequest{
 		Namespace:           apidefaults.Namespace,
 		ResourceType:        types.KindDatabaseServer,
-		PredicateExpression: fmt.Sprintf(`name == "%s"`, req.ServiceName),
+		PredicateExpression: fmt.Sprintf(`name == %q`, req.ServiceName),
 		Limit:               1,
 	})
 	if err != nil {
@@ -950,7 +950,7 @@ func fetchDatabaseServersWithName(ctx context.Context, clt resourcesAPIGetter, r
 	resp, err := clt.ListResources(ctx, proto.ListResourcesRequest{
 		Limit:               defaults.MaxIterationLimit,
 		ResourceType:        types.KindDatabaseServer,
-		PredicateExpression: fmt.Sprintf(`name == "%s"`, databaseName),
+		PredicateExpression: fmt.Sprintf(`name == %q`, databaseName),
 		UseSearchAsRoles:    r.URL.Query().Get("searchAsRoles") == "yes",
 	})
 	if err != nil {

--- a/lib/web/terminal.go
+++ b/lib/web/terminal.go
@@ -919,7 +919,7 @@ func (t *sshBaseHandler) connectToNode(ctx context.Context, scopePin *scopesv1.P
 				SortBy:              types.SortBy{Field: types.ResourceKind},
 				Kinds:               []string{types.KindNode},
 				Limit:               1,
-				PredicateExpression: fmt.Sprintf(`resource.metadata.name == "%s"`, t.sessionData.ServerID),
+				PredicateExpression: fmt.Sprintf(`resource.metadata.name == %q`, t.sessionData.ServerID),
 			}); err == nil && len(resp.Resources) > 0 {
 				return nil, trace.AccessDenied("access denied to %q connecting to %v", sshConfig.User, resp.Resources[0].GetNode().GetHostname())
 			}

--- a/tool/tctl/common/resource_command.go
+++ b/tool/tctl/common/resource_command.go
@@ -927,7 +927,7 @@ func (rc *ResourceCommand) getCollection(ctx context.Context, client *authclient
 			ResourceType: types.KindDatabaseService,
 		}
 		if resourceName != "" {
-			listReq.PredicateExpression = fmt.Sprintf(`name == "%s"`, resourceName)
+			listReq.PredicateExpression = fmt.Sprintf(`name == %q`, resourceName)
 		}
 
 		getResp, err := apiclient.GetResourcesWithFilters(ctx, client, listReq)

--- a/tool/tsh/common/app.go
+++ b/tool/tsh/common/app.go
@@ -811,7 +811,7 @@ func getApp(ctx context.Context, clt apiclient.GetResourcesClient, name string) 
 	res, err := apiclient.GetEnrichedResourcePage(ctx, clt, &proto.ListResourcesRequest{
 		ResourceType:        types.KindAppServer,
 		SortBy:              types.SortBy{Field: types.ResourceMetadataName},
-		PredicateExpression: fmt.Sprintf(`name == "%s"`, name),
+		PredicateExpression: fmt.Sprintf(`name == %q`, name),
 		Limit:               1,
 		IncludeLogins:       true,
 	})

--- a/tool/tsh/common/tsh.go
+++ b/tool/tsh/common/tsh.go
@@ -4461,7 +4461,7 @@ func onResolve(cf *CLIConf) error {
 	// on the hostname of the server. Otherwise, this would end up listing
 	// the first two servers that the user has access to and yield unexpected results.
 	if len(tc.Labels) == 0 && len(tc.SearchKeywords) == 0 && tc.PredicateExpression == "" {
-		req.PredicateExpression = fmt.Sprintf(`name == "%s"`, tc.Host)
+		req.PredicateExpression = fmt.Sprintf(`name == %q`, tc.Host)
 	}
 
 	// Only enable the re-authentication behavior if not invoked with `-q`. When


### PR DESCRIPTION
## Context
Predicate filter expressions are constructed using `fmt.Sprintf` with manual quoting (`"%s"`) in some locations. The predicate parser uses `go/parser.ParseExpr`, meaning a value containing `"` would break out of the string boundary and be interpreted as expression syntax.

Not all resource types restrict name characters; some only checking for non-empty, so resource types like servers and apps can have names containing `"`. While all affected callsites go through `AuthWithRoles`, using `%q` ensures these lookups match the intended resource name exactly rather than producing a malformed predicate.

## Manual Test Plan
### Test Environment
- Local build of teleport & tsh from this branch.

### Test Cases
- [ ] Create a database or app resource whose name contains a `"` character (e.g., `test"db`) and verify it can be looked up via the affected code paths without parse errors.
- [ ] Verify that existing resources with normal names continue to resolve as before.
- [ ] Verify that existing tests pass with no failures.
