### PR TITLE
Enforce maximum message size when decoding fastpath PDUs

### DIFF
--- a/lib/srv/desktop/tdp/protocol/legacy/proto.go
+++ b/lib/srv/desktop/tdp/protocol/legacy/proto.go
@@ -45,6 +45,9 @@ import (
 // ProtocolName is the identifier for the TDP protocol.
 const ProtocolName = "teleport-tdp"
 
+// Re-use the same maximum message length as TDPB for consistency.
+const MaxMessageLength = 2 ^ 24 - 1
+
 // MessageType identifies the type of the message.
 type MessageType byte
 
@@ -331,6 +334,10 @@ func decodeRDPFastPathPDU(in tdp.ByteReader) (RDPFastPathPDU, error) {
 		return RDPFastPathPDU(nil), trace.Wrap(err)
 	}
 
+	if dataLength > MaxMessageLength {
+		return RDPFastPathPDU{}, trace.LimitExceeded("TDP message exceeds maximum length")
+	}
+
 	// Allocate buffer that will fit the data
 	// TODO(isaiah): improve performance by changing
 	// this api to allow buffer re-use.
@@ -369,6 +376,10 @@ func decodeRDPResponsePDU(in tdp.ByteReader) (RDPResponsePDU, error) {
 	var resFrameLength uint32
 	if err := binary.Read(in, binary.BigEndian, &resFrameLength); err != nil {
 		return RDPResponsePDU{}, trace.Wrap(err)
+	}
+
+	if resFrameLength > MaxMessageLength {
+		return RDPResponsePDU{}, trace.LimitExceeded("TDP message exceeds maximum length")
 	}
 
 	resFrame := make([]byte, resFrameLength)


### PR DESCRIPTION
Prevent the TDP implementation from allocating unbounded chunks of memory during message decoding.

<!-- Provide a descriptive entry for the changelog of the next release. -->

Changelog:


<!-- Include manual testing efforts to verify the change. -->
<!-- Detail where the tests where run and what configurations were used. -->
<!-- Include all the test cases which were run to validate the change. -->

## Manual Test Plan
### Test Environment

### Test Cases
- [ ] 
