### PR TITLE
check arguments for NULL in converse PAM converse func, trim trailing newlines in user input

### DIFF
--- a/session/pam/pam.c
+++ b/session/pam/pam.c
@@ -43,9 +43,9 @@ int converse(int n, const struct pam_message **msg, struct pam_response **resp, 
     int i;
     struct pam_response *aresp;
 
-    // If no messages arrived, or the number of messages is greater than
-    // allowed, something is wrong with the caller.
-    if (n <= 0 || n > PAM_MAX_NUM_MSG) {
+    // If no messages arrived, the number of messages is greater than
+    // allowed, or msg or resp is NULL, something is wrong with the caller.
+    if (n <= 0 || n > PAM_MAX_NUM_MSG || msg == NULL || resp == NULL) {
         return PAM_CONV_ERR;
     }
 
@@ -60,6 +60,10 @@ int converse(int n, const struct pam_message **msg, struct pam_response **resp, 
 
     // Loop over all messages and process them.
     for (i = 0; i < n; ++i) {
+        if (msg[i] == NULL) {
+            goto fail;
+        }
+
         aresp[i].resp_retcode = 0;
         aresp[i].resp = NULL;
 

--- a/session/pam/pam.c
+++ b/session/pam/pam.c
@@ -43,8 +43,10 @@ int converse(int n, const struct pam_message **msg, struct pam_response **resp, 
     int i;
     struct pam_response *aresp;
 
-    // If no messages arrived, the number of messages is greater than
-    // allowed, or msg or resp is NULL, something is wrong with the caller.
+    // Something is wrong with the caller if:
+    // - no messages arrived
+    // - the number of messages is greater than allowed
+    // - msg or resp is NULL
     if (n <= 0 || n > PAM_MAX_NUM_MSG || msg == NULL || resp == NULL) {
         return PAM_CONV_ERR;
     }

--- a/session/pam/pam.go
+++ b/session/pam/pam.go
@@ -500,7 +500,8 @@ func (p *PAM) readStream(echo bool) (string, error) {
 		return "", trace.Wrap(err)
 	}
 
-	return text, nil
+	// Trim trailing newlines from the response.
+	return strings.TrimRight(text, "\r\n"), nil
 }
 
 // codeToError returns a human readable string from the PAM error.


### PR DESCRIPTION
Fixes https://github.com/gravitational/pressure-washing/issues/337.
Fixes https://github.com/gravitational/pressure-washing/issues/295.