### PR TITLE
e2e: Add a login test, remove auth setup from report, better error reporting

### DIFF
--- a/e2e/global-setup.ts
+++ b/e2e/global-setup.ts
@@ -47,6 +47,9 @@ export { globalSetup as default };
 // When executed directly (e.g. `tsx global-setup.ts`) rather than imported as
 // Playwright's configured globalSetup, run immediately. The runner's browse and
 // codegen modes use this to generate auth state without a full test run.
-if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(process.argv[1]).href
+) {
   await globalSetup();
 }

--- a/e2e/global-setup.ts
+++ b/e2e/global-setup.ts
@@ -26,12 +26,17 @@ import { directLogin } from './helpers/login';
 const authDir = join(dirname(fileURLToPath(import.meta.url)), '.auth');
 
 export default async function globalSetup() {
+  const browser = process.env.E2E_BROWSER;
+  if (!browser) {
+    throw new Error('E2E_BROWSER must be set by the runner');
+  }
+
   mkdirSync(authDir, { recursive: true });
 
   for (const [username, creds] of Object.entries(users)) {
     const state = await directLogin(startUrl, username, creds.password);
     writeFileSync(
-      join(authDir, `${username}.json`),
+      join(authDir, `${browser}-${username}.json`),
       JSON.stringify(state, null, 2)
     );
   }

--- a/e2e/global-setup.ts
+++ b/e2e/global-setup.ts
@@ -18,7 +18,7 @@
 
 import { mkdirSync, writeFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 
 import { startUrl, users } from './helpers/env';
 import { directLogin } from './helpers/login';
@@ -43,3 +43,10 @@ async function globalSetup() {
 }
 
 export { globalSetup as default };
+
+// When executed directly (e.g. `tsx global-setup.ts`) rather than imported as
+// Playwright's configured globalSetup, run immediately. The runner's browse and
+// codegen modes use this to generate auth state without a full test run.
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  await globalSetup();
+}

--- a/e2e/global-setup.ts
+++ b/e2e/global-setup.ts
@@ -20,9 +20,6 @@ import { mkdirSync, writeFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 
-import { startUrl, users } from './helpers/env';
-import { directLogin } from './helpers/login';
-
 const authDir = join(dirname(fileURLToPath(import.meta.url)), '.auth');
 
 async function globalSetup() {
@@ -30,6 +27,19 @@ async function globalSetup() {
   if (!browser) {
     throw new Error('E2E_BROWSER must be set by the runner');
   }
+
+  // No bootstrapped users — e.g. runs against an existing cluster via
+  // --teleport-url, or unauthenticated/connect-only runs. There's nothing to
+  // set up, and helpers/env throws on the missing E2E_USERS_FILE, so bail
+  // before importing it.
+  if (!process.env.E2E_USERS_FILE) {
+    return;
+  }
+
+  // Imported lazily so reading E2E_USERS_FILE only happens once we know there
+  // are credentials to generate auth state from.
+  const { startUrl, users } = await import('./helpers/env');
+  const { directLogin } = await import('./helpers/login');
 
   mkdirSync(authDir, { recursive: true });
 

--- a/e2e/global-setup.ts
+++ b/e2e/global-setup.ts
@@ -20,25 +20,19 @@ import { mkdirSync, writeFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-import { startUrl, users } from '@gravitational/e2e/helpers/env';
-import { directLogin } from '@gravitational/e2e/helpers/login';
-// oxlint-disable-next-line no-restricted-imports
-import { test as setup } from '@playwright/test';
+import { startUrl, users } from './helpers/env';
+import { directLogin } from './helpers/login';
 
-const authDir = join(dirname(fileURLToPath(import.meta.url)), '../../.auth');
+const authDir = join(dirname(fileURLToPath(import.meta.url)), '.auth');
 
-mkdirSync(authDir, { recursive: true });
+export default async function globalSetup() {
+  mkdirSync(authDir, { recursive: true });
 
-for (const [username, creds] of Object.entries(users)) {
-  // oxlint-disable-next-line no-empty-pattern -- Playwright requires fixture argument to be destructured.
-  setup(`authenticate as ${username}`, async ({}, testInfo) => {
+  for (const [username, creds] of Object.entries(users)) {
     const state = await directLogin(startUrl, username, creds.password);
-
-    const browser = testInfo.project.name.split(':')[0];
-
     writeFileSync(
-      join(authDir, `${browser}-${username}.json`),
+      join(authDir, `${username}.json`),
       JSON.stringify(state, null, 2)
     );
-  });
+  }
 }

--- a/e2e/global-setup.ts
+++ b/e2e/global-setup.ts
@@ -25,7 +25,7 @@ import { directLogin } from './helpers/login';
 
 const authDir = join(dirname(fileURLToPath(import.meta.url)), '.auth');
 
-export default async function globalSetup() {
+async function globalSetup() {
   const browser = process.env.E2E_BROWSER;
   if (!browser) {
     throw new Error('E2E_BROWSER must be set by the runner');
@@ -41,3 +41,5 @@ export default async function globalSetup() {
     );
   }
 }
+
+export { globalSetup as default };

--- a/e2e/helpers/login.ts
+++ b/e2e/helpers/login.ts
@@ -22,10 +22,10 @@ import { Agent, fetch as undiciFetch } from 'undici';
 import { users } from './env';
 import { mockWebAuthn, signWebAuthnAssertion } from './webauthn';
 
-// directLogin runs during the auth setup project against a Teleport instance
-// the runner brings up with a freshly-generated self-signed cert, so the
-// global default verifier rejects the connection. Scope the bypass to these
-// two fetches via a dedicated dispatcher rather than disabling TLS globally.
+// directLogin runs during global setup against a Teleport instance the runner
+// brings up with a freshly-generated self-signed cert, so the global default
+// verifier rejects the connection. Scope the bypass to these two fetches via
+// a dedicated dispatcher rather than disabling TLS globally.
 const insecureDispatcher = new Agent({
   connect: { rejectUnauthorized: false },
 });

--- a/e2e/helpers/tctl.ts
+++ b/e2e/helpers/tctl.ts
@@ -51,6 +51,19 @@ export function deleteUser(username: string) {
   tctl('users', 'rm', username);
 }
 
+// Removes a user if present, swallowing only tctl's "not found" error so it can
+// be used to clean up before a test (and on retries) without failing when the
+// user doesn't exist yet.
+export function deleteUserIfExists(username: string) {
+  try {
+    tctl('users', 'rm', username);
+  } catch (err) {
+    if (!isNotFoundError(err)) {
+      throw err;
+    }
+  }
+}
+
 // Removes a resource (e.g. `role/test-role`) if it exists. Swallows only the
 // "not found" error tctl returns when the resource is absent; any other
 // failure (auth, network, etc.) is re-thrown so it doesn't get masked.

--- a/e2e/helpers/test.ts
+++ b/e2e/helpers/test.ts
@@ -126,8 +126,6 @@ export const test = base.extend<E2EFixtures>({
       );
     }
 
-    const browser = testInfo.project.name.split(':')[0];
-
     await use(async (index: number): Promise<LoginAsResult> => {
       const definition = users[index];
       if (!definition) {
@@ -147,7 +145,7 @@ export const test = base.extend<E2EFixtures>({
       }
 
       const state: StorageState = JSON.parse(
-        readFileSync(join(authDir, `${browser}-${name}.json`), 'utf-8')
+        readFileSync(join(authDir, `${name}.json`), 'utf-8')
       );
 
       const ctx = page.context();
@@ -211,9 +209,7 @@ export const test = base.extend<E2EFixtures>({
       return;
     }
 
-    const browser = testInfo.project.name.split(':')[0];
-
-    await use(join(authDir, `${browser}-${username}.json`));
+    await use(join(authDir, `${username}.json`));
   },
   unifiedResourcesPage: async ({ page }, use) => {
     await use(new UnifiedResourcesPage(page));

--- a/e2e/helpers/test.ts
+++ b/e2e/helpers/test.ts
@@ -126,6 +126,8 @@ export const test = base.extend<E2EFixtures>({
       );
     }
 
+    const browser = testInfo.project.name.split(':')[0];
+
     await use(async (index: number): Promise<LoginAsResult> => {
       const definition = users[index];
       if (!definition) {
@@ -145,7 +147,7 @@ export const test = base.extend<E2EFixtures>({
       }
 
       const state: StorageState = JSON.parse(
-        readFileSync(join(authDir, `${name}.json`), 'utf-8')
+        readFileSync(join(authDir, `${browser}-${name}.json`), 'utf-8')
       );
 
       const ctx = page.context();
@@ -209,7 +211,9 @@ export const test = base.extend<E2EFixtures>({
       return;
     }
 
-    await use(join(authDir, `${username}.json`));
+    const browser = testInfo.project.name.split(':')[0];
+
+    await use(join(authDir, `${browser}-${username}.json`));
   },
   unifiedResourcesPage: async ({ page }, use) => {
     await use(new UnifiedResourcesPage(page));

--- a/e2e/helpers/test.ts
+++ b/e2e/helpers/test.ts
@@ -199,9 +199,14 @@ export const test = base.extend<E2EFixtures>({
     await use(page);
   },
   storageState: async ({ username }, use, testInfo) => {
-    // Connect tests drive login through the Electron app and don't have a
-    // setup project that writes shared storage state files, so leave it unset.
-    if (!username || testInfo.project.name === 'connect') {
+    // Connect tests drive login through the Electron app, and unauthenticated
+    // tests intentionally start without a session, so neither has a storage
+    // state file to load even when the test declares a user.
+    if (
+      !username ||
+      testInfo.project.name === 'connect' ||
+      testInfo.project.name.endsWith(':unauthenticated')
+    ) {
       await use(undefined as unknown as string);
       return;
     }

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -36,6 +36,7 @@ export default defineConfig({
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 1 : 0,
   workers: process.env.CI ? 1 : undefined,
+  globalSetup: './global-setup.ts',
   reporter: [
     ['html', { open: 'never' }],
     ['json', { outputFile: 'test-results/results.json' }],
@@ -49,28 +50,18 @@ export default defineConfig({
   },
 
   projects: [
-    ...browserList.flatMap(browser => {
-      const setupName = `${browser}:setup`;
-      return [
-        {
-          name: setupName,
-          testDir: './tests/web',
-          testMatch: /.*\.setup\.ts/,
-          use: browserDevices[browser],
-        },
-        {
-          name: `${browser}:authenticated`,
-          testDir: './tests/web/authenticated',
-          use: { ...browserDevices[browser] },
-          dependencies: [setupName],
-        },
-        {
-          name: `${browser}:unauthenticated`,
-          testDir: './tests/web/unauthenticated',
-          use: { ...browserDevices[browser] },
-        },
-      ];
-    }),
+    ...browserList.flatMap(browser => [
+      {
+        name: `${browser}:authenticated`,
+        testDir: './tests/web/authenticated',
+        use: { ...browserDevices[browser] },
+      },
+      {
+        name: `${browser}:unauthenticated`,
+        testDir: './tests/web/unauthenticated',
+        use: { ...browserDevices[browser] },
+      },
+    ]),
 
     {
       name: 'connect',

--- a/e2e/runner/github.go
+++ b/e2e/runner/github.go
@@ -131,7 +131,7 @@ func firstErrorMsg(results []pwResult) string {
 func emitAnnotations(failures, flaky []mergedFailure, errors []pwError) {
 	for _, f := range failures {
 		browsers := strings.Join(f.projects, ", ")
-		msg := fmt.Sprintf("[%s] %s", browsers, firstErrorLine(f))
+		msg := fmt.Sprintf("[%s] %s — %s", browsers, f.title, firstErrorLine(f))
 		fmt.Printf("::error file=%s,line=%d,col=%d::%s\n",
 			escapeProp(f.file), f.line, f.column, escapeData(msg))
 	}

--- a/e2e/runner/github.go
+++ b/e2e/runner/github.go
@@ -170,18 +170,20 @@ func writeJobSummary(report pwReport, failures, flaky []mergedFailure) error {
 }
 
 func renderMarkdownReport(w io.Writer, report pwReport, failures, flaky []mergedFailure) {
+	stats := reportableStats(report)
+
 	fmt.Fprint(w, "### E2E Test Results\n\n")
 
 	fmt.Fprint(w, "```diff\n")
-	fmt.Fprintf(w, "+ %d passed\n", report.Stats.Expected)
-	if report.Stats.Unexpected > 0 {
-		fmt.Fprintf(w, "- %d failed\n", report.Stats.Unexpected)
+	fmt.Fprintf(w, "+ %d passed\n", stats.expected)
+	if stats.unexpected > 0 {
+		fmt.Fprintf(w, "- %d failed\n", stats.unexpected)
 	}
-	if report.Stats.Flaky > 0 {
-		fmt.Fprintf(w, "! %d flaky\n", report.Stats.Flaky)
+	if stats.flaky > 0 {
+		fmt.Fprintf(w, "! %d flaky\n", stats.flaky)
 	}
-	if report.Stats.Skipped > 0 {
-		fmt.Fprintf(w, "# %d skipped\n", report.Stats.Skipped)
+	if stats.skipped > 0 {
+		fmt.Fprintf(w, "# %d skipped\n", stats.skipped)
 	}
 	fmt.Fprintf(w, "# %s\n", formatDuration(report.Stats.Duration))
 	fmt.Fprint(w, "```\n")
@@ -370,6 +372,58 @@ func writeFailureErrors(w io.Writer, results []pwResult) {
 		fmt.Fprint(w, "*Retried once and failed with the same error.*\n\n")
 	} else {
 		fmt.Fprintf(w, "*Retried %d times and failed with the same error.*\n\n", retries)
+	}
+}
+
+type reportStats struct {
+	expected   int
+	unexpected int
+	flaky      int
+	skipped    int
+}
+
+// reportableStats walks the suite tree and tallies tests excluding the setup
+// projects (e.g. `chromium:setup`). Playwright's top-level stats include those
+// auth-setup tests, which are infrastructure rather than test cases readers
+// care about.
+func reportableStats(report pwReport) reportStats {
+	var stats reportStats
+	walkSpecs(report.Suites, func(s pwSpec) {
+		// Treat the spec as flaky if any retry succeeded, matching how
+		// Playwright classifies flaky specs in its top-level stats.
+		flaky := false
+		var finalStatus string
+		for _, t := range s.Tests {
+			if strings.HasSuffix(t.ProjectName, ":setup") {
+				continue
+			}
+			finalStatus = t.Status
+			if len(t.Results) > 1 && t.Status == "expected" {
+				flaky = true
+			}
+		}
+		switch {
+		case finalStatus == "":
+			// All tests for this spec were filtered out (setup-only).
+		case flaky:
+			stats.flaky++
+		case finalStatus == "expected":
+			stats.expected++
+		case finalStatus == "unexpected":
+			stats.unexpected++
+		case finalStatus == "skipped":
+			stats.skipped++
+		}
+	})
+	return stats
+}
+
+func walkSpecs(suites []pwSuite, fn func(pwSpec)) {
+	for _, s := range suites {
+		for _, spec := range s.Specs {
+			fn(spec)
+		}
+		walkSpecs(s.Suites, fn)
 	}
 }
 

--- a/e2e/runner/github.go
+++ b/e2e/runner/github.go
@@ -55,7 +55,7 @@ func writeGitHubReport(resultsPath string) error {
 	mergedFailures := mergeFailures(failures)
 	mergedFlaky := mergeFailures(flaky)
 
-	emitAnnotations(mergedFailures, mergedFlaky)
+	emitAnnotations(mergedFailures, mergedFlaky, report.Errors)
 
 	if err := writeJobSummary(report, mergedFailures, mergedFlaky); err != nil {
 		slog.Warn("could not write job summary", "error", err)
@@ -128,7 +128,7 @@ func firstErrorMsg(results []pwResult) string {
 	return ""
 }
 
-func emitAnnotations(failures, flaky []mergedFailure) {
+func emitAnnotations(failures, flaky []mergedFailure, errors []pwError) {
 	for _, f := range failures {
 		browsers := strings.Join(f.projects, ", ")
 		msg := fmt.Sprintf("[%s] %s", browsers, firstErrorLine(f))
@@ -141,6 +141,16 @@ func emitAnnotations(failures, flaky []mergedFailure) {
 		msg := fmt.Sprintf("[%s] Flaky: %s", browsers, f.title)
 		fmt.Printf("::warning file=%s,line=%d,col=%d::%s\n",
 			escapeProp(f.file), f.line, f.column, escapeData(msg))
+	}
+
+	// Errors not associated with any test have no file/line; emit them as plain
+	// error annotations so they aren't lost (Playwright still exits non-zero).
+	for _, e := range errors {
+		msg := stripANSI(e.Message)
+		if line, _, ok := strings.Cut(msg, "\n"); ok {
+			msg = line
+		}
+		fmt.Printf("::error::%s\n", escapeData(msg))
 	}
 }
 
@@ -170,22 +180,25 @@ func writeJobSummary(report pwReport, failures, flaky []mergedFailure) error {
 }
 
 func renderMarkdownReport(w io.Writer, report pwReport, failures, flaky []mergedFailure) {
-	stats := reportableStats(report)
+	stats := report.Stats
 
 	fmt.Fprint(w, "### E2E Test Results\n\n")
 
 	fmt.Fprint(w, "```diff\n")
-	fmt.Fprintf(w, "+ %d passed\n", stats.expected)
-	if stats.unexpected > 0 {
-		fmt.Fprintf(w, "- %d failed\n", stats.unexpected)
+	fmt.Fprintf(w, "+ %d passed\n", stats.Expected)
+	if stats.Unexpected > 0 {
+		fmt.Fprintf(w, "- %d failed\n", stats.Unexpected)
 	}
-	if stats.flaky > 0 {
-		fmt.Fprintf(w, "! %d flaky\n", stats.flaky)
+	if stats.Flaky > 0 {
+		fmt.Fprintf(w, "! %d flaky\n", stats.Flaky)
 	}
-	if stats.skipped > 0 {
-		fmt.Fprintf(w, "# %d skipped\n", stats.skipped)
+	if stats.Skipped > 0 {
+		fmt.Fprintf(w, "# %d skipped\n", stats.Skipped)
 	}
-	fmt.Fprintf(w, "# %s\n", formatDuration(report.Stats.Duration))
+	if len(report.Errors) > 0 {
+		fmt.Fprintf(w, "- %d %s not associated with any test\n", len(report.Errors), pluralErrors(len(report.Errors)))
+	}
+	fmt.Fprintf(w, "# %s\n", formatDuration(stats.Duration))
 	fmt.Fprint(w, "```\n")
 
 	if len(failures) > 0 {
@@ -199,6 +212,19 @@ func renderMarkdownReport(w io.Writer, report pwReport, failures, flaky []merged
 			writeFailureErrors(w, f.results)
 
 			fmt.Fprint(w, "</details>\n\n")
+		}
+	}
+
+	if len(report.Errors) > 0 {
+		fmt.Fprint(w, "\n#### Errors (not associated with any test)\n\n")
+
+		for _, e := range report.Errors {
+			if e.Message != "" {
+				writeCodeFence(w, e.Message)
+			}
+			if e.Snippet != "" {
+				writeCodeFence(w, e.Snippet)
+			}
 		}
 	}
 
@@ -237,7 +263,7 @@ func renderMarkdownReport(w io.Writer, report pwReport, failures, flaky []merged
 func writePRCommentFile(resultsPath string, report pwReport, failures, flaky []mergedFailure) error {
 	commentPath := filepath.Join(filepath.Dir(resultsPath), "pr-comment.md")
 
-	hasIssues := len(failures) > 0 || len(flaky) > 0
+	hasIssues := len(failures) > 0 || len(flaky) > 0 || len(report.Errors) > 0
 	if !hasIssues {
 		// Write an empty file to signal that the comment should be deleted.
 		if err := os.WriteFile(commentPath, nil, 0o644); err != nil {
@@ -375,56 +401,12 @@ func writeFailureErrors(w io.Writer, results []pwResult) {
 	}
 }
 
-type reportStats struct {
-	expected   int
-	unexpected int
-	flaky      int
-	skipped    int
-}
-
-// reportableStats walks the suite tree and tallies tests excluding the setup
-// projects (e.g. `chromium:setup`). Playwright's top-level stats include those
-// auth-setup tests, which are infrastructure rather than test cases readers
-// care about.
-func reportableStats(report pwReport) reportStats {
-	var stats reportStats
-	walkSpecs(report.Suites, func(s pwSpec) {
-		// Treat the spec as flaky if any retry succeeded, matching how
-		// Playwright classifies flaky specs in its top-level stats.
-		flaky := false
-		var finalStatus string
-		for _, t := range s.Tests {
-			if strings.HasSuffix(t.ProjectName, ":setup") {
-				continue
-			}
-			finalStatus = t.Status
-			if len(t.Results) > 1 && t.Status == "expected" {
-				flaky = true
-			}
-		}
-		switch {
-		case finalStatus == "":
-			// All tests for this spec were filtered out (setup-only).
-		case flaky:
-			stats.flaky++
-		case finalStatus == "expected":
-			stats.expected++
-		case finalStatus == "unexpected":
-			stats.unexpected++
-		case finalStatus == "skipped":
-			stats.skipped++
-		}
-	})
-	return stats
-}
-
-func walkSpecs(suites []pwSuite, fn func(pwSpec)) {
-	for _, s := range suites {
-		for _, spec := range s.Specs {
-			fn(spec)
-		}
-		walkSpecs(s.Suites, fn)
+func pluralErrors(n int) string {
+	if n == 1 {
+		return "error"
 	}
+
+	return "errors"
 }
 
 func firstErrorLine(f mergedFailure) string {

--- a/e2e/runner/playwright.go
+++ b/e2e/runner/playwright.go
@@ -303,6 +303,7 @@ func (p *playwrightRunner) startEnv(inst *testInstance) ([]string, error) {
 	env = append(env, "E2E_TCTL_BIN="+p.config.tctlBin)
 	env = append(env, "E2E_TELEPORT_CONFIG="+inst.teleportConfigPath)
 	env = append(env, "E2E_BROWSERS="+strings.Join(p.config.browsers, ","))
+	env = append(env, "E2E_BROWSER="+inst.browser)
 
 	env = append(env, "E2E_CONNECT_TSH_BIN="+p.config.connectTshBinPath)
 	env = append(env, "E2E_CONNECT_APP_DIR="+p.config.connectAppDir)

--- a/e2e/runner/playwright.go
+++ b/e2e/runner/playwright.go
@@ -229,7 +229,7 @@ func (p *playwrightRunner) codegen(ctx context.Context) error {
 	return p.openWebAuthenticated(ctx, "codegen")
 }
 
-// openWebAuthenticated runs the setup project to generate auth state, then opens
+// openWebAuthenticated runs the global setup to generate auth state, then opens
 // a Chromium browser with a virtual WebAuthn authenticator pre-loaded so that
 // MFA challenges resolve automatically.
 func (p *playwrightRunner) openWebAuthenticated(ctx context.Context, playwrightCmd string) error {
@@ -248,8 +248,8 @@ func (p *playwrightRunner) openWebAuthenticated(ctx context.Context, playwrightC
 		return err
 	}
 
-	slog.Debug("running setup project to generate auth state")
-	if err := p.pnpm(ctx, []string{"exec", "playwright", "test", p.configFlag(), "--project=" + inst.browser + ":setup"}, env); err != nil {
+	slog.Debug("running global setup to generate auth state")
+	if err := p.pnpm(ctx, []string{"exec", "tsx", filepath.Join(p.config.sharedDir, "global-setup.ts")}, env); err != nil {
 		return err
 	}
 

--- a/e2e/runner/playwright.go
+++ b/e2e/runner/playwright.go
@@ -121,6 +121,8 @@ func (p *playwrightRunner) test(ctx context.Context, debug bool) error {
 			args := []string{"exec", "playwright", "test", p.configFlag()}
 			args = append(args, extraArgs...)
 			args = append(args, "--reporter=blob,"+filepath.Join(p.config.sharedDir, "scripts", "dot-progress-reporter.ts"))
+			// Avoid `.playwright-artifacts-<n>` collisions across parallel pnpm runs.
+			args = append(args, "--output=test-results/"+inst.browser)
 
 			for _, proj := range baseProjects {
 				args = append(args, "--project="+inst.browser+":"+proj)
@@ -162,7 +164,7 @@ func (p *playwrightRunner) test(ctx context.Context, debug bool) error {
 
 			args := []string{"exec", "playwright", "test", p.configFlag()}
 			args = append(args, extraArgs...)
-			args = append(args, "--reporter=blob,"+filepath.Join(p.config.sharedDir, "scripts", "dot-progress-reporter.ts"), "--project=connect")
+			args = append(args, "--reporter=blob,"+filepath.Join(p.config.sharedDir, "scripts", "dot-progress-reporter.ts"), "--project=connect", "--output=test-results/connect")
 
 			if len(p.config.testFiles) > 0 {
 				args = append(args, p.config.testFiles...)

--- a/e2e/runner/playwright.go
+++ b/e2e/runner/playwright.go
@@ -85,7 +85,12 @@ func (p *playwrightRunner) run(ctx context.Context, mode runMode) error {
 }
 
 func (p *playwrightRunner) test(ctx context.Context, debug bool) error {
-	blobBaseDir := filepath.Join(p.config.e2eDir, "blob-reports")
+	// Keep blobs (and the attachments Playwright extracts into
+	// blob-reports/resources during merge) under test-results, so they're part
+	// of the uploaded test-results artifact and the --test-results trace flow
+	// can resolve them. Outside test-results the merged report references a
+	// transient sibling dir that's deleted next run and never uploaded.
+	blobBaseDir := filepath.Join(p.config.e2eDir, "test-results", "blob-reports")
 	if err := os.RemoveAll(blobBaseDir); err != nil {
 		return fmt.Errorf("cleaning blob-reports directory: %w", err)
 	}
@@ -193,6 +198,15 @@ func (p *playwrightRunner) test(ctx context.Context, debug bool) error {
 		slog.Warn("failed to merge reports", "error", err)
 		if testErr == nil {
 			return err
+		}
+	} else {
+		// Merge consumed the per-browser blobs; drop them so the test-results
+		// artifact carries only the extracted resources/, not the (redundant,
+		// larger) raw blob archives with every attachment embedded twice.
+		if blobs, err := filepath.Glob(filepath.Join(blobBaseDir, "*.zip")); err == nil {
+			for _, b := range blobs {
+				_ = os.Remove(b)
+			}
 		}
 	}
 

--- a/e2e/runner/summary.go
+++ b/e2e/runner/summary.go
@@ -75,6 +75,17 @@ func printTestSummary(e2eDir, resultsPath string) {
 		}
 	}
 
+	// Errors not associated with any test (worker crashes, teardown failures,
+	// unhandled rejections). These are why Playwright can exit non-zero while
+	// every spec in the report passes, so always surface them.
+	if len(report.Errors) > 0 {
+		for _, e := range report.Errors {
+			printPwError(w, e)
+		}
+
+		fmt.Fprintln(w, red(fmt.Sprintf("  %d %s not associated with any test", len(report.Errors), pluralErrors(len(report.Errors)))))
+	}
+
 	if report.Stats.Flaky > 0 {
 		fmt.Fprintln(w, yellow(fmt.Sprintf("  %d flaky", report.Stats.Flaky)))
 	}
@@ -122,6 +133,33 @@ func printTestSummary(e2eDir, resultsPath string) {
 	}
 }
 
+// printPwError renders a single Playwright error (message, snippet, stack) with
+// the indentation used in the test summary. Shared by per-test failures and by
+// top-level errors not associated with any test.
+func printPwError(w io.Writer, e pwError) {
+	fmt.Fprintln(w)
+
+	if e.Message != "" {
+		for _, line := range strings.Split(e.Message, "\n") {
+			fmt.Fprintf(w, "    %s\n", line)
+		}
+	}
+
+	if e.Snippet != "" {
+		fmt.Fprintln(w)
+		for _, line := range strings.Split(e.Snippet, "\n") {
+			fmt.Fprintf(w, "    %s\n", line)
+		}
+	}
+
+	if e.Stack != "" {
+		fmt.Fprintln(w)
+		for _, line := range strings.Split(e.Stack, "\n") {
+			fmt.Fprintf(w, "    %s\n", dim(line))
+		}
+	}
+}
+
 func printFailureErrors(w io.Writer, f pwFailure, e2eDir, pathPrefix string) {
 	for _, result := range f.results {
 		if result.Retry > 0 {
@@ -130,27 +168,7 @@ func printFailureErrors(w io.Writer, f pwFailure, e2eDir, pathPrefix string) {
 		}
 
 		for _, e := range result.Errors {
-			fmt.Fprintln(w)
-
-			if e.Message != "" {
-				for _, line := range strings.Split(e.Message, "\n") {
-					fmt.Fprintf(w, "    %s\n", line)
-				}
-			}
-
-			if e.Snippet != "" {
-				fmt.Fprintln(w)
-				for _, line := range strings.Split(e.Snippet, "\n") {
-					fmt.Fprintf(w, "    %s\n", line)
-				}
-			}
-
-			if e.Stack != "" {
-				fmt.Fprintln(w)
-				for _, line := range strings.Split(e.Stack, "\n") {
-					fmt.Fprintf(w, "    %s\n", dim(line))
-				}
-			}
+			printPwError(w, e)
 		}
 
 		attachNum := 0
@@ -197,6 +215,11 @@ func printFailureErrors(w io.Writer, f pwFailure, e2eDir, pathPrefix string) {
 
 type pwReport struct {
 	Suites []pwSuite `json:"suites"`
+	// Errors holds failures that happened outside of test execution (global
+	// setup/teardown, worker crashes, unhandled rejections). Playwright records
+	// these separately from suites/stats and exits non-zero for them, so they
+	// must be surfaced explicitly or a run looks green while having failed.
+	Errors []pwError `json:"errors"`
 	Stats  pwStats   `json:"stats"`
 }
 

--- a/e2e/runner/summary.go
+++ b/e2e/runner/summary.go
@@ -139,7 +139,9 @@ func printTestSummary(e2eDir, resultsPath string) {
 					traceCmd += " --sha " + sha
 				}
 			} else {
-				traceCmd = fmt.Sprintf("pnpm exec playwright show-trace %s", pathPrefix+t.relPath)
+				// relPath is relative to test-results (matching the CI
+				// --test-results flow); the local path needs that segment back.
+				traceCmd = fmt.Sprintf("pnpm exec playwright show-trace %s", pathPrefix+"test-results/"+t.relPath)
 			}
 			fmt.Fprintf(w, "    %s\n      %s\n", dim(t.title), cyan(traceCmd))
 		}

--- a/e2e/runner/summary.go
+++ b/e2e/runner/summary.go
@@ -44,6 +44,7 @@ func printTestSummary(e2eDir, resultsPath string) {
 	}
 
 	failed := collectTests(report.Suites, "unexpected")
+	flaky := collectTests(report.Suites, "flaky")
 
 	// rewrite the paths relative to the caller directory
 	pathPrefix := ""
@@ -55,6 +56,9 @@ func printTestSummary(e2eDir, resultsPath string) {
 
 	for i := range failed {
 		failed[i].file = pathPrefix + "tests/" + failed[i].file
+	}
+	for i := range flaky {
+		flaky[i].file = pathPrefix + "tests/" + flaky[i].file
 	}
 
 	w := os.Stderr
@@ -86,8 +90,17 @@ func printTestSummary(e2eDir, resultsPath string) {
 		fmt.Fprintln(w, red(fmt.Sprintf("  %d %s not associated with any test", len(report.Errors), pluralErrors(len(report.Errors)))))
 	}
 
-	if report.Stats.Flaky > 0 {
-		fmt.Fprintln(w, yellow(fmt.Sprintf("  %d flaky", report.Stats.Flaky)))
+	// Flaky tests (failed then passed on retry) are easy to miss as a bare
+	// count, so print each one's initial failure — this is usually where an
+	// intermittent timeout/failure actually shows up.
+	if len(flaky) > 0 {
+		for _, f := range flaky {
+			fmt.Fprintln(w, yellow(formatTestHeader(f, "  ")))
+
+			printFailureErrors(w, f, e2eDir, pathPrefix)
+		}
+
+		fmt.Fprintln(w, yellow(fmt.Sprintf("  %d flaky", len(flaky))))
 	}
 
 	if report.Stats.Skipped > 0 {
@@ -114,7 +127,8 @@ func printTestSummary(e2eDir, resultsPath string) {
 
 	fmt.Fprintf(w, "\n  To open last HTML report run:\n\n    %s\n\n", cyan(showReportCmd))
 
-	traces := collectTraces(failed, e2eDir)
+	traceTests := append(append([]pwFailure(nil), failed...), flaky...)
+	traces := collectTraces(traceTests, e2eDir)
 	if len(traces) > 0 {
 		fmt.Fprintln(w, "  Traces:")
 		for _, t := range traces {

--- a/e2e/scripts/open-with-webauthn.ts
+++ b/e2e/scripts/open-with-webauthn.ts
@@ -66,7 +66,7 @@ const browserTypes = { chromium, firefox, webkit };
 const browserType =
   browserTypes[browserName as keyof typeof browserTypes] ?? chromium;
 const username = defaultUsername();
-const storageStatePath = join(e2eDir, `.auth/${username}.json`);
+const storageStatePath = join(e2eDir, `.auth/${browserName}-${username}.json`);
 
 info(`launching ${browserName} ${dim(`(mode: ${mode})`)}`);
 

--- a/e2e/scripts/open-with-webauthn.ts
+++ b/e2e/scripts/open-with-webauthn.ts
@@ -66,7 +66,7 @@ const browserTypes = { chromium, firefox, webkit };
 const browserType =
   browserTypes[browserName as keyof typeof browserTypes] ?? chromium;
 const username = defaultUsername();
-const storageStatePath = join(e2eDir, `.auth/${browserName}-${username}.json`);
+const storageStatePath = join(e2eDir, `.auth/${username}.json`);
 
 info(`launching ${browserName} ${dim(`(mode: ${mode})`)}`);
 

--- a/e2e/tests/web/authenticated/rbac.spec.ts
+++ b/e2e/tests/web/authenticated/rbac.spec.ts
@@ -114,9 +114,7 @@ test.describe('read-only access', () => {
     await test.step('User can see roles but cant create/delete/update', async () => {
       await rolesPage.goto();
 
-      await expect(
-        page.getByRole('heading', { name: 'Roles' })
-      ).toBeVisible();
+      await expect(page.getByRole('heading', { name: 'Roles' })).toBeVisible();
 
       await expect(rolesPage.createNewRoleButton).toBeDisabled();
 

--- a/e2e/tests/web/authenticated/rbac.spec.ts
+++ b/e2e/tests/web/authenticated/rbac.spec.ts
@@ -114,7 +114,9 @@ test.describe('read-only access', () => {
     await test.step('User can see roles but cant create/delete/update', async () => {
       await rolesPage.goto();
 
-      await expect(page.getByText('Roles').first()).toBeVisible();
+      await expect(
+        page.getByRole('heading', { name: 'Roles' })
+      ).toBeVisible();
 
       await expect(rolesPage.createNewRoleButton).toBeDisabled();
 

--- a/e2e/tests/web/unauthenticated/darktheme.spec.ts
+++ b/e2e/tests/web/unauthenticated/darktheme.spec.ts
@@ -18,7 +18,7 @@
 
 import { login, logout } from '@gravitational/e2e/helpers/login';
 import { defaultPassword, signup } from '@gravitational/e2e/helpers/signup';
-import { deleteUser } from '@gravitational/e2e/helpers/tctl';
+import { deleteUserIfExists } from '@gravitational/e2e/helpers/tctl';
 import { expect, test } from '@gravitational/e2e/helpers/test';
 import { TestInfo } from '@playwright/test';
 
@@ -30,6 +30,10 @@ function username(testInfo: TestInfo) {
 }
 
 test('switching between dark and light theme', async ({ page }, testInfo) => {
+  // The re-login below can trip Teleport's challenge-generation rate limiter,
+  // so allow extra time to retry it.
+  test.slow();
+
   await signup(page, username(testInfo), defaultPassword);
   await expect(page.locator('body')).toHaveCSS('background-color', lightBody);
 
@@ -53,7 +57,12 @@ test('switching between dark and light theme', async ({ page }, testInfo) => {
   // signing in on a fresh browser.
   await page.context().clearCookies();
   await page.evaluate(() => localStorage.clear());
-  await login(page, username(testInfo), defaultPassword);
+  // Logging back in right after signup can trip Teleport's challenge-generation
+  // rate limiter ("rate limit exceeded, try again in Ns"); retry until it lets
+  // us through.
+  await expect(async () => {
+    await login(page, username(testInfo), defaultPassword);
+  }).toPass({ timeout: 30_000, intervals: [3_000] });
   await expect(page.locator('body')).toHaveCSS('background-color', darkBody);
 
   // Switch to light theme.
@@ -62,7 +71,14 @@ test('switching between dark and light theme', async ({ page }, testInfo) => {
   await expect(page.locator('body')).toHaveCSS('background-color', lightBody);
 });
 
+// Clean the user before each attempt (and after) so retries start clean rather
+// than failing on an already-registered user / consumed invite.
+// oxlint-disable-next-line no-empty-pattern
+test.beforeEach(({}, testInfo) => {
+  deleteUserIfExists(username(testInfo));
+});
+
 // oxlint-disable-next-line no-empty-pattern
 test.afterEach(({}, testInfo) => {
-  deleteUser(username(testInfo));
+  deleteUserIfExists(username(testInfo));
 });

--- a/e2e/tests/web/unauthenticated/login.spec.ts
+++ b/e2e/tests/web/unauthenticated/login.spec.ts
@@ -1,0 +1,29 @@
+/**
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { login } from '@gravitational/e2e/helpers/login';
+import { test } from '@gravitational/e2e/helpers/test';
+
+test.use({ user: { roles: ['access', 'editor'] } });
+
+test('verify that a user can log in with username, password, and webauthn', async ({
+  page,
+  username,
+}) => {
+  await login(page, username);
+});

--- a/e2e/tests/web/unauthenticated/signup.spec.ts
+++ b/e2e/tests/web/unauthenticated/signup.spec.ts
@@ -17,7 +17,7 @@
  */
 
 import { signup } from '@gravitational/e2e/helpers/signup';
-import { deleteUser } from '@gravitational/e2e/helpers/tctl';
+import { deleteUserIfExists } from '@gravitational/e2e/helpers/tctl';
 import { expect, test } from '@gravitational/e2e/helpers/test';
 import { TestInfo } from '@playwright/test';
 
@@ -28,6 +28,10 @@ function username(testInfo: TestInfo) {
 test('verify that a user can sign up with webauthn and login', async ({
   page,
 }, testInfo) => {
+  // Signing up auto-logs-in and we then log straight back in; that burst can
+  // trip Teleport's challenge-generation rate limiter, so allow time to retry.
+  test.slow();
+
   await signup(page, username(testInfo));
 
   await page.getByRole('button', { name: 'User Menu' }).click();
@@ -37,15 +41,29 @@ test('verify that a user can sign up with webauthn and login', async ({
     .fill(username(testInfo));
   await page.getByRole('textbox', { name: 'Username' }).press('Tab');
   await page.getByRole('textbox', { name: 'Password' }).fill('passwordtest123');
-  await page
-    .getByTestId('userpassword')
-    .getByRole('button', { name: 'Sign In' })
-    .click();
 
-  await expect(page.getByRole('heading', { name: 'Resources' })).toBeVisible();
+  // The web login challenge endpoint is rate limited; signing up then logging
+  // back in immediately can trip it ("rate limit exceeded, try again in Ns").
+  // Retry the sign-in until the limiter lets it through.
+  await expect(async () => {
+    await page
+      .getByTestId('userpassword')
+      .getByRole('button', { name: 'Sign In' })
+      .click();
+    await expect(
+      page.getByRole('heading', { name: 'Resources' })
+    ).toBeVisible({ timeout: 5_000 });
+  }).toPass({ timeout: 30_000, intervals: [3_000] });
+});
+
+// Clean the user before each attempt (and after) so retries start clean rather
+// than failing on an already-registered user / consumed invite.
+// oxlint-disable-next-line no-empty-pattern
+test.beforeEach(({}, testInfo) => {
+  deleteUserIfExists(username(testInfo));
 });
 
 // oxlint-disable-next-line no-empty-pattern
 test.afterEach(({}, testInfo) => {
-  deleteUser(username(testInfo));
+  deleteUserIfExists(username(testInfo));
 });

--- a/e2e/tests/web/unauthenticated/signup.spec.ts
+++ b/e2e/tests/web/unauthenticated/signup.spec.ts
@@ -50,9 +50,9 @@ test('verify that a user can sign up with webauthn and login', async ({
       .getByTestId('userpassword')
       .getByRole('button', { name: 'Sign In' })
       .click();
-    await expect(
-      page.getByRole('heading', { name: 'Resources' })
-    ).toBeVisible({ timeout: 5_000 });
+    await expect(page.getByRole('heading', { name: 'Resources' })).toBeVisible({
+      timeout: 5_000,
+    });
   }).toPass({ timeout: 30_000, intervals: [3_000] });
 });
 


### PR DESCRIPTION
This replaces #66518 and adds more visibility around errors during e2e runs so we can figure out why firefox is failing

Also fixes the flakiness for Firefox (turns out it was getting rate limited)