### PR TITLE
Disable the embedded session helper by default

### DIFF
--- a/integration/helpers/testmain.go
+++ b/integration/helpers/testmain.go
@@ -33,10 +33,10 @@ import (
 // TestMainImplementation will re-execute Teleport to run a command if "exec" is passed to
 // it as an argument. Otherwise, it will run tests as normal.
 func TestMainImplementation(m *testing.M) {
-	if ok, err := reexec.InitEmbeddedReexec(); err != nil {
-		panic(err)
-	} else if !ok {
+	if !reexec.EmbeddedReexecAvailable {
 		reexec.MaybeReexec()
+	} else if err := reexec.InitEmbeddedReexec(); err != nil {
+		panic(err)
 	} else if reexec.IsReexec() {
 		panic("reexec attempted when embedded reexec was supposed to be available")
 	}

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -3568,14 +3568,7 @@ func (process *TeleportProcess) initSSH() error {
 			logger.WarnContext(process.ExitContext(), warn)
 		}
 
-		// TODO(espadolini): relax this once the selinux module is updated to support the potentially embedded reexec helper
-		if !cfg.SSH.EnableSELinux {
-			checkEmbeddedReexecAndLog(process.ExitContext(), logger)
-		} else {
-			logger.DebugContext(process.ExitContext(),
-				"The embedded session helper is not supported when SELinux support is enabled.",
-			)
-		}
+		checkEmbeddedReexecAndLog(process.ExitContext(), cfg.SSH.EnableSELinux, logger)
 
 		useLocalListener := cfg.SSH.ForceListen || !conn.UseTunnel()
 
@@ -3869,19 +3862,75 @@ func (process *TeleportProcess) initSSH() error {
 	return nil
 }
 
-func checkEmbeddedReexecAndLog(ctx context.Context, logger *slog.Logger) {
-	if ok, err := reexec.InitEmbeddedReexec(); err != nil {
-		logger.WarnContext(ctx,
-			"This Teleport build supports the embedded session helper but it is not available in this environment, performance of user sessions might be impacted.",
-			"error", err,
+func checkEmbeddedReexecAndLog(ctx context.Context, selinux bool, logger *slog.Logger) {
+	var explicitlyDisabled, explicitlyEnabled bool
+	if e := os.Getenv("TELEPORT_UNSTABLE_DISABLE_EMBEDDED_REEXEC"); e != "" {
+		b, err := apiutils.ParseBool(e)
+		if err != nil {
+			logger.WarnContext(ctx,
+				"Failed to parse the TELEPORT_UNSTABLE_DISABLE_EMBEDDED_REEXEC envvar, proceeding as if it was set to true",
+				"error", err,
+			)
+			b = true
+		}
+		if b {
+			explicitlyDisabled = true
+		} else {
+			explicitlyEnabled = true
+		}
+	}
+
+	if !reexec.EmbeddedReexecAvailable {
+		level := slog.LevelDebug
+		if explicitlyEnabled {
+			level = slog.LevelWarn
+		}
+		logger.LogAttrs(ctx, level,
+			"This Teleport build does not support the embedded session helper for user sessions.",
 		)
-	} else if ok {
-		logger.DebugContext(ctx,
-			"The embedded session helper is available and will be used for user sessions.",
+		return
+	}
+
+	// TODO(espadolini): relax this once the selinux module is updated to support the potentially embedded reexec helper
+	if selinux {
+		level := slog.LevelDebug
+		if explicitlyEnabled {
+			level = slog.LevelWarn
+		}
+		logger.LogAttrs(ctx, level,
+			"The embedded session helper is not supported when SELinux support is enabled.",
+		)
+		return
+	}
+
+	if explicitlyDisabled {
+		slog.InfoContext(ctx, "The embedded session helper was explicitly disabled and will not be used for user sessions.")
+		return
+	}
+
+	// TODO(espadolini): enable by default in v19
+	if !explicitlyEnabled {
+		slog.DebugContext(ctx, "The embedded session helper is not enabled and will not be used for user sessions.")
+		return
+	}
+
+	if err := reexec.InitEmbeddedReexec(); err != nil {
+		// TODO(espadolini): always warn in v19
+		level := slog.LevelDebug
+		if explicitlyEnabled {
+			level = slog.LevelWarn
+		}
+		logger.LogAttrs(ctx, level,
+			"This Teleport build supports the embedded session helper but it is not available in this environment, performance of user sessions might be impacted.",
+			slog.Any("error", err),
 		)
 	} else {
-		logger.DebugContext(ctx,
-			"This Teleport build does not support the embedded session helper for user sessions.",
+		level := slog.LevelDebug
+		if explicitlyEnabled {
+			level = slog.LevelInfo
+		}
+		logger.LogAttrs(ctx, level,
+			"The embedded session helper is available and will be used for user sessions.",
 		)
 	}
 }

--- a/session/reexec/embed.go
+++ b/session/reexec/embed.go
@@ -16,13 +16,17 @@
 
 package reexec
 
-// InitEmbeddedReexec tries to set up the embedded session helper for execution,
-// returning true if the helper is available and was tested successfully, false
-// if there is no embedded session helper in the build, or an error if the
-// helper is present in the build but the setup failed. This function can be
-// called multiple times with no adverse effects, and, if successful, any
-// subsequent call to [CommandOSTweaks] will result in a reexecution using the
-// embedded helper rather than the current process.
-func InitEmbeddedReexec() (bool, error) {
+// EmbeddedReexecAvailable is true if the embedded session helper could be
+// enabled in this build.
+const EmbeddedReexecAvailable bool = embeddedReexecAvailable
+
+// InitEmbeddedReexec tries to set up the embedded session helper for execution.
+// This function can be called multiple times with no adverse effects, and, if
+// successful, any subsequent call to [CommandOSTweaks] will result in a
+// reexecution using the embedded helper rather than the current process. On
+// builds without support for the embedded session helper, this function will
+// unconditionally fail. Such a condition can be more clearly checked by using
+// [EmbeddedReexecAvailable].
+func InitEmbeddedReexec() error {
 	return initEmbeddedReexec()
 }

--- a/session/reexec/embed_embed_linux.go
+++ b/session/reexec/embed_embed_linux.go
@@ -28,18 +28,19 @@ import (
 	"github.com/gravitational/trace"
 )
 
+// embeddedReexecAvailable is the definition of [EmbeddedReexecAvailable] in
+// this build.
+const embeddedReexecAvailable = true
+
 var embeddedReexecMemfd atomic.Pointer[os.File]
 
 var embeddedReexecOnce sync.Once
 var embeddedReexecError error
 
-func initEmbeddedReexec() (bool, error) {
+// initEmbeddedReexec is the implementation of [InitEmbeddedReexec] in this
+// build.
+func initEmbeddedReexec() error {
 	embeddedReexecOnce.Do(func() {
-		if os.Getenv("TELEPORT_UNSTABLE_DISABLE_EMBEDDED_REEXEC") == "yes" {
-			embeddedReexecError = trace.Errorf("embedded binary disabled by TELEPORT_UNSTABLE_DISABLE_EMBEDDED_REEXEC")
-			return
-		}
-
 		// this name is only displayed as a link in /proc/<pid>/exe or /proc/<pid>/fd/<n>
 		mf, err := loadEmbeddedReexec("teleport-sessionhelper", sessionHelperGZ)
 		if err != nil {
@@ -50,7 +51,7 @@ func initEmbeddedReexec() (bool, error) {
 		embeddedReexecMemfd.Store(mf)
 	})
 
-	return true, embeddedReexecError
+	return embeddedReexecError
 }
 
 func setLinuxReexecPath(cmd *exec.Cmd) {

--- a/session/reexec/embed_noembed.go
+++ b/session/reexec/embed_noembed.go
@@ -18,6 +18,14 @@
 
 package reexec
 
-func initEmbeddedReexec() (bool, error) {
-	return false, nil
+import "github.com/gravitational/trace"
+
+// embeddedReexecAvailable is the definition of [EmbeddedReexecAvailable] in
+// this build.
+const embeddedReexecAvailable = false
+
+// initEmbeddedReexec is the implementation of [InitEmbeddedReexec] in this
+// build.
+func initEmbeddedReexec() error {
+	return trace.Errorf("the embedded session helper is not available in this build")
 }

--- a/tool/teleport/common/teleport.go
+++ b/tool/teleport/common/teleport.go
@@ -849,21 +849,16 @@ Examples:
 	case metricsCmd.FullCommand():
 		err = onMetrics(ctx, ccf.ConfigFile)
 	case checkSessionHelperCmd.FullCommand():
-		var ok bool
-		ok, err = reexec.InitEmbeddedReexec()
+		if !reexec.EmbeddedReexecAvailable {
+			fmt.Println("The embedded session helper is not available in this build.")
+			break
+		}
+		err = reexec.InitEmbeddedReexec()
 		if err == nil {
-			if ok {
-				fmt.Println("The embedded session helper is available in this build.")
-			} else {
-				fmt.Println("The embedded session helper is not available in this build.")
-			}
+			fmt.Println("The embedded session helper is available in this build.")
 		}
 	case requireSessionHelperCmd.FullCommand():
-		var ok bool
-		ok, err = reexec.InitEmbeddedReexec()
-		if err == nil && !ok {
-			err = errors.New("the embedded session helper is not available in this build")
-		}
+		err = reexec.InitEmbeddedReexec()
 	case moduleSourceCmd.FullCommand():
 		if runtime.GOOS != "linux" {
 			break


### PR DESCRIPTION
Disable the SSH session helper reexec by default, since more than a few customers have encountered issues due to endpoint security software preventing sessions from starting or outright killing the Teleport agent. The functionality can be enabled by setting the `TELEPORT_UNSTABLE_DISABLE_EMBEDDED_REEXEC` envvar to `no`; the double negative comes from the fact that the same envvar can be set to `yes` in versions of Teleport that default to using the session helper, and using the same envvar is preferrable to having two envvars that only apply in different versions of Teleport.

This PR also moves the handling of the envvar up to lib/service and expands on the messages logged about it.

<!-- Provide a descriptive entry for the changelog of the next release. -->

Changelog: the embedded session helper functionality introduced in v18.8.0 to improve memory usage and latency of SSH sessions is now disabled by default due to incompatibility with some endpoint protection services. It can be enabled by setting the `TELEPORT_UNSTABLE_DISABLE_EMBEDDED_REEXEC` envvar to `no`.


<!-- Include manual testing efforts to verify the change. -->
<!-- Detail where the tests where run and what configurations were used. -->
<!-- Include all the test cases which were run to validate the change. -->

## Manual Test Plan
### Test Environment

Cloud staging control plane (version is irrelevant), agent with this PR running on ubuntu 24.04 on EC2

### Test Cases
- [x] running Teleport with no envvars does not use the embedded session helper
- [x] running Teleport with `TELEPORT_UNSTABLE_DISABLE_EMBEDDED_REEXEC=no` uses the embedded session helper 