### PR TITLE
[v18] Fix TestLeaseBucketing in the Flaky Tests Detector

### DIFF
--- a/lib/backend/etcdbk/etcd_test.go
+++ b/lib/backend/etcdbk/etcd_test.go
@@ -218,13 +218,16 @@ func TestLeaseBucketing(t *testing.T) {
 	require.NoError(t, err)
 	defer bk.Close()
 
+	// Stagger expiry times so items land in different lease buckets.
+	baseExpiry := time.Now().Add(time.Minute)
+
 	buckets := make(map[int64]struct{})
 	for i := 0; i < count; i++ {
 		key := backend.NewKey(pfx, fmt.Sprintf("%d", i))
 		_, err := bk.Put(ctx, backend.Item{
 			Key:     key,
 			Value:   []byte(fmt.Sprintf("val-%d", i)),
-			Expires: time.Now().Add(time.Minute),
+			Expires: baseExpiry.Add(time.Duration(i) * 200 * time.Millisecond),
 		})
 		require.NoError(t, err)
 
@@ -232,7 +235,6 @@ func TestLeaseBucketing(t *testing.T) {
 		require.NoError(t, err)
 
 		buckets[item.Expires.Unix()] = struct{}{}
-		time.Sleep(time.Millisecond * 200)
 	}
 
 	start := backend.NewKey(pfx, "")


### PR DESCRIPTION
Backport of #66987 to branch/v18.
