### PR TITLE
Clean up desktop alerts

### DIFF
--- a/web/packages/shared/components/DesktopSession/AlertDropdown.tsx
+++ b/web/packages/shared/components/DesktopSession/AlertDropdown.tsx
@@ -51,16 +51,13 @@ export function AlertDropdown(
   if (alerts.length === 0 && showDropdown) setShowDropdown(false);
 
   // Close the dropdown if it's open and the user clicks outside of it
-  useClickOutside(ref, () => {
-    setShowDropdown(prevState => {
-      if (prevState) {
-        return false;
-      }
-    });
-  });
+  useClickOutside(ref, () => setShowDropdown(false));
 
   return (
-    <>
+    // `display: contents` keeps this wrapper out of the layout while still
+    // giving useClickOutside a node that contains both the toggle button and
+    // the dropdown, so clicks on either are treated as "inside".
+    <div ref={ref} style={{ display: 'contents' }}>
       <HoverTooltip
         tipContent={`${alerts.length} ${pluralize(alerts.length, 'alert')}`}
         placement="top"
@@ -84,9 +81,16 @@ export function AlertDropdown(
           }}
           {...boxProps}
         >
-          <Flex alignItems="center" justifyContent="space-between">
+          <Flex
+            alignItems="center"
+            justifyContent="space-between"
+            pb={2}
+            mb={1}
+            borderBottom={1}
+            borderColor="spotBackground.1"
+          >
             <H3 px={3} style={{ overflow: 'visible' }}>
-              {alerts.length} {alerts.length > 1 ? 'Alerts' : 'Alert'}
+              {alerts.length} {pluralize(alerts.length, 'Alert')}
             </H3>
             <ButtonIcon size={1} ml={1} mr={2} onClick={toggleDropdown}>
               <Cross size="medium" />
@@ -104,7 +108,7 @@ export function AlertDropdown(
           </StyledOverflow>
         </StyledCard>
       )}
-    </>
+    </div>
   );
 }
 
@@ -112,10 +116,12 @@ const StyledButton = styled(Button)`
   color: ${({ theme }) => theme.colors.light};
   min-height: 0;
   height: ${({ theme }) => theme.fontSizes[7] + 'px'};
-  background-color: ${props => props.theme.colors.warning.main};
+  background-color: ${props =>
+    props.theme.colors.interactive.solid.alert.default};
   &:hover,
   &:focus {
-    background-color: ${props => props.theme.colors.warning.hover};
+    background-color: ${props =>
+      props.theme.colors.interactive.solid.alert.hover};
   }
 `;
 
@@ -127,13 +133,13 @@ const StyledCard = styled(Card).attrs(props => ({
   display: flex;
   flex-direction: column;
   position: absolute;
+  /* 320px notification width + horizontal card padding. */
+  width: 336px;
   background-color: ${({ theme }) => theme.colors.levels.elevated};
 `;
 
 const StyledNotification = styled(ToastNotification)`
-  background: ${({ theme }) => theme.colors.spotBackground[0]};
-  ${({ theme }) =>
-    theme.type === 'light' && `border: 1px solid ${theme.colors.text.muted};`}
+  background: ${({ theme }) => theme.colors.interactive.tonal.neutral[0]};
   box-shadow: none;
 `;
 

--- a/web/packages/shared/components/DesktopSession/DesktopSession.tsx
+++ b/web/packages/shared/components/DesktopSession/DesktopSession.tsx
@@ -205,7 +205,7 @@ export function DesktopSession({
   const addWarning = useCallback(
     (warning: string) => {
       addAlert({
-        content: warning,
+        content: { title: 'Warning', description: warning },
         severity: 'warn',
       });
     },
@@ -219,7 +219,7 @@ export function DesktopSession({
     useCallback(
       info => {
         addAlert({
-          content: info,
+          content: { title: 'Notice', description: info },
           severity: 'info',
         });
       },

--- a/web/packages/shared/hooks/useClickOutside.ts
+++ b/web/packages/shared/hooks/useClickOutside.ts
@@ -16,10 +16,10 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { MutableRefObject, useEffect } from 'react';
+import { RefObject, useEffect } from 'react';
 
 function useClickOutside(
-  ref: MutableRefObject<Node>,
+  ref: RefObject<Node>,
   handler: (e: MouseEvent) => void
 ) {
   useEffect(() => {


### PR DESCRIPTION
Fix some special casing for the light theme that caused the alerts to look different (with a full border).

Fix the ability to dismiss the alerts by clicking anywhere outside. (We were never setting the ref correctly so this functionality wasn't working).

Improve the styling with some padding, a divider, and consistent width.

Lastly, avoid specifying the entire alert content as the title, which renders in bold. Large amount of bold text are difficult to read.

Before:
<img width="359" height="292" alt="image" src="https://github.com/user-attachments/assets/8ab80af5-55d7-4c9f-ba6d-dc00379daf4d" />

After:
<img width="418" height="313" alt="image" src="https://github.com/user-attachments/assets/cd6a07ee-75f7-47f9-8b1c-ec85ab259148" />
