### PR TITLE
[3] Final migration to the Opaque API

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -135,6 +135,21 @@ jobs:
             popd > /dev/null;
           done
 
+      # Prevent any new uses of the Open API from being added until teleport is converted
+      # to exclusively use the Opaque API.
+      - name: Check for Open API usage
+        run: |
+          # We have to add the current directory as a safe directory or else git commands will not work as expected.
+          git config --global --add safe.directory "$(realpath .)"
+          go install golang.org/x/tools/cmd/goimports@v0.46.0
+          go run google.golang.org/open2opaque@v0.1.7 rewrite -levels=red ./...
+          if ! git diff --quiet --exit-code -- '*.go'; then
+            echo "Detected Open API usage - Update code to use the Opaque API manually or run go run google.golang.org/open2opaque@v0.1.7 rewrite -levels=red ./..."
+            git diff --stat -- '*.go'
+            git diff -- '*.go'
+            exit 1
+          fi
+
       - name: Set linter versions
         run: |
           echo GOLANGCI_LINT_VERSION=$(cd build.assets; make print-golangci-lint-version) >> $GITHUB_ENV

--- a/integration/hostuser_test.go
+++ b/integration/hostuser_test.go
@@ -251,7 +251,7 @@ func TestRootHostUsers(t *testing.T) {
 		users := srv.NewHostUsers(context.Background(), presence, "host_uuid")
 
 		testGroups := []string{"group1", "group2"}
-		closer, err := users.UpsertUser(testuser, &decisionpb.HostUsersInfo{Groups: testGroups, Mode: decisionpb.HostUserMode_HOST_USER_MODE_DROP})
+		closer, err := users.UpsertUser(testuser, decisionpb.HostUsersInfo_builder{Groups: testGroups, Mode: decisionpb.HostUserMode_HOST_USER_MODE_DROP}.Build())
 		require.NoError(t, err)
 
 		testGroups = append(testGroups, apiconstants.TeleportDropGroup)
@@ -276,11 +276,11 @@ func TestRootHostUsers(t *testing.T) {
 		_, err := user.LookupGroupId(testGID)
 		require.ErrorIs(t, err, user.UnknownGroupIdError(testGID))
 
-		closer, err := users.UpsertUser(testuser, &decisionpb.HostUsersInfo{
+		closer, err := users.UpsertUser(testuser, decisionpb.HostUsersInfo_builder{
 			Mode: decisionpb.HostUserMode_HOST_USER_MODE_DROP,
 			Uid:  testUID,
 			Gid:  testGID,
-		})
+		}.Build())
 		require.NoError(t, err)
 
 		t.Cleanup(func() { cleanupUsersAndGroups([]string{testuser}, []string{apiconstants.TeleportDropGroup}) })
@@ -305,7 +305,7 @@ func TestRootHostUsers(t *testing.T) {
 		expectedHome := filepath.Join("/home", testuser)
 		require.NoDirExists(t, expectedHome)
 
-		closer, err := users.UpsertUser(testuser, &decisionpb.HostUsersInfo{Mode: decisionpb.HostUserMode_HOST_USER_MODE_KEEP})
+		closer, err := users.UpsertUser(testuser, decisionpb.HostUsersInfo_builder{Mode: decisionpb.HostUserMode_HOST_USER_MODE_KEEP}.Build())
 		require.NoError(t, err)
 		require.Nil(t, closer)
 		t.Cleanup(func() { cleanupUsersAndGroups([]string{testuser}, []string{apiconstants.TeleportKeepGroup}) })
@@ -332,9 +332,9 @@ func TestRootHostUsers(t *testing.T) {
 			cleanupUsersAndGroups([]string{testuser}, nil)
 		})
 		closer, err := users.UpsertUser(testuser,
-			&decisionpb.HostUsersInfo{
+			decisionpb.HostUsersInfo_builder{
 				Mode: decisionpb.HostUserMode_HOST_USER_MODE_DROP,
-			})
+			}.Build())
 		require.NoError(t, err)
 		err = sudoers.WriteSudoers(testuser, []string{"ALL=(ALL) ALL"})
 		require.NoError(t, err)
@@ -360,14 +360,14 @@ func TestRootHostUsers(t *testing.T) {
 
 		deleteableUsers := []string{"teleport-user1", "teleport-user2", "teleport-user3"}
 		for _, user := range deleteableUsers {
-			_, err := users.UpsertUser(user, &decisionpb.HostUsersInfo{Mode: decisionpb.HostUserMode_HOST_USER_MODE_DROP})
+			_, err := users.UpsertUser(user, decisionpb.HostUsersInfo_builder{Mode: decisionpb.HostUserMode_HOST_USER_MODE_DROP}.Build())
 			require.NoError(t, err)
 		}
 
 		// this user should not be in the service group as it was created with mode keep.
-		closer, err := users.UpsertUser("teleport-user4", &decisionpb.HostUsersInfo{
+		closer, err := users.UpsertUser("teleport-user4", decisionpb.HostUsersInfo_builder{
 			Mode: decisionpb.HostUserMode_HOST_USER_MODE_KEEP,
-		})
+		}.Build())
 		require.NoError(t, err)
 		require.Nil(t, closer)
 
@@ -421,20 +421,20 @@ func TestRootHostUsers(t *testing.T) {
 
 				// Verify that the user is created with the first set of groups.
 				users := srv.NewHostUsers(context.Background(), presence, "host_uuid")
-				_, err := users.UpsertUser(testuser, &decisionpb.HostUsersInfo{
+				_, err := users.UpsertUser(testuser, decisionpb.HostUsersInfo_builder{
 					Groups: tc.firstGroups,
 					Mode:   decisionpb.HostUserMode_HOST_USER_MODE_KEEP,
-				})
+				}.Build())
 				require.NoError(t, err)
 				u, err := user.Lookup(testuser)
 				require.NoError(t, err)
 				requireUserInGroups(t, u, tc.firstGroups)
 
 				// Verify that the user is updated with the second set of groups.
-				_, err = users.UpsertUser(testuser, &decisionpb.HostUsersInfo{
+				_, err = users.UpsertUser(testuser, decisionpb.HostUsersInfo_builder{
 					Groups: tc.secondGroups,
 					Mode:   decisionpb.HostUserMode_HOST_USER_MODE_KEEP,
-				})
+				}.Build())
 				require.NoError(t, err)
 				u, err = user.Lookup(testuser)
 				require.NoError(t, err)
@@ -462,23 +462,23 @@ func TestRootHostUsers(t *testing.T) {
 
 		// Create a user with a named shell expected to be available in the PATH
 		users := srv.NewHostUsers(context.Background(), presence, "host_uuid")
-		_, err := users.UpsertUser(namedShellUser, &decisionpb.HostUsersInfo{
+		_, err := users.UpsertUser(namedShellUser, decisionpb.HostUsersInfo_builder{
 			Mode:  decisionpb.HostUserMode_HOST_USER_MODE_KEEP,
 			Shell: "bash",
-		})
+		}.Build())
 		require.NoError(t, err)
 
 		// Create a user with the host default shell (default behavior)
-		_, err = users.UpsertUser(defaultShellUser, &decisionpb.HostUsersInfo{
+		_, err = users.UpsertUser(defaultShellUser, decisionpb.HostUsersInfo_builder{
 			Mode: decisionpb.HostUserMode_HOST_USER_MODE_KEEP,
-		})
+		}.Build())
 		require.NoError(t, err)
 
 		// Create a user with an absolute path to a shell
-		_, err = users.UpsertUser(absoluteShellUser, &decisionpb.HostUsersInfo{
+		_, err = users.UpsertUser(absoluteShellUser, decisionpb.HostUsersInfo_builder{
 			Mode:  decisionpb.HostUserMode_HOST_USER_MODE_KEEP,
 			Shell: "/usr/bin/bash",
-		})
+		}.Build())
 		require.NoError(t, err)
 
 		_, err = user.Lookup(namedShellUser)
@@ -505,10 +505,10 @@ func TestRootHostUsers(t *testing.T) {
 		// User's shell should be overwritten when a different shell
 		// is provided
 		expectedShell = "/usr/bin/sh"
-		_, err = users.UpsertUser(namedShellUser, &decisionpb.HostUsersInfo{
+		_, err = users.UpsertUser(namedShellUser, decisionpb.HostUsersInfo_builder{
 			Mode:  decisionpb.HostUserMode_HOST_USER_MODE_KEEP,
 			Shell: "sh",
-		})
+		}.Build())
 		require.NoError(t, err)
 
 		userShells, err = getUserShells("/etc/passwd")
@@ -517,10 +517,10 @@ func TestRootHostUsers(t *testing.T) {
 
 		// Make sure we can change the user's shell back again.
 		expectedShell = "/usr/bin/bash"
-		_, err = users.UpsertUser(namedShellUser, &decisionpb.HostUsersInfo{
+		_, err = users.UpsertUser(namedShellUser, decisionpb.HostUsersInfo_builder{
 			Mode:  decisionpb.HostUserMode_HOST_USER_MODE_KEEP,
 			Shell: "bash",
-		})
+		}.Build())
 		require.NoError(t, err)
 
 		userShells, err = getUserShells("/etc/passwd")
@@ -548,9 +548,9 @@ func TestRootHostUsers(t *testing.T) {
 		require.True(t, hasExpirations)
 
 		// Upsert a new user which should have the expirations removed
-		_, err = users.UpsertUser(expiredUser, &decisionpb.HostUsersInfo{
+		_, err = users.UpsertUser(expiredUser, decisionpb.HostUsersInfo_builder{
 			Mode: decisionpb.HostUserMode_HOST_USER_MODE_KEEP,
-		})
+		}.Build())
 		require.NoError(t, err)
 
 		hasExpirations, _, err = host.UserHasExpirations(expiredUser)
@@ -571,9 +571,9 @@ func TestRootHostUsers(t *testing.T) {
 		require.True(t, hasExpirations)
 
 		// Update user without any changes
-		_, err = users.UpsertUser(expiredUser, &decisionpb.HostUsersInfo{
+		_, err = users.UpsertUser(expiredUser, decisionpb.HostUsersInfo_builder{
 			Mode: decisionpb.HostUserMode_HOST_USER_MODE_KEEP,
-		})
+		}.Build())
 		require.NoError(t, err)
 
 		hasExpirations, _, err = host.UserHasExpirations(expiredUser)
@@ -587,10 +587,10 @@ func TestRootHostUsers(t *testing.T) {
 		require.True(t, hasExpirations)
 
 		// Update user with changes
-		_, err = users.UpsertUser(expiredUser, &decisionpb.HostUsersInfo{
+		_, err = users.UpsertUser(expiredUser, decisionpb.HostUsersInfo_builder{
 			Mode:   decisionpb.HostUserMode_HOST_USER_MODE_KEEP,
 			Groups: []string{"test-group"},
-		})
+		}.Build())
 		require.NoError(t, err)
 
 		hasExpirations, _, err = host.UserHasExpirations(expiredUser)
@@ -605,7 +605,7 @@ func TestRootHostUsers(t *testing.T) {
 		_, err := host.UserAdd(testuser, nil, host.UserOpts{})
 		require.NoError(t, err)
 
-		closer, err := users.UpsertUser(testuser, &decisionpb.HostUsersInfo{Mode: decisionpb.HostUserMode_HOST_USER_MODE_KEEP, Groups: []string{apiconstants.TeleportKeepGroup}})
+		closer, err := users.UpsertUser(testuser, decisionpb.HostUsersInfo_builder{Mode: decisionpb.HostUserMode_HOST_USER_MODE_KEEP, Groups: []string{apiconstants.TeleportKeepGroup}}.Build())
 		require.NoError(t, err)
 		require.Nil(t, closer)
 
@@ -773,67 +773,67 @@ func TestRootStaticHostUsers(t *testing.T) {
 	// Create host user resources.
 	groups := []string{"foo", "bar"}
 	goodLogin := testutils.GenerateLocalUsername(t)
-	goodUser := userprovisioning.NewStaticHostUser(goodLogin, &userprovisioningpb.StaticHostUserSpec{
+	goodUser := userprovisioning.NewStaticHostUser(goodLogin, userprovisioningpb.StaticHostUserSpec_builder{
 		Matchers: []*userprovisioningpb.Matcher{
-			{
+			userprovisioningpb.Matcher_builder{
 				NodeLabels: []*labelv1.Label{
-					{
+					labelv1.Label_builder{
 						Name:   "foo",
 						Values: []string{"bar"},
-					},
+					}.Build(),
 				},
 				Groups:  groups,
 				Sudoers: []string{"All = (root) NOPASSWD: /usr/bin/systemctl restart nginx.service"},
-			},
+			}.Build(),
 		},
-	})
+	}.Build())
 	goodLoginWithShell := testutils.GenerateLocalUsername(t)
-	goodUserWithShell := userprovisioning.NewStaticHostUser(goodLoginWithShell, &userprovisioningpb.StaticHostUserSpec{
+	goodUserWithShell := userprovisioning.NewStaticHostUser(goodLoginWithShell, userprovisioningpb.StaticHostUserSpec_builder{
 		Matchers: []*userprovisioningpb.Matcher{
-			{
+			userprovisioningpb.Matcher_builder{
 				NodeLabels: []*labelv1.Label{
-					{
+					labelv1.Label_builder{
 						Name:   "foo",
 						Values: []string{"bar"},
-					},
+					}.Build(),
 				},
 				Groups:       groups,
 				DefaultShell: "bash",
-			},
+			}.Build(),
 		},
-	})
+	}.Build())
 	nonMatchingLogin := testutils.GenerateLocalUsername(t)
-	nonMatchingUser := userprovisioning.NewStaticHostUser(nonMatchingLogin, &userprovisioningpb.StaticHostUserSpec{
+	nonMatchingUser := userprovisioning.NewStaticHostUser(nonMatchingLogin, userprovisioningpb.StaticHostUserSpec_builder{
 		Matchers: []*userprovisioningpb.Matcher{
-			{
+			userprovisioningpb.Matcher_builder{
 				NodeLabels: []*labelv1.Label{
-					{
+					labelv1.Label_builder{
 						Name:   "foo",
 						Values: []string{"baz"},
-					},
+					}.Build(),
 				},
 				Groups: groups,
-			},
+			}.Build(),
 		},
-	})
+	}.Build())
 	conflictingLogin := testutils.GenerateLocalUsername(t)
-	conflictingUser := userprovisioning.NewStaticHostUser(conflictingLogin, &userprovisioningpb.StaticHostUserSpec{
+	conflictingUser := userprovisioning.NewStaticHostUser(conflictingLogin, userprovisioningpb.StaticHostUserSpec_builder{
 		Matchers: []*userprovisioningpb.Matcher{
-			{
+			userprovisioningpb.Matcher_builder{
 				NodeLabels: []*labelv1.Label{
-					{
+					labelv1.Label_builder{
 						Name:   "foo",
 						Values: []string{"bar"},
-					},
+					}.Build(),
 				},
 				Groups: groups,
-			},
-			{
+			}.Build(),
+			userprovisioningpb.Matcher_builder{
 				NodeLabelsExpression: `labels["foo"] == "bar"`,
 				Groups:               groups,
-			},
+			}.Build(),
 		},
-	})
+	}.Build())
 
 	clt := instance.Process.GetAuthServer()
 	for _, hostUser := range []*userprovisioningpb.StaticHostUser{goodUser, goodUserWithShell, nonMatchingUser, conflictingUser} {

--- a/integrations/operator/controllers/resources/testlib/login_rule_controller_tests.go
+++ b/integrations/operator/controllers/resources/testlib/login_rule_controller_tests.go
@@ -23,8 +23,8 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/gravitational/trace"
+	"google.golang.org/protobuf/testing/protocmp"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kclient "sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -52,7 +52,7 @@ func (l *loginRuleTestingPrimitives) SetupTeleportFixtures(context.Context) erro
 }
 
 func (l *loginRuleTestingPrimitives) CreateTeleportResource(ctx context.Context, name string) error {
-	rule := loginrulepb.LoginRule{
+	rule := loginrulepb.LoginRule_builder{
 		Metadata: &types.Metadata{
 			Name: name,
 		},
@@ -66,10 +66,10 @@ func (l *loginRuleTestingPrimitives) CreateTeleportResource(ctx context.Context,
 				Values: []string{"external.groups"},
 			},
 		},
-	}
+	}.Build()
 	rule.GetMetadata().SetOrigin(types.OriginKubernetes)
 	_, err := l.setup.TeleportClient.LoginRuleClient().CreateLoginRule(ctx, loginrulepb.CreateLoginRuleRequest_builder{
-		LoginRule: &rule,
+		LoginRule: rule,
 	}.Build())
 	return trace.Wrap(err)
 }
@@ -139,9 +139,7 @@ func (l *loginRuleTestingPrimitives) ModifyKubernetesResource(ctx context.Contex
 func (l *loginRuleTestingPrimitives) CompareTeleportAndKubernetesResource(
 	tResource *resourcesv1.LoginRuleResource,
 	kubeResource *resourcesv1.TeleportLoginRule) (bool, string) {
-	diff := cmp.Diff(tResource, kubeResource.ToTeleport(),
-		CompareOptions(cmpopts.IgnoreUnexported(loginrulepb.LoginRule{}))...,
-	)
+	diff := cmp.Diff(tResource, kubeResource.ToTeleport(), CompareOptions(protocmp.Transform())...)
 	return diff == "", diff
 }
 

--- a/lib/auth/auth_test.go
+++ b/lib/auth/auth_test.go
@@ -5461,7 +5461,7 @@ func TestServer_GetAnonymizationKey(t *testing.T) {
 func newUserNotificationWithExpiry(t *testing.T, username string, title string, expires *timestamppb.Timestamp) *notificationsv1.Notification {
 	t.Helper()
 
-	notification := notificationsv1.Notification{
+	notification := notificationsv1.Notification_builder{
 		SubKind: "test-subkind",
 		Spec: notificationsv1.NotificationSpec_builder{
 			Username: username,
@@ -5472,15 +5472,15 @@ func newUserNotificationWithExpiry(t *testing.T, username string, title string, 
 				types.NotificationTitleLabel: title,
 			},
 		}.Build(),
-	}
+	}.Build()
 
-	return &notification
+	return notification
 }
 
 func newGlobalNotificationWithExpiry(t *testing.T, title string, expires *timestamppb.Timestamp) *notificationsv1.GlobalNotification {
 	t.Helper()
 
-	notification := notificationsv1.GlobalNotification{
+	notification := notificationsv1.GlobalNotification_builder{
 		Spec: notificationsv1.GlobalNotificationSpec_builder{
 			All: proto.Bool(true),
 			Notification: notificationsv1.Notification_builder{
@@ -5494,9 +5494,9 @@ func newGlobalNotificationWithExpiry(t *testing.T, title string, expires *timest
 				}.Build(),
 			}.Build(),
 		}.Build(),
-	}
+	}.Build()
 
-	return &notification
+	return notification
 }
 
 // TestServerHostnameSanitization tests that persisting servers with

--- a/lib/auth/authclient/httpfallback.go
+++ b/lib/auth/authclient/httpfallback.go
@@ -165,7 +165,7 @@ func (c *Client) GetAllTunnelConnections(ctx context.Context) ([]types.TunnelCon
 func (c *Client) listAllTunnelConnections(ctx context.Context, clusterName string) ([]types.TunnelConnection, error) {
 	var filter *trustpb.ListTunnelConnectionsFilter
 	if clusterName != "" {
-		filter = &trustpb.ListTunnelConnectionsFilter{ClusterName: clusterName}
+		filter = trustpb.ListTunnelConnectionsFilter_builder{ClusterName: clusterName}.Build()
 	}
 
 	items, err := clientutils.CollectWithFallback(

--- a/lib/auth/authtest/authtest.go
+++ b/lib/auth/authtest/authtest.go
@@ -1292,14 +1292,14 @@ func TestScopePinnedHost(clusterName, hostID, scope string, roles ...types.Syste
 	if clusterName != "" {
 		serverFQDN = utils.HostFQDN(hostID, clusterName)
 	}
-	pin := &scopesv1.Pin{
+	pin := scopesv1.Pin_builder{
 		Kind:  scopesv1.PinKind_PIN_KIND_AGENT,
 		Scope: scope,
-		SystemRoles: &scopesv1.SystemRoles{
+		SystemRoles: scopesv1.SystemRoles_builder{
 			Primary:    string(types.RoleInstance),
 			Additional: types.SystemRoles(roles).StringSlice(),
-		},
-	}
+		}.Build(),
+	}.Build()
 	return TestIdentity{
 		I: authz.ScopedBuiltinRole{
 			ClusterName: clusterName,

--- a/lib/auth/bot_test.go
+++ b/lib/auth/bot_test.go
@@ -1258,9 +1258,9 @@ func TestRegisterBotWithInvalidUserLoginState(t *testing.T) {
 	require.ElementsMatch(t, []string{"bot-" + botName}, ident.Groups)
 
 	// Delete the bot; it should delete the invalid ULS.
-	_, err = client.BotServiceClient().DeleteBot(ctx, &machineidv1pb.DeleteBotRequest{
+	_, err = client.BotServiceClient().DeleteBot(ctx, machineidv1pb.DeleteBotRequest_builder{
 		BotName: botName,
-	})
+	}.Build())
 	require.NoError(t, err)
 
 	_, err = client.UserLoginStateClient().GetUserLoginState(ctx, "bot-"+botName)

--- a/lib/auth/clusterconfig/clusterconfigv1/service_test.go
+++ b/lib/auth/clusterconfig/clusterconfigv1/service_test.go
@@ -2569,13 +2569,13 @@ func TestScopedGetClusterNetworkingConfig(t *testing.T) {
 			scopedAuthorizer: scopedAuthorizerFunc(func(ctx context.Context) (*authz.ScopedContext, error) {
 				// we setup a full scoped checker context to make sure that we're evaluating scoped access rules
 				// and determining that VerbRead is not permitted for KindClusterName
-				checkerCtx, err := services.NewScopedAccessCheckerContextForAgentPin(&scopesv1.Pin{
+				checkerCtx, err := services.NewScopedAccessCheckerContextForAgentPin(scopesv1.Pin_builder{
 					Kind:  scopesv1.PinKind_PIN_KIND_AGENT,
 					Scope: scope,
-					SystemRoles: &scopesv1.SystemRoles{
+					SystemRoles: scopesv1.SystemRoles_builder{
 						Primary: string(systemRole),
-					},
-				}, map[string]*services.ScopedAccessChecker{
+					}.Build(),
+				}.Build(), map[string]*services.ScopedAccessChecker{
 					string(systemRole): services.NewScopedAccessCheckerFromUnscoped(noopChecker{}),
 				})
 				if err != nil {
@@ -2600,13 +2600,13 @@ func TestScopedGetClusterNetworkingConfig(t *testing.T) {
 				checker := services.NewAccessCheckerWithRoleSet(&services.AccessInfo{
 					Roles: []string{string(systemRole)},
 				}, clusterName, roleSet)
-				checkerCtx, err := services.NewScopedAccessCheckerContextForAgentPin(&scopesv1.Pin{
+				checkerCtx, err := services.NewScopedAccessCheckerContextForAgentPin(scopesv1.Pin_builder{
 					Kind:  scopesv1.PinKind_PIN_KIND_AGENT,
 					Scope: scope,
-					SystemRoles: &scopesv1.SystemRoles{
+					SystemRoles: scopesv1.SystemRoles_builder{
 						Primary: string(systemRole),
-					},
-				}, map[string]*services.ScopedAccessChecker{
+					}.Build(),
+				}.Build(), map[string]*services.ScopedAccessChecker{
 					string(systemRole): services.NewScopedAccessCheckerForSystemRole(string(systemRole), checker),
 				})
 				if err != nil {
@@ -2666,13 +2666,13 @@ func TestScopedGetClusterName(t *testing.T) {
 			scopedAuthorizer: scopedAuthorizerFunc(func(ctx context.Context) (*authz.ScopedContext, error) {
 				// we setup a full scoped checker context to make sure that we're evaluating scoped access rules
 				// and determining that VerbRead is not permitted for KindClusterName
-				checkerCtx, err := services.NewScopedAccessCheckerContextForAgentPin(&scopesv1.Pin{
+				checkerCtx, err := services.NewScopedAccessCheckerContextForAgentPin(scopesv1.Pin_builder{
 					Kind:  scopesv1.PinKind_PIN_KIND_AGENT,
 					Scope: scope,
-					SystemRoles: &scopesv1.SystemRoles{
+					SystemRoles: scopesv1.SystemRoles_builder{
 						Primary: string(systemRole),
-					},
-				}, map[string]*services.ScopedAccessChecker{
+					}.Build(),
+				}.Build(), map[string]*services.ScopedAccessChecker{
 					string(systemRole): services.NewScopedAccessCheckerFromUnscoped(noopChecker{}),
 				})
 				if err != nil {
@@ -2697,13 +2697,13 @@ func TestScopedGetClusterName(t *testing.T) {
 				checker := services.NewAccessCheckerWithRoleSet(&services.AccessInfo{
 					Roles: []string{string(systemRole)},
 				}, defaultCN.GetClusterName(), roleSet)
-				checkerCtx, err := services.NewScopedAccessCheckerContextForAgentPin(&scopesv1.Pin{
+				checkerCtx, err := services.NewScopedAccessCheckerContextForAgentPin(scopesv1.Pin_builder{
 					Kind:  scopesv1.PinKind_PIN_KIND_AGENT,
 					Scope: scope,
-					SystemRoles: &scopesv1.SystemRoles{
+					SystemRoles: scopesv1.SystemRoles_builder{
 						Primary: string(systemRole),
-					},
-				}, map[string]*services.ScopedAccessChecker{
+					}.Build(),
+				}.Build(), map[string]*services.ScopedAccessChecker{
 					string(systemRole): services.NewScopedAccessCheckerForSystemRole(string(systemRole), checker),
 				})
 				if err != nil {

--- a/lib/auth/dynamicwindows/dynamicwindowsv1/service_test.go
+++ b/lib/auth/dynamicwindows/dynamicwindowsv1/service_test.go
@@ -45,10 +45,10 @@ func TestFailedAccessCheck(t *testing.T) {
 	s := newService(t, authz.AdminActionAuthMFAVerified, &checker)
 	desktop, err := types.NewDynamicWindowsDesktopV1("test2", nil, types.DynamicWindowsDesktopSpecV1{Addr: "addr"})
 	require.NoError(t, err)
-	req := dynamicwindowsv1.CreateDynamicWindowsDesktopRequest{
+	req := dynamicwindowsv1.CreateDynamicWindowsDesktopRequest_builder{
 		Desktop: desktop,
-	}
-	_, err = s.CreateDynamicWindowsDesktop(context.Background(), &req)
+	}.Build()
+	_, err = s.CreateDynamicWindowsDesktop(context.Background(), req)
 	require.NoError(t, err)
 	checker.failAccess = true
 	testCases := []string{
@@ -65,10 +65,10 @@ func TestFailedAccessCheck(t *testing.T) {
 		})
 	}
 	t.Run("ListDynamicWindowsDesktops failed access check", func(t *testing.T) {
-		req := dynamicwindowsv1.ListDynamicWindowsDesktopsRequest{
+		req := dynamicwindowsv1.ListDynamicWindowsDesktopsRequest_builder{
 			PageSize: 10,
-		}
-		resp, err := s.ListDynamicWindowsDesktops(context.Background(), &req)
+		}.Build()
+		resp, err := s.ListDynamicWindowsDesktops(context.Background(), req)
 		require.NoError(t, err)
 		require.Empty(t, resp.GetDesktops())
 	})

--- a/lib/auth/machineid/workloadidentityv1/issuer_service.go
+++ b/lib/auth/machineid/workloadidentityv1/issuer_service.go
@@ -447,9 +447,9 @@ func (s *IssuanceService) IssueTeleportWorkloadIdentity(
 		if !authz.HasBuiltinRole(*authCtx, string(types.RoleApp)) {
 			return nil, trace.AccessDenied("only app services can issue workload identity for app access")
 		}
-		switch credParams := req.Credential.(type) {
-		case *workloadidentityv1pb.IssueTeleportWorkloadIdentityRequest_X509SvidParams:
-			return s.issueAppAccessX509Identity(ctx, builtin.GetServerID(), req, req.GetAppAccess(), credParams)
+		switch req.WhichCredential() {
+		case workloadidentityv1pb.IssueTeleportWorkloadIdentityRequest_X509SvidParams_case:
+			return s.issueAppAccessX509Identity(ctx, builtin.GetServerID(), req, req.GetAppAccess(), req.GetX509SvidParams())
 		default:
 			return nil, trace.BadParameter("app access usage only supports issuing x509 credentials")
 		}
@@ -463,7 +463,7 @@ func (s *IssuanceService) issueAppAccessX509Identity(
 	hostID string,
 	req *workloadidentityv1pb.IssueTeleportWorkloadIdentityRequest,
 	appUsage *workloadidentityv1pb.AppAccessUsage,
-	credParams *workloadidentityv1pb.IssueTeleportWorkloadIdentityRequest_X509SvidParams,
+	credParams *workloadidentityv1pb.X509SVIDParams,
 ) (_ *workloadidentityv1pb.IssueTeleportWorkloadIdentityResponse, err error) {
 	ctx, span := tracer.Start(ctx, "IssuanceService/issueAppAccessX509Identity")
 	defer func() { tracing.EndSpan(span, err) }()
@@ -482,7 +482,7 @@ func (s *IssuanceService) issueAppAccessX509Identity(
 		return nil, trace.Wrap(err, "unable to locate app")
 	}
 
-	pubKey, err := x509.ParsePKIXPublicKey(credParams.X509SvidParams.GetPublicKey())
+	pubKey, err := x509.ParsePKIXPublicKey(credParams.GetPublicKey())
 	if err != nil {
 		return nil, trace.Wrap(err, "parsing public key")
 	}

--- a/lib/auth/machineid/workloadidentityv1/workloadidentityv1_test.go
+++ b/lib/auth/machineid/workloadidentityv1/workloadidentityv1_test.go
@@ -2518,12 +2518,12 @@ func TestResourceService_ListWorkloadIdentities(t *testing.T) {
 		}
 		require.NotEmpty(t, want)
 
-		res, err := client.ListWorkloadIdentitiesV2(ctx, &workloadidentityv1pb.ListWorkloadIdentitiesV2Request{
+		res, err := client.ListWorkloadIdentitiesV2(ctx, workloadidentityv1pb.ListWorkloadIdentitiesV2Request_builder{
 			FilterSearchTerm: "test/1",
-		})
+		}.Build())
 		require.NoError(t, err)
-		require.Len(t, res.WorkloadIdentities, len(want))
-		for _, wi := range res.WorkloadIdentities {
+		require.Len(t, res.GetWorkloadIdentities(), len(want))
+		for _, wi := range res.GetWorkloadIdentities() {
 			require.Contains(t, wi.GetSpec().GetSpiffe().GetId(), "/test/1/")
 		}
 	})

--- a/lib/auth/presence/presencev1/service_test.go
+++ b/lib/auth/presence/presencev1/service_test.go
@@ -762,7 +762,7 @@ func TestListAuthServers(t *testing.T) {
 				require.Empty(
 					t, cmp.Diff(
 						tt.want,
-						res.Servers,
+						res.GetServers(),
 						cmpopts.IgnoreFields(types.Metadata{}, "Revision"),
 					),
 				)
@@ -892,7 +892,7 @@ func TestListProxyServers(t *testing.T) {
 				require.Empty(
 					t, cmp.Diff(
 						tt.want,
-						res.Servers,
+						res.GetServers(),
 						cmpopts.IgnoreFields(types.Metadata{}, "Revision"),
 					),
 				)

--- a/lib/auth/tls_test.go
+++ b/lib/auth/tls_test.go
@@ -1690,15 +1690,15 @@ func TestTunnelConnectionsCRUD(t *testing.T) {
 		require.NoError(t, clt.UpsertTunnelConnection(ctx, c))
 	}
 
-	resp, err := clt.TrustClient().ListTunnelConnections(ctx, &trustpb.ListTunnelConnectionsRequest{
-		Filter: &trustpb.ListTunnelConnectionsFilter{ClusterName: clusterName},
-	})
+	resp, err := clt.TrustClient().ListTunnelConnections(ctx, trustpb.ListTunnelConnectionsRequest_builder{
+		Filter: trustpb.ListTunnelConnectionsFilter_builder{ClusterName: clusterName}.Build(),
+	}.Build())
 	require.NoError(t, err)
 	require.Len(t, resp.GetTunnelConnections(), 3)
 
-	resp, err = clt.TrustClient().ListTunnelConnections(ctx, &trustpb.ListTunnelConnectionsRequest{
-		Filter: &trustpb.ListTunnelConnectionsFilter{ClusterName: "other.example.com"},
-	})
+	resp, err = clt.TrustClient().ListTunnelConnections(ctx, trustpb.ListTunnelConnectionsRequest_builder{
+		Filter: trustpb.ListTunnelConnectionsFilter_builder{ClusterName: "other.example.com"}.Build(),
+	}.Build())
 	require.NoError(t, err)
 	require.Empty(t, resp.GetTunnelConnections())
 }

--- a/lib/auth/trust/trustv1/tunnelconnection_test.go
+++ b/lib/auth/trust/trustv1/tunnelconnection_test.go
@@ -267,9 +267,9 @@ func TestListTunnelConnections(t *testing.T) {
 		},
 		{
 			name: "success filter by cluster",
-			req: &trustpb.ListTunnelConnectionsRequest{
-				Filter: &trustpb.ListTunnelConnectionsFilter{ClusterName: leaf1},
-			},
+			req: trustpb.ListTunnelConnectionsRequest_builder{
+				Filter: trustpb.ListTunnelConnectionsFilter_builder{ClusterName: leaf1}.Build(),
+			}.Build(),
 			allow:     map[check]bool{{types.KindTunnelConnection, types.VerbList}: true, {types.KindTunnelConnection, types.VerbRead}: true},
 			assertErr: require.NoError,
 			want: want{
@@ -279,9 +279,9 @@ func TestListTunnelConnections(t *testing.T) {
 		},
 		{
 			name: "success filter unknown cluster returns empty",
-			req: &trustpb.ListTunnelConnectionsRequest{
-				Filter: &trustpb.ListTunnelConnectionsFilter{ClusterName: "nonexistent"},
-			},
+			req: trustpb.ListTunnelConnectionsRequest_builder{
+				Filter: trustpb.ListTunnelConnectionsFilter_builder{ClusterName: "nonexistent"}.Build(),
+			}.Build(),
 			allow:     map[check]bool{{types.KindTunnelConnection, types.VerbList}: true, {types.KindTunnelConnection, types.VerbRead}: true},
 			assertErr: require.NoError,
 		},
@@ -361,10 +361,10 @@ func TestListTunnelConnections_Pagination(t *testing.T) {
 	var gotNames []string
 	var pageToken string
 	for {
-		resp, err := service.ListTunnelConnections(ctx, &trustpb.ListTunnelConnectionsRequest{
+		resp, err := service.ListTunnelConnections(ctx, trustpb.ListTunnelConnectionsRequest_builder{
 			PageSize:  2,
 			PageToken: pageToken,
-		})
+		}.Build())
 		require.NoError(t, err)
 		for _, c := range resp.GetTunnelConnections() {
 			gotNames = append(gotNames, c.GetName())

--- a/lib/cache/remote_cluster_test.go
+++ b/lib/cache/remote_cluster_test.go
@@ -178,9 +178,9 @@ func TestTunnelConnections(t *testing.T) {
 		require.Len(t, all, 20)
 
 		// Filter by cluster name should only return matching tunnel connections.
-		filtered, next, err := p.cache.ListTunnelConnections(ctx, 0, "", &trustpb.ListTunnelConnectionsFilter{
+		filtered, next, err := p.cache.ListTunnelConnections(ctx, 0, "", trustpb.ListTunnelConnectionsFilter_builder{
 			ClusterName: clusterName,
-		})
+		}.Build())
 		require.NoError(t, err)
 		require.Empty(t, next)
 		require.Len(t, filtered, 17)
@@ -188,9 +188,9 @@ func TestTunnelConnections(t *testing.T) {
 			require.Equal(t, clusterName, tc.GetClusterName())
 		}
 
-		filtered, next, err = p.cache.ListTunnelConnections(ctx, 0, "", &trustpb.ListTunnelConnectionsFilter{
+		filtered, next, err = p.cache.ListTunnelConnections(ctx, 0, "", trustpb.ListTunnelConnectionsFilter_builder{
 			ClusterName: "other-cluster",
-		})
+		}.Build())
 		require.NoError(t, err)
 		require.Empty(t, next)
 		require.Len(t, filtered, 3)
@@ -199,9 +199,9 @@ func TestTunnelConnections(t *testing.T) {
 		}
 
 		// Filter for a cluster with no tunnel connections.
-		filtered, next, err = p.cache.ListTunnelConnections(ctx, 0, "", &trustpb.ListTunnelConnectionsFilter{
+		filtered, next, err = p.cache.ListTunnelConnections(ctx, 0, "", trustpb.ListTunnelConnectionsFilter_builder{
 			ClusterName: "does-not-exist",
-		})
+		}.Build())
 		require.NoError(t, err)
 		require.Empty(t, next)
 		require.Empty(t, filtered)
@@ -211,9 +211,9 @@ func TestTunnelConnections(t *testing.T) {
 		pageToken = ""
 		pages := 0
 		for {
-			page, next, err := p.cache.ListTunnelConnections(ctx, 5, pageToken, &trustpb.ListTunnelConnectionsFilter{
+			page, next, err := p.cache.ListTunnelConnections(ctx, 5, pageToken, trustpb.ListTunnelConnectionsFilter_builder{
 				ClusterName: clusterName,
-			})
+			}.Build())
 			require.NoError(t, err)
 			require.LessOrEqual(t, len(page), 5)
 			pages++

--- a/lib/cache/workload_identity_test.go
+++ b/lib/cache/workload_identity_test.go
@@ -377,6 +377,6 @@ func TestWorkloadIdentityCaseSensitiveName(t *testing.T) {
 	// name sorts before the uppercase one.
 	results := collectWorkloadIdentities(t, p.cache.RangeWorkloadIdentities(ctx, "", "", "name", true))
 	require.Len(t, results, 2)
-	require.Equal(t, "test-workload-identity-1", results[0].Metadata.Name)
-	require.Equal(t, "TEST-WORKLOAD-IDENTITY-1", results[1].Metadata.Name)
+	require.Equal(t, "test-workload-identity-1", results[0].GetMetadata().GetName())
+	require.Equal(t, "TEST-WORKLOAD-IDENTITY-1", results[1].GetMetadata().GetName())
 }

--- a/lib/client/ssh/ssh_test.go
+++ b/lib/client/ssh/ssh_test.go
@@ -117,9 +117,7 @@ func TestKeyboardInteractive_InvalidAuthPrompt_NilPromptField(t *testing.T) {
 	)
 	require.NotNil(t, authMethod)
 
-	mfaPrompt := &sshpb.AuthPrompt{
-		Prompt: nil,
-	}
+	mfaPrompt := sshpb.AuthPrompt_builder{}.Build()
 	mfaPromptJSON, err := protojson.Marshal(mfaPrompt)
 	require.NoError(t, err)
 

--- a/lib/devicetrust/native/device_linux.go
+++ b/lib/devicetrust/native/device_linux.go
@@ -180,7 +180,7 @@ func collectDeviceData(mode CollectDataMode) (*devicepb.DeviceCollectedData, err
 		displayName = displayName[:maxUsernameLen]
 	}
 
-	return &devicepb.DeviceCollectedData{
+	return devicepb.DeviceCollectedData_builder{
 		CollectTime:           timestamppb.Now(),
 		OsType:                devicepb.OSType_OS_TYPE_LINUX,
 		SerialNumber:          firstValidAssetTag(reportedAssetTag, systemSerialNumber, baseBoardSerialNumber),
@@ -193,7 +193,7 @@ func collectDeviceData(mode CollectDataMode) (*devicepb.DeviceCollectedData, err
 		ReportedAssetTag:      reportedAssetTag,
 		SystemSerialNumber:    systemSerialNumber,
 		BaseBoardSerialNumber: baseBoardSerialNumber,
-	}, nil
+	}.Build(), nil
 }
 
 func readDMIInfoAccordingToMode(mode CollectDataMode) (*linux.DMIInfo, error) {

--- a/lib/devicetrust/native/device_linux_test.go
+++ b/lib/devicetrust/native/device_linux_test.go
@@ -48,7 +48,7 @@ func TestCollectDeviceData_linux(t *testing.T) {
 	u, err := user.Current()
 	require.NoError(t, err, "reading current user")
 
-	wantCD := &devicepb.DeviceCollectedData{
+	wantCD := devicepb.DeviceCollectedData_builder{
 		CollectTime:           nil, // Verified by test body.
 		OsType:                devicepb.OSType_OS_TYPE_LINUX,
 		SerialNumber:          "PF0A0AAA",
@@ -61,14 +61,14 @@ func TestCollectDeviceData_linux(t *testing.T) {
 		SystemSerialNumber:    "PF0A0AAA",
 		BaseBoardSerialNumber: "L1AA00A00A0",
 		OsId:                  "ubuntu",
-	}
+	}.Build()
 
 	dmiInfoSuccess := func() (*linux.DMIInfo, error) {
 		return &linux.DMIInfo{
-			ProductName:     wantCD.ModelIdentifier,
-			ProductSerial:   wantCD.SystemSerialNumber,
-			BoardSerial:     wantCD.BaseBoardSerialNumber,
-			ChassisAssetTag: wantCD.ReportedAssetTag,
+			ProductName:     wantCD.GetModelIdentifier(),
+			ProductSerial:   wantCD.GetSystemSerialNumber(),
+			BoardSerial:     wantCD.GetBaseBoardSerialNumber(),
+			ChassisAssetTag: wantCD.GetReportedAssetTag(),
 		}, nil
 	}
 	dmiInfoPermissionError := func() (*linux.DMIInfo, error) {
@@ -81,9 +81,9 @@ func TestCollectDeviceData_linux(t *testing.T) {
 	// Default configuration reflects a successful DMI read with an empty cache.
 	cddFuncs.parseOSRelease = func() (*linux.OSRelease, error) {
 		return &linux.OSRelease{
-			VersionID: wantCD.OsVersion,
-			Version:   wantCD.OsBuild,
-			ID:        wantCD.OsId,
+			VersionID: wantCD.GetOsVersion(),
+			Version:   wantCD.GetOsBuild(),
+			ID:        wantCD.GetOsId(),
 		}, nil
 	}
 	cddFuncs.dmiInfoFromSysfs = dmiInfoSuccess
@@ -152,7 +152,7 @@ func TestCollectDeviceData_linux(t *testing.T) {
 			mode: CollectedDataNeverEscalate,
 			dmiFromSysfsOverride: func() (*linux.DMIInfo, error) {
 				return &linux.DMIInfo{
-					ProductName: wantCD.ModelIdentifier,
+					ProductName: wantCD.GetModelIdentifier(),
 				}, fs.ErrPermission
 			},
 			dmiFromCacheOverride: dmiInfoCacheNotFound,
@@ -161,10 +161,10 @@ func TestCollectDeviceData_linux(t *testing.T) {
 			},
 			want: func() *devicepb.DeviceCollectedData {
 				cp := proto.Clone(wantCD).(*devicepb.DeviceCollectedData)
-				cp.SerialNumber = ""
-				cp.ReportedAssetTag = ""
-				cp.SystemSerialNumber = ""
-				cp.BaseBoardSerialNumber = ""
+				cp.SetSerialNumber("")
+				cp.SetReportedAssetTag("")
+				cp.SetSystemSerialNumber("")
+				cp.SetBaseBoardSerialNumber("")
 				return cp
 			}(),
 		},
@@ -194,10 +194,10 @@ func TestCollectDeviceData_linux(t *testing.T) {
 
 			got, err := CollectDeviceData(test.mode)
 			require.NoError(t, err, "CollectDeviceData")
-			assert.NotNil(t, got.CollectTime, "CollectTime must not be nil")
+			assert.NotNil(t, got.GetCollectTime(), "CollectTime must not be nil")
 
 			want := test.want
-			want.CollectTime = got.CollectTime
+			want.SetCollectTime(got.GetCollectTime())
 			if diff := cmp.Diff(want, got, protocmp.Transform()); diff != "" {
 				t.Errorf("CollectDeviceData mismatch (-want +got)\n%s", diff)
 			}

--- a/lib/devicetrust/native/tpm_device.go
+++ b/lib/devicetrust/native/tpm_device.go
@@ -33,6 +33,7 @@ import (
 
 	"github.com/google/go-attestation/attest"
 	"github.com/gravitational/trace"
+	"google.golang.org/protobuf/proto"
 
 	"github.com/gravitational/teleport"
 	devicepb "github.com/gravitational/teleport/api/gen/proto/go/teleport/devicetrust/v1"
@@ -172,30 +173,26 @@ func (d *tpmDevice) enrollDeviceInit() (*devicepb.EnrollDeviceInit, error) {
 		return nil, trace.Wrap(err, "determining credential id")
 	}
 
-	enrollPayload := &devicepb.TPMEnrollPayload{
+	enrollPayload := devicepb.TPMEnrollPayload_builder{
 		AttestationParameters: devicetrust.AttestationParametersToProto(
 			ak.AttestationParameters(),
 		),
-	}
+	}.Build()
 	switch {
 	// Prefer ekCert over ekPub
 	case ekCert != nil:
-		enrollPayload.Ek = &devicepb.TPMEnrollPayload_EkCert{
-			EkCert: ekCert,
-		}
+		enrollPayload.SetEkCert(proto.ValueOrDefaultBytes(ekCert))
 	case ekKey != nil:
-		enrollPayload.Ek = &devicepb.TPMEnrollPayload_EkKey{
-			EkKey: ekKey,
-		}
+		enrollPayload.SetEkKey(proto.ValueOrDefaultBytes(ekKey))
 	default:
 		return nil, trace.BadParameter("tpm has neither ek_key or ek_cert")
 	}
 
-	return &devicepb.EnrollDeviceInit{
+	return devicepb.EnrollDeviceInit_builder{
 		CredentialId: credentialID,
 		DeviceData:   deviceData,
 		Tpm:          enrollPayload,
-	}, nil
+	}.Build(), nil
 }
 
 // credentialIDFromAK produces a deterministic, short-ish, unique-ish, printable
@@ -261,9 +258,9 @@ func (d *tpmDevice) getDeviceCredential() (*devicepb.DeviceCredential, error) {
 		return nil, trace.Wrap(err, "determining credential id")
 	}
 
-	return &devicepb.DeviceCredential{
+	return devicepb.DeviceCredential_builder{
 		Id: credentialID,
-	}, nil
+	}.Build(), nil
 }
 
 func (d *tpmDevice) solveTPMEnrollChallenge(
@@ -296,7 +293,7 @@ func (d *tpmDevice) solveTPMEnrollChallenge(
 	defer ak.Close(tpm)
 
 	// Next perform a platform attestation using the AK.
-	platformsParams, err := attestPlatform(tpm, ak, challenge.AttestationNonce)
+	platformsParams, err := attestPlatform(tpm, ak, challenge.GetAttestationNonce())
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -305,7 +302,7 @@ func (d *tpmDevice) solveTPMEnrollChallenge(
 	// auth server.
 	logger.DebugContext(ctx, "Activating credential")
 	encryptedCredential := devicetrust.EncryptedCredentialFromProto(
-		challenge.EncryptedCredential,
+		challenge.GetEncryptedCredential(),
 	)
 	if encryptedCredential == nil {
 		return nil, trace.BadParameter("missing encrypted credential in challenge from server")
@@ -343,12 +340,12 @@ func (d *tpmDevice) solveTPMEnrollChallenge(
 	}
 
 	logger.DebugContext(ctx, "Enrollment challenge completed.")
-	return &devicepb.TPMEnrollChallengeResponse{
+	return devicepb.TPMEnrollChallengeResponse_builder{
 		Solution: activationSolution,
 		PlatformParameters: devicetrust.PlatformParametersToProto(
 			platformsParams,
 		),
-	}, nil
+	}.Build(), nil
 }
 
 //nolint:unused // Used by Windows builds.
@@ -435,17 +432,17 @@ func (d *tpmDevice) solveTPMAuthnDeviceChallenge(
 	defer ak.Close(tpm)
 
 	// Next perform a platform attestation using the AK.
-	platformsParams, err := attestPlatform(tpm, ak, challenge.AttestationNonce)
+	platformsParams, err := attestPlatform(tpm, ak, challenge.GetAttestationNonce())
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
 	logger.DebugContext(ctx, "Authenticate device challenge completed")
-	return &devicepb.TPMAuthenticateDeviceChallengeResponse{
+	return devicepb.TPMAuthenticateDeviceChallengeResponse_builder{
 		PlatformParameters: devicetrust.PlatformParametersToProto(
 			platformsParams,
 		),
-	}, nil
+	}.Build(), nil
 }
 
 func attestPlatform(tpm *attest.TPM, ak *attest.AK, nonce []byte) (*attest.PlatformParameters, error) {

--- a/lib/integrations/awsra/list_rolesanywhere_profiles_test.go
+++ b/lib/integrations/awsra/list_rolesanywhere_profiles_test.go
@@ -26,9 +26,9 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/rolesanywhere"
 	ratypes "github.com/aws/aws-sdk-go-v2/service/rolesanywhere/types"
 	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/testing/protocmp"
 
 	integrationv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/integration/v1"
 )
@@ -182,16 +182,13 @@ func TestListRolesAnywhereProfilesPage(t *testing.T) {
 			},
 			expectedResp: func(t *testing.T, page []*integrationv1.RolesAnywhereProfile) {
 				require.Len(t, page, 5)
-				cmpOpts := []cmp.Option{
-					cmpopts.IgnoreUnexported(integrationv1.RolesAnywhereProfile{}),
-				}
 				require.Empty(t, cmp.Diff(page, []*integrationv1.RolesAnywhereProfile{
 					integrationv1.RolesAnywhereProfile_builder{Arn: "arn:aws:rolesanywhere:eu-west-2:123456789012:profile/id2", Name: "TeamA-subteam2", Tags: make(map[string]string)}.Build(),
 					integrationv1.RolesAnywhereProfile_builder{Arn: "arn:aws:rolesanywhere:eu-west-2:123456789012:profile/id3", Name: "TeamA-subteam3", Tags: make(map[string]string)}.Build(),
 					integrationv1.RolesAnywhereProfile_builder{Arn: "arn:aws:rolesanywhere:eu-west-2:123456789012:profile/id4", Name: "TeamB-subteam1", Tags: make(map[string]string)}.Build(),
 					integrationv1.RolesAnywhereProfile_builder{Arn: "arn:aws:rolesanywhere:eu-west-2:123456789012:profile/id5", Name: "TeamB-subteam2", Tags: make(map[string]string)}.Build(),
 					integrationv1.RolesAnywhereProfile_builder{Arn: "arn:aws:rolesanywhere:eu-west-2:123456789012:profile/id6", Name: "TeamB-subteam3", Tags: make(map[string]string)}.Build(),
-				}, cmpOpts...))
+				}, protocmp.Transform()))
 			},
 			expectedErrCheck: require.NoError,
 		},

--- a/lib/kube/proxy/exec_test.go
+++ b/lib/kube/proxy/exec_test.go
@@ -127,37 +127,37 @@ func TestExecKubeService(t *testing.T) {
 		t,
 		"scoped-"+username,
 		scopedTestScope,
-		&accessv1.ScopedRoleSpec{
+		accessv1.ScopedRoleSpec_builder{
 			AssignableScopes: []string{scopedTestScope},
-			Kube: &accessv1.ScopedRoleKube{
+			Kube: accessv1.ScopedRoleKube_builder{
 				Users:  roleKubeUsers,
 				Groups: roleKubeGroups,
 				Labels: []*labelv1.Label{
-					{
+					labelv1.Label_builder{
 						Name:   types.Wildcard,
 						Values: []string{types.Wildcard},
-					},
+					}.Build(),
 				},
-			},
-		})
+			}.Build(),
+		}.Build())
 
 	scopedMultiKubeUsers, scopedMultiKubeUserRole := testCtx.CreateUserAndScopedRole(
 		t,
 		"scoped-"+usernameMultiUsers,
 		scopedTestScope,
-		&accessv1.ScopedRoleSpec{
+		accessv1.ScopedRoleSpec_builder{
 			AssignableScopes: []string{scopedTestScope},
-			Kube: &accessv1.ScopedRoleKube{
+			Kube: accessv1.ScopedRoleKube_builder{
 				Users:  append(slices.Clone(roleKubeUsers), "admin"),
 				Groups: roleKubeGroups,
 				Labels: []*labelv1.Label{
-					{
+					labelv1.Label_builder{
 						Name:   types.Wildcard,
 						Values: []string{types.Wildcard},
-					},
+					}.Build(),
 				},
-			},
-		},
+			}.Build(),
+		}.Build(),
 	)
 	waitForSRACache(t, testCtx.TLSServer, scopedSingleKubeUserRole, scopedMultiKubeUserRole)
 
@@ -556,19 +556,19 @@ func TestExecMissingGETPermissionError(t *testing.T) {
 					t,
 					"scoped-"+username,
 					scopedTestScope,
-					&accessv1.ScopedRoleSpec{
+					accessv1.ScopedRoleSpec_builder{
 						AssignableScopes: []string{scopedTestScope},
-						Kube: &accessv1.ScopedRoleKube{
+						Kube: accessv1.ScopedRoleKube_builder{
 							Users:  roleKubeUsers,
 							Groups: roleKubeGroups,
 							Labels: []*labelv1.Label{
-								{
+								labelv1.Label_builder{
 									Name:   types.Wildcard,
 									Values: []string{types.Wildcard},
-								},
+								}.Build(),
 							},
-						},
-					})
+						}.Build(),
+					}.Build())
 
 				waitForSRACache(t, testCtx.TLSServer, scopedUserRole)
 
@@ -785,10 +785,10 @@ func waitForSRACache(t *testing.T, srv *authtest.TLSServer, resps ...*accessv1.C
 	ctx := t.Context()
 	require.EventuallyWithT(t, func(t *assert.CollectT) {
 		for _, resp := range resps {
-			_, err := srv.Auth().ScopedAccessCache.GetScopedRoleAssignment(ctx, &accessv1.GetScopedRoleAssignmentRequest{
+			_, err := srv.Auth().ScopedAccessCache.GetScopedRoleAssignment(ctx, accessv1.GetScopedRoleAssignmentRequest_builder{
 				Name:    resp.GetAssignment().GetMetadata().GetName(),
 				SubKind: resp.GetAssignment().GetSubKind(),
-			})
+			}.Build())
 			require.NoError(t, err)
 		}
 	}, 10*time.Second, 100*time.Millisecond)

--- a/lib/kube/proxy/forwarder_test.go
+++ b/lib/kube/proxy/forwarder_test.go
@@ -1744,13 +1744,13 @@ func (ap mockAccessPoint) GetCertAuthority(ctx context.Context, id types.CertAut
 
 func (ap mockAccessPoint) GetScopedRole(ctx context.Context, req *scopedaccessv1.GetScopedRoleRequest) (*scopedaccessv1.GetScopedRoleResponse, error) {
 	if role, ok := ap.scopedRoles[req.GetName()]; ok {
-		return &scopedaccessv1.GetScopedRoleResponse{Role: role}, nil
+		return scopedaccessv1.GetScopedRoleResponse_builder{Role: role}.Build(), nil
 	}
 	return nil, trace.NotFound("role %q not found", req.GetName())
 }
 
 func (ap mockAccessPoint) ListScopedRoles(ctx context.Context, req *scopedaccessv1.ListScopedRolesRequest) (*scopedaccessv1.ListScopedRolesResponse, error) {
-	return &scopedaccessv1.ListScopedRolesResponse{Roles: slices.Collect(maps.Values(ap.scopedRoles))}, nil
+	return scopedaccessv1.ListScopedRolesResponse_builder{Roles: slices.Collect(maps.Values(ap.scopedRoles))}.Build(), nil
 }
 
 type mockRevTunnel struct {

--- a/lib/kube/proxy/resource_rbac_test.go
+++ b/lib/kube/proxy/resource_rbac_test.go
@@ -127,19 +127,19 @@ func TestListPodRBAC(t *testing.T) {
 		t,
 		"scoped-"+usernameWithFullAccess,
 		scope,
-		&accessv1.ScopedRoleSpec{
+		accessv1.ScopedRoleSpec_builder{
 			AssignableScopes: []string{scope},
-			Kube: &accessv1.ScopedRoleKube{
+			Kube: accessv1.ScopedRoleKube_builder{
 				Users:  roleKubeUsers,
 				Groups: roleKubeGroups,
 				Labels: []*labelv1.Label{
-					{
+					labelv1.Label_builder{
 						Name:   types.Wildcard,
 						Values: []string{types.Wildcard},
-					},
+					}.Build(),
 				},
-			},
-		})
+			}.Build(),
+		}.Build())
 	waitForSRACache(t, testCtx.TLSServer, scopedRoleWithFullAccess)
 
 	// create a user with full access to kubernetes Pods.
@@ -1187,19 +1187,19 @@ func TestDeletePodCollectionRBAC(t *testing.T) {
 		t,
 		"scoped-"+usernameWithFullAccess,
 		scope,
-		&accessv1.ScopedRoleSpec{
+		accessv1.ScopedRoleSpec_builder{
 			AssignableScopes: []string{scope},
-			Kube: &accessv1.ScopedRoleKube{
+			Kube: accessv1.ScopedRoleKube_builder{
 				Users:  roleKubeUsers,
 				Groups: roleKubeGroups,
 				Labels: []*labelv1.Label{
-					{
+					labelv1.Label_builder{
 						Name:   types.Wildcard,
 						Values: []string{types.Wildcard},
-					},
+					}.Build(),
 				},
-			},
-		})
+			}.Build(),
+		}.Build())
 	waitForSRACache(t, testCtx.TLSServer, scopedRoleWithFullAccess)
 
 	// create a user with full access to kubernetes Pods.
@@ -1427,19 +1427,19 @@ func TestDeleteCRDCollectionRBAC(t *testing.T) {
 		t,
 		"scoped-"+usernameWithFullAccess,
 		scope,
-		&accessv1.ScopedRoleSpec{
+		accessv1.ScopedRoleSpec_builder{
 			AssignableScopes: []string{scope},
-			Kube: &accessv1.ScopedRoleKube{
+			Kube: accessv1.ScopedRoleKube_builder{
 				Users:  roleKubeUsers,
 				Groups: roleKubeGroups,
 				Labels: []*labelv1.Label{
-					{
+					labelv1.Label_builder{
 						Name:   types.Wildcard,
 						Values: []string{types.Wildcard},
-					},
+					}.Build(),
 				},
-			},
-		})
+			}.Build(),
+		}.Build())
 	waitForSRACache(t, testCtx.TLSServer, scopedRoleWithFullAccess)
 
 	// create a user with full access to kubernetes Pods.
@@ -1672,19 +1672,19 @@ func TestListClusterRoleRBAC(t *testing.T) {
 		t,
 		"scoped-"+usernameWithFullAccess,
 		scope,
-		&accessv1.ScopedRoleSpec{
+		accessv1.ScopedRoleSpec_builder{
 			AssignableScopes: []string{scope},
-			Kube: &accessv1.ScopedRoleKube{
+			Kube: accessv1.ScopedRoleKube_builder{
 				Users:  roleKubeUsers,
 				Groups: roleKubeGroups,
 				Labels: []*labelv1.Label{
-					{
+					labelv1.Label_builder{
 						Name:   types.Wildcard,
 						Values: []string{types.Wildcard},
-					},
+					}.Build(),
 				},
-			},
-		})
+			}.Build(),
+		}.Build())
 	waitForSRACache(t, testCtx.TLSServer, scopedRoleWithFullAccess)
 
 	// Create a moderator user with access to kubernetes
@@ -1909,19 +1909,19 @@ func TestGenericCustomResourcesRBAC(t *testing.T) {
 		t,
 		"scoped-"+usernameWithFullAccess,
 		scope,
-		&accessv1.ScopedRoleSpec{
+		accessv1.ScopedRoleSpec_builder{
 			AssignableScopes: []string{scope},
-			Kube: &accessv1.ScopedRoleKube{
+			Kube: accessv1.ScopedRoleKube_builder{
 				Users:  roleKubeUsers,
 				Groups: roleKubeGroups,
 				Labels: []*labelv1.Label{
-					{
+					labelv1.Label_builder{
 						Name:   types.Wildcard,
 						Values: []string{types.Wildcard},
-					},
+					}.Build(),
 				},
-			},
-		})
+			}.Build(),
+		}.Build())
 	waitForSRACache(t, testCtx.TLSServer, scopedRoleWithFullAccess)
 
 	// create a user with limited access to kubernetes namespaces.

--- a/lib/kube/proxy/utils_test.go
+++ b/lib/kube/proxy/utils_test.go
@@ -551,39 +551,39 @@ func (c *TestContext) CreateUserAndScopedRole(t *testing.T, username, scope stri
 	require.NoError(t, err)
 
 	scopedAccess := c.TLSServer.Auth().ScopedAccess()
-	role, err := scopedAccess.CreateScopedRole(t.Context(), &accessv1.CreateScopedRoleRequest{
-		Role: &accessv1.ScopedRole{
+	role, err := scopedAccess.CreateScopedRole(t.Context(), accessv1.CreateScopedRoleRequest_builder{
+		Role: accessv1.ScopedRole_builder{
 			Kind:    access.KindScopedRole,
 			Version: types.V1,
-			Metadata: &headerv1.Metadata{
+			Metadata: headerv1.Metadata_builder{
 				Name: username,
-			},
+			}.Build(),
 			Scope: scope,
 			Spec:  roleSpec,
-		},
-	})
+		}.Build(),
+	}.Build())
 	require.NoError(t, err)
 
-	assignment, err := scopedAccess.CreateScopedRoleAssignment(t.Context(), &accessv1.CreateScopedRoleAssignmentRequest{
-		Assignment: &accessv1.ScopedRoleAssignment{
+	assignment, err := scopedAccess.CreateScopedRoleAssignment(t.Context(), accessv1.CreateScopedRoleAssignmentRequest_builder{
+		Assignment: accessv1.ScopedRoleAssignment_builder{
 			Kind:    access.KindScopedRoleAssignment,
 			Version: types.V1,
 			SubKind: access.SubKindDynamic,
 			Scope:   scope,
-			Metadata: &headerv1.Metadata{
+			Metadata: headerv1.Metadata_builder{
 				Name: uuid.New().String(),
-			},
-			Spec: &accessv1.ScopedRoleAssignmentSpec{
+			}.Build(),
+			Spec: accessv1.ScopedRoleAssignmentSpec_builder{
 				User: username,
 				Assignments: []*accessv1.Assignment{
-					{
+					accessv1.Assignment_builder{
 						Role:  role.GetRole().GetMetadata().GetName(),
 						Scope: scope,
-					},
+					}.Build(),
 				},
-			},
-		},
-	})
+			}.Build(),
+		}.Build(),
+	}.Build())
 	require.NoError(t, err)
 
 	return user, assignment
@@ -803,10 +803,10 @@ func (f *fakeCluster) DialTCP(p reversetunnelclient.DialParams) (conn net.Conn, 
 }
 
 func (c *TestContext) GetScopePinForUser(t *testing.T, username, scope string) *scopesv1.Pin {
-	pin := &scopesv1.Pin{
+	pin := scopesv1.Pin_builder{
 		Kind:  scopesv1.PinKind_PIN_KIND_USER,
 		Scope: scope,
-	}
+	}.Build()
 	err := c.AuthServer.ScopedAccessCache.PopulatePinnedAssignmentsForUser(t.Context(), username, pin)
 	require.NoError(t, err)
 

--- a/lib/mobile/verify/enroll/enroll.go
+++ b/lib/mobile/verify/enroll/enroll.go
@@ -89,9 +89,9 @@ func (c *Client) CreateMobileEnrollToken(pairingToken string, deviceData *Device
 	// TODO(ravicious): Replace this with a call to the public gRPC service.
 	client := devicepb.NewDeviceTrustServiceClient(grpcConn)
 	resp, err := client.CreateDeviceEnrollToken(ctx,
-		&devicepb.CreateDeviceEnrollTokenRequest{
+		devicepb.CreateDeviceEnrollTokenRequest_builder{
 			DeviceData: toPBDeviceData(deviceData),
-		})
+		}.Build())
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -107,12 +107,12 @@ func toPBDeviceData(d *DeviceCollectedData) *devicepb.DeviceCollectedData {
 	if d == nil {
 		d = &DeviceCollectedData{}
 	}
-	return &devicepb.DeviceCollectedData{
+	return devicepb.DeviceCollectedData_builder{
 		CollectTime:        timestamppb.Now(),
 		SerialNumber:       d.SerialNumber,
 		ModelIdentifier:    d.ModelIdentifier,
 		OsVersion:          d.VersionOS,
 		OsBuild:            d.BuildOS,
 		SystemSerialNumber: d.SystemSerialNumber,
-	}
+	}.Build()
 }

--- a/lib/scopes/access/compat_test.go
+++ b/lib/scopes/access/compat_test.go
@@ -260,7 +260,11 @@ func TestX11ForwardingNotInClassicRole(t *testing.T) {
 	t.Parallel()
 
 	sr := baseScopedRole()
-	sr.GetSpec().GetSsh().PermitX11Forwarding = ptr(true)
+	if x := ptr(true); x != nil {
+		sr.GetSpec().GetSsh().SetPermitX11Forwarding(*x)
+	} else {
+		sr.GetSpec().GetSsh().ClearPermitX11Forwarding()
+	}
 
 	role, err := ScopedRoleToRole(sr, "/foo/bar")
 	require.NoError(t, err)
@@ -271,7 +275,11 @@ func TestForwardAgentNotInClassicRole(t *testing.T) {
 	t.Parallel()
 
 	sr := baseScopedRole()
-	sr.GetSpec().GetSsh().ForwardAgent = ptr(true)
+	if x := ptr(true); x != nil {
+		sr.GetSpec().GetSsh().SetForwardAgent(*x)
+	} else {
+		sr.GetSpec().GetSsh().ClearForwardAgent()
+	}
 
 	role, err := ScopedRoleToRole(sr, "/foo/bar")
 	require.NoError(t, err)
@@ -282,7 +290,11 @@ func TestMaxSessionsNotInClassicRole(t *testing.T) {
 	t.Parallel()
 
 	sr := baseScopedRole()
-	sr.GetSpec().GetSsh().MaxSessions = ptr(int64(10))
+	if x := ptr(int64(10)); x != nil {
+		sr.GetSpec().GetSsh().SetMaxSessions(*x)
+	} else {
+		sr.GetSpec().GetSsh().ClearMaxSessions()
+	}
 
 	role, err := ScopedRoleToRole(sr, "/foo/bar")
 	require.NoError(t, err)
@@ -320,7 +332,11 @@ func TestSSHFileCopyNotInClassicRole(t *testing.T) {
 	t.Parallel()
 
 	sr := baseScopedRole()
-	sr.GetSpec().GetSsh().FileCopy = ptr(false)
+	if x := ptr(false); x != nil {
+		sr.GetSpec().GetSsh().SetFileCopy(*x)
+	} else {
+		sr.GetSpec().GetSsh().ClearFileCopy()
+	}
 
 	role, err := ScopedRoleToRole(sr, "/foo/bar")
 	require.NoError(t, err)
@@ -346,7 +362,11 @@ func TestDisconnectExpiredCertNotInClassicRole(t *testing.T) {
 	t.Parallel()
 
 	sr := baseScopedRole()
-	sr.GetSpec().GetSsh().DisconnectExpiredCert = ptr(true)
+	if x := ptr(true); x != nil {
+		sr.GetSpec().GetSsh().SetDisconnectExpiredCert(*x)
+	} else {
+		sr.GetSpec().GetSsh().ClearDisconnectExpiredCert()
+	}
 
 	role, err := ScopedRoleToRole(sr, "/foo/bar")
 	require.NoError(t, err)

--- a/lib/services/appauthconfig_test.go
+++ b/lib/services/appauthconfig_test.go
@@ -52,12 +52,12 @@ func TestValidatAppAuthConfig(t *testing.T) {
 					Metadata: headerv1.Metadata_builder{
 						Name: "example",
 					}.Build(),
-					Spec: &appauthconfigv1.AppAuthConfigSpec{
+					Spec: appauthconfigv1.AppAuthConfigSpec_builder{
 						AppLabels: []*labelv1.Label{
 							labelv1.Label_builder{Name: "*", Values: []string{"*"}}.Build(),
 						},
-						SubKindSpec: validConfig,
-					},
+						Jwt: proto.ValueOrDefault(validConfig.Jwt),
+					}.Build(),
 				}.Build(),
 				assertErr: require.NoError,
 			},
@@ -68,12 +68,12 @@ func TestValidatAppAuthConfig(t *testing.T) {
 					Metadata: headerv1.Metadata_builder{
 						Name: "example",
 					}.Build(),
-					Spec: &appauthconfigv1.AppAuthConfigSpec{
+					Spec: appauthconfigv1.AppAuthConfigSpec_builder{
 						AppLabels: []*labelv1.Label{
 							labelv1.Label_builder{Name: "*", Values: []string{"*"}}.Build(),
 						},
-						SubKindSpec: validConfig,
-					},
+						Jwt: proto.ValueOrDefault(validConfig.Jwt),
+					}.Build(),
 				}.Build(),
 				assertErr: require.Error,
 			},
@@ -81,12 +81,12 @@ func TestValidatAppAuthConfig(t *testing.T) {
 				res: appauthconfigv1.AppAuthConfig_builder{
 					Version: types.V1,
 					Kind:    types.KindAppAuthConfig,
-					Spec: &appauthconfigv1.AppAuthConfigSpec{
+					Spec: appauthconfigv1.AppAuthConfigSpec_builder{
 						AppLabels: []*labelv1.Label{
 							labelv1.Label_builder{Name: "*", Values: []string{"*"}}.Build(),
 						},
-						SubKindSpec: validConfig,
-					},
+						Jwt: proto.ValueOrDefault(validConfig.Jwt),
+					}.Build(),
 				}.Build(),
 				assertErr: require.Error,
 			},
@@ -97,9 +97,9 @@ func TestValidatAppAuthConfig(t *testing.T) {
 					Metadata: headerv1.Metadata_builder{
 						Name: "example",
 					}.Build(),
-					Spec: &appauthconfigv1.AppAuthConfigSpec{
-						SubKindSpec: validConfig,
-					},
+					Spec: appauthconfigv1.AppAuthConfigSpec_builder{
+						Jwt: proto.ValueOrDefault(validConfig.Jwt),
+					}.Build(),
 				}.Build(),
 				assertErr: require.Error,
 			},
@@ -110,12 +110,12 @@ func TestValidatAppAuthConfig(t *testing.T) {
 					Metadata: headerv1.Metadata_builder{
 						Name: "example",
 					}.Build(),
-					Spec: &appauthconfigv1.AppAuthConfigSpec{
+					Spec: appauthconfigv1.AppAuthConfigSpec_builder{
 						AppLabels: []*labelv1.Label{
 							labelv1.Label_builder{Name: "*", Values: []string{"some-random-value"}}.Build(),
 						},
-						SubKindSpec: validConfig,
-					},
+						Jwt: proto.ValueOrDefault(validConfig.Jwt),
+					}.Build(),
 				}.Build(),
 				assertErr: require.Error,
 			},

--- a/lib/services/local/access_monitoring_rules_test.go
+++ b/lib/services/local/access_monitoring_rules_test.go
@@ -24,10 +24,10 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/gravitational/trace"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/testing/protocmp"
 
 	apidefaults "github.com/gravitational/teleport/api/defaults"
 	accessmonitoringrulesv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/accessmonitoringrules/v1"
@@ -82,11 +82,7 @@ func TestAccessMonitoringRulesCRUD(t *testing.T) {
 	// Fetch a specific AccessMonitoringRule.
 	rule, err := service.GetAccessMonitoringRule(ctx, AccessMonitoringRule2.GetMetadata().GetName())
 	require.NoError(t, err)
-	require.Empty(t, cmp.Diff(rule, AccessMonitoringRule2,
-		cmpopts.IgnoreUnexported(accessmonitoringrulesv1.AccessMonitoringRule{}),
-		cmpopts.IgnoreUnexported(accessmonitoringrulesv1.AccessMonitoringRuleSpec{}),
-		cmpopts.IgnoreUnexported(v1.Metadata{}),
-	))
+	require.Empty(t, cmp.Diff(rule, AccessMonitoringRule2, protocmp.Transform()))
 
 	// Try to fetch a AccessMonitoringRule that doesn't exist.
 	_, err = service.GetAccessMonitoringRule(ctx, "doesnotexist")
@@ -327,11 +323,7 @@ func TestListAccessMonitoringRules(t *testing.T) {
 		fetchedAccessMonitoringRules = append(fetchedAccessMonitoringRules, page2...)
 		fetchedAccessMonitoringRules = append(fetchedAccessMonitoringRules, page3...)
 
-		require.Empty(t, cmp.Diff(insertedAccessMonitoringRules, fetchedAccessMonitoringRules,
-			cmpopts.IgnoreUnexported(accessmonitoringrulesv1.AccessMonitoringRule{}),
-			cmpopts.IgnoreUnexported(accessmonitoringrulesv1.AccessMonitoringRuleSpec{}),
-			cmpopts.IgnoreUnexported(v1.Metadata{}),
-		))
+		require.Empty(t, cmp.Diff(insertedAccessMonitoringRules, fetchedAccessMonitoringRules, protocmp.Transform()))
 	})
 
 	t.Run("single", func(t *testing.T) {
@@ -339,10 +331,6 @@ func TestListAccessMonitoringRules(t *testing.T) {
 		require.NoError(t, err)
 		require.Empty(t, nextKey)
 
-		require.Empty(t, cmp.Diff(insertedAccessMonitoringRules, fetchedAccessMonitoringRules,
-			cmpopts.IgnoreUnexported(accessmonitoringrulesv1.AccessMonitoringRule{}),
-			cmpopts.IgnoreUnexported(accessmonitoringrulesv1.AccessMonitoringRuleSpec{}),
-			cmpopts.IgnoreUnexported(v1.Metadata{}),
-		))
+		require.Empty(t, cmp.Diff(insertedAccessMonitoringRules, fetchedAccessMonitoringRules, protocmp.Transform()))
 	})
 }

--- a/lib/services/local/autoupdate_test.go
+++ b/lib/services/local/autoupdate_test.go
@@ -24,7 +24,6 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
 	"github.com/gravitational/trace"
 	"github.com/stretchr/testify/require"
@@ -64,7 +63,7 @@ func TestAutoUpdateServiceConfigCRUD(t *testing.T) {
 	created, err := service.CreateAutoUpdateConfig(ctx, config)
 	require.NoError(t, err)
 	diff := cmp.Diff(config, created,
-		cmpopts.IgnoreFields(headerv1.Metadata{}, "Revision"),
+		protocmp.IgnoreFields(&headerv1.Metadata{}, "revision"),
 		protocmp.Transform(),
 	)
 	require.Empty(t, diff)
@@ -73,7 +72,7 @@ func TestAutoUpdateServiceConfigCRUD(t *testing.T) {
 	got, err := service.GetAutoUpdateConfig(ctx)
 	require.NoError(t, err)
 	diff = cmp.Diff(config, got,
-		cmpopts.IgnoreFields(headerv1.Metadata{}, "Revision"),
+		protocmp.IgnoreFields(&headerv1.Metadata{}, "revision"),
 		protocmp.Transform(),
 	)
 	require.Empty(t, diff)
@@ -129,7 +128,7 @@ func TestAutoUpdateServiceVersionCRUD(t *testing.T) {
 	created, err := service.CreateAutoUpdateVersion(ctx, version)
 	require.NoError(t, err)
 	diff := cmp.Diff(version, created,
-		cmpopts.IgnoreFields(headerv1.Metadata{}, "Revision"),
+		protocmp.IgnoreFields(&headerv1.Metadata{}, "revision"),
 		protocmp.Transform(),
 	)
 	require.Empty(t, diff)
@@ -138,7 +137,7 @@ func TestAutoUpdateServiceVersionCRUD(t *testing.T) {
 	got, err := service.GetAutoUpdateVersion(ctx)
 	require.NoError(t, err)
 	diff = cmp.Diff(version, got,
-		cmpopts.IgnoreFields(headerv1.Metadata{}, "Revision"),
+		protocmp.IgnoreFields(&headerv1.Metadata{}, "revision"),
 		protocmp.Transform(),
 	)
 	require.Empty(t, diff)
@@ -209,7 +208,7 @@ func TestAutoUpdateServiceAgentReportCRUD(t *testing.T) {
 	created, err := service.CreateAutoUpdateAgentReport(ctx, report)
 	require.NoError(t, err)
 	diff := cmp.Diff(report, created,
-		cmpopts.IgnoreFields(headerv1.Metadata{}, "Revision"),
+		protocmp.IgnoreFields(&headerv1.Metadata{}, "revision"),
 		protocmp.Transform(),
 	)
 	require.Empty(t, diff)
@@ -218,7 +217,7 @@ func TestAutoUpdateServiceAgentReportCRUD(t *testing.T) {
 	got, err := service.GetAutoUpdateAgentReport(ctx, authID.String())
 	require.NoError(t, err)
 	diff = cmp.Diff(report, got,
-		cmpopts.IgnoreFields(headerv1.Metadata{}, "Revision"),
+		protocmp.IgnoreFields(&headerv1.Metadata{}, "revision"),
 		protocmp.Transform(),
 	)
 	require.Empty(t, diff)

--- a/lib/services/local/backendinfo_test.go
+++ b/lib/services/local/backendinfo_test.go
@@ -23,7 +23,6 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/gravitational/trace"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/testing/protocmp"
@@ -58,7 +57,7 @@ func TestAutoInfoServiceCRUD(t *testing.T) {
 	created, err := service.CreateBackendInfo(ctx, info)
 	require.NoError(t, err)
 	diff := cmp.Diff(info, created,
-		cmpopts.IgnoreFields(headerv1.Metadata{}, "Revision"),
+		protocmp.IgnoreFields(&headerv1.Metadata{}, "revision"),
 		protocmp.Transform(),
 	)
 	require.Empty(t, diff)
@@ -67,7 +66,7 @@ func TestAutoInfoServiceCRUD(t *testing.T) {
 	got, err := service.GetBackendInfo(ctx)
 	require.NoError(t, err)
 	diff = cmp.Diff(info, got,
-		cmpopts.IgnoreFields(headerv1.Metadata{}, "Revision"),
+		protocmp.IgnoreFields(&headerv1.Metadata{}, "revision"),
 		protocmp.Transform(),
 	)
 	require.Empty(t, diff)

--- a/lib/services/local/generic/generic_wrapper_test.go
+++ b/lib/services/local/generic/generic_wrapper_test.go
@@ -22,7 +22,6 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
 	"github.com/stretchr/testify/assert"
@@ -213,7 +212,7 @@ func TestGenericWrapperCRUD(t *testing.T) {
 	r, err = service.GetResource(ctx, r1.GetMetadata().GetName())
 	require.NoError(t, err)
 	require.Empty(t, cmp.Diff(r1, r,
-		cmpopts.IgnoreFields(headerv1.Metadata{}, "Revision"),
+		protocmp.IgnoreFields(&headerv1.Metadata{}, "revision"),
 		protocmp.Transform(),
 	))
 
@@ -247,7 +246,7 @@ func TestGenericWrapperCRUD(t *testing.T) {
 	require.NoError(t, err)
 	require.Empty(t, nextToken)
 	require.Empty(t, cmp.Diff([]*testResource153{r1, r2}, out,
-		cmpopts.IgnoreFields(headerv1.Metadata{}, "Revision"),
+		protocmp.IgnoreFields(&headerv1.Metadata{}, "revision"),
 		protocmp.Transform(),
 	))
 
@@ -259,7 +258,7 @@ func TestGenericWrapperCRUD(t *testing.T) {
 	require.NoError(t, err)
 	require.Empty(t, nextToken)
 	require.Empty(t, cmp.Diff([]*testResource153{r1, r2}, out,
-		cmpopts.IgnoreFields(headerv1.Metadata{}, "Revision"),
+		protocmp.IgnoreFields(&headerv1.Metadata{}, "revision"),
 		protocmp.Transform(),
 	))
 

--- a/lib/services/local/notifications_test.go
+++ b/lib/services/local/notifications_test.go
@@ -487,7 +487,7 @@ func TestUniqueNotificationIdentifierCRUD(t *testing.T) {
 func newUserNotification(t *testing.T, username string, title string) *notificationsv1.Notification {
 	t.Helper()
 
-	notification := notificationsv1.Notification{
+	notification := notificationsv1.Notification_builder{
 		SubKind: "test-subkind",
 		Spec: notificationsv1.NotificationSpec_builder{
 			Username: username,
@@ -497,15 +497,15 @@ func newUserNotification(t *testing.T, username string, title string) *notificat
 				types.NotificationTitleLabel: title,
 			},
 		}.Build(),
-	}
+	}.Build()
 
-	return &notification
+	return notification
 }
 
 func newGlobalNotification(t *testing.T, title string) *notificationsv1.GlobalNotification {
 	t.Helper()
 
-	notification := notificationsv1.GlobalNotification{
+	notification := notificationsv1.GlobalNotification_builder{
 		Spec: notificationsv1.GlobalNotificationSpec_builder{
 			All: proto.Bool(true),
 			Notification: notificationsv1.Notification_builder{
@@ -518,7 +518,7 @@ func newGlobalNotification(t *testing.T, title string) *notificationsv1.GlobalNo
 				}.Build(),
 			}.Build(),
 		}.Build(),
-	}
+	}.Build()
 
-	return &notification
+	return notification
 }

--- a/lib/services/local/recording_encryption_test.go
+++ b/lib/services/local/recording_encryption_test.go
@@ -39,17 +39,17 @@ func TestRecordingEncryption(t *testing.T) {
 
 	ctx := context.Background()
 
-	initialEncryption := pb.RecordingEncryption{
+	initialEncryption := pb.RecordingEncryption_builder{
 		Spec: pb.RecordingEncryptionSpec_builder{
 			ActiveKeyPairs: nil,
 		}.Build(),
-	}
+	}.Build()
 
 	// get should fail when there's no recording encryption
 	_, err = service.GetRecordingEncryption(ctx)
 	require.Error(t, err)
 
-	created, err := service.CreateRecordingEncryption(ctx, &initialEncryption)
+	created, err := service.CreateRecordingEncryption(ctx, initialEncryption)
 	require.NoError(t, err)
 
 	encryption, err := service.GetRecordingEncryption(ctx)

--- a/lib/services/local/trust_test.go
+++ b/lib/services/local/trust_test.go
@@ -542,9 +542,9 @@ func TestCA_TunnelConnections_CorruptItem(t *testing.T) {
 	got = nil
 	pageToken = ""
 	for {
-		page, next, err := trustService.ListTunnelConnections(ctx, 2, pageToken, &trustpb.ListTunnelConnectionsFilter{
+		page, next, err := trustService.ListTunnelConnections(ctx, 2, pageToken, trustpb.ListTunnelConnectionsFilter_builder{
 			ClusterName: cluster,
-		})
+		}.Build())
 		require.NoError(t, err)
 		for _, c := range page {
 			got = append(got, c.GetName())

--- a/lib/services/local/users_test.go
+++ b/lib/services/local/users_test.go
@@ -1423,11 +1423,11 @@ func TestIdentityService_ListUsers(t *testing.T) {
 
 	// List a few users at a time and validate that all users are eventually returned.
 	var retrieved []*types.UserV2
-	req := userspb.ListUsersRequest{
+	req := userspb.ListUsersRequest_builder{
 		PageSize: 2,
-	}
+	}.Build()
 	for {
-		rsp, err := identity.ListUsers(ctx, &req)
+		rsp, err := identity.ListUsers(ctx, req)
 		require.NoError(t, err, "no error returned when no users exist")
 
 		for _, user := range rsp.GetUsers() {
@@ -1471,12 +1471,12 @@ func TestIdentityService_ListUsers(t *testing.T) {
 
 	// List a few users at a time and validate that all users are eventually returned with their secrets.
 	retrieved = nil
-	req = userspb.ListUsersRequest{
+	req = userspb.ListUsersRequest_builder{
 		PageSize:    2,
 		WithSecrets: true,
-	}
+	}.Build()
 	for {
-		rsp, err := identity.ListUsers(ctx, &req)
+		rsp, err := identity.ListUsers(ctx, req)
 		require.NoError(t, err, "no error returned when no users exist")
 
 		retrieved = append(retrieved, rsp.GetUsers()...)

--- a/lib/services/local/vnet_config_test.go
+++ b/lib/services/local/vnet_config_test.go
@@ -21,9 +21,9 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/gravitational/trace"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/testing/protocmp"
 
 	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
 	"github.com/gravitational/teleport/api/gen/proto/go/teleport/vnet/v1"
@@ -54,8 +54,8 @@ func TestVnetConfigService(t *testing.T) {
 	created, err := service.CreateVnetConfig(ctx, vnetConfig)
 	require.NoError(t, err)
 	diff := cmp.Diff(vnetConfig, created,
-		cmpopts.IgnoreFields(headerv1.Metadata{}, "Revision"),
-		cmpopts.IgnoreUnexported(vnet.VnetConfig{}, vnet.VnetConfigSpec{}, vnet.CustomDNSZone{}, headerv1.Metadata{}),
+		protocmp.IgnoreFields(&headerv1.Metadata{}, "revision"),
+		protocmp.Transform(),
 	)
 	require.Empty(t, diff)
 	require.NotEmpty(t, created.GetMetadata().GetRevision())
@@ -64,8 +64,8 @@ func TestVnetConfigService(t *testing.T) {
 	got, err := service.GetVnetConfig(ctx)
 	require.NoError(t, err)
 	diff = cmp.Diff(vnetConfig, got,
-		cmpopts.IgnoreFields(headerv1.Metadata{}, "Revision"),
-		cmpopts.IgnoreUnexported(vnet.VnetConfig{}, vnet.VnetConfigSpec{}, vnet.CustomDNSZone{}, headerv1.Metadata{}),
+		protocmp.IgnoreFields(&headerv1.Metadata{}, "revision"),
+		protocmp.Transform(),
 	)
 	require.Empty(t, diff)
 	require.Equal(t, created.GetMetadata().GetRevision(), got.GetMetadata().GetRevision())

--- a/lib/services/notifications_cache_test.go
+++ b/lib/services/notifications_cache_test.go
@@ -422,7 +422,7 @@ func TestGlobalNotificationsCache(t *testing.T) {
 func newUserNotification(t *testing.T, username string, title string) *notificationsv1.Notification {
 	t.Helper()
 
-	notification := notificationsv1.Notification{
+	notification := notificationsv1.Notification_builder{
 		SubKind: "test-subkind",
 		Spec: notificationsv1.NotificationSpec_builder{
 			Username: username,
@@ -432,15 +432,15 @@ func newUserNotification(t *testing.T, username string, title string) *notificat
 				types.NotificationTitleLabel: title,
 			},
 		}.Build(),
-	}
+	}.Build()
 
-	return &notification
+	return notification
 }
 
 func newGlobalNotification(t *testing.T, title string) *notificationsv1.GlobalNotification {
 	t.Helper()
 
-	notification := notificationsv1.GlobalNotification{
+	notification := notificationsv1.GlobalNotification_builder{
 		Spec: notificationsv1.GlobalNotificationSpec_builder{
 			All: proto.Bool(true),
 			Notification: notificationsv1.Notification_builder{
@@ -453,7 +453,7 @@ func newGlobalNotification(t *testing.T, title string) *notificationsv1.GlobalNo
 				}.Build(),
 			}.Build(),
 		}.Build(),
-	}
+	}.Build()
 
-	return &notification
+	return notification
 }

--- a/lib/services/reconciler_test.go
+++ b/lib/services/reconciler_test.go
@@ -29,17 +29,17 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/gravitational/trace"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/testing/protocmp"
 
 	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/utils"
 )
 
-type updateCall struct{ new, old testResource }
+type updateCall struct{ New, Old testResource }
 
 // TestReconciler makes sure appropriate callbacks are called during reconciliation.
 func TestReconciler(t *testing.T) {
-	type updateCall struct{ new, old testResource }
 	tests := []struct {
 		description         string
 		selectors           []ResourceMatcher
@@ -98,8 +98,8 @@ func TestReconciler(t *testing.T) {
 			newResources:        []testResource{makeDynamicResource("res1", nil)},
 			onUpdateCalls: []updateCall{
 				{
-					old: makeStaticResource("res1", nil),
-					new: makeDynamicResource("res1", nil),
+					Old: makeStaticResource("res1", nil),
+					New: makeDynamicResource("res1", nil),
 				},
 			},
 		},
@@ -140,8 +140,8 @@ func TestReconciler(t *testing.T) {
 			newResources:        []testResource{makeDynamicResource("res1", map[string]string{"env": "dev"})},
 			onUpdateCalls: []updateCall{
 				{
-					old: makeDynamicResource("res1", nil),
-					new: makeDynamicResource("res1", map[string]string{"env": "dev"}),
+					Old: makeDynamicResource("res1", nil),
+					New: makeDynamicResource("res1", map[string]string{"env": "dev"}),
 				},
 			},
 		},
@@ -179,8 +179,8 @@ func TestReconciler(t *testing.T) {
 			},
 			onUpdateCalls: []updateCall{
 				{
-					new: makeDynamicResource("res2", map[string]string{"env": "prod", "a": "b"}),
-					old: makeDynamicResource("res2", map[string]string{"env": "prod"}),
+					New: makeDynamicResource("res2", map[string]string{"env": "prod", "a": "b"}),
+					Old: makeDynamicResource("res2", map[string]string{"env": "prod"}),
 				},
 			},
 			onDeleteCalls: []testResource{
@@ -222,14 +222,14 @@ func TestReconciler(t *testing.T) {
 			},
 			onUpdateCalls: []updateCall{
 				{
-					new: makeDynamicResource("res0", map[string]string{"env": "prod", "updated": "yes"}),
-					old: makeDynamicResource("res0", map[string]string{"env": "prod"}),
+					New: makeDynamicResource("res0", map[string]string{"env": "prod", "updated": "yes"}),
+					Old: makeDynamicResource("res0", map[string]string{"env": "prod"}),
 				}, {
-					new: makeDynamicResource("res3", map[string]string{"env": "prod", "updated": "yes"}),
-					old: makeDynamicResource("res3", map[string]string{"env": "prod"}),
+					New: makeDynamicResource("res3", map[string]string{"env": "prod", "updated": "yes"}),
+					Old: makeDynamicResource("res3", map[string]string{"env": "prod"}),
 				}, {
-					new: makeDynamicResource("res4", map[string]string{"env": "prod", "updated": "yes"}),
-					old: makeDynamicResource("res4", map[string]string{"env": "prod"}),
+					New: makeDynamicResource("res4", map[string]string{"env": "prod", "updated": "yes"}),
+					Old: makeDynamicResource("res4", map[string]string{"env": "prod"}),
 				},
 			},
 		},
@@ -260,14 +260,14 @@ func TestReconciler(t *testing.T) {
 						return test.comparator(tr1, tr2)
 					}
 
-					return EqualFromBool(cmp.Equal(tr1, tr2, cmpopts.IgnoreUnexported(headerv1.Metadata{})))
+					return EqualFromBool(cmp.Equal(tr1, tr2, protocmp.Transform()))
 				},
 				OnCreate: func(ctx context.Context, tr testResource) error {
 					onCreateCalls = append(onCreateCalls, tr)
 					return nil
 				},
 				OnUpdate: func(ctx context.Context, tr, old testResource) error {
-					onUpdateCalls = append(onUpdateCalls, updateCall{new: tr, old: old})
+					onUpdateCalls = append(onUpdateCalls, updateCall{New: tr, Old: old})
 					return nil
 				},
 				OnDelete: func(ctx context.Context, tr testResource) error {
@@ -280,15 +280,20 @@ func TestReconciler(t *testing.T) {
 				test.configure(&cfg)
 			}
 
-			reconciler, err := NewReconciler[testResource](cfg)
+			reconciler, err := NewReconciler(cfg)
 			require.NoError(t, err)
 
 			// Reconcile and make sure we got all expected callback calls.
 			err = reconciler.Reconcile(context.Background())
 			require.NoError(t, err)
-			require.ElementsMatch(t, test.onCreateCalls, onCreateCalls)
-			require.ElementsMatch(t, test.onUpdateCalls, onUpdateCalls)
-			require.ElementsMatch(t, test.onDeleteCalls, onDeleteCalls)
+			require.Empty(t, cmp.Diff(test.onCreateCalls, onCreateCalls, protocmp.Transform(), cmpopts.SortSlices(func(a, b testResource) bool { return a.GetName() < b.GetName() })))
+			require.Empty(t, cmp.Diff(test.onUpdateCalls, onUpdateCalls, protocmp.Transform(), cmpopts.SortSlices(func(a, b updateCall) bool {
+				if a.New.GetName() != b.New.GetName() {
+					return a.New.GetName() < b.New.GetName()
+				}
+				return a.Old.GetName() < b.Old.GetName()
+			})))
+			require.Empty(t, cmp.Diff(test.onDeleteCalls, onDeleteCalls, protocmp.Transform(), cmpopts.SortSlices(func(a, b testResource) bool { return a.GetName() < b.GetName() })))
 		})
 	}
 }
@@ -331,7 +336,7 @@ func TestGenericReconciler(t *testing.T) {
 			return MatchResourceLabels(selectors, tr.GetMetadata().GetLabels())
 		},
 		CompareResources: func(tr1, tr2 testResource) int {
-			return EqualFromBool(cmp.Equal(tr1, tr2, cmpopts.IgnoreUnexported(headerv1.Metadata{})))
+			return EqualFromBool(cmp.Equal(tr1, tr2, protocmp.Transform()))
 		},
 		GetCurrentResources: func() map[resourceID]testResource {
 			return registeredResources
@@ -344,7 +349,7 @@ func TestGenericReconciler(t *testing.T) {
 			return nil
 		},
 		OnUpdate: func(ctx context.Context, tr, old testResource) error {
-			onUpdateCalls = append(onUpdateCalls, updateCall{new: tr, old: old})
+			onUpdateCalls = append(onUpdateCalls, updateCall{New: tr, Old: old})
 			return nil
 		},
 		OnDelete: func(ctx context.Context, tr testResource) error {
@@ -365,17 +370,22 @@ func TestGenericReconciler(t *testing.T) {
 	expectedCreateCalls := []testResource{
 		makeDynamicResource("res5", map[string]string{"env": "prod"}),
 	}
-	require.ElementsMatch(t, expectedCreateCalls, onCreateCalls)
+	require.Empty(t, cmp.Diff(expectedCreateCalls, onCreateCalls, protocmp.Transform(), cmpopts.SortSlices(func(a, b testResource) bool { return a.GetName() < b.GetName() })))
 
 	// EXPECT that the matching resources updated in the "new" set have been
 	// had an update callback invoked on them
 	expectedUpdateCalls := []updateCall{
 		{
-			new: makeDynamicResource("res2", map[string]string{"env": "prod", "a": "b"}),
-			old: makeDynamicResource("res2", map[string]string{"env": "prod"}),
+			New: makeDynamicResource("res2", map[string]string{"env": "prod", "a": "b"}),
+			Old: makeDynamicResource("res2", map[string]string{"env": "prod"}),
 		},
 	}
-	require.ElementsMatch(t, expectedUpdateCalls, onUpdateCalls)
+	require.Empty(t, cmp.Diff(expectedUpdateCalls, onUpdateCalls, protocmp.Transform(), cmpopts.SortSlices(func(a, b updateCall) bool {
+		if a.New.GetName() != b.New.GetName() {
+			return a.New.GetName() < b.New.GetName()
+		}
+		return a.Old.GetName() < b.Old.GetName()
+	})))
 
 	// EXPECT that the elements in the "old" set missing from the "new" set have
 	// had the delete callback invoked on them.
@@ -383,7 +393,7 @@ func TestGenericReconciler(t *testing.T) {
 		makeDynamicResource("res1", map[string]string{"env": "prod"}),
 		makeDynamicResource("res4", map[string]string{"env": "prod"}),
 	}
-	require.ElementsMatch(t, expectedDeleteCalls, onDeleteCalls)
+	require.Empty(t, cmp.Diff(expectedDeleteCalls, onDeleteCalls, protocmp.Transform(), cmpopts.SortSlices(func(a, b testResource) bool { return a.GetName() < b.GetName() })))
 }
 
 // TestGenericReconcilerConcurrent verifies that the concurrent reconciliation
@@ -417,7 +427,7 @@ func TestGenericReconcilerConcurrent(t *testing.T) {
 	r, err := NewGenericReconciler(GenericReconcilerConfig[int, testResource]{
 		Matcher: func(tr testResource) bool { return true },
 		CompareResources: func(tr1, tr2 testResource) int {
-			return EqualFromBool(cmp.Equal(tr1, tr2, cmpopts.IgnoreUnexported(headerv1.Metadata{})))
+			return EqualFromBool(cmp.Equal(tr1, tr2, protocmp.Transform()))
 		},
 		GetCurrentResources: func() map[int]testResource { return currentResources },
 		GetNewResources:     func() map[int]testResource { return newResources },
@@ -430,7 +440,7 @@ func TestGenericReconcilerConcurrent(t *testing.T) {
 		OnUpdate: func(ctx context.Context, tr, old testResource) error {
 			mu.Lock()
 			defer mu.Unlock()
-			onUpdateCalls = append(onUpdateCalls, updateCall{new: tr, old: old})
+			onUpdateCalls = append(onUpdateCalls, updateCall{New: tr, Old: old})
 			return nil
 		},
 		OnDelete: func(ctx context.Context, tr testResource) error {
@@ -449,25 +459,30 @@ func TestGenericReconcilerConcurrent(t *testing.T) {
 	for i := n; i < 2*n; i++ {
 		expectedCreates = append(expectedCreates, makeDynamicResource(fmt.Sprintf("res%d", i), maps.Clone(labels)))
 	}
-	require.ElementsMatch(t, expectedCreates, onCreateCalls)
+	require.Empty(t, cmp.Diff(expectedCreates, onCreateCalls, protocmp.Transform(), cmpopts.SortSlices(func(a, b testResource) bool { return a.GetName() < b.GetName() })))
 
 	// 50 resources (IDs 0–49) should be updated.
 	var expectedUpdates []updateCall
 	for i := 0; i < n/2; i++ {
 		name := fmt.Sprintf("res%d", i)
 		expectedUpdates = append(expectedUpdates, updateCall{
-			new: makeDynamicResource(name, map[string]string{"env": "stage"}),
-			old: makeDynamicResource(name, maps.Clone(labels)),
+			New: makeDynamicResource(name, map[string]string{"env": "stage"}),
+			Old: makeDynamicResource(name, maps.Clone(labels)),
 		})
 	}
-	require.ElementsMatch(t, expectedUpdates, onUpdateCalls)
+	require.Empty(t, cmp.Diff(expectedUpdates, onUpdateCalls, protocmp.Transform(), cmpopts.SortSlices(func(a, b updateCall) bool {
+		if a.New.GetName() != b.New.GetName() {
+			return a.New.GetName() < b.New.GetName()
+		}
+		return a.Old.GetName() < b.Old.GetName()
+	})))
 
 	// 50 resources (IDs 50–99) absent from new set should be deleted.
 	var expectedDeletes []testResource
 	for i := n / 2; i < n; i++ {
 		expectedDeletes = append(expectedDeletes, makeDynamicResource(fmt.Sprintf("res%d", i), maps.Clone(labels)))
 	}
-	require.ElementsMatch(t, expectedDeletes, onDeleteCalls)
+	require.Empty(t, cmp.Diff(expectedDeletes, onDeleteCalls, protocmp.Transform(), cmpopts.SortSlices(func(a, b testResource) bool { return a.GetName() < b.GetName() })))
 }
 
 func makeStaticResource(name string, labels map[string]string) testResource {

--- a/lib/services/sigstore_policies_test.go
+++ b/lib/services/sigstore_policies_test.go
@@ -140,12 +140,9 @@ func TestValidateSigstorePolicy(t *testing.T) {
 		"no keyless identity subject": {
 			mod: func(p *workloadidentityv1.SigstorePolicy) {
 				p.GetSpec().GetKeyless().SetIdentities([]*workloadidentityv1.SigstoreKeylessSigningIdentity{
-					{
-						SubjectMatcher: nil,
-						IssuerMatcher: &workloadidentityv1.SigstoreKeylessSigningIdentity_Issuer{
-							Issuer: "some issuer",
-						},
-					},
+					workloadidentityv1.SigstoreKeylessSigningIdentity_builder{
+						Issuer: proto.String("some issuer"),
+					}.Build(),
 				})
 			},
 			err: "spec.keyless.identities[0].subject_matcher: subject or subject_regex is required",
@@ -164,12 +161,9 @@ func TestValidateSigstorePolicy(t *testing.T) {
 		"no keyless identity issuer": {
 			mod: func(p *workloadidentityv1.SigstorePolicy) {
 				p.GetSpec().GetKeyless().SetIdentities([]*workloadidentityv1.SigstoreKeylessSigningIdentity{
-					{
-						IssuerMatcher: nil,
-						SubjectMatcher: &workloadidentityv1.SigstoreKeylessSigningIdentity_Subject{
-							Subject: "some subject",
-						},
-					},
+					workloadidentityv1.SigstoreKeylessSigningIdentity_builder{
+						Subject: proto.String("some subject"),
+					}.Build(),
 				})
 			},
 			err: "spec.keyless.identities[0].issuer_matcher: issuer or issuer_regex is required",

--- a/lib/srv/discovery/fetchers/azuresync/roledefinitions.go
+++ b/lib/srv/discovery/fetchers/azuresync/roledefinitions.go
@@ -58,11 +58,11 @@ func fetchRoleDefinitions(ctx context.Context, subscriptionID string, cli RoleDe
 				fetchErrs = append(fetchErrs, trace.BadParameter("nil values on Permission object: %v", perm))
 				continue
 			}
-			pbPerm := accessgraphv1alpha.AzureRBACPermission{
+			pbPerm := accessgraphv1alpha.AzureRBACPermission_builder{
 				Actions:    slices.FromPointers(perm.Actions),
 				NotActions: slices.FromPointers(perm.NotActions),
-			}
-			pbPerms = append(pbPerms, &pbPerm)
+			}.Build()
+			pbPerms = append(pbPerms, pbPerm)
 		}
 		pbRoleDef := accessgraphv1alpha.AzureRoleDefinition_builder{
 			Id:             *roleDef.ID,

--- a/lib/srv/discovery/fetchers/azuresync/virtualmachines.go
+++ b/lib/srv/discovery/fetchers/azuresync/virtualmachines.go
@@ -48,12 +48,12 @@ func fetchVirtualMachines(ctx context.Context, subscriptionID string, cli Virtua
 			fetchErrs = append(fetchErrs, trace.BadParameter("empty values on AzureVirtualMachine object: %v", vm))
 			continue
 		}
-		pbVm := accessgraphv1alpha.AzureVirtualMachine{
+		pbVm := accessgraphv1alpha.AzureVirtualMachine_builder{
 			Id:             vm.ID,
 			SubscriptionId: subscriptionID,
 			Name:           vm.Name,
-		}
-		pbVms = append(pbVms, &pbVm)
+		}.Build()
+		pbVms = append(pbVms, pbVm)
 	}
 	return pbVms, trace.NewAggregate(fetchErrs...)
 }

--- a/lib/srv/ssh/mfa_test.go
+++ b/lib/srv/ssh/mfa_test.go
@@ -170,7 +170,7 @@ func TestMFAPromptVerifier_VerifyAnswer_MissingResponse(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	resp := &sshpb.MFAPromptResponse{Response: nil}
+	resp := sshpb.MFAPromptResponse_builder{}.Build()
 	respJSON, err := protojson.Marshal(resp)
 	require.NoError(t, err)
 

--- a/lib/srv/statichostusers.go
+++ b/lib/srv/statichostusers.go
@@ -253,18 +253,18 @@ func (s *StaticHostUserHandler) handleNewHostUser(ctx context.Context, hostUser 
 	}
 
 	slog.DebugContext(ctx, "Attempt to update matched static host user.", "login", login)
-	ui := decisionpb.HostUsersInfo{
+	ui := decisionpb.HostUsersInfo_builder{
 		Groups: createUser.GetGroups(),
 		Mode:   decisionpb.HostUserMode_HOST_USER_MODE_STATIC,
 		Shell:  createUser.GetDefaultShell(),
-	}
+	}.Build()
 	if createUser.GetUid() != 0 {
 		ui.SetUid(strconv.Itoa(int(createUser.GetUid())))
 	}
 	if createUser.GetGid() != 0 {
 		ui.SetGid(strconv.Itoa(int(createUser.GetGid())))
 	}
-	if _, err := s.users.UpsertUser(login, &ui, TakeOwnershipIfUserExists(createUser.GetTakeOwnershipIfUserExists())); err != nil {
+	if _, err := s.users.UpsertUser(login, ui, TakeOwnershipIfUserExists(createUser.GetTakeOwnershipIfUserExists())); err != nil {
 		return trace.Wrap(err)
 	}
 	if s.sudoers != nil && len(createUser.GetSudoers()) != 0 {

--- a/lib/srv/transport/transportv1/transport.go
+++ b/lib/srv/transport/transportv1/transport.go
@@ -263,13 +263,13 @@ func (s *Service) ProxySSH(stream transportv1pb.TransportService_ProxySSHServer)
 			// The writes to the channels are intentionally not selecting
 			// on `ctx.Done()` to ensure that all data is flushed to the
 			// clients.
-			switch frame := req.Frame.(type) {
-			case *transportv1pb.ProxySSHRequest_Ssh:
-				sshStream.incomingC <- frame.Ssh.GetPayload()
-			case *transportv1pb.ProxySSHRequest_Agent:
-				agentStream.incomingC <- frame.Agent.GetPayload()
+			switch req.WhichFrame() {
+			case transportv1pb.ProxySSHRequest_Ssh_case:
+				sshStream.incomingC <- req.GetSsh().GetPayload()
+			case transportv1pb.ProxySSHRequest_Agent_case:
+				agentStream.incomingC <- req.GetAgent().GetPayload()
 			default:
-				s.cfg.Logger.ErrorContext(ctx, "received unexpected ssh frame", "frame", logutils.TypeAttr(frame))
+				s.cfg.Logger.ErrorContext(ctx, "received unexpected ssh frame", "frame", logutils.TypeAttr(req))
 				continue
 			}
 		}

--- a/lib/srv/usermgmt_test.go
+++ b/lib/srv/usermgmt_test.go
@@ -235,12 +235,12 @@ func TestUserMgmt_CreateTemporaryUser(t *testing.T) {
 
 	users, backend := initBackend(t, nil)
 
-	userinfo := decisionpb.HostUsersInfo{
+	userinfo := decisionpb.HostUsersInfo_builder{
 		Groups: []string{"hello", "sudo"},
 		Mode:   decisionpb.HostUserMode_HOST_USER_MODE_DROP,
-	}
+	}.Build()
 	// create a user with some groups
-	closer, err := users.UpsertUser("bob", &userinfo)
+	closer, err := users.UpsertUser("bob", userinfo)
 	require.NoError(t, err)
 	// NOTE (eriktate): assert.Nil and assert.NotNil will pass for nil interfaces where nilInterface != nil.
 	// assert.Equal and assert.NotEqual perform the same comparisons we would in non-test code and are safer
@@ -255,7 +255,7 @@ func TestUserMgmt_CreateTemporaryUser(t *testing.T) {
 	}, backend.users["bob"])
 
 	// try create the same user again
-	secondCloser, err := users.UpsertUser("bob", &userinfo)
+	secondCloser, err := users.UpsertUser("bob", userinfo)
 	require.NoError(t, err)
 	require.NotEqual(t, nil, secondCloser)
 
@@ -267,7 +267,7 @@ func TestUserMgmt_CreateTemporaryUser(t *testing.T) {
 	backend.CreateUser("simon", []string{}, host.UserOpts{})
 
 	// an existing, unmanaged user should not be changed
-	closer, err = users.UpsertUser("simon", &userinfo)
+	closer, err = users.UpsertUser("simon", userinfo)
 	require.ErrorIs(t, err, errUnmanagedUser)
 	require.Equal(t, nil, closer)
 }
@@ -435,13 +435,13 @@ func Test_UpdateUserGroups_Keep(t *testing.T) {
 	allGroups := []string{"foo", "bar", "baz", "quux"}
 	users, backend := initBackend(t, allGroups)
 
-	userinfo := decisionpb.HostUsersInfo{
+	userinfo := decisionpb.HostUsersInfo_builder{
 		Groups: slices.Clone(allGroups[:2]),
 		Mode:   decisionpb.HostUserMode_HOST_USER_MODE_KEEP,
-	}
+	}.Build()
 
 	// Create user
-	closer, err := users.UpsertUser("alice", &userinfo)
+	closer, err := users.UpsertUser("alice", userinfo)
 	assert.NoError(t, err)
 	assert.Equal(t, nil, closer)
 	assert.Zero(t, backend.updateUserCalls)
@@ -451,7 +451,7 @@ func Test_UpdateUserGroups_Keep(t *testing.T) {
 	// Update user with new groups.
 	userinfo.SetGroups(slices.Clone(allGroups[2:]))
 
-	closer, err = users.UpsertUser("alice", &userinfo)
+	closer, err = users.UpsertUser("alice", userinfo)
 	assert.NoError(t, err)
 	assert.Equal(t, nil, closer)
 	assert.Equal(t, 1, backend.updateUserCalls)
@@ -459,7 +459,7 @@ func Test_UpdateUserGroups_Keep(t *testing.T) {
 	assert.NotContains(t, backend.users["alice"], apiconstants.TeleportDropGroup)
 
 	// Upsert again with same groups should not call UpdateUser.
-	closer, err = users.UpsertUser("alice", &userinfo)
+	closer, err = users.UpsertUser("alice", userinfo)
 	assert.NoError(t, err)
 	assert.Equal(t, nil, closer)
 	assert.Equal(t, 1, backend.updateUserCalls)
@@ -468,7 +468,7 @@ func Test_UpdateUserGroups_Keep(t *testing.T) {
 
 	// Do not convert the managed user to static.
 	userinfo.SetMode(decisionpb.HostUserMode_HOST_USER_MODE_STATIC)
-	closer, err = users.UpsertUser("alice", &userinfo)
+	closer, err = users.UpsertUser("alice", userinfo)
 	assert.ErrorIs(t, err, errStaticConversion)
 	assert.Equal(t, nil, closer)
 	assert.Equal(t, 1, backend.updateUserCalls)
@@ -477,7 +477,7 @@ func Test_UpdateUserGroups_Keep(t *testing.T) {
 	// Updates with INSECURE_DROP mode should convert the managed user
 	userinfo.SetMode(decisionpb.HostUserMode_HOST_USER_MODE_DROP)
 	userinfo.SetGroups(slices.Clone(allGroups[:2]))
-	closer, err = users.UpsertUser("alice", &userinfo)
+	closer, err = users.UpsertUser("alice", userinfo)
 	assert.NoError(t, err)
 	assert.NotEqual(t, nil, closer)
 	assert.Equal(t, 2, backend.updateUserCalls)
@@ -491,13 +491,13 @@ func Test_UpdateUserGroups_Drop(t *testing.T) {
 	allGroups := []string{"foo", "bar", "baz", "quux"}
 	users, backend := initBackend(t, allGroups)
 
-	userinfo := decisionpb.HostUsersInfo{
+	userinfo := decisionpb.HostUsersInfo_builder{
 		Groups: slices.Clone(allGroups[:2]),
 		Mode:   decisionpb.HostUserMode_HOST_USER_MODE_DROP,
-	}
+	}.Build()
 
 	// Create user
-	closer, err := users.UpsertUser("alice", &userinfo)
+	closer, err := users.UpsertUser("alice", userinfo)
 	assert.NoError(t, err)
 	assert.NotEqual(t, nil, closer)
 	assert.Zero(t, backend.updateUserCalls)
@@ -507,7 +507,7 @@ func Test_UpdateUserGroups_Drop(t *testing.T) {
 	// Update user with new groups.
 	userinfo.SetGroups(slices.Clone(allGroups[2:]))
 
-	closer, err = users.UpsertUser("alice", &userinfo)
+	closer, err = users.UpsertUser("alice", userinfo)
 	assert.NoError(t, err)
 	assert.NotEqual(t, nil, closer)
 	assert.Equal(t, 1, backend.updateUserCalls)
@@ -515,7 +515,7 @@ func Test_UpdateUserGroups_Drop(t *testing.T) {
 	assert.NotContains(t, backend.users["alice"], apiconstants.TeleportKeepGroup)
 
 	// Upsert again with same groups should not call SetUserGroups.
-	closer, err = users.UpsertUser("alice", &userinfo)
+	closer, err = users.UpsertUser("alice", userinfo)
 	assert.NoError(t, err)
 	assert.NotEqual(t, nil, closer)
 	assert.Equal(t, 1, backend.updateUserCalls)
@@ -524,7 +524,7 @@ func Test_UpdateUserGroups_Drop(t *testing.T) {
 
 	// Do not convert the managed user to static.
 	userinfo.SetMode(decisionpb.HostUserMode_HOST_USER_MODE_STATIC)
-	closer, err = users.UpsertUser("alice", &userinfo)
+	closer, err = users.UpsertUser("alice", userinfo)
 	assert.ErrorIs(t, err, errStaticConversion)
 	assert.Equal(t, nil, closer)
 	assert.Equal(t, 1, backend.updateUserCalls)
@@ -533,7 +533,7 @@ func Test_UpdateUserGroups_Drop(t *testing.T) {
 	// Updates with KEEP mode should convert the ephemeral user
 	userinfo.SetMode(decisionpb.HostUserMode_HOST_USER_MODE_KEEP)
 	userinfo.SetGroups(slices.Clone(allGroups[:2]))
-	closer, err = users.UpsertUser("alice", &userinfo)
+	closer, err = users.UpsertUser("alice", userinfo)
 	assert.NoError(t, err)
 	assert.Equal(t, nil, closer)
 	assert.Equal(t, 2, backend.updateUserCalls)
@@ -547,13 +547,13 @@ func Test_UpdateUserGroups_Static(t *testing.T) {
 
 	allGroups := []string{"foo", "bar", "baz", "quux"}
 	users, backend := initBackend(t, allGroups)
-	userinfo := decisionpb.HostUsersInfo{
+	userinfo := decisionpb.HostUsersInfo_builder{
 		Groups: slices.Clone(allGroups[:2]),
 		Mode:   decisionpb.HostUserMode_HOST_USER_MODE_STATIC,
-	}
+	}.Build()
 
 	// Create user.
-	closer, err := users.UpsertUser("alice", &userinfo)
+	closer, err := users.UpsertUser("alice", userinfo)
 	assert.NoError(t, err)
 	assert.Equal(t, nil, closer)
 	assert.Zero(t, backend.updateUserCalls)
@@ -561,14 +561,14 @@ func Test_UpdateUserGroups_Static(t *testing.T) {
 
 	// Update user with new groups.
 	userinfo.SetGroups(slices.Clone(allGroups[2:]))
-	closer, err = users.UpsertUser("alice", &userinfo)
+	closer, err = users.UpsertUser("alice", userinfo)
 	assert.NoError(t, err)
 	assert.Equal(t, nil, closer)
 	assert.Equal(t, 1, backend.updateUserCalls)
 	assert.ElementsMatch(t, append(userinfo.GetGroups(), apiconstants.TeleportStaticGroup), backend.users["alice"])
 
 	// Upsert again with same groups should not call SetUserGroups.
-	closer, err = users.UpsertUser("alice", &userinfo)
+	closer, err = users.UpsertUser("alice", userinfo)
 	assert.NoError(t, err)
 	assert.Equal(t, nil, closer)
 	assert.Equal(t, 1, backend.updateUserCalls)
@@ -576,7 +576,7 @@ func Test_UpdateUserGroups_Static(t *testing.T) {
 
 	// Do not convert to KEEP.
 	userinfo.SetMode(decisionpb.HostUserMode_HOST_USER_MODE_KEEP)
-	closer, err = users.UpsertUser("alice", &userinfo)
+	closer, err = users.UpsertUser("alice", userinfo)
 	assert.ErrorIs(t, err, errStaticConversion)
 	assert.Equal(t, nil, closer)
 	assert.Equal(t, 1, backend.updateUserCalls)
@@ -584,7 +584,7 @@ func Test_UpdateUserGroups_Static(t *testing.T) {
 
 	// Do not convert to INSECURE_DROP.
 	userinfo.SetMode(decisionpb.HostUserMode_HOST_USER_MODE_DROP)
-	closer, err = users.UpsertUser("alice", &userinfo)
+	closer, err = users.UpsertUser("alice", userinfo)
 	assert.ErrorIs(t, err, errStaticConversion)
 	assert.Equal(t, nil, closer)
 	assert.Equal(t, 1, backend.updateUserCalls)
@@ -599,13 +599,13 @@ func Test_DontManageExistingUser(t *testing.T) {
 
 	assert.NoError(t, backend.CreateUser("alice", allGroups, host.UserOpts{}))
 
-	userinfo := decisionpb.HostUsersInfo{
+	userinfo := decisionpb.HostUsersInfo_builder{
 		Groups: allGroups[:2],
 		Mode:   decisionpb.HostUserMode_HOST_USER_MODE_DROP,
-	}
+	}.Build()
 
 	// Update user in DROP mode
-	closer, err := users.UpsertUser("alice", &userinfo)
+	closer, err := users.UpsertUser("alice", userinfo)
 	assert.ErrorIs(t, err, errUnmanagedUser)
 	assert.Equal(t, nil, closer)
 	assert.Zero(t, backend.updateUserCalls)
@@ -613,7 +613,7 @@ func Test_DontManageExistingUser(t *testing.T) {
 
 	// Update user in KEEP mode
 	userinfo.SetMode(decisionpb.HostUserMode_HOST_USER_MODE_KEEP)
-	closer, err = users.UpsertUser("alice", &userinfo)
+	closer, err = users.UpsertUser("alice", userinfo)
 	assert.ErrorIs(t, err, errUnmanagedUser)
 	assert.Equal(t, nil, closer)
 	assert.Zero(t, backend.updateUserCalls)
@@ -621,7 +621,7 @@ func Test_DontManageExistingUser(t *testing.T) {
 
 	// Update static user
 	userinfo.SetMode(decisionpb.HostUserMode_HOST_USER_MODE_STATIC)
-	closer, err = users.UpsertUser("alice", &userinfo)
+	closer, err = users.UpsertUser("alice", userinfo)
 	assert.ErrorIs(t, err, errUnmanagedUser)
 	assert.Equal(t, nil, closer)
 	assert.Zero(t, backend.updateUserCalls)
@@ -683,13 +683,13 @@ func Test_AllowExplicitlyManageExistingUsers(t *testing.T) {
 	assert.NoError(t, backend.CreateUser("alice-keep", []string{}, host.UserOpts{}))
 	assert.NoError(t, backend.CreateUser("alice-static", []string{}, host.UserOpts{}))
 	assert.NoError(t, backend.CreateUser("alice-drop", []string{}, host.UserOpts{}))
-	userinfo := decisionpb.HostUsersInfo{
+	userinfo := decisionpb.HostUsersInfo_builder{
 		Groups: slices.Clone(allGroups),
 		Mode:   decisionpb.HostUserMode_HOST_USER_MODE_KEEP,
-	}
+	}.Build()
 
 	// Take ownership of existing user when in KEEP mode
-	closer, err := users.UpsertUser("alice-keep", &userinfo)
+	closer, err := users.UpsertUser("alice-keep", userinfo)
 	assert.NoError(t, err)
 	assert.Equal(t, nil, closer)
 	assert.Equal(t, 1, backend.updateUserCalls)
@@ -699,7 +699,7 @@ func Test_AllowExplicitlyManageExistingUsers(t *testing.T) {
 
 	// Take ownership of existing user when in STATIC mode
 	userinfo.SetMode(decisionpb.HostUserMode_HOST_USER_MODE_STATIC)
-	closer, err = users.UpsertUser("alice-static", &userinfo, TakeOwnershipIfUserExists(true))
+	closer, err = users.UpsertUser("alice-static", userinfo, TakeOwnershipIfUserExists(true))
 	assert.NoError(t, err)
 	assert.Equal(t, nil, closer)
 	assert.Equal(t, 2, backend.updateUserCalls)
@@ -710,7 +710,7 @@ func Test_AllowExplicitlyManageExistingUsers(t *testing.T) {
 
 	// Don't take ownership of existing user when in DROP mode
 	userinfo.SetMode(decisionpb.HostUserMode_HOST_USER_MODE_DROP)
-	closer, err = users.UpsertUser("alice-drop", &userinfo)
+	closer, err = users.UpsertUser("alice-drop", userinfo)
 	assert.ErrorIs(t, err, errUnmanagedUser)
 	assert.Equal(t, nil, closer)
 	assert.Equal(t, 2, backend.updateUserCalls)
@@ -718,7 +718,7 @@ func Test_AllowExplicitlyManageExistingUsers(t *testing.T) {
 
 	// Don't assign teleport-keep to users created in DROP mode
 	userinfo.SetMode(decisionpb.HostUserMode_HOST_USER_MODE_DROP)
-	closer, err = users.UpsertUser("bob", &userinfo)
+	closer, err = users.UpsertUser("bob", userinfo)
 	assert.NoError(t, err)
 	assert.NotEqual(t, nil, closer)
 	assert.Equal(t, 2, backend.updateUserCalls)
@@ -760,34 +760,34 @@ func TestCreateUserWithExistingPrimaryGroup(t *testing.T) {
 		require.NoError(t, backend.CreateGroup(group, ""))
 	}
 
-	userinfo := decisionpb.HostUsersInfo{
+	userinfo := decisionpb.HostUsersInfo_builder{
 		Groups: []string{},
 		Mode:   decisionpb.HostUserMode_HOST_USER_MODE_DROP,
-	}
+	}.Build()
 
 	// create a user without an existing primary group
-	closer, err := users.UpsertUser("bob", &userinfo)
+	closer, err := users.UpsertUser("bob", userinfo)
 	assert.NoError(t, err)
 	assert.NotEqual(t, nil, closer)
 	assert.Zero(t, backend.updateUserCalls)
 
 	// create a user with primary group defined in userinfo.Groups, but not yet on the host
 	userinfo.SetGroups([]string{"fred"})
-	closer, err = users.UpsertUser("fred", &userinfo)
+	closer, err = users.UpsertUser("fred", userinfo)
 	assert.NoError(t, err)
 	assert.NotEqual(t, nil, closer)
 	assert.Zero(t, backend.updateUserCalls)
 
 	// create a user with primary group defined in userinfo.Groups that already exists on the host
 	userinfo.SetGroups([]string{"alice"})
-	closer, err = users.UpsertUser("alice", &userinfo)
+	closer, err = users.UpsertUser("alice", userinfo)
 	assert.NoError(t, err)
 	assert.NotEqual(t, nil, closer)
 	assert.Zero(t, backend.updateUserCalls)
 
 	// create a user with primary group that already exists on the host but is not defined in userinfo.Groups
 	userinfo.SetGroups([]string{""})
-	closer, err = users.UpsertUser("simon", &userinfo)
+	closer, err = users.UpsertUser("simon", userinfo)
 	assert.True(t, trace.IsAlreadyExists(err))
 	assert.Contains(t, err.Error(), "conflicts with an existing group")
 	assert.Equal(t, nil, closer)
@@ -1137,13 +1137,13 @@ func TestRegressionGroupErrorDoesNotPanic(t *testing.T) {
 	allGroups := []string{"foo", "bar", "baz"}
 	users, backend := initBackend(t, allGroups)
 
-	userinfo := decisionpb.HostUsersInfo{
+	userinfo := decisionpb.HostUsersInfo_builder{
 		Groups: slices.Clone(allGroups[:2]),
 		Mode:   decisionpb.HostUserMode_HOST_USER_MODE_KEEP,
-	}
+	}.Build()
 
 	// Create user
-	closer, err := users.UpsertUser("alice", &userinfo)
+	closer, err := users.UpsertUser("alice", userinfo)
 	assert.NoError(t, err)
 	assert.Equal(t, nil, closer)
 	assert.Zero(t, backend.updateUserCalls)
@@ -1151,20 +1151,20 @@ func TestRegressionGroupErrorDoesNotPanic(t *testing.T) {
 	assert.NotContains(t, backend.users["alice"], apiconstants.TeleportDropGroup)
 
 	backend.groupDatabaseErr = errors.New("could not find group")
-	_, err = users.UpsertUser("alice", &userinfo)
+	_, err = users.UpsertUser("alice", userinfo)
 	require.Error(t, err)
 }
 
 func TestIsUserShell(t *testing.T) {
 	allGroups := []string{"foo", "bar", "baz"}
 	users, backend := initBackend(t, allGroups)
-	userinfo := decisionpb.HostUsersInfo{
+	userinfo := decisionpb.HostUsersInfo_builder{
 		Groups: slices.Clone(allGroups[:2]),
 		Mode:   decisionpb.HostUserMode_HOST_USER_MODE_KEEP,
-	}
+	}.Build()
 
 	// no shell defined, create with default
-	closer, err := users.UpsertUser("alice", &userinfo)
+	closer, err := users.UpsertUser("alice", userinfo)
 	assert.NoError(t, err)
 	assert.Equal(t, nil, closer)
 	hasShell, err := backend.IsUsingShell("alice", "/usr/bin/sh")
@@ -1173,7 +1173,7 @@ func TestIsUserShell(t *testing.T) {
 
 	// shell defined, create with shell
 	userinfo.SetShell("/usr/bin/bash")
-	closer, err = users.UpsertUser("bob", &userinfo)
+	closer, err = users.UpsertUser("bob", userinfo)
 	assert.NoError(t, err)
 	assert.Equal(t, nil, closer)
 	hasShell, err = backend.IsUsingShell("bob", "/usr/bin/bash")
@@ -1181,7 +1181,7 @@ func TestIsUserShell(t *testing.T) {
 	require.True(t, hasShell)
 
 	// shell defined but unchanged, do nothing on update
-	closer, err = users.UpsertUser("bob", &userinfo)
+	closer, err = users.UpsertUser("bob", userinfo)
 	assert.NoError(t, err)
 	assert.Equal(t, nil, closer)
 	hasShell, err = backend.IsUsingShell("bob", "/usr/bin/bash")
@@ -1191,7 +1191,7 @@ func TestIsUserShell(t *testing.T) {
 
 	// shell defined and changed, update user
 	userinfo.SetShell("/usr/bin/zsh")
-	closer, err = users.UpsertUser("bob", &userinfo)
+	closer, err = users.UpsertUser("bob", userinfo)
 	assert.NoError(t, err)
 	assert.Equal(t, nil, closer)
 	hasShell, err = backend.IsUsingShell("bob", "/usr/bin/zsh")

--- a/lib/tbot/workloadidentity/workloadattest/systemd_linux.go
+++ b/lib/tbot/workloadidentity/workloadattest/systemd_linux.go
@@ -71,10 +71,10 @@ func (a *SystemdAttestor) Attest(ctx context.Context, pid int) (*workloadidentit
 		return nil, trace.Errorf("unit %q is not a service", unit)
 	}
 
-	return &workloadidentityv1pb.WorkloadAttrsSystemd{
+	return workloadidentityv1pb.WorkloadAttrsSystemd_builder{
 		Attested: true,
 		Service:  service,
-	}, nil
+	}.Build(), nil
 }
 
 type dbusConn interface {

--- a/lib/tbot/workloadidentity/workloadattest/systemd_linux_test.go
+++ b/lib/tbot/workloadidentity/workloadattest/systemd_linux_test.go
@@ -47,10 +47,10 @@ func TestSystemdAttestor_Success(t *testing.T) {
 	attrs, err := attestor.Attest(context.Background(), 1)
 	require.NoError(t, err)
 
-	expected := &workloadidentityv1.WorkloadAttrsSystemd{
+	expected := workloadidentityv1.WorkloadAttrsSystemd_builder{
 		Attested: true,
 		Service:  "foo",
-	}
+	}.Build()
 	require.Empty(t, cmp.Diff(expected, attrs, protocmp.Transform()))
 }
 

--- a/lib/teleterm/apiserver/handler/handler_unified_resources.go
+++ b/lib/teleterm/apiserver/handler/handler_unified_resources.go
@@ -60,9 +60,9 @@ func (s *Handler) ListUnifiedResources(ctx context.Context, req *api.ListUnified
 		return nil, trace.Wrap(err)
 	}
 
-	response := api.ListUnifiedResourcesResponse{
+	response := api.ListUnifiedResourcesResponse_builder{
 		Resources: []*api.PaginatedResource{}, NextKey: daemonResponse.NextKey,
-	}
+	}.Build()
 
 	for _, resource := range daemonResponse.Resources {
 		if resource.Server != nil {
@@ -103,7 +103,7 @@ func (s *Handler) ListUnifiedResources(ctx context.Context, req *api.ListUnified
 		}
 	}
 
-	return &response, nil
+	return response, nil
 }
 
 func newAPIServer(server clusters.Server) *api.Server {

--- a/lib/teleterm/vnet/service.go
+++ b/lib/teleterm/vnet/service.go
@@ -297,7 +297,7 @@ func (s *Service) RunDiagnostics(ctx context.Context, req *api.RunDiagnosticsReq
 
 	// Skip the DNS check if NetworkStack is unavailable we need at least one
 	// of Ipv6Prefix, Ipv4CidrRanges to derive a VNet DNS server address.
-	if ns := nsa.NetworkStack; ns != nil && (ns.Ipv6Prefix != "" || len(ns.Ipv4CidrRanges) > 0) {
+	if ns := nsa.GetNetworkStack(); ns != nil && (ns.GetIpv6Prefix() != "" || len(ns.GetIpv4CidrRanges()) > 0) {
 		dnsDiag, err := s.dnsDiag(ns)
 		if err != nil {
 			return nil, trace.Wrap(err)
@@ -337,16 +337,16 @@ func (s *Service) sshDiag() (diag.DiagCheck, error) {
 // dnsDiag builds the DNS diagnostic check. It is platform-agnostic.
 func (s *Service) dnsDiag(ns *diagv1.NetworkStack) (diag.DiagCheck, error) {
 	// TODO(tangyatsu): make NetworkStackInfo return DNS server addresses directly.
-	cfg := &diag.DNSConfig{DNSZones: ns.DnsZones}
-	if ns.Ipv6Prefix != "" {
-		s, err := diag.DNSServerForIPv6Prefix(ns.Ipv6Prefix)
+	cfg := &diag.DNSConfig{DNSZones: ns.GetDnsZones()}
+	if ns.GetIpv6Prefix() != "" {
+		s, err := diag.DNSServerForIPv6Prefix(ns.GetIpv6Prefix())
 		if err != nil {
 			return nil, trace.Wrap(err, "computing VNet IPv6 DNS server address for DNS diag check")
 		}
 		cfg.VNetDNSIPv6 = s
 	}
-	if len(ns.Ipv4CidrRanges) > 0 {
-		s, err := diag.DNSServerForIPv4CIDRRange(ns.Ipv4CidrRanges[0])
+	if len(ns.GetIpv4CidrRanges()) > 0 {
+		s, err := diag.DNSServerForIPv4CIDRRange(ns.GetIpv4CidrRanges()[0])
 		if err != nil {
 			return nil, trace.Wrap(err, "computing VNet IPv4 DNS server address for DNS diag check")
 		}
@@ -469,19 +469,19 @@ func (p *clientApplication) ReissueAppCert(ctx context.Context, appInfo *vnetv1.
 	appURI := clusterURI.AppendApp(appKey.GetName())
 
 	routeToApp := vnet.RouteToApp(appInfo, targetPort)
-	apiteletermRouteToApp := apiteleterm.RouteToApp{
+	apiteletermRouteToApp := apiteleterm.RouteToApp_builder{
 		Name:        routeToApp.Name,
 		PublicAddr:  routeToApp.PublicAddr,
 		ClusterName: routeToApp.ClusterName,
 		Uri:         routeToApp.URI,
 		TargetPort:  routeToApp.TargetPort,
-	}
+	}.Build()
 
 	reloginReq := apiteleterm.ReloginRequest_builder{
 		RootClusterUri: clusterURI.GetRootClusterURI().String(),
 		VnetCertExpired: apiteleterm.VnetCertExpired_builder{
 			TargetUri:  appURI.String(),
-			RouteToApp: &apiteletermRouteToApp,
+			RouteToApp: apiteletermRouteToApp,
 		}.Build(),
 	}.Build()
 
@@ -506,7 +506,7 @@ func (p *clientApplication) ReissueAppCert(ctx context.Context, appInfo *vnetv1.
 		notifyErr := p.daemonService.NotifyApp(ctx, apiteleterm.SendNotificationRequest_builder{
 			CannotProxyVnetConnection: apiteleterm.CannotProxyVnetConnection_builder{
 				TargetUri:  appURI.String(),
-				RouteToApp: &apiteletermRouteToApp,
+				RouteToApp: apiteletermRouteToApp,
 				CertReissueError: apiteleterm.CertReissueError_builder{
 					Error: err.Error(),
 				}.Build(),
@@ -638,13 +638,13 @@ func (p *clientApplication) OnInvalidLocalPort(ctx context.Context, appInfo *vne
 		AppendLeafCluster(appKey.GetLeafCluster()).
 		AppendApp(appKey.GetName())
 	routeToApp := vnet.RouteToApp(appInfo, targetPort)
-	apiteletermRouteToApp := apiteleterm.RouteToApp{
+	apiteletermRouteToApp := apiteleterm.RouteToApp_builder{
 		Name:        routeToApp.Name,
 		PublicAddr:  routeToApp.PublicAddr,
 		ClusterName: routeToApp.ClusterName,
 		Uri:         routeToApp.URI,
 		TargetPort:  routeToApp.TargetPort,
-	}
+	}.Build()
 
 	invalidLocalPort := &apiteleterm.InvalidLocalPort{}
 	// Send ports only if there's less than 10 ranges. A bigger number would be difficult to show in
@@ -661,7 +661,7 @@ func (p *clientApplication) OnInvalidLocalPort(ctx context.Context, appInfo *vne
 	err := p.daemonService.NotifyApp(ctx, apiteleterm.SendNotificationRequest_builder{
 		CannotProxyVnetConnection: apiteleterm.CannotProxyVnetConnection_builder{
 			TargetUri:        appURI.String(),
-			RouteToApp:       &apiteletermRouteToApp,
+			RouteToApp:       apiteletermRouteToApp,
 			InvalidLocalPort: proto.ValueOrDefault(invalidLocalPort),
 		}.Build(),
 	}.Build())

--- a/lib/vnet/diag/dns.go
+++ b/lib/vnet/diag/dns.go
@@ -31,6 +31,7 @@ import (
 	"time"
 
 	"github.com/gravitational/trace"
+	"google.golang.org/protobuf/proto"
 
 	diagv1 "github.com/gravitational/teleport/gen/proto/go/teleport/lib/vnet/diag/v1"
 	vnetdns "github.com/gravitational/teleport/lib/vnet/dns"
@@ -137,7 +138,7 @@ func NewDNSDiag(cfg *DNSConfig) (*DNSDiag, error) {
 }
 
 func (d *DNSDiag) EmptyCheckReport() *diagv1.CheckReport {
-	return &diagv1.CheckReport{Report: &diagv1.CheckReport_DnsReport{}}
+	return diagv1.CheckReport_builder{DnsReport: &diagv1.DNSReport{}}.Build()
 }
 
 // Commands returns platform-specific commands that capture additional DNS configuration state.
@@ -150,19 +151,19 @@ func (d *DNSDiag) Run(ctx context.Context) (*diagv1.CheckReport, error) {
 	report := &diagv1.DNSReport{}
 
 	v4, v6 := d.runReachabilityCheck(ctx)
-	report.Ipv4Reachability = toReachabilityProto(v4)
-	report.Ipv6Reachability = toReachabilityProto(v6)
+	report.SetIpv4Reachability(toReachabilityProto(v4))
+	report.SetIpv6Reachability(toReachabilityProto(v6))
 
 	expectedA, expectedAAAA := mergeExpected(ctx, v6, v4)
 
 	if expectedA.IsValid() || expectedAAAA.IsValid() {
-		report.ZoneResults = d.runPerZoneCheck(ctx, expectedA, expectedAAAA)
+		report.SetZoneResults(d.runPerZoneCheck(ctx, expectedA, expectedAAAA))
 	}
 
-	return &diagv1.CheckReport{
-		Status: computeReportStatus(report),
-		Report: &diagv1.CheckReport_DnsReport{DnsReport: report},
-	}, nil
+	return diagv1.CheckReport_builder{
+		Status:    computeReportStatus(report),
+		DnsReport: proto.ValueOrDefault(report),
+	}.Build(), nil
 }
 
 // reachabilityCheckResult captures the result of probing one VNet nameserver for both A and AAAA.
@@ -246,13 +247,13 @@ func toReachabilityProto(o reachabilityCheckResult) *diagv1.VNetDNSReachability 
 	if !o.server.IsValid() {
 		return nil
 	}
-	m := &diagv1.VNetDNSReachability{
+	m := diagv1.VNetDNSReachability_builder{
 		Address:       o.server.String(),
 		RespondedA:    o.a.addr.IsValid(),
 		RespondedAaaa: o.aaaa.addr.IsValid(),
-	}
-	m.Reachable = m.RespondedA || m.RespondedAaaa
-	if !m.Reachable {
+	}.Build()
+	m.SetReachable(m.GetRespondedA() || m.GetRespondedAaaa())
+	if !m.GetReachable() {
 		var errs []string
 		if o.a.err != nil {
 			errs = append(errs, o.a.err.Error())
@@ -260,9 +261,9 @@ func toReachabilityProto(o reachabilityCheckResult) *diagv1.VNetDNSReachability 
 		if o.aaaa.err != nil {
 			errs = append(errs, o.aaaa.err.Error())
 		}
-		m.Error = strings.Join(errs, "\n")
-		if m.Error == "" {
-			m.Error = "server returned no records"
+		m.SetError(strings.Join(errs, "\n"))
+		if m.GetError() == "" {
+			m.SetError("server returned no records")
 		}
 	}
 	return m
@@ -317,16 +318,16 @@ func (d *DNSDiag) runPerZoneCheck(ctx context.Context, expectedA, expectedAAAA n
 
 // queryZone runs A and AAAA queries for a single zone in parallel.
 func (d *DNSDiag) queryZone(ctx context.Context, zone string, expectedA, expectedAAAA netip.Addr) *diagv1.DNSZoneResult {
-	result := &diagv1.DNSZoneResult{Zone: zone}
+	result := diagv1.DNSZoneResult_builder{Zone: zone}.Build()
 	var wg sync.WaitGroup
 	if expectedA.IsValid() {
 		wg.Go(func() {
-			result.ARecord = d.queryZoneRecord(ctx, zone, "ip4", expectedA)
+			result.SetARecord(d.queryZoneRecord(ctx, zone, "ip4", expectedA))
 		})
 	}
 	if expectedAAAA.IsValid() {
 		wg.Go(func() {
-			result.AaaaRecord = d.queryZoneRecord(ctx, zone, "ip6", expectedAAAA)
+			result.SetAaaaRecord(d.queryZoneRecord(ctx, zone, "ip6", expectedAAAA))
 		})
 	}
 	wg.Wait()
@@ -336,7 +337,7 @@ func (d *DNSDiag) queryZone(ctx context.Context, zone string, expectedA, expecte
 // queryZoneRecord runs a single record-type query.
 func (d *DNSDiag) queryZoneRecord(ctx context.Context, zone, network string, expected netip.Addr) *diagv1.RecordResult {
 	result := d.queryZoneRecordOnce(ctx, zone, network, expected)
-	if result.Status != diagv1.DNSZoneStatus_DNS_ZONE_STATUS_NOT_REGISTERED {
+	if result.GetStatus() != diagv1.DNSZoneStatus_DNS_ZONE_STATUS_NOT_REGISTERED {
 		return result
 	}
 	if d.cfg.NotRegisteredRetryDelay <= 0 {
@@ -366,35 +367,35 @@ func classifyRecordResult(addrs []netip.Addr, err error, expected netip.Addr) *d
 		if errors.As(err, &dnsErr) {
 			switch {
 			case dnsErr.IsNotFound:
-				return &diagv1.RecordResult{Status: diagv1.DNSZoneStatus_DNS_ZONE_STATUS_NOT_REGISTERED}
+				return diagv1.RecordResult_builder{Status: diagv1.DNSZoneStatus_DNS_ZONE_STATUS_NOT_REGISTERED}.Build()
 			case dnsErr.IsTimeout:
-				return &diagv1.RecordResult{
+				return diagv1.RecordResult_builder{
 					Status: diagv1.DNSZoneStatus_DNS_ZONE_STATUS_TIMEOUT,
 					Error:  err.Error(),
-				}
+				}.Build()
 			}
 		}
 		if errors.Is(err, context.DeadlineExceeded) {
-			return &diagv1.RecordResult{
+			return diagv1.RecordResult_builder{
 				Status: diagv1.DNSZoneStatus_DNS_ZONE_STATUS_TIMEOUT,
 				Error:  err.Error(),
-			}
+			}.Build()
 		}
-		return &diagv1.RecordResult{
+		return diagv1.RecordResult_builder{
 			Status: diagv1.DNSZoneStatus_DNS_ZONE_STATUS_RESOLVER_ERROR,
 			Error:  err.Error(),
-		}
+		}.Build()
 	}
 	if len(addrs) == 0 {
-		return &diagv1.RecordResult{Status: diagv1.DNSZoneStatus_DNS_ZONE_STATUS_NOT_REGISTERED}
+		return diagv1.RecordResult_builder{Status: diagv1.DNSZoneStatus_DNS_ZONE_STATUS_NOT_REGISTERED}.Build()
 	}
 	if slices.Contains(addrs, expected) {
-		return &diagv1.RecordResult{Status: diagv1.DNSZoneStatus_DNS_ZONE_STATUS_OK}
+		return diagv1.RecordResult_builder{Status: diagv1.DNSZoneStatus_DNS_ZONE_STATUS_OK}.Build()
 	}
-	return &diagv1.RecordResult{
+	return diagv1.RecordResult_builder{
 		Status:     diagv1.DNSZoneStatus_DNS_ZONE_STATUS_HIJACKED,
 		ObservedIp: addrs[0].String(),
-	}
+	}.Build()
 }
 
 // computeReportStatus returns ISSUES_FOUND if every configured nameserver is
@@ -404,11 +405,11 @@ func computeReportStatus(report *diagv1.DNSReport) diagv1.CheckReportStatus {
 		!report.GetIpv6Reachability().GetReachable() {
 		return diagv1.CheckReportStatus_CHECK_REPORT_STATUS_ISSUES_FOUND
 	}
-	for _, zr := range report.ZoneResults {
-		if rr := zr.ARecord; rr != nil && rr.Status != diagv1.DNSZoneStatus_DNS_ZONE_STATUS_OK {
+	for _, zr := range report.GetZoneResults() {
+		if rr := zr.GetARecord(); rr != nil && rr.GetStatus() != diagv1.DNSZoneStatus_DNS_ZONE_STATUS_OK {
 			return diagv1.CheckReportStatus_CHECK_REPORT_STATUS_ISSUES_FOUND
 		}
-		if rr := zr.AaaaRecord; rr != nil && rr.Status != diagv1.DNSZoneStatus_DNS_ZONE_STATUS_OK {
+		if rr := zr.GetAaaaRecord(); rr != nil && rr.GetStatus() != diagv1.DNSZoneStatus_DNS_ZONE_STATUS_OK {
 			return diagv1.CheckReportStatus_CHECK_REPORT_STATUS_ISSUES_FOUND
 		}
 	}

--- a/lib/vnet/diag/dns_test.go
+++ b/lib/vnet/diag/dns_test.go
@@ -153,22 +153,22 @@ func TestDNSDiagAllZonesOK(t *testing.T) {
 
 	report, err := d.Run(t.Context())
 	require.NoError(t, err)
-	require.Equal(t, diagv1.CheckReportStatus_CHECK_REPORT_STATUS_OK, report.Status)
+	require.Equal(t, diagv1.CheckReportStatus_CHECK_REPORT_STATUS_OK, report.GetStatus())
 	dnsReport := report.GetDnsReport()
-	require.NotNil(t, dnsReport.Ipv4Reachability)
-	require.True(t, dnsReport.Ipv4Reachability.Reachable)
-	require.True(t, dnsReport.Ipv4Reachability.RespondedA)
-	require.True(t, dnsReport.Ipv4Reachability.RespondedAaaa)
-	require.NotNil(t, dnsReport.Ipv6Reachability)
-	require.True(t, dnsReport.Ipv6Reachability.Reachable)
-	require.True(t, dnsReport.Ipv6Reachability.RespondedA)
-	require.True(t, dnsReport.Ipv6Reachability.RespondedAaaa)
-	require.Len(t, dnsReport.ZoneResults, 2)
-	for _, zr := range dnsReport.ZoneResults {
-		require.NotNil(t, zr.ARecord, zr.Zone)
-		require.Equal(t, diagv1.DNSZoneStatus_DNS_ZONE_STATUS_OK, zr.ARecord.Status, zr.Zone)
-		require.NotNil(t, zr.AaaaRecord, zr.Zone)
-		require.Equal(t, diagv1.DNSZoneStatus_DNS_ZONE_STATUS_OK, zr.AaaaRecord.Status, zr.Zone)
+	require.NotNil(t, dnsReport.GetIpv4Reachability())
+	require.True(t, dnsReport.GetIpv4Reachability().GetReachable())
+	require.True(t, dnsReport.GetIpv4Reachability().GetRespondedA())
+	require.True(t, dnsReport.GetIpv4Reachability().GetRespondedAaaa())
+	require.NotNil(t, dnsReport.GetIpv6Reachability())
+	require.True(t, dnsReport.GetIpv6Reachability().GetReachable())
+	require.True(t, dnsReport.GetIpv6Reachability().GetRespondedA())
+	require.True(t, dnsReport.GetIpv6Reachability().GetRespondedAaaa())
+	require.Len(t, dnsReport.GetZoneResults(), 2)
+	for _, zr := range dnsReport.GetZoneResults() {
+		require.NotNil(t, zr.GetARecord(), zr.GetZone())
+		require.Equal(t, diagv1.DNSZoneStatus_DNS_ZONE_STATUS_OK, zr.GetARecord().GetStatus(), zr.GetZone())
+		require.NotNil(t, zr.GetAaaaRecord(), zr.GetZone())
+		require.Equal(t, diagv1.DNSZoneStatus_DNS_ZONE_STATUS_OK, zr.GetAaaaRecord().GetStatus(), zr.GetZone())
 	}
 }
 
@@ -191,13 +191,13 @@ func TestDNSDiagBothReachabilityFailureSkipsPerZone(t *testing.T) {
 
 	report, err := d.Run(t.Context())
 	require.NoError(t, err)
-	require.Equal(t, diagv1.CheckReportStatus_CHECK_REPORT_STATUS_ISSUES_FOUND, report.Status)
+	require.Equal(t, diagv1.CheckReportStatus_CHECK_REPORT_STATUS_ISSUES_FOUND, report.GetStatus())
 	dnsReport := report.GetDnsReport()
-	require.False(t, dnsReport.Ipv4Reachability.Reachable)
-	require.Contains(t, dnsReport.Ipv4Reachability.Error, "connection refused")
-	require.False(t, dnsReport.Ipv6Reachability.Reachable)
-	require.Contains(t, dnsReport.Ipv6Reachability.Error, "connection refused")
-	require.Empty(t, dnsReport.ZoneResults, "per-zone check must be skipped when no nameserver returned expected IPs")
+	require.False(t, dnsReport.GetIpv4Reachability().GetReachable())
+	require.Contains(t, dnsReport.GetIpv4Reachability().GetError(), "connection refused")
+	require.False(t, dnsReport.GetIpv6Reachability().GetReachable())
+	require.Contains(t, dnsReport.GetIpv6Reachability().GetError(), "connection refused")
+	require.Empty(t, dnsReport.GetZoneResults(), "per-zone check must be skipped when no nameserver returned expected IPs")
 	require.False(t, resolverCalled, "OS resolver must not be called when both VNet DNS nameservers are unreachable")
 }
 
@@ -220,15 +220,15 @@ func TestDNSDiagOnlyIPv6Reachable(t *testing.T) {
 	report, err := d.Run(t.Context())
 	require.NoError(t, err)
 	dnsReport := report.GetDnsReport()
-	require.False(t, dnsReport.Ipv4Reachability.Reachable)
-	require.True(t, dnsReport.Ipv6Reachability.Reachable)
-	require.Len(t, dnsReport.ZoneResults, 1)
-	zr := dnsReport.ZoneResults[0]
-	require.Equal(t, diagv1.DNSZoneStatus_DNS_ZONE_STATUS_OK, zr.ARecord.Status,
+	require.False(t, dnsReport.GetIpv4Reachability().GetReachable())
+	require.True(t, dnsReport.GetIpv6Reachability().GetReachable())
+	require.Len(t, dnsReport.GetZoneResults(), 1)
+	zr := dnsReport.GetZoneResults()[0]
+	require.Equal(t, diagv1.DNSZoneStatus_DNS_ZONE_STATUS_OK, zr.GetARecord().GetStatus(),
 		"A still verified because the IPv6 nameserver returned an expected A")
-	require.Equal(t, diagv1.DNSZoneStatus_DNS_ZONE_STATUS_OK, zr.AaaaRecord.Status)
+	require.Equal(t, diagv1.DNSZoneStatus_DNS_ZONE_STATUS_OK, zr.GetAaaaRecord().GetStatus())
 	// One unreachable nameserver does not fail the overall check
-	require.Equal(t, diagv1.CheckReportStatus_CHECK_REPORT_STATUS_OK, report.Status)
+	require.Equal(t, diagv1.CheckReportStatus_CHECK_REPORT_STATUS_OK, report.GetStatus())
 }
 
 func TestDNSDiagOnlyIPv6ServerNoAAnswer(t *testing.T) {
@@ -250,16 +250,16 @@ func TestDNSDiagOnlyIPv6ServerNoAAnswer(t *testing.T) {
 	report, err := d.Run(t.Context())
 	require.NoError(t, err)
 	dnsReport := report.GetDnsReport()
-	require.Nil(t, dnsReport.Ipv4Reachability, "IPv4 reachability must be unset when IPv4 server is not configured")
-	require.NotNil(t, dnsReport.Ipv6Reachability)
-	require.True(t, dnsReport.Ipv6Reachability.Reachable)
-	require.True(t, dnsReport.Ipv6Reachability.RespondedAaaa)
-	require.False(t, dnsReport.Ipv6Reachability.RespondedA, "expected no A response")
-	require.Len(t, dnsReport.ZoneResults, 1)
-	zr := dnsReport.ZoneResults[0]
-	require.Nil(t, zr.ARecord, "A record result must be nil when no expected A was captured")
-	require.NotNil(t, zr.AaaaRecord)
-	require.Equal(t, diagv1.DNSZoneStatus_DNS_ZONE_STATUS_OK, zr.AaaaRecord.Status)
+	require.Nil(t, dnsReport.GetIpv4Reachability(), "IPv4 reachability must be unset when IPv4 server is not configured")
+	require.NotNil(t, dnsReport.GetIpv6Reachability())
+	require.True(t, dnsReport.GetIpv6Reachability().GetReachable())
+	require.True(t, dnsReport.GetIpv6Reachability().GetRespondedAaaa())
+	require.False(t, dnsReport.GetIpv6Reachability().GetRespondedA(), "expected no A response")
+	require.Len(t, dnsReport.GetZoneResults(), 1)
+	zr := dnsReport.GetZoneResults()[0]
+	require.Nil(t, zr.GetARecord(), "A record result must be nil when no expected A was captured")
+	require.NotNil(t, zr.GetAaaaRecord())
+	require.Equal(t, diagv1.DNSZoneStatus_DNS_ZONE_STATUS_OK, zr.GetAaaaRecord().GetStatus())
 }
 
 func TestDNSDiagPerRecordTypeClassification(t *testing.T) {
@@ -318,36 +318,36 @@ func TestDNSDiagPerRecordTypeClassification(t *testing.T) {
 
 	report, err := d.Run(t.Context())
 	require.NoError(t, err)
-	require.Equal(t, diagv1.CheckReportStatus_CHECK_REPORT_STATUS_ISSUES_FOUND, report.Status)
+	require.Equal(t, diagv1.CheckReportStatus_CHECK_REPORT_STATUS_ISSUES_FOUND, report.GetStatus())
 
 	byZone := map[string]*diagv1.DNSZoneResult{}
-	for _, zr := range report.GetDnsReport().ZoneResults {
-		byZone[zr.Zone] = zr
+	for _, zr := range report.GetDnsReport().GetZoneResults() {
+		byZone[zr.GetZone()] = zr
 	}
 
-	assert.Equal(t, diagv1.DNSZoneStatus_DNS_ZONE_STATUS_OK, byZone["ok.test"].ARecord.Status)
-	assert.Equal(t, diagv1.DNSZoneStatus_DNS_ZONE_STATUS_OK, byZone["ok.test"].AaaaRecord.Status)
+	assert.Equal(t, diagv1.DNSZoneStatus_DNS_ZONE_STATUS_OK, byZone["ok.test"].GetARecord().GetStatus())
+	assert.Equal(t, diagv1.DNSZoneStatus_DNS_ZONE_STATUS_OK, byZone["ok.test"].GetAaaaRecord().GetStatus())
 
-	assert.Equal(t, diagv1.DNSZoneStatus_DNS_ZONE_STATUS_HIJACKED, byZone["a-hijacked.test"].ARecord.Status)
-	assert.Equal(t, testHijackA.String(), byZone["a-hijacked.test"].ARecord.ObservedIp)
-	assert.Equal(t, diagv1.DNSZoneStatus_DNS_ZONE_STATUS_OK, byZone["a-hijacked.test"].AaaaRecord.Status)
+	assert.Equal(t, diagv1.DNSZoneStatus_DNS_ZONE_STATUS_HIJACKED, byZone["a-hijacked.test"].GetARecord().GetStatus())
+	assert.Equal(t, testHijackA.String(), byZone["a-hijacked.test"].GetARecord().GetObservedIp())
+	assert.Equal(t, diagv1.DNSZoneStatus_DNS_ZONE_STATUS_OK, byZone["a-hijacked.test"].GetAaaaRecord().GetStatus())
 
-	assert.Equal(t, diagv1.DNSZoneStatus_DNS_ZONE_STATUS_OK, byZone["aaaa-hijacked.test"].ARecord.Status)
-	assert.Equal(t, diagv1.DNSZoneStatus_DNS_ZONE_STATUS_HIJACKED, byZone["aaaa-hijacked.test"].AaaaRecord.Status)
-	assert.Equal(t, testHijackAAAA.String(), byZone["aaaa-hijacked.test"].AaaaRecord.ObservedIp)
+	assert.Equal(t, diagv1.DNSZoneStatus_DNS_ZONE_STATUS_OK, byZone["aaaa-hijacked.test"].GetARecord().GetStatus())
+	assert.Equal(t, diagv1.DNSZoneStatus_DNS_ZONE_STATUS_HIJACKED, byZone["aaaa-hijacked.test"].GetAaaaRecord().GetStatus())
+	assert.Equal(t, testHijackAAAA.String(), byZone["aaaa-hijacked.test"].GetAaaaRecord().GetObservedIp())
 
-	assert.Equal(t, diagv1.DNSZoneStatus_DNS_ZONE_STATUS_TIMEOUT, byZone["mixed.test"].ARecord.Status)
-	assert.Equal(t, diagv1.DNSZoneStatus_DNS_ZONE_STATUS_HIJACKED, byZone["mixed.test"].AaaaRecord.Status)
-	assert.Equal(t, testHijackAAAA.String(), byZone["mixed.test"].AaaaRecord.ObservedIp)
+	assert.Equal(t, diagv1.DNSZoneStatus_DNS_ZONE_STATUS_TIMEOUT, byZone["mixed.test"].GetARecord().GetStatus())
+	assert.Equal(t, diagv1.DNSZoneStatus_DNS_ZONE_STATUS_HIJACKED, byZone["mixed.test"].GetAaaaRecord().GetStatus())
+	assert.Equal(t, testHijackAAAA.String(), byZone["mixed.test"].GetAaaaRecord().GetObservedIp())
 
-	assert.Equal(t, diagv1.DNSZoneStatus_DNS_ZONE_STATUS_NOT_REGISTERED, byZone["missing.test"].ARecord.Status)
-	assert.Equal(t, diagv1.DNSZoneStatus_DNS_ZONE_STATUS_NOT_REGISTERED, byZone["missing.test"].AaaaRecord.Status)
+	assert.Equal(t, diagv1.DNSZoneStatus_DNS_ZONE_STATUS_NOT_REGISTERED, byZone["missing.test"].GetARecord().GetStatus())
+	assert.Equal(t, diagv1.DNSZoneStatus_DNS_ZONE_STATUS_NOT_REGISTERED, byZone["missing.test"].GetAaaaRecord().GetStatus())
 
-	assert.Equal(t, diagv1.DNSZoneStatus_DNS_ZONE_STATUS_TIMEOUT, byZone["slow.test"].ARecord.Status)
-	assert.NotEmpty(t, byZone["slow.test"].ARecord.Error)
+	assert.Equal(t, diagv1.DNSZoneStatus_DNS_ZONE_STATUS_TIMEOUT, byZone["slow.test"].GetARecord().GetStatus())
+	assert.NotEmpty(t, byZone["slow.test"].GetARecord().GetError())
 
-	assert.Equal(t, diagv1.DNSZoneStatus_DNS_ZONE_STATUS_RESOLVER_ERROR, byZone["borked.test"].ARecord.Status)
-	assert.Contains(t, byZone["borked.test"].ARecord.Error, "SERVFAIL")
+	assert.Equal(t, diagv1.DNSZoneStatus_DNS_ZONE_STATUS_RESOLVER_ERROR, byZone["borked.test"].GetARecord().GetStatus())
+	assert.Contains(t, byZone["borked.test"].GetARecord().GetError(), "SERVFAIL")
 }
 
 func TestDNSDiagEmptyZonesOnlyReachability(t *testing.T) {
@@ -363,10 +363,10 @@ func TestDNSDiagEmptyZonesOnlyReachability(t *testing.T) {
 
 	report, err := d.Run(t.Context())
 	require.NoError(t, err)
-	require.Equal(t, diagv1.CheckReportStatus_CHECK_REPORT_STATUS_OK, report.Status)
-	require.True(t, report.GetDnsReport().Ipv4Reachability.Reachable)
-	require.True(t, report.GetDnsReport().Ipv6Reachability.Reachable)
-	require.Empty(t, report.GetDnsReport().ZoneResults)
+	require.Equal(t, diagv1.CheckReportStatus_CHECK_REPORT_STATUS_OK, report.GetStatus())
+	require.True(t, report.GetDnsReport().GetIpv4Reachability().GetReachable())
+	require.True(t, report.GetDnsReport().GetIpv6Reachability().GetReachable())
+	require.Empty(t, report.GetDnsReport().GetZoneResults())
 }
 
 func TestDNSDiagReachabilityNoAnswer(t *testing.T) {
@@ -384,11 +384,11 @@ func TestDNSDiagReachabilityNoAnswer(t *testing.T) {
 
 	report, err := d.Run(t.Context())
 	require.NoError(t, err)
-	require.Equal(t, diagv1.CheckReportStatus_CHECK_REPORT_STATUS_ISSUES_FOUND, report.Status)
-	require.False(t, report.GetDnsReport().Ipv4Reachability.Reachable)
-	require.Contains(t, report.GetDnsReport().Ipv4Reachability.Error, "server returned no records")
-	require.False(t, report.GetDnsReport().Ipv6Reachability.Reachable)
-	require.Contains(t, report.GetDnsReport().Ipv6Reachability.Error, "server returned no records")
+	require.Equal(t, diagv1.CheckReportStatus_CHECK_REPORT_STATUS_ISSUES_FOUND, report.GetStatus())
+	require.False(t, report.GetDnsReport().GetIpv4Reachability().GetReachable())
+	require.Contains(t, report.GetDnsReport().GetIpv4Reachability().GetError(), "server returned no records")
+	require.False(t, report.GetDnsReport().GetIpv6Reachability().GetReachable())
+	require.Contains(t, report.GetDnsReport().GetIpv6Reachability().GetError(), "server returned no records")
 }
 
 func TestDNSDiagCrossTransportFallback(t *testing.T) {
@@ -422,15 +422,15 @@ func TestDNSDiagCrossTransportFallback(t *testing.T) {
 	report, err := d.Run(t.Context())
 	require.NoError(t, err)
 	dnsReport := report.GetDnsReport()
-	require.True(t, dnsReport.Ipv6Reachability.RespondedAaaa)
-	require.False(t, dnsReport.Ipv6Reachability.RespondedA)
-	require.True(t, dnsReport.Ipv4Reachability.RespondedA)
-	require.True(t, dnsReport.Ipv4Reachability.RespondedAaaa)
-	require.Len(t, dnsReport.ZoneResults, 1)
-	zr := dnsReport.ZoneResults[0]
-	require.NotNil(t, zr.ARecord, "A check must still run using A captured from the IPv4 nameserver")
-	require.Equal(t, diagv1.DNSZoneStatus_DNS_ZONE_STATUS_OK, zr.ARecord.Status)
-	require.Equal(t, diagv1.DNSZoneStatus_DNS_ZONE_STATUS_OK, zr.AaaaRecord.Status)
+	require.True(t, dnsReport.GetIpv6Reachability().GetRespondedAaaa())
+	require.False(t, dnsReport.GetIpv6Reachability().GetRespondedA())
+	require.True(t, dnsReport.GetIpv4Reachability().GetRespondedA())
+	require.True(t, dnsReport.GetIpv4Reachability().GetRespondedAaaa())
+	require.Len(t, dnsReport.GetZoneResults(), 1)
+	zr := dnsReport.GetZoneResults()[0]
+	require.NotNil(t, zr.GetARecord(), "A check must still run using A captured from the IPv4 nameserver")
+	require.Equal(t, diagv1.DNSZoneStatus_DNS_ZONE_STATUS_OK, zr.GetARecord().GetStatus())
+	require.Equal(t, diagv1.DNSZoneStatus_DNS_ZONE_STATUS_OK, zr.GetAaaaRecord().GetStatus())
 }
 
 func TestDNSDiagProbeFormat(t *testing.T) {
@@ -483,11 +483,11 @@ func TestDNSDiagNotRegisteredRetryRecovers(t *testing.T) {
 
 	report, err := d.Run(t.Context())
 	require.NoError(t, err)
-	require.Equal(t, diagv1.CheckReportStatus_CHECK_REPORT_STATUS_OK, report.Status,
+	require.Equal(t, diagv1.CheckReportStatus_CHECK_REPORT_STATUS_OK, report.GetStatus(),
 		"transient NOT_REGISTERED followed by OK on retry must result in overall OK")
-	zr := report.GetDnsReport().ZoneResults[0]
-	require.Equal(t, diagv1.DNSZoneStatus_DNS_ZONE_STATUS_OK, zr.ARecord.Status)
-	require.Equal(t, diagv1.DNSZoneStatus_DNS_ZONE_STATUS_OK, zr.AaaaRecord.Status)
+	zr := report.GetDnsReport().GetZoneResults()[0]
+	require.Equal(t, diagv1.DNSZoneStatus_DNS_ZONE_STATUS_OK, zr.GetARecord().GetStatus())
+	require.Equal(t, diagv1.DNSZoneStatus_DNS_ZONE_STATUS_OK, zr.GetAaaaRecord().GetStatus())
 
 	for _, network := range []string{"ip4", "ip6"} {
 		calls, _ := callsPerKey.Load(key{"company.test", network})
@@ -512,10 +512,10 @@ func TestDNSDiagNotRegisteredRetryPersistentFailure(t *testing.T) {
 
 	report, err := d.Run(t.Context())
 	require.NoError(t, err)
-	zr := report.GetDnsReport().ZoneResults[0]
-	require.Equal(t, diagv1.DNSZoneStatus_DNS_ZONE_STATUS_NOT_REGISTERED, zr.ARecord.Status,
+	zr := report.GetDnsReport().GetZoneResults()[0]
+	require.Equal(t, diagv1.DNSZoneStatus_DNS_ZONE_STATUS_NOT_REGISTERED, zr.GetARecord().GetStatus(),
 		"persistent NOT_REGISTERED must still report NOT_REGISTERED after the retry")
-	require.Equal(t, diagv1.DNSZoneStatus_DNS_ZONE_STATUS_NOT_REGISTERED, zr.AaaaRecord.Status)
+	require.Equal(t, diagv1.DNSZoneStatus_DNS_ZONE_STATUS_NOT_REGISTERED, zr.GetAaaaRecord().GetStatus())
 	require.Equal(t, int32(4), calls.Load(), "resolver must be called exactly 4 times (2 record types × 2 attempts each)")
 }
 
@@ -544,7 +544,7 @@ func TestDNSDiagReachabilityRetryRecoversFromStartupGap(t *testing.T) {
 
 	report, err := d.Run(t.Context())
 	require.NoError(t, err)
-	require.True(t, report.GetDnsReport().Ipv6Reachability.Reachable,
+	require.True(t, report.GetDnsReport().GetIpv6Reachability().GetReachable(),
 		"reachability check must succeed on the third attempt once VNet's DNS comes up")
 	require.Equal(t, int32(3), attempts.Load(), "reachability check must be attempted 3 times (2 failures + 1 success)")
 }
@@ -573,8 +573,8 @@ func TestDNSDiagReachabilityRetryPersistentFailure(t *testing.T) {
 	report, err := d.Run(t.Context())
 	require.NoError(t, err)
 	dnsReport := report.GetDnsReport()
-	require.False(t, dnsReport.Ipv6Reachability.Reachable)
-	require.Contains(t, dnsReport.Ipv6Reachability.Error, "i/o timeout")
+	require.False(t, dnsReport.GetIpv6Reachability().GetReachable())
+	require.Contains(t, dnsReport.GetIpv6Reachability().GetError(), "i/o timeout")
 	require.Equal(t, int32(defaultReachabilityMaxAttempts), attempts.Load(),
 		"reachability check must be retried up to ReachabilityMaxAttempts before giving up")
 }

--- a/lib/web/machineid.go
+++ b/lib/web/machineid.go
@@ -305,10 +305,10 @@ func updateBot(ctx context.Context, botName string, request updateBotRequestV3, 
 		return nil, trace.Wrap(err)
 	}
 
-	metadata := headerv1.Metadata{
+	metadata := headerv1.Metadata_builder{
 		Name: botName,
-	}
-	spec := machineidv1.BotSpec{}
+	}.Build()
+	spec := &machineidv1.BotSpec{}
 
 	if request.Roles != nil {
 		mask.Append(&machineidv1.Bot{}, "spec.roles")
@@ -352,8 +352,8 @@ func updateBot(ctx context.Context, botName string, request updateBotRequestV3, 
 		Bot: machineidv1.Bot_builder{
 			Kind:     types.KindBot,
 			Version:  types.V1,
-			Metadata: &metadata,
-			Spec:     &spec,
+			Metadata: metadata,
+			Spec:     spec,
 		}.Build(),
 	}.Build())
 	if err != nil {

--- a/lib/web/machineid_test.go
+++ b/lib/web/machineid_test.go
@@ -1243,7 +1243,7 @@ func TestGetBotInstance(t *testing.T) {
 	var resp GetBotInstanceResponse
 	require.NoError(t, json.Unmarshal(response.Bytes(), &resp), "invalid response received")
 
-	require.Empty(t, cmp.Diff(resp.BotInstance, machineidv1.BotInstance{
+	require.Empty(t, cmp.Diff(resp.BotInstance, machineidv1.BotInstance_builder{
 		Kind:    types.KindBotInstance,
 		Version: types.V1,
 		Spec: machineidv1.BotInstanceSpec_builder{
@@ -1258,7 +1258,7 @@ func TestGetBotInstance(t *testing.T) {
 				},
 			}.Build(),
 		}.Build(),
-	}, protocmp.Transform(), protocmp.IgnoreFields(&machineidv1.BotInstance{}, "metadata")))
+	}.Build(), protocmp.Transform(), protocmp.IgnoreFields(&machineidv1.BotInstance{}, "metadata")))
 	assert.YAMLEq(t, fmt.Sprintf("kind: bot_instance\nmetadata:\n  name: %[1]s\n  revision: %[2]s\nspec:\n  bot_name: test-bot\n  instance_id: %[1]s\nstatus:\n  initial_heartbeat:\n    recorded_at: \"1970-01-01T00:00:01Z\"\nversion: v1\n", instanceID, resp.BotInstance.GetMetadata().GetRevision()), resp.YAML)
 }
 

--- a/lib/web/notifications_test.go
+++ b/lib/web/notifications_test.go
@@ -238,7 +238,7 @@ func unmarshalNotificationsResponse(t *testing.T, resp []byte) *GetNotifications
 func newUserNotification(t *testing.T, username string, title string) *notificationsv1.Notification {
 	t.Helper()
 
-	notification := notificationsv1.Notification{
+	notification := notificationsv1.Notification_builder{
 		SubKind: "test-subkind",
 		Spec: notificationsv1.NotificationSpec_builder{
 			Username: username,
@@ -248,9 +248,9 @@ func newUserNotification(t *testing.T, username string, title string) *notificat
 				types.NotificationTitleLabel: title,
 			},
 		}.Build(),
-	}
+	}.Build()
 
-	return &notification
+	return notification
 }
 
 func newGlobalNotification(t *testing.T, title string, spec *notificationsv1.GlobalNotificationSpec) *notificationsv1.GlobalNotification {
@@ -266,11 +266,11 @@ func newGlobalNotification(t *testing.T, title string, spec *notificationsv1.Glo
 		}.Build(),
 	}.Build())
 
-	notification := notificationsv1.GlobalNotification{
+	notification := notificationsv1.GlobalNotification_builder{
 		Spec: spec,
-	}
+	}.Build()
 
-	return &notification
+	return notification
 }
 
 // notificationsToTitlesList accepts a list of notifications notifications and returns a slice of strings containing their titles in order, this is used to compare against

--- a/tool/tctl/common/autoupdate_command_test.go
+++ b/tool/tctl/common/autoupdate_command_test.go
@@ -658,27 +658,27 @@ Agent Version dev  prod stage
 func TestAutoUpdateAgentStatusStructuredOutput(t *testing.T) {
 	ctx := t.Context()
 	now := time.Date(2026, 5, 28, 12, 0, 0, 0, time.UTC)
-	rollout := &autoupdatepb.AutoUpdateAgentRollout{
-		Spec: &autoupdatepb.AutoUpdateAgentRolloutSpec{
+	rollout := autoupdatepb.AutoUpdateAgentRollout_builder{
+		Spec: autoupdatepb.AutoUpdateAgentRolloutSpec_builder{
 			AutoupdateMode: "enabled",
 			StartVersion:   "1.2.3",
 			TargetVersion:  "1.2.4",
 			Schedule:       "regular",
 			Strategy:       "time-based",
-		},
-		Status: &autoupdatepb.AutoUpdateAgentRolloutStatus{
+		}.Build(),
+		Status: autoupdatepb.AutoUpdateAgentRolloutStatus_builder{
 			StartTime: timestamppb.New(now),
 			State:     autoupdatepb.AutoUpdateAgentRolloutState_AUTO_UPDATE_AGENT_ROLLOUT_STATE_ACTIVE,
 			Groups: []*autoupdatepb.AutoUpdateAgentRolloutStatusGroup{
-				{
+				autoupdatepb.AutoUpdateAgentRolloutStatusGroup_builder{
 					Name:          "dev",
 					State:         autoupdatepb.AutoUpdateAgentGroupState_AUTO_UPDATE_AGENT_GROUP_STATE_ACTIVE,
 					PresentCount:  3,
 					UpToDateCount: 2,
-				},
+				}.Build(),
 			},
-		},
-	}
+		}.Build(),
+	}.Build()
 
 	for _, format := range []string{"json", "yaml"} {
 		t.Run(format, func(t *testing.T) {
@@ -705,22 +705,22 @@ func TestAutoUpdateAgentReportStructuredOutput(t *testing.T) {
 	ctx := t.Context()
 	now := time.Now()
 	reports := []*autoupdatepb.AutoUpdateAgentReport{
-		{
-			Metadata: &headerv1.Metadata{Name: "auth1"},
-			Spec: &autoupdatepb.AutoUpdateAgentReportSpec{
+		autoupdatepb.AutoUpdateAgentReport_builder{
+			Metadata: headerv1.Metadata_builder{Name: "auth1"}.Build(),
+			Spec: autoupdatepb.AutoUpdateAgentReportSpec_builder{
 				Timestamp: timestamppb.New(now),
 				Groups: map[string]*autoupdatepb.AutoUpdateAgentReportSpecGroup{
-					"dev": {
+					"dev": autoupdatepb.AutoUpdateAgentReportSpecGroup_builder{
 						Versions: map[string]*autoupdatepb.AutoUpdateAgentReportSpecGroupVersion{
-							"1.2.3": {Count: 2},
+							"1.2.3": autoupdatepb.AutoUpdateAgentReportSpecGroupVersion_builder{Count: 2}.Build(),
 						},
-					},
+					}.Build(),
 				},
 				Omitted: []*autoupdatepb.AutoUpdateAgentReportSpecOmitted{
-					{Reason: "agent is too old", Count: 1},
+					autoupdatepb.AutoUpdateAgentReportSpecOmitted_builder{Reason: "agent is too old", Count: 1}.Build(),
 				},
-			},
-		},
+			}.Build(),
+		}.Build(),
 	}
 
 	for _, format := range []string{"json", "yaml"} {

--- a/tool/tctl/common/bots_command_test.go
+++ b/tool/tctl/common/bots_command_test.go
@@ -501,18 +501,18 @@ func TestAddAndListBotInstancesJSON(t *testing.T) {
 func TestAggregateServiceHealth(t *testing.T) {
 	t.Parallel()
 
-	healthy := machineidv1pb.BotInstanceServiceHealth{
+	healthy := machineidv1pb.BotInstanceServiceHealth_builder{
 		Status: machineidv1pb.BotInstanceHealthStatus_BOT_INSTANCE_HEALTH_STATUS_HEALTHY,
-	}
-	unhealthy := machineidv1pb.BotInstanceServiceHealth{
+	}.Build()
+	unhealthy := machineidv1pb.BotInstanceServiceHealth_builder{
 		Status: machineidv1pb.BotInstanceHealthStatus_BOT_INSTANCE_HEALTH_STATUS_UNHEALTHY,
-	}
-	initializing := machineidv1pb.BotInstanceServiceHealth{
+	}.Build()
+	initializing := machineidv1pb.BotInstanceServiceHealth_builder{
 		Status: machineidv1pb.BotInstanceHealthStatus_BOT_INSTANCE_HEALTH_STATUS_INITIALIZING,
-	}
-	unknown := machineidv1pb.BotInstanceServiceHealth{
+	}.Build()
+	unknown := machineidv1pb.BotInstanceServiceHealth_builder{
 		Status: machineidv1pb.BotInstanceHealthStatus_BOT_INSTANCE_HEALTH_STATUS_UNSPECIFIED,
-	}
+	}.Build()
 
 	tcs := []struct {
 		name      string
@@ -533,73 +533,50 @@ func TestAggregateServiceHealth(t *testing.T) {
 			status:    0,
 		},
 		{
-			name: "one item - healthy",
-			services: []*machineidv1pb.BotInstanceServiceHealth{
-				&healthy,
-			},
+			name:      "one item - healthy",
+			services:  []*machineidv1pb.BotInstanceServiceHealth{healthy},
 			hasStatus: true,
 			status:    machineidv1pb.BotInstanceHealthStatus_BOT_INSTANCE_HEALTH_STATUS_HEALTHY,
 		},
 		{
-			name: "one item - unhealthy",
-			services: []*machineidv1pb.BotInstanceServiceHealth{
-				&unhealthy,
-			},
+			name:      "one item - unhealthy",
+			services:  []*machineidv1pb.BotInstanceServiceHealth{unhealthy},
 			hasStatus: true,
 			status:    machineidv1pb.BotInstanceHealthStatus_BOT_INSTANCE_HEALTH_STATUS_UNHEALTHY,
 		},
 		{
-			name: "one item - initializing",
-			services: []*machineidv1pb.BotInstanceServiceHealth{
-				&initializing,
-			},
+			name:      "one item - initializing",
+			services:  []*machineidv1pb.BotInstanceServiceHealth{initializing},
 			hasStatus: true,
 			status:    machineidv1pb.BotInstanceHealthStatus_BOT_INSTANCE_HEALTH_STATUS_INITIALIZING,
 		},
 		{
-			name: "one item - unknown",
-			services: []*machineidv1pb.BotInstanceServiceHealth{
-				&unknown,
-			},
+			name:      "one item - unknown",
+			services:  []*machineidv1pb.BotInstanceServiceHealth{unknown},
 			hasStatus: true,
 			status:    machineidv1pb.BotInstanceHealthStatus_BOT_INSTANCE_HEALTH_STATUS_UNSPECIFIED,
 		},
 		{
-			name: "multiple items - healthy",
-			services: []*machineidv1pb.BotInstanceServiceHealth{
-				&healthy,
-				&healthy,
-			},
+			name:      "multiple items - healthy",
+			services:  []*machineidv1pb.BotInstanceServiceHealth{healthy, healthy},
 			hasStatus: true,
 			status:    machineidv1pb.BotInstanceHealthStatus_BOT_INSTANCE_HEALTH_STATUS_HEALTHY,
 		},
 		{
-			name: "multiple items - unhealthy",
-			services: []*machineidv1pb.BotInstanceServiceHealth{
-				&unhealthy,
-				&healthy,
-				&initializing,
-				&unknown,
-			},
+			name:      "multiple items - unhealthy",
+			services:  []*machineidv1pb.BotInstanceServiceHealth{unhealthy, healthy, initializing, unknown},
 			hasStatus: true,
 			status:    machineidv1pb.BotInstanceHealthStatus_BOT_INSTANCE_HEALTH_STATUS_UNHEALTHY,
 		},
 		{
-			name: "multiple items - unknown",
-			services: []*machineidv1pb.BotInstanceServiceHealth{
-				&healthy,
-				&initializing,
-				&unknown,
-			},
+			name:      "multiple items - unknown",
+			services:  []*machineidv1pb.BotInstanceServiceHealth{healthy, initializing, unknown},
 			hasStatus: true,
 			status:    machineidv1pb.BotInstanceHealthStatus_BOT_INSTANCE_HEALTH_STATUS_UNSPECIFIED,
 		},
 		{
-			name: "multiple items - initializing",
-			services: []*machineidv1pb.BotInstanceServiceHealth{
-				&healthy,
-				&initializing,
-			},
+			name:      "multiple items - initializing",
+			services:  []*machineidv1pb.BotInstanceServiceHealth{healthy, initializing},
 			hasStatus: true,
 			status:    machineidv1pb.BotInstanceHealthStatus_BOT_INSTANCE_HEALTH_STATUS_INITIALIZING,
 		},

--- a/tool/tctl/common/plugin/awsic.go
+++ b/tool/tctl/common/plugin/awsic.go
@@ -461,20 +461,18 @@ func (p *PluginsCommand) RotateAWSICCreds(ctx context.Context, args pluginServic
 		return trace.BadParameter("plugin has no credentials reference")
 	}
 
-	req := pluginspb.UpdatePluginStaticCredentialsRequest{
-		Target: &pluginspb.UpdatePluginStaticCredentialsRequest_Query{
-			Query: pluginspb.CredentialQuery_builder{
-				Labels: staticCredsRef.Labels,
-			}.Build(),
-		},
+	req := pluginspb.UpdatePluginStaticCredentialsRequest_builder{
+		Query: pluginspb.CredentialQuery_builder{
+			Labels: staticCredsRef.Labels,
+		}.Build(),
 		Credential: &types.PluginStaticCredentialsSpecV1{
 			Credentials: &types.PluginStaticCredentialsSpecV1_APIToken{
 				APIToken: p.rotateCreds.awsic.payload,
 			},
 		},
-	}
+	}.Build()
 
-	_, err = args.plugins.UpdatePluginStaticCredentials(ctx, &req)
+	_, err = args.plugins.UpdatePluginStaticCredentials(ctx, req)
 	if err != nil {
 		return trace.Wrap(err, "updating credentials")
 	}

--- a/tool/tctl/common/plugin/plugins_command_test.go
+++ b/tool/tctl/common/plugin/plugins_command_test.go
@@ -23,13 +23,15 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/gravitational/trace"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/crypto/bcrypt"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/testing/protocmp"
 	"google.golang.org/protobuf/types/known/emptypb"
 
-	"github.com/gravitational/teleport/api/client/proto"
+	clientproto "github.com/gravitational/teleport/api/client/proto"
 	pluginsv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/plugins/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/service/servicecfg"
@@ -291,7 +293,7 @@ func TestPluginsInstallOkta(t *testing.T) {
 						},
 						Spec: &types.PluginStaticCredentialsSpecV1{
 							Credentials: &types.PluginStaticCredentialsSpecV1_APIToken{
-								APIToken: "scim-token-goes-here",
+								APIToken: "i am a scim token",
 							},
 						},
 					},
@@ -355,6 +357,21 @@ func TestPluginsInstallOkta(t *testing.T) {
 							},
 						},
 					},
+					{
+						ResourceHeader: types.ResourceHeader{
+							Metadata: types.Metadata{
+								Name: "okta-barebones-test-scim-token",
+								Labels: map[string]string{
+									types.OktaCredPurposeLabel: types.OktaCredPurposeSCIMToken,
+								},
+							},
+						},
+						Spec: &types.PluginStaticCredentialsSpecV1{
+							Credentials: &types.PluginStaticCredentialsSpecV1_APIToken{
+								APIToken: "OktaCredPurposeSCIMToken",
+							},
+						},
+					},
 				},
 				CredentialLabels: map[string]string{
 					types.OktaOrgURLLabel: "https://example.okta.com",
@@ -412,6 +429,21 @@ func TestPluginsInstallOkta(t *testing.T) {
 						Spec: &types.PluginStaticCredentialsSpecV1{
 							Credentials: &types.PluginStaticCredentialsSpecV1_APIToken{
 								APIToken: "api-token-goes-here",
+							},
+						},
+					},
+					{
+						ResourceHeader: types.ResourceHeader{
+							Metadata: types.Metadata{
+								Name: "okta-scim-token",
+								Labels: map[string]string{
+									types.OktaCredPurposeLabel: types.OktaCredPurposeSCIMToken,
+								},
+							},
+						},
+						Spec: &types.PluginStaticCredentialsSpecV1{
+							Credentials: &types.PluginStaticCredentialsSpecV1_APIToken{
+								APIToken: "test-scim-token",
 							},
 						},
 					},
@@ -485,20 +517,6 @@ func TestPluginsInstallOkta(t *testing.T) {
 		},
 	}
 
-	cmpOptions := []cmp.Option{
-		// Ignore extraneous fields for protobuf bookkeeping
-		cmpopts.IgnoreUnexported(pluginsv1.CreatePluginRequest{}),
-
-		// Ignore any SCIM-token credentials because the bcrypt hash of the token
-		// will change on every run.
-		// TODO: Find a way to only exclude the token hash from the comparison,
-		//       rather than the whole credential
-		cmpopts.IgnoreSliceElements(func(c *types.PluginStaticCredentialsV1) bool {
-			l, _ := c.GetLabel(types.OktaCredPurposeLabel)
-			return l == types.OktaCredPurposeSCIMToken
-		}),
-	}
-
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
 			var args pluginServices
@@ -512,7 +530,8 @@ func TestPluginsInstallOkta(t *testing.T) {
 					Run(func(args mock.Arguments) {
 						require.IsType(t, (*pluginsv1.CreatePluginRequest)(nil), args.Get(1))
 						request := args.Get(1).(*pluginsv1.CreatePluginRequest)
-						require.Empty(t, cmp.Diff(testCase.expectRequest, request, cmpOptions...))
+						request = normalizeSCIMTokenHashes(t, testCase.expectRequest, request)
+						require.Empty(t, cmp.Diff(testCase.expectRequest, request, protocmp.Transform()))
 					}).
 					Return(&emptypb.Empty{}, nil)
 
@@ -533,7 +552,7 @@ func TestPluginsInstallOkta(t *testing.T) {
 			if testCase.expectPing {
 				authClient.
 					On("Ping", anyContext).
-					Return(proto.PingResponse{
+					Return(clientproto.PingResponse{
 						ProxyPublicAddr: "example.com",
 					}, nil)
 			}
@@ -548,6 +567,36 @@ func TestPluginsInstallOkta(t *testing.T) {
 			testCase.expectError(t, err)
 		})
 	}
+}
+
+func normalizeSCIMTokenHashes(t *testing.T, expected, actual *pluginsv1.CreatePluginRequest) *pluginsv1.CreatePluginRequest {
+	t.Helper()
+
+	expectedTokens := make(map[string]string)
+	for _, cred := range expected.GetStaticCredentialsList() {
+		if !isSCIMTokenCredential(cred) {
+			continue
+		}
+		expectedTokens[cred.GetName()] = cred.GetAPIToken()
+	}
+
+	normalized := proto.CloneOf(actual)
+	for _, cred := range normalized.GetStaticCredentialsList() {
+		if !isSCIMTokenCredential(cred) {
+			continue
+		}
+
+		expectedToken, ok := expectedTokens[cred.GetName()]
+		require.True(t, ok, "unexpected SCIM token credential %q", cred.GetName())
+		require.NoError(t, bcrypt.CompareHashAndPassword([]byte(cred.GetAPIToken()), []byte(expectedToken)))
+		cred.Spec.Credentials = &types.PluginStaticCredentialsSpecV1_APIToken{APIToken: expectedToken}
+	}
+	return normalized
+}
+
+func isSCIMTokenCredential(cred *types.PluginStaticCredentialsV1) bool {
+	label, _ := cred.GetLabel(types.OktaCredPurposeLabel)
+	return label == types.OktaCredPurposeSCIMToken
 }
 
 func requireBadParameter(t require.TestingT, err error, msgAndArgs ...any) {

--- a/tool/tsh/common/access_request.go
+++ b/tool/tsh/common/access_request.go
@@ -540,7 +540,7 @@ func searchRequestableResources(cf *CLIConf) error {
 		if cf.kubeAPIGroup != "" {
 			resourceType = resourceType + "." + cf.kubeAPIGroup
 		}
-		req := kubeproto.ListKubernetesResourcesRequest{
+		req := kubeproto.ListKubernetesResourcesRequest_builder{
 			ResourceType:        resourceType,
 			Labels:              tc.Labels,
 			PredicateExpression: cf.PredicateExpression,
@@ -549,9 +549,9 @@ func searchRequestableResources(cf *CLIConf) error {
 			KubernetesCluster:   cf.KubernetesCluster,
 			KubernetesNamespace: cf.kubeNamespace,
 			TeleportCluster:     tc.SiteName,
-		}
+		}.Build()
 
-		resources, err := client.GetKubernetesResourcesWithFilters(cf.Context, proxyGRPCClient, &req)
+		resources, err := client.GetKubernetesResourcesWithFilters(cf.Context, proxyGRPCClient, req)
 		if err != nil {
 			return trace.Wrap(err)
 		}

--- a/tool/tsh/common/vnet.go
+++ b/tool/tsh/common/vnet.go
@@ -136,8 +136,8 @@ func runDNSDiag(ctx context.Context, vnetProcess *vnet.UserProcess) error {
 		return trace.Wrap(err, "getting unified cluster config for DNS diag")
 	}
 	dnsCfg := &diag.DNSConfig{DNSZones: cfg.AllDNSZones()}
-	if nsi.Ipv6Prefix != "" {
-		s, err := diag.DNSServerForIPv6Prefix(nsi.Ipv6Prefix)
+	if nsi.GetIpv6Prefix() != "" {
+		s, err := diag.DNSServerForIPv6Prefix(nsi.GetIpv6Prefix())
 		if err != nil {
 			return trace.Wrap(err, "computing VNet IPv6 DNS server address for DNS diag")
 		}
@@ -175,32 +175,32 @@ func printDNSReport(r *diagv1.DNSReport) {
 		family string
 		r      *diagv1.VNetDNSReachability
 	}{
-		{"IPv6", r.Ipv6Reachability},
-		{"IPv4", r.Ipv4Reachability},
+		{"IPv6", r.GetIpv6Reachability()},
+		{"IPv4", r.GetIpv4Reachability()},
 	} {
 		if f.r == nil {
 			continue
 		}
-		if !f.r.Reachable {
-			fmt.Printf("VNet %s DNS unreachable on %s: %s\n", f.family, f.r.Address, f.r.Error)
+		if !f.r.GetReachable() {
+			fmt.Printf("VNet %s DNS unreachable on %s: %s\n", f.family, f.r.GetAddress(), f.r.GetError())
 			continue
 		}
-		fmt.Printf("VNet %s DNS reachable on %s (responds to %s)\n", f.family, f.r.Address, respondedRecordTypes(f.r))
+		fmt.Printf("VNet %s DNS reachable on %s (responds to %s)\n", f.family, f.r.GetAddress(), respondedRecordTypes(f.r))
 	}
-	for _, zr := range r.ZoneResults {
-		printZoneRecordResult(zr.Zone, "A", zr.ARecord)
-		printZoneRecordResult(zr.Zone, "AAAA", zr.AaaaRecord)
+	for _, zr := range r.GetZoneResults() {
+		printZoneRecordResult(zr.GetZone(), "A", zr.GetARecord())
+		printZoneRecordResult(zr.GetZone(), "AAAA", zr.GetAaaaRecord())
 	}
 }
 
 // respondedRecordTypes returns a human-readable list of record types the server responded to.
 func respondedRecordTypes(r *diagv1.VNetDNSReachability) string {
 	switch {
-	case r.RespondedA && r.RespondedAaaa:
+	case r.GetRespondedA() && r.GetRespondedAaaa():
 		return "A, AAAA"
-	case r.RespondedA:
+	case r.GetRespondedA():
 		return "A only"
-	case r.RespondedAaaa:
+	case r.GetRespondedAaaa():
 		return "AAAA only"
 	default:
 		return "nothing"
@@ -211,18 +211,18 @@ func printZoneRecordResult(zone, recordType string, r *diagv1.RecordResult) {
 	if r == nil {
 		return
 	}
-	switch r.Status {
+	switch r.GetStatus() {
 	case diagv1.DNSZoneStatus_DNS_ZONE_STATUS_OK:
 		// Working as expected; not printed.
 	case diagv1.DNSZoneStatus_DNS_ZONE_STATUS_HIJACKED:
-		fmt.Printf("DNS zone %q %s record is hijacked: observed=%s\n", zone, recordType, r.ObservedIp)
+		fmt.Printf("DNS zone %q %s record is hijacked: observed=%s\n", zone, recordType, r.GetObservedIp())
 	case diagv1.DNSZoneStatus_DNS_ZONE_STATUS_NOT_REGISTERED:
 		fmt.Printf("DNS zone %q %s record is not registered with the OS resolver\n", zone, recordType)
 	case diagv1.DNSZoneStatus_DNS_ZONE_STATUS_TIMEOUT:
-		fmt.Printf("DNS zone %q %s record timed out: %s\n", zone, recordType, r.Error)
+		fmt.Printf("DNS zone %q %s record timed out: %s\n", zone, recordType, r.GetError())
 	case diagv1.DNSZoneStatus_DNS_ZONE_STATUS_RESOLVER_ERROR:
-		fmt.Printf("DNS zone %q %s record resolver error: %s\n", zone, recordType, r.Error)
+		fmt.Printf("DNS zone %q %s record resolver error: %s\n", zone, recordType, r.GetError())
 	default:
-		fmt.Printf("DNS zone %q %s record has unexpected status %s\n", zone, recordType, r.Status)
+		fmt.Printf("DNS zone %q %s record has unexpected status %s\n", zone, recordType, r.GetStatus())
 	}
 }

--- a/tool/tsh/common/vnet_linux.go
+++ b/tool/tsh/common/vnet_linux.go
@@ -65,7 +65,7 @@ func newPlatformVnetUninstallServiceCommand(app *kingpin.Application) vnetComman
 func runVnetDiagnostics(ctx context.Context, vnetProcess *vnet.UserProcess) error {
 	nsi := vnetProcess.NetworkStackInfo()
 	routeConflictDiag, err := diag.NewRouteConflictDiag(&diag.RouteConflictConfig{
-		VnetIfaceName: nsi.InterfaceName,
+		VnetIfaceName: nsi.GetInterfaceName(),
 		Routing:       &diag.LinuxRouting{},
 		Interfaces:    &diag.NetInterfaces{},
 	})
@@ -77,7 +77,7 @@ func runVnetDiagnostics(ctx context.Context, vnetProcess *vnet.UserProcess) erro
 		return trace.Wrap(err)
 	}
 
-	for _, rc := range rcs.GetRouteConflictReport().RouteConflicts {
+	for _, rc := range rcs.GetRouteConflictReport().GetRouteConflicts() {
 		fmt.Printf("Found a conflicting route: %+v\n", rc)
 	}
 


### PR DESCRIPTION
All of the changes here are mechanical conversions generated from open2opaque rewrite -levels=red./.... This concludes the conversion of teleport to consume the opaque APIs. The corresponding changes in teleport.e must be completed prior to switching entirely to opaque codegen.

See https://protobuf.dev/reference/go/opaque-migration/ for more details.