### PR TITLE
[v17] Connect: Improve error message for pre-v17 clusters that may not advertise tools version

### DIFF
--- a/web/packages/teleterm/src/services/appUpdater/autoUpdatesStatus.test.ts
+++ b/web/packages/teleterm/src/services/appUpdater/autoUpdatesStatus.test.ts
@@ -527,8 +527,7 @@ test.each<{
 test('throws when a reachable cluster does not advertise a tools version', async () => {
   await expect(
     resolveAutoUpdatesStatus({
-      cdnBaseUrl,
-      configToolsVersion: '',
+      versionEnvVar: '',
       managingClusterUri: '',
       getClusterVersions: async () => ({
         reachableClusters: [

--- a/web/packages/teleterm/src/services/appUpdater/autoUpdatesStatus.test.ts
+++ b/web/packages/teleterm/src/services/appUpdater/autoUpdatesStatus.test.ts
@@ -523,6 +523,36 @@ test.each<{
   expect(result).toEqual(expected);
 });
 
+// Pre-v17 clusters may return empty toolsVersion.
+test('throws when a reachable cluster does not advertise a tools version', async () => {
+  await expect(
+    resolveAutoUpdatesStatus({
+      cdnBaseUrl,
+      configToolsVersion: '',
+      managingClusterUri: '',
+      getClusterVersions: async () => ({
+        reachableClusters: [
+          {
+            clusterUri: '/clusters/cluster-a',
+            toolsAutoUpdate: true,
+            toolsVersion: '16.0.0',
+            minToolsVersion: '15.0.0-aa',
+          },
+          {
+            clusterUri: '/clusters/old-cluster',
+            toolsAutoUpdate: false,
+            toolsVersion: '',
+            minToolsVersion: '15.0.0-aa',
+          },
+        ],
+        unreachableClusters: [],
+      }),
+    })
+  ).rejects.toThrow(
+    `Cluster old-cluster advertised an empty tools version and is not supported by this version of Teleport Connect.`
+  );
+});
+
 test('should not auto download when there is unreachable cluster in highest-compatible resolution', () => {
   const result = shouldAutoDownload({
     enabled: true,

--- a/web/packages/teleterm/src/services/appUpdater/autoUpdatesStatus.test.ts
+++ b/web/packages/teleterm/src/services/appUpdater/autoUpdatesStatus.test.ts
@@ -549,7 +549,7 @@ test('throws when a reachable cluster does not advertise a tools version', async
       }),
     })
   ).rejects.toThrow(
-    `Cluster old-cluster advertised an empty tools version and is not supported by this version of Teleport Connect.`
+    `Cluster old-cluster is not supported by this version of Teleport Connect.`
   );
 });
 

--- a/web/packages/teleterm/src/services/appUpdater/autoUpdatesStatus.ts
+++ b/web/packages/teleterm/src/services/appUpdater/autoUpdatesStatus.ts
@@ -190,7 +190,7 @@ function makeClusters(versions: ClusterVersionInfo[]): Cluster[] {
   for (const v of versions) {
     if (!v.toolsVersion) {
       throw new Error(
-        `Cluster ${routing.parseClusterName(v.clusterUri)} advertised an empty tools version and is not supported by this version of Teleport Connect.`
+        `Cluster ${routing.parseClusterName(v.clusterUri)} is not supported by this version of Teleport Connect.`
       );
     }
   }

--- a/web/packages/teleterm/src/services/appUpdater/autoUpdatesStatus.ts
+++ b/web/packages/teleterm/src/services/appUpdater/autoUpdatesStatus.ts
@@ -24,7 +24,7 @@ import type {
 import { compare, major } from 'shared/utils/semVer';
 
 import Logger from 'teleterm/logger';
-import { RootClusterUri } from 'teleterm/ui/uri';
+import { RootClusterUri, routing } from 'teleterm/ui/uri';
 
 const logger = new Logger('resolveAutoUpdatesStatus');
 
@@ -185,6 +185,16 @@ export function shouldAutoDownload(updatesStatus: AutoUpdatesEnabled): boolean {
 
 /** Assigns each cluster a compatibility with client tools from other clusters. */
 function makeClusters(versions: ClusterVersionInfo[]): Cluster[] {
+  // Pre-v17 clusters may not advertise a tools version https://github.com/gravitational/teleport/pull/47872.
+  // Fail here instead of letting semver throw a cryptic 'Invalid Version: '.
+  for (const v of versions) {
+    if (!v.toolsVersion) {
+      throw new Error(
+        `Cluster ${routing.parseClusterName(v.clusterUri)} advertised an empty tools version and is not supported by this version of Teleport Connect.`
+      );
+    }
+  }
+
   return versions.map(version => {
     const majorToolsVersion = major(version.toolsVersion);
 


### PR DESCRIPTION
Backport #67256 to branch/v17

## Manual Test Plan
### Test Environment
Locally built app.

### Test Cases
- [x] Tested the change by hardcoding an empty tools version. 