### PR TITLE
Scope-qualify Bot references in ScopedToken/ScopedRoleAssignment

### DIFF
--- a/api/gen/proto/go/teleport/scopes/access/v1/assignment.pb.go
+++ b/api/gen/proto/go/teleport/scopes/access/v1/assignment.pb.go
@@ -233,17 +233,17 @@ func (b0 ScopedRoleAssignment_builder) Build() *ScopedRoleAssignment {
 type ScopedRoleAssignmentSpec struct {
 	state protoimpl.MessageState `protogen:"hybrid.v1"`
 	// User is the user to whom all contained assignments apply.
-	// Mutually exclusive with `bot_name`.
+	// Mutually exclusive with `bot`.
 	User string `protobuf:"bytes,1,opt,name=user,proto3" json:"user,omitempty"`
 	// Assignments is a list of individual role @ scope assignments.
 	Assignments []*Assignment `protobuf:"bytes,2,rep,name=assignments,proto3" json:"assignments,omitempty"`
-	// Name of the Bot to whom all contained assignments apply.
+	// The Bot to whom all contained assignments apply, as a scope-qualified name
+	// of the form "<scope>::<bot-name>" (e.g. "/staging/west::mybot").
 	// Mutually exclusive with `user`.
-	BotName string `protobuf:"bytes,3,opt,name=bot_name,json=botName,proto3" json:"bot_name,omitempty"`
-	// Scope of the Bot to whom all contained assignments apply.
-	// Required if `bot_name` is set.
-	// If specified, assignment scopes must be equal or descendent of this scope.
-	BotScope      string `protobuf:"bytes,4,opt,name=bot_scope,json=botScope,proto3" json:"bot_scope,omitempty"`
+	//
+	// When specified, assignment scopes must be equal or descendent of the scope
+	// indicated by this field.
+	Bot           string `protobuf:"bytes,5,opt,name=bot,proto3" json:"bot,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -287,16 +287,9 @@ func (x *ScopedRoleAssignmentSpec) GetAssignments() []*Assignment {
 	return nil
 }
 
-func (x *ScopedRoleAssignmentSpec) GetBotName() string {
+func (x *ScopedRoleAssignmentSpec) GetBot() string {
 	if x != nil {
-		return x.BotName
-	}
-	return ""
-}
-
-func (x *ScopedRoleAssignmentSpec) GetBotScope() string {
-	if x != nil {
-		return x.BotScope
+		return x.Bot
 	}
 	return ""
 }
@@ -309,29 +302,25 @@ func (x *ScopedRoleAssignmentSpec) SetAssignments(v []*Assignment) {
 	x.Assignments = v
 }
 
-func (x *ScopedRoleAssignmentSpec) SetBotName(v string) {
-	x.BotName = v
-}
-
-func (x *ScopedRoleAssignmentSpec) SetBotScope(v string) {
-	x.BotScope = v
+func (x *ScopedRoleAssignmentSpec) SetBot(v string) {
+	x.Bot = v
 }
 
 type ScopedRoleAssignmentSpec_builder struct {
 	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
 
 	// User is the user to whom all contained assignments apply.
-	// Mutually exclusive with `bot_name`.
+	// Mutually exclusive with `bot`.
 	User string
 	// Assignments is a list of individual role @ scope assignments.
 	Assignments []*Assignment
-	// Name of the Bot to whom all contained assignments apply.
+	// The Bot to whom all contained assignments apply, as a scope-qualified name
+	// of the form "<scope>::<bot-name>" (e.g. "/staging/west::mybot").
 	// Mutually exclusive with `user`.
-	BotName string
-	// Scope of the Bot to whom all contained assignments apply.
-	// Required if `bot_name` is set.
-	// If specified, assignment scopes must be equal or descendent of this scope.
-	BotScope string
+	//
+	// When specified, assignment scopes must be equal or descendent of the scope
+	// indicated by this field.
+	Bot string
 }
 
 func (b0 ScopedRoleAssignmentSpec_builder) Build() *ScopedRoleAssignmentSpec {
@@ -340,8 +329,7 @@ func (b0 ScopedRoleAssignmentSpec_builder) Build() *ScopedRoleAssignmentSpec {
 	_, _ = b, x
 	x.User = b.User
 	x.Assignments = b.Assignments
-	x.BotName = b.BotName
-	x.BotScope = b.BotScope
+	x.Bot = b.Bot
 	return m0
 }
 
@@ -582,12 +570,11 @@ const file_teleport_scopes_access_v1_assignment_proto_rawDesc = "" +
 	"\bmetadata\x18\x04 \x01(\v2\x1c.teleport.header.v1.MetadataR\bmetadata\x12\x14\n" +
 	"\x05scope\x18\x05 \x01(\tR\x05scope\x12G\n" +
 	"\x04spec\x18\x06 \x01(\v23.teleport.scopes.access.v1.ScopedRoleAssignmentSpecR\x04spec\x12M\n" +
-	"\x06status\x18\a \x01(\v25.teleport.scopes.access.v1.ScopedRoleAssignmentStatusR\x06status\"\xaf\x01\n" +
+	"\x06status\x18\a \x01(\v25.teleport.scopes.access.v1.ScopedRoleAssignmentStatusR\x06status\"\xaa\x01\n" +
 	"\x18ScopedRoleAssignmentSpec\x12\x12\n" +
 	"\x04user\x18\x01 \x01(\tR\x04user\x12G\n" +
-	"\vassignments\x18\x02 \x03(\v2%.teleport.scopes.access.v1.AssignmentR\vassignments\x12\x19\n" +
-	"\bbot_name\x18\x03 \x01(\tR\abotName\x12\x1b\n" +
-	"\tbot_scope\x18\x04 \x01(\tR\bbotScope\"6\n" +
+	"\vassignments\x18\x02 \x03(\v2%.teleport.scopes.access.v1.AssignmentR\vassignments\x12\x10\n" +
+	"\x03bot\x18\x05 \x01(\tR\x03botJ\x04\b\x03\x10\x04J\x04\b\x04\x10\x05R\bbot_nameR\tbot_scope\"6\n" +
 	"\n" +
 	"Assignment\x12\x12\n" +
 	"\x04role\x18\x01 \x01(\tR\x04role\x12\x14\n" +

--- a/api/gen/proto/go/teleport/scopes/access/v1/assignment_protoopaque.pb.go
+++ b/api/gen/proto/go/teleport/scopes/access/v1/assignment_protoopaque.pb.go
@@ -227,8 +227,7 @@ type ScopedRoleAssignmentSpec struct {
 	state                  protoimpl.MessageState `protogen:"opaque.v1"`
 	xxx_hidden_User        string                 `protobuf:"bytes,1,opt,name=user,proto3"`
 	xxx_hidden_Assignments *[]*Assignment         `protobuf:"bytes,2,rep,name=assignments,proto3"`
-	xxx_hidden_BotName     string                 `protobuf:"bytes,3,opt,name=bot_name,json=botName,proto3"`
-	xxx_hidden_BotScope    string                 `protobuf:"bytes,4,opt,name=bot_scope,json=botScope,proto3"`
+	xxx_hidden_Bot         string                 `protobuf:"bytes,5,opt,name=bot,proto3"`
 	unknownFields          protoimpl.UnknownFields
 	sizeCache              protoimpl.SizeCache
 }
@@ -274,16 +273,9 @@ func (x *ScopedRoleAssignmentSpec) GetAssignments() []*Assignment {
 	return nil
 }
 
-func (x *ScopedRoleAssignmentSpec) GetBotName() string {
+func (x *ScopedRoleAssignmentSpec) GetBot() string {
 	if x != nil {
-		return x.xxx_hidden_BotName
-	}
-	return ""
-}
-
-func (x *ScopedRoleAssignmentSpec) GetBotScope() string {
-	if x != nil {
-		return x.xxx_hidden_BotScope
+		return x.xxx_hidden_Bot
 	}
 	return ""
 }
@@ -296,29 +288,25 @@ func (x *ScopedRoleAssignmentSpec) SetAssignments(v []*Assignment) {
 	x.xxx_hidden_Assignments = &v
 }
 
-func (x *ScopedRoleAssignmentSpec) SetBotName(v string) {
-	x.xxx_hidden_BotName = v
-}
-
-func (x *ScopedRoleAssignmentSpec) SetBotScope(v string) {
-	x.xxx_hidden_BotScope = v
+func (x *ScopedRoleAssignmentSpec) SetBot(v string) {
+	x.xxx_hidden_Bot = v
 }
 
 type ScopedRoleAssignmentSpec_builder struct {
 	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
 
 	// User is the user to whom all contained assignments apply.
-	// Mutually exclusive with `bot_name`.
+	// Mutually exclusive with `bot`.
 	User string
 	// Assignments is a list of individual role @ scope assignments.
 	Assignments []*Assignment
-	// Name of the Bot to whom all contained assignments apply.
+	// The Bot to whom all contained assignments apply, as a scope-qualified name
+	// of the form "<scope>::<bot-name>" (e.g. "/staging/west::mybot").
 	// Mutually exclusive with `user`.
-	BotName string
-	// Scope of the Bot to whom all contained assignments apply.
-	// Required if `bot_name` is set.
-	// If specified, assignment scopes must be equal or descendent of this scope.
-	BotScope string
+	//
+	// When specified, assignment scopes must be equal or descendent of the scope
+	// indicated by this field.
+	Bot string
 }
 
 func (b0 ScopedRoleAssignmentSpec_builder) Build() *ScopedRoleAssignmentSpec {
@@ -327,8 +315,7 @@ func (b0 ScopedRoleAssignmentSpec_builder) Build() *ScopedRoleAssignmentSpec {
 	_, _ = b, x
 	x.xxx_hidden_User = b.User
 	x.xxx_hidden_Assignments = &b.Assignments
-	x.xxx_hidden_BotName = b.BotName
-	x.xxx_hidden_BotScope = b.BotScope
+	x.xxx_hidden_Bot = b.Bot
 	return m0
 }
 
@@ -563,12 +550,11 @@ const file_teleport_scopes_access_v1_assignment_proto_rawDesc = "" +
 	"\bmetadata\x18\x04 \x01(\v2\x1c.teleport.header.v1.MetadataR\bmetadata\x12\x14\n" +
 	"\x05scope\x18\x05 \x01(\tR\x05scope\x12G\n" +
 	"\x04spec\x18\x06 \x01(\v23.teleport.scopes.access.v1.ScopedRoleAssignmentSpecR\x04spec\x12M\n" +
-	"\x06status\x18\a \x01(\v25.teleport.scopes.access.v1.ScopedRoleAssignmentStatusR\x06status\"\xaf\x01\n" +
+	"\x06status\x18\a \x01(\v25.teleport.scopes.access.v1.ScopedRoleAssignmentStatusR\x06status\"\xaa\x01\n" +
 	"\x18ScopedRoleAssignmentSpec\x12\x12\n" +
 	"\x04user\x18\x01 \x01(\tR\x04user\x12G\n" +
-	"\vassignments\x18\x02 \x03(\v2%.teleport.scopes.access.v1.AssignmentR\vassignments\x12\x19\n" +
-	"\bbot_name\x18\x03 \x01(\tR\abotName\x12\x1b\n" +
-	"\tbot_scope\x18\x04 \x01(\tR\bbotScope\"6\n" +
+	"\vassignments\x18\x02 \x03(\v2%.teleport.scopes.access.v1.AssignmentR\vassignments\x12\x10\n" +
+	"\x03bot\x18\x05 \x01(\tR\x03botJ\x04\b\x03\x10\x04J\x04\b\x04\x10\x05R\bbot_nameR\tbot_scope\"6\n" +
 	"\n" +
 	"Assignment\x12\x12\n" +
 	"\x04role\x18\x01 \x01(\tR\x04role\x12\x14\n" +

--- a/api/gen/proto/go/teleport/scopes/joining/v1/token.pb.go
+++ b/api/gen/proto/go/teleport/scopes/joining/v1/token.pb.go
@@ -265,11 +265,13 @@ type ScopedTokenSpec struct {
 	Kubernetes *Kubernetes `protobuf:"bytes,11,opt,name=kubernetes,proto3" json:"kubernetes,omitempty"`
 	// Configuration specific to the "bound_keypair" join method.
 	BoundKeypair *BoundKeypairSpec `protobuf:"bytes,12,opt,name=bound_keypair,json=boundKeypair,proto3" json:"bound_keypair,omitempty"`
-	// Name of the bot associated with this join token, if any.
-	BotName string `protobuf:"bytes,13,opt,name=bot_name,json=botName,proto3" json:"bot_name,omitempty"`
-	// Scope of the bot associated with this join token. Required if bot_name is
-	// set, and mutually exclusive with assigned_scope.
-	BotScope      string `protobuf:"bytes,14,opt,name=bot_scope,json=botScope,proto3" json:"bot_scope,omitempty"`
+	// The bot associated with this join token, if any, as a scope-qualified name
+	// of the form "<scope>::<bot-name>" (e.g. "/staging/west::mybot"). The scope
+	// component must be a descendant of or equivalent to the token's resource
+	// scope.
+	//
+	// Mutually exclusive with assigned_scope.
+	Bot           string `protobuf:"bytes,15,opt,name=bot,proto3" json:"bot,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -383,16 +385,9 @@ func (x *ScopedTokenSpec) GetBoundKeypair() *BoundKeypairSpec {
 	return nil
 }
 
-func (x *ScopedTokenSpec) GetBotName() string {
+func (x *ScopedTokenSpec) GetBot() string {
 	if x != nil {
-		return x.BotName
-	}
-	return ""
-}
-
-func (x *ScopedTokenSpec) GetBotScope() string {
-	if x != nil {
-		return x.BotScope
+		return x.Bot
 	}
 	return ""
 }
@@ -445,12 +440,8 @@ func (x *ScopedTokenSpec) SetBoundKeypair(v *BoundKeypairSpec) {
 	x.BoundKeypair = v
 }
 
-func (x *ScopedTokenSpec) SetBotName(v string) {
-	x.BotName = v
-}
-
-func (x *ScopedTokenSpec) SetBotScope(v string) {
-	x.BotScope = v
+func (x *ScopedTokenSpec) SetBot(v string) {
+	x.Bot = v
 }
 
 func (x *ScopedTokenSpec) HasImmutableLabels() bool {
@@ -576,11 +567,13 @@ type ScopedTokenSpec_builder struct {
 	Kubernetes *Kubernetes
 	// Configuration specific to the "bound_keypair" join method.
 	BoundKeypair *BoundKeypairSpec
-	// Name of the bot associated with this join token, if any.
-	BotName string
-	// Scope of the bot associated with this join token. Required if bot_name is
-	// set, and mutually exclusive with assigned_scope.
-	BotScope string
+	// The bot associated with this join token, if any, as a scope-qualified name
+	// of the form "<scope>::<bot-name>" (e.g. "/staging/west::mybot"). The scope
+	// component must be a descendant of or equivalent to the token's resource
+	// scope.
+	//
+	// Mutually exclusive with assigned_scope.
+	Bot string
 }
 
 func (b0 ScopedTokenSpec_builder) Build() *ScopedTokenSpec {
@@ -599,8 +592,7 @@ func (b0 ScopedTokenSpec_builder) Build() *ScopedTokenSpec {
 	x.Oracle = b.Oracle
 	x.Kubernetes = b.Kubernetes
 	x.BoundKeypair = b.BoundKeypair
-	x.BotName = b.BotName
-	x.BotScope = b.BotScope
+	x.Bot = b.Bot
 	return m0
 }
 
@@ -3457,7 +3449,7 @@ const file_teleport_scopes_joining_v1_token_proto_rawDesc = "" +
 	"\bmetadata\x18\x04 \x01(\v2\x1c.teleport.header.v1.MetadataR\bmetadata\x12\x14\n" +
 	"\x05scope\x18\x05 \x01(\tR\x05scope\x12?\n" +
 	"\x04spec\x18\x06 \x01(\v2+.teleport.scopes.joining.v1.ScopedTokenSpecR\x04spec\x12E\n" +
-	"\x06status\x18\a \x01(\v2-.teleport.scopes.joining.v1.ScopedTokenStatusR\x06status\"\xe0\x05\n" +
+	"\x06status\x18\a \x01(\v2-.teleport.scopes.joining.v1.ScopedTokenStatusR\x06status\"\xdb\x05\n" +
 	"\x0fScopedTokenSpec\x12%\n" +
 	"\x0eassigned_scope\x18\x01 \x01(\tR\rassignedScope\x12\x14\n" +
 	"\x05roles\x18\x02 \x03(\tR\x05roles\x12\x1f\n" +
@@ -3475,9 +3467,8 @@ const file_teleport_scopes_joining_v1_token_proto_rawDesc = "" +
 	"\n" +
 	"kubernetes\x18\v \x01(\v2&.teleport.scopes.joining.v1.KubernetesR\n" +
 	"kubernetes\x12Q\n" +
-	"\rbound_keypair\x18\f \x01(\v2,.teleport.scopes.joining.v1.BoundKeypairSpecR\fboundKeypair\x12\x19\n" +
-	"\bbot_name\x18\r \x01(\tR\abotName\x12\x1b\n" +
-	"\tbot_scope\x18\x0e \x01(\tR\bbotScope\"\xb6\x01\n" +
+	"\rbound_keypair\x18\f \x01(\v2,.teleport.scopes.joining.v1.BoundKeypairSpecR\fboundKeypair\x12\x10\n" +
+	"\x03bot\x18\x0f \x01(\tR\x03botJ\x04\b\r\x10\x0eJ\x04\b\x0e\x10\x0fR\bbot_nameR\tbot_scope\"\xb6\x01\n" +
 	"\x0eHostCertParams\x12\x17\n" +
 	"\ahost_id\x18\x01 \x01(\tR\x06hostId\x12\x1b\n" +
 	"\tnode_name\x18\x02 \x01(\tR\bnodeName\x12\x12\n" +

--- a/api/gen/proto/go/teleport/scopes/joining/v1/token_protoopaque.pb.go
+++ b/api/gen/proto/go/teleport/scopes/joining/v1/token_protoopaque.pb.go
@@ -238,8 +238,7 @@ type ScopedTokenSpec struct {
 	xxx_hidden_Oracle          *Oracle                `protobuf:"bytes,10,opt,name=oracle,proto3"`
 	xxx_hidden_Kubernetes      *Kubernetes            `protobuf:"bytes,11,opt,name=kubernetes,proto3"`
 	xxx_hidden_BoundKeypair    *BoundKeypairSpec      `protobuf:"bytes,12,opt,name=bound_keypair,json=boundKeypair,proto3"`
-	xxx_hidden_BotName         string                 `protobuf:"bytes,13,opt,name=bot_name,json=botName,proto3"`
-	xxx_hidden_BotScope        string                 `protobuf:"bytes,14,opt,name=bot_scope,json=botScope,proto3"`
+	xxx_hidden_Bot             string                 `protobuf:"bytes,15,opt,name=bot,proto3"`
 	unknownFields              protoimpl.UnknownFields
 	sizeCache                  protoimpl.SizeCache
 }
@@ -353,16 +352,9 @@ func (x *ScopedTokenSpec) GetBoundKeypair() *BoundKeypairSpec {
 	return nil
 }
 
-func (x *ScopedTokenSpec) GetBotName() string {
+func (x *ScopedTokenSpec) GetBot() string {
 	if x != nil {
-		return x.xxx_hidden_BotName
-	}
-	return ""
-}
-
-func (x *ScopedTokenSpec) GetBotScope() string {
-	if x != nil {
-		return x.xxx_hidden_BotScope
+		return x.xxx_hidden_Bot
 	}
 	return ""
 }
@@ -415,12 +407,8 @@ func (x *ScopedTokenSpec) SetBoundKeypair(v *BoundKeypairSpec) {
 	x.xxx_hidden_BoundKeypair = v
 }
 
-func (x *ScopedTokenSpec) SetBotName(v string) {
-	x.xxx_hidden_BotName = v
-}
-
-func (x *ScopedTokenSpec) SetBotScope(v string) {
-	x.xxx_hidden_BotScope = v
+func (x *ScopedTokenSpec) SetBot(v string) {
+	x.xxx_hidden_Bot = v
 }
 
 func (x *ScopedTokenSpec) HasImmutableLabels() bool {
@@ -546,11 +534,13 @@ type ScopedTokenSpec_builder struct {
 	Kubernetes *Kubernetes
 	// Configuration specific to the "bound_keypair" join method.
 	BoundKeypair *BoundKeypairSpec
-	// Name of the bot associated with this join token, if any.
-	BotName string
-	// Scope of the bot associated with this join token. Required if bot_name is
-	// set, and mutually exclusive with assigned_scope.
-	BotScope string
+	// The bot associated with this join token, if any, as a scope-qualified name
+	// of the form "<scope>::<bot-name>" (e.g. "/staging/west::mybot"). The scope
+	// component must be a descendant of or equivalent to the token's resource
+	// scope.
+	//
+	// Mutually exclusive with assigned_scope.
+	Bot string
 }
 
 func (b0 ScopedTokenSpec_builder) Build() *ScopedTokenSpec {
@@ -569,8 +559,7 @@ func (b0 ScopedTokenSpec_builder) Build() *ScopedTokenSpec {
 	x.xxx_hidden_Oracle = b.Oracle
 	x.xxx_hidden_Kubernetes = b.Kubernetes
 	x.xxx_hidden_BoundKeypair = b.BoundKeypair
-	x.xxx_hidden_BotName = b.BotName
-	x.xxx_hidden_BotScope = b.BotScope
+	x.xxx_hidden_Bot = b.Bot
 	return m0
 }
 
@@ -3241,7 +3230,7 @@ const file_teleport_scopes_joining_v1_token_proto_rawDesc = "" +
 	"\bmetadata\x18\x04 \x01(\v2\x1c.teleport.header.v1.MetadataR\bmetadata\x12\x14\n" +
 	"\x05scope\x18\x05 \x01(\tR\x05scope\x12?\n" +
 	"\x04spec\x18\x06 \x01(\v2+.teleport.scopes.joining.v1.ScopedTokenSpecR\x04spec\x12E\n" +
-	"\x06status\x18\a \x01(\v2-.teleport.scopes.joining.v1.ScopedTokenStatusR\x06status\"\xe0\x05\n" +
+	"\x06status\x18\a \x01(\v2-.teleport.scopes.joining.v1.ScopedTokenStatusR\x06status\"\xdb\x05\n" +
 	"\x0fScopedTokenSpec\x12%\n" +
 	"\x0eassigned_scope\x18\x01 \x01(\tR\rassignedScope\x12\x14\n" +
 	"\x05roles\x18\x02 \x03(\tR\x05roles\x12\x1f\n" +
@@ -3259,9 +3248,8 @@ const file_teleport_scopes_joining_v1_token_proto_rawDesc = "" +
 	"\n" +
 	"kubernetes\x18\v \x01(\v2&.teleport.scopes.joining.v1.KubernetesR\n" +
 	"kubernetes\x12Q\n" +
-	"\rbound_keypair\x18\f \x01(\v2,.teleport.scopes.joining.v1.BoundKeypairSpecR\fboundKeypair\x12\x19\n" +
-	"\bbot_name\x18\r \x01(\tR\abotName\x12\x1b\n" +
-	"\tbot_scope\x18\x0e \x01(\tR\bbotScope\"\xb6\x01\n" +
+	"\rbound_keypair\x18\f \x01(\v2,.teleport.scopes.joining.v1.BoundKeypairSpecR\fboundKeypair\x12\x10\n" +
+	"\x03bot\x18\x0f \x01(\tR\x03botJ\x04\b\r\x10\x0eJ\x04\b\x0e\x10\x0fR\bbot_nameR\tbot_scope\"\xb6\x01\n" +
 	"\x0eHostCertParams\x12\x17\n" +
 	"\ahost_id\x18\x01 \x01(\tR\x06hostId\x12\x1b\n" +
 	"\tnode_name\x18\x02 \x01(\tR\bnodeName\x12\x12\n" +

--- a/api/proto/teleport/scopes/access/v1/assignment.proto
+++ b/api/proto/teleport/scopes/access/v1/assignment.proto
@@ -50,20 +50,22 @@ message ScopedRoleAssignment {
 // ScopedRoleAssignmentSpec is the specification of a scoped role assignment.
 message ScopedRoleAssignmentSpec {
   // User is the user to whom all contained assignments apply.
-  // Mutually exclusive with `bot_name`.
+  // Mutually exclusive with `bot`.
   string user = 1;
 
   // Assignments is a list of individual role @ scope assignments.
   repeated Assignment assignments = 2;
 
-  // Name of the Bot to whom all contained assignments apply.
-  // Mutually exclusive with `user`.
-  string bot_name = 3;
+  reserved 3, 4;
+  reserved "bot_name", "bot_scope";
 
-  // Scope of the Bot to whom all contained assignments apply.
-  // Required if `bot_name` is set.
-  // If specified, assignment scopes must be equal or descendent of this scope.
-  string bot_scope = 4;
+  // The Bot to whom all contained assignments apply, as a scope-qualified name
+  // of the form "<scope>::<bot-name>" (e.g. "/staging/west::mybot").
+  // Mutually exclusive with `user`.
+  //
+  // When specified, assignment scopes must be equal or descendent of the scope
+  // indicated by this field.
+  string bot = 5;
 }
 
 // Assignment is a role/scope pair that defines an individual assignment.

--- a/api/proto/teleport/scopes/joining/v1/token.proto
+++ b/api/proto/teleport/scopes/joining/v1/token.proto
@@ -94,12 +94,16 @@ message ScopedTokenSpec {
   // Configuration specific to the "bound_keypair" join method.
   BoundKeypairSpec bound_keypair = 12;
 
-  // Name of the bot associated with this join token, if any.
-  string bot_name = 13;
+  reserved 13, 14;
+  reserved "bot_name", "bot_scope";
 
-  // Scope of the bot associated with this join token. Required if bot_name is
-  // set, and mutually exclusive with assigned_scope.
-  string bot_scope = 14;
+  // The bot associated with this join token, if any, as a scope-qualified name
+  // of the form "<scope>::<bot-name>" (e.g. "/staging/west::mybot"). The scope
+  // component must be a descendant of or equivalent to the token's resource
+  // scope.
+  //
+  // Mutually exclusive with assigned_scope.
+  string bot = 15;
 }
 
 // The host certificate parameters that should be cached and leveraged for

--- a/api/types/provisioning.go
+++ b/api/types/provisioning.go
@@ -178,9 +178,6 @@ type ProvisionToken interface {
 	GetJoinMethod() JoinMethod
 	// GetBotName returns the BotName field which must be set for joining bots.
 	GetBotName() string
-	// GetBotScope returns the BotScope field which must be set for bots joining
-	// with a scoped token. It is empty for unscoped bots.
-	GetBotScope() string
 	// IsStatic returns true if the token is statically configured
 	IsStatic() bool
 	// GetSuggestedLabels returns the set of labels that the resource should add when adding itself to the cluster
@@ -612,13 +609,6 @@ func (p *ProvisionTokenV2) IsStatic() bool {
 // GetBotName returns the BotName field which must be set for joining bots.
 func (p *ProvisionTokenV2) GetBotName() string {
 	return p.Spec.BotName
-}
-
-// GetBotScope returns the BotScope field which must be set for bots joining
-// with a scoped token. It is empty for unscoped bots.
-func (p *ProvisionTokenV2) GetBotScope() string {
-	// Always empty for ProvisionTokenV2
-	return ""
 }
 
 // GetKind returns resource kind

--- a/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-scopedroleassignmentsv1.mdx
+++ b/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-scopedroleassignmentsv1.mdx
@@ -31,9 +31,8 @@ resource, which you can apply after installing the Teleport Kubernetes operator.
 |Field|Type|Description|
 |---|---|---|
 |assignments|[][object](#specassignments-items)|Assignments is a list of individual role @ scope assignments.|
-|bot_name|string|Name of the Bot to whom all contained assignments apply. Mutually exclusive with `user`.|
-|bot_scope|string|Scope of the Bot to whom all contained assignments apply. Required if `bot_name` is set. If specified, assignment scopes must be equal or descendent of this scope.|
-|user|string|User is the user to whom all contained assignments apply. Mutually exclusive with `bot_name`.|
+|bot|string|The Bot to whom all contained assignments apply, as a scope-qualified name of the form "<scope>::<bot-name>" (e.g. "/staging/west::mybot"). Mutually exclusive with `user`.  When specified, assignment scopes must be equal or descendent of the scope indicated by this field.|
+|user|string|User is the user to whom all contained assignments apply. Mutually exclusive with `bot`.|
 
 ### spec.assignments items
 

--- a/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-scopedtokensv1.mdx
+++ b/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-scopedtokensv1.mdx
@@ -34,8 +34,7 @@ resource, which you can apply after installing the Teleport Kubernetes operator.
 |aws|[object](#specaws)|The AWS-specific configuration used with the "ec2" and "iam" join methods.|
 |azure|[object](#specazure)|The Azure-specific configuration used with the "azure" join method.|
 |azure_devops|[object](#specazure_devops)|The Azure Devops-specific configuration used with the "azure_devops" join method.|
-|bot_name|string|Name of the bot associated with this join token, if any.|
-|bot_scope|string|Scope of the bot associated with this join token. Required if bot_name is set, and mutually exclusive with assigned_scope.|
+|bot|string|The bot associated with this join token, if any, as a scope-qualified name of the form "<scope>::<bot-name>" (e.g. "/staging/west::mybot"). The scope component must be a descendant of or equivalent to the token's resource scope.  Mutually exclusive with assigned_scope.|
 |bound_keypair|[object](#specbound_keypair)|Configuration specific to the "bound_keypair" join method.|
 |gcp|[object](#specgcp)|The GCP-specific configuration used with the "gcp" join method.|
 |immutable_labels|[object](#specimmutable_labels)|Immutable labels that should be applied to any resulting resources provisioned using this token.|

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/scoped_role_assignment.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/scoped_role_assignment.mdx
@@ -50,9 +50,8 @@ Required:
 
 Optional:
 
-- `bot_name` (String) Name of the Bot to whom all contained assignments apply. Mutually exclusive with `user`.
-- `bot_scope` (String) Scope of the Bot to whom all contained assignments apply. Required if `bot_name` is set. If specified, assignment scopes must be equal or descendent of this scope.
-- `user` (String) User is the user to whom all contained assignments apply. Mutually exclusive with `bot_name`.
+- `bot` (String) The Bot to whom all contained assignments apply, as a scope-qualified name of the form "<scope>::<bot-name>" (e.g. "/staging/west::mybot"). Mutually exclusive with `user`.  When specified, assignment scopes must be equal or descendent of the scope indicated by this field.
+- `user` (String) User is the user to whom all contained assignments apply. Mutually exclusive with `bot`.
 
 ### Nested Schema for `spec.assignments`
 

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/scoped_token.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/scoped_token.mdx
@@ -59,8 +59,7 @@ Optional:
 - `aws` (Attributes) The AWS-specific configuration used with the "ec2" and "iam" join methods. (see [below for nested schema](#nested-schema-for-specaws))
 - `azure` (Attributes) The Azure-specific configuration used with the "azure" join method. (see [below for nested schema](#nested-schema-for-specazure))
 - `azure_devops` (Attributes) The Azure Devops-specific configuration used with the "azure_devops" join method. (see [below for nested schema](#nested-schema-for-specazure_devops))
-- `bot_name` (String) Name of the bot associated with this join token, if any.
-- `bot_scope` (String) Scope of the bot associated with this join token. Required if bot_name is set, and mutually exclusive with assigned_scope.
+- `bot` (String) The bot associated with this join token, if any, as a scope-qualified name of the form "<scope>::<bot-name>" (e.g. "/staging/west::mybot"). The scope component must be a descendant of or equivalent to the token's resource scope.  Mutually exclusive with assigned_scope.
 - `bound_keypair` (Attributes) Configuration specific to the "bound_keypair" join method. (see [below for nested schema](#nested-schema-for-specbound_keypair))
 - `gcp` (Attributes) The GCP-specific configuration used with the "gcp" join method. (see [below for nested schema](#nested-schema-for-specgcp))
 - `immutable_labels` (Attributes) Immutable labels that should be applied to any resulting resources provisioned using this token. (see [below for nested schema](#nested-schema-for-specimmutable_labels))

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/scoped_role_assignment.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/scoped_role_assignment.mdx
@@ -93,9 +93,8 @@ Required:
 
 Optional:
 
-- `bot_name` (String) Name of the Bot to whom all contained assignments apply. Mutually exclusive with `user`.
-- `bot_scope` (String) Scope of the Bot to whom all contained assignments apply. Required if `bot_name` is set. If specified, assignment scopes must be equal or descendent of this scope.
-- `user` (String) User is the user to whom all contained assignments apply. Mutually exclusive with `bot_name`.
+- `bot` (String) The Bot to whom all contained assignments apply, as a scope-qualified name of the form "<scope>::<bot-name>" (e.g. "/staging/west::mybot"). Mutually exclusive with `user`.  When specified, assignment scopes must be equal or descendent of the scope indicated by this field.
+- `user` (String) User is the user to whom all contained assignments apply. Mutually exclusive with `bot`.
 
 ### Nested Schema for `spec.assignments`
 

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/scoped_token.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/scoped_token.mdx
@@ -103,8 +103,7 @@ Optional:
 - `aws` (Attributes) The AWS-specific configuration used with the "ec2" and "iam" join methods. (see [below for nested schema](#nested-schema-for-specaws))
 - `azure` (Attributes) The Azure-specific configuration used with the "azure" join method. (see [below for nested schema](#nested-schema-for-specazure))
 - `azure_devops` (Attributes) The Azure Devops-specific configuration used with the "azure_devops" join method. (see [below for nested schema](#nested-schema-for-specazure_devops))
-- `bot_name` (String) Name of the bot associated with this join token, if any.
-- `bot_scope` (String) Scope of the bot associated with this join token. Required if bot_name is set, and mutually exclusive with assigned_scope.
+- `bot` (String) The bot associated with this join token, if any, as a scope-qualified name of the form "<scope>::<bot-name>" (e.g. "/staging/west::mybot"). The scope component must be a descendant of or equivalent to the token's resource scope.  Mutually exclusive with assigned_scope.
 - `bound_keypair` (Attributes) Configuration specific to the "bound_keypair" join method. (see [below for nested schema](#nested-schema-for-specbound_keypair))
 - `gcp` (Attributes) The GCP-specific configuration used with the "gcp" join method. (see [below for nested schema](#nested-schema-for-specgcp))
 - `immutable_labels` (Attributes) Immutable labels that should be applied to any resulting resources provisioned using this token. (see [below for nested schema](#nested-schema-for-specimmutable_labels))

--- a/examples/chart/teleport-cluster/charts/teleport-operator/operator-crds/resources.teleport.dev_scopedroleassignmentsv1.yaml
+++ b/examples/chart/teleport-cluster/charts/teleport-operator/operator-crds/resources.teleport.dev_scopedroleassignmentsv1.yaml
@@ -67,18 +67,15 @@ spec:
                   type: object
                 nullable: true
                 type: array
-              bot_name:
-                description: Name of the Bot to whom all contained assignments apply.
-                  Mutually exclusive with `user`.
-                type: string
-              bot_scope:
-                description: Scope of the Bot to whom all contained assignments apply.
-                  Required if `bot_name` is set. If specified, assignment scopes must
-                  be equal or descendent of this scope.
+              bot:
+                description: The Bot to whom all contained assignments apply, as a
+                  scope-qualified name of the form "<scope>::<bot-name>" (e.g. "/staging/west::mybot").
+                  Mutually exclusive with `user`.  When specified, assignment scopes
+                  must be equal or descendent of the scope indicated by this field.
                 type: string
               user:
                 description: User is the user to whom all contained assignments apply.
-                  Mutually exclusive with `bot_name`.
+                  Mutually exclusive with `bot`.
                 type: string
             type: object
           status:

--- a/examples/chart/teleport-cluster/charts/teleport-operator/operator-crds/resources.teleport.dev_scopedtokensv1.yaml
+++ b/examples/chart/teleport-cluster/charts/teleport-operator/operator-crds/resources.teleport.dev_scopedtokensv1.yaml
@@ -153,12 +153,11 @@ spec:
                       field.
                     type: string
                 type: object
-              bot_name:
-                description: Name of the bot associated with this join token, if any.
-                type: string
-              bot_scope:
-                description: Scope of the bot associated with this join token. Required
-                  if bot_name is set, and mutually exclusive with assigned_scope.
+              bot:
+                description: The bot associated with this join token, if any, as a
+                  scope-qualified name of the form "<scope>::<bot-name>" (e.g. "/staging/west::mybot").
+                  The scope component must be a descendant of or equivalent to the
+                  token's resource scope.  Mutually exclusive with assigned_scope.
                 type: string
               bound_keypair:
                 description: Configuration specific to the "bound_keypair" join method.

--- a/integrations/lib/embeddedtbot/bot_test.go
+++ b/integrations/lib/embeddedtbot/bot_test.go
@@ -345,7 +345,7 @@ func TestScopedBotJoinAuth(t *testing.T) {
 					Scope: testRootScope,
 				}.Build(),
 			},
-			Bot: testRootScope + "::" + testBotName,
+			Bot: scopes.QualifiedName{Scope: testRootScope, Name: testBotName}.String(),
 		}.Build(),
 	}.Build()
 	_, err = adminClient.ScopedAccessServiceClient().CreateScopedRoleAssignment(
@@ -405,7 +405,7 @@ func TestScopedBotJoinAuth(t *testing.T) {
 				Type:       string(types.KubernetesJoinTypeStaticJWKS),
 				StaticJwks: scopedjoiningv1.Kubernetes_StaticJWKSConfig_builder{Jwks: jwks}.Build(),
 			}.Build(),
-			Bot:   testRootScope + "::" + testBotName,
+			Bot:   scopes.QualifiedName{Scope: testRootScope, Name: testBotName}.String(),
 			Roles: []string{string(types.RoleBot)},
 		}.Build(),
 	}.Build()

--- a/integrations/lib/embeddedtbot/bot_test.go
+++ b/integrations/lib/embeddedtbot/bot_test.go
@@ -345,8 +345,7 @@ func TestScopedBotJoinAuth(t *testing.T) {
 					Scope: testRootScope,
 				}.Build(),
 			},
-			BotName:  testBotName,
-			BotScope: testRootScope,
+			Bot: testRootScope + "::" + testBotName,
 		}.Build(),
 	}.Build()
 	_, err = adminClient.ScopedAccessServiceClient().CreateScopedRoleAssignment(
@@ -406,9 +405,8 @@ func TestScopedBotJoinAuth(t *testing.T) {
 				Type:       string(types.KubernetesJoinTypeStaticJWKS),
 				StaticJwks: scopedjoiningv1.Kubernetes_StaticJWKSConfig_builder{Jwks: jwks}.Build(),
 			}.Build(),
-			BotName:  testBotName,
-			BotScope: testRootScope,
-			Roles:    []string{string(types.RoleBot)},
+			Bot:   testRootScope + "::" + testBotName,
+			Roles: []string{string(types.RoleBot)},
 		}.Build(),
 	}.Build()
 	// Somehow the admin client interface doesn't expose CreateScopedToken ¯\_(ツ)_/¯

--- a/integrations/operator/config/crd/bases/resources.teleport.dev_scopedroleassignmentsv1.yaml
+++ b/integrations/operator/config/crd/bases/resources.teleport.dev_scopedroleassignmentsv1.yaml
@@ -67,18 +67,15 @@ spec:
                   type: object
                 nullable: true
                 type: array
-              bot_name:
-                description: Name of the Bot to whom all contained assignments apply.
-                  Mutually exclusive with `user`.
-                type: string
-              bot_scope:
-                description: Scope of the Bot to whom all contained assignments apply.
-                  Required if `bot_name` is set. If specified, assignment scopes must
-                  be equal or descendent of this scope.
+              bot:
+                description: The Bot to whom all contained assignments apply, as a
+                  scope-qualified name of the form "<scope>::<bot-name>" (e.g. "/staging/west::mybot").
+                  Mutually exclusive with `user`.  When specified, assignment scopes
+                  must be equal or descendent of the scope indicated by this field.
                 type: string
               user:
                 description: User is the user to whom all contained assignments apply.
-                  Mutually exclusive with `bot_name`.
+                  Mutually exclusive with `bot`.
                 type: string
             type: object
           status:

--- a/integrations/operator/config/crd/bases/resources.teleport.dev_scopedtokensv1.yaml
+++ b/integrations/operator/config/crd/bases/resources.teleport.dev_scopedtokensv1.yaml
@@ -153,12 +153,11 @@ spec:
                       field.
                     type: string
                 type: object
-              bot_name:
-                description: Name of the bot associated with this join token, if any.
-                type: string
-              bot_scope:
-                description: Scope of the bot associated with this join token. Required
-                  if bot_name is set, and mutually exclusive with assigned_scope.
+              bot:
+                description: The bot associated with this join token, if any, as a
+                  scope-qualified name of the form "<scope>::<bot-name>" (e.g. "/staging/west::mybot").
+                  The scope component must be a descendant of or equivalent to the
+                  token's resource scope.  Mutually exclusive with assigned_scope.
                 type: string
               bound_keypair:
                 description: Configuration specific to the "bound_keypair" join method.

--- a/integrations/terraform/testlib/bot_test.go
+++ b/integrations/terraform/testlib/bot_test.go
@@ -308,8 +308,7 @@ func (s *TerraformSuiteOSSScopedResources) TestBotWithScope() {
 					resource.TestCheckResourceAttr(scopedRoleName, "scope", "/test-scope"),
 					resource.TestCheckResourceAttr(assignmentName, "metadata.name", "test-bot-assignment"),
 					resource.TestCheckResourceAttr(assignmentName, "scope", "/test-scope"),
-					resource.TestCheckResourceAttr(assignmentName, "spec.bot_name", "test-scoped-bot"),
-					resource.TestCheckResourceAttr(assignmentName, "spec.bot_scope", "/test-scope"),
+					resource.TestCheckResourceAttr(assignmentName, "spec.bot", "/test-scope::test-scoped-bot"),
 					resource.TestCheckResourceAttr(assignmentName, "spec.assignments.0.role", "scoped-operator"),
 					resource.TestCheckResourceAttr(assignmentName, "spec.assignments.0.scope", "/test-scope"),
 				),
@@ -340,7 +339,7 @@ func (s *TerraformSuiteOSSScopedResources) TestBotWithScope() {
 					resource.TestCheckResourceAttr(scopedRoleName, "scope", "/different-scope"),
 					resource.TestCheckResourceAttr(assignmentName, "metadata.name", "test-bot-assignment-different"),
 					resource.TestCheckResourceAttr(assignmentName, "scope", "/different-scope"),
-					resource.TestCheckResourceAttr(assignmentName, "spec.bot_scope", "/different-scope"),
+					resource.TestCheckResourceAttr(assignmentName, "spec.bot", "/different-scope::test-scoped-bot"),
 				),
 			},
 			{

--- a/integrations/terraform/testlib/fixtures/bot_scoped_0_create.tf
+++ b/integrations/terraform/testlib/fixtures/bot_scoped_0_create.tf
@@ -41,8 +41,7 @@ resource "teleport_scoped_role_assignment" "bot_assignment" {
   }
   scope = local.scope_path
   spec = {
-    bot_name  = teleport_bot.test_scoped.metadata.name
-    bot_scope = teleport_bot.test_scoped.scope
+    bot = "${teleport_bot.test_scoped.scope}::${teleport_bot.test_scoped.metadata.name}"
     assignments = [{
       role  = teleport_scoped_role.scoped_operator.metadata.name
       scope = local.scope_path

--- a/integrations/terraform/testlib/fixtures/bot_scoped_1_update.tf
+++ b/integrations/terraform/testlib/fixtures/bot_scoped_1_update.tf
@@ -45,8 +45,7 @@ resource "teleport_scoped_role_assignment" "bot_assignment" {
   }
   scope = local.scope_path
   spec = {
-    bot_name  = teleport_bot.test_scoped.metadata.name
-    bot_scope = teleport_bot.test_scoped.scope
+    bot = "${teleport_bot.test_scoped.scope}::${teleport_bot.test_scoped.metadata.name}"
     assignments = [{
       role  = teleport_scoped_role.scoped_operator.metadata.name
       scope = local.scope_path

--- a/integrations/terraform/testlib/fixtures/bot_scoped_2_change_scope.tf
+++ b/integrations/terraform/testlib/fixtures/bot_scoped_2_change_scope.tf
@@ -45,8 +45,7 @@ resource "teleport_scoped_role_assignment" "bot_assignment" {
   }
   scope = local.scope_path
   spec = {
-    bot_name  = teleport_bot.test_scoped.metadata.name
-    bot_scope = teleport_bot.test_scoped.scope
+    bot = "${teleport_bot.test_scoped.scope}::${teleport_bot.test_scoped.metadata.name}"
     assignments = [{
       role  = teleport_scoped_role.scoped_operator.metadata.name
       scope = local.scope_path

--- a/integrations/terraform/tfschema/scopes/access/assignment/v1/assignment_terraform.go
+++ b/integrations/terraform/tfschema/scopes/access/assignment/v1/assignment_terraform.go
@@ -124,18 +124,13 @@ func GenSchemaScopedRoleAssignment(ctx context.Context) (github_com_hashicorp_te
 					Description: "Assignments is a list of individual role @ scope assignments.",
 					Required:    true,
 				},
-				"bot_name": {
-					Description: "Name of the Bot to whom all contained assignments apply. Mutually exclusive with `user`.",
-					Optional:    true,
-					Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
-				},
-				"bot_scope": {
-					Description: "Scope of the Bot to whom all contained assignments apply. Required if `bot_name` is set. If specified, assignment scopes must be equal or descendent of this scope.",
+				"bot": {
+					Description: "The Bot to whom all contained assignments apply, as a scope-qualified name of the form \"<scope>::<bot-name>\" (e.g. \"/staging/west::mybot\"). Mutually exclusive with `user`.  When specified, assignment scopes must be equal or descendent of the scope indicated by this field.",
 					Optional:    true,
 					Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
 				},
 				"user": {
-					Description: "User is the user to whom all contained assignments apply. Mutually exclusive with `bot_name`.",
+					Description: "User is the user to whom all contained assignments apply. Mutually exclusive with `bot`.",
 					Optional:    true,
 					Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
 				},
@@ -442,36 +437,19 @@ func CopyScopedRoleAssignmentFromTerraform(_ context.Context, tf github_com_hash
 						}
 					}
 					{
-						a, ok := tf.Attrs["bot_name"]
+						a, ok := tf.Attrs["bot"]
 						if !ok {
-							diags.Append(attrReadMissingDiag{"ScopedRoleAssignment.spec.bot_name"})
+							diags.Append(attrReadMissingDiag{"ScopedRoleAssignment.spec.bot"})
 						} else {
 							v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.String)
 							if !ok {
-								diags.Append(attrReadConversionFailureDiag{"ScopedRoleAssignment.spec.bot_name", "github.com/hashicorp/terraform-plugin-framework/types.String"})
+								diags.Append(attrReadConversionFailureDiag{"ScopedRoleAssignment.spec.bot", "github.com/hashicorp/terraform-plugin-framework/types.String"})
 							} else {
 								var t string
 								if !v.Null && !v.Unknown {
 									t = string(v.Value)
 								}
-								obj.BotName = t
-							}
-						}
-					}
-					{
-						a, ok := tf.Attrs["bot_scope"]
-						if !ok {
-							diags.Append(attrReadMissingDiag{"ScopedRoleAssignment.spec.bot_scope"})
-						} else {
-							v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.String)
-							if !ok {
-								diags.Append(attrReadConversionFailureDiag{"ScopedRoleAssignment.spec.bot_scope", "github.com/hashicorp/terraform-plugin-framework/types.String"})
-							} else {
-								var t string
-								if !v.Null && !v.Unknown {
-									t = string(v.Value)
-								}
-								obj.BotScope = t
+								obj.Bot = t
 							}
 						}
 					}
@@ -908,47 +886,25 @@ func CopyScopedRoleAssignmentToTerraform(ctx context.Context, obj *github_com_gr
 						}
 					}
 					{
-						t, ok := tf.AttrTypes["bot_name"]
+						t, ok := tf.AttrTypes["bot"]
 						if !ok {
-							diags.Append(attrWriteMissingDiag{"ScopedRoleAssignment.spec.bot_name"})
+							diags.Append(attrWriteMissingDiag{"ScopedRoleAssignment.spec.bot"})
 						} else {
-							v, ok := tf.Attrs["bot_name"].(github_com_hashicorp_terraform_plugin_framework_types.String)
+							v, ok := tf.Attrs["bot"].(github_com_hashicorp_terraform_plugin_framework_types.String)
 							if !ok {
 								i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 								if err != nil {
-									diags.Append(attrWriteGeneralError{"ScopedRoleAssignment.spec.bot_name", err})
+									diags.Append(attrWriteGeneralError{"ScopedRoleAssignment.spec.bot", err})
 								}
 								v, ok = i.(github_com_hashicorp_terraform_plugin_framework_types.String)
 								if !ok {
-									diags.Append(attrWriteConversionFailureDiag{"ScopedRoleAssignment.spec.bot_name", "github.com/hashicorp/terraform-plugin-framework/types.String"})
+									diags.Append(attrWriteConversionFailureDiag{"ScopedRoleAssignment.spec.bot", "github.com/hashicorp/terraform-plugin-framework/types.String"})
 								}
-								v.Null = string(obj.BotName) == ""
+								v.Null = string(obj.Bot) == ""
 							}
-							v.Value = string(obj.BotName)
+							v.Value = string(obj.Bot)
 							v.Unknown = false
-							tf.Attrs["bot_name"] = v
-						}
-					}
-					{
-						t, ok := tf.AttrTypes["bot_scope"]
-						if !ok {
-							diags.Append(attrWriteMissingDiag{"ScopedRoleAssignment.spec.bot_scope"})
-						} else {
-							v, ok := tf.Attrs["bot_scope"].(github_com_hashicorp_terraform_plugin_framework_types.String)
-							if !ok {
-								i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
-								if err != nil {
-									diags.Append(attrWriteGeneralError{"ScopedRoleAssignment.spec.bot_scope", err})
-								}
-								v, ok = i.(github_com_hashicorp_terraform_plugin_framework_types.String)
-								if !ok {
-									diags.Append(attrWriteConversionFailureDiag{"ScopedRoleAssignment.spec.bot_scope", "github.com/hashicorp/terraform-plugin-framework/types.String"})
-								}
-								v.Null = string(obj.BotScope) == ""
-							}
-							v.Value = string(obj.BotScope)
-							v.Unknown = false
-							tf.Attrs["bot_scope"] = v
+							tf.Attrs["bot"] = v
 						}
 					}
 				}

--- a/integrations/terraform/tfschema/scopes/joining/v1/token_terraform.go
+++ b/integrations/terraform/tfschema/scopes/joining/v1/token_terraform.go
@@ -243,13 +243,8 @@ func GenSchemaScopedToken(ctx context.Context) (github_com_hashicorp_terraform_p
 					Description: "The Azure Devops-specific configuration used with the \"azure_devops\" join method.",
 					Optional:    true,
 				},
-				"bot_name": {
-					Description: "Name of the bot associated with this join token, if any.",
-					Optional:    true,
-					Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
-				},
-				"bot_scope": {
-					Description: "Scope of the bot associated with this join token. Required if bot_name is set, and mutually exclusive with assigned_scope.",
+				"bot": {
+					Description: "The bot associated with this join token, if any, as a scope-qualified name of the form \"<scope>::<bot-name>\" (e.g. \"/staging/west::mybot\"). The scope component must be a descendant of or equivalent to the token's resource scope.  Mutually exclusive with assigned_scope.",
 					Optional:    true,
 					Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
 				},
@@ -1877,36 +1872,19 @@ func CopyScopedTokenFromTerraform(_ context.Context, tf github_com_hashicorp_ter
 						}
 					}
 					{
-						a, ok := tf.Attrs["bot_name"]
+						a, ok := tf.Attrs["bot"]
 						if !ok {
-							diags.Append(attrReadMissingDiag{"ScopedToken.spec.bot_name"})
+							diags.Append(attrReadMissingDiag{"ScopedToken.spec.bot"})
 						} else {
 							v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.String)
 							if !ok {
-								diags.Append(attrReadConversionFailureDiag{"ScopedToken.spec.bot_name", "github.com/hashicorp/terraform-plugin-framework/types.String"})
+								diags.Append(attrReadConversionFailureDiag{"ScopedToken.spec.bot", "github.com/hashicorp/terraform-plugin-framework/types.String"})
 							} else {
 								var t string
 								if !v.Null && !v.Unknown {
 									t = string(v.Value)
 								}
-								obj.BotName = t
-							}
-						}
-					}
-					{
-						a, ok := tf.Attrs["bot_scope"]
-						if !ok {
-							diags.Append(attrReadMissingDiag{"ScopedToken.spec.bot_scope"})
-						} else {
-							v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.String)
-							if !ok {
-								diags.Append(attrReadConversionFailureDiag{"ScopedToken.spec.bot_scope", "github.com/hashicorp/terraform-plugin-framework/types.String"})
-							} else {
-								var t string
-								if !v.Null && !v.Unknown {
-									t = string(v.Value)
-								}
-								obj.BotScope = t
+								obj.Bot = t
 							}
 						}
 					}
@@ -4200,47 +4178,25 @@ func CopyScopedTokenToTerraform(ctx context.Context, obj *github_com_gravitation
 						}
 					}
 					{
-						t, ok := tf.AttrTypes["bot_name"]
+						t, ok := tf.AttrTypes["bot"]
 						if !ok {
-							diags.Append(attrWriteMissingDiag{"ScopedToken.spec.bot_name"})
+							diags.Append(attrWriteMissingDiag{"ScopedToken.spec.bot"})
 						} else {
-							v, ok := tf.Attrs["bot_name"].(github_com_hashicorp_terraform_plugin_framework_types.String)
+							v, ok := tf.Attrs["bot"].(github_com_hashicorp_terraform_plugin_framework_types.String)
 							if !ok {
 								i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 								if err != nil {
-									diags.Append(attrWriteGeneralError{"ScopedToken.spec.bot_name", err})
+									diags.Append(attrWriteGeneralError{"ScopedToken.spec.bot", err})
 								}
 								v, ok = i.(github_com_hashicorp_terraform_plugin_framework_types.String)
 								if !ok {
-									diags.Append(attrWriteConversionFailureDiag{"ScopedToken.spec.bot_name", "github.com/hashicorp/terraform-plugin-framework/types.String"})
+									diags.Append(attrWriteConversionFailureDiag{"ScopedToken.spec.bot", "github.com/hashicorp/terraform-plugin-framework/types.String"})
 								}
-								v.Null = string(obj.BotName) == ""
+								v.Null = string(obj.Bot) == ""
 							}
-							v.Value = string(obj.BotName)
+							v.Value = string(obj.Bot)
 							v.Unknown = false
-							tf.Attrs["bot_name"] = v
-						}
-					}
-					{
-						t, ok := tf.AttrTypes["bot_scope"]
-						if !ok {
-							diags.Append(attrWriteMissingDiag{"ScopedToken.spec.bot_scope"})
-						} else {
-							v, ok := tf.Attrs["bot_scope"].(github_com_hashicorp_terraform_plugin_framework_types.String)
-							if !ok {
-								i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
-								if err != nil {
-									diags.Append(attrWriteGeneralError{"ScopedToken.spec.bot_scope", err})
-								}
-								v, ok = i.(github_com_hashicorp_terraform_plugin_framework_types.String)
-								if !ok {
-									diags.Append(attrWriteConversionFailureDiag{"ScopedToken.spec.bot_scope", "github.com/hashicorp/terraform-plugin-framework/types.String"})
-								}
-								v.Null = string(obj.BotScope) == ""
-							}
-							v.Value = string(obj.BotScope)
-							v.Unknown = false
-							tf.Attrs["bot_scope"] = v
+							tf.Attrs["bot"] = v
 						}
 					}
 				}

--- a/lib/auth/bot_test.go
+++ b/lib/auth/bot_test.go
@@ -1415,7 +1415,7 @@ func createScopedBot(t *testing.T, srv *authtest.TLSServer, adminClient *authcli
 			SubKind: scopedaccess.SubKindDynamic,
 			Scope:   "/test",
 			Spec: scopedaccessv1.ScopedRoleAssignmentSpec_builder{
-				Bot: "/test::test-scoped",
+				Bot: scopes.QualifiedName{Scope: "/test", Name: "test-scoped"}.String(),
 				Assignments: []*scopedaccessv1.Assignment{
 					scopedaccessv1.Assignment_builder{Role: "scoped-example", Scope: "/test"}.Build(),
 				},
@@ -1470,7 +1470,7 @@ func TestRegisterBotWithScopedKubernetesToken(t *testing.T) {
 			JoinMethod: string(types.JoinMethodKubernetes),
 			Roles:      []string{string(types.RoleBot)},
 			UsageMode:  joining.TokenUsageModeBot,
-			Bot:        "/test::test-scoped",
+			Bot:        scopes.QualifiedName{Scope: "/test", Name: "test-scoped"}.String(),
 			Kubernetes: joiningv1.Kubernetes_builder{
 				Type: string(types.KubernetesJoinTypeStaticJWKS),
 				StaticJwks: joiningv1.Kubernetes_StaticJWKSConfig_builder{

--- a/lib/auth/bot_test.go
+++ b/lib/auth/bot_test.go
@@ -1415,8 +1415,7 @@ func createScopedBot(t *testing.T, srv *authtest.TLSServer, adminClient *authcli
 			SubKind: scopedaccess.SubKindDynamic,
 			Scope:   "/test",
 			Spec: scopedaccessv1.ScopedRoleAssignmentSpec_builder{
-				BotName:  "test-scoped",
-				BotScope: "/test",
+				Bot: "/test::test-scoped",
 				Assignments: []*scopedaccessv1.Assignment{
 					scopedaccessv1.Assignment_builder{Role: "scoped-example", Scope: "/test"}.Build(),
 				},
@@ -1471,8 +1470,7 @@ func TestRegisterBotWithScopedKubernetesToken(t *testing.T) {
 			JoinMethod: string(types.JoinMethodKubernetes),
 			Roles:      []string{string(types.RoleBot)},
 			UsageMode:  joining.TokenUsageModeBot,
-			BotName:    "test-scoped",
-			BotScope:   "/test",
+			Bot:        "/test::test-scoped",
 			Kubernetes: joiningv1.Kubernetes_builder{
 				Type: string(types.KubernetesJoinTypeStaticJWKS),
 				StaticJwks: joiningv1.Kubernetes_StaticJWKSConfig_builder{

--- a/lib/auth/grpcserver_test.go
+++ b/lib/auth/grpcserver_test.go
@@ -7115,7 +7115,7 @@ func TestGenerateUserCertsScopedBot(t *testing.T) {
 						}.Build(),
 						Scope: c.scope,
 						Spec: scopedaccessv1.ScopedRoleAssignmentSpec_builder{
-							Bot: c.scope + "::" + bot.GetMetadata().GetName(),
+							Bot: scopes.QualifiedName{Scope: c.scope, Name: bot.GetMetadata().GetName()}.String(),
 							Assignments: []*scopedaccessv1.Assignment{
 								scopedaccessv1.Assignment_builder{Role: roleResp.GetRole().GetMetadata().GetName(), Scope: c.scope}.Build(),
 							},

--- a/lib/auth/grpcserver_test.go
+++ b/lib/auth/grpcserver_test.go
@@ -7115,8 +7115,7 @@ func TestGenerateUserCertsScopedBot(t *testing.T) {
 						}.Build(),
 						Scope: c.scope,
 						Spec: scopedaccessv1.ScopedRoleAssignmentSpec_builder{
-							BotName:  bot.GetMetadata().GetName(),
-							BotScope: c.scope,
+							Bot: c.scope + "::" + bot.GetMetadata().GetName(),
 							Assignments: []*scopedaccessv1.Assignment{
 								scopedaccessv1.Assignment_builder{Role: roleResp.GetRole().GetMetadata().GetName(), Scope: c.scope}.Build(),
 							},

--- a/lib/auth/issuance/v1/service_test.go
+++ b/lib/auth/issuance/v1/service_test.go
@@ -134,7 +134,7 @@ func TestIssueScopedBotCerts(t *testing.T) {
 			}.Build(),
 			Scope: botScope,
 			Spec: scopedaccessv1.ScopedRoleAssignmentSpec_builder{
-				Bot: botScope + "::" + bot.GetMetadata().GetName(),
+				Bot: scopes.QualifiedName{Scope: botScope, Name: bot.GetMetadata().GetName()}.String(),
 				Assignments: []*scopedaccessv1.Assignment{
 					scopedaccessv1.Assignment_builder{Role: "bot-role", Scope: botScope}.Build(),
 				},
@@ -364,7 +364,7 @@ func TestIssueScopedBotCerts_Unauthorized(t *testing.T) {
 			}.Build(),
 			Scope: testScope,
 			Spec: scopedaccessv1.ScopedRoleAssignmentSpec_builder{
-				Bot: testScope + "::" + scopedBot.GetMetadata().GetName(),
+				Bot: scopes.QualifiedName{Scope: testScope, Name: scopedBot.GetMetadata().GetName()}.String(),
 				Assignments: []*scopedaccessv1.Assignment{
 					scopedaccessv1.Assignment_builder{Role: "test-role", Scope: testScope}.Build(),
 				},

--- a/lib/auth/issuance/v1/service_test.go
+++ b/lib/auth/issuance/v1/service_test.go
@@ -134,8 +134,7 @@ func TestIssueScopedBotCerts(t *testing.T) {
 			}.Build(),
 			Scope: botScope,
 			Spec: scopedaccessv1.ScopedRoleAssignmentSpec_builder{
-				BotName:  bot.GetMetadata().GetName(),
-				BotScope: botScope,
+				Bot: botScope + "::" + bot.GetMetadata().GetName(),
 				Assignments: []*scopedaccessv1.Assignment{
 					scopedaccessv1.Assignment_builder{Role: "bot-role", Scope: botScope}.Build(),
 				},
@@ -365,8 +364,7 @@ func TestIssueScopedBotCerts_Unauthorized(t *testing.T) {
 			}.Build(),
 			Scope: testScope,
 			Spec: scopedaccessv1.ScopedRoleAssignmentSpec_builder{
-				BotName:  scopedBot.GetMetadata().GetName(),
-				BotScope: testScope,
+				Bot: testScope + "::" + scopedBot.GetMetadata().GetName(),
 				Assignments: []*scopedaccessv1.Assignment{
 					scopedaccessv1.Assignment_builder{Role: "test-role", Scope: testScope}.Build(),
 				},

--- a/lib/auth/join.go
+++ b/lib/auth/join.go
@@ -136,11 +136,6 @@ func (a *Server) handleJoinFailure(
 			botJoinEvent.Method = string(pt.GetJoinMethod())
 			botJoinEvent.TokenName = pt.GetSafeName()
 			botJoinEvent.BotName = pt.GetBotName()
-
-			// We don't want to perform a backend fetch here, so we'll use the
-			// bot scope indicated in the token rather than the one embedded in
-			// the user.
-			botJoinEvent.Scope = pt.GetBotScope()
 		}
 		evt = botJoinEvent
 	} else {
@@ -467,7 +462,7 @@ func (a *Server) GenerateBotCertsForJoin(
 			return nil, "", trace.AccessDenied("scoped token usage mode must be 'bot' for bot joining")
 		}
 
-		tokenBot, err := scopes.ParseQualifiedName(scoped.GetScoped().GetSpec().GetBot())
+		tokenBot, err := scoped.GetBot()
 		if err != nil {
 			return nil, "", trace.Wrap(err, "parsing scoped token bot")
 		}

--- a/lib/auth/join.go
+++ b/lib/auth/join.go
@@ -444,6 +444,10 @@ func (a *Server) GenerateBotCertsForJoin(
 		a.logger.WarnContext(ctx, "Unable to encode struct value for join metadata", "error", err)
 	}
 
+	// TODO(scopes): scoped bots are currently looked up by their bare name and
+	// scope-checked via the BotScopeLabel below. Once scoped bots are namespaced
+	// by scope in the backend, the bare name is no longer a unique identifier and
+	// this lookup must key on the scope-qualified name instead.
 	user, err := a.GetUserOrLoginState(ctx, machineidv1.BotResourceName(botName))
 	if err != nil {
 		return nil, "", trace.Wrap(err)
@@ -463,13 +467,17 @@ func (a *Server) GenerateBotCertsForJoin(
 			return nil, "", trace.AccessDenied("scoped token usage mode must be 'bot' for bot joining")
 		}
 
-		tokenBotScope := scoped.GetScoped().GetSpec().GetBotScope()
+		tokenBot, err := scopes.ParseQualifiedName(scoped.GetScoped().GetSpec().GetBot())
+		if err != nil {
+			return nil, "", trace.Wrap(err, "parsing scoped token bot")
+		}
+		tokenBotScope := tokenBot.Scope
 		if botScope != tokenBotScope {
 			a.logger.WarnContext(ctx, "bot scope must match token scope",
 				"token_scope", tokenBotScope,
 				"bot_scope", botScope,
 			)
-			return nil, "", trace.AccessDenied("bot scope must match token's spec.bot_scope")
+			return nil, "", trace.AccessDenied("bot scope must match token's spec.bot")
 		}
 
 		if !scopes.ResourceScope(botScope).IsSubjectToScopeOfEffect(scoped.GetScoped().GetScope()) {

--- a/lib/auth/machineid/machineidv1/machineidv1_test.go
+++ b/lib/auth/machineid/machineidv1/machineidv1_test.go
@@ -3625,7 +3625,7 @@ func TestBotInstanceService_SubmitHeartbeat(t *testing.T) {
 				SubKind: scopedaccess.SubKindDynamic,
 				Scope:   "/scopes",
 				Spec: scopedaccessv1.ScopedRoleAssignmentSpec_builder{
-					Bot: "/scopes/test::" + botName,
+					Bot: scopes.QualifiedName{Scope: "/scopes/test", Name: botName}.String(),
 					Assignments: []*scopedaccessv1.Assignment{
 						scopedaccessv1.Assignment_builder{Role: scopedRole.GetRole().GetMetadata().GetName(), Scope: "/scopes/test"}.Build(),
 					},

--- a/lib/auth/machineid/machineidv1/machineidv1_test.go
+++ b/lib/auth/machineid/machineidv1/machineidv1_test.go
@@ -3625,8 +3625,7 @@ func TestBotInstanceService_SubmitHeartbeat(t *testing.T) {
 				SubKind: scopedaccess.SubKindDynamic,
 				Scope:   "/scopes",
 				Spec: scopedaccessv1.ScopedRoleAssignmentSpec_builder{
-					BotName:  botName,
-					BotScope: "/scopes/test",
+					Bot: "/scopes/test::" + botName,
 					Assignments: []*scopedaccessv1.Assignment{
 						scopedaccessv1.Assignment_builder{Role: scopedRole.GetRole().GetMetadata().GetName(), Scope: "/scopes/test"}.Build(),
 					},

--- a/lib/join/join_bound_keypair_test.go
+++ b/lib/join/join_bound_keypair_test.go
@@ -1870,8 +1870,7 @@ func createScopedBot(t *testing.T, srv *authtest.TLSServer, adminClient *authcli
 			SubKind: scopedaccess.SubKindDynamic,
 			Scope:   "/test",
 			Spec: scopedaccessv1.ScopedRoleAssignmentSpec_builder{
-				BotName:  "test-scoped",
-				BotScope: "/test",
+				Bot: "/test::test-scoped",
 				Assignments: []*scopedaccessv1.Assignment{
 					scopedaccessv1.Assignment_builder{Role: "scoped-example", Scope: "/test"}.Build(),
 				},
@@ -1938,8 +1937,7 @@ func TestJoinBoundKeypair_ScopedToken(t *testing.T) {
 			JoinMethod: string(types.JoinMethodBoundKeypair),
 			Roles:      []string{string(types.RoleBot)},
 			UsageMode:  joining.TokenUsageModeBot,
-			BotName:    "test-scoped",
-			BotScope:   "/test",
+			Bot:        "/test::test-scoped",
 			BoundKeypair: joiningv1.BoundKeypairSpec_builder{
 				Onboarding: joiningv1.BoundKeypairSpec_OnboardingSpec_builder{
 					InitialPublicKey: correctPublicKey,

--- a/lib/join/join_bound_keypair_test.go
+++ b/lib/join/join_bound_keypair_test.go
@@ -1870,7 +1870,7 @@ func createScopedBot(t *testing.T, srv *authtest.TLSServer, adminClient *authcli
 			SubKind: scopedaccess.SubKindDynamic,
 			Scope:   "/test",
 			Spec: scopedaccessv1.ScopedRoleAssignmentSpec_builder{
-				Bot: "/test::test-scoped",
+				Bot: scopes.QualifiedName{Scope: "/test", Name: "test-scoped"}.String(),
 				Assignments: []*scopedaccessv1.Assignment{
 					scopedaccessv1.Assignment_builder{Role: "scoped-example", Scope: "/test"}.Build(),
 				},
@@ -1937,7 +1937,7 @@ func TestJoinBoundKeypair_ScopedToken(t *testing.T) {
 			JoinMethod: string(types.JoinMethodBoundKeypair),
 			Roles:      []string{string(types.RoleBot)},
 			UsageMode:  joining.TokenUsageModeBot,
-			Bot:        "/test::test-scoped",
+			Bot:        scopes.QualifiedName{Scope: "/test", Name: "test-scoped"}.String(),
 			BoundKeypair: joiningv1.BoundKeypairSpec_builder{
 				Onboarding: joiningv1.BoundKeypairSpec_OnboardingSpec_builder{
 					InitialPublicKey: correctPublicKey,

--- a/lib/join/provision/token.go
+++ b/lib/join/provision/token.go
@@ -44,10 +44,11 @@ type Token interface {
 	// Expiry returns the token's expiration time.
 	Expiry() time.Time
 	// GetBotName returns the BotName field which must be set for joining bots.
+	// The bare name does not uniquely identify a bot across scopes, so it is
+	// suitable for display and resource lookups only; identity comparisons
+	// involving scoped bots must use the scope-qualified bot reference from
+	// the underlying scoped token instead.
 	GetBotName() string
-	// GetBotScope returns the BotScope field which must be set for bots joining
-	// with a scoped token. It is empty for unscoped bots.
-	GetBotScope() string
 	// GetAssignedScope returns the scope that will be assigned to provisioned resources
 	// provisioned using the wrapped [joiningv1.ScopedToken].
 	GetAssignedScope() string

--- a/lib/join/server.go
+++ b/lib/join/server.go
@@ -282,7 +282,11 @@ func (s *Server) Join(stream messages.ServerStream) (err error) {
 
 		// It's not worth fetching the true bot scope here (via bot user label)
 		// so we'll just include the one embedded in the token.
-		i.BotScope = token.GetBotScope()
+		if scoped, ok := token.(*joining.Token); ok {
+			if bot, err := scoped.GetBot(); err == nil {
+				i.BotScope = bot.Scope
+			}
+		}
 	})
 
 	// Validate that the requested join method matches the join method

--- a/lib/scopes/access/access.go
+++ b/lib/scopes/access/access.go
@@ -480,23 +480,21 @@ func StrongValidateAssignment(assignment *scopedaccessv1.ScopedRoleAssignment) e
 		return trace.BadParameter("scoped role assignment %q contains too many sub-assignments (max %d)", assignment.GetMetadata().GetName(), MaxRolesPerAssignment)
 	}
 
-	// Assigning to Bot is mutually exclusive with assigning to User. When
-	// assigning to Bot, we also want to ensure Bot's scope is specified.
-	botSet := assignment.GetSpec().GetBotName() != ""
-	botScope := assignment.GetSpec().GetBotScope()
-	if botSet && assignment.GetSpec().GetUser() != "" {
-		return trace.BadParameter("scoped role assignment %q cannot have both spec.bot_name and spec.user set", assignment.GetMetadata().GetName())
-	}
-	if botSet && botScope == "" {
-		return trace.BadParameter("scoped role assignment %q with spec.bot_name set must also have spec.bot_scope set", assignment.GetMetadata().GetName())
-	}
-	if !botSet && botScope != "" {
-		return trace.BadParameter("scoped role assignment %q with spec.bot_scope set must also have spec.bot_name set", assignment.GetMetadata().GetName())
-	}
+	// Assigning to Bot is mutually exclusive with assigning to User.
+	botSet := assignment.GetSpec().GetBot() != ""
+	var botScope string
 	if botSet {
-		if err := scopes.StrongValidate(botScope); err != nil {
-			return trace.BadParameter("scoped role assignment %q has invalid spec.bot_scope: %v", assignment.GetMetadata().GetName(), err)
+		if assignment.GetSpec().GetUser() != "" {
+			return trace.BadParameter("scoped role assignment %q cannot have both spec.bot and spec.user set", assignment.GetMetadata().GetName())
 		}
+		if err := scopes.StrongValidateQualifiedName(assignment.GetSpec().GetBot()); err != nil {
+			return trace.BadParameter("scoped role assignment %q has invalid spec.bot: %v", assignment.GetMetadata().GetName(), err)
+		}
+		bot, err := scopes.ParseQualifiedName(assignment.GetSpec().GetBot())
+		if err != nil {
+			return trace.Wrap(err)
+		}
+		botScope = bot.Scope
 	}
 
 	for i, subAssignment := range assignment.GetSpec().GetAssignments() {
@@ -531,7 +529,7 @@ func StrongValidateAssignment(assignment *scopedaccessv1.ScopedRoleAssignment) e
 					assignment.GetMetadata().GetName(),
 					i,
 					subAssignment.GetScope(),
-					assignment.GetSpec().GetBotScope(),
+					botScope,
 				)
 			}
 		}
@@ -565,8 +563,8 @@ func commonValidateAssignment(assignment *scopedaccessv1.ScopedRoleAssignment) e
 		return trace.BadParameter("scoped role assignment %q is missing scope", assignment.GetMetadata().GetName())
 	}
 
-	if assignment.GetSpec().GetUser() == "" && assignment.GetSpec().GetBotName() == "" {
-		return trace.BadParameter("scoped role assignment %q is missing spec.user or spec.bot_name", assignment.GetMetadata().GetName())
+	if assignment.GetSpec().GetUser() == "" && assignment.GetSpec().GetBot() == "" {
+		return trace.BadParameter("scoped role assignment %q is missing spec.user or spec.bot", assignment.GetMetadata().GetName())
 	}
 
 	return nil

--- a/lib/scopes/access/access.go
+++ b/lib/scopes/access/access.go
@@ -487,12 +487,12 @@ func StrongValidateAssignment(assignment *scopedaccessv1.ScopedRoleAssignment) e
 		if assignment.GetSpec().GetUser() != "" {
 			return trace.BadParameter("scoped role assignment %q cannot have both spec.bot and spec.user set", assignment.GetMetadata().GetName())
 		}
-		if err := scopes.StrongValidateQualifiedName(assignment.GetSpec().GetBot()); err != nil {
-			return trace.BadParameter("scoped role assignment %q has invalid spec.bot: %v", assignment.GetMetadata().GetName(), err)
-		}
 		bot, err := scopes.ParseQualifiedName(assignment.GetSpec().GetBot())
 		if err != nil {
-			return trace.Wrap(err)
+			return trace.BadParameter("scoped role assignment %q has invalid spec.bot: %v", assignment.GetMetadata().GetName(), err)
+		}
+		if err := bot.StrongValidate(); err != nil {
+			return trace.BadParameter("scoped role assignment %q has invalid spec.bot: %v", assignment.GetMetadata().GetName(), err)
 		}
 		botScope = bot.Scope
 	}

--- a/lib/scopes/access/access_test.go
+++ b/lib/scopes/access/access_test.go
@@ -1047,8 +1047,7 @@ func TestValidateAsssignment(t *testing.T) {
 				}.Build(),
 				Scope: "/",
 				Spec: scopedaccessv1.ScopedRoleAssignmentSpec_builder{
-					BotName:  "mybot",
-					BotScope: "/foo/bar",
+					Bot: "/foo/bar::mybot",
 					Assignments: []*scopedaccessv1.Assignment{
 						scopedaccessv1.Assignment_builder{
 							Role:  "test",
@@ -1062,7 +1061,7 @@ func TestValidateAsssignment(t *testing.T) {
 			weakOk:   true,
 		},
 		{
-			name: "bot_name and user both set",
+			name: "bot and user both set",
 			assignment: scopedaccessv1.ScopedRoleAssignment_builder{
 				Kind:    KindScopedRoleAssignment,
 				SubKind: SubKindDynamic,
@@ -1071,9 +1070,8 @@ func TestValidateAsssignment(t *testing.T) {
 				}.Build(),
 				Scope: "/",
 				Spec: scopedaccessv1.ScopedRoleAssignmentSpec_builder{
-					User:     "alice",
-					BotName:  "mybot",
-					BotScope: "/foo/bar",
+					User: "alice",
+					Bot:  "/foo/bar::mybot",
 					Assignments: []*scopedaccessv1.Assignment{
 						scopedaccessv1.Assignment_builder{
 							Role:  "test",
@@ -1087,7 +1085,7 @@ func TestValidateAsssignment(t *testing.T) {
 			weakOk:   true,
 		},
 		{
-			name: "bot_name without bot_scope",
+			name: "bot missing scope qualification",
 			assignment: scopedaccessv1.ScopedRoleAssignment_builder{
 				Kind:    KindScopedRoleAssignment,
 				SubKind: SubKindDynamic,
@@ -1096,7 +1094,7 @@ func TestValidateAsssignment(t *testing.T) {
 				}.Build(),
 				Scope: "/",
 				Spec: scopedaccessv1.ScopedRoleAssignmentSpec_builder{
-					BotName: "mybot",
+					Bot: "mybot",
 					Assignments: []*scopedaccessv1.Assignment{
 						scopedaccessv1.Assignment_builder{
 							Role:  "test",
@@ -1110,7 +1108,7 @@ func TestValidateAsssignment(t *testing.T) {
 			weakOk:   true,
 		},
 		{
-			name: "bot_scope without bot_name",
+			name: "bot with empty name component",
 			assignment: scopedaccessv1.ScopedRoleAssignment_builder{
 				Kind:    KindScopedRoleAssignment,
 				SubKind: SubKindDynamic,
@@ -1119,8 +1117,7 @@ func TestValidateAsssignment(t *testing.T) {
 				}.Build(),
 				Scope: "/",
 				Spec: scopedaccessv1.ScopedRoleAssignmentSpec_builder{
-					User:     "alice",
-					BotScope: "/foo/bar",
+					Bot: "/foo/bar::",
 					Assignments: []*scopedaccessv1.Assignment{
 						scopedaccessv1.Assignment_builder{
 							Role:  "test",
@@ -1134,7 +1131,7 @@ func TestValidateAsssignment(t *testing.T) {
 			weakOk:   true,
 		},
 		{
-			name: "invalid bot_scope",
+			name: "invalid bot scope",
 			assignment: scopedaccessv1.ScopedRoleAssignment_builder{
 				Kind:    KindScopedRoleAssignment,
 				SubKind: SubKindDynamic,
@@ -1143,8 +1140,7 @@ func TestValidateAsssignment(t *testing.T) {
 				}.Build(),
 				Scope: "/",
 				Spec: scopedaccessv1.ScopedRoleAssignmentSpec_builder{
-					BotName:  "mybot",
-					BotScope: "not-a-scope",
+					Bot: "not-a-scope::mybot",
 					Assignments: []*scopedaccessv1.Assignment{
 						scopedaccessv1.Assignment_builder{
 							Role:  "test",
@@ -1167,8 +1163,7 @@ func TestValidateAsssignment(t *testing.T) {
 				}.Build(),
 				Scope: "/",
 				Spec: scopedaccessv1.ScopedRoleAssignmentSpec_builder{
-					BotName:  "mybot",
-					BotScope: "/foo/bar",
+					Bot: "/foo/bar::mybot",
 					Assignments: []*scopedaccessv1.Assignment{
 						// Valid
 						scopedaccessv1.Assignment_builder{

--- a/lib/scopes/cache/assignments/pinning.go
+++ b/lib/scopes/cache/assignments/pinning.go
@@ -199,12 +199,11 @@ func (c *AssignmentCache) PopulatePinnedAssignmentsForBot(
 	var lastErr error
 
 	// all non-orthogonal assignments for this bot *may* assign roles relevant to this pin
+	wantBot := scopes.QualifiedName{Scope: botScope, Name: botName}.String()
 	assignments := c.cache.AllNonOrthogonalResources(pin.GetScope(), c.cache.WithFilter(func(assignment *scopedaccessv1.ScopedRoleAssignment) bool {
-		matchesBotName := assignment.GetSpec().GetBotName() == botName
-		// ignore assignments where actual bot scope mismatches bot scope
-		// specified in SRA. this mitigates name reuse attacks across scopes.
-		matchesBotScope := assignment.GetSpec().GetBotScope() == botScope
-		return matchesBotName && matchesBotScope
+		// match on the full scope-qualified name. comparing the scope component
+		// as well as the name mitigates name reuse attacks across scopes.
+		return assignment.GetSpec().GetBot() == wantBot
 	}))
 
 	// iterate over all potentially relevant assignments and populate the assignment tree

--- a/lib/scopes/cache/assignments/pinning_test.go
+++ b/lib/scopes/cache/assignments/pinning_test.go
@@ -390,8 +390,7 @@ func TestPopulatePinnedAssignmentsForBot(t *testing.T) {
 			}.Build(),
 			Scope: bernardScope,
 			Spec: scopedaccessv1.ScopedRoleAssignmentSpec_builder{
-				BotName:  "bernard",
-				BotScope: bernardScope,
+				Bot: bernardScope + "::bernard",
 				Assignments: []*scopedaccessv1.Assignment{
 					scopedaccessv1.Assignment_builder{
 						Role:  "role-01",
@@ -410,8 +409,7 @@ func TestPopulatePinnedAssignmentsForBot(t *testing.T) {
 			}.Build(),
 			Scope: bernardScope,
 			Spec: scopedaccessv1.ScopedRoleAssignmentSpec_builder{
-				BotName:  "bernard",
-				BotScope: bernardScope,
+				Bot: bernardScope + "::bernard",
 				Assignments: []*scopedaccessv1.Assignment{
 					scopedaccessv1.Assignment_builder{
 						Role:  "role-02",
@@ -430,8 +428,7 @@ func TestPopulatePinnedAssignmentsForBot(t *testing.T) {
 			}.Build(),
 			Scope: "/",
 			Spec: scopedaccessv1.ScopedRoleAssignmentSpec_builder{
-				BotName:  "bernard",
-				BotScope: bernardScope,
+				Bot: bernardScope + "::bernard",
 				Assignments: []*scopedaccessv1.Assignment{
 					scopedaccessv1.Assignment_builder{
 						Role:  "role-03",
@@ -450,8 +447,7 @@ func TestPopulatePinnedAssignmentsForBot(t *testing.T) {
 			}.Build(),
 			Scope: "/",
 			Spec: scopedaccessv1.ScopedRoleAssignmentSpec_builder{
-				BotName:  "bernard",
-				BotScope: bernardScope,
+				Bot: bernardScope + "::bernard",
 				Assignments: []*scopedaccessv1.Assignment{
 					scopedaccessv1.Assignment_builder{
 						Role:  "role-04",
@@ -470,8 +466,7 @@ func TestPopulatePinnedAssignmentsForBot(t *testing.T) {
 			}.Build(),
 			Scope: bernardScope,
 			Spec: scopedaccessv1.ScopedRoleAssignmentSpec_builder{
-				BotName:  "bernard",
-				BotScope: "/mismatched",
+				Bot: "/mismatched::bernard",
 				Assignments: []*scopedaccessv1.Assignment{
 					scopedaccessv1.Assignment_builder{
 						Role:  "bernard-invalid-01",
@@ -491,8 +486,7 @@ func TestPopulatePinnedAssignmentsForBot(t *testing.T) {
 			}.Build(),
 			Scope: "/",
 			Spec: scopedaccessv1.ScopedRoleAssignmentSpec_builder{
-				BotName:  "bernard",
-				BotScope: bernardScope,
+				Bot: bernardScope + "::bernard",
 				Assignments: []*scopedaccessv1.Assignment{
 					scopedaccessv1.Assignment_builder{
 						Role:  "bernard-invalid-02",

--- a/lib/scopes/cache/assignments/pinning_test.go
+++ b/lib/scopes/cache/assignments/pinning_test.go
@@ -31,6 +31,7 @@ import (
 	scopedaccessv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/access/v1"
 	scopesv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/v1"
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/scopes"
 	scopedaccess "github.com/gravitational/teleport/lib/scopes/access"
 	"github.com/gravitational/teleport/lib/scopes/pinning"
 )
@@ -390,7 +391,7 @@ func TestPopulatePinnedAssignmentsForBot(t *testing.T) {
 			}.Build(),
 			Scope: bernardScope,
 			Spec: scopedaccessv1.ScopedRoleAssignmentSpec_builder{
-				Bot: bernardScope + "::bernard",
+				Bot: scopes.QualifiedName{Scope: bernardScope, Name: "bernard"}.String(),
 				Assignments: []*scopedaccessv1.Assignment{
 					scopedaccessv1.Assignment_builder{
 						Role:  "role-01",
@@ -409,7 +410,7 @@ func TestPopulatePinnedAssignmentsForBot(t *testing.T) {
 			}.Build(),
 			Scope: bernardScope,
 			Spec: scopedaccessv1.ScopedRoleAssignmentSpec_builder{
-				Bot: bernardScope + "::bernard",
+				Bot: scopes.QualifiedName{Scope: bernardScope, Name: "bernard"}.String(),
 				Assignments: []*scopedaccessv1.Assignment{
 					scopedaccessv1.Assignment_builder{
 						Role:  "role-02",
@@ -428,7 +429,7 @@ func TestPopulatePinnedAssignmentsForBot(t *testing.T) {
 			}.Build(),
 			Scope: "/",
 			Spec: scopedaccessv1.ScopedRoleAssignmentSpec_builder{
-				Bot: bernardScope + "::bernard",
+				Bot: scopes.QualifiedName{Scope: bernardScope, Name: "bernard"}.String(),
 				Assignments: []*scopedaccessv1.Assignment{
 					scopedaccessv1.Assignment_builder{
 						Role:  "role-03",
@@ -447,7 +448,7 @@ func TestPopulatePinnedAssignmentsForBot(t *testing.T) {
 			}.Build(),
 			Scope: "/",
 			Spec: scopedaccessv1.ScopedRoleAssignmentSpec_builder{
-				Bot: bernardScope + "::bernard",
+				Bot: scopes.QualifiedName{Scope: bernardScope, Name: "bernard"}.String(),
 				Assignments: []*scopedaccessv1.Assignment{
 					scopedaccessv1.Assignment_builder{
 						Role:  "role-04",
@@ -457,7 +458,7 @@ func TestPopulatePinnedAssignmentsForBot(t *testing.T) {
 			}.Build(),
 			Version: types.V1,
 		}.Build(),
-		// `bot_scope` mismatches bot's actual scope - this should be ignored.
+		// Scope component of `bot` mismatches bot's actual scope - this should be ignored.
 		scopedaccessv1.ScopedRoleAssignment_builder{
 			Kind:    scopedaccess.KindScopedRoleAssignment,
 			SubKind: scopedaccess.SubKindDynamic,
@@ -466,7 +467,7 @@ func TestPopulatePinnedAssignmentsForBot(t *testing.T) {
 			}.Build(),
 			Scope: bernardScope,
 			Spec: scopedaccessv1.ScopedRoleAssignmentSpec_builder{
-				Bot: "/mismatched::bernard",
+				Bot: scopes.QualifiedName{Scope: "/mismatched", Name: "bernard"}.String(),
 				Assignments: []*scopedaccessv1.Assignment{
 					scopedaccessv1.Assignment_builder{
 						Role:  "bernard-invalid-01",
@@ -486,7 +487,7 @@ func TestPopulatePinnedAssignmentsForBot(t *testing.T) {
 			}.Build(),
 			Scope: "/",
 			Spec: scopedaccessv1.ScopedRoleAssignmentSpec_builder{
-				Bot: bernardScope + "::bernard",
+				Bot: scopes.QualifiedName{Scope: bernardScope, Name: "bernard"}.String(),
 				Assignments: []*scopedaccessv1.Assignment{
 					scopedaccessv1.Assignment_builder{
 						Role:  "bernard-invalid-02",

--- a/lib/scopes/joining/token.go
+++ b/lib/scopes/joining/token.go
@@ -299,16 +299,17 @@ func validateJoinMethod(token *joiningv1.ScopedToken) error {
 func validateBotToken(token *joiningv1.ScopedToken, roles types.SystemRoles) error {
 	spec := token.GetSpec()
 
-	if spec.GetBotName() == "" {
-		return trace.BadParameter("expected non-empty bot_name for a scoped bot token")
+	if spec.GetBot() == "" {
+		return trace.BadParameter("expected non-empty bot for a scoped bot token")
 	}
 
-	if spec.GetBotScope() == "" {
-		return trace.BadParameter("expected non-empty bot_scope for a scoped bot token")
+	if err := scopes.StrongValidateQualifiedName(spec.GetBot()); err != nil {
+		return trace.Wrap(err, "validating scoped token bot")
 	}
 
-	if err := scopes.StrongValidate(spec.GetBotScope()); err != nil {
-		return trace.Wrap(err, "validating scoped token bot_scope")
+	bot, err := scopes.ParseQualifiedName(spec.GetBot())
+	if err != nil {
+		return trace.Wrap(err)
 	}
 
 	if spec.GetUsageMode() != TokenUsageModeBot {
@@ -319,8 +320,8 @@ func validateBotToken(token *joiningv1.ScopedToken, roles types.SystemRoles) err
 		return trace.BadParameter("roles must only be '[Bot]' for a scoped bot token")
 	}
 
-	if !scopes.ScopeOfOrigin(token.GetScope()).IsAssignableToScopeOfEffect(spec.GetBotScope()) {
-		return trace.BadParameter("scoped token bot_scope must be a descendant of or equivalent to its resource scope")
+	if !scopes.ScopeOfOrigin(token.GetScope()).IsAssignableToScopeOfEffect(bot.Scope) {
+		return trace.BadParameter("scoped token bot scope must be a descendant of or equivalent to its resource scope")
 	}
 
 	if spec.GetAssignedScope() != "" {
@@ -339,12 +340,8 @@ func validateBotToken(token *joiningv1.ScopedToken, roles types.SystemRoles) err
 func validateNonBotToken(token *joiningv1.ScopedToken) error {
 	spec := token.GetSpec()
 
-	if spec.GetBotName() != "" {
-		return trace.BadParameter("bot_name cannot be set for a non-bot token")
-	}
-
-	if spec.GetBotScope() != "" {
-		return trace.BadParameter("bot_scope cannot be set for a non-bot token")
+	if spec.GetBot() != "" {
+		return trace.BadParameter("bot cannot be set for a non-bot token")
 	}
 
 	if spec.GetUsageMode() == TokenUsageModeBot {
@@ -457,16 +454,12 @@ func WeakValidateToken(token *joiningv1.ScopedToken) error {
 	// other unknown roles.
 	isBotToken := slices.Contains(spec.GetRoles(), string(types.RoleBot))
 	if isBotToken {
-		if token.GetSpec().GetBotName() == "" {
-			return trace.BadParameter("expected non-empty bot_name for a scoped bot token")
+		if spec.GetBot() == "" {
+			return trace.BadParameter("expected non-empty bot for a scoped bot token")
 		}
 
-		if token.GetSpec().GetBotScope() == "" {
-			return trace.BadParameter("expected non-empty bot_scope for a scoped bot token")
-		}
-
-		if err := scopes.WeakValidate(spec.GetBotScope()); err != nil {
-			return trace.Wrap(err, "validating scoped token bot_scope")
+		if err := scopes.WeakValidateQualifiedName(spec.GetBot()); err != nil {
+			return trace.Wrap(err, "validating scoped token bot")
 		}
 	} else {
 		if err := scopes.WeakValidate(token.GetSpec().GetAssignedScope()); err != nil {
@@ -614,16 +607,25 @@ func (t *Token) Expiry() time.Time {
 	return expiry.AsTime()
 }
 
-// GetBotName returns an empty string because scoped tokens do not currently
-// support configuring a bot name.
+// GetBotName returns the name component of the token's scope-qualified bot
+// reference. It is empty for non-bot tokens.
 func (t *Token) GetBotName() string {
-	return t.scoped.GetSpec().GetBotName()
+	bot, err := scopes.ParseQualifiedName(t.scoped.GetSpec().GetBot())
+	if err != nil {
+		return ""
+	}
+	return bot.Name
 }
 
-// GetBotScope returns the BotScope field which must be set for bots joining
-// with a scoped token. It is empty for unscoped bots.
+// GetBotScope returns the scope component of the token's scope-qualified bot
+// reference, which must be set for bots joining with a scoped token. It is
+// empty for non-bot tokens.
 func (t *Token) GetBotScope() string {
-	return t.scoped.GetSpec().GetBotScope()
+	bot, err := scopes.ParseQualifiedName(t.scoped.GetSpec().GetBot())
+	if err != nil {
+		return ""
+	}
+	return bot.Scope
 }
 
 // GetAssignedScope returns the scope that will be assigned to resources

--- a/lib/scopes/joining/token.go
+++ b/lib/scopes/joining/token.go
@@ -303,13 +303,13 @@ func validateBotToken(token *joiningv1.ScopedToken, roles types.SystemRoles) err
 		return trace.BadParameter("expected non-empty bot for a scoped bot token")
 	}
 
-	if err := scopes.StrongValidateQualifiedName(spec.GetBot()); err != nil {
+	bot, err := scopes.ParseQualifiedName(spec.GetBot())
+	if err != nil {
 		return trace.Wrap(err, "validating scoped token bot")
 	}
 
-	bot, err := scopes.ParseQualifiedName(spec.GetBot())
-	if err != nil {
-		return trace.Wrap(err)
+	if err := bot.StrongValidate(); err != nil {
+		return trace.Wrap(err, "validating scoped token bot")
 	}
 
 	if spec.GetUsageMode() != TokenUsageModeBot {
@@ -607,25 +607,29 @@ func (t *Token) Expiry() time.Time {
 	return expiry.AsTime()
 }
 
+// GetBot returns the token's scope-qualified bot reference, parsed from the
+// spec.bot field. It returns an error for non-bot tokens (where spec.bot is
+// empty) and for malformed values.
+func (t *Token) GetBot() (scopes.QualifiedName, error) {
+	bot, err := scopes.ParseQualifiedName(t.scoped.GetSpec().GetBot())
+	if err != nil {
+		return scopes.QualifiedName{}, trace.Wrap(err)
+	}
+	return bot, nil
+}
+
 // GetBotName returns the name component of the token's scope-qualified bot
 // reference. It is empty for non-bot tokens.
+//
+// This exists for compatibility with unscoped provision token v2s. We should
+// The bare name does not uniquely identify a bot across scopes; use
+// [Token.GetBot] when comparing bot identities.
 func (t *Token) GetBotName() string {
-	bot, err := scopes.ParseQualifiedName(t.scoped.GetSpec().GetBot())
+	bot, err := t.GetBot()
 	if err != nil {
 		return ""
 	}
 	return bot.Name
-}
-
-// GetBotScope returns the scope component of the token's scope-qualified bot
-// reference, which must be set for bots joining with a scoped token. It is
-// empty for non-bot tokens.
-func (t *Token) GetBotScope() string {
-	bot, err := scopes.ParseQualifiedName(t.scoped.GetSpec().GetBot())
-	if err != nil {
-		return ""
-	}
-	return bot.Scope
 }
 
 // GetAssignedScope returns the scope that will be assigned to resources

--- a/lib/scopes/joining/token.go
+++ b/lib/scopes/joining/token.go
@@ -621,9 +621,10 @@ func (t *Token) GetBot() (scopes.QualifiedName, error) {
 // GetBotName returns the name component of the token's scope-qualified bot
 // reference. It is empty for non-bot tokens.
 //
-// This exists for compatibility with unscoped provision token v2s. We should
-// The bare name does not uniquely identify a bot across scopes; use
-// [Token.GetBot] when comparing bot identities.
+// This exists for compatibility with unscoped provision token v2s. You should
+// avoid using this method and prefer [Token.GetBot] since this keeps the
+// Scope/Name pair combined. If you must use this method, ensure that it is
+// only used for display purposes (i.e audit/logs).
 func (t *Token) GetBotName() string {
 	bot, err := t.GetBot()
 	if err != nil {

--- a/lib/scopes/joining/token_test.go
+++ b/lib/scopes/joining/token_test.go
@@ -71,8 +71,7 @@ func TestValidateScopedToken(t *testing.T) {
 		}.Build(),
 		Spec: joiningv1.ScopedTokenSpec_builder{
 			Roles:      []string{types.RoleBot.String()},
-			BotScope:   "/aa/bb",
-			BotName:    "test-bot",
+			Bot:        "/aa/bb::test-bot",
 			JoinMethod: string(types.JoinMethodBoundKeypair),
 			UsageMode:  joining.TokenUsageModeBot,
 		}.Build(),
@@ -955,18 +954,11 @@ func TestValidateScopedToken(t *testing.T) {
 			},
 		},
 		{
-			name: "non-bot token with bot_scope",
+			name: "non-bot token with bot",
 			modFn: func(tok *joiningv1.ScopedToken) {
-				tok.GetSpec().SetBotScope("/aa/bb")
+				tok.GetSpec().SetBot("/aa/bb::foo")
 			},
-			expectedStrongErr: "bot_scope cannot be set",
-		},
-		{
-			name: "non-bot token with bot_name",
-			modFn: func(tok *joiningv1.ScopedToken) {
-				tok.GetSpec().SetBotName("foo")
-			},
-			expectedStrongErr: "bot_name cannot be set",
+			expectedStrongErr: "bot cannot be set",
 		},
 		{
 			name: "non-bot token with bot usage mode",
@@ -980,31 +972,31 @@ func TestValidateScopedToken(t *testing.T) {
 			baseToken: baseBotToken,
 		},
 		{
-			name:      "bot token without a bot_name",
+			name:      "bot token without a bot",
 			baseToken: baseBotToken,
 			modFn: func(tok *joiningv1.ScopedToken) {
-				tok.GetSpec().SetBotName("")
+				tok.GetSpec().SetBot("")
 			},
-			expectedStrongErr: "expected non-empty bot_name",
-			expectedWeakErr:   "expected non-empty bot_name",
+			expectedStrongErr: "expected non-empty bot",
+			expectedWeakErr:   "expected non-empty bot",
 		},
 		{
-			name:      "bot token without a bot_scope",
+			name:      "bot token with bot missing scope qualification",
 			baseToken: baseBotToken,
 			modFn: func(tok *joiningv1.ScopedToken) {
-				tok.GetSpec().SetBotScope("")
+				tok.GetSpec().SetBot("test-bot")
 			},
-			expectedStrongErr: "expected non-empty bot_scope",
-			expectedWeakErr:   "expected non-empty bot_scope",
+			expectedStrongErr: "validating scoped token bot",
+			expectedWeakErr:   "validating scoped token bot",
 		},
 		{
 			name:      "bot token with an invalid bot scope",
 			baseToken: baseBotToken,
 			modFn: func(tok *joiningv1.ScopedToken) {
-				tok.GetSpec().SetBotScope("aa/bb}")
+				tok.GetSpec().SetBot("aa/bb}::test-bot")
 			},
-			expectedStrongErr: "validating scoped token bot_scope",
-			expectedWeakErr:   "validating scoped token bot_scope",
+			expectedStrongErr: "validating scoped token bot",
+			expectedWeakErr:   "validating scoped token bot",
 		},
 		{
 			name:      "bot token with invalid usage mode",
@@ -1027,9 +1019,9 @@ func TestValidateScopedToken(t *testing.T) {
 			baseToken: baseBotToken,
 			modFn: func(tok *joiningv1.ScopedToken) {
 				tok.SetScope("/aa/bb")
-				tok.GetSpec().SetBotScope("/aa/cc")
+				tok.GetSpec().SetBot("/aa/cc::test-bot")
 			},
-			expectedStrongErr: "scoped token bot_scope must be a descendant of",
+			expectedStrongErr: "scoped token bot scope must be a descendant of",
 		},
 		{
 			name:      "bot token with assigned_scope",

--- a/lib/services/local/scoped_tokens_test.go
+++ b/lib/services/local/scoped_tokens_test.go
@@ -606,8 +606,7 @@ func newBoundKeypairToken() *joiningv1.ScopedToken {
 		Scope: "/test",
 		Spec: joiningv1.ScopedTokenSpec_builder{
 			AssignedScope: "",
-			BotName:       "example",
-			BotScope:      "/test",
+			Bot:           "/test::example",
 			JoinMethod:    string(types.JoinMethodBoundKeypair),
 			Roles:         []string{types.RoleBot.String()},
 			UsageMode:     string(joining.TokenUsageModeBot),

--- a/lib/services/local/scoped_tokens_test.go
+++ b/lib/services/local/scoped_tokens_test.go
@@ -42,6 +42,7 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/backend"
 	"github.com/gravitational/teleport/lib/backend/memory"
+	"github.com/gravitational/teleport/lib/scopes"
 	"github.com/gravitational/teleport/lib/scopes/joining"
 	"github.com/gravitational/teleport/lib/services/local"
 )
@@ -606,7 +607,7 @@ func newBoundKeypairToken() *joiningv1.ScopedToken {
 		Scope: "/test",
 		Spec: joiningv1.ScopedTokenSpec_builder{
 			AssignedScope: "",
-			Bot:           "/test::example",
+			Bot:           scopes.QualifiedName{Scope: "/test", Name: "example"}.String(),
 			JoinMethod:    string(types.JoinMethodBoundKeypair),
 			Roles:         []string{types.RoleBot.String()},
 			UsageMode:     string(joining.TokenUsageModeBot),

--- a/lib/tbot/tbot_test.go
+++ b/lib/tbot/tbot_test.go
@@ -1911,7 +1911,7 @@ func createScopedBot(
 				Roles:      []string{types.RoleBot.String()},
 				JoinMethod: string(types.JoinMethodBoundKeypair),
 				UsageMode:  jointoken.TokenUsageModeBot,
-				Bot:        scopeName + "::" + botName,
+				Bot:        scopes.QualifiedName{Scope: scopeName, Name: botName}.String(),
 				BoundKeypair: joiningv1.BoundKeypairSpec_builder{
 					Onboarding: joiningv1.BoundKeypairSpec_OnboardingSpec_builder{
 						InitialPublicKey: botPublicKey,
@@ -1939,7 +1939,7 @@ func createScopedBot(
 			Metadata: headerv1.Metadata_builder{Name: uuid.NewString()}.Build(),
 			Scope:    scopeName,
 			Spec: scopedaccessv1.ScopedRoleAssignmentSpec_builder{
-				Bot: scopeName + "::" + botName,
+				Bot: scopes.QualifiedName{Scope: scopeName, Name: botName}.String(),
 				Assignments: []*scopedaccessv1.Assignment{
 					scopedaccessv1.Assignment_builder{Role: scopedRoleName, Scope: scopeName}.Build(),
 				},

--- a/lib/tbot/tbot_test.go
+++ b/lib/tbot/tbot_test.go
@@ -1911,8 +1911,7 @@ func createScopedBot(
 				Roles:      []string{types.RoleBot.String()},
 				JoinMethod: string(types.JoinMethodBoundKeypair),
 				UsageMode:  jointoken.TokenUsageModeBot,
-				BotName:    botName,
-				BotScope:   scopeName,
+				Bot:        scopeName + "::" + botName,
 				BoundKeypair: joiningv1.BoundKeypairSpec_builder{
 					Onboarding: joiningv1.BoundKeypairSpec_OnboardingSpec_builder{
 						InitialPublicKey: botPublicKey,
@@ -1940,8 +1939,7 @@ func createScopedBot(
 			Metadata: headerv1.Metadata_builder{Name: uuid.NewString()}.Build(),
 			Scope:    scopeName,
 			Spec: scopedaccessv1.ScopedRoleAssignmentSpec_builder{
-				BotName:  botName,
-				BotScope: scopeName,
+				Bot: scopeName + "::" + botName,
 				Assignments: []*scopedaccessv1.Assignment{
 					scopedaccessv1.Assignment_builder{Role: scopedRoleName, Scope: scopeName}.Build(),
 				},


### PR DESCRIPTION
BREAKING!

Depends on https://github.com/gravitational/teleport/pull/67364

Previously, ScopedToken and ScopedRoleAssignment referenced bots using two fields `bot_scope` and `bot_name`. Following https://github.com/gravitational/teleport/pull/67364, we now have a defined format for a "scope-qualified name" that provides both the resource name and the scope.

This PR replaces `bot_scope` and `bot_name` with a singular `bot` field which must be a scope-qualified name.

Breaking: Prior ScopedRoleAssignments and ScopeTokens that reference Bots will become invalid.

<!-- Include manual testing efforts to verify the change. -->
<!-- Detail where the tests where run and what configurations were used. -->
<!-- Include all the test cases which were run to validate the change. -->

## Manual Test Plan
### Test Environment

Local cluster

### Test Cases

- [ ] E2E smoke test - create new scoped Bot, scoped token and SRA, and perform join and access SSH resource using resulting certificates.
- [ ] Regression - create unscoped Bot, unscoped token and perform join and access unscoped SSH resource.
- [ ] tbd: more test cases.
