### PR TITLE
Add a multi value label parser

### DIFF
--- a/lib/utils/parse/parse.go
+++ b/lib/utils/parse/parse.go
@@ -27,6 +27,7 @@ import (
 	"fmt"
 	"net/mail"
 	"regexp"
+	"slices"
 	"strings"
 	"unicode"
 	"unicode/utf8"
@@ -51,6 +52,44 @@ const (
 // LabelSelectorSpec parses a string like 'name=value,"long name"="quoted value"` into a map like
 // { "name" -> "value", "long name" -> "quoted value" }.
 func LabelSelectorSpec(spec string) (map[string]string, error) {
+	tokens, err := tokenizeLabelSpec(spec)
+	if err != nil {
+		return nil, err
+	}
+	// break tokens in pairs and put into a map:
+	labels := make(map[string]string)
+	for i := 0; i < len(tokens); i += 2 {
+		labels[tokens[i]] = tokens[i+1]
+	}
+	return labels, nil
+}
+
+// MultiValueLabelSelectorSpec parses a string like 'name=value,name=other,"long name"="quoted value"`
+// into a map like { "name" -> ["value", "other"], "long name" -> ["quoted value"] }.
+// Similar to LabelSelectorSpec but allows repeated key values stored into a slice.
+// Duplicate values for the same key are dropped.
+//
+// Multi valued labels are supported for role resources e.g. node_labels.
+func MultiValueLabelSelectorSpec(spec string) (map[string][]string, error) {
+	tokens, err := tokenizeLabelSpec(spec)
+	if err != nil {
+		return nil, err
+	}
+	// break tokens in pairs and put into a map, appending repeated keys:
+	labels := make(map[string][]string)
+	for i := 0; i < len(tokens); i += 2 {
+		key := tokens[i]
+		val := tokens[i+1]
+		if !slices.Contains(labels[key], val) {
+			labels[key] = append(labels[key], val)
+		}
+	}
+	return labels, nil
+}
+
+// tokenizeLabelSpec breaks a label spec like 'name=value,"long name"="quoted value"'
+// into a list of key/value tokens (name, value, long name, quoted value...).
+func tokenizeLabelSpec(spec string) ([]string, error) {
 	var tokens []string
 	openQuotes := false
 	var tokenStart, assignCount int
@@ -84,12 +123,7 @@ func LabelSelectorSpec(spec string) (map[string]string, error) {
 	if len(tokens)%2 != 0 || assignCount != len(tokens)/2 {
 		return nil, fmt.Errorf("invalid label spec: '%s', should be 'key=value'", spec)
 	}
-	// break tokens in pairs and put into a map:
-	labels := make(map[string]string)
-	for i := 0; i < len(tokens); i += 2 {
-		labels[tokens[i]] = tokens[i+1]
-	}
-	return labels, nil
+	return tokens, nil
 }
 
 var (

--- a/lib/utils/parse/parse_test.go
+++ b/lib/utils/parse/parse_test.go
@@ -63,6 +63,56 @@ func TestParseLabels(t *testing.T) {
 	require.Error(t, err)
 }
 
+func TestMultiValueLabelSelectorSpec(t *testing.T) {
+	// empty:
+	m, err := MultiValueLabelSelectorSpec("")
+	require.NoError(t, err)
+	require.Empty(t, m)
+
+	// simplest case:
+	m, err = MultiValueLabelSelectorSpec("key=value")
+	require.NotNil(t, m)
+	require.NoError(t, err)
+	require.Empty(t, cmp.Diff(m, map[string][]string{
+		"key": {"value"},
+	}))
+
+	// repeated keys, same values de-dupped:
+	m, err = MultiValueLabelSelectorSpec("env=staging,region=west,region=east,env=prod,fruit=apple,fruit=apple,region=east")
+	require.NoError(t, err)
+	require.Empty(t, cmp.Diff(m, map[string][]string{
+		"env":    {"staging", "prod"},
+		"region": {"west", "east"},
+		"fruit":  {"apple"},
+	}))
+
+	// unicode, same value unicode de-dupped:
+	m, err = MultiValueLabelSelectorSpec(`服务器环境=测试,操作系统类别=Linux,机房=华北,服务器环境=something,服务器环境=测试`)
+	require.NoError(t, err)
+	require.Empty(t, cmp.Diff(m, map[string][]string{
+		"服务器环境":  {"测试", "something"},
+		"操作系统类别": {"Linux"},
+		"机房":     {"华北"},
+	}))
+
+	// quoting and separators inside quotes:
+	m, err = MultiValueLabelSelectorSpec(`type="database";" role"=master,ver="mongoDB v1,2", type=db2`)
+	require.NoError(t, err)
+	require.Empty(t, cmp.Diff(m, map[string][]string{
+		"type": {"database", "db2"},
+		"role": {"master"},
+		"ver":  {"mongoDB v1,2"},
+	}))
+
+	// invalid specs
+	m, err = MultiValueLabelSelectorSpec(`type="database,"role"=master,ver="mongoDB v1,2"`)
+	require.Nil(t, m)
+	require.Error(t, err)
+	m, err = MultiValueLabelSelectorSpec(`type="database",role,master`)
+	require.Nil(t, m)
+	require.Error(t, err)
+}
+
 // TestVariable tests variable parsing
 func TestVariable(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
part of https://github.com/gravitational/teleport.e/issues/8271 and https://github.com/gravitational/rfd/pull/29

RFD: https://github.com/gravitational/rfd/pull/29/changes#diff-16323cdc1336bae2a0bafc670691b4dd79eb4acf2c168b92e4d70ee619b40361R459

Today, current CLI label related flags only parse into single valued map. This PR introduces a parser that parses a string into multi valued map. Same values for a key are de-duplicated.

The RFD linked above requires CLI flags that parses multi valued labels. These flags are directly translated into labels found in a role resource e.g. `--node-labels` which accepts multi value map.

No test plan as the unit test should suffice. It is also not being used yet.
