### PR TITLE
[v18] Fix cleanup in session setup failure path

### DIFF
--- a/lib/srv/sess.go
+++ b/lib/srv/sess.go
@@ -410,14 +410,21 @@ func (s *SessionRegistry) JoinSession(ctx context.Context, ch ssh.Channel, scx *
 }
 
 // OpenExecSession opens a non-interactive exec session.
-func (s *SessionRegistry) OpenExecSession(ctx context.Context, channel ssh.Channel, scx *ServerContext) error {
+func (s *SessionRegistry) OpenExecSession(ctx context.Context, channel ssh.Channel, scx *ServerContext) (err error) {
 	// This logic allows concurrent request to create a new session
 	// to fail, what is ok because we should never have this condition.
-	sess, _, err := newSession(ctx, s, scx, channel, sessionTypeNonInteractive)
+	sess, p, err := newSession(ctx, s, scx, channel, sessionTypeNonInteractive)
 	if err != nil {
 		return trace.Wrap(err)
 	}
 	scx.Logger.InfoContext(ctx, "Creating exec session", "session_id", sess.id)
+
+	// Make sure to close the session when returning an error
+	defer func() {
+		if err != nil {
+			sess.Close()
+		}
+	}()
 
 	approved, err := s.isApprovedFileTransfer(scx)
 	if err != nil {
@@ -441,9 +448,8 @@ func (s *SessionRegistry) OpenExecSession(ctx context.Context, channel ssh.Chann
 	// occurs, otherwise it will be closed by the callee.
 	scx.setSession(ctx, sess)
 
-	err = sess.startExec(ctx, channel, scx)
+	err = sess.startExec(ctx, channel, scx, p)
 	if err != nil {
-		sess.Close()
 		return trace.Wrap(err)
 	}
 
@@ -812,7 +818,7 @@ const (
 )
 
 // newSession creates a new session with a given ID within a given context.
-func newSession(ctx context.Context, r *SessionRegistry, scx *ServerContext, ch ssh.Channel, sessType sessionType) (*session, *party, error) {
+func newSession(ctx context.Context, r *SessionRegistry, scx *ServerContext, ch ssh.Channel, sessType sessionType) (s *session, p *party, err error) {
 	var sessionRecordingMode constants.SessionRecordingMode
 	switch {
 	case scx.Identity.AccessPermit != nil:
@@ -823,7 +829,6 @@ func newSession(ctx context.Context, r *SessionRegistry, scx *ServerContext, ch 
 		return nil, nil, trace.BadParameter("session creation only supported in context of ssh access or proxying permit")
 	}
 
-	serverSessions.Inc()
 	startTime := time.Now().UTC()
 	rsess := rsession.Session{
 		Kind: types.SSHSessionKind,
@@ -857,6 +862,7 @@ func newSession(ctx context.Context, r *SessionRegistry, scx *ServerContext, ch 
 		policySets = scx.Identity.UnstableSessionJoiningAccessChecker.SessionPolicySets()
 	}
 
+	serverSessions.Inc()
 	access := moderation.NewSessionAccessEvaluator(policySets, types.SSHSessionKind, scx.Identity.TeleportUser)
 	sess := &session{
 		logger: slog.With(
@@ -885,6 +891,13 @@ func newSession(ctx context.Context, r *SessionRegistry, scx *ServerContext, ch 
 		serverMeta:                     scx.srv.EventMetadata(),
 	}
 
+	// Make sure to close the session when returning an error
+	defer func() {
+		if err != nil {
+			sess.Close()
+		}
+	}()
+
 	sess.io.OnWriteError = sess.onWriteErrorCallback(sessionRecordingMode)
 
 	go func() {
@@ -896,12 +909,9 @@ func newSession(ctx context.Context, r *SessionRegistry, scx *ServerContext, ch 
 		}
 	}()
 
-	// create a new "party" (connected client) and launch/join the session.
-	p := newParty(sess, types.SessionPeerMode, ch, scx)
-	sess.parties[p.id] = p
-	sess.participants[p.id] = p
+	// create a new "party" (connected client).
+	p = newParty(sess, types.SessionPeerMode, ch, scx)
 
-	var err error
 	if err = sess.trackSession(ctx, scx.Identity.TeleportUser, policySets, p, sessType); err != nil {
 		if trace.IsNotImplemented(err) {
 			return nil, nil, trace.NotImplemented("Attempted to use Moderated Sessions with an Auth Server below the minimum version of 9.0.0.")
@@ -973,8 +983,10 @@ func (s *session) Stop() {
 	s.haltTerminal()
 
 	// Close session tracker and mark it as terminated
-	if err := s.tracker.Close(s.serverCtx); err != nil {
-		s.logger.DebugContext(s.serverCtx, "Failed to close session tracker.", "error", err)
+	if s.tracker != nil {
+		if err := s.tracker.Close(s.serverCtx); err != nil {
+			s.logger.DebugContext(s.serverCtx, "Failed to close session tracker.", "error", err)
+		}
 	}
 }
 
@@ -1622,7 +1634,7 @@ func newRecorder(s *session, ctx *ServerContext, sessType sessionType) (events.S
 	return rec, nil
 }
 
-func (s *session) startExec(ctx context.Context, channel ssh.Channel, scx *ServerContext) error {
+func (s *session) startExec(ctx context.Context, channel ssh.Channel, scx *ServerContext, p *party) error {
 	// Emit a session.start event for the exec session.
 	s.emitSessionStartEvent(scx)
 
@@ -1646,6 +1658,12 @@ func (s *session) startExec(ctx context.Context, channel ssh.Channel, scx *Serve
 		)
 		scx.SendExecResult(ctx, *result)
 	}
+
+	// Add the party to the session once it is running.
+	s.mu.Lock()
+	s.parties[p.id] = p
+	s.participants[p.id] = p
+	s.mu.Unlock()
 
 	var eventsMap map[string]bool
 	if scx.Identity.AccessPermit != nil {

--- a/lib/srv/sess_test.go
+++ b/lib/srv/sess_test.go
@@ -32,6 +32,7 @@ import (
 
 	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
+	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/crypto/ssh"
@@ -345,6 +346,141 @@ func TestSession_newRecorder(t *testing.T) {
 			rec, err := newRecorder(sess, tt.sctx, sessType)
 			tt.errAssertion(t, err)
 			tt.recAssertion(t, rec)
+		})
+	}
+}
+
+func TestSessionRegistrySetupFailureCleanup(t *testing.T) {
+	moderatedRole, err := types.NewRole("access", types.RoleSpecV6{
+		Allow: types.RoleConditions{
+			RequireSessionJoin: []*types.SessionRequirePolicy{{
+				Name:   "foo",
+				Filter: "contains(user.roles, 'auditor')",
+				Kinds:  []string{string(types.SSHSessionKind)},
+				Modes:  []string{string(types.SessionModeratorMode)},
+				Count:  1,
+			}},
+		},
+	})
+	require.NoError(t, err)
+
+	recordAtNodeSync := func() *types.SessionRecordingConfigV2 {
+		return &types.SessionRecordingConfigV2{
+			Kind:    types.KindSessionRecordingConfig,
+			Version: types.V2,
+			Spec: types.SessionRecordingConfigSpecV2{
+				Mode: types.RecordAtNodeSync,
+			},
+		}
+	}
+
+	type testCase struct {
+		name         string
+		openSession  func(context.Context, *SessionRegistry, ssh.Channel, *ServerContext) error
+		sessionRoles services.RoleSet
+		configure    func(*testing.T, *mockServer, *ServerContext, *trackerService)
+		errAssertion require.ErrorAssertionFunc
+	}
+
+	cases := []testCase{
+		{
+			name: "interactive track session failure",
+			openSession: func(ctx context.Context, reg *SessionRegistry, ch ssh.Channel, scx *ServerContext) error {
+				return reg.OpenSession(ctx, ch, scx)
+			},
+			sessionRoles: services.NewRoleSet(moderatedRole),
+			configure: func(t *testing.T, srv *mockServer, scx *ServerContext, trackingService *trackerService) {
+				scx.SessionRecordingConfig = recordAtNodeSync()
+				trackingService.createError = trace.ConnectionProblem(context.DeadlineExceeded, "")
+			},
+		},
+		{
+			name: "interactive recorder failure",
+			openSession: func(ctx context.Context, reg *SessionRegistry, ch ssh.Channel, scx *ServerContext) error {
+				return reg.OpenSession(ctx, ch, scx)
+			},
+			configure: func(t *testing.T, srv *mockServer, scx *ServerContext, _ *trackerService) {
+				srv.datadir = ""
+				scx.SessionRecordingConfig = recordAtNodeSync()
+			},
+		},
+		{
+			name: "exec unapproved moderated session",
+			openSession: func(ctx context.Context, reg *SessionRegistry, ch ssh.Channel, scx *ServerContext) error {
+				return reg.OpenExecSession(ctx, ch, scx)
+			},
+			sessionRoles: services.NewRoleSet(moderatedRole),
+			configure: func(t *testing.T, _ *mockServer, scx *ServerContext, _ *trackerService) {
+				scx.SessionRecordingConfig = recordAtNodeSync()
+			},
+			errAssertion: func(t require.TestingT, err error, _ ...any) {
+				require.ErrorIs(t, err, errCannotStartUnattendedSession)
+			},
+		},
+		{
+			name: "exec unapproved moderated file transfer",
+			openSession: func(ctx context.Context, reg *SessionRegistry, ch ssh.Channel, scx *ServerContext) error {
+				return reg.OpenExecSession(ctx, ch, scx)
+			},
+			configure: func(t *testing.T, _ *mockServer, scx *ServerContext, _ *trackerService) {
+				scx.SetEnv(sftp.EnvModeratedSessionID, string(rsession.NewID()))
+			},
+			errAssertion: func(t require.TestingT, err error, _ ...any) {
+				require.True(t, trace.IsNotFound(err))
+			},
+		},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			srv := newMockServer(t)
+
+			mockTrackerService := &mockSessiontrackerService{
+				trackers: make(map[string]types.SessionTracker),
+			}
+			trackingService := &trackerService{
+				SessionTrackerService: mockTrackerService,
+			}
+
+			reg, err := NewSessionRegistry(SessionRegistryConfig{
+				Srv:                   srv,
+				SessionTrackerService: trackingService,
+				clock:                 clockwork.NewFakeClock(),
+			})
+			require.NoError(t, err)
+			t.Cleanup(func() { reg.Close() })
+
+			// Use strict recording mode so that recorder errors aren't ignored.
+			accessPermit := &decisionpb.SSHAccessPermit{
+				SessionRecordingMode: string(constants.SessionRecordingModeStrict),
+			}
+
+			scx := newTestServerContext(t, reg.Srv, tt.sessionRoles, accessPermit)
+			t.Cleanup(func() { require.NoError(t, scx.Close()) })
+
+			tt.configure(t, srv, scx, trackingService)
+
+			channel := newMockSSHChannel()
+			t.Cleanup(func() { require.NoError(t, channel.Close()) })
+
+			countBefore := testutil.ToFloat64(serverSessions)
+
+			err = tt.openSession(t.Context(), reg, channel, scx)
+			require.Error(t, err)
+			require.Nil(t, scx.session)
+
+			if tt.errAssertion != nil {
+				tt.errAssertion(t, err)
+			}
+
+			require.InDelta(t, countBefore, testutil.ToFloat64(serverSessions), 0)
+
+			// If we created a tracker before the failure, the tracker should be updated to terminated.
+			if trackingService.CreatedCount() != 0 {
+				for _, tracker := range mockTrackerService.trackers {
+					require.Equal(t, types.SessionState_SessionStateTerminated, tracker.GetState())
+				}
+			}
 		})
 	}
 }


### PR DESCRIPTION
Backport https://github.com/gravitational/teleport/pull/64649 to branch/v18

## Manual Test Plan

### Test Cases
- [x] interactive session
  - [x] emits start/leave/end events
  - [x] creates session recording
- [x] non-interactive session
  - [x] emits start/leave/end events