### PR TITLE
Support resource constraints for narrower access request role suggestions

### DIFF
--- a/api/proto/teleport/legacy/types/types.proto
+++ b/api/proto/teleport/legacy/types/types.proto
@@ -3542,6 +3542,14 @@ message AccessCapabilitiesRequest {
   // list of roles that the user can request should be filtered to only include
   // roles that allow access to the provided ResourceIDs.
   bool FilterRequestableRolesByResource = 6 [(gogoproto.jsontag) = "filter_requestable_roles_by_resource,omitempty"];
+  // resource_access_ids is a list of resources paired with optional constraints
+  // for which we would like to view the necessary roles. When present,
+  // these are deduplicated against provided ResourceIDs to form the full set
+  // of requested resources.
+  repeated ResourceAccessID resource_access_ids = 7 [
+    (gogoproto.jsontag) = "resource_access_ids,omitempty",
+    (gogoproto.nullable) = false
+  ];
 }
 
 // RemoteAccessCapabilities is a summary of the capabilites that a remote cluster
@@ -3568,6 +3576,15 @@ message RemoteAccessCapabilitiesRequest {
   // the necessary roles for.
   repeated ResourceID ResourceIDs = 3 [
     (gogoproto.jsontag) = "resource_ids,omitempty",
+    (gogoproto.nullable) = false
+  ];
+
+  // resource_access_ids is a list of resources paired with optional constraints
+  // for which we would like to view the necessary roles. When present,
+  // these are deduplicated against provided ResourceIDs to form the full set
+  // of requested resources.
+  repeated ResourceAccessID resource_access_ids = 4 [
+    (gogoproto.jsontag) = "resource_access_ids,omitempty",
     (gogoproto.nullable) = false
   ];
 }

--- a/api/types/access_request.go
+++ b/api/types/access_request.go
@@ -620,7 +620,13 @@ func (r *AccessRequestV3) SetRequestedResourceAccessIDs(ids []ResourceAccessID) 
 	r.Spec.RequestedResourceAccessIDs = append([]ResourceAccessID{}, ids...)
 }
 
-// GetAllRequestedResourceIDs gets all [ResourceAccessID]-based representations of requested resources.
+// GetAllRequestedResourceIDs gets all [ResourceAccessID]-based representations
+// of requested resources, merging the spec's RequestedResourceIDs and
+// RequestedResourceAccessIDs fields without deduplication. The two spec fields
+// are deduplicated against each other when the request is created, with
+// constrained entries taking precedence. To merge the equivalent parallel
+// fields on API request parameters, which are not validated this way, use
+// [CombineAsResourceAccessIDs] instead.
 func (r *AccessRequestV3) GetAllRequestedResourceIDs() []ResourceAccessID {
 	wrapped := make([]ResourceAccessID, 0, len(r.Spec.RequestedResourceIDs)+len(r.Spec.RequestedResourceAccessIDs))
 	for _, rid := range r.Spec.RequestedResourceIDs {

--- a/api/types/resource_ids.go
+++ b/api/types/resource_ids.go
@@ -122,16 +122,40 @@ func ResourceIDsToResourceAccessIDs(ids []ResourceID) []ResourceAccessID {
 }
 
 // CombineAsResourceAccessIDs converts plain [ResourceID]s to [ResourceAccessID]s
-// and combines them with existing [ResourceAccessID]s into a single slice.
+// and merges them with existing [ResourceAccessID]s into a single deduplicated
+// slice. When the same resource appears in both lists, the [ResourceAccessID]
+// entry wins so that any constraints it carries are preserved. Dropping the
+// plain duplicate is safe: a [ResourceAccessID] without constraints is
+// equivalent to its plain [ResourceID], and one with constraints expresses
+// strictly narrower access to the same resource, which is the caller's intent
+// when constraints were supplied at all.
+//
+// Use this for API request parameters that carry separate ResourceIDs and
+// ResourceAccessIDs fields (e.g. [AccessCapabilitiesRequest],
+// [RemoteAccessCapabilitiesRequest]), where older clients may populate only
+// the former. For persisted access requests, use
+// [AccessRequestV3.GetAllRequestedResourceIDs] instead: the two spec fields
+// are already deduplicated against each other at creation time validation.
 func CombineAsResourceAccessIDs(ids []ResourceID, accessIDs []ResourceAccessID) []ResourceAccessID {
 	if ids == nil && accessIDs == nil {
 		return nil
 	}
-	totalLen := len(ids) + len(accessIDs)
-	zipped := make([]ResourceAccessID, 0, totalLen)
-	zipped = append(zipped, ResourceIDsToResourceAccessIDs(ids)...)
-	zipped = append(zipped, accessIDs...)
-	return zipped
+	// Process constrained ids first so they take precedence.
+	seen := make(map[string]struct{}, len(ids)+len(accessIDs))
+	result := make([]ResourceAccessID, 0, len(ids)+len(accessIDs))
+	for _, raid := range accessIDs {
+		key := ResourceIDToString(raid.GetResourceID())
+		seen[key] = struct{}{}
+		result = append(result, raid)
+	}
+	for _, id := range ids {
+		key := ResourceIDToString(id)
+		if _, exists := seen[key]; !exists {
+			seen[key] = struct{}{}
+			result = append(result, ResourceAccessID{Id: id})
+		}
+	}
+	return result
 }
 
 // UnwrapResourceAccessIDs separates a slice of [ResourceAccessID]s back into plain

--- a/api/types/resource_ids_test.go
+++ b/api/types/resource_ids_test.go
@@ -844,10 +844,10 @@ func TestCombineAsResourceAccessIDs(t *testing.T) {
 	out := CombineAsResourceAccessIDs([]ResourceID{id1, id2}, []ResourceAccessID{c1, c2})
 
 	require.Equal(t, []ResourceAccessID{
-		{Id: id1},
-		{Id: id2},
 		c1,
 		c2,
+		{Id: id1},
+		{Id: id2},
 	}, out)
 
 	t.Run("nil ids", func(t *testing.T) {
@@ -858,6 +858,16 @@ func TestCombineAsResourceAccessIDs(t *testing.T) {
 	t.Run("nil accessIDs", func(t *testing.T) {
 		out := CombineAsResourceAccessIDs([]ResourceID{id1}, nil)
 		require.Equal(t, []ResourceAccessID{{Id: id1}}, out)
+	})
+
+	t.Run("duplicate resource prefers constrained version", func(t *testing.T) {
+		// Same resource appears as both a plain ResourceID and a constrained
+		// ResourceAccessID. The constrained version should win.
+		plainID := c1.GetResourceID()
+		other := ResourceID{ClusterName: "leaf", Kind: "node", Name: "n1"}
+		out := CombineAsResourceAccessIDs([]ResourceID{plainID, other}, []ResourceAccessID{c1})
+		// plainID is not in the result; deduplicated in favor of c1.
+		require.Equal(t, []ResourceAccessID{c1, {Id: other}}, out)
 	})
 }
 

--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -6015,13 +6015,16 @@ func (a *Server) CreateAccessRequestV2(ctx context.Context, req types.AccessRequ
 	}
 
 	// Look for user groups and associated applications to the request.
-	requestedResourceIDs, err := a.appendImplicitlyRequiredResources(ctx, req.GetRequestedResourceIDs())
+	allRequestedResourceIDs, err := a.appendImplicitlyRequiredResources(ctx, req.GetAllRequestedResourceIDs())
 	if err != nil {
 		return nil, trace.Wrap(err, "adding additional implicitly required resources")
 	}
+	// We get back the combination of both types; split back and set individually
+	requestedResourceIDs, requestedResourceAccessIDs := types.UnwrapResourceAccessIDs(allRequestedResourceIDs)
 	req.SetRequestedResourceIDs(requestedResourceIDs)
+	req.SetRequestedResourceAccessIDs(requestedResourceAccessIDs)
 
-	if err := a.checkResourcesRequestable(ctx, requestedResourceIDs); err != nil {
+	if err := a.checkResourcesRequestable(ctx, types.RiskyExtractResourceIDs(allRequestedResourceIDs)); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
@@ -6189,19 +6192,20 @@ func (a *Server) CreateAccessRequestV2(ctx context.Context, req types.AccessRequ
 
 // appendImplicitlyRequiredResources examines the set of requested resources and adds
 // any extra resources that are implicitly required by the request.
-func (a *Server) appendImplicitlyRequiredResources(ctx context.Context, resources []types.ResourceID) ([]types.ResourceID, error) {
+func (a *Server) appendImplicitlyRequiredResources(ctx context.Context, resources []types.ResourceAccessID) ([]types.ResourceAccessID, error) {
 	addedApps := set.New[string]()
 	var userGroups []types.ResourceID
 	var accountAssignments []types.ResourceID
 
-	for _, resource := range resources {
-		switch resource.Kind {
+	for _, raid := range resources {
+		rid := raid.GetResourceID()
+		switch rid.Kind {
 		case types.KindApp:
-			addedApps.Add(resource.Name)
+			addedApps.Add(rid.Name)
 		case types.KindUserGroup:
-			userGroups = append(userGroups, resource)
+			userGroups = append(userGroups, rid)
 		case types.KindIdentityCenterAccountAssignment:
-			accountAssignments = append(accountAssignments, resource)
+			accountAssignments = append(accountAssignments, rid)
 		}
 	}
 
@@ -6214,10 +6218,12 @@ func (a *Server) appendImplicitlyRequiredResources(ctx context.Context, resource
 		for _, app := range userGroup.GetApplications() {
 			// Only add to the request if we haven't already added it.
 			if !addedApps.Contains(app) {
-				resources = append(resources, types.ResourceID{
-					ClusterName: resource.ClusterName,
-					Kind:        types.KindApp,
-					Name:        app,
+				resources = append(resources, types.ResourceAccessID{
+					Id: types.ResourceID{
+						ClusterName: resource.ClusterName,
+						Kind:        types.KindApp,
+						Name:        app,
+					},
 				})
 				addedApps.Add(app)
 			}
@@ -6238,10 +6244,12 @@ func (a *Server) appendImplicitlyRequiredResources(ctx context.Context, resource
 			continue
 		}
 
-		resources = append(resources, types.ResourceID{
-			ClusterName: resource.ClusterName,
-			Kind:        types.KindIdentityCenterAccount,
-			Name:        asmt.GetSpec().GetAccountId(),
+		resources = append(resources, types.ResourceAccessID{
+			Id: types.ResourceID{
+				ClusterName: resource.ClusterName,
+				Kind:        types.KindIdentityCenterAccount,
+				Name:        asmt.GetSpec().GetAccountId(),
+			},
 		})
 		icAccounts.Add(asmt.GetSpec().GetAccountId())
 	}

--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -3521,7 +3521,7 @@ func (a *ServerWithRoles) GetRemoteAccessCapabilities(ctx context.Context, req t
 		"remote_roles", req.SearchAsRoles,
 		"local_roles", localSearchAsRoles)
 
-	localAccessRoles, err := services.PruneMappedSearchAsRoles(ctx, a.authServer.clock, a.authServer, a.context.User, localSearchAsRoles, types.ResourceIDsToResourceAccessIDs(req.ResourceIDs), "")
+	localAccessRoles, err := services.PruneMappedSearchAsRoles(ctx, a.authServer.clock, a.authServer, a.context.User, localSearchAsRoles, types.CombineAsResourceAccessIDs(req.ResourceIDs, req.ResourceAccessIds), "")
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/services/access_request.go
+++ b/lib/services/access_request.go
@@ -135,7 +135,8 @@ func ValidateAccessRequestClusterNames(cg ClusterGetter, ar types.AccessRequest)
 		return trace.Wrap(err)
 	}
 	var invalidClusters []string
-	for _, resourceID := range ar.GetRequestedResourceIDs() {
+	for _, resourceAccessID := range ar.GetAllRequestedResourceIDs() {
+		resourceID := resourceAccessID.GetResourceID()
 		if resourceID.ClusterName == "" {
 			continue
 		}
@@ -222,8 +223,8 @@ func shouldFilterRequestableRolesByResource(a RequestValidatorGetter, req types.
 	if err != nil {
 		return false, trace.Wrap(err)
 	}
-	for _, resourceID := range req.ResourceIDs {
-		if resourceID.ClusterName != currentCluster.GetClusterName() {
+	for _, resourceAccessID := range types.CombineAsResourceAccessIDs(req.ResourceIDs, req.ResourceAccessIds) {
+		if resourceAccessID.GetResourceID().ClusterName != currentCluster.GetClusterName() {
 			// Requested resource is from another cluster, so we can't know
 			// all of the roles which would grant access to it.
 			return false, nil
@@ -241,6 +242,7 @@ func CalculateAccessCapabilities(ctx context.Context, clock clockwork.Clock, clt
 	}
 	if !shouldFilter && req.FilterRequestableRolesByResource {
 		req.ResourceIDs = nil
+		req.ResourceAccessIds = nil
 	}
 
 	var caps types.AccessCapabilities
@@ -251,19 +253,21 @@ func CalculateAccessCapabilities(ctx context.Context, clock clockwork.Clock, clt
 		return nil, trace.Wrap(err)
 	}
 
-	if len(req.ResourceIDs) != 0 && !req.FilterRequestableRolesByResource {
-		caps.ApplicableRolesForResources, err = v.applicableSearchAsRoles(ctx, types.ResourceIDsToResourceAccessIDs(req.ResourceIDs), req.Login)
+	resourceAccessIDs := types.CombineAsResourceAccessIDs(req.ResourceIDs, req.ResourceAccessIds)
+
+	if len(resourceAccessIDs) != 0 && !req.FilterRequestableRolesByResource {
+		caps.ApplicableRolesForResources, err = v.applicableSearchAsRoles(ctx, resourceAccessIDs, req.Login)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
 	}
 
 	if req.RequestableRoles {
-		var resourceIDs []types.ResourceID
+		var requestableResourceAccessIDs []types.ResourceAccessID
 		if req.FilterRequestableRolesByResource {
-			resourceIDs = req.ResourceIDs
+			requestableResourceAccessIDs = resourceAccessIDs
 		}
-		caps.RequestableRoles, err = v.getRequestableRoles(ctx, identity, types.ResourceIDsToResourceAccessIDs(resourceIDs), req.Login)
+		caps.RequestableRoles, err = v.getRequestableRoles(ctx, identity, requestableResourceAccessIDs, req.Login)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
@@ -1772,11 +1776,18 @@ func (m *RequestValidator) getRequestableRoles(ctx context.Context, identity tls
 		return nil, trace.Wrap(err)
 	}
 
-	// Filter out resources the user requested but doesn't have access to.
+	// Filter out resources the user requested but doesn't have access to and
+	// pair each remaining resource with matchers for any requested constraints.
 	filteredResources := make([]types.ResourceWithLabels, 0, len(underlyingResources))
+	constraintMatchers := make([][]RoleMatcher, 0, len(underlyingResources))
 	for _, resource := range underlyingResources {
 		if err := accessChecker.CheckAccess(resource, AccessState{MFAVerified: true}); err == nil {
+			matchers, err := BuildResourceConstraintMatchers(resourceAccessIDs, resource)
+			if err != nil {
+				return nil, trace.Wrap(err)
+			}
 			filteredResources = append(filteredResources, resource)
+			constraintMatchers = append(constraintMatchers, matchers)
 		}
 	}
 
@@ -1788,25 +1799,8 @@ func (m *RequestValidator) getRequestableRoles(ctx context.Context, identity tls
 		}
 
 		roleAllowsAccess := true
-		for _, resource := range filteredResources {
-			var extraMatchers []RoleMatcher
-			for _, raid := range resourceAccessIDs {
-				if rid := raid.GetResourceID(); rid.Name != resource.GetName() || rid.Kind != resource.GetKind() {
-					continue
-				}
-				if c := raid.GetConstraints(); c != nil {
-					rm, err := MatcherFromConstraints(raid.GetConstraints())
-					if err != nil {
-						return nil, trace.Wrap(err)
-					}
-					if rm != nil {
-						extraMatchers = append(extraMatchers, rm)
-					}
-					break
-				}
-			}
-
-			access, err := m.roleAllowsResource(role, resource, loginHint, extraMatchers...)
+		for i, resource := range filteredResources {
+			access, err := m.roleAllowsResource(role, resource, loginHint, constraintMatchers[i]...)
 			if err != nil {
 				return nil, trace.Wrap(err)
 			}

--- a/lib/services/access_request_test.go
+++ b/lib/services/access_request_test.go
@@ -2251,6 +2251,242 @@ func TestGetRequestableRoles(t *testing.T) {
 	}
 }
 
+// TestCalculateAccessCapabilities_WithResourceAccessIDs verifies CalculateAccessCapabilities
+// correctly filters roles when ResourceAccessIDs carry constraints.
+func TestCalculateAccessCapabilities_WithResourceAccessIDs(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+	clusterName := "my-cluster"
+
+	g := &mockGetter{
+		roles:       make(map[string]types.Role),
+		userStates:  make(map[string]*userloginstate.UserLoginState),
+		nodes:       make(map[string]types.Server),
+		kubeServers: make(map[string]types.KubeServer),
+		dbServers:   make(map[string]types.DatabaseServer),
+		appServers:  make(map[string]types.AppServer),
+		desktops:    make(map[string]types.WindowsDesktop),
+		clusterName: clusterName,
+	}
+
+	// Create node
+	node, err := types.NewServerWithLabels("node-1", types.KindNode, types.ServerSpecV2{}, map[string]string{"env": "prod"})
+	require.NoError(t, err)
+	g.nodes["node-1"] = node
+
+	// Create an AWS console app
+	awsApp, err := types.NewAppV3(types.Metadata{
+		Name:   "awsconsole",
+		Labels: map[string]string{"env": "prod"},
+	}, types.AppSpecV3{
+		URI: "https://console.aws.amazon.com",
+	})
+	require.NoError(t, err)
+	awsAppServer, err := types.NewAppServerV3FromApp(awsApp, "aws-host", "aws-host")
+	require.NoError(t, err)
+	g.appServers[awsApp.GetName()] = awsAppServer
+
+	roleDesc := map[string]types.RoleSpecV6{
+		"requester": {
+			Allow: types.RoleConditions{
+				Request: &types.AccessRequestConditions{
+					SearchAsRoles: []string{
+						"aws-readonly",
+						"aws-admin",
+						"ssh-basic",
+						"ssh-root",
+					},
+				},
+			},
+		},
+		"aws-readonly": {
+			Allow: types.RoleConditions{
+				AppLabels:   types.Labels{"env": {"prod"}},
+				AWSRoleARNs: []string{"arn:aws:iam::111111111111:role/readonly"},
+			},
+		},
+		"aws-admin": {
+			Allow: types.RoleConditions{
+				AppLabels:   types.Labels{"env": {"prod"}},
+				AWSRoleARNs: []string{"arn:aws:iam::111111111111:role/readonly", "arn:aws:iam::111111111111:role/admin"},
+			},
+		},
+		"ssh-basic": {
+			Allow: types.RoleConditions{
+				NodeLabels: types.Labels{"env": {"prod"}},
+				Logins:     []string{"{{internal.logins}}"},
+			},
+		},
+		"ssh-root": {
+			Allow: types.RoleConditions{
+				NodeLabels: types.Labels{"env": {"prod"}},
+				Logins:     []string{"{{internal.logins}}", "root"},
+			},
+		},
+	}
+	for name, spec := range roleDesc {
+		role, err := types.NewRole(name, spec)
+		require.NoError(t, err)
+		g.roles[name] = role
+	}
+
+	user := g.user(t, "requester")
+	g.userStates[user].Spec.Traits = map[string][]string{
+		"logins": {"ubuntu"},
+	}
+
+	tests := []struct {
+		name              string
+		resourceIDs       []types.ResourceID
+		resourceAccessIDs []types.ResourceAccessID
+		expectedRoles     []string
+	}{
+		{
+			name: "unconstrained ResourceIDs only (backwards-compat)",
+			resourceIDs: []types.ResourceID{
+				{ClusterName: clusterName, Kind: types.KindApp, Name: "awsconsole"},
+			},
+			expectedRoles: []string{"aws-readonly", "aws-admin"},
+		},
+		{
+			name: "constrained ResourceAccessIDs filters to matching ARN",
+			resourceAccessIDs: []types.ResourceAccessID{
+				{
+					Id: types.ResourceID{ClusterName: clusterName, Kind: types.KindApp, Name: "awsconsole"},
+					Constraints: &types.ResourceConstraints{
+						Details: &types.ResourceConstraints_AwsConsole{
+							AwsConsole: &types.AWSConsoleResourceConstraints{
+								RoleArns: []string{"arn:aws:iam::111111111111:role/admin"},
+							},
+						},
+					},
+				},
+			},
+			// Only aws-admin has the admin ARN.
+			expectedRoles: []string{"aws-admin"},
+		},
+		{
+			name: "constrained SSH login filters to matching role",
+			resourceAccessIDs: []types.ResourceAccessID{
+				{
+					Id: types.ResourceID{ClusterName: clusterName, Kind: types.KindNode, Name: "node-1"},
+					Constraints: &types.ResourceConstraints{
+						Details: &types.ResourceConstraints_Ssh{
+							Ssh: &types.SSHResourceConstraints{
+								Logins: []string{"root"},
+							},
+						},
+					},
+				},
+			},
+			// ssh-basic only has {{internal.logins}} = "ubuntu", not "root".
+			expectedRoles: []string{"ssh-root"},
+		},
+		{
+			name: "mixed: unconstrained ResourceIDs + constrained ResourceAccessIDs",
+			resourceIDs: []types.ResourceID{
+				{ClusterName: clusterName, Kind: types.KindNode, Name: "node-1"},
+			},
+			resourceAccessIDs: []types.ResourceAccessID{
+				{
+					Id: types.ResourceID{ClusterName: clusterName, Kind: types.KindApp, Name: "awsconsole"},
+					Constraints: &types.ResourceConstraints{
+						Details: &types.ResourceConstraints_AwsConsole{
+							AwsConsole: &types.AWSConsoleResourceConstraints{
+								RoleArns: []string{"arn:aws:iam::111111111111:role/admin"},
+							},
+						},
+					},
+				},
+			},
+			// ssh-basic and ssh-root for the unconstrained node, aws-admin for the constrained app.
+			expectedRoles: []string{"ssh-basic", "ssh-root", "aws-admin"},
+		},
+		{
+			name: "unconstrained ResourceAccessIDs behave like ResourceIDs",
+			resourceAccessIDs: []types.ResourceAccessID{
+				{
+					Id: types.ResourceID{ClusterName: clusterName, Kind: types.KindApp, Name: "awsconsole"},
+				},
+			},
+			expectedRoles: []string{"aws-readonly", "aws-admin"},
+		},
+		{
+			name: "multi-principal constraint: both ARNs from different roles are covered",
+			resourceAccessIDs: []types.ResourceAccessID{
+				{
+					Id: types.ResourceID{ClusterName: clusterName, Kind: types.KindApp, Name: "awsconsole"},
+					Constraints: &types.ResourceConstraints{
+						Details: &types.ResourceConstraints_AwsConsole{
+							AwsConsole: &types.AWSConsoleResourceConstraints{
+								RoleArns: []string{
+									"arn:aws:iam::111111111111:role/readonly",
+									"arn:aws:iam::111111111111:role/admin",
+								},
+							},
+						},
+					},
+				},
+			},
+			// aws-readonly matches "readonly", aws-admin matches both.
+			// The union of suggested roles covers all requested ARNs.
+			expectedRoles: []string{"aws-readonly", "aws-admin"},
+		},
+		{
+			name: "multi-principal constraint: both logins from different roles are covered",
+			resourceAccessIDs: []types.ResourceAccessID{
+				{
+					Id: types.ResourceID{ClusterName: clusterName, Kind: types.KindNode, Name: "node-1"},
+					Constraints: &types.ResourceConstraints{
+						Details: &types.ResourceConstraints_Ssh{
+							Ssh: &types.SSHResourceConstraints{
+								Logins: []string{"ubuntu", "root"},
+							},
+						},
+					},
+				},
+			},
+			// ssh-basic has "ubuntu" only, ssh-root has both. Both match via AnyOf,
+			// and their union covers all requested logins.
+			expectedRoles: []string{"ssh-basic", "ssh-root"},
+		},
+		{
+			name: "backwards-compat: new proxy sends both fields, new auth deduplicates",
+			resourceIDs: []types.ResourceID{
+				{ClusterName: clusterName, Kind: types.KindApp, Name: "awsconsole"},
+			},
+			resourceAccessIDs: []types.ResourceAccessID{
+				{
+					Id: types.ResourceID{ClusterName: clusterName, Kind: types.KindApp, Name: "awsconsole"},
+					Constraints: &types.ResourceConstraints{
+						Details: &types.ResourceConstraints_AwsConsole{
+							AwsConsole: &types.AWSConsoleResourceConstraints{
+								RoleArns: []string{"arn:aws:iam::111111111111:role/admin"},
+							},
+						},
+					},
+				},
+			},
+			// Constrained version wins dedup, results in only aws-admin.
+			expectedRoles: []string{"aws-admin"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			accessCaps, err := CalculateAccessCapabilities(ctx, clockwork.NewFakeClock(), g,
+				tlsca.Identity{},
+				types.AccessCapabilitiesRequest{
+					User:              user,
+					ResourceIDs:       tc.resourceIDs,
+					ResourceAccessIds: tc.resourceAccessIDs,
+				})
+			require.NoError(t, err)
+			require.ElementsMatch(t, tc.expectedRoles, accessCaps.ApplicableRolesForResources)
+		})
+	}
+}
+
 // TestCalculatePendingRequestTTL verifies that the TTL for the Access Request is capped to the
 // request's access expiry or capped to the default const requestTTL, whichever is smaller.
 func TestCalculatePendingRequestTTL(t *testing.T) {

--- a/lib/services/resource_constraints.go
+++ b/lib/services/resource_constraints.go
@@ -116,6 +116,37 @@ func buildStringConstraintTransform(
 	}
 }
 
+// BuildResourceConstraintMatchers returns RoleMatchers derived from any
+// ResourceConstraints requested for the given resource, correlating the
+// resource against resourceAccessIDs by kind and name. Entries without
+// constraints contribute no matchers, so resource kinds that cannot carry
+// constraints are unaffected.
+//
+// Correlating by kind and name mirrors how requested resources are looked up
+// from their IDs (see [accessrequest.GetResourcesByResourceIDs]); callers are
+// expected to pass resources and resourceAccessIDs scoped to the same cluster.
+//
+// TODO(kiosion): When constraints extend for Kubernetes support, kube sub-resource
+// IDs need name-only correlation against the kube_cluster resource, like
+// getKubeResourcesFromResourceIDs
+func BuildResourceConstraintMatchers(resourceAccessIDs []types.ResourceAccessID, resource types.Resource) ([]RoleMatcher, error) {
+	var matchers []RoleMatcher
+	for _, raid := range resourceAccessIDs {
+		rid := raid.GetResourceID()
+		if rid.Name != resource.GetName() || rid.Kind != resource.GetKind() {
+			continue
+		}
+		rm, err := MatcherFromConstraints(raid.GetConstraints())
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		if rm != nil {
+			matchers = append(matchers, rm)
+		}
+	}
+	return matchers, nil
+}
+
 // MatcherFromConstraints constructs a RoleMatcher encoding the requested
 // ResourceConstraints for role resolution/validation time.
 //

--- a/lib/services/resource_constraints_test.go
+++ b/lib/services/resource_constraints_test.go
@@ -210,6 +210,75 @@ func TestMatcherFromConstraints_AWSConsole_BuildsAnyOf(t *testing.T) {
 	require.False(t, ok)
 }
 
+func TestBuildResourceConstraintMatchers(t *testing.T) {
+	node, err := types.NewServerWithLabels("node-1", types.KindNode, types.ServerSpecV2{}, nil)
+	require.NoError(t, err)
+
+	sshConstraints := &types.ResourceConstraints{
+		Details: &types.ResourceConstraints_Ssh{
+			Ssh: &types.SSHResourceConstraints{
+				Logins: []string{"ubuntu"},
+			},
+		},
+	}
+
+	t.Run("constrained entry matching the resource yields its matcher", func(t *testing.T) {
+		matchers, err := BuildResourceConstraintMatchers([]types.ResourceAccessID{
+			{
+				Id:          types.ResourceID{ClusterName: "cluster", Kind: types.KindNode, Name: "node-1"},
+				Constraints: sshConstraints,
+			},
+		}, node)
+		require.NoError(t, err)
+		require.Len(t, matchers, 1)
+
+		ok, err := matchers[0].Match(roleAllowingSSHLogins("ubuntu"), types.Allow)
+		require.NoError(t, err)
+		require.True(t, ok)
+
+		ok, err = matchers[0].Match(roleAllowingSSHLogins("root"), types.Allow)
+		require.NoError(t, err)
+		require.False(t, ok)
+	})
+
+	t.Run("entries without constraints yield no matchers", func(t *testing.T) {
+		matchers, err := BuildResourceConstraintMatchers([]types.ResourceAccessID{
+			{Id: types.ResourceID{ClusterName: "cluster", Kind: types.KindNode, Name: "node-1"}},
+		}, node)
+		require.NoError(t, err)
+		require.Empty(t, matchers)
+	})
+
+	t.Run("entries for other resources yield no matchers", func(t *testing.T) {
+		matchers, err := BuildResourceConstraintMatchers([]types.ResourceAccessID{
+			{
+				Id:          types.ResourceID{ClusterName: "cluster", Kind: types.KindNode, Name: "other-node"},
+				Constraints: sshConstraints,
+			},
+			{
+				Id:          types.ResourceID{ClusterName: "cluster", Kind: types.KindApp, Name: "node-1"},
+				Constraints: sshConstraints,
+			},
+		}, node)
+		require.NoError(t, err)
+		require.Empty(t, matchers)
+	})
+
+	t.Run("invalid constraints return an error", func(t *testing.T) {
+		_, err := BuildResourceConstraintMatchers([]types.ResourceAccessID{
+			{
+				Id: types.ResourceID{ClusterName: "cluster", Kind: types.KindNode, Name: "node-1"},
+				Constraints: &types.ResourceConstraints{
+					Details: &types.ResourceConstraints_Ssh{
+						Ssh: &types.SSHResourceConstraints{Logins: nil},
+					},
+				},
+			},
+		}, node)
+		require.Error(t, err)
+	})
+}
+
 func TestValidateAccessRequest_ConstraintKinds(t *testing.T) {
 	makeRequest := func(kind string, constraints *types.ResourceConstraints) types.AccessRequest {
 		req, err := types.NewAccessRequest(uuid.New().String(), "user", "role")


### PR DESCRIPTION
## Context
When creating a resource-based Access Request, a dryRun calls `CalculateAccessCapabilities` to suggest roles that grant access to the requested resources. Currently, this is done with only plain `ResourceIDs`, so all roles matching a resource are suggested. This may be more broad than required, and may include roles even if they don't grant the specified constraints (e.g., AWS IAM role or SSH login) the user selected for a resource.

This PR adds a `ResourceAccessIDs` field to the capability request types so Auth can filter suggested roles to only those that satisfy the requested constraints on resources, and updates a few places Auth was previously ignoring constraints when performing this filtering.

Related: [gravitational/teleport.e#8838](https://github.com/gravitational/teleport.e/pull/8838)

### Backwards Compatibility
The added proto field is additive and coexists with the existing field across mismatched component versions. Older callers that only populate `ResourceIDs` are unaffected; `CombineAsResourceAccessIDs` with nil `ResourceAccessIDs` simply wraps the plain IDs unchanged. Older Auth versions that receive the new field ignore it via proto3's standard unknown field handling.

## Manual Test Plan
### Test Environment
- Local cluster with separate Auth and Proxy.
- Builds for this branch ("new"), and master ("old").
- Requestable resources of each kind, each covered by two or more roles.
- Test user with ability to request all resources, and search_as_roles covering all requestable roles.

### Test Cases
- [x] Validate no changes in existing access request creation flows with either a) old Auth + new Proxy, b) new Auth + old Proxy, c) new Auth + new Proxy, when:
  - [x] Checking out a resource-based access request for an app; verify correct roles suggested and request can be created successfully.
  - [x] Checking out a resource-based access request for an SSH node; verify correct roles suggested and request can be created successfully.
  - [x] Checking out a resource-based access request for a resource with an associated user group; verify the required app resources are added to the request and the request can be created successfully.
