### PR TITLE
docs: distinguish host user creation from host sudoers in SSH guides

### DIFF
--- a/docs/pages/enroll-resources/server-access/guides/host-user-creation.mdx
+++ b/docs/pages/enroll-resources/server-access/guides/host-user-creation.mdx
@@ -15,8 +15,8 @@ capabilities:
 - **Host user creation** creates a local Unix user when a Teleport user opens an
   SSH session (or, for static host users, independently of any session), based
   on the user's Teleport roles.
-- **Host sudoers** writes a temporary entry to `/etc/sudoers.d` granting the
-  created user specific sudo permissions.
+- **Host sudoers** writes a temporary entry to `/etc/sudoers.d` granting the login user 
+  specific sudo permissions.
 
 Host user creation saves you from manually managing a Unix account for each
 member of your organization and gives you fine-grained, per-host control of
@@ -26,17 +26,19 @@ deleted at the end of an SSH session if required by your environment.
 
 ## How it works
 
-While these capabilities are distinct, they are behaviorally coupled. 
+These two capabilities are configured on the same Teleport roles and are often used together, but they operate independently.
 
 **Host user creation behavior:** When a user logs into a Teleport Node, the SSH 
 service checks if the user's roles permit automatic user creation. If permitted, 
 it executes `useradd` to provision the user and assign them to the specified groups.
 
-**Host sudoers behavior:** If the user's roles also include `host_sudoers` entries, 
-Teleport writes a temporary sudoers file to `/etc/sudoers.d` for the duration of 
-the session. **Note:** Host sudoers entries only take effect on servers where 
-host user creation is enabled, as Teleport must write the file for the user it 
-creates at login.
+**Host sudoers behavior:** If the user's roles include `host_sudoers` entries,
+Teleport writes a temporary sudoers file to `/etc/sudoers.d` for the user you
+log in as, lasting the duration of the session. This is independent of host user
+creation. The login user may be one Teleport creates for this session, a host
+user Teleport created earlier (in `keep` mode or as a static host user), or a
+user that already existed on the host outside of Teleport. When host user
+creation does apply, Teleport writes the sudoers file after creating the user.
 
 ## Prerequisites
 
@@ -97,7 +99,7 @@ The following role enables user creation without granting any sudo privileges. T
 
 ```yaml
 kind: role
-version: v5
+version: v8
 metadata:
   name: auto-users-basic
 spec:
@@ -117,7 +119,7 @@ If you already have host user creation enabled on another role, you can isolate 
 
 ```yaml
 kind: role
-version: v5
+version: v8
 metadata:
   name: auto-users-sudo
 spec:
@@ -136,7 +138,7 @@ The following role specification combines both features. Add this content to a f
 
 ```yaml
 kind: role
-version: v5
+version: v8
 metadata:
   name: auto-users
 spec:
@@ -171,7 +173,7 @@ rules are matched literally when filtering:
 
 ```yaml
 kind: role
-version: v5
+version: v8
 metadata:
   name: auto-users
 spec:
@@ -338,8 +340,6 @@ not already exist are created on the host. The `nginxrestarter` user is added to
 the `ubuntu`, `nginx`, and `other` groups, as specified in the `host_groups`
 field.
 
----
-
 ## Static host users
 
 In this section, you will configure Teleport to create local users independently
@@ -370,7 +370,7 @@ any matching server. Add this content to a file called `auto-users.yaml`:
 
 ```yaml
 kind: role
-version: v5
+version: v8
 metadata:
   name: auto-users
 spec:
@@ -467,8 +467,6 @@ $ grep "other" /etc/group
 # other:x:1002:nginxrestarter
 ```
 
----
-
 ## Under the hood
 
 The Teleport SSH Service executes `useradd` to create new users on the host, and
@@ -478,8 +476,7 @@ separately creates a new home directory with the name of the new host user.
 
 The SSH Service executes
 `useradd --no-create-home --home-dir <home> <username> --groups <groups> --uid <uid> --gid <gid>`
-when adding a user, with all other options using system defaults. For example, it associates the user with the
-default login shell for the host, which you can specify by setting the `SHELL`
+when adding a user, with all other options using system defaults. For example, it associates the user with the default login shell for the host, which you can specify by setting the `SHELL`
 field in `/etc/default/useradd`. See the `useradd` manual for your system for a
 full description of the default behavior.
 
@@ -487,17 +484,13 @@ The Teleport SSH Service also creates a file in `/etc/sudoers.d` with the
 contents of the `host_sudoers` file written with one entry per line, each
 prefixed with the username of the user that has logged in.
 
-The session can then proceed as usual. When the SSH session ends, the user
-and their home directory will be kept on the machine. It is possible to remove host users
-by setting `create_host_user_mode` to `insecure-drop` in the role definition. However,
-the potential for a user ID to be reused on the system opens up a number of potential security risks,
-so we recommend using `keep` mode unless you have a specific need and understand
+The session can then proceed as usual. When the SSH session ends, the user and their home directory are kept on the machine by default. To have Teleport remove them instead as part of session-end cleanup, set `create_host_user_mode` to `insecure-drop` in the role definition.
+
+However, the potential for a user ID to be reused on the system opens up a number of potential security risks, so we recommend using `keep` mode unless you have a specific need and understand
 the potential impacts.
 
 Should a Teleport SSH instance be restarted while a session is in progress, the user
 will be cleaned up at the next Teleport restart.
-
----
 
 ## Migrating unmanaged users
 
@@ -514,8 +507,6 @@ user, the `take_ownership_if_user_exists` flag can be set to `true` on the stati
 the existing user under Teleport's management and override the groups assigned to that user. Similar to migrating
 `teleport-keep` users, it is possible to migrate users manually by adding them to the `teleport-static` group directly
 on the hosts.
-
----
 
 ## Next steps
 

--- a/docs/pages/enroll-resources/server-access/guides/host-user-creation.mdx
+++ b/docs/pages/enroll-resources/server-access/guides/host-user-creation.mdx
@@ -8,13 +8,24 @@ tags:
  - infrastructure-identity
 ---
 
-Teleport's SSH Service can be configured to automatically create local Unix users
-upon login.
+Teleport's SSH Service can automatically create local Unix users on a server,
+and can grant those users temporary sudo permissions. These are two distinct
+capabilities:
 
-This saves you from having to manually create users for each member of an
-organization and provides more fine-grained control of permissions on a given
-host. Host users created by Teleport are transient and will be deleted at the
-end of an SSH session.
+- **Host user creation** creates a local Unix user when a Teleport user opens an
+  SSH session (or, for static host users, independently of any session), based
+  on the user's Teleport roles.
+- **Host sudoers** writes a temporary entry to `/etc/sudoers.d` granting the
+  created user specific sudo permissions.
+
+Host user creation saves you from manually managing a Unix account for each
+member of your organization and gives you fine-grained, per-host control of
+permissions. Host users created by Teleport are transient and will be deleted at
+the end of an SSH session unless you configure Teleport to keep them.
+
+Host sudoers entries only take effect on servers where host user creation is
+enabled, since Teleport writes the sudoers file for the user it creates at
+login.
 
 ## Prerequisites
 
@@ -64,10 +75,10 @@ To enable host user creation, you will:
 
 1. Make the following change to the configuration file:
 
-   ```diff
+```diff
      labels:
    +   app: "nginx"
-   ```
+```
 
 1. Restart Teleport on the server.
 
@@ -83,14 +94,15 @@ metadata:
   name: auto-users
 spec:
   options:
-    # Allow automatic creation of users.
+    # Host user creation: "keep" enables creation and retains the user after the
+    # session ends.
     create_host_user_mode: keep
     create_host_user_default_shell: /bin/bash
   allow:
     logins: [ "nginxrestarter" ]
-    # List of host groups the created user will be added to. Any that don't already exist are created.
+    # Host user creation: groups the created user joins. Any that don't already exist are created.
     host_groups: [ubuntu, nginx, other]
-    # List of entries to include in a temporary sudoers file created in /etc/sudoers.d
+    # Host sudoers: entries written to a temporary file in /etc/sudoers.d. These only apply when host user creation is enabled (above).
     host_sudoers: [
        # This line will allow the `nginxrestarter` user to run
        # `systemctl restart nginx.service` as
@@ -181,9 +193,9 @@ $ tctl create -f auto-users.yaml
 1. Run the following command to create a Teleport user with the `auto-users`
    role:
 
-   ```code
+```code
    $ tctl users add demo-user --roles=auto-users --logins=nginxrestarter
-   ```
+```
 
 1. Follow the instructions in your terminal to visit the Teleport Web UI and
    create the user.
@@ -317,10 +329,10 @@ servers, SSH services, and `tctl`.
 
 1. Make the following change to the configuration file:
 
-   ```diff
+```diff
      labels:
    +   app: "nginx"
-   ```
+```
 
 1. Restart Teleport on the server.
 
@@ -353,9 +365,9 @@ $ tctl create -f auto-users.yaml
 1. Run the following command to create a Teleport user with the `auto-users`
    role:
 
-   ```code
+```code
    $ tctl users add demo-user --roles=auto-users --logins=nginxrestarter
-   ```
+```
 
 1. Follow the instructions in your terminal to visit the Teleport Web UI and
    create the user.

--- a/docs/pages/enroll-resources/server-access/guides/host-user-creation.mdx
+++ b/docs/pages/enroll-resources/server-access/guides/host-user-creation.mdx
@@ -1,7 +1,7 @@
 ---
 title: Configure Teleport to Create Host Users
 sidebar_label: Host User Creation
-description: How to configure Teleport to automatically create transient host users.
+description: How to configure Teleport to automatically create host users and manage sudoers.
 tags:
  - how-to
  - zero-trust
@@ -20,12 +20,23 @@ capabilities:
 
 Host user creation saves you from manually managing a Unix account for each
 member of your organization and gives you fine-grained, per-host control of
-permissions. Host users created by Teleport are transient and will be deleted at
-the end of an SSH session unless you configure Teleport to keep them.
+permissions. As a security best practice, Teleport provisions these users and 
+keeps them on the host for auditability, though they can be configured to be 
+deleted at the end of an SSH session if required by your environment.
 
-Host sudoers entries only take effect on servers where host user creation is
-enabled, since Teleport writes the sudoers file for the user it creates at
-login.
+## How it works
+
+While these capabilities are distinct, they are behaviorally coupled. 
+
+**Host user creation behavior:** When a user logs into a Teleport Node, the SSH 
+service checks if the user's roles permit automatic user creation. If permitted, 
+it executes `useradd` to provision the user and assign them to the specified groups.
+
+**Host sudoers behavior:** If the user's roles also include `host_sudoers` entries, 
+Teleport writes a temporary sudoers file to `/etc/sudoers.d` for the duration of 
+the session. **Note:** Host sudoers entries only take effect on servers where 
+host user creation is enabled, as Teleport must write the file for the user it 
+creates at login.
 
 ## Prerequisites
 
@@ -36,8 +47,7 @@ login.
   cluster. We recommend enrolling a server that runs in a demo environment for
   the purpose of this guide until you are familiar with the instructions.
 - The following utilities should be available in the PATH for the Teleport SSH
-  Service, since it must execute these commands in order to create transient
-  users:
+  Service, since it must execute these commands in order to create users:
   - `useradd`
   - `userdel`
   - `usermod`
@@ -56,16 +66,10 @@ Teleport user starts an SSH session.
 When a Teleport user accesses an SSH Service instance, Teleport checks each of
 the user's roles that match the instance. If at least one role matches the
 instance but does not set `create_host_user_mode`, automatic user creation will
-be disabled. Roles that do not match the server will not be checked.
+be disabled. 
 
-To enable host user creation, you will:
-
-- Label your server so you can match it with a Teleport role that enables host
-  user creation.
-- Create a role that enables host user creation for servers with the label you
-  added.
-- For the purpose of this guide, create a Teleport user with only the role you
-  created.
+To enable host user creation, you will first label your server, and then map 
+a Teleport role to it.
 
 #### Label your server
 
@@ -75,17 +79,60 @@ To enable host user creation, you will:
 
 1. Make the following change to the configuration file:
 
-```diff
-     labels:
-   +   app: "nginx"
-```
+   ```diff
+       labels:
+      +   app: "nginx"
+   ```
 
 1. Restart Teleport on the server.
 
 #### Define a Teleport role
 
-The following role specification allows users to log in as `nginxrestarter` on
-any matching server. Add this content to a file called `auto-users.yaml`:
+Below are examples of how to configure roles for host user creation, host sudoers, 
+and a combined approach.
+
+**Example A: Configuring Host User Creation (Only)**
+
+The following role enables user creation without granting any sudo privileges. The `create_host_user_mode` field enables host user creation when the value is `keep`. 
+
+```yaml
+kind: role
+version: v5
+metadata:
+  name: auto-users-basic
+spec:
+  options:
+    create_host_user_mode: keep
+    create_host_user_default_shell: /bin/bash
+  allow:
+    logins: [ "developer" ]
+    host_groups: [ubuntu, other]
+    node_labels:
+      "app": "nginx"
+```
+
+**Example B: Configuring Host Sudoers (Only)**
+
+If you already have host user creation enabled on another role, you can isolate `host_sudoers` permissions into a secondary role. 
+
+```yaml
+kind: role
+version: v5
+metadata:
+  name: auto-users-sudo
+spec:
+  allow:
+    logins: [ "developer" ]
+    host_sudoers: [
+       "ALL = (root) NOPASSWD: /usr/bin/systemctl restart nginx.service"
+    ]
+    node_labels:
+      "app": "nginx"
+```
+
+**Example C: Combined Example**
+
+The following role specification combines both features. Add this content to a file called `auto-users.yaml`. It allows users to log in as `nginxrestarter` on any matching server, creates the user, and grants them sudo permission to restart Nginx.
 
 ```yaml
 kind: role
@@ -94,35 +141,17 @@ metadata:
   name: auto-users
 spec:
   options:
-    # Host user creation: "keep" enables creation and retains the user after the
-    # session ends.
     create_host_user_mode: keep
     create_host_user_default_shell: /bin/bash
   allow:
     logins: [ "nginxrestarter" ]
-    # Host user creation: groups the created user joins. Any that don't already exist are created.
     host_groups: [ubuntu, nginx, other]
-    # Host sudoers: entries written to a temporary file in /etc/sudoers.d. These only apply when host user creation is enabled (above).
     host_sudoers: [
-       # This line will allow the `nginxrestarter` user to run
-       # `systemctl restart nginx.service` as
-       # root without requiring a password.
-       # The sudoers entries will be prefixed with `nginxrestarter` in this case.
-       # sudoers file reference documentation: https://www.sudo.ws/docs/man/1.8.17/sudoers.man/
        "ALL = (root) NOPASSWD: /usr/bin/systemctl restart nginx.service"
     ]
     node_labels:
       "app": "nginx"
 ```
-
-The `create_host_user_mode` field enables host user creation when the value is
-`keep`.  When a user with the `auto-users` role logs in to a server that matches
-the `app:nginx` label, the Teleport SSH Service creates a host user, adds it to
-the groups listed in `host_groups`, and gives it the sudoer permissions
-specified in the `host_sudoers` field. In this case, the new user receives
-permission to restart the Nginx service as root. In Teleport 16.4.0 and later,
-the default shell for a created user can be configured with `create_host_user_default_shell`. 
-Otherwise the host's default shell will be used.
 
 {/*TODO (ptgott): We should move the information below into a reference guide*/}
 <details>
@@ -134,7 +163,7 @@ Syntax](https://systemd.io/USER_NAMES/) for requirements in common
 distributions.
 
 When multiple roles contain `host_sudoers` entries, the sudoers file
-will have the entries written to it ordered by role name
+will have the entries written to it ordered by role name.
 
 If a role includes a `deny` rule that sets `host_sudoers` to `'*'`, the user will
 have all sudoers entries removed when accessing matching Nodes, otherwise `deny`
@@ -150,14 +179,14 @@ spec:
     create_host_user_mode: keep
   deny:
     host_sudoers: [
-       "*" # ensure that users in this role never have sudoers files created on matching Nodes
+       "*", # ensure that users in this role never have sudoers files created on matching Nodes
        "ALL=(ALL) NOPASSWD: ALL" # host_sudoers entries matching this are filtered out
     ]
     node_labels:
       "app": "nginx"
 ```
 
-If a server must never allow the automatic creation of transient Unix users you
+If a server must never allow the automatic creation of Unix users you
 can set `disable_create_host_user` to `true` in the Node's configuration:
 
 ```yaml
@@ -170,16 +199,16 @@ ssh_service:
   disable_create_host_user: true
 ```
 
-In low-security environments, you can also set `create_host_user_mode` to
+In low-security environments, you can set `create_host_user_mode` to
 `insecure-drop`, which deletes users once the session ends. However, in this
 mode it is possible for a created user to get the same UID as a previously
 deleted user, which would give the new user access to all of the old user's
-files if they are not deleted. Use `keep` mode unless you really need users to
-be removed.
+files if they are not deleted. Use `keep` mode unless you strictly require users 
+to be automatically removed.
 
 </details>
 
-Create the role:
+Create the combined role:
 
 ```code
 $ tctl create -f auto-users.yaml
@@ -193,9 +222,9 @@ $ tctl create -f auto-users.yaml
 1. Run the following command to create a Teleport user with the `auto-users`
    role:
 
-```code
-   $ tctl users add demo-user --roles=auto-users --logins=nginxrestarter
-```
+   ```code
+      $ tctl users add demo-user --roles=auto-users --logins=nginxrestarter
+   ```
 
 1. Follow the instructions in your terminal to visit the Teleport Web UI and
    create the user.
@@ -218,7 +247,7 @@ kind: user
 metadata:
   name: demo-user
 spec:
-  ...
+  # ...
   traits:
     logins:
     - nginxrestarter
@@ -302,16 +331,14 @@ $ grep "nginxrestarter" /etc/passwd
 $ grep "other" /etc/group
 # other:x:1002:nginxrestarter
 $ exit
-$ tsh ssh admin@develnode # checking the user was deleted after logout
-$ grep "nginxrestarter" /etc/passwd
-$ echo $?
-# 1
 ```
 
 When the user above logs in, the `nginxrestarter` user and any groups that do
 not already exist are created on the host. The `nginxrestarter` user is added to
 the `ubuntu`, `nginx`, and `other` groups, as specified in the `host_groups`
 field.
+
+---
 
 ## Static host users
 
@@ -329,10 +356,10 @@ servers, SSH services, and `tctl`.
 
 1. Make the following change to the configuration file:
 
-```diff
-     labels:
-   +   app: "nginx"
-```
+   ```diff
+       labels:
+      +   app: "nginx"
+   ```
 
 1. Restart Teleport on the server.
 
@@ -365,9 +392,9 @@ $ tctl create -f auto-users.yaml
 1. Run the following command to create a Teleport user with the `auto-users`
    role:
 
-```code
-   $ tctl users add demo-user --roles=auto-users --logins=nginxrestarter
-```
+   ```code
+      $ tctl users add demo-user --roles=auto-users --logins=nginxrestarter
+   ```
 
 1. Follow the instructions in your terminal to visit the Teleport Web UI and
    create the user.
@@ -387,16 +414,13 @@ spec:
     - node_labels:
       - name: app
         values: ["nginx"]
-      node_labels_expression: 'labels["app"] == "nginx"'
+      # node_labels_expression: 'labels["app"] == "nginx"'
+      
       # List of host groups the created user will be added to. Any that don't already exist are created.
       groups: [ubuntu, nginx, other]
+      
       # List of entries to include in a temporary sudoers file created in /etc/sudoers.d
       sudoers: [
-        # This line will allow the `nginxrestarter` user to run
-        # `systemctl restart nginx.service` as
-        # root without requiring a password.
-        # The sudoers entries will be prefixed with `nginxrestarter` in this case.
-        # sudoers file reference documentation: https://www.sudo.ws/docs/man/1.8.17/sudoers.man/
         "ALL = (root) NOPASSWD: /usr/bin/systemctl restart nginx.service"
       ]
       # UID of the host user. Optional.
@@ -408,11 +432,6 @@ spec:
       # Whether or not static host user provisioning should automatically take ownership of existing users
       # created outside of Teleport. Optional.
       # take_ownership_if_user_exists: true
-
-    # Add additional matchers if needed to configure nginxrestarter differently
-    # on different servers.
-    # - node_labels:
-      # ...
 ```
 
 The name of the static host user resource must match the login of the user to
@@ -448,6 +467,8 @@ $ grep "other" /etc/group
 # other:x:1002:nginxrestarter
 ```
 
+---
+
 ## Under the hood
 
 The Teleport SSH Service executes `useradd` to create new users on the host, and
@@ -467,14 +488,16 @@ contents of the `host_sudoers` file written with one entry per line, each
 prefixed with the username of the user that has logged in.
 
 The session can then proceed as usual. When the SSH session ends, the user
-and their home directory will be kept on the machine. It is possible to remove automatic host users
+and their home directory will be kept on the machine. It is possible to remove host users
 by setting `create_host_user_mode` to `insecure-drop` in the role definition. However,
-the potential for a user id to be reused on the system opens up a number of potential security risks,
+the potential for a user ID to be reused on the system opens up a number of potential security risks,
 so we recommend using `keep` mode unless you have a specific need and understand
 the potential impacts.
 
 Should a Teleport SSH instance be restarted while a session is in progress, the user
 will be cleaned up at the next Teleport restart.
+
+---
 
 ## Migrating unmanaged users
 
@@ -491,6 +514,8 @@ user, the `take_ownership_if_user_exists` flag can be set to `true` on the stati
 the existing user under Teleport's management and override the groups assigned to that user. Similar to migrating
 `teleport-keep` users, it is possible to migrate users manually by adding them to the `teleport-static` group directly
 on the hosts.
+
+---
 
 ## Next steps
 

--- a/docs/pages/enroll-resources/server-access/guides/host-user-creation.mdx
+++ b/docs/pages/enroll-resources/server-access/guides/host-user-creation.mdx
@@ -485,6 +485,7 @@ contents of the `host_sudoers` file written with one entry per line, each
 prefixed with the username of the user that has logged in.
 
 The session can then proceed as usual. When the SSH session ends, the user and their home directory are kept on the machine by default. To have Teleport remove them instead as part of session-end cleanup, set `create_host_user_mode` to `insecure-drop` in the role definition.
+Note that `insecure-drop` only removes users that Teleport created; if the user already existed on the host, Teleport leaves the account and its home directory in place.
 
 However, the potential for a user ID to be reused on the system opens up a number of potential security risks, so we recommend using `keep` mode unless you have a specific need and understand
 the potential impacts.

--- a/docs/pages/enroll-resources/server-access/rbac.mdx
+++ b/docs/pages/enroll-resources/server-access/rbac.mdx
@@ -54,7 +54,8 @@ spec:
     # is not 'off'.
     host_groups: [ubuntu, nginx, other]
 
-    # Assign the user to the sudoers group
+    # Host sudoers: entries written to a temporary sudoers file for the created
+    # user. Only applies when create_host_user_mode is not 'off' (set below).
     host_sudoers:
     - 'ALL=(ALL) NOPASSWD: ALL'
 
@@ -71,6 +72,19 @@ spec:
   Deny rules will match greedily. In the example above, a server session
   attempting to use the "root" server user  account will be rejected.
 </Admonition>
+
+Several of the fields above relate to the SSH Service provisioning a host user,
+which involves two distinct capabilities:
+
+- **Host user creation** — `host_groups` (above), together with
+  `create_host_user_mode` (see [Server role options](#server-role-options)),
+  control whether and how Teleport creates a local Unix user at login.
+- **Host sudoers** — `host_sudoers` grants the created user temporary sudo
+  permissions. These entries only apply on servers where host user creation is
+  enabled.
+
+For a full walkthrough of both, see
+[Configure Teleport to Create Host Users](guides/host-user-creation.mdx).
 
 ## Template variables
 

--- a/docs/pages/enroll-resources/server-access/rbac.mdx
+++ b/docs/pages/enroll-resources/server-access/rbac.mdx
@@ -76,10 +76,10 @@ spec:
 Several of the fields above relate to the SSH Service provisioning a host user,
 which involves two distinct capabilities:
 
-- **Host user creation** — `host_groups` (above), together with
+- **Host user creation** `host_groups` (above), together with
   `create_host_user_mode` (see [Server role options](#server-role-options)),
   control whether and how Teleport creates a local Unix user at login.
-- **Host sudoers** — `host_sudoers` grants the created user temporary sudo
+- **Host sudoers** `host_sudoers` grants the created user temporary sudo
   permissions. These entries only apply on servers where host user creation is
   enabled.
 

--- a/docs/pages/enroll-resources/server-access/rbac.mdx
+++ b/docs/pages/enroll-resources/server-access/rbac.mdx
@@ -54,8 +54,8 @@ spec:
     # is not 'off'.
     host_groups: [ubuntu, nginx, other]
 
-    # Host sudoers: entries written to a temporary sudoers file for the created
-    # user. Only applies when create_host_user_mode is not 'off' (set below).
+    # Host sudoers: entries written to a temporary file in /etc/sudoers.d for
+    # the login user. Applied independently of host user creation.
     host_sudoers:
     - 'ALL=(ALL) NOPASSWD: ALL'
 
@@ -73,15 +73,16 @@ spec:
   attempting to use the "root" server user  account will be rejected.
 </Admonition>
 
-Several of the fields above relate to the SSH Service provisioning a host user,
-which involves two distinct capabilities:
+Several of the fields above relate to the SSH Service provisioning host users,
+which is two distinct capabilities:
 
-- **Host user creation** `host_groups` (above), together with
+- **Host user creation** — `host_groups` (above), together with
   `create_host_user_mode` (see [Server role options](#server-role-options)),
   control whether and how Teleport creates a local Unix user at login.
-- **Host sudoers** `host_sudoers` grants the created user temporary sudo
-  permissions. These entries only apply on servers where host user creation is
-  enabled.
+- **Host sudoers** — `host_sudoers` grants the login user temporary sudo
+  permissions, written to a file in `/etc/sudoers.d` for the duration of the
+  session. This is independent of host user creation: the entry is applied
+  whether the login user was created by Teleport or already existed on the host.
 
 For a full walkthrough of both, see
 [Configure Teleport to Create Host Users](guides/host-user-creation.mdx).


### PR DESCRIPTION
This closes https://github.com/gravitational/teleport/issues/66943, a request for changes this quarter to better clarify host user creation from host sudoers. Preview changes:

[Configure Teleport to Create Host Users](https://host-creation-sudoers.d1v2yqnl3ruxch.amplifyapp.com/docs/enroll-resources/server-access/guides/host-user-creation/)

[Access Controls for Servers](https://host-creation-sudoers.d1v2yqnl3ruxch.amplifyapp.com/docs/enroll-resources/server-access/rbac/)