### PR TITLE
Add secondary index for application server lookup by application name

### DIFF
--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -8075,19 +8075,18 @@ func (a *Server) isMFARequired(ctx context.Context, scopedCtx *authz.ScopedConte
 			return nil, trace.BadParameter("missing Name field in an app-only UserCertsRequest")
 		}
 
-		servers, err := a.GetApplicationServers(ctx, apidefaults.Namespace)
-		if err != nil {
-			return nil, trace.Wrap(err)
+		var app types.Application
+		for server, err := range a.RangeApplicationServersWithName(ctx, t.App.Name) {
+			if err != nil {
+				return nil, trace.Wrap(err)
+			}
+			app = server.GetApp()
+			break
 		}
-
-		i := slices.IndexFunc(servers, func(server types.AppServer) bool {
-			return server.GetApp().GetName() == t.App.Name
-		})
-		if i == -1 {
+		if app == nil {
 			return nil, trace.NotFound("application service %q not found", t.App.Name)
 		}
 
-		app := servers[i].GetApp()
 		noMFAAccessErr = checker.CheckAccess(app, services.AccessState{})
 
 	default:

--- a/lib/auth/authclient/api.go
+++ b/lib/auth/authclient/api.go
@@ -1262,6 +1262,9 @@ type Cache interface {
 	// GetApplicationServers returns all registered application servers.
 	GetApplicationServers(ctx context.Context, namespace string) ([]types.AppServer, error)
 
+	// RangeApplicationServersWithName returns an iterator over application servers for a given app name.
+	RangeApplicationServersWithName(ctx context.Context, appName string) iter.Seq2[types.AppServer, error]
+
 	// GetAppSession gets an application web session.
 	GetAppSession(context.Context, types.GetAppSessionRequest) (types.WebSession, error)
 

--- a/lib/cache/app.go
+++ b/lib/cache/app.go
@@ -19,13 +19,19 @@ package cache
 import (
 	"context"
 	"iter"
+	"strings"
 
 	"github.com/gravitational/trace"
+	"rsc.io/ordered"
 
+	clientproto "github.com/gravitational/teleport/api/client/proto"
 	"github.com/gravitational/teleport/api/defaults"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/utils/clientutils"
+	"github.com/gravitational/teleport/lib/backend"
+	"github.com/gravitational/teleport/lib/itertools/stream"
 	"github.com/gravitational/teleport/lib/services"
+	logutils "github.com/gravitational/teleport/lib/utils/log"
 )
 
 type appIndex string
@@ -152,6 +158,18 @@ func (c *Cache) GetApp(ctx context.Context, name string) (types.Application, err
 type appServerIndex string
 
 const appServerNameIndex appServerIndex = "name"
+const appServerAppNameIndex appServerIndex = "app_name"
+
+func appServerByAppNameKey(s types.AppServer) string {
+	// Delete events deliver header only resources with a nil App. This returns
+	// "" so the secondary index lookup is a no-op. The primary index deletion
+	// removes the entry from all indexes.
+	app := s.GetApp()
+	if app == nil {
+		return ""
+	}
+	return string(ordered.Encode(app.GetName(), s.GetHostID(), s.GetName()))
+}
 
 func newAppServerCollection(p services.Presence, w types.WatchKind) (*collection[types.AppServer, appServerIndex], error) {
 	if p == nil {
@@ -166,6 +184,7 @@ func newAppServerCollection(p services.Presence, w types.WatchKind) (*collection
 				appServerNameIndex: func(u types.AppServer) string {
 					return u.GetHostID() + "/" + u.GetName()
 				},
+				appServerAppNameIndex: appServerByAppNameKey,
 			}),
 		fetcher: func(ctx context.Context, loadSecrets bool) ([]types.AppServer, error) {
 			return p.GetApplicationServers(ctx, defaults.Namespace)
@@ -208,4 +227,89 @@ func (c *Cache) GetApplicationServers(ctx context.Context, namespace string) ([]
 
 	servers, err := c.Config.Presence.GetApplicationServers(ctx, namespace)
 	return servers, trace.Wrap(err)
+}
+
+// RangeApplicationServersWithName returns an iterator over application servers for a given app name.
+func (c *Cache) RangeApplicationServersWithName(ctx context.Context, appName string) iter.Seq2[types.AppServer, error] {
+	if appName == "" {
+		return stream.Fail[types.AppServer](trace.BadParameter("missing application name"))
+	}
+
+	return func(yield func(types.AppServer, error) bool) {
+		ctx, span := c.Tracer.Start(ctx, "cache/RangeApplicationServersWithName")
+		defer span.End()
+
+		upstreamListFn := func(ctx context.Context, pageSize int, startToken string) ([]types.AppServer, string, error) {
+			var tokenAppName string
+			rest, err := ordered.DecodePrefix([]byte(startToken), &tokenAppName)
+			if err != nil {
+				return nil, "", trace.Wrap(err)
+			}
+
+			// Verify that the token's app name matches the requested app name.
+			// This ensures that if the token is malformed or belongs to a different
+			// app, we don't return incorrect results.
+			if tokenAppName != appName {
+				return nil, "", trace.BadParameter("pagination token does not match the requested application name")
+			}
+
+			backendKey := ""
+			if len(rest) > 0 {
+				var hostID, serverName string
+				if err := ordered.Decode(rest, &hostID, &serverName); err != nil {
+					return nil, "", trace.Wrap(err)
+				}
+				backendKey = hostID + "/" + serverName
+			}
+
+			resp, err := c.Config.Presence.ListResources(ctx, clientproto.ListResourcesRequest{
+				ResourceType: types.KindAppServer,
+				Namespace:    defaults.Namespace,
+				Limit:        int32(pageSize),
+				StartKey:     backendKey,
+			})
+			if err != nil {
+				return nil, "", trace.Wrap(err)
+			}
+
+			var page []types.AppServer
+			for _, r := range resp.Resources {
+				server, ok := r.(types.AppServer)
+				if !ok {
+					c.Logger.WarnContext(ctx, "expected AppServer but received unexpected type", "resource_type", logutils.TypeAttr(r))
+					continue
+				}
+				if app := server.GetApp(); app != nil && app.GetName() == appName {
+					page = append(page, server)
+				}
+			}
+
+			next := ""
+			if resp.NextKey != "" {
+				hostID, serverName, ok := strings.Cut(resp.NextKey, backend.SeparatorString)
+				if !ok {
+					return nil, "", trace.BadParameter("invalid pagination token: %q", resp.NextKey)
+				}
+				next = string(ordered.Encode(appName, hostID, serverName))
+			}
+			return page, next, nil
+		}
+
+		lister := genericLister[types.AppServer, appServerIndex]{
+			cache:           c,
+			collection:      c.collections.appServers,
+			index:           appServerAppNameIndex,
+			nextToken:       appServerByAppNameKey,
+			defaultPageSize: defaults.DefaultChunkSize,
+			upstreamList:    upstreamListFn,
+		}
+
+		start := string(ordered.Encode(appName))
+		end := string(ordered.Encode(appName, ordered.Inf))
+		for item, err := range lister.Range(ctx, start, end) {
+			if !yield(item, err) {
+				return
+			}
+		}
+	}
 }

--- a/lib/cache/app_test.go
+++ b/lib/cache/app_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/gravitational/teleport/api/client/proto"
 	apidefaults "github.com/gravitational/teleport/api/defaults"
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/services"
 )
 
 // TestApps tests that CRUD operations on application resources are
@@ -140,4 +141,40 @@ func TestApplicationServers(t *testing.T) {
 		})
 	})
 
+}
+
+func mustCreateAppServer(t testing.TB, hostID, appName string) types.AppServer {
+	t.Helper()
+
+	app, err := types.NewAppV3(types.Metadata{
+		Name: appName,
+	}, types.AppSpecV3{
+		URI: "localhost",
+	})
+	require.NoError(t, err)
+
+	appServer, err := types.NewAppServerV3FromApp(app, "localhost", hostID)
+	require.NoError(t, err)
+	return appServer
+}
+
+var appServerRangeFuncs = rangeServersWithTargetNameFuncs[types.AppServer]{
+	newResource: mustCreateAppServer,
+	create: func(ctx context.Context, presence services.Presence, s types.AppServer) error {
+		_, err := presence.UpsertApplicationServer(ctx, s)
+		return err
+	},
+	delete: func(ctx context.Context, presence services.Presence, s types.AppServer) error {
+		return presence.DeleteApplicationServer(ctx, s.GetNamespace(), s.GetHostID(), s.GetName())
+	},
+	rangeByName: (*Cache).RangeApplicationServersWithName,
+}
+
+func TestRangeApplicationServersWithName(t *testing.T) {
+	t.Parallel()
+	testRangeServersWithTargetName(t, appServerRangeFuncs)
+}
+
+func BenchmarkRangeApplicationServersWithName(b *testing.B) {
+	benchmarkRangeServersWithTargetName(b, appServerRangeFuncs)
 }

--- a/lib/services/local/presence.go
+++ b/lib/services/local/presence.go
@@ -1181,6 +1181,32 @@ func (s *PresenceService) getApplicationServers(ctx context.Context, namespace s
 	return servers, nil
 }
 
+// RangeApplicationServersWithName returns an iterator over application servers for a given app name.
+func (s *PresenceService) RangeApplicationServersWithName(ctx context.Context, appName string) iter.Seq2[types.AppServer, error] {
+	if appName == "" {
+		return stream.Fail[types.AppServer](trace.BadParameter("missing application name"))
+	}
+
+	mapFn := func(item backend.Item) (types.AppServer, bool) {
+		server, err := services.UnmarshalAppServer(
+			item.Value,
+			services.WithExpires(item.Expires),
+			services.WithRevision(item.Revision),
+		)
+		if err != nil {
+			s.logger.WarnContext(ctx, "Failed to unmarshal application server", "key", item.Key, "error", err)
+			return nil, false
+		}
+		app := server.GetApp()
+		return server, app != nil && app.GetName() == appName
+	}
+
+	startKey := backend.ExactKey(appServersPrefix, apidefaults.Namespace)
+	endKey := backend.RangeEnd(startKey)
+
+	return stream.FilterMap(s.Backend.Items(ctx, backend.ItemsParams{StartKey: startKey, EndKey: endKey}), mapFn)
+}
+
 // UpsertApplicationServer registers an application server.
 func (s *PresenceService) UpsertApplicationServer(ctx context.Context, server types.AppServer) (*types.KeepAlive, error) {
 	if err := services.CheckAndSetDefaults(server); err != nil {

--- a/lib/services/local/presence_test.go
+++ b/lib/services/local/presence_test.go
@@ -144,6 +144,77 @@ func TestApplicationServersCRUD(t *testing.T) {
 	require.Empty(t, out)
 }
 
+func mustCreateApplicationServer(t *testing.T, appName string) types.AppServer {
+	t.Helper()
+	app, err := types.NewAppV3(types.Metadata{
+		Name: appName,
+	}, types.AppSpecV3{
+		URI: "localhost",
+	})
+	require.NoError(t, err)
+
+	server, err := types.NewAppServerV3FromApp(app, "localhost", uuid.New().String())
+	require.NoError(t, err)
+	return server
+}
+
+func TestRangeApplicationServersWithName(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+
+	bk, err := memory.New(memory.Config{})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = bk.Close() })
+
+	presence := NewPresenceService(bk)
+
+	t.Run("ParameterValidation", func(t *testing.T) {
+		_, err = iterstream.Collect(presence.RangeApplicationServersWithName(ctx, ""))
+		require.ErrorAs(t, err, new(*trace.BadParameterError))
+	})
+
+	server1 := mustCreateApplicationServer(t, "shared-app")
+	server2 := mustCreateApplicationServer(t, "shared-app")
+	server3 := mustCreateApplicationServer(t, "standalone-app")
+
+	for _, s := range []types.AppServer{server1, server2, server3} {
+		_, err := presence.UpsertApplicationServer(ctx, s)
+		require.NoError(t, err)
+	}
+
+	t.Run("MultipleServersSameApplication", func(t *testing.T) {
+		servers, err := iterstream.Collect(presence.RangeApplicationServersWithName(ctx, "shared-app"))
+		require.NoError(t, err)
+		require.Len(t, servers, 2)
+		for _, s := range servers {
+			require.Equal(t, "shared-app", s.GetApp().GetName())
+		}
+	})
+
+	t.Run("SingleServerForApplication", func(t *testing.T) {
+		servers, err := iterstream.Collect(presence.RangeApplicationServersWithName(ctx, "standalone-app"))
+		require.NoError(t, err)
+		require.Len(t, servers, 1)
+		require.Equal(t, "standalone-app", servers[0].GetApp().GetName())
+	})
+
+	t.Run("NoServersForApplication", func(t *testing.T) {
+		servers, err := iterstream.Collect(presence.RangeApplicationServersWithName(ctx, "nonexistent-app"))
+		require.NoError(t, err)
+		require.Empty(t, servers)
+	})
+
+	t.Run("DeletedServersNotReturned", func(t *testing.T) {
+		err := presence.DeleteApplicationServer(ctx, server1.GetNamespace(), server1.GetHostID(), server1.GetName())
+		require.NoError(t, err)
+
+		servers, err := iterstream.Collect(presence.RangeApplicationServersWithName(ctx, "shared-app"))
+		require.NoError(t, err)
+		require.Len(t, servers, 1)
+		require.Equal(t, server2.GetHostID(), servers[0].GetHostID())
+	})
+}
+
 func mustCreateDatabase(t *testing.T, name, protocol, uri string) *types.DatabaseV3 {
 	database, err := types.NewDatabaseV3(
 		types.Metadata{

--- a/lib/services/presence.go
+++ b/lib/services/presence.go
@@ -217,6 +217,9 @@ type PresenceInternal interface {
 	// doesn't check the revision of the app_server in storage).
 	UnconditionalUpdateApplicationServer(ctx context.Context, server types.AppServer) (types.AppServer, error)
 
+	// RangeApplicationServersWithName returns an iterator over application servers for a given app name.
+	RangeApplicationServersWithName(ctx context.Context, appName string) iter.Seq2[types.AppServer, error]
+
 	// AppendPutNodeActions adds conditional actions to an atomic write to create
 	// or update a node resource.
 	AppendPutNodeActions(


### PR DESCRIPTION
Continuation of `IsMFARequired` enhancements (re: https://github.com/gravitational/teleport/pull/66484)

Adds a new function, `RangeApplicationServersWithName`, to the cache and PresenceInternal interfaces that returns an iterator over application servers matching a given application name.

Replaces the full scan in `IsMFARequiredRequest_App`, which fetched all application servers and filtered in-memory, with a range scan over a secondary index keyed by application name. 

Changelog: Improved performance and reduced resource usage of the auth service for clusters with large numbers of registered applications with per-session MFA enabled.

## Manual Test Plan
### Test Environment

Teleport Cloud tenant with at least one enrolled application and a role that requires per-session MFA for application access.

### Test Cases
- [x] Connect to an application where the role requires per-session MFA and confirm MFA prompt appears and connection succeeds after verification
- [x] Connect to an application where no per-session MFA is required and confirm connection succeeds without an MFA prompt
- [x] Unregister a previously registered application, attempt to connect, and confirm a not found error is returned
