### PR TITLE
Set websocket read limits on all handler read paths

### DIFF
--- a/lib/kube/proxy/forwarder.go
+++ b/lib/kube/proxy/forwarder.go
@@ -1563,6 +1563,8 @@ func (f *Forwarder) getSessionHostID(ctx context.Context, authCtx *authContext, 
 // wsProxy proxies a websocket connection between two clusters transparently to allow for
 // remote joins.
 func wsProxy(ctx context.Context, log *slog.Logger, wsSource *gwebsocket.Conn, wsTarget *gwebsocket.Conn) {
+	wsSource.SetReadLimit(teleport.MaxHTTPRequestSize)
+	wsTarget.SetReadLimit(teleport.MaxHTTPRequestSize)
 	errS := make(chan error, 1)
 	errT := make(chan error, 1)
 	wg := &sync.WaitGroup{}

--- a/lib/kube/proxy/streamproto/proto.go
+++ b/lib/kube/proxy/streamproto/proto.go
@@ -32,6 +32,7 @@ import (
 	"github.com/gravitational/trace"
 	"k8s.io/client-go/tools/remotecommand"
 
+	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/utils"
 )
@@ -166,6 +167,7 @@ func NewSessionStream(conn *websocket.Conn, handshake any) (*SessionStream, erro
 
 func (s *SessionStream) readTask() {
 	defer s.closeOnce.Do(func() { close(s.done) })
+	s.conn.SetReadLimit(teleport.MaxHTTPRequestSize)
 	for {
 		ty, data, err := s.conn.ReadMessage()
 		if err != nil {

--- a/lib/web/desktop.go
+++ b/lib/web/desktop.go
@@ -36,6 +36,7 @@ import (
 	"github.com/jonboulle/clockwork"
 	"github.com/julienschmidt/httprouter"
 
+	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/client/proto"
 	"github.com/gravitational/teleport/api/constants"
 	tdpbv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/desktop/v1"
@@ -364,6 +365,7 @@ func (h *Handler) createDesktopConnection(
 	ws *websocket.Conn,
 ) error {
 	defer ws.Close()
+	ws.SetReadLimit(teleport.MaxHTTPRequestSize)
 	ctx := r.Context()
 
 	// Client may speak TDP or TDPB. We'll know based on the existence of the 'tdpb' query parameter.

--- a/lib/web/desktop/playback.go
+++ b/lib/web/desktop/playback.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/gorilla/websocket"
 
+	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/types/events"
 	"github.com/gravitational/teleport/lib/player"
 	"github.com/gravitational/teleport/lib/utils"
@@ -69,6 +70,7 @@ func ReceivePlaybackActions(
 	logger *slog.Logger,
 	ws *websocket.Conn,
 	player *player.Player) {
+	ws.SetReadLimit(teleport.MaxHTTPRequestSize)
 	// playback always starts in a playing state
 	playing := true
 

--- a/lib/web/recordingplayback.go
+++ b/lib/web/recordingplayback.go
@@ -276,6 +276,7 @@ func (s *recordingPlayback) logWebsocketError(err error) {
 
 // readLoop reads messages from the websocket connection and processes them.
 func (s *recordingPlayback) readLoop() {
+	s.ws.SetReadLimit(teleport.MaxHTTPRequestSize)
 	for {
 		msgType, data, err := s.ws.ReadMessage()
 		if err != nil {

--- a/lib/web/tty_playback.go
+++ b/lib/web/tty_playback.go
@@ -29,6 +29,7 @@ import (
 	"github.com/gravitational/trace"
 	"github.com/julienschmidt/httprouter"
 
+	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/types/events"
 	"github.com/gravitational/teleport/lib/player"
 	"github.com/gravitational/teleport/lib/reversetunnelclient"
@@ -130,6 +131,7 @@ func (h *Handler) ttyPlaybackHandle(
 		// (this means we don't need to return an error here)
 		return nil, nil
 	}
+	ws.SetReadLimit(teleport.MaxHTTPRequestSize)
 
 	player, err := player.New(&player.Config{
 		Clock:     h.clock,


### PR DESCRIPTION
## Context
gorilla/websocket defaults to no read limit. Without calling `SetReadLimit`, the server will attempt to buffer an entire incoming frame in memory. The terminal websocket handler already calls `SetReadLimit(teleport.MaxHTTPRequestSize)`, but other websocket handlers do not. All affected endpoints first require authentication, but a single oversized frame can still cause significant memory pressure or OOM the proxy.

Add `ws.SetReadLimit(teleport.MaxHTTPRequestSize)` before the first read on all websocket connections that were missing it.

## Manual Test Plan
### Test Environment
- Local Auth+Proxy built from master and from this branch.

### Test Cases
- [ ] Open a desktop or terminal session in the web UI, then in the browser console run:
  ```js
  const ws = new WebSocket("wss://localhost:3080/v1/webapi/sites/local/ttyplayback/test");
  ws.onclose = e => console.log("close code:", e.code, e.reason);
  ws.onopen = () => ws.send(new Uint8Array(10 * 1024 * 1024 + 1));
  ```
  Verify that the connection:
  - [ ] on master build, succeeds and increases Proxy memory usage.
  - [ ] on this branch build, is rejected with close code 1009.