### PR TITLE
Connect: harden osascripts

### DIFF
--- a/lib/vnet/escalate_nodaemon_darwin.go
+++ b/lib/vnet/escalate_nodaemon_darwin.go
@@ -40,25 +40,32 @@ func execAdminProcess(ctx context.Context, config daemon.Config) error {
 		return trace.Wrap(err, "getting executable path")
 	}
 
-	appleScript := fmt.Sprintf(`
-set executableName to "%s"
-set addr to "%s"
-set credPath to "%s"
-do shell script quoted form of executableName & `+
-		`" %s -d --addr " & quoted form of addr & `+
+	const appleScript = `
+on run argv
+  set executableName to item 1 of argv
+  set subCommand to item 2 of argv
+  set addr to item 3 of argv
+  set credPath to item 4 of argv
+  do shell script quoted form of executableName & `+
+		`" " & quoted form of subCommand & `+
+		`" -d --addr " & quoted form of addr & `+
 		`" --cred-path " & quoted form of credPath & `+
 		`" >/var/log/vnet.log 2>&1" `+
-		`with prompt "Teleport VNet wants to set up a virtual network device." with administrator privileges`,
-		executableName,
-		config.ClientApplicationServiceAddr,
-		config.ServiceCredentialPath,
-		teleport.VnetAdminSetupSubCommand,
-	)
+		`with prompt "Teleport VNet wants to set up a virtual network device." `+
+		`with administrator privileges
+end run
+`
 
 	// The context we pass here has effect only on the password prompt being shown. Once osascript spawns the
 	// privileged process, canceling the context (and thus killing osascript) has no effect on the privileged
 	// process.
-	cmd := exec.CommandContext(ctx, "osascript", "-e", appleScript)
+	cmd := exec.CommandContext(ctx, "osascript",
+		"-e", appleScript,
+		executableName,
+		teleport.VnetAdminSetupSubCommand,
+		config.ClientApplicationServiceAddr,
+		config.ServiceCredentialPath,
+	)
 	var stderr strings.Builder
 	cmd.Stderr = &stderr
 

--- a/web/packages/teleterm/src/mainProcess/mainProcess.ts
+++ b/web/packages/teleterm/src/mainProcess/mainProcess.ts
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { ChildProcess, exec, fork, spawn } from 'node:child_process';
+import { ChildProcess, execFile, fork, spawn } from 'node:child_process';
 import fs from 'node:fs/promises';
 import path from 'node:path';
 import { promisify } from 'node:util';
@@ -490,10 +490,24 @@ export default class MainProcess {
       const target = '/usr/local/bin/tsh';
       const prompt =
         'Teleport Connect wants to create a symlink for tsh in /usr/local/bin.';
-      const command = `osascript -e "do shell script \\"mkdir -p /usr/local/bin && ln -sf '${source}' '${target}'\\" with prompt \\"${prompt}\\" with administrator privileges"`;
+
+      const script = `
+on run argv
+  set src to item 1 of argv
+  set tgt to item 2 of argv
+  set msg to item 3 of argv
+  do shell script "mkdir -p /usr/local/bin && ln -sf " & quoted form of src & " " & quoted form of tgt with prompt msg with administrator privileges
+end run
+  `;
 
       try {
-        await promisify(exec)(command);
+        await promisify(execFile)('osascript', [
+          '-e',
+          script,
+          source,
+          target,
+          prompt,
+        ]);
         this.logger.info(`Created the symlink to ${source} under ${target}`);
         return true;
       } catch (error) {
@@ -511,10 +525,15 @@ export default class MainProcess {
       const target = '/usr/local/bin/tsh';
       const prompt =
         'Teleport Connect wants to remove a symlink for tsh from /usr/local/bin.';
-      const command = `osascript -e "do shell script \\"rm '${target}'\\" with prompt \\"${prompt}\\" with administrator privileges"`;
-
+      const script = `
+on run argv
+  set tgt to item 1 of argv
+  set msg to item 2 of argv
+  do shell script "rm " & quoted form of tgt with prompt msg with administrator privileges
+end run
+  `;
       try {
-        await promisify(exec)(command);
+        await promisify(execFile)('osascript', ['-e', script, target, prompt]);
         this.logger.info(`Removed the symlink under ${target}`);
         return true;
       } catch (error) {


### PR DESCRIPTION
I updated the AppleScripts to use proper escaping when installing or removing tsh from PATH. I also aligned the VNet setup script with the same syntax for consistency.

<!-- Include manual testing efforts to verify the change. -->
<!-- Detail where the tests where run and what configurations were used. -->
<!-- Include all the test cases which were run to validate the change. -->

## Manual Test Plan
### Test Environment
Packaged app.

### Test Cases
- [x] Installing/removing tsh in PATH via osascript works.
- [x] Setting up VNet with osascript works.
