### PR TITLE
Replace `asciitable.AsBuffer()` with `WriteTo`/`String` methods

### DIFF
--- a/lib/asciitable/example_test.go
+++ b/lib/asciitable/example_test.go
@@ -19,7 +19,7 @@
 package asciitable
 
 import (
-	"fmt"
+	"os"
 )
 
 func ExampleMakeTable() {
@@ -32,7 +32,7 @@ func ExampleMakeTable() {
 	t.AddRow([]string{"9333929146c08928a36466aea12df963", "trusted_cluster", "30 Aug 18 23:33 UTC"})
 
 	// Write the table to stdout.
-	fmt.Println(t.AsBuffer().String())
+	t.WriteTo(os.Stdout)
 }
 
 func ExampleMakeColumnsAndRows() {
@@ -57,5 +57,5 @@ func ExampleMakeColumnsAndRows() {
 	table := MakeTable(cols, data...)
 
 	// Write the table to stdout.
-	fmt.Println(table.AsBuffer().String())
+	table.WriteTo(os.Stdout)
 }

--- a/lib/asciitable/table.go
+++ b/lib/asciitable/table.go
@@ -21,7 +21,6 @@
 package asciitable
 
 import (
-	"bytes"
 	"fmt"
 	"io"
 	"os"
@@ -157,17 +156,6 @@ func (t *Table) truncateCell(colIndex int, cell string) (string, bool) {
 		return truncatedCell, false
 	}
 	return fmt.Sprintf("%v %v", truncatedCell, footnoteLabel), true
-}
-
-// AsBuffer returns a *bytes.Buffer with the printed output of the table.
-//
-// TODO(nklaassen): delete this, all calls either immediately copy the buffer to
-// another writer or just call .String() once.
-func (t *Table) AsBuffer() *bytes.Buffer {
-	var buffer bytes.Buffer
-	// Writes to bytes.Buffer never return an error.
-	_ = t.WriteTo(&buffer)
-	return &buffer
 }
 
 func (t *Table) String() string {

--- a/lib/asciitable/table.go
+++ b/lib/asciitable/table.go
@@ -158,6 +158,8 @@ func (t *Table) truncateCell(colIndex int, cell string) (string, bool) {
 	return fmt.Sprintf("%v %v", truncatedCell, footnoteLabel), true
 }
 
+// WriteTo returns the table as a string. Prefer using [WriteTo] when
+// printing tables to [io.Writer]s like os.Stdout or os.Stderr
 func (t *Table) String() string {
 	var sb strings.Builder
 	// Writes to strings.Builder never return an error.

--- a/lib/asciitable/table.go
+++ b/lib/asciitable/table.go
@@ -158,7 +158,7 @@ func (t *Table) truncateCell(colIndex int, cell string) (string, bool) {
 	return fmt.Sprintf("%v %v", truncatedCell, footnoteLabel), true
 }
 
-// WriteTo returns the table as a string. Prefer using [WriteTo] when
+// String returns the table as a string. Prefer using [WriteTo] when
 // printing tables to [io.Writer]s like os.Stdout or os.Stderr
 func (t *Table) String() string {
 	var sb strings.Builder

--- a/lib/asciitable/table_test.go
+++ b/lib/asciitable/table_test.go
@@ -49,7 +49,7 @@ func TestFullTable(t *testing.T) {
 	table.AddRow([]string{"Joe Forrester", "Trains are much better than cars", "40"})
 	table.AddRow([]string{"Jesus", "Read the bible", "2018"})
 
-	require.Equal(t, fullTable, table.AsBuffer().String())
+	require.Equal(t, fullTable, table.String())
 }
 
 func TestHeadlessTable(t *testing.T) {
@@ -58,7 +58,7 @@ func TestHeadlessTable(t *testing.T) {
 	table.AddRow([]string{"1", "2", "3"})
 
 	// The table shall have no header and also the 3rd column must be chopped off.
-	require.Equal(t, headlessTable, table.AsBuffer().String())
+	require.Equal(t, headlessTable, table.String())
 }
 
 func TestTruncatedTable(t *testing.T) {
@@ -80,7 +80,7 @@ func TestTruncatedTable(t *testing.T) {
 	table.AddRow([]string{"Jesus", "Read the bible", "for ever and ever"})
 	table.AddRow([]string{"X", strings.Repeat("y", 26), ""})
 
-	require.Equal(t, truncatedTable, table.AsBuffer().String())
+	require.Equal(t, truncatedTable, table.String())
 }
 
 func TestMakeTableWithTruncatedColumn(t *testing.T) {
@@ -127,7 +127,7 @@ func TestMakeTableWithTruncatedColumn(t *testing.T) {
 	for _, testCase := range testCases {
 		t.Run(testCase.truncatedColumn, func(t *testing.T) {
 			table := MakeTableWithTruncatedColumn(columns, rows, testCase.truncatedColumn)
-			rows := strings.Split(table.AsBuffer().String(), "\n")
+			rows := strings.Split(table.String(), "\n")
 			require.Len(t, rows, 4)
 			require.Len(t, rows[2], testCase.expectedWidth)
 			require.Equal(t, testCase.expectedOutput, rows)

--- a/lib/client/db/postgres/repl/commands.go
+++ b/lib/client/db/postgres/repl/commands.go
@@ -107,7 +107,7 @@ func initCommands() map[string]*command {
 				var res strings.Builder
 				for i, cmdType := range slices.Sorted(maps.Keys(typesTable)) {
 					res.WriteString(string(cmdType) + lineBreak)
-					typesTable[cmdType].AsBuffer().WriteTo(&res)
+					typesTable[cmdType].WriteTo(&res)
 					if i < len(typesTable)-1 {
 						res.WriteString(lineBreak)
 					}

--- a/tool/common/common.go
+++ b/tool/common/common.go
@@ -101,7 +101,7 @@ func (e *SessionsCollection) WriteText(w io.Writer) error {
 
 		t.AddRow([]string{id, typ, participants, target, timestamp})
 	}
-	_, err := t.AsBuffer().WriteTo(w)
+	err := t.WriteTo(w)
 	return trace.Wrap(err)
 }
 

--- a/tool/common/common.go
+++ b/tool/common/common.go
@@ -101,8 +101,7 @@ func (e *SessionsCollection) WriteText(w io.Writer) error {
 
 		t.AddRow([]string{id, typ, participants, target, timestamp})
 	}
-	err := t.WriteTo(w)
-	return trace.Wrap(err)
+	return trace.Wrap(t.WriteTo(w))
 }
 
 // WriteJSON writes the session collection as JSON to the provided io.Writer.

--- a/tool/common/touchid/touchid.go
+++ b/tool/common/touchid/touchid.go
@@ -22,6 +22,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 	"sort"
 	"strings"
 	"time"
@@ -150,7 +151,9 @@ func (c *LsCommand) Run() error {
 			info.CredentialID,
 		})
 	}
-	fmt.Println(t.AsBuffer().String())
+	if err := t.WriteTo(os.Stdout); err != nil {
+		return trace.Wrap(err)
+	}
 
 	return nil
 }

--- a/tool/common/touchid/touchid.go
+++ b/tool/common/touchid/touchid.go
@@ -154,6 +154,7 @@ func (c *LsCommand) Run() error {
 	if err := t.WriteTo(os.Stdout); err != nil {
 		return trace.Wrap(err)
 	}
+	fmt.Fprintln(os.Stdout)
 
 	return nil
 }

--- a/tool/tctl/common/access_request_command.go
+++ b/tool/tctl/common/access_request_command.go
@@ -414,8 +414,7 @@ func (c *AccessRequestCommand) Caps(ctx context.Context, client *authclient.Clie
 		}
 		table.AddRow([]string{"Suggested Reviewers:", sr})
 
-		err := table.WriteTo(os.Stdout)
-		return trace.Wrap(err)
+		return trace.Wrap(table.WriteTo(os.Stdout))
 	case teleport.JSON:
 		return printJSON(caps, "capabilities")
 	default:
@@ -507,8 +506,7 @@ func printRequestsOverview(reqs []types.AccessRequest, format string) error {
 				quoteOrDefault(req.GetResolveReason(), ""),
 			})
 		}
-		err := table.WriteTo(os.Stdout)
-		return trace.Wrap(err)
+		return trace.Wrap(table.WriteTo(os.Stdout))
 	case teleport.JSON:
 		return printJSON(reqs, "requests")
 	default:

--- a/tool/tctl/common/access_request_command.go
+++ b/tool/tctl/common/access_request_command.go
@@ -414,7 +414,7 @@ func (c *AccessRequestCommand) Caps(ctx context.Context, client *authclient.Clie
 		}
 		table.AddRow([]string{"Suggested Reviewers:", sr})
 
-		_, err := table.AsBuffer().WriteTo(os.Stdout)
+		err := table.WriteTo(os.Stdout)
 		return trace.Wrap(err)
 	case teleport.JSON:
 		return printJSON(caps, "capabilities")
@@ -507,7 +507,7 @@ func printRequestsOverview(reqs []types.AccessRequest, format string) error {
 				quoteOrDefault(req.GetResolveReason(), ""),
 			})
 		}
-		_, err := table.AsBuffer().WriteTo(os.Stdout)
+		err := table.WriteTo(os.Stdout)
 		return trace.Wrap(err)
 	case teleport.JSON:
 		return printJSON(reqs, "requests")
@@ -538,7 +538,7 @@ func printRequestsDetailed(reqs []types.AccessRequest, format string) error {
 			table.AddRow([]string{"Request Reason: ", quoteOrDefault(req.GetRequestReason(), "[none]")})
 			table.AddRow([]string{"Resolve Reason: ", quoteOrDefault(req.GetResolveReason(), "[none]")})
 
-			_, err = table.AsBuffer().WriteTo(os.Stdout)
+			err = table.WriteTo(os.Stdout)
 			if err != nil {
 				return trace.Wrap(err)
 			}

--- a/tool/tctl/common/accessmonitoring/command.go
+++ b/tool/tctl/common/accessmonitoring/command.go
@@ -193,7 +193,7 @@ func (c *cmdHandler) onAuditQuerySchema(ctx context.Context, authClient *authcli
 		for _, v := range view.Columns {
 			table.AddRow([]string{v.Name, v.Type, v.Desc})
 		}
-		_, err = table.AsBuffer().WriteTo(os.Stdout)
+		err = table.WriteTo(os.Stdout)
 		if err != nil {
 			return trace.Wrap(err)
 		}

--- a/tool/tctl/common/acl_command.go
+++ b/tool/tctl/common/acl_command.go
@@ -347,8 +347,11 @@ func (c *ACLCommand) displayAccessListMembersText(ctx context.Context, client *a
 		})
 	}
 
-	err := table.WriteTo(c.Stdout)
-	return trace.Wrap(err)
+	if err := table.WriteTo(c.Stdout); err != nil {
+		return trace.Wrap(err)
+	}
+	fmt.Fprintln(c.Stdout)
+	return nil
 }
 
 func formatAccessListMember(ctx context.Context, client *authclient.Client, member *accesslist.AccessListMember) (string, error) {
@@ -457,8 +460,11 @@ func (c *ACLCommand) displayAccessListReviewsText(reviews []*accesslist.Review) 
 			review.Spec.Notes,
 		})
 	}
-	err := table.WriteTo(c.Stdout)
-	return trace.Wrap(err)
+	if err := table.WriteTo(c.Stdout); err != nil {
+		return trace.Wrap(err)
+	}
+	fmt.Fprintln(c.Stdout)
+	return nil
 }
 
 func (c *ACLCommand) displayAccessLists(accessLists ...*accesslist.AccessList) error {
@@ -493,8 +499,11 @@ func (c *ACLCommand) displayAccessListsText(accessLists ...*accesslist.AccessLis
 			grantedTraits,
 		})
 	}
-	err := table.WriteTo(c.Stdout)
-	return trace.Wrap(err)
+	if err := table.WriteTo(c.Stdout); err != nil {
+		return trace.Wrap(err)
+	}
+	fmt.Fprintln(c.Stdout)
+	return nil
 }
 
 type accessList struct {

--- a/tool/tctl/common/acl_command.go
+++ b/tool/tctl/common/acl_command.go
@@ -347,7 +347,7 @@ func (c *ACLCommand) displayAccessListMembersText(ctx context.Context, client *a
 		})
 	}
 
-	_, err := fmt.Fprintln(c.Stdout, table.AsBuffer().String())
+	err := table.WriteTo(c.Stdout)
 	return trace.Wrap(err)
 }
 
@@ -457,7 +457,7 @@ func (c *ACLCommand) displayAccessListReviewsText(reviews []*accesslist.Review) 
 			review.Spec.Notes,
 		})
 	}
-	_, err := fmt.Fprintln(c.Stdout, table.AsBuffer().String())
+	err := table.WriteTo(c.Stdout)
 	return trace.Wrap(err)
 }
 
@@ -493,7 +493,7 @@ func (c *ACLCommand) displayAccessListsText(accessLists ...*accesslist.AccessLis
 			grantedTraits,
 		})
 	}
-	_, err := fmt.Fprintln(c.Stdout, table.AsBuffer().String())
+	err := table.WriteTo(c.Stdout)
 	return trace.Wrap(err)
 }
 

--- a/tool/tctl/common/alert_command.go
+++ b/tool/tctl/common/alert_command.go
@@ -151,7 +151,7 @@ func (c *AlertCommand) ListAck(ctx context.Context, client *authclient.Client) e
 			table.AddRow([]string{ack.AlertID, fmt.Sprintf("%q", ack.Reason), expires})
 		}
 
-		fmt.Fprintln(c.stdout, table.AsBuffer().String())
+		table.WriteTo(c.stdout)
 	case teleport.JSON:
 		return trace.Wrap(utils.WriteJSONArray(c.stdout, acks), "failed to marshal alert acks")
 	case teleport.YAML:
@@ -270,7 +270,7 @@ func (c *AlertCommand) displayAlertsText(alerts []types.ClusterAlert, verbose bo
 				strings.Join(labelPairs, ", "),
 			})
 		}
-		fmt.Fprintln(c.stdout, table.AsBuffer().String())
+		table.WriteTo(c.stdout)
 	} else {
 		table := asciitable.MakeTable([]string{"ID", "Severity", "Expires In", "Message"})
 		for _, alert := range alerts {
@@ -281,7 +281,7 @@ func (c *AlertCommand) displayAlertsText(alerts []types.ClusterAlert, verbose bo
 				fmt.Sprintf("%q", alert.Spec.Message),
 			})
 		}
-		fmt.Fprintln(c.stdout, table.AsBuffer().String())
+		table.WriteTo(c.stdout)
 	}
 }
 

--- a/tool/tctl/common/alert_command.go
+++ b/tool/tctl/common/alert_command.go
@@ -152,6 +152,7 @@ func (c *AlertCommand) ListAck(ctx context.Context, client *authclient.Client) e
 		}
 
 		table.WriteTo(c.stdout)
+		fmt.Fprintln(c.stdout)
 	case teleport.JSON:
 		return trace.Wrap(utils.WriteJSONArray(c.stdout, acks), "failed to marshal alert acks")
 	case teleport.YAML:
@@ -271,6 +272,7 @@ func (c *AlertCommand) displayAlertsText(alerts []types.ClusterAlert, verbose bo
 			})
 		}
 		table.WriteTo(c.stdout)
+		fmt.Fprintln(c.stdout)
 	} else {
 		table := asciitable.MakeTable([]string{"ID", "Severity", "Expires In", "Message"})
 		for _, alert := range alerts {
@@ -282,6 +284,7 @@ func (c *AlertCommand) displayAlertsText(alerts []types.ClusterAlert, verbose bo
 			})
 		}
 		table.WriteTo(c.stdout)
+		fmt.Fprintln(c.stdout)
 	}
 }
 

--- a/tool/tctl/common/autoupdate_command.go
+++ b/tool/tctl/common/autoupdate_command.go
@@ -322,7 +322,7 @@ func (c *AutoUpdateCommand) agentsReportCommand(ctx context.Context, client auto
 			t.AddRow(row)
 		}
 
-		_, err = t.AsBuffer().WriteTo(c.stdout)
+		err = t.WriteTo(c.stdout)
 	}
 
 	fmt.Fprint(c.stdout, c.omittedSummary(validReports))
@@ -416,7 +416,7 @@ func rolloutGroupTable(rollout *autoupdatev1pb.AutoUpdateAgentRollout, writer io
 				strconv.FormatUint(groupUpToDate, 10),
 			})
 		}
-		writer.Write(table.AsBuffer().Bytes())
+		table.WriteTo(writer)
 
 	case len(groups) != 0:
 		headers := []string{"Group Name", "State", "Start Time", "State Reason"}
@@ -429,7 +429,7 @@ func rolloutGroupTable(rollout *autoupdatev1pb.AutoUpdateAgentRollout, writer io
 				formatTimeIfNotEmpty(group.GetStartTime().AsTime(), time.DateTime),
 				group.GetLastUpdateReason()})
 		}
-		writer.Write(table.AsBuffer().Bytes())
+		table.WriteTo(writer)
 	default:
 	}
 }

--- a/tool/tctl/common/bots_command.go
+++ b/tool/tctl/common/bots_command.go
@@ -287,6 +287,7 @@ func (c *BotsCommand) ListBots(ctx context.Context, client botsCommandClient) er
 			})
 		}
 		t.WriteTo(c.stdout)
+		fmt.Fprintln(c.stdout)
 
 		executableFileName := filepath.Base(os.Args[0])
 		fmt.Fprintf(c.stdout, "\nTo view active instances of a bot, run:\n\n> %s bots instances list [name]\n", executableFileName)
@@ -858,6 +859,7 @@ func (c *BotsCommand) ListBotInstances(ctx context.Context, client botsCommandCl
 		})
 	}
 	t.WriteTo(c.stdout)
+	fmt.Fprintln(c.stdout)
 
 	executableFileName := filepath.Base(os.Args[0])
 	fmt.Fprintf(c.stdout, "\nTo view more information on a particular instance, run:\n\n> %s bots instances show [id]\n", executableFileName)

--- a/tool/tctl/common/bots_command.go
+++ b/tool/tctl/common/bots_command.go
@@ -286,7 +286,7 @@ func (c *BotsCommand) ListBots(ctx context.Context, client botsCommandClient) er
 				u.Metadata.Name, u.Status.UserName, strings.Join(u.Spec.GetRoles(), ","),
 			})
 		}
-		fmt.Fprintln(c.stdout, t.AsBuffer().String())
+		t.WriteTo(c.stdout)
 
 		executableFileName := filepath.Base(os.Args[0])
 		fmt.Fprintf(c.stdout, "\nTo view active instances of a bot, run:\n\n> %s bots instances list [name]\n", executableFileName)
@@ -857,7 +857,7 @@ func (c *BotsCommand) ListBotInstances(ctx context.Context, client botsCommandCl
 			version, hostname, healthStatus, lastSeen.Format(time.RFC3339),
 		})
 	}
-	fmt.Fprintln(c.stdout, t.AsBuffer().String())
+	t.WriteTo(c.stdout)
 
 	executableFileName := filepath.Base(os.Args[0])
 	fmt.Fprintf(c.stdout, "\nTo view more information on a particular instance, run:\n\n> %s bots instances show [id]\n", executableFileName)
@@ -1137,7 +1137,7 @@ func (c *BotsCommand) outputToken(
 	templateData := map[string]any{
 		"join_method": joinMethod,
 		"join_uri":    uri.String(),
-		"param_table": indentString(paramTable.AsBuffer().String(), "  "),
+		"param_table": indentString(paramTable.String(), "  "),
 	}
 	if !token.Expiry().IsZero() {
 		templateData["minutes"] = int(time.Until(token.Expiry()).Minutes())
@@ -1204,7 +1204,7 @@ func formatBotInstanceAuthentication(record *machineidv1pb.BotInstanceStatusAuth
 	table.AddRow([]string{"Generation:", fmt.Sprint(record.Generation)})
 	table.AddRow([]string{"Public Key:", fmt.Sprintf("<%d bytes>", len(record.PublicKey))})
 
-	return "\n" + indentString(table.AsBuffer().String(), "  ")
+	return "\n" + indentString(table.String(), "  ")
 }
 
 // formatBotInstanceHeartbeat returns a multiline, indented string containing
@@ -1221,7 +1221,7 @@ func formatBotInstanceHeartbeat(record *machineidv1pb.BotInstanceStatusHeartbeat
 	table.AddRow([]string{"Architecture:", record.Architecture})
 	table.AddRow([]string{"OS:", record.Os})
 
-	return "\n" + indentString(table.AsBuffer().String(), "  ")
+	return "\n" + indentString(table.String(), "  ")
 }
 
 // formatServices returns a string containing a tabular representation of a

--- a/tool/tctl/common/collection.go
+++ b/tool/tctl/common/collection.go
@@ -63,7 +63,7 @@ func (r *reverseTunnelCollection) WriteText(w io.Writer, verbose bool) error {
 			tunnel.GetClusterName(), strings.Join(tunnel.GetDialAddrs(), ","),
 		})
 	}
-	_, err := t.AsBuffer().WriteTo(w)
+	err := t.WriteTo(w)
 	return trace.Wrap(err)
 }
 
@@ -92,7 +92,7 @@ func (c *trustedClusterCollection) WriteText(w io.Writer, verbose bool) error {
 			fmt.Sprintf("%v", tc.CombinedMapping()),
 		})
 	}
-	_, err := t.AsBuffer().WriteTo(w)
+	err := t.WriteTo(w)
 	return trace.Wrap(err)
 }
 
@@ -113,7 +113,7 @@ func (c *remoteClusterCollection) WriteText(w io.Writer, verbose bool) error {
 		lastHeartbeat := cluster.GetLastHeartbeat()
 		t.AddRow([]string{cluster.GetName(), cluster.GetConnectionStatus(), formatLastHeartbeat(lastHeartbeat)})
 	}
-	_, err := t.AsBuffer().WriteTo(w)
+	err := t.WriteTo(w)
 	return trace.Wrap(err)
 }
 
@@ -152,7 +152,7 @@ func (c *semaphoreCollection) WriteText(w io.Writer, verbose bool) error {
 			})
 		}
 	}
-	_, err := t.AsBuffer().WriteTo(w)
+	err := t.WriteTo(w)
 	return trace.Wrap(err)
 }
 
@@ -226,7 +226,7 @@ func (c *databaseServerCollection) WriteText(w io.Writer, verbose bool) error {
 	}
 	// stable sort by hostname then by name.
 	t.SortRowsBy([]int{0, 1}, true)
-	_, err := t.AsBuffer().WriteTo(w)
+	err := t.WriteTo(w)
 	return trace.Wrap(err)
 }
 
@@ -267,7 +267,7 @@ func (c *crownJewelCollection) WriteText(w io.Writer, verbose bool) error {
 	}
 	// stable sort by name.
 	t.SortRowsBy([]int{0}, true)
-	_, err := t.AsBuffer().WriteTo(w)
+	err := t.WriteTo(w)
 	return trace.Wrap(err)
 }
 
@@ -298,7 +298,7 @@ func (c *integrationCollection) WriteText(w io.Writer, verbose bool) error {
 	}
 	headers := []string{"Name", "Type", "Spec"}
 	t := asciitable.MakeTable(headers, rows...)
-	_, err := t.AsBuffer().WriteTo(w)
+	err := t.WriteTo(w)
 	return trace.Wrap(err)
 }
 
@@ -351,7 +351,7 @@ func (c *databaseServiceCollection) WriteText(w io.Writer, verbose bool) error {
 		})
 	}
 
-	_, err := t.AsBuffer().WriteTo(w)
+	err := t.WriteTo(w)
 	return trace.Wrap(err)
 }
 
@@ -379,7 +379,7 @@ func (c *deviceCollection) WriteText(w io.Writer, verbose bool) error {
 			device.UpdateTime.AsTime().Format(time.RFC3339),
 		})
 	}
-	_, err := t.AsBuffer().WriteTo(w)
+	err := t.WriteTo(w)
 	return trace.Wrap(err)
 }
 
@@ -400,7 +400,7 @@ func (c *oktaImportRuleCollection) WriteText(w io.Writer, verbose bool) error {
 	for _, importRule := range c.importRules {
 		t.AddRow([]string{importRule.GetName()})
 	}
-	_, err := t.AsBuffer().WriteTo(w)
+	err := t.WriteTo(w)
 	return trace.Wrap(err)
 }
 
@@ -421,7 +421,7 @@ func (c *oktaAssignmentCollection) WriteText(w io.Writer, verbose bool) error {
 	for _, assignment := range c.assignments {
 		t.AddRow([]string{assignment.GetName()})
 	}
-	_, err := t.AsBuffer().WriteTo(w)
+	err := t.WriteTo(w)
 	return trace.Wrap(err)
 }
 
@@ -445,7 +445,7 @@ func (c *userGroupCollection) WriteText(w io.Writer, verbose bool) error {
 			userGroup.Origin(),
 		})
 	}
-	_, err := t.AsBuffer().WriteTo(w)
+	err := t.WriteTo(w)
 	return trace.Wrap(err)
 }
 
@@ -470,7 +470,7 @@ func (c *securityReportCollection) WriteText(w io.Writer, verbose bool) error {
 		}
 		t.AddRow([]string{v.GetName(), v.Spec.Title, strings.Join(auditQueriesNames, ", "), v.Spec.Description})
 	}
-	_, err := t.AsBuffer().WriteTo(w)
+	err := t.WriteTo(w)
 	return trace.Wrap(err)
 }
 
@@ -626,7 +626,7 @@ func (c *pluginCollection) WriteText(w io.Writer, verbose bool) error {
 			plugin.GetStatus().GetCode().String(),
 		})
 	}
-	_, err := t.AsBuffer().WriteTo(w)
+	err := t.WriteTo(w)
 	return trace.Wrap(err)
 }
 
@@ -667,6 +667,6 @@ func (c *healthCheckConfigCollection) WriteText(w io.Writer, verbose bool) error
 
 	// stable sort by name.
 	t.SortRowsBy([]int{0}, true)
-	_, err := t.AsBuffer().WriteTo(w)
+	err := t.WriteTo(w)
 	return trace.Wrap(err)
 }

--- a/tool/tctl/common/collection.go
+++ b/tool/tctl/common/collection.go
@@ -63,8 +63,7 @@ func (r *reverseTunnelCollection) WriteText(w io.Writer, verbose bool) error {
 			tunnel.GetClusterName(), strings.Join(tunnel.GetDialAddrs(), ","),
 		})
 	}
-	err := t.WriteTo(w)
-	return trace.Wrap(err)
+	return trace.Wrap(t.WriteTo(w))
 }
 
 type trustedClusterCollection struct {
@@ -92,8 +91,7 @@ func (c *trustedClusterCollection) WriteText(w io.Writer, verbose bool) error {
 			fmt.Sprintf("%v", tc.CombinedMapping()),
 		})
 	}
-	err := t.WriteTo(w)
-	return trace.Wrap(err)
+	return trace.Wrap(t.WriteTo(w))
 }
 
 type remoteClusterCollection struct {
@@ -113,8 +111,7 @@ func (c *remoteClusterCollection) WriteText(w io.Writer, verbose bool) error {
 		lastHeartbeat := cluster.GetLastHeartbeat()
 		t.AddRow([]string{cluster.GetName(), cluster.GetConnectionStatus(), formatLastHeartbeat(lastHeartbeat)})
 	}
-	err := t.WriteTo(w)
-	return trace.Wrap(err)
+	return trace.Wrap(t.WriteTo(w))
 }
 
 func formatLastHeartbeat(t time.Time) string {
@@ -152,8 +149,7 @@ func (c *semaphoreCollection) WriteText(w io.Writer, verbose bool) error {
 			})
 		}
 	}
-	err := t.WriteTo(w)
-	return trace.Wrap(err)
+	return trace.Wrap(t.WriteTo(w))
 }
 
 type netRestrictionsCollection struct {
@@ -226,8 +222,7 @@ func (c *databaseServerCollection) WriteText(w io.Writer, verbose bool) error {
 	}
 	// stable sort by hostname then by name.
 	t.SortRowsBy([]int{0, 1}, true)
-	err := t.WriteTo(w)
-	return trace.Wrap(err)
+	return trace.Wrap(t.WriteTo(w))
 }
 
 func (c *databaseServerCollection) writeJSON(w io.Writer) error {
@@ -267,8 +262,7 @@ func (c *crownJewelCollection) WriteText(w io.Writer, verbose bool) error {
 	}
 	// stable sort by name.
 	t.SortRowsBy([]int{0}, true)
-	err := t.WriteTo(w)
-	return trace.Wrap(err)
+	return trace.Wrap(t.WriteTo(w))
 }
 
 type integrationCollection struct {
@@ -298,8 +292,7 @@ func (c *integrationCollection) WriteText(w io.Writer, verbose bool) error {
 	}
 	headers := []string{"Name", "Type", "Spec"}
 	t := asciitable.MakeTable(headers, rows...)
-	err := t.WriteTo(w)
-	return trace.Wrap(err)
+	return trace.Wrap(t.WriteTo(w))
 }
 
 type databaseServiceCollection struct {
@@ -351,8 +344,7 @@ func (c *databaseServiceCollection) WriteText(w io.Writer, verbose bool) error {
 		})
 	}
 
-	err := t.WriteTo(w)
-	return trace.Wrap(err)
+	return trace.Wrap(t.WriteTo(w))
 }
 
 type deviceCollection struct {
@@ -379,8 +371,7 @@ func (c *deviceCollection) WriteText(w io.Writer, verbose bool) error {
 			device.UpdateTime.AsTime().Format(time.RFC3339),
 		})
 	}
-	err := t.WriteTo(w)
-	return trace.Wrap(err)
+	return trace.Wrap(t.WriteTo(w))
 }
 
 type oktaImportRuleCollection struct {
@@ -400,8 +391,7 @@ func (c *oktaImportRuleCollection) WriteText(w io.Writer, verbose bool) error {
 	for _, importRule := range c.importRules {
 		t.AddRow([]string{importRule.GetName()})
 	}
-	err := t.WriteTo(w)
-	return trace.Wrap(err)
+	return trace.Wrap(t.WriteTo(w))
 }
 
 type oktaAssignmentCollection struct {
@@ -421,8 +411,7 @@ func (c *oktaAssignmentCollection) WriteText(w io.Writer, verbose bool) error {
 	for _, assignment := range c.assignments {
 		t.AddRow([]string{assignment.GetName()})
 	}
-	err := t.WriteTo(w)
-	return trace.Wrap(err)
+	return trace.Wrap(t.WriteTo(w))
 }
 
 type userGroupCollection struct {
@@ -445,8 +434,7 @@ func (c *userGroupCollection) WriteText(w io.Writer, verbose bool) error {
 			userGroup.Origin(),
 		})
 	}
-	err := t.WriteTo(w)
-	return trace.Wrap(err)
+	return trace.Wrap(t.WriteTo(w))
 }
 
 type securityReportCollection struct {
@@ -470,8 +458,7 @@ func (c *securityReportCollection) WriteText(w io.Writer, verbose bool) error {
 		}
 		t.AddRow([]string{v.GetName(), v.Spec.Title, strings.Join(auditQueriesNames, ", "), v.Spec.Description})
 	}
-	err := t.WriteTo(w)
-	return trace.Wrap(err)
+	return trace.Wrap(t.WriteTo(w))
 }
 
 type pluginCollection struct {
@@ -626,8 +613,7 @@ func (c *pluginCollection) WriteText(w io.Writer, verbose bool) error {
 			plugin.GetStatus().GetCode().String(),
 		})
 	}
-	err := t.WriteTo(w)
-	return trace.Wrap(err)
+	return trace.Wrap(t.WriteTo(w))
 }
 
 type healthCheckConfigCollection struct {
@@ -667,6 +653,5 @@ func (c *healthCheckConfigCollection) WriteText(w io.Writer, verbose bool) error
 
 	// stable sort by name.
 	t.SortRowsBy([]int{0}, true)
-	err := t.WriteTo(w)
-	return trace.Wrap(err)
+	return trace.Wrap(t.WriteTo(w))
 }

--- a/tool/tctl/common/collection_test.go
+++ b/tool/tctl/common/collection_test.go
@@ -116,7 +116,7 @@ func testKubeClusterCollection_writeText(t *testing.T) {
 					{"cluster3", formatTestLabels(staticLabelsFixture, eksDiscoveredNameLabel, false)},
 				},
 				"Labels")
-			return table.AsBuffer().String()
+			return table.String()
 		},
 		wantVerboseTable: func() string {
 			table := asciitable.MakeTable(
@@ -126,7 +126,7 @@ func testKubeClusterCollection_writeText(t *testing.T) {
 				[]string{"cluster2", formatTestLabels(staticLabelsFixture, longLabelFixture, true)},
 				[]string{"cluster3-eks-us-west-1-123456789012", formatTestLabels(staticLabelsFixture, eksDiscoveredNameLabel, true)},
 			)
-			return table.AsBuffer().String()
+			return table.String()
 		},
 	}
 	test.run(t)
@@ -154,7 +154,7 @@ func testKubeServerCollection_writeText(t *testing.T) {
 					{"cluster3", formatTestLabels(staticLabelsFixture, eksDiscoveredNameLabel, false), api.Version},
 				},
 				"Labels")
-			return table.AsBuffer().String()
+			return table.String()
 		},
 		wantVerboseTable: func() string {
 			table := asciitable.MakeTable(
@@ -164,7 +164,7 @@ func testKubeServerCollection_writeText(t *testing.T) {
 				[]string{"cluster2", formatTestLabels(staticLabelsFixture, longLabelFixture, true), api.Version},
 				[]string{"cluster3-eks-us-west-1-123456789012", formatTestLabels(staticLabelsFixture, eksDiscoveredNameLabel, true), api.Version},
 			)
-			return table.AsBuffer().String()
+			return table.String()
 		},
 	}
 	test.run(t)
@@ -195,7 +195,7 @@ func testDatabaseCollection_writeText(t *testing.T) {
 					{"database-B", "postgres", "localhost:5432", formatTestLabels(staticLabelsFixture, longLabelFixture, false)},
 				},
 				"Labels")
-			return table.AsBuffer().String()
+			return table.String()
 		},
 		wantVerboseTable: func() string {
 			table := asciitable.MakeTable(
@@ -205,7 +205,7 @@ func testDatabaseCollection_writeText(t *testing.T) {
 				[]string{"database-B", "postgres", "localhost:5432", formatTestLabels(staticLabelsFixture, longLabelFixture, true)},
 				[]string{"database-rds-us-west-1-123456789012", "postgres", rdsURI, formatTestLabels(staticLabelsFixture, rdsDiscoveredNameLabel, true)},
 			)
-			return table.AsBuffer().String()
+			return table.String()
 		},
 	}
 	test.run(t)
@@ -236,7 +236,7 @@ func testDatabaseServerCollection_writeText(t *testing.T) {
 					{"some-host", "database-B", "postgres", "localhost:5432", formatTestLabels(staticLabelsFixture, longLabelFixture, false), api.Version},
 				},
 				"Labels")
-			return table.AsBuffer().String()
+			return table.String()
 		},
 		wantVerboseTable: func() string {
 			table := asciitable.MakeTable(
@@ -246,7 +246,7 @@ func testDatabaseServerCollection_writeText(t *testing.T) {
 				[]string{"some-host", "database-B", "postgres", "localhost:5432", formatTestLabels(staticLabelsFixture, longLabelFixture, true), api.Version},
 				[]string{"some-host", "database-rds-us-west-1-123456789012", "postgres", rdsURI, formatTestLabels(staticLabelsFixture, rdsDiscoveredNameLabel, true), api.Version},
 			)
-			return table.AsBuffer().String()
+			return table.String()
 		},
 	}
 	test.run(t)

--- a/tool/tctl/common/devices.go
+++ b/tool/tctl/common/devices.go
@@ -310,7 +310,7 @@ func (c *deviceListCommand) Run(ctx context.Context, authClient *authclient.Clie
 				dev.Id,
 			})
 		}
-		fmt.Fprintln(c.stdout, table.AsBuffer().String())
+		table.WriteTo(c.stdout)
 	case teleport.JSON:
 		return trace.Wrap(utils.WriteJSONArray(c.stdout, devs), "failed to marshal devices list")
 	case teleport.YAML:

--- a/tool/tctl/common/devices.go
+++ b/tool/tctl/common/devices.go
@@ -311,6 +311,7 @@ func (c *deviceListCommand) Run(ctx context.Context, authClient *authclient.Clie
 			})
 		}
 		table.WriteTo(c.stdout)
+		fmt.Fprintln(c.stdout)
 	case teleport.JSON:
 		return trace.Wrap(utils.WriteJSONArray(c.stdout, devs), "failed to marshal devices list")
 	case teleport.YAML:

--- a/tool/tctl/common/discovery/render.go
+++ b/tool/tctl/common/discovery/render.go
@@ -54,6 +54,6 @@ func renderText(w io.Writer, instances []instanceInfo) error {
 		})
 	}
 	t := asciitable.MakeTableWithTruncatedColumn(columns, rows, "Details")
-	_, err := t.AsBuffer().WriteTo(w)
+	err := t.WriteTo(w)
 	return trace.Wrap(err)
 }

--- a/tool/tctl/common/discovery/render.go
+++ b/tool/tctl/common/discovery/render.go
@@ -54,6 +54,5 @@ func renderText(w io.Writer, instances []instanceInfo) error {
 		})
 	}
 	t := asciitable.MakeTableWithTruncatedColumn(columns, rows, "Details")
-	err := t.WriteTo(w)
-	return trace.Wrap(err)
+	return trace.Wrap(t.WriteTo(w))
 }

--- a/tool/tctl/common/idp_command.go
+++ b/tool/tctl/common/idp_command.go
@@ -197,6 +197,7 @@ func (t *testAttributeMapping) run(ctx context.Context, c *authclient.Client) er
 			if err := table.WriteTo(os.Stdout); err != nil {
 				return trace.Wrap(err)
 			}
+			fmt.Fprintln(os.Stdout)
 		}
 	}
 

--- a/tool/tctl/common/idp_command.go
+++ b/tool/tctl/common/idp_command.go
@@ -194,7 +194,9 @@ func (t *testAttributeMapping) run(ctx context.Context, c *authclient.Client) er
 					strings.Join(value.Values, ", "),
 				})
 			}
-			fmt.Println(table.AsBuffer().String())
+			if err := table.WriteTo(os.Stdout); err != nil {
+				return trace.Wrap(err)
+			}
 		}
 	}
 

--- a/tool/tctl/common/inventory_command.go
+++ b/tool/tctl/common/inventory_command.go
@@ -135,8 +135,7 @@ func (c *InventoryCommand) Status(ctx context.Context, client *authclient.Client
 				})
 			}
 
-			err := table.WriteTo(os.Stdout)
-			return trace.Wrap(err)
+			return trace.Wrap(table.WriteTo(os.Stdout))
 		}
 
 		printHierarchicalData(map[string]any{
@@ -279,8 +278,7 @@ func (c *InventoryCommand) List(ctx context.Context, client *authclient.Client) 
 			return trace.Wrap(err)
 		}
 
-		err := table.WriteTo(os.Stdout)
-		return trace.Wrap(err)
+		return trace.Wrap(table.WriteTo(os.Stdout))
 	case teleport.JSON:
 		if err := utils.StreamJSONArray(instances, os.Stdout, true); err != nil {
 			return trace.Wrap(err)

--- a/tool/tctl/common/inventory_command.go
+++ b/tool/tctl/common/inventory_command.go
@@ -135,7 +135,7 @@ func (c *InventoryCommand) Status(ctx context.Context, client *authclient.Client
 				})
 			}
 
-			_, err := table.AsBuffer().WriteTo(os.Stdout)
+			err := table.WriteTo(os.Stdout)
 			return trace.Wrap(err)
 		}
 
@@ -279,7 +279,7 @@ func (c *InventoryCommand) List(ctx context.Context, client *authclient.Client) 
 			return trace.Wrap(err)
 		}
 
-		_, err := table.AsBuffer().WriteTo(os.Stdout)
+		err := table.WriteTo(os.Stdout)
 		return trace.Wrap(err)
 	case teleport.JSON:
 		if err := utils.StreamJSONArray(instances, os.Stdout, true); err != nil {

--- a/tool/tctl/common/notification_command.go
+++ b/tool/tctl/common/notification_command.go
@@ -296,7 +296,7 @@ func displayNotifications(format string, notifications []*notificationspb.Notifi
 				common.FormatLabels(n.GetMetadata().GetLabels(), false),
 			})
 		}
-		fmt.Fprint(w, table.AsBuffer().String())
+		table.WriteTo(w)
 	case teleport.JSON:
 		utils.WriteJSONArray(w, notifications)
 	case teleport.YAML:

--- a/tool/tctl/common/recordings_encryption_command.go
+++ b/tool/tctl/common/recordings_encryption_command.go
@@ -189,7 +189,7 @@ func (c *recordingsEncryptionCommand) writeStatusText(w io.Writer, keyStates []*
 		fmt.Fprintln(w, "Rotation in progress")
 	}
 
-	_, err := t.AsBuffer().WriteTo(w)
+	err := t.WriteTo(w)
 	return trace.Wrap(err)
 }
 

--- a/tool/tctl/common/recordings_encryption_command.go
+++ b/tool/tctl/common/recordings_encryption_command.go
@@ -189,8 +189,7 @@ func (c *recordingsEncryptionCommand) writeStatusText(w io.Writer, keyStates []*
 		fmt.Fprintln(w, "Rotation in progress")
 	}
 
-	err := t.WriteTo(w)
-	return trace.Wrap(err)
+	return trace.Wrap(t.WriteTo(w))
 }
 
 func (c *recordingsEncryptionCommand) getFriendlyStatusString(state recordingencryptionv1.KeyPairState) string {

--- a/tool/tctl/common/resources/access_monitoring_rule.go
+++ b/tool/tctl/common/resources/access_monitoring_rule.go
@@ -58,7 +58,7 @@ func (c *accessMonitoringRuleCollection) WriteText(w io.Writer, verbose bool) er
 
 	// stable sort by name.
 	t.SortRowsBy([]int{0}, true)
-	_, err := t.AsBuffer().WriteTo(w)
+	err := t.WriteTo(w)
 	return trace.Wrap(err)
 }
 

--- a/tool/tctl/common/resources/access_monitoring_rule.go
+++ b/tool/tctl/common/resources/access_monitoring_rule.go
@@ -58,8 +58,7 @@ func (c *accessMonitoringRuleCollection) WriteText(w io.Writer, verbose bool) er
 
 	// stable sort by name.
 	t.SortRowsBy([]int{0}, true)
-	err := t.WriteTo(w)
-	return trace.Wrap(err)
+	return trace.Wrap(t.WriteTo(w))
 }
 
 func accessMonitoringRuleHandler() Handler {

--- a/tool/tctl/common/resources/access_request.go
+++ b/tool/tctl/common/resources/access_request.go
@@ -63,7 +63,7 @@ func (c *accessRequestCollection) WriteText(w io.Writer, verbose bool) error {
 		t = asciitable.MakeTableWithTruncatedColumn([]string{"Name", "User", "Roles", "Annotations"}, rows, "Annotations")
 	}
 
-	_, err := t.AsBuffer().WriteTo(w)
+	err := t.WriteTo(w)
 	return trace.Wrap(err)
 }
 

--- a/tool/tctl/common/resources/access_request.go
+++ b/tool/tctl/common/resources/access_request.go
@@ -63,8 +63,7 @@ func (c *accessRequestCollection) WriteText(w io.Writer, verbose bool) error {
 		t = asciitable.MakeTableWithTruncatedColumn([]string{"Name", "User", "Roles", "Annotations"}, rows, "Annotations")
 	}
 
-	err := t.WriteTo(w)
-	return trace.Wrap(err)
+	return trace.Wrap(t.WriteTo(w))
 }
 
 func accessRequestHandler() Handler {

--- a/tool/tctl/common/resources/accessgraphsettings.go
+++ b/tool/tctl/common/resources/accessgraphsettings.go
@@ -46,7 +46,7 @@ func (c *accessGraphSettingsCollection) WriteText(w io.Writer, verbose bool) err
 	t.AddRow([]string{
 		c.accessGraphSettings.Spec.SecretsScanConfig,
 	})
-	_, err := t.AsBuffer().WriteTo(w)
+	err := t.WriteTo(w)
 	return trace.Wrap(err)
 }
 

--- a/tool/tctl/common/resources/accessgraphsettings.go
+++ b/tool/tctl/common/resources/accessgraphsettings.go
@@ -46,8 +46,7 @@ func (c *accessGraphSettingsCollection) WriteText(w io.Writer, verbose bool) err
 	t.AddRow([]string{
 		c.accessGraphSettings.Spec.SecretsScanConfig,
 	})
-	err := t.WriteTo(w)
-	return trace.Wrap(err)
+	return trace.Wrap(t.WriteTo(w))
 }
 
 func accessGraphSettingsHandler() Handler {

--- a/tool/tctl/common/resources/accesslist.go
+++ b/tool/tctl/common/resources/accesslist.go
@@ -56,8 +56,7 @@ func (c *accessListCollection) WriteText(w io.Writer, verbose bool) error {
 			al.Spec.Audit.NextAuditDate.Format(time.RFC822),
 		})
 	}
-	err := t.WriteTo(w)
-	return trace.Wrap(err)
+	return trace.Wrap(t.WriteTo(w))
 }
 
 func accessListHandler() Handler {

--- a/tool/tctl/common/resources/accesslist.go
+++ b/tool/tctl/common/resources/accesslist.go
@@ -56,7 +56,7 @@ func (c *accessListCollection) WriteText(w io.Writer, verbose bool) error {
 			al.Spec.Audit.NextAuditDate.Format(time.RFC822),
 		})
 	}
-	_, err := t.AsBuffer().WriteTo(w)
+	err := t.WriteTo(w)
 	return trace.Wrap(err)
 }
 

--- a/tool/tctl/common/resources/app.go
+++ b/tool/tctl/common/resources/app.go
@@ -65,8 +65,7 @@ func (c *appCollection) WriteText(w io.Writer, verbose bool) error {
 	} else {
 		t = asciitable.MakeTableWithTruncatedColumn(headers, rows, "Labels")
 	}
-	err := t.WriteTo(w)
-	return trace.Wrap(err)
+	return trace.Wrap(t.WriteTo(w))
 }
 
 func appHandler() Handler {

--- a/tool/tctl/common/resources/app.go
+++ b/tool/tctl/common/resources/app.go
@@ -65,7 +65,7 @@ func (c *appCollection) WriteText(w io.Writer, verbose bool) error {
 	} else {
 		t = asciitable.MakeTableWithTruncatedColumn(headers, rows, "Labels")
 	}
-	_, err := t.AsBuffer().WriteTo(w)
+	err := t.WriteTo(w)
 	return trace.Wrap(err)
 }
 

--- a/tool/tctl/common/resources/app_server.go
+++ b/tool/tctl/common/resources/app_server.go
@@ -68,8 +68,7 @@ func (a *appServerCollection) WriteText(w io.Writer, verbose bool) error {
 		t = asciitable.MakeTableWithTruncatedColumn(headers, rows, "Labels")
 	}
 
-	err := t.WriteTo(w)
-	return trace.Wrap(err)
+	return trace.Wrap(t.WriteTo(w))
 }
 
 func appServerHandler() Handler {

--- a/tool/tctl/common/resources/app_server.go
+++ b/tool/tctl/common/resources/app_server.go
@@ -68,7 +68,7 @@ func (a *appServerCollection) WriteText(w io.Writer, verbose bool) error {
 		t = asciitable.MakeTableWithTruncatedColumn(headers, rows, "Labels")
 	}
 
-	_, err := t.AsBuffer().WriteTo(w)
+	err := t.WriteTo(w)
 	return trace.Wrap(err)
 }
 

--- a/tool/tctl/common/resources/appauthconfig.go
+++ b/tool/tctl/common/resources/appauthconfig.go
@@ -76,7 +76,7 @@ func (c *appAuthConfigCollection) WriteText(w io.Writer, verbose bool) error {
 
 	// stable sort by name.
 	t.SortRowsBy([]int{0}, true)
-	_, err := t.AsBuffer().WriteTo(w)
+	err := t.WriteTo(w)
 	return trace.Wrap(err)
 }
 

--- a/tool/tctl/common/resources/appauthconfig.go
+++ b/tool/tctl/common/resources/appauthconfig.go
@@ -76,8 +76,7 @@ func (c *appAuthConfigCollection) WriteText(w io.Writer, verbose bool) error {
 
 	// stable sort by name.
 	t.SortRowsBy([]int{0}, true)
-	err := t.WriteTo(w)
-	return trace.Wrap(err)
+	return trace.Wrap(t.WriteTo(w))
 }
 
 func appAuthConfigHandler() Handler {

--- a/tool/tctl/common/resources/audit_query.go
+++ b/tool/tctl/common/resources/audit_query.go
@@ -49,8 +49,7 @@ func (c *auditQueryCollection) WriteText(w io.Writer, verbose bool) error {
 	for _, v := range c.auditQueries {
 		t.AddRow([]string{v.GetName(), v.Spec.Title, v.Spec.Query, v.Spec.Description})
 	}
-	err := t.WriteTo(w)
-	return trace.Wrap(err)
+	return trace.Wrap(t.WriteTo(w))
 }
 
 func auditQueryHandler() Handler {

--- a/tool/tctl/common/resources/audit_query.go
+++ b/tool/tctl/common/resources/audit_query.go
@@ -49,7 +49,7 @@ func (c *auditQueryCollection) WriteText(w io.Writer, verbose bool) error {
 	for _, v := range c.auditQueries {
 		t.AddRow([]string{v.GetName(), v.Spec.Title, v.Spec.Query, v.Spec.Description})
 	}
-	_, err := t.AsBuffer().WriteTo(w)
+	err := t.WriteTo(w)
 	return trace.Wrap(err)
 }
 

--- a/tool/tctl/common/resources/autoupdate_agent_report.go
+++ b/tool/tctl/common/resources/autoupdate_agent_report.go
@@ -81,8 +81,7 @@ func (c *autoUpdateAgentReportCollection) WriteText(w io.Writer, verbose bool) e
 		}
 		t.AddRow(make([]string, len(versionNames)+2))
 	}
-	err := t.WriteTo(w)
-	return trace.Wrap(err)
+	return trace.Wrap(t.WriteTo(w))
 }
 
 func autoUpdateAgentReportHandler() Handler {

--- a/tool/tctl/common/resources/autoupdate_agent_report.go
+++ b/tool/tctl/common/resources/autoupdate_agent_report.go
@@ -81,7 +81,7 @@ func (c *autoUpdateAgentReportCollection) WriteText(w io.Writer, verbose bool) e
 		}
 		t.AddRow(make([]string, len(versionNames)+2))
 	}
-	_, err := t.AsBuffer().WriteTo(w)
+	err := t.WriteTo(w)
 	return trace.Wrap(err)
 }
 

--- a/tool/tctl/common/resources/autoupdate_agent_rollout.go
+++ b/tool/tctl/common/resources/autoupdate_agent_rollout.go
@@ -51,7 +51,7 @@ func (c *autoUpdateAgentRolloutCollection) WriteText(w io.Writer, verbose bool) 
 		fmt.Sprintf("%v", c.rollout.GetSpec().GetSchedule()),
 		fmt.Sprintf("%v", c.rollout.GetSpec().GetStrategy()),
 	})
-	_, err := t.AsBuffer().WriteTo(w)
+	err := t.WriteTo(w)
 	return trace.Wrap(err)
 }
 

--- a/tool/tctl/common/resources/autoupdate_agent_rollout.go
+++ b/tool/tctl/common/resources/autoupdate_agent_rollout.go
@@ -51,8 +51,7 @@ func (c *autoUpdateAgentRolloutCollection) WriteText(w io.Writer, verbose bool) 
 		fmt.Sprintf("%v", c.rollout.GetSpec().GetSchedule()),
 		fmt.Sprintf("%v", c.rollout.GetSpec().GetStrategy()),
 	})
-	err := t.WriteTo(w)
-	return trace.Wrap(err)
+	return trace.Wrap(t.WriteTo(w))
 }
 
 func autoUpdateAgentRolloutHandler() Handler {

--- a/tool/tctl/common/resources/autoupdate_config.go
+++ b/tool/tctl/common/resources/autoupdate_config.go
@@ -53,7 +53,7 @@ func (c *autoUpdateConfigCollection) WriteText(w io.Writer, verbose bool) error 
 		c.config.GetMetadata().GetName(),
 		fmt.Sprintf("%v", c.config.GetSpec().GetTools().GetMode()),
 	})
-	_, err := t.AsBuffer().WriteTo(w)
+	err := t.WriteTo(w)
 	return trace.Wrap(err)
 }
 

--- a/tool/tctl/common/resources/autoupdate_config.go
+++ b/tool/tctl/common/resources/autoupdate_config.go
@@ -53,8 +53,7 @@ func (c *autoUpdateConfigCollection) WriteText(w io.Writer, verbose bool) error 
 		c.config.GetMetadata().GetName(),
 		fmt.Sprintf("%v", c.config.GetSpec().GetTools().GetMode()),
 	})
-	err := t.WriteTo(w)
-	return trace.Wrap(err)
+	return trace.Wrap(t.WriteTo(w))
 }
 
 func autoUpdateConfigHandler() Handler {

--- a/tool/tctl/common/resources/autoupdate_version.go
+++ b/tool/tctl/common/resources/autoupdate_version.go
@@ -53,8 +53,7 @@ func (c *autoUpdateVersionCollection) WriteText(w io.Writer, verbose bool) error
 		c.version.GetMetadata().GetName(),
 		fmt.Sprintf("%v", c.version.GetSpec().GetTools().TargetVersion),
 	})
-	err := t.WriteTo(w)
-	return trace.Wrap(err)
+	return trace.Wrap(t.WriteTo(w))
 }
 
 func autoUpdateVersionHandler() Handler {

--- a/tool/tctl/common/resources/autoupdate_version.go
+++ b/tool/tctl/common/resources/autoupdate_version.go
@@ -53,7 +53,7 @@ func (c *autoUpdateVersionCollection) WriteText(w io.Writer, verbose bool) error
 		c.version.GetMetadata().GetName(),
 		fmt.Sprintf("%v", c.version.GetSpec().GetTools().TargetVersion),
 	})
-	_, err := t.AsBuffer().WriteTo(w)
+	err := t.WriteTo(w)
 	return trace.Wrap(err)
 }
 

--- a/tool/tctl/common/resources/bot.go
+++ b/tool/tctl/common/resources/bot.go
@@ -54,8 +54,7 @@ func (c *botCollection) WriteText(w io.Writer, verbose bool) error {
 			strings.Join(b.Spec.Roles, ", "),
 		})
 	}
-	err := t.WriteTo(w)
-	return trace.Wrap(err)
+	return trace.Wrap(t.WriteTo(w))
 }
 
 func botHandler() Handler {

--- a/tool/tctl/common/resources/bot.go
+++ b/tool/tctl/common/resources/bot.go
@@ -54,7 +54,7 @@ func (c *botCollection) WriteText(w io.Writer, verbose bool) error {
 			strings.Join(b.Spec.Roles, ", "),
 		})
 	}
-	_, err := t.AsBuffer().WriteTo(w)
+	err := t.WriteTo(w)
 	return trace.Wrap(err)
 }
 

--- a/tool/tctl/common/resources/bot_instance.go
+++ b/tool/tctl/common/resources/bot_instance.go
@@ -57,8 +57,7 @@ func (c *botInstanceCollection) WriteText(w io.Writer, verbose bool) error {
 
 	// stable sort by name.
 	t.SortRowsBy([]int{0}, true)
-	err := t.WriteTo(w)
-	return trace.Wrap(err)
+	return trace.Wrap(t.WriteTo(w))
 }
 
 func botInstanceHandler() Handler {

--- a/tool/tctl/common/resources/bot_instance.go
+++ b/tool/tctl/common/resources/bot_instance.go
@@ -57,7 +57,7 @@ func (c *botInstanceCollection) WriteText(w io.Writer, verbose bool) error {
 
 	// stable sort by name.
 	t.SortRowsBy([]int{0}, true)
-	_, err := t.AsBuffer().WriteTo(w)
+	err := t.WriteTo(w)
 	return trace.Wrap(err)
 }
 

--- a/tool/tctl/common/resources/bot_instance_report.go
+++ b/tool/tctl/common/resources/bot_instance_report.go
@@ -51,7 +51,7 @@ func (c *autoUpdateBotInstanceReportCollection) WriteText(w io.Writer, _ bool) e
 	}
 	t.SortRowsBy([]int{0, 1}, true)
 
-	_, err := t.AsBuffer().WriteTo(w)
+	err := t.WriteTo(w)
 	return trace.Wrap(err)
 }
 

--- a/tool/tctl/common/resources/bot_instance_report.go
+++ b/tool/tctl/common/resources/bot_instance_report.go
@@ -51,8 +51,7 @@ func (c *autoUpdateBotInstanceReportCollection) WriteText(w io.Writer, _ bool) e
 	}
 	t.SortRowsBy([]int{0, 1}, true)
 
-	err := t.WriteTo(w)
-	return trace.Wrap(err)
+	return trace.Wrap(t.WriteTo(w))
 }
 
 func autoUpdateBotInstanceReportHandler() Handler {

--- a/tool/tctl/common/resources/cert_authority.go
+++ b/tool/tctl/common/resources/cert_authority.go
@@ -66,7 +66,7 @@ func (a *certAuthorityCollection) WriteText(w io.Writer, verbose bool) error {
 			})
 		}
 	}
-	_, err := t.AsBuffer().WriteTo(w)
+	err := t.WriteTo(w)
 	return trace.Wrap(err)
 }
 

--- a/tool/tctl/common/resources/cert_authority.go
+++ b/tool/tctl/common/resources/cert_authority.go
@@ -66,8 +66,7 @@ func (a *certAuthorityCollection) WriteText(w io.Writer, verbose bool) error {
 			})
 		}
 	}
-	err := t.WriteTo(w)
-	return trace.Wrap(err)
+	return trace.Wrap(t.WriteTo(w))
 }
 
 func certAuthorityHandler() Handler {

--- a/tool/tctl/common/resources/cluster_auth_preference.go
+++ b/tool/tctl/common/resources/cluster_auth_preference.go
@@ -52,8 +52,7 @@ func (c *authPreferenceCollection) WriteText(w io.Writer, verbose bool) error {
 
 	t := asciitable.MakeTable([]string{"Type", "Second Factors"})
 	t.AddRow([]string{c.authPref.GetType(), strings.Join(secondFactorStrings, ", ")})
-	err := t.WriteTo(w)
-	return trace.Wrap(err)
+	return trace.Wrap(t.WriteTo(w))
 }
 
 func authPreferenceHandler() Handler {

--- a/tool/tctl/common/resources/cluster_auth_preference.go
+++ b/tool/tctl/common/resources/cluster_auth_preference.go
@@ -52,7 +52,7 @@ func (c *authPreferenceCollection) WriteText(w io.Writer, verbose bool) error {
 
 	t := asciitable.MakeTable([]string{"Type", "Second Factors"})
 	t.AddRow([]string{c.authPref.GetType(), strings.Join(secondFactorStrings, ", ")})
-	_, err := t.AsBuffer().WriteTo(w)
+	err := t.WriteTo(w)
 	return trace.Wrap(err)
 }
 

--- a/tool/tctl/common/resources/cluster_maintenance_config.go
+++ b/tool/tctl/common/resources/cluster_maintenance_config.go
@@ -61,8 +61,7 @@ func (c *clusterMaintenanceConfigCollection) WriteText(w io.Writer, verbose bool
 
 	t.AddRow([]string{"Agent Upgrades", agentUpgradeParams})
 
-	err := t.WriteTo(w)
-	return trace.Wrap(err)
+	return trace.Wrap(t.WriteTo(w))
 }
 
 func clusterMaintenanceConfigHandler() Handler {

--- a/tool/tctl/common/resources/cluster_maintenance_config.go
+++ b/tool/tctl/common/resources/cluster_maintenance_config.go
@@ -61,7 +61,7 @@ func (c *clusterMaintenanceConfigCollection) WriteText(w io.Writer, verbose bool
 
 	t.AddRow([]string{"Agent Upgrades", agentUpgradeParams})
 
-	_, err := t.AsBuffer().WriteTo(w)
+	err := t.WriteTo(w)
 	return trace.Wrap(err)
 }
 

--- a/tool/tctl/common/resources/cluster_networking_config.go
+++ b/tool/tctl/common/resources/cluster_networking_config.go
@@ -48,7 +48,7 @@ func (c *networkingConfigCollection) WriteText(w io.Writer, verbose bool) error 
 		strconv.FormatInt(c.netConfig.GetKeepAliveCountMax(), 10),
 		c.netConfig.GetSessionControlTimeout().String(),
 	})
-	_, err := t.AsBuffer().WriteTo(w)
+	err := t.WriteTo(w)
 	return trace.Wrap(err)
 }
 

--- a/tool/tctl/common/resources/cluster_networking_config.go
+++ b/tool/tctl/common/resources/cluster_networking_config.go
@@ -48,8 +48,7 @@ func (c *networkingConfigCollection) WriteText(w io.Writer, verbose bool) error 
 		strconv.FormatInt(c.netConfig.GetKeepAliveCountMax(), 10),
 		c.netConfig.GetSessionControlTimeout().String(),
 	})
-	err := t.WriteTo(w)
-	return trace.Wrap(err)
+	return trace.Wrap(t.WriteTo(w))
 }
 
 func networkingConfigHandler() Handler {

--- a/tool/tctl/common/resources/database.go
+++ b/tool/tctl/common/resources/database.go
@@ -69,7 +69,7 @@ func (c *databaseCollection) WriteText(w io.Writer, verbose bool) error {
 	}
 	// stable sort by name.
 	t.SortRowsBy([]int{0}, true)
-	_, err := t.AsBuffer().WriteTo(w)
+	err := t.WriteTo(w)
 	return trace.Wrap(err)
 }
 

--- a/tool/tctl/common/resources/database.go
+++ b/tool/tctl/common/resources/database.go
@@ -69,8 +69,7 @@ func (c *databaseCollection) WriteText(w io.Writer, verbose bool) error {
 	}
 	// stable sort by name.
 	t.SortRowsBy([]int{0}, true)
-	err := t.WriteTo(w)
-	return trace.Wrap(err)
+	return trace.Wrap(t.WriteTo(w))
 }
 
 func databaseHandler() Handler {

--- a/tool/tctl/common/resources/database_object.go
+++ b/tool/tctl/common/resources/database_object.go
@@ -55,8 +55,7 @@ func (c *databaseObjectCollection) WriteText(w io.Writer, verbose bool) error {
 			fmt.Sprintf("%v", b.GetSpec().GetProtocol()),
 		})
 	}
-	err := t.WriteTo(w)
-	return trace.Wrap(err)
+	return trace.Wrap(t.WriteTo(w))
 }
 
 func databaseObjectHandler() Handler {

--- a/tool/tctl/common/resources/database_object.go
+++ b/tool/tctl/common/resources/database_object.go
@@ -55,7 +55,7 @@ func (c *databaseObjectCollection) WriteText(w io.Writer, verbose bool) error {
 			fmt.Sprintf("%v", b.GetSpec().GetProtocol()),
 		})
 	}
-	_, err := t.AsBuffer().WriteTo(w)
+	err := t.WriteTo(w)
 	return trace.Wrap(err)
 }
 

--- a/tool/tctl/common/resources/database_object_import_rule.go
+++ b/tool/tctl/common/resources/database_object_import_rule.go
@@ -55,8 +55,7 @@ func (c *databaseObjectImportRuleCollection) WriteText(w io.Writer, _ bool) erro
 			fmt.Sprintf("%v", len(b.GetSpec().GetDatabaseLabels())),
 		})
 	}
-	err := t.WriteTo(w)
-	return trace.Wrap(err)
+	return trace.Wrap(t.WriteTo(w))
 }
 
 func databaseObjectImportRuleHandler() Handler {

--- a/tool/tctl/common/resources/database_object_import_rule.go
+++ b/tool/tctl/common/resources/database_object_import_rule.go
@@ -55,7 +55,7 @@ func (c *databaseObjectImportRuleCollection) WriteText(w io.Writer, _ bool) erro
 			fmt.Sprintf("%v", len(b.GetSpec().GetDatabaseLabels())),
 		})
 	}
-	_, err := t.AsBuffer().WriteTo(w)
+	err := t.WriteTo(w)
 	return trace.Wrap(err)
 }
 

--- a/tool/tctl/common/resources/database_object_import_rule_test.go
+++ b/tool/tctl/common/resources/database_object_import_rule_test.go
@@ -65,7 +65,7 @@ func TestDatabaseImportRuleCollection_writeText(t *testing.T) {
 		[]string{"rule_3", "33", "1", "2"},
 	)
 
-	formatted := table.AsBuffer().String()
+	formatted := table.String()
 
 	collectionFormatTest(t, &databaseObjectImportRuleCollection{rules}, formatted, formatted)
 }

--- a/tool/tctl/common/resources/database_object_test.go
+++ b/tool/tctl/common/resources/database_object_test.go
@@ -52,7 +52,7 @@ func TestDatabaseObjectCollection_writeText(t *testing.T) {
 		[]string{"object_3", "table", "pg", "postgres"},
 	)
 
-	formatted := table.AsBuffer().String()
+	formatted := table.String()
 
 	collectionFormatTest(t, &databaseObjectCollection{items}, formatted, formatted)
 }

--- a/tool/tctl/common/resources/discoveryconfig.go
+++ b/tool/tctl/common/resources/discoveryconfig.go
@@ -57,7 +57,7 @@ func (u *discoveryConfigCollection) WriteText(w io.Writer, verbose bool) error {
 			discoveryConfig.GetDiscoveryGroup(),
 		})
 	}
-	_, err := t.AsBuffer().WriteTo(w)
+	err := t.WriteTo(w)
 	return trace.Wrap(err)
 }
 

--- a/tool/tctl/common/resources/discoveryconfig.go
+++ b/tool/tctl/common/resources/discoveryconfig.go
@@ -57,8 +57,7 @@ func (u *discoveryConfigCollection) WriteText(w io.Writer, verbose bool) error {
 			discoveryConfig.GetDiscoveryGroup(),
 		})
 	}
-	err := t.WriteTo(w)
-	return trace.Wrap(err)
+	return trace.Wrap(t.WriteTo(w))
 }
 
 func discoveryConfigHandler() Handler {

--- a/tool/tctl/common/resources/external_audit_storage.go
+++ b/tool/tctl/common/resources/external_audit_storage.go
@@ -146,6 +146,6 @@ func (c *externalAuditStorageCollection) WriteText(w io.Writer, verbose bool) er
 	}
 	headers := []string{"Name", "IntegrationName", "PolicyName", "Region", "SessionRecordingsURI", "AuditEventsLongTermURI", "AthenaResultsURI", "AthenaWorkgroup", "GlueDatabase", "GlueTable"}
 	t := asciitable.MakeTable(headers, rows...)
-	_, err := t.AsBuffer().WriteTo(w)
+	err := t.WriteTo(w)
 	return trace.Wrap(err)
 }

--- a/tool/tctl/common/resources/external_audit_storage.go
+++ b/tool/tctl/common/resources/external_audit_storage.go
@@ -146,6 +146,5 @@ func (c *externalAuditStorageCollection) WriteText(w io.Writer, verbose bool) er
 	}
 	headers := []string{"Name", "IntegrationName", "PolicyName", "Region", "SessionRecordingsURI", "AuditEventsLongTermURI", "AthenaResultsURI", "AthenaWorkgroup", "GlueDatabase", "GlueTable"}
 	t := asciitable.MakeTable(headers, rows...)
-	err := t.WriteTo(w)
-	return trace.Wrap(err)
+	return trace.Wrap(t.WriteTo(w))
 }

--- a/tool/tctl/common/resources/github_connector.go
+++ b/tool/tctl/common/resources/github_connector.go
@@ -50,8 +50,7 @@ func (c *githubConnectorCollection) WriteText(w io.Writer, verbose bool) error {
 		t.AddRow([]string{conn.GetName(), formatTeamsToLogins(
 			conn.GetTeamsToLogins())})
 	}
-	err := t.WriteTo(w)
-	return trace.Wrap(err)
+	return trace.Wrap(t.WriteTo(w))
 }
 
 func formatTeamsToLogins(mappings []types.TeamMapping) string {

--- a/tool/tctl/common/resources/github_connector.go
+++ b/tool/tctl/common/resources/github_connector.go
@@ -50,7 +50,7 @@ func (c *githubConnectorCollection) WriteText(w io.Writer, verbose bool) error {
 		t.AddRow([]string{conn.GetName(), formatTeamsToLogins(
 			conn.GetTeamsToLogins())})
 	}
-	_, err := t.AsBuffer().WriteTo(w)
+	err := t.WriteTo(w)
 	return trace.Wrap(err)
 }
 

--- a/tool/tctl/common/resources/inference_model.go
+++ b/tool/tctl/common/resources/inference_model.go
@@ -72,8 +72,7 @@ func (c inferenceModelCollection) WriteText(w io.Writer, verbose bool) error {
 		t = asciitable.MakeTableWithTruncatedColumn(headers, rows, "Description")
 	}
 	t.SortRowsBy([]int{0}, true)
-	err := t.WriteTo(w)
-	return trace.Wrap(err)
+	return trace.Wrap(t.WriteTo(w))
 }
 
 func inferenceModelHandler() Handler {

--- a/tool/tctl/common/resources/inference_model.go
+++ b/tool/tctl/common/resources/inference_model.go
@@ -72,7 +72,7 @@ func (c inferenceModelCollection) WriteText(w io.Writer, verbose bool) error {
 		t = asciitable.MakeTableWithTruncatedColumn(headers, rows, "Description")
 	}
 	t.SortRowsBy([]int{0}, true)
-	_, err := t.AsBuffer().WriteTo(w)
+	err := t.WriteTo(w)
 	return trace.Wrap(err)
 }
 

--- a/tool/tctl/common/resources/inference_model_test.go
+++ b/tool/tctl/common/resources/inference_model_test.go
@@ -48,7 +48,7 @@ func TestInferenceModelCollection_writeText(t *testing.T) {
 		[]string{"model_3", "", "OpenAI", "gpt-4o-3"},
 	)
 
-	formatted := table.AsBuffer().String()
+	formatted := table.String()
 
 	collectionFormatTest(t, inferenceModelCollection(models), formatted, formatted)
 }

--- a/tool/tctl/common/resources/inference_policy.go
+++ b/tool/tctl/common/resources/inference_policy.go
@@ -68,7 +68,7 @@ func (c inferencePolicyCollection) WriteText(w io.Writer, verbose bool) error {
 
 	// stable sort by name.
 	t.SortRowsBy([]int{0}, true)
-	_, err := t.AsBuffer().WriteTo(w)
+	err := t.WriteTo(w)
 	return trace.Wrap(err)
 }
 

--- a/tool/tctl/common/resources/inference_policy.go
+++ b/tool/tctl/common/resources/inference_policy.go
@@ -68,8 +68,7 @@ func (c inferencePolicyCollection) WriteText(w io.Writer, verbose bool) error {
 
 	// stable sort by name.
 	t.SortRowsBy([]int{0}, true)
-	err := t.WriteTo(w)
-	return trace.Wrap(err)
+	return trace.Wrap(t.WriteTo(w))
 }
 
 func inferencePolicyHandler() Handler {

--- a/tool/tctl/common/resources/inference_policy_test.go
+++ b/tool/tctl/common/resources/inference_policy_test.go
@@ -47,10 +47,10 @@ func TestInferencePolicyCollection_writeText(t *testing.T) {
 	}
 
 	table := asciitable.MakeTableWithTruncatedColumn(headers, rows, "Description")
-	formatted := table.AsBuffer().String()
+	formatted := table.String()
 
 	verboseTable := asciitable.MakeTable(headers, rows...)
-	verboseFormatted := verboseTable.AsBuffer().String()
+	verboseFormatted := verboseTable.String()
 
 	collectionFormatTest(t, inferencePolicyCollection(policies), verboseFormatted, formatted)
 }

--- a/tool/tctl/common/resources/inference_secret.go
+++ b/tool/tctl/common/resources/inference_secret.go
@@ -63,8 +63,7 @@ func (c inferenceSecretCollection) WriteText(w io.Writer, verbose bool) error {
 
 	// stable sort by name.
 	t.SortRowsBy([]int{0}, true)
-	err := t.WriteTo(w)
-	return trace.Wrap(err)
+	return trace.Wrap(t.WriteTo(w))
 }
 
 func inferenceSecretHandler() Handler {

--- a/tool/tctl/common/resources/inference_secret.go
+++ b/tool/tctl/common/resources/inference_secret.go
@@ -63,7 +63,7 @@ func (c inferenceSecretCollection) WriteText(w io.Writer, verbose bool) error {
 
 	// stable sort by name.
 	t.SortRowsBy([]int{0}, true)
-	_, err := t.AsBuffer().WriteTo(w)
+	err := t.WriteTo(w)
 	return trace.Wrap(err)
 }
 

--- a/tool/tctl/common/resources/inference_secret_test.go
+++ b/tool/tctl/common/resources/inference_secret_test.go
@@ -44,7 +44,7 @@ func TestInferenceSecretCollection_writeText(t *testing.T) {
 		[]string{"secret_3", ""},
 	)
 
-	formatted := table.AsBuffer().String()
+	formatted := table.String()
 
 	collectionFormatTest(t, inferenceSecretCollection(secrets), formatted, formatted)
 }

--- a/tool/tctl/common/resources/kube_cluster.go
+++ b/tool/tctl/common/resources/kube_cluster.go
@@ -72,8 +72,7 @@ func (c *kubeClusterCollection) WriteText(w io.Writer, verbose bool) error {
 	}
 	// stable sort by name.
 	t.SortRowsBy([]int{0}, true)
-	err := t.WriteTo(w)
-	return trace.Wrap(err)
+	return trace.Wrap(t.WriteTo(w))
 }
 
 func kubeClusterHandler() Handler {

--- a/tool/tctl/common/resources/kube_cluster.go
+++ b/tool/tctl/common/resources/kube_cluster.go
@@ -72,7 +72,7 @@ func (c *kubeClusterCollection) WriteText(w io.Writer, verbose bool) error {
 	}
 	// stable sort by name.
 	t.SortRowsBy([]int{0}, true)
-	_, err := t.AsBuffer().WriteTo(w)
+	err := t.WriteTo(w)
 	return trace.Wrap(err)
 }
 

--- a/tool/tctl/common/resources/kube_server.go
+++ b/tool/tctl/common/resources/kube_server.go
@@ -70,7 +70,7 @@ func (c *kubeServerCollection) WriteText(w io.Writer, verbose bool) error {
 	// stable sort by cluster name.
 	t.SortRowsBy([]int{0}, true)
 
-	_, err := t.AsBuffer().WriteTo(w)
+	err := t.WriteTo(w)
 	return trace.Wrap(err)
 }
 

--- a/tool/tctl/common/resources/kube_server.go
+++ b/tool/tctl/common/resources/kube_server.go
@@ -70,8 +70,7 @@ func (c *kubeServerCollection) WriteText(w io.Writer, verbose bool) error {
 	// stable sort by cluster name.
 	t.SortRowsBy([]int{0}, true)
 
-	err := t.WriteTo(w)
-	return trace.Wrap(err)
+	return trace.Wrap(t.WriteTo(w))
 }
 
 func kubeServerHandler() Handler {

--- a/tool/tctl/common/resources/linux_desktop.go
+++ b/tool/tctl/common/resources/linux_desktop.go
@@ -71,7 +71,7 @@ func (c *linuxDesktopCollection) WriteText(w io.Writer, verbose bool) error {
 	} else {
 		t = asciitable.MakeTableWithTruncatedColumn(headers, rows, "Labels")
 	}
-	_, err := t.AsBuffer().WriteTo(w)
+	err := t.WriteTo(w)
 	return trace.Wrap(err)
 }
 

--- a/tool/tctl/common/resources/linux_desktop.go
+++ b/tool/tctl/common/resources/linux_desktop.go
@@ -71,8 +71,7 @@ func (c *linuxDesktopCollection) WriteText(w io.Writer, verbose bool) error {
 	} else {
 		t = asciitable.MakeTableWithTruncatedColumn(headers, rows, "Labels")
 	}
-	err := t.WriteTo(w)
-	return trace.Wrap(err)
+	return trace.Wrap(t.WriteTo(w))
 }
 
 func getLinuxDesktops(ctx context.Context, client *authclient.Client, ref services.Ref, opts GetOpts) (Collection, error) {

--- a/tool/tctl/common/resources/linux_desktop_test.go
+++ b/tool/tctl/common/resources/linux_desktop_test.go
@@ -64,7 +64,7 @@ func TestLinuxDesktopCollection_WriteText(t *testing.T) {
 		[]string{"desktop-3", "192.168.1.102:22", "test-host-1", "env=test"},
 	)
 
-	formatted := table.AsBuffer().String()
+	formatted := table.String()
 
 	collectionFormatTest(t, &linuxDesktopCollection{desktops: desktops}, formatted, formatted)
 }

--- a/tool/tctl/common/resources/lock.go
+++ b/tool/tctl/common/resources/lock.go
@@ -55,8 +55,7 @@ func (c *lockCollection) WriteText(w io.Writer, verbose bool) error {
 		}
 		t.AddRow([]string{lock.GetName(), target.String(), lock.Message(), expires})
 	}
-	err := t.WriteTo(w)
-	return trace.Wrap(err)
+	return trace.Wrap(t.WriteTo(w))
 }
 
 func lockHandler() Handler {

--- a/tool/tctl/common/resources/lock.go
+++ b/tool/tctl/common/resources/lock.go
@@ -55,7 +55,7 @@ func (c *lockCollection) WriteText(w io.Writer, verbose bool) error {
 		}
 		t.AddRow([]string{lock.GetName(), target.String(), lock.Message(), expires})
 	}
-	_, err := t.AsBuffer().WriteTo(w)
+	err := t.WriteTo(w)
 	return trace.Wrap(err)
 }
 

--- a/tool/tctl/common/resources/login_rule.go
+++ b/tool/tctl/common/resources/login_rule.go
@@ -46,8 +46,7 @@ func (l *loginRuleCollection) WriteText(w io.Writer, verbose bool) error {
 	for _, rule := range l.rules {
 		t.AddRow([]string{rule.GetMetadata().GetName(), strconv.FormatInt(int64(rule.GetPriority()), 10)})
 	}
-	err := t.WriteTo(w)
-	return trace.Wrap(err)
+	return trace.Wrap(t.WriteTo(w))
 }
 
 func (l *loginRuleCollection) Resources() []types.Resource {

--- a/tool/tctl/common/resources/login_rule.go
+++ b/tool/tctl/common/resources/login_rule.go
@@ -46,7 +46,7 @@ func (l *loginRuleCollection) WriteText(w io.Writer, verbose bool) error {
 	for _, rule := range l.rules {
 		t.AddRow([]string{rule.GetMetadata().GetName(), strconv.FormatInt(int64(rule.GetPriority()), 10)})
 	}
-	_, err := t.AsBuffer().WriteTo(w)
+	err := t.WriteTo(w)
 	return trace.Wrap(err)
 }
 

--- a/tool/tctl/common/resources/oidc_connector.go
+++ b/tool/tctl/common/resources/oidc_connector.go
@@ -51,8 +51,7 @@ func (c *oidcConnectorCollection) WriteText(w io.Writer, verbose bool) error {
 			conn.GetName(), conn.GetIssuerURL(), strings.Join(conn.GetScope(), ","),
 		})
 	}
-	err := t.WriteTo(w)
-	return trace.Wrap(err)
+	return trace.Wrap(t.WriteTo(w))
 }
 
 func oidcConnectorHandler() Handler {

--- a/tool/tctl/common/resources/oidc_connector.go
+++ b/tool/tctl/common/resources/oidc_connector.go
@@ -51,7 +51,7 @@ func (c *oidcConnectorCollection) WriteText(w io.Writer, verbose bool) error {
 			conn.GetName(), conn.GetIssuerURL(), strings.Join(conn.GetScope(), ","),
 		})
 	}
-	_, err := t.AsBuffer().WriteTo(w)
+	err := t.WriteTo(w)
 	return trace.Wrap(err)
 }
 

--- a/tool/tctl/common/resources/retrieval_model.go
+++ b/tool/tctl/common/resources/retrieval_model.go
@@ -73,7 +73,7 @@ func (c retrievalModelCollection) WriteText(w io.Writer, verbose bool) error {
 	} else {
 		t = asciitable.MakeTableWithTruncatedColumn(headers, rows, "Description")
 	}
-	_, err := t.AsBuffer().WriteTo(w)
+	err := t.WriteTo(w)
 	return trace.Wrap(err)
 }
 

--- a/tool/tctl/common/resources/retrieval_model.go
+++ b/tool/tctl/common/resources/retrieval_model.go
@@ -73,8 +73,7 @@ func (c retrievalModelCollection) WriteText(w io.Writer, verbose bool) error {
 	} else {
 		t = asciitable.MakeTableWithTruncatedColumn(headers, rows, "Description")
 	}
-	err := t.WriteTo(w)
-	return trace.Wrap(err)
+	return trace.Wrap(t.WriteTo(w))
 }
 
 func retrievalModelHandler() Handler {

--- a/tool/tctl/common/resources/role.go
+++ b/tool/tctl/common/resources/role.go
@@ -71,7 +71,7 @@ func (r *roleCollection) WriteText(w io.Writer, verbose bool) error {
 		t = asciitable.MakeTableWithTruncatedColumn(headers, rows, "Access to resources")
 	}
 
-	_, err := t.AsBuffer().WriteTo(w)
+	err := t.WriteTo(w)
 	return trace.Wrap(err)
 }
 

--- a/tool/tctl/common/resources/role.go
+++ b/tool/tctl/common/resources/role.go
@@ -71,8 +71,7 @@ func (r *roleCollection) WriteText(w io.Writer, verbose bool) error {
 		t = asciitable.MakeTableWithTruncatedColumn(headers, rows, "Access to resources")
 	}
 
-	err := t.WriteTo(w)
-	return trace.Wrap(err)
+	return trace.Wrap(t.WriteTo(w))
 }
 
 func printActions(rules []types.Rule) string {

--- a/tool/tctl/common/resources/saml_connector.go
+++ b/tool/tctl/common/resources/saml_connector.go
@@ -48,8 +48,7 @@ func (c *samlConnectorCollection) WriteText(w io.Writer, verbose bool) error {
 	for _, conn := range c.connectors {
 		t.AddRow([]string{conn.GetName(), conn.GetSSO()})
 	}
-	err := t.WriteTo(w)
-	return trace.Wrap(err)
+	return trace.Wrap(t.WriteTo(w))
 }
 
 func samlConnectorHandler() Handler {

--- a/tool/tctl/common/resources/saml_connector.go
+++ b/tool/tctl/common/resources/saml_connector.go
@@ -48,7 +48,7 @@ func (c *samlConnectorCollection) WriteText(w io.Writer, verbose bool) error {
 	for _, conn := range c.connectors {
 		t.AddRow([]string{conn.GetName(), conn.GetSSO()})
 	}
-	_, err := t.AsBuffer().WriteTo(w)
+	err := t.WriteTo(w)
 	return trace.Wrap(err)
 }
 

--- a/tool/tctl/common/resources/saml_idp_service_provider.go
+++ b/tool/tctl/common/resources/saml_idp_service_provider.go
@@ -54,8 +54,7 @@ func (c *samlIdPServiceProviderCollection) WriteText(w io.Writer, verbose bool) 
 	for _, serviceProvider := range c.serviceProviders {
 		t.AddRow([]string{serviceProvider.GetName()})
 	}
-	err := t.WriteTo(w)
-	return trace.Wrap(err)
+	return trace.Wrap(t.WriteTo(w))
 }
 
 func samlIdPServiceProviderHandler() Handler {

--- a/tool/tctl/common/resources/saml_idp_service_provider.go
+++ b/tool/tctl/common/resources/saml_idp_service_provider.go
@@ -54,7 +54,7 @@ func (c *samlIdPServiceProviderCollection) WriteText(w io.Writer, verbose bool) 
 	for _, serviceProvider := range c.serviceProviders {
 		t.AddRow([]string{serviceProvider.GetName()})
 	}
-	_, err := t.AsBuffer().WriteTo(w)
+	err := t.WriteTo(w)
 	return trace.Wrap(err)
 }
 

--- a/tool/tctl/common/resources/scoped_role.go
+++ b/tool/tctl/common/resources/scoped_role.go
@@ -62,7 +62,7 @@ func (c *scopedRoleCollection) WriteText(w io.Writer, verbose bool) error {
 
 	t := asciitable.MakeTable(headers, rows...)
 
-	_, err := t.AsBuffer().WriteTo(w)
+	err := t.WriteTo(w)
 	return trace.Wrap(err)
 }
 

--- a/tool/tctl/common/resources/scoped_role.go
+++ b/tool/tctl/common/resources/scoped_role.go
@@ -62,8 +62,7 @@ func (c *scopedRoleCollection) WriteText(w io.Writer, verbose bool) error {
 
 	t := asciitable.MakeTable(headers, rows...)
 
-	err := t.WriteTo(w)
-	return trace.Wrap(err)
+	return trace.Wrap(t.WriteTo(w))
 }
 
 func scopedRoleHandler() Handler {

--- a/tool/tctl/common/resources/scoped_role_assignment.go
+++ b/tool/tctl/common/resources/scoped_role_assignment.go
@@ -73,8 +73,7 @@ func (c *ScopedRoleAssignmentCollection) WriteText(w io.Writer, verbose bool) er
 
 	t := asciitable.MakeTable(headers, rows...)
 
-	err := t.WriteTo(w)
-	return trace.Wrap(err)
+	return trace.Wrap(t.WriteTo(w))
 }
 
 func scopedRoleAssignmentHandler() Handler {

--- a/tool/tctl/common/resources/scoped_role_assignment.go
+++ b/tool/tctl/common/resources/scoped_role_assignment.go
@@ -73,7 +73,7 @@ func (c *ScopedRoleAssignmentCollection) WriteText(w io.Writer, verbose bool) er
 
 	t := asciitable.MakeTable(headers, rows...)
 
-	_, err := t.AsBuffer().WriteTo(w)
+	err := t.WriteTo(w)
 	return trace.Wrap(err)
 }
 

--- a/tool/tctl/common/resources/scoped_token.go
+++ b/tool/tctl/common/resources/scoped_token.go
@@ -16,7 +16,6 @@
 package resources
 
 import (
-	"bytes"
 	"context"
 	"fmt"
 	"io"
@@ -55,8 +54,8 @@ func (c *scopedTokenCollection) Resources() []types.Resource {
 
 func (c *scopedTokenCollection) WriteText(w io.Writer, verbose bool) error {
 	// when calling the getScopedToken, the secrets would already have been properly hidden or exposed.
-	_, err := ScopedTokenTextHelper(c.tokens, false).WriteTo(w)
-	return trace.Wrap(err)
+	t := ScopedTokenTextHelper(c.tokens, false)
+	return trace.Wrap(t.WriteTo(w))
 }
 
 func scopedTokenHandler() Handler {
@@ -170,7 +169,7 @@ func deleteScopedToken(ctx context.Context, client *authclient.Client, ref servi
 	return nil
 }
 
-func ScopedTokenTextHelper(tokens []*joiningv1.ScopedToken, withSecrets bool) *bytes.Buffer {
+func ScopedTokenTextHelper(tokens []*joiningv1.ScopedToken, withSecrets bool) asciitable.Table {
 	headers := []string{
 		"Token",
 		"Type",
@@ -206,5 +205,5 @@ func ScopedTokenTextHelper(tokens []*joiningv1.ScopedToken, withSecrets bool) *b
 		}
 		table.AddRow(row)
 	}
-	return table.AsBuffer()
+	return table
 }

--- a/tool/tctl/common/resources/server.go
+++ b/tool/tctl/common/resources/server.go
@@ -70,7 +70,7 @@ func (s *ServerCollection) WriteText(w io.Writer, verbose bool) error {
 		t = asciitable.MakeTableWithTruncatedColumn(headers, rows, "Labels")
 	}
 
-	_, err := t.AsBuffer().WriteTo(w)
+	err := t.WriteTo(w)
 	return trace.Wrap(err)
 }
 

--- a/tool/tctl/common/resources/server.go
+++ b/tool/tctl/common/resources/server.go
@@ -70,8 +70,7 @@ func (s *ServerCollection) WriteText(w io.Writer, verbose bool) error {
 		t = asciitable.MakeTableWithTruncatedColumn(headers, rows, "Labels")
 	}
 
-	err := t.WriteTo(w)
-	return trace.Wrap(err)
+	return trace.Wrap(t.WriteTo(w))
 }
 
 func (s *ServerCollection) WriteYAML(w io.Writer) error {

--- a/tool/tctl/common/resources/server_info.go
+++ b/tool/tctl/common/resources/server_info.go
@@ -52,7 +52,7 @@ func (c *serverInfoCollection) WriteText(w io.Writer, verbose bool) error {
 		}
 		t.AddRow([]string{si.GetName(), strings.Join(pairs, ",")})
 	}
-	_, err := t.AsBuffer().WriteTo(w)
+	err := t.WriteTo(w)
 	return trace.Wrap(err)
 }
 

--- a/tool/tctl/common/resources/server_info.go
+++ b/tool/tctl/common/resources/server_info.go
@@ -52,8 +52,7 @@ func (c *serverInfoCollection) WriteText(w io.Writer, verbose bool) error {
 		}
 		t.AddRow([]string{si.GetName(), strings.Join(pairs, ",")})
 	}
-	err := t.WriteTo(w)
-	return trace.Wrap(err)
+	return trace.Wrap(t.WriteTo(w))
 }
 
 func serverInfoHandler() Handler {

--- a/tool/tctl/common/resources/session_recording_config.go
+++ b/tool/tctl/common/resources/session_recording_config.go
@@ -43,8 +43,7 @@ func (c *sessionRecordingConfigCollection) Resources() (r []types.Resource) {
 func (c *sessionRecordingConfigCollection) WriteText(w io.Writer, verbose bool) error {
 	t := asciitable.MakeTable([]string{"Mode", "Proxy Checks Host Keys"})
 	t.AddRow([]string{c.recConfig.GetMode(), strconv.FormatBool(c.recConfig.GetProxyChecksHostKeys())})
-	err := t.WriteTo(w)
-	return trace.Wrap(err)
+	return trace.Wrap(t.WriteTo(w))
 }
 
 func sessionRecordingConfigHandler() Handler {

--- a/tool/tctl/common/resources/session_recording_config.go
+++ b/tool/tctl/common/resources/session_recording_config.go
@@ -43,7 +43,7 @@ func (c *sessionRecordingConfigCollection) Resources() (r []types.Resource) {
 func (c *sessionRecordingConfigCollection) WriteText(w io.Writer, verbose bool) error {
 	t := asciitable.MakeTable([]string{"Mode", "Proxy Checks Host Keys"})
 	t.AddRow([]string{c.recConfig.GetMode(), strconv.FormatBool(c.recConfig.GetProxyChecksHostKeys())})
-	_, err := t.AsBuffer().WriteTo(w)
+	err := t.WriteTo(w)
 	return trace.Wrap(err)
 }
 

--- a/tool/tctl/common/resources/spiffe_federation.go
+++ b/tool/tctl/common/resources/spiffe_federation.go
@@ -62,7 +62,7 @@ func (c *spiffeFederationCollection) WriteText(w io.Writer, verbose bool) error 
 
 	// stable sort by name.
 	t.SortRowsBy([]int{0}, true)
-	_, err := t.AsBuffer().WriteTo(w)
+	err := t.WriteTo(w)
 	return trace.Wrap(err)
 }
 

--- a/tool/tctl/common/resources/spiffe_federation.go
+++ b/tool/tctl/common/resources/spiffe_federation.go
@@ -62,8 +62,7 @@ func (c *spiffeFederationCollection) WriteText(w io.Writer, verbose bool) error 
 
 	// stable sort by name.
 	t.SortRowsBy([]int{0}, true)
-	err := t.WriteTo(w)
-	return trace.Wrap(err)
+	return trace.Wrap(t.WriteTo(w))
 }
 
 func spiffeFederationHandler() Handler {

--- a/tool/tctl/common/resources/static_host_user.go
+++ b/tool/tctl/common/resources/static_host_user.go
@@ -91,7 +91,7 @@ func (c *staticHostUserCollection) WriteText(w io.Writer, verbose bool) error {
 		t = asciitable.MakeTableWithTruncatedColumn(headers, rows, "Node Expression")
 	}
 	t.SortRowsBy([]int{0}, true)
-	_, err := t.AsBuffer().WriteTo(w)
+	err := t.WriteTo(w)
 	return trace.Wrap(err)
 }
 

--- a/tool/tctl/common/resources/static_host_user.go
+++ b/tool/tctl/common/resources/static_host_user.go
@@ -91,8 +91,7 @@ func (c *staticHostUserCollection) WriteText(w io.Writer, verbose bool) error {
 		t = asciitable.MakeTableWithTruncatedColumn(headers, rows, "Node Expression")
 	}
 	t.SortRowsBy([]int{0}, true)
-	err := t.WriteTo(w)
-	return trace.Wrap(err)
+	return trace.Wrap(t.WriteTo(w))
 }
 
 func printSortedStringSlice(s []string) string {

--- a/tool/tctl/common/resources/uiconfig.go
+++ b/tool/tctl/common/resources/uiconfig.go
@@ -43,8 +43,7 @@ func (c *uiConfigCollection) Resources() []types.Resource {
 func (c *uiConfigCollection) WriteText(w io.Writer, verbose bool) error {
 	t := asciitable.MakeTable([]string{"Scrollback Lines", "Show Resources"})
 	t.AddRow([]string{strconv.FormatInt(int64(c.uiconfig.GetScrollbackLines()), 10), string(c.uiconfig.GetShowResources())})
-	err := t.WriteTo(w)
-	return trace.Wrap(err)
+	return trace.Wrap(t.WriteTo(w))
 }
 
 func uiConfigHandler() Handler {

--- a/tool/tctl/common/resources/uiconfig.go
+++ b/tool/tctl/common/resources/uiconfig.go
@@ -43,7 +43,7 @@ func (c *uiConfigCollection) Resources() []types.Resource {
 func (c *uiConfigCollection) WriteText(w io.Writer, verbose bool) error {
 	t := asciitable.MakeTable([]string{"Scrollback Lines", "Show Resources"})
 	t.AddRow([]string{strconv.FormatInt(int64(c.uiconfig.GetScrollbackLines()), 10), string(c.uiconfig.GetShowResources())})
-	_, err := t.AsBuffer().WriteTo(w)
+	err := t.WriteTo(w)
 	return trace.Wrap(err)
 }
 

--- a/tool/tctl/common/resources/user.go
+++ b/tool/tctl/common/resources/user.go
@@ -51,8 +51,7 @@ func (u *userCollection) WriteText(w io.Writer, verbose bool) error {
 	for _, user := range u.users {
 		t.AddRow([]string{user.GetName()})
 	}
-	fmt.Println(t.AsBuffer().String())
-	return nil
+	return trace.Wrap(t.WriteTo(w))
 }
 
 func userHandler() Handler {

--- a/tool/tctl/common/resources/vnetconfig.go
+++ b/tool/tctl/common/resources/vnetconfig.go
@@ -90,8 +90,7 @@ func (c *vnetConfigCollection) WriteText(w io.Writer, verbose bool) error {
 		c.vnetConfig.GetSpec().GetIpv4CidrRange(),
 		strings.Join(dnsZoneSuffixes, ", "),
 	})
-	err := t.WriteTo(w)
-	return trace.Wrap(err)
+	return trace.Wrap(t.WriteTo(w))
 }
 
 func vnetConfigHandler() Handler {

--- a/tool/tctl/common/resources/vnetconfig.go
+++ b/tool/tctl/common/resources/vnetconfig.go
@@ -90,7 +90,7 @@ func (c *vnetConfigCollection) WriteText(w io.Writer, verbose bool) error {
 		c.vnetConfig.GetSpec().GetIpv4CidrRange(),
 		strings.Join(dnsZoneSuffixes, ", "),
 	})
-	_, err := t.AsBuffer().WriteTo(w)
+	err := t.WriteTo(w)
 	return trace.Wrap(err)
 }
 

--- a/tool/tctl/common/resources/windows_desktop.go
+++ b/tool/tctl/common/resources/windows_desktop.go
@@ -72,7 +72,7 @@ func (c *windowsDesktopCollection) WriteText(w io.Writer, verbose bool) error {
 	} else {
 		t = asciitable.MakeTableWithTruncatedColumn(headers, rows, "Labels")
 	}
-	_, err := t.AsBuffer().WriteTo(w)
+	err := t.WriteTo(w)
 	return trace.Wrap(err)
 }
 
@@ -190,7 +190,7 @@ func (c *windowsDesktopServiceCollection) WriteText(w io.Writer, verbose bool) e
 		}
 		t.AddRow([]string{service.GetName(), addr, service.GetTeleportVersion()})
 	}
-	_, err := t.AsBuffer().WriteTo(w)
+	err := t.WriteTo(w)
 	return trace.Wrap(err)
 }
 
@@ -252,7 +252,7 @@ func (c *dynamicWindowsDesktopCollection) WriteText(w io.Writer, verbose bool) e
 	} else {
 		t = asciitable.MakeTableWithTruncatedColumn(headers, rows, "Labels")
 	}
-	_, err := t.AsBuffer().WriteTo(w)
+	err := t.WriteTo(w)
 	return trace.Wrap(err)
 }
 

--- a/tool/tctl/common/resources/windows_desktop.go
+++ b/tool/tctl/common/resources/windows_desktop.go
@@ -72,8 +72,7 @@ func (c *windowsDesktopCollection) WriteText(w io.Writer, verbose bool) error {
 	} else {
 		t = asciitable.MakeTableWithTruncatedColumn(headers, rows, "Labels")
 	}
-	err := t.WriteTo(w)
-	return trace.Wrap(err)
+	return trace.Wrap(t.WriteTo(w))
 }
 
 func getDesktops(ctx context.Context, client *authclient.Client, ref services.Ref, opts GetOpts) (Collection, error) {
@@ -190,8 +189,7 @@ func (c *windowsDesktopServiceCollection) WriteText(w io.Writer, verbose bool) e
 		}
 		t.AddRow([]string{service.GetName(), addr, service.GetTeleportVersion()})
 	}
-	err := t.WriteTo(w)
-	return trace.Wrap(err)
+	return trace.Wrap(t.WriteTo(w))
 }
 
 func getWindowsDesktopService(ctx context.Context, client *authclient.Client, ref services.Ref, opts GetOpts) (Collection, error) {
@@ -252,8 +250,7 @@ func (c *dynamicWindowsDesktopCollection) WriteText(w io.Writer, verbose bool) e
 	} else {
 		t = asciitable.MakeTableWithTruncatedColumn(headers, rows, "Labels")
 	}
-	err := t.WriteTo(w)
-	return trace.Wrap(err)
+	return trace.Wrap(t.WriteTo(w))
 }
 
 func createDynamicWindowsDesktop(ctx context.Context, client *authclient.Client, raw services.UnknownResource, opts CreateOpts) error {

--- a/tool/tctl/common/resources/workload_identity.go
+++ b/tool/tctl/common/resources/workload_identity.go
@@ -59,7 +59,7 @@ func (c *workloadIdentityCollection) WriteText(w io.Writer, verbose bool) error 
 
 	// stable sort by name.
 	t.SortRowsBy([]int{0}, true)
-	_, err := t.AsBuffer().WriteTo(w)
+	err := t.WriteTo(w)
 	return trace.Wrap(err)
 }
 

--- a/tool/tctl/common/resources/workload_identity.go
+++ b/tool/tctl/common/resources/workload_identity.go
@@ -59,8 +59,7 @@ func (c *workloadIdentityCollection) WriteText(w io.Writer, verbose bool) error 
 
 	// stable sort by name.
 	t.SortRowsBy([]int{0}, true)
-	err := t.WriteTo(w)
-	return trace.Wrap(err)
+	return trace.Wrap(t.WriteTo(w))
 }
 
 func workloadIdentityHandler() Handler {

--- a/tool/tctl/common/resources/workload_identity_x509_revocation.go
+++ b/tool/tctl/common/resources/workload_identity_x509_revocation.go
@@ -65,8 +65,7 @@ func (c *workloadIdentityX509RevocationCollection) WriteText(w io.Writer, verbos
 
 	// stable sort by name.
 	t.SortRowsBy([]int{0}, true)
-	err := t.WriteTo(w)
-	return trace.Wrap(err)
+	return trace.Wrap(t.WriteTo(w))
 }
 
 func workloadIdentityX509RevocationHandler() Handler {

--- a/tool/tctl/common/resources/workload_identity_x509_revocation.go
+++ b/tool/tctl/common/resources/workload_identity_x509_revocation.go
@@ -65,7 +65,7 @@ func (c *workloadIdentityX509RevocationCollection) WriteText(w io.Writer, verbos
 
 	// stable sort by name.
 	t.SortRowsBy([]int{0}, true)
-	_, err := t.AsBuffer().WriteTo(w)
+	err := t.WriteTo(w)
 	return trace.Wrap(err)
 }
 

--- a/tool/tctl/common/resources/workloadcluster.go
+++ b/tool/tctl/common/resources/workloadcluster.go
@@ -55,8 +55,7 @@ func (c *workloadClusterCollection) WriteText(w io.Writer, verbose bool) error {
 			cc.GetMetadata().GetName(),
 		})
 	}
-	err := t.WriteTo(w)
-	return trace.Wrap(err)
+	return trace.Wrap(t.WriteTo(w))
 }
 
 func workloadClusterHandler() Handler {

--- a/tool/tctl/common/resources/workloadcluster.go
+++ b/tool/tctl/common/resources/workloadcluster.go
@@ -55,7 +55,7 @@ func (c *workloadClusterCollection) WriteText(w io.Writer, verbose bool) error {
 			cc.GetMetadata().GetName(),
 		})
 	}
-	_, err := t.AsBuffer().WriteTo(w)
+	err := t.WriteTo(w)
 	return trace.Wrap(err)
 }
 

--- a/tool/tctl/common/scoped_command.go
+++ b/tool/tctl/common/scoped_command.go
@@ -154,6 +154,6 @@ func (c *scopedStatusCommand) status(ctx context.Context, client *authclient.Cli
 		})
 	}
 
-	fmt.Fprint(c.stdout, table.AsBuffer().String())
+	table.WriteTo(c.stdout)
 	return nil
 }

--- a/tool/tctl/common/scoped_token_command.go
+++ b/tool/tctl/common/scoped_token_command.go
@@ -326,7 +326,10 @@ func (c *ScopedTokensCommand) List(ctx context.Context, client *authclient.Clien
 			fmt.Fprintln(c.Stdout, token.GetMetadata().GetName())
 		}
 	default:
-		fmt.Fprint(c.Stdout, resources.ScopedTokenTextHelper(tokens, c.withSecrets).String())
+		t := resources.ScopedTokenTextHelper(tokens, c.withSecrets)
+		if err := t.WriteTo(c.Stdout); err != nil {
+			return trace.Wrap(err)
+		}
 	}
 	return nil
 }

--- a/tool/tctl/common/testdata/TestWorkloadIdentity/workload-identity_ls.golden
+++ b/tool/tctl/common/testdata/TestWorkloadIdentity/workload-identity_ls.golden
@@ -1,4 +1,3 @@
 Name SPIFFE ID 
 ---- --------- 
 test /test     
-

--- a/tool/tctl/common/testdata/TestWorkloadIdentity/workload-identity_ls.golden
+++ b/tool/tctl/common/testdata/TestWorkloadIdentity/workload-identity_ls.golden
@@ -1,3 +1,4 @@
 Name SPIFFE ID 
 ---- --------- 
 test /test     
+

--- a/tool/tctl/common/testdata/TestWorkloadIdentityRevocation/workload-identity_revocations_ls_with_value.golden
+++ b/tool/tctl/common/testdata/TestWorkloadIdentityRevocation/workload-identity_revocations_ls_with_value.golden
@@ -1,3 +1,4 @@
 Type Serial   Revoked At           Expires At                        Reason      
 ---- -------- -------------------- --------------------------------- ----------- 
 x509 aabbccdd 2024-02-05T15:04:00Z 2030-02-24T15:04:00Z (53064h0m0s) compromised 
+

--- a/tool/tctl/common/testdata/TestWorkloadIdentityRevocation/workload-identity_revocations_ls_with_value.golden
+++ b/tool/tctl/common/testdata/TestWorkloadIdentityRevocation/workload-identity_revocations_ls_with_value.golden
@@ -1,4 +1,3 @@
 Type Serial   Revoked At           Expires At                        Reason      
 ---- -------- -------------------- --------------------------------- ----------- 
 x509 aabbccdd 2024-02-05T15:04:00Z 2030-02-24T15:04:00Z (53064h0m0s) compromised 
-

--- a/tool/tctl/common/token_command.go
+++ b/tool/tctl/common/token_command.go
@@ -414,7 +414,7 @@ func (c *TokensCommand) List(ctx context.Context, client *authclient.Client) err
 				}
 				table.AddRow([]string{nameFunc(t), t.GetRoles().String(), resources.PrintMetadataLabels(t.GetMetadata().Labels), expiry})
 			}
-			return table.AsBuffer().String()
+			return table.String()
 		}
 		fmt.Fprint(c.Stdout, tokensView())
 	}

--- a/tool/tctl/common/user_command.go
+++ b/tool/tctl/common/user_command.go
@@ -539,7 +539,9 @@ func (u *UserCommand) List(ctx context.Context, client *authclient.Client) error
 				u.GetName(), strings.Join(u.GetRoles(), ","),
 			})
 		}
-		fmt.Println(t.AsBuffer().String())
+		if err := t.WriteTo(os.Stdout); err != nil {
+			return trace.Wrap(err)
+		}
 	} else {
 		err := utils.WriteJSONArray(os.Stdout, users)
 		if err != nil {

--- a/tool/tctl/common/user_command.go
+++ b/tool/tctl/common/user_command.go
@@ -542,6 +542,7 @@ func (u *UserCommand) List(ctx context.Context, client *authclient.Client) error
 		if err := t.WriteTo(os.Stdout); err != nil {
 			return trace.Wrap(err)
 		}
+		fmt.Fprintln(os.Stdout)
 	} else {
 		err := utils.WriteJSONArray(os.Stdout, users)
 		if err != nil {

--- a/tool/tctl/common/workload_identity_command.go
+++ b/tool/tctl/common/workload_identity_command.go
@@ -301,6 +301,7 @@ func (c *WorkloadIdentityCommand) ListWorkloadIdentities(
 			})
 		}
 		t.WriteTo(c.stdout)
+		fmt.Fprintln(c.stdout)
 	} else {
 		err := utils.WriteJSONArray(c.stdout, workloadIdentities)
 		if err != nil {
@@ -447,6 +448,7 @@ func (c *WorkloadIdentityCommand) ListRevocations(
 			})
 		}
 		t.WriteTo(c.stdout)
+		fmt.Fprintln(c.stdout)
 	} else {
 		converted := []types.Resource{}
 		for _, resource := range revocations {

--- a/tool/tctl/common/workload_identity_command.go
+++ b/tool/tctl/common/workload_identity_command.go
@@ -300,7 +300,7 @@ func (c *WorkloadIdentityCommand) ListWorkloadIdentities(
 				u.GetMetadata().GetName(), u.GetSpec().GetSpiffe().GetId(),
 			})
 		}
-		fmt.Fprintln(c.stdout, t.AsBuffer().String())
+		t.WriteTo(c.stdout)
 	} else {
 		err := utils.WriteJSONArray(c.stdout, workloadIdentities)
 		if err != nil {
@@ -446,7 +446,7 @@ func (c *WorkloadIdentityCommand) ListRevocations(
 				u.GetSpec().GetReason(),
 			})
 		}
-		fmt.Fprintln(c.stdout, t.AsBuffer().String())
+		t.WriteTo(c.stdout)
 	} else {
 		converted := []types.Resource{}
 		for _, resource := range revocations {

--- a/tool/tctl/sso/configure/oidc.go
+++ b/tool/tctl/sso/configure/oidc.go
@@ -144,7 +144,7 @@ func addOIDCCommand(cmd *SSOConfigureCommand) *AuthKindCommand {
 	for _, preset := range oidcPresets {
 		pTable.AddRow([]string{preset.name, preset.description, preset.display, preset.issuerURL})
 	}
-	presets := tester.Indent(pTable.AsBuffer().String(), 2)
+	presets := tester.Indent(pTable.String(), 2)
 
 	extra := &oidcExtraFlags{}
 

--- a/tool/tctl/sso/configure/saml.go
+++ b/tool/tctl/sso/configure/saml.go
@@ -89,7 +89,7 @@ func addSAMLCommand(cmd *SSOConfigureCommand) *AuthKindCommand {
 	for _, preset := range samlPresets {
 		pTable.AddRow([]string{preset.name, preset.description, preset.display})
 	}
-	presets := tester.Indent(pTable.AsBuffer().String(), 2)
+	presets := tester.Indent(pTable.String(), 2)
 
 	sub := cmd.ConfigureCmd.Command("saml", fmt.Sprintf("Configure SAML auth connector, optionally using a preset. Available presets: %v.", samlPresets.getNames()))
 

--- a/tool/tsh/common/access_request.go
+++ b/tool/tsh/common/access_request.go
@@ -207,7 +207,7 @@ func printRequest(cf *CLIConf, req types.AccessRequest) error {
 	}
 	table.AddRow([]string{"Status:", req.GetState().String()})
 
-	_, err = table.AsBuffer().WriteTo(cf.Stdout())
+	err = table.WriteTo(cf.Stdout())
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -238,7 +238,7 @@ func printRequest(cf *CLIConf, req types.AccessRequest) error {
 			subTable := asciitable.MakeHeadlessTable(2)
 			subTable.AddRow([]string{"  Reviewer:", rev.Author})
 			subTable.AddRow([]string{"  Reason:", revReason})
-			_, err = subTable.AsBuffer().WriteTo(cf.Stdout())
+			err = subTable.WriteTo(cf.Stdout())
 			if err != nil {
 				return trace.Wrap(err)
 			}
@@ -382,7 +382,7 @@ func showRequestTable(cf *CLIConf, reqs []types.AccessRequest) error {
 			req.GetState().String(),
 		})
 	}
-	_, err := table.AsBuffer().WriteTo(cf.Stdout())
+	err := table.WriteTo(cf.Stdout())
 
 	fmt.Fprintf(cf.Stdout(), "\nhint: use 'tsh request show <request-id>' for additional details\n")
 	fmt.Fprintf(cf.Stdout(), "      %v\n", requestLoginHint)
@@ -494,7 +494,7 @@ func printRequestableRoles(cf *CLIConf, rows []requestableRoleRow) error {
 			table = asciitable.MakeTableWithTruncatedColumn(columns, rows, "Description")
 		}
 
-		if _, err := table.AsBuffer().WriteTo(cf.Stdout()); err != nil {
+		if err := table.WriteTo(cf.Stdout()); err != nil {
 			return trace.Wrap(err)
 		}
 		return nil
@@ -678,7 +678,7 @@ func printRequestableResources[T resourceRow](cf *CLIConf, rows []T, resourceIDs
 			table = asciitable.MakeTableWithTruncatedColumn(columns, tableRows, "Labels")
 		}
 
-		if _, err := table.AsBuffer().WriteTo(cf.Stdout()); err != nil {
+		if err := table.WriteTo(cf.Stdout()); err != nil {
 			return trace.Wrap(err)
 		}
 

--- a/tool/tsh/common/access_request_test.go
+++ b/tool/tsh/common/access_request_test.go
@@ -114,7 +114,7 @@ func TestAccessRequestSearch(t *testing.T) {
 						{"test", "default", "", fmt.Sprintf("/%s/kube:ns:pods/%s/default/test", rootClusterName, rootKubeCluster)},
 					},
 					"Labels")
-				return table.AsBuffer().String()
+				return table.String()
 			},
 		},
 		{
@@ -131,7 +131,7 @@ func TestAccessRequestSearch(t *testing.T) {
 						{"nginx-1", "dev", "", fmt.Sprintf("/%s/kube:ns:pods/%s/dev/nginx-1", rootClusterName, rootKubeCluster)},
 					},
 					"Labels")
-				return table.AsBuffer().String()
+				return table.String()
 			},
 		},
 		{
@@ -150,7 +150,7 @@ func TestAccessRequestSearch(t *testing.T) {
 						{"test", "default", "", fmt.Sprintf("/%s/kube:ns:pods/%s/default/test", leafClusterName, leafKubeCluster)},
 					},
 					"Labels")
-				return table.AsBuffer().String()
+				return table.String()
 			},
 		},
 		{
@@ -168,7 +168,7 @@ func TestAccessRequestSearch(t *testing.T) {
 						{"nginx-1", "dev", "", fmt.Sprintf("/%s/kube:ns:pods/%s/dev/nginx-1", leafClusterName, leafKubeCluster)},
 					},
 					"Labels")
-				return table.AsBuffer().String()
+				return table.String()
 			},
 		},
 		{
@@ -184,7 +184,7 @@ func TestAccessRequestSearch(t *testing.T) {
 						{leafKubeCluster, "", "", fmt.Sprintf("/%s/kube_cluster/%s", leafClusterName, leafKubeCluster)},
 					},
 					"Labels")
-				return table.AsBuffer().String()
+				return table.String()
 			},
 		},
 	}
@@ -605,7 +605,7 @@ func TestRequestSearchRequestableRoles(t *testing.T) {
 		table := asciitable.MakeTable([]string{"Role", "Description"})
 		table.AddRow([]string{"access", "base access role"})
 		table.AddRow([]string{"db-admin", "database administrator role"})
-		return table.AsBuffer().String()
+		return table.String()
 	}
 
 	tests := []struct {
@@ -693,7 +693,7 @@ func TestPrintRequestableResources(t *testing.T) {
 				{"pod-2", "dev", "env=dev", "id2"},
 			}...,
 		)
-		expectedTable := table.AsBuffer().String()
+		expectedTable := table.String()
 		out := buf.String()
 
 		require.Contains(t, out, expectedTable)
@@ -769,7 +769,7 @@ func TestPrintRequestableResources(t *testing.T) {
 		table := asciitable.MakeTable(
 			[]string{"Name", "Namespace", "Labels", "Resource ID"},
 		)
-		expectedTable := table.AsBuffer().String()
+		expectedTable := table.String()
 		require.Equal(t, expectedTable, out)
 	})
 
@@ -813,7 +813,7 @@ func TestPrintRequestableRoles(t *testing.T) {
 				{"db-admin", "database administrator role"},
 			}...,
 		)
-		expectedTable := table.AsBuffer().String()
+		expectedTable := table.String()
 		out := buf.String()
 
 		require.Equal(t, expectedTable, out)

--- a/tool/tsh/common/app.go
+++ b/tool/tsh/common/app.go
@@ -643,7 +643,7 @@ func formatAppConfig(tc *client.TeleportClient, profile *client.ProfileStatus, r
 			t.AddRow([]string{"GCP Service Account:", routeToApp.GCPServiceAccount})
 		}
 
-		return t.AsBuffer().String(), nil
+		return t.String(), nil
 	default:
 		acceptedFormats := []string{
 			"", "default",

--- a/tool/tsh/common/app_aws.go
+++ b/tool/tsh/common/app_aws.go
@@ -216,6 +216,7 @@ func printAWSRoles(w io.Writer, roles awsutils.Roles) {
 
 	fmt.Fprintln(w, "Available AWS roles:")
 	t.WriteTo(w)
+	fmt.Fprintln(w)
 }
 
 func getARNFromFlags(cf *CLIConf, app types.Application, logins []string) (string, error) {

--- a/tool/tsh/common/app_aws.go
+++ b/tool/tsh/common/app_aws.go
@@ -215,7 +215,7 @@ func printAWSRoles(w io.Writer, roles awsutils.Roles) {
 	}
 
 	fmt.Fprintln(w, "Available AWS roles:")
-	fmt.Fprintln(w, t.AsBuffer().String())
+	t.WriteTo(w)
 }
 
 func getARNFromFlags(cf *CLIConf, app types.Application, logins []string) (string, error) {

--- a/tool/tsh/common/app_azure.go
+++ b/tool/tsh/common/app_azure.go
@@ -323,7 +323,7 @@ func formatAzureIdentities(identities []string) string {
 		t.AddRow([]string{identity})
 	}
 
-	return t.AsBuffer().String()
+	return t.String()
 }
 
 func getAzureIdentityFromFlags(cf *CLIConf, profile *client.ProfileStatus) (string, error) {

--- a/tool/tsh/common/app_gcp.go
+++ b/tool/tsh/common/app_gcp.go
@@ -304,7 +304,7 @@ func formatGCPServiceAccounts(accounts []string) string {
 		t.AddRow([]string{account})
 	}
 
-	return t.AsBuffer().String()
+	return t.String()
 }
 
 func getGCPServiceAccountFromFlags(cf *CLIConf, profile *client.ProfileStatus) (string, error) {

--- a/tool/tsh/common/app_test.go
+++ b/tool/tsh/common/app_test.go
@@ -491,13 +491,13 @@ uri: https://test-app.example.com:8443
 			name:     "format default",
 			tc:       defaultTc,
 			format:   "default",
-			expected: defaultFormatTable.AsBuffer().String(),
+			expected: defaultFormatTable.String(),
 		},
 		{
 			name:     "empty format means default",
 			tc:       defaultTc,
 			format:   "",
-			expected: defaultFormatTable.AsBuffer().String(),
+			expected: defaultFormatTable.String(),
 		},
 		{
 			name:    "reject invalid format",
@@ -511,7 +511,7 @@ uri: https://test-app.example.com:8443
 			tc:            defaultTc,
 			azureIdentity: "/subscriptions/11111111-1111-1111-1111-111111111111/resourceGroups/my-resource-group/providers/Microsoft.ManagedIdentity/userAssignedIdentities/teleport-azure",
 			format:        "default",
-			expected:      defaultFormatTableAzure.AsBuffer().String(),
+			expected:      defaultFormatTableAzure.String(),
 		},
 		{
 			name:          "azure JSON format",
@@ -553,7 +553,7 @@ uri: https://test-app.example.com:8443
 			tc:                defaultTc,
 			gcpServiceAccount: "dev@example-123456.iam.gserviceaccount.com",
 			format:            "default",
-			expected:          defaultFormatTableGCP.AsBuffer().String(),
+			expected:          defaultFormatTableGCP.String(),
 		},
 		{
 			name:              "gcp JSON format",

--- a/tool/tsh/common/db_print.go
+++ b/tool/tsh/common/db_print.go
@@ -126,7 +126,7 @@ func printDatabaseTable(cfg printDatabaseTableConfig) {
 	} else {
 		t = asciitable.MakeTableWithTruncatedColumn(printColumns, printRows, "Labels")
 	}
-	fmt.Fprintln(cfg.writer, t.AsBuffer().String())
+	t.WriteTo(cfg.writer)
 }
 
 func formatDatabaseRolesForDB(database types.Database, accessChecker services.AccessChecker) string {

--- a/tool/tsh/common/db_print.go
+++ b/tool/tsh/common/db_print.go
@@ -127,6 +127,7 @@ func printDatabaseTable(cfg printDatabaseTableConfig) {
 		t = asciitable.MakeTableWithTruncatedColumn(printColumns, printRows, "Labels")
 	}
 	t.WriteTo(cfg.writer)
+	fmt.Fprintln(cfg.writer)
 }
 
 func formatDatabaseRolesForDB(database types.Database, accessChecker services.AccessChecker) string {

--- a/tool/tsh/common/db_print_test.go
+++ b/tool/tsh/common/db_print_test.go
@@ -77,7 +77,6 @@ func Test_printDatabaseTable(t *testing.T) {
 ---- ------------ ------------- -------- ------------------- 
 db1  describe db1 [*]           Env=dev  tsh db connect d... 
 db2  describe db2 [alice]       Env=prod                     
-
 `,
 		},
 		{
@@ -91,7 +90,6 @@ db2  describe db2 [alice]       Env=prod
 ---- ------------ -------- ----------- -------------- ------------- -------------- -------- ------------------ 
 db1  describe db1 postgres self-hosted localhost:5432 [*]                          Env=dev  tsh db connect db1 
 db2  describe db2 mysql    self-hosted localhost:3306 [alice]       [readonly]     Env=prod                    
-
 `,
 		},
 		{
@@ -105,7 +103,6 @@ db2  describe db2 mysql    self-hosted localhost:3306 [alice]       [readonly]  
 ----- -------- ---- ------------ -------- ----------- -------------- ------------- -------------- -------- ------------------ 
 proxy cluster1 db1  describe db1 postgres self-hosted localhost:5432 [*]                          Env=dev  tsh db connect db1 
 proxy cluster1 db2  describe db2 mysql    self-hosted localhost:3306 [alice]       [readonly]     Env=prod                    
-
 `,
 		},
 		{
@@ -118,7 +115,6 @@ proxy cluster1 db2  describe db2 mysql    self-hosted localhost:3306 [alice]    
 ---- ------------ -------- -------- 
 db1  describe db1 postgres Env=dev  
 db2  describe db2 mysql    Env=prod 
-
 `,
 		},
 	}

--- a/tool/tsh/common/db_print_test.go
+++ b/tool/tsh/common/db_print_test.go
@@ -77,6 +77,7 @@ func Test_printDatabaseTable(t *testing.T) {
 ---- ------------ ------------- -------- ------------------- 
 db1  describe db1 [*]           Env=dev  tsh db connect d... 
 db2  describe db2 [alice]       Env=prod                     
+
 `,
 		},
 		{
@@ -90,6 +91,7 @@ db2  describe db2 [alice]       Env=prod
 ---- ------------ -------- ----------- -------------- ------------- -------------- -------- ------------------ 
 db1  describe db1 postgres self-hosted localhost:5432 [*]                          Env=dev  tsh db connect db1 
 db2  describe db2 mysql    self-hosted localhost:3306 [alice]       [readonly]     Env=prod                    
+
 `,
 		},
 		{
@@ -103,6 +105,7 @@ db2  describe db2 mysql    self-hosted localhost:3306 [alice]       [readonly]  
 ----- -------- ---- ------------ -------- ----------- -------------- ------------- -------------- -------- ------------------ 
 proxy cluster1 db1  describe db1 postgres self-hosted localhost:5432 [*]                          Env=dev  tsh db connect db1 
 proxy cluster1 db2  describe db2 mysql    self-hosted localhost:3306 [alice]       [readonly]     Env=prod                    
+
 `,
 		},
 		{
@@ -115,6 +118,7 @@ proxy cluster1 db2  describe db2 mysql    self-hosted localhost:3306 [alice]    
 ---- ------------ -------- -------- 
 db1  describe db1 postgres Env=dev  
 db2  describe db2 mysql    Env=prod 
+
 `,
 		},
 	}

--- a/tool/tsh/common/git_list.go
+++ b/tool/tsh/common/git_list.go
@@ -160,7 +160,7 @@ func printGitServersAsText(cf *CLIConf, servers []types.Server) error {
 	}
 
 	t := asciitable.MakeTable([]string{"Type", "Organization", "Username", "URL"}, rows...)
-	if _, err := fmt.Fprintln(cf.Stdout(), t.AsBuffer().String()); err != nil {
+	if err := t.WriteTo(cf.Stdout()); err != nil {
 		return trace.Wrap(err)
 	}
 

--- a/tool/tsh/common/git_list.go
+++ b/tool/tsh/common/git_list.go
@@ -163,6 +163,7 @@ func printGitServersAsText(cf *CLIConf, servers []types.Server) error {
 	if err := t.WriteTo(cf.Stdout()); err != nil {
 		return trace.Wrap(err)
 	}
+	fmt.Fprintln(cf.Stdout())
 
 	if showLoginNote {
 		fmt.Fprint(cf.Stdout(), gitLoginNote)

--- a/tool/tsh/common/kube.go
+++ b/tool/tsh/common/kube.go
@@ -1032,7 +1032,7 @@ func formatKubeClustersAsText(kubeClusters types.KubeClusters, selectedCluster s
 
 	// stable sort by kube cluster name.
 	t.SortRowsBy([]int{0}, true)
-	return t.AsBuffer().String()
+	return t.String()
 }
 
 func isClusterSelected(kubeClusters []types.KubeCluster, cluster types.KubeCluster, selectedCluster string) bool {
@@ -1198,7 +1198,7 @@ func formatKubeListingsAsText(listings kubeListings, quiet, verbose bool) string
 	}
 	// stable sort by proxy, then cluster, then kube cluster name.
 	t.SortRowsBy([]int{0, 1, 2}, true)
-	return t.AsBuffer().String()
+	return t.String()
 }
 
 func serializeKubeListings(kubeListings []kubeListing, format string) (string, error) {

--- a/tool/tsh/common/kube_proxy.go
+++ b/tool/tsh/common/kube_proxy.go
@@ -293,7 +293,7 @@ func (c *proxyKubeCommand) printPrepare(cf *CLIConf, title string, clusters kube
 		}
 		table.AddRow([]string{cluster.TeleportCluster, cluster.KubeCluster, contextName})
 	}
-	fmt.Fprintln(cf.Stdout(), table.AsBuffer().String())
+	table.WriteTo(cf.Stdout())
 }
 
 func (c *proxyKubeCommand) printTemplate(w io.Writer, isReexec bool, localProxy *kubeLocalProxy) error {

--- a/tool/tsh/common/kube_proxy.go
+++ b/tool/tsh/common/kube_proxy.go
@@ -294,6 +294,7 @@ func (c *proxyKubeCommand) printPrepare(cf *CLIConf, title string, clusters kube
 		table.AddRow([]string{cluster.TeleportCluster, cluster.KubeCluster, contextName})
 	}
 	table.WriteTo(cf.Stdout())
+	fmt.Fprintln(cf.Stdout())
 }
 
 func (c *proxyKubeCommand) printTemplate(w io.Writer, isReexec bool, localProxy *kubeLocalProxy) error {

--- a/tool/tsh/common/kube_test.go
+++ b/tool/tsh/common/kube_test.go
@@ -215,7 +215,7 @@ func (p *kubeTestPack) testListKube(t *testing.T) {
 						{p.rootKubeCluster1, formattedRootLabels, "", ""},
 					},
 					"Labels")
-				return table.AsBuffer().String()
+				return table.String()
 			},
 		},
 		{
@@ -226,7 +226,7 @@ func (p *kubeTestPack) testListKube(t *testing.T) {
 					[]string{"Kube Cluster Name", "Labels", "Scope", "Selected"},
 					[]string{p.rootKubeCluster2, formattedRootLabelsVerbose, "", ""},
 					[]string{p.rootKubeCluster1, formattedRootLabelsVerbose, "", ""})
-				return table.AsBuffer().String()
+				return table.String()
 			},
 		},
 		{
@@ -237,7 +237,7 @@ func (p *kubeTestPack) testListKube(t *testing.T) {
 				table.AddRow([]string{p.rootKubeCluster2, formattedRootLabels, ""})
 				table.AddRow([]string{p.rootKubeCluster1, formattedRootLabels, ""})
 
-				return table.AsBuffer().String()
+				return table.String()
 			},
 		},
 		{
@@ -257,7 +257,7 @@ func (p *kubeTestPack) testListKube(t *testing.T) {
 					},
 					"Labels",
 				)
-				return table.AsBuffer().String()
+				return table.String()
 			},
 		},
 		{
@@ -270,7 +270,7 @@ func (p *kubeTestPack) testListKube(t *testing.T) {
 					[]string{p.root.Config.Proxy.WebAddr.String(), "root", p.rootKubeCluster2, formattedRootLabelsVerbose, ""},
 					[]string{p.root.Config.Proxy.WebAddr.String(), "root", p.rootKubeCluster1, formattedRootLabelsVerbose, ""},
 				)
-				return table.AsBuffer().String()
+				return table.String()
 			},
 		},
 		{
@@ -281,7 +281,7 @@ func (p *kubeTestPack) testListKube(t *testing.T) {
 				table.AddRow([]string{p.root.Config.Proxy.WebAddr.String(), "leaf1", "leaf-cluster", formattedLeafLabels, ""})
 				table.AddRow([]string{p.root.Config.Proxy.WebAddr.String(), "root", p.rootKubeCluster2, formattedRootLabels, ""})
 				table.AddRow([]string{p.root.Config.Proxy.WebAddr.String(), "root", p.rootKubeCluster1, formattedRootLabels, ""})
-				return table.AsBuffer().String()
+				return table.String()
 			},
 		},
 	}

--- a/tool/tsh/common/mfa.go
+++ b/tool/tsh/common/mfa.go
@@ -177,7 +177,7 @@ func printMFADevices(devs []*types.MFADevice, verbose bool) {
 				dev.LastUsed.Format(time.RFC1123),
 			})
 		}
-		fmt.Println(t.AsBuffer().String())
+		t.WriteTo(os.Stdout)
 	} else {
 		t := asciitable.MakeTable([]string{"Name", "Type", "Added at", "Last used"})
 		for _, dev := range devs {
@@ -188,7 +188,7 @@ func printMFADevices(devs []*types.MFADevice, verbose bool) {
 				dev.LastUsed.Format(time.RFC1123),
 			})
 		}
-		fmt.Println(t.AsBuffer().String())
+		t.WriteTo(os.Stdout)
 	}
 }
 

--- a/tool/tsh/common/mfa.go
+++ b/tool/tsh/common/mfa.go
@@ -178,6 +178,7 @@ func printMFADevices(devs []*types.MFADevice, verbose bool) {
 			})
 		}
 		t.WriteTo(os.Stdout)
+		fmt.Fprintln(os.Stdout)
 	} else {
 		t := asciitable.MakeTable([]string{"Name", "Type", "Added at", "Last used"})
 		for _, dev := range devs {
@@ -189,6 +190,7 @@ func printMFADevices(devs []*types.MFADevice, verbose bool) {
 			})
 		}
 		t.WriteTo(os.Stdout)
+		fmt.Fprintln(os.Stdout)
 	}
 }
 

--- a/tool/tsh/common/scopes.go
+++ b/tool/tsh/common/scopes.go
@@ -136,7 +136,7 @@ func (c *scopesLSCommand) run(cf *CLIConf) error {
 			})
 		}
 
-		fmt.Fprint(cf.Stdout(), table.AsBuffer().String())
+		table.WriteTo(cf.Stdout())
 		return nil
 	}
 

--- a/tool/tsh/common/testdata/TestPrintNodesAsText/mixed_scoped_and_unscoped_verbose.golden
+++ b/tool/tsh/common/testdata/TestPrintNodesAsText/mixed_scoped_and_unscoped_verbose.golden
@@ -4,4 +4,3 @@ Scope         Node Name            Node ID              Address    Labels
 /staging/west scoped-direct-name   scoped-direct-uuid   1.2.3.4:44 key1=val1,key2=val2 
               unscoped-tunnel-name unscoped-tunnel-uuid ⟵ Tunnel                       
 /staging/west scoped-tunnel-name   scoped-tunnel-uuid   ⟵ Tunnel                       
-

--- a/tool/tsh/common/testdata/TestPrintNodesAsText/mixed_scoped_and_unscoped_verbose.golden
+++ b/tool/tsh/common/testdata/TestPrintNodesAsText/mixed_scoped_and_unscoped_verbose.golden
@@ -4,3 +4,4 @@ Scope         Node Name            Node ID              Address    Labels
 /staging/west scoped-direct-name   scoped-direct-uuid   1.2.3.4:44 key1=val1,key2=val2 
               unscoped-tunnel-name unscoped-tunnel-uuid ⟵ Tunnel                       
 /staging/west scoped-tunnel-name   scoped-tunnel-uuid   ⟵ Tunnel                       
+

--- a/tool/tsh/common/testdata/TestPrintNodesAsText/non-verbose_scoped.golden
+++ b/tool/tsh/common/testdata/TestPrintNodesAsText/non-verbose_scoped.golden
@@ -2,3 +2,4 @@ Scope         Node Name          Address    Labels
 ------------- ------------------ ---------- ------------------- 
 /staging/west scoped-direct-name 1.2.3.4:44 key1=val1,key2=val2 
 /staging/west scoped-tunnel-name ⟵ Tunnel                       
+

--- a/tool/tsh/common/testdata/TestPrintNodesAsText/non-verbose_scoped.golden
+++ b/tool/tsh/common/testdata/TestPrintNodesAsText/non-verbose_scoped.golden
@@ -2,4 +2,3 @@ Scope         Node Name          Address    Labels
 ------------- ------------------ ---------- ------------------- 
 /staging/west scoped-direct-name 1.2.3.4:44 key1=val1,key2=val2 
 /staging/west scoped-tunnel-name ⟵ Tunnel                       
-

--- a/tool/tsh/common/testdata/TestPrintNodesAsText/non-verbose_unscoped.golden
+++ b/tool/tsh/common/testdata/TestPrintNodesAsText/non-verbose_unscoped.golden
@@ -2,4 +2,3 @@ Node Name            Address    Labels
 -------------------- ---------- ------- 
 unscoped-direct-name 1.2.3.4:22 key=val 
 unscoped-tunnel-name ⟵ Tunnel           
-

--- a/tool/tsh/common/testdata/TestPrintNodesAsText/non-verbose_unscoped.golden
+++ b/tool/tsh/common/testdata/TestPrintNodesAsText/non-verbose_unscoped.golden
@@ -2,3 +2,4 @@ Node Name            Address    Labels
 -------------------- ---------- ------- 
 unscoped-direct-name 1.2.3.4:22 key=val 
 unscoped-tunnel-name ⟵ Tunnel           
+

--- a/tool/tsh/common/testdata/TestPrintNodesAsText/verbose_scoped.golden
+++ b/tool/tsh/common/testdata/TestPrintNodesAsText/verbose_scoped.golden
@@ -2,4 +2,3 @@ Scope         Node Name          Node ID            Address    Labels
 ------------- ------------------ ------------------ ---------- ------------------- 
 /staging/west scoped-direct-name scoped-direct-uuid 1.2.3.4:44 key1=val1,key2=val2 
 /staging/west scoped-tunnel-name scoped-tunnel-uuid ⟵ Tunnel                       
-

--- a/tool/tsh/common/testdata/TestPrintNodesAsText/verbose_scoped.golden
+++ b/tool/tsh/common/testdata/TestPrintNodesAsText/verbose_scoped.golden
@@ -2,3 +2,4 @@ Scope         Node Name          Node ID            Address    Labels
 ------------- ------------------ ------------------ ---------- ------------------- 
 /staging/west scoped-direct-name scoped-direct-uuid 1.2.3.4:44 key1=val1,key2=val2 
 /staging/west scoped-tunnel-name scoped-tunnel-uuid ⟵ Tunnel                       
+

--- a/tool/tsh/common/testdata/TestPrintNodesAsText/verbose_unscoped.golden
+++ b/tool/tsh/common/testdata/TestPrintNodesAsText/verbose_unscoped.golden
@@ -2,4 +2,3 @@ Node Name            Node ID              Address    Labels
 -------------------- -------------------- ---------- ------- 
 unscoped-direct-name unscoped-direct-uuid 1.2.3.4:22 key=val 
 unscoped-tunnel-name unscoped-tunnel-uuid ⟵ Tunnel           
-

--- a/tool/tsh/common/testdata/TestPrintNodesAsText/verbose_unscoped.golden
+++ b/tool/tsh/common/testdata/TestPrintNodesAsText/verbose_unscoped.golden
@@ -2,3 +2,4 @@ Node Name            Node ID              Address    Labels
 -------------------- -------------------- ---------- ------- 
 unscoped-direct-name unscoped-direct-uuid 1.2.3.4:22 key=val 
 unscoped-tunnel-name unscoped-tunnel-uuid ⟵ Tunnel           
+

--- a/tool/tsh/common/tsh.go
+++ b/tool/tsh/common/tsh.go
@@ -3214,6 +3214,7 @@ func printNodesWithClusters(nodes []nodeListing, verbose bool, output io.Writer)
 	if err := t.WriteTo(output); err != nil {
 		return trace.Wrap(err)
 	}
+	fmt.Fprintln(output)
 	return nil
 }
 
@@ -3482,6 +3483,7 @@ func printNodesAsText[T types.Server](output io.Writer, nodes []T, verbose bool)
 	if err := t.WriteTo(output); err != nil {
 		return trace.Wrap(err)
 	}
+	fmt.Fprintln(output)
 
 	return nil
 }
@@ -3645,8 +3647,11 @@ func writeAppTable(w io.Writer, appListings []appListing, config appTableConfig)
 		t = asciitable.MakeTableWithTruncatedColumn(headers, rows, labelsColumn)
 	}
 
-	err := t.WriteTo(w)
-	return trace.Wrap(err)
+	if err := t.WriteTo(w); err != nil {
+		return trace.Wrap(err)
+	}
+	fmt.Fprintln(w)
+	return nil
 }
 
 type appTableColumn struct {
@@ -3982,6 +3987,7 @@ func onListClusters(cf *CLIConf) error {
 		if err := t.WriteTo(cf.Stdout()); err != nil {
 			return trace.Wrap(err)
 		}
+		fmt.Fprintln(cf.Stdout())
 	case teleport.JSON, teleport.YAML:
 		rootClusterInfo := clusterInfo{
 			ClusterName: rootClusterName,

--- a/tool/tsh/common/tsh.go
+++ b/tool/tsh/common/tsh.go
@@ -3211,7 +3211,7 @@ func printNodesWithClusters(nodes []nodeListing, verbose bool, output io.Writer)
 			t = asciitable.MakeTableWithTruncatedColumn([]string{"Proxy", "Cluster", "Node Name", "Address", "Labels"}, rows, "Labels")
 		}
 	}
-	if _, err := fmt.Fprintln(output, t.AsBuffer().String()); err != nil {
+	if err := t.WriteTo(output); err != nil {
 		return trace.Wrap(err)
 	}
 	return nil
@@ -3479,7 +3479,7 @@ func printNodesAsText[T types.Server](output io.Writer, nodes []T, verbose bool)
 			t = asciitable.MakeTableWithTruncatedColumn([]string{"Node Name", "Address", "Labels"}, rows, "Labels")
 		}
 	}
-	if _, err := fmt.Fprintln(output, t.AsBuffer().String()); err != nil {
+	if err := t.WriteTo(output); err != nil {
 		return trace.Wrap(err)
 	}
 
@@ -3645,7 +3645,7 @@ func writeAppTable(w io.Writer, appListings []appListing, config appTableConfig)
 		t = asciitable.MakeTableWithTruncatedColumn(headers, rows, labelsColumn)
 	}
 
-	_, err := fmt.Fprintln(w, t.AsBuffer().String())
+	err := t.WriteTo(w)
 	return trace.Wrap(err)
 }
 
@@ -3979,7 +3979,9 @@ func onListClusters(cf *CLIConf) error {
 			t = asciitable.MakeTableWithTruncatedColumn(header, rows, "Labels")
 		}
 
-		fmt.Println(t.AsBuffer().String())
+		if err := t.WriteTo(cf.Stdout()); err != nil {
+			return trace.Wrap(err)
+		}
 	case teleport.JSON, teleport.YAML:
 		rootClusterInfo := clusterInfo{
 			ClusterName: rootClusterName,
@@ -4091,7 +4093,7 @@ func printSessions(output io.Writer, sessions []types.SessionTracker) {
 		})
 	}
 
-	tableOutput := table.AsBuffer().String()
+	tableOutput := table.String()
 	fmt.Fprintln(output, tableOutput)
 }
 
@@ -4699,7 +4701,7 @@ func onBenchmark(cf *CLIConf, suite benchmark.Suite) error {
 			fmt.Sprintf("%v ms", result.Histogram.ValueAtQuantile(quantile)),
 		})
 	}
-	if _, err := io.Copy(cf.Stdout(), t.AsBuffer()); err != nil {
+	if err := t.WriteTo(cf.Stdout()); err != nil {
 		return trace.Wrap(err)
 	}
 	fmt.Fprintf(cf.Stdout(), "\n")


### PR DESCRIPTION
Whilst reviewing a PR, I noticed a call to `table.AsBuffer().String()` and investigated a little deeper and discovered the `WriteTo()` and `String()` methods. Calling `WriteTo()` instead of `AsBuffer().String()` avoids creating a copy of the table data unnecessarily - although since this code is primarily used in CLIs, the actual impact here is minimal.

It looks like when we introduced the `WriteTo` and `String` methods, we recorded a TODO note to remove the `AsBuffer()` method.

Whilst working on some other bits, I spun Claude on a worktree to generate this PR to see what this change would look like.



<!-- Provide a descriptive entry for the changelog of the next release. -->

Changelog:


<!-- Include manual testing efforts to verify the change. -->
<!-- Detail where the tests where run and what configurations were used. -->
<!-- Include all the test cases which were run to validate the change. -->

## Manual Test Plan
### Test Environment

### Test Cases
- [ ] 
