### PR TITLE
[v18] Adding missing validations when creating scoped join tokens

### DIFF
--- a/lib/scopes/joining/token.go
+++ b/lib/scopes/joining/token.go
@@ -137,6 +137,134 @@ func validateKubernetes(kube *joiningv1.Kubernetes) error {
 	return nil
 }
 
+// validates the given AWS EC2 configuration. Also implemented by
+// api/types/provisioning.go:ProvisionTokenV2.CheckAndSetDefaults() for unscoped tokens
+func validateEC2(aws *joiningv1.AWS) error {
+	ttl := aws.GetIidTtl()
+	if _, err := types.ParseDuration(ttl); ttl != "" && err != nil {
+		return trace.BadParameter("invalid IID TTL value %q, must be empty or a valid duration string (e.g. 30m, 12h, 1mo)", ttl)
+	}
+
+	if len(aws.GetAllow()) == 0 {
+		return trace.BadParameter("aws configuration with at least one allow rule must be defined")
+	}
+
+	for i, rule := range aws.GetAllow() {
+		if rule.GetAwsArn() != "" {
+			return trace.BadParameter(`allow[%d]: "aws_arn" parameter not supported`, i)
+		}
+		if rule.GetAwsOrganizationId() != "" {
+			return trace.BadParameter(`allow[%d]: "aws_organization_id" parameter not supported`, i)
+		}
+		if rule.GetAwsAccount() == "" && rule.GetAwsRole() == "" {
+			return trace.BadParameter(`allow[%d]: must set "aws_account" or "aws_role"`, i)
+		}
+	}
+
+	return nil
+}
+
+// validates the given AWS IAM configuration. Also implemented by
+// api/types/provisioning.go:ProvisionTokenV2.CheckAndSetDefaults() for unscoped tokens
+func validateIAM(aws *joiningv1.AWS) error {
+	if len(aws.GetAllow()) == 0 {
+		return trace.BadParameter("aws configuration with at least one allow rule must be defined")
+	}
+
+	for i, rule := range aws.GetAllow() {
+		if rule.GetAwsRole() != "" {
+			return trace.BadParameter(`allow[%d]: "aws_role" parameter not supported`, i)
+		}
+		if len(rule.GetAwsRegions()) != 0 {
+			return trace.BadParameter(`allow[%d]: "aws_regions" parameter not supported`, i)
+		}
+		if rule.GetAwsAccount() == "" && rule.GetAwsArn() == "" && rule.GetAwsOrganizationId() == "" {
+			return trace.BadParameter(`allow[%d]: must set "aws_account", "aws_arn", or "aws_organization"`, i)
+		}
+	}
+
+	return nil
+}
+
+// validates the given GCP configuration. Also implemented by
+// api/types/provisioning.go:ProvisionTokenSpecV2GCP.checkAndSetDefaults() for unscoped tokens
+func validateGCP(gcp *joiningv1.GCP) error {
+	if len(gcp.GetAllow()) == 0 {
+		return trace.BadParameter("gcp configuration with at least one allow rule must be defined")
+	}
+
+	for i, rule := range gcp.GetAllow() {
+		if len(rule.GetProjectIds()) == 0 {
+			return trace.BadParameter("allow[%d]: requires at least one project ID", i)
+		}
+		for j, projectID := range rule.GetProjectIds() {
+			if len(projectID) == 0 {
+				return trace.BadParameter("allow[%d].project_ids[%d]: must not be empty", i, j)
+			}
+		}
+	}
+
+	return nil
+}
+
+// validates the given Azure configuration. Also implemented by
+// api/types/provisioning.go:ProvisionTokenSpecV2Azure.checkAndSetDefaults() for unscoped tokens
+func validateAzure(azure *joiningv1.Azure) error {
+	if len(azure.GetAllow()) == 0 {
+		return trace.BadParameter("azure configuration with at least one allow rule must be defined")
+	}
+
+	for i, rule := range azure.GetAllow() {
+		if rule.GetSubscription() == "" && rule.GetTenant() == "" {
+			return trace.BadParameter(`allow[%d]: must set "subscription" or "tenant"`, i)
+		}
+	}
+
+	return nil
+}
+
+// validates the given Azure DevOps configuration. Also implemented by
+// api/types/provisioning.go:ProvisionTokenSpecV2AzureDevops.checkAndSetDefaults() for unscoped tokens
+func validateAzureDevops(azdo *joiningv1.AzureDevops) error {
+	if len(azdo.GetAllow()) == 0 {
+		return trace.BadParameter("azure_devops configuration with at least one allow rule must be defined")
+	}
+	if azdo.GetOrganizationId() == "" {
+		return trace.BadParameter(`"organization_id" must be set`)
+	}
+
+	for i, rule := range azdo.GetAllow() {
+		if rule.GetSub() == "" && rule.GetProjectName() == "" && rule.GetProjectId() == "" {
+			return trace.BadParameter(
+				`allow[%d]: must set "sub", "project_name", or "project_id"`,
+				i,
+			)
+		}
+	}
+
+	return nil
+}
+
+// validates the given Oracle configuration. Also implemented by
+// api/types/provisioning.go:ProvisionTokenSpecV2Oracle.checkAndSetDefaults() for unscoped tokens
+func validateOracle(oracle *joiningv1.Oracle) error {
+	if len(oracle.GetAllow()) == 0 {
+		return trace.BadParameter("oracle configuration with at least one allow rule must be defined")
+	}
+
+	for i, rule := range oracle.GetAllow() {
+		if rule.GetTenancy() == "" {
+			return trace.BadParameter(`allow[%d]: "tenancy" must be set`, i)
+		}
+		if len(rule.GetInstances()) > 100 {
+			return trace.BadParameter("allow[%d]: maximum 100 instances may be set (found %d)", i, len(rule.GetInstances()))
+		}
+	}
+
+	return nil
+}
+
+// validates per join method token configurations
 func validateJoinMethod(token *joiningv1.ScopedToken) error {
 	switch types.JoinMethod(token.GetSpec().GetJoinMethod()) {
 	case types.JoinMethodToken:
@@ -144,31 +272,17 @@ func validateJoinMethod(token *joiningv1.ScopedToken) error {
 			return trace.BadParameter("secret value must be defined for a scoped token when using the token join method")
 		}
 	case types.JoinMethodEC2:
-		ttl := token.GetSpec().GetAws().GetIidTtl()
-		if _, err := types.ParseDuration(ttl); ttl != "" && err != nil {
-			return trace.BadParameter("invalid IID TTL value %q, must be empty or a valid duration string (e.g. 30m, 12h, 1mo)", ttl)
-		}
-		fallthrough
+		return trace.Wrap(validateEC2(token.GetSpec().GetAws()), "ec2 join method")
 	case types.JoinMethodIAM:
-		if len(token.GetSpec().GetAws().GetAllow()) == 0 {
-			return trace.BadParameter("aws configuration must be defined for a scoped token when using the ec2 or iam join methods")
-		}
+		return trace.Wrap(validateIAM(token.GetSpec().GetAws()), "iam join method")
 	case types.JoinMethodGCP:
-		if len(token.GetSpec().GetGcp().GetAllow()) == 0 {
-			return trace.BadParameter("gcp configuration must be defined for a scoped token when using the gcp join method")
-		}
+		return trace.Wrap(validateGCP(token.GetSpec().GetGcp()), "gcp join method")
 	case types.JoinMethodAzure:
-		if len(token.GetSpec().GetAzure().GetAllow()) == 0 {
-			return trace.BadParameter("azure configuration must be defined for a scoped token when using the azure join method")
-		}
+		return trace.Wrap(validateAzure(token.GetSpec().GetAzure()), "azure join method")
 	case types.JoinMethodAzureDevops:
-		if len(token.GetSpec().GetAzureDevops().GetAllow()) == 0 {
-			return trace.BadParameter("azure_devops configuration must be defined for a scoped token when using the azure_devops join method")
-		}
+		return trace.Wrap(validateAzureDevops(token.GetSpec().GetAzureDevops()), "azure_devops join method")
 	case types.JoinMethodOracle:
-		if len(token.GetSpec().GetOracle().GetAllow()) == 0 {
-			return trace.BadParameter("oracle configuration must be defined for a scoped token when using the oracle join method")
-		}
+		return trace.Wrap(validateOracle(token.GetSpec().GetOracle()), "oracle join method")
 	case types.JoinMethodKubernetes:
 		return trace.Wrap(validateKubernetes(token.GetSpec().GetKubernetes()), "kubernetes join method")
 	case types.JoinMethodBoundKeypair:

--- a/lib/scopes/joining/token.go
+++ b/lib/scopes/joining/token.go
@@ -492,7 +492,7 @@ var ErrTokenExhausted = &trace.LimitExceededError{Message: "scoped token usage e
 // ValidateTokenForUse checks if a given scoped token can be used for
 // provisioning. Returns a [*trace.LimitExceededError] if the token is expired
 func ValidateTokenForUse(token *joiningv1.ScopedToken) error {
-	if err := WeakValidateToken(token); err != nil {
+	if err := StrongValidateToken(token); err != nil {
 		return trace.Wrap(err)
 	}
 

--- a/lib/scopes/joining/token_test.go
+++ b/lib/scopes/joining/token_test.go
@@ -259,8 +259,8 @@ func TestValidateScopedToken(t *testing.T) {
 			modFn: func(tok *joiningv1.ScopedToken) {
 				tok.Spec.JoinMethod = string(types.JoinMethodEC2)
 			},
-			expectedStrongErr: "aws configuration must be defined for a scoped token when using the ec2 or iam join methods",
-			expectedWeakErr:   "aws configuration must be defined for a scoped token when using the ec2 or iam join methods",
+			expectedStrongErr: "aws configuration with at least one allow rule must be defined",
+			expectedWeakErr:   "aws configuration with at least one allow rule must be defined",
 		},
 		{
 			name: "ec2 token with invalid IID TTL",
@@ -279,44 +279,221 @@ func TestValidateScopedToken(t *testing.T) {
 			expectedWeakErr:   "invalid IID TTL value",
 		},
 		{
+			name: "ec2 token with aws_arn",
+			modFn: func(tok *joiningv1.ScopedToken) {
+				tok.Spec.JoinMethod = string(types.JoinMethodEC2)
+				tok.Spec.Aws = &joiningv1.AWS{
+					Allow: []*joiningv1.AWS_Rule{
+						{
+							AwsAccount: "1234567890",
+							AwsArn:     "arn:aws:sts::1234567890:assumed-role/role/i-1234567890abcdef0",
+						},
+					},
+				}
+			},
+			expectedStrongErr: `allow[0]: "aws_arn" parameter not supported`,
+			expectedWeakErr:   `allow[0]: "aws_arn" parameter not supported`,
+		},
+		{
+			name: "ec2 token with aws_organization_id",
+			modFn: func(tok *joiningv1.ScopedToken) {
+				tok.Spec.JoinMethod = string(types.JoinMethodEC2)
+				tok.Spec.Aws = &joiningv1.AWS{
+					Allow: []*joiningv1.AWS_Rule{
+						{
+							AwsAccount:        "1234567890",
+							AwsOrganizationId: "o-123abcd",
+						},
+					},
+				}
+			},
+			expectedStrongErr: `allow[0]: "aws_organization_id" parameter not supported`,
+			expectedWeakErr:   `allow[0]: "aws_organization_id" parameter not supported`,
+		},
+		{
+			name: "ec2 token with empty allow rule",
+			modFn: func(tok *joiningv1.ScopedToken) {
+				tok.Spec.JoinMethod = string(types.JoinMethodEC2)
+				tok.Spec.Aws = &joiningv1.AWS{
+					Allow: []*joiningv1.AWS_Rule{{}},
+				}
+			},
+			expectedStrongErr: `allow[0]: must set "aws_account" or "aws_role"`,
+			expectedWeakErr:   `allow[0]: must set "aws_account" or "aws_role"`,
+		},
+		{
 			name: "iam token without aws configuration",
 			modFn: func(tok *joiningv1.ScopedToken) {
 				tok.Spec.JoinMethod = string(types.JoinMethodIAM)
 			},
-			expectedStrongErr: "aws configuration must be defined for a scoped token when using the ec2 or iam join methods",
-			expectedWeakErr:   "aws configuration must be defined for a scoped token when using the ec2 or iam join methods",
+			expectedStrongErr: "aws configuration with at least one allow rule must be defined",
+			expectedWeakErr:   "aws configuration with at least one allow rule must be defined",
+		},
+		{
+			name: "iam token with aws_role",
+			modFn: func(tok *joiningv1.ScopedToken) {
+				tok.Spec.JoinMethod = string(types.JoinMethodIAM)
+				tok.Spec.Aws = &joiningv1.AWS{
+					Allow: []*joiningv1.AWS_Rule{
+						{
+							AwsAccount: "1234567890",
+							AwsRole:    "arn:aws:iam::1234567890:role/TeleportJoin",
+						},
+					},
+				}
+			},
+			expectedStrongErr: `allow[0]: "aws_role" parameter not supported`,
+			expectedWeakErr:   `allow[0]: "aws_role" parameter not supported`,
+		},
+		{
+			name: "iam token with aws_regions",
+			modFn: func(tok *joiningv1.ScopedToken) {
+				tok.Spec.JoinMethod = string(types.JoinMethodIAM)
+				tok.Spec.Aws = &joiningv1.AWS{
+					Allow: []*joiningv1.AWS_Rule{
+						{
+							AwsAccount: "1234567890",
+							AwsRegions: []string{"us-west-2"},
+						},
+					},
+				}
+			},
+			expectedStrongErr: `allow[0]: "aws_regions" parameter not supported`,
+			expectedWeakErr:   `allow[0]: "aws_regions" parameter not supported`,
+		},
+		{
+			name: "iam token with empty allow rule",
+			modFn: func(tok *joiningv1.ScopedToken) {
+				tok.Spec.JoinMethod = string(types.JoinMethodIAM)
+				tok.Spec.Aws = &joiningv1.AWS{
+					Allow: []*joiningv1.AWS_Rule{{}},
+				}
+			},
+			expectedStrongErr: `allow[0]: must set "aws_account", "aws_arn", or "aws_organization"`,
+			expectedWeakErr:   `allow[0]: must set "aws_account", "aws_arn", or "aws_organization"`,
 		},
 		{
 			name: "gcp token without gcp configuration",
 			modFn: func(tok *joiningv1.ScopedToken) {
 				tok.Spec.JoinMethod = string(types.JoinMethodGCP)
 			},
-			expectedStrongErr: "gcp configuration must be defined for a scoped token when using the gcp join method",
-			expectedWeakErr:   "gcp configuration must be defined for a scoped token when using the gcp join method",
+			expectedStrongErr: "gcp configuration with at least one allow rule must be defined",
+			expectedWeakErr:   "gcp configuration with at least one allow rule must be defined",
+		},
+		{
+			name: "gcp token with empty allow rule",
+			modFn: func(tok *joiningv1.ScopedToken) {
+				tok.Spec.JoinMethod = string(types.JoinMethodGCP)
+				tok.Spec.Gcp = &joiningv1.GCP{
+					Allow: []*joiningv1.GCP_Rule{{}},
+				}
+			},
+			expectedStrongErr: "allow[0]: requires at least one project ID",
+			expectedWeakErr:   "allow[0]: requires at least one project ID",
+		},
+		{
+			name: "gcp token with allow rule with empty project ID",
+			modFn: func(tok *joiningv1.ScopedToken) {
+				tok.Spec.JoinMethod = string(types.JoinMethodGCP)
+				tok.Spec.Gcp = &joiningv1.GCP{
+					Allow: []*joiningv1.GCP_Rule{{ProjectIds: []string{""}}},
+				}
+			},
+			expectedStrongErr: "allow[0].project_ids[0]: must not be empty",
+			expectedWeakErr:   "allow[0].project_ids[0]: must not be empty",
 		},
 		{
 			name: "azure token without azure configuration",
 			modFn: func(tok *joiningv1.ScopedToken) {
 				tok.Spec.JoinMethod = string(types.JoinMethodAzure)
 			},
-			expectedStrongErr: "azure configuration must be defined for a scoped token when using the azure join method",
-			expectedWeakErr:   "azure configuration must be defined for a scoped token when using the azure join method",
+			expectedStrongErr: "azure configuration with at least one allow rule must be defined",
+			expectedWeakErr:   "azure configuration with at least one allow rule must be defined",
+		},
+		{
+			name: "azure token with empty allow rule",
+			modFn: func(tok *joiningv1.ScopedToken) {
+				tok.Spec.JoinMethod = string(types.JoinMethodAzure)
+				tok.Spec.Azure = &joiningv1.Azure{
+					Allow: []*joiningv1.Azure_Rule{{}},
+				}
+			},
+			expectedStrongErr: `allow[0]: must set "subscription" or "tenant"`,
+			expectedWeakErr:   `allow[0]: must set "subscription" or "tenant"`,
 		},
 		{
 			name: "azure_devops token without azure configuration",
 			modFn: func(tok *joiningv1.ScopedToken) {
 				tok.Spec.JoinMethod = string(types.JoinMethodAzureDevops)
 			},
-			expectedStrongErr: "azure_devops configuration must be defined for a scoped token when using the azure_devops join method",
-			expectedWeakErr:   "azure_devops configuration must be defined for a scoped token when using the azure_devops join method",
+			expectedStrongErr: "azure_devops configuration with at least one allow rule must be defined",
+			expectedWeakErr:   "azure_devops configuration with at least one allow rule must be defined",
+		},
+		{
+			name: "azure_devops token without organization_id",
+			modFn: func(tok *joiningv1.ScopedToken) {
+				tok.Spec.JoinMethod = string(types.JoinMethodAzureDevops)
+				tok.Spec.AzureDevops = &joiningv1.AzureDevops{
+					Allow: []*joiningv1.AzureDevops_Rule{
+						{
+							Sub: "p://my-org/my-project/my-pipeline",
+						},
+					},
+				}
+			},
+			expectedStrongErr: `"organization_id" must be set`,
+			expectedWeakErr:   `"organization_id" must be set`,
+		},
+		{
+			name: "azure_devops token with allow rule missing key field",
+			modFn: func(tok *joiningv1.ScopedToken) {
+				tok.Spec.JoinMethod = string(types.JoinMethodAzureDevops)
+				tok.Spec.AzureDevops = &joiningv1.AzureDevops{
+					OrganizationId: "00000000-0000-0000-0000-000000000000",
+					Allow: []*joiningv1.AzureDevops_Rule{
+						{
+							RepositoryVersion: "aaabbccddeefgghhjjiii",
+						},
+					},
+				}
+			},
+			expectedStrongErr: `allow[0]: must set "sub", "project_name", or "project_id"`,
+			expectedWeakErr:   `allow[0]: must set "sub", "project_name", or "project_id"`,
 		},
 		{
 			name: "oracle token without oracle configuration",
 			modFn: func(tok *joiningv1.ScopedToken) {
 				tok.Spec.JoinMethod = string(types.JoinMethodOracle)
 			},
-			expectedStrongErr: "oracle configuration must be defined for a scoped token when using the oracle join method",
-			expectedWeakErr:   "oracle configuration must be defined for a scoped token when using the oracle join method",
+			expectedStrongErr: "oracle configuration with at least one allow rule must be defined",
+			expectedWeakErr:   "oracle configuration with at least one allow rule must be defined",
+		},
+		{
+			name: "oracle token without tenancy",
+			modFn: func(tok *joiningv1.ScopedToken) {
+				tok.Spec.JoinMethod = string(types.JoinMethodOracle)
+				tok.Spec.Oracle = &joiningv1.Oracle{
+					Allow: []*joiningv1.Oracle_Rule{{}},
+				}
+			},
+			expectedStrongErr: `allow[0]: "tenancy" must be set`,
+			expectedWeakErr:   `allow[0]: "tenancy" must be set`,
+		},
+		{
+			name: "oracle token with too many instance IDs",
+			modFn: func(tok *joiningv1.ScopedToken) {
+				tok.Spec.JoinMethod = string(types.JoinMethodOracle)
+				tok.Spec.Oracle = &joiningv1.Oracle{
+					Allow: []*joiningv1.Oracle_Rule{
+						{
+							Tenancy:   "ocid1.tenancy.oc1..aaaaaaaa",
+							Instances: make([]string, 101),
+						},
+					},
+				}
+			},
+			expectedStrongErr: "allow[0]: maximum 100 instances may be set (found 101)",
+			expectedWeakErr:   "allow[0]: maximum 100 instances may be set (found 101)",
 		},
 		{
 			name: "kubernetes token without configuration",
@@ -678,6 +855,7 @@ func TestValidateScopedToken(t *testing.T) {
 			modFn: func(tok *joiningv1.ScopedToken) {
 				tok.Spec.JoinMethod = string(types.JoinMethodAzureDevops)
 				tok.Spec.AzureDevops = &joiningv1.AzureDevops{
+					OrganizationId: "00000000-0000-0000-0000-000000000000",
 					Allow: []*joiningv1.AzureDevops_Rule{
 						{
 							Sub: "1234567890",

--- a/lib/scopes/joining/token_test.go
+++ b/lib/scopes/joining/token_test.go
@@ -1355,3 +1355,24 @@ func TestValidateTokenUpdate(t *testing.T) {
 		})
 	}
 }
+
+func TestValidateTokenForUse(t *testing.T) {
+	token := &joiningv1.ScopedToken{
+		Scope: "/test",
+		Spec: &joiningv1.ScopedTokenSpec{
+			Roles:         []string{types.RoleNode.String()},
+			JoinMethod:    string(types.JoinMethodToken),
+			AssignedScope: "/test",
+		},
+		Status: &joiningv1.ScopedTokenStatus{
+			Secret: "secret",
+		},
+	}
+	// we want to ensure that token validation before use is always the strongest
+	// available, so we confirm that the test token passes weak validation and then
+	// assert that StrongValidateToken and ValidateTokenForUse fail with the same error
+	assert.NoError(t, joining.WeakValidateToken(token))
+	strongValidateErr := joining.StrongValidateToken(token)
+	assert.Error(t, strongValidateErr)
+	assert.ErrorIs(t, strongValidateErr, joining.ValidateTokenForUse(token))
+}


### PR DESCRIPTION
Backport #66977 to branch/v18

## Manual Test Plan
### Test Environment
- Cloud tenant with `TELEPORT_UNSTABLE_SCOPES` enabled

### Test Cases
- [x] IAM token
  - [x] Create fails when no `allow` rules are defined
  - [x] Create fails when `allow.aws_account` is empty
  - [x] Create fails when `allow.aws_regions` are defined
  - [x] Create fails when `allow.aws_role` is defined
  - [x] Create succeeds when `allow.aws_account` is defined
  - [x] Create succeeds when `allow.aws_arn` is defined
  - [x] Create succeeds when `aws_organization` is defined
- [x] EC2 token creation
  - [x] Create fails for invalid `iid_ttl`
  - [x] Create fails when no `allow` rules are defined
  - [x] Create fails when `allow.aws_arn` is defined
  - [x] Create fails when `allow.aws_account` is empty
  - [x] Create succeeds when `allow.aws_account` is defined
  - [x] Create succeeds when `allow.aws_role` is defined
  - [x] Create succeeds when `allow.aws_regions` are defined
- [x] GCP token creation
  - [x] Create fails when no `allow` rules are defined
  - [x] Create fails when `allow.project_ids` are empty
  - [x] Create fails when a value in `allow.project_ids` is empty
  - [x] Create succeeds when `allow.project_ids` is defined
- [x] Azure token creation
  - [x] Create fails when no `allow` rules are defined
  - [x] Create fails when `allow.subscription` and `allow.tenant` are empty
  - [x] Create succeeds when `allow.subscription` is defined
  - [x] Create succeeds when `allow.tenant` is defined
- [x] Oracle token creation
  - [x] Create fails when no `allow` rules are defined
  - [x] Create fails when `allow.tenancy` is empty
  - [x] Create fails when `allow.instances` exeeds 100 elements
  - [x] Create succeeds when `allow.tenancy` is defined