### PR TITLE
Move plugin CheckAndSetDefaults from marshal to write path

### DIFF
--- a/api/types/plugin.go
+++ b/api/types/plugin.go
@@ -157,6 +157,8 @@ func NewPluginV1(metadata Metadata, spec PluginSpecV1, creds *PluginCredentialsV
 		p.SetCredentials(creds)
 	}
 
+	p.setStaticFields()
+
 	return p
 }
 

--- a/lib/services/local/plugins.go
+++ b/lib/services/local/plugins.go
@@ -49,6 +49,9 @@ func (s *PluginsService) CreatePlugin(ctx context.Context, plugin types.Plugin) 
 	if err := libplugin.Validate(plugin); err != nil {
 		return trace.Wrap(err)
 	}
+	if err := services.CheckAndSetDefaults(plugin); err != nil {
+		return trace.Wrap(err)
+	}
 	value, err := services.MarshalPlugin(plugin)
 	if err != nil {
 		return trace.Wrap(err)
@@ -246,6 +249,10 @@ func (s *PluginsService) updateAndSwap(ctx context.Context, name string, modify 
 
 	err = modify(newPlugin)
 	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	if err := services.CheckAndSetDefaults(newPlugin); err != nil {
 		return trace.Wrap(err)
 	}
 

--- a/lib/services/local/plugins_test.go
+++ b/lib/services/local/plugins_test.go
@@ -221,6 +221,71 @@ func TestListPlugins(t *testing.T) {
 	})
 }
 
+func TestPlugins_invalid_create_and_update(t *testing.T) {
+	t.Parallel()
+
+	validSlackPlugin := func(name string) *types.PluginV1 {
+		return types.NewPluginV1(
+			types.Metadata{Name: name},
+			types.PluginSpecV1{
+				Settings: &types.PluginSpecV1_SlackAccessPlugin{
+					SlackAccessPlugin: &types.PluginSlackAccessSettings{
+						FallbackChannel: "#general",
+					},
+				},
+			},
+			nil,
+		)
+	}
+
+	for _, tt := range []struct {
+		desc         string
+		mutate       func(*types.PluginV1)
+		requireErrFn func(t require.TestingT, err error, msgAndArgs ...any)
+	}{
+		{
+			desc: "empty_fallback_channel",
+			mutate: func(p *types.PluginV1) {
+				p.Spec.GetSlackAccessPlugin().FallbackChannel = ""
+			},
+			requireErrFn: func(t require.TestingT, err error, msgAndArgs ...any) {
+				require.Error(t, err, msgAndArgs...)
+				require.True(t, trace.IsBadParameter(err), msgAndArgs...)
+				require.ErrorContains(t, err, "fallback_channel must be set", msgAndArgs...)
+			},
+		},
+	} {
+		t.Run(tt.desc, func(t *testing.T) {
+			ctx := t.Context()
+			mem, err := memory.New(memory.Config{
+				Context: ctx,
+				Clock:   clockwork.NewFakeClock(),
+			})
+			require.NoError(t, err)
+			t.Cleanup(func() { mem.Close() })
+			svc := NewPluginsService(mem)
+
+			plugin := validSlackPlugin("test_plugin")
+			tt.mutate(plugin)
+			err = svc.CreatePlugin(ctx, plugin)
+			tt.requireErrFn(t, err, "CreatePlugin")
+
+			if err != nil {
+				plugin = validSlackPlugin("test_plugin")
+				require.NoError(t, svc.CreatePlugin(ctx, plugin))
+			}
+			p, err := svc.GetPlugin(ctx, plugin.GetName(), true)
+			require.NoError(t, err)
+			require.IsType(t, &types.PluginV1{}, p)
+			plugin = p.(*types.PluginV1)
+
+			tt.mutate(plugin)
+			_, err = svc.UpdatePlugin(ctx, plugin)
+			tt.requireErrFn(t, err, "UpdatePlugin")
+		})
+	}
+}
+
 func TestPlugins_validate_okta(t *testing.T) {
 	t.Parallel()
 	ctx := t.Context()

--- a/lib/services/plugins.go
+++ b/lib/services/plugins.go
@@ -55,10 +55,6 @@ func MarshalPlugin(plugin types.Plugin, opts ...MarshalOption) ([]byte, error) {
 	}
 	switch plugin := plugin.(type) {
 	case *types.PluginV1:
-		if err := plugin.CheckAndSetDefaults(); err != nil {
-			return nil, trace.Wrap(err)
-		}
-
 		var buf bytes.Buffer
 		err := (&jsonpb.Marshaler{}).Marshal(&buf, maybeResetProtoRevision(cfg.PreserveRevision, plugin))
 		if err != nil {

--- a/lib/services/plugins_test.go
+++ b/lib/services/plugins_test.go
@@ -49,6 +49,8 @@ func TestMarshalPluginRoundTrip(t *testing.T) {
 
 	plugin := types.NewPluginV1(types.Metadata{Name: "foobar"}, spec, creds)
 
+	err := plugin.CheckAndSetDefaults()
+	require.NoError(t, err)
 	payload, err := MarshalPlugin(plugin)
 	require.NoError(t, err)
 
@@ -125,6 +127,9 @@ func TestMarshalPluginJamfDurationRoundTrip(t *testing.T) {
 
 	plugin := types.NewPluginV1(types.Metadata{Name: "test-jamf"}, spec, creds)
 
+	err := plugin.CheckAndSetDefaults()
+	require.NoError(t, err)
+
 	payload, err := MarshalPlugin(plugin)
 	require.NoError(t, err)
 
@@ -174,7 +179,8 @@ func TestMarshalPluginWithStatus(t *testing.T) {
 		},
 	}
 	require.NoError(t, plugin.SetStatus(status))
-
+	err := plugin.CheckAndSetDefaults()
+	require.NoError(t, err)
 	payload, err := MarshalPlugin(plugin)
 	require.NoError(t, err)
 


### PR DESCRIPTION
CheckAndSetDefaults was being called inside MarshalPlugin as a side effect of serialization, which caused defaults (e.g. Namespace) to be applied to the in-memory object after roundtrip but not at construction time. Move the call to CreatePlugin and updateAndSwap where mutations belong, and call setStaticFields in NewPluginV1 so constructed objects are consistent from the start.






<!-- Provide a descriptive entry for the changelog of the next release. -->

Changelog:


<!-- Include manual testing efforts to verify the change. -->
<!-- Detail where the tests where run and what configurations were used. -->
<!-- Include all the test cases which were run to validate the change. -->

## Manual Test Plan
### Test Environment

### Test Cases
- [ ] 
