### PR TITLE
kube: route internal mode checks via resolver

### DIFF
--- a/lib/kube/proxy/auth.go
+++ b/lib/kube/proxy/auth.go
@@ -72,40 +72,39 @@ import (
 //   - if no credentials are loaded, returns an error
 //   - permission self-test failures cause an error to be returned
 func (f *Forwarder) getKubeDetails(ctx context.Context) error {
-	serviceType := f.cfg.KubeServiceType
 	kubeconfigPath := f.cfg.KubeconfigPath
 	kubeClusterName := f.cfg.KubeClusterName
 	tpClusterName := f.cfg.ClusterName
+	component := f.component()
 
 	f.log.DebugContext(ctx, "Reading Kubernetes details",
 		"kubeconfig_path", kubeconfigPath,
 		"kube_cluster_name", kubeClusterName,
-		"service_type", serviceType,
+		"service_type", component,
 	)
 
-	// Proxy service should never have creds, forwards to kube service
-	if serviceType == ProxyService {
+	// Proxy service should never have creds, forwards to kube service.
+	if !f.upstream.servesLocalClusters() {
 		return nil
 	}
 
-	// Load kubeconfig or local pod credentials.
-	loadAll := serviceType == KubeService
+	// kubernetes_service owns all kubeconfig contexts; legacy proxy only loads
+	// current-context.
+	loadAll := !f.upstream.forwardsToOtherAgents()
 	cfg, err := kubeutils.GetKubeConfig(kubeconfigPath, loadAll, kubeClusterName)
 	if err != nil && !trace.IsNotFound(err) {
 		return trace.Wrap(err)
 	}
 
 	if trace.IsNotFound(err) || len(cfg.Contexts) == 0 {
-		switch serviceType {
-		case KubeService:
+		if !f.upstream.forwardsToOtherAgents() {
 			return trace.BadParameter("no Kubernetes credentials found; Kubernetes_service requires either a valid kubeconfig_file or to run inside of a Kubernetes pod")
-		case LegacyProxyService:
-			f.log.DebugContext(ctx, "Could not load Kubernetes credentials. This proxy will still handle Kubernetes requests for trusted teleport clusters or Kubernetes nodes in this teleport cluster")
 		}
+		f.log.DebugContext(ctx, "Could not load Kubernetes credentials. This proxy will still handle Kubernetes requests for trusted teleport clusters or Kubernetes nodes in this teleport cluster")
 		return nil
 	}
 
-	if serviceType == LegacyProxyService {
+	if f.upstream.forwardsToOtherAgents() {
 		// Hack for legacy proxy service - register a k8s cluster named after
 		// the teleport cluster name to route legacy requests.
 		//
@@ -122,7 +121,7 @@ func (f *Forwarder) getKubeDetails(ctx context.Context) error {
 
 	// Convert kubeconfig contexts into kubeCreds.
 	for cluster, clientCfg := range cfg.Contexts {
-		clusterCreds, err := extractKubeCreds(ctx, serviceType, cluster, clientCfg, f.log, f.cfg.CheckImpersonationPermissions)
+		clusterCreds, err := extractKubeCreds(ctx, component, cluster, clientCfg, f.log, f.cfg.CheckImpersonationPermissions)
 		if err != nil {
 			f.log.WarnContext(ctx, "failed to load credentials for cluster",
 				"cluster", cluster,
@@ -150,7 +149,7 @@ func (f *Forwarder) getKubeDetails(ctx context.Context) error {
 				kubeCreds: clusterCreds,
 				log:       f.log.With("cluster", kubeCluster.GetName()),
 				checker:   f.cfg.CheckImpersonationPermissions,
-				component: serviceType,
+				component: component,
 				clock:     f.cfg.Clock,
 			})
 		if err != nil {

--- a/lib/kube/proxy/forwarder.go
+++ b/lib/kube/proxy/forwarder.go
@@ -390,7 +390,7 @@ func NewForwarder(cfg ForwarderConfig) (*Forwarder, error) {
 	if cfg.ClusterOverride != "" {
 		fwd.log.DebugContext(closeCtx, "Cluster override is set, forwarder will send all requests to remote cluster", "cluster_override", cfg.ClusterOverride)
 	}
-	if len(cfg.KubeClusterName) > 0 || len(cfg.KubeconfigPath) > 0 || cfg.KubeServiceType != KubeService {
+	if len(cfg.KubeClusterName) > 0 || len(cfg.KubeconfigPath) > 0 || fwd.upstream.forwardsToOtherAgents() {
 		if err := fwd.getKubeDetails(cfg.Context); err != nil {
 			return nil, trace.Wrap(err)
 		}

--- a/lib/kube/proxy/server.go
+++ b/lib/kube/proxy/server.go
@@ -249,7 +249,7 @@ func NewTLSServer(cfg TLSServerConfig) (*TLSServer, error) {
 		return nil, trace.Wrap(err)
 	}
 
-	if len(fwd.kubeClusters()) == 0 && cfg.KubeServiceType == KubeService &&
+	if len(fwd.kubeClusters()) == 0 && !fwd.upstream.forwardsToOtherAgents() &&
 		len(cfg.ResourceMatchers) == 0 {
 		// if fwd has no clusters and the service type is KubeService but no resource watcher is configured
 		// then the kube_service does not need to start since it will not serve any static or dynamic cluster.
@@ -539,7 +539,7 @@ func (t *TLSServer) GetServerInfo(name string) (*types.KubernetesServerV3, error
 	//
 	// Note: we *don't* want to add suffix for kubernetes_service!
 	// This breaks reverse tunnel routing, which uses server.Name.
-	if t.KubeServiceType != KubeService {
+	if t.fwd.upstream.forwardsToOtherAgents() {
 		name += teleport.KubeLegacyProxySuffix
 	}
 

--- a/lib/kube/proxy/watcher.go
+++ b/lib/kube/proxy/watcher.go
@@ -37,7 +37,7 @@ import (
 // startReconciler starts reconciler that registers/unregisters proxied
 // kubernetes clusters according to the up-to-date list of kube_cluster resources.
 func (s *TLSServer) startReconciler(ctx context.Context) (err error) {
-	if len(s.ResourceMatchers) == 0 || s.KubeServiceType != KubeService {
+	if len(s.ResourceMatchers) == 0 || s.fwd.upstream.forwardsToOtherAgents() {
 		s.log.DebugContext(ctx, "Not initializing Kube Cluster resource watcher")
 		return nil
 	}
@@ -94,7 +94,7 @@ func (s *TLSServer) startReconciler(ctx context.Context) (err error) {
 // startKubeClusterResourceWatcher starts watching changes to Kube Clusters resources and
 // registers/unregisters the proxied Kube Cluster accordingly.
 func (s *TLSServer) startKubeClusterResourceWatcher(ctx context.Context) (*services.GenericWatcher[types.KubeCluster, readonly.KubeCluster], error) {
-	if len(s.ResourceMatchers) == 0 || s.KubeServiceType != KubeService {
+	if len(s.ResourceMatchers) == 0 || s.fwd.upstream.forwardsToOtherAgents() {
 		s.log.DebugContext(ctx, "Not initializing Kube Cluster resource watcher")
 		return nil, nil
 	}
@@ -186,7 +186,7 @@ func (s *TLSServer) buildClusterDetailsConfigForCluster(cluster types.KubeCluste
 		checker:          s.CheckImpersonationPermissions,
 		resourceMatchers: s.ResourceMatchers,
 		clock:            s.Clock,
-		component:        s.KubeServiceType,
+		component:        s.fwd.component(),
 	}
 }
 


### PR DESCRIPTION
Eliminates internal reads of `ForwarderConfig.KubeServiceType` outside the field definition, public-API validation, and the single call site that builds the resolver. `auth.go`'s 3-way service-type switch becomes `servesLocalClusters()` + `forwardsToOtherAgents()` calls, and `server.go` / `watcher.go` use the same booleans.

The `KubeServiceType` field stays on `ForwarderConfig` so callers in `lib/service/` are untouched. Next (optional) step would remove the field entirely and have callers pass an `Upstream upstreamResolver` directly, which requires exporting the resolver factory.