### PR TITLE
Reject empty challenges in `devicetrust`

### DIFF
--- a/lib/devicetrust/challenge/challenge.go
+++ b/lib/devicetrust/challenge/challenge.go
@@ -41,6 +41,13 @@ func New() ([]byte, error) {
 // Verify verifies that [sig] is a signature over [chal] by the private key
 // corresponding to [pubKey].
 func Verify(chal, sig []byte, pubKey crypto.PublicKey) error {
+	if len(chal) == 0 {
+		return trace.BadParameter("zero-length challenge")
+	}
+	if len(sig) == 0 {
+		return trace.BadParameter("zero-length signature")
+	}
+
 	switch pub := pubKey.(type) {
 	case *ecdsa.PublicKey:
 		digest, err := hash(crypto.SHA256, chal)
@@ -75,6 +82,9 @@ func Verify(chal, sig []byte, pubKey crypto.PublicKey) error {
 // Sign returns a signature over [challenge] by [signer]. A SHA256 hash is used
 // for ECDSA and RSA, no pre-hash is used for Ed25519.
 func Sign(challenge []byte, signer crypto.Signer) ([]byte, error) {
+	if len(challenge) == 0 {
+		return nil, trace.BadParameter("zero-length challenge")
+	}
 	switch pub := signer.Public().(type) {
 	case *ecdsa.PublicKey, *rsa.PublicKey:
 		digest, err := hash(crypto.SHA256, challenge)

--- a/lib/devicetrust/challenge/challenge_test.go
+++ b/lib/devicetrust/challenge/challenge_test.go
@@ -19,6 +19,7 @@ package challenge_test
 import (
 	"testing"
 
+	"github.com/gravitational/trace"
 	"github.com/stretchr/testify/require"
 
 	"github.com/gravitational/teleport/lib/cryptosuites"
@@ -35,27 +36,36 @@ func TestSignAndVerify(t *testing.T) {
 			t.Parallel()
 
 			chal, err := challenge.New()
-			if err != nil {
-				t.Fatalf("New failed: %v", err)
-			}
+			require.NoError(t, err, "Creating new challenge")
 
 			signer, err := cryptosuites.GenerateKeyWithAlgorithm(algo)
 			require.NoError(t, err)
 			sig, err := challenge.Sign(chal, signer)
-			if err != nil {
-				t.Fatalf("Sign failed: %v", err)
-			}
+			require.NoError(t, err, "Signing failed")
 
-			// Verify correct challenge signature.
-			if err := challenge.Verify(chal, sig, signer.Public()); err != nil {
-				t.Errorf("Verify returned err=%v, want nil", err)
-			}
+			t.Run("verify valid signature", func(t *testing.T) {
+				require.NoError(t, challenge.Verify(chal, sig, signer.Public()))
+			})
 
-			// Verify bad challenge signature.
-			sig = []byte("invalid sig")
-			if err := challenge.Verify(chal, sig, signer.Public()); err == nil {
-				t.Error("Verify returned nil err, want non-nil")
-			}
+			t.Run("verifying an invalid signature is an error", func(t *testing.T) {
+				sig = []byte("invalid sig")
+				require.Error(t, challenge.Verify(chal, sig, signer.Public()))
+			})
+
+			t.Run("signing an empty challenge is an error", func(t *testing.T) {
+				_, err = challenge.Sign([]byte{}, signer)
+				require.ErrorAs(t, err, new(*trace.BadParameterError))
+			})
+
+			t.Run("verifying an empty challenge is an error", func(t *testing.T) {
+				err = challenge.Verify([]byte{}, sig, signer.Public())
+				require.ErrorAs(t, err, new(*trace.BadParameterError))
+			})
+
+			t.Run("verifying an empty signature is an error", func(t *testing.T) {
+				err = challenge.Verify(chal, []byte{}, signer.Public())
+				require.ErrorAs(t, err, new(*trace.BadParameterError))
+			})
 		})
 	}
 }


### PR DESCRIPTION
As an empty challenge is never legal, this patch tightens the `devicetrust`
signer and verifier to explicitly reject them.

Changelog: Tightened signature handling in Device Trust challenge/response validation.