### PR TITLE
docs: SSH and app enrollment fixes

### DIFF
--- a/docs/pages/enroll-resources/application-access/getting-started.mdx
+++ b/docs/pages/enroll-resources/application-access/getting-started.mdx
@@ -150,7 +150,7 @@ To install on Linux:
 
 1. (!docs/pages/includes/install-linux.mdx!)
 
-1. Create the configuration file for Grafana at `/etc/app_config.yaml`
+1. Create the configuration file for Grafana at `/etc/teleport.yaml`
 with a command similar to the following:
    
    ```code
@@ -195,7 +195,7 @@ $ helm install teleport-kube-agent teleport/teleport-kube-agent \
 
 - Set `proxyAddr` to the address for your Teleport cluster (for example, 
 `teleport.example.com` or `mytenant.teleport.sh`).
-- Set `-authToken` to the invitation token that you previously generated.
+- Set `authToken` to the invitation token that you previously generated.
 - Change `apps[0].name` and `apps[0].uri` if you're configuring access to a different 
 web application.
 

--- a/docs/pages/enroll-resources/server-access/guides/encrypted-session-recordings/rotating-keys.mdx
+++ b/docs/pages/enroll-resources/server-access/guides/encrypted-session-recordings/rotating-keys.mdx
@@ -77,7 +77,7 @@ $ tctl recordings encryption complete-rotation
 If any key is in an `inaccessible` state, then attempting to complete the
 rotation will result in an error.
 
-### Rollback
+## Rollback
 
 If an in progress rotation needs to be rolled back for any reason it can be
 reverted to the previous state using:

--- a/docs/pages/enroll-resources/server-access/guides/encrypted-session-recordings/rotating-manual-keys.mdx
+++ b/docs/pages/enroll-resources/server-access/guides/encrypted-session-recordings/rotating-manual-keys.mdx
@@ -48,7 +48,7 @@ encryption:
     enabled: yes
     active_keys:
       - type: pkcs11
-        label: 'session_recordings_001'
+        label: 'session_recording_001'
 ```
 
 ## Step 1/2. Add the new key

--- a/docs/pages/enroll-resources/server-access/guides/encrypted-session-recordings/rotating-manual-keys.mdx
+++ b/docs/pages/enroll-resources/server-access/guides/encrypted-session-recordings/rotating-manual-keys.mdx
@@ -33,7 +33,7 @@ administrator, the `manual_key_management` configuration can be leveraged to hel
 
 As an example, we will assume an existing Teleport Auth Service configured to
 use a PKCS#11 compatible HSM with an active key identified by the label
-`session_recording_001`:
+`session_recordings_001`:
 
 <Admonition type="note">
 All configuration examples are reduced to the `encryption` configuration block
@@ -48,7 +48,7 @@ encryption:
     enabled: yes
     active_keys:
       - type: pkcs11
-        label: 'session_recording_001'
+        label: 'session_recordings_001'
 ```
 
 ## Step 1/2. Add the new key

--- a/docs/pages/enroll-resources/server-access/guides/ssh-pam.mdx
+++ b/docs/pages/enroll-resources/server-access/guides/ssh-pam.mdx
@@ -13,7 +13,7 @@ Pluggable Authentication Modules (PAM).
 Teleport currently supports the `auth`, `account`, and `session` PAM modules. The `auth`
 stack is optional and not used by default.
 
-These are a few things leverage PAM for:
+These are a few things Teleport can leverage PAM for:
 
 - Create a custom Message of the Day (MOTD)
 - Create local Unix users on login

--- a/docs/pages/enroll-resources/server-access/rbac.mdx
+++ b/docs/pages/enroll-resources/server-access/rbac.mdx
@@ -47,7 +47,7 @@ spec:
       # regular expressions start with ^ and end with $
       # Teleport uses Go's regexp syntax (https://github.com/google/re2/wiki/Syntax)
       # the list example above can be expressed as:
-      'reg': '^us-west-1|eu-central-1$'
+      'region': '^us-west-1|eu-central-1$'
 
     # List of host groups the created user will be added to. Any that don't
     # already exist are created. Only applies when create_host_user_mode
@@ -88,7 +88,7 @@ server environment types and allowed logins from the user's Okta `environments` 
 spec:
   allow:
     node_labels:
-    - env:  '{{external.environments}}'
+      env:  '{{external.environments}}'
     logins:
     - '{{external.allowedlogins}}'
 ```
@@ -134,7 +134,7 @@ spec:
   allow:
     #....
   options:
-    # Sets the default shell for automatically provisioned SSH users. An absolute path to a shell or a name
+    # Sets the default shell for automatically provisioning SSH users. An absolute path to a shell or a name
     # reachable through the system PATH are both valid values. Only applies when
     # create_host_user_mode is not set to off.
     create_host_user_default_shell: bash

--- a/docs/pages/enroll-resources/server-access/troubleshooting-server.mdx
+++ b/docs/pages/enroll-resources/server-access/troubleshooting-server.mdx
@@ -127,7 +127,7 @@ the server has stopped sending the heartbeat.
 Teleport allows multiple users to observe or participate in active sessions. You can define rules and
 configure role-based policies to control which users can join other users' sessions from `tsh` and the
 Teleport Web UI. If you are unable to join a shared session, you should check your role assignments
-and ensure you have a role that include the `join_session` permission.
+and ensure you have a role that include the `join_sessions` permission.
 For example:
 
 ```yaml


### PR DESCRIPTION
docs/pages/enroll-resources/server-access/guides/encrypted-session-recordings/rotating-keys.mdx:
- heading fix

docs/pages/enroll-resources/server-access/guides/encrypted-session-recordings/rotating-manual-keys.mdx:
- label fix

docs/pages/enroll-resources/server-access/guides/ssh-pam.mdx:
- grammar fix

docs/pages/enroll-resources/server-access/rbac.mdx:
- yaml fixes
- grammar fix

docs/pages/enroll-resources/server-access/troubleshooting-server.mdx:
- reference fix

docs/pages/enroll-resources/application-access/getting-started.mdx:
- file and parameter reference fixes
