### PR TITLE
Fix error in List calls terminating iteration too early on failure

### DIFF
--- a/lib/services/local/apps.go
+++ b/lib/services/local/apps.go
@@ -88,7 +88,6 @@ func (s *AppService) ListApps(ctx context.Context, limit int, startKey string) (
 	for item, err := range s.Backend.Items(ctx, backend.ItemsParams{
 		StartKey: appKey.AppendKey(backend.KeyFromString(startKey)),
 		EndKey:   backend.RangeEnd(appKey),
-		Limit:    limit + 1,
 	}) {
 		if err != nil {
 			return nil, "", trace.Wrap(err)

--- a/lib/services/local/apps_test.go
+++ b/lib/services/local/apps_test.go
@@ -256,7 +256,7 @@ func TestAppsCRUD(t *testing.T) {
 	))
 }
 
-func TestListApps_SkipsUnmarshalErrorsHittingPageBounrary(t *testing.T) {
+func TestListApps_SkipsUnmarshalErrorsHittingPageBoundary(t *testing.T) {
 	ctx := t.Context()
 
 	const pageLimit = 64

--- a/lib/services/local/apps_test.go
+++ b/lib/services/local/apps_test.go
@@ -21,6 +21,7 @@ package local
 import (
 	"cmp"
 	"context"
+	"fmt"
 	"slices"
 	"strconv"
 	"testing"
@@ -33,6 +34,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/backend"
 	"github.com/gravitational/teleport/lib/backend/memory"
 )
 
@@ -252,4 +254,72 @@ func TestAppsCRUD(t *testing.T) {
 	assert.Empty(t, gocmp.Diff(expected, append(page1, iterOut...),
 		cmpopts.IgnoreFields(types.Metadata{}, "Revision"),
 	))
+}
+
+func TestListApps_SkipsUnmarshalErrorsHittingPageBounrary(t *testing.T) {
+	ctx := t.Context()
+
+	const pageLimit = 64
+	const numberOfPages = 5
+
+	clock := clockwork.NewFakeClock()
+	mem, err := memory.New(memory.Config{
+		Context: t.Context(),
+		Clock:   clock,
+	})
+	require.NoError(t, err)
+	service := NewAppService(mem)
+
+	createApp := func(name string) {
+		app, err := types.NewAppV3(types.Metadata{
+			Name: name,
+		}, types.AppSpecV3{
+			URI: "localhost1",
+		})
+
+		require.NoError(t, err)
+
+		err = service.CreateApp(ctx, app)
+		require.NoError(t, err)
+	}
+
+	createMalformedApp := func(name string) {
+		_, err := mem.Put(ctx, backend.Item{
+			Key:   backend.NewKey(appPrefix, name),
+			Value: []byte("not-valid-json"),
+		})
+		require.NoError(t, err)
+	}
+
+	for i := range pageLimit * numberOfPages {
+		key := fmt.Sprintf("r%d", i)
+		if i%2 == 0 {
+			createMalformedApp(key)
+		} else {
+			createApp(key)
+		}
+	}
+
+	page1, next, err := service.ListApps(ctx, pageLimit, "")
+	require.NoError(t, err)
+	require.Len(t, page1, pageLimit)
+	require.NotEmpty(t, next)
+
+	page2, next, err := service.ListApps(ctx, pageLimit, next)
+	require.NoError(t, err)
+	require.Len(t, page2, pageLimit)
+	require.NotEmpty(t, next)
+
+	page3, next, err := service.ListApps(ctx, pageLimit, next)
+	require.NoError(t, err)
+	require.Len(t, page3, pageLimit/2)
+	require.Empty(t, next)
+
+	slices := [][]types.Application{page1, page2, page3}
+	for i := range len(slices) {
+		for j := i + 1; j < len(slices); j++ {
+			assert.NotEqual(t, slices[i], slices[j], "slices %d and %d should differ", i, j)
+		}
+	}
+
 }

--- a/lib/services/local/generic/generic.go
+++ b/lib/services/local/generic/generic.go
@@ -288,7 +288,6 @@ func (s *Service[T]) listResourcesReturnNextResourceWithKey(ctx context.Context,
 	for item, err := range s.backend.Items(ctx, backend.ItemsParams{
 		StartKey: s.backendPrefix.AppendKey(backend.KeyFromString(pageToken)),
 		EndKey:   backend.RangeEnd(s.backendPrefix.ExactKey()),
-		Limit:    pageSize + 1,
 	}) {
 		if err != nil {
 			return nil, nil, "", trace.Wrap(err)

--- a/lib/services/local/generic/generic_test.go
+++ b/lib/services/local/generic/generic_test.go
@@ -804,9 +804,9 @@ func TestGenericKeyOverride(t *testing.T) {
 	})
 }
 
-// TestResourcesSkipsUnmarshalErrorsHittingPageBounrary guards against a regression where hitting a page boundary with a malformed backend item would
+// TestResourcesSkipsUnmarshalErrorsHittingPageBoundary guards against a regression where hitting a page boundary with a malformed backend item would
 // return less items than the page limit and no next token. This would cause callers to miss resources and fail to paginate properly when malformed items are present in the backend.
-func TestResourcesSkipsUnmarshalErrorsHittingPageBounrary(t *testing.T) {
+func TestResourcesSkipsUnmarshalErrorsHittingPageBoundary(t *testing.T) {
 	ctx := t.Context()
 
 	memBackend, err := memory.New(memory.Config{

--- a/lib/services/local/generic/generic_test.go
+++ b/lib/services/local/generic/generic_test.go
@@ -803,3 +803,65 @@ func TestGenericKeyOverride(t *testing.T) {
 		require.ErrorAs(t, s.DeleteResource(ctx, ""), new(*trace.NotFoundError), "2nd DeleteResource error mismatch")
 	})
 }
+
+// TestResourcesSkipsUnmarshalErrorsHittingPageBounrary guards against a regression where hitting a page boundary with a malformed backend item would
+// return less items than the page limit and no next token. This would cause callers to miss resources and fail to paginate properly when malformed items are present in the backend.
+func TestResourcesSkipsUnmarshalErrorsHittingPageBounrary(t *testing.T) {
+	ctx := t.Context()
+
+	memBackend, err := memory.New(memory.Config{
+		Context: ctx,
+		Clock:   clockwork.NewFakeClock(),
+	})
+	require.NoError(t, err)
+
+	const pageLimit = 64
+	const numberOfPages = 5
+	service, err := NewService(&ServiceConfig[*testResource]{
+		Backend:       memBackend,
+		ResourceKind:  "generic resource",
+		PageLimit:     pageLimit,
+		BackendPrefix: backend.NewKey("generic_prefix"),
+		UnmarshalFunc: unmarshalResource,
+		MarshalFunc:   marshalResource,
+	})
+	require.NoError(t, err)
+
+	for i := range pageLimit * numberOfPages {
+		key := fmt.Sprintf("r%d", i)
+		if i%2 == 0 {
+			_, err = memBackend.Put(ctx, backend.Item{
+				Key:   service.MakeKey(backend.NewKey(key)),
+				Value: []byte("not-valid-json"),
+			})
+			require.NoError(t, err)
+		} else {
+			r := newTestResource(key)
+			_, err = service.CreateResource(ctx, r)
+			require.NoError(t, err)
+		}
+	}
+
+	page1, next, err := service.ListResources(ctx, pageLimit, "")
+	require.NoError(t, err)
+	require.Len(t, page1, pageLimit)
+	require.NotEmpty(t, next)
+
+	page2, next, err := service.ListResources(ctx, pageLimit, next)
+	require.NoError(t, err)
+	require.Len(t, page2, pageLimit)
+	require.NotEmpty(t, next)
+
+	page3, next, err := service.ListResources(ctx, pageLimit, next)
+	require.NoError(t, err)
+	require.Len(t, page3, pageLimit/2)
+	require.Empty(t, next)
+
+	slices := [][]*testResource{page1, page2, page3}
+	for i := range len(slices) {
+		for j := i + 1; j < len(slices); j++ {
+			assert.NotEqual(t, slices[i], slices[j], "slices %d and %d should differ", i, j)
+		}
+	}
+
+}

--- a/lib/services/local/plugins.go
+++ b/lib/services/local/plugins.go
@@ -20,6 +20,7 @@ package local
 
 import (
 	"context"
+	"iter"
 	"log/slog"
 
 	"github.com/gravitational/trace"
@@ -27,8 +28,10 @@ import (
 	apidefaults "github.com/gravitational/teleport/api/defaults"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/backend"
+	"github.com/gravitational/teleport/lib/itertools/stream"
 	libplugin "github.com/gravitational/teleport/lib/plugin"
 	"github.com/gravitational/teleport/lib/services"
+	"github.com/gravitational/teleport/lib/services/local/generic"
 	logutils "github.com/gravitational/teleport/lib/utils/log"
 )
 
@@ -161,39 +164,53 @@ func (s *PluginsService) GetPlugins(ctx context.Context, withSecrets bool) ([]ty
 // ListPlugins returns a paginated list of plugin instances.
 // StartKey is a resource name, which is the suffix of its key.
 func (s *PluginsService) ListPlugins(ctx context.Context, limit int, startKey string, withSecrets bool) ([]types.Plugin, string, error) {
-	if limit <= 0 {
-		limit = apidefaults.DefaultChunkSize
-	}
-	// Get at most limit+1 results to determine if there will be a next key.
-	maxLimit := limit + 1
+	return generic.CollectPageAndCursor(s.rangePlugins(ctx, startKey, "", withSecrets), limit, func(p types.Plugin) string {
+		return backend.GetPaginationKey(p)
+	})
+}
 
-	startKeyBytes := backend.NewKey(pluginsPrefix, startKey)
-	endKey := backend.RangeEnd(backend.ExactKey(pluginsPrefix))
-	result, err := s.backend.GetRange(ctx, startKeyBytes, endKey, maxLimit)
-	if err != nil {
-		return nil, "", trace.Wrap(err)
-	}
+// rangePlugins returns plugin resources within the range [start, end).
+func (s *PluginsService) rangePlugins(ctx context.Context, start, end string, withSecrets bool) iter.Seq2[types.Plugin, error] {
+	mapFn := func(item backend.Item) (types.Plugin, bool) {
+		plugin, err := services.UnmarshalPlugin(item.Value,
+			services.WithExpires(item.Expires),
+			services.WithRevision(item.Revision))
 
-	plugins := make([]types.Plugin, 0, len(result.Items))
-	for _, item := range result.Items {
-		plugin, err := services.UnmarshalPlugin(item.Value, services.WithExpires(item.Expires), services.WithRevision(item.Revision))
 		if err != nil {
-			slog.WarnContext(ctx, "skipping plugin resource due to unmarshal error", "error", err, "key", logutils.StringerAttr(item.Key))
-			continue
+			slog.WarnContext(ctx, "Failed to unmarshal plugin",
+				"key", logutils.StringerAttr(item.Key),
+				"error", err,
+			)
+			return nil, false
 		}
+
 		if !withSecrets {
 			plugin = plugin.WithoutSecrets().(types.Plugin)
 		}
-		plugins = append(plugins, plugin)
+
+		return plugin, true
 	}
 
-	var nextKey string
-	if len(plugins) == maxLimit {
-		nextKey = backend.GetPaginationKey(plugins[len(plugins)-1])
-		plugins = plugins[:limit]
+	pluginKey := backend.NewKey(pluginsPrefix)
+	startKey := pluginKey.AppendKey(backend.KeyFromString(start))
+	endKey := backend.RangeEnd(pluginKey)
+	if end != "" {
+		endKey = pluginKey.AppendKey(backend.KeyFromString(end)).ExactKey()
 	}
 
-	return plugins, nextKey, nil
+	return stream.TakeWhile(
+		stream.FilterMap(
+			s.backend.Items(ctx, backend.ItemsParams{
+				StartKey: startKey,
+				EndKey:   endKey,
+			}),
+			mapFn, // mapping function
+		),
+		func(plugin types.Plugin) bool {
+			// The range is not inclusive of the end key, so return early
+			// if the end has been reached.
+			return end == "" || plugin.GetName() < end
+		})
 }
 
 // HasPluginType will return true if a plugin of the given type is registered.

--- a/lib/services/local/plugins_test.go
+++ b/lib/services/local/plugins_test.go
@@ -27,10 +27,12 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	apidefaults "github.com/gravitational/teleport/api/defaults"
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/backend"
 	"github.com/gravitational/teleport/lib/backend/memory"
 )
 
@@ -323,4 +325,83 @@ func TestPlugins_validate_okta(t *testing.T) {
 			tt.requireErrFn(t, err, "UpdatePlugin")
 		})
 	}
+}
+
+func TestPlugins_SkipsUnmarshalErrorsHittingPageBoundary(t *testing.T) {
+	ctx := t.Context()
+
+	const pageLimit = 64
+	const numberOfPages = 5
+
+	clock := clockwork.NewFakeClock()
+	mem, err := memory.New(memory.Config{
+		Context: t.Context(),
+		Clock:   clock,
+	})
+	require.NoError(t, err)
+	service := NewPluginsService(mem)
+
+	createApp := func(name string) {
+		dummyStaticCreds := &types.PluginCredentialsV1{
+			Credentials: &types.PluginCredentialsV1_StaticCredentialsRef{
+				StaticCredentialsRef: &types.PluginStaticCredentialsRef{
+					Labels: map[string]string{"test_cred_label_1": "test_cred_value_1"},
+				},
+			},
+		}
+
+		plugin := types.NewPluginV1(types.Metadata{Name: name}, types.PluginSpecV1{
+			Settings: &types.PluginSpecV1_Okta{
+				Okta: &types.PluginOktaSettings{
+					OrgUrl: "https://my.okta.org.example.com",
+				},
+			},
+		}, nil)
+		require.NoError(t, err)
+
+		plugin.Credentials = dummyStaticCreds
+
+		err = service.CreatePlugin(ctx, plugin)
+		require.NoError(t, err)
+	}
+
+	createMalformedApp := func(name string) {
+		_, err := mem.Put(ctx, backend.Item{
+			Key:   backend.NewKey(pluginsPrefix, name),
+			Value: []byte("not-valid-json"),
+		})
+		require.NoError(t, err)
+	}
+
+	for i := range pageLimit * numberOfPages {
+		key := fmt.Sprintf("r%d", i)
+		if i%2 == 0 {
+			createMalformedApp(key)
+		} else {
+			createApp(key)
+		}
+	}
+
+	page1, next, err := service.ListPlugins(ctx, pageLimit, "", false)
+	require.NoError(t, err)
+	require.Len(t, page1, pageLimit)
+	require.NotEmpty(t, next)
+
+	page2, next, err := service.ListPlugins(ctx, pageLimit, next, false)
+	require.NoError(t, err)
+	require.Len(t, page2, pageLimit)
+	require.NotEmpty(t, next)
+
+	page3, next, err := service.ListPlugins(ctx, pageLimit, next, false)
+	require.NoError(t, err)
+	require.Len(t, page3, pageLimit/2)
+	require.Empty(t, next)
+
+	slices := [][]types.Plugin{page1, page2, page3}
+	for i := range len(slices) {
+		for j := i + 1; j < len(slices); j++ {
+			assert.NotEqual(t, slices[i], slices[j], "slices %d and %d should differ", i, j)
+		}
+	}
+
 }

--- a/lib/services/local/presence.go
+++ b/lib/services/local/presence.go
@@ -44,6 +44,7 @@ import (
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/services/local/generic"
 	"github.com/gravitational/teleport/lib/utils"
+	logutils "github.com/gravitational/teleport/lib/utils/log"
 	"github.com/gravitational/teleport/lib/utils/typical"
 )
 
@@ -545,42 +546,49 @@ func (s *PresenceService) DeleteReverseTunnel(ctx context.Context, clusterName s
 func (s *PresenceService) ListReverseTunnels(
 	ctx context.Context, pageSize int, pageToken string,
 ) ([]types.ReverseTunnel, string, error) {
-	rangeStart := backend.NewKey(reverseTunnelsPrefix, pageToken)
-	rangeEnd := backend.RangeEnd(backend.ExactKey(reverseTunnelsPrefix))
+	return generic.CollectPageAndCursor(s.rangeReverseTunnels(ctx, pageToken, ""), pageSize, func(c types.ReverseTunnel) string {
+		return backend.GetPaginationKey(c)
+	})
+}
 
-	// Adjust page size, so it can't be too large.
-	if pageSize <= 0 || pageSize > apidefaults.DefaultChunkSize {
-		pageSize = apidefaults.DefaultChunkSize
-	}
-
-	limit := pageSize + 1
-
-	result, err := s.GetRange(ctx, rangeStart, rangeEnd, limit)
-	if err != nil {
-		return nil, "", trace.Wrap(err)
-	}
-
-	tunnels := make([]types.ReverseTunnel, 0, len(result.Items))
-	for _, item := range result.Items {
+// rangeReverseTunnels returns reverse tunnel resources within the range [start, end).
+func (s *PresenceService) rangeReverseTunnels(ctx context.Context, start, end string) iter.Seq2[types.ReverseTunnel, error] {
+	mapFn := func(item backend.Item) (types.ReverseTunnel, bool) {
 		tunnel, err := services.UnmarshalReverseTunnel(item.Value,
 			services.WithExpires(item.Expires),
-			services.WithRevision(item.Revision),
-		)
+			services.WithRevision(item.Revision))
+
 		if err != nil {
-			slog.WarnContext(ctx, "Skipping item during ListReverseTunnels because conversion from backend item failed", "key", item.Key, "error", err)
-			continue
+			slog.WarnContext(ctx, "Failed to unmarshal reverse tunnel from backend item",
+				"key", logutils.StringerAttr(item.Key),
+				"error", err,
+			)
+			return nil, false
 		}
-		tunnels = append(tunnels, tunnel)
+
+		return tunnel, true
 	}
 
-	next := ""
-	if len(tunnels) > pageSize {
-		next = backend.GetPaginationKey(tunnels[pageSize])
-		clear(tunnels[pageSize:])
-		// Truncate the last item that was used to determine next row existence.
-		tunnels = tunnels[:pageSize]
+	rcKey := backend.NewKey(reverseTunnelsPrefix)
+	startKey := rcKey.AppendKey(backend.KeyFromString(start))
+	endKey := backend.RangeEnd(rcKey)
+	if end != "" {
+		endKey = rcKey.AppendKey(backend.KeyFromString(end)).ExactKey()
 	}
-	return tunnels, next, nil
+
+	return stream.TakeWhile(
+		stream.FilterMap(
+			s.Backend.Items(ctx, backend.ItemsParams{
+				StartKey: startKey,
+				EndKey:   endKey,
+			}),
+			mapFn, // mapping function
+		),
+		func(tunnel types.ReverseTunnel) bool {
+			// The range is not inclusive of the end key, so return early
+			// if the end has been reached.
+			return end == "" || tunnel.GetName() < end
+		})
 }
 
 // this combination of backoff parameters leads to worst-case total time spent

--- a/lib/services/local/presence_test.go
+++ b/lib/services/local/presence_test.go
@@ -1887,3 +1887,65 @@ func TestPresenceService_ListSemaphores(t *testing.T) {
 	})
 
 }
+
+func TestReverseTunnels_SkipsUnmarshalErrorsHittingPageBoundary(t *testing.T) {
+	ctx := t.Context()
+
+	const pageLimit = 64
+	const numberOfPages = 5
+
+	clock := clockwork.NewFakeClock()
+	mem, err := memory.New(memory.Config{
+		Context: t.Context(),
+		Clock:   clock,
+	})
+	require.NoError(t, err)
+	service := NewPresenceService(mem)
+
+	createResource := func(name string) {
+		rc, err := types.NewReverseTunnel(name, []string{"example.com:443"})
+		require.NoError(t, err)
+		_, err = service.UpsertReverseTunnel(ctx, rc)
+		require.NoError(t, err)
+	}
+
+	createMalformedApp := func(name string) {
+		_, err := mem.Put(ctx, backend.Item{
+			Key:   backend.NewKey(reverseTunnelsPrefix, name),
+			Value: []byte("not-valid-json"),
+		})
+		require.NoError(t, err)
+	}
+
+	for i := range pageLimit * numberOfPages {
+		key := fmt.Sprintf("r%d", i)
+		if i%2 == 0 {
+			createMalformedApp(key)
+		} else {
+			createResource(key)
+		}
+	}
+
+	page1, next, err := service.ListReverseTunnels(ctx, pageLimit, "")
+	require.NoError(t, err)
+	require.Len(t, page1, pageLimit)
+	require.NotEmpty(t, next)
+
+	page2, next, err := service.ListReverseTunnels(ctx, pageLimit, next)
+	require.NoError(t, err)
+	require.Len(t, page2, pageLimit)
+	require.NotEmpty(t, next)
+
+	page3, next, err := service.ListReverseTunnels(ctx, pageLimit, next)
+	require.NoError(t, err)
+	require.Len(t, page3, pageLimit/2)
+	require.Empty(t, next)
+
+	slices := [][]types.ReverseTunnel{page1, page2, page3}
+	for i := range len(slices) {
+		for j := i + 1; j < len(slices); j++ {
+			assert.NotEqual(t, slices[i], slices[j], "slices %d and %d should differ", i, j)
+		}
+	}
+
+}

--- a/lib/services/local/trust.go
+++ b/lib/services/local/trust.go
@@ -30,12 +30,12 @@ import (
 	"github.com/gravitational/trace"
 
 	"github.com/gravitational/teleport"
-	"github.com/gravitational/teleport/api/defaults"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/backend"
 	"github.com/gravitational/teleport/lib/itertools/stream"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/services/local/generic"
+	logutils "github.com/gravitational/teleport/lib/utils/log"
 )
 
 // CA is local implementation of Trust service that
@@ -1106,45 +1106,50 @@ func (s *CA) GetRemoteClusters(ctx context.Context) ([]types.RemoteCluster, erro
 }
 
 // ListRemoteClusters returns a page of remote clusters
-func (s *CA) ListRemoteClusters(
-	ctx context.Context, pageSize int, pageToken string,
-) ([]types.RemoteCluster, string, error) {
-	rangeStart := backend.NewKey(remoteClustersPrefix, pageToken)
-	rangeEnd := backend.RangeEnd(backend.ExactKey(remoteClustersPrefix))
+func (s *CA) ListRemoteClusters(ctx context.Context, pageSize int, pageToken string) ([]types.RemoteCluster, string, error) {
+	return generic.CollectPageAndCursor(s.rangeRemoteClusters(ctx, pageToken, ""), pageSize, func(c types.RemoteCluster) string {
+		return backend.GetPaginationKey(c)
+	})
+}
 
-	// Adjust page size, so it can't be too large.
-	if pageSize <= 0 || pageSize > defaults.DefaultChunkSize {
-		pageSize = defaults.DefaultChunkSize
-	}
-
-	limit := pageSize + 1
-
-	result, err := s.GetRange(ctx, rangeStart, rangeEnd, limit)
-	if err != nil {
-		return nil, "", trace.Wrap(err)
-	}
-
-	clusters := make([]types.RemoteCluster, 0, len(result.Items))
-	for _, item := range result.Items {
+// rangeRemoteClusters returns remote cluster resources within the range [start, end).
+func (s *CA) rangeRemoteClusters(ctx context.Context, start, end string) iter.Seq2[types.RemoteCluster, error] {
+	mapFn := func(item backend.Item) (types.RemoteCluster, bool) {
 		cluster, err := services.UnmarshalRemoteCluster(item.Value,
 			services.WithExpires(item.Expires),
-			services.WithRevision(item.Revision),
-		)
+			services.WithRevision(item.Revision))
+
 		if err != nil {
-			slog.WarnContext(ctx, "Skipping item during ListRemoteClusters because conversion from backend item failed", "key", item.Key, "error", err)
-			continue
+			slog.WarnContext(ctx, "Failed to unmarshal remote cluster from backend item",
+				"key", logutils.StringerAttr(item.Key),
+				"error", err,
+			)
+			return nil, false
 		}
-		clusters = append(clusters, cluster)
+
+		return cluster, true
 	}
 
-	next := ""
-	if len(clusters) > pageSize {
-		next = backend.GetPaginationKey(clusters[pageSize])
-		clear(clusters[pageSize:])
-		// Truncate the last item that was used to determine next row existence.
-		clusters = clusters[:pageSize]
+	rcKey := backend.NewKey(remoteClustersPrefix)
+	startKey := rcKey.AppendKey(backend.KeyFromString(start))
+	endKey := backend.RangeEnd(rcKey)
+	if end != "" {
+		endKey = rcKey.AppendKey(backend.KeyFromString(end)).ExactKey()
 	}
-	return clusters, next, nil
+
+	return stream.TakeWhile(
+		stream.FilterMap(
+			s.Backend.Items(ctx, backend.ItemsParams{
+				StartKey: startKey,
+				EndKey:   endKey,
+			}),
+			mapFn, // mapping function
+		),
+		func(cluster types.RemoteCluster) bool {
+			// The range is not inclusive of the end key, so return early
+			// if the end has been reached.
+			return end == "" || cluster.GetName() < end
+		})
 }
 
 // GetRemoteCluster returns a remote cluster by name

--- a/lib/services/local/trust_test.go
+++ b/lib/services/local/trust_test.go
@@ -29,11 +29,13 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/auth/testauthority"
+	"github.com/gravitational/teleport/lib/backend"
 	"github.com/gravitational/teleport/lib/backend/memory"
 	"github.com/gravitational/teleport/lib/itertools/stream"
 	"github.com/gravitational/teleport/lib/tlsca"
@@ -653,4 +655,66 @@ func newCertAuthority(t *testing.T, caType types.CertAuthType, domain string) ty
 	require.NoError(t, err)
 
 	return ca
+}
+
+func TestRemoteCluster_SkipsUnmarshalErrorsHittingPageBoundary(t *testing.T) {
+	ctx := t.Context()
+
+	const pageLimit = 64
+	const numberOfPages = 5
+
+	clock := clockwork.NewFakeClock()
+	mem, err := memory.New(memory.Config{
+		Context: t.Context(),
+		Clock:   clock,
+	})
+	require.NoError(t, err)
+	service := NewCAService(mem)
+
+	createResource := func(name string) {
+		rc, err := types.NewRemoteCluster(name)
+		require.NoError(t, err)
+		_, err = service.CreateRemoteCluster(ctx, rc)
+		require.NoError(t, err)
+	}
+
+	createMalformedApp := func(name string) {
+		_, err := mem.Put(ctx, backend.Item{
+			Key:   backend.NewKey(remoteClustersPrefix, name),
+			Value: []byte("not-valid-json"),
+		})
+		require.NoError(t, err)
+	}
+
+	for i := range pageLimit * numberOfPages {
+		key := fmt.Sprintf("r%d", i)
+		if i%2 == 0 {
+			createMalformedApp(key)
+		} else {
+			createResource(key)
+		}
+	}
+
+	page1, next, err := service.ListRemoteClusters(ctx, pageLimit, "")
+	require.NoError(t, err)
+	require.Len(t, page1, pageLimit)
+	require.NotEmpty(t, next)
+
+	page2, next, err := service.ListRemoteClusters(ctx, pageLimit, next)
+	require.NoError(t, err)
+	require.Len(t, page2, pageLimit)
+	require.NotEmpty(t, next)
+
+	page3, next, err := service.ListRemoteClusters(ctx, pageLimit, next)
+	require.NoError(t, err)
+	require.Len(t, page3, pageLimit/2)
+	require.Empty(t, next)
+
+	slices := [][]types.RemoteCluster{page1, page2, page3}
+	for i := range len(slices) {
+		for j := i + 1; j < len(slices); j++ {
+			assert.NotEqual(t, slices[i], slices[j], "slices %d and %d should differ", i, j)
+		}
+	}
+
 }

--- a/lib/services/local/usertoken.go
+++ b/lib/services/local/usertoken.go
@@ -45,7 +45,6 @@ func (s *IdentityService) ListUserTokens(ctx context.Context, limit int, startKe
 	for item, err := range s.Backend.Items(ctx, backend.ItemsParams{
 		StartKey: rangeStart,
 		EndKey:   rangeEnd,
-		Limit:    limit + 1,
 	}) {
 		if err != nil {
 			return nil, "", trace.Wrap(err)

--- a/lib/services/local/usertoken_test.go
+++ b/lib/services/local/usertoken_test.go
@@ -149,7 +149,7 @@ func TestIdentityService_ListUserTokens(t *testing.T) {
 	})
 }
 
-func TestListUserTokens_SkipsUnmarshalErrorsHittingPageBounrary(t *testing.T) {
+func TestListUserTokens_SkipsUnmarshalErrorsHittingPageBoundary(t *testing.T) {
 	ctx := t.Context()
 
 	const pageLimit = 64

--- a/lib/services/local/usertoken_test.go
+++ b/lib/services/local/usertoken_test.go
@@ -19,11 +19,13 @@
 package local
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/jonboulle/clockwork"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/testing/protocmp"
 
@@ -145,4 +147,76 @@ func TestIdentityService_ListUserTokens(t *testing.T) {
 			protocmp.Transform(),
 		))
 	})
+}
+
+func TestListUserTokens_SkipsUnmarshalErrorsHittingPageBounrary(t *testing.T) {
+	ctx := t.Context()
+
+	const pageLimit = 64
+	const numberOfPages = 5
+
+	clock := clockwork.NewFakeClock()
+	mem, err := memory.New(memory.Config{
+		Context: t.Context(),
+		Clock:   clock,
+	})
+	require.NoError(t, err)
+
+	service, err := NewIdentityService(backend.NewSanitizer(mem))
+	require.NoError(t, err)
+
+	createUserToken := func(name, user string) {
+		_, err := service.CreateUserToken(ctx, &types.UserTokenV3{
+			Kind:    types.KindUserToken,
+			Version: types.V3,
+			Metadata: types.Metadata{
+				Name: name,
+			},
+			Spec: types.UserTokenSpecV3{
+				User:    user,
+				Created: time.Now(),
+			},
+		})
+		require.NoError(t, err)
+	}
+
+	createMalformedUserToken := func(name string) {
+		_, err := mem.Put(ctx, backend.Item{
+			Key:   backend.NewKey(userTokenPrefix, name, paramsPrefix),
+			Value: []byte("not-valid-json"),
+		})
+		require.NoError(t, err)
+	}
+
+	for i := range pageLimit * numberOfPages {
+		key := fmt.Sprintf("r%d", i)
+		if i%2 == 0 {
+			createMalformedUserToken(key)
+		} else {
+			createUserToken(key, fmt.Sprintf("user%d", i))
+		}
+	}
+
+	page1, next, err := service.ListUserTokens(ctx, pageLimit, "")
+	require.NoError(t, err)
+	require.Len(t, page1, pageLimit)
+	require.NotEmpty(t, next)
+
+	page2, next, err := service.ListUserTokens(ctx, pageLimit, next)
+	require.NoError(t, err)
+	require.Len(t, page2, pageLimit)
+	require.NotEmpty(t, next)
+
+	page3, next, err := service.ListUserTokens(ctx, pageLimit, next)
+	require.NoError(t, err)
+	require.Len(t, page3, pageLimit/2)
+	require.Empty(t, next)
+
+	slices := [][]types.UserToken{page1, page2, page3}
+	for i := range len(slices) {
+		for j := i + 1; j < len(slices); j++ {
+			assert.NotEqual(t, slices[i], slices[j], "slices %d and %d should differ", i, j)
+		}
+	}
+
 }


### PR DESCRIPTION
The List calls in generic in a handful of handrolled implementations would pass `Limit` to `s.Backend.Items`. This means that if enough items fail to unmarshall in the loop we could exit early and never return the next page token.

Similar problem was found in List{Plugins,ReverseTunnels,RemoteClusters}, these have been refactored to follow recommendations set out by RFD153. 

