### PR TITLE
[v18] Filter desktop logins to granted-only in clusterUnifiedResourcesGet

### DIFF
--- a/lib/teleterm/clusters/cluster.go
+++ b/lib/teleterm/clusters/cluster.go
@@ -271,6 +271,11 @@ func (c *Cluster) GetRoles(ctx context.Context) ([]*types.Role, error) {
 	return roles, nil
 }
 
+// NewAccessChecker creates a new AccessChecker for the cluster using the given auth client.
+func (c *Cluster) NewAccessChecker(ctx context.Context, authClient services.CurrentUserRoleGetter) (services.AccessChecker, error) {
+	return services.NewAccessCheckerForRemoteCluster(ctx, c.status.AccessInfo(), c.Name, authClient)
+}
+
 // GetRequestableRoles returns the requestable roles for the currently logged-in user
 func (c *Cluster) GetRequestableRoles(ctx context.Context, req *api.GetRequestableRolesRequest, authClient authclient.ClientI) (*types.AccessCapabilities, error) {
 	var (

--- a/lib/teleterm/services/unifiedresources/unifiedresources.go
+++ b/lib/teleterm/services/unifiedresources/unifiedresources.go
@@ -28,8 +28,16 @@ import (
 	"github.com/gravitational/teleport/api/client/proto"
 	"github.com/gravitational/teleport/api/types"
 	libclient "github.com/gravitational/teleport/lib/client"
+	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/teleterm/clusters"
 )
+
+// AuthClient combines the interfaces needed by [List] to fetch unified
+// resources and to build an access checker for login filtering.
+type AuthClient interface {
+	services.CurrentUserRoleGetter
+	apiclient.ListUnifiedResourcesClient
+}
 
 // TODO(gabrielcorado): add support to LLM.
 var supportedResourceKinds = []string{
@@ -42,7 +50,7 @@ var supportedResourceKinds = []string{
 	types.KindMCP,
 }
 
-func List(ctx context.Context, cluster *clusters.Cluster, client apiclient.ListUnifiedResourcesClient, req *proto.ListUnifiedResourcesRequest) (*ListResponse, error) {
+func List(ctx context.Context, cluster *clusters.Cluster, authClient AuthClient, req *proto.ListUnifiedResourcesRequest) (*ListResponse, error) {
 	kinds := req.GetKinds()
 	if len(kinds) == 0 {
 		kinds = supportedResourceKinds
@@ -56,7 +64,12 @@ func List(ctx context.Context, cluster *clusters.Cluster, client apiclient.ListU
 
 	req.Kinds = kinds
 	req.IncludeLogins = true
-	enrichedResources, nextKey, err := apiclient.GetUnifiedResourcePage(ctx, client, req)
+	enrichedResources, nextKey, err := apiclient.GetUnifiedResourcePage(ctx, authClient, req)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	accessChecker, err := cluster.NewAccessChecker(ctx, authClient)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -135,11 +148,19 @@ func List(ctx context.Context, cluster *clusters.Cluster, client apiclient.ListU
 			}
 			response.Resources = append(response.Resources, ur)
 		case types.WindowsDesktop:
+			logins := enrichedResource.Logins
+			if req.IncludeRequestable || req.UseSearchAsRoles {
+				var err error
+				logins, err = accessChecker.GetAllowedLoginsForResource(r)
+				if err != nil {
+					return nil, trace.Wrap(err)
+				}
+			}
 			response.Resources = append(response.Resources, UnifiedResource{
 				WindowsDesktop: &clusters.WindowsDesktop{
 					URI:            cluster.URI.AppendWindowsDesktop(r.GetName()),
 					WindowsDesktop: r,
-					Logins:         enrichedResource.Logins,
+					Logins:         logins,
 				},
 				RequiresRequest: requiresRequest,
 			})

--- a/lib/teleterm/services/unifiedresources/unififedresources_test.go
+++ b/lib/teleterm/services/unifiedresources/unififedresources_test.go
@@ -177,9 +177,55 @@ func TestUnifiedResourcesList(t *testing.T) {
 	require.Equal(t, mockedNextKey, response.NextKey)
 }
 
+// TestUnifiedResourcesGet_DesktopLoginFiltering verifies that the logins
+// returned for Windows/Linux Desktop resources in the unified resources endpoint
+// only include logins from the user's currently-granted roles, not logins
+// from roles reachable via search_as_roles when includedResourceMode=all.
+func TestUnifiedResourcesList_DesktopLoginFiltering(t *testing.T) {
+	ctx := t.Context()
+	cluster := &clusters.Cluster{URI: uri.NewClusterURI("foo"), ProfileName: "foo"}
+
+	desktop, err := types.NewWindowsDesktopV3("test-desktop", nil,
+		types.WindowsDesktopSpecV3{Addr: "1.2.3.4:3389", HostID: "host-1"})
+	require.NoError(t, err)
+
+	// The assigned role grants "granted-login" for desktops.
+	assignedRole, err := types.NewRole("assigned-role", types.RoleSpecV6{
+		Allow: types.RoleConditions{
+			WindowsDesktopLabels: types.Labels{types.Wildcard: {types.Wildcard}},
+			WindowsDesktopLogins: []string{"granted-login"},
+		},
+	})
+	require.NoError(t, err)
+
+	// Simulate what the auth layer returns when IncludeRequestable is set:
+	// enriched logins contain the union of granted + requestable logins.
+	mockedResources := []*proto.PaginatedResource{
+		{
+			Resource: &proto.PaginatedResource_WindowsDesktop{WindowsDesktop: desktop},
+			Logins:   []string{"granted-login", "requestable-login"},
+		},
+	}
+
+	response, err := List(ctx, cluster, &mockClient{
+		paginatedResources: mockedResources,
+		// Only the assigned role. the requestable role is not held by the user.
+		roles: []types.Role{assignedRole},
+	}, &proto.ListUnifiedResourcesRequest{
+		IncludeRequestable: true,
+	})
+	require.NoError(t, err)
+	require.Len(t, response.Resources, 1)
+
+	require.ElementsMatch(t, []string{"granted-login"},
+		response.Resources[0].WindowsDesktop.Logins,
+		"desktop logins should only contain granted logins, not requestable ones")
+}
+
 type mockClient struct {
 	paginatedResources []*proto.PaginatedResource
 	nextKey            string
+	roles              []types.Role
 }
 
 func (m *mockClient) ListUnifiedResources(ctx context.Context, req *proto.ListUnifiedResourcesRequest) (*proto.ListUnifiedResourcesResponse, error) {
@@ -187,4 +233,19 @@ func (m *mockClient) ListUnifiedResources(ctx context.Context, req *proto.ListUn
 		Resources: m.paginatedResources,
 		NextKey:   m.nextKey,
 	}, nil
+}
+
+func (m *mockClient) GetCurrentUserRoles(ctx context.Context) ([]types.Role, error) {
+	if m.roles != nil {
+		return m.roles, nil
+	}
+	role, err := types.NewRole("default-test-role", types.RoleSpecV6{})
+	if err != nil {
+		return nil, err
+	}
+	return []types.Role{role}, nil
+}
+
+func (m *mockClient) GetCurrentUser(ctx context.Context) (types.User, error) {
+	return types.NewUser("testUser")
 }

--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -3522,7 +3522,15 @@ func (h *Handler) clusterUnifiedResourcesGet(w http.ResponseWriter, request *htt
 			})
 			unifiedResources = append(unifiedResources, app)
 		case types.WindowsDesktop:
-			unifiedResources = append(unifiedResources, ui.MakeDesktop(r, enriched.Logins, enriched.RequiresRequest))
+			logins := enriched.Logins
+			if req.IncludeRequestable || req.UseSearchAsRoles {
+				var err error
+				logins, err = accessChecker.GetAllowedLoginsForResource(r)
+				if err != nil {
+					return nil, trace.Wrap(err)
+				}
+			}
+			unifiedResources = append(unifiedResources, ui.MakeDesktop(r, logins, enriched.RequiresRequest))
 		case types.KubeCluster:
 			kube := ui.MakeKubeCluster(r, accessChecker, enriched.RequiresRequest)
 			unifiedResources = append(unifiedResources, kube)

--- a/lib/web/apiserver_test.go
+++ b/lib/web/apiserver_test.go
@@ -1695,6 +1695,83 @@ func TestUnifiedResourcesGet(t *testing.T) {
 	})
 }
 
+// TestUnifiedResourcesGet_DesktopLoginFiltering verifies that the logins
+// returned for Windows/Linux Desktop resources in the unified resources endpoint
+// only include logins from the user's currently-granted roles, not logins
+// from roles reachable via search_as_roles when includedResourceMode=all.
+func TestUnifiedResourcesGet_DesktopLoginFiltering(t *testing.T) {
+	t.Parallel()
+	env := newWebPack(t, 1)
+	proxy := env.proxies[0]
+
+	const username = "desktop-login-test@example.com"
+
+	// requestableRole has desktop logins the user can only get via access request.
+	requestableRole, err := types.NewRole("emg-access", types.RoleSpecV6{
+		Allow: types.RoleConditions{
+			WindowsDesktopLabels: types.Labels{types.Wildcard: {types.Wildcard}},
+			WindowsDesktopLogins: []string{"requestable-login"},
+		},
+	})
+	require.NoError(t, err)
+
+	// assignedRole is the user's default role with search_as_roles pointing
+	// at requestableRole so the user can discover resources for access requests.
+	assignedRole, err := types.NewRole("assigned-role", types.RoleSpecV6{
+		Allow: types.RoleConditions{
+			// Give wildcard node/desktop access so the resource is visible.
+			NodeLabels:           types.Labels{types.Wildcard: {types.Wildcard}},
+			WindowsDesktopLabels: types.Labels{types.Wildcard: {types.Wildcard}},
+			WindowsDesktopLogins: []string{"granted-login"},
+			Logins:               []string{"granted-login"},
+			Request: &types.AccessRequestConditions{
+				Roles:         []string{requestableRole.GetName()},
+				SearchAsRoles: []string{requestableRole.GetName()},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	_, err = env.server.Auth().UpsertRole(context.Background(), requestableRole)
+	require.NoError(t, err)
+
+	pack := proxy.authPack(t, username, []types.Role{assignedRole})
+
+	// Create a Windows Desktop resource.
+	desktop, err := types.NewWindowsDesktopV3("test-desktop", nil, types.WindowsDesktopSpecV3{
+		Addr:   "1.2.3.4:3389",
+		HostID: "host-1",
+	})
+	require.NoError(t, err)
+	require.NoError(t, env.server.Auth().UpsertWindowsDesktop(context.Background(), desktop))
+
+	clusterName := env.server.ClusterName()
+	endpoint := pack.clt.Endpoint("webapi", "sites", clusterName, "resources")
+
+	type desktopResponse struct {
+		Items []webui.Desktop `json:"items"`
+	}
+
+	// Fetch with includedResourceMode=all, which enables IncludeRequestable on
+	// the backend and causes the auth layer to use search_as_roles when
+	// computing logins.
+	query := url.Values{
+		"kinds":                []string{types.KindWindowsDesktop},
+		"includedResourceMode": []string{"all"},
+	}
+	re, err := pack.clt.Get(context.Background(), endpoint, query)
+	require.NoError(t, err)
+
+	var resp desktopResponse
+	require.NoError(t, json.Unmarshal(re.Bytes(), &resp))
+	require.Len(t, resp.Items, 1, "expected exactly one desktop")
+
+	// The logins present should only be ones the user currently can access,
+	// not ones from requestable roles.
+	require.ElementsMatch(t, []string{"granted-login"}, resp.Items[0].Logins,
+		"desktop logins should only contain granted logins, not requestable ones")
+}
+
 type clusterAlertsGetResponse struct {
 	Alerts []types.ClusterAlert `json:"alerts"`
 }


### PR DESCRIPTION
Backport #67013 to v18.

Changelog: Fixed Windows and Linux desktop Connect dropdowns showing logins from roles the user can request but hasn't been granted.

## Manual Test Plan
### Test Environment
- Teleport cluster built from this branch
- Two roles: an assigned role with `search_as_roles` pointing at a requestable role, each with distinct `windows_desktop_logins`
- A Windows Desktop resource registered in the cluster
- A user assigned only the first role

### Test Cases
- [x] Web UI: Log in as test user, navigate to Resources, toggle the resource availability filter to include requestable resources, click "Connect" on the Windows Desktop. Validate logins are only ones currently granted by the first role.
- [x] Web UI: With the same setup, add `logins` and `node_labels` to both roles, register an SSH node, and validate SSH logins remain unaffected.
- [x] Web UI: Create and approve an Access Request for the second role as test user. Validate that when assumed, clicking "Connect" on the Windows Desktop shows only logins granted by the second role.
- [x] Teleport Connect: Validate above steps within Connect.
