### PR TITLE
kube: move kubeconfig loading onto resolver

### DIFF
--- a/lib/kube/proxy/auth.go
+++ b/lib/kube/proxy/auth.go
@@ -44,124 +44,28 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/transport"
 
-	"github.com/gravitational/teleport/api/types"
-	kubeutils "github.com/gravitational/teleport/lib/kube/utils"
 	"github.com/gravitational/teleport/lib/service/servicecfg"
 )
 
-// getKubeDetails fetches the kubernetes API credentials.
-//
-// There are 2 possible sources of credentials:
-//   - pod service account credentials: files in hardcoded paths when running
-//     inside of a k8s pod; this is used when kubeClusterName is set
-//   - kubeconfig: a file with a set of k8s endpoints and credentials mapped to
-//     them this is used when kubeconfigPath is set
-//
-// serviceType changes the loading behavior:
-// - LegacyProxyService:
-//   - if loading from kubeconfig, only "current-context" is returned; the
-//     returned map key matches tpClusterName
-//   - if no credentials are loaded, no error is returned
-//   - permission self-test failures are only logged
-//
-// - ProxyService:
-//   - no credentials are loaded and no error is returned
-//
-// - KubeService:
-//   - if loading from kubeconfig, all contexts are returned
-//   - if no credentials are loaded, returns an error
-//   - permission self-test failures cause an error to be returned
+// getKubeDetails delegates startup credential loading to the resolver. Each
+// resolver implements its own kubeconfig policy (kubernetes_service loads all
+// contexts and errors on empty; legacy proxy loads current-context and
+// remaps it; proxy_service is a no-op).
 func (f *Forwarder) getKubeDetails(ctx context.Context) error {
-	kubeconfigPath := f.cfg.KubeconfigPath
-	kubeClusterName := f.cfg.KubeClusterName
-	tpClusterName := f.cfg.ClusterName
-	component := f.component()
-
 	f.log.DebugContext(ctx, "Reading Kubernetes details",
-		"kubeconfig_path", kubeconfigPath,
-		"kube_cluster_name", kubeClusterName,
-		"service_type", component,
+		"kubeconfig_path", f.cfg.KubeconfigPath,
+		"kube_cluster_name", f.cfg.KubeClusterName,
+		"service_type", f.component(),
 	)
-
-	// Proxy service should never have creds, forwards to kube service.
-	if !f.upstream.servesLocalClusters() {
-		return nil
-	}
-
-	// kubernetes_service owns all kubeconfig contexts; legacy proxy only loads
-	// current-context.
-	loadAll := !f.upstream.forwardsToOtherAgents()
-	cfg, err := kubeutils.GetKubeConfig(kubeconfigPath, loadAll, kubeClusterName)
-	if err != nil && !trace.IsNotFound(err) {
-		return trace.Wrap(err)
-	}
-
-	if trace.IsNotFound(err) || len(cfg.Contexts) == 0 {
-		if !f.upstream.forwardsToOtherAgents() {
-			return trace.BadParameter("no Kubernetes credentials found; Kubernetes_service requires either a valid kubeconfig_file or to run inside of a Kubernetes pod")
-		}
-		f.log.DebugContext(ctx, "Could not load Kubernetes credentials. This proxy will still handle Kubernetes requests for trusted teleport clusters or Kubernetes nodes in this teleport cluster")
-		return nil
-	}
-
-	if f.upstream.forwardsToOtherAgents() {
-		// Hack for legacy proxy service - register a k8s cluster named after
-		// the teleport cluster name to route legacy requests.
-		//
-		// Also, remove all other contexts. Multiple kubeconfig entries are
-		// only supported for kubernetes_service.
-		if currentContext, ok := cfg.Contexts[cfg.CurrentContext]; ok {
-			cfg.Contexts = map[string]*rest.Config{
-				tpClusterName: currentContext,
-			}
-		} else {
-			return trace.BadParameter("no Kubernetes current-context found; Kubernetes proxy service requires either a valid kubeconfig_file with a current-context or to run inside of a Kubernetes pod")
-		}
-	}
-
-	// Convert kubeconfig contexts into kubeCreds.
-	for cluster, clientCfg := range cfg.Contexts {
-		clusterCreds, err := extractKubeCreds(ctx, component, cluster, clientCfg, f.log, f.cfg.CheckImpersonationPermissions)
-		if err != nil {
-			f.log.WarnContext(ctx, "failed to load credentials for cluster",
-				"cluster", cluster,
-				"error", err,
-			)
-			continue
-		}
-		kubeCluster, err := types.NewKubernetesClusterV3(
-			types.Metadata{
-				Name: cluster,
-			}, types.KubernetesClusterSpecV3{},
-			types.KubeClusterWithScope(f.cfg.GetScope()),
-		)
-		if err != nil {
-			f.log.WarnContext(ctx, "failed to create KubernetesClusterV3 from credentials for cluster",
-				"cluster", cluster,
-				"error", err,
-			)
-			continue
-		}
-
-		details, err := newClusterDetails(ctx,
-			clusterDetailsConfig{
-				cluster:   kubeCluster,
-				kubeCreds: clusterCreds,
-				log:       f.log.With("cluster", kubeCluster.GetName()),
-				checker:   f.cfg.CheckImpersonationPermissions,
-				component: component,
-				clock:     f.cfg.Clock,
-			})
-		if err != nil {
-			f.log.WarnContext(ctx, "Failed to create cluster details for cluster",
-				"cluster", cluster,
-				"error", err,
-			)
-			return trace.Wrap(err)
-		}
-		f.upsertKubeDetails(cluster, details)
-	}
-	return nil
+	return trace.Wrap(f.upstream.loadInitialClusters(ctx, initialKubeLoadConfig{
+		kubeconfigPath:  f.cfg.KubeconfigPath,
+		kubeClusterName: f.cfg.KubeClusterName,
+		tpClusterName:   f.cfg.ClusterName,
+		scope:           f.cfg.GetScope(),
+		checker:         f.cfg.CheckImpersonationPermissions,
+		clock:           f.cfg.Clock,
+		log:             f.log,
+	}))
 }
 
 func extractKubeCreds(ctx context.Context, component string, cluster string, clientCfg *rest.Config, log *slog.Logger, checkPermissions servicecfg.ImpersonationPermissionsChecker) (*staticKubeCreds, error) {

--- a/lib/kube/proxy/upstream_resolver.go
+++ b/lib/kube/proxy/upstream_resolver.go
@@ -17,11 +17,17 @@
 package proxy
 
 import (
+	"context"
+	"log/slog"
 	"sync"
 
 	"github.com/gravitational/trace"
+	"github.com/jonboulle/clockwork"
+	"k8s.io/client-go/rest"
 
 	"github.com/gravitational/teleport/api/types"
+	kubeutils "github.com/gravitational/teleport/lib/kube/utils"
+	"github.com/gravitational/teleport/lib/service/servicecfg"
 )
 
 // clusterStore holds the kube clusters served by a teleport service.
@@ -88,6 +94,25 @@ type UpstreamResolver interface {
 	servesLocalClusters() bool
 	forwardsToOtherAgents() bool
 	store() *clusterStore
+	// loadInitialClusters reads kubeconfig / in-pod credentials at startup and
+	// populates the resolver's cluster store. Each shape has its own loading
+	// policy: kubernetes_service loads all contexts and errors on empty;
+	// legacy proxy_service loads current-context and remaps it to the teleport
+	// cluster name (warning on empty); proxy_service is a no-op.
+	loadInitialClusters(ctx context.Context, cfg initialKubeLoadConfig) error
+}
+
+// initialKubeLoadConfig captures everything a resolver needs to load its
+// startup credentials. Owned by the Forwarder; passed by value into the
+// resolver.
+type initialKubeLoadConfig struct {
+	kubeconfigPath     string
+	kubeClusterName    string
+	tpClusterName      string
+	scope              string
+	checker            servicecfg.ImpersonationPermissionsChecker
+	clock              clockwork.Clock
+	log                *slog.Logger
 }
 
 // NewKubeServiceUpstream returns the resolver for a teleport kubernetes_service
@@ -122,6 +147,17 @@ func (*kubeServiceResolver) servesLocalClusters() bool   { return true }
 func (*kubeServiceResolver) forwardsToOtherAgents() bool { return false }
 func (r *kubeServiceResolver) store() *clusterStore      { return r.clusters }
 
+func (r *kubeServiceResolver) loadInitialClusters(ctx context.Context, cfg initialKubeLoadConfig) error {
+	kubeCfg, err := loadKubeconfig(cfg.kubeconfigPath, true, cfg.kubeClusterName)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	if kubeCfg == nil || len(kubeCfg.Contexts) == 0 {
+		return trace.BadParameter("no Kubernetes credentials found; Kubernetes_service requires either a valid kubeconfig_file or to run inside of a Kubernetes pod")
+	}
+	return trace.Wrap(populateStore(ctx, r.clusters, kubeCfg.Contexts, KubeService, cfg))
+}
+
 type proxyServiceResolver struct{}
 
 func (proxyServiceResolver) resolveDetails(string) (*kubeDetails, error) { return nil, nil }
@@ -130,6 +166,10 @@ func (proxyServiceResolver) component() string           { return ProxyService }
 func (proxyServiceResolver) servesLocalClusters() bool   { return false }
 func (proxyServiceResolver) forwardsToOtherAgents() bool { return true }
 func (proxyServiceResolver) store() *clusterStore        { return nil }
+
+func (proxyServiceResolver) loadInitialClusters(context.Context, initialKubeLoadConfig) error {
+	return nil
+}
 
 type legacyProxyResolver struct {
 	clusters *clusterStore
@@ -148,6 +188,82 @@ func (*legacyProxyResolver) component() string           { return LegacyProxySer
 func (*legacyProxyResolver) servesLocalClusters() bool   { return true }
 func (*legacyProxyResolver) forwardsToOtherAgents() bool { return true }
 func (r *legacyProxyResolver) store() *clusterStore      { return r.clusters }
+
+func (r *legacyProxyResolver) loadInitialClusters(ctx context.Context, cfg initialKubeLoadConfig) error {
+	kubeCfg, err := loadKubeconfig(cfg.kubeconfigPath, false, cfg.kubeClusterName)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	if kubeCfg == nil || len(kubeCfg.Contexts) == 0 {
+		cfg.log.DebugContext(ctx, "Could not load Kubernetes credentials. This proxy will still handle Kubernetes requests for trusted teleport clusters or Kubernetes nodes in this teleport cluster")
+		return nil
+	}
+	// Legacy proxy routes one cluster, named after the teleport cluster.
+	current, ok := kubeCfg.Contexts[kubeCfg.CurrentContext]
+	if !ok {
+		return trace.BadParameter("no Kubernetes current-context found; Kubernetes proxy service requires either a valid kubeconfig_file with a current-context or to run inside of a Kubernetes pod")
+	}
+	return trace.Wrap(populateStore(ctx, r.clusters, map[string]*rest.Config{cfg.tpClusterName: current}, LegacyProxyService, cfg))
+}
+
+// loadKubeconfig wraps kubeutils.GetKubeConfig and translates a NotFound into
+// (nil, nil) so callers can treat absence as "no clusters" without inspecting
+// the error.
+func loadKubeconfig(path string, loadAll bool, kubeClusterName string) (*kubeutils.Kubeconfig, error) {
+	kubeCfg, err := kubeutils.GetKubeConfig(path, loadAll, kubeClusterName)
+	if trace.IsNotFound(err) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return kubeCfg, nil
+}
+
+// populateStore turns a kubeconfig context map into kubeDetails and inserts
+// them into the resolver's store. Shared between kubernetes_service and
+// legacy proxy_service loaders.
+func populateStore(ctx context.Context, store *clusterStore, contexts map[string]*rest.Config, component string, cfg initialKubeLoadConfig) error {
+	for name, clientCfg := range contexts {
+		clusterCreds, err := extractKubeCreds(ctx, component, name, clientCfg, cfg.log, cfg.checker)
+		if err != nil {
+			cfg.log.WarnContext(ctx, "failed to load credentials for cluster",
+				"cluster", name,
+				"error", err,
+			)
+			continue
+		}
+		kubeCluster, err := types.NewKubernetesClusterV3(
+			types.Metadata{Name: name},
+			types.KubernetesClusterSpecV3{},
+			types.KubeClusterWithScope(cfg.scope),
+		)
+		if err != nil {
+			cfg.log.WarnContext(ctx, "failed to create KubernetesClusterV3 from credentials for cluster",
+				"cluster", name,
+				"error", err,
+			)
+			continue
+		}
+		details, err := newClusterDetails(ctx, clusterDetailsConfig{
+			cluster:   kubeCluster,
+			kubeCreds: clusterCreds,
+			log:       cfg.log.With("cluster", kubeCluster.GetName()),
+			checker:   cfg.checker,
+			component: component,
+			clock:     cfg.clock,
+		})
+		if err != nil {
+			cfg.log.WarnContext(ctx, "Failed to create cluster details for cluster",
+				"cluster", name,
+				"error", err,
+			)
+			return trace.Wrap(err)
+		}
+		store.upsert(name, details)
+	}
+	return nil
+}
 
 // newUpstreamResolver returns a resolver matching the given service type
 // string. Internal helper used by tests that drive Forwarder behavior off the


### PR DESCRIPTION
Replaces the 90-line three-way switch in \`auth.go\`'s \`getKubeDetails\` with a per-resolver \`loadInitialClusters\` method. Each shape implements its own kubeconfig policy:

- \`kubeServiceResolver\`: loads all contexts, errors on empty.
- \`legacyProxyResolver\`: loads current-context, remaps it to the teleport cluster name, warns on empty.
- \`proxyServiceResolver\`: no-op.

\`getKubeDetails\` shrinks to a one-line delegation. Shared cred-extraction + store-population stays in \`upstream_resolver.go\` as a helper.