### PR TITLE
Register with rate/connection limiter earlier to prevent denial of service attack against proxy service postgres and mysql endpoints

### DIFF
--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -6162,20 +6162,6 @@ func (process *TeleportProcess) initProxyEndpoint(conn *Connector) error {
 				MatchFunc: alpnproxy.MatchByProtocol(alpncommon.ProtocolPostgres),
 				Handler:   dbProxyServer.PostgresProxy().HandleConnection,
 			})
-			alpnRouter.Add(alpnproxy.HandlerDecs{
-				// For the following protocols ALPN Proxy will handle the
-				// connection internally (terminate wrapped TLS traffic) and
-				// route extracted connection to ALPN Proxy DB TLS Handler.
-				MatchFunc: alpnproxy.MatchByProtocol(
-					alpncommon.ProtocolMongoDB,
-					alpncommon.ProtocolOracle,
-					alpncommon.ProtocolRedisDB,
-					alpncommon.ProtocolSnowflake,
-					alpncommon.ProtocolSQLServer,
-					alpncommon.ProtocolCassandra,
-					alpncommon.ProtocolSpanner,
-				),
-			})
 		}
 
 		logger := process.logger.With(teleport.ComponentKey, teleport.Component(teleport.ComponentDatabase))

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -6152,11 +6152,11 @@ func (process *TeleportProcess) initProxyEndpoint(conn *Connector) error {
 		if alpnRouter != nil && !cfg.Proxy.DisableDatabaseProxy {
 			alpnRouter.Add(alpnproxy.HandlerDecs{
 				MatchFunc:           alpnproxy.MatchByALPNPrefix(string(alpncommon.ProtocolMySQL)),
-				HandlerWithConnInfo: alpnproxy.ExtractMySQLEngineVersion(dbProxyServer.MySQLProxy().HandleConnection),
+				HandlerWithConnInfo: alpnproxy.ExtractMySQLEngineVersion(dbProxyServer.MySQLProxy().HandleConnectionWithLimiting),
 			})
 			alpnRouter.Add(alpnproxy.HandlerDecs{
 				MatchFunc: alpnproxy.MatchByProtocol(alpncommon.ProtocolMySQL),
-				Handler:   dbProxyServer.MySQLProxy().HandleConnection,
+				Handler:   dbProxyServer.MySQLProxy().HandleConnectionWithLimiting,
 			})
 			alpnRouter.Add(alpnproxy.HandlerDecs{
 				MatchFunc: alpnproxy.MatchByProtocol(alpncommon.ProtocolPostgres),

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -6160,7 +6160,7 @@ func (process *TeleportProcess) initProxyEndpoint(conn *Connector) error {
 			})
 			alpnRouter.Add(alpnproxy.HandlerDecs{
 				MatchFunc: alpnproxy.MatchByProtocol(alpncommon.ProtocolPostgres),
-				Handler:   dbProxyServer.PostgresProxy().HandleConnection,
+				Handler:   dbProxyServer.PostgresProxy().HandleConnectionWithLimiting,
 			})
 		}
 

--- a/lib/srv/db/mysql/proxy.go
+++ b/lib/srv/db/mysql/proxy.go
@@ -62,8 +62,26 @@ type Proxy struct {
 	ServerVersion string
 }
 
+func (p *Proxy) HandleConnectionWithLimiting(ctx context.Context, clientConn net.Conn) error {
+	// Apply connection and rate limiting.
+	clientIP, err := utils.ClientIPFromConn(clientConn)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	releaseConn, err := p.Limiter.RegisterRequestAndConnection(clientIP)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	defer releaseConn()
+
+	return trace.Wrap(p.HandleConnection(ctx, clientConn))
+}
+
 // HandleConnection accepts connection from a MySQL client, authenticates
 // it and proxies it to an appropriate database service.
+//
+// Does not apply connection or rate limiting. Use HandleConnectionWithLimiting
+// when accepting untrusted connections directly.
 func (p *Proxy) HandleConnection(ctx context.Context, clientConn net.Conn) (err error) {
 	if p.IngressReporter != nil {
 		p.IngressReporter.ConnectionAccepted(ingress.MySQL, clientConn)
@@ -106,12 +124,6 @@ func (p *Proxy) HandleConnection(ctx context.Context, clientConn net.Conn) (err 
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	// Apply connection and rate limiting.
-	releaseConn, err := p.Limiter.RegisterRequestAndConnection(clientIP)
-	if err != nil {
-		return trace.Wrap(err)
-	}
-	defer releaseConn()
 
 	proxyCtx, err := p.Service.Authorize(ctx, tlsConn, common.ConnectParams{
 		User:     mysqlServer.GetUser(),

--- a/lib/srv/db/postgres/proxy.go
+++ b/lib/srv/db/postgres/proxy.go
@@ -53,8 +53,26 @@ type Proxy struct {
 	IngressReporter *ingress.Reporter
 }
 
+func (p *Proxy) HandleConnectionWithLimiting(ctx context.Context, clientConn net.Conn) error {
+	// Apply connection and rate limiting.
+	clientIP, err := utils.ClientIPFromConn(clientConn)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	releaseConn, err := p.Limiter.RegisterRequestAndConnection(clientIP)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	defer releaseConn()
+
+	return trace.Wrap(p.HandleConnection(ctx, clientConn))
+}
+
 // HandleConnection accepts connection from a Postgres client, authenticates
 // it and proxies it to an appropriate database service.
+//
+// Does not apply connection or rate limiting. Use HandleConnectionWithLimiting
+// when accepting untrusted connections directly.
 func (p *Proxy) HandleConnection(ctx context.Context, clientConn net.Conn) (err error) {
 	if p.IngressReporter != nil {
 		p.IngressReporter.ConnectionAccepted(ingress.Postgres, clientConn)
@@ -82,13 +100,6 @@ func (p *Proxy) handleConnection(ctx context.Context, clientConn utils.TLSConn, 
 	if err != nil {
 		return trace.Wrap(err)
 	}
-
-	// Apply connection and rate limiting.
-	releaseConn, err := p.Limiter.RegisterRequestAndConnection(clientIP)
-	if err != nil {
-		return trace.Wrap(err)
-	}
-	defer releaseConn()
 
 	proxyCtx, err := p.Service.Authorize(ctx, clientConn, common.ConnectParams{
 		ClientIP: clientIP,

--- a/lib/srv/db/proxyserver.go
+++ b/lib/srv/db/proxyserver.go
@@ -196,7 +196,7 @@ func (s *ProxyServer) ServePostgres(listener net.Listener) error {
 		// to listening.
 		go func() {
 			defer clientConn.Close()
-			err := s.PostgresProxy().HandleConnection(s.closeCtx, clientConn)
+			err := s.PostgresProxy().HandleConnectionWithLimiting(s.closeCtx, clientConn)
 			if err != nil && !utils.IsOKNetworkError(err) {
 				s.log.ErrorContext(s.closeCtx, "Failed to handle Postgres client connection.", "error", err)
 			}

--- a/lib/srv/db/proxyserver.go
+++ b/lib/srv/db/proxyserver.go
@@ -220,7 +220,7 @@ func (s *ProxyServer) ServeMySQL(listener net.Listener) error {
 		// Pass over to the MySQL proxy handler.
 		go func() {
 			defer clientConn.Close()
-			err := s.MySQLProxy().HandleConnection(s.closeCtx, clientConn)
+			err := s.MySQLProxy().HandleConnectionWithLimiting(s.closeCtx, clientConn)
 			if err != nil && !utils.IsOKNetworkError(err) {
 				s.log.ErrorContext(s.closeCtx, "Failed to handle MySQL client connection.", "error", err)
 			}

--- a/lib/srv/db/proxyserver_test.go
+++ b/lib/srv/db/proxyserver_test.go
@@ -20,9 +20,11 @@ package db
 
 import (
 	"context"
+	"io"
 	"testing"
 	"time"
 
+	"github.com/go-mysql-org/go-mysql/mysql"
 	"github.com/stretchr/testify/require"
 
 	"github.com/gravitational/teleport/api/types"
@@ -57,8 +59,9 @@ func TestProxyConnectionLimiting(t *testing.T) {
 	testCtx.createUserAndRole(ctx, t, user, role, []string{types.Wildcard}, []string{types.Wildcard})
 
 	tests := []struct {
-		name    string
-		connect func() (func(context.Context) error, error)
+		name          string
+		connect       func() (func(context.Context) error, error)
+		expectedError error
 	}{
 		{
 			"postgres",
@@ -66,6 +69,7 @@ func TestProxyConnectionLimiting(t *testing.T) {
 				pgConn, err := testCtx.postgresClient(ctx, user, "postgres", dbUser, postgresDbName)
 				return pgConn.Close, err
 			},
+			io.EOF,
 		},
 		{
 			"mysql",
@@ -75,6 +79,7 @@ func TestProxyConnectionLimiting(t *testing.T) {
 					return mysqlClient.Close()
 				}, err
 			},
+			mysql.ErrBadConn,
 		},
 	}
 
@@ -102,7 +107,7 @@ func TestProxyConnectionLimiting(t *testing.T) {
 				// This connection should go over the limit.
 				_, err = tt.connect()
 				require.Error(t, err)
-				require.Contains(t, err.Error(), "exceeded connection limit")
+				require.ErrorIs(t, err, tt.expectedError)
 			})
 
 			// When a connection is released a new can be established
@@ -124,7 +129,7 @@ func TestProxyConnectionLimiting(t *testing.T) {
 				// Here the limit should be reached again.
 				_, err = tt.connect()
 				require.Error(t, err)
-				require.Contains(t, err.Error(), "exceeded connection limit")
+				require.ErrorIs(t, err, tt.expectedError)
 			})
 		})
 	}
@@ -167,8 +172,9 @@ func TestProxyRateLimiting(t *testing.T) {
 	testCtx.createUserAndRole(ctx, t, user, role, []string{types.Wildcard}, []string{types.Wildcard})
 
 	tests := []struct {
-		name    string
-		connect func() (func(context.Context) error, error)
+		name          string
+		connect       func() (func(context.Context) error, error)
+		expectedError error
 	}{
 		{
 			"postgres",
@@ -176,6 +182,7 @@ func TestProxyRateLimiting(t *testing.T) {
 				pgConn, err := testCtx.postgresClient(ctx, user, "postgres", dbUser, postgresDbName)
 				return pgConn.Close, err
 			},
+			io.EOF,
 		},
 		{
 			"mysql",
@@ -185,6 +192,7 @@ func TestProxyRateLimiting(t *testing.T) {
 					return mysqlClient.Close()
 				}, err
 			},
+			mysql.ErrBadConn,
 		},
 		{
 			"mongodb",
@@ -192,6 +200,7 @@ func TestProxyRateLimiting(t *testing.T) {
 				mongoClient, err := testCtx.mongoClient(ctx, user, "mongodb", dbUser)
 				return mongoClient.Disconnect, err
 			},
+			io.EOF,
 		},
 		{
 			"redis",
@@ -201,6 +210,7 @@ func TestProxyRateLimiting(t *testing.T) {
 					return redisClient.Close()
 				}, err
 			},
+			io.EOF,
 		},
 	}
 
@@ -224,17 +234,8 @@ func TestProxyRateLimiting(t *testing.T) {
 
 					continue
 				}
-
 				require.Error(t, err)
-
-				switch tt.name {
-				case "mongodb", "redis":
-					//TODO(jakule) currently TLS proxy (which is used by mongodb and redis) doesn't know
-					// how to propagate errors, so this check is disabled.
-				default:
-					require.Contains(t, err.Error(), "rate limit exceeded")
-				}
-
+				require.ErrorIs(t, err, tt.expectedError)
 				return
 			}
 

--- a/lib/srv/db/proxyserver_test.go
+++ b/lib/srv/db/proxyserver_test.go
@@ -60,24 +60,50 @@ func TestProxyConnectionLimiting(t *testing.T) {
 
 	tests := []struct {
 		name          string
-		connect       func() (func(context.Context) error, error)
+		connect       func() (func(context.Context) error, func() error, error)
 		expectedError error
 	}{
 		{
 			"postgres",
-			func() (func(context.Context) error, error) {
+			func() (func(context.Context) error, func() error, error) {
 				pgConn, err := testCtx.postgresClient(ctx, user, "postgres", dbUser, postgresDbName)
-				return pgConn.Close, err
+				return pgConn.Close, func() error { return nil }, err
+			},
+			io.EOF,
+		},
+		// This test case targets ServeTLS, which previously registered the connection
+		// twice with the rate/connection limiter.
+		{
+			"postgres with local proxy",
+			func() (func(context.Context) error, func() error, error) {
+				pgConn, localProxy, err := testCtx.postgresClientLocalProxy(ctx, user, "postgres", dbUser, postgresDbName)
+				return pgConn.Close, localProxy.Close, err
 			},
 			io.EOF,
 		},
 		{
 			"mysql",
-			func() (func(context.Context) error, error) {
+			func() (func(context.Context) error, func() error, error) {
 				mysqlClient, err := testCtx.mysqlClient(user, "mysql", dbUser)
 				return func(_ context.Context) error {
-					return mysqlClient.Close()
-				}, err
+						return mysqlClient.Close()
+					},
+					func() error { return nil },
+					err
+			},
+			mysql.ErrBadConn,
+		},
+		// This test case targets ServeTLS, which previously registered the connection
+		// twice with the rate/connection limiter.
+		{
+			"mysql with local proxy",
+			func() (func(context.Context) error, func() error, error) {
+				mysqlClient, localProxy, err := testCtx.mysqlClientLocalProxy(ctx, user, "mysql", dbUser)
+				return func(_ context.Context) error {
+						return mysqlClient.Close()
+					},
+					localProxy.Close,
+					err
 			},
 			mysql.ErrBadConn,
 		},
@@ -86,7 +112,7 @@ func TestProxyConnectionLimiting(t *testing.T) {
 	for _, tt := range tests {
 
 		t.Run(tt.name, func(t *testing.T) {
-			// Keep close functions to all connections. Call and release all active connection at the end of test.
+			// Keep close functions to all connections and local proxies. Close everything at end of test.
 			connsClosers := make([]func(context.Context) error, 0)
 			t.Cleanup(func() {
 				for _, connClose := range connsClosers {
@@ -94,18 +120,26 @@ func TestProxyConnectionLimiting(t *testing.T) {
 					require.NoError(t, err)
 				}
 			})
+			localProxyCloseFuncs := make([]func() error, 0)
+			t.Cleanup(func() {
+				for _, localProxyCloseFunc := range localProxyCloseFuncs {
+					err := localProxyCloseFunc()
+					require.NoError(t, err)
+				}
+			})
 
 			t.Run("limit can be hit", func(t *testing.T) {
 				for range connLimitNumber {
 					// Try to connect to the database.
-					dbConn, err := tt.connect()
+					dbConn, localProxyCloseFunc, err := tt.connect()
 					require.NoError(t, err)
 
 					connsClosers = append(connsClosers, dbConn)
+					localProxyCloseFuncs = append(localProxyCloseFuncs, localProxyCloseFunc)
 				}
 
 				// This connection should go over the limit.
-				_, err = tt.connect()
+				_, _, err = tt.connect()
 				require.Error(t, err)
 				require.ErrorIs(t, err, tt.expectedError)
 			})
@@ -114,20 +148,26 @@ func TestProxyConnectionLimiting(t *testing.T) {
 			t.Run("reconnect one", func(t *testing.T) {
 				// Get one open connection.
 				require.NotEmpty(t, connsClosers)
+				require.NotEmpty(t, localProxyCloseFuncs)
 				oneConn := connsClosers[len(connsClosers)-1]
 				connsClosers = connsClosers[:len(connsClosers)-1]
+				localProxyCloseFunc := localProxyCloseFuncs[len(localProxyCloseFuncs)-1]
+				localProxyCloseFuncs = localProxyCloseFuncs[:len(localProxyCloseFuncs)-1]
 
 				// Close it, this should decrease the connection limit.
 				err = oneConn(ctx)
 				require.NoError(t, err)
+				err = localProxyCloseFunc()
+				require.NoError(t, err)
 
 				// Create a new connection. We do not expect an error here as we have just closed one.
-				dbConn, err := tt.connect()
+				dbConn, localProxyCloseFunc, err := tt.connect()
 				require.NoError(t, err)
 				connsClosers = append(connsClosers, dbConn)
+				localProxyCloseFuncs = append(localProxyCloseFuncs, localProxyCloseFunc)
 
 				// Here the limit should be reached again.
-				_, err = tt.connect()
+				_, _, err = tt.connect()
 				require.Error(t, err)
 				require.ErrorIs(t, err, tt.expectedError)
 			})


### PR DESCRIPTION
This PR addresses https://github.com/gravitational/pressure-washing/issues/249. Specifically, it registers with the rate/connection limiter earlier in the proxy service connection handling for both postgres and mysql. As far as I can tell, there are three paths a connection can take to hit `HandleConnection` in either case:
1. `proxy_listener_mode: separate` -> `ServePostgres`/`ServeMySQL`
2. ALPN proxy where client cert contains `RouteToDatabase` information.
3. ALPN proxy where client cert does not contain `RouteToDatabase` information but `MatchFunc` in the `HandlerDecs` (sic) matches.

Other things fixed:
1. Removed dead code registering a `HandlerDecs` for non-postgres/non-mysql case in `TeleportProcess.initProxyEndpoint`. See commit message for more information here.
2. Removed double registration with rate/connection limiter in `ProxyServer.handleConnection` -> `s.PostgresProxyNoTLS().HandleConnection` -> `postgres.Proxy.handleConnection` (and equivalent for mysql).
3. Updated unit tests with new error (server now simply closes connection, rather than reporting that rate limiting is being encountered), and with cases for catching double limiter registration.

Changelog: Prevent denial of service attack against proxy service postgresql and mysql endpoints

## Manual Test Plan

### Test Environment

- Local Teleport cluster spun up using the [`teleport-dbtest`](https://github.com/adamkpickering/dbtest) Claude Code skill, which automates starting a Teleport proxy/auth/node with one or more real databases for testing database access features. It requires a directory of Teleport binaries as input and handles `tsh`/`tctl` configuration.
- Postgres and MySQL databases both registered and reachable.
- Tests run by an AI agent: Claude Sonnet 4.6 (`claude-sonnet-4-6`) via the Claude Code CLI harness (FleetView), invoked as an interactive coding agent with access to Bash, file, and skill tools.

### Test Cases

- [x] Postgres, direct connection (bypasses `ServeTLS`).
  - [x] `tsh db connect postgres` succeeds and accepts queries.
- [x] Postgres via local proxy (`tsh proxy db`), which routes through `ServeTLS`.
  - [x] Connection succeeds and accepts queries.
- [x] MySQL, direct connection.
  - [x] `tsh db connect mysql` succeeds and accepts queries.
- [x] MySQL via local proxy (`tsh proxy db`), which routes through `ServeTLS`.
  - [x] Connection succeeds and accepts queries.
