### PR TITLE
[v18] kube: reject duplicate SPDY stream types in exec/attach

### DIFF
--- a/lib/kube/proxy/remotecommand.go
+++ b/lib/kube/proxy/remotecommand.go
@@ -447,7 +447,10 @@ func (*v4ProtocolHandler) supportsTerminalResizing() bool { return true }
 func waitStreamReply(ctx context.Context, replySent <-chan struct{}, notify chan<- struct{}) {
 	select {
 	case <-replySent:
-		notify <- struct{}{}
+		select {
+		case notify <- struct{}{}:
+		case <-ctx.Done():
+		}
 	case <-ctx.Done():
 	}
 }

--- a/lib/kube/proxy/remotecommand.go
+++ b/lib/kube/proxy/remotecommand.go
@@ -388,6 +388,7 @@ func (*v4ProtocolHandler) waitForStreams(connContext context.Context, streams <-
 	remoteProxy := &remoteCommandProxy{}
 	receivedStreams := 0
 	replyChan := make(chan struct{})
+	seen := make(map[string]bool, 5)
 
 	stopCtx, cancel := context.WithCancel(connContext)
 	defer cancel()
@@ -396,21 +397,29 @@ WaitForStreams:
 		select {
 		case stream := <-streams:
 			streamType := stream.Headers().Get(StreamType)
+			if seen[streamType] {
+				return nil, trace.BadParameter("client opened duplicate %q stream", streamType)
+			}
 			switch streamType {
 			case StreamTypeError:
 				remoteProxy.writeStatus = v4WriteStatusFunc(stream)
+				seen[streamType] = true
 				go waitStreamReply(stopCtx, stream.replySent, replyChan)
 			case StreamTypeStdin:
 				remoteProxy.stdinStream = stream
+				seen[streamType] = true
 				go waitStreamReply(stopCtx, stream.replySent, replyChan)
 			case StreamTypeStdout:
 				remoteProxy.stdoutStream = stream
+				seen[streamType] = true
 				go waitStreamReply(stopCtx, stream.replySent, replyChan)
 			case StreamTypeStderr:
 				remoteProxy.stderrStream = stream
+				seen[streamType] = true
 				go waitStreamReply(stopCtx, stream.replySent, replyChan)
 			case StreamTypeResize:
 				remoteProxy.resizeStream = stream
+				seen[streamType] = true
 				go waitStreamReply(stopCtx, stream.replySent, replyChan)
 			default:
 				slog.WarnContext(stopCtx, "Ignoring unexpected stream type", "stream_type", streamType)

--- a/lib/kube/proxy/sess.go
+++ b/lib/kube/proxy/sess.go
@@ -182,6 +182,9 @@ func (p *kubeProxyClientStreams) stderrStream() io.Writer {
 
 func (p *kubeProxyClientStreams) resizeQueue() <-chan terminalResizeMessage {
 	ch := make(chan terminalResizeMessage)
+	if p.sizeQueue == nil {
+		return ch
+	}
 	p.wg.Add(1)
 	go func() {
 		defer p.wg.Done()

--- a/lib/kube/proxy/spdy_stream_dedup_repro_test.go
+++ b/lib/kube/proxy/spdy_stream_dedup_repro_test.go
@@ -23,7 +23,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"go.uber.org/goleak"
 )
 
 // On a request with tty=true, stdin=true, stdout=true, expectedStreams==4 (error + stdin + stdout + resize).
@@ -52,37 +51,6 @@ func TestRegression_WaitForStreams_RejectsDuplicateStream(t *testing.T) {
 
 	_, err := handler.waitForStreams(t.Context(), streams, expectedStreams, nil)
 	require.Error(t, err, "waitForStreams should return an error when a duplicate stream type arrives")
-}
-
-// When waitForStreams returns early on a duplicate stream, every waitStreamReply
-// goroutine it spawned must exit. Otherwise repeated malformed requests
-// accumulate goroutines parked on the unbuffered notify send.
-func TestRegression_WaitForStreams_DuplicateStream_NoGoroutineLeak(t *testing.T) {
-	ignore := goleak.IgnoreCurrent()
-	defer goleak.VerifyNone(t, ignore)
-
-	handler := &v4ProtocolHandler{}
-
-	const expectedStreams = 4
-	streams := make(chan streamAndReply, expectedStreams)
-	for _, st := range []string{
-		StreamTypeError,
-		StreamTypeStdin,
-		StreamTypeStdout,
-		StreamTypeStdin,
-	} {
-		hdr := http.Header{}
-		hdr.Set(StreamType, st)
-		reply := make(chan struct{})
-		close(reply)
-		streams <- streamAndReply{
-			Stream:    &fakeSPDYStream{headers: hdr},
-			replySent: reply,
-		}
-	}
-
-	_, err := handler.waitForStreams(t.Context(), streams, expectedStreams, nil)
-	require.Error(t, err)
 }
 
 // Calling kubeProxyClientStreams.resizeQueue() with a nil sizeQueue must not panic.

--- a/lib/kube/proxy/spdy_stream_dedup_repro_test.go
+++ b/lib/kube/proxy/spdy_stream_dedup_repro_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"go.uber.org/goleak"
 )
 
 // On a request with tty=true, stdin=true, stdout=true, expectedStreams==4 (error + stdin + stdout + resize).
@@ -51,6 +52,36 @@ func TestRegression_WaitForStreams_RejectsDuplicateStream(t *testing.T) {
 
 	_, err := handler.waitForStreams(t.Context(), streams, expectedStreams, nil)
 	require.Error(t, err, "waitForStreams should return an error when a duplicate stream type arrives")
+}
+
+// When waitForStreams returns early on a duplicate stream, every waitStreamReply
+// goroutine it spawned must exit. Otherwise repeated malformed requests
+// accumulate goroutines parked on the unbuffered notify send.
+func TestRegression_WaitForStreams_DuplicateStream_NoGoroutineLeak(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
+	handler := &v4ProtocolHandler{}
+
+	const expectedStreams = 4
+	streams := make(chan streamAndReply, expectedStreams)
+	for _, st := range []string{
+		StreamTypeError,
+		StreamTypeStdin,
+		StreamTypeStdout,
+		StreamTypeStdin,
+	} {
+		hdr := http.Header{}
+		hdr.Set(StreamType, st)
+		reply := make(chan struct{})
+		close(reply)
+		streams <- streamAndReply{
+			Stream:    &fakeSPDYStream{headers: hdr},
+			replySent: reply,
+		}
+	}
+
+	_, err := handler.waitForStreams(t.Context(), streams, expectedStreams, nil)
+	require.Error(t, err)
 }
 
 // Calling kubeProxyClientStreams.resizeQueue() with a nil sizeQueue must not panic.

--- a/lib/kube/proxy/spdy_stream_dedup_repro_test.go
+++ b/lib/kube/proxy/spdy_stream_dedup_repro_test.go
@@ -58,7 +58,8 @@ func TestRegression_WaitForStreams_RejectsDuplicateStream(t *testing.T) {
 // goroutine it spawned must exit. Otherwise repeated malformed requests
 // accumulate goroutines parked on the unbuffered notify send.
 func TestRegression_WaitForStreams_DuplicateStream_NoGoroutineLeak(t *testing.T) {
-	defer goleak.VerifyNone(t)
+	ignore := goleak.IgnoreCurrent()
+	defer goleak.VerifyNone(t, ignore)
 
 	handler := &v4ProtocolHandler{}
 

--- a/lib/kube/proxy/spdy_stream_dedup_repro_test.go
+++ b/lib/kube/proxy/spdy_stream_dedup_repro_test.go
@@ -1,0 +1,69 @@
+/*
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package proxy
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// On a request with tty=true, stdin=true, stdout=true, expectedStreams==4 (error + stdin + stdout + resize).
+// A correct waitForStreams must NOT return a successful proxy with resizeStream==nil
+// when a resize stream was counted in expectedStreams.
+func TestRegression_WaitForStreams_RejectsDuplicateStream(t *testing.T) {
+	handler := &v4ProtocolHandler{}
+
+	const expectedStreams = 4 // mirrors tty+stdin+stdout+(implicit error)
+	streams := make(chan streamAndReply, expectedStreams)
+	for _, st := range []string{
+		StreamTypeError,
+		StreamTypeStdin,
+		StreamTypeStdout,
+		StreamTypeStdin, // duplicate; would-be resize
+	} {
+		hdr := http.Header{}
+		hdr.Set(StreamType, st)
+		reply := make(chan struct{})
+		close(reply) // immediate, so waitStreamReply increments receivedStreams right away
+		streams <- streamAndReply{
+			Stream:    &fakeSPDYStream{headers: hdr},
+			replySent: reply,
+		}
+	}
+
+	_, err := handler.waitForStreams(t.Context(), streams, expectedStreams, nil)
+	require.Error(t, err, "waitForStreams should return an error when a duplicate stream type arrives")
+}
+
+// Calling kubeProxyClientStreams.resizeQueue() with a nil sizeQueue must not panic.
+func TestRegression_KubeProxyClientStreams_ResizeQueue_NilSafe(t *testing.T) {
+	c := &kubeProxyClientStreams{ /* sizeQueue is nil */ }
+
+	ch := c.resizeQueue()
+	require.NotNil(t, ch)
+
+	select {
+	case _, ok := <-ch:
+		require.False(t, ok, "channel should be closed, not deliver messages")
+	default:
+		// channel idle, no panic.
+	}
+}

--- a/lib/kube/proxy/spdy_stream_dedup_repro_test.go
+++ b/lib/kube/proxy/spdy_stream_dedup_repro_test.go
@@ -90,11 +90,4 @@ func TestRegression_KubeProxyClientStreams_ResizeQueue_NilSafe(t *testing.T) {
 
 	ch := c.resizeQueue()
 	require.NotNil(t, ch)
-
-	select {
-	case _, ok := <-ch:
-		require.False(t, ok, "channel should be closed, not deliver messages")
-	default:
-		// channel idle, no panic.
-	}
 }

--- a/lib/kube/proxy/testing/kube_server/kube_mock.go
+++ b/lib/kube/proxy/testing/kube_server/kube_mock.go
@@ -809,7 +809,10 @@ func (*v4ProtocolHandler) supportsTerminalResizing() bool { return true }
 func waitStreamReply(ctx context.Context, replySent <-chan struct{}, notify chan<- struct{}) {
 	select {
 	case <-replySent:
-		notify <- struct{}{}
+		select {
+		case notify <- struct{}{}:
+		case <-ctx.Done():
+		}
 	case <-ctx.Done():
 	}
 }


### PR DESCRIPTION
Backport of #67157 to branch/v18.

Backport-specific change: the goroutine-leak regression test was dropped because it would require adding `go.uber.org/goleak` as a direct dependency on this release branch. The dedupe + cancellable-notify-send fixes (the actual bug fix) are unchanged from master.