### PR TITLE
Replacing bare scope with `ScopePin` in kube agent

### DIFF
--- a/lib/kube/proxy/auth.go
+++ b/lib/kube/proxy/auth.go
@@ -34,7 +34,6 @@ import (
 	utilnet "k8s.io/apimachinery/pkg/util/net"
 	"k8s.io/client-go/kubernetes"
 	authztypes "k8s.io/client-go/kubernetes/typed/authorization/v1"
-
 	// Load kubeconfig auth plugins for gcp and azure.
 	// Without this, users can't provide a kubeconfig using those.
 	//

--- a/lib/kube/proxy/auth.go
+++ b/lib/kube/proxy/auth.go
@@ -34,6 +34,7 @@ import (
 	utilnet "k8s.io/apimachinery/pkg/util/net"
 	"k8s.io/client-go/kubernetes"
 	authztypes "k8s.io/client-go/kubernetes/typed/authorization/v1"
+
 	// Load kubeconfig auth plugins for gcp and azure.
 	// Without this, users can't provide a kubeconfig using those.
 	//
@@ -134,7 +135,7 @@ func (f *Forwarder) getKubeDetails(ctx context.Context) error {
 			types.Metadata{
 				Name: cluster,
 			}, types.KubernetesClusterSpecV3{},
-			types.KubeClusterWithScope(f.cfg.Scope),
+			types.KubeClusterWithScope(f.cfg.ScopePin.GetScope()),
 		)
 		if err != nil {
 			f.log.WarnContext(ctx, "failed to create KubernetesClusterV3 from credentials for cluster",

--- a/lib/kube/proxy/auth.go
+++ b/lib/kube/proxy/auth.go
@@ -135,7 +135,7 @@ func (f *Forwarder) getKubeDetails(ctx context.Context) error {
 			types.Metadata{
 				Name: cluster,
 			}, types.KubernetesClusterSpecV3{},
-			types.KubeClusterWithScope(f.cfg.ScopePin.GetScope()),
+			types.KubeClusterWithScope(f.cfg.GetScope()),
 		)
 		if err != nil {
 			f.log.WarnContext(ctx, "failed to create KubernetesClusterV3 from credentials for cluster",

--- a/lib/kube/proxy/ephemeral_containers.go
+++ b/lib/kube/proxy/ephemeral_containers.go
@@ -349,7 +349,7 @@ func (f *Forwarder) getPatchedPodEvent(ctx context.Context, sess *clusterSession
 // getUserEphemeralContainersForPod returns a list of ephemeral containers
 // created by the username and are waiting to be created for a given pod.
 func (f *Forwarder) getUserEphemeralContainersForPod(ctx context.Context, username, kubeCluster, namespace, pod string) ([]*kubewaitingcontainerpb.KubernetesWaitingContainer, error) {
-	if f.cfg.ScopePin.GetScope() != "" {
+	if f.cfg.GetScope() != "" {
 		// If the kube forwarder is scoped then moderated sessions are not supported and access to
 		// KindKubernetesWaitingContainer will be denied. We need to return without error to prevent
 		// interactive exec from failing

--- a/lib/kube/proxy/ephemeral_containers.go
+++ b/lib/kube/proxy/ephemeral_containers.go
@@ -349,7 +349,7 @@ func (f *Forwarder) getPatchedPodEvent(ctx context.Context, sess *clusterSession
 // getUserEphemeralContainersForPod returns a list of ephemeral containers
 // created by the username and are waiting to be created for a given pod.
 func (f *Forwarder) getUserEphemeralContainersForPod(ctx context.Context, username, kubeCluster, namespace, pod string) ([]*kubewaitingcontainerpb.KubernetesWaitingContainer, error) {
-	if f.cfg.Scope != "" {
+	if f.cfg.ScopePin.GetScope() != "" {
 		// If the kube forwarder is scoped then moderated sessions are not supported and access to
 		// KindKubernetesWaitingContainer will be denied. We need to return without error to prevent
 		// interactive exec from failing

--- a/lib/kube/proxy/forwarder.go
+++ b/lib/kube/proxy/forwarder.go
@@ -63,6 +63,7 @@ import (
 	"github.com/gravitational/teleport/api/client/proto"
 	"github.com/gravitational/teleport/api/constants"
 	apidefaults "github.com/gravitational/teleport/api/defaults"
+	scopesv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/v1"
 	"github.com/gravitational/teleport/api/observability/tracing"
 	tracehttp "github.com/gravitational/teleport/api/observability/tracing/http"
 	"github.com/gravitational/teleport/api/types"
@@ -82,6 +83,7 @@ import (
 	"github.com/gravitational/teleport/lib/modules"
 	"github.com/gravitational/teleport/lib/multiplexer"
 	"github.com/gravitational/teleport/lib/reversetunnelclient"
+	"github.com/gravitational/teleport/lib/scopes/pinning"
 	"github.com/gravitational/teleport/lib/service/servicecfg"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/srv"
@@ -181,8 +183,8 @@ type ForwarderConfig struct {
 	// ClusterFeaturesGetter is a function that returns the Teleport cluster licensed features.
 	// It is used to determine if the cluster is licensed for Kubernetes usage.
 	ClusterFeatures ClusterFeaturesGetter
-	// Scope that the forwarder is pinned to.
-	Scope string
+	// ScopePin is the scope and scoped roles the forwarder is pinned to.
+	ScopePin *scopesv1.Pin
 }
 
 // ClusterFeaturesGetter is a function that returns the Teleport cluster licensed features.
@@ -281,6 +283,12 @@ func (f *ForwarderConfig) CheckAndSetDefaults() error {
 	}
 	if f.log == nil {
 		f.log = slog.Default()
+	}
+
+	if f.ScopePin != nil {
+		if err := pinning.WeakValidate(f.ScopePin); err != nil {
+			return trace.Wrap(err)
+		}
 	}
 	return nil
 }

--- a/lib/kube/proxy/forwarder.go
+++ b/lib/kube/proxy/forwarder.go
@@ -299,6 +299,9 @@ func (f *ForwarderConfig) CheckAndSetDefaults() error {
 			return trace.Wrap(err)
 		}
 	}
+	if f.ScopePin.GetScope() != "" && f.Scope != "" {
+		return trace.BadParameter("either a scope pin or a bare scope must be set for a scoped kube forwarder, not both")
+	}
 	return nil
 }
 

--- a/lib/kube/proxy/forwarder.go
+++ b/lib/kube/proxy/forwarder.go
@@ -19,6 +19,7 @@
 package proxy
 
 import (
+	"cmp"
 	"context"
 	"crypto/tls"
 	"encoding/json"
@@ -83,6 +84,7 @@ import (
 	"github.com/gravitational/teleport/lib/modules"
 	"github.com/gravitational/teleport/lib/multiplexer"
 	"github.com/gravitational/teleport/lib/reversetunnelclient"
+	"github.com/gravitational/teleport/lib/scopes"
 	"github.com/gravitational/teleport/lib/scopes/pinning"
 	"github.com/gravitational/teleport/lib/service/servicecfg"
 	"github.com/gravitational/teleport/lib/services"
@@ -183,7 +185,9 @@ type ForwarderConfig struct {
 	// ClusterFeaturesGetter is a function that returns the Teleport cluster licensed features.
 	// It is used to determine if the cluster is licensed for Kubernetes usage.
 	ClusterFeatures ClusterFeaturesGetter
-	// ScopePin is the scope and scoped roles the forwarder is pinned to.
+	// Scope is the scope the forwarder is pinned to if a full scope pin is not present.
+	Scope string
+	// ScopePin is the scope and scoped role assignments the forwarder is pinned to.
 	ScopePin *scopesv1.Pin
 }
 
@@ -290,7 +294,17 @@ func (f *ForwarderConfig) CheckAndSetDefaults() error {
 			return trace.Wrap(err)
 		}
 	}
+	if f.Scope != "" {
+		if err := scopes.WeakValidate(f.Scope); err != nil {
+			return trace.Wrap(err)
+		}
+	}
 	return nil
+}
+
+// GetScope returns the scope the forwarder is pinned to whether it's a bare scope or a scope pin.
+func (f *ForwarderConfig) GetScope() string {
+	return cmp.Or(f.ScopePin.GetScope(), f.Scope)
 }
 
 // transportCacheTTL is the TTL for the transport cache.

--- a/lib/kube/proxy/forwarder_test.go
+++ b/lib/kube/proxy/forwarder_test.go
@@ -2440,7 +2440,7 @@ func TestForwarderConfig(t *testing.T) {
 	require.NoError(t, err)
 	t.Cleanup(lockWatcher.Close)
 
-	// baseCfg contains all required fields for a successfull call to CheckAndSetDefaults.
+	// baseCfg contains all required fields for a successful call to CheckAndSetDefaults.
 	// The mutateFn for each case should introduce the specific changes that
 	// lead to expected end states.
 	baseCfg := ForwarderConfig{

--- a/lib/kube/proxy/forwarder_test.go
+++ b/lib/kube/proxy/forwarder_test.go
@@ -70,6 +70,7 @@ import (
 	"github.com/gravitational/teleport/lib/auth/testauthority"
 	"github.com/gravitational/teleport/lib/authz"
 	"github.com/gravitational/teleport/lib/backend/memory"
+	"github.com/gravitational/teleport/lib/events"
 	"github.com/gravitational/teleport/lib/fixtures"
 	testingkubemock "github.com/gravitational/teleport/lib/kube/proxy/testing/kube_server"
 	"github.com/gravitational/teleport/lib/modules"
@@ -2418,6 +2419,109 @@ func TestGOAWAYHandling_Concurrent(t *testing.T) {
 	wg.Wait()
 
 	require.Zero(t, rewindLeaks.Load(), "rewind-body error must never reach the client")
+}
+
+func TestForwarderConfig(t *testing.T) {
+	t.Parallel()
+
+	clock := clockwork.NewFakeClock()
+	authority, err := testauthority.NewKeygen(modules.BuildOSS, clock.Now)
+	require.NoError(t, err)
+
+	authClient, err := newMockCAClient()
+	require.NoError(t, err)
+
+	lockWatcher, err := services.NewLockWatcher(t.Context(), services.LockWatcherConfig{
+		ResourceWatcherConfig: services.ResourceWatcherConfig{
+			Component: teleport.ComponentKube,
+			Client:    &mockEventClient{},
+		},
+	})
+	require.NoError(t, err)
+	t.Cleanup(lockWatcher.Close)
+
+	// baseCfg contains all required fields for a successfull call to CheckAndSetDefaults.
+	// The mutateFn for each case should introduce the specific changes that
+	// lead to expected end states.
+	baseCfg := ForwarderConfig{
+		AuthClient:        authClient,
+		CachingAuthClient: mockAccessPoint{},
+		ScopedAuthz:       mockAuthorizer{},
+		LockWatcher:       lockWatcher,
+		Emitter:           events.NewDiscardEmitter(),
+		ClusterName:       "local",
+		Keygen:            authority,
+		DataDir:           t.TempDir(),
+		HostID:            "host-id",
+		ClusterFeatures:   fakeClusterFeatures,
+		KubeServiceType:   KubeService,
+	}
+	cases := []struct {
+		name string
+		// mutateFn accepts a value and returns a pointer so that we don't
+		// alter the baseCfg for other cases
+		mutateFn    func(cfg ForwarderConfig) *ForwarderConfig
+		expectScope string
+		expectErr   string
+	}{
+		{
+			name: "unscoped",
+		},
+		{
+			name:        "scoped with agent scope",
+			expectScope: "/test",
+			mutateFn: func(cfg ForwarderConfig) *ForwarderConfig {
+				cfg.Scope = "/test"
+				return &cfg
+			},
+		},
+		{
+			name:        "scoped with scope pin",
+			expectScope: "/test",
+			mutateFn: func(cfg ForwarderConfig) *ForwarderConfig {
+				cfg.ScopePin = &scopesv1.Pin{
+					Kind:  scopesv1.PinKind_PIN_KIND_AGENT,
+					Scope: "/test",
+					SystemRoles: &scopesv1.SystemRoles{
+						Primary: types.RoleKube.String(),
+					},
+				}
+				return &cfg
+			},
+		},
+		{
+			name: "scoped with both an agent scope and scope pin",
+			mutateFn: func(cfg ForwarderConfig) *ForwarderConfig {
+				cfg.Scope = "/test"
+				cfg.ScopePin = &scopesv1.Pin{
+					Kind:  scopesv1.PinKind_PIN_KIND_AGENT,
+					Scope: "/test",
+					SystemRoles: &scopesv1.SystemRoles{
+						Primary: types.RoleKube.String(),
+					},
+				}
+				return &cfg
+			},
+			expectErr: "either a scope pin or a bare scope must be set for a scoped kube forwarder, not both",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			cfg := baseCfg
+			if c.mutateFn != nil {
+				cfg = *c.mutateFn(cfg)
+			}
+			err := cfg.CheckAndSetDefaults()
+			if c.expectErr != "" {
+				require.Error(t, err)
+				require.ErrorContains(t, err, c.expectErr)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, c.expectScope, cfg.GetScope())
+			}
+		})
+	}
 }
 
 // goawayServer is a fake [http2.Server] that terminates all received client

--- a/lib/kube/proxy/server.go
+++ b/lib/kube/proxy/server.go
@@ -170,7 +170,7 @@ func (c *TLSServerConfig) CheckAndSetDefaults() error {
 			return trace.BadParameter("missing parameter KubernetesServersWatcher")
 		}
 	case KubeService:
-		if c.ScopePin.GetScope() != "" && c.KubernetesServersWatcher != nil {
+		if c.GetScope() != "" && c.KubernetesServersWatcher != nil {
 			return trace.BadParameter("KubernetesServersWatcher is not supported for scoped KubeService")
 		}
 	}
@@ -242,7 +242,7 @@ func NewTLSServer(cfg TLSServerConfig) (*TLSServer, error) {
 	}
 
 	// TODO(eriktate/scopes): remove this validation once dynamic cluster registration supports scopes
-	if cfg.ScopePin.GetScope() != "" && len(cfg.ResourceMatchers) > 0 {
+	if cfg.GetScope() != "" && len(cfg.ResourceMatchers) > 0 {
 		return nil, trace.BadParameter("dynamic cluster registration not supported for scoped kube_service, resource matchers must be empty")
 	}
 	cfg.ForwarderConfig.log = log
@@ -656,8 +656,8 @@ func (t *TLSServer) getKubeClusterWithServiceLabels(name string) (*types.Kuberne
 
 	// The Proxy Service forwarder will always be unscoped and needs to be able to forward
 	// to scoped clusters as well.
-	if t.ScopePin.GetScope() != "" {
-		if scopes.Compare(t.ScopePin.GetScope(), details.kubeCluster.GetScope()) != scopes.Equivalent {
+	if t.GetScope() != "" {
+		if scopes.Compare(t.GetScope(), details.kubeCluster.GetScope()) != scopes.Equivalent {
 			// This should only happen if there's a bug in scoped access checking for KubernetesCluster resources.
 			// The kube proxy should never have access to clusters from orthogonal scopes. We also block access
 			// to clusters in child scopes but this may be relaxed in the future.

--- a/lib/kube/proxy/server.go
+++ b/lib/kube/proxy/server.go
@@ -170,7 +170,7 @@ func (c *TLSServerConfig) CheckAndSetDefaults() error {
 			return trace.BadParameter("missing parameter KubernetesServersWatcher")
 		}
 	case KubeService:
-		if c.Scope != "" && c.KubernetesServersWatcher != nil {
+		if c.ScopePin.GetScope() != "" && c.KubernetesServersWatcher != nil {
 			return trace.BadParameter("KubernetesServersWatcher is not supported for scoped KubeService")
 		}
 	}
@@ -242,7 +242,7 @@ func NewTLSServer(cfg TLSServerConfig) (*TLSServer, error) {
 	}
 
 	// TODO(eriktate/scopes): remove this validation once dynamic cluster registration supports scopes
-	if cfg.Scope != "" && len(cfg.ResourceMatchers) > 0 {
+	if cfg.ScopePin.GetScope() != "" && len(cfg.ResourceMatchers) > 0 {
 		return nil, trace.BadParameter("dynamic cluster registration not supported for scoped kube_service, resource matchers must be empty")
 	}
 	cfg.ForwarderConfig.log = log
@@ -656,8 +656,8 @@ func (t *TLSServer) getKubeClusterWithServiceLabels(name string) (*types.Kuberne
 
 	// The Proxy Service forwarder will always be unscoped and needs to be able to forward
 	// to scoped clusters as well.
-	if t.Scope != "" {
-		if scopes.Compare(t.Scope, details.kubeCluster.GetScope()) != scopes.Equivalent {
+	if t.ScopePin.GetScope() != "" {
+		if scopes.Compare(t.ScopePin.GetScope(), details.kubeCluster.GetScope()) != scopes.Equivalent {
 			// This should only happen if there's a bug in scoped access checking for KubernetesCluster resources.
 			// The kube proxy should never have access to clusters from orthogonal scopes. We also block access
 			// to clusters in child scopes but this may be relaxed in the future.

--- a/lib/kube/proxy/sess.go
+++ b/lib/kube/proxy/sess.go
@@ -462,7 +462,7 @@ func newSession(ctx authContext, forwarder *Forwarder, req *http.Request, params
 
 	q := req.URL.Query()
 	accessEvaluator := moderation.NewSessionAccessEvaluator(policySets, types.KubernetesSessionKind, ctx.User.GetName())
-	if accessEvaluator.IsModerated() && forwarder.cfg.Scope != "" {
+	if accessEvaluator.IsModerated() && forwarder.cfg.ScopePin.GetScope() != "" {
 		// If the kube forwarder is scoped then moderated sessions are not supported and access to
 		// KindKubernetesWaitingContainer will be denied. We need to return an explicit error for unscoped,
 		// moderated sessions in order to prevent any sort of bypass interacting with kube waiting containers.
@@ -1158,7 +1158,7 @@ func (s *session) createEphemeralContainer() (*corev1.ContainerStatus, error) {
 	podName := s.params.ByName("podName")
 	container := s.req.URL.Query().Get("container")
 
-	if s.forwarder.cfg.Scope != "" {
+	if s.forwarder.cfg.ScopePin.GetScope() != "" {
 		// If the kube forwarder is scoped then moderated sessions are not supported and access to
 		// KindKubernetesWaitingContainer will be denied. We need to return without error to prevent
 		// interactive exec from failing

--- a/lib/kube/proxy/sess.go
+++ b/lib/kube/proxy/sess.go
@@ -462,7 +462,7 @@ func newSession(ctx authContext, forwarder *Forwarder, req *http.Request, params
 
 	q := req.URL.Query()
 	accessEvaluator := moderation.NewSessionAccessEvaluator(policySets, types.KubernetesSessionKind, ctx.User.GetName())
-	if accessEvaluator.IsModerated() && forwarder.cfg.ScopePin.GetScope() != "" {
+	if accessEvaluator.IsModerated() && forwarder.cfg.GetScope() != "" {
 		// If the kube forwarder is scoped then moderated sessions are not supported and access to
 		// KindKubernetesWaitingContainer will be denied. We need to return an explicit error for unscoped,
 		// moderated sessions in order to prevent any sort of bypass interacting with kube waiting containers.
@@ -1158,7 +1158,7 @@ func (s *session) createEphemeralContainer() (*corev1.ContainerStatus, error) {
 	podName := s.params.ByName("podName")
 	container := s.req.URL.Query().Get("container")
 
-	if s.forwarder.cfg.ScopePin.GetScope() != "" {
+	if s.forwarder.cfg.GetScope() != "" {
 		// If the kube forwarder is scoped then moderated sessions are not supported and access to
 		// KindKubernetesWaitingContainer will be denied. We need to return without error to prevent
 		// interactive exec from failing

--- a/lib/kube/proxy/watcher.go
+++ b/lib/kube/proxy/watcher.go
@@ -93,7 +93,7 @@ func (s *TLSServer) startReconciler(ctx context.Context) (err error) {
 // startKubeClusterResourceWatcher starts watching changes to Kube Clusters resources and
 // registers/unregisters the proxied Kube Cluster accordingly.
 func (s *TLSServer) startKubeClusterResourceWatcher(ctx context.Context) (*services.GenericWatcher[types.KubeCluster, readonly.KubeCluster], error) {
-	if len(s.ResourceMatchers) == 0 || s.KubeServiceType != KubeService || s.Scope != "" {
+	if len(s.ResourceMatchers) == 0 || s.KubeServiceType != KubeService || s.ScopePin.GetScope() != "" {
 		s.log.DebugContext(ctx, "Not initializing Kube Cluster resource watcher")
 		return nil, nil
 	}

--- a/lib/kube/proxy/watcher.go
+++ b/lib/kube/proxy/watcher.go
@@ -93,7 +93,7 @@ func (s *TLSServer) startReconciler(ctx context.Context) (err error) {
 // startKubeClusterResourceWatcher starts watching changes to Kube Clusters resources and
 // registers/unregisters the proxied Kube Cluster accordingly.
 func (s *TLSServer) startKubeClusterResourceWatcher(ctx context.Context) (*services.GenericWatcher[types.KubeCluster, readonly.KubeCluster], error) {
-	if len(s.ResourceMatchers) == 0 || s.KubeServiceType != KubeService || s.ScopePin.GetScope() != "" {
+	if len(s.ResourceMatchers) == 0 || s.KubeServiceType != KubeService || s.GetScope() != "" {
 		s.log.DebugContext(ctx, "Not initializing Kube Cluster resource watcher")
 		return nil, nil
 	}

--- a/lib/service/kubernetes.go
+++ b/lib/service/kubernetes.go
@@ -292,6 +292,7 @@ func (process *TeleportProcess) initKubernetesService(logger *slog.Logger, conn 
 			PublicAddr:                    publicAddr,
 			ClusterFeatures:               process.GetClusterFeatures,
 			ScopePin:                      conn.ScopePin(),
+			Scope:                         conn.Scope(),
 		},
 		TLS:                  tlsConfig,
 		AccessPoint:          accessPoint,

--- a/lib/service/kubernetes.go
+++ b/lib/service/kubernetes.go
@@ -291,7 +291,7 @@ func (process *TeleportProcess) initKubernetesService(logger *slog.Logger, conn 
 			CheckImpersonationPermissions: cfg.Kube.CheckImpersonationPermissions,
 			PublicAddr:                    publicAddr,
 			ClusterFeatures:               process.GetClusterFeatures,
-			Scope:                         conn.Scope(),
+			ScopePin:                      conn.ScopePin(),
 		},
 		TLS:                  tlsConfig,
 		AccessPoint:          accessPoint,

--- a/lib/service/kubernetes.go
+++ b/lib/service/kubernetes.go
@@ -271,6 +271,12 @@ func (process *TeleportProcess) initKubernetesService(logger *slog.Logger, conn 
 		publicAddr = cfg.Kube.PublicAddrs[0].String()
 	}
 
+	// if scope pin is set, we should not pass the bare agent scope along to the kube forwarder
+	agentScope := conn.Scope()
+	scopePin := conn.ScopePin()
+	if scopePin != nil {
+		agentScope = ""
+	}
 	kubeServer, err := kubeproxy.NewTLSServer(kubeproxy.TLSServerConfig{
 		ForwarderConfig: kubeproxy.ForwarderConfig{
 			Namespace:                     apidefaults.Namespace,
@@ -291,8 +297,8 @@ func (process *TeleportProcess) initKubernetesService(logger *slog.Logger, conn 
 			CheckImpersonationPermissions: cfg.Kube.CheckImpersonationPermissions,
 			PublicAddr:                    publicAddr,
 			ClusterFeatures:               process.GetClusterFeatures,
-			ScopePin:                      conn.ScopePin(),
-			Scope:                         conn.Scope(),
+			ScopePin:                      scopePin,
+			Scope:                         agentScope,
 		},
 		TLS:                  tlsConfig,
 		AccessPoint:          accessPoint,

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -376,7 +376,7 @@ func newConnector(clientIdentity, serverIdentity *state.Identity) (*Connector, e
 	c := &Connector{
 		clusterName: clientIdentity.ClusterName,
 		hostID:      clientIdentity.ID.HostUUID,
-		scope:       clientIdentity.GetAgentScope(),
+		scope:       clientIdentity.AgentScope,
 		scopePin:    clientIdentity.ScopePin,
 		role:        clientIdentity.ID.Role,
 	}

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -76,6 +76,7 @@ import (
 	integrationpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/integration/v1"
 	kubeproto "github.com/gravitational/teleport/api/gen/proto/go/teleport/kube/v1"
 	joiningv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/joining/v1"
+	scopesv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/v1"
 	transportpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/transport/v1"
 	apissh "github.com/gravitational/teleport/api/ssh"
 	"github.com/gravitational/teleport/api/types"
@@ -376,6 +377,7 @@ func newConnector(clientIdentity, serverIdentity *state.Identity) (*Connector, e
 		clusterName: clientIdentity.ClusterName,
 		hostID:      clientIdentity.ID.HostUUID,
 		scope:       clientIdentity.GetAgentScope(),
+		scopePin:    clientIdentity.ScopePin,
 		role:        clientIdentity.ID.Role,
 	}
 	c.clientState.Store(clientState)
@@ -444,6 +446,7 @@ type Connector struct {
 	clusterName string
 	hostID      string
 	scope       string
+	scopePin    *scopesv1.Pin
 	role        types.SystemRole
 
 	// clientState contains the current connector state for outbound connections
@@ -480,6 +483,11 @@ func (c *Connector) HostUUID() string {
 // Scope returns the host's AgentScope
 func (c *Connector) Scope() string {
 	return c.scope
+}
+
+// ScopePin returns the host's ScopePin
+func (c *Connector) ScopePin() *scopesv1.Pin {
+	return c.scopePin
 }
 
 func (c *Connector) Role() types.SystemRole {

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -376,7 +376,7 @@ func newConnector(clientIdentity, serverIdentity *state.Identity) (*Connector, e
 	c := &Connector{
 		clusterName: clientIdentity.ClusterName,
 		hostID:      clientIdentity.ID.HostUUID,
-		scope:       clientIdentity.AgentScope,
+		scope:       clientIdentity.GetAgentScope(),
 		scopePin:    clientIdentity.ScopePin,
 		role:        clientIdentity.ID.Role,
 	}


### PR DESCRIPTION
Updates the kube agent to use the `ScopePin` rather than the `AgentScope` from the host certificate. A later PR will update the agent's perms to allow calling kube related APIs.

edit:
The "With new `ScopePin`" test cases below are not actually possible due to many required APIs not yet supporting scoped agent identities. When I did my testing I think I inadvertently used an older binary and did not think to verify that the generated certificate contained a `ScopePin` instead of an `AgentScope`
## Manual Test Plan
### Test Environment
- Local teleport cluster
### Test Cases
- [x] With new `ScopePin`
  ~- [x] Scoped kube clusters can still join and heartbeat with the correct scope~
  ~- [x] Scoped kube clusters can still be logged into~
  ~- [x] `kubectl` commands can still be executed against scoped clusters~
- [x] With old `AgentScope`
  - [x] Scoped kube clusters can still join and heartbeat with the correct scope
  - [x] Scoped kube clusters can still be logged into
  - [x] `kubectl` commands can still be executed against scoped clusters