### PR TITLE
[cache] add name-prefixed index helpers

### DIFF
--- a/lib/backend/backend.go
+++ b/lib/backend/backend.go
@@ -23,6 +23,7 @@ import (
 	"context"
 	"fmt"
 	"iter"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -296,10 +297,28 @@ type KeyedItem interface {
 // have the HostID part.
 func GetPaginationKey(ki KeyedItem) string {
 	if h, ok := ki.(HostID); ok {
-		return h.GetHostID() + SeparatorString + h.GetName()
+		return HostIDPaginationKey(h.GetHostID(), h.GetName())
 	}
 
 	return ki.GetName()
+}
+
+// HostIDPaginationKey returns a pagination key for resources identified by host ID and name.
+func HostIDPaginationKey(hostID, name string) string {
+	return hostID + SeparatorString + name
+}
+
+// ParseHostIDPaginationKey parses a pagination key for resources identified by host ID and name.
+func ParseHostIDPaginationKey(paginationKey string) (hostID, name string, err error) {
+	// TODO(wethreetrees): if Metadata.Name == Spec.Database.GetName() becomes a
+	// DatabaseServerV3.CheckAndSetDefaults invariant or server name validation
+	// is added (e.g. no separator allowed), we can simplify this function by
+	// parsing with KeyFromString and validating the components and their values.
+	hostID, name, ok := strings.Cut(paginationKey, SeparatorString)
+	if !ok || hostID == "" || name == "" {
+		return "", "", trace.BadParameter("invalid host ID pagination key %q", paginationKey)
+	}
+	return hostID, name, nil
 }
 
 // MaskKeyName masks the given key name.

--- a/lib/backend/backend_test.go
+++ b/lib/backend/backend_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/gravitational/trace"
 	"github.com/stretchr/testify/require"
 )
 
@@ -69,6 +70,66 @@ func TestRangeEnd(t *testing.T) {
 		t.Run(test.key.String(), func(t *testing.T) {
 			end := RangeEnd(test.key)
 			require.Empty(t, cmp.Diff(test.expected, end, cmp.AllowUnexported(Key{})))
+		})
+	}
+}
+
+func TestHostIDPaginationKey(t *testing.T) {
+	t.Parallel()
+
+	const (
+		expectedHostID        = "host-id"
+		expectedServerName    = "server-name"
+		expectedPaginationKey = expectedHostID + SeparatorString + expectedServerName
+	)
+
+	key := HostIDPaginationKey(expectedHostID, expectedServerName)
+	require.Equal(t, expectedPaginationKey, key)
+
+	hostID, name, err := ParseHostIDPaginationKey(key)
+	require.NoError(t, err)
+	require.Equal(t, expectedHostID, hostID)
+	require.Equal(t, expectedServerName, name)
+
+	_, _, err = ParseHostIDPaginationKey("invalid")
+	require.ErrorAs(t, err, new(*trace.BadParameterError))
+}
+
+func TestParseHostIDPaginationKeyRejectsInvalidKeys(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		key  string
+	}{
+		{
+			name: "empty key",
+			key:  "",
+		},
+		{
+			name: "separator only",
+			key:  SeparatorString,
+		},
+		{
+			name: "missing separator",
+			key:  "invalid",
+		},
+		{
+			name: "missing name",
+			key:  "host-id" + SeparatorString,
+		},
+		{
+			name: "missing host ID",
+			key:  SeparatorString + "server-name",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			_, _, err := ParseHostIDPaginationKey(tt.key)
+			require.ErrorAs(t, err, new(*trace.BadParameterError))
 		})
 	}
 }

--- a/lib/cache/database.go
+++ b/lib/cache/database.go
@@ -19,11 +19,9 @@ package cache
 import (
 	"context"
 	"iter"
-	"strings"
 
 	"github.com/gravitational/trace"
 	"google.golang.org/protobuf/proto"
-	"rsc.io/ordered"
 
 	"github.com/gravitational/teleport/api/client"
 	clientproto "github.com/gravitational/teleport/api/client/proto"
@@ -180,7 +178,7 @@ func databaseServerByDatabaseNameKey(s types.DatabaseServer) string {
 	if db == nil {
 		return ""
 	}
-	return string(ordered.Encode(db.GetName(), s.GetHostID(), s.GetName()))
+	return namePrefixedServerIndexKey(db.GetName(), s.GetHostID(), s.GetName())
 }
 
 func newDatabaseServerCollection(p services.Presence, w types.WatchKind) (*collection[types.DatabaseServer, databaseServerIndex], error) {
@@ -194,7 +192,7 @@ func newDatabaseServerCollection(p services.Presence, w types.WatchKind) (*colle
 			types.DatabaseServer.Copy,
 			map[databaseServerIndex]func(types.DatabaseServer) string{
 				databaseServerNameIndex: func(u types.DatabaseServer) string {
-					return u.GetHostID() + "/" + u.GetName()
+					return backend.GetPaginationKey(u)
 				},
 				databaseServerDatabaseNameIndex: databaseServerByDatabaseNameKey,
 			}),
@@ -252,33 +250,16 @@ func (c *Cache) RangeDatabaseServersWithName(ctx context.Context, databaseName s
 		defer span.End()
 
 		upstreamListFn := func(ctx context.Context, pageSize int, startToken string) ([]types.DatabaseServer, string, error) {
-			var tokenDatabaseName string
-			rest, err := ordered.DecodePrefix([]byte(startToken), &tokenDatabaseName)
+			listStartKey, err := namePrefixedServerIndexKeyToListResourcesKey(startToken, databaseName)
 			if err != nil {
 				return nil, "", trace.Wrap(err)
-			}
-
-			// Verify that the token's database name matches the requested database name.
-			// This ensures that if the token is malformed or belongs to a different
-			// database, we don't return incorrect results.
-			if tokenDatabaseName != databaseName {
-				return nil, "", trace.BadParameter("pagination token does not match the requested database name")
-			}
-
-			backendKey := ""
-			if len(rest) > 0 {
-				var hostID, serverName string
-				if err := ordered.Decode(rest, &hostID, &serverName); err != nil {
-					return nil, "", trace.Wrap(err)
-				}
-				backendKey = hostID + "/" + serverName
 			}
 
 			resp, err := c.Config.Presence.ListResources(ctx, clientproto.ListResourcesRequest{
 				ResourceType: types.KindDatabaseServer,
 				Namespace:    defaults.Namespace,
 				Limit:        int32(pageSize),
-				StartKey:     backendKey,
+				StartKey:     listStartKey,
 			})
 			if err != nil {
 				return nil, "", trace.Wrap(err)
@@ -296,13 +277,9 @@ func (c *Cache) RangeDatabaseServersWithName(ctx context.Context, databaseName s
 				}
 			}
 
-			next := ""
-			if resp.NextKey != "" {
-				hostID, serverName, ok := strings.Cut(resp.NextKey, backend.SeparatorString)
-				if !ok {
-					return nil, "", trace.BadParameter("invalid pagination token: %q", resp.NextKey)
-				}
-				next = string(ordered.Encode(databaseName, hostID, serverName))
+			next, err := listResourcesKeyToNamePrefixedServerIndexKey(resp.NextKey, databaseName)
+			if err != nil {
+				return nil, "", trace.Wrap(err)
 			}
 			return page, next, nil
 		}
@@ -316,8 +293,7 @@ func (c *Cache) RangeDatabaseServersWithName(ctx context.Context, databaseName s
 			upstreamList:    upstreamListFn,
 		}
 
-		start := string(ordered.Encode(databaseName))
-		end := string(ordered.Encode(databaseName, ordered.Inf))
+		start, end := namePrefixedServerIndexRange(databaseName)
 		for item, err := range lister.Range(ctx, start, end) {
 			if !yield(item, err) {
 				return

--- a/lib/cache/name_prefixed_server_index.go
+++ b/lib/cache/name_prefixed_server_index.go
@@ -1,0 +1,77 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package cache
+
+import (
+	"github.com/gravitational/trace"
+	"rsc.io/ordered"
+
+	"github.com/gravitational/teleport/lib/backend"
+)
+
+// namePrefixedServerIndexKey constructs an index key prefixed by resourceName
+// and positioned by host ID and server name.
+func namePrefixedServerIndexKey(resourceName, hostID, serverName string) string {
+	return string(ordered.Encode(resourceName, hostID, serverName))
+}
+
+// namePrefixedServerIndexRange returns the start and end index keys for a
+// given resource name.
+func namePrefixedServerIndexRange(resourceName string) (start, end string) {
+	return string(ordered.Encode(resourceName)), string(ordered.Encode(resourceName, ordered.Inf))
+}
+
+// namePrefixedServerIndexKeyToListResourcesKey converts an index key from the
+// name-prefixed server index into a pagination key for ListResources.
+func namePrefixedServerIndexKeyToListResourcesKey(key, expectedResourceName string) (string, error) {
+	var actualResourceName string
+	rest, err := ordered.DecodePrefix([]byte(key), &actualResourceName)
+	if err != nil {
+		return "", trace.Wrap(err)
+	}
+
+	// Verify that the token's resource name matches the expected resource name.
+	// This ensures that if the token is malformed or belongs to a different
+	// resource, we don't return incorrect results.
+	if actualResourceName != expectedResourceName {
+		return "", trace.BadParameter("pagination token does not match the expected name")
+	}
+
+	if len(rest) == 0 {
+		return "", nil
+	}
+
+	var hostID, serverName string
+	if err := ordered.Decode(rest, &hostID, &serverName); err != nil {
+		return "", trace.Wrap(err)
+	}
+	return backend.HostIDPaginationKey(hostID, serverName), nil
+}
+
+// listResourcesKeyToNamePrefixedServerIndexKey converts a ListResources
+// pagination key into an index key for the name-prefixed server index.
+func listResourcesKeyToNamePrefixedServerIndexKey(key, resourceName string) (string, error) {
+	if key == "" {
+		return "", nil
+	}
+
+	hostID, serverName, err := backend.ParseHostIDPaginationKey(key)
+	if err != nil {
+		return "", trace.Wrap(err)
+	}
+	return namePrefixedServerIndexKey(resourceName, hostID, serverName), nil
+}

--- a/lib/cache/name_prefixed_server_index_test.go
+++ b/lib/cache/name_prefixed_server_index_test.go
@@ -1,0 +1,60 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package cache
+
+import (
+	"testing"
+
+	"github.com/gravitational/teleport/lib/backend"
+	"github.com/gravitational/trace"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNamePrefixedServerIndexKey(t *testing.T) {
+	t.Parallel()
+
+	const (
+		resourceName    = "resource-name"
+		hostID          = "host-id"
+		serverName      = "server-name"
+		expectedListKey = hostID + backend.SeparatorString + serverName
+	)
+
+	start, end := namePrefixedServerIndexRange(resourceName)
+	indexKey := namePrefixedServerIndexKey(resourceName, hostID, serverName)
+	require.Less(t, start, indexKey)
+	require.Less(t, indexKey, end)
+
+	listKey, err := namePrefixedServerIndexKeyToListResourcesKey(start, resourceName)
+	require.NoError(t, err)
+	require.Empty(t, listKey, "expected no pagination key for the starting index key")
+
+	listKey, err = namePrefixedServerIndexKeyToListResourcesKey(indexKey, resourceName)
+	require.NoError(t, err)
+	require.Equal(t, expectedListKey, listKey, "expected to get the list key back from the index key")
+
+	namePrefixedKey, err := listResourcesKeyToNamePrefixedServerIndexKey(listKey, resourceName)
+	require.NoError(t, err)
+	require.Equal(t, indexKey, namePrefixedKey, "expected to get the same index key back from the pagination key")
+
+	namePrefixedKey, err = listResourcesKeyToNamePrefixedServerIndexKey("", resourceName)
+	require.NoError(t, err)
+	require.Empty(t, namePrefixedKey)
+
+	_, err = namePrefixedServerIndexKeyToListResourcesKey(indexKey, "other-name")
+	require.ErrorAs(t, err, new(*trace.BadParameterError))
+}

--- a/lib/cache/name_prefixed_server_index_test.go
+++ b/lib/cache/name_prefixed_server_index_test.go
@@ -19,9 +19,10 @@ package cache
 import (
 	"testing"
 
-	"github.com/gravitational/teleport/lib/backend"
 	"github.com/gravitational/trace"
 	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport/lib/backend"
 )
 
 func TestNamePrefixedServerIndexKey(t *testing.T) {


### PR DESCRIPTION
Add shared helpers for converting host ID pagination keys to/from name-prefixed cache index keys so the logic is consistent across server resources in the cache fallback.

Add backend helpers to generate and parse host ID pagination keys.

Update database server name-prefixed index and RangeDatabaseServersWithName to use the new helpers.

## Manual Test Plan
### Test Environment

Teleport Cloud tenant with at least one enrolled database and a role that requires per-session MFA for database access.

### Test Cases
- [ ] Connect to a database where the role requires per-session MFA and confirm MFA prompt appears and connection succeeds after verification
- [ ] Connect to a database where no per-session MFA is required and confirm connection succeeds without an MFA prompt
- [ ] Unregister a previously registered database, attempt to connect, and confirm a not found error is returned