### PR TITLE
Update Sub CA proto comments

### DIFF
--- a/api/client/proto/authservice.pb.go
+++ b/api/client/proto/authservice.pb.go
@@ -6226,7 +6226,9 @@ type DatabaseCertResponse struct {
 	// Cert and TrustChain are the certificates the client should present
 	// (tls.Config.Certificates). Pseudocode:
 	//
-	// 	tlsConfig.Certificates = append([]*tls.Certificate{resp.Cert}, resp.TrustChain...)
+	// 	tlsConfig.Certificates = []tls.Certificate{{
+	// 		Certificate: append([][]byte{resp.Cert}, resp.TrustChain...),
+	// 	}}
 	TrustChain [][]byte `protobuf:"bytes,3,rep,name=TrustChain,proto3" json:"trust_chain"`
 	// CA override details. Optional.
 	// If present then a CA override was active during certificate issuance.

--- a/api/gen/proto/go/teleport/subca/v1/cert_authority_override.pb.go
+++ b/api/gen/proto/go/teleport/subca/v1/cert_authority_override.pb.go
@@ -291,7 +291,8 @@ func (b0 CertAuthorityOverrideSpec_builder) Build() *CertAuthorityOverrideSpec {
 // CertAuthorityOverride resource.
 type CertAuthorityOverrideStatus struct {
 	state protoimpl.MessageState `protogen:"hybrid.v1"`
-	// CRLs generated for each certificate override.
+	// CRLs generated for each certificate override, keyed by normalized/lowercase
+	// public_key_hash.
 	PublicKeyHashToCrl map[string]*CertificateRevocationList `protobuf:"bytes,1,rep,name=public_key_hash_to_crl,json=publicKeyHashToCrl,proto3" json:"public_key_hash_to_crl,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
 	unknownFields      protoimpl.UnknownFields
 	sizeCache          protoimpl.SizeCache
@@ -336,7 +337,8 @@ func (x *CertAuthorityOverrideStatus) SetPublicKeyHashToCrl(v map[string]*Certif
 type CertAuthorityOverrideStatus_builder struct {
 	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
 
-	// CRLs generated for each certificate override.
+	// CRLs generated for each certificate override, keyed by normalized/lowercase
+	// public_key_hash.
 	PublicKeyHashToCrl map[string]*CertificateRevocationList
 }
 

--- a/api/gen/proto/go/teleport/subca/v1/cert_authority_override_protoopaque.pb.go
+++ b/api/gen/proto/go/teleport/subca/v1/cert_authority_override_protoopaque.pb.go
@@ -327,7 +327,8 @@ func (x *CertAuthorityOverrideStatus) SetPublicKeyHashToCrl(v map[string]*Certif
 type CertAuthorityOverrideStatus_builder struct {
 	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
 
-	// CRLs generated for each certificate override.
+	// CRLs generated for each certificate override, keyed by normalized/lowercase
+	// public_key_hash.
 	PublicKeyHashToCrl map[string]*CertificateRevocationList
 }
 

--- a/api/proto/teleport/legacy/client/proto/authservice.proto
+++ b/api/proto/teleport/legacy/client/proto/authservice.proto
@@ -1196,7 +1196,9 @@ message DatabaseCertResponse {
   // Cert and TrustChain are the certificates the client should present
   // (tls.Config.Certificates). Pseudocode:
   //
-  // 	tlsConfig.Certificates = append([]*tls.Certificate{resp.Cert}, resp.TrustChain...)
+  // 	tlsConfig.Certificates = []tls.Certificate{{
+  // 		Certificate: append([][]byte{resp.Cert}, resp.TrustChain...),
+  // 	}}
   repeated bytes TrustChain = 3 [(gogoproto.jsontag) = "trust_chain"];
   // CA override details. Optional.
   // If present then a CA override was active during certificate issuance.

--- a/api/proto/teleport/subca/v1/cert_authority_override.proto
+++ b/api/proto/teleport/subca/v1/cert_authority_override.proto
@@ -61,6 +61,7 @@ message CertAuthorityOverrideSpec {
 // CertAuthorityOverrideStatus is the dynamic, system-managed state of a
 // CertAuthorityOverride resource.
 message CertAuthorityOverrideStatus {
-  // CRLs generated for each certificate override.
+  // CRLs generated for each certificate override, keyed by normalized/lowercase
+  // public_key_hash.
   map<string, CertificateRevocationList> public_key_hash_to_crl = 1;
 }


### PR DESCRIPTION
Update comments:

* Mention key normalization on CertAuthorityOverrideStatus (https://github.com/gravitational/teleport.e/pull/8863).
* Update the pseudocode example on DatabaseCertResponse so it correctly shows the Cert+TrustChain append as a single tls.Certificate.

https://github.com/gravitational/teleport.e/issues/7675