### PR TITLE
[terraform] Remove `metadata.expires` from `computed_fields`

### DIFF
--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/scoped_role.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/scoped_role.mdx
@@ -41,7 +41,6 @@ Required:
 Optional:
 
 - `description` (String) description is object description.
-- `expires` (String) expires is a global expiry time header can be set on any resource in the system.
 - `labels` (Map of String) labels is a set of labels.
 
 

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/scoped_role_assignment.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/scoped_role_assignment.mdx
@@ -38,7 +38,6 @@ Required:
 Optional:
 
 - `description` (String) description is object description.
-- `expires` (String) expires is a global expiry time header can be set on any resource in the system.
 - `labels` (Map of String) labels is a set of labels.
 
 

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/scoped_role.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/scoped_role.mdx
@@ -70,7 +70,6 @@ Required:
 Optional:
 
 - `description` (String) description is object description.
-- `expires` (String) expires is a global expiry time header can be set on any resource in the system.
 - `labels` (Map of String) labels is a set of labels.
 
 

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/scoped_role_assignment.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/scoped_role_assignment.mdx
@@ -81,7 +81,6 @@ Required:
 Optional:
 
 - `description` (String) description is object description.
-- `expires` (String) expires is a global expiry time header can be set on any resource in the system.
 - `labels` (Map of String) labels is a set of labels.
 
 

--- a/integrations/terraform/protoc-gen-terraform-accesslist.yaml
+++ b/integrations/terraform/protoc-gen-terraform-accesslist.yaml
@@ -56,11 +56,9 @@ exclude_fields:
 # These fields will be marked as Computed: true
 computed_fields:
     - "AccessList.header.kind"
-    - "AccessList.header.metadata.expires"
     - "AccessList.header.metadata.namespace"
     - "AccessList.spec.audit.next_audit_date"
     - "Member.header.kind"
-    - "Member.header.metadata.expires"
     - "Member.header.metadata.namespace"
     - "Member.spec.name"
     - "Member.spec.joined"

--- a/integrations/terraform/protoc-gen-terraform-appauthconfig.yaml
+++ b/integrations/terraform/protoc-gen-terraform-appauthconfig.yaml
@@ -39,7 +39,6 @@ exclude_fields:
 # These fields will be marked as Computed: true
 computed_fields:
   # Metadata
-  - "AppAuthConfig.metadata.expires"
   - "AppAuthConfig.metadata.namespace"
   - "AppAuthConfig.kind"
 

--- a/integrations/terraform/protoc-gen-terraform-discoveryconfig.yaml
+++ b/integrations/terraform/protoc-gen-terraform-discoveryconfig.yaml
@@ -41,7 +41,6 @@ exclude_fields:
 # These fields will be marked as Computed: true
 computed_fields:
   # Metadata
-  - 'DiscoveryConfig.header.metadata.expires'
   - 'DiscoveryConfig.header.metadata.namespace'
   - 'DiscoveryConfig.header.kind'
   - 'DiscoveryConfig.header.sub_kind'

--- a/integrations/terraform/protoc-gen-terraform-healthcheckconfig.yaml
+++ b/integrations/terraform/protoc-gen-terraform-healthcheckconfig.yaml
@@ -39,7 +39,6 @@ exclude_fields:
 # These fields will be marked as Computed: true
 computed_fields:
   # Metadata
-  - "HealthCheckConfig.metadata.expires"
   - "HealthCheckConfig.metadata.namespace"
   - "HealthCheckConfig.kind"
   - "HealthCheckConfig.sub_kind"

--- a/integrations/terraform/protoc-gen-terraform-scopedrole.yaml
+++ b/integrations/terraform/protoc-gen-terraform-scopedrole.yaml
@@ -32,10 +32,10 @@ exclude_fields:
   # Metadata (we id resources by name on our side)
   - "ScopedRole.metadata.id"
   - "ScopedRole.metadata.revision"
+  - "ScopedRole.metadata.expires"
 
 # These fields will be marked as Computed: true
 computed_fields:
-  - "ScopedRole.metadata.expires"
   - "ScopedRole.metadata.namespace"
   - "ScopedRole.kind"
 

--- a/integrations/terraform/protoc-gen-terraform-scopedroleassignment.yaml
+++ b/integrations/terraform/protoc-gen-terraform-scopedroleassignment.yaml
@@ -30,12 +30,12 @@ injected_fields:
 exclude_fields:
   - "ScopedRoleAssignment.metadata.id"
   - "ScopedRoleAssignment.metadata.revision"
+  - "ScopedRoleAssignment.metadata.expires"
   # Usage tracking is server-side only
   - "ScopedRoleAssignment.status"
 
 # These fields will be marked as Computed: true
 computed_fields:
-  - "ScopedRoleAssignment.metadata.expires"
   - "ScopedRoleAssignment.metadata.namespace"
   - "ScopedRoleAssignment.kind"
 

--- a/integrations/terraform/protoc-gen-terraform-scopedtoken.yaml
+++ b/integrations/terraform/protoc-gen-terraform-scopedtoken.yaml
@@ -36,7 +36,6 @@ exclude_fields:
 
 # These fields will be marked as Computed: true
 computed_fields:
-  - "ScopedToken.metadata.expires"
   - "ScopedToken.metadata.namespace"
   - "ScopedToken.kind"
 

--- a/integrations/terraform/protoc-gen-terraform-summarizer.yaml
+++ b/integrations/terraform/protoc-gen-terraform-summarizer.yaml
@@ -86,16 +86,12 @@ exclude_fields:
 # These fields will be marked as Computed: true
 computed_fields:
   - "InferenceModel.kind"
-  - "InferenceModel.metadata.expires"
   - "InferenceModel.metadata.namespace"
   - "InferenceSecret.kind"
-  - "InferenceSecret.metadata.expires"
   - "InferenceSecret.metadata.namespace"
   - "InferencePolicy.kind"
-  - "InferencePolicy.metadata.expires"
   - "InferencePolicy.metadata.namespace"
   - "RetrievalModel.kind"
-  - "RetrievalModel.metadata.expires"
   - "RetrievalModel.metadata.namespace"
 
 # These fields will be marked as Required: true

--- a/integrations/terraform/protoc-gen-terraform-workloadcluster.yaml
+++ b/integrations/terraform/protoc-gen-terraform-workloadcluster.yaml
@@ -39,7 +39,6 @@ exclude_fields:
 # These fields will be marked as Computed: true
 computed_fields:
   # Metadata
-  - "WorkloadCluster.metadata.expires"
   - "WorkloadCluster.metadata.namespace"
   - "WorkloadCluster.kind"
 

--- a/integrations/terraform/testlib/discovery_config_test.go
+++ b/integrations/terraform/testlib/discovery_config_test.go
@@ -192,9 +192,6 @@ resource "teleport_discovery_config" "test" {
 }
 
 func (s *TerraformSuiteOSS) TestDiscoveryConfigAzureComputedFields() {
-	// TODO: `metadata.expires` should no longer be computed.
-	s.T().Skip("After applying this test step, the plan was not empty")
-
 	t := s.T()
 	name := "teleport_discovery_config.test"
 

--- a/integrations/terraform/tfschema/accesslist/v1/accesslist_terraform.go
+++ b/integrations/terraform/tfschema/accesslist/v1/accesslist_terraform.go
@@ -66,11 +66,9 @@ func GenSchemaAccessList(ctx context.Context) (github_com_hashicorp_terraform_pl
 							Type:          github_com_hashicorp_terraform_plugin_framework_types.StringType,
 						},
 						"expires": GenSchemaTimestamp(ctx, github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
-							Computed:      true,
-							Description:   "expires is a global expiry time header can be set on any resource in the system.",
-							Optional:      true,
-							PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributePlanModifier{github_com_hashicorp_terraform_plugin_framework_tfsdk.UseStateForUnknown()},
-							Validators:    []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributeValidator{github_com_gravitational_teleport_integrations_terraform_tfschema.MustTimeBeInFuture()},
+							Description: "expires is a global expiry time header can be set on any resource in the system.",
+							Optional:    true,
+							Validators:  []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributeValidator{github_com_gravitational_teleport_integrations_terraform_tfschema.MustTimeBeInFuture()},
 						}),
 						"labels": {
 							Computed:      true,
@@ -422,11 +420,9 @@ func GenSchemaMember(ctx context.Context) (github_com_hashicorp_terraform_plugin
 							Type:          github_com_hashicorp_terraform_plugin_framework_types.StringType,
 						},
 						"expires": GenSchemaTimestamp(ctx, github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
-							Computed:      true,
-							Description:   "expires is a global expiry time header can be set on any resource in the system.",
-							Optional:      true,
-							PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributePlanModifier{github_com_hashicorp_terraform_plugin_framework_tfsdk.UseStateForUnknown()},
-							Validators:    []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributeValidator{github_com_gravitational_teleport_integrations_terraform_tfschema.MustTimeBeInFuture()},
+							Description: "expires is a global expiry time header can be set on any resource in the system.",
+							Optional:    true,
+							Validators:  []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributeValidator{github_com_gravitational_teleport_integrations_terraform_tfschema.MustTimeBeInFuture()},
 						}),
 						"labels": {
 							Computed:      true,

--- a/integrations/terraform/tfschema/appauthconfig/v1/appauthconfig_terraform.go
+++ b/integrations/terraform/tfschema/appauthconfig/v1/appauthconfig_terraform.go
@@ -69,11 +69,9 @@ func GenSchemaAppAuthConfig(ctx context.Context) (github_com_hashicorp_terraform
 					Type:          github_com_hashicorp_terraform_plugin_framework_types.StringType,
 				},
 				"expires": GenSchemaTimestamp(ctx, github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
-					Computed:      true,
-					Description:   "expires is a global expiry time header can be set on any resource in the system.",
-					Optional:      true,
-					PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributePlanModifier{github_com_hashicorp_terraform_plugin_framework_tfsdk.UseStateForUnknown()},
-					Validators:    []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributeValidator{github_com_gravitational_teleport_integrations_terraform_tfschema.MustTimeBeInFuture()},
+					Description: "expires is a global expiry time header can be set on any resource in the system.",
+					Optional:    true,
+					Validators:  []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributeValidator{github_com_gravitational_teleport_integrations_terraform_tfschema.MustTimeBeInFuture()},
 				}),
 				"labels": {
 					Computed:      true,

--- a/integrations/terraform/tfschema/discoveryconfig/v1/discoveryconfig_terraform.go
+++ b/integrations/terraform/tfschema/discoveryconfig/v1/discoveryconfig_terraform.go
@@ -68,11 +68,9 @@ func GenSchemaDiscoveryConfig(ctx context.Context) (github_com_hashicorp_terrafo
 							Type:          github_com_hashicorp_terraform_plugin_framework_types.StringType,
 						},
 						"expires": GenSchemaTimestamp(ctx, github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
-							Computed:      true,
-							Description:   "expires is a global expiry time header can be set on any resource in the system.",
-							Optional:      true,
-							PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributePlanModifier{github_com_hashicorp_terraform_plugin_framework_tfsdk.UseStateForUnknown()},
-							Validators:    []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributeValidator{github_com_gravitational_teleport_integrations_terraform_tfschema.MustTimeBeInFuture()},
+							Description: "expires is a global expiry time header can be set on any resource in the system.",
+							Optional:    true,
+							Validators:  []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributeValidator{github_com_gravitational_teleport_integrations_terraform_tfschema.MustTimeBeInFuture()},
 						}),
 						"labels": {
 							Computed:      true,

--- a/integrations/terraform/tfschema/healthcheckconfig/v1/health_check_config_terraform.go
+++ b/integrations/terraform/tfschema/healthcheckconfig/v1/health_check_config_terraform.go
@@ -70,11 +70,9 @@ func GenSchemaHealthCheckConfig(ctx context.Context) (github_com_hashicorp_terra
 					Type:          github_com_hashicorp_terraform_plugin_framework_types.StringType,
 				},
 				"expires": GenSchemaTimestamp(ctx, github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
-					Computed:      true,
-					Description:   "expires is a global expiry time header can be set on any resource in the system.",
-					Optional:      true,
-					PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributePlanModifier{github_com_hashicorp_terraform_plugin_framework_tfsdk.UseStateForUnknown()},
-					Validators:    []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributeValidator{github_com_gravitational_teleport_integrations_terraform_tfschema.MustTimeBeInFuture()},
+					Description: "expires is a global expiry time header can be set on any resource in the system.",
+					Optional:    true,
+					Validators:  []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributeValidator{github_com_gravitational_teleport_integrations_terraform_tfschema.MustTimeBeInFuture()},
 				}),
 				"labels": {
 					Computed:      true,

--- a/integrations/terraform/tfschema/scopes/access/assignment/v1/assignment_terraform.go
+++ b/integrations/terraform/tfschema/scopes/access/assignment/v1/assignment_terraform.go
@@ -27,7 +27,6 @@ import (
 	_ "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
 	github_com_gravitational_teleport_api_gen_proto_go_teleport_header_v1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
 	github_com_gravitational_teleport_api_gen_proto_go_teleport_scopes_access_v1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/access/v1"
-	github_com_gravitational_teleport_integrations_terraform_tfschema "github.com/gravitational/teleport/integrations/terraform/tfschema"
 	github_com_hashicorp_terraform_plugin_framework_attr "github.com/hashicorp/terraform-plugin-framework/attr"
 	github_com_hashicorp_terraform_plugin_framework_diag "github.com/hashicorp/terraform-plugin-framework/diag"
 	github_com_hashicorp_terraform_plugin_framework_tfsdk "github.com/hashicorp/terraform-plugin-framework/tfsdk"
@@ -66,13 +65,6 @@ func GenSchemaScopedRoleAssignment(ctx context.Context) (github_com_hashicorp_te
 					PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributePlanModifier{github_com_hashicorp_terraform_plugin_framework_tfsdk.UseStateForUnknown()},
 					Type:          github_com_hashicorp_terraform_plugin_framework_types.StringType,
 				},
-				"expires": GenSchemaTimestamp(ctx, github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
-					Computed:      true,
-					Description:   "expires is a global expiry time header can be set on any resource in the system.",
-					Optional:      true,
-					PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributePlanModifier{github_com_hashicorp_terraform_plugin_framework_tfsdk.UseStateForUnknown()},
-					Validators:    []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributeValidator{github_com_gravitational_teleport_integrations_terraform_tfschema.MustTimeBeInFuture()},
-				}),
 				"labels": {
 					Computed:      true,
 					Description:   "labels is a set of labels.",
@@ -308,13 +300,6 @@ func CopyScopedRoleAssignmentFromTerraform(_ context.Context, tf github_com_hash
 								}
 							}
 						}
-					}
-					{
-						a, ok := tf.Attrs["expires"]
-						if !ok {
-							diags.Append(attrReadMissingDiag{"ScopedRoleAssignment.metadata.expires"})
-						}
-						CopyFromTimestamp(diags, a, &obj.Expires)
 					}
 				}
 			}
@@ -713,15 +698,6 @@ func CopyScopedRoleAssignmentToTerraform(ctx context.Context, obj *github_com_gr
 								c.Unknown = false
 								tf.Attrs["labels"] = c
 							}
-						}
-					}
-					{
-						t, ok := tf.AttrTypes["expires"]
-						if !ok {
-							diags.Append(attrWriteMissingDiag{"ScopedRoleAssignment.metadata.expires"})
-						} else {
-							v := CopyToTimestamp(diags, obj.Expires, t, tf.Attrs["expires"])
-							tf.Attrs["expires"] = v
 						}
 					}
 				}

--- a/integrations/terraform/tfschema/scopes/access/v1/role_terraform.go
+++ b/integrations/terraform/tfschema/scopes/access/v1/role_terraform.go
@@ -29,7 +29,6 @@ import (
 	_ "github.com/gravitational/teleport/api/gen/proto/go/teleport/label/v1"
 	github_com_gravitational_teleport_api_gen_proto_go_teleport_label_v1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/label/v1"
 	github_com_gravitational_teleport_api_gen_proto_go_teleport_scopes_access_v1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/access/v1"
-	github_com_gravitational_teleport_integrations_terraform_tfschema "github.com/gravitational/teleport/integrations/terraform/tfschema"
 	github_com_hashicorp_terraform_plugin_framework_attr "github.com/hashicorp/terraform-plugin-framework/attr"
 	github_com_hashicorp_terraform_plugin_framework_diag "github.com/hashicorp/terraform-plugin-framework/diag"
 	github_com_hashicorp_terraform_plugin_framework_tfsdk "github.com/hashicorp/terraform-plugin-framework/tfsdk"
@@ -68,13 +67,6 @@ func GenSchemaScopedRole(ctx context.Context) (github_com_hashicorp_terraform_pl
 					PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributePlanModifier{github_com_hashicorp_terraform_plugin_framework_tfsdk.UseStateForUnknown()},
 					Type:          github_com_hashicorp_terraform_plugin_framework_types.StringType,
 				},
-				"expires": GenSchemaTimestamp(ctx, github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
-					Computed:      true,
-					Description:   "expires is a global expiry time header can be set on any resource in the system.",
-					Optional:      true,
-					PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributePlanModifier{github_com_hashicorp_terraform_plugin_framework_tfsdk.UseStateForUnknown()},
-					Validators:    []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributeValidator{github_com_gravitational_teleport_integrations_terraform_tfschema.MustTimeBeInFuture()},
-				}),
 				"labels": {
 					Computed:      true,
 					Description:   "labels is a set of labels.",
@@ -571,13 +563,6 @@ func CopyScopedRoleFromTerraform(_ context.Context, tf github_com_hashicorp_terr
 								}
 							}
 						}
-					}
-					{
-						a, ok := tf.Attrs["expires"]
-						if !ok {
-							diags.Append(attrReadMissingDiag{"ScopedRole.metadata.expires"})
-						}
-						CopyFromTimestamp(diags, a, &obj.Expires)
 					}
 				}
 			}
@@ -1873,15 +1858,6 @@ func CopyScopedRoleToTerraform(ctx context.Context, obj *github_com_gravitationa
 								c.Unknown = false
 								tf.Attrs["labels"] = c
 							}
-						}
-					}
-					{
-						t, ok := tf.AttrTypes["expires"]
-						if !ok {
-							diags.Append(attrWriteMissingDiag{"ScopedRole.metadata.expires"})
-						} else {
-							v := CopyToTimestamp(diags, obj.Expires, t, tf.Attrs["expires"])
-							tf.Attrs["expires"] = v
 						}
 					}
 				}

--- a/integrations/terraform/tfschema/scopes/joining/v1/token_terraform.go
+++ b/integrations/terraform/tfschema/scopes/joining/v1/token_terraform.go
@@ -68,11 +68,9 @@ func GenSchemaScopedToken(ctx context.Context) (github_com_hashicorp_terraform_p
 					Type:          github_com_hashicorp_terraform_plugin_framework_types.StringType,
 				},
 				"expires": GenSchemaTimestamp(ctx, github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
-					Computed:      true,
-					Description:   "expires is a global expiry time header can be set on any resource in the system.",
-					Optional:      true,
-					PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributePlanModifier{github_com_hashicorp_terraform_plugin_framework_tfsdk.UseStateForUnknown()},
-					Validators:    []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributeValidator{github_com_gravitational_teleport_integrations_terraform_tfschema.MustTimeBeInFuture()},
+					Description: "expires is a global expiry time header can be set on any resource in the system.",
+					Optional:    true,
+					Validators:  []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributeValidator{github_com_gravitational_teleport_integrations_terraform_tfschema.MustTimeBeInFuture()},
 				}),
 				"labels": {
 					Computed:      true,

--- a/integrations/terraform/tfschema/summarizer/v1/summarizer_terraform.go
+++ b/integrations/terraform/tfschema/summarizer/v1/summarizer_terraform.go
@@ -70,11 +70,9 @@ func GenSchemaInferenceModel(ctx context.Context) (github_com_hashicorp_terrafor
 					Type:          github_com_hashicorp_terraform_plugin_framework_types.StringType,
 				},
 				"expires": GenSchemaTimestamp(ctx, github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
-					Computed:      true,
-					Description:   "expires is a global expiry time header can be set on any resource in the system.",
-					Optional:      true,
-					PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributePlanModifier{github_com_hashicorp_terraform_plugin_framework_tfsdk.UseStateForUnknown()},
-					Validators:    []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributeValidator{github_com_gravitational_teleport_integrations_terraform_tfschema.MustTimeBeInFuture()},
+					Description: "expires is a global expiry time header can be set on any resource in the system.",
+					Optional:    true,
+					Validators:  []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributeValidator{github_com_gravitational_teleport_integrations_terraform_tfschema.MustTimeBeInFuture()},
 				}),
 				"labels": {
 					Computed:      true,
@@ -211,11 +209,9 @@ func GenSchemaInferenceSecret(ctx context.Context) (github_com_hashicorp_terrafo
 					Type:          github_com_hashicorp_terraform_plugin_framework_types.StringType,
 				},
 				"expires": GenSchemaTimestamp(ctx, github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
-					Computed:      true,
-					Description:   "expires is a global expiry time header can be set on any resource in the system.",
-					Optional:      true,
-					PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributePlanModifier{github_com_hashicorp_terraform_plugin_framework_tfsdk.UseStateForUnknown()},
-					Validators:    []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributeValidator{github_com_gravitational_teleport_integrations_terraform_tfschema.MustTimeBeInFuture()},
+					Description: "expires is a global expiry time header can be set on any resource in the system.",
+					Optional:    true,
+					Validators:  []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributeValidator{github_com_gravitational_teleport_integrations_terraform_tfschema.MustTimeBeInFuture()},
 				}),
 				"labels": {
 					Computed:      true,
@@ -296,11 +292,9 @@ func GenSchemaInferencePolicy(ctx context.Context) (github_com_hashicorp_terrafo
 					Type:          github_com_hashicorp_terraform_plugin_framework_types.StringType,
 				},
 				"expires": GenSchemaTimestamp(ctx, github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
-					Computed:      true,
-					Description:   "expires is a global expiry time header can be set on any resource in the system.",
-					Optional:      true,
-					PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributePlanModifier{github_com_hashicorp_terraform_plugin_framework_tfsdk.UseStateForUnknown()},
-					Validators:    []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributeValidator{github_com_gravitational_teleport_integrations_terraform_tfschema.MustTimeBeInFuture()},
+					Description: "expires is a global expiry time header can be set on any resource in the system.",
+					Optional:    true,
+					Validators:  []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributeValidator{github_com_gravitational_teleport_integrations_terraform_tfschema.MustTimeBeInFuture()},
 				}),
 				"labels": {
 					Computed:      true,
@@ -393,11 +387,9 @@ func GenSchemaRetrievalModel(ctx context.Context) (github_com_hashicorp_terrafor
 					Type:          github_com_hashicorp_terraform_plugin_framework_types.StringType,
 				},
 				"expires": GenSchemaTimestamp(ctx, github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
-					Computed:      true,
-					Description:   "expires is a global expiry time header can be set on any resource in the system.",
-					Optional:      true,
-					PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributePlanModifier{github_com_hashicorp_terraform_plugin_framework_tfsdk.UseStateForUnknown()},
-					Validators:    []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributeValidator{github_com_gravitational_teleport_integrations_terraform_tfschema.MustTimeBeInFuture()},
+					Description: "expires is a global expiry time header can be set on any resource in the system.",
+					Optional:    true,
+					Validators:  []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributeValidator{github_com_gravitational_teleport_integrations_terraform_tfschema.MustTimeBeInFuture()},
 				}),
 				"labels": {
 					Computed:      true,

--- a/integrations/terraform/tfschema/workloadcluster/v1/workloadcluster_terraform.go
+++ b/integrations/terraform/tfschema/workloadcluster/v1/workloadcluster_terraform.go
@@ -67,11 +67,9 @@ func GenSchemaWorkloadCluster(ctx context.Context) (github_com_hashicorp_terrafo
 					Type:          github_com_hashicorp_terraform_plugin_framework_types.StringType,
 				},
 				"expires": GenSchemaTimestamp(ctx, github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
-					Computed:      true,
-					Description:   "expires is a global expiry time header can be set on any resource in the system.",
-					Optional:      true,
-					PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributePlanModifier{github_com_hashicorp_terraform_plugin_framework_tfsdk.UseStateForUnknown()},
-					Validators:    []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributeValidator{github_com_gravitational_teleport_integrations_terraform_tfschema.MustTimeBeInFuture()},
+					Description: "expires is a global expiry time header can be set on any resource in the system.",
+					Optional:    true,
+					Validators:  []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributeValidator{github_com_gravitational_teleport_integrations_terraform_tfschema.MustTimeBeInFuture()},
 				}),
 				"labels": {
 					Computed:      true,


### PR DESCRIPTION
Supports https://github.com/gravitational/teleport/issues/66912

This is a follow up to https://github.com/gravitational/teleport/pull/67345. In #67345, the `GenSchemaTimestamp` function is modified so that the `Computed` constraint is preserved.

This becomes an issue in some cases because Teleport may return a null value for the `expires` attribute resulting in a perpetual Terraform diff.

To resolve the issue, this PR removes `metadata.expires` from the list of `computed_fields`. Additionally, `scoped_role.metadata.expires` and `scoped_role_assignment.metadata.expires` are now `excluded_fields` because they are not supported configuration.

<!-- Include manual testing efforts to verify the change. -->
<!-- Detail where the tests where run and what configurations were used. -->
<!-- Include all the test cases which were run to validate the change. -->

## Manual Test Plan
### Test Environment
Local cluster environment

### Test Cases
- [x] Verify `metadata.expires` cannot be set for `scoped_role` and `scoped_role_assignment` resources.
- [x] Create, update, and clear the `metadata.expires` for a `teleport_role` resource.
