### PR TITLE
contain client tools update archive entries to extractDir

### DIFF
--- a/lib/utils/packaging/unarchive.go
+++ b/lib/utils/packaging/unarchive.go
@@ -124,6 +124,11 @@ func replaceZip(archivePath string, extractDir string, execNames []string) (map[
 			defer file.Close()
 
 			dest := filepath.Join(extractDir, zipFile.Name)
+			// Ensure the entry resolves inside extractDir, otherwise a crafted
+			// archive could escape it with a name like "../../foo".
+			if !strings.HasPrefix(dest, filepath.Clean(extractDir)+string(os.PathSeparator)) {
+				return trace.BadParameter("%s: illegal file path", zipFile.Name)
+			}
 			// Preserve the archive directory structure.
 			if err := os.MkdirAll(filepath.Dir(dest), directoryPerm); err != nil {
 				return trace.Wrap(err)

--- a/lib/utils/packaging/unarchive_unix.go
+++ b/lib/utils/packaging/unarchive_unix.go
@@ -30,6 +30,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"slices"
+	"strings"
 
 	"github.com/gravitational/trace"
 
@@ -87,6 +88,11 @@ func replaceTarGz(archivePath string, extractDir string, execNames []string) (ma
 
 		if err = func(header *tar.Header) error {
 			dest := filepath.Join(extractDir, header.Name)
+			// Ensure the entry resolves inside extractDir, otherwise a crafted
+			// archive could escape it with a name like "../../foo".
+			if !strings.HasPrefix(dest, filepath.Clean(extractDir)+string(os.PathSeparator)) {
+				return trace.BadParameter("%s: illegal file path", header.Name)
+			}
 			// Preserve the archive directory structure.
 			if err := os.MkdirAll(filepath.Dir(dest), directoryPerm); err != nil {
 				return trace.Wrap(err)


### PR DESCRIPTION
Noticed replaceTarGz and replaceZip extract entries with filepath.Join(extractDir, header.Name) and never check the result stays under extractDir, so an entry named ../../foo/tsh writes outside it. The archive hash is fetched from the same server as the archive, so it only guards integrity, not a malicious or MITM'd CDN. Added the same containment check utils.Extract already uses in sanitizeTarPath.