### PR TITLE
kube: extract upstreamResolver from proxy Forwarder

### DIFF
--- a/lib/kube/proxy/forwarder.go
+++ b/lib/kube/proxy/forwarder.go
@@ -347,6 +347,11 @@ func NewForwarder(cfg ForwarderConfig) (*Forwarder, error) {
 		clusterDetails:  make(map[string]*kubeDetails),
 		cachedTransport: transportClients,
 	}
+	upstream, err := newUpstreamResolver(cfg.KubeServiceType, fwd.findKubeDetailsByClusterName)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	fwd.upstream = upstream
 
 	router := httprouter.New()
 	router.UseRawPath = true
@@ -403,6 +408,10 @@ type Forwarder struct {
 	log    *slog.Logger
 	router http.Handler
 	cfg    ForwarderConfig
+	// upstream decides how the Forwarder treats a target kube cluster: serve
+	// it locally or forward to the next hop. It replaces per-request branching
+	// on cfg.KubeServiceType.
+	upstream upstreamResolver
 	// activeRequests is a map used to serialize active CSR requests to the auth server
 	activeRequests map[string]context.Context
 	// close is a close function
@@ -975,38 +984,15 @@ func checkAmbiguousClusters(kubeServers []types.KubeServer) error {
 }
 
 func (f *Forwarder) parseResourceFromRequest(req *http.Request, kubeClusterName string) (metaResource, error) {
-	switch f.cfg.KubeServiceType {
-	case LegacyProxyService:
-		if details, err := f.findKubeDetailsByClusterName(kubeClusterName); err == nil {
-			out, err := getResourceFromRequest(req, details)
-			return out, trace.Wrap(err)
-		}
-		// When the cluster is not being served by the local service, the LegacyProxy
-		// is working as a normal proxy and will forward the request to the remote
-		// service. When this happens, proxy won't enforce any Kubernetes RBAC rules
-		// and will forward the request as is to the remote service. The remote
-		// service will enforce RBAC rules and will return an error if the user is
-		// not authorized.
-		fallthrough
-	case ProxyService:
-		// When the service is acting as a proxy (ProxyService or LegacyProxyService
-		// if the local cluster wasn't found), the proxy will forward the request
-		// to the remote service without enforcing any RBAC rules - we send the
-		// details = nil to indicate that we don't want to extract the kube resource
-		// from the request.
-		out, err := getResourceFromRequest(req, nil /*details*/)
-		return out, trace.Wrap(err)
-	case KubeService:
-		details, err := f.findKubeDetailsByClusterName(kubeClusterName)
-		if err != nil {
-			return metaResource{}, trace.Wrap(err)
-		}
-		out, err := getResourceFromRequest(req, details)
-		return out, trace.Wrap(err)
-
-	default:
-		return metaResource{}, trace.BadParameter("unsupported kube service type: %q", f.cfg.KubeServiceType)
+	// Nil details means the resolver wants this request passed through to the
+	// next hop; getResourceFromRequest interprets nil as "do not extract the
+	// kube resource, the next hop enforces RBAC."
+	details, err := f.upstream.resolveDetails(kubeClusterName)
+	if err != nil {
+		return metaResource{}, trace.Wrap(err)
 	}
+	out, err := getResourceFromRequest(req, details)
+	return out, trace.Wrap(err)
 }
 
 // emitAuditEvent emits the audit event for a `kube.request` event if the session
@@ -2988,20 +2974,15 @@ func (f *Forwarder) removeKubeDetails(name string) {
 }
 
 // isLocalKubeCluster reports whether this teleport service serves the target
-// kube cluster directly. KubeService and LegacyProxyService can serve clusters
-// they hold details for; ProxyService never does. Requests for remote (leaf)
-// teleport clusters are always forwarded, never served locally.
+// kube cluster directly. Requests for remote (leaf) teleport clusters are
+// always forwarded, never served locally; otherwise the upstream resolver
+// is the authority.
 func (f *Forwarder) isLocalKubeCluster(isRemoteTeleportCluster bool, kubeClusterName string) bool {
-	switch f.cfg.KubeServiceType {
-	case KubeService, LegacyProxyService:
-		if isRemoteTeleportCluster {
-			return false
-		}
-		_, err := f.findKubeDetailsByClusterName(kubeClusterName)
-		return err == nil
-	default:
+	if isRemoteTeleportCluster {
 		return false
 	}
+	details, _ := f.upstream.resolveDetails(kubeClusterName)
+	return details != nil
 }
 
 // kubeResourceDeniedAccessMsg creates a Kubernetes API like forbidden response.

--- a/lib/kube/proxy/forwarder_test.go
+++ b/lib/kube/proxy/forwarder_test.go
@@ -172,7 +172,8 @@ func TestAuthenticate(t *testing.T) {
 	}
 	newForwarder := func() *Forwarder {
 		return &Forwarder{
-			log: logtest.NewLogger(),
+			log:      logtest.NewLogger(),
+			upstream: proxyServiceResolver{},
 			cfg: ForwarderConfig{
 				ClusterName:       "local",
 				CachingAuthClient: ap,
@@ -1645,8 +1646,9 @@ func newMockForwarder(ctx context.Context, t *testing.T) *Forwarder {
 	require.NoError(t, err)
 
 	return &Forwarder{
-		log:    logtest.NewLogger(),
-		router: httprouter.New(),
+		log:      logtest.NewLogger(),
+		router:   httprouter.New(),
+		upstream: proxyServiceResolver{},
 		cfg: ForwarderConfig{
 			Keygen:            authority,
 			AuthClient:        caClient,
@@ -1903,13 +1905,19 @@ func (m *mockWatcher) Done() <-chan struct{} {
 }
 
 func newTestForwarder(ctx context.Context, cfg ForwarderConfig) *Forwarder {
-	return &Forwarder{
+	f := &Forwarder{
 		log:            logtest.NewLogger(),
 		router:         httprouter.New(),
 		cfg:            cfg,
 		activeRequests: make(map[string]context.Context),
 		ctx:            ctx,
 	}
+	if upstream, err := newUpstreamResolver(cfg.KubeServiceType, f.findKubeDetailsByClusterName); err == nil {
+		f.upstream = upstream
+	} else {
+		f.upstream = proxyServiceResolver{}
+	}
+	return f
 }
 
 type mockSemaphoreClient struct {
@@ -2302,6 +2310,7 @@ func TestForwarderTLSConfigCAs(t *testing.T) {
 
 	var getConnTLSRootsCalled bool
 	f := &Forwarder{
+		upstream: proxyServiceResolver{},
 		cfg: ForwarderConfig{
 			Keygen:            authority,
 			AuthClient:        cl,

--- a/lib/kube/proxy/upstream_resolver.go
+++ b/lib/kube/proxy/upstream_resolver.go
@@ -1,0 +1,86 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package proxy
+
+import "github.com/gravitational/trace"
+
+// upstreamResolver decides, per request, how the Forwarder should treat a
+// target kubernetes cluster: serve it locally with the returned details, or
+// forward the request to the next hop without enforcing RBAC.
+//
+// Three return shapes:
+//   - (details, nil)  : this service serves the cluster directly. Use the
+//     details for credentials and enforce kube RBAC at this hop.
+//   - (nil, nil)      : this service is acting as a passthrough; the next hop
+//     is responsible for credentials and RBAC.
+//   - (nil, err)      : this service is supposed to serve the cluster but
+//     does not know about it. Caller should surface the error.
+//
+// Implementations correspond to the three deployment shapes today (kubernetes
+// service, proxy service, legacy proxy service), but the Forwarder no longer
+// needs to switch on the shape — it asks the resolver.
+type upstreamResolver interface {
+	resolveDetails(kubeClusterName string) (*kubeDetails, error)
+	component() string
+}
+
+type kubeServiceResolver struct {
+	lookup func(name string) (*kubeDetails, error)
+}
+
+func (r *kubeServiceResolver) resolveDetails(name string) (*kubeDetails, error) {
+	return r.lookup(name)
+}
+
+func (*kubeServiceResolver) component() string { return KubeService }
+
+type proxyServiceResolver struct{}
+
+func (proxyServiceResolver) resolveDetails(string) (*kubeDetails, error) { return nil, nil }
+
+func (proxyServiceResolver) component() string { return ProxyService }
+
+type legacyProxyResolver struct {
+	lookup func(name string) (*kubeDetails, error)
+}
+
+func (r *legacyProxyResolver) resolveDetails(name string) (*kubeDetails, error) {
+	d, err := r.lookup(name)
+	if err != nil {
+		// LegacyProxyService falls back to passthrough when the cluster is not
+		// served locally. The next hop will enforce RBAC.
+		return nil, nil
+	}
+	return d, nil
+}
+
+func (*legacyProxyResolver) component() string { return LegacyProxyService }
+
+// newUpstreamResolver builds the resolver matching the given KubeServiceType,
+// wiring it to lookup for credential/details resolution.
+func newUpstreamResolver(svc KubeServiceType, lookup func(string) (*kubeDetails, error)) (upstreamResolver, error) {
+	switch svc {
+	case KubeService:
+		return &kubeServiceResolver{lookup: lookup}, nil
+	case ProxyService:
+		return proxyServiceResolver{}, nil
+	case LegacyProxyService:
+		return &legacyProxyResolver{lookup: lookup}, nil
+	default:
+		return nil, trace.BadParameter("unknown KubeServiceType %q", svc)
+	}
+}


### PR DESCRIPTION
Stacked on #66823. Pure refactor in `lib/kube/proxy`. No behavior change.

The proxy `Forwarder` had two `KubeServiceType` `switch` statements doing per-request work: `parseResourceFromRequest` (the security-relevant "do I enforce kube RBAC here?" decision) and `isLocalKubeCluster`. Introduces a small `upstreamResolver` interface with three implementations (kube_service, proxy_service, legacy_proxy_service) and replaces both switches with a single `resolveDetails(name)` call. The Forwarder no longer asks "what kind of teleport service am I?" — it asks the resolver "should I serve this cluster?"

Next in the stack: server.go switches, then state ownership, then retiring the `KubeServiceType` field entirely.