### PR TITLE
Add a Shared UserDisplayName Component for the Web UI

### DIFF
--- a/web/packages/shared/components/UserDisplayName/UserDisplayName.story.tsx
+++ b/web/packages/shared/components/UserDisplayName/UserDisplayName.story.tsx
@@ -52,6 +52,8 @@ export default meta;
 
 type Story = StoryObj<typeof UserDisplayName>;
 
+export const Playground: Story = {};
+
 export const LayoutVariants: Story = {
   render: () => (
     <Flex

--- a/web/packages/shared/components/UserDisplayName/UserDisplayName.story.tsx
+++ b/web/packages/shared/components/UserDisplayName/UserDisplayName.story.tsx
@@ -1,0 +1,156 @@
+/**
+ * Teleport
+ * Copyright (C) 2026 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import type { ReactNode } from 'react';
+import styled from 'styled-components';
+
+import { Flex, Text } from 'design';
+
+import { UserDisplayName } from './UserDisplayName';
+
+const meta: Meta<typeof UserDisplayName> = {
+  title: 'Shared/UserDisplayName',
+  component: UserDisplayName,
+  args: {
+    username: 'alice@example.com',
+    primaryText: 'Alice Jones',
+    secondaryText: 'Engineering',
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof UserDisplayName>;
+
+export const LayoutVariants: Story = {
+  render: () => (
+    <Flex
+      alignItems="flex-start"
+      flexDirection="column"
+      gap={3}
+      maxWidth="320px"
+    >
+      <LayoutExample
+        value="inline"
+        description="Primary, secondary, and username stay on one line."
+      >
+        <UserDisplayName
+          username="alice@example.com"
+          primaryText="Alice Jones"
+          secondaryText="Engineering"
+          layout="inline"
+        />
+      </LayoutExample>
+      <LayoutExample
+        value="stacked"
+        description="Primary stays first, with supporting values below it."
+      >
+        <UserDisplayName
+          username="alice@example.com"
+          primaryText="Alice Jones"
+          secondaryText="Engineering"
+          layout="stacked"
+        />
+      </LayoutExample>
+      <LayoutExample
+        value="tooltip"
+        description="Primary stays visible, and username appears in a tooltip."
+      >
+        <UserDisplayName
+          username="alice@example.com"
+          primaryText="Alice Jones"
+          secondaryText="Engineering"
+          layout="tooltip"
+        />
+      </LayoutExample>
+    </Flex>
+  ),
+};
+
+export const LayoutVariantsWithoutSecondary: Story = {
+  render: () => (
+    <Flex
+      alignItems="flex-start"
+      flexDirection="column"
+      gap={3}
+      maxWidth="320px"
+    >
+      <LayoutExample
+        value="inline"
+        description="Primary and username stay on one line."
+      >
+        <UserDisplayName
+          username="alice@example.com"
+          primaryText="Alice Jones"
+          layout="inline"
+        />
+      </LayoutExample>
+      <LayoutExample
+        value="stacked"
+        description="Primary stays first, with username below it."
+      >
+        <UserDisplayName
+          username="alice@example.com"
+          primaryText="Alice Jones"
+          layout="stacked"
+        />
+      </LayoutExample>
+      <LayoutExample
+        value="tooltip"
+        description="Primary stays visible, and username appears in a tooltip."
+      >
+        <UserDisplayName
+          username="alice@example.com"
+          primaryText="Alice Jones"
+          layout="tooltip"
+        />
+      </LayoutExample>
+    </Flex>
+  ),
+};
+
+function LayoutExample({
+  children,
+  description,
+  value,
+}: {
+  children: ReactNode;
+  description: string;
+  value: string;
+}) {
+  return (
+    <Flex alignItems="flex-start" flexDirection="column" gap={2}>
+      <StoryNote>
+        <Text typography="body3">{`layout="${value}"`}</Text>
+        <Text typography="body3" color="text.muted">
+          {description}
+        </Text>
+      </StoryNote>
+      {children}
+    </Flex>
+  );
+}
+
+const StoryNote = styled.div`
+  padding: ${props => props.theme.space[1]}px ${props => props.theme.space[2]}px;
+  border-left: 2px solid
+    ${props => props.theme.colors.interactive.solid.primary.default};
+  border-radius: 0 4px 4px 0;
+  background: ${props => props.theme.colors.levels.surface};
+`;

--- a/web/packages/shared/components/UserDisplayName/UserDisplayName.story.tsx
+++ b/web/packages/shared/components/UserDisplayName/UserDisplayName.story.tsx
@@ -31,7 +31,21 @@ const meta: Meta<typeof UserDisplayName> = {
     username: 'alice@example.com',
     primaryText: 'Alice Jones',
     secondaryText: 'Engineering',
+    layout: 'tooltip',
   },
+  argTypes: {
+    layout: {
+      control: { type: 'radio' },
+      options: ['inline', 'stacked', 'tooltip'],
+    },
+  },
+  decorators: [
+    Story => (
+      <Flex maxWidth="320px">
+        <Story />
+      </Flex>
+    ),
+  ],
 };
 
 export default meta;
@@ -125,6 +139,111 @@ export const LayoutVariantsWithoutSecondary: Story = {
   ),
 };
 
+export const LayoutVariantsWithoutPrimary: Story = {
+  render: () => (
+    <Flex
+      alignItems="flex-start"
+      flexDirection="column"
+      gap={3}
+      maxWidth="320px"
+    >
+      <LayoutExample
+        value="inline"
+        description="Username and secondary stay on one line."
+      >
+        <UserDisplayName
+          username="alice@example.com"
+          secondaryText="Engineering"
+          layout="inline"
+        />
+      </LayoutExample>
+      <LayoutExample
+        value="stacked"
+        description="Username stays first, with secondary below it."
+      >
+        <UserDisplayName
+          username="alice@example.com"
+          secondaryText="Engineering"
+          layout="stacked"
+        />
+      </LayoutExample>
+      <LayoutExample
+        value="tooltip"
+        description="Username stays visible, with secondary below it."
+      >
+        <UserDisplayName
+          username="alice@example.com"
+          secondaryText="Engineering"
+          layout="tooltip"
+        />
+      </LayoutExample>
+    </Flex>
+  ),
+};
+
+export const LayoutVariantsWithoutPrimaryOrSecondary: Story = {
+  render: () => (
+    <Flex
+      alignItems="flex-start"
+      flexDirection="column"
+      gap={3}
+      maxWidth="320px"
+    >
+      <LayoutExample value="inline" description="Username is the only value.">
+        <UserDisplayName username="alice@example.com" layout="inline" />
+      </LayoutExample>
+      <LayoutExample value="stacked" description="Username is the only value.">
+        <UserDisplayName username="alice@example.com" layout="stacked" />
+      </LayoutExample>
+      <LayoutExample value="tooltip" description="Username is the only value.">
+        <UserDisplayName username="alice@example.com" layout="tooltip" />
+      </LayoutExample>
+    </Flex>
+  ),
+};
+
+// LongValues demonstrates that overly long values are truncated with an
+// ellipsis within their container instead of pushing the layout outward.
+export const LongValues: Story = {
+  render: () => (
+    <Flex alignItems="stretch" flexDirection="column" gap={3} width="240px">
+      <LayoutExample
+        value="inline"
+        description="Long values are truncated within a narrow container."
+      >
+        <UserDisplayName
+          username="alice.jones.engineering@very-long-example-domain.com"
+          primaryText="Alice Jones-Anderson-Engineering"
+          secondaryText="Platform Engineering"
+          layout="inline"
+        />
+      </LayoutExample>
+      <LayoutExample
+        value="stacked"
+        description="Each stacked line truncates independently."
+      >
+        <UserDisplayName
+          username="alice.jones.engineering@very-long-example-domain.com"
+          primaryText="Alice Jones-Anderson-Engineering"
+          secondaryText="Platform Engineering"
+          layout="stacked"
+        />
+      </LayoutExample>
+      <LayoutExample
+        value="tooltip"
+        description="Primary truncates inline; full username appears on hover."
+      >
+        <UserDisplayName
+          username="alice.jones.engineering@very-long-example-domain.com"
+          primaryText="Alice Jones-Anderson-Engineering"
+          secondaryText="Platform Engineering"
+          layout="tooltip"
+        />
+      </LayoutExample>
+    </Flex>
+  ),
+};
+
 function LayoutExample({
   children,
   description,
@@ -148,6 +267,8 @@ function LayoutExample({
 }
 
 const StoryNote = styled.div`
+  box-sizing: border-box;
+  max-width: 100%;
   padding: ${props => props.theme.space[1]}px ${props => props.theme.space[2]}px;
   border-left: 2px solid
     ${props => props.theme.colors.interactive.solid.primary.default};

--- a/web/packages/shared/components/UserDisplayName/UserDisplayName.test.tsx
+++ b/web/packages/shared/components/UserDisplayName/UserDisplayName.test.tsx
@@ -112,7 +112,7 @@ describe('UserDisplayName', () => {
     }
   }
 
-  it('formats inline supporting values with delimiters', () => {
+  it('formats inline username with delimiters', () => {
     render(
       <UserDisplayName
         username={username}
@@ -124,14 +124,8 @@ describe('UserDisplayName', () => {
 
     const primaryLine = screen.getByText('Alice Jones')
       .parentElement as HTMLElement;
-    const secondary = within(primaryLine).getByText('Engineering');
+    expect(within(primaryLine).getByText('Engineering')).toBeInTheDocument();
     const inlineUsername = within(primaryLine).getByText(username);
-    expect(secondary).toHaveStyleRule('content', "'<'", {
-      modifier: '::before',
-    });
-    expect(secondary).toHaveStyleRule('content', "'>'", {
-      modifier: '::after',
-    });
     expect(inlineUsername).toHaveStyleRule('content', "'('", {
       modifier: '::before',
     });

--- a/web/packages/shared/components/UserDisplayName/UserDisplayName.test.tsx
+++ b/web/packages/shared/components/UserDisplayName/UserDisplayName.test.tsx
@@ -1,0 +1,191 @@
+/**
+ * Teleport
+ * Copyright (C) 2026 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { render, screen, userEvent, within } from 'design/utils/testing';
+
+import { UserDisplayName, type UserDisplayNameLayout } from './UserDisplayName';
+
+describe('UserDisplayName', () => {
+  const username = 'alice@example.com';
+  const layouts: UserDisplayNameLayout[] = ['inline', 'stacked', 'tooltip'];
+  const valueScenarios: {
+    name: string;
+    primaryText?: string;
+    secondaryText?: string;
+    expectedPrimary: string;
+    expectedSecondary: string | null;
+    expectedVisibleUsernameCountByLayout: Record<UserDisplayNameLayout, number>;
+  }[] = [
+    {
+      name: 'primary, secondary, and username',
+      primaryText: 'Alice Jones',
+      secondaryText: 'Engineering',
+      expectedPrimary: 'Alice Jones',
+      expectedSecondary: 'Engineering',
+      expectedVisibleUsernameCountByLayout: {
+        inline: 1,
+        stacked: 1,
+        tooltip: 0,
+      },
+    },
+    {
+      name: 'only username',
+      expectedPrimary: username,
+      expectedSecondary: null,
+      expectedVisibleUsernameCountByLayout: {
+        inline: 1,
+        stacked: 1,
+        tooltip: 1,
+      },
+    },
+    {
+      name: 'primary and username',
+      primaryText: 'Alice Jones',
+      expectedPrimary: 'Alice Jones',
+      expectedSecondary: null,
+      expectedVisibleUsernameCountByLayout: {
+        inline: 1,
+        stacked: 1,
+        tooltip: 0,
+      },
+    },
+    {
+      name: 'secondary and username',
+      secondaryText: 'Engineering',
+      expectedPrimary: username,
+      expectedSecondary: 'Engineering',
+      expectedVisibleUsernameCountByLayout: {
+        inline: 1,
+        stacked: 1,
+        tooltip: 1,
+      },
+    },
+  ];
+
+  for (const scenario of valueScenarios) {
+    for (const layout of layouts) {
+      it(`renders ${scenario.name} with ${layout} layout`, () => {
+        render(
+          <UserDisplayName
+            username={username}
+            primaryText={scenario.primaryText}
+            secondaryText={scenario.secondaryText}
+            layout={layout}
+          />
+        );
+
+        expect(screen.getByText(scenario.expectedPrimary)).toBeInTheDocument();
+        expect(screen.queryAllByText('Engineering')).toHaveLength(
+          scenario.expectedSecondary ? 1 : 0
+        );
+
+        const expectedVisibleUsernameCount =
+          scenario.expectedVisibleUsernameCountByLayout[layout];
+        expect(screen.queryAllByText(username)).toHaveLength(
+          expectedVisibleUsernameCount
+        );
+
+        const tooltipTriggerLabel = getTooltipAriaLabel(
+          scenario.expectedPrimary,
+          scenario.expectedSecondary,
+          username
+        );
+        expect(screen.queryAllByLabelText(tooltipTriggerLabel)).toHaveLength(
+          layout === 'tooltip' && expectedVisibleUsernameCount === 0 ? 1 : 0
+        );
+      });
+    }
+  }
+
+  it('formats inline supporting values with delimiters', () => {
+    render(
+      <UserDisplayName
+        username={username}
+        primaryText="Alice Jones"
+        secondaryText="Engineering"
+        layout="inline"
+      />
+    );
+
+    const primaryLine = screen.getByText('Alice Jones')
+      .parentElement as HTMLElement;
+    const secondary = within(primaryLine).getByText('Engineering');
+    const inlineUsername = within(primaryLine).getByText(username);
+    expect(secondary).toHaveStyleRule('content', "'<'", {
+      modifier: '::before',
+    });
+    expect(secondary).toHaveStyleRule('content', "'>'", {
+      modifier: '::after',
+    });
+    expect(inlineUsername).toHaveStyleRule('content', "'('", {
+      modifier: '::before',
+    });
+    expect(inlineUsername).toHaveStyleRule('content', "')'", {
+      modifier: '::after',
+    });
+  });
+
+  it('renders stacked supporting values outside the primary line', () => {
+    render(
+      <UserDisplayName
+        username={username}
+        primaryText="Alice Jones"
+        secondaryText="Engineering"
+        layout="stacked"
+      />
+    );
+
+    const primaryLine = screen.getByText('Alice Jones')
+      .parentElement as HTMLElement;
+    expect(
+      within(primaryLine).queryByText('Engineering')
+    ).not.toBeInTheDocument();
+    expect(within(primaryLine).queryByText(username)).not.toBeInTheDocument();
+    expect(screen.getByText('Engineering')).toBeInTheDocument();
+    expect(screen.getByText(username)).toBeInTheDocument();
+  });
+
+  it('defaults to tooltip layout', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <UserDisplayName
+        username={username}
+        primaryText="Alice Jones"
+        secondaryText="Engineering"
+      />
+    );
+
+    expect(screen.queryByText(username)).not.toBeInTheDocument();
+
+    await user.hover(screen.getByText('Alice Jones'));
+
+    const tooltip = await screen.findByRole('tooltip');
+    expect(within(tooltip).getByText(username)).toBeInTheDocument();
+  });
+
+  function getTooltipAriaLabel(
+    primary: string,
+    secondary: string | null | undefined,
+    username: string
+  ) {
+    return [primary, secondary, `username ${username}`]
+      .filter(Boolean)
+      .join(', ');
+  }
+});

--- a/web/packages/shared/components/UserDisplayName/UserDisplayName.tsx
+++ b/web/packages/shared/components/UserDisplayName/UserDisplayName.tsx
@@ -1,0 +1,190 @@
+/**
+ * Teleport
+ * Copyright (C) 2026 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import styled, { css } from 'styled-components';
+
+import { Text } from 'design';
+import { HoverTooltip } from 'design/Tooltip';
+
+export type UserDisplayNameLayout = 'inline' | 'stacked' | 'tooltip';
+
+export type UserDisplayNameProps = {
+  username: string;
+  primaryText?: string;
+  secondaryText?: string;
+  layout?: UserDisplayNameLayout;
+  className?: string;
+};
+
+export function UserDisplayName({
+  username,
+  primaryText,
+  secondaryText,
+  layout = 'tooltip',
+  className,
+}: UserDisplayNameProps) {
+  const displayPrimary = normalizeText(primaryText);
+  const displaySecondary = normalizeText(secondaryText);
+  const primary = displayPrimary || username;
+
+  switch (layout) {
+    case 'inline':
+      return (
+        <Root className={className}>
+          <DisplayLine>
+            <PrimaryValue title={primary}>{primary}</PrimaryValue>
+            {displaySecondary && (
+              <InlineSecondaryValue title={displaySecondary}>
+                {displaySecondary}
+              </InlineSecondaryValue>
+            )}
+            {displayPrimary && (
+              <InlineUsernameValue title={username}>
+                {username}
+              </InlineUsernameValue>
+            )}
+          </DisplayLine>
+        </Root>
+      );
+
+    case 'stacked':
+      return (
+        <Root className={className}>
+          <DisplayLine>
+            <PrimaryValue title={primary}>{primary}</PrimaryValue>
+          </DisplayLine>
+          {displaySecondary && (
+            <SecondaryValue title={displaySecondary}>
+              {displaySecondary}
+            </SecondaryValue>
+          )}
+          {displayPrimary && (
+            <UsernameValue title={username}>{username}</UsernameValue>
+          )}
+        </Root>
+      );
+
+    case 'tooltip':
+      return (
+        <Root className={className}>
+          {displayPrimary ? (
+            <HoverTooltip tipContent={username}>
+              <DisplayLine
+                aria-label={getTooltipAriaLabel(
+                  primary,
+                  displaySecondary,
+                  username
+                )}
+              >
+                <PrimaryValue title={primary}>{primary}</PrimaryValue>
+              </DisplayLine>
+            </HoverTooltip>
+          ) : (
+            <DisplayLine>
+              <PrimaryValue title={primary}>{primary}</PrimaryValue>
+            </DisplayLine>
+          )}
+          {displaySecondary && (
+            <SecondaryValue title={displaySecondary}>
+              {displaySecondary}
+            </SecondaryValue>
+          )}
+        </Root>
+      );
+
+    default:
+      layout satisfies never;
+      return null;
+  }
+}
+
+function normalizeText(text?: string) {
+  const trimmedText = text?.trim();
+  return trimmedText || undefined;
+}
+
+function getTooltipAriaLabel(
+  primary: string,
+  secondary: string | undefined,
+  username: string
+) {
+  return [primary, secondary, `username ${username}`]
+    .filter(Boolean)
+    .join(', ');
+}
+
+const containedContent = css`
+  min-width: 0;
+  max-width: 100%;
+`;
+
+const singleLineText = styled(Text).attrs({
+  as: 'span',
+})`
+  ${containedContent}
+  white-space: nowrap;
+`;
+
+const Root = styled.span`
+  ${containedContent}
+  display: inline-flex;
+  flex-direction: column;
+  vertical-align: middle;
+`;
+
+const DisplayLine = styled.span`
+  ${containedContent}
+  display: inline-flex;
+  align-items: baseline;
+  gap: ${props => props.theme.space[1]}px;
+  overflow: hidden;
+`;
+
+const PrimaryValue = styled(singleLineText).attrs({
+  typography: 'body2',
+})``;
+
+const UsernameValue = styled(singleLineText).attrs({
+  color: 'text.muted',
+  typography: 'body3',
+})``;
+
+const SecondaryValue = styled(singleLineText).attrs({
+  color: 'text.muted',
+  typography: 'body3',
+})``;
+
+const InlineSecondaryValue = styled(SecondaryValue)`
+  &::before {
+    content: '<';
+  }
+
+  &::after {
+    content: '>';
+  }
+`;
+
+const InlineUsernameValue = styled(UsernameValue)`
+  &::before {
+    content: '(';
+  }
+
+  &::after {
+    content: ')';
+  }
+`;

--- a/web/packages/shared/components/UserDisplayName/UserDisplayName.tsx
+++ b/web/packages/shared/components/UserDisplayName/UserDisplayName.tsx
@@ -42,22 +42,36 @@ export function UserDisplayName({
   const displaySecondary = normalizeText(secondaryText);
   const primary = displayPrimary || username;
 
+  const primaryValue = <PrimaryValue title={primary}>{primary}</PrimaryValue>;
+
+  const secondaryValue =
+    displaySecondary &&
+    (layout === 'inline' ? (
+      <InlineSecondaryValue title={displaySecondary}>
+        {displaySecondary}
+      </InlineSecondaryValue>
+    ) : (
+      <SecondaryValue title={displaySecondary}>
+        {displaySecondary}
+      </SecondaryValue>
+    ));
+
+  const usernameValue =
+    displayPrimary &&
+    (layout === 'inline' ? (
+      <InlineUsernameValue title={username}>{username}</InlineUsernameValue>
+    ) : (
+      <UsernameValue title={username}>{username}</UsernameValue>
+    ));
+
   switch (layout) {
     case 'inline':
       return (
         <Root className={className}>
           <DisplayLine>
-            <PrimaryValue title={primary}>{primary}</PrimaryValue>
-            {displaySecondary && (
-              <InlineSecondaryValue title={displaySecondary}>
-                {displaySecondary}
-              </InlineSecondaryValue>
-            )}
-            {displayPrimary && (
-              <InlineUsernameValue title={username}>
-                {username}
-              </InlineUsernameValue>
-            )}
+            {primaryValue}
+            {secondaryValue}
+            {usernameValue}
           </DisplayLine>
         </Root>
       );
@@ -65,17 +79,9 @@ export function UserDisplayName({
     case 'stacked':
       return (
         <Root className={className}>
-          <DisplayLine>
-            <PrimaryValue title={primary}>{primary}</PrimaryValue>
-          </DisplayLine>
-          {displaySecondary && (
-            <SecondaryValue title={displaySecondary}>
-              {displaySecondary}
-            </SecondaryValue>
-          )}
-          {displayPrimary && (
-            <UsernameValue title={username}>{username}</UsernameValue>
-          )}
+          <DisplayLine>{primaryValue}</DisplayLine>
+          {secondaryValue}
+          {usernameValue}
         </Root>
       );
 
@@ -91,19 +97,13 @@ export function UserDisplayName({
                   username
                 )}
               >
-                <PrimaryValue title={primary}>{primary}</PrimaryValue>
+                {primaryValue}
               </DisplayLine>
             </HoverTooltip>
           ) : (
-            <DisplayLine>
-              <PrimaryValue title={primary}>{primary}</PrimaryValue>
-            </DisplayLine>
+            <DisplayLine>{primaryValue}</DisplayLine>
           )}
-          {displaySecondary && (
-            <SecondaryValue title={displaySecondary}>
-              {displaySecondary}
-            </SecondaryValue>
-          )}
+          {secondaryValue}
         </Root>
       );
 

--- a/web/packages/shared/components/UserDisplayName/UserDisplayName.tsx
+++ b/web/packages/shared/components/UserDisplayName/UserDisplayName.tsx
@@ -23,13 +23,13 @@ import { HoverTooltip } from 'design/Tooltip';
 
 export type UserDisplayNameLayout = 'inline' | 'stacked' | 'tooltip';
 
-export type UserDisplayNameProps = {
+export interface UserDisplayNameProps {
   username: string;
   primaryText?: string;
   secondaryText?: string;
   layout?: UserDisplayNameLayout;
   className?: string;
-};
+}
 
 export function UserDisplayName({
   username,
@@ -44,17 +44,9 @@ export function UserDisplayName({
 
   const primaryValue = <PrimaryValue title={primary}>{primary}</PrimaryValue>;
 
-  const secondaryValue =
-    displaySecondary &&
-    (layout === 'inline' ? (
-      <InlineSecondaryValue title={displaySecondary}>
-        {displaySecondary}
-      </InlineSecondaryValue>
-    ) : (
-      <SecondaryValue title={displaySecondary}>
-        {displaySecondary}
-      </SecondaryValue>
-    ));
+  const secondaryValue = displaySecondary && (
+    <SecondaryValue title={displaySecondary}>{displaySecondary}</SecondaryValue>
+  );
 
   const usernameValue =
     displayPrimary &&
@@ -128,6 +120,11 @@ function getTooltipAriaLabel(
     .join(', ');
 }
 
+// `min-width: 0` lets a flex item shrink below its content size, which is what
+// allows the child text to actually trigger ellipsis instead of forcing the
+// container to grow.
+// `max-width: 100%` then keeps the element from spilling past its parent.
+// Without either, long names will push the layout sideways instead of getting truncated.
 const containedContent = css`
   min-width: 0;
   max-width: 100%;
@@ -138,6 +135,8 @@ const singleLineText = styled(Text).attrs({
 })`
   ${containedContent}
   white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 `;
 
 const Root = styled.span`
@@ -151,7 +150,6 @@ const DisplayLine = styled.span`
   display: inline-flex;
   align-items: baseline;
   gap: ${props => props.theme.space[1]}px;
-  overflow: hidden;
 `;
 
 const PrimaryValue = styled(singleLineText).attrs({
@@ -168,16 +166,10 @@ const SecondaryValue = styled(singleLineText).attrs({
   typography: 'body3',
 })``;
 
-const InlineSecondaryValue = styled(SecondaryValue)`
-  &::before {
-    content: '<';
-  }
-
-  &::after {
-    content: '>';
-  }
-`;
-
+// The parentheses are decorative wrappers around the inline username — using
+// `::before/::after` keeps them out of the React text content so they don't
+// appear in `textContent`, snapshots, or the accessibility tree, and lets us
+// style them independently from the value itself.
 const InlineUsernameValue = styled(UsernameValue)`
   &::before {
     content: '(';

--- a/web/packages/shared/components/UserDisplayName/UserDisplayName.tsx
+++ b/web/packages/shared/components/UserDisplayName/UserDisplayName.tsx
@@ -144,7 +144,6 @@ const Root = styled.span`
   ${containedContent}
   display: inline-flex;
   flex-direction: column;
-  vertical-align: middle;
 `;
 
 const DisplayLine = styled.span`

--- a/web/packages/shared/components/UserDisplayName/UserDisplayName.tsx
+++ b/web/packages/shared/components/UserDisplayName/UserDisplayName.tsx
@@ -23,21 +23,19 @@ import { HoverTooltip } from 'design/Tooltip';
 
 export type UserDisplayNameLayout = 'inline' | 'stacked' | 'tooltip';
 
-export interface UserDisplayNameProps {
-  username: string;
-  primaryText?: string;
-  secondaryText?: string;
-  layout?: UserDisplayNameLayout;
-  className?: string;
-}
-
 export function UserDisplayName({
   username,
   primaryText,
   secondaryText,
   layout = 'tooltip',
   className,
-}: UserDisplayNameProps) {
+}: {
+  username: string;
+  primaryText?: string;
+  secondaryText?: string;
+  layout?: UserDisplayNameLayout;
+  className?: string;
+}) {
   const displayPrimary = normalizeText(primaryText);
   const displaySecondary = normalizeText(secondaryText);
   const primary = displayPrimary || username;

--- a/web/packages/shared/components/UserDisplayName/index.ts
+++ b/web/packages/shared/components/UserDisplayName/index.ts
@@ -1,3 +1,21 @@
+/**
+ * Teleport
+ * Copyright (C) 2026 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 export { UserDisplayName } from './UserDisplayName';
 export type {
   UserDisplayNameProps,

--- a/web/packages/shared/components/UserDisplayName/index.ts
+++ b/web/packages/shared/components/UserDisplayName/index.ts
@@ -17,7 +17,4 @@
  */
 
 export { UserDisplayName } from './UserDisplayName';
-export type {
-  UserDisplayNameProps,
-  UserDisplayNameLayout,
-} from './UserDisplayName';
+export type { UserDisplayNameLayout } from './UserDisplayName';

--- a/web/packages/shared/components/UserDisplayName/index.ts
+++ b/web/packages/shared/components/UserDisplayName/index.ts
@@ -1,0 +1,5 @@
+export { UserDisplayName } from './UserDisplayName';
+export type {
+  UserDisplayNameProps,
+  UserDisplayNameLayout,
+} from './UserDisplayName';


### PR DESCRIPTION
This PR addresses [#66993](https://github.com/gravitational/teleport/issues/66993) by adding a shared `UserDisplayName` component under `web/packages/shared/components/UserDisplayName`. The component renders a user's display primary, display secondary, and username in a consistent way so that future Users, Access Request, Access List, and picker surfaces (RFD 302) do not each invent their own display-name rules.

The following changes were made:

- **New shared component (`UserDisplayName`):** Accepts `username`, optional `primaryText` and `secondaryText`, and an optional `layout` prop with three modes:
  - `inline` — primary, secondary, and username render on a single line, with the secondary in smaller font and the username wrapped in `(…)`.
  - `stacked` — primary on the first line; secondary and username stacked below it.
  - `tooltip` (default) — primary stays visible and the username appears in a hover tooltip; secondary, if present, stacks below.

## Storybook rendering ##

[with secondary](https://localhost:9002/?path=/story/shared-userdisplayname--layout-variants)

<img width="368" height="408" alt="Screenshot 2026-05-28 at 6 29 34 PM" src="https://github.com/user-attachments/assets/dc795708-7b10-4342-ba23-0b14d336de60" />


[without secondary](https://localhost:9002/?path=/story/shared-userdisplayname--layout-variants-without-secondary)

<img width="408" height="383" alt="Screenshot 2026-05-27 at 10 34 23 PM" src="https://github.com/user-attachments/assets/10540d05-e478-4393-aeb1-20924d71aadd" />

