### PR TITLE
kube: move kube cluster state onto upstream resolver

### DIFF
--- a/lib/kube/proxy/auth.go
+++ b/lib/kube/proxy/auth.go
@@ -160,7 +160,7 @@ func (f *Forwarder) getKubeDetails(ctx context.Context) error {
 			)
 			return trace.Wrap(err)
 		}
-		f.clusterDetails[cluster] = details
+		f.upsertKubeDetails(cluster, details)
 	}
 	return nil
 }

--- a/lib/kube/proxy/auth_test.go
+++ b/lib/kube/proxy/auth_test.go
@@ -323,8 +323,10 @@ current-context: foo
 	for _, tt := range tests {
 		t.Run(tt.desc, func(t *testing.T) {
 			t.Parallel()
+			upstream, err := newUpstreamResolver(tt.serviceType)
+			require.NoError(t, err)
 			fwd := &Forwarder{
-				clusterDetails: map[string]*kubeDetails{},
+				upstream: upstream,
 				cfg: ForwarderConfig{
 					ClusterName:                   teleClusterName,
 					KubeServiceType:               tt.serviceType,
@@ -334,12 +336,16 @@ current-context: foo
 				},
 				log: logtest.NewLogger(),
 			}
-			err := fwd.getKubeDetails(ctx)
+			err = fwd.getKubeDetails(ctx)
 			tt.assertErr(t, err)
 			if err != nil {
 				return
 			}
-			require.Empty(t, cmp.Diff(fwd.clusterDetails, tt.want,
+			got := map[string]*kubeDetails{}
+			if s := fwd.upstream.store(); s != nil {
+				got = s.details
+			}
+			require.Empty(t, cmp.Diff(got, tt.want,
 				cmp.AllowUnexported(staticKubeCreds{}),
 				cmp.AllowUnexported(kubeDetails{}),
 				cmpopts.IgnoreFields(kubeDetails{}, "rwMu", "kubeCodecs", "wg", "cancelFunc", "gvkSupportedResources", "refreshGroup"),

--- a/lib/kube/proxy/ephemeral_admin_client_test.go
+++ b/lib/kube/proxy/ephemeral_admin_client_test.go
@@ -92,14 +92,14 @@ func TestGetPodForEphemeralPatch_UsesImpersonatedIdentity(t *testing.T) {
 		cfg: ForwarderConfig{
 			tracer: otel.Tracer("test"),
 		},
-		clusterDetails: map[string]*kubeDetails{
+		upstream: &kubeServiceResolver{clusters: &clusterStore{details: map[string]*kubeDetails{
 			clusterName: {
 				kubeCreds: &staticKubeCreds{
 					kubeClient:    adminClient,
 					clientRestCfg: adminRestCfg,
 				},
 			},
-		},
+		}}},
 	}
 
 	teleportUser, err := types.NewUser("alice")
@@ -178,14 +178,14 @@ func TestGetPatchedPodEvent_ReplaysStoredImpersonation(t *testing.T) {
 	fwd := &Forwarder{
 		log: logtest.NewLogger(),
 		cfg: ForwarderConfig{tracer: otel.Tracer("test")},
-		clusterDetails: map[string]*kubeDetails{
+		upstream: &kubeServiceResolver{clusters: &clusterStore{details: map[string]*kubeDetails{
 			clusterName: {
 				kubeCreds: &staticKubeCreds{
 					kubeClient:    adminClient,
 					clientRestCfg: adminRestCfg,
 				},
 			},
-		},
+		}}},
 	}
 
 	teleportUser, err := types.NewUser("alice")

--- a/lib/kube/proxy/forwarder.go
+++ b/lib/kube/proxy/forwarder.go
@@ -344,10 +344,9 @@ func NewForwarder(cfg ForwarderConfig) (*Forwarder, error) {
 			ReadBufferSize:  1024,
 			WriteBufferSize: 1024,
 		},
-		clusterDetails:  make(map[string]*kubeDetails),
 		cachedTransport: transportClients,
 	}
-	upstream, err := newUpstreamResolver(cfg.KubeServiceType, fwd.findKubeDetailsByClusterName)
+	upstream, err := newUpstreamResolver(cfg.KubeServiceType)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -418,10 +417,6 @@ type Forwarder struct {
 	close context.CancelFunc
 	// ctx is a global context signaling exit
 	ctx context.Context
-	// clusterDetails contain kubernetes credentials for multiple clusters.
-	// map key is cluster name.
-	clusterDetails map[string]*kubeDetails
-	rwMutexDetails sync.RWMutex
 	// sessions tracks in-flight sessions
 	sessions map[uuid.UUID]*session
 	// upgrades connections to websockets
@@ -2923,54 +2918,41 @@ func (f *Forwarder) makeSessionForwarder(sess *clusterSession) (*reverseproxy.Fo
 	return forwarder, trace.Wrap(err)
 }
 
-// kubeClusters returns the list of available clusters
+// kubeClusters returns the list of clusters served locally by this teleport
+// service. Empty for ProxyService.
 func (f *Forwarder) kubeClusters() types.KubeClusters {
-	f.rwMutexDetails.RLock()
-	defer f.rwMutexDetails.RUnlock()
-	res := make(types.KubeClusters, 0, len(f.clusterDetails))
-	for _, cred := range f.clusterDetails {
-		cluster := cred.kubeCluster.Copy()
-		res = append(res,
-			cluster,
-		)
+	s := f.upstream.store()
+	if s == nil {
+		return types.KubeClusters{}
 	}
-	return res
+	return s.clusters()
 }
 
-// findKubeDetailsByClusterName searches for the cluster details otherwise returns a trace.NotFound error.
+// findKubeDetailsByClusterName searches for the cluster details, returning a
+// trace.NotFound when this service does not serve clusters locally or the
+// cluster is unknown.
 func (f *Forwarder) findKubeDetailsByClusterName(name string) (*kubeDetails, error) {
-	f.rwMutexDetails.RLock()
-	defer f.rwMutexDetails.RUnlock()
-
-	if creds, ok := f.clusterDetails[name]; ok {
-		return creds, nil
+	s := f.upstream.store()
+	if s == nil {
+		return nil, trace.NotFound("cluster %s not found", name)
 	}
-
-	return nil, trace.NotFound("cluster %s not found", name)
+	return s.find(name)
 }
 
-// upsertKubeDetails updates the details in f.ClusterDetails for key if they exist,
-// otherwise inserts them.
+// upsertKubeDetails inserts or replaces the details for key. A no-op for
+// services that do not serve clusters locally.
 func (f *Forwarder) upsertKubeDetails(key string, clusterDetails *kubeDetails) {
-	f.rwMutexDetails.Lock()
-	defer f.rwMutexDetails.Unlock()
-
-	if oldDetails, ok := f.clusterDetails[key]; ok {
-		oldDetails.Close()
+	if s := f.upstream.store(); s != nil {
+		s.upsert(key, clusterDetails)
 	}
-	// replace existing details in map
-	f.clusterDetails[key] = clusterDetails
 }
 
-// removeKubeDetails removes the kubeDetails from map.
+// removeKubeDetails removes the details for name. A no-op for services that
+// do not serve clusters locally.
 func (f *Forwarder) removeKubeDetails(name string) {
-	f.rwMutexDetails.Lock()
-	defer f.rwMutexDetails.Unlock()
-
-	if oldDetails, ok := f.clusterDetails[name]; ok {
-		oldDetails.Close()
+	if s := f.upstream.store(); s != nil {
+		s.remove(name)
 	}
-	delete(f.clusterDetails, name)
 }
 
 // isLocalKubeCluster reports whether this teleport service serves the target

--- a/lib/kube/proxy/forwarder_test.go
+++ b/lib/kube/proxy/forwarder_test.go
@@ -1205,9 +1205,13 @@ func TestAuthenticate(t *testing.T) {
 			req = req.WithContext(ctx)
 
 			if tt.haveKubeCreds {
-				f.clusterDetails = map[string]*kubeDetails{tt.routeToCluster: {kubeCreds: &staticKubeCreds{targetAddr: "k8s.example.com"}}}
+				// Legacy-proxy semantics: this proxy happens to hold creds for
+				// some clusters and forwards the rest.
+				s := newClusterStore()
+				s.details[tt.routeToCluster] = &kubeDetails{kubeCreds: &staticKubeCreds{targetAddr: "k8s.example.com"}}
+				f.upstream = &legacyProxyResolver{clusters: s}
 			} else {
-				f.clusterDetails = nil
+				f.upstream = proxyServiceResolver{}
 			}
 
 			gotCtx, err := f.authenticate(req)
@@ -1227,7 +1231,7 @@ func TestAuthenticate(t *testing.T) {
 
 			require.Empty(t, cmp.Diff(gotCtx, tt.wantCtx,
 				cmp.AllowUnexported(authContext{}, teleportClusterClient{}, metaResource{}, apiResource{}),
-				cmpopts.IgnoreFields(authContext{}, "clientIdleTimeout", "sessionTTL", "ScopedContext", "recordingConfig", "disconnectExpiredCert", "kubeCluster", "checker", "accessState", "LockingMode"),
+				cmpopts.IgnoreFields(authContext{}, "clientIdleTimeout", "sessionTTL", "ScopedContext", "recordingConfig", "disconnectExpiredCert", "kubeCluster", "checker", "accessState", "LockingMode", "isLocalKubernetesCluster"),
 			))
 
 			if tt.wantDisconnectExpiredCert != nil {
@@ -1593,15 +1597,15 @@ func TestKubeFwdHTTPProxyEnv(t *testing.T) {
 		},
 	} {
 
-		f.clusterDetails = map[string]*kubeDetails{
-			"local": {
-				kubeCreds: &staticKubeCreds{
-					targetAddr: mockKubeAPI.URL,
-					tlsConfig:  mockKubeAPI.TLS,
-					transport:  test.rtBuilder(t),
-				},
+		s := newClusterStore()
+		s.details["local"] = &kubeDetails{
+			kubeCreds: &staticKubeCreds{
+				targetAddr: mockKubeAPI.URL,
+				tlsConfig:  mockKubeAPI.TLS,
+				transport:  test.rtBuilder(t),
 			},
 		}
+		f.upstream = &kubeServiceResolver{clusters: s}
 
 		authCtx.kubeClusterName = "local"
 		sess, err := f.newClusterSession(ctx, authCtx)
@@ -1912,7 +1916,7 @@ func newTestForwarder(ctx context.Context, cfg ForwarderConfig) *Forwarder {
 		activeRequests: make(map[string]context.Context),
 		ctx:            ctx,
 	}
-	if upstream, err := newUpstreamResolver(cfg.KubeServiceType, f.findKubeDetailsByClusterName); err == nil {
+	if upstream, err := newUpstreamResolver(cfg.KubeServiceType); err == nil {
 		f.upstream = upstream
 	} else {
 		f.upstream = proxyServiceResolver{}
@@ -2404,15 +2408,15 @@ func TestKubeForwarder_GOAWAYErrors(t *testing.T) {
 			// Plug a stub round tripper that returns the GOAWAY-related error
 			// into a fake Kubernetes cluster, so the kube proxy's full
 			// error-handling pipeline runs against it.
-			f.clusterDetails = map[string]*kubeDetails{
-				"kube-cluster": {
-					kubeCreds: &staticKubeCreds{
-						targetAddr: "kube.invalid:443",
-						tlsConfig:  &tls.Config{InsecureSkipVerify: true},
-						transport:  &errRoundTripper{err: tt.err},
-					},
+			s := newClusterStore()
+			s.details["kube-cluster"] = &kubeDetails{
+				kubeCreds: &staticKubeCreds{
+					targetAddr: "kube.invalid:443",
+					tlsConfig:  &tls.Config{InsecureSkipVerify: true},
+					transport:  &errRoundTripper{err: tt.err},
 				},
 			}
+			f.upstream = &kubeServiceResolver{clusters: s}
 
 			authCtx := mockAuthCtx(t, "kube-cluster", false)
 			sess, err := f.newClusterSession(ctx, authCtx)
@@ -2470,19 +2474,19 @@ func TestGOAWAYHandling(t *testing.T) {
 	go func() { require.NoError(t, gs.Serve()) }()
 
 	// Insert a fake Kubernetes cluster that forwards requests to the GOAWAY server above.
-	f.clusterDetails = map[string]*kubeDetails{
-		"kube-cluster": {
-			kubeCreds: &staticKubeCreds{
-				targetAddr: gs.URL(),
-				tlsConfig:  gs.tlsConfig,
-				transport: &http2.Transport{
-					TLSClientConfig: &tls.Config{
-						InsecureSkipVerify: true,
-					},
+	s := newClusterStore()
+	s.details["kube-cluster"] = &kubeDetails{
+		kubeCreds: &staticKubeCreds{
+			targetAddr: gs.URL(),
+			tlsConfig:  gs.tlsConfig,
+			transport: &http2.Transport{
+				TLSClientConfig: &tls.Config{
+					InsecureSkipVerify: true,
 				},
 			},
 		},
 	}
+	f.upstream = &kubeServiceResolver{clusters: s}
 
 	// Create a user session.
 	authCtx := mockAuthCtx(t, "kube-cluster", false)
@@ -2556,15 +2560,15 @@ func TestGOAWAYHandling_Concurrent(t *testing.T) {
 	prodTransport, err := newH2Transport(tlsCfg, nil)
 	require.NoError(t, err)
 
-	f.clusterDetails = map[string]*kubeDetails{
-		"kube-cluster": {
-			kubeCreds: &staticKubeCreds{
-				targetAddr: gs.URL(),
-				tlsConfig:  tlsCfg,
-				transport:  prodTransport,
-			},
+	s := newClusterStore()
+	s.details["kube-cluster"] = &kubeDetails{
+		kubeCreds: &staticKubeCreds{
+			targetAddr: gs.URL(),
+			tlsConfig:  tlsCfg,
+			transport:  prodTransport,
 		},
 	}
+	f.upstream = &kubeServiceResolver{clusters: s}
 
 	authCtx := mockAuthCtx(t, "kube-cluster", false)
 	sess, err := f.newClusterSession(ctx, authCtx)

--- a/lib/kube/proxy/server_test.go
+++ b/lib/kube/proxy/server_test.go
@@ -222,11 +222,11 @@ func TestGetServerInfo(t *testing.T) {
 		},
 		fwd: &Forwarder{
 			cfg: ForwarderConfig{},
-			clusterDetails: map[string]*kubeDetails{
+			upstream: &kubeServiceResolver{clusters: &clusterStore{details: map[string]*kubeDetails{
 				"kube-cluster": {
 					kubeCluster: mustCreateKubernetesClusterV3(t, "kube-cluster"),
 				},
-			},
+			}}},
 		},
 		listener: listener,
 	}

--- a/lib/kube/proxy/upstream_resolver.go
+++ b/lib/kube/proxy/upstream_resolver.go
@@ -16,7 +16,63 @@
 
 package proxy
 
-import "github.com/gravitational/trace"
+import (
+	"sync"
+
+	"github.com/gravitational/trace"
+
+	"github.com/gravitational/teleport/api/types"
+)
+
+// clusterStore holds the kube clusters served by a teleport service.
+// Safe for concurrent use. Only the resolvers that serve clusters locally
+// (kube_service, legacy proxy_service) embed a store; the proxy_service
+// resolver does not.
+type clusterStore struct {
+	mu      sync.RWMutex
+	details map[string]*kubeDetails
+}
+
+func newClusterStore() *clusterStore {
+	return &clusterStore{details: make(map[string]*kubeDetails)}
+}
+
+func (s *clusterStore) find(name string) (*kubeDetails, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if d, ok := s.details[name]; ok {
+		return d, nil
+	}
+	return nil, trace.NotFound("cluster %s not found", name)
+}
+
+func (s *clusterStore) upsert(name string, details *kubeDetails) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if old, ok := s.details[name]; ok {
+		old.Close()
+	}
+	s.details[name] = details
+}
+
+func (s *clusterStore) remove(name string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if old, ok := s.details[name]; ok {
+		old.Close()
+	}
+	delete(s.details, name)
+}
+
+func (s *clusterStore) clusters() types.KubeClusters {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	res := make(types.KubeClusters, 0, len(s.details))
+	for _, d := range s.details {
+		res = append(res, d.kubeCluster.Copy())
+	}
+	return res
+}
 
 // upstreamResolver decides, per request, how the Forwarder should treat a
 // target kubernetes cluster: serve it locally with the returned details, or
@@ -47,56 +103,63 @@ type upstreamResolver interface {
 	// cluster is not served locally. ProxyService always does; LegacyProxyService
 	// does as a fallback; KubeService does not.
 	forwardsToOtherAgents() bool
+
+	// store returns the cluster store for resolvers that serve clusters
+	// locally, or nil otherwise. Callers must nil-check.
+	store() *clusterStore
 }
 
 type kubeServiceResolver struct {
-	lookup func(name string) (*kubeDetails, error)
+	clusters *clusterStore
 }
 
 func (r *kubeServiceResolver) resolveDetails(name string) (*kubeDetails, error) {
-	return r.lookup(name)
+	return r.clusters.find(name)
 }
 
-func (*kubeServiceResolver) component() string        { return KubeService }
-func (*kubeServiceResolver) servesLocalClusters() bool { return true }
+func (*kubeServiceResolver) component() string          { return KubeService }
+func (*kubeServiceResolver) servesLocalClusters() bool  { return true }
 func (*kubeServiceResolver) forwardsToOtherAgents() bool { return false }
+func (r *kubeServiceResolver) store() *clusterStore     { return r.clusters }
 
 type proxyServiceResolver struct{}
 
 func (proxyServiceResolver) resolveDetails(string) (*kubeDetails, error) { return nil, nil }
 
-func (proxyServiceResolver) component() string          { return ProxyService }
-func (proxyServiceResolver) servesLocalClusters() bool  { return false }
+func (proxyServiceResolver) component() string           { return ProxyService }
+func (proxyServiceResolver) servesLocalClusters() bool   { return false }
 func (proxyServiceResolver) forwardsToOtherAgents() bool { return true }
+func (proxyServiceResolver) store() *clusterStore        { return nil }
 
 type legacyProxyResolver struct {
-	lookup func(name string) (*kubeDetails, error)
+	clusters *clusterStore
 }
 
 func (r *legacyProxyResolver) resolveDetails(name string) (*kubeDetails, error) {
-	d, err := r.lookup(name)
-	if err != nil {
-		// LegacyProxyService falls back to passthrough when the cluster is not
-		// served locally. The next hop will enforce RBAC.
-		return nil, nil
+	if d, err := r.clusters.find(name); err == nil {
+		return d, nil
 	}
-	return d, nil
+	// LegacyProxyService falls back to passthrough when the cluster is not
+	// served locally. The next hop will enforce RBAC.
+	return nil, nil
 }
 
-func (*legacyProxyResolver) component() string          { return LegacyProxyService }
-func (*legacyProxyResolver) servesLocalClusters() bool  { return true }
+func (*legacyProxyResolver) component() string           { return LegacyProxyService }
+func (*legacyProxyResolver) servesLocalClusters() bool   { return true }
 func (*legacyProxyResolver) forwardsToOtherAgents() bool { return true }
+func (r *legacyProxyResolver) store() *clusterStore      { return r.clusters }
 
-// newUpstreamResolver builds the resolver matching the given KubeServiceType,
-// wiring it to lookup for credential/details resolution.
-func newUpstreamResolver(svc KubeServiceType, lookup func(string) (*kubeDetails, error)) (upstreamResolver, error) {
+// newUpstreamResolver builds the resolver matching the given KubeServiceType.
+// Resolvers that serve clusters locally are given a fresh, empty store; the
+// proxy resolver has none.
+func newUpstreamResolver(svc KubeServiceType) (upstreamResolver, error) {
 	switch svc {
 	case KubeService:
-		return &kubeServiceResolver{lookup: lookup}, nil
+		return &kubeServiceResolver{clusters: newClusterStore()}, nil
 	case ProxyService:
 		return proxyServiceResolver{}, nil
 	case LegacyProxyService:
-		return &legacyProxyResolver{lookup: lookup}, nil
+		return &legacyProxyResolver{clusters: newClusterStore()}, nil
 	default:
 		return nil, trace.BadParameter("unknown KubeServiceType %q", svc)
 	}

--- a/lib/kube/proxy/watcher_test.go
+++ b/lib/kube/proxy/watcher_test.go
@@ -190,7 +190,9 @@ func TestWatcher(t *testing.T) {
 			cmpopts.IgnoreFields(types.Metadata{}, "Revision"),
 		))
 		// make sure credentials were updated as well.
-		require.Equal(t, strings.TrimPrefix(kubeMock.URL, "https://"), testCtx.KubeServer.fwd.clusterDetails["kube2"].kubeCreds.getTargetAddr())
+		kube2Details, err := testCtx.KubeServer.fwd.findKubeDetailsByClusterName("kube2")
+		require.NoError(t, err)
+		require.Equal(t, strings.TrimPrefix(kubeMock.URL, "https://"), kube2Details.kubeCreds.getTargetAddr())
 	case <-time.After(time.Second):
 		t.Fatal("Didn't receive reconcile event after 1s.")
 	}


### PR DESCRIPTION
Stacked on the previous server.go PR. Pure refactor in `lib/kube/proxy`. No behavior change.

The `Forwarder` no longer owns the kube cluster state. Introduces a `clusterStore` type (map + rwmutex + lifecycle-aware add/remove) owned by the resolvers that serve clusters locally (kube_service, legacy_proxy_service). The proxy_service resolver has no store. The Forwarder's four cluster-state methods (`kubeClusters`, `findKubeDetailsByClusterName`, `upsertKubeDetails`, `removeKubeDetails`) became thin façades over `f.upstream.store()`, and the direct map access in `auth.go` now goes through the façade.

Most diff is test fixtures that constructed `Forwarder{}` literals with `clusterDetails: map{...}`. They now construct the resolver with a populated store. One TestAuthenticate fixture moved from `ProxyService` to `legacyProxyResolver`, which is structurally what it always was — pre-refactor it exploited that `isLocalKubeCluster` ignored the map for `ProxyService`.

Next (separate effort): route ~25 metric/span label sites through `component()`, retire `KubeServiceType` field from `ForwarderConfig`, delete `LegacyProxyService` once deployment migration permits.