### PR TITLE
[v18] Fix updater chart not honouring podSecurityContext

### DIFF
--- a/examples/chart/teleport-kube-agent/tests/__snapshot__/updater_deployment_test.yaml.snap
+++ b/examples/chart/teleport-kube-agent/tests/__snapshot__/updater_deployment_test.yaml.snap
@@ -63,6 +63,8 @@ sets the affinity:
         runAsUser: 9807
         seccompProfile:
           type: RuntimeDefault
+    securityContext:
+      fsGroup: 9807
     serviceAccountName: RELEASE-NAME-updater
 sets the tolerations:
   1: |
@@ -109,6 +111,8 @@ sets the tolerations:
         runAsUser: 9807
         seccompProfile:
           type: RuntimeDefault
+    securityContext:
+      fsGroup: 9807
     serviceAccountName: RELEASE-NAME-updater
     tolerations:
     - effect: NoExecute

--- a/examples/chart/teleport-kube-agent/tests/updater_deployment_test.yaml
+++ b/examples/chart/teleport-kube-agent/tests/updater_deployment_test.yaml
@@ -380,3 +380,26 @@ tests:
             name: docker-config
             mountPath: "/mnt/docker"
             readOnly: true
+
+  - it: sets the pod security context
+    documentIndex: 0
+    values:
+      - ../.lint/updater.yaml
+    set:
+      podSecurityContext:
+        seccompProfile:
+          type: RuntimeDefault
+        runAsUser: 65532
+        runAsGroup: 65532
+        fsGroup: 65532
+        runAsNonRoot: true
+      asserts:
+        - equal:
+            path: spec.template.spec.securityContext
+            value:
+              seccompProfile:
+                type: RuntimeDefault
+              runAsUser: 65532
+              runAsGroup: 65532
+              fsGroup: 65532
+              runAsNonRoot: true

--- a/examples/chart/teleport-kube-updater/templates/_deployment.tpl
+++ b/examples/chart/teleport-kube-updater/templates/_deployment.tpl
@@ -131,5 +131,8 @@ spec:
 {{- if .priorityClassName }}
       priorityClassName: {{ .priorityClassName }}
 {{- end }}
+{{- if .podSecurityContext }}
+      securityContext: {{- toYaml .podSecurityContext | nindent 8 }}
+{{- end }}
       serviceAccountName: {{ .serviceAccount.name }}
 {{- end -}}


### PR DESCRIPTION
Backport #67044 to branch/v18

changelog: Fixed the `teleport-kube-agent` updater not honouring the `podSecurityContext` value.
