### PR TITLE
[v18] MCP: Reject tools/call Requests without lowercase "name" param

### DIFF
--- a/lib/srv/mcp/helpers_test.go
+++ b/lib/srv/mcp/helpers_test.go
@@ -496,3 +496,10 @@ func newStreamableMCPServer(t *testing.T, upstream *mcpserver.MCPServer, role ty
 
 	return &emitter, mcpClientTransport
 }
+
+func testJSONString(t *testing.T, v any) string {
+	t.Helper()
+	data, err := json.Marshal(v)
+	require.NoError(t, err)
+	return string(data)
+}

--- a/lib/srv/mcp/helpers_test.go
+++ b/lib/srv/mcp/helpers_test.go
@@ -496,10 +496,3 @@ func newStreamableMCPServer(t *testing.T, upstream *mcpserver.MCPServer, role ty
 
 	return &emitter, mcpClientTransport
 }
-
-func testJSONString(t *testing.T, v any) string {
-	t.Helper()
-	data, err := json.Marshal(v)
-	require.NoError(t, err)
-	return string(data)
-}

--- a/lib/srv/mcp/helpers_test.go
+++ b/lib/srv/mcp/helpers_test.go
@@ -24,6 +24,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"net"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"slices"
 	"sync"
@@ -33,6 +35,7 @@ import (
 
 	"github.com/gravitational/trace"
 	"github.com/mark3labs/mcp-go/mcp"
+	mcpserver "github.com/mark3labs/mcp-go/server"
 	"github.com/moby/moby/api/types/container"
 	docker "github.com/moby/moby/client"
 	"github.com/stretchr/testify/assert"
@@ -42,9 +45,11 @@ import (
 	apievents "github.com/gravitational/teleport/api/types/events"
 	apiutils "github.com/gravitational/teleport/api/utils"
 	"github.com/gravitational/teleport/lib/authz"
+	"github.com/gravitational/teleport/lib/events/eventstest"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/tlsca"
 	"github.com/gravitational/teleport/lib/utils"
+	listenerutils "github.com/gravitational/teleport/lib/utils/listener"
 	"github.com/gravitational/teleport/lib/utils/log/logtest"
 	"github.com/gravitational/teleport/lib/utils/mcputils"
 )
@@ -404,4 +409,88 @@ func checkSessionStartHasExternalSessionID() func(*testing.T, *apievents.MCPSess
 		t.Helper()
 		require.NotEmpty(t, sessionStart.SessionID)
 	}
+}
+
+func newAllowAllDenyForbiddenToolRole(t *testing.T, forbiddenTool string) types.Role {
+	t.Helper()
+	role, err := types.NewRole("allow-all-deny-forbidden", types.RoleSpecV6{
+		Allow: types.RoleConditions{
+			AppLabels: map[string]apiutils.Strings{
+				types.Wildcard: {types.Wildcard},
+			},
+			MCP: &types.MCPPermissions{
+				Tools: []string{types.Wildcard},
+			},
+		},
+		Deny: types.RoleConditions{
+			MCP: &types.MCPPermissions{
+				Tools: []string{forbiddenTool},
+			},
+		},
+	})
+	require.NoError(t, err)
+	return role
+}
+
+func newStreamableMCPServer(t *testing.T, upstream *mcpserver.MCPServer, role types.Role) (*eventstest.MockRecorderEmitter, *http.Client) {
+	t.Helper()
+
+	remoteMCPServer := mcpserver.NewStreamableHTTPServer(upstream)
+	remoteHTTPServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/mcp" {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		remoteMCPServer.ServeHTTP(w, r)
+	}))
+	t.Cleanup(remoteHTTPServer.Close)
+
+	app, err := types.NewAppV3(
+		types.Metadata{
+			Name:   "test-mcp-server",
+			Labels: map[string]string{"env": "prod"},
+		},
+		types.AppSpecV3{
+			URI: fmt.Sprintf("mcp+%s/mcp", remoteHTTPServer.URL),
+		},
+	)
+	require.NoError(t, err)
+
+	emitter := eventstest.MockRecorderEmitter{}
+	s, err := NewServer(ServerConfig{
+		Emitter:       &emitter,
+		ParentContext: t.Context(),
+		HostID:        "my-host-id",
+		AccessPoint:   fakeAccessPoint{},
+		CipherSuites:  utils.DefaultCipherSuites(),
+		AuthClient:    &mockAuthClient{},
+	})
+	require.NoError(t, err)
+
+	var wg sync.WaitGroup
+	t.Cleanup(wg.Wait)
+	listener := listenerutils.NewInMemoryListener()
+	t.Cleanup(func() { _ = listener.Close() })
+	go func() {
+		for {
+			conn, err := listener.Accept()
+			if err != nil {
+				assert.True(t, utils.IsOKNetworkError(err))
+				return
+			}
+			wg.Go(func() {
+				defer conn.Close()
+				testCtx := setupTestContext(t,
+					withRole(role),
+					withApp(app),
+					withClientConn(conn),
+				)
+				assert.NoError(t, s.HandleSession(t.Context(), testCtx.SessionCtx))
+			})
+		}
+	}()
+
+	httpClient := listener.MakeHTTPClient()
+
+	return &emitter, httpClient
 }

--- a/lib/srv/mcp/helpers_test.go
+++ b/lib/srv/mcp/helpers_test.go
@@ -34,6 +34,7 @@ import (
 	"time"
 
 	"github.com/gravitational/trace"
+	mcpclienttransport "github.com/mark3labs/mcp-go/client/transport"
 	"github.com/mark3labs/mcp-go/mcp"
 	mcpserver "github.com/mark3labs/mcp-go/server"
 	"github.com/moby/moby/api/types/container"
@@ -49,7 +50,6 @@ import (
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/tlsca"
 	"github.com/gravitational/teleport/lib/utils"
-	listenerutils "github.com/gravitational/teleport/lib/utils/listener"
 	"github.com/gravitational/teleport/lib/utils/log/logtest"
 	"github.com/gravitational/teleport/lib/utils/mcputils"
 )
@@ -432,7 +432,7 @@ func newAllowAllDenyForbiddenToolRole(t *testing.T, forbiddenTool string) types.
 	return role
 }
 
-func newStreamableMCPServer(t *testing.T, upstream *mcpserver.MCPServer, role types.Role) (*eventstest.MockRecorderEmitter, *http.Client) {
+func newStreamableMCPServer(t *testing.T, upstream *mcpserver.MCPServer, role types.Role) (*eventstest.MockRecorderEmitter, *mcpclienttransport.StreamableHTTP) {
 	t.Helper()
 
 	remoteMCPServer := mcpserver.NewStreamableHTTPServer(upstream)
@@ -469,7 +469,8 @@ func newStreamableMCPServer(t *testing.T, upstream *mcpserver.MCPServer, role ty
 
 	var wg sync.WaitGroup
 	t.Cleanup(wg.Wait)
-	listener := listenerutils.NewInMemoryListener()
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
 	t.Cleanup(func() { _ = listener.Close() })
 	go func() {
 		for {
@@ -490,7 +491,15 @@ func newStreamableMCPServer(t *testing.T, upstream *mcpserver.MCPServer, role ty
 		}
 	}()
 
-	httpClient := listener.MakeHTTPClient()
+	mcpClientTransport, err := mcpclienttransport.NewStreamableHTTP("http://" + listener.Addr().String())
+	require.NoError(t, err)
 
-	return &emitter, httpClient
+	return &emitter, mcpClientTransport
+}
+
+func testJSONString(t *testing.T, v any) string {
+	t.Helper()
+	data, err := json.Marshal(v)
+	require.NoError(t, err)
+	return string(data)
 }

--- a/lib/srv/mcp/http.go
+++ b/lib/srv/mcp/http.go
@@ -228,6 +228,7 @@ func (t *streamableHTTPTransport) handleMCPMessage(r *http.Request) (*http.Respo
 	case baseMessage.IsRequest():
 		mcpRequest := baseMessage.MakeRequest()
 		if errResp := t.sessionHandler.processClientRequest(r.Context(), mcpRequest); errResp != nil {
+			t.emitRequestEvent(r.Context(), mcpRequest, eventWithError(toError(*errResp)))
 			return t.handleRequestError(r, *errResp)
 		}
 	case baseMessage.IsNotification():

--- a/lib/srv/mcp/http.go
+++ b/lib/srv/mcp/http.go
@@ -228,7 +228,7 @@ func (t *streamableHTTPTransport) handleMCPMessage(r *http.Request) (*http.Respo
 	case baseMessage.IsRequest():
 		mcpRequest := baseMessage.MakeRequest()
 		if errResp := t.sessionHandler.processClientRequest(r.Context(), mcpRequest); errResp != nil {
-			t.emitRequestEvent(t.parentCtx, mcpRequest, eventWithError(toError(*errResp)))
+			t.emitRequestEvent(t.parentCtx, mcpRequest, eventWithError(toError(*errResp)), eventWithHeader(r.Header))
 			return t.handleRequestError(r, *errResp)
 		}
 	case baseMessage.IsNotification():

--- a/lib/srv/mcp/http.go
+++ b/lib/srv/mcp/http.go
@@ -228,7 +228,7 @@ func (t *streamableHTTPTransport) handleMCPMessage(r *http.Request) (*http.Respo
 	case baseMessage.IsRequest():
 		mcpRequest := baseMessage.MakeRequest()
 		if errResp := t.sessionHandler.processClientRequest(r.Context(), mcpRequest); errResp != nil {
-			t.emitRequestEvent(r.Context(), mcpRequest, eventWithError(toError(*errResp)))
+			t.emitRequestEvent(t.parentCtx, mcpRequest, eventWithError(toError(*errResp)))
 			return t.handleRequestError(r, *errResp)
 		}
 	case baseMessage.IsNotification():
@@ -256,7 +256,7 @@ func (t *streamableHTTPTransport) handleMCPMessage(r *http.Request) (*http.Respo
 		if mcpRequest.Method == mcputils.MethodInitialize && respErrForAudit == nil {
 			t.appendStartEvent(r.Context(), eventWithHeader(r.Header))
 		}
-		t.emitRequestEvent(r.Context(), mcpRequest, eventWithError(respErrForAudit), eventWithHeader(r.Header))
+		t.emitRequestEvent(t.parentCtx, mcpRequest, eventWithError(respErrForAudit), eventWithHeader(r.Header))
 	case baseMessage.IsNotification():
 		t.emitNotificationEvent(r.Context(), baseMessage.MakeNotification(), eventWithError(respErrForAudit), eventWithHeader(r.Header))
 	}

--- a/lib/srv/mcp/http.go
+++ b/lib/srv/mcp/http.go
@@ -227,8 +227,8 @@ func (t *streamableHTTPTransport) handleMCPMessage(r *http.Request) (*http.Respo
 	switch {
 	case baseMessage.IsRequest():
 		mcpRequest := baseMessage.MakeRequest()
-		if errResp, authErr := t.sessionHandler.processClientRequest(r.Context(), mcpRequest); authErr != nil {
-			return t.handleRequestAuthError(r, mcpRequest, errResp, authErr)
+		if errResp := t.sessionHandler.processClientRequest(r.Context(), mcpRequest); errResp != nil {
+			return t.handleRequestError(r, *errResp)
 		}
 	case baseMessage.IsNotification():
 		t.sessionHandler.processClientNotification(r.Context(), baseMessage.MakeNotification())
@@ -262,9 +262,7 @@ func (t *streamableHTTPTransport) handleMCPMessage(r *http.Request) (*http.Respo
 	return resp, trace.Wrap(err)
 }
 
-func (t *streamableHTTPTransport) handleRequestAuthError(r *http.Request, mcpRequest *mcputils.JSONRPCRequest, errResp mcp.JSONRPCMessage, authErr error) (*http.Response, error) {
-	t.emitRequestEvent(t.parentCtx, mcpRequest, eventWithError(authErr), eventWithHeader(r.Header))
-
+func (t *streamableHTTPTransport) handleRequestError(r *http.Request, errResp mcp.JSONRPCMessage) (*http.Response, error) {
 	errRespAsBody, err := json.Marshal(errResp)
 	if err != nil {
 		// Should not happen. If it does, we are failing the request either way.

--- a/lib/srv/mcp/http_test.go
+++ b/lib/srv/mcp/http_test.go
@@ -19,10 +19,15 @@
 package mcp
 
 import (
+	"context"
+	"encoding/json"
 	"fmt"
+	"io"
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -94,8 +99,7 @@ func Test_handleStreamableHTTP(t *testing.T) {
 	var wg sync.WaitGroup
 	t.Cleanup(wg.Wait)
 	listener := listenerutils.NewInMemoryListener()
-	require.NoError(t, err)
-	defer listener.Close()
+	t.Cleanup(func() { _ = listener.Close() })
 	go func() {
 		for {
 			conn, err := listener.Accept()
@@ -211,6 +215,114 @@ func Test_handleStreamableHTTP(t *testing.T) {
 		events := emitter.Events()
 		require.Empty(t, events)
 	})
+}
+
+// Test_Server_HandleSession_reject_req_missing_name makes sure requests with missing canonical
+// "name" param are rejected.
+func Test_Server_HandleSession_reject_req_missing_name(t *testing.T) {
+	t.Parallel()
+
+	const forbiddenTool = "forbidden_tool"
+	const forbiddenToolTextContent = "FORBIDDEN_TOOL_EXECUTED_ON_UPSTREAM"
+
+	role := newAllowAllDenyForbiddenToolRole(t, forbiddenTool)
+
+	upstream := mcpserver.NewMCPServer("test-server", "1.0.0")
+	upstream.AddTool(
+		mcp.Tool{
+			Name: forbiddenTool,
+		},
+		func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+			return &mcp.CallToolResult{
+				Content: []mcp.Content{mcp.NewTextContent(forbiddenToolTextContent)},
+			}, nil
+		},
+	)
+
+	emitter, httpClient := newStreamableMCPServer(t, upstream, role)
+
+	// initialize establishes an upstream streamable-HTTP session and returns
+	// the Mcp-Session-Id the upstream expects on follow-up requests.
+	initialize := func(t *testing.T) string {
+		t.Helper()
+
+		req, err := http.NewRequestWithContext(t.Context(), http.MethodPost, "http://memory/", strings.NewReader(`{
+			"jsonrpc": "2.0",
+			"id": 1,
+			"method": "initialize",
+			"params": {
+				"protocolVersion": "`+mcp.LATEST_PROTOCOL_VERSION+`",
+				"capabilities": {},
+				"clientInfo": {"name": "raw-test-client", "version": "1.0.0"}
+			}
+		}`))
+		require.NoError(t, err)
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("Accept", "application/json, text/event-stream")
+
+		resp, err := httpClient.Do(req)
+		require.NoError(t, err)
+		resp.Body.Close()
+
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+		sessionID := resp.Header.Get("Mcp-Session-Id")
+		require.NotEmpty(t, sessionID)
+
+		return sessionID
+	}
+
+	postToolsCall := func(t *testing.T, sessionID, body string) (int, string) {
+		t.Helper()
+		req, err := http.NewRequestWithContext(t.Context(), http.MethodPost, "http://memory/", strings.NewReader(body))
+		require.NoError(t, err)
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("Accept", "application/json, text/event-stream")
+		req.Header.Set("Mcp-Session-Id", sessionID)
+
+		resp, err := httpClient.Do(req)
+		require.NoError(t, err)
+		defer resp.Body.Close()
+
+		respBody, err := io.ReadAll(resp.Body)
+		require.NoError(t, err)
+		return resp.StatusCode, string(respBody)
+	}
+
+	// Verify it works as expected if the canonical lower-case "name" param is provided.
+	emitter.Reset()
+	sessionID := initialize(t)
+	status, body := postToolsCall(t, sessionID, `{
+		"jsonrpc": "2.0",
+		"id": 2,
+		"method": "tools/call",
+		"params": {
+			"name": "`+forbiddenTool+`",
+			"arguments": {}
+		}
+	}`)
+	require.Equal(t, http.StatusOK, status)
+	require.NotContains(t, body, forbiddenToolTextContent)
+	require.Contains(t, body, `"code":`+strconv.Itoa(mcp.INVALID_PARAMS))
+	require.Contains(t, body, "User does not have permissions")
+
+	// Verify that when non-canonical capitalized "Name" param is specified the request is
+	// rejected.
+	emitter.Reset()
+	sessionID = initialize(t)
+	status, body = postToolsCall(t, sessionID, `{
+			"jsonrpc": "2.0",
+			"id": 2,
+			"method": "tools/call",
+			"params": {
+				"Name": "`+forbiddenTool+`",
+				"arguments": {}
+			}
+		}`)
+	require.Equal(t, http.StatusOK, status)
+	require.Contains(t, body, `"code":`+strconv.Itoa(mcp.INVALID_REQUEST))
+	escaped, err := json.Marshal(errorInvalidRequestMissingName.Error())
+	require.NoError(t, err)
+	require.Contains(t, body, string(escaped))
 }
 
 func Test_handleAuthErrHTTP(t *testing.T) {

--- a/lib/srv/mcp/http_test.go
+++ b/lib/srv/mcp/http_test.go
@@ -320,7 +320,7 @@ func Test_Server_HandleSession_reject_req_missing_name(t *testing.T) {
 		}`)
 	require.Equal(t, http.StatusOK, status)
 	require.Contains(t, body, `"code":`+strconv.Itoa(mcp.INVALID_REQUEST))
-	escaped, err := json.Marshal(errorInvalidRequestMissingName.Error())
+	escaped, err := json.Marshal(errInvalidRequestMissingName.Error())
 	require.NoError(t, err)
 	require.Contains(t, body, string(escaped))
 }

--- a/lib/srv/mcp/http_test.go
+++ b/lib/srv/mcp/http_test.go
@@ -22,12 +22,9 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io"
 	"net"
 	"net/http"
 	"net/http/httptest"
-	"strconv"
-	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -222,6 +219,8 @@ func Test_handleStreamableHTTP(t *testing.T) {
 func Test_Server_HandleSession_reject_req_missing_name(t *testing.T) {
 	t.Parallel()
 
+	ctx := t.Context()
+
 	const forbiddenTool = "forbidden_tool"
 	const forbiddenToolTextContent = "FORBIDDEN_TOOL_EXECUTED_ON_UPSTREAM"
 
@@ -239,90 +238,63 @@ func Test_Server_HandleSession_reject_req_missing_name(t *testing.T) {
 		},
 	)
 
-	emitter, httpClient := newStreamableMCPServer(t, upstream, role)
+	emitter, mcpClientTransport := newStreamableMCPServer(t, upstream, role)
 
-	// initialize establishes an upstream streamable-HTTP session and returns
-	// the Mcp-Session-Id the upstream expects on follow-up requests.
-	initialize := func(t *testing.T) string {
-		t.Helper()
-
-		req, err := http.NewRequestWithContext(t.Context(), http.MethodPost, "http://memory/", strings.NewReader(`{
-			"jsonrpc": "2.0",
-			"id": 1,
-			"method": "initialize",
-			"params": {
-				"protocolVersion": "`+mcp.LATEST_PROTOCOL_VERSION+`",
-				"capabilities": {},
-				"clientInfo": {"name": "raw-test-client", "version": "1.0.0"}
-			}
-		}`))
-		require.NoError(t, err)
-		req.Header.Set("Content-Type", "application/json")
-		req.Header.Set("Accept", "application/json, text/event-stream")
-
-		resp, err := httpClient.Do(req)
-		require.NoError(t, err)
-		resp.Body.Close()
-
-		require.Equal(t, http.StatusOK, resp.StatusCode)
-		sessionID := resp.Header.Get("Mcp-Session-Id")
-		require.NotEmpty(t, sessionID)
-
-		return sessionID
-	}
-
-	postToolsCall := func(t *testing.T, sessionID, body string) (int, string) {
-		t.Helper()
-		req, err := http.NewRequestWithContext(t.Context(), http.MethodPost, "http://memory/", strings.NewReader(body))
-		require.NoError(t, err)
-		req.Header.Set("Content-Type", "application/json")
-		req.Header.Set("Accept", "application/json, text/event-stream")
-		req.Header.Set("Mcp-Session-Id", sessionID)
-
-		resp, err := httpClient.Do(req)
-		require.NoError(t, err)
-		defer resp.Body.Close()
-
-		respBody, err := io.ReadAll(resp.Body)
-		require.NoError(t, err)
-		return resp.StatusCode, string(respBody)
-	}
+	_, err := mcpClientTransport.SendRequest(ctx, mcpclienttransport.JSONRPCRequest{
+		JSONRPC: mcp.JSONRPC_VERSION,
+		ID:      mcp.NewRequestId(1),
+		Method:  string(mcp.MethodInitialize),
+		Params: map[string]any{
+			"protocolVersion": mcp.LATEST_PROTOCOL_VERSION,
+			"clientInfo": map[string]any{
+				"name":    "test-client-transport",
+				"version": "1.0.0",
+			},
+		},
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, mcpClientTransport.GetSessionId())
 
 	// Verify it works as expected if the canonical lower-case "name" param is provided.
 	emitter.Reset()
-	sessionID := initialize(t)
-	status, body := postToolsCall(t, sessionID, `{
-		"jsonrpc": "2.0",
-		"id": 2,
-		"method": "tools/call",
-		"params": {
-			"name": "`+forbiddenTool+`",
-			"arguments": {}
-		}
-	}`)
-	require.Equal(t, http.StatusOK, status)
-	require.NotContains(t, body, forbiddenToolTextContent)
-	require.Contains(t, body, `"code":`+strconv.Itoa(mcp.INVALID_PARAMS))
-	require.Contains(t, body, "User does not have permissions")
+	resp, err := mcpClientTransport.SendRequest(ctx, mcpclienttransport.JSONRPCRequest{
+		JSONRPC: mcp.JSONRPC_VERSION,
+		ID:      mcp.NewRequestId(2),
+		Method:  string(mcp.MethodToolsCall),
+		Params: map[string]any{
+			"name": forbiddenTool,
+		},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, resp.Error)
+	require.Equal(t, mcp.INVALID_PARAMS, resp.Error.Code)
+	respJSON, err := json.Marshal(resp)
+	require.NoError(t, err)
+	respBody := string(respJSON)
+	require.NotContains(t, respBody, forbiddenToolTextContent)
+	require.Contains(t, respBody, "User does not have permissions")
 
 	// Verify that when non-canonical capitalized "Name" param is specified the request is
 	// rejected.
 	emitter.Reset()
-	sessionID = initialize(t)
-	status, body = postToolsCall(t, sessionID, `{
-			"jsonrpc": "2.0",
-			"id": 2,
-			"method": "tools/call",
-			"params": {
-				"Name": "`+forbiddenTool+`",
-				"arguments": {}
-			}
-		}`)
-	require.Equal(t, http.StatusOK, status)
-	require.Contains(t, body, `"code":`+strconv.Itoa(mcp.INVALID_REQUEST))
+	resp, err = mcpClientTransport.SendRequest(ctx, mcpclienttransport.JSONRPCRequest{
+		JSONRPC: mcp.JSONRPC_VERSION,
+		ID:      mcp.NewRequestId(3),
+		Method:  string(mcp.MethodToolsCall),
+		Params: map[string]any{
+			"Name": forbiddenTool,
+		},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, resp.Error)
+	require.Equal(t, mcp.INVALID_REQUEST, resp.Error.Code)
+	respJSON, err = json.Marshal(resp)
+	require.NoError(t, err)
+	respBody = string(respJSON)
+	require.NotContains(t, respBody, forbiddenToolTextContent)
 	escaped, err := json.Marshal(errInvalidRequestMissingName.Error())
 	require.NoError(t, err)
-	require.Contains(t, body, string(escaped))
+	require.Contains(t, respBody, string(escaped))
 }
 
 func Test_handleAuthErrHTTP(t *testing.T) {

--- a/lib/srv/mcp/http_test.go
+++ b/lib/srv/mcp/http_test.go
@@ -20,7 +20,6 @@ package mcp
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"net"
 	"net/http"
@@ -268,11 +267,9 @@ func Test_Server_HandleSession_reject_req_missing_name(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, resp.Error)
 	require.Equal(t, mcp.INVALID_PARAMS, resp.Error.Code)
-	respJSON, err := json.Marshal(resp)
-	require.NoError(t, err)
-	respBody := string(respJSON)
-	require.NotContains(t, respBody, forbiddenToolTextContent)
-	require.Contains(t, respBody, "User does not have permissions")
+	respJSON := testJSONString(t, resp)
+	require.NotContains(t, respJSON, forbiddenToolTextContent)
+	require.Contains(t, respJSON, "User does not have permissions")
 
 	// Verify that when non-canonical capitalized "Name" param is specified the request is
 	// rejected.
@@ -288,13 +285,43 @@ func Test_Server_HandleSession_reject_req_missing_name(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, resp.Error)
 	require.Equal(t, mcp.INVALID_REQUEST, resp.Error.Code)
-	respJSON, err = json.Marshal(resp)
+	respJSON = testJSONString(t, resp)
+	require.NotContains(t, respJSON, forbiddenToolTextContent)
+	require.Contains(t, respJSON, testJSONString(t, errInvalidRequestMissingName.Error()))
+
+	// Verify that when an empty "name" param is specified the request is rejected.
+	emitter.Reset()
+	resp, err = mcpClientTransport.SendRequest(ctx, mcpclienttransport.JSONRPCRequest{
+		JSONRPC: mcp.JSONRPC_VERSION,
+		ID:      mcp.NewRequestId(4),
+		Method:  string(mcp.MethodToolsCall),
+		Params: map[string]any{
+			"name": "",
+		},
+	})
 	require.NoError(t, err)
-	respBody = string(respJSON)
-	require.NotContains(t, respBody, forbiddenToolTextContent)
-	escaped, err := json.Marshal(errInvalidRequestMissingName.Error())
+	require.NotNil(t, resp.Error)
+	require.Equal(t, mcp.INVALID_REQUEST, resp.Error.Code)
+	respJSON = testJSONString(t, resp)
+	require.NotContains(t, respJSON, forbiddenToolTextContent)
+	require.Contains(t, respJSON, testJSONString(t, errInvalidRequestMissingName.Error()))
+
+	// Verify that correct request is properly unauthorized.
+	emitter.Reset()
+	resp, err = mcpClientTransport.SendRequest(ctx, mcpclienttransport.JSONRPCRequest{
+		JSONRPC: mcp.JSONRPC_VERSION,
+		ID:      mcp.NewRequestId(5),
+		Method:  string(mcp.MethodToolsCall),
+		Params: map[string]any{
+			"name": forbiddenTool,
+		},
+	})
 	require.NoError(t, err)
-	require.Contains(t, respBody, string(escaped))
+	require.NotNil(t, resp.Error)
+	require.Equal(t, mcp.INVALID_PARAMS, resp.Error.Code)
+	respJSON = testJSONString(t, resp)
+	require.NotContains(t, respJSON, forbiddenToolTextContent)
+	require.Contains(t, respJSON, "User does not have permissions.")
 }
 
 func Test_handleAuthErrHTTP(t *testing.T) {

--- a/lib/srv/mcp/session.go
+++ b/lib/srv/mcp/session.go
@@ -337,13 +337,13 @@ func (s *sessionHandler) rewriteHTTPRequestHeaders(r *http.Request) error {
 	return nil
 }
 
-var errInvalidRequestMissingName = trace.Errorf(`"name" parameter missing, note parameter names are case-sensitive`)
+var errInvalidRequestMissingName = &trace.BadParameterError{Message: `"name" parameter missing`}
 
 func makeInvalidRequestResponse(req *mcputils.JSONRPCRequest, err error) *mcp.JSONRPCError {
 	r := mcp.NewJSONRPCError(
 		req.ID,
 		mcp.INVALID_REQUEST,
-		"Teleport did not forward an invalid Request object. Contact your Teleport Admin for more details.",
+		"Teleport did not forward an invalid Request object.",
 		err,
 	)
 	return &r

--- a/lib/srv/mcp/session.go
+++ b/lib/srv/mcp/session.go
@@ -222,12 +222,12 @@ func (s *sessionHandler) onClientNotification(serverRequestWriter mcputils.Messa
 
 func (s *sessionHandler) onClientRequest(clientResponseWriter, serverRequestWriter mcputils.MessageWriter) mcputils.HandleRequestFunc {
 	return func(ctx context.Context, request *mcputils.JSONRPCRequest) error {
-		msg, authErr := s.processClientRequest(ctx, request)
-		s.emitRequestEvent(ctx, request, eventWithError(authErr))
-		if authErr != nil {
-			return trace.Wrap(clientResponseWriter.WriteMessage(ctx, msg))
+		if errMsg := s.processClientRequest(ctx, request); errMsg != nil {
+			// Respond immediately
+			return trace.Wrap(clientResponseWriter.WriteMessage(ctx, *errMsg))
 		}
-		return trace.Wrap(serverRequestWriter.WriteMessage(ctx, msg))
+		s.emitRequestEvent(ctx, request)
+		return trace.Wrap(serverRequestWriter.WriteMessage(ctx, request))
 	}
 }
 
@@ -248,20 +248,28 @@ func (s *sessionHandler) onServerResponse(clientResponseWriter mcputils.MessageW
 	}
 }
 
-func (s *sessionHandler) processClientRequest(ctx context.Context, req *mcputils.JSONRPCRequest) (mcp.JSONRPCMessage, error) {
+func (s *sessionHandler) processClientRequest(ctx context.Context, req *mcputils.JSONRPCRequest) *mcp.JSONRPCError {
 	messagesFromClient.WithLabelValues(s.transport, "request", reportRequestMethod(req.Method)).Inc()
+
+	switch req.Method {
+	case mcputils.MethodToolsCall:
+		toolName, _ := req.Params.GetName()
+		if toolName == "" {
+			err := errorInvalidRequestMissingName
+			s.emitRequestEvent(ctx, req, eventWithError(err))
+			return makeInvalidRequestResponse(req, err)
+		}
+		if authErr := s.checkAccessToTool(ctx, toolName); authErr != nil {
+			s.emitRequestEvent(ctx, req, eventWithError(authErr))
+			return makeToolAccessDeniedResponse(req, authErr)
+		}
+	}
 
 	// TODO(greedy52) add checks to ensure that the initialize request is the
 	// first request coming in (with the exception of the ping).
 	s.idTracker.PushRequest(req)
-	switch req.Method {
-	case mcputils.MethodToolsCall:
-		methodName, _ := req.Params.GetName()
-		if authErr := s.checkAccessToTool(ctx, methodName); authErr != nil {
-			return makeToolAccessDeniedResponse(req, authErr), trace.Wrap(authErr)
-		}
-	}
-	return req, nil
+
+	return nil
 }
 
 func (s *sessionHandler) processClientNotification(ctx context.Context, notification *mcputils.JSONRPCNotification) {
@@ -331,11 +339,24 @@ func (s *sessionHandler) rewriteHTTPRequestHeaders(r *http.Request) error {
 	return nil
 }
 
-func makeToolAccessDeniedResponse(msg *mcputils.JSONRPCRequest, authErr error) mcp.JSONRPCMessage {
-	return mcp.NewJSONRPCError(
-		msg.ID,
+var errorInvalidRequestMissingName = trace.Errorf(`"name" parameter missing, note parameter names are case-sensitive`)
+
+func makeInvalidRequestResponse(req *mcputils.JSONRPCRequest, err error) *mcp.JSONRPCError {
+	r := mcp.NewJSONRPCError(
+		req.ID,
+		mcp.INVALID_REQUEST,
+		"Teleport did not forward an invalid Request object. Contact your Teleport Admin for more details.",
+		err,
+	)
+	return &r
+}
+
+func makeToolAccessDeniedResponse(req *mcputils.JSONRPCRequest, authErr error) *mcp.JSONRPCError {
+	r := mcp.NewJSONRPCError(
+		req.ID,
 		mcp.INVALID_PARAMS,
 		"RBAC is enforced by your Teleport roles. Contact your Teleport Admin for more details.",
 		authErr,
 	)
+	return &r
 }

--- a/lib/srv/mcp/session.go
+++ b/lib/srv/mcp/session.go
@@ -224,6 +224,7 @@ func (s *sessionHandler) onClientRequest(clientResponseWriter, serverRequestWrit
 	return func(ctx context.Context, request *mcputils.JSONRPCRequest) error {
 		if errMsg := s.processClientRequest(ctx, request); errMsg != nil {
 			// Respond immediately
+			s.emitRequestEvent(ctx, request, eventWithError(toError(*errMsg)))
 			return trace.Wrap(clientResponseWriter.WriteMessage(ctx, *errMsg))
 		}
 		s.emitRequestEvent(ctx, request)
@@ -255,12 +256,9 @@ func (s *sessionHandler) processClientRequest(ctx context.Context, req *mcputils
 	case mcputils.MethodToolsCall:
 		toolName, _ := req.Params.GetName()
 		if toolName == "" {
-			err := errorInvalidRequestMissingName
-			s.emitRequestEvent(ctx, req, eventWithError(err))
-			return makeInvalidRequestResponse(req, err)
+			return makeInvalidRequestResponse(req, errInvalidRequestMissingName)
 		}
 		if authErr := s.checkAccessToTool(ctx, toolName); authErr != nil {
-			s.emitRequestEvent(ctx, req, eventWithError(authErr))
 			return makeToolAccessDeniedResponse(req, authErr)
 		}
 	}
@@ -339,7 +337,7 @@ func (s *sessionHandler) rewriteHTTPRequestHeaders(r *http.Request) error {
 	return nil
 }
 
-var errorInvalidRequestMissingName = trace.Errorf(`"name" parameter missing, note parameter names are case-sensitive`)
+var errInvalidRequestMissingName = trace.Errorf(`"name" parameter missing, note parameter names are case-sensitive`)
 
 func makeInvalidRequestResponse(req *mcputils.JSONRPCRequest, err error) *mcp.JSONRPCError {
 	r := mcp.NewJSONRPCError(
@@ -359,4 +357,16 @@ func makeToolAccessDeniedResponse(req *mcputils.JSONRPCRequest, authErr error) *
 		authErr,
 	)
 	return &r
+}
+
+func toError(e mcp.JSONRPCError) error {
+	// If the data holds an underlying error, replace the message with that, before
+	// constructing the final error. In that case the Message should be a high-level
+	// user-facing error. Otherwise fall back to the original message.
+	if e.Error.Data != nil {
+		if dataErr, ok := e.Error.Data.(error); ok {
+			e.Error.Message = dataErr.Error()
+		}
+	}
+	return e.Error.AsError()
 }

--- a/lib/srv/mcp/session_test.go
+++ b/lib/srv/mcp/session_test.go
@@ -168,8 +168,8 @@ func Test_sessionHandler(t *testing.T) {
 
 				// First make a request so the handler can track the method by ID.
 				clientReq := requestBuilder.makeToolsListRequest()
-				_, authErr := handler.processClientRequest(ctx, clientReq)
-				require.NoError(t, authErr)
+				respErr := handler.processClientRequest(ctx, clientReq)
+				require.Nil(t, respErr)
 
 				// tools/list does not trigger audit event.
 				require.Nil(t, mockEmitter.LastEvent())

--- a/lib/utils/mcputils/id_tracker.go
+++ b/lib/utils/mcputils/id_tracker.go
@@ -47,14 +47,13 @@ func NewIDTracker(size int) (*IDTracker, error) {
 
 // PushRequest tracks a request. Returns true if the request has been added to
 // cache.
-func (t *IDTracker) PushRequest(msg *JSONRPCRequest) bool {
+func (t *IDTracker) PushRequest(msg *JSONRPCRequest) {
 	if msg == nil || msg.ID.IsNil() || msg.Method == "" {
-		return false
+		return
 	}
 	t.mu.Lock()
 	defer t.mu.Unlock()
 	t.lruCache.Add(msg.ID, msg.Method)
-	return true
 }
 
 // PopByID retrieves the tracked information and remove it from the tracker.

--- a/lib/utils/mcputils/id_tracker_test.go
+++ b/lib/utils/mcputils/id_tracker_test.go
@@ -33,17 +33,17 @@ func TestIDTracker(t *testing.T) {
 	require.Empty(t, tracker.Len())
 
 	t.Run("request missing ID not tracked", func(t *testing.T) {
-		require.False(t, tracker.PushRequest(&JSONRPCRequest{
+		tracker.PushRequest(&JSONRPCRequest{
 			Method: "bad",
-		}))
+		})
 		require.Empty(t, tracker.Len())
 	})
 
 	t.Run("request tracked", func(t *testing.T) {
-		require.True(t, tracker.PushRequest(&JSONRPCRequest{
+		tracker.PushRequest(&JSONRPCRequest{
 			ID:     mcp.NewRequestId(0),
 			Method: MethodToolsList,
-		}))
+		})
 		require.Equal(t, 1, tracker.Len())
 	})
 


### PR DESCRIPTION
Backport #66989 to branch/v18

changelog: Reject MCP tools/call requests with missing canonical case-sensitive "name" param. This is to protect bypassing RBAC check for servers which incorrectly accept non-canonical "name" param, e.g. "Name".

## Manual Test Plan
### Test Environment

Teleport cluster with demo-mcp server enabled.

### Test Cases

- [ ] Valid tools/call works

<details>
<summary>Valid "name"</summary>

```
2026/05/27 20:38:22 Writing request...
--- Client Request -----------
{
    "id": 3,
    "jsonrpc": "2.0",
    "method": "tools/call",
    "params": {
        "name": "teleport_demo_info"
    }
}
--- End of Client Request ----
2026/05/27 20:38:22 Waiting for response...
--- Server Response ----------
{
    "id": 3,
    "jsonrpc": "2.0",
    "result": {
        "content": [
            {
                "text": "Teleport can provide secure connections to your MCP servers while\nimproving both access control and visibility.\n\nThis 'teleport-demo' MCP server is a demonstration that showcases how Teleport\nMCP access works.\n\nYou can find this 'teleport-demo' server in the Teleport Web UI or by running\n'tsh mcp ls'.\n\nTo connect to the demo server with stdio transport from your AI tool, use 'tsh\nmcp connect teleport-demo'. Or run 'tsh mcp config teleport-demo' for more\nconfiguration details.\n\nIf you are an auditor, you can also find this MCP session and corresponding\nrequests in the audit events.\n\nAvailable Tools from the demo server:\n- 'teleport_user_info': Shows basic information about your Teleport user.\n- 'teleport_session_info': Shows information about this MCP session.\n- 'teleport_demo_info' (this tool): Shows information about this Teleport Demo MCP server.\n\nYou can restrict what tools a user can access by listing allowed MCP tools in\nthe role spec 'role.allow.mcp.tools'.\n\nTo learn more about enrolling MCP servers and additional reference materials, please visit:\nhttps://goteleport.com/docs/enroll-resources/mcp-access\n",
                "type": "text"
            }
        ]
    }
}
--- End of Server Response ---
```

</details>

- [ ] Empty "name" fails

<details>
<summary>Empty "name"</summary>

```
2026/05/27 20:37:49 Writing request...
--- Client Request -----------
{
    "id": 3,
    "jsonrpc": "2.0",
    "method": "tools/call",
    "params": {
        "name": ""
    }
}
--- End of Client Request ----
2026/05/27 20:37:49 Waiting for response...
--- Server Response ----------
{
    "error": {
        "code": -32600,
        "data": {
            "message": "\"name\" parameter missing"
        },
        "message": "Teleport did not forward an invalid Request object."
    },
    "id": 3,
    "jsonrpc": "2.0"
}
--- End of Server Response ---
```

</details>

- [ ] Non-canonical "Name" fails

<details>
<summary>Non-canonical "Name"</summary>

```
2026/05/27 20:36:50 Writing request...
--- Client Request -----------
{
    "id": 3,
    "jsonrpc": "2.0",
    "method": "tools/call",
    "params": {
        "Name": "teleport_demo_info"
    }
}
--- End of Client Request ----
2026/05/27 20:36:50 Waiting for response...
--- Server Response ----------
{
    "error": {
        "code": -32600,
        "data": {
            "message": "\"name\" parameter missing"
        },
        "message": "Teleport did not forward an invalid Request object."
    },
    "id": 3,
    "jsonrpc": "2.0"
}
--- End of Server Response ---
```

</details>