### PR TITLE
[v18] Update terraform module for Azure VMs to allow uniform VMSS enrollment

### DIFF
--- a/integrations/terraform-modules/teleport/discovery/azure/azure_role_definition.tf
+++ b/integrations/terraform-modules/teleport/discovery/azure/azure_role_definition.tf
@@ -12,10 +12,12 @@ locals {
 
   vm_actions = [
     "Microsoft.Compute/virtualMachines/read",
-    "Microsoft.Compute/virtualMachines/runCommand/action",
-    "Microsoft.Compute/virtualMachines/runCommands/delete",
     "Microsoft.Compute/virtualMachines/runCommands/read",
     "Microsoft.Compute/virtualMachines/runCommands/write",
+    "Microsoft.Compute/virtualMachineScaleSets/read",
+    "Microsoft.Compute/virtualMachineScaleSets/virtualMachines/read",
+    "Microsoft.Compute/virtualMachineScaleSets/virtualMachines/runCommands/read",
+    "Microsoft.Compute/virtualMachineScaleSets/virtualMachines/runCommands/write",
   ]
 
   role_actions = distinct(concat(


### PR DESCRIPTION
Backport #66999 to branch/v18

changelog: Added support for auto discovering VMs deployed in uniform Azure VM Scale Sets to terraform modules used in Auto Discovery.
