### PR TITLE
app access: fix proxy connection leak

### DIFF
--- a/lib/utils/fncache.go
+++ b/lib/utils/fncache.go
@@ -82,6 +82,12 @@ type FnCacheConfig struct {
 	// any method on the same FnCache instance because the cache mutex may
 	// be held when the callback is invoked.
 	OnExpiry func(ctx context.Context, key any, value any)
+
+	// OnRemove is an optional callback that will be invoked when an item
+	// is explicitly purged with [Remove].
+	// It must not call any method on the same FnCache instance because
+	// the cache mutex may be held when the callback is invoked.
+	OnRemove func(ctx context.Context, key any, value any)
 }
 
 // CheckAndSetDefaults validates the FnCacheConfig is populated
@@ -177,6 +183,11 @@ func (c *FnCache) Shutdown(ctx context.Context) {
 func (c *FnCache) Remove(key any) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
+	if c.cfg.OnRemove != nil {
+		if entry, ok := c.entries[key]; ok {
+			c.cfg.OnRemove(context.WithoutCancel(c.cfg.Context), key, entry.v)
+		}
+	}
 	delete(c.entries, key)
 }
 

--- a/lib/utils/fncache_test.go
+++ b/lib/utils/fncache_test.go
@@ -599,12 +599,12 @@ func TestFnCacheRemove(t *testing.T) {
 		k any
 		v any
 	}
-	expiredC := make(chan item, 5)
+	removedC := make(chan item, 1)
 	cache, err := NewFnCache(FnCacheConfig{
 		TTL:     time.Hour,
 		Context: ctx,
-		OnExpiry: func(ctx context.Context, key, expired any) {
-			expiredC <- item{k: key, v: expired}
+		OnRemove: func(ctx context.Context, key, expired any) {
+			removedC <- item{k: key, v: expired}
 		},
 	})
 	require.NoError(t, err)
@@ -627,6 +627,10 @@ func TestFnCacheRemove(t *testing.T) {
 	// Remove the entry explicitly.
 	cache.Remove("test")
 
+	// Verify that the OnRemove callback executed
+	removedItem := <-removedC
+	require.Equal(t, "test", removedItem.k)
+
 	// Retrieve the entry again, this time the loadFn should
 	// be called because the item was explicitly removed.
 	out, err = FnCacheGet(ctx, cache, "test", func(ctx context.Context) (int, error) {
@@ -642,18 +646,10 @@ func TestFnCacheSet(t *testing.T) {
 	ctx := t.Context()
 
 	clock := clockwork.NewFakeClock()
-	type item struct {
-		k any
-		v any
-	}
-	expiredC := make(chan item, 5)
 	cache, err := NewFnCache(FnCacheConfig{
 		TTL:     time.Hour,
 		Context: ctx,
 		Clock:   clock,
-		OnExpiry: func(ctx context.Context, key, expired any) {
-			expiredC <- item{k: key, v: expired}
-		},
 	})
 	require.NoError(t, err)
 
@@ -888,21 +884,10 @@ func TestGetIfExists(t *testing.T) {
 		require.NoError(t, err)
 
 		var wg sync.WaitGroup
-		for i := 0; i < 100; i++ {
-			wg.Add(3)
-			go func() {
-				defer wg.Done()
-				cache.GetIfExists("key")
-			}()
-			go func() {
-				defer wg.Done()
-				cache.Remove("key")
-			}()
-
-			go func() {
-				defer wg.Done()
-				cache.Set("key", "value")
-			}()
+		for range 100 {
+			wg.Go(func() { cache.GetIfExists("key") })
+			wg.Go(func() { cache.Remove("key") })
+			wg.Go(func() { cache.Set("key", "value") })
 		}
 		wg.Wait()
 	})

--- a/lib/web/app/handler.go
+++ b/lib/web/app/handler.go
@@ -119,6 +119,14 @@ func NewHandler(ctx context.Context, c *HandlerConfig) (*Handler, error) {
 		logger:       slog.With(teleport.ComponentKey, teleport.ComponentAppProxy),
 	}
 
+	closeSession := func(ctx context.Context, key, value any) {
+		session, ok := value.(*session)
+		if !ok {
+			return
+		}
+		session.Close()
+	}
+
 	// Create a new session cache, this holds sessions that can be used to
 	// forward requests.
 	h.cache, err = utils.NewFnCache(utils.FnCacheConfig{
@@ -127,6 +135,8 @@ func NewHandler(ctx context.Context, c *HandlerConfig) (*Handler, error) {
 		Context:         ctx,
 		CleanupInterval: time.Second,
 		ReloadOnErr:     true,
+		OnExpiry:        closeSession,
+		OnRemove:        closeSession,
 	})
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/web/app/session.go
+++ b/lib/web/app/session.go
@@ -42,6 +42,12 @@ type session struct {
 	tr *transport
 }
 
+func (s *session) Close() {
+	if s != nil && s.tr != nil {
+		s.tr.CloseIdleConnections()
+	}
+}
+
 // getIdentityFromWebSession parses the TLS certificate from the web session and
 // extracts the user identity from its subject.
 func getIdentityFromWebSession(ws types.WebSession) (*tlsca.Identity, error) {

--- a/lib/web/app/transport.go
+++ b/lib/web/app/transport.go
@@ -152,6 +152,12 @@ func newTransport(c *transportConfig) (*transport, error) {
 	return t, nil
 }
 
+func (t *transport) CloseIdleConnections() {
+	if httpTransport, ok := t.tr.(*http.Transport); ok {
+		httpTransport.CloseIdleConnections()
+	}
+}
+
 // RoundTrip will rewrite the request, forward the request to the target
 // application, emit an event to the audit log, then rewrite the response.
 func (t *transport) RoundTrip(r *http.Request) (*http.Response, error) {


### PR DESCRIPTION
This looks like a similar case of the gotcha described in https://kev.fan/posts/02-go-routine-leak-http-connections/

See #66595 for some similar findings.

Make sure that any idle connections are closed when an app session expires from the proxy's cache.
