### PR TITLE
[v18] Add Display Values to the Web UI User Response

### DIFF
--- a/lib/web/ui/user.go
+++ b/lib/web/ui/user.go
@@ -40,6 +40,10 @@ type UserListEntry struct {
 	Origin string `json:"origin"`
 	// IsBot is true if the user is a Bot User.
 	IsBot bool `json:"isBot"`
+	// DisplayPrimary is a display name when distinct from the username. May be empty.
+	DisplayPrimary string `json:"displayPrimary"`
+	// DisplaySecondary is extra context (usually email) when distinct from the username. May be empty.
+	DisplaySecondary string `json:"displaySecondary"`
 }
 
 type userTraits struct {
@@ -87,13 +91,17 @@ func NewUserListEntry(teleUser types.User) (*UserListEntry, error) {
 		}
 	}
 
+	display := teleUser.GetDisplay()
+
 	return &UserListEntry{
-		Name:      teleUser.GetName(),
-		Roles:     teleUser.GetRoles(),
-		AuthType:  authType,
-		Origin:    teleUser.Origin(),
-		AllTraits: teleUser.GetTraits(),
-		IsBot:     teleUser.IsBot(),
+		Name:             teleUser.GetName(),
+		Roles:            teleUser.GetRoles(),
+		AuthType:         authType,
+		Origin:           teleUser.Origin(),
+		AllTraits:        teleUser.GetTraits(),
+		IsBot:            teleUser.IsBot(),
+		DisplayPrimary:   display.Primary,
+		DisplaySecondary: display.Secondary,
 	}, nil
 }
 

--- a/lib/web/ui/user_test.go
+++ b/lib/web/ui/user_test.go
@@ -84,6 +84,32 @@ func TestNewUserListEntry(t *testing.T) {
 				AuthType: unknownSSOAuthType,
 			},
 		},
+		{
+			name: "display values populated from traits",
+			user: &types.UserV2{
+				Metadata: types.Metadata{
+					Name: "alice",
+				},
+				Spec: types.UserSpecV2{
+					Roles: []string{"access"},
+					Traits: map[string][]string{
+						"displayName": {"Alice Anderson"},
+						"email":       {"alice@example.com"},
+					},
+				},
+			},
+			want: &UserListEntry{
+				Name:     "alice",
+				Roles:    []string{"access"},
+				AuthType: "local",
+				AllTraits: map[string][]string{
+					"displayName": {"Alice Anderson"},
+					"email":       {"alice@example.com"},
+				},
+				DisplayPrimary:   "Alice Anderson",
+				DisplaySecondary: "alice@example.com",
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -96,4 +122,42 @@ func TestNewUserListEntry(t *testing.T) {
 		})
 	}
 
+}
+
+// ui.User embeds UserListEntry, so the detail response carries display values too.
+func TestNewUserDisplayValues(t *testing.T) {
+	t.Run("populated", func(t *testing.T) {
+		teleUser := &types.UserV2{
+			Metadata: types.Metadata{Name: "alice"},
+			Spec: types.UserSpecV2{
+				Traits: map[string][]string{
+					"displayName": {"Alice Anderson"},
+					"email":       {"alice@example.com"},
+				},
+			},
+		}
+
+		got, err := NewUser(teleUser)
+		require.NoError(t, err)
+		require.Equal(t, "alice", got.Name)
+		require.Equal(t, "Alice Anderson", got.DisplayPrimary)
+		require.Equal(t, "alice@example.com", got.DisplaySecondary)
+	})
+
+	t.Run("empty when no display traits", func(t *testing.T) {
+		teleUser := &types.UserV2{
+			Metadata: types.Metadata{Name: "bob"},
+			Spec: types.UserSpecV2{
+				Traits: map[string][]string{
+					"logins": {"bob"},
+				},
+			},
+		}
+
+		got, err := NewUser(teleUser)
+		require.NoError(t, err)
+		require.Equal(t, "bob", got.Name)
+		require.Empty(t, got.DisplayPrimary)
+		require.Empty(t, got.DisplaySecondary)
+	})
 }

--- a/lib/web/ui/user_test.go
+++ b/lib/web/ui/user_test.go
@@ -110,6 +110,76 @@ func TestNewUserListEntry(t *testing.T) {
 				DisplaySecondary: "alice@example.com",
 			},
 		},
+		{
+			name: "empty display traits yield no display values",
+			user: &types.UserV2{
+				Metadata: types.Metadata{
+					Name: "alice",
+				},
+				Spec: types.UserSpecV2{
+					Roles: []string{"access"},
+					Traits: map[string][]string{
+						"displayName": {},
+						"email":       {},
+					},
+				},
+			},
+			want: &UserListEntry{
+				Name:     "alice",
+				Roles:    []string{"access"},
+				AuthType: "local",
+				AllTraits: map[string][]string{
+					"displayName": {},
+					"email":       {},
+				},
+			},
+		},
+		{
+			name: "only displayName populates primary",
+			user: &types.UserV2{
+				Metadata: types.Metadata{
+					Name: "alice",
+				},
+				Spec: types.UserSpecV2{
+					Roles: []string{"access"},
+					Traits: map[string][]string{
+						"displayName": {"Alice Anderson"},
+					},
+				},
+			},
+			want: &UserListEntry{
+				Name:     "alice",
+				Roles:    []string{"access"},
+				AuthType: "local",
+				AllTraits: map[string][]string{
+					"displayName": {"Alice Anderson"},
+				},
+				DisplayPrimary: "Alice Anderson",
+			},
+		},
+		{
+			name: "only email populates secondary",
+			user: &types.UserV2{
+				Metadata: types.Metadata{
+					Name: "alice",
+				},
+				Spec: types.UserSpecV2{
+					Roles: []string{"access"},
+					Traits: map[string][]string{
+						"email": {"alice@example.com"},
+					},
+				},
+			},
+			want: &UserListEntry{
+				Name:     "alice",
+				Roles:    []string{"access"},
+				AuthType: "local",
+				AllTraits: map[string][]string{
+					"email": {"alice@example.com"},
+				},
+				DisplaySecondary: "alice@example.com",
+			},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Backport #67292 to branch/v18

## Manual Test Plan
### Test Environment
- a local cluster

### Test Cases

- [ ] The Web UI users API responses include the `displayPrimary` and `displaySecondary` fields
   1. Send a `GET` request to `https://localhost:3080/v2/webapi/users`
   2. Confirm each user entry in the response includes the `displayPrimary` and `displaySecondary` fields
   3. Send a `GET` request to `https://localhost:3080/webapi/users`
   4. Confirm each user entry in this response includes the `displayPrimary` and `displaySecondary` fields too