### PR TITLE
kube: replace KubeServiceType with Upstream

### DIFF
--- a/lib/kube/grpc/utils_test.go
+++ b/lib/kube/grpc/utils_test.go
@@ -291,7 +291,7 @@ func SetupTestContext(ctx context.Context, t *testing.T, cfg TestConfig) *TestCo
 			HostID:            testCtx.HostID,
 			Context:           testCtx.Context,
 			KubeconfigPath:    kubeConfigLocation,
-			KubeServiceType:   proxy.KubeService,
+			Upstream:          proxy.NewKubeServiceUpstream(),
 			Component:         teleport.ComponentKube,
 			LockWatcher:       testCtx.lockWatcher,
 			// skip Impersonation validation
@@ -371,7 +371,7 @@ func SetupTestContext(ctx context.Context, t *testing.T, cfg TestConfig) *TestCo
 			CachingAuthClient: client,
 			HostID:            testCtx.HostID,
 			Context:           testCtx.Context,
-			KubeServiceType:   proxy.ProxyService,
+			Upstream:          proxy.NewProxyServiceUpstream(),
 			Component:         teleport.ComponentKube,
 			LockWatcher:       testCtx.lockWatcher,
 			Clock:             clockwork.NewRealClock(),

--- a/lib/kube/proxy/auth_test.go
+++ b/lib/kube/proxy/auth_test.go
@@ -329,7 +329,7 @@ current-context: foo
 				upstream: upstream,
 				cfg: ForwarderConfig{
 					ClusterName:                   teleClusterName,
-					KubeServiceType:               tt.serviceType,
+					Upstream:                      upstream,
 					KubeconfigPath:                tt.kubeconfigPath,
 					CheckImpersonationPermissions: tt.impersonationCheck,
 					Clock:                         clockwork.NewFakeClock(),

--- a/lib/kube/proxy/forwarder.go
+++ b/lib/kube/proxy/forwarder.go
@@ -142,8 +142,10 @@ type ForwarderConfig struct {
 	Context context.Context
 	// KubeconfigPath is a path to kubernetes configuration
 	KubeconfigPath string
-	// KubeServiceType specifies which Teleport service type this forwarder is for
-	KubeServiceType KubeServiceType
+	// Upstream decides per request whether this forwarder serves the target
+	// kube cluster locally or forwards it to another agent. Construct with
+	// NewKubeServiceUpstream, NewProxyServiceUpstream, or NewLegacyProxyUpstream.
+	Upstream UpstreamResolver
 	// KubeClusterName is the name of the kubernetes cluster that this
 	// forwarder handles.
 	KubeClusterName string
@@ -238,7 +240,10 @@ func (f *ForwarderConfig) CheckAndSetDefaults() error {
 	if f.ClusterFeatures == nil {
 		return trace.BadParameter("missing parameter ClusterFeatures")
 	}
-	if f.KubeServiceType != KubeService && f.PROXYSigner == nil {
+	if f.Upstream == nil {
+		return trace.BadParameter("missing parameter Upstream")
+	}
+	if f.Upstream.forwardsToOtherAgents() && f.PROXYSigner == nil {
 		return trace.BadParameter("missing parameter PROXYSigner")
 	}
 	if f.Namespace == "" {
@@ -267,19 +272,16 @@ func (f *ForwarderConfig) CheckAndSetDefaults() error {
 
 	f.tracer = f.TracerProvider.Tracer("kube")
 
-	switch f.KubeServiceType {
-	case KubeService:
-	case ProxyService, LegacyProxyService:
+	if f.Upstream.forwardsToOtherAgents() {
 		if f.GetConnTLSCertificate == nil {
 			return trace.BadParameter("missing parameter GetConnTLSCertificate")
 		}
 		if f.GetConnTLSRoots == nil {
 			return trace.BadParameter("missing parameter GetConnTLSRoots")
 		}
-	default:
-		return trace.BadParameter("unknown value for KubeServiceType")
 	}
-	if f.KubeClusterName == "" && f.KubeconfigPath == "" && f.KubeServiceType == LegacyProxyService {
+	if f.KubeClusterName == "" && f.KubeconfigPath == "" &&
+		f.Upstream.servesLocalClusters() && f.Upstream.forwardsToOtherAgents() {
 		// Running without a kubeconfig and explicit k8s cluster name. Use
 		// teleport cluster name instead, to ask kubeutils.GetKubeConfig to
 		// attempt loading the in-cluster credentials.
@@ -346,11 +348,7 @@ func NewForwarder(cfg ForwarderConfig) (*Forwarder, error) {
 		},
 		cachedTransport: transportClients,
 	}
-	upstream, err := newUpstreamResolver(cfg.KubeServiceType)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	fwd.upstream = upstream
+	fwd.upstream = cfg.Upstream
 
 	router := httprouter.New()
 	router.UseRawPath = true
@@ -407,10 +405,9 @@ type Forwarder struct {
 	log    *slog.Logger
 	router http.Handler
 	cfg    ForwarderConfig
-	// upstream decides how the Forwarder treats a target kube cluster: serve
-	// it locally or forward to the next hop. It replaces per-request branching
-	// on cfg.KubeServiceType.
-	upstream upstreamResolver
+	// upstream is the per-request resolver from cfg.Upstream, hoisted here
+	// for convenience.
+	upstream UpstreamResolver
 	// activeRequests is a map used to serialize active CSR requests to the auth server
 	activeRequests map[string]context.Context
 	// close is a close function
@@ -1671,7 +1668,7 @@ func (f *Forwarder) acquireConnectionLock(ctx context.Context, user string, maxC
 		"kube.Forwarder/acquireConnectionLock",
 		oteltrace.WithSpanKind(oteltrace.SpanKindServer),
 		oteltrace.WithAttributes(
-			semconv.RPCServiceKey.String(f.cfg.KubeServiceType),
+			semconv.RPCServiceKey.String(f.component()),
 			semconv.RPCSystemKey.String("kube"),
 		),
 	)

--- a/lib/kube/proxy/forwarder_test.go
+++ b/lib/kube/proxy/forwarder_test.go
@@ -180,7 +180,7 @@ func TestAuthenticate(t *testing.T) {
 				TracerProvider:    otel.GetTracerProvider(),
 				tracer:            otel.Tracer(teleport.ComponentKube),
 				ClusterFeatures:   fakeClusterFeatures,
-				KubeServiceType:   ProxyService,
+				Upstream:          NewProxyServiceUpstream(),
 				LockWatcher:       lockWatcher,
 			},
 			getKubernetesServersForKubeCluster: func(ctx context.Context, name string) ([]types.KubeServer, error) {
@@ -1916,10 +1916,10 @@ func newTestForwarder(ctx context.Context, cfg ForwarderConfig) *Forwarder {
 		activeRequests: make(map[string]context.Context),
 		ctx:            ctx,
 	}
-	if upstream, err := newUpstreamResolver(cfg.KubeServiceType); err == nil {
-		f.upstream = upstream
+	if cfg.Upstream != nil {
+		f.upstream = cfg.Upstream
 	} else {
-		f.upstream = proxyServiceResolver{}
+		f.upstream = NewProxyServiceUpstream()
 	}
 	return f
 }
@@ -2320,7 +2320,7 @@ func TestForwarderTLSConfigCAs(t *testing.T) {
 			AuthClient:        cl,
 			TracerProvider:    otel.GetTracerProvider(),
 			tracer:            otel.Tracer(teleport.ComponentKube),
-			KubeServiceType:   ProxyService,
+			Upstream:          NewProxyServiceUpstream(),
 			CachingAuthClient: cl,
 
 			GetConnTLSCertificate: func() (*tls.Certificate, error) {
@@ -2651,7 +2651,7 @@ func TestForwarderConfig(t *testing.T) {
 		DataDir:           t.TempDir(),
 		HostID:            "host-id",
 		ClusterFeatures:   fakeClusterFeatures,
-		KubeServiceType:   KubeService,
+		Upstream:          NewKubeServiceUpstream(),
 	}
 	cases := []struct {
 		name string

--- a/lib/kube/proxy/server.go
+++ b/lib/kube/proxy/server.go
@@ -166,15 +166,15 @@ func (c *TLSServerConfig) CheckAndSetDefaults() error {
 		return trace.Wrap(err)
 	}
 
-	switch c.KubeServiceType {
-	case ProxyService, LegacyProxyService:
+	if c.Upstream == nil {
+		return trace.BadParameter("missing parameter Upstream")
+	}
+	if c.Upstream.forwardsToOtherAgents() {
 		if c.KubernetesServersWatcher == nil {
 			return trace.BadParameter("missing parameter KubernetesServersWatcher")
 		}
-	case KubeService:
-		if c.GetScope() != "" && c.KubernetesServersWatcher != nil {
-			return trace.BadParameter("KubernetesServersWatcher is not supported for scoped KubeService")
-		}
+	} else if c.GetScope() != "" && c.KubernetesServersWatcher != nil {
+		return trace.BadParameter("KubernetesServersWatcher is not supported for scoped KubeService")
 	}
 
 	if c.Log == nil {

--- a/lib/kube/proxy/upstream_resolver.go
+++ b/lib/kube/proxy/upstream_resolver.go
@@ -74,39 +74,39 @@ func (s *clusterStore) clusters() types.KubeClusters {
 	return res
 }
 
-// upstreamResolver decides, per request, how the Forwarder should treat a
+// UpstreamResolver decides, per request, how the Forwarder should treat a
 // target kubernetes cluster: serve it locally with the returned details, or
 // forward the request to the next hop without enforcing RBAC.
 //
-// Three return shapes:
-//   - (details, nil)  : this service serves the cluster directly. Use the
-//     details for credentials and enforce kube RBAC at this hop.
-//   - (nil, nil)      : this service is acting as a passthrough; the next hop
-//     is responsible for credentials and RBAC.
-//   - (nil, err)      : this service is supposed to serve the cluster but
-//     does not know about it. Caller should surface the error.
-//
-// Implementations correspond to the three deployment shapes today (kubernetes
-// service, proxy service, legacy proxy service), but the Forwarder no longer
-// needs to switch on the shape — it asks the resolver.
-type upstreamResolver interface {
+// Callers construct one via NewKubeServiceUpstream, NewProxyServiceUpstream,
+// or NewLegacyProxyUpstream and pass it to ForwarderConfig.Upstream. All
+// methods are package-private — the interface exists only so the Forwarder
+// can be configured with one of the three built-in shapes.
+type UpstreamResolver interface {
 	resolveDetails(kubeClusterName string) (*kubeDetails, error)
 	component() string
-
-	// servesLocalClusters reports whether this service can hold details for
-	// kube clusters directly. KubeService and LegacyProxyService do;
-	// ProxyService does not.
 	servesLocalClusters() bool
-
-	// forwardsToOtherAgents reports whether this service queries the
-	// kube_servers watcher and forwards to another agent when the target
-	// cluster is not served locally. ProxyService always does; LegacyProxyService
-	// does as a fallback; KubeService does not.
 	forwardsToOtherAgents() bool
-
-	// store returns the cluster store for resolvers that serve clusters
-	// locally, or nil otherwise. Callers must nil-check.
 	store() *clusterStore
+}
+
+// NewKubeServiceUpstream returns the resolver for a teleport kubernetes_service
+// instance: serves only its own clusters, never forwards.
+func NewKubeServiceUpstream() UpstreamResolver {
+	return &kubeServiceResolver{clusters: newClusterStore()}
+}
+
+// NewProxyServiceUpstream returns the resolver for a proxy_service instance:
+// holds no clusters, always forwards to a kubernetes_service agent.
+func NewProxyServiceUpstream() UpstreamResolver {
+	return proxyServiceResolver{}
+}
+
+// NewLegacyProxyUpstream returns the resolver for the legacy proxy_service
+// shape: serves its own clusters and falls back to forwarding for any cluster
+// it does not serve directly.
+func NewLegacyProxyUpstream() UpstreamResolver {
+	return &legacyProxyResolver{clusters: newClusterStore()}
 }
 
 type kubeServiceResolver struct {
@@ -117,10 +117,10 @@ func (r *kubeServiceResolver) resolveDetails(name string) (*kubeDetails, error) 
 	return r.clusters.find(name)
 }
 
-func (*kubeServiceResolver) component() string          { return KubeService }
-func (*kubeServiceResolver) servesLocalClusters() bool  { return true }
+func (*kubeServiceResolver) component() string           { return KubeService }
+func (*kubeServiceResolver) servesLocalClusters() bool   { return true }
 func (*kubeServiceResolver) forwardsToOtherAgents() bool { return false }
-func (r *kubeServiceResolver) store() *clusterStore     { return r.clusters }
+func (r *kubeServiceResolver) store() *clusterStore      { return r.clusters }
 
 type proxyServiceResolver struct{}
 
@@ -149,17 +149,17 @@ func (*legacyProxyResolver) servesLocalClusters() bool   { return true }
 func (*legacyProxyResolver) forwardsToOtherAgents() bool { return true }
 func (r *legacyProxyResolver) store() *clusterStore      { return r.clusters }
 
-// newUpstreamResolver builds the resolver matching the given KubeServiceType.
-// Resolvers that serve clusters locally are given a fresh, empty store; the
-// proxy resolver has none.
-func newUpstreamResolver(svc KubeServiceType) (upstreamResolver, error) {
+// newUpstreamResolver returns a resolver matching the given service type
+// string. Internal helper used by tests that drive Forwarder behavior off the
+// legacy KubeServiceType string.
+func newUpstreamResolver(svc KubeServiceType) (UpstreamResolver, error) {
 	switch svc {
 	case KubeService:
-		return &kubeServiceResolver{clusters: newClusterStore()}, nil
+		return NewKubeServiceUpstream(), nil
 	case ProxyService:
-		return proxyServiceResolver{}, nil
+		return NewProxyServiceUpstream(), nil
 	case LegacyProxyService:
-		return &legacyProxyResolver{clusters: newClusterStore()}, nil
+		return NewLegacyProxyUpstream(), nil
 	default:
 		return nil, trace.BadParameter("unknown KubeServiceType %q", svc)
 	}

--- a/lib/kube/proxy/utils_test.go
+++ b/lib/kube/proxy/utils_test.go
@@ -329,7 +329,7 @@ func SetupTestContext(ctx context.Context, t *testing.T, cfg TestConfig) *TestCo
 			HostID:            testCtx.HostID,
 			Context:           testCtx.Context,
 			KubeconfigPath:    kubeConfigLocation,
-			KubeServiceType:   KubeService,
+			Upstream:          NewKubeServiceUpstream(),
 			Component:         teleport.ComponentKube,
 			LockWatcher:       testCtx.lockWatcher,
 			// skip Impersonation validation
@@ -414,7 +414,7 @@ func SetupTestContext(ctx context.Context, t *testing.T, cfg TestConfig) *TestCo
 			CachingAuthClient: client,
 			HostID:            testCtx.HostID,
 			Context:           testCtx.Context,
-			KubeServiceType:   ProxyService,
+			Upstream:          NewProxyServiceUpstream(),
 			Component:         teleport.ComponentKube,
 			LockWatcher:       testCtx.lockWatcher,
 			Clock:             clockwork.NewRealClock(),

--- a/lib/service/kubernetes.go
+++ b/lib/service/kubernetes.go
@@ -296,7 +296,7 @@ func (process *TeleportProcess) initKubernetesService(logger *slog.Logger, conn 
 			Context:                       process.ExitContext(),
 			KubeconfigPath:                cfg.Kube.KubeconfigPath,
 			KubeClusterName:               cfg.Kube.KubeClusterName,
-			KubeServiceType:               kubeproxy.KubeService,
+			Upstream:                      kubeproxy.NewKubeServiceUpstream(),
 			Component:                     teleport.ComponentKube,
 			LockWatcher:                   lockWatcher,
 			CheckImpersonationPermissions: cfg.Kube.CheckImpersonationPermissions,

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -6206,9 +6206,9 @@ func (process *TeleportProcess) initProxyEndpoint(conn *Connector) error {
 		// Register TLS endpoint of the Kube proxy service
 		component := teleport.Component(teleport.ComponentProxy, teleport.ComponentProxyKube)
 
-		kubeServiceType := kubeproxy.ProxyService
+		kubeUpstream := kubeproxy.NewProxyServiceUpstream()
 		if cfg.Proxy.Kube.LegacyKubeProxy {
-			kubeServiceType = kubeproxy.LegacyProxyService
+			kubeUpstream = kubeproxy.NewLegacyProxyUpstream()
 		}
 
 		// kubeServerWatcher is used to watch for changes in the Kubernetes servers
@@ -6254,7 +6254,7 @@ func (process *TeleportProcess) initProxyEndpoint(conn *Connector) error {
 				ClusterOverride:               cfg.Proxy.Kube.ClusterOverride,
 				KubeconfigPath:                cfg.Proxy.Kube.KubeconfigPath,
 				Component:                     component,
-				KubeServiceType:               kubeServiceType,
+				Upstream:                      kubeUpstream,
 				LockWatcher:                   lockWatcher,
 				CheckImpersonationPermissions: cfg.Kube.CheckImpersonationPermissions,
 				PROXYSigner:                   proxySigner,

--- a/lib/web/apiserver_test.go
+++ b/lib/web/apiserver_test.go
@@ -10569,6 +10569,17 @@ func startKube(ctx context.Context, t *testing.T, cfg startKubeOptions) net.Addr
 
 type cleanupFunc func() error
 
+func upstreamForServiceType(svc kubeproxy.KubeServiceType) kubeproxy.UpstreamResolver {
+	switch svc {
+	case kubeproxy.KubeService:
+		return kubeproxy.NewKubeServiceUpstream()
+	case kubeproxy.LegacyProxyService:
+		return kubeproxy.NewLegacyProxyUpstream()
+	default:
+		return kubeproxy.NewProxyServiceUpstream()
+	}
+}
+
 func startKubeWithoutCleanup(ctx context.Context, t *testing.T, cfg startKubeOptions) (*kubeproxy.TLSServer, cleanupFunc, net.Addr) {
 	role := types.RoleProxy
 	if cfg.serviceType == kubeproxy.KubeService {
@@ -10678,7 +10689,7 @@ func startKubeWithoutCleanup(ctx context.Context, t *testing.T, cfg startKubeOpt
 			HostID:            hostID,
 			Context:           ctx,
 			KubeconfigPath:    kubeConfigLocation,
-			KubeServiceType:   cfg.serviceType,
+			Upstream:          upstreamForServiceType(cfg.serviceType),
 			Component:         component,
 			LockWatcher:       proxyLockWatcher,
 			ReverseTunnelSrv:  cfg.revTunnel,


### PR DESCRIPTION
Replaces `ForwarderConfig.KubeServiceType` (a string enum) with `Upstream UpstreamResolver`. Callers construct the resolver via `NewKubeServiceUpstream`, `NewProxyServiceUpstream`, or `NewLegacyProxyUpstream`. The interface's methods stay unexported so external packages can hold but cannot implement it.

This is the final step of the resolver refactor: the mode field is gone from the public API and the package's three deployment shapes are now expressed as values, not as a string the constructor switches on. The `KubeServiceType` type alias and the three string constants stay for now (still referenced by `lib/web` tests for routing logic that does not depend on the forwarder).