### PR TITLE
docs: Fix beams role example

### DIFF
--- a/docs/pages/beams/beams.mdx
+++ b/docs/pages/beams/beams.mdx
@@ -235,7 +235,7 @@ application instead of a web application, add the `--tcp` flag.
 Beams are single-user by design. Only the user who created a beam can access it.
 
 Access control is enforced using owner labels on the beam's node and application
-resources (`teleport.internal/beam/owner: <username>`) and a `beam-user` role
+resources (`teleport.internal/beams/owner: <username>`) and a `beam-user` role
 that restricts access to matching resources:
 
 ```yaml
@@ -248,15 +248,15 @@ spec:
     logins:
       - beams
     node_labels:
-      teleport.internal/beam/owner: '{{internal.username}}'
+      teleport.internal/beams/owner: '{{internal.username}}'
     app_labels_expression: |
       labels["teleport.internal/beams/app-type"] == "llm" ||
-      contains(user.spec.traits.username, labels["teleport.internal/beam/owner"])
+      contains(user.spec.traits.username, labels["teleport.internal/beams/owner"])
     rules:
       - resources: [beam]
         verbs: ["*"]
     beam_labels:
-      teleport.internal/beam/owner: '{{internal.username}}'
+      teleport.internal/beams/owner: '{{internal.username}}'
 ```
 
 This role is automatically assigned to users on Beams-enabled clusters.


### PR DESCRIPTION
Matching the beams role that is provided in a beams instance.

```yaml
kind: role
metadata:
  name: beam-user
spec:
  allow:
    app_labels_expression: |
      labels["teleport.internal/beams/app-type"] == "llm" ||
      contains(user.metadata.name, labels["teleport.internal/beams/owner"])
    beam_labels:
      teleport.internal/beams/owner: '{{user.metadata.name}}'
    logins:
    - beams
    node_labels:
      teleport.internal/beams/owner: '{{user.metadata.name}}'
    rules:
    - resources:
      - beam
      verbs:
      - '*'
```
