### PR TITLE
access-changes[1]: Add `tctl access-changes ls` command

### DIFF
--- a/docs/pages/reference/cli/tctl.mdx
+++ b/docs/pages/reference/cli/tctl.mdx
@@ -45,6 +45,27 @@ Global environment variables:
 |`TELEPORT_IDENTITY_FILE`|*no default*|Path to an identity file. Must be provided to make remote connections to auth. An identity file can be exported with 'tctl auth sign'|
 |`TELEPORT_MFA_MODE`|`auto` (one of: `auto`, `cross-platform`, `platform`, `sso`, `browser`)|Preferred mode for MFA assertions.|
 
+## tctl access-changes ls
+
+List access path changes for your crown jewels
+
+Usage:
+
+```code
+$ tctl access-changes ls [<flags>]
+```
+
+Flags:
+
+|Flag|Default|Description|
+|---|---|---|
+|`--filter`|*no default*|Filter by comma-separated key=value pairs (keys: type, kind, source). Pairs within one --filter are AND'd; repeat --filter to OR. Example: --filter kind=resource,source=AWS --filter type=teleport_user.|
+|`--kind`|*no default* (any of (repeatable): `identity`, `resource`)|Filter by change kind (repeatable; each is OR'd). Combine axes with --filter.|
+|`--limit`|`100`|Maximum number of changes to return (0 for unlimited).|
+|`--search`|*no default*|Search term to filter access changes.|
+|`--source`|*no default* (any of (repeatable): `AWS`, `Entra`, `Gitlab`, `Okta`, `TELEPORT`)|Filter by source (repeatable; each is OR'd). Combine axes with --filter.|
+|`--type`|*no default* (any of (repeatable): `aws_ec2`, `aws_eks`, `aws_rds`, `aws_s3`, `aws_user`, `entra_user`, `gitlab_project`, `gitlab_user`, `okta_application`, `okta_user`, `teleport_application`, `teleport_bot`, `teleport_database`, `teleport_desktop`, `teleport_kubernetes`, `teleport_node`, `teleport_user`)|Filter by origin type (repeatable; each is OR'd). Combine axes with --filter.|
+
 ## tctl acl get
 
 Get detailed information for an Access List.

--- a/tool/tctl/common/accessgraph/access_changes_command.go
+++ b/tool/tctl/common/accessgraph/access_changes_command.go
@@ -1,0 +1,279 @@
+/*
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package accessgraph
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"slices"
+	"strings"
+	"time"
+
+	"github.com/alecthomas/kingpin/v2"
+	"github.com/gravitational/trace"
+
+	"github.com/gravitational/teleport"
+	accessgraph "github.com/gravitational/teleport/lib/accessgraph/apiclient"
+	"github.com/gravitational/teleport/lib/asciitable"
+)
+
+type accessChangesArgs struct {
+	cmd    *kingpin.CmdClause
+	ls     accessChangesListArgs
+	format string
+}
+
+type accessChangesListArgs struct {
+	cmd *kingpin.CmdClause
+
+	// General filters
+	search string
+	// Structured filters
+	source []string
+	kind   []string
+	typ    []string
+	// filters allows you to combine structured filters in the form of `--filters source=x,kind=y`
+	filters []string
+
+	// Output control
+	limit int
+}
+
+func (c *AccessGraphCommand) initAccessChanges(app *kingpin.Application) {
+	accessChangesCmd := app.Command("access-changes", "Monitor access path changes to crown jewels.")
+	accessChangesCmd.Flag("format", "Output format. (Values: text, json, yaml)").
+		Default(teleport.Text).
+		EnumVar(&c.accessChanges.format, teleport.Text, teleport.JSON, teleport.YAML)
+	c.accessChanges.cmd = accessChangesCmd
+	c.initAccessChangesList(c.accessChanges.cmd)
+}
+
+func (c *AccessGraphCommand) initAccessChangesList(parent *kingpin.CmdClause) {
+	lsCmd := parent.Command("ls", "List access path changes for your crown jewels")
+
+	lsCmd.Flag("search", "Search term to filter access changes.").
+		StringVar(&c.accessChanges.ls.search)
+	lsCmd.Flag("filter", "Filter by comma-separated key=value pairs (keys: type, kind, source). Pairs within one --filter are AND'd; repeat --filter to OR. Example: --filter kind=resource,source=AWS --filter type=teleport_user.").
+		StringsVar(&c.accessChanges.ls.filters)
+	lsCmd.Flag("type", "Filter by origin type (repeatable; each is OR'd). Combine axes with --filter.").
+		EnumsVar(&c.accessChanges.ls.typ, allowedOriginTypes...)
+	lsCmd.Flag("kind", "Filter by change kind (repeatable; each is OR'd). Combine axes with --filter.").
+		EnumsVar(&c.accessChanges.ls.kind, allowedKinds...)
+	lsCmd.Flag("source", "Filter by source (repeatable; each is OR'd). Combine axes with --filter.").
+		EnumsVar(&c.accessChanges.ls.source, allowedSources...)
+
+	lsCmd.Flag("limit", "Maximum number of changes to return (0 for unlimited).").
+		Default("100").
+		IntVar(&c.accessChanges.ls.limit)
+
+	c.accessChanges.ls.cmd = lsCmd
+}
+
+// AccessChangesList executes `tctl access-changes ls`.
+func (c *AccessGraphCommand) AccessChangesList(ctx context.Context, client *accessgraph.ClientWithResponses) error {
+	params, err := constructAccessChangesListQuery(c.accessChanges)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	changes, err := fetchAccessChanges(ctx, client, params, c.accessChanges.ls.limit)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	return displayAccessChanges(c.stdout, changes, c.accessChanges.format)
+}
+
+// fetchAccessChanges paginates ListCrownJewelAccessPaths until limit items have been collected or the server runs out of pages; limit<=0 disables the cap.
+func fetchAccessChanges(
+	ctx context.Context,
+	client *accessgraph.ClientWithResponses,
+	params accessgraph.ListCrownJewelAccessPathsParams,
+	limit int,
+) ([]accessgraph.AccessPathSummaryItem, error) {
+	var (
+		changes []accessgraph.AccessPathSummaryItem
+		cursor  *string
+	)
+	for {
+		params.Iterator = cursor
+		resp, err := doRequest(client.ListCrownJewelAccessPathsWithResponse(ctx, &params))
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		if resp.JSON200 == nil {
+			return nil, trace.Errorf("received nil json response from Access Graph API")
+		}
+		// Guard against a backend that returns a non-advancing cursor, which would otherwise spin forever.
+		if cursor != nil && resp.JSON200.NextCursor != nil && *resp.JSON200.NextCursor == *cursor {
+			slog.DebugContext(ctx, "Access Graph cursor did not advance; stopping pagination", "cursor", *cursor)
+			return changes, nil
+		}
+		changes = append(changes, resp.JSON200.Data...)
+		if limit > 0 && len(changes) >= limit {
+			return changes[:limit], nil
+		}
+		if resp.JSON200.NextCursor == nil {
+			return changes, nil
+		}
+		cursor = resp.JSON200.NextCursor
+	}
+}
+
+// Allowed filter values, derived from the Access Graph web filter tree
+// (access-graph/web/src/routes/crownjewels/access/typeOptions.ts)
+var (
+	// allowedOriginTypes backs --type and the type key of --filter.
+	allowedOriginTypes = []string{
+		"aws_ec2", "aws_eks", "aws_rds", "aws_s3", "aws_user",
+		"entra_user", "gitlab_project", "gitlab_user",
+		"okta_application", "okta_user",
+		"teleport_application", "teleport_bot", "teleport_database",
+		"teleport_desktop", "teleport_kubernetes", "teleport_node", "teleport_user",
+	}
+	// allowedSources backs --source and the source key of --filter.
+	allowedSources = []string{"AWS", "Entra", "Gitlab", "Okta", "TELEPORT"}
+	// allowedKinds backs --kind and the kind key of --filter.
+	allowedKinds = []string{"identity", "resource"}
+)
+
+type accessChangeTypeFilter struct {
+	OriginType *string `json:"origin_type,omitempty"`
+	Source     *string `json:"source,omitempty"`
+	Kind       *string `json:"kind,omitempty"`
+}
+
+func constructAccessChangesListQuery(args accessChangesArgs) (accessgraph.ListCrownJewelAccessPathsParams, error) {
+	params := accessgraph.ListCrownJewelAccessPathsParams{}
+
+	// Assemble the OR'd envelope list. --filter envelopes come first, in the
+	// order given then --type, --kind, and --source value. (Order is cosmetic
+	// and to make testing easier)
+	var envelopes []accessChangeTypeFilter
+	for _, raw := range args.ls.filters {
+		env, err := parseFilterEnvelope(raw)
+		if err != nil {
+			return params, trace.Wrap(err)
+		}
+		envelopes = append(envelopes, env)
+	}
+	for _, t := range args.ls.typ {
+		v := t
+		envelopes = append(envelopes, accessChangeTypeFilter{OriginType: &v})
+	}
+	for _, k := range args.ls.kind {
+		v := k
+		envelopes = append(envelopes, accessChangeTypeFilter{Kind: &v})
+	}
+	for _, s := range args.ls.source {
+		v := s
+		envelopes = append(envelopes, accessChangeTypeFilter{Source: &v})
+	}
+
+	if len(envelopes) > 0 {
+		filterJson, err := json.Marshal(envelopes)
+		if err != nil {
+			return params, trace.Wrap(err)
+		}
+		filterStr := string(filterJson)
+		params.TypeFilter = &filterStr
+	}
+
+	if args.ls.search != "" {
+		params.Search = &args.ls.search
+	}
+
+	return params, nil
+}
+
+// parseFilterEnvelope turns a single --filter value ("kind=resource,source=AWS")
+// into one type_filter envelope, where the comma-separated pairs are AND'd.
+func parseFilterEnvelope(s string) (accessChangeTypeFilter, error) {
+	var env accessChangeTypeFilter
+	seenKeys := make(map[string]struct{})
+	for pair := range strings.SplitSeq(s, ",") {
+		key, value, ok := strings.Cut(pair, "=")
+		key, value = strings.TrimSpace(key), strings.TrimSpace(value)
+		if !ok || key == "" || value == "" {
+			return env, trace.BadParameter("invalid filter %q: want comma-separated key=value pairs", s)
+		}
+		if _, seen := seenKeys[key]; seen {
+			return env, trace.BadParameter("duplicate filter key %q in filter %q", key, s)
+		}
+		seenKeys[key] = struct{}{}
+		v := value
+		switch key {
+		case "type":
+			if !slices.Contains(allowedOriginTypes, v) {
+				return env, trace.BadParameter("invalid type %q: want one of %v", v, allowedOriginTypes)
+			}
+			env.OriginType = &v
+		case "kind":
+			if !slices.Contains(allowedKinds, v) {
+				return env, trace.BadParameter("invalid kind %q: want one of %v", v, allowedKinds)
+			}
+			env.Kind = &v
+		case "source":
+			if !slices.Contains(allowedSources, v) {
+				return env, trace.BadParameter("invalid source %q: want one of %v", v, allowedSources)
+			}
+			env.Source = &v
+		default:
+			return env, trace.BadParameter("unknown filter key %q: want type, kind, or source", key)
+		}
+	}
+
+	return env, nil
+}
+
+func displayAccessChanges(out io.Writer, changes []accessgraph.AccessPathSummaryItem, format string) error {
+	if changes == nil {
+		changes = []accessgraph.AccessPathSummaryItem{}
+	}
+	return writeOutput(out, changes, format, func(w io.Writer) error {
+		return displayAccessChangesText(w, changes)
+	})
+}
+
+func displayAccessChangesText(out io.Writer, changes []accessgraph.AccessPathSummaryItem) error {
+	table := asciitable.MakeTable([]string{
+		"Change ID",
+		"Kind",
+		"Name",
+		"Source",
+		"Origin Type",
+		"Alias",
+		"Created At",
+	})
+
+	for _, change := range changes {
+		table.AddRow([]string{
+			change.Id,
+			change.AffectedNode.Kind,
+			change.AffectedNode.Name,
+			change.AffectedNode.Source,
+			change.AffectedNode.OriginType,
+			change.AffectedNode.Alias,
+			change.CreatedAt.Format(time.RFC3339),
+		})
+	}
+	_, err := fmt.Fprintln(out, table.AsBuffer().String())
+	return trace.Wrap(err)
+}

--- a/tool/tctl/common/accessgraph/access_changes_command_test.go
+++ b/tool/tctl/common/accessgraph/access_changes_command_test.go
@@ -1,0 +1,468 @@
+/*
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package accessgraph
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/url"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/alecthomas/kingpin/v2"
+	"github.com/google/uuid"
+	"github.com/gravitational/trace"
+	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport"
+	accessgraph "github.com/gravitational/teleport/lib/accessgraph/apiclient"
+)
+
+// AG-mounted paths the access-changes commands hit — kept as constants so
+// the test fails loudly if the generated client's operation paths drift.
+const (
+	listAccessChangesPath = accessGraphAPIPath + "graph/crown-jewel/access-paths"
+)
+
+var (
+	fixtureChangeID   = "ch-1111"
+	fixtureAffectedID = uuid.MustParse("66666666-7777-8888-9999-000000000000")
+	fixtureChangeTime = time.Date(2026, 5, 1, 9, 30, 0, 0, time.UTC)
+)
+
+func accessPathSummaryItemFixture() accessgraph.AccessPathSummaryItem {
+	return accessgraph.AccessPathSummaryItem{
+		Id:        fixtureChangeID,
+		CreatedAt: fixtureChangeTime,
+		AffectedNode: accessgraph.AccessPathSummaryItemNode{
+			Id:         fixtureAffectedID,
+			Kind:       "resource",
+			Name:       "prod-db",
+			Source:     "Teleport",
+			OriginType: "teleport_database",
+			Alias:      "prod-db-alias",
+		},
+	}
+}
+
+type accessChangesRequest struct {
+	path  string
+	query url.Values
+}
+
+func newListAccessChangesHandler(t *testing.T, items []accessgraph.AccessPathSummaryItem, captured *accessChangesRequest, statusCode int, errBody string) http.Handler {
+	t.Helper()
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if captured != nil {
+			*captured = accessChangesRequest{path: r.URL.Path, query: r.URL.Query()}
+		}
+		require.Equal(t, listAccessChangesPath, r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		if statusCode != 0 && statusCode != http.StatusOK {
+			w.WriteHeader(statusCode)
+			_, _ = w.Write([]byte(errBody))
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(map[string]any{"data": items})
+	})
+}
+
+type fetchAccessChangesPage struct {
+	data       []accessgraph.AccessPathSummaryItem
+	nextCursor *string
+}
+
+// newPaginatedAccessChangesHandler advances through pages on each request,
+// asserting the inbound iterator matches the prior page's cursor.
+func newPaginatedAccessChangesHandler(t *testing.T, pages []fetchAccessChangesPage) http.Handler {
+	t.Helper()
+	var calls atomic.Int64
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		idx := int(calls.Add(1) - 1)
+		require.Less(t, idx, len(pages), "more page requests than configured")
+		if idx > 0 {
+			prev := pages[idx-1].nextCursor
+			require.NotNil(t, prev, "fetchAccessChanges continued past a nil cursor")
+			require.Equal(t, *prev, r.URL.Query().Get("iterator"))
+		}
+		page := pages[idx]
+		body := map[string]any{"data": page.data}
+		if page.nextCursor != nil {
+			body["next_cursor"] = *page.nextCursor
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(body)
+	})
+}
+
+// newAccessChangesCommand returns a command wired to a captured stdout
+// buffer. Tests call AccessChangesList/AccessChangesGet directly — TryRun
+// is bypassed because it owns credential loading, not behavior.
+func newAccessChangesCommand(t *testing.T, format string) (*AccessGraphCommand, *bytes.Buffer) {
+	t.Helper()
+	var buf bytes.Buffer
+	c := &AccessGraphCommand{
+		stdout:        &buf,
+		accessChanges: accessChangesArgs{format: format},
+	}
+	return c, &buf
+}
+
+func TestAccessChangesList(t *testing.T) {
+
+	t.Run("request shaping carries filter envelopes and search", func(t *testing.T) {
+		var got accessChangesRequest
+		ag := newAccessGraphTestClient(t, newListAccessChangesHandler(t,
+			[]accessgraph.AccessPathSummaryItem{accessPathSummaryItemFixture()}, &got, 0, ""))
+
+		c, _ := newAccessChangesCommand(t, teleport.JSON)
+		c.accessChanges.ls = accessChangesListArgs{
+			search:  "prod-db",
+			filters: []string{"kind=resource,source=TELEPORT", "type=teleport_user"},
+			limit:   10,
+		}
+		require.NoError(t, c.AccessChangesList(context.Background(), ag))
+
+		require.Equal(t, "prod-db", got.query.Get("search"))
+
+		// type_filter is a JSON array with one envelope per --filter; the order
+		// is preserved and within-envelope pairs are AND'd.
+		var filters []accessChangeTypeFilter
+		require.NoError(t, json.Unmarshal([]byte(got.query.Get("type_filter")), &filters))
+		require.Len(t, filters, 2)
+		require.NotNil(t, filters[0].Kind)
+		require.Equal(t, "resource", *filters[0].Kind)
+		require.NotNil(t, filters[0].Source)
+		require.Equal(t, "TELEPORT", *filters[0].Source)
+		require.Nil(t, filters[0].OriginType)
+		require.NotNil(t, filters[1].OriginType)
+		require.Equal(t, "teleport_user", *filters[1].OriginType)
+
+		// constructAccessChangesListQuery deliberately leaves the per-page
+		// Limit unset — the user --limit only trims via fetchAccessChanges.
+		require.Empty(t, got.query.Get("limit"), "params.Limit must not be sent; server picks the page size")
+	})
+
+	t.Run("text format renders headers and row data", func(t *testing.T) {
+		ag := newAccessGraphTestClient(t, newListAccessChangesHandler(t,
+			[]accessgraph.AccessPathSummaryItem{accessPathSummaryItemFixture()}, nil, 0, ""))
+
+		c, buf := newAccessChangesCommand(t, teleport.Text)
+		require.NoError(t, c.AccessChangesList(context.Background(), ag))
+
+		out := buf.String()
+		for _, h := range []string{"Change ID", "Kind", "Name", "Source", "Origin Type", "Alias", "Created At"} {
+			require.Contains(t, out, h, "missing column header %q", h)
+		}
+		require.Contains(t, out, fixtureChangeID)
+		require.Contains(t, out, "prod-db")
+		require.Contains(t, out, "Teleport")
+	})
+
+	t.Run("nil data renders as empty JSON array", func(t *testing.T) {
+		// Handler returns {"data": null} — displayAccessChanges normalizes
+		// the nil to [] so JSON output is a valid empty array.
+		ag := newAccessGraphTestClient(t, newListAccessChangesHandler(t, nil, nil, 0, ""))
+
+		c, buf := newAccessChangesCommand(t, teleport.JSON)
+		require.NoError(t, c.AccessChangesList(context.Background(), ag))
+		require.JSONEq(t, "[]", buf.String())
+	})
+
+	t.Run("HTTP 500 surfaces as apiResponseError", func(t *testing.T) {
+		ag := newAccessGraphTestClient(t, newListAccessChangesHandler(t, nil, nil,
+			http.StatusInternalServerError, `{"message":"changes backend exploded"}`))
+
+		c, _ := newAccessChangesCommand(t, teleport.JSON)
+		err := c.AccessChangesList(context.Background(), ag)
+		var agErr *apiResponseError
+		require.ErrorAs(t, err, &agErr)
+		require.Equal(t, http.StatusInternalServerError, agErr.StatusCode)
+		require.Equal(t, "changes backend exploded", agErr.Message)
+	})
+
+}
+
+func TestInitAccessChangesFlags(t *testing.T) {
+
+	parse := func(t *testing.T, argv ...string) (accessChangesArgs, error) {
+		t.Helper()
+		app := kingpin.New("tctl-test", "")
+		c := &AccessGraphCommand{}
+		c.initAccessChanges(app)
+		_, err := app.Parse(argv)
+		return c.accessChanges, err
+	}
+
+	t.Run("ls defaults", func(t *testing.T) {
+		got, err := parse(t, "access-changes", "ls")
+		require.NoError(t, err)
+		require.Equal(t, teleport.Text, got.format)
+		require.Equal(t, 100, got.ls.limit)
+		require.Empty(t, got.ls.search)
+		require.Empty(t, got.ls.filters)
+	})
+
+	t.Run("ls collects repeated --filter flags in order", func(t *testing.T) {
+		got, err := parse(t, "access-changes", "ls",
+			"--search", "prod",
+			"--filter", "kind=resource,source=AWS",
+			"--filter", "type=teleport_user",
+			"--limit", "250",
+		)
+		require.NoError(t, err)
+		require.Equal(t, "prod", got.ls.search)
+		require.Equal(t, []string{"kind=resource,source=AWS", "type=teleport_user"}, got.ls.filters)
+		require.Equal(t, 250, got.ls.limit)
+	})
+
+	t.Run("ls collects repeated dedicated flags in order", func(t *testing.T) {
+		got, err := parse(t, "access-changes", "ls",
+			"--type", "teleport_user",
+			"--type", "aws_s3",
+			"--kind", "identity",
+			"--source", "AWS",
+		)
+		require.NoError(t, err)
+		require.Equal(t, []string{"teleport_user", "aws_s3"}, got.ls.typ)
+		require.Equal(t, []string{"identity"}, got.ls.kind)
+		require.Equal(t, []string{"AWS"}, got.ls.source)
+	})
+
+	t.Run("ls rejects out-of-enum flag values", func(t *testing.T) {
+		_, err := parse(t, "access-changes", "ls", "--kind", "bogus")
+		require.Error(t, err)
+	})
+}
+
+func TestFetchAccessChanges(t *testing.T) {
+
+	t.Run("multi-page response walks the cursor", func(t *testing.T) {
+		cursor := "page2"
+		ag := newAccessGraphTestClient(t, newPaginatedAccessChangesHandler(t, []fetchAccessChangesPage{
+			{data: []accessgraph.AccessPathSummaryItem{accessPathSummaryItemFixture()}, nextCursor: &cursor},
+			{data: []accessgraph.AccessPathSummaryItem{accessPathSummaryItemFixture()}},
+		}))
+		got, err := fetchAccessChanges(context.Background(), ag, accessgraph.ListCrownJewelAccessPathsParams{}, 100)
+		require.NoError(t, err)
+		require.Len(t, got, 2)
+	})
+
+	t.Run("limit caps and trims across pages", func(t *testing.T) {
+		cursor := "page2"
+		page1 := []accessgraph.AccessPathSummaryItem{accessPathSummaryItemFixture(), accessPathSummaryItemFixture(), accessPathSummaryItemFixture()}
+		page2 := []accessgraph.AccessPathSummaryItem{accessPathSummaryItemFixture(), accessPathSummaryItemFixture(), accessPathSummaryItemFixture()}
+		ag := newAccessGraphTestClient(t, newPaginatedAccessChangesHandler(t, []fetchAccessChangesPage{
+			{data: page1, nextCursor: &cursor},
+			{data: page2},
+		}))
+		got, err := fetchAccessChanges(context.Background(), ag, accessgraph.ListCrownJewelAccessPathsParams{}, 4)
+		require.NoError(t, err)
+		require.Len(t, got, 4)
+	})
+
+	t.Run("limit zero disables the cap", func(t *testing.T) {
+		cursor := "page2"
+		ag := newAccessGraphTestClient(t, newPaginatedAccessChangesHandler(t, []fetchAccessChangesPage{
+			{data: []accessgraph.AccessPathSummaryItem{accessPathSummaryItemFixture(), accessPathSummaryItemFixture()}, nextCursor: &cursor},
+			{data: []accessgraph.AccessPathSummaryItem{accessPathSummaryItemFixture()}},
+		}))
+		got, err := fetchAccessChanges(context.Background(), ag, accessgraph.ListCrownJewelAccessPathsParams{}, 0)
+		require.NoError(t, err)
+		require.Len(t, got, 3)
+	})
+
+	t.Run("non-advancing cursor breaks the loop", func(t *testing.T) {
+		var calls atomic.Int64
+		// Always returns the same non-nil cursor regardless of input.
+		handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			calls.Add(1)
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"data":        []accessgraph.AccessPathSummaryItem{accessPathSummaryItemFixture()},
+				"next_cursor": "stuck",
+			})
+		})
+		ag := newAccessGraphTestClient(t, handler)
+		got, err := fetchAccessChanges(context.Background(), ag, accessgraph.ListCrownJewelAccessPathsParams{}, 0)
+		require.NoError(t, err)
+		require.Len(t, got, 1, "should not return items collected before the loop broke")
+		require.EqualValues(t, 2, calls.Load(), "loop must stop on the first non-advancing cursor")
+	})
+}
+
+func TestConstructAccessChangesListQuery(t *testing.T) {
+
+	t.Run("no filters leaves TypeFilter and Search nil", func(t *testing.T) {
+		params, err := constructAccessChangesListQuery(accessChangesArgs{})
+		require.NoError(t, err)
+		require.Nil(t, params.TypeFilter)
+		require.Nil(t, params.Search)
+	})
+
+	t.Run("single key populates only that axis in the envelope", func(t *testing.T) {
+		args := accessChangesArgs{}
+		args.ls.filters = []string{"kind=resource"}
+		params, err := constructAccessChangesListQuery(args)
+		require.NoError(t, err)
+		require.NotNil(t, params.TypeFilter)
+
+		var filters []accessChangeTypeFilter
+		require.NoError(t, json.Unmarshal([]byte(*params.TypeFilter), &filters))
+		require.Len(t, filters, 1)
+		require.NotNil(t, filters[0].Kind)
+		require.Equal(t, "resource", *filters[0].Kind)
+		// Unset axes drop out of the JSON envelope (omitempty + nil pointers).
+		require.Nil(t, filters[0].OriginType)
+		require.Nil(t, filters[0].Source)
+
+		// Pin the JSON shape too — use the "key": form to avoid matching
+		// "resource" as a substring of "source".
+		require.NotContains(t, *params.TypeFilter, `"type":`)
+		require.NotContains(t, *params.TypeFilter, `"source":`)
+	})
+
+	t.Run("kind and source AND into one envelope", func(t *testing.T) {
+		args := accessChangesArgs{}
+		args.ls.filters = []string{"kind=resource,source=TELEPORT"}
+		params, err := constructAccessChangesListQuery(args)
+		require.NoError(t, err)
+		require.NotNil(t, params.TypeFilter)
+
+		var filters []accessChangeTypeFilter
+		require.NoError(t, json.Unmarshal([]byte(*params.TypeFilter), &filters))
+		require.Len(t, filters, 1)
+		require.Equal(t, "resource", *filters[0].Kind)
+		require.Equal(t, "TELEPORT", *filters[0].Source)
+		require.Nil(t, filters[0].OriginType)
+	})
+
+	t.Run("repeated filters OR into separate envelopes in order", func(t *testing.T) {
+		args := accessChangesArgs{}
+		args.ls.filters = []string{"type=teleport_bot", "kind=resource,source=AWS"}
+		params, err := constructAccessChangesListQuery(args)
+		require.NoError(t, err)
+		require.NotNil(t, params.TypeFilter)
+
+		var filters []accessChangeTypeFilter
+		require.NoError(t, json.Unmarshal([]byte(*params.TypeFilter), &filters))
+		require.Len(t, filters, 2)
+		require.Equal(t, "teleport_bot", *filters[0].OriginType)
+		require.Equal(t, "resource", *filters[1].Kind)
+		require.Equal(t, "AWS", *filters[1].Source)
+	})
+
+	t.Run("dedicated --type produces a single origin_type envelope", func(t *testing.T) {
+		args := accessChangesArgs{}
+		args.ls.typ = []string{"teleport_database"}
+		params, err := constructAccessChangesListQuery(args)
+		require.NoError(t, err)
+		require.NotNil(t, params.TypeFilter)
+
+		var filters []accessChangeTypeFilter
+		require.NoError(t, json.Unmarshal([]byte(*params.TypeFilter), &filters))
+		require.Len(t, filters, 1)
+		require.Equal(t, "teleport_database", *filters[0].OriginType)
+		require.Nil(t, filters[0].Kind)
+		require.Nil(t, filters[0].Source)
+	})
+
+	t.Run("dedicated --kind and --source never combine into one envelope", func(t *testing.T) {
+		args := accessChangesArgs{}
+		args.ls.kind = []string{"identity"}
+		args.ls.source = []string{"AWS"}
+		params, err := constructAccessChangesListQuery(args)
+		require.NoError(t, err)
+		require.NotNil(t, params.TypeFilter)
+
+		var filters []accessChangeTypeFilter
+		require.NoError(t, json.Unmarshal([]byte(*params.TypeFilter), &filters))
+		require.Len(t, filters, 2)
+		// Assembly order places kind envelopes before source envelopes.
+		require.Equal(t, "identity", *filters[0].Kind)
+		require.Nil(t, filters[0].Source)
+		require.Equal(t, "AWS", *filters[1].Source)
+		require.Nil(t, filters[1].Kind)
+	})
+
+	t.Run("repeated dedicated --type flags OR into separate envelopes", func(t *testing.T) {
+		args := accessChangesArgs{}
+		args.ls.typ = []string{"teleport_user", "aws_s3"}
+		params, err := constructAccessChangesListQuery(args)
+		require.NoError(t, err)
+
+		var filters []accessChangeTypeFilter
+		require.NoError(t, json.Unmarshal([]byte(*params.TypeFilter), &filters))
+		require.Len(t, filters, 2)
+		require.Equal(t, "teleport_user", *filters[0].OriginType)
+		require.Equal(t, "aws_s3", *filters[1].OriginType)
+	})
+
+	t.Run("mixed --filter and dedicated flags assemble filters, type, kind, source", func(t *testing.T) {
+		args := accessChangesArgs{}
+		args.ls.filters = []string{"kind=resource,source=AWS"}
+		args.ls.typ = []string{"teleport_user"}
+		args.ls.kind = []string{"identity"}
+		args.ls.source = []string{"Okta"}
+		params, err := constructAccessChangesListQuery(args)
+		require.NoError(t, err)
+
+		var filters []accessChangeTypeFilter
+		require.NoError(t, json.Unmarshal([]byte(*params.TypeFilter), &filters))
+		require.Len(t, filters, 4)
+		// 0: the --filter envelope (AND'd pair).
+		require.Equal(t, "resource", *filters[0].Kind)
+		require.Equal(t, "AWS", *filters[0].Source)
+		// 1: --type, 2: --kind, 3: --source.
+		require.Equal(t, "teleport_user", *filters[1].OriginType)
+		require.Equal(t, "identity", *filters[2].Kind)
+		require.Equal(t, "Okta", *filters[3].Source)
+	})
+
+	t.Run("invalid filters surface BadParameter", func(t *testing.T) {
+		for _, tc := range []struct {
+			name   string
+			filter string
+		}{
+			{"unknown key", "color=blue"},
+			{"missing value", "kind="},
+			{"missing key", "=resource"},
+			{"no equals", "resource"},
+			{"invalid type value", "type=not_a_type"},
+			{"invalid kind value", "kind=bogus"},
+			{"invalid source value", "source=NotReal"},
+			{"trailing comma", "kind=resource,"},
+			{"leading comma", ",kind=resource"},
+			{"empty segment", "kind=resource,,source=AWS"},
+			{"duplicate key", "kind=resource,kind=identity"},
+		} {
+			t.Run(tc.name, func(t *testing.T) {
+				args := accessChangesArgs{}
+				args.ls.filters = []string{tc.filter}
+				_, err := constructAccessChangesListQuery(args)
+				require.True(t, trace.IsBadParameter(err), "want BadParameter, got %v", err)
+			})
+		}
+	})
+}

--- a/tool/tctl/common/accessgraph/command.go
+++ b/tool/tctl/common/accessgraph/command.go
@@ -40,8 +40,9 @@ type AccessGraphCommand struct {
 	config *servicecfg.Config
 	stdout io.Writer
 
-	detections  detectionsArgs
-	investigate investigateArgs
+	detections    detectionsArgs
+	investigate   investigateArgs
+	accessChanges accessChangesArgs
 }
 
 // Initialize allows AccessGraphCommand to plug itself into the CLI parser.
@@ -55,6 +56,7 @@ func (c *AccessGraphCommand) Initialize(app *kingpin.Application, cliFlags *tctl
 	// Initialize AG subcommands.
 	c.initDetections(app)
 	c.initInvestigate(app)
+	c.initAccessChanges(app)
 }
 
 // TryRun takes the CLI command as an argument and executes it.
@@ -74,6 +76,8 @@ func (c *AccessGraphCommand) TryRun(ctx context.Context, cmd string, clientFunc 
 		commandFunc = c.DetectionsGet
 	case c.investigate.cmd.FullCommand():
 		commandFunc = c.Investigate
+	case c.accessChanges.ls.cmd.FullCommand():
+		commandFunc = c.AccessChangesList
 	default:
 		return false, nil
 	}

--- a/tool/tctl/common/accessgraph/detections_command.go
+++ b/tool/tctl/common/accessgraph/detections_command.go
@@ -71,7 +71,7 @@ type detectionsListArgs struct {
 }
 
 func (c *AccessGraphCommand) initDetections(app *kingpin.Application) {
-	detectionsCmd := app.Command("detections", "Investigate security detections and anomalies.").Hidden()
+	detectionsCmd := app.Command("detections", "Investigate security detections and anomalies.")
 	detectionsCmd.Flag("from", fmt.Sprintf("Include activity at or after this time. (Examples: %s, %s, 24h, 7d; negative durations like -1h are future-relative. Default: 30d)", time.RFC3339, time.DateOnly)).
 		Default("30d").
 		SetValue(timeValue{target: &c.detections.from})


### PR DESCRIPTION
Issue: https://github.com/gravitational/access-graph/issues/1933

This PR adds a `tctl access-changes ls` command for inspecting how access paths to your crown jewels change over time, talking directly to Access Graph through the web proxy.

It's part of a small `tctl access-changes` stack.

| #   | PR                                  | What it does                                                    |
| --- | ----------------------------------- | --------------------------------------------------------------- |
| 1   | **Access Changes List (this PR)**   | `tctl accesss-changes ls` — view/filter search access changes   |
| 2   | [Access Changes Get](https://github.com/gravitational/teleport/pull/67329) | `tctl access-changes get` - view details about an access change |

## What changed

- Adds `tctl access-changes ls` — lists access-path changes to crown jewels with `--search`, `--kind`, `--type`, `--source` and `--filter` filters, cursor-based pagination, a `--limit` cap, and text/json/yaml output.
- Un-hides the `tctl detections` command (the `.Hidden()` was landed by mistake).

## Why

This is part of the work related to [access-graph#1933](https://github.com/gravitational/access-graph/issues/1933), which adds `tctl` commands that talk directly to Access Graph through the web proxy. Crown-jewel access-change monitoring lets operators see, from the CLI, how access to sensitive resources has shifted — which identities/resources/edges were added or removed — without leaving the terminal.

A few decisions worth flagging:

- **Typed Filters** `--kind`/`--type`/`--source`/`--filter` are enum backed, this is to match the Web UI which gives a subset of all possible filters so they are more targetted for crown-jewels

Changelog: Added the `tctl access-changes ls` command to list access-path changes to crown jewels.

## Manual Test Plan

### Test Environment

- Local dev cluster (current `teleport` branch + local Access Graph).

### Test Cases

- [X] Default `tctl access-changes ls` renders the text table (Change ID, Kind, Name, Source, Origin Type, Alias, Created At); `--format json`/`yaml` render correctly.
- [X] Filters narrow results: `--search`, `--kind`, `--type`, `--source`, `--filter` shape the request as expected, and `--limit N` caps the returned rows across paginated pages.
- [X] `tctl detections` is now visible in `tctl --help` (no longer hidden).