### PR TITLE
Update ansible-like load test

### DIFF
--- a/.github/ISSUE_TEMPLATE/testplan.md
+++ b/.github/ISSUE_TEMPLATE/testplan.md
@@ -1392,7 +1392,8 @@ Where applicable nodes used should be configured as follows:
 ### Ansible-like Test
 
 Run the [ansible-like](https://github.com/gravitational/teleport/tree/4fd411add0c6fa7d4d0d19b1cf0c5c13c541498e/assets/loadtest/ansible-like)
-test against a Cloud tenant with 60k nodes dispersed geographically in multiple regions.
+test against a Cloud tenant with at least 120k nodes dispersed geographically in multiple regions. During the test, the cluster should be manually
+tested to confirm that the ansible-like load does not slow down the control plane beyond the point of usability.
 
  - [ ] DynamoDB
  - [ ] CRDB

--- a/assets/loadtest/ansible-like/proxy_templates.yaml
+++ b/assets/loadtest/ansible-like/proxy_templates.yaml
@@ -1,5 +1,5 @@
 proxy_templates:
   - template: "^(.*).CLUSTERNAME:[0-9]+$" # <nodename>.<clustername>:<port>
     query: 'contains(split(labels.NODENAME, ","), "$1")'
-    # query: 'labels.NODENAME == "$1"'
-    # search: "$1"
+    # query: 'labels.NODENAME == "foobar,foobaz,$1,barbaz"'
+    # search: "foobar,foobaz,$1,barbaz"

--- a/assets/loadtest/helm/node-agent/templates/config.yaml
+++ b/assets/loadtest/helm/node-agent/templates/config.yaml
@@ -31,7 +31,7 @@ data:
     sed -i 's!/sbin/nologin!/busybox/sh!' /etc/passwd
     cp /etc/teleport-config/teleport.yaml /etc/teleport.yaml
     nodename="$( hostname )-$REPLICA"
-    echo "    NODENAME: ${nodename}" >> /etc/teleport.yaml
+    echo "    NODENAME: foobar,foobaz,${nodename},barbaz" >> /etc/teleport.yaml
     echo "    POD: $( hostname )" >> /etc/teleport.yaml
     echo "  listen_addr: '0.0.0.0:30$REPLICA'" >> /etc/teleport.yaml
     cat /etc/teleport.yaml


### PR DESCRIPTION
This PR updates the test plan template and the node-agents helm chart to increase the node count a bit and to make it slightly harder on the auth when resolving SSH targets via proxy templates, by adding more than one field in the comma-delimited label.