### PR TITLE
[v17] Connect: Prevent unbounded allocation on legacy TDP shared directory read

### DIFF
--- a/lib/srv/desktop/tdp/proto.go
+++ b/lib/srv/desktop/tdp/proto.go
@@ -170,7 +170,7 @@ func decodeMessage(firstByte byte, in byteReader) (Message, error) {
 	case TypeSharedDirectoryListResponse:
 		return decodeSharedDirectoryListResponse(in)
 	case TypeSharedDirectoryReadRequest:
-		return decodeSharedDirectoryReadRequest(in)
+		return decodeSharedDirectoryReadRequest(in, tdpMaxFileReadWriteLength)
 	case TypeSharedDirectoryReadResponse:
 		return decodeSharedDirectoryReadResponse(in, tdpMaxFileReadWriteLength)
 	case TypeSharedDirectoryWriteRequest:
@@ -1302,7 +1302,7 @@ func (s SharedDirectoryReadRequest) Encode() ([]byte, error) {
 	return buf.Bytes(), nil
 }
 
-func decodeSharedDirectoryReadRequest(in io.Reader) (SharedDirectoryReadRequest, error) {
+func decodeSharedDirectoryReadRequest(in io.Reader, maxLen uint32) (SharedDirectoryReadRequest, error) {
 	var completionID, directoryID, length uint32
 	var offset uint64
 
@@ -1329,6 +1329,10 @@ func decodeSharedDirectoryReadRequest(in io.Reader) (SharedDirectoryReadRequest,
 	err = binary.Read(in, binary.BigEndian, &length)
 	if err != nil {
 		return SharedDirectoryReadRequest{}, trace.Wrap(err)
+	}
+
+	if length > maxLen {
+		return SharedDirectoryReadRequest{}, fileReadWriteMaxLenErr
 	}
 
 	return SharedDirectoryReadRequest{

--- a/lib/srv/desktop/tdp/proto_test.go
+++ b/lib/srv/desktop/tdp/proto_test.go
@@ -270,9 +270,16 @@ func TestSizeLimitsAreNonFatal(t *testing.T) {
 			fatal: false,
 		},
 		{
-			name: "rejects long SharedDirectoryReadRequest",
+			name: "rejects long SharedDirectoryReadRequest path",
 			msg: SharedDirectoryReadRequest{
 				Path: string(bytes.Repeat([]byte("a"), tdpMaxPathLength+1)),
+			},
+			fatal: false,
+		},
+		{
+			name: "rejects long SharedDirectoryReadRequest length",
+			msg: SharedDirectoryReadRequest{
+				Length: tdpMaxFileReadWriteLength + 1,
 			},
 			fatal: false,
 		},

--- a/lib/teleterm/services/desktop/desktop.go
+++ b/lib/teleterm/services/desktop/desktop.go
@@ -321,6 +321,11 @@ func (d *fsRequestHandler) handleSharedDirectoryListRequest(r tdp.SharedDirector
 }
 
 func (d *fsRequestHandler) handleSharedDirectoryReadRequest(r tdp.SharedDirectoryReadRequest, sendToServer func(message tdp.Message) error) error {
+	// Defense in depth: the protocol decoder already caps Length, but re-check here so
+	// the make([]byte, r.Length) below can't be driven into an unbounded allocation by a future caller.
+	if r.Length > tdp.MaxFileReadWriteLength {
+		return tdp.FileReadWriteMaxLenErr
+	}
 	dirAccess, err := d.directoryAccessProvider.GetDirectoryAccess()
 	if err != nil {
 		return trace.Wrap(err)

--- a/lib/teleterm/services/desktop/desktop.go
+++ b/lib/teleterm/services/desktop/desktop.go
@@ -34,6 +34,8 @@ import (
 	"github.com/gravitational/teleport/lib/teleterm/api/uri"
 )
 
+const tdpMaxFileReadWriteLength = 1024 * 1024 // 1MB
+
 // Session uniquely describes a desktop session.
 // There can be only one session for the given desktop and login pair.
 type Session struct {
@@ -323,8 +325,8 @@ func (d *fsRequestHandler) handleSharedDirectoryListRequest(r tdp.SharedDirector
 func (d *fsRequestHandler) handleSharedDirectoryReadRequest(r tdp.SharedDirectoryReadRequest, sendToServer func(message tdp.Message) error) error {
 	// Defense in depth: the protocol decoder already caps Length, but re-check here so
 	// the make([]byte, r.Length) below can't be driven into an unbounded allocation by a future caller.
-	if r.Length > tdp.MaxFileReadWriteLength {
-		return tdp.FileReadWriteMaxLenErr
+	if r.Length > tdpMaxFileReadWriteLength {
+		return trace.LimitExceeded("TDP file read or write message exceeds maximum size limit")
 	}
 	dirAccess, err := d.directoryAccessProvider.GetDirectoryAccess()
 	if err != nil {


### PR DESCRIPTION
Backport #66950 to branch/v17


## Manual Test Plan
### Test Environment
Locally built teleport and Connect.

### Test Cases
- [x] Opening a file in a shared directory in Connect still works. 