### PR TITLE
[v18] Scoped Locking mode, Disconnect Expired Cert, Enhanced Session Recording, Session Recording mode support for scoped roles

### DIFF
--- a/api/gen/proto/go/teleport/scopes/access/v1/role.pb.go
+++ b/api/gen/proto/go/teleport/scopes/access/v1/role.pb.go
@@ -380,8 +380,17 @@ type ScopedRoleDefaults struct {
 	// ClientIdleTimeout sets the default idle timeout for access sessions across all protocols
 	// that do not specify their own value. Must be a valid Go duration string (e.g. "30m", "1h").
 	ClientIdleTimeout string `protobuf:"bytes,1,opt,name=client_idle_timeout,json=clientIdleTimeout,proto3" json:"client_idle_timeout,omitempty"`
-	unknownFields     protoimpl.UnknownFields
-	sizeCache         protoimpl.SizeCache
+	// SessionRecording configures the session recording strategy for all protocols that don't
+	// explicitly set their session recording mode.
+	SessionRecording *SessionRecording `protobuf:"bytes,2,opt,name=session_recording,json=sessionRecording,proto3" json:"session_recording,omitempty"`
+	// DisconnectExpiredCert defines the default behavior of all protocols when certs expire for a session.
+	// If unset, cluster wide defaults are used.
+	DisconnectExpiredCert *bool `protobuf:"varint,3,opt,name=disconnect_expired_cert,json=disconnectExpiredCert,proto3,oneof" json:"disconnect_expired_cert,omitempty"`
+	// Lock specifies the default locking mode for access sessions across all protocols that
+	// do not specify their own value. If unset, cluster wide defaults are used.
+	Lock          *Lock `protobuf:"bytes,4,opt,name=lock,proto3" json:"lock,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
 }
 
 func (x *ScopedRoleDefaults) Reset() {
@@ -416,8 +425,74 @@ func (x *ScopedRoleDefaults) GetClientIdleTimeout() string {
 	return ""
 }
 
+func (x *ScopedRoleDefaults) GetSessionRecording() *SessionRecording {
+	if x != nil {
+		return x.SessionRecording
+	}
+	return nil
+}
+
+func (x *ScopedRoleDefaults) GetDisconnectExpiredCert() bool {
+	if x != nil && x.DisconnectExpiredCert != nil {
+		return *x.DisconnectExpiredCert
+	}
+	return false
+}
+
+func (x *ScopedRoleDefaults) GetLock() *Lock {
+	if x != nil {
+		return x.Lock
+	}
+	return nil
+}
+
 func (x *ScopedRoleDefaults) SetClientIdleTimeout(v string) {
 	x.ClientIdleTimeout = v
+}
+
+func (x *ScopedRoleDefaults) SetSessionRecording(v *SessionRecording) {
+	x.SessionRecording = v
+}
+
+func (x *ScopedRoleDefaults) SetDisconnectExpiredCert(v bool) {
+	x.DisconnectExpiredCert = &v
+}
+
+func (x *ScopedRoleDefaults) SetLock(v *Lock) {
+	x.Lock = v
+}
+
+func (x *ScopedRoleDefaults) HasSessionRecording() bool {
+	if x == nil {
+		return false
+	}
+	return x.SessionRecording != nil
+}
+
+func (x *ScopedRoleDefaults) HasDisconnectExpiredCert() bool {
+	if x == nil {
+		return false
+	}
+	return x.DisconnectExpiredCert != nil
+}
+
+func (x *ScopedRoleDefaults) HasLock() bool {
+	if x == nil {
+		return false
+	}
+	return x.Lock != nil
+}
+
+func (x *ScopedRoleDefaults) ClearSessionRecording() {
+	x.SessionRecording = nil
+}
+
+func (x *ScopedRoleDefaults) ClearDisconnectExpiredCert() {
+	x.DisconnectExpiredCert = nil
+}
+
+func (x *ScopedRoleDefaults) ClearLock() {
+	x.Lock = nil
 }
 
 type ScopedRoleDefaults_builder struct {
@@ -426,6 +501,15 @@ type ScopedRoleDefaults_builder struct {
 	// ClientIdleTimeout sets the default idle timeout for access sessions across all protocols
 	// that do not specify their own value. Must be a valid Go duration string (e.g. "30m", "1h").
 	ClientIdleTimeout string
+	// SessionRecording configures the session recording strategy for all protocols that don't
+	// explicitly set their session recording mode.
+	SessionRecording *SessionRecording
+	// DisconnectExpiredCert defines the default behavior of all protocols when certs expire for a session.
+	// If unset, cluster wide defaults are used.
+	DisconnectExpiredCert *bool
+	// Lock specifies the default locking mode for access sessions across all protocols that
+	// do not specify their own value. If unset, cluster wide defaults are used.
+	Lock *Lock
 }
 
 func (b0 ScopedRoleDefaults_builder) Build() *ScopedRoleDefaults {
@@ -433,6 +517,9 @@ func (b0 ScopedRoleDefaults_builder) Build() *ScopedRoleDefaults {
 	b, x := &b0, m0
 	_, _ = b, x
 	x.ClientIdleTimeout = b.ClientIdleTimeout
+	x.SessionRecording = b.SessionRecording
+	x.DisconnectExpiredCert = b.DisconnectExpiredCert
+	x.Lock = b.Lock
 	return m0
 }
 
@@ -467,7 +554,17 @@ type ScopedRoleSSH struct {
 	HostSudoers []string `protobuf:"bytes,10,rep,name=host_sudoers,json=hostSudoers,proto3" json:"host_sudoers,omitempty"`
 	// FileCopy indicates whether remote file operations via SCP or SFTP are allowed
 	// over an SSH session. It defaults to allowing the user to download and upload files by default.
-	FileCopy      *bool `protobuf:"varint,11,opt,name=file_copy,json=fileCopy,proto3,oneof" json:"file_copy,omitempty"`
+	FileCopy *bool `protobuf:"varint,11,opt,name=file_copy,json=fileCopy,proto3,oneof" json:"file_copy,omitempty"`
+	// EnhancedRecording is the set of BPF events to record for enhanced session recording.
+	EnhancedRecording *EnhancedRecording `protobuf:"bytes,12,opt,name=enhanced_recording,json=enhancedRecording,proto3" json:"enhanced_recording,omitempty"`
+	// SessionRecording configures the session recording strategy for SSH sessions.
+	SessionRecording *SessionRecording `protobuf:"bytes,13,opt,name=session_recording,json=sessionRecording,proto3" json:"session_recording,omitempty"`
+	// DisconnectExpiredCert controls whether SSH sessions are disconnected when the
+	// user certificate expires.
+	// Defaults to value cluster wide auth preference if not set.
+	DisconnectExpiredCert *bool `protobuf:"varint,14,opt,name=disconnect_expired_cert,json=disconnectExpiredCert,proto3,oneof" json:"disconnect_expired_cert,omitempty"`
+	// Lock configures the role's locking behavior for SSH sessions.
+	Lock          *Lock `protobuf:"bytes,15,opt,name=lock,proto3" json:"lock,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -567,6 +664,34 @@ func (x *ScopedRoleSSH) GetFileCopy() bool {
 	return false
 }
 
+func (x *ScopedRoleSSH) GetEnhancedRecording() *EnhancedRecording {
+	if x != nil {
+		return x.EnhancedRecording
+	}
+	return nil
+}
+
+func (x *ScopedRoleSSH) GetSessionRecording() *SessionRecording {
+	if x != nil {
+		return x.SessionRecording
+	}
+	return nil
+}
+
+func (x *ScopedRoleSSH) GetDisconnectExpiredCert() bool {
+	if x != nil && x.DisconnectExpiredCert != nil {
+		return *x.DisconnectExpiredCert
+	}
+	return false
+}
+
+func (x *ScopedRoleSSH) GetLock() *Lock {
+	if x != nil {
+		return x.Lock
+	}
+	return nil
+}
+
 func (x *ScopedRoleSSH) SetLogins(v []string) {
 	x.Logins = v
 }
@@ -605,6 +730,22 @@ func (x *ScopedRoleSSH) SetHostSudoers(v []string) {
 
 func (x *ScopedRoleSSH) SetFileCopy(v bool) {
 	x.FileCopy = &v
+}
+
+func (x *ScopedRoleSSH) SetEnhancedRecording(v *EnhancedRecording) {
+	x.EnhancedRecording = v
+}
+
+func (x *ScopedRoleSSH) SetSessionRecording(v *SessionRecording) {
+	x.SessionRecording = v
+}
+
+func (x *ScopedRoleSSH) SetDisconnectExpiredCert(v bool) {
+	x.DisconnectExpiredCert = &v
+}
+
+func (x *ScopedRoleSSH) SetLock(v *Lock) {
+	x.Lock = v
 }
 
 func (x *ScopedRoleSSH) HasPermitX11Forwarding() bool {
@@ -649,6 +790,34 @@ func (x *ScopedRoleSSH) HasFileCopy() bool {
 	return x.FileCopy != nil
 }
 
+func (x *ScopedRoleSSH) HasEnhancedRecording() bool {
+	if x == nil {
+		return false
+	}
+	return x.EnhancedRecording != nil
+}
+
+func (x *ScopedRoleSSH) HasSessionRecording() bool {
+	if x == nil {
+		return false
+	}
+	return x.SessionRecording != nil
+}
+
+func (x *ScopedRoleSSH) HasDisconnectExpiredCert() bool {
+	if x == nil {
+		return false
+	}
+	return x.DisconnectExpiredCert != nil
+}
+
+func (x *ScopedRoleSSH) HasLock() bool {
+	if x == nil {
+		return false
+	}
+	return x.Lock != nil
+}
+
 func (x *ScopedRoleSSH) ClearPermitX11Forwarding() {
 	x.PermitX11Forwarding = nil
 }
@@ -671,6 +840,22 @@ func (x *ScopedRoleSSH) ClearMaxSessions() {
 
 func (x *ScopedRoleSSH) ClearFileCopy() {
 	x.FileCopy = nil
+}
+
+func (x *ScopedRoleSSH) ClearEnhancedRecording() {
+	x.EnhancedRecording = nil
+}
+
+func (x *ScopedRoleSSH) ClearSessionRecording() {
+	x.SessionRecording = nil
+}
+
+func (x *ScopedRoleSSH) ClearDisconnectExpiredCert() {
+	x.DisconnectExpiredCert = nil
+}
+
+func (x *ScopedRoleSSH) ClearLock() {
+	x.Lock = nil
 }
 
 type ScopedRoleSSH_builder struct {
@@ -701,6 +886,16 @@ type ScopedRoleSSH_builder struct {
 	// FileCopy indicates whether remote file operations via SCP or SFTP are allowed
 	// over an SSH session. It defaults to allowing the user to download and upload files by default.
 	FileCopy *bool
+	// EnhancedRecording is the set of BPF events to record for enhanced session recording.
+	EnhancedRecording *EnhancedRecording
+	// SessionRecording configures the session recording strategy for SSH sessions.
+	SessionRecording *SessionRecording
+	// DisconnectExpiredCert controls whether SSH sessions are disconnected when the
+	// user certificate expires.
+	// Defaults to value cluster wide auth preference if not set.
+	DisconnectExpiredCert *bool
+	// Lock configures the role's locking behavior for SSH sessions.
+	Lock *Lock
 }
 
 func (b0 ScopedRoleSSH_builder) Build() *ScopedRoleSSH {
@@ -717,6 +912,10 @@ func (b0 ScopedRoleSSH_builder) Build() *ScopedRoleSSH {
 	x.MaxSessions = b.MaxSessions
 	x.HostSudoers = b.HostSudoers
 	x.FileCopy = b.FileCopy
+	x.EnhancedRecording = b.EnhancedRecording
+	x.SessionRecording = b.SessionRecording
+	x.DisconnectExpiredCert = b.DisconnectExpiredCert
+	x.Lock = b.Lock
 	return m0
 }
 
@@ -737,8 +936,12 @@ type ScopedRoleKube struct {
 	// Must be a valid Go duration string (e.g. "30m", "1h"). If empty, the defaults block value
 	// (or global default) applies.
 	ClientIdleTimeout string `protobuf:"bytes,5,opt,name=client_idle_timeout,json=clientIdleTimeout,proto3" json:"client_idle_timeout,omitempty"`
-	unknownFields     protoimpl.UnknownFields
-	sizeCache         protoimpl.SizeCache
+	// DisconnectExpiredCert controls whether Kube sessions are disconnected when the user certificate expires.
+	DisconnectExpiredCert *bool `protobuf:"varint,6,opt,name=disconnect_expired_cert,json=disconnectExpiredCert,proto3,oneof" json:"disconnect_expired_cert,omitempty"`
+	// Lock configures the role's locking behavior for kubernetes sessions.
+	Lock          *Lock `protobuf:"bytes,7,opt,name=lock,proto3" json:"lock,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
 }
 
 func (x *ScopedRoleKube) Reset() {
@@ -794,6 +997,20 @@ func (x *ScopedRoleKube) GetClientIdleTimeout() string {
 	return ""
 }
 
+func (x *ScopedRoleKube) GetDisconnectExpiredCert() bool {
+	if x != nil && x.DisconnectExpiredCert != nil {
+		return *x.DisconnectExpiredCert
+	}
+	return false
+}
+
+func (x *ScopedRoleKube) GetLock() *Lock {
+	if x != nil {
+		return x.Lock
+	}
+	return nil
+}
+
 func (x *ScopedRoleKube) SetLabels(v []*v11.Label) {
 	x.Labels = v
 }
@@ -810,6 +1027,36 @@ func (x *ScopedRoleKube) SetClientIdleTimeout(v string) {
 	x.ClientIdleTimeout = v
 }
 
+func (x *ScopedRoleKube) SetDisconnectExpiredCert(v bool) {
+	x.DisconnectExpiredCert = &v
+}
+
+func (x *ScopedRoleKube) SetLock(v *Lock) {
+	x.Lock = v
+}
+
+func (x *ScopedRoleKube) HasDisconnectExpiredCert() bool {
+	if x == nil {
+		return false
+	}
+	return x.DisconnectExpiredCert != nil
+}
+
+func (x *ScopedRoleKube) HasLock() bool {
+	if x == nil {
+		return false
+	}
+	return x.Lock != nil
+}
+
+func (x *ScopedRoleKube) ClearDisconnectExpiredCert() {
+	x.DisconnectExpiredCert = nil
+}
+
+func (x *ScopedRoleKube) ClearLock() {
+	x.Lock = nil
+}
+
 type ScopedRoleKube_builder struct {
 	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
 
@@ -823,6 +1070,10 @@ type ScopedRoleKube_builder struct {
 	// Must be a valid Go duration string (e.g. "30m", "1h"). If empty, the defaults block value
 	// (or global default) applies.
 	ClientIdleTimeout string
+	// DisconnectExpiredCert controls whether Kube sessions are disconnected when the user certificate expires.
+	DisconnectExpiredCert *bool
+	// Lock configures the role's locking behavior for kubernetes sessions.
+	Lock *Lock
 }
 
 func (b0 ScopedRoleKube_builder) Build() *ScopedRoleKube {
@@ -833,6 +1084,8 @@ func (b0 ScopedRoleKube_builder) Build() *ScopedRoleKube {
 	x.Groups = b.Groups
 	x.Users = b.Users
 	x.ClientIdleTimeout = b.ClientIdleTimeout
+	x.DisconnectExpiredCert = b.DisconnectExpiredCert
+	x.Lock = b.Lock
 	return m0
 }
 
@@ -1241,6 +1494,254 @@ func (b0 CreateHostUser_builder) Build() *CreateHostUser {
 	return m0
 }
 
+// EnhancedRecording enables what events to record for the BPF-based session recorder.
+type EnhancedRecording struct {
+	state protoimpl.MessageState `protogen:"hybrid.v1"`
+	// Command enables session.command in audit logs
+	Command *bool `protobuf:"varint,1,opt,name=command,proto3,oneof" json:"command,omitempty"`
+	// Network enables session.network in audit logs
+	Network *bool `protobuf:"varint,2,opt,name=network,proto3,oneof" json:"network,omitempty"`
+	// Disk enables session.disk in audit logs
+	Disk          *bool `protobuf:"varint,3,opt,name=disk,proto3,oneof" json:"disk,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *EnhancedRecording) Reset() {
+	*x = EnhancedRecording{}
+	mi := &file_teleport_scopes_access_v1_role_proto_msgTypes[10]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *EnhancedRecording) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*EnhancedRecording) ProtoMessage() {}
+
+func (x *EnhancedRecording) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_scopes_access_v1_role_proto_msgTypes[10]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+func (x *EnhancedRecording) GetCommand() bool {
+	if x != nil && x.Command != nil {
+		return *x.Command
+	}
+	return false
+}
+
+func (x *EnhancedRecording) GetNetwork() bool {
+	if x != nil && x.Network != nil {
+		return *x.Network
+	}
+	return false
+}
+
+func (x *EnhancedRecording) GetDisk() bool {
+	if x != nil && x.Disk != nil {
+		return *x.Disk
+	}
+	return false
+}
+
+func (x *EnhancedRecording) SetCommand(v bool) {
+	x.Command = &v
+}
+
+func (x *EnhancedRecording) SetNetwork(v bool) {
+	x.Network = &v
+}
+
+func (x *EnhancedRecording) SetDisk(v bool) {
+	x.Disk = &v
+}
+
+func (x *EnhancedRecording) HasCommand() bool {
+	if x == nil {
+		return false
+	}
+	return x.Command != nil
+}
+
+func (x *EnhancedRecording) HasNetwork() bool {
+	if x == nil {
+		return false
+	}
+	return x.Network != nil
+}
+
+func (x *EnhancedRecording) HasDisk() bool {
+	if x == nil {
+		return false
+	}
+	return x.Disk != nil
+}
+
+func (x *EnhancedRecording) ClearCommand() {
+	x.Command = nil
+}
+
+func (x *EnhancedRecording) ClearNetwork() {
+	x.Network = nil
+}
+
+func (x *EnhancedRecording) ClearDisk() {
+	x.Disk = nil
+}
+
+type EnhancedRecording_builder struct {
+	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
+
+	// Command enables session.command in audit logs
+	Command *bool
+	// Network enables session.network in audit logs
+	Network *bool
+	// Disk enables session.disk in audit logs
+	Disk *bool
+}
+
+func (b0 EnhancedRecording_builder) Build() *EnhancedRecording {
+	m0 := &EnhancedRecording{}
+	b, x := &b0, m0
+	_, _ = b, x
+	x.Command = b.Command
+	x.Network = b.Network
+	x.Disk = b.Disk
+	return m0
+}
+
+// SessionRecording sets the session recording behavior.
+type SessionRecording struct {
+	state protoimpl.MessageState `protogen:"hybrid.v1"`
+	// Mode sets the session recording mode. Allowed values: strict or best_effort.
+	Mode          string `protobuf:"bytes,1,opt,name=mode,proto3" json:"mode,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *SessionRecording) Reset() {
+	*x = SessionRecording{}
+	mi := &file_teleport_scopes_access_v1_role_proto_msgTypes[11]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *SessionRecording) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*SessionRecording) ProtoMessage() {}
+
+func (x *SessionRecording) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_scopes_access_v1_role_proto_msgTypes[11]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+func (x *SessionRecording) GetMode() string {
+	if x != nil {
+		return x.Mode
+	}
+	return ""
+}
+
+func (x *SessionRecording) SetMode(v string) {
+	x.Mode = v
+}
+
+type SessionRecording_builder struct {
+	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
+
+	// Mode sets the session recording mode. Allowed values: strict or best_effort.
+	Mode string
+}
+
+func (b0 SessionRecording_builder) Build() *SessionRecording {
+	m0 := &SessionRecording{}
+	b, x := &b0, m0
+	_, _ = b, x
+	x.Mode = b.Mode
+	return m0
+}
+
+// Lock controls locking mode for sessions authorized via this
+// scoped role.
+type Lock struct {
+	state protoimpl.MessageState `protogen:"hybrid.v1"`
+	// Allowed values: strict or best_effort.
+	// Defaults to value cluster wide auth preference if not set.
+	Mode          string `protobuf:"bytes,1,opt,name=mode,proto3" json:"mode,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *Lock) Reset() {
+	*x = Lock{}
+	mi := &file_teleport_scopes_access_v1_role_proto_msgTypes[12]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *Lock) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*Lock) ProtoMessage() {}
+
+func (x *Lock) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_scopes_access_v1_role_proto_msgTypes[12]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+func (x *Lock) GetMode() string {
+	if x != nil {
+		return x.Mode
+	}
+	return ""
+}
+
+func (x *Lock) SetMode(v string) {
+	x.Mode = v
+}
+
+type Lock_builder struct {
+	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
+
+	// Allowed values: strict or best_effort.
+	// Defaults to value cluster wide auth preference if not set.
+	Mode string
+}
+
+func (b0 Lock_builder) Build() *Lock {
+	m0 := &Lock{}
+	b, x := &b0, m0
+	_, _ = b, x
+	x.Mode = b.Mode
+	return m0
+}
+
 var File_teleport_scopes_access_v1_role_proto protoreflect.FileDescriptor
 
 const file_teleport_scopes_access_v1_role_proto_rawDesc = "" +
@@ -1259,9 +1760,13 @@ const file_teleport_scopes_access_v1_role_proto_rawDesc = "" +
 	"\bdefaults\x18\x05 \x01(\v2-.teleport.scopes.access.v1.ScopedRoleDefaultsR\bdefaults\x12;\n" +
 	"\x05rules\x18\x06 \x03(\v2%.teleport.scopes.access.v1.ScopedRuleR\x05rules\x12:\n" +
 	"\x03ssh\x18\a \x01(\v2(.teleport.scopes.access.v1.ScopedRoleSSHR\x03ssh\x12=\n" +
-	"\x04kube\x18\b \x01(\v2).teleport.scopes.access.v1.ScopedRoleKubeR\x04kubeJ\x04\b\x02\x10\x03J\x04\b\x03\x10\x04R\x05allowR\aoptions\"D\n" +
+	"\x04kube\x18\b \x01(\v2).teleport.scopes.access.v1.ScopedRoleKubeR\x04kubeJ\x04\b\x02\x10\x03J\x04\b\x03\x10\x04R\x05allowR\aoptions\"\xac\x02\n" +
 	"\x12ScopedRoleDefaults\x12.\n" +
-	"\x13client_idle_timeout\x18\x01 \x01(\tR\x11clientIdleTimeout\"\xd4\x04\n" +
+	"\x13client_idle_timeout\x18\x01 \x01(\tR\x11clientIdleTimeout\x12X\n" +
+	"\x11session_recording\x18\x02 \x01(\v2+.teleport.scopes.access.v1.SessionRecordingR\x10sessionRecording\x12;\n" +
+	"\x17disconnect_expired_cert\x18\x03 \x01(\bH\x00R\x15disconnectExpiredCert\x88\x01\x01\x123\n" +
+	"\x04lock\x18\x04 \x01(\v2\x1f.teleport.scopes.access.v1.LockR\x04lockB\x1a\n" +
+	"\x18_disconnect_expired_cert\"\x99\a\n" +
 	"\rScopedRoleSSH\x12\x16\n" +
 	"\x06logins\x18\x01 \x03(\tR\x06logins\x120\n" +
 	"\x06labels\x18\x02 \x03(\v2\x18.teleport.label.v1.LabelR\x06labels\x12.\n" +
@@ -1273,17 +1778,25 @@ const file_teleport_scopes_access_v1_role_proto_rawDesc = "" +
 	"\fmax_sessions\x18\t \x01(\x03H\x02R\vmaxSessions\x88\x01\x01\x12!\n" +
 	"\fhost_sudoers\x18\n" +
 	" \x03(\tR\vhostSudoers\x12 \n" +
-	"\tfile_copy\x18\v \x01(\bH\x03R\bfileCopy\x88\x01\x01B\x18\n" +
+	"\tfile_copy\x18\v \x01(\bH\x03R\bfileCopy\x88\x01\x01\x12[\n" +
+	"\x12enhanced_recording\x18\f \x01(\v2,.teleport.scopes.access.v1.EnhancedRecordingR\x11enhancedRecording\x12X\n" +
+	"\x11session_recording\x18\r \x01(\v2+.teleport.scopes.access.v1.SessionRecordingR\x10sessionRecording\x12;\n" +
+	"\x17disconnect_expired_cert\x18\x0e \x01(\bH\x04R\x15disconnectExpiredCert\x88\x01\x01\x123\n" +
+	"\x04lock\x18\x0f \x01(\v2\x1f.teleport.scopes.access.v1.LockR\x04lockB\x18\n" +
 	"\x16_permit_x11_forwardingB\x10\n" +
 	"\x0e_forward_agentB\x0f\n" +
 	"\r_max_sessionsB\f\n" +
 	"\n" +
-	"_file_copy\"\xb1\x01\n" +
+	"_file_copyB\x1a\n" +
+	"\x18_disconnect_expired_cert\"\xbf\x02\n" +
 	"\x0eScopedRoleKube\x120\n" +
 	"\x06labels\x18\x01 \x03(\v2\x18.teleport.label.v1.LabelR\x06labels\x12\x16\n" +
 	"\x06groups\x18\x02 \x03(\tR\x06groups\x12\x14\n" +
 	"\x05users\x18\x03 \x03(\tR\x05users\x12.\n" +
-	"\x13client_idle_timeout\x18\x05 \x01(\tR\x11clientIdleTimeoutJ\x04\b\x04\x10\x05R\tresources\"@\n" +
+	"\x13client_idle_timeout\x18\x05 \x01(\tR\x11clientIdleTimeout\x12;\n" +
+	"\x17disconnect_expired_cert\x18\x06 \x01(\bH\x00R\x15disconnectExpiredCert\x88\x01\x01\x123\n" +
+	"\x04lock\x18\a \x01(\v2\x1f.teleport.scopes.access.v1.LockR\x04lockB\x1a\n" +
+	"\x18_disconnect_expired_certJ\x04\b\x04\x10\x05R\tresources\"@\n" +
 	"\n" +
 	"ScopedRule\x12\x1c\n" +
 	"\tresources\x18\x01 \x03(\tR\tresources\x12\x14\n" +
@@ -1302,9 +1815,22 @@ const file_teleport_scopes_access_v1_role_proto_rawDesc = "" +
 	"\x0eCreateHostUser\x12\x12\n" +
 	"\x04mode\x18\x01 \x01(\tR\x04mode\x12\x16\n" +
 	"\x06groups\x18\x02 \x03(\tR\x06groups\x12\x14\n" +
-	"\x05shell\x18\x03 \x01(\tR\x05shellBWZUgithub.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/access/v1;accessv1b\x06proto3"
+	"\x05shell\x18\x03 \x01(\tR\x05shell\"\x8b\x01\n" +
+	"\x11EnhancedRecording\x12\x1d\n" +
+	"\acommand\x18\x01 \x01(\bH\x00R\acommand\x88\x01\x01\x12\x1d\n" +
+	"\anetwork\x18\x02 \x01(\bH\x01R\anetwork\x88\x01\x01\x12\x17\n" +
+	"\x04disk\x18\x03 \x01(\bH\x02R\x04disk\x88\x01\x01B\n" +
+	"\n" +
+	"\b_commandB\n" +
+	"\n" +
+	"\b_networkB\a\n" +
+	"\x05_disk\"&\n" +
+	"\x10SessionRecording\x12\x12\n" +
+	"\x04mode\x18\x01 \x01(\tR\x04mode\"\x1a\n" +
+	"\x04Lock\x12\x12\n" +
+	"\x04mode\x18\x01 \x01(\tR\x04modeBWZUgithub.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/access/v1;accessv1b\x06proto3"
 
-var file_teleport_scopes_access_v1_role_proto_msgTypes = make([]protoimpl.MessageInfo, 10)
+var file_teleport_scopes_access_v1_role_proto_msgTypes = make([]protoimpl.MessageInfo, 13)
 var file_teleport_scopes_access_v1_role_proto_goTypes = []any{
 	(*ScopedRole)(nil),              // 0: teleport.scopes.access.v1.ScopedRole
 	(*ScopedRoleSpec)(nil),          // 1: teleport.scopes.access.v1.ScopedRoleSpec
@@ -1316,27 +1842,36 @@ var file_teleport_scopes_access_v1_role_proto_goTypes = []any{
 	(*SSHLocalPortForwarding)(nil),  // 7: teleport.scopes.access.v1.SSHLocalPortForwarding
 	(*SSHRemotePortForwarding)(nil), // 8: teleport.scopes.access.v1.SSHRemotePortForwarding
 	(*CreateHostUser)(nil),          // 9: teleport.scopes.access.v1.CreateHostUser
-	(*v1.Metadata)(nil),             // 10: teleport.header.v1.Metadata
-	(*v11.Label)(nil),               // 11: teleport.label.v1.Label
+	(*EnhancedRecording)(nil),       // 10: teleport.scopes.access.v1.EnhancedRecording
+	(*SessionRecording)(nil),        // 11: teleport.scopes.access.v1.SessionRecording
+	(*Lock)(nil),                    // 12: teleport.scopes.access.v1.Lock
+	(*v1.Metadata)(nil),             // 13: teleport.header.v1.Metadata
+	(*v11.Label)(nil),               // 14: teleport.label.v1.Label
 }
 var file_teleport_scopes_access_v1_role_proto_depIdxs = []int32{
-	10, // 0: teleport.scopes.access.v1.ScopedRole.metadata:type_name -> teleport.header.v1.Metadata
+	13, // 0: teleport.scopes.access.v1.ScopedRole.metadata:type_name -> teleport.header.v1.Metadata
 	1,  // 1: teleport.scopes.access.v1.ScopedRole.spec:type_name -> teleport.scopes.access.v1.ScopedRoleSpec
 	2,  // 2: teleport.scopes.access.v1.ScopedRoleSpec.defaults:type_name -> teleport.scopes.access.v1.ScopedRoleDefaults
 	5,  // 3: teleport.scopes.access.v1.ScopedRoleSpec.rules:type_name -> teleport.scopes.access.v1.ScopedRule
 	3,  // 4: teleport.scopes.access.v1.ScopedRoleSpec.ssh:type_name -> teleport.scopes.access.v1.ScopedRoleSSH
 	4,  // 5: teleport.scopes.access.v1.ScopedRoleSpec.kube:type_name -> teleport.scopes.access.v1.ScopedRoleKube
-	11, // 6: teleport.scopes.access.v1.ScopedRoleSSH.labels:type_name -> teleport.label.v1.Label
-	6,  // 7: teleport.scopes.access.v1.ScopedRoleSSH.port_forwarding:type_name -> teleport.scopes.access.v1.SSHPortForwarding
-	9,  // 8: teleport.scopes.access.v1.ScopedRoleSSH.host_user_creation:type_name -> teleport.scopes.access.v1.CreateHostUser
-	11, // 9: teleport.scopes.access.v1.ScopedRoleKube.labels:type_name -> teleport.label.v1.Label
-	7,  // 10: teleport.scopes.access.v1.SSHPortForwarding.local:type_name -> teleport.scopes.access.v1.SSHLocalPortForwarding
-	8,  // 11: teleport.scopes.access.v1.SSHPortForwarding.remote:type_name -> teleport.scopes.access.v1.SSHRemotePortForwarding
-	12, // [12:12] is the sub-list for method output_type
-	12, // [12:12] is the sub-list for method input_type
-	12, // [12:12] is the sub-list for extension type_name
-	12, // [12:12] is the sub-list for extension extendee
-	0,  // [0:12] is the sub-list for field type_name
+	11, // 6: teleport.scopes.access.v1.ScopedRoleDefaults.session_recording:type_name -> teleport.scopes.access.v1.SessionRecording
+	12, // 7: teleport.scopes.access.v1.ScopedRoleDefaults.lock:type_name -> teleport.scopes.access.v1.Lock
+	14, // 8: teleport.scopes.access.v1.ScopedRoleSSH.labels:type_name -> teleport.label.v1.Label
+	6,  // 9: teleport.scopes.access.v1.ScopedRoleSSH.port_forwarding:type_name -> teleport.scopes.access.v1.SSHPortForwarding
+	9,  // 10: teleport.scopes.access.v1.ScopedRoleSSH.host_user_creation:type_name -> teleport.scopes.access.v1.CreateHostUser
+	10, // 11: teleport.scopes.access.v1.ScopedRoleSSH.enhanced_recording:type_name -> teleport.scopes.access.v1.EnhancedRecording
+	11, // 12: teleport.scopes.access.v1.ScopedRoleSSH.session_recording:type_name -> teleport.scopes.access.v1.SessionRecording
+	12, // 13: teleport.scopes.access.v1.ScopedRoleSSH.lock:type_name -> teleport.scopes.access.v1.Lock
+	14, // 14: teleport.scopes.access.v1.ScopedRoleKube.labels:type_name -> teleport.label.v1.Label
+	12, // 15: teleport.scopes.access.v1.ScopedRoleKube.lock:type_name -> teleport.scopes.access.v1.Lock
+	7,  // 16: teleport.scopes.access.v1.SSHPortForwarding.local:type_name -> teleport.scopes.access.v1.SSHLocalPortForwarding
+	8,  // 17: teleport.scopes.access.v1.SSHPortForwarding.remote:type_name -> teleport.scopes.access.v1.SSHRemotePortForwarding
+	18, // [18:18] is the sub-list for method output_type
+	18, // [18:18] is the sub-list for method input_type
+	18, // [18:18] is the sub-list for extension type_name
+	18, // [18:18] is the sub-list for extension extendee
+	0,  // [0:18] is the sub-list for field type_name
 }
 
 func init() { file_teleport_scopes_access_v1_role_proto_init() }
@@ -1344,16 +1879,19 @@ func file_teleport_scopes_access_v1_role_proto_init() {
 	if File_teleport_scopes_access_v1_role_proto != nil {
 		return
 	}
+	file_teleport_scopes_access_v1_role_proto_msgTypes[2].OneofWrappers = []any{}
 	file_teleport_scopes_access_v1_role_proto_msgTypes[3].OneofWrappers = []any{}
+	file_teleport_scopes_access_v1_role_proto_msgTypes[4].OneofWrappers = []any{}
 	file_teleport_scopes_access_v1_role_proto_msgTypes[7].OneofWrappers = []any{}
 	file_teleport_scopes_access_v1_role_proto_msgTypes[8].OneofWrappers = []any{}
+	file_teleport_scopes_access_v1_role_proto_msgTypes[10].OneofWrappers = []any{}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_teleport_scopes_access_v1_role_proto_rawDesc), len(file_teleport_scopes_access_v1_role_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   10,
+			NumMessages:   13,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/api/gen/proto/go/teleport/scopes/access/v1/role_protoopaque.pb.go
+++ b/api/gen/proto/go/teleport/scopes/access/v1/role_protoopaque.pb.go
@@ -365,10 +365,15 @@ func (b0 ScopedRoleSpec_builder) Build() *ScopedRoleSpec {
 // ScopedRoleDefaults provides fallback values for controls shared across multiple protocols.
 // A control in a protocol-specific block takes precedence over the value specified here.
 type ScopedRoleDefaults struct {
-	state                        protoimpl.MessageState `protogen:"opaque.v1"`
-	xxx_hidden_ClientIdleTimeout string                 `protobuf:"bytes,1,opt,name=client_idle_timeout,json=clientIdleTimeout,proto3"`
-	unknownFields                protoimpl.UnknownFields
-	sizeCache                    protoimpl.SizeCache
+	state                            protoimpl.MessageState `protogen:"opaque.v1"`
+	xxx_hidden_ClientIdleTimeout     string                 `protobuf:"bytes,1,opt,name=client_idle_timeout,json=clientIdleTimeout,proto3"`
+	xxx_hidden_SessionRecording      *SessionRecording      `protobuf:"bytes,2,opt,name=session_recording,json=sessionRecording,proto3"`
+	xxx_hidden_DisconnectExpiredCert bool                   `protobuf:"varint,3,opt,name=disconnect_expired_cert,json=disconnectExpiredCert,proto3,oneof"`
+	xxx_hidden_Lock                  *Lock                  `protobuf:"bytes,4,opt,name=lock,proto3"`
+	XXX_raceDetectHookData           protoimpl.RaceDetectHookData
+	XXX_presence                     [1]uint32
+	unknownFields                    protoimpl.UnknownFields
+	sizeCache                        protoimpl.SizeCache
 }
 
 func (x *ScopedRoleDefaults) Reset() {
@@ -403,8 +408,76 @@ func (x *ScopedRoleDefaults) GetClientIdleTimeout() string {
 	return ""
 }
 
+func (x *ScopedRoleDefaults) GetSessionRecording() *SessionRecording {
+	if x != nil {
+		return x.xxx_hidden_SessionRecording
+	}
+	return nil
+}
+
+func (x *ScopedRoleDefaults) GetDisconnectExpiredCert() bool {
+	if x != nil {
+		return x.xxx_hidden_DisconnectExpiredCert
+	}
+	return false
+}
+
+func (x *ScopedRoleDefaults) GetLock() *Lock {
+	if x != nil {
+		return x.xxx_hidden_Lock
+	}
+	return nil
+}
+
 func (x *ScopedRoleDefaults) SetClientIdleTimeout(v string) {
 	x.xxx_hidden_ClientIdleTimeout = v
+}
+
+func (x *ScopedRoleDefaults) SetSessionRecording(v *SessionRecording) {
+	x.xxx_hidden_SessionRecording = v
+}
+
+func (x *ScopedRoleDefaults) SetDisconnectExpiredCert(v bool) {
+	x.xxx_hidden_DisconnectExpiredCert = v
+	protoimpl.X.SetPresent(&(x.XXX_presence[0]), 2, 4)
+}
+
+func (x *ScopedRoleDefaults) SetLock(v *Lock) {
+	x.xxx_hidden_Lock = v
+}
+
+func (x *ScopedRoleDefaults) HasSessionRecording() bool {
+	if x == nil {
+		return false
+	}
+	return x.xxx_hidden_SessionRecording != nil
+}
+
+func (x *ScopedRoleDefaults) HasDisconnectExpiredCert() bool {
+	if x == nil {
+		return false
+	}
+	return protoimpl.X.Present(&(x.XXX_presence[0]), 2)
+}
+
+func (x *ScopedRoleDefaults) HasLock() bool {
+	if x == nil {
+		return false
+	}
+	return x.xxx_hidden_Lock != nil
+}
+
+func (x *ScopedRoleDefaults) ClearSessionRecording() {
+	x.xxx_hidden_SessionRecording = nil
+}
+
+func (x *ScopedRoleDefaults) ClearDisconnectExpiredCert() {
+	protoimpl.X.ClearPresent(&(x.XXX_presence[0]), 2)
+	x.xxx_hidden_DisconnectExpiredCert = false
+}
+
+func (x *ScopedRoleDefaults) ClearLock() {
+	x.xxx_hidden_Lock = nil
 }
 
 type ScopedRoleDefaults_builder struct {
@@ -413,6 +486,15 @@ type ScopedRoleDefaults_builder struct {
 	// ClientIdleTimeout sets the default idle timeout for access sessions across all protocols
 	// that do not specify their own value. Must be a valid Go duration string (e.g. "30m", "1h").
 	ClientIdleTimeout string
+	// SessionRecording configures the session recording strategy for all protocols that don't
+	// explicitly set their session recording mode.
+	SessionRecording *SessionRecording
+	// DisconnectExpiredCert defines the default behavior of all protocols when certs expire for a session.
+	// If unset, cluster wide defaults are used.
+	DisconnectExpiredCert *bool
+	// Lock specifies the default locking mode for access sessions across all protocols that
+	// do not specify their own value. If unset, cluster wide defaults are used.
+	Lock *Lock
 }
 
 func (b0 ScopedRoleDefaults_builder) Build() *ScopedRoleDefaults {
@@ -420,6 +502,12 @@ func (b0 ScopedRoleDefaults_builder) Build() *ScopedRoleDefaults {
 	b, x := &b0, m0
 	_, _ = b, x
 	x.xxx_hidden_ClientIdleTimeout = b.ClientIdleTimeout
+	x.xxx_hidden_SessionRecording = b.SessionRecording
+	if b.DisconnectExpiredCert != nil {
+		protoimpl.X.SetPresentNonAtomic(&(x.XXX_presence[0]), 2, 4)
+		x.xxx_hidden_DisconnectExpiredCert = *b.DisconnectExpiredCert
+	}
+	x.xxx_hidden_Lock = b.Lock
 	return m0
 }
 
@@ -429,21 +517,25 @@ func (b0 ScopedRoleDefaults_builder) Build() *ScopedRoleDefaults {
 // to the SSH access it permits, but defaults and global or scope-bound controls may also affect the nature of
 // the resulting access.
 type ScopedRoleSSH struct {
-	state                          protoimpl.MessageState `protogen:"opaque.v1"`
-	xxx_hidden_Logins              []string               `protobuf:"bytes,1,rep,name=logins,proto3"`
-	xxx_hidden_Labels              *[]*v11.Label          `protobuf:"bytes,2,rep,name=labels,proto3"`
-	xxx_hidden_ClientIdleTimeout   string                 `protobuf:"bytes,3,opt,name=client_idle_timeout,json=clientIdleTimeout,proto3"`
-	xxx_hidden_PermitX11Forwarding bool                   `protobuf:"varint,4,opt,name=permit_x11_forwarding,json=permitX11Forwarding,proto3,oneof"`
-	xxx_hidden_ForwardAgent        bool                   `protobuf:"varint,6,opt,name=forward_agent,json=forwardAgent,proto3,oneof"`
-	xxx_hidden_PortForwarding      *SSHPortForwarding     `protobuf:"bytes,7,opt,name=port_forwarding,json=portForwarding,proto3"`
-	xxx_hidden_HostUserCreation    *CreateHostUser        `protobuf:"bytes,8,opt,name=host_user_creation,json=hostUserCreation,proto3"`
-	xxx_hidden_MaxSessions         int64                  `protobuf:"varint,9,opt,name=max_sessions,json=maxSessions,proto3,oneof"`
-	xxx_hidden_HostSudoers         []string               `protobuf:"bytes,10,rep,name=host_sudoers,json=hostSudoers,proto3"`
-	xxx_hidden_FileCopy            bool                   `protobuf:"varint,11,opt,name=file_copy,json=fileCopy,proto3,oneof"`
-	XXX_raceDetectHookData         protoimpl.RaceDetectHookData
-	XXX_presence                   [1]uint32
-	unknownFields                  protoimpl.UnknownFields
-	sizeCache                      protoimpl.SizeCache
+	state                            protoimpl.MessageState `protogen:"opaque.v1"`
+	xxx_hidden_Logins                []string               `protobuf:"bytes,1,rep,name=logins,proto3"`
+	xxx_hidden_Labels                *[]*v11.Label          `protobuf:"bytes,2,rep,name=labels,proto3"`
+	xxx_hidden_ClientIdleTimeout     string                 `protobuf:"bytes,3,opt,name=client_idle_timeout,json=clientIdleTimeout,proto3"`
+	xxx_hidden_PermitX11Forwarding   bool                   `protobuf:"varint,4,opt,name=permit_x11_forwarding,json=permitX11Forwarding,proto3,oneof"`
+	xxx_hidden_ForwardAgent          bool                   `protobuf:"varint,6,opt,name=forward_agent,json=forwardAgent,proto3,oneof"`
+	xxx_hidden_PortForwarding        *SSHPortForwarding     `protobuf:"bytes,7,opt,name=port_forwarding,json=portForwarding,proto3"`
+	xxx_hidden_HostUserCreation      *CreateHostUser        `protobuf:"bytes,8,opt,name=host_user_creation,json=hostUserCreation,proto3"`
+	xxx_hidden_MaxSessions           int64                  `protobuf:"varint,9,opt,name=max_sessions,json=maxSessions,proto3,oneof"`
+	xxx_hidden_HostSudoers           []string               `protobuf:"bytes,10,rep,name=host_sudoers,json=hostSudoers,proto3"`
+	xxx_hidden_FileCopy              bool                   `protobuf:"varint,11,opt,name=file_copy,json=fileCopy,proto3,oneof"`
+	xxx_hidden_EnhancedRecording     *EnhancedRecording     `protobuf:"bytes,12,opt,name=enhanced_recording,json=enhancedRecording,proto3"`
+	xxx_hidden_SessionRecording      *SessionRecording      `protobuf:"bytes,13,opt,name=session_recording,json=sessionRecording,proto3"`
+	xxx_hidden_DisconnectExpiredCert bool                   `protobuf:"varint,14,opt,name=disconnect_expired_cert,json=disconnectExpiredCert,proto3,oneof"`
+	xxx_hidden_Lock                  *Lock                  `protobuf:"bytes,15,opt,name=lock,proto3"`
+	XXX_raceDetectHookData           protoimpl.RaceDetectHookData
+	XXX_presence                     [1]uint32
+	unknownFields                    protoimpl.UnknownFields
+	sizeCache                        protoimpl.SizeCache
 }
 
 func (x *ScopedRoleSSH) Reset() {
@@ -543,6 +635,34 @@ func (x *ScopedRoleSSH) GetFileCopy() bool {
 	return false
 }
 
+func (x *ScopedRoleSSH) GetEnhancedRecording() *EnhancedRecording {
+	if x != nil {
+		return x.xxx_hidden_EnhancedRecording
+	}
+	return nil
+}
+
+func (x *ScopedRoleSSH) GetSessionRecording() *SessionRecording {
+	if x != nil {
+		return x.xxx_hidden_SessionRecording
+	}
+	return nil
+}
+
+func (x *ScopedRoleSSH) GetDisconnectExpiredCert() bool {
+	if x != nil {
+		return x.xxx_hidden_DisconnectExpiredCert
+	}
+	return false
+}
+
+func (x *ScopedRoleSSH) GetLock() *Lock {
+	if x != nil {
+		return x.xxx_hidden_Lock
+	}
+	return nil
+}
+
 func (x *ScopedRoleSSH) SetLogins(v []string) {
 	x.xxx_hidden_Logins = v
 }
@@ -557,12 +677,12 @@ func (x *ScopedRoleSSH) SetClientIdleTimeout(v string) {
 
 func (x *ScopedRoleSSH) SetPermitX11Forwarding(v bool) {
 	x.xxx_hidden_PermitX11Forwarding = v
-	protoimpl.X.SetPresent(&(x.XXX_presence[0]), 3, 10)
+	protoimpl.X.SetPresent(&(x.XXX_presence[0]), 3, 14)
 }
 
 func (x *ScopedRoleSSH) SetForwardAgent(v bool) {
 	x.xxx_hidden_ForwardAgent = v
-	protoimpl.X.SetPresent(&(x.XXX_presence[0]), 4, 10)
+	protoimpl.X.SetPresent(&(x.XXX_presence[0]), 4, 14)
 }
 
 func (x *ScopedRoleSSH) SetPortForwarding(v *SSHPortForwarding) {
@@ -575,7 +695,7 @@ func (x *ScopedRoleSSH) SetHostUserCreation(v *CreateHostUser) {
 
 func (x *ScopedRoleSSH) SetMaxSessions(v int64) {
 	x.xxx_hidden_MaxSessions = v
-	protoimpl.X.SetPresent(&(x.XXX_presence[0]), 7, 10)
+	protoimpl.X.SetPresent(&(x.XXX_presence[0]), 7, 14)
 }
 
 func (x *ScopedRoleSSH) SetHostSudoers(v []string) {
@@ -584,7 +704,24 @@ func (x *ScopedRoleSSH) SetHostSudoers(v []string) {
 
 func (x *ScopedRoleSSH) SetFileCopy(v bool) {
 	x.xxx_hidden_FileCopy = v
-	protoimpl.X.SetPresent(&(x.XXX_presence[0]), 9, 10)
+	protoimpl.X.SetPresent(&(x.XXX_presence[0]), 9, 14)
+}
+
+func (x *ScopedRoleSSH) SetEnhancedRecording(v *EnhancedRecording) {
+	x.xxx_hidden_EnhancedRecording = v
+}
+
+func (x *ScopedRoleSSH) SetSessionRecording(v *SessionRecording) {
+	x.xxx_hidden_SessionRecording = v
+}
+
+func (x *ScopedRoleSSH) SetDisconnectExpiredCert(v bool) {
+	x.xxx_hidden_DisconnectExpiredCert = v
+	protoimpl.X.SetPresent(&(x.XXX_presence[0]), 12, 14)
+}
+
+func (x *ScopedRoleSSH) SetLock(v *Lock) {
+	x.xxx_hidden_Lock = v
 }
 
 func (x *ScopedRoleSSH) HasPermitX11Forwarding() bool {
@@ -629,6 +766,34 @@ func (x *ScopedRoleSSH) HasFileCopy() bool {
 	return protoimpl.X.Present(&(x.XXX_presence[0]), 9)
 }
 
+func (x *ScopedRoleSSH) HasEnhancedRecording() bool {
+	if x == nil {
+		return false
+	}
+	return x.xxx_hidden_EnhancedRecording != nil
+}
+
+func (x *ScopedRoleSSH) HasSessionRecording() bool {
+	if x == nil {
+		return false
+	}
+	return x.xxx_hidden_SessionRecording != nil
+}
+
+func (x *ScopedRoleSSH) HasDisconnectExpiredCert() bool {
+	if x == nil {
+		return false
+	}
+	return protoimpl.X.Present(&(x.XXX_presence[0]), 12)
+}
+
+func (x *ScopedRoleSSH) HasLock() bool {
+	if x == nil {
+		return false
+	}
+	return x.xxx_hidden_Lock != nil
+}
+
 func (x *ScopedRoleSSH) ClearPermitX11Forwarding() {
 	protoimpl.X.ClearPresent(&(x.XXX_presence[0]), 3)
 	x.xxx_hidden_PermitX11Forwarding = false
@@ -655,6 +820,23 @@ func (x *ScopedRoleSSH) ClearMaxSessions() {
 func (x *ScopedRoleSSH) ClearFileCopy() {
 	protoimpl.X.ClearPresent(&(x.XXX_presence[0]), 9)
 	x.xxx_hidden_FileCopy = false
+}
+
+func (x *ScopedRoleSSH) ClearEnhancedRecording() {
+	x.xxx_hidden_EnhancedRecording = nil
+}
+
+func (x *ScopedRoleSSH) ClearSessionRecording() {
+	x.xxx_hidden_SessionRecording = nil
+}
+
+func (x *ScopedRoleSSH) ClearDisconnectExpiredCert() {
+	protoimpl.X.ClearPresent(&(x.XXX_presence[0]), 12)
+	x.xxx_hidden_DisconnectExpiredCert = false
+}
+
+func (x *ScopedRoleSSH) ClearLock() {
+	x.xxx_hidden_Lock = nil
 }
 
 type ScopedRoleSSH_builder struct {
@@ -685,6 +867,16 @@ type ScopedRoleSSH_builder struct {
 	// FileCopy indicates whether remote file operations via SCP or SFTP are allowed
 	// over an SSH session. It defaults to allowing the user to download and upload files by default.
 	FileCopy *bool
+	// EnhancedRecording is the set of BPF events to record for enhanced session recording.
+	EnhancedRecording *EnhancedRecording
+	// SessionRecording configures the session recording strategy for SSH sessions.
+	SessionRecording *SessionRecording
+	// DisconnectExpiredCert controls whether SSH sessions are disconnected when the
+	// user certificate expires.
+	// Defaults to value cluster wide auth preference if not set.
+	DisconnectExpiredCert *bool
+	// Lock configures the role's locking behavior for SSH sessions.
+	Lock *Lock
 }
 
 func (b0 ScopedRoleSSH_builder) Build() *ScopedRoleSSH {
@@ -695,24 +887,31 @@ func (b0 ScopedRoleSSH_builder) Build() *ScopedRoleSSH {
 	x.xxx_hidden_Labels = &b.Labels
 	x.xxx_hidden_ClientIdleTimeout = b.ClientIdleTimeout
 	if b.PermitX11Forwarding != nil {
-		protoimpl.X.SetPresentNonAtomic(&(x.XXX_presence[0]), 3, 10)
+		protoimpl.X.SetPresentNonAtomic(&(x.XXX_presence[0]), 3, 14)
 		x.xxx_hidden_PermitX11Forwarding = *b.PermitX11Forwarding
 	}
 	if b.ForwardAgent != nil {
-		protoimpl.X.SetPresentNonAtomic(&(x.XXX_presence[0]), 4, 10)
+		protoimpl.X.SetPresentNonAtomic(&(x.XXX_presence[0]), 4, 14)
 		x.xxx_hidden_ForwardAgent = *b.ForwardAgent
 	}
 	x.xxx_hidden_PortForwarding = b.PortForwarding
 	x.xxx_hidden_HostUserCreation = b.HostUserCreation
 	if b.MaxSessions != nil {
-		protoimpl.X.SetPresentNonAtomic(&(x.XXX_presence[0]), 7, 10)
+		protoimpl.X.SetPresentNonAtomic(&(x.XXX_presence[0]), 7, 14)
 		x.xxx_hidden_MaxSessions = *b.MaxSessions
 	}
 	x.xxx_hidden_HostSudoers = b.HostSudoers
 	if b.FileCopy != nil {
-		protoimpl.X.SetPresentNonAtomic(&(x.XXX_presence[0]), 9, 10)
+		protoimpl.X.SetPresentNonAtomic(&(x.XXX_presence[0]), 9, 14)
 		x.xxx_hidden_FileCopy = *b.FileCopy
 	}
+	x.xxx_hidden_EnhancedRecording = b.EnhancedRecording
+	x.xxx_hidden_SessionRecording = b.SessionRecording
+	if b.DisconnectExpiredCert != nil {
+		protoimpl.X.SetPresentNonAtomic(&(x.XXX_presence[0]), 12, 14)
+		x.xxx_hidden_DisconnectExpiredCert = *b.DisconnectExpiredCert
+	}
+	x.xxx_hidden_Lock = b.Lock
 	return m0
 }
 
@@ -722,13 +921,17 @@ func (b0 ScopedRoleSSH_builder) Build() *ScopedRoleSSH {
 // to the kube access it permits, but defaults and global or scope-bound controls may also affect the nature of
 // the resulting access.
 type ScopedRoleKube struct {
-	state                        protoimpl.MessageState `protogen:"opaque.v1"`
-	xxx_hidden_Labels            *[]*v11.Label          `protobuf:"bytes,1,rep,name=labels,proto3"`
-	xxx_hidden_Groups            []string               `protobuf:"bytes,2,rep,name=groups,proto3"`
-	xxx_hidden_Users             []string               `protobuf:"bytes,3,rep,name=users,proto3"`
-	xxx_hidden_ClientIdleTimeout string                 `protobuf:"bytes,5,opt,name=client_idle_timeout,json=clientIdleTimeout,proto3"`
-	unknownFields                protoimpl.UnknownFields
-	sizeCache                    protoimpl.SizeCache
+	state                            protoimpl.MessageState `protogen:"opaque.v1"`
+	xxx_hidden_Labels                *[]*v11.Label          `protobuf:"bytes,1,rep,name=labels,proto3"`
+	xxx_hidden_Groups                []string               `protobuf:"bytes,2,rep,name=groups,proto3"`
+	xxx_hidden_Users                 []string               `protobuf:"bytes,3,rep,name=users,proto3"`
+	xxx_hidden_ClientIdleTimeout     string                 `protobuf:"bytes,5,opt,name=client_idle_timeout,json=clientIdleTimeout,proto3"`
+	xxx_hidden_DisconnectExpiredCert bool                   `protobuf:"varint,6,opt,name=disconnect_expired_cert,json=disconnectExpiredCert,proto3,oneof"`
+	xxx_hidden_Lock                  *Lock                  `protobuf:"bytes,7,opt,name=lock,proto3"`
+	XXX_raceDetectHookData           protoimpl.RaceDetectHookData
+	XXX_presence                     [1]uint32
+	unknownFields                    protoimpl.UnknownFields
+	sizeCache                        protoimpl.SizeCache
 }
 
 func (x *ScopedRoleKube) Reset() {
@@ -786,6 +989,20 @@ func (x *ScopedRoleKube) GetClientIdleTimeout() string {
 	return ""
 }
 
+func (x *ScopedRoleKube) GetDisconnectExpiredCert() bool {
+	if x != nil {
+		return x.xxx_hidden_DisconnectExpiredCert
+	}
+	return false
+}
+
+func (x *ScopedRoleKube) GetLock() *Lock {
+	if x != nil {
+		return x.xxx_hidden_Lock
+	}
+	return nil
+}
+
 func (x *ScopedRoleKube) SetLabels(v []*v11.Label) {
 	x.xxx_hidden_Labels = &v
 }
@@ -802,6 +1019,38 @@ func (x *ScopedRoleKube) SetClientIdleTimeout(v string) {
 	x.xxx_hidden_ClientIdleTimeout = v
 }
 
+func (x *ScopedRoleKube) SetDisconnectExpiredCert(v bool) {
+	x.xxx_hidden_DisconnectExpiredCert = v
+	protoimpl.X.SetPresent(&(x.XXX_presence[0]), 4, 6)
+}
+
+func (x *ScopedRoleKube) SetLock(v *Lock) {
+	x.xxx_hidden_Lock = v
+}
+
+func (x *ScopedRoleKube) HasDisconnectExpiredCert() bool {
+	if x == nil {
+		return false
+	}
+	return protoimpl.X.Present(&(x.XXX_presence[0]), 4)
+}
+
+func (x *ScopedRoleKube) HasLock() bool {
+	if x == nil {
+		return false
+	}
+	return x.xxx_hidden_Lock != nil
+}
+
+func (x *ScopedRoleKube) ClearDisconnectExpiredCert() {
+	protoimpl.X.ClearPresent(&(x.XXX_presence[0]), 4)
+	x.xxx_hidden_DisconnectExpiredCert = false
+}
+
+func (x *ScopedRoleKube) ClearLock() {
+	x.xxx_hidden_Lock = nil
+}
+
 type ScopedRoleKube_builder struct {
 	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
 
@@ -815,6 +1064,10 @@ type ScopedRoleKube_builder struct {
 	// Must be a valid Go duration string (e.g. "30m", "1h"). If empty, the defaults block value
 	// (or global default) applies.
 	ClientIdleTimeout string
+	// DisconnectExpiredCert controls whether Kube sessions are disconnected when the user certificate expires.
+	DisconnectExpiredCert *bool
+	// Lock configures the role's locking behavior for kubernetes sessions.
+	Lock *Lock
 }
 
 func (b0 ScopedRoleKube_builder) Build() *ScopedRoleKube {
@@ -825,6 +1078,11 @@ func (b0 ScopedRoleKube_builder) Build() *ScopedRoleKube {
 	x.xxx_hidden_Groups = b.Groups
 	x.xxx_hidden_Users = b.Users
 	x.xxx_hidden_ClientIdleTimeout = b.ClientIdleTimeout
+	if b.DisconnectExpiredCert != nil {
+		protoimpl.X.SetPresentNonAtomic(&(x.XXX_presence[0]), 4, 6)
+		x.xxx_hidden_DisconnectExpiredCert = *b.DisconnectExpiredCert
+	}
+	x.xxx_hidden_Lock = b.Lock
 	return m0
 }
 
@@ -1240,6 +1498,265 @@ func (b0 CreateHostUser_builder) Build() *CreateHostUser {
 	return m0
 }
 
+// EnhancedRecording enables what events to record for the BPF-based session recorder.
+type EnhancedRecording struct {
+	state                  protoimpl.MessageState `protogen:"opaque.v1"`
+	xxx_hidden_Command     bool                   `protobuf:"varint,1,opt,name=command,proto3,oneof"`
+	xxx_hidden_Network     bool                   `protobuf:"varint,2,opt,name=network,proto3,oneof"`
+	xxx_hidden_Disk        bool                   `protobuf:"varint,3,opt,name=disk,proto3,oneof"`
+	XXX_raceDetectHookData protoimpl.RaceDetectHookData
+	XXX_presence           [1]uint32
+	unknownFields          protoimpl.UnknownFields
+	sizeCache              protoimpl.SizeCache
+}
+
+func (x *EnhancedRecording) Reset() {
+	*x = EnhancedRecording{}
+	mi := &file_teleport_scopes_access_v1_role_proto_msgTypes[10]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *EnhancedRecording) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*EnhancedRecording) ProtoMessage() {}
+
+func (x *EnhancedRecording) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_scopes_access_v1_role_proto_msgTypes[10]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+func (x *EnhancedRecording) GetCommand() bool {
+	if x != nil {
+		return x.xxx_hidden_Command
+	}
+	return false
+}
+
+func (x *EnhancedRecording) GetNetwork() bool {
+	if x != nil {
+		return x.xxx_hidden_Network
+	}
+	return false
+}
+
+func (x *EnhancedRecording) GetDisk() bool {
+	if x != nil {
+		return x.xxx_hidden_Disk
+	}
+	return false
+}
+
+func (x *EnhancedRecording) SetCommand(v bool) {
+	x.xxx_hidden_Command = v
+	protoimpl.X.SetPresent(&(x.XXX_presence[0]), 0, 3)
+}
+
+func (x *EnhancedRecording) SetNetwork(v bool) {
+	x.xxx_hidden_Network = v
+	protoimpl.X.SetPresent(&(x.XXX_presence[0]), 1, 3)
+}
+
+func (x *EnhancedRecording) SetDisk(v bool) {
+	x.xxx_hidden_Disk = v
+	protoimpl.X.SetPresent(&(x.XXX_presence[0]), 2, 3)
+}
+
+func (x *EnhancedRecording) HasCommand() bool {
+	if x == nil {
+		return false
+	}
+	return protoimpl.X.Present(&(x.XXX_presence[0]), 0)
+}
+
+func (x *EnhancedRecording) HasNetwork() bool {
+	if x == nil {
+		return false
+	}
+	return protoimpl.X.Present(&(x.XXX_presence[0]), 1)
+}
+
+func (x *EnhancedRecording) HasDisk() bool {
+	if x == nil {
+		return false
+	}
+	return protoimpl.X.Present(&(x.XXX_presence[0]), 2)
+}
+
+func (x *EnhancedRecording) ClearCommand() {
+	protoimpl.X.ClearPresent(&(x.XXX_presence[0]), 0)
+	x.xxx_hidden_Command = false
+}
+
+func (x *EnhancedRecording) ClearNetwork() {
+	protoimpl.X.ClearPresent(&(x.XXX_presence[0]), 1)
+	x.xxx_hidden_Network = false
+}
+
+func (x *EnhancedRecording) ClearDisk() {
+	protoimpl.X.ClearPresent(&(x.XXX_presence[0]), 2)
+	x.xxx_hidden_Disk = false
+}
+
+type EnhancedRecording_builder struct {
+	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
+
+	// Command enables session.command in audit logs
+	Command *bool
+	// Network enables session.network in audit logs
+	Network *bool
+	// Disk enables session.disk in audit logs
+	Disk *bool
+}
+
+func (b0 EnhancedRecording_builder) Build() *EnhancedRecording {
+	m0 := &EnhancedRecording{}
+	b, x := &b0, m0
+	_, _ = b, x
+	if b.Command != nil {
+		protoimpl.X.SetPresentNonAtomic(&(x.XXX_presence[0]), 0, 3)
+		x.xxx_hidden_Command = *b.Command
+	}
+	if b.Network != nil {
+		protoimpl.X.SetPresentNonAtomic(&(x.XXX_presence[0]), 1, 3)
+		x.xxx_hidden_Network = *b.Network
+	}
+	if b.Disk != nil {
+		protoimpl.X.SetPresentNonAtomic(&(x.XXX_presence[0]), 2, 3)
+		x.xxx_hidden_Disk = *b.Disk
+	}
+	return m0
+}
+
+// SessionRecording sets the session recording behavior.
+type SessionRecording struct {
+	state           protoimpl.MessageState `protogen:"opaque.v1"`
+	xxx_hidden_Mode string                 `protobuf:"bytes,1,opt,name=mode,proto3"`
+	unknownFields   protoimpl.UnknownFields
+	sizeCache       protoimpl.SizeCache
+}
+
+func (x *SessionRecording) Reset() {
+	*x = SessionRecording{}
+	mi := &file_teleport_scopes_access_v1_role_proto_msgTypes[11]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *SessionRecording) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*SessionRecording) ProtoMessage() {}
+
+func (x *SessionRecording) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_scopes_access_v1_role_proto_msgTypes[11]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+func (x *SessionRecording) GetMode() string {
+	if x != nil {
+		return x.xxx_hidden_Mode
+	}
+	return ""
+}
+
+func (x *SessionRecording) SetMode(v string) {
+	x.xxx_hidden_Mode = v
+}
+
+type SessionRecording_builder struct {
+	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
+
+	// Mode sets the session recording mode. Allowed values: strict or best_effort.
+	Mode string
+}
+
+func (b0 SessionRecording_builder) Build() *SessionRecording {
+	m0 := &SessionRecording{}
+	b, x := &b0, m0
+	_, _ = b, x
+	x.xxx_hidden_Mode = b.Mode
+	return m0
+}
+
+// Lock controls locking mode for sessions authorized via this
+// scoped role.
+type Lock struct {
+	state           protoimpl.MessageState `protogen:"opaque.v1"`
+	xxx_hidden_Mode string                 `protobuf:"bytes,1,opt,name=mode,proto3"`
+	unknownFields   protoimpl.UnknownFields
+	sizeCache       protoimpl.SizeCache
+}
+
+func (x *Lock) Reset() {
+	*x = Lock{}
+	mi := &file_teleport_scopes_access_v1_role_proto_msgTypes[12]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *Lock) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*Lock) ProtoMessage() {}
+
+func (x *Lock) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_scopes_access_v1_role_proto_msgTypes[12]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+func (x *Lock) GetMode() string {
+	if x != nil {
+		return x.xxx_hidden_Mode
+	}
+	return ""
+}
+
+func (x *Lock) SetMode(v string) {
+	x.xxx_hidden_Mode = v
+}
+
+type Lock_builder struct {
+	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
+
+	// Allowed values: strict or best_effort.
+	// Defaults to value cluster wide auth preference if not set.
+	Mode string
+}
+
+func (b0 Lock_builder) Build() *Lock {
+	m0 := &Lock{}
+	b, x := &b0, m0
+	_, _ = b, x
+	x.xxx_hidden_Mode = b.Mode
+	return m0
+}
+
 var File_teleport_scopes_access_v1_role_proto protoreflect.FileDescriptor
 
 const file_teleport_scopes_access_v1_role_proto_rawDesc = "" +
@@ -1258,9 +1775,13 @@ const file_teleport_scopes_access_v1_role_proto_rawDesc = "" +
 	"\bdefaults\x18\x05 \x01(\v2-.teleport.scopes.access.v1.ScopedRoleDefaultsR\bdefaults\x12;\n" +
 	"\x05rules\x18\x06 \x03(\v2%.teleport.scopes.access.v1.ScopedRuleR\x05rules\x12:\n" +
 	"\x03ssh\x18\a \x01(\v2(.teleport.scopes.access.v1.ScopedRoleSSHR\x03ssh\x12=\n" +
-	"\x04kube\x18\b \x01(\v2).teleport.scopes.access.v1.ScopedRoleKubeR\x04kubeJ\x04\b\x02\x10\x03J\x04\b\x03\x10\x04R\x05allowR\aoptions\"D\n" +
+	"\x04kube\x18\b \x01(\v2).teleport.scopes.access.v1.ScopedRoleKubeR\x04kubeJ\x04\b\x02\x10\x03J\x04\b\x03\x10\x04R\x05allowR\aoptions\"\xac\x02\n" +
 	"\x12ScopedRoleDefaults\x12.\n" +
-	"\x13client_idle_timeout\x18\x01 \x01(\tR\x11clientIdleTimeout\"\xd4\x04\n" +
+	"\x13client_idle_timeout\x18\x01 \x01(\tR\x11clientIdleTimeout\x12X\n" +
+	"\x11session_recording\x18\x02 \x01(\v2+.teleport.scopes.access.v1.SessionRecordingR\x10sessionRecording\x12;\n" +
+	"\x17disconnect_expired_cert\x18\x03 \x01(\bH\x00R\x15disconnectExpiredCert\x88\x01\x01\x123\n" +
+	"\x04lock\x18\x04 \x01(\v2\x1f.teleport.scopes.access.v1.LockR\x04lockB\x1a\n" +
+	"\x18_disconnect_expired_cert\"\x99\a\n" +
 	"\rScopedRoleSSH\x12\x16\n" +
 	"\x06logins\x18\x01 \x03(\tR\x06logins\x120\n" +
 	"\x06labels\x18\x02 \x03(\v2\x18.teleport.label.v1.LabelR\x06labels\x12.\n" +
@@ -1272,17 +1793,25 @@ const file_teleport_scopes_access_v1_role_proto_rawDesc = "" +
 	"\fmax_sessions\x18\t \x01(\x03H\x02R\vmaxSessions\x88\x01\x01\x12!\n" +
 	"\fhost_sudoers\x18\n" +
 	" \x03(\tR\vhostSudoers\x12 \n" +
-	"\tfile_copy\x18\v \x01(\bH\x03R\bfileCopy\x88\x01\x01B\x18\n" +
+	"\tfile_copy\x18\v \x01(\bH\x03R\bfileCopy\x88\x01\x01\x12[\n" +
+	"\x12enhanced_recording\x18\f \x01(\v2,.teleport.scopes.access.v1.EnhancedRecordingR\x11enhancedRecording\x12X\n" +
+	"\x11session_recording\x18\r \x01(\v2+.teleport.scopes.access.v1.SessionRecordingR\x10sessionRecording\x12;\n" +
+	"\x17disconnect_expired_cert\x18\x0e \x01(\bH\x04R\x15disconnectExpiredCert\x88\x01\x01\x123\n" +
+	"\x04lock\x18\x0f \x01(\v2\x1f.teleport.scopes.access.v1.LockR\x04lockB\x18\n" +
 	"\x16_permit_x11_forwardingB\x10\n" +
 	"\x0e_forward_agentB\x0f\n" +
 	"\r_max_sessionsB\f\n" +
 	"\n" +
-	"_file_copy\"\xb1\x01\n" +
+	"_file_copyB\x1a\n" +
+	"\x18_disconnect_expired_cert\"\xbf\x02\n" +
 	"\x0eScopedRoleKube\x120\n" +
 	"\x06labels\x18\x01 \x03(\v2\x18.teleport.label.v1.LabelR\x06labels\x12\x16\n" +
 	"\x06groups\x18\x02 \x03(\tR\x06groups\x12\x14\n" +
 	"\x05users\x18\x03 \x03(\tR\x05users\x12.\n" +
-	"\x13client_idle_timeout\x18\x05 \x01(\tR\x11clientIdleTimeoutJ\x04\b\x04\x10\x05R\tresources\"@\n" +
+	"\x13client_idle_timeout\x18\x05 \x01(\tR\x11clientIdleTimeout\x12;\n" +
+	"\x17disconnect_expired_cert\x18\x06 \x01(\bH\x00R\x15disconnectExpiredCert\x88\x01\x01\x123\n" +
+	"\x04lock\x18\a \x01(\v2\x1f.teleport.scopes.access.v1.LockR\x04lockB\x1a\n" +
+	"\x18_disconnect_expired_certJ\x04\b\x04\x10\x05R\tresources\"@\n" +
 	"\n" +
 	"ScopedRule\x12\x1c\n" +
 	"\tresources\x18\x01 \x03(\tR\tresources\x12\x14\n" +
@@ -1301,9 +1830,22 @@ const file_teleport_scopes_access_v1_role_proto_rawDesc = "" +
 	"\x0eCreateHostUser\x12\x12\n" +
 	"\x04mode\x18\x01 \x01(\tR\x04mode\x12\x16\n" +
 	"\x06groups\x18\x02 \x03(\tR\x06groups\x12\x14\n" +
-	"\x05shell\x18\x03 \x01(\tR\x05shellBWZUgithub.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/access/v1;accessv1b\x06proto3"
+	"\x05shell\x18\x03 \x01(\tR\x05shell\"\x8b\x01\n" +
+	"\x11EnhancedRecording\x12\x1d\n" +
+	"\acommand\x18\x01 \x01(\bH\x00R\acommand\x88\x01\x01\x12\x1d\n" +
+	"\anetwork\x18\x02 \x01(\bH\x01R\anetwork\x88\x01\x01\x12\x17\n" +
+	"\x04disk\x18\x03 \x01(\bH\x02R\x04disk\x88\x01\x01B\n" +
+	"\n" +
+	"\b_commandB\n" +
+	"\n" +
+	"\b_networkB\a\n" +
+	"\x05_disk\"&\n" +
+	"\x10SessionRecording\x12\x12\n" +
+	"\x04mode\x18\x01 \x01(\tR\x04mode\"\x1a\n" +
+	"\x04Lock\x12\x12\n" +
+	"\x04mode\x18\x01 \x01(\tR\x04modeBWZUgithub.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/access/v1;accessv1b\x06proto3"
 
-var file_teleport_scopes_access_v1_role_proto_msgTypes = make([]protoimpl.MessageInfo, 10)
+var file_teleport_scopes_access_v1_role_proto_msgTypes = make([]protoimpl.MessageInfo, 13)
 var file_teleport_scopes_access_v1_role_proto_goTypes = []any{
 	(*ScopedRole)(nil),              // 0: teleport.scopes.access.v1.ScopedRole
 	(*ScopedRoleSpec)(nil),          // 1: teleport.scopes.access.v1.ScopedRoleSpec
@@ -1315,27 +1857,36 @@ var file_teleport_scopes_access_v1_role_proto_goTypes = []any{
 	(*SSHLocalPortForwarding)(nil),  // 7: teleport.scopes.access.v1.SSHLocalPortForwarding
 	(*SSHRemotePortForwarding)(nil), // 8: teleport.scopes.access.v1.SSHRemotePortForwarding
 	(*CreateHostUser)(nil),          // 9: teleport.scopes.access.v1.CreateHostUser
-	(*v1.Metadata)(nil),             // 10: teleport.header.v1.Metadata
-	(*v11.Label)(nil),               // 11: teleport.label.v1.Label
+	(*EnhancedRecording)(nil),       // 10: teleport.scopes.access.v1.EnhancedRecording
+	(*SessionRecording)(nil),        // 11: teleport.scopes.access.v1.SessionRecording
+	(*Lock)(nil),                    // 12: teleport.scopes.access.v1.Lock
+	(*v1.Metadata)(nil),             // 13: teleport.header.v1.Metadata
+	(*v11.Label)(nil),               // 14: teleport.label.v1.Label
 }
 var file_teleport_scopes_access_v1_role_proto_depIdxs = []int32{
-	10, // 0: teleport.scopes.access.v1.ScopedRole.metadata:type_name -> teleport.header.v1.Metadata
+	13, // 0: teleport.scopes.access.v1.ScopedRole.metadata:type_name -> teleport.header.v1.Metadata
 	1,  // 1: teleport.scopes.access.v1.ScopedRole.spec:type_name -> teleport.scopes.access.v1.ScopedRoleSpec
 	2,  // 2: teleport.scopes.access.v1.ScopedRoleSpec.defaults:type_name -> teleport.scopes.access.v1.ScopedRoleDefaults
 	5,  // 3: teleport.scopes.access.v1.ScopedRoleSpec.rules:type_name -> teleport.scopes.access.v1.ScopedRule
 	3,  // 4: teleport.scopes.access.v1.ScopedRoleSpec.ssh:type_name -> teleport.scopes.access.v1.ScopedRoleSSH
 	4,  // 5: teleport.scopes.access.v1.ScopedRoleSpec.kube:type_name -> teleport.scopes.access.v1.ScopedRoleKube
-	11, // 6: teleport.scopes.access.v1.ScopedRoleSSH.labels:type_name -> teleport.label.v1.Label
-	6,  // 7: teleport.scopes.access.v1.ScopedRoleSSH.port_forwarding:type_name -> teleport.scopes.access.v1.SSHPortForwarding
-	9,  // 8: teleport.scopes.access.v1.ScopedRoleSSH.host_user_creation:type_name -> teleport.scopes.access.v1.CreateHostUser
-	11, // 9: teleport.scopes.access.v1.ScopedRoleKube.labels:type_name -> teleport.label.v1.Label
-	7,  // 10: teleport.scopes.access.v1.SSHPortForwarding.local:type_name -> teleport.scopes.access.v1.SSHLocalPortForwarding
-	8,  // 11: teleport.scopes.access.v1.SSHPortForwarding.remote:type_name -> teleport.scopes.access.v1.SSHRemotePortForwarding
-	12, // [12:12] is the sub-list for method output_type
-	12, // [12:12] is the sub-list for method input_type
-	12, // [12:12] is the sub-list for extension type_name
-	12, // [12:12] is the sub-list for extension extendee
-	0,  // [0:12] is the sub-list for field type_name
+	11, // 6: teleport.scopes.access.v1.ScopedRoleDefaults.session_recording:type_name -> teleport.scopes.access.v1.SessionRecording
+	12, // 7: teleport.scopes.access.v1.ScopedRoleDefaults.lock:type_name -> teleport.scopes.access.v1.Lock
+	14, // 8: teleport.scopes.access.v1.ScopedRoleSSH.labels:type_name -> teleport.label.v1.Label
+	6,  // 9: teleport.scopes.access.v1.ScopedRoleSSH.port_forwarding:type_name -> teleport.scopes.access.v1.SSHPortForwarding
+	9,  // 10: teleport.scopes.access.v1.ScopedRoleSSH.host_user_creation:type_name -> teleport.scopes.access.v1.CreateHostUser
+	10, // 11: teleport.scopes.access.v1.ScopedRoleSSH.enhanced_recording:type_name -> teleport.scopes.access.v1.EnhancedRecording
+	11, // 12: teleport.scopes.access.v1.ScopedRoleSSH.session_recording:type_name -> teleport.scopes.access.v1.SessionRecording
+	12, // 13: teleport.scopes.access.v1.ScopedRoleSSH.lock:type_name -> teleport.scopes.access.v1.Lock
+	14, // 14: teleport.scopes.access.v1.ScopedRoleKube.labels:type_name -> teleport.label.v1.Label
+	12, // 15: teleport.scopes.access.v1.ScopedRoleKube.lock:type_name -> teleport.scopes.access.v1.Lock
+	7,  // 16: teleport.scopes.access.v1.SSHPortForwarding.local:type_name -> teleport.scopes.access.v1.SSHLocalPortForwarding
+	8,  // 17: teleport.scopes.access.v1.SSHPortForwarding.remote:type_name -> teleport.scopes.access.v1.SSHRemotePortForwarding
+	18, // [18:18] is the sub-list for method output_type
+	18, // [18:18] is the sub-list for method input_type
+	18, // [18:18] is the sub-list for extension type_name
+	18, // [18:18] is the sub-list for extension extendee
+	0,  // [0:18] is the sub-list for field type_name
 }
 
 func init() { file_teleport_scopes_access_v1_role_proto_init() }
@@ -1343,16 +1894,19 @@ func file_teleport_scopes_access_v1_role_proto_init() {
 	if File_teleport_scopes_access_v1_role_proto != nil {
 		return
 	}
+	file_teleport_scopes_access_v1_role_proto_msgTypes[2].OneofWrappers = []any{}
 	file_teleport_scopes_access_v1_role_proto_msgTypes[3].OneofWrappers = []any{}
+	file_teleport_scopes_access_v1_role_proto_msgTypes[4].OneofWrappers = []any{}
 	file_teleport_scopes_access_v1_role_proto_msgTypes[7].OneofWrappers = []any{}
 	file_teleport_scopes_access_v1_role_proto_msgTypes[8].OneofWrappers = []any{}
+	file_teleport_scopes_access_v1_role_proto_msgTypes[10].OneofWrappers = []any{}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_teleport_scopes_access_v1_role_proto_rawDesc), len(file_teleport_scopes_access_v1_role_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   10,
+			NumMessages:   13,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/api/proto/teleport/scopes/access/v1/role.proto
+++ b/api/proto/teleport/scopes/access/v1/role.proto
@@ -85,6 +85,18 @@ message ScopedRoleDefaults {
   // ClientIdleTimeout sets the default idle timeout for access sessions across all protocols
   // that do not specify their own value. Must be a valid Go duration string (e.g. "30m", "1h").
   string client_idle_timeout = 1;
+
+  // SessionRecording configures the session recording strategy for all protocols that don't
+  // explicitly set their session recording mode.
+  SessionRecording session_recording = 2;
+
+  // DisconnectExpiredCert defines the default behavior of all protocols when certs expire for a session.
+  // If unset, cluster wide defaults are used.
+  optional bool disconnect_expired_cert = 3;
+
+  // Lock specifies the default locking mode for access sessions across all protocols that
+  // do not specify their own value. If unset, cluster wide defaults are used.
+  Lock lock = 4;
 }
 
 // ScopedRoleSSH groups all scoped role fields relevant to SSH access. Fields within the SSH block
@@ -126,6 +138,20 @@ message ScopedRoleSSH {
   // FileCopy indicates whether remote file operations via SCP or SFTP are allowed
   // over an SSH session. It defaults to allowing the user to download and upload files by default.
   optional bool file_copy = 11;
+
+  // EnhancedRecording is the set of BPF events to record for enhanced session recording.
+  EnhancedRecording enhanced_recording = 12;
+
+  // SessionRecording configures the session recording strategy for SSH sessions.
+  SessionRecording session_recording = 13;
+
+  // DisconnectExpiredCert controls whether SSH sessions are disconnected when the
+  // user certificate expires.
+  // Defaults to value cluster wide auth preference if not set.
+  optional bool disconnect_expired_cert = 14;
+
+  // Lock configures the role's locking behavior for SSH sessions.
+  Lock lock = 15;
 }
 
 // The group of all scoped role fields relevant to kube access. Fields within the kube block
@@ -150,6 +176,12 @@ message ScopedRoleKube {
   // Must be a valid Go duration string (e.g. "30m", "1h"). If empty, the defaults block value
   // (or global default) applies.
   string client_idle_timeout = 5;
+
+  // DisconnectExpiredCert controls whether Kube sessions are disconnected when the user certificate expires.
+  optional bool disconnect_expired_cert = 6;
+
+  // Lock configures the role's locking behavior for kubernetes sessions.
+  Lock lock = 7;
 }
 
 // ScopedRule maps resources to verbs. This is the underlying type used to describe
@@ -189,4 +221,28 @@ message CreateHostUser {
 
   // Shell is the shell to set for the user.
   string shell = 3;
+}
+
+// EnhancedRecording enables what events to record for the BPF-based session recorder.
+message EnhancedRecording {
+  // Command enables session.command in audit logs
+  optional bool command = 1;
+  // Network enables session.network in audit logs
+  optional bool network = 2;
+  // Disk enables session.disk in audit logs
+  optional bool disk = 3;
+}
+
+// SessionRecording sets the session recording behavior.
+message SessionRecording {
+  // Mode sets the session recording mode. Allowed values: strict or best_effort.
+  string mode = 1;
+}
+
+// Lock controls locking mode for sessions authorized via this
+// scoped role.
+message Lock {
+  // Allowed values: strict or best_effort.
+  // Defaults to value cluster wide auth preference if not set.
+  string mode = 1;
 }

--- a/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-scopedrolesv1.mdx
+++ b/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-scopedrolesv1.mdx
@@ -37,14 +37,31 @@ resource, which you can apply after installing the Teleport Kubernetes operator.
 |Field|Type|Description|
 |---|---|---|
 |client_idle_timeout|string|ClientIdleTimeout sets the default idle timeout for access sessions across all protocols that do not specify their own value. Must be a valid Go duration string (e.g. "30m", "1h").|
+|disconnect_expired_cert|boolean|DisconnectExpiredCert defines the default behavior of all protocols when certs expire for a session. If unset, cluster wide defaults are used.|
+|lock|[object](#specdefaultslock)|Lock specifies the default locking mode for access sessions across all protocols that do not specify their own value. If unset, cluster wide defaults are used.|
+|session_recording|[object](#specdefaultssession_recording)|SessionRecording configures the session recording strategy for all protocols that don't explicitly set their session recording mode.|
+
+### spec.defaults.lock
+
+|Field|Type|Description|
+|---|---|---|
+|mode|string|Allowed values: strict or best_effort. Defaults to value cluster wide auth preference if not set.|
+
+### spec.defaults.session_recording
+
+|Field|Type|Description|
+|---|---|---|
+|mode|string|Mode sets the session recording mode. Allowed values: strict or best_effort.|
 
 ### spec.kube
 
 |Field|Type|Description|
 |---|---|---|
 |client_idle_timeout|string|Overrides the defaults block idle timeout specifically for kube sessions. Must be a valid Go duration string (e.g. "30m", "1h"). If empty, the defaults block value (or global default) applies.|
+|disconnect_expired_cert|boolean|DisconnectExpiredCert controls whether Kube sessions are disconnected when the user certificate expires.|
 |groups|[]string|The list of kubernetes groups this role allows.|
 |labels|[][object](#speckubelabels-items)|The map of kubernetes cluster labels used for RBAC.|
+|lock|[object](#speckubelock)|Lock configures the role's locking behavior for kubernetes sessions.|
 |users|[]string|An optional list of impersonatable kubernetes users this role allows.|
 
 ### spec.kube.labels items
@@ -53,6 +70,12 @@ resource, which you can apply after installing the Teleport Kubernetes operator.
 |---|---|---|
 |name|string|The name of the label.|
 |values|[]string|The values associated with the label.|
+
+### spec.kube.lock
+
+|Field|Type|Description|
+|---|---|---|
+|mode|string|Allowed values: strict or best_effort. Defaults to value cluster wide auth preference if not set.|
 
 ### spec.rules items
 
@@ -66,15 +89,27 @@ resource, which you can apply after installing the Teleport Kubernetes operator.
 |Field|Type|Description|
 |---|---|---|
 |client_idle_timeout|string|ClientIdleTimeout overrides the defaults block idle timeout specifically for SSH sessions. Must be a valid Go duration string (e.g. "30m", "1h"). If empty, the defaults block value (or global default) applies.|
+|disconnect_expired_cert|boolean|DisconnectExpiredCert controls whether SSH sessions are disconnected when the user certificate expires. Defaults to value cluster wide auth preference if not set.|
+|enhanced_recording|[object](#specsshenhanced_recording)|EnhancedRecording is the set of BPF events to record for enhanced session recording.|
 |file_copy|boolean|FileCopy indicates whether remote file operations via SCP or SFTP are allowed over an SSH session. It defaults to allowing the user to download and upload files by default.|
 |forward_agent|boolean|ForwardAgent enables SSH agent forwarding.|
 |host_sudoers|[]string|Sudoers is a list of entries to include in a users sudoer file|
 |host_user_creation|[object](#specsshhost_user_creation)|HostUserCreation configures the creation of host users.|
 |labels|[][object](#specsshlabels-items)|Labels is the set of node labels used to dynamically select which nodes this role applies to.|
+|lock|[object](#specsshlock)|Lock configures the role's locking behavior for SSH sessions.|
 |logins|[]string|Logins is the list of OS logins this role permits on matching nodes.|
 |max_sessions|integer|MaxSessions defines the maximum number of concurrent sessions per connection.|
 |permit_x11_forwarding|boolean|PermitX11Forwarding, when true, authorizes use of X11 forwarding over SSH sessions. If not set, X11 forwarding is not permitted.|
 |port_forwarding|[object](#specsshport_forwarding)|SSHPortForwarding configures what types of SSH port forwarding are allowed by a role.|
+|session_recording|[object](#specsshsession_recording)|SessionRecording configures the session recording strategy for SSH sessions.|
+
+### spec.ssh.enhanced_recording
+
+|Field|Type|Description|
+|---|---|---|
+|command|boolean|Command enables session.command in audit logs|
+|disk|boolean|Disk enables session.disk in audit logs|
+|network|boolean|Network enables session.network in audit logs|
 
 ### spec.ssh.host_user_creation
 
@@ -90,6 +125,12 @@ resource, which you can apply after installing the Teleport Kubernetes operator.
 |---|---|---|
 |name|string|The name of the label.|
 |values|[]string|The values associated with the label.|
+
+### spec.ssh.lock
+
+|Field|Type|Description|
+|---|---|---|
+|mode|string|Allowed values: strict or best_effort. Defaults to value cluster wide auth preference if not set.|
 
 ### spec.ssh.port_forwarding
 
@@ -109,4 +150,10 @@ resource, which you can apply after installing the Teleport Kubernetes operator.
 |Field|Type|Description|
 |---|---|---|
 |enabled|boolean||
+
+### spec.ssh.session_recording
+
+|Field|Type|Description|
+|---|---|---|
+|mode|string|Mode sets the session recording mode. Allowed values: strict or best_effort.|
 

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/scoped_role.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/scoped_role.mdx
@@ -59,6 +59,23 @@ Optional:
 Optional:
 
 - `client_idle_timeout` (String) ClientIdleTimeout sets the default idle timeout for access sessions across all protocols that do not specify their own value. Must be a valid Go duration string (e.g. "30m", "1h").
+- `disconnect_expired_cert` (Boolean) DisconnectExpiredCert defines the default behavior of all protocols when certs expire for a session. If unset, cluster wide defaults are used.
+- `lock` (Attributes) Lock specifies the default locking mode for access sessions across all protocols that do not specify their own value. If unset, cluster wide defaults are used. (see [below for nested schema](#nested-schema-for-specdefaultslock))
+- `session_recording` (Attributes) SessionRecording configures the session recording strategy for all protocols that don't explicitly set their session recording mode. (see [below for nested schema](#nested-schema-for-specdefaultssession_recording))
+
+### Nested Schema for `spec.defaults.lock`
+
+Optional:
+
+- `mode` (String) Allowed values: strict or best_effort. Defaults to value cluster wide auth preference if not set.
+
+
+### Nested Schema for `spec.defaults.session_recording`
+
+Optional:
+
+- `mode` (String) Mode sets the session recording mode. Allowed values: strict or best_effort.
+
 
 
 ### Nested Schema for `spec.kube`
@@ -66,8 +83,10 @@ Optional:
 Optional:
 
 - `client_idle_timeout` (String) Overrides the defaults block idle timeout specifically for kube sessions. Must be a valid Go duration string (e.g. "30m", "1h"). If empty, the defaults block value (or global default) applies.
+- `disconnect_expired_cert` (Boolean) DisconnectExpiredCert controls whether Kube sessions are disconnected when the user certificate expires.
 - `groups` (List of String) The list of kubernetes groups this role allows.
 - `labels` (Attributes List) The map of kubernetes cluster labels used for RBAC. (see [below for nested schema](#nested-schema-for-speckubelabels))
+- `lock` (Attributes) Lock configures the role's locking behavior for kubernetes sessions. (see [below for nested schema](#nested-schema-for-speckubelock))
 - `users` (List of String) An optional list of impersonatable kubernetes users this role allows.
 
 ### Nested Schema for `spec.kube.labels`
@@ -76,6 +95,13 @@ Optional:
 
 - `name` (String) The name of the label.
 - `values` (List of String) The values associated with the label.
+
+
+### Nested Schema for `spec.kube.lock`
+
+Optional:
+
+- `mode` (String) Allowed values: strict or best_effort. Defaults to value cluster wide auth preference if not set.
 
 
 
@@ -92,15 +118,28 @@ Optional:
 Optional:
 
 - `client_idle_timeout` (String) ClientIdleTimeout overrides the defaults block idle timeout specifically for SSH sessions. Must be a valid Go duration string (e.g. "30m", "1h"). If empty, the defaults block value (or global default) applies.
+- `disconnect_expired_cert` (Boolean) DisconnectExpiredCert controls whether SSH sessions are disconnected when the user certificate expires. Defaults to value cluster wide auth preference if not set.
+- `enhanced_recording` (Attributes) EnhancedRecording is the set of BPF events to record for enhanced session recording. (see [below for nested schema](#nested-schema-for-specsshenhanced_recording))
 - `file_copy` (Boolean) FileCopy indicates whether remote file operations via SCP or SFTP are allowed over an SSH session. It defaults to allowing the user to download and upload files by default.
 - `forward_agent` (Boolean) ForwardAgent enables SSH agent forwarding.
 - `host_sudoers` (List of String) Sudoers is a list of entries to include in a users sudoer file
 - `host_user_creation` (Attributes) HostUserCreation configures the creation of host users. (see [below for nested schema](#nested-schema-for-specsshhost_user_creation))
 - `labels` (Attributes List) Labels is the set of node labels used to dynamically select which nodes this role applies to. (see [below for nested schema](#nested-schema-for-specsshlabels))
+- `lock` (Attributes) Lock configures the role's locking behavior for SSH sessions. (see [below for nested schema](#nested-schema-for-specsshlock))
 - `logins` (List of String) Logins is the list of OS logins this role permits on matching nodes.
 - `max_sessions` (Number) MaxSessions defines the maximum number of concurrent sessions per connection.
 - `permit_x11_forwarding` (Boolean) PermitX11Forwarding, when true, authorizes use of X11 forwarding over SSH sessions. If not set, X11 forwarding is not permitted.
 - `port_forwarding` (Attributes) SSHPortForwarding configures what types of SSH port forwarding are allowed by a role. (see [below for nested schema](#nested-schema-for-specsshport_forwarding))
+- `session_recording` (Attributes) SessionRecording configures the session recording strategy for SSH sessions. (see [below for nested schema](#nested-schema-for-specsshsession_recording))
+
+### Nested Schema for `spec.ssh.enhanced_recording`
+
+Optional:
+
+- `command` (Boolean) Command enables session.command in audit logs
+- `disk` (Boolean) Disk enables session.disk in audit logs
+- `network` (Boolean) Network enables session.network in audit logs
+
 
 ### Nested Schema for `spec.ssh.host_user_creation`
 
@@ -117,6 +156,13 @@ Optional:
 
 - `name` (String) The name of the label.
 - `values` (List of String) The values associated with the label.
+
+
+### Nested Schema for `spec.ssh.lock`
+
+Optional:
+
+- `mode` (String) Allowed values: strict or best_effort. Defaults to value cluster wide auth preference if not set.
 
 
 ### Nested Schema for `spec.ssh.port_forwarding`
@@ -138,4 +184,12 @@ Optional:
 Optional:
 
 - `enabled` (Boolean)
+
+
+
+### Nested Schema for `spec.ssh.session_recording`
+
+Optional:
+
+- `mode` (String) Mode sets the session recording mode. Allowed values: strict or best_effort.
 

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/scoped_role.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/scoped_role.mdx
@@ -88,6 +88,23 @@ Optional:
 Optional:
 
 - `client_idle_timeout` (String) ClientIdleTimeout sets the default idle timeout for access sessions across all protocols that do not specify their own value. Must be a valid Go duration string (e.g. "30m", "1h").
+- `disconnect_expired_cert` (Boolean) DisconnectExpiredCert defines the default behavior of all protocols when certs expire for a session. If unset, cluster wide defaults are used.
+- `lock` (Attributes) Lock specifies the default locking mode for access sessions across all protocols that do not specify their own value. If unset, cluster wide defaults are used. (see [below for nested schema](#nested-schema-for-specdefaultslock))
+- `session_recording` (Attributes) SessionRecording configures the session recording strategy for all protocols that don't explicitly set their session recording mode. (see [below for nested schema](#nested-schema-for-specdefaultssession_recording))
+
+### Nested Schema for `spec.defaults.lock`
+
+Optional:
+
+- `mode` (String) Allowed values: strict or best_effort. Defaults to value cluster wide auth preference if not set.
+
+
+### Nested Schema for `spec.defaults.session_recording`
+
+Optional:
+
+- `mode` (String) Mode sets the session recording mode. Allowed values: strict or best_effort.
+
 
 
 ### Nested Schema for `spec.kube`
@@ -95,8 +112,10 @@ Optional:
 Optional:
 
 - `client_idle_timeout` (String) Overrides the defaults block idle timeout specifically for kube sessions. Must be a valid Go duration string (e.g. "30m", "1h"). If empty, the defaults block value (or global default) applies.
+- `disconnect_expired_cert` (Boolean) DisconnectExpiredCert controls whether Kube sessions are disconnected when the user certificate expires.
 - `groups` (List of String) The list of kubernetes groups this role allows.
 - `labels` (Attributes List) The map of kubernetes cluster labels used for RBAC. (see [below for nested schema](#nested-schema-for-speckubelabels))
+- `lock` (Attributes) Lock configures the role's locking behavior for kubernetes sessions. (see [below for nested schema](#nested-schema-for-speckubelock))
 - `users` (List of String) An optional list of impersonatable kubernetes users this role allows.
 
 ### Nested Schema for `spec.kube.labels`
@@ -105,6 +124,13 @@ Optional:
 
 - `name` (String) The name of the label.
 - `values` (List of String) The values associated with the label.
+
+
+### Nested Schema for `spec.kube.lock`
+
+Optional:
+
+- `mode` (String) Allowed values: strict or best_effort. Defaults to value cluster wide auth preference if not set.
 
 
 
@@ -121,15 +147,28 @@ Optional:
 Optional:
 
 - `client_idle_timeout` (String) ClientIdleTimeout overrides the defaults block idle timeout specifically for SSH sessions. Must be a valid Go duration string (e.g. "30m", "1h"). If empty, the defaults block value (or global default) applies.
+- `disconnect_expired_cert` (Boolean) DisconnectExpiredCert controls whether SSH sessions are disconnected when the user certificate expires. Defaults to value cluster wide auth preference if not set.
+- `enhanced_recording` (Attributes) EnhancedRecording is the set of BPF events to record for enhanced session recording. (see [below for nested schema](#nested-schema-for-specsshenhanced_recording))
 - `file_copy` (Boolean) FileCopy indicates whether remote file operations via SCP or SFTP are allowed over an SSH session. It defaults to allowing the user to download and upload files by default.
 - `forward_agent` (Boolean) ForwardAgent enables SSH agent forwarding.
 - `host_sudoers` (List of String) Sudoers is a list of entries to include in a users sudoer file
 - `host_user_creation` (Attributes) HostUserCreation configures the creation of host users. (see [below for nested schema](#nested-schema-for-specsshhost_user_creation))
 - `labels` (Attributes List) Labels is the set of node labels used to dynamically select which nodes this role applies to. (see [below for nested schema](#nested-schema-for-specsshlabels))
+- `lock` (Attributes) Lock configures the role's locking behavior for SSH sessions. (see [below for nested schema](#nested-schema-for-specsshlock))
 - `logins` (List of String) Logins is the list of OS logins this role permits on matching nodes.
 - `max_sessions` (Number) MaxSessions defines the maximum number of concurrent sessions per connection.
 - `permit_x11_forwarding` (Boolean) PermitX11Forwarding, when true, authorizes use of X11 forwarding over SSH sessions. If not set, X11 forwarding is not permitted.
 - `port_forwarding` (Attributes) SSHPortForwarding configures what types of SSH port forwarding are allowed by a role. (see [below for nested schema](#nested-schema-for-specsshport_forwarding))
+- `session_recording` (Attributes) SessionRecording configures the session recording strategy for SSH sessions. (see [below for nested schema](#nested-schema-for-specsshsession_recording))
+
+### Nested Schema for `spec.ssh.enhanced_recording`
+
+Optional:
+
+- `command` (Boolean) Command enables session.command in audit logs
+- `disk` (Boolean) Disk enables session.disk in audit logs
+- `network` (Boolean) Network enables session.network in audit logs
+
 
 ### Nested Schema for `spec.ssh.host_user_creation`
 
@@ -146,6 +185,13 @@ Optional:
 
 - `name` (String) The name of the label.
 - `values` (List of String) The values associated with the label.
+
+
+### Nested Schema for `spec.ssh.lock`
+
+Optional:
+
+- `mode` (String) Allowed values: strict or best_effort. Defaults to value cluster wide auth preference if not set.
 
 
 ### Nested Schema for `spec.ssh.port_forwarding`
@@ -167,3 +213,11 @@ Optional:
 Optional:
 
 - `enabled` (Boolean)
+
+
+
+### Nested Schema for `spec.ssh.session_recording`
+
+Optional:
+
+- `mode` (String) Mode sets the session recording mode. Allowed values: strict or best_effort.

--- a/examples/chart/teleport-cluster/charts/teleport-operator/operator-crds/resources.teleport.dev_scopedrolesv1.yaml
+++ b/examples/chart/teleport-cluster/charts/teleport-operator/operator-crds/resources.teleport.dev_scopedrolesv1.yaml
@@ -61,6 +61,33 @@ spec:
                       access sessions across all protocols that do not specify their
                       own value. Must be a valid Go duration string (e.g. "30m", "1h").
                     type: string
+                  disconnect_expired_cert:
+                    description: DisconnectExpiredCert defines the default behavior
+                      of all protocols when certs expire for a session. If unset,
+                      cluster wide defaults are used.
+                    type: boolean
+                  lock:
+                    description: Lock specifies the default locking mode for access
+                      sessions across all protocols that do not specify their own
+                      value. If unset, cluster wide defaults are used.
+                    nullable: true
+                    properties:
+                      mode:
+                        description: 'Allowed values: strict or best_effort. Defaults
+                          to value cluster wide auth preference if not set.'
+                        type: string
+                    type: object
+                  session_recording:
+                    description: SessionRecording configures the session recording
+                      strategy for all protocols that don't explicitly set their session
+                      recording mode.
+                    nullable: true
+                    properties:
+                      mode:
+                        description: 'Mode sets the session recording mode. Allowed
+                          values: strict or best_effort.'
+                        type: string
+                    type: object
                 type: object
               kube:
                 description: The kubernetes specific configuration for a scoped role.
@@ -72,6 +99,10 @@ spec:
                       "30m", "1h"). If empty, the defaults block value (or global
                       default) applies.
                     type: string
+                  disconnect_expired_cert:
+                    description: DisconnectExpiredCert controls whether Kube sessions
+                      are disconnected when the user certificate expires.
+                    type: boolean
                   groups:
                     description: The list of kubernetes groups this role allows.
                     items:
@@ -94,6 +125,16 @@ spec:
                       type: object
                     nullable: true
                     type: array
+                  lock:
+                    description: Lock configures the role's locking behavior for kubernetes
+                      sessions.
+                    nullable: true
+                    properties:
+                      mode:
+                        description: 'Allowed values: strict or best_effort. Defaults
+                          to value cluster wide auth preference if not set.'
+                        type: string
+                    type: object
                   users:
                     description: An optional list of impersonatable kubernetes users
                       this role allows.
@@ -134,6 +175,26 @@ spec:
                       string (e.g. "30m", "1h"). If empty, the defaults block value
                       (or global default) applies.
                     type: string
+                  disconnect_expired_cert:
+                    description: DisconnectExpiredCert controls whether SSH sessions
+                      are disconnected when the user certificate expires. Defaults
+                      to value cluster wide auth preference if not set.
+                    type: boolean
+                  enhanced_recording:
+                    description: EnhancedRecording is the set of BPF events to record
+                      for enhanced session recording.
+                    nullable: true
+                    properties:
+                      command:
+                        description: Command enables session.command in audit logs
+                        type: boolean
+                      disk:
+                        description: Disk enables session.disk in audit logs
+                        type: boolean
+                      network:
+                        description: Network enables session.network in audit logs
+                        type: boolean
+                    type: object
                   file_copy:
                     description: FileCopy indicates whether remote file operations
                       via SCP or SFTP are allowed over an SSH session. It defaults
@@ -185,6 +246,16 @@ spec:
                       type: object
                     nullable: true
                     type: array
+                  lock:
+                    description: Lock configures the role's locking behavior for SSH
+                      sessions.
+                    nullable: true
+                    properties:
+                      mode:
+                        description: 'Allowed values: strict or best_effort. Defaults
+                          to value cluster wide auth preference if not set.'
+                        type: string
+                    type: object
                   logins:
                     description: Logins is the list of OS logins this role permits
                       on matching nodes.
@@ -221,6 +292,16 @@ spec:
                           enabled:
                             type: boolean
                         type: object
+                    type: object
+                  session_recording:
+                    description: SessionRecording configures the session recording
+                      strategy for SSH sessions.
+                    nullable: true
+                    properties:
+                      mode:
+                        description: 'Mode sets the session recording mode. Allowed
+                          values: strict or best_effort.'
+                        type: string
                     type: object
                 type: object
             type: object

--- a/integrations/operator/config/crd/bases/resources.teleport.dev_scopedrolesv1.yaml
+++ b/integrations/operator/config/crd/bases/resources.teleport.dev_scopedrolesv1.yaml
@@ -61,6 +61,33 @@ spec:
                       access sessions across all protocols that do not specify their
                       own value. Must be a valid Go duration string (e.g. "30m", "1h").
                     type: string
+                  disconnect_expired_cert:
+                    description: DisconnectExpiredCert defines the default behavior
+                      of all protocols when certs expire for a session. If unset,
+                      cluster wide defaults are used.
+                    type: boolean
+                  lock:
+                    description: Lock specifies the default locking mode for access
+                      sessions across all protocols that do not specify their own
+                      value. If unset, cluster wide defaults are used.
+                    nullable: true
+                    properties:
+                      mode:
+                        description: 'Allowed values: strict or best_effort. Defaults
+                          to value cluster wide auth preference if not set.'
+                        type: string
+                    type: object
+                  session_recording:
+                    description: SessionRecording configures the session recording
+                      strategy for all protocols that don't explicitly set their session
+                      recording mode.
+                    nullable: true
+                    properties:
+                      mode:
+                        description: 'Mode sets the session recording mode. Allowed
+                          values: strict or best_effort.'
+                        type: string
+                    type: object
                 type: object
               kube:
                 description: The kubernetes specific configuration for a scoped role.
@@ -72,6 +99,10 @@ spec:
                       "30m", "1h"). If empty, the defaults block value (or global
                       default) applies.
                     type: string
+                  disconnect_expired_cert:
+                    description: DisconnectExpiredCert controls whether Kube sessions
+                      are disconnected when the user certificate expires.
+                    type: boolean
                   groups:
                     description: The list of kubernetes groups this role allows.
                     items:
@@ -94,6 +125,16 @@ spec:
                       type: object
                     nullable: true
                     type: array
+                  lock:
+                    description: Lock configures the role's locking behavior for kubernetes
+                      sessions.
+                    nullable: true
+                    properties:
+                      mode:
+                        description: 'Allowed values: strict or best_effort. Defaults
+                          to value cluster wide auth preference if not set.'
+                        type: string
+                    type: object
                   users:
                     description: An optional list of impersonatable kubernetes users
                       this role allows.
@@ -134,6 +175,26 @@ spec:
                       string (e.g. "30m", "1h"). If empty, the defaults block value
                       (or global default) applies.
                     type: string
+                  disconnect_expired_cert:
+                    description: DisconnectExpiredCert controls whether SSH sessions
+                      are disconnected when the user certificate expires. Defaults
+                      to value cluster wide auth preference if not set.
+                    type: boolean
+                  enhanced_recording:
+                    description: EnhancedRecording is the set of BPF events to record
+                      for enhanced session recording.
+                    nullable: true
+                    properties:
+                      command:
+                        description: Command enables session.command in audit logs
+                        type: boolean
+                      disk:
+                        description: Disk enables session.disk in audit logs
+                        type: boolean
+                      network:
+                        description: Network enables session.network in audit logs
+                        type: boolean
+                    type: object
                   file_copy:
                     description: FileCopy indicates whether remote file operations
                       via SCP or SFTP are allowed over an SSH session. It defaults
@@ -185,6 +246,16 @@ spec:
                       type: object
                     nullable: true
                     type: array
+                  lock:
+                    description: Lock configures the role's locking behavior for SSH
+                      sessions.
+                    nullable: true
+                    properties:
+                      mode:
+                        description: 'Allowed values: strict or best_effort. Defaults
+                          to value cluster wide auth preference if not set.'
+                        type: string
+                    type: object
                   logins:
                     description: Logins is the list of OS logins this role permits
                       on matching nodes.
@@ -221,6 +292,16 @@ spec:
                           enabled:
                             type: boolean
                         type: object
+                    type: object
+                  session_recording:
+                    description: SessionRecording configures the session recording
+                      strategy for SSH sessions.
+                    nullable: true
+                    properties:
+                      mode:
+                        description: 'Mode sets the session recording mode. Allowed
+                          values: strict or best_effort.'
+                        type: string
                     type: object
                 type: object
             type: object

--- a/integrations/terraform/tfschema/scopes/access/v1/role_terraform.go
+++ b/integrations/terraform/tfschema/scopes/access/v1/role_terraform.go
@@ -115,11 +115,36 @@ func GenSchemaScopedRole(ctx context.Context) (github_com_hashicorp_terraform_pl
 					Type:        github_com_hashicorp_terraform_plugin_framework_types.ListType{ElemType: github_com_hashicorp_terraform_plugin_framework_types.StringType},
 				},
 				"defaults": {
-					Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.SingleNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{"client_idle_timeout": {
-						Description: "ClientIdleTimeout sets the default idle timeout for access sessions across all protocols that do not specify their own value. Must be a valid Go duration string (e.g. \"30m\", \"1h\").",
-						Optional:    true,
-						Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
-					}}),
+					Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.SingleNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
+						"client_idle_timeout": {
+							Description: "ClientIdleTimeout sets the default idle timeout for access sessions across all protocols that do not specify their own value. Must be a valid Go duration string (e.g. \"30m\", \"1h\").",
+							Optional:    true,
+							Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
+						},
+						"disconnect_expired_cert": {
+							Description: "DisconnectExpiredCert defines the default behavior of all protocols when certs expire for a session. If unset, cluster wide defaults are used.",
+							Optional:    true,
+							Type:        github_com_hashicorp_terraform_plugin_framework_types.BoolType,
+						},
+						"lock": {
+							Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.SingleNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{"mode": {
+								Description: "Allowed values: strict or best_effort. Defaults to value cluster wide auth preference if not set.",
+								Optional:    true,
+								Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
+							}}),
+							Description: "Lock specifies the default locking mode for access sessions across all protocols that do not specify their own value. If unset, cluster wide defaults are used.",
+							Optional:    true,
+						},
+						"session_recording": {
+							Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.SingleNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{"mode": {
+								Description: "Mode sets the session recording mode. Allowed values: strict or best_effort.",
+								Optional:    true,
+								Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
+							}}),
+							Description: "SessionRecording configures the session recording strategy for all protocols that don't explicitly set their session recording mode.",
+							Optional:    true,
+						},
+					}),
 					Description: "Defaults specifies default values for controls common across multiple protocols. If the same control specified in defaults is also specified in a protocol block, the value in the protocol block takes precedence.",
 					Optional:    true,
 				},
@@ -129,6 +154,11 @@ func GenSchemaScopedRole(ctx context.Context) (github_com_hashicorp_terraform_pl
 							Description: "Overrides the defaults block idle timeout specifically for kube sessions. Must be a valid Go duration string (e.g. \"30m\", \"1h\"). If empty, the defaults block value (or global default) applies.",
 							Optional:    true,
 							Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
+						},
+						"disconnect_expired_cert": {
+							Description: "DisconnectExpiredCert controls whether Kube sessions are disconnected when the user certificate expires.",
+							Optional:    true,
+							Type:        github_com_hashicorp_terraform_plugin_framework_types.BoolType,
 						},
 						"groups": {
 							Description: "The list of kubernetes groups this role allows.",
@@ -149,6 +179,15 @@ func GenSchemaScopedRole(ctx context.Context) (github_com_hashicorp_terraform_pl
 								},
 							}),
 							Description: "The map of kubernetes cluster labels used for RBAC.",
+							Optional:    true,
+						},
+						"lock": {
+							Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.SingleNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{"mode": {
+								Description: "Allowed values: strict or best_effort. Defaults to value cluster wide auth preference if not set.",
+								Optional:    true,
+								Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
+							}}),
+							Description: "Lock configures the role's locking behavior for kubernetes sessions.",
 							Optional:    true,
 						},
 						"users": {
@@ -182,6 +221,32 @@ func GenSchemaScopedRole(ctx context.Context) (github_com_hashicorp_terraform_pl
 							Description: "ClientIdleTimeout overrides the defaults block idle timeout specifically for SSH sessions. Must be a valid Go duration string (e.g. \"30m\", \"1h\"). If empty, the defaults block value (or global default) applies.",
 							Optional:    true,
 							Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
+						},
+						"disconnect_expired_cert": {
+							Description: "DisconnectExpiredCert controls whether SSH sessions are disconnected when the user certificate expires. Defaults to value cluster wide auth preference if not set.",
+							Optional:    true,
+							Type:        github_com_hashicorp_terraform_plugin_framework_types.BoolType,
+						},
+						"enhanced_recording": {
+							Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.SingleNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
+								"command": {
+									Description: "Command enables session.command in audit logs",
+									Optional:    true,
+									Type:        github_com_hashicorp_terraform_plugin_framework_types.BoolType,
+								},
+								"disk": {
+									Description: "Disk enables session.disk in audit logs",
+									Optional:    true,
+									Type:        github_com_hashicorp_terraform_plugin_framework_types.BoolType,
+								},
+								"network": {
+									Description: "Network enables session.network in audit logs",
+									Optional:    true,
+									Type:        github_com_hashicorp_terraform_plugin_framework_types.BoolType,
+								},
+							}),
+							Description: "EnhancedRecording is the set of BPF events to record for enhanced session recording.",
+							Optional:    true,
 						},
 						"file_copy": {
 							Description: "FileCopy indicates whether remote file operations via SCP or SFTP are allowed over an SSH session. It defaults to allowing the user to download and upload files by default.",
@@ -235,6 +300,15 @@ func GenSchemaScopedRole(ctx context.Context) (github_com_hashicorp_terraform_pl
 							Description: "Labels is the set of node labels used to dynamically select which nodes this role applies to.",
 							Optional:    true,
 						},
+						"lock": {
+							Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.SingleNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{"mode": {
+								Description: "Allowed values: strict or best_effort. Defaults to value cluster wide auth preference if not set.",
+								Optional:    true,
+								Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
+							}}),
+							Description: "Lock configures the role's locking behavior for SSH sessions.",
+							Optional:    true,
+						},
 						"logins": {
 							Description: "Logins is the list of OS logins this role permits on matching nodes.",
 							Optional:    true,
@@ -272,6 +346,15 @@ func GenSchemaScopedRole(ctx context.Context) (github_com_hashicorp_terraform_pl
 								},
 							}),
 							Description: "SSHPortForwarding configures what types of SSH port forwarding are allowed by a role.",
+							Optional:    true,
+						},
+						"session_recording": {
+							Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.SingleNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{"mode": {
+								Description: "Mode sets the session recording mode. Allowed values: strict or best_effort.",
+								Optional:    true,
+								Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
+							}}),
+							Description: "SessionRecording configures the session recording strategy for SSH sessions.",
 							Optional:    true,
 						},
 					}),
@@ -555,6 +638,94 @@ func CopyScopedRoleFromTerraform(_ context.Context, tf github_com_hashicorp_terr
 													t = string(v.Value)
 												}
 												obj.ClientIdleTimeout = t
+											}
+										}
+									}
+									{
+										a, ok := tf.Attrs["session_recording"]
+										if !ok {
+											diags.Append(attrReadMissingDiag{"ScopedRole.spec.defaults.session_recording"})
+										} else {
+											v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.Object)
+											if !ok {
+												diags.Append(attrReadConversionFailureDiag{"ScopedRole.spec.defaults.session_recording", "github.com/hashicorp/terraform-plugin-framework/types.Object"})
+											} else {
+												obj.SessionRecording = nil
+												if !v.Null && !v.Unknown {
+													tf := v
+													obj.SessionRecording = &github_com_gravitational_teleport_api_gen_proto_go_teleport_scopes_access_v1.SessionRecording{}
+													obj := obj.SessionRecording
+													{
+														a, ok := tf.Attrs["mode"]
+														if !ok {
+															diags.Append(attrReadMissingDiag{"ScopedRole.spec.defaults.session_recording.mode"})
+														} else {
+															v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.String)
+															if !ok {
+																diags.Append(attrReadConversionFailureDiag{"ScopedRole.spec.defaults.session_recording.mode", "github.com/hashicorp/terraform-plugin-framework/types.String"})
+															} else {
+																var t string
+																if !v.Null && !v.Unknown {
+																	t = string(v.Value)
+																}
+																obj.Mode = t
+															}
+														}
+													}
+												}
+											}
+										}
+									}
+									{
+										a, ok := tf.Attrs["disconnect_expired_cert"]
+										if !ok {
+											diags.Append(attrReadMissingDiag{"ScopedRole.spec.defaults.disconnect_expired_cert"})
+										} else {
+											v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.Bool)
+											if !ok {
+												diags.Append(attrReadConversionFailureDiag{"ScopedRole.spec.defaults.disconnect_expired_cert", "github.com/hashicorp/terraform-plugin-framework/types.Bool"})
+											} else {
+												var t *bool
+												if !v.Null && !v.Unknown {
+													c := bool(v.Value)
+													t = &c
+												}
+												obj.DisconnectExpiredCert = t
+											}
+										}
+									}
+									{
+										a, ok := tf.Attrs["lock"]
+										if !ok {
+											diags.Append(attrReadMissingDiag{"ScopedRole.spec.defaults.lock"})
+										} else {
+											v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.Object)
+											if !ok {
+												diags.Append(attrReadConversionFailureDiag{"ScopedRole.spec.defaults.lock", "github.com/hashicorp/terraform-plugin-framework/types.Object"})
+											} else {
+												obj.Lock = nil
+												if !v.Null && !v.Unknown {
+													tf := v
+													obj.Lock = &github_com_gravitational_teleport_api_gen_proto_go_teleport_scopes_access_v1.Lock{}
+													obj := obj.Lock
+													{
+														a, ok := tf.Attrs["mode"]
+														if !ok {
+															diags.Append(attrReadMissingDiag{"ScopedRole.spec.defaults.lock.mode"})
+														} else {
+															v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.String)
+															if !ok {
+																diags.Append(attrReadConversionFailureDiag{"ScopedRole.spec.defaults.lock.mode", "github.com/hashicorp/terraform-plugin-framework/types.String"})
+															} else {
+																var t string
+																if !v.Null && !v.Unknown {
+																	t = string(v.Value)
+																}
+																obj.Mode = t
+															}
+														}
+													}
+												}
 											}
 										}
 									}
@@ -1044,6 +1215,166 @@ func CopyScopedRoleFromTerraform(_ context.Context, tf github_com_hashicorp_terr
 											}
 										}
 									}
+									{
+										a, ok := tf.Attrs["enhanced_recording"]
+										if !ok {
+											diags.Append(attrReadMissingDiag{"ScopedRole.spec.ssh.enhanced_recording"})
+										} else {
+											v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.Object)
+											if !ok {
+												diags.Append(attrReadConversionFailureDiag{"ScopedRole.spec.ssh.enhanced_recording", "github.com/hashicorp/terraform-plugin-framework/types.Object"})
+											} else {
+												obj.EnhancedRecording = nil
+												if !v.Null && !v.Unknown {
+													tf := v
+													obj.EnhancedRecording = &github_com_gravitational_teleport_api_gen_proto_go_teleport_scopes_access_v1.EnhancedRecording{}
+													obj := obj.EnhancedRecording
+													{
+														a, ok := tf.Attrs["command"]
+														if !ok {
+															diags.Append(attrReadMissingDiag{"ScopedRole.spec.ssh.enhanced_recording.command"})
+														} else {
+															v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.Bool)
+															if !ok {
+																diags.Append(attrReadConversionFailureDiag{"ScopedRole.spec.ssh.enhanced_recording.command", "github.com/hashicorp/terraform-plugin-framework/types.Bool"})
+															} else {
+																var t *bool
+																if !v.Null && !v.Unknown {
+																	c := bool(v.Value)
+																	t = &c
+																}
+																obj.Command = t
+															}
+														}
+													}
+													{
+														a, ok := tf.Attrs["network"]
+														if !ok {
+															diags.Append(attrReadMissingDiag{"ScopedRole.spec.ssh.enhanced_recording.network"})
+														} else {
+															v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.Bool)
+															if !ok {
+																diags.Append(attrReadConversionFailureDiag{"ScopedRole.spec.ssh.enhanced_recording.network", "github.com/hashicorp/terraform-plugin-framework/types.Bool"})
+															} else {
+																var t *bool
+																if !v.Null && !v.Unknown {
+																	c := bool(v.Value)
+																	t = &c
+																}
+																obj.Network = t
+															}
+														}
+													}
+													{
+														a, ok := tf.Attrs["disk"]
+														if !ok {
+															diags.Append(attrReadMissingDiag{"ScopedRole.spec.ssh.enhanced_recording.disk"})
+														} else {
+															v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.Bool)
+															if !ok {
+																diags.Append(attrReadConversionFailureDiag{"ScopedRole.spec.ssh.enhanced_recording.disk", "github.com/hashicorp/terraform-plugin-framework/types.Bool"})
+															} else {
+																var t *bool
+																if !v.Null && !v.Unknown {
+																	c := bool(v.Value)
+																	t = &c
+																}
+																obj.Disk = t
+															}
+														}
+													}
+												}
+											}
+										}
+									}
+									{
+										a, ok := tf.Attrs["session_recording"]
+										if !ok {
+											diags.Append(attrReadMissingDiag{"ScopedRole.spec.ssh.session_recording"})
+										} else {
+											v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.Object)
+											if !ok {
+												diags.Append(attrReadConversionFailureDiag{"ScopedRole.spec.ssh.session_recording", "github.com/hashicorp/terraform-plugin-framework/types.Object"})
+											} else {
+												obj.SessionRecording = nil
+												if !v.Null && !v.Unknown {
+													tf := v
+													obj.SessionRecording = &github_com_gravitational_teleport_api_gen_proto_go_teleport_scopes_access_v1.SessionRecording{}
+													obj := obj.SessionRecording
+													{
+														a, ok := tf.Attrs["mode"]
+														if !ok {
+															diags.Append(attrReadMissingDiag{"ScopedRole.spec.ssh.session_recording.mode"})
+														} else {
+															v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.String)
+															if !ok {
+																diags.Append(attrReadConversionFailureDiag{"ScopedRole.spec.ssh.session_recording.mode", "github.com/hashicorp/terraform-plugin-framework/types.String"})
+															} else {
+																var t string
+																if !v.Null && !v.Unknown {
+																	t = string(v.Value)
+																}
+																obj.Mode = t
+															}
+														}
+													}
+												}
+											}
+										}
+									}
+									{
+										a, ok := tf.Attrs["disconnect_expired_cert"]
+										if !ok {
+											diags.Append(attrReadMissingDiag{"ScopedRole.spec.ssh.disconnect_expired_cert"})
+										} else {
+											v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.Bool)
+											if !ok {
+												diags.Append(attrReadConversionFailureDiag{"ScopedRole.spec.ssh.disconnect_expired_cert", "github.com/hashicorp/terraform-plugin-framework/types.Bool"})
+											} else {
+												var t *bool
+												if !v.Null && !v.Unknown {
+													c := bool(v.Value)
+													t = &c
+												}
+												obj.DisconnectExpiredCert = t
+											}
+										}
+									}
+									{
+										a, ok := tf.Attrs["lock"]
+										if !ok {
+											diags.Append(attrReadMissingDiag{"ScopedRole.spec.ssh.lock"})
+										} else {
+											v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.Object)
+											if !ok {
+												diags.Append(attrReadConversionFailureDiag{"ScopedRole.spec.ssh.lock", "github.com/hashicorp/terraform-plugin-framework/types.Object"})
+											} else {
+												obj.Lock = nil
+												if !v.Null && !v.Unknown {
+													tf := v
+													obj.Lock = &github_com_gravitational_teleport_api_gen_proto_go_teleport_scopes_access_v1.Lock{}
+													obj := obj.Lock
+													{
+														a, ok := tf.Attrs["mode"]
+														if !ok {
+															diags.Append(attrReadMissingDiag{"ScopedRole.spec.ssh.lock.mode"})
+														} else {
+															v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.String)
+															if !ok {
+																diags.Append(attrReadConversionFailureDiag{"ScopedRole.spec.ssh.lock.mode", "github.com/hashicorp/terraform-plugin-framework/types.String"})
+															} else {
+																var t string
+																if !v.Null && !v.Unknown {
+																	t = string(v.Value)
+																}
+																obj.Mode = t
+															}
+														}
+													}
+												}
+											}
+										}
+									}
 								}
 							}
 						}
@@ -1203,6 +1534,59 @@ func CopyScopedRoleFromTerraform(_ context.Context, tf github_com_hashicorp_terr
 													t = string(v.Value)
 												}
 												obj.ClientIdleTimeout = t
+											}
+										}
+									}
+									{
+										a, ok := tf.Attrs["disconnect_expired_cert"]
+										if !ok {
+											diags.Append(attrReadMissingDiag{"ScopedRole.spec.kube.disconnect_expired_cert"})
+										} else {
+											v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.Bool)
+											if !ok {
+												diags.Append(attrReadConversionFailureDiag{"ScopedRole.spec.kube.disconnect_expired_cert", "github.com/hashicorp/terraform-plugin-framework/types.Bool"})
+											} else {
+												var t *bool
+												if !v.Null && !v.Unknown {
+													c := bool(v.Value)
+													t = &c
+												}
+												obj.DisconnectExpiredCert = t
+											}
+										}
+									}
+									{
+										a, ok := tf.Attrs["lock"]
+										if !ok {
+											diags.Append(attrReadMissingDiag{"ScopedRole.spec.kube.lock"})
+										} else {
+											v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.Object)
+											if !ok {
+												diags.Append(attrReadConversionFailureDiag{"ScopedRole.spec.kube.lock", "github.com/hashicorp/terraform-plugin-framework/types.Object"})
+											} else {
+												obj.Lock = nil
+												if !v.Null && !v.Unknown {
+													tf := v
+													obj.Lock = &github_com_gravitational_teleport_api_gen_proto_go_teleport_scopes_access_v1.Lock{}
+													obj := obj.Lock
+													{
+														a, ok := tf.Attrs["mode"]
+														if !ok {
+															diags.Append(attrReadMissingDiag{"ScopedRole.spec.kube.lock.mode"})
+														} else {
+															v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.String)
+															if !ok {
+																diags.Append(attrReadConversionFailureDiag{"ScopedRole.spec.kube.lock.mode", "github.com/hashicorp/terraform-plugin-framework/types.String"})
+															} else {
+																var t string
+																if !v.Null && !v.Unknown {
+																	t = string(v.Value)
+																}
+																obj.Mode = t
+															}
+														}
+													}
+												}
 											}
 										}
 									}
@@ -1617,6 +2001,140 @@ func CopyScopedRoleToTerraform(ctx context.Context, obj *github_com_gravitationa
 											v.Value = string(obj.ClientIdleTimeout)
 											v.Unknown = false
 											tf.Attrs["client_idle_timeout"] = v
+										}
+									}
+									{
+										a, ok := tf.AttrTypes["session_recording"]
+										if !ok {
+											diags.Append(attrWriteMissingDiag{"ScopedRole.spec.defaults.session_recording"})
+										} else {
+											o, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.ObjectType)
+											if !ok {
+												diags.Append(attrWriteConversionFailureDiag{"ScopedRole.spec.defaults.session_recording", "github.com/hashicorp/terraform-plugin-framework/types.ObjectType"})
+											} else {
+												v, ok := tf.Attrs["session_recording"].(github_com_hashicorp_terraform_plugin_framework_types.Object)
+												if !ok {
+													v = github_com_hashicorp_terraform_plugin_framework_types.Object{
+
+														AttrTypes: o.AttrTypes,
+														Attrs:     make(map[string]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(o.AttrTypes)),
+													}
+												} else {
+													if v.Attrs == nil {
+														v.Attrs = make(map[string]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(tf.AttrTypes))
+													}
+												}
+												if obj.SessionRecording == nil {
+													v.Null = true
+												} else {
+													obj := obj.SessionRecording
+													tf := &v
+													{
+														t, ok := tf.AttrTypes["mode"]
+														if !ok {
+															diags.Append(attrWriteMissingDiag{"ScopedRole.spec.defaults.session_recording.mode"})
+														} else {
+															v, ok := tf.Attrs["mode"].(github_com_hashicorp_terraform_plugin_framework_types.String)
+															if !ok {
+																i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
+																if err != nil {
+																	diags.Append(attrWriteGeneralError{"ScopedRole.spec.defaults.session_recording.mode", err})
+																}
+																v, ok = i.(github_com_hashicorp_terraform_plugin_framework_types.String)
+																if !ok {
+																	diags.Append(attrWriteConversionFailureDiag{"ScopedRole.spec.defaults.session_recording.mode", "github.com/hashicorp/terraform-plugin-framework/types.String"})
+																}
+																v.Null = string(obj.Mode) == ""
+															}
+															v.Value = string(obj.Mode)
+															v.Unknown = false
+															tf.Attrs["mode"] = v
+														}
+													}
+												}
+												v.Unknown = false
+												tf.Attrs["session_recording"] = v
+											}
+										}
+									}
+									{
+										t, ok := tf.AttrTypes["disconnect_expired_cert"]
+										if !ok {
+											diags.Append(attrWriteMissingDiag{"ScopedRole.spec.defaults.disconnect_expired_cert"})
+										} else {
+											v, ok := tf.Attrs["disconnect_expired_cert"].(github_com_hashicorp_terraform_plugin_framework_types.Bool)
+											if !ok {
+												i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
+												if err != nil {
+													diags.Append(attrWriteGeneralError{"ScopedRole.spec.defaults.disconnect_expired_cert", err})
+												}
+												v, ok = i.(github_com_hashicorp_terraform_plugin_framework_types.Bool)
+												if !ok {
+													diags.Append(attrWriteConversionFailureDiag{"ScopedRole.spec.defaults.disconnect_expired_cert", "github.com/hashicorp/terraform-plugin-framework/types.Bool"})
+												}
+											}
+											if obj.DisconnectExpiredCert == nil {
+												v.Null = true
+											} else {
+												v.Null = false
+												v.Value = bool(*obj.DisconnectExpiredCert)
+											}
+											v.Unknown = false
+											tf.Attrs["disconnect_expired_cert"] = v
+										}
+									}
+									{
+										a, ok := tf.AttrTypes["lock"]
+										if !ok {
+											diags.Append(attrWriteMissingDiag{"ScopedRole.spec.defaults.lock"})
+										} else {
+											o, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.ObjectType)
+											if !ok {
+												diags.Append(attrWriteConversionFailureDiag{"ScopedRole.spec.defaults.lock", "github.com/hashicorp/terraform-plugin-framework/types.ObjectType"})
+											} else {
+												v, ok := tf.Attrs["lock"].(github_com_hashicorp_terraform_plugin_framework_types.Object)
+												if !ok {
+													v = github_com_hashicorp_terraform_plugin_framework_types.Object{
+
+														AttrTypes: o.AttrTypes,
+														Attrs:     make(map[string]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(o.AttrTypes)),
+													}
+												} else {
+													if v.Attrs == nil {
+														v.Attrs = make(map[string]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(tf.AttrTypes))
+													}
+												}
+												if obj.Lock == nil {
+													v.Null = true
+												} else {
+													obj := obj.Lock
+													tf := &v
+													{
+														t, ok := tf.AttrTypes["mode"]
+														if !ok {
+															diags.Append(attrWriteMissingDiag{"ScopedRole.spec.defaults.lock.mode"})
+														} else {
+															v, ok := tf.Attrs["mode"].(github_com_hashicorp_terraform_plugin_framework_types.String)
+															if !ok {
+																i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
+																if err != nil {
+																	diags.Append(attrWriteGeneralError{"ScopedRole.spec.defaults.lock.mode", err})
+																}
+																v, ok = i.(github_com_hashicorp_terraform_plugin_framework_types.String)
+																if !ok {
+																	diags.Append(attrWriteConversionFailureDiag{"ScopedRole.spec.defaults.lock.mode", "github.com/hashicorp/terraform-plugin-framework/types.String"})
+																}
+																v.Null = string(obj.Mode) == ""
+															}
+															v.Value = string(obj.Mode)
+															v.Unknown = false
+															tf.Attrs["mode"] = v
+														}
+													}
+												}
+												v.Unknown = false
+												tf.Attrs["lock"] = v
+											}
 										}
 									}
 								}
@@ -2457,6 +2975,250 @@ func CopyScopedRoleToTerraform(ctx context.Context, obj *github_com_gravitationa
 											tf.Attrs["file_copy"] = v
 										}
 									}
+									{
+										a, ok := tf.AttrTypes["enhanced_recording"]
+										if !ok {
+											diags.Append(attrWriteMissingDiag{"ScopedRole.spec.ssh.enhanced_recording"})
+										} else {
+											o, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.ObjectType)
+											if !ok {
+												diags.Append(attrWriteConversionFailureDiag{"ScopedRole.spec.ssh.enhanced_recording", "github.com/hashicorp/terraform-plugin-framework/types.ObjectType"})
+											} else {
+												v, ok := tf.Attrs["enhanced_recording"].(github_com_hashicorp_terraform_plugin_framework_types.Object)
+												if !ok {
+													v = github_com_hashicorp_terraform_plugin_framework_types.Object{
+
+														AttrTypes: o.AttrTypes,
+														Attrs:     make(map[string]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(o.AttrTypes)),
+													}
+												} else {
+													if v.Attrs == nil {
+														v.Attrs = make(map[string]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(tf.AttrTypes))
+													}
+												}
+												if obj.EnhancedRecording == nil {
+													v.Null = true
+												} else {
+													obj := obj.EnhancedRecording
+													tf := &v
+													{
+														t, ok := tf.AttrTypes["command"]
+														if !ok {
+															diags.Append(attrWriteMissingDiag{"ScopedRole.spec.ssh.enhanced_recording.command"})
+														} else {
+															v, ok := tf.Attrs["command"].(github_com_hashicorp_terraform_plugin_framework_types.Bool)
+															if !ok {
+																i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
+																if err != nil {
+																	diags.Append(attrWriteGeneralError{"ScopedRole.spec.ssh.enhanced_recording.command", err})
+																}
+																v, ok = i.(github_com_hashicorp_terraform_plugin_framework_types.Bool)
+																if !ok {
+																	diags.Append(attrWriteConversionFailureDiag{"ScopedRole.spec.ssh.enhanced_recording.command", "github.com/hashicorp/terraform-plugin-framework/types.Bool"})
+																}
+															}
+															if obj.Command == nil {
+																v.Null = true
+															} else {
+																v.Null = false
+																v.Value = bool(*obj.Command)
+															}
+															v.Unknown = false
+															tf.Attrs["command"] = v
+														}
+													}
+													{
+														t, ok := tf.AttrTypes["network"]
+														if !ok {
+															diags.Append(attrWriteMissingDiag{"ScopedRole.spec.ssh.enhanced_recording.network"})
+														} else {
+															v, ok := tf.Attrs["network"].(github_com_hashicorp_terraform_plugin_framework_types.Bool)
+															if !ok {
+																i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
+																if err != nil {
+																	diags.Append(attrWriteGeneralError{"ScopedRole.spec.ssh.enhanced_recording.network", err})
+																}
+																v, ok = i.(github_com_hashicorp_terraform_plugin_framework_types.Bool)
+																if !ok {
+																	diags.Append(attrWriteConversionFailureDiag{"ScopedRole.spec.ssh.enhanced_recording.network", "github.com/hashicorp/terraform-plugin-framework/types.Bool"})
+																}
+															}
+															if obj.Network == nil {
+																v.Null = true
+															} else {
+																v.Null = false
+																v.Value = bool(*obj.Network)
+															}
+															v.Unknown = false
+															tf.Attrs["network"] = v
+														}
+													}
+													{
+														t, ok := tf.AttrTypes["disk"]
+														if !ok {
+															diags.Append(attrWriteMissingDiag{"ScopedRole.spec.ssh.enhanced_recording.disk"})
+														} else {
+															v, ok := tf.Attrs["disk"].(github_com_hashicorp_terraform_plugin_framework_types.Bool)
+															if !ok {
+																i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
+																if err != nil {
+																	diags.Append(attrWriteGeneralError{"ScopedRole.spec.ssh.enhanced_recording.disk", err})
+																}
+																v, ok = i.(github_com_hashicorp_terraform_plugin_framework_types.Bool)
+																if !ok {
+																	diags.Append(attrWriteConversionFailureDiag{"ScopedRole.spec.ssh.enhanced_recording.disk", "github.com/hashicorp/terraform-plugin-framework/types.Bool"})
+																}
+															}
+															if obj.Disk == nil {
+																v.Null = true
+															} else {
+																v.Null = false
+																v.Value = bool(*obj.Disk)
+															}
+															v.Unknown = false
+															tf.Attrs["disk"] = v
+														}
+													}
+												}
+												v.Unknown = false
+												tf.Attrs["enhanced_recording"] = v
+											}
+										}
+									}
+									{
+										a, ok := tf.AttrTypes["session_recording"]
+										if !ok {
+											diags.Append(attrWriteMissingDiag{"ScopedRole.spec.ssh.session_recording"})
+										} else {
+											o, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.ObjectType)
+											if !ok {
+												diags.Append(attrWriteConversionFailureDiag{"ScopedRole.spec.ssh.session_recording", "github.com/hashicorp/terraform-plugin-framework/types.ObjectType"})
+											} else {
+												v, ok := tf.Attrs["session_recording"].(github_com_hashicorp_terraform_plugin_framework_types.Object)
+												if !ok {
+													v = github_com_hashicorp_terraform_plugin_framework_types.Object{
+
+														AttrTypes: o.AttrTypes,
+														Attrs:     make(map[string]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(o.AttrTypes)),
+													}
+												} else {
+													if v.Attrs == nil {
+														v.Attrs = make(map[string]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(tf.AttrTypes))
+													}
+												}
+												if obj.SessionRecording == nil {
+													v.Null = true
+												} else {
+													obj := obj.SessionRecording
+													tf := &v
+													{
+														t, ok := tf.AttrTypes["mode"]
+														if !ok {
+															diags.Append(attrWriteMissingDiag{"ScopedRole.spec.ssh.session_recording.mode"})
+														} else {
+															v, ok := tf.Attrs["mode"].(github_com_hashicorp_terraform_plugin_framework_types.String)
+															if !ok {
+																i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
+																if err != nil {
+																	diags.Append(attrWriteGeneralError{"ScopedRole.spec.ssh.session_recording.mode", err})
+																}
+																v, ok = i.(github_com_hashicorp_terraform_plugin_framework_types.String)
+																if !ok {
+																	diags.Append(attrWriteConversionFailureDiag{"ScopedRole.spec.ssh.session_recording.mode", "github.com/hashicorp/terraform-plugin-framework/types.String"})
+																}
+																v.Null = string(obj.Mode) == ""
+															}
+															v.Value = string(obj.Mode)
+															v.Unknown = false
+															tf.Attrs["mode"] = v
+														}
+													}
+												}
+												v.Unknown = false
+												tf.Attrs["session_recording"] = v
+											}
+										}
+									}
+									{
+										t, ok := tf.AttrTypes["disconnect_expired_cert"]
+										if !ok {
+											diags.Append(attrWriteMissingDiag{"ScopedRole.spec.ssh.disconnect_expired_cert"})
+										} else {
+											v, ok := tf.Attrs["disconnect_expired_cert"].(github_com_hashicorp_terraform_plugin_framework_types.Bool)
+											if !ok {
+												i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
+												if err != nil {
+													diags.Append(attrWriteGeneralError{"ScopedRole.spec.ssh.disconnect_expired_cert", err})
+												}
+												v, ok = i.(github_com_hashicorp_terraform_plugin_framework_types.Bool)
+												if !ok {
+													diags.Append(attrWriteConversionFailureDiag{"ScopedRole.spec.ssh.disconnect_expired_cert", "github.com/hashicorp/terraform-plugin-framework/types.Bool"})
+												}
+											}
+											if obj.DisconnectExpiredCert == nil {
+												v.Null = true
+											} else {
+												v.Null = false
+												v.Value = bool(*obj.DisconnectExpiredCert)
+											}
+											v.Unknown = false
+											tf.Attrs["disconnect_expired_cert"] = v
+										}
+									}
+									{
+										a, ok := tf.AttrTypes["lock"]
+										if !ok {
+											diags.Append(attrWriteMissingDiag{"ScopedRole.spec.ssh.lock"})
+										} else {
+											o, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.ObjectType)
+											if !ok {
+												diags.Append(attrWriteConversionFailureDiag{"ScopedRole.spec.ssh.lock", "github.com/hashicorp/terraform-plugin-framework/types.ObjectType"})
+											} else {
+												v, ok := tf.Attrs["lock"].(github_com_hashicorp_terraform_plugin_framework_types.Object)
+												if !ok {
+													v = github_com_hashicorp_terraform_plugin_framework_types.Object{
+
+														AttrTypes: o.AttrTypes,
+														Attrs:     make(map[string]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(o.AttrTypes)),
+													}
+												} else {
+													if v.Attrs == nil {
+														v.Attrs = make(map[string]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(tf.AttrTypes))
+													}
+												}
+												if obj.Lock == nil {
+													v.Null = true
+												} else {
+													obj := obj.Lock
+													tf := &v
+													{
+														t, ok := tf.AttrTypes["mode"]
+														if !ok {
+															diags.Append(attrWriteMissingDiag{"ScopedRole.spec.ssh.lock.mode"})
+														} else {
+															v, ok := tf.Attrs["mode"].(github_com_hashicorp_terraform_plugin_framework_types.String)
+															if !ok {
+																i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
+																if err != nil {
+																	diags.Append(attrWriteGeneralError{"ScopedRole.spec.ssh.lock.mode", err})
+																}
+																v, ok = i.(github_com_hashicorp_terraform_plugin_framework_types.String)
+																if !ok {
+																	diags.Append(attrWriteConversionFailureDiag{"ScopedRole.spec.ssh.lock.mode", "github.com/hashicorp/terraform-plugin-framework/types.String"})
+																}
+																v.Null = string(obj.Mode) == ""
+															}
+															v.Value = string(obj.Mode)
+															v.Unknown = false
+															tf.Attrs["mode"] = v
+														}
+													}
+												}
+												v.Unknown = false
+												tf.Attrs["lock"] = v
+											}
+										}
+									}
 								}
 								v.Unknown = false
 								tf.Attrs["ssh"] = v
@@ -2748,6 +3510,86 @@ func CopyScopedRoleToTerraform(ctx context.Context, obj *github_com_gravitationa
 											v.Value = string(obj.ClientIdleTimeout)
 											v.Unknown = false
 											tf.Attrs["client_idle_timeout"] = v
+										}
+									}
+									{
+										t, ok := tf.AttrTypes["disconnect_expired_cert"]
+										if !ok {
+											diags.Append(attrWriteMissingDiag{"ScopedRole.spec.kube.disconnect_expired_cert"})
+										} else {
+											v, ok := tf.Attrs["disconnect_expired_cert"].(github_com_hashicorp_terraform_plugin_framework_types.Bool)
+											if !ok {
+												i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
+												if err != nil {
+													diags.Append(attrWriteGeneralError{"ScopedRole.spec.kube.disconnect_expired_cert", err})
+												}
+												v, ok = i.(github_com_hashicorp_terraform_plugin_framework_types.Bool)
+												if !ok {
+													diags.Append(attrWriteConversionFailureDiag{"ScopedRole.spec.kube.disconnect_expired_cert", "github.com/hashicorp/terraform-plugin-framework/types.Bool"})
+												}
+											}
+											if obj.DisconnectExpiredCert == nil {
+												v.Null = true
+											} else {
+												v.Null = false
+												v.Value = bool(*obj.DisconnectExpiredCert)
+											}
+											v.Unknown = false
+											tf.Attrs["disconnect_expired_cert"] = v
+										}
+									}
+									{
+										a, ok := tf.AttrTypes["lock"]
+										if !ok {
+											diags.Append(attrWriteMissingDiag{"ScopedRole.spec.kube.lock"})
+										} else {
+											o, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.ObjectType)
+											if !ok {
+												diags.Append(attrWriteConversionFailureDiag{"ScopedRole.spec.kube.lock", "github.com/hashicorp/terraform-plugin-framework/types.ObjectType"})
+											} else {
+												v, ok := tf.Attrs["lock"].(github_com_hashicorp_terraform_plugin_framework_types.Object)
+												if !ok {
+													v = github_com_hashicorp_terraform_plugin_framework_types.Object{
+
+														AttrTypes: o.AttrTypes,
+														Attrs:     make(map[string]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(o.AttrTypes)),
+													}
+												} else {
+													if v.Attrs == nil {
+														v.Attrs = make(map[string]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(tf.AttrTypes))
+													}
+												}
+												if obj.Lock == nil {
+													v.Null = true
+												} else {
+													obj := obj.Lock
+													tf := &v
+													{
+														t, ok := tf.AttrTypes["mode"]
+														if !ok {
+															diags.Append(attrWriteMissingDiag{"ScopedRole.spec.kube.lock.mode"})
+														} else {
+															v, ok := tf.Attrs["mode"].(github_com_hashicorp_terraform_plugin_framework_types.String)
+															if !ok {
+																i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
+																if err != nil {
+																	diags.Append(attrWriteGeneralError{"ScopedRole.spec.kube.lock.mode", err})
+																}
+																v, ok = i.(github_com_hashicorp_terraform_plugin_framework_types.String)
+																if !ok {
+																	diags.Append(attrWriteConversionFailureDiag{"ScopedRole.spec.kube.lock.mode", "github.com/hashicorp/terraform-plugin-framework/types.String"})
+																}
+																v.Null = string(obj.Mode) == ""
+															}
+															v.Value = string(obj.Mode)
+															v.Unknown = false
+															tf.Attrs["mode"] = v
+														}
+													}
+												}
+												v.Unknown = false
+												tf.Attrs["lock"] = v
+											}
 										}
 									}
 								}

--- a/lib/authz/scoped.go
+++ b/lib/authz/scoped.go
@@ -184,19 +184,21 @@ func (s *ScopedContext) GetDisconnectCertExpiry(authPref readonly.AuthPreference
 	if s.unscopedContext != nil {
 		return s.unscopedContext.GetDisconnectCertExpiry(authPref)
 	}
-
 	if !authPref.GetDisconnectExpiredCert() {
 		return time.Time{}
 	}
+	return s.GetDisconnectCertExpiryTime()
+}
 
+// GetDisconnectCertExpiryTime returns the timestamp for when the identity expires.
+// It takes in a bool parameter to specify whether to return the expiry time or not.
+func (s *ScopedContext) GetDisconnectCertExpiryTime() time.Time {
 	identity := s.Identity.GetIdentity()
 	if !identity.PreviousIdentityExpires.IsZero() {
 		// If this is a short-lived mfa verified cert, return the certificate extension
 		// that holds its issuing certificates expiry value.
 		return identity.PreviousIdentityExpires
 	}
-
-	// Otherwise, return the current certificates expiration
 	return identity.Expires
 }
 

--- a/lib/kube/proxy/forwarder.go
+++ b/lib/kube/proxy/forwarder.go
@@ -211,6 +211,9 @@ func (f *ForwarderConfig) CheckAndSetDefaults() error {
 	if f.ScopedAuthz == nil {
 		return trace.BadParameter("missing parameter ScopedAuthz")
 	}
+	if f.LockWatcher == nil {
+		return trace.BadParameter("missing parameter LockWatcher")
+	}
 	if f.Emitter == nil {
 		return trace.BadParameter("missing parameter Emitter")
 	}
@@ -470,6 +473,9 @@ type authContext struct {
 	// It is false if the target cluster is served by another teleport service or a different
 	// Teleport cluster.
 	isLocalKubernetesCluster bool
+
+	// LockingMode determines the kubernetes' behavior when locks are stale
+	LockingMode constants.LockingMode
 }
 
 func (c authContext) String() string {
@@ -1287,6 +1293,27 @@ func (f *Forwarder) authorize(ctx context.Context, actx *authContext) error {
 	actx.clientIdleTimeout, err = actx.checker.Kube().AdjustClientIdleTimeout(actx.clientIdleTimeout)
 	if err != nil {
 		return trace.Wrap(err)
+	}
+
+	authPref, err := f.cfg.CachingAuthClient.GetAuthPreference(ctx)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	if actx.checker.Kube().AdjustDisconnectExpiredCert(authPref.GetDisconnectExpiredCert()) {
+		actx.disconnectExpiredCert = actx.ScopedContext.GetDisconnectCertExpiryTime()
+	} else {
+		actx.disconnectExpiredCert = time.Time{}
+	}
+
+	// For scoped roles, check for the locking mode here so that we can verify whether users can connect or not when not
+	// when the lock is stale.
+	if isScoped {
+		actx.LockingMode = actx.checker.Kube().LockingMode(authPref.GetLockingMode())
+		// TODO(williamo/scopes): Potentially delete this in favor of checking locks in lib/authz/scoped.go
+		if err := f.cfg.LockWatcher.CheckLockInForce(actx.LockingMode, actx.LockTargets()...); err != nil {
+			return trace.Wrap(err)
+		}
 	}
 
 	// If the user has active Access requests we need to validate that they allow
@@ -2634,6 +2661,7 @@ func (s *clusterSession) monitorConn(conn net.Conn, err error, hostID string) (n
 		Emitter:               s.parent.cfg.AuthClient,
 		EmitterContext:        s.parent.ctx,
 		MessageWriter:         formatForwardResponseError(s.sendErrStatus),
+		LockingMode:           s.LockingMode,
 	})
 	if err != nil {
 		tc.CloseWithCause(err)

--- a/lib/kube/proxy/forwarder_test.go
+++ b/lib/kube/proxy/forwarder_test.go
@@ -57,6 +57,11 @@ import (
 
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/client/proto"
+	"github.com/gravitational/teleport/api/constants"
+	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
+	labelv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/label/v1"
+	scopedaccessv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/access/v1"
+	scopesv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/v1"
 	"github.com/gravitational/teleport/api/types"
 	apievents "github.com/gravitational/teleport/api/types/events"
 	"github.com/gravitational/teleport/api/utils/tlsutils"
@@ -69,6 +74,7 @@ import (
 	testingkubemock "github.com/gravitational/teleport/lib/kube/proxy/testing/kube_server"
 	"github.com/gravitational/teleport/lib/modules"
 	"github.com/gravitational/teleport/lib/reversetunnelclient"
+	"github.com/gravitational/teleport/lib/scopes/pinning"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/services/local"
 	"github.com/gravitational/teleport/lib/tlsca"
@@ -121,6 +127,27 @@ func TestAuthenticate(t *testing.T) {
 	})
 	require.NoError(t, err)
 
+	newTestLockWatcher := func(t *testing.T) *services.LockWatcher {
+		lockWatcher, err := services.NewLockWatcher(t.Context(), services.LockWatcherConfig{
+			ResourceWatcherConfig: services.ResourceWatcherConfig{
+				Component: teleport.ComponentProxy,
+				Client:    &mockEventClient{},
+			},
+		})
+		require.NoError(t, err)
+		t.Cleanup(lockWatcher.Close)
+		return lockWatcher
+	}
+	lockWatcher := newTestLockWatcher(t)
+
+	// marks the lock watcher as stale
+	configureStaleLockWatcher := func(t *testing.T, f *Forwarder) {
+		staleLockWatcher := newTestLockWatcher(t)
+		close(staleLockWatcher.StaleC)
+		require.Eventually(t, staleLockWatcher.IsStale, time.Second, 10*time.Millisecond)
+		f.cfg.LockWatcher = staleLockWatcher
+	}
+
 	ap := &mockAccessPoint{
 		netConfig:       nc,
 		recordingConfig: types.DefaultSessionRecordingConfig(),
@@ -141,49 +168,58 @@ func TestAuthenticate(t *testing.T) {
 			"local":  mockCluster{name: "local"},
 		},
 	}
-	f := &Forwarder{
-		log: logtest.NewLogger(),
-		cfg: ForwarderConfig{
-			ClusterName:       "local",
-			CachingAuthClient: ap,
-			TracerProvider:    otel.GetTracerProvider(),
-			tracer:            otel.Tracer(teleport.ComponentKube),
-			ClusterFeatures:   fakeClusterFeatures,
-			KubeServiceType:   ProxyService,
-		},
-		getKubernetesServersForKubeCluster: func(ctx context.Context, name string) ([]types.KubeServer, error) {
-			servers, err := ap.GetKubernetesServers(ctx)
-			if err != nil {
-				return nil, err
-			}
-			var filtered []types.KubeServer
-			for _, server := range servers {
-				if server.GetCluster().GetName() == name {
-					filtered = append(filtered, server)
+	newForwarder := func() *Forwarder {
+		return &Forwarder{
+			log: logtest.NewLogger(),
+			cfg: ForwarderConfig{
+				ClusterName:       "local",
+				CachingAuthClient: ap,
+				TracerProvider:    otel.GetTracerProvider(),
+				tracer:            otel.Tracer(teleport.ComponentKube),
+				ClusterFeatures:   fakeClusterFeatures,
+				KubeServiceType:   ProxyService,
+				LockWatcher:       lockWatcher,
+			},
+			getKubernetesServersForKubeCluster: func(ctx context.Context, name string) ([]types.KubeServer, error) {
+				servers, err := ap.GetKubernetesServers(ctx)
+				if err != nil {
+					return nil, err
 				}
-			}
-			return filtered, nil
-		},
+				var filtered []types.KubeServer
+				for _, server := range servers {
+					if server.GetCluster().GetName() == name {
+						filtered = append(filtered, server)
+					}
+				}
+				return filtered, nil
+			},
+		}
 	}
 
 	const remoteAddr = "user.example.com"
 	activeAccessRequests := []string{uuid.NewString(), uuid.NewString()}
 	tests := []struct {
-		desc              string
-		user              authz.IdentityGetter
-		authzErr          bool
-		roleKubeUsers     []string
-		roleKubeGroups    []string
-		routeToCluster    string
-		kubernetesCluster string
-		haveKubeCreds     bool
-		tunnel            reversetunnelclient.Server
-		kubeServers       []types.KubeServer
-		activeRequests    []string
+		desc                            string
+		user                            authz.IdentityGetter
+		authzErr                        bool
+		roleKubeUsers                   []string
+		roleKubeGroups                  []string
+		routeToCluster                  string
+		kubernetesCluster               string
+		haveKubeCreds                   bool
+		tunnel                          reversetunnelclient.Server
+		kubeServers                     []types.KubeServer
+		activeRequests                  []string
+		configureForwarder              func(t *testing.T, f *Forwarder)
+		scoped                          bool
+		scopedKubeLockMode              constants.LockingMode
+		scopedKubeDisconnectExpiredCert *bool
 
-		wantCtx     *authContext
-		wantErr     bool
-		wantAuthErr bool
+		wantCtx                   *authContext
+		wantErr                   bool
+		wantAuthErr               bool
+		wantAuthorizeErrContains  string
+		wantDisconnectExpiredCert *time.Time
 	}{
 		{
 			desc:              "local user and cluster with active access request",
@@ -309,6 +345,227 @@ func TestAuthenticate(t *testing.T) {
 								"static_label2": "static_value2",
 							},
 						},
+						Spec: types.KubernetesClusterSpecV3{
+							DynamicLabels: map[string]types.CommandLabelV2{},
+						},
+					},
+				),
+			},
+		},
+		{
+			desc:               "scoped user with stale locks and best effort locking produces no error",
+			user:               authz.LocalUser{},
+			scoped:             true,
+			roleKubeGroups:     []string{"kube-group-a", "kube-group-b"},
+			scopedKubeLockMode: constants.LockingModeBestEffort,
+			routeToCluster:     "local",
+			kubernetesCluster:  "local",
+			haveKubeCreds:      true,
+			tunnel:             tun,
+			configureForwarder: configureStaleLockWatcher,
+			kubeServers: newKubeServersFromKubeClusters(
+				t,
+				&types.KubernetesClusterV3{
+					Metadata: types.Metadata{
+						Name:   "local",
+						Labels: map[string]string{},
+					},
+					Scope: scopedTestScope,
+					Spec: types.KubernetesClusterSpecV3{
+						DynamicLabels: map[string]types.CommandLabelV2{},
+					},
+				},
+			),
+			wantCtx: &authContext{
+				kubeUsers:         set.New("user-a"),
+				kubeGroups:        set.New("kube-group-a", "kube-group-b", teleport.KubeSystemAuthenticated),
+				kubeClusterName:   "local",
+				kubeClusterLabels: make(map[string]string),
+				certExpires:       certExpiration,
+				teleportCluster: teleportClusterClient{
+					name:       "local",
+					remoteAddr: *utils.MustParseAddr(remoteAddr),
+				},
+				kubeServers: newKubeServersFromKubeClusters(
+					t,
+					&types.KubernetesClusterV3{
+						Metadata: types.Metadata{
+							Name:   "local",
+							Labels: map[string]string{},
+						},
+						Scope: scopedTestScope,
+						Spec: types.KubernetesClusterSpecV3{
+							DynamicLabels: map[string]types.CommandLabelV2{},
+						},
+					},
+				),
+			},
+		},
+		{
+			desc:                     "scoped user with stale locks and strict locking produces error",
+			user:                     authz.LocalUser{},
+			scoped:                   true,
+			roleKubeGroups:           []string{"kube-group-a", "kube-group-b"},
+			scopedKubeLockMode:       constants.LockingModeStrict,
+			routeToCluster:           "local",
+			kubernetesCluster:        "local",
+			haveKubeCreds:            true,
+			tunnel:                   tun,
+			configureForwarder:       configureStaleLockWatcher,
+			wantAuthorizeErrContains: services.StrictLockingModeAccessDenied.Error(),
+			kubeServers: newKubeServersFromKubeClusters(
+				t,
+				&types.KubernetesClusterV3{
+					Metadata: types.Metadata{
+						Name:   "local",
+						Labels: map[string]string{},
+					},
+					Scope: scopedTestScope,
+					Spec: types.KubernetesClusterSpecV3{
+						DynamicLabels: map[string]types.CommandLabelV2{},
+					},
+				},
+			),
+		},
+		{
+			desc:                      "scoped user inherits disconnect on cert expiry from auth pref",
+			user:                      authz.LocalUser{},
+			scoped:                    true,
+			roleKubeGroups:            []string{"kube-group-a", "kube-group-b"},
+			routeToCluster:            "local",
+			kubernetesCluster:         "local",
+			haveKubeCreds:             true,
+			tunnel:                    tun,
+			wantDisconnectExpiredCert: &certExpiration,
+			kubeServers: newKubeServersFromKubeClusters(
+				t,
+				&types.KubernetesClusterV3{
+					Metadata: types.Metadata{
+						Name:   "local",
+						Labels: map[string]string{},
+					},
+					Scope: scopedTestScope,
+					Spec: types.KubernetesClusterSpecV3{
+						DynamicLabels: map[string]types.CommandLabelV2{},
+					},
+				},
+			),
+			wantCtx: &authContext{
+				kubeUsers:         set.New("user-a"),
+				kubeGroups:        set.New("kube-group-a", "kube-group-b", teleport.KubeSystemAuthenticated),
+				kubeClusterName:   "local",
+				kubeClusterLabels: make(map[string]string),
+				certExpires:       certExpiration,
+				teleportCluster: teleportClusterClient{
+					name:       "local",
+					remoteAddr: *utils.MustParseAddr(remoteAddr),
+				},
+				kubeServers: newKubeServersFromKubeClusters(
+					t,
+					&types.KubernetesClusterV3{
+						Metadata: types.Metadata{
+							Name:   "local",
+							Labels: map[string]string{},
+						},
+						Scope: scopedTestScope,
+						Spec: types.KubernetesClusterSpecV3{
+							DynamicLabels: map[string]types.CommandLabelV2{},
+						},
+					},
+				),
+			},
+		},
+		{
+			desc:                            "scoped user disables on cert expiry",
+			user:                            authz.LocalUser{},
+			scoped:                          true,
+			roleKubeGroups:                  []string{"kube-group-a", "kube-group-b"},
+			routeToCluster:                  "local",
+			kubernetesCluster:               "local",
+			scopedKubeDisconnectExpiredCert: ptr(false),
+			wantDisconnectExpiredCert:       &time.Time{},
+			haveKubeCreds:                   true,
+			tunnel:                          tun,
+			kubeServers: newKubeServersFromKubeClusters(
+				t,
+				&types.KubernetesClusterV3{
+					Metadata: types.Metadata{
+						Name:   "local",
+						Labels: map[string]string{},
+					},
+					Scope: scopedTestScope,
+					Spec: types.KubernetesClusterSpecV3{
+						DynamicLabels: map[string]types.CommandLabelV2{},
+					},
+				},
+			),
+			wantCtx: &authContext{
+				kubeUsers:         set.New("user-a"),
+				kubeGroups:        set.New("kube-group-a", "kube-group-b", teleport.KubeSystemAuthenticated),
+				kubeClusterName:   "local",
+				kubeClusterLabels: make(map[string]string),
+				certExpires:       certExpiration,
+				teleportCluster: teleportClusterClient{
+					name:       "local",
+					remoteAddr: *utils.MustParseAddr(remoteAddr),
+				},
+				kubeServers: newKubeServersFromKubeClusters(
+					t,
+					&types.KubernetesClusterV3{
+						Metadata: types.Metadata{
+							Name:   "local",
+							Labels: map[string]string{},
+						},
+						Scope: scopedTestScope,
+						Spec: types.KubernetesClusterSpecV3{
+							DynamicLabels: map[string]types.CommandLabelV2{},
+						},
+					},
+				),
+			},
+		},
+		{
+			desc:                            "scoped user sets disconnectExpiredCert to true",
+			user:                            authz.LocalUser{},
+			scoped:                          true,
+			roleKubeGroups:                  []string{"kube-group-a", "kube-group-b"},
+			scopedKubeDisconnectExpiredCert: ptr(true),
+			wantDisconnectExpiredCert:       &certExpiration,
+			routeToCluster:                  "local",
+			kubernetesCluster:               "local",
+			haveKubeCreds:                   true,
+			tunnel:                          tun,
+			kubeServers: newKubeServersFromKubeClusters(
+				t,
+				&types.KubernetesClusterV3{
+					Metadata: types.Metadata{
+						Name:   "local",
+						Labels: map[string]string{},
+					},
+					Scope: scopedTestScope,
+					Spec: types.KubernetesClusterSpecV3{
+						DynamicLabels: map[string]types.CommandLabelV2{},
+					},
+				},
+			),
+			wantCtx: &authContext{
+				kubeUsers:         set.New("user-a"),
+				kubeGroups:        set.New("kube-group-a", "kube-group-b", teleport.KubeSystemAuthenticated),
+				kubeClusterName:   "local",
+				kubeClusterLabels: make(map[string]string),
+				certExpires:       certExpiration,
+				teleportCluster: teleportClusterClient{
+					name:       "local",
+					remoteAddr: *utils.MustParseAddr(remoteAddr),
+				},
+				kubeServers: newKubeServersFromKubeClusters(
+					t,
+					&types.KubernetesClusterV3{
+						Metadata: types.Metadata{
+							Name:   "local",
+							Labels: map[string]string{},
+						},
+						Scope: scopedTestScope,
 						Spec: types.KubernetesClusterSpecV3{
 							DynamicLabels: map[string]types.CommandLabelV2{},
 						},
@@ -707,6 +964,10 @@ func TestAuthenticate(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.desc, func(t *testing.T) {
+			f := newForwarder()
+			if tt.configureForwarder != nil {
+				tt.configureForwarder(t, f)
+			}
 			f.cfg.ReverseTunnelSrv = tt.tunnel
 			ap.kubeServers = tt.kubeServers
 			roles, err := services.RoleSetFromSpec("ops", types.RoleSpecV6{
@@ -723,13 +984,36 @@ func TestAuthenticate(t *testing.T) {
 					Roles: roles.RoleNames(),
 				}, "local", roles),
 				Identity: authz.WrapIdentity(tlsca.Identity{
+					Username:          username,
+					Groups:            roles.RoleNames(),
+					RouteToCluster:    tt.routeToCluster,
+					KubernetesCluster: tt.kubernetesCluster,
+					ActiveRequests:    tt.activeRequests,
+					Expires:           certExpiration,
+				}),
+				UnmappedIdentity: authz.WrapIdentity(tlsca.Identity{
+					Username:          username,
+					Groups:            roles.RoleNames(),
 					RouteToCluster:    tt.routeToCluster,
 					KubernetesCluster: tt.kubernetesCluster,
 					ActiveRequests:    tt.activeRequests,
 					Expires:           certExpiration,
 				}),
 			}
-			authorizer := mockAuthorizer{scopedCtx: authz.ScopedContextFromUnscopedContext(&authCtx)}
+			var authorizer mockAuthorizer
+			if tt.scoped {
+				authorizer = newScopedKubeAuthorizer(t, scopedKubeAuthorizerConfig{
+					user:                  user,
+					identity:              authCtx.Identity,
+					kubeUsers:             tt.roleKubeUsers,
+					kubeGroups:            tt.roleKubeGroups,
+					kubeLockMode:          tt.scopedKubeLockMode,
+					kubeDisconnectExpired: tt.scopedKubeDisconnectExpiredCert,
+					clusterName:           "local",
+				})
+			} else {
+				authorizer = mockAuthorizer{scopedCtx: authz.ScopedContextFromUnscopedContext(&authCtx)}
+			}
 			if tt.authzErr {
 				authorizer.err = trace.AccessDenied("denied!")
 			}
@@ -767,12 +1051,21 @@ func TestAuthenticate(t *testing.T) {
 			}
 			require.NoError(t, err)
 			err = f.authorize(context.Background(), gotCtx)
+			if tt.wantAuthorizeErrContains != "" {
+				require.ErrorContains(t, err, tt.wantAuthorizeErrContains)
+				return
+			}
+
 			require.NoError(t, err)
 
 			require.Empty(t, cmp.Diff(gotCtx, tt.wantCtx,
 				cmp.AllowUnexported(authContext{}, teleportClusterClient{}, metaResource{}, apiResource{}),
-				cmpopts.IgnoreFields(authContext{}, "clientIdleTimeout", "sessionTTL", "ScopedContext", "recordingConfig", "disconnectExpiredCert", "kubeCluster", "checker", "accessState"),
+				cmpopts.IgnoreFields(authContext{}, "clientIdleTimeout", "sessionTTL", "ScopedContext", "recordingConfig", "disconnectExpiredCert", "kubeCluster", "checker", "accessState", "LockingMode"),
 			))
+
+			if tt.wantDisconnectExpiredCert != nil {
+				require.Equal(t, *tt.wantDisconnectExpiredCert, gotCtx.disconnectExpiredCert)
+			}
 
 			// validate authCtx.key() to make sure it includes certExpires timestamp.
 			// this is important to make sure user's credentials are correctly cached
@@ -1312,6 +1605,89 @@ type mockAuthorizer struct {
 
 func (a mockAuthorizer) AuthorizeScoped(context.Context) (*authz.ScopedContext, error) {
 	return a.scopedCtx, a.err
+}
+
+const scopedTestRole = "scoped-kube-admin"
+const scopedTestScope = "/staging"
+
+type scopedKubeAuthorizerConfig struct {
+	user                  types.User
+	identity              authz.IdentityGetter
+	kubeUsers             []string
+	kubeGroups            []string
+	kubeLockMode          constants.LockingMode
+	kubeDisconnectExpired *bool
+	clusterName           string
+}
+
+func newScopedKubeAuthorizer(t *testing.T, cfg scopedKubeAuthorizerConfig) mockAuthorizer {
+	t.Helper()
+
+	var lock *scopedaccessv1.Lock
+	if cfg.kubeLockMode != "" {
+		lock = &scopedaccessv1.Lock{Mode: string(cfg.kubeLockMode)}
+	}
+
+	role := &scopedaccessv1.ScopedRole{
+		Kind: "scoped_role",
+		Metadata: &headerv1.Metadata{
+			Name: scopedTestRole,
+		},
+		Scope: "/",
+		Spec: &scopedaccessv1.ScopedRoleSpec{
+			AssignableScopes: []string{scopedTestScope},
+			Kube: &scopedaccessv1.ScopedRoleKube{
+				Labels: []*labelv1.Label{
+					{Name: types.Wildcard, Values: []string{types.Wildcard}},
+				},
+				Groups:                cfg.kubeGroups,
+				Users:                 cfg.kubeUsers,
+				Lock:                  lock,
+				DisconnectExpiredCert: cfg.kubeDisconnectExpired,
+			},
+		},
+		Version: types.V1,
+	}
+
+	reader := &fakeScopedRoleReader{
+		role: role,
+	}
+
+	pin := &scopesv1.Pin{Scope: scopedTestScope}
+	pin.AssignmentTree = pinning.AssignmentTreeFromMap(map[string]map[string][]string{
+		"/": {
+			scopedTestScope: {scopedTestRole},
+		},
+	})
+
+	checkerCtx, err := services.NewScopedAccessCheckerContext(t.Context(), &services.AccessInfo{
+		Username: cfg.user.GetName(),
+		ScopePin: pin,
+	}, cfg.clusterName, reader)
+	require.NoError(t, err)
+
+	return mockAuthorizer{
+		scopedCtx: &authz.ScopedContext{
+			User:           cfg.user,
+			Identity:       cfg.identity,
+			CheckerContext: checkerCtx,
+		},
+	}
+}
+
+func ptr[T any](v T) *T { return &v }
+
+type fakeScopedRoleReader struct {
+	role *scopedaccessv1.ScopedRole
+}
+
+func (r *fakeScopedRoleReader) GetScopedRole(_ context.Context, req *scopedaccessv1.GetScopedRoleRequest) (*scopedaccessv1.GetScopedRoleResponse, error) {
+
+	return &scopedaccessv1.GetScopedRoleResponse{Role: r.role}, nil
+}
+
+func (r *fakeScopedRoleReader) ListScopedRoles(context.Context, *scopedaccessv1.ListScopedRolesRequest) (*scopedaccessv1.ListScopedRolesResponse, error) {
+	return &scopedaccessv1.ListScopedRolesResponse{Roles: []*scopedaccessv1.ScopedRole{r.role}}, nil
 }
 
 type mockEventClient struct {

--- a/lib/scopes/access/access.go
+++ b/lib/scopes/access/access.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/gravitational/trace"
 
+	"github.com/gravitational/teleport/api/constants"
 	scopedaccessv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/access/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/scopes"
@@ -254,6 +255,46 @@ func StrongValidateRole(role *scopedaccessv1.ScopedRole) error {
 		return trace.BadParameter("scoped role %q has invalid ssh.max_sessions %d: must be non-negative", role.GetMetadata().GetName(), ms)
 	}
 
+	// verify that session_recording_mode fields are recognized values
+	if mode := role.GetSpec().GetSsh().GetSessionRecording().GetMode(); mode != "" {
+		switch constants.SessionRecordingMode(mode) {
+		case constants.SessionRecordingModeStrict, constants.SessionRecordingModeBestEffort:
+		default:
+			return trace.BadParameter("scoped role %q has invalid ssh.session_recording_mode. %q: must be %q or %q",
+				role.GetMetadata().GetName(), mode, constants.SessionRecordingModeStrict, constants.SessionRecordingModeBestEffort)
+		}
+	}
+
+	if mode := role.GetSpec().GetDefaults().GetSessionRecording().GetMode(); mode != "" {
+		switch constants.SessionRecordingMode(mode) {
+		case constants.SessionRecordingModeStrict, constants.SessionRecordingModeBestEffort:
+		default:
+			return trace.BadParameter("scoped role %q has invalid defaults.session_recording_mode %q: must be %q or %q",
+				role.GetMetadata().GetName(), mode, constants.SessionRecordingModeStrict, constants.SessionRecordingModeBestEffort)
+		}
+	}
+
+	// verify that the lock.Mode is a recognized value for Defaults
+	if lock := role.GetSpec().GetDefaults().GetLock(); lock != nil {
+		if err := validateLock(lock); err != nil {
+			return trace.BadParameter("scoped role %q has invalid defaults.lock.mode %q", role.GetMetadata().GetName(), lock.GetMode())
+		}
+	}
+
+	// verify that lock.Mode is a recognized value for SSH
+	if lock := role.GetSpec().GetSsh().GetLock(); lock != nil {
+		if err := validateLock(lock); err != nil {
+			return trace.BadParameter("scoped role %q has invalid ssh.lock.mode %q", role.GetMetadata().GetName(), lock.GetMode())
+		}
+	}
+
+	// verify that lock.Mode is a recognized value for Kube
+	if lock := role.GetSpec().GetKube().GetLock(); lock != nil {
+		if err := validateLock(lock); err != nil {
+			return trace.BadParameter("scoped role %q has invalid kube.lock.mode %q", role.GetMetadata().GetName(), lock.GetMode())
+		}
+	}
+
 	// verify that kube labels are well-formed
 	for _, label := range role.GetSpec().GetKube().GetLabels() {
 		// we currently don't support any form of wildcard/regex/substitution in scoped role
@@ -302,6 +343,19 @@ func validateDoesNotContain(values []string, invalidSet string) string {
 	}
 
 	return ""
+}
+
+func validateLock(lock *scopedaccessv1.Lock) error {
+	mode := lock.GetMode()
+	switch constants.LockingMode(mode) {
+	// Allow for empty string - we will fall back to the cluster defaults - or best_effort if not set.
+	// This matches current behavior for unscoped lock mode checks.
+	case "":
+	case constants.LockingModeBestEffort, constants.LockingModeStrict:
+	default:
+		return trace.Errorf("invalid lock mode")
+	}
+	return nil
 }
 
 func validateRoleName(name string) error {

--- a/lib/scopes/access/access_test.go
+++ b/lib/scopes/access/access_test.go
@@ -25,6 +25,7 @@ import (
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/reflect/protoreflect"
 
+	"github.com/gravitational/teleport/api/constants"
 	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
 	labelv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/label/v1"
 	scopedaccessv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/access/v1"
@@ -394,8 +395,285 @@ func TestValidateRole(t *testing.T) {
 			strongOk: true,
 			weakOk:   true,
 		},
-	}
+		{
+			name: "invalid defaults.session_recording_mode",
+			role: &scopedaccessv1.ScopedRole{
+				Kind:     KindScopedRole,
+				Metadata: &headerv1.Metadata{Name: "test"},
+				Scope:    "/",
+				Spec: &scopedaccessv1.ScopedRoleSpec{
+					AssignableScopes: []string{"/foo"},
+					Defaults: &scopedaccessv1.ScopedRoleDefaults{
+						SessionRecording: &scopedaccessv1.SessionRecording{
+							Mode: "blah",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "invalid defaults.lock.mode",
+			role: &scopedaccessv1.ScopedRole{
+				Kind: KindScopedRole,
+				Metadata: &headerv1.Metadata{
+					Name: "test",
+				},
+				Scope: "/",
+				Spec: &scopedaccessv1.ScopedRoleSpec{
+					AssignableScopes: []string{"/foo"},
+					Defaults: &scopedaccessv1.ScopedRoleDefaults{
+						Lock: &scopedaccessv1.Lock{
+							Mode: "invalid",
+						},
+					},
+				},
+				Version: types.V1,
+			},
+			strongOk: false,
+			weakOk:   true,
+		},
+		{
+			name: "valid defaults.session_recording_mode",
+			role: &scopedaccessv1.ScopedRole{
+				Kind:     KindScopedRole,
+				Metadata: &headerv1.Metadata{Name: "test"},
+				Scope:    "/",
+				Spec: &scopedaccessv1.ScopedRoleSpec{
+					AssignableScopes: []string{"/foo"},
+					Defaults: &scopedaccessv1.ScopedRoleDefaults{
+						SessionRecording: &scopedaccessv1.SessionRecording{
+							Mode: string(constants.SessionRecordingModeStrict),
+						},
+					},
+				},
+				Version: types.V1,
+			},
+			strongOk: true,
+			weakOk:   true,
+		},
+		{
+			name: "invalid ssh.session_recording_mode",
+			role: &scopedaccessv1.ScopedRole{
+				Kind:     KindScopedRole,
+				Metadata: &headerv1.Metadata{Name: "test"},
+				Scope:    "/",
+				Spec: &scopedaccessv1.ScopedRoleSpec{
+					AssignableScopes: []string{"/foo"},
+					Ssh: &scopedaccessv1.ScopedRoleSSH{
+						SessionRecording: &scopedaccessv1.SessionRecording{
+							Mode: "blah",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "invalid ssh.lock.mode",
+			role: &scopedaccessv1.ScopedRole{
+				Kind: KindScopedRole,
+				Metadata: &headerv1.Metadata{
+					Name: "test",
+				},
+				Scope: "/",
+				Spec: &scopedaccessv1.ScopedRoleSpec{
+					AssignableScopes: []string{"/foo"},
+					Ssh: &scopedaccessv1.ScopedRoleSSH{
+						Lock: &scopedaccessv1.Lock{
+							Mode: "invalid",
+						},
+					},
+				},
+				Version: types.V1,
+			},
+			strongOk: false,
+			weakOk:   true,
+		},
+		{
+			name: "valid ssh.session_recording_mode",
+			role: &scopedaccessv1.ScopedRole{
+				Kind:     KindScopedRole,
+				Metadata: &headerv1.Metadata{Name: "test"},
+				Scope:    "/",
+				Spec: &scopedaccessv1.ScopedRoleSpec{
+					AssignableScopes: []string{"/foo"},
+					Ssh: &scopedaccessv1.ScopedRoleSSH{
+						SessionRecording: &scopedaccessv1.SessionRecording{
+							Mode: string(constants.SessionRecordingModeStrict),
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "valid ssh.lock.mode",
+			role: &scopedaccessv1.ScopedRole{
+				Kind: KindScopedRole,
+				Metadata: &headerv1.Metadata{
+					Name: "test",
+				},
+				Scope: "/",
+				Spec: &scopedaccessv1.ScopedRoleSpec{
+					AssignableScopes: []string{"/foo"},
+					Ssh: &scopedaccessv1.ScopedRoleSSH{
+						Lock: &scopedaccessv1.Lock{
+							Mode: string(constants.LockingModeStrict),
+						},
+					},
+				},
+				Version: types.V1,
+			},
+			strongOk: true,
+			weakOk:   true,
+		},
 
+		{
+			name: "empty ssh.lock.mode",
+			role: &scopedaccessv1.ScopedRole{
+				Kind: KindScopedRole,
+				Metadata: &headerv1.Metadata{
+					Name: "test",
+				},
+				Scope: "/",
+				Spec: &scopedaccessv1.ScopedRoleSpec{
+					AssignableScopes: []string{"/foo"},
+					Ssh: &scopedaccessv1.ScopedRoleSSH{
+						Lock: &scopedaccessv1.Lock{
+							Mode: "",
+						},
+					},
+				},
+				Version: types.V1,
+			},
+			strongOk: true,
+			weakOk:   true,
+		},
+		{
+			name: "invalid kube.lock.mode",
+			role: &scopedaccessv1.ScopedRole{
+				Kind: KindScopedRole,
+				Metadata: &headerv1.Metadata{
+					Name: "test",
+				},
+				Scope: "/",
+				Spec: &scopedaccessv1.ScopedRoleSpec{
+					AssignableScopes: []string{"/foo"},
+					Kube: &scopedaccessv1.ScopedRoleKube{
+						Lock: &scopedaccessv1.Lock{
+							Mode: "invalid",
+						},
+					},
+				},
+				Version: types.V1,
+			},
+			strongOk: false,
+			weakOk:   true,
+		},
+		{
+			name: "valid Kube.lock.mode",
+			role: &scopedaccessv1.ScopedRole{
+				Kind: KindScopedRole,
+				Metadata: &headerv1.Metadata{
+					Name: "test",
+				},
+				Scope: "/",
+				Spec: &scopedaccessv1.ScopedRoleSpec{
+					AssignableScopes: []string{"/foo"},
+					Kube: &scopedaccessv1.ScopedRoleKube{
+						Lock: &scopedaccessv1.Lock{
+							Mode: string(constants.LockingModeStrict),
+						},
+					},
+				},
+				Version: types.V1,
+			},
+			strongOk: true,
+			weakOk:   true,
+		},
+		{
+			name: "empty Kube.lock.mode",
+			role: &scopedaccessv1.ScopedRole{
+				Kind: KindScopedRole,
+				Metadata: &headerv1.Metadata{
+					Name: "test",
+				},
+				Scope: "/",
+				Spec: &scopedaccessv1.ScopedRoleSpec{
+					AssignableScopes: []string{"/foo"},
+					Kube: &scopedaccessv1.ScopedRoleKube{
+						Lock: &scopedaccessv1.Lock{
+							Mode: "",
+						},
+					},
+				},
+				Version: types.V1,
+			},
+			strongOk: true,
+			weakOk:   true,
+		},
+		{
+			name: "invalid defaults.lock.mode",
+			role: &scopedaccessv1.ScopedRole{
+				Kind: KindScopedRole,
+				Metadata: &headerv1.Metadata{
+					Name: "test",
+				},
+				Scope: "/",
+				Spec: &scopedaccessv1.ScopedRoleSpec{
+					AssignableScopes: []string{"/foo"},
+					Defaults: &scopedaccessv1.ScopedRoleDefaults{
+						Lock: &scopedaccessv1.Lock{
+							Mode: "invalid",
+						},
+					},
+				},
+				Version: types.V1,
+			},
+			strongOk: false,
+			weakOk:   true,
+		},
+		{
+			name: "valid defaults.lock.mode",
+			role: &scopedaccessv1.ScopedRole{
+				Kind: KindScopedRole,
+				Metadata: &headerv1.Metadata{
+					Name: "test",
+				},
+				Scope: "/",
+				Spec: &scopedaccessv1.ScopedRoleSpec{
+					AssignableScopes: []string{"/foo"},
+					Defaults: &scopedaccessv1.ScopedRoleDefaults{
+						Lock: &scopedaccessv1.Lock{
+							Mode: string(constants.LockingModeStrict),
+						},
+					},
+				},
+				Version: types.V1,
+			},
+			strongOk: true,
+			weakOk:   true,
+		},
+		{
+			name: "empty defaults.lock.mode",
+			role: &scopedaccessv1.ScopedRole{
+				Kind: KindScopedRole,
+				Metadata: &headerv1.Metadata{
+					Name: "test",
+				},
+				Scope: "/",
+				Spec: &scopedaccessv1.ScopedRoleSpec{
+					AssignableScopes: []string{"/foo"},
+					Defaults: &scopedaccessv1.ScopedRoleDefaults{
+						Lock: &scopedaccessv1.Lock{
+							Mode: "",
+						},
+					},
+				},
+				Version: types.V1,
+			},
+			strongOk: true,
+			weakOk:   true,
+		},
+	}
 	for _, tt := range tts {
 		t.Run(tt.name, func(t *testing.T) {
 			err := StrongValidateRole(tt.role)
@@ -1217,6 +1495,13 @@ func TestStrongValidateRoleSpecAllFieldsValidated(t *testing.T) {
 		AssignableScopes: []string{"/foo"},
 		Defaults: &scopedaccessv1.ScopedRoleDefaults{
 			ClientIdleTimeout: "30m",
+			SessionRecording: &scopedaccessv1.SessionRecording{
+				Mode: string(constants.SessionRecordingModeStrict),
+			},
+			Lock: &scopedaccessv1.Lock{
+				Mode: "strict",
+			},
+			DisconnectExpiredCert: ptr(true),
 		},
 		Rules: []*scopedaccessv1.ScopedRule{
 			{
@@ -1244,6 +1529,18 @@ func TestStrongValidateRoleSpecAllFieldsValidated(t *testing.T) {
 			},
 			HostSudoers: []string{"ALL=(ALL) NOPASSWD:ALL"},
 			MaxSessions: proto.Int64(10),
+			EnhancedRecording: &scopedaccessv1.EnhancedRecording{
+				Disk:    proto.Bool(true),
+				Network: proto.Bool(true),
+				Command: proto.Bool(true),
+			},
+			SessionRecording: &scopedaccessv1.SessionRecording{
+				Mode: string(constants.SessionRecordingModeStrict),
+			},
+			Lock: &scopedaccessv1.Lock{
+				Mode: string(constants.LockingModeBestEffort),
+			},
+			DisconnectExpiredCert: proto.Bool(true),
 		},
 		Kube: &scopedaccessv1.ScopedRoleKube{
 			Groups: []string{"viewer"},
@@ -1251,7 +1548,11 @@ func TestStrongValidateRoleSpecAllFieldsValidated(t *testing.T) {
 			Labels: []*labelv1.Label{
 				{Name: "env", Values: []string{"prod"}},
 			},
-			ClientIdleTimeout: "1h",
+			ClientIdleTimeout:     "1h",
+			DisconnectExpiredCert: ptr(true),
+			Lock: &scopedaccessv1.Lock{
+				Mode: "strict",
+			},
 		},
 	}
 

--- a/lib/scopes/access/compat.go
+++ b/lib/scopes/access/compat.go
@@ -168,7 +168,7 @@ func ScopedRoleToRole(sr *scopedaccessv1.ScopedRole, assignedScope string) (type
 			// per-protocol disconnect on expired cert, with the global setting always applying for operations that are not tied to a
 			// specific access check. By setting this value to false we effectively make the default behavior one where we
 			// are always deferring to the global setting for scoped identities, which aught to be forwards compatible with
-			// whatever solution we eventually land on	.
+			// whatever solution we eventually land on.
 			DisconnectExpiredCert: types.NewBool(false),
 		},
 	})

--- a/lib/scopes/access/compat_test.go
+++ b/lib/scopes/access/compat_test.go
@@ -22,6 +22,8 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/require"
 
+	"github.com/gravitational/teleport/api/constants"
+	apidefaults "github.com/gravitational/teleport/api/defaults"
 	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
 	labelv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/label/v1"
 	scopedaccessv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/access/v1"
@@ -229,10 +231,13 @@ func baseScopedRole() *scopedaccessv1.ScopedRole {
 		Spec: &scopedaccessv1.ScopedRoleSpec{
 			AssignableScopes: []string{"/foo/bar"},
 			Ssh:              &scopedaccessv1.ScopedRoleSSH{},
+			Kube:             &scopedaccessv1.ScopedRoleKube{},
 		},
 		Version: types.V1,
 	}
 }
+
+func ptr[T any](v T) *T { return &v }
 
 // TestClientIdleTimeoutNotInClassicRole verifies that ScopedRoleToRole does not populate ClientIdleTimeout
 // in the classic role options. Per the scoped role design, client_idle_timeout is read directly from the
@@ -254,9 +259,8 @@ func TestClientIdleTimeoutNotInClassicRole(t *testing.T) {
 func TestX11ForwardingNotInClassicRole(t *testing.T) {
 	t.Parallel()
 
-	boolPtr := func(v bool) *bool { return &v }
 	sr := baseScopedRole()
-	sr.Spec.Ssh.PermitX11Forwarding = boolPtr(true)
+	sr.Spec.Ssh.PermitX11Forwarding = ptr(true)
 
 	role, err := ScopedRoleToRole(sr, "/foo/bar")
 	require.NoError(t, err)
@@ -266,9 +270,8 @@ func TestX11ForwardingNotInClassicRole(t *testing.T) {
 func TestForwardAgentNotInClassicRole(t *testing.T) {
 	t.Parallel()
 
-	boolPtr := func(v bool) *bool { return &v }
 	sr := baseScopedRole()
-	sr.Spec.Ssh.ForwardAgent = boolPtr(true)
+	sr.Spec.Ssh.ForwardAgent = ptr(true)
 
 	role, err := ScopedRoleToRole(sr, "/foo/bar")
 	require.NoError(t, err)
@@ -278,9 +281,8 @@ func TestForwardAgentNotInClassicRole(t *testing.T) {
 func TestMaxSessionsNotInClassicRole(t *testing.T) {
 	t.Parallel()
 
-	int64Ptr := func(v int64) *int64 { return &v }
 	sr := baseScopedRole()
-	sr.Spec.Ssh.MaxSessions = int64Ptr(10)
+	sr.Spec.Ssh.MaxSessions = ptr(int64(10))
 
 	role, err := ScopedRoleToRole(sr, "/foo/bar")
 	require.NoError(t, err)
@@ -290,11 +292,10 @@ func TestMaxSessionsNotInClassicRole(t *testing.T) {
 func TestSSHPortForwardingNotInClassicRole(t *testing.T) {
 	t.Parallel()
 
-	boolPtr := func(v bool) *bool { return &v }
 	sr := baseScopedRole()
 	sr.Spec.Ssh.PortForwarding = &scopedaccessv1.SSHPortForwarding{
-		Local:  &scopedaccessv1.SSHLocalPortForwarding{Enabled: boolPtr(false)},
-		Remote: &scopedaccessv1.SSHRemotePortForwarding{Enabled: boolPtr(false)},
+		Local:  &scopedaccessv1.SSHLocalPortForwarding{Enabled: ptr(false)},
+		Remote: &scopedaccessv1.SSHRemotePortForwarding{Enabled: ptr(false)},
 	}
 
 	role, err := ScopedRoleToRole(sr, "/foo/bar")
@@ -318,13 +319,96 @@ func TestHostUserCreationNotInClassicRole(t *testing.T) {
 func TestSSHFileCopyNotInClassicRole(t *testing.T) {
 	t.Parallel()
 
-	boolPtr := func(v bool) *bool { return &v }
 	sr := baseScopedRole()
-	sr.Spec.Ssh.FileCopy = boolPtr(false)
+	sr.Spec.Ssh.FileCopy = ptr(false)
 
 	role, err := ScopedRoleToRole(sr, "/foo/bar")
 	require.NoError(t, err)
 	require.Equal(t, types.NewBoolOption(true), role.GetOptions().SSHFileCopy)
+}
+
+func TestEnhancedRecordingNotInClassicRole(t *testing.T) {
+	t.Parallel()
+
+	sr := baseScopedRole()
+	sr.Spec.Ssh.EnhancedRecording = &scopedaccessv1.EnhancedRecording{
+		Command: ptr(true),
+		Network: ptr(true),
+		Disk:    ptr(true),
+	}
+	role, err := ScopedRoleToRole(sr, "/foo/bar")
+	require.NoError(t, err)
+	// BPF is the classic role equivalent of enhanced_recording.
+	require.Equal(t, apidefaults.EnhancedEvents(), role.GetOptions().BPF)
+}
+
+func TestDisconnectExpiredCertNotInClassicRole(t *testing.T) {
+	t.Parallel()
+
+	sr := baseScopedRole()
+	sr.Spec.Ssh.DisconnectExpiredCert = ptr(true)
+
+	role, err := ScopedRoleToRole(sr, "/foo/bar")
+	require.NoError(t, err)
+	require.Equal(t, types.NewBool(false), role.GetOptions().DisconnectExpiredCert)
+}
+
+func TestKubeDisconnectExpiredCertNotInClassicRole(t *testing.T) {
+	t.Parallel()
+
+	sr := baseScopedRole()
+	sr.Spec.Kube = &scopedaccessv1.ScopedRoleKube{
+		DisconnectExpiredCert: ptr(true),
+	}
+
+	role, err := ScopedRoleToRole(sr, "/foo/bar")
+	require.NoError(t, err)
+	require.Equal(t, types.NewBool(false), role.GetOptions().DisconnectExpiredCert)
+}
+
+func TestSessionRecordingNotInClassicRole(t *testing.T) {
+	t.Parallel()
+
+	sr := baseScopedRole()
+	sr.Spec.Ssh.SessionRecording = &scopedaccessv1.SessionRecording{
+		Mode: string(constants.SessionRecordingModeBestEffort),
+	}
+
+	role, err := ScopedRoleToRole(sr, "/foo/bar")
+	require.NoError(t, err)
+
+	// RecordSession is the classic role equivalent of session_recording_mode.
+	require.Equal(t, &types.RecordSession{
+		Desktop: types.NewBoolOption(true),
+		Default: constants.SessionRecordingModeBestEffort,
+	}, role.GetOptions().RecordSession)
+}
+
+func TestSSHLockingModeNotInClassicRole(t *testing.T) {
+	t.Parallel()
+
+	sr := baseScopedRole()
+	sr.Spec.Ssh.Lock = &scopedaccessv1.Lock{
+		Mode: "strict",
+	}
+
+	role, err := ScopedRoleToRole(sr, "/foo/bar")
+	require.NoError(t, err)
+
+	require.Empty(t, string(role.GetOptions().Lock))
+}
+
+func TestKubeLockingModeNotInClassicRole(t *testing.T) {
+	t.Parallel()
+
+	sr := baseScopedRole()
+	sr.Spec.Kube.Lock = &scopedaccessv1.Lock{
+		Mode: "strict",
+	}
+
+	role, err := ScopedRoleToRole(sr, "/foo/bar")
+	require.NoError(t, err)
+	require.Empty(t, string(role.GetOptions().Lock))
 }
 
 // TestKubeConversion verifies the various kube-related scoped role conversion scenarios.

--- a/lib/services/common_access_checker.go
+++ b/lib/services/common_access_checker.go
@@ -1,0 +1,75 @@
+/*
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package services
+
+import (
+	"time"
+
+	"github.com/gravitational/trace"
+
+	"github.com/gravitational/teleport/api/constants"
+	accessv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/access/v1"
+)
+
+// adjust the client idle timeout value - preferring the default if not set
+func (c *ScopedAccessChecker) adjustScopedClientIdleTimeout(idleStr string, timeout time.Duration) (time.Duration, error) {
+	if idleStr == "" {
+		idleStr = c.role.GetSpec().GetDefaults().GetClientIdleTimeout()
+	}
+	if idleStr != "" {
+		d, err := time.ParseDuration(idleStr)
+		if err != nil {
+			return 0, trace.Errorf("invalid client_idle_timeout %q in scoped role %q: %w", idleStr, c.role.GetMetadata().GetName(), err)
+		}
+		if d > 0 && (timeout == 0 || d < timeout) {
+			return max(d, 0), nil
+		}
+	}
+	return max(timeout, 0), nil
+}
+
+// adjustScopedDisconnectExpiredCert returns the disconnect on Expired Cert condition - - applying the default if applicable.
+func (c *ScopedAccessChecker) adjustScopedDisconnectExpiredCert(roleSpecifiedDisconnect *bool, defaultdisconnect bool) bool {
+	if roleSpecifiedDisconnect == nil && c.role.GetSpec().GetDefaults() != nil {
+		roleSpecifiedDisconnect = c.role.GetSpec().GetDefaults().DisconnectExpiredCert
+	}
+
+	if roleSpecifiedDisconnect != nil {
+		return *roleSpecifiedDisconnect
+	}
+	return defaultdisconnect
+}
+
+// LockingMode returns the lock enforcement mode to apply - applying the default if applicable.
+func (c *ScopedAccessChecker) scopedLockingMode(lock *accessv1.Lock, defaultMode constants.LockingMode) constants.LockingMode {
+	if lock == nil {
+		lock = c.role.GetSpec().GetDefaults().GetLock()
+	}
+	// both protocol specific lock and the default locks are nil, so return the defaultMode.
+	if lock == nil {
+		return defaultMode
+	}
+
+	mode := constants.LockingMode(lock.GetMode())
+	switch mode {
+	case constants.LockingModeStrict, constants.LockingModeBestEffort:
+		return mode
+	default:
+		return defaultMode
+	}
+}

--- a/lib/services/kube_access_checker.go
+++ b/lib/services/kube_access_checker.go
@@ -21,8 +21,7 @@ package services
 import (
 	"time"
 
-	"github.com/gravitational/trace"
-
+	"github.com/gravitational/teleport/api/constants"
 	"github.com/gravitational/teleport/api/types"
 )
 
@@ -78,19 +77,27 @@ func (c *KubeAccessChecker) AdjustClientIdleTimeout(timeout time.Duration) (time
 	if !c.checker.isScoped() {
 		return c.checker.unscopedChecker.AdjustClientIdleTimeout(timeout), nil
 	}
-	// Kube block takes precedence over defaults block.
-	idleStr := c.checker.role.GetSpec().GetKube().GetClientIdleTimeout()
-	if idleStr == "" {
-		idleStr = c.checker.role.GetSpec().GetDefaults().GetClientIdleTimeout()
+	return c.checker.adjustScopedClientIdleTimeout(c.checker.role.GetSpec().GetKube().GetClientIdleTimeout(), timeout)
+}
+
+// AdjustDisconnectExpiredCert adjusts whether to disconnect on certificate expiry.
+func (c *KubeAccessChecker) AdjustDisconnectExpiredCert(disconnect bool) bool {
+	if !c.checker.isScoped() {
+		return c.checker.unscopedChecker.AdjustDisconnectExpiredCert(disconnect)
 	}
-	if idleStr != "" {
-		d, err := time.ParseDuration(idleStr)
-		if err != nil {
-			return 0, trace.Errorf("invalid client_idle_timeout %q in scoped role %q: %w", idleStr, c.checker.role.GetMetadata().GetName(), err)
-		}
-		if d > 0 && (timeout == 0 || d < timeout) {
-			return max(d, 0), nil
-		}
+	kube := c.checker.role.GetSpec().GetKube()
+	var disconnectExpiredCert *bool
+	if kube != nil {
+		disconnectExpiredCert = kube.DisconnectExpiredCert
 	}
-	return max(timeout, 0), nil
+	return c.checker.adjustScopedDisconnectExpiredCert(disconnectExpiredCert, disconnect)
+}
+
+// LockingMode returns the SSH lock enforcement mode to apply.
+func (c *KubeAccessChecker) LockingMode(defaultMode constants.LockingMode) constants.LockingMode {
+	if !c.checker.isScoped() {
+		return c.checker.unscopedChecker.LockingMode(defaultMode)
+	}
+
+	return c.checker.scopedLockingMode(c.checker.role.GetSpec().GetKube().GetLock(), defaultMode)
 }

--- a/lib/services/kube_access_checker_test.go
+++ b/lib/services/kube_access_checker_test.go
@@ -1,0 +1,171 @@
+/*
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package services
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport/api/constants"
+	scopedaccessv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/access/v1"
+)
+
+func TestKubeAccessCheckerAdjustDisconnectExpiredCert(t *testing.T) {
+
+	tts := []struct {
+		name       string
+		spec       *scopedaccessv1.ScopedRoleSpec
+		defaultVal bool
+		expect     bool
+	}{
+		{
+			name: "unset defers to default false",
+			spec: &scopedaccessv1.ScopedRoleSpec{
+				Kube: &scopedaccessv1.ScopedRoleKube{},
+			},
+			defaultVal: false,
+			expect:     false,
+		},
+		{
+			name: "unset kube and default defers to default true",
+			spec: &scopedaccessv1.ScopedRoleSpec{
+				Kube: &scopedaccessv1.ScopedRoleKube{},
+			},
+			defaultVal: true,
+			expect:     true,
+		},
+		{
+			name: "explicit true overrides default false",
+			spec: &scopedaccessv1.ScopedRoleSpec{
+				Kube: &scopedaccessv1.ScopedRoleKube{
+					DisconnectExpiredCert: ptr(true),
+				},
+			},
+			defaultVal: false,
+			expect:     true,
+		},
+		{
+			name: "explicit false overrides default true",
+			spec: &scopedaccessv1.ScopedRoleSpec{
+				Kube: &scopedaccessv1.ScopedRoleKube{
+					DisconnectExpiredCert: ptr(false),
+				},
+			},
+			defaultVal: true,
+			expect:     false,
+		},
+		{
+			name: "default block is applied when kube block is empty",
+			spec: &scopedaccessv1.ScopedRoleSpec{
+				Defaults: &scopedaccessv1.ScopedRoleDefaults{
+					DisconnectExpiredCert: ptr(false),
+				},
+				Kube: &scopedaccessv1.ScopedRoleKube{},
+			},
+			defaultVal: true,
+			expect:     false,
+		},
+	}
+
+	for _, tt := range tts {
+		t.Run(tt.name, func(t *testing.T) {
+			checker := newScopedCheckerWithRole(tt.spec).Kube()
+			require.Equal(t, tt.expect, checker.AdjustDisconnectExpiredCert(tt.defaultVal))
+		})
+	}
+}
+
+func TestKubeAccessCheckerLockingMode(t *testing.T) {
+
+	tts := []struct {
+		name        string
+		spec        *scopedaccessv1.ScopedRoleSpec
+		defaultMode constants.LockingMode
+		expect      constants.LockingMode
+	}{
+		{
+			name: "unset kube and default blocks defers to default mode",
+			spec: &scopedaccessv1.ScopedRoleSpec{
+				Kube: &scopedaccessv1.ScopedRoleKube{},
+			},
+			defaultMode: constants.LockingModeBestEffort,
+			expect:      constants.LockingModeBestEffort,
+		},
+		{
+			name: "strict from role",
+			spec: &scopedaccessv1.ScopedRoleSpec{
+				Kube: &scopedaccessv1.ScopedRoleKube{
+					Lock: &scopedaccessv1.Lock{
+						Mode: string(constants.LockingModeStrict),
+					},
+				},
+			},
+			defaultMode: constants.LockingModeBestEffort,
+			expect:      constants.LockingModeStrict,
+		},
+		{
+			name: "best effort from role",
+			spec: &scopedaccessv1.ScopedRoleSpec{
+				Kube: &scopedaccessv1.ScopedRoleKube{
+					Lock: &scopedaccessv1.Lock{
+						Mode: string(constants.LockingModeBestEffort),
+					},
+				},
+			},
+			defaultMode: constants.LockingModeStrict,
+			expect:      constants.LockingModeBestEffort,
+		},
+		{
+			name: "invalid value falls back to default",
+			spec: &scopedaccessv1.ScopedRoleSpec{
+				Kube: &scopedaccessv1.ScopedRoleKube{
+
+					Lock: &scopedaccessv1.Lock{
+						Mode: "invalid",
+					},
+				},
+			},
+			defaultMode: constants.LockingModeStrict,
+			expect:      constants.LockingModeStrict,
+		},
+		{
+			name: "empty mode falls back to default block",
+			spec: &scopedaccessv1.ScopedRoleSpec{
+				Defaults: &scopedaccessv1.ScopedRoleDefaults{
+					Lock: &scopedaccessv1.Lock{
+						Mode: string(constants.LockingModeStrict),
+					},
+				},
+				Kube: &scopedaccessv1.ScopedRoleKube{
+					Lock: nil,
+				},
+			},
+			defaultMode: constants.LockingModeBestEffort,
+			expect:      constants.LockingModeStrict,
+		},
+	}
+
+	for _, tt := range tts {
+		t.Run(tt.name, func(t *testing.T) {
+			checker := newScopedCheckerWithRole(tt.spec).Kube()
+			require.Equal(t, tt.expect, checker.LockingMode(tt.defaultMode))
+		})
+	}
+}

--- a/lib/services/ssh_access_checker.go
+++ b/lib/services/ssh_access_checker.go
@@ -62,21 +62,8 @@ func (c *SSHAccessChecker) AdjustClientIdleTimeout(timeout time.Duration) (time.
 	if !c.checker.isScoped() {
 		return c.checker.unscopedChecker.AdjustClientIdleTimeout(timeout), nil
 	}
-	// SSH block takes precedence over defaults block.
-	idleStr := c.checker.role.GetSpec().GetSsh().GetClientIdleTimeout()
-	if idleStr == "" {
-		idleStr = c.checker.role.GetSpec().GetDefaults().GetClientIdleTimeout()
-	}
-	if idleStr != "" {
-		d, err := time.ParseDuration(idleStr)
-		if err != nil {
-			return 0, trace.Errorf("invalid client_idle_timeout %q in scoped role %q: %w", idleStr, c.checker.role.GetMetadata().GetName(), err)
-		}
-		if d > 0 && (timeout == 0 || d < timeout) {
-			return max(d, 0), nil
-		}
-	}
-	return max(timeout, 0), nil
+
+	return c.checker.adjustScopedClientIdleTimeout(c.checker.role.GetSpec().GetSsh().GetClientIdleTimeout(), timeout)
 }
 
 // AdjustDisconnectExpiredCert adjusts whether to disconnect on certificate expiry.
@@ -84,15 +71,37 @@ func (c *SSHAccessChecker) AdjustDisconnectExpiredCert(disconnect bool) bool {
 	if !c.checker.isScoped() {
 		return c.checker.unscopedChecker.AdjustDisconnectExpiredCert(disconnect)
 	}
-	return c.checker.scopedCompatChecker.AdjustDisconnectExpiredCert(disconnect)
+	ssh := c.checker.role.GetSpec().GetSsh()
+	var disconnectExpiredCert *bool
+	if ssh != nil {
+		disconnectExpiredCert = ssh.DisconnectExpiredCert
+	}
+	return c.checker.adjustScopedDisconnectExpiredCert(disconnectExpiredCert, disconnect)
+}
+
+// LockingMode returns the SSH lock enforcement mode to apply.
+func (c *SSHAccessChecker) LockingMode(defaultMode constants.LockingMode) constants.LockingMode {
+	if !c.checker.isScoped() {
+		return c.checker.unscopedChecker.LockingMode(defaultMode)
+	}
+
+	return c.checker.scopedLockingMode(c.checker.role.GetSpec().GetSsh().GetLock(), defaultMode)
 }
 
 // SessionRecordingMode returns the session recording mode for SSH sessions.
+// SSH recording mode takes precedence over the defaults
 func (c *SSHAccessChecker) SessionRecordingMode() constants.SessionRecordingMode {
 	if !c.checker.isScoped() {
 		return c.checker.unscopedChecker.SessionRecordingMode(constants.SessionRecordingServiceSSH)
 	}
-	return c.checker.scopedCompatChecker.SessionRecordingMode(constants.SessionRecordingServiceSSH)
+	sr := c.checker.role.GetSpec().GetSsh().GetSessionRecording()
+	if sr == nil {
+		sr = c.checker.role.GetSpec().GetDefaults().GetSessionRecording()
+	}
+	if sr.GetMode() != "" {
+		return constants.SessionRecordingMode(sr.GetMode())
+	}
+	return constants.SessionRecordingModeBestEffort
 }
 
 // CanPortForward returns true if port forwarding is permitted.
@@ -162,7 +171,18 @@ func (c *SSHAccessChecker) EnhancedRecordingSet() map[string]bool {
 	if !c.checker.isScoped() {
 		return c.checker.unscopedChecker.EnhancedRecordingSet()
 	}
-	return c.checker.scopedCompatChecker.EnhancedRecordingSet()
+	events := c.checker.role.GetSpec().GetSsh().GetEnhancedRecording()
+	m := make(map[string]bool)
+	if events.GetCommand() {
+		m[constants.EnhancedRecordingCommand] = true
+	}
+	if events.GetDisk() {
+		m[constants.EnhancedRecordingDisk] = true
+	}
+	if events.GetNetwork() {
+		m[constants.EnhancedRecordingNetwork] = true
+	}
+	return m
 }
 
 // HostUsers returns host user creation information for the server, or nil if host user creation is disabled.

--- a/lib/services/ssh_access_checker_test.go
+++ b/lib/services/ssh_access_checker_test.go
@@ -195,6 +195,149 @@ func TestSSHAccessCheckerAdjustClientIdleTimeout(t *testing.T) {
 
 func ptr[T any](v T) *T { return &v }
 
+func TestSSHAccessCheckerAdjustDisconnectExpiredCert(t *testing.T) {
+	t.Parallel()
+
+	tts := []struct {
+		name       string
+		spec       *scopedaccessv1.ScopedRoleSpec
+		defaultVal bool
+		expect     bool
+	}{
+		{
+			name: "unset defers to default false",
+			spec: &scopedaccessv1.ScopedRoleSpec{
+				Ssh: &scopedaccessv1.ScopedRoleSSH{},
+			},
+			defaultVal: false,
+			expect:     false,
+		},
+		{
+			name: "unset defers to default true",
+			spec: &scopedaccessv1.ScopedRoleSpec{
+				Ssh: &scopedaccessv1.ScopedRoleSSH{},
+			},
+			defaultVal: true,
+			expect:     true,
+		},
+		{
+			name: "explicit true overrides default false",
+			spec: &scopedaccessv1.ScopedRoleSpec{
+				Ssh: &scopedaccessv1.ScopedRoleSSH{
+					DisconnectExpiredCert: ptr(true),
+				},
+			},
+			defaultVal: false,
+			expect:     true,
+		},
+		{
+			name: "explicit false overrides default true",
+			spec: &scopedaccessv1.ScopedRoleSpec{
+				Ssh: &scopedaccessv1.ScopedRoleSSH{
+					DisconnectExpiredCert: ptr(false),
+				},
+			},
+			defaultVal: true,
+			expect:     false,
+		},
+		{
+			name: "unset ssh block defaults to default block",
+			spec: &scopedaccessv1.ScopedRoleSpec{
+				Defaults: &scopedaccessv1.ScopedRoleDefaults{
+					DisconnectExpiredCert: ptr(false),
+				},
+				Ssh: &scopedaccessv1.ScopedRoleSSH{},
+			},
+			defaultVal: true,
+			expect:     false,
+		},
+	}
+
+	for _, tt := range tts {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			checker := newScopedCheckerWithRole(tt.spec).SSH()
+			require.Equal(t, tt.expect, checker.AdjustDisconnectExpiredCert(tt.defaultVal))
+		})
+	}
+}
+
+func TestSSHAccessCheckerLockingMode(t *testing.T) {
+	t.Parallel()
+
+	tts := []struct {
+		name        string
+		spec        *scopedaccessv1.ScopedRoleSpec
+		defaultMode constants.LockingMode
+		expect      constants.LockingMode
+	}{
+		{
+			name: "unset defers to default",
+			spec: &scopedaccessv1.ScopedRoleSpec{
+				Ssh: &scopedaccessv1.ScopedRoleSSH{},
+			},
+			defaultMode: constants.LockingModeBestEffort,
+			expect:      constants.LockingModeBestEffort,
+		},
+		{
+			name: "strict from role",
+			spec: &scopedaccessv1.ScopedRoleSpec{
+				Ssh: &scopedaccessv1.ScopedRoleSSH{
+					Lock: &scopedaccessv1.Lock{
+						Mode: string(constants.LockingModeStrict),
+					},
+				},
+			},
+			defaultMode: constants.LockingModeBestEffort,
+			expect:      constants.LockingModeStrict,
+		},
+		{
+			name: "best effort from role",
+			spec: &scopedaccessv1.ScopedRoleSpec{
+				Ssh: &scopedaccessv1.ScopedRoleSSH{
+					Lock: &scopedaccessv1.Lock{
+						Mode: string(constants.LockingModeBestEffort),
+					},
+				},
+			},
+			defaultMode: constants.LockingModeStrict,
+			expect:      constants.LockingModeBestEffort,
+		},
+		{
+			name: "invalid value falls back to default",
+			spec: &scopedaccessv1.ScopedRoleSpec{
+				Ssh: &scopedaccessv1.ScopedRoleSSH{
+
+					Lock: &scopedaccessv1.Lock{
+						Mode: "invalid",
+					},
+				},
+			},
+			defaultMode: constants.LockingModeStrict,
+			expect:      constants.LockingModeStrict,
+		},
+		{
+			name: "empty mode falls back to default",
+			spec: &scopedaccessv1.ScopedRoleSpec{
+				Ssh: &scopedaccessv1.ScopedRoleSSH{
+
+					Lock: &scopedaccessv1.Lock{},
+				},
+			},
+			defaultMode: constants.LockingModeStrict,
+			expect:      constants.LockingModeStrict,
+		},
+	}
+
+	for _, tt := range tts {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			checker := newScopedCheckerWithRole(tt.spec).SSH()
+			require.Equal(t, tt.expect, checker.LockingMode(tt.defaultMode))
+		})
+	}
+}
+
 func TestSSHAccessCheckerPermitX11Forwarding(t *testing.T) {
 	t.Parallel()
 
@@ -503,6 +646,109 @@ func TestSSHAccessCheckerHostSudoers(t *testing.T) {
 			sudoers, err := checker.HostSudoers(srv)
 			require.NoError(t, err)
 			require.Equal(t, tt.expect, sudoers)
+		})
+	}
+}
+
+func TestSSHAccessCheckerSessionRecordingMode(t *testing.T) {
+	t.Parallel()
+
+	tts := []struct {
+		name   string
+		spec   *scopedaccessv1.ScopedRoleSpec
+		expect constants.SessionRecordingMode
+	}{
+		{
+			name:   "unset defaults to best_effort",
+			spec:   &scopedaccessv1.ScopedRoleSpec{Ssh: &scopedaccessv1.ScopedRoleSSH{}},
+			expect: constants.SessionRecordingModeBestEffort,
+		},
+		{
+			name: "ssh strict",
+			spec: &scopedaccessv1.ScopedRoleSpec{
+				Ssh: &scopedaccessv1.ScopedRoleSSH{
+					SessionRecording: &scopedaccessv1.SessionRecording{
+						Mode: string(constants.SessionRecordingModeStrict),
+					},
+				},
+			},
+			expect: constants.SessionRecordingModeStrict,
+		},
+		{
+			name: "defaults used when ssh unset",
+			spec: &scopedaccessv1.ScopedRoleSpec{
+				Defaults: &scopedaccessv1.ScopedRoleDefaults{
+					SessionRecording: &scopedaccessv1.SessionRecording{
+						Mode: string(constants.SessionRecordingModeStrict),
+					},
+				},
+			},
+			expect: constants.SessionRecordingModeStrict,
+		},
+		{
+			name: "ssh overrides defaults",
+			spec: &scopedaccessv1.ScopedRoleSpec{
+				Defaults: &scopedaccessv1.ScopedRoleDefaults{
+					SessionRecording: &scopedaccessv1.SessionRecording{
+						Mode: string(constants.SessionRecordingModeBestEffort),
+					},
+				},
+				Ssh: &scopedaccessv1.ScopedRoleSSH{
+					SessionRecording: &scopedaccessv1.SessionRecording{
+						Mode: string(constants.SessionRecordingModeBestEffort),
+					},
+				},
+			},
+			expect: constants.SessionRecordingModeBestEffort,
+		},
+	}
+
+	for _, tt := range tts {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			checker := newScopedCheckerWithRole(tt.spec).SSH()
+			require.Equal(t, tt.expect, checker.SessionRecordingMode())
+		})
+	}
+}
+
+func TestSSHAccessCheckerEnhancedRecording(t *testing.T) {
+	t.Parallel()
+
+	tts := []struct {
+		name   string
+		spec   *scopedaccessv1.ScopedRoleSpec
+		expect map[string]bool
+	}{
+		{
+			name: "no events",
+			spec: &scopedaccessv1.ScopedRoleSpec{
+				Ssh: &scopedaccessv1.ScopedRoleSSH{
+					EnhancedRecording: nil,
+				},
+			},
+			expect: map[string]bool{},
+		},
+		{
+			name: "has events",
+			spec: &scopedaccessv1.ScopedRoleSpec{
+				Ssh: &scopedaccessv1.ScopedRoleSSH{
+					EnhancedRecording: &scopedaccessv1.EnhancedRecording{
+						Network: ptr(true),
+						Command: ptr(true),
+						Disk:    ptr(true),
+					},
+				},
+			},
+			expect: map[string]bool{"command": true, "network": true, "disk": true},
+		},
+	}
+
+	for _, tt := range tts {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			checker := newScopedCheckerWithRole(tt.spec).SSH()
+			require.Equal(t, tt.expect, checker.EnhancedRecordingSet())
 		})
 	}
 }

--- a/lib/srv/authhandlers.go
+++ b/lib/srv/authhandlers.go
@@ -1031,7 +1031,7 @@ func (a *ahLoginChecker) evaluateScopedSSHAccess(ident *sshca.Identity, ca types
 		ClientIdleTimeout:     durationpb.New(clientIdleTimeout),
 		DisconnectExpiredCert: timestampFromGoTime(getDisconnectExpiredCertFromSSHIdentityScoped(checker.SSH(), authPref, ident)),
 		SessionRecordingMode:  string(checker.SSH().SessionRecordingMode()),
-		LockingMode:           string(checker.LockingMode(authPref.GetLockingMode())),
+		LockingMode:           string(checker.SSH().LockingMode(authPref.GetLockingMode())),
 		PrivateKeyPolicy:      string(privateKeyPolicy),
 		LockTargets:           decision.LockTargetsToProto(lockTargets),
 		MappedRoles:           accessInfo.Roles,


### PR DESCRIPTION
This has dependencies on scope kube access - https://github.com/gravitational/teleport/pull/66345

Backports of https://github.com/gravitational/teleport/pull/66376 and https://github.com/gravitational/teleport/pull/65996

<!-- Provide a descriptive entry for the changelog of the next release. -->

Changelog: Add locking mode, disconnect expired cert, enhanced session recording, and session recording mode to scoped roles


<!-- Include manual testing efforts to verify the change. -->
<!-- Detail where the tests where run and what configurations were used. -->
<!-- Include all the test cases which were run to validate the change. -->

## Manual Test Plan
### Test Environment

EC2 instance to test bpf
K3d and local clusters to test other options

### Test Cases
- [x] disconnect_expired_cert = true: Log in and wait until cert expires - expect to get kicked out (test on kube and ssh)
- [x] disconnect_expired_cert = false: Log in and wait until cert expires - don't get kicked out (test on kube and ssh)
- [x] Lock = strict: Log in and fail to sync the locks - expect ssh to fail to connect (test on kube and ssh)
- [x] Lock = best_effort: Log in and fail to sync the locks - expect ssh to be able to connect (test on kube and ssh)
- [x] Enable BPF on EC2 linux node and verified that scoped roles with disk, network, and command bpf enabled have the relevant audit logs recorded
- [x] Users that don't have bpf enabled don't have the relevant audit logs recorded
- [x] When set to strict, failure to record the session ends the ssh session
- [x] When set to best effort, session continues
