### PR TITLE
operator: add secret lookup to oidc's google_service_account

### DIFF
--- a/docs/pages/zero-trust-access/infrastructure-as-code/teleport-operator/secret-lookup.mdx
+++ b/docs/pages/zero-trust-access/infrastructure-as-code/teleport-operator/secret-lookup.mdx
@@ -19,6 +19,7 @@ Kubernetes secret and the operator will retrieve the value from the secret when 
 Currently supported fields for secret lookup:
 - GithubConnector `client_secret`
 - OIDCConnector `client_secret`
+- OIDCConnector `google_service_account`
 - TrustedClusterV2 `token`
 
 ## Prerequisites

--- a/integrations/operator/controllers/resources/oidc_connector_controller.go
+++ b/integrations/operator/controllers/resources/oidc_connector_controller.go
@@ -66,9 +66,18 @@ func (r oidcConnectorClient) Mutate(ctx context.Context, new, _ types.OIDCConnec
 	if secretlookup.IsNeeded(secret) {
 		resolvedSecret, err := secretlookup.Try(ctx, r.kubeClient, crKey.Name, crKey.Namespace, secret)
 		if err != nil {
-			return trace.Wrap(err)
+			return trace.Wrap(err, "resolving client secret")
 		}
 		new.SetClientSecret(resolvedSecret)
+	}
+
+	gcpSA := new.GetGoogleServiceAccount()
+	if secretlookup.IsNeeded(gcpSA) {
+		resolvedSecret, err := secretlookup.Try(ctx, r.kubeClient, crKey.Name, crKey.Namespace, gcpSA)
+		if err != nil {
+			return trace.Wrap(err, "resolving google service account secret")
+		}
+		new.SetGoogleServiceAccount(resolvedSecret)
 	}
 	return nil
 }

--- a/integrations/operator/controllers/resources/oidc_connector_controller_test.go
+++ b/integrations/operator/controllers/resources/oidc_connector_controller_test.go
@@ -158,7 +158,9 @@ func TestOIDCConnectorSecretLookup(t *testing.T) {
 	crName := validRandomResourceName("oidc")
 	secretName := validRandomResourceName("oidc-secret")
 	secretKey := "client-secret"
+	googleSecretKey := "google-service-account"
 	secretValue := validRandomResourceName("secret-value")
+	googleSecretValue := `{"name": "projects/PROJECT-ID/service-accounts/SERVICEACCOUNT"}`
 
 	secret := &v1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
@@ -171,7 +173,8 @@ func TestOIDCConnectorSecretLookup(t *testing.T) {
 		// Real kube servers convert stringData into data.
 		// The fake client does not, so we must use Data instead.
 		Data: map[string][]byte{
-			secretKey: []byte(secretValue),
+			secretKey:       []byte(secretValue),
+			googleSecretKey: []byte(googleSecretValue),
 		},
 		Type: v1.SecretTypeOpaque,
 	}
@@ -187,6 +190,8 @@ func TestOIDCConnectorSecretLookup(t *testing.T) {
 	}
 
 	oidc.Spec.ClientSecret = "secret://" + secretName + "/" + secretKey
+	oidc.Spec.GoogleServiceAccount = "secret://" + secretName + "/" + googleSecretKey
+	oidc.Spec.GoogleAdminEmail = "this-is-required-for-gcp-sa@example.com"
 	require.NoError(t, kubeClient.Create(ctx, oidc))
 
 	reconciler, err := resources.NewOIDCConnectorReconciler(kubeClient, setup.TeleportClient)
@@ -212,6 +217,6 @@ func TestOIDCConnectorSecretLookup(t *testing.T) {
 		if err != nil {
 			return false
 		}
-		return oidc.GetClientSecret() == secretValue
+		return oidc.GetClientSecret() == secretValue && oidc.GetGoogleServiceAccount() == googleSecretValue
 	})
 }


### PR DESCRIPTION
Fixes: https://github.com/gravitational/teleport/issues/66998
Changelog: Added secret lookup support for `TeleportOIDCConnector.spec.google_service_account` to the Teleport Kubernetes Operator.

## Manual Test Plan
### Test Environment

- Local cluster running 18.8.1 + custom operator build

### Test Cases
- [x] Can create OIDC Connector
- [x] Can create OIDC connected wit GCP SA secret lookup
