### PR TITLE
Deprecate async state hooks

### DIFF
--- a/.oxlintrc.jsonc
+++ b/.oxlintrc.jsonc
@@ -320,6 +320,28 @@
           {
             "patterns": [
               { "group": ["teleport/**", "e-teleport/**", "teleterm/**"] }
+            ],
+            "paths": [
+              {
+                "name": "shared/hooks/useAsync",
+                "importNames": ["useAsync"],
+                "message": "useAsync is deprecated; use TanStack Query (useQuery/useMutation) instead. See RFD 197."
+              },
+              {
+                "name": "shared/hooks/useAttempt",
+                "importNames": ["default"],
+                "message": "useAttempt is deprecated; use TanStack Query (useQuery/useMutation) instead. See RFD 197."
+              },
+              {
+                "name": "shared/hooks/useAttemptNext",
+                "importNames": ["default"],
+                "message": "useAttemptNext is deprecated; use TanStack Query (useQuery/useMutation) instead. See RFD 197."
+              },
+              {
+                "name": "shared/hooks",
+                "importNames": ["useAttempt", "useAttemptNext"],
+                "message": "useAttempt/useAttemptNext are deprecated; use TanStack Query (useQuery/useMutation) instead. See RFD 197."
+              }
             ]
           }
         ]
@@ -342,6 +364,26 @@
                 "name": "usehooks-ts",
                 "importNames": ["useCopyToClipboard"],
                 "message": "Use 'copyToClipboard' from 'design/utils/copyToClipboard' instead."
+              },
+              {
+                "name": "shared/hooks/useAsync",
+                "importNames": ["useAsync"],
+                "message": "useAsync is deprecated; use TanStack Query (useQuery/useMutation) instead. See RFD 197."
+              },
+              {
+                "name": "shared/hooks/useAttempt",
+                "importNames": ["default"],
+                "message": "useAttempt is deprecated; use TanStack Query (useQuery/useMutation) instead. See RFD 197."
+              },
+              {
+                "name": "shared/hooks/useAttemptNext",
+                "importNames": ["default"],
+                "message": "useAttemptNext is deprecated; use TanStack Query (useQuery/useMutation) instead. See RFD 197."
+              },
+              {
+                "name": "shared/hooks",
+                "importNames": ["useAttempt", "useAttemptNext"],
+                "message": "useAttempt/useAttemptNext are deprecated; use TanStack Query (useQuery/useMutation) instead. See RFD 197."
               }
             ]
           }
@@ -365,6 +407,26 @@
                 "name": "usehooks-ts",
                 "importNames": ["useCopyToClipboard"],
                 "message": "Use 'copyToClipboard' from 'design/utils/copyToClipboard' instead."
+              },
+              {
+                "name": "shared/hooks/useAsync",
+                "importNames": ["useAsync"],
+                "message": "useAsync is deprecated; use TanStack Query (useQuery/useMutation) instead. See RFD 197."
+              },
+              {
+                "name": "shared/hooks/useAttempt",
+                "importNames": ["default"],
+                "message": "useAttempt is deprecated; use TanStack Query (useQuery/useMutation) instead. See RFD 197."
+              },
+              {
+                "name": "shared/hooks/useAttemptNext",
+                "importNames": ["default"],
+                "message": "useAttemptNext is deprecated; use TanStack Query (useQuery/useMutation) instead. See RFD 197."
+              },
+              {
+                "name": "shared/hooks",
+                "importNames": ["useAttempt", "useAttemptNext"],
+                "message": "useAttempt/useAttemptNext are deprecated; use TanStack Query (useQuery/useMutation) instead. See RFD 197."
               }
             ]
           }
@@ -388,6 +450,26 @@
                 "name": "usehooks-ts",
                 "importNames": ["useCopyToClipboard"],
                 "message": "Use 'copyToClipboard' from 'design/utils/copyToClipboard' instead."
+              },
+              {
+                "name": "shared/hooks/useAsync",
+                "importNames": ["useAsync"],
+                "message": "useAsync is deprecated; use TanStack Query (useQuery/useMutation) instead. See RFD 197."
+              },
+              {
+                "name": "shared/hooks/useAttempt",
+                "importNames": ["default"],
+                "message": "useAttempt is deprecated; use TanStack Query (useQuery/useMutation) instead. See RFD 197."
+              },
+              {
+                "name": "shared/hooks/useAttemptNext",
+                "importNames": ["default"],
+                "message": "useAttemptNext is deprecated; use TanStack Query (useQuery/useMutation) instead. See RFD 197."
+              },
+              {
+                "name": "shared/hooks",
+                "importNames": ["useAttempt", "useAttemptNext"],
+                "message": "useAttempt/useAttemptNext are deprecated; use TanStack Query (useQuery/useMutation) instead. See RFD 197."
               }
             ]
           }
@@ -413,6 +495,26 @@
                 "name": "usehooks-ts",
                 "importNames": ["useCopyToClipboard"],
                 "message": "Use 'copyToClipboard' from 'design/utils/copyToClipboard' instead."
+              },
+              {
+                "name": "shared/hooks/useAsync",
+                "importNames": ["useAsync"],
+                "message": "useAsync is deprecated; use TanStack Query (useQuery/useMutation) instead. See RFD 197."
+              },
+              {
+                "name": "shared/hooks/useAttempt",
+                "importNames": ["default"],
+                "message": "useAttempt is deprecated; use TanStack Query (useQuery/useMutation) instead. See RFD 197."
+              },
+              {
+                "name": "shared/hooks/useAttemptNext",
+                "importNames": ["default"],
+                "message": "useAttemptNext is deprecated; use TanStack Query (useQuery/useMutation) instead. See RFD 197."
+              },
+              {
+                "name": "shared/hooks",
+                "importNames": ["useAttempt", "useAttemptNext"],
+                "message": "useAttempt/useAttemptNext are deprecated; use TanStack Query (useQuery/useMutation) instead. See RFD 197."
               }
             ]
           }

--- a/.oxlintrc.jsonc
+++ b/.oxlintrc.jsonc
@@ -597,6 +597,277 @@
           }
         ]
       }
+    },
+    // Legacy async state hook call sites (RFD 197). These files predate the ban added to
+    // the per-directory blocks above. Each one keeps its directory's cross-package import
+    // restrictions but is exempt from the new hook ban. As files migrate to TanStack Query,
+    // remove them from these lists. Because oxlint replaces (not merges) no-restricted-imports
+    // across overrides, these blocks come last so they win for the listed files.
+    //
+    // TODO(ravicious): Migrate these to a suppression file once it's available.
+    // https://github.com/oxc-project/oxc/issues/10549
+    {
+      "files": [
+        "web/packages/shared/components/DesktopSession/DesktopSession.tsx",
+        "web/packages/shared/components/FieldSelect/FieldSelect.tsx",
+        "web/packages/shared/components/FieldSelect/FieldSelectCreatable.tsx",
+        "web/packages/shared/components/MenuLogin/MenuLogin.tsx",
+        "web/packages/shared/components/UnifiedResources/UnifiedResources.tsx"
+      ],
+      "rules": {
+        "no-restricted-imports": [
+          "error",
+          {
+            "patterns": [{ "group": ["teleport/**", "e-teleport/**", "teleterm/**"] }]
+          }
+        ]
+      }
+    },
+    {
+      "files": [
+        "web/packages/teleport/src/Account/ChangePasswordWizard/ChangePasswordWizard.tsx",
+        "web/packages/teleport/src/Account/ManageDevices/useManageDevices.ts",
+        "web/packages/teleport/src/Account/ManageDevices/wizards/AddAuthDeviceWizard.tsx",
+        "web/packages/teleport/src/Account/ManageDevices/wizards/DeleteAuthDeviceWizard.tsx",
+        "web/packages/teleport/src/Account/Preferences.tsx",
+        "web/packages/teleport/src/AppLauncher/AppLauncher.tsx",
+        "web/packages/teleport/src/Apps/AddApp/useAddApp.ts",
+        "web/packages/teleport/src/AuthConnectors/AuthConnectorEditor/GitHubConnectorEditor.tsx",
+        "web/packages/teleport/src/AuthConnectors/AuthConnectors.tsx",
+        "web/packages/teleport/src/AuthConnectors/DeleteConnectorDialog/DeleteConnectorDialog.tsx",
+        "web/packages/teleport/src/Bots/Add/GitHubActionsSsh/ConfigureBot.tsx",
+        "web/packages/teleport/src/Bots/Add/GitHubActionsSsh/useGitHubSshFlow.tsx",
+        "web/packages/teleport/src/Bots/List/Bots.tsx",
+        "web/packages/teleport/src/BrowserMFA/BrowserMFA.tsx",
+        "web/packages/teleport/src/Clusters/Clusters.tsx",
+        "web/packages/teleport/src/Clusters/ManageCluster/ManageCluster.tsx",
+        "web/packages/teleport/src/components/Authenticated/Authenticated.tsx",
+        "web/packages/teleport/src/components/FormLogin/FormIdentifierFirst.tsx",
+        "web/packages/teleport/src/components/FormLogin/FormLogin.tsx",
+        "web/packages/teleport/src/components/hooks/useServersidePagination.ts",
+        "web/packages/teleport/src/components/MfaDeviceList/RemoveDialog/RemoveDialog.tsx",
+        "web/packages/teleport/src/components/ReAuthenticate/useReAuthenticate.ts",
+        "web/packages/teleport/src/components/ResourceEditor/ResourceEditor.jsx",
+        "web/packages/teleport/src/Console/Console.tsx",
+        "web/packages/teleport/src/Console/DocumentDb/ConnectDialog.tsx",
+        "web/packages/teleport/src/DesktopSession/DesktopSession.tsx",
+        "web/packages/teleport/src/Discover/AwsMangementConsole/CreateAppAccess/CreateAppAccess.tsx",
+        "web/packages/teleport/src/Discover/ConnectMyComputer/TestConnection/TestConnection.tsx",
+        "web/packages/teleport/src/Discover/Database/CreateDatabase/useCreateDatabase.ts",
+        "web/packages/teleport/src/Discover/Database/DeployService/AutoDeploy/AutoDeploy.tsx",
+        "web/packages/teleport/src/Discover/Database/DeployService/AutoDeploy/SelectSecurityGroups.tsx",
+        "web/packages/teleport/src/Discover/Database/DeployService/AutoDeploy/SelectSubnetIds.tsx",
+        "web/packages/teleport/src/Discover/Database/EnrollRdsDatabase/AutoEnrollment.tsx",
+        "web/packages/teleport/src/Discover/Database/EnrollRdsDatabase/EnrollRdsDatabase.tsx",
+        "web/packages/teleport/src/Discover/Database/IamPolicy/useIamPolicy.ts",
+        "web/packages/teleport/src/Discover/Database/MutualTls/useMutualTls.ts",
+        "web/packages/teleport/src/Discover/Kubernetes/EnrollEKSCluster/EnrollEksCluster.tsx",
+        "web/packages/teleport/src/Discover/SelectResource/SelectResource.tsx",
+        "web/packages/teleport/src/Discover/Server/DiscoveryConfigSsm/DiscoveryConfigSsm.tsx",
+        "web/packages/teleport/src/Discover/Shared/AwsAccount/AwsAccount.tsx",
+        "web/packages/teleport/src/Discover/Shared/ConfigureDiscoveryService/ConfigureDiscoveryService.tsx",
+        "web/packages/teleport/src/Discover/Shared/ConnectionDiagnostic/useConnectionDiagnostic.ts",
+        "web/packages/teleport/src/Discover/Shared/SetupAccess/useUserTraits.ts",
+        "web/packages/teleport/src/Integrations/DeleteAwsOidcIntegrationDialog.tsx",
+        "web/packages/teleport/src/Integrations/EditAwsOidcIntegrationDialog.tsx",
+        "web/packages/teleport/src/Integrations/Enroll/AwsOidc/useAwsOidcIntegration.tsx",
+        "web/packages/teleport/src/Integrations/IntegrationList.tsx",
+        "web/packages/teleport/src/Integrations/Integrations.tsx",
+        "web/packages/teleport/src/Integrations/RemoveIntegrationDialog.tsx",
+        "web/packages/teleport/src/Integrations/status/AwsOidc/Details/Agents.tsx",
+        "web/packages/teleport/src/Integrations/status/AwsOidc/Tasks/Task.tsx",
+        "web/packages/teleport/src/Integrations/status/AwsOidc/useAwsOidcStatus.tsx",
+        "web/packages/teleport/src/JoinTokens/JoinTokens.tsx",
+        "web/packages/teleport/src/JoinTokens/UpsertJoinTokenDialog.tsx",
+        "web/packages/teleport/src/lib/useMfa.ts",
+        "web/packages/teleport/src/LocksV2/Locks/DeleteLockDialogue.tsx",
+        "web/packages/teleport/src/LocksV2/Locks/Locks.tsx",
+        "web/packages/teleport/src/LocksV2/NewLock/LockCheckout/LockCheckout.tsx",
+        "web/packages/teleport/src/LocksV2/NewLock/NewLock.tsx",
+        "web/packages/teleport/src/Login/useLogin.ts",
+        "web/packages/teleport/src/Main/Main.tsx",
+        "web/packages/teleport/src/Notifications/Notification.tsx",
+        "web/packages/teleport/src/Recordings/useRecordings.ts",
+        "web/packages/teleport/src/Roles/DeleteRole/DeleteRole.tsx",
+        "web/packages/teleport/src/Roles/RoleEditor/RoleEditor.story.tsx",
+        "web/packages/teleport/src/Roles/RoleEditor/RoleEditor.tsx",
+        "web/packages/teleport/src/Roles/RoleEditor/RoleEditorAdapter.tsx",
+        "web/packages/teleport/src/Roles/RoleEditor/StandardEditor/MetadataSection.tsx",
+        "web/packages/teleport/src/Sessions/useSessions.ts",
+        "web/packages/teleport/src/TrustedClusters/DeleteTrust/DeleteTrust.tsx",
+        "web/packages/teleport/src/TrustedClusters/useTrustedClusters.ts",
+        "web/packages/teleport/src/User/UserContext.tsx",
+        "web/packages/teleport/src/Users/UserReset/UserReset.tsx",
+        "web/packages/teleport/src/Welcome/useToken.ts"
+      ],
+      "rules": {
+        "no-restricted-imports": [
+          "error",
+          {
+            "patterns": [{ "group": ["e-teleport/**", "teleterm/**"] }],
+            "paths": [
+              {
+                "name": "usehooks-ts",
+                "importNames": ["useResizeObserver"],
+                "message": "Use 'useResizeObserver' from 'design/utils/useResizeObserver' instead."
+              },
+              {
+                "name": "usehooks-ts",
+                "importNames": ["useCopyToClipboard"],
+                "message": "Use 'copyToClipboard' from 'design/utils/copyToClipboard' instead."
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "files": [
+        "web/packages/teleterm/src/ui/AccessRequestCheckout/useAccessRequestCheckout.ts",
+        "web/packages/teleterm/src/ui/AccessRequests/AccessRequestsContext.tsx",
+        "web/packages/teleterm/src/ui/AccessRequests/SelectorMenu.tsx",
+        "web/packages/teleterm/src/ui/ClusterConnect/ClusterAdd/ClusterAdd.tsx",
+        "web/packages/teleterm/src/ui/ClusterConnect/ClusterLogin/useClusterLogin.ts",
+        "web/packages/teleterm/src/ui/ClusterLogout/ClusterLogout.tsx",
+        "web/packages/teleterm/src/ui/ConnectMyComputer/connectMyComputerContext.tsx",
+        "web/packages/teleterm/src/ui/ConnectMyComputer/DocumentConnectMyComputer/Setup.tsx",
+        "web/packages/teleterm/src/ui/DocumentAccessRequests/NewRequest/NewRequest.tsx",
+        "web/packages/teleterm/src/ui/DocumentAccessRequests/ReviewAccessRequest/useReviewAccessRequest.ts",
+        "web/packages/teleterm/src/ui/DocumentAccessRequests/useAssumeAccess.ts",
+        "web/packages/teleterm/src/ui/DocumentAuthorizeWebSession/DocumentAuthorizeWebSession.tsx",
+        "web/packages/teleterm/src/ui/DocumentCluster/DocumentCluster.tsx",
+        "web/packages/teleterm/src/ui/DocumentCluster/useUserPreferences.ts",
+        "web/packages/teleterm/src/ui/DocumentGateway/useGateway.ts",
+        "web/packages/teleterm/src/ui/DocumentGatewayApp/AppGateway.tsx",
+        "web/packages/teleterm/src/ui/DocumentGatewayKube/DocumentGatewayKube.tsx",
+        "web/packages/teleterm/src/ui/DocumentTerminal/useDocumentTerminal.ts",
+        "web/packages/teleterm/src/ui/HeadlessAuthn/HeadlessAuthentication.tsx",
+        "web/packages/teleterm/src/ui/Search/pickers/ParameterPicker.tsx",
+        "web/packages/teleterm/src/ui/Search/pickers/useActionAttempts.ts",
+        "web/packages/teleterm/src/ui/StatusBar/ShareFeedback/useShareFeedback.ts",
+        "web/packages/teleterm/src/ui/Vnet/ConfigureSSHClients.tsx",
+        "web/packages/teleterm/src/ui/Vnet/DocumentVnetDiagReport.tsx",
+        "web/packages/teleterm/src/ui/Vnet/vnetContext.tsx"
+      ],
+      "rules": {
+        "no-restricted-imports": [
+          "error",
+          {
+            "patterns": [{ "group": ["teleport/**", "e-teleport/**"] }],
+            "paths": [
+              {
+                "name": "usehooks-ts",
+                "importNames": ["useResizeObserver"],
+                "message": "Use 'useResizeObserver' from 'design/utils/useResizeObserver' instead."
+              },
+              {
+                "name": "usehooks-ts",
+                "importNames": ["useCopyToClipboard"],
+                "message": "Use 'copyToClipboard' from 'design/utils/copyToClipboard' instead."
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "files": [
+        "e/web/teleport/src/AccessAutomations/AccessAutomations.tsx",
+        "e/web/teleport/src/AccessAutomations/RuleEditor/DeleteRuleDialogue.tsx",
+        "e/web/teleport/src/AccessAutomations/RuleEditor/RuleEditor.tsx",
+        "e/web/teleport/src/AccessListManagement/AccessListManagementContext.tsx",
+        "e/web/teleport/src/AccessListManagement/CreateAccessList/CreateAccessListContextProvider.tsx",
+        "e/web/teleport/src/AccessListManagement/CreateAccessList/GrantSection.tsx",
+        "e/web/teleport/src/AccessListManagement/GuideEditor/Preset/DefineIdentities/DefineIdentities.tsx",
+        "e/web/teleport/src/AccessListManagement/Shared/Shared.tsx",
+        "e/web/teleport/src/AccessListManagement/ViewEditAccessList/AuditAndReviews/EditAudit.tsx",
+        "e/web/teleport/src/AccessListManagement/ViewEditAccessList/DeleteAccessList/DeleteAccessListConfirmDialog.tsx",
+        "e/web/teleport/src/AccessListManagement/ViewEditAccessList/DeleteUserConfirmDialog.tsx",
+        "e/web/teleport/src/AccessListManagement/ViewEditAccessList/Members/EnrollNewMembers.tsx",
+        "e/web/teleport/src/AccessListManagement/ViewEditAccessList/Owners/EnrollNewOwners.tsx",
+        "e/web/teleport/src/AccessListManagement/ViewEditAccessList/ReviewAccessList/ReviewAccessList.tsx",
+        "e/web/teleport/src/AccessListManagement/ViewEditAccessList/Specs/EditEligibilityOrGrants.tsx",
+        "e/web/teleport/src/AccessListManagement/ViewEditAccessList/Specs/EditTitleOrDescription.tsx",
+        "e/web/teleport/src/AccessListManagement/ViewEditAccessList/ViewEditAccessList.tsx",
+        "e/web/teleport/src/AccessMonitoring/QueryEditor/QueryEditor.tsx",
+        "e/web/teleport/src/AccessMonitoring/QueryEditor/Result.tsx",
+        "e/web/teleport/src/AccessMonitoring/Report/Report.tsx",
+        "e/web/teleport/src/AccessMonitoring/ReportList.tsx",
+        "e/web/teleport/src/Account/Recovery/RecoveryCodesDialog/useRecoveryCodesDialog.ts",
+        "e/web/teleport/src/Account/Recovery/useRecovery.ts",
+        "e/web/teleport/src/AuthConnectors/AuthConnectorEditor/AuthConnectorEditor.tsx",
+        "e/web/teleport/src/AuthConnectors/AuthConnectors.tsx",
+        "e/web/teleport/src/Banner/Switchback/useSwitchback.ts",
+        "e/web/teleport/src/DeviceTrust/useDevices.tsx",
+        "e/web/teleport/src/Downloads/useDownloads.ts",
+        "e/web/teleport/src/Integrations/EditGitHubIntegrationDialog.tsx",
+        "e/web/teleport/src/Integrations/IntegrationEnroll/DeleteDialogs/ExternalAuditStorageDelete.tsx",
+        "e/web/teleport/src/Integrations/IntegrationEnroll/DeleteDialogs/GitHubRepoAccessDelete.tsx",
+        "e/web/teleport/src/Integrations/IntegrationEnroll/ExternalAuditStorage/ConfigurePermissions/ConfigurePermissions.tsx",
+        "e/web/teleport/src/Integrations/IntegrationEnroll/ExternalAuditStorage/ExternalAuditStorage.tsx",
+        "e/web/teleport/src/Integrations/IntegrationEnroll/ExternalAuditStorage/SelectIntegration/SelectIntegration.tsx",
+        "e/web/teleport/src/Integrations/IntegrationEnroll/ExternalAuditStorage/TestConnection/TestConnection.tsx",
+        "e/web/teleport/src/Integrations/IntegrationEnroll/ExternalAuditStorage/useExternalAuditStorage.tsx",
+        "e/web/teleport/src/Integrations/IntegrationEnroll/IntegrationPick/IntegrationPick.tsx",
+        "e/web/teleport/src/Integrations/IntegrationEnroll/PluginEnroll/MultiStep/AwsIdentityCenter/IdentitySource/IdentitySource.tsx",
+        "e/web/teleport/src/Integrations/IntegrationEnroll/PluginEnroll/MultiStep/AwsIdentityCenter/ImportResources/ImportResources.tsx",
+        "e/web/teleport/src/Integrations/IntegrationEnroll/PluginEnroll/MultiStep/AwsIdentityCenter/OidcIntegration/OidcIntegration.tsx",
+        "e/web/teleport/src/Integrations/IntegrationEnroll/PluginEnroll/MultiStep/AwsIdentityCenter/Scim/Scim.tsx",
+        "e/web/teleport/src/Integrations/IntegrationEnroll/PluginEnroll/MultiStep/Email/EmailService.tsx",
+        "e/web/teleport/src/Integrations/IntegrationEnroll/PluginEnroll/MultiStep/Entra/FormMixin.tsx",
+        "e/web/teleport/src/Integrations/IntegrationEnroll/PluginEnroll/MultiStep/Entra/RunScript.tsx",
+        "e/web/teleport/src/Integrations/IntegrationEnroll/PluginEnroll/MultiStep/GitHub/ConfigureAccess/ConfigureAccess.tsx",
+        "e/web/teleport/src/Integrations/IntegrationEnroll/PluginEnroll/MultiStep/GitHub/ConfigureSshCert/ConfigureSshCert.tsx",
+        "e/web/teleport/src/Integrations/IntegrationEnroll/PluginEnroll/MultiStep/GitHub/CreateIntegration/CreatingDialog.tsx",
+        "e/web/teleport/src/Integrations/IntegrationEnroll/PluginEnroll/SubmittablePluginForm.tsx",
+        "e/web/teleport/src/Integrations/PluginDelete.tsx",
+        "e/web/teleport/src/Integrations/useIntegrations.tsx",
+        "e/web/teleport/src/InviteCollaborators/EmailPasswordResetDialog.tsx",
+        "e/web/teleport/src/InviteCollaborators/InviteCollaboratorsDialog.tsx",
+        "e/web/teleport/src/Notifications/notificationContentFactoryE.tsx",
+        "e/web/teleport/src/Recovery/RecoveryFlow/Devices/useDevices.ts",
+        "e/web/teleport/src/Recovery/RecoveryFlow/NewMfaDevice/useNewMfaDevice.ts",
+        "e/web/teleport/src/Recovery/RecoveryFlow/NewPassword/useNewPassword.ts",
+        "e/web/teleport/src/Recovery/RecoveryFlow/NewRecoveryCodes/useNewRecoveryCodes.ts",
+        "e/web/teleport/src/Recovery/RecoveryFlow/useRecoveryFlow.ts",
+        "e/web/teleport/src/Recovery/RecoveryFlow/VerifyUser/useVerifyUser.ts",
+        "e/web/teleport/src/Recovery/RecoveryStart/useRecoveryStart.ts",
+        "e/web/teleport/src/Roles/AccessGraphDemoContext.tsx",
+        "e/web/teleport/src/Roles/useRoleWithAccessGraph.tsx",
+        "e/web/teleport/src/SamlApplication/components/ButtonDownloadMetadataFile.tsx",
+        "e/web/teleport/src/SamlApplication/hooks/useSamlAppActionsE.tsx",
+        "e/web/teleport/src/SamlApplication/hooks/useSamlApplication.tsx",
+        "e/web/teleport/src/SAMLIdPLogin/SAMLIdPLogin.tsx",
+        "e/web/teleport/src/Support/ClientIpRestrictions/ClientIpRestrictions.tsx",
+        "e/web/teleport/src/Support/Contacts/Contacts.tsx",
+        "e/web/teleport/src/WaitingRoom/RequestReason/useRequestReason.ts",
+        "e/web/teleport/src/WaitingRoom/useWaitingRoom.ts",
+        "e/web/teleport/src/Workflow/NewRequest/useNewRequest.ts",
+        "e/web/teleport/src/Workflow/NewRequest/useRequestCheckout.tsx",
+        "e/web/teleport/src/Workflow/ReviewRequests/RequestList/useRequestList.ts",
+        "e/web/teleport/src/Workflow/ReviewRequests/RequestView/RequestView.tsx",
+        "e/web/teleport/src/Workflow/ReviewRequests/RequestView/useRequestView.ts"
+      ],
+      "rules": {
+        "no-restricted-imports": [
+          "error",
+          {
+            "patterns": [{ "group": ["teleterm/**"] }],
+            "paths": [
+              {
+                "name": "usehooks-ts",
+                "importNames": ["useResizeObserver"],
+                "message": "Use 'useResizeObserver' from 'design/utils/useResizeObserver' instead."
+              },
+              {
+                "name": "usehooks-ts",
+                "importNames": ["useCopyToClipboard"],
+                "message": "Use 'copyToClipboard' from 'design/utils/copyToClipboard' instead."
+              }
+            ]
+          }
+        ]
+      }
     }
   ]
 }

--- a/rfd/0197-better-async-state-management-with-tanstack-query.md
+++ b/rfd/0197-better-async-state-management-with-tanstack-query.md
@@ -1,9 +1,9 @@
 ---
 authors: Ryan Clark (ryan.clark@goteleport.com)
-state: draft
+state: implemented
 ---
 
-# RFD 0195 - Better async state management with TanStack Query
+# RFD 0197 - Better async state management with TanStack Query
 
 ## Required Approvers
 

--- a/web/packages/shared/hooks/useAsync.ts
+++ b/web/packages/shared/hooks/useAsync.ts
@@ -19,6 +19,8 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 
 /**
+ * @deprecated Use TanStack Query (useQuery/useMutation) instead. See RFD 197.
+ *
  * `useAsync` lets you represent the state of an async operation as data. It accepts an async function
  * that you want to execute. Calling the hook returns an array of three elements:
  *

--- a/web/packages/shared/hooks/useAttempt.ts
+++ b/web/packages/shared/hooks/useAttempt.ts
@@ -29,6 +29,9 @@ const defaultState = {
   message: '',
 };
 
+/**
+ * @deprecated Use TanStack Query (useQuery/useMutation) instead. See RFD 197.
+ */
 export default function useAttempt(
   initialState: Partial<State>
 ): [State, Actions] {

--- a/web/packages/shared/hooks/useAttemptNext.ts
+++ b/web/packages/shared/hooks/useAttemptNext.ts
@@ -22,7 +22,11 @@ import Logger from 'shared/libs/logger';
 
 const logger = Logger.create('shared/hooks/useAttempt');
 
-// This is the next version of existing useAttempt hook
+/**
+ * @deprecated Use TanStack Query (useQuery/useMutation) instead. See RFD 197.
+ *
+ * This was the next version of the existing useAttempt hook.
+ */
 export default function useAttemptNext(status = '' as Attempt['status']) {
   const [attempt, setAttempt] = useState<Attempt>(() => ({
     status,


### PR DESCRIPTION
[As discussed on Slack](https://gravitational.slack.com/archives/C02DQ1C2BMW/p1780071293236089), this PR deprecates old hooks used for async state management in favor of TanStack Query (see [RFD 197](https://github.com/gravitational/teleport/blob/master/rfd/0197-better-async-state-management-with-tanstack-query.md)).

The way it's done… is not the best. But a better solution is coming!

In short, I wanted to mirror #66582 where new uses are banned but existing call sites are exempt from the ban. Oxlint doesn't really offer a good way to do this at the moment. We already use no-restricted-imports to ban cross-package imports (see https://github.com/gravitational/teleport/issues/54872). This means that there are four rule blocks to which we have to add bans of async state hooks (e4f21e22) which in itself is not that bad…

However, if we want to exempt existing callsites from the ban, there's no good way of doing this. We could add inline disable comments to each callsites but that's a lot of files. For now, I made Claude replicate the cross-package imports for the affected files (085d8811). This effectively bans cross-package imports within those files but still allows them to use async state hooks.

This is messy and a nightmare to maintain. If we ever need to add another no-restricted-imports rule, we'll need to replicate across many blocks in Oxlint's config file. Fortunately, Oxlint is soon going to add support for suppression file. One thing that's neat is that (AFAIK) it's going to have support for automatically cleaning up suppressions that are no longer necessary (e.g., when someone migrates the callsite to use TanStack Query).

* https://eslint.org/blog/2025/04/introducing-bulk-suppressions/
* https://github.com/oxc-project/oxc/issues/10549

In the meantime, I think this is a good compromise. I'm subscribed to the above issue so I'll make sure to migrate to this feature once it becomes available.

## Manual Test Plan
### Test Environment

My laptop.

### Test Cases
- [x] New uses of async state hooks are banned.
- [x] Existing files retain other bans enforced with no-restricted-imports.