### PR TITLE
Server Discovery: use /opt/teleport when checking for disk space

### DIFF
--- a/lib/srv/server/installer_script.go
+++ b/lib/srv/server/installer_script.go
@@ -197,8 +197,8 @@ func preFlightInstallerChecks(proxyAddr string) map[installstatus.ExitCode]strin
 		// check if there's enough disk space for the installation
 		// df -Pm outputs disk usage in megabytes; awk selects the data row (NR==2) and
 		// exits non-zero if the available column ($4) is below the required threshold.
-		// Falls back to checking "/" if "/opt" does not exist.
-		installstatus.InsufficientDiskSpace: fmt.Sprintf(`df -Pm $([ -d /opt ] && echo /opt || echo /) | awk 'NR==2{exit($4<%d)}' %s`,
+		// It tries to check /opt/teleport first if it exists, then /opt, and finally / as a last resort.
+		installstatus.InsufficientDiskSpace: fmt.Sprintf(`df -Pm $(p=/opt/teleport; until [ -e "$p" ]; do p=$(dirname "$p"); done; echo "$p") | awk 'NR==2{exit($4<%d)}' %s`,
 			installstatus.InstallerMinFreeDiskMB,
 			orExitWithMessageScriptSnippet(installstatus.InsufficientDiskSpace, "insufficient disk space"),
 		),

--- a/lib/srv/server/installer_script_test.go
+++ b/lib/srv/server/installer_script_test.go
@@ -34,7 +34,7 @@ func installerScriptChecksFor(proxyAddr string) string {
 	return `command -v bash > /dev/null 2>&1 || { echo "bash is missing"; exit 100; }` +
 		`; command -v sudo > /dev/null 2>&1 || { echo "sudo is missing"; exit 101; }` +
 		`; command -v curl > /dev/null 2>&1 || { echo "curl is missing"; exit 102; }` +
-		`; df -Pm $([ -d /opt ] && echo /opt || echo /) | awk 'NR==2{exit($4<1250)}' || { echo "insufficient disk space"; exit 103; }` +
+		`; df -Pm $(p=/opt/teleport; until [ -e "$p" ]; do p=$(dirname "$p"); done; echo "$p") | awk 'NR==2{exit($4<1250)}' || { echo "insufficient disk space"; exit 103; }` +
 		`; curl --silent --max-time 10 --output /dev/null https://` + proxyAddr + `/webapi/find || { echo "proxy is unreachable"; exit 104; }` +
 		`; `
 }


### PR DESCRIPTION
When Discovery Service tries to install teleport in a given instance, so that it can join the cluster, it first does a couple of preflight checks:
- sudo, bash, curl commands exist?
- enough disk space?
- ...

When checking for disk space we are using /opt folder. Howevers VMs can have a specific mount point for the /opt/teleport.

This changes ensures we check the correct folder, and in order. So, if /opt/teleport exists, that's the folder that will be used when checking for required space.


Changelog: Fixed a preflight check in Server Discovery where the script would exit even though there was enough space in `/opt/teleport`


<!-- Include manual testing efforts to verify the change. -->
<!-- Detail where the tests where run and what configurations were used. -->
<!-- Include all the test cases which were run to validate the change. -->

## Manual Test Plan
### Test Environment

Local cluster

### Test Cases
- [x] See below

| /         | /opt                 | /opt/teleport        | Outcome  |
|-----------|----------------------|----------------------|----------|
| No space  | No space             | Mount point with 2GB | No error |
| No space  | Mount point with 2GB | -                    | No error |
| No space  | -                    | -                    | Error    |
| Has space | Has space            | Mount point with 1GB | Error    |
| Has space | -                    | -                    | No error |

