### PR TITLE
Improve access request message titles for slack and discord plugins

### DIFF
--- a/integrations/access/accessrequest/app.go
+++ b/integrations/access/accessrequest/app.go
@@ -261,6 +261,7 @@ func (a *App) onPendingRequest(ctx context.Context, req types.AccessRequest) err
 	reqData := pd.AccessRequestData{
 		User:              req.GetUser(),
 		Roles:             req.GetRoles(),
+		RequestKind:       req.GetRequestKind().String(),
 		RequestReason:     req.GetRequestReason(),
 		SystemAnnotations: req.GetSystemAnnotations(),
 		Resources:         resourceNames,

--- a/integrations/access/accessrequest/message.go
+++ b/integrations/access/accessrequest/message.go
@@ -56,7 +56,7 @@ func MsgTitle(reqData pd.AccessRequestData) string {
 	}
 	titleText := fmt.Sprintf("You have a new %s Request", requestBase)
 	if reqData.RequestKind == types.AccessRequestKind_LONG_TERM.String() {
-		titleText += " (long-term)"
+		titleText += " (long-term access)"
 	}
 	titleText += ":\n"
 

--- a/integrations/access/accessrequest/message.go
+++ b/integrations/access/accessrequest/message.go
@@ -49,6 +49,20 @@ Resolution: {{.ProposedStateEmoji}} {{.ProposedState}}.
 {{if .Reason}}Reason: {{.Reason}}{{end}}`,
 ))
 
+func MsgTitle(reqData pd.AccessRequestData) string {
+	requestBase := "Role"
+	if len(reqData.Resources) > 0 {
+		requestBase = "Resource"
+	}
+	titleText := fmt.Sprintf("You have a new %s Request", requestBase)
+	if reqData.RequestKind == types.AccessRequestKind_LONG_TERM.String() {
+		titleText += " (long-term)"
+	}
+	titleText += ":\n"
+
+	return titleText
+}
+
 func MsgStatusText(tag pd.ResolutionTag, reason string) string {
 	var statusEmoji string
 	status := string(tag)

--- a/integrations/access/accessrequest/message_test.go
+++ b/integrations/access/accessrequest/message_test.go
@@ -106,3 +106,64 @@ func ExampleMsgReview() {
 	// Reason: ```
 	// example reason```
 }
+
+func ExampleMsgTitle_roles() {
+	req := plugindata.AccessRequestData{
+		User:  "example@goteleport.com",
+		Roles: []string{"admin", "foo", "bar", "dev"},
+		LoginsByRole: map[string][]string{
+			"admin": {"foo", "bar", "root"},
+			"foo":   {"foo"},
+			"bar":   {"bar"},
+			"dev":   {},
+		},
+		RequestReason: "test",
+	}
+
+	msg := MsgTitle(req)
+	fmt.Println(msg)
+
+	// Output: You have a new Role Request:
+}
+
+func ExampleMsgTitle_resources() {
+	req := plugindata.AccessRequestData{
+		User:  "example@goteleport.com",
+		Roles: []string{"admin", "foo", "bar", "dev"},
+		LoginsByRole: map[string][]string{
+			"admin": {"foo", "bar", "root"},
+			"foo":   {"foo"},
+			"bar":   {"bar"},
+			"dev":   {},
+		},
+		Resources:     []string{"/example.teleport.sh/node/0000"},
+		RequestKind:   "SHORT_TERM",
+		RequestReason: "test",
+	}
+
+	msg := MsgTitle(req)
+	fmt.Println(msg)
+
+	// Output: You have a new Resource Request:
+}
+
+func ExampleMsgTitle_resourcesLongTerm() {
+	req := plugindata.AccessRequestData{
+		User:  "example@goteleport.com",
+		Roles: []string{"admin", "foo", "bar", "dev"},
+		LoginsByRole: map[string][]string{
+			"admin": {"foo", "bar", "root"},
+			"foo":   {"foo"},
+			"bar":   {"bar"},
+			"dev":   {},
+		},
+		Resources:     []string{"/example.teleport.sh/node/0000"},
+		RequestKind:   "LONG_TERM",
+		RequestReason: "test",
+	}
+
+	msg := MsgTitle(req)
+	fmt.Println(msg)
+
+	// Output: You have a new Resource Request (long-term):
+}

--- a/integrations/access/accessrequest/message_test.go
+++ b/integrations/access/accessrequest/message_test.go
@@ -165,5 +165,5 @@ func ExampleMsgTitle_resourcesLongTerm() {
 	msg := MsgTitle(req)
 	fmt.Println(msg)
 
-	// Output: You have a new Resource Request (long-term):
+	// Output: You have a new Resource Request (long-term access):
 }

--- a/integrations/access/accessrequest/plugindata_test.go
+++ b/integrations/access/accessrequest/plugindata_test.go
@@ -36,6 +36,7 @@ func getSamplePluginData(t *testing.T) PluginData {
 			User:             "user-foo",
 			Roles:            []string{"role-foo", "role-bar"},
 			Resources:        []string{"cluster-a/node/foo", "cluster-a/node/bar"},
+			RequestKind:      "LONG_TERM",
 			RequestReason:    "foo reason",
 			ReviewsCount:     3,
 			ResolutionTag:    plugindata.ResolvedApproved,
@@ -52,10 +53,11 @@ func getSamplePluginData(t *testing.T) PluginData {
 func TestEncodePluginData(t *testing.T) {
 	dataMap, err := EncodePluginData(getSamplePluginData(t))
 	assert.NoError(t, err)
-	assert.Len(t, dataMap, 9)
+	assert.Len(t, dataMap, 10)
 	assert.Equal(t, "user-foo", dataMap["user"])
 	assert.Equal(t, "role-foo,role-bar", dataMap["roles"])
 	assert.Equal(t, `["cluster-a/node/foo","cluster-a/node/bar"]`, dataMap["resources"])
+	assert.Equal(t, "LONG_TERM", dataMap["request_kind"])
 	assert.Equal(t, "foo reason", dataMap["request_reason"])
 	assert.Equal(t, "3", dataMap["reviews_count"])
 	assert.Equal(t, "APPROVED", dataMap["resolution"])
@@ -69,6 +71,7 @@ func TestDecodePluginData(t *testing.T) {
 		"user":           "user-foo",
 		"roles":          "role-foo,role-bar",
 		"resources":      `["cluster-a/node/foo","cluster-a/node/bar"]`,
+		"request_kind":   "LONG_TERM",
 		"request_reason": "foo reason",
 		"reviews_count":  "3",
 		"resolution":     "APPROVED",
@@ -83,7 +86,7 @@ func TestDecodePluginData(t *testing.T) {
 func TestEncodeEmptyPluginData(t *testing.T) {
 	dataMap, err := EncodePluginData(PluginData{})
 	assert.NoError(t, err)
-	assert.Len(t, dataMap, 8)
+	assert.Len(t, dataMap, 9)
 	for key, value := range dataMap {
 		assert.Emptyf(t, value, "value at key %q must be empty", key)
 	}

--- a/integrations/access/discord/bot.go
+++ b/integrations/access/discord/bot.go
@@ -213,7 +213,7 @@ func (b DiscordBot) discordEmbeds(reviews []types.AccessReview) []DiscordEmbed {
 }
 
 func (b DiscordBot) discordMsgText(reqID string, reqData pd.AccessRequestData) string {
-	return "You have a new Role Request:\n" +
+	return accessrequest.MsgTitle(reqData) +
 		accessrequest.MsgFields(reqID, reqData, b.clusterName, b.webProxyURL) +
 		accessrequest.MsgStatusText(reqData.ResolutionTag, reqData.ResolutionReason)
 }

--- a/integrations/access/slack/bot.go
+++ b/integrations/access/slack/bot.go
@@ -364,10 +364,11 @@ func (b Bot) slackAccessListBatchedReminderMsgSection(accessLists []*accesslist.
 func (b Bot) slackAccessRequestMsgSections(reqID string, reqData pd.AccessRequestData) []BlockItem {
 	fields := accessrequest.MsgFields(reqID, reqData, b.clusterName, b.webProxyURL)
 	statusText := accessrequest.MsgStatusText(reqData.ResolutionTag, reqData.ResolutionReason)
+	titleText := accessrequest.MsgTitle(reqData)
 
 	sections := []BlockItem{
 		NewBlockItem(SectionBlock{
-			Text: NewTextObjectItem(MarkdownObject{Text: "You have a new Role Request:"}),
+			Text: NewTextObjectItem(MarkdownObject{Text: titleText}),
 		}),
 		NewBlockItem(SectionBlock{
 			Text: NewTextObjectItem(MarkdownObject{

--- a/integrations/lib/plugindata/access_request.go
+++ b/integrations/lib/plugindata/access_request.go
@@ -42,6 +42,7 @@ const (
 type AccessRequestData struct {
 	User               string
 	Roles              []string
+	RequestKind        string
 	RequestReason      string
 	ReviewsCount       int
 	ResolutionTag      ResolutionTag
@@ -59,6 +60,7 @@ func DecodeAccessRequestData(dataMap map[string]string) (data AccessRequestData,
 	if str := dataMap["roles"]; str != "" {
 		data.Roles = strings.Split(str, ",")
 	}
+	data.RequestKind = dataMap["request_kind"]
 	data.RequestReason = dataMap["request_reason"]
 	if str := dataMap["reviews_count"]; str != "" {
 		fmt.Sscanf(str, "%d", &data.ReviewsCount)
@@ -118,13 +120,14 @@ func DecodeAccessRequestData(dataMap map[string]string) (data AccessRequestData,
 	return
 }
 
-// EncodeAccessRequestData deserializes a string map to PluginData struct.
+// EncodeAccessRequestData serializes a PluginData struct into a string map.
 func EncodeAccessRequestData(data AccessRequestData) (map[string]string, error) {
 	result := make(map[string]string)
 
 	result["user"] = data.User
 	result["roles"] = strings.Join(data.Roles, ",")
 	result["resources"] = strings.Join(data.Resources, ",")
+	result["request_kind"] = data.RequestKind
 	result["request_reason"] = data.RequestReason
 
 	if len(data.Resources) != 0 {

--- a/integrations/lib/plugindata/access_request_test.go
+++ b/integrations/lib/plugindata/access_request_test.go
@@ -28,6 +28,7 @@ var sampleAccessRequestData = AccessRequestData{
 	User:               "user-foo",
 	Roles:              []string{"role-foo", "role-bar"},
 	Resources:          []string{"cluster/node/foo", "cluster/node/bar"},
+	RequestKind:        "LONG_TERM",
 	RequestReason:      "foo reason",
 	ReviewsCount:       3,
 	ResolutionTag:      ResolvedApproved,
@@ -41,10 +42,11 @@ var sampleAccessRequestData = AccessRequestData{
 func TestEncodeAccessRequestData(t *testing.T) {
 	dataMap, err := EncodeAccessRequestData(sampleAccessRequestData)
 	assert.NoError(t, err)
-	assert.Len(t, dataMap, 9)
+	assert.Len(t, dataMap, 10)
 	assert.Equal(t, "user-foo", dataMap["user"])
 	assert.Equal(t, "role-foo,role-bar", dataMap["roles"])
 	assert.Equal(t, `["cluster/node/foo","cluster/node/bar"]`, dataMap["resources"])
+	assert.Equal(t, "LONG_TERM", dataMap["request_kind"])
 	assert.Equal(t, "foo reason", dataMap["request_reason"])
 	assert.Equal(t, "3", dataMap["reviews_count"])
 	assert.Equal(t, "APPROVED", dataMap["resolution"])
@@ -59,6 +61,7 @@ func TestDecodeAccessRequestData(t *testing.T) {
 		"user":                "user-foo",
 		"roles":               "role-foo,role-bar",
 		"resources":           `["cluster/node/foo", "cluster/node/bar"]`,
+		"request_kind":        "LONG_TERM",
 		"request_reason":      "foo reason",
 		"reviews_count":       "3",
 		"resolution":          "APPROVED",
@@ -73,7 +76,7 @@ func TestDecodeAccessRequestData(t *testing.T) {
 func TestEncodeEmptyAccessRequestData(t *testing.T) {
 	dataMap, err := EncodeAccessRequestData(AccessRequestData{})
 	assert.NoError(t, err)
-	assert.Len(t, dataMap, 7)
+	assert.Len(t, dataMap, 8)
 	for key, value := range dataMap {
 		assert.Emptyf(t, value, "value at key %q must be empty", key)
 	}


### PR DESCRIPTION
Depends on #67281

Instead of static "new Role Request" title, now create access request notification title based on "role-based" or "resource-based", and `RequestKind`: "long-term" (permanent access via access list promotion).

Changelog: Improved notification messaging for Slack and Discord access plugins

<details><summary>Slack example</summary>
<p>

<img width="716" height="639" alt="Screenshot 2026-05-29 at 3 17 30 PM" src="https://github.com/user-attachments/assets/092806c1-a124-4cdb-9bf2-573a7139bc8b" />


</p>
</details> 

<details><summary>Discord example</summary>
<p>

<img width="1281" height="816" alt="Screenshot 2026-05-29 152151" src="https://github.com/user-attachments/assets/1f93adcb-b5bc-44d6-8f83-ea00e59e7835" />
<img width="1274" height="416" alt="Screenshot 2026-05-29 152216" src="https://github.com/user-attachments/assets/8b091de8-fe05-4ea7-a345-19849b76213e" />


</p>
</details> 

## Manual Test Plan
### Test Environment

Teleport Cloud. Local Slack and Discord plugins.

### Test Cases
- [x] Output is formatted properly for Slack and Discord plugins:
	- [x] Role request
	- [x] Resource request
	- [x] Long-term resource request
