### PR TITLE
Add Slack Socket Mode client for app interactions

### DIFF
--- a/integrations/access/slack/socketmode.go
+++ b/integrations/access/slack/socketmode.go
@@ -35,6 +35,8 @@ import (
 )
 
 const (
+	// interactionsBufferSize is the number of interaction events to buffer between Socket Mode client and consumer app.
+	interactionsBufferSize = 10
 	// reconnectBackoffBase is an initial (minimum) backoff value.
 	reconnectBackoffBase = time.Millisecond
 	// reconnectBackoffMax is a backoff threshold.
@@ -42,37 +44,44 @@ const (
 	// pingInterval is the interval to ping the Socket Mode server.
 	pingInterval = 5 * time.Second
 	// pingWriteWait is the write deadline for pings to the Socket Mode server.
-	pingWriteWait = 2 * time.Second
+	pingWriteWait = 3 * time.Second
 	// pongWait is how long to wait for server pongs.
 	pongWait = 4 * pingInterval
 )
 
+// ErrSocketModeDisconnect indicates that Slack Socket Mode server requests a disconnect
+// and the WebSocket connection should be rebuilt.
 var ErrSocketModeDisconnect = errors.New("slack requested disconnect")
 
+// WebSocketURLGenerator provides a method to generate a WebSocket URL for Slack Socket Mode.
 type WebSocketURLGenerator interface {
 	GenerateWebSocketURL(ctx context.Context) (string, error)
 }
 
+// SocketModeClient is the client that receives app interaction events from the Slack Socket Mode server.
 type SocketModeClient struct {
 	interactionsCh chan InteractionEvent
 	urlGenerator   WebSocketURLGenerator
 }
 
 // NewSocketModeClient creates a client to connect to Slack Socket Mode.
-func NewSocketModeClient(urlGenerator WebSocketURLGenerator, bufferSize int) *SocketModeClient {
+func NewSocketModeClient(urlGenerator WebSocketURLGenerator) *SocketModeClient {
 	return &SocketModeClient{
-		interactionsCh: make(chan InteractionEvent, bufferSize),
+		interactionsCh: make(chan InteractionEvent, interactionsBufferSize),
 		urlGenerator:   urlGenerator,
 	}
 }
 
-// Interactions returns the interaction events channel.
+// Interactions returns the interaction events channel. Consumer apps should read from
+// this channel and process Slack interactions for downstream logic.
 func (smc *SocketModeClient) Interactions() <-chan InteractionEvent {
 	return smc.interactionsCh
 }
 
-// Start begins the Socket Mode client. It handles automatic reconnects to the Socket Mode server.
-func (smc *SocketModeClient) Start(ctx context.Context) error {
+// Run starts the Socket Mode client to receive interaction events into the Interactions() channel.
+// It handles automatic reconnects to the Socket Mode server.
+// This is a blocking function that exits on fatal errors or if context is canceled.
+func (smc *SocketModeClient) Run(ctx context.Context) error {
 	log := logger.Get(ctx)
 
 	retry, err := retryutils.NewRetryV2(retryutils.RetryV2Config{
@@ -113,21 +122,21 @@ func (smc *SocketModeClient) Start(ctx context.Context) error {
 }
 
 // run creates a WebSocket connection with the Socket Mode server and
-// receives incoming interaction events.
+// processes incoming Socket Mode events.
 func (smc *SocketModeClient) run(ctx context.Context) error {
 	log := logger.Get(ctx)
 
 	ws, err := smc.connect(ctx)
 	if err != nil {
-		log.ErrorContext(ctx, "failed to connect to Socket Mode server", "error", err)
+		log.ErrorContext(ctx, "Failed to connect to Socket Mode server", "error", err)
 		return trace.Wrap(err)
 	}
 	defer ws.Close()
 
 	log.InfoContext(ctx, "Receiving Socket Mode events...")
 
-	rawCh := make(chan json.RawMessage, 1)
-	ackCh := make(chan string, 1)
+	rawCh := make(chan json.RawMessage)
+	ackCh := make(chan string)
 
 	g, gctx := errgroup.WithContext(ctx)
 
@@ -162,7 +171,7 @@ func (smc *SocketModeClient) connect(ctx context.Context) (*websocket.Conn, erro
 
 	socketModeURL, err := smc.urlGenerator.GenerateWebSocketURL(ctx)
 	if err != nil {
-		log.ErrorContext(ctx, "failed to open a WebSocket URL for Socket Mode", "error", err)
+		log.ErrorContext(ctx, "Failed to open a WebSocket URL for Socket Mode", "error", err)
 		return nil, trace.Wrap(err)
 	}
 
@@ -216,7 +225,7 @@ func (smc *SocketModeClient) readPump(ctx context.Context, ws *websocket.Conn, r
 		err := ws.ReadJSON(&raw)
 		if err != nil {
 			// Only log unexpected network errors to avoid cluttering the logs.
-			if websocket.IsUnexpectedCloseError(err, websocket.CloseNormalClosure, websocket.CloseGoingAway) &&
+			if !websocket.IsCloseError(err, websocket.CloseNormalClosure, websocket.CloseGoingAway) &&
 				!utils.IsOKNetworkError(err) {
 				log.WarnContext(ctx, "websocket ReadJSON error", "error", err)
 			}
@@ -248,7 +257,7 @@ func (smc *SocketModeClient) writePump(ctx context.Context, ws *websocket.Conn, 
 	}
 }
 
-// parseEvents parses events from the raw events channel to the client channel.
+// parseEvents parses events from the raw events channel and sends to the client Interactions() channel.
 // It sends ack responses to the write pump.
 func (smc *SocketModeClient) parseEvents(ctx context.Context, rawCh <-chan json.RawMessage, ackCh chan<- string) error {
 	log := logger.Get(ctx)
@@ -259,20 +268,24 @@ func (smc *SocketModeClient) parseEvents(ctx context.Context, rawCh <-chan json.
 		case raw := <-rawCh:
 			var e SocketModeEvent
 			if err := json.Unmarshal(raw, &e); err != nil {
-				log.WarnContext(ctx, "error unmarshaling slack event, skipping...", "error", err)
+				log.WarnContext(ctx, "Error unmarshaling slack event, skipping...", "error", err, "raw_event", raw)
 				continue
 			}
 
 			switch e.Type {
 			case SocketModeEventTypeHello:
-				log.DebugContext(ctx, "received hello")
+				log.DebugContext(ctx, "Received hello",
+					"connection_info", e.ConnectionInfo,
+					"num_connections", e.NumConnections,
+					"debug_info", e.DebugInfo,
+				)
 			case SocketModeEventTypeDisconnect:
-				log.DebugContext(ctx, "received disconnect", "reason", e.Reason, "debug_info", e.DebugInfo)
+				log.DebugContext(ctx, "Received disconnect", "reason", e.Reason, "debug_info", e.DebugInfo)
 
 				// Socket Mode server wants to rebuild WebSocket connection.
 				return trace.Wrap(ErrSocketModeDisconnect)
 			case SocketModeEventTypeInteractive:
-				log.DebugContext(ctx, "received interaction event")
+				log.DebugContext(ctx, "Received interaction event")
 
 				// Send an ack to the write goroutine immediately.
 				// Slack expects an ack within 3 seconds of interaction receipt.
@@ -284,7 +297,9 @@ func (smc *SocketModeClient) parseEvents(ctx context.Context, rawCh <-chan json.
 
 				interaction, err := UnmarshalInteractionEvent(e.Payload)
 				if err != nil {
-					log.WarnContext(ctx, "error unmarshaling interaction event, skipping...")
+					log.WarnContext(ctx, "Error unmarshaling interaction event, skipping...",
+						"error", err,
+						"raw_interaction_payload", e.Payload)
 					continue
 				}
 
@@ -302,7 +317,7 @@ func (smc *SocketModeClient) parseEvents(ctx context.Context, rawCh <-chan json.
 // isFatalSocketModeError returns true if the error is fatal for the Socket Mode client, eg. invalid app-level token.
 func isFatalSocketModeError(err error) bool {
 	switch err.Error() {
-	case "token_expired", "not_authed", "invalid_auth", "account_inactive", "token_revoked", "no_permission", "not_allowed_token_type", "missing_args":
+	case "token_expired", "not_authed", "invalid_auth", "account_inactive", "token_revoked", "no_permission", "not_allowed_token_type":
 		return true
 	default:
 		return false

--- a/integrations/access/slack/socketmode.go
+++ b/integrations/access/slack/socketmode.go
@@ -41,6 +41,9 @@ const (
 	reconnectBackoffBase = time.Millisecond
 	// reconnectBackoffMax is a backoff threshold.
 	reconnectBackoffMax = 5 * time.Second
+	// reconnectAutoResetMultiplier is the multiplier applied to reconnectBackoffMax that determines
+	// when the retry attempt counter should be reset.
+	reconnectAutoResetMultiplier = 2
 	// pingInterval is the interval to ping the Socket Mode server.
 	pingInterval = 5 * time.Second
 	// pingWriteWait is the write deadline for pings to the Socket Mode server.
@@ -85,10 +88,11 @@ func (smc *SocketModeClient) Run(ctx context.Context) error {
 	log := logger.Get(ctx)
 
 	retry, err := retryutils.NewRetryV2(retryutils.RetryV2Config{
-		Driver: retryutils.NewExponentialDriver(reconnectBackoffBase),
-		First:  reconnectBackoffBase,
-		Max:    reconnectBackoffMax,
-		Jitter: retryutils.DefaultJitter,
+		Driver:    retryutils.NewExponentialDriver(reconnectBackoffBase),
+		First:     reconnectBackoffBase,
+		Max:       reconnectBackoffMax,
+		Jitter:    retryutils.DefaultJitter,
+		AutoReset: reconnectAutoResetMultiplier,
 	})
 	if err != nil {
 		return trace.Wrap(err)
@@ -268,7 +272,7 @@ func (smc *SocketModeClient) parseEvents(ctx context.Context, rawCh <-chan json.
 		case raw := <-rawCh:
 			var e SocketModeEvent
 			if err := json.Unmarshal(raw, &e); err != nil {
-				log.WarnContext(ctx, "Error unmarshaling slack event, skipping...", "error", err, "raw_event", raw)
+				log.WarnContext(ctx, "Error unmarshaling socket mode event, skipping...", "error", err, "raw_event", raw)
 				continue
 			}
 
@@ -297,9 +301,7 @@ func (smc *SocketModeClient) parseEvents(ctx context.Context, rawCh <-chan json.
 
 				interaction, err := UnmarshalInteractionEvent(e.Payload)
 				if err != nil {
-					log.WarnContext(ctx, "Error unmarshaling interaction event, skipping...",
-						"error", err,
-						"raw_interaction_payload", e.Payload)
+					log.WarnContext(ctx, "Unsupported interaction event, skipping...", "error", err)
 					continue
 				}
 
@@ -317,7 +319,7 @@ func (smc *SocketModeClient) parseEvents(ctx context.Context, rawCh <-chan json.
 // isFatalSocketModeError returns true if the error is fatal for the Socket Mode client, eg. invalid app-level token.
 func isFatalSocketModeError(err error) bool {
 	switch err.Error() {
-	case "token_expired", "not_authed", "invalid_auth", "account_inactive", "token_revoked", "no_permission", "not_allowed_token_type":
+	case "token_expired", "not_authed", "invalid_auth", "account_inactive", "token_revoked", "no_permission", "not_allowed_token_type", "team_access_not_granted", "missing_scope":
 		return true
 	default:
 		return false

--- a/integrations/access/slack/socketmode.go
+++ b/integrations/access/slack/socketmode.go
@@ -102,7 +102,7 @@ func (smc *SocketModeClient) Run(ctx context.Context) error {
 		err := smc.run(ctx)
 		// We must exit on fatal connection errors (eg. invalid auth token to Slack).
 		// Otherwise, reconnect after a backoff for transient errors or Slack disconnect requests.
-		if err != nil && isFatalSocketModeError(err) {
+		if err != nil && isFatalSocketModeError(trace.Unwrap(err)) {
 			return trace.Wrap(err)
 		}
 		// Context is done, exit immediately.
@@ -151,19 +151,19 @@ func (smc *SocketModeClient) run(ctx context.Context) error {
 	defer stop()
 
 	g.Go(func() error {
-		return smc.ping(gctx, ws)
+		return trace.Wrap(smc.ping(gctx, ws), "ping routine")
 	})
 
 	g.Go(func() error {
-		return smc.parseEvents(gctx, rawCh, ackCh)
+		return trace.Wrap(smc.parseEvents(gctx, rawCh, ackCh), "parseEvents routine")
 	})
 
 	g.Go(func() error {
-		return smc.writePump(gctx, ws, ackCh)
+		return trace.Wrap(smc.writePump(gctx, ws, ackCh), "writePump routine")
 	})
 
 	g.Go(func() error {
-		return smc.readPump(gctx, ws, rawCh)
+		return trace.Wrap(smc.readPump(gctx, ws, rawCh), "readPump routine")
 	})
 
 	return trace.Wrap(g.Wait())
@@ -322,6 +322,8 @@ func (smc *SocketModeClient) parseEvents(ctx context.Context, rawCh <-chan json.
 }
 
 // isFatalSocketModeError returns true if the error is fatal for the Socket Mode client, eg. invalid app-level token or Socket Mode is disabled.
+// See https://docs.slack.dev/reference/methods/apps.connections.open/ for generating a WebSocket URL and its error list.
+// See https://docs.slack.dev/apis/events-api/using-socket-mode/#disconnect for Socket Mode disconnect messages.
 func isFatalSocketModeError(err error) bool {
 	switch err.Error() {
 	case SocketModeEventReasonLinkDisabled:

--- a/integrations/access/slack/socketmode.go
+++ b/integrations/access/slack/socketmode.go
@@ -1,0 +1,310 @@
+/*
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package slack
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"time"
+
+	"github.com/gorilla/websocket"
+	"github.com/gravitational/trace"
+	"golang.org/x/sync/errgroup"
+
+	"github.com/gravitational/teleport/api/utils/retryutils"
+	"github.com/gravitational/teleport/integrations/lib/logger"
+	"github.com/gravitational/teleport/lib/utils"
+)
+
+const (
+	// reconnectBackoffBase is an initial (minimum) backoff value.
+	reconnectBackoffBase = time.Millisecond
+	// reconnectBackoffMax is a backoff threshold.
+	reconnectBackoffMax = 5 * time.Second
+	// pingInterval is the interval to ping the Socket Mode server.
+	pingInterval = 5 * time.Second
+	// pingWriteWait is the write deadline for pings to the Socket Mode server.
+	pingWriteWait = 2 * time.Second
+	// pongWait is how long to wait for server pongs.
+	pongWait = 4 * pingInterval
+)
+
+var ErrSocketModeDisconnect = errors.New("slack requested disconnect")
+
+type WebSocketURLGenerator interface {
+	GenerateWebSocketURL(ctx context.Context) (string, error)
+}
+
+type SocketModeClient struct {
+	interactionsCh chan InteractionEvent
+	urlGenerator   WebSocketURLGenerator
+}
+
+// NewSocketModeClient creates a client to connect to Slack Socket Mode.
+func NewSocketModeClient(urlGenerator WebSocketURLGenerator, bufferSize int) *SocketModeClient {
+	return &SocketModeClient{
+		interactionsCh: make(chan InteractionEvent, bufferSize),
+		urlGenerator:   urlGenerator,
+	}
+}
+
+// Interactions returns the interaction events channel.
+func (smc *SocketModeClient) Interactions() <-chan InteractionEvent {
+	return smc.interactionsCh
+}
+
+// Start begins the Socket Mode client. It handles automatic reconnects to the Socket Mode server.
+func (smc *SocketModeClient) Start(ctx context.Context) error {
+	log := logger.Get(ctx)
+
+	retry, err := retryutils.NewRetryV2(retryutils.RetryV2Config{
+		Driver: retryutils.NewExponentialDriver(reconnectBackoffBase),
+		First:  reconnectBackoffBase,
+		Max:    reconnectBackoffMax,
+		Jitter: retryutils.DefaultJitter,
+	})
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	for {
+		err := smc.run(ctx)
+		// We must exit on fatal connection errors (eg. invalid auth token to Slack).
+		// Otherwise, reconnect after a backoff for transient errors or Slack disconnect requests.
+		if err != nil && isFatalSocketModeError(err) {
+			return trace.Wrap(err)
+		}
+		// Context is done, exit immediately.
+		if ctx.Err() != nil {
+			log.DebugContext(ctx, "Socket Mode client is canceled")
+			return nil
+		}
+
+		log.DebugContext(ctx, "Disconnected from Socket Mode server, reconnecting...",
+			"error", trace.UserMessageWithFields(err),
+		)
+
+		select {
+		case <-retry.After():
+			retry.Inc()
+		case <-ctx.Done():
+			log.DebugContext(ctx, "Socket Mode client is canceled")
+			return nil
+		}
+	}
+}
+
+// run creates a WebSocket connection with the Socket Mode server and
+// receives incoming interaction events.
+func (smc *SocketModeClient) run(ctx context.Context) error {
+	log := logger.Get(ctx)
+
+	ws, err := smc.connect(ctx)
+	if err != nil {
+		log.ErrorContext(ctx, "failed to connect to Socket Mode server", "error", err)
+		return trace.Wrap(err)
+	}
+	defer ws.Close()
+
+	log.InfoContext(ctx, "Receiving Socket Mode events...")
+
+	rawCh := make(chan json.RawMessage, 1)
+	ackCh := make(chan string, 1)
+
+	g, gctx := errgroup.WithContext(ctx)
+
+	// Upon context cancellation, force close connection to unblock ws.ReadJSON.
+	stop := context.AfterFunc(gctx, func() {
+		_ = ws.Close()
+	})
+	defer stop()
+
+	g.Go(func() error {
+		return smc.ping(gctx, ws)
+	})
+
+	g.Go(func() error {
+		return smc.parseEvents(gctx, rawCh, ackCh)
+	})
+
+	g.Go(func() error {
+		return smc.writePump(gctx, ws, ackCh)
+	})
+
+	g.Go(func() error {
+		return smc.readPump(gctx, ws, rawCh)
+	})
+
+	return trace.Wrap(g.Wait())
+}
+
+// connect opens and dials a temporary WebSocket URL from the Slack API.
+func (smc *SocketModeClient) connect(ctx context.Context) (*websocket.Conn, error) {
+	log := logger.Get(ctx)
+
+	socketModeURL, err := smc.urlGenerator.GenerateWebSocketURL(ctx)
+	if err != nil {
+		log.ErrorContext(ctx, "failed to open a WebSocket URL for Socket Mode", "error", err)
+		return nil, trace.Wrap(err)
+	}
+
+	ws, resp, err := websocket.DefaultDialer.DialContext(ctx, socketModeURL, nil)
+	if resp != nil && resp.Body != nil {
+		defer resp.Body.Close()
+	}
+	if err != nil {
+		if errors.Is(err, websocket.ErrBadHandshake) {
+			// resp is non-nil in this case, so we can read the http response body
+			body, readErr := io.ReadAll(resp.Body)
+			if readErr != nil {
+				return nil, trace.Wrap(readErr)
+			}
+			return nil, trace.BadParameter("websocket bad handshake: %s", string(body))
+		}
+		return nil, trace.Wrap(err)
+	}
+
+	return ws, nil
+}
+
+// ping will periodically ping Socket Mode server to maintain connectivity.
+func (smc *SocketModeClient) ping(ctx context.Context, ws *websocket.Conn) error {
+	ticker := time.NewTicker(pingInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-ticker.C:
+			if err := ws.WriteControl(websocket.PingMessage, nil, time.Now().Add(pingWriteWait)); err != nil {
+				return trace.Wrap(err)
+			}
+		}
+	}
+}
+
+// readPump pumps incoming Socket Mode interaction events to the raw events channel.
+func (smc *SocketModeClient) readPump(ctx context.Context, ws *websocket.Conn, rawCh chan<- json.RawMessage) error {
+	log := logger.Get(ctx)
+
+	ws.SetReadDeadline(time.Now().Add(pongWait))
+	ws.SetPongHandler(func(string) error {
+		ws.SetReadDeadline(time.Now().Add(pongWait))
+		return nil
+	})
+	for {
+		var raw json.RawMessage
+		err := ws.ReadJSON(&raw)
+		if err != nil {
+			// Only log unexpected network errors to avoid cluttering the logs.
+			if websocket.IsUnexpectedCloseError(err, websocket.CloseNormalClosure, websocket.CloseGoingAway) &&
+				!utils.IsOKNetworkError(err) {
+				log.WarnContext(ctx, "websocket ReadJSON error", "error", err)
+			}
+			return trace.Wrap(err)
+		}
+
+		select {
+		case rawCh <- raw:
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+}
+
+// writePump writes ack messages back to the WebSocket connection.
+func (smc *SocketModeClient) writePump(ctx context.Context, ws *websocket.Conn, ackCh <-chan string) error {
+	log := logger.Get(ctx)
+	for {
+		select {
+		case envelopeID := <-ackCh:
+			err := ws.WriteJSON(SocketModeAckResponse{EnvelopeID: envelopeID})
+			if err != nil {
+				log.WarnContext(ctx, "websocket WriteJSON error", "error", err)
+				return trace.Wrap(err)
+			}
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+}
+
+// parseEvents parses events from the raw events channel to the client channel.
+// It sends ack responses to the write pump.
+func (smc *SocketModeClient) parseEvents(ctx context.Context, rawCh <-chan json.RawMessage, ackCh chan<- string) error {
+	log := logger.Get(ctx)
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case raw := <-rawCh:
+			var e SocketModeEvent
+			if err := json.Unmarshal(raw, &e); err != nil {
+				log.WarnContext(ctx, "error unmarshaling slack event, skipping...", "error", err)
+				continue
+			}
+
+			switch e.Type {
+			case SocketModeEventTypeHello:
+				log.DebugContext(ctx, "received hello")
+			case SocketModeEventTypeDisconnect:
+				log.DebugContext(ctx, "received disconnect", "reason", e.Reason, "debug_info", e.DebugInfo)
+
+				// Socket Mode server wants to rebuild WebSocket connection.
+				return trace.Wrap(ErrSocketModeDisconnect)
+			case SocketModeEventTypeInteractive:
+				log.DebugContext(ctx, "received interaction event")
+
+				// Send an ack to the write goroutine immediately.
+				// Slack expects an ack within 3 seconds of interaction receipt.
+				select {
+				case ackCh <- e.EnvelopeID:
+				case <-ctx.Done():
+					return ctx.Err()
+				}
+
+				interaction, err := UnmarshalInteractionEvent(e.Payload)
+				if err != nil {
+					log.WarnContext(ctx, "error unmarshaling interaction event, skipping...")
+					continue
+				}
+
+				// Send to consumer app to handle interactions downstream.
+				select {
+				case smc.interactionsCh <- interaction:
+				case <-ctx.Done():
+					return ctx.Err()
+				}
+			}
+		}
+	}
+}
+
+// isFatalSocketModeError returns true if the error is fatal for the Socket Mode client, eg. invalid app-level token.
+func isFatalSocketModeError(err error) bool {
+	switch err.Error() {
+	case "token_expired", "not_authed", "invalid_auth", "account_inactive", "token_revoked", "no_permission", "not_allowed_token_type", "missing_args":
+		return true
+	default:
+		return false
+	}
+}

--- a/integrations/access/slack/socketmode.go
+++ b/integrations/access/slack/socketmode.go
@@ -286,6 +286,11 @@ func (smc *SocketModeClient) parseEvents(ctx context.Context, rawCh <-chan json.
 			case SocketModeEventTypeDisconnect:
 				log.DebugContext(ctx, "Received disconnect", "reason", e.Reason, "debug_info", e.DebugInfo)
 
+				// Socket Mode is disabled in Slack app settings.
+				if e.Reason == SocketModeEventReasonLinkDisabled {
+					return trace.Errorf("%s", SocketModeEventReasonLinkDisabled)
+				}
+
 				// Socket Mode server wants to rebuild WebSocket connection.
 				return trace.Wrap(ErrSocketModeDisconnect)
 			case SocketModeEventTypeInteractive:
@@ -316,10 +321,14 @@ func (smc *SocketModeClient) parseEvents(ctx context.Context, rawCh <-chan json.
 	}
 }
 
-// isFatalSocketModeError returns true if the error is fatal for the Socket Mode client, eg. invalid app-level token.
+// isFatalSocketModeError returns true if the error is fatal for the Socket Mode client, eg. invalid app-level token or Socket Mode is disabled.
 func isFatalSocketModeError(err error) bool {
 	switch err.Error() {
+	case SocketModeEventReasonLinkDisabled:
+		// Socket Mode is disabled in app settings.
+		return true
 	case "token_expired", "not_authed", "invalid_auth", "account_inactive", "token_revoked", "no_permission", "not_allowed_token_type", "team_access_not_granted", "missing_scope":
+		// API authn/authz errors that are not retry-able.
 		return true
 	default:
 		return false

--- a/integrations/access/slack/socketmode_test.go
+++ b/integrations/access/slack/socketmode_test.go
@@ -1,0 +1,187 @@
+/*
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package slack
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"testing/synctest"
+	"time"
+
+	"github.com/gorilla/websocket"
+	"github.com/stretchr/testify/require"
+)
+
+var interactionPayload = `{
+	"type":"interactive",
+	"envelope_id":"env-1",
+	"payload":{
+		"type":"block_actions",
+		"user":{"id":"U1"},
+		"channel":{"id":"C1"},
+		"actions":[{"type":"button","action_id":"approve_button","value":"req-1"}]
+	}
+}`
+
+var malformedPayload = `{ malformed }`
+
+var nonBlockActionsPayload = `{
+	"type":"interactive",
+	"envelope_id":"env-1",
+	"payload":{
+		"type":"slash"
+	}
+}`
+
+var disconnectPayload = `{
+  	"type": "disconnect",
+  	"reason": "warning",
+  	"debug_info": {
+    	"host": "example_slack_host"
+  	}
+}`
+
+func newTestSocket(t *testing.T, onConn func(*websocket.Conn)) *websocket.Conn {
+	t.Helper()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		upgrader := websocket.Upgrader{}
+		serverConn, err := upgrader.Upgrade(w, r, nil)
+		require.NoError(t, err)
+		defer serverConn.Close()
+
+		onConn(serverConn)
+	}))
+
+	wsURL := "ws" + strings.TrimPrefix(srv.URL, "http")
+	clientConn, resp, err := websocket.DefaultDialer.Dial(wsURL, nil)
+	if resp != nil && resp.Body != nil {
+		defer resp.Body.Close()
+	}
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		srv.Close()
+	})
+
+	return clientConn
+}
+
+func TestReadPump_WebSocketCloseError(t *testing.T) {
+	clientConn := newTestSocket(t, func(ws *websocket.Conn) {
+		require.NoError(t, ws.WriteMessage(websocket.TextMessage, []byte(disconnectPayload)))
+		require.NoError(t, ws.WriteControl(websocket.CloseMessage,
+			websocket.FormatCloseMessage(websocket.CloseNormalClosure, ""),
+			time.Time{}))
+	})
+	defer clientConn.Close()
+
+	client := &SocketModeClient{
+		interactionsCh: make(chan InteractionEvent, 1),
+	}
+
+	rawCh := make(chan json.RawMessage, 1)
+
+	err := client.readPump(t.Context(), clientConn, rawCh)
+
+	select {
+	case raw := <-rawCh:
+		require.JSONEq(t, disconnectPayload, string(raw))
+	default:
+		t.Fatal("failed to receive disconnect payload")
+	}
+	// WebSocket close should return an error in order to trigger reconnect.
+	require.Error(t, err)
+}
+
+func TestParseEvents(t *testing.T) {
+	tests := []struct {
+		name           string
+		payload        string
+		hasInteraction bool
+		wantAck        bool
+		wantErr        error
+	}{
+		{
+			name:           "interaction payload",
+			payload:        interactionPayload,
+			wantAck:        true,
+			hasInteraction: true,
+		},
+		{
+			name:    "malformed payload; skip",
+			payload: malformedPayload,
+		},
+		{
+			name:    "non block_actions payload; ack & skip",
+			payload: nonBlockActionsPayload,
+			wantAck: true,
+		},
+		{
+			name:    "disconnect",
+			payload: disconnectPayload,
+			wantErr: ErrSocketModeDisconnect,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			synctest.Test(t, func(t *testing.T) {
+				ctx, cancel := context.WithCancel(t.Context())
+				client := &SocketModeClient{
+					interactionsCh: make(chan InteractionEvent, 1),
+				}
+
+				rawCh := make(chan json.RawMessage, 1)
+				ackCh := make(chan string, 1)
+
+				done := make(chan error)
+				go func() {
+					done <- client.parseEvents(ctx, rawCh, ackCh)
+				}()
+
+				rawCh <- json.RawMessage(tt.payload)
+
+				synctest.Wait()
+				if tt.wantAck {
+					select {
+					case envelopeID := <-ackCh:
+						require.Equal(t, "env-1", envelopeID)
+					default:
+						t.Fatal("failed to receive ack")
+					}
+				}
+
+				require.Equal(t, tt.hasInteraction, len(client.Interactions()) > 0)
+
+				cancel()
+				synctest.Wait()
+				if tt.wantErr != nil {
+					require.ErrorIs(t, <-done, tt.wantErr)
+				} else {
+					require.ErrorIs(t, <-done, context.Canceled)
+				}
+			})
+		})
+	}
+}

--- a/integrations/access/slack/status.go
+++ b/integrations/access/slack/status.go
@@ -35,7 +35,7 @@ func statusFromResponse(resp *APIResponse) types.PluginStatus {
 	switch resp.Error {
 	case "channel_not_found", "not_in_channel":
 		code = types.PluginStatusCode_SLACK_NOT_IN_CHANNEL
-	case "token_expired", "not_authed", "invalid_auth", "account_inactive", "token_revoked", "no_permission", "org_login_required":
+	case "token_expired", "not_authed", "invalid_auth", "account_inactive", "token_revoked", "no_permission", "org_login_required", "not_allowed_token_type":
 		code = types.PluginStatusCode_UNAUTHORIZED
 	}
 	return &types.PluginStatusV1{Code: code}

--- a/integrations/access/slack/status.go
+++ b/integrations/access/slack/status.go
@@ -35,7 +35,7 @@ func statusFromResponse(resp *APIResponse) types.PluginStatus {
 	switch resp.Error {
 	case "channel_not_found", "not_in_channel":
 		code = types.PluginStatusCode_SLACK_NOT_IN_CHANNEL
-	case "token_expired", "not_authed", "invalid_auth", "account_inactive", "token_revoked", "no_permission", "org_login_required", "not_allowed_token_type":
+	case "token_expired", "not_authed", "invalid_auth", "account_inactive", "token_revoked", "no_permission", "org_login_required", "not_allowed_token_type", "team_access_not_granted", "missing_scope":
 		code = types.PluginStatusCode_UNAUTHORIZED
 	}
 	return &types.PluginStatusV1{Code: code}

--- a/integrations/access/slack/types.go
+++ b/integrations/access/slack/types.go
@@ -93,13 +93,16 @@ type SocketModeEvent struct {
 	DebugInfo json.RawMessage `json:"debug_info,omitempty"`
 
 	// `hello` type
+
 	NumConnections int             `json:"num_connections"`
 	ConnectionInfo json.RawMessage `json:"connection_info"`
 
 	// `disconnect` type
+
 	Reason string `json:"reason"`
 
 	// `interactive` type
+
 	EnvelopeID             string          `json:"envelope_id"`
 	AcceptsResponsePayload bool            `json:"accepts_response_payload"`
 	Payload                json.RawMessage `json:"payload"`
@@ -107,12 +110,18 @@ type SocketModeEvent struct {
 	RetryReason            string          `json:"retry_reason"`
 }
 
+// InteractionEventType is the type of interaction event received from Slack Socket Mode.
 type InteractionEventType string
 
+// InteractionEvent is an app interaction event received from Slack Socket Mode,
+// such as a button interaction within an Actions block.
 type InteractionEvent interface {
+	// Type is type of InteractionEvent.
 	Type() InteractionEventType
 }
 
+// UnmarshalInteractionEvent unmarshals a raw interaction payload based on the type
+// of interaction. Currently, we only handle "block_actions" type.
 func UnmarshalInteractionEvent(data []byte) (InteractionEvent, error) {
 	var interactionType struct {
 		Type InteractionEventType `json:"type"`
@@ -145,8 +154,8 @@ type BlockActionsEvent struct {
 	APIAppID      string          `json:"api_app_id"`
 	Actions       []Action        `json:"actions"`
 	Interactivity json.RawMessage `json:"interactivity"`
-	Channel       Channel         `json:"channel,omitempty"`
-	Message       Message         `json:"message,omitempty"`
+	Channel       Channel         `json:"channel,omitzero"`
+	Message       Message         `json:"message,omitzero"`
 }
 
 func (p BlockActionsEvent) Type() InteractionEventType {

--- a/integrations/access/slack/types.go
+++ b/integrations/access/slack/types.go
@@ -24,6 +24,14 @@ import (
 	"github.com/gravitational/trace"
 )
 
+// Slack API: Socket Mode constants
+
+const (
+	SocketModeEventTypeHello       = "hello"
+	SocketModeEventTypeDisconnect  = "disconnect"
+	SocketModeEventTypeInteractive = "interactive"
+)
+
 // Slack API types
 
 type APIResponse struct {
@@ -70,6 +78,92 @@ type AccessResponse struct {
 	AccessToken      string `json:"access_token"`
 	RefreshToken     string `json:"refresh_token"`
 	ExpiresInSeconds int    `json:"expires_in"`
+}
+
+// Slack API: Socket Mode (interactivity)
+
+type SocketModeAckResponse struct {
+	EnvelopeID string          `json:"envelope_id"`
+	Payload    json.RawMessage `json:"payload,omitempty"`
+}
+
+type SocketModeEvent struct {
+	Type      string          `json:"type"`
+	DebugInfo json.RawMessage `json:"debug_info,omitempty"`
+
+	// `hello` type
+	NumConnections int             `json:"num_connections"`
+	ConnectionInfo json.RawMessage `json:"connection_info"`
+
+	// `disconnect` type
+	Reason string `json:"reason"`
+
+	// `interactive` type
+	EnvelopeID             string          `json:"envelope_id"`
+	AcceptsResponsePayload bool            `json:"accepts_response_payload"`
+	Payload                json.RawMessage `json:"payload"`
+	RetryAttempt           int             `json:"retry_attempt"`
+	RetryReason            string          `json:"retry_reason"`
+}
+
+type InteractionEventType string
+
+type InteractionEvent interface {
+	Type() InteractionEventType
+}
+
+func UnmarshalInteractionEvent(data []byte) (InteractionEvent, error) {
+	var interactionType struct {
+		Type InteractionEventType `json:"type"`
+	}
+	if err := json.Unmarshal(data, &interactionType); err != nil {
+		return nil, trace.Wrap(err)
+	}
+	var interaction InteractionEvent
+	var err error
+	switch interactionType.Type {
+	case BlockActionsEvent{}.Type():
+		var val BlockActionsEvent
+		err = trace.Wrap(json.Unmarshal(data, &val))
+		interaction = val
+	default:
+		err = trace.BadParameter("unsupported interaction event type %q", interactionType.Type)
+	}
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return interaction, nil
+}
+
+type BlockActionsEvent struct {
+	User          User            `json:"user"`
+	Team          json.RawMessage `json:"team"`
+	TriggerID     string          `json:"trigger_id"`
+	Container     json.RawMessage `json:"container"`
+	APIAppID      string          `json:"api_app_id"`
+	Actions       []Action        `json:"actions"`
+	Interactivity json.RawMessage `json:"interactivity"`
+	Channel       Channel         `json:"channel,omitempty"`
+	Message       Message         `json:"message,omitempty"`
+}
+
+func (p BlockActionsEvent) Type() InteractionEventType {
+	return InteractionEventType("block_actions")
+}
+
+type Action struct {
+	Type      string         `json:"type"`
+	ID        string         `json:"action_id"`
+	Timestamp string         `json:"action_ts"`
+	BlockID   string         `json:"block_id"`
+	Text      TextObjectItem `json:"text"`
+	Value     string         `json:"value"`
+}
+
+type Channel struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
 }
 
 // Slack API: blocks

--- a/integrations/access/slack/types.go
+++ b/integrations/access/slack/types.go
@@ -27,9 +27,10 @@ import (
 // Slack API: Socket Mode constants
 
 const (
-	SocketModeEventTypeHello       = "hello"
-	SocketModeEventTypeDisconnect  = "disconnect"
-	SocketModeEventTypeInteractive = "interactive"
+	SocketModeEventTypeHello          = "hello"
+	SocketModeEventTypeDisconnect     = "disconnect"
+	SocketModeEventTypeInteractive    = "interactive"
+	SocketModeEventReasonLinkDisabled = "link_disabled"
 )
 
 // Slack API types


### PR DESCRIPTION
Followup PR:
- https://github.com/gravitational/teleport/pull/67217

Adds a WebSocket client to the Slack plugin to receive app interactions from the Slack Socket Mode server.
Client currently unused, will be used in followup PR by Slack `ReviewApp`.

Context for reviewers: This supports the upcoming feature for native reviews in Slack, where the Slack plugin submits access reviews to the Teleport Auth Server on behalf of human Slack users.

The client receives app interactions from the Slack server, which include Approve/Deny button clicks for access reviews.

In a followup PR, a downstream "ReviewApp" parses these interactions and sends access review requests to the Teleport Auth Server:

<details><summary>ReviewApp</summary>
<p>

```go
	// Ingest interaction events from Socket Mode client.
	// Currently, we only handle "block_actions" interactions.
	go func() {
		for {
			select {
			case interaction := <-a.socketModeClient.Interactions():
				switch interaction.Type() {
				case BlockActionsEvent{}.Type():
					blockActionsEvent, ok := interaction.(BlockActionsEvent)
					if !ok {
						log.WarnContext(ctx, "error unmarshaling `block_actions` interaction")
						continue
					}
					a.handleBlockActionsEvent(ctx, blockActionsEvent)
				}
			case <-ctx.Done():
				return
			}
		}
	}()
```

</p>
</details> 

## Manual Test Plan
### Test Environment

Teleport Cloud. Local Slack plugin.

### Test Cases
- [x] Socket Mode client reconnects upon receiving disconnect warning message from Slack Socket Mode server
- [x] Client pings receive Socket Mode server pongs at the ping interval
- [x] Fatal errors (eg. invalid auth token) exit the service
- [x] Canceling Slack app gracefully shuts down Socket Mode client
- [x] Downstream review app logic properly parses/handles Socket Mode interaction events