### PR TITLE
 access-changes[2]: Add `tctl access-changes get` command

### DIFF
--- a/docs/pages/reference/cli/tctl.mdx
+++ b/docs/pages/reference/cli/tctl.mdx
@@ -45,6 +45,22 @@ Global environment variables:
 |`TELEPORT_IDENTITY_FILE`|*no default*|Path to an identity file. Must be provided to make remote connections to auth. An identity file can be exported with 'tctl auth sign'|
 |`TELEPORT_MFA_MODE`|`auto` (one of: `auto`, `cross-platform`, `platform`, `sso`, `browser`)|Preferred mode for MFA assertions.|
 
+## tctl access-changes get
+
+Get details about an access path change
+
+Usage:
+
+```code
+$ tctl access-changes get <change-id>
+```
+
+Arguments:
+
+|Argument|Default|Description|
+|---|---|---|
+|change-id|*no default* (required)|The ID of the access path change to retrieve.|
+
 ## tctl access-changes ls
 
 List access path changes for your crown jewels

--- a/tool/tctl/common/accessgraph/access_changes_command.go
+++ b/tool/tctl/common/accessgraph/access_changes_command.go
@@ -33,12 +33,15 @@ import (
 
 	"github.com/gravitational/teleport"
 	accessgraph "github.com/gravitational/teleport/lib/accessgraph/apiclient"
+	graphmodels "github.com/gravitational/teleport/lib/accessgraph/apiclient/models/graph"
+	diffmodels "github.com/gravitational/teleport/lib/accessgraph/apiclient/models/jsondiff"
 	"github.com/gravitational/teleport/lib/asciitable"
 )
 
 type accessChangesArgs struct {
 	cmd    *kingpin.CmdClause
 	ls     accessChangesListArgs
+	get    accessChangesGetArgs
 	format string
 }
 
@@ -58,6 +61,11 @@ type accessChangesListArgs struct {
 	limit int
 }
 
+type accessChangesGetArgs struct {
+	cmd      *kingpin.CmdClause
+	changeID string
+}
+
 func (c *AccessGraphCommand) initAccessChanges(app *kingpin.Application) {
 	accessChangesCmd := app.Command("access-changes", "Monitor access path changes to crown jewels.")
 	accessChangesCmd.Flag("format", "Output format. (Values: text, json, yaml)").
@@ -65,6 +73,7 @@ func (c *AccessGraphCommand) initAccessChanges(app *kingpin.Application) {
 		EnumVar(&c.accessChanges.format, teleport.Text, teleport.JSON, teleport.YAML)
 	c.accessChanges.cmd = accessChangesCmd
 	c.initAccessChangesList(c.accessChanges.cmd)
+	c.initAccessChangesGet(c.accessChanges.cmd)
 }
 
 func (c *AccessGraphCommand) initAccessChangesList(parent *kingpin.CmdClause) {
@@ -86,6 +95,26 @@ func (c *AccessGraphCommand) initAccessChangesList(parent *kingpin.CmdClause) {
 		IntVar(&c.accessChanges.ls.limit)
 
 	c.accessChanges.ls.cmd = lsCmd
+}
+
+func (c *AccessGraphCommand) initAccessChangesGet(parent *kingpin.CmdClause) {
+	getCmd := parent.Command("get", "Get details about an access path change")
+
+	getCmd.Arg("change-id", "The ID of the access path change to retrieve.").Required().StringVar(&c.accessChanges.get.changeID)
+
+	c.accessChanges.get.cmd = getCmd
+}
+
+// AccessChangesGet executes `tctl access-changes get <change-id>`.
+func (c *AccessGraphCommand) AccessChangesGet(ctx context.Context, client *accessgraph.ClientWithResponses) error {
+	resp, err := doRequest(client.GetCrownJewelAccessPathsWithResponse(ctx, c.accessChanges.get.changeID))
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	if resp.JSON200 == nil {
+		return trace.Errorf("received nil json response from Access Graph API")
+	}
+	return displayAccessChange(c.stdout, resp.JSON200, c.accessChanges.format)
 }
 
 // AccessChangesList executes `tctl access-changes ls`.
@@ -276,4 +305,201 @@ func displayAccessChangesText(out io.Writer, changes []accessgraph.AccessPathSum
 	}
 	_, err := fmt.Fprintln(out, table.AsBuffer().String())
 	return trace.Wrap(err)
+}
+
+func displayAccessChange(out io.Writer, change *accessgraph.AccessPathDiff, format string) error {
+	return writeOutput(out, change, format, func(w io.Writer) error {
+		return displayAccessChangeText(w, change)
+	})
+}
+
+func displayAccessChangeText(out io.Writer, change *accessgraph.AccessPathDiff) error {
+	fmt.Fprintf(out, "Change ID: %s\n\n", change.ChangeId)
+
+	fmt.Fprintln(out, "Affected Node:")
+	nodeTable := asciitable.MakeTable([]string{"ID", "Kind", "Name", "Source", "Origin Type", "Alias"})
+	nodeTable.AddRow([]string{
+		change.AffectedNode.Id.String(),
+		change.AffectedNode.Kind,
+		change.AffectedNode.Name,
+		change.AffectedNode.Source,
+		change.AffectedNode.OriginType,
+		change.AffectedNode.Alias,
+	})
+	fmt.Fprintln(out, nodeTable.AsBuffer().String())
+
+	if len(change.Diff) == 0 {
+		_, err := fmt.Fprintln(out, "No changes.")
+		return trace.Wrap(err)
+	}
+
+	// Fold diff additions into the base lookups so an edge pointing at a
+	// newly-added node resolves to its name, not a raw UUID.
+	baseNodes, baseEdges := buildBaseLookups(change.Base)
+	baseNodes, baseEdges = addDiffAdditionsToLookups(change.Diff, baseNodes, baseEdges)
+
+	// Sort nodes before edges; clone first to avoid mutating the caller's slice.
+	ops := slices.Clone(change.Diff)
+	slices.SortStableFunc(ops, func(a, b diffmodels.Operation) int {
+		typeA := diffEntityType(strPtrToStr(a.Path))
+		typeB := diffEntityType(strPtrToStr(b.Path))
+		if typeA == typeB {
+			return 0
+		}
+		if typeA == "node" {
+			return -1
+		}
+		return 1
+	})
+
+	fmt.Fprintf(out, "Changes (%d):\n", len(ops))
+	var rows [][]string
+	for _, op := range ops {
+		path := strPtrToStr(op.Path)
+		entityType := diffEntityType(path)
+		id := diffEntityID(path)
+
+		var name, kind, originType string
+		if op.Value != nil && *op.Value != nil {
+			// Op carries a payload (add/replace) — decode into the typed entity for this path prefix.
+			switch entityType {
+			case "node":
+				var n accessgraph.GenericNode
+				if err := remarshal(*op.Value, &n); err == nil {
+					name, kind, originType = nodeLabel(n), n.Kind, n.OriginType
+				}
+			case "edge":
+				var e graphmodels.Edge
+				if err := remarshal(*op.Value, &e); err == nil {
+					name, kind = edgeLabel(e, baseNodes), e.EdgeType
+				}
+			}
+		} else {
+			// remove: no payload — resolve entity from the pre-change base graph.
+			switch entityType {
+			case "node":
+				if n, ok := baseNodes[id]; ok {
+					name, kind, originType = nodeLabel(n), n.Kind, n.OriginType
+				}
+			case "edge":
+				if e, ok := baseEdges[id]; ok {
+					name, kind = edgeLabel(e, baseNodes), e.EdgeType
+				}
+			}
+		}
+		if name == "" {
+			name = id
+		}
+		rows = append(rows, []string{string(op.Op), entityType, name, kind, originType})
+	}
+	diffTable := asciitable.MakeTableWithTruncatedColumn([]string{"Operation", "Type", "Name", "Kind", "Origin Type"}, rows, "Name")
+	_, err := fmt.Fprintln(out, diffTable.AsBuffer().String())
+	return trace.Wrap(err)
+}
+
+// buildBaseLookups indexes the pre-change graph by UUID so removed entities (which carry no value in the diff) can be resolved.
+func buildBaseLookups(base accessgraph.GenericNodesList) (nodes map[string]accessgraph.GenericNode, edges map[string]graphmodels.Edge) {
+	if base.Nodes != nil {
+		nodes = make(map[string]accessgraph.GenericNode, len(*base.Nodes))
+		for _, n := range *base.Nodes {
+			nodes[n.Id] = n
+		}
+	}
+	if base.Edges != nil {
+		edges = make(map[string]graphmodels.Edge, len(*base.Edges))
+		for _, e := range *base.Edges {
+			edges[e.Id.String()] = e
+		}
+	}
+	return
+}
+
+// addDiffAdditionsToLookups folds nodes and edges from "add" operations into the
+// base lookups so entities added by the diff resolve like pre-change ones. The
+// maps may arrive nil. Edge payloads carry their UUID only in the path, so edges
+// are keyed by the path id.
+func addDiffAdditionsToLookups(
+	ops []diffmodels.Operation,
+	nodes map[string]accessgraph.GenericNode,
+	edges map[string]graphmodels.Edge,
+) (map[string]accessgraph.GenericNode, map[string]graphmodels.Edge) {
+	for _, op := range ops {
+		if op.Op != diffmodels.OperationOpAdd || op.Value == nil || *op.Value == nil {
+			continue
+		}
+		path := strPtrToStr(op.Path)
+		switch diffEntityType(path) {
+		case "node":
+			var n accessgraph.GenericNode
+			if err := remarshal(*op.Value, &n); err == nil {
+				if nodes == nil {
+					nodes = make(map[string]accessgraph.GenericNode)
+				}
+				nodes[n.Id] = n
+			}
+		case "edge":
+			var e graphmodels.Edge
+			if err := remarshal(*op.Value, &e); err == nil {
+				if edges == nil {
+					edges = make(map[string]graphmodels.Edge)
+				}
+				edges[diffEntityID(path)] = e
+			}
+		}
+	}
+	return nodes, edges
+}
+
+// remarshal round-trips src through JSON into dst (used to decode jsondiff Operation values into typed structs).
+func remarshal(src, dst any) error {
+	data, err := json.Marshal(src)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	return trace.Wrap(json.Unmarshal(data, dst))
+}
+
+// diffEntityType returns "node" or "edge" based on a JSON Patch path (e.g. "/nodes/<id>").
+func diffEntityType(path string) string {
+	switch {
+	case strings.HasPrefix(path, "/nodes/"):
+		return "node"
+	case strings.HasPrefix(path, "/edges/"):
+		return "edge"
+	default:
+		return ""
+	}
+}
+
+// diffEntityID extracts the UUID from a JSON Patch path (e.g. "/nodes/<id>" → "<id>").
+func diffEntityID(path string) string {
+	if idx := strings.LastIndexByte(path, '/'); idx >= 0 {
+		return path[idx+1:]
+	}
+	return path
+}
+
+// nodeLabel returns the most descriptive label for a node: alias > name > ID.
+func nodeLabel(n accessgraph.GenericNode) string {
+	switch {
+	case n.Alias != "":
+		return n.Alias
+	case n.Name != "":
+		return n.Name
+	default:
+		return n.Id
+	}
+}
+
+// edgeLabel formats an edge as "from → to" using node labels from the base graph.
+func edgeLabel(e graphmodels.Edge, nodes map[string]accessgraph.GenericNode) string {
+	fromID, toID := e.From.String(), e.To.String()
+	fromLabel, toLabel := fromID, toID
+	if n, ok := nodes[fromID]; ok {
+		fromLabel = nodeLabel(n)
+	}
+	if n, ok := nodes[toID]; ok {
+		toLabel = nodeLabel(n)
+	}
+	return fmt.Sprintf("%s → %s", fromLabel, toLabel)
 }

--- a/tool/tctl/common/accessgraph/access_changes_command_test.go
+++ b/tool/tctl/common/accessgraph/access_changes_command_test.go
@@ -35,18 +35,25 @@ import (
 
 	"github.com/gravitational/teleport"
 	accessgraph "github.com/gravitational/teleport/lib/accessgraph/apiclient"
+	graphmodels "github.com/gravitational/teleport/lib/accessgraph/apiclient/models/graph"
+	diffmodels "github.com/gravitational/teleport/lib/accessgraph/apiclient/models/jsondiff"
 )
 
 // AG-mounted paths the access-changes commands hit — kept as constants so
 // the test fails loudly if the generated client's operation paths drift.
 const (
 	listAccessChangesPath = accessGraphAPIPath + "graph/crown-jewel/access-paths"
+	getAccessChangePath   = accessGraphAPIPath + "graph/crown-jewel/access-paths/" // + <id>
 )
 
 var (
-	fixtureChangeID   = "ch-1111"
-	fixtureAffectedID = uuid.MustParse("66666666-7777-8888-9999-000000000000")
-	fixtureChangeTime = time.Date(2026, 5, 1, 9, 30, 0, 0, time.UTC)
+	fixtureChangeID    = "ch-1111"
+	fixtureChangeUUID  = uuid.MustParse("11111111-2222-3333-4444-555555555555")
+	fixtureAffectedID  = uuid.MustParse("66666666-7777-8888-9999-000000000000")
+	fixtureChangeTime  = time.Date(2026, 5, 1, 9, 30, 0, 0, time.UTC)
+	fixtureBaseNodeID1 = "aaaaaaaa-1111-1111-1111-111111111111"
+	fixtureBaseNodeID2 = "bbbbbbbb-2222-2222-2222-222222222222"
+	fixtureBaseEdgeID  = uuid.MustParse("cccccccc-3333-3333-3333-333333333333")
 )
 
 func accessPathSummaryItemFixture() accessgraph.AccessPathSummaryItem {
@@ -60,6 +67,56 @@ func accessPathSummaryItemFixture() accessgraph.AccessPathSummaryItem {
 			Source:     "Teleport",
 			OriginType: "teleport_database",
 			Alias:      "prod-db-alias",
+		},
+	}
+}
+
+// accessPathDiffFixture returns a diff that exercises both the typed-value
+// branch (add ops carry a payload) and the base-lookup branch (remove ops
+// have no payload — labels come from change.Base).
+func accessPathDiffFixture() *accessgraph.AccessPathDiff {
+	nodes := []accessgraph.GenericNode{
+		{Id: fixtureBaseNodeID1, Kind: "identity", Name: "alice", OriginType: "teleport_user"},
+		{Id: fixtureBaseNodeID2, Kind: "resource", Name: "prod-db", Alias: "prod-db-alias", OriginType: "teleport_database"},
+	}
+	edges := []graphmodels.Edge{
+		{Id: fixtureBaseEdgeID, EdgeType: "has_access", From: uuid.MustParse(fixtureBaseNodeID1), To: uuid.MustParse(fixtureBaseNodeID2)},
+	}
+
+	newNodeID := "dddddddd-4444-4444-4444-444444444444"
+	addNode := map[string]any{
+		"id":          newNodeID,
+		"kind":        "identity",
+		"name":        "bob",
+		"origin_type": "teleport_user",
+	}
+	newEdgeID := "eeeeeeee-5555-5555-5555-555555555555"
+	addEdge := map[string]any{
+		"id":        newEdgeID,
+		"edge_type": "owns",
+		"from":      fixtureBaseNodeID1,
+		"to":        fixtureBaseNodeID2,
+	}
+
+	strRef := func(s string) *string { return &s }
+	anyRef := func(v any) *any { return &v }
+
+	return &accessgraph.AccessPathDiff{
+		ChangeId: fixtureChangeUUID,
+		AffectedNode: accessgraph.AccessPathSummaryItemNode{
+			Id:         fixtureAffectedID,
+			Kind:       "resource",
+			Name:       "prod-db",
+			Source:     "Teleport",
+			OriginType: "teleport_database",
+			Alias:      "prod-db-alias",
+		},
+		Base: accessgraph.GenericNodesList{Nodes: &nodes, Edges: &edges},
+		Diff: []diffmodels.Operation{
+			{Op: diffmodels.OperationOpAdd, Path: strRef("/nodes/" + newNodeID), Value: anyRef(addNode)},
+			{Op: diffmodels.OperationOpAdd, Path: strRef("/edges/" + newEdgeID), Value: anyRef(addEdge)},
+			{Op: diffmodels.OperationOpRemove, Path: strRef("/nodes/" + fixtureBaseNodeID1)},
+			{Op: diffmodels.OperationOpRemove, Path: strRef("/edges/" + fixtureBaseEdgeID.String())},
 		},
 	}
 }
@@ -113,6 +170,22 @@ func newPaginatedAccessChangesHandler(t *testing.T, pages []fetchAccessChangesPa
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 		_ = json.NewEncoder(w).Encode(body)
+	})
+}
+
+func newGetAccessChangeHandler(t *testing.T, id string, diff *accessgraph.AccessPathDiff, statusCode int, errBody string) http.Handler {
+	t.Helper()
+	wantPath := getAccessChangePath + id
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, wantPath, r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		if statusCode != 0 && statusCode != http.StatusOK {
+			w.WriteHeader(statusCode)
+			_, _ = w.Write([]byte(errBody))
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(diff)
 	})
 }
 
@@ -204,6 +277,94 @@ func TestAccessChangesList(t *testing.T) {
 
 }
 
+func TestAccessChangesGet(t *testing.T) {
+
+	t.Run("text format renders the affected node, diff count, and node-before-edge ordering", func(t *testing.T) {
+		diff := accessPathDiffFixture()
+		ag := newAccessGraphTestClient(t, newGetAccessChangeHandler(t, fixtureChangeID, diff, 0, ""))
+
+		c, buf := newAccessChangesCommand(t, teleport.Text)
+		c.accessChanges.get.changeID = fixtureChangeID
+		require.NoError(t, c.AccessChangesGet(context.Background(), ag))
+
+		out := buf.String()
+
+		require.Contains(t, out, "Change ID: "+fixtureChangeUUID.String())
+		require.Contains(t, out, "Affected Node:")
+		require.Contains(t, out, "prod-db-alias")
+		require.Contains(t, out, "Changes (4):")
+
+		// nodeLabel resolves both add (typed payload → "bob") and remove
+		// (base lookup → "alice").
+		require.Contains(t, out, "bob")
+		require.Contains(t, out, "alice")
+		// edgeLabel "from → to" uses base-node labels.
+		require.Contains(t, out, "alice → prod-db-alias")
+
+		// Sort places nodes before edges; verify the first node row
+		// precedes the first edge row in the rendered output.
+		nodeIdx := bytes.Index(buf.Bytes(), []byte("bob"))
+		edgeIdx := bytes.Index(buf.Bytes(), []byte("alice → prod-db-alias"))
+		require.Less(t, nodeIdx, edgeIdx, "node rows must render before edge rows")
+	})
+
+	t.Run("edge to a newly-added node resolves the added node's name", func(t *testing.T) {
+		strRef := func(s string) *string { return &s }
+		anyRef := func(v any) *any { return &v }
+		// The edge "add" payload mirrors the real API shape: UUID only in the
+		// path, no "id" in the value body.
+
+		baseNodeID := "aaaaaaaa-1111-1111-1111-111111111111"
+		addedNodeID := "970da4d2-e6e2-4b61-a73e-979ff35cca64"
+		addedEdgeID := "1f99da7c-04b6-5ca1-a75c-f7b7b49bbd5b"
+
+		baseNodes := []accessgraph.GenericNode{
+			{Id: baseNodeID, Kind: "identity", Name: "alice", OriginType: "teleport_user"},
+		}
+		diff := &accessgraph.AccessPathDiff{
+			ChangeId:     fixtureChangeUUID,
+			AffectedNode: accessgraph.AccessPathSummaryItemNode{Id: fixtureAffectedID, Kind: "resource", Name: "prod-db"},
+			Base:         accessgraph.GenericNodesList{Nodes: &baseNodes},
+			Diff: []diffmodels.Operation{
+				{Op: diffmodels.OperationOpAdd, Path: strRef("/edges/" + addedEdgeID), Value: anyRef(map[string]any{
+					"from": baseNodeID, "to": addedNodeID, "kind": "access", "properties": map[string]any{},
+				})},
+				{Op: diffmodels.OperationOpAdd, Path: strRef("/nodes/" + addedNodeID), Value: anyRef(map[string]any{
+					"id": addedNodeID, "kind": "resource", "name": "excalidraw",
+					"origin_type": "teleport_application", "source": "TELEPORT", "sub_kind": "app",
+				})},
+			},
+		}
+		ag := newAccessGraphTestClient(t, newGetAccessChangeHandler(t, fixtureChangeID, diff, 0, ""))
+
+		c, buf := newAccessChangesCommand(t, teleport.Text)
+		c.accessChanges.get.changeID = fixtureChangeID
+		require.NoError(t, c.AccessChangesGet(context.Background(), ag))
+
+		require.Contains(t, buf.String(), "alice → excalidraw")
+		require.NotContains(t, buf.String(), addedNodeID)
+	})
+
+	t.Run("text format with empty diff prints 'No changes.'", func(t *testing.T) {
+		diff := &accessgraph.AccessPathDiff{
+			ChangeId: fixtureChangeUUID,
+			AffectedNode: accessgraph.AccessPathSummaryItemNode{
+				Id: fixtureAffectedID, Kind: "resource", Name: "prod-db",
+			},
+		}
+		ag := newAccessGraphTestClient(t, newGetAccessChangeHandler(t, fixtureChangeID, diff, 0, ""))
+
+		c, buf := newAccessChangesCommand(t, teleport.Text)
+		c.accessChanges.get.changeID = fixtureChangeID
+		require.NoError(t, c.AccessChangesGet(context.Background(), ag))
+
+		out := buf.String()
+		require.Contains(t, out, "Affected Node:")
+		require.Contains(t, out, "No changes.")
+		require.NotContains(t, out, "Changes (")
+	})
+}
+
 func TestInitAccessChangesFlags(t *testing.T) {
 
 	parse := func(t *testing.T, argv ...string) (accessChangesArgs, error) {
@@ -252,6 +413,11 @@ func TestInitAccessChangesFlags(t *testing.T) {
 
 	t.Run("ls rejects out-of-enum flag values", func(t *testing.T) {
 		_, err := parse(t, "access-changes", "ls", "--kind", "bogus")
+		require.Error(t, err)
+	})
+
+	t.Run("get requires change-id positional", func(t *testing.T) {
+		_, err := parse(t, "access-changes", "get")
 		require.Error(t, err)
 	})
 }

--- a/tool/tctl/common/accessgraph/command.go
+++ b/tool/tctl/common/accessgraph/command.go
@@ -78,6 +78,8 @@ func (c *AccessGraphCommand) TryRun(ctx context.Context, cmd string, clientFunc 
 		commandFunc = c.Investigate
 	case c.accessChanges.ls.cmd.FullCommand():
 		commandFunc = c.AccessChangesList
+	case c.accessChanges.get.cmd.FullCommand():
+		commandFunc = c.AccessChangesGet
 	default:
 		return false, nil
 	}


### PR DESCRIPTION
Issue: https://github.com/gravitational/access-graph/issues/1933

This PR adds a `tctl access-changes get` to retrieve details for access paths changes to your crown jewels.

It's part of a small `tctl access-changes` stack.

| #   | PR                                   | What it does                                                    |
| --- | ------------------------------------ | --------------------------------------------------------------- |
| 1   | [Access Changes List](https://github.com/gravitational/teleport/pull/67328) | `tctl accesss-changes ls` — view/filter search access changes   |
| 2   | **Access Changes Get (this PR)**     | `tctl access-changes get` - view details about an access change |

## What changed

- Adds `tctl access-changes get <change-id>` — renders a single change: the affected node plus its diff (a JSON-Patch over graph nodes/edges), sorted nodes-before-edges, with labels resolved from the pre-change base graph for removals that carry no payload.

## Why

This is part of the work related to [access-graph#1933](https://github.com/gravitational/access-graph/issues/1933), which adds `tctl` commands that talk directly to Access Graph through the web proxy. Crown-jewel access-change monitoring lets operators see, from the CLI, how access to sensitive resources has shifted — which identities/resources/edges were added or removed — without leaving the terminal.

Changelog: Added the `tctl access-changes get` command view details about access path changes.

## Manual Test Plan

### Test Environment

- Local dev cluster (current `teleport` branch + local Access Graph).

### Test Cases

- [X] `tctl access-changes get <change-id>` renders the affected node and the diff table (add/replace/remove rows, nodes before edges), with labels resolved from the base graph; a change with an empty diff prints "No changes."
- [X] `tctl access-changes get` defaults to `text` output, and `yaml/json` work as expected. 
- [X] `tctl access-changes get` shows the expected list of changes, and uses human friendly names where possible.