### PR TITLE
Add `FilterFn` to beams filter options

### DIFF
--- a/lib/services/beam.go
+++ b/lib/services/beam.go
@@ -163,8 +163,11 @@ func ValidateBeamAlias(alias string) error {
 // options.
 func MakeBeamFilterFunc(options *ListBeamsRequestOptions) func(beam *beamsv1.Beam) bool {
 	return func(b *beamsv1.Beam) bool {
-		if options != nil && options.GetFilterUsers().Len() > 0 {
-			return options.FilterUsers.Contains(b.GetStatus().GetUser())
+		if options.GetFilterUsers().Len() > 0 && !options.FilterUsers.Contains(b.GetStatus().GetUser()) {
+			return false
+		}
+		if options.GetFilterFn() != nil && !options.FilterFn(b) {
+			return false
 		}
 		return true
 	}
@@ -180,6 +183,10 @@ type ListBeamsRequestOptions struct {
 	// FilterUsers filters the results to only include beams owned by the
 	// provided users.
 	FilterUsers set.Set[string]
+	// FilterFn is a general-use filter delegate. Useful when the state required
+	// for a filter means the filter cant be easily implemented in the backend
+	// or cache (e.g. access control context).
+	FilterFn func(*beamsv1.Beam) bool
 }
 
 // GetSortField is a nil-safe getter for SortField
@@ -204,4 +211,12 @@ func (o *ListBeamsRequestOptions) GetFilterUsers() set.Set[string] {
 		return set.Set[string]{}
 	}
 	return o.FilterUsers
+}
+
+// GetFilterFn is a nil-safe getter for FilterFn
+func (o *ListBeamsRequestOptions) GetFilterFn() func(*beamsv1.Beam) bool {
+	if o == nil {
+		return nil
+	}
+	return o.FilterFn
 }

--- a/lib/services/beam.go
+++ b/lib/services/beam.go
@@ -184,7 +184,7 @@ type ListBeamsRequestOptions struct {
 	// provided users.
 	FilterUsers set.Set[string]
 	// FilterFn is a general-use filter delegate. Useful when the state required
-	// for a filter means the filter cant be easily implemented in the backend
+	// for a filter means the filter can't be easily implemented in the backend
 	// or cache (e.g. access control context).
 	FilterFn func(*beamsv1.Beam) bool
 }

--- a/lib/services/beam_test.go
+++ b/lib/services/beam_test.go
@@ -206,6 +206,9 @@ func TestMakeBeamFilterFunc(t *testing.T) {
 			name: "filter users",
 			options: &services.ListBeamsRequestOptions{
 				FilterUsers: set.New("user-1"),
+				FilterFn: func(b *beamsv1.Beam) bool {
+					return true
+				},
 			},
 			beam:     testBeam(withUser("user-2")),
 			expected: false,
@@ -214,6 +217,9 @@ func TestMakeBeamFilterFunc(t *testing.T) {
 			name: "filter users match",
 			options: &services.ListBeamsRequestOptions{
 				FilterUsers: set.New("user-1"),
+				FilterFn: func(b *beamsv1.Beam) bool {
+					return true
+				},
 			},
 			beam:     testBeam(withUser("user-1")),
 			expected: true,
@@ -222,6 +228,9 @@ func TestMakeBeamFilterFunc(t *testing.T) {
 			name: "filter users empty",
 			options: &services.ListBeamsRequestOptions{
 				FilterUsers: set.NewWithCapacity[string](0),
+				FilterFn: func(b *beamsv1.Beam) bool {
+					return true
+				},
 			},
 			beam:     testBeam(withUser("user-1")),
 			expected: true,
@@ -232,8 +241,9 @@ func TestMakeBeamFilterFunc(t *testing.T) {
 				FilterFn: func(b *beamsv1.Beam) bool {
 					return false
 				},
+				FilterUsers: set.New("user-1"),
 			},
-			beam:     testBeam(),
+			beam:     testBeam(withUser("user-1")),
 			expected: false,
 		},
 		{
@@ -242,8 +252,9 @@ func TestMakeBeamFilterFunc(t *testing.T) {
 				FilterFn: func(b *beamsv1.Beam) bool {
 					return true
 				},
+				FilterUsers: set.New("user-1"),
 			},
-			beam:     testBeam(),
+			beam:     testBeam(withUser("user-1")),
 			expected: true,
 		},
 		{

--- a/lib/services/beam_test.go
+++ b/lib/services/beam_test.go
@@ -237,7 +237,7 @@ func TestMakeBeamFilterFunc(t *testing.T) {
 			expected: false,
 		},
 		{
-			name: "filter fn",
+			name: "filter fn match",
 			options: &services.ListBeamsRequestOptions{
 				FilterFn: func(b *beamsv1.Beam) bool {
 					return true

--- a/lib/services/beam_test.go
+++ b/lib/services/beam_test.go
@@ -31,14 +31,15 @@ import (
 	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/services"
+	"github.com/gravitational/teleport/lib/utils/set"
 )
 
 func TestValidateBeam(t *testing.T) {
 	t.Parallel()
 
-	require.NoError(t, services.ValidateBeam(testBeam("beam-alias")))
+	require.NoError(t, services.ValidateBeam(testBeam(withAlias("beam-alias"))))
 
-	unrestrictedBeam := testBeam("beam-alias")
+	unrestrictedBeam := testBeam(withAlias("beam-alias"))
 	unrestrictedBeam.Spec.Egress = beamsv1.EgressMode_EGRESS_MODE_UNRESTRICTED
 	unrestrictedBeam.Spec.AllowedDomains = nil
 	require.NoError(t, services.ValidateBeam(unrestrictedBeam))
@@ -53,126 +54,126 @@ func TestValidateBeam(t *testing.T) {
 			err:  "beam must not be nil",
 		},
 		"wrong version": {
-			beam: testBeam("beam-alias"),
+			beam: testBeam(withAlias("beam-alias")),
 			modFn: func(b *beamsv1.Beam) {
 				b.Version = ""
 			},
 			err: `version: only supports version "v1", got ""`,
 		},
 		"wrong kind": {
-			beam: testBeam("beam-alias"),
+			beam: testBeam(withAlias("beam-alias")),
 			modFn: func(b *beamsv1.Beam) {
 				b.Kind = ""
 			},
 			err: `kind: must be "beam", got ""`,
 		},
 		"missing metadata": {
-			beam: testBeam("beam-alias"),
+			beam: testBeam(withAlias("beam-alias")),
 			modFn: func(b *beamsv1.Beam) {
 				b.Metadata = nil
 			},
 			err: "metadata: is required",
 		},
 		"missing metadata name": {
-			beam: testBeam("beam-alias"),
+			beam: testBeam(withAlias("beam-alias")),
 			modFn: func(b *beamsv1.Beam) {
 				b.Metadata.Name = ""
 			},
 			err: "metadata.name: is required",
 		},
 		"missing spec": {
-			beam: testBeam("beam-alias"),
+			beam: testBeam(withAlias("beam-alias")),
 			modFn: func(b *beamsv1.Beam) {
 				b.Spec = nil
 			},
 			err: "spec: is required",
 		},
 		"unspecified egress": {
-			beam: testBeam("beam-alias"),
+			beam: testBeam(withAlias("beam-alias")),
 			modFn: func(b *beamsv1.Beam) {
 				b.Spec.Egress = beamsv1.EgressMode_EGRESS_MODE_UNSPECIFIED
 			},
 			err: "spec.egress: must be EGRESS_MODE_RESTRICTED or EGRESS_MODE_UNRESTRICTED",
 		},
 		"invalid egress": {
-			beam: testBeam("beam-alias"),
+			beam: testBeam(withAlias("beam-alias")),
 			modFn: func(b *beamsv1.Beam) {
 				b.Spec.Egress = beamsv1.EgressMode(42)
 			},
 			err: "spec.egress: must be EGRESS_MODE_RESTRICTED or EGRESS_MODE_UNRESTRICTED",
 		},
 		"allowed domains with unrestricted egress": {
-			beam: testBeam("beam-alias"),
+			beam: testBeam(withAlias("beam-alias")),
 			modFn: func(b *beamsv1.Beam) {
 				b.Spec.Egress = beamsv1.EgressMode_EGRESS_MODE_UNRESTRICTED
 			},
 			err: "spec.allowed_domains: may only be set when spec.egress is EGRESS_MODE_RESTRICTED",
 		},
 		"empty allowed domain": {
-			beam: testBeam("beam-alias"),
+			beam: testBeam(withAlias("beam-alias")),
 			modFn: func(b *beamsv1.Beam) {
 				b.Spec.AllowedDomains = []string{""}
 			},
 			err: `spec.allowed_domains[0]: "" must be a fully qualified domain name ending with '.'`,
 		},
 		"invalid allowed domain": {
-			beam: testBeam("beam-alias"),
+			beam: testBeam(withAlias("beam-alias")),
 			modFn: func(b *beamsv1.Beam) {
 				b.Spec.AllowedDomains = []string{"Example.COM."}
 			},
 			err: `spec.allowed_domains[0]: "Example.COM." is invalid`,
 		},
 		"wildcard allowed domain": {
-			beam: testBeam("beam-alias"),
+			beam: testBeam(withAlias("beam-alias")),
 			modFn: func(b *beamsv1.Beam) {
 				b.Spec.AllowedDomains = []string{"*.example.com."}
 			},
 			err: `spec.allowed_domains[0]: "*.example.com." is invalid`,
 		},
 		"allowed domain missing trailing dot": {
-			beam: testBeam("beam-alias"),
+			beam: testBeam(withAlias("beam-alias")),
 			modFn: func(b *beamsv1.Beam) {
 				b.Spec.AllowedDomains = []string{"example.com"}
 			},
 			err: `spec.allowed_domains[0]: "example.com" must be a fully qualified domain name ending with '.'`,
 		},
 		"allowed domain is not fqdn": {
-			beam: testBeam("beam-alias"),
+			beam: testBeam(withAlias("beam-alias")),
 			modFn: func(b *beamsv1.Beam) {
 				b.Spec.AllowedDomains = []string{"localhost."}
 			},
 			err: `spec.allowed_domains[0]: "localhost." must be a fully qualified domain name ending with '.'`,
 		},
 		"invalid publish port": {
-			beam: testBeam("beam-alias"),
+			beam: testBeam(withAlias("beam-alias")),
 			modFn: func(b *beamsv1.Beam) {
 				b.Spec.Publish.Port = 9090
 			},
 			err: `spec.publish.port: must be 8080`,
 		},
 		"invalid publish protocol": {
-			beam: testBeam("beam-alias"),
+			beam: testBeam(withAlias("beam-alias")),
 			modFn: func(b *beamsv1.Beam) {
 				b.Spec.Publish.Protocol = beamsv1.Protocol(9999)
 			},
 			err: `spec.publish.protocol: must be HTTP or TCP`,
 		},
 		"missing expires": {
-			beam: testBeam("beam-alias"),
+			beam: testBeam(withAlias("beam-alias")),
 			modFn: func(b *beamsv1.Beam) {
 				b.Spec.Expires = nil
 			},
 			err: "spec.expires: is required",
 		},
 		"missing status": {
-			beam: testBeam("beam-alias"),
+			beam: testBeam(withAlias("beam-alias")),
 			modFn: func(b *beamsv1.Beam) {
 				b.Status = nil
 			},
 			err: "status: is required",
 		},
 		"invalid alias": {
-			beam: testBeam("beam-alias"),
+			beam: testBeam(withAlias("beam-alias")),
 			modFn: func(b *beamsv1.Beam) {
 				b.Status.Alias = "beam-123"
 			},
@@ -194,8 +195,90 @@ func TestValidateBeam(t *testing.T) {
 	}
 }
 
-func testBeam(alias string) *beamsv1.Beam {
-	return &beamsv1.Beam{
+func TestMakeBeamFilterFunc(t *testing.T) {
+	testCases := []struct {
+		name     string
+		options  *services.ListBeamsRequestOptions
+		beam     *beamsv1.Beam
+		expected bool
+	}{
+		{
+			name: "filter users",
+			options: &services.ListBeamsRequestOptions{
+				FilterUsers: set.New("user-1"),
+			},
+			beam:     testBeam(withUser("user-2")),
+			expected: false,
+		},
+		{
+			name: "filter users match",
+			options: &services.ListBeamsRequestOptions{
+				FilterUsers: set.New("user-1"),
+			},
+			beam:     testBeam(withUser("user-1")),
+			expected: true,
+		},
+		{
+			name: "filter users empty",
+			options: &services.ListBeamsRequestOptions{
+				FilterUsers: set.NewWithCapacity[string](0),
+			},
+			beam:     testBeam(withUser("user-1")),
+			expected: true,
+		},
+		{
+			name: "filter fn",
+			options: &services.ListBeamsRequestOptions{
+				FilterFn: func(b *beamsv1.Beam) bool {
+					return false
+				},
+			},
+			beam:     testBeam(),
+			expected: false,
+		},
+		{
+			name: "filter fn",
+			options: &services.ListBeamsRequestOptions{
+				FilterFn: func(b *beamsv1.Beam) bool {
+					return true
+				},
+			},
+			beam:     testBeam(),
+			expected: true,
+		},
+		{
+			name:     "zero filters",
+			options:  &services.ListBeamsRequestOptions{},
+			beam:     testBeam(),
+			expected: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			fn := services.MakeBeamFilterFunc(tc.options)
+			actual := fn(tc.beam)
+			require.Equal(t, tc.expected, actual)
+		})
+	}
+}
+
+type testBeamOption = func(*beamsv1.Beam)
+
+func withAlias(alias string) testBeamOption {
+	return func(beam *beamsv1.Beam) {
+		beam.Status.Alias = alias
+	}
+}
+
+func withUser(user string) testBeamOption {
+	return func(beam *beamsv1.Beam) {
+		beam.Status.User = user
+	}
+}
+
+func testBeam(options ...testBeamOption) *beamsv1.Beam {
+	beam := &beamsv1.Beam{
 		Kind:    types.KindBeam,
 		Version: types.V1,
 		Metadata: &headerv1.Metadata{
@@ -212,7 +295,11 @@ func testBeam(alias string) *beamsv1.Beam {
 		},
 		Status: &beamsv1.BeamStatus{
 			User:  "alice",
-			Alias: alias,
+			Alias: "beam",
 		},
 	}
+	for _, opt := range options {
+		opt(beam)
+	}
+	return beam
 }

--- a/lib/services/beam_test.go
+++ b/lib/services/beam_test.go
@@ -37,9 +37,9 @@ import (
 func TestValidateBeam(t *testing.T) {
 	t.Parallel()
 
-	require.NoError(t, services.ValidateBeam(testBeam(withAlias("beam-alias"))))
+	require.NoError(t, services.ValidateBeam(testBeam(withBeamAlias("beam-alias"))))
 
-	unrestrictedBeam := testBeam(withAlias("beam-alias"))
+	unrestrictedBeam := testBeam(withBeamAlias("beam-alias"))
 	unrestrictedBeam.Spec.Egress = beamsv1.EgressMode_EGRESS_MODE_UNRESTRICTED
 	unrestrictedBeam.Spec.AllowedDomains = nil
 	require.NoError(t, services.ValidateBeam(unrestrictedBeam))
@@ -54,126 +54,126 @@ func TestValidateBeam(t *testing.T) {
 			err:  "beam must not be nil",
 		},
 		"wrong version": {
-			beam: testBeam(withAlias("beam-alias")),
+			beam: testBeam(withBeamAlias("beam-alias")),
 			modFn: func(b *beamsv1.Beam) {
 				b.Version = ""
 			},
 			err: `version: only supports version "v1", got ""`,
 		},
 		"wrong kind": {
-			beam: testBeam(withAlias("beam-alias")),
+			beam: testBeam(withBeamAlias("beam-alias")),
 			modFn: func(b *beamsv1.Beam) {
 				b.Kind = ""
 			},
 			err: `kind: must be "beam", got ""`,
 		},
 		"missing metadata": {
-			beam: testBeam(withAlias("beam-alias")),
+			beam: testBeam(withBeamAlias("beam-alias")),
 			modFn: func(b *beamsv1.Beam) {
 				b.Metadata = nil
 			},
 			err: "metadata: is required",
 		},
 		"missing metadata name": {
-			beam: testBeam(withAlias("beam-alias")),
+			beam: testBeam(withBeamAlias("beam-alias")),
 			modFn: func(b *beamsv1.Beam) {
 				b.Metadata.Name = ""
 			},
 			err: "metadata.name: is required",
 		},
 		"missing spec": {
-			beam: testBeam(withAlias("beam-alias")),
+			beam: testBeam(withBeamAlias("beam-alias")),
 			modFn: func(b *beamsv1.Beam) {
 				b.Spec = nil
 			},
 			err: "spec: is required",
 		},
 		"unspecified egress": {
-			beam: testBeam(withAlias("beam-alias")),
+			beam: testBeam(withBeamAlias("beam-alias")),
 			modFn: func(b *beamsv1.Beam) {
 				b.Spec.Egress = beamsv1.EgressMode_EGRESS_MODE_UNSPECIFIED
 			},
 			err: "spec.egress: must be EGRESS_MODE_RESTRICTED or EGRESS_MODE_UNRESTRICTED",
 		},
 		"invalid egress": {
-			beam: testBeam(withAlias("beam-alias")),
+			beam: testBeam(withBeamAlias("beam-alias")),
 			modFn: func(b *beamsv1.Beam) {
 				b.Spec.Egress = beamsv1.EgressMode(42)
 			},
 			err: "spec.egress: must be EGRESS_MODE_RESTRICTED or EGRESS_MODE_UNRESTRICTED",
 		},
 		"allowed domains with unrestricted egress": {
-			beam: testBeam(withAlias("beam-alias")),
+			beam: testBeam(withBeamAlias("beam-alias")),
 			modFn: func(b *beamsv1.Beam) {
 				b.Spec.Egress = beamsv1.EgressMode_EGRESS_MODE_UNRESTRICTED
 			},
 			err: "spec.allowed_domains: may only be set when spec.egress is EGRESS_MODE_RESTRICTED",
 		},
 		"empty allowed domain": {
-			beam: testBeam(withAlias("beam-alias")),
+			beam: testBeam(withBeamAlias("beam-alias")),
 			modFn: func(b *beamsv1.Beam) {
 				b.Spec.AllowedDomains = []string{""}
 			},
 			err: `spec.allowed_domains[0]: "" must be a fully qualified domain name ending with '.'`,
 		},
 		"invalid allowed domain": {
-			beam: testBeam(withAlias("beam-alias")),
+			beam: testBeam(withBeamAlias("beam-alias")),
 			modFn: func(b *beamsv1.Beam) {
 				b.Spec.AllowedDomains = []string{"Example.COM."}
 			},
 			err: `spec.allowed_domains[0]: "Example.COM." is invalid`,
 		},
 		"wildcard allowed domain": {
-			beam: testBeam(withAlias("beam-alias")),
+			beam: testBeam(withBeamAlias("beam-alias")),
 			modFn: func(b *beamsv1.Beam) {
 				b.Spec.AllowedDomains = []string{"*.example.com."}
 			},
 			err: `spec.allowed_domains[0]: "*.example.com." is invalid`,
 		},
 		"allowed domain missing trailing dot": {
-			beam: testBeam(withAlias("beam-alias")),
+			beam: testBeam(withBeamAlias("beam-alias")),
 			modFn: func(b *beamsv1.Beam) {
 				b.Spec.AllowedDomains = []string{"example.com"}
 			},
 			err: `spec.allowed_domains[0]: "example.com" must be a fully qualified domain name ending with '.'`,
 		},
 		"allowed domain is not fqdn": {
-			beam: testBeam(withAlias("beam-alias")),
+			beam: testBeam(withBeamAlias("beam-alias")),
 			modFn: func(b *beamsv1.Beam) {
 				b.Spec.AllowedDomains = []string{"localhost."}
 			},
 			err: `spec.allowed_domains[0]: "localhost." must be a fully qualified domain name ending with '.'`,
 		},
 		"invalid publish port": {
-			beam: testBeam(withAlias("beam-alias")),
+			beam: testBeam(withBeamAlias("beam-alias")),
 			modFn: func(b *beamsv1.Beam) {
 				b.Spec.Publish.Port = 9090
 			},
 			err: `spec.publish.port: must be 8080`,
 		},
 		"invalid publish protocol": {
-			beam: testBeam(withAlias("beam-alias")),
+			beam: testBeam(withBeamAlias("beam-alias")),
 			modFn: func(b *beamsv1.Beam) {
 				b.Spec.Publish.Protocol = beamsv1.Protocol(9999)
 			},
 			err: `spec.publish.protocol: must be HTTP or TCP`,
 		},
 		"missing expires": {
-			beam: testBeam(withAlias("beam-alias")),
+			beam: testBeam(withBeamAlias("beam-alias")),
 			modFn: func(b *beamsv1.Beam) {
 				b.Spec.Expires = nil
 			},
 			err: "spec.expires: is required",
 		},
 		"missing status": {
-			beam: testBeam(withAlias("beam-alias")),
+			beam: testBeam(withBeamAlias("beam-alias")),
 			modFn: func(b *beamsv1.Beam) {
 				b.Status = nil
 			},
 			err: "status: is required",
 		},
 		"invalid alias": {
-			beam: testBeam(withAlias("beam-alias")),
+			beam: testBeam(withBeamAlias("beam-alias")),
 			modFn: func(b *beamsv1.Beam) {
 				b.Status.Alias = "beam-123"
 			},
@@ -210,7 +210,7 @@ func TestMakeBeamFilterFunc(t *testing.T) {
 					return true
 				},
 			},
-			beam:     testBeam(withUser("user-2")),
+			beam:     testBeam(withBeamUser("user-2")),
 			expected: false,
 		},
 		{
@@ -221,7 +221,7 @@ func TestMakeBeamFilterFunc(t *testing.T) {
 					return true
 				},
 			},
-			beam:     testBeam(withUser("user-1")),
+			beam:     testBeam(withBeamUser("user-1")),
 			expected: true,
 		},
 		{
@@ -232,7 +232,7 @@ func TestMakeBeamFilterFunc(t *testing.T) {
 					return true
 				},
 			},
-			beam:     testBeam(withUser("user-1")),
+			beam:     testBeam(withBeamUser("user-1")),
 			expected: true,
 		},
 		{
@@ -243,7 +243,7 @@ func TestMakeBeamFilterFunc(t *testing.T) {
 				},
 				FilterUsers: set.New("user-1"),
 			},
-			beam:     testBeam(withUser("user-1")),
+			beam:     testBeam(withBeamUser("user-1")),
 			expected: false,
 		},
 		{
@@ -254,7 +254,7 @@ func TestMakeBeamFilterFunc(t *testing.T) {
 				},
 				FilterUsers: set.New("user-1"),
 			},
-			beam:     testBeam(withUser("user-1")),
+			beam:     testBeam(withBeamUser("user-1")),
 			expected: true,
 		},
 		{
@@ -276,13 +276,13 @@ func TestMakeBeamFilterFunc(t *testing.T) {
 
 type testBeamOption = func(*beamsv1.Beam)
 
-func withAlias(alias string) testBeamOption {
+func withBeamAlias(alias string) testBeamOption {
 	return func(beam *beamsv1.Beam) {
 		beam.Status.Alias = alias
 	}
 }
 
-func withUser(user string) testBeamOption {
+func withBeamUser(user string) testBeamOption {
 	return func(beam *beamsv1.Beam) {
 		beam.Status.User = user
 	}


### PR DESCRIPTION
## Summary

This change adds a `FilterFn` to the filter options for beams. It will be used to filter items based on a beam's owner. This type of filter cannot be easily applied in the cache or backend without passing access list config and user roles. Passing a filter delegate seems cleaner.

The new property will have no effect until it is used.

### Example
```go
func (s *BeamsService) ListBeams(ctx context.Context, req *beamsv1.ListBeamsRequest) (*beamsv1.ListBeamsResponse, error) {
	authContext := authContextFromRequest(req);

	list, next, err := s.beamReader.ListBeamsV2(ctx, pageSize, pageToken, &services.ListBeamsRequestOptions{
		FilterFn: func(b *beamsv1.Beam) bool {
			return checkAccessToBeamForUser(b, authContext);
		},
	})

	// snip
}
```

## Changes

- Add `FilterFn` to `ListBeamsRequestOptions`
- Add tests
