### PR TITLE
Limit Windows desktop MFA lookup

### DIFF
--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -8124,15 +8124,18 @@ func (a *Server) isMFARequired(ctx context.Context, scopedCtx *authz.ScopedConte
 		noMFAAccessErr = checker.CheckAccess(db, services.AccessState{})
 
 	case *proto.IsMFARequiredRequest_WindowsDesktop:
-		desktops, err := a.GetWindowsDesktops(ctx, types.WindowsDesktopFilter{Name: t.WindowsDesktop.GetWindowsDesktop()})
+		resp, err := a.ListWindowsDesktops(ctx, types.ListWindowsDesktopsRequest{
+			WindowsDesktopFilter: types.WindowsDesktopFilter{Name: t.WindowsDesktop.GetWindowsDesktop()},
+			Limit:                1,
+		})
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
-		if len(desktops) == 0 {
+		if len(resp.Desktops) == 0 {
 			return nil, trace.NotFound("windows desktop %q not found", t.WindowsDesktop.GetWindowsDesktop())
 		}
 
-		noMFAAccessErr = checker.CheckAccess(desktops[0],
+		noMFAAccessErr = checker.CheckAccess(resp.Desktops[0],
 			services.AccessState{},
 			services.NewWindowsLoginMatcher(t.WindowsDesktop.GetLogin()))
 


### PR DESCRIPTION
Continuation of `IsMFARequired` enhancements (re: https://github.com/gravitational/teleport/pull/66484)

`IsMFARequiredRequest_WindowsDesktop` now resolves the target Windows desktop with `ListWindowsDesktops` and `Limit: 1` instead of fetching every matching desktop via `GetWindowsDesktops` avoiding unecessary allocations when there are
many matching desktops.

Changelog: Improved performance and reduced resource usage of the auth service for clusters with large numbers of registered Windows desktops with per-session MFA enabled.

## Manual Test Plan
### Test Environment

Teleport Cloud tenant with at least one enrolled Windows desktop and a role that requires per-session MFA for Windows desktop access.

### Test Cases
- [x] Connect to a Windows desktop where the role requires per-session MFA and confirm MFA prompt appears and connection succeeds after verification
- [x] Connect to a Windows desktop where no per-session MFA is required and confirm connection succeeds without an MFA prompt
- [x] Unregister a previously registered Windows desktop, attempt to connect, and confirm a not found error is returned
