### PR TITLE
[v18] Connect: Prevent unbounded allocation on legacy TDP shared directory read

### DIFF
--- a/lib/srv/desktop/tdp/protocol/legacy/proto.go
+++ b/lib/srv/desktop/tdp/protocol/legacy/proto.go
@@ -172,7 +172,7 @@ func decodeMessage(firstByte byte, in tdp.ByteReader) (tdp.Message, error) {
 	case TypeSharedDirectoryListResponse:
 		return decodeSharedDirectoryListResponse(in)
 	case TypeSharedDirectoryReadRequest:
-		return decodeSharedDirectoryReadRequest(in)
+		return decodeSharedDirectoryReadRequest(in, tdp.MaxFileReadWriteLength)
 	case TypeSharedDirectoryReadResponse:
 		return decodeSharedDirectoryReadResponse(in, tdp.MaxFileReadWriteLength)
 	case TypeSharedDirectoryWriteRequest:
@@ -1318,7 +1318,7 @@ func (s SharedDirectoryReadRequest) Encode() ([]byte, error) {
 	return buf.Bytes(), nil
 }
 
-func decodeSharedDirectoryReadRequest(in io.Reader) (SharedDirectoryReadRequest, error) {
+func decodeSharedDirectoryReadRequest(in io.Reader, maxLen uint32) (SharedDirectoryReadRequest, error) {
 	var completionID, directoryID, length uint32
 	var offset uint64
 
@@ -1345,6 +1345,10 @@ func decodeSharedDirectoryReadRequest(in io.Reader) (SharedDirectoryReadRequest,
 	err = binary.Read(in, binary.BigEndian, &length)
 	if err != nil {
 		return SharedDirectoryReadRequest{}, trace.Wrap(err)
+	}
+
+	if length > maxLen {
+		return SharedDirectoryReadRequest{}, tdp.FileReadWriteMaxLenErr
 	}
 
 	return SharedDirectoryReadRequest{

--- a/lib/srv/desktop/tdp/protocol/legacy/proto_test.go
+++ b/lib/srv/desktop/tdp/protocol/legacy/proto_test.go
@@ -275,9 +275,16 @@ func TestSizeLimitsAreNonFatal(t *testing.T) {
 			fatal: false,
 		},
 		{
-			name: "rejects long SharedDirectoryReadRequest",
+			name: "rejects long SharedDirectoryReadRequest path",
 			msg: SharedDirectoryReadRequest{
 				Path: string(bytes.Repeat([]byte("a"), tdp.MaxPathLength+1)),
+			},
+			fatal: false,
+		},
+		{
+			name: "rejects long SharedDirectoryReadRequest length",
+			msg: SharedDirectoryReadRequest{
+				Length: tdp.MaxFileReadWriteLength + 1,
 			},
 			fatal: false,
 		},

--- a/lib/teleterm/services/desktop/desktop.go
+++ b/lib/teleterm/services/desktop/desktop.go
@@ -390,6 +390,12 @@ func (d *fsRequestHandler) handleSharedDirectoryListRequest(completionID uint32,
 }
 
 func (d *fsRequestHandler) handleSharedDirectoryReadRequest(completionID uint32, r *tdpbv1.SharedDirectoryRequest_Read, sendToServer func(message tdp.Message) error) error {
+	// Defense in depth: the protocol decoder already caps Length, but re-check here so
+	// the make([]byte, r.Length) below can't be driven into an unbounded allocation by a future caller.
+	if r.Length > tdp.MaxFileReadWriteLength {
+		return tdp.FileReadWriteMaxLenErr
+	}
+
 	dirAccess, err := d.directoryAccessProvider.GetDirectoryAccess()
 	if err != nil {
 		return trace.Wrap(err)


### PR DESCRIPTION
Backport #66950 to branch/v18


## Manual Test Plan
### Test Environment
Locally built teleport and Connect.

### Test Cases
- [x] Opening a file in a shared directory in Connect still works. 