### PR TITLE
MCP: Remove all non-lowercase ID fields from Notifications

### DIFF
--- a/lib/srv/mcp/helpers_test.go
+++ b/lib/srv/mcp/helpers_test.go
@@ -19,6 +19,7 @@
 package mcp
 
 import (
+	"bytes"
 	"cmp"
 	"context"
 	"encoding/json"
@@ -35,6 +36,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/gravitational/trace"
 	mcpclienttransport "github.com/mark3labs/mcp-go/client/transport"
 	"github.com/mark3labs/mcp-go/mcp"
@@ -416,7 +418,20 @@ func checkSessionStartHasExternalSessionID() func(*testing.T, *apievents.MCPSess
 	}
 }
 
-func newStreamableMCPServer(t *testing.T, upstream *mcpserver.MCPServer, role types.Role) (_ *eventstest.MockRecorderEmitter, _ *mcpclienttransport.StreamableHTTP, proxyURL string) {
+func newStreamableMCPServer(t *testing.T, upstream *mcpserver.MCPServer, role types.Role) (
+	_ *eventstest.MockRecorderEmitter,
+	_ *mcpclienttransport.StreamableHTTP,
+	proxyURL string,
+) {
+	t.Helper()
+	return newStreamableMCPServerWithUpstreamRequestRecorder(t, upstream, role, nil)
+}
+
+func newStreamableMCPServerWithUpstreamRequestRecorder(t *testing.T, upstream *mcpserver.MCPServer, role types.Role, upstreamRequestRecorder *testRequestsRecorder) (
+	_ *eventstest.MockRecorderEmitter,
+	_ *mcpclienttransport.StreamableHTTP,
+	proxyURL string,
+) {
 	t.Helper()
 
 	remoteMCPServer := mcpserver.NewStreamableHTTPServer(upstream)
@@ -424,6 +439,9 @@ func newStreamableMCPServer(t *testing.T, upstream *mcpserver.MCPServer, role ty
 		if r.URL.Path != "/mcp" {
 			w.WriteHeader(http.StatusNotFound)
 			return
+		}
+		if upstreamRequestRecorder != nil {
+			upstreamRequestRecorder.record(r)
 		}
 		remoteMCPServer.ServeHTTP(w, r)
 	}))
@@ -482,6 +500,40 @@ func newStreamableMCPServer(t *testing.T, upstream *mcpserver.MCPServer, role ty
 	return &emitter, mcpClientTransport, proxyURL
 }
 
+type testRequestsRecorder struct {
+	mu       sync.RWMutex
+	contents [][]byte
+}
+
+func (r *testRequestsRecorder) record(req *http.Request) {
+	body, err := io.ReadAll(req.Body)
+	if err != nil {
+		panic(err.Error())
+	}
+	req.Body = io.NopCloser(bytes.NewReader(body))
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.contents = append(r.contents, body)
+}
+
+func (r *testRequestsRecorder) Contents() [][]byte {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	copy := make([][]byte, len(r.contents))
+	for i, c := range r.contents {
+		copy[i] = bytes.Clone(c)
+	}
+	return copy
+}
+
+func (r *testRequestsRecorder) Reset() {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.contents = r.contents[:0]
+}
+
 func testJSONString(t *testing.T, v any) string {
 	t.Helper()
 	data, err := json.Marshal(v)
@@ -505,7 +557,31 @@ func testSendRAWRequest(t *testing.T, method, url, sessionID string, body string
 
 	respBody, err := io.ReadAll(resp.Body)
 	require.NoError(t, err)
-	require.Equal(t, http.StatusOK, resp.StatusCode, "body: %s", respBody)
+	require.GreaterOrEqual(t, resp.StatusCode, 200, "body: %s", respBody)
+	require.Less(t, resp.StatusCode, 300, "body: %s", respBody)
 
 	return respBody
+}
+
+func testMCPInit(t *testing.T, transport *mcpclienttransport.StreamableHTTP) (sessionID string) {
+	t.Helper()
+	ctx := t.Context()
+
+	_, err := transport.SendRequest(ctx, mcpclienttransport.JSONRPCRequest{
+		JSONRPC: mcp.JSONRPC_VERSION,
+		ID:      mcp.NewRequestId(uuid.NewString()),
+		Method:  string(mcp.MethodInitialize),
+		Params: map[string]any{
+			"protocolVersion": mcp.LATEST_PROTOCOL_VERSION,
+			"clientInfo": map[string]any{
+				"name":    "test-client-transport",
+				"version": "1.0.0",
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	sessionID = transport.GetSessionId()
+	require.NotEmpty(t, sessionID)
+	return sessionID
 }

--- a/lib/srv/mcp/helpers_test.go
+++ b/lib/srv/mcp/helpers_test.go
@@ -23,11 +23,13 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"slices"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -414,28 +416,7 @@ func checkSessionStartHasExternalSessionID() func(*testing.T, *apievents.MCPSess
 	}
 }
 
-func newAllowAllDenyForbiddenToolRole(t *testing.T, forbiddenTool string) types.Role {
-	t.Helper()
-	role, err := types.NewRole("allow-all-deny-forbidden", types.RoleSpecV6{
-		Allow: types.RoleConditions{
-			AppLabels: map[string]apiutils.Strings{
-				types.Wildcard: {types.Wildcard},
-			},
-			MCP: &types.MCPPermissions{
-				Tools: []string{types.Wildcard},
-			},
-		},
-		Deny: types.RoleConditions{
-			MCP: &types.MCPPermissions{
-				Tools: []string{forbiddenTool},
-			},
-		},
-	})
-	require.NoError(t, err)
-	return role
-}
-
-func newStreamableMCPServer(t *testing.T, upstream *mcpserver.MCPServer, role types.Role) (*eventstest.MockRecorderEmitter, *mcpclienttransport.StreamableHTTP) {
+func newStreamableMCPServer(t *testing.T, upstream *mcpserver.MCPServer, role types.Role) (_ *eventstest.MockRecorderEmitter, _ *mcpclienttransport.StreamableHTTP, proxyURL string) {
 	t.Helper()
 
 	remoteMCPServer := mcpserver.NewStreamableHTTPServer(upstream)
@@ -494,10 +475,11 @@ func newStreamableMCPServer(t *testing.T, upstream *mcpserver.MCPServer, role ty
 		}
 	}()
 
-	mcpClientTransport, err := mcpclienttransport.NewStreamableHTTP("http://" + listener.Addr().String())
+	proxyURL = "http://" + listener.Addr().String()
+	mcpClientTransport, err := mcpclienttransport.NewStreamableHTTP(proxyURL)
 	require.NoError(t, err)
 
-	return &emitter, mcpClientTransport
+	return &emitter, mcpClientTransport, proxyURL
 }
 
 func testJSONString(t *testing.T, v any) string {
@@ -505,4 +487,25 @@ func testJSONString(t *testing.T, v any) string {
 	data, err := json.Marshal(v)
 	require.NoError(t, err)
 	return string(data)
+}
+
+func testSendRAWRequest(t *testing.T, method, url, sessionID string, body string) (response []byte) {
+	t.Helper()
+	ctx := t.Context()
+
+	req, err := http.NewRequestWithContext(ctx, method, url, strings.NewReader(body))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json, text/event-stream")
+	req.Header.Set(mcpclienttransport.HeaderKeySessionID, sessionID)
+
+	resp, err := (&http.Client{Timeout: 5 * time.Second}).Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode, "body: %s", respBody)
+
+	return respBody
 }

--- a/lib/srv/mcp/http.go
+++ b/lib/srv/mcp/http.go
@@ -225,30 +225,26 @@ func (t *streamableHTTPTransport) handleMCPMessage(r *http.Request) (*http.Respo
 		return nil, trace.BadParameter("invalid request body %v", err)
 	}
 
-	var mcpRequest *mcputils.JSONRPCRequest
+	var msg any
 	switch {
 	case baseMessage.IsRequest():
-		mcpRequest = baseMessage.MakeRequest()
-		if errResp := t.sessionHandler.processClientRequest(r.Context(), mcpRequest); errResp != nil {
-			t.emitRequestEvent(t.parentCtx, mcpRequest, eventWithError(toError(*errResp)), eventWithHeader(r.Header))
+		requestMsg := baseMessage.MakeRequest()
+		msg = requestMsg
+		if errResp := t.sessionHandler.processClientRequest(r.Context(), requestMsg); errResp != nil {
+			t.emitRequestEvent(t.parentCtx, requestMsg, eventWithError(toError(*errResp)), eventWithHeader(r.Header))
 			return t.handleRequestError(r, *errResp)
 		}
 	case baseMessage.IsNotification():
-		t.sessionHandler.processClientNotification(r.Context(), baseMessage.MakeNotification())
+		notificationMsg := baseMessage.MakeNotification()
+		msg = notificationMsg
+		t.sessionHandler.processClientNotification(r.Context(), notificationMsg)
 	default:
 		// Not sending it to the server if we don't understand it.
 		t.emitInvalidHTTPRequest(t.parentCtx, r)
 		return nil, trace.BadParameter("not a MCP request or notification")
 	}
 
-	var resp *http.Response
-	var sendReqErr error
-	switch {
-	case mcpRequest != nil:
-		resp, sendReqErr = t.rewriteAndSendRequestWithBody(r, mcpRequest)
-	default:
-		resp, sendReqErr = t.rewriteAndSendRequest(r)
-	}
+	resp, sendReqErr := t.rewriteAndSendRequestWithBody(r, msg)
 
 	// Prefer session ID from server response if present. For example,
 	// "initialize" request does not have an ID but the server response may have

--- a/lib/srv/mcp/http.go
+++ b/lib/srv/mcp/http.go
@@ -170,7 +170,11 @@ func (t *streamableHTTPTransport) setExternalSessionID(header http.Header) {
 	}
 }
 
-func (t *streamableHTTPTransport) rewriteRequest(r *http.Request) (*http.Request, error) {
+func (t *streamableHTTPTransport) rewriteAndSendRequest(r *http.Request) (*http.Response, error) {
+	return t.rewriteAndSendRequestWithBody(r, nil)
+}
+
+func (t *streamableHTTPTransport) rewriteAndSendRequestWithBody(r *http.Request, bodyOverwrite any) (*http.Response, error) {
 	r = r.Clone(r.Context())
 	r.URL.Scheme = t.targetURI.Scheme
 	r.URL.Host = t.targetURI.Host
@@ -186,15 +190,17 @@ func (t *streamableHTTPTransport) rewriteRequest(r *http.Request) (*http.Request
 	if err := t.rewriteHTTPRequestHeaders(r); err != nil {
 		return nil, trace.Wrap(err)
 	}
-	return r, nil
-}
 
-func (t *streamableHTTPTransport) rewriteAndSendRequest(r *http.Request) (*http.Response, error) {
-	rCopy, err := t.rewriteRequest(r)
-	if err != nil {
-		return nil, trace.Wrap(err)
+	if bodyOverwrite != nil {
+		data, err := json.Marshal(bodyOverwrite)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		r.Body = io.NopCloser(bytes.NewReader(data))
+		r.ContentLength = int64(len(data))
 	}
-	return t.targetTransport.RoundTrip(rCopy)
+
+	return t.targetTransport.RoundTrip(r)
 }
 
 func (t *streamableHTTPTransport) handleSessionEndRequest(r *http.Request) (*http.Response, error) {
@@ -219,9 +225,10 @@ func (t *streamableHTTPTransport) handleMCPMessage(r *http.Request) (*http.Respo
 		return nil, trace.BadParameter("invalid request body %v", err)
 	}
 
+	var mcpRequest *mcputils.JSONRPCRequest
 	switch {
 	case baseMessage.IsRequest():
-		mcpRequest := baseMessage.MakeRequest()
+		mcpRequest = baseMessage.MakeRequest()
 		if errResp := t.sessionHandler.processClientRequest(r.Context(), mcpRequest); errResp != nil {
 			t.emitRequestEvent(t.parentCtx, mcpRequest, eventWithError(toError(*errResp)), eventWithHeader(r.Header))
 			return t.handleRequestError(r, *errResp)
@@ -234,7 +241,15 @@ func (t *streamableHTTPTransport) handleMCPMessage(r *http.Request) (*http.Respo
 		return nil, trace.BadParameter("not a MCP request or notification")
 	}
 
-	resp, err := t.rewriteAndSendRequest(r)
+	var resp *http.Response
+	var sendReqErr error
+	switch {
+	case mcpRequest != nil:
+		resp, sendReqErr = t.rewriteAndSendRequestWithBody(r, mcpRequest)
+	default:
+		resp, sendReqErr = t.rewriteAndSendRequest(r)
+	}
+
 	// Prefer session ID from server response if present. For example,
 	// "initialize" request does not have an ID but the server response may have
 	// it.
@@ -243,19 +258,19 @@ func (t *streamableHTTPTransport) handleMCPMessage(r *http.Request) (*http.Respo
 	}
 
 	// Take care of audit events after round trip.
-	respErrForAudit := convertHTTPResponseErrorForAudit(resp, err)
+	auditErr := convertHTTPResponseErrorForAudit(resp, sendReqErr)
 	switch {
 	case baseMessage.IsRequest():
 		mcpRequest := baseMessage.MakeRequest()
 		// Only emit session start if "initialize" succeeded.
-		if mcpRequest.Method == mcputils.MethodInitialize && respErrForAudit == nil {
+		if mcpRequest.Method == mcputils.MethodInitialize && auditErr == nil {
 			t.appendStartEvent(r.Context(), eventWithHeader(r.Header))
 		}
-		t.emitRequestEvent(t.parentCtx, mcpRequest, eventWithError(respErrForAudit), eventWithHeader(r.Header))
+		t.emitRequestEvent(t.parentCtx, mcpRequest, eventWithError(auditErr), eventWithHeader(r.Header))
 	case baseMessage.IsNotification():
-		t.emitNotificationEvent(r.Context(), baseMessage.MakeNotification(), eventWithError(respErrForAudit), eventWithHeader(r.Header))
+		t.emitNotificationEvent(r.Context(), baseMessage.MakeNotification(), eventWithError(auditErr), eventWithHeader(r.Header))
 	}
-	return resp, trace.Wrap(err)
+	return resp, trace.Wrap(sendReqErr)
 }
 
 func (t *streamableHTTPTransport) handleRequestError(r *http.Request, errResp mcp.JSONRPCMessage) (*http.Response, error) {

--- a/lib/srv/mcp/http_test.go
+++ b/lib/srv/mcp/http_test.go
@@ -25,10 +25,12 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strconv"
+	"strings"
 	"sync"
 	"testing"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/gravitational/trace"
 	mcpclient "github.com/mark3labs/mcp-go/client"
 	mcpclienttransport "github.com/mark3labs/mcp-go/client/transport"
@@ -253,26 +255,13 @@ func Test_Server_HandleSession_reject_req_missing_name(t *testing.T) {
 
 	emitter, mcpClientTransport, proxyURL := newStreamableMCPServer(t, upstream, role)
 
-	_, err = mcpClientTransport.SendRequest(ctx, mcpclienttransport.JSONRPCRequest{
-		JSONRPC: mcp.JSONRPC_VERSION,
-		ID:      mcp.NewRequestId(1),
-		Method:  string(mcp.MethodInitialize),
-		Params: map[string]any{
-			"protocolVersion": mcp.LATEST_PROTOCOL_VERSION,
-			"clientInfo": map[string]any{
-				"name":    "test-client-transport",
-				"version": "1.0.0",
-			},
-		},
-	})
-	require.NoError(t, err)
-	require.NotEmpty(t, mcpClientTransport.GetSessionId())
+	sessionID := testMCPInit(t, mcpClientTransport)
 
 	// Verify it works as expected if the canonical lower-case "name" param is provided.
 	emitter.Reset()
 	resp, err := mcpClientTransport.SendRequest(ctx, mcpclienttransport.JSONRPCRequest{
 		JSONRPC: mcp.JSONRPC_VERSION,
-		ID:      mcp.NewRequestId(2),
+		ID:      mcp.NewRequestId(uuid.NewString()),
 		Method:  string(mcp.MethodToolsCall),
 		Params: map[string]any{
 			"name": deniedTool,
@@ -290,7 +279,7 @@ func Test_Server_HandleSession_reject_req_missing_name(t *testing.T) {
 	emitter.Reset()
 	resp, err = mcpClientTransport.SendRequest(ctx, mcpclienttransport.JSONRPCRequest{
 		JSONRPC: mcp.JSONRPC_VERSION,
-		ID:      mcp.NewRequestId(3),
+		ID:      mcp.NewRequestId(uuid.NewString()),
 		Method:  string(mcp.MethodToolsCall),
 		Params: map[string]any{
 			"Name": deniedTool,
@@ -307,7 +296,7 @@ func Test_Server_HandleSession_reject_req_missing_name(t *testing.T) {
 	emitter.Reset()
 	resp, err = mcpClientTransport.SendRequest(ctx, mcpclienttransport.JSONRPCRequest{
 		JSONRPC: mcp.JSONRPC_VERSION,
-		ID:      mcp.NewRequestId(4),
+		ID:      mcp.NewRequestId(uuid.NewString()),
 		Method:  string(mcp.MethodToolsCall),
 		Params: map[string]any{
 			"name": "",
@@ -324,7 +313,7 @@ func Test_Server_HandleSession_reject_req_missing_name(t *testing.T) {
 	emitter.Reset()
 	resp, err = mcpClientTransport.SendRequest(ctx, mcpclienttransport.JSONRPCRequest{
 		JSONRPC: mcp.JSONRPC_VERSION,
-		ID:      mcp.NewRequestId(5),
+		ID:      mcp.NewRequestId(uuid.NewString()),
 		Method:  string(mcp.MethodToolsCall),
 		Params: map[string]any{
 			"name": deniedTool,
@@ -341,8 +330,8 @@ func Test_Server_HandleSession_reject_req_missing_name(t *testing.T) {
 	// along side the canonical lower-case one, they are pruned from the request before
 	// forwarding.
 	emitter.Reset()
-	respBytes := testSendRAWRequest(t, http.MethodPost, proxyURL, mcpClientTransport.GetSessionId(), fmt.Sprintf(
-		`{"jsonrpc":"2.0","id":7,"method":"tools/call","params":{%q:%q,%q:%q,%q:%q,%q:%q}}`,
+	respBytes := testSendRAWRequest(t, http.MethodPost, proxyURL, sessionID, fmt.Sprintf(
+		`{"jsonrpc":"2.0","id":"raw-1","method":"tools/call","params":{%q:%q,%q:%q,%q:%q,%q:%q}}`,
 		"Name", allowedTool,
 		"NaMe", allowedTool,
 		"name", deniedTool,
@@ -361,8 +350,8 @@ func Test_Server_HandleSession_reject_req_missing_name(t *testing.T) {
 	require.Equal(t, deniedTool, event.Message.Params.Fields["name"].GetStringValue())
 
 	emitter.Reset()
-	respBytes = testSendRAWRequest(t, http.MethodPost, proxyURL, mcpClientTransport.GetSessionId(), fmt.Sprintf(
-		`{"jsonrpc":"2.0","id":7,"method":"tools/call","params":{%q:%q,%q:%q,%q:%q,%q:%q}}`,
+	respBytes = testSendRAWRequest(t, http.MethodPost, proxyURL, sessionID, fmt.Sprintf(
+		`{"jsonrpc":"2.0","id":"raw-2","method":"tools/call","params":{%q:%q,%q:%q,%q:%q,%q:%q}}`,
 		"Name", deniedTool,
 		"NaMe", deniedTool,
 		"name", allowedTool,
@@ -377,6 +366,90 @@ func Test_Server_HandleSession_reject_req_missing_name(t *testing.T) {
 	// Verify there was 1 param sent and it was the lowercase "name".
 	require.Len(t, event.Message.Params.Fields, 1)
 	require.Equal(t, allowedTool, event.Message.Params.Fields["name"].GetStringValue())
+}
+
+func Test_Server_HandleSession_remove_non_canonical_ID(t *testing.T) {
+	t.Parallel()
+
+	const testTool = "test_tool"
+
+	role, err := types.NewRole("all_mcp_tools_access", types.RoleSpecV6{
+		Allow: types.RoleConditions{
+			AppLabels: map[string]apiutils.Strings{
+				types.Wildcard: {types.Wildcard},
+			},
+			MCP: &types.MCPPermissions{
+				Tools: []string{types.Wildcard},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	upstream := mcpserver.NewMCPServer("test-server", "1.0.0")
+	upstream.AddTool(
+		mcp.Tool{Name: testTool},
+		func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+			return &mcp.CallToolResult{Content: []mcp.Content{mcp.NewTextContent("test_tool_context")}}, nil
+		},
+	)
+
+	upstreamRequestRecorder := &testRequestsRecorder{}
+	emitter, mcpClientTransport, proxyURL := newStreamableMCPServerWithUpstreamRequestRecorder(t, upstream, role, upstreamRequestRecorder)
+
+	sessionID := testMCPInit(t, mcpClientTransport)
+
+	// Verify that a request with a non-canonical "ID" field is forwarded as a
+	// notification body, so a case-insensitive upstream cannot reinterpret it as
+	// an authorized tools/call request.
+	emitter.Reset()
+	upstreamRequestRecorder.Reset()
+	requestToSend := fmt.Sprintf(
+		`{"jsonrpc":"2.0","ID":100,"method":"tools/call","params":{"name":%q}}`, testTool,
+	)
+	expectedForwardedRequest := fmt.Sprintf(
+		`{"jsonrpc":"2.0","method":"tools/call","params":{"name":%q}}`, testTool,
+	)
+	_ = testSendRAWRequest(t, http.MethodPost, proxyURL, sessionID, requestToSend)
+	forwarded := upstreamRequestRecorder.Contents()
+	require.Len(t, forwarded, 1, printableContents(forwarded))
+	require.JSONEq(t, expectedForwardedRequest, string(forwarded[0]))
+
+	// Same for "iD".
+	emitter.Reset()
+	upstreamRequestRecorder.Reset()
+	requestToSend = fmt.Sprintf(
+		`{"jsonrpc":"2.0","iD":100,"method":"tools/call","params":{"name":%q}}`, testTool,
+	)
+	expectedForwardedRequest = fmt.Sprintf(
+		`{"jsonrpc":"2.0","method":"tools/call","params":{"name":%q}}`, testTool,
+	)
+	_ = testSendRAWRequest(t, http.MethodPost, proxyURL, sessionID, requestToSend)
+	forwarded = upstreamRequestRecorder.Contents()
+	require.Len(t, forwarded, 1)
+	require.JSONEq(t, expectedForwardedRequest, string(forwarded[0]))
+
+	// But canonical "id" is forwarded.
+	emitter.Reset()
+	upstreamRequestRecorder.Reset()
+	requestToSend = fmt.Sprintf(
+		`{"jsonrpc":"2.0","id":100,"method":"tools/call","params":{"name":%q}}`, testTool,
+	)
+	expectedForwardedRequest = requestToSend
+	_ = testSendRAWRequest(t, http.MethodPost, proxyURL, sessionID, requestToSend)
+	forwarded = upstreamRequestRecorder.Contents()
+	require.Len(t, forwarded, 1)
+	require.JSONEq(t, expectedForwardedRequest, string(forwarded[0]))
+}
+
+type printableContents [][]byte
+
+func (c printableContents) String() string {
+	var b strings.Builder
+	for _, bs := range c {
+		b.Write(bs)
+		b.WriteString(",")
+	}
+	return b.String()[:max(0, b.Len()-1)]
 }
 
 func Test_handleAuthErrHTTP(t *testing.T) {

--- a/lib/srv/mcp/http_test.go
+++ b/lib/srv/mcp/http_test.go
@@ -24,6 +24,7 @@ import (
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"sync"
 	"testing"
 	"time"
@@ -38,6 +39,7 @@ import (
 
 	"github.com/gravitational/teleport/api/types"
 	apievents "github.com/gravitational/teleport/api/types/events"
+	apiutils "github.com/gravitational/teleport/api/utils"
 	libevents "github.com/gravitational/teleport/lib/events"
 	"github.com/gravitational/teleport/lib/events/eventstest"
 	"github.com/gravitational/teleport/lib/utils"
@@ -218,26 +220,40 @@ func Test_Server_HandleSession_reject_req_missing_name(t *testing.T) {
 
 	ctx := t.Context()
 
-	const forbiddenTool = "forbidden_tool"
-	const forbiddenToolTextContent = "FORBIDDEN_TOOL_EXECUTED_ON_UPSTREAM"
+	const allowedTool = "allowed_tool"
+	const allowedToolContext = "allowed_tool_executed_on_upstream"
+	const deniedTool = "denied_tool"
+	const deniedToolTextContent = "DENIED_TOOL_EXECUTED_ON_UPSTREAM"
 
-	role := newAllowAllDenyForbiddenToolRole(t, forbiddenTool)
+	role, err := types.NewRole("allowed_tool_access", types.RoleSpecV6{
+		Allow: types.RoleConditions{
+			AppLabels: map[string]apiutils.Strings{
+				types.Wildcard: {types.Wildcard},
+			},
+			MCP: &types.MCPPermissions{
+				Tools: []string{allowedTool},
+			},
+		},
+	})
+	require.NoError(t, err)
 
 	upstream := mcpserver.NewMCPServer("test-server", "1.0.0")
 	upstream.AddTool(
-		mcp.Tool{
-			Name: forbiddenTool,
-		},
+		mcp.Tool{Name: allowedTool},
 		func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-			return &mcp.CallToolResult{
-				Content: []mcp.Content{mcp.NewTextContent(forbiddenToolTextContent)},
-			}, nil
+			return &mcp.CallToolResult{Content: []mcp.Content{mcp.NewTextContent(allowedToolContext)}}, nil
+		},
+	)
+	upstream.AddTool(
+		mcp.Tool{Name: deniedTool},
+		func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+			return &mcp.CallToolResult{Content: []mcp.Content{mcp.NewTextContent(deniedToolTextContent)}}, nil
 		},
 	)
 
-	emitter, mcpClientTransport := newStreamableMCPServer(t, upstream, role)
+	emitter, mcpClientTransport, proxyURL := newStreamableMCPServer(t, upstream, role)
 
-	_, err := mcpClientTransport.SendRequest(ctx, mcpclienttransport.JSONRPCRequest{
+	_, err = mcpClientTransport.SendRequest(ctx, mcpclienttransport.JSONRPCRequest{
 		JSONRPC: mcp.JSONRPC_VERSION,
 		ID:      mcp.NewRequestId(1),
 		Method:  string(mcp.MethodInitialize),
@@ -259,14 +275,14 @@ func Test_Server_HandleSession_reject_req_missing_name(t *testing.T) {
 		ID:      mcp.NewRequestId(2),
 		Method:  string(mcp.MethodToolsCall),
 		Params: map[string]any{
-			"name": forbiddenTool,
+			"name": deniedTool,
 		},
 	})
 	require.NoError(t, err)
 	require.NotNil(t, resp.Error)
 	require.Equal(t, mcp.INVALID_PARAMS, resp.Error.Code)
 	respJSON := testJSONString(t, resp)
-	require.NotContains(t, respJSON, forbiddenToolTextContent)
+	require.NotContains(t, respJSON, deniedToolTextContent)
 	require.Contains(t, respJSON, "User does not have permissions")
 
 	// Verify that when non-canonical capitalized "Name" param is specified the request is
@@ -277,14 +293,14 @@ func Test_Server_HandleSession_reject_req_missing_name(t *testing.T) {
 		ID:      mcp.NewRequestId(3),
 		Method:  string(mcp.MethodToolsCall),
 		Params: map[string]any{
-			"Name": forbiddenTool,
+			"Name": deniedTool,
 		},
 	})
 	require.NoError(t, err)
 	require.NotNil(t, resp.Error)
 	require.Equal(t, mcp.INVALID_REQUEST, resp.Error.Code)
 	respJSON = testJSONString(t, resp)
-	require.NotContains(t, respJSON, forbiddenToolTextContent)
+	require.NotContains(t, respJSON, deniedToolTextContent)
 	require.Contains(t, respJSON, testJSONString(t, errInvalidRequestMissingName.Error()))
 
 	// Verify that when an empty "name" param is specified the request is rejected.
@@ -301,7 +317,7 @@ func Test_Server_HandleSession_reject_req_missing_name(t *testing.T) {
 	require.NotNil(t, resp.Error)
 	require.Equal(t, mcp.INVALID_REQUEST, resp.Error.Code)
 	respJSON = testJSONString(t, resp)
-	require.NotContains(t, respJSON, forbiddenToolTextContent)
+	require.NotContains(t, respJSON, deniedToolTextContent)
 	require.Contains(t, respJSON, testJSONString(t, errInvalidRequestMissingName.Error()))
 
 	// Verify that correct request is properly unauthorized.
@@ -311,15 +327,56 @@ func Test_Server_HandleSession_reject_req_missing_name(t *testing.T) {
 		ID:      mcp.NewRequestId(5),
 		Method:  string(mcp.MethodToolsCall),
 		Params: map[string]any{
-			"name": forbiddenTool,
+			"name": deniedTool,
 		},
 	})
 	require.NoError(t, err)
 	require.NotNil(t, resp.Error)
 	require.Equal(t, mcp.INVALID_PARAMS, resp.Error.Code)
 	respJSON = testJSONString(t, resp)
-	require.NotContains(t, respJSON, forbiddenToolTextContent)
+	require.NotContains(t, respJSON, deniedToolTextContent)
 	require.Contains(t, respJSON, "User does not have permissions.")
+
+	// Verify that when non-canonical non-lower-case "name" params are specified in the request
+	// along side the canonical lower-case one, they are pruned from the request before
+	// forwarding.
+	emitter.Reset()
+	respBytes := testSendRAWRequest(t, http.MethodPost, proxyURL, mcpClientTransport.GetSessionId(), fmt.Sprintf(
+		`{"jsonrpc":"2.0","id":7,"method":"tools/call","params":{%q:%q,%q:%q,%q:%q,%q:%q}}`,
+		"Name", allowedTool,
+		"NaMe", allowedTool,
+		"name", deniedTool,
+		"NAME", allowedTool,
+	))
+	respJSON = string(respBytes)
+	require.Contains(t, respJSON, strconv.Itoa(mcp.INVALID_PARAMS))
+	require.NotContains(t, respJSON, allowedToolContext)
+	require.NotContains(t, respJSON, deniedToolTextContent)
+	require.Contains(t, respJSON, "User does not have permissions.")
+	require.Len(t, emitter.Events(), 1)
+	event, ok := emitter.LastEvent().(*apievents.MCPSessionRequest)
+	require.True(t, ok)
+	// Verify there was 1 param sent and it was the lowercase "name".
+	require.Len(t, event.Message.Params.Fields, 1)
+	require.Equal(t, deniedTool, event.Message.Params.Fields["name"].GetStringValue())
+
+	emitter.Reset()
+	respBytes = testSendRAWRequest(t, http.MethodPost, proxyURL, mcpClientTransport.GetSessionId(), fmt.Sprintf(
+		`{"jsonrpc":"2.0","id":7,"method":"tools/call","params":{%q:%q,%q:%q,%q:%q,%q:%q}}`,
+		"Name", deniedTool,
+		"NaMe", deniedTool,
+		"name", allowedTool,
+		"NAME", deniedTool,
+	))
+	respJSON = string(respBytes)
+	require.NotContains(t, respJSON, deniedToolTextContent)
+	require.Contains(t, respJSON, allowedToolContext)
+	require.Len(t, emitter.Events(), 1)
+	event, ok = emitter.LastEvent().(*apievents.MCPSessionRequest)
+	require.True(t, ok)
+	// Verify there was 1 param sent and it was the lowercase "name".
+	require.Len(t, event.Message.Params.Fields, 1)
+	require.Equal(t, allowedTool, event.Message.Params.Fields["name"].GetStringValue())
 }
 
 func Test_handleAuthErrHTTP(t *testing.T) {

--- a/lib/srv/mcp/session.go
+++ b/lib/srv/mcp/session.go
@@ -23,6 +23,7 @@ import (
 	"log/slog"
 	"net"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/gravitational/trace"
@@ -254,6 +255,12 @@ func (s *sessionHandler) processClientRequest(ctx context.Context, req *mcputils
 
 	switch req.Method {
 	case mcputils.MethodToolsCall:
+		// Remove all non-canonical name params, like "Name" or "NaMe", trying to prevent
+		// malicious clients to bypass RBAC for vulnerable upstream MCP servers. E.g. it
+		// may happen that a MCP server using case-insensitive Go "json" package decodes
+		// "Name" while the RBAC was performed on "name" if both are present in the
+		// request.
+		sanitizeParamsName(req.Params)
 		toolName, _ := req.Params.GetName()
 		if toolName == "" {
 			return makeInvalidRequestResponse(req, errInvalidRequestMissingName)
@@ -270,7 +277,7 @@ func (s *sessionHandler) processClientRequest(ctx context.Context, req *mcputils
 	return nil
 }
 
-func (s *sessionHandler) processClientNotification(ctx context.Context, notification *mcputils.JSONRPCNotification) {
+func (s *sessionHandler) processClientNotification(_ context.Context, notification *mcputils.JSONRPCNotification) {
 	messagesFromClient.WithLabelValues(s.transport, "notification", reportNotificationMethod(notification.Method)).Inc()
 }
 
@@ -369,4 +376,12 @@ func toError(e mcp.JSONRPCError) error {
 		}
 	}
 	return e.Error.AsError()
+}
+
+func sanitizeParamsName(p mcputils.JSONRPCParams) {
+	for k := range p {
+		if k != mcputils.ParamName && strings.ToLower(k) == mcputils.ParamName {
+			delete(p, k)
+		}
+	}
 }

--- a/lib/srv/mcp/session_test.go
+++ b/lib/srv/mcp/session_test.go
@@ -20,6 +20,7 @@ package mcp
 
 import (
 	"context"
+	"fmt"
 	"slices"
 	"sync"
 	"testing"
@@ -161,6 +162,39 @@ func Test_sessionHandler(t *testing.T) {
 					require.Len(t, clientMessages, 1)
 					require.IsType(t, mcp.JSONRPCError{}, clientMessages[0])
 				})
+			}
+
+			for _, allowedTool := range tt.allowedTools {
+				for _, deniedTool := range tt.deniedTools {
+					t.Run(fmt.Sprintf("deny %q tool while allowed tool %q is passed with a non-canonical name param", deniedTool, allowedTool), func(t *testing.T) {
+						clientReq := requestBuilder.makeToolsCallRequest(deniedTool)
+						clientReq.Params["Name"] = allowedTool
+						clientReq.Params["NaMe"] = allowedTool
+						clientReq.Params["NAME"] = allowedTool
+						clientCapture := &captureMessageWriter{}
+						serverCapture := &captureMessageWriter{}
+						require.NoError(t, handler.onClientRequest(clientCapture, serverCapture)(ctx, clientReq))
+
+						event := mockEmitter.LastEvent()
+						require.NotNil(t, event)
+						requestEvent, ok := event.(*apievents.MCPSessionRequest)
+						require.True(t, ok)
+						require.False(t, requestEvent.Success)
+						require.Equal(t, mcputils.MethodToolsCall, requestEvent.Message.Method)
+						// Verify there is only 1 param and it's "name" and
+						// all other non-lower-case name params are removed
+						// from the request.
+						require.Len(t, requestEvent.Message.Params.Fields, 1)
+						require.Equal(t, deniedTool, requestEvent.Message.Params.Fields["name"].GetStringValue(), 1)
+
+						// Server does not receive the client's request. An error is
+						// sent to client.
+						require.Empty(t, serverCapture.messages())
+						clientMessages := clientCapture.messages()
+						require.Len(t, clientMessages, 1)
+						require.IsType(t, mcp.JSONRPCError{}, clientMessages[0])
+					})
+				}
 			}
 
 			t.Run("tools list", func(t *testing.T) {

--- a/lib/srv/mcp/session_test.go
+++ b/lib/srv/mcp/session_test.go
@@ -19,8 +19,10 @@
 package mcp
 
 import (
+	"bufio"
 	"context"
 	"fmt"
+	"io"
 	"slices"
 	"sync"
 	"testing"
@@ -221,4 +223,65 @@ func Test_sessionHandler(t *testing.T) {
 			})
 		})
 	}
+}
+
+func Test_sessionHandler_StreamingReserializesNonCanonicalIDNotification(t *testing.T) {
+	ctx := t.Context()
+	testCtx := setupTestContext(t, withAdminRole(t), withDenyToolsRole(t))
+	mockEmitter := &eventstest.MockRecorderEmitter{}
+	auditor, err := newSessionAuditor(sessionAuditorConfig{
+		emitter:    mockEmitter,
+		hostID:     "test-host-id",
+		sessionCtx: testCtx.SessionCtx,
+		preparer:   &libevents.NoOpPreparer{},
+	})
+	require.NoError(t, err)
+
+	handler, err := newSessionHandler(sessionHandlerConfig{
+		SessionCtx:     testCtx.SessionCtx,
+		sessionAuth:    &sessionAuth{},
+		sessionAuditor: auditor,
+		accessPoint:    fakeAccessPoint{},
+		parentCtx:      ctx,
+	})
+	require.NoError(t, err)
+
+	readFromClient, writeFromClient := io.Pipe()
+	readFromProxy, writeToServer := io.Pipe()
+	t.Cleanup(func() {
+		readFromClient.Close()
+		writeFromClient.Close()
+		readFromProxy.Close()
+		writeToServer.Close()
+	})
+
+	clientCapture := &captureMessageWriter{}
+	serverWriter := mcputils.NewStdioMessageWriter(writeToServer)
+	reader, err := mcputils.NewMessageReader(mcputils.MessageReaderConfig{
+		Transport:      mcputils.NewStdioReader(readFromClient),
+		OnParseError:   mcputils.ReplyParseError(clientCapture),
+		OnRequest:      handler.onClientRequest(clientCapture, serverWriter),
+		OnNotification: handler.onClientNotification(serverWriter),
+	})
+	require.NoError(t, err)
+
+	const deniedTool = "denied_tool"
+	go reader.Run(ctx)
+	_, err = fmt.Fprintf(writeFromClient, `{"jsonrpc":"2.0","ID":99,"method":"tools/call","params":{"name":%q}}`+"\n", deniedTool)
+	require.NoError(t, err)
+
+	forwardedMessage, err := bufio.NewReader(readFromProxy).ReadString('\n')
+	require.NoError(t, err)
+	require.JSONEq(t,
+		fmt.Sprintf(`{"jsonrpc":"2.0","method":"tools/call","params":{"name":%q}}`, deniedTool),
+		forwardedMessage,
+	)
+	require.Empty(t, clientCapture.messages())
+
+	event := mockEmitter.LastEvent()
+	require.NotNil(t, event)
+	notificationEvent, ok := event.(*apievents.MCPSessionNotification)
+	require.True(t, ok)
+	require.Equal(t, mcputils.MethodToolsCall, notificationEvent.Message.Method)
+	checkParamsHaveNameField(t, notificationEvent.Message.Params, deniedTool)
 }

--- a/lib/utils/mcputils/protocol.go
+++ b/lib/utils/mcputils/protocol.go
@@ -28,6 +28,10 @@ import (
 	apievents "github.com/gravitational/teleport/api/types/events"
 )
 
+const (
+	ParamName = "name"
+)
+
 // Type definitions from both mcp-go/client/transport or mcp-go are not suitable
 // for our reverse proxy use, thus this file redefines them.
 //
@@ -53,7 +57,7 @@ func (p JSONRPCParams) GetName() (string, bool) {
 	if p == nil {
 		return "", false
 	}
-	name, ok := p["name"].(string)
+	name, ok := p[ParamName].(string)
 	return name, ok
 }
 


### PR DESCRIPTION
Based on https://github.com/gravitational/teleport/pull/67262

Whether an MCP message is considered a request or notification based on teh presence of the ID. From [the spec](https://modelcontextprotocol.io/specification/2025-11-25/basic):

- "Requests MUST include a string or integer ID."
- "Notifications MUST NOT include an ID."

[JSONRPCRequest](https://modelcontextprotocol.io/specification/2025-11-25/schema#jsonrpcrequest).`id` is lowercased and JSON-RPC is case-sensitive. But builtin Go "json" package decodes JSON ignoring case so there are chances that a message containing `"ID":"x"` or `"Id":"x"` will be interpreted as a MCP Request in the upstream server, while Teleport proxy won't do any corresponding RBAC checks correctly treating the message as a Notification. Removing all non-canonical ID fields will prevent that potentially confusing UX.

No changelog as I'm planning to combine those PRs in the backport.

## Manual Test Plan
### Test Environment

### Test Cases
- [ ] 
