### PR TITLE
Implement in-memory audit log queue.

### DIFF
--- a/lib/events/auditqueue/auditqueue.go
+++ b/lib/events/auditqueue/auditqueue.go
@@ -46,8 +46,10 @@ var (
 type Kind string
 
 const (
-	// KindSQLite selects the SQLite-backed implementation.
-	KindSQLite Kind = "sqlite"
+	// KindSQLiteDisk selects the SQLite-backed on-disk implementation.
+	KindSQLiteDisk Kind = "sqlite_disk"
+	// KindSQLiteMemory selects the SQLite-backed in-memory implementation.
+	KindSQLiteMemory Kind = "sqlite_memory"
 )
 
 // Config configures a Queue.
@@ -57,7 +59,7 @@ type Config struct {
 	// OrphanScanInterval is how often the queue scans for orphaned audit log
 	// queues.
 	OrphanScanInterval time.Duration
-	// MaxBytes sets the maximum database file size
+	// MaxBytes sets the maximum database size
 	MaxBytes int64
 	// SoftLimit is the size of the audit log queue at which we start logging
 	// warning messages.
@@ -102,8 +104,10 @@ type Queue interface {
 // New constructs a Queue of the given kind.
 func New(kind Kind, cfg Config) (Queue, error) {
 	switch kind {
-	case KindSQLite:
+	case KindSQLiteDisk:
 		return newSQLiteQueue(cfg)
+	case KindSQLiteMemory:
+		return newSQLiteInMemoryQueue(cfg)
 	default:
 		return nil, trace.BadParameter("unknown audit queue kind: '%s'", kind)
 	}

--- a/lib/events/auditqueue/auditqueue_test.go
+++ b/lib/events/auditqueue/auditqueue_test.go
@@ -35,7 +35,7 @@ import (
 
 const testDefaultTimeout = 2 * time.Second
 
-var allKinds []Kind = []Kind{KindSQLite}
+var allKinds []Kind = []Kind{KindSQLiteDisk, KindSQLiteMemory}
 
 func newTestQueue(tb testing.TB, kind Kind) Queue {
 	tb.Helper()
@@ -51,6 +51,19 @@ func newTestQueueWithConfig(tb testing.TB, kind Kind, cfg Config) Queue {
 		require.NoError(tb, q.Close())
 	})
 	return q
+}
+
+func underlyingQueue(tb testing.TB, q Queue) *sqliteQueue {
+	tb.Helper()
+	switch v := q.(type) {
+	case *sqliteQueue:
+		return v
+	case *sqliteInMemoryQueue:
+		return v.inner
+	default:
+		tb.Fatalf("unexpected queue type %T", q)
+		return nil
+	}
 }
 
 func quietLogs(tb testing.TB) {
@@ -420,8 +433,7 @@ func TestRun_DeadLetter_RedeliversAfterRecovery(t *testing.T) {
 			runErr := make(chan error, 1)
 			go func() { runErr <- q.Run(runCtx, handler) }()
 
-			sq, ok := q.(*sqliteQueue)
-			require.True(t, ok)
+			sq := underlyingQueue(t, q)
 
 			// Wait for the event to exhaust its attempts and land in the
 			// dead-letter queue, then signal recovery.

--- a/lib/events/auditqueue/sqlite.go
+++ b/lib/events/auditqueue/sqlite.go
@@ -26,8 +26,6 @@ import (
 	"log/slog"
 	"net/url"
 	"os"
-	"path/filepath"
-	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -36,24 +34,15 @@ import (
 	sqlite "modernc.org/sqlite"
 	sqlite3 "modernc.org/sqlite/lib"
 
-	"github.com/gravitational/teleport"
 	apievents "github.com/gravitational/teleport/api/types/events"
 	"github.com/gravitational/teleport/lib/observability/metrics"
-	"github.com/gravitational/teleport/lib/utils"
 )
 
 const (
 	pollInterval                   = 100 * time.Millisecond
-	incrementalVacuumInterval      = 10 * time.Minute
-	defaultOrphanScanInterval      = 10 * time.Minute
-	queueLockFile                  = "queue.lock"
-	queueDBFile                    = "queue.db"
+	sqlitePageSize                 = 4096 // Bytes
 	auditQueueTable                = "audit_queue"
 	auditDeadLetterTable           = "audit_dead_letter"
-	tmpDirSuffix                   = ".tmp"
-	defaultSoftLimit               = 100 * 1024 * 1024 // 100 MiB
-	softLimitCheckInterval         = time.Minute
-	sqlitePageSize                 = 4096 // Bytes
 	defaultMaxAttempts             = 10
 	defaultDeadLetterSweepInterval = 10 * time.Minute
 	defaultDeadLetterTTL           = 30 * 24 * time.Hour // 30 days
@@ -67,23 +56,9 @@ const (
 	defaultMaxBatch  = 25
 	dequeueBatchSize = 25
 
-	// walJournalSizeLimit is the number of bytes the `-wal` file gets
-	// truncated to in between checkpoints.
-	walJournalSizeLimit = 64 * 1024 * 1024 // 64 MiB
-
 	// busyTimeoutMillis sets the maximum time we will wait for a SQLite DB
 	// operation.
 	busyTimeoutMillis = 5000
-
-	// defaultMaxBytes limits the size of the SQLite database file.
-	defaultMaxBytes int64 = 5 * 1024 * 1024 * 1024 // 5 GiB
-
-	// staleTmpThreshold is how old an in-progress <uuid>.tmp/ directory
-	// must be before the orphan scanner removes it. Under normal circumstances,
-	// A `.tmp` directory will only exist for a few milliseconds.
-	staleTmpThreshold       = time.Hour
-	initQueueDirMaxAttempts = 10
-	initQueueDirRetryDelay  = 50 * time.Millisecond
 )
 
 // A note on `AUTOINCREMENT`, to quote the SQLite docs:
@@ -175,62 +150,20 @@ func bytesToPages(nBytes int64) int64 {
 	return nBytes / sqlitePageSize
 }
 
-func getDSN(dbPath string, maxBytes int64) string {
-	maxPages := bytesToPages(maxBytes)
-	params := url.Values{}
-	params.Add("_pragma", "auto_vacuum(INCREMENTAL)")
-	params.Add("_pragma", "journal_mode(WAL)")
-	params.Add("_pragma", "synchronous(NORMAL)")
-	params.Add("_pragma", fmt.Sprintf("journal_size_limit(%d)", walJournalSizeLimit))
+// addSharedParams adds the shared parameters between both the in-memory sqlite
+// implementation and the on-disk implementation.
+func addSharedParams(params url.Values, maxBytes int64) {
 	params.Add("_pragma", fmt.Sprintf("busy_timeout(%d)", busyTimeoutMillis))
 	params.Add("_pragma", "temp_store(MEMORY)")
-	params.Add("_pragma", fmt.Sprintf("max_page_count(%d)", maxPages))
-	u := url.URL{
-		Scheme:   "file",
-		OmitHost: true,
-		Path:     dbPath,
-		RawQuery: params.Encode(),
-	}
-	return u.String()
+	params.Add("_pragma", fmt.Sprintf("max_page_count(%d)", bytesToPages(maxBytes)))
 }
 
-func newSQLiteQueue(cfg Config) (*sqliteQueue, error) {
-	if cfg.Path == "" {
-		return nil, trace.BadParameter("Path is required to create an sqlite queue")
-	}
-
+// newBaseQueue creates the common core of a sqliteQueue. It is used so
+// that shared initialization between the `sqliteQueue` and the
+// `sqliteInMemoryQueue` can re-use code.
+func newBaseQueue(db *sql.DB, cfg Config) (*sqliteQueue, error) {
 	if err := metrics.RegisterPrometheusCollectors(prometheusCollectors...); err != nil {
 		return nil, trace.Wrap(err)
-	}
-
-	unlock, err := initQueueDir(cfg.Path)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-
-	db, err := initializeDb(cfg.Path, cfg.MaxBytes)
-	if err != nil {
-		_ = unlock()
-		_ = os.RemoveAll(cfg.Path)
-		return nil, trace.Wrap(err)
-	}
-
-	selfStat, err := os.Stat(cfg.Path)
-	if err != nil {
-		db.Close()
-		_ = unlock()
-		_ = os.RemoveAll(cfg.Path)
-		return nil, trace.ConvertSystemError(err)
-	}
-
-	scanInterval := cfg.OrphanScanInterval
-	if scanInterval <= 0 {
-		scanInterval = defaultOrphanScanInterval
-	}
-
-	softLimit := cfg.SoftLimit
-	if softLimit <= 0 {
-		softLimit = defaultSoftLimit
 	}
 
 	maxAttempts := cfg.MaxAttempts
@@ -251,168 +184,19 @@ func newSQLiteQueue(cfg Config) (*sqliteQueue, error) {
 	ctx, cancel := context.WithCancel(context.Background())
 	q := &sqliteQueue{
 		db:                      db,
-		path:                    cfg.Path,
 		toBeWritten:             make(chan writeRequest),
 		maxBatch:                defaultMaxBatch,
 		ctx:                     ctx,
 		cancel:                  cancel,
-		parentDir:               filepath.Dir(cfg.Path),
-		selfStat:                selfStat,
-		unlock:                  unlock,
-		orphanScanInterval:      scanInterval,
-		softLimit:               softLimit,
 		maxAttempts:             maxAttempts,
 		deadLetterSweepInterval: deadLetterSweepInterval,
 		deadLetterTTL:           deadLetterTTL,
 		deadLetterKick:          make(chan struct{}, 1),
 	}
 
-	maxBytes := cfg.MaxBytes
-	if maxBytes <= 0 {
-		maxBytes = defaultMaxBytes
-	}
-	slog.InfoContext(q.ctx, "Audit queue initialized.",
-		"path", cfg.Path,
-		"max_bytes", maxBytes,
-		"soft_limit", softLimit,
-		"max_attempts", maxAttempts,
-		"dead_letter_ttl", deadLetterTTL,
-	)
-
 	q.wg.Go(q.writeLoop)
-	q.wg.Go(q.vacuumLoop)
-	q.wg.Go(q.softLimitLoop)
 
 	return q, nil
-}
-
-func initializeDb(path string, maxBytes int64) (*sql.DB, error) {
-	if maxBytes <= 0 {
-		maxBytes = defaultMaxBytes
-	}
-
-	dbPath := filepath.Join(path, queueDBFile)
-	db, err := sql.Open("sqlite", getDSN(dbPath, maxBytes))
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-
-	db.SetMaxOpenConns(1)
-	if _, err := db.Exec(schemaSQL); err != nil {
-		db.Close()
-		return nil, trace.Wrap(err)
-	}
-	if err := recordTeleportVersion(db, teleport.Version); err != nil {
-		db.Close()
-		return nil, trace.Wrap(err)
-	}
-
-	return db, nil
-}
-
-// initQueueDir creates and initializes the directory where the audit log queue
-// will reside. It does this in a way that is safe from race conditions.
-func initQueueDir(path string) (func() error, error) {
-	tmpPath := path + tmpDirSuffix
-	var err error
-	for attempt := range initQueueDirMaxAttempts {
-		var unlock func() error
-		unlock, err = tryInitQueueDir(path, tmpPath)
-		if err == nil {
-			return unlock, nil
-		}
-
-		isRetryableError := errors.Is(err, utils.ErrUnsuccessfulLockTry) || trace.IsNotFound(err)
-		if !isRetryableError {
-			return nil, trace.Wrap(err)
-		}
-
-		if attempt < initQueueDirMaxAttempts-1 {
-			time.Sleep(initQueueDirRetryDelay)
-		}
-	}
-	return nil, trace.Wrap(err, "failed to initialize audit-queue directory %q after %d attempts (is the system time set correctly?)", path, initQueueDirMaxAttempts)
-}
-
-func tryInitQueueDir(path, tmpPath string) (func() error, error) {
-	if err := os.MkdirAll(tmpPath, 0o700); err != nil {
-		return nil, trace.ConvertSystemError(err)
-	}
-
-	// Take the lock on the `queue.lock` file. This ensures that no other
-	// instances try to adopt this queue.
-	unlock, err := utils.FSTryWriteLock(filepath.Join(tmpPath, queueLockFile))
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-
-	// Remove the `.tmp` suffix, marking this as a live queue.
-	if err := os.Rename(tmpPath, path); err != nil {
-		// Only remove the directory if we own the flock.
-		_ = os.RemoveAll(tmpPath)
-		_ = unlock()
-		return nil, trace.ConvertSystemError(err)
-	}
-	return unlock, nil
-}
-
-// vacuumLoop periodically cleans up deleted records from the SQLite database
-// file.
-func (q *sqliteQueue) vacuumLoop() {
-	timer := time.NewTimer(incrementalVacuumInterval)
-	defer timer.Stop()
-	for {
-		select {
-		case <-q.ctx.Done():
-			return
-		case <-timer.C:
-			if _, err := q.db.ExecContext(q.ctx, "PRAGMA incremental_vacuum"); err != nil {
-				slog.ErrorContext(q.ctx, "Failed to run incremental_vacuum.", "error", err)
-			}
-			timer.Reset(incrementalVacuumInterval)
-		}
-	}
-}
-
-// softLimitLoop periodically stats queue.db and emits a warning when its
-// size exceeds the configured soft limit.
-func (q *sqliteQueue) softLimitLoop() {
-	ticker := time.NewTicker(softLimitCheckInterval)
-	defer ticker.Stop()
-	for {
-		select {
-		case <-q.ctx.Done():
-			return
-		case <-ticker.C:
-		}
-		above, size, err := q.aboveSoftLimit()
-		if err != nil {
-			slog.ErrorContext(q.ctx,
-				"Failed to stat audit queue file.",
-				"path", q.path,
-				"error", err,
-			)
-			continue
-		}
-		if above {
-			slog.WarnContext(q.ctx,
-				"audit event queue above soft limit",
-				"path", q.path,
-				"size_bytes", size,
-				"soft_limit_bytes", q.softLimit,
-			)
-			softLimitWarnings.Inc()
-		}
-	}
-}
-
-func (q *sqliteQueue) aboveSoftLimit() (bool, int64, error) {
-	info, err := os.Stat(filepath.Join(q.path, queueDBFile))
-	if err != nil {
-		return false, 0, trace.ConvertSystemError(err)
-	}
-	size := info.Size()
-	return size > q.softLimit, size, nil
 }
 
 // Enqueue writes the event to the SQLite based queue. If you get a nil error
@@ -555,26 +339,7 @@ func isSQLiteFullError(err error) bool {
 	return errors.As(err, &e) && (e.Code() == sqlite3.SQLITE_FULL)
 }
 
-// Run drains the queue. `handler` is the function called for each audit log
-// event that is held within the queue. The audit log queue follows a single
-// consumer model in order to batch events together and commit them as groups.
-func (q *sqliteQueue) Run(ctx context.Context, handler Handler) error {
-	// Ensure we only have a single consumer running.
-	if !q.runMu.TryLock() {
-		return trace.Wrap(ErrAlreadyRunning)
-	}
-	defer q.runMu.Unlock()
-
-	// Startup the orphan scanner and dead-letter sweeper.
-	var wg sync.WaitGroup
-	wg.Go(func() {
-		q.orphanScanLoop(ctx)
-	})
-	wg.Go(func() {
-		q.deadLetterSweepLoop(ctx, handler)
-	})
-	defer wg.Wait()
-
+func (q *sqliteQueue) runPollLoop(ctx context.Context, handler Handler) error {
 	pollTimer := time.NewTimer(pollInterval)
 	defer pollTimer.Stop()
 
@@ -942,384 +707,6 @@ func (q *sqliteQueue) expireDeadLetter() {
 	}
 }
 
-func (q *sqliteQueue) orphanScanLoop(ctx context.Context) {
-	ticker := time.NewTicker(q.orphanScanInterval)
-	defer ticker.Stop()
-	for {
-		q.sweepStaleTmp()
-		q.adoptOrphans(ctx)
-
-		select {
-		case <-ctx.Done():
-			return
-		case <-q.ctx.Done():
-			return
-		case <-ticker.C:
-		}
-	}
-}
-
-// sweepStaleTmp cleans up any audit queue directories that have been orphaned
-// during their initialization phase. This should be rare, but we still want to
-// account for it.
-func (q *sqliteQueue) sweepStaleTmp() {
-	entries, err := os.ReadDir(q.parentDir)
-	if err != nil {
-		orphanScanErrors.Inc()
-		slog.ErrorContext(q.ctx,
-			"Failed to list audit-queue parent directory.",
-			"parent_dir", q.parentDir,
-			"error", err,
-		)
-		return
-	}
-	cutoff := time.Now().Add(-staleTmpThreshold)
-	for _, dirEntry := range entries {
-		if !dirEntry.IsDir() || !strings.HasSuffix(dirEntry.Name(), tmpDirSuffix) {
-			continue
-		}
-		info, err := dirEntry.Info()
-		if err != nil {
-			orphanScanErrors.Inc()
-			slog.ErrorContext(q.ctx,
-				"Failed to stat audit-queue tmp directory.",
-				"name", dirEntry.Name(),
-				"error", err,
-			)
-			continue
-		}
-		if info.ModTime().After(cutoff) {
-			continue
-		}
-
-		// If we get to this point, then the directory is older than the cutoff,
-		// which should not be the case for a tmp directory. These directories
-		// should have their `*.tmp` suffix removed as soon as they are done
-		// initializing, which should be a very quick process.
-		stalePath := filepath.Join(q.parentDir, dirEntry.Name())
-		tryRemoveStaleTmp(q.ctx, stalePath)
-	}
-}
-
-func tryRemoveStaleTmp(ctx context.Context, stalePath string) {
-	unlock, err := utils.FSTryWriteLock(filepath.Join(stalePath, queueLockFile))
-	if err != nil {
-		// The lock is held, so a creator is still active. Leave the directory
-		// for its owner and try again on the next sweep.
-		if errors.Is(err, utils.ErrUnsuccessfulLockTry) {
-			slog.WarnContext(ctx,
-				"Audit-queue tmp directory is still locked past the stale threshold. Leaving it for its owner.",
-				"path", stalePath,
-				"stale_threshold", staleTmpThreshold,
-			)
-			return
-		}
-		orphanScanErrors.Inc()
-		slog.ErrorContext(ctx,
-			"Failed to lock stale audit-queue tmp directory.",
-			"path", stalePath,
-			"error", err,
-		)
-		return
-	}
-	defer func() {
-		if err := unlock(); err != nil {
-			slog.ErrorContext(ctx,
-				"Failed to release stale audit-queue tmp flock.",
-				"path", stalePath,
-				"error", err,
-			)
-		}
-	}()
-
-	// We hold the lock, so the directory is unowned. Tmp directories were
-	// orphaned before they finished initializing, therefore they will have no
-	// audit log events, hence they are safe to remove.
-	if err := os.RemoveAll(stalePath); err != nil {
-		orphanScanErrors.Inc()
-		slog.ErrorContext(ctx,
-			"Failed to remove stale audit-queue tmp directory.",
-			"path", stalePath,
-			"error", err,
-		)
-	}
-}
-
-func (q *sqliteQueue) adoptOrphans(ctx context.Context) {
-	entries, err := os.ReadDir(q.parentDir)
-	if err != nil {
-		orphanScanErrors.Inc()
-		slog.ErrorContext(q.ctx,
-			"Failed to list audit-queue parent directory.",
-			"parent_dir", q.parentDir,
-			"error", err,
-		)
-		return
-	}
-	for _, dirEntry := range entries {
-		if ctx.Err() != nil {
-			return
-		}
-		if !dirEntry.IsDir() || strings.HasSuffix(dirEntry.Name(), tmpDirSuffix) {
-			continue
-		}
-
-		entryPath := filepath.Join(q.parentDir, dirEntry.Name())
-		entryStat, err := os.Stat(entryPath)
-		if err != nil {
-			orphanScanErrors.Inc()
-			slog.ErrorContext(q.ctx,
-				"Failed to stat audit-queue candidate directory.",
-				"path", entryPath,
-				"error", err,
-			)
-			continue
-		}
-		if os.SameFile(entryStat, q.selfStat) {
-			continue
-		}
-
-		// If we got to this point, then we have found a directory that is not a
-		// tmp directory and is not the same directory as the one this process
-		// is already using. We are safe to attempt to adopt it.
-		q.tryAdoptOrphan(ctx, entryPath)
-	}
-}
-
-func (q *sqliteQueue) tryAdoptOrphan(ctx context.Context, path string) {
-	unlock, err := utils.FSTryWriteLock(filepath.Join(path, queueLockFile))
-	if err != nil {
-		// This error indicates that the lock has already been taken, hence this
-		// queue is not an orphan. We can skip it.
-		if errors.Is(err, utils.ErrUnsuccessfulLockTry) {
-			return
-		}
-
-		// Otherwise, an error occurred while attempting to take the file lock.
-		orphanScanErrors.Inc()
-		slog.ErrorContext(q.ctx,
-			"Failed to attempt orphan flock.",
-			"path", path,
-			"error", err,
-		)
-		return
-	}
-	defer func() {
-		if err := unlock(); err != nil {
-			slog.ErrorContext(q.ctx,
-				"Failed to release orphan flock.",
-				"path", path,
-				"error", err,
-			)
-		}
-	}()
-
-	dbFilePath := filepath.Join(path, queueDBFile)
-	db, err := sql.Open("sqlite", getDSN(dbFilePath, defaultMaxBytes))
-	if err != nil {
-		orphanScanErrors.Inc()
-		slog.ErrorContext(q.ctx, "Failed to open orphan SQLite database.", "path", path, "error", err)
-		return
-	}
-	db.SetMaxOpenConns(1)
-
-	if err := db.PingContext(ctx); err != nil {
-		orphanScanErrors.Inc()
-		slog.ErrorContext(q.ctx,
-			"Failed to connect to orphan SQLite database.",
-			"path", path,
-			"error", err,
-		)
-		_ = db.Close()
-		return
-	}
-
-	migrateErr := q.migrateOrphanDB(ctx, db, filepath.Base(path))
-	if err := db.Close(); err != nil {
-		slog.ErrorContext(q.ctx,
-			"Failed to close orphan SQLite database.",
-			"path", path,
-			"error", err,
-		)
-		return
-	}
-
-	if migrateErr != nil {
-		// If we fail to migrate, we will try again on the next orphan adoption
-		// cycle. Cancellation is a normal shutdown, not a migration failure.
-		if ctx.Err() == nil && q.ctx.Err() == nil {
-			orphanScanErrors.Inc()
-			slog.ErrorContext(q.ctx,
-				"Failed to migrate orphaned audit-queue database.",
-				"path", path,
-				"error", migrateErr,
-			)
-		}
-		return
-	}
-
-	// If we got here, then we have successfully migrated the orphan. We can now
-	// safely remove it.
-	if err := os.RemoveAll(path); err != nil {
-		orphanScanErrors.Inc()
-		slog.ErrorContext(q.ctx,
-			"Failed to remove migrated orphan directory.",
-			"path", path,
-			"error", err,
-		)
-		return
-	}
-	q.clearOrphanWatermarks(ctx, filepath.Base(path))
-	orphansAdopted.Inc()
-	slog.InfoContext(q.ctx, "Adopted orphaned audit-queue directory.", "path", path)
-}
-
-func (q *sqliteQueue) migrateOrphanDB(ctx context.Context, db *sql.DB, name string) error {
-	if err := q.migrateOrphanQueue(ctx, db, name); err != nil {
-		return trace.Wrap(err)
-	}
-	return trace.Wrap(q.migrateOrphanDeadLetter(ctx, db, name))
-}
-
-func (q *sqliteQueue) migrateOrphanQueue(ctx context.Context, orphan *sql.DB, name string) error {
-	return q.migrateOrphanTable(ctx, orphan, name, auditQueueTable,
-		"SELECT id, payload, attempts FROM audit_queue WHERE id > ? ORDER BY id ASC LIMIT ?",
-		"INSERT INTO audit_queue (payload, attempts) VALUES (?, ?)",
-	)
-}
-
-func (q *sqliteQueue) migrateOrphanDeadLetter(ctx context.Context, orphan *sql.DB, name string) error {
-	return q.migrateOrphanTable(ctx, orphan, name, auditDeadLetterTable,
-		"SELECT id, payload, failed_at FROM audit_dead_letter WHERE id > ? ORDER BY id ASC LIMIT ?",
-		"INSERT INTO audit_dead_letter (payload, failed_at) VALUES (?, ?)",
-	)
-}
-
-func orphanWatermarkKey(name, table string) string {
-	return "orphan_migration:" + name + ":" + table
-}
-
-func (q *sqliteQueue) migrateOrphanTable(ctx context.Context, orphan *sql.DB, name, table, selectSQL, insertSQL string) error {
-	watermarkKey := orphanWatermarkKey(name, table)
-	watermark, err := q.readOrphanWatermark(ctx, watermarkKey)
-	if err != nil {
-		return trace.Wrap(err, "reading orphan %s watermark", table)
-	}
-	for {
-		if err := ctx.Err(); err != nil {
-			return trace.Wrap(err)
-		}
-		if err := q.ctx.Err(); err != nil {
-			return trace.Wrap(err)
-		}
-		batch, err := fetchOrphanRows(ctx, orphan, selectSQL, watermark, dequeueBatchSize)
-		if err != nil {
-			return trace.Wrap(err, "fetching orphan %s rows", table)
-		}
-		if len(batch) == 0 {
-			return nil
-		}
-
-		maxID := batch[len(batch)-1].id
-		if err := q.insertMigratedBatch(ctx, insertSQL, batch, watermarkKey, maxID); err != nil {
-			return trace.Wrap(err, "migrating orphan %s rows", table)
-		}
-		watermark = maxID
-
-		ids := make([]int64, len(batch))
-		for i, r := range batch {
-			ids[i] = r.id
-		}
-		if err := deleteIDsFromTable(ctx, orphan, table, ids); err != nil {
-			return trace.Wrap(err, "deleting migrated orphan %s rows", table)
-		}
-	}
-}
-
-func (q *sqliteQueue) readOrphanWatermark(ctx context.Context, key string) (int64, error) {
-	var value string
-	err := q.db.QueryRowContext(ctx,
-		"SELECT value FROM teleport_info WHERE key = ?", key).Scan(&value)
-	if errors.Is(err, sql.ErrNoRows) {
-		return 0, nil
-	}
-	if err != nil {
-		return 0, trace.Wrap(err)
-	}
-	watermark, err := strconv.ParseInt(value, 10, 64)
-	return watermark, trace.Wrap(err)
-}
-
-func (q *sqliteQueue) clearOrphanWatermarks(ctx context.Context, name string) {
-	if _, err := q.db.ExecContext(ctx,
-		"DELETE FROM teleport_info WHERE key IN (?, ?)",
-		orphanWatermarkKey(name, auditQueueTable),
-		orphanWatermarkKey(name, auditDeadLetterTable),
-	); err != nil {
-		slog.ErrorContext(q.ctx,
-			"Failed to clear orphan migration watermarks.",
-			"orphan", name,
-			"error", err,
-		)
-	}
-}
-
-type migratedRow struct {
-	id     int64
-	values []any
-}
-
-func fetchOrphanRows(ctx context.Context, db *sql.DB, selectSQL string, afterID int64, limit int) ([]migratedRow, error) {
-	rows, err := db.QueryContext(ctx, selectSQL, afterID, limit)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	defer rows.Close()
-	cols, err := rows.Columns()
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	var out []migratedRow
-	for rows.Next() {
-		r := migratedRow{values: make([]any, len(cols)-1)}
-		targets := make([]any, 0, len(cols))
-		targets = append(targets, &r.id)
-		for i := range r.values {
-			targets = append(targets, &r.values[i])
-		}
-		if err := rows.Scan(targets...); err != nil {
-			return nil, trace.Wrap(err)
-		}
-		out = append(out, r)
-	}
-	return out, trace.Wrap(rows.Err())
-}
-
-func (q *sqliteQueue) insertMigratedBatch(ctx context.Context, insertSQL string, batch []migratedRow, watermarkKey string, maxID int64) error {
-	tx, err := q.db.BeginTx(ctx, nil)
-	if err != nil {
-		return trace.Wrap(err)
-	}
-	defer tx.Rollback()
-	stmt, err := tx.PrepareContext(ctx, insertSQL)
-	if err != nil {
-		return trace.Wrap(err)
-	}
-	defer stmt.Close()
-	for _, r := range batch {
-		if _, err := stmt.ExecContext(ctx, r.values...); err != nil {
-			return trace.Wrap(err)
-		}
-	}
-	if _, err := tx.ExecContext(ctx,
-		"INSERT OR REPLACE INTO teleport_info (key, value) VALUES (?, ?)",
-		watermarkKey, strconv.FormatInt(maxID, 10),
-	); err != nil {
-		return trace.Wrap(err)
-	}
-	return trace.Wrap(tx.Commit())
-}
-
 func (q *sqliteQueue) fetch(limit int) ([]Item, error) {
 	return fetchDB(q.ctx, q.db, limit)
 }
@@ -1407,62 +794,6 @@ func deleteByIDs(ctx context.Context, db *sql.DB, table string, items []Item) er
 // ackDB deletes the rows for items from the audit_queue table.
 func ackDB(ctx context.Context, db *sql.DB, items []Item) error {
 	return deleteByIDs(ctx, db, auditQueueTable, items)
-}
-
-func (q *sqliteQueue) Close() error {
-	var errs []error
-	q.closeOnce.Do(func() {
-		q.cancel()
-		q.wg.Wait()
-
-		// Flush the WAL file.
-		if _, err := q.db.Exec("PRAGMA wal_checkpoint(TRUNCATE)"); err != nil {
-			slog.ErrorContext(q.ctx,
-				"Failed to checkpoint WAL on close.",
-				"path", q.path,
-				"error", err,
-			)
-		}
-
-		empty, err := isQueueEmpty(q.db)
-		if err != nil {
-			slog.ErrorContext(q.ctx,
-				"Failed to check whether audit queue is empty on close.",
-				"path", q.path,
-				"error", err,
-			)
-		}
-
-		if err := q.db.Close(); err != nil {
-			errs = append(errs, err)
-		}
-
-		// Remove the directory before releasing the lock. This ensures no other
-		// process can adopt and start draining a queue we are about to delete.
-		if empty {
-			if err := os.RemoveAll(q.path); err != nil {
-				slog.ErrorContext(q.ctx, "Failed to remove empty audit-queue directory on close.", "path", q.path, "error", err)
-			}
-		}
-
-		if q.unlock != nil {
-			if err := q.unlock(); err != nil {
-				errs = append(errs, err)
-			}
-		}
-	})
-	return trace.NewAggregate(errs...)
-}
-
-func isQueueEmpty(db *sql.DB) (bool, error) {
-	var hasRows int
-	err := db.QueryRow(
-		"SELECT EXISTS(SELECT 1 FROM audit_queue) OR EXISTS(SELECT 1 FROM audit_dead_letter)",
-	).Scan(&hasRows)
-	if err != nil {
-		return false, trace.Wrap(err)
-	}
-	return hasRows == 0, nil
 }
 
 func recordTeleportVersion(db *sql.DB, version string) error {

--- a/lib/events/auditqueue/sqlite_disk.go
+++ b/lib/events/auditqueue/sqlite_disk.go
@@ -1,0 +1,736 @@
+/*
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package auditqueue
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/gravitational/trace"
+
+	"github.com/gravitational/teleport"
+	"github.com/gravitational/teleport/lib/utils"
+)
+
+const (
+	incrementalVacuumInterval = 10 * time.Minute
+	defaultOrphanScanInterval = 10 * time.Minute
+	queueLockFile             = "queue.lock"
+	queueDBFile               = "queue.db"
+	tmpDirSuffix              = ".tmp"
+	defaultSoftLimit          = 100 * 1024 * 1024 // 100 MiB
+	softLimitCheckInterval    = time.Minute
+
+	initQueueDirMaxAttempts = 10
+	initQueueDirRetryDelay  = 50 * time.Millisecond
+
+	// walJournalSizeLimit is the number of bytes the `-wal` file gets
+	// truncated to in between checkpoints.
+	walJournalSizeLimit = 64 * 1024 * 1024 // 64 MiB
+
+	// defaultMaxBytes limits the size of the SQLite database file.
+	defaultMaxBytes = 5 * 1024 * 1024 * 1024 // 5 GiB
+
+	// staleTmpThreshold is how old an in-progress <uuid>.tmp/ directory
+	// must be before the orphan scanner removes it. Anything younger may
+	// still belong to a peer that's mid-creation.
+	staleTmpThreshold = time.Hour
+)
+
+func getDSN(dbPath string, maxBytes int64) string {
+	params := url.Values{}
+	params.Add("_pragma", "auto_vacuum(INCREMENTAL)")
+	params.Add("_pragma", "journal_mode(WAL)")
+	params.Add("_pragma", "synchronous(NORMAL)")
+	params.Add("_pragma", fmt.Sprintf("journal_size_limit(%d)", walJournalSizeLimit))
+	addSharedParams(params, maxBytes)
+	u := url.URL{
+		Scheme:   "file",
+		OmitHost: true,
+		Path:     dbPath,
+		RawQuery: params.Encode(),
+	}
+	return u.String()
+}
+
+func newSQLiteQueue(cfg Config) (*sqliteQueue, error) {
+	if cfg.Path == "" {
+		return nil, trace.BadParameter("Path is required to create an sqlite queue")
+	}
+
+	unlock, err := initQueueDir(cfg.Path)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	db, err := initializeDb(cfg.Path, cfg.MaxBytes)
+	if err != nil {
+		_ = unlock()
+		_ = os.RemoveAll(cfg.Path)
+		return nil, trace.Wrap(err)
+	}
+
+	selfStat, err := os.Stat(cfg.Path)
+	if err != nil {
+		db.Close()
+		_ = unlock()
+		_ = os.RemoveAll(cfg.Path)
+		return nil, trace.ConvertSystemError(err)
+	}
+
+	scanInterval := cfg.OrphanScanInterval
+	if scanInterval <= 0 {
+		scanInterval = defaultOrphanScanInterval
+	}
+
+	softLimit := cfg.SoftLimit
+	if softLimit <= 0 {
+		softLimit = defaultSoftLimit
+	}
+
+	q, err := newBaseQueue(db, cfg)
+	if err != nil {
+		db.Close()
+		_ = unlock()
+		_ = os.RemoveAll(cfg.Path)
+		return nil, trace.Wrap(err)
+	}
+
+	q.path = cfg.Path
+	q.parentDir = filepath.Dir(cfg.Path)
+	q.selfStat = selfStat
+	q.unlock = unlock
+	q.orphanScanInterval = scanInterval
+	q.softLimit = softLimit
+
+	maxBytes := cfg.MaxBytes
+	if maxBytes <= 0 {
+		maxBytes = defaultMaxBytes
+	}
+	slog.InfoContext(q.ctx, "Audit queue initialized.",
+		"path", cfg.Path,
+		"max_bytes", maxBytes,
+		"soft_limit", softLimit,
+		"max_attempts", q.maxAttempts,
+		"dead_letter_ttl", q.deadLetterTTL,
+	)
+
+	q.wg.Go(q.softLimitLoop)
+	q.wg.Go(q.vacuumLoop)
+
+	return q, nil
+}
+
+func initializeDb(path string, maxBytes int64) (*sql.DB, error) {
+	if maxBytes <= 0 {
+		maxBytes = defaultMaxBytes
+	}
+
+	dbPath := filepath.Join(path, queueDBFile)
+	db, err := sql.Open("sqlite", getDSN(dbPath, maxBytes))
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	db.SetMaxOpenConns(1)
+	if _, err := db.Exec(schemaSQL); err != nil {
+		db.Close()
+		return nil, trace.Wrap(err)
+	}
+	if err := recordTeleportVersion(db, teleport.Version); err != nil {
+		db.Close()
+		return nil, trace.Wrap(err)
+	}
+
+	return db, nil
+}
+
+// initQueueDir creates and initializes the directory where the audit log queue
+// will reside. It does this in a way that is safe from race conditions. If the
+// directory is transiently claimed by another instance (e.g. due to clock
+// skew), it retries a bounded number of times.
+func initQueueDir(path string) (func() error, error) {
+	tmpPath := path + tmpDirSuffix
+	var err error
+	for attempt := range initQueueDirMaxAttempts {
+		var unlock func() error
+		unlock, err = tryInitQueueDir(path, tmpPath)
+		if err == nil {
+			return unlock, nil
+		}
+
+		isRetryableError := errors.Is(err, utils.ErrUnsuccessfulLockTry) || trace.IsNotFound(err)
+		if !isRetryableError {
+			return nil, trace.Wrap(err)
+		}
+
+		if attempt < initQueueDirMaxAttempts-1 {
+			time.Sleep(initQueueDirRetryDelay)
+		}
+	}
+	return nil, trace.Wrap(err, "failed to initialize audit-queue directory %q after %d attempts (is the system time set correctly?)", path, initQueueDirMaxAttempts)
+}
+
+func tryInitQueueDir(path, tmpPath string) (func() error, error) {
+	if err := os.MkdirAll(tmpPath, 0o700); err != nil {
+		return nil, trace.ConvertSystemError(err)
+	}
+
+	// Take the lock on the `queue.lock` file. This ensures that no other
+	// instances try to adopt this queue.
+	unlock, err := utils.FSTryWriteLock(filepath.Join(tmpPath, queueLockFile))
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	// Remove the `.tmp` suffix, marking this as a live queue.
+	if err := os.Rename(tmpPath, path); err != nil {
+		// Only remove the directory if we own the flock.
+		_ = os.RemoveAll(tmpPath)
+		_ = unlock()
+		return nil, trace.ConvertSystemError(err)
+	}
+	return unlock, nil
+}
+
+// vacuumLoop periodically cleans up deleted records from the SQLite database
+// file.
+func (q *sqliteQueue) vacuumLoop() {
+	timer := time.NewTimer(incrementalVacuumInterval)
+	defer timer.Stop()
+	for {
+		select {
+		case <-q.ctx.Done():
+			return
+		case <-timer.C:
+			if _, err := q.db.ExecContext(q.ctx, "PRAGMA incremental_vacuum"); err != nil {
+				slog.ErrorContext(q.ctx, "Failed to run incremental_vacuum.", "error", err)
+			}
+			timer.Reset(incrementalVacuumInterval)
+		}
+	}
+}
+
+// softLimitLoop periodically stats queue.db and emits a warning when its
+// size exceeds the configured soft limit.
+func (q *sqliteQueue) softLimitLoop() {
+	ticker := time.NewTicker(softLimitCheckInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-q.ctx.Done():
+			return
+		case <-ticker.C:
+		}
+		above, size, err := q.aboveSoftLimit()
+		if err != nil {
+			slog.ErrorContext(q.ctx,
+				"Failed to stat audit queue file.",
+				"path", q.path,
+				"error", err,
+			)
+			continue
+		}
+		if above {
+			slog.WarnContext(q.ctx,
+				"audit event queue above soft limit",
+				"path", q.path,
+				"size_bytes", size,
+				"soft_limit_bytes", q.softLimit,
+			)
+			softLimitWarnings.Inc()
+		}
+	}
+}
+
+func (q *sqliteQueue) aboveSoftLimit() (bool, int64, error) {
+	info, err := os.Stat(filepath.Join(q.path, queueDBFile))
+	if err != nil {
+		return false, 0, trace.ConvertSystemError(err)
+	}
+	size := info.Size()
+	return size > q.softLimit, size, nil
+}
+
+// Run drains the queue. `handler` is the function called for each audit log
+// event that is held within the queue. The audit log queue follows a single
+// consumer model in order to batch events together and commit them as groups.
+func (q *sqliteQueue) Run(ctx context.Context, handler Handler) error {
+	// Ensure we only have a single consumer running.
+	if !q.runMu.TryLock() {
+		return trace.Wrap(ErrAlreadyRunning)
+	}
+	defer q.runMu.Unlock()
+
+	// Startup the orphan scanner and dead-letter sweeper.
+	var wg sync.WaitGroup
+	wg.Go(func() {
+		q.orphanScanLoop(ctx)
+	})
+	wg.Go(func() {
+		q.deadLetterSweepLoop(ctx, handler)
+	})
+	defer wg.Wait()
+
+	return q.runPollLoop(ctx, handler)
+}
+
+func (q *sqliteQueue) orphanScanLoop(ctx context.Context) {
+	ticker := time.NewTicker(q.orphanScanInterval)
+	defer ticker.Stop()
+	for {
+		q.sweepStaleTmp()
+		q.adoptOrphans(ctx)
+
+		select {
+		case <-ctx.Done():
+			return
+		case <-q.ctx.Done():
+			return
+		case <-ticker.C:
+		}
+	}
+}
+
+// sweepStaleTmp cleans up any audit queue directories that have been orphaned
+// during their initialization phase. This should be rare, but we still want to
+// account for it.
+func (q *sqliteQueue) sweepStaleTmp() {
+	entries, err := os.ReadDir(q.parentDir)
+	if err != nil {
+		orphanScanErrors.Inc()
+		slog.ErrorContext(q.ctx,
+			"Failed to list audit-queue parent directory.",
+			"parent_dir", q.parentDir,
+			"error", err,
+		)
+		return
+	}
+	cutoff := time.Now().Add(-staleTmpThreshold)
+	for _, dirEntry := range entries {
+		if !dirEntry.IsDir() || !strings.HasSuffix(dirEntry.Name(), tmpDirSuffix) {
+			continue
+		}
+		info, err := dirEntry.Info()
+		if err != nil {
+			orphanScanErrors.Inc()
+			slog.ErrorContext(q.ctx,
+				"Failed to stat audit-queue tmp directory.",
+				"name", dirEntry.Name(),
+				"error", err,
+			)
+			continue
+		}
+		if info.ModTime().After(cutoff) {
+			continue
+		}
+
+		// If we get to this point, then the directory is older than the cutoff,
+		// which should not be the case for a tmp directory. These directories
+		// should have their `*.tmp` suffix removed as soon as they are done
+		// initializing, which should be a very quick process.
+		stalePath := filepath.Join(q.parentDir, dirEntry.Name())
+		tryRemoveStaleTmp(q.ctx, stalePath)
+	}
+}
+
+func tryRemoveStaleTmp(ctx context.Context, stalePath string) {
+	unlock, err := utils.FSTryWriteLock(filepath.Join(stalePath, queueLockFile))
+	if err != nil {
+		// The lock is held, so a creator is still active. Leave the directory
+		// for its owner and try again on the next sweep.
+		if errors.Is(err, utils.ErrUnsuccessfulLockTry) {
+			slog.WarnContext(ctx,
+				"Audit-queue tmp directory is still locked past the stale threshold. Leaving it for its owner.",
+				"path", stalePath,
+				"stale_threshold", staleTmpThreshold,
+			)
+			return
+		}
+		orphanScanErrors.Inc()
+		slog.ErrorContext(ctx,
+			"Failed to lock stale audit-queue tmp directory.",
+			"path", stalePath,
+			"error", err,
+		)
+		return
+	}
+	defer func() {
+		if err := unlock(); err != nil {
+			slog.ErrorContext(ctx,
+				"Failed to release stale audit-queue tmp flock.",
+				"path", stalePath,
+				"error", err,
+			)
+		}
+	}()
+
+	// We hold the lock, so the directory is unowned. Tmp directories were
+	// orphaned before they finished initializing, therefore they will have no
+	// audit log events, hence they are safe to remove.
+	if err := os.RemoveAll(stalePath); err != nil {
+		orphanScanErrors.Inc()
+		slog.ErrorContext(ctx,
+			"Failed to remove stale audit-queue tmp directory.",
+			"path", stalePath,
+			"error", err,
+		)
+	}
+}
+
+func (q *sqliteQueue) adoptOrphans(ctx context.Context) {
+	entries, err := os.ReadDir(q.parentDir)
+	if err != nil {
+		orphanScanErrors.Inc()
+		slog.ErrorContext(q.ctx,
+			"Failed to list audit-queue parent directory.",
+			"parent_dir", q.parentDir,
+			"error", err,
+		)
+		return
+	}
+	for _, dirEntry := range entries {
+		if ctx.Err() != nil {
+			return
+		}
+		if !dirEntry.IsDir() || strings.HasSuffix(dirEntry.Name(), tmpDirSuffix) {
+			continue
+		}
+
+		entryPath := filepath.Join(q.parentDir, dirEntry.Name())
+		entryStat, err := os.Stat(entryPath)
+		if err != nil {
+			orphanScanErrors.Inc()
+			slog.ErrorContext(q.ctx,
+				"Failed to stat audit-queue candidate directory.",
+				"path", entryPath,
+				"error", err,
+			)
+			continue
+		}
+		if os.SameFile(entryStat, q.selfStat) {
+			continue
+		}
+
+		// If we got to this point, then we have found a directory that is not a
+		// tmp directory and is not the same directory as the one this process
+		// is already using. We are safe to attempt to adopt it.
+		q.tryAdoptOrphan(ctx, entryPath)
+	}
+}
+
+func (q *sqliteQueue) tryAdoptOrphan(ctx context.Context, path string) {
+	unlock, err := utils.FSTryWriteLock(filepath.Join(path, queueLockFile))
+	if err != nil {
+		// This error indicates that the lock has already been taken, hence this
+		// queue is not an orphan. We can skip it.
+		if errors.Is(err, utils.ErrUnsuccessfulLockTry) {
+			return
+		}
+
+		// Otherwise, an error occurred while attempting to take the file lock.
+		orphanScanErrors.Inc()
+		slog.ErrorContext(q.ctx,
+			"Failed to attempt orphan flock.",
+			"path", path,
+			"error", err,
+		)
+		return
+	}
+	defer func() {
+		if err := unlock(); err != nil {
+			slog.ErrorContext(q.ctx,
+				"Failed to release orphan flock.",
+				"path", path,
+				"error", err,
+			)
+		}
+	}()
+
+	dbFilePath := filepath.Join(path, queueDBFile)
+	db, err := sql.Open("sqlite", getDSN(dbFilePath, defaultMaxBytes))
+	if err != nil {
+		orphanScanErrors.Inc()
+		slog.ErrorContext(q.ctx, "Failed to open orphan SQLite database.", "path", path, "error", err)
+		return
+	}
+	db.SetMaxOpenConns(1)
+
+	if err := db.PingContext(ctx); err != nil {
+		orphanScanErrors.Inc()
+		slog.ErrorContext(q.ctx,
+			"Failed to connect to orphan SQLite database.",
+			"path", path,
+			"error", err,
+		)
+		_ = db.Close()
+		return
+	}
+
+	migrateErr := q.migrateOrphanDB(ctx, db, filepath.Base(path))
+	if err := db.Close(); err != nil {
+		slog.ErrorContext(q.ctx,
+			"Failed to close orphan SQLite database.",
+			"path", path,
+			"error", err,
+		)
+		return
+	}
+
+	if migrateErr != nil {
+		// If we fail to migrate, we will try again on the next orphan adoption
+		// cycle. Cancellation is a normal shutdown, not a migration failure.
+		if ctx.Err() == nil && q.ctx.Err() == nil {
+			orphanScanErrors.Inc()
+			slog.ErrorContext(q.ctx,
+				"Failed to migrate orphaned audit-queue database.",
+				"path", path,
+				"error", migrateErr,
+			)
+		}
+		return
+	}
+
+	// If we got here, then we have successfully migrated the orphan. We can now
+	// safely remove it.
+	if err := os.RemoveAll(path); err != nil {
+		orphanScanErrors.Inc()
+		slog.ErrorContext(q.ctx,
+			"Failed to remove migrated orphan directory.",
+			"path", path,
+			"error", err,
+		)
+		return
+	}
+	q.clearOrphanWatermarks(ctx, filepath.Base(path))
+	orphansAdopted.Inc()
+	slog.InfoContext(q.ctx, "Adopted orphaned audit-queue directory.", "path", path)
+}
+
+func (q *sqliteQueue) migrateOrphanDB(ctx context.Context, db *sql.DB, name string) error {
+	if err := q.migrateOrphanQueue(ctx, db, name); err != nil {
+		return trace.Wrap(err)
+	}
+	return trace.Wrap(q.migrateOrphanDeadLetter(ctx, db, name))
+}
+
+func (q *sqliteQueue) migrateOrphanQueue(ctx context.Context, orphan *sql.DB, name string) error {
+	return q.migrateOrphanTable(ctx, orphan, name, auditQueueTable,
+		"SELECT id, payload, attempts FROM audit_queue WHERE id > ? ORDER BY id ASC LIMIT ?",
+		"INSERT INTO audit_queue (payload, attempts) VALUES (?, ?)",
+	)
+}
+
+func (q *sqliteQueue) migrateOrphanDeadLetter(ctx context.Context, orphan *sql.DB, name string) error {
+	return q.migrateOrphanTable(ctx, orphan, name, auditDeadLetterTable,
+		"SELECT id, payload, failed_at FROM audit_dead_letter WHERE id > ? ORDER BY id ASC LIMIT ?",
+		"INSERT INTO audit_dead_letter (payload, failed_at) VALUES (?, ?)",
+	)
+}
+
+func orphanWatermarkKey(name, table string) string {
+	return "orphan_migration:" + name + ":" + table
+}
+
+func (q *sqliteQueue) migrateOrphanTable(ctx context.Context, orphan *sql.DB, name, table, selectSQL, insertSQL string) error {
+	watermarkKey := orphanWatermarkKey(name, table)
+	watermark, err := q.readOrphanWatermark(ctx, watermarkKey)
+	if err != nil {
+		return trace.Wrap(err, "reading orphan %s watermark", table)
+	}
+	for {
+		if err := ctx.Err(); err != nil {
+			return trace.Wrap(err)
+		}
+		if err := q.ctx.Err(); err != nil {
+			return trace.Wrap(err)
+		}
+		batch, err := fetchOrphanRows(ctx, orphan, selectSQL, watermark, dequeueBatchSize)
+		if err != nil {
+			return trace.Wrap(err, "fetching orphan %s rows", table)
+		}
+		if len(batch) == 0 {
+			return nil
+		}
+
+		maxID := batch[len(batch)-1].id
+		if err := q.insertMigratedBatch(ctx, insertSQL, batch, watermarkKey, maxID); err != nil {
+			return trace.Wrap(err, "migrating orphan %s rows", table)
+		}
+		watermark = maxID
+
+		ids := make([]int64, len(batch))
+		for i, r := range batch {
+			ids[i] = r.id
+		}
+		if err := deleteIDsFromTable(ctx, orphan, table, ids); err != nil {
+			return trace.Wrap(err, "deleting migrated orphan %s rows", table)
+		}
+	}
+}
+
+func (q *sqliteQueue) readOrphanWatermark(ctx context.Context, key string) (int64, error) {
+	var value string
+	err := q.db.QueryRowContext(ctx,
+		"SELECT value FROM teleport_info WHERE key = ?", key).Scan(&value)
+	if errors.Is(err, sql.ErrNoRows) {
+		return 0, nil
+	}
+	if err != nil {
+		return 0, trace.Wrap(err)
+	}
+	watermark, err := strconv.ParseInt(value, 10, 64)
+	return watermark, trace.Wrap(err)
+}
+
+func (q *sqliteQueue) clearOrphanWatermarks(ctx context.Context, name string) {
+	if _, err := q.db.ExecContext(ctx,
+		"DELETE FROM teleport_info WHERE key IN (?, ?)",
+		orphanWatermarkKey(name, auditQueueTable),
+		orphanWatermarkKey(name, auditDeadLetterTable),
+	); err != nil {
+		slog.ErrorContext(q.ctx,
+			"Failed to clear orphan migration watermarks.",
+			"orphan", name,
+			"error", err,
+		)
+	}
+}
+
+type migratedRow struct {
+	id     int64
+	values []any
+}
+
+func fetchOrphanRows(ctx context.Context, db *sql.DB, selectSQL string, afterID int64, limit int) ([]migratedRow, error) {
+	rows, err := db.QueryContext(ctx, selectSQL, afterID, limit)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	defer rows.Close()
+	cols, err := rows.Columns()
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	var out []migratedRow
+	for rows.Next() {
+		r := migratedRow{values: make([]any, len(cols)-1)}
+		targets := make([]any, 0, len(cols))
+		targets = append(targets, &r.id)
+		for i := range r.values {
+			targets = append(targets, &r.values[i])
+		}
+		if err := rows.Scan(targets...); err != nil {
+			return nil, trace.Wrap(err)
+		}
+		out = append(out, r)
+	}
+	return out, trace.Wrap(rows.Err())
+}
+
+func (q *sqliteQueue) insertMigratedBatch(ctx context.Context, insertSQL string, batch []migratedRow, watermarkKey string, maxID int64) error {
+	tx, err := q.db.BeginTx(ctx, nil)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	defer tx.Rollback()
+	stmt, err := tx.PrepareContext(ctx, insertSQL)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	defer stmt.Close()
+	for _, r := range batch {
+		if _, err := stmt.ExecContext(ctx, r.values...); err != nil {
+			return trace.Wrap(err)
+		}
+	}
+	if _, err := tx.ExecContext(ctx,
+		"INSERT OR REPLACE INTO teleport_info (key, value) VALUES (?, ?)",
+		watermarkKey, strconv.FormatInt(maxID, 10),
+	); err != nil {
+		return trace.Wrap(err)
+	}
+	return trace.Wrap(tx.Commit())
+}
+
+func (q *sqliteQueue) Close() error {
+	var errs []error
+	q.closeOnce.Do(func() {
+		q.cancel()
+		q.wg.Wait()
+
+		// Flush the WAL file.
+		if _, err := q.db.Exec("PRAGMA wal_checkpoint(TRUNCATE)"); err != nil {
+			slog.ErrorContext(q.ctx,
+				"Failed to checkpoint WAL on close.",
+				"path", q.path,
+				"error", err,
+			)
+		}
+
+		empty, err := isQueueEmpty(q.db)
+		if err != nil {
+			slog.ErrorContext(q.ctx,
+				"Failed to check whether audit queue is empty on close.",
+				"path", q.path,
+				"error", err,
+			)
+		}
+
+		if err := q.db.Close(); err != nil {
+			errs = append(errs, err)
+		}
+
+		// Remove the directory before releasing the lock. This ensures no other
+		// process can adopt and start draining a queue we are about to delete.
+		if empty {
+			if err := os.RemoveAll(q.path); err != nil {
+				slog.ErrorContext(q.ctx, "Failed to remove empty audit-queue directory on close.", "path", q.path, "error", err)
+			}
+		}
+
+		if q.unlock != nil {
+			if err := q.unlock(); err != nil {
+				errs = append(errs, err)
+			}
+		}
+	})
+	return trace.NewAggregate(errs...)
+}
+
+func isQueueEmpty(db *sql.DB) (bool, error) {
+	var hasRows int
+	err := db.QueryRow(
+		"SELECT EXISTS(SELECT 1 FROM audit_queue) OR EXISTS(SELECT 1 FROM audit_dead_letter)",
+	).Scan(&hasRows)
+	if err != nil {
+		return false, trace.Wrap(err)
+	}
+	return hasRows == 0, nil
+}

--- a/lib/events/auditqueue/sqlite_memory.go
+++ b/lib/events/auditqueue/sqlite_memory.go
@@ -1,0 +1,143 @@
+/*
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package auditqueue
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"net/url"
+	"sync"
+
+	"github.com/google/uuid"
+	"github.com/gravitational/trace"
+
+	"github.com/gravitational/teleport"
+	apievents "github.com/gravitational/teleport/api/types/events"
+)
+
+const (
+	defaultInMemoryMaxBytes = 100 * 1024 * 1024 // 100 MiB
+)
+
+func getInMemoryDSN(name string, maxBytes int64) string {
+	if maxBytes <= 0 {
+		maxBytes = defaultInMemoryMaxBytes
+	}
+	params := url.Values{}
+	params.Add("mode", "memory")
+	params.Add("cache", "shared")
+	addSharedParams(params, maxBytes)
+	u := url.URL{
+		Scheme:   "file",
+		OmitHost: true,
+		Path:     name,
+		RawQuery: params.Encode(),
+	}
+	return u.String()
+}
+
+// sqliteInMemoryQueue is a fully in-memory SQLite database. No filesystem
+// access needed.
+type sqliteInMemoryQueue struct {
+	inner       *sqliteQueue
+	id          string
+	keepAliveDB *sql.DB
+	keepAlive   *sql.Conn
+}
+
+// Ensure that we implement the interface Queue at compile time.
+var _ Queue = (*sqliteInMemoryQueue)(nil)
+
+func newSQLiteInMemoryQueue(cfg Config) (*sqliteInMemoryQueue, error) {
+	id := uuid.NewString()
+	dsn := getInMemoryDSN(id, cfg.MaxBytes)
+	db, err := sql.Open("sqlite", dsn)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	db.SetMaxOpenConns(1)
+	if _, err := db.Exec(schemaSQL); err != nil {
+		db.Close()
+		return nil, trace.Wrap(err)
+	}
+	if err := recordTeleportVersion(db, teleport.Version); err != nil {
+		db.Close()
+		return nil, trace.Wrap(err)
+	}
+
+	// The shared in-memory database is destroyed when its last connection
+	// closes, so keep one connection pinned for the queue's lifetime.
+	keepAliveDB, err := sql.Open("sqlite", dsn)
+	if err != nil {
+		db.Close()
+		return nil, trace.Wrap(err)
+	}
+	keepAliveDB.SetMaxOpenConns(1)
+	keepAlive, err := keepAliveDB.Conn(context.Background())
+	if err != nil {
+		keepAliveDB.Close()
+		db.Close()
+		return nil, trace.Wrap(err)
+	}
+
+	inner, err := newBaseQueue(db, cfg)
+	if err != nil {
+		_ = keepAlive.Close()
+		keepAliveDB.Close()
+		db.Close()
+		return nil, trace.Wrap(err)
+	}
+
+	return &sqliteInMemoryQueue{
+		inner:       inner,
+		id:          id,
+		keepAliveDB: keepAliveDB,
+		keepAlive:   keepAlive,
+	}, nil
+}
+
+func (m *sqliteInMemoryQueue) Enqueue(event apievents.AuditEvent) error {
+	return m.inner.Enqueue(event)
+}
+
+// Run drains the in-memory queue.
+func (m *sqliteInMemoryQueue) Run(ctx context.Context, handler Handler) error {
+	if !m.inner.runMu.TryLock() {
+		return trace.Wrap(ErrAlreadyRunning)
+	}
+	defer m.inner.runMu.Unlock()
+
+	var wg sync.WaitGroup
+	wg.Go(func() { m.inner.deadLetterSweepLoop(ctx, handler) })
+	defer wg.Wait()
+
+	return m.inner.runPollLoop(ctx, handler)
+}
+
+// Close shuts down the in-memory queue.
+func (m *sqliteInMemoryQueue) Close() error {
+	var err error
+	m.inner.closeOnce.Do(func() {
+		m.inner.cancel()
+		m.inner.wg.Wait()
+		err = errors.Join(m.inner.db.Close(), m.keepAlive.Close(), m.keepAliveDB.Close())
+	})
+	return trace.Wrap(err)
+}

--- a/lib/events/auditqueue/sqlite_memory_test.go
+++ b/lib/events/auditqueue/sqlite_memory_test.go
@@ -1,0 +1,133 @@
+/*
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package auditqueue
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSQLiteInMemoryQueue_IsInMemory(t *testing.T) {
+	t.Parallel()
+
+	q, err := New(KindSQLiteMemory, Config{})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, q.Close()) })
+
+	mem, ok := q.(*sqliteInMemoryQueue)
+	require.True(t, ok)
+
+	rows, err := mem.inner.db.Query("PRAGMA database_list")
+	require.NoError(t, err)
+	defer rows.Close()
+
+	var foundMain bool
+	for rows.Next() {
+		var seq int
+		var name, file string
+		require.NoError(t, rows.Scan(&seq, &name, &file))
+		if name == "main" {
+			foundMain = true
+			require.Empty(t, file,
+				"main database file path should be empty for in-memory DB, got %q", file)
+		}
+	}
+	require.NoError(t, rows.Err())
+	require.True(t, foundMain, "main database not found in PRAGMA database_list")
+}
+
+func TestSQLiteInMemoryQueue_InstancesAreIsolated(t *testing.T) {
+	t.Parallel()
+
+	a, err := New(KindSQLiteMemory, Config{})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, a.Close()) })
+
+	b, err := New(KindSQLiteMemory, Config{})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, b.Close()) })
+
+	require.NoError(t, a.Enqueue(newTestEvent(1)))
+
+	memA := a.(*sqliteInMemoryQueue)
+	memB := b.(*sqliteInMemoryQueue)
+	require.NotEqual(t, memA.id, memB.id, "each instance should have a unique DB id")
+
+	// Wait for the event to land in instance A's DB.
+	require.Eventually(t, func() bool {
+		var n int
+		if err := memA.inner.db.QueryRow("SELECT COUNT(*) FROM audit_queue").Scan(&n); err != nil {
+			return false
+		}
+		return n == 1
+	}, testDefaultTimeout, 10*time.Millisecond, "instance a never received the enqueued event")
+
+	// b should see zero events because it owns a different DB.
+	var n int
+	require.NoError(t, memB.inner.db.QueryRow("SELECT COUNT(*) FROM audit_queue").Scan(&n))
+	require.Equal(t, 0, n, "instance b should not see events enqueued into instance a")
+}
+
+func TestSQLiteInMemoryQueue_SingleQueueConnection(t *testing.T) {
+	t.Parallel()
+
+	q, err := New(KindSQLiteMemory, Config{})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, q.Close()) })
+
+	mem, ok := q.(*sqliteInMemoryQueue)
+	require.True(t, ok)
+
+	require.Equal(t, 1, mem.inner.db.Stats().MaxOpenConnections,
+		"queue DB must be capped at one connection to avoid shared-cache lock errors")
+
+	const N = 100
+	var wg sync.WaitGroup
+	errs := make([]error, N)
+	for i := range N {
+		wg.Go(func() {
+			errs[i] = q.Enqueue(newTestEvent(int64(i)))
+		})
+	}
+	wg.Wait()
+
+	for i, err := range errs {
+		require.NoError(t, err, "Enqueue %d failed", i)
+	}
+}
+
+func TestSQLiteInMemoryQueue_MaxBytesEnforced(t *testing.T) {
+	t.Parallel()
+
+	const maxBytes = 1 * 1024 * 1024 // 1 MiB
+	q, err := New(KindSQLiteMemory, Config{MaxBytes: maxBytes})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, q.Close()) })
+
+	mem, ok := q.(*sqliteInMemoryQueue)
+	require.True(t, ok)
+
+	var pages int64
+	require.NoError(t, mem.inner.db.QueryRow("PRAGMA max_page_count").Scan(&pages))
+	require.Equal(t, bytesToPages(maxBytes), pages,
+		"max_page_count should be derived from cfg.MaxBytes")
+}

--- a/lib/events/auditqueue/sqlite_test.go
+++ b/lib/events/auditqueue/sqlite_test.go
@@ -242,7 +242,7 @@ func TestNew_ReturnsQueue(t *testing.T) {
 	t.Parallel()
 
 	path := filepath.Join(t.TempDir(), queueDir)
-	q, err := New(KindSQLite, Config{Path: path})
+	q, err := New(KindSQLiteDisk, Config{Path: path})
 	require.NoError(t, err)
 	require.NotNil(t, q)
 	t.Cleanup(func() { require.NoError(t, q.Close()) })

--- a/lib/events/emitter.go
+++ b/lib/events/emitter.go
@@ -116,7 +116,7 @@ func makeQueue(dataDir string) (auditqueue.Queue, error) {
 	queueCfg := auditqueue.Config{
 		Path: queuePath,
 	}
-	queue, err := auditqueue.New(auditqueue.KindSQLite, queueCfg)
+	queue, err := auditqueue.New(auditqueue.KindSQLiteDisk, queueCfg)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}


### PR DESCRIPTION
Changelog: Implement in-memory audit log queue.

**NOTE:** This diff appears much larger than it really is. The file sqlite.go was split into sqlite_disk.go and sqlite_memory.go. A lot of the diff is a cut-and-paste from the original sqlite.go file in master.

This PR is the third in what will be multiple PRs that implement [RFD 254](https://github.com/gravitational/teleport.e/pull/8641)

This adds an in-memory SQLite-backed audit log queue. The intention is this can act as a fallback if there is an error constructing a disk backed queue, for example, if writing to the filesystem causes an error. A follow-up PR will implement the fallback logic.

## Previous PRs in this project:
1. https://github.com/gravitational/teleport/pull/66883 
2. https://github.com/gravitational/teleport/pull/67019

## Features in this PR

This PR implements a subset of the RFD. The rest of the RFD will be implemented in future PRs. This PR implements the following feature set as described in the RFD:
- In-memory queue.

## Features that will be included in future PRs

Outstanding items that will be implemented in follow-up PR(s) include:
- tctl additions for audit queue observability.
- Protobuf changes.
- teleport.yaml configuration options.
- Encryption at rest (deferred to v19)
- Integration tests.
- Graceful shutdown drain.
- Skipping events that fail to deserialize.

## Manual Test Plan

I have tested this feature by running an enterprise build of the binary, verifying audit log events are being displayed correctly in the web UI, then I ran benchmarks using `tsh bench`.

### Test Environment

This has been tested on a Linux AMD64 machine.

### Test Cases

- [x] Verify audit log events show up in web UI as expected.
- [x] Benchmark that SQLite based queue can handle at least the level of traffic as in-memory version.
- [x] Verify we we don't see warnings of dropped audit log events.

### Test Description

This has been tested by running an enterprise binary like so:
```sh
TELEPORT_UNSTABLE_AUDIT_LOG_RELIABILITY=true ./e/build/teleport start --config="/etc/teleport.yaml"
```

From there, I observed that audit log events get propagated to the web UI as expected.

Next, I ran the following benchmark. Running the following `tsh` bench on the legacy audit log queue causes events to be dropped.

```sh
tsh bench --duration=60s --rate=224 ssh root@<TEST_MACHINE> "echo hi"
```

Running with the SQLite based audit log queue enabled results in the following count of audit log events being emitted:

```sh
$ curl -s localhost:3000/metrics | grep teleport_audit_emit_events
# HELP teleport_audit_emit_events Number of audit events emitted
# TYPE teleport_audit_emit_events counter
teleport_audit_emit_events 133585
```