### PR TITLE
tctl: add YAML parity for structured output commands

### DIFF
--- a/docs/pages/reference/cli/tctl.mdx
+++ b/docs/pages/reference/cli/tctl.mdx
@@ -2623,7 +2623,6 @@ Flags:
 |Flag|Default|Description|
 |---|---|---|
 |`-f`, `--[no-]force`|`false`|Overwrite the existing override if it exists.|
-|`--format`|`yaml` (one of: `yaml`, `json`)|Output format for --dry-run, 'yaml' or 'json'.|
 |`--name`|`default`|The name of the override resource to write.|
 |`--[no-]dry-run`|`false`|Print the workload_identity_x509_issuer_override that would have been created, without actually creating it.|
 

--- a/docs/pages/reference/cli/tctl.mdx
+++ b/docs/pages/reference/cli/tctl.mdx
@@ -192,7 +192,7 @@ Flags:
 
 |Flag|Default|Description|
 |---|---|---|
-|`--format`|`text` (one of: `json`, `text`)|Output format.|
+|`--format`|`text` (one of: `json`, `yaml`, `text`)|Output format.|
 
 Arguments:
 
@@ -781,7 +781,7 @@ Flags:
 
 |Flag|Default|Description|
 |---|---|---|
-|`--format`|`text` (one of: `text`, `json`)|Output format.|
+|`--format`|`text` (one of: `text`, `json`, `yaml`)|Output format.|
 |`--initial-public-key`|*no default*|If set, use the given initial public key in SSH authorized_keys format, instead of generating a registration secret. The value must be quoted. Not compatible with --token or --legacy.|
 |`--logins`|*no default*|List of allowed SSH logins for the bot user|
 |`--max-session-ttl`|*no default*|Set a max session TTL for the bot's internal identity. 12h default, 168h maximum.|
@@ -813,7 +813,7 @@ Flags:
 
 |Flag|Default|Description|
 |---|---|---|
-|`--format`|`text` (one of: `text`, `json`)|Output format.|
+|`--format`|`text` (one of: `text`, `json`, `yaml`)|Output format.|
 |`--initial-public-key`|*no default*|If set, use the given initial public key in SSH authorized_keys format, instead of generating a registration secret. The value must be quoted. Not compatible with --token or --legacy.|
 |`--[no-]legacy`|`false`|If set, generate a legacy joining token instead of a bound keypair token. No effect if --token is set.|
 |`--recovery-limit`|*no default*|Overrides the recovery limit (default: 1) for the bound keypair token. No effect if --token or --legacy is set, or if --recovery-mode is not standard. Must be greater than 1.|
@@ -842,7 +842,7 @@ Flags:
 
 |Flag|Default|Description|
 |---|---|---|
-|`--format`|`text` (one of: `text`, `json`)|Output format.|
+|`--format`|`text` (one of: `text`, `json`, `yaml`)|Output format.|
 |`--query`|*no default*|An expression in the Teleport predicate language used to filter bot instances|
 |`--search`|*no default*|Fuzzy search query used to filter bot instances|
 |`--sort-index`|`bot_name`|Request sort index, 'bot_name', 'active_at_latest', 'version_latest' or 'host_name_latest'|
@@ -1123,7 +1123,7 @@ Flags:
 |Flag|Default|Description|
 |---|---|---|
 |`--cloud`|``|Comma-separated list of cloud providers to include (allowed: aws, azure). Empty (default) returns all.|
-|`--format`|`text` (one of: `text`, `json`)|Output format.|
+|`--format`|`text` (one of: `text`, `json`, `yaml`)|Output format.|
 |`--last`|`1h`|Time window to look back for failures in Teleport audit log (e.g. 1h, 24h, 30m).|
 |`--[no-]failures-only`|`false`|Only show instances with enrollment failures.|
 
@@ -1216,7 +1216,7 @@ Flags:
 |Flag|Default|Description|
 |---|---|---|
 |`--exact-version`|*no default*|Filter output by teleport version|
-|`--format`|`text`|Output format, 'text' or 'json'|
+|`--format`|`text` (one of: `text`, `json`)|Output format, 'text' or 'json'|
 |`--newer-than`|*no default*|Filter for newer teleport versions|
 |`--older-than`|*no default*|Filter for older teleport versions|
 |`--services`|*no default*|Filter output by service (node,kube,proxy,etc)|
@@ -1253,7 +1253,7 @@ Flags:
 
 |Flag|Default|Description|
 |---|---|---|
-|`--format`|`text`|Output format, 'text' or 'json'|
+|`--format`|`text` (one of: `text`, `json`, `yaml`)|Output format, 'text', 'json', or 'yaml'|
 |`--[no-]connected`|`false`|Show locally connected instances summary|
 
 ## tctl kube ls
@@ -1382,7 +1382,7 @@ Flags:
 
 |Flag|Default|Description|
 |---|---|---|
-|`--format`|`text`|Output format, 'text', or 'yaml'|
+|`--format`|`text` (one of: `text`, `json`, `yaml`)|Output format, 'text', 'json', or 'yaml'|
 |`--query`|*no default*|Query by predicate language enclosed in single quotes. Supports ==, !=, &&, and \|\| (e.g. --query='labels\["key1"\] == "value1" && labels\["key2"\] != "value2"')|
 |`--search`|*no default*|List of comma separated search keywords or phrases enclosed in quotations (e.g. --search=foo,bar,"some phrase")|
 |`-v`, `--[no-]verbose`|`false`|Verbose table output, shows full label output|
@@ -2623,6 +2623,7 @@ Flags:
 |Flag|Default|Description|
 |---|---|---|
 |`-f`, `--[no-]force`|`false`|Overwrite the existing override if it exists.|
+|`--format`|`yaml` (one of: `yaml`, `json`)|Output format for --dry-run, 'yaml' or 'json'.|
 |`--name`|`default`|The name of the override resource to write.|
 |`--[no-]dry-run`|`false`|Print the workload_identity_x509_issuer_override that would have been created, without actually creating it.|
 

--- a/tool/tctl/common/access_request_command.go
+++ b/tool/tctl/common/access_request_command.go
@@ -39,6 +39,7 @@ import (
 	"github.com/gravitational/teleport/lib/service/servicecfg"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/tlsca"
+	"github.com/gravitational/teleport/lib/utils"
 	"github.com/gravitational/teleport/tool/common"
 	commonclient "github.com/gravitational/teleport/tool/tctl/common/client"
 	tctlcfg "github.com/gravitational/teleport/tool/tctl/common/config"
@@ -84,13 +85,13 @@ func (c *AccessRequestCommand) Initialize(app *kingpin.Application, _ *tctlcfg.G
 	requests := app.Command("requests", "Manage Access Requests.").Alias("request")
 
 	c.requestList = requests.Command("ls", "Show active Access Requests.")
-	c.requestList.Flag("format", "Output format, 'text' or 'json'").Hidden().Default(teleport.Text).StringVar(&c.format)
+	c.requestList.Flag("format", "Output format, 'text', 'json', or 'yaml'").Hidden().Default(teleport.Text).EnumVar(&c.format, teleport.Text, teleport.JSON, teleport.YAML)
 	c.requestList.Flag("sort-index", "Request sort index, 'created' or 'state'").Default("created").StringVar(&c.sortIndex)
 	c.requestList.Flag("sort-order", "Request sort order, 'ascending' or 'descending'").Default("descending").StringVar(&c.sortOrder)
 
 	c.requestGet = requests.Command("get", "Show Access Request by ID.")
 	c.requestGet.Arg("request-id", "ID of target request(s)").Required().StringVar(&c.reqIDs)
-	c.requestGet.Flag("format", "Output format, 'text' or 'json'").Hidden().Default(teleport.Text).StringVar(&c.format)
+	c.requestGet.Flag("format", "Output format, 'text', 'json', or 'yaml'").Hidden().Default(teleport.Text).EnumVar(&c.format, teleport.Text, teleport.JSON, teleport.YAML)
 
 	c.requestApprove = requests.Command("approve", "Approve pending Access Request.")
 	c.requestApprove.Arg("request-id", "ID of target request(s)").Required().StringVar(&c.reqIDs)
@@ -119,7 +120,7 @@ func (c *AccessRequestCommand) Initialize(app *kingpin.Application, _ *tctlcfg.G
 
 	c.requestCaps = requests.Command("capabilities", "Check a user's access capabilities.").Alias("caps").Hidden()
 	c.requestCaps.Arg("username", "Name of target user").Required().StringVar(&c.user)
-	c.requestCaps.Flag("format", "Output format, 'text' or 'json'").Hidden().Default(teleport.Text).StringVar(&c.format)
+	c.requestCaps.Flag("format", "Output format, 'text', 'json', or 'yaml'").Hidden().Default(teleport.Text).EnumVar(&c.format, teleport.Text, teleport.JSON, teleport.YAML)
 	c.requestReview = requests.Command("review", "Review an Access Request.")
 	c.requestReview.Arg("request-id", "ID of target request").Required().StringVar(&c.reqIDs)
 	c.requestReview.Flag("author", "Username of reviewer").Required().StringVar(&c.user)
@@ -418,8 +419,10 @@ func (c *AccessRequestCommand) Caps(ctx context.Context, client *authclient.Clie
 		return trace.Wrap(err)
 	case teleport.JSON:
 		return printJSON(caps, "capabilities")
+	case teleport.YAML:
+		return trace.Wrap(utils.WriteYAML(os.Stdout, caps), "failed to marshal capabilities")
 	default:
-		return trace.BadParameter("unknown format %q, must be one of [%q, %q]", c.format, teleport.Text, teleport.JSON)
+		return trace.BadParameter("unknown format %q, must be one of [%q, %q, %q]", c.format, teleport.Text, teleport.JSON, teleport.YAML)
 	}
 }
 
@@ -511,8 +514,10 @@ func printRequestsOverview(reqs []types.AccessRequest, format string) error {
 		return trace.Wrap(err)
 	case teleport.JSON:
 		return printJSON(reqs, "requests")
+	case teleport.YAML:
+		return trace.Wrap(utils.WriteYAML(os.Stdout, reqs), "failed to marshal requests")
 	default:
-		return trace.BadParameter("unknown format %q, must be one of [%q, %q]", format, teleport.Text, teleport.JSON)
+		return trace.BadParameter("unknown format %q, must be one of [%q, %q, %q]", format, teleport.Text, teleport.JSON, teleport.YAML)
 	}
 }
 
@@ -547,8 +552,10 @@ func printRequestsDetailed(reqs []types.AccessRequest, format string) error {
 		return nil
 	case teleport.JSON:
 		return printJSON(reqs, "requests")
+	case teleport.YAML:
+		return trace.Wrap(utils.WriteYAML(os.Stdout, reqs), "failed to marshal requests")
 	default:
-		return trace.BadParameter("unknown format %q, must be one of [%q, %q]", format, teleport.Text, teleport.JSON)
+		return trace.BadParameter("unknown format %q, must be one of [%q, %q, %q]", format, teleport.Text, teleport.JSON, teleport.YAML)
 	}
 }
 

--- a/tool/tctl/common/access_request_command.go
+++ b/tool/tctl/common/access_request_command.go
@@ -20,7 +20,6 @@ package common
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"os"
 	"strings"
@@ -338,7 +337,7 @@ func (c *AccessRequestCommand) Create(ctx context.Context, client *authclient.Cl
 		if err != nil {
 			return trace.Wrap(err)
 		}
-		return trace.Wrap(printJSON(req, "request"))
+		return trace.Wrap(utils.WriteJSON(os.Stdout, req), "failed to marshal request")
 	}
 	req, err = client.CreateAccessRequestV2(ctx, req)
 	if err != nil {
@@ -418,7 +417,7 @@ func (c *AccessRequestCommand) Caps(ctx context.Context, client *authclient.Clie
 		_, err := table.AsBuffer().WriteTo(os.Stdout)
 		return trace.Wrap(err)
 	case teleport.JSON:
-		return printJSON(caps, "capabilities")
+		return trace.Wrap(utils.WriteJSON(os.Stdout, caps), "failed to marshal capabilities")
 	case teleport.YAML:
 		return trace.Wrap(utils.WriteYAML(os.Stdout, caps), "failed to marshal capabilities")
 	default:
@@ -513,7 +512,7 @@ func printRequestsOverview(reqs []types.AccessRequest, format string) error {
 		_, err := table.AsBuffer().WriteTo(os.Stdout)
 		return trace.Wrap(err)
 	case teleport.JSON:
-		return printJSON(reqs, "requests")
+		return trace.Wrap(utils.WriteJSONArray(os.Stdout, reqs), "failed to marshal requests")
 	case teleport.YAML:
 		return trace.Wrap(utils.WriteYAML(os.Stdout, reqs), "failed to marshal requests")
 	default:
@@ -551,21 +550,12 @@ func printRequestsDetailed(reqs []types.AccessRequest, format string) error {
 		}
 		return nil
 	case teleport.JSON:
-		return printJSON(reqs, "requests")
+		return trace.Wrap(utils.WriteJSONArray(os.Stdout, reqs), "failed to marshal requests")
 	case teleport.YAML:
 		return trace.Wrap(utils.WriteYAML(os.Stdout, reqs), "failed to marshal requests")
 	default:
 		return trace.BadParameter("unknown format %q", format)
 	}
-}
-
-func printJSON(in any, desc string) error {
-	out, err := json.MarshalIndent(in, "", "  ")
-	if err != nil {
-		return trace.Wrap(err, fmt.Sprintf("failed to marshal %v", desc))
-	}
-	fmt.Printf("%s\n", out)
-	return nil
 }
 
 func quoteOrDefault(s, d string) string {

--- a/tool/tctl/common/access_request_command.go
+++ b/tool/tctl/common/access_request_command.go
@@ -422,7 +422,7 @@ func (c *AccessRequestCommand) Caps(ctx context.Context, client *authclient.Clie
 	case teleport.YAML:
 		return trace.Wrap(utils.WriteYAML(os.Stdout, caps), "failed to marshal capabilities")
 	default:
-		return trace.BadParameter("unknown format %q, must be one of [%q, %q, %q]", c.format, teleport.Text, teleport.JSON, teleport.YAML)
+		return trace.BadParameter("unknown format %q", c.format)
 	}
 }
 
@@ -517,7 +517,7 @@ func printRequestsOverview(reqs []types.AccessRequest, format string) error {
 	case teleport.YAML:
 		return trace.Wrap(utils.WriteYAML(os.Stdout, reqs), "failed to marshal requests")
 	default:
-		return trace.BadParameter("unknown format %q, must be one of [%q, %q, %q]", format, teleport.Text, teleport.JSON, teleport.YAML)
+		return trace.BadParameter("unknown format %q", format)
 	}
 }
 
@@ -555,7 +555,7 @@ func printRequestsDetailed(reqs []types.AccessRequest, format string) error {
 	case teleport.YAML:
 		return trace.Wrap(utils.WriteYAML(os.Stdout, reqs), "failed to marshal requests")
 	default:
-		return trace.BadParameter("unknown format %q, must be one of [%q, %q, %q]", format, teleport.Text, teleport.JSON, teleport.YAML)
+		return trace.BadParameter("unknown format %q", format)
 	}
 }
 

--- a/tool/tctl/common/acl_command.go
+++ b/tool/tctl/common/acl_command.go
@@ -118,7 +118,7 @@ func (c *ACLCommand) Initialize(app *kingpin.Application, _ *tctlcfg.GlobalCLIFl
 
 	c.usersList = users.Command("ls", "List users that are members of an Access List.")
 	c.usersList.Arg("access-list-name", "The Access List name.").Required().StringVar(&c.accessListName)
-	c.usersList.Flag("format", "Output format.").Default(teleport.Text).EnumVar(&c.format, teleport.JSON, teleport.Text)
+	c.usersList.Flag("format", "Output format.").Default(teleport.Text).EnumVar(&c.format, teleport.JSON, teleport.YAML, teleport.Text)
 
 	reviews := acl.Command("reviews", "Manage access list reviews.")
 
@@ -320,6 +320,8 @@ func (c *ACLCommand) UsersList(ctx context.Context, client *authclient.Client) e
 	switch c.format {
 	case teleport.JSON:
 		return trace.Wrap(utils.WriteJSONArray(c.Stdout, allMembers))
+	case teleport.YAML:
+		return trace.Wrap(utils.WriteYAML(c.Stdout, allMembers))
 	case teleport.Text:
 		if len(allMembers) == 0 {
 			fmt.Fprintf(c.Stdout, "No members found for access list %s", c.accessListName)

--- a/tool/tctl/common/bots_command.go
+++ b/tool/tctl/common/bots_command.go
@@ -301,7 +301,7 @@ func (c *BotsCommand) ListBots(ctx context.Context, client botsCommandClient) er
 			return trace.Wrap(err, "failed to marshal bots")
 		}
 	default:
-		return trace.BadParameter("unknown format %q, must be one of [%q, %q, %q]", c.format, teleport.Text, teleport.JSON, teleport.YAML)
+		return trace.BadParameter("unknown format %q", c.format)
 	}
 	return nil
 }
@@ -805,7 +805,7 @@ func (c *BotsCommand) ListBotInstances(ctx context.Context, client botsCommandCl
 		return nil
 	case teleport.Text:
 	default:
-		return trace.BadParameter("unknown format %q, must be one of [%q, %q, %q]", c.format, teleport.Text, teleport.JSON, teleport.YAML)
+		return trace.BadParameter("unknown format %q", c.format)
 	}
 
 	if len(instances) == 0 {
@@ -1112,7 +1112,7 @@ func (c *BotsCommand) outputToken(
 		return trace.Wrap(utils.WriteYAML(c.stdout, response), "failed to marshal CreateBot response")
 	case teleport.Text:
 	default:
-		return trace.BadParameter("unknown format %q, must be one of [%q, %q, %q]", c.format, teleport.Text, teleport.JSON, teleport.YAML)
+		return trace.BadParameter("unknown format %q", c.format)
 	}
 
 	if c.legacy {

--- a/tool/tctl/common/bots_command.go
+++ b/tool/tctl/common/bots_command.go
@@ -21,7 +21,6 @@ package common
 import (
 	"cmp"
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -117,7 +116,7 @@ type BotsCommand struct {
 // `bot instances add`
 func (c *BotsCommand) initSharedBotTokenFlags(cmd *kingpin.CmdClause) {
 	cmd.Flag("token", "The token to use, if any. If unset, a new single-use token will be created.").StringVar(&c.tokenID)
-	cmd.Flag("format", "Output format.").Default(teleport.Text).EnumVar(&c.format, teleport.Text, teleport.JSON)
+	cmd.Flag("format", "Output format.").Default(teleport.Text).EnumVar(&c.format, teleport.Text, teleport.JSON, teleport.YAML)
 
 	// TODO(timothyb89): Remove in v20 (optional)
 	cmd.Flag("legacy", "If set, generate a legacy joining token instead of a bound keypair token. No effect if --token is set.").BoolVar(&c.legacy)
@@ -157,7 +156,7 @@ func (c *BotsCommand) Initialize(app *kingpin.Application, _ *tctlcfg.GlobalCLIF
 	bots := app.Command("bots", "Manage Machine & Workload Identity bots on the cluster.").Alias("bot")
 
 	c.botsList = bots.Command("ls", "List all certificate renewal bots registered with the cluster.")
-	c.botsList.Flag("format", "Output format.").Hidden().Default(teleport.Text).EnumVar(&c.format, teleport.Text, teleport.JSON)
+	c.botsList.Flag("format", "Output format.").Hidden().Default(teleport.Text).EnumVar(&c.format, teleport.Text, teleport.JSON, teleport.YAML)
 
 	c.botsAdd = bots.Command("add", "Add a new bot to the cluster.")
 	c.botsAdd.Arg("name", "A name to uniquely identify this bot in the cluster.").Required().StringVar(&c.botName)
@@ -190,7 +189,7 @@ func (c *BotsCommand) Initialize(app *kingpin.Application, _ *tctlcfg.GlobalCLIF
 
 	c.botsInstancesList = c.botsInstances.Command("list", "List bot instances.").Alias("ls")
 	c.botsInstancesList.Arg("name", "The name of the bot from which to list instances. If unset, lists instances from all bots.").StringVar(&c.botName)
-	c.botsInstancesList.Flag("format", "Output format.").Default(teleport.Text).EnumVar(&c.format, teleport.Text, teleport.JSON)
+	c.botsInstancesList.Flag("format", "Output format.").Default(teleport.Text).EnumVar(&c.format, teleport.Text, teleport.JSON, teleport.YAML)
 	c.botsInstancesList.Flag("search", "Fuzzy search query used to filter bot instances").StringVar(&c.search)
 	c.botsInstancesList.Flag("query", "An expression in the Teleport predicate language used to filter bot instances").StringVar(&c.query)
 	c.botsInstancesList.Flag("sort-index", "Request sort index, 'bot_name', 'active_at_latest', 'version_latest' or 'host_name_latest'").Default("bot_name").StringVar(&c.sortIndex)
@@ -275,7 +274,8 @@ func (c *BotsCommand) ListBots(ctx context.Context, client botsCommandClient) er
 		req.PageToken = resp.NextPageToken
 	}
 
-	if c.format == teleport.Text {
+	switch c.format {
+	case teleport.Text:
 		if len(bots) == 0 {
 			fmt.Fprintln(c.stdout, "No bots found")
 			return nil
@@ -290,11 +290,18 @@ func (c *BotsCommand) ListBots(ctx context.Context, client botsCommandClient) er
 
 		executableFileName := filepath.Base(os.Args[0])
 		fmt.Fprintf(c.stdout, "\nTo view active instances of a bot, run:\n\n> %s bots instances list [name]\n", executableFileName)
-	} else {
+	case teleport.JSON:
 		err := utils.WriteJSONArray(c.stdout, bots)
 		if err != nil {
 			return trace.Wrap(err, "failed to marshal bots")
 		}
+	case teleport.YAML:
+		err := utils.WriteYAML(c.stdout, bots)
+		if err != nil {
+			return trace.Wrap(err, "failed to marshal bots")
+		}
+	default:
+		return trace.BadParameter("unknown format %q, must be one of [%q, %q, %q]", c.format, teleport.Text, teleport.JSON, teleport.YAML)
 	}
 	return nil
 }
@@ -773,7 +780,8 @@ func (c *BotsCommand) ListBotInstances(ctx context.Context, client botsCommandCl
 		return trace.Wrap(err)
 	}
 
-	if c.format == teleport.JSON {
+	switch c.format {
+	case teleport.JSON, teleport.YAML:
 		// Wrap resource type so the correct protojson marshaling is used for
 		// timestamp fields.
 		wrappedInstances := make([]types.Resource, 0, len(instances))
@@ -782,12 +790,22 @@ func (c *BotsCommand) ListBotInstances(ctx context.Context, client botsCommandCl
 				wrappedInstances, types.ProtoResource153ToLegacy(instance),
 			)
 		}
-		err := utils.WriteJSONArray(c.stdout, wrappedInstances)
-		if err != nil {
-			return trace.Wrap(err, "failed to marshal bot instances")
+		if c.format == teleport.JSON {
+			err := utils.WriteJSONArray(c.stdout, wrappedInstances)
+			if err != nil {
+				return trace.Wrap(err, "failed to marshal bot instances")
+			}
+		} else {
+			err := utils.WriteYAML(c.stdout, wrappedInstances)
+			if err != nil {
+				return trace.Wrap(err, "failed to marshal bot instances")
+			}
 		}
 
 		return nil
+	case teleport.Text:
+	default:
+		return trace.BadParameter("unknown format %q, must be one of [%q, %q, %q]", c.format, teleport.Text, teleport.JSON, teleport.YAML)
 	}
 
 	if len(instances) == 0 {
@@ -1024,8 +1042,8 @@ func (c *BotsCommand) ShowBotInstance(ctx context.Context, client botsCommandCli
 	return trace.Wrap(showMessageTemplate.Execute(os.Stdout, templateData))
 }
 
-// botJSONResponse is a response generated by the `tctl bots add` family of
-// commands when the format is `json`
+// botJSONResponse is a structured response generated by the `tctl bots add`
+// family of commands when the format is `json` or `yaml`.
 type botJSONResponse struct {
 	UserName           string        `json:"user_name"`
 	RoleName           string        `json:"role_name"`
@@ -1061,7 +1079,8 @@ func (c *BotsCommand) outputToken(
 
 	secret, _ := uri.ToURL().User.Password()
 
-	if c.format == teleport.JSON {
+	switch c.format {
+	case teleport.JSON, teleport.YAML:
 		tokenTTL := time.Duration(0)
 		if exp := token.Expiry(); !exp.IsZero() {
 			tokenTTL = time.Until(exp)
@@ -1087,13 +1106,13 @@ func (c *BotsCommand) outputToken(
 			response.RegistrationSecret = secret
 		}
 
-		out, err := json.MarshalIndent(response, "", "  ")
-		if err != nil {
-			return trace.Wrap(err, "failed to marshal CreateBot response")
+		if c.format == teleport.JSON {
+			return trace.Wrap(utils.WriteJSON(c.stdout, response), "failed to marshal CreateBot response")
 		}
-
-		fmt.Fprintln(c.stdout, string(out))
-		return nil
+		return trace.Wrap(utils.WriteYAML(c.stdout, response), "failed to marshal CreateBot response")
+	case teleport.Text:
+	default:
+		return trace.BadParameter("unknown format %q, must be one of [%q, %q, %q]", c.format, teleport.Text, teleport.JSON, teleport.YAML)
 	}
 
 	if c.legacy {

--- a/tool/tctl/common/decision/command.go
+++ b/tool/tctl/common/decision/command.go
@@ -23,10 +23,12 @@ import (
 	"os"
 
 	"github.com/alecthomas/kingpin/v2"
+	"github.com/ghodss/yaml"
 	"github.com/gravitational/trace"
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/proto"
 
+	"github.com/gravitational/teleport"
 	decisionpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/decision/v1alpha1"
 	"github.com/gravitational/teleport/lib/service/servicecfg"
 	"github.com/gravitational/teleport/lib/services"
@@ -98,4 +100,33 @@ func WriteProtoJSON(w io.Writer, v proto.Message) error {
 	out = append(out, '\n')
 	_, err = w.Write(out)
 	return trace.Wrap(err)
+}
+
+// WriteProtoYAML outputs the given [proto.Message] in YAML format to the given
+// [io.Writer], preserving the same proto field names as WriteProtoJSON.
+func WriteProtoYAML(w io.Writer, v proto.Message) error {
+	out, err := protojson.MarshalOptions{
+		UseProtoNames: true,
+		Indent:        "    ",
+	}.Marshal(v)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	out, err = yaml.JSONToYAML(out)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	_, err = w.Write(out)
+	return trace.Wrap(err)
+}
+
+func WriteProto(w io.Writer, format string, v proto.Message) error {
+	switch format {
+	case "", teleport.JSON:
+		return trace.Wrap(WriteProtoJSON(w, v))
+	case teleport.YAML:
+		return trace.Wrap(WriteProtoYAML(w, v))
+	default:
+		return trace.BadParameter("unknown format %q, must be one of [%q, %q]", format, teleport.JSON, teleport.YAML)
+	}
 }

--- a/tool/tctl/common/decision/command.go
+++ b/tool/tctl/common/decision/command.go
@@ -120,6 +120,8 @@ func WriteProtoYAML(w io.Writer, v proto.Message) error {
 	return trace.Wrap(err)
 }
 
+// WriteProto outputs the given [proto.Message] in the requested structured
+// format to the given [io.Writer].
 func WriteProto(w io.Writer, format string, v proto.Message) error {
 	switch format {
 	case "", teleport.JSON:

--- a/tool/tctl/common/decision/command.go
+++ b/tool/tctl/common/decision/command.go
@@ -129,6 +129,6 @@ func WriteProto(w io.Writer, format string, v proto.Message) error {
 	case teleport.YAML:
 		return trace.Wrap(WriteProtoYAML(w, v))
 	default:
-		return trace.BadParameter("unknown format %q, must be one of [%q, %q]", format, teleport.JSON, teleport.YAML)
+		return trace.BadParameter("unknown format %q", format)
 	}
 }

--- a/tool/tctl/common/decision/evaluate_db_command.go
+++ b/tool/tctl/common/decision/evaluate_db_command.go
@@ -32,6 +32,7 @@ import (
 type EvaluateDatabaseCommand struct {
 	Output     io.Writer
 	DatabaseID string
+	Format     string
 	command    *kingpin.CmdClause
 }
 
@@ -40,6 +41,7 @@ func (c *EvaluateDatabaseCommand) Initialize(cmd *kingpin.CmdClause, output io.W
 	c.Output = output
 	c.command = cmd.Command("evaluate-db-access", "Evaluate database access for a user.").Hidden()
 	c.command.Flag("database-id", "The id of the target database.").StringVar(&c.DatabaseID)
+	c.command.Flag("format", "Output format.").Hidden().Default(teleport.JSON).EnumVar(&c.Format, teleport.JSON, teleport.YAML)
 }
 
 // FullCommand returns the fully qualified name of
@@ -62,7 +64,7 @@ func (c *EvaluateDatabaseCommand) Run(ctx context.Context, clt Client) error {
 		return trace.Wrap(err)
 	}
 
-	if err := WriteProtoJSON(c.Output, resp); err != nil {
+	if err := WriteProto(c.Output, c.Format, resp); err != nil {
 		return trace.Wrap(err, "failed to marshal result")
 	}
 

--- a/tool/tctl/common/decision/evaluate_db_command.go
+++ b/tool/tctl/common/decision/evaluate_db_command.go
@@ -41,7 +41,7 @@ func (c *EvaluateDatabaseCommand) Initialize(cmd *kingpin.CmdClause, output io.W
 	c.Output = output
 	c.command = cmd.Command("evaluate-db-access", "Evaluate database access for a user.").Hidden()
 	c.command.Flag("database-id", "The id of the target database.").StringVar(&c.DatabaseID)
-	c.command.Flag("format", "Output format.").Hidden().Default(teleport.JSON).EnumVar(&c.Format, teleport.JSON, teleport.YAML)
+	c.command.Flag("format", "Output format.").Default(teleport.JSON).EnumVar(&c.Format, teleport.JSON, teleport.YAML)
 }
 
 // FullCommand returns the fully qualified name of

--- a/tool/tctl/common/decision/evaluate_db_command_test.go
+++ b/tool/tctl/common/decision/evaluate_db_command_test.go
@@ -31,6 +31,7 @@ import (
 func TestEvaluateDB(t *testing.T) {
 	tests := []struct {
 		name     string
+		format   string
 		response *decisionpb.EvaluateDatabaseAccessResponse
 	}{
 		{
@@ -47,7 +48,8 @@ func TestEvaluateDB(t *testing.T) {
 			},
 		},
 		{
-			name: "permitted",
+			name:   "permitted",
+			format: teleport.YAML,
 			response: &decisionpb.EvaluateDatabaseAccessResponse{
 				Result: &decisionpb.EvaluateDatabaseAccessResponse_Permit{
 					Permit: &decisionpb.DatabaseAccessPermit{
@@ -67,6 +69,7 @@ func TestEvaluateDB(t *testing.T) {
 			cmd := decision.EvaluateDatabaseCommand{
 				Output:     &output,
 				DatabaseID: "database",
+				Format:     test.format,
 			}
 
 			clt := fakeClient{
@@ -80,7 +83,7 @@ func TestEvaluateDB(t *testing.T) {
 			require.NoError(t, err, "evaluating database access failed")
 
 			var expected bytes.Buffer
-			err = decision.WriteProtoJSON(&expected, test.response)
+			err = decision.WriteProto(&expected, test.format, test.response)
 			require.NoError(t, err, "marshaling expected output failed")
 			require.Equal(t, output.String(), expected.String(), "output did not match")
 		})

--- a/tool/tctl/common/decision/evaluate_ssh_command.go
+++ b/tool/tctl/common/decision/evaluate_ssh_command.go
@@ -34,6 +34,7 @@ type EvaluateSSHCommand struct {
 	Username string
 	ServerID string
 	Login    string
+	Format   string
 	command  *kingpin.CmdClause
 }
 
@@ -44,6 +45,7 @@ func (c *EvaluateSSHCommand) Initialize(cmd *kingpin.CmdClause, output io.Writer
 	c.command.Flag("username", "The username to evaluate access for.").StringVar(&c.Username)
 	c.command.Flag("login", "The os login to evaluate access for.").StringVar(&c.Login)
 	c.command.Flag("server-id", "The host id of the target server.").StringVar(&c.ServerID)
+	c.command.Flag("format", "Output format.").Hidden().Default(teleport.JSON).EnumVar(&c.Format, teleport.JSON, teleport.YAML)
 }
 
 // FullCommand returns the fully qualified name of
@@ -87,7 +89,7 @@ func (c *EvaluateSSHCommand) Run(ctx context.Context, clt Client) error {
 		return trace.Wrap(err)
 	}
 
-	if err := WriteProtoJSON(c.Output, resp); err != nil {
+	if err := WriteProto(c.Output, c.Format, resp); err != nil {
 		return trace.Wrap(err, "failed to marshal result")
 	}
 

--- a/tool/tctl/common/decision/evaluate_ssh_command.go
+++ b/tool/tctl/common/decision/evaluate_ssh_command.go
@@ -45,7 +45,7 @@ func (c *EvaluateSSHCommand) Initialize(cmd *kingpin.CmdClause, output io.Writer
 	c.command.Flag("username", "The username to evaluate access for.").StringVar(&c.Username)
 	c.command.Flag("login", "The os login to evaluate access for.").StringVar(&c.Login)
 	c.command.Flag("server-id", "The host id of the target server.").StringVar(&c.ServerID)
-	c.command.Flag("format", "Output format.").Hidden().Default(teleport.JSON).EnumVar(&c.Format, teleport.JSON, teleport.YAML)
+	c.command.Flag("format", "Output format.").Default(teleport.JSON).EnumVar(&c.Format, teleport.JSON, teleport.YAML)
 }
 
 // FullCommand returns the fully qualified name of

--- a/tool/tctl/common/decision/evaluate_ssh_command_test.go
+++ b/tool/tctl/common/decision/evaluate_ssh_command_test.go
@@ -31,6 +31,7 @@ import (
 func TestEvaluateSSH(t *testing.T) {
 	tests := []struct {
 		name     string
+		format   string
 		response *decisionpb.EvaluateSSHAccessResponse
 	}{
 		{
@@ -47,7 +48,8 @@ func TestEvaluateSSH(t *testing.T) {
 			},
 		},
 		{
-			name: "permitted",
+			name:   "permitted",
+			format: teleport.YAML,
 			response: &decisionpb.EvaluateSSHAccessResponse{
 				Decision: &decisionpb.EvaluateSSHAccessResponse_Permit{
 					Permit: &decisionpb.SSHAccessPermit{
@@ -72,6 +74,7 @@ func TestEvaluateSSH(t *testing.T) {
 				Username: "alice",
 				ServerID: "server",
 				Login:    "root",
+				Format:   test.format,
 			}
 
 			clt := fakeClient{
@@ -85,7 +88,7 @@ func TestEvaluateSSH(t *testing.T) {
 			require.NoError(t, err, "evaluating SSH access failed")
 
 			var expected bytes.Buffer
-			err = decision.WriteProtoJSON(&expected, test.response)
+			err = decision.WriteProto(&expected, test.format, test.response)
 			require.NoError(t, err, "marshaling expected output failed")
 			require.Equal(t, output.String(), expected.String(), "output did not match")
 		})

--- a/tool/tctl/common/discovery/command.go
+++ b/tool/tctl/common/discovery/command.go
@@ -129,6 +129,6 @@ func (c *Command) runNodes(ctx context.Context, clt discoveryClient, w io.Writer
 	case teleport.YAML:
 		return trace.Wrap(utils.WriteYAML(w, instances))
 	default:
-		return trace.BadParameter("unknown format %q, must be one of [%q, %q, %q]", c.nodesFormat, teleport.Text, teleport.JSON, teleport.YAML)
+		return trace.BadParameter("unknown format %q", c.nodesFormat)
 	}
 }

--- a/tool/tctl/common/discovery/command.go
+++ b/tool/tctl/common/discovery/command.go
@@ -65,7 +65,7 @@ Examples:
 		DurationVar(&c.nodesLast)
 	c.nodesCmd.Flag("format", "Output format.").
 		Default(teleport.Text).
-		EnumVar(&c.nodesFormat, teleport.Text, teleport.JSON)
+		EnumVar(&c.nodesFormat, teleport.Text, teleport.JSON, teleport.YAML)
 	c.nodesCmd.Flag("failures-only", "Only show instances with enrollment failures.").
 		BoolVar(&c.nodesFailuresOnly)
 	c.nodesCmd.Flag("cloud", "Comma-separated list of cloud providers to include (allowed: aws, azure). Empty (default) returns all.").
@@ -122,9 +122,13 @@ func (c *Command) runNodes(ctx context.Context, clt discoveryClient, w io.Writer
 	)
 
 	switch c.nodesFormat {
+	case teleport.Text:
+		return trace.Wrap(renderText(w, instances))
 	case teleport.JSON:
 		return trace.Wrap(utils.WriteJSONArray(w, instances))
+	case teleport.YAML:
+		return trace.Wrap(utils.WriteYAML(w, instances))
 	default:
-		return trace.Wrap(renderText(w, instances))
+		return trace.BadParameter("unknown format %q, must be one of [%q, %q, %q]", c.nodesFormat, teleport.Text, teleport.JSON, teleport.YAML)
 	}
 }

--- a/tool/tctl/common/inventory_command.go
+++ b/tool/tctl/common/inventory_command.go
@@ -75,14 +75,14 @@ func (c *InventoryCommand) Initialize(app *kingpin.Application, _ *tctlcfg.Globa
 
 	c.inventoryStatus = inventory.Command("status", "Show inventory status summary.")
 	c.inventoryStatus.Flag("connected", "Show locally connected instances summary").BoolVar(&c.getConnected)
-	c.inventoryStatus.Flag("format", "Output format, 'text' or 'json'").Default(teleport.Text).StringVar(&c.format)
+	c.inventoryStatus.Flag("format", "Output format, 'text', 'json', or 'yaml'").Default(teleport.Text).EnumVar(&c.format, teleport.Text, teleport.JSON, teleport.YAML)
 
 	c.inventoryList = inventory.Command("list", "List Teleport instance inventory.").Alias("ls")
 	c.inventoryList.Flag("older-than", "Filter for older teleport versions").StringVar(&c.olderThan)
 	c.inventoryList.Flag("newer-than", "Filter for newer teleport versions").StringVar(&c.newerThan)
 	c.inventoryList.Flag("exact-version", "Filter output by teleport version").StringVar(&c.version)
 	c.inventoryList.Flag("services", "Filter output by service (node,kube,proxy,etc)").StringVar(&c.services)
-	c.inventoryList.Flag("format", "Output format, 'text' or 'json'").Default(teleport.Text).StringVar(&c.format)
+	c.inventoryList.Flag("format", "Output format, 'text' or 'json'").Default(teleport.Text).EnumVar(&c.format, teleport.Text, teleport.JSON)
 	c.inventoryList.Flag("upgrader", "Filter output by upgrader (kube,unit,none)").StringVar(&c.upgrader)
 	c.inventoryList.Flag("update-group", "Filter output by update group").StringVar(&c.updateGroup)
 
@@ -151,8 +151,12 @@ func (c *InventoryCommand) Status(ctx context.Context, client *authclient.Client
 			return trace.Wrap(err, "marshaling inventory status to json")
 		}
 		fmt.Println(string(output))
+	case teleport.YAML:
+		if err := utils.WriteYAML(os.Stdout, rsp); err != nil {
+			return trace.Wrap(err, "marshaling inventory status to yaml")
+		}
 	default:
-		return trace.BadParameter("unknown format: %q", c.format)
+		return trace.BadParameter("unknown format %q, must be one of [%q, %q, %q]", c.format, teleport.Text, teleport.JSON, teleport.YAML)
 	}
 
 	return nil

--- a/tool/tctl/common/inventory_command.go
+++ b/tool/tctl/common/inventory_command.go
@@ -156,7 +156,7 @@ func (c *InventoryCommand) Status(ctx context.Context, client *authclient.Client
 			return trace.Wrap(err, "marshaling inventory status to yaml")
 		}
 	default:
-		return trace.BadParameter("unknown format %q, must be one of [%q, %q, %q]", c.format, teleport.Text, teleport.JSON, teleport.YAML)
+		return trace.BadParameter("unknown format %q", c.format)
 	}
 
 	return nil
@@ -292,7 +292,7 @@ func (c *InventoryCommand) List(ctx context.Context, client *authclient.Client) 
 		fmt.Fprintf(os.Stdout, "\n")
 		return nil
 	default:
-		return trace.BadParameter("unknown format %q, must be one of [%q, %q]", c.format, teleport.Text, teleport.JSON)
+		return trace.BadParameter("unknown format %q", c.format)
 	}
 }
 

--- a/tool/tctl/common/node_command.go
+++ b/tool/tctl/common/node_command.go
@@ -50,7 +50,7 @@ import (
 // NodeCommand implements `tctl nodes` group of commands
 type NodeCommand struct {
 	config *servicecfg.Config
-	// format is the output format, e.g. text or json
+	// format is the output format, e.g. text, json, or yaml.
 	format string
 	// list of roles for the new node to assume
 	roles string
@@ -88,12 +88,12 @@ func (c *NodeCommand) Initialize(app *kingpin.Application, _ *tctlcfg.GlobalCLIF
 	c.nodeAdd.Flag("roles", "Comma-separated list of roles for the new node to assume [node]").Default("node").StringVar(&c.roles)
 	c.nodeAdd.Flag("ttl", "Time to live for a generated token").Default(defaults.ProvisioningTokenTTL.String()).DurationVar(&c.ttl)
 	c.nodeAdd.Flag("token", "Override the default random generated token with a specified value").StringVar(&c.token)
-	c.nodeAdd.Flag("format", "Output format, 'text' or 'json'").Hidden().Default(teleport.Text).StringVar(&c.format)
+	c.nodeAdd.Flag("format", "Output format, 'text', 'json', or 'yaml'").Hidden().Default(teleport.Text).EnumVar(&c.format, teleport.Text, teleport.JSON, teleport.YAML)
 	c.nodeAdd.Alias(AddNodeHelp)
 
 	c.nodeList = nodes.Command("ls", "List all active SSH nodes within the cluster.")
 	c.nodeList.Flag("namespace", "Namespace of the nodes").Hidden().Default(apidefaults.Namespace).StringVar(&c.namespace)
-	c.nodeList.Flag("format", "Output format, 'text', or 'yaml'").Default(teleport.Text).StringVar(&c.lsFormat)
+	c.nodeList.Flag("format", "Output format, 'text', 'json', or 'yaml'").Default(teleport.Text).EnumVar(&c.lsFormat, teleport.Text, teleport.JSON, teleport.YAML)
 	c.nodeList.Flag("verbose", "Verbose table output, shows full label output").Short('v').BoolVar(&c.verbose)
 	c.nodeList.Alias(ListNodesHelp)
 	c.nodeList.Arg("labels", labelHelp).StringVar(&c.labels)
@@ -201,7 +201,8 @@ func (c *NodeCommand) Invite(ctx context.Context, client *authclient.Client) err
 	}
 
 	// output format switch:
-	if c.format == teleport.Text {
+	switch c.format {
+	case teleport.Text:
 		if roles.Include(types.RoleTrustedCluster) {
 			fmt.Printf(trustedClusterMessage, token, int(c.ttl.Minutes()))
 		} else {
@@ -213,7 +214,7 @@ func (c *NodeCommand) Invite(ctx context.Context, client *authclient.Client) err
 				"auth_server": controlPlaneAddr(ctx, client, authServers[0].GetAddr()),
 			})
 		}
-	} else {
+	case teleport.JSON:
 		// Always return a list, otherwise we'll break users tooling. See #1846 for
 		// more details.
 		tokens := []string{token}
@@ -222,6 +223,14 @@ func (c *NodeCommand) Invite(ctx context.Context, client *authclient.Client) err
 			return trace.Wrap(err, "failed to marshal token")
 		}
 		fmt.Print(string(out))
+	case teleport.YAML:
+		// Always return a list, otherwise we'll break users tooling. See #1846 for
+		// more details.
+		if err := utils.WriteYAML(os.Stdout, []string{token}); err != nil {
+			return trace.Wrap(err, "failed to marshal token")
+		}
+	default:
+		return trace.BadParameter("unknown format %q, must be one of [%q, %q, %q]", c.format, teleport.Text, teleport.JSON, teleport.YAML)
 	}
 	return nil
 }

--- a/tool/tctl/common/node_command.go
+++ b/tool/tctl/common/node_command.go
@@ -230,7 +230,7 @@ func (c *NodeCommand) Invite(ctx context.Context, client *authclient.Client) err
 			return trace.Wrap(err, "failed to marshal token")
 		}
 	default:
-		return trace.BadParameter("unknown format %q, must be one of [%q, %q, %q]", c.format, teleport.Text, teleport.JSON, teleport.YAML)
+		return trace.BadParameter("unknown format %q", c.format)
 	}
 	return nil
 }
@@ -272,7 +272,7 @@ func (c *NodeCommand) ListActive(ctx context.Context, clt *authclient.Client) er
 			return trace.Wrap(err)
 		}
 	default:
-		return trace.Errorf("Invalid format %s, only text, json and yaml are supported", c.lsFormat)
+		return trace.BadParameter("unknown format %q", c.lsFormat)
 	}
 	return nil
 }

--- a/tool/tctl/common/user_command.go
+++ b/tool/tctl/common/user_command.go
@@ -242,7 +242,7 @@ func (u *UserCommand) printResetPasswordToken(token types.UserToken, messageForm
 	case teleport.Text:
 		err = printTokenAsText(token, messageFormat)
 	default:
-		err = trace.BadParameter("unknown format %q, must be one of [%q, %q, %q]", u.format, teleport.Text, teleport.JSON, teleport.YAML)
+		err = trace.BadParameter("unknown format %q", u.format)
 	}
 
 	if err != nil {
@@ -558,7 +558,7 @@ func (u *UserCommand) List(ctx context.Context, client *authclient.Client) error
 			return trace.Wrap(err, "failed to marshal users")
 		}
 	default:
-		return trace.BadParameter("unknown format %q, must be one of [%q, %q, %q]", u.format, teleport.Text, teleport.JSON, teleport.YAML)
+		return trace.BadParameter("unknown format %q", u.format)
 	}
 	return nil
 }

--- a/tool/tctl/common/user_command.go
+++ b/tool/tctl/common/user_command.go
@@ -75,7 +75,7 @@ type UserCommand struct {
 
 	ttl time.Duration
 
-	// format is the output format, e.g. text or json
+	// format is the output format, e.g. text, json, or yaml.
 	format string
 
 	userAdd           *kingpin.CmdClause
@@ -115,7 +115,7 @@ func (u *UserCommand) Initialize(app *kingpin.Application, _ *tctlcfg.GlobalCLIF
 	u.userAdd.Flag("ttl", fmt.Sprintf("Set expiration time for token, default is %v, maximum is %v",
 		defaults.SignupTokenTTL, defaults.MaxSignupTokenTTL)).
 		Default(fmt.Sprintf("%v", defaults.SignupTokenTTL)).DurationVar(&u.ttl)
-	u.userAdd.Flag("format", "Output format, 'text' or 'json'").Hidden().Default(teleport.Text).StringVar(&u.format)
+	u.userAdd.Flag("format", "Output format, 'text', 'json', or 'yaml'").Hidden().Default(teleport.Text).EnumVar(&u.format, teleport.Text, teleport.JSON, teleport.YAML)
 	u.userAdd.Alias(AddUserHelp)
 
 	u.userUpdate = users.Command("update", "Update user account.")
@@ -148,7 +148,7 @@ func (u *UserCommand) Initialize(app *kingpin.Application, _ *tctlcfg.GlobalCLIF
 	u.userUpdate.Flag("set-default-relay-addr", "Relay address that clients should use by default. Value can be reset by providing an empty string").IsSetByUser(&u.defaultRelayAddrProvided).StringVar(&u.defaultRelayAddr)
 
 	u.userList = users.Command("ls", "Lists all user accounts.")
-	u.userList.Flag("format", "Output format, 'text' or 'json'").Hidden().Default(teleport.Text).StringVar(&u.format)
+	u.userList.Flag("format", "Output format, 'text', 'json', or 'yaml'").Hidden().Default(teleport.Text).EnumVar(&u.format, teleport.Text, teleport.JSON, teleport.YAML)
 
 	u.userDelete = users.Command("rm", "Deletes user accounts.").Alias("del")
 	u.userDelete.Arg("logins", "Comma-separated list of user logins to delete").
@@ -159,7 +159,7 @@ func (u *UserCommand) Initialize(app *kingpin.Application, _ *tctlcfg.GlobalCLIF
 	u.userResetPassword.Flag("ttl", fmt.Sprintf("Set expiration time for token, default is %v, maximum is %v",
 		defaults.ChangePasswordTokenTTL, defaults.MaxChangePasswordTokenTTL)).
 		Default(fmt.Sprintf("%v", defaults.ChangePasswordTokenTTL)).DurationVar(&u.ttl)
-	u.userResetPassword.Flag("format", "Output format, 'text' or 'json'").Hidden().Default(teleport.Text).StringVar(&u.format)
+	u.userResetPassword.Flag("format", "Output format, 'text', 'json', or 'yaml'").Hidden().Default(teleport.Text).EnumVar(&u.format, teleport.Text, teleport.JSON, teleport.YAML)
 }
 
 // TryRun takes the CLI command as an argument (like "users add") and executes it.
@@ -237,10 +237,12 @@ func (u *UserCommand) printResetPasswordToken(token types.UserToken, messageForm
 	switch strings.ToLower(u.format) {
 	case teleport.JSON:
 		err = printTokenAsJSON(token)
+	case teleport.YAML:
+		err = printTokenAsYAML(token)
 	case teleport.Text:
 		err = printTokenAsText(token, messageFormat)
 	default:
-		err = printTokenAsText(token, messageFormat)
+		err = trace.BadParameter("unknown format %q, must be one of [%q, %q, %q]", u.format, teleport.Text, teleport.JSON, teleport.YAML)
 	}
 
 	if err != nil {
@@ -372,6 +374,10 @@ func printTokenAsJSON(token types.UserToken) error {
 	}
 	fmt.Print(string(out))
 	return nil
+}
+
+func printTokenAsYAML(token types.UserToken) error {
+	return trace.Wrap(utils.WriteYAML(os.Stdout, token), "failed to marshal reset password token")
 }
 
 func printTokenAsText(token types.UserToken, messageFormat string) error {
@@ -528,7 +534,8 @@ func (u *UserCommand) List(ctx context.Context, client *authclient.Client) error
 		return trace.Wrap(err)
 	}
 
-	if u.format == teleport.Text {
+	switch u.format {
+	case teleport.Text:
 		if len(users) == 0 {
 			fmt.Println("No users found")
 			return nil
@@ -540,11 +547,18 @@ func (u *UserCommand) List(ctx context.Context, client *authclient.Client) error
 			})
 		}
 		fmt.Println(t.AsBuffer().String())
-	} else {
+	case teleport.JSON:
 		err := utils.WriteJSONArray(os.Stdout, users)
 		if err != nil {
 			return trace.Wrap(err, "failed to marshal users")
 		}
+	case teleport.YAML:
+		err := utils.WriteYAML(os.Stdout, users)
+		if err != nil {
+			return trace.Wrap(err, "failed to marshal users")
+		}
+	default:
+		return trace.BadParameter("unknown format %q, must be one of [%q, %q, %q]", u.format, teleport.Text, teleport.JSON, teleport.YAML)
 	}
 	return nil
 }

--- a/tool/tctl/common/workload_identity_command.go
+++ b/tool/tctl/common/workload_identity_command.go
@@ -190,10 +190,6 @@ func (c *WorkloadIdentityCommand) Initialize(
 		Flag("dry-run", "Print the workload_identity_x509_issuer_override that would have been created, without actually creating it.").
 		BoolVar(&c.overridesCreateDryRun)
 	c.overridesCreateCmd.
-		Flag("format", "Output format for --dry-run, 'yaml' or 'json'.").
-		Default(teleport.YAML).
-		EnumVar(&c.format, teleport.YAML, teleport.JSON)
-	c.overridesCreateCmd.
 		Flag("name", "The name of the override resource to write.").
 		Default("default").
 		StringVar(&c.overridesCreateName)
@@ -633,24 +629,10 @@ func (c *WorkloadIdentityCommand) runOverridesCreate(ctx context.Context, client
 
 	if c.overridesCreateDryRun {
 		fmt.Fprintln(c.stderr, "Dry run mode enabled, the following override would have been created:")
-		resource := types.ProtoResource153ToLegacy(override)
-		switch c.format {
-		case teleport.YAML:
-			if err := utils.WriteYAML(c.stdout, resource); err != nil {
-				return trace.Wrap(err, "failed to marshal override")
-			}
-		case teleport.JSON:
-			if err := utils.WriteJSON(c.stdout, resource); err != nil {
-				return trace.Wrap(err, "failed to marshal override")
-			}
-		default:
-			return trace.BadParameter("unknown format %q, must be one of [%q, %q]", c.format, teleport.YAML, teleport.JSON)
+		if err := utils.WriteYAML(c.stdout, types.ProtoResource153ToLegacy(override)); err != nil {
+			return trace.Wrap(err, "failed to marshal override")
 		}
 		return nil
-	}
-
-	if c.format != teleport.YAML {
-		return trace.BadParameter("--format is only supported with --dry-run")
 	}
 
 	if c.overridesCreateForce {

--- a/tool/tctl/common/workload_identity_command.go
+++ b/tool/tctl/common/workload_identity_command.go
@@ -313,7 +313,7 @@ func (c *WorkloadIdentityCommand) ListWorkloadIdentities(
 			return trace.Wrap(err, "failed to marshal workload identities")
 		}
 	default:
-		return trace.BadParameter("unknown format %q, must be one of [%q, %q, %q]", c.format, teleport.Text, teleport.JSON, teleport.YAML)
+		return trace.BadParameter("unknown format %q", c.format)
 	}
 	return nil
 }
@@ -473,7 +473,7 @@ func (c *WorkloadIdentityCommand) ListRevocations(
 			}
 		}
 	default:
-		return trace.BadParameter("unknown format %q, must be one of [%q, %q, %q]", c.format, teleport.Text, teleport.JSON, teleport.YAML)
+		return trace.BadParameter("unknown format %q", c.format)
 	}
 	return nil
 }

--- a/tool/tctl/common/workload_identity_command.go
+++ b/tool/tctl/common/workload_identity_command.go
@@ -100,11 +100,11 @@ func (c *WorkloadIdentityCommand) Initialize(
 	c.listCmd.
 		Flag(
 			"format",
-			"Output format, 'text' or 'json'",
+			"Output format, 'text', 'json', or 'yaml'",
 		).
 		Hidden().
 		Default(teleport.Text).
-		EnumVar(&c.format, teleport.Text, teleport.JSON)
+		EnumVar(&c.format, teleport.Text, teleport.JSON, teleport.YAML)
 
 	c.rmCmd = cmd.Command(
 		"rm",
@@ -140,11 +140,11 @@ func (c *WorkloadIdentityCommand) Initialize(
 	c.revocationsLsCmd.
 		Flag(
 			"format",
-			"Output format, 'text' or 'json'",
+			"Output format, 'text', 'json', or 'yaml'",
 		).
 		Hidden().
 		Default(teleport.Text).
-		EnumVar(&c.format, teleport.Text, teleport.JSON)
+		EnumVar(&c.format, teleport.Text, teleport.JSON, teleport.YAML)
 
 	c.revocationsCrlCmd = revocationsCmd.Command(
 		"crl", "Fetch the signed CRL for existing revocations.",
@@ -189,6 +189,10 @@ func (c *WorkloadIdentityCommand) Initialize(
 	c.overridesCreateCmd.
 		Flag("dry-run", "Print the workload_identity_x509_issuer_override that would have been created, without actually creating it.").
 		BoolVar(&c.overridesCreateDryRun)
+	c.overridesCreateCmd.
+		Flag("format", "Output format for --dry-run, 'yaml' or 'json'.").
+		Default(teleport.YAML).
+		EnumVar(&c.format, teleport.YAML, teleport.JSON)
 	c.overridesCreateCmd.
 		Flag("name", "The name of the override resource to write.").
 		Default("default").
@@ -289,7 +293,8 @@ func (c *WorkloadIdentityCommand) ListWorkloadIdentities(
 		req.PageToken = resp.NextPageToken
 	}
 
-	if c.format == teleport.Text {
+	switch c.format {
+	case teleport.Text:
 		if len(workloadIdentities) == 0 {
 			fmt.Fprintln(c.stdout, "No workload identities configured")
 			return nil
@@ -301,11 +306,18 @@ func (c *WorkloadIdentityCommand) ListWorkloadIdentities(
 			})
 		}
 		fmt.Fprintln(c.stdout, t.AsBuffer().String())
-	} else {
+	case teleport.JSON:
 		err := utils.WriteJSONArray(c.stdout, workloadIdentities)
 		if err != nil {
 			return trace.Wrap(err, "failed to marshal workload identities")
 		}
+	case teleport.YAML:
+		err := utils.WriteYAML(c.stdout, workloadIdentities)
+		if err != nil {
+			return trace.Wrap(err, "failed to marshal workload identities")
+		}
+	default:
+		return trace.BadParameter("unknown format %q, must be one of [%q, %q, %q]", c.format, teleport.Text, teleport.JSON, teleport.YAML)
 	}
 	return nil
 }
@@ -426,7 +438,8 @@ func (c *WorkloadIdentityCommand) ListRevocations(
 		req.PageToken = resp.NextPageToken
 	}
 
-	if c.format == teleport.Text {
+	switch c.format {
+	case teleport.Text:
 		if len(revocations) == 0 {
 			fmt.Fprintln(c.stdout, "No revocations configured")
 			return nil
@@ -447,15 +460,24 @@ func (c *WorkloadIdentityCommand) ListRevocations(
 			})
 		}
 		fmt.Fprintln(c.stdout, t.AsBuffer().String())
-	} else {
+	case teleport.JSON, teleport.YAML:
 		converted := []types.Resource{}
 		for _, resource := range revocations {
 			converted = append(converted, types.ProtoResource153ToLegacy(resource))
 		}
-		err := utils.WriteJSONArray(c.stdout, converted)
-		if err != nil {
-			return trace.Wrap(err, "failed to marshal revocations")
+		if c.format == teleport.JSON {
+			err := utils.WriteJSONArray(c.stdout, converted)
+			if err != nil {
+				return trace.Wrap(err, "failed to marshal revocations")
+			}
+		} else {
+			err := utils.WriteYAML(c.stdout, converted)
+			if err != nil {
+				return trace.Wrap(err, "failed to marshal revocations")
+			}
 		}
+	default:
+		return trace.BadParameter("unknown format %q, must be one of [%q, %q, %q]", c.format, teleport.Text, teleport.JSON, teleport.YAML)
 	}
 	return nil
 }
@@ -611,10 +633,24 @@ func (c *WorkloadIdentityCommand) runOverridesCreate(ctx context.Context, client
 
 	if c.overridesCreateDryRun {
 		fmt.Fprintln(c.stderr, "Dry run mode enabled, the following override would have been created:")
-		if err := utils.WriteYAML(c.stdout, types.ProtoResource153ToLegacy(override)); err != nil {
-			return trace.Wrap(err, "failed to marshal override")
+		resource := types.ProtoResource153ToLegacy(override)
+		switch c.format {
+		case teleport.YAML:
+			if err := utils.WriteYAML(c.stdout, resource); err != nil {
+				return trace.Wrap(err, "failed to marshal override")
+			}
+		case teleport.JSON:
+			if err := utils.WriteJSON(c.stdout, resource); err != nil {
+				return trace.Wrap(err, "failed to marshal override")
+			}
+		default:
+			return trace.BadParameter("unknown format %q, must be one of [%q, %q]", c.format, teleport.YAML, teleport.JSON)
 		}
 		return nil
+	}
+
+	if c.format != teleport.YAML {
+		return trace.BadParameter("--format is only supported with --dry-run")
 	}
 
 	if c.overridesCreateForce {


### PR DESCRIPTION
<!-- Provide a descriptive entry for the changelog of the next release. -->

Changelog: Added YAML output support to selected `tctl` commands that already exposed bounded JSON structured output.

Closes https://github.com/gravitational/teleport/issues/67070

## Summary

This PR adds JSON/YAML parity for `tctl` commands where the existing structured output is a finite resource or result object. The default text output remains unchanged.

Examples:

```sh
tctl users ls --format=json
tctl users ls --format=yaml
```

```json
[
    {
        "kind": "user",
        "version": "v2",
        "metadata": {
            "name": "admin"
        },
        "spec": {
            "roles": [
                "editor",
                "access",
                "auditor"
            ]
        }
    }
]
```

```yaml
kind: user
metadata:
  name: admin
spec:
  roles:
  - editor
  - access
  - auditor
version: v2
```

```sh
tctl nodes add --roles=node --format=json
# ["4c8b4430c88424c1b0be044aef7c612d"]

tctl nodes add --roles=node --format=yaml
# - 3ed2b3bd0de88fd64c8c60db9bd42639
```

```sh
tctl bots add fmt-yaml-bot --roles=access --format=json
tctl bots add fmt-yaml-bot --roles=access --format=yaml
```

```json
{
    "user_name": "bot-fmt-json-bot",
    "role_name": "bot-fmt-json-bot",
    "token_id": "bot-fmt-json-bot-d25ce996",
    "token_ttl": 3599987402000,
    "join_uri": "tbot+proxy+bound-keypair://...",
    "registration_secret": "..."
}
```

```yaml
join_uri: tbot+proxy+bound-keypair://...
registration_secret: ...
role_name: bot-fmt-yaml-bot
token_id: bot-fmt-yaml-bot-6a73f0f9
token_ttl: 3599986958000
user_name: bot-fmt-yaml-bot
```

Some commands from the original audit were intentionally left out:

- `tctl inventory list` and hidden `tctl loadtest watch` stream results/events. JSON is a better fit for the existing streaming behavior, and adding YAML document streams would introduce a new output contract rather than simple parity.
- `tctl inventory status` currently serializes a raw RPC response for JSON, while the text output uses friendlier labels. Adding YAML would further bless the raw shape without solving the broader structured-output design question.
- `tctl sso configure github`, `tctl sso configure oidc`, and `tctl sso configure saml` generate YAML connector configuration intended to be used as Teleport resource files. JSON output is possible, but the use case is weaker and less clearly part of this parity fix.
- - `tctl workload-identity x509-issuer-overrides create --dry-run` already emits YAML resource configuration. JSON output is possible, but the format flag would only apply to the dry-run preview, making the command behaviour less clear for this parity-focused PR.

<!-- Include manual testing efforts to verify the change. -->
<!-- Detail where the tests where run and what configurations were used. -->
<!-- Include all the test cases which were run to validate the change. -->

## Manual Test Plan

### Test Environment

Manual testing was run locally from a Teleport development checkout against a local Teleport cluster using the rebuilt `tctl` binary.

- Command binary: `./build/tctl` / local `tctl`
- Cluster: local development cluster
- Version under test: `19.0.0-prealpha.2`

### Test Cases

- [x] `tctl users ls --format=json`
- [x] `tctl users ls --format=yaml`
- [x] `tctl users ls`
- [x] `tctl nodes ls --format=json`
- [x] `tctl nodes ls --format=yaml`
- [x] `tctl nodes ls`
- [x] `tctl workload-identity ls --format=json`
- [x] `tctl workload-identity ls --format=yaml`
- [x] `tctl workload-identity revocations ls --format=json`
- [x] `tctl workload-identity revocations ls --format=yaml`
- [x] `tctl requests capabilities test --format=json`
- [x] `tctl requests capabilities test --format=yaml`
- [x] `tctl requests capabilities test`
- [x] `tctl discovery nodes --format=json`
- [x] `tctl discovery nodes --format=yaml`
- [x] `tctl discovery nodes`
- [x] `tctl users add fmt-json-user --roles=auditor --format=json`
- [x] `tctl users add fmt-yaml-user --roles=auditor --format=yaml`
- [x] `tctl users reset fmt-json-user --format=json`
- [x] `tctl users reset fmt-yaml-user --format=yaml`
- [x] `tctl users rm fmt-json-user,fmt-yaml-user`
- [x] `tctl nodes add --roles=node --format=json`
- [x] `tctl nodes add --roles=node --format=yaml`
- [x] `tctl bots add fmt-json-bot --roles=access --format=json`
- [x] `tctl bots add fmt-yaml-bot --roles=access --format=yaml`
- [x] `tctl bots ls --format=json`
- [x] `tctl bots ls --format=yaml`
- [x] `tctl bots instances add fmt-json-bot --format=json`
- [x] `tctl bots instances add fmt-yaml-bot --format=yaml`

Structured JSON/YAML outputs were checked manually to confirm that both formats represented the same underlying resource/result data. Default text output was checked for representative commands to confirm it remained unchanged.
