### PR TITLE
Add secondary index for Kubernetes server lookup by cluster name

### DIFF
--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -8016,18 +8016,13 @@ func (a *Server) isMFARequired(ctx context.Context, scopedCtx *authz.ScopedConte
 		if t.KubernetesCluster == "" {
 			return nil, trace.BadParameter("missing KubernetesCluster field in a kubernetes-only UserCertsRequest")
 		}
-		// Find the target cluster and check whether MFA is required.
-		svcs, err := a.GetKubernetesServers(ctx)
-		if err != nil {
-			return nil, trace.Wrap(err)
-		}
 		var cluster types.KubeCluster
-		for _, svc := range svcs {
-			kubeCluster := svc.GetCluster()
-			if kubeCluster.GetName() == t.KubernetesCluster {
-				cluster = kubeCluster
-				break
+		for server, err := range a.RangeKubernetesServersWithName(ctx, t.KubernetesCluster) {
+			if err != nil {
+				return nil, trace.Wrap(err)
 			}
+			cluster = server.GetCluster()
+			break
 		}
 		if cluster == nil {
 			return nil, trace.NotFound("kubernetes cluster %q not found", t.KubernetesCluster)

--- a/lib/auth/authclient/api.go
+++ b/lib/auth/authclient/api.go
@@ -1295,6 +1295,9 @@ type Cache interface {
 	// GetKubernetesServers returns a list of kubernetes servers registered in the cluster
 	GetKubernetesServers(context.Context) ([]types.KubeServer, error)
 
+	// RangeKubernetesServersWithName returns an iterator over kubernetes servers for a given cluster name.
+	RangeKubernetesServersWithName(ctx context.Context, clusterName string) iter.Seq2[types.KubeServer, error]
+
 	// ListKubernetesWaitingContainers lists Kubernetes ephemeral
 	// containers that are waiting to be created until moderated
 	// session conditions are met.

--- a/lib/cache/kube.go
+++ b/lib/cache/kube.go
@@ -19,20 +19,38 @@ package cache
 import (
 	"context"
 	"iter"
+	"strings"
 
 	"github.com/gravitational/trace"
 	"google.golang.org/protobuf/proto"
+	"rsc.io/ordered"
 
+	clientproto "github.com/gravitational/teleport/api/client/proto"
+	"github.com/gravitational/teleport/api/defaults"
 	kubewaitingcontainerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/kubewaitingcontainer/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/utils/clientutils"
+	"github.com/gravitational/teleport/lib/backend"
 	"github.com/gravitational/teleport/lib/itertools/stream"
 	"github.com/gravitational/teleport/lib/services"
+	logutils "github.com/gravitational/teleport/lib/utils/log"
 )
 
 type kubeServerIndex string
 
 const kubeServerNameIndex kubeServerIndex = "name"
+const kubeServerClusterNameIndex kubeServerIndex = "cluster_name"
+
+func kubeServerByClusterNameKey(s types.KubeServer) string {
+	// Delete events deliver header only resources with a nil Cluster. This
+	// returns "" so the secondary index lookup is a no-op. The primary
+	// index deletion removes the entry from all indexes.
+	cluster := s.GetCluster()
+	if cluster == nil {
+		return ""
+	}
+	return string(ordered.Encode(cluster.GetName(), s.GetHostID(), s.GetName()))
+}
 
 func newKubernetesServerCollection(p services.Presence, w types.WatchKind) (*collection[types.KubeServer, kubeServerIndex], error) {
 	if p == nil {
@@ -47,6 +65,7 @@ func newKubernetesServerCollection(p services.Presence, w types.WatchKind) (*col
 				kubeServerNameIndex: func(u types.KubeServer) string {
 					return u.GetHostID() + "/" + u.GetName()
 				},
+				kubeServerClusterNameIndex: kubeServerByClusterNameKey,
 			}),
 		fetcher: func(ctx context.Context, loadSecrets bool) ([]types.KubeServer, error) {
 			return p.GetKubernetesServers(ctx)
@@ -89,6 +108,91 @@ func (c *Cache) GetKubernetesServers(ctx context.Context) ([]types.KubeServer, e
 	}
 
 	return out, nil
+}
+
+// RangeKubernetesServersWithName returns an iterator over kubernetes servers for a given cluster name.
+func (c *Cache) RangeKubernetesServersWithName(ctx context.Context, clusterName string) iter.Seq2[types.KubeServer, error] {
+	if clusterName == "" {
+		return stream.Fail[types.KubeServer](trace.BadParameter("missing kubernetes cluster name"))
+	}
+
+	return func(yield func(types.KubeServer, error) bool) {
+		ctx, span := c.Tracer.Start(ctx, "cache/RangeKubernetesServersWithName")
+		defer span.End()
+
+		upstreamListFn := func(ctx context.Context, pageSize int, startToken string) ([]types.KubeServer, string, error) {
+			var tokenClusterName string
+			rest, err := ordered.DecodePrefix([]byte(startToken), &tokenClusterName)
+			if err != nil {
+				return nil, "", trace.Wrap(err)
+			}
+
+			// Verify that the token's cluster name matches the requested cluster name.
+			// This ensures that if the token is malformed or belongs to a different
+			// cluster, we don't return incorrect results.
+			if tokenClusterName != clusterName {
+				return nil, "", trace.BadParameter("pagination token does not match the requested kubernetes cluster name")
+			}
+
+			backendKey := ""
+			if len(rest) > 0 {
+				var hostID, serverName string
+				if err := ordered.Decode(rest, &hostID, &serverName); err != nil {
+					return nil, "", trace.Wrap(err)
+				}
+				backendKey = hostID + "/" + serverName
+			}
+
+			resp, err := c.Config.Presence.ListResources(ctx, clientproto.ListResourcesRequest{
+				ResourceType: types.KindKubeServer,
+				Namespace:    defaults.Namespace,
+				Limit:        int32(pageSize),
+				StartKey:     backendKey,
+			})
+			if err != nil {
+				return nil, "", trace.Wrap(err)
+			}
+
+			var page []types.KubeServer
+			for _, r := range resp.Resources {
+				server, ok := r.(types.KubeServer)
+				if !ok {
+					c.Logger.WarnContext(ctx, "expected KubeServer but received unexpected type", "resource_type", logutils.TypeAttr(r))
+					continue
+				}
+				if cluster := server.GetCluster(); cluster != nil && cluster.GetName() == clusterName {
+					page = append(page, server)
+				}
+			}
+
+			next := ""
+			if resp.NextKey != "" {
+				hostID, serverName, ok := strings.Cut(resp.NextKey, backend.SeparatorString)
+				if !ok {
+					return nil, "", trace.BadParameter("invalid pagination token: %q", resp.NextKey)
+				}
+				next = string(ordered.Encode(clusterName, hostID, serverName))
+			}
+			return page, next, nil
+		}
+
+		lister := genericLister[types.KubeServer, kubeServerIndex]{
+			cache:           c,
+			collection:      c.collections.kubeServers,
+			index:           kubeServerClusterNameIndex,
+			nextToken:       kubeServerByClusterNameKey,
+			defaultPageSize: defaults.DefaultChunkSize,
+			upstreamList:    upstreamListFn,
+		}
+
+		start := string(ordered.Encode(clusterName))
+		end := string(ordered.Encode(clusterName, ordered.Inf))
+		for item, err := range lister.Range(ctx, start, end) {
+			if !yield(item, err) {
+				return
+			}
+		}
+	}
 }
 
 type kubeClusterIndex string

--- a/lib/cache/kube_test.go
+++ b/lib/cache/kube_test.go
@@ -27,6 +27,7 @@ import (
 	kubewaitingcontainerpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/kubewaitingcontainer/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/types/kubewaitingcontainer"
+	"github.com/gravitational/teleport/lib/services"
 )
 
 // TestKubernetes tests that CRUD operations on kubernetes clusters resources are
@@ -134,6 +135,40 @@ func TestKubernetesServers(t *testing.T) {
 		})
 	})
 
+}
+
+func mustCreateKubeServer(t testing.TB, hostID, clusterName string) types.KubeServer {
+	t.Helper()
+
+	cluster, err := types.NewKubernetesClusterV3(types.Metadata{
+		Name: clusterName,
+	}, types.KubernetesClusterSpecV3{})
+	require.NoError(t, err)
+
+	kubeServer, err := types.NewKubernetesServerV3FromCluster(cluster, "localhost", hostID)
+	require.NoError(t, err)
+	return kubeServer
+}
+
+var kubeServerRangeFuncs = rangeServersWithTargetNameFuncs[types.KubeServer]{
+	newResource: mustCreateKubeServer,
+	create: func(ctx context.Context, presence services.Presence, s types.KubeServer) error {
+		_, err := presence.UpsertKubernetesServer(ctx, s)
+		return err
+	},
+	delete: func(ctx context.Context, presence services.Presence, s types.KubeServer) error {
+		return presence.DeleteKubernetesServer(ctx, s.GetHostID(), s.GetName())
+	},
+	rangeByName: (*Cache).RangeKubernetesServersWithName,
+}
+
+func TestRangeKubernetesServersWithName(t *testing.T) {
+	t.Parallel()
+	testRangeServersWithTargetName(t, kubeServerRangeFuncs)
+}
+
+func BenchmarkRangeKubernetesServersWithName(b *testing.B) {
+	benchmarkRangeServersWithTargetName(b, kubeServerRangeFuncs)
 }
 
 func TestKubernetesWaitingContainers(t *testing.T) {

--- a/lib/services/local/presence.go
+++ b/lib/services/local/presence.go
@@ -1010,6 +1010,36 @@ func (s *PresenceService) GetKubernetesServers(ctx context.Context) ([]types.Kub
 	return servers, trace.Wrap(err)
 }
 
+// RangeKubernetesServersWithName returns an iterator over kubernetes servers for a given cluster name.
+func (s *PresenceService) RangeKubernetesServersWithName(ctx context.Context, clusterName string) iter.Seq2[types.KubeServer, error] {
+	if clusterName == "" {
+		return stream.Fail[types.KubeServer](trace.BadParameter("missing kubernetes cluster name"))
+	}
+
+	// TODO(wethreetrees): if Metadata.Name == Spec.Cluster.GetName() becomes a
+	// CheckAndSetDefaults invariant, this filter could check against the backend
+	// key's trailing component before unmarshalling. Currently no such invariant
+	// exists, so we unmarshal every item to read the embedded cluster name.
+	mapFn := func(item backend.Item) (types.KubeServer, bool) {
+		server, err := services.UnmarshalKubeServer(
+			item.Value,
+			services.WithExpires(item.Expires),
+			services.WithRevision(item.Revision),
+		)
+		if err != nil {
+			s.logger.WarnContext(ctx, "Failed to unmarshal kubernetes server", "key", item.Key, "error", err)
+			return nil, false
+		}
+		cluster := server.GetCluster()
+		return server, cluster != nil && cluster.GetName() == clusterName
+	}
+
+	startKey := backend.ExactKey(kubeServersPrefix)
+	endKey := backend.RangeEnd(startKey)
+
+	return stream.FilterMap(s.Backend.Items(ctx, backend.ItemsParams{StartKey: startKey, EndKey: endKey}), mapFn)
+}
+
 func (s *PresenceService) getKubernetesServers(ctx context.Context) ([]types.KubeServer, error) {
 	startKey := backend.ExactKey(kubeServersPrefix)
 	result, err := s.GetRange(ctx, startKey, backend.RangeEnd(startKey), backend.NoLimit)

--- a/lib/services/local/presence_test.go
+++ b/lib/services/local/presence_test.go
@@ -313,6 +313,75 @@ func TestRangeDatabaseServersWithName(t *testing.T) {
 	})
 }
 
+func mustCreateKubernetesServer(t *testing.T, clusterName string) types.KubeServer {
+	t.Helper()
+	cluster, err := types.NewKubernetesClusterV3(types.Metadata{
+		Name: clusterName,
+	}, types.KubernetesClusterSpecV3{})
+	require.NoError(t, err)
+
+	server, err := types.NewKubernetesServerV3FromCluster(cluster, "localhost", uuid.New().String())
+	require.NoError(t, err)
+	return server
+}
+
+func TestRangeKubernetesServersWithName(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+
+	bk, err := memory.New(memory.Config{})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = bk.Close() })
+
+	presence := NewPresenceService(bk)
+
+	t.Run("ParameterValidation", func(t *testing.T) {
+		_, err = iterstream.Collect(presence.RangeKubernetesServersWithName(ctx, ""))
+		require.ErrorAs(t, err, new(*trace.BadParameterError))
+	})
+
+	server1 := mustCreateKubernetesServer(t, "shared-cluster")
+	server2 := mustCreateKubernetesServer(t, "shared-cluster")
+	server3 := mustCreateKubernetesServer(t, "standalone-cluster")
+
+	for _, s := range []types.KubeServer{server1, server2, server3} {
+		_, err := presence.UpsertKubernetesServer(ctx, s)
+		require.NoError(t, err)
+	}
+
+	t.Run("MultipleServersSameCluster", func(t *testing.T) {
+		servers, err := iterstream.Collect(presence.RangeKubernetesServersWithName(ctx, "shared-cluster"))
+		require.NoError(t, err)
+		require.Len(t, servers, 2)
+		for _, s := range servers {
+			require.Equal(t, "shared-cluster", s.GetCluster().GetName())
+		}
+	})
+
+	t.Run("SingleServerForCluster", func(t *testing.T) {
+		servers, err := iterstream.Collect(presence.RangeKubernetesServersWithName(ctx, "standalone-cluster"))
+		require.NoError(t, err)
+		require.Len(t, servers, 1)
+		require.Equal(t, "standalone-cluster", servers[0].GetCluster().GetName())
+	})
+
+	t.Run("NoServersForCluster", func(t *testing.T) {
+		servers, err := iterstream.Collect(presence.RangeKubernetesServersWithName(ctx, "nonexistent-cluster"))
+		require.NoError(t, err)
+		require.Empty(t, servers)
+	})
+
+	t.Run("DeletedServersNotReturned", func(t *testing.T) {
+		err := presence.DeleteKubernetesServer(ctx, server1.GetHostID(), server1.GetName())
+		require.NoError(t, err)
+
+		servers, err := iterstream.Collect(presence.RangeKubernetesServersWithName(ctx, "shared-cluster"))
+		require.NoError(t, err)
+		require.Len(t, servers, 1)
+		require.Equal(t, server2.GetHostID(), servers[0].GetHostID())
+	})
+}
+
 func TestNodeCRUD(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()

--- a/lib/services/presence.go
+++ b/lib/services/presence.go
@@ -236,4 +236,7 @@ type PresenceInternal interface {
 
 	// RangeDatabaseServersWithName returns an iterator over database proxy servers for a given database name.
 	RangeDatabaseServersWithName(ctx context.Context, databaseName string) iter.Seq2[types.DatabaseServer, error]
+
+	// RangeKubernetesServersWithName returns an iterator over kubernetes servers for a given cluster name.
+	RangeKubernetesServersWithName(ctx context.Context, clusterName string) iter.Seq2[types.KubeServer, error]
 }


### PR DESCRIPTION
Continuation of `IsMFARequired` enhancements (re: https://github.com/gravitational/teleport/pull/66484)

Adds a new function, RangeKubernetesServersWithName, to the cache and presence APIs that returns an iterator over Kubernetes servers matching a given cluster name.

Replaces the full scan in IsMFARequiredRequest_KubernetesCluster, which fetched all Kubernetes servers and filtered in-memory, with a range scan over a secondary index keyed by cluster name.

Changelog: Improved performance and reduced resource usage of the auth service for clusters with large numbers of registered Kubernetes clusters with per-session MFA enabled.

## Manual Test Plan
### Test Environment

Teleport Cloud tenant with at least one enrolled Kubernetes cluster and a role that requires per-session MFA for Kubernetes cluster access.

### Test Cases
- [x] Connect to a Kubernetes cluster where the role requires per-session MFA and confirm MFA prompt appears and connection succeeds after verification
- [x] Connect to a Kubernetes cluster where no per-session MFA is required and confirm connection succeeds without an MFA prompt
- [x] Unregister a previously registered Kubernetes cluster, attempt to connect, and confirm a not found error is returned
