### PR TITLE
docs: Fix zypper remove command parameter

### DIFF
--- a/docs/pages/installation/uninstall-teleport.mdx
+++ b/docs/pages/installation/uninstall-teleport.mdx
@@ -163,7 +163,7 @@ Then, follow the instructions for your Linux distribution:
 
   ```code
   # Change the package name to "teleport" for Teleport Community Edition
-  $ sudo zypper -y remove teleport-ent
+  $ sudo zypper -n remove teleport-ent
   ```
 
   Uninstall the Teleport zypper repo:


### PR DESCRIPTION
`-y` is not a valid parameter for `zypper remove`, `-n` is the parameter that should be used for non-interactive. 
