### PR TITLE
Validate audit event reference example types

### DIFF
--- a/docs/pages/reference/audit-events.mdx
+++ b/docs/pages/reference/audit-events.mdx
@@ -184,9 +184,9 @@ Example:
 }
 ```
 
-## access_list.member.add
+## access_list.member.create
 
-There are multiple events with the `access_list.member.add` type.
+There are multiple events with the `access_list.member.create` type.
 
 ### TAL005I
 
@@ -197,7 +197,7 @@ Example:
 ```json
 {
   "code": "TAL005I",
-  "event": "access_list.member.add",
+  "event": "access_list.member.create",
   "time": "2023-05-08T19:21:36.144Z",
   "access_list_name": "access-list",
   "access_list_title": "example_title",
@@ -219,7 +219,7 @@ Example:
 ```json
 {
   "code": "TAL005E",
-  "event": "access_list.member.add",
+  "event": "access_list.member.create",
   "time": "2023-05-08T19:21:36.144Z",
   "access_list_name": "access-list",
   "access_list_title": "example_title",
@@ -3487,34 +3487,6 @@ Example:
 }
 ```
 
-## device
-
-Device Enrolled
-
-Example:
-
-```json
-{
-  "cluster_name": "im-a-cluster-name",
-  "code": "TV005I",
-  "device": {
-    "asset_tag": "M2CQVQV64R",
-    "device_id": "99d39707-efdd-436c-94f3-6a1aeef1fbf2",
-    "os_type": 2
-  },
-  "ei": 0,
-  "event": "device",
-  "status": {
-    "success": true
-  },
-  "time": "2023-01-12T19:28:36.842Z",
-  "uid": "94d33b77-82cd-4558-8893-0320699bf755",
-  "user": {
-    "user": "this user wont render properly"
-  }
-}
-```
-
 ## device.authenticate
 
 Device Authenticated
@@ -3602,6 +3574,30 @@ Example:
   "time": "2023-01-12T20:33:20.527Z",
   "uid": "a12e693e-1c45-43e4-a9d1-5fd8399e303c",
   "user": "3827e8ad-7cbe-4423-a80f-dfc89e83eb86.im-a-cluster-name"
+}
+```
+
+## device.enroll
+
+Device Enrolled
+
+Example:
+
+```json
+{
+  "cluster_name": "im-a-cluster-name",
+  "code": "TV005I",
+  "device": {
+    "asset_tag": "M2CQVQV64R",
+    "device_id": "0e288b23-f99f-4635-b182-06e9308095a8",
+    "os_type": 2
+  },
+  "ei": 0,
+  "event": "device.enroll",
+  "success": true,
+  "time": "2023-01-12T21:31:29.191Z",
+  "uid": "bbbc496f-820b-4f49-ae0d-1c1b29faee85",
+  "user": "lisa"
 }
 ```
 
@@ -5020,11 +5016,7 @@ Example:
 }
 ```
 
-## mfa.delete
-
-There are multiple events with the `mfa.delete` type.
-
-### T1006I
+## mfa.add
 
 MFA Device Added
 
@@ -5038,14 +5030,14 @@ Example:
   "mfa_device_type": "U2F",
   "mfa_device_uuid": "7a6fbf23-d75c-4c62-8215-e962d0f2a1f3",
   "ei": 0,
-  "event": "mfa.delete",
+  "event": "mfa.add",
   "time": "2021-03-03T22:58:34.737Z",
   "uid": "9be91d9e-79ec-422b-b6ae-ccf7235476d4",
   "user": "awly"
 }
 ```
 
-### T1007I
+## mfa.delete
 
 MFA Device Deleted
 
@@ -5868,22 +5860,6 @@ Example:
 }
 ```
 
-### TSI004I
-
-All SAML IdP service provider deleted
-
-Example:
-
-```json
-{
-  "code": "TSI004I",
-  "event": "saml.idp.service.provider.delete",
-  "time": "2023-01-25T19:21:36.144Z",
-  "name": "saml-idp",
-  "updated_by": "mike"
-}
-```
-
 ### TSI004W
 
 SAML IdP service provider delete failed
@@ -5894,6 +5870,22 @@ Example:
 {
   "code": "TSI004W",
   "event": "saml.idp.service.provider.delete",
+  "time": "2023-01-25T19:21:36.144Z",
+  "name": "saml-idp",
+  "updated_by": "mike"
+}
+```
+
+## saml.idp.service.provider.delete_all
+
+All SAML IdP service provider deleted
+
+Example:
+
+```json
+{
+  "code": "TSI004I",
+  "event": "saml.idp.service.provider.delete_all",
   "time": "2023-01-25T19:21:36.144Z",
   "name": "saml-idp",
   "updated_by": "mike"

--- a/web/packages/teleport/src/Audit/fixtures/index.ts
+++ b/web/packages/teleport/src/Audit/fixtures/index.ts
@@ -1606,7 +1606,7 @@ export const events = [
     mfa_device_type: 'U2F',
     mfa_device_uuid: '7a6fbf23-d75c-4c62-8215-e962d0f2a1f3',
     ei: 0,
-    event: 'mfa.delete',
+    event: 'mfa.add',
     time: '2021-03-03T22:58:34.737Z',
     uid: '9be91d9e-79ec-422b-b6ae-ccf7235476d4',
     user: 'awly',
@@ -3031,44 +3031,6 @@ export const events = [
   },
   {
     cluster_name: 'im-a-cluster-name',
-    code: 'TV005I',
-    device: {
-      asset_tag: 'M2CQVQV64R',
-      device_id: '99d39707-efdd-436c-94f3-6a1aeef1fbf2',
-      os_type: 2,
-    },
-    ei: 0,
-    event: 'device', // legacy event
-    status: {
-      success: true,
-    },
-    time: '2023-01-12T19:28:36.842Z',
-    uid: '94d33b77-82cd-4558-8893-0320699bf755',
-    user: {
-      user: 'this user wont render properly',
-    },
-  },
-  {
-    cluster_name: 'im-a-cluster-name',
-    code: 'TV005I',
-    device: {
-      asset_tag: 'M2CQVQV64R',
-      device_id: '99d39707-efdd-436c-94f3-6a1aeef1fbf2',
-      os_type: 2,
-    },
-    ei: 0,
-    event: 'device', // legacy event
-    status: {
-      success: false,
-    },
-    time: '2023-01-12T19:28:36.842Z',
-    uid: '94d33b77-82cd-4558-8893-0320699bf755',
-    user: {
-      user: 'this user wont render properly',
-    },
-  },
-  {
-    cluster_name: 'im-a-cluster-name',
     code: 'TV001I',
     device: {
       asset_tag: 'M2CQVQV64R',
@@ -3408,7 +3370,7 @@ export const events = [
   },
   {
     code: 'TSI004I',
-    event: 'saml.idp.service.provider.delete',
+    event: 'saml.idp.service.provider.delete_all',
     time: '2023-01-25T19:21:36.144Z',
     name: 'saml-idp',
     updated_by: 'mike',
@@ -3569,7 +3531,7 @@ export const events = [
   },
   {
     code: 'TAL005I',
-    event: 'access_list.member.add',
+    event: 'access_list.member.create',
     time: '2023-05-08T19:21:36.144Z',
     access_list_name: 'access-list',
     access_list_title: 'example_title',
@@ -3582,7 +3544,7 @@ export const events = [
   },
   {
     code: 'TAL005E',
-    event: 'access_list.member.add',
+    event: 'access_list.member.create',
     time: '2023-05-08T19:21:36.144Z',
     access_list_name: 'access-list',
     access_list_title: 'example_title',

--- a/web/packages/teleport/src/services/audit/gen-event-reference/gen-event-reference.test.ts
+++ b/web/packages/teleport/src/services/audit/gen-event-reference/gen-event-reference.test.ts
@@ -20,6 +20,7 @@ import {
   createEventSection,
   createReferencePage,
   eventsWithoutExamples,
+  fixtureTypeMismatches,
   ReferencePageEventData,
   removeUnknowns,
 } from './gen-event-reference';
@@ -150,6 +151,210 @@ describe('removeUnknowns', () => {
 
   test.each(testCases)('$description', testCase => {
     expect(removeUnknowns(testCase.events, testCase.formatters)).toEqual(
+      testCase.expected
+    );
+  });
+});
+
+describe('fixtureTypeMismatches', () => {
+  const testCases = [
+    {
+      description: 'matching codes with mismatched types',
+      events: [
+        {
+          id: '056517e0-f7e1-4286-b437-c75f3a865af4',
+          time: new Date('2021-03-18T16:28:51.219Z'),
+          user: 'root',
+          message: 'User [root] has deleted a card',
+          codeDesc: 'Unknown',
+          code: 'ABC123',
+          raw: {
+            event: 'billing.delete_card',
+            time: '2020-06-05T16:24:05Z',
+            uid: '68a83a99-73ce-4bd7-bbf7-99103c2ba6a0',
+            code: 'ABC123',
+          },
+        },
+      ],
+      formatters: {
+        ABC123: {
+          type: 'billing.create_card',
+          desc: 'Card created',
+          format: () => {
+            return 'Card created';
+          },
+        },
+      },
+      expected: [
+        {
+          fixtureType: 'billing.delete_card',
+          code: 'ABC123',
+          formatterType: 'billing.create_card',
+        },
+      ],
+    },
+    {
+      description: 'valid case with one event',
+      events: [
+        {
+          id: '056517e0-f7e1-4286-b437-c75f3a865af4',
+          time: new Date('2021-03-18T16:28:51.219Z'),
+          user: 'root',
+          message: 'User [root] has created a card',
+          codeDesc: 'Unknown',
+          code: 'ABC123',
+          raw: {
+            event: 'billing.create_card',
+            time: '2020-06-05T16:24:05Z',
+            uid: '68a83a99-73ce-4bd7-bbf7-99103c2ba6a0',
+            code: 'ABC123',
+          },
+        },
+      ],
+      formatters: {
+        ABC123: {
+          type: 'billing.create_card',
+          desc: 'Card created',
+          format: () => {
+            return 'Card created';
+          },
+        },
+      },
+      expected: [],
+    },
+    {
+      description: 'valid case with event variations',
+      events: [
+        {
+          id: '056517e0-f7e1-4286-b437-c75f3a865af4',
+          time: new Date('2021-03-18T16:28:51.219Z'),
+          user: 'root',
+          message: 'User [root] has created a card',
+          codeDesc: 'Unknown',
+          code: 'ABC123',
+          raw: {
+            event: 'billing.create_card',
+            time: '2020-06-05T16:24:05Z',
+            uid: '68a83a99-73ce-4bd7-bbf7-99103c2ba6a0',
+            code: 'ABC123',
+          },
+        },
+        {
+          id: '056517e0-f7e1-4286-b437-c75f3a865af4',
+          time: new Date('2021-03-18T16:28:51.219Z'),
+          user: 'root',
+          message: 'User [root] has failed to create',
+          codeDesc: 'Unknown',
+          code: 'ABC123E',
+          raw: {
+            event: 'billing.create_card',
+            time: '2020-06-05T16:24:05Z',
+            uid: '68a83a99-73ce-4bd7-bbf7-99103c2ba6a0',
+            code: 'ABC123E',
+          },
+        },
+      ],
+      formatters: {
+        ABC123: {
+          type: 'billing.create_card',
+          desc: 'Card created',
+          format: () => {
+            return 'Card created';
+          },
+        },
+        ABC123E: {
+          type: 'billing.create_card',
+          desc: 'Card creation failure',
+          format: () => {
+            return 'Card created';
+          },
+        },
+      },
+      expected: [],
+    },
+    {
+      description: 'valid case with event variations and missing fixture',
+      events: [
+        {
+          id: '056517e0-f7e1-4286-b437-c75f3a865af4',
+          time: new Date('2021-03-18T16:28:51.219Z'),
+          user: 'root',
+          message: 'User [root] has created a card',
+          codeDesc: 'Unknown',
+          code: 'ABC123',
+          raw: {
+            event: 'billing.create_card',
+            time: '2020-06-05T16:24:05Z',
+            uid: '68a83a99-73ce-4bd7-bbf7-99103c2ba6a0',
+            code: 'ABC123',
+          },
+        },
+      ],
+      formatters: {
+        ABC123: {
+          type: 'billing.create_card',
+          desc: 'Card created',
+          format: () => {
+            return 'Card created';
+          },
+        },
+        ABC123E: {
+          type: 'billing.create_card',
+          desc: 'Card creation failure',
+          format: () => {
+            return 'Card created';
+          },
+        },
+      },
+      expected: [],
+    },
+    {
+      description: 'valid case with event variations and missing formatter',
+      events: [
+        {
+          id: '056517e0-f7e1-4286-b437-c75f3a865af4',
+          time: new Date('2021-03-18T16:28:51.219Z'),
+          user: 'root',
+          message: 'User [root] has created a card',
+          codeDesc: 'Unknown',
+          code: 'ABC123',
+          raw: {
+            event: 'billing.create_card',
+            time: '2020-06-05T16:24:05Z',
+            uid: '68a83a99-73ce-4bd7-bbf7-99103c2ba6a0',
+            code: 'ABC123',
+          },
+        },
+        {
+          id: '056517e0-f7e1-4286-b437-c75f3a865af4',
+          time: new Date('2021-03-18T16:28:51.219Z'),
+          user: 'root',
+          message: 'User [root] has failed to create',
+          codeDesc: 'Unknown',
+          code: 'ABC123E',
+          raw: {
+            event: 'billing.create_card',
+            time: '2020-06-05T16:24:05Z',
+            uid: '68a83a99-73ce-4bd7-bbf7-99103c2ba6a0',
+            code: 'ABC123E',
+          },
+        },
+      ],
+      formatters: {
+        ABC123: {
+          type: 'billing.create_card',
+          desc: 'Card created',
+          format: () => {
+            return 'Card created';
+          },
+        },
+      },
+      expected: [],
+    },
+  ];
+
+  test.each(testCases)('$description', testCase => {
+    expect(fixtureTypeMismatches(testCase.events, testCase.formatters)).toEqual(
       testCase.expected
     );
   });

--- a/web/packages/teleport/src/services/audit/gen-event-reference/gen-event-reference.ts
+++ b/web/packages/teleport/src/services/audit/gen-event-reference/gen-event-reference.ts
@@ -58,6 +58,40 @@ export function removeUnknowns(
   return fixtures.filter(r => r.code in formatters);
 }
 
+export interface FixtureTypeMismatch {
+  code: string;
+  fixtureType: string;
+  formatterType: string;
+}
+
+// fixtureTypeMismatches detects event fixtures with the same code as a
+// formatter, but with a different event type. This prevents incorrect example
+// fixtures from making it into the documentation.
+export function fixtureTypeMismatches(
+  fixtures: Event[],
+  formatters: Formatters
+): FixtureTypeMismatch[] {
+  const formatterCodesToTypes: Map<string, string> = new Map();
+  for (const code in formatters) {
+    const f = formatters[code];
+    formatterCodesToTypes.set(code, f.type);
+  }
+
+  let result: FixtureTypeMismatch[] = [];
+  fixtures.forEach(f => {
+    // Find matching codes with mismatched types
+    const formatterType = formatterCodesToTypes.get(f.code);
+    if (formatterType && f.raw.event !== formatterType) {
+      result.push({
+        code: f.code,
+        formatterType: formatterType,
+        fixtureType: f.raw.event,
+      });
+    }
+  });
+  return result;
+}
+
 // exampleOrAttributes returns a string to include in a reference entry for an
 // audit event that describes the event's attributes.
 //

--- a/web/packages/teleport/src/services/audit/gen-event-reference/index.ts
+++ b/web/packages/teleport/src/services/audit/gen-event-reference/index.ts
@@ -24,9 +24,12 @@ import { formatters } from '../makeEvent';
 import {
   createReferencePage,
   eventsWithoutExamples,
+  fixtureTypeMismatches,
   removeUnknowns,
 } from './gen-event-reference.js';
 
+const fixturePath = 'web/packages/teleport/src/Audit/fixtures/index.ts';
+const formatterPath = 'web/packages/teleport/src/services/audit/makeEvent.ts';
 const introParagraph = `{/*cSpell:disable*/}
 
 {/* Formatted event examples sometimes include different capitalization than
@@ -70,6 +73,16 @@ noExampleEvents.forEach(e => {
     `Warning: adding an entry for ${e.code} (${e.raw.event}) with no example. Add a test fixture to web/packages/teleport/src/Audit/fixtures/index.ts`
   );
 });
+
+const mismatches = fixtureTypeMismatches(events, formatters);
+if (mismatches.length > 0) {
+  mismatches.forEach(m => {
+    console.error(
+      `Fatal: event formatter code ${m.code} has type ${m.formatterType}, but its corresponding fixture has type ${m.fixtureType}. Ensure the formatter at ${formatterPath} matches the fixture at ${fixturePath}`
+    );
+  });
+  process.exit(1);
+}
 
 fs.writeFileSync(
   process.argv[2],

--- a/web/packages/teleport/src/services/audit/makeEvent.ts
+++ b/web/packages/teleport/src/services/audit/makeEvent.ts
@@ -1389,6 +1389,8 @@ export const formatters: Formatters = {
       return `User [${user}] failed to write [${length}] bytes to file [${file_path}] in shared directory [${directory_name}] on desktop [${desktop}]`;
     },
   },
+  // Formatters for DEVICE_* event codes need to check for the presence of a
+  // status field to support legacy events.
   [eventCodes.DEVICE_CREATE]: {
     type: 'device.create',
     desc: 'Device Registered',
@@ -1504,7 +1506,7 @@ export const formatters: Formatters = {
     },
   },
   [eventCodes.UPGRADE_WINDOW_UPDATED]: {
-    type: 'upgradewindow.update',
+    type: 'upgradewindowstart.update',
     desc: 'Upgrade Window Start Updated',
     format: ({ user, upgrade_window_start }) => {
       return `Upgrade Window Start updated to [${upgrade_window_start}] by user [${user}]`;
@@ -1937,7 +1939,7 @@ export const formatters: Formatters = {
       `Access list [${access_list_title || access_list_name}] is invalid and was skipped for member [${user}] because it references non-existent role${missing_roles.length > 1 ? 's' : ''} [${missing_roles}]`,
   },
   [eventCodes.SECURITY_REPORT_AUDIT_QUERY_RUN]: {
-    type: 'secreports.audit.query.run"',
+    type: 'secreports.audit.query.run',
     desc: 'Access Monitoring Query Executed',
     format: ({ user, query }) =>
       `User [${user}] executed Access Monitoring query [${truncateStr(
@@ -1946,7 +1948,7 @@ export const formatters: Formatters = {
       )}]`,
   },
   [eventCodes.SECURITY_REPORT_RUN]: {
-    type: 'secreports.report.run""',
+    type: 'secreports.report.run',
     desc: 'Access Monitoring Report Executed',
     format: ({ user, name }) =>
       `User [${user}] executed [${name}] access monitoring report`,


### PR DESCRIPTION
Closes #62889

Edit the audit event reference generator to identify test fixtures (which we use to generate reference examples) in which the event code maps to a valid event formatter for the Web UI but the event type does not. This way, we can ensure that examples in the audit event reference include valid event types.

Update event types to pass validation:
- Remove trailing `""` characters in event types in some formatters.
- Fix an incorrect event type in a formatter: `upgradewindow.update` should be `upgradewindowstart.update`.
- Fix incorrect event names in fixtures.
- Remove support for legacy `device` events from fixtures. Teleport no longer emits these in v18 and v17. Removing these allows the current variations of these events to appear in the guide instead. Do not change the formatter logic for handling legacy `device` events, since we need to accommodate legacy event types for historical data.