### PR TITLE
Change PluginData encoding to use base64

### DIFF
--- a/integrations/access/accessrequest/plugindata.go
+++ b/integrations/access/accessrequest/plugindata.go
@@ -19,7 +19,8 @@
 package accessrequest
 
 import (
-	"fmt"
+	"encoding/base64"
+	"encoding/json"
 	"strings"
 
 	"github.com/gravitational/trace"
@@ -36,10 +37,10 @@ type PluginData struct {
 // MessageData contains all the required information to identify and edit a message.
 type MessageData struct {
 	// ChannelID identifies a channel.
-	ChannelID string
+	ChannelID string `json:"channelId"`
 	// MessageID identifies a specific message in the channel.
 	// For example: on Discord this is an ID while on Slack this is a timestamp.
-	MessageID string
+	MessageID string `json:"messageId"`
 }
 
 type SentMessages []MessageData
@@ -47,40 +48,60 @@ type SentMessages []MessageData
 // DecodePluginData deserializes a string map to PluginData struct.
 func DecodePluginData(dataMap map[string]string) (PluginData, error) {
 	data := PluginData{}
+	var errors []error
 
-	var err error
-	data.AccessRequestData, err = plugindata.DecodeAccessRequestData(dataMap)
+	accessRequestData, err := plugindata.DecodeAccessRequestData(dataMap)
 	if err != nil {
-		return PluginData{}, trace.Wrap(err)
+		return data, trace.Wrap(err, "failed to decode access request data")
 	}
+	data.AccessRequestData = accessRequestData
 
+	// Backward compatibility for single-message data
 	if channelID, timestamp := dataMap["channel_id"], dataMap["timestamp"]; channelID != "" && timestamp != "" {
 		data.SentMessages = append(data.SentMessages, MessageData{ChannelID: channelID, MessageID: timestamp})
 	}
 
 	if str := dataMap["messages"]; str != "" {
 		for encodedMsg := range strings.SplitSeq(str, ",") {
-			if parts := strings.Split(encodedMsg, "/"); len(parts) == 2 {
-				data.SentMessages = append(data.SentMessages, MessageData{ChannelID: parts[0], MessageID: parts[1]})
+			var msg MessageData
+			decodedMsg, err := base64.StdEncoding.DecodeString(encodedMsg)
+			if err == nil {
+				err = json.Unmarshal(decodedMsg, &msg)
 			}
+			if err != nil {
+				// Backward compatibility
+				parts := strings.Split(encodedMsg, "/")
+				if len(parts) == 2 {
+					data.SentMessages = append(data.SentMessages, MessageData{ChannelID: parts[0], MessageID: parts[1]})
+				} else {
+					errors = append(errors, err)
+				}
+				continue
+			}
+			data.SentMessages = append(data.SentMessages, msg)
 		}
 	}
-	return data, nil
+	return data, trace.NewAggregate(errors...)
 }
 
 // EncodePluginData serializes a PluginData struct into a string map.
 func EncodePluginData(data PluginData) (map[string]string, error) {
 	result, err := plugindata.EncodeAccessRequestData(data.AccessRequestData)
 	if err != nil {
-		return nil, trace.Wrap(err)
+		return nil, trace.Wrap(err, "failed to encode access request data")
 	}
 
+	var errors []error
 	var encodedMessages []string
 	for _, msg := range data.SentMessages {
-		// TODO(hugoShaka): switch to base64 encode to avoid having / and , characters that could lead to bad parsing
-		encodedMessages = append(encodedMessages, fmt.Sprintf("%s/%s", msg.ChannelID, msg.MessageID))
+		jsonMessage, err := json.Marshal(msg)
+		if err != nil {
+			errors = append(errors, err)
+		}
+		encodedMessage := base64.StdEncoding.EncodeToString(jsonMessage)
+		encodedMessages = append(encodedMessages, encodedMessage)
 	}
 	result["messages"] = strings.Join(encodedMessages, ",")
 
-	return result, nil
+	return result, trace.NewAggregate(errors...)
 }

--- a/integrations/access/accessrequest/plugindata_test.go
+++ b/integrations/access/accessrequest/plugindata_test.go
@@ -50,6 +50,8 @@ func getSamplePluginData(t *testing.T) PluginData {
 	}
 }
 
+const messageData = "eyJjaGFubmVsSWQiOiJDSEFOTkVMMSIsIm1lc3NhZ2VJZCI6IjAwMDAwMDEifQ==,eyJjaGFubmVsSWQiOiJDSEFOTkVMMiIsIm1lc3NhZ2VJZCI6IjAwMDAwMDIifQ=="
+
 func TestEncodePluginData(t *testing.T) {
 	dataMap, err := EncodePluginData(getSamplePluginData(t))
 	assert.NoError(t, err)
@@ -62,8 +64,25 @@ func TestEncodePluginData(t *testing.T) {
 	assert.Equal(t, "3", dataMap["reviews_count"])
 	assert.Equal(t, "APPROVED", dataMap["resolution"])
 	assert.Equal(t, "foo ok", dataMap["resolve_reason"])
-	assert.Equal(t, "CHANNEL1/0000001,CHANNEL2/0000002", dataMap["messages"])
+	assert.Equal(t, messageData, dataMap["messages"])
 	assert.Equal(t, "2006-01-02T15:04:05Z", dataMap["max_duration"])
+}
+
+func TestDecodePluginDataCompatibility(t *testing.T) {
+	pluginData, err := DecodePluginData(map[string]string{
+		"user":           "user-foo",
+		"roles":          "role-foo,role-bar",
+		"resources":      `["cluster-a/node/foo","cluster-a/node/bar"]`,
+		"request_kind":   "LONG_TERM",
+		"request_reason": "foo reason",
+		"reviews_count":  "3",
+		"resolution":     "APPROVED",
+		"resolve_reason": "foo ok",
+		"messages":       "CHANNEL1/0000001,CHANNEL2/0000002",
+		"max_duration":   "2006-01-02T15:04:05Z",
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, getSamplePluginData(t), pluginData)
 }
 
 func TestDecodePluginData(t *testing.T) {
@@ -76,7 +95,7 @@ func TestDecodePluginData(t *testing.T) {
 		"reviews_count":  "3",
 		"resolution":     "APPROVED",
 		"resolve_reason": "foo ok",
-		"messages":       "CHANNEL1/0000001,CHANNEL2/0000002",
+		"messages":       messageData,
 		"max_duration":   "2006-01-02T15:04:05Z",
 	})
 	assert.NoError(t, err)


### PR DESCRIPTION
Closes [gravitational/pressure-washing#273](https://github.com/gravitational/pressure-washing/issues/273)

Uses base64 encoding instead of delimiters for encoding plugin data.
Backward compatibility for decoding messages with existing delimiters.

## Manual Test Plan
### Test Environment

Teleport Cloud. Local Slack plugin.

### Test Cases
- [x] Plugin works normally for access request notifications