### PR TITLE
MCP: Remove all non-canonical fields impacting RBAC from tools/call request 

### DIFF
--- a/lib/srv/mcp/helpers_test.go
+++ b/lib/srv/mcp/helpers_test.go
@@ -23,11 +23,13 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"slices"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -414,28 +416,7 @@ func checkSessionStartHasExternalSessionID() func(*testing.T, *apievents.MCPSess
 	}
 }
 
-func newAllowAllDenyForbiddenToolRole(t *testing.T, forbiddenTool string) types.Role {
-	t.Helper()
-	role, err := types.NewRole("allow-all-deny-forbidden", types.RoleSpecV6{
-		Allow: types.RoleConditions{
-			AppLabels: map[string]apiutils.Strings{
-				types.Wildcard: {types.Wildcard},
-			},
-			MCP: &types.MCPPermissions{
-				Tools: []string{types.Wildcard},
-			},
-		},
-		Deny: types.RoleConditions{
-			MCP: &types.MCPPermissions{
-				Tools: []string{forbiddenTool},
-			},
-		},
-	})
-	require.NoError(t, err)
-	return role
-}
-
-func newStreamableMCPServer(t *testing.T, upstream *mcpserver.MCPServer, role types.Role) (*eventstest.MockRecorderEmitter, *mcpclienttransport.StreamableHTTP) {
+func newStreamableMCPServer(t *testing.T, upstream *mcpserver.MCPServer, role types.Role) (_ *eventstest.MockRecorderEmitter, _ *mcpclienttransport.StreamableHTTP, proxyURL string) {
 	t.Helper()
 
 	remoteMCPServer := mcpserver.NewStreamableHTTPServer(upstream)
@@ -494,10 +475,11 @@ func newStreamableMCPServer(t *testing.T, upstream *mcpserver.MCPServer, role ty
 		}
 	}()
 
-	mcpClientTransport, err := mcpclienttransport.NewStreamableHTTP("http://" + listener.Addr().String())
+	proxyURL = "http://" + listener.Addr().String()
+	mcpClientTransport, err := mcpclienttransport.NewStreamableHTTP(proxyURL)
 	require.NoError(t, err)
 
-	return &emitter, mcpClientTransport
+	return &emitter, mcpClientTransport, proxyURL
 }
 
 func testJSONString(t *testing.T, v any) string {
@@ -505,4 +487,25 @@ func testJSONString(t *testing.T, v any) string {
 	data, err := json.Marshal(v)
 	require.NoError(t, err)
 	return string(data)
+}
+
+func testSendRAWRequest(t *testing.T, method, url, sessionID string, body string) (response []byte) {
+	t.Helper()
+	ctx := t.Context()
+
+	req, err := http.NewRequestWithContext(ctx, method, url, strings.NewReader(body))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json, text/event-stream")
+	req.Header.Set(mcpclienttransport.HeaderKeySessionID, sessionID)
+
+	resp, err := (&http.Client{Timeout: 5 * time.Second}).Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode, "body: %s", respBody)
+
+	return respBody
 }

--- a/lib/srv/mcp/helpers_test.go
+++ b/lib/srv/mcp/helpers_test.go
@@ -530,7 +530,10 @@ func (r *testHTTPRequestRecorder) registerHttpRequest(t *testing.T, req *http.Re
 	data, err := utils.GetAndReplaceRequestBody(req)
 	require.NoError(t, err)
 	req = req.Clone(t.Context())
-	utils.WriteRequestBody(req, data)
+	// The requests is now cloned, but it's a shallow clone holding a pointer to the original
+	// body. Let's now set a the cloned body.
+	utils.OverwriteRequestBodyNoDrain(req, data)
+	require.NoError(t, err)
 
 	r.mu.Lock()
 	defer r.mu.Unlock()

--- a/lib/srv/mcp/helpers_test.go
+++ b/lib/srv/mcp/helpers_test.go
@@ -416,11 +416,14 @@ func checkSessionStartHasExternalSessionID() func(*testing.T, *apievents.MCPSess
 	}
 }
 
-func newStreamableMCPServer(t *testing.T, upstream *mcpserver.MCPServer, role types.Role) (_ *eventstest.MockRecorderEmitter, _ *mcpclienttransport.StreamableHTTP, proxyURL string) {
+func newStreamableMCPServer(t *testing.T, upstream *mcpserver.MCPServer, role types.Role) (_ *testRecorder, _ *mcpclienttransport.StreamableHTTP, proxyURL string) {
 	t.Helper()
+
+	recorder := newTestRecorders()
 
 	remoteMCPServer := mcpserver.NewStreamableHTTPServer(upstream)
 	remoteHTTPServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		recorder.registerHttpRequest(t, r)
 		if r.URL.Path != "/mcp" {
 			w.WriteHeader(http.StatusNotFound)
 			return
@@ -440,9 +443,8 @@ func newStreamableMCPServer(t *testing.T, upstream *mcpserver.MCPServer, role ty
 	)
 	require.NoError(t, err)
 
-	emitter := eventstest.MockRecorderEmitter{}
 	s, err := NewServer(ServerConfig{
-		Emitter:       &emitter,
+		Emitter:       recorder,
 		ParentContext: t.Context(),
 		HostID:        "my-host-id",
 		AccessPoint:   fakeAccessPoint{},
@@ -479,14 +481,7 @@ func newStreamableMCPServer(t *testing.T, upstream *mcpserver.MCPServer, role ty
 	mcpClientTransport, err := mcpclienttransport.NewStreamableHTTP(proxyURL)
 	require.NoError(t, err)
 
-	return &emitter, mcpClientTransport, proxyURL
-}
-
-func testJSONString(t *testing.T, v any) string {
-	t.Helper()
-	data, err := json.Marshal(v)
-	require.NoError(t, err)
-	return string(data)
+	return recorder, mcpClientTransport, proxyURL
 }
 
 func testSendRAWRequest(t *testing.T, method, url, sessionID string, body string) (response []byte) {
@@ -505,7 +500,105 @@ func testSendRAWRequest(t *testing.T, method, url, sessionID string, body string
 
 	respBody, err := io.ReadAll(resp.Body)
 	require.NoError(t, err)
-	require.Equal(t, http.StatusOK, resp.StatusCode, "body: %s", respBody)
+	require.Contains(t, []int{http.StatusOK, http.StatusAccepted}, resp.StatusCode)
 
 	return respBody
+}
+
+type testRecorder struct {
+	*testHTTPRequestRecorder
+	*eventstest.MockRecorderEmitter
+}
+
+func newTestRecorders() *testRecorder {
+	return &testRecorder{&testHTTPRequestRecorder{}, &eventstest.MockRecorderEmitter{}}
+}
+
+func (r *testRecorder) Reset() {
+	r.testHTTPRequestRecorder.Reset()
+	r.MockRecorderEmitter.Reset()
+}
+
+type testHTTPRequestRecorder struct {
+	mu       sync.RWMutex
+	requests []*http.Request
+}
+
+func (r *testHTTPRequestRecorder) registerHttpRequest(t *testing.T, req *http.Request) {
+	t.Helper()
+
+	data, err := utils.GetAndReplaceRequestBody(req)
+	require.NoError(t, err)
+	req = req.Clone(t.Context())
+	utils.WriteRequestBody(req, data)
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.requests = append(r.requests, req)
+}
+
+func (r *testHTTPRequestRecorder) Reset() {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.requests = r.requests[:0]
+}
+
+func (r *testHTTPRequestRecorder) HTTPRequests() []*http.Request {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return r.requests
+}
+
+func testGetRequestPayload(t *testing.T, req *http.Request) []byte {
+	t.Helper()
+	defer req.Body.Close()
+	payload, err := io.ReadAll(req.Body)
+	require.NoError(t, err)
+	return payload
+}
+
+func testJSON(t *testing.T, v any) []byte {
+	t.Helper()
+	data, err := json.Marshal(v)
+	require.NoError(t, err)
+	return data
+}
+
+func requireDeniedToolResponse(t *testing.T, respJSON []byte) {
+	t.Helper()
+	requireRequestResponseError(t, respJSON, mcp.INVALID_PARAMS, "User does not have permissions")
+}
+
+func requireToolNameMissingResponse(t *testing.T, respJSON []byte) {
+	t.Helper()
+	requireRequestResponseError(t, respJSON, mcp.INVALID_REQUEST, errInvalidRequestMissingName.Error())
+}
+
+func requireRequestResponseError(t *testing.T, respJSON []byte, expectedCode int, includedData string) {
+	t.Helper()
+
+	var baseMessage mcputils.BaseJSONRPCMessage
+	err := json.Unmarshal(respJSON, &baseMessage)
+	require.NoError(t, err, string(respJSON))
+
+	// Case everything to string so it's displayed nicely in case of error.
+	require.Empty(t, string(baseMessage.Result), string(respJSON))
+	require.NotEmpty(t, baseMessage.ID)
+	require.NotEmpty(t, string(baseMessage.Error))
+
+	var messageErrorDetails map[string]json.RawMessage
+	err = json.Unmarshal(baseMessage.Error, &messageErrorDetails)
+	require.NoError(t, err)
+
+	require.Contains(t, messageErrorDetails, "code")
+	var code int
+	err = json.Unmarshal(messageErrorDetails["code"], &code)
+	require.NoError(t, err)
+	require.Equal(t, expectedCode, code)
+
+	require.Contains(t, messageErrorDetails, "data")
+	escapedIncludedData, err := json.Marshal(includedData)
+	escapedIncludedData = escapedIncludedData[1 : len(escapedIncludedData)-1]
+	require.NoError(t, err)
+	require.Contains(t, string(messageErrorDetails["data"]), string(escapedIncludedData))
 }

--- a/lib/srv/mcp/http.go
+++ b/lib/srv/mcp/http.go
@@ -170,7 +170,11 @@ func (t *streamableHTTPTransport) setExternalSessionID(header http.Header) {
 	}
 }
 
-func (t *streamableHTTPTransport) rewriteRequest(r *http.Request) (*http.Request, error) {
+func (t *streamableHTTPTransport) rewriteAndSendRequest(r *http.Request) (*http.Response, error) {
+	return t.rewriteAndSendRequestWithBody(r, nil)
+}
+
+func (t *streamableHTTPTransport) rewriteAndSendRequestWithBody(r *http.Request, bodyOverwrite any) (*http.Response, error) {
 	r = r.Clone(r.Context())
 	r.URL.Scheme = t.targetURI.Scheme
 	r.URL.Host = t.targetURI.Host
@@ -186,15 +190,17 @@ func (t *streamableHTTPTransport) rewriteRequest(r *http.Request) (*http.Request
 	if err := t.rewriteHTTPRequestHeaders(r); err != nil {
 		return nil, trace.Wrap(err)
 	}
-	return r, nil
-}
 
-func (t *streamableHTTPTransport) rewriteAndSendRequest(r *http.Request) (*http.Response, error) {
-	rCopy, err := t.rewriteRequest(r)
-	if err != nil {
-		return nil, trace.Wrap(err)
+	if bodyOverwrite != nil {
+		data, err := json.Marshal(bodyOverwrite)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		r.Body = io.NopCloser(bytes.NewReader(data))
+		r.ContentLength = int64(len(data))
 	}
-	return t.targetTransport.RoundTrip(rCopy)
+
+	return t.targetTransport.RoundTrip(r)
 }
 
 func (t *streamableHTTPTransport) handleSessionEndRequest(r *http.Request) (*http.Response, error) {
@@ -219,9 +225,10 @@ func (t *streamableHTTPTransport) handleMCPMessage(r *http.Request) (*http.Respo
 		return nil, trace.BadParameter("invalid request body %v", err)
 	}
 
+	var mcpRequest *mcputils.JSONRPCRequest
 	switch {
 	case baseMessage.IsRequest():
-		mcpRequest := baseMessage.MakeRequest()
+		mcpRequest = baseMessage.MakeRequest()
 		if errResp := t.sessionHandler.processClientRequest(r.Context(), mcpRequest); errResp != nil {
 			t.emitRequestEvent(t.parentCtx, mcpRequest, eventWithError(toError(*errResp)), eventWithHeader(r.Header))
 			return t.handleRequestError(r, *errResp)
@@ -234,7 +241,15 @@ func (t *streamableHTTPTransport) handleMCPMessage(r *http.Request) (*http.Respo
 		return nil, trace.BadParameter("not a MCP request or notification")
 	}
 
-	resp, err := t.rewriteAndSendRequest(r)
+	var resp *http.Response
+	var sendReqErr error
+	switch {
+	case mcpRequest != nil:
+		resp, sendReqErr = t.rewriteAndSendRequestWithBody(r, mcpRequest)
+	default:
+		resp, sendReqErr = t.rewriteAndSendRequest(r)
+	}
+
 	// Prefer session ID from server response if present. For example,
 	// "initialize" request does not have an ID but the server response may have
 	// it.
@@ -243,19 +258,19 @@ func (t *streamableHTTPTransport) handleMCPMessage(r *http.Request) (*http.Respo
 	}
 
 	// Take care of audit events after round trip.
-	respErrForAudit := convertHTTPResponseErrorForAudit(resp, err)
+	auditErr := convertHTTPResponseErrorForAudit(resp, sendReqErr)
 	switch {
 	case baseMessage.IsRequest():
 		mcpRequest := baseMessage.MakeRequest()
 		// Only emit session start if "initialize" succeeded.
-		if mcpRequest.Method == mcputils.MethodInitialize && respErrForAudit == nil {
+		if mcpRequest.Method == mcputils.MethodInitialize && auditErr == nil {
 			t.appendStartEvent(r.Context(), eventWithHeader(r.Header))
 		}
-		t.emitRequestEvent(t.parentCtx, mcpRequest, eventWithError(respErrForAudit), eventWithHeader(r.Header))
+		t.emitRequestEvent(t.parentCtx, mcpRequest, eventWithError(auditErr), eventWithHeader(r.Header))
 	case baseMessage.IsNotification():
-		t.emitNotificationEvent(r.Context(), baseMessage.MakeNotification(), eventWithError(respErrForAudit), eventWithHeader(r.Header))
+		t.emitNotificationEvent(r.Context(), baseMessage.MakeNotification(), eventWithError(auditErr), eventWithHeader(r.Header))
 	}
-	return resp, trace.Wrap(err)
+	return resp, trace.Wrap(sendReqErr)
 }
 
 func (t *streamableHTTPTransport) handleRequestError(r *http.Request, errResp mcp.JSONRPCMessage) (*http.Response, error) {

--- a/lib/srv/mcp/http.go
+++ b/lib/srv/mcp/http.go
@@ -225,29 +225,24 @@ func (t *streamableHTTPTransport) handleMCPMessage(r *http.Request) (*http.Respo
 		return nil, trace.BadParameter("invalid request body %v", err)
 	}
 
-	var mcpRequest *mcputils.JSONRPCRequest
+	var resp *http.Response
+	var sendReqErr error
 	switch {
 	case baseMessage.IsRequest():
-		mcpRequest = baseMessage.MakeRequest()
-		if errResp := t.sessionHandler.processClientRequest(r.Context(), mcpRequest); errResp != nil {
+		mcpRequest := baseMessage.MakeRequest()
+		mcpRequest, errResp := t.sessionHandler.processClientRequest(r.Context(), mcpRequest)
+		if errResp != nil {
 			t.emitRequestEvent(t.parentCtx, mcpRequest, eventWithError(toError(*errResp)), eventWithHeader(r.Header))
 			return t.handleRequestError(r, *errResp)
 		}
+		resp, sendReqErr = t.rewriteAndSendRequestWithBody(r, mcpRequest)
 	case baseMessage.IsNotification():
 		t.sessionHandler.processClientNotification(r.Context(), baseMessage.MakeNotification())
+		resp, sendReqErr = t.rewriteAndSendRequest(r)
 	default:
 		// Not sending it to the server if we don't understand it.
 		t.emitInvalidHTTPRequest(t.parentCtx, r)
 		return nil, trace.BadParameter("not a MCP request or notification")
-	}
-
-	var resp *http.Response
-	var sendReqErr error
-	switch {
-	case mcpRequest != nil:
-		resp, sendReqErr = t.rewriteAndSendRequestWithBody(r, mcpRequest)
-	default:
-		resp, sendReqErr = t.rewriteAndSendRequest(r)
 	}
 
 	// Prefer session ID from server response if present. For example,

--- a/lib/srv/mcp/http.go
+++ b/lib/srv/mcp/http.go
@@ -203,7 +203,7 @@ func (t *streamableHTTPTransport) handleListenSSEStreamRequest(r *http.Request) 
 }
 
 func (t *streamableHTTPTransport) handleMCPMessage(r *http.Request) (*http.Response, error) {
-	reqBody, err := utils.GetRequestBody(r)
+	reqBody, err := utils.GetAndReplaceRequestBody(r)
 	if err != nil {
 		t.emitInvalidHTTPRequest(t.parentCtx, r)
 		return nil, trace.BadParameter("invalid request body %v", err)

--- a/lib/srv/mcp/http.go
+++ b/lib/srv/mcp/http.go
@@ -171,10 +171,6 @@ func (t *streamableHTTPTransport) setExternalSessionID(header http.Header) {
 }
 
 func (t *streamableHTTPTransport) rewriteAndSendRequest(r *http.Request) (*http.Response, error) {
-	return t.rewriteAndSendRequestWithBody(r, nil)
-}
-
-func (t *streamableHTTPTransport) rewriteAndSendRequestWithBody(r *http.Request, bodyOverwrite any) (*http.Response, error) {
 	r = r.Clone(r.Context())
 	r.URL.Scheme = t.targetURI.Scheme
 	r.URL.Host = t.targetURI.Host
@@ -189,15 +185,6 @@ func (t *streamableHTTPTransport) rewriteAndSendRequestWithBody(r *http.Request,
 
 	if err := t.rewriteHTTPRequestHeaders(r); err != nil {
 		return nil, trace.Wrap(err)
-	}
-
-	if bodyOverwrite != nil {
-		data, err := json.Marshal(bodyOverwrite)
-		if err != nil {
-			return nil, trace.Wrap(err)
-		}
-		r.Body = io.NopCloser(bytes.NewReader(data))
-		r.ContentLength = int64(len(data))
 	}
 
 	return t.targetTransport.RoundTrip(r)
@@ -216,35 +203,40 @@ func (t *streamableHTTPTransport) handleListenSSEStreamRequest(r *http.Request) 
 }
 
 func (t *streamableHTTPTransport) handleMCPMessage(r *http.Request) (*http.Response, error) {
-	var baseMessage mcputils.BaseJSONRPCMessage
-	if reqBody, err := utils.GetAndReplaceRequestBody(r); err != nil {
+	reqBody, err := utils.GetRequestBody(r)
+	if err != nil {
 		t.emitInvalidHTTPRequest(t.parentCtx, r)
 		return nil, trace.BadParameter("invalid request body %v", err)
-	} else if err := json.Unmarshal(reqBody, &baseMessage); err != nil {
+	}
+	reqBody, err = sanitizeRawRequest(reqBody)
+	if err != nil {
+		t.emitInvalidHTTPRequest(t.parentCtx, r)
+		return nil, trace.BadParameter("invalid request body %v", err)
+	}
+	utils.WriteRequestBody(r, reqBody)
+	var baseMessage mcputils.BaseJSONRPCMessage
+	if err := json.Unmarshal(reqBody, &baseMessage); err != nil {
 		t.emitInvalidHTTPRequest(t.parentCtx, r)
 		return nil, trace.BadParameter("invalid request body %v", err)
 	}
 
-	var resp *http.Response
-	var sendReqErr error
 	switch {
 	case baseMessage.IsRequest():
 		mcpRequest := baseMessage.MakeRequest()
-		mcpRequest, errResp := t.sessionHandler.processClientRequest(r.Context(), mcpRequest)
+		errResp := t.sessionHandler.processClientRequest(r.Context(), mcpRequest)
 		if errResp != nil {
 			t.emitRequestEvent(t.parentCtx, mcpRequest, eventWithError(toError(*errResp)), eventWithHeader(r.Header))
 			return t.handleRequestError(r, *errResp)
 		}
-		resp, sendReqErr = t.rewriteAndSendRequestWithBody(r, mcpRequest)
 	case baseMessage.IsNotification():
 		t.sessionHandler.processClientNotification(r.Context(), baseMessage.MakeNotification())
-		resp, sendReqErr = t.rewriteAndSendRequest(r)
 	default:
 		// Not sending it to the server if we don't understand it.
 		t.emitInvalidHTTPRequest(t.parentCtx, r)
 		return nil, trace.BadParameter("not a MCP request or notification")
 	}
 
+	resp, sendReqErr := t.rewriteAndSendRequest(r)
 	// Prefer session ID from server response if present. For example,
 	// "initialize" request does not have an ID but the server response may have
 	// it.

--- a/lib/srv/mcp/http.go
+++ b/lib/srv/mcp/http.go
@@ -213,7 +213,9 @@ func (t *streamableHTTPTransport) handleMCPMessage(r *http.Request) (*http.Respo
 		t.emitInvalidHTTPRequest(t.parentCtx, r)
 		return nil, trace.BadParameter("invalid request body %v", err)
 	}
-	utils.WriteRequestBody(r, reqBody)
+	if err := utils.OverwriteRequestBody(r, reqBody); err != nil {
+		return nil, trace.Wrap(err, "overwriting request body with sanitized value")
+	}
 	var baseMessage mcputils.BaseJSONRPCMessage
 	if err := json.Unmarshal(reqBody, &baseMessage); err != nil {
 		t.emitInvalidHTTPRequest(t.parentCtx, r)

--- a/lib/srv/mcp/http.go
+++ b/lib/srv/mcp/http.go
@@ -208,7 +208,7 @@ func (t *streamableHTTPTransport) handleMCPMessage(r *http.Request) (*http.Respo
 		t.emitInvalidHTTPRequest(t.parentCtx, r)
 		return nil, trace.BadParameter("invalid request body %v", err)
 	}
-	reqBody, err = sanitizeRawRequest(reqBody)
+	reqBody, err = sanitizeRawMCPRequest(reqBody)
 	if err != nil {
 		t.emitInvalidHTTPRequest(t.parentCtx, r)
 		return nil, trace.BadParameter("invalid request body %v", err)

--- a/lib/srv/mcp/http_test.go
+++ b/lib/srv/mcp/http_test.go
@@ -24,6 +24,7 @@ import (
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"sync"
 	"testing"
 	"time"
@@ -38,6 +39,7 @@ import (
 
 	"github.com/gravitational/teleport/api/types"
 	apievents "github.com/gravitational/teleport/api/types/events"
+	apiutils "github.com/gravitational/teleport/api/utils"
 	libevents "github.com/gravitational/teleport/lib/events"
 	"github.com/gravitational/teleport/lib/events/eventstest"
 	"github.com/gravitational/teleport/lib/utils"
@@ -218,26 +220,40 @@ func Test_Server_HandleSession_reject_req_missing_name(t *testing.T) {
 
 	ctx := t.Context()
 
-	const forbiddenTool = "forbidden_tool"
-	const forbiddenToolTextContent = "FORBIDDEN_TOOL_EXECUTED_ON_UPSTREAM"
+	const allowedTool = "allowed_tool"
+	const allowedToolContext = "allowed_tool_executed_on_upstream"
+	const deniedTool = "denied_tool"
+	const deniedToolTextContent = "DENIED_TOOL_EXECUTED_ON_UPSTREAM"
 
-	role := newAllowAllDenyForbiddenToolRole(t, forbiddenTool)
+	role, err := types.NewRole("allowed_tool_access", types.RoleSpecV6{
+		Allow: types.RoleConditions{
+			AppLabels: map[string]apiutils.Strings{
+				types.Wildcard: {types.Wildcard},
+			},
+			MCP: &types.MCPPermissions{
+				Tools: []string{allowedTool},
+			},
+		},
+	})
+	require.NoError(t, err)
 
 	upstream := mcpserver.NewMCPServer("test-server", "1.0.0")
 	upstream.AddTool(
-		mcp.Tool{
-			Name: forbiddenTool,
-		},
+		mcp.Tool{Name: allowedTool},
 		func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-			return &mcp.CallToolResult{
-				Content: []mcp.Content{mcp.NewTextContent(forbiddenToolTextContent)},
-			}, nil
+			return &mcp.CallToolResult{Content: []mcp.Content{mcp.NewTextContent(allowedToolContext)}}, nil
+		},
+	)
+	upstream.AddTool(
+		mcp.Tool{Name: deniedTool},
+		func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+			return &mcp.CallToolResult{Content: []mcp.Content{mcp.NewTextContent(deniedToolTextContent)}}, nil
 		},
 	)
 
-	emitter, mcpClientTransport := newStreamableMCPServer(t, upstream, role)
+	emitter, mcpClientTransport, proxyURL := newStreamableMCPServer(t, upstream, role)
 
-	_, err := mcpClientTransport.SendRequest(ctx, mcpclienttransport.JSONRPCRequest{
+	_, err = mcpClientTransport.SendRequest(ctx, mcpclienttransport.JSONRPCRequest{
 		JSONRPC: mcp.JSONRPC_VERSION,
 		ID:      mcp.NewRequestId(1),
 		Method:  string(mcp.MethodInitialize),
@@ -259,14 +275,14 @@ func Test_Server_HandleSession_reject_req_missing_name(t *testing.T) {
 		ID:      mcp.NewRequestId(2),
 		Method:  string(mcp.MethodToolsCall),
 		Params: map[string]any{
-			"name": forbiddenTool,
+			"name": deniedTool,
 		},
 	})
 	require.NoError(t, err)
 	require.NotNil(t, resp.Error)
 	require.Equal(t, mcp.INVALID_PARAMS, resp.Error.Code)
 	respJSON := testJSONString(t, resp)
-	require.NotContains(t, respJSON, forbiddenToolTextContent)
+	require.NotContains(t, respJSON, deniedToolTextContent)
 	require.Contains(t, respJSON, "User does not have permissions")
 
 	// Verify that when non-canonical capitalized "Name" param is specified the request is
@@ -277,14 +293,14 @@ func Test_Server_HandleSession_reject_req_missing_name(t *testing.T) {
 		ID:      mcp.NewRequestId(3),
 		Method:  string(mcp.MethodToolsCall),
 		Params: map[string]any{
-			"Name": forbiddenTool,
+			"Name": deniedTool,
 		},
 	})
 	require.NoError(t, err)
 	require.NotNil(t, resp.Error)
 	require.Equal(t, mcp.INVALID_REQUEST, resp.Error.Code)
 	respJSON = testJSONString(t, resp)
-	require.NotContains(t, respJSON, forbiddenToolTextContent)
+	require.NotContains(t, respJSON, deniedToolTextContent)
 	require.Contains(t, respJSON, testJSONString(t, errInvalidRequestMissingName.Error()))
 
 	// Verify that when an empty "name" param is specified the request is rejected.
@@ -301,7 +317,7 @@ func Test_Server_HandleSession_reject_req_missing_name(t *testing.T) {
 	require.NotNil(t, resp.Error)
 	require.Equal(t, mcp.INVALID_REQUEST, resp.Error.Code)
 	respJSON = testJSONString(t, resp)
-	require.NotContains(t, respJSON, forbiddenToolTextContent)
+	require.NotContains(t, respJSON, deniedToolTextContent)
 	require.Contains(t, respJSON, testJSONString(t, errInvalidRequestMissingName.Error()))
 
 	// Verify that correct request is properly unauthorized.
@@ -311,15 +327,56 @@ func Test_Server_HandleSession_reject_req_missing_name(t *testing.T) {
 		ID:      mcp.NewRequestId(5),
 		Method:  string(mcp.MethodToolsCall),
 		Params: map[string]any{
-			"name": forbiddenTool,
+			"name": deniedTool,
 		},
 	})
 	require.NoError(t, err)
 	require.NotNil(t, resp.Error)
 	require.Equal(t, mcp.INVALID_PARAMS, resp.Error.Code)
 	respJSON = testJSONString(t, resp)
-	require.NotContains(t, respJSON, forbiddenToolTextContent)
+	require.NotContains(t, respJSON, deniedToolTextContent)
 	require.Contains(t, respJSON, "User does not have permissions.")
+
+	// Verify that when non-canonical non-lower-case "name" params are specified in the request
+	// along side the canonical lower-case one, they are pruned from the request before
+	// forwarding.
+	emitter.Reset()
+	respBytes := testSendRAWRequest(t, http.MethodPost, proxyURL, mcpClientTransport.GetSessionId(), fmt.Sprintf(
+		`{"jsonrpc":"2.0","id":7,"method":"tools/call","params":{%q:%q,%q:%q,%q:%q,%q:%q}}`,
+		"Name", allowedTool,
+		"NaMe", allowedTool,
+		"name", deniedTool,
+		"NAME", allowedTool,
+	))
+	respJSON = string(respBytes)
+	require.Contains(t, respJSON, strconv.Itoa(mcp.INVALID_PARAMS))
+	require.NotContains(t, respJSON, allowedToolContext)
+	require.NotContains(t, respJSON, deniedToolTextContent)
+	require.Contains(t, respJSON, "User does not have permissions.")
+	require.Len(t, emitter.Events(), 1)
+	event, ok := emitter.LastEvent().(*apievents.MCPSessionRequest)
+	require.True(t, ok)
+	// Verify there was 1 param sent and it was the lowercase "name".
+	require.Len(t, event.Message.Params.Fields, 1)
+	require.Equal(t, deniedTool, event.Message.Params.Fields["name"].GetStringValue())
+
+	emitter.Reset()
+	respBytes = testSendRAWRequest(t, http.MethodPost, proxyURL, mcpClientTransport.GetSessionId(), fmt.Sprintf(
+		`{"jsonrpc":"2.0","id":7,"method":"tools/call","params":{%q:%q,%q:%q,%q:%q,%q:%q}}`,
+		"Name", deniedTool,
+		"NaMe", deniedTool,
+		"name", allowedTool,
+		"NAME", deniedTool,
+	))
+	respJSON = string(respBytes)
+	require.NotContains(t, respJSON, deniedToolTextContent)
+	require.Contains(t, respJSON, allowedToolContext)
+	require.Len(t, emitter.Events(), 1)
+	event, ok = emitter.LastEvent().(*apievents.MCPSessionRequest)
+	require.True(t, ok)
+	// Verify there was 1 param sent and it was the lowercase "name".
+	require.Len(t, event.Message.Params.Fields, 1)
+	require.Equal(t, allowedTool, event.Message.Params.Fields["name"].GetStringValue())
 }
 
 func Test_handleAuthErrHTTP(t *testing.T) {

--- a/lib/srv/mcp/http_test.go
+++ b/lib/srv/mcp/http_test.go
@@ -24,7 +24,6 @@ import (
 	"net"
 	"net/http"
 	"net/http/httptest"
-	"strconv"
 	"sync"
 	"testing"
 	"time"
@@ -213,15 +212,15 @@ func Test_handleStreamableHTTP(t *testing.T) {
 	})
 }
 
-// Test_Server_HandleSession_reject_req_missing_name makes sure requests with missing canonical
-// "name" param are rejected.
-func Test_Server_HandleSession_reject_req_missing_name(t *testing.T) {
+// Test_Server_HandleSession_request_sanitization verifies the forwarded request is stripped of
+// non-canonical fields (e.g. uppercase) which may confuse the upstream server.
+func Test_Server_HandleSession_request_sanitization(t *testing.T) {
 	t.Parallel()
 
 	ctx := t.Context()
 
 	const allowedTool = "allowed_tool"
-	const allowedToolContext = "allowed_tool_executed_on_upstream"
+	const allowedToolTextContent = "allowed_tool_executed_on_upstream"
 	const deniedTool = "denied_tool"
 	const deniedToolTextContent = "DENIED_TOOL_EXECUTED_ON_UPSTREAM"
 
@@ -241,7 +240,7 @@ func Test_Server_HandleSession_reject_req_missing_name(t *testing.T) {
 	upstream.AddTool(
 		mcp.Tool{Name: allowedTool},
 		func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-			return &mcp.CallToolResult{Content: []mcp.Content{mcp.NewTextContent(allowedToolContext)}}, nil
+			return &mcp.CallToolResult{Content: []mcp.Content{mcp.NewTextContent(allowedToolTextContent)}}, nil
 		},
 	)
 	upstream.AddTool(
@@ -251,8 +250,9 @@ func Test_Server_HandleSession_reject_req_missing_name(t *testing.T) {
 		},
 	)
 
-	emitter, mcpClientTransport, proxyURL := newStreamableMCPServer(t, upstream, role)
+	recorder, mcpClientTransport, proxyURL := newStreamableMCPServer(t, upstream, role)
 
+	// Initialize message has to be sent first. It isn't a part of the test.
 	_, err = mcpClientTransport.SendRequest(ctx, mcpclienttransport.JSONRPCRequest{
 		JSONRPC: mcp.JSONRPC_VERSION,
 		ID:      mcp.NewRequestId(1),
@@ -268,9 +268,26 @@ func Test_Server_HandleSession_reject_req_missing_name(t *testing.T) {
 	require.NoError(t, err)
 	require.NotEmpty(t, mcpClientTransport.GetSessionId())
 
-	// Verify it works as expected if the canonical lower-case "name" param is provided.
-	emitter.Reset()
+	// Verify everything works as expected if the canonical lower-case "name" param is
+	// provided and allowed tool is executed.
+	recorder.Reset()
 	resp, err := mcpClientTransport.SendRequest(ctx, mcpclienttransport.JSONRPCRequest{
+		JSONRPC: mcp.JSONRPC_VERSION,
+		ID:      mcp.NewRequestId(2),
+		Method:  string(mcp.MethodToolsCall),
+		Params: map[string]any{
+			"name": allowedTool,
+		},
+	})
+	require.NoError(t, err)
+	require.Contains(t, string(resp.Result), allowedToolTextContent)
+	// Verify the request was forwarded.
+	require.Len(t, recorder.requests, 1)
+
+	// Verify everything works as expected if the canonical lower-case "name" param is
+	// provided and denied tool is rejected.
+	recorder.Reset()
+	resp, err = mcpClientTransport.SendRequest(ctx, mcpclienttransport.JSONRPCRequest{
 		JSONRPC: mcp.JSONRPC_VERSION,
 		ID:      mcp.NewRequestId(2),
 		Method:  string(mcp.MethodToolsCall),
@@ -279,32 +296,12 @@ func Test_Server_HandleSession_reject_req_missing_name(t *testing.T) {
 		},
 	})
 	require.NoError(t, err)
-	require.NotNil(t, resp.Error)
-	require.Equal(t, mcp.INVALID_PARAMS, resp.Error.Code)
-	respJSON := testJSONString(t, resp)
-	require.NotContains(t, respJSON, deniedToolTextContent)
-	require.Contains(t, respJSON, "User does not have permissions")
+	requireDeniedToolResponse(t, testJSON(t, resp))
+	// Verify the request was not forwarded.
+	require.Len(t, recorder.requests, 0)
 
-	// Verify that when non-canonical capitalized "Name" param is specified the request is
-	// rejected.
-	emitter.Reset()
-	resp, err = mcpClientTransport.SendRequest(ctx, mcpclienttransport.JSONRPCRequest{
-		JSONRPC: mcp.JSONRPC_VERSION,
-		ID:      mcp.NewRequestId(3),
-		Method:  string(mcp.MethodToolsCall),
-		Params: map[string]any{
-			"Name": deniedTool,
-		},
-	})
-	require.NoError(t, err)
-	require.NotNil(t, resp.Error)
-	require.Equal(t, mcp.INVALID_REQUEST, resp.Error.Code)
-	respJSON = testJSONString(t, resp)
-	require.NotContains(t, respJSON, deniedToolTextContent)
-	require.Contains(t, respJSON, testJSONString(t, errInvalidRequestMissingName.Error()))
-
-	// Verify that when an empty "name" param is specified the request is rejected.
-	emitter.Reset()
+	// Verify that when an empty "name" param is specified the request is rejected as invalid.
+	recorder.Reset()
 	resp, err = mcpClientTransport.SendRequest(ctx, mcpclienttransport.JSONRPCRequest{
 		JSONRPC: mcp.JSONRPC_VERSION,
 		ID:      mcp.NewRequestId(4),
@@ -314,94 +311,126 @@ func Test_Server_HandleSession_reject_req_missing_name(t *testing.T) {
 		},
 	})
 	require.NoError(t, err)
-	require.NotNil(t, resp.Error)
-	require.Equal(t, mcp.INVALID_REQUEST, resp.Error.Code)
-	respJSON = testJSONString(t, resp)
-	require.NotContains(t, respJSON, deniedToolTextContent)
-	require.Contains(t, respJSON, testJSONString(t, errInvalidRequestMissingName.Error()))
+	requireToolNameMissingResponse(t, testJSON(t, resp))
+	// Verify the request was not forwarded.
+	require.Len(t, recorder.requests, 0)
 
-	// Verify that correct request is properly unauthorized.
-	emitter.Reset()
+	// Verify that when non-canonical capitalized "Name" param is specified and send through
+	// streamable transport the request is correctly rejected.
+	recorder.Reset()
 	resp, err = mcpClientTransport.SendRequest(ctx, mcpclienttransport.JSONRPCRequest{
 		JSONRPC: mcp.JSONRPC_VERSION,
-		ID:      mcp.NewRequestId(5),
+		ID:      mcp.NewRequestId(3),
 		Method:  string(mcp.MethodToolsCall),
 		Params: map[string]any{
+			"Name": allowedTool,
 			"name": deniedTool,
+			"NAME": allowedTool,
 		},
 	})
 	require.NoError(t, err)
-	require.NotNil(t, resp.Error)
-	require.Equal(t, mcp.INVALID_PARAMS, resp.Error.Code)
-	respJSON = testJSONString(t, resp)
-	require.NotContains(t, respJSON, deniedToolTextContent)
-	require.Contains(t, respJSON, "User does not have permissions.")
+	requireDeniedToolResponse(t, testJSON(t, resp))
+	// Verify the request was not forwarded.
+	require.Len(t, recorder.requests, 0)
 
-	// Verify that when non-canonical non-lower-case "name" params are specified in the request
-	// along side the canonical lower-case one, they are pruned from the request before
-	// forwarding.
-	emitter.Reset()
-	respBytes := testSendRAWRequest(t, http.MethodPost, proxyURL, mcpClientTransport.GetSessionId(), fmt.Sprintf(
+	// Verify that when non-canonical capitalized "Name" param is specified and send through
+	// HTTP transport the request is correctly rejected.
+	recorder.Reset()
+	proxyRequest := fmt.Sprintf(
 		`{"jsonrpc":"2.0","id":7,"method":"tools/call","params":{%q:%q,%q:%q,%q:%q,%q:%q}}`,
 		"Name", allowedTool,
 		"NaMe", allowedTool,
 		"name", deniedTool,
 		"NAME", allowedTool,
-	))
-	respJSON = string(respBytes)
-	require.Contains(t, respJSON, strconv.Itoa(mcp.INVALID_PARAMS))
-	require.NotContains(t, respJSON, allowedToolContext)
-	require.NotContains(t, respJSON, deniedToolTextContent)
-	require.Contains(t, respJSON, "User does not have permissions.")
-	require.Len(t, emitter.Events(), 1)
-	event, ok := emitter.LastEvent().(*apievents.MCPSessionRequest)
-	require.True(t, ok)
-	// Verify there was 1 param sent and it was the lowercase "name".
-	require.Len(t, event.Message.Params.Fields, 1)
-	require.Equal(t, deniedTool, event.Message.Params.Fields["name"].GetStringValue())
+	)
+	expectedForwardedRequest := fmt.Sprintf(
+		`{"jsonrpc":"2.0","id":7,"method":"tools/call","params":{%q:%q}}`,
+		"name", deniedTool,
+	)
+	rawResp := testSendRAWRequest(t, http.MethodPost, proxyURL, mcpClientTransport.GetSessionId(), proxyRequest)
+	requireDeniedToolResponse(t, rawResp)
+	// Verify the request was not forwarded.
+	require.Len(t, recorder.requests, 0)
 
-	emitter.Reset()
-	respBytes = testSendRAWRequest(t, http.MethodPost, proxyURL, mcpClientTransport.GetSessionId(), fmt.Sprintf(
-		`{"jsonrpc":"2.0","id":7,"method":"tools/call","params":{%q:%q,%q:%q,%q:%q,%q:%q}}`,
+	// Verify that when non-canonical capitalized "Params" field is specified and send through
+	// HTTP transport the request is correctly rejected.
+	recorder.Reset()
+	proxyRequest = fmt.Sprintf(
+		`{"jsonrpc":"2.0","id":8,"method":"tools/call","Params":{%q:%q}}`,
+		"name", deniedTool,
+	)
+	expectedForwardedRequest =
+		`{"jsonrpc":"2.0","id":8,"method":"tools/call"}`
+	rawResp = testSendRAWRequest(t, http.MethodPost, proxyURL, mcpClientTransport.GetSessionId(), proxyRequest)
+	requireToolNameMissingResponse(t, rawResp)
+	// Verify the request was not forwarded.
+	require.Len(t, recorder.requests, 0)
+
+	// Verify that when non-canonical capitalized "Method" field is specified and send through
+	// HTTP transport the request is sanitized before forwarding, resulting in a ping message.
+	recorder.Reset()
+	proxyRequest = fmt.Sprintf(
+		`{"jsonrpc":"2.0","id":9,"method":"ping","Method":"tools/call","params":{%q:%q}}`,
+		"name", deniedTool,
+	)
+	expectedForwardedRequest = fmt.Sprintf(
+		`{"jsonrpc":"2.0","id":9,"method":"ping","params":{%q:%q}}`,
+		"name", deniedTool,
+	)
+	rawResp = testSendRAWRequest(t, http.MethodPost, proxyURL, mcpClientTransport.GetSessionId(), proxyRequest)
+	require.JSONEq(t, `{"jsonrpc":"2.0","id":9,"result":{}}`, string(rawResp))
+	// Verify the request was forwarded as ping.
+	require.Len(t, recorder.requests, 1)
+	forwardedRequest := string(testGetRequestPayload(t, recorder.requests[0]))
+	require.JSONEq(t, expectedForwardedRequest, forwardedRequest)
+	require.Contains(t, proxyRequest, `"Method"`)
+	require.NotContains(t, forwardedRequest, `"Method"`)
+
+	// Verify that when non-canonical capitalized "ID" field is specified and send through HTTP
+	// transport the request is sanitized before forwarding, resulting in a Notification
+	// message.
+	recorder.Reset()
+	proxyRequest = fmt.Sprintf(
+		`{"jsonrpc":"2.0","ID":8,"method":"tools/call","params":{%q:%q}}`, "name", deniedTool,
+	)
+	expectedForwardedRequest = fmt.Sprintf(
+		`{"jsonrpc":"2.0","method":"tools/call","params":{%q:%q}}`, "name", deniedTool,
+	)
+	rawResp = testSendRAWRequest(t, http.MethodPost, proxyURL, mcpClientTransport.GetSessionId(), proxyRequest)
+	require.Empty(t, rawResp) // MCP Notification response.
+	// Verify the forwarded request's confusing fields are pruned.
+	require.Len(t, recorder.requests, 1)
+	forwardedRequest = string(testGetRequestPayload(t, recorder.requests[0]))
+	require.JSONEq(t, expectedForwardedRequest, forwardedRequest)
+	require.Contains(t, proxyRequest, `"ID":8`)
+	require.NotContains(t, forwardedRequest, `"ID":8`)
+
+	// Verify multiple non-canonical fields are stripped from a message send over HTTP before
+	// forwarding.
+	recorder.Reset()
+	proxyRequest = fmt.Sprintf(
+		`{"jsonrpc":"2.0","ID":100,"id":9,"Method":"ping","method":"tools/call","Params":{"a":"b"},"params":{%q:%q,%q:%q,%q:%q,%q:%q}}`,
 		"Name", deniedTool,
 		"NaMe", deniedTool,
 		"name", allowedTool,
 		"NAME", deniedTool,
-	))
-	respJSON = string(respBytes)
-	require.NotContains(t, respJSON, deniedToolTextContent)
-	require.Contains(t, respJSON, allowedToolContext)
-	require.Len(t, emitter.Events(), 1)
-	event, ok = emitter.LastEvent().(*apievents.MCPSessionRequest)
-	require.True(t, ok)
-	// Verify there was 1 param sent and it was the lowercase "name".
-	require.Len(t, event.Message.Params.Fields, 1)
-	require.Equal(t, allowedTool, event.Message.Params.Fields["name"].GetStringValue())
-
-	// Verify that when a non-canonical "Params" field is specified, the request is rejected
-	// instead of forwarding a request that Go-based upstream servers can decode
-	// case-insensitively.
-	emitter.Reset()
-	respBytes = testSendRAWRequest(t, http.MethodPost, proxyURL, mcpClientTransport.GetSessionId(), fmt.Sprintf(
-		`{"jsonrpc":"2.0","id":8,"method":"tools/call","Params":{%q:%q}}`,
-		"name", deniedTool,
-	))
-	respJSON = string(respBytes)
-	require.Contains(t, respJSON, strconv.Itoa(mcp.INVALID_REQUEST))
-	require.NotContains(t, respJSON, deniedToolTextContent)
-	require.Contains(t, respJSON, testJSONString(t, errInvalidRequestMissingName.Error()))
-
-	// Verify that a non-canonical top-level "Method" field cannot make Teleport authorize one
-	// method while the upstream executes another.
-	emitter.Reset()
-	respBytes = testSendRAWRequest(t, http.MethodPost, proxyURL, mcpClientTransport.GetSessionId(), fmt.Sprintf(
-		`{"jsonrpc":"2.0","id":9,"method":"ping","Method":"tools/call","params":{%q:%q}}`,
-		"name", deniedTool,
-	))
-	respJSON = string(respBytes)
-	require.NotContains(t, respJSON, deniedToolTextContent)
-	require.NotContains(t, respJSON, strconv.Itoa(mcp.INVALID_PARAMS))
-	require.NotContains(t, respJSON, "User does not have permissions.")
+	)
+	expectedForwardedRequest = fmt.Sprintf(
+		`{"jsonrpc":"2.0","id":9,"method":"tools/call","params":{%q:%q}}`,
+		"name", allowedTool,
+	)
+	rawResp = testSendRAWRequest(t, http.MethodPost, proxyURL, mcpClientTransport.GetSessionId(), proxyRequest)
+	require.Contains(t, string(rawResp), allowedToolTextContent)
+	// Verify the forwarded request's confusing fields are pruned.
+	require.Len(t, recorder.requests, 1)
+	forwardedRequest = string(testGetRequestPayload(t, recorder.requests[0]))
+	require.JSONEq(t, expectedForwardedRequest, forwardedRequest)
+	require.Contains(t, proxyRequest, `"ID":`)
+	require.NotContains(t, forwardedRequest, `"ID"`)
+	require.Contains(t, proxyRequest, `"Method":`)
+	require.NotContains(t, forwardedRequest, `"Method"`)
+	require.Contains(t, proxyRequest, `"Params":`)
+	require.NotContains(t, forwardedRequest, `"Params"`)
 }
 
 func Test_handleAuthErrHTTP(t *testing.T) {

--- a/lib/srv/mcp/http_test.go
+++ b/lib/srv/mcp/http_test.go
@@ -377,6 +377,31 @@ func Test_Server_HandleSession_reject_req_missing_name(t *testing.T) {
 	// Verify there was 1 param sent and it was the lowercase "name".
 	require.Len(t, event.Message.Params.Fields, 1)
 	require.Equal(t, allowedTool, event.Message.Params.Fields["name"].GetStringValue())
+
+	// Verify that when a non-canonical "Params" field is specified, the request is rejected
+	// instead of forwarding a request that Go-based upstream servers can decode
+	// case-insensitively.
+	emitter.Reset()
+	respBytes = testSendRAWRequest(t, http.MethodPost, proxyURL, mcpClientTransport.GetSessionId(), fmt.Sprintf(
+		`{"jsonrpc":"2.0","id":8,"method":"tools/call","Params":{%q:%q}}`,
+		"name", deniedTool,
+	))
+	respJSON = string(respBytes)
+	require.Contains(t, respJSON, strconv.Itoa(mcp.INVALID_REQUEST))
+	require.NotContains(t, respJSON, deniedToolTextContent)
+	require.Contains(t, respJSON, testJSONString(t, errInvalidRequestMissingName.Error()))
+
+	// Verify that a non-canonical top-level "Method" field cannot make Teleport authorize one
+	// method while the upstream executes another.
+	emitter.Reset()
+	respBytes = testSendRAWRequest(t, http.MethodPost, proxyURL, mcpClientTransport.GetSessionId(), fmt.Sprintf(
+		`{"jsonrpc":"2.0","id":9,"method":"ping","Method":"tools/call","params":{%q:%q}}`,
+		"name", deniedTool,
+	))
+	respJSON = string(respBytes)
+	require.NotContains(t, respJSON, deniedToolTextContent)
+	require.NotContains(t, respJSON, strconv.Itoa(mcp.INVALID_PARAMS))
+	require.NotContains(t, respJSON, "User does not have permissions.")
 }
 
 func Test_handleAuthErrHTTP(t *testing.T) {

--- a/lib/srv/mcp/http_test.go
+++ b/lib/srv/mcp/http_test.go
@@ -298,7 +298,7 @@ func Test_Server_HandleSession_request_sanitization(t *testing.T) {
 	require.NoError(t, err)
 	requireDeniedToolResponse(t, testJSON(t, resp))
 	// Verify the request was not forwarded.
-	require.Len(t, recorder.requests, 0)
+	require.Empty(t, recorder.requests)
 
 	// Verify that when an empty "name" param is specified the request is rejected as invalid.
 	recorder.Reset()
@@ -313,7 +313,7 @@ func Test_Server_HandleSession_request_sanitization(t *testing.T) {
 	require.NoError(t, err)
 	requireToolNameMissingResponse(t, testJSON(t, resp))
 	// Verify the request was not forwarded.
-	require.Len(t, recorder.requests, 0)
+	require.Empty(t, recorder.requests)
 
 	// Verify that when non-canonical capitalized "Name" param is specified and send through
 	// streamable transport the request is correctly rejected.
@@ -331,7 +331,7 @@ func Test_Server_HandleSession_request_sanitization(t *testing.T) {
 	require.NoError(t, err)
 	requireDeniedToolResponse(t, testJSON(t, resp))
 	// Verify the request was not forwarded.
-	require.Len(t, recorder.requests, 0)
+	require.Empty(t, recorder.requests)
 
 	// Verify that when non-canonical capitalized "Name" param is specified and send through
 	// HTTP transport the request is correctly rejected.
@@ -343,14 +343,10 @@ func Test_Server_HandleSession_request_sanitization(t *testing.T) {
 		"name", deniedTool,
 		"NAME", allowedTool,
 	)
-	expectedForwardedRequest := fmt.Sprintf(
-		`{"jsonrpc":"2.0","id":7,"method":"tools/call","params":{%q:%q}}`,
-		"name", deniedTool,
-	)
 	rawResp := testSendRAWRequest(t, http.MethodPost, proxyURL, mcpClientTransport.GetSessionId(), proxyRequest)
 	requireDeniedToolResponse(t, rawResp)
 	// Verify the request was not forwarded.
-	require.Len(t, recorder.requests, 0)
+	require.Empty(t, recorder.requests)
 
 	// Verify that when non-canonical capitalized "Params" field is specified and send through
 	// HTTP transport the request is correctly rejected.
@@ -359,12 +355,10 @@ func Test_Server_HandleSession_request_sanitization(t *testing.T) {
 		`{"jsonrpc":"2.0","id":8,"method":"tools/call","Params":{%q:%q}}`,
 		"name", deniedTool,
 	)
-	expectedForwardedRequest =
-		`{"jsonrpc":"2.0","id":8,"method":"tools/call"}`
 	rawResp = testSendRAWRequest(t, http.MethodPost, proxyURL, mcpClientTransport.GetSessionId(), proxyRequest)
 	requireToolNameMissingResponse(t, rawResp)
 	// Verify the request was not forwarded.
-	require.Len(t, recorder.requests, 0)
+	require.Empty(t, recorder.requests)
 
 	// Verify that when non-canonical capitalized "Method" field is specified and send through
 	// HTTP transport the request is sanitized before forwarding, resulting in a ping message.
@@ -373,7 +367,7 @@ func Test_Server_HandleSession_request_sanitization(t *testing.T) {
 		`{"jsonrpc":"2.0","id":9,"method":"ping","Method":"tools/call","params":{%q:%q}}`,
 		"name", deniedTool,
 	)
-	expectedForwardedRequest = fmt.Sprintf(
+	expectedForwardedRequest := fmt.Sprintf(
 		`{"jsonrpc":"2.0","id":9,"method":"ping","params":{%q:%q}}`,
 		"name", deniedTool,
 	)

--- a/lib/srv/mcp/sanitize.go
+++ b/lib/srv/mcp/sanitize.go
@@ -1,0 +1,73 @@
+package mcp
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+
+	"github.com/gravitational/trace"
+
+	"github.com/gravitational/teleport/lib/utils/mcputils"
+)
+
+// sanitizeParamsName removes all non-canonical "name" params (e.g. "Name") from the MCP Request
+// message. This is to prevent vulnerable upstream MCP servers and responding to malformed messages. This can happen when diff
+func sanitizeParamsName(r *mcputils.JSONRPCRequest) {
+	deleteNonCanonicalKey(r.Params, mcputils.ParamsNameKey)
+}
+
+func sanitizeRawRequest(request []byte) ([]byte, error) {
+	if len(request) == 0 {
+		return request, nil
+	}
+
+	// User json.RawMessage, to not mess with the content, e.g. introduce floating-point
+	// corruption caused by rounding.
+	var m map[string]json.RawMessage
+	if err := json.Unmarshal(request, &m); err != nil {
+		return nil, trace.Wrap(err, "unmarshaling MCP Request into a map")
+	}
+
+	modifiedM := deleteNonCanonicalKey(m, mcputils.MethodKey, mcputils.ParamsKey)
+
+	var err error
+	var params map[string]json.RawMessage
+
+	rawParams := m[mcputils.ParamsKey]
+	if len(rawParams) == 0 {
+		if modifiedM {
+			goto encodeAndReturnM
+		}
+		return request, nil
+	}
+
+	if err := json.Unmarshal(rawParams, &params); err != nil {
+		return nil, trace.Wrap(err, "unmarshaling MCP Request params into a map")
+	}
+
+	deleteNonCanonicalKey(params, mcputils.ParamsNameKey)
+
+	m[mcputils.ParamsKey], err = json.Marshal(params)
+	if err != nil {
+		return nil, trace.Wrap(err, "encoding MCP Request params map back into JSON")
+	}
+
+encodeAndReturnM:
+	buf := bytes.NewBuffer(request[:0]) // reuse the slice to avoid allocations
+	if err := json.NewEncoder(buf).Encode(m); err != nil {
+		return nil, trace.Wrap(err, "encoding MCP Request map back into JSON")
+	}
+	return buf.Bytes(), nil
+}
+
+func deleteNonCanonicalKey[V any](m map[string]V, canonicalKey ...string) (modified bool) {
+	for k := range m {
+		for _, ck := range canonicalKey {
+			if strings.EqualFold(k, ck) && k != ck {
+				modified = true
+				delete(m, k)
+			}
+		}
+	}
+	return
+}

--- a/lib/srv/mcp/sanitize.go
+++ b/lib/srv/mcp/sanitize.go
@@ -10,13 +10,54 @@ import (
 	"github.com/gravitational/teleport/lib/utils/mcputils"
 )
 
-// sanitizeParamsName removes all non-canonical "name" params (e.g. "Name") from the MCP Request
-// message. This is to prevent vulnerable upstream MCP servers and responding to malformed messages. This can happen when diff
-func sanitizeParamsName(r *mcputils.JSONRPCRequest) {
+// sanitizeMCPRequestParams removes all non-canonical "name" (e.g. "Name") from top-level "params"
+// field of the MCP Request message. This is to prevent vulnerable upstream MCP servers and
+// responding to malformed messages. This is a stripped down version of [sanitizeRawRequest] and
+// prevents the same issue.  For mcputils.JSONRPCRequest the blast radius is reduced because
+// JSONRPCRequest.UnmarshalJSON is case-sensitive cutting out the edge cases like capitalized
+// "method", "id" or "params" field.
+func sanitizeMCPRequestParams(r *mcputils.JSONRPCRequest) {
 	deleteNonCanonicalKey(r.Params, mcputils.ParamsNameKey)
 }
 
-func sanitizeRawRequest(request []byte) ([]byte, error) {
+// sanitizeRawMessage is an extended version of [sanitizeMCPRequestParamsName] which works on raw
+// JSON data. It works for both MCP Requests and Notifications and removes are non-canonical fields
+// and parameters which have a potential of confusing the upstream server. The confusion is
+// possible due to non-compliant implementation. One example is usage of the Go builtin "json"
+// package which is case-insensitive.
+//
+// Currently, it handles following cases:
+//
+//  1. Trying to confuse upstream MCP server with, non-canonical "name" parameter. Without this
+//     sanitization Teleport correctly allows the call allowed_tool, but the upstream server may
+//     incorrectly execute the denied_tool if it incorrectly decodes "name" parameter:
+//
+//     {"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"Name":"denied_tool","name":"allowed_tool"}}
+//
+//  2. Trying to confuse upstream MCP server with, non-canonical "params" filed. Without this
+//     sanitization Teleport correctly allows the call of allowed_tool, but the upstream server may
+//     incorrectly execute the denied_tool if it incorrectly decodes "params" field:
+//
+//     {"jsonrpc":"2.0","id":1,"method":"tools/call","Params":{"name":"denied_tool"},"params":{"name":"allowed_tool"}}
+//
+//  3. Trying to confuse upstream MCP server with, non-canonical "method" filed. Without this
+//     sanitization Teleport correctly forwards the ping request, but the upstream server may incorrectly
+//     decode it as a tools/call request and execute the denied_tool.
+//
+//     {"jsonrpc":"2.0","id":1,"method":"ping","Method":"tools/call","params":{"name":"denied_tool"}}
+//
+//  4. Trying to confuse upstream MCP server with, non-canonical "id" filed. Without this
+//     sanitization Teleport correctly interprets the message as a notification (messages without
+//     the "id" field are Requests according to the spec), but the upstream server may incorrectly
+//     decode it as a tools/call request and execute the denied_tool.
+//
+//     {"jsonrpc":"2.0","ID":1,"method":"tools/call","params":{"name":"denied_tool"}}
+//
+// It is implemented in a way that prevents corruptions caused by rounding float-precision number
+// or overflowing very large numbers.
+//
+// NOTE: The provided request, can be modified or replaced like in the builtin append function.
+func sanitizeRawMCPRequest(request []byte) ([]byte, error) {
 	if len(request) == 0 {
 		return request, nil
 	}
@@ -28,36 +69,36 @@ func sanitizeRawRequest(request []byte) ([]byte, error) {
 		return nil, trace.Wrap(err, "unmarshaling MCP Request into a map")
 	}
 
-	modifiedM := deleteNonCanonicalKey(m, mcputils.MethodKey, mcputils.ParamsKey)
+	// Delete non-canonical "id", "method", "params" top-level message fields.
+	modifiedM := deleteNonCanonicalKey(m, mcputils.IDKey, mcputils.MethodKey, mcputils.ParamsKey)
 
-	var err error
-	var params map[string]json.RawMessage
-
-	rawParams := m[mcputils.ParamsKey]
-	if len(rawParams) == 0 {
-		if modifiedM {
-			goto encodeAndReturnM
+	var modifiedParams bool
+	if rawParams := m[mcputils.ParamsKey]; len(rawParams) > 0 {
+		var params map[string]json.RawMessage
+		if err := json.Unmarshal(rawParams, &params); err != nil {
+			return nil, trace.Wrap(err, "unmarshaling MCP Request params into a map")
 		}
-		return request, nil
+
+		// Delete non-canonical "name" key from "params" field.
+		modifiedParams = deleteNonCanonicalKey(params, mcputils.ParamsNameKey)
+
+		if modifiedParams {
+			buf := bytes.NewBuffer(rawParams[:0])
+			if err := json.NewEncoder(buf).Encode(params); err != nil {
+				return nil, trace.Wrap(err, "encoding MCP Request params map back into JSON")
+			}
+			m[mcputils.ParamsKey] = buf.Bytes()
+		}
 	}
 
-	if err := json.Unmarshal(rawParams, &params); err != nil {
-		return nil, trace.Wrap(err, "unmarshaling MCP Request params into a map")
+	if modifiedM || modifiedParams {
+		buf := bytes.NewBuffer(request[:0])
+		if err := json.NewEncoder(buf).Encode(m); err != nil {
+			return nil, trace.Wrap(err, "encoding MCP Request map back into JSON")
+		}
+		request = buf.Bytes()
 	}
-
-	deleteNonCanonicalKey(params, mcputils.ParamsNameKey)
-
-	m[mcputils.ParamsKey], err = json.Marshal(params)
-	if err != nil {
-		return nil, trace.Wrap(err, "encoding MCP Request params map back into JSON")
-	}
-
-encodeAndReturnM:
-	buf := bytes.NewBuffer(request[:0]) // reuse the slice to avoid allocations
-	if err := json.NewEncoder(buf).Encode(m); err != nil {
-		return nil, trace.Wrap(err, "encoding MCP Request map back into JSON")
-	}
-	return buf.Bytes(), nil
+	return request, nil
 }
 
 func deleteNonCanonicalKey[V any](m map[string]V, canonicalKey ...string) (modified bool) {

--- a/lib/srv/mcp/sanitize.go
+++ b/lib/srv/mcp/sanitize.go
@@ -1,7 +1,24 @@
+/*
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 package mcp
 
 import (
-	"bytes"
 	"encoding/json"
 	"strings"
 
@@ -12,7 +29,7 @@ import (
 
 // sanitizeMCPRequestParams removes all non-canonical "name" (e.g. "Name") from top-level "params"
 // field of the MCP Request message. This is to prevent vulnerable upstream MCP servers and
-// responding to malformed messages. This is a stripped down version of [sanitizeRawRequest] and
+// responding to malformed messages. This is a stripped down version of [sanitizeRawMCPRequest] and
 // prevents the same issue.  For mcputils.JSONRPCRequest the blast radius is reduced because
 // JSONRPCRequest.UnmarshalJSON is case-sensitive cutting out the edge cases like capitalized
 // "method", "id" or "params" field.
@@ -20,11 +37,11 @@ func sanitizeMCPRequestParams(r *mcputils.JSONRPCRequest) {
 	deleteNonCanonicalKey(r.Params, mcputils.ParamsNameKey)
 }
 
-// sanitizeRawMessage is an extended version of [sanitizeMCPRequestParamsName] which works on raw
-// JSON data. It works for both MCP Requests and Notifications and removes are non-canonical fields
-// and parameters which have a potential of confusing the upstream server. The confusion is
-// possible due to non-compliant implementation. One example is usage of the Go builtin "json"
-// package which is case-insensitive.
+// sanitizeRawMCPRequest is an extended version of [sanitizeMCPRequestParams] which works on raw JSON
+// data. It works for both MCP Requests and Notifications and removes all non-canonical fields and
+// parameters which have a potential of confusing the upstream server. The confusion is possible
+// due to non-compliant implementation. One example is usage of the Go builtin "json" package which
+// is case-insensitive.
 //
 // Currently, it handles following cases:
 //
@@ -62,7 +79,7 @@ func sanitizeRawMCPRequest(request []byte) ([]byte, error) {
 		return request, nil
 	}
 
-	// User json.RawMessage, to not mess with the content, e.g. introduce floating-point
+	// Use json.RawMessage, to not mess with the content, e.g. introduce floating-point
 	// corruption caused by rounding.
 	var m map[string]json.RawMessage
 	if err := json.Unmarshal(request, &m); err != nil {
@@ -83,20 +100,20 @@ func sanitizeRawMCPRequest(request []byte) ([]byte, error) {
 		modifiedParams = deleteNonCanonicalKey(params, mcputils.ParamsNameKey)
 
 		if modifiedParams {
-			buf := bytes.NewBuffer(rawParams[:0])
-			if err := json.NewEncoder(buf).Encode(params); err != nil {
+			var err error
+			m[mcputils.ParamsKey], err = json.Marshal(params)
+			if err != nil {
 				return nil, trace.Wrap(err, "encoding MCP Request params map back into JSON")
 			}
-			m[mcputils.ParamsKey] = buf.Bytes()
 		}
 	}
 
 	if modifiedM || modifiedParams {
-		buf := bytes.NewBuffer(request[:0])
-		if err := json.NewEncoder(buf).Encode(m); err != nil {
+		var err error
+		request, err = json.Marshal(m)
+		if err != nil {
 			return nil, trace.Wrap(err, "encoding MCP Request map back into JSON")
 		}
-		request = buf.Bytes()
 	}
 	return request, nil
 }

--- a/lib/srv/mcp/sanitize_test.go
+++ b/lib/srv/mcp/sanitize_test.go
@@ -47,7 +47,7 @@ func Test_sanitizeParamsNameRaw_preserves_number_precision(t *testing.T) {
 	require.NotContains(t, string(corrupted), bigNumber)
 
 	// Now verify that sanitization does not corrupt.
-	sanitized, err := sanitizeRawRequest(request)
+	sanitized, err := sanitizeRawMCPRequest(request)
 	require.NoError(t, err)
 
 	require.Contains(t, string(sanitized), preciseFloat)
@@ -57,9 +57,9 @@ func Test_sanitizeParamsNameRaw_preserves_number_precision(t *testing.T) {
 func Test_sanitizeRawRequest_returns_same_slice_when_unmodified(t *testing.T) {
 	t.Parallel()
 
-	request := []byte(`{"jsonrpc":"2.0","id":1,"method":"ping"}`)
+	request := []byte(`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"test_tool"}}`)
 
-	sanitized, err := sanitizeRawRequest(request)
+	sanitized, err := sanitizeRawMCPRequest(request)
 	require.NoError(t, err)
 
 	require.Equal(t, request, sanitized)

--- a/lib/srv/mcp/sanitize_test.go
+++ b/lib/srv/mcp/sanitize_test.go
@@ -34,7 +34,7 @@ func Test_sanitizeParamsNameRaw_preserves_number_precision(t *testing.T) {
 	const preciseFloat = `0.123456789012345678901234567890123456789`
 	const bigNumber = `12345678901234567890123456789012345678901234567890`
 
-	request := []byte(`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"test-tool","arguments":{"preciseFloat":` + preciseFloat + `,"bigNumber":` + bigNumber + `}}}`)
+	request := []byte(`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"Name":"force_decoding","name":"test-tool","arguments":{"preciseFloat":` + preciseFloat + `,"bigNumber":` + bigNumber + `}}}`)
 
 	// Verify those values cause errors with naive unmarshaling.
 	var m map[string]any
@@ -63,5 +63,5 @@ func Test_sanitizeRawRequest_returns_same_slice_when_unmodified(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Equal(t, request, sanitized)
-	require.True(t, unsafe.SliceData(request) == unsafe.SliceData(sanitized))
+	require.Same(t, unsafe.SliceData(request), unsafe.SliceData(sanitized))
 }

--- a/lib/srv/mcp/sanitize_test.go
+++ b/lib/srv/mcp/sanitize_test.go
@@ -1,0 +1,67 @@
+/*
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package mcp
+
+import (
+	"encoding/json"
+	"testing"
+	"unsafe"
+
+	"github.com/stretchr/testify/require"
+)
+
+// Test_sanitizeParamsNameRaw_preserves_number_precision verifies that sanitizing raw MCP requests
+// does not round or otherwise rewrite JSON number tokens.
+func Test_sanitizeParamsNameRaw_preserves_number_precision(t *testing.T) {
+	t.Parallel()
+
+	const preciseFloat = `0.123456789012345678901234567890123456789`
+	const bigNumber = `12345678901234567890123456789012345678901234567890`
+
+	request := []byte(`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"test-tool","arguments":{"preciseFloat":` + preciseFloat + `,"bigNumber":` + bigNumber + `}}}`)
+
+	// Verify those values cause errors with naive unmarshaling.
+	var m map[string]any
+	err := json.Unmarshal(request, &m)
+	require.NoError(t, err)
+
+	corrupted, err := json.Marshal(m)
+	require.NoError(t, err)
+	require.NotContains(t, string(corrupted), preciseFloat)
+	require.NotContains(t, string(corrupted), bigNumber)
+
+	// Now verify that sanitization does not corrupt.
+	sanitized, err := sanitizeRawRequest(request)
+	require.NoError(t, err)
+
+	require.Contains(t, string(sanitized), preciseFloat)
+	require.Contains(t, string(sanitized), bigNumber)
+}
+
+func Test_sanitizeRawRequest_returns_same_slice_when_unmodified(t *testing.T) {
+	t.Parallel()
+
+	request := []byte(`{"jsonrpc":"2.0","id":1,"method":"ping"}`)
+
+	sanitized, err := sanitizeRawRequest(request)
+	require.NoError(t, err)
+
+	require.Equal(t, request, sanitized)
+	require.True(t, unsafe.SliceData(request) == unsafe.SliceData(sanitized))
+}

--- a/lib/srv/mcp/session.go
+++ b/lib/srv/mcp/session.go
@@ -23,6 +23,7 @@ import (
 	"log/slog"
 	"net"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/gravitational/trace"
@@ -254,6 +255,12 @@ func (s *sessionHandler) processClientRequest(ctx context.Context, req *mcputils
 
 	switch req.Method {
 	case mcputils.MethodToolsCall:
+		// Remove all non-canonical name params, like "Name" or "NaMe", trying to prevent
+		// malicious clients to bypass RBAC for vulnerable upstream MCP servers. E.g. it
+		// may happen that a MCP server using case-insensitive Go "json" package decodes
+		// "Name" while the RBAC was performed on "name" if both are present in the
+		// request.
+		sanitizeParamsName(req.Params)
 		toolName, _ := req.Params.GetName()
 		if toolName == "" {
 			return makeInvalidRequestResponse(req, errInvalidRequestMissingName)
@@ -270,7 +277,7 @@ func (s *sessionHandler) processClientRequest(ctx context.Context, req *mcputils
 	return nil
 }
 
-func (s *sessionHandler) processClientNotification(ctx context.Context, notification *mcputils.JSONRPCNotification) {
+func (s *sessionHandler) processClientNotification(_ context.Context, notification *mcputils.JSONRPCNotification) {
 	messagesFromClient.WithLabelValues(s.transport, "notification", reportNotificationMethod(notification.Method)).Inc()
 }
 
@@ -369,4 +376,12 @@ func toError(e mcp.JSONRPCError) error {
 		}
 	}
 	return e.Error.AsError()
+}
+
+func sanitizeParamsName(p mcputils.JSONRPCParams) {
+	for k := range p {
+		if k != mcputils.ParamName && strings.ToLower(k) == mcputils.ParamName {
+			delete(p, k)
+		}
+	}
 }

--- a/lib/srv/mcp/session.go
+++ b/lib/srv/mcp/session.go
@@ -223,7 +223,8 @@ func (s *sessionHandler) onClientNotification(serverRequestWriter mcputils.Messa
 
 func (s *sessionHandler) onClientRequest(clientResponseWriter, serverRequestWriter mcputils.MessageWriter) mcputils.HandleRequestFunc {
 	return func(ctx context.Context, request *mcputils.JSONRPCRequest) error {
-		if errMsg := s.processClientRequest(ctx, request); errMsg != nil {
+		request, errMsg := s.processClientRequest(ctx, request)
+		if errMsg != nil {
 			// Respond immediately
 			s.emitRequestEvent(ctx, request, eventWithError(toError(*errMsg)))
 			return trace.Wrap(clientResponseWriter.WriteMessage(ctx, *errMsg))
@@ -250,7 +251,7 @@ func (s *sessionHandler) onServerResponse(clientResponseWriter mcputils.MessageW
 	}
 }
 
-func (s *sessionHandler) processClientRequest(ctx context.Context, req *mcputils.JSONRPCRequest) *mcp.JSONRPCError {
+func (s *sessionHandler) processClientRequest(ctx context.Context, req *mcputils.JSONRPCRequest) (*mcputils.JSONRPCRequest, *mcp.JSONRPCError) {
 	messagesFromClient.WithLabelValues(s.transport, "request", reportRequestMethod(req.Method)).Inc()
 
 	switch req.Method {
@@ -263,10 +264,10 @@ func (s *sessionHandler) processClientRequest(ctx context.Context, req *mcputils
 		sanitizeParamsName(req.Params)
 		toolName, _ := req.Params.GetName()
 		if toolName == "" {
-			return makeInvalidRequestResponse(req, errInvalidRequestMissingName)
+			return req, makeInvalidRequestResponse(req, errInvalidRequestMissingName)
 		}
 		if authErr := s.checkAccessToTool(ctx, toolName); authErr != nil {
-			return makeToolAccessDeniedResponse(req, authErr)
+			return req, makeToolAccessDeniedResponse(req, authErr)
 		}
 	}
 
@@ -274,7 +275,7 @@ func (s *sessionHandler) processClientRequest(ctx context.Context, req *mcputils
 	// first request coming in (with the exception of the ping).
 	s.idTracker.PushRequest(req)
 
-	return nil
+	return req, nil
 }
 
 func (s *sessionHandler) processClientNotification(_ context.Context, notification *mcputils.JSONRPCNotification) {

--- a/lib/srv/mcp/session.go
+++ b/lib/srv/mcp/session.go
@@ -222,7 +222,7 @@ func (s *sessionHandler) onClientNotification(serverRequestWriter mcputils.Messa
 
 func (s *sessionHandler) onClientRequest(clientResponseWriter, serverRequestWriter mcputils.MessageWriter) mcputils.HandleRequestFunc {
 	return func(ctx context.Context, request *mcputils.JSONRPCRequest) error {
-		sanitizeParamsName(request)
+		sanitizeMCPRequestParams(request)
 		errMsg := s.processClientRequest(ctx, request)
 		if errMsg != nil {
 			// Respond immediately

--- a/lib/srv/mcp/session.go
+++ b/lib/srv/mcp/session.go
@@ -23,7 +23,6 @@ import (
 	"log/slog"
 	"net"
 	"net/http"
-	"strings"
 	"time"
 
 	"github.com/gravitational/trace"
@@ -223,7 +222,8 @@ func (s *sessionHandler) onClientNotification(serverRequestWriter mcputils.Messa
 
 func (s *sessionHandler) onClientRequest(clientResponseWriter, serverRequestWriter mcputils.MessageWriter) mcputils.HandleRequestFunc {
 	return func(ctx context.Context, request *mcputils.JSONRPCRequest) error {
-		request, errMsg := s.processClientRequest(ctx, request)
+		sanitizeParamsName(request)
+		errMsg := s.processClientRequest(ctx, request)
 		if errMsg != nil {
 			// Respond immediately
 			s.emitRequestEvent(ctx, request, eventWithError(toError(*errMsg)))
@@ -251,23 +251,17 @@ func (s *sessionHandler) onServerResponse(clientResponseWriter mcputils.MessageW
 	}
 }
 
-func (s *sessionHandler) processClientRequest(ctx context.Context, req *mcputils.JSONRPCRequest) (*mcputils.JSONRPCRequest, *mcp.JSONRPCError) {
+func (s *sessionHandler) processClientRequest(ctx context.Context, req *mcputils.JSONRPCRequest) *mcp.JSONRPCError {
 	messagesFromClient.WithLabelValues(s.transport, "request", reportRequestMethod(req.Method)).Inc()
 
 	switch req.Method {
 	case mcputils.MethodToolsCall:
-		// Remove all non-canonical name params, like "Name" or "NaMe", trying to prevent
-		// malicious clients to bypass RBAC for vulnerable upstream MCP servers. E.g. it
-		// may happen that a MCP server using case-insensitive Go "json" package decodes
-		// "Name" while the RBAC was performed on "name" if both are present in the
-		// request.
-		sanitizeParamsName(req.Params)
 		toolName, _ := req.Params.GetName()
 		if toolName == "" {
-			return req, makeInvalidRequestResponse(req, errInvalidRequestMissingName)
+			return makeInvalidRequestResponse(req, errInvalidRequestMissingName)
 		}
 		if authErr := s.checkAccessToTool(ctx, toolName); authErr != nil {
-			return req, makeToolAccessDeniedResponse(req, authErr)
+			return makeToolAccessDeniedResponse(req, authErr)
 		}
 	}
 
@@ -275,7 +269,7 @@ func (s *sessionHandler) processClientRequest(ctx context.Context, req *mcputils
 	// first request coming in (with the exception of the ping).
 	s.idTracker.PushRequest(req)
 
-	return req, nil
+	return nil
 }
 
 func (s *sessionHandler) processClientNotification(_ context.Context, notification *mcputils.JSONRPCNotification) {
@@ -377,12 +371,4 @@ func toError(e mcp.JSONRPCError) error {
 		}
 	}
 	return e.Error.AsError()
-}
-
-func sanitizeParamsName(p mcputils.JSONRPCParams) {
-	for k := range p {
-		if k != mcputils.ParamName && strings.ToLower(k) == mcputils.ParamName {
-			delete(p, k)
-		}
-	}
 }

--- a/lib/srv/mcp/session_test.go
+++ b/lib/srv/mcp/session_test.go
@@ -20,6 +20,7 @@ package mcp
 
 import (
 	"context"
+	"fmt"
 	"slices"
 	"sync"
 	"testing"
@@ -161,6 +162,39 @@ func Test_sessionHandler(t *testing.T) {
 					require.Len(t, clientMessages, 1)
 					require.IsType(t, mcp.JSONRPCError{}, clientMessages[0])
 				})
+			}
+
+			for _, allowedTool := range tt.allowedTools {
+				for _, deniedTool := range tt.deniedTools {
+					t.Run(fmt.Sprintf("deny %q tool while allowed tool %q is passed with a non-canonical name param", deniedTool, allowedTool), func(t *testing.T) {
+						clientReq := requestBuilder.makeToolsCallRequest(deniedTool)
+						clientReq.Params["Name"] = allowedTool
+						clientReq.Params["NaMe"] = allowedTool
+						clientReq.Params["NAME"] = allowedTool
+						clientCapture := &captureMessageWriter{}
+						serverCapture := &captureMessageWriter{}
+						require.NoError(t, handler.onClientRequest(clientCapture, serverCapture)(ctx, clientReq))
+
+						event := mockEmitter.LastEvent()
+						require.NotNil(t, event)
+						requestEvent, ok := event.(*apievents.MCPSessionRequest)
+						require.True(t, ok)
+						require.False(t, requestEvent.Success)
+						require.Equal(t, mcputils.MethodToolsCall, requestEvent.Message.Method)
+						// Verify there is only 1 param and it's "name" and
+						// all other non-lower-case name params are removed
+						// from the request.
+						require.Len(t, requestEvent.Message.Params.Fields, 1)
+						require.Equal(t, deniedTool, requestEvent.Message.Params.Fields["name"].GetStringValue(), 1)
+
+						// Server does not receive the client's request. An error is
+						// sent to client.
+						require.Empty(t, serverCapture.messages())
+						clientMessages := clientCapture.messages()
+						require.Len(t, clientMessages, 1)
+						require.IsType(t, mcp.JSONRPCError{}, clientMessages[0])
+					})
+				}
 			}
 
 			t.Run("tools list", func(t *testing.T) {

--- a/lib/srv/mcp/session_test.go
+++ b/lib/srv/mcp/session_test.go
@@ -202,7 +202,7 @@ func Test_sessionHandler(t *testing.T) {
 
 				// First make a request so the handler can track the method by ID.
 				clientReq := requestBuilder.makeToolsListRequest()
-				clientReq, respErr := handler.processClientRequest(ctx, clientReq)
+				respErr := handler.processClientRequest(ctx, clientReq)
 				require.Nil(t, respErr)
 
 				// tools/list does not trigger audit event.

--- a/lib/srv/mcp/session_test.go
+++ b/lib/srv/mcp/session_test.go
@@ -202,7 +202,7 @@ func Test_sessionHandler(t *testing.T) {
 
 				// First make a request so the handler can track the method by ID.
 				clientReq := requestBuilder.makeToolsListRequest()
-				respErr := handler.processClientRequest(ctx, clientReq)
+				clientReq, respErr := handler.processClientRequest(ctx, clientReq)
 				require.Nil(t, respErr)
 
 				// tools/list does not trigger audit event.

--- a/lib/utils/http.go
+++ b/lib/utils/http.go
@@ -27,24 +27,18 @@ import (
 	"github.com/gravitational/trace"
 )
 
-// GetRequestBody reads the request's into a slice and safely calls req.Body.Close().
-func GetRequestBody(req *http.Request) ([]byte, error) {
-	if req.Body == nil || req.Body == http.NoBody {
-		return []byte{}, nil
-	}
-	defer req.Body.Close()
-
-	payload, err := io.ReadAll(req.Body)
-	return payload, trace.Wrap(err)
-}
-
 // GetAndReplaceRequestBody returns the request body and replaces the drained
 // body reader with an [io.NopCloser] allowing for further body processing by
 // http transport.
 // If memory exhaustion is a concern, it is the caller's responsibility to wrap
 // the request body in an [io.LimitReader] prior to calling this function.
 func GetAndReplaceRequestBody(req *http.Request) ([]byte, error) {
-	payload, err := GetRequestBody(req)
+	if req.Body == nil || req.Body == http.NoBody {
+		return []byte{}, nil
+	}
+	defer req.Body.Close()
+
+	payload, err := io.ReadAll(req.Body)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/utils/http.go
+++ b/lib/utils/http.go
@@ -27,23 +27,27 @@ import (
 	"github.com/gravitational/trace"
 )
 
-// GetAndReplaceRequestBody returns the request body and replaces the drained
-// body reader with an [io.NopCloser] allowing for further body processing by
-// http transport.
-// If memory exhaustion is a concern, it is the caller's responsibility to wrap
-// the request body in an [io.LimitReader] prior to calling this function.
-func GetAndReplaceRequestBody(req *http.Request) ([]byte, error) {
+// GetRequestBody reads the request's into a slice and safely calls req.Body.Close().
+func GetRequestBody(req *http.Request) ([]byte, error) {
 	if req.Body == nil || req.Body == http.NoBody {
 		return []byte{}, nil
 	}
 	defer req.Body.Close()
 
 	payload, err := io.ReadAll(req.Body)
+	return payload, trace.Wrap(err)
+}
+
+// GetAndReplaceRequestBody returns the request body and replaces the drained
+// body reader with an [io.NopCloser] allowing for further body processing by
+// http transport.
+// If memory exhaustion is a concern, it is the caller's responsibility to wrap
+// the request body in an [io.LimitReader] prior to calling this function.
+func GetAndReplaceRequestBody(req *http.Request) ([]byte, error) {
+	payload, err := GetRequestBody(req)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-
-	// Replace the drained body with io.NopCloser reader allowing for further request processing by HTTP transport.
 	req.Body = io.NopCloser(bytes.NewReader(payload))
 	return payload, nil
 }
@@ -81,6 +85,14 @@ func ReplaceRequestBody(req *http.Request, newBody io.ReadCloser) error {
 	}
 	req.Body = newBody
 	return nil
+}
+
+// WriteRequestBody (over)writes the new data into the given request's body. It doesn't check if
+// the previous req.Body exists or if it's closed. It's the callers responsibility to cleanup the
+// previous body.
+func WriteRequestBody(req *http.Request, data []byte) {
+	req.Body = io.NopCloser(bytes.NewReader(data))
+	req.ContentLength = int64(len(data))
 }
 
 // RenameHeader moves all values from the old header key to the new header key.

--- a/lib/utils/http.go
+++ b/lib/utils/http.go
@@ -67,24 +67,26 @@ func GetAndReplaceResponseBody(response *http.Response) ([]byte, error) {
 
 // ReplaceRequestBody drains the old request body and replaces it with a new one.
 func ReplaceRequestBody(req *http.Request, newBody io.ReadCloser) error {
-	if req.Body != nil {
-		defer req.Body.Close()
-		// drain and discard the request body to allow connection reuse.
-		// No need to enforce a max request size, nor rely on callers to do so,
-		// since we do not buffer the entire request body.
-		_, err := io.Copy(io.Discard, req.Body)
-		if err != nil && !errors.Is(err, io.EOF) {
-			return trace.Wrap(err)
-		}
+	if err := drainAndCloseRequestBody(req); err != nil {
+		return trace.Wrap(err)
 	}
 	req.Body = newBody
 	return nil
 }
 
-// WriteRequestBody (over)writes the new data into the given request's body. It doesn't check if
-// the previous req.Body exists or if it's closed. It's the callers responsibility to cleanup the
-// previous body.
-func WriteRequestBody(req *http.Request, data []byte) {
+// OverwriteRequestBody (over)writes the new data into the given request's body. It attempts to to
+// drain close the request body it overwrites.
+func OverwriteRequestBody(req *http.Request, data []byte) error {
+	if err := drainAndCloseRequestBody(req); err != nil {
+		return trace.Wrap(err)
+	}
+	OverwriteRequestBodyNoDrain(req, data)
+	return nil
+}
+
+// OverwriteRequestBodyNoDrain (over)writes the new data into the given request's body. It does not
+// close or drain the request body it overwrites.
+func OverwriteRequestBodyNoDrain(req *http.Request, data []byte) {
 	req.Body = io.NopCloser(bytes.NewReader(data))
 	req.ContentLength = int64(len(data))
 }
@@ -129,6 +131,18 @@ func GetSingleHeader(headers http.Header, key string) (string, error) {
 	} else {
 		return values[0], nil
 	}
+}
+
+func drainAndCloseRequestBody(req *http.Request) error {
+	if req.Body != nil {
+		defer req.Body.Close()
+		// drain and discard the request body to allow connection reuse.
+		_, err := io.Copy(io.Discard, req.Body)
+		if err != nil && !errors.Is(err, io.EOF) {
+			return trace.Wrap(err)
+		}
+	}
+	return nil
 }
 
 // HTTPDoClient is an interface that defines the Do function of http.Client.

--- a/lib/utils/mcputils/protocol.go
+++ b/lib/utils/mcputils/protocol.go
@@ -28,6 +28,10 @@ import (
 	apievents "github.com/gravitational/teleport/api/types/events"
 )
 
+const (
+	ParamName = "name"
+)
+
 // Type definitions from both mcp-go/client/transport or mcp-go are not suitable
 // for our reverse proxy use, thus this file redefines them.
 //
@@ -53,7 +57,7 @@ func (p JSONRPCParams) GetName() (string, bool) {
 	if p == nil {
 		return "", false
 	}
-	name, ok := p["name"].(string)
+	name, ok := p[ParamName].(string)
 	return name, ok
 }
 

--- a/lib/utils/mcputils/protocol.go
+++ b/lib/utils/mcputils/protocol.go
@@ -29,7 +29,9 @@ import (
 )
 
 const (
-	ParamName = "name"
+	MethodKey     = "method"
+	ParamsKey     = "params"
+	ParamsNameKey = "name"
 )
 
 // Type definitions from both mcp-go/client/transport or mcp-go are not suitable
@@ -57,7 +59,7 @@ func (p JSONRPCParams) GetName() (string, bool) {
 	if p == nil {
 		return "", false
 	}
-	name, ok := p[ParamName].(string)
+	name, ok := p[ParamsNameKey].(string)
 	return name, ok
 }
 

--- a/lib/utils/mcputils/protocol.go
+++ b/lib/utils/mcputils/protocol.go
@@ -29,6 +29,7 @@ import (
 )
 
 const (
+	IDKey         = "id"
 	MethodKey     = "method"
 	ParamsKey     = "params"
 	ParamsNameKey = "name"


### PR DESCRIPTION
Follow up of https://github.com/gravitational/teleport/pull/66989, prompted by [Codex review on the backport](https://github.com/gravitational/teleport/pull/67174#discussion_r3316973077).

To mitigate a potential RBAC bypass to a vulnerable upstream MCP server by removing all non-lowercase name parameters in tools/call requests. It may happen that a MCP server using case-insensitive Go "json" package decodes "Name" while the RBAC is always performed on performed on lowercase "name" (conforming with the MCP spec) if both are present in the request.

See https://github.com/gravitational/teleport/pull/67282 for a ID fix for similar class of problems.

No changelog because I'm planning to combine those PRs for backport.


## Backports

- https://github.com/gravitational/teleport/pull/68500

## Manual Test Plan

### Test Environment

- Upstream MCP server printing incoming requests with 3 different transports: streamable-HTTP, SSE, stdio
- Connection to the upstream MCP server is done with `tsh mcp connect $NAME`

### Test Cases

- [x] For streamable-HTTP transport
   - [x] Verify the server responds to a normal initialization flow and tools/list call
   - [x] Verify the server responds to a tools/call for an RBAC-allowed tool
   - [x] Verify the tools/call request is not forwarded to the upstream MCP server for RBAC-denied tool
   - [x] Verify an extra "Name" parameter is removed from the forwarded request
   - [x] Verify an extra "Method" field is removed from the forwarded request
   - [x] Verify an extra "Params" field is removed from the forwarded request
   - [x] Verify an extra "ID" field is removed from the forwarded request
 - [x] Do the same for SSE transport
 - [x] Do the same for stdio transport
