### PR TITLE
[v18] Fix `tsh request show` output formatting

### DIFF
--- a/tool/tsh/common/access_request.go
+++ b/tool/tsh/common/access_request.go
@@ -242,11 +242,11 @@ func printRequest(cf *CLIConf, req types.AccessRequest) error {
 	}
 
 	printReviewBlock := func(title string, revs []types.AccessReview) error {
-		fmt.Fprint(cf.Stdout(), "------------------------------------------------")
+		fmt.Fprintln(cf.Stdout(), "------------------------------------------------")
 		fmt.Fprintf(cf.Stdout(), "%s:\n", title)
 
 		for _, rev := range revs {
-			fmt.Fprint(cf.Stdout(), "  ----------------------------------------------")
+			fmt.Fprintln(cf.Stdout(), "  ----------------------------------------------")
 
 			revReason := "[none]"
 			if rev.Reason != "" {


### PR DESCRIPTION
Backport #66232 to branch/v18

changelog: Fixed minor formatting bug on `tsh request show` output

## Manual Test Plan
### Test Environment

Teleport Cloud + local dev `tsh` build.

### Test Cases
- [x]  Verify `tsh request show` output properly formats newlines