### PR TITLE
[v18] Set component features on Proxy integration-hosted appServers

### DIFF
--- a/lib/integrations/awsra/profile_syncer.go
+++ b/lib/integrations/awsra/profile_syncer.go
@@ -41,6 +41,7 @@ import (
 	"github.com/gravitational/teleport/api/utils/clientutils"
 	"github.com/gravitational/teleport/api/utils/retryutils"
 	"github.com/gravitational/teleport/lib/backend"
+	"github.com/gravitational/teleport/lib/componentfeatures"
 	"github.com/gravitational/teleport/lib/integrations/awsra/createsession"
 	"github.com/gravitational/teleport/lib/utils"
 )
@@ -591,6 +592,7 @@ func convertProfile(params AWSRolesAnywhereProfileSyncerParams, profile *integra
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
+	appServer.SetComponentFeatures(componentfeatures.ForAppServer(appServer))
 
 	return appServer, nil
 }

--- a/lib/web/integrations_awsoidc.go
+++ b/lib/web/integrations_awsoidc.go
@@ -46,6 +46,7 @@ import (
 	"github.com/gravitational/teleport/api/utils"
 	"github.com/gravitational/teleport/api/utils/aws"
 	"github.com/gravitational/teleport/lib/auth/authclient"
+	"github.com/gravitational/teleport/lib/componentfeatures"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/httplib"
 	"github.com/gravitational/teleport/lib/integrations/awsoidc"
@@ -1120,6 +1121,7 @@ func (h *Handler) awsOIDCCreateAWSAppAccess(w http.ResponseWriter, r *http.Reque
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
+	appServer.SetComponentFeatures(componentfeatures.ForAppServer(appServer))
 
 	// If the integration name contains a dot, then the proxy must provide a certificate allowing *.<something>.<proxyPublicAddr>
 	if strings.Contains(integrationName, ".") {

--- a/lib/web/integrations_awsoidc_test.go
+++ b/lib/web/integrations_awsoidc_test.go
@@ -37,6 +37,7 @@ import (
 
 	"github.com/gravitational/teleport/api"
 	"github.com/gravitational/teleport/api/client/proto"
+	componentfeaturesv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/componentfeatures/v1"
 	integrationv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/integration/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/types/discoveryconfig"
@@ -1147,6 +1148,11 @@ func TestAWSOIDCAppAccessAppServerCreationDeletion(t *testing.T) {
 		Spec: types.AppServerSpecV3{
 			Version: api.Version,
 			HostID:  "proxy0",
+			ComponentFeatures: &componentfeaturesv1.ComponentFeatures{
+				Features: []componentfeaturesv1.ComponentFeatureID{
+					componentfeaturesv1.ComponentFeatureID_COMPONENT_FEATURE_ID_RESOURCE_CONSTRAINTS_V1,
+				},
+			},
 			App: &types.AppV3{
 				Kind:    types.KindApp,
 				Version: types.V3,


### PR DESCRIPTION
## Context
Backport #67456 to v18.

## Manual Test Plan
### Test Environment
- Cloud tenant w/ Auth v18.8.2, Proxy built from this patch.
- AWS OIDC integration set up with Console app access enabled.

### Test Cases
- [x] Verify `tctl get app_servers --format json | jq `.[].spec.component_features' shows `1` for the AWS Console app server resource.
- [x] Verify web UI unified resources response includes `supportedFeatureIds` for the AWS Console app server resource.
- [x] Verify the Resource Constraints UI (ARN selection on requests) is visible for the AWS Console app.
- [x] For Roles Anywhere: set up integration with imported profiles and verify the same advertisement appears on synced app server resources.
