### PR TITLE
[v18] Connect: do not crash tsh daemon if user preferences update is nil

### DIFF
--- a/lib/teleterm/apiserver/apiserver.go
+++ b/lib/teleterm/apiserver/apiserver.go
@@ -82,12 +82,12 @@ func New(cfg Config) (*APIServer, error) {
 
 	grpcServer := grpc.NewServer(cfg.TshdServerCreds,
 		grpc.ChainUnaryInterceptor(
-			withUnaryPanicRecovery(cfg.Logger),
 			withUnaryErrorHandling(cfg.Logger),
+			withUnaryPanicRecovery(cfg.Logger),
 		),
 		grpc.ChainStreamInterceptor(
-			withStreamPanicRecovery(cfg.Logger),
 			withStreamErrorHandling(cfg.Logger),
+			withStreamPanicRecovery(cfg.Logger),
 		),
 		grpc.MaxConcurrentStreams(defaults.GRPCMaxConcurrentStreams),
 	)

--- a/lib/teleterm/apiserver/apiserver.go
+++ b/lib/teleterm/apiserver/apiserver.go
@@ -81,7 +81,14 @@ func New(cfg Config) (*APIServer, error) {
 	}
 
 	grpcServer := grpc.NewServer(cfg.TshdServerCreds,
-		grpc.ChainUnaryInterceptor(withErrorHandling(cfg.Logger)),
+		grpc.ChainUnaryInterceptor(
+			withUnaryPanicRecovery(cfg.Logger),
+			withUnaryErrorHandling(cfg.Logger),
+		),
+		grpc.ChainStreamInterceptor(
+			withStreamPanicRecovery(cfg.Logger),
+			withStreamErrorHandling(cfg.Logger),
+		),
 		grpc.MaxConcurrentStreams(defaults.GRPCMaxConcurrentStreams),
 	)
 

--- a/lib/teleterm/apiserver/middleware.go
+++ b/lib/teleterm/apiserver/middleware.go
@@ -21,8 +21,8 @@ package apiserver
 import (
 	"context"
 	"log/slog"
-	"runtime/debug"
 
+	"github.com/gravitational/trace"
 	"github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/recovery"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
@@ -81,10 +81,12 @@ func withStreamPanicRecovery(log *slog.Logger) grpc.StreamServerInterceptor {
 
 func panicRecoveryOption(log *slog.Logger) recovery.Option {
 	return recovery.WithRecoveryHandlerContext(func(ctx context.Context, p any) error {
+		// trace captures the stack trace.
+		// p is not logged as it may contain sensitive data.
+		err := trace.Errorf("handler panic")
 		log.ErrorContext(ctx, "Recovered from panic in gRPC handler",
-			"panic", p,
-			"stack", string(debug.Stack()),
+			"error", err,
 		)
-		return status.Errorf(codes.Internal, "handler panic: %v", p)
+		return status.Errorf(codes.Internal, "handler panic")
 	})
 }

--- a/lib/teleterm/apiserver/middleware.go
+++ b/lib/teleterm/apiserver/middleware.go
@@ -21,14 +21,19 @@ package apiserver
 import (
 	"context"
 	"log/slog"
+	"runtime/debug"
 
+	"github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/recovery"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	"github.com/gravitational/teleport/api/trail"
 )
 
-// withErrorHandling is gRPC middleware that maps internal errors to proper gRPC error codes
-func withErrorHandling(log *slog.Logger) grpc.UnaryServerInterceptor {
+// withUnaryErrorHandling is gRPC middleware that maps internal errors from unary
+// handlers to proper gRPC error codes.
+func withUnaryErrorHandling(log *slog.Logger) grpc.UnaryServerInterceptor {
 	return func(
 		ctx context.Context,
 		req interface{},
@@ -43,4 +48,43 @@ func withErrorHandling(log *slog.Logger) grpc.UnaryServerInterceptor {
 
 		return resp, nil
 	}
+}
+
+// withStreamErrorHandling is gRPC middleware that maps internal errors from streaming
+// handlers to proper gRPC error codes.
+func withStreamErrorHandling(log *slog.Logger) grpc.StreamServerInterceptor {
+	return func(
+		srv any,
+		stream grpc.ServerStream,
+		info *grpc.StreamServerInfo,
+		handler grpc.StreamHandler,
+	) error {
+		err := handler(srv, stream)
+		if err != nil {
+			log.ErrorContext(stream.Context(), "Stream request failed", "error", err)
+			return trail.ToGRPC(err)
+		}
+
+		return nil
+	}
+}
+
+// withUnaryPanicRecovery is gRPC middleware that recovers from panics in unary handlers.
+func withUnaryPanicRecovery(log *slog.Logger) grpc.UnaryServerInterceptor {
+	return recovery.UnaryServerInterceptor(panicRecoveryOption(log))
+}
+
+// withStreamPanicRecovery is gRPC middleware that recovers from panics in streaming handlers.
+func withStreamPanicRecovery(log *slog.Logger) grpc.StreamServerInterceptor {
+	return recovery.StreamServerInterceptor(panicRecoveryOption(log))
+}
+
+func panicRecoveryOption(log *slog.Logger) recovery.Option {
+	return recovery.WithRecoveryHandlerContext(func(ctx context.Context, p any) error {
+		log.ErrorContext(ctx, "Recovered from panic in gRPC handler",
+			"panic", p,
+			"stack", string(debug.Stack()),
+		)
+		return status.Errorf(codes.Internal, "handler panic: %v", p)
+	})
 }

--- a/lib/teleterm/apiserver/middleware_test.go
+++ b/lib/teleterm/apiserver/middleware_test.go
@@ -89,7 +89,7 @@ func TestWithUnaryPanicRecovery(t *testing.T) {
 	resp, err := interceptor(t.Context(), nil, info, handler)
 	require.Nil(t, resp)
 	require.Equal(t, codes.Internal, status.Code(err))
-	require.ErrorContains(t, err, "handler panic: oh no")
+	require.Errorf(t, err, "handler panic")
 }
 
 func TestWithStreamPanicRecovery(t *testing.T) {
@@ -102,7 +102,7 @@ func TestWithStreamPanicRecovery(t *testing.T) {
 
 	err := interceptor(nil, &fakeServerStream{ctx: t.Context()}, info, handler)
 	require.Equal(t, codes.Internal, status.Code(err))
-	require.ErrorContains(t, err, "handler panic: oh no")
+	require.Errorf(t, err, "handler panic")
 }
 
 type fakeServerStream struct {

--- a/lib/teleterm/apiserver/middleware_test.go
+++ b/lib/teleterm/apiserver/middleware_test.go
@@ -1,0 +1,113 @@
+/*
+ * Teleport
+ * Copyright (C) 2026 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package apiserver
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+
+	"github.com/gravitational/trace"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+func TestWithUnaryErrorHandling(t *testing.T) {
+	info := &grpc.UnaryServerInfo{FullMethod: "/test.Service/Method"}
+	interceptor := withUnaryErrorHandling(slog.New(slog.DiscardHandler))
+
+	t.Run("passes through successful response", func(t *testing.T) {
+		handler := func(ctx context.Context, req any) (any, error) {
+			return "ok", nil
+		}
+
+		resp, err := interceptor(t.Context(), nil, info, handler)
+		require.NoError(t, err)
+		require.Equal(t, "ok", resp)
+	})
+
+	t.Run("converts trace error to gRPC status", func(t *testing.T) {
+		handler := func(ctx context.Context, req any) (any, error) {
+			return nil, trace.NotFound("missing")
+		}
+
+		resp, err := interceptor(t.Context(), nil, info, handler)
+		require.Nil(t, resp)
+		require.Equal(t, codes.NotFound, status.Code(err))
+	})
+}
+
+func TestWithStreamErrorHandling(t *testing.T) {
+	info := &grpc.StreamServerInfo{FullMethod: "/test.Service/Method"}
+	interceptor := withStreamErrorHandling(slog.New(slog.DiscardHandler))
+
+	t.Run("passes through successful response", func(t *testing.T) {
+		handler := func(srv any, stream grpc.ServerStream) error {
+			return nil
+		}
+
+		err := interceptor(nil, &fakeServerStream{ctx: t.Context()}, info, handler)
+		require.NoError(t, err)
+	})
+
+	t.Run("converts trace error to gRPC status", func(t *testing.T) {
+		handler := func(srv any, stream grpc.ServerStream) error {
+			return trace.NotFound("missing")
+		}
+
+		err := interceptor(nil, &fakeServerStream{ctx: t.Context()}, info, handler)
+		require.Equal(t, codes.NotFound, status.Code(err))
+	})
+}
+
+func TestWithUnaryPanicRecovery(t *testing.T) {
+	info := &grpc.UnaryServerInfo{FullMethod: "/test.Service/Method"}
+	interceptor := withUnaryPanicRecovery(slog.New(slog.DiscardHandler))
+
+	handler := func(ctx context.Context, req any) (any, error) {
+		panic("oh no")
+	}
+
+	resp, err := interceptor(t.Context(), nil, info, handler)
+	require.Nil(t, resp)
+	require.Equal(t, codes.Internal, status.Code(err))
+	require.ErrorContains(t, err, "handler panic: oh no")
+}
+
+func TestWithStreamPanicRecovery(t *testing.T) {
+	info := &grpc.StreamServerInfo{FullMethod: "/test.Service/Method"}
+	interceptor := withStreamPanicRecovery(slog.New(slog.DiscardHandler))
+
+	handler := func(srv any, stream grpc.ServerStream) error {
+		panic("oh no")
+	}
+
+	err := interceptor(nil, &fakeServerStream{ctx: t.Context()}, info, handler)
+	require.Equal(t, codes.Internal, status.Code(err))
+	require.ErrorContains(t, err, "handler panic: oh no")
+}
+
+type fakeServerStream struct {
+	grpc.ServerStream
+	ctx context.Context
+}
+
+func (s *fakeServerStream) Context() context.Context { return s.ctx }

--- a/lib/teleterm/apiserver/middleware_test.go
+++ b/lib/teleterm/apiserver/middleware_test.go
@@ -89,7 +89,7 @@ func TestWithUnaryPanicRecovery(t *testing.T) {
 	resp, err := interceptor(t.Context(), nil, info, handler)
 	require.Nil(t, resp)
 	require.Equal(t, codes.Internal, status.Code(err))
-	require.Errorf(t, err, "handler panic")
+	require.ErrorContains(t, err, "handler panic")
 }
 
 func TestWithStreamPanicRecovery(t *testing.T) {
@@ -102,7 +102,7 @@ func TestWithStreamPanicRecovery(t *testing.T) {
 
 	err := interceptor(nil, &fakeServerStream{ctx: t.Context()}, info, handler)
 	require.Equal(t, codes.Internal, status.Code(err))
-	require.Errorf(t, err, "handler panic")
+	require.ErrorContains(t, err, "handler panic")
 }
 
 type fakeServerStream struct {

--- a/lib/teleterm/services/userpreferences/userpreferences.go
+++ b/lib/teleterm/services/userpreferences/userpreferences.go
@@ -95,9 +95,15 @@ func Update(ctx context.Context, rootClient Client, leafClient Client, newPrefer
 	}
 
 	rootPreferences := rootPreferencesResponse.GetPreferences()
+	if rootPreferences == nil {
+		rootPreferences = &userpreferencesv1.UserPreferences{}
+	}
 	var leafPreferences *userpreferencesv1.UserPreferences
 	if leafPreferencesResponse != nil {
 		leafPreferences = leafPreferencesResponse.GetPreferences()
+		if leafPreferences == nil {
+			leafPreferences = &userpreferencesv1.UserPreferences{}
+		}
 	}
 
 	// We do not use errgroup.WithContext since we don't want to cancel
@@ -111,17 +117,26 @@ func Update(ctx context.Context, rootClient Client, leafClient Client, newPrefer
 	// we can still update pinned resources for leaf.
 	upsertGroup := errgroup.Group{}
 
-	hasUnifiedResourcePreferencesForRoot := newPreferences.UnifiedResourcePreferences != nil
-	hasClusterPreferencesForRoot := newPreferences.ClusterPreferences != nil && leafPreferences == nil
+	hasRootUpdate := false
+	// Unified resource preferences. Only updated in the root cluster.
+	if newPreferences != nil && newPreferences.UnifiedResourcePreferences != nil {
+		rootPreferences.UnifiedResourcePreferences = updateUnifiedResourcePreferences(
+			rootPreferences.UnifiedResourcePreferences,
+			newPreferences.UnifiedResourcePreferences,
+		)
+		hasRootUpdate = true
+	}
 
-	if hasUnifiedResourcePreferencesForRoot || hasClusterPreferencesForRoot {
-		if hasUnifiedResourcePreferencesForRoot {
-			rootPreferences.UnifiedResourcePreferences = updateUnifiedResourcePreferences(rootPreferences.UnifiedResourcePreferences, newPreferences.UnifiedResourcePreferences)
-		}
-		if hasClusterPreferencesForRoot {
-			rootPreferences.ClusterPreferences = updateClusterPreferences(rootPreferences.ClusterPreferences, newPreferences.ClusterPreferences)
-		}
+	// Cluster preferences. Updated in the root cluster if set.
+	if newPreferences != nil && newPreferences.ClusterPreferences != nil && leafPreferences == nil {
+		rootPreferences.ClusterPreferences = updateClusterPreferences(
+			rootPreferences.ClusterPreferences,
+			newPreferences.ClusterPreferences,
+		)
+		hasRootUpdate = true
+	}
 
+	if hasRootUpdate {
 		upsertGroup.Go(func() error {
 			err := rootClient.UpsertUserPreferences(ctx, &userpreferencesv1.UpsertUserPreferencesRequest{
 				Preferences: rootPreferences,
@@ -130,8 +145,8 @@ func Update(ctx context.Context, rootClient Client, leafClient Client, newPrefer
 		})
 	}
 
-	hasClusterPreferencesForLeaf := newPreferences.ClusterPreferences != nil && leafPreferences != nil
-	if hasClusterPreferencesForLeaf {
+	// Cluster preferences. Updated in the leaf cluster if set.
+	if newPreferences != nil && newPreferences.ClusterPreferences != nil && leafPreferences != nil {
 		leafPreferences.ClusterPreferences = updateClusterPreferences(leafPreferences.ClusterPreferences, newPreferences.ClusterPreferences)
 
 		upsertGroup.Go(func() error {
@@ -157,30 +172,43 @@ func Update(ctx context.Context, rootClient Client, leafClient Client, newPrefer
 	return updatedPreferences, nil
 }
 
-// updateUnifiedResourcePreferences updates DefaultTab, ViewMode,
-// and LabelsViewMode fields in UnifiedResourcePreferences.
+// updateUnifiedResourcePreferences updates DefaultTab, ViewMode, LabelsViewMode,
+// and AvailableResourceMode fields in UnifiedResourcePreferences.
 // The fields are updated one by one (instead of passing the entire struct as new preferences)
 // to prevent potential new fields from being overwritten.
 func updateUnifiedResourcePreferences(oldPreferences *userpreferencesv1.UnifiedResourcePreferences, newPreferences *userpreferencesv1.UnifiedResourcePreferences) *userpreferencesv1.UnifiedResourcePreferences {
-	updated := oldPreferences
+	if newPreferences == nil {
+		return oldPreferences
+	}
+	if oldPreferences == nil {
+		oldPreferences = &userpreferencesv1.UnifiedResourcePreferences{}
+	}
 
-	updated.DefaultTab = newPreferences.DefaultTab
-	updated.ViewMode = newPreferences.ViewMode
-	updated.LabelsViewMode = newPreferences.LabelsViewMode
-	updated.AvailableResourceMode = newPreferences.AvailableResourceMode
+	oldPreferences.DefaultTab = newPreferences.GetDefaultTab()
+	oldPreferences.ViewMode = newPreferences.GetViewMode()
+	oldPreferences.LabelsViewMode = newPreferences.GetLabelsViewMode()
+	oldPreferences.AvailableResourceMode = newPreferences.GetAvailableResourceMode()
 
-	return updated
+	return oldPreferences
 }
 
 // updateClusterPreferences updates pinned resources in ClusterUserPreferences.
 // The fields are updated one by one (instead of passing the entire struct as new preferences)
 // to prevent potential new fields from being overwritten.
 func updateClusterPreferences(oldPreferences *userpreferencesv1.ClusterUserPreferences, newPreferences *userpreferencesv1.ClusterUserPreferences) *userpreferencesv1.ClusterUserPreferences {
-	updated := oldPreferences
+	if newPreferences == nil || newPreferences.PinnedResources == nil {
+		return oldPreferences
+	}
+	if oldPreferences == nil {
+		oldPreferences = &userpreferencesv1.ClusterUserPreferences{}
+	}
+	if oldPreferences.PinnedResources == nil {
+		oldPreferences.PinnedResources = &userpreferencesv1.PinnedResourcesUserPreferences{}
+	}
 
-	updated.PinnedResources.ResourceIds = newPreferences.PinnedResources.ResourceIds
+	oldPreferences.PinnedResources.ResourceIds = newPreferences.PinnedResources.ResourceIds
 
-	return updated
+	return oldPreferences
 }
 
 // Client represents auth.ClientI methods used by [Get] and [Update].

--- a/lib/teleterm/services/userpreferences/userpreferences.go
+++ b/lib/teleterm/services/userpreferences/userpreferences.go
@@ -56,7 +56,7 @@ func Get(ctx context.Context, rootClient Client, leafClient Client) (*api.UserPr
 	}
 
 	return &api.UserPreferences{
-		UnifiedResourcePreferences: rootPreferences.UnifiedResourcePreferences,
+		UnifiedResourcePreferences: rootPreferences.GetUnifiedResourcePreferences(),
 		ClusterPreferences:         clusterPreferences,
 	}, nil
 }
@@ -119,19 +119,19 @@ func Update(ctx context.Context, rootClient Client, leafClient Client, newPrefer
 
 	hasRootUpdate := false
 	// Unified resource preferences. Only updated in the root cluster.
-	if newPreferences != nil && newPreferences.UnifiedResourcePreferences != nil {
+	if newPreferences.GetUnifiedResourcePreferences() != nil {
 		rootPreferences.UnifiedResourcePreferences = updateUnifiedResourcePreferences(
-			rootPreferences.UnifiedResourcePreferences,
-			newPreferences.UnifiedResourcePreferences,
+			rootPreferences.GetUnifiedResourcePreferences(),
+			newPreferences.GetUnifiedResourcePreferences(),
 		)
 		hasRootUpdate = true
 	}
 
 	// Cluster preferences. Updated in the root cluster if set.
-	if newPreferences != nil && newPreferences.ClusterPreferences != nil && leafPreferences == nil {
+	if newPreferences.GetClusterPreferences() != nil && leafPreferences == nil {
 		rootPreferences.ClusterPreferences = updateClusterPreferences(
-			rootPreferences.ClusterPreferences,
-			newPreferences.ClusterPreferences,
+			rootPreferences.GetClusterPreferences(),
+			newPreferences.GetClusterPreferences(),
 		)
 		hasRootUpdate = true
 	}
@@ -146,8 +146,8 @@ func Update(ctx context.Context, rootClient Client, leafClient Client, newPrefer
 	}
 
 	// Cluster preferences. Updated in the leaf cluster if set.
-	if newPreferences != nil && newPreferences.ClusterPreferences != nil && leafPreferences != nil {
-		leafPreferences.ClusterPreferences = updateClusterPreferences(leafPreferences.ClusterPreferences, newPreferences.ClusterPreferences)
+	if newPreferences.GetClusterPreferences() != nil && leafPreferences != nil {
+		leafPreferences.ClusterPreferences = updateClusterPreferences(leafPreferences.GetClusterPreferences(), newPreferences.GetClusterPreferences())
 
 		upsertGroup.Go(func() error {
 			err := leafClient.UpsertUserPreferences(ctx, &userpreferencesv1.UpsertUserPreferencesRequest{
@@ -162,11 +162,11 @@ func Update(ctx context.Context, rootClient Client, leafClient Client, newPrefer
 	}
 
 	updatedPreferences := &api.UserPreferences{
-		ClusterPreferences:         rootPreferences.ClusterPreferences,
-		UnifiedResourcePreferences: rootPreferences.UnifiedResourcePreferences,
+		ClusterPreferences:         rootPreferences.GetClusterPreferences(),
+		UnifiedResourcePreferences: rootPreferences.GetUnifiedResourcePreferences(),
 	}
 	if leafPreferences != nil {
-		updatedPreferences.ClusterPreferences = leafPreferences.ClusterPreferences
+		updatedPreferences.ClusterPreferences = leafPreferences.GetClusterPreferences()
 	}
 
 	return updatedPreferences, nil
@@ -196,17 +196,17 @@ func updateUnifiedResourcePreferences(oldPreferences *userpreferencesv1.UnifiedR
 // The fields are updated one by one (instead of passing the entire struct as new preferences)
 // to prevent potential new fields from being overwritten.
 func updateClusterPreferences(oldPreferences *userpreferencesv1.ClusterUserPreferences, newPreferences *userpreferencesv1.ClusterUserPreferences) *userpreferencesv1.ClusterUserPreferences {
-	if newPreferences == nil || newPreferences.PinnedResources == nil {
+	if newPreferences.GetPinnedResources() == nil {
 		return oldPreferences
 	}
 	if oldPreferences == nil {
 		oldPreferences = &userpreferencesv1.ClusterUserPreferences{}
 	}
-	if oldPreferences.PinnedResources == nil {
+	if oldPreferences.GetPinnedResources() == nil {
 		oldPreferences.PinnedResources = &userpreferencesv1.PinnedResourcesUserPreferences{}
 	}
 
-	oldPreferences.PinnedResources.ResourceIds = newPreferences.PinnedResources.ResourceIds
+	oldPreferences.PinnedResources.ResourceIds = newPreferences.GetPinnedResources().GetResourceIds()
 
 	return oldPreferences
 }

--- a/lib/teleterm/services/userpreferences/userpreferences_test.go
+++ b/lib/teleterm/services/userpreferences/userpreferences_test.go
@@ -52,22 +52,16 @@ var leafPreferencesMock = &userpreferencesv1.UserPreferences{
 }
 
 func TestUserPreferencesGet(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	t.Cleanup(cancel)
-
 	mockedRootClient := &mockClient{preferences: rootPreferencesMock}
 	mockedLeafClient := &mockClient{preferences: leafPreferencesMock}
 
-	response, err := Get(ctx, mockedRootClient, mockedLeafClient)
+	response, err := Get(t.Context(), mockedRootClient, mockedLeafClient)
 	require.NoError(t, err)
 	require.Equal(t, rootPreferencesMock.GetUnifiedResourcePreferences(), response.GetUnifiedResourcePreferences())
 	require.Equal(t, leafPreferencesMock.GetClusterPreferences(), response.GetClusterPreferences())
 }
 
 func TestUserPreferencesUpdateForRoot(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	t.Cleanup(cancel)
-
 	mockedClient := &mockClient{preferences: rootPreferencesMock}
 
 	newPreferences := &api.UserPreferences{
@@ -79,7 +73,7 @@ func TestUserPreferencesUpdateForRoot(t *testing.T) {
 		UnifiedResourcePreferences: nil,
 	}
 
-	updatedPreferences, err := Update(ctx, mockedClient, nil, newPreferences)
+	updatedPreferences, err := Update(t.Context(), mockedClient, nil, newPreferences)
 	require.NoError(t, err)
 	// ClusterPreferences field has been updated with the new value.
 	require.Equal(t, newPreferences.ClusterPreferences, mockedClient.upsertCalledWith.ClusterPreferences)
@@ -91,10 +85,34 @@ func TestUserPreferencesUpdateForRoot(t *testing.T) {
 	require.Equal(t, rootPreferencesMock.Theme, mockedClient.upsertCalledWith.Theme)
 }
 
-func TestUserPreferencesUpdateForRootAndLeaf(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	t.Cleanup(cancel)
+func TestUserPreferencesUpdateForRootWithNoExistingPinnedResources(t *testing.T) {
+	rootPreferences := &userpreferencesv1.UserPreferences{
+		Theme: userpreferencesv1.Theme_THEME_LIGHT,
+		ClusterPreferences: &userpreferencesv1.ClusterUserPreferences{
+			PinnedResources: nil,
+		},
+		UnifiedResourcePreferences: rootPreferencesMock.UnifiedResourcePreferences,
+	}
+	mockedClient := &mockClient{preferences: rootPreferences}
 
+	newPreferences := &api.UserPreferences{
+		ClusterPreferences: &userpreferencesv1.ClusterUserPreferences{
+			PinnedResources: &userpreferencesv1.PinnedResourcesUserPreferences{
+				ResourceIds: []string{"foo", "bar"},
+			},
+		},
+	}
+
+	updatedPreferences, err := Update(t.Context(), mockedClient, nil, newPreferences)
+	require.NoError(t, err)
+
+	require.Equal(t, newPreferences.ClusterPreferences, mockedClient.upsertCalledWith.ClusterPreferences)
+	require.Equal(t, newPreferences.ClusterPreferences, updatedPreferences.ClusterPreferences)
+	require.Equal(t, rootPreferencesMock.UnifiedResourcePreferences, mockedClient.upsertCalledWith.UnifiedResourcePreferences)
+	require.Equal(t, userpreferencesv1.Theme_THEME_LIGHT, mockedClient.upsertCalledWith.Theme)
+}
+
+func TestUserPreferencesUpdateForRootAndLeaf(t *testing.T) {
 	mockedRootClient := &mockClient{preferences: rootPreferencesMock}
 	mockedLeafClient := &mockClient{preferences: leafPreferencesMock}
 
@@ -112,7 +130,7 @@ func TestUserPreferencesUpdateForRootAndLeaf(t *testing.T) {
 		},
 	}
 
-	updatedPreferences, err := Update(ctx, mockedRootClient, mockedLeafClient, newPreferences)
+	updatedPreferences, err := Update(t.Context(), mockedRootClient, mockedLeafClient, newPreferences)
 	require.NoError(t, err)
 	// ClusterPreferences field has been updated with the leaf cluster value.
 	require.Equal(t, updatedPreferences.ClusterPreferences, mockedLeafClient.upsertCalledWith.ClusterPreferences)
@@ -122,6 +140,48 @@ func TestUserPreferencesUpdateForRootAndLeaf(t *testing.T) {
 	require.Equal(t, newPreferences.UnifiedResourcePreferences, updatedPreferences.UnifiedResourcePreferences)
 	// Other user preferences have not been touched.
 	require.Equal(t, rootPreferencesMock.Theme, mockedRootClient.upsertCalledWith.Theme)
+}
+
+func TestNilUserPreferencesUpdate(t *testing.T) {
+	tests := []struct {
+		name                       string
+		leafPreferences            *userpreferencesv1.UserPreferences
+		expectedClusterPreferences *userpreferencesv1.ClusterUserPreferences
+	}{
+		{
+			name:                       "root",
+			expectedClusterPreferences: rootPreferencesMock.ClusterPreferences,
+		},
+		{
+			name:                       "leaf",
+			leafPreferences:            leafPreferencesMock,
+			expectedClusterPreferences: leafPreferencesMock.ClusterPreferences,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := t.Context()
+
+			mockedRootClient := &mockClient{preferences: rootPreferencesMock}
+			var leafClient Client
+			var mockedLeafClient *mockClient
+			if tt.leafPreferences != nil {
+				mockedLeafClient = &mockClient{preferences: tt.leafPreferences}
+				leafClient = mockedLeafClient
+			}
+
+			updatedPreferences, err := Update(ctx, mockedRootClient, leafClient, nil)
+			require.NoError(t, err)
+
+			require.Nil(t, mockedRootClient.upsertCalledWith)
+			if mockedLeafClient != nil {
+				require.Nil(t, mockedLeafClient.upsertCalledWith)
+			}
+			require.Equal(t, rootPreferencesMock.UnifiedResourcePreferences, updatedPreferences.UnifiedResourcePreferences)
+			require.Equal(t, tt.expectedClusterPreferences, updatedPreferences.ClusterPreferences)
+		})
+	}
 }
 
 type mockClient struct {


### PR DESCRIPTION
Backport #66899 to branch/v18

## Manual Test Plan
### Test Environment
Locally built app.

### Test Cases
- [x] tsh daemon no longer panic if it gets  null in `UpdateUserPreferences`.
- [x] tsh deamon recovers if a handler panics (I tested it calling `panic` manually).
- [x] Updating cluster preferences and pinned resources still works.