### PR TITLE
[v18] service: use GracefulExitContext on event waiting

### DIFF
--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -910,7 +910,7 @@ func (process *TeleportProcess) addConnector(connector *Connector) {
 
 // WaitForConnector is a utility function to wait for an identity event and cast
 // the resulting payload as a *Connector. Returns (nil, nil) when the
-// ExitContext is done, so error checking should happen on the connector rather
+// GracefulExitContext is done, so error checking should happen on the connector rather
 // than the error:
 //
 //	conn, err := process.WaitForConnector("FooIdentity", log)
@@ -918,7 +918,7 @@ func (process *TeleportProcess) addConnector(connector *Connector) {
 //		return trace.Wrap(err)
 //	}
 func (process *TeleportProcess) WaitForConnector(identityEvent string, log *slog.Logger) (*Connector, error) {
-	event, err := process.WaitForEvent(process.ExitContext(), identityEvent)
+	event, err := process.WaitForEvent(process.GracefulExitContext(), identityEvent)
 	if err != nil {
 		if log != nil {
 			log.DebugContext(process.ExitContext(), "Process is exiting.")


### PR DESCRIPTION
Backport #67146 to branch/v18

It was observed in cloud that proxies will hang on deletion if they lose connection to auth prior to being terminated. This will cause pods to hang until the termination grace period is hit which can be quite long in some cases. Testing this in cloud allowed disconnected proxies to exit quickly when terminated.