### PR TITLE
Add RequestKind to plugin AccessRequestData

### DIFF
--- a/integrations/access/accessrequest/app.go
+++ b/integrations/access/accessrequest/app.go
@@ -261,6 +261,7 @@ func (a *App) onPendingRequest(ctx context.Context, req types.AccessRequest) err
 	reqData := pd.AccessRequestData{
 		User:              req.GetUser(),
 		Roles:             req.GetRoles(),
+		RequestKind:       req.GetRequestKind().String(),
 		RequestReason:     req.GetRequestReason(),
 		SystemAnnotations: req.GetSystemAnnotations(),
 		Resources:         resourceNames,

--- a/integrations/access/accessrequest/plugindata_test.go
+++ b/integrations/access/accessrequest/plugindata_test.go
@@ -36,6 +36,7 @@ func getSamplePluginData(t *testing.T) PluginData {
 			User:             "user-foo",
 			Roles:            []string{"role-foo", "role-bar"},
 			Resources:        []string{"cluster-a/node/foo", "cluster-a/node/bar"},
+			RequestKind:      "LONG_TERM",
 			RequestReason:    "foo reason",
 			ReviewsCount:     3,
 			ResolutionTag:    plugindata.ResolvedApproved,
@@ -52,10 +53,11 @@ func getSamplePluginData(t *testing.T) PluginData {
 func TestEncodePluginData(t *testing.T) {
 	dataMap, err := EncodePluginData(getSamplePluginData(t))
 	assert.NoError(t, err)
-	assert.Len(t, dataMap, 9)
+	assert.Len(t, dataMap, 10)
 	assert.Equal(t, "user-foo", dataMap["user"])
 	assert.Equal(t, "role-foo,role-bar", dataMap["roles"])
 	assert.Equal(t, `["cluster-a/node/foo","cluster-a/node/bar"]`, dataMap["resources"])
+	assert.Equal(t, "LONG_TERM", dataMap["request_kind"])
 	assert.Equal(t, "foo reason", dataMap["request_reason"])
 	assert.Equal(t, "3", dataMap["reviews_count"])
 	assert.Equal(t, "APPROVED", dataMap["resolution"])
@@ -69,6 +71,7 @@ func TestDecodePluginData(t *testing.T) {
 		"user":           "user-foo",
 		"roles":          "role-foo,role-bar",
 		"resources":      `["cluster-a/node/foo","cluster-a/node/bar"]`,
+		"request_kind":   "LONG_TERM",
 		"request_reason": "foo reason",
 		"reviews_count":  "3",
 		"resolution":     "APPROVED",
@@ -83,7 +86,7 @@ func TestDecodePluginData(t *testing.T) {
 func TestEncodeEmptyPluginData(t *testing.T) {
 	dataMap, err := EncodePluginData(PluginData{})
 	assert.NoError(t, err)
-	assert.Len(t, dataMap, 8)
+	assert.Len(t, dataMap, 9)
 	for key, value := range dataMap {
 		assert.Emptyf(t, value, "value at key %q must be empty", key)
 	}

--- a/integrations/lib/plugindata/access_request.go
+++ b/integrations/lib/plugindata/access_request.go
@@ -42,6 +42,7 @@ const (
 type AccessRequestData struct {
 	User               string
 	Roles              []string
+	RequestKind        string
 	RequestReason      string
 	ReviewsCount       int
 	ResolutionTag      ResolutionTag
@@ -59,6 +60,7 @@ func DecodeAccessRequestData(dataMap map[string]string) (data AccessRequestData,
 	if str := dataMap["roles"]; str != "" {
 		data.Roles = strings.Split(str, ",")
 	}
+	data.RequestKind = dataMap["request_kind"]
 	data.RequestReason = dataMap["request_reason"]
 	if str := dataMap["reviews_count"]; str != "" {
 		fmt.Sscanf(str, "%d", &data.ReviewsCount)
@@ -118,13 +120,14 @@ func DecodeAccessRequestData(dataMap map[string]string) (data AccessRequestData,
 	return
 }
 
-// EncodeAccessRequestData deserializes a string map to PluginData struct.
+// EncodeAccessRequestData serializes a PluginData struct into a string map.
 func EncodeAccessRequestData(data AccessRequestData) (map[string]string, error) {
 	result := make(map[string]string)
 
 	result["user"] = data.User
 	result["roles"] = strings.Join(data.Roles, ",")
 	result["resources"] = strings.Join(data.Resources, ",")
+	result["request_kind"] = data.RequestKind
 	result["request_reason"] = data.RequestReason
 
 	if len(data.Resources) != 0 {

--- a/integrations/lib/plugindata/access_request_test.go
+++ b/integrations/lib/plugindata/access_request_test.go
@@ -28,6 +28,7 @@ var sampleAccessRequestData = AccessRequestData{
 	User:               "user-foo",
 	Roles:              []string{"role-foo", "role-bar"},
 	Resources:          []string{"cluster/node/foo", "cluster/node/bar"},
+	RequestKind:        "LONG_TERM",
 	RequestReason:      "foo reason",
 	ReviewsCount:       3,
 	ResolutionTag:      ResolvedApproved,
@@ -41,10 +42,11 @@ var sampleAccessRequestData = AccessRequestData{
 func TestEncodeAccessRequestData(t *testing.T) {
 	dataMap, err := EncodeAccessRequestData(sampleAccessRequestData)
 	assert.NoError(t, err)
-	assert.Len(t, dataMap, 9)
+	assert.Len(t, dataMap, 10)
 	assert.Equal(t, "user-foo", dataMap["user"])
 	assert.Equal(t, "role-foo,role-bar", dataMap["roles"])
 	assert.Equal(t, `["cluster/node/foo","cluster/node/bar"]`, dataMap["resources"])
+	assert.Equal(t, "LONG_TERM", dataMap["request_kind"])
 	assert.Equal(t, "foo reason", dataMap["request_reason"])
 	assert.Equal(t, "3", dataMap["reviews_count"])
 	assert.Equal(t, "APPROVED", dataMap["resolution"])
@@ -59,6 +61,7 @@ func TestDecodeAccessRequestData(t *testing.T) {
 		"user":                "user-foo",
 		"roles":               "role-foo,role-bar",
 		"resources":           `["cluster/node/foo", "cluster/node/bar"]`,
+		"request_kind":        "LONG_TERM",
 		"request_reason":      "foo reason",
 		"reviews_count":       "3",
 		"resolution":          "APPROVED",
@@ -73,7 +76,7 @@ func TestDecodeAccessRequestData(t *testing.T) {
 func TestEncodeEmptyAccessRequestData(t *testing.T) {
 	dataMap, err := EncodeAccessRequestData(AccessRequestData{})
 	assert.NoError(t, err)
-	assert.Len(t, dataMap, 7)
+	assert.Len(t, dataMap, 8)
 	for key, value := range dataMap {
 		assert.Emptyf(t, value, "value at key %q must be empty", key)
 	}


### PR DESCRIPTION
Adds `RequestKind` field to the data used by access plugins. The field denotes an Access Request kind, eg. "LONG_TERM" (requesting permanent access via access list promotion) or "SHORT_TERM".

Currently only the Web UI exposes creating an Access Request with strict permanent access controls.

This field will be used to enhance access plugin messages in followup PR.
