### PR TITLE
Add tctl rm support for access list

### DIFF
--- a/docs/pages/reference/cli/tctl.mdx
+++ b/docs/pages/reference/cli/tctl.mdx
@@ -166,6 +166,28 @@ Arguments:
 |---|---|---|
 |access-list-name|*no default* (required)|The access list name to fetch review history for.|
 
+## tctl acl rm
+
+Delete an Access List.
+
+Usage:
+
+```code
+$ tctl acl rm [<flags>] <access-list-name>
+```
+
+Flags:
+
+|Flag|Default|Description|
+|---|---|---|
+|`--format`|`text` (one of: `text`, `json`)|Output format.|
+
+Arguments:
+
+|Argument|Default|Description|
+|---|---|---|
+|access-list-name|*no default* (required)|The Access List name.|
+
 ## tctl acl summary
 
 Show summary information for access lists, including their members and last

--- a/tool/tctl/common/accesslist/command.go
+++ b/tool/tctl/common/accesslist/command.go
@@ -57,6 +57,7 @@ type Command struct {
 	usersList     *kingpin.CmdClause
 	reviewsCreate *kingpin.CmdClause
 	reviewsList   *kingpin.CmdClause
+	remove        *kingpin.CmdClause
 
 	// Used for managing a particular access list.
 	accessListName string
@@ -131,6 +132,10 @@ func (c *Command) Initialize(app *kingpin.Application, _ *tctlcfg.GlobalCLIFlags
 	c.reviewsList.Arg("access-list-name", "The access list name to fetch review history for.").Required().StringVar(&c.accessListName)
 	c.reviewsList.Flag("format", "Output format.").Default(teleport.Text).EnumVar(&c.format, teleport.YAML, teleport.JSON, teleport.Text)
 
+	c.remove = acl.Command("rm", "Delete an Access List.").Alias("del").Alias("delete")
+	c.remove.Arg("access-list-name", "The Access List name.").Required().StringVar(&c.accessListName)
+	c.remove.Flag("format", "Output format.").Default(teleport.Text).EnumVar(&c.format, teleport.Text, teleport.JSON)
+
 	if c.Stdout == nil {
 		c.Stdout = os.Stdout
 	}
@@ -156,6 +161,8 @@ func (c *Command) TryRun(ctx context.Context, cmd string, clientFunc commonclien
 		commandFunc = c.ReviewsCreate
 	case c.reviewsList.FullCommand():
 		commandFunc = c.ReviewsList
+	case c.remove.FullCommand():
+		commandFunc = c.Remove
 	default:
 		return false, nil
 	}

--- a/tool/tctl/common/accesslist/remove.go
+++ b/tool/tctl/common/accesslist/remove.go
@@ -1,0 +1,80 @@
+/*
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package accesslist
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/gravitational/trace"
+
+	"github.com/gravitational/teleport"
+	"github.com/gravitational/teleport/lib/auth/authclient"
+	"github.com/gravitational/teleport/lib/utils"
+)
+
+// Remove deletes an access list. If the list was created with a preset
+// (which automatically creates supporting roles), after deletion those
+// roles will be listed for the user to optionally manually
+// delete with `tctl rm roles/<name>`.
+//
+// Roles are not automatically deleted for the user since nothing stops a user
+// from assigning these roles to other users or referencing them in other roles.
+// Deleting a role assigned to other resources will lock a user out of their account.
+func (c *Command) Remove(ctx context.Context, client *authclient.Client) error {
+	al, err := client.AccessListClient().GetAccessList(ctx, c.accessListName)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	if err := client.AccessListClient().DeleteAccessList(ctx, c.accessListName); err != nil {
+		return trace.Wrap(err)
+	}
+
+	resp := RemoveJSONResponse{
+		RolesToDelete: al.PresetRoleNames(),
+	}
+
+	if c.format == teleport.JSON {
+		return trace.Wrap(utils.WriteJSON(c.Stdout, resp), "failed to marshal access list delete response")
+	}
+
+	fmt.Fprintf(c.Stdout, "Deleted access list %q\n", c.accessListName)
+	if len(resp.RolesToDelete) == 0 {
+		return nil
+	}
+	fmt.Fprintln(c.Stdout)
+	fmt.Fprintln(c.Stdout, "The following roles are no longer used by this access list:")
+	for _, name := range resp.RolesToDelete {
+		fmt.Fprintf(c.Stdout, "  - %s\n", name)
+	}
+	fmt.Fprintln(c.Stdout)
+	fmt.Fprintln(c.Stdout, "These roles may still be assigned to users or referenced by other roles.")
+	fmt.Fprintln(c.Stdout, "Verify each role is unused before deleting it with:")
+	fmt.Fprintln(c.Stdout, "  tctl rm roles/<name>")
+	return nil
+}
+
+// RemoveJSONResponse is a structured response when `format=json`
+// is requested.
+type RemoveJSONResponse struct {
+	// RolesToDelete contains role names that are no longer
+	// valid for the deleted access list.
+	RolesToDelete []string `json:"roles_to_delete,omitempty"`
+}

--- a/tool/tctl/common/accesslist/remove.go
+++ b/tool/tctl/common/accesslist/remove.go
@@ -48,6 +48,10 @@ func (c *Command) Remove(ctx context.Context, client *authclient.Client) error {
 	}
 
 	resp := RemoveJSONResponse{
+		// TODO(kimlisa): The list of role names from GetAccessList can refer to stale roles
+		// since in between the Get and Delete call, an update may have occurred.
+		// Have a new rpc "DeleteAccessListV2" return the list of role names to delete instead,
+		// and fall back to GetAccessList/DeleteAccessList otherwise.
 		RolesToDelete: al.PresetRoleNames(),
 	}
 


### PR DESCRIPTION
part of https://github.com/gravitational/teleport.e/issues/8271 and https://github.com/gravitational/rfd/pull/29

Changelog: Added `tctl acl rm` for deleting an access list.

This PR adds a `tctl acl rm` command to delete an access list.

Deleting an access list is already possible with `tctl rm accesslist/<name>`, but the new command goes a step further (listing supporting roles that needs to be deleted) and should be more discoverable (e.g. agents) since it's under the `tctl acl` namespace

Tests are written in the enterprise repo: https://github.com/gravitational/teleport.e/pull/8881

Example tested outputs:

with `--help` output:
```bash
usage: tctl acl rm [<flags>] <access-list-name>

Delete an Access List.

Flags:
  .... <other commands>
      --format=text        Output format. (one of: text, json)

Args:
  <access-list-name>  The Access List name.

Aliases:
del
delete
```

when `--format=json` for deleting an access list created with a preset:
```bash
$ tctl acl rm --format=json ABC
{
    "roles_to_be_deleted": [
        "reviewer-acl-preset-ABC",
        "requester-acl-preset-ABC",
        "access-standard-acl-preset-ABC"
    ]
}
```

when deleting an access list created with a preset:
```bash
$ tctl acl rm ABC
Deleted access list "ABC"

The following roles are no longer used by this access list:
  - reviewer-acl-preset-ABC
  - requester-acl-preset-ABC
  - access-standard-acl-preset-ABC

These roles may still be assigned to users or referenced by other roles.
Verify each role is unused before deleting it with:
  tctl rm roles/<name>
```

when deleting a regular access list:
```bash
$ tctl acl rm ABC
Deleted access list "ABC"
```

`--format=json` when deleting a regular access list:
```bash
$ tctl acl rm ABC
{}
```



<!-- Provide a descriptive entry for the changelog of the next release. -->

<!-- Include manual testing efforts to verify the change. -->
<!-- Detail where the tests where run and what configurations were used. -->
<!-- Include all the test cases which were run to validate the change. -->

## Manual Test Plan
### Test Environment
local

### Test Cases
tctl acl rm:
- [x] delete regular access list
- [x] delete access list created with a preset, response lists roles to be deleted
- [x] tctl acl rm --format=json, prints `rolesToBeDeleted` json object instead of text