### PR TITLE
Extend WatchEvents/SPIFFEFederation RPCs for Scoped SPIFFE

### DIFF
--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -1352,16 +1352,21 @@ func (a *ServerWithRoles) hasWatchPermissionForKind(
 }
 
 // hasWatchPermissionForKind is the scoped equivalent of [ServerWithRoles.hasWatchPermissionForKind].
-// Currently only cert_authority with load_secrets=false is permitted for scoped identities.
+// Currently only cert_authority (with load_secrets=false) and spiffe_federation are permitted for
+// scoped identities. Both are cluster-global config and are authorized as unpinned root reads.
 func (a *ScopedServerWithRoles) hasWatchPermissionForKind(ctx context.Context, kind types.WatchKind) error {
-	if kind.Kind != types.KindCertAuthority {
+	ruleCtx := a.scopedContext.RuleContext()
+	switch kind.Kind {
+	case types.KindCertAuthority:
+		if kind.LoadSecrets {
+			return trace.AccessDenied("scoped identities are not permitted to watch cert_authority with load_secrets=true")
+		}
+		return a.scopedContext.CheckerContext.RiskyAuthorizeUnpinnedRead(ctx, services.UnpinnedReadCertAuthority, &ruleCtx)
+	case types.KindSPIFFEFederation:
+		return a.scopedContext.CheckerContext.RiskyAuthorizeUnpinnedRead(ctx, services.UnpinnedReadSPIFFEFederation, &ruleCtx)
+	default:
 		return trace.AccessDenied("scoped identities are not permitted to watch kind %q", kind.Kind)
 	}
-	if kind.LoadSecrets {
-		return trace.AccessDenied("scoped identities are not permitted to watch cert_authority with load_secrets=true")
-	}
-	ruleCtx := a.scopedContext.RuleContext()
-	return a.scopedContext.CheckerContext.RiskyAuthorizeUnpinnedRead(ctx, services.UnpinnedReadCertAuthority, &ruleCtx)
 }
 
 // DeleteAllNodes deletes all nodes in a given namespace

--- a/lib/auth/grpcserver.go
+++ b/lib/auth/grpcserver.go
@@ -6154,11 +6154,12 @@ func NewGRPCServer(cfg GRPCServerConfig) (*GRPCServer, error) {
 	machineidv1pb.RegisterWorkloadIdentityServiceServer(server, workloadIdentityService)
 
 	spiffeFederationService, err := machineidv1.NewSPIFFEFederationService(machineidv1.SPIFFEFederationServiceConfig{
-		Authorizer: cfg.Authorizer,
-		Backend:    cfg.AuthServer.Services.SPIFFEFederations,
-		Cache:      cfg.AuthServer.Cache,
-		Clock:      cfg.AuthServer.GetClock(),
-		Emitter:    cfg.Emitter,
+		Authorizer:       cfg.Authorizer,
+		ScopedAuthorizer: cfg.ScopedAuthorizer,
+		Backend:          cfg.AuthServer.Services.SPIFFEFederations,
+		Cache:            cfg.AuthServer.Cache,
+		Clock:            cfg.AuthServer.GetClock(),
+		Emitter:          cfg.Emitter,
 	})
 	if err != nil {
 		return nil, trace.Wrap(err, "creating SPIFFE federation service")

--- a/lib/auth/machineid/machineidv1/spiffe_federation_service.go
+++ b/lib/auth/machineid/machineidv1/spiffe_federation_service.go
@@ -50,8 +50,7 @@ type spiffeFederationReadWriter interface {
 type SPIFFEFederationServiceConfig struct {
 	// Authorizer is the authorizer service which checks access to resources.
 	Authorizer authz.Authorizer
-	// ScopedAuthorizer is the scoped equivalent of Authorizer, used by the
-	// read RPCs so that scoped identities (in addition to unscoped ones) may
+	// ScopedAuthorizer authorizes the read RPCs, allowing scoped identities to
 	// read SPIFFE federations.
 	ScopedAuthorizer authz.ScopedAuthorizer
 	// Backend will be used reading and writing the SPIFFE Federation resources.
@@ -124,9 +123,7 @@ func (s *SPIFFEFederationService) GetSPIFFEFederation(
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	// SPIFFE federations are cluster-global config with no scope of their own,
-	// so reads are authorized as an unpinned root read. This is equivalent to
-	// CheckAccessToKind(KindSPIFFEFederation, VerbRead) for unscoped callers.
+	// SPIFFE federations are cluster-global, so reads are an unpinned root read.
 	ruleCtx := authCtx.RuleContext()
 	if err := authCtx.CheckerContext.RiskyAuthorizeUnpinnedRead(ctx, services.UnpinnedReadSPIFFEFederation, &ruleCtx); err != nil {
 		return nil, trace.Wrap(err)
@@ -154,10 +151,7 @@ func (s *SPIFFEFederationService) ListSPIFFEFederations(
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	// SPIFFE federations are cluster-global config with no scope of their own,
-	// so reads are authorized as an unpinned root read. This is equivalent to
-	// CheckAccessToKind(KindSPIFFEFederation, VerbRead, VerbList) for unscoped
-	// callers.
+	// SPIFFE federations are cluster-global, so reads are an unpinned root read.
 	ruleCtx := authCtx.RuleContext()
 	if err := authCtx.CheckerContext.RiskyAuthorizeUnpinnedRead(ctx, services.UnpinnedReadSPIFFEFederations, &ruleCtx); err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/auth/machineid/machineidv1/spiffe_federation_service.go
+++ b/lib/auth/machineid/machineidv1/spiffe_federation_service.go
@@ -31,6 +31,7 @@ import (
 	apievents "github.com/gravitational/teleport/api/types/events"
 	"github.com/gravitational/teleport/lib/authz"
 	"github.com/gravitational/teleport/lib/events"
+	"github.com/gravitational/teleport/lib/services"
 )
 
 type spiffeFederationReader interface {
@@ -49,6 +50,10 @@ type spiffeFederationReadWriter interface {
 type SPIFFEFederationServiceConfig struct {
 	// Authorizer is the authorizer service which checks access to resources.
 	Authorizer authz.Authorizer
+	// ScopedAuthorizer is the scoped equivalent of Authorizer, used by the
+	// read RPCs so that scoped identities (in addition to unscoped ones) may
+	// read SPIFFE federations.
+	ScopedAuthorizer authz.ScopedAuthorizer
 	// Backend will be used reading and writing the SPIFFE Federation resources.
 	Backend spiffeFederationReadWriter
 	// Cache will be used when reading SPIFFE Federation resources.
@@ -72,6 +77,8 @@ func NewSPIFFEFederationService(
 		return nil, trace.BadParameter("cache service is required")
 	case cfg.Authorizer == nil:
 		return nil, trace.BadParameter("authorizer is required")
+	case cfg.ScopedAuthorizer == nil:
+		return nil, trace.BadParameter("scoped authorizer is required")
 	case cfg.Emitter == nil:
 		return nil, trace.BadParameter("emitter is required")
 	}
@@ -84,12 +91,13 @@ func NewSPIFFEFederationService(
 	}
 
 	return &SPIFFEFederationService{
-		authorizer: cfg.Authorizer,
-		backend:    cfg.Backend,
-		cache:      cfg.Cache,
-		clock:      cfg.Clock,
-		emitter:    cfg.Emitter,
-		logger:     cfg.Logger,
+		authorizer:       cfg.Authorizer,
+		scopedAuthorizer: cfg.ScopedAuthorizer,
+		backend:          cfg.Backend,
+		cache:            cfg.Cache,
+		clock:            cfg.Clock,
+		emitter:          cfg.Emitter,
+		logger:           cfg.Logger,
 	}, nil
 }
 
@@ -98,12 +106,13 @@ func NewSPIFFEFederationService(
 type SPIFFEFederationService struct {
 	machineidv1.UnimplementedSPIFFEFederationServiceServer
 
-	authorizer authz.Authorizer
-	backend    spiffeFederationReadWriter
-	cache      spiffeFederationReader
-	clock      clockwork.Clock
-	emitter    apievents.Emitter
-	logger     *slog.Logger
+	authorizer       authz.Authorizer
+	scopedAuthorizer authz.ScopedAuthorizer
+	backend          spiffeFederationReadWriter
+	cache            spiffeFederationReader
+	clock            clockwork.Clock
+	emitter          apievents.Emitter
+	logger           *slog.Logger
 }
 
 // GetSPIFFEFederation returns a SPIFFE Federation by name.
@@ -111,11 +120,15 @@ type SPIFFEFederationService struct {
 func (s *SPIFFEFederationService) GetSPIFFEFederation(
 	ctx context.Context, req *machineidv1.GetSPIFFEFederationRequest,
 ) (*machineidv1.SPIFFEFederation, error) {
-	authCtx, err := s.authorizer.Authorize(ctx)
+	authCtx, err := s.scopedAuthorizer.AuthorizeScoped(ctx)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	if err := authCtx.CheckAccessToKind(types.KindSPIFFEFederation, types.VerbRead); err != nil {
+	// SPIFFE federations are cluster-global config with no scope of their own,
+	// so reads are authorized as an unpinned root read. This is equivalent to
+	// CheckAccessToKind(KindSPIFFEFederation, VerbRead) for unscoped callers.
+	ruleCtx := authCtx.RuleContext()
+	if err := authCtx.CheckerContext.RiskyAuthorizeUnpinnedRead(ctx, services.UnpinnedReadSPIFFEFederation, &ruleCtx); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
@@ -137,11 +150,16 @@ func (s *SPIFFEFederationService) GetSPIFFEFederation(
 func (s *SPIFFEFederationService) ListSPIFFEFederations(
 	ctx context.Context, req *machineidv1.ListSPIFFEFederationsRequest,
 ) (*machineidv1.ListSPIFFEFederationsResponse, error) {
-	authCtx, err := s.authorizer.Authorize(ctx)
+	authCtx, err := s.scopedAuthorizer.AuthorizeScoped(ctx)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	if err := authCtx.CheckAccessToKind(types.KindSPIFFEFederation, types.VerbRead, types.VerbList); err != nil {
+	// SPIFFE federations are cluster-global config with no scope of their own,
+	// so reads are authorized as an unpinned root read. This is equivalent to
+	// CheckAccessToKind(KindSPIFFEFederation, VerbRead, VerbList) for unscoped
+	// callers.
+	ruleCtx := authCtx.RuleContext()
+	if err := authCtx.CheckerContext.RiskyAuthorizeUnpinnedRead(ctx, services.UnpinnedReadSPIFFEFederations, &ruleCtx); err != nil {
 		return nil, trace.Wrap(err)
 	}
 

--- a/lib/auth/machineid/machineidv1/spiffe_federation_service_test.go
+++ b/lib/auth/machineid/machineidv1/spiffe_federation_service_test.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/google/uuid"
 	"github.com/gravitational/trace"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/proto"
@@ -34,10 +35,12 @@ import (
 
 	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
 	machineidv1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/machineid/v1"
+	scopedaccessv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/access/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/types/events"
 	"github.com/gravitational/teleport/lib/auth/authtest"
 	libevents "github.com/gravitational/teleport/lib/events"
+	scopedaccess "github.com/gravitational/teleport/lib/scopes/access"
 )
 
 // TestSPIFFEFederationService_CreateSPIFFEFederation is an integration test
@@ -574,4 +577,102 @@ func TestSPIFFEFederationService_ListSPIFFEFederations(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestSPIFFEFederationService_ScopedIdentity verifies that a scope-pinned
+// identity can read SPIFFE federations via GetSPIFFEFederation and
+// ListSPIFFEFederations. SPIFFE federations are cluster-global config readable
+// by all identities (via the default implicit role), so an empty scoped role is
+// sufficient.
+func TestSPIFFEFederationService_ScopedIdentity(t *testing.T) {
+	t.Setenv("TELEPORT_UNSTABLE_SCOPES", "yes")
+	srv, _ := newTestTLSServer(t)
+	ctx := context.Background()
+
+	adminClient, err := srv.NewClient(authtest.TestAdmin())
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = adminClient.Close()
+	})
+
+	// Create a scoped role with an empty allow block (no explicit rules). Reads
+	// of cluster-global SPIFFE federations are granted via the default implicit
+	// role, so no extra permissions are required.
+	scopedSvc := adminClient.ScopedAccessServiceClient()
+	scopedRole, err := scopedSvc.CreateScopedRole(ctx, &scopedaccessv1.CreateScopedRoleRequest{
+		Role: &scopedaccessv1.ScopedRole{
+			Kind:    scopedaccess.KindScopedRole,
+			Version: types.V1,
+			Metadata: &headerv1.Metadata{
+				Name: "spiffe-federation-reader",
+			},
+			Scope: "/scopes",
+			Spec: &scopedaccessv1.ScopedRoleSpec{
+				AssignableScopes: []string{"/scopes/granted"},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	scopedUser, err := authtest.CreateUser(ctx, srv.Auth(), "scoped-reader")
+	require.NoError(t, err)
+
+	sraResp, err := scopedSvc.CreateScopedRoleAssignment(ctx, &scopedaccessv1.CreateScopedRoleAssignmentRequest{
+		Assignment: &scopedaccessv1.ScopedRoleAssignment{
+			Kind:    scopedaccess.KindScopedRoleAssignment,
+			SubKind: scopedaccess.SubKindDynamic,
+			Version: types.V1,
+			Metadata: &headerv1.Metadata{
+				Name: uuid.NewString(),
+			},
+			Scope: "/scopes",
+			Spec: &scopedaccessv1.ScopedRoleAssignmentSpec{
+				User: scopedUser.GetName(),
+				Assignments: []*scopedaccessv1.Assignment{
+					{Role: scopedRole.Role.Metadata.Name, Scope: "/scopes/granted"},
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+	waitForSRACache(t, srv, sraResp)
+
+	name := "example.com"
+	resource, err := srv.Auth().Services.SPIFFEFederations.CreateSPIFFEFederation(
+		ctx, &machineidv1pb.SPIFFEFederation{
+			Kind:    types.KindSPIFFEFederation,
+			Version: types.V1,
+			Metadata: &headerv1.Metadata{
+				Name: name,
+			},
+			Spec: &machineidv1pb.SPIFFEFederationSpec{
+				BundleSource: &machineidv1pb.SPIFFEFederationBundleSource{
+					HttpsWeb: &machineidv1pb.SPIFFEFederationBundleSourceHTTPSWeb{
+						BundleEndpointUrl: "https://example.com/bundle.json",
+					},
+				},
+			},
+		},
+	)
+	require.NoError(t, err)
+
+	scopedClient, err := srv.NewClient(authtest.TestScopedUser(scopedUser.GetName(), "/scopes/granted"))
+	require.NoError(t, err)
+	defer scopedClient.Close()
+
+	t.Run("GetSPIFFEFederation", func(t *testing.T) {
+		got, err := scopedClient.SPIFFEFederationServiceClient().GetSPIFFEFederation(ctx, &machineidv1pb.GetSPIFFEFederationRequest{
+			Name: name,
+		})
+		require.NoError(t, err)
+		require.Empty(t, cmp.Diff(resource, got, protocmp.Transform()))
+	})
+
+	t.Run("ListSPIFFEFederations", func(t *testing.T) {
+		resp, err := scopedClient.SPIFFEFederationServiceClient().ListSPIFFEFederations(ctx, &machineidv1pb.ListSPIFFEFederationsRequest{})
+		require.NoError(t, err)
+		require.True(t, slices.ContainsFunc(resp.SpiffeFederations, func(federation *machineidv1pb.SPIFFEFederation) bool {
+			return proto.Equal(resource, federation)
+		}))
+	})
 }

--- a/lib/auth/machineid/machineidv1/spiffe_federation_service_test.go
+++ b/lib/auth/machineid/machineidv1/spiffe_federation_service_test.go
@@ -587,7 +587,7 @@ func TestSPIFFEFederationService_ListSPIFFEFederations(t *testing.T) {
 func TestSPIFFEFederationService_ScopedIdentity(t *testing.T) {
 	t.Setenv("TELEPORT_UNSTABLE_SCOPES", "yes")
 	srv, _ := newTestTLSServer(t)
-	ctx := context.Background()
+	ctx := t.Context()
 
 	adminClient, err := srv.NewClient(authtest.TestAdmin())
 	require.NoError(t, err)

--- a/lib/auth/machineid/machineidv1/spiffe_federation_service_test.go
+++ b/lib/auth/machineid/machineidv1/spiffe_federation_service_test.go
@@ -40,6 +40,7 @@ import (
 	"github.com/gravitational/teleport/api/types/events"
 	"github.com/gravitational/teleport/lib/auth/authtest"
 	libevents "github.com/gravitational/teleport/lib/events"
+	"github.com/gravitational/teleport/lib/scopes"
 	scopedaccess "github.com/gravitational/teleport/lib/scopes/access"
 )
 
@@ -585,8 +586,7 @@ func TestSPIFFEFederationService_ListSPIFFEFederations(t *testing.T) {
 // by all identities (via the default implicit role), so an empty scoped role is
 // sufficient.
 func TestSPIFFEFederationService_ScopedIdentity(t *testing.T) {
-	t.Setenv("TELEPORT_UNSTABLE_SCOPES", "yes")
-	srv, _ := newTestTLSServer(t)
+	srv, _ := newTestTLSServerWithScopesFeatures(t, scopes.Features{Enabled: true})
 	ctx := t.Context()
 
 	adminClient, err := srv.NewClient(authtest.TestAdmin())

--- a/lib/auth/machineid/machineidv1/spiffe_federation_service_test.go
+++ b/lib/auth/machineid/machineidv1/spiffe_federation_service_test.go
@@ -599,60 +599,60 @@ func TestSPIFFEFederationService_ScopedIdentity(t *testing.T) {
 	// of cluster-global SPIFFE federations are granted via the default implicit
 	// role, so no extra permissions are required.
 	scopedSvc := adminClient.ScopedAccessServiceClient()
-	scopedRole, err := scopedSvc.CreateScopedRole(ctx, &scopedaccessv1.CreateScopedRoleRequest{
-		Role: &scopedaccessv1.ScopedRole{
+	scopedRole, err := scopedSvc.CreateScopedRole(ctx, scopedaccessv1.CreateScopedRoleRequest_builder{
+		Role: scopedaccessv1.ScopedRole_builder{
 			Kind:    scopedaccess.KindScopedRole,
 			Version: types.V1,
-			Metadata: &headerv1.Metadata{
+			Metadata: headerv1.Metadata_builder{
 				Name: "spiffe-federation-reader",
-			},
+			}.Build(),
 			Scope: "/scopes",
-			Spec: &scopedaccessv1.ScopedRoleSpec{
+			Spec: scopedaccessv1.ScopedRoleSpec_builder{
 				AssignableScopes: []string{"/scopes/granted"},
-			},
-		},
-	})
+			}.Build(),
+		}.Build(),
+	}.Build())
 	require.NoError(t, err)
 
 	scopedUser, err := authtest.CreateUser(ctx, srv.Auth(), "scoped-reader")
 	require.NoError(t, err)
 
-	sraResp, err := scopedSvc.CreateScopedRoleAssignment(ctx, &scopedaccessv1.CreateScopedRoleAssignmentRequest{
-		Assignment: &scopedaccessv1.ScopedRoleAssignment{
+	sraResp, err := scopedSvc.CreateScopedRoleAssignment(ctx, scopedaccessv1.CreateScopedRoleAssignmentRequest_builder{
+		Assignment: scopedaccessv1.ScopedRoleAssignment_builder{
 			Kind:    scopedaccess.KindScopedRoleAssignment,
 			SubKind: scopedaccess.SubKindDynamic,
 			Version: types.V1,
-			Metadata: &headerv1.Metadata{
+			Metadata: headerv1.Metadata_builder{
 				Name: uuid.NewString(),
-			},
+			}.Build(),
 			Scope: "/scopes",
-			Spec: &scopedaccessv1.ScopedRoleAssignmentSpec{
+			Spec: scopedaccessv1.ScopedRoleAssignmentSpec_builder{
 				User: scopedUser.GetName(),
 				Assignments: []*scopedaccessv1.Assignment{
-					{Role: scopedRole.Role.Metadata.Name, Scope: "/scopes/granted"},
+					scopedaccessv1.Assignment_builder{Role: scopedRole.GetRole().GetMetadata().GetName(), Scope: "/scopes/granted"}.Build(),
 				},
-			},
-		},
-	})
+			}.Build(),
+		}.Build(),
+	}.Build())
 	require.NoError(t, err)
 	waitForSRACache(t, srv, sraResp)
 
 	name := "example.com"
 	resource, err := srv.Auth().Services.SPIFFEFederations.CreateSPIFFEFederation(
-		ctx, &machineidv1pb.SPIFFEFederation{
+		ctx, machineidv1pb.SPIFFEFederation_builder{
 			Kind:    types.KindSPIFFEFederation,
 			Version: types.V1,
-			Metadata: &headerv1.Metadata{
+			Metadata: headerv1.Metadata_builder{
 				Name: name,
-			},
-			Spec: &machineidv1pb.SPIFFEFederationSpec{
-				BundleSource: &machineidv1pb.SPIFFEFederationBundleSource{
-					HttpsWeb: &machineidv1pb.SPIFFEFederationBundleSourceHTTPSWeb{
+			}.Build(),
+			Spec: machineidv1pb.SPIFFEFederationSpec_builder{
+				BundleSource: machineidv1pb.SPIFFEFederationBundleSource_builder{
+					HttpsWeb: machineidv1pb.SPIFFEFederationBundleSourceHTTPSWeb_builder{
 						BundleEndpointUrl: "https://example.com/bundle.json",
-					},
-				},
-			},
-		},
+					}.Build(),
+				}.Build(),
+			}.Build(),
+		}.Build(),
 	)
 	require.NoError(t, err)
 
@@ -661,17 +661,17 @@ func TestSPIFFEFederationService_ScopedIdentity(t *testing.T) {
 	defer scopedClient.Close()
 
 	t.Run("GetSPIFFEFederation", func(t *testing.T) {
-		got, err := scopedClient.SPIFFEFederationServiceClient().GetSPIFFEFederation(ctx, &machineidv1pb.GetSPIFFEFederationRequest{
+		got, err := scopedClient.SPIFFEFederationServiceClient().GetSPIFFEFederation(ctx, machineidv1pb.GetSPIFFEFederationRequest_builder{
 			Name: name,
-		})
+		}.Build())
 		require.NoError(t, err)
 		require.Empty(t, cmp.Diff(resource, got, protocmp.Transform()))
 	})
 
 	t.Run("ListSPIFFEFederations", func(t *testing.T) {
-		resp, err := scopedClient.SPIFFEFederationServiceClient().ListSPIFFEFederations(ctx, &machineidv1pb.ListSPIFFEFederationsRequest{})
+		resp, err := scopedClient.SPIFFEFederationServiceClient().ListSPIFFEFederations(ctx, machineidv1pb.ListSPIFFEFederationsRequest_builder{}.Build())
 		require.NoError(t, err)
-		require.True(t, slices.ContainsFunc(resp.SpiffeFederations, func(federation *machineidv1pb.SPIFFEFederation) bool {
+		require.True(t, slices.ContainsFunc(resp.GetSpiffeFederations(), func(federation *machineidv1pb.SPIFFEFederation) bool {
 			return proto.Equal(resource, federation)
 		}))
 	})

--- a/lib/auth/tls_test.go
+++ b/lib/auth/tls_test.go
@@ -5302,6 +5302,27 @@ func TestWatchEvents_ScopedIdentity(t *testing.T) {
 		}
 	})
 
+	t.Run("spiffe_federation", func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+		defer cancel()
+
+		watcher, err := scopedClient.NewWatcher(ctx, types.Watch{
+			Name: "spiffe-federation-watch",
+			Kinds: []types.WatchKind{{
+				Kind: types.KindSPIFFEFederation,
+			}},
+		})
+		require.NoError(t, err)
+		defer watcher.Close()
+
+		select {
+		case e := <-watcher.Events():
+			require.Equal(t, types.OpInit, e.Type)
+		case <-watcher.Done():
+			t.Fatalf("watcher closed unexpectedly: %v", watcher.Error())
+		}
+	})
+
 	t.Run("ca with secrets", func(t *testing.T) {
 		ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
 		defer cancel()

--- a/lib/services/scoped_access_checker_context.go
+++ b/lib/services/scoped_access_checker_context.go
@@ -499,4 +499,18 @@ var (
 		kind:          types.KindVnetConfig,
 		verbs:         []string{types.VerbRead},
 	}
+	// UnpinnedReadSPIFFEFederation is a special authorization to complete an
+	// unscoped access check to read a SPIFFE federation.
+	UnpinnedReadSPIFFEFederation = UnpinnedReadAuthorization{
+		resourceScope: scopes.Root,
+		kind:          types.KindSPIFFEFederation,
+		verbs:         []string{types.VerbRead},
+	}
+	// UnpinnedReadSPIFFEFederations is a special authorization to complete an
+	// unscoped access check to list and read SPIFFE federations.
+	UnpinnedReadSPIFFEFederations = UnpinnedReadAuthorization{
+		resourceScope: scopes.Root,
+		kind:          types.KindSPIFFEFederation,
+		verbs:         []string{types.VerbList, types.VerbRead},
+	}
 )


### PR DESCRIPTION
Part of https://github.com/gravitational/teleport/issues/66349

Depends on https://github.com/gravitational/teleport/pull/67133

Extends the List/Get SPIFFEFederation RPCs and the WatchEvents RPC for the SPIFFEFederation kind to support scoped identities - this unblocks future work to add scopes support for SPIFFE issuance in Teleport.

## Manual Test Plan
### Test Environment

Local cluster

### Test Cases

- [x] Regression: Spin up unscoped `tbot`, validate that SPIFFEFederation cache initialises correctly and trust bundle is output.
