### PR TITLE
scope-qualified names

### DIFF
--- a/docs/pages/reference/cli/tctl.mdx
+++ b/docs/pages/reference/cli/tctl.mdx
@@ -1195,13 +1195,14 @@ Edit a Teleport resource.
 Usage:
 
 ```code
-$ tctl edit [<resource type/resource name>]
+$ tctl edit [<resource type/resource name>] [<id>]
 ```
 
 Arguments:
 
 |Argument|Default|Description|
 |---|---|---|
+|id|*no default* (optional)|Resource identifier: scope-qualified name (e.g. "/staging/west::myrole") or bare name for unscoped kinds|
 |resource type/resource name|*no default* (optional)|Resource to update, e.g., "user/myuser"|
 
 ## tctl get
@@ -1211,7 +1212,7 @@ Print a YAML declaration of various Teleport resources.
 Usage:
 
 ```code
-$ tctl get [<flags>] <resources>
+$ tctl get [<flags>] <resources> [<id>]
 ```
 
 Flags:
@@ -1226,6 +1227,7 @@ Arguments:
 
 |Argument|Default|Description|
 |---|---|---|
+|id|*no default* (optional)|Resource identifier: scope-qualified name (e.g. "/staging/west::myrole") or bare name for unscoped kinds|
 |resources|*no default* (required)|Resource spec: 'type/\[name\]\[,...\]' or 'all'|
 
 ## tctl help
@@ -2053,13 +2055,14 @@ Delete a resource.
 Usage:
 
 ```code
-$ tctl rm [<resource type/resource name>]
+$ tctl rm [<resource type/resource name>] [<id>]
 ```
 
 Arguments:
 
 |Argument|Default|Description|
 |---|---|---|
+|id|*no default* (optional)|Resource identifier: scope-qualified name (e.g. "/staging/west::myrole") or bare name for unscoped kinds|
 |resource type/resource name|*no default* (optional)|Resource to delete
 	\<resource type\>  Type of a resource \[for example: connector,user,cluster,token\]
 	\<resource name\>  Resource name to delete
@@ -2444,7 +2447,7 @@ Update resource fields.
 Usage:
 
 ```code
-$ tctl update [<flags>] [<resource type/resource name>]
+$ tctl update [<flags>] [<resource type/resource name>] [<id>]
 ```
 
 Flags:
@@ -2458,6 +2461,7 @@ Arguments:
 
 |Argument|Default|Description|
 |---|---|---|
+|id|*no default* (optional)|Resource identifier: scope-qualified name (e.g. "/staging/west::myrole") or bare name for unscoped kinds|
 |resource type/resource name|*no default* (optional)|Resource to update
 	\<resource type\>  Type of a resource \[for example: rc\]
 	\<resource name\>  Resource name to update

--- a/fuzz/oss-fuzz-build.sh
+++ b/fuzz/oss-fuzz-build.sh
@@ -131,6 +131,12 @@ build_teleport_fuzzers() {
   compile_native_go_fuzzer $TELEPORT_PREFIX/lib/httplib/sse \
     FuzzRead fuzz_read_sse_events
 
+  compile_native_go_fuzzer $TELEPORT_PREFIX/lib/scopes \
+    FuzzParseQualifiedName fuzz_parse_qualified_name
+
+  compile_native_go_fuzzer $TELEPORT_PREFIX/lib/scopes \
+    FuzzValidateQualifiedName fuzz_validate_qualified_name
+
 }
 
 build_teleport_api_fuzzers() {

--- a/lib/scopes/fuzz_test.go
+++ b/lib/scopes/fuzz_test.go
@@ -1,0 +1,101 @@
+/*
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package scopes
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// FuzzParseQualifiedName verifies that ParseQualifiedName never panics and that
+// any successfully parsed value round-trips through String() unchanged.
+func FuzzParseQualifiedName(f *testing.F) {
+	// valid SQNs
+	f.Add("/staging/west::myrole")
+	f.Add("/staging::myrole")
+	f.Add("/::myrole")
+	f.Add("/staging::my-role")
+	f.Add("/staging::318ea8be-129c-41f4-ad95-fd830e14e3e7")
+	// multiple separators — splits on first
+	f.Add("/staging::my::role")
+	// invalid but parseable
+	f.Add("staging::myrole")
+	// parse errors
+	f.Add("")
+	f.Add("::")
+	f.Add("::myrole")
+	f.Add("/staging::")
+	f.Add("no-separator")
+	f.Add("/staging/west::my role")
+
+	f.Fuzz(func(t *testing.T, sqn string) {
+		var qn QualifiedName
+		var err error
+		require.NotPanics(t, func() { qn, err = ParseQualifiedName(sqn) })
+		if err != nil {
+			return
+		}
+
+		// round-trip: String() must re-parse to the same value
+		require.NotPanics(t, func() {
+			qn2, err2 := ParseQualifiedName(qn.String())
+			require.NoError(t, err2, "String() of a parsed QualifiedName must re-parse without error")
+			require.Equal(t, qn, qn2, "String() of a parsed QualifiedName must round-trip to an identical value")
+		})
+	})
+}
+
+// FuzzValidateQualifiedName verifies that neither validate function panics, and that
+// strong validation passing implies weak validation passing.
+func FuzzValidateQualifiedName(f *testing.F) {
+	// valid under both
+	f.Add("/staging/west::myrole")
+	f.Add("/staging::myrole")
+	f.Add("/::myrole")
+	f.Add("/staging::my-role")
+	f.Add("/staging::318ea8be-129c-41f4-ad95-fd830e14e3e7")
+	// valid under weak only
+	f.Add("staging::myrole")
+	f.Add("/Staging/west::myrole")
+	f.Add("/staging::MyRole")
+	f.Add("/a/west::myrole")
+	f.Add("/staging::x")
+	// invalid under both
+	f.Add("")
+	f.Add("::")
+	f.Add("::myrole")
+	f.Add("/staging::")
+	f.Add("no-separator")
+	f.Add("/staging::my role")
+	f.Add("/stag@ing::myrole")
+	f.Add("/staging::my::role")
+
+	f.Fuzz(func(t *testing.T, sqn string) {
+		var strongErr, weakErr error
+
+		require.NotPanics(t, func() { strongErr = StrongValidateQualifiedName(sqn) })
+		require.NotPanics(t, func() { weakErr = WeakValidateQualifiedName(sqn) })
+
+		// strong passing must imply weak passing
+		if strongErr == nil {
+			require.NoError(t, weakErr, "StrongValidateQualifiedName passed but WeakValidateQualifiedName failed for %q", sqn)
+		}
+	})
+}

--- a/lib/scopes/qualified.go
+++ b/lib/scopes/qualified.go
@@ -1,0 +1,141 @@
+/*
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package scopes
+
+import (
+	"strings"
+
+	"github.com/gravitational/trace"
+)
+
+// QualifiedNameSeparator is the separator between scope and name in a
+// scope-qualified name. This separator must never appear in scope segements.
+const QualifiedNameSeparator = "::"
+
+// QualifiedName pairs a scope with a resource name to uniquely identify a scoped
+// resource. The canonical form of a scope-qualified name (SQN) is "<scope>::<name>",
+// e.g. "/staging/west::myrole". SQNs take the place of bare names in configuration
+// resource specs, CLI interfaces, and user-facing messages (e.g. errors) where it
+// is necessary to fully specify the unique identifier of a scoped resource. Internally,
+// teleport APIs should generally continue to use separate scope and name fields, as
+// should structured logs/events.
+type QualifiedName struct {
+	// Scope is the resource's scope path, e.g. "/staging/west".
+	Scope string
+	// Name is the resource's name within its scope, e.g. "myrole".
+	Name string
+}
+
+// String returns encodes the string representation of the QualifiedName.
+func (q QualifiedName) String() string {
+	return q.Scope + QualifiedNameSeparator + q.Name
+}
+
+// StrongValidate validates this QualifiedName using strong validation rules. This method
+// *must* be called on all QualifiedName values derived from user input and/or cluster-external
+// sources. Use [QualifiedName.WeakValidate] when checking values from the control plane in
+// logic that may run agent-side.
+func (q QualifiedName) StrongValidate() error {
+	if err := StrongValidate(q.Scope); err != nil {
+		return trace.BadParameter("scope-qualified name %q has invalid scope: %v", q, err)
+	}
+
+	if err := StrongValidateSegment(q.Name); err != nil {
+		return trace.BadParameter("scope-qualified name %q has invalid name: %v", q, err)
+	}
+
+	// as an extra precaution, also run all weak checks just to be certain we didn't accidentally
+	// construct a weak check that rejects something that would otherwise pass a strong check.
+	if err := q.WeakValidate(); err != nil {
+		return trace.Wrap(err)
+	}
+
+	return nil
+}
+
+// WeakValidate performs a weak form of validation on this QualifiedName. This is useful for
+// ensuring that values received from trusted sources (e.g. the control plane) haven't been
+// altered beyond our ability to reason effectively about them. Prefer [QualifiedName.StrongValidate]
+// for values derived from external sources (e.g. user input).
+func (q QualifiedName) WeakValidate() error {
+	if err := WeakValidate(q.Scope); err != nil {
+		return trace.BadParameter("scope-qualified name %q has invalid scope: %v", q, err)
+	}
+
+	if err := WeakValidateSegment(q.Name); err != nil {
+		return trace.BadParameter("scope-qualified name %q has invalid name: %v", q, err)
+	}
+
+	return nil
+}
+
+// ParseQualifiedName parses a scope-qualified name string into its scope and name
+// components by splitting on the first occurrence of "::". Returns an error if the
+// separator is absent or either component is empty. This function does not validate
+// the format of the scope or name components; use [QualifiedName.StrongValidate] or
+// [QualifiedName.WeakValidate] for validation.
+func ParseQualifiedName(sqn string) (QualifiedName, error) {
+	idx := strings.Index(sqn, QualifiedNameSeparator)
+	if idx < 0 {
+		return QualifiedName{}, trace.BadParameter("scope-qualified name %q missing %q separator", sqn, QualifiedNameSeparator)
+	}
+
+	scope := sqn[:idx]
+	name := sqn[idx+len(QualifiedNameSeparator):]
+
+	if scope == "" {
+		return QualifiedName{}, trace.BadParameter("scope-qualified name %q has empty scope component", sqn)
+	}
+
+	if name == "" {
+		return QualifiedName{}, trace.BadParameter("scope-qualified name %q has empty name component", sqn)
+	}
+
+	return QualifiedName{Scope: scope, Name: name}, nil
+}
+
+// StrongValidateQualifiedName validates a scope-qualified name string using strong validation
+// rules. This function *must* be called on all scope-qualified name values received from
+// user input and/or cluster-external sources. Use [WeakValidateQualifiedName] when
+// checking values from the control plane in logic that may run agent-side.
+//
+// Prefer parsing with [ParseQualifiedName] and then calling [QualifiedName.StrongValidate]
+// directly when the parsed value is needed, to avoid parsing twice.
+func StrongValidateQualifiedName(sqn string) error {
+	qn, err := ParseQualifiedName(sqn)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	return qn.StrongValidate()
+}
+
+// WeakValidateQualifiedName performs a weak form of validation on a scope-qualified name string.
+// This is useful for ensuring that values received from trusted sources (e.g. the control
+// plane) haven't been altered beyond our ability to reason effectively about them. Prefer
+// [StrongValidateQualifiedName] for values received from external sources (e.g. user input).
+//
+// Prefer parsing with [ParseQualifiedName] and then calling [QualifiedName.WeakValidate]
+// directly when the parsed value is needed, to avoid parsing twice.
+func WeakValidateQualifiedName(sqn string) error {
+	qn, err := ParseQualifiedName(sqn)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	return qn.WeakValidate()
+}

--- a/lib/scopes/qualified_test.go
+++ b/lib/scopes/qualified_test.go
@@ -1,0 +1,299 @@
+/*
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package scopes
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestQualifiedNameRoundTrip verifies encoding/decoding of scope-qualified names,
+// including cases that parse successfully but fail strong or weak validation.
+func TestQualifiedNameRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	tts := []struct {
+		name      string
+		scope     string
+		rname     string
+		sqn       string
+		strongErr bool
+		weakErr   bool
+	}{
+		{
+			name:  "basic",
+			scope: "/staging/west",
+			rname: "myrole",
+			sqn:   "/staging/west::myrole",
+		},
+		{
+			name:  "single-segment scope",
+			scope: "/staging",
+			rname: "myrole",
+			sqn:   "/staging::myrole",
+		},
+		{
+			name:  "root scope",
+			scope: "/",
+			rname: "myrole",
+			sqn:   "/::myrole",
+		},
+		{
+			name:  "hyphenated name",
+			scope: "/staging/west",
+			rname: "my-role",
+			sqn:   "/staging/west::my-role",
+		},
+		{
+			name:  "uuid name",
+			scope: "/staging",
+			rname: "318ea8be-129c-41f4-ad95-fd830e14e3e7",
+			sqn:   "/staging::318ea8be-129c-41f4-ad95-fd830e14e3e7",
+		},
+		{
+			name:      "multiple separators split on first",
+			scope:     "/staging",
+			rname:     "my::role",
+			sqn:       "/staging::my::role",
+			strongErr: true,
+		},
+		{
+			name:      "scope without leading slash",
+			scope:     "staging",
+			rname:     "myrole",
+			sqn:       "staging::myrole",
+			strongErr: true,
+		},
+		{
+			name:      "name with breaking character",
+			scope:     "/staging",
+			rname:     "my role",
+			sqn:       "/staging::my role",
+			strongErr: true,
+			weakErr:   true,
+		},
+	}
+
+	for _, tt := range tts {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if tt.strongErr {
+				require.Error(t, StrongValidateQualifiedName(tt.sqn))
+			} else {
+				require.NoError(t, StrongValidateQualifiedName(tt.sqn))
+			}
+
+			if tt.weakErr {
+				require.Error(t, WeakValidateQualifiedName(tt.sqn))
+			} else {
+				require.NoError(t, WeakValidateQualifiedName(tt.sqn))
+			}
+
+			require.Equal(t, tt.sqn, QualifiedName{Scope: tt.scope, Name: tt.rname}.String())
+
+			qn, err := ParseQualifiedName(tt.sqn)
+			require.NoError(t, err)
+			require.Equal(t, tt.scope, qn.Scope)
+			require.Equal(t, tt.rname, qn.Name)
+		})
+	}
+}
+
+// TestParseQualifiedNameErrors verifies expected error cases for ParseQualifiedName.
+func TestParseQualifiedNameErrors(t *testing.T) {
+	t.Parallel()
+
+	tts := []struct {
+		name string
+		sqn  string
+	}{
+		{
+			name: "no separator",
+			sqn:  "staging-west-myrole",
+		},
+		{
+			name: "empty scope",
+			sqn:  "::myrole",
+		},
+		{
+			name: "empty name",
+			sqn:  "/staging/west::",
+		},
+		{
+			name: "empty string",
+			sqn:  "",
+		},
+		{
+			name: "separator only",
+			sqn:  "::",
+		},
+	}
+
+	for _, tt := range tts {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := ParseQualifiedName(tt.sqn)
+			require.Error(t, err)
+			require.Error(t, WeakValidateQualifiedName(tt.sqn))
+			require.Error(t, StrongValidateQualifiedName(tt.sqn))
+		})
+	}
+}
+
+func TestValidateQualifiedName(t *testing.T) {
+	t.Parallel()
+
+	tts := []struct {
+		name     string
+		sqn      string
+		strongOk bool
+		weakOk   bool
+	}{
+		{
+			name:     "basic valid",
+			sqn:      "/staging/west::myrole",
+			strongOk: true,
+			weakOk:   true,
+		},
+		{
+			name:     "root scope",
+			sqn:      "/::myrole",
+			strongOk: true,
+			weakOk:   true,
+		},
+		{
+			name:     "single-segment scope",
+			sqn:      "/staging::myrole",
+			strongOk: true,
+			weakOk:   true,
+		},
+		{
+			name:     "hyphenated name",
+			sqn:      "/staging::my-role",
+			strongOk: true,
+			weakOk:   true,
+		},
+		{
+			name:     "uuid name",
+			sqn:      "/staging::318ea8be-129c-41f4-ad95-fd830e14e3e7",
+			strongOk: true,
+			weakOk:   true,
+		},
+		{
+			name:     "scope with breaking char",
+			sqn:      "/stag@ing::myrole",
+			strongOk: false,
+			weakOk:   false,
+		},
+		{
+			name:     "scope with space",
+			sqn:      "/stag ing::myrole",
+			strongOk: false,
+			weakOk:   false,
+		},
+		{
+			name:     "uppercase scope segment",
+			sqn:      "/Staging/west::myrole",
+			strongOk: false,
+			weakOk:   true,
+		},
+		{
+			name:     "scope segment too short",
+			sqn:      "/a/west::myrole",
+			strongOk: false,
+			weakOk:   true,
+		},
+		{
+			name:     "missing leading slash in scope",
+			sqn:      "staging::myrole",
+			strongOk: false,
+			weakOk:   true,
+		},
+		{
+			name:     "name with breaking char",
+			sqn:      "/staging::my@role",
+			strongOk: false,
+			weakOk:   false,
+		},
+		{
+			name:     "name with whitespace",
+			sqn:      "/staging::my role",
+			strongOk: false,
+			weakOk:   false,
+		},
+		{
+			name:     "name with slash",
+			sqn:      "/staging::my/role",
+			strongOk: false,
+			weakOk:   false,
+		},
+		{
+			name:     "uppercase name",
+			sqn:      "/staging::MyRole",
+			strongOk: false,
+			weakOk:   true,
+		},
+		{
+			name:     "name too short",
+			sqn:      "/staging::x",
+			strongOk: false,
+			weakOk:   true,
+		},
+		{
+			name:     "no separator",
+			sqn:      "/staging-myrole",
+			strongOk: false,
+			weakOk:   false,
+		},
+		{
+			name:     "empty scope component",
+			sqn:      "::myrole",
+			strongOk: false,
+			weakOk:   false,
+		},
+		{
+			name:     "empty name component",
+			sqn:      "/staging::",
+			strongOk: false,
+			weakOk:   false,
+		},
+	}
+
+	for _, tt := range tts {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := StrongValidateQualifiedName(tt.sqn)
+			if tt.strongOk {
+				require.NoError(t, err)
+			} else {
+				require.Error(t, err)
+			}
+
+			err = WeakValidateQualifiedName(tt.sqn)
+			if tt.weakOk {
+				require.NoError(t, err)
+			} else {
+				require.Error(t, err)
+			}
+		})
+	}
+}

--- a/tool/tctl/common/edit_command.go
+++ b/tool/tctl/common/edit_command.go
@@ -53,7 +53,8 @@ type EditCommand struct {
 	app     *kingpin.Application
 	cmd     *kingpin.CmdClause
 	config  *servicecfg.Config
-	ref     services.Ref
+	ref     string
+	id      string
 	confirm bool
 
 	// Editor is used by tests to inject the editing mechanism
@@ -65,7 +66,8 @@ func (e *EditCommand) Initialize(app *kingpin.Application, _ *tctlcfg.GlobalCLIF
 	e.app = app
 	e.config = config
 	e.cmd = app.Command("edit", "Edit a Teleport resource.")
-	e.cmd.Arg("resource type/resource name", `Resource to update, e.g., "user/myuser"`).SetValue(&e.ref)
+	e.cmd.Arg("resource type/resource name", `Resource to update, e.g., "user/myuser"`).StringVar(&e.ref)
+	e.cmd.Arg("id", `Resource identifier: scope-qualified name (e.g. "/staging/west::myrole") or bare name for unscoped kinds`).StringVar(&e.id)
 	e.cmd.Flag("confirm", "Confirm an unsafe or temporary resource update").Hidden().BoolVar(&e.confirm)
 }
 
@@ -116,7 +118,8 @@ func (e *EditCommand) editResource(ctx context.Context, client *authclient.Clien
 	}()
 
 	rc := &ResourceCommand{
-		refs:        services.Refs{e.ref},
+		ref:         e.ref,
+		id:          e.id,
 		format:      teleport.YAML,
 		Stdout:      f,
 		filename:    f.Name(),
@@ -134,12 +137,19 @@ func (e *EditCommand) editResource(ctx context.Context, client *authclient.Clien
 		return trace.Wrap(err)
 	}
 
+	// Build a user-facing resource descriptor that includes the id (SQN or bare
+	// name) when one was provided, so error messages reflect what the user typed.
+	resourceDesc := e.ref
+	if e.id != "" {
+		resourceDesc = e.ref + " " + e.id
+	}
+
 	err = rc.Get(ctx, client)
 	if closeErr := f.Close(); closeErr != nil {
 		return trace.Wrap(err)
 	}
 	if err != nil {
-		return trace.Wrap(err, "could not get resource %v", rc.ref.String())
+		return trace.Wrap(err, "could not get resource %v", resourceDesc)
 	}
 
 	originalSum, err := checksum(f.Name())
@@ -162,12 +172,13 @@ func (e *EditCommand) editResource(ctx context.Context, client *authclient.Clien
 	if len(originalResourcesMap) != len(originalResources) {
 		slog.DebugContext(ctx, "tctl edit clobbered resources on originalResourcesMap",
 			"ref", e.ref,
+			"id", e.id,
 			"original_resources_map_len", len(originalResourcesMap),
 			"original_resources_len", len(originalResources),
 		)
 		return trace.BadParameter(
 			"tctl edit cannot handle multiple resources of kind %q, please specify a single resource to edit",
-			e.ref.Kind,
+			e.ref,
 		)
 	}
 
@@ -217,14 +228,22 @@ func (e *EditCommand) editResource(ctx context.Context, client *authclient.Clien
 			continue
 		}
 
+		opts := resources.CreateOpts{
+			Force:   rc.force,
+			Confirm: rc.confirm,
+		}
+
 		// Try looking for a resource handler
 		if resourceHandler, found := resources.Handlers()[newResource.Kind]; found {
-			opts := resources.CreateOpts{
-				Force:   rc.force,
-				Confirm: rc.confirm,
+			if err := editUpdateWithFallback(ctx, client, resourceHandler, newResource, opts); err != nil {
+				return trace.Wrap(err)
 			}
-			if err := editUpdateWithFallback(
-				ctx, client, resourceHandler, newResource, opts); err != nil {
+			continue
+		}
+
+		// Try looking for a scoped resource handler
+		if scopedHandler, found := resources.ScopedHandlers()[newResource.Kind]; found {
+			if err := editUpdateWithFallbackScoped(ctx, client, scopedHandler, newResource, opts); err != nil {
 				return trace.Wrap(err)
 			}
 			continue
@@ -272,6 +291,25 @@ func editUpdateWithFallback(
 	// TODO(tross) remove the fallback to CreateHandlers once all the resources
 	// have been updated to implement an UpdateHandler.
 	if err := resourceHandler.Create(ctx, client, resource, opts); trace.IsNotImplemented(err) {
+		return trace.BadParameter("updating resources of type %q is not supported", resource.Kind)
+	} else {
+		return trace.Wrap(err)
+	}
+}
+
+func editUpdateWithFallbackScoped(
+	ctx context.Context,
+	client *authclient.Client,
+	handler resources.ScopedHandler,
+	resource services.UnknownResource,
+	opts resources.CreateOpts,
+) error {
+	err := handler.Update(ctx, client, resource, opts)
+	if err == nil || !trace.IsNotImplemented(err) {
+		return trace.Wrap(err)
+	}
+
+	if err := handler.Create(ctx, client, resource, opts); trace.IsNotImplemented(err) {
 		return trace.BadParameter("updating resources of type %q is not supported", resource.Kind)
 	} else {
 		return trace.Wrap(err)

--- a/tool/tctl/common/edit_command_test.go
+++ b/tool/tctl/common/edit_command_test.go
@@ -746,7 +746,7 @@ func testEditScopedToken(t *testing.T, clt *authclient.Client) {
 		return trace.NewAggregate(writeYAML(collection, f), f.Close())
 	}
 
-	_, err = runEditCommand(t, clt, []string{"edit", types.KindScopedToken + "/" + created.GetMetadata().GetName()}, withEditor(editor))
+	_, err = runEditCommand(t, clt, []string{"edit", types.KindScopedToken, "/staging::" + created.GetMetadata().GetName()}, withEditor(editor))
 	require.NoError(t, err)
 
 	actual, err := clt.GetScopedToken(ctx, created.GetMetadata().GetName(), true)
@@ -754,7 +754,7 @@ func testEditScopedToken(t *testing.T, clt *authclient.Client) {
 	require.Equal(t, "test", actual.GetMetadata().GetLabels()["env"])
 
 	// Second edit with the stale original revision should fail.
-	_, err = runEditCommand(t, clt, []string{"edit", types.KindScopedToken + "/" + created.GetMetadata().GetName()}, withEditor(editor))
+	_, err = runEditCommand(t, clt, []string{"edit", types.KindScopedToken, "/staging::" + created.GetMetadata().GetName()}, withEditor(editor))
 	require.Error(t, err)
 	require.True(t, trace.IsCompareFailed(err))
 }

--- a/tool/tctl/common/resource_command.go
+++ b/tool/tctl/common/resource_command.go
@@ -68,8 +68,8 @@ type ResourceCreateHandler func(context.Context, *authclient.Client, services.Un
 // Teleport resources
 type ResourceCommand struct {
 	config      *servicecfg.Config
-	ref         services.Ref
-	refs        services.Refs
+	ref         string
+	id          string
 	format      string
 	namespace   string
 	withSecrets bool
@@ -139,7 +139,8 @@ func (rc *ResourceCommand) Initialize(app *kingpin.Application, _ *tctlcfg.Globa
 	<resource name>  Resource name to update
 
 	Example:
-	$ tctl update rc/remote`).SetValue(&rc.ref)
+	$ tctl update rc/remote`).StringVar(&rc.ref)
+	rc.updateCmd.Arg("id", `Resource identifier: scope-qualified name (e.g. "/staging/west::myrole") or bare name for unscoped kinds`).StringVar(&rc.id)
 	rc.updateCmd.Flag("set-labels", "Set labels").StringVar(&rc.labels)
 	rc.updateCmd.Flag("set-ttl", "Set TTL").StringVar(&rc.ttl)
 
@@ -150,10 +151,12 @@ func (rc *ResourceCommand) Initialize(app *kingpin.Application, _ *tctlcfg.Globa
 
 	Examples:
 	$ tctl rm role/devs
-	$ tctl rm cluster/main`).SetValue(&rc.ref)
+	$ tctl rm cluster/main`).StringVar(&rc.ref)
+	rc.deleteCmd.Arg("id", `Resource identifier: scope-qualified name (e.g. "/staging/west::myrole") or bare name for unscoped kinds`).StringVar(&rc.id)
 
 	rc.getCmd = app.Command("get", "Print a YAML declaration of various Teleport resources.")
-	rc.getCmd.Arg("resources", "Resource spec: 'type/[name][,...]' or 'all'").Required().SetValue(&rc.refs)
+	rc.getCmd.Arg("resources", "Resource spec: 'type/[name][,...]' or 'all'").Required().StringVar(&rc.ref)
+	rc.getCmd.Arg("id", `Resource identifier: scope-qualified name (e.g. "/staging/west::myrole") or bare name for unscoped kinds`).StringVar(&rc.id)
 	rc.getCmd.Flag("format", "Output format: 'yaml', 'json' or 'text'").Default(teleport.YAML).StringVar(&rc.format)
 	rc.getCmd.Flag("namespace", "Namespace of the resources").Hidden().Default(apidefaults.Namespace).StringVar(&rc.namespace)
 	rc.getCmd.Flag("with-secrets", "Include secrets in resources like certificate authorities or OIDC connectors").Default("false").BoolVar(&rc.withSecrets)
@@ -209,12 +212,6 @@ func (rc *ResourceCommand) IsDeleteSubcommand(cmd string) bool {
 	return cmd == rc.deleteCmd.FullCommand()
 }
 
-// GetRef returns the reference (basically type/name pair) of the resource
-// the command is operating on
-func (rc *ResourceCommand) GetRef() services.Ref {
-	return rc.ref
-}
-
 // Get prints one or many resources of a certain type
 func (rc *ResourceCommand) Get(ctx context.Context, client *authclient.Client) error {
 	// Some resources require MFA to list with secrets. Check if we are trying to
@@ -225,82 +222,115 @@ func (rc *ResourceCommand) Get(ctx context.Context, client *authclient.Client) e
 			mfaKinds = append(mfaKinds, kind)
 		}
 	}
-
-	withSecrets := rc.withSecrets || slices.ContainsFunc(rc.refs, func(r services.Ref) bool {
-		// tokens cannot be retrieved without secrets.
-		return r.Kind == types.KindToken
-	})
-
-	mfaRequired := withSecrets && slices.ContainsFunc(rc.refs, func(r services.Ref) bool {
-		return slices.Contains(mfaKinds, r.Kind)
-	})
-
-	// Check if MFA has already been provided.
-	if _, err := mfa.MFAResponseFromContext(ctx); err == nil {
-		mfaRequired = false
+	for kind, handler := range resources.ScopedHandlers() {
+		if handler.MFARequired() {
+			mfaKinds = append(mfaKinds, kind)
+		}
 	}
 
-	if mfaRequired {
+	// performMFAIfNeeded runs the MFA ceremony when required is true and MFA
+	// has not already been provided. It updates ctx in-place on success.
+	performMFAIfNeeded := func(required bool) error {
+		if !required {
+			return nil
+		}
+		if _, err := mfa.MFAResponseFromContext(ctx); err == nil {
+			return nil // already provided
+		}
 		mfaResponse, err := mfa.PerformAdminActionMFACeremony(ctx, client.PerformMFACeremony, true /*allowReuse*/)
 		if err == nil {
 			ctx = mfa.ContextWithMFAResponse(ctx, mfaResponse)
 		} else if !errors.Is(err, &mfa.ErrMFANotRequired) && !errors.Is(err, &mfa.ErrMFANotSupported) {
 			return trace.Wrap(err)
 		}
+		return nil
 	}
 
-	if rc.refs.IsAll() {
-		return rc.GetAll(ctx, client)
+	// writeCollection writes a collection to rc.Stdout in the requested format.
+	// Note that only YAML is officially supported; text and JSON are experimental.
+	writeCollection := func(coll resources.Collection) error {
+		switch rc.format {
+		case teleport.Text:
+			return coll.WriteText(rc.Stdout, rc.verbose)
+		case teleport.YAML:
+			return writeYAML(coll, rc.Stdout)
+		case teleport.JSON:
+			return writeJSON(coll, rc.Stdout)
+		}
+		return trace.BadParameter("unsupported format")
 	}
-	if len(rc.refs) != 1 {
-		return rc.GetMany(ctx, client)
+
+	// When a second positional arg (id) is present, short-circuit to the
+	// single-resource/scoped-resource path (note: this path relies on ScopedRef,
+	// but the underlying logic supports lookup of scoped and unscoped resources).
+	if rc.id != "" {
+		sr, err := ParseScopedRef(rc.ref, rc.id)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+		withSecrets := rc.withSecrets
+		if err := performMFAIfNeeded(withSecrets && slices.Contains(mfaKinds, sr.Kind)); err != nil {
+			return trace.Wrap(err)
+		}
+		collection, err := rc.getCollectionByScopedRef(ctx, client, sr, resources.GetOpts{WithSecrets: withSecrets})
+		if err != nil {
+			return trace.Wrap(err)
+		}
+		return writeCollection(collection)
 	}
-	rc.ref = rc.refs[0]
-	collection, err := rc.getCollection(ctx, client)
+
+	// No id: parse the full ref string, which may be "all", a comma-separated
+	// list, or a single kind[/subkind[/name]].
+	refs, err := services.ParseRefs(rc.ref)
 	if err != nil {
 		return trace.Wrap(err)
 	}
-
-	// Note that only YAML is officially supported. Support for text and JSON
-	// is experimental.
-	switch rc.format {
-	case teleport.Text:
-		return collection.WriteText(rc.Stdout, rc.verbose)
-	case teleport.YAML:
-		return writeYAML(collection, rc.Stdout)
-	case teleport.JSON:
-		return writeJSON(collection, rc.Stdout)
+	withSecrets := rc.withSecrets || slices.ContainsFunc(refs, func(r services.Ref) bool {
+		return r.Kind == types.KindToken // tokens cannot be retrieved without secrets
+	})
+	mfaRequired := withSecrets && slices.ContainsFunc(refs, func(r services.Ref) bool {
+		return slices.Contains(mfaKinds, r.Kind)
+	})
+	if err := performMFAIfNeeded(mfaRequired); err != nil {
+		return trace.Wrap(err)
 	}
-	return trace.BadParameter("unsupported format")
-}
 
-func (rc *ResourceCommand) GetMany(ctx context.Context, client *authclient.Client) error {
-	const skipNotSupported = false
-	return trace.Wrap(rc.getMany(ctx, client, skipNotSupported))
+	if refs.IsAll() {
+		return rc.GetAll(ctx, client)
+	}
+	if len(refs) != 1 {
+		return rc.getMany(ctx, client, false, refs)
+	}
+	collection, err := rc.getCollectionByRef(ctx, client, refs[0], resources.GetOpts{WithSecrets: withSecrets})
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	return writeCollection(collection)
 }
 
 func (rc *ResourceCommand) getMany(
 	ctx context.Context,
 	client *authclient.Client,
 	skipNotSupported bool,
+	refs services.Refs,
 ) error {
 	if rc.format != teleport.YAML {
 		return trace.BadParameter("mixed resource types only support YAML formatting")
 	}
 
-	var resources []types.Resource
-	for _, ref := range rc.refs {
-		rc.ref = ref
-		collection, err := rc.getCollection(ctx, client)
+	opts := resources.GetOpts{WithSecrets: rc.withSecrets}
+	var allResources []types.Resource
+	for _, ref := range refs {
+		collection, err := rc.getCollectionByRef(ctx, client, ref, opts)
 		if skipNotSupported && errors.As(err, new(*errNotSupported)) {
 			continue
 		}
 		if err != nil {
 			return trace.Wrap(err)
 		}
-		resources = append(resources, collection.Resources()...)
+		allResources = append(allResources, collection.Resources()...)
 	}
-	if err := utils.WriteYAML(rc.Stdout, resources); err != nil {
+	if err := utils.WriteYAML(rc.Stdout, allResources); err != nil {
 		return trace.Wrap(err)
 	}
 	return nil
@@ -309,20 +339,16 @@ func (rc *ResourceCommand) getMany(
 func (rc *ResourceCommand) GetAll(ctx context.Context, client *authclient.Client) error {
 	rc.withSecrets = true
 	allKinds := services.GetResourceMarshalerKinds()
-	allRefs := make([]services.Ref, 0, len(allKinds))
+	allRefs := make(services.Refs, 0, len(allKinds))
 	for _, kind := range allKinds {
-		ref := services.Ref{
-			Kind: kind,
-		}
-		allRefs = append(allRefs, ref)
+		allRefs = append(allRefs, services.Ref{Kind: kind})
 	}
-	rc.refs = services.Refs(allRefs)
 
 	// This lets OSS query Enterprise-only kinds without failing when the
 	// corresponding RPCs return "NotImplemented".
 	const skipNotSupported = true
 
-	return rc.getMany(ctx, client, skipNotSupported)
+	return rc.getMany(ctx, client, skipNotSupported, allRefs)
 }
 
 // Create updates or inserts one or many resources
@@ -370,14 +396,15 @@ func (rc *ResourceCommand) Create(ctx context.Context, client *authclient.Client
 
 		count++
 
+		opts := resources.CreateOpts{
+			Force:   rc.force,
+			Confirm: rc.confirm,
+		}
+
 		// Try looking for a resource handler
 		if resourceHandler, found := resources.Handlers()[raw.Kind]; found {
 			// only return in case of error, to create multiple resources
 			// in case if yaml spec is a list
-			opts := resources.CreateOpts{
-				Force:   rc.force,
-				Confirm: rc.confirm,
-			}
 			if err := resourceHandler.Create(ctx, client, raw, opts); err != nil {
 				if trace.IsAlreadyExists(err) {
 					return trace.Wrap(err, "use -f or --force flag to overwrite")
@@ -390,6 +417,21 @@ func (rc *ResourceCommand) Create(ctx context.Context, client *authclient.Client
 			// continue to next resource
 			continue
 		}
+
+		// Try looking for a scoped resource handler
+		if scopedHandler, found := resources.ScopedHandlers()[raw.Kind]; found {
+			if err := scopedHandler.Create(ctx, client, raw, opts); err != nil {
+				if trace.IsAlreadyExists(err) {
+					return trace.Wrap(err, "use -f or --force flag to overwrite")
+				}
+				if trace.IsNotImplemented(err) {
+					return trace.BadParameter("creating resources of type %q is not supported", raw.Kind)
+				}
+				return trace.Wrap(err)
+			}
+			continue
+		}
+
 		// Else fallback to the legacy logic
 
 		// locate the creator function for a given resource kind:
@@ -607,29 +649,61 @@ func (rc *ResourceCommand) createIntegration(ctx context.Context, client *authcl
 
 // Delete deletes resource by name
 func (rc *ResourceCommand) Delete(ctx context.Context, client *authclient.Client) (err error) {
+	sr, err := ParseScopedRef(rc.ref, rc.id)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
 	// Connectors are a special case. As it's the only meta-resource we have,
 	// it's easier to special-case it here instead of adding a case in the
 	// generic [resources.Handler].
-	if rc.ref.Kind == types.KindConnectors {
+	if sr.Kind == types.KindConnectors {
 		return trace.BadParameter(
 			"Deleting connector resources requires using an explicit connector type. Please try again with the appropriate type: %s",
 			[]string{
-				types.KindGithubConnector + "/" + rc.ref.Name,
-				types.KindOIDCConnector + "/" + rc.ref.Name,
-				types.KindSAMLConnector + "/" + rc.ref.Name,
+				types.KindGithubConnector + "/" + sr.Name,
+				types.KindOIDCConnector + "/" + sr.Name,
+				types.KindSAMLConnector + "/" + sr.Name,
 			},
 		)
 	}
 
+	if sr.Scope != "" {
+		handler, found := resources.ScopedHandlers()[sr.Kind]
+		if !found {
+			return trace.BadParameter("resource type %q does not support scope-qualified names", sr.Kind)
+		}
+		return trace.Wrap(handler.Delete(ctx, client, sr.SubKind, sr.SQN()))
+	}
+
+	// if scope was not set, we're about to interact with a bunch of functions that expect
+	// an explicitly unscoped ref.
+	ref := sr.Ref()
+
 	// Try looking for a resource handler
-	if resourceHandler, found := resources.Handlers()[rc.ref.Kind]; found {
-		if err := resourceHandler.Delete(ctx, client, rc.ref); err != nil {
+	if resourceHandler, found := resources.Handlers()[ref.Kind]; found {
+		if err := resourceHandler.Delete(ctx, client, ref); err != nil {
 			if trace.IsNotImplemented(err) {
-				return trace.BadParameter("deleting resources of type %q is not supported", rc.ref.Kind)
+				return trace.BadParameter("deleting resources of type %q is not supported", ref.Kind)
 			}
-			return trace.Wrap(err, "error deleting resource %q of type %q", rc.ref.Name, rc.ref.Kind)
+			return trace.Wrap(err, "error deleting resource %q of type %q", ref.Name, ref.Kind)
 		}
 		return nil
+	}
+
+	// check if this kind has a scoped handler. note that we check this *after* checking for an unscoped handler. resource
+	// kinds can be "double registered" as both a scoped and unscoped handler if/when we want to support a mix of scoped and
+	// unscoped interaction with the resource, so a missing scope isn't necessarily an error until we confirm that there
+	// isn't a suitable unscoped handler.
+	if _, found := resources.ScopedHandlers()[ref.Kind]; found {
+		kindSpec := ref.Kind
+		if ref.SubKind != "" {
+			kindSpec = ref.Kind + "/" + ref.SubKind
+		}
+		if sr.Name != "" {
+			return trace.BadParameter("resource type %q requires a scope-qualified name: tctl rm %s <scope>::%s", ref.Kind, kindSpec, sr.Name)
+		}
+		return trace.BadParameter("use 'tctl rm %s <scope>::<name>' to delete a %s", kindSpec, ref.Kind)
 	}
 
 	// Else fallback to the legacy logic
@@ -639,49 +713,49 @@ func (rc *ResourceCommand) Delete(ctx context.Context, client *authclient.Client
 		types.KindUIConfig,
 		types.KindNetworkRestrictions,
 	}
-	if !slices.Contains(singletonResources, rc.ref.Kind) && (rc.ref.Kind == "" || rc.ref.Name == "") {
+	if !slices.Contains(singletonResources, ref.Kind) && (ref.Kind == "" || ref.Name == "") {
 		return trace.BadParameter("provide a full resource name to delete, for example:\n$ tctl rm cluster/east\n")
 	}
 
-	switch rc.ref.Kind {
+	switch ref.Kind {
 	case types.KindReverseTunnel:
-		if err := client.DeleteReverseTunnel(ctx, rc.ref.Name); err != nil {
+		if err := client.DeleteReverseTunnel(ctx, ref.Name); err != nil {
 			return trace.Wrap(err)
 		}
-		fmt.Printf("reverse tunnel %v has been deleted\n", rc.ref.Name)
+		fmt.Printf("reverse tunnel %v has been deleted\n", ref.Name)
 	case types.KindTrustedCluster:
-		if err = client.DeleteTrustedCluster(ctx, rc.ref.Name); err != nil {
+		if err = client.DeleteTrustedCluster(ctx, ref.Name); err != nil {
 			return trace.Wrap(err)
 		}
-		fmt.Printf("trusted cluster %q has been deleted\n", rc.ref.Name)
+		fmt.Printf("trusted cluster %q has been deleted\n", ref.Name)
 	case types.KindRemoteCluster:
-		if err = client.DeleteRemoteCluster(ctx, rc.ref.Name); err != nil {
+		if err = client.DeleteRemoteCluster(ctx, ref.Name); err != nil {
 			return trace.Wrap(err)
 		}
-		fmt.Printf("remote cluster %q has been deleted\n", rc.ref.Name)
+		fmt.Printf("remote cluster %q has been deleted\n", ref.Name)
 	case types.KindSemaphore:
-		if rc.ref.SubKind == "" || rc.ref.Name == "" {
+		if ref.SubKind == "" || ref.Name == "" {
 			return trace.BadParameter(
 				"full semaphore path must be specified (e.g. '%s/%s/alice@example.com')",
 				types.KindSemaphore, types.SemaphoreKindConnection,
 			)
 		}
 		err := client.DeleteSemaphore(ctx, types.SemaphoreFilter{
-			SemaphoreKind: rc.ref.SubKind,
-			SemaphoreName: rc.ref.Name,
+			SemaphoreKind: ref.SubKind,
+			SemaphoreName: ref.Name,
 		})
 		if err != nil {
 			return trace.Wrap(err)
 		}
-		fmt.Printf("semaphore '%s/%s' has been deleted\n", rc.ref.SubKind, rc.ref.Name)
+		fmt.Printf("semaphore '%s/%s' has been deleted\n", ref.SubKind, ref.Name)
 	case types.KindDatabaseServer:
 		servers, err := client.GetDatabaseServers(ctx, apidefaults.Namespace)
 		if err != nil {
 			return trace.Wrap(err)
 		}
 		resDesc := "database server"
-		servers = resources.FilterByNameOrDiscoveredName(servers, rc.ref.Name)
-		name, err := resources.GetOneResourceNameToDelete(servers, rc.ref, resDesc)
+		servers = resources.FilterByNameOrDiscoveredName(servers, ref.Name)
+		name, err := resources.GetOneResourceNameToDelete(servers, ref, resDesc)
 		if err != nil {
 			return trace.Wrap(err)
 		}
@@ -698,13 +772,13 @@ func (rc *ResourceCommand) Delete(ctx context.Context, client *authclient.Client
 		}
 		fmt.Printf("network restrictions have been reset to defaults (allow all)\n")
 	case types.KindCrownJewel:
-		if err := client.CrownJewelsClient().DeleteCrownJewel(ctx, rc.ref.Name); err != nil {
+		if err := client.CrownJewelsClient().DeleteCrownJewel(ctx, ref.Name); err != nil {
 			return trace.Wrap(err)
 		}
-		fmt.Printf("crown_jewel %q has been deleted\n", rc.ref.Name)
+		fmt.Printf("crown_jewel %q has been deleted\n", ref.Name)
 	case types.KindDevice:
 		remote := client.DevicesClient()
-		device, err := findDeviceByIDOrTag(ctx, remote, rc.ref.Name)
+		device, err := findDeviceByIDOrTag(ctx, remote, ref.Name)
 		if err != nil {
 			return trace.Wrap(err)
 		}
@@ -714,37 +788,37 @@ func (rc *ResourceCommand) Delete(ctx context.Context, client *authclient.Client
 		}.Build()); err != nil {
 			return trace.Wrap(err)
 		}
-		fmt.Printf("Device %q removed\n", rc.ref.Name)
+		fmt.Printf("Device %q removed\n", ref.Name)
 
 	case types.KindIntegration:
-		if err := client.DeleteIntegration(ctx, rc.ref.Name); err != nil {
+		if err := client.DeleteIntegration(ctx, ref.Name); err != nil {
 			return trace.Wrap(err)
 		}
-		fmt.Printf("Integration %q removed\n", rc.ref.Name)
+		fmt.Printf("Integration %q removed\n", ref.Name)
 	case types.KindOktaAssignment:
-		if err := client.OktaClient().DeleteOktaAssignment(ctx, rc.ref.Name); err != nil {
+		if err := client.OktaClient().DeleteOktaAssignment(ctx, ref.Name); err != nil {
 			return trace.Wrap(err)
 		}
-		fmt.Printf("Okta assignment %q has been deleted\n", rc.ref.Name)
+		fmt.Printf("Okta assignment %q has been deleted\n", ref.Name)
 	case types.KindOktaImportRule:
-		if err := client.OktaClient().DeleteOktaImportRule(ctx, rc.ref.Name); err != nil {
+		if err := client.OktaClient().DeleteOktaImportRule(ctx, ref.Name); err != nil {
 			return trace.Wrap(err)
 		}
-		fmt.Printf("Okta import rule %q has been deleted\n", rc.ref.Name)
+		fmt.Printf("Okta import rule %q has been deleted\n", ref.Name)
 	case types.KindUserGroup:
-		if err := client.DeleteUserGroup(ctx, rc.ref.Name); err != nil {
+		if err := client.DeleteUserGroup(ctx, ref.Name); err != nil {
 			return trace.Wrap(err)
 		}
-		fmt.Printf("User group %q has been deleted\n", rc.ref.Name)
+		fmt.Printf("User group %q has been deleted\n", ref.Name)
 	case types.KindSecurityReport:
-		if err := client.SecReportsClient().DeleteSecurityReport(ctx, rc.ref.Name); err != nil {
+		if err := client.SecReportsClient().DeleteSecurityReport(ctx, ref.Name); err != nil {
 			return trace.Wrap(err)
 		}
-		fmt.Printf("Security report %q has been deleted\n", rc.ref.Name)
+		fmt.Printf("Security report %q has been deleted\n", ref.Name)
 	case types.KindHealthCheckConfig:
-		return trace.Wrap(rc.deleteHealthCheckConfig(ctx, client))
+		return trace.Wrap(rc.deleteHealthCheckConfig(ctx, client, ref.Name))
 	default:
-		return trace.BadParameter("deleting resources of type %q is not supported", rc.ref.Kind)
+		return trace.BadParameter("deleting resources of type %q is not supported", ref.Kind)
 	}
 	return nil
 }
@@ -755,11 +829,17 @@ func resetNetworkRestrictions(ctx context.Context, client *authclient.Client) er
 
 // UpdateFields updates select resource fields: expiry and labels
 func (rc *ResourceCommand) UpdateFields(ctx context.Context, clt *authclient.Client) error {
-	if rc.ref.Kind == "" || rc.ref.Name == "" {
+	sr, err := ParseScopedRef(rc.ref, rc.id)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	if sr.Kind == "" || sr.Name == "" {
 		return trace.BadParameter("provide a full resource name to update, for example:\n$ tctl update rc/remote --set-labels=env=prod\n")
 	}
+	if sr.Scope != "" {
+		return trace.BadParameter("resource type %q does not support scope-qualified names", sr.Kind)
+	}
 
-	var err error
 	var labels map[string]string
 	if rc.labels != "" {
 		labels, err = parse.LabelSelectorSpec(rc.labels)
@@ -781,9 +861,9 @@ func (rc *ResourceCommand) UpdateFields(ctx context.Context, clt *authclient.Cli
 		return trace.BadParameter("use at least one of --set-labels or --set-ttl")
 	}
 
-	switch rc.ref.Kind {
+	switch sr.Kind {
 	case types.KindRemoteCluster:
-		cluster, err := clt.GetRemoteCluster(ctx, rc.ref.Name)
+		cluster, err := clt.GetRemoteCluster(ctx, sr.Name)
 		if err != nil {
 			return trace.Wrap(err)
 		}
@@ -798,9 +878,9 @@ func (rc *ResourceCommand) UpdateFields(ctx context.Context, clt *authclient.Cli
 		if _, err = clt.UpdateRemoteCluster(ctx, cluster); err != nil {
 			return trace.Wrap(err)
 		}
-		fmt.Printf("cluster %v has been updated\n", rc.ref.Name)
+		fmt.Printf("cluster %v has been updated\n", sr.Name)
 	default:
-		return trace.BadParameter("updating resources of type %q is not supported, supported are: %q", rc.ref.Kind, types.KindRemoteCluster)
+		return trace.BadParameter("updating resources of type %q is not supported, supported are: %q", sr.Kind, types.KindRemoteCluster)
 	}
 	return nil
 }
@@ -810,28 +890,83 @@ func (rc *ResourceCommand) IsForced() bool {
 	return rc.force
 }
 
-// getCollection lists all resources of a given type
-func (rc *ResourceCommand) getCollection(ctx context.Context, client *authclient.Client) (resources.Collection, error) {
-	if rc.ref.Kind == "" {
+func (rc *ResourceCommand) getCollectionByScopedRef(ctx context.Context, client *authclient.Client, sr ScopedRef, opts resources.GetOpts) (resources.Collection, error) {
+	if sr.Scope != "" {
+		handler, found := resources.ScopedHandlers()[sr.Kind]
+		if !found {
+			return nil, trace.BadParameter("resource type %q does not support scope-qualified names", sr.Kind)
+		}
+		sqn := sr.SQN()
+		return handler.Get(ctx, client, sr.SubKind, &sqn, opts)
+	}
+
+	// get was invoked without a scope being specified. this is valid for unscoped types, or when doing a list operation
+	// for a scoped type. some types are registered as both scoped and unscoped. therefore we specifically want to
+	// reject attempts to invoke a single-resource get at this point only if it targets a type that *does* have a scoped
+	// handler and *does not* have an unscoped handler.
+	if sr.Name != "" {
+		_, classicFound := resources.Handlers()[sr.Kind]
+		_, scopedFound := resources.ScopedHandlers()[sr.Kind]
+		if !classicFound && scopedFound {
+			kindSpec := sr.Kind
+			if sr.SubKind != "" {
+				kindSpec = fmt.Sprintf("%s/%s", sr.Kind, sr.SubKind)
+			}
+			return nil, trace.BadParameter(
+				"resource type %q requires a scope-qualified name, e.g.:\n  tctl get %s <scope>::%s",
+				kindSpec, kindSpec, sr.Name,
+			)
+		}
+	}
+
+	// fallthrough to the general getCollectionByRef logic. getCollectionByRef handles unscoped types, but it also handles
+	// invocations for scoped list operations.
+	return rc.getCollectionByRef(ctx, client, sr.Ref(), opts)
+}
+
+func (rc *ResourceCommand) getCollectionByRef(ctx context.Context, client *authclient.Client, ref services.Ref, opts resources.GetOpts) (resources.Collection, error) {
+	if ref.Kind == "" {
 		return nil, trace.BadParameter("specify resource to list, e.g. 'tctl get roles'")
 	}
 
-	// Looking if the resource has been converted to the handler format.
-	if handler, found := resources.Handlers()[rc.ref.Kind]; found {
-		coll, err := handler.Get(ctx, client, rc.ref, resources.GetOpts{WithSecrets: rc.withSecrets})
+	if handler, found := resources.Handlers()[ref.Kind]; found {
+		coll, err := handler.Get(ctx, client, ref, opts)
 		if err != nil {
 			if trace.IsNotImplemented(err) {
-				return nil, &errNotSupported{trace.BadParameter("getting %q is not supported", rc.ref.String())}
+				return nil, &errNotSupported{trace.BadParameter("getting %q is not supported", ref.String())}
 			}
-			return nil, trace.Wrap(err, "getting resource %q of type %q", rc.ref.Name, rc.ref.Kind)
+			return nil, trace.Wrap(err, "getting resource %q of type %q", ref.Name, ref.Kind)
 		}
 		return coll, nil
 	}
+
+	// Scoped handler path: list-all only. Single-resource lookup for purely-scoped
+	// kinds requires a scope-qualified name, handled by getCollectionByScopedRef.
+	if handler, found := resources.ScopedHandlers()[ref.Kind]; found {
+		if ref.Name != "" {
+			kindSpec := ref.Kind
+			if ref.SubKind != "" {
+				kindSpec = fmt.Sprintf("%s/%s", ref.Kind, ref.SubKind)
+			}
+			return nil, trace.BadParameter(
+				"resource type %q requires a scope-qualified name, e.g.:\n  tctl get %s <scope>::%s\nuse 'tctl get %s' to list all resources of this type",
+				kindSpec, kindSpec, ref.Name, ref.Kind,
+			)
+		}
+		if ref.SubKind != "" {
+			// technically our current CLI syntax does not support specifying a sub-kind without specifying
+			// a name so this should currently be unreachable, but its a good defensive check since hander.Get
+			// will likely not know how to handle sub-kind listing if future changes make it possible to express.
+			return nil, trace.BadParameter("listing resources by sub-kind is not supported, use 'tctl get %s' to list all resources of this kind", ref.Kind)
+		}
+		return handler.Get(ctx, client, "", nil, opts)
+	}
+
 	// The resource hasn't been migrated yet, falling back to the old logic.
 
-	switch rc.ref.Kind {
+	switch ref.Kind {
 	case types.KindReverseTunnel:
-		if rc.ref.Name != "" {
+		if ref.Name != "" {
 			return nil, trace.BadParameter("reverse tunnel cannot be searched by name")
 		}
 
@@ -842,7 +977,7 @@ func (rc *ResourceCommand) getCollection(ctx context.Context, client *authclient
 
 		return &reverseTunnelCollection{tunnels: tunnels}, nil
 	case types.KindTrustedCluster:
-		if rc.ref.Name == "" {
+		if ref.Name == "" {
 			// TODO(okraport): DELETE IN v21.0.0, replace with regular Collect
 			trustedClusters, err := clientutils.CollectWithFallback(
 				ctx,
@@ -855,28 +990,28 @@ func (rc *ResourceCommand) getCollection(ctx context.Context, client *authclient
 
 			return &trustedClusterCollection{trustedClusters: trustedClusters}, nil
 		}
-		trustedCluster, err := client.GetTrustedCluster(ctx, rc.ref.Name)
+		trustedCluster, err := client.GetTrustedCluster(ctx, ref.Name)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
 		return &trustedClusterCollection{trustedClusters: []types.TrustedCluster{trustedCluster}}, nil
 	case types.KindRemoteCluster:
-		if rc.ref.Name == "" {
+		if ref.Name == "" {
 			remoteClusters, err := client.GetRemoteClusters(ctx)
 			if err != nil {
 				return nil, trace.Wrap(err)
 			}
 			return &remoteClusterCollection{remoteClusters: remoteClusters}, nil
 		}
-		remoteCluster, err := client.GetRemoteCluster(ctx, rc.ref.Name)
+		remoteCluster, err := client.GetRemoteCluster(ctx, ref.Name)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
 		return &remoteClusterCollection{remoteClusters: []types.RemoteCluster{remoteCluster}}, nil
 	case types.KindSemaphore:
 		filter := types.SemaphoreFilter{
-			SemaphoreKind: rc.ref.SubKind,
-			SemaphoreName: rc.ref.Name,
+			SemaphoreKind: ref.SubKind,
+			SemaphoreName: ref.Name,
 		}
 		sems, err := clientutils.CollectWithFallback(ctx,
 			func(ctx context.Context, pageSize int, pageToken string) ([]types.Semaphore, string, error) {
@@ -897,13 +1032,13 @@ func (rc *ResourceCommand) getCollection(ctx context.Context, client *authclient
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
-		if rc.ref.Name == "" {
+		if ref.Name == "" {
 			return &databaseServerCollection{servers: servers}, nil
 		}
 
-		servers = resources.FilterByNameOrDiscoveredName(servers, rc.ref.Name)
+		servers = resources.FilterByNameOrDiscoveredName(servers, ref.Name)
 		if len(servers) == 0 {
-			return nil, trace.NotFound("database server %q not found", rc.ref.Name)
+			return nil, trace.NotFound("database server %q not found", ref.Name)
 		}
 		return &databaseServerCollection{servers: servers}, nil
 	case types.KindNetworkRestrictions:
@@ -923,7 +1058,7 @@ func (rc *ResourceCommand) getCollection(ctx context.Context, client *authclient
 		return &crownJewelCollection{items: jewels}, nil
 	case types.KindToken:
 	case types.KindDatabaseService:
-		resourceName := rc.ref.Name
+		resourceName := ref.Name
 		listReq := proto.ListResourcesRequest{
 			ResourceType: types.KindDatabaseService,
 		}
@@ -948,9 +1083,9 @@ func (rc *ResourceCommand) getCollection(ctx context.Context, client *authclient
 		return &databaseServiceCollection{databaseServices: databaseServices}, nil
 	case types.KindDevice:
 		remote := client.DevicesClient()
-		if rc.ref.Name != "" {
+		if ref.Name != "" {
 			resp, err := remote.FindDevices(ctx, devicepb.FindDevicesRequest_builder{
-				IdOrTag: rc.ref.Name,
+				IdOrTag: ref.Name,
 			}.Build())
 			if err != nil {
 				return nil, trace.Wrap(err)
@@ -990,8 +1125,8 @@ func (rc *ResourceCommand) getCollection(ctx context.Context, client *authclient
 
 		return &deviceCollection{devices: devs}, nil
 	case types.KindOktaImportRule:
-		if rc.ref.Name != "" {
-			importRule, err := client.OktaClient().GetOktaImportRule(ctx, rc.ref.Name)
+		if ref.Name != "" {
+			importRule, err := client.OktaClient().GetOktaImportRule(ctx, ref.Name)
 			if err != nil {
 				return nil, trace.Wrap(err)
 			}
@@ -1005,8 +1140,8 @@ func (rc *ResourceCommand) getCollection(ctx context.Context, client *authclient
 
 		return &oktaImportRuleCollection{importRules: resources}, nil
 	case types.KindOktaAssignment:
-		if rc.ref.Name != "" {
-			assignment, err := client.OktaClient().GetOktaAssignment(ctx, rc.ref.Name)
+		if ref.Name != "" {
+			assignment, err := client.OktaClient().GetOktaAssignment(ctx, ref.Name)
 			if err != nil {
 				return nil, trace.Wrap(err)
 			}
@@ -1020,8 +1155,8 @@ func (rc *ResourceCommand) getCollection(ctx context.Context, client *authclient
 
 		return &oktaAssignmentCollection{assignments: resources}, nil
 	case types.KindUserGroup:
-		if rc.ref.Name != "" {
-			userGroup, err := client.GetUserGroup(ctx, rc.ref.Name)
+		if ref.Name != "" {
+			userGroup, err := client.GetUserGroup(ctx, ref.Name)
 			if err != nil {
 				return nil, trace.Wrap(err)
 			}
@@ -1035,8 +1170,8 @@ func (rc *ResourceCommand) getCollection(ctx context.Context, client *authclient
 
 		return &userGroupCollection{userGroups: resources}, nil
 	case types.KindIntegration:
-		if rc.ref.Name != "" {
-			ig, err := client.GetIntegration(ctx, rc.ref.Name)
+		if ref.Name != "" {
+			ig, err := client.GetIntegration(ctx, ref.Name)
 			if err != nil {
 				return nil, trace.Wrap(err)
 			}
@@ -1050,9 +1185,9 @@ func (rc *ResourceCommand) getCollection(ctx context.Context, client *authclient
 
 		return &integrationCollection{integrations: resources}, nil
 	case types.KindSecurityReport:
-		if rc.ref.Name != "" {
+		if ref.Name != "" {
 
-			resource, err := client.SecReportsClient().GetSecurityReport(ctx, rc.ref.Name)
+			resource, err := client.SecReportsClient().GetSecurityReport(ctx, ref.Name)
 			if err != nil {
 				return nil, trace.Wrap(err)
 			}
@@ -1064,8 +1199,8 @@ func (rc *ResourceCommand) getCollection(ctx context.Context, client *authclient
 		}
 		return &securityReportCollection{items: resources}, nil
 	case types.KindPlugin:
-		if rc.ref.Name != "" {
-			plugin, err := client.PluginsClient().GetPlugin(ctx, pluginsv1.GetPluginRequest_builder{Name: rc.ref.Name}.Build())
+		if ref.Name != "" {
+			plugin, err := client.PluginsClient().GetPlugin(ctx, pluginsv1.GetPluginRequest_builder{Name: ref.Name}.Build())
 			if err != nil {
 				return nil, trace.Wrap(err)
 			}
@@ -1093,8 +1228,8 @@ func (rc *ResourceCommand) getCollection(ctx context.Context, client *authclient
 		return &pluginCollection{plugins: plugins}, nil
 
 	case types.KindHealthCheckConfig:
-		if rc.ref.Name != "" {
-			cfg, err := client.GetHealthCheckConfig(ctx, rc.ref.Name)
+		if ref.Name != "" {
+			cfg, err := client.GetHealthCheckConfig(ctx, ref.Name)
 			if err != nil {
 				return nil, trace.Wrap(err)
 			}
@@ -1110,7 +1245,7 @@ func (rc *ResourceCommand) getCollection(ctx context.Context, client *authclient
 
 		return &healthCheckConfigCollection{items: items}, nil
 	}
-	return nil, trace.BadParameter("getting %q is not supported", rc.ref.String())
+	return nil, trace.BadParameter("getting %q is not supported", ref.String())
 }
 
 // errNotSupported is used to mark NotImplemented errors that were transformed
@@ -1238,7 +1373,16 @@ func resourceKindRows() []resourceKindRow {
 			Description:       handler.Description(),
 		})
 	}
-	slices.SortFunc(rows, func(a, b resourceKindRow) int {
+	for kind, handler := range resources.ScopedHandlers() {
+		rows = append(rows, resourceKindRow{
+			Kind:              kind,
+			SupportedCommands: handler.SupportedCommands(),
+			Singleton:         false, // scoped resources are never singletons
+			MFARequired:       handler.MFARequired(),
+			Description:       handler.Description(),
+		})
+	}
+	slices.SortStableFunc(rows, func(a, b resourceKindRow) int {
 		return strings.Compare(a.Kind, b.Kind)
 	})
 	return rows

--- a/tool/tctl/common/resource_command_test.go
+++ b/tool/tctl/common/resource_command_test.go
@@ -418,7 +418,7 @@ version: v1
 	var raw []byte
 	for {
 		// Get the scoped role
-		buff, err := runResourceCommand(t, clt, []string{"get", "scoped_role/some-role", "--format=json"})
+		buff, err := runResourceCommand(t, clt, []string{"get", "scoped_role", "/::some-role", "--format=json"})
 		if err == nil {
 			raw = buff.Bytes()
 			break
@@ -452,6 +452,33 @@ version: v1
 	}.Build()
 
 	require.Empty(t, cmp.Diff(expected, rs[0], protocmp.Transform(), protocmp.IgnoreFields(&headerv1.Metadata{}, "revision")))
+
+	// list-all for scoped_role (no SQN)
+	buff, err := runResourceCommand(t, clt, []string{"get", "scoped_role", "--format=json"})
+	require.NoError(t, err)
+	allRoles, err := services.UnmarshalProtoResourceArray[*scopedaccessv1.ScopedRole](buff.Bytes(), services.DisallowUnknown())
+	require.NoError(t, err)
+	require.Len(t, allRoles, 1)
+	require.Equal(t, "some-role", allRoles[0].GetMetadata().GetName())
+
+	// bare name without SQN separator should require a scope-qualified name
+	_, err = runResourceCommand(t, clt, []string{"get", "scoped_role", "some-role"})
+	require.True(t, trace.IsBadParameter(err), "expected BadParameter for bare name, got %v", err)
+	require.ErrorContains(t, err, "scope-qualified name")
+
+	// sub-kind segment on a type with no sub-kinds should be rejected on get
+	_, err = runResourceCommand(t, clt, []string{"get", "scoped_role/badsubkind", "/::some-role"})
+	require.True(t, trace.IsBadParameter(err), "expected BadParameter for invalid sub-kind on get, got %v", err)
+	require.ErrorContains(t, err, "does not support sub-kinds")
+
+	// sub-kind segment on a type with no sub-kinds should be rejected on delete
+	_, err = runResourceCommand(t, clt, []string{"rm", "scoped_role/badsubkind", "/::some-role"})
+	require.True(t, trace.IsBadParameter(err), "expected BadParameter for invalid sub-kind on delete, got %v", err)
+	require.ErrorContains(t, err, "does not support sub-kinds")
+
+	// scope mismatch on delete should return NotFound (role lives at "/", not "/wrong")
+	_, err = runResourceCommand(t, clt, []string{"rm", "scoped_role", "/wrong::some-role"})
+	require.True(t, trace.IsNotFound(err), "expected NotFound for scope mismatch on delete, got %v", err)
 
 	// now that a role exists, test commands for assignment creation
 
@@ -499,15 +526,15 @@ version: v1
 	assignmentName := as[0].GetMetadata().GetName()
 
 	// Ensure that retrieving the scoped role assignment with incorrect sub_kind fails.
-	_, err = runResourceCommand(t, clt, []string{"get", "scoped_role_assignment/materialized/" + assignmentName, "--format=json"})
+	_, err = runResourceCommand(t, clt, []string{"get", "scoped_role_assignment/materialized", "/::" + assignmentName, "--format=json"})
 	require.True(t, trace.IsNotFound(err), "expected NotFound error, got %v", err)
 
 	// Ensure that trying to retrieve the scoped role assignment without a subkind fails.
-	_, err = runResourceCommand(t, clt, []string{"get", "scoped_role_assignment/" + assignmentName, "--format=json"})
-	require.ErrorContains(t, err, "requires an explicit subkind")
+	_, err = runResourceCommand(t, clt, []string{"get", "scoped_role_assignment", "/::" + assignmentName, "--format=json"})
+	require.ErrorContains(t, err, "requires a sub-kind")
 
 	// Ensure that retrieving the scoped role assignment by name with explicit sub_kind works.
-	buff, err := runResourceCommand(t, clt, []string{"get", "scoped_role_assignment/dynamic/" + assignmentName, "--format=json"})
+	buff, err = runResourceCommand(t, clt, []string{"get", "scoped_role_assignment/dynamic", "/::" + assignmentName, "--format=json"})
 	require.NoError(t, err)
 	var asByName []*scopedaccessv1.ScopedRoleAssignment
 	err = json.Unmarshal(buff.Bytes(), &asByName)
@@ -537,23 +564,33 @@ version: v1
 
 	require.Empty(t, cmp.Diff(expectedAssignment, as[0], protocmp.Transform(), protocmp.IgnoreFields(&headerv1.Metadata{}, "revision")))
 
+	// a bare segment for a scoped-only resource (previously treated as a name)
+	// should now be an explicit error rather than silently returning all resources.
+	_, err = runResourceCommand(t, clt, []string{"get", "scoped_role_assignment/dynamic"})
+	require.True(t, trace.IsBadParameter(err), "expected BadParameter for old-format subkind filter, got %v", err)
+	require.ErrorContains(t, err, "scope-qualified name")
+
+	// scope mismatch on delete should return NotFound (assignment lives at "/", not "/wrong")
+	_, err = runResourceCommand(t, clt, []string{"rm", "scoped_role_assignment/dynamic", "/wrong::" + assignmentName})
+	require.True(t, trace.IsNotFound(err), "expected NotFound for scope mismatch on assignment delete, got %v", err)
+
 	// verify delete of assignment fails without subkind
-	_, err = runResourceCommand(t, clt, []string{"rm", "scoped_role_assignment/" + assignmentName})
-	require.ErrorContains(t, err, "requires an explicit subkind")
+	_, err = runResourceCommand(t, clt, []string{"rm", "scoped_role_assignment", "/::" + assignmentName})
+	require.ErrorContains(t, err, "requires a sub-kind")
 
 	// verify delete of assignment fails without materialized subkind.
-	_, err = runResourceCommand(t, clt, []string{"rm", "scoped_role_assignment/materialized/" + assignmentName})
+	_, err = runResourceCommand(t, clt, []string{"rm", "scoped_role_assignment/materialized", "/::" + assignmentName})
 	require.ErrorContains(t, err, "cannot be deleted")
 
 	// verify delete of assignment
-	_, err = runResourceCommand(t, clt, []string{"rm", "scoped_role_assignment/dynamic/" + assignmentName})
+	_, err = runResourceCommand(t, clt, []string{"rm", "scoped_role_assignment/dynamic", "/::" + assignmentName})
 	require.NoError(t, err)
 
 	// wait for delete cache propagation
 	timeout = time.After(time.Second * 30)
 	for {
 		// verify assignment is gone
-		_, err = runResourceCommand(t, clt, []string{"get", "scoped_role_assignment/dynamic/" + assignmentName, "--format=json"})
+		_, err = runResourceCommand(t, clt, []string{"get", "scoped_role_assignment/dynamic", "/::" + assignmentName, "--format=json"})
 		if err != nil {
 			require.True(t, trace.IsNotFound(err), "expected a NotFound error, got %v", err)
 			break
@@ -567,14 +604,14 @@ version: v1
 	}
 
 	// verify delete of role
-	_, err = runResourceCommand(t, clt, []string{"rm", "scoped_role/some-role"})
+	_, err = runResourceCommand(t, clt, []string{"rm", "scoped_role", "/::some-role"})
 	require.NoError(t, err)
 
 	// wait for delete cache propagation
 	timeout = time.After(time.Second * 30)
 	for {
 		// verify role is gone
-		_, err = runResourceCommand(t, clt, []string{"get", "scoped_role/some-role", "--format=json"})
+		_, err = runResourceCommand(t, clt, []string{"get", "scoped_role", "/::some-role", "--format=json"})
 		if err != nil {
 			require.True(t, trace.IsNotFound(err), "expected a NotFound error, got %v", err)
 			break
@@ -662,7 +699,7 @@ spec:
 	var raw []byte
 	require.EventuallyWithT(t, func(ct *assert.CollectT) {
 		// Get the scoped token by name
-		buff, err := runResourceCommand(t, clt, []string{"get", "scoped_token/test-token", "--format=json"})
+		buff, err := runResourceCommand(t, clt, []string{"get", "scoped_token", "/::test-token", "--format=json"})
 		require.NoError(t, err)
 		raw = buff.Bytes()
 	}, time.Second*30, time.Millisecond*100, "Timed out waiting for scoped token cache propagation")
@@ -682,6 +719,26 @@ spec:
 	require.Equal(t, "unlimited", token.GetSpec().GetUsageMode())
 	// Secret is stripped server-side when not requested with --with-secrets.
 	require.Empty(t, token.GetStatus().GetSecret())
+
+	// A bare name (no :: separator) should produce a helpful "scope-qualified name" error.
+	_, err = runResourceCommand(t, clt, []string{"get", "scoped_token", "test-token"})
+	require.ErrorContains(t, err, "scope-qualified name")
+	_, err = runResourceCommand(t, clt, []string{"rm", "scoped_token", "test-token"})
+	require.ErrorContains(t, err, "scope-qualified name")
+
+	// sub-kind segment on a type with no sub-kinds should be rejected on get
+	_, err = runResourceCommand(t, clt, []string{"get", "scoped_token/badsubkind", "/::test-token"})
+	require.True(t, trace.IsBadParameter(err), "expected BadParameter for invalid sub-kind on get, got %v", err)
+	require.ErrorContains(t, err, "does not support sub-kinds")
+
+	// sub-kind segment on a type with no sub-kinds should be rejected on delete
+	_, err = runResourceCommand(t, clt, []string{"rm", "scoped_token/badsubkind", "/::test-token"})
+	require.True(t, trace.IsBadParameter(err), "expected BadParameter for invalid sub-kind on delete, got %v", err)
+	require.ErrorContains(t, err, "does not support sub-kinds")
+
+	// scope mismatch on delete should return NotFound (token lives at "/", not "/wrong")
+	_, err = runResourceCommand(t, clt, []string{"rm", "scoped_token", "/wrong::test-token"})
+	require.True(t, trace.IsNotFound(err), "expected NotFound for scope mismatch on delete, got %v", err)
 
 	// Get all scoped tokens
 	buff, err := runResourceCommand(t, clt, []string{"get", "scoped_token", "--format=json", "--with-secrets"})
@@ -717,7 +774,7 @@ spec:
 
 	// Wait for cache propagation and verify the update took effect
 	require.EventuallyWithT(t, func(ct *assert.CollectT) {
-		buff, err := runResourceCommand(t, clt, []string{"get", "scoped_token/test-token", "--format=json"})
+		buff, err := runResourceCommand(t, clt, []string{"get", "scoped_token", "/::test-token", "--format=json"})
 		require.NoError(t, err)
 		updated, err := services.UnmarshalProtoResourceArray[*joiningv1.ScopedToken](buff.Bytes(), services.DisallowUnknown())
 		require.NoError(t, err)
@@ -728,12 +785,12 @@ spec:
 	}, time.Second*30, time.Millisecond*100, "Timed out waiting for upserted scoped token cache propagation")
 
 	// verify delete of token
-	_, err = runResourceCommand(t, clt, []string{"rm", "scoped_token/test-token"})
+	_, err = runResourceCommand(t, clt, []string{"rm", "scoped_token", "/::test-token"})
 	require.NoError(t, err)
 
 	// wait for delete cache propagation
 	require.EventuallyWithT(t, func(ct *assert.CollectT) {
-		_, err = runResourceCommand(t, clt, []string{"get", "scoped_token/test-token", "--format=json"})
+		_, err = runResourceCommand(t, clt, []string{"get", "scoped_token", "/::test-token", "--format=json"})
 		require.True(ct, trace.IsNotFound(err))
 	}, time.Second*30, time.Millisecond*100, "Timed out waiting for scoped token cache propagation")
 
@@ -746,7 +803,7 @@ spec:
 
 	// Wait for cache propagation.
 	require.EventuallyWithT(t, func(ct *assert.CollectT) {
-		_, err := runResourceCommand(t, clt, []string{"get", "scoped_token/gcp-test-token", "--format=json"})
+		_, err := runResourceCommand(t, clt, []string{"get", "scoped_token", "/::gcp-test-token", "--format=json"})
 		require.NoError(ct, err)
 	}, time.Second*30, time.Millisecond*100, "Timed out waiting for GCP scoped token cache propagation")
 
@@ -760,6 +817,203 @@ spec:
 	require.Equal(t, "gcp", gcpTokens[0].GetSpec().GetJoinMethod())
 	require.Len(t, gcpTokens[0].GetSpec().GetGcp().GetAllow(), 1)
 	require.Equal(t, []string{"example-project-123456"}, gcpTokens[0].GetSpec().GetGcp().GetAllow()[0].GetProjectIds())
+
+	// Verify scope mismatch: name exists at "/" but a different scope is requested. Must produce
+	// a NotFound error to comply with namespacing behavior. Future iterations may not be able
+	// to provide hints as namespacing may prevent it.
+	_, err = runResourceCommand(t, clt, []string{"get", "scoped_token", "/other-scope::gcp-test-token", "--format=json"})
+	require.True(t, trace.IsNotFound(err), "expected NotFound for scope mismatch, got: %v", err)
+	require.ErrorContains(t, err, "tctl get scoped_token /::gcp-test-token")
+}
+
+// TestScopedAndUnscopedNodeResource exercises tctl get/rm on nodes which are double
+// registered as both a scoped and unscoped resource handler in order to support a
+// mix of scope and classic style interactions. This test is intended specifically
+// to help verify that we are handling double-registration sensibly.
+func TestScopedAndUnscopedNodeResource(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	dynAddr := helpers.NewDynamicServiceAddr(t)
+	fileConfig := &config.FileConfig{
+		Global: config.Global{DataDir: t.TempDir()},
+		Proxy: config.Proxy{
+			Service: config.Service{EnabledFlag: "true"},
+			WebAddr: dynAddr.WebAddr,
+			TunAddr: dynAddr.TunnelAddr,
+		},
+		Auth: config.Auth{
+			Service: config.Service{
+				EnabledFlag:   "true",
+				ListenAddress: dynAddr.AuthAddr,
+			},
+		},
+	}
+	auth := makeAndRunTestAuthServer(t, withFileConfig(fileConfig), withFileDescriptors(dynAddr.Descriptors))
+	clt, err := testenv.NewDefaultAuthClient(auth)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = clt.Close() })
+
+	// classicNode has no explicit scope (scope == "").
+	classicNode, err := types.NewServer("unscoped-node", types.KindNode, types.ServerSpecV2{
+		Hostname: "unscoped-host",
+		Addr:     "127.0.0.1:22",
+	})
+	require.NoError(t, err)
+	_, err = clt.UpsertNode(ctx, classicNode)
+	require.NoError(t, err)
+
+	// scopedNode has scope "/" so SQN lookups with "/::scoped-node" succeed.
+	scopedNode, err := types.NewServer("scoped-node", types.KindNode, types.ServerSpecV2{
+		Hostname: "scoped-host",
+		Addr:     "127.0.0.1:23",
+	})
+	require.NoError(t, err)
+	scopedNode.(*types.ServerV2).Scope = "/staging"
+	_, err = clt.UpsertNode(ctx, scopedNode)
+	require.NoError(t, err)
+
+	// Poll until both nodes appear via the unified-resource list (cache propagation).
+	timeout := time.After(30 * time.Second)
+	for {
+		buf, err := runResourceCommand(t, clt, []string{"get", "node", "--format=json"})
+		if err == nil && strings.Contains(buf.String(), "scoped-node") && strings.Contains(buf.String(), "unscoped-node") {
+			break
+		}
+		select {
+		case <-timeout:
+			require.FailNow(t, "timed out waiting for nodes to appear in list")
+		case <-time.After(100 * time.Millisecond):
+		}
+	}
+
+	t.Run("list all", func(t *testing.T) {
+		buf, err := runResourceCommand(t, clt, []string{"get", "node", "--format=json"})
+		require.NoError(t, err)
+		out := buf.String()
+		require.Contains(t, out, "unscoped-node")
+		require.Contains(t, out, "scoped-node")
+	})
+
+	t.Run("single-arg unscoped get", func(t *testing.T) {
+		buf, err := runResourceCommand(t, clt, []string{"get", "node/unscoped-node", "--format=json"})
+		require.NoError(t, err)
+		require.Contains(t, buf.String(), "unscoped-node")
+	})
+
+	t.Run("two-arg unscoped get", func(t *testing.T) {
+		buf, err := runResourceCommand(t, clt, []string{"get", "node", "unscoped-node", "--format=json"})
+		require.NoError(t, err)
+		require.Contains(t, buf.String(), "unscoped-node")
+	})
+
+	t.Run("scope-qualified get", func(t *testing.T) {
+		buf, err := runResourceCommand(t, clt, []string{"get", "node", "/staging::scoped-node", "--format=json"})
+		require.NoError(t, err)
+		require.Contains(t, buf.String(), "scoped-node")
+	})
+
+	t.Run("scope-qualified get with scope mismatch", func(t *testing.T) {
+		_, err := runResourceCommand(t, clt, []string{"get", "node", "/prod::scoped-node", "--format=json"})
+		require.True(t, trace.IsNotFound(err), "expected NotFound on scope mismatch, got: %v", err)
+	})
+
+	t.Run("scope-qualified delete with scope mismatch", func(t *testing.T) {
+		_, err := runResourceCommand(t, clt, []string{"rm", "node", "/prod::scoped-node"})
+		require.True(t, trace.IsNotFound(err), "expected NotFound on scope mismatch delete, got: %v", err)
+	})
+
+	t.Run("edit via single-arg classic form", func(t *testing.T) {
+		editor := func(name string) error {
+			data, err := os.ReadFile(name)
+			if err != nil {
+				return err
+			}
+			data = bytes.ReplaceAll(data, []byte("unscoped-host"), []byte("unscoped-host-edited"))
+			return os.WriteFile(name, data, 0600)
+		}
+		_, err := runEditCommand(t, clt, []string{"edit", "node/unscoped-node"}, withEditor(editor))
+		require.NoError(t, err)
+
+		timeout := time.After(30 * time.Second)
+		for {
+			node, err := clt.GetNode(ctx, apidefaults.Namespace, "unscoped-node")
+			if err == nil && node.GetHostname() == "unscoped-host-edited" {
+				break
+			}
+			require.NoError(t, err, "unexpected error waiting for unscoped-node edit")
+			select {
+			case <-timeout:
+				require.FailNow(t, "timed out waiting for unscoped-node hostname edit")
+			case <-time.After(100 * time.Millisecond):
+			}
+		}
+	})
+
+	t.Run("edit via two-arg SQN form", func(t *testing.T) {
+		editor := func(name string) error {
+			data, err := os.ReadFile(name)
+			if err != nil {
+				return err
+			}
+			data = bytes.ReplaceAll(data, []byte("scoped-host"), []byte("scoped-host-edited"))
+			return os.WriteFile(name, data, 0600)
+		}
+		_, err := runEditCommand(t, clt, []string{"edit", "node", "/staging::scoped-node"}, withEditor(editor))
+		require.NoError(t, err)
+
+		timeout := time.After(30 * time.Second)
+		for {
+			node, err := clt.GetNode(ctx, apidefaults.Namespace, "scoped-node")
+			if err == nil && node.GetHostname() == "scoped-host-edited" {
+				break
+			}
+			require.NoError(t, err, "unexpected error waiting for scoped-node edit")
+			select {
+			case <-timeout:
+				require.FailNow(t, "timed out waiting for scoped-node hostname edit")
+			case <-time.After(100 * time.Millisecond):
+			}
+		}
+	})
+
+	t.Run("scope-qualified delete", func(t *testing.T) {
+		_, err := runResourceCommand(t, clt, []string{"rm", "node", "/staging::scoped-node"})
+		require.NoError(t, err)
+
+		timeout := time.After(30 * time.Second)
+		for {
+			_, err = clt.GetNode(ctx, apidefaults.Namespace, "scoped-node")
+			if trace.IsNotFound(err) {
+				break
+			}
+			require.NoError(t, err, "unexpected error waiting for scoped-node deletion")
+			select {
+			case <-timeout:
+				require.FailNow(t, "timed out waiting for scoped-node to be deleted")
+			case <-time.After(100 * time.Millisecond):
+			}
+		}
+	})
+
+	t.Run("two-arg unscoped delete", func(t *testing.T) {
+		_, err := runResourceCommand(t, clt, []string{"rm", "node", "unscoped-node"})
+		require.NoError(t, err)
+
+		timeout := time.After(30 * time.Second)
+		for {
+			_, err = clt.GetNode(ctx, apidefaults.Namespace, "unscoped-node")
+			if trace.IsNotFound(err) {
+				break
+			}
+			require.NoError(t, err, "unexpected error waiting for unscoped-node deletion")
+			select {
+			case <-timeout:
+				require.FailNow(t, "timed out waiting for unscoped-node to be deleted")
+			case <-time.After(100 * time.Millisecond):
+			}
+		}
+	})
 }
 
 // TestIntegrationResource tests tctl integration commands.
@@ -3076,6 +3330,80 @@ func TestPluginResourceWrapper(t *testing.T) {
 			err = json.Unmarshal(buff, &item)
 			require.NoError(t, err)
 			require.Empty(t, cmp.Diff(tc.plugin, item.PluginV1))
+		})
+	}
+}
+
+func TestParseScopedRef(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		ref     string
+		id      string
+		want    ScopedRef
+		wantErr bool
+	}{
+		{
+			name: "empty id returns ref unchanged",
+			ref:  "role/myrole",
+			id:   "",
+			want: ScopedRef{Kind: "role", Name: "myrole"},
+		},
+		{
+			name: "bare name, no subkind",
+			ref:  "scoped_role",
+			id:   "myrole",
+			want: ScopedRef{Kind: "scoped_role", Name: "myrole"},
+		},
+		{
+			name: "bare name with subkind promotion",
+			ref:  "scoped_role_assignment/dynamic",
+			id:   "myassignment",
+			want: ScopedRef{Kind: "scoped_role_assignment", SubKind: "dynamic", Name: "myassignment"},
+		},
+		{
+			name: "SQN, no subkind",
+			ref:  "scoped_role",
+			id:   "/staging/west::myrole",
+			want: ScopedRef{Kind: "scoped_role", Scope: "/staging/west", Name: "myrole"},
+		},
+		{
+			name: "SQN with subkind promotion",
+			ref:  "scoped_role_assignment/dynamic",
+			id:   "/staging/west::myassignment",
+			want: ScopedRef{Kind: "scoped_role_assignment", SubKind: "dynamic", Scope: "/staging/west", Name: "myassignment"},
+		},
+		{
+			name: "root scope SQN",
+			ref:  "scoped_token",
+			id:   "/::test-token",
+			want: ScopedRef{Kind: "scoped_token", Scope: "/", Name: "test-token"},
+		},
+		{
+			name:    "three-segment first arg with second arg is an error",
+			ref:     "scoped_role_assignment/dynamic/myassignment",
+			id:      "/staging::extra",
+			wantErr: true,
+		},
+		{
+			name:    "invalid SQN is an error",
+			ref:     "scoped_role",
+			id:      "/staging::my role",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := ParseScopedRef(tt.ref, tt.id)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tt.want, got)
 		})
 	}
 }

--- a/tool/tctl/common/resource_health_check_config.go
+++ b/tool/tctl/common/resource_health_check_config.go
@@ -56,10 +56,10 @@ func (rc *ResourceCommand) updateHealthCheckConfig(ctx context.Context, clt *aut
 	return nil
 }
 
-func (rc *ResourceCommand) deleteHealthCheckConfig(ctx context.Context, clt *authclient.Client) error {
-	if err := clt.DeleteHealthCheckConfig(ctx, rc.ref.Name); err != nil {
+func (rc *ResourceCommand) deleteHealthCheckConfig(ctx context.Context, clt *authclient.Client, name string) error {
+	if err := clt.DeleteHealthCheckConfig(ctx, name); err != nil {
 		return trace.Wrap(err)
 	}
-	fmt.Printf("health_check_config %q has been deleted\n", rc.ref.Name)
+	fmt.Printf("health_check_config %q has been deleted\n", name)
 	return nil
 }

--- a/tool/tctl/common/resources/resource.go
+++ b/tool/tctl/common/resources/resource.go
@@ -25,7 +25,6 @@ import (
 
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/auth/authclient"
-	scopedaccess "github.com/gravitational/teleport/lib/scopes/access"
 	"github.com/gravitational/teleport/lib/services"
 )
 
@@ -34,10 +33,9 @@ import (
 // to the Handler format.
 func Handlers() map[string]Handler {
 	// When adding resources, please keep the map alphabetically ordered.
+	// Note: scoped_role, scoped_role_assignment, and scoped_token are registered in
+	// ScopedHandlers() rather than here because they require scope-qualified names.
 	return map[string]Handler{
-		scopedaccess.KindScopedRole:                  scopedRoleHandler(),
-		scopedaccess.KindScopedRoleAssignment:        scopedRoleAssignmentHandler(),
-		scopedaccess.KindScopedToken:                 scopedTokenHandler(),
 		types.KindAccessGraphSettings:                accessGraphSettingsHandler(),
 		types.KindAccessList:                         accessListHandler(),
 		types.KindAccessMonitoringRule:               accessMonitoringRuleHandler(),

--- a/tool/tctl/common/resources/scoped_handler.go
+++ b/tool/tctl/common/resources/scoped_handler.go
@@ -1,0 +1,165 @@
+// Teleport
+// Copyright (C) 2026  Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package resources
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/gravitational/trace"
+
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/auth/authclient"
+	"github.com/gravitational/teleport/lib/scopes"
+	scopedaccess "github.com/gravitational/teleport/lib/scopes/access"
+	"github.com/gravitational/teleport/lib/services"
+)
+
+// ScopedHandlers returns a map of ScopedHandler per kind for resource types that
+// require scope-qualified names. Resource types that also support classic (unscoped)
+// access can register in both Handlers() and ScopedHandlers().
+func ScopedHandlers() map[string]ScopedHandler {
+	return map[string]ScopedHandler{
+		types.KindNode:                        serverScopedHandler(),
+		scopedaccess.KindScopedRole:           scopedRoleScopedHandler(),
+		types.KindScopedToken:                 scopedTokenScopedHandler(),
+		scopedaccess.KindScopedRoleAssignment: scopedRoleAssignmentScopedHandler(),
+	}
+}
+
+// ScopedHandler represents a scoped resource supported by tctl resource commands.
+// Get and delete operations for scoped handlers require an explicit scope-qualified
+// name to disambiguate types in different scopes.
+//
+// Create and update retain the classic [services.UnknownResource] signature because
+// the scope travels in the resource itself, not in the CLI args.
+type ScopedHandler struct {
+	// getHandler powers "tctl get <kind>[/<subkind>] <scope>::<name>" and "tctl get <kind>"
+	// (list all). A nil qn lists all resources; a non-nil qn fetches a single resource.
+	getHandler func(ctx context.Context, client *authclient.Client, subKind string, sqn *scopes.QualifiedName, opts GetOpts) (Collection, error)
+	// deleteHandler powers "tctl rm <kind>[/<subkind>] <scope>::<name>". The SQN is always
+	// non-nil at call time. subKind is empty when the user omits the sub-kind segment.
+	deleteHandler func(ctx context.Context, client *authclient.Client, subKind string, sqn scopes.QualifiedName) error
+	// createHandler powers "tctl create". Scope comes from the resource.
+	createHandler func(ctx context.Context, client *authclient.Client, raw services.UnknownResource, opts CreateOpts) error
+	// updateHandler powers "tctl edit". Scope comes from the resource.
+	updateHandler func(ctx context.Context, client *authclient.Client, raw services.UnknownResource, opts CreateOpts) error
+	// description is a resource description used by "tctl list-kinds".
+	description string
+	// mfaRequired informs "tctl get" whether the resource is read sensitive.
+	mfaRequired bool
+}
+
+// Get queries the cluster for a scoped resource collection.
+// A nil sqn lists all resources of this kind.
+// A non-nil sqn returns only the resource matching that scope and name.
+func (h *ScopedHandler) Get(ctx context.Context, clt *authclient.Client, subKind string, sqn *scopes.QualifiedName, opts GetOpts) (Collection, error) {
+	if h.getHandler == nil {
+		return nil, trace.NotImplemented("resource does not support 'tctl get'")
+	}
+	return h.getHandler(ctx, clt, subKind, sqn, opts)
+}
+
+// Create takes a raw resource manifest and creates the resource.
+func (h *ScopedHandler) Create(ctx context.Context, clt *authclient.Client, raw services.UnknownResource, opts CreateOpts) error {
+	if h.createHandler == nil {
+		return trace.NotImplemented("resource does not support 'tctl create'")
+	}
+	return h.createHandler(ctx, clt, raw, opts)
+}
+
+// Update takes a raw resource manifest and updates the resource.
+func (h *ScopedHandler) Update(ctx context.Context, clt *authclient.Client, raw services.UnknownResource, opts CreateOpts) error {
+	if h.updateHandler == nil {
+		return trace.NotImplemented("resource does not have an update handler")
+	}
+	return h.updateHandler(ctx, clt, raw, opts)
+}
+
+// Delete deletes a scoped resource by its qualified name.
+// subKind is required for resource types that have sub-kinds; pass "" otherwise.
+func (h *ScopedHandler) Delete(ctx context.Context, clt *authclient.Client, subKind string, sqn scopes.QualifiedName) error {
+	if h.deleteHandler == nil {
+		return trace.NotImplemented("resource does not support 'tctl rm'")
+	}
+	return h.deleteHandler(ctx, clt, subKind, sqn)
+}
+
+// MFARequired indicates that this resource requires MFA to Get.
+func (h *ScopedHandler) MFARequired() bool {
+	return h.mfaRequired
+}
+
+// Description returns the description of the handler's resource.
+func (h *ScopedHandler) Description() string {
+	return h.description
+}
+
+// SupportedCommands returns the list of tctl commands this handler supports.
+func (h *ScopedHandler) SupportedCommands() []string {
+	var verbs []string
+	if h.getHandler != nil {
+		verbs = append(verbs, "get")
+	}
+	if h.createHandler != nil {
+		verbs = append(verbs, "create")
+	}
+	if h.deleteHandler != nil {
+		verbs = append(verbs, "rm")
+	}
+	// No check on the update handler for the "update" command because it is not
+	// doing anything useful today: https://github.com/gravitational/teleport/issues/61381
+
+	return verbs
+}
+
+// rejectSubKind returns an error for resource types that don't support sub-kinds.
+// The error message also covers the case where the user may have intended the segment
+// as a resource name, directing them toward the scope-qualified name form.
+func rejectSubKind(kind, subKind string) error {
+	return trace.BadParameter(
+		"resource type %q does not support sub-kinds (got %q)\n"+
+			"hint: if %q was intended as a resource name, provide it as a scope-qualified name:\n"+
+			"  tctl get %s <scope>::%s",
+		kind, subKind, subKind, kind, subKind,
+	)
+}
+
+// scopeMismatchNotFound builds a NotFound error for the pre-namespacing case where a
+// resource was found by name but lives in a different scope than requested. This mirrors
+// the behavior that namespacing will make automatic: from the perspective of the requested
+// scope, the resource does not exist.
+//
+// Note: this check is client-side and inherently racy as the resource's scope could change
+// between the lookup and the caller's subsequent action. It is a temporary measure to
+// prevent obviously misleading results until the backend APIs are updated to accept
+// scope-qualified identifiers natively and enforce the scope constraint server-side.
+func scopeMismatchNotFound(kind string, requested scopes.QualifiedName, actualScope string) error {
+	var hint string
+	if actualScope == "" {
+		// Resource is unscoped; the SQN form is not valid for unscoped resources.
+		hint = fmt.Sprintf("tctl get %s/%s", kind, requested.Name)
+	} else {
+		hint = fmt.Sprintf("tctl get %s %s::%s", kind, actualScope, requested.Name)
+	}
+	return trace.NotFound(
+		"%s %q not found in scope %q (a %s with that name exists in scope %q, try: %s)",
+		kind, requested.Name, requested.Scope,
+		kind, actualScope,
+		hint,
+	)
+}

--- a/tool/tctl/common/resources/scoped_role.go
+++ b/tool/tctl/common/resources/scoped_role.go
@@ -27,6 +27,7 @@ import (
 	"github.com/gravitational/teleport/lib/asciitable"
 	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/itertools/stream"
+	"github.com/gravitational/teleport/lib/scopes"
 	scopedaccess "github.com/gravitational/teleport/lib/scopes/access"
 	scopedutils "github.com/gravitational/teleport/lib/scopes/utils"
 	"github.com/gravitational/teleport/lib/services"
@@ -51,13 +52,10 @@ func (c *scopedRoleCollection) Resources() []types.Resource {
 }
 
 func (c *scopedRoleCollection) WriteText(w io.Writer, verbose bool) error {
-	headers := []string{"Scope", "Name"}
+	headers := []string{"ID"}
 	rows := make([][]string, len(c.roles))
 	for i, item := range c.roles {
-		rows[i] = []string{
-			item.GetScope(),
-			item.GetMetadata().GetName(),
-		}
+		rows[i] = []string{scopes.QualifiedName{Scope: item.GetScope(), Name: item.GetMetadata().GetName()}.String()}
 	}
 
 	t := asciitable.MakeTable(headers, rows...)
@@ -66,8 +64,8 @@ func (c *scopedRoleCollection) WriteText(w io.Writer, verbose bool) error {
 	return trace.Wrap(err)
 }
 
-func scopedRoleHandler() Handler {
-	return Handler{
+func scopedRoleScopedHandler() ScopedHandler {
+	return ScopedHandler{
 		getHandler:    getScopedRole,
 		createHandler: createScopedRole,
 		updateHandler: updateScopedRole,
@@ -133,16 +131,23 @@ func updateScopedRole(ctx context.Context, client *authclient.Client, raw servic
 	return nil
 }
 
-func getScopedRole(ctx context.Context, client *authclient.Client, ref services.Ref, opts GetOpts) (Collection, error) {
-	if ref.Name != "" {
+func getScopedRole(ctx context.Context, client *authclient.Client, subKind string, sqn *scopes.QualifiedName, opts GetOpts) (Collection, error) {
+	if subKind != "" {
+		return nil, rejectSubKind(scopedaccess.KindScopedRole, subKind)
+	}
+
+	if sqn != nil {
 		rsp, err := client.ScopedAccessServiceClient().GetScopedRole(ctx, scopedaccessv1.GetScopedRoleRequest_builder{
-			Name: ref.Name,
+			Name: sqn.Name,
 		}.Build())
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
-
-		return &scopedRoleCollection{roles: []*scopedaccessv1.ScopedRole{rsp.GetRole()}}, nil
+		role := rsp.GetRole()
+		if role.GetScope() != sqn.Scope {
+			return nil, scopeMismatchNotFound(scopedaccess.KindScopedRole, *sqn, role.GetScope())
+		}
+		return &scopedRoleCollection{roles: []*scopedaccessv1.ScopedRole{role}}, nil
 	}
 
 	items, err := stream.Collect(scopedutils.RangeScopedRoles(ctx, client.ScopedAccessServiceClient(), &scopedaccessv1.ListScopedRolesRequest{}))
@@ -152,16 +157,31 @@ func getScopedRole(ctx context.Context, client *authclient.Client, ref services.
 	return &scopedRoleCollection{roles: items}, nil
 }
 
-func deleteScopedRole(ctx context.Context, client *authclient.Client, ref services.Ref) error {
+func deleteScopedRole(ctx context.Context, client *authclient.Client, subKind string, sqn scopes.QualifiedName) error {
+	if subKind != "" {
+		return rejectSubKind(scopedaccess.KindScopedRole, subKind)
+	}
+
+	// Fetch first to verify scope before deleting.
+	rsp, err := client.ScopedAccessServiceClient().GetScopedRole(ctx, scopedaccessv1.GetScopedRoleRequest_builder{
+		Name: sqn.Name,
+	}.Build())
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	if rsp.GetRole().GetScope() != sqn.Scope {
+		return scopeMismatchNotFound(scopedaccess.KindScopedRole, sqn, rsp.GetRole().GetScope())
+	}
+
 	if _, err := client.ScopedAccessServiceClient().DeleteScopedRole(ctx, scopedaccessv1.DeleteScopedRoleRequest_builder{
-		Name: ref.Name,
+		Name: sqn.Name,
 	}.Build()); err != nil {
 		return trace.Wrap(err)
 	}
 	fmt.Printf(
 		"%v %q has been deleted\n",
 		scopedaccess.KindScopedRole,
-		ref.Name,
+		sqn.Name,
 	)
 	return nil
 }

--- a/tool/tctl/common/resources/scoped_role_assignment.go
+++ b/tool/tctl/common/resources/scoped_role_assignment.go
@@ -29,6 +29,7 @@ import (
 	"github.com/gravitational/teleport/lib/asciitable"
 	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/itertools/stream"
+	"github.com/gravitational/teleport/lib/scopes"
 	scopedaccess "github.com/gravitational/teleport/lib/scopes/access"
 	scopedutils "github.com/gravitational/teleport/lib/scopes/utils"
 	"github.com/gravitational/teleport/lib/services"
@@ -53,7 +54,7 @@ func (c *ScopedRoleAssignmentCollection) Resources() []types.Resource {
 }
 
 func (c *ScopedRoleAssignmentCollection) WriteText(w io.Writer, verbose bool) error {
-	headers := []string{"SubKind", "Scope", "Name", "User", "Assigns"}
+	headers := []string{"SubKind", "ID", "User", "Assigns"}
 	rows := make([][]string, len(c.roleAssignments))
 
 	for i, item := range c.roleAssignments {
@@ -61,11 +62,9 @@ func (c *ScopedRoleAssignmentCollection) WriteText(w io.Writer, verbose bool) er
 		for j, subAssignment := range item.GetSpec().GetAssignments() {
 			assigns[j] = fmt.Sprintf("%s -> %s", subAssignment.GetRole(), subAssignment.GetScope())
 		}
-
 		rows[i] = []string{
 			item.GetSubKind(),
-			item.GetScope(),
-			item.GetMetadata().GetName(),
+			scopes.QualifiedName{Scope: item.GetScope(), Name: item.GetMetadata().GetName()}.String(),
 			item.GetSpec().GetUser(),
 			strings.Join(assigns, ", "),
 		}
@@ -77,8 +76,8 @@ func (c *ScopedRoleAssignmentCollection) WriteText(w io.Writer, verbose bool) er
 	return trace.Wrap(err)
 }
 
-func scopedRoleAssignmentHandler() Handler {
-	return Handler{
+func scopedRoleAssignmentScopedHandler() ScopedHandler {
+	return ScopedHandler{
 		getHandler:    getScopedRoleAssignment,
 		createHandler: createScopedRoleAssignment,
 		updateHandler: updateScopedRoleAssignment,
@@ -148,20 +147,28 @@ func updateScopedRoleAssignment(ctx context.Context, client *authclient.Client, 
 	return nil
 }
 
-func getScopedRoleAssignment(ctx context.Context, client *authclient.Client, ref services.Ref, opts GetOpts) (Collection, error) {
-	if ref.Name != "" {
-		if ref.SubKind == "" {
-			return nil, trace.BadParameter("scoped_role_assignment requires an explicit subkind when getting a single resource, try: tctl get scoped_role_assignment/dynamic/%s", ref.Name)
+func getScopedRoleAssignment(ctx context.Context, client *authclient.Client, subKind string, sqn *scopes.QualifiedName, opts GetOpts) (Collection, error) {
+	if sqn != nil {
+		if subKind == "" {
+			return nil, trace.BadParameter(
+				"%s requires a sub-kind to get a specific resource, try:\n  tctl get %s/%s %s::%s",
+				scopedaccess.KindScopedRoleAssignment,
+				scopedaccess.KindScopedRoleAssignment, scopedaccess.SubKindDynamic,
+				sqn.Scope, sqn.Name,
+			)
 		}
 		rsp, err := client.ScopedAccessServiceClient().GetScopedRoleAssignment(ctx, scopedaccessv1.GetScopedRoleAssignmentRequest_builder{
-			Name:    ref.Name,
-			SubKind: ref.SubKind,
+			Name:    sqn.Name,
+			SubKind: subKind,
 		}.Build())
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
-
-		return &ScopedRoleAssignmentCollection{roleAssignments: []*scopedaccessv1.ScopedRoleAssignment{rsp.GetAssignment()}}, nil
+		assignment := rsp.GetAssignment()
+		if assignment.GetScope() != sqn.Scope {
+			return nil, scopeMismatchNotFound(scopedaccess.KindScopedRoleAssignment, *sqn, assignment.GetScope())
+		}
+		return &ScopedRoleAssignmentCollection{roleAssignments: []*scopedaccessv1.ScopedRoleAssignment{assignment}}, nil
 	}
 
 	items, err := stream.Collect(scopedutils.RangeScopedRoleAssignments(ctx, client.ScopedAccessServiceClient(), &scopedaccessv1.ListScopedRoleAssignmentsRequest{}))
@@ -171,23 +178,41 @@ func getScopedRoleAssignment(ctx context.Context, client *authclient.Client, ref
 	return NewScopedRoleAssignmentCollection(items), nil
 }
 
-func deleteScopedRoleAssignment(ctx context.Context, client *authclient.Client, ref services.Ref) error {
-	if ref.SubKind == "" {
-		return trace.BadParameter("scoped_role_assignment requires an explicit subkind when deleting a resource, try: tctl rm scoped_role_assignment/%s/%s", scopedaccess.SubKindDynamic, ref.Name)
+func deleteScopedRoleAssignment(ctx context.Context, client *authclient.Client, subKind string, sqn scopes.QualifiedName) error {
+	if subKind == "" {
+		return trace.BadParameter(
+			"%s requires a sub-kind to delete a resource, try:\n  tctl rm %s/%s %s::%s",
+			scopedaccess.KindScopedRoleAssignment,
+			scopedaccess.KindScopedRoleAssignment, scopedaccess.SubKindDynamic,
+			sqn.Scope, sqn.Name,
+		)
 	}
-	if ref.SubKind == scopedaccess.SubKindMaterialized {
+	if subKind == scopedaccess.SubKindMaterialized {
 		return trace.BadParameter("%s scoped_role_assignments are derived from access lists and cannot be deleted directly", scopedaccess.SubKindMaterialized)
 	}
+
+	// Fetch first to verify scope before deleting.
+	rsp, err := client.ScopedAccessServiceClient().GetScopedRoleAssignment(ctx, scopedaccessv1.GetScopedRoleAssignmentRequest_builder{
+		Name:    sqn.Name,
+		SubKind: subKind,
+	}.Build())
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	if rsp.GetAssignment().GetScope() != sqn.Scope {
+		return scopeMismatchNotFound(scopedaccess.KindScopedRoleAssignment, sqn, rsp.GetAssignment().GetScope())
+	}
+
 	if _, err := client.ScopedAccessServiceClient().DeleteScopedRoleAssignment(ctx, scopedaccessv1.DeleteScopedRoleAssignmentRequest_builder{
-		Name:    ref.Name,
-		SubKind: ref.SubKind,
+		Name:    sqn.Name,
+		SubKind: subKind,
 	}.Build()); err != nil {
 		return trace.Wrap(err)
 	}
 	fmt.Printf(
 		"%v %q has been deleted\n",
 		scopedaccess.KindScopedRoleAssignment,
-		ref.Name,
+		sqn.Name,
 	)
 	return nil
 }

--- a/tool/tctl/common/resources/scoped_token.go
+++ b/tool/tctl/common/resources/scoped_token.go
@@ -32,6 +32,7 @@ import (
 	"github.com/gravitational/teleport/lib/asciitable"
 	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/itertools/stream"
+	"github.com/gravitational/teleport/lib/scopes"
 	"github.com/gravitational/teleport/lib/services"
 )
 
@@ -59,8 +60,8 @@ func (c *scopedTokenCollection) WriteText(w io.Writer, verbose bool) error {
 	return trace.Wrap(err)
 }
 
-func scopedTokenHandler() Handler {
-	return Handler{
+func scopedTokenScopedHandler() ScopedHandler {
+	return ScopedHandler{
 		getHandler:    getScopedToken,
 		createHandler: createScopedToken,
 		deleteHandler: deleteScopedToken,
@@ -111,18 +112,22 @@ func updateScopedToken(ctx context.Context, client *authclient.Client, raw servi
 	return nil
 }
 
-func getScopedToken(ctx context.Context, client *authclient.Client, ref services.Ref, opts GetOpts) (Collection, error) {
-	// If a specific token name is requested, filter the results
-	if ref.Name != "" {
-		token, err := client.GetScopedToken(ctx, ref.Name, opts.WithSecrets)
+func getScopedToken(ctx context.Context, client *authclient.Client, subKind string, sqn *scopes.QualifiedName, opts GetOpts) (Collection, error) {
+	if subKind != "" {
+		return nil, rejectSubKind(types.KindScopedToken, subKind)
+	}
+
+	if sqn != nil {
+		token, err := client.GetScopedToken(ctx, sqn.Name, opts.WithSecrets)
 		if err != nil {
 			return nil, trace.Wrap(err)
+		}
+		if token.GetScope() != sqn.Scope {
+			return nil, scopeMismatchNotFound(types.KindScopedToken, *sqn, token.GetScope())
 		}
 		if !opts.WithSecrets && token.GetStatus().GetSecret() != "" {
 			token.GetStatus().SetSecret("******")
 		}
-		// As a note, this seems to be dead code, these secrets are always empty
-		// if WithSecrets is unset, since the server will strip the value.
 		if !opts.WithSecrets && token.GetStatus().GetUsage().GetBoundKeypair().GetRegistrationSecret() != "" {
 			token.GetStatus().GetUsage().GetBoundKeypair().SetRegistrationSecret("******")
 		}
@@ -158,23 +163,35 @@ func getScopedToken(ctx context.Context, client *authclient.Client, ref services
 	return &scopedTokenCollection{tokens: tokens}, nil
 }
 
-func deleteScopedToken(ctx context.Context, client *authclient.Client, ref services.Ref) error {
-	if err := client.DeleteScopedToken(ctx, ref.Name); err != nil {
+func deleteScopedToken(ctx context.Context, client *authclient.Client, subKind string, sqn scopes.QualifiedName) error {
+	if subKind != "" {
+		return rejectSubKind(types.KindScopedToken, subKind)
+	}
+
+	// Fetch first to verify scope before deleting.
+	token, err := client.GetScopedToken(ctx, sqn.Name, false)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	if token.GetScope() != sqn.Scope {
+		return scopeMismatchNotFound(types.KindScopedToken, sqn, token.GetScope())
+	}
+
+	if err := client.DeleteScopedToken(ctx, sqn.Name); err != nil {
 		return trace.Wrap(err)
 	}
 	fmt.Printf(
 		"%v %q has been deleted\n",
 		types.KindScopedToken,
-		ref.Name,
+		sqn.Name,
 	)
 	return nil
 }
 
 func ScopedTokenTextHelper(tokens []*joiningv1.ScopedToken, withSecrets bool) *bytes.Buffer {
 	headers := []string{
-		"Token",
+		"ID",
 		"Type",
-		"Scope",
 		"Assigns Scope",
 		"Labels",
 		"Expiry Time (UTC)",
@@ -194,9 +211,8 @@ func ScopedTokenTextHelper(tokens []*joiningv1.ScopedToken, withSecrets bool) *b
 			expiry = fmt.Sprintf("%s (%s)", exptime, expdur.String())
 		}
 		row := []string{
-			t.GetMetadata().GetName(),
+			scopes.QualifiedName{Scope: t.GetScope(), Name: t.GetMetadata().GetName()}.String(),
 			strings.Join(t.GetSpec().GetRoles(), ","),
-			t.GetScope(),
 			t.GetSpec().GetAssignedScope(),
 			PrintMetadataLabels(t.GetMetadata().GetLabels()),
 			expiry,

--- a/tool/tctl/common/resources/server.go
+++ b/tool/tctl/common/resources/server.go
@@ -30,6 +30,7 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/asciitable"
 	"github.com/gravitational/teleport/lib/auth/authclient"
+	"github.com/gravitational/teleport/lib/scopes"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/utils"
 	logutils "github.com/gravitational/teleport/lib/utils/log"
@@ -58,11 +59,15 @@ func (s *ServerCollection) WriteText(w io.Writer, verbose bool) error {
 	rows := make([][]string, 0, len(s.servers))
 	for _, se := range s.servers {
 		labels := common.FormatLabels(se.GetAllLabels(), verbose)
+		id := se.GetName()
+		if scope := se.GetScope(); scope != "" {
+			id = scopes.QualifiedName{Scope: scope, Name: se.GetName()}.String()
+		}
 		rows = append(rows, []string{
-			se.GetHostname(), se.GetName(), se.GetAddr(), labels, se.GetTeleportVersion(),
+			se.GetHostname(), id, se.GetAddr(), labels, se.GetTeleportVersion(),
 		})
 	}
-	headers := []string{"Host", "UUID", "Public Address", "Labels", "Version"}
+	headers := []string{"Host", "ID", "Public Address", "Labels", "Version"}
 	var t asciitable.Table
 	if verbose {
 		t = asciitable.MakeTable(headers, rows...)
@@ -91,6 +96,56 @@ func serverHandler() Handler {
 		mfaRequired:   false,
 		description:   "Represents an SSH instance in the cluster, either a Teleport SSH agent or OpenSSH",
 	}
+}
+
+// serverScopedHandler returns a limited [ScopedHandler] for nodes that are registered with a scope. This is necessary to support
+// nodes being accessed with a mix of scoped and unscoped semantics.
+//
+// TODO(fspmmarshall/scopes): revisit this pattern. would it be better to represent handlers with mixed semantics in some more
+// unified manner?
+func serverScopedHandler() ScopedHandler {
+	return ScopedHandler{
+		getHandler:    getScopedNode,
+		deleteHandler: deleteScopedNode,
+		description:   "Represents an SSH instance in the cluster, either a Teleport SSH agent or OpenSSH",
+	}
+}
+
+func getScopedNode(ctx context.Context, client *authclient.Client, subKind string, sqn *scopes.QualifiedName, opts GetOpts) (Collection, error) {
+	if subKind != "" {
+		return nil, rejectSubKind(types.KindNode, subKind)
+	}
+	if sqn == nil {
+		// this isn't expected to happen, the unscoped handler should catch anything that didn't include an explicit SQN, but there's no
+		// harm in falling back to the unscoped handler here.
+		return getServer(ctx, client, services.Ref{Kind: types.KindNode}, opts)
+	}
+	node, err := client.GetNode(ctx, defaults.Namespace, sqn.Name)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	if node.GetScope() != sqn.Scope {
+		return nil, scopeMismatchNotFound(types.KindNode, *sqn, node.GetScope())
+	}
+	return &ServerCollection{servers: []types.Server{node}}, nil
+}
+
+func deleteScopedNode(ctx context.Context, client *authclient.Client, subKind string, sqn scopes.QualifiedName) error {
+	if subKind != "" {
+		return rejectSubKind(types.KindNode, subKind)
+	}
+	node, err := client.GetNode(ctx, defaults.Namespace, sqn.Name)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	if node.GetScope() != sqn.Scope {
+		return scopeMismatchNotFound(types.KindNode, sqn, node.GetScope())
+	}
+	if err := client.DeleteNode(ctx, defaults.Namespace, sqn.Name); err != nil {
+		return trace.Wrap(err)
+	}
+	fmt.Printf("node %v has been deleted\n", sqn.String())
+	return nil
 }
 
 func createServer(ctx context.Context, client *authclient.Client, raw services.UnknownResource, opts CreateOpts) error {

--- a/tool/tctl/common/scoped_ref.go
+++ b/tool/tctl/common/scoped_ref.go
@@ -1,0 +1,119 @@
+/*
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package common
+
+import (
+	"strings"
+
+	"github.com/gravitational/trace"
+
+	"github.com/gravitational/teleport/lib/scopes"
+	"github.com/gravitational/teleport/lib/services"
+)
+
+// ScopedRef is the fully-resolved representation of a tctl resource reference,
+// produced by ParseScopedRef from the two CLI positional arguments and encompasses
+// both the more standard kind[/subkind]/name format, and the newer kind[/subkind] [scope::]name
+// format.
+//
+// When Scope is empty the reference is unscoped and equivalent to a services.Ref,
+// suitable for classic Handlers. When Scope is non-empty the reference is scope-qualified.
+type ScopedRef struct {
+	Kind    string
+	SubKind string
+	Name    string
+	Scope   string // non-empty iff scope-qualified
+}
+
+// String returns the user-facing representation of the reference, approximately matching
+// what the user originally typed on the command line (note that a user who typed in the
+// newer space-separated format without a scope will see the older slash separated format
+// since the scope qualification is what determines the format, not the original input).
+func (sr ScopedRef) String() string {
+	var b strings.Builder
+	b.WriteString(sr.Kind)
+	if sr.SubKind != "" {
+		b.WriteByte('/')
+		b.WriteString(sr.SubKind)
+	}
+	if sr.Scope != "" {
+		b.WriteByte(' ')
+		b.WriteString(scopes.QualifiedName{Scope: sr.Scope, Name: sr.Name}.String())
+	} else if sr.Name != "" {
+		b.WriteByte('/')
+		b.WriteString(sr.Name)
+	}
+	return b.String()
+}
+
+// Ref converts the ScopedRef to a services.Ref for use with classic (unscoped)
+// Handlers. Only meaningful when Scope is empty.
+func (sr ScopedRef) Ref() services.Ref {
+	return services.Ref{Kind: sr.Kind, SubKind: sr.SubKind, Name: sr.Name}
+}
+
+// SQN returns the scope-qualified name for use with ScopedHandlers.
+// Only meaningful when Scope is non-empty.
+func (sr ScopedRef) SQN() scopes.QualifiedName {
+	return scopes.QualifiedName{Scope: sr.Scope, Name: sr.Name}
+}
+
+// ParseScopedRef resolves the two tctl positional CLI arguments into a ScopedRef. The ref and id
+// positional arguments must be decoded together as we support two different formats and resource name
+// may appear in either argument depending on the format.
+//
+// - Older/Unscoped Format: <kind>[/<subkind>]/<name>
+// - Newer/Scoped Format: <kind>[/<subkind>] [<scope>::]<name>
+//
+// The resulting ScopedRef will have Scope set iff the input was the newer/scoped format *and* scope qualification
+// was not present. When scope qualification is absent, the two formats convey the same information.
+func ParseScopedRef(ref, id string) (ScopedRef, error) {
+	// start with older/unscoped format parssing. this should succeed for both formats, but the older
+	// style may have misinterpreted the subkind as a name if the caller is using the newer format.
+	r, err := services.ParseRef(ref)
+	if err != nil {
+		return ScopedRef{}, trace.Wrap(err)
+	}
+	if id == "" {
+		return ScopedRef{Kind: r.Kind, SubKind: r.SubKind, Name: r.Name}, nil
+	}
+
+	if r.SubKind != "" {
+		// Three-segment first arg (kind/subkind/name) with a second arg is one
+		// identifier too many.
+		return ScopedRef{}, trace.BadParameter(
+			"arguments must take the form '<kind>[/<subkind>] [<scope>::]<name>' or '<kind>[/<subkind>]/<name>'",
+		)
+	}
+
+	// the old format always treats token/token as kind/name, but if id was set then the second token
+	// is actually a subkind in the new format.
+	subKind := r.Name
+	if strings.Contains(id, scopes.QualifiedNameSeparator) {
+		if err := scopes.StrongValidateQualifiedName(id); err != nil {
+			return ScopedRef{}, trace.Wrap(err)
+		}
+		qn, err := scopes.ParseQualifiedName(id)
+		if err != nil {
+			return ScopedRef{}, trace.Wrap(err)
+		}
+		return ScopedRef{Kind: r.Kind, SubKind: subKind, Scope: qn.Scope, Name: qn.Name}, nil
+	}
+	return ScopedRef{Kind: r.Kind, SubKind: subKind, Name: id}, nil
+}

--- a/tool/tctl/common/scoped_token_command_test.go
+++ b/tool/tctl/common/scoped_token_command_test.go
@@ -125,7 +125,7 @@ func TestScopedTokens(t *testing.T) {
 	// Test all output formats of "tokens ls".
 	buf, err = runScopedCommand(t, clt, []string{"tokens", "ls"})
 	require.NoError(t, err)
-	require.True(t, strings.HasPrefix(buf.String(), "Token "))
+	require.True(t, strings.HasPrefix(buf.String(), "ID"))
 	require.Equal(t, 8, strings.Count(buf.String(), "\n")) // account for header lines
 
 	buf, err = runScopedCommand(t, clt, []string{"tokens", "ls", "--format", teleport.Text})


### PR DESCRIPTION
This PR introduces scope-qualified names, a pre-requisite to upcoming work related to scoped namespaces.

A scope-qualified name takes the form `<scope>::<name>` and unambiguously identifies an individual scoped resource at a specific scope.  For example, the scoped role `some-role` at scope `/staging/west` would have the scope-qualified name `/staging/west::some-role`.

The core of this PR is the new `scopes.QualifiedName` type and related helpers, which provide encoding/decoding/validation for scope-qualified names.

In addition to the core impl, this PR introduces support for scope-qualified names in `tctl` resource commands.  In order to disambiguate scope-qualified names, we now support referencing resources (scoped or otherwise) via separate `kind[/subkind]` and `id` arguments.  This means that scoped resources should now be referenced like so:

```
tctl get scoped_role /staging/west::some-role
```

But it also means that existing unscoped resources can be referenced with this new style:

```
tctl get user alice
```

`tctl`'s resource handler system has been updated to support the concept of a scoped resource handler, so that the type system can express wether a handler expects to be operating using scoped or unscoped references.  This PR also makes provisions for "double registration" in the event it needs to be possible to interact with a type using scope-qualified names *and* classic unscoped syntax (e.g. in the case of existing types that are having scope support added to them retroactively).

Once namespacing lands, any attempt to read/modify a scoped resource will fail with a `NotFound` error if no resource with the specified name is in the specified scope.  In preparation for that change, the resource handlers that support scope-qualified names have been updated to convert scope mismatches _into_ `NotFound` errors, to avoid needing to make a separate breaking change at a later date.

This PR does not yet update any configuration resources to contain scope-qualified names.  Future work will update any cross-resource references in configuration resources (e.g. role names in `ScopedRoleAssignment` resources) to also use scope-qualified names.

## Manual Test Plan
### Test Environment

Local env.

### Test Cases
- [x] Verify that unscoped tctl resource APIs work as expected.
- [x] Verify the new syntax/behavior of scoped tclt resource APIs.
- [x] Verify that nodes offer expected mix of both interaction styles.
