### PR TITLE
multiple small fixes around PAM error handling and cleanup

### DIFF
--- a/session/pam/pam.go
+++ b/session/pam/pam.go
@@ -522,7 +522,9 @@ func (p *PAM) codeToError() error {
 		return trace.BadParameter("%s", C.GoString(err))
 	}
 
-	return nil
+	// Return a generic error message with the error code if pam_strerror
+	// somehow failed to return a string.
+	return trace.Errorf("PAM call failed with error code %d", p.retval)
 }
 
 // BuildHasPAM returns true if the binary was build with support for PAM

--- a/session/pam/pam.go
+++ b/session/pam/pam.go
@@ -340,6 +340,7 @@ func Open(config *pamcfg.PAMConfig) (_ *PAM, retErr error) {
 
 	defer func() {
 		if retErr != nil {
+			unregisterHandler(p.handlerIndex)
 			p.free()
 		}
 	}()

--- a/session/pam/pam.go
+++ b/session/pam/pam.go
@@ -309,7 +309,7 @@ type PAM struct {
 
 // Open creates a PAM context and initiates a PAM transaction to check the
 // account and then opens a session.
-func Open(config *pamcfg.PAMConfig) (*PAM, error) {
+func Open(config *pamcfg.PAMConfig) (_ *PAM, retErr error) {
 	if config == nil {
 		return nil, trace.BadParameter("PAM configuration is required.")
 	}
@@ -337,6 +337,12 @@ func Open(config *pamcfg.PAMConfig) (*PAM, error) {
 	// PAM context has it's own handle which is used to communicate between C
 	// and a instance of a PAM context.
 	p.handlerIndex = registerHandler(p)
+
+	defer func() {
+		if retErr != nil {
+			p.free()
+		}
+	}()
 
 	// Create and initialize a PAM context. The pam_start function will
 	// allocate pamh if needed and the pam_end function will release any
@@ -403,9 +409,10 @@ func Open(config *pamcfg.PAMConfig) (*PAM, error) {
 func (p *PAM) Close() error {
 	// Close the PAM session. Closing a session can entail anything from
 	// unmounting a home directory and updating auth.log.
+	var closeErr error
 	p.retval = C._pam_close_session(pamHandle, p.pamh, 0)
 	if p.retval != C.PAM_SUCCESS {
-		return p.codeToError()
+		closeErr = p.codeToError()
 	}
 
 	// Unregister handler index at the package level.
@@ -414,7 +421,7 @@ func (p *PAM) Close() error {
 	// Free any allocated memory on close.
 	p.free()
 
-	return nil
+	return closeErr
 }
 
 // Environment returns the PAM environment variables associated with a PAM
@@ -461,7 +468,7 @@ func (p *PAM) free() {
 			slog.WarnContext(context.Background(),
 				"Failed to end PAM transaction",
 				logconstants.ComponentKey, logComponent,
-				"error", p._codeToError(),
+				"error", p.codeToError(),
 			)
 		}
 
@@ -507,18 +514,8 @@ func (p *PAM) readStream(echo bool) (string, error) {
 	return text, nil
 }
 
-// codeToError returns a human readable string from the PAM error and
-// frees any memory that was allocated.
+// codeToError returns a human readable string from the PAM error.
 func (p *PAM) codeToError() error {
-	// If an error is being returned, free any memory that was allocated.
-	defer p.free()
-
-	return p._codeToError()
-}
-
-func (p *PAM) _codeToError() error {
-	// Error strings are not allocated on the heap, so memory does not need
-	// released.
 	err := C._pam_strerror(pamHandle, p.pamh, p.retval)
 	if err != nil {
 		return trace.BadParameter("%s", C.GoString(err))

--- a/session/pam/pam.go
+++ b/session/pam/pam.go
@@ -144,9 +144,11 @@ type handler interface {
 	readStream(bool) (string, error)
 }
 
-var handlerMu sync.Mutex
-var handlerCount int
-var handlers map[int]handler = make(map[int]handler)
+var (
+	handlerMu    sync.Mutex
+	handlerCount int
+	handlers     map[int]handler = make(map[int]handler)
+)
 
 //export writeCallback
 func writeCallback(index C.int, stream C.int, s *C.char) {
@@ -246,8 +248,10 @@ func lookupHandler(handlerIndex int) (handler, error) {
 	return handle, nil
 }
 
-var buildHasPAM bool = true
-var systemHasPAM bool = false
+var (
+	buildHasPAM  bool = true
+	systemHasPAM bool = false
+)
 
 // pamHandle is a opaque handle to the libpam object.
 var pamHandle unsafe.Pointer
@@ -339,7 +343,7 @@ func Open(config *pamcfg.PAMConfig) (*PAM, error) {
 	// allocated memory.
 	p.retval = C._pam_start(pamHandle, p.service_name, p.login, p.conv, &p.pamh)
 	if p.retval != C.PAM_SUCCESS {
-		return nil, p.codeToError(p.retval)
+		return nil, p.codeToError()
 	}
 
 	for k, v := range config.Env {
@@ -352,9 +356,9 @@ func Open(config *pamcfg.PAMConfig) (*PAM, error) {
 		kv := C.CString(fmt.Sprintf("%s=%s", k, v))
 		// pam_putenv makes a copy of kv, so we can free it right away.
 		defer C.free(unsafe.Pointer(kv))
-		retval := C._pam_putenv(pamHandle, p.pamh, kv)
-		if retval != C.PAM_SUCCESS {
-			return nil, p.codeToError(retval)
+		p.retval = C._pam_putenv(pamHandle, p.pamh, kv)
+		if p.retval != C.PAM_SUCCESS {
+			return nil, p.codeToError()
 		}
 	}
 
@@ -365,9 +369,9 @@ func Open(config *pamcfg.PAMConfig) (*PAM, error) {
 	// checking if the account is expired or has access restrictions.
 	//
 	// Note: This function does not perform any authentication!
-	retval := C._pam_acct_mgmt(pamHandle, p.pamh, 0)
-	if retval != C.PAM_SUCCESS {
-		return nil, p.codeToError(retval)
+	p.retval = C._pam_acct_mgmt(pamHandle, p.pamh, 0)
+	if p.retval != C.PAM_SUCCESS {
+		return nil, p.codeToError()
 	}
 
 	if config.UsePAMAuth {
@@ -375,9 +379,9 @@ func Open(config *pamcfg.PAMConfig) (*PAM, error) {
 		//
 		// These would perform any extra authentication steps configured in the PAM
 		// stack, like per-session 2FA.
-		retval = C._pam_authenticate(pamHandle, p.pamh, 0)
-		if retval != C.PAM_SUCCESS {
-			return nil, p.codeToError(retval)
+		p.retval = C._pam_authenticate(pamHandle, p.pamh, 0)
+		if p.retval != C.PAM_SUCCESS {
+			return nil, p.codeToError()
 		}
 	}
 
@@ -388,7 +392,7 @@ func Open(config *pamcfg.PAMConfig) (*PAM, error) {
 	// printing the MOTD, mounting a home directory, updating auth.log.
 	p.retval = C._pam_open_session(pamHandle, p.pamh, 0)
 	if p.retval != C.PAM_SUCCESS {
-		return nil, p.codeToError(p.retval)
+		return nil, p.codeToError()
 	}
 
 	return p, nil
@@ -401,7 +405,7 @@ func (p *PAM) Close() error {
 	// unmounting a home directory and updating auth.log.
 	p.retval = C._pam_close_session(pamHandle, p.pamh, 0)
 	if p.retval != C.PAM_SUCCESS {
-		return p.codeToError(p.retval)
+		return p.codeToError()
 	}
 
 	// Unregister handler index at the package level.
@@ -452,12 +456,12 @@ func (p *PAM) free() {
 	// Only free memory one time to prevent double free bugs.
 	p.once.Do(func() {
 		// Terminate the PAM transaction.
-		retval := C._pam_end(pamHandle, p.pamh, p.retval)
-		if retval != C.PAM_SUCCESS {
+		p.retval = C._pam_end(pamHandle, p.pamh, p.retval)
+		if p.retval != C.PAM_SUCCESS {
 			slog.WarnContext(context.Background(),
 				"Failed to end PAM transaction",
 				logconstants.ComponentKey, logComponent,
-				"error", p.codeToError(retval),
+				"error", p._codeToError(),
 			)
 		}
 
@@ -503,14 +507,19 @@ func (p *PAM) readStream(echo bool) (string, error) {
 	return text, nil
 }
 
-// codeToError returns a human readable string from the PAM error.
-func (p *PAM) codeToError(returnValue C.int) error {
+// codeToError returns a human readable string from the PAM error and
+// frees any memory that was allocated.
+func (p *PAM) codeToError() error {
 	// If an error is being returned, free any memory that was allocated.
 	defer p.free()
 
+	return p._codeToError()
+}
+
+func (p *PAM) _codeToError() error {
 	// Error strings are not allocated on the heap, so memory does not need
 	// released.
-	err := C._pam_strerror(pamHandle, p.pamh, returnValue)
+	err := C._pam_strerror(pamHandle, p.pamh, p.retval)
 	if err != nil {
 		return trace.BadParameter("%s", C.GoString(err))
 	}


### PR DESCRIPTION
Per `pam_end(3)`: "The pam_status argument should be set to the value returned to the application by the last PAM library call." `p.retval` wasn't consistently set after calling PAM library functions.

Also addressed a few other very minor issues found by pressure washing that are all related.

Fixes https://github.com/gravitational/pressure-washing/issues/292.
Fixes https://github.com/gravitational/pressure-washing/issues/289.
Fixes https://github.com/gravitational/pressure-washing/issues/293.
Fixes https://github.com/gravitational/pressure-washing/issues/294.

## Manual Test Plan
### Test Environment

### Test Cases
- [x] Use tsh ssh to connect to Node with PAM enabled
- [x] Verify that custom PAM environment variables are available as expected.
