### PR TITLE
Skip signup e2e test temporarily, remove e2e PR comment

### DIFF
--- a/.github/workflows/e2e-tests-base.yaml
+++ b/.github/workflows/e2e-tests-base.yaml
@@ -274,15 +274,6 @@ jobs:
         env:
           E2E_DIR: ${{ github.workspace }}/${{ inputs.e2e-dir }}
 
-      - name: Upload PR comment
-        if: ${{ !cancelled() && github.event_name == 'pull_request' }}
-        uses: actions/upload-artifact@v7
-        with:
-          name: pr-comment
-          path: ${{ inputs.e2e-dir }}/test-results/pr-comment.md
-          if-no-files-found: ignore
-          retention-days: 1
-
       - name: Upload Playwright report
         if: ${{ !cancelled() }}
         uses: actions/upload-artifact@v7

--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -75,10 +75,3 @@ jobs:
       build-command: make e2e-binaries
     permissions:
       contents: read
-
-  update-pr-comment:
-    needs: e2e
-    if: ${{ always() && needs.e2e.result != 'skipped' && github.event_name == 'pull_request' }}
-    uses: ./.github/workflows/e2e-pr-comment.yaml
-    permissions:
-      pull-requests: write

--- a/e2e/runner/github.go
+++ b/e2e/runner/github.go
@@ -24,7 +24,6 @@ import (
 	"io"
 	"log/slog"
 	"os"
-	"path/filepath"
 	"slices"
 	"strings"
 )
@@ -59,10 +58,6 @@ func writeGitHubReport(resultsPath string) error {
 
 	if err := writeJobSummary(report, mergedFailures, mergedFlaky); err != nil {
 		slog.Warn("could not write job summary", "error", err)
-	}
-
-	if err := writePRCommentFile(resultsPath, report, mergedFailures, mergedFlaky); err != nil {
-		slog.Warn("could not write PR comment file", "error", err)
 	}
 
 	return nil
@@ -255,37 +250,6 @@ func renderMarkdownReport(w io.Writer, report pwReport, failures, flaky []merged
 		fmt.Fprint(w, "---\n\n")
 		fmt.Fprintf(w, "##### View full report\n```\n./%s\n```\n", ciReportCmd(pr))
 	}
-}
-
-// writePRCommentFile writes the PR comment body to a file next to the results
-// JSON so that a trusted workflow step can post it via `gh` without passing
-// a write-scoped token to this (PR-built) binary.
-func writePRCommentFile(resultsPath string, report pwReport, failures, flaky []mergedFailure) error {
-	commentPath := filepath.Join(filepath.Dir(resultsPath), "pr-comment.md")
-
-	hasIssues := len(failures) > 0 || len(flaky) > 0 || len(report.Errors) > 0
-	if !hasIssues {
-		// Write an empty file to signal that the comment should be deleted.
-		if err := os.WriteFile(commentPath, nil, 0o644); err != nil {
-			return fmt.Errorf("writing empty PR comment file: %w", err)
-		}
-
-		slog.Info("wrote empty PR comment file (no issues)", "path", commentPath)
-
-		return nil
-	}
-
-	var body strings.Builder
-	body.WriteString(commentMarker + "\n")
-	renderMarkdownReport(&body, report, failures, flaky)
-
-	if err := os.WriteFile(commentPath, []byte(body.String()), 0o644); err != nil {
-		return fmt.Errorf("writing PR comment file: %w", err)
-	}
-
-	slog.Info("wrote PR comment file", "path", commentPath)
-
-	return nil
 }
 
 func escapeProp(s string) string {

--- a/e2e/tests/web/unauthenticated/signup.spec.ts
+++ b/e2e/tests/web/unauthenticated/signup.spec.ts
@@ -25,7 +25,8 @@ function username(testInfo: TestInfo) {
   return `testuser-${testInfo.workerIndex}`;
 }
 
-test('verify that a user can sign up with webauthn and login', async ({
+// TODO(ryan): re-enable this test once Firefox flakiness is resolved.
+test.skip('verify that a user can sign up with webauthn and login', async ({
   page,
 }, testInfo) => {
   // Signing up auto-logs-in and we then log straight back in; that burst can


### PR DESCRIPTION
Skips the signup test until the flakiness in firefox is figured out

Removes the PR results from being commented on a PR