### PR TITLE
fix tsh login checking for updates when profile is expired

### DIFF
--- a/integration/autoupdate/tools/updater_tsh_test.go
+++ b/integration/autoupdate/tools/updater_tsh_test.go
@@ -264,6 +264,47 @@ func TestLoginWithDisabledUpdateForcedByEnv(t *testing.T) {
 	matchVersion(t, string(out), testVersions[0])
 }
 
+// TestLoginWithExpiredProfileUpdates verifies that login performs a managed update
+// when the current profile exists but its credentials are no longer usable.
+func TestLoginWithExpiredProfileUpdates(t *testing.T) {
+	ctx := context.Background()
+
+	rootServer, homeDir := bootstrapTestServer(t)
+	setupManagedUpdates(t, rootServer.GetAuthServer(), autoupdate.ToolsUpdateModeDisabled, testVersions[1])
+
+	proxyAddr, err := rootServer.ProxyWebAddr()
+	require.NoError(t, err)
+
+	cmd := exec.CommandContext(ctx, tshPath,
+		"login", "--proxy", proxyAddr.String(), "--insecure", "--user", "alice", "--auth", constants.LocalConnector)
+	cmd.Env = os.Environ()
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	require.NoError(t, cmd.Run())
+
+	// Remove the stored key material while leaving the profile in place so the
+	// next login sees an existing-but-expired profile.
+	require.NoError(t, client.NewFSKeyStore(homeDir).DeleteKeyRing(client.KeyRingIndex{
+		ProxyHost:   proxyAddr.Host(),
+		Username:    "alice",
+		ClusterName: "root",
+	}))
+
+	setupManagedUpdates(t, rootServer.GetAuthServer(), autoupdate.ToolsUpdateModeEnabled, testVersions[1])
+
+	cmd = exec.CommandContext(ctx, tshPath,
+		"login", "--proxy", proxyAddr.String(), "--insecure", "--user", "alice", "--auth", constants.LocalConnector)
+	cmd.Env = os.Environ()
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	require.NoError(t, cmd.Run())
+
+	cmd = exec.CommandContext(ctx, tshPath, "version")
+	out, err := cmd.Output()
+	require.NoError(t, err)
+	matchVersion(t, string(out), testVersions[1])
+}
+
 // TestMigratedUpdateNotReExec verifies that the version is migrated without errors,
 // and that the previous version of the updated tools is ignored.
 func TestMigratedUpdateNotReExec(t *testing.T) {

--- a/integration/autoupdate/tools/updater_tsh_test.go
+++ b/integration/autoupdate/tools/updater_tsh_test.go
@@ -267,7 +267,7 @@ func TestLoginWithDisabledUpdateForcedByEnv(t *testing.T) {
 // TestLoginWithExpiredProfileUpdates verifies that login performs a managed update
 // when the current profile exists but its credentials are no longer usable.
 func TestLoginWithExpiredProfileUpdates(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 
 	rootServer, homeDir := bootstrapTestServer(t)
 	setupManagedUpdates(t, rootServer.GetAuthServer(), autoupdate.ToolsUpdateModeDisabled, testVersions[1])

--- a/tool/tsh/common/tsh.go
+++ b/tool/tsh/common/tsh.go
@@ -1754,6 +1754,12 @@ func Run(ctx context.Context, args []string, opts ...CliOption) error {
 		)
 	}
 
+	if command == login.FullCommand() {
+		if err := maybeCheckLoginManagedUpdate(&cf, args); err != nil {
+			return trace.Wrap(err)
+		}
+	}
+
 	switch command {
 	case ver.FullCommand():
 		err = onVersion(&cf)
@@ -2409,14 +2415,6 @@ func onLogin(cf *CLIConf, reExecArgs ...string) (err error) {
 		}()
 	}
 
-	// The user is not logged in and has typed in `tsh --proxy=... login`, if
-	// the running binary needs to be updated, update and re-exec.
-	if profile == nil {
-		if err := autoupdatetools.CheckAndUpdateRemote(cf.Context, tc.WebProxyAddr, tc.InsecureSkipVerify, reExecArgs); err != nil {
-			return trace.Wrap(err)
-		}
-	}
-
 	// client is already logged in and profile is not expired and scope hasn't changed
 	if profile != nil && !profile.IsExpired(time.Now()) && !scopeChanged {
 		switch {
@@ -2715,6 +2713,26 @@ func onLogin(cf *CLIConf, reExecArgs ...string) (err error) {
 	}
 
 	return nil
+}
+
+// maybeCheckLoginManagedUpdate checks for updates if the current profile
+// does not exist or if the profile is expired.
+func maybeCheckLoginManagedUpdate(cf *CLIConf, reExecArgs []string) error {
+	profile, _, err := cf.FullProfileStatus()
+	if err != nil && !trace.IsNotFound(err) {
+		return trace.Wrap(err)
+	}
+
+	if profile != nil && !profile.IsExpired(time.Now()) {
+		return nil
+	}
+
+	tc, err := makeClient(cf)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	return trace.Wrap(autoupdatetools.CheckAndUpdateRemote(cf.Context, tc.WebProxyAddr, tc.InsecureSkipVerify, reExecArgs))
 }
 
 // onLogout deletes a "session certificate" from ~/.tsh for a given proxy

--- a/tool/tsh/common/tsh.go
+++ b/tool/tsh/common/tsh.go
@@ -2723,6 +2723,7 @@ func maybeCheckLoginManagedUpdate(cf *CLIConf, reExecArgs []string) error {
 		return trace.Wrap(err)
 	}
 
+	// NOTE: checking for updates for an active profile is already handled elsewhere
 	if profile != nil && !profile.IsExpired(time.Now()) {
 		return nil
 	}

--- a/tool/tsh/common/tsh.go
+++ b/tool/tsh/common/tsh.go
@@ -2718,6 +2718,14 @@ func onLogin(cf *CLIConf, reExecArgs ...string) (err error) {
 // maybeCheckLoginManagedUpdate checks for updates if the current profile
 // does not exist or if the profile is expired.
 func maybeCheckLoginManagedUpdate(cf *CLIConf, reExecArgs []string) error {
+	if cf.IdentityFileIn != "" {
+		// Skip the update check if using flattened identities to avoid
+		// initializing the identity store too early. Otherwise, if the identity store
+		// is initialized then later the flattened identity store will fail to be
+		// created since an identity store already exists.
+		return nil
+	}
+
 	profile, _, err := cf.FullProfileStatus()
 	if err != nil && !trace.IsNotFound(err) {
 		return trace.Wrap(err)

--- a/tool/tsh/common/tsh.go
+++ b/tool/tsh/common/tsh.go
@@ -1754,12 +1754,6 @@ func Run(ctx context.Context, args []string, opts ...CliOption) error {
 		)
 	}
 
-	if command == login.FullCommand() {
-		if err := maybeCheckLoginManagedUpdate(&cf, args); err != nil {
-			return trace.Wrap(err)
-		}
-	}
-
 	switch command {
 	case ver.FullCommand():
 		err = onVersion(&cf)
@@ -2415,6 +2409,15 @@ func onLogin(cf *CLIConf, reExecArgs ...string) (err error) {
 		}()
 	}
 
+	// The user has typed `tsh login`, if the running binary needs to be updated,
+	// update and re-exec. Keep this check inside onLogin so login-specific setup
+	// above like hardware-key and identity-store configuration happens first.
+	// Otherwise, errors will be encountered such as the identity store as already
+	// been set.
+	if err := autoupdatetools.CheckAndUpdateRemote(cf.Context, tc.WebProxyAddr, tc.InsecureSkipVerify, reExecArgs); err != nil {
+		return trace.Wrap(err)
+	}
+
 	// client is already logged in and profile is not expired and scope hasn't changed
 	if profile != nil && !profile.IsExpired(time.Now()) && !scopeChanged {
 		switch {
@@ -2425,12 +2428,6 @@ func onLogin(cf *CLIConf, reExecArgs ...string) (err error) {
 		// current status
 		case cf.Proxy == "" && cf.SiteName == "" && cf.DesiredRoles == "" && cf.RequestID == "" && cf.IdentityFileOut == "" ||
 			utils.TryHost(cf.Proxy) == utils.TryHost(profile.ProxyURL.Host) && cf.SiteName == profile.Cluster && cf.DesiredRoles == "" && cf.RequestID == "":
-
-			// The user has typed `tsh login`, if the running binary needs to
-			// be updated, update and re-exec.
-			if err := autoupdatetools.CheckAndUpdateRemote(cf.Context, tc.WebProxyAddr, tc.InsecureSkipVerify, reExecArgs); err != nil {
-				return trace.Wrap(err)
-			}
 
 			_, err := tc.PingAndShowMOTD(cf.Context)
 			if err != nil {
@@ -2445,12 +2442,6 @@ func onLogin(cf *CLIConf, reExecArgs ...string) (err error) {
 		// if the proxy names match but nothing else is specified; show motd and update active profile and kube configs
 		case utils.TryHost(cf.Proxy) == utils.TryHost(profile.ProxyURL.Host) &&
 			cf.SiteName == "" && cf.DesiredRoles == "" && cf.RequestID == "" && cf.IdentityFileOut == "":
-
-			// The user has typed `tsh login`, if the running binary needs to
-			// be updated, update and re-exec.
-			if err := autoupdatetools.CheckAndUpdateRemote(cf.Context, tc.WebProxyAddr, tc.InsecureSkipVerify, reExecArgs); err != nil {
-				return trace.Wrap(err)
-			}
 
 			_, err := tc.PingAndShowMOTD(cf.Context)
 			if err != nil {
@@ -2527,13 +2518,6 @@ func onLogin(cf *CLIConf, reExecArgs ...string) (err error) {
 			// Print status to show information of the logged in user.
 			return trace.Wrap(printLoginInformation(cf, profile, profiles))
 
-		// otherwise just pass through to standard login
-		default:
-			// The user is logged in and has typed in `tsh --proxy=... login`, if
-			// the running binary needs to be updated, update and re-exec.
-			if err := autoupdatetools.CheckAndUpdateRemote(cf.Context, tc.WebProxyAddr, tc.InsecureSkipVerify, reExecArgs); err != nil {
-				return trace.Wrap(err)
-			}
 		}
 	}
 
@@ -2713,35 +2697,6 @@ func onLogin(cf *CLIConf, reExecArgs ...string) (err error) {
 	}
 
 	return nil
-}
-
-// maybeCheckLoginManagedUpdate checks for updates if the current profile
-// does not exist or if the profile is expired.
-func maybeCheckLoginManagedUpdate(cf *CLIConf, reExecArgs []string) error {
-	if cf.IdentityFileIn != "" {
-		// Skip the update check if using flattened identities to avoid
-		// initializing the identity store too early. Otherwise, if the identity store
-		// is initialized then later the flattened identity store will fail to be
-		// created since an identity store already exists.
-		return nil
-	}
-
-	profile, _, err := cf.FullProfileStatus()
-	if err != nil && !trace.IsNotFound(err) {
-		return trace.Wrap(err)
-	}
-
-	// NOTE: checking for updates for an active profile is already handled elsewhere
-	if profile != nil && !profile.IsExpired(time.Now()) {
-		return nil
-	}
-
-	tc, err := makeClient(cf)
-	if err != nil {
-		return trace.Wrap(err)
-	}
-
-	return trace.Wrap(autoupdatetools.CheckAndUpdateRemote(cf.Context, tc.WebProxyAddr, tc.InsecureSkipVerify, reExecArgs))
 }
 
 // onLogout deletes a "session certificate" from ~/.tsh for a given proxy

--- a/tool/tsh/common/tsh_test.go
+++ b/tool/tsh/common/tsh_test.go
@@ -6636,18 +6636,25 @@ func TestFlatten(t *testing.T) {
 	_, err = identityfile.KeyRingFromIdentityFile(identityPath, "proxy.example.com", "")
 	require.NoError(t, err)
 
-	// Test execution: flatten the identity previously obtained in a new home.
+	// Test execution: flatten the identity previously obtained in a new home
+	// via the login command. The login command will update pre-login hooks,
+	// such as determining if an upgrade check should be performed.
 	freshHome := t.TempDir()
+	err = Run(context.Background(), []string{
+		"login",
+		"--insecure",
+		"--proxy", proxyAddr.String(),
+		"-i", identityPath,
+	}, setHomePath(freshHome))
+	require.NoError(t, err)
+
+	// Test execution: validate that the newly created profile can be used to build a valid client.
 	conf = CLIConf{
 		Proxy:              proxyAddr.String(),
 		InsecureSkipVerify: true,
-		IdentityFileIn:     identityPath,
 		HomePath:           freshHome,
 		Context:            context.Background(),
 	}
-	require.NoError(t, flattenIdentity(&conf))
-
-	// Test execution: validate that the newly created profile can be used to build a valid client.
 	clt, err := makeClient(&conf)
 	require.NoError(t, err)
 


### PR DESCRIPTION
Previously, if a user executed `tsh login` with an expired profile then the update check for `tsh` would be skipped. Now, an update check is performed if the profile is expired.

Note: this pull request was LLM assisted and then human refactored. I'm not super familiar with this codebase, so extra eyes are appreciated.

Current codebase already handles checking for an update when logging in with an active profile. In fact, this is a workaround until this fix is released. Users may run `tsh login` twice in a row to have an update check performed.


Changelog: Fix tsh login so update checks are performed when logging in with an expired profile


<!-- Include manual testing efforts to verify the change. -->
<!-- Detail where the tests where run and what configurations were used. -->
<!-- Include all the test cases which were run to validate the change. -->

## Manual Test Plan
### Test Environment

Staging Teleport Cloud tenant running 18.8.2

1. Run `make build/tsh`
1. Run `export TELEPORT_CDN_BASE_URL=https://cdn.teleport.dev`
2. Run `./build/tsh login --proxy <proxy> --ttl 1m`
3. Wait a minute and verify `./build/tsh status` shows the current profile as expired
4. Run `./build/tsh update --clear`
5. Run `./build/tsh login --proxy <proxy>` (this now does an update check)

### Test Cases
- [x] Update check is performed when logging in with previously expired profile
