### PR TITLE
[v18] Sanitize AWS federation transport errors

### DIFF
--- a/lib/srv/app/cloud.go
+++ b/lib/srv/app/cloud.go
@@ -282,7 +282,7 @@ func (c *cloud) getAWSSigninToken(ctx context.Context, req *AWSSigninRequest, en
 	tokenURL.RawQuery = values.Encode()
 	resp, err := http.Get(tokenURL.String())
 	if err != nil {
-		return "", trace.Wrap(traceAWSSigninTokenRequestError(err))
+		return "", trace.Wrap(redactAWSSigninTokenRequestError(err))
 	}
 
 	respBytes, err := io.ReadAll(resp.Body)
@@ -304,7 +304,7 @@ func (c *cloud) getAWSSigninToken(ctx context.Context, req *AWSSigninRequest, en
 	return fedResp.SigninToken, nil
 }
 
-func traceAWSSigninTokenRequestError(err error) error {
+func redactAWSSigninTokenRequestError(err error) error {
 	var urlErr *url.Error
 	if errors.As(err, &urlErr) {
 		return trace.ConnectionProblem(urlErr.Err, "failed to request AWS federation sign-in token")

--- a/lib/srv/app/cloud.go
+++ b/lib/srv/app/cloud.go
@@ -21,6 +21,7 @@ package app
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"log/slog"
 	"net/http"
@@ -281,7 +282,7 @@ func (c *cloud) getAWSSigninToken(ctx context.Context, req *AWSSigninRequest, en
 	tokenURL.RawQuery = values.Encode()
 	resp, err := http.Get(tokenURL.String())
 	if err != nil {
-		return "", trace.Wrap(err)
+		return "", trace.Wrap(traceAWSSigninTokenRequestError(err))
 	}
 
 	respBytes, err := io.ReadAll(resp.Body)
@@ -301,6 +302,14 @@ func (c *cloud) getAWSSigninToken(ctx context.Context, req *AWSSigninRequest, en
 	}
 
 	return fedResp.SigninToken, nil
+}
+
+func traceAWSSigninTokenRequestError(err error) error {
+	var urlErr *url.Error
+	if errors.As(err, &urlErr) {
+		return trace.ConnectionProblem(urlErr.Err, "failed to request AWS federation sign-in token")
+	}
+	return trace.ConnectionProblem(nil, "failed to request AWS federation sign-in token")
 }
 
 func getAssumeDetailedRolesOption(ctx context.Context, req *AWSSigninRequest, temporarySession bool, duration time.Duration) awsconfig.OptionsFn {

--- a/lib/srv/app/cloud_test.go
+++ b/lib/srv/app/cloud_test.go
@@ -23,6 +23,7 @@ import (
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"testing"
 	"time"
 
@@ -273,6 +274,55 @@ func TestCloudGetAWSSigninToken(t *testing.T) {
 				require.Equal(t, test.expectedToken, actualToken)
 			}
 		})
+	}
+}
+
+func TestCloudGetAWSSigninTokenTransportErrorDoesNotLeakSession(t *testing.T) {
+	const (
+		accessKeyID     = "FAKE_ACCESS_KEY_ID_SHOULD_NOT_LEAK"
+		secretAccessKey = "FAKE/SECRET+ACCESS=KEY_SHOULD_NOT_LEAK"
+		sessionToken    = "FAKE/SESSION+TOKEN=SHOULD_NOT_LEAK"
+	)
+
+	c, err := NewCloud(CloudConfig{
+		AWSConfigOptions: []awsconfig.OptionsFn{
+			awsconfig.WithBaseCredentialsProvider(credentials.NewStaticCredentialsProvider(accessKeyID, secretAccessKey, sessionToken)),
+			awsconfig.WithSTSClientProvider(mocks.NewAssumeRoleClientProviderFunc(&mocks.STSClient{})),
+		},
+		Logger: slog.New(slog.DiscardHandler),
+	})
+	require.NoError(t, err)
+
+	cloud, ok := c.(*cloud)
+	require.True(t, ok)
+
+	req := &AWSSigninRequest{
+		Identity: &tlsca.Identity{
+			RouteToApp: tlsca.RouteToApp{
+				AWSRoleARN: "arn:aws:iam::123456789012:role/test",
+			},
+			Expires: time.Now().Add(24 * time.Hour),
+		},
+		Issuer: "test",
+	}
+
+	_, err = cloud.getAWSSigninToken(t.Context(), req, "ftp://signin.aws.amazon.com/federation")
+	require.Error(t, err)
+	require.True(t, trace.IsConnectionProblem(err), "expected connection problem, got %v", err)
+	require.Contains(t, err.Error(), "failed to request AWS federation sign-in token")
+
+	errMsg := err.Error()
+	for _, sensitive := range []string{
+		"Session=",
+		"sessionId",
+		"sessionKey",
+		"sessionToken",
+		accessKeyID,
+		secretAccessKey,
+		sessionToken,
+	} {
+		require.NotContains(t, errMsg, sensitive)
+		require.NotContains(t, errMsg, url.QueryEscape(sensitive))
 	}
 }
 

--- a/lib/srv/app/cloud_test.go
+++ b/lib/srv/app/cloud_test.go
@@ -278,15 +278,9 @@ func TestCloudGetAWSSigninToken(t *testing.T) {
 }
 
 func TestCloudGetAWSSigninTokenTransportErrorDoesNotLeakSession(t *testing.T) {
-	const (
-		accessKeyID     = "FAKE_ACCESS_KEY_ID_SHOULD_NOT_LEAK"
-		secretAccessKey = "FAKE/SECRET+ACCESS=KEY_SHOULD_NOT_LEAK"
-		sessionToken    = "FAKE/SESSION+TOKEN=SHOULD_NOT_LEAK"
-	)
-
 	c, err := NewCloud(CloudConfig{
 		AWSConfigOptions: []awsconfig.OptionsFn{
-			awsconfig.WithBaseCredentialsProvider(credentials.NewStaticCredentialsProvider(accessKeyID, secretAccessKey, sessionToken)),
+			awsconfig.WithBaseCredentialsProvider(credentials.NewStaticCredentialsProvider("base-access-key-id", "base-secret-access-key", "base-session-token")),
 			awsconfig.WithSTSClientProvider(mocks.NewAssumeRoleClientProviderFunc(&mocks.STSClient{})),
 		},
 		Logger: slog.New(slog.DiscardHandler),
@@ -313,13 +307,8 @@ func TestCloudGetAWSSigninTokenTransportErrorDoesNotLeakSession(t *testing.T) {
 
 	errMsg := err.Error()
 	for _, sensitive := range []string{
-		"Session=",
-		"sessionId",
-		"sessionKey",
-		"sessionToken",
-		accessKeyID,
-		secretAccessKey,
-		sessionToken,
+		"sessionId", "sessionKey", "sessionToken",
+		"FAKEACCESSKEYID",
 	} {
 		require.NotContains(t, errMsg, sensitive)
 		require.NotContains(t, errMsg, url.QueryEscape(sensitive))


### PR DESCRIPTION
Backport #66753 to branch/v18

changelog: Sanitized AWS console federation transport errors to avoid logging AWS session credential material.
