### PR TITLE
[v18] winpki: don't encode null groups in the certificate (#57968)

### DIFF
--- a/lib/services/access_checker.go
+++ b/lib/services/access_checker.go
@@ -1278,7 +1278,10 @@ func (a *accessChecker) DesktopGroups(s types.WindowsDesktop) ([]string, error) 
 		}
 	}
 
-	return groups.Elements(), nil
+	// These groups get encoded into a certificate that's parsed by
+	// Rust code on Windows. That code expects an empty JSON array,
+	// not a null value.
+	return groups.ElementsNotNil(), nil
 }
 
 func convertHostUserMode(mode types.CreateHostUserMode) decisionpb.HostUserMode {

--- a/lib/services/access_checker_test.go
+++ b/lib/services/access_checker_test.go
@@ -603,6 +603,101 @@ func TestAccessCheckerHostUsersShell(t *testing.T) {
 	require.Equal(t, expectedShell, hui.Shell)
 }
 
+func TestAccessCheckerDesktopGroups(t *testing.T) {
+	localCluster := "cluster"
+
+	allowCreateNoGroups := newRole(func(r *types.RoleV6) { r.Spec.Options.CreateDesktopUser = types.NewBoolOption(true) })
+	denyUserCreation := newRole(func(r *types.RoleV6) { r.Spec.Options.CreateDesktopUser = types.NewBoolOption(false) })
+	allowGroupA := newRole(func(r *types.RoleV6) {
+		r.Spec.Options.CreateDesktopUser = types.NewBoolOption(true)
+		r.Spec.Allow.WindowsDesktopLabels = types.Labels{"group": []string{"a"}}
+		r.Spec.Allow.DesktopGroups = []string{"groupA"}
+	})
+	allowGroupB := newRole(func(r *types.RoleV6) {
+		r.Spec.Options.CreateDesktopUser = types.NewBoolOption(true)
+		r.Spec.Allow.WindowsDesktopLabels = types.Labels{"group": []string{"b"}}
+		r.Spec.Allow.DesktopGroups = []string{"groupB"}
+	})
+	allowABC := newRole(func(r *types.RoleV6) {
+		r.Spec.Options.CreateDesktopUser = types.NewBoolOption(true)
+		r.Spec.Allow.WindowsDesktopLabels = types.Labels{"group": []string{"all"}}
+		r.Spec.Allow.DesktopGroups = []string{"groupA", "groupB", "groupC"}
+	})
+	denyGroupB := newRole(func(r *types.RoleV6) {
+		r.Spec.Options.CreateDesktopUser = types.NewBoolOption(true)
+		r.Spec.Allow.WindowsDesktopLabels = types.Labels{"group": []string{"all"}}
+
+		r.Spec.Deny.WindowsDesktopLabels = types.Labels{"denygroup": []string{"b"}}
+		r.Spec.Deny.DesktopGroups = []string{"groupB"}
+	})
+	denyGroupC := newRole(func(r *types.RoleV6) {
+		r.Spec.Options.CreateDesktopUser = types.NewBoolOption(true)
+
+		r.Spec.Deny.WindowsDesktopLabels = types.Labels{"denygroup": []string{"c"}}
+		r.Spec.Deny.DesktopGroups = []string{"groupC"}
+	})
+
+	for _, test := range []struct {
+		name          string
+		roles         RoleSet
+		desktopLabels map[string]string
+		wantGroups    []string
+		assert        require.ErrorAssertionFunc
+	}{
+		{
+			name:       "empty groups",
+			roles:      NewRoleSet(allowCreateNoGroups),
+			wantGroups: []string{},
+			assert:     require.NoError,
+		},
+		{
+			name:          "multiple groups",
+			roles:         NewRoleSet(allowABC),
+			desktopLabels: map[string]string{"group": "all"},
+			wantGroups:    []string{"groupA", "groupB", "groupC"},
+			assert:        require.NoError,
+		},
+		{
+			name:          "only considers matching labels",
+			roles:         NewRoleSet(allowGroupA, allowGroupB),
+			desktopLabels: map[string]string{"group": "a"},
+			wantGroups:    []string{"groupA"},
+			assert:        require.NoError,
+		},
+		{
+			name:          "denied groups are removed",
+			roles:         NewRoleSet(allowABC, denyGroupB, denyGroupC),
+			desktopLabels: map[string]string{"group": "all", "denygroup": "b"},
+			// B gets removed due to deny rule, but C doesn't since labels don't match
+			wantGroups: []string{"groupA", "groupC"},
+			assert:     require.NoError,
+		},
+		{
+			name:          "error if user creation is disabled",
+			roles:         NewRoleSet(allowCreateNoGroups, denyUserCreation),
+			desktopLabels: map[string]string{},
+			wantGroups:    nil,
+			assert:        require.Error,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			desktop, err := types.NewWindowsDesktopV3("test-desktop", test.desktopLabels, types.WindowsDesktopSpecV3{
+				Addr: "example.com:3389",
+			})
+			require.NoError(t, err)
+
+			ac := NewAccessCheckerWithRoleSet(&AccessInfo{}, localCluster, test.roles)
+			groups, err := ac.DesktopGroups(desktop)
+			require.ElementsMatch(t, test.wantGroups, groups)
+			test.assert(t, err)
+
+			if err == nil {
+				require.NotNil(t, groups, "desktop groups should never be nil, use an empty slice instead")
+			}
+		})
+	}
+}
+
 func TestSSHPortForwarding(t *testing.T) {
 	anyLabels := types.Labels{"*": {"*"}}
 	localCluster := "cluster"


### PR DESCRIPTION
Backport #57968

<!-- Provide a descriptive entry for the changelog of the next release. -->

Changelog: Fixed potential Windows desktop login failures for local users caused by an incompatibility between Teleport v18.7.6 or later and Teleport Windows Auth modules released before v18.8.0.


<!-- Include manual testing efforts to verify the change. -->
<!-- Detail where the tests where run and what configurations were used. -->
<!-- Include all the test cases which were run to validate the change. -->

## Manual Test Plan
### Test Environment
Local Cluster with at least one target Windows Desktop that has a Teleport Windows Authentication module from v18.8 or earlier.  Configure a user with a single role that allows access to the target desktop, has `createuser=true` and `desktop_groups` omitted entirely from the role.
### Test Cases
- [x] While logged in as the user specified above connect as a local user to the target desktop running the pre v18.8 Teleport Windows Auth module. Verify that the connection succeeds.
