### PR TITLE
[docs] Update admonition about Deny Rules in Access Lists

### DIFF
--- a/docs/pages/reference/access-controls/access-lists.mdx
+++ b/docs/pages/reference/access-controls/access-lists.mdx
@@ -50,7 +50,7 @@ Owners are not able to add or remove owners from an Access List or control what 
 and traits are granted by the Access List.
 
 Access List owners are also automatically added as suggested reviewers to any
-Access Requests related to the Access List. 
+Access Requests related to the Access List.
 Learn more in the [Reviewing Access Requests](../../identity-governance/access-lists/reviewing-access-requests.mdx)
 and [Access Request Configuration](../../identity-governance/access-requests/access-request-configuration.mdx#access-list-owners-as-suggested-reviewers)
 guides.
@@ -198,10 +198,12 @@ spec:
 
 ## Access Lists and Deny Rules
 
-Use of [deny rules](./roles.mdx) in Access List roles is discouraged.
-Access Lists are not intended to be used as a tool for privilege reduction,
-and Teleport may assume it is safe to ignore Access Lists under certain conditions.
-Roles intended to reduce privileges should be assigned directly to users.
+Avoid using [deny rules](./roles.mdx) in Access Lists' roles to reduce privileges granted
+by other Access Lists or by statically-assigned roles. Access Lists are not intended as a
+tool for privilege reduction, and relying on them for this is fragile. Losing Access List
+membership removes allow and deny rules alike, but the effects are asymmetric. Lost allow
+rules reduce a user's access; lost deny rules can broaden it. Roles intended to reduce
+privileges should be assigned directly to users instead.
 
 ## Managing Access Lists from the CLI
 

--- a/docs/pages/reference/access-controls/roles.mdx
+++ b/docs/pages/reference/access-controls/roles.mdx
@@ -16,7 +16,8 @@ A Teleport role manages access by having two lists of rules: `allow` rules and
 
 - Nothing is allowed by default.
 - Deny rules get evaluated first and take priority.
-- Deny rules should be avoided on roles granted through Access Lists.
+- Deny rules should be avoided on roles granted through [Access
+Lists](./access-lists.mdx#access-lists-and-deny-rules).
 
 You can use any of the following to manage Teleport roles and other dynamic
 resources:
@@ -289,7 +290,7 @@ allow:
 If this rule was declared in the `deny` section of a role definition, it would
 prohibit users from getting a list of active sessions. If a role does not allow
 access to list a resource, the user will not be able to view it in the Web UI
-or remotely with `tctl`.  The only exception is that a user can always view their 
+or remotely with `tctl`.  The only exception is that a user can always view their
 assigned roles and their own user information with `tctl`.  You can see all of the
 available resources and verbs under the `allow` section in the example role
 configuration below.
@@ -524,8 +525,8 @@ spec:
     - resources: [session]
       verbs: [list, read]
       where: >
-        (contains(session.participants, user.metadata.name) || 
-         contains(user.spec.traits["team"], session.server_labels["team"])) && 
+        (contains(session.participants, user.metadata.name) ||
+         contains(user.spec.traits["team"], session.server_labels["team"])) &&
         session.proto == "ssh"
 ```
 


### PR DESCRIPTION
## Context
Reword admonition about avoiding Deny rules in Access Lists to provide more detail on why this is discouraged. Prior wording was a bit vague.
