### PR TITLE
Implement configuration options for the audit queue

### DIFF
--- a/lib/config/configuration.go
+++ b/lib/config/configuration.go
@@ -667,6 +667,12 @@ func ApplyFileConfig(fc *FileConfig, cfg *servicecfg.Config) error {
 	}
 	cfg.AuthConnectionConfig = *authConnectionConfig
 
+	auditQueue, err := fc.AuditQueue.Parse()
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	cfg.AuditQueue = auditQueue
+
 	cfg.ShutdownDelay = time.Duration(fc.ShutdownDelay)
 
 	// Apply (TLS) cipher suites and (SSH) ciphers, KEX algorithms, and MAC

--- a/lib/config/configuration_test.go
+++ b/lib/config/configuration_test.go
@@ -48,6 +48,7 @@ import (
 	"github.com/gravitational/teleport/lib/backend/lite"
 	"github.com/gravitational/teleport/lib/cryptosuites"
 	"github.com/gravitational/teleport/lib/defaults"
+	"github.com/gravitational/teleport/lib/events/auditqueue"
 	"github.com/gravitational/teleport/lib/fixtures"
 	"github.com/gravitational/teleport/lib/limiter"
 	"github.com/gravitational/teleport/lib/modules"
@@ -6441,4 +6442,34 @@ func TestSignatureAlgorithmSuite(t *testing.T) {
 			require.NoError(t, err)
 		})
 	}
+}
+
+func TestApplyAuditQueueConfig(t *testing.T) {
+	t.Parallel()
+	text := editConfig(t, func(cfg cfgMap) {
+		cfg["teleport"].(cfgMap)["audit_queue"] = cfgMap{
+			"soft_limit":                 "50MiB",
+			"hard_limit":                 "500MiB",
+			"max_attempts":               3,
+			"dead_letter_ttl":            "48h",
+			"dead_letter_sweep_interval": "10m",
+			"orphan_scan_interval":       "15m",
+			"backend":                    []any{auditqueue.KindSQLiteDisk, auditqueue.KindSQLiteMemory},
+			"synchronous":                auditqueue.SynchronousFull,
+		}
+	})
+	fc, err := ReadConfig(bytes.NewReader(text))
+	require.NoError(t, err)
+	cfg := servicecfg.MakeDefaultConfig()
+	require.NoError(t, ApplyFileConfig(fc, cfg))
+	require.Equal(t, servicecfg.AuditQueueConfig{
+		SoftLimit:               50 * 1024 * 1024,
+		MaxBytes:                500 * 1024 * 1024,
+		MaxAttempts:             3,
+		DeadLetterTTL:           48 * time.Hour,
+		DeadLetterSweepInterval: 10 * time.Minute,
+		OrphanScanInterval:      15 * time.Minute,
+		Backends:                []string{"sqlite_disk", "sqlite_memory"},
+		Synchronous:             "FULL",
+	}, cfg.AuditQueue)
 }

--- a/lib/config/fileconf.go
+++ b/lib/config/fileconf.go
@@ -36,6 +36,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/dustin/go-humanize"
 	"github.com/gravitational/trace"
 	"golang.org/x/crypto/acme"
 	"golang.org/x/crypto/ssh"
@@ -52,6 +53,7 @@ import (
 	"github.com/gravitational/teleport/lib/automaticupgrades"
 	"github.com/gravitational/teleport/lib/backend"
 	"github.com/gravitational/teleport/lib/defaults"
+	"github.com/gravitational/teleport/lib/events/auditqueue"
 	"github.com/gravitational/teleport/lib/scopes"
 	"github.com/gravitational/teleport/lib/scopes/joining"
 	"github.com/gravitational/teleport/lib/service/servicecfg"
@@ -705,6 +707,69 @@ type Global struct {
 
 	// AuthConnectionConfig defines the parameters used to connect to the Auth Service.
 	AuthConnectionConfig AuthConnectionConfig `yaml:"auth_connection_config,omitempty"`
+
+	// AuditQueue is used for configuration options for the audit log event
+	// queue.
+	AuditQueue AuditQueueConfig `yaml:"audit_queue,omitempty"`
+}
+
+// AuditQueueConfig is used to control the audit log event queue.
+type AuditQueueConfig struct {
+	// SoftLimit is the database file size when we start warning.
+	SoftLimit string `yaml:"soft_limit,omitempty"`
+	// HardLimit is the database file size when we start dropping events.
+	HardLimit string `yaml:"hard_limit,omitempty"`
+	// MaxAttempts is the maximum number of times we retry sending an event
+	// before moving it to the dead-letter queue.
+	MaxAttempts int `yaml:"max_attempts,omitempty"`
+	// DeadLetterTTL is the time to live for an event in the dead-letter queue
+	// before we delete it.
+	DeadLetterTTL types.Duration `yaml:"dead_letter_ttl,omitempty"`
+	// DeadLetterSweepInterval is how often the dead-letter sweeper attempts to
+	// redeliver failed events.
+	DeadLetterSweepInterval types.Duration `yaml:"dead_letter_sweep_interval,omitempty"`
+	// OrphanScanInterval is how often the process scans for orphaned queues.
+	OrphanScanInterval types.Duration `yaml:"orphan_scan_interval,omitempty"`
+	// Backend is the ordered list of preferred audit queue backends.
+	Backend []string `yaml:"backend,omitempty"`
+	// Synchronous can either be NORMAL or FULL, depending on the tradeoffs
+	// between durability and performance we want to make
+	Synchronous string `yaml:"synchronous,omitempty"`
+}
+
+// Parse parses the audit log options from the Teleport config.
+func (a *AuditQueueConfig) Parse() (servicecfg.AuditQueueConfig, error) {
+	out := servicecfg.AuditQueueConfig{
+		MaxAttempts:             a.MaxAttempts,
+		DeadLetterTTL:           a.DeadLetterTTL.Value(),
+		DeadLetterSweepInterval: a.DeadLetterSweepInterval.Value(),
+		OrphanScanInterval:      a.OrphanScanInterval.Value(),
+		Backends:                a.Backend,
+	}
+	if a.SoftLimit != "" {
+		v, err := humanize.ParseBytes(a.SoftLimit)
+		if err != nil {
+			return out, trace.BadParameter("invalid audit_queue.soft_limit %q: %v", a.SoftLimit, err)
+		}
+		out.SoftLimit = int64(v)
+	}
+	if a.HardLimit != "" {
+		v, err := humanize.ParseBytes(a.HardLimit)
+		if err != nil {
+			return out, trace.BadParameter("invalid audit_queue.hard_limit %q: %v", a.HardLimit, err)
+		}
+		out.MaxBytes = int64(v)
+	}
+	switch auditqueue.SynchronousMode(a.Synchronous) {
+	case "", auditqueue.SynchronousNormal:
+		out.Synchronous = auditqueue.SynchronousNormal
+	case auditqueue.SynchronousFull:
+		out.Synchronous = auditqueue.SynchronousFull
+	default:
+		return out, trace.BadParameter("invalid audit_queue.synchronous %q: must be %q or %q",
+			a.Synchronous, auditqueue.SynchronousNormal, auditqueue.SynchronousFull)
+	}
+	return out, nil
 }
 
 // CachePolicy is used to control  local cache

--- a/lib/config/fileconf_test.go
+++ b/lib/config/fileconf_test.go
@@ -41,6 +41,7 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	apiutils "github.com/gravitational/teleport/api/utils"
 	"github.com/gravitational/teleport/lib/defaults"
+	"github.com/gravitational/teleport/lib/events/auditqueue"
 	"github.com/gravitational/teleport/lib/scopes/joining"
 	"github.com/gravitational/teleport/lib/service/servicecfg"
 	"github.com/gravitational/teleport/session/networking/x11"
@@ -1932,4 +1933,85 @@ func TestMakeSampleFileConfig(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, apiutils.Strings{"sha256:7e12c17c20d9cb", "sha256:7e12c17c20d9cb"}, fc.CAPin)
 	})
+}
+
+func TestAuditQueueConfig_Parse(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		desc      string
+		cfg       AuditQueueConfig
+		want      servicecfg.AuditQueueConfig
+		assertErr require.ErrorAssertionFunc
+	}{
+		{
+			desc: "empty",
+			cfg:  AuditQueueConfig{},
+			want: servicecfg.AuditQueueConfig{
+				Synchronous: auditqueue.SynchronousNormal,
+			},
+			assertErr: require.NoError,
+		},
+		{
+			desc: "valid fields",
+			cfg: AuditQueueConfig{
+				SoftLimit:               "100MiB",
+				HardLimit:               "1GiB",
+				MaxAttempts:             5,
+				DeadLetterTTL:           types.Duration(24 * time.Hour),
+				DeadLetterSweepInterval: types.Duration(5 * time.Minute),
+				OrphanScanInterval:      types.Duration(10 * time.Minute),
+				Backend:                 []string{"sqlite_disk", "sqlite_memory"},
+			},
+			want: servicecfg.AuditQueueConfig{
+				SoftLimit:               100 * 1024 * 1024,
+				MaxBytes:                1024 * 1024 * 1024,
+				MaxAttempts:             5,
+				DeadLetterTTL:           24 * time.Hour,
+				DeadLetterSweepInterval: 5 * time.Minute,
+				OrphanScanInterval:      10 * time.Minute,
+				Backends:                []string{"sqlite_disk", "sqlite_memory"},
+				Synchronous:             auditqueue.SynchronousNormal,
+			},
+			assertErr: require.NoError,
+		},
+		{
+			desc: "synchronous FULL",
+			cfg:  AuditQueueConfig{Synchronous: "FULL"},
+			want: servicecfg.AuditQueueConfig{
+				Synchronous: auditqueue.SynchronousFull,
+			},
+			assertErr: require.NoError,
+		},
+		{
+			desc: "invalid soft_limit",
+			cfg:  AuditQueueConfig{SoftLimit: "not-a-size"},
+			assertErr: func(t require.TestingT, err error, _ ...any) {
+				require.True(t, trace.IsBadParameter(err))
+			},
+		},
+		{
+			desc: "invalid hard_limit",
+			cfg:  AuditQueueConfig{HardLimit: "not-a-size"},
+			assertErr: func(t require.TestingT, err error, _ ...any) {
+				require.True(t, trace.IsBadParameter(err))
+			},
+		},
+		{
+			desc: "invalid synchronous",
+			cfg:  AuditQueueConfig{Synchronous: "OFF"},
+			assertErr: func(t require.TestingT, err error, _ ...any) {
+				require.True(t, trace.IsBadParameter(err))
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			t.Parallel()
+			got, err := tt.cfg.Parse()
+			tt.assertErr(t, err)
+			if err == nil {
+				require.Equal(t, tt.want, got)
+			}
+		})
+	}
 }

--- a/lib/events/auditqueue/auditqueue.go
+++ b/lib/events/auditqueue/auditqueue.go
@@ -52,6 +52,19 @@ const (
 	KindSQLiteMemory Kind = "sqlite_memory"
 )
 
+// SynchronousMode controls the SQLite synchronous pragma.
+type SynchronousMode string
+
+const (
+	// SynchronousNormal commits are durable against OS crashes but not against
+	// power loss mid-write. This is the default for SQLite and is safe for most
+	// use cases in WAL mode.
+	SynchronousNormal SynchronousMode = "NORMAL"
+	// SynchronousFull syncs to disk before each commit, providing full
+	// durability at the cost of higher write latency.
+	SynchronousFull SynchronousMode = "FULL"
+)
+
 // Config configures a Queue.
 type Config struct {
 	// Path is the path to the directory used by the audit log queue.
@@ -73,6 +86,8 @@ type Config struct {
 	// DeadLetterTTL is the maximum age of a dead-letter event before it is
 	// permanently deleted.
 	DeadLetterTTL time.Duration
+	// Synchronous controls the SQLite synchronous pragma.
+	Synchronous SynchronousMode
 }
 
 // Item is an event yielded to a Handler.

--- a/lib/events/auditqueue/auditqueue_test.go
+++ b/lib/events/auditqueue/auditqueue_test.go
@@ -457,6 +457,62 @@ func TestRun_DeadLetter_RedeliversAfterRecovery(t *testing.T) {
 	}
 }
 
+func TestEnqueueDequeue_RoundTrip(t *testing.T) {
+	t.Parallel()
+
+	original := &apievents.UserLogin{
+		Metadata: apievents.Metadata{
+			Type:        "user.login",
+			Code:        "T1000I",
+			Index:       42,
+			ClusterName: "my-cluster",
+		},
+		UserMetadata: apievents.UserMetadata{
+			User:  "alice",
+			Login: "root",
+		},
+		ConnectionMetadata: apievents.ConnectionMetadata{
+			RemoteAddr: "1.2.3.4:5678",
+			Protocol:   "ssh",
+		},
+		Status: apievents.Status{
+			Success: true,
+		},
+		Method: "local",
+	}
+
+	for _, kind := range allKinds {
+		t.Run(string(kind), func(t *testing.T) {
+			t.Parallel()
+			ctx := t.Context()
+			runCtx, cancel := context.WithCancel(ctx)
+			t.Cleanup(cancel)
+
+			q := newTestQueue(t, kind)
+
+			require.NoError(t, q.Enqueue(original))
+
+			delivered := make(chan apievents.AuditEvent, 1)
+			handler := func(_ context.Context, items []Item) []Item {
+				for _, item := range items {
+					delivered <- item.Event
+				}
+				return items
+			}
+
+			runErr := make(chan error, 1)
+			go func() { runErr <- q.Run(runCtx, handler) }()
+
+			got := <-delivered
+			require.IsType(t, original, got)
+			require.Equal(t, original, got)
+
+			cancel()
+			require.ErrorIs(t, <-runErr, context.Canceled)
+		})
+	}
+}
+
 func BenchmarkEnqueue(b *testing.B) {
 	for _, kind := range allKinds {
 		b.Run(string(kind), func(b *testing.B) {

--- a/lib/events/auditqueue/sqlite.go
+++ b/lib/events/auditqueue/sqlite.go
@@ -138,6 +138,7 @@ type sqliteQueue struct {
 	maxAttempts             int
 	deadLetterSweepInterval time.Duration
 	deadLetterTTL           time.Duration
+	synchronous             SynchronousMode
 	// deadLetterKick wakes the dead-letter sweeper ahead of its timer. It has
 	// capacity 1 so pending kicks coalesce into a single sweep.
 	deadLetterKick chan struct{}
@@ -191,6 +192,7 @@ func newBaseQueue(db *sql.DB, cfg Config) (*sqliteQueue, error) {
 		maxAttempts:             maxAttempts,
 		deadLetterSweepInterval: deadLetterSweepInterval,
 		deadLetterTTL:           deadLetterTTL,
+		synchronous:             cfg.Synchronous,
 		deadLetterKick:          make(chan struct{}, 1),
 	}
 

--- a/lib/events/auditqueue/sqlite_disk.go
+++ b/lib/events/auditqueue/sqlite_disk.go
@@ -63,11 +63,14 @@ const (
 	staleTmpThreshold = time.Hour
 )
 
-func getDSN(dbPath string, maxBytes int64) string {
+func getDSN(dbPath string, maxBytes int64, synchronous SynchronousMode) string {
+	if synchronous == "" {
+		synchronous = SynchronousNormal
+	}
 	params := url.Values{}
 	params.Add("_pragma", "auto_vacuum(INCREMENTAL)")
 	params.Add("_pragma", "journal_mode(WAL)")
-	params.Add("_pragma", "synchronous(NORMAL)")
+	params.Add("_pragma", fmt.Sprintf("synchronous(%s)", synchronous))
 	params.Add("_pragma", fmt.Sprintf("journal_size_limit(%d)", walJournalSizeLimit))
 	addSharedParams(params, maxBytes)
 	u := url.URL{
@@ -89,7 +92,7 @@ func newSQLiteQueue(cfg Config) (*sqliteQueue, error) {
 		return nil, trace.Wrap(err)
 	}
 
-	db, err := initializeDb(cfg.Path, cfg.MaxBytes)
+	db, err := initializeDb(cfg.Path, cfg.MaxBytes, cfg.Synchronous)
 	if err != nil {
 		_ = unlock()
 		_ = os.RemoveAll(cfg.Path)
@@ -147,13 +150,13 @@ func newSQLiteQueue(cfg Config) (*sqliteQueue, error) {
 	return q, nil
 }
 
-func initializeDb(path string, maxBytes int64) (*sql.DB, error) {
+func initializeDb(path string, maxBytes int64, synchronous SynchronousMode) (*sql.DB, error) {
 	if maxBytes <= 0 {
 		maxBytes = defaultMaxBytes
 	}
 
 	dbPath := filepath.Join(path, queueDBFile)
-	db, err := sql.Open("sqlite", getDSN(dbPath, maxBytes))
+	db, err := sql.Open("sqlite", getDSN(dbPath, maxBytes, synchronous))
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -474,7 +477,7 @@ func (q *sqliteQueue) tryAdoptOrphan(ctx context.Context, path string) {
 	}()
 
 	dbFilePath := filepath.Join(path, queueDBFile)
-	db, err := sql.Open("sqlite", getDSN(dbFilePath, defaultMaxBytes))
+	db, err := sql.Open("sqlite", getDSN(dbFilePath, defaultMaxBytes, q.synchronous))
 	if err != nil {
 		orphanScanErrors.Inc()
 		slog.ErrorContext(q.ctx, "Failed to open orphan SQLite database.", "path", path, "error", err)

--- a/lib/events/auditqueue/sqlite_test.go
+++ b/lib/events/auditqueue/sqlite_test.go
@@ -434,6 +434,31 @@ func TestEnqueue_FullReturnsErrQueueFull(t *testing.T) {
 		"Enqueue should map SQLITE_FULL to ErrQueueFull; got %v", got)
 }
 
+func TestEnqueue_FileSizeStaysWithinMaxBytes(t *testing.T) {
+	t.Parallel()
+
+	const maxBytes = 50 * sqlitePageSize
+	path := filepath.Join(t.TempDir(), "queue")
+	q, err := newSQLiteQueue(Config{
+		Path:     path,
+		MaxBytes: maxBytes,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = q.Close() })
+
+	for i := range 10000 {
+		if err := q.Enqueue(newTestEvent(int64(i))); err != nil {
+			require.ErrorIs(t, err, ErrQueueFull)
+			break
+		}
+	}
+
+	info, err := os.Stat(filepath.Join(path, queueDBFile))
+	require.NoError(t, err)
+	require.LessOrEqual(t, info.Size(), int64(maxBytes),
+		"queue.db size %d exceeded MaxBytes %d", info.Size(), maxBytes)
+}
+
 func TestOrphanAdoption_DrainsAndDeletes(t *testing.T) {
 	t.Parallel()
 	parent := t.TempDir()
@@ -842,7 +867,7 @@ func TestIsSQLiteFullError(t *testing.T) {
 	t.Parallel()
 
 	dbPath := filepath.Join(t.TempDir(), "test.db")
-	db, err := sql.Open("sqlite", getDSN(dbPath, 10*sqlitePageSize))
+	db, err := sql.Open("sqlite", getDSN(dbPath, 10*sqlitePageSize, SynchronousNormal))
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = db.Close() })
 

--- a/lib/events/emitter.go
+++ b/lib/events/emitter.go
@@ -40,8 +40,12 @@ import (
 	"github.com/gravitational/teleport/lib/utils"
 )
 
-// AsyncBufferSize is a default buffer size for async emitters
-const AsyncBufferSize = 1024
+const (
+	// AsyncBufferSize is a default buffer size for async emitters
+	AsyncBufferSize = 1024
+	// auditQueueDir is the directory where the audit queue resides.
+	auditQueueDir = "audit-queue"
+)
 
 // AsyncEmitterConfig provides parameters for emitter
 type AsyncEmitterConfig struct {
@@ -55,6 +59,10 @@ type AsyncEmitterConfig struct {
 	// EnableSQLiteQueue enables the SQLite-backed audit queue. When false,
 	// the legacy in-memory channel is used.
 	EnableSQLiteQueue bool
+	// AuditQueueCfg holds the options from the Teleport yaml config.
+	AuditQueueCfg auditqueue.Config
+	// AuditQueueBackends is the ordered list of backends to try on startup.
+	AuditQueueBackends []auditqueue.Kind
 }
 
 // CheckAndSetDefaults checks and sets default values
@@ -79,7 +87,7 @@ func NewAsyncEmitter(cfg AsyncEmitterConfig) (*AsyncEmitter, error) {
 	var queue auditqueue.Queue
 	if cfg.EnableSQLiteQueue {
 		var err error
-		queue, err = makeQueue(cfg.DataDir)
+		queue, err = makeQueue(cfg)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
@@ -111,17 +119,35 @@ func NewAsyncEmitter(cfg AsyncEmitterConfig) (*AsyncEmitter, error) {
 	return a, nil
 }
 
-func makeQueue(dataDir string) (auditqueue.Queue, error) {
-	queuePath := filepath.Join(dataDir, "audit-queue", uuid.NewString())
-	queueCfg := auditqueue.Config{
-		Path: queuePath,
-	}
-	queue, err := auditqueue.New(auditqueue.KindSQLiteDisk, queueCfg)
-	if err != nil {
-		return nil, trace.Wrap(err)
+func makeQueue(cfg AsyncEmitterConfig) (auditqueue.Queue, error) {
+	queueCfg := cfg.AuditQueueCfg
+	queueCfg.Path = filepath.Join(cfg.DataDir, auditQueueDir, uuid.NewString())
+
+	backends := cfg.AuditQueueBackends
+	if len(backends) == 0 {
+		backends = []auditqueue.Kind{auditqueue.KindSQLiteDisk}
 	}
 
-	return queue, nil
+	var lastErr error
+	for i, backend := range backends {
+		q, err := auditqueue.New(backend, queueCfg)
+		if err == nil {
+			if i > 0 {
+				slog.WarnContext(context.TODO(),
+					"Using fallback audit queue backend.",
+					"backend", backend,
+				)
+			}
+			return q, nil
+		}
+		slog.WarnContext(context.TODO(),
+			"Failed to create audit queue backend, trying next.",
+			"backend", backend,
+			"error", err,
+		)
+		lastErr = err
+	}
+	return nil, trace.Wrap(lastErr)
 }
 
 // AsyncEmitter accepts events to a buffered channel and emits

--- a/lib/events/emitter_test.go
+++ b/lib/events/emitter_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/gravitational/teleport"
 	apievents "github.com/gravitational/teleport/api/types/events"
 	"github.com/gravitational/teleport/lib/events"
+	"github.com/gravitational/teleport/lib/events/auditqueue"
 	"github.com/gravitational/teleport/lib/events/eventstest"
 	"github.com/gravitational/teleport/lib/session"
 	"github.com/gravitational/teleport/lib/utils"
@@ -310,4 +311,70 @@ func TestExport(t *testing.T) {
 	}
 	require.NoError(t, snl.Err())
 	require.Len(t, outEvents, count)
+}
+
+func TestAsyncEmitterAuditQueueBackends(t *testing.T) {
+	ctx := t.Context()
+
+	t.Run("in-memory backend", func(t *testing.T) {
+		emitter, err := events.NewAsyncEmitter(events.AsyncEmitterConfig{
+			Inner:              eventstest.NewChannelEmitter(10),
+			EnableSQLiteQueue:  true,
+			AuditQueueBackends: []auditqueue.Kind{auditqueue.KindSQLiteMemory},
+		})
+		require.NoError(t, err)
+		defer emitter.Close()
+		err = emitter.EmitAuditEvent(ctx, &apievents.UserLogin{
+			Metadata: apievents.Metadata{
+				Type: events.UserLoginEvent,
+				Code: events.UserLocalLoginCode,
+			},
+		})
+		require.NoError(t, err)
+	})
+
+	t.Run("fallback to in-memory", func(t *testing.T) {
+		emitter, err := events.NewAsyncEmitter(events.AsyncEmitterConfig{
+			Inner:              eventstest.NewChannelEmitter(10),
+			EnableSQLiteQueue:  true,
+			AuditQueueBackends: []auditqueue.Kind{"invalid_backend", auditqueue.KindSQLiteMemory},
+		})
+		require.NoError(t, err)
+		defer emitter.Close()
+	})
+
+	t.Run("all backends fail", func(t *testing.T) {
+		_, err := events.NewAsyncEmitter(events.AsyncEmitterConfig{
+			Inner:              eventstest.NewChannelEmitter(10),
+			EnableSQLiteQueue:  true,
+			AuditQueueBackends: []auditqueue.Kind{"invalid_backend"},
+		})
+		require.Error(t, err)
+	})
+
+	t.Run("delivers to inner emitter", func(t *testing.T) {
+		inner := eventstest.NewChannelEmitter(1)
+		emitter, err := events.NewAsyncEmitter(events.AsyncEmitterConfig{
+			Inner:              inner,
+			EnableSQLiteQueue:  true,
+			AuditQueueBackends: []auditqueue.Kind{auditqueue.KindSQLiteMemory},
+		})
+		require.NoError(t, err)
+		defer emitter.Close()
+
+		sent := &apievents.UserLogin{
+			Metadata: apievents.Metadata{
+				Type: events.UserLoginEvent,
+				Code: events.UserLocalLoginCode,
+			},
+		}
+		require.NoError(t, emitter.EmitAuditEvent(ctx, sent))
+
+		select {
+		case got := <-inner.C():
+			require.Equal(t, sent, got)
+		case <-time.After(5 * time.Second):
+			t.Fatal("event was never delivered to inner emitter")
+		}
+	})
 }

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -132,6 +132,7 @@ import (
 	devicetrustgrpcproxy "github.com/gravitational/teleport/lib/devicetrust/grpcproxy"
 	"github.com/gravitational/teleport/lib/events"
 	"github.com/gravitational/teleport/lib/events/athena"
+	"github.com/gravitational/teleport/lib/events/auditqueue"
 	"github.com/gravitational/teleport/lib/events/azsessions"
 	"github.com/gravitational/teleport/lib/events/dynamoevents"
 	"github.com/gravitational/teleport/lib/events/filesessions"
@@ -3482,6 +3483,11 @@ func isSQLiteQueueEnabled() bool {
 // NewAsyncEmitter wraps client and returns emitter that never blocks, logs some events and checks values.
 // It is caller's responsibility to call Close on the emitter once done.
 func (process *TeleportProcess) NewAsyncEmitter(clt apievents.Emitter) (*events.CheckingAsyncEmitter, error) {
+	var backends []auditqueue.Kind
+	for _, backend := range process.Config.AuditQueue.Backends {
+		backends = append(backends, auditqueue.Kind(backend))
+	}
+
 	// Wrap the AsyncEmitter in a CheckingEmitter to ensure event fields are
 	// properly set before inserting events into the queue.
 	return events.NewCheckingAsyncEmitter(
@@ -3492,6 +3498,16 @@ func (process *TeleportProcess) NewAsyncEmitter(clt apievents.Emitter) (*events.
 			Inner:             events.NewMultiEmitter(events.NewLoggingEmitter(process.GetClusterFeatures().Cloud), clt),
 			DataDir:           process.Config.DataDir,
 			EnableSQLiteQueue: isSQLiteQueueEnabled(),
+			AuditQueueCfg: auditqueue.Config{
+				SoftLimit:               process.Config.AuditQueue.SoftLimit,
+				MaxBytes:                process.Config.AuditQueue.MaxBytes,
+				MaxAttempts:             process.Config.AuditQueue.MaxAttempts,
+				DeadLetterTTL:           process.Config.AuditQueue.DeadLetterTTL,
+				DeadLetterSweepInterval: process.Config.AuditQueue.DeadLetterSweepInterval,
+				OrphanScanInterval:      process.Config.AuditQueue.OrphanScanInterval,
+				Synchronous:             process.Config.AuditQueue.Synchronous,
+			},
+			AuditQueueBackends: backends,
 		},
 	)
 }

--- a/lib/service/servicecfg/auditqueue.go
+++ b/lib/service/servicecfg/auditqueue.go
@@ -1,0 +1,48 @@
+/*
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package servicecfg
+
+import (
+	"time"
+
+	"github.com/gravitational/teleport/lib/events/auditqueue"
+)
+
+// AuditQueueConfig is used to control the audit log event queue.
+type AuditQueueConfig struct {
+	// SoftLimit is the database file size when we start warning.
+	SoftLimit int64
+	// HardLimit is the database file size when we start dropping events.
+	MaxBytes int64
+	// MaxAttempts is the maximum number of times we retry sending an event
+	// before moving it to the dead-letter queue.
+	MaxAttempts int
+	// DeadLetterTTL is the time to live for an event in the dead-letter queue
+	// before we delete it.
+	DeadLetterTTL time.Duration
+	// DeadLetterSweepInterval is how often the dead-letter sweeper attempts to
+	// redeliver failed events.
+	DeadLetterSweepInterval time.Duration
+	// OrphanScanInterval is how often the process scans for orphaned queues.
+	OrphanScanInterval time.Duration
+	// Backend is the ordered list of preferred audit queue backends.
+	Backends []string
+	// Synchronous controls the SQLite synchronous pragma.
+	Synchronous auditqueue.SynchronousMode
+}

--- a/lib/service/servicecfg/config.go
+++ b/lib/service/servicecfg/config.go
@@ -99,6 +99,9 @@ type Config struct {
 	// the beginning of the shutdown procedures.
 	ShutdownDelay time.Duration
 
+	// AuditQueue configures the audit log event queue.
+	AuditQueue AuditQueueConfig
+
 	// Auth service configuration. Manages cluster state and configuration.
 	Auth AuthConfig
 


### PR DESCRIPTION
Changelog: Implement configuration options for the audit queue.

This PR is the fourth in what will be multiple PRs that implement [RFD 254](https://github.com/gravitational/teleport.e/pull/8641)

This implements the configuration options for the audit log queue as described in the RFD. As requested, the queue implements a fallback mechanism where the operator may specify an ordered list of audit log queue backends to use. If we encounter an error constructing a queue backend, we will fallback to the next option to try.

## Previous PRs in this project:
1. https://github.com/gravitational/teleport/pull/66883 
2. https://github.com/gravitational/teleport/pull/67019
3. https://github.com/gravitational/teleport/pull/67095

## Features in this PR

This PR implements a subset of the RFD. The rest of the RFD will be implemented in future PRs. This PR implements the following feature set as described in the RFD:
- teleport.yaml configuration options.
- Fallback to next audit log backend option on error.

## Features that will be included in future PRs

Outstanding items that will be implemented in follow-up PR(s) include:
- tctl additions for audit queue observability.
- Protobuf changes.
- Encryption at rest (deferred to v19)
- Integration tests.
- Graceful shutdown drain.
- Skipping events that fail to deserialize.

## Manual Test Plan

I have tested this feature by running an enterprise build of the binary, verifying audit log events are being displayed correctly in the web UI, then I ran benchmarks using `tsh bench`.

### Test Environment

This has been tested on a Linux AMD64 machine.

### Test Cases

- [x] Verify audit log events show up in web UI as expected.
- [x] Benchmark that SQLite based queue can handle at least the level of traffic as in-memory version.
- [x] Verify we we don't see warnings of dropped audit log events.

### Test Description

This has been tested by running an enterprise binary like so:
```sh
TELEPORT_UNSTABLE_AUDIT_LOG_RELIABILITY=true ./e/build/teleport start --config="/etc/teleport.yaml"
```

From there, I observed that audit log events get propagated to the web UI as expected.

Next, I ran the following benchmark. Running the following `tsh` bench on the legacy audit log queue causes events to be dropped.

```sh
tsh bench --duration=60s --rate=224 ssh root@<TEST_MACHINE> "echo hi"
```

Running with the SQLite based audit log queue enabled results in the following count of audit log events being emitted:

```sh
$ curl -s localhost:3000/metrics | grep teleport_audit_emit_events
# HELP teleport_audit_emit_events Number of audit events emitted
# TYPE teleport_audit_emit_events counter
teleport_audit_emit_events 134179
```