### PR TITLE
[v18] Allow concurrent connections to forwarded SSH agents

### DIFF
--- a/lib/sshagent/client.go
+++ b/lib/sshagent/client.go
@@ -103,6 +103,8 @@ const channelType = "auth-agent@openssh.com"
 // signature requests. This issue may be resolved directly by the
 // [agent] library once https://github.com/golang/go/issues/61383
 // is addressed.
+//
+// The agent getter must be safe to call concurrently.
 func ServeChannelRequests(ctx context.Context, client *ssh.Client, getForwardAgent ClientGetter) error {
 	channels := client.HandleChannelOpen(channelType)
 	if channels == nil {
@@ -111,23 +113,24 @@ func ServeChannelRequests(ctx context.Context, client *ssh.Client, getForwardAge
 
 	go func() {
 		for ch := range channels {
-			channel, reqs, err := ch.Accept()
-			if err != nil {
-				continue
-			}
-
-			go ssh.DiscardRequests(reqs)
-
-			forwardAgent, err := getForwardAgent()
-			if err != nil {
-				_ = channel.Close()
-				slog.ErrorContext(ctx, "failed to connect to forwarded agent", "err", err)
-				continue
-			}
-
 			go func() {
-				defer channel.Close()
+				forwardAgent, err := getForwardAgent()
+				if err != nil {
+					slog.ErrorContext(ctx, "failed to connect to forwarded agent", "err", err)
+					_ = ch.Reject(ssh.ConnectionFailed, ssh.ConnectionFailed.String())
+					return
+				}
 				defer forwardAgent.Close()
+
+				channel, reqs, err := ch.Accept()
+				if err != nil {
+					return
+				}
+				defer channel.Close()
+
+				go ssh.DiscardRequests(reqs)
+				go io.Copy(io.Discard, channel.Stderr())
+
 				if err := agent.ServeAgent(forwardAgent, channel); err != nil && !errors.Is(err, io.EOF) {
 					slog.ErrorContext(ctx, "unexpected error serving forwarded agent", "err", err)
 				}

--- a/lib/sshagent/client_test.go
+++ b/lib/sshagent/client_test.go
@@ -18,15 +18,23 @@ package sshagent_test
 
 import (
 	"context"
+	"crypto/ed25519"
+	"crypto/rand"
+	"errors"
 	"io"
 	"net"
 	"path/filepath"
 	"sync"
+	"sync/atomic"
 	"testing"
+	"testing/synctest"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/crypto/ssh"
 	"golang.org/x/crypto/ssh/agent"
+	"golang.org/x/sync/errgroup"
+	"google.golang.org/grpc/test/bufconn"
 
 	"github.com/gravitational/teleport/lib/sshagent"
 	"github.com/gravitational/teleport/lib/utils"
@@ -130,4 +138,115 @@ func TestSSHAgentClient(t *testing.T) {
 	require.NoError(t, err)
 	_, err = agentClient.List()
 	require.Error(t, err)
+}
+
+func TestConcurrentServeChannelRequests(t *testing.T) {
+	synctest.Test(t, synctestConcurrentServeChannelRequests)
+}
+func synctestConcurrentServeChannelRequests(t *testing.T) {
+	cfg := &ssh.ServerConfig{
+		NoClientAuth: true,
+	}
+	_, k, err := ed25519.GenerateKey(rand.Reader)
+	require.NoError(t, err)
+	signer, err := ssh.NewSignerFromSigner(k)
+	require.NoError(t, err)
+	cfg.AddHostKey(signer)
+
+	c, s, err := bufconnPipe()
+	require.NoError(t, err)
+	defer c.Close()
+	defer s.Close()
+
+	const concurrentRequests = 5
+
+	var waiting atomic.Int32
+	barrier := make(chan struct{})
+	clientReady := make(chan struct{})
+
+	go func() {
+		defer s.Close()
+		conn, newChC, reqC, err := ssh.NewServerConn(s, cfg)
+		if !assert.NoError(t, err) {
+			return
+		}
+		go func() {
+			for newCh := range newChC {
+				_ = newCh.Reject(ssh.UnknownChannelType, ssh.UnknownChannelType.String())
+			}
+		}()
+		go ssh.DiscardRequests(reqC)
+
+		<-clientReady
+		for range concurrentRequests {
+			go func() {
+				ch, reqC, err := conn.OpenChannel("auth-agent@openssh.com", nil)
+				if !assert.Error(t, err) {
+					defer ch.Close()
+					go ssh.DiscardRequests(reqC)
+				}
+				if oc := *new(*ssh.OpenChannelError); assert.ErrorAs(t, err, &oc) {
+					assert.Equal(t, ssh.ConnectionFailed, oc.Reason)
+				}
+			}()
+		}
+		_ = conn.Wait()
+	}()
+
+	go func() {
+		defer c.Close()
+		conn, newChC, reqC, err := ssh.NewClientConn(c, "localhost:22", &ssh.ClientConfig{
+			User:            "u",
+			HostKeyCallback: ssh.InsecureIgnoreHostKey(),
+		})
+		if !assert.NoError(t, err) {
+			return
+		}
+		clt := ssh.NewClient(conn, newChC, reqC)
+		defer clt.Close()
+		err = sshagent.ServeChannelRequests(t.Context(), clt, func() (sshagent.Client, error) {
+			waiting.Add(1)
+			<-barrier
+			return nil, errors.New("nope")
+		})
+		if !assert.NoError(t, err) {
+			return
+		}
+		_ = conn.Wait()
+	}()
+
+	synctest.Wait()
+	close(clientReady)
+	synctest.Wait()
+	require.EqualValues(t, concurrentRequests, waiting.Load())
+	close(barrier)
+	synctest.Wait()
+}
+
+func bufconnPipe() (net.Conn, net.Conn, error) {
+	l := bufconn.Listen(16384)
+	defer l.Close()
+	var eg errgroup.Group
+	var c1, c2 net.Conn
+
+	eg.Go(func() error {
+		c, err := l.Dial()
+		c1 = c
+		return err
+	})
+	eg.Go(func() error {
+		c, err := l.Accept()
+		c2 = c
+		return err
+	})
+	if err := eg.Wait(); err != nil {
+		if c1 != nil {
+			_ = c1.Close()
+		}
+		if c2 != nil {
+			_ = c2.Close()
+		}
+		return nil, nil, err
+	}
+	return c1, c2, nil
 }

--- a/lib/sshagent/client_test.go
+++ b/lib/sshagent/client_test.go
@@ -195,6 +195,7 @@ func synctestConcurrentServeChannelRequests(t *testing.T) {
 
 	go func() {
 		defer c.Close()
+		//nolint:forbidigo // this client is not speaking to a teleport server
 		conn, newChC, reqC, err := ssh.NewClientConn(c, "localhost:22", &ssh.ClientConfig{
 			User:            "u",
 			HostKeyCallback: ssh.InsecureIgnoreHostKey(),
@@ -202,6 +203,7 @@ func synctestConcurrentServeChannelRequests(t *testing.T) {
 		if !assert.NoError(t, err) {
 			return
 		}
+		//nolint:forbidigo // this client is not speaking to a teleport server
 		clt := ssh.NewClient(conn, newChC, reqC)
 		defer clt.Close()
 		err = sshagent.ServeChannelRequests(t.Context(), clt, func() (sshagent.Client, error) {

--- a/lib/sshagent/server.go
+++ b/lib/sshagent/server.go
@@ -44,7 +44,8 @@ type Server struct {
 	Dir      string
 }
 
-// NewServer returns a new [Server].
+// NewServer returns a new [Server]. The agent getter must be safe to call
+// concurrently.
 func NewServer(agentClient ClientGetter) *Server {
 	return &Server{getAgent: agentClient}
 }
@@ -81,46 +82,35 @@ func (a *Server) Serve() error {
 	}
 
 	ctx := context.Background()
-	var tempDelay time.Duration // how long to sleep on accept failure
+	var tempDelay time.Duration // how long to sleep on temporary accept failure
 	for {
 		conn, err := a.listener.Accept()
 		if err != nil {
-			var neterr net.Error
-			if !errors.As(err, &neterr) {
-				return trace.Wrap(err, "unknown error")
+			// same logic as net/http.Server.Serve
+			if t := *new(interface{ Temporary() bool }); errors.As(err, &t) && t.Temporary() {
+				tempDelay = min(max(5*time.Millisecond, tempDelay*2), time.Second)
+				slog.ErrorContext(ctx, "Got temporary accept error, backing off", "delay_time", tempDelay.String(), "error", err)
+				time.Sleep(tempDelay)
+				continue
 			}
-			if utils.IsUseOfClosedNetworkError(neterr) {
+			if utils.IsUseOfClosedNetworkError(err) {
 				return nil
 			}
-			if !neterr.Timeout() {
-				slog.ErrorContext(ctx, "Got non-timeout error", "error", err)
-				return trace.Wrap(err)
-			}
-			if tempDelay == 0 {
-				tempDelay = 5 * time.Millisecond
-			} else {
-				tempDelay *= 2
-			}
-			if max := 1 * time.Second; tempDelay > max {
-				tempDelay = max
-			}
-			slog.ErrorContext(ctx, "Got timeout error - backing off", "delay_time", tempDelay, "error", err)
-			time.Sleep(tempDelay)
-			continue
+			return trace.Wrap(err)
 		}
 		tempDelay = 0
 
-		// get an agent instance for serving this conn
-		instance, err := a.getAgent()
-		if err != nil {
-			slog.ErrorContext(ctx, "Failed to get agent", "error", err)
-			return trace.Wrap(err)
-		}
-
-		// serve agent protocol against conn in a
-		// separate goroutine.
 		go func() {
+			defer conn.Close()
+
+			// get an agent instance for serving this conn
+			instance, err := a.getAgent()
+			if err != nil {
+				slog.ErrorContext(ctx, "Failed to get agent", "error", err)
+				return
+			}
 			defer instance.Close()
+
 			if err := agent.ServeAgent(instance, conn); err != nil && !errors.Is(err, io.EOF) {
 				slog.ErrorContext(ctx, "Serving agent terminated unexpectedly", "error", err)
 			}

--- a/lib/sshagent/server_test.go
+++ b/lib/sshagent/server_test.go
@@ -1,0 +1,75 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package sshagent
+
+import (
+	"errors"
+	"io"
+	"net"
+	"sync/atomic"
+	"testing"
+	"testing/synctest"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/test/bufconn"
+)
+
+func TestConcurrentServerAccept(t *testing.T) {
+	synctest.Test(t, synctestConcurrentServerAccept)
+}
+func synctestConcurrentServerAccept(t *testing.T) {
+	l := bufconn.Listen(16384)
+	defer l.Close()
+
+	const concurrentRequests = 5
+
+	var waiting atomic.Int32
+	barrier := make(chan struct{})
+
+	s := &Server{
+		getAgent: func() (Client, error) {
+			waiting.Add(1)
+			<-barrier
+			return nil, errors.New("nope")
+		},
+		listener: l,
+	}
+	go s.Serve()
+	defer s.Close()
+
+	conns := make([]net.Conn, 0, concurrentRequests)
+	defer func() {
+		for _, c := range conns {
+			_ = c.Close()
+		}
+	}()
+
+	for range concurrentRequests {
+		c, err := l.Dial()
+		require.NoError(t, err)
+		conns = append(conns, c)
+	}
+
+	synctest.Wait()
+	require.EqualValues(t, concurrentRequests, waiting.Load())
+	close(barrier)
+	for _, c := range conns {
+		n, err := c.Read(make([]byte, 1))
+		require.Zero(t, n)
+		require.ErrorIs(t, err, io.EOF)
+	}
+}

--- a/lib/sshutils/ctx.go
+++ b/lib/sshutils/ctx.go
@@ -149,6 +149,7 @@ func (c *ConnectionContext) StartAgentChannel() (*AgentChannel, error) {
 		return nil, trace.Wrap(err)
 	}
 	go ssh.DiscardRequests(reqC)
+	go io.Copy(io.Discard, ch.Stderr())
 	return &AgentChannel{
 		ExtendedAgent: agent.NewClient(ch),
 		ch:            ch,


### PR DESCRIPTION
Backport #67116 to branch/v18

changelog: improved the latency of SSH agent forwarding used by multiple clients at once

## Manual Test Plan
### Test Environment

Cloud staging control plane, teleport agent and tsh with and without this PR.

### Test Cases
- [x] SSH agent forwarding works
- [x] When adding forced delays in tsh, multiple clients running in parallel (`ssh-add -l`, for example) are not blocked waiting for the delay sequentially