### PR TITLE
docs: Amazon Keyspaces fixes

### DIFF
--- a/docs/pages/enroll-resources/database-access/enrollment/aws/aws-cassandra-keyspaces.mdx
+++ b/docs/pages/enroll-resources/database-access/enrollment/aws/aws-cassandra-keyspaces.mdx
@@ -17,10 +17,10 @@ tags:
 
 <Tabs>
 <TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
-![Enroll Redis with a Self-Hosted Teleport Cluster](../../../../../img/database-access/guides/cassandra_keyspaces_selfhosted.png)
+![Enroll Amazon Keyspaces with a Self-Hosted Teleport Cluster](../../../../../img/database-access/guides/cassandra_keyspaces_selfhosted.png)
 </TabItem>
 <TabItem scope={["cloud"]} label="Teleport Enterprise Cloud">
-![Enroll Redis with a Cloud-Hosted Teleport Cluster](../../../../../img/database-access/guides/cassandra_keyspaces_cloud.png)
+![Enroll Amazon Keyspaces with a Cloud-Hosted Teleport Cluster](../../../../../img/database-access/guides/cassandra_keyspaces_cloud.png)
 </TabItem>
 
 </Tabs>
@@ -101,7 +101,7 @@ AWS provides the `AmazonKeyspacesReadOnlyAccess` and `AmazonKeyspacesFullAccess`
 You can choose `AmazonKeyspacesReadOnlyAccess` for read-only access to Amazon Keyspaces or `AmazonKeyspacesFullAccess` for full access.
 
 <Admonition type="tip">
-  The `AmazonKeyspacesReadOnlyAccess` and `AmazonKeyspacesReadOnlyAccess` policies may
+  The `AmazonKeyspacesReadOnlyAccess` and `AmazonKeyspacesFullAccess` policies may
   provide too much or not enough access for your intentions.
   Validate that these meet your expectations if you plan on using them.
   You can also create your own custom Amazon Keyspaces Permissions Policies: [Amazon Keyspaces identity-based policy examples](https://docs.aws.amazon.com/keyspaces/latest/devguide/security_iam_id-based-policy-examples.html).


### PR DESCRIPTION

A couple small fixes for the image alt text and a duplicate IAM policy reference.