### PR TITLE
use HTTPS for vault.centos.org baseurl in centos7 buildbox

### DIFF
--- a/build.assets/Dockerfile-centos7
+++ b/build.assets/Dockerfile-centos7
@@ -32,7 +32,7 @@ EOF
 RUN cat <<EOF > /tmp/fix-yum-repo-list.sh
 #!/bin/sh
 sed -e 's/mirror.centos.org/vault.centos.org/g' \
-    -e 's/^#.*baseurl=http/baseurl=http/g' \
+    -e 's/^#.*baseurl=http/baseurl=https/g' \
     -e 's/^mirrorlist=http/#mirrorlist=http/g' \
     -i /etc/yum.repos.d/*.repo
 if [ "$(uname -m)" = 'aarch64' ]; then

--- a/build.assets/Dockerfile-centos7-assets
+++ b/build.assets/Dockerfile-centos7-assets
@@ -24,7 +24,7 @@ EOF
 RUN cat <<EOF > /tmp/fix-yum-repo-list.sh
 #!/bin/sh
 sed -e 's/mirror.centos.org/vault.centos.org/g' \
-    -e 's/^#.*baseurl=http/baseurl=http/g' \
+    -e 's/^#.*baseurl=http/baseurl=https/g' \
     -e 's/^mirrorlist=http/#mirrorlist=http/g' \
     -i /etc/yum.repos.d/*.repo
 if [ "$(uname -m)" = 'aarch64' ]; then


### PR DESCRIPTION
Fix HTTPS for vault.centos.org baseurl in CentOS 7 buildbox

When CentOS 7 went EOL in June 2024, the yum repo fixup script was
introduced to redirect package downloads from the defunct
`mirror.centos.org` to `vault.centos.org`. However, the sed expression
that uncomments the `baseurl` lines had a typo — it replaced the
commented-out URL with `baseurl=http://...` instead of
`baseurl=https://...`, meaning packages were fetched over plain HTTP.

This fix corrects the replacement to use HTTPS.

## Manual Test Plan
### Test Environment
Local Docker on macOS (darwin 24.6.0, arm64) `centos:7` image pulled from Docker Hub

### Test Cases
- [x] Verified sed script output by running against a fresh `centos:7` container — all `baseurl=` lines are uncommented and use `https://vault.centos.org/...`, all `mirrorlist=` lines are commented out
- [x] cd build.assets && make buildbox-centos7