### PR TITLE
Fix flaky tsh tests in the Flaky Tests Detector

### DIFF
--- a/tool/tsh/common/access_request_test.go
+++ b/tool/tsh/common/access_request_test.go
@@ -32,7 +32,6 @@ import (
 	"github.com/gravitational/teleport/lib/asciitable"
 	"github.com/gravitational/teleport/lib/modules/modulestest"
 	"github.com/gravitational/teleport/lib/service/servicecfg"
-	"github.com/gravitational/teleport/lib/utils"
 )
 
 func TestAccessRequestSearch(t *testing.T) {
@@ -51,7 +50,7 @@ func TestAccessRequestSearch(t *testing.T) {
 			cfg.Auth.NetworkingConfig.SetProxyListenerMode(types.ProxyListenerMode_Multiplex)
 			cfg.Kube.Enabled = true
 			cfg.SSH.Enabled = false
-			cfg.Kube.ListenAddr = utils.MustParseAddr(localListenerAddr())
+			cfg.Kube.ListenAddr = localListenerAddr(t)
 			cfg.Kube.KubeconfigPath = newKubeConfigFile(t, rootKubeCluster)
 		}),
 		withLeafCluster(),
@@ -63,7 +62,7 @@ func TestAccessRequestSearch(t *testing.T) {
 				cfg.Auth.NetworkingConfig.SetProxyListenerMode(types.ProxyListenerMode_Multiplex)
 				cfg.Kube.Enabled = true
 				cfg.SSH.Enabled = false
-				cfg.Kube.ListenAddr = utils.MustParseAddr(localListenerAddr())
+				cfg.Kube.ListenAddr = localListenerAddr(t)
 				cfg.Kube.KubeconfigPath = newKubeConfigFile(t, leafKubeCluster)
 			},
 		),

--- a/tool/tsh/common/app_test.go
+++ b/tool/tsh/common/app_test.go
@@ -28,6 +28,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os/user"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -315,7 +316,7 @@ func TestAppCommands(t *testing.T) {
 
 							// Test connecting to the app through a local proxy.
 							t.Run("tsh proxy app", func(t *testing.T) {
-								localProxyPort := ports.Pop()
+								localProxyPort := strconv.Itoa(localListenerAddr(t).Port(0))
 								proxyCtx, proxyCancel := context.WithTimeout(ctx, 10*time.Second)
 								defer proxyCancel()
 

--- a/tool/tsh/common/db_test.go
+++ b/tool/tsh/common/db_test.go
@@ -151,9 +151,9 @@ func testDatabaseLogin(t *testing.T) {
 			cfg.Auth.NetworkingConfig.SetProxyListenerMode(types.ProxyListenerMode_Multiplex)
 			// separate MySQL port with TLS routing.
 			// set the public address to be sure even on v2+, tsh clients will see the separate port.
-			mySQLAddr := localListenerAddr()
-			cfg.Proxy.MySQLAddr = utils.NetAddr{AddrNetwork: "tcp", Addr: mySQLAddr}
-			cfg.Proxy.MySQLPublicAddrs = []utils.NetAddr{{AddrNetwork: "tcp", Addr: mySQLAddr}}
+			mySQLAddr := localListenerAddr(t)
+			cfg.Proxy.MySQLAddr = *mySQLAddr
+			cfg.Proxy.MySQLPublicAddrs = []utils.NetAddr{*mySQLAddr}
 			cfg.Databases.Enabled = true
 			cfg.Databases.Databases = []servicecfg.Database{
 				{
@@ -2243,9 +2243,9 @@ func TestMongoDBSeparatePortCommandError(t *testing.T) {
 		testserver.WithClusterName("root"),
 		testserver.WithBootstrap(connector, alice),
 		testserver.WithConfig(func(cfg *servicecfg.Config) {
-			mongoPublicAddr := localListenerAddr()
-			cfg.Proxy.MongoAddr = utils.NetAddr{AddrNetwork: "tcp", Addr: mongoPublicAddr}
-			cfg.Proxy.MongoPublicAddrs = []utils.NetAddr{{AddrNetwork: "tcp", Addr: mongoPublicAddr}}
+			mongoPublicAddr := localListenerAddr(t)
+			cfg.Proxy.MongoAddr = *mongoPublicAddr
+			cfg.Proxy.MongoPublicAddrs = []utils.NetAddr{*mongoPublicAddr}
 			cfg.Databases.Enabled = true
 			cfg.Databases.Databases = []servicecfg.Database{
 				{

--- a/tool/tsh/common/kube_test.go
+++ b/tool/tsh/common/kube_test.go
@@ -29,6 +29,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"slices"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -140,11 +141,11 @@ func setupKubeTestPack(t *testing.T, withMultiplexMode bool) *kubeTestPack {
 			}
 			cfg.InsecureMode = true
 			cfg.Kube.Enabled = true
-			cfg.Kube.ListenAddr = utils.MustParseAddr(localListenerAddr())
+			cfg.Kube.ListenAddr = localListenerAddr(t)
 			cfg.Kube.KubeconfigPath = newKubeConfigFile(t, rootKubeCluster1, rootKubeCluster2)
 			cfg.Kube.StaticLabels = rootLabels
 			cfg.Proxy.Kube.Enabled = true
-			cfg.Proxy.Kube.ListenAddr = *utils.MustParseAddr(localListenerAddr())
+			cfg.Proxy.Kube.ListenAddr = *localListenerAddr(t)
 			cfg.SSH.Enabled = false
 		}),
 		withLeafCluster(),
@@ -155,7 +156,7 @@ func setupKubeTestPack(t *testing.T, withMultiplexMode bool) *kubeTestPack {
 				}
 				cfg.InsecureMode = true
 				cfg.Kube.Enabled = true
-				cfg.Kube.ListenAddr = utils.MustParseAddr(localListenerAddr())
+				cfg.Kube.ListenAddr = localListenerAddr(t)
 				cfg.Kube.KubeconfigPath = newKubeConfigFile(t, leafKubeCluster)
 				cfg.Kube.StaticLabels = leafLabels
 				cfg.SSH.Enabled = false
@@ -364,7 +365,7 @@ func TestKubeSelection(t *testing.T) {
 			cfg.Auth.NetworkingConfig.SetProxyListenerMode(types.ProxyListenerMode_Multiplex)
 			cfg.SSH.Enabled = false
 			cfg.Kube.Enabled = true
-			cfg.Kube.ListenAddr = utils.MustParseAddr(localListenerAddr())
+			cfg.Kube.ListenAddr = localListenerAddr(t)
 			cfg.Kube.ResourceMatchers = []services.ResourceMatcher{{
 				Labels: map[string]apiutils.Strings{"*": {"*"}},
 			}}
@@ -565,7 +566,7 @@ func TestKubeSelection(t *testing.T) {
 						return nil
 					}
 				}
-				err := Run(ctx, append([]string{"proxy", "kube", "--insecure", "--port", ports.Pop()}, test.args...),
+				err := Run(ctx, append([]string{"proxy", "kube", "--insecure", "--port", strconv.Itoa(localListenerAddr(t).Port(0))}, test.args...),
 					setCmdRunner(cmdRunner),
 					setHomePath(tshHome),
 					setKubeConfigPath(kubeConfigPath),

--- a/tool/tsh/common/proxy_test.go
+++ b/tool/tsh/common/proxy_test.go
@@ -1560,7 +1560,7 @@ func TestProxyAppWithIdentity(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	port := ports.Pop()
+	port := strconv.Itoa(localListenerAddr(t).Port(0))
 	tshArgs := []string{
 		"--debug",
 		"--insecure",
@@ -1642,7 +1642,7 @@ func TestProxyAppMultiPort(t *testing.T) {
 	// tsh proxy app seems to not handle multiple concurrent invocations well. Because of that, the
 	// test needs to first set up a local proxy, verify it and only then set up another one.
 
-	fooProxyPort := ports.Pop()
+	fooProxyPort := strconv.Itoa(localListenerAddr(t).Port(0))
 	fooTshArgs := []string{
 		"--debug",
 		"--insecure",
@@ -1658,7 +1658,7 @@ func TestProxyAppMultiPort(t *testing.T) {
 	})
 	mustDialLocalAppProxy(t, fooProxyPort, "foo")
 
-	fooNoTargetPortProxyPort := ports.Pop()
+	fooNoTargetPortProxyPort := strconv.Itoa(localListenerAddr(t).Port(0))
 	fooNoTargetPortTshArgs := []string{
 		"--debug",
 		"--insecure",
@@ -1675,7 +1675,7 @@ func TestProxyAppMultiPort(t *testing.T) {
 	// If there's no target port, the connections should still be routed to the first TCP port.
 	mustDialLocalAppProxy(t, fooNoTargetPortProxyPort, "foo")
 
-	barProxyPort := ports.Pop()
+	barProxyPort := strconv.Itoa(localListenerAddr(t).Port(0))
 	barTshArgs := []string{
 		"--debug",
 		"--insecure",

--- a/tool/tsh/common/tsh_helper_test.go
+++ b/tool/tsh/common/tsh_helper_test.go
@@ -20,9 +20,9 @@ package common
 
 import (
 	"context"
-	"fmt"
 	"io"
 	"io/fs"
+	"net"
 	"os"
 	"os/user"
 	"path/filepath"
@@ -50,6 +50,7 @@ import (
 	"github.com/gravitational/teleport/lib/service"
 	"github.com/gravitational/teleport/lib/service/servicecfg"
 	"github.com/gravitational/teleport/lib/services"
+	"github.com/gravitational/teleport/lib/utils"
 	"github.com/gravitational/teleport/lib/utils/log/logtest"
 )
 
@@ -185,7 +186,7 @@ func (s *suite) setupLeafCluster(t *testing.T, options testSuiteOptions) {
 		Auth: config.Auth{
 			Service: config.Service{
 				EnabledFlag:   "true",
-				ListenAddress: localListenerAddr(),
+				ListenAddress: localListenerAddr(t).String(),
 			},
 			ClusterName:       "leaf1",
 			ProxyListenerMode: types.ProxyListenerMode_Multiplex,
@@ -367,8 +368,17 @@ func runTeleport(t *testing.T, cfg *servicecfg.Config) *service.TeleportProcess 
 	return process
 }
 
-func localListenerAddr() string {
-	return fmt.Sprintf("localhost:%d", ports.PopInt())
+func localListenerAddr(t *testing.T) *utils.NetAddr {
+	t.Helper()
+
+	// Acquire a free port by listening on :0 and closing the listener. There is a small race between closing the
+	// listener and the process binding to the port, but it's unlikely to cause issues in practice. The port is
+	// immediately reusable since closing a listening socket that never accepted connections should not enter TIME_WAIT.
+	l, err := (&net.ListenConfig{}).Listen(t.Context(), "tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	require.NoError(t, l.Close())
+
+	return &utils.NetAddr{AddrNetwork: "tcp", Addr: l.Addr().String()}
 }
 
 func waitForEvents(t *testing.T, svc service.Supervisor, events ...string) {

--- a/tool/tsh/common/tsh_test.go
+++ b/tool/tsh/common/tsh_test.go
@@ -120,19 +120,11 @@ const (
 	tshBinMockHeadlessAddrEnv = "TSH_BIN_MOCK_HEADLESS_ADDR"
 )
 
-var ports utils.PortList
-
 const initTestSentinel = "init_test"
 
 func TestMain(m *testing.M) {
 	reexec.MaybeReexec()
 	handleReexec()
-
-	var err error
-	ports, err = utils.GetFreeTCPPorts(5000, utils.PortStartingNumber)
-	if err != nil {
-		panic(fmt.Sprintf("failed to allocate tcp ports for tests: %v", err))
-	}
 
 	modules.SetModules(&cliModules{})
 	modules.SetInsecureTestMode(true)
@@ -4462,14 +4454,14 @@ func makeTestServers(t *testing.T, opts ...testServerOptFunc) (auth *service.Tel
 		opt(&options)
 	}
 
-	authAddr := utils.NetAddr{AddrNetwork: "tcp", Addr: net.JoinHostPort("127.0.0.1", ports.Pop())}
+	authAddr := localListenerAddr(t)
 	var err error
 	// Set up a test auth server.
 	cfg := servicecfg.MakeDefaultConfig()
 	cfg.CircuitBreakerConfig = breaker.NoopBreakerConfig()
 	cfg.Hostname = "localhost"
 	cfg.DataDir = t.TempDir()
-	cfg.SetAuthServerAddress(authAddr)
+	cfg.SetAuthServerAddress(*authAddr)
 	cfg.Auth.BootstrapResources = options.bootstrap
 	cfg.Auth.StorageConfig.Params = backend.Params{defaults.BackendPath: filepath.Join(cfg.DataDir, defaults.BackendDir)}
 	cfg.Auth.StaticTokens, err = types.NewStaticTokens(types.StaticTokensSpecV2{
@@ -4483,12 +4475,12 @@ func makeTestServers(t *testing.T, opts ...testServerOptFunc) (auth *service.Tel
 	cfg.SetToken(staticToken)
 	cfg.SSH.Enabled = false
 	cfg.Auth.Enabled = true
-	cfg.Auth.ListenAddr = authAddr
+	cfg.Auth.ListenAddr = *authAddr
 	cfg.Auth.Preference.SetSignatureAlgorithmSuite(types.SignatureAlgorithmSuite_SIGNATURE_ALGORITHM_SUITE_BALANCED_V1)
 	cfg.Proxy.Enabled = true
-	cfg.Proxy.WebAddr = utils.NetAddr{AddrNetwork: "tcp", Addr: net.JoinHostPort("127.0.0.1", ports.Pop())}
-	cfg.Proxy.SSHAddr = utils.NetAddr{AddrNetwork: "tcp", Addr: net.JoinHostPort("127.0.0.1", ports.Pop())}
-	cfg.Proxy.ReverseTunnelListenAddr = utils.NetAddr{AddrNetwork: "tcp", Addr: net.JoinHostPort("127.0.0.1", ports.Pop())}
+	cfg.Proxy.WebAddr = *localListenerAddr(t)
+	cfg.Proxy.SSHAddr = *localListenerAddr(t)
+	cfg.Proxy.ReverseTunnelListenAddr = *localListenerAddr(t)
 	cfg.Proxy.DisableWebInterface = true
 	cfg.Logger = logtest.NewLogger()
 	// Disabling debug service for tests so that it doesn't break if the data
@@ -7464,10 +7456,7 @@ func TestInteractiveCompatibilityFlags(t *testing.T) {
 		withConfig(func(cfg *servicecfg.Config) {
 			cfg.Hostname = hostname
 			cfg.SSH.Enabled = true
-			cfg.SSH.Addr = utils.NetAddr{
-				AddrNetwork: "tcp",
-				Addr:        net.JoinHostPort("127.0.0.1", ports.Pop()),
-			}
+			cfg.SSH.Addr = *localListenerAddr(t)
 		}))
 
 	// Extract Auth Service and Proxy Service address.


### PR DESCRIPTION
## Problem

`tool/tsh/common` uses a shared global `ports utils.PortList` with 5000 pre-allocated port numbers. Under `-count 100 -shuffle on`, the pool exhausts and `ports.Pop()` panics. Tests that catch the panic or fail to bind to the resulting port enter retry loops in `mustRunOpenSSHCommand` (10s timeout), blocking `t.Parallel()` slots and causing a cascade of hanging tests until the `10m` timeout.

Seen in:
- https://github.com/gravitational/teleport/actions/runs/26771681307/job/78912517827
- https://github.com/gravitational/teleport/actions/runs/26771681307/job/78949586411

## Solution

Replace the fixed pool with on-demand OS port allocation via `net.ListenConfig.Listen(ctx, "tcp", "127.0.0.1:0")`.