### PR TITLE
Web: allow pointer events on disabled tabs

### DIFF
--- a/web/packages/design/src/Tabs/Tabs.test.tsx
+++ b/web/packages/design/src/Tabs/Tabs.test.tsx
@@ -16,9 +16,16 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+import { MemoryRouter } from 'react-router';
+
 import { render, screen, userEvent } from 'design/utils/testing';
 
-import { TabBorder, TabContainer, TabsContainer } from './Tabs';
+import {
+  TabBorder,
+  TabContainer,
+  TabContainerNavLink,
+  TabsContainer,
+} from './Tabs';
 
 test('enabled tab calls onClick when clicked', async () => {
   const user = userEvent.setup();
@@ -67,4 +74,21 @@ test('disabled tab keeps pointer events', () => {
   expect(screen.getByText('Disabled Tab')).not.toHaveStyle({
     'pointer-events': 'none',
   });
+});
+
+test('disabled TabContainerNavLink prevents default navigation', async () => {
+  const user = userEvent.setup();
+  const handleClick = jest.fn();
+  render(
+    <MemoryRouter>
+      <div onClick={handleClick}>
+        <TabContainerNavLink to="/other" disabled>
+          Disabled Link Tab
+        </TabContainerNavLink>
+      </div>
+    </MemoryRouter>
+  );
+
+  await user.click(screen.getByText('Disabled Link Tab'));
+  expect(handleClick.mock.calls[0][0].defaultPrevented).toBe(true);
 });

--- a/web/packages/design/src/Tabs/Tabs.test.tsx
+++ b/web/packages/design/src/Tabs/Tabs.test.tsx
@@ -1,0 +1,70 @@
+/*
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { render, screen, userEvent } from 'design/utils/testing';
+
+import { TabBorder, TabContainer, TabsContainer } from './Tabs';
+
+test('enabled tab calls onClick when clicked', async () => {
+  const user = userEvent.setup();
+  const onClick = jest.fn();
+  render(
+    <TabsContainer>
+      <TabContainer onClick={onClick}>Enabled Tab</TabContainer>
+      <TabBorder />
+    </TabsContainer>
+  );
+
+  const tab = screen.getByText('Enabled Tab');
+  expect(tab).not.toHaveAttribute('aria-disabled');
+  await user.click(tab);
+  expect(onClick).toHaveBeenCalledTimes(1);
+});
+
+test('disabled tab does not call onClick when clicked', async () => {
+  const user = userEvent.setup();
+  const onClick = jest.fn();
+  render(
+    <TabsContainer>
+      <TabContainer disabled onClick={onClick}>
+        Disabled Tab
+      </TabContainer>
+      <TabBorder />
+    </TabsContainer>
+  );
+
+  const tab = screen.getByText('Disabled Tab');
+  expect(tab).toHaveAttribute('aria-disabled', 'true');
+  await user.click(tab);
+  expect(onClick).not.toHaveBeenCalled();
+});
+
+// Disabled tabs keep pointer events enabled so hover-based
+// behavior like hover tooltips still works.
+test('disabled tab keeps pointer events', () => {
+  render(
+    <TabsContainer>
+      <TabContainer disabled>Disabled Tab</TabContainer>
+      <TabBorder />
+    </TabsContainer>
+  );
+
+  expect(screen.getByText('Disabled Tab')).not.toHaveStyle({
+    'pointer-events': 'none',
+  });
+});

--- a/web/packages/design/src/Tabs/Tabs.ts
+++ b/web/packages/design/src/Tabs/Tabs.ts
@@ -55,6 +55,7 @@ export const TabContainer = styled.div.attrs<{
   // to allow hover-based behavior (e.g. tooltips) to work on
   // disabled tabs.
   onClick: p.disabled ? undefined : p.onClick,
+  'aria-disabled': p.disabled || undefined,
 }))`
   padding: ${p => p.theme.space[1] + p.theme.space[2]}px
     ${p => p.theme.space[2]}px;

--- a/web/packages/design/src/Tabs/Tabs.ts
+++ b/web/packages/design/src/Tabs/Tabs.ts
@@ -46,11 +46,16 @@ export const TabsContainer = styled.div<TabsContainerProps>`
   ${space}
 `;
 
-export const TabContainer = styled.div<{
+export const TabContainer = styled.div.attrs<{
   selected?: boolean;
   size?: 'small';
   disabled?: boolean;
-}>`
+}>(p => ({
+  // The alternative "pointer-events: none" is not used here
+  // to allow hover-based behavior (e.g. tooltips) to work on
+  // disabled tabs.
+  onClick: p.disabled ? undefined : p.onClick,
+}))`
   padding: ${p => p.theme.space[1] + p.theme.space[2]}px
     ${p => p.theme.space[2]}px;
   position: relative;
@@ -82,7 +87,6 @@ export const TabContainer = styled.div<{
     p.disabled &&
     `
     cursor: not-allowed;
-    pointer-events: none;
     opacity: 0.3;
     &:hover {
       opacity: 0.3;

--- a/web/packages/design/src/Tabs/Tabs.ts
+++ b/web/packages/design/src/Tabs/Tabs.ts
@@ -16,6 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+import { MouseEvent } from 'react';
 import { NavLink } from 'react-router';
 import styled from 'styled-components';
 
@@ -53,8 +54,10 @@ export const TabContainer = styled.div.attrs<{
 }>(p => ({
   // The alternative "pointer-events: none" is not used here
   // to allow hover-based behavior (e.g. tooltips) to work on
-  // disabled tabs.
-  onClick: p.disabled ? undefined : p.onClick,
+  // disabled tabs. preventDefault is needed (rather than just
+  // undefined) so that TabContainerNavLink (an anchor element)
+  // doesn't follow their href when disabled.
+  onClick: p.disabled ? (e: MouseEvent) => e.preventDefault() : p.onClick,
   'aria-disabled': p.disabled || undefined,
 }))`
   padding: ${p => p.theme.space[1] + p.theme.space[2]}px


### PR DESCRIPTION
This PR just changes how a disabled tab should be represented. Using `pointer-events: none;` prevented the disabled tab from taking on any pointer events so tool tips would not render, so it's been changed to keep the onclick but set it to do nothing on click.

example working usage of a disabled tab:


https://github.com/user-attachments/assets/2eca712e-9eb1-4212-b01a-09a0eb921e81

