### PR TITLE
Add a Shared User Display Formatter for the CLI

### DIFF
--- a/tool/common/common.go
+++ b/tool/common/common.go
@@ -27,6 +27,7 @@ import (
 	"log/slog"
 	"sort"
 	"strings"
+	"unicode"
 
 	"github.com/ghodss/yaml"
 	"github.com/gravitational/trace"
@@ -322,4 +323,40 @@ func PrintYAML(w io.Writer, v any) error {
 	}
 	_, err = fmt.Fprintln(w, string(out))
 	return trace.Wrap(err)
+}
+
+// FormatUserDisplay renders a user identity from display values plus username:
+//
+//	"Primary <Secondary> (username)" — all three present
+//	"Primary (username)"             — primary + username
+//	"username <Secondary>"           — secondary + username
+//	"username"                       — username only
+func FormatUserDisplay(primary, secondary, username string) string {
+	primary = sanitizeDisplayValue(primary)
+	secondary = sanitizeDisplayValue(secondary)
+	username = sanitizeDisplayValue(username)
+
+	switch {
+	case primary != "" && secondary != "":
+		return fmt.Sprintf("%s <%s> (%s)", primary, secondary, username)
+	case primary != "":
+		return fmt.Sprintf("%s (%s)", primary, username)
+	case secondary != "":
+		return fmt.Sprintf("%s <%s>", username, secondary)
+	default:
+		return username
+	}
+}
+
+// sanitizeDisplayValue drops control characters and trims whitespace so the
+// result is safe to print in a single-line terminal cell.
+func sanitizeDisplayValue(s string) string {
+	var b strings.Builder
+	b.Grow(len(s))
+	for _, r := range s {
+		if !unicode.IsControl(r) {
+			b.WriteRune(r)
+		}
+	}
+	return strings.TrimSpace(b.String())
 }

--- a/tool/common/common.go
+++ b/tool/common/common.go
@@ -28,6 +28,7 @@ import (
 	"sort"
 	"strings"
 	"unicode"
+	"unicode/utf8"
 
 	"github.com/ghodss/yaml"
 	"github.com/gravitational/trace"
@@ -348,15 +349,129 @@ func FormatUserDisplay(primary, secondary, username string) string {
 	}
 }
 
-// sanitizeDisplayValue drops control characters and trims whitespace so the
-// result is safe to print in a single-line terminal cell.
+// sanitizeDisplayValue removes terminal controls, newlines, and tabs for a
+// single-line terminal cell.
 func sanitizeDisplayValue(s string) string {
+	s = StripTerminalControlSequences(s)
+	// Preserve word boundaries while keeping the value to one terminal line.
+	return strings.Join(strings.Fields(s), " ")
+}
+
+// StripTerminalControlSequences removes terminal control sequences from s,
+// preserving printable text, newlines, and tabs.
+func StripTerminalControlSequences(s string) string {
 	var b strings.Builder
 	b.Grow(len(s))
-	for _, r := range s {
-		if !unicode.IsControl(r) {
-			b.WriteRune(r)
+
+	for i := 0; i < len(s); {
+		r, size := utf8.DecodeRuneInString(s[i:])
+		if r == utf8.RuneError && size == 1 {
+			c := s[i]
+			switch {
+			case c == '\x1b':
+				i = consumeEscapeSequence(s, i+1)
+			case c == '\x90' || c == '\x98' || c == '\x9d' || c == '\x9e' || c == '\x9f':
+				i = consumeStringControl(s, i+1)
+			case c == '\x9b':
+				i = consumeCSISequence(s, i+1)
+			case c == '\n' || c == '\t':
+				b.WriteByte(c)
+				i++
+			case c < ' ' || c == '\x7f' || (c >= '\x80' && c <= '\x9f'):
+				i++
+			default:
+				b.WriteByte(c)
+				i++
+			}
+			continue
+		}
+
+		switch r {
+		case '\x1b':
+			i = consumeEscapeSequence(s, i+size)
+			continue
+		case '\u0090', '\u0098', '\u009d', '\u009e', '\u009f':
+			i = consumeStringControl(s, i+size)
+			continue
+		case '\u009b':
+			i = consumeCSISequence(s, i+size)
+			continue
+		}
+
+		if unicode.IsControl(r) && r != '\n' && r != '\t' {
+			i += size
+			continue
+		}
+
+		b.WriteString(s[i : i+size])
+		i += size
+	}
+
+	return b.String()
+}
+
+func consumeEscapeSequence(s string, i int) int {
+	if i >= len(s) {
+		return i
+	}
+
+	switch s[i] {
+	case '[':
+		return consumeCSISequence(s, i+1)
+	case ']', 'P', 'X', '^', '_':
+		return consumeStringControl(s, i+1)
+	case '(', ')', '*', '+', '-', '.', '/', '#':
+		if i+1 < len(s) {
+			return i + 2
+		}
+		return i + 1
+	}
+
+	for i < len(s) {
+		c := s[i]
+		i++
+		if c >= '\x30' && c <= '\x7e' {
+			return i
+		}
+		if c < ' ' || c > '\x7e' {
+			return i
 		}
 	}
-	return strings.TrimSpace(b.String())
+	return i
+}
+
+func consumeCSISequence(s string, i int) int {
+	for i < len(s) {
+		c := s[i]
+		i++
+		if c >= '\x40' && c <= '\x7e' {
+			return i
+		}
+	}
+	return i
+}
+
+func consumeStringControl(s string, i int) int {
+	for i < len(s) {
+		if s[i] == '\a' {
+			return i + 1
+		}
+		if s[i] == '\x1b' && i+1 < len(s) && s[i+1] == '\\' {
+			return i + 2
+		}
+
+		r, size := utf8.DecodeRuneInString(s[i:])
+		if r == utf8.RuneError && size == 1 {
+			if s[i] == '\x9c' {
+				return i + 1
+			}
+			i++
+			continue
+		}
+		if r == '\u009c' {
+			return i + size
+		}
+		i += size
+	}
+	return i
 }

--- a/tool/common/common.go
+++ b/tool/common/common.go
@@ -328,9 +328,9 @@ func PrintYAML(w io.Writer, v any) error {
 
 // FormatUserDisplay renders a user identity from display values plus username:
 //
-//	"Primary <Secondary> (username)" — all three present
-//	"Primary (username)"             — primary + username
-//	"username <Secondary>"           — secondary + username
+//	"username (Primary) <Secondary>" — all three present
+//	"username (Primary)"             — username + primary
+//	"username <Secondary>"           — username + secondary
 //	"username"                       — username only
 func FormatUserDisplay(primary, secondary, username string) string {
 	primary = sanitizeDisplayValue(primary)
@@ -339,9 +339,9 @@ func FormatUserDisplay(primary, secondary, username string) string {
 
 	switch {
 	case primary != "" && secondary != "":
-		return fmt.Sprintf("%s <%s> (%s)", primary, secondary, username)
+		return fmt.Sprintf("%s (%s) <%s>", username, primary, secondary)
 	case primary != "":
-		return fmt.Sprintf("%s (%s)", primary, username)
+		return fmt.Sprintf("%s (%s)", username, primary)
 	case secondary != "":
 		return fmt.Sprintf("%s <%s>", username, secondary)
 	default:

--- a/tool/common/common_test.go
+++ b/tool/common/common_test.go
@@ -271,7 +271,7 @@ func TestFormatUserDisplay_CanonicalForms(t *testing.T) {
 		FormatUserDisplay("", "", "123456"))
 }
 
-// Control-byte stripping (one per class) and whitespace handling.
+// Whitespace handling after terminal controls are stripped.
 func TestFormatUserDisplay_Sanitization(t *testing.T) {
 	t.Parallel()
 
@@ -283,40 +283,16 @@ func TestFormatUserDisplay_Sanitization(t *testing.T) {
 		want      string
 	}{
 		{
-			// Only the ESC byte is a control rune, so "[31m" stays — but
-			// without the ESC the terminal won't read it as a color escape.
-			name:     "ansi CSI escape introducer stripped from primary",
-			primary:  "Jane\x1b[31m",
+			name:     "newline and tab collapsed in primary",
+			primary:  "Jane\n\tAdmin",
 			username: "jgarcia",
-			want:     "Jane[31m (jgarcia)",
+			want:     "Jane Admin (jgarcia)",
 		},
 		{
-			name:     "newline stripped from primary",
-			primary:  "Jane\nAdmin",
-			username: "jgarcia",
-			want:     "JaneAdmin (jgarcia)",
-		},
-		{
-			name:      "carriage return stripped from secondary",
-			secondary: "real\rfake",
+			name:      "newline and tab collapsed in secondary",
+			secondary: "team\n\tlead",
 			username:  "jgarcia",
-			want:      "jgarcia <realfake>",
-		},
-		{
-			name:     "backspace stripped from username",
-			username: "real\bX",
-			want:     "realX",
-		},
-		{
-			name:     "NUL stripped from username",
-			username: "a\x00b",
-			want:     "ab",
-		},
-		{
-			name:     "tab stripped from primary",
-			primary:  "Jane\tGarcia",
-			username: "jgarcia",
-			want:     "JaneGarcia (jgarcia)",
+			want:      "jgarcia <team lead>",
 		},
 		{
 			name:     "surrounding whitespace trimmed",
@@ -330,13 +306,6 @@ func TestFormatUserDisplay_Sanitization(t *testing.T) {
 			username: "jgarcia",
 			want:     "jgarcia",
 		},
-		{
-			name:      "primary of only control bytes treated as absent",
-			primary:   "\x1b\x00",
-			secondary: "team",
-			username:  "jgarcia",
-			want:      "jgarcia <team>",
-		},
 	}
 
 	for _, tt := range tests {
@@ -346,6 +315,51 @@ func TestFormatUserDisplay_Sanitization(t *testing.T) {
 			require.Equal(t, tt.want, got)
 			require.Equal(t, strings.TrimSpace(got), got,
 				"output must have no leading/trailing whitespace: %q", got)
+		})
+	}
+}
+
+func TestStripTerminalControlSequences(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "csi",
+			in:   "safe\x1b[31mred\x1b[0m text",
+			want: "safered text",
+		},
+		{
+			name: "osc_bel",
+			in:   "safe\x1b]0;owned title\a text",
+			want: "safe text",
+		},
+		{
+			name: "osc_st",
+			in:   "safe\x1b]8;;https://example.com\x1b\\link\x1b]8;;\x1b\\ text",
+			want: "safelink text",
+		},
+		{
+			name: "unterminated_osc",
+			in:   "safe\x1b]0;owned title",
+			want: "safe",
+		},
+		{
+			name: "raw_c1_csi",
+			in:   "safe\x9b31mred text",
+			want: "safered text",
+		},
+		{
+			name: "utf8_preserved",
+			in:   "safe caf\xc3\xa9\n\ttext",
+			want: "safe caf\xc3\xa9\n\ttext",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := StripTerminalControlSequences(tt.in); got != tt.want {
+				t.Fatalf("StripTerminalControlSequences(%q) = %q, want %q", tt.in, got, tt.want)
+			}
 		})
 	}
 }

--- a/tool/common/common_test.go
+++ b/tool/common/common_test.go
@@ -23,6 +23,7 @@ import (
 	"context"
 	"fmt"
 	"maps"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -254,4 +255,97 @@ func TestFormatResourceAccessIDs(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, "[\"/cluster/kube:ns:pods/my-kube-cluster/default/nginx\"]", out)
 	})
+}
+
+// The four output forms with realistic values.
+func TestFormatUserDisplay_CanonicalForms(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(t, "Jane Garcia <jane.garcia@example.com> (123456)",
+		FormatUserDisplay("Jane Garcia", "jane.garcia@example.com", "123456"))
+	require.Equal(t, "Jane Garcia (123456)",
+		FormatUserDisplay("Jane Garcia", "", "123456"))
+	require.Equal(t, "123456 <jane.garcia@example.com>",
+		FormatUserDisplay("", "jane.garcia@example.com", "123456"))
+	require.Equal(t, "123456",
+		FormatUserDisplay("", "", "123456"))
+}
+
+// Control-byte stripping (one per class) and whitespace handling.
+func TestFormatUserDisplay_Sanitization(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		primary   string
+		secondary string
+		username  string
+		want      string
+	}{
+		{
+			// Only the ESC byte is a control rune, so "[31m" stays — but
+			// without the ESC the terminal won't read it as a color escape.
+			name:     "ansi CSI escape introducer stripped from primary",
+			primary:  "Jane\x1b[31m",
+			username: "jgarcia",
+			want:     "Jane[31m (jgarcia)",
+		},
+		{
+			name:     "newline stripped from primary",
+			primary:  "Jane\nAdmin",
+			username: "jgarcia",
+			want:     "JaneAdmin (jgarcia)",
+		},
+		{
+			name:      "carriage return stripped from secondary",
+			secondary: "real\rfake",
+			username:  "jgarcia",
+			want:      "jgarcia <realfake>",
+		},
+		{
+			name:     "backspace stripped from username",
+			username: "real\bX",
+			want:     "realX",
+		},
+		{
+			name:     "NUL stripped from username",
+			username: "a\x00b",
+			want:     "ab",
+		},
+		{
+			name:     "tab stripped from primary",
+			primary:  "Jane\tGarcia",
+			username: "jgarcia",
+			want:     "JaneGarcia (jgarcia)",
+		},
+		{
+			name:     "surrounding whitespace trimmed",
+			primary:  "  Jane  ",
+			username: "  jgarcia  ",
+			want:     "Jane (jgarcia)",
+		},
+		{
+			name:     "whitespace-only primary treated as absent",
+			primary:  "   ",
+			username: "jgarcia",
+			want:     "jgarcia",
+		},
+		{
+			name:      "primary of only control bytes treated as absent",
+			primary:   "\x1b\x00",
+			secondary: "team",
+			username:  "jgarcia",
+			want:      "jgarcia <team>",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := FormatUserDisplay(tt.primary, tt.secondary, tt.username)
+			require.Equal(t, tt.want, got)
+			require.Equal(t, strings.TrimSpace(got), got,
+				"output must have no leading/trailing whitespace: %q", got)
+		})
+	}
 }

--- a/tool/common/common_test.go
+++ b/tool/common/common_test.go
@@ -261,9 +261,9 @@ func TestFormatResourceAccessIDs(t *testing.T) {
 func TestFormatUserDisplay_CanonicalForms(t *testing.T) {
 	t.Parallel()
 
-	require.Equal(t, "Jane Garcia <jane.garcia@example.com> (123456)",
+	require.Equal(t, "123456 (Jane Garcia) <jane.garcia@example.com>",
 		FormatUserDisplay("Jane Garcia", "jane.garcia@example.com", "123456"))
-	require.Equal(t, "Jane Garcia (123456)",
+	require.Equal(t, "123456 (Jane Garcia)",
 		FormatUserDisplay("Jane Garcia", "", "123456"))
 	require.Equal(t, "123456 <jane.garcia@example.com>",
 		FormatUserDisplay("", "jane.garcia@example.com", "123456"))
@@ -286,7 +286,7 @@ func TestFormatUserDisplay_Sanitization(t *testing.T) {
 			name:     "newline and tab collapsed in primary",
 			primary:  "Jane\n\tAdmin",
 			username: "jgarcia",
-			want:     "Jane Admin (jgarcia)",
+			want:     "jgarcia (Jane Admin)",
 		},
 		{
 			name:      "newline and tab collapsed in secondary",
@@ -298,7 +298,7 @@ func TestFormatUserDisplay_Sanitization(t *testing.T) {
 			name:     "surrounding whitespace trimmed",
 			primary:  "  Jane  ",
 			username: "  jgarcia  ",
-			want:     "Jane (jgarcia)",
+			want:     "jgarcia (Jane)",
 		},
 		{
 			name:     "whitespace-only primary treated as absent",

--- a/tool/common/common_test.go
+++ b/tool/common/common_test.go
@@ -257,7 +257,7 @@ func TestFormatResourceAccessIDs(t *testing.T) {
 	})
 }
 
-// The four output forms with realistic values.
+// The output forms, plus the all-empty input.
 func TestFormatUserDisplay_CanonicalForms(t *testing.T) {
 	t.Parallel()
 
@@ -269,6 +269,7 @@ func TestFormatUserDisplay_CanonicalForms(t *testing.T) {
 		FormatUserDisplay("", "jane.garcia@example.com", "123456"))
 	require.Equal(t, "123456",
 		FormatUserDisplay("", "", "123456"))
+	require.Empty(t, FormatUserDisplay("", "", ""))
 }
 
 // Whitespace handling after terminal controls are stripped.

--- a/tool/tctl/common/recordings/detail.go
+++ b/tool/tctl/common/recordings/detail.go
@@ -23,13 +23,12 @@ import (
 	"sort"
 	"strings"
 	"time"
-	"unicode"
-	"unicode/utf8"
 
 	"github.com/charmbracelet/lipgloss"
 
 	sessionsearchv1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/sessionsearch/v1"
 	summarizerv1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/summarizer/v1"
+	toolcommon "github.com/gravitational/teleport/tool/common"
 )
 
 const fieldLabelWidth = 20
@@ -39,120 +38,7 @@ const fieldLabelWidth = 20
 // external data (session metadata, resource names, command summaries, etc.) to
 // prevent terminal injection.
 func sanitize(s string) string {
-	var b strings.Builder
-	b.Grow(len(s))
-
-	for i := 0; i < len(s); {
-		r, size := utf8.DecodeRuneInString(s[i:])
-		if r == utf8.RuneError && size == 1 {
-			c := s[i]
-			switch {
-			case c == '\x1b':
-				i = consumeEscapeSequence(s, i+1)
-			case c == '\x90' || c == '\x98' || c == '\x9d' || c == '\x9e' || c == '\x9f':
-				i = consumeStringControl(s, i+1)
-			case c == '\x9b':
-				i = consumeCSISequence(s, i+1)
-			case c == '\n' || c == '\t':
-				b.WriteByte(c)
-				i++
-			case c < ' ' || c == '\x7f' || (c >= '\x80' && c <= '\x9f'):
-				i++
-			default:
-				b.WriteByte(c)
-				i++
-			}
-			continue
-		}
-
-		switch r {
-		case '\x1b':
-			i = consumeEscapeSequence(s, i+size)
-			continue
-		case '\u0090', '\u0098', '\u009d', '\u009e', '\u009f':
-			i = consumeStringControl(s, i+size)
-			continue
-		case '\u009b':
-			i = consumeCSISequence(s, i+size)
-			continue
-		}
-
-		if unicode.IsControl(r) && r != '\n' && r != '\t' {
-			i += size
-			continue
-		}
-
-		b.WriteString(s[i : i+size])
-		i += size
-	}
-
-	return b.String()
-}
-
-func consumeEscapeSequence(s string, i int) int {
-	if i >= len(s) {
-		return i
-	}
-
-	switch s[i] {
-	case '[':
-		return consumeCSISequence(s, i+1)
-	case ']', 'P', 'X', '^', '_':
-		return consumeStringControl(s, i+1)
-	case '(', ')', '*', '+', '-', '.', '/', '#':
-		if i+1 < len(s) {
-			return i + 2
-		}
-		return i + 1
-	}
-
-	for i < len(s) {
-		c := s[i]
-		i++
-		if c >= '\x30' && c <= '\x7e' {
-			return i
-		}
-		if c < ' ' || c > '\x7e' {
-			return i
-		}
-	}
-	return i
-}
-
-func consumeCSISequence(s string, i int) int {
-	for i < len(s) {
-		c := s[i]
-		i++
-		if c >= '\x40' && c <= '\x7e' {
-			return i
-		}
-	}
-	return i
-}
-
-func consumeStringControl(s string, i int) int {
-	for i < len(s) {
-		if s[i] == '\a' {
-			return i + 1
-		}
-		if s[i] == '\x1b' && i+1 < len(s) && s[i+1] == '\\' {
-			return i + 2
-		}
-
-		r, size := utf8.DecodeRuneInString(s[i:])
-		if r == utf8.RuneError && size == 1 {
-			if s[i] == '\x9c' {
-				return i + 1
-			}
-			i++
-			continue
-		}
-		if r == '\u009c' {
-			return i + size
-		}
-		i += size
-	}
-	return i
+	return toolcommon.StripTerminalControlSequences(s)
 }
 
 // renderDetail builds the scrollable content string for the right-side detail

--- a/tool/tctl/common/recordings/sanitize_test.go
+++ b/tool/tctl/common/recordings/sanitize_test.go
@@ -25,51 +25,6 @@ import (
 	summarizerv1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/summarizer/v1"
 )
 
-func TestSanitizeRemovesTerminalControlSequences(t *testing.T) {
-	for _, tt := range []struct {
-		name string
-		in   string
-		want string
-	}{
-		{
-			name: "csi",
-			in:   "safe\x1b[31mred\x1b[0m text",
-			want: "safered text",
-		},
-		{
-			name: "osc_bel",
-			in:   "safe\x1b]0;owned title\a text",
-			want: "safe text",
-		},
-		{
-			name: "osc_st",
-			in:   "safe\x1b]8;;https://example.com\x1b\\link\x1b]8;;\x1b\\ text",
-			want: "safelink text",
-		},
-		{
-			name: "unterminated_osc",
-			in:   "safe\x1b]0;owned title",
-			want: "safe",
-		},
-		{
-			name: "raw_c1_csi",
-			in:   "safe\x9b31mred text",
-			want: "safered text",
-		},
-		{
-			name: "utf8_preserved",
-			in:   "safe caf\xc3\xa9\n\ttext",
-			want: "safe caf\xc3\xa9\n\ttext",
-		},
-	} {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := sanitize(tt.in); got != tt.want {
-				t.Fatalf("sanitize(%q) = %q, want %q", tt.in, got, tt.want)
-			}
-		})
-	}
-}
-
 func TestRenderTimelineSanitizesTerminalControlSequences(t *testing.T) {
 	timeline := renderTimeline(&summarizerv1pb.EnhancedSummary{
 		NotableCommandIndexes: []int32{0},


### PR DESCRIPTION
This PR contributes to [#66993](https://github.com/gravitational/teleport/issues/66993) (RFD 302 — User Display Names) by adding a shared CLI formatter for rendering user identities. It mirrors the Web UI `UserDisplayName` component ([#67147](https://github.com/gravitational/teleport/pull/67147)) so that CLI surfaces can present display names consistently. No CLI commands consume the helper yet. This is a reusable building block on its own.



