### PR TITLE
app: Evict idle forwarding sessions from proxy cache

### DIFF
--- a/lib/utils/fncache.go
+++ b/lib/utils/fncache.go
@@ -82,6 +82,10 @@ type FnCacheConfig struct {
 	// any method on the same FnCache instance because the cache mutex may
 	// be held when the callback is invoked.
 	OnExpiry func(ctx context.Context, key any, value any)
+	// RefreshTTLOnGet makes the TTL an idle timeout: each hit resets the
+	// entry's deadline, so it expires only after a full TTL without access.
+	// The default expires a fixed TTL after load, regardless of access.
+	RefreshTTLOnGet bool
 }
 
 // CheckAndSetDefaults validates the FnCacheConfig is populated
@@ -180,26 +184,50 @@ func (c *FnCache) Remove(key any) {
 	delete(c.entries, key)
 }
 
+// Pop atomically removes the entry for key and returns its loaded value if one
+// was present, even if expired. A still-loading or errored entry is removed and
+// reported absent. Unlike Remove it returns the value so the caller can run the
+// teardown OnExpiry would otherwise do, with no window for a concurrent reuse.
+func (c *FnCache) Pop(key any) (any, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	entry := c.entries[key]
+	delete(c.entries, key)
+	if entry == nil {
+		return nil, false
+	}
+	select {
+	case <-entry.loaded:
+		if entry.e != nil {
+			return nil, false
+		}
+		return entry.v, true
+	default:
+		return nil, false
+	}
+}
+
 // Set places an item in the cache using the default TTL.
 func (c *FnCache) Set(key, value any) {
 	c.SetWithTTL(key, value, c.cfg.TTL)
 }
 
-// GetIfExists retrieves a value from the cache without triggering a load operation.
-// It returns (value, true) if a valid, non-expired entry exists, or (nil, false)
-// otherwise. If an entry is currently being loaded by FnCacheGet, Get will
-// return false immediately without blocking. Get returns false for entries that
-// contain errors.
-// For most of the cases the FnCacheGet function should be used instead.
+// GetIfExists retrieves a value from the cache without triggering a load
+// operation. It returns (value, true) if a valid, non-expired entry exists, or
+// (nil, false) otherwise. A still-loading entry, an errored entry, and an
+// expired entry all return (nil, false) without blocking. GetIfExists is a
+// peek: unlike a FnCacheGet hit it never refreshes the deadline under
+// RefreshTTLOnGet. For most cases FnCacheGet should be used instead.
 func (c *FnCache) GetIfExists(key any) (any, bool) {
+	// Hold the mutex through the entry reads: with RefreshTTLOnGet, get()
+	// mutates a loaded entry's t/ttl under this lock. The select still has a
+	// default case, so a still-loading entry returns without blocking.
 	c.mu.Lock()
+	defer c.mu.Unlock()
 	if c.closed {
-		c.mu.Unlock()
 		return nil, false
 	}
 	entry := c.entries[key]
-	c.mu.Unlock()
-
 	if entry == nil {
 		return nil, false
 	}
@@ -328,6 +356,11 @@ func (c *FnCache) get(ctx context.Context, key any, ttl time.Duration, loadfn fu
 			needsReload = now.After(entry.t.Add(entry.ttl))
 			if c.cfg.ReloadOnErr && entry.e != nil {
 				needsReload = true
+			}
+			// Refresh the deadline on a hit for idle-timeout semantics.
+			if !needsReload && c.cfg.RefreshTTLOnGet {
+				entry.t = now
+				entry.ttl = ttl
 			}
 		default:
 			// reload is already in progress

--- a/lib/utils/fncache_test.go
+++ b/lib/utils/fncache_test.go
@@ -200,6 +200,124 @@ func TestFnCacheExpiry(t *testing.T) {
 	require.False(t, ttlGet())
 }
 
+func TestFnCacheRefreshTTLOnGet(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	clock := clockwork.NewFakeClock()
+
+	cache, err := NewFnCache(FnCacheConfig{
+		TTL:             10 * time.Minute,
+		Clock:           clock,
+		CleanupInterval: time.Hour,
+		RefreshTTLOnGet: true,
+	})
+	require.NoError(t, err)
+
+	get := func() (load bool) {
+		v, err := FnCacheGet(ctx, cache, "key", func(context.Context) (string, error) {
+			load = true
+			return "val", nil
+		})
+		require.NoError(t, err)
+		require.Equal(t, "val", v)
+		return
+	}
+
+	require.True(t, get())
+
+	// Access within the window keeps the entry alive indefinitely.
+	for range 5 {
+		clock.Advance(9 * time.Minute)
+		require.False(t, get())
+	}
+
+	// A full window without access expires the entry.
+	clock.Advance(11 * time.Minute)
+	require.True(t, get())
+
+	// GetIfExists is a peek: it does not refresh the deadline, the property
+	// renewSession relies on. A refreshing peek here would push the deadline
+	// out and the second peek would still find the entry.
+	clock.Advance(9 * time.Minute)
+	_, ok := cache.GetIfExists("key")
+	require.True(t, ok)
+	clock.Advance(2 * time.Minute)
+	_, ok = cache.GetIfExists("key")
+	require.False(t, ok)
+}
+
+// TestFnCacheRefreshTTLOnGetChurn proves the aggregate eviction behavior the
+// app proxy relies on under session churn. With an idle TTL, every one of many
+// distinct entries is evicted a full TTL after its last access, so retention
+// levels off. The default absolute-TTL cache instead pins every entry until
+// its lifetime elapses, growing one entry per session.
+func TestFnCacheRefreshTTLOnGetChurn(t *testing.T) {
+	t.Parallel()
+
+	const (
+		sessions        = 100
+		idleTTL         = 5 * time.Minute
+		sessionLifetime = 8 * time.Hour
+	)
+
+	ctx := t.Context()
+
+	load := func(cache *FnCache, ttl time.Duration) {
+		for i := range sessions {
+			_, err := FnCacheGetWithTTL(ctx, cache, i, ttl, func(context.Context) (int, error) {
+				return i, nil
+			})
+			require.NoError(t, err)
+		}
+	}
+
+	t.Run("idle TTL evicts churned entries", func(t *testing.T) {
+		clock := clockwork.NewFakeClock()
+		var evicted atomic.Int64
+		cache, err := NewFnCache(FnCacheConfig{
+			TTL:             idleTTL,
+			Clock:           clock,
+			CleanupInterval: time.Hour,
+			RefreshTTLOnGet: true,
+			OnExpiry:        func(context.Context, any, any) { evicted.Add(1) },
+		})
+		require.NoError(t, err)
+
+		// getSession caps the idle TTL at the session's remaining lifetime.
+		load(cache, min(idleTTL, sessionLifetime))
+
+		clock.Advance(idleTTL + time.Second)
+		cache.RemoveExpired()
+
+		require.Equal(t, int64(sessions), evicted.Load())
+	})
+
+	t.Run("absolute TTL pins entries until lifetime", func(t *testing.T) {
+		clock := clockwork.NewFakeClock()
+		var evicted atomic.Int64
+		cache, err := NewFnCache(FnCacheConfig{
+			TTL:             sessionLifetime,
+			Clock:           clock,
+			CleanupInterval: time.Hour,
+			OnExpiry:        func(context.Context, any, any) { evicted.Add(1) },
+		})
+		require.NoError(t, err)
+
+		load(cache, sessionLifetime)
+
+		// Past the idle TTL the entries are still pinned.
+		clock.Advance(idleTTL + time.Second)
+		cache.RemoveExpired()
+		require.Zero(t, evicted.Load())
+
+		// They drop only once the lifetime elapses.
+		clock.Advance(sessionLifetime)
+		cache.RemoveExpired()
+		require.Equal(t, int64(sessions), evicted.Load())
+	})
+}
+
 // TestFnCacheFuzzy runs basic FnCache test cases that rely on fuzzy logic and timing to detect
 // success/failure. This test isn't really suitable for running in our CI env due to its sensitivery
 // to fluxuations in perf, but is arguably a *better* test in that it more accurately simulates real

--- a/lib/web/app/handler.go
+++ b/lib/web/app/handler.go
@@ -101,6 +101,10 @@ type Handler struct {
 
 	cache *utils.FnCache
 
+	// sessionCacheIdleTTL is how long a forwarding session stays cached
+	// without use before it is evicted.
+	sessionCacheIdleTTL time.Duration
+
 	clusterName string
 
 	logger *slog.Logger
@@ -114,19 +118,28 @@ func NewHandler(ctx context.Context, c *HandlerConfig) (*Handler, error) {
 	}
 
 	h := &Handler{
-		c:            c,
-		closeContext: ctx,
-		logger:       slog.With(teleport.ComponentKey, teleport.ComponentAppProxy),
+		c:                   c,
+		closeContext:        ctx,
+		sessionCacheIdleTTL: defaultAppSessionIdleTTL,
+		logger:              slog.With(teleport.ComponentKey, teleport.ComponentAppProxy),
 	}
 
-	// Create a new session cache, this holds sessions that can be used to
-	// forward requests.
+	// Create the session cache holding forwarders used to proxy requests.
+	// Entries are evicted after sessionCacheIdleTTL without use so the proxy
+	// does not pin one forwarder per session for the whole session lifetime.
+	// On eviction the transport's idle HTTP keep-alive connections are closed.
 	h.cache, err = utils.NewFnCache(utils.FnCacheConfig{
-		TTL:             time.Second, // Doesn't matter, TTL is always set on an item by item basis.
+		TTL:             h.sessionCacheIdleTTL,
 		Clock:           h.c.Clock,
 		Context:         ctx,
 		CleanupInterval: time.Second,
 		ReloadOnErr:     true,
+		RefreshTTLOnGet: true,
+		OnExpiry: func(_ context.Context, _ any, value any) {
+			if sess, ok := value.(*session); ok {
+				sess.tr.closeIdleConns()
+			}
+		},
 	})
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -149,7 +162,27 @@ func NewHandler(ctx context.Context, c *HandlerConfig) (*Handler, error) {
 	h.router.GET("/teleport-logout", h.withRouterAuth(h.handleLogout))
 	h.router.NotFound = h.withAuth(h.handleHttp)
 
+	go h.expireSessions(h.closeContext)
+
 	return h, nil
+}
+
+// expireSessions periodically evicts idle forwarding sessions so a proxy that
+// has stopped receiving requests does not keep a session and its idle
+// connections pinned until traffic resumes. The cache's own CleanupInterval
+// sweep only runs inside get(), so it never fires while the proxy is idle;
+// this ticker covers that gap.
+func (h *Handler) expireSessions(ctx context.Context) {
+	ticker := h.c.Clock.NewTicker(time.Second)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ticker.Chan():
+			h.cache.RemoveExpired()
+		case <-ctx.Done():
+			return
+		}
+	}
 }
 
 // ServeHTTP hands the request to the request router.
@@ -364,9 +397,14 @@ func (h *Handler) renewSession(r *http.Request) (*session, error) {
 		return nil, trace.AccessDenied("invalid session")
 	}
 
-	// Remove the session from the cache, this will force a new session to be
-	// generated and cached.
-	h.cache.Remove(ws.GetName())
+	// Evict the cached forwarder so the next request rebuilds it, closing the
+	// discarded transport's idle connections. Pop removes and returns the entry
+	// atomically; Remove alone would skip the OnExpiry idle-conn cleanup.
+	if v, ok := h.cache.Pop(ws.GetName()); ok {
+		if prev, ok := v.(*session); ok {
+			prev.tr.closeIdleConns()
+		}
+	}
 
 	// Fetches a new session using the same flow as `authenticate`.
 	session, err := h.getSession(r.Context(), ws)
@@ -575,12 +613,14 @@ func (h *Handler) checkForDualCredentialMismatch(outerIdentity *tlsca.Identity, 
 	return nil
 }
 
-// getSession returns a request session used to proxy the request to the
-// application service. Always checks if the session is valid first and if so,
-// will return a cached session, otherwise will create one.
+// getSession returns the forwarding session used to proxy a request to the
+// application service, reusing the cached one or building it on a miss. The
+// cache TTL is capped at the web session's remaining lifetime. Callers must
+// validate the web session first; getSession does not re-check it.
 func (h *Handler) getSession(ctx context.Context, ws types.WebSession) (*session, error) {
-	// Put the session in the cache so the next request can use it.
-	ttl := ws.Expiry().Sub(h.c.Clock.Now())
+	// Cap the idle TTL at the session's remaining lifetime so a cached
+	// forwarder never outlives its web session.
+	ttl := min(h.sessionCacheIdleTTL, ws.Expiry().Sub(h.c.Clock.Now()))
 	sess, err := utils.FnCacheGetWithTTL(ctx, h.cache, ws.GetName(), ttl, func(ctx context.Context) (*session, error) {
 		sess, err := h.newSession(ctx, ws)
 		return sess, trace.Wrap(err)
@@ -705,6 +745,9 @@ const (
 	// initial authentication flow.
 	AuthStateCookieName = "__Host-grv_app_auth_state"
 )
+
+// defaultAppSessionIdleTTL is the default for Handler.sessionCacheIdleTTL.
+const defaultAppSessionIdleTTL = 5 * time.Minute
 
 // makeAppRedirectURL constructs a URL that will redirect the user to the
 // application launcher route in the web UI.

--- a/lib/web/app/handler_test.go
+++ b/lib/web/app/handler_test.go
@@ -263,6 +263,75 @@ func TestAuthPOST(t *testing.T) {
 	}
 }
 
+func TestSessionCacheIdleEviction(t *testing.T) {
+	// A short idle TTL that expires well before the session and cert,
+	// isolating idle eviction from session expiry.
+	const idleTTL = time.Minute
+
+	clusterName := "test-cluster"
+	publicAddr := "app.example.com"
+
+	key, cert, err := tlsca.GenerateSelfSignedCA(
+		pkix.Name{CommonName: clusterName},
+		[]string{publicAddr, apiutils.EncodeClusterName(clusterName)},
+		defaults.CATTL,
+	)
+	require.NoError(t, err)
+
+	fakeClock := clockwork.NewFakeClock()
+	authClient := &mockAuthClient{
+		clusterName: clusterName,
+		appSession:  createAppSession(t, fakeClock, key, cert, clusterName, publicAddr, "testapp"),
+		appServers: []types.AppServer{
+			createAppServer(t, publicAddr),
+			createAppServer(t, publicAddr),
+			createAppServer(t, publicAddr),
+		},
+		caKey:  key,
+		caCert: cert,
+	}
+
+	fakeCluster := startFakeAppServerOnCluster(t, clusterName, authClient, cert, key)
+	tunnel := &reversetunnelclient.FakeServer{
+		FakeClusters: []reversetunnelclient.Cluster{fakeCluster},
+	}
+
+	p := setup(t, fakeClock, authClient, tunnel)
+	p.handler.sessionCacheIdleTTL = idleTTL
+	cookies := []http.Cookie{
+		{Name: CookieName, Value: "abc"},
+		{Name: SubjectCookieName, Value: authClient.appSession.GetBearerToken()},
+	}
+	get := func() {
+		status, _ := p.makeRequest(t, "GET", "/", []byte{}, cookies)
+		require.Equal(t, http.StatusOK, status)
+	}
+
+	healthDials := int64(len(authClient.appServers))
+	// A session build does one health-check dial per app server, then one
+	// forward dial.
+	built := healthDials + 1
+
+	// First request builds the session.
+	get()
+	require.Equal(t, built, fakeCluster.DialCount())
+
+	// Access within the idle window refreshes the deadline, so the session
+	// stays cached past one TTL in aggregate and dials nothing new. This fails
+	// under a fixed, non-refreshing TTL.
+	for range 3 {
+		fakeClock.Advance(idleTTL - 10*time.Second)
+		get()
+		require.Equal(t, built, fakeCluster.DialCount())
+	}
+
+	// A full idle window with no access evicts the session; the next request
+	// rebuilds it.
+	fakeClock.Advance(idleTTL + time.Second)
+	get()
+	require.Equal(t, 2*built, fakeCluster.DialCount())
+}
+
 func TestHasName(t *testing.T) {
 	for _, test := range []struct {
 		desc        string
@@ -461,12 +530,17 @@ func TestHealthCheckAppServer(t *testing.T) {
 type testServer struct {
 	serverURL *url.URL
 
+	// handler is the app handler under test, exposed so tests can tune it.
+	handler *Handler
+
 	// serverConnContext provides ConnContext to the HTTP server if not nil.
 	serverConnContext atomic.Pointer[func(context.Context, net.Conn) context.Context]
 }
 
 func setup(t *testing.T, clock *clockwork.FakeClock, authClient authclient.ClientI, clusterGetter reversetunnelclient.ClusterGetter) *testServer {
-	appHandler, err := NewHandler(context.Background(), &HandlerConfig{
+	ctx, cancel := context.WithCancel(t.Context())
+	t.Cleanup(cancel)
+	appHandler, err := NewHandler(ctx, &HandlerConfig{
 		Clock:                 clock,
 		AuthClient:            authClient,
 		AccessPoint:           authClient,
@@ -476,7 +550,7 @@ func setup(t *testing.T, clock *clockwork.FakeClock, authClient authclient.Clien
 	})
 	require.NoError(t, err)
 
-	ts := &testServer{}
+	ts := &testServer{handler: appHandler}
 	server := httptest.NewUnstartedServer(appHandler)
 	server.Config.ConnContext = func(ctx context.Context, c net.Conn) context.Context {
 		if fn := ts.serverConnContext.Load(); fn != nil {

--- a/lib/web/app/transport.go
+++ b/lib/web/app/transport.go
@@ -152,6 +152,15 @@ func newTransport(c *transportConfig) (*transport, error) {
 	return t, nil
 }
 
+// closeIdleConns closes idle keep-alive connections on the underlying HTTP
+// transport. Active and directly-dialed TCP connections are caller-owned and
+// unaffected.
+func (t *transport) closeIdleConns() {
+	if tr, ok := t.tr.(*http.Transport); ok {
+		tr.CloseIdleConnections()
+	}
+}
+
 // RoundTrip will rewrite the request, forward the request to the target
 // application, emit an event to the audit log, then rewrite the response.
 func (t *transport) RoundTrip(r *http.Request) (*http.Response, error) {


### PR DESCRIPTION
The proxy caches a full forwarding session per application session - the reverse-tunnel transport, the matched app-server list, and the parsed client certificate - keyed by session ID and held until the session's absolute expiry. Heap profiles from a high-churn cluster show this cache accounts for about half of proxy heap: each session renewal creates a fresh session ID, so one heavyweight forwarder accumulates per session and stays pinned for the full session lifetime even when it is never reused again.

Give the cache an idle timeout. A forwarding session is now evicted once it has gone unused for `appSessionIdleTTL` (5 minutes), capped at the session's remaining lifetime so a cached forwarder never outlives its web session. On eviction the transport's idle keep-alive connections are closed. Both HTTP and plain-TCP application connections share this cache path, since `HandleConnection` and the HTTP router both call `getSession`, so the change covers both.

Add the idle behaviour to `FnCache` as an opt-in `RefreshTTLOnGet` flag that resets an entry's deadline on each hit. It defaults off, so the other `FnCache` callers keep their existing absolute-lifetime semantics.

## Manual Test Plan

### Test Environment

Local Teleport cluster with one app service serving an HTTP app and a
plain-TCP app, reached through the proxy.

### Test Cases

#### Test 1: HTTP app idle rebuild

Connect to an HTTP app, leave the session idle past the idle TTL
(5 minutes), then make a later request.

- [ ] The first request succeeds.
- [ ] After the idle period the cached forwarding session is evicted and
      its idle keep-alive connections are closed.
- [ ] The later request still succeeds, rebuilding the session
      transparently with no user-visible error.

#### Test 2: TCP app live connection survives eviction

Connect to a TCP app, hold the connection open and idle past the idle TTL.

- [ ] The held-open connection is not dropped when the cache entry is
      evicted.
- [ ] Only idle keep-alive connections are closed, not the active
      directly-dialed TCP stream.

#### Test 3: Retention levels off under session churn

The "levels off" claim is a cache-policy property: with an idle TTL, every
one of many distinct entries is evicted a full TTL after its last access. A
live multi-process heap-profile churn run (master vs branch) was judged not
worth the cost for this signal, so the property is asserted with a fake clock.

- [x] `go test -run TestFnCacheRefreshTTLOnGetChurn/idle ./lib/utils/` passes:
      100 churned entries are all evicted once idle past the TTL.

#### Test 4: Regression baseline (absolute TTL pins per session)

- [x] `go test -run TestFnCacheRefreshTTLOnGetChurn/absolute ./lib/utils/`
      passes: with the default absolute TTL the same 100 entries stay pinned
      past the idle TTL and drop only once their lifetime elapses, matching
      master's grow-one-forwarder-per-session behaviour.

Changelog: Reduce proxy memory use under high application-session churn by evicting idle application forwarding sessions from the proxy cache.
