### PR TITLE
service: use GracefulExitContext on event waiting

### DIFF
--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -915,7 +915,7 @@ func (process *TeleportProcess) addConnector(connector *Connector) {
 
 // WaitForConnector is a utility function to wait for an identity event and cast
 // the resulting payload as a *Connector. Returns (nil, nil) when the
-// ExitContext is done, so error checking should happen on the connector rather
+// GracefulExitContext is done, so error checking should happen on the connector rather
 // than the error:
 //
 //	conn, err := process.WaitForConnector("FooIdentity", log)
@@ -923,7 +923,7 @@ func (process *TeleportProcess) addConnector(connector *Connector) {
 //		return trace.Wrap(err)
 //	}
 func (process *TeleportProcess) WaitForConnector(identityEvent string, log *slog.Logger) (*Connector, error) {
-	event, err := process.WaitForEvent(process.ExitContext(), identityEvent)
+	event, err := process.WaitForEvent(process.GracefulExitContext(), identityEvent)
 	if err != nil {
 		if log != nil {
 			log.DebugContext(process.ExitContext(), "Process is exiting.")


### PR DESCRIPTION
It was observed in cloud that proxies will hang on deletion if they lose connection to auth prior to being terminated. This will cause pods to hang until the termination grace period is hit which can be quite long in some cases. Testing this in cloud allowed disconnected proxies to exit quickly when terminated.






<!-- Provide a descriptive entry for the changelog of the next release. -->

Changelog:


<!-- Include manual testing efforts to verify the change. -->
<!-- Detail where the tests where run and what configurations were used. -->
<!-- Include all the test cases which were run to validate the change. -->

## Manual Test Plan
### Test Environment

Cloud Dev environment

### Test Cases
- [x] Disconnected proxies using Chaos Mesh network partition and then terminated pod. 
