### PR TITLE
[v17] Fix cleanup in session setup failure path

### DIFF
--- a/lib/srv/sess.go
+++ b/lib/srv/sess.go
@@ -413,7 +413,7 @@ func (s *SessionRegistry) OpenSession(ctx context.Context, ch ssh.Channel, scx *
 }
 
 // OpenExecSession opens a non-interactive exec session.
-func (s *SessionRegistry) OpenExecSession(ctx context.Context, channel ssh.Channel, scx *ServerContext) error {
+func (s *SessionRegistry) OpenExecSession(ctx context.Context, channel ssh.Channel, scx *ServerContext) (err error) {
 	sessionID := scx.SessionID()
 
 	if sessionID.IsZero() {
@@ -427,11 +427,18 @@ func (s *SessionRegistry) OpenExecSession(ctx context.Context, channel ssh.Chann
 
 	// This logic allows concurrent request to create a new session
 	// to fail, what is ok because we should never have this condition.
-	sess, _, err := newSession(ctx, sessionID, s, scx, channel, sessionTypeNonInteractive)
+	sess, p, err := newSession(ctx, sessionID, s, scx, channel, sessionTypeNonInteractive)
 	if err != nil {
 		return trace.Wrap(err)
 	}
 	scx.Infof("Creating (exec) session %v.", sessionID)
+
+	// Make sure to close the session when returning an error
+	defer func() {
+		if err != nil {
+			sess.Close()
+		}
+	}()
 
 	approved, err := s.isApprovedFileTransfer(scx)
 	if err != nil {
@@ -455,9 +462,8 @@ func (s *SessionRegistry) OpenExecSession(ctx context.Context, channel ssh.Chann
 	// occurs, otherwise it will be closed by the callee.
 	scx.setSession(sess, channel)
 
-	err = sess.startExec(ctx, channel, scx)
+	err = sess.startExec(ctx, channel, scx, p)
 	if err != nil {
-		sess.Close()
 		return trace.Wrap(err)
 	}
 
@@ -808,8 +814,7 @@ const (
 )
 
 // newSession creates a new session with a given ID within a given context.
-func newSession(ctx context.Context, id rsession.ID, r *SessionRegistry, scx *ServerContext, ch ssh.Channel, sessType sessionType) (*session, *party, error) {
-	serverSessions.Inc()
+func newSession(ctx context.Context, id rsession.ID, r *SessionRegistry, scx *ServerContext, ch ssh.Channel, sessType sessionType) (s *session, p *party, err error) {
 	startTime := time.Now().UTC()
 	rsess := rsession.Session{
 		Kind: types.SSHSessionKind,
@@ -839,6 +844,7 @@ func newSession(ctx context.Context, id rsession.ID, r *SessionRegistry, scx *Se
 	}
 
 	policySets := scx.Identity.AccessChecker.SessionPolicySets()
+	serverSessions.Inc()
 	access := moderation.NewSessionAccessEvaluator(policySets, types.SSHSessionKind, scx.Identity.TeleportUser)
 	sess := &session{
 		logger: slog.With(
@@ -864,6 +870,13 @@ func newSession(ctx context.Context, id rsession.ID, r *SessionRegistry, scx *Se
 		serverMeta:                     scx.srv.TargetMetadata(),
 	}
 
+	// Make sure to close the session when returning an error
+	defer func() {
+		if err != nil {
+			sess.Close()
+		}
+	}()
+
 	sess.io.OnWriteError = sess.onWriteError
 
 	go func() {
@@ -875,12 +888,9 @@ func newSession(ctx context.Context, id rsession.ID, r *SessionRegistry, scx *Se
 		}
 	}()
 
-	// create a new "party" (connected client) and launch/join the session.
-	p := newParty(sess, types.SessionPeerMode, ch, scx)
-	sess.parties[p.id] = p
-	sess.participants[p.id] = p
+	// create a new "party" (connected client).
+	p = newParty(sess, types.SessionPeerMode, ch, scx)
 
-	var err error
 	if err = sess.trackSession(ctx, scx.Identity.TeleportUser, policySets, p, sessType); err != nil {
 		if trace.IsNotImplemented(err) {
 			return nil, nil, trace.NotImplemented("Attempted to use Moderated Sessions with an Auth Server below the minimum version of 9.0.0.")
@@ -952,8 +962,10 @@ func (s *session) Stop() {
 	s.haltTerminal()
 
 	// Close session tracker and mark it as terminated
-	if err := s.tracker.Close(s.serverCtx); err != nil {
-		s.logger.DebugContext(s.serverCtx, "Failed to close session tracker.", "error", err)
+	if s.tracker != nil {
+		if err := s.tracker.Close(s.serverCtx); err != nil {
+			s.logger.DebugContext(s.serverCtx, "Failed to close session tracker.", "error", err)
+		}
 	}
 }
 
@@ -1563,7 +1575,7 @@ func newRecorder(s *session, ctx *ServerContext) (events.SessionPreparerRecorder
 	return rec, nil
 }
 
-func (s *session) startExec(ctx context.Context, channel ssh.Channel, scx *ServerContext) error {
+func (s *session) startExec(ctx context.Context, channel ssh.Channel, scx *ServerContext, p *party) error {
 	// Emit a session.start event for the exec session.
 	s.emitSessionStartEvent(scx)
 
@@ -1587,6 +1599,12 @@ func (s *session) startExec(ctx context.Context, channel ssh.Channel, scx *Serve
 		)
 		scx.SendExecResult(*result)
 	}
+
+	// Add the party to the session once it is running.
+	s.mu.Lock()
+	s.parties[p.id] = p
+	s.participants[p.id] = p
+	s.mu.Unlock()
 
 	// Open a BPF recording session. If BPF was not configured, not available,
 	// or running in a recording proxy, OpenSession is a NOP.

--- a/lib/srv/sess_test.go
+++ b/lib/srv/sess_test.go
@@ -31,6 +31,7 @@ import (
 
 	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
+	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/crypto/ssh"
@@ -375,6 +376,141 @@ func TestSession_newRecorder(t *testing.T) {
 			rec, err := newRecorder(tt.sess, tt.sctx)
 			tt.errAssertion(t, err)
 			tt.recAssertion(t, rec)
+		})
+	}
+}
+
+func TestSessionRegistrySetupFailureCleanup(t *testing.T) {
+	moderatedRole, err := types.NewRole("access", types.RoleSpecV6{
+		Allow: types.RoleConditions{
+			RequireSessionJoin: []*types.SessionRequirePolicy{{
+				Name:   "foo",
+				Filter: "contains(user.roles, 'auditor')",
+				Kinds:  []string{string(types.SSHSessionKind)},
+				Modes:  []string{string(types.SessionModeratorMode)},
+				Count:  1,
+			}},
+		},
+	})
+	require.NoError(t, err)
+
+	recordAtNodeSync := func() *types.SessionRecordingConfigV2 {
+		return &types.SessionRecordingConfigV2{
+			Kind:    types.KindSessionRecordingConfig,
+			Version: types.V2,
+			Spec: types.SessionRecordingConfigSpecV2{
+				Mode: types.RecordAtNodeSync,
+			},
+		}
+	}
+
+	type testCase struct {
+		name         string
+		openSession  func(context.Context, *SessionRegistry, ssh.Channel, *ServerContext) error
+		sessionRoles services.RoleSet
+		configure    func(*testing.T, *mockServer, *ServerContext, *trackerService)
+		errAssertion require.ErrorAssertionFunc
+	}
+
+	cases := []testCase{
+		{
+			name: "interactive track session failure",
+			openSession: func(ctx context.Context, reg *SessionRegistry, ch ssh.Channel, scx *ServerContext) error {
+				return reg.OpenSession(ctx, ch, scx)
+			},
+			sessionRoles: services.NewRoleSet(moderatedRole),
+			configure: func(t *testing.T, srv *mockServer, scx *ServerContext, trackingService *trackerService) {
+				scx.SessionRecordingConfig = recordAtNodeSync()
+				trackingService.createError = trace.ConnectionProblem(context.DeadlineExceeded, "")
+			},
+		},
+		{
+			name: "interactive recorder failure",
+			openSession: func(ctx context.Context, reg *SessionRegistry, ch ssh.Channel, scx *ServerContext) error {
+				return reg.OpenSession(ctx, ch, scx)
+			},
+			configure: func(t *testing.T, srv *mockServer, scx *ServerContext, _ *trackerService) {
+				srv.datadir = ""
+				scx.SessionRecordingConfig = recordAtNodeSync()
+			},
+		},
+		{
+			name: "exec unapproved moderated session",
+			openSession: func(ctx context.Context, reg *SessionRegistry, ch ssh.Channel, scx *ServerContext) error {
+				return reg.OpenExecSession(ctx, ch, scx)
+			},
+			sessionRoles: services.NewRoleSet(moderatedRole),
+			configure: func(t *testing.T, _ *mockServer, scx *ServerContext, _ *trackerService) {
+				scx.SessionRecordingConfig = recordAtNodeSync()
+			},
+			errAssertion: func(t require.TestingT, err error, _ ...any) {
+				require.ErrorIs(t, err, errCannotStartUnattendedSession)
+			},
+		},
+		{
+			name: "exec unapproved moderated file transfer",
+			openSession: func(ctx context.Context, reg *SessionRegistry, ch ssh.Channel, scx *ServerContext) error {
+				return reg.OpenExecSession(ctx, ch, scx)
+			},
+			configure: func(t *testing.T, _ *mockServer, scx *ServerContext, _ *trackerService) {
+				scx.SetEnv(sftp.EnvModeratedSessionID, string(rsession.NewID()))
+			},
+			errAssertion: func(t require.TestingT, err error, _ ...any) {
+				require.True(t, trace.IsNotFound(err))
+			},
+		},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			srv := newMockServer(t)
+
+			mockTrackerService := &mockSessiontrackerService{
+				trackers: make(map[string]types.SessionTracker),
+			}
+			trackingService := &trackerService{
+				SessionTrackerService: mockTrackerService,
+			}
+
+			reg, err := NewSessionRegistry(SessionRegistryConfig{
+				Srv:                   srv,
+				SessionTrackerService: trackingService,
+				clock:                 clockwork.NewFakeClock(),
+			})
+			require.NoError(t, err)
+			t.Cleanup(func() { reg.Close() })
+
+			// Use strict recording mode so that recorder errors aren't ignored.
+			accessPermit := &decisionpb.SSHAccessPermit{
+				SessionRecordingMode: string(constants.SessionRecordingModeStrict),
+			}
+
+			scx := newTestServerContext(t, reg.Srv, tt.sessionRoles, accessPermit)
+			t.Cleanup(func() { require.NoError(t, scx.Close()) })
+
+			tt.configure(t, srv, scx, trackingService)
+
+			channel := newMockSSHChannel()
+			t.Cleanup(func() { require.NoError(t, channel.Close()) })
+
+			countBefore := testutil.ToFloat64(serverSessions)
+
+			err = tt.openSession(t.Context(), reg, channel, scx)
+			require.Error(t, err)
+			require.Nil(t, scx.session)
+
+			if tt.errAssertion != nil {
+				tt.errAssertion(t, err)
+			}
+
+			require.InDelta(t, countBefore, testutil.ToFloat64(serverSessions), 0)
+
+			// If we created a tracker before the failure, the tracker should be updated to terminated.
+			if trackingService.CreatedCount() != 0 {
+				for _, tracker := range mockTrackerService.trackers {
+					require.Equal(t, types.SessionState_SessionStateTerminated, tracker.GetState())
+				}
+			}
 		})
 	}
 }

--- a/lib/srv/sess_test.go
+++ b/lib/srv/sess_test.go
@@ -394,6 +394,16 @@ func TestSessionRegistrySetupFailureCleanup(t *testing.T) {
 	})
 	require.NoError(t, err)
 
+	// Use strict recording mode so that recorder errors aren't ignored.
+	strictRecordingRole, err := types.NewRole("strict-recording", types.RoleSpecV6{
+		Options: types.RoleOptions{
+			RecordSession: &types.RecordSession{
+				Default: constants.SessionRecordingModeStrict,
+			},
+		},
+	})
+	require.NoError(t, err)
+
 	recordAtNodeSync := func() *types.SessionRecordingConfigV2 {
 		return &types.SessionRecordingConfigV2{
 			Kind:    types.KindSessionRecordingConfig,
@@ -429,8 +439,10 @@ func TestSessionRegistrySetupFailureCleanup(t *testing.T) {
 			openSession: func(ctx context.Context, reg *SessionRegistry, ch ssh.Channel, scx *ServerContext) error {
 				return reg.OpenSession(ctx, ch, scx)
 			},
+			sessionRoles: services.NewRoleSet(strictRecordingRole),
 			configure: func(t *testing.T, srv *mockServer, scx *ServerContext, _ *trackerService) {
 				srv.datadir = ""
+				srv.bpf = fakeBPF{}
 				scx.SessionRecordingConfig = recordAtNodeSync()
 			},
 		},
@@ -453,7 +465,7 @@ func TestSessionRegistrySetupFailureCleanup(t *testing.T) {
 				return reg.OpenExecSession(ctx, ch, scx)
 			},
 			configure: func(t *testing.T, _ *mockServer, scx *ServerContext, _ *trackerService) {
-				scx.SetEnv(sftp.EnvModeratedSessionID, string(rsession.NewID()))
+				scx.SetEnv(string(sftp.ModeratedSessionID), string(rsession.NewID()))
 			},
 			errAssertion: func(t require.TestingT, err error, _ ...any) {
 				require.True(t, trace.IsNotFound(err))
@@ -480,12 +492,7 @@ func TestSessionRegistrySetupFailureCleanup(t *testing.T) {
 			require.NoError(t, err)
 			t.Cleanup(func() { reg.Close() })
 
-			// Use strict recording mode so that recorder errors aren't ignored.
-			accessPermit := &decisionpb.SSHAccessPermit{
-				SessionRecordingMode: string(constants.SessionRecordingModeStrict),
-			}
-
-			scx := newTestServerContext(t, reg.Srv, tt.sessionRoles, accessPermit)
+			scx := newTestServerContext(t, reg.Srv, tt.sessionRoles)
 			t.Cleanup(func() { require.NoError(t, scx.Close()) })
 
 			tt.configure(t, srv, scx, trackingService)


### PR DESCRIPTION
Backport https://github.com/gravitational/teleport/pull/64649 to branch/v18

## Manual Test Plan

### Test Cases
- [x] interactive session
  - [x] emits start/leave/end events
  - [x] creates session recording
- [x] non-interactive session
  - [x] emits start/leave/end events