### PR TITLE
Add page_type and outcome statements to 54 guides

### DIFF
--- a/docs/pages/enroll-resources/application-access/application-access.mdx
+++ b/docs/pages/enroll-resources/application-access/application-access.mdx
@@ -5,6 +5,7 @@ template: doc-page
 tags:
  - zero-trust
  - infrastructure-identity
+page_type: landing
 ---
 
 import DocHero from "@site/src/components/Pages/Landing/DocHero";

--- a/docs/pages/enroll-resources/application-access/cloud-apis/aws-console-roles-anywhere.mdx
+++ b/docs/pages/enroll-resources/application-access/cloud-apis/aws-console-roles-anywhere.mdx
@@ -7,6 +7,7 @@ tags:
  - zero-trust
  - infrastructure-identity
  - aws
+page_type: how-to
 ---
 
 Teleport integrates with AWS IAM Roles Anywhere to provide AWS Console and CLI access.
@@ -25,7 +26,7 @@ If you instead want AWS CLI traffic to be proxied by Teleport so that every API 
 in the Teleport audit log, or if Roles Anywhere is not adopted at your organization, see the
 guide for [agent-based AWS access](aws-console.mdx) instead.
 
-This guide will explain how to:
+In this guide, you will:
 
 - Configure AWS Console and CLI access with Teleport using Roles Anywhere
 - Access the AWS Management Console

--- a/docs/pages/enroll-resources/application-access/cloud-apis/aws-console.mdx
+++ b/docs/pages/enroll-resources/application-access/cloud-apis/aws-console.mdx
@@ -7,6 +7,7 @@ tags:
  - zero-trust
  - infrastructure-identity
  - aws
+page_type: how-to
 ---
 
 <Admonition type="tip">
@@ -20,7 +21,7 @@ like Access Requests, Access Lists, and identity locking. You can also configure
 Teleport to provide different levels of AWS access automatically when users
 authenticate using your single sign-on solution.
 
-This guide will explain how to:
+In this guide, you will:
 
 - Access the AWS Management Console through Teleport.
 - Access the AWS Command Line Interface (CLI) through Teleport.

--- a/docs/pages/enroll-resources/application-access/cloud-apis/awsoidc-integration-console.mdx
+++ b/docs/pages/enroll-resources/application-access/cloud-apis/awsoidc-integration-console.mdx
@@ -6,6 +6,7 @@ tags:
  - zero-trust
  - infrastructure-identity
  - aws
+page_type: how-to
 ---
 
 Teleport integrates with AWS IAM Identity Provider to provide AWS CLI and Console access.
@@ -19,6 +20,12 @@ If you're looking to provide AWS CLI access to your users with audit capture by 
 </Admonition>
 
 You can set up access using the "AWS CLI/Console Access via AWS OIDC IdP" enrollment wizard from the Teleport Web UI or you can follow this guide to set it up manually.
+
+In this guide, you will:
+- Use the Teleport Web UI to set up the AWS OIDC integration
+- Configure the AWS OIDC integration to assume other AWS IAM roles.
+- Enroll the AWS management console as a Teleport-protected application
+- Access the AWS management console through Teleport
 
 ## How it works
 

--- a/docs/pages/enroll-resources/application-access/cloud-apis/awsoidc-integration-rds.mdx
+++ b/docs/pages/enroll-resources/application-access/cloud-apis/awsoidc-integration-rds.mdx
@@ -6,6 +6,7 @@ tags:
  - zero-trust
  - infrastructure-identity
  - aws
+page_type: how-to
 ---
 
 The AWS RDS enrollment wizard is available in your Teleport cluster Web UI as
@@ -18,6 +19,10 @@ databases.
 The enrollment wizard can be used to enroll RDS databases in a Teleport cluster.
 It's also useful as an example of a serverless Teleport Database Service
 deployment on ECS.
+
+In this guide, you will authorize your Teleport user to enroll Amazon RDS
+databases with your Teleport cluster, then use the Teleport Web UI to enable the
+AWS OIDC integration in order to enroll your databases.
 
 ## How it works
 

--- a/docs/pages/enroll-resources/application-access/cloud-apis/awsoidc-integration.mdx
+++ b/docs/pages/enroll-resources/application-access/cloud-apis/awsoidc-integration.mdx
@@ -5,9 +5,8 @@ tags:
  - how-to
  - platform-wide
  - aws
+page_type: how-to
 ---
-
-This guide explains how to set up the Teleport AWS OIDC integration.
 
 With the AWS OIDC integration you will no longer need to deploy Teleport Agents in AWS manually for most use cases.
 The following features use an AWS OIDC integration to interact with AWS:
@@ -18,6 +17,8 @@ The following features use an AWS OIDC integration to interact with AWS:
 - [Protect AWS CLI and Console access with Teleport](./awsoidc-integration-console.mdx)
 
 It targets users who would prefer a more manual approach or to manage the integration with Infrastructure as Code tools.
+
+In this guide, you will set up the Teleport AWS OIDC integration.
 
 As an alternative to this guide, you can use the Teleport Web UI. In the left-hand pane, click **Add New** -> **Integration**.
 

--- a/docs/pages/enroll-resources/application-access/cloud-apis/azure-aks-workload-id.mdx
+++ b/docs/pages/enroll-resources/application-access/cloud-apis/azure-aks-workload-id.mdx
@@ -7,6 +7,7 @@ tags:
  - zero-trust
  - infrastructure-identity
  - azure
+page_type: how-to
 ---
 
 (!docs/pages/includes/application-access/azure-intro.mdx!)

--- a/docs/pages/enroll-resources/application-access/cloud-apis/azure.mdx
+++ b/docs/pages/enroll-resources/application-access/cloud-apis/azure.mdx
@@ -8,6 +8,7 @@ tags:
  - zero-trust
  - infrastructure-identity
  - azure
+page_type: how-to
 ---
 
 (!docs/pages/includes/application-access/azure-intro.mdx!)

--- a/docs/pages/enroll-resources/application-access/cloud-apis/cloud-apis.mdx
+++ b/docs/pages/enroll-resources/application-access/cloud-apis/cloud-apis.mdx
@@ -7,6 +7,7 @@ description: "Use Teleport to achieve secure access to your cloud-based APIs."
 tags:
  - zero-trust
  - infrastructure-identity
+page_type: landing
 ---
 import EnrollmentMethods, { Method } from "@site/src/components/Pages/Landing/EnrollmentMethods/EnrollmentMethods";
 

--- a/docs/pages/enroll-resources/application-access/cloud-apis/github-integration.mdx
+++ b/docs/pages/enroll-resources/application-access/cloud-apis/github-integration.mdx
@@ -5,6 +5,7 @@ tags:
  - how-to
  - zero-trust
  - infrastructure-identity
+page_type: how-to
 ---
 
 Teleport can proxy Git commands and use short-lived SSH certificates to

--- a/docs/pages/enroll-resources/application-access/cloud-apis/google-cloud.mdx
+++ b/docs/pages/enroll-resources/application-access/cloud-apis/google-cloud.mdx
@@ -7,12 +7,15 @@ tags:
  - zero-trust
  - infrastructure-identity
  - google-cloud
+page_type: how-to
 ---
 
 You can use Teleport to manage access to CLI tools that interact with Google
 Cloud's APIs. This lets you control access to your infrastructure's management
 APIs using the same RBAC system that you use to protect your infrastructure
 itself.
+
+In this guide, you will enroll the Google Cloud API with Teleport.
 
 ## How it works
 

--- a/docs/pages/enroll-resources/application-access/configuration/configuration.mdx
+++ b/docs/pages/enroll-resources/application-access/configuration/configuration.mdx
@@ -2,6 +2,7 @@
 title: Teleport Application Service Configuration
 sidebar_label: Configuration Guides
 description: Provides instructions for configuring the Teleport Application Service
+page_type: landing
 ---
 
 The guides in this section show you how to configure the Teleport Application

--- a/docs/pages/enroll-resources/application-access/configuration/controls.mdx
+++ b/docs/pages/enroll-resources/application-access/configuration/controls.mdx
@@ -6,10 +6,12 @@ tags:
  - conceptual
  - zero-trust
  - infrastructure-identity
+page_type: conceptual
 ---
 
-This article describes access control concepts particularly relevant to the
-Teleport Application Service.
+This page describes the options available for the Teleport Application Service
+and Teleport roles that grant or deny permissions to access applications through
+Teleport.
 
 ## Assigning labels to applications
 

--- a/docs/pages/enroll-resources/application-access/configuration/dynamic-registration.mdx
+++ b/docs/pages/enroll-resources/application-access/configuration/dynamic-registration.mdx
@@ -6,6 +6,7 @@ tags:
  - conceptual
  - zero-trust
  - infrastructure-identity
+page_type: conceptual
 ---
 
 Dynamic app registration allows Teleport administrators to register new apps (or
@@ -20,6 +21,9 @@ Dynamic registration is useful for managing pools of Application Service
 instances. And behind the scenes, the Teleport Discovery Service uses dynamic
 registration to [register Kubernetes
 applications](../../auto-discovery/kubernetes-applications/kubernetes-applications.mdx).
+
+This page describes the Teleport configuration options for dynamic application
+registration.
 
 ## Required permissions
 

--- a/docs/pages/enroll-resources/application-access/getting-started.mdx
+++ b/docs/pages/enroll-resources/application-access/getting-started.mdx
@@ -7,14 +7,15 @@ tags:
  - how-to
  - zero-trust
  - infrastructure-identity
+page_type: how-to
 ---
 
-This tutorial demonstrates how to configure secure access to an application 
-through Teleport. The tutorial uses Grafana as a sample application because 
-it's straightforward to install and run in a Docker container or Kubernetes cluster 
-with no additional configuration required. If you want to configure access 
-for a different web application, you can use this tutorial as a 
-general guide for what to do. 
+In this guide, you will configure secure access to an application through
+Teleport. The tutorial uses Grafana as a sample application because it's
+straightforward to install and run in a Docker container or Kubernetes cluster
+with no additional configuration required. If you want to configure access for a
+different web application, you can use this tutorial as a general guide for what
+to do. 
 
 At a high level, configuring access for applications involves the following steps:
 

--- a/docs/pages/enroll-resources/application-access/jwt/elasticsearch.mdx
+++ b/docs/pages/enroll-resources/application-access/jwt/elasticsearch.mdx
@@ -6,6 +6,7 @@ tags:
  - how-to
  - zero-trust
  - infrastructure-identity
+page_type: how-to
 ---
 
 {/* lint disable page-structure remark-lint */}

--- a/docs/pages/enroll-resources/application-access/jwt/grafana.mdx
+++ b/docs/pages/enroll-resources/application-access/jwt/grafana.mdx
@@ -6,11 +6,12 @@ tags:
  - how-to
  - zero-trust
  - infrastructure-identity
+page_type: how-to
 ---
 
-This guide will help you configure Grafana [JWT
-authentication](https://grafana.com/docs/grafana/latest/setup-grafana/configure-access/configure-authentication/jwt/)
-with Teleport.
+In this guide, you will enroll Grafana as a Teleport-protected application that
+uses [JSON Web Token
+authentication](https://grafana.com/docs/grafana/latest/setup-grafana/configure-access/configure-authentication/jwt/).
 
 ## How it works
 

--- a/docs/pages/enroll-resources/application-access/jwt/introduction.mdx
+++ b/docs/pages/enroll-resources/application-access/jwt/introduction.mdx
@@ -6,7 +6,11 @@ tags:
  - conceptual
  - zero-trust
  - infrastructure-identity
+page_type: conceptual
 ---
+
+This page describes how Teleport supports JSON Web Token authentication with
+protected applications.
 
 (!docs/pages/includes/application-access/jwt-intro.mdx!)
 

--- a/docs/pages/enroll-resources/application-access/jwt/jwt.mdx
+++ b/docs/pages/enroll-resources/application-access/jwt/jwt.mdx
@@ -7,6 +7,7 @@ template: "no-toc"
 tags:
  - zero-trust
  - infrastructure-identity
+page_type: landing
 ---
 
 These guides explain how web apps behind the Teleport Application Service can

--- a/docs/pages/enroll-resources/application-access/protect-apps/amazon-athena.mdx
+++ b/docs/pages/enroll-resources/application-access/protect-apps/amazon-athena.mdx
@@ -7,6 +7,7 @@ tags:
  - zero-trust
  - infrastructure-identity
  - aws
+page_type: how-to
 ---
 
 {/* lint disable page-structure remark-lint */}

--- a/docs/pages/enroll-resources/application-access/protect-apps/api-access.mdx
+++ b/docs/pages/enroll-resources/application-access/protect-apps/api-access.mdx
@@ -6,6 +6,7 @@ tags:
  - how-to
  - zero-trust
  - infrastructure-identity
+page_type: how-to
 ---
 
 The Teleport Application Service can be used to access applications' (REST or
@@ -15,6 +16,10 @@ Teleport's own gRPC) APIs with tools like
 <Admonition type="note" title="Non-HTTP API Support">
 Use [TCP application access](./tcp.mdx) for non-HTTP APIs (like gRPC).
 </Admonition>
+
+In this guide, you will use `tsh` to authenticate to Teleport, list available
+applications, and use Teleport-issued TLS credentials to interact with them
+using an HTTP client.
 
 ## Prerequisites
 

--- a/docs/pages/enroll-resources/application-access/protect-apps/connecting-apps.mdx
+++ b/docs/pages/enroll-resources/application-access/protect-apps/connecting-apps.mdx
@@ -6,6 +6,7 @@ tags:
  - how-to
  - zero-trust
  - infrastructure-identity
+page_type: how-to
 ---
 
 This guide shows you how to enroll a web application with your Teleport cluster

--- a/docs/pages/enroll-resources/application-access/protect-apps/dynamodb.mdx
+++ b/docs/pages/enroll-resources/application-access/protect-apps/dynamodb.mdx
@@ -7,12 +7,13 @@ tags:
  - zero-trust
  - infrastructure-identity
  - aws
+page_type: how-to
 ---
 
 You can configure the Teleport Application Service to enable secure access to
 Amazon DynamoDB.
 
-This guide will help you to:
+In this guide, you will:
 
 - Install the Teleport Application Service.
 - Set up the Teleport Application Service to access the AWS Console and API.

--- a/docs/pages/enroll-resources/application-access/protect-apps/openclaw.mdx
+++ b/docs/pages/enroll-resources/application-access/protect-apps/openclaw.mdx
@@ -7,6 +7,7 @@ tags:
  - how-to
  - zero-trust
  - infrastructure-identity
+page_type: how-to
 ---
 
 [OpenClaw](https://openclaw.ai) is a personal AI assistant that you can deploy on your own hardware or cloud servers.

--- a/docs/pages/enroll-resources/application-access/protect-apps/protect-apps.mdx
+++ b/docs/pages/enroll-resources/application-access/protect-apps/protect-apps.mdx
@@ -3,6 +3,7 @@ title: Protecting Applications with Teleport
 sidebar_label: Internal Applications
 sidebar_position: 3
 description: Provides step-by-step instructions to protecting different kinds of applications with Teleport.
+page_type: landing
 ---
 
 The guides in this section show you how to enroll specific kinds of applications

--- a/docs/pages/enroll-resources/application-access/protect-apps/tcp.mdx
+++ b/docs/pages/enroll-resources/application-access/protect-apps/tcp.mdx
@@ -6,12 +6,15 @@ tags:
  - how-to
  - zero-trust
  - infrastructure-identity
+page_type: how-to
 ---
 
 Teleport can provide access to any TCP-based application. This allows users to
 connect to applications which Teleport doesn't natively support such as SMTP
 servers or databases not yet natively supported by the Teleport Database
 Service.
+
+In this guide, you will enroll a local TCP application with Teleport.
 
 ## How it works
 

--- a/docs/pages/enroll-resources/application-access/reference.mdx
+++ b/docs/pages/enroll-resources/application-access/reference.mdx
@@ -7,9 +7,10 @@ tags:
  - reference
  - zero-trust
  - infrastructure-identity
+page_type: reference
 ---
 
-This guide describes interfaces and options for interacting with the Teleport
+This page lists the interfaces and options for interacting with the Teleport
 Application Service, including the static configuration file for the `teleport`
 binary, the dynamic `app` resource, and `tsh apps` commands.
 

--- a/docs/pages/enroll-resources/application-access/troubleshooting-apps.mdx
+++ b/docs/pages/enroll-resources/application-access/troubleshooting-apps.mdx
@@ -6,9 +6,10 @@ tags:
  - how-to
  - zero-trust
  - infrastructure-identity
+page_type: troubleshooting
 ---
 
-This section describes common issues that you might encounter in managing access to applications
+This page describes common issues that you might encounter in managing access to applications
 with Teleport and how to work around or resolve them.
 
 ## Unable to access applications

--- a/docs/pages/enroll-resources/application-access/vnet.mdx
+++ b/docs/pages/enroll-resources/application-access/vnet.mdx
@@ -6,10 +6,13 @@ tags:
  - how-to
  - zero-trust
  - infrastructure-identity
+page_type: how-to
 ---
 
 VNet automatically proxies connections made to TCP applications available under the public address
-of a Proxy Service. This guide explains how to configure VNet to support apps with [custom public
+of a Proxy Service. 
+
+In this guide, you will configure VNet to support apps with [custom public
 addresses](protect-apps/connecting-apps.mdx#customize-public-address).
 
 ## How it works

--- a/docs/pages/enroll-resources/database-access/auto-user-provisioning/auto-user-provisioning.mdx
+++ b/docs/pages/enroll-resources/database-access/auto-user-provisioning/auto-user-provisioning.mdx
@@ -5,6 +5,7 @@ description: Configure automatic user provisioning for databases.
 tags:
  - zero-trust
  - infrastructure-identity
+page_type: landing
 ---
 
 (!docs/pages/includes/database-access/auto-user-provisioning/intro.mdx!)

--- a/docs/pages/enroll-resources/database-access/auto-user-provisioning/mysql.mdx
+++ b/docs/pages/enroll-resources/database-access/auto-user-provisioning/mysql.mdx
@@ -6,6 +6,7 @@ tags:
  - how-to
  - zero-trust
  - infrastructure-identity
+page_type: how-to
 ---
 
 Teleport can automatically create an account in your MySQL database when a

--- a/docs/pages/enroll-resources/database-access/database-access.mdx
+++ b/docs/pages/enroll-resources/database-access/database-access.mdx
@@ -5,6 +5,7 @@ template: doc-page
 tags:
  - zero-trust
  - infrastructure-identity
+page_type: landing
 ---
 import DocHero from "@site/src/components/Pages/Landing/DocHero";
 import UseCasesList from "@site/src/components/Pages/Landing/UseCasesList";

--- a/docs/pages/enroll-resources/database-access/enrollment/aws/aws-cross-account.mdx
+++ b/docs/pages/enroll-resources/database-access/enrollment/aws/aws-cross-account.mdx
@@ -8,11 +8,17 @@ tags:
  - zero-trust
  - infrastructure-identity
  - aws
+page_type: conceptual
 ---
 
 You can deploy the Teleport Database Service with AWS IAM credentials in one
 AWS account and use an AWS IAM role to grant Teleport access to databases in
 another AWS account.
+
+This page describes the requirements for configuring Teleport to protect
+databases across AWS accounts.
+
+## How it works
 
 When the Teleport Database Service needs to discover, configure, or retrieve
 short-lived authentication tokens for AWS databases, it uses credentials for an

--- a/docs/pages/enroll-resources/database-access/enrollment/aws/aws.mdx
+++ b/docs/pages/enroll-resources/database-access/enrollment/aws/aws.mdx
@@ -6,6 +6,7 @@ tags:
  - zero-trust
  - infrastructure-identity
  - aws
+page_type: landing
 ---
 
 The guides in this section show you how to protect AWS-managed databases with

--- a/docs/pages/enroll-resources/database-access/enrollment/aws/rds-proxy/rds-proxy-mysql.mdx
+++ b/docs/pages/enroll-resources/database-access/enrollment/aws/rds-proxy/rds-proxy-mysql.mdx
@@ -7,6 +7,7 @@ tags:
  - zero-trust
  - infrastructure-identity
  - aws
+page_type: how-to
 ---
 
 (!docs/pages/includes/database-access/db-introduction.mdx dbType="Amazon RDS proxy for MariaDB or MySQL" dbConfigure="with IAM authentication"!)

--- a/docs/pages/enroll-resources/database-access/enrollment/aws/rds-proxy/rds-proxy-postgres.mdx
+++ b/docs/pages/enroll-resources/database-access/enrollment/aws/rds-proxy/rds-proxy-postgres.mdx
@@ -7,6 +7,7 @@ tags:
  - zero-trust
  - infrastructure-identity
  - aws
+page_type: how-to
 ---
 
 (!docs/pages/includes/database-access/db-introduction.mdx dbType="Amazon RDS proxy for PostgreSQL" dbConfigure="with IAM authentication"!)

--- a/docs/pages/enroll-resources/database-access/enrollment/aws/rds-proxy/rds-proxy-sqlserver.mdx
+++ b/docs/pages/enroll-resources/database-access/enrollment/aws/rds-proxy/rds-proxy-sqlserver.mdx
@@ -7,6 +7,7 @@ tags:
  - zero-trust
  - aws
  - infrastructure-identity
+page_type: how-to
 ---
 
 (!docs/pages/includes/database-access/db-introduction.mdx dbType="Amazon RDS proxy for Microsoft SQL Server" dbConfigure="with IAM authentication"!)

--- a/docs/pages/enroll-resources/database-access/enrollment/aws/rds-proxy/rds-proxy.mdx
+++ b/docs/pages/enroll-resources/database-access/enrollment/aws/rds-proxy/rds-proxy.mdx
@@ -2,6 +2,7 @@
 title: Protecting Amazon RDS Proxy
 sidebar_label: RDS Proxy
 description: Provides guidance on enrolling Amazon RDS Proxy databases with Teleport.
+page_type: landing
 ---
 
 The guides in this section show you how to enroll Amazon RDS Proxy databases

--- a/docs/pages/enroll-resources/database-access/enrollment/aws/rds/rds.mdx
+++ b/docs/pages/enroll-resources/database-access/enrollment/aws/rds/rds.mdx
@@ -2,6 +2,7 @@
 title: Protecting Amazon RDS and Aurora Databases
 sidebar_label: RDS and Aurora
 description: Guides for protecting Amazon RDS databases with Teleport
+page_type: landing
 ---
 
 The guides in this section show you how to protect Amazon RDS and Aurora

--- a/docs/pages/enroll-resources/database-access/enrollment/azure/azure.mdx
+++ b/docs/pages/enroll-resources/database-access/enrollment/azure/azure.mdx
@@ -6,6 +6,7 @@ tags:
  - zero-trust
  - infrastructure-identity
  - azure
+page_type: landing
 ---
 
 You can protect Azure-managed databases with Teleport. Learn how to enroll the

--- a/docs/pages/enroll-resources/database-access/enrollment/enrollment.mdx
+++ b/docs/pages/enroll-resources/database-access/enrollment/enrollment.mdx
@@ -3,6 +3,7 @@ title: Database Enrollment Guides
 sidebar_label: Enrollment Guides
 sidebar_position: 2
 description: Provides instructions on enrolling databases with your Teleport cluster for secure access, authentication, authorization, and audit.
+page_type: landing
 ---
 
 The guides in this section show you how to enroll your database with Teleport

--- a/docs/pages/enroll-resources/database-access/enrollment/google-cloud/google-cloud.mdx
+++ b/docs/pages/enroll-resources/database-access/enrollment/google-cloud/google-cloud.mdx
@@ -6,6 +6,7 @@ tags:
  - zero-trust
  - infrastructure-identity
  - google-cloud
+page_type: landing
 ---
 
 You can protect databases hosted on Google Cloud with Teleport. Read the

--- a/docs/pages/enroll-resources/database-access/enrollment/managed/managed.mdx
+++ b/docs/pages/enroll-resources/database-access/enrollment/managed/managed.mdx
@@ -5,6 +5,7 @@ description: "Provides instructions on protecting managed databases in your infr
 tags:
  - zero-trust
  - infrastructure-identity
+page_type: landing
 ---
 
 Teleport can protect databases that are managed as a dedicated cloud platform.

--- a/docs/pages/enroll-resources/database-access/enrollment/self-hosted/self-hosted.mdx
+++ b/docs/pages/enroll-resources/database-access/enrollment/self-hosted/self-hosted.mdx
@@ -5,6 +5,7 @@ description: "Provides instructions on protecting self-hosted databases in your 
 tags:
  - zero-trust
  - infrastructure-identity
+page_type: landing
 ---
 
 You can protect self-hosted databases with Teleport. Learn how to enroll your

--- a/docs/pages/enroll-resources/database-access/faq.mdx
+++ b/docs/pages/enroll-resources/database-access/faq.mdx
@@ -6,11 +6,12 @@ tags:
  - faq
  - zero-trust
  - infrastructure-identity
+page_type: faq
 ---
 
-This page provides the answers to common questions about enrolling databases
-with Teleport. For a list of frequently asked questions about Teleport in
-general, see [Frequently Asked Questions](../../faq.mdx).
+This page provides answers to frequently asked questions about enrolling
+databases with Teleport. For a list of frequently asked questions about Teleport
+in general, see [Frequently Asked Questions](../../faq.mdx).
 
 ## Which database protocols does Teleport the Database Service support?
 

--- a/docs/pages/enroll-resources/database-access/guides/guides.mdx
+++ b/docs/pages/enroll-resources/database-access/guides/guides.mdx
@@ -6,6 +6,7 @@ template: "no-toc"
 tags:
  - zero-trust
  - infrastructure-identity
+page_type: landing
 ---
 
 The Teleport Database Service proxies connections to databases protected by

--- a/docs/pages/enroll-resources/database-access/guides/health-checks.mdx
+++ b/docs/pages/enroll-resources/database-access/guides/health-checks.mdx
@@ -6,10 +6,15 @@ tags:
 - conceptual
 - zero-trust
 - infrastructure-identity
+page_type: conceptual
 ---
 
-This documentation explains how to manage database health checks.
-Available in Teleport 18, database health checks are used to monitor connectivity from Teleport Database Service instances to databases enrolled in a Teleport cluster.
+Available in Teleport 18, database health checks are used to monitor
+connectivity from Teleport Database Service instances to databases enrolled in a
+Teleport cluster.
+
+This page describes how database health checks work and how you can configure
+them with the `health_check_config` resource.
 
 Why monitor database connectivity with health checks?
 

--- a/docs/pages/enroll-resources/database-access/rbac.mdx
+++ b/docs/pages/enroll-resources/database-access/rbac.mdx
@@ -6,12 +6,19 @@ tags:
  - conceptual
  - zero-trust
  - privileged-access
+page_type: conceptual
 ---
 
 **Database Access Controls** is a Teleport feature that lets you configure
 role-based access controls for databases and the data within them. With Database
 Access Controls, you can ensure that users only have permissions to manage the
 data they need.
+
+This page describes the configuration options in Teleport roles and database
+object import rules that allow you to restrict the operations that users can
+perform against Teleport-protected databases.
+
+## How it works
 
 Access Controls encompasses two levels of granularity:
 

--- a/docs/pages/enroll-resources/database-access/reference/audit.mdx
+++ b/docs/pages/enroll-resources/database-access/reference/audit.mdx
@@ -6,8 +6,11 @@ tags:
  - reference
  - zero-trust
  - infrastructure-identity
+page_type: reference
 ---
 
+This page lists the audit events that pertain to sessions in Teleport-protected
+databases.
 
 (!docs/pages/includes/database-access/db-audit-events.mdx!)
 

--- a/docs/pages/enroll-resources/database-access/reference/aws.mdx
+++ b/docs/pages/enroll-resources/database-access/reference/aws.mdx
@@ -6,6 +6,7 @@ tags:
  - reference
  - zero-trust
  - infrastructure-identity
+page_type: reference
 ---
 
 The Teleport Database Service requires IAM permissions for various tasks
@@ -22,8 +23,9 @@ policies:
 $ teleport db configure aws print-iam --types rds,redshift --role teleport-db-service-role
 ```
 
-To learn more about IAM permissions for a specific type of database, refer to
-the related section below.
+This page lists the AWS IAM permissions required for protecting different
+databases with Teleport. To learn more about IAM permissions for a specific type
+of database, refer to the related section below.
 
 ## DocumentDB
 

--- a/docs/pages/enroll-resources/database-access/reference/cli.mdx
+++ b/docs/pages/enroll-resources/database-access/reference/cli.mdx
@@ -6,10 +6,11 @@ tags:
  - reference
  - zero-trust
  - infrastructure-identity
+page_type: reference
 ---
 
-This reference shows you how to run common commands for managing Teleport
-the Database Service, including:
+This page lists the Teleport CLI commands that are relevant to managing
+Teleport-protected databases, including:
 
 - The `teleport` daemon command, which is executed on the host where you
   will run the Teleport Database Service.

--- a/docs/pages/enroll-resources/database-access/reference/labels.mdx
+++ b/docs/pages/enroll-resources/database-access/reference/labels.mdx
@@ -6,10 +6,13 @@ tags:
  - reference
  - zero-trust
  - infrastructure-identity
+page_type: reference
 ---
 
-Teleport assigns system-defined labels to protected databases. This guide
-describes the system-defined labels and how Teleport uses them.
+Teleport assigns system-defined labels to protected databases. 
+
+This page lists the labels that Teleport assigns to protected databases and
+describes how Teleport uses them.
 
 ## Origin
 

--- a/docs/pages/enroll-resources/database-access/reference/reference.mdx
+++ b/docs/pages/enroll-resources/database-access/reference/reference.mdx
@@ -6,6 +6,7 @@ description: Configuration and CLI reference for the Teleport Database Service.
 tags:
  - zero-trust
  - infrastructure-identity
+page_type: landing
 ---
 
 - [CLI](cli.mdx)

--- a/docs/pages/enroll-resources/database-access/troubleshooting.mdx
+++ b/docs/pages/enroll-resources/database-access/troubleshooting.mdx
@@ -6,9 +6,11 @@ tags:
  - how-to
  - zero-trust
  - infrastructure-identity
+page_type: troubleshooting
 ---
 
-Common issues and resolution steps.
+This page describes common issues that occur when enrolling databases with
+Teleport and how to work around or resolve them.
 
 ## Connection attempts fail
 


### PR DESCRIPTION
We are standardizing docs guides to add a page_type frontmatter field, with values for how-to guides, references, etc. We can then use this field to apply linting rules that ensure each guide type follows type-specific docs site conventions. The first convention is that each docs page must have an outcome statement, the structure of which depends on the guide's type. Human and AI agent readers can determine from the outcome statement whether to continue reading the guide or not.

This change assigns the `page_type` frontmatter field to 55 guides. Where an outcome statement is missing, it adds one.  Where an outcome statement exists, it ensures that the statement matches the standard structure so we can add a linter later on. (A majority of guides were already compliant.)