### PR TITLE
[v17] Connect: Avoid falling back to system CA in tshd gRPC server when cert cannot be read

### DIFF
--- a/lib/teleterm/grpccredentials.go
+++ b/lib/teleterm/grpccredentials.go
@@ -63,6 +63,7 @@ func createServerCredentials(serverKeyPair tls.Certificate, clientCertPaths []st
 	config := &tls.Config{
 		ClientAuth:   tls.RequireAndVerifyClientCert,
 		Certificates: []tls.Certificate{serverKeyPair},
+		ClientCAs:    x509.NewCertPool(),
 	}
 
 	config.GetConfigForClient = func(_ *tls.ClientHelloInfo) (*tls.Config, error) {

--- a/lib/teleterm/grpccredentials.go
+++ b/lib/teleterm/grpccredentials.go
@@ -63,7 +63,9 @@ func createServerCredentials(serverKeyPair tls.Certificate, clientCertPaths []st
 	config := &tls.Config{
 		ClientAuth:   tls.RequireAndVerifyClientCert,
 		Certificates: []tls.Certificate{serverKeyPair},
-		ClientCAs:    x509.NewCertPool(),
+		// Must not be nil. GetConfigForClient falls back to this config on read
+		// failure, a nil ClientCAs would fall back to the OS system-trusted CAs.
+		ClientCAs: x509.NewCertPool(),
 	}
 
 	config.GetConfigForClient = func(_ *tls.ClientHelloInfo) (*tls.Config, error) {

--- a/lib/teleterm/teleterm_test.go
+++ b/lib/teleterm/teleterm_test.go
@@ -130,6 +130,16 @@ func TestStart(t *testing.T) {
 			addr: "tcp://localhost:0",
 			createClientTLSConfigFunc: func(t *testing.T, certsDir string) *tls.Config {
 				systemTrustedClientCert := newSystemTrustedCert(t)
+				// Confirm the cert is actually trusted by the process default verifier.
+				// Without this check, a broken SetFallbackRoots setup would silently turn
+				// this case into "server rejects an unknown CA", which would no longer
+				// prove that the server avoids the OS trust store.
+				leaf, err := x509.ParseCertificate(systemTrustedClientCert.Certificate[0])
+				require.NoError(t, err)
+				_, err = leaf.Verify(x509.VerifyOptions{
+					KeyUsages: []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+				})
+				require.NoError(t, err, "fake system-trusted CA is not honored by the default verifier; check x509.SetFallbackRoots wiring")
 				tlsConfig, err := createClientTLSConfig(systemTrustedClientCert, filepath.Join(certsDir, tshdCertFileName))
 				require.NoError(t, err)
 				return withH2(tlsConfig)

--- a/lib/teleterm/teleterm_test.go
+++ b/lib/teleterm/teleterm_test.go
@@ -51,13 +51,34 @@ const (
 type createClientTLSConfigFunc func(t *testing.T, certsDir string) *tls.Config
 type connReadExpectationFunc func(t *testing.T, connReadErr error)
 
+// systemTrustedCA allows us to generate certs that the OS would trust.
+var systemTrustedCA *tlsca.CertAuthority
+
+func init() {
+	caKeyPEM, caCertPEM, err := tlsca.GenerateSelfSignedCA(
+		pkix.Name{CommonName: "Teleport test system root"}, nil, time.Hour)
+	if err != nil {
+		panic(err)
+	}
+	systemTrustedCA, err = tlsca.FromKeys(caCertPEM, caKeyPEM)
+	if err != nil {
+		panic(err)
+	}
+	caCert, err := tlsca.ParseCertificatePEM(caCertPEM)
+	if err != nil {
+		panic(err)
+	}
+
+	pool := x509.NewCertPool()
+	pool.AddCert(caCert)
+	x509.SetFallbackRoots(pool)
+}
+
 func TestStart(t *testing.T) {
 	t.Parallel()
 
 	sockDir := t.TempDir()
 	sockPath := filepath.Join(sockDir, "teleterm.sock")
-
-	systemTrustedClientCert := newSystemTrustedClient(t)
 
 	tests := []struct {
 		name                    string
@@ -108,6 +129,7 @@ func TestStart(t *testing.T) {
 			name: "tcp with system-trusted client cert not saved to disk",
 			addr: "tcp://localhost:0",
 			createClientTLSConfigFunc: func(t *testing.T, certsDir string) *tls.Config {
+				systemTrustedClientCert := newSystemTrustedCert(t)
 				tlsConfig, err := createClientTLSConfig(systemTrustedClientCert, filepath.Join(certsDir, tshdCertFileName))
 				require.NoError(t, err)
 				return withH2(tlsConfig)
@@ -254,26 +276,13 @@ func createValidClientTLSConfig(t *testing.T, certsDir string) *tls.Config {
 	return withH2(tlsConfig)
 }
 
-// newSystemTrustedClient creates a CA, sets it as the process's fallback
-// system root, and returns a client cert signed by it.
-func newSystemTrustedClient(t *testing.T) tls.Certificate {
+// newSystemTrustedCert gets a fresh client cert signed by CA set as the process's fallback system root.
+func newSystemTrustedCert(t *testing.T) tls.Certificate {
 	t.Helper()
-
-	caKeyPEM, caCertPEM, err := tlsca.GenerateSelfSignedCA(
-		pkix.Name{CommonName: "Teleport test system root"}, nil, time.Hour)
-	require.NoError(t, err)
-	ca, err := tlsca.FromKeys(caCertPEM, caKeyPEM)
-	require.NoError(t, err)
-	caCert, err := tlsca.ParseCertificatePEM(caCertPEM)
-	require.NoError(t, err)
-
-	pool := x509.NewCertPool()
-	pool.AddCert(caCert)
-	x509.SetFallbackRoots(pool)
 
 	clientKey, err := cryptosuites.GenerateKeyWithAlgorithm(cryptosuites.ECDSAP256)
 	require.NoError(t, err)
-	clientCertPEM, err := ca.GenerateCertificate(tlsca.CertificateRequest{
+	clientCertPEM, err := systemTrustedCA.GenerateCertificate(tlsca.CertificateRequest{
 		PublicKey: clientKey.Public(),
 		Subject:   pkix.Name{CommonName: "Teleport test system-trusted client"},
 		NotAfter:  time.Now().Add(time.Hour),

--- a/lib/teleterm/teleterm_test.go
+++ b/lib/teleterm/teleterm_test.go
@@ -16,12 +16,16 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+// Forces the fallback behavior for x509.SetFallbackRoots on all platforms during tests.
+//go:debug x509usefallbackroots=1
+
 package teleterm
 
 import (
 	"context"
 	"crypto/tls"
 	"crypto/x509"
+	"crypto/x509/pkix"
 	"errors"
 	"fmt"
 	"net"
@@ -33,6 +37,9 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/gravitational/teleport/api/utils/keys"
+	"github.com/gravitational/teleport/lib/cryptosuites"
+	"github.com/gravitational/teleport/lib/tlsca"
 	"github.com/gravitational/teleport/lib/utils"
 )
 
@@ -49,6 +56,8 @@ func TestStart(t *testing.T) {
 
 	sockDir := t.TempDir()
 	sockPath := filepath.Join(sockDir, "teleterm.sock")
+
+	systemTrustedClientCert := newSystemTrustedClient(t)
 
 	tests := []struct {
 		name                    string
@@ -86,6 +95,22 @@ func TestStart(t *testing.T) {
 			addr: "tcp://localhost:0",
 			createClientTLSConfigFunc: func(t *testing.T, certsDir string) *tls.Config {
 				return &tls.Config{InsecureSkipVerify: true}
+			},
+			connReadExpectationFunc: func(t *testing.T, connReadErr error) {
+				require.ErrorContains(t, connReadErr, "tls:")
+			},
+		},
+		{
+			// Even when the client presents a cert signed by a system-trusted
+			// CA (the test binary installs one via x509.SetFallbackRoots), the
+			// server must reject it. This guards against accidentally trusting
+			// any system-rooted client when the on-disk client certs cannot be read.
+			name: "tcp with system-trusted client cert not saved to disk",
+			addr: "tcp://localhost:0",
+			createClientTLSConfigFunc: func(t *testing.T, certsDir string) *tls.Config {
+				tlsConfig, err := createClientTLSConfig(systemTrustedClientCert, filepath.Join(certsDir, tshdCertFileName))
+				require.NoError(t, err)
+				return withH2(tlsConfig)
 			},
 			connReadExpectationFunc: func(t *testing.T, connReadErr error) {
 				require.ErrorContains(t, connReadErr, "tls:")
@@ -226,14 +251,46 @@ func createValidClientTLSConfig(t *testing.T, certsDir string) *tls.Config {
 
 	tlsConfig, err := createClientTLSConfig(clientCert, serverCertPath)
 	require.NoError(t, err)
+	return withH2(tlsConfig)
+}
 
+// newSystemTrustedClient creates a CA, sets it as the process's fallback
+// system root, and returns a client cert signed by it.
+func newSystemTrustedClient(t *testing.T) tls.Certificate {
+	t.Helper()
+
+	caKeyPEM, caCertPEM, err := tlsca.GenerateSelfSignedCA(
+		pkix.Name{CommonName: "Teleport test system root"}, nil, time.Hour)
+	require.NoError(t, err)
+	ca, err := tlsca.FromKeys(caCertPEM, caKeyPEM)
+	require.NoError(t, err)
+	caCert, err := tlsca.ParseCertificatePEM(caCertPEM)
+	require.NoError(t, err)
+
+	pool := x509.NewCertPool()
+	pool.AddCert(caCert)
+	x509.SetFallbackRoots(pool)
+
+	clientKey, err := cryptosuites.GenerateKeyWithAlgorithm(cryptosuites.ECDSAP256)
+	require.NoError(t, err)
+	clientCertPEM, err := ca.GenerateCertificate(tlsca.CertificateRequest{
+		PublicKey: clientKey.Public(),
+		Subject:   pkix.Name{CommonName: "Teleport test system-trusted client"},
+		NotAfter:  time.Now().Add(time.Hour),
+	})
+	require.NoError(t, err)
+	clientCert, err := keys.TLSCertificateForSigner(clientKey, clientCertPEM)
+	require.NoError(t, err)
+	return clientCert
+}
+
+func withH2(cfg *tls.Config) *tls.Config {
 	// this would be done by the grpc TransportCredential in the grpc client,
 	// but we're going to fake it with just a tls.Client, so we have to add the
 	// http2 next proto ourselves (enforced by grpc-go starting from v1.67, and
 	// required by the http2 spec when speaking http2 in TLS)
-	if !slices.Contains(tlsConfig.NextProtos, "h2") {
-		tlsConfig.NextProtos = append(tlsConfig.NextProtos, "h2")
+	if !slices.Contains(cfg.NextProtos, "h2") {
+		cfg.NextProtos = append(cfg.NextProtos, "h2")
 	}
-
-	return tlsConfig
+	return cfg
 }


### PR DESCRIPTION
Backport #67038 to branch/v17

## Manual Test Plan
### Test Environment
Locally built app.

### Test Cases
- [x] Teleport Connect on Windows starts as usual. 
