### PR TITLE
Fix data race on dynamic TAG fetchers map

### DIFF
--- a/lib/srv/discovery/access_graph_aws.go
+++ b/lib/srv/discovery/access_graph_aws.go
@@ -200,9 +200,8 @@ func (s *Server) reconcileAccessGraph(
 
 // getAllAWSSyncFetchers returns all AWS sync fetchers.
 func (s *Server) getAllAWSSyncFetchers() []*aws_sync.Fetcher {
-	allFetchers := make([]*aws_sync.Fetcher, 0, len(s.dynamicTAGAWSFetchers))
-
 	s.muDynamicTAGAWSFetchers.RLock()
+	allFetchers := make([]*aws_sync.Fetcher, 0, len(s.dynamicTAGAWSFetchers))
 	for _, fetcherSet := range s.dynamicTAGAWSFetchers {
 		allFetchers = append(allFetchers, fetcherSet...)
 	}

--- a/lib/srv/discovery/access_graph_azure.go
+++ b/lib/srv/discovery/access_graph_azure.go
@@ -196,9 +196,8 @@ func azurePush(
 
 // getAllTAGSyncAzureFetchers returns both static and dynamic TAG Azure fetchers
 func (s *Server) getAllTAGSyncAzureFetchers() []*azuresync.Fetcher {
-	allFetchers := make([]*azuresync.Fetcher, 0, len(s.dynamicTAGAzureFetchers))
-
 	s.muDynamicTAGAzureFetchers.RLock()
+	allFetchers := make([]*azuresync.Fetcher, 0, len(s.dynamicTAGAzureFetchers))
 	for _, fetcherSet := range s.dynamicTAGAzureFetchers {
 		allFetchers = append(allFetchers, fetcherSet...)
 	}

--- a/lib/srv/discovery/discovery_test.go
+++ b/lib/srv/discovery/discovery_test.go
@@ -33,7 +33,6 @@ import (
 	"strconv"
 	"strings"
 	"sync"
-	"sync/atomic"
 	"testing"
 	"testing/synctest"
 	"time"
@@ -1226,67 +1225,40 @@ func TestDiscoveryServer_getAllTAGFetchersConcurrentAccess(t *testing.T) {
 		readerCount = 4
 		writeCount  = 1_000
 	)
+
 	// Only initialize fields used by the TAG fetcher getters.
 	server := &Server{
 		dynamicTAGAWSFetchers:   make(map[string][]*awssync.Fetcher),
 		dynamicTAGAzureFetchers: make(map[string][]*azuresync.Fetcher),
 	}
-	wantAWSFetcher := &awssync.Fetcher{}
-	wantAzureFetcher := &azuresync.Fetcher{}
 
-	readersReady := make(chan bool, readerCount)
-	startReaders := make(chan struct{})
-	writerDone := make(chan struct{})
-	var observedExpected atomic.Int32
+	// Readers: exercise the real read paths until both getters observe a
+	// write, which guarantees the reads overlap the writer's mutations.
 	var wg sync.WaitGroup
 	for range readerCount {
 		wg.Go(func() {
-			readersReady <- len(server.getAllAWSSyncFetchers()) == 0 && len(server.getAllTAGSyncAzureFetchers()) == 0
-			<-startReaders
-
-			observed := false
-			for {
-				if slices.Contains(server.getAllAWSSyncFetchers(), wantAWSFetcher) &&
-					slices.Contains(server.getAllTAGSyncAzureFetchers(), wantAzureFetcher) {
-					observed = true
-				}
-				select {
-				case <-writerDone:
-					if observed {
-						observedExpected.Add(1)
-					}
-					return
-				default:
-				}
+			for len(server.getAllAWSSyncFetchers()) == 0 || len(server.getAllTAGSyncAzureFetchers()) == 0 {
 				runtime.Gosched()
 			}
 		})
 	}
 
-	for range readerCount {
-		require.True(t, <-readersReady, "reader did not observe empty dynamic TAG fetchers before writes")
-	}
-	close(startReaders)
-
-	// Keep the maps small while repeatedly changing their length to exercise both
-	// TAG fetcher getters against concurrent writes.
+	// Writer: mutate the maps under their exclusive locks, mimicking upsertDynamicMatchers/deleteDynamicFetchers
+	// adding and removing fetchers while repeatedly changing the map lengths.
 	keys := [2]string{"a", "b"}
 	for i := range writeCount {
 		server.muDynamicTAGAWSFetchers.Lock()
 		delete(server.dynamicTAGAWSFetchers, keys[(i+1)%len(keys)])
-		server.dynamicTAGAWSFetchers[keys[i%len(keys)]] = []*awssync.Fetcher{wantAWSFetcher}
+		server.dynamicTAGAWSFetchers[keys[i%len(keys)]] = []*awssync.Fetcher{{}}
 		server.muDynamicTAGAWSFetchers.Unlock()
 
 		server.muDynamicTAGAzureFetchers.Lock()
 		delete(server.dynamicTAGAzureFetchers, keys[(i+1)%len(keys)])
-		server.dynamicTAGAzureFetchers[keys[i%len(keys)]] = []*azuresync.Fetcher{wantAzureFetcher}
+		server.dynamicTAGAzureFetchers[keys[i%len(keys)]] = []*azuresync.Fetcher{{}}
 		server.muDynamicTAGAzureFetchers.Unlock()
-
-		runtime.Gosched()
 	}
-	close(writerDone)
+
 	wg.Wait()
-	require.Equal(t, int32(readerCount), observedExpected.Load())
 }
 
 // TestDiscoveryServer_dynamicMatcherGroupReassign covers the OpPut branch

--- a/lib/srv/discovery/discovery_test.go
+++ b/lib/srv/discovery/discovery_test.go
@@ -28,10 +28,12 @@ import (
 	"net/url"
 	"os"
 	"regexp"
+	"runtime"
 	"slices"
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"testing/synctest"
 	"time"
@@ -66,7 +68,7 @@ import (
 	"google.golang.org/protobuf/testing/protocmp"
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
+	k8sruntime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/fake"
 
 	"github.com/gravitational/teleport/api/client/proto"
@@ -104,6 +106,8 @@ import (
 	"github.com/gravitational/teleport/lib/services/local"
 	"github.com/gravitational/teleport/lib/srv/discovery/common"
 	"github.com/gravitational/teleport/lib/srv/discovery/fetchers"
+	awssync "github.com/gravitational/teleport/lib/srv/discovery/fetchers/aws-sync"
+	azuresync "github.com/gravitational/teleport/lib/srv/discovery/fetchers/azuresync"
 	"github.com/gravitational/teleport/lib/srv/discovery/fetchers/db"
 	"github.com/gravitational/teleport/lib/srv/server"
 	"github.com/gravitational/teleport/lib/srv/server/installstatus"
@@ -1137,8 +1141,7 @@ func (f *fakeAccessPointWithWatcher) NewWatcher(ctx context.Context, watch types
 }
 
 // This test exercises the dynamic matcher watcher and ensures that if there's a failure in the watcher,
-// it restarts and continues to pick up new Discovery Configs matchers. It also reads the TAG fetchers
-// concurrently with the watcher's upserts to catch unsynchronized map access under -race.
+// it restarts and continues to pick up new Discovery Configs matchers.
 func TestDiscoveryServer_dynamicMatcherRestart(t *testing.T) {
 	const discoveryGroup = "discovery-group"
 
@@ -1178,34 +1181,10 @@ func TestDiscoveryServer_dynamicMatcherRestart(t *testing.T) {
 		)
 		require.NoError(t, err)
 
-		// Readers read the TAG fetcher maps in a loop until dc-a is processed,
-		// which upsertDynamicMatchers records after writing those maps; this
-		// makes the reads overlap the write.
-		// Note: dc-a has no AccessGraph matchers, so the fetchers stay empty but
-		// there's still a race on the map access itself.
-		// Waiting for a non-empty result would just loop forever.
-		var wg sync.WaitGroup
-		for range 4 {
-			wg.Go(func() {
-				for {
-					_ = server.getAllAWSSyncFetchers()
-					_ = server.getAllTAGSyncAzureFetchers()
-
-					server.dynamicDiscoveryConfigMu.RLock()
-					processed := len(server.dynamicDiscoveryConfig) > 0
-					server.dynamicDiscoveryConfigMu.RUnlock()
-					if processed {
-						return
-					}
-				}
-			})
-		}
-
 		go mockAccessPoint.createDiscoveryConfig(discoveryConfigA)
 
 		// Wait until the event is processed.
 		synctest.Wait()
-		wg.Wait()
 
 		server.dynamicDiscoveryConfigMu.RLock()
 		require.Len(t, server.dynamicDiscoveryConfig, 1)
@@ -1236,6 +1215,78 @@ func TestDiscoveryServer_dynamicMatcherRestart(t *testing.T) {
 		require.Len(t, server.dynamicDiscoveryConfig, 2)
 		server.dynamicDiscoveryConfigMu.RUnlock()
 	})
+}
+
+// TestDiscoveryServer_getAllTAGFetchersConcurrentAccess verifies that TAG
+// fetcher getters can read dynamic fetcher maps while DiscoveryConfig updates
+// mutate them under the corresponding locks. Run with -race to detect unsafe
+// concurrent access.
+func TestDiscoveryServer_getAllTAGFetchersConcurrentAccess(t *testing.T) {
+	const (
+		readerCount = 4
+		writeCount  = 1_000
+	)
+	// Only initialize fields used by the TAG fetcher getters.
+	server := &Server{
+		dynamicTAGAWSFetchers:   make(map[string][]*awssync.Fetcher),
+		dynamicTAGAzureFetchers: make(map[string][]*azuresync.Fetcher),
+	}
+	wantAWSFetcher := &awssync.Fetcher{}
+	wantAzureFetcher := &azuresync.Fetcher{}
+
+	readersReady := make(chan bool, readerCount)
+	startReaders := make(chan struct{})
+	writerDone := make(chan struct{})
+	var observedExpected atomic.Int32
+	var wg sync.WaitGroup
+	for range readerCount {
+		wg.Go(func() {
+			readersReady <- len(server.getAllAWSSyncFetchers()) == 0 && len(server.getAllTAGSyncAzureFetchers()) == 0
+			<-startReaders
+
+			observed := false
+			for {
+				if slices.Contains(server.getAllAWSSyncFetchers(), wantAWSFetcher) &&
+					slices.Contains(server.getAllTAGSyncAzureFetchers(), wantAzureFetcher) {
+					observed = true
+				}
+				select {
+				case <-writerDone:
+					if observed {
+						observedExpected.Add(1)
+					}
+					return
+				default:
+				}
+				runtime.Gosched()
+			}
+		})
+	}
+
+	for range readerCount {
+		require.True(t, <-readersReady, "reader did not observe empty dynamic TAG fetchers before writes")
+	}
+	close(startReaders)
+
+	// Keep the maps small while repeatedly changing their length to exercise both
+	// TAG fetcher getters against concurrent writes.
+	keys := [2]string{"a", "b"}
+	for i := range writeCount {
+		server.muDynamicTAGAWSFetchers.Lock()
+		delete(server.dynamicTAGAWSFetchers, keys[(i+1)%len(keys)])
+		server.dynamicTAGAWSFetchers[keys[i%len(keys)]] = []*awssync.Fetcher{wantAWSFetcher}
+		server.muDynamicTAGAWSFetchers.Unlock()
+
+		server.muDynamicTAGAzureFetchers.Lock()
+		delete(server.dynamicTAGAzureFetchers, keys[(i+1)%len(keys)])
+		server.dynamicTAGAzureFetchers[keys[i%len(keys)]] = []*azuresync.Fetcher{wantAzureFetcher}
+		server.muDynamicTAGAzureFetchers.Unlock()
+
+		runtime.Gosched()
+	}
+	close(writerDone)
+	wg.Wait()
+	require.Equal(t, int32(readerCount), observedExpected.Load())
 }
 
 // TestDiscoveryServer_dynamicMatcherGroupReassign covers the OpPut branch
@@ -1567,7 +1618,7 @@ func TestDiscoveryKubeServices(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			var objects []runtime.Object
+			var objects []k8sruntime.Object
 			for _, s := range mockKubeServices {
 				objects = append(objects, s)
 			}

--- a/lib/srv/discovery/discovery_test.go
+++ b/lib/srv/discovery/discovery_test.go
@@ -1137,7 +1137,8 @@ func (f *fakeAccessPointWithWatcher) NewWatcher(ctx context.Context, watch types
 }
 
 // This test exercises the dynamic matcher watcher and ensures that if there's a failure in the watcher,
-// it restarts and continues to pick up new Discovery Configs matchers.
+// it restarts and continues to pick up new Discovery Configs matchers. It also reads the TAG fetchers
+// concurrently with the watcher's upserts to catch unsynchronized map access under -race.
 func TestDiscoveryServer_dynamicMatcherRestart(t *testing.T) {
 	const discoveryGroup = "discovery-group"
 
@@ -1177,15 +1178,25 @@ func TestDiscoveryServer_dynamicMatcherRestart(t *testing.T) {
 		)
 		require.NoError(t, err)
 
-		// Exercise the TAG fetcher read paths while the DiscoveryConfig watcher
-		// upserts dynamic fetchers. The race detector catches any map reads in
-		// getAll*Fetchers that are not protected by the dynamic fetcher locks.
+		// Readers read the TAG fetcher maps in a loop until dc-a is processed,
+		// which upsertDynamicMatchers records after writing those maps; this
+		// makes the reads overlap the write.
+		// Note: dc-a has no AccessGraph matchers, so the fetchers stay empty but
+		// there's still a race on the map access itself.
+		// Waiting for a non-empty result would just loop forever.
 		var wg sync.WaitGroup
 		for range 4 {
 			wg.Go(func() {
-				for range 1000 {
+				for {
 					_ = server.getAllAWSSyncFetchers()
 					_ = server.getAllTAGSyncAzureFetchers()
+
+					server.dynamicDiscoveryConfigMu.RLock()
+					processed := len(server.dynamicDiscoveryConfig) > 0
+					server.dynamicDiscoveryConfigMu.RUnlock()
+					if processed {
+						return
+					}
 				}
 			})
 		}

--- a/lib/srv/discovery/discovery_test.go
+++ b/lib/srv/discovery/discovery_test.go
@@ -1176,10 +1176,25 @@ func TestDiscoveryServer_dynamicMatcherRestart(t *testing.T) {
 			},
 		)
 		require.NoError(t, err)
+
+		// Exercise the TAG fetcher read paths while the DiscoveryConfig watcher
+		// upserts dynamic fetchers. The race detector catches any map reads in
+		// getAll*Fetchers that are not protected by the dynamic fetcher locks.
+		var wg sync.WaitGroup
+		for range 4 {
+			wg.Go(func() {
+				for range 1000 {
+					_ = server.getAllAWSSyncFetchers()
+					_ = server.getAllTAGSyncAzureFetchers()
+				}
+			})
+		}
+
 		go mockAccessPoint.createDiscoveryConfig(discoveryConfigA)
 
 		// Wait until the event is processed.
 		synctest.Wait()
+		wg.Wait()
 
 		server.dynamicDiscoveryConfigMu.RLock()
 		require.Len(t, server.dynamicDiscoveryConfig, 1)


### PR DESCRIPTION
The slice pre-allocation in `getAllAWSSyncFetchers` and `getAllTAGSyncAzureFetchers` read `len()` of the dynamic fetchers map outside the read lock. That map is mutated under an exclusive lock by `upsertDynamicMatchers`/`deleteDynamicFetchers` on the DiscoveryConfig watch goroutine, so the unprotected read raced with concurrent writes.