### PR TITLE
app: Reject duplicate app public addresses at startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,13 @@ change is backwards compatible apart from three cases:
 Rolling upgrades are supported: older-agent heartbeats are
 normalized so previously valid names still pass.
 
+Static configs with two apps that resolve to the same public address
+are now rejected when the app service starts. Previously Teleport
+accepted the config and routed requests to those apps
+non-deterministically. The effective address is resolved the same way
+it is at registration, from the app's `public_addr` or, when unset,
+from a registered proxy's public address.
+
 #### CLI --help Output Improvements
 
 In the past, Teleport CLI programs printed all subcommands, subcommands'

--- a/docs/pages/enroll-resources/application-access/protect-apps/connecting-apps.mdx
+++ b/docs/pages/enroll-resources/application-access/protect-apps/connecting-apps.mdx
@@ -222,6 +222,13 @@ is registered:
 `public_addr` (if set) must be a bare, lowercase DNS hostname. URI
 schemes, ports, IP addresses, and uppercase letters are rejected.
 
+In static config, two apps cannot resolve to the same public address.
+The effective address is `public_addr` if set, otherwise
+`<name>.<proxy_public_addr>`, derived from a registered proxy. When the
+app service starts, Teleport rejects a config where two apps resolve to
+the same address, including the case where one app's `public_addr`
+matches another app's name-plus-proxy default.
+
 After Teleport is running, users can access the app at `app-name.proxy_public_addr.com`
 e.g. `grafana.teleport.example.com`. You can also override `public_addr` e.g
 `grafana.acme.com` if you configure the appropriate DNS entry to point to the

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -6817,13 +6817,16 @@ func (process *TeleportProcess) initApps() {
 			})
 		}
 
+		// Reject duplicate public addresses before creating servers.
+		publicAddrs, err := resolveStaticAppPublicAddrs(process.ExitContext(), accessPoint, process.Config.Apps.Apps)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+
 		// Loop over each application and create a server.
 		var applications types.Apps
-		for _, app := range process.Config.Apps.Apps {
-			publicAddr, err := getPublicAddr(process.ExitContext(), accessPoint, app)
-			if err != nil {
-				return trace.Wrap(err)
-			}
+		for i, app := range process.Config.Apps.Apps {
+			publicAddr := publicAddrs[i]
 
 			var rewrite *types.Rewrite
 			if app.Rewrite != nil {
@@ -7377,22 +7380,59 @@ func dumperHandler(w http.ResponseWriter, r *http.Request) {
 	fmt.Fprint(w, string(requestDump))
 }
 
-// getPublicAddr waits for a proxy to be registered with Teleport.
-func getPublicAddr(ctx context.Context, authClient authclient.ReadAppsAccessPoint, a servicecfg.App) (string, error) {
+// resolveStaticAppPublicAddrs resolves the effective public address of
+// each app, returned index-aligned with apps, and rejects two apps
+// that resolve to the same address. The proxy dispatches matching app
+// servers at random, so a shared public address routes
+// non-deterministically.
+func resolveStaticAppPublicAddrs(ctx context.Context, client app.FindPublicAddrClient, apps []servicecfg.App) ([]string, error) {
+	publicAddrs := make([]string, len(apps))
+	seen := make(map[string]string, len(apps))
+	for i, a := range apps {
+		publicAddr, err := getPublicAddr(ctx, client, a.PublicAddr, a.Name)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		publicAddrs[i] = publicAddr
+
+		// A use_any_proxy_public_addr app routes at <name>.<proxy>,
+		// not its public_addr (see utils.AssembleAppFQDN), so dedupe
+		// on that form.
+		routingAddr := publicAddr
+		if a.UseAnyProxyPublicAddr {
+			routingAddr, err = getPublicAddr(ctx, client, "", a.Name)
+			if err != nil {
+				return nil, trace.Wrap(err)
+			}
+		}
+		if first, ok := seen[routingAddr]; ok {
+			return nil, trace.BadParameter("apps %q and %q resolve to the same public address %q; each app must resolve to a unique address", first, a.Name, routingAddr)
+		}
+		seen[routingAddr] = a.Name
+	}
+	return publicAddrs, nil
+}
+
+// getPublicAddr resolves appPublicAddr, waiting up to five seconds for
+// a proxy to register so the default <name>.<proxy_public_addr> form
+// can be derived when appPublicAddr is empty.
+func getPublicAddr(ctx context.Context, client app.FindPublicAddrClient, appPublicAddr, appName string) (string, error) {
 	ticker := time.NewTicker(500 * time.Millisecond)
 	defer ticker.Stop()
 	timeout := time.NewTimer(5 * time.Second)
 	defer timeout.Stop()
 
 	for {
+		publicAddr, err := app.FindPublicAddr(ctx, client, appPublicAddr, appName)
+		if err == nil {
+			return publicAddr, nil
+		}
 		select {
 		case <-ticker.C:
-			publicAddr, err := app.FindPublicAddr(ctx, authClient, a.PublicAddr, a.Name)
-			if err == nil {
-				return publicAddr, nil
-			}
 		case <-timeout.C:
-			return "", trace.BadParameter("timed out waiting for proxy with public address")
+			return "", trace.Wrap(err, "timed out resolving the public address for app %q", appName)
+		case <-ctx.Done():
+			return "", trace.Wrap(ctx.Err())
 		}
 	}
 }

--- a/lib/service/service_test.go
+++ b/lib/service/service_test.go
@@ -2480,6 +2480,177 @@ func TestInitAppsEmptyConfig(t *testing.T) {
 	require.Equal(t, AppsReady, event.Name)
 }
 
+// fakeFindPublicAddrClient resolves a single proxy public address and
+// cluster name, mirroring what app.FindPublicAddr reads at startup.
+type fakeFindPublicAddrClient struct {
+	proxyRegistered bool
+	proxyPublicAddr string
+	clusterName     string
+}
+
+func (c fakeFindPublicAddrClient) proxies() []types.Server {
+	if !c.proxyRegistered {
+		return nil
+	}
+	var publicAddrs []string
+	if c.proxyPublicAddr != "" {
+		publicAddrs = []string{c.proxyPublicAddr}
+	}
+	proxy, _ := types.NewServer("proxy", types.KindProxy, types.ServerSpecV2{
+		PublicAddrs: publicAddrs,
+	})
+	return []types.Server{proxy}
+}
+
+func (c fakeFindPublicAddrClient) GetProxies() ([]types.Server, error) {
+	return c.proxies(), nil
+}
+
+func (c fakeFindPublicAddrClient) ListProxyServers(context.Context, int, string) ([]types.Server, string, error) {
+	return c.proxies(), "", nil
+}
+
+func (c fakeFindPublicAddrClient) GetClusterName(context.Context) (types.ClusterName, error) {
+	return types.NewClusterName(types.ClusterNameSpecV2{
+		ClusterName: c.clusterName,
+		ClusterID:   "cluster-id",
+	})
+}
+
+func TestResolveStaticAppPublicAddrs(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		client  fakeFindPublicAddrClient
+		apps    []servicecfg.App
+		want    []string
+		wantErr string
+	}{
+		{
+			name:   "distinct addresses accepted",
+			client: fakeFindPublicAddrClient{proxyRegistered: true, proxyPublicAddr: "proxy.example.com"},
+			apps: []servicecfg.App{
+				{Name: "app1", PublicAddr: "app1.example.com"},
+				{Name: "app2"},
+			},
+			want: []string{"app1.example.com", "app2.proxy.example.com"},
+		},
+		{
+			name:   "duplicate explicit public_addr rejected",
+			client: fakeFindPublicAddrClient{proxyRegistered: true, proxyPublicAddr: "proxy.example.com"},
+			apps: []servicecfg.App{
+				{Name: "app1", PublicAddr: "app.example.com"},
+				{Name: "app2", PublicAddr: "app.example.com"},
+			},
+			wantErr: `apps "app1" and "app2" resolve to the same public address "app.example.com"`,
+		},
+		{
+			name:   "name-plus-proxy default collides with explicit addr",
+			client: fakeFindPublicAddrClient{proxyRegistered: true, proxyPublicAddr: "example.com"},
+			apps: []servicecfg.App{
+				{Name: "other", PublicAddr: "app.example.com"},
+				{Name: "app"},
+			},
+			wantErr: `apps "other" and "app" resolve to the same public address "app.example.com"`,
+		},
+		{
+			name:   "cluster_name fallback collides when no proxy public_addr",
+			client: fakeFindPublicAddrClient{proxyRegistered: true, clusterName: "cluster.example.com"},
+			apps: []servicecfg.App{
+				{Name: "other", PublicAddr: "app.cluster.example.com"},
+				{Name: "app"},
+			},
+			wantErr: `apps "other" and "app" resolve to the same public address "app.cluster.example.com"`,
+		},
+		{
+			name:   "cluster_name fallback resolves default apps",
+			client: fakeFindPublicAddrClient{proxyRegistered: true, clusterName: "cluster.example.com"},
+			apps: []servicecfg.App{
+				{Name: "app1"},
+				{Name: "app2", PublicAddr: "explicit.example.com"},
+			},
+			want: []string{"app1.cluster.example.com", "explicit.example.com"},
+		},
+		{
+			name:   "use_any_proxy_public_addr collides on name-proxy form",
+			client: fakeFindPublicAddrClient{proxyRegistered: true, proxyPublicAddr: "proxy.example.com"},
+			apps: []servicecfg.App{
+				{Name: "dashboard", PublicAddr: "custom.example.com", UseAnyProxyPublicAddr: true},
+				{Name: "other", PublicAddr: "dashboard.proxy.example.com"},
+			},
+			wantErr: `apps "dashboard" and "other" resolve to the same public address "dashboard.proxy.example.com"`,
+		},
+		{
+			name:   "use_any_proxy_public_addr keeps explicit addr for registration",
+			client: fakeFindPublicAddrClient{proxyRegistered: true, proxyPublicAddr: "proxy.example.com"},
+			apps: []servicecfg.App{
+				{Name: "dashboard", PublicAddr: "custom.example.com", UseAnyProxyPublicAddr: true},
+			},
+			want: []string{"custom.example.com"},
+		},
+		{
+			name:   "no apps",
+			client: fakeFindPublicAddrClient{proxyRegistered: true, proxyPublicAddr: "proxy.example.com"},
+			apps:   nil,
+			want:   []string{},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := resolveStaticAppPublicAddrs(t.Context(), tt.client, tt.apps)
+			if tt.wantErr != "" {
+				require.ErrorContains(t, err, tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestResolveStaticAppPublicAddrsContextCanceled(t *testing.T) {
+	t.Parallel()
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+	// No proxy registered, so getPublicAddr loops; a canceled context
+	// must end the wait instead of blocking for the timeout.
+	_, err := resolveStaticAppPublicAddrs(ctx, fakeFindPublicAddrClient{}, []servicecfg.App{{Name: "app"}})
+	require.ErrorIs(t, err, context.Canceled)
+}
+
+// countingFindPublicAddrClient registers a proxy only after readyAfter
+// calls, exercising getPublicAddr's retry loop.
+type countingFindPublicAddrClient struct {
+	calls           int
+	readyAfter      int
+	proxyPublicAddr string
+}
+
+func (c *countingFindPublicAddrClient) ListProxyServers(context.Context, int, string) ([]types.Server, string, error) {
+	c.calls++
+	if c.calls <= c.readyAfter {
+		return nil, "", nil
+	}
+	proxy, _ := types.NewServer("proxy", types.KindProxy, types.ServerSpecV2{
+		PublicAddrs: []string{c.proxyPublicAddr},
+	})
+	return []types.Server{proxy}, "", nil
+}
+
+func (c *countingFindPublicAddrClient) GetProxies() ([]types.Server, error) { return nil, nil }
+
+func (c *countingFindPublicAddrClient) GetClusterName(context.Context) (types.ClusterName, error) {
+	return types.NewClusterName(types.ClusterNameSpecV2{ClusterName: "cluster", ClusterID: "id"})
+}
+
+func TestResolveStaticAppPublicAddrsRetriesUntilProxyReady(t *testing.T) {
+	t.Parallel()
+	client := &countingFindPublicAddrClient{readyAfter: 1, proxyPublicAddr: "proxy.example.com"}
+	got, err := resolveStaticAppPublicAddrs(t.Context(), client, []servicecfg.App{{Name: "app"}})
+	require.NoError(t, err)
+	require.Equal(t, []string{"app.proxy.example.com"}, got)
+}
+
 func TestInitKubernetesUnlicensed(t *testing.T) {
 	t.Parallel()
 	clock := clockwork.NewFakeClock()


### PR DESCRIPTION
Reject a static `app_service` config in which two apps resolve to the same public address. The proxy dispatches matching app servers at random, so two apps that share an address route non-deterministically.

Resolve each static app's effective public address when the app service starts, through the same `FindPublicAddr` path used at registration, and reject duplicates before any server is created. Because `FindPublicAddr` reads the registered proxies from the backend, the check covers every topology, including a standalone app-service agent, rather than only a proxy colocated in the same config.

Limit the check to static `app_service.apps`. Dynamic apps are out of scope and deferred to a follow-up RFD.

Do not backport: a config that previously started, routing non-deterministically, would now fail to start.

Changelog: Reject duplicate static app public addresses at app service startup.

## Manual Test Plan

### Test Environment

macOS, single-node Teleport (auth + proxy + app service in one process),
enterprise build from this branch. The proxy advertises `public_addr:
t.tp:443`, so an app with no `public_addr` defaults to `<name>.t.tp`.

### Test Cases

#### Test 1: duplicate explicit public_addr rejected (with fix)

Configure two static apps with the same explicit `public_addr`:

```yaml
app_service:
  enabled: true
  apps:
    - name: app-a
      uri: http://localhost:19080
      public_addr: app.t.tp
    - name: app-b
      uri: http://localhost:19080
      public_addr: app.t.tp
```

- [ ] The app service fails at startup with an error naming both apps and the shared address.

#### Test 2: name-plus-proxy default collides with explicit public_addr (with fix)

One app has no `public_addr` (so it defaults to `<name>.<proxy_public_addr>`),
and a second app sets that same address explicitly:

```yaml
app_service:
  enabled: true
  apps:
    - name: app
      uri: http://localhost:19080
    - name: app-explicit
      uri: http://localhost:19080
      public_addr: app.t.tp
```

- [ ] The app service fails at startup with an error naming both apps and the resolved address `app.t.tp`.

#### Test 3: distinct addresses accepted (with fix)

Configure two apps with distinct public addresses.

```yaml
app_service:
  enabled: true
  apps:
    - name: app-a
      uri: http://localhost:19080
      public_addr: a.t.tp
    - name: app-b
      uri: http://localhost:19080
      public_addr: b.t.tp
```

- [ ] The app service starts and both apps appear in `tsh apps ls`.

#### Test 4: Regression baseline (without fix)

Build from master (before this fix) and apply the Test 1 config.

- [ ] The app service starts without error and silently keeps only one of the two colliding apps.
