### PR TITLE
Add native review config and app-level client for Slack plugin

### DIFF
--- a/integrations/access/slack/bot.go
+++ b/integrations/access/slack/bot.go
@@ -54,10 +54,15 @@ const statusEmitTimeout = 10 * time.Second
 // action occurs with an access request: a new request popped up, or a
 // request is processed/updated.
 type Bot struct {
-	client      *resty.Client
-	clock       clockwork.Clock
+	// client is the bot-level Slack API client.
+	client *resty.Client
+	// appClient is the app-level Slack API client, used to connect to Slack Socket Mode for native reviews.
+	appClient   *resty.Client
 	clusterName string
 	webProxyURL *url.URL
+	// reviewConfig is the configuration for native review.
+	reviewConfig ReviewConfig
+	clock        clockwork.Clock
 }
 
 // onAfterResponseSlack resty error function for Slack

--- a/integrations/access/slack/cmd/teleport-slack/example_config.toml
+++ b/integrations/access/slack/cmd/teleport-slack/example_config.toml
@@ -22,6 +22,21 @@
 # Slack Bot OAuth token
 token = "xoxb-11xx"
 
+[review]
+# Toggles native review feature. Default is false.
+enabled = false
+# Slack App-level token to enable app interactions via Socket Mode.
+# app_token = "xapp-..."
+#
+# Name of the Teleport trait to resolve Slack user to Teleport user.
+# The trait should hold value of Slack user ID.
+# slack_user_id_trait = "slack_uid"
+#
+# Allows exact Slack email to Teleport username match.
+# This should only be true if `slack_user_id_trait` is not configured in Teleport.
+# We recommend configuring a trait for stronger identity binding. Default is false.
+# allow_email_username_match = false
+
 [role_to_recipients]
 # Map roles to recipients.
 #

--- a/integrations/access/slack/cmd/teleport-slack/example_config.toml
+++ b/integrations/access/slack/cmd/teleport-slack/example_config.toml
@@ -1,4 +1,4 @@
-# Example slack plugin configuration TOML file
+# Example Slack plugin configuration TOML file
 
 [teleport]
 # Teleport Auth/Proxy Server address.
@@ -19,13 +19,30 @@
 # root_cas = "/var/lib/teleport/plugins/slack/auth.cas"   # Teleport CA certs
 
 [slack]
-# Slack Bot OAuth token
+# Slack Bot OAuth token.
+# Provides the plugin permissions to read Slack user info and write to channels.
+# Set this up under "OAuth & Permissions" in your Slack app settings.
+#
+# You can also use an absolute path to a token file, e.g.,
+# "/var/lib/teleport/token"
 token = "xoxb-11xx"
 
 [review]
+# Allows for native review of Teleport Access Requests within Slack.
+# Important: enabling this feature reduces the security of the Teleport cluster.
+# Access Request reviews submitted through Slack are bound to a Slack identity rather than
+# the reviewer's Teleport identity, and bypass Teleport authentication (and MFA for admin actions if enabled on the cluster).
+# As a result, a compromised Slack account can approve requests from Slack and escalate privileges in Teleport.
+#
 # Toggles native review feature. Default is false.
 enabled = false
-# Slack App-level token to enable app interactions via Socket Mode.
+# Slack App-level token.
+# This is different from the Bot OAuth token, and must be set up separately.
+# The App-level token provides the plugin permissions to receive user interactions from Slack.
+# Set this up under "Basic Information" in your Slack app settings.
+#
+# You can also use an absolute path to a token file, e.g.,
+# "/var/lib/teleport/appToken"
 # app_token = "xapp-..."
 #
 # Name of the Teleport trait to resolve Slack user to Teleport user.

--- a/integrations/access/slack/config.go
+++ b/integrations/access/slack/config.go
@@ -37,9 +37,22 @@ import (
 type Config struct {
 	common.BaseConfig
 	Slack               common.GenericAPIConfig
-	AccessTokenProvider auth.AccessTokenProvider
+	Review              ReviewConfig
+	AccessTokenProvider auth.AccessTokenProvider `json:"-"`
+	AppTokenProvider    auth.AccessTokenProvider `json:"-"`
 	StatusSink          common.StatusSink
 	Clock               clockwork.Clock
+}
+
+type ReviewConfig struct {
+	Enabled bool `toml:"enabled"`
+	// AppToken is the app-level token used for Slack Socket Mode API.
+	AppToken string `toml:"app_token"`
+	// SlackUserIDTrait is the name of the Teleport trait to resolve Slack user to Teleport user.
+	SlackUserIDTrait string `toml:"slack_user_id_trait"`
+	// AllowEmailUsernameMatch allows exact Slack email to Teleport username match
+	// for Slack user resolution.
+	AllowEmailUsernameMatch bool `toml:"allow_email_username_match"`
 }
 
 // LoadSlackConfig reads the config file, initializes a new SlackConfig struct object, and returns it.
@@ -62,6 +75,13 @@ func LoadSlackConfig(filepath string) (*Config, error) {
 		}
 	}
 
+	if strings.HasPrefix(conf.Review.AppToken, "/") {
+		conf.Review.AppToken, err = lib.ReadPassword(conf.Review.AppToken)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+	}
+
 	if err := conf.CheckAndSetDefaults(); err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -76,6 +96,10 @@ func (c *Config) CheckAndSetDefaults() error {
 		return trace.Wrap(err)
 	}
 
+	if c.Slack.APIURL == "" {
+		c.Slack.APIURL = slackAPIURL
+	}
+
 	if c.AccessTokenProvider == nil {
 		if c.Slack.Token == "" {
 			return trace.BadParameter("missing required value slack.token")
@@ -84,6 +108,28 @@ func (c *Config) CheckAndSetDefaults() error {
 	} else {
 		if c.Slack.Token != "" {
 			return trace.BadParameter("exactly one of slack.token and AccessTokenProvider must be set")
+		}
+	}
+
+	// Native review config defaults.
+	if c.Review.Enabled {
+		if c.AppTokenProvider == nil {
+			if c.Review.AppToken == "" {
+				return trace.BadParameter("missing required value review.app_token")
+			}
+			c.AppTokenProvider = auth.NewStaticAccessTokenProvider(c.Review.AppToken)
+		} else {
+			if c.Review.AppToken != "" {
+				return trace.BadParameter("exactly one of review.app_token and AppTokenProvider must be set")
+			}
+		}
+
+		// Consider `review.slack_user_id_trait` a critical value that should return error if missing,
+		// since it governs Slack user to Teleport user binding.
+		// However, if user sets `review.allow_email_username_match` to true, and the field is unset,
+		// we assume no trait is set up in Teleport and user wants the fallback logic.
+		if c.Review.SlackUserIDTrait == "" && !c.Review.AllowEmailUsernameMatch {
+			return trace.BadParameter("missing required value review.slack_user_id_trait")
 		}
 	}
 
@@ -124,25 +170,35 @@ func (c *Config) NewBot(clusterName, webProxyAddr string) (common.MessagingBot, 
 		}
 	}
 
-	var apiURL = slackAPIURL
-	if endpoint := c.Slack.APIURL; endpoint != "" {
-		apiURL = endpoint
-	}
-
-	client := makeSlackClient(apiURL).
+	client := makeSlackClient(c.Slack.APIURL).
 		OnBeforeRequest(func(_ *resty.Client, r *resty.Request) error {
-			token, err := c.AccessTokenProvider.GetAccessToken()
+			botToken, err := c.AccessTokenProvider.GetAccessToken()
 			if err != nil {
 				return trace.Wrap(err)
 			}
-			r.SetHeader("Authorization", "Bearer "+token)
+			r.SetAuthToken(botToken)
 			return nil
 		}).
 		OnAfterResponse(onAfterResponseSlack(c.StatusSink))
+
+	// For native review, we require a client with a separate auth header using the app-level token.
+	appClient := makeSlackClient(c.Slack.APIURL).
+		OnBeforeRequest(func(_ *resty.Client, r *resty.Request) error {
+			appToken, err := c.AppTokenProvider.GetAccessToken()
+			if err != nil {
+				return trace.Wrap(err)
+			}
+			r.SetAuthToken(appToken)
+			return nil
+		}).
+		OnAfterResponse(onAfterResponseSlack(c.StatusSink))
+
 	return Bot{
-		client:      client,
-		clock:       c.Clock,
-		clusterName: clusterName,
-		webProxyURL: webProxyURL,
+		client:       client,
+		appClient:    appClient,
+		clusterName:  clusterName,
+		webProxyURL:  webProxyURL,
+		reviewConfig: c.Review,
+		clock:        c.Clock,
 	}, nil
 }

--- a/integrations/access/slack/config.go
+++ b/integrations/access/slack/config.go
@@ -129,7 +129,8 @@ func (c *Config) CheckAndSetDefaults() error {
 		// However, if user sets `review.allow_email_username_match` to true, and the field is unset,
 		// we assume no trait is set up in Teleport and user wants the fallback logic.
 		if c.Review.SlackUserIDTrait == "" && !c.Review.AllowEmailUsernameMatch {
-			return trace.BadParameter("missing required value review.slack_user_id_trait")
+			return trace.BadParameter("missing required value review.slack_user_id_trait." +
+				" Either set up a Teleport trait binding Slack user ID (preferred), or enable review.allow_email_username_match (less secure)")
 		}
 	}
 


### PR DESCRIPTION
Followup PR:
- https://github.com/gravitational/teleport/pull/67217

The review config and app-level client extend the Slack plugin bot to support Slack `ReviewApp` (native review).
Important note: config will be enforced, particularly "review.enabled" checks, in final PR.

Context for reviewers: This supports the upcoming feature for native reviews in Slack, where the Slack plugin submits access reviews to the Teleport Auth Server on behalf of human Slack users.

## Manual Test Plan
### Test Environment

Teleport Cloud. Local Slack plugin.

### Test Cases
- [x] App-level token can be read from absolute path
- [x] If `review.slack_user_id_trait` is empty and `review.allow_email_username_match` is false, return error missing
