### PR TITLE
[v18] Improve access request message titles for slack and discord plugins

### DIFF
--- a/integrations/access/accessrequest/message.go
+++ b/integrations/access/accessrequest/message.go
@@ -49,6 +49,20 @@ Resolution: {{.ProposedStateEmoji}} {{.ProposedState}}.
 {{if .Reason}}Reason: {{.Reason}}.{{end}}`,
 ))
 
+func MsgTitle(reqData pd.AccessRequestData) string {
+	requestBase := "Role"
+	if len(reqData.Resources) > 0 {
+		requestBase = "Resource"
+	}
+	titleText := fmt.Sprintf("You have a new %s Request", requestBase)
+	if reqData.RequestKind == types.AccessRequestKind_LONG_TERM.String() {
+		titleText += " (long-term access)"
+	}
+	titleText += ":\n"
+
+	return titleText
+}
+
 func MsgStatusText(tag pd.ResolutionTag, reason string) string {
 	var statusEmoji string
 	status := string(tag)

--- a/integrations/access/accessrequest/message_test.go
+++ b/integrations/access/accessrequest/message_test.go
@@ -89,3 +89,64 @@ func ExampleMsgFields_logins() {
 	// test```
 	// *Link*: https://example.teleport.sh/web/requests/00000000-0000-0000-0000-000000000000
 }
+
+func ExampleMsgTitle_roles() {
+	req := plugindata.AccessRequestData{
+		User:  "example@goteleport.com",
+		Roles: []string{"admin", "foo", "bar", "dev"},
+		LoginsByRole: map[string][]string{
+			"admin": {"foo", "bar", "root"},
+			"foo":   {"foo"},
+			"bar":   {"bar"},
+			"dev":   {},
+		},
+		RequestReason: "test",
+	}
+
+	msg := MsgTitle(req)
+	fmt.Println(msg)
+
+	// Output: You have a new Role Request:
+}
+
+func ExampleMsgTitle_resources() {
+	req := plugindata.AccessRequestData{
+		User:  "example@goteleport.com",
+		Roles: []string{"admin", "foo", "bar", "dev"},
+		LoginsByRole: map[string][]string{
+			"admin": {"foo", "bar", "root"},
+			"foo":   {"foo"},
+			"bar":   {"bar"},
+			"dev":   {},
+		},
+		Resources:     []string{"/example.teleport.sh/node/0000"},
+		RequestKind:   "SHORT_TERM",
+		RequestReason: "test",
+	}
+
+	msg := MsgTitle(req)
+	fmt.Println(msg)
+
+	// Output: You have a new Resource Request:
+}
+
+func ExampleMsgTitle_resourcesLongTerm() {
+	req := plugindata.AccessRequestData{
+		User:  "example@goteleport.com",
+		Roles: []string{"admin", "foo", "bar", "dev"},
+		LoginsByRole: map[string][]string{
+			"admin": {"foo", "bar", "root"},
+			"foo":   {"foo"},
+			"bar":   {"bar"},
+			"dev":   {},
+		},
+		Resources:     []string{"/example.teleport.sh/node/0000"},
+		RequestKind:   "LONG_TERM",
+		RequestReason: "test",
+	}
+
+	msg := MsgTitle(req)
+	fmt.Println(msg)
+
+	// Output: You have a new Resource Request (long-term access):
+}

--- a/integrations/access/discord/bot.go
+++ b/integrations/access/discord/bot.go
@@ -213,7 +213,7 @@ func (b DiscordBot) discordEmbeds(reviews []types.AccessReview) []DiscordEmbed {
 }
 
 func (b DiscordBot) discordMsgText(reqID string, reqData pd.AccessRequestData) string {
-	return "You have a new Role Request:\n" +
+	return accessrequest.MsgTitle(reqData) +
 		accessrequest.MsgFields(reqID, reqData, b.clusterName, b.webProxyURL) +
 		accessrequest.MsgStatusText(reqData.ResolutionTag, reqData.ResolutionReason)
 }

--- a/integrations/access/slack/bot.go
+++ b/integrations/access/slack/bot.go
@@ -364,10 +364,11 @@ func (b Bot) slackAccessListBatchedReminderMsgSection(accessLists []*accesslist.
 func (b Bot) slackAccessRequestMsgSections(reqID string, reqData pd.AccessRequestData) []BlockItem {
 	fields := accessrequest.MsgFields(reqID, reqData, b.clusterName, b.webProxyURL)
 	statusText := accessrequest.MsgStatusText(reqData.ResolutionTag, reqData.ResolutionReason)
+	titleText := accessrequest.MsgTitle(reqData)
 
 	sections := []BlockItem{
 		NewBlockItem(SectionBlock{
-			Text: NewTextObjectItem(MarkdownObject{Text: "You have a new Role Request:"}),
+			Text: NewTextObjectItem(MarkdownObject{Text: titleText}),
 		}),
 		NewBlockItem(SectionBlock{
 			Text: NewTextObjectItem(MarkdownObject{


### PR DESCRIPTION
Backport #67285 to branch/v18

Changelog: Improved notification messaging for Slack and Discord access plugins

## Manual Test Plan
### Test Environment

Teleport Cloud. Local Slack and Discord plugins.

### Test Cases
- [x] Output is formatted properly for Slack and Discord plugins:
	- [x] Role request
	- [x] Resource request
	- [x] Long-term resource request