### PR TITLE
[terraform] set `role.spec.options.record_session` as a computed attribute

### DIFF
--- a/integrations/terraform/protoc-gen-terraform-teleport.yaml
+++ b/integrations/terraform/protoc-gen-terraform-teleport.yaml
@@ -327,6 +327,7 @@ computed_fields:
     - "RoleV6.Spec.Options.CreateDesktopUser"
     - "RoleV6.Spec.Options.DesktopClipboard"
     - "RoleV6.Spec.Options.DesktopDirectorySharing"
+    - "RoleV6.Spec.Options.RecordSession"
 
     # SAML connector
     - "SAMLConnectorV2.Spec.Audience"

--- a/integrations/terraform/testlib/fixtures/role_with_options_0.tf
+++ b/integrations/terraform/testlib/fixtures/role_with_options_0.tf
@@ -1,0 +1,8 @@
+resource "teleport_role" "with_options" {
+  version = "v8"
+  metadata = {
+    name = "with_options"
+  }
+
+  spec = {}
+}

--- a/integrations/terraform/testlib/fixtures/role_with_options_1.tf
+++ b/integrations/terraform/testlib/fixtures/role_with_options_1.tf
@@ -1,0 +1,16 @@
+resource "teleport_role" "with_options" {
+  version = "v8"
+  metadata = {
+    name = "with_options"
+  }
+
+  spec = {
+    options = {
+      record_session = {
+        default = "strict"
+        desktop = false
+        ssh     = "strict"
+      }
+    }
+  }
+}

--- a/integrations/terraform/testlib/role_test.go
+++ b/integrations/terraform/testlib/role_test.go
@@ -673,6 +673,18 @@ func (s *TerraformSuiteOSS) TestRoleWithOptions() {
 				Config:   s.getFixture("role_with_options_1.tf"),
 				PlanOnly: true,
 			},
+			{
+				Config: s.getFixture("role_with_options_0.tf"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(name, "spec.options.record_session.default", "best_effort"),
+					resource.TestCheckResourceAttr(name, "spec.options.record_session.desktop", "true"),
+					resource.TestCheckResourceAttr(name, "spec.options.record_session.ssh", ""),
+				),
+			},
+			{
+				Config:   s.getFixture("role_with_options_0.tf"),
+				PlanOnly: true,
+			},
 		},
 	})
 }

--- a/integrations/terraform/testlib/role_test.go
+++ b/integrations/terraform/testlib/role_test.go
@@ -73,9 +73,6 @@ func (s *TerraformSuiteOSS) TestRoleDataSource() {
 }
 
 func (s *TerraformSuiteOSS) TestRole() {
-	// TODO: `spec.options.record_session` should be a computed attribute.
-	s.T().Skip("Provider produced invalid plan")
-
 	ctx, cancel := context.WithCancel(context.Background())
 	s.T().Cleanup(cancel)
 

--- a/integrations/terraform/testlib/role_test.go
+++ b/integrations/terraform/testlib/role_test.go
@@ -632,3 +632,50 @@ func (s *TerraformSuiteOSS) TestRoleNoVersion() {
 		},
 	})
 }
+
+func (s *TerraformSuiteOSS) TestRoleWithOptions() {
+	ctx, cancel := context.WithCancel(context.Background())
+	s.T().Cleanup(cancel)
+
+	checkDestroyed := func(state *terraform.State) error {
+		_, err := s.client.GetRole(ctx, "with_options")
+		if trace.IsNotFound(err) {
+			return nil
+		}
+
+		return err
+	}
+
+	name := "teleport_role.with_options"
+
+	resource.Test(s.T(), resource.TestCase{
+		ProtoV6ProviderFactories: s.terraformProviders,
+		CheckDestroy:             checkDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config: s.getFixture("role_with_options_0.tf"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(name, "spec.options.record_session.default", "best_effort"),
+					resource.TestCheckResourceAttr(name, "spec.options.record_session.desktop", "true"),
+					resource.TestCheckResourceAttr(name, "spec.options.record_session.ssh", ""),
+				),
+			},
+			{
+				Config:   s.getFixture("role_with_options_0.tf"),
+				PlanOnly: true,
+			},
+			{
+				Config: s.getFixture("role_with_options_1.tf"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(name, "spec.options.record_session.default", "strict"),
+					resource.TestCheckResourceAttr(name, "spec.options.record_session.desktop", "false"),
+					resource.TestCheckResourceAttr(name, "spec.options.record_session.ssh", "strict"),
+				),
+			},
+			{
+				Config:   s.getFixture("role_with_options_1.tf"),
+				PlanOnly: true,
+			},
+		},
+	})
+}

--- a/integrations/terraform/tfschema/types_terraform.go
+++ b/integrations/terraform/tfschema/types_terraform.go
@@ -5269,8 +5269,10 @@ func GenSchemaRoleV6(ctx context.Context) (github_com_hashicorp_terraform_plugin
 									Type:          github_com_hashicorp_terraform_plugin_framework_types.StringType,
 								},
 							}),
-							Description: "RecordDesktopSession indicates whether desktop access sessions should be recorded. It defaults to true unless explicitly set to false.",
-							Optional:    true,
+							Computed:      true,
+							Description:   "RecordDesktopSession indicates whether desktop access sessions should be recorded. It defaults to true unless explicitly set to false.",
+							Optional:      true,
+							PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributePlanModifier{github_com_hashicorp_terraform_plugin_framework_tfsdk.UseStateForUnknown()},
 						},
 						"request_access": {
 							Computed:      true,


### PR DESCRIPTION
Supports https://github.com/gravitational/teleport/issues/66912

This PR marks the `role.spec.options.record_session` attribute as a `computed_field`.

With the `protoc-gen-terraform` v4 upgrade, the updated roundtrip logic ensures that the attribute value is in sync with the Teleport backend. Additionally, the `role.spec.options` uses a defaults plan modifier that sets default values during the planning phase. As a result, the provider now report an `Provider produced invalid plan` error because a default value is being planned for a non-computed attribute.

To resolve the issue, `role.spec.options.record_session` should be marked as a `computed` attribute.

<!-- Provide a descriptive entry for the changelog of the next release. -->

Changelog: The `spec.options.record_session` attribute is now a `computed` attribute in the Terraform Role resource.

<!-- Include manual testing efforts to verify the change. -->
<!-- Detail where the tests where run and what configurations were used. -->
<!-- Include all the test cases which were run to validate the change. -->

## Manual Test Plan
### Test Environment
Local cluster environment
### Test Cases
- [x] Create role with omitted `spec.options`. Verify default `record_session` values.
- [x] Update role with explicit values for `record_session`.
- [x] Import existing role with `record_sessions`.
