### PR TITLE
[2] Migration to the Opaque API

### DIFF
--- a/lib/auth/issuance/v1/service_test.go
+++ b/lib/auth/issuance/v1/service_test.go
@@ -166,12 +166,12 @@ func TestIssueScopedBotCerts(t *testing.T) {
 	now := srv.Clock().Now()
 
 	t.Run("success", func(t *testing.T) {
-		resp, err := issuanceClient.IssueScopedBotCerts(ctx, &issuancev1pb.IssueScopedBotCertsRequest{
+		resp, err := issuanceClient.IssueScopedBotCerts(ctx, issuancev1pb.IssueScopedBotCertsRequest_builder{
 			SshPublicKey: sshPubKeyBytes,
 			TlsPublicKey: tlsPubKeyPEM,
 			Ttl:          durationpb.New(requestedTTL),
-			Usage:        &issuancev1pb.IssueScopedBotCertsRequest_Identity{},
-		})
+			Identity:     &issuancev1pb.UsageIdentity{},
+		}.Build())
 		require.NoError(t, err)
 		require.NotNil(t, resp.GetCerts())
 		require.NotEmpty(t, resp.GetCerts().GetSsh())
@@ -203,12 +203,12 @@ func TestIssueScopedBotCerts(t *testing.T) {
 	})
 
 	t.Run("excessive TTL rejected", func(t *testing.T) {
-		_, err := issuanceClient.IssueScopedBotCerts(ctx, &issuancev1pb.IssueScopedBotCertsRequest{
+		_, err := issuanceClient.IssueScopedBotCerts(ctx, issuancev1pb.IssueScopedBotCertsRequest_builder{
 			SshPublicKey: sshPubKeyBytes,
 			TlsPublicKey: tlsPubKeyPEM,
 			Ttl:          durationpb.New(defaults.MaxRenewableCertTTL + time.Hour),
-			Usage:        &issuancev1pb.IssueScopedBotCertsRequest_Identity{},
-		})
+			Identity:     &issuancev1pb.UsageIdentity{},
+		}.Build())
 		require.True(t, trace.IsBadParameter(err), "expected bad parameter for excessive TTL, got: %v", err)
 	})
 
@@ -222,11 +222,11 @@ func TestIssueScopedBotCerts(t *testing.T) {
 	})
 
 	t.Run("ssh only", func(t *testing.T) {
-		resp, err := issuanceClient.IssueScopedBotCerts(ctx, &issuancev1pb.IssueScopedBotCertsRequest{
+		resp, err := issuanceClient.IssueScopedBotCerts(ctx, issuancev1pb.IssueScopedBotCertsRequest_builder{
 			SshPublicKey: sshPubKeyBytes,
 			Ttl:          durationpb.New(requestedTTL),
-			Usage:        &issuancev1pb.IssueScopedBotCertsRequest_Identity{},
-		})
+			Identity:     &issuancev1pb.UsageIdentity{},
+		}.Build())
 		require.NoError(t, err)
 		require.NotNil(t, resp.GetCerts())
 		require.NotEmpty(t, resp.GetCerts().GetSsh())
@@ -234,11 +234,11 @@ func TestIssueScopedBotCerts(t *testing.T) {
 	})
 
 	t.Run("tls only", func(t *testing.T) {
-		resp, err := issuanceClient.IssueScopedBotCerts(ctx, &issuancev1pb.IssueScopedBotCertsRequest{
+		resp, err := issuanceClient.IssueScopedBotCerts(ctx, issuancev1pb.IssueScopedBotCertsRequest_builder{
 			TlsPublicKey: tlsPubKeyPEM,
 			Ttl:          durationpb.New(requestedTTL),
-			Usage:        &issuancev1pb.IssueScopedBotCertsRequest_Identity{},
-		})
+			Identity:     &issuancev1pb.UsageIdentity{},
+		}.Build())
 		require.NoError(t, err)
 		require.NotNil(t, resp.GetCerts())
 		require.Empty(t, resp.GetCerts().GetSsh())
@@ -246,32 +246,32 @@ func TestIssueScopedBotCerts(t *testing.T) {
 	})
 
 	t.Run("missing keys rejected", func(t *testing.T) {
-		_, err := issuanceClient.IssueScopedBotCerts(ctx, &issuancev1pb.IssueScopedBotCertsRequest{
-			Ttl:   durationpb.New(requestedTTL),
-			Usage: &issuancev1pb.IssueScopedBotCertsRequest_Identity{},
-		})
+		_, err := issuanceClient.IssueScopedBotCerts(ctx, issuancev1pb.IssueScopedBotCertsRequest_builder{
+			Ttl:      durationpb.New(requestedTTL),
+			Identity: &issuancev1pb.UsageIdentity{},
+		}.Build())
 		require.True(t, trace.IsBadParameter(err), "expected bad parameter, got: %v", err)
 		require.ErrorContains(t, err, "at least one of ssh_public_key or tls_public_key is required")
 	})
 
 	t.Run("zero ttl rejected", func(t *testing.T) {
-		_, err := issuanceClient.IssueScopedBotCerts(ctx, &issuancev1pb.IssueScopedBotCertsRequest{
+		_, err := issuanceClient.IssueScopedBotCerts(ctx, issuancev1pb.IssueScopedBotCertsRequest_builder{
 			SshPublicKey: sshPubKeyBytes,
 			TlsPublicKey: tlsPubKeyPEM,
 			Ttl:          durationpb.New(0),
-			Usage:        &issuancev1pb.IssueScopedBotCertsRequest_Identity{},
-		})
+			Identity:     &issuancev1pb.UsageIdentity{},
+		}.Build())
 		require.True(t, trace.IsBadParameter(err), "expected bad parameter for zero TTL, got: %v", err)
 		require.ErrorContains(t, err, "must be greater than zero")
 	})
 
 	t.Run("negative ttl rejected", func(t *testing.T) {
-		_, err := issuanceClient.IssueScopedBotCerts(ctx, &issuancev1pb.IssueScopedBotCertsRequest{
+		_, err := issuanceClient.IssueScopedBotCerts(ctx, issuancev1pb.IssueScopedBotCertsRequest_builder{
 			SshPublicKey: sshPubKeyBytes,
 			TlsPublicKey: tlsPubKeyPEM,
 			Ttl:          durationpb.New(-time.Hour),
-			Usage:        &issuancev1pb.IssueScopedBotCertsRequest_Identity{},
-		})
+			Identity:     &issuancev1pb.UsageIdentity{},
+		}.Build())
 		require.True(t, trace.IsBadParameter(err), "expected bad parameter for negative TTL, got: %v", err)
 		require.ErrorContains(t, err, "must be greater than zero")
 	})
@@ -294,12 +294,12 @@ func TestIssueScopedBotCerts_FeatureFlagRequired(t *testing.T) {
 	require.NoError(t, err)
 
 	issuanceClient := issuancev1pb.NewIssuanceServiceClient(adminClient.GetConnection())
-	_, err = issuanceClient.IssueScopedBotCerts(ctx, &issuancev1pb.IssueScopedBotCertsRequest{
+	_, err = issuanceClient.IssueScopedBotCerts(ctx, issuancev1pb.IssueScopedBotCertsRequest_builder{
 		SshPublicKey: ssh.MarshalAuthorizedKey(sshPubKey),
 		TlsPublicKey: tlsPubKeyPEM,
 		Ttl:          durationpb.New(time.Hour),
-		Usage:        &issuancev1pb.IssueScopedBotCertsRequest_Identity{},
-	})
+		Identity:     &issuancev1pb.UsageIdentity{},
+	}.Build())
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "scoping features are not enabled")
 }
@@ -376,12 +376,12 @@ func TestIssueScopedBotCerts_Unauthorized(t *testing.T) {
 	require.NoError(t, err)
 	waitForSRACache(t, srv, sraResp)
 
-	req := &issuancev1pb.IssueScopedBotCertsRequest{
+	req := issuancev1pb.IssueScopedBotCertsRequest_builder{
 		SshPublicKey: sshPubKeyBytes,
 		TlsPublicKey: tlsPubKeyPEM,
 		Ttl:          durationpb.New(time.Hour),
-		Usage:        &issuancev1pb.IssueScopedBotCertsRequest_Identity{},
-	}
+		Identity:     &issuancev1pb.UsageIdentity{},
+	}.Build()
 
 	t.Run("non-bot user without scope", func(t *testing.T) {
 		_, err := adminClient.IssuanceClient().IssueScopedBotCerts(ctx, req)

--- a/lib/auth/recordingmetadata/recordingmetadatav1/service.go
+++ b/lib/auth/recordingmetadata/recordingmetadatav1/service.go
@@ -155,11 +155,9 @@ func (r *Service) GetMetadata(req *pb.GetMetadataRequest, stream grpc.ServerStre
 		// Try to decode as metadata
 		metadata := &pb.SessionRecordingMetadata{}
 		if err := proto.Unmarshal(msgBytes, metadata); err == nil {
-			metadataChunk := &pb.GetMetadataResponseChunk{
-				Chunk: &pb.GetMetadataResponseChunk_Metadata{
-					Metadata: metadata,
-				},
-			}
+			metadataChunk := pb.GetMetadataResponseChunk_builder{
+				Metadata: proto.ValueOrDefault(metadata),
+			}.Build()
 
 			if err := stream.Send(metadataChunk); err != nil {
 				if !errors.Is(err, io.EOF) {
@@ -175,11 +173,9 @@ func (r *Service) GetMetadata(req *pb.GetMetadataRequest, stream grpc.ServerStre
 		// Try to decode as thumbnail
 		thumbnail := &pb.SessionRecordingThumbnail{}
 		if err := proto.Unmarshal(msgBytes, thumbnail); err == nil {
-			frameChunk := &pb.GetMetadataResponseChunk{
-				Chunk: &pb.GetMetadataResponseChunk_Frame{
-					Frame: thumbnail,
-				},
-			}
+			frameChunk := pb.GetMetadataResponseChunk_builder{
+				Frame: proto.ValueOrDefault(thumbnail),
+			}.Build()
 
 			if err := stream.Send(frameChunk); err != nil {
 				if !errors.Is(err, io.EOF) {

--- a/lib/cache/inventory/inventory_cache.go
+++ b/lib/cache/inventory/inventory_cache.go
@@ -1220,15 +1220,11 @@ func (ic *InventoryCache) getKeyForIndex(ui *inventoryInstance, index inventoryI
 // unifiedInstanceToProto converts a unified instance to a proto UnifiedInstanceItem.
 func (ic *InventoryCache) unifiedInstanceToProto(ui *inventoryInstance) *inventoryv1.UnifiedInstanceItem {
 	if ui.isInstance() {
-		return &inventoryv1.UnifiedInstanceItem{
-			Item: &inventoryv1.UnifiedInstanceItem_Instance{
-				Instance: ui.instance,
-			},
-		}
+		return inventoryv1.UnifiedInstanceItem_builder{
+			Instance: ui.instance,
+		}.Build()
 	}
-	return &inventoryv1.UnifiedInstanceItem{
-		Item: &inventoryv1.UnifiedInstanceItem_BotInstance{
-			BotInstance: ui.bot,
-		},
-	}
+	return inventoryv1.UnifiedInstanceItem_builder{
+		BotInstance: proto.ValueOrDefault(ui.bot),
+	}.Build()
 }

--- a/lib/decision/service.go
+++ b/lib/decision/service.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/gravitational/trace"
 	"golang.org/x/crypto/ssh"
+	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/durationpb"
 
 	"github.com/gravitational/teleport"
@@ -251,11 +252,9 @@ func (s *Service) EvaluateSSHAccess(ctx context.Context, req *decisionpb.Evaluat
 		}.Build()))
 	}
 
-	return &decisionpb.EvaluateSSHAccessResponse{
-		Decision: &decisionpb.EvaluateSSHAccessResponse_Permit{
-			Permit: permit,
-		},
-	}, nil
+	return decisionpb.EvaluateSSHAccessResponse_builder{
+		Permit: proto.ValueOrDefault(permit),
+	}.Build(), nil
 }
 
 func (s *Service) getLocalClusterName(ctx context.Context) (string, error) {

--- a/lib/devicetrust/assert/assert.go
+++ b/lib/devicetrust/assert/assert.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/gravitational/trace"
 	"google.golang.org/grpc"
+	"google.golang.org/protobuf/proto"
 
 	devicepb "github.com/gravitational/teleport/api/gen/proto/go/teleport/devicetrust/v1"
 	"github.com/gravitational/teleport/lib/devicetrust/authn"
@@ -132,17 +133,13 @@ func (s *authnStreamAdapter) Recv() (*devicepb.AuthenticateDeviceResponse, error
 
 	switch resp.WhichPayload() {
 	case devicepb.AssertDeviceResponse_Challenge_case:
-		return &devicepb.AuthenticateDeviceResponse{
-			Payload: &devicepb.AuthenticateDeviceResponse_Challenge{
-				Challenge: resp.GetChallenge(),
-			},
-		}, nil
+		return devicepb.AuthenticateDeviceResponse_builder{
+			Challenge: proto.ValueOrDefault(resp.GetChallenge()),
+		}.Build(), nil
 	case devicepb.AssertDeviceResponse_TpmChallenge_case:
-		return &devicepb.AuthenticateDeviceResponse{
-			Payload: &devicepb.AuthenticateDeviceResponse_TpmChallenge{
-				TpmChallenge: resp.GetTpmChallenge(),
-			},
-		}, nil
+		return devicepb.AuthenticateDeviceResponse_builder{
+			TpmChallenge: proto.ValueOrDefault(resp.GetTpmChallenge()),
+		}.Build(), nil
 	case devicepb.AssertDeviceResponse_DeviceAsserted_case:
 		// Pass an empty UserCertificates to signify success.
 		return devicepb.AuthenticateDeviceResponse_builder{
@@ -167,13 +164,9 @@ func (s *authnStreamAdapter) Send(authnReq *devicepb.AuthenticateDeviceRequest) 
 			DeviceData:   init.GetDeviceData(),
 		}.Build())
 	case devicepb.AuthenticateDeviceRequest_ChallengeResponse_case:
-		req.Payload = &devicepb.AssertDeviceRequest_ChallengeResponse{
-			ChallengeResponse: authnReq.GetChallengeResponse(),
-		}
+		req.SetChallengeResponse(proto.ValueOrDefault(authnReq.GetChallengeResponse()))
 	case devicepb.AuthenticateDeviceRequest_TpmChallengeResponse_case:
-		req.Payload = &devicepb.AssertDeviceRequest_TpmChallengeResponse{
-			TpmChallengeResponse: authnReq.GetTpmChallengeResponse(),
-		}
+		req.SetTpmChallengeResponse(proto.ValueOrDefault(authnReq.GetTpmChallengeResponse()))
 	default:
 		return trace.BadParameter("unexpected authenticate request payload: %T", authnReq.Payload)
 	}

--- a/lib/devicetrust/authn/authn.go
+++ b/lib/devicetrust/authn/authn.go
@@ -25,6 +25,7 @@ import (
 	"io"
 
 	"github.com/gravitational/trace"
+	"google.golang.org/protobuf/proto"
 
 	devicepb "github.com/gravitational/teleport/api/gen/proto/go/teleport/devicetrust/v1"
 	"github.com/gravitational/teleport/lib/devicetrust"
@@ -157,11 +158,9 @@ func (c *Ceremony) run(
 	// 1. Init.
 	init.SetCredentialId(cred.GetId())
 	init.SetDeviceData(cd)
-	if err := stream.Send(&devicepb.AuthenticateDeviceRequest{
-		Payload: &devicepb.AuthenticateDeviceRequest_Init{
-			Init: init,
-		},
-	}); err != nil && !errors.Is(err, io.EOF) {
+	if err := stream.Send(devicepb.AuthenticateDeviceRequest_builder{
+		Init: proto.ValueOrDefault(init),
+	}.Build()); err != nil && !errors.Is(err, io.EOF) {
 		// [io.EOF] indicates that the server has closed the stream.
 		// The client should handle the underlying error on the subsequent Recv call.
 		// All other errors are client-side errors and should be returned.
@@ -249,11 +248,9 @@ func (c *Ceremony) authenticateDeviceTPM(
 			return trace.Wrap(err)
 		}
 	}
-	err = stream.Send(&devicepb.AuthenticateDeviceRequest{
-		Payload: &devicepb.AuthenticateDeviceRequest_TpmChallengeResponse{
-			TpmChallengeResponse: challengeResponse,
-		},
-	})
+	err = stream.Send(devicepb.AuthenticateDeviceRequest_builder{
+		TpmChallengeResponse: proto.ValueOrDefault(challengeResponse),
+	}.Build())
 	if err != nil && !errors.Is(err, io.EOF) {
 		// [io.EOF] indicates that the server has closed the stream.
 		// The client should handle the underlying error on the subsequent Recv call.

--- a/lib/devicetrust/authn/authn_test.go
+++ b/lib/devicetrust/authn/authn_test.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
 
 	devicepb "github.com/gravitational/teleport/api/gen/proto/go/teleport/devicetrust/v1"
 	"github.com/gravitational/teleport/lib/devicetrust/authn"
@@ -208,11 +209,9 @@ func enrollDevice(ctx context.Context, devices devicepb.DeviceTrustServiceClient
 		return nil, fmt.Errorf("enroll device init: %w", err)
 	}
 	enrollDeviceInit.SetToken(testenv.FakeEnrollmentToken)
-	if err := stream.Send(&devicepb.EnrollDeviceRequest{
-		Payload: &devicepb.EnrollDeviceRequest_Init{
-			Init: enrollDeviceInit,
-		},
-	}); err != nil {
+	if err := stream.Send(devicepb.EnrollDeviceRequest_builder{
+		Init: proto.ValueOrDefault(enrollDeviceInit),
+	}.Build()); err != nil {
 		return nil, err
 	}
 
@@ -239,11 +238,9 @@ func enrollDevice(ctx context.Context, devices devicepb.DeviceTrustServiceClient
 		if err != nil {
 			return nil, err
 		}
-		if err := stream.Send(&devicepb.EnrollDeviceRequest{
-			Payload: &devicepb.EnrollDeviceRequest_TpmChallengeResponse{
-				TpmChallengeResponse: solution,
-			},
-		}); err != nil {
+		if err := stream.Send(devicepb.EnrollDeviceRequest_builder{
+			TpmChallengeResponse: proto.ValueOrDefault(solution),
+		}.Build()); err != nil {
 			return nil, err
 		}
 	default:

--- a/lib/devicetrust/enroll/enroll.go
+++ b/lib/devicetrust/enroll/enroll.go
@@ -25,6 +25,7 @@ import (
 	"log/slog"
 
 	"github.com/gravitational/trace"
+	"google.golang.org/protobuf/proto"
 
 	devicepb "github.com/gravitational/teleport/api/gen/proto/go/teleport/devicetrust/v1"
 	"github.com/gravitational/teleport/api/trail"
@@ -194,11 +195,9 @@ func (c *Ceremony) run(ctx context.Context, devicesClient devicepb.DeviceTrustSe
 	defer stream.CloseSend()
 
 	// 1. Init.
-	if err := stream.Send(&devicepb.EnrollDeviceRequest{
-		Payload: &devicepb.EnrollDeviceRequest_Init{
-			Init: init,
-		},
-	}); err != nil && !errors.Is(err, io.EOF) {
+	if err := stream.Send(devicepb.EnrollDeviceRequest_builder{
+		Init: proto.ValueOrDefault(init),
+	}.Build()); err != nil && !errors.Is(err, io.EOF) {
 		// [io.EOF] indicates that the server has closed the stream.
 		// The client should handle the underlying error on the subsequent Recv call.
 		// All other errors are client-side errors and should be returned.
@@ -277,11 +276,9 @@ func (c *Ceremony) enrollDeviceTPM(ctx context.Context, stream devicepb.DeviceTr
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	err = stream.Send(&devicepb.EnrollDeviceRequest{
-		Payload: &devicepb.EnrollDeviceRequest_TpmChallengeResponse{
-			TpmChallengeResponse: challengeResponse,
-		},
-	})
+	err = stream.Send(devicepb.EnrollDeviceRequest_builder{
+		TpmChallengeResponse: proto.ValueOrDefault(challengeResponse),
+	}.Build())
 	// [io.EOF] indicates that the server has closed the stream.
 	// The client should handle the underlying error on the subsequent Recv call.
 	// All other errors are client-side errors and should be returned.

--- a/lib/devicetrust/testenv/fake_device_service.go
+++ b/lib/devicetrust/testenv/fake_device_service.go
@@ -529,9 +529,9 @@ func (s *FakeDeviceService) AssertDevice(ctx context.Context, stream assertserve
 	}
 
 	// Success.
-	return dev.pb, trace.Wrap(stream.Send(&devicepb.AssertDeviceResponse{
-		Payload: &devicepb.AssertDeviceResponse_DeviceAsserted{},
-	}))
+	return dev.pb, trace.Wrap(stream.Send(devicepb.AssertDeviceResponse_builder{
+		DeviceAsserted: &devicepb.DeviceAsserted{},
+	}.Build()))
 }
 
 // AuthenticateDevice implements a fake, server-side device authentication
@@ -599,11 +599,9 @@ func (s *FakeDeviceService) AuthenticateDevice(stream devicepb.DeviceTrustServic
 	}
 
 	// Web authentication.
-	return trace.Wrap(stream.Send(&devicepb.AuthenticateDeviceResponse{
-		Payload: &devicepb.AuthenticateDeviceResponse_ConfirmationToken{
-			ConfirmationToken: confirmToken,
-		},
-	}))
+	return trace.Wrap(stream.Send(devicepb.AuthenticateDeviceResponse_builder{
+		ConfirmationToken: proto.ValueOrDefault(confirmToken),
+	}.Build()))
 }
 
 func (s *FakeDeviceService) spendDeviceWebToken(webToken *devicepb.DeviceWebToken, dev *storedDevice) (*devicepb.DeviceConfirmationToken, error) {
@@ -836,13 +834,9 @@ func (s assertStreamAdapter) Recv() (*devicepb.AuthenticateDeviceRequest, error)
 	authnReq := &devicepb.AuthenticateDeviceRequest{}
 	switch req.WhichPayload() {
 	case devicepb.AssertDeviceRequest_ChallengeResponse_case:
-		authnReq.Payload = &devicepb.AuthenticateDeviceRequest_ChallengeResponse{
-			ChallengeResponse: req.GetChallengeResponse(),
-		}
+		authnReq.SetChallengeResponse(proto.ValueOrDefault(req.GetChallengeResponse()))
 	case devicepb.AssertDeviceRequest_TpmChallengeResponse_case:
-		authnReq.Payload = &devicepb.AuthenticateDeviceRequest_TpmChallengeResponse{
-			TpmChallengeResponse: req.GetTpmChallengeResponse(),
-		}
+		authnReq.SetTpmChallengeResponse(proto.ValueOrDefault(req.GetTpmChallengeResponse()))
 	default:
 		return nil, trace.BadParameter("unexpected assert request payload: %T", req.Payload)
 	}
@@ -859,13 +853,9 @@ func (s assertStreamAdapter) Send(authnResp *devicepb.AuthenticateDeviceResponse
 	resp := &devicepb.AssertDeviceResponse{}
 	switch authnResp.WhichPayload() {
 	case devicepb.AuthenticateDeviceResponse_Challenge_case:
-		resp.Payload = &devicepb.AssertDeviceResponse_Challenge{
-			Challenge: authnResp.GetChallenge(),
-		}
+		resp.SetChallenge(proto.ValueOrDefault(authnResp.GetChallenge()))
 	case devicepb.AuthenticateDeviceResponse_TpmChallenge_case:
-		resp.Payload = &devicepb.AssertDeviceResponse_TpmChallenge{
-			TpmChallenge: authnResp.GetTpmChallenge(),
-		}
+		resp.SetTpmChallenge(proto.ValueOrDefault(authnResp.GetTpmChallenge()))
 	default:
 		return trace.BadParameter("unexpected authentication response payload: %T", authnResp.Payload)
 	}

--- a/lib/devicetrust/testenv/fake_tpm_device.go
+++ b/lib/devicetrust/testenv/fake_tpm_device.go
@@ -22,6 +22,7 @@ import (
 	"errors"
 
 	"github.com/google/uuid"
+	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	devicepb "github.com/gravitational/teleport/api/gen/proto/go/teleport/devicetrust/v1"
@@ -76,12 +77,10 @@ func (f *FakeTPMDevice) EnrollDeviceInit() (*devicepb.EnrollDeviceInit, error) {
 	return devicepb.EnrollDeviceInit_builder{
 		CredentialId: f.CredentialID,
 		DeviceData:   cd,
-		Tpm: &devicepb.TPMEnrollPayload{
-			Ek: &devicepb.TPMEnrollPayload_EkKey{
-				EkKey: validEKKey,
-			},
+		Tpm: devicepb.TPMEnrollPayload_builder{
+			EkKey:                 proto.ValueOrDefaultBytes(validEKKey),
 			AttestationParameters: validAttestationParameters,
-		},
+		}.Build(),
 	}.Build(), nil
 }
 

--- a/lib/join/joinv1/messages.go
+++ b/lib/join/joinv1/messages.go
@@ -18,6 +18,7 @@ package joinv1
 
 import (
 	"github.com/gravitational/trace"
+	"google.golang.org/protobuf/proto"
 	timestamppb "google.golang.org/protobuf/types/known/timestamppb"
 
 	joinv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/join/v1"
@@ -60,91 +61,73 @@ func requestToMessage(req *joinv1.JoinRequest) (messages.Request, error) {
 func requestFromMessage(msg messages.Request) (*joinv1.JoinRequest, error) {
 	switch typedMsg := msg.(type) {
 	case *messages.ClientInit:
-		return &joinv1.JoinRequest{
-			Payload: &joinv1.JoinRequest_ClientInit{
-				ClientInit: clientInitFromMessage(typedMsg),
-			},
-		}, nil
+		return joinv1.JoinRequest_builder{
+			ClientInit: proto.ValueOrDefault(clientInitFromMessage(typedMsg)),
+		}.Build(), nil
 	case *messages.TokenInit:
 		tokenInit, err := tokenInitFromMessage(typedMsg)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
-		return &joinv1.JoinRequest{
-			Payload: &joinv1.JoinRequest_TokenInit{
-				TokenInit: tokenInit,
-			},
-		}, nil
+		return joinv1.JoinRequest_builder{
+			TokenInit: proto.ValueOrDefault(tokenInit),
+		}.Build(), nil
 	case *messages.BoundKeypairInit:
 		boundKeypairInit, err := boundKeypairInitFromMessage(typedMsg)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
-		return &joinv1.JoinRequest{
-			Payload: &joinv1.JoinRequest_BoundKeypairInit{
-				BoundKeypairInit: boundKeypairInit,
-			},
-		}, nil
+		return joinv1.JoinRequest_builder{
+			BoundKeypairInit: proto.ValueOrDefault(boundKeypairInit),
+		}.Build(), nil
 	case *messages.IAMInit:
 		iamInit, err := iamInitFromMessage(typedMsg)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
-		return &joinv1.JoinRequest{
-			Payload: &joinv1.JoinRequest_IamInit{
-				IamInit: iamInit,
-			},
-		}, nil
+		return joinv1.JoinRequest_builder{
+			IamInit: proto.ValueOrDefault(iamInit),
+		}.Build(), nil
 	case *messages.EC2Init:
 		ec2Init, err := ec2InitFromMessage(typedMsg)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
-		return &joinv1.JoinRequest{
-			Payload: &joinv1.JoinRequest_Ec2Init{
-				Ec2Init: ec2Init,
-			},
-		}, nil
+		return joinv1.JoinRequest_builder{
+			Ec2Init: proto.ValueOrDefault(ec2Init),
+		}.Build(), nil
 	case *messages.OIDCInit:
 		oidcInit, err := oidcInitFromMessage(typedMsg)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
-		return &joinv1.JoinRequest{
-			Payload: &joinv1.JoinRequest_OidcInit{
-				OidcInit: oidcInit,
-			},
-		}, nil
+		return joinv1.JoinRequest_builder{
+			OidcInit: proto.ValueOrDefault(oidcInit),
+		}.Build(), nil
 	case *messages.OracleInit:
 		oracleInit, err := oracleInitFromMessage(typedMsg)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
-		return &joinv1.JoinRequest{
-			Payload: &joinv1.JoinRequest_OracleInit{
-				OracleInit: oracleInit,
-			},
-		}, nil
+		return joinv1.JoinRequest_builder{
+			OracleInit: proto.ValueOrDefault(oracleInit),
+		}.Build(), nil
 	case *messages.TPMInit:
 		tpmInit, err := tpmInitFromMessage(typedMsg)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
-		return &joinv1.JoinRequest{
-			Payload: &joinv1.JoinRequest_TpmInit{
-				TpmInit: tpmInit,
-			},
-		}, nil
+		return joinv1.JoinRequest_builder{
+			TpmInit: proto.ValueOrDefault(tpmInit),
+		}.Build(), nil
 	case *messages.AzureInit:
 		azureInit, err := azureInitFromMessage(typedMsg)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
-		return &joinv1.JoinRequest{
-			Payload: &joinv1.JoinRequest_AzureInit{
-				AzureInit: azureInit,
-			},
-		}, nil
+		return joinv1.JoinRequest_builder{
+			AzureInit: proto.ValueOrDefault(azureInit),
+		}.Build(), nil
 	case *messages.BoundKeypairChallengeSolution,
 		*messages.BoundKeypairRotationResponse,
 		*messages.IAMChallengeSolution,
@@ -155,17 +138,13 @@ func requestFromMessage(msg messages.Request) (*joinv1.JoinRequest, error) {
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
-		return &joinv1.JoinRequest{
-			Payload: &joinv1.JoinRequest_Solution{
-				Solution: solution,
-			},
-		}, nil
+		return joinv1.JoinRequest_builder{
+			Solution: proto.ValueOrDefault(solution),
+		}.Build(), nil
 	case *messages.GivingUp:
-		return &joinv1.JoinRequest{
-			Payload: &joinv1.JoinRequest_GivingUp{
-				GivingUp: givingUpFromMessage(typedMsg),
-			},
-		}, nil
+		return joinv1.JoinRequest_builder{
+			GivingUp: proto.ValueOrDefault(givingUpFromMessage(typedMsg)),
+		}.Build(), nil
 	default:
 		return nil, trace.BadParameter("unrecognized join request message type %T", msg)
 	}
@@ -244,13 +223,9 @@ func clientParamsFromMessage(msg messages.ClientParams) (*joinv1.ClientParams, e
 	req := &joinv1.ClientParams{}
 	switch {
 	case msg.HostParams != nil:
-		req.Payload = &joinv1.ClientParams_HostParams{
-			HostParams: hostParamsFromMessage(msg.HostParams),
-		}
+		req.SetHostParams(proto.ValueOrDefault(hostParamsFromMessage(msg.HostParams)))
 	case msg.BotParams != nil:
-		req.Payload = &joinv1.ClientParams_BotParams{
-			BotParams: botParamsFromMessage(msg.BotParams),
-		}
+		req.SetBotParams(proto.ValueOrDefault(botParamsFromMessage(msg.BotParams)))
 	default:
 		return nil, trace.BadParameter("ClientParams has no payload")
 	}
@@ -332,41 +307,29 @@ func challengeSolutionToMessage(req *joinv1.ChallengeSolution) (messages.Request
 func challengeSolutionFromMessage(msg messages.Request) (*joinv1.ChallengeSolution, error) {
 	switch typedMsg := msg.(type) {
 	case *messages.BoundKeypairChallengeSolution:
-		return &joinv1.ChallengeSolution{
-			Payload: &joinv1.ChallengeSolution_BoundKeypairChallengeSolution{
-				BoundKeypairChallengeSolution: boundKeypairChallengeSolutionFromMessage(typedMsg),
-			},
-		}, nil
+		return joinv1.ChallengeSolution_builder{
+			BoundKeypairChallengeSolution: proto.ValueOrDefault(boundKeypairChallengeSolutionFromMessage(typedMsg)),
+		}.Build(), nil
 	case *messages.BoundKeypairRotationResponse:
-		return &joinv1.ChallengeSolution{
-			Payload: &joinv1.ChallengeSolution_BoundKeypairRotationResponse{
-				BoundKeypairRotationResponse: boundKeypairRotationResponseFromMessage(typedMsg),
-			},
-		}, nil
+		return joinv1.ChallengeSolution_builder{
+			BoundKeypairRotationResponse: proto.ValueOrDefault(boundKeypairRotationResponseFromMessage(typedMsg)),
+		}.Build(), nil
 	case *messages.IAMChallengeSolution:
-		return &joinv1.ChallengeSolution{
-			Payload: &joinv1.ChallengeSolution_IamChallengeSolution{
-				IamChallengeSolution: iamChallengeSolutionFromMessage(typedMsg),
-			},
-		}, nil
+		return joinv1.ChallengeSolution_builder{
+			IamChallengeSolution: proto.ValueOrDefault(iamChallengeSolutionFromMessage(typedMsg)),
+		}.Build(), nil
 	case *messages.OracleChallengeSolution:
-		return &joinv1.ChallengeSolution{
-			Payload: &joinv1.ChallengeSolution_OracleChallengeSolution{
-				OracleChallengeSolution: oracleChallengeSolutionFromMessage(typedMsg),
-			},
-		}, nil
+		return joinv1.ChallengeSolution_builder{
+			OracleChallengeSolution: proto.ValueOrDefault(oracleChallengeSolutionFromMessage(typedMsg)),
+		}.Build(), nil
 	case *messages.TPMSolution:
-		return &joinv1.ChallengeSolution{
-			Payload: &joinv1.ChallengeSolution_TpmSolution{
-				TpmSolution: tpmSolutionFromMessage(typedMsg),
-			},
-		}, nil
+		return joinv1.ChallengeSolution_builder{
+			TpmSolution: proto.ValueOrDefault(tpmSolutionFromMessage(typedMsg)),
+		}.Build(), nil
 	case *messages.AzureChallengeSolution:
-		return &joinv1.ChallengeSolution{
-			Payload: &joinv1.ChallengeSolution_AzureChallengeSolution{
-				AzureChallengeSolution: azureChallengeSolutionFromMessage(typedMsg),
-			},
-		}, nil
+		return joinv1.ChallengeSolution_builder{
+			AzureChallengeSolution: proto.ValueOrDefault(azureChallengeSolutionFromMessage(typedMsg)),
+		}.Build(), nil
 	default:
 		return nil, trace.BadParameter("unrecognized challenge solution message type %T", msg)
 	}
@@ -391,11 +354,9 @@ func responseToMessage(resp *joinv1.JoinResponse) (messages.Response, error) {
 func responseFromMessage(msg messages.Response) (*joinv1.JoinResponse, error) {
 	switch typedMsg := msg.(type) {
 	case *messages.ServerInit:
-		return &joinv1.JoinResponse{
-			Payload: &joinv1.JoinResponse_Init{
-				Init: serverInitFromMessage(typedMsg),
-			},
-		}, nil
+		return joinv1.JoinResponse_builder{
+			Init: proto.ValueOrDefault(serverInitFromMessage(typedMsg)),
+		}.Build(), nil
 	case *messages.BoundKeypairChallenge,
 		*messages.BoundKeypairRotationRequest,
 		*messages.IAMChallenge,
@@ -406,26 +367,20 @@ func responseFromMessage(msg messages.Response) (*joinv1.JoinResponse, error) {
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
-		return &joinv1.JoinResponse{
-			Payload: &joinv1.JoinResponse_Challenge{
-				Challenge: challenge,
-			},
-		}, nil
+		return joinv1.JoinResponse_builder{
+			Challenge: proto.ValueOrDefault(challenge),
+		}.Build(), nil
 	case *messages.HostResult:
 		return joinv1.JoinResponse_builder{
-			Result: &joinv1.Result{
-				Payload: &joinv1.Result_HostResult{
-					HostResult: hostResultFromMessage(typedMsg),
-				},
-			},
+			Result: joinv1.Result_builder{
+				HostResult: proto.ValueOrDefault(hostResultFromMessage(typedMsg)),
+			}.Build(),
 		}.Build(), nil
 	case *messages.BotResult:
 		return joinv1.JoinResponse_builder{
-			Result: &joinv1.Result{
-				Payload: &joinv1.Result_BotResult{
-					BotResult: botResultFromMessage(typedMsg),
-				},
-			},
+			Result: joinv1.Result_builder{
+				BotResult: proto.ValueOrDefault(botResultFromMessage(typedMsg)),
+			}.Build(),
 		}.Build(), nil
 	default:
 		return nil, trace.BadParameter("unrecognized join response message type %T", msg)
@@ -472,41 +427,29 @@ func challengeToMessage(resp *joinv1.Challenge) (messages.Response, error) {
 func challengeFromMessage(resp messages.Response) (*joinv1.Challenge, error) {
 	switch msg := resp.(type) {
 	case *messages.BoundKeypairChallenge:
-		return &joinv1.Challenge{
-			Payload: &joinv1.Challenge_BoundKeypairChallenge{
-				BoundKeypairChallenge: boundKeypairChallengeFromMessage(msg),
-			},
-		}, nil
+		return joinv1.Challenge_builder{
+			BoundKeypairChallenge: proto.ValueOrDefault(boundKeypairChallengeFromMessage(msg)),
+		}.Build(), nil
 	case *messages.BoundKeypairRotationRequest:
-		return &joinv1.Challenge{
-			Payload: &joinv1.Challenge_BoundKeypairRotationRequest{
-				BoundKeypairRotationRequest: boundKeypairRotationRequestFromMessage(msg),
-			},
-		}, nil
+		return joinv1.Challenge_builder{
+			BoundKeypairRotationRequest: proto.ValueOrDefault(boundKeypairRotationRequestFromMessage(msg)),
+		}.Build(), nil
 	case *messages.IAMChallenge:
-		return &joinv1.Challenge{
-			Payload: &joinv1.Challenge_IamChallenge{
-				IamChallenge: iamChallengeFromMessage(msg),
-			},
-		}, nil
+		return joinv1.Challenge_builder{
+			IamChallenge: proto.ValueOrDefault(iamChallengeFromMessage(msg)),
+		}.Build(), nil
 	case *messages.OracleChallenge:
-		return &joinv1.Challenge{
-			Payload: &joinv1.Challenge_OracleChallenge{
-				OracleChallenge: oracleChallengeFromMessage(msg),
-			},
-		}, nil
+		return joinv1.Challenge_builder{
+			OracleChallenge: proto.ValueOrDefault(oracleChallengeFromMessage(msg)),
+		}.Build(), nil
 	case *messages.TPMEncryptedCredential:
-		return &joinv1.Challenge{
-			Payload: &joinv1.Challenge_TpmEncryptedCredential{
-				TpmEncryptedCredential: tpmEncryptedCredentialFromMessage(msg),
-			},
-		}, nil
+		return joinv1.Challenge_builder{
+			TpmEncryptedCredential: proto.ValueOrDefault(tpmEncryptedCredentialFromMessage(msg)),
+		}.Build(), nil
 	case *messages.AzureChallenge:
-		return &joinv1.Challenge{
-			Payload: &joinv1.Challenge_AzureChallenge{
-				AzureChallenge: azureChallengeFromMessage(msg),
-			},
-		}, nil
+		return joinv1.Challenge_builder{
+			AzureChallenge: proto.ValueOrDefault(azureChallengeFromMessage(msg)),
+		}.Build(), nil
 	default:
 		return nil, trace.BadParameter("unrecognized challenge message type %T", msg)
 	}

--- a/lib/join/joinv1/messages_test.go
+++ b/lib/join/joinv1/messages_test.go
@@ -42,65 +42,65 @@ func TestRequestToMessage(t *testing.T) {
 		},
 		{
 			desc: "empty ClientInit",
-			req: &joinv1.JoinRequest{
-				Payload: &joinv1.JoinRequest_ClientInit{},
-			},
+			req: joinv1.JoinRequest_builder{
+				ClientInit: &joinv1.ClientInit{},
+			}.Build(),
 		},
 		{
 			desc: "empty TokenInit",
-			req: &joinv1.JoinRequest{
-				Payload: &joinv1.JoinRequest_TokenInit{},
-			},
+			req: joinv1.JoinRequest_builder{
+				TokenInit: &joinv1.TokenInit{},
+			}.Build(),
 		},
 		{
 			desc: "empty BoundKeypairInit",
-			req: &joinv1.JoinRequest{
-				Payload: &joinv1.JoinRequest_BoundKeypairInit{},
-			},
+			req: joinv1.JoinRequest_builder{
+				BoundKeypairInit: &joinv1.BoundKeypairInit{},
+			}.Build(),
 		},
 		{
 			desc: "empty IAMInit",
-			req: &joinv1.JoinRequest{
-				Payload: &joinv1.JoinRequest_IamInit{},
-			},
+			req: joinv1.JoinRequest_builder{
+				IamInit: &joinv1.IAMInit{},
+			}.Build(),
 		},
 		{
 			desc: "empty EC2Init",
-			req: &joinv1.JoinRequest{
-				Payload: &joinv1.JoinRequest_Ec2Init{},
-			},
+			req: joinv1.JoinRequest_builder{
+				Ec2Init: &joinv1.EC2Init{},
+			}.Build(),
 		},
 		{
 			desc: "empty OIDCInit",
-			req: &joinv1.JoinRequest{
-				Payload: &joinv1.JoinRequest_OidcInit{},
-			},
+			req: joinv1.JoinRequest_builder{
+				OidcInit: &joinv1.OIDCInit{},
+			}.Build(),
 		},
 		{
 			desc: "empty OracleInit",
-			req: &joinv1.JoinRequest{
-				Payload: &joinv1.JoinRequest_OracleInit{},
-			},
+			req: joinv1.JoinRequest_builder{
+				OracleInit: &joinv1.OracleInit{},
+			}.Build(),
 		},
 		{
 			desc: "empty TpmInit",
-			req: &joinv1.JoinRequest{
-				Payload: &joinv1.JoinRequest_TpmInit{},
-			},
+			req: joinv1.JoinRequest_builder{
+				TpmInit: &joinv1.TPMInit{},
+			}.Build(),
 		},
 		{
 			desc: "empty AzureInit",
-			req: &joinv1.JoinRequest{
-				Payload: &joinv1.JoinRequest_AzureInit{},
-			},
+			req: joinv1.JoinRequest_builder{
+				AzureInit: &joinv1.AzureInit{},
+			}.Build(),
 		},
 		{
 			desc: "empty HostParams",
 			req: joinv1.JoinRequest_builder{
 				TokenInit: joinv1.TokenInit_builder{
-					ClientParams: &joinv1.ClientParams{
-						Payload: &joinv1.ClientParams_HostParams{},
-					},
+					ClientParams: joinv1.ClientParams_builder{
+						HostParams: &joinv1.HostParams{},
+					}.Build(),
 				}.Build(),
 			}.Build(),
 		},
@@ -108,71 +108,71 @@ func TestRequestToMessage(t *testing.T) {
 			desc: "empty BotParams",
 			req: joinv1.JoinRequest_builder{
 				TokenInit: joinv1.TokenInit_builder{
-					ClientParams: &joinv1.ClientParams{
-						Payload: &joinv1.ClientParams_BotParams{},
-					},
+					ClientParams: joinv1.ClientParams_builder{
+						BotParams: &joinv1.BotParams{},
+					}.Build(),
 				}.Build(),
 			}.Build(),
 		},
 		{
 			desc: "empty Solution",
-			req: &joinv1.JoinRequest{
-				Payload: &joinv1.JoinRequest_Solution{},
-			},
+			req: joinv1.JoinRequest_builder{
+				Solution: &joinv1.ChallengeSolution{},
+			}.Build(),
 		},
 		{
 			desc: "empty BoundKeypairChallengeSolution",
 			req: joinv1.JoinRequest_builder{
-				Solution: &joinv1.ChallengeSolution{
-					Payload: &joinv1.ChallengeSolution_BoundKeypairChallengeSolution{},
-				},
+				Solution: joinv1.ChallengeSolution_builder{
+					BoundKeypairChallengeSolution: &joinv1.BoundKeypairChallengeSolution{},
+				}.Build(),
 			}.Build(),
 		},
 		{
 			desc: "empty BoundKeypairRotationResponse",
 			req: joinv1.JoinRequest_builder{
-				Solution: &joinv1.ChallengeSolution{
-					Payload: &joinv1.ChallengeSolution_BoundKeypairRotationResponse{},
-				},
+				Solution: joinv1.ChallengeSolution_builder{
+					BoundKeypairRotationResponse: &joinv1.BoundKeypairRotationResponse{},
+				}.Build(),
 			}.Build(),
 		},
 		{
 			desc: "empty IamChallengeSolution",
 			req: joinv1.JoinRequest_builder{
-				Solution: &joinv1.ChallengeSolution{
-					Payload: &joinv1.ChallengeSolution_IamChallengeSolution{},
-				},
+				Solution: joinv1.ChallengeSolution_builder{
+					IamChallengeSolution: &joinv1.IAMChallengeSolution{},
+				}.Build(),
 			}.Build(),
 		},
 		{
 			desc: "empty OracleChallengeSolution",
 			req: joinv1.JoinRequest_builder{
-				Solution: &joinv1.ChallengeSolution{
-					Payload: &joinv1.ChallengeSolution_OracleChallengeSolution{},
-				},
+				Solution: joinv1.ChallengeSolution_builder{
+					OracleChallengeSolution: &joinv1.OracleChallengeSolution{},
+				}.Build(),
 			}.Build(),
 		},
 		{
 			desc: "empty TpmSolution",
 			req: joinv1.JoinRequest_builder{
-				Solution: &joinv1.ChallengeSolution{
-					Payload: &joinv1.ChallengeSolution_TpmSolution{},
-				},
+				Solution: joinv1.ChallengeSolution_builder{
+					TpmSolution: &joinv1.TPMSolution{},
+				}.Build(),
 			}.Build(),
 		},
 		{
 			desc: "empty AzureSolution",
 			req: joinv1.JoinRequest_builder{
-				Solution: &joinv1.ChallengeSolution{
-					Payload: &joinv1.ChallengeSolution_AzureChallengeSolution{},
-				},
+				Solution: joinv1.ChallengeSolution_builder{
+					AzureChallengeSolution: &joinv1.AzureChallengeSolution{},
+				}.Build(),
 			}.Build(),
 		},
 		{
 			desc: "empty GivingUp",
-			req: &joinv1.JoinRequest{
-				Payload: &joinv1.JoinRequest_GivingUp{},
-			},
+			req: joinv1.JoinRequest_builder{
+				GivingUp: &joinv1.GivingUp{},
+			}.Build(),
 		},
 	} {
 		t.Run(tc.desc, func(t *testing.T) {

--- a/lib/join/joinv1/messages_tpm.go
+++ b/lib/join/joinv1/messages_tpm.go
@@ -18,6 +18,7 @@ package joinv1
 
 import (
 	"github.com/gravitational/trace"
+	"google.golang.org/protobuf/proto"
 
 	joinv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/join/v1"
 	"github.com/gravitational/teleport/lib/join/internal/messages"
@@ -59,13 +60,9 @@ func tpmInitFromMessage(msg *messages.TPMInit) (*joinv1.TPMInit, error) {
 	case hasEKCert == hasEKKey:
 		return nil, trace.BadParameter("exactly one of EKCert and EKKey must be set")
 	case hasEKCert:
-		req.Ek = &joinv1.TPMInit_EkCert{
-			EkCert: msg.EKCert,
-		}
+		req.SetEkCert(proto.ValueOrDefaultBytes(msg.EKCert))
 	case hasEKKey:
-		req.Ek = &joinv1.TPMInit_EkKey{
-			EkKey: msg.EKKey,
-		}
+		req.SetEkKey(proto.ValueOrDefaultBytes(msg.EKKey))
 	}
 	return req, nil
 }

--- a/lib/secretsscanner/reporter/env_test.go
+++ b/lib/secretsscanner/reporter/env_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
+	"google.golang.org/protobuf/proto"
 
 	accessgraphsecretsv1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/accessgraph/v1"
 	devicepb "github.com/gravitational/teleport/api/gen/proto/go/teleport/devicetrust/v1"
@@ -188,11 +189,9 @@ type streamAdapter struct {
 }
 
 func (s streamAdapter) Send(rsp *devicepb.AssertDeviceResponse) error {
-	msg := &accessgraphsecretsv1pb.ReportSecretsResponse{
-		Payload: &accessgraphsecretsv1pb.ReportSecretsResponse_DeviceAssertion{
-			DeviceAssertion: rsp,
-		},
-	}
+	msg := accessgraphsecretsv1pb.ReportSecretsResponse_builder{
+		DeviceAssertion: proto.ValueOrDefault(rsp),
+	}.Build()
 	err := s.stream.Send(msg)
 	return trace.Wrap(err)
 }

--- a/lib/secretsscanner/reporter/report.go
+++ b/lib/secretsscanner/reporter/report.go
@@ -25,6 +25,7 @@ import (
 	"log/slog"
 
 	"github.com/gravitational/trace"
+	"google.golang.org/protobuf/proto"
 
 	accessgraphsecretsv1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/accessgraph/v1"
 	devicepb "github.com/gravitational/teleport/api/gen/proto/go/teleport/devicetrust/v1"
@@ -170,11 +171,9 @@ type reportToAssertStreamAdapter struct {
 func (s reportToAssertStreamAdapter) Send(request *devicepb.AssertDeviceRequest) error {
 	return trace.Wrap(
 		s.stream.Send(
-			&accessgraphsecretsv1pb.ReportSecretsRequest{
-				Payload: &accessgraphsecretsv1pb.ReportSecretsRequest_DeviceAssertion{
-					DeviceAssertion: request,
-				},
-			},
+			accessgraphsecretsv1pb.ReportSecretsRequest_builder{
+				DeviceAssertion: proto.ValueOrDefault(request),
+			}.Build(),
 		),
 	)
 }

--- a/lib/services/common_access_checker.go
+++ b/lib/services/common_access_checker.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/gravitational/trace"
+	"google.golang.org/protobuf/proto"
 
 	"github.com/gravitational/teleport/api/constants"
 	accessv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/access/v1"
@@ -46,7 +47,7 @@ func (c *ScopedAccessChecker) adjustScopedClientIdleTimeout(idleStr string, time
 // adjustScopedDisconnectExpiredCert returns the disconnect on Expired Cert condition - - applying the default if applicable.
 func (c *ScopedAccessChecker) adjustScopedDisconnectExpiredCert(roleSpecifiedDisconnect *bool, defaultdisconnect bool) bool {
 	if roleSpecifiedDisconnect == nil && c.role.GetSpec().GetDefaults() != nil {
-		roleSpecifiedDisconnect = c.role.GetSpec().GetDefaults().DisconnectExpiredCert
+		roleSpecifiedDisconnect = proto.ValueOrNil(c.role.GetSpec().GetDefaults().HasDisconnectExpiredCert(), c.role.GetSpec().GetDefaults().GetDisconnectExpiredCert)
 	}
 
 	if roleSpecifiedDisconnect != nil {

--- a/lib/services/kube_access_checker.go
+++ b/lib/services/kube_access_checker.go
@@ -21,6 +21,8 @@ package services
 import (
 	"time"
 
+	"google.golang.org/protobuf/proto"
+
 	"github.com/gravitational/teleport/api/constants"
 	"github.com/gravitational/teleport/api/types"
 )
@@ -88,7 +90,7 @@ func (c *KubeAccessChecker) AdjustDisconnectExpiredCert(disconnect bool) bool {
 	kube := c.checker.role.GetSpec().GetKube()
 	var disconnectExpiredCert *bool
 	if kube != nil {
-		disconnectExpiredCert = kube.DisconnectExpiredCert
+		disconnectExpiredCert = proto.ValueOrNil(kube.HasDisconnectExpiredCert(), kube.GetDisconnectExpiredCert)
 	}
 	return c.checker.adjustScopedDisconnectExpiredCert(disconnectExpiredCert, disconnect)
 }

--- a/lib/services/local/scoped_tokens.go
+++ b/lib/services/local/scoped_tokens.go
@@ -625,11 +625,9 @@ func maybeInitBoundKeypair(token *joiningv1.ScopedToken) error {
 	status := token.GetStatus().GetUsage().GetBoundKeypair()
 	if status == nil {
 		status = &joiningv1.BoundKeypairStatus{}
-		token.GetStatus().SetUsage(&joiningv1.UsageStatus{
-			Status: &joiningv1.UsageStatus_BoundKeypair{
-				BoundKeypair: status,
-			},
-		})
+		token.GetStatus().SetUsage(joiningv1.UsageStatus_builder{
+			BoundKeypair: proto.ValueOrDefault(status),
+		}.Build())
 	}
 
 	// If necessary, generate a registration secret.

--- a/lib/services/ssh_access_checker.go
+++ b/lib/services/ssh_access_checker.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/gravitational/trace"
+	"google.golang.org/protobuf/proto"
 
 	"github.com/gravitational/teleport/api/constants"
 	decisionpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/decision/v1alpha1"
@@ -74,7 +75,7 @@ func (c *SSHAccessChecker) AdjustDisconnectExpiredCert(disconnect bool) bool {
 	ssh := c.checker.role.GetSpec().GetSsh()
 	var disconnectExpiredCert *bool
 	if ssh != nil {
-		disconnectExpiredCert = ssh.DisconnectExpiredCert
+		disconnectExpiredCert = proto.ValueOrNil(ssh.HasDisconnectExpiredCert(), ssh.GetDisconnectExpiredCert)
 	}
 	return c.checker.adjustScopedDisconnectExpiredCert(disconnectExpiredCert, disconnect)
 }

--- a/lib/srv/desktop/tdp/protocol/tdpb/tdpb.go
+++ b/lib/srv/desktop/tdp/protocol/tdpb/tdpb.go
@@ -62,11 +62,9 @@ type ClientHello tdpbv1.ClientHello
 
 // Encode encodes a ClientHello message.
 func (c *ClientHello) Encode() ([]byte, error) {
-	return marshalWithHeader(&tdpbv1.Envelope{
-		Payload: &tdpbv1.Envelope_ClientHello{
-			ClientHello: (*tdpbv1.ClientHello)(c),
-		},
-	})
+	return marshalWithHeader(tdpbv1.Envelope_builder{
+		ClientHello: proto.ValueOrDefault((*tdpbv1.ClientHello)(c)),
+	}.Build())
 }
 
 func (*ClientHello) validate() error { return nil }
@@ -78,11 +76,9 @@ type ServerHello tdpbv1.ServerHello
 
 // Encode encodes a ServerHello message.
 func (s *ServerHello) Encode() ([]byte, error) {
-	return marshalWithHeader(&tdpbv1.Envelope{
-		Payload: &tdpbv1.Envelope_ServerHello{
-			ServerHello: (*tdpbv1.ServerHello)(s),
-		},
-	})
+	return marshalWithHeader(tdpbv1.Envelope_builder{
+		ServerHello: proto.ValueOrDefault((*tdpbv1.ServerHello)(s)),
+	}.Build())
 }
 
 func (*ServerHello) validate() error { return nil }
@@ -94,11 +90,9 @@ type PNGFrame tdpbv1.PNGFrame
 
 // Encode encodes a PNGFrame message.
 func (p *PNGFrame) Encode() ([]byte, error) {
-	return marshalWithHeader(&tdpbv1.Envelope{
-		Payload: &tdpbv1.Envelope_PngFrame{
-			PngFrame: (*tdpbv1.PNGFrame)(p),
-		},
-	})
+	return marshalWithHeader(tdpbv1.Envelope_builder{
+		PngFrame: proto.ValueOrDefault((*tdpbv1.PNGFrame)(p)),
+	}.Build())
 }
 
 func (*PNGFrame) validate() error { return nil }
@@ -108,11 +102,9 @@ type FastPathPDU tdpbv1.FastPathPDU
 
 // Encode encodes a FastPathPDU message.
 func (f *FastPathPDU) Encode() ([]byte, error) {
-	return marshalWithHeader(&tdpbv1.Envelope{
-		Payload: &tdpbv1.Envelope_FastPathPdu{
-			FastPathPdu: (*tdpbv1.FastPathPDU)(f),
-		},
-	})
+	return marshalWithHeader(tdpbv1.Envelope_builder{
+		FastPathPdu: proto.ValueOrDefault((*tdpbv1.FastPathPDU)(f)),
+	}.Build())
 }
 
 func (*FastPathPDU) validate() error { return nil }
@@ -122,11 +114,9 @@ type RDPResponsePDU tdpbv1.RDPResponsePDU
 
 // Encode encodes a RDPResponsePDU message.
 func (f *RDPResponsePDU) Encode() ([]byte, error) {
-	return marshalWithHeader(&tdpbv1.Envelope{
-		Payload: &tdpbv1.Envelope_RdpResponsePdu{
-			RdpResponsePdu: (*tdpbv1.RDPResponsePDU)(f),
-		},
-	})
+	return marshalWithHeader(tdpbv1.Envelope_builder{
+		RdpResponsePdu: proto.ValueOrDefault((*tdpbv1.RDPResponsePDU)(f)),
+	}.Build())
 }
 
 func (*RDPResponsePDU) validate() error { return nil }
@@ -137,11 +127,9 @@ type SyncKeys tdpbv1.SyncKeys
 
 // Encode encodes a SyncKeys message.
 func (s *SyncKeys) Encode() ([]byte, error) {
-	return marshalWithHeader(&tdpbv1.Envelope{
-		Payload: &tdpbv1.Envelope_SyncKeys{
-			SyncKeys: (*tdpbv1.SyncKeys)(s),
-		},
-	})
+	return marshalWithHeader(tdpbv1.Envelope_builder{
+		SyncKeys: proto.ValueOrDefault((*tdpbv1.SyncKeys)(s)),
+	}.Build())
 }
 
 func (*SyncKeys) validate() error { return nil }
@@ -151,11 +139,9 @@ type MouseMove tdpbv1.MouseMove
 
 // Encode encodes a MouseMove message.
 func (m *MouseMove) Encode() ([]byte, error) {
-	return marshalWithHeader(&tdpbv1.Envelope{
-		Payload: &tdpbv1.Envelope_MouseMove{
-			MouseMove: (*tdpbv1.MouseMove)(m),
-		},
-	})
+	return marshalWithHeader(tdpbv1.Envelope_builder{
+		MouseMove: proto.ValueOrDefault((*tdpbv1.MouseMove)(m)),
+	}.Build())
 }
 
 func (*MouseMove) validate() error { return nil }
@@ -165,11 +151,9 @@ type MouseButton tdpbv1.MouseButton
 
 // Encode encodes a MouseButton message.
 func (m *MouseButton) Encode() ([]byte, error) {
-	return marshalWithHeader(&tdpbv1.Envelope{
-		Payload: &tdpbv1.Envelope_MouseButton{
-			MouseButton: (*tdpbv1.MouseButton)(m),
-		},
-	})
+	return marshalWithHeader(tdpbv1.Envelope_builder{
+		MouseButton: proto.ValueOrDefault((*tdpbv1.MouseButton)(m)),
+	}.Build())
 }
 
 func (*MouseButton) validate() error { return nil }
@@ -179,11 +163,9 @@ type KeyboardButton tdpbv1.KeyboardButton
 
 // Encode encodes a KeyboardButton message.
 func (k *KeyboardButton) Encode() ([]byte, error) {
-	return marshalWithHeader(&tdpbv1.Envelope{
-		Payload: &tdpbv1.Envelope_KeyboardButton{
-			KeyboardButton: (*tdpbv1.KeyboardButton)(k),
-		},
-	})
+	return marshalWithHeader(tdpbv1.Envelope_builder{
+		KeyboardButton: proto.ValueOrDefault((*tdpbv1.KeyboardButton)(k)),
+	}.Build())
 }
 
 func (*KeyboardButton) validate() error { return nil }
@@ -195,11 +177,9 @@ type ClientScreenSpec tdpbv1.ClientScreenSpec
 
 // Encode encodes a ClientScreenSpec message.
 func (c *ClientScreenSpec) Encode() ([]byte, error) {
-	return marshalWithHeader(&tdpbv1.Envelope{
-		Payload: &tdpbv1.Envelope_ClientScreenSpec{
-			ClientScreenSpec: (*tdpbv1.ClientScreenSpec)(c),
-		},
-	})
+	return marshalWithHeader(tdpbv1.Envelope_builder{
+		ClientScreenSpec: proto.ValueOrDefault((*tdpbv1.ClientScreenSpec)(c)),
+	}.Build())
 }
 
 func (*ClientScreenSpec) validate() error { return nil }
@@ -210,11 +190,9 @@ type Alert tdpbv1.Alert
 
 // Encode encodes a Alert message.
 func (a *Alert) Encode() ([]byte, error) {
-	return marshalWithHeader(&tdpbv1.Envelope{
-		Payload: &tdpbv1.Envelope_Alert{
-			Alert: (*tdpbv1.Alert)(a),
-		},
-	})
+	return marshalWithHeader(tdpbv1.Envelope_builder{
+		Alert: proto.ValueOrDefault((*tdpbv1.Alert)(a)),
+	}.Build())
 }
 
 func (*Alert) validate() error { return nil }
@@ -224,11 +202,9 @@ type MouseWheel tdpbv1.MouseWheel
 
 // Encode encodes a MouseWheel message.
 func (m *MouseWheel) Encode() ([]byte, error) {
-	return marshalWithHeader(&tdpbv1.Envelope{
-		Payload: &tdpbv1.Envelope_MouseWheel{
-			MouseWheel: (*tdpbv1.MouseWheel)(m),
-		},
-	})
+	return marshalWithHeader(tdpbv1.Envelope_builder{
+		MouseWheel: proto.ValueOrDefault((*tdpbv1.MouseWheel)(m)),
+	}.Build())
 }
 
 func (*MouseWheel) validate() error { return nil }
@@ -239,11 +215,9 @@ type ClipboardData tdpbv1.ClipboardData
 
 // Encode encodes a ClipboardData message.
 func (c *ClipboardData) Encode() ([]byte, error) {
-	return marshalWithHeader(&tdpbv1.Envelope{
-		Payload: &tdpbv1.Envelope_ClipboardData{
-			ClipboardData: (*tdpbv1.ClipboardData)(c),
-		},
-	})
+	return marshalWithHeader(tdpbv1.Envelope_builder{
+		ClipboardData: proto.ValueOrDefault((*tdpbv1.ClipboardData)(c)),
+	}.Build())
 }
 
 func (c *ClipboardData) validate() error {
@@ -259,11 +233,9 @@ type MFA tdpbv1.MFA
 
 // Encode encodes a MFA message.
 func (m *MFA) Encode() ([]byte, error) {
-	return marshalWithHeader(&tdpbv1.Envelope{
-		Payload: &tdpbv1.Envelope_Mfa{
-			Mfa: (*tdpbv1.MFA)(m),
-		},
-	})
+	return marshalWithHeader(tdpbv1.Envelope_builder{
+		Mfa: proto.ValueOrDefault((*tdpbv1.MFA)(m)),
+	}.Build())
 }
 
 func (*MFA) validate() error { return nil }
@@ -273,11 +245,9 @@ type SharedDirectoryAnnounce tdpbv1.SharedDirectoryAnnounce
 
 // Encode encodes a SharedDirectoryAnnounce message.
 func (s *SharedDirectoryAnnounce) Encode() ([]byte, error) {
-	return marshalWithHeader(&tdpbv1.Envelope{
-		Payload: &tdpbv1.Envelope_SharedDirectoryAnnounce{
-			SharedDirectoryAnnounce: (*tdpbv1.SharedDirectoryAnnounce)(s),
-		},
-	})
+	return marshalWithHeader(tdpbv1.Envelope_builder{
+		SharedDirectoryAnnounce: proto.ValueOrDefault((*tdpbv1.SharedDirectoryAnnounce)(s)),
+	}.Build())
 }
 
 func (*SharedDirectoryAnnounce) validate() error { return nil }
@@ -287,11 +257,9 @@ type SharedDirectoryRemove tdpbv1.SharedDirectoryRemove
 
 // Encode encodes a SharedDirectoryAnnounce message.
 func (s *SharedDirectoryRemove) Encode() ([]byte, error) {
-	return marshalWithHeader(&tdpbv1.Envelope{
-		Payload: &tdpbv1.Envelope_SharedDirectoryRemove{
-			SharedDirectoryRemove: (*tdpbv1.SharedDirectoryRemove)(s),
-		},
-	})
+	return marshalWithHeader(tdpbv1.Envelope_builder{
+		SharedDirectoryRemove: proto.ValueOrDefault((*tdpbv1.SharedDirectoryRemove)(s)),
+	}.Build())
 }
 
 func (*SharedDirectoryRemove) validate() error { return nil }
@@ -302,11 +270,9 @@ type SharedDirectoryAcknowledge tdpbv1.SharedDirectoryAcknowledge
 
 // Encode encodes a SharedDirectoryAcknowledge message.
 func (s *SharedDirectoryAcknowledge) Encode() ([]byte, error) {
-	return marshalWithHeader(&tdpbv1.Envelope{
-		Payload: &tdpbv1.Envelope_SharedDirectoryAcknowledge{
-			SharedDirectoryAcknowledge: (*tdpbv1.SharedDirectoryAcknowledge)(s),
-		},
-	})
+	return marshalWithHeader(tdpbv1.Envelope_builder{
+		SharedDirectoryAcknowledge: proto.ValueOrDefault((*tdpbv1.SharedDirectoryAcknowledge)(s)),
+	}.Build())
 }
 
 func (*SharedDirectoryAcknowledge) validate() error { return nil }
@@ -317,11 +283,9 @@ type SharedDirectoryRequest tdpbv1.SharedDirectoryRequest
 
 // Encode encodes a SharedDirectoryRequest message.
 func (s *SharedDirectoryRequest) Encode() ([]byte, error) {
-	return marshalWithHeader(&tdpbv1.Envelope{
-		Payload: &tdpbv1.Envelope_SharedDirectoryRequest{
-			SharedDirectoryRequest: (*tdpbv1.SharedDirectoryRequest)(s),
-		},
-	})
+	return marshalWithHeader(tdpbv1.Envelope_builder{
+		SharedDirectoryRequest: proto.ValueOrDefault((*tdpbv1.SharedDirectoryRequest)(s)),
+	}.Build())
 }
 
 func (s *SharedDirectoryRequest) validate() error {
@@ -374,11 +338,9 @@ type SharedDirectoryResponse tdpbv1.SharedDirectoryResponse
 
 // Encode encodes a SharedDirectoryResponse message.
 func (s *SharedDirectoryResponse) Encode() ([]byte, error) {
-	return marshalWithHeader(&tdpbv1.Envelope{
-		Payload: &tdpbv1.Envelope_SharedDirectoryResponse{
-			SharedDirectoryResponse: (*tdpbv1.SharedDirectoryResponse)(s),
-		},
-	})
+	return marshalWithHeader(tdpbv1.Envelope_builder{
+		SharedDirectoryResponse: proto.ValueOrDefault((*tdpbv1.SharedDirectoryResponse)(s)),
+	}.Build())
 }
 
 func (s *SharedDirectoryResponse) validate() error {
@@ -416,11 +378,9 @@ type LatencyStats tdpbv1.LatencyStats
 
 // Encode encodes a LatencyStats message.
 func (l *LatencyStats) Encode() ([]byte, error) {
-	return marshalWithHeader(&tdpbv1.Envelope{
-		Payload: &tdpbv1.Envelope_LatencyStats{
-			LatencyStats: (*tdpbv1.LatencyStats)(l),
-		},
-	})
+	return marshalWithHeader(tdpbv1.Envelope_builder{
+		LatencyStats: proto.ValueOrDefault((*tdpbv1.LatencyStats)(l)),
+	}.Build())
 }
 
 func (*LatencyStats) validate() error { return nil }
@@ -431,11 +391,9 @@ type Ping tdpbv1.Ping
 
 // Encodes a ping message.
 func (p *Ping) Encode() ([]byte, error) {
-	return marshalWithHeader(&tdpbv1.Envelope{
-		Payload: &tdpbv1.Envelope_Ping{
-			Ping: (*tdpbv1.Ping)(p),
-		},
-	})
+	return marshalWithHeader(tdpbv1.Envelope_builder{
+		Ping: proto.ValueOrDefault((*tdpbv1.Ping)(p)),
+	}.Build())
 }
 
 func (*Ping) validate() error { return nil }

--- a/lib/srv/discovery/access_graph_aws.go
+++ b/lib/srv/discovery/access_graph_aws.go
@@ -296,9 +296,9 @@ func push(
 		return trace.Wrap(err)
 	}
 	err = client.Send(
-		&accessgraphv1alpha.AWSEventsStreamRequest{
-			Operation: &accessgraphv1alpha.AWSEventsStreamRequest_Sync{},
-		},
+		accessgraphv1alpha.AWSEventsStreamRequest_builder{
+			Sync: &accessgraphv1alpha.AWSSyncOperation{},
+		}.Build(),
 	)
 	return trace.Wrap(err)
 }

--- a/lib/srv/discovery/access_graph_azure.go
+++ b/lib/srv/discovery/access_graph_azure.go
@@ -187,9 +187,9 @@ func azurePush(
 		return trace.Wrap(err)
 	}
 	err = client.Send(
-		&accessgraphv1alpha.AzureEventsStreamRequest{
-			Operation: &accessgraphv1alpha.AzureEventsStreamRequest_Sync{},
-		},
+		accessgraphv1alpha.AzureEventsStreamRequest_builder{
+			Sync: &accessgraphv1alpha.AzureSyncOperation{},
+		}.Build(),
 	)
 	return trace.Wrap(err)
 }

--- a/lib/srv/discovery/eks_audit_log_watcher.go
+++ b/lib/srv/discovery/eks_audit_log_watcher.go
@@ -26,6 +26,7 @@ import (
 	"time"
 
 	"github.com/gravitational/trace"
+	"google.golang.org/protobuf/proto"
 
 	accessgraphv1alpha "github.com/gravitational/teleport/gen/proto/go/accessgraph/v1alpha"
 	aws_sync "github.com/gravitational/teleport/lib/srv/discovery/fetchers/aws-sync"
@@ -277,9 +278,9 @@ func mapDifference[K comparable, V1 any, V2 any](m1 map[K]V1, m2 map[K]V2) iter.
 
 func sendTAGKubeAuditLogConfig(ctx context.Context, stream accessgraphv1alpha.AccessGraphService_KubeAuditLogStreamClient, config *accessgraphv1alpha.KubeAuditLogConfig) error {
 	err := stream.Send(
-		&accessgraphv1alpha.KubeAuditLogStreamRequest{
-			Action: &accessgraphv1alpha.KubeAuditLogStreamRequest_Config{Config: config},
-		},
+		accessgraphv1alpha.KubeAuditLogStreamRequest_builder{
+			Config: proto.ValueOrDefault(config),
+		}.Build(),
 	)
 	if err != nil {
 		err = consumeTillErr(stream)

--- a/lib/srv/discovery/eks_audit_log_watcher_test.go
+++ b/lib/srv/discovery/eks_audit_log_watcher_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/gravitational/trace"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
+	"google.golang.org/protobuf/proto"
 
 	accessgraphv1alpha "github.com/gravitational/teleport/gen/proto/go/accessgraph/v1alpha"
 	aws_sync "github.com/gravitational/teleport/lib/srv/discovery/fetchers/aws-sync"
@@ -235,11 +236,9 @@ func (f *fakeEksAuditLogFetcher) Run(ctx context.Context) error {
 }
 
 func newKubeAuditLogResponseConfig(cfg *accessgraphv1alpha.KubeAuditLogConfig) *accessgraphv1alpha.KubeAuditLogStreamResponse {
-	return &accessgraphv1alpha.KubeAuditLogStreamResponse{
-		State: &accessgraphv1alpha.KubeAuditLogStreamResponse_Config{
-			Config: cfg,
-		},
-	}
+	return accessgraphv1alpha.KubeAuditLogStreamResponse_builder{
+		Config: proto.ValueOrDefault(cfg),
+	}.Build()
 }
 
 func newFakeKubeAuditLogClient(ctx context.Context) *fakeKubeAuditLogClient {

--- a/lib/srv/discovery/fetchers/aws-sync/reconcile.go
+++ b/lib/srv/discovery/fetchers/aws-sync/reconcile.go
@@ -143,7 +143,7 @@ func instanceKey(instance *accessgraphv1alpha.AWSInstanceV1) string {
 }
 
 func instanceWrap(instance *accessgraphv1alpha.AWSInstanceV1) *accessgraphv1alpha.AWSResource {
-	return &accessgraphv1alpha.AWSResource{Resource: &accessgraphv1alpha.AWSResource_Instance{Instance: instance}}
+	return accessgraphv1alpha.AWSResource_builder{Instance: proto.ValueOrDefault(instance)}.Build()
 }
 
 func usersKey(user *accessgraphv1alpha.AWSUserV1) string {
@@ -151,7 +151,7 @@ func usersKey(user *accessgraphv1alpha.AWSUserV1) string {
 }
 
 func usersWrap(user *accessgraphv1alpha.AWSUserV1) *accessgraphv1alpha.AWSResource {
-	return &accessgraphv1alpha.AWSResource{Resource: &accessgraphv1alpha.AWSResource_User{User: user}}
+	return accessgraphv1alpha.AWSResource_builder{User: proto.ValueOrDefault(user)}.Build()
 }
 
 func userInlinePolKey(policy *accessgraphv1alpha.AWSUserInlinePolicyV1) string {
@@ -159,7 +159,7 @@ func userInlinePolKey(policy *accessgraphv1alpha.AWSUserInlinePolicyV1) string {
 }
 
 func userInlinePolWrap(policy *accessgraphv1alpha.AWSUserInlinePolicyV1) *accessgraphv1alpha.AWSResource {
-	return &accessgraphv1alpha.AWSResource{Resource: &accessgraphv1alpha.AWSResource_UserInlinePolicy{UserInlinePolicy: policy}}
+	return accessgraphv1alpha.AWSResource_builder{UserInlinePolicy: proto.ValueOrDefault(policy)}.Build()
 }
 
 func userAttchPolKey(policy *accessgraphv1alpha.AWSUserAttachedPolicies) string {
@@ -167,7 +167,7 @@ func userAttchPolKey(policy *accessgraphv1alpha.AWSUserAttachedPolicies) string 
 }
 
 func userAttchPolWrap(policy *accessgraphv1alpha.AWSUserAttachedPolicies) *accessgraphv1alpha.AWSResource {
-	return &accessgraphv1alpha.AWSResource{Resource: &accessgraphv1alpha.AWSResource_UserAttachedPolicies{UserAttachedPolicies: policy}}
+	return accessgraphv1alpha.AWSResource_builder{UserAttachedPolicies: proto.ValueOrDefault(policy)}.Build()
 }
 
 func userGroupKey(group *accessgraphv1alpha.AWSUserGroupsV1) string {
@@ -175,7 +175,7 @@ func userGroupKey(group *accessgraphv1alpha.AWSUserGroupsV1) string {
 }
 
 func userGroupWrap(group *accessgraphv1alpha.AWSUserGroupsV1) *accessgraphv1alpha.AWSResource {
-	return &accessgraphv1alpha.AWSResource{Resource: &accessgraphv1alpha.AWSResource_UserGroups{UserGroups: group}}
+	return accessgraphv1alpha.AWSResource_builder{UserGroups: proto.ValueOrDefault(group)}.Build()
 }
 
 func groupKey(group *accessgraphv1alpha.AWSGroupV1) string {
@@ -183,7 +183,7 @@ func groupKey(group *accessgraphv1alpha.AWSGroupV1) string {
 }
 
 func groupWrap(group *accessgraphv1alpha.AWSGroupV1) *accessgraphv1alpha.AWSResource {
-	return &accessgraphv1alpha.AWSResource{Resource: &accessgraphv1alpha.AWSResource_Group{Group: group}}
+	return accessgraphv1alpha.AWSResource_builder{Group: proto.ValueOrDefault(group)}.Build()
 }
 
 func grpInlinePolKey(policy *accessgraphv1alpha.AWSGroupInlinePolicyV1) string {
@@ -191,7 +191,7 @@ func grpInlinePolKey(policy *accessgraphv1alpha.AWSGroupInlinePolicyV1) string {
 }
 
 func grpInlinePolWrap(policy *accessgraphv1alpha.AWSGroupInlinePolicyV1) *accessgraphv1alpha.AWSResource {
-	return &accessgraphv1alpha.AWSResource{Resource: &accessgraphv1alpha.AWSResource_GroupInlinePolicy{GroupInlinePolicy: policy}}
+	return accessgraphv1alpha.AWSResource_builder{GroupInlinePolicy: proto.ValueOrDefault(policy)}.Build()
 }
 
 func grpAttchPolKey(policy *accessgraphv1alpha.AWSGroupAttachedPolicies) string {
@@ -199,7 +199,7 @@ func grpAttchPolKey(policy *accessgraphv1alpha.AWSGroupAttachedPolicies) string 
 }
 
 func grpAttchPolWrap(policy *accessgraphv1alpha.AWSGroupAttachedPolicies) *accessgraphv1alpha.AWSResource {
-	return &accessgraphv1alpha.AWSResource{Resource: &accessgraphv1alpha.AWSResource_GroupAttachedPolicies{GroupAttachedPolicies: policy}}
+	return accessgraphv1alpha.AWSResource_builder{GroupAttachedPolicies: proto.ValueOrDefault(policy)}.Build()
 }
 
 func policyKey(policy *accessgraphv1alpha.AWSPolicyV1) string {
@@ -207,7 +207,7 @@ func policyKey(policy *accessgraphv1alpha.AWSPolicyV1) string {
 }
 
 func policyWrap(policy *accessgraphv1alpha.AWSPolicyV1) *accessgraphv1alpha.AWSResource {
-	return &accessgraphv1alpha.AWSResource{Resource: &accessgraphv1alpha.AWSResource_Policy{Policy: policy}}
+	return accessgraphv1alpha.AWSResource_builder{Policy: proto.ValueOrDefault(policy)}.Build()
 }
 
 func s3bucketKey(s3 *accessgraphv1alpha.AWSS3BucketV1) string {
@@ -215,7 +215,7 @@ func s3bucketKey(s3 *accessgraphv1alpha.AWSS3BucketV1) string {
 }
 
 func s3bucketWrap(s3 *accessgraphv1alpha.AWSS3BucketV1) *accessgraphv1alpha.AWSResource {
-	return &accessgraphv1alpha.AWSResource{Resource: &accessgraphv1alpha.AWSResource_S3Bucket{S3Bucket: s3}}
+	return accessgraphv1alpha.AWSResource_builder{S3Bucket: proto.ValueOrDefault(s3)}.Build()
 }
 
 func roleKey(role *accessgraphv1alpha.AWSRoleV1) string {
@@ -223,7 +223,7 @@ func roleKey(role *accessgraphv1alpha.AWSRoleV1) string {
 }
 
 func roleWrap(role *accessgraphv1alpha.AWSRoleV1) *accessgraphv1alpha.AWSResource {
-	return &accessgraphv1alpha.AWSResource{Resource: &accessgraphv1alpha.AWSResource_Role{Role: role}}
+	return accessgraphv1alpha.AWSResource_builder{Role: proto.ValueOrDefault(role)}.Build()
 }
 
 func roleInlinePolKey(policy *accessgraphv1alpha.AWSRoleInlinePolicyV1) string {
@@ -231,7 +231,7 @@ func roleInlinePolKey(policy *accessgraphv1alpha.AWSRoleInlinePolicyV1) string {
 }
 
 func roleInlinePolWrap(policy *accessgraphv1alpha.AWSRoleInlinePolicyV1) *accessgraphv1alpha.AWSResource {
-	return &accessgraphv1alpha.AWSResource{Resource: &accessgraphv1alpha.AWSResource_RoleInlinePolicy{RoleInlinePolicy: policy}}
+	return accessgraphv1alpha.AWSResource_builder{RoleInlinePolicy: proto.ValueOrDefault(policy)}.Build()
 }
 
 func roleAttchPolKey(policy *accessgraphv1alpha.AWSRoleAttachedPolicies) string {
@@ -239,7 +239,7 @@ func roleAttchPolKey(policy *accessgraphv1alpha.AWSRoleAttachedPolicies) string 
 }
 
 func roleAttchPolWrap(policy *accessgraphv1alpha.AWSRoleAttachedPolicies) *accessgraphv1alpha.AWSResource {
-	return &accessgraphv1alpha.AWSResource{Resource: &accessgraphv1alpha.AWSResource_RoleAttachedPolicies{RoleAttachedPolicies: policy}}
+	return accessgraphv1alpha.AWSResource_builder{RoleAttachedPolicies: proto.ValueOrDefault(policy)}.Build()
 }
 
 func instanceProfKey(profile *accessgraphv1alpha.AWSInstanceProfileV1) string {
@@ -247,7 +247,7 @@ func instanceProfKey(profile *accessgraphv1alpha.AWSInstanceProfileV1) string {
 }
 
 func instanceProfWrap(profile *accessgraphv1alpha.AWSInstanceProfileV1) *accessgraphv1alpha.AWSResource {
-	return &accessgraphv1alpha.AWSResource{Resource: &accessgraphv1alpha.AWSResource_InstanceProfile{InstanceProfile: profile}}
+	return accessgraphv1alpha.AWSResource_builder{InstanceProfile: proto.ValueOrDefault(profile)}.Build()
 }
 
 func eksClusterKey(cluster *accessgraphv1alpha.AWSEKSClusterV1) string {
@@ -255,7 +255,7 @@ func eksClusterKey(cluster *accessgraphv1alpha.AWSEKSClusterV1) string {
 }
 
 func eksClusterWrap(cluster *accessgraphv1alpha.AWSEKSClusterV1) *accessgraphv1alpha.AWSResource {
-	return &accessgraphv1alpha.AWSResource{Resource: &accessgraphv1alpha.AWSResource_EksCluster{EksCluster: cluster}}
+	return accessgraphv1alpha.AWSResource_builder{EksCluster: proto.ValueOrDefault(cluster)}.Build()
 }
 
 func assocAccPolKey(policy *accessgraphv1alpha.AWSEKSAssociatedAccessPolicyV1) string {
@@ -263,7 +263,7 @@ func assocAccPolKey(policy *accessgraphv1alpha.AWSEKSAssociatedAccessPolicyV1) s
 }
 
 func assocAccPolWrap(policy *accessgraphv1alpha.AWSEKSAssociatedAccessPolicyV1) *accessgraphv1alpha.AWSResource {
-	return &accessgraphv1alpha.AWSResource{Resource: &accessgraphv1alpha.AWSResource_EksClusterAssociatedPolicy{EksClusterAssociatedPolicy: policy}}
+	return accessgraphv1alpha.AWSResource_builder{EksClusterAssociatedPolicy: proto.ValueOrDefault(policy)}.Build()
 }
 
 func accessEntryKey(entry *accessgraphv1alpha.AWSEKSClusterAccessEntryV1) string {
@@ -271,7 +271,7 @@ func accessEntryKey(entry *accessgraphv1alpha.AWSEKSClusterAccessEntryV1) string
 }
 
 func accessEntryWrap(entry *accessgraphv1alpha.AWSEKSClusterAccessEntryV1) *accessgraphv1alpha.AWSResource {
-	return &accessgraphv1alpha.AWSResource{Resource: &accessgraphv1alpha.AWSResource_EksClusterAccessEntry{EksClusterAccessEntry: entry}}
+	return accessgraphv1alpha.AWSResource_builder{EksClusterAccessEntry: proto.ValueOrDefault(entry)}.Build()
 }
 
 func rdsDbKey(db *accessgraphv1alpha.AWSRDSDatabaseV1) string {
@@ -279,7 +279,7 @@ func rdsDbKey(db *accessgraphv1alpha.AWSRDSDatabaseV1) string {
 }
 
 func rdsDbWrap(db *accessgraphv1alpha.AWSRDSDatabaseV1) *accessgraphv1alpha.AWSResource {
-	return &accessgraphv1alpha.AWSResource{Resource: &accessgraphv1alpha.AWSResource_Rds{Rds: db}}
+	return accessgraphv1alpha.AWSResource_builder{Rds: proto.ValueOrDefault(db)}.Build()
 }
 
 func samlProvKey(provider *accessgraphv1alpha.AWSSAMLProviderV1) string {
@@ -287,7 +287,7 @@ func samlProvKey(provider *accessgraphv1alpha.AWSSAMLProviderV1) string {
 }
 
 func samlProvWrap(provider *accessgraphv1alpha.AWSSAMLProviderV1) *accessgraphv1alpha.AWSResource {
-	return &accessgraphv1alpha.AWSResource{Resource: &accessgraphv1alpha.AWSResource_SamlProvider{SamlProvider: provider}}
+	return accessgraphv1alpha.AWSResource_builder{SamlProvider: proto.ValueOrDefault(provider)}.Build()
 }
 
 func oidcProvKey(provider *accessgraphv1alpha.AWSOIDCProviderV1) string {
@@ -295,7 +295,7 @@ func oidcProvKey(provider *accessgraphv1alpha.AWSOIDCProviderV1) string {
 }
 
 func oidcProvWrap(provider *accessgraphv1alpha.AWSOIDCProviderV1) *accessgraphv1alpha.AWSResource {
-	return &accessgraphv1alpha.AWSResource{Resource: &accessgraphv1alpha.AWSResource_OidcProvider{OidcProvider: provider}}
+	return accessgraphv1alpha.AWSResource_builder{OidcProvider: proto.ValueOrDefault(provider)}.Build()
 }
 
 func kmsKeyKey(key *accessgraphv1alpha.AWSKMSKeyV1) string {
@@ -303,5 +303,5 @@ func kmsKeyKey(key *accessgraphv1alpha.AWSKMSKeyV1) string {
 }
 
 func kmsKeyWrap(key *accessgraphv1alpha.AWSKMSKeyV1) *accessgraphv1alpha.AWSResource {
-	return &accessgraphv1alpha.AWSResource{Resource: &accessgraphv1alpha.AWSResource_KmsKey{KmsKey: key}}
+	return accessgraphv1alpha.AWSResource_builder{KmsKey: proto.ValueOrDefault(key)}.Build()
 }

--- a/lib/srv/discovery/fetchers/aws-sync/reconcile_test.go
+++ b/lib/srv/discovery/fetchers/aws-sync/reconcile_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/wrapperspb"
 
 	accessgraphv1alpha "github.com/gravitational/teleport/gen/proto/go/accessgraph/v1alpha"
@@ -46,39 +47,27 @@ func TestReconcileResults(t *testing.T) {
 	upsert, delete := ReconcileResults(&oldResults, &newResults)
 
 	wantDelete := []*accessgraphv1alpha.AWSResource{
-		{
-			Resource: &accessgraphv1alpha.AWSResource_Role{
-				Role: oldRoles[0],
-			},
-		},
+		accessgraphv1alpha.AWSResource_builder{
+			Role: proto.ValueOrDefault(oldRoles[0]),
+		}.Build(),
 	}
 
 	wantUpsert := []*accessgraphv1alpha.AWSResource{
-		{
-			Resource: &accessgraphv1alpha.AWSResource_Role{
-				Role: newRoles[0],
-			},
-		},
-		{
-			Resource: &accessgraphv1alpha.AWSResource_Role{
-				Role: newRoles[1],
-			},
-		},
-		{
-			Resource: &accessgraphv1alpha.AWSResource_User{
-				User: newUsers[1],
-			},
-		},
-		{
-			Resource: &accessgraphv1alpha.AWSResource_User{
-				User: newUsers[2],
-			},
-		},
-		{
-			Resource: &accessgraphv1alpha.AWSResource_Instance{
-				Instance: newEC2[2],
-			},
-		},
+		accessgraphv1alpha.AWSResource_builder{
+			Role: proto.ValueOrDefault(newRoles[0]),
+		}.Build(),
+		accessgraphv1alpha.AWSResource_builder{
+			Role: proto.ValueOrDefault(newRoles[1]),
+		}.Build(),
+		accessgraphv1alpha.AWSResource_builder{
+			User: proto.ValueOrDefault(newUsers[1]),
+		}.Build(),
+		accessgraphv1alpha.AWSResource_builder{
+			User: proto.ValueOrDefault(newUsers[2]),
+		}.Build(),
+		accessgraphv1alpha.AWSResource_builder{
+			Instance: proto.ValueOrDefault(newEC2[2]),
+		}.Build(),
 	}
 
 	require.ElementsMatch(t, wantDelete, delete.GetResources())

--- a/lib/srv/discovery/fetchers/azuresync/reconcile.go
+++ b/lib/srv/discovery/fetchers/azuresync/reconcile.go
@@ -137,7 +137,7 @@ func azurePrincipalsKey(user *accessgraphv1alpha.AzurePrincipal) string {
 }
 
 func azurePrincipalsWrap(principal *accessgraphv1alpha.AzurePrincipal) *accessgraphv1alpha.AzureResource {
-	return &accessgraphv1alpha.AzureResource{Resource: &accessgraphv1alpha.AzureResource_Principal{Principal: principal}}
+	return accessgraphv1alpha.AzureResource_builder{Principal: proto.ValueOrDefault(principal)}.Build()
 }
 
 func azureRoleAssignKey(roleAssign *accessgraphv1alpha.AzureRoleAssignment) string {
@@ -145,7 +145,7 @@ func azureRoleAssignKey(roleAssign *accessgraphv1alpha.AzureRoleAssignment) stri
 }
 
 func azureRoleAssignWrap(roleAssign *accessgraphv1alpha.AzureRoleAssignment) *accessgraphv1alpha.AzureResource {
-	return &accessgraphv1alpha.AzureResource{Resource: &accessgraphv1alpha.AzureResource_RoleAssignment{RoleAssignment: roleAssign}}
+	return accessgraphv1alpha.AzureResource_builder{RoleAssignment: proto.ValueOrDefault(roleAssign)}.Build()
 }
 
 func azureRoleDefKey(roleDef *accessgraphv1alpha.AzureRoleDefinition) string {
@@ -153,7 +153,7 @@ func azureRoleDefKey(roleDef *accessgraphv1alpha.AzureRoleDefinition) string {
 }
 
 func azureRoleDefWrap(roleDef *accessgraphv1alpha.AzureRoleDefinition) *accessgraphv1alpha.AzureResource {
-	return &accessgraphv1alpha.AzureResource{Resource: &accessgraphv1alpha.AzureResource_RoleDefinition{RoleDefinition: roleDef}}
+	return accessgraphv1alpha.AzureResource_builder{RoleDefinition: proto.ValueOrDefault(roleDef)}.Build()
 }
 
 func azureVmKey(vm *accessgraphv1alpha.AzureVirtualMachine) string {
@@ -161,5 +161,5 @@ func azureVmKey(vm *accessgraphv1alpha.AzureVirtualMachine) string {
 }
 
 func azureVmWrap(vm *accessgraphv1alpha.AzureVirtualMachine) *accessgraphv1alpha.AzureResource {
-	return &accessgraphv1alpha.AzureResource{Resource: &accessgraphv1alpha.AzureResource_VirtualMachine{VirtualMachine: vm}}
+	return accessgraphv1alpha.AzureResource_builder{VirtualMachine: proto.ValueOrDefault(vm)}.Build()
 }

--- a/lib/tbot/identity/generator.go
+++ b/lib/tbot/identity/generator.go
@@ -464,10 +464,10 @@ func (g *Generator) generateDelegationCertificates(ctx context.Context, req prot
 func (g *Generator) GenerateScoped(
 	ctx context.Context, ttl, renewalInterval time.Duration,
 ) (*Identity, error) {
-	req := &issuancev1pb.IssueScopedBotCertsRequest{
-		Ttl:   durationpb.New(ttl),
-		Usage: &issuancev1pb.IssueScopedBotCertsRequest_Identity{},
-	}
+	req := issuancev1pb.IssueScopedBotCertsRequest_builder{
+		Ttl:      durationpb.New(ttl),
+		Identity: &issuancev1pb.UsageIdentity{},
+	}.Build()
 
 	keyPurpose := cryptosuites.BotImpersonatedIdentity
 	key, err := cryptosuites.GenerateKey(ctx,

--- a/lib/tbot/workloadidentity/workloadattest/unix_test.go
+++ b/lib/tbot/workloadidentity/workloadattest/unix_test.go
@@ -97,7 +97,7 @@ func TestUnixAttestor_BinaryTooLarge(t *testing.T) {
 
 	att, err := attestor.Attest(ctx, os.Getpid())
 	require.NoError(t, err)
-	require.Nil(t, att.BinaryHash)
+	require.Nil(t, proto.ValueOrNil(att.HasBinaryHash(), att.GetBinaryHash))
 }
 
 type testOS struct {

--- a/lib/teleterm/apiserver/handler/handler_unified_resources.go
+++ b/lib/teleterm/apiserver/handler/handler_unified_resources.go
@@ -22,8 +22,9 @@ import (
 	"context"
 
 	"github.com/gravitational/trace"
+	"google.golang.org/protobuf/proto"
 
-	"github.com/gravitational/teleport/api/client/proto"
+	clientproto "github.com/gravitational/teleport/api/client/proto"
 	"github.com/gravitational/teleport/api/types"
 	api "github.com/gravitational/teleport/gen/proto/go/teleport/lib/teleterm/v1"
 	"github.com/gravitational/teleport/lib/client"
@@ -44,7 +45,7 @@ func (s *Handler) ListUnifiedResources(ctx context.Context, req *api.ListUnified
 		sortBy.Field = req.GetSortBy().GetField()
 	}
 
-	daemonResponse, err := s.DaemonService.ListUnifiedResources(ctx, clusterURI, &proto.ListUnifiedResourcesRequest{
+	daemonResponse, err := s.DaemonService.ListUnifiedResources(ctx, clusterURI, &clientproto.ListUnifiedResourcesRequest{
 		Kinds:               req.GetKinds(),
 		Limit:               req.GetLimit(),
 		StartKey:            req.GetStartKey(),
@@ -65,52 +66,40 @@ func (s *Handler) ListUnifiedResources(ctx context.Context, req *api.ListUnified
 
 	for _, resource := range daemonResponse.Resources {
 		if resource.Server != nil {
-			response.SetResources(append(response.GetResources(), &api.PaginatedResource{
-				Resource: &api.PaginatedResource_Server{
-					Server: newAPIServer(*resource.Server),
-				},
+			response.SetResources(append(response.GetResources(), api.PaginatedResource_builder{
+				Server:          proto.ValueOrDefault(newAPIServer(*resource.Server)),
 				RequiresRequest: resource.RequiresRequest,
-			}))
+			}.Build()))
 		}
 		if resource.Database != nil {
-			response.SetResources(append(response.GetResources(), &api.PaginatedResource{
-				Resource: &api.PaginatedResource_Database{
-					Database: newAPIDatabase(*resource.Database),
-				},
+			response.SetResources(append(response.GetResources(), api.PaginatedResource_builder{
+				Database:        proto.ValueOrDefault(newAPIDatabase(*resource.Database)),
 				RequiresRequest: resource.RequiresRequest,
-			}))
+			}.Build()))
 		}
 		if resource.Kube != nil {
-			response.SetResources(append(response.GetResources(), &api.PaginatedResource{
-				Resource: &api.PaginatedResource_Kube{
-					Kube: newAPIKube(*resource.Kube),
-				},
+			response.SetResources(append(response.GetResources(), api.PaginatedResource_builder{
+				Kube:            proto.ValueOrDefault(newAPIKube(*resource.Kube)),
 				RequiresRequest: resource.RequiresRequest,
-			}))
+			}.Build()))
 		}
 		if resource.App != nil {
-			response.SetResources(append(response.GetResources(), &api.PaginatedResource{
-				Resource: &api.PaginatedResource_App{
-					App: newAPIApp(*resource.App),
-				},
+			response.SetResources(append(response.GetResources(), api.PaginatedResource_builder{
+				App:             proto.ValueOrDefault(newAPIApp(*resource.App)),
 				RequiresRequest: resource.RequiresRequest,
-			}))
+			}.Build()))
 		}
 		if resource.SAMLIdPServiceProvider != nil {
-			response.SetResources(append(response.GetResources(), &api.PaginatedResource{
-				Resource: &api.PaginatedResource_App{
-					App: newSAMLIdPServiceProviderAPIApp(*resource.SAMLIdPServiceProvider),
-				},
+			response.SetResources(append(response.GetResources(), api.PaginatedResource_builder{
+				App:             proto.ValueOrDefault(newSAMLIdPServiceProviderAPIApp(*resource.SAMLIdPServiceProvider)),
 				RequiresRequest: resource.RequiresRequest,
-			}))
+			}.Build()))
 		}
 		if resource.WindowsDesktop != nil {
-			response.SetResources(append(response.GetResources(), &api.PaginatedResource{
-				Resource: &api.PaginatedResource_WindowsDesktop{
-					WindowsDesktop: newAPIWindowsDesktop(*resource.WindowsDesktop),
-				},
+			response.SetResources(append(response.GetResources(), api.PaginatedResource_builder{
+				WindowsDesktop:  proto.ValueOrDefault(newAPIWindowsDesktop(*resource.WindowsDesktop)),
 				RequiresRequest: resource.RequiresRequest,
-			}))
+			}.Build()))
 		}
 	}
 

--- a/lib/teleterm/vnet/service.go
+++ b/lib/teleterm/vnet/service.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
+	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	"github.com/gravitational/teleport"
@@ -604,13 +605,11 @@ func (p *clientApplication) OnInvalidLocalPort(ctx context.Context, appInfo *vne
 	}
 
 	err := p.daemonService.NotifyApp(ctx, apiteleterm.SendNotificationRequest_builder{
-		CannotProxyVnetConnection: &apiteleterm.CannotProxyVnetConnection{
-			TargetUri:  appURI.String(),
-			RouteToApp: &apiteletermRouteToApp,
-			Reason: &apiteleterm.CannotProxyVnetConnection_InvalidLocalPort{
-				InvalidLocalPort: invalidLocalPort,
-			},
-		},
+		CannotProxyVnetConnection: apiteleterm.CannotProxyVnetConnection_builder{
+			TargetUri:        appURI.String(),
+			RouteToApp:       &apiteletermRouteToApp,
+			InvalidLocalPort: proto.ValueOrDefault(invalidLocalPort),
+		}.Build(),
 	}.Build())
 	if err != nil {
 		log.ErrorContext(ctx, "Could not notify the Electron app about invalid local port",

--- a/lib/vnet/diag/routeconflict.go
+++ b/lib/vnet/diag/routeconflict.go
@@ -143,9 +143,9 @@ func (c *RouteConflictDiag) Run(ctx context.Context) (*diagv1.CheckReport, error
 }
 
 func (c *RouteConflictDiag) EmptyCheckReport() *diagv1.CheckReport {
-	return &diagv1.CheckReport{
-		Report: &diagv1.CheckReport_RouteConflictReport{},
-	}
+	return diagv1.CheckReport_builder{
+		RouteConflictReport: &diagv1.RouteConflictReport{},
+	}.Build()
 }
 
 func (c *RouteConflictDiag) run(ctx context.Context) ([]*diagv1.RouteConflict, error) {

--- a/lib/vnet/diag/ssh.go
+++ b/lib/vnet/diag/ssh.go
@@ -30,6 +30,7 @@ import (
 
 	"github.com/dustin/go-humanize"
 	"github.com/gravitational/trace"
+	"google.golang.org/protobuf/proto"
 
 	"github.com/gravitational/teleport/api/constants"
 	"github.com/gravitational/teleport/api/profile"
@@ -74,7 +75,7 @@ func (d *SSHDiag) Commands(ctx context.Context) []*exec.Cmd {
 
 // EmptyCheckReport returns an empty SSH configuration report.
 func (d *SSHDiag) EmptyCheckReport() *diagv1.CheckReport {
-	return &diagv1.CheckReport{Report: &diagv1.CheckReport_SshConfigurationReport{}}
+	return diagv1.CheckReport_builder{SshConfigurationReport: &diagv1.SSHConfigurationReport{}}.Build()
 }
 
 // Run runs the diagnostic.
@@ -83,16 +84,14 @@ func (d *SSHDiag) Run(ctx context.Context) (*diagv1.CheckReport, error) {
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	return &diagv1.CheckReport{
+	return diagv1.CheckReport_builder{
 		// This intentionally always returns CHECK_REPORT_STATUS_OK even if
 		// ~/.ssh/config does not include the VNet generated SSH config. It is
 		// not mandatory to configure SSH and returning an error status would
 		// cause an alert and notification in Connect.
-		Status: diagv1.CheckReportStatus_CHECK_REPORT_STATUS_OK,
-		Report: &diagv1.CheckReport_SshConfigurationReport{
-			SshConfigurationReport: report,
-		},
-	}, nil
+		Status:                 diagv1.CheckReportStatus_CHECK_REPORT_STATUS_OK,
+		SshConfigurationReport: proto.ValueOrDefault(report),
+	}.Build(), nil
 }
 
 func (d *SSHDiag) run(ctx context.Context) (*diagv1.SSHConfigurationReport, error) {

--- a/tool/tctl/common/recordings_command.go
+++ b/tool/tctl/common/recordings_command.go
@@ -30,6 +30,7 @@ import (
 	"github.com/alecthomas/kingpin/v2"
 	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
+	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	"github.com/gravitational/teleport"
@@ -433,11 +434,9 @@ func (c *RecordingsCommand) buildSearchResourceProperties() (*sessionsearchv1pb.
 		if c.searchServerAddr != "" {
 			props.SetServerAddr(c.searchServerAddr)
 		}
-		return &sessionsearchv1pb.ResourceProperties{
-			Type: &sessionsearchv1pb.ResourceProperties_Ssh{
-				Ssh: props,
-			},
-		}, nil
+		return sessionsearchv1pb.ResourceProperties_builder{
+			Ssh: proto.ValueOrDefault(props),
+		}.Build(), nil
 	case kubernetesSet:
 		props := &sessionsearchv1pb.KubernetesProperties{}
 		if c.searchPodNamespace != "" {
@@ -446,11 +445,9 @@ func (c *RecordingsCommand) buildSearchResourceProperties() (*sessionsearchv1pb.
 		if c.searchPodName != "" {
 			props.SetPodName(c.searchPodName)
 		}
-		return &sessionsearchv1pb.ResourceProperties{
-			Type: &sessionsearchv1pb.ResourceProperties_Kubernetes{
-				Kubernetes: props,
-			},
-		}, nil
+		return sessionsearchv1pb.ResourceProperties_builder{
+			Kubernetes: proto.ValueOrDefault(props),
+		}.Build(), nil
 	case databaseSet:
 		return sessionsearchv1pb.ResourceProperties_builder{
 			Database: sessionsearchv1pb.DatabaseProperties_builder{


### PR DESCRIPTION
Contributes to #66776.

All of the changes here are mechanical conversions generated from open2opaque rewrite -levels=yellow./.... There will be a follow up to this in teleport.e which does the same. Once all changes have been merged the process will be repeated with -levels=red.

See https://protobuf.dev/reference/go/opaque-migration/ for more details.
