### PR TITLE
Remove lib/client as a dependency of lib/config

### DIFF
--- a/e2e/aws/fixtures_test.go
+++ b/e2e/aws/fixtures_test.go
@@ -33,10 +33,10 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/integration/helpers"
 	"github.com/gravitational/teleport/lib/auth/testauthority"
-	"github.com/gravitational/teleport/lib/client"
 	"github.com/gravitational/teleport/lib/service/servicecfg"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/utils/log/logtest"
+	"github.com/gravitational/teleport/lib/utils/parse"
 )
 
 // hostUser is the name of the host user used for tests.
@@ -107,7 +107,7 @@ func mustGetEnv(t *testing.T, key string) string {
 func mustGetDiscoveryMatcherLabels(t *testing.T) types.Labels {
 	t.Helper()
 	labelSpec := mustGetEnv(t, discoveryMatcherLabelsEnv)
-	labels, err := client.ParseLabelSpec(labelSpec)
+	labels, err := parse.LabelSelectorSpec(labelSpec)
 	require.NoError(t, err)
 	out := make(types.Labels)
 	for k, v := range labels {

--- a/fuzz/oss-fuzz-build.sh
+++ b/fuzz/oss-fuzz-build.sh
@@ -68,8 +68,8 @@ build_teleport_fuzzers() {
   compile_native_go_fuzzer $TELEPORT_PREFIX/lib/client \
     FuzzParseProxyHost fuzz_parse_proxy_host
 
-  compile_native_go_fuzzer $TELEPORT_PREFIX/lib/client \
-    FuzzParseLabelSpec fuzz_parse_label_spec
+  compile_native_go_fuzzer $TELEPORT_PREFIX/lib/utils/parse \
+    FuzzLabelSpec fuzz_label_spec
 
   compile_native_go_fuzzer $TELEPORT_PREFIX/lib/client \
     FuzzParseSearchKeywords fuzz_parse_search_keywords

--- a/lib/client/api.go
+++ b/lib/client/api.go
@@ -5089,50 +5089,6 @@ func (tc *TeleportClient) LoadTLSConfigForClusters(clusters []string) (*tls.Conf
 	return tlsConfig, nil
 }
 
-// ParseLabelSpec parses a string like 'name=value,"long name"="quoted value"` into a map like
-// { "name" -> "value", "long name" -> "quoted value" }
-func ParseLabelSpec(spec string) (map[string]string, error) {
-	var tokens []string
-	openQuotes := false
-	var tokenStart, assignCount int
-	specLen := len(spec)
-	// tokenize the label spec:
-	for i, ch := range spec {
-		endOfToken := false
-		// end of line?
-		if i+utf8.RuneLen(ch) == specLen {
-			i += utf8.RuneLen(ch)
-			endOfToken = true
-		}
-		switch ch {
-		case '"':
-			openQuotes = !openQuotes
-		case '=', ',', ';':
-			if !openQuotes {
-				endOfToken = true
-				if ch == '=' {
-					assignCount++
-				}
-			}
-		}
-		if endOfToken && i > tokenStart {
-			tokens = append(tokens, strings.TrimSpace(strings.Trim(spec[tokenStart:i], `"`)))
-			tokenStart = i + 1
-		}
-	}
-	// simple validation of tokenization: must have an even number of tokens (because they're pairs)
-	// and the number of such pairs must be equal the number of assignments
-	if len(tokens)%2 != 0 || assignCount != len(tokens)/2 {
-		return nil, fmt.Errorf("invalid label spec: '%s', should be 'key=value'", spec)
-	}
-	// break tokens in pairs and put into a map:
-	labels := make(map[string]string)
-	for i := 0; i < len(tokens); i += 2 {
-		labels[tokens[i]] = tokens[i+1]
-	}
-	return labels, nil
-}
-
 // ParseSearchKeywords parses a string ie: foo,bar,"quoted value"` into a slice of
 // strings: ["foo", "bar", "quoted value"].
 // Almost a replica to ParseLabelSpec, but with few modifications such as

--- a/lib/client/api_test.go
+++ b/lib/client/api_test.go
@@ -228,42 +228,6 @@ func TestNew(t *testing.T) {
 	require.NotNil(t, la)
 }
 
-func TestParseLabels(t *testing.T) {
-	// simplest case:
-	m, err := ParseLabelSpec("key=value")
-	require.NotNil(t, m)
-	require.NoError(t, err)
-	require.Empty(t, cmp.Diff(m, map[string]string{
-		"key": "value",
-	}))
-
-	// multiple values:
-	m, err = ParseLabelSpec(`type="database";" role"=master,ver="mongoDB v1,2"`)
-	require.NotNil(t, m)
-	require.NoError(t, err)
-	require.Len(t, m, 3)
-	require.Equal(t, "master", m["role"])
-	require.Equal(t, "database", m["type"])
-	require.Equal(t, "mongoDB v1,2", m["ver"])
-
-	// multiple and unicode:
-	m, err = ParseLabelSpec(`服务器环境=测试,操作系统类别=Linux,机房=华北`)
-	require.NoError(t, err)
-	require.NotNil(t, m)
-	require.Len(t, m, 3)
-	require.Equal(t, "测试", m["服务器环境"])
-	require.Equal(t, "Linux", m["操作系统类别"])
-	require.Equal(t, "华北", m["机房"])
-
-	// invalid specs
-	m, err = ParseLabelSpec(`type="database,"role"=master,ver="mongoDB v1,2"`)
-	require.Nil(t, m)
-	require.Error(t, err)
-	m, err = ParseLabelSpec(`type="database",role,master`)
-	require.Nil(t, m)
-	require.Error(t, err)
-}
-
 func TestPortsParsing(t *testing.T) {
 	// empty:
 	ports, err := ParsePortForwardSpec(nil)

--- a/lib/client/fuzz_test.go
+++ b/lib/client/fuzz_test.go
@@ -36,17 +36,6 @@ func FuzzParseProxyHost(f *testing.F) {
 	})
 }
 
-func FuzzParseLabelSpec(f *testing.F) {
-	f.Add("XXXX=YYYY")
-	f.Add(`type="database";" role"=master,ver="mongoDB v1,2"`)
-
-	f.Fuzz(func(t *testing.T, spec string) {
-		require.NotPanics(t, func() {
-			_, _ = ParseLabelSpec(spec)
-		})
-	})
-}
-
 func FuzzParseSearchKeywords(f *testing.F) {
 	f.Add("XXXX,YYYY", ',')
 	f.Add(`XXXX"YYYY`, '"')

--- a/lib/config/configuration.go
+++ b/lib/config/configuration.go
@@ -58,7 +58,6 @@ import (
 	"github.com/gravitational/teleport/lib/backend"
 	"github.com/gravitational/teleport/lib/backend/lite"
 	"github.com/gravitational/teleport/lib/backend/memory"
-	"github.com/gravitational/teleport/lib/client"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/integrations/externalauditstorage/easconfig"
 	"github.com/gravitational/teleport/lib/integrations/samlidp/samlidpconfig"
@@ -70,6 +69,7 @@ import (
 	"github.com/gravitational/teleport/lib/utils"
 	awsregion "github.com/gravitational/teleport/lib/utils/aws/region"
 	logutils "github.com/gravitational/teleport/lib/utils/log"
+	"github.com/gravitational/teleport/lib/utils/parse"
 	libslices "github.com/gravitational/teleport/lib/utils/slices"
 )
 
@@ -2681,7 +2681,7 @@ func Configure(clf *CommandLineFlags, cfg *servicecfg.Config, legacyAppFlags boo
 		var sessionTags map[string]string
 		if clf.DatabaseAWSSessionTags != "" {
 			var err error
-			sessionTags, err = client.ParseLabelSpec(clf.DatabaseAWSSessionTags)
+			sessionTags, err = parse.LabelSelectorSpec(clf.DatabaseAWSSessionTags)
 			if err != nil {
 				return trace.Wrap(err)
 			}
@@ -3028,7 +3028,7 @@ func ConfigureOpenSSH(clf *CommandLineFlags, cfg *servicecfg.Config) error {
 		}
 		cfg.OpenSSH.AdditionalPrincipals = append(cfg.OpenSSH.AdditionalPrincipals, principal)
 	}
-	cfg.OpenSSH.Labels, err = client.ParseLabelSpec(clf.Labels)
+	cfg.OpenSSH.Labels, err = parse.LabelSelectorSpec(clf.Labels)
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -3051,7 +3051,7 @@ func ConfigureOpenSSH(clf *CommandLineFlags, cfg *servicecfg.Config) error {
 // dynamic labels.
 func parseLabels(spec string) (map[string]string, services.CommandLabels, error) {
 	// Base syntax parsing, the spec must be in the form of 'key=value,more="better"'.
-	lmap, err := client.ParseLabelSpec(spec)
+	lmap, err := parse.LabelSelectorSpec(spec)
 	if err != nil {
 		return nil, nil, trace.Wrap(err)
 	}

--- a/lib/config/database.go
+++ b/lib/config/database.go
@@ -28,10 +28,10 @@ import (
 	"github.com/gravitational/trace"
 
 	"github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/teleport/lib/client"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/service/servicecfg"
 	"github.com/gravitational/teleport/lib/services"
+	"github.com/gravitational/teleport/lib/utils/parse"
 )
 
 // databaseConfigTemplateFunc list of template functions used on the database
@@ -703,10 +703,10 @@ func (f *DatabaseSampleFlags) CheckAndSetDefaults() error {
 	}
 
 	var err error
-	if f.AWSTags, err = client.ParseLabelSpec(f.AWSRawTags); err != nil {
+	if f.AWSTags, err = parse.LabelSelectorSpec(f.AWSRawTags); err != nil {
 		return trace.Wrap(err)
 	}
-	if f.AzureTags, err = client.ParseLabelSpec(f.AzureRawTags); err != nil {
+	if f.AzureTags, err = parse.LabelSelectorSpec(f.AzureRawTags); err != nil {
 		return trace.Wrap(err)
 	}
 
@@ -726,7 +726,7 @@ func (f *DatabaseSampleFlags) CheckAndSetDefaults() error {
 
 	// Labels for "resources" section.
 	for i := range f.DynamicResourcesRawLabels {
-		labels, err := client.ParseLabelSpec(f.DynamicResourcesRawLabels[i])
+		labels, err := parse.LabelSelectorSpec(f.DynamicResourcesRawLabels[i])
 		if err != nil {
 			return trace.Wrap(err)
 		}

--- a/lib/config/fileconf.go
+++ b/lib/config/fileconf.go
@@ -51,13 +51,13 @@ import (
 	"github.com/gravitational/teleport/api/utils/tlsutils"
 	"github.com/gravitational/teleport/lib/automaticupgrades"
 	"github.com/gravitational/teleport/lib/backend"
-	"github.com/gravitational/teleport/lib/client"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/scopes"
 	"github.com/gravitational/teleport/lib/scopes/joining"
 	"github.com/gravitational/teleport/lib/service/servicecfg"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/parse"
 	"github.com/gravitational/teleport/session/networking/x11"
 	"github.com/gravitational/teleport/session/pam/pamcfg"
 )
@@ -339,7 +339,7 @@ func makeSampleSSHConfig(conf *servicecfg.Config, flags SampleFlags, enabled boo
 	if enabled {
 		s.EnabledFlag = "yes"
 		s.ListenAddress = conf.SSH.Addr.Addr
-		labels, err := client.ParseLabelSpec(flags.NodeLabels)
+		labels, err := parse.LabelSelectorSpec(flags.NodeLabels)
 		if err != nil {
 			return s, trace.Wrap(err)
 		}

--- a/lib/tbot/cli/start_kubernetes_v2.go
+++ b/lib/tbot/cli/start_kubernetes_v2.go
@@ -25,9 +25,9 @@ import (
 	"github.com/alecthomas/kingpin/v2"
 	"github.com/gravitational/trace"
 
-	"github.com/gravitational/teleport/lib/client"
 	"github.com/gravitational/teleport/lib/tbot/config"
 	"github.com/gravitational/teleport/lib/tbot/services/k8s"
+	"github.com/gravitational/teleport/lib/utils/parse"
 )
 
 // KubernetesV2Command implements `tbot start kubernetes` and
@@ -81,7 +81,7 @@ func (c *KubernetesV2Command) ApplyConfig(cfg *config.BotConfig, l *slog.Logger)
 	}
 
 	for _, s := range c.KubernetesClusterLabels {
-		labels, err := client.ParseLabelSpec(s)
+		labels, err := parse.LabelSelectorSpec(s)
 		if err != nil {
 			return trace.Wrap(err)
 		}

--- a/lib/tbot/cli/start_workload_identity_api.go
+++ b/lib/tbot/cli/start_workload_identity_api.go
@@ -23,9 +23,9 @@ import (
 	"github.com/alecthomas/kingpin/v2"
 	"github.com/gravitational/trace"
 
-	"github.com/gravitational/teleport/lib/client"
 	"github.com/gravitational/teleport/lib/tbot/config"
 	"github.com/gravitational/teleport/lib/tbot/services/workloadidentity"
+	"github.com/gravitational/teleport/lib/utils/parse"
 )
 
 // WorkloadIdentityAPICommand implements `tbot start workload-identity-api` and
@@ -89,7 +89,7 @@ func (c *WorkloadIdentityAPICommand) ApplyConfig(cfg *config.BotConfig, l *slog.
 	case c.NameSelector != "":
 		svc.Selector.Name = c.NameSelector
 	case c.LabelSelector != "":
-		labels, err := client.ParseLabelSpec(c.LabelSelector)
+		labels, err := parse.LabelSelectorSpec(c.LabelSelector)
 		if err != nil {
 			return trace.Wrap(err, "parsing label-selector")
 		}

--- a/lib/tbot/cli/start_workload_identity_aws_ra.go
+++ b/lib/tbot/cli/start_workload_identity_aws_ra.go
@@ -24,9 +24,9 @@ import (
 	"github.com/alecthomas/kingpin/v2"
 	"github.com/gravitational/trace"
 
-	"github.com/gravitational/teleport/lib/client"
 	"github.com/gravitational/teleport/lib/tbot/config"
 	"github.com/gravitational/teleport/lib/tbot/services/awsra"
+	"github.com/gravitational/teleport/lib/utils/parse"
 )
 
 // WorkloadIdentityAWSRACommand implements `tbot start workload-identity-aws-ra`
@@ -155,7 +155,7 @@ func (c *WorkloadIdentityAWSRACommand) ApplyConfig(cfg *config.BotConfig, l *slo
 	case c.NameSelector != "":
 		svc.Selector.Name = c.NameSelector
 	case c.LabelSelector != "":
-		labels, err := client.ParseLabelSpec(c.LabelSelector)
+		labels, err := parse.LabelSelectorSpec(c.LabelSelector)
 		if err != nil {
 			return trace.Wrap(err, "parsing --label-selector")
 		}

--- a/lib/tbot/cli/start_workload_identity_jwt.go
+++ b/lib/tbot/cli/start_workload_identity_jwt.go
@@ -23,9 +23,9 @@ import (
 	"github.com/alecthomas/kingpin/v2"
 	"github.com/gravitational/trace"
 
-	"github.com/gravitational/teleport/lib/client"
 	"github.com/gravitational/teleport/lib/tbot/config"
 	"github.com/gravitational/teleport/lib/tbot/services/workloadidentity"
+	"github.com/gravitational/teleport/lib/utils/parse"
 )
 
 // WorkloadIdentityJWTCommand implements `tbot start workload-identity-jwt` and
@@ -95,7 +95,7 @@ func (c *WorkloadIdentityJWTCommand) ApplyConfig(cfg *config.BotConfig, l *slog.
 	case c.NameSelector != "":
 		svc.Selector.Name = c.NameSelector
 	case c.LabelSelector != "":
-		labels, err := client.ParseLabelSpec(c.LabelSelector)
+		labels, err := parse.LabelSelectorSpec(c.LabelSelector)
 		if err != nil {
 			return trace.Wrap(err, "parsing --label-selector")
 		}

--- a/lib/tbot/cli/start_workload_identity_x509.go
+++ b/lib/tbot/cli/start_workload_identity_x509.go
@@ -23,9 +23,9 @@ import (
 	"github.com/alecthomas/kingpin/v2"
 	"github.com/gravitational/trace"
 
-	"github.com/gravitational/teleport/lib/client"
 	"github.com/gravitational/teleport/lib/tbot/config"
 	"github.com/gravitational/teleport/lib/tbot/services/workloadidentity"
+	"github.com/gravitational/teleport/lib/utils/parse"
 )
 
 // WorkloadIdentityX509Command implements `tbot start workload-identity-x509` and
@@ -93,7 +93,7 @@ func (c *WorkloadIdentityX509Command) ApplyConfig(cfg *config.BotConfig, l *slog
 	case c.NameSelector != "":
 		svc.Selector.Name = c.NameSelector
 	case c.LabelSelector != "":
-		labels, err := client.ParseLabelSpec(c.LabelSelector)
+		labels, err := parse.LabelSelectorSpec(c.LabelSelector)
 		if err != nil {
 			return trace.Wrap(err, "parsing --label-selector")
 		}

--- a/lib/utils/parse/fuzz_test.go
+++ b/lib/utils/parse/fuzz_test.go
@@ -24,6 +24,17 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func FuzzLabelSpec(f *testing.F) {
+	f.Add("XXXX=YYYY")
+	f.Add(`type="database";" role"=master,ver="mongoDB v1,2"`)
+
+	f.Fuzz(func(t *testing.T, spec string) {
+		require.NotPanics(t, func() {
+			_, _ = LabelSelectorSpec(spec)
+		})
+	})
+}
+
 func FuzzNewExpression(f *testing.F) {
 	f.Add("")
 	f.Add("foo")

--- a/lib/utils/parse/parse.go
+++ b/lib/utils/parse/parse.go
@@ -24,10 +24,12 @@
 package parse
 
 import (
+	"fmt"
 	"net/mail"
 	"regexp"
 	"strings"
 	"unicode"
+	"unicode/utf8"
 
 	"github.com/gravitational/trace"
 
@@ -45,6 +47,50 @@ const (
 	// RegexpReplaceFnName is a name for regexp.replace function.
 	RegexpReplaceFnName = "regexp.replace"
 )
+
+// LabelSelectorSpec parses a string like 'name=value,"long name"="quoted value"` into a map like
+// { "name" -> "value", "long name" -> "quoted value" }.
+func LabelSelectorSpec(spec string) (map[string]string, error) {
+	var tokens []string
+	openQuotes := false
+	var tokenStart, assignCount int
+	specLen := len(spec)
+	// tokenize the label spec:
+	for i, ch := range spec {
+		endOfToken := false
+		// end of line?
+		if i+utf8.RuneLen(ch) == specLen {
+			i += utf8.RuneLen(ch)
+			endOfToken = true
+		}
+		switch ch {
+		case '"':
+			openQuotes = !openQuotes
+		case '=', ',', ';':
+			if !openQuotes {
+				endOfToken = true
+				if ch == '=' {
+					assignCount++
+				}
+			}
+		}
+		if endOfToken && i > tokenStart {
+			tokens = append(tokens, strings.TrimSpace(strings.Trim(spec[tokenStart:i], `"`)))
+			tokenStart = i + 1
+		}
+	}
+	// simple validation of tokenization: must have an even number of tokens (because they're pairs)
+	// and the number of such pairs must be equal the number of assignments
+	if len(tokens)%2 != 0 || assignCount != len(tokens)/2 {
+		return nil, fmt.Errorf("invalid label spec: '%s', should be 'key=value'", spec)
+	}
+	// break tokens in pairs and put into a map:
+	labels := make(map[string]string)
+	for i := 0; i < len(tokens); i += 2 {
+		labels[tokens[i]] = tokens[i+1]
+	}
+	return labels, nil
+}
 
 var (
 	traitsTemplateParser = mustNewTraitsTemplateParser()

--- a/lib/utils/parse/parse_test.go
+++ b/lib/utils/parse/parse_test.go
@@ -22,9 +22,46 @@ import (
 	"regexp"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/gravitational/trace"
 	"github.com/stretchr/testify/require"
 )
+
+func TestParseLabels(t *testing.T) {
+	// simplest case:
+	m, err := LabelSelectorSpec("key=value")
+	require.NotNil(t, m)
+	require.NoError(t, err)
+	require.Empty(t, cmp.Diff(m, map[string]string{
+		"key": "value",
+	}))
+
+	// multiple values:
+	m, err = LabelSelectorSpec(`type="database";" role"=master,ver="mongoDB v1,2"`)
+	require.NotNil(t, m)
+	require.NoError(t, err)
+	require.Len(t, m, 3)
+	require.Equal(t, "master", m["role"])
+	require.Equal(t, "database", m["type"])
+	require.Equal(t, "mongoDB v1,2", m["ver"])
+
+	// multiple and unicode:
+	m, err = LabelSelectorSpec(`服务器环境=测试,操作系统类别=Linux,机房=华北`)
+	require.NoError(t, err)
+	require.NotNil(t, m)
+	require.Len(t, m, 3)
+	require.Equal(t, "测试", m["服务器环境"])
+	require.Equal(t, "Linux", m["操作系统类别"])
+	require.Equal(t, "华北", m["机房"])
+
+	// invalid specs
+	m, err = LabelSelectorSpec(`type="database,"role"=master,ver="mongoDB v1,2"`)
+	require.Nil(t, m)
+	require.Error(t, err)
+	m, err = LabelSelectorSpec(`type="database",role,master`)
+	require.Nil(t, m)
+	require.Error(t, err)
+}
 
 // TestVariable tests variable parsing
 func TestVariable(t *testing.T) {

--- a/tool/tctl/common/alert_command.go
+++ b/tool/tctl/common/alert_command.go
@@ -36,10 +36,10 @@ import (
 	apiutils "github.com/gravitational/teleport/api/utils"
 	"github.com/gravitational/teleport/lib/asciitable"
 	"github.com/gravitational/teleport/lib/auth/authclient"
-	libclient "github.com/gravitational/teleport/lib/client"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/service/servicecfg"
 	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/parse"
 	commonclient "github.com/gravitational/teleport/tool/tctl/common/client"
 	tctlcfg "github.com/gravitational/teleport/tool/tctl/common/config"
 )
@@ -215,7 +215,7 @@ func (c *AlertCommand) ClearAck(ctx context.Context, client *authclient.Client) 
 }
 
 func (c *AlertCommand) List(ctx context.Context, client *authclient.Client) error {
-	labels, err := libclient.ParseLabelSpec(c.labels)
+	labels, err := parse.LabelSelectorSpec(c.labels)
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -299,7 +299,7 @@ func calculateTTL(expiration *time.Time) time.Duration {
 }
 
 func (c *AlertCommand) Create(ctx context.Context, client *authclient.Client) error {
-	labels, err := libclient.ParseLabelSpec(c.labels)
+	labels, err := parse.LabelSelectorSpec(c.labels)
 	if err != nil {
 		return trace.Wrap(err)
 	}

--- a/tool/tctl/common/app_command.go
+++ b/tool/tctl/common/app_command.go
@@ -34,6 +34,7 @@ import (
 	libclient "github.com/gravitational/teleport/lib/client"
 	"github.com/gravitational/teleport/lib/service/servicecfg"
 	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/parse"
 	commonclient "github.com/gravitational/teleport/tool/tctl/common/client"
 	tctlcfg "github.com/gravitational/teleport/tool/tctl/common/config"
 	"github.com/gravitational/teleport/tool/tctl/common/resources"
@@ -92,7 +93,7 @@ func (c *AppsCommand) TryRun(ctx context.Context, cmd string, clientFunc commonc
 // ListApps prints the list of applications that have recently sent heartbeats
 // to the cluster.
 func (c *AppsCommand) ListApps(ctx context.Context, clt *authclient.Client) error {
-	labels, err := libclient.ParseLabelSpec(c.labels)
+	labels, err := parse.LabelSelectorSpec(c.labels)
 	if err != nil {
 		return trace.Wrap(err)
 	}

--- a/tool/tctl/common/db_command.go
+++ b/tool/tctl/common/db_command.go
@@ -34,6 +34,7 @@ import (
 	libclient "github.com/gravitational/teleport/lib/client"
 	"github.com/gravitational/teleport/lib/service/servicecfg"
 	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/parse"
 	commonclient "github.com/gravitational/teleport/tool/tctl/common/client"
 	tctlcfg "github.com/gravitational/teleport/tool/tctl/common/config"
 )
@@ -91,7 +92,7 @@ func (c *DBCommand) TryRun(ctx context.Context, cmd string, clientFunc commoncli
 // ListDatabases prints the list of database proxies that have recently sent
 // heartbeats to the cluster.
 func (c *DBCommand) ListDatabases(ctx context.Context, clt *authclient.Client) error {
-	labels, err := libclient.ParseLabelSpec(c.labels)
+	labels, err := parse.LabelSelectorSpec(c.labels)
 	if err != nil {
 		return trace.Wrap(err)
 	}

--- a/tool/tctl/common/kube_command.go
+++ b/tool/tctl/common/kube_command.go
@@ -34,6 +34,7 @@ import (
 	libclient "github.com/gravitational/teleport/lib/client"
 	"github.com/gravitational/teleport/lib/service/servicecfg"
 	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/parse"
 	commonclient "github.com/gravitational/teleport/tool/tctl/common/client"
 	tctlcfg "github.com/gravitational/teleport/tool/tctl/common/config"
 	"github.com/gravitational/teleport/tool/tctl/common/resources"
@@ -91,7 +92,7 @@ func (c *KubeCommand) TryRun(ctx context.Context, cmd string, clientFunc commonc
 // ListKube prints the list of kube clusters that have recently sent heartbeats
 // to the cluster.
 func (c *KubeCommand) ListKube(ctx context.Context, clt *authclient.Client) error {
-	labels, err := libclient.ParseLabelSpec(c.labels)
+	labels, err := parse.LabelSelectorSpec(c.labels)
 	if err != nil {
 		return trace.Wrap(err)
 	}

--- a/tool/tctl/common/node_command.go
+++ b/tool/tctl/common/node_command.go
@@ -42,6 +42,7 @@ import (
 	"github.com/gravitational/teleport/lib/service/servicecfg"
 	"github.com/gravitational/teleport/lib/tlsca"
 	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/parse"
 	commonclient "github.com/gravitational/teleport/tool/tctl/common/client"
 	tctlcfg "github.com/gravitational/teleport/tool/tctl/common/config"
 	"github.com/gravitational/teleport/tool/tctl/common/resources"
@@ -238,7 +239,7 @@ func (c *NodeCommand) Invite(ctx context.Context, client *authclient.Client) err
 // ListActive retrieves the list of nodes who recently sent heartbeats to
 // to a cluster and prints it to stdout
 func (c *NodeCommand) ListActive(ctx context.Context, clt *authclient.Client) error {
-	labels, err := libclient.ParseLabelSpec(c.labels)
+	labels, err := parse.LabelSelectorSpec(c.labels)
 	if err != nil {
 		return trace.Wrap(err)
 	}

--- a/tool/tctl/common/notification_command.go
+++ b/tool/tctl/common/notification_command.go
@@ -40,10 +40,10 @@ import (
 	"github.com/gravitational/teleport/api/utils/clientutils"
 	"github.com/gravitational/teleport/lib/asciitable"
 	"github.com/gravitational/teleport/lib/auth/authclient"
-	libclient "github.com/gravitational/teleport/lib/client"
 	"github.com/gravitational/teleport/lib/itertools/stream"
 	"github.com/gravitational/teleport/lib/service/servicecfg"
 	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/parse"
 	"github.com/gravitational/teleport/tool/common"
 	commonclient "github.com/gravitational/teleport/tool/tctl/common/client"
 	tctlcfg "github.com/gravitational/teleport/tool/tctl/common/config"
@@ -125,7 +125,7 @@ func (n *NotificationCommand) TryRun(ctx context.Context, cmd string, clientFunc
 
 // Create creates a new notification.
 func (n *NotificationCommand) Create(ctx context.Context, client *authclient.Client) error {
-	labels, err := libclient.ParseLabelSpec(n.labels)
+	labels, err := parse.LabelSelectorSpec(n.labels)
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -242,7 +242,7 @@ func (n *NotificationCommand) Create(ctx context.Context, client *authclient.Cli
 }
 
 func (n *NotificationCommand) List(ctx context.Context, client *authclient.Client) error {
-	labels, err := libclient.ParseLabelSpec(n.labels)
+	labels, err := parse.LabelSelectorSpec(n.labels)
 	if err != nil {
 		return trace.Wrap(err)
 	}

--- a/tool/tctl/common/plugin/awsic.go
+++ b/tool/tctl/common/plugin/awsic.go
@@ -31,10 +31,10 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	apicommon "github.com/gravitational/teleport/api/types/common"
 	icfilters "github.com/gravitational/teleport/lib/aws/identitycenter/filters"
-	"github.com/gravitational/teleport/lib/client"
 	awsutils "github.com/gravitational/teleport/lib/utils/aws"
 	icutils "github.com/gravitational/teleport/lib/utils/aws/identitycenterutils"
 	awsregion "github.com/gravitational/teleport/lib/utils/aws/region"
+	"github.com/gravitational/teleport/lib/utils/parse"
 )
 
 const (
@@ -190,7 +190,7 @@ func (a *awsICInstallArgs) parseUserFilters() ([]*types.AWSICUserSyncFilter, err
 	if len(a.userLabels) > 0 {
 		result = slices.Grow(result, len(a.userLabels))
 		for _, labelSpec := range a.userLabels {
-			labels, err := client.ParseLabelSpec(labelSpec)
+			labels, err := parse.LabelSelectorSpec(labelSpec)
 			if err != nil {
 				return nil, trace.Wrap(err)
 			}

--- a/tool/tctl/common/recordings_command.go
+++ b/tool/tctl/common/recordings_command.go
@@ -45,6 +45,7 @@ import (
 	"github.com/gravitational/teleport/lib/service/servicecfg"
 	"github.com/gravitational/teleport/lib/session"
 	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/parse"
 	"github.com/gravitational/teleport/tool/common"
 	commonclient "github.com/gravitational/teleport/tool/tctl/common/client"
 	tctlcfg "github.com/gravitational/teleport/tool/tctl/common/config"
@@ -286,7 +287,7 @@ func (c *RecordingsCommand) SearchRecordings(ctx context.Context, tc *authclient
 
 	var labels map[string]string
 	if c.searchLabel != "" {
-		labels, err = client.ParseLabelSpec(c.searchLabel)
+		labels, err = parse.LabelSelectorSpec(c.searchLabel)
 		if err != nil {
 			return trace.Wrap(err, "parsing --label")
 		}

--- a/tool/tctl/common/resource_command.go
+++ b/tool/tctl/common/resource_command.go
@@ -49,13 +49,13 @@ import (
 	"github.com/gravitational/teleport/api/utils/clientutils"
 	"github.com/gravitational/teleport/lib/asciitable"
 	"github.com/gravitational/teleport/lib/auth/authclient"
-	"github.com/gravitational/teleport/lib/client"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/devicetrust"
 	"github.com/gravitational/teleport/lib/itertools/stream"
 	"github.com/gravitational/teleport/lib/service/servicecfg"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/parse"
 	commonclient "github.com/gravitational/teleport/tool/tctl/common/client"
 	tctlcfg "github.com/gravitational/teleport/tool/tctl/common/config"
 	"github.com/gravitational/teleport/tool/tctl/common/resources"
@@ -761,7 +761,7 @@ func (rc *ResourceCommand) UpdateFields(ctx context.Context, clt *authclient.Cli
 	var err error
 	var labels map[string]string
 	if rc.labels != "" {
-		labels, err = client.ParseLabelSpec(rc.labels)
+		labels, err = parse.LabelSelectorSpec(rc.labels)
 		if err != nil {
 			return trace.Wrap(err)
 		}

--- a/tool/tctl/common/scoped_token_command.go
+++ b/tool/tctl/common/scoped_token_command.go
@@ -39,11 +39,11 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/utils/clientutils"
 	"github.com/gravitational/teleport/lib/auth/authclient"
-	libclient "github.com/gravitational/teleport/lib/client"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/itertools/stream"
 	"github.com/gravitational/teleport/lib/scopes/joining"
 	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/parse"
 	commonclient "github.com/gravitational/teleport/tool/tctl/common/client"
 	"github.com/gravitational/teleport/tool/tctl/common/resources"
 )
@@ -178,7 +178,7 @@ func (c *ScopedTokensCommand) Add(ctx context.Context, client *authclient.Client
 
 	var labels map[string]string
 	if c.labels != "" {
-		labels, err = libclient.ParseLabelSpec(c.labels)
+		labels, err = parse.LabelSelectorSpec(c.labels)
 		if err != nil {
 			return trace.Wrap(err)
 		}
@@ -186,7 +186,7 @@ func (c *ScopedTokensCommand) Add(ctx context.Context, client *authclient.Client
 
 	var immutableLabels *joiningv1.ImmutableLabels
 	if c.sshLabels != "" {
-		sshLabels, err := libclient.ParseLabelSpec(c.sshLabels)
+		sshLabels, err := parse.LabelSelectorSpec(c.sshLabels)
 		if err != nil {
 			return trace.Wrap(err)
 		}

--- a/tool/tctl/common/token_command.go
+++ b/tool/tctl/common/token_command.go
@@ -48,13 +48,13 @@ import (
 	"github.com/gravitational/teleport/api/utils/clientutils"
 	"github.com/gravitational/teleport/lib/asciitable"
 	"github.com/gravitational/teleport/lib/auth/authclient"
-	libclient "github.com/gravitational/teleport/lib/client"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/modules"
 	"github.com/gravitational/teleport/lib/observability/otelhttp"
 	"github.com/gravitational/teleport/lib/service/servicecfg"
 	"github.com/gravitational/teleport/lib/tlsca"
 	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/parse"
 	"github.com/gravitational/teleport/lib/utils/teleportassets"
 	commonclient "github.com/gravitational/teleport/tool/tctl/common/client"
 	tctlcfg "github.com/gravitational/teleport/tool/tctl/common/config"
@@ -255,7 +255,7 @@ func (c *TokensCommand) Add(ctx context.Context, client *authclient.Client) erro
 	}
 
 	if c.labels != "" {
-		labels, err := libclient.ParseLabelSpec(c.labels)
+		labels, err := parse.LabelSelectorSpec(c.labels)
 		if err != nil {
 			return trace.Wrap(err)
 		}
@@ -345,7 +345,7 @@ func (c *TokensCommand) Del(ctx context.Context, client *authclient.Client) erro
 
 // List is called to execute "tokens ls" command.
 func (c *TokensCommand) List(ctx context.Context, client *authclient.Client) error {
-	labels, err := libclient.ParseLabelSpec(c.labels)
+	labels, err := parse.LabelSelectorSpec(c.labels)
 	if err != nil {
 		return trace.Wrap(err)
 	}

--- a/tool/tsh/common/tsh.go
+++ b/tool/tsh/common/tsh.go
@@ -104,6 +104,7 @@ import (
 	"github.com/gravitational/teleport/lib/utils/diagnostics/latency"
 	logutils "github.com/gravitational/teleport/lib/utils/log"
 	"github.com/gravitational/teleport/lib/utils/mlock"
+	"github.com/gravitational/teleport/lib/utils/parse"
 	stacksignal "github.com/gravitational/teleport/lib/utils/signal"
 	"github.com/gravitational/teleport/session/networking/x11"
 	"github.com/gravitational/teleport/session/shell"
@@ -4892,7 +4893,7 @@ func loadClientConfigFromCLIConf(cf *CLIConf, proxy string) (*client.Config, err
 		}
 		// see if remote host is specified as a set of labels
 		if strings.Contains(hostUser, "=") {
-			labels, err = client.ParseLabelSpec(hostUser)
+			labels, err = parse.LabelSelectorSpec(hostUser)
 			if err != nil {
 				return nil, trace.Wrap(err)
 			}
@@ -4919,7 +4920,7 @@ func loadClientConfigFromCLIConf(cf *CLIConf, proxy string) (*client.Config, err
 
 	// explicitly passed --labels overrides user@labels positional arg form.
 	if cf.Labels != "" {
-		labels, err = client.ParseLabelSpec(cf.Labels)
+		labels, err = parse.LabelSelectorSpec(cf.Labels)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}

--- a/tool/tsh/common/workload_identity.go
+++ b/tool/tsh/common/workload_identity.go
@@ -37,6 +37,7 @@ import (
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/tbot/bot"
 	"github.com/gravitational/teleport/lib/tbot/workloadidentity"
+	"github.com/gravitational/teleport/lib/utils/parse"
 )
 
 // Based on the default paths listed in
@@ -111,7 +112,7 @@ func (c *issueX509Command) run(cf *CLIConf) error {
 	case c.nameSelector != "":
 		selector.Name = c.nameSelector
 	case c.labelSelector != "":
-		labels, err := client.ParseLabelSpec(c.labelSelector)
+		labels, err := parse.LabelSelectorSpec(c.labelSelector)
 		if err != nil {
 			return trace.Wrap(err)
 		}
@@ -300,7 +301,7 @@ func (c *issueJWTCommand) run(cf *CLIConf) error {
 	case c.nameSelector != "":
 		selector.Name = c.nameSelector
 	case c.labelSelector != "":
-		labels, err := client.ParseLabelSpec(c.labelSelector)
+		labels, err := parse.LabelSelectorSpec(c.labelSelector)
 		if err != nil {
 			return trace.Wrap(err)
 		}


### PR DESCRIPTION
Relocates client.ParseLabelSpec to lib/utils/parse. This results in a net 5MB reduction in the weight of lib/config. This may not have a correlation in binary size since lib/client is heavily consumed by other packages.

```bash
$ goda cut './lib/config:all' | rg '^github.com/gravitational/teleport/lib/client\b|^ID'
github.com/gravitational/teleport/lib/client   InDegree=1   Cut.PackageCount=75   Cut.AllFiles.Size=5.3MB   Cut.Go.Lines=129512
```
