### PR TITLE
Fix missing assignment of ctx including tracing span

### DIFF
--- a/lib/auth/init.go
+++ b/lib/auth/init.go
@@ -663,24 +663,24 @@ func initCluster(ctx context.Context, cfg InitConfig, asrv *Server) error {
 	})
 
 	g.Go(func() error {
-		_, span := cfg.Tracer.Start(gctx, "auth/SetStaticTokens")
+		ctx, span := cfg.Tracer.Start(gctx, "auth/SetStaticTokens")
 		defer span.End()
 		asrv.logger.InfoContext(ctx, "Updating cluster configuration", "static_tokens", cfg.StaticTokens)
 		return trace.Wrap(asrv.SetStaticTokens(cfg.StaticTokens))
 	})
 
 	g.Go(func() error {
-		_, span := cfg.Tracer.Start(gctx, "auth/SetStaticScopedTokens")
+		ctx, span := cfg.Tracer.Start(gctx, "auth/SetStaticScopedTokens")
 		defer span.End()
 		if cfg.StaticScopedTokens != nil {
-			return trace.Wrap(asrv.SetStaticScopedTokens(gctx, cfg.StaticScopedTokens))
+			return trace.Wrap(asrv.SetStaticScopedTokens(ctx, cfg.StaticScopedTokens))
 		}
 		return nil
 	})
 
 	var cn types.ClusterName
 	g.Go(func() error {
-		_, span := cfg.Tracer.Start(gctx, "auth/SetClusterName")
+		ctx, span := cfg.Tracer.Start(gctx, "auth/SetClusterName")
 		defer span.End()
 
 		// The first Auth Server that starts gets to set the name of the cluster.

--- a/lib/auth/migration/0001_db_ca.go
+++ b/lib/auth/migration/0001_db_ca.go
@@ -97,7 +97,8 @@ func (d createDBAuthority) Up(ctx context.Context, b backend.Backend) error {
 
 // Down deletes any existing CAs of the new CA type for all clusters.
 func (d createDBAuthority) Down(ctx context.Context, b backend.Backend) error {
-	ctx, span := tracer.Start(ctx, "CreateDBAuthorityDown")
+	// Nota Bene: If at a later date this function consumes ctx, ensure you use the value returned by tracer.Start as to ensure span propagation works correctly.
+	_, span := tracer.Start(ctx, "CreateDBAuthorityDown")
 	defer span.End()
 
 	if d.trustServiceFn == nil {

--- a/lib/auth/migration/0001_db_ca.go
+++ b/lib/auth/migration/0001_db_ca.go
@@ -97,8 +97,8 @@ func (d createDBAuthority) Up(ctx context.Context, b backend.Backend) error {
 
 // Down deletes any existing CAs of the new CA type for all clusters.
 func (d createDBAuthority) Down(ctx context.Context, b backend.Backend) error {
-	// Nota Bene: If at a later date this function consumes ctx, ensure you use the value returned by tracer.Start as to ensure span propagation works correctly.
-	_, span := tracer.Start(ctx, "CreateDBAuthorityDown")
+	//nolint:ineffassign,staticcheck // ctx is shadowed so future downstream calls inherit the span.
+	ctx, span := tracer.Start(ctx, "CreateDBAuthorityDown")
 	defer span.End()
 
 	if d.trustServiceFn == nil {

--- a/lib/auth/migration/0001_db_ca.go
+++ b/lib/auth/migration/0001_db_ca.go
@@ -97,7 +97,7 @@ func (d createDBAuthority) Up(ctx context.Context, b backend.Backend) error {
 
 // Down deletes any existing CAs of the new CA type for all clusters.
 func (d createDBAuthority) Down(ctx context.Context, b backend.Backend) error {
-	_, span := tracer.Start(ctx, "CreateDBAuthorityDown")
+	ctx, span := tracer.Start(ctx, "CreateDBAuthorityDown")
 	defer span.End()
 
 	if d.trustServiceFn == nil {

--- a/lib/cache/cache.go
+++ b/lib/cache/cache.go
@@ -1739,7 +1739,7 @@ func (c *Cache) listResourcesFallback(ctx context.Context, req authproto.ListRes
 }
 
 func (c *Cache) listResources(ctx context.Context, req authproto.ListResourcesRequest) (*types.ListResourcesResponse, error) {
-	_, span := c.Tracer.Start(ctx, "cache/listResources")
+	ctx, span := c.Tracer.Start(ctx, "cache/listResources")
 	defer span.End()
 
 	filter, err := services.MatchResourceFilterFromListResourceRequest(&req)

--- a/lib/cache/cache.go
+++ b/lib/cache/cache.go
@@ -1739,8 +1739,8 @@ func (c *Cache) listResourcesFallback(ctx context.Context, req authproto.ListRes
 }
 
 func (c *Cache) listResources(ctx context.Context, req authproto.ListResourcesRequest) (*types.ListResourcesResponse, error) {
-	// Nota Bene: If at a later date this function consumes ctx, ensure you use the value returned by tracer.Start as to ensure span propagation works correctly.
-	_, span := c.Tracer.Start(ctx, "cache/listResources")
+	//nolint:ineffassign,staticcheck // ctx is shadowed so future downstream calls inherit the span.
+	ctx, span := c.Tracer.Start(ctx, "cache/listResources")
 	defer span.End()
 
 	filter, err := services.MatchResourceFilterFromListResourceRequest(&req)

--- a/lib/cache/cache.go
+++ b/lib/cache/cache.go
@@ -1739,7 +1739,8 @@ func (c *Cache) listResourcesFallback(ctx context.Context, req authproto.ListRes
 }
 
 func (c *Cache) listResources(ctx context.Context, req authproto.ListResourcesRequest) (*types.ListResourcesResponse, error) {
-	ctx, span := c.Tracer.Start(ctx, "cache/listResources")
+	// Nota Bene: If at a later date this function consumes ctx, ensure you use the value returned by tracer.Start as to ensure span propagation works correctly.
+	_, span := c.Tracer.Start(ctx, "cache/listResources")
 	defer span.End()
 
 	filter, err := services.MatchResourceFilterFromListResourceRequest(&req)

--- a/lib/cache/plugins.go
+++ b/lib/cache/plugins.go
@@ -69,7 +69,7 @@ func newPluginsCollection(service services.Plugins, watch types.WatchKind) (*col
 // If the cache is not healthy, it falls back to fetching the plugin from the upstream.
 // The `withSecrets` flag controls whether secrets should be included in the result.
 func (c *Cache) GetPlugin(ctx context.Context, name string, withSecrets bool) (types.Plugin, error) {
-	_, span := c.Tracer.Start(ctx, "cache/GetPlugin")
+	ctx, span := c.Tracer.Start(ctx, "cache/GetPlugin")
 	defer span.End()
 
 	rg, err := acquireReadGuard(c, c.collections.plugins)
@@ -100,7 +100,7 @@ func (c *Cache) GetPlugin(ctx context.Context, name string, withSecrets bool) (t
 // If the cache is not healthy, it falls back to fetching the plugin from the upstream.
 // The `withSecrets` flag controls whether secrets are included in the response.
 func (c *Cache) GetPlugins(ctx context.Context, withSecrets bool) ([]types.Plugin, error) {
-	_, span := c.Tracer.Start(ctx, "cache/GetPlugins")
+	ctx, span := c.Tracer.Start(ctx, "cache/GetPlugins")
 	defer span.End()
 
 	rg, err := acquireReadGuard(c, c.collections.plugins)
@@ -131,7 +131,7 @@ func (c *Cache) GetPlugins(ctx context.Context, withSecrets bool) ([]types.Plugi
 // If the cache is not healthy, it fetches directly from the backend.
 // The `withSecrets` flag controls inclusion of secrets in the result.
 func (c *Cache) ListPlugins(ctx context.Context, limit int, startKey string, withSecrets bool) ([]types.Plugin, string, error) {
-	_, span := c.Tracer.Start(ctx, "cache/ListPlugins")
+	ctx, span := c.Tracer.Start(ctx, "cache/ListPlugins")
 	defer span.End()
 
 	rg, err := acquireReadGuard(c, c.collections.plugins)
@@ -167,7 +167,7 @@ func (c *Cache) ListPlugins(ctx context.Context, limit int, startKey string, wit
 
 // HasPluginType will return true if a plugin of the given type is registered.
 func (c *Cache) HasPluginType(ctx context.Context, pluginType types.PluginType) (bool, error) {
-	_, span := c.Tracer.Start(ctx, "cache/HasPluginType")
+	ctx, span := c.Tracer.Start(ctx, "cache/HasPluginType")
 	defer span.End()
 
 	rg, err := acquireReadGuard(c, c.collections.plugins)

--- a/lib/cache/remote_cluster.go
+++ b/lib/cache/remote_cluster.go
@@ -240,7 +240,7 @@ func (c *Cache) GetRemoteCluster(ctx context.Context, clusterName string) (types
 
 // ListRemoteClusters returns a page of remote clusters.
 func (c *Cache) ListRemoteClusters(ctx context.Context, pageSize int, nextToken string) ([]types.RemoteCluster, string, error) {
-	_, span := c.Tracer.Start(ctx, "cache/ListRemoteClusters")
+	ctx, span := c.Tracer.Start(ctx, "cache/ListRemoteClusters")
 	defer span.End()
 
 	lister := genericLister[types.RemoteCluster, remoteClusterIndex]{

--- a/lib/cache/tokens.go
+++ b/lib/cache/tokens.go
@@ -67,7 +67,7 @@ func newStaticTokensCollection(c services.ClusterConfiguration, w types.WatchKin
 
 // GetStaticTokens gets the list of static tokens used to provision nodes.
 func (c *Cache) GetStaticTokens(ctx context.Context) (types.StaticTokens, error) {
-	_, span := c.Tracer.Start(ctx, "cache/GetStaticTokens")
+	ctx, span := c.Tracer.Start(ctx, "cache/GetStaticTokens")
 	defer span.End()
 
 	rg, err := acquireReadGuard(c, c.collections.staticTokens)

--- a/lib/cache/users.go
+++ b/lib/cache/users.go
@@ -83,7 +83,7 @@ func newUserCollection(upstream services.UsersService, w types.WatchKind) (*coll
 
 // GetUser is a part of auth.Cache implementation.
 func (c *Cache) GetUser(ctx context.Context, name string, withSecrets bool) (types.User, error) {
-	_, span := c.Tracer.Start(ctx, "cache/GetUser")
+	ctx, span := c.Tracer.Start(ctx, "cache/GetUser")
 	defer span.End()
 
 	if withSecrets { // cache never tracks user secrets
@@ -125,7 +125,7 @@ func (c *Cache) GetUser(ctx context.Context, name string, withSecrets bool) (typ
 
 // GetUsers is a part of auth.Cache implementation
 func (c *Cache) GetUsers(ctx context.Context, withSecrets bool) ([]types.User, error) {
-	_, span := c.Tracer.Start(ctx, "cache/GetUsers")
+	ctx, span := c.Tracer.Start(ctx, "cache/GetUsers")
 	defer span.End()
 
 	if withSecrets { // cache never tracks user secrets
@@ -157,7 +157,7 @@ func (c *Cache) GetUsers(ctx context.Context, withSecrets bool) ([]types.User, e
 
 // ListUsers returns a page of users.
 func (c *Cache) ListUsers(ctx context.Context, req *userspb.ListUsersRequest) (*userspb.ListUsersResponse, error) {
-	_, span := c.Tracer.Start(ctx, "cache/ListUsers")
+	ctx, span := c.Tracer.Start(ctx, "cache/ListUsers")
 	defer span.End()
 
 	if req.WithSecrets { // cache never tracks user secrets

--- a/lib/client/api.go
+++ b/lib/client/api.go
@@ -1387,10 +1387,8 @@ func (tc *TeleportClient) ProfileStatus() (*ProfileStatus, error) {
 // LoadKeyForCluster fetches a cluster-specific SSH key and loads it into the
 // SSH agent.
 func (tc *TeleportClient) LoadKeyForCluster(ctx context.Context, clusterName string) error {
-	// Nota Bene: If at a later date this function consumes ctx, ensure you
-	// use the value returned by tracer.Start as to ensure span propagation
-	// works correctly.
-	_, span := tc.Tracer.Start(
+	//nolint:ineffassign,staticcheck // ctx is shadowed so future downstream calls inherit the span.
+	ctx, span := tc.Tracer.Start(
 		ctx,
 		"teleportClient/LoadKeyForCluster",
 		oteltrace.WithSpanKind(oteltrace.SpanKindClient),
@@ -1449,10 +1447,8 @@ func (tc *TeleportClient) LocalAgent() *LocalKeyAgent {
 
 // RootClusterName returns root cluster name.
 func (tc *TeleportClient) RootClusterName(ctx context.Context) (string, error) {
-	// Nota Bene: If at a later date this function consumes ctx, ensure you
-	// use the value returned by tracer.Start as to ensure span propagation
-	// works correctly.
-	_, span := tc.Tracer.Start(ctx,
+	//nolint:ineffassign,staticcheck // ctx is shadowed so future downstream calls inherit the span.
+	ctx, span := tc.Tracer.Start(ctx,
 		"teleportClient/RootClusterName",
 		oteltrace.WithSpanKind(oteltrace.SpanKindClient),
 	)
@@ -4402,10 +4398,8 @@ func (tc *TeleportClient) ConnectToRootCluster(ctx context.Context, keyRing *Key
 // activateKeyRing saves the target session cert into the local
 // keystore (and into the ssh-agent) for future use.
 func (tc *TeleportClient) activateKeyRing(ctx context.Context, keyRing *KeyRing) error {
-	// Nota Bene: If at a later date this function consumes ctx, ensure you
-	// use the value returned by tracer.Start as to ensure span propagation
-	// works correctly.
-	_, span := tc.Tracer.Start(
+	//nolint:ineffassign,staticcheck // ctx is shadowed so future downstream calls inherit the span.
+	ctx, span := tc.Tracer.Start(
 		ctx,
 		"teleportClient/activateKey",
 		oteltrace.WithSpanKind(oteltrace.SpanKindClient),
@@ -4893,10 +4887,8 @@ func (tc *TeleportClient) applyAuthSettings(authSettings webclient.Authenticatio
 
 // AddTrustedCA adds a new CA as trusted CA for this client, used in tests
 func (tc *TeleportClient) AddTrustedCA(ctx context.Context, ca types.CertAuthority) error {
-	// Nota Bene: If at a later date this function consumes ctx, ensure you
-	// use the value returned by tracer.Start as to ensure span propagation
-	// works correctly.
-	_, span := tc.Tracer.Start(
+	//nolint:ineffassign,staticcheck // ctx is shadowed so future downstream calls inherit the span.
+	ctx, span := tc.Tracer.Start(
 		ctx,
 		"teleportClient/AddTrustedCA",
 		oteltrace.WithSpanKind(oteltrace.SpanKindClient),
@@ -5391,10 +5383,8 @@ func (tc *TeleportClient) IsALPNConnUpgradeRequiredForWebProxy(ctx context.Conte
 
 // RootClusterCACertPool returns a *x509.CertPool with the root cluster CA.
 func (tc *TeleportClient) RootClusterCACertPool(ctx context.Context) (*x509.CertPool, error) {
-	// Nota Bene: If at a later date this function consumes ctx, ensure you
-	// use the value returned by tracer.Start as to ensure span propagation
-	// works correctly.
-	_, span := tc.Tracer.Start(
+	//nolint:ineffassign,staticcheck // ctx is shadowed so future downstream calls inherit the span.
+	ctx, span := tc.Tracer.Start(
 		ctx,
 		"teleportClient/RootClusterCACertPool",
 		oteltrace.WithSpanKind(oteltrace.SpanKindClient),
@@ -5417,10 +5407,8 @@ func (tc *TeleportClient) RootClusterCACertPool(ctx context.Context) (*x509.Cert
 
 // RootClusterCACertPoolPEM returns a PEM-encoded cert pool with the root cluster CA.
 func (tc *TeleportClient) RootClusterCACertPoolPEM(ctx context.Context) ([]byte, error) {
-	// Nota Bene: If at a later date this function consumes ctx, ensure you
-	// use the value returned by tracer.Start as to ensure span propagation
-	// works correctly.
-	_, span := tc.Tracer.Start(
+	//nolint:ineffassign,staticcheck // ctx is shadowed so future downstream calls inherit the span.
+	ctx, span := tc.Tracer.Start(
 		ctx,
 		"teleportClient/RootClusterCACertPoolPEM",
 		oteltrace.WithSpanKind(oteltrace.SpanKindClient),

--- a/lib/client/api.go
+++ b/lib/client/api.go
@@ -1387,7 +1387,10 @@ func (tc *TeleportClient) ProfileStatus() (*ProfileStatus, error) {
 // LoadKeyForCluster fetches a cluster-specific SSH key and loads it into the
 // SSH agent.
 func (tc *TeleportClient) LoadKeyForCluster(ctx context.Context, clusterName string) error {
-	ctx, span := tc.Tracer.Start(
+	// Nota Bene: If at a later date this function consumes ctx, ensure you
+	// use the value returned by tracer.Start as to ensure span propagation
+	// works correctly.
+	_, span := tc.Tracer.Start(
 		ctx,
 		"teleportClient/LoadKeyForCluster",
 		oteltrace.WithSpanKind(oteltrace.SpanKindClient),
@@ -1446,7 +1449,10 @@ func (tc *TeleportClient) LocalAgent() *LocalKeyAgent {
 
 // RootClusterName returns root cluster name.
 func (tc *TeleportClient) RootClusterName(ctx context.Context) (string, error) {
-	ctx, span := tc.Tracer.Start(ctx,
+	// Nota Bene: If at a later date this function consumes ctx, ensure you
+	// use the value returned by tracer.Start as to ensure span propagation
+	// works correctly.
+	_, span := tc.Tracer.Start(ctx,
 		"teleportClient/RootClusterName",
 		oteltrace.WithSpanKind(oteltrace.SpanKindClient),
 	)
@@ -4396,7 +4402,10 @@ func (tc *TeleportClient) ConnectToRootCluster(ctx context.Context, keyRing *Key
 // activateKeyRing saves the target session cert into the local
 // keystore (and into the ssh-agent) for future use.
 func (tc *TeleportClient) activateKeyRing(ctx context.Context, keyRing *KeyRing) error {
-	ctx, span := tc.Tracer.Start(
+	// Nota Bene: If at a later date this function consumes ctx, ensure you
+	// use the value returned by tracer.Start as to ensure span propagation
+	// works correctly.
+	_, span := tc.Tracer.Start(
 		ctx,
 		"teleportClient/activateKey",
 		oteltrace.WithSpanKind(oteltrace.SpanKindClient),
@@ -4884,7 +4893,10 @@ func (tc *TeleportClient) applyAuthSettings(authSettings webclient.Authenticatio
 
 // AddTrustedCA adds a new CA as trusted CA for this client, used in tests
 func (tc *TeleportClient) AddTrustedCA(ctx context.Context, ca types.CertAuthority) error {
-	ctx, span := tc.Tracer.Start(
+	// Nota Bene: If at a later date this function consumes ctx, ensure you
+	// use the value returned by tracer.Start as to ensure span propagation
+	// works correctly.
+	_, span := tc.Tracer.Start(
 		ctx,
 		"teleportClient/AddTrustedCA",
 		oteltrace.WithSpanKind(oteltrace.SpanKindClient),
@@ -5379,7 +5391,10 @@ func (tc *TeleportClient) IsALPNConnUpgradeRequiredForWebProxy(ctx context.Conte
 
 // RootClusterCACertPool returns a *x509.CertPool with the root cluster CA.
 func (tc *TeleportClient) RootClusterCACertPool(ctx context.Context) (*x509.CertPool, error) {
-	ctx, span := tc.Tracer.Start(
+	// Nota Bene: If at a later date this function consumes ctx, ensure you
+	// use the value returned by tracer.Start as to ensure span propagation
+	// works correctly.
+	_, span := tc.Tracer.Start(
 		ctx,
 		"teleportClient/RootClusterCACertPool",
 		oteltrace.WithSpanKind(oteltrace.SpanKindClient),
@@ -5402,7 +5417,10 @@ func (tc *TeleportClient) RootClusterCACertPool(ctx context.Context) (*x509.Cert
 
 // RootClusterCACertPoolPEM returns a PEM-encoded cert pool with the root cluster CA.
 func (tc *TeleportClient) RootClusterCACertPoolPEM(ctx context.Context) ([]byte, error) {
-	ctx, span := tc.Tracer.Start(
+	// Nota Bene: If at a later date this function consumes ctx, ensure you
+	// use the value returned by tracer.Start as to ensure span propagation
+	// works correctly.
+	_, span := tc.Tracer.Start(
 		ctx,
 		"teleportClient/RootClusterCACertPoolPEM",
 		oteltrace.WithSpanKind(oteltrace.SpanKindClient),

--- a/lib/client/api.go
+++ b/lib/client/api.go
@@ -1387,7 +1387,7 @@ func (tc *TeleportClient) ProfileStatus() (*ProfileStatus, error) {
 // LoadKeyForCluster fetches a cluster-specific SSH key and loads it into the
 // SSH agent.
 func (tc *TeleportClient) LoadKeyForCluster(ctx context.Context, clusterName string) error {
-	_, span := tc.Tracer.Start(
+	ctx, span := tc.Tracer.Start(
 		ctx,
 		"teleportClient/LoadKeyForCluster",
 		oteltrace.WithSpanKind(oteltrace.SpanKindClient),
@@ -1446,8 +1446,7 @@ func (tc *TeleportClient) LocalAgent() *LocalKeyAgent {
 
 // RootClusterName returns root cluster name.
 func (tc *TeleportClient) RootClusterName(ctx context.Context) (string, error) {
-	_, span := tc.Tracer.Start(
-		ctx,
+	ctx, span := tc.Tracer.Start(ctx,
 		"teleportClient/RootClusterName",
 		oteltrace.WithSpanKind(oteltrace.SpanKindClient),
 	)
@@ -4103,7 +4102,7 @@ func (tc *TeleportClient) updatePrivateKeyPolicy(policy keys.PrivateKeyPolicy) e
 
 // GetNewLoginKeyRing gets a KeyRing with new private keys for login.
 func (tc *TeleportClient) GetNewLoginKeyRing(ctx context.Context) (keyRing *KeyRing, err error) {
-	_, span := tc.Tracer.Start(
+	ctx, span := tc.Tracer.Start(
 		ctx,
 		"teleportClient/GetNewLoginKeyRing",
 		oteltrace.WithSpanKind(oteltrace.SpanKindClient),
@@ -4397,7 +4396,7 @@ func (tc *TeleportClient) ConnectToRootCluster(ctx context.Context, keyRing *Key
 // activateKeyRing saves the target session cert into the local
 // keystore (and into the ssh-agent) for future use.
 func (tc *TeleportClient) activateKeyRing(ctx context.Context, keyRing *KeyRing) error {
-	_, span := tc.Tracer.Start(
+	ctx, span := tc.Tracer.Start(
 		ctx,
 		"teleportClient/activateKey",
 		oteltrace.WithSpanKind(oteltrace.SpanKindClient),
@@ -4885,7 +4884,7 @@ func (tc *TeleportClient) applyAuthSettings(authSettings webclient.Authenticatio
 
 // AddTrustedCA adds a new CA as trusted CA for this client, used in tests
 func (tc *TeleportClient) AddTrustedCA(ctx context.Context, ca types.CertAuthority) error {
-	_, span := tc.Tracer.Start(
+	ctx, span := tc.Tracer.Start(
 		ctx,
 		"teleportClient/AddTrustedCA",
 		oteltrace.WithSpanKind(oteltrace.SpanKindClient),
@@ -5380,7 +5379,7 @@ func (tc *TeleportClient) IsALPNConnUpgradeRequiredForWebProxy(ctx context.Conte
 
 // RootClusterCACertPool returns a *x509.CertPool with the root cluster CA.
 func (tc *TeleportClient) RootClusterCACertPool(ctx context.Context) (*x509.CertPool, error) {
-	_, span := tc.Tracer.Start(
+	ctx, span := tc.Tracer.Start(
 		ctx,
 		"teleportClient/RootClusterCACertPool",
 		oteltrace.WithSpanKind(oteltrace.SpanKindClient),
@@ -5403,7 +5402,7 @@ func (tc *TeleportClient) RootClusterCACertPool(ctx context.Context) (*x509.Cert
 
 // RootClusterCACertPoolPEM returns a PEM-encoded cert pool with the root cluster CA.
 func (tc *TeleportClient) RootClusterCACertPoolPEM(ctx context.Context) ([]byte, error) {
-	_, span := tc.Tracer.Start(
+	ctx, span := tc.Tracer.Start(
 		ctx,
 		"teleportClient/RootClusterCACertPoolPEM",
 		oteltrace.WithSpanKind(oteltrace.SpanKindClient),

--- a/lib/kube/proxy/transport.go
+++ b/lib/kube/proxy/transport.go
@@ -231,7 +231,7 @@ func (f *Forwarder) getTLSConfigForLeafCluster(clusterName string) (*tls.Config,
 // in a remote Teleport cluster via the reverse tunnel.
 func (f *Forwarder) remoteClusterDialer(clusterName string) dialContextFunc {
 	return func(ctx context.Context, _, _ string) (net.Conn, error) {
-		_, span := f.cfg.tracer.Start(
+		ctx, span := f.cfg.tracer.Start(
 			ctx,
 			"kube.Forwarder/remoteClusterDiater",
 			oteltrace.WithSpanKind(oteltrace.SpanKindClient),
@@ -302,7 +302,7 @@ func (f *Forwarder) localClusterDialer(kubeClusterName, scope string, opts ...co
 		o(&opt)
 	}
 	return func(ctx context.Context, _, _ string) (net.Conn, error) {
-		_, span := f.cfg.tracer.Start(
+		ctx, span := f.cfg.tracer.Start(
 			ctx,
 			"kube.Forwarder/localClusterDiater",
 			oteltrace.WithSpanKind(oteltrace.SpanKindClient),

--- a/lib/proxy/router.go
+++ b/lib/proxy/router.go
@@ -397,7 +397,7 @@ func (c *checkedPrefixWriter) Write(p []byte) (int, error) {
 // getRemoteCluster looks up the provided clusterName to determine if a remote cluster exists with
 // that name and determines if the user has access to it.
 func (r *Router) getRemoteCluster(ctx context.Context, clusterName string, clusterAccessChecker func(types.RemoteCluster) error) (reversetunnelclient.Cluster, error) {
-	_, span := r.tracer.Start(
+	ctx, span := r.tracer.Start(
 		ctx,
 		"router/getRemoteCluster",
 		oteltrace.WithAttributes(
@@ -615,7 +615,7 @@ func getServerWithResolver(ctx context.Context, scopePin *scopesv1.Pin, host, po
 // cluster. If the clusterName is an empty string then a connection to
 // the local auth server will be established.
 func (r *Router) DialSite(ctx context.Context, clusterName string, clientSrcAddr, clientDstAddr net.Addr) (_ net.Conn, err error) {
-	_, span := r.tracer.Start(
+	ctx, span := r.tracer.Start(
 		ctx,
 		"router/DialSite",
 		oteltrace.WithAttributes(

--- a/lib/srv/alpnproxy/auth/auth_proxy.go
+++ b/lib/srv/alpnproxy/auth/auth_proxy.go
@@ -151,7 +151,7 @@ func (s *AuthProxyDialerService) dialLocalAuthServer(ctx context.Context, client
 }
 
 func (s *AuthProxyDialerService) dialRemoteAuthServer(ctx context.Context, clusterName string, clientSrcAddr, clientDstAddr net.Addr) (net.Conn, error) {
-	_, span := s.tracer.Start(ctx, "authProxyDialerService/dialRemoteAuthServer",
+	ctx, span := s.tracer.Start(ctx, "authProxyDialerService/dialRemoteAuthServer",
 		oteltrace.WithSpanKind(oteltrace.SpanKindServer),
 		oteltrace.WithAttributes(
 			attribute.String("src_addr", fmt.Sprintf("%v", clientSrcAddr)),

--- a/lib/tbot/bot/destination/directory.go
+++ b/lib/tbot/bot/destination/directory.go
@@ -456,10 +456,8 @@ func (dd *Directory) Write(ctx context.Context, name string, data []byte) error 
 }
 
 func (dd *Directory) Read(ctx context.Context, name string) ([]byte, error) {
-	// Nota Bene: If at a later date this function consumes ctx, ensure you
-	// use the value returned by tracer.Start as to ensure span propagation
-	// works correctly.
-	_, span := tracer.Start(
+	//nolint:ineffassign,staticcheck // ctx is shadowed so future downstream calls inherit the span.
+	ctx, span := tracer.Start(
 		ctx,
 		"Directory/Read",
 		oteltrace.WithAttributes(attribute.String("name", name)),

--- a/lib/tbot/bot/destination/directory.go
+++ b/lib/tbot/bot/destination/directory.go
@@ -405,7 +405,7 @@ func (dd *Directory) verifyAndCorrectACL(ctx context.Context, subpath string) er
 }
 
 func (dd *Directory) Write(ctx context.Context, name string, data []byte) error {
-	_, span := tracer.Start(
+	ctx, span := tracer.Start(
 		ctx,
 		"Directory/Write",
 		oteltrace.WithAttributes(attribute.String("name", name)),
@@ -456,7 +456,7 @@ func (dd *Directory) Write(ctx context.Context, name string, data []byte) error 
 }
 
 func (dd *Directory) Read(ctx context.Context, name string) ([]byte, error) {
-	_, span := tracer.Start(
+	ctx, span := tracer.Start(
 		ctx,
 		"Directory/Read",
 		oteltrace.WithAttributes(attribute.String("name", name)),

--- a/lib/tbot/bot/destination/directory.go
+++ b/lib/tbot/bot/destination/directory.go
@@ -456,7 +456,10 @@ func (dd *Directory) Write(ctx context.Context, name string, data []byte) error 
 }
 
 func (dd *Directory) Read(ctx context.Context, name string) ([]byte, error) {
-	ctx, span := tracer.Start(
+	// Nota Bene: If at a later date this function consumes ctx, ensure you
+	// use the value returned by tracer.Start as to ensure span propagation
+	// works correctly.
+	_, span := tracer.Start(
 		ctx,
 		"Directory/Read",
 		oteltrace.WithAttributes(attribute.String("name", name)),

--- a/lib/tbot/bot/destination/memory.go
+++ b/lib/tbot/bot/destination/memory.go
@@ -85,7 +85,7 @@ func (dm *Memory) Verify(keys []string) error {
 }
 
 func (dm *Memory) Write(ctx context.Context, name string, data []byte) error {
-	_, span := tracer.Start(
+	ctx, span := tracer.Start(
 		ctx,
 		"Memory/Write",
 		oteltrace.WithAttributes(attribute.String("name", name)),
@@ -100,7 +100,7 @@ func (dm *Memory) Write(ctx context.Context, name string, data []byte) error {
 }
 
 func (dm *Memory) Read(ctx context.Context, name string) ([]byte, error) {
-	_, span := tracer.Start(
+	ctx, span := tracer.Start(
 		ctx,
 		"Memory/Read",
 		oteltrace.WithAttributes(attribute.String("name", name)),

--- a/lib/tbot/bot/destination/memory.go
+++ b/lib/tbot/bot/destination/memory.go
@@ -85,7 +85,10 @@ func (dm *Memory) Verify(keys []string) error {
 }
 
 func (dm *Memory) Write(ctx context.Context, name string, data []byte) error {
-	ctx, span := tracer.Start(
+	// Nota Bene: If at a later date this function consumes ctx, ensure you
+	// use the value returned by tracer.Start as to ensure span propagation
+	// works correctly.
+	_, span := tracer.Start(
 		ctx,
 		"Memory/Write",
 		oteltrace.WithAttributes(attribute.String("name", name)),
@@ -100,7 +103,10 @@ func (dm *Memory) Write(ctx context.Context, name string, data []byte) error {
 }
 
 func (dm *Memory) Read(ctx context.Context, name string) ([]byte, error) {
-	ctx, span := tracer.Start(
+	// Nota Bene: If at a later date this function consumes ctx, ensure you
+	// use the value returned by tracer.Start as to ensure span propagation
+	// works correctly.
+	_, span := tracer.Start(
 		ctx,
 		"Memory/Read",
 		oteltrace.WithAttributes(attribute.String("name", name)),

--- a/lib/tbot/bot/destination/memory.go
+++ b/lib/tbot/bot/destination/memory.go
@@ -85,10 +85,8 @@ func (dm *Memory) Verify(keys []string) error {
 }
 
 func (dm *Memory) Write(ctx context.Context, name string, data []byte) error {
-	// Nota Bene: If at a later date this function consumes ctx, ensure you
-	// use the value returned by tracer.Start as to ensure span propagation
-	// works correctly.
-	_, span := tracer.Start(
+	//nolint:ineffassign,staticcheck // ctx is shadowed so future downstream calls inherit the span.
+	ctx, span := tracer.Start(
 		ctx,
 		"Memory/Write",
 		oteltrace.WithAttributes(attribute.String("name", name)),
@@ -103,10 +101,8 @@ func (dm *Memory) Write(ctx context.Context, name string, data []byte) error {
 }
 
 func (dm *Memory) Read(ctx context.Context, name string) ([]byte, error) {
-	// Nota Bene: If at a later date this function consumes ctx, ensure you
-	// use the value returned by tracer.Start as to ensure span propagation
-	// works correctly.
-	_, span := tracer.Start(
+	//nolint:ineffassign,staticcheck // ctx is shadowed so future downstream calls inherit the span.
+	ctx, span := tracer.Start(
 		ctx,
 		"Memory/Read",
 		oteltrace.WithAttributes(attribute.String("name", name)),

--- a/lib/tbot/internal/identity/service.go
+++ b/lib/tbot/internal/identity/service.go
@@ -735,7 +735,7 @@ func botIdentityFromToken(
 	cfg Config,
 	authClient *apiclient.Client,
 ) (*identity.Identity, error) {
-	_, span := tracer.Start(ctx, "botIdentityFromToken")
+	ctx, span := tracer.Start(ctx, "botIdentityFromToken")
 	defer span.End()
 
 	log.InfoContext(ctx, "Fetching bot identity using token")

--- a/lib/tpm/validate.go
+++ b/lib/tpm/validate.go
@@ -147,8 +147,8 @@ func Validate(ctx context.Context, params ValidateParams) (*ValidatedTPM, error)
 func parseEK(
 	ctx context.Context, params ValidateParams,
 ) (*x509.Certificate, crypto.PublicKey, error) {
-	// Nota Bene: If at a later date this function consumes ctx, ensure you use the value returned by tracer.Start as to ensure span propagation works correctly.
-	_, span := tracer.Start(ctx, "parseEK")
+	//nolint:ineffassign,staticcheck // ctx is shadowed so future downstream calls inherit the span.
+	ctx, span := tracer.Start(ctx, "parseEK")
 	defer span.End()
 
 	ekCertPresent := len(params.EKCert) > 0
@@ -176,8 +176,8 @@ func verifyEKCert(
 	allowedCAs *x509.CertPool,
 	ekCert *x509.Certificate,
 ) error {
-	// Nota Bene: If at a later date this function consumes ctx, ensure you use the value returned by tracer.Start as to ensure span propagation works correctly.
-	_, span := tracer.Start(ctx, "verifyEKCert")
+	//nolint:ineffassign,staticcheck // ctx is shadowed so future downstream calls inherit the span.
+	ctx, span := tracer.Start(ctx, "verifyEKCert")
 	defer span.End()
 
 	if ekCert == nil {

--- a/lib/tpm/validate.go
+++ b/lib/tpm/validate.go
@@ -147,7 +147,7 @@ func Validate(ctx context.Context, params ValidateParams) (*ValidatedTPM, error)
 func parseEK(
 	ctx context.Context, params ValidateParams,
 ) (*x509.Certificate, crypto.PublicKey, error) {
-	_, span := tracer.Start(ctx, "parseEK")
+	ctx, span := tracer.Start(ctx, "parseEK")
 	defer span.End()
 
 	ekCertPresent := len(params.EKCert) > 0
@@ -175,7 +175,7 @@ func verifyEKCert(
 	allowedCAs *x509.CertPool,
 	ekCert *x509.Certificate,
 ) error {
-	_, span := tracer.Start(ctx, "verifyEKCert")
+	ctx, span := tracer.Start(ctx, "verifyEKCert")
 	defer span.End()
 
 	if ekCert == nil {

--- a/lib/tpm/validate.go
+++ b/lib/tpm/validate.go
@@ -147,7 +147,8 @@ func Validate(ctx context.Context, params ValidateParams) (*ValidatedTPM, error)
 func parseEK(
 	ctx context.Context, params ValidateParams,
 ) (*x509.Certificate, crypto.PublicKey, error) {
-	ctx, span := tracer.Start(ctx, "parseEK")
+	// Nota Bene: If at a later date this function consumes ctx, ensure you use the value returned by tracer.Start as to ensure span propagation works correctly.
+	_, span := tracer.Start(ctx, "parseEK")
 	defer span.End()
 
 	ekCertPresent := len(params.EKCert) > 0
@@ -175,7 +176,8 @@ func verifyEKCert(
 	allowedCAs *x509.CertPool,
 	ekCert *x509.Certificate,
 ) error {
-	ctx, span := tracer.Start(ctx, "verifyEKCert")
+	// Nota Bene: If at a later date this function consumes ctx, ensure you use the value returned by tracer.Start as to ensure span propagation works correctly.
+	_, span := tracer.Start(ctx, "verifyEKCert")
 	defer span.End()
 
 	if ekCert == nil {

--- a/tool/tsh/common/kube.go
+++ b/tool/tsh/common/kube.go
@@ -730,7 +730,7 @@ func (c *kubeCredentialsCommand) issueCert(cf *CLIConf) error {
 		return trace.Wrap(err)
 	}
 
-	_, span := tc.Tracer.Start(cf.Context, "tsh.kubeCredentials/GetKey")
+	ctx, span := tc.Tracer.Start(cf.Context, "tsh.kubeCredentials/GetKey")
 	// Try loading existing keys.
 	k, err := tc.LocalAgent().GetKeyRing(c.teleportCluster, client.WithKubeCerts{})
 	span.End()
@@ -741,14 +741,14 @@ func (c *kubeCredentialsCommand) issueCert(cf *CLIConf) error {
 	// Loaded existing credentials and have a cert for this cluster? Return it
 	// right away.
 	if err == nil {
-		_, span := tc.Tracer.Start(cf.Context, "tsh.kubeCredentials/KubeX509Cert")
+		_, span := tc.Tracer.Start(ctx, "tsh.kubeCredentials/KubeX509Cert")
 		crt, err := k.KubeX509Cert(c.kubeCluster)
 		span.End()
 		if err != nil && !trace.IsNotFound(err) {
 			return trace.Wrap(err)
 		}
 		if crt != nil && time.Until(crt.NotAfter) > time.Minute {
-			logger.DebugContext(cf.Context, "Re-using existing TLS cert for Kubernetes cluster", "cluster", c.kubeCluster)
+			logger.DebugContext(ctx, "Re-using existing TLS cert for Kubernetes cluster", "cluster", c.kubeCluster)
 
 			return c.writeKeyResponse(cf.Stdout(), k, c.kubeCluster)
 		}
@@ -756,7 +756,7 @@ func (c *kubeCredentialsCommand) issueCert(cf *CLIConf) error {
 		// a new one.
 	}
 
-	logger.DebugContext(cf.Context, "Requesting TLS cert for Kubernetes cluster", "cluster", c.kubeCluster)
+	logger.DebugContext(ctx, "Requesting TLS cert for Kubernetes cluster", "cluster", c.kubeCluster)
 	var unlockKubeCred func(bool)
 	deleteKubeCredsLock := false
 	defer func() {
@@ -765,7 +765,7 @@ func (c *kubeCredentialsCommand) issueCert(cf *CLIConf) error {
 		}
 	}()
 
-	ctx, span := tc.Tracer.Start(cf.Context, "tsh.kubeCredentials/RetryWithRelogin")
+	ctx, span = tc.Tracer.Start(cf.Context, "tsh.kubeCredentials/RetryWithRelogin")
 	err = client.RetryWithRelogin(
 		ctx,
 		tc,
@@ -803,7 +803,7 @@ func (c *kubeCredentialsCommand) issueCert(cf *CLIConf) error {
 				if proxy == "" {
 					proxy = tc.WebProxyAddr
 				}
-				unlockKubeCred, err = takeKubeCredLock(cf.Context, cf.HomePath, proxy, lockTimeout)
+				unlockKubeCred, err = takeKubeCredLock(ctx, cf.HomePath, proxy, lockTimeout)
 				return trace.Wrap(err)
 			},
 		),


### PR DESCRIPTION
`Tracer.Start` accepts a context, and returns a new context that includes the trace span. If there is a pre-existing span/trace within the context, then the new span will be a "child" of the pre-existing span. If this context is not properly propagated, then the spans will be not connected to one another.

It looks like we've made a number of copy-paste (or similar) mistakes where we've ignored the returned `context.Context`. It seems preferable to get into the habit of shadowing the input context with the returned context as to avoid this mistake in future. 
