### PR TITLE
Fix flaky test `TestModeratedSession`

### DIFF
--- a/integration/kube_integration_test.go
+++ b/integration/kube_integration_test.go
@@ -2581,10 +2581,10 @@ func testKubeJoin(t *testing.T, suite *KubeSuite) {
 }
 
 func waitForOutput(ctx context.Context, r ReaderWithDeadline, expected string) error {
-	var prev string
-	out := make([]byte, int64(len(expected)*3))
+	var out strings.Builder
+	chunk := make([]byte, int64(len(expected)*2))
 	defer func() {
-		slog.DebugContext(ctx, "waitForOutput final read", "output", prev, "expected", expected)
+		slog.DebugContext(ctx, "waitForOutput final read", "output", removeSpace(out.String()), "expected", expected)
 	}()
 	for {
 		select {
@@ -2599,25 +2599,26 @@ func waitForOutput(ctx context.Context, r ReaderWithDeadline, expected string) e
 				return trace.Wrap(err)
 			}
 		}
-		n, err := r.Read(out)
-		outStr := removeSpace(string(out[:n]))
+		n, err := r.Read(chunk)
+		out.Write(chunk[:n])
 
-		prev += outStr
-		slog.DebugContext(ctx, "waitForOutput read", "output", prev, "expected", expected)
+		normalized := removeSpace(out.String())
+		slog.DebugContext(ctx, "waitForOutput read", "output", normalized, "expected", expected)
+
 		// Check for [expected] before checking the error,
 		// as it's valid for n > 0 even when there is an error.
 		// The [expected] is checked against the current and previous
 		// output to account for scenarios where the [expected] is split
-		// across two reads. While we try to prevent this by reading
+		// across 2+ reads. While we try to prevent this by reading
 		// twice the length of [expected] there are no guarantees the
-		// whole thing will arrive in a single read.
-		if n > 0 && strings.Contains(prev, expected) {
+		// whole thing will arrive in a single read since there is no
+		// minimum chunk length.
+		if n > 0 && strings.Contains(normalized, expected) {
 			return nil
 		}
 		if err != nil {
 			return trace.Wrap(err)
 		}
-
 	}
 }
 

--- a/lib/web/apiserver_test.go
+++ b/lib/web/apiserver_test.go
@@ -8696,22 +8696,23 @@ func waitForOutputWithDuration(ctx context.Context, r io.Reader, substr string, 
 	timeoutCh := time.After(timeout)
 	errC := make(chan error, 1)
 	go func() {
-		var prev string
-		out := make([]byte, int64(len(substr)*3))
+		var allOut strings.Builder
+		out := make([]byte, int64(len(substr)*2))
 		for {
 			n, err := r.Read(out)
-			outStr := removeSpace(string(out[:n]))
+			allOut.Write(out[:n])
 
-			slog.DebugContext(ctx, "waitForOutput read", "output", outStr, "expected", substr)
+			normalized := removeSpace(allOut.String())
+			slog.DebugContext(ctx, "waitForOutput read", "output", normalized, "expected", substr)
 
 			// Check for [substr] before checking the error,
 			// as it's valid for n > 0 even when there is an error.
 			// The [substr] is checked against the current and previous
 			// output to account for scenarios where the [substr] is split
-			// across two reads. While we try to prevent this by reading
+			// across 2+ reads. While we try to prevent this by reading
 			// twice the length of [substr] there are no guarantees the
 			// whole thing will arrive in a single read.
-			if n > 0 && strings.Contains(prev+outStr, substr) {
+			if n > 0 && strings.Contains(normalized, substr) {
 				errC <- nil
 				return
 			}
@@ -8719,7 +8720,6 @@ func waitForOutputWithDuration(ctx context.Context, r io.Reader, substr string, 
 				errC <- err
 				return
 			}
-			prev = outStr
 		}
 	}()
 

--- a/lib/web/apiserver_test.go
+++ b/lib/web/apiserver_test.go
@@ -8696,13 +8696,13 @@ func waitForOutputWithDuration(ctx context.Context, r io.Reader, substr string, 
 	timeoutCh := time.After(timeout)
 	errC := make(chan error, 1)
 	go func() {
-		var allOut strings.Builder
-		out := make([]byte, int64(len(substr)*2))
+		var out strings.Builder
+		chunk := make([]byte, int64(len(substr)*2))
 		for {
-			n, err := r.Read(out)
-			allOut.Write(out[:n])
+			n, err := r.Read(chunk)
+			out.Write(chunk[:n])
 
-			normalized := removeSpace(allOut.String())
+			normalized := removeSpace(out.String())
 			slog.DebugContext(ctx, "waitForOutput read", "output", normalized, "expected", substr)
 
 			// Check for [substr] before checking the error,
@@ -8711,7 +8711,8 @@ func waitForOutputWithDuration(ctx context.Context, r io.Reader, substr string, 
 			// output to account for scenarios where the [substr] is split
 			// across 2+ reads. While we try to prevent this by reading
 			// twice the length of [substr] there are no guarantees the
-			// whole thing will arrive in a single read.
+			// whole thing will arrive in a single read since there is no
+			// minimum chunk length.
 			if n > 0 && strings.Contains(normalized, substr) {
 				errC <- nil
 				return


### PR DESCRIPTION
The cause of the new test flake is clear by looking at the logs.

```
2026-05-23T12:40:34.5081557Z {"timestamp":"2026-05-23T10:48:36Z","level":"debug","caller":"web/apiserver_test.go:8596","message":"waitForOutput read","output":"Teleport > User bar joined the session with participant mode: moderator.","expected":"Teleport > Connecting to node over SSH"}
2026-05-23T12:40:34.5083123Z {"timestamp":"2026-05-23T10:48:36Z","level":"debug","caller":"web/apiserver_test.go:8596","message":"waitForOutput read","output":"\u001b[?2004h\u001b]0;root@47141e43a4e5: ~\u0007root@47141e43a4e5:~#  \u001b[K\u001b]0;root@47141e43a4e5: ~\u0007root@47141e43a4e5:~# Teleport >","expected":"Teleport > Connecting to node over SSH"}
2026-05-23T12:40:34.5084540Z {"timestamp":"2026-05-23T10:48:36Z","level":"debug","caller":"web/apiserver_test.go:8596","message":"waitForOutput read","output":"Connecting to node over SSH","expected":"Teleport > Connecting to node over SSH"}
```

`waitForOutput` first sees `... Teleport >` and then `Connecting to node over SSH`. When concatenated, this produces `Teleport >Connecting to node over SSH` instead of ` `Teleport > Connecting to node over SSH`. The solution is to only remove whitespace on the comparison string rather than our accumulation string.

Note: I also applied this fix to the kubernetes moderated sessions test, though we haven't seen this flake in the wild yet.

Additionally, there's a chance that the expected output could happen across 3+ reads, so we accumulate all output rather than just prev+current. I haven't seen this flake in practice, but it's definitely possible since there is no "minimum" read size for each chunk.

Closes https://github.com/gravitational/teleport/pull/65358