### PR TITLE
cache: Prune expired sessions via relative expiry

### DIFF
--- a/lib/cache/cache.go
+++ b/lib/cache/cache.go
@@ -782,8 +782,9 @@ type Config struct {
 	// "relative expiration" checks which are used to compensate for real backends
 	// that have suffer from overly lazy ttl'ing of resources.
 	RelativeExpiryCheckInterval time.Duration
-	// RelativeExpiryLimit determines the maximum number of nodes that may be
-	// removed during relative expiration.
+	// RelativeExpiryLimit determines the maximum number of resources of each
+	// kind (nodes, and web, app, and snowflake sessions) that may be removed
+	// during a single relative expiration pass.
 	RelativeExpiryLimit int
 	// EventsC is a channel for event notifications,
 	// used in tests
@@ -1534,33 +1535,32 @@ func (c *Cache) performRelativeSessionExpiry(ctx context.Context) error {
 	gracePeriod := apidefaults.ServerAnnounceTTL + backend.DefaultCreationGracePeriod
 	now := c.Clock.Now()
 
-	// The three session subkinds share a single budget so that a high churn
-	// rate on one kind cannot starve the others while still bounding the total
-	// number of synthesized deletes per sweep.
-	budget := c.Config.RelativeExpiryLimit
+	// Each session kind gets its own removal budget, the same per-kind bound
+	// the node sweep applies, so a high churn rate on one kind cannot crowd
+	// out pruning of the others. The expiry of each kind is read with the same
+	// function the backend uses to set the item's TTL (see
+	// lib/services/local/session.go), so the sweep removes exactly the entries
+	// the backend will eventually delete: GetEarliestExpiry for regular web
+	// sessions, whose bearer token can expire before the session, and
+	// GetExpiryTime for app and snowflake sessions.
+	limit := c.Config.RelativeExpiryLimit
 
-	removed, err := expireStaleSessions(ctx, c, c.collections.webSessions, webSessionNameIndex, types.KindWebSession, gracePeriod, now, budget)
+	removedWeb, err := expireStaleSessions(ctx, c, c.collections.webSessions, webSessionNameIndex, types.KindWebSession, types.WebSession.GetEarliestExpiry, gracePeriod, now, limit)
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	budget -= removed
 
-	if budget > 0 {
-		n, err := expireStaleSessions(ctx, c, c.collections.appSessions, appSessionNameIndex, types.KindAppSession, gracePeriod, now, budget)
-		if err != nil {
-			return trace.Wrap(err)
-		}
-		removed += n
-		budget -= n
+	removedApp, err := expireStaleSessions(ctx, c, c.collections.appSessions, appSessionNameIndex, types.KindAppSession, types.WebSession.GetExpiryTime, gracePeriod, now, limit)
+	if err != nil {
+		return trace.Wrap(err)
 	}
 
-	if budget > 0 {
-		n, err := expireStaleSessions(ctx, c, c.collections.snowflakeSessions, snowflakeSessionNameIndex, types.KindSnowflakeSession, gracePeriod, now, budget)
-		if err != nil {
-			return trace.Wrap(err)
-		}
-		removed += n
+	removedSnowflake, err := expireStaleSessions(ctx, c, c.collections.snowflakeSessions, snowflakeSessionNameIndex, types.KindSnowflakeSession, types.WebSession.GetExpiryTime, gracePeriod, now, limit)
+	if err != nil {
+		return trace.Wrap(err)
 	}
+
+	removed := removedWeb + removedApp + removedSnowflake
 
 	if removed > 0 {
 		c.Logger.DebugContext(ctx, "Removed sessions via relative expiry",
@@ -1576,6 +1576,10 @@ func (c *Cache) performRelativeSessionExpiry(ctx context.Context) error {
 // (or now, whichever is earlier) less the grace period. It returns the number
 // of entries removed, capped at budget.
 //
+// expiryOf reports the time after which an entry should be considered expired.
+// It must match the function the backend uses to set the entry's item TTL so
+// the sweep removes exactly the entries the backend will eventually delete.
+//
 // The collection's btree cannot be mutated while it is being iterated, so the
 // entries are snapshotted under the read guard first and the deletes are
 // issued afterwards. Only the name and expiry are read off each stored entry,
@@ -1587,10 +1591,17 @@ func expireStaleSessions[I comparable](
 	coll *collection[types.WebSession, I],
 	index I,
 	subKind string,
+	expiryOf func(types.WebSession) time.Time,
 	gracePeriod time.Duration,
 	now time.Time,
 	budget int,
 ) (int, error) {
+	// The collection is absent when its kind is not watched, which can happen
+	// if relative expiry is enabled with a reduced watch set.
+	if coll == nil {
+		return 0, nil
+	}
+
 	rg, err := acquireReadGuard(c, coll)
 	if err != nil {
 		return 0, trace.Wrap(err)
@@ -1614,7 +1625,7 @@ func expireStaleSessions[I comparable](
 		latestExp time.Time
 	)
 	for session := range rg.store.resources(index, "", "") {
-		exp := session.Expiry()
+		exp := expiryOf(session)
 		entries = append(entries, sessionEntry{name: session.GetName(), expiry: exp})
 		if exp.IsZero() {
 			continue

--- a/lib/cache/cache.go
+++ b/lib/cache/cache.go
@@ -1355,6 +1355,9 @@ func (c *Cache) fetchAndWatch(ctx context.Context, retry retryutils.Retry, timer
 			if err := c.performRelativeNodeExpiry(ctx); err != nil {
 				return trace.Wrap(err)
 			}
+			if err := c.performRelativeSessionExpiry(ctx); err != nil {
+				return trace.Wrap(err)
+			}
 			c.notify(ctx, Event{Type: RelativeExpiry})
 		case event := <-watcher.Events():
 			// check for expired resources in OpPut events and log them periodically. stale OpPut events
@@ -1512,6 +1515,157 @@ func (c *Cache) performRelativeNodeExpiry(ctx context.Context) error {
 	}
 
 	return nil
+}
+
+// performRelativeSessionExpiry applies the same relative-expiry strategy as
+// performRelativeNodeExpiry to the web, app, and snowflake session
+// collections. Session backends such as DynamoDB delete expired records via a
+// native TTL that AWS applies asynchronously, sometimes long after the
+// session's own expiry, so the cache can otherwise retain expired sessions for
+// the whole deletion-lag window. Pruning them here, anchored to the cache's
+// own clock and held back by the same grace period as the node sweep, bounds
+// the cached set to roughly the live sessions without depending on the backend
+// to emit a timely delete.
+//
+// Like performRelativeNodeExpiry, this is only sane to call on the watch
+// goroutine, where it cannot run concurrently with event processing.
+func (c *Cache) performRelativeSessionExpiry(ctx context.Context) error {
+	// See performRelativeNodeExpiry for the reasoning behind the grace period.
+	gracePeriod := apidefaults.ServerAnnounceTTL + backend.DefaultCreationGracePeriod
+	now := c.Clock.Now()
+
+	// The three session subkinds share a single budget so that a high churn
+	// rate on one kind cannot starve the others while still bounding the total
+	// number of synthesized deletes per sweep.
+	budget := c.Config.RelativeExpiryLimit
+
+	removed, err := expireStaleSessions(ctx, c, c.collections.webSessions, webSessionNameIndex, types.KindWebSession, gracePeriod, now, budget)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	budget -= removed
+
+	if budget > 0 {
+		n, err := expireStaleSessions(ctx, c, c.collections.appSessions, appSessionNameIndex, types.KindAppSession, gracePeriod, now, budget)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+		removed += n
+		budget -= n
+	}
+
+	if budget > 0 {
+		n, err := expireStaleSessions(ctx, c, c.collections.snowflakeSessions, snowflakeSessionNameIndex, types.KindSnowflakeSession, gracePeriod, now, budget)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+		removed += n
+	}
+
+	if removed > 0 {
+		c.Logger.DebugContext(ctx, "Removed sessions via relative expiry",
+			"removed_session_count", removed,
+		)
+	}
+
+	return nil
+}
+
+// expireStaleSessions removes from a single session collection every entry
+// that is expired relative to the most recent expiry seen in that collection
+// (or now, whichever is earlier) less the grace period. It returns the number
+// of entries removed, capped at budget.
+//
+// The collection's btree cannot be mutated while it is being iterated, so the
+// entries are snapshotted under the read guard first and the deletes are
+// issued afterwards. Only the name and expiry are read off each stored entry,
+// never a clone, since cloning the whole set would defeat the purpose of
+// reclaiming its memory.
+func expireStaleSessions[I comparable](
+	ctx context.Context,
+	c *Cache,
+	coll *collection[types.WebSession, I],
+	index I,
+	subKind string,
+	gracePeriod time.Duration,
+	now time.Time,
+	budget int,
+) (int, error) {
+	rg, err := acquireReadGuard(c, coll)
+	if err != nil {
+		return 0, trace.Wrap(err)
+	}
+
+	// If the collection is not currently served from the cache, there is
+	// nothing local to prune. Falling through to the upstream would defeat the
+	// point of a sweep, so skip it.
+	if !rg.ReadCache() {
+		rg.Release()
+		return 0, nil
+	}
+
+	type sessionEntry struct {
+		name   string
+		expiry time.Time
+	}
+
+	var (
+		entries   []sessionEntry
+		latestExp time.Time
+	)
+	for session := range rg.store.resources(index, "", "") {
+		exp := session.Expiry()
+		entries = append(entries, sessionEntry{name: session.GetName(), expiry: exp})
+		if exp.IsZero() {
+			continue
+		}
+		if latestExp.IsZero() || exp.After(latestExp) {
+			latestExp = exp
+		}
+	}
+	rg.Release()
+
+	if latestExp.IsZero() {
+		return 0, nil
+	}
+
+	// Anchor the threshold to now when the most recent expiry is still in the
+	// future, so a population of long-lived sessions cannot push the window
+	// far enough out to prune live entries. This clamp is load-bearing.
+	if latestExp.After(now) {
+		latestExp = now
+	}
+	retentionThreshold := latestExp.Add(-gracePeriod)
+
+	var removed int
+	for _, entry := range entries {
+		if entry.expiry.IsZero() || entry.expiry.After(retentionThreshold) {
+			continue
+		}
+
+		// Route the delete through processEvent so the local store, the event
+		// fanout, and any derivative caches stay consistent. The web-session
+		// collections are keyed by kind and subkind, so both must be set for
+		// the event to reach the right collection.
+		if err := c.processEvent(ctx, types.Event{
+			Type: types.OpDelete,
+			Resource: &types.ResourceHeader{
+				Kind:    types.KindWebSession,
+				SubKind: subKind,
+				Metadata: types.Metadata{
+					Name: entry.name,
+				},
+			},
+		}); err != nil {
+			return removed, trace.Wrap(err)
+		}
+
+		if removed++; removed >= budget {
+			break
+		}
+	}
+
+	return removed, nil
 }
 
 // isClosing checks if the cache has begun closing.

--- a/lib/cache/cache_test.go
+++ b/lib/cache/cache_test.go
@@ -1724,6 +1724,103 @@ func TestRelativeExpiryOnlyForAuth(t *testing.T) {
 	}
 }
 
+// TestRelativeSessionExpiry verifies that the relative-expiry sweep prunes
+// expired web, app, and snowflake sessions from the auth cache while keeping
+// live sessions and the most recent sliding-window entries.
+func TestRelativeSessionExpiry(t *testing.T) {
+	t.Parallel()
+
+	const checkInterval = time.Second
+	const sessionCount = 100
+
+	// keep the event buffer well above the number of seeded sessions so the
+	// batch insert does not block on event delivery.
+	require.Less(t, sessionCount*3, eventBufferSize)
+
+	ctx := context.Background()
+
+	clock := clockwork.NewFakeClockAt(time.Now().Add(time.Hour))
+	p := newTestPack(t, func(c Config) Config {
+		c.RelativeExpiryCheckInterval = checkInterval
+		c.Clock = clock
+		return ForAuth(c)
+	})
+	t.Cleanup(p.Close)
+
+	newSession := func(subKind, name string, exp time.Time) *types.WebSessionV2 {
+		s := &types.WebSessionV2{
+			Kind:    types.KindWebSession,
+			SubKind: subKind,
+			Version: types.V2,
+			Metadata: types.Metadata{
+				Name: name,
+			},
+			Spec: types.WebSessionSpecV2{
+				User: "bot",
+			},
+		}
+		s.SetExpiry(exp)
+		return s
+	}
+
+	// seed each session kind with expiries spread across a range. The memory
+	// backend runs on the real clock and so will not delete these as the
+	// cache's fake clock advances, isolating the removals to the sweep.
+	now := clock.Now()
+	for i := range sessionCount {
+		exp := now.Add(time.Minute * time.Duration(i))
+		id := fmt.Sprintf("%d", i)
+		require.NoError(t, p.appSessionS.UpsertAppSession(ctx, newSession(types.KindAppSession, "app-"+id, exp)))
+		require.NoError(t, p.webSessionS.Upsert(ctx, newSession(types.KindWebSession, "web-"+id, exp)))
+		require.NoError(t, p.snowflakeSessionS.UpsertSnowflakeSession(ctx, newSession(types.KindSnowflakeSession, "snow-"+id, exp)))
+	}
+
+	appLen := func() int { return p.cache.collections.appSessions.store.len() }
+	webLen := func() int { return p.cache.collections.webSessions.store.len() }
+	snowLen := func() int { return p.cache.collections.snowflakeSessions.store.len() }
+
+	// wait for every session to replicate into the cache.
+	require.EventuallyWithT(t, func(t *assert.CollectT) {
+		assert.Equal(t, sessionCount, appLen())
+		assert.Equal(t, sessionCount, webLen())
+		assert.Equal(t, sessionCount, snowLen())
+	}, 15*time.Second, 100*time.Millisecond)
+
+	// advance past the earliest expiries and let one sweep run.
+	clock.Advance(25 * time.Minute)
+	drainEvents(p.eventsC)
+	expectEvent(t, p.eventsC, RelativeExpiry)
+
+	// each kind should lose its earliest-expiring entries but not all of them.
+	for _, tc := range []struct {
+		kind string
+		size int
+	}{
+		{"app", appLen()},
+		{"web", webLen()},
+		{"snowflake", snowLen()},
+	} {
+		require.True(t, tc.size < sessionCount && tc.size > sessionCount*3/4, "%s_count=%d", tc.kind, tc.size)
+	}
+
+	// a session pruned from the cache but still present in the backend must
+	// self-heal on a single get rather than returning an error.
+	healed, err := p.cache.GetAppSession(ctx, types.GetAppSessionRequest{SessionID: "app-0"})
+	require.NoError(t, err)
+	require.NotNil(t, healed)
+
+	// advancing well past the newest expiry must still leave the sliding
+	// window's most recent sessions in place, since the threshold is anchored
+	// to the latest expiry rather than to the current time.
+	clock.Advance(24 * time.Hour)
+	drainEvents(p.eventsC)
+	expectEvent(t, p.eventsC, RelativeExpiry)
+
+	require.NotZero(t, appLen(), "app sessions fully drained")
+	require.NotZero(t, webLen(), "web sessions fully drained")
+	require.NotZero(t, snowLen(), "snowflake sessions fully drained")
+}
+
 func TestCache_Backoff(t *testing.T) {
 	t.Parallel()
 

--- a/lib/cache/cache_test.go
+++ b/lib/cache/cache_test.go
@@ -1747,20 +1747,22 @@ func TestRelativeSessionExpiry(t *testing.T) {
 	})
 	t.Cleanup(p.Close)
 
+	// Set the expiry on the spec, which is where the backend reads the item
+	// TTL from and what the sweep keys off, not just the metadata.
 	newSession := func(subKind, name string, exp time.Time) *types.WebSessionV2 {
-		s := &types.WebSessionV2{
+		return &types.WebSessionV2{
 			Kind:    types.KindWebSession,
 			SubKind: subKind,
 			Version: types.V2,
 			Metadata: types.Metadata{
-				Name: name,
+				Name:    name,
+				Expires: &exp,
 			},
 			Spec: types.WebSessionSpecV2{
-				User: "bot",
+				User:    "bot",
+				Expires: exp,
 			},
 		}
-		s.SetExpiry(exp)
-		return s
 	}
 
 	// seed each session kind with expiries spread across a range. The memory
@@ -1819,6 +1821,79 @@ func TestRelativeSessionExpiry(t *testing.T) {
 	require.NotZero(t, appLen(), "app sessions fully drained")
 	require.NotZero(t, webLen(), "web sessions fully drained")
 	require.NotZero(t, snowLen(), "snowflake sessions fully drained")
+}
+
+// TestRelativeSessionExpiryWebUsesEarliestExpiry verifies that the sweep
+// considers a regular web session expired once its bearer token expires, even
+// though the session itself expires much later. This matches the TTL the
+// backend writes (GetEarliestExpiry), so the sweep does not retain web
+// sessions past the point the backend would delete them.
+func TestRelativeSessionExpiryWebUsesEarliestExpiry(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	clock := clockwork.NewFakeClockAt(time.Now().Add(time.Hour))
+	p := newTestPack(t, func(c Config) Config {
+		c.RelativeExpiryCheckInterval = time.Second
+		c.Clock = clock
+		return ForAuth(c)
+	})
+	t.Cleanup(p.Close)
+
+	now := clock.Now()
+
+	// The bearer token is about to expire while the session itself is set far
+	// in the future. Reading the session expiry alone would keep this entry;
+	// reading the earliest expiry prunes it.
+	bearerExpired := &types.WebSessionV2{
+		Kind:    types.KindWebSession,
+		SubKind: types.KindWebSession,
+		Version: types.V2,
+		Metadata: types.Metadata{
+			Name: "bearer-expired",
+		},
+		Spec: types.WebSessionSpecV2{
+			User:               "bot",
+			Expires:            now.Add(48 * time.Hour),
+			BearerTokenExpires: now.Add(time.Minute),
+		},
+	}
+	require.NoError(t, p.webSessionS.Upsert(ctx, bearerExpired))
+
+	// A second session expiring later anchors the sliding window so the sweep
+	// has a recent reference point and does not prune everything.
+	anchorExp := now.Add(30 * time.Minute)
+	anchor := &types.WebSessionV2{
+		Kind:    types.KindWebSession,
+		SubKind: types.KindWebSession,
+		Version: types.V2,
+		Metadata: types.Metadata{
+			Name:    "anchor",
+			Expires: &anchorExp,
+		},
+		Spec: types.WebSessionSpecV2{
+			User:    "bot",
+			Expires: anchorExp,
+		},
+	}
+	require.NoError(t, p.webSessionS.Upsert(ctx, anchor))
+
+	store := p.cache.collections.webSessions.store
+	require.EventuallyWithT(t, func(t *assert.CollectT) {
+		assert.Equal(t, 2, store.len())
+	}, 15*time.Second, 100*time.Millisecond)
+
+	// advance past the bearer-token expiry but well before the session expiry.
+	clock.Advance(20 * time.Minute)
+	drainEvents(p.eventsC)
+	expectEvent(t, p.eventsC, RelativeExpiry)
+
+	_, err := store.get(webSessionNameIndex, "bearer-expired")
+	require.True(t, trace.IsNotFound(err), "session with expired bearer token should be pruned, got err=%v", err)
+
+	_, err = store.get(webSessionNameIndex, "anchor")
+	require.NoError(t, err, "session expiring later should be kept")
 }
 
 func TestCache_Backoff(t *testing.T) {


### PR DESCRIPTION
Extend the cache's relative-expiry sweep, which already prunes stale nodes, to the web, app, and snowflake session collections.

The auth and proxy caches replicate every web, app, and snowflake session from the backend and drop an entry only when the backend emits a delete event. On a DynamoDB backend that delete rides the table's native TTL, which AWS applies asynchronously and can lag well past a session's expiry. Under high session churn, for example bots that mint a fresh session every renewal, expired sessions then accumulate in every auth and proxy pod's in-memory cache for the whole lag window, growing heap steadily until a restart.

`performRelativeSessionExpiry` mirrors the existing `performRelativeNodeExpiry`. Each sweep removes only sessions that are expired from within the cache's own frame of reference, anchored to the cache clock and held back by a grace window, so a lagging event stream never triggers eviction. The sweep runs only on the auth cache's watch goroutine, alongside the node sweep, and routes each removal through `processEvent`, so the synthesized delete also fans out to proxy caches and they drop their copies too. Removing an expired session locally degrades a concurrent single-session read to one backend fetch, which the session getters already handle, rather than to an error.

On a watcher reset the backend re-seeds any sessions whose native TTL has not yet fired, so a pruned session can briefly reappear until the next sweep re-prunes it. That is transient churn rather than a correctness issue, since only already-expired sessions are ever pruned.

## Manual Test Plan

The sweep keys off `GetExpiryTime` for app and snowflake sessions and `GetEarliestExpiry` for regular web sessions, matching the expiry the backend writes as each item's TTL. The sweep interval (`ServerKeepAliveTTL + 5s`, 65 seconds) and grace window (`ServerAnnounceTTL + DefaultCreationGracePeriod`, about 13 minutes) are fixed and not configurable through `teleport.yaml`. The prune threshold anchors to the most recent expiry in each collection, so a single population of live sessions is never pruned.

Tests 1 and 2 were verified live on a real DynamoDB-backed cluster (single auth and proxy, app access). To exercise the deletion lag deterministically, the short session's DynamoDB `Expires` TTL attribute was bumped far into the future while its real session expiry stayed near-term, so the backend never deleted it and the sweep was the only mechanism that could. The sweep removed the expired session from the cache (`Removed sessions via relative expiry removed_session_count:1`) about 13 minutes after its expiry, while the backend item was still present, and left the longer-lived anchor session untouched.

### Test Environment

- Single auth and proxy on one host, app access configured, DynamoDB backend, cache log level at DEBUG.

### Test Cases

#### Test 1: Live session survives a sweep

- [x] A longer-lived app session is not removed while a sweep prunes an expired sibling (the sweep logged a single removal and left the anchor session in place).

#### Test 2: Expired session pruned without a backend delete

- [x] A `Removed sessions via relative expiry` log line appears with a non-zero `removed_session_count`.
- [x] The expired session is gone from the cache while the backend item is still present, confirming the sweep does not wait for the backend's own delete.

#### Test 3: Pruned-but-present session self-heals on a single get

- [x] A single get of a pruned-but-still-present session falls through to the backend rather than erroring. Verified by the unit test `TestRelativeSessionExpiry` (not live): it asserts the fallback and logs `Cache was forced to load session from upstream`. A clean live trigger is impractical, since a request carrying a still-valid credential keeps the session live so it is never pruned, and a request carrying an expired credential is rejected before the session lookup.

#### Test 4: Regression baseline (without the fix)

- [x] Built from the PR base (without the fix) and run against the same DynamoDB table with the session's TTL decoupled, the expired session was not removed over the full grace window: no `Removed sessions via relative expiry` log appeared and the session remained, confirming the sweep is the change that removes it. The pre-fix binary contains no session-sweep code at all.

Changelog: Reduce auth and proxy memory use under high session churn by pruning expired web, app, and snowflake sessions from the cache instead of waiting for the backend to delete them.
