### PR TITLE
[v18] Spinner for "tsh beams add"

### DIFF
--- a/lib/utils/spinner/spinner.go
+++ b/lib/utils/spinner/spinner.go
@@ -64,7 +64,7 @@ func (s *Spinner) run(msg string) {
 	for {
 		select {
 		case final := <-s.finalMessage:
-			fmt.Fprintf(s.w, "\r%s\r", strings.Repeat(" ", len(msg)+4))
+			fmt.Fprintf(s.w, "\r%s\r", strings.Repeat(" ", len(msg)+2))
 			if final != "" {
 				fmt.Fprintln(s.w, final)
 			}

--- a/lib/utils/spinner/spinner.go
+++ b/lib/utils/spinner/spinner.go
@@ -35,18 +35,18 @@ type Spinner struct {
 	model spinner.Spinner
 	style lipgloss.Style
 
-	finalMessage chan string
-	done         chan struct{}
-	stopOnce     sync.Once
+	stop     chan struct{}
+	done     chan struct{}
+	stopOnce sync.Once
 }
 
 // New creates and starts an inline spinner that writes to w.
 // Call Stop to replace the spinner line with a final message.
 func New(w io.Writer, msg string) *Spinner {
 	s := &Spinner{
-		w:            w,
-		finalMessage: make(chan string, 1),
-		done:         make(chan struct{}),
+		w:    w,
+		stop: make(chan struct{}),
+		done: make(chan struct{}),
 		// ANSI color "6" is cyan. style and model are hard-coded atm but can
 		// potentially become options for spinners.
 		style: lipgloss.NewStyle().Foreground(lipgloss.Color("6")).Bold(true),
@@ -63,11 +63,8 @@ func (s *Spinner) run(msg string) {
 	i := 0
 	for {
 		select {
-		case final := <-s.finalMessage:
+		case <-s.stop:
 			fmt.Fprintf(s.w, "\r%s\r", strings.Repeat(" ", len(msg)+2))
-			if final != "" {
-				fmt.Fprintln(s.w, final)
-			}
 			return
 		case <-ticker.C:
 			frame := s.model.Frames[i%len(s.model.Frames)]
@@ -77,15 +74,10 @@ func (s *Spinner) run(msg string) {
 	}
 }
 
-// Stop clears the spinner line.
+// Stop clears the spinner line. Safe to call multiple times.
 func (s *Spinner) Stop() {
-	s.StopWithMessage("")
-}
-
-// StopWithMessage clears the spinner line and prints msg.
-func (s *Spinner) StopWithMessage(msg string) {
 	s.stopOnce.Do(func() {
-		s.finalMessage <- msg
+		close(s.stop)
 		<-s.done
 	})
 }

--- a/lib/utils/spinner/spinner.go
+++ b/lib/utils/spinner/spinner.go
@@ -1,0 +1,91 @@
+/*
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package spinner
+
+import (
+	"fmt"
+	"io"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/charmbracelet/bubbles/spinner"
+	"github.com/charmbracelet/lipgloss"
+)
+
+// Spinner renders an inline animated spinner to a writer.
+type Spinner struct {
+	w     io.Writer
+	model spinner.Spinner
+	style lipgloss.Style
+
+	finalMessage chan string
+	done         chan struct{}
+	stopOnce     sync.Once
+}
+
+// New creates and starts an inline spinner that writes to w.
+// Call Stop to replace the spinner line with a final message.
+func New(w io.Writer, msg string) *Spinner {
+	s := &Spinner{
+		w:            w,
+		finalMessage: make(chan string, 1),
+		done:         make(chan struct{}),
+		// ANSI color "6" is cyan. style and model are hard-coded atm but can
+		// potentially become options for spinners.
+		style: lipgloss.NewStyle().Foreground(lipgloss.Color("6")).Bold(true),
+		model: spinner.MiniDot,
+	}
+	go s.run(msg)
+	return s
+}
+
+func (s *Spinner) run(msg string) {
+	defer close(s.done)
+	ticker := time.NewTicker(s.model.FPS)
+	defer ticker.Stop()
+	i := 0
+	for {
+		select {
+		case final := <-s.finalMessage:
+			fmt.Fprintf(s.w, "\r%s\r", strings.Repeat(" ", len(msg)+4))
+			if final != "" {
+				fmt.Fprintln(s.w, final)
+			}
+			return
+		case <-ticker.C:
+			frame := s.model.Frames[i%len(s.model.Frames)]
+			fmt.Fprintf(s.w, "\r%s %s", s.style.Render(frame), msg)
+			i++
+		}
+	}
+}
+
+// Stop clears the spinner line.
+func (s *Spinner) Stop() {
+	s.StopWithMessage("")
+}
+
+// StopWithMessage clears the spinner line and prints msg.
+func (s *Spinner) StopWithMessage(msg string) {
+	s.stopOnce.Do(func() {
+		s.finalMessage <- msg
+		<-s.done
+	})
+}

--- a/lib/utils/spinner/spinner_test.go
+++ b/lib/utils/spinner/spinner_test.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestSpinner(t *testing.T) {
@@ -32,6 +33,10 @@ func TestSpinner(t *testing.T) {
 		var buf bytes.Buffer
 		s := New(&buf, "creating...")
 		t.Cleanup(s.Stop)
+
+		// Sanity check that the bubbletea spinner model defines enough frames
+		// to produce a visible animation. The threshold is arbitrary.
+		require.Greater(t, len(s.model.Frames), 5)
 
 		time.Sleep(s.model.FPS * time.Duration(len(s.model.Frames)*2))
 		s.Stop()

--- a/lib/utils/spinner/spinner_test.go
+++ b/lib/utils/spinner/spinner_test.go
@@ -20,7 +20,6 @@ package spinner
 
 import (
 	"bytes"
-	"strings"
 	"testing"
 	"testing/synctest"
 	"time"
@@ -35,16 +34,12 @@ func TestSpinner(t *testing.T) {
 		t.Cleanup(s.Stop)
 
 		time.Sleep(s.model.FPS * time.Duration(len(s.model.Frames)*2))
-
-		s.StopWithMessage("done!")
-		s.StopWithMessage("second stop should be ignored")
+		s.Stop()
 
 		// Every frame should be preceded by a carriage return after two full cycles.
 		output := buf.String()
 		for _, frame := range s.model.Frames {
 			assert.Contains(t, output, "\r"+s.style.Render(frame)+" creating...")
 		}
-		assert.True(t, strings.HasSuffix(output, "done!\n"))
-		assert.NotContains(t, output, "second stop should be ignored")
 	})
 }

--- a/lib/utils/spinner/spinner_test.go
+++ b/lib/utils/spinner/spinner_test.go
@@ -29,6 +29,7 @@ import (
 )
 
 func TestSpinner(t *testing.T) {
+	t.Parallel()
 	synctest.Test(t, func(t *testing.T) {
 		var buf bytes.Buffer
 		s := New(&buf, "creating...")

--- a/lib/utils/spinner/spinner_test.go
+++ b/lib/utils/spinner/spinner_test.go
@@ -1,0 +1,50 @@
+/*
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package spinner
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+	"testing/synctest"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSpinner(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		var buf bytes.Buffer
+		s := New(&buf, "creating...")
+		t.Cleanup(s.Stop)
+
+		time.Sleep(s.model.FPS * time.Duration(len(s.model.Frames)*2))
+
+		s.StopWithMessage("done!")
+		s.StopWithMessage("second stop should be ignored")
+
+		// Every frame should be preceded by a carriage return after two full cycles.
+		output := buf.String()
+		for _, frame := range s.model.Frames {
+			assert.Contains(t, output, "\r"+s.style.Render(frame)+" creating...")
+		}
+		assert.True(t, strings.HasSuffix(output, "done!\n"))
+		assert.NotContains(t, output, "second stop should be ignored")
+	})
+}

--- a/tool/tsh/common/beams_add.go
+++ b/tool/tsh/common/beams_add.go
@@ -20,6 +20,7 @@ package common
 
 import (
 	"fmt"
+	"io"
 	"strings"
 
 	"github.com/alecthomas/kingpin/v2"
@@ -37,8 +38,9 @@ import (
 
 type beamsAddCommand struct {
 	*kingpin.CmdClause
-	console bool
-	format  string
+	console             bool
+	format              string
+	isTerminalOverwrite func(io.Writer) bool
 }
 
 func newBeamsAddCommand(parent *kingpin.CmdClause) *beamsAddCommand {
@@ -62,19 +64,6 @@ func (c *beamsAddCommand) run(cf *CLIConf) error {
 		return trace.Wrap(err)
 	}
 
-	showSpinner := utils.IsTerminal(cf.Stdout())
-	format := strings.ToLower(c.format)
-	switch format {
-	case teleport.JSON, teleport.YAML:
-		showSpinner = false
-	}
-
-	var s *spinner.Spinner
-	if showSpinner {
-		s = spinner.New(cf.Stdout(), "Creating beam...")
-		defer s.Stop()
-	}
-
 	var beam *beamsv1.Beam
 	err = client.RetryWithRelogin(ctx, tc, func() error {
 		clusterClient, err := tc.ConnectToCluster(ctx)
@@ -82,6 +71,12 @@ func (c *beamsAddCommand) run(cf *CLIConf) error {
 			return trace.Wrap(err)
 		}
 		defer clusterClient.Close()
+
+		// Show spinner after successful connection to avoid spinning during re-login.
+		if c.shouldShowSpinner(cf.Stdout(), c.format) {
+			creatingBeamSpinner := spinner.New(cf.Stdout(), "Creating beam...")
+			defer creatingBeamSpinner.Stop()
+		}
 
 		rootClient, err := clusterClient.ConnectToRootCluster(ctx)
 		if err != nil {
@@ -110,27 +105,46 @@ func (c *beamsAddCommand) run(cf *CLIConf) error {
 	// the beam won't be published yet, there's no need to actually fetch it.
 	const proxyAddr = ""
 
-	switch format {
+	switch strings.ToLower(c.format) {
 	case teleport.JSON:
 		return trace.Wrap(common.PrintJSONIndent(cf.Stdout(), formatBeam(beam, proxyAddr)))
 	case teleport.YAML:
 		return trace.Wrap(common.PrintYAML(cf.Stdout(), formatBeam(beam, proxyAddr)))
 	default:
-		alias := beam.GetStatus().GetAlias()
-		if s != nil {
-			s.StopWithMessage(fmt.Sprintf("Beam %q created.\n", alias))
-		} else {
-			fmt.Fprintf(cf.Stdout(), "Beam %q created.\n", alias)
+		if _, err := fmt.Fprintf(
+			cf.Stdout(),
+			"Beam %q created.\n",
+			beam.GetStatus().GetAlias(),
+		); err != nil {
+			return trace.Wrap(err)
 		}
 
+		// Connect to the beam via SSH.
 		if c.console {
 			if err := sshBeam(cf, tc, beam, nil); err != nil {
 				return trace.Wrap(err)
 			}
-			gray := lipgloss.NewStyle().Foreground(lipgloss.Color("8"))
-			fmt.Fprintln(cf.Stdout(), gray.Render(fmt.Sprintf("\nTo reconnect to this beam, run:\n    tsh beams ssh %s", alias)))
+			return trace.Wrap(c.printReconnectMessage(cf.Stdout(), beam.GetStatus().GetAlias()))
 		}
 	}
 
 	return nil
+}
+
+func (c *beamsAddCommand) printReconnectMessage(w io.Writer, alias string) error {
+	gray := lipgloss.NewStyle().Foreground(lipgloss.Color("8"))
+	_, err := fmt.Fprintln(w, gray.Render(fmt.Sprintf("\nTo reconnect to this beam, run:\n    tsh beams ssh %s", alias)))
+	return trace.Wrap(err)
+}
+
+func (c *beamsAddCommand) shouldShowSpinner(w io.Writer, format string) bool {
+	switch strings.ToLower(format) {
+	case teleport.JSON, teleport.YAML:
+		return false
+	default:
+		if c.isTerminalOverwrite != nil {
+			return c.isTerminalOverwrite(w)
+		}
+		return utils.IsTerminal(w)
+	}
 }

--- a/tool/tsh/common/beams_add.go
+++ b/tool/tsh/common/beams_add.go
@@ -62,15 +62,15 @@ func (c *beamsAddCommand) run(cf *CLIConf) error {
 		return trace.Wrap(err)
 	}
 
-	interactive := utils.IsTerminal(cf.Stdout())
+	showSpinner := utils.IsTerminal(cf.Stdout())
 	format := strings.ToLower(c.format)
 	switch format {
 	case teleport.JSON, teleport.YAML:
-		interactive = false
+		showSpinner = false
 	}
 
 	var s *spinner.Spinner
-	if interactive {
+	if showSpinner {
 		s = spinner.New(cf.Stdout(), "Creating beam...")
 		defer s.Stop()
 	}
@@ -110,14 +110,13 @@ func (c *beamsAddCommand) run(cf *CLIConf) error {
 	// the beam won't be published yet, there's no need to actually fetch it.
 	const proxyAddr = ""
 
-	alias := beam.GetStatus().GetAlias()
-
 	switch format {
 	case teleport.JSON:
 		return trace.Wrap(common.PrintJSONIndent(cf.Stdout(), formatBeam(beam, proxyAddr)))
 	case teleport.YAML:
 		return trace.Wrap(common.PrintYAML(cf.Stdout(), formatBeam(beam, proxyAddr)))
 	default:
+		alias := beam.GetStatus().GetAlias()
 		if s != nil {
 			s.StopWithMessage(fmt.Sprintf("Beam %q created.\n", alias))
 		} else {

--- a/tool/tsh/common/beams_add.go
+++ b/tool/tsh/common/beams_add.go
@@ -29,6 +29,8 @@ import (
 	beamsv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/beams/v1"
 	"github.com/gravitational/teleport/lib/client"
 	"github.com/gravitational/teleport/lib/defaults"
+	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/spinner"
 	"github.com/gravitational/teleport/tool/common"
 )
 
@@ -56,6 +58,19 @@ func (c *beamsAddCommand) run(cf *CLIConf) error {
 	tc, err := makeClient(cf)
 	if err != nil {
 		return trace.Wrap(err)
+	}
+
+	interactive := utils.IsTerminal(cf.Stdout())
+	format := strings.ToLower(c.format)
+	switch format {
+	case teleport.JSON, teleport.YAML:
+		interactive = false
+	}
+
+	var s *spinner.Spinner
+	if interactive {
+		s = spinner.New(cf.Stdout(), "Creating beam...")
+		defer s.Stop()
 	}
 
 	var beam *beamsv1.Beam
@@ -93,21 +108,20 @@ func (c *beamsAddCommand) run(cf *CLIConf) error {
 	// the beam won't be published yet, there's no need to actually fetch it.
 	const proxyAddr = ""
 
-	switch strings.ToLower(c.format) {
+	alias := beam.GetStatus().GetAlias()
+
+	switch format {
 	case teleport.JSON:
 		return trace.Wrap(common.PrintJSONIndent(cf.Stdout(), formatBeam(beam, proxyAddr)))
 	case teleport.YAML:
 		return trace.Wrap(common.PrintYAML(cf.Stdout(), formatBeam(beam, proxyAddr)))
 	default:
-		if _, err := fmt.Fprintf(
-			cf.Stdout(),
-			"Beam %q created.\n",
-			beam.GetStatus().GetAlias(),
-		); err != nil {
-			return trace.Wrap(err)
+		if s != nil {
+			s.StopWithMessage(fmt.Sprintf("Beam %q created.\n", alias))
+		} else {
+			fmt.Fprintf(cf.Stdout(), "Beam %q created.\n", alias)
 		}
 
-		// Connect to the beam via SSH.
 		if c.console {
 			return trace.Wrap(sshBeam(cf, tc, beam, nil))
 		}

--- a/tool/tsh/common/beams_add.go
+++ b/tool/tsh/common/beams_add.go
@@ -50,6 +50,7 @@ func newBeamsAddCommand(parent *kingpin.CmdClause) *beamsAddCommand {
 		Short('f').
 		Default(teleport.Text).
 		EnumVar(&cmd.format, defaults.DefaultFormats...)
+	cmd.Alias(beamsAddHelp)
 	return cmd
 }
 

--- a/tool/tsh/common/beams_add.go
+++ b/tool/tsh/common/beams_add.go
@@ -23,6 +23,7 @@ import (
 	"strings"
 
 	"github.com/alecthomas/kingpin/v2"
+	"github.com/charmbracelet/lipgloss"
 	"github.com/gravitational/trace"
 
 	"github.com/gravitational/teleport"
@@ -123,7 +124,11 @@ func (c *beamsAddCommand) run(cf *CLIConf) error {
 		}
 
 		if c.console {
-			return trace.Wrap(sshBeam(cf, tc, beam, nil))
+			if err := sshBeam(cf, tc, beam, nil); err != nil {
+				return trace.Wrap(err)
+			}
+			gray := lipgloss.NewStyle().Foreground(lipgloss.Color("8"))
+			fmt.Fprintln(cf.Stdout(), gray.Render(fmt.Sprintf("\nTo reconnect to this beam, run:\n    tsh beams ssh %s", alias)))
 		}
 	}
 

--- a/tool/tsh/common/beams_add_test.go
+++ b/tool/tsh/common/beams_add_test.go
@@ -19,7 +19,6 @@
 package common
 
 import (
-	"bytes"
 	"io"
 	"testing"
 
@@ -29,7 +28,6 @@ import (
 )
 
 func Test_beamsAddCommand_shouldShowSpinner(t *testing.T) {
-	dummyWriter := &bytes.Buffer{}
 	fakeTTY := func(io.Writer) bool { return true }
 	fakeNonTTY := func(io.Writer) bool { return false }
 
@@ -82,7 +80,7 @@ func Test_beamsAddCommand_shouldShowSpinner(t *testing.T) {
 			cmd := &beamsAddCommand{
 				isTerminalOverwrite: tt.isTerminalOverwrite,
 			}
-			tt.check(t, cmd.shouldShowSpinner(dummyWriter, tt.format))
+			tt.check(t, cmd.shouldShowSpinner(io.Discard, tt.format))
 		})
 	}
 }

--- a/tool/tsh/common/beams_add_test.go
+++ b/tool/tsh/common/beams_add_test.go
@@ -1,0 +1,88 @@
+/*
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package common
+
+import (
+	"bytes"
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport"
+)
+
+func Test_beamsAddCommand_shouldShowSpinner(t *testing.T) {
+	dummyWriter := &bytes.Buffer{}
+	fakeTTY := func(io.Writer) bool { return true }
+	fakeNonTTY := func(io.Writer) bool { return false }
+
+	tests := []struct {
+		name                string
+		format              string
+		isTerminalOverwrite func(io.Writer) bool
+		check               require.BoolAssertionFunc
+	}{
+		{
+			name:                "json format with TTY",
+			format:              teleport.JSON,
+			isTerminalOverwrite: fakeTTY,
+			check:               require.False,
+		},
+		{
+			name:                "yaml format with TTY",
+			format:              teleport.YAML,
+			isTerminalOverwrite: fakeTTY,
+			check:               require.False,
+		},
+		{
+			name:                "text format with TTY",
+			format:              teleport.Text,
+			isTerminalOverwrite: fakeTTY,
+			check:               require.True,
+		},
+		{
+			name:                "text format with non-TTY",
+			format:              teleport.Text,
+			isTerminalOverwrite: fakeNonTTY,
+			check:               require.False,
+		},
+		{
+			name:                "empty format with TTY",
+			format:              "",
+			isTerminalOverwrite: fakeTTY,
+			check:               require.True,
+		},
+		{
+			name:                "empty format with non-TTY",
+			format:              "",
+			isTerminalOverwrite: fakeNonTTY,
+			check:               require.False,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd := &beamsAddCommand{
+				isTerminalOverwrite: tt.isTerminalOverwrite,
+			}
+			tt.check(t, cmd.shouldShowSpinner(dummyWriter, tt.format))
+		})
+	}
+}

--- a/tool/tsh/common/beams_add_test.go
+++ b/tool/tsh/common/beams_add_test.go
@@ -28,6 +28,7 @@ import (
 )
 
 func Test_beamsAddCommand_shouldShowSpinner(t *testing.T) {
+	t.Parallel()
 	fakeTTY := func(io.Writer) bool { return true }
 	fakeNonTTY := func(io.Writer) bool { return false }
 

--- a/tool/tsh/common/help.go
+++ b/tool/tsh/common/help.go
@@ -126,4 +126,13 @@ Examples:
   Add the database configuration to the specified JSON file
   $ tsh mcp db config --db-user=mydbuser --db-name=mydbname --client-config=my-config.json my-db-resource
 `
+
+	beamsAddHelp = `
+Examples:
+  Create a beam and connect via SSH:
+  $ tsh beams add
+
+  Create a beam without connecting and save its ID:
+  $ BEAM_ID=$(tsh beams add --no-console -f json | jq -r '.id')
+  $ tsh beams exec $BEAM_ID -- ls examples`
 )

--- a/tool/tsh/common/help.go
+++ b/tool/tsh/common/help.go
@@ -133,6 +133,6 @@ Examples:
   $ tsh beams add
 
   Create a beam without connecting and save its ID:
-  $ BEAM_ID=$(tsh beams add --no-console -f json | jq -r '.id')
+  $ BEAM_ID=$(tsh beams add -f json | jq -r '.id')
   $ tsh beams exec $BEAM_ID -- ls examples`
 )


### PR DESCRIPTION
Backport #66881 to branch/v18

minor `tsh beams add` UX improvements. not adding changelog since no functional change. no conflict

## Manual Test Plan
### Test Environment

falling-sea.beams.run

### Test Cases
- [x] `tsh beams add` shows spinner
- [x] quit `tsh beams add` session and see the reconnect message
- [x] `tsh beam add -h`
- [x] `tsh beam add` while t
<img width="293" height="172" alt="Screenshot 2026-05-27 at 12 40 53 PM" src="https://github.com/user-attachments/assets/1929a71d-ecb7-4bf5-9921-150d9f88f7d9" />
sh session expired
