### PR TITLE
Add Slack review UI buttons

### DIFF
--- a/integrations/access/slack/bot.go
+++ b/integrations/access/slack/bot.go
@@ -432,7 +432,7 @@ func (b Bot) slackAccessRequestMsgSections(reqID string, reqData pd.AccessReques
 
 // slackAccessReviewMsgSection builds an access review Slack message section.
 // This should only be returned when native review is enabled.
-func (b Bot) slackAccessReviewMsgSection(reqID string) []BlockItem {
+func (b Bot) slackAccessReviewMsgSection(reqID string) []BlockItem { //nolint:unused // TODO(kshi36): used in follow-up PR.
 	return []BlockItem{
 		NewBlockItem(ActionsBlock{
 			ElementItems: []ActionElementItem{

--- a/integrations/access/slack/bot.go
+++ b/integrations/access/slack/bot.go
@@ -430,6 +430,36 @@ func (b Bot) slackAccessRequestMsgSections(reqID string, reqData pd.AccessReques
 	return sections
 }
 
+// slackAccessReviewMsgSection builds an access review Slack message section.
+// This should only be returned when native review is enabled.
+func (b Bot) slackAccessReviewMsgSection(reqID string) []BlockItem {
+	return []BlockItem{
+		NewBlockItem(ActionsBlock{
+			ElementItems: []ActionElementItem{
+				NewActionElementItem(ButtonElement{
+					Text: NewTextObjectItem(PlainTextObject{
+						Text: "Approve",
+					}),
+					ActionID:           approveButtonID,
+					Value:              reqID,
+					Style:              "primary",
+					AccessibilityLabel: "Approve access request button",
+				}),
+				NewActionElementItem(ButtonElement{
+					Text: NewTextObjectItem(PlainTextObject{
+						Text: "Deny",
+					}),
+					ActionID:           denyButtonID,
+					Value:              reqID,
+					Style:              "danger",
+					AccessibilityLabel: "Deny access request button",
+				}),
+			},
+			BlockID: actionsBlockID,
+		}),
+	}
+}
+
 func truncateTextObjectString(s string) string {
 	truncateMsg := " (truncated)"
 	if len(s) <= textObjectMaxCharLimit {

--- a/integrations/access/slack/types.go
+++ b/integrations/access/slack/types.go
@@ -301,12 +301,59 @@ func NewBlockItem(block Block) BlockItem {
 // Slack API: actions blocks
 
 type ActionsBlock struct {
-	Elements []json.RawMessage `json:"elements"`
-	BlockID  string            `json:"block_id,omitempty"`
+	ElementItems []ActionElementItem `json:"elements"`
+	BlockID      string              `json:"block_id,omitempty"`
 }
 
 func (b ActionsBlock) BlockType() BlockType {
 	return BlockType("actions")
+}
+
+type ActionElementType string
+
+type ActionElement interface {
+	ActionElementType() ActionElementType
+}
+
+type ActionElementItem struct{ ActionElement }
+
+func NewActionElementItem(element ActionElement) ActionElementItem {
+	return ActionElementItem{element}
+}
+
+func (p *ActionElementItem) UnmarshalJSON(data []byte) error {
+	var itemType struct {
+		Type ActionElementType `json:"type"`
+	}
+	if err := json.Unmarshal(data, &itemType); err != nil {
+		return trace.Wrap(err)
+	}
+	var element ActionElement
+	var err error
+	switch itemType.Type {
+	case ButtonElement{}.ActionElementType():
+		var val ButtonElement
+		err = trace.Wrap(json.Unmarshal(data, &val))
+		element = val
+	}
+	if err != nil {
+		return err
+	}
+	p.ActionElement = element
+	return nil
+}
+
+func (p ActionElementItem) MarshalJSON() ([]byte, error) {
+	typeVal := string(p.ActionElementType())
+	switch val := p.ActionElement.(type) {
+	case ButtonElement:
+		return json.Marshal(struct {
+			Type string `json:"type"`
+			ButtonElement
+		}{typeVal, val})
+	default:
+		return json.Marshal(val)
+	}
 }
 
 // Slack API: context blocks
@@ -544,4 +591,71 @@ func (t MarkdownObject) ContextElementType() ContextElementType {
 
 func (t MarkdownObject) GetText() string {
 	return t.Text
+}
+
+// Slack API: block elements
+
+type BlockElementType string
+
+type BlockElement interface {
+	BlockElementType() BlockElementType
+}
+
+type BlockElementItem struct{ BlockElement }
+
+func NewBlockElementItem(element BlockElement) BlockElementItem {
+	return BlockElementItem{element}
+}
+
+func (p *BlockElementItem) UnmarshalJSON(data []byte) error {
+	var itemType struct {
+		Type BlockElementType `json:"type"`
+	}
+	if err := json.Unmarshal(data, &itemType); err != nil {
+		return trace.Wrap(err)
+	}
+	var element BlockElement
+	var err error
+	switch itemType.Type {
+	case ButtonElement{}.BlockElementType():
+		var val ButtonElement
+		err = trace.Wrap(json.Unmarshal(data, &val))
+		element = val
+	}
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	p.BlockElement = element
+	return nil
+}
+
+func (p BlockElementItem) MarshalJSON() ([]byte, error) {
+	typeVal := string(p.BlockElementType())
+	switch val := p.BlockElement.(type) {
+	case ButtonElement:
+		return json.Marshal(struct {
+			Type string `json:"type"`
+			ButtonElement
+		}{typeVal, val})
+	default:
+		return json.Marshal(val)
+	}
+}
+
+type ButtonElement struct {
+	Text               TextObjectItem  `json:"text"`
+	ActionID           string          `json:"action_id,omitempty"`
+	URL                string          `json:"url,omitempty"`
+	Value              string          `json:"value,omitempty"`
+	Style              string          `json:"style,omitempty"`
+	Confirm            json.RawMessage `json:"confirm,omitempty"`
+	AccessibilityLabel string          `json:"accessibility_label,omitempty"`
+}
+
+func (b ButtonElement) BlockElementType() BlockElementType {
+	return BlockElementType("button")
+}
+
+func (b ButtonElement) ActionElementType() ActionElementType {
+	return ActionElementType("button")
 }


### PR DESCRIPTION
Depends on:
- https://github.com/gravitational/teleport/pull/67217

Adds Approve/Deny review UI block for Slack plugin, to support native reviews.
The IDs used in the block (block ID, button IDs) live in `ReviewApp` for it to validate incoming payload data.

Context for reviewers: This supports the upcoming feature for native reviews in Slack, where the Slack plugin submits access reviews to the Teleport Auth Server on behalf of human Slack users.

Comprehensive manual test plan saved for final PR where the review block is built conditionally.