### PR TITLE
Add Azure Identifiers validators

### DIFF
--- a/lib/cloud/azure/errors.go
+++ b/lib/cloud/azure/errors.go
@@ -19,6 +19,7 @@
 package azure
 
 import (
+	"encoding/json"
 	"errors"
 	"net/http"
 
@@ -46,9 +47,55 @@ func ConvertResponseError(err error) error {
 			return trace.AlreadyExists("%s", responseErr)
 		case http.StatusNotFound:
 			return trace.NotFound("%s", responseErr)
+		case http.StatusTooManyRequests:
+			// TODO(marco): Extract the Retry-After header or any other indication of when we can retry the request.
+			return trace.LimitExceeded("%s", responseErr)
+
+		case http.StatusBadRequest:
+			// Azure API return BadRequest in multiple scenarios, so we need to inspect the error details to ensure we return the most accurate error type.
+			if errorDetails := errorDetails(responseErr); errorDetails != nil {
+				switch errorDetails.Code {
+				case "SubscriptionsContainInvalidGuids":
+					return trace.BadParameter("%s", responseErr)
+
+				case "NoValidSubscriptionsInQueryRequest":
+					return trace.AccessDenied("%s", responseErr)
+				}
+			}
 		}
 	case errors.As(err, &authenticationFailedErr):
 		return trace.AccessDenied("%s", authenticationFailedErr)
 	}
 	return err // Return unmodified.
+}
+
+// errorDetails does a best-effort attempt to extract error details, and may return nil if the detail cannot be extracted for any reason.
+func errorDetails(responseErr *azcore.ResponseError) *apiErrorDetail {
+	if responseErr == nil || responseErr.RawResponse == nil {
+		return nil
+	}
+	body := responseErr.RawResponse.Body
+	defer body.Close()
+
+	var apiErrResp apiResponseError
+	if err := json.NewDecoder(body).Decode(&apiErrResp); err != nil {
+		return nil
+	}
+
+	if len(apiErrResp.Error.Details) == 0 {
+		return nil
+	}
+
+	return &apiErrResp.Error.Details[0]
+}
+
+type apiResponseError struct {
+	Error struct {
+		Details []apiErrorDetail `json:"details"`
+	} `json:"error"`
+}
+
+type apiErrorDetail struct {
+	Code    string `json:"code"`
+	Message string `json:"message"`
 }

--- a/lib/cloud/azure/errors_test.go
+++ b/lib/cloud/azure/errors_test.go
@@ -1,0 +1,205 @@
+/*
+ * Teleport
+ * Copyright (C) 2026 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package azure
+
+import (
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
+	"github.com/gravitational/trace"
+	"github.com/stretchr/testify/require"
+)
+
+// responseWithBody builds an *http.Response carrying the given JSON body so
+// ConvertResponseError's BadRequest branch can exercise errorDetails decoding.
+func responseWithBody(status int, body string) *http.Response {
+	return &http.Response{
+		StatusCode: status,
+		Body:       io.NopCloser(strings.NewReader(body)),
+	}
+}
+
+func TestConvertResponseError(t *testing.T) {
+	t.Parallel()
+
+	badRequestErrorWithUnknownCode := &azcore.ResponseError{
+		StatusCode: http.StatusBadRequest,
+		RawResponse: responseWithBody(http.StatusBadRequest,
+			`{"error":{"details":[{"code":"SomeOtherCode","message":"x"}]}}`),
+	}
+	// The bodyclose linter trips if we don't explicitly close the body, even though it's a no-op in this case.
+	badRequestErrorWithUnknownCode.RawResponse.Body.Close()
+
+	badRequestErrorWithNilBody := &azcore.ResponseError{StatusCode: http.StatusBadRequest}
+
+	badRequestErrorWithInvalidJSON := &azcore.ResponseError{
+		StatusCode:  http.StatusBadRequest,
+		RawResponse: responseWithBody(http.StatusBadRequest, `not-json`),
+	}
+
+	badRequestErrorWithEmptyDetails := &azcore.ResponseError{
+		StatusCode:  http.StatusBadRequest,
+		RawResponse: responseWithBody(http.StatusBadRequest, `{"error":{"details":[]}}`),
+	}
+
+	internalServerError := &azcore.ResponseError{StatusCode: http.StatusInternalServerError}
+
+	nonAzureError := errors.New("non-azure error")
+
+	cases := []struct {
+		name  string
+		err   error
+		check require.ErrorAssertionFunc
+	}{
+		{
+			name:  "nil input returns nil",
+			check: require.NoError,
+		},
+		{
+			name: "403 maps to AccessDenied",
+			err:  &azcore.ResponseError{StatusCode: http.StatusForbidden},
+			check: func(tt require.TestingT, err error, i ...any) {
+				require.True(t, trace.IsAccessDenied(err), "got %T", err)
+			},
+		},
+		{
+			name: "409 maps to AlreadyExists",
+			err:  &azcore.ResponseError{StatusCode: http.StatusConflict},
+			check: func(tt require.TestingT, err error, i ...any) {
+				require.True(t, trace.IsAlreadyExists(err), "got %T", err)
+			},
+		},
+		{
+			name: "404 maps to NotFound",
+			err:  &azcore.ResponseError{StatusCode: http.StatusNotFound},
+			check: func(tt require.TestingT, err error, i ...any) {
+				require.True(t, trace.IsNotFound(err), "got %T", err)
+			},
+		},
+		{
+			name: "429 maps to LimitExceeded",
+			err:  &azcore.ResponseError{StatusCode: http.StatusTooManyRequests},
+			check: func(tt require.TestingT, err error, i ...any) {
+				require.True(t, trace.IsLimitExceeded(err), "got %T", err)
+			},
+		},
+		{
+			name: "400 SubscriptionsContainInvalidGuids maps to BadParameter",
+			err: &azcore.ResponseError{
+				StatusCode: http.StatusBadRequest,
+				RawResponse: responseWithBody(http.StatusBadRequest,
+					`{"error":{"details":[{"code":"SubscriptionsContainInvalidGuids","message":"bad guid"}]}}`),
+			},
+			check: func(tt require.TestingT, err error, i ...any) {
+				require.True(t, trace.IsBadParameter(err), "got %T", err)
+			},
+		},
+		{
+			name: "400 NoValidSubscriptionsInQueryRequest maps to AccessDenied",
+			err: &azcore.ResponseError{
+				StatusCode: http.StatusBadRequest,
+				RawResponse: responseWithBody(http.StatusBadRequest,
+					`{"error":{"details":[{"code":"NoValidSubscriptionsInQueryRequest","message":"no subs"}]}}`),
+			},
+			check: func(tt require.TestingT, err error, i ...any) {
+				require.True(t, trace.IsAccessDenied(err), "got %T", err)
+			},
+		},
+		{
+			name: "400 with unknown details code returns original error",
+			err:  badRequestErrorWithUnknownCode,
+			check: func(tt require.TestingT, err error, i ...any) {
+				require.Same(t, badRequestErrorWithUnknownCode, err, "unknown 400 code must pass through unmodified")
+			},
+		},
+		{
+			name: "400 with nil RawResponse returns original error",
+			err:  badRequestErrorWithNilBody,
+			check: func(tt require.TestingT, err error, i ...any) {
+				require.Same(t, badRequestErrorWithNilBody, err, "400 without RawResponse must pass through unmodified")
+			},
+		},
+		{
+			name: "400 with invalid JSON returns original error",
+			err:  badRequestErrorWithInvalidJSON,
+			check: func(tt require.TestingT, err error, i ...any) {
+				require.Same(t, badRequestErrorWithInvalidJSON, err, "400 with undecodable body must pass through unmodified")
+			},
+		},
+		{
+			name: "400 with empty details returns original error",
+			err:  badRequestErrorWithEmptyDetails,
+			check: func(tt require.TestingT, err error, i ...any) {
+				require.Same(t, badRequestErrorWithEmptyDetails, err, "400 with no details must pass through unmodified")
+			},
+		},
+		{
+			name: "unhandled status code returns original error",
+			err:  internalServerError,
+			check: func(tt require.TestingT, err error, i ...any) {
+				require.Same(t, internalServerError, err, "unhandled status code must pass through unmodified")
+			},
+		},
+		{
+			name: "AuthenticationFailedError maps to AccessDenied",
+			err:  &azidentity.AuthenticationFailedError{},
+			check: func(tt require.TestingT, err error, i ...any) {
+				require.Error(t, err)
+				require.True(t, trace.IsAccessDenied(err), "got %T: %v", err, err)
+			},
+		},
+		{
+			name: "non-Azure error returns original error",
+			err:  nonAzureError,
+			check: func(tt require.TestingT, err error, i ...any) {
+				require.Same(t, nonAzureError, err, "unrelated error types must pass through unmodified")
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := ConvertResponseError(tc.err)
+			tc.check(t, got)
+		})
+	}
+}
+
+func TestConvertResponseError_WrappedErrors(t *testing.T) {
+	t.Parallel()
+
+	t.Run("wrapped ResponseError still maps by status", func(t *testing.T) {
+		wrapped := trace.Wrap(&azcore.ResponseError{StatusCode: http.StatusForbidden}, "while listing")
+		got := ConvertResponseError(wrapped)
+		require.Error(t, got)
+		require.True(t, trace.IsAccessDenied(got), "got %T: %v", got, got)
+	})
+
+	t.Run("wrapped AuthenticationFailedError still maps to AccessDenied", func(t *testing.T) {
+		wrapped := trace.Wrap(&azidentity.AuthenticationFailedError{}, "while authenticating")
+		got := ConvertResponseError(wrapped)
+		require.Error(t, got)
+		require.True(t, trace.IsAccessDenied(got), "got %T: %v", got, got)
+	})
+}

--- a/lib/cloud/azure/identifiers.go
+++ b/lib/cloud/azure/identifiers.go
@@ -1,0 +1,79 @@
+/*
+ * Teleport
+ * Copyright (C) 2026 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package azure
+
+import (
+	"strings"
+	"unicode"
+
+	"github.com/gravitational/trace"
+)
+
+// IsValidResourceGroupName validates that the provided name is a valid Azure Resource Group name.
+// Azure defines the following rules for resource group names:
+// https://learn.microsoft.com/en-us/rest/api/resources/resource-groups/create-or-update
+//
+// > The name of the resource group to create or update.
+// > Can include alphanumeric, underscore, parentheses, hyphen, period (except at end), and Unicode characters that match the allowed characters.
+// > minLength: 1
+// > maxLength: 90
+// > pattern: ^[-\w\._\(\)]+$
+//
+// In this scenario, \w includes characters like á, à, ã, ꣲ, ...
+func IsValidResourceGroupName(name string) error {
+	const allowedSymbols = "-._()"
+	if name == "" || len(name) > 90 {
+		return trace.BadParameter("invalid resource group name")
+	}
+
+	for i, r := range name {
+		// Period is not allowed at the end of the name.
+		if r == '.' && i == len(name)-1 {
+			return trace.BadParameter("invalid resource group name")
+		}
+
+		if unicode.IsLetter(r) || unicode.IsNumber(r) || strings.ContainsRune(allowedSymbols, r) {
+			continue
+		}
+
+		return trace.BadParameter("invalid resource group name")
+	}
+
+	return nil
+}
+
+// IsValidLocationNameWeak validates that the provided name looks to be a valid Azure Location name.
+// Currently active regions are listed here:
+// https://learn.microsoft.com/en-us/azure/reliability/regions-list?tabs=all
+// This is a weak validation that only checks for well formedness of the name, not that it corresponds to an actual Azure region.
+func IsValidLocationNameWeak(name string) error {
+	if name == "" {
+		return trace.BadParameter("invalid location name")
+	}
+
+	for _, r := range name {
+		if r >= 'a' && r <= 'z' || r >= 'A' && r <= 'Z' || r >= '0' && r <= '9' {
+			continue
+		}
+
+		return trace.BadParameter("invalid location name")
+	}
+
+	return nil
+}

--- a/lib/cloud/azure/identifiers_test.go
+++ b/lib/cloud/azure/identifiers_test.go
@@ -1,0 +1,98 @@
+/*
+ * Teleport
+ * Copyright (C) 2026 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package azure
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestIsValidResourceGroupName(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		valid bool
+		name  string
+	}{
+		{true, "valid"},
+		{true, "valid-"},
+		{true, "valid.name"},
+		{true, "valid_"},
+		{true, "valid("},
+		{true, "valid)"},
+		{true, "válíd"},
+		{true, "VALIDNAME"},
+		{true, "ꣲ"},
+
+		{false, ""},
+		{false, strings.Repeat("a", 91)},
+		{false, "invalid."},
+		{false, "invalid name"},
+		{false, "invalid\tname"},
+		{false, "invalid\nname"},
+		{false, "invalid\\name"},
+		{false, "invalid*name"},
+		{false, "invalid~name"},
+		{false, "invalid`name"},
+		{false, "invalid'name"},
+		{false, "invalid'name"},
+		{false, "invalid\"name"},
+		{false, "invalid@name"},
+		{false, "invalid$name"},
+	} {
+		if err := IsValidResourceGroupName(tc.name); (err == nil) != tc.valid {
+			t.Errorf("IsValidResourceGroupName(%q) = %v, want valid=%v", tc.name, err, tc.valid)
+		}
+	}
+}
+
+// Azure UI has the following javascript in the page's source code to validate resource group names:
+// const c = ["\\s", "~", "!", "@", "#", "$", "%", "^", "&", "*", "+", "=", "<", ">", ",", "`", "\\?", "/", "\\\\", "\\:", ";", "'", '"', "\\[", "\\]", "\\{", "\\}", "\\|"].join("")
+// u = new RegExp(`^[^${c}]*[^.${c}]$`,"i")
+// This test ensures that our IsValidResourceGroupName function rejects the same characters as the Azure UI, and thus behaves consistently with it.
+// Note that this regex is not exactly the same as the one in IsValidResourceGroupName, which also checks for length and non-empty string, but this test focuses on the character restrictions.
+func TestIsValidResourceGroupName_usingUIRegex(t *testing.T) {
+	t.Parallel()
+	const invalidChars = " \t\n~!@#$%^&*+=<>,`?/\\:;'\"[]{}|"
+	for _, char := range invalidChars {
+		name := "invalid" + string(char) + "name"
+		if err := IsValidResourceGroupName(name); err == nil {
+			t.Errorf("IsValidResourceGroupName(%q) = nil, want error", name)
+		}
+	}
+}
+
+func TestIsValidLocationNameWeak(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		valid bool
+		name  string
+	}{
+		{true, "eastus"},
+		{true, "eastus2"},
+		{true, "westeurope"},
+		{true, "uksouth"},
+
+		{false, ""},
+		{false, "invalid location"},
+	} {
+		if err := IsValidLocationNameWeak(tc.name); (err == nil) != tc.valid {
+			t.Errorf("IsValidLocationNameWeak(%q) = %v, want valid=%v", tc.name, err, tc.valid)
+		}
+	}
+}


### PR DESCRIPTION
This PR adds Azure identifiers validators: resource groups and locations.
It also adds some more error handling for Azure API responses.

The validations will be used in a coming PR where we will be constructing queries for Azure Resource Graph.