### PR TITLE
Fix rate limiting for signup test in Firefox

### DIFF
--- a/e2e/helpers/test.ts
+++ b/e2e/helpers/test.ts
@@ -235,6 +235,11 @@ export const test = base.extend<E2EFixtures>({
   },
 });
 
+export function configureNoRetries() {
+  test.describe.configure({ retries: 0 });
+  test.use({ trace: 'retain-on-failure' });
+}
+
 export { expect } from '@playwright/test';
 export type { Locator, Page } from '@playwright/test';
 

--- a/e2e/tests/web/authenticated/darktheme.spec.ts
+++ b/e2e/tests/web/authenticated/darktheme.spec.ts
@@ -17,13 +17,17 @@
  */
 
 import { login, logout } from '@gravitational/e2e/helpers/login';
-import { expect, test } from '@gravitational/e2e/helpers/test';
+import {
+  configureNoRetries,
+  expect,
+  test,
+} from '@gravitational/e2e/helpers/test';
 
 const lightBody = 'rgb(241, 242, 244)';
 const darkBody = 'rgb(12, 20, 61)';
 
 // Don't retry: a retry could have a user with the theme preference flipped and cause flakiness.
-test.describe.configure({ retries: 0 });
+configureNoRetries();
 
 test.use({ user: { roles: ['access', 'editor'] } });
 

--- a/e2e/tests/web/authenticated/darktheme.spec.ts
+++ b/e2e/tests/web/authenticated/darktheme.spec.ts
@@ -17,24 +17,18 @@
  */
 
 import { login, logout } from '@gravitational/e2e/helpers/login';
-import { defaultPassword, signup } from '@gravitational/e2e/helpers/signup';
-import { deleteUserIfExists } from '@gravitational/e2e/helpers/tctl';
 import { expect, test } from '@gravitational/e2e/helpers/test';
-import { TestInfo } from '@playwright/test';
 
 const lightBody = 'rgb(241, 242, 244)';
 const darkBody = 'rgb(12, 20, 61)';
 
-function username(testInfo: TestInfo) {
-  return `testuser-${testInfo.workerIndex}`;
-}
+// Don't retry: a retry could have a user with the theme preference flipped and cause flakiness.
+test.describe.configure({ retries: 0 });
 
-test('switching between dark and light theme', async ({ page }, testInfo) => {
-  // The re-login below can trip Teleport's challenge-generation rate limiter,
-  // so allow extra time to retry it.
-  test.slow();
+test.use({ user: { roles: ['access', 'editor'] } });
 
-  await signup(page, username(testInfo), defaultPassword);
+test('switching between dark and light theme', async ({ page, username }) => {
+  await page.goto('/');
   await expect(page.locator('body')).toHaveCSS('background-color', lightBody);
 
   // Switch to dark theme. Make sure that the change gets persisted in user
@@ -57,28 +51,13 @@ test('switching between dark and light theme', async ({ page }, testInfo) => {
   // signing in on a fresh browser.
   await page.context().clearCookies();
   await page.evaluate(() => localStorage.clear());
-  // Logging back in right after signup can trip Teleport's challenge-generation
-  // rate limiter ("rate limit exceeded, try again in Ns"); retry until it lets
-  // us through.
-  await expect(async () => {
-    await login(page, username(testInfo), defaultPassword);
-  }).toPass({ timeout: 30_000, intervals: [3_000] });
+
+  await login(page, username);
+
   await expect(page.locator('body')).toHaveCSS('background-color', darkBody);
 
   // Switch to light theme.
   await page.getByRole('button', { name: 'User Menu' }).click();
   await page.getByText('Switch to Light Theme').click();
   await expect(page.locator('body')).toHaveCSS('background-color', lightBody);
-});
-
-// Clean the user before each attempt (and after) so retries start clean rather
-// than failing on an already-registered user / consumed invite.
-// oxlint-disable-next-line no-empty-pattern
-test.beforeEach(({}, testInfo) => {
-  deleteUserIfExists(username(testInfo));
-});
-
-// oxlint-disable-next-line no-empty-pattern
-test.afterEach(({}, testInfo) => {
-  deleteUserIfExists(username(testInfo));
 });

--- a/e2e/tests/web/unauthenticated/signup.spec.ts
+++ b/e2e/tests/web/unauthenticated/signup.spec.ts
@@ -17,9 +17,13 @@
  */
 
 import { signup } from '@gravitational/e2e/helpers/signup';
-import { expect, test } from '@gravitational/e2e/helpers/test';
+import {
+  configureNoRetries,
+  expect,
+  test,
+} from '@gravitational/e2e/helpers/test';
 
-test.describe.configure({ retries: 0 });
+configureNoRetries();
 
 test('verify that a user can sign up with webauthn and login', async ({
   page,

--- a/e2e/tests/web/unauthenticated/signup.spec.ts
+++ b/e2e/tests/web/unauthenticated/signup.spec.ts
@@ -17,30 +17,25 @@
  */
 
 import { signup } from '@gravitational/e2e/helpers/signup';
-import { deleteUserIfExists } from '@gravitational/e2e/helpers/tctl';
 import { expect, test } from '@gravitational/e2e/helpers/test';
-import { TestInfo } from '@playwright/test';
 
-function username(testInfo: TestInfo) {
-  return `testuser-${testInfo.workerIndex}`;
-}
+test.describe.configure({ retries: 0 });
 
-// TODO(ryan): re-enable this test once Firefox flakiness is resolved.
-test.skip('verify that a user can sign up with webauthn and login', async ({
+test('verify that a user can sign up with webauthn and login', async ({
   page,
 }, testInfo) => {
   // Signing up auto-logs-in and we then log straight back in; that burst can
   // trip Teleport's challenge-generation rate limiter, so allow time to retry.
   test.slow();
 
-  await signup(page, username(testInfo));
+  const username = 'testuser-signup';
+
+  await signup(page, username);
 
   await page.getByRole('button', { name: 'User Menu' }).click();
   await page.getByText('Logout').click();
-  await page
-    .getByRole('textbox', { name: 'Username' })
-    .fill(username(testInfo));
-  await page.getByRole('textbox', { name: 'Username' }).press('Tab');
+
+  await page.getByRole('textbox', { name: 'Username' }).fill(username);
   await page.getByRole('textbox', { name: 'Password' }).fill('passwordtest123');
 
   // The web login challenge endpoint is rate limited; signing up then logging
@@ -55,16 +50,4 @@ test.skip('verify that a user can sign up with webauthn and login', async ({
       timeout: 5_000,
     });
   }).toPass({ timeout: 30_000, intervals: [3_000] });
-});
-
-// Clean the user before each attempt (and after) so retries start clean rather
-// than failing on an already-registered user / consumed invite.
-// oxlint-disable-next-line no-empty-pattern
-test.beforeEach(({}, testInfo) => {
-  deleteUserIfExists(username(testInfo));
-});
-
-// oxlint-disable-next-line no-empty-pattern
-test.afterEach(({}, testInfo) => {
-  deleteUserIfExists(username(testInfo));
 });


### PR DESCRIPTION
This moves the theme switching test to be authenticated so only the login and signup tests remain as unauthenticated tests. Hopefully, this releases the pressure on the unauthenticated endpoints and we won't see it fail in Firefox.

Also sets the theme switching test and signup tests to not be retried if they fail - theme switching could result in the same user being used and the theme state being mid-flip, causing the retry to fail anyway. Sign up should not retry because, well, it should pass first time.