### PR TITLE
docs/rdp: Specifically recommend 32-bit color depth

### DIFF
--- a/docs/pages/enroll-resources/desktop-access/active-directory.mdx
+++ b/docs/pages/enroll-resources/desktop-access/active-directory.mdx
@@ -433,7 +433,7 @@ the performance of remote desktop connections.
 
    ![Enable RemoteFX](../../../img/desktop-access/enable-remotefx-step-2.png)
 
-1. Again left-click **Remote Session Environment** in the left pane, and from the items in the right pane, right-click **Limit maximum color depth**, select **Edit**, select **Enabled**, then click **OK**.
+1. Again left-click **Remote Session Environment** in the left pane, and from the items in the right pane, right-click **Limit maximum color depth**, select **Edit**, select **Enabled**, and under **Color depth** select **32-bit**, then click **OK**.
 
    ![Enable RemoteFX](../../../img/desktop-access/enable-remotefx-step-3.png)
 


### PR DESCRIPTION
In a recent support ticket, the customer was experiencing the Windows Desktop service failing to connect to the remote host with the following error:

```
Teleport requires the RemoteFX codec for Windows desktop sessions, but the Windows host sent a bitmap update with unknown compression instead.
```

On investigation, the remote host was correctly advertising support for RemoteFX, but falling back to legacy interleaved bitmaps because the "Limit maximum color depth" policy was capping color depth at 24-bit, implicitly disabling RemoteFX. I assume this was caused by another GPO or environmental difference.

This PR changes the documentation to explicitly encourage users to set the color depth to 32-bit, rather than assume it is always the default.
