### PR TITLE
 [v17] Fix duplicate cache backend metric registration causing metrics gather error logs

### DIFF
--- a/lib/auth/accesspoint/accesspoint.go
+++ b/lib/auth/accesspoint/accesspoint.go
@@ -152,9 +152,10 @@ func NewCache(cfg Config) (*cache.Cache, error) {
 	}
 
 	reporter, err := backend.NewReporter(backend.ReporterConfig{
-		Component: teleport.ComponentCache,
-		Backend:   mem,
-		Tracer:    tracer,
+		Component:  teleport.ComponentCache,
+		Backend:    mem,
+		Tracer:     tracer,
+		Registerer: cfg.Registerer,
 	})
 	if err != nil {
 		return nil, trace.Wrap(err)


### PR DESCRIPTION
Changelog: Fixed "error gathering metrics" log spam.

Registers the cache's in-memory backend `Reporter` metrics with the provided
`Registerer` instead of the global `prometheus.DefaultRegisterer`. Without this,
the shared backend metric collectors land in two registries that the metrics
service scrapes together, producing `collected metric ... was collected before
with the same name and label values` errors for `component="cache"`.

This is a minimal backport of the relevant part of #56096 (not backported to
v17), needed because #64983 (which makes `RegisterCollectors` honor the provided
registry) was backported and activated the latent duplicate registration.

## Manual Test Plan
### Test Environment
Teleport cluster with `diag_addr` set.

### Test Cases
- [x] `curl -s http://127.0.0.1:3000/metrics` produces no `was collected before` / `error gathering metrics` lines in the logs
