### PR TITLE
[terraform] exclude `nonce` attribute

### DIFF
--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/cluster_maintenance_config.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/cluster_maintenance_config.mdx
@@ -28,7 +28,6 @@ Teleport Terraform provider.
 ### Optional
 
 - `metadata` (Attributes) Metadata is resource metadata (see [below for nested schema](#nested-schema-for-metadata))
-- `nonce` (Number) Nonce is used to protect against concurrent modification of the maintenance window. Clients should treat nonces as opaque.
 - `spec` (Attributes) (see [below for nested schema](#nested-schema-for-spec))
 - `sub_kind` (String) SubKind is an optional resource sub kind, used in some resources
 

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/cluster_maintenance_config.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/cluster_maintenance_config.mdx
@@ -46,7 +46,6 @@ resource "teleport_cluster_maintenance_config" "example" {
 ### Optional
 
 - `metadata` (Attributes) Metadata is resource metadata (see [below for nested schema](#nested-schema-for-metadata))
-- `nonce` (Number) Nonce is used to protect against concurrent modification of the maintenance window. Clients should treat nonces as opaque.
 - `spec` (Attributes) (see [below for nested schema](#nested-schema-for-spec))
 - `sub_kind` (String) SubKind is an optional resource sub kind, used in some resources
 

--- a/integrations/terraform/protoc-gen-terraform-teleport.yaml
+++ b/integrations/terraform/protoc-gen-terraform-teleport.yaml
@@ -199,6 +199,9 @@ exclude_fields:
     # ClusterMaintenanceConfig
     - "ClusterMaintenanceConfigV1.Metadata.Name" # It's a singleton resource
 
+    # Nonce value is opaque and can be hidden from users.
+    - "ClusterMaintenanceConfigV1.Nonce"
+
     # NetworkingConfig
     - "ClusterNetworkingConfigV2.Metadata.Name" # It's a singleton resource
 

--- a/integrations/terraform/testlib/cluster_maintenance_config_test.go
+++ b/integrations/terraform/testlib/cluster_maintenance_config_test.go
@@ -21,9 +21,6 @@ import (
 )
 
 func (s *TerraformSuiteOSS) TestClusterMaintenanceConfig() {
-	// TODO: Nonce should be an excluded attribute.
-	s.T().Skip("Provider produced inconsistent result after apply")
-
 	name := "teleport_cluster_maintenance_config.test"
 
 	resource.Test(s.T(), resource.TestCase{

--- a/integrations/terraform/testlib/cluster_maintenance_config_test.go
+++ b/integrations/terraform/testlib/cluster_maintenance_config_test.go
@@ -37,6 +37,8 @@ func (s *TerraformSuiteOSS) TestClusterMaintenanceConfig() {
 					resource.TestCheckResourceAttr(name, "kind", "cluster_maintenance_config"),
 					resource.TestCheckResourceAttr(name, "spec.agent_upgrades.utc_start_hour", "1"),
 					resource.TestCheckResourceAttr(name, "spec.agent_upgrades.weekdays.0", "monday"),
+
+					resource.TestCheckNoResourceAttr(name, "nonce"),
 				),
 			},
 			{
@@ -49,6 +51,8 @@ func (s *TerraformSuiteOSS) TestClusterMaintenanceConfig() {
 					resource.TestCheckResourceAttr(name, "kind", "cluster_maintenance_config"),
 					resource.TestCheckResourceAttr(name, "spec.agent_upgrades.utc_start_hour", "12"),
 					resource.TestCheckResourceAttr(name, "spec.agent_upgrades.weekdays.0", "tuesday"),
+
+					resource.TestCheckNoResourceAttr(name, "nonce"),
 				),
 			},
 			{

--- a/integrations/terraform/tfschema/types_terraform.go
+++ b/integrations/terraform/tfschema/types_terraform.go
@@ -7659,13 +7659,6 @@ func GenSchemaClusterMaintenanceConfigV1(ctx context.Context) (github_com_hashic
 			Optional:      true,
 			PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributePlanModifier{github_com_hashicorp_terraform_plugin_framework_tfsdk.UseStateForUnknown()},
 		},
-		"nonce": {
-			Computed:      true,
-			Description:   "Nonce is used to protect against concurrent modification of the maintenance window. Clients should treat nonces as opaque.",
-			Optional:      true,
-			PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributePlanModifier{github_com_hashicorp_terraform_plugin_framework_tfsdk.UseStateForUnknown()},
-			Type:          github_com_hashicorp_terraform_plugin_framework_types.Int64Type,
-		},
 		"spec": {
 			Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.SingleNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{"agent_upgrades": {
 				Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.SingleNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
@@ -62384,23 +62377,6 @@ func CopyClusterMaintenanceConfigV1FromTerraform(_ context.Context, tf github_co
 			}
 		}
 	}
-	{
-		a, ok := tf.Attrs["nonce"]
-		if !ok {
-			diags.Append(attrReadMissingDiag{"ClusterMaintenanceConfigV1.Nonce"})
-		} else {
-			v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.Int64)
-			if !ok {
-				diags.Append(attrReadConversionFailureDiag{"ClusterMaintenanceConfigV1.Nonce", "github.com/hashicorp/terraform-plugin-framework/types.Int64"})
-			} else {
-				var t uint64
-				if !v.Null && !v.Unknown {
-					t = uint64(v.Value)
-				}
-				obj.Nonce = t
-			}
-		}
-	}
 	return diags
 }
 
@@ -62823,32 +62799,6 @@ func CopyClusterMaintenanceConfigV1ToTerraform(ctx context.Context, obj *github_
 				v.Unknown = false
 				tf.Attrs["spec"] = v
 			}
-		}
-	}
-	{
-		t, ok := tf.AttrTypes["nonce"]
-		if !ok {
-			diags.Append(attrWriteMissingDiag{"ClusterMaintenanceConfigV1.Nonce"})
-		} else {
-			v, ok := tf.Attrs["nonce"].(github_com_hashicorp_terraform_plugin_framework_types.Int64)
-			if !ok {
-				if tf.Attrs["nonce"] != nil {
-					diags.Append(attrWriteUnexpectedExistingTypeDiag{"ClusterMaintenanceConfigV1.Nonce", "github.com/hashicorp/terraform-plugin-framework/types.Int64"})
-				}
-				i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
-				if err != nil {
-					diags.Append(attrWriteGeneralError{"ClusterMaintenanceConfigV1.Nonce", err})
-				}
-				v, ok = i.(github_com_hashicorp_terraform_plugin_framework_types.Int64)
-				if !ok {
-					diags.Append(attrWriteConversionFailureDiag{"ClusterMaintenanceConfigV1.Nonce", "github.com/hashicorp/terraform-plugin-framework/types.Int64"})
-				}
-			}
-
-			v.Null = false
-			v.Value = int64(obj.Nonce)
-			v.Unknown = false
-			tf.Attrs["nonce"] = v
 		}
 	}
 	return diags


### PR DESCRIPTION
Supports: https://github.com/gravitational/teleport/issues/66912

This PR marks the `cluster_maintenance_config.nonce` attribute as an `excluded_field`.

With the `protoc-gen-terraform` v4 upgrade, the attribute will be converted into a `computed_field` and every write will result in a `Provider produced inconsistent result after apply` error. This is because the attribute will now be in sync with the Teleport backend value which changes on every write.

To address this issue, the `nonce` attribute will be marked as an `excluded_field` and be omitted from TF state. The `nonce` field is only available for the `cluster_maintenance_config` resource. It is an opaque value to users and it should be safe to hide it from users.

<!-- Provide a descriptive entry for the changelog of the next release. -->

Changelog: Exclude the `nonce` attribute  from the `cluster_maintenance_config` Terraform resource 

<!-- Include manual testing efforts to verify the change. -->
<!-- Detail where the tests where run and what configurations were used. -->
<!-- Include all the test cases which were run to validate the change. -->

## Manual Test Plan

### Test Environment
Local cluster environment

### Test Cases
- [x] Create  `cluster_maintenance_config` TF resource.
- [x] Upgrade provider with protoc-gen-terraform v4 changes included.
- [x] Run `terraform plan`, `terraform apply` and `terraform show`.
