### PR TITLE
kube: route server.go heartbeat and lookup via resolver

### DIFF
--- a/lib/kube/proxy/server.go
+++ b/lib/kube/proxy/server.go
@@ -719,23 +719,19 @@ func (t *TLSServer) getRotationState() types.Rotation {
 }
 
 func (t *TLSServer) startStaticClustersHeartbeat() error {
-	// Start the heartbeat to announce kubernetes_service presence.
-	//
-	// Only announce when running in an actual kube_server, or when
-	// running in proxy_service with local kube credentials. This means that
-	// proxy_service will pretend to also be kube_server.
-	if t.KubeServiceType == KubeService ||
-		t.KubeServiceType == LegacyProxyService {
-		t.log.DebugContext(t.closeContext, "Starting kubernetes_service heartbeats and health checks")
-		for _, kc := range t.fwd.kubeClusters() {
-			if err := t.startHeartbeatAndHealthCheck(kc); err != nil {
-				return trace.Wrap(err)
-			}
-		}
-	} else {
+	// Only announce kubernetes_service presence when this service holds
+	// cluster details locally. A pure proxy never announces; a legacy proxy
+	// pretends to be a kube_server for any locally-held clusters.
+	if !t.fwd.upstream.servesLocalClusters() {
 		t.log.DebugContext(t.closeContext, "No local kube credentials on proxy, will not start kubernetes_service heartbeats and health checks")
+		return nil
 	}
-
+	t.log.DebugContext(t.closeContext, "Starting kubernetes_service heartbeats and health checks")
+	for _, kc := range t.fwd.kubeClusters() {
+		if err := t.startHeartbeatAndHealthCheck(kc); err != nil {
+			return trace.Wrap(err)
+		}
+	}
 	return nil
 }
 
@@ -791,42 +787,41 @@ func (t *TLSServer) setServiceLabels(cluster types.KubeCluster) {
 	}
 }
 
-// getKubernetesServersForKubeClusterFunc returns a function that returns the kubernetes servers
-// for a given kube cluster depending on the type of service.
+// getKubernetesServersForKubeClusterFunc returns a function that looks up the
+// kube_server resources for a named kube cluster. The strategy is dictated by
+// the upstream resolver: services that hold clusters locally return a
+// self-server entry; services that forward to other agents query the
+// KubernetesServersWatcher. A legacy proxy does both, preferring local.
 func (t *TLSServer) getKubernetesServersForKubeClusterFunc() (getKubeServersByNameFunc, error) {
-	switch t.KubeServiceType {
-	case KubeService:
-		return func(_ context.Context, name string) ([]types.KubeServer, error) {
-			// If this is a kube_service, we can just return the local kube servers.
-			kube, err := t.getKubeClusterWithServiceLabels(name)
-			if err != nil {
-				return nil, trace.Wrap(err)
-			}
-			srv, err := types.NewKubernetesServerV3FromCluster(kube, "", t.HostID)
-			if err != nil {
-				return nil, trace.Wrap(err)
-			}
-			return []types.KubeServer{srv}, nil
-		}, nil
-	case ProxyService:
-		return t.KubernetesServersWatcher.GetKubeServersForClusterName, nil
-	case LegacyProxyService:
+	upstream := t.fwd.upstream
+	fromWatcher := t.KubernetesServersWatcher.GetKubeServersForClusterName
+	fromLocal := func(name string) ([]types.KubeServer, error) {
+		kube, err := t.getKubeClusterWithServiceLabels(name)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		srv, err := types.NewKubernetesServerV3FromCluster(kube, "", t.HostID)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		return []types.KubeServer{srv}, nil
+	}
+
+	switch {
+	case upstream.servesLocalClusters() && upstream.forwardsToOtherAgents():
 		return func(ctx context.Context, name string) ([]types.KubeServer, error) {
-			// If this is a legacy kube proxy, then we need to return the local kube servers if
-			// the local server is proxying the target cluster, otherwise act like a proxy_service.
-			// and forward the request to the next proxy.
-			kube, err := t.getKubeClusterWithServiceLabels(name)
-			if err != nil {
-				servers, err := t.KubernetesServersWatcher.GetKubeServersForClusterName(ctx, name)
-				return servers, trace.Wrap(err)
+			if servers, err := fromLocal(name); err == nil {
+				return servers, nil
 			}
-			srv, err := types.NewKubernetesServerV3FromCluster(kube, "", t.HostID)
-			if err != nil {
-				return nil, trace.Wrap(err)
-			}
-			return []types.KubeServer{srv}, nil
+			return fromWatcher(ctx, name)
 		}, nil
+	case upstream.servesLocalClusters():
+		return func(_ context.Context, name string) ([]types.KubeServer, error) {
+			return fromLocal(name)
+		}, nil
+	case upstream.forwardsToOtherAgents():
+		return fromWatcher, nil
 	default:
-		return nil, trace.BadParameter("unknown kubernetes service type %q", t.KubeServiceType)
+		return nil, trace.BadParameter("upstream resolver %q does neither", upstream.component())
 	}
 }

--- a/lib/kube/proxy/upstream_resolver.go
+++ b/lib/kube/proxy/upstream_resolver.go
@@ -36,6 +36,17 @@ import "github.com/gravitational/trace"
 type upstreamResolver interface {
 	resolveDetails(kubeClusterName string) (*kubeDetails, error)
 	component() string
+
+	// servesLocalClusters reports whether this service can hold details for
+	// kube clusters directly. KubeService and LegacyProxyService do;
+	// ProxyService does not.
+	servesLocalClusters() bool
+
+	// forwardsToOtherAgents reports whether this service queries the
+	// kube_servers watcher and forwards to another agent when the target
+	// cluster is not served locally. ProxyService always does; LegacyProxyService
+	// does as a fallback; KubeService does not.
+	forwardsToOtherAgents() bool
 }
 
 type kubeServiceResolver struct {
@@ -46,13 +57,17 @@ func (r *kubeServiceResolver) resolveDetails(name string) (*kubeDetails, error) 
 	return r.lookup(name)
 }
 
-func (*kubeServiceResolver) component() string { return KubeService }
+func (*kubeServiceResolver) component() string        { return KubeService }
+func (*kubeServiceResolver) servesLocalClusters() bool { return true }
+func (*kubeServiceResolver) forwardsToOtherAgents() bool { return false }
 
 type proxyServiceResolver struct{}
 
 func (proxyServiceResolver) resolveDetails(string) (*kubeDetails, error) { return nil, nil }
 
-func (proxyServiceResolver) component() string { return ProxyService }
+func (proxyServiceResolver) component() string          { return ProxyService }
+func (proxyServiceResolver) servesLocalClusters() bool  { return false }
+func (proxyServiceResolver) forwardsToOtherAgents() bool { return true }
 
 type legacyProxyResolver struct {
 	lookup func(name string) (*kubeDetails, error)
@@ -68,7 +83,9 @@ func (r *legacyProxyResolver) resolveDetails(name string) (*kubeDetails, error) 
 	return d, nil
 }
 
-func (*legacyProxyResolver) component() string { return LegacyProxyService }
+func (*legacyProxyResolver) component() string          { return LegacyProxyService }
+func (*legacyProxyResolver) servesLocalClusters() bool  { return true }
+func (*legacyProxyResolver) forwardsToOtherAgents() bool { return true }
 
 // newUpstreamResolver builds the resolver matching the given KubeServiceType,
 // wiring it to lookup for credential/details resolution.


### PR DESCRIPTION
Stacked on the previous resolver extraction PR. Pure refactor in `lib/kube/proxy`. No behavior change.

Migrates two `KubeServiceType` switches in `server.go` (`startStaticClustersHeartbeat` and `getKubernetesServersForKubeClusterFunc`) to the `upstreamResolver`. Adds two booleans to the resolver interface: `servesLocalClusters` (this service holds clusters → announces heartbeats, returns self as upstream kube_server) and `forwardsToOtherAgents` (queries the kube_servers watcher when not serving locally). The legacy-proxy "local first, watcher fallback" pattern is now visible as a composition rather than duplicated code.

Three switches in `server.go` deliberately left alone: config validation (idiosyncratic required-fields-per-mode), KubeService-specific empty-fleet check, and the reverse-tunnel name suffix. They don't share an abstraction axis with the resolver.

Next in the stack: move cluster state ownership onto the resolver.