### PR TITLE
[v18] discovery: Fix watcher deadlock on group reassign

### DIFF
--- a/lib/srv/discovery/discovery.go
+++ b/lib/srv/discovery/discovery.go
@@ -2021,11 +2021,12 @@ func (s *Server) startDynamicWatcherUpdater(ctx context.Context, dynamicMatcherW
 
 				if dc.GetDiscoveryGroup() != s.DiscoveryGroup {
 					name := dc.GetName()
-					// If the DiscoveryConfig was never part part of this discovery service because the
+					// If the DiscoveryConfig was never part of this discovery service because the
 					// discovery group never matched, then it must be ignored.
 					s.dynamicDiscoveryConfigMu.RLock()
-					if _, ok := s.dynamicDiscoveryConfig[name]; !ok {
-						s.dynamicDiscoveryConfigMu.RUnlock()
+					_, ok := s.dynamicDiscoveryConfig[name]
+					s.dynamicDiscoveryConfigMu.RUnlock()
+					if !ok {
 						continue
 					}
 					// Let's assume there's a DiscoveryConfig DC1 has DiscoveryGroup DG1, which this process is monitoring.

--- a/lib/srv/discovery/discovery_test.go
+++ b/lib/srv/discovery/discovery_test.go
@@ -1151,6 +1151,72 @@ func TestDiscoveryServer_dynamicMatcherRestart(t *testing.T) {
 	})
 }
 
+// TestDiscoveryServer_dynamicMatcherGroupReassign covers the OpPut branch
+// where a tracked DiscoveryConfig is reassigned to a non-matching group.
+func TestDiscoveryServer_dynamicMatcherGroupReassign(t *testing.T) {
+	const localGroup = "dg-local"
+	const otherGroup = "dg-other"
+
+	synctest.Test(t, func(t *testing.T) {
+		backend, err := memory.New(memory.Config{})
+		require.NoError(t, err)
+
+		mockAuthServer := &mockAuthServer{events: local.NewEventsService(backend)}
+		mockAccessPoint := &fakeAccessPointWithWatcher{mockAuthServer: mockAuthServer}
+
+		server, err := New(t.Context(), &Config{
+			ClusterFeatures: func() proto.Features { return proto.Features{} },
+			AccessPoint:     mockAccessPoint,
+			Matchers:        Matchers{},
+			Emitter:         &mockEmitter{},
+			Log:             logtest.NewLogger(),
+			DiscoveryGroup:  localGroup,
+		})
+		require.NoError(t, err)
+		err = server.Start()
+		require.NoError(t, err)
+		t.Cleanup(server.Stop)
+
+		synctest.Wait()
+
+		dc, err := discoveryconfig.NewDiscoveryConfig(
+			header.Metadata{Name: "dc-reassign"},
+			discoveryconfig.Spec{DiscoveryGroup: localGroup},
+		)
+		require.NoError(t, err)
+		go mockAccessPoint.createDiscoveryConfig(dc)
+		synctest.Wait()
+
+		server.dynamicDiscoveryConfigMu.RLock()
+		require.Len(t, server.dynamicDiscoveryConfig, 1)
+		server.dynamicDiscoveryConfigMu.RUnlock()
+
+		reassigned, err := discoveryconfig.NewDiscoveryConfig(
+			header.Metadata{Name: "dc-reassign"},
+			discoveryconfig.Spec{DiscoveryGroup: otherGroup},
+		)
+		require.NoError(t, err)
+		go mockAccessPoint.createDiscoveryConfig(reassigned)
+		synctest.Wait()
+
+		server.dynamicDiscoveryConfigMu.RLock()
+		require.Empty(t, server.dynamicDiscoveryConfig)
+		server.dynamicDiscoveryConfigMu.RUnlock()
+
+		next, err := discoveryconfig.NewDiscoveryConfig(
+			header.Metadata{Name: "dc-next"},
+			discoveryconfig.Spec{DiscoveryGroup: localGroup},
+		)
+		require.NoError(t, err)
+		go mockAccessPoint.createDiscoveryConfig(next)
+		synctest.Wait()
+
+		server.dynamicDiscoveryConfigMu.RLock()
+		require.Contains(t, server.dynamicDiscoveryConfig, "dc-next")
+		server.dynamicDiscoveryConfigMu.RUnlock()
+	})
+}
+
 func TestDiscoveryServerConcurrency(t *testing.T) {
 	t.Parallel()
 	logger := logtest.NewLogger()


### PR DESCRIPTION
Fix a self-deadlock in `(*Server).startDynamicWatcherUpdater`. When the watcher receives an `OpPut` event for an already-tracked `DiscoveryConfig` whose `DiscoveryGroup` no longer matches the local server, the handler acquires `dynamicDiscoveryConfigMu.RLock()` for the existence check, never releases it on the fall-through path, then calls `dynamicDiscoveryConfigMu.Lock()`. Go's `sync.RWMutex` does not allow a same-goroutine upgrade from read to write, so `Lock()` blocks indefinitely. The dynamic-config watcher goroutine wedges and no further `DiscoveryConfig` events are processed until the process is restarted.

Mirror the sibling `OpDelete` handler: take `RLock`, read, `RUnlock`, then branch on the membership flag, then acquire the write lock.

Add `TestDiscoveryServer_dynamicMatcherGroupReassign`, which drives an `OpPut` for an already-tracked config with a non-matching group, then sends an unrelated event and asserts forward progress. Without the fix, the test times out at 30s with the watcher goroutine blocked on `Lock()`.

Backport: https://github.com/gravitational/teleport/pull/67098

## Manual Test Plan

### Test Environment

Local Teleport cluster, single auth + proxy + discovery process. `teleport.yaml` enables the discovery service with `discovery_group: dg-local`; no real cloud credentials are needed since the test exercises only the in-memory dynamic-config watcher.

### Test Cases

#### Test 1: Fix verification (with this branch)

Start Teleport from this branch. Create a `DiscoveryConfig` with `discovery_group: dg-local`. Update it to `discovery_group: dg-other`, then create a second unrelated `DiscoveryConfig` with `discovery_group: dg-local`.

```yaml
kind: discovery_config
version: v1
metadata:
  name: dc-reassign
spec:
  discovery_group: dg-local   # later updated to dg-other
  aws:
    - types: ["ec2"]
      regions: ["us-east-1"]
      tags:
        env: "prod"
      ssm:
        document_name: "AWS-RunShellScript"
```

- [x] The reassign returns without error and the discovery service continues running (no log warnings).
- [x] The second `DiscoveryConfig` is processed (debug log mentions the new name in `Fetching instances`).
- [x] Goroutine profile shows the watcher parked on its events channel; no `sync.(*RWMutex).Lock` frame on `dynamicDiscoveryConfigMu`.

#### Test 2: Regression baseline (without the fix)

Build from `origin/master`, then repeat Test 1's sequence.

- [x] The reassign event wedges the dynamic-config watcher goroutine.
- [x] The second `DiscoveryConfig` is upserted in the backend (audit event fires) but the discovery service does not process it (no `Fetching instances` log).
- [x] Goroutine profile shows `(*Server).startDynamicWatcherUpdater` blocked at `sync.(*RWMutex).Lock` via `sync.runtime_SemacquireRWMutex`, confirming the same-goroutine RLock to Lock upgrade is the deadlock point.
