### PR TITLE
app: Add policy decision engine

### DIFF
--- a/lib/srv/app/policy/engine.go
+++ b/lib/srv/app/policy/engine.go
@@ -1,0 +1,246 @@
+/*
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package policy
+
+import "slices"
+
+// Decision is the result of evaluating one request against an app's
+// attached policies. The tctl evaluate output and the audit event both
+// project from it via JSON.
+type Decision struct {
+	// Allow is true when the request is permitted.
+	Allow bool
+
+	// Method, Path, and App echo the request. Path is the wire-form path
+	// the rules matched against.
+	Method string
+	Path   string
+	App    string
+
+	// PolicyRef identifies what drove the decision: the matched rule's
+	// reference as the loader assembled it on an allow, the reason code on
+	// a deny.
+	PolicyRef string
+	// AuditCode is the matched rule's audit_code and gates allow-event
+	// emission. Empty on a deny or when the rule sets none.
+	AuditCode string
+	// Binding names the binding the matched rule came through. Empty for an
+	// inline match or a deny.
+	Binding string
+	// PathCaptures holds the {name} captures from the matched path. Nil
+	// when there are none; it projects to {}.
+	PathCaptures map[string]string
+
+	// ReasonCode and Reason describe a deny and are empty on an allow.
+	// Reason is the 403 body text.
+	ReasonCode string
+	Reason     string
+
+	// AttachedPolicies is the app's full attached set, identical on allow
+	// and deny; first-match short-circuiting never truncates it.
+	AttachedPolicies []string
+}
+
+// Rule is one resolved allow rule: match criteria plus the audit
+// provenance the loader computed. The engine copies provenance into a
+// matching Decision unchanged and never inspects where the rule
+// originated. Predicate (where:) evaluation comes later.
+type Rule struct {
+	// Paths are the compiled patterns; any one matching satisfies the
+	// rule. Empty matches any path.
+	Paths []*Matcher
+	// Methods are the upper-case methods the rule permits. Empty matches
+	// any method.
+	Methods []string
+
+	// PolicyRef, AuditCode, and Binding are the loader-assembled provenance
+	// copied into a matching Decision.
+	PolicyRef string
+	AuditCode string
+	Binding   string
+}
+
+// Request carries the per-request inputs. Path is the wire-form path
+// (r.URL.EscapedPath()) the caller already cleared with ValidateWireform;
+// Method is upper-case.
+type Request struct {
+	App    string
+	Method string
+	Path   string
+}
+
+// Input bundles the resolved inputs to Evaluate.
+type Input struct {
+	// Request is the per-request input.
+	Request Request
+	// Rules are the allow rules in evaluation order. Evaluate walks them
+	// and stops at the first match.
+	Rules []Rule
+	// AttachedPolicies is the attached set, and its emptiness is the "no
+	// policies attached" signal: empty selects the permissive branch (or a
+	// deny under RequirePolicy); non-empty makes an unmatched request
+	// default-deny.
+	AttachedPolicies []string
+	// RequirePolicy denies, rather than permits, a request to an app with
+	// no attached policy. Maps to the cluster app_access_requires_policy
+	// setting.
+	RequirePolicy bool
+}
+
+// Audit event types emitted per request, one per decision outcome.
+const (
+	EventAllow = "app.session.policy.allow"
+	EventDeny  = "app.session.policy.deny"
+)
+
+// Teleport-generated reason codes set on deny decisions. Customer
+// audit_code values may not begin with the teleport_ prefix.
+const (
+	// ReasonNoMatchingAllow is the deny code when policies are attached but
+	// no allow rule matched.
+	ReasonNoMatchingAllow = "teleport_no_matching_allow"
+	// ReasonNoPolicyAttached is the deny code when RequirePolicy is set and
+	// the app has none attached.
+	ReasonNoPolicyAttached = "teleport_no_policy_attached"
+
+	// DefaultDenyReason is the reason text on every deny; allow-only rules
+	// have no custom message.
+	DefaultDenyReason = "Access denied by policy."
+)
+
+// Evaluate runs the policy decision model and returns a Decision. It is
+// pure: no I/O, no clock, no audit emission, and it never errors. The path
+// must already have cleared ValidateWireform.
+//
+// With no policies attached it permits, unless RequirePolicy denies with
+// teleport_no_policy_attached. With policies attached it allows on the
+// first rule whose method and path match, else denies with
+// teleport_no_matching_allow.
+func Evaluate(in Input) Decision {
+	dec := Decision{
+		Method:           in.Request.Method,
+		Path:             in.Request.Path,
+		App:              in.Request.App,
+		AttachedPolicies: in.AttachedPolicies,
+	}
+
+	if len(in.AttachedPolicies) == 0 {
+		if in.RequirePolicy {
+			return deny(dec, ReasonNoPolicyAttached)
+		}
+		dec.Allow = true
+		return dec
+	}
+
+	for _, rule := range in.Rules {
+		if !matchMethod(rule.Methods, in.Request.Method) {
+			continue
+		}
+		captures, ok := matchPath(rule.Paths, in.Request.Path)
+		if !ok {
+			continue
+		}
+		dec.Allow = true
+		dec.PolicyRef = rule.PolicyRef
+		dec.AuditCode = rule.AuditCode
+		dec.Binding = rule.Binding
+		dec.PathCaptures = captures
+		return dec
+	}
+
+	return deny(dec, ReasonNoMatchingAllow)
+}
+
+// deny marks dec denied with code. PolicyRef carries the code to match the
+// audit-event projection.
+func deny(dec Decision, code string) Decision {
+	dec.Allow = false
+	dec.ReasonCode = code
+	dec.Reason = DefaultDenyReason
+	dec.PolicyRef = code
+	return dec
+}
+
+// matchMethod reports whether method satisfies the filter. Empty matches
+// any; otherwise an exact, case-sensitive compare.
+func matchMethod(methods []string, method string) bool {
+	return len(methods) == 0 || slices.Contains(methods, method)
+}
+
+// matchPath returns the captures from the first pattern that matches path.
+// Empty matches any path with no captures; the bool reports whether any
+// matched.
+func matchPath(paths []*Matcher, path string) (map[string]string, bool) {
+	if len(paths) == 0 {
+		return nil, true
+	}
+	for _, m := range paths {
+		if captures, ok := m.Match(path); ok {
+			return captures, true
+		}
+	}
+	return nil, false
+}
+
+// DecisionJSON is the deterministic subset of a Decision that both tctl
+// evaluate and the audit event serialize, so the two cannot drift. The
+// audit event adds metadata (time, resource metadata) on top.
+type DecisionJSON struct {
+	Event            string            `json:"event"`
+	Method           string            `json:"method"`
+	Path             string            `json:"path"`
+	App              string            `json:"app"`
+	Binding          string            `json:"binding,omitempty"`
+	AuditCode        string            `json:"audit_code,omitempty"`
+	ReasonCode       string            `json:"reason_code,omitempty"`
+	Reason           string            `json:"reason,omitempty"`
+	PolicyRef        string            `json:"policy_ref"`
+	PathCaptures     map[string]string `json:"path_captures"`
+	AttachedPolicies []string          `json:"attached_policies"`
+}
+
+// JSON projects the Decision to DecisionJSON, normalizing PathCaptures to
+// {} and AttachedPolicies to [] so neither serializes as null.
+func (d Decision) JSON() DecisionJSON {
+	event := EventDeny
+	if d.Allow {
+		event = EventAllow
+	}
+	captures := d.PathCaptures
+	if captures == nil {
+		captures = map[string]string{}
+	}
+	attached := d.AttachedPolicies
+	if attached == nil {
+		attached = []string{}
+	}
+	return DecisionJSON{
+		Event:            event,
+		Method:           d.Method,
+		Path:             d.Path,
+		App:              d.App,
+		Binding:          d.Binding,
+		AuditCode:        d.AuditCode,
+		ReasonCode:       d.ReasonCode,
+		Reason:           d.Reason,
+		PolicyRef:        d.PolicyRef,
+		PathCaptures:     captures,
+		AttachedPolicies: attached,
+	}
+}

--- a/lib/srv/app/policy/engine_test.go
+++ b/lib/srv/app/policy/engine_test.go
@@ -1,0 +1,387 @@
+/*
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package policy
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// mustCompile compiles a path pattern for a test rule and fails the test
+// if the pattern is malformed.
+func mustCompile(t *testing.T, patterns ...string) []*Matcher {
+	t.Helper()
+	out := make([]*Matcher, len(patterns))
+	for i, p := range patterns {
+		m, err := Compile(p)
+		require.NoError(t, err)
+		out[i] = m
+	}
+	return out
+}
+
+// TestEvaluate pins the decision model. The three named seed cases
+// (conformance cases 01, 04, 05) are reproduced here in their resolved
+// form: the rule provenance and attached-policy list are what the loader
+// will hand the engine, so these rows exercise the engine and its JSON
+// projection without depending on the loader. The remaining rows cover
+// the no-policies-attached branch in both RequirePolicy states.
+func TestEvaluate(t *testing.T) {
+	// inlineHealth is the resolved form of cases 01 and 05: one inline
+	// policy "health" with a single GET /api/v4/health allow rule.
+	inlineHealth := Input{
+		AttachedPolicies: []string{"health"},
+		Rules: []Rule{{
+			Paths:     mustCompile(t, "/api/v4/health"),
+			Methods:   []string{"GET"},
+			PolicyRef: "health",
+		}},
+	}
+	// boundRepoRead is the resolved form of case 04: a standalone policy
+	// reached through the "gitlab" binding, with an audit_code and a
+	// capture.
+	boundRepoRead := Input{
+		AttachedPolicies: []string{"gitlab/gitlab-repo-read"},
+		Rules: []Rule{{
+			Paths:     mustCompile(t, "/api/v4/projects/{project}/repository/**"),
+			Methods:   []string{"GET", "HEAD"},
+			PolicyRef: "gitlab/gitlab-repo-read/repo_read",
+			AuditCode: "repo_read",
+			Binding:   "gitlab",
+		}},
+	}
+
+	withRequest := func(base Input, app, method, path string) Input {
+		base.Request = Request{App: app, Method: method, Path: path}
+		return base
+	}
+
+	tests := []struct {
+		name string
+		in   Input
+		want DecisionJSON
+	}{
+		// Case 01: exact path match, GET allowed, no audit_code.
+		{
+			name: "01/exact path allow",
+			in:   withRequest(inlineHealth, "gitlab", "GET", "/api/v4/health"),
+			want: DecisionJSON{
+				Event:            EventAllow,
+				Method:           "GET",
+				Path:             "/api/v4/health",
+				App:              "gitlab",
+				PolicyRef:        "health",
+				PathCaptures:     map[string]string{},
+				AttachedPolicies: []string{"health"},
+			},
+		},
+		{
+			name: "01/method mismatch deny",
+			in:   withRequest(inlineHealth, "gitlab", "POST", "/api/v4/health"),
+			want: DecisionJSON{
+				Event:            EventDeny,
+				Method:           "POST",
+				Path:             "/api/v4/health",
+				App:              "gitlab",
+				ReasonCode:       ReasonNoMatchingAllow,
+				Reason:           DefaultDenyReason,
+				PolicyRef:        ReasonNoMatchingAllow,
+				PathCaptures:     map[string]string{},
+				AttachedPolicies: []string{"health"},
+			},
+		},
+		{
+			name: "01/sibling path deny",
+			in:   withRequest(inlineHealth, "gitlab", "GET", "/api/v4/health/details"),
+			want: DecisionJSON{
+				Event:            EventDeny,
+				Method:           "GET",
+				Path:             "/api/v4/health/details",
+				App:              "gitlab",
+				ReasonCode:       ReasonNoMatchingAllow,
+				Reason:           DefaultDenyReason,
+				PolicyRef:        ReasonNoMatchingAllow,
+				PathCaptures:     map[string]string{},
+				AttachedPolicies: []string{"health"},
+			},
+		},
+		// Case 04: binding-resolved standalone policy, multiple methods,
+		// capture, audit_code, method mismatch.
+		{
+			name: "04/GET allow with capture and binding",
+			in:   withRequest(boundRepoRead, "gitlab", "GET", "/api/v4/projects/123/repository/files/README"),
+			want: DecisionJSON{
+				Event:            EventAllow,
+				Method:           "GET",
+				Path:             "/api/v4/projects/123/repository/files/README",
+				App:              "gitlab",
+				Binding:          "gitlab",
+				AuditCode:        "repo_read",
+				PolicyRef:        "gitlab/gitlab-repo-read/repo_read",
+				PathCaptures:     map[string]string{"project": "123"},
+				AttachedPolicies: []string{"gitlab/gitlab-repo-read"},
+			},
+		},
+		{
+			name: "04/HEAD allow",
+			in:   withRequest(boundRepoRead, "gitlab", "HEAD", "/api/v4/projects/123/repository/files/README"),
+			want: DecisionJSON{
+				Event:            EventAllow,
+				Method:           "HEAD",
+				Path:             "/api/v4/projects/123/repository/files/README",
+				App:              "gitlab",
+				Binding:          "gitlab",
+				AuditCode:        "repo_read",
+				PolicyRef:        "gitlab/gitlab-repo-read/repo_read",
+				PathCaptures:     map[string]string{"project": "123"},
+				AttachedPolicies: []string{"gitlab/gitlab-repo-read"},
+			},
+		},
+		{
+			name: "04/DELETE method mismatch deny",
+			in:   withRequest(boundRepoRead, "gitlab", "DELETE", "/api/v4/projects/123/repository/files/README"),
+			want: DecisionJSON{
+				Event:            EventDeny,
+				Method:           "DELETE",
+				Path:             "/api/v4/projects/123/repository/files/README",
+				App:              "gitlab",
+				ReasonCode:       ReasonNoMatchingAllow,
+				Reason:           DefaultDenyReason,
+				PolicyRef:        ReasonNoMatchingAllow,
+				PathCaptures:     map[string]string{},
+				AttachedPolicies: []string{"gitlab/gitlab-repo-read"},
+			},
+		},
+		// Case 05: same inline policy denies a non-matching path and
+		// allows the matching one (default-deny once a policy attaches).
+		{
+			name: "05/non-matching path deny",
+			in:   withRequest(inlineHealth, "gitlab", "GET", "/api/v4/admin/users"),
+			want: DecisionJSON{
+				Event:            EventDeny,
+				Method:           "GET",
+				Path:             "/api/v4/admin/users",
+				App:              "gitlab",
+				ReasonCode:       ReasonNoMatchingAllow,
+				Reason:           DefaultDenyReason,
+				PolicyRef:        ReasonNoMatchingAllow,
+				PathCaptures:     map[string]string{},
+				AttachedPolicies: []string{"health"},
+			},
+		},
+		{
+			name: "05/matching path allow",
+			in:   withRequest(inlineHealth, "gitlab", "GET", "/api/v4/health"),
+			want: DecisionJSON{
+				Event:            EventAllow,
+				Method:           "GET",
+				Path:             "/api/v4/health",
+				App:              "gitlab",
+				PolicyRef:        "health",
+				PathCaptures:     map[string]string{},
+				AttachedPolicies: []string{"health"},
+			},
+		},
+		// A lowercase method does not match an upper-case stored method:
+		// the loader uppercases, so matching is case-sensitive.
+		{
+			name: "lowercase method denies",
+			in:   withRequest(inlineHealth, "gitlab", "get", "/api/v4/health"),
+			want: DecisionJSON{
+				Event:            EventDeny,
+				Method:           "get",
+				Path:             "/api/v4/health",
+				App:              "gitlab",
+				ReasonCode:       ReasonNoMatchingAllow,
+				Reason:           DefaultDenyReason,
+				PolicyRef:        ReasonNoMatchingAllow,
+				PathCaptures:     map[string]string{},
+				AttachedPolicies: []string{"health"},
+			},
+		},
+		// An empty method filter matches any method.
+		{
+			name: "empty methods matches any method",
+			in: Input{
+				Request:          Request{App: "gitlab", Method: "PATCH", Path: "/api/v4/health"},
+				AttachedPolicies: []string{"any-method"},
+				Rules: []Rule{{
+					Paths:     mustCompile(t, "/api/v4/health"),
+					PolicyRef: "any-method",
+				}},
+			},
+			want: DecisionJSON{
+				Event:            EventAllow,
+				Method:           "PATCH",
+				Path:             "/api/v4/health",
+				App:              "gitlab",
+				PolicyRef:        "any-method",
+				PathCaptures:     map[string]string{},
+				AttachedPolicies: []string{"any-method"},
+			},
+		},
+		// An empty path list matches any path.
+		{
+			name: "empty paths matches any path",
+			in: Input{
+				Request:          Request{App: "gitlab", Method: "GET", Path: "/anything/at/all"},
+				AttachedPolicies: []string{"any-path"},
+				Rules: []Rule{{
+					Methods:   []string{"GET"},
+					PolicyRef: "any-path",
+				}},
+			},
+			want: DecisionJSON{
+				Event:            EventAllow,
+				Method:           "GET",
+				Path:             "/anything/at/all",
+				App:              "gitlab",
+				PolicyRef:        "any-path",
+				PathCaptures:     map[string]string{},
+				AttachedPolicies: []string{"any-path"},
+			},
+		},
+		// A rule with several path patterns matches when a later one
+		// matches, not only the first.
+		{
+			name: "second path pattern in a rule matches",
+			in: Input{
+				Request:          Request{App: "gitlab", Method: "GET", Path: "/api/v4/version"},
+				AttachedPolicies: []string{"multi"},
+				Rules: []Rule{{
+					Paths:     mustCompile(t, "/api/v4/health", "/api/v4/version"),
+					Methods:   []string{"GET"},
+					PolicyRef: "multi",
+				}},
+			},
+			want: DecisionJSON{
+				Event:            EventAllow,
+				Method:           "GET",
+				Path:             "/api/v4/version",
+				App:              "gitlab",
+				PolicyRef:        "multi",
+				PathCaptures:     map[string]string{},
+				AttachedPolicies: []string{"multi"},
+			},
+		},
+		// An attached policy that contributes no rules still default-denies:
+		// the no-match branch keys off the attached set, not the rule count.
+		{
+			name: "attached policy with no usable rules denies",
+			in: Input{
+				Request:          Request{App: "gitlab", Method: "GET", Path: "/anything"},
+				AttachedPolicies: []string{"empty-policy"},
+			},
+			want: DecisionJSON{
+				Event:            EventDeny,
+				Method:           "GET",
+				Path:             "/anything",
+				App:              "gitlab",
+				ReasonCode:       ReasonNoMatchingAllow,
+				Reason:           DefaultDenyReason,
+				PolicyRef:        ReasonNoMatchingAllow,
+				PathCaptures:     map[string]string{},
+				AttachedPolicies: []string{"empty-policy"},
+			},
+		},
+		// No policies attached: permissive today, deny under enforcement.
+		{
+			name: "no policies permissive allow",
+			in: Input{
+				Request: Request{App: "gitlab", Method: "GET", Path: "/anything"},
+			},
+			want: DecisionJSON{
+				Event:            EventAllow,
+				Method:           "GET",
+				Path:             "/anything",
+				App:              "gitlab",
+				PathCaptures:     map[string]string{},
+				AttachedPolicies: []string{},
+			},
+		},
+		{
+			name: "no policies require-policy deny",
+			in: Input{
+				Request:       Request{App: "gitlab", Method: "GET", Path: "/anything"},
+				RequirePolicy: true,
+			},
+			want: DecisionJSON{
+				Event:            EventDeny,
+				Method:           "GET",
+				Path:             "/anything",
+				App:              "gitlab",
+				ReasonCode:       ReasonNoPolicyAttached,
+				Reason:           DefaultDenyReason,
+				PolicyRef:        ReasonNoPolicyAttached,
+				PathCaptures:     map[string]string{},
+				AttachedPolicies: []string{},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := Evaluate(tc.in).JSON()
+			require.Equal(t, tc.want, got)
+		})
+	}
+}
+
+// TestEvaluateFirstMatchWins checks that the earliest rule in evaluation
+// order decides, and that its provenance, not a later rule's, is the one
+// reported.
+func TestEvaluateFirstMatchWins(t *testing.T) {
+	in := Input{
+		Request:          Request{App: "gitlab", Method: "GET", Path: "/api/v4/health"},
+		AttachedPolicies: []string{"first", "second"},
+		Rules: []Rule{
+			{Paths: mustCompile(t, "/api/v4/health"), Methods: []string{"GET"}, PolicyRef: "first", AuditCode: "first_code"},
+			{Paths: mustCompile(t, "/api/v4/**"), Methods: []string{"GET"}, PolicyRef: "second", AuditCode: "second_code"},
+		},
+	}
+
+	dec := Evaluate(in)
+	require.True(t, dec.Allow)
+	require.Equal(t, "first", dec.PolicyRef)
+	require.Equal(t, "first_code", dec.AuditCode)
+}
+
+// TestDecisionJSONNormalizesEmptyCollections checks that the projection
+// renders empty captures and an empty attached set as a JSON object and
+// array rather than null, since the conformance output and audit payload
+// both rely on path_captures being {} when a decision has no captures.
+func TestDecisionJSONNormalizesEmptyCollections(t *testing.T) {
+	out, err := json.Marshal(Decision{Allow: true}.JSON())
+	require.NoError(t, err)
+
+	require.Contains(t, string(out), `"path_captures":{}`)
+	require.Contains(t, string(out), `"attached_policies":[]`)
+	// Fields the decision does not set are omitted, not emitted empty.
+	require.NotContains(t, string(out), `"binding"`)
+	require.NotContains(t, string(out), `"audit_code"`)
+	require.NotContains(t, string(out), `"reason_code"`)
+
+	// A deny emits reason_code and reason.
+	denyOut, err := json.Marshal(deny(Decision{}, ReasonNoMatchingAllow).JSON())
+	require.NoError(t, err)
+	require.Contains(t, string(denyOut), `"reason_code":"`+ReasonNoMatchingAllow+`"`)
+	require.Contains(t, string(denyOut), `"reason":"`+DefaultDenyReason+`"`)
+}


### PR DESCRIPTION
Add the decision engine for per-request HTTP authorization in App Access (RFD 0303). It follows the matcher and wire-form validator in [#67224](https://github.com/gravitational/teleport/pull/67224) and has no callers yet, so it changes no runtime behavior.

`Evaluate` runs the three-outcome model. It permits when no policy is attached unless `RequirePolicy` is set, allows on the first rule whose method and path both match, and otherwise denies. It treats `policy_ref`, `audit_code`, and `binding` as opaque strings the loader assembles, so it never inspects where a policy attaches.

**For reviewers:** this PR stays valid for any path-based authorization model, whatever the attachment decision turns out to be.

Manual test plan: not applicable (`no-test-plan` label). Coverage is unit tests via `go test ./lib/srv/app/policy/...`.

Related-PR: https://github.com/gravitational/teleport/pull/67224
Related-RFD: https://github.com/gravitational/rfd/pull/15
