### PR TITLE
return an error when an absolute path isn't specified in a moderated upload, or if the path is a dir

### DIFF
--- a/lib/session/session.go
+++ b/lib/session/session.go
@@ -126,7 +126,8 @@ type FileTransferRequestParams struct {
 	Download bool `json:"direction"`
 	// Location is location of file to download, or where to put an upload
 	Location string `json:"location"`
-	// Filename is the name of the file to be uploaded
+	// Filename is the name of the file to be uploaded, should not be considered
+	// when deciding if a file transfer should be approved
 	Filename string `json:"filename"`
 	// Requester is the authenticated Teleport user who requested the file transfer
 	Requester string `json:"requester"`

--- a/lib/session/session.go
+++ b/lib/session/session.go
@@ -126,8 +126,7 @@ type FileTransferRequestParams struct {
 	Download bool `json:"direction"`
 	// Location is location of file to download, or where to put an upload
 	Location string `json:"location"`
-	// Filename is the name of the file to be uploaded, should not be considered
-	// when deciding if a file transfer should be approved
+	// Filename is the name of the file to be uploaded
 	Filename string `json:"filename"`
 	// Requester is the authenticated Teleport user who requested the file transfer
 	Requester string `json:"requester"`

--- a/lib/srv/sess.go
+++ b/lib/srv/sess.go
@@ -572,7 +572,7 @@ func (s *SessionRegistry) notifyFileTransferRequestUnderLock(req *fileTransferRe
 		RequestID:       req.ID,
 		Requester:       req.Requester,
 		Location:        req.Location,
-		Filename:        req.Filename,
+		Filename:        req.filename,
 		Download:        req.Download,
 		Approvers:       make([]string, 0),
 	}
@@ -1871,6 +1871,8 @@ func (s *session) checkPresence(ctx context.Context) error {
 
 type fileTransferRequestWithApprovers struct {
 	reexecsftp.FileTransferRequest
+	// filename is the name of the file to be uploaded
+	filename string
 	// approvers is a list of participants of moderator or peer type that have approved the request
 	approvers map[string]*party
 }
@@ -1924,9 +1926,9 @@ func (s *session) addFileTransferRequest(params *rsession.FileTransferRequestPar
 			ID:        uuid.New().String(),
 			Requester: params.Requester,
 			Location:  params.Location,
-			Filename:  params.Filename,
 			Download:  params.Download,
 		},
+		filename:  params.Filename,
 		approvers: make(map[string]*party),
 	}
 

--- a/lib/srv/sess.go
+++ b/lib/srv/sess.go
@@ -1935,7 +1935,7 @@ func (s *session) addFileTransferRequest(params *rsession.FileTransferRequestPar
 	if params.Download {
 		s.BroadcastMessage("User %s would like to download: %s", params.Requester, params.Location)
 	} else {
-		s.BroadcastMessage("User %s would like to upload %s to: %s", params.Requester, params.Filename, params.Location)
+		s.BroadcastMessage("User %s would like to upload to: %s", params.Requester, params.Location)
 	}
 	err := s.registry.notifyFileTransferRequestUnderLock(s.fileTransferReq, FileTransferUpdate, scx)
 

--- a/session/reexec/reexecsftp/sess.go
+++ b/session/reexec/reexecsftp/sess.go
@@ -25,8 +25,6 @@ type FileTransferRequest struct {
 	Requester string
 	// Download is true if the request is a download, false if its an upload
 	Download bool
-	// Filename is the name of the file to upload.
-	Filename string
 	// Location of the requested download or where a file will be uploaded
 	Location string
 }

--- a/session/reexec/reexecsftp/sftp.go
+++ b/session/reexec/reexecsftp/sftp.go
@@ -106,6 +106,14 @@ func (s *sftpHandler) ensureReqIsAllowed(req *sftp.Request) error {
 		return nil
 	}
 
+	isDir, err := pathIsDir(req.Filepath)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	if isDir {
+		return trace.Errorf("destination path %s is a directory, it must be a file", req.Filepath)
+	}
+
 	cleaned := path.Clean(filepath.ToSlash(req.Filepath))
 	if s.allowed.path != cleaned {
 		return trace.Errorf("operations are only allowed on %s, not %s", s.allowed.path, cleaned)
@@ -129,6 +137,18 @@ func (s *sftpHandler) ensureReqIsAllowed(req *sftp.Request) error {
 	}
 
 	return nil
+}
+
+func pathIsDir(path string) (bool, error) {
+	fi, err := os.Stat(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return false, nil
+		}
+		return false, trace.Wrap(err)
+	}
+
+	return fi.IsDir(), nil
 }
 
 // OpenFile handles Open requests for both reading and writing. Required to

--- a/session/reexec/reexecsftp/sftp_test.go
+++ b/session/reexec/reexecsftp/sftp_test.go
@@ -32,7 +32,10 @@ import (
 
 func TestEnsureReqIsAllowed(t *testing.T) {
 	t.Parallel()
-	const filePath = "/foo/bar/baz.txt"
+
+	dir := t.TempDir()
+	filePath := filepath.Join(dir, "baz.txt")
+
 	passTests := []struct {
 		name    string
 		allowed *allowedOps
@@ -113,7 +116,11 @@ func TestEnsureReqIsAllowed(t *testing.T) {
 		})
 	}
 
-	const convolutedPath = "/foo/bar/../bar/baz.txt"
+	sep := string(filepath.Separator)
+	// the path is built manually to avoid filepath.Join calling
+	// filepath.Clean which would remove the relative part of the path
+	convolutedPath := dir + sep + ".." + sep + filepath.Base(dir) + sep + "baz.txt"
+
 	failTests := []struct {
 		name    string
 		allowed *allowedOps
@@ -157,6 +164,14 @@ func TestEnsureReqIsAllowed(t *testing.T) {
 			req: &sftp.Request{
 				Filepath: filePath,
 				Method:   sftputils.MethodRename,
+			},
+		},
+		{
+			name:    "dir filepath",
+			allowed: &allowedOps{path: dir},
+			req: &sftp.Request{
+				Filepath: dir,
+				Method:   sftputils.MethodGet,
 			},
 		},
 	}

--- a/web/packages/shared/components/FileTransfer/FileTransferStateless/DownloadForm/DownloadForm.tsx
+++ b/web/packages/shared/components/FileTransfer/FileTransferStateless/DownloadForm/DownloadForm.tsx
@@ -28,7 +28,7 @@ interface DownloadFormProps {
 }
 
 export function DownloadForm(props: DownloadFormProps) {
-  const [sourcePath, setSourcePath] = useState('~/');
+  const [sourcePath, setSourcePath] = useState('/');
   const inputId = useId();
   const isSourcePathValid = !sourcePath.endsWith('/');
 

--- a/web/packages/shared/components/FileTransfer/FileTransferStateless/UploadForm/UploadForm.test.tsx
+++ b/web/packages/shared/components/FileTransfer/FileTransferStateless/UploadForm/UploadForm.test.tsx
@@ -51,8 +51,8 @@ test('files can be selected using input', () => {
   });
 
   expect(handleAddUpload).toHaveBeenCalledTimes(2);
-  expect(handleAddUpload).toHaveBeenCalledWith('~/', files[0]);
-  expect(handleAddUpload).toHaveBeenCalledWith('~/', files[1]);
+  expect(handleAddUpload).toHaveBeenCalledWith('/', files[0]);
+  expect(handleAddUpload).toHaveBeenCalledWith('/', files[1]);
 });
 
 test('files can be dropped into upload area', () => {
@@ -65,6 +65,6 @@ test('files can be dropped into upload area', () => {
   });
 
   expect(handleAddUpload).toHaveBeenCalledTimes(2);
-  expect(handleAddUpload).toHaveBeenCalledWith('~/', files[0]);
-  expect(handleAddUpload).toHaveBeenCalledWith('~/', files[1]);
+  expect(handleAddUpload).toHaveBeenCalledWith('/', files[0]);
+  expect(handleAddUpload).toHaveBeenCalledWith('/', files[1]);
 });

--- a/web/packages/shared/components/FileTransfer/FileTransferStateless/UploadForm/UploadForm.tsx
+++ b/web/packages/shared/components/FileTransfer/FileTransferStateless/UploadForm/UploadForm.tsx
@@ -31,7 +31,7 @@ interface UploadFormProps {
 export function UploadForm(props: UploadFormProps) {
   const dropzoneRef = useRef<HTMLButtonElement>(null);
   const fileSelectorRef = useRef<HTMLInputElement>(null);
-  const [destinationPath, setDestinationPath] = useState('~/');
+  const [destinationPath, setDestinationPath] = useState('/');
 
   function onFileSelected(e: React.ChangeEvent<HTMLInputElement>): void {
     upload(Array.from(e.target.files));

--- a/web/packages/teleport/src/Console/DocumentSsh/FileTransferRequests.tsx
+++ b/web/packages/teleport/src/Console/DocumentSsh/FileTransferRequests.tsx
@@ -102,7 +102,7 @@ const getOwnPendingText = (request: FileTransferRequest) => {
   if (request.download) {
     return `Pending download: ${request.location}`;
   }
-  return `Pending upload: ${request.filename} to ${request.location}`;
+  return `Pending upload: ${request.location}`;
 };
 
 type RequestFormProps = {
@@ -157,7 +157,7 @@ const getPendingText = (request: FileTransferRequest) => {
   if (request.download) {
     return `${request.requester} wants to download ${request.location}`;
   }
-  return `${request.requester} wants to upload ${request.filename} to ${request.location}`;
+  return `${request.requester} wants to upload to ${request.location}`;
 };
 
 const Container = styled.div<{ backgroundColor?: string }>`


### PR DESCRIPTION
I removed the `Filename` field of `reexecsftp.FileTransferRequest` because it isn't used and to make it more clear that it shouldn't be considered when deciding to approve a file transfer request or not.

Fixes https://github.com/gravitational/teleport/issues/64844.
Fixes https://github.com/gravitational/teleport/issues/66806.

<!-- Provide a descriptive entry for the changelog of the next release. -->

Changelog: Updated moderated upload path validation to require an absolute path to a file to prevent confusion

<!-- Include manual testing efforts to verify the change. -->
<!-- Detail where the tests where run and what configurations were used. -->
<!-- Include all the test cases which were run to validate the change. -->

## Manual Test Plan
### Test Environment

### Test Cases
- [x] (checkbox to appease the test plan check action)
#### Moderated sessions:
- [x] Download succeeds
- [x] Upload fails to relative path
- [x] Upload fails to path with symlink
- [x] Upload fails to abs path to dir
- [x] Upload succeeds to abs path to file
- [x] Upload succeeds to abs path to nonexistent file
- [x] Upload succeeds where local and remote filenames differ
#### Non-moderated sessions:
- [x] Upload succeeds to abs path to file
- [x] Upload succeeds to abs path to dir
- [x] Download succeeds 
#### CLI
- [x] Upload succeeds using tsh scp
- [x] Download succeeds using tsh scp
- [x] Upload succeeds using openssh scp
- [x] Download succeeds using openssh scp
