### PR TITLE
docs: add Redshift DBeaver connection guide

### DIFF
--- a/docs/pages/connect-your-client/third-party/gui-clients.mdx
+++ b/docs/pages/connect-your-client/third-party/gui-clients.mdx
@@ -363,7 +363,7 @@ Click Connect to connect.
 
 To connect to your Redshift instance, use the authenticated proxy address.
 This is `127.0.0.1:62652` in the example above (see the "Authenticated Proxy"
-section on [Get connection information](./gui-clients.mdx#how-gui-clients-access-teleport-protected-databases)
+section in [Get connection information](./gui-clients.mdx#how-gui-clients-access-teleport-protected-databases)
 for more information).
 
 Use the "Username/password" authentication. Set the username to match the database

--- a/docs/pages/connect-your-client/third-party/gui-clients.mdx
+++ b/docs/pages/connect-your-client/third-party/gui-clients.mdx
@@ -353,6 +353,33 @@ Example:
   
 Click Connect to connect.
 
+## Redshift DBeaver
+
+<Admonition type="note">
+  You can also use the [PostgreSQL DBeaver](./gui-clients.mdx#postgresql-dbeaver) setup
+  to connect to Redshift, but using the native Redshift driver additionally provides
+  support for Redshift-specific datatypes and external schemas.
+</Admonition>
+
+To connect to your Redshift instance, use the authenticated proxy address.
+This is `127.0.0.1:62652` in the example above (see the "Authenticated Proxy"
+section on [Get connection information](./gui-clients.mdx#how-gui-clients-access-teleport-protected-databases)
+for more information).
+
+Use the "Username/password" authentication. Set the username to match the database
+user passed to `--db-user` and leave the password empty:
+
+![DBeaver Redshift Configure
+Server](https://website.goteleport.com/_uploads/dbeaver_redshift_new_connection_1476289fec.png)
+
+Go to **Driver Properties** and set `ssl=false`. This disables encryption on the
+local connection only — the connection to Redshift is encrypted by Teleport.
+
+![DBeaver Redshift Driver Properties](https://website.goteleport.com/_uploads/dbeaver_redshift_new_connection_ssl_b3e0c732ee.png)
+
+Clicking on "Test connection" should return a connection success message. Then,
+click on "Finish" to save the configuration.
+
 ## Redis Insight
 
 <Admonition type="note">


### PR DESCRIPTION
Add guide on how to connect to Redshift DB using DBeaver GUI client.

Preview link: https://taras-docs-gui-redshift-dbeaver.d1v2yqnl3ruxch.amplifyapp.com/docs/connect-your-client/third-party/gui-clients/#redshift-dbeaver