### PR TITLE
kube: route component label via resolver

### DIFF
--- a/lib/kube/proxy/ephemeral_containers.go
+++ b/lib/kube/proxy/ephemeral_containers.go
@@ -56,7 +56,7 @@ func (f *Forwarder) ephemeralContainers(authCtx *authContext, w http.ResponseWri
 		"kube.Forwarder/ephemeralContainers",
 		oteltrace.WithSpanKind(oteltrace.SpanKindServer),
 		oteltrace.WithAttributes(
-			semconv.RPCServiceKey.String(f.cfg.KubeServiceType),
+			semconv.RPCServiceKey.String(f.component()),
 			semconv.RPCMethodKey.String("ephemeralContainers"),
 			semconv.RPCSystemKey.String("kube"),
 		),

--- a/lib/kube/proxy/forwarder.go
+++ b/lib/kube/proxy/forwarder.go
@@ -385,7 +385,7 @@ func NewForwarder(cfg ForwarderConfig) (*Forwarder, error) {
 
 	router.NotFound = fwd.withAuthStd(fwd.catchAll)
 
-	fwd.router = instrumentHTTPHandler(fwd.cfg.KubeServiceType, router)
+	fwd.router = instrumentHTTPHandler(fwd.component(), router)
 
 	if cfg.ClusterOverride != "" {
 		fwd.log.DebugContext(closeCtx, "Cluster override is set, forwarder will send all requests to remote cluster", "cluster_override", cfg.ClusterOverride)
@@ -446,6 +446,13 @@ type cachedTransportEntry struct {
 // getKubeServersByNameFunc is a function that returns a list of
 // kubernetes servers for a given kube cluster.
 type getKubeServersByNameFunc = func(ctx context.Context, name string) ([]types.KubeServer, error)
+
+// component returns the Teleport service name used for metric labels and
+// tracing spans. Sourced from the upstream resolver so call sites do not need
+// to switch on KubeServiceType.
+func (f *Forwarder) component() string {
+	return f.upstream.component()
+}
 
 // Close signals close to all outstanding or background operations
 // to complete
@@ -589,7 +596,7 @@ func (f *Forwarder) authenticate(req *http.Request) (*authContext, error) {
 		"kube.Forwarder/authenticate",
 		oteltrace.WithSpanKind(oteltrace.SpanKindServer),
 		oteltrace.WithAttributes(
-			semconv.RPCServiceKey.String(f.cfg.KubeServiceType),
+			semconv.RPCServiceKey.String(f.component()),
 			semconv.RPCSystemKey.String("kube"),
 		),
 	)
@@ -642,7 +649,7 @@ func (f *Forwarder) withAuthStd(handler handlerWithAuthFuncStd) http.HandlerFunc
 			"kube.Forwarder/withAuthStd",
 			oteltrace.WithSpanKind(oteltrace.SpanKindServer),
 			oteltrace.WithAttributes(
-				semconv.RPCServiceKey.String(f.cfg.KubeServiceType),
+				semconv.RPCServiceKey.String(f.component()),
 				semconv.RPCSystemKey.String("kube"),
 			),
 		)
@@ -711,7 +718,7 @@ func (f *Forwarder) withAuth(handler handlerWithAuthFunc, opts ...authOption) ht
 			"kube.Forwarder/withAuth",
 			oteltrace.WithSpanKind(oteltrace.SpanKindServer),
 			oteltrace.WithAttributes(
-				semconv.RPCServiceKey.String(f.cfg.KubeServiceType),
+				semconv.RPCServiceKey.String(f.component()),
 				semconv.RPCSystemKey.String("kube"),
 			),
 		)
@@ -741,7 +748,7 @@ func (f *Forwarder) withAuthPassthrough(handler handlerWithAuthFunc) httprouter.
 			"kube.Forwarder/withAuthPassthrough",
 			oteltrace.WithSpanKind(oteltrace.SpanKindServer),
 			oteltrace.WithAttributes(
-				semconv.RPCServiceKey.String(f.cfg.KubeServiceType),
+				semconv.RPCServiceKey.String(f.component()),
 				semconv.RPCSystemKey.String("kube"),
 			),
 		)
@@ -861,7 +868,7 @@ func (f *Forwarder) setupContext(
 		"kube.Forwarder/setupContext",
 		oteltrace.WithSpanKind(oteltrace.SpanKindServer),
 		oteltrace.WithAttributes(
-			semconv.RPCServiceKey.String(f.cfg.KubeServiceType),
+			semconv.RPCServiceKey.String(f.component()),
 			semconv.RPCSystemKey.String("kube"),
 		),
 	)
@@ -998,7 +1005,7 @@ func (f *Forwarder) emitAuditEvent(req *http.Request, sess *clusterSession, stat
 		"kube.Forwarder/emitAuditEvent",
 		oteltrace.WithSpanKind(oteltrace.SpanKindServer),
 		oteltrace.WithAttributes(
-			semconv.RPCServiceKey.String(f.cfg.KubeServiceType),
+			semconv.RPCServiceKey.String(f.component()),
 			semconv.RPCSystemKey.String("kube"),
 		),
 	)
@@ -1182,7 +1189,7 @@ func (f *Forwarder) authorize(ctx context.Context, actx *authContext) error {
 		"kube.Forwarder/authorize",
 		oteltrace.WithSpanKind(oteltrace.SpanKindServer),
 		oteltrace.WithAttributes(
-			semconv.RPCServiceKey.String(f.cfg.KubeServiceType),
+			semconv.RPCServiceKey.String(f.component()),
 			semconv.RPCSystemKey.String("kube"),
 		),
 	)
@@ -1400,9 +1407,9 @@ func matchKubernetesResource(resource types.KubernetesResource, isClusterWideRes
 // join joins an existing session over a websocket connection
 func (f *Forwarder) join(ctx *authContext, w http.ResponseWriter, req *http.Request, p httprouter.Params) (resp any, err error) {
 	// Increment the request counter and the in-flight gauge.
-	joinSessionsRequestCounter.WithLabelValues(f.cfg.KubeServiceType).Inc()
-	joinSessionsInFlightGauge.WithLabelValues(f.cfg.KubeServiceType).Inc()
-	defer joinSessionsInFlightGauge.WithLabelValues(f.cfg.KubeServiceType).Dec()
+	joinSessionsRequestCounter.WithLabelValues(f.component()).Inc()
+	joinSessionsInFlightGauge.WithLabelValues(f.component()).Inc()
+	defer joinSessionsInFlightGauge.WithLabelValues(f.component()).Dec()
 
 	f.log.DebugContext(req.Context(), "Joining session", "join_url", logutils.StringerAttr(req.URL))
 
@@ -1866,16 +1873,16 @@ func exitCode(err error) (errMsg, code string) {
 // all output from the session
 func (f *Forwarder) exec(authCtx *authContext, w http.ResponseWriter, req *http.Request, p httprouter.Params) (resp any, err error) {
 	// Increment the request counter and the in-flight gauge.
-	execSessionsRequestCounter.WithLabelValues(f.cfg.KubeServiceType).Inc()
-	execSessionsInFlightGauge.WithLabelValues(f.cfg.KubeServiceType).Inc()
-	defer execSessionsInFlightGauge.WithLabelValues(f.cfg.KubeServiceType).Dec()
+	execSessionsRequestCounter.WithLabelValues(f.component()).Inc()
+	execSessionsInFlightGauge.WithLabelValues(f.component()).Inc()
+	defer execSessionsInFlightGauge.WithLabelValues(f.component()).Dec()
 
 	ctx, span := f.cfg.tracer.Start(
 		req.Context(),
 		"kube.Forwarder/exec",
 		oteltrace.WithSpanKind(oteltrace.SpanKindServer),
 		oteltrace.WithAttributes(
-			semconv.RPCServiceKey.String(f.cfg.KubeServiceType),
+			semconv.RPCServiceKey.String(f.component()),
 			semconv.RPCMethodKey.String("Exec"),
 			semconv.RPCSystemKey.String("kube"),
 		),
@@ -1991,16 +1998,16 @@ func (f *Forwarder) remoteExec(req *http.Request, sess *clusterSession, proxy *r
 // portForward starts port forwarding to the remote cluster
 func (f *Forwarder) portForward(authCtx *authContext, w http.ResponseWriter, req *http.Request, p httprouter.Params) (any, error) {
 	// Increment the request counter and the in-flight gauge.
-	portforwardRequestCounter.WithLabelValues(f.cfg.KubeServiceType).Inc()
-	portforwardSessionsInFlightGauge.WithLabelValues(f.cfg.KubeServiceType).Inc()
-	defer portforwardSessionsInFlightGauge.WithLabelValues(f.cfg.KubeServiceType).Dec()
+	portforwardRequestCounter.WithLabelValues(f.component()).Inc()
+	portforwardSessionsInFlightGauge.WithLabelValues(f.component()).Inc()
+	defer portforwardSessionsInFlightGauge.WithLabelValues(f.component()).Dec()
 
 	ctx, span := f.cfg.tracer.Start(
 		req.Context(),
 		"kube.Forwarder/portForward",
 		oteltrace.WithSpanKind(oteltrace.SpanKindServer),
 		oteltrace.WithAttributes(
-			semconv.RPCServiceKey.String(f.cfg.KubeServiceType),
+			semconv.RPCServiceKey.String(f.component()),
 			semconv.RPCMethodKey.String("portForward"),
 			semconv.RPCSystemKey.String("kube"),
 		),
@@ -2345,7 +2352,7 @@ func (f *Forwarder) catchAll(authCtx *authContext, w http.ResponseWriter, req *h
 		"kube.Forwarder/catchAll",
 		oteltrace.WithSpanKind(oteltrace.SpanKindServer),
 		oteltrace.WithAttributes(
-			semconv.RPCServiceKey.String(f.cfg.KubeServiceType),
+			semconv.RPCServiceKey.String(f.component()),
 			semconv.RPCMethodKey.String("catchAll"),
 			semconv.RPCSystemKey.String("kube"),
 		),
@@ -2793,7 +2800,7 @@ func (f *Forwarder) newClusterSession(ctx context.Context, authCtx authContext) 
 		"kube.Forwarder/newClusterSession",
 		oteltrace.WithSpanKind(oteltrace.SpanKindServer),
 		oteltrace.WithAttributes(
-			semconv.RPCServiceKey.String(f.cfg.KubeServiceType),
+			semconv.RPCServiceKey.String(f.component()),
 			semconv.RPCMethodKey.String("GlobalRequest"),
 			semconv.RPCSystemKey.String("kube"),
 		),

--- a/lib/kube/proxy/resource_deletecollection.go
+++ b/lib/kube/proxy/resource_deletecollection.go
@@ -52,7 +52,7 @@ func (f *Forwarder) deleteResourcesCollection(sess *clusterSession, w http.Respo
 		"kube.Forwarder/deleteResourcesCollection",
 		oteltrace.WithSpanKind(oteltrace.SpanKindServer),
 		oteltrace.WithAttributes(
-			semconv.RPCServiceKey.String(f.cfg.KubeServiceType),
+			semconv.RPCServiceKey.String(f.component()),
 			semconv.RPCMethodKey.String("deleteResourcesCollection"),
 			semconv.RPCSystemKey.String("kube"),
 		),
@@ -101,7 +101,7 @@ func (f *Forwarder) handleDeleteCollectionReq(req *http.Request, sess *clusterSe
 		"kube.Forwarder/handleDeleteCollectionReq",
 		oteltrace.WithSpanKind(oteltrace.SpanKindServer),
 		oteltrace.WithAttributes(
-			semconv.RPCServiceKey.String(f.cfg.KubeServiceType),
+			semconv.RPCServiceKey.String(f.component()),
 			semconv.RPCMethodKey.String("deletePodsCollection"),
 			semconv.RPCSystemKey.String("kube"),
 		),

--- a/lib/kube/proxy/resource_list.go
+++ b/lib/kube/proxy/resource_list.go
@@ -45,7 +45,7 @@ func (f *Forwarder) listResources(sess *clusterSession, w http.ResponseWriter, r
 		"kube.Forwarder/listResources",
 		oteltrace.WithSpanKind(oteltrace.SpanKindServer),
 		oteltrace.WithAttributes(
-			semconv.RPCServiceKey.String(f.cfg.KubeServiceType),
+			semconv.RPCServiceKey.String(f.component()),
 			semconv.RPCMethodKey.String("listResources"),
 			semconv.RPCSystemKey.String("kube"),
 		),
@@ -129,7 +129,7 @@ func (f *Forwarder) listResourcesList(req *http.Request, w http.ResponseWriter, 
 		"kube.Forwarder/listResourcesList",
 		oteltrace.WithSpanKind(oteltrace.SpanKindServer),
 		oteltrace.WithAttributes(
-			semconv.RPCServiceKey.String(f.cfg.KubeServiceType),
+			semconv.RPCServiceKey.String(f.component()),
 			semconv.RPCSystemKey.String("kube"),
 		),
 	)
@@ -156,7 +156,7 @@ func (f *Forwarder) listResourcesList(req *http.Request, w http.ResponseWriter, 
 	// and routes the body to either the streaming or buffered filter path.
 	matcher := newMatcher(sess.metaResource, allowedResources, deniedResources, f.log)
 	filterWrapper := newResourceFilterer(sess.metaResource, sess.codecFactory, matcher, f.log)
-	fw := newFilteringResponseWriter(w, matcher, filterWrapper, f.log, ctx, f.cfg.tracer, f.cfg.KubeServiceType)
+	fw := newFilteringResponseWriter(w, matcher, filterWrapper, f.log, ctx, f.cfg.tracer, f.component())
 	sess.forwarder.ServeHTTP(fw, req)
 	return fw.Finish()
 }
@@ -203,7 +203,7 @@ func (f *Forwarder) listResourcesWatcher(req *http.Request, w http.ResponseWrite
 		"kube.Forwarder/listResourcesWatcher",
 		oteltrace.WithSpanKind(oteltrace.SpanKindServer),
 		oteltrace.WithAttributes(
-			semconv.RPCServiceKey.String(f.cfg.KubeServiceType),
+			semconv.RPCServiceKey.String(f.component()),
 			semconv.RPCSystemKey.String("kube"),
 		),
 	)

--- a/lib/kube/proxy/self_subject_reviews.go
+++ b/lib/kube/proxy/self_subject_reviews.go
@@ -50,7 +50,7 @@ func (f *Forwarder) selfSubjectAccessReviews(authCtx *authContext, w http.Respon
 		"kube.Forwarder/selfSubjectAccessReviews",
 		oteltrace.WithSpanKind(oteltrace.SpanKindServer),
 		oteltrace.WithAttributes(
-			semconv.RPCServiceKey.String(f.cfg.KubeServiceType),
+			semconv.RPCServiceKey.String(f.component()),
 			semconv.RPCMethodKey.String("selfSubjectAccessReviews"),
 			semconv.RPCSystemKey.String("kube"),
 		),

--- a/lib/kube/proxy/transport.go
+++ b/lib/kube/proxy/transport.go
@@ -184,7 +184,7 @@ func (f *Forwarder) newRemoteClusterTransport(clusterName string) (http.RoundTri
 	}
 
 	return instrumentedRoundtripper(
-		f.cfg.KubeServiceType,
+		f.component(),
 		internal.NewImpersonatorRoundTripper(h2Transport),
 	), tlsConfig.Clone(), nil
 }
@@ -234,7 +234,7 @@ func (f *Forwarder) remoteClusterDialer(clusterName string) dialContextFunc {
 			"kube.Forwarder/remoteClusterDiater",
 			oteltrace.WithSpanKind(oteltrace.SpanKindClient),
 			oteltrace.WithAttributes(
-				semconv.RPCServiceKey.String(f.cfg.KubeServiceType),
+				semconv.RPCServiceKey.String(f.component()),
 				semconv.RPCMethodKey.String("reverse_tunnel.Dial"),
 				semconv.RPCSystemKey.String("kube"),
 			),
@@ -285,7 +285,7 @@ func (f *Forwarder) newLocalClusterTransport(kubeClusterName, scope string) (htt
 	}
 
 	return instrumentedRoundtripper(
-		f.cfg.KubeServiceType,
+		f.component(),
 		internal.NewImpersonatorRoundTripper(h2Transport),
 	), tlsConfig.Clone(), nil
 }
@@ -305,7 +305,7 @@ func (f *Forwarder) localClusterDialer(kubeClusterName, scope string, opts ...co
 			"kube.Forwarder/localClusterDiater",
 			oteltrace.WithSpanKind(oteltrace.SpanKindClient),
 			oteltrace.WithAttributes(
-				semconv.RPCServiceKey.String(f.cfg.KubeServiceType),
+				semconv.RPCServiceKey.String(f.component()),
 				semconv.RPCMethodKey.String("reverse_tunnel.Dial"),
 				semconv.RPCSystemKey.String("kube"),
 			),

--- a/lib/kube/proxy/transport_test.go
+++ b/lib/kube/proxy/transport_test.go
@@ -58,6 +58,7 @@ func TestForwarderClusterDialer(t *testing.T) {
 			tracer:      otel.Tracer("test"),
 			ClusterName: clusterName,
 		},
+		upstream: proxyServiceResolver{},
 		getKubernetesServersForKubeCluster: func(_ context.Context, kubeClusterName string) ([]types.KubeServer, error) {
 			switch kubeClusterName {
 			case clusterName:
@@ -233,6 +234,7 @@ func TestDirectTransportNotCached(t *testing.T) {
 	forwarder := &Forwarder{
 		ctx:             context.Background(),
 		cachedTransport: transportClients,
+		upstream:        proxyServiceResolver{},
 	}
 
 	kubeAPICreds := &dynamicKubeCreds{
@@ -294,6 +296,7 @@ func TestTransportCache(t *testing.T) {
 		},
 		ctx:             ctx,
 		cachedTransport: transportClients,
+		upstream:        proxyServiceResolver{},
 		getKubernetesServersForKubeCluster: func(_ context.Context, _ string) ([]types.KubeServer, error) {
 			return []types.KubeServer{
 				unscopedServer,
@@ -439,6 +442,7 @@ func TestLocalClusterDialsByHealth(t *testing.T) {
 					ClusterName:      clusterName,
 					ReverseTunnelSrv: healthReverseTunnel{},
 				},
+				upstream: proxyServiceResolver{},
 				getKubernetesServersForKubeCluster: func(context.Context, string) ([]types.KubeServer, error) {
 					return tt.servers, nil
 				},


### PR DESCRIPTION
Adds `Forwarder.component()` that delegates to the resolver, and replaces ~33 `f.cfg.KubeServiceType` references at metric/span label call sites with `f.component()`. No behavior change — the resolver's `component()` returns the same string that was previously read from `KubeServiceType`.

Mechanical cleanup that decouples instrumentation from the mode field. The remaining direct reads of `KubeServiceType` are config validation and credential loading, which are intentional. Next PR removes the field from `ForwarderConfig` and makes the public API accept an `upstreamResolver` directly.