### PR TITLE
[v17] Use text template for installer script rendering

### DIFF
--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -28,7 +28,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"html/template"
+	htmltemplate "html/template"
 	"io"
 	"log/slog"
 	"math/rand/v2"
@@ -41,6 +41,7 @@ import (
 	"strings"
 	"sync"
 	"sync/atomic"
+	texttemplate "text/template"
 	"time"
 
 	gogoproto "github.com/gogo/protobuf/proto"
@@ -616,7 +617,7 @@ func NewHandler(cfg Config, opts ...HandlerOption) (*APIHandler, error) {
 	}
 
 	// serve the web UI from the embedded filesystem
-	var indexPage *template.Template
+	var indexPage *htmltemplate.Template
 	// we will set our etag based on the teleport version and
 	// the webasset app hash if available. The version only will not
 	// suffice as it can cause incorrect caching for local development.
@@ -638,7 +639,7 @@ func NewHandler(cfg Config, opts ...HandlerOption) (*APIHandler, error) {
 		if err != nil {
 			return nil, trace.ConvertSystemError(err)
 		}
-		indexPage, err = template.New("index").Parse(string(indexContent))
+		indexPage, err = htmltemplate.New("index").Parse(string(indexContent))
 		if err != nil {
 			return nil, trace.BadParameter("failed parsing index.html template: %v", err)
 		}
@@ -2346,7 +2347,7 @@ func (h *Handler) installer(w http.ResponseWriter, r *http.Request, p httprouter
 		targetVersion = teleport.SemVer()
 	}
 
-	instTmpl, err := template.New("").Parse(installer.GetScript())
+	instTmpl, err := texttemplate.New("").Parse(installer.GetScript())
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/web/apiserver_test.go
+++ b/lib/web/apiserver_test.go
@@ -3121,6 +3121,37 @@ echo AutomaticUpgrades: {{ .AutomaticUpgrades }}
 	})
 }
 
+func TestInstallerScriptRenderedWithTextTemplate(t *testing.T) {
+	t.Parallel()
+	s := newWebSuite(t)
+	wc := s.client(t)
+
+	require.NoError(t, s.server.Auth().SetInstaller(
+		s.ctx,
+		types.MustNewInstallerV1("custom", `{{ .AzureClientID }}`),
+	))
+
+	const azureClientID = `abc&<>'";$(touch /tmp/pwn)`
+
+	re, err := wc.Get(
+		s.ctx,
+		wc.Endpoint("webapi", "scripts", "installer", "custom"),
+		url.Values{"azure-client-id": []string{azureClientID}},
+	)
+	require.NoError(t, err)
+
+	response := string(re.Bytes())
+
+	require.Equal(t, `abc\&\<\>\'\"\;\$\(touch\ /tmp/pwn\)`, response)
+
+	// Assert that HTML escaping did not occur.
+	require.NotContains(t, response, "&amp;")
+	require.NotContains(t, response, "&lt;")
+	require.NotContains(t, response, "&gt;")
+	require.NotContains(t, response, "&#39;")
+	require.NotContains(t, response, "&#34;")
+}
+
 func TestMultipleConnectors(t *testing.T) {
 	t.Parallel()
 	s := newWebSuite(t)


### PR DESCRIPTION
Backport #67136 to branch/v17

Changelog: Fixed an issue where generated installer scripts could incorrectly escape special characters in some values.

## Manual Test Plan
### Test Environment

Local cluster running this branch.

### Test Cases
- [x] Installer script retrieved does not HTML encode data.

```bash
$ curl -sG --data-urlencode 'azure-client-id=abc&<>'\''";$(touch /tmp/pwn)' "https://proxy.example.com:443/webapi/scripts/installer/default-installer" | grep -- '--azure-client-id'
entrypointArgs='install autodiscover-node --public-proxy-addr=proxy.example.com:443 --teleport-package=teleport --repo-channel=stable/v19 --auto-upgrade=false --azure-client-id=abc\&\<\>\'\"\;\$\(touch\ /tmp/pwn\)'
```