### PR TITLE
[terraform] fix plural resource update method

### DIFF
--- a/integrations/terraform/gen/main.go
+++ b/integrations/terraform/gen/main.go
@@ -450,6 +450,10 @@ var (
 		HasStaticID:            false,
 		TerraformResourceType:  "teleport_saml_idp_service_provider",
 		HasCheckAndSetDefaults: true,
+		// TODO: The Teleport SAML IdP API mutates the generated
+		// `spec.entity_descriptor` based on `spec.attribute_mapping`. This can
+		// result in `inconsistent state after apply` errors.
+		SaveSpecStateFromPlan: true,
 	}
 
 	provisionToken = payload{

--- a/integrations/terraform/gen/plural_resource.go.tpl
+++ b/integrations/terraform/gen/plural_resource.go.tpl
@@ -91,8 +91,8 @@ func (r resourceTeleport{{.Name}}) Create(ctx context.Context, req tfsdk.CreateR
 	}
 
 	{{- if .SaveSpecStateFromPlan}}
-	specFromPlan, ok := plan.Attrs["spec"]
-	if !ok {
+	specFromPlan, exist := plan.Attrs["spec"]
+	if !exist {
 		resp.Diagnostics.Append(diagFromWrappedErr("Error reading {{.Name}}", trace.Wrap(trace.Errorf("spec not found in the plan")), "{{.Kind}}"))
 		return
 	}
@@ -482,11 +482,18 @@ func (r resourceTeleport{{.Name}}) Update(ctx context.Context, req tfsdk.UpdateR
 
 {{- if .SaveSpecStateFromPlan}}
 
-	specFromPlan, ok := plan.Attrs["spec"]
-	if !ok {
+	specFromPlan, exist := plan.Attrs["spec"]
+	if !exist {
 		resp.Diagnostics.Append(diagFromWrappedErr("Error reading {{.Name}}", trace.Wrap(trace.Errorf("spec not found in the plan")), "{{.Kind}}"))
 		return
 	}
+
+	specFromPlan, err := deepCopyAttrValue(ctx, specFromPlan)
+	if err != nil {
+		resp.Diagnostics.Append(diagFromWrappedErr("Error copying {{.Name}} spec", trace.Wrap(err), "{{.Kind}}"))
+		return
+	}
+
 {{- end}}
 
 	{{.VarName}} := &{{.ProtoPackage}}.{{.TypeName}}{}

--- a/integrations/terraform/gen/plural_resource.go.tpl
+++ b/integrations/terraform/gen/plural_resource.go.tpl
@@ -480,6 +480,15 @@ func (r resourceTeleport{{.Name}}) Update(ctx context.Context, req tfsdk.UpdateR
 		return
 	}
 
+{{- if .SaveSpecStateFromPlan}}
+
+	specFromPlan, ok := plan.Attrs["spec"]
+	if !ok {
+		resp.Diagnostics.Append(diagFromWrappedErr("Error reading {{.Name}}", trace.Wrap(trace.Errorf("spec not found in the plan")), "{{.Kind}}"))
+		return
+	}
+{{- end}}
+
 	{{.VarName}} := &{{.ProtoPackage}}.{{.TypeName}}{}
 	diags = {{.SchemaPackage}}.Copy{{.TypeName}}FromTerraform(ctx, plan, {{.VarName}})
 	resp.Diagnostics.Append(diags...)
@@ -649,6 +658,11 @@ func (r resourceTeleport{{.Name}}) Update(ctx context.Context, req tfsdk.UpdateR
 	if resp.Diagnostics.HasError() {
 		return
 	}
+
+{{- if .SaveSpecStateFromPlan}}
+
+	plan.Attrs["spec"] = specFromPlan
+{{- end}}
 
 	diags = resp.State.Set(ctx, plan)
 	resp.Diagnostics.Append(diags...)

--- a/integrations/terraform/gen/plural_resource.go.tpl
+++ b/integrations/terraform/gen/plural_resource.go.tpl
@@ -637,6 +637,13 @@ func (r resourceTeleport{{.Name}}) Update(ctx context.Context, req tfsdk.UpdateR
 		return
 	}
 	{{- end}}
+
+{{- if .ConvertPackagePath}}
+	{{.VarName}} = convert.{{ if .ConvertToProtoFunc }}{{.ConvertToProtoFunc}}{{ else }}ToProto{{ end }}({{.VarName}}Resource)
+{{- else }}
+	{{.VarName}} = {{.VarName}}Resource
+{{- end }}
+
 	diags = {{.SchemaPackage}}.Copy{{.TypeName}}ToTerraform(ctx, {{.VarName}}, &plan)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {

--- a/integrations/terraform/protoc-gen-terraform-summarizer.yaml
+++ b/integrations/terraform/protoc-gen-terraform-summarizer.yaml
@@ -92,6 +92,7 @@ computed_fields:
   - "InferencePolicy.kind"
   - "InferencePolicy.metadata.namespace"
   - "RetrievalModel.kind"
+  - "RetrievalModel.metadata"
   - "RetrievalModel.metadata.namespace"
 
 # These fields will be marked as Required: true

--- a/integrations/terraform/provider/copy.go
+++ b/integrations/terraform/provider/copy.go
@@ -1,0 +1,39 @@
+/*
+Copyright 2026 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package provider
+
+import (
+	"context"
+
+	"github.com/gravitational/trace"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+)
+
+// deepCopyAttrValue returns a deep copy of the value.
+func deepCopyAttrValue(ctx context.Context, value attr.Value) (attr.Value, error) {
+	tv, err := value.ToTerraformValue(ctx)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	copied, err := value.Type(ctx).ValueFromTerraform(ctx, tv)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return copied, nil
+}

--- a/integrations/terraform/provider/resource_teleport_access_list.go
+++ b/integrations/terraform/provider/resource_teleport_access_list.go
@@ -286,6 +286,8 @@ func (r resourceTeleportAccessList) Update(ctx context.Context, req tfsdk.Update
 
 	accessListResource = accessListI
 	
+	accessList = convert.ToProto(accessListResource)
+
 	diags = schemav1.CopyAccessListToTerraform(ctx, accessList, &plan)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {

--- a/integrations/terraform/provider/resource_teleport_access_list_member.go
+++ b/integrations/terraform/provider/resource_teleport_access_list_member.go
@@ -295,6 +295,8 @@ func (r resourceTeleportMember) Update(ctx context.Context, req tfsdk.UpdateReso
 
 	accessListMemberResource = accessListMemberI
 	
+	accessListMember = convert.ToMemberProto(accessListMemberResource)
+
 	diags = schemav1.CopyMemberToTerraform(ctx, accessListMember, &plan)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {

--- a/integrations/terraform/provider/resource_teleport_access_monitoring_rule.go
+++ b/integrations/terraform/provider/resource_teleport_access_monitoring_rule.go
@@ -273,6 +273,8 @@ func (r resourceTeleportAccessMonitoringRule) Update(ctx context.Context, req tf
 
 	accessMonitoringRuleResource = accessMonitoringRuleI
 	
+	accessMonitoringRule = accessMonitoringRuleResource
+
 	diags = schemav1.CopyAccessMonitoringRuleToTerraform(ctx, accessMonitoringRule, &plan)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {

--- a/integrations/terraform/provider/resource_teleport_app.go
+++ b/integrations/terraform/provider/resource_teleport_app.go
@@ -289,6 +289,8 @@ func (r resourceTeleportApp) Update(ctx context.Context, req tfsdk.UpdateResourc
 		resp.Diagnostics.Append(diagFromWrappedErr("Error reading App", trace.Errorf("Can not convert %T to AppV3", appI), "app"))
 		return
 	}
+	app = appResource
+
 	diags = tfschema.CopyAppV3ToTerraform(ctx, app, &plan)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {

--- a/integrations/terraform/provider/resource_teleport_app_auth_config.go
+++ b/integrations/terraform/provider/resource_teleport_app_auth_config.go
@@ -273,6 +273,8 @@ func (r resourceTeleportAppAuthConfig) Update(ctx context.Context, req tfsdk.Upd
 
 	appauthconfigResource = appauthconfigI
 	
+	appauthconfig = appauthconfigResource
+
 	diags = schemav1.CopyAppAuthConfigToTerraform(ctx, appauthconfig, &plan)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {

--- a/integrations/terraform/provider/resource_teleport_database.go
+++ b/integrations/terraform/provider/resource_teleport_database.go
@@ -289,6 +289,8 @@ func (r resourceTeleportDatabase) Update(ctx context.Context, req tfsdk.UpdateRe
 		resp.Diagnostics.Append(diagFromWrappedErr("Error reading Database", trace.Errorf("Can not convert %T to DatabaseV3", databaseI), "db"))
 		return
 	}
+	database = databaseResource
+
 	diags = tfschema.CopyDatabaseV3ToTerraform(ctx, database, &plan)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {

--- a/integrations/terraform/provider/resource_teleport_db_object_import_rule.go
+++ b/integrations/terraform/provider/resource_teleport_db_object_import_rule.go
@@ -297,6 +297,8 @@ func (r resourceTeleportDatabaseObjectImportRule) Update(ctx context.Context, re
 
 	importRuleResource = importRuleI
 	
+	importRule = importRuleResource
+
 	diags = schemav1.CopyDatabaseObjectImportRuleToTerraform(ctx, importRule, &plan)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {

--- a/integrations/terraform/provider/resource_teleport_device_trust.go
+++ b/integrations/terraform/provider/resource_teleport_device_trust.go
@@ -274,6 +274,8 @@ func (r resourceTeleportDeviceV1) Update(ctx context.Context, req tfsdk.UpdateRe
 
 	trustedDeviceResource = trustedDeviceI
 	
+	trustedDevice = trustedDeviceResource
+
 	diags = schemav1.CopyDeviceV1ToTerraform(ctx, trustedDevice, &plan)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {

--- a/integrations/terraform/provider/resource_teleport_discovery_config.go
+++ b/integrations/terraform/provider/resource_teleport_discovery_config.go
@@ -280,6 +280,8 @@ func (r resourceTeleportDiscoveryConfig) Update(ctx context.Context, req tfsdk.U
 
 	discoveryConfigResource = discoveryConfigI
 	
+	discoveryConfig = convert.ToProto(discoveryConfigResource)
+
 	diags = schemav1.CopyDiscoveryConfigToTerraform(ctx, discoveryConfig, &plan)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {

--- a/integrations/terraform/provider/resource_teleport_dynamic_windows_desktop.go
+++ b/integrations/terraform/provider/resource_teleport_dynamic_windows_desktop.go
@@ -289,6 +289,8 @@ func (r resourceTeleportDynamicWindowsDesktop) Update(ctx context.Context, req t
 		resp.Diagnostics.Append(diagFromWrappedErr("Error reading DynamicWindowsDesktop", trace.Errorf("Can not convert %T to DynamicWindowsDesktopV1", desktopI), "dynamic_windows_desktop"))
 		return
 	}
+	desktop = desktopResource
+
 	diags = tfschema.CopyDynamicWindowsDesktopV1ToTerraform(ctx, desktop, &plan)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {

--- a/integrations/terraform/provider/resource_teleport_github_connector.go
+++ b/integrations/terraform/provider/resource_teleport_github_connector.go
@@ -289,6 +289,8 @@ func (r resourceTeleportGithubConnector) Update(ctx context.Context, req tfsdk.U
 		resp.Diagnostics.Append(diagFromWrappedErr("Error reading GithubConnector", trace.Errorf("Can not convert %T to GithubConnectorV3", githubConnectorI), "github"))
 		return
 	}
+	githubConnector = githubConnectorResource
+
 	diags = tfschema.CopyGithubConnectorV3ToTerraform(ctx, githubConnector, &plan)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {

--- a/integrations/terraform/provider/resource_teleport_health_check_config.go
+++ b/integrations/terraform/provider/resource_teleport_health_check_config.go
@@ -273,6 +273,8 @@ func (r resourceTeleportHealthCheckConfig) Update(ctx context.Context, req tfsdk
 
 	healthCheckConfigResource = healthCheckConfigI
 	
+	healthCheckConfig = healthCheckConfigResource
+
 	diags = schemav1.CopyHealthCheckConfigToTerraform(ctx, healthCheckConfig, &plan)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {

--- a/integrations/terraform/provider/resource_teleport_inference_model.go
+++ b/integrations/terraform/provider/resource_teleport_inference_model.go
@@ -273,6 +273,8 @@ func (r resourceTeleportInferenceModel) Update(ctx context.Context, req tfsdk.Up
 
 	inferenceModelResource = inferenceModelI
 	
+	inferenceModel = inferenceModelResource
+
 	diags = schemav1.CopyInferenceModelToTerraform(ctx, inferenceModel, &plan)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {

--- a/integrations/terraform/provider/resource_teleport_inference_policy.go
+++ b/integrations/terraform/provider/resource_teleport_inference_policy.go
@@ -273,6 +273,8 @@ func (r resourceTeleportInferencePolicy) Update(ctx context.Context, req tfsdk.U
 
 	inferencePolicyResource = inferencePolicyI
 	
+	inferencePolicy = inferencePolicyResource
+
 	diags = schemav1.CopyInferencePolicyToTerraform(ctx, inferencePolicy, &plan)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {

--- a/integrations/terraform/provider/resource_teleport_inference_secret.go
+++ b/integrations/terraform/provider/resource_teleport_inference_secret.go
@@ -67,8 +67,8 @@ func (r resourceTeleportInferenceSecret) Create(ctx context.Context, req tfsdk.C
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	specFromPlan, ok := plan.Attrs["spec"]
-	if !ok {
+	specFromPlan, exist := plan.Attrs["spec"]
+	if !exist {
 		resp.Diagnostics.Append(diagFromWrappedErr("Error reading InferenceSecret", trace.Wrap(trace.Errorf("spec not found in the plan")), "inference_secret"))
 		return
 	}
@@ -219,9 +219,15 @@ func (r resourceTeleportInferenceSecret) Update(ctx context.Context, req tfsdk.U
 		return
 	}
 
-	specFromPlan, ok := plan.Attrs["spec"]
-	if !ok {
+	specFromPlan, exist := plan.Attrs["spec"]
+	if !exist {
 		resp.Diagnostics.Append(diagFromWrappedErr("Error reading InferenceSecret", trace.Wrap(trace.Errorf("spec not found in the plan")), "inference_secret"))
+		return
+	}
+
+	specFromPlan, err := deepCopyAttrValue(ctx, specFromPlan)
+	if err != nil {
+		resp.Diagnostics.Append(diagFromWrappedErr("Error copying InferenceSecret spec", trace.Wrap(err), "inference_secret"))
 		return
 	}
 

--- a/integrations/terraform/provider/resource_teleport_inference_secret.go
+++ b/integrations/terraform/provider/resource_teleport_inference_secret.go
@@ -281,6 +281,8 @@ func (r resourceTeleportInferenceSecret) Update(ctx context.Context, req tfsdk.U
 
 	inferenceSecretResource = inferenceSecretI
 	
+	inferenceSecret = inferenceSecretResource
+
 	diags = schemav1.CopyInferenceSecretToTerraform(ctx, inferenceSecret, &plan)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {

--- a/integrations/terraform/provider/resource_teleport_inference_secret.go
+++ b/integrations/terraform/provider/resource_teleport_inference_secret.go
@@ -219,6 +219,12 @@ func (r resourceTeleportInferenceSecret) Update(ctx context.Context, req tfsdk.U
 		return
 	}
 
+	specFromPlan, ok := plan.Attrs["spec"]
+	if !ok {
+		resp.Diagnostics.Append(diagFromWrappedErr("Error reading InferenceSecret", trace.Wrap(trace.Errorf("spec not found in the plan")), "inference_secret"))
+		return
+	}
+
 	inferenceSecret := &summarizerv1.InferenceSecret{}
 	diags = schemav1.CopyInferenceSecretFromTerraform(ctx, plan, inferenceSecret)
 	resp.Diagnostics.Append(diags...)
@@ -288,6 +294,8 @@ func (r resourceTeleportInferenceSecret) Update(ctx context.Context, req tfsdk.U
 	if resp.Diagnostics.HasError() {
 		return
 	}
+
+	plan.Attrs["spec"] = specFromPlan
 
 	diags = resp.State.Set(ctx, plan)
 	resp.Diagnostics.Append(diags...)

--- a/integrations/terraform/provider/resource_teleport_installer.go
+++ b/integrations/terraform/provider/resource_teleport_installer.go
@@ -289,6 +289,8 @@ func (r resourceTeleportInstaller) Update(ctx context.Context, req tfsdk.UpdateR
 		resp.Diagnostics.Append(diagFromWrappedErr("Error reading Installer", trace.Errorf("Can not convert %T to InstallerV1", installerI), "installer"))
 		return
 	}
+	installer = installerResource
+
 	diags = tfschema.CopyInstallerV1ToTerraform(ctx, installer, &plan)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {

--- a/integrations/terraform/provider/resource_teleport_integration.go
+++ b/integrations/terraform/provider/resource_teleport_integration.go
@@ -289,6 +289,8 @@ func (r resourceTeleportIntegration) Update(ctx context.Context, req tfsdk.Updat
 		resp.Diagnostics.Append(diagFromWrappedErr("Error reading Integration", trace.Errorf("Can not convert %T to IntegrationV1", integrationI), "integration"))
 		return
 	}
+	integration = integrationResource
+
 	diags = tfschema.CopyIntegrationV1ToTerraform(ctx, integration, &plan)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {

--- a/integrations/terraform/provider/resource_teleport_kube_cluster.go
+++ b/integrations/terraform/provider/resource_teleport_kube_cluster.go
@@ -289,6 +289,8 @@ func (r resourceTeleportKubeCluster) Update(ctx context.Context, req tfsdk.Updat
 		resp.Diagnostics.Append(diagFromWrappedErr("Error reading KubeCluster", trace.Errorf("Can not convert %T to KubernetesClusterV3", kubeClusterI), "kube_cluster"))
 		return
 	}
+	kubeCluster = kubeClusterResource
+
 	diags = tfschema.CopyKubernetesClusterV3ToTerraform(ctx, kubeCluster, &plan)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {

--- a/integrations/terraform/provider/resource_teleport_lock.go
+++ b/integrations/terraform/provider/resource_teleport_lock.go
@@ -289,6 +289,8 @@ func (r resourceTeleportLock) Update(ctx context.Context, req tfsdk.UpdateResour
 		resp.Diagnostics.Append(diagFromWrappedErr("Error reading Lock", trace.Errorf("Can not convert %T to LockV2", lockI), "lock"))
 		return
 	}
+	lock = lockResource
+
 	diags = tfschema.CopyLockV2ToTerraform(ctx, lock, &plan)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {

--- a/integrations/terraform/provider/resource_teleport_login_rule.go
+++ b/integrations/terraform/provider/resource_teleport_login_rule.go
@@ -270,6 +270,8 @@ func (r resourceTeleportLoginRule) Update(ctx context.Context, req tfsdk.UpdateR
 
 	loginRuleResource = loginRuleI
 	
+	loginRule = loginRuleResource
+
 	diags = schemav1.CopyLoginRuleToTerraform(ctx, loginRule, &plan)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {

--- a/integrations/terraform/provider/resource_teleport_oidc_connector.go
+++ b/integrations/terraform/provider/resource_teleport_oidc_connector.go
@@ -289,6 +289,8 @@ func (r resourceTeleportOIDCConnector) Update(ctx context.Context, req tfsdk.Upd
 		resp.Diagnostics.Append(diagFromWrappedErr("Error reading OIDCConnector", trace.Errorf("Can not convert %T to OIDCConnectorV3", oidcConnectorI), "oidc"))
 		return
 	}
+	oidcConnector = oidcConnectorResource
+
 	diags = tfschema.CopyOIDCConnectorV3ToTerraform(ctx, oidcConnector, &plan)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {

--- a/integrations/terraform/provider/resource_teleport_okta_import_rule.go
+++ b/integrations/terraform/provider/resource_teleport_okta_import_rule.go
@@ -289,6 +289,8 @@ func (r resourceTeleportOktaImportRule) Update(ctx context.Context, req tfsdk.Up
 		resp.Diagnostics.Append(diagFromWrappedErr("Error reading OktaImportRule", trace.Errorf("Can not convert %T to OktaImportRuleV1", oktaImportRuleI), "okta_import_rule"))
 		return
 	}
+	oktaImportRule = oktaImportRuleResource
+
 	diags = tfschema.CopyOktaImportRuleV1ToTerraform(ctx, oktaImportRule, &plan)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {

--- a/integrations/terraform/provider/resource_teleport_provision_token.go
+++ b/integrations/terraform/provider/resource_teleport_provision_token.go
@@ -300,6 +300,8 @@ func (r resourceTeleportProvisionToken) Update(ctx context.Context, req tfsdk.Up
 		resp.Diagnostics.Append(diagFromWrappedErr("Error reading ProvisionToken", trace.Errorf("Can not convert %T to ProvisionTokenV2", provisionTokenI), "token"))
 		return
 	}
+	provisionToken = provisionTokenResource
+
 	diags = token.CopyProvisionTokenV2ToTerraform(ctx, provisionToken, &plan)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {

--- a/integrations/terraform/provider/resource_teleport_role.go
+++ b/integrations/terraform/provider/resource_teleport_role.go
@@ -289,6 +289,8 @@ func (r resourceTeleportRole) Update(ctx context.Context, req tfsdk.UpdateResour
 		resp.Diagnostics.Append(diagFromWrappedErr("Error reading Role", trace.Errorf("Can not convert %T to RoleV6", roleI), "role"))
 		return
 	}
+	role = roleResource
+
 	diags = tfschema.CopyRoleV6ToTerraform(ctx, role, &plan)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {

--- a/integrations/terraform/provider/resource_teleport_saml_connector.go
+++ b/integrations/terraform/provider/resource_teleport_saml_connector.go
@@ -289,6 +289,8 @@ func (r resourceTeleportSAMLConnector) Update(ctx context.Context, req tfsdk.Upd
 		resp.Diagnostics.Append(diagFromWrappedErr("Error reading SAMLConnector", trace.Errorf("Can not convert %T to SAMLConnectorV2", samlConnectorI), "saml"))
 		return
 	}
+	samlConnector = samlConnectorResource
+
 	diags = tfschema.CopySAMLConnectorV2ToTerraform(ctx, samlConnector, &plan)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {

--- a/integrations/terraform/provider/resource_teleport_saml_idp_service_provider.go
+++ b/integrations/terraform/provider/resource_teleport_saml_idp_service_provider.go
@@ -289,6 +289,8 @@ func (r resourceTeleportSAMLIdPServiceProvider) Update(ctx context.Context, req 
 		resp.Diagnostics.Append(diagFromWrappedErr("Error reading SAMLIdPServiceProvider", trace.Errorf("Can not convert %T to SAMLIdPServiceProviderV1", samlIdPServiceProviderI), "saml_idp_service_provider"))
 		return
 	}
+	samlIdPServiceProvider = samlIdPServiceProviderResource
+
 	diags = tfschema.CopySAMLIdPServiceProviderV1ToTerraform(ctx, samlIdPServiceProvider, &plan)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {

--- a/integrations/terraform/provider/resource_teleport_saml_idp_service_provider.go
+++ b/integrations/terraform/provider/resource_teleport_saml_idp_service_provider.go
@@ -66,6 +66,12 @@ func (r resourceTeleportSAMLIdPServiceProvider) Create(ctx context.Context, req 
 	if resp.Diagnostics.HasError() {
 		return
 	}
+	specFromPlan, exist := plan.Attrs["spec"]
+	if !exist {
+		resp.Diagnostics.Append(diagFromWrappedErr("Error reading SAMLIdPServiceProvider", trace.Wrap(trace.Errorf("spec not found in the plan")), "saml_idp_service_provider"))
+		return
+	}
+	
 
 	samlIdPServiceProvider := &apitypes.SAMLIdPServiceProviderV1{}
 	diags = tfschema.CopySAMLIdPServiceProviderV1FromTerraform(ctx, plan, samlIdPServiceProvider)
@@ -157,6 +163,8 @@ func (r resourceTeleportSAMLIdPServiceProvider) Create(ctx context.Context, req 
 	}
 
 	plan.Attrs["id"] = types.String{Value: samlIdPServiceProvider.Metadata.Name}
+	plan.Attrs["spec"] = specFromPlan
+	
 
 	diags = resp.State.Set(ctx, &plan)
 	resp.Diagnostics.Append(diags...)
@@ -217,6 +225,18 @@ func (r resourceTeleportSAMLIdPServiceProvider) Update(ctx context.Context, req 
 
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	specFromPlan, exist := plan.Attrs["spec"]
+	if !exist {
+		resp.Diagnostics.Append(diagFromWrappedErr("Error reading SAMLIdPServiceProvider", trace.Wrap(trace.Errorf("spec not found in the plan")), "saml_idp_service_provider"))
+		return
+	}
+
+	specFromPlan, err := deepCopyAttrValue(ctx, specFromPlan)
+	if err != nil {
+		resp.Diagnostics.Append(diagFromWrappedErr("Error copying SAMLIdPServiceProvider spec", trace.Wrap(err), "saml_idp_service_provider"))
 		return
 	}
 
@@ -296,6 +316,8 @@ func (r resourceTeleportSAMLIdPServiceProvider) Update(ctx context.Context, req 
 	if resp.Diagnostics.HasError() {
 		return
 	}
+
+	plan.Attrs["spec"] = specFromPlan
 
 	diags = resp.State.Set(ctx, plan)
 	resp.Diagnostics.Append(diags...)

--- a/integrations/terraform/provider/resource_teleport_scoped_role.go
+++ b/integrations/terraform/provider/resource_teleport_scoped_role.go
@@ -297,6 +297,8 @@ func (r resourceTeleportScopedRole) Update(ctx context.Context, req tfsdk.Update
 
 	scopedRoleResource = scopedRoleI
 	
+	scopedRole = scopedRoleResource
+
 	diags = schemav1.CopyScopedRoleToTerraform(ctx, scopedRole, &plan)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {

--- a/integrations/terraform/provider/resource_teleport_scoped_role_assignment.go
+++ b/integrations/terraform/provider/resource_teleport_scoped_role_assignment.go
@@ -318,6 +318,8 @@ func (r resourceTeleportScopedRoleAssignment) Update(ctx context.Context, req tf
 
 	scopedRoleAssignmentResource = scopedRoleAssignmentI
 	
+	scopedRoleAssignment = scopedRoleAssignmentResource
+
 	diags = assignmentschemav1.CopyScopedRoleAssignmentToTerraform(ctx, scopedRoleAssignment, &plan)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {

--- a/integrations/terraform/provider/resource_teleport_scoped_token.go
+++ b/integrations/terraform/provider/resource_teleport_scoped_token.go
@@ -273,6 +273,8 @@ func (r resourceTeleportScopedToken) Update(ctx context.Context, req tfsdk.Updat
 
 	scopedTokenResource = scopedTokenI
 	
+	scopedToken = scopedTokenResource
+
 	diags = schemav1.CopyScopedTokenToTerraform(ctx, scopedToken, &plan)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {

--- a/integrations/terraform/provider/resource_teleport_server.go
+++ b/integrations/terraform/provider/resource_teleport_server.go
@@ -292,6 +292,8 @@ func (r resourceTeleportServer) Update(ctx context.Context, req tfsdk.UpdateReso
 		resp.Diagnostics.Append(diagFromWrappedErr("Error reading Server", trace.Errorf("Can not convert %T to ServerV2", serverI), "node"))
 		return
 	}
+	server = serverResource
+
 	diags = tfschema.CopyServerV2ToTerraform(ctx, server, &plan)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {

--- a/integrations/terraform/provider/resource_teleport_static_host_user.go
+++ b/integrations/terraform/provider/resource_teleport_static_host_user.go
@@ -273,6 +273,8 @@ func (r resourceTeleportStaticHostUser) Update(ctx context.Context, req tfsdk.Up
 
 	staticHostUserResource = staticHostUserI
 	
+	staticHostUser = staticHostUserResource
+
 	diags = schemav1.CopyStaticHostUserToTerraform(ctx, staticHostUser, &plan)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {

--- a/integrations/terraform/provider/resource_teleport_trusted_cluster.go
+++ b/integrations/terraform/provider/resource_teleport_trusted_cluster.go
@@ -289,6 +289,8 @@ func (r resourceTeleportTrustedCluster) Update(ctx context.Context, req tfsdk.Up
 		resp.Diagnostics.Append(diagFromWrappedErr("Error reading TrustedCluster", trace.Errorf("Can not convert %T to TrustedClusterV2", trustedClusterI), "trusted_cluster"))
 		return
 	}
+	trustedCluster = trustedClusterResource
+
 	diags = tfschema.CopyTrustedClusterV2ToTerraform(ctx, trustedCluster, &plan)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {

--- a/integrations/terraform/provider/resource_teleport_user.go
+++ b/integrations/terraform/provider/resource_teleport_user.go
@@ -289,6 +289,8 @@ func (r resourceTeleportUser) Update(ctx context.Context, req tfsdk.UpdateResour
 		resp.Diagnostics.Append(diagFromWrappedErr("Error reading User", trace.Errorf("Can not convert %T to UserV2", userI), "user"))
 		return
 	}
+	user = userResource
+
 	diags = tfschema.CopyUserV2ToTerraform(ctx, user, &plan)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {

--- a/integrations/terraform/provider/resource_teleport_workload_cluster.go
+++ b/integrations/terraform/provider/resource_teleport_workload_cluster.go
@@ -305,6 +305,8 @@ func (r resourceTeleportWorkloadCluster) Update(ctx context.Context, req tfsdk.U
 
 	workloadclusterResource = workloadclusterI
 	
+	workloadcluster = workloadclusterResource
+
 	diags = schemav1.CopyWorkloadClusterToTerraform(ctx, workloadcluster, &plan)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {

--- a/integrations/terraform/provider/resource_teleport_workload_identity.go
+++ b/integrations/terraform/provider/resource_teleport_workload_identity.go
@@ -272,6 +272,8 @@ func (r resourceTeleportWorkloadIdentity) Update(ctx context.Context, req tfsdk.
 
 	workloadIdentityResource = workloadIdentityI
 	
+	workloadIdentity = workloadIdentityResource
+
 	diags = schemav1.CopyWorkloadIdentityToTerraform(ctx, workloadIdentity, &plan)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {

--- a/integrations/terraform/testlib/retrieval_model_test.go
+++ b/integrations/terraform/testlib/retrieval_model_test.go
@@ -31,9 +31,6 @@ import (
 )
 
 func (s *TerraformSuiteEnterprise) TestRetrievalModel() {
-	// TODO: `metadata` should be a computed or required attribute.
-	s.T().Skip("Provider produced inconsistent result after apply")
-
 	t := s.T()
 	ctx := t.Context()
 

--- a/integrations/terraform/tfschema/summarizer/v1/summarizer_terraform.go
+++ b/integrations/terraform/tfschema/summarizer/v1/summarizer_terraform.go
@@ -406,8 +406,10 @@ func GenSchemaRetrievalModel(ctx context.Context) (github_com_hashicorp_terrafor
 					Type:          github_com_hashicorp_terraform_plugin_framework_types.StringType,
 				},
 			}),
-			Description: "",
-			Optional:    true,
+			Computed:      true,
+			Description:   "",
+			Optional:      true,
+			PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributePlanModifier{github_com_hashicorp_terraform_plugin_framework_tfsdk.UseStateForUnknown()},
 		},
 		"spec": {
 			Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.SingleNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{


### PR DESCRIPTION
Supersedes https://github.com/gravitational/teleport/pull/65112
Supports https://github.com/gravitational/teleport/issues/66912
Closes https://github.com/gravitational/teleport/issues/64651

This PR modifies the Terraform resource `Update` method for plural resources to ensure that the latest Teleport state is written to local Terraform state.

Before this change, the `Update` method was storing the Terraform plan as the final applied state.
As a result, the final state would not include computed values provided by Teleport. This would cause unexpected behavior for attributes computed during updates.

Note that the `saml_idp_service_provider` resource will continue to behave the same way where `spec` is saved from the plan. This is because the SAML IdP API mutates the `spec.entity_descriptor` based on the `spec.attribute_mapping`. The plan modifier must be updated to handle this case, but this fix is being deferred.

<!-- Provide a descriptive entry for the changelog of the next release. -->

Changelog: Fixed potential Terraform issues due to storing stale Terraform state on updates

<!-- Include manual testing efforts to verify the change. -->
<!-- Detail where the tests where run and what configurations were used. -->
<!-- Include all the test cases which were run to validate the change. -->

## Manual Test Plan
### Test Environment
Local cluster environment

### Test Cases
- [x] Create, update `saml_idp_service_provider` with `attribute_mapping` changes.
- [x] Create, update `inference_secret` with `spec.value` changes.
- [x] Create, update `retrieval_model` without `metadata`.