### PR TITLE
Improve Azure VM discovery performance

### DIFF
--- a/lib/cloud/azure/vm.go
+++ b/lib/cloud/azure/vm.go
@@ -21,6 +21,7 @@ package azure
 import (
 	"context"
 	"log/slog"
+	"net/http"
 	"os"
 	"time"
 
@@ -444,7 +445,17 @@ func (r *RunCommandResult) Failure() bool {
 // RunCommandClient is a client for Azure Run Commands.
 type RunCommandClient interface {
 	// Run runs Teleport installation command on a virtual machine.
-	Run(ctx context.Context, req RunCommandRequest) (*RunCommandResult, error)
+	Run(ctx context.Context, req RunCommandRequest) (RunCommandResultPoller, error)
+}
+
+// RunCommandResultPoller polls and returns the result of an Azure Run Command.
+type RunCommandResultPoller interface {
+	// Poll polls the latest state of the run-command operation.
+	Poll(ctx context.Context) error
+	// Done returns true if the run-command result is ready.
+	Done() bool
+	// Result returns the result of the run-command operation.
+	Result(ctx context.Context) (*RunCommandResult, error)
 }
 
 type runCommandClient struct {
@@ -475,90 +486,81 @@ func NewRunCommandClient(subscription string, cred azcore.TokenCredential, optio
 const runCommandName = "teleport-install"
 
 // Run runs Teleport installation command on a virtual machine.
-func (c *runCommandClient) Run(ctx context.Context, req RunCommandRequest) (*RunCommandResult, error) {
-	runCommandTimeout := getRunCommandTimeout()
-	// pad the timeout so we can still attempt to collect output if it times out
-	ctx, cancel := context.WithTimeout(ctx, runCommandTimeout+time.Minute)
+func (c *runCommandClient) Run(ctx context.Context, req RunCommandRequest) (RunCommandResultPoller, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, trace.Wrap(err)
+	}
+	ctx, cancel := context.WithTimeout(ctx, time.Minute)
 	defer cancel()
 
 	runCommand := armcompute.VirtualMachineRunCommand{
 		Location: to.Ptr(req.Region),
 		Properties: &armcompute.VirtualMachineRunCommandProperties{
+			// NOTE: The AsyncExecution option can be very misleading.
+			// It has no effect on whether BeginCreateOrUpdate blocks.
+			// Instead, it affects poller.PollUntilDone.
+			// If set to true, then calling poller.PollUntilDone will actually
+			// return as soon as the script is "provisioned" even if
+			// the script execution state is still "running".
+			// We always want this option set to false.
 			AsyncExecution: to.Ptr(false),
 			Source: &armcompute.VirtualMachineRunCommandScriptSource{
 				Script: to.Ptr(req.Script),
 			},
-			TimeoutInSeconds: to.Ptr(int32(runCommandTimeout.Seconds())),
+			TimeoutInSeconds: to.Ptr(int32(GetRunCommandTimeout().Seconds())),
 		},
 	}
 
-	var runCommandProperties *armcompute.VirtualMachineRunCommandProperties
-	var err error
-
 	if req.isUniformVMSS() {
-		runCommandProperties, err = c.uniformScaleSetVirtualMachineRunCommand(ctx, req, runCommand)
-		if err != nil {
-			return nil, trace.Wrap(err)
-		}
-	} else {
-		runCommandProperties, err = c.regularVirtualMachineRunCommand(ctx, req, runCommand)
-		if err != nil {
-			return nil, trace.Wrap(err)
-		}
+		return c.uniformScaleSetVirtualMachineRunCommand(ctx, req, runCommand)
 	}
-
-	commandResult, err := commandResultFromInstanceView(runCommandProperties)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-
-	return commandResult, nil
+	return c.regularVirtualMachineRunCommand(ctx, req, runCommand)
 }
 
-func (c *runCommandClient) regularVirtualMachineRunCommand(ctx context.Context, req RunCommandRequest, runCommand armcompute.VirtualMachineRunCommand) (*armcompute.VirtualMachineRunCommandProperties, error) {
+func (c *runCommandClient) regularVirtualMachineRunCommand(ctx context.Context, req RunCommandRequest, runCommand armcompute.VirtualMachineRunCommand) (RunCommandResultPoller, error) {
 	poller, err := c.virtualMachineRunCommandsAPI.BeginCreateOrUpdate(ctx, req.ResourceGroup, req.VMName, runCommandName, runCommand, nil)
 	if err != nil {
 		return nil, trace.Wrap(ConvertResponseError(err))
 	}
 
-	_, err = poller.PollUntilDone(ctx, &runtime.PollUntilDoneOptions{Frequency: 10 * time.Second})
-	if err != nil {
-		return nil, trace.Wrap(ConvertResponseError(err))
-	}
-
-	// note: we are not guaranteed to receive the output of the command above if the req.Name is not unique.
-	// in particular, two discovery services may race, causing the output to be empty: our attempt can be shadowed by a newer one.
-	resp, err := c.virtualMachineRunCommandsAPI.GetByVirtualMachine(ctx, req.ResourceGroup, req.VMName, runCommandName, &armcompute.VirtualMachineRunCommandsClientGetByVirtualMachineOptions{
-		Expand: to.Ptr("instanceView"),
-	})
-	if err != nil {
-		return nil, trace.Wrap(ConvertResponseError(err))
-	}
-
-	return resp.Properties, nil
+	return &pendingRunCommandResult{
+		poller: poller,
+		getProperties: func(ctx context.Context) (*armcompute.VirtualMachineRunCommandProperties, error) {
+			// note: we are not guaranteed to receive the output of the command above if the req.Name is not unique.
+			// in particular, two discovery services may race, causing the output to be empty: our attempt can be shadowed by a newer one.
+			opts := &armcompute.VirtualMachineRunCommandsClientGetByVirtualMachineOptions{
+				Expand: to.Ptr("instanceView"),
+			}
+			resp, err := c.virtualMachineRunCommandsAPI.GetByVirtualMachine(ctx, req.ResourceGroup, req.VMName, runCommandName, opts)
+			if err != nil {
+				return nil, trace.Wrap(err)
+			}
+			return resp.Properties, nil
+		},
+	}, nil
 }
 
-func (c *runCommandClient) uniformScaleSetVirtualMachineRunCommand(ctx context.Context, req RunCommandRequest, runCommand armcompute.VirtualMachineRunCommand) (*armcompute.VirtualMachineRunCommandProperties, error) {
+func (c *runCommandClient) uniformScaleSetVirtualMachineRunCommand(ctx context.Context, req RunCommandRequest, runCommand armcompute.VirtualMachineRunCommand) (RunCommandResultPoller, error) {
 	poller, err := c.scaleSetVMRunCommandsAPI.BeginCreateOrUpdate(ctx, req.ResourceGroup, req.UniformScaleSetName, req.UniformScaleSetVMInstanceID, runCommandName, runCommand, nil)
 	if err != nil {
 		return nil, trace.Wrap(ConvertResponseError(err))
 	}
 
-	_, err = poller.PollUntilDone(ctx, &runtime.PollUntilDoneOptions{Frequency: 10 * time.Second})
-	if err != nil {
-		return nil, trace.Wrap(ConvertResponseError(err))
-	}
-
-	// note: we are not guaranteed to receive the output of the command above if the req.Name is not unique.
-	// in particular, two discovery services may race, causing the output to be empty: our attempt can be shadowed by a newer one.
-	resp, err := c.scaleSetVMRunCommandsAPI.Get(ctx, req.ResourceGroup, req.UniformScaleSetName, req.UniformScaleSetVMInstanceID, runCommandName, &armcompute.VirtualMachineScaleSetVMRunCommandsClientGetOptions{
-		Expand: to.Ptr("instanceView"),
-	})
-	if err != nil {
-		return nil, trace.Wrap(ConvertResponseError(err))
-	}
-
-	return resp.Properties, nil
+	return &pendingRunCommandResult{
+		poller: poller,
+		getProperties: func(ctx context.Context) (*armcompute.VirtualMachineRunCommandProperties, error) {
+			// note: we are not guaranteed to receive the output of the command above if the req.Name is not unique.
+			// in particular, two discovery services may race, causing the output to be empty: our attempt can be shadowed by a newer one.
+			opts := &armcompute.VirtualMachineScaleSetVMRunCommandsClientGetOptions{
+				Expand: to.Ptr("instanceView"),
+			}
+			resp, err := c.scaleSetVMRunCommandsAPI.Get(ctx, req.ResourceGroup, req.UniformScaleSetName, req.UniformScaleSetVMInstanceID, runCommandName, opts)
+			if err != nil {
+				return nil, trace.Wrap(err)
+			}
+			return resp.Properties, nil
+		},
+	}, nil
 }
 
 func commandResultFromInstanceView(properties *armcompute.VirtualMachineRunCommandProperties) (*RunCommandResult, error) {
@@ -581,7 +583,8 @@ func fromPtr[T any](ptr *T) T {
 	return out
 }
 
-func getRunCommandTimeout() time.Duration {
+// GetRunCommandTimeout returns the timeout for Azure commands.
+func GetRunCommandTimeout() time.Duration {
 	const timeoutEnv = "TELEPORT_UNSTABLE_AZURE_RUN_COMMAND_TIMEOUT"
 	if dur, err := time.ParseDuration(os.Getenv(timeoutEnv)); err == nil {
 		// clamp the timeout to a reasonable duration.
@@ -661,4 +664,51 @@ func parseVMIdentities(identity *armcompute.VirtualMachineIdentity) []Identity {
 	}
 
 	return identities
+}
+
+type poller interface {
+	// Done returns true if the LRO has reached a terminal state.
+	Done() bool
+
+	// Poll fetches the latest state of the LRO.
+	Poll(ctx context.Context) (*http.Response, error)
+}
+
+// pendingRunCommandResult represents a pending run-command result that can be
+// polled.
+type pendingRunCommandResult struct {
+	poller        poller
+	getProperties func(ctx context.Context) (*armcompute.VirtualMachineRunCommandProperties, error)
+}
+
+// Poll polls the latest state of the run-command operation.
+func (r *pendingRunCommandResult) Poll(ctx context.Context) error {
+	_, err := r.poller.Poll(ctx)
+	return trace.Wrap(ConvertResponseError(err))
+}
+
+// Done returns true if the run-command result is ready.
+func (r *pendingRunCommandResult) Done() bool {
+	return r.poller.Done()
+}
+
+// Result returns the result of the run-command operation. Calling this on a
+// result that is not Done will return an error.
+func (r *pendingRunCommandResult) Result(ctx context.Context) (*RunCommandResult, error) {
+	if !r.Done() {
+		return nil, trace.BadParameter("command result is not available")
+	}
+	ctx, cancel := context.WithTimeout(ctx, time.Minute)
+	defer cancel()
+
+	props, err := r.getProperties(ctx)
+	if err != nil {
+		return nil, trace.Wrap(err, "get VM run command properties")
+	}
+
+	res, err := commandResultFromInstanceView(props)
+	if err != nil {
+		return nil, trace.Wrap(err, "convert VM run command properties to result")
+	}
+	return res, nil
 }

--- a/lib/srv/discovery/discovery.go
+++ b/lib/srv/discovery/discovery.go
@@ -455,7 +455,7 @@ type Server struct {
 	awsEC2Tasks           awsEC2Tasks
 	awsEKSTasks           awsEKSTasks
 	awsRDSTasks           awsRDSTasks
-	azureVMStatus         atomic.Pointer[resourceStatusMap]
+	azureVMStatus         atomic.Pointer[discoveryStatus]
 
 	// caRotationCh receives nodes that need to have their CAs rotated.
 	caRotationCh chan []types.Server
@@ -1456,9 +1456,9 @@ func (s *Server) startAWSServerDiscovery() {
 	go s.watchCARotation(s.ctx)
 }
 
-func (s *Server) emitAzureInstallEvents(log *slog.Logger, instances *server.AzureInstances, result server.AzureInstallResult) {
+func (s *Server) emitAzureInstallEvents(log *slog.Logger, md server.AzureInstancesMetadata, result server.AzureInstallResult) {
 	// emit run event.
-	runEvent := instances.MakeRunEvent(result)
+	runEvent := md.MakeRunEvent(result)
 	err := s.Emitter.EmitAuditEvent(s.ctx, runEvent)
 	if err != nil {
 		log.WarnContext(s.ctx, "Failed to emit audit event", "error", err)
@@ -1469,7 +1469,7 @@ func (s *Server) emitAzureInstallEvents(log *slog.Logger, instances *server.Azur
 	}
 
 	// on success, emit usage event.
-	vmKey, usageEvent := instances.MakeUsageEvent(result.Instance)
+	vmKey, usageEvent := md.MakeUsageEvent(result.Instance)
 	err = s.emitUsageEvent(vmKey, usageEvent)
 	if err != nil {
 		log.WarnContext(s.ctx, "Failed to emit usage event", "error", err)
@@ -1532,25 +1532,18 @@ func (e *limitedErrorReporter) summary(ctx context.Context) {
 	}
 }
 
-func (s *Server) enrollAzureVirtualMachines(log *slog.Logger, instances *server.AzureInstances) ([]server.AzureInstallResult, error) {
+// runAzureVMInstallers runs the installer script on Azure instances and returns
+// a list of result pollers to poll the results.
+func (s *Server) runAzureVMInstallers(instances *server.AzureInstances) ([]server.AzureInstallResultPoller, error) {
 	azureClients, err := s.getAzureClients(s.ctx, instances.Integration)
 	if err != nil {
-		return nil, trace.Wrap(err)
+		return nil, trace.Wrap(err, "failed to get Azure clients")
 	}
 
 	runClient, err := azureClients.GetRunCommandClient(s.ctx, instances.SubscriptionID)
 	if err != nil {
-		return nil, trace.Wrap(err)
+		return nil, trace.Wrap(err, "failed to get Azure Run Command client")
 	}
-
-	const maxReportedErrors = 10
-	reporter := &limitedErrorReporter{
-		logger:      log,
-		reportLimit: maxReportedErrors,
-	}
-
-	var mu sync.Mutex
-	var failedInstances []server.AzureInstallResult
 
 	req := server.AzureInstallRequest{
 		Instances:       instances.Instances,
@@ -1558,30 +1551,17 @@ func (s *Server) enrollAzureVirtualMachines(log *slog.Logger, instances *server.
 		ResourceGroup:   instances.ResourceGroup,
 		InstallerParams: instances.InstallerParams,
 		ProxyAddrGetter: s.publicProxyAddress,
-		OnRunCommandFinished: func(result server.AzureInstallResult) {
-			s.emitAzureInstallEvents(log, instances, result)
-			if result.Failure() {
-				reporter.report(s.ctx, result)
-
-				// collect the failed instance
-				mu.Lock()
-				failedInstances = append(failedInstances, result)
-				mu.Unlock()
-			}
-		},
 	}
 
-	err = req.Run(s.ctx, runClient)
+	pollers, err := req.Run(s.ctx, runClient)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
-	log.InfoContext(s.ctx, "Finished installation batch",
-		"total_instances", len(instances.Instances),
-		"failures", len(failedInstances))
-	reporter.summary(s.ctx)
-
-	return failedInstances, nil
+	s.Log.InfoContext(s.ctx, "Finished sending commands for installation group",
+		"group", instances,
+	)
+	return pollers, nil
 }
 
 // startAzureServerDiscovery starts the Azure VM discovery.
@@ -1616,7 +1596,7 @@ func (s *Server) startAzureServerDiscovery() {
 		azureWatcher.ReplaceFetchers(replaceMap)
 	}
 
-	var sm *resourceStatusMap
+	var sm *discoveryStatus
 	var vmTasks *azureVMTasks
 	var runStart time.Time
 
@@ -1639,28 +1619,29 @@ func (s *Server) startAzureServerDiscovery() {
 			// "0 found/enrolled/failed" update instead of leaving stale non-zero status from a
 			// previous iteration.
 			for _, fetcher := range fetchers {
-				fgKey := fetcherGroupKey{
+				fgKey := discoveryGroupStatusKey{
 					discoveryConfigName: fetcher.GetDiscoveryConfigName(),
 					integration:         fetcher.IntegrationName(),
 				}
-				sm.add(fgKey, make(map[statusType]int))
+				sm.set(fgKey, &discoveryGroupStatus{})
 			}
 			s.updateDiscoveryConfigStatus(sm.discoveryConfigs()...)
 		}),
 		server.WithPerInstanceHookFn(func(instanceGroups []*server.AzureInstances) {
 			for _, group := range instanceGroups {
-				fgKey := fetcherGroupKey{
+				key := discoveryGroupStatusKey{
 					discoveryConfigName: group.DiscoveryConfigName,
 					integration:         group.Integration,
 				}
-				results := s.installAzureServers(group, vmTasks)
-				sm.add(fgKey, results)
+				status := sm.get(key)
+				s.installAzureServers(group, status, vmTasks)
 			}
 		}),
 		server.WithPostFetchHookFn[*server.AzureInstances](func() {
 			// refresh the fetchers after every iteration to avoid stale config
 			defer fullRefresh()
 
+			s.processResults(s.ctx, sm, vmTasks)
 			sm.syncEnded(s.clock.Now())
 			// update statuses of relevant discovery configs.
 			s.azureVMStatus.Store(sm)
@@ -1681,19 +1662,15 @@ func (s *Server) startAzureServerDiscovery() {
 	go azureWatcher.Run()
 }
 
-func (s *Server) installAzureServers(instances *server.AzureInstances, vmTasks *azureVMTasks) (results map[statusType]int) {
-	results = make(map[statusType]int)
-
+func (s *Server) installAzureServers(instances *server.AzureInstances, status *discoveryGroupStatus, vmTasks *azureVMTasks) {
 	log := s.Log.With("group", instances)
 	log.DebugContext(s.ctx, "Processing instance group")
-
-	allFound := len(instances.Instances)
-	results[statusFound] = allFound
-
-	if allFound == 0 {
+	found := len(instances.Instances)
+	if found == 0 {
 		log.DebugContext(s.ctx, "No Azure instances found, skipping installation")
 		return
 	}
+	status.found += found
 
 	nodes, err := s.nodeWatcher.CurrentResources(s.ctx)
 	if err != nil {
@@ -1701,87 +1678,31 @@ func (s *Server) installAzureServers(instances *server.AzureInstances, vmTasks *
 		return
 	}
 	instances.FilterExistingNodes(nodes)
-
-	// count machines that have already been enrolled in previous cycles.
 	needInstall := len(instances.Instances)
-	results[statusEnrolled] = allFound - needInstall
+	status.enrolled += found - needInstall
 
 	if len(instances.Instances) == 0 {
 		log.DebugContext(s.ctx, "No Azure instances remain to enroll, skipping installation")
 		return
 	}
 
-	addFailedEnrollment := func(vm *azure.VirtualMachine, issueType string) {
-		// Static matchers don't have a discovery config resource, so skip creating user tasks
-		// because validation requires a discovery config name.
-		if instances.DiscoveryConfigName == noDiscoveryConfig {
-			return
-		}
-
-		tg := usertasks.TaskGroup{
-			Integration: instances.Integration,
-			IssueType:   issueType,
-		}
-		vmTasks.addFailedEnrollment(
-			tg,
-			azureVMTaskKey{
-				subscriptionID: instances.SubscriptionID,
-				resourceGroup:  instances.ResourceGroup,
-				region:         instances.Region,
-			},
-			&usertasksv1.DiscoverAzureVMInstance{
-				VmId:            vm.VMID,
-				ResourceId:      vm.ID,
-				Name:            vm.Name,
-				DiscoveryConfig: instances.DiscoveryConfigName,
-				DiscoveryGroup:  s.DiscoveryGroup,
-				SyncTime:        timestamppb.New(s.clock.Now()),
-			},
-		)
-	}
-
-	log.DebugContext(s.ctx, "Running Teleport installation on virtual machines", "group", instances, "vms", genAzureInstancesLogStr(instances.Instances))
-	failures, err := s.enrollAzureVirtualMachines(log, instances)
+	log.DebugContext(s.ctx, "Running Teleport installation on virtual machines",
+		"vms", genAzureInstancesLogStr(instances.Instances),
+	)
+	pollers, err := s.runAzureVMInstallers(instances)
 	if err != nil {
+		log.WarnContext(s.ctx, "Failed to enroll discovered Azure VMs", "error", err)
 		// treat non-nil err as deployment failure affecting all machines.
-		log.WarnContext(s.ctx, "Failed to enroll discovered Azure VMs", "error", err, "count", len(instances.Instances))
-		results[statusFailed] = len(instances.Instances)
-
+		status.failed += len(instances.Instances)
 		issueType := classifyAzureVMEnrollmentError(err)
 		for _, vm := range instances.Instances {
-			addFailedEnrollment(vm, issueType)
-		}
-		return
-	}
-
-	if len(failures) > 0 {
-		log.WarnContext(s.ctx, "Failed to enroll some discovered Azure VMs", "count", len(failures))
-	}
-
-	// count individual failed enrollments.
-	results[statusFailed] = len(failures)
-
-	// Record failures as user tasks.
-	for _, result := range failures {
-		if result.CommandResult != nil {
-			// TODO (Tener): check exit codes and create more detailed user tasks.
-			addFailedEnrollment(result.Instance, usertasks.AutoDiscoverAzureVMIssueEnrollmentError)
-		} else {
-			addFailedEnrollment(result.Instance, classifyAzureVMEnrollmentError(result.APIError))
+			s.addFailedAzureEnrollment(instances.AzureInstancesMetadata, vmTasks, vm, issueType)
 		}
 	}
-
-	pendingCount := len(instances.Instances) - len(failures)
-	if pendingCount > 0 {
-		// Note: we have no "installation in progress" or "installation succeeded" counter, so we ignore those.
-		// If the installation went fine the "enrolled" counter will increase during next iteration.
-		// Otherwise, we will try to enroll those once again, possibly failing.
-		// There is a gap here: we will ignore join failures as those happen out of our sight.
-		// There is no easy way to close that gap in the current architecture.
-		log.DebugContext(s.ctx, "Installation attempt finished. If the machines have joined the cluster successfully, they will be counted as enrolled during the next iteration.", "pending", pendingCount)
-	}
-
-	return
+	status.pending = append(status.pending, pendingInstall{
+		md:      instances.AzureInstancesMetadata,
+		pollers: pollers,
+	})
 }
 
 func (s *Server) filterExistingGCPNodes(instances *server.GCPInstances) error {
@@ -2383,4 +2304,74 @@ func (s *Server) resolveCreateErr(createErr error, discoveryOrigin string, gette
 	}
 
 	return nil
+}
+
+func (s *Server) processResults(ctx context.Context, sm *discoveryStatus, vmTasks *azureVMTasks) {
+	const maxReportedErrors = 10
+	reporter := &limitedErrorReporter{
+		logger:      s.Log,
+		reportLimit: maxReportedErrors,
+	}
+	defer reporter.summary(ctx)
+
+	var pollers []poller
+	for _, status := range sm.statuses {
+		for _, pending := range status.pending {
+			for _, poller := range pending.pollers {
+				pollers = append(pollers, poller)
+			}
+		}
+	}
+	manager := newPollerManager(s.Log, s.clock, pollers...)
+	manager.runWithTimeout(ctx, azureResultPollingTimeout)
+	for _, status := range sm.statuses {
+		for _, pending := range status.pending {
+			for _, poller := range pending.pollers {
+				result := poller.Result(ctx)
+				s.emitAzureInstallEvents(s.Log, pending.md, result)
+				if result.Failure() {
+					reporter.report(ctx, result)
+					status.failed++
+					s.addFailedAzureEnrollment(pending.md, vmTasks, result.Instance, getAzureIssueType(result))
+				}
+			}
+		}
+	}
+	s.Log.DebugContext(ctx, "Installation attempt finished. If the machines have joined the cluster successfully, they will be counted as enrolled during the next iteration.")
+}
+
+func (s *Server) addFailedAzureEnrollment(md server.AzureInstancesMetadata, vmTasks *azureVMTasks, vm *azure.VirtualMachine, issueType string) {
+	// Static matchers don't have a discovery config resource, so skip creating user tasks
+	// because validation requires a discovery config name.
+	if md.DiscoveryConfigName == noDiscoveryConfig {
+		return
+	}
+
+	tg := usertasks.TaskGroup{
+		Integration: md.Integration,
+		IssueType:   issueType,
+	}
+	vmTasks.addFailedEnrollment(
+		tg,
+		azureVMTaskKey{
+			subscriptionID: md.SubscriptionID,
+			resourceGroup:  md.ResourceGroup,
+			region:         md.Region,
+		},
+		&usertasksv1.DiscoverAzureVMInstance{
+			VmId:            vm.VMID,
+			ResourceId:      vm.ID,
+			Name:            vm.Name,
+			DiscoveryConfig: md.DiscoveryConfigName,
+			DiscoveryGroup:  s.DiscoveryGroup,
+			SyncTime:        timestamppb.New(s.clock.Now()),
+		},
+	)
+}
+
+func getAzureIssueType(installResult server.AzureInstallResult) string {
+	if installResult.CommandResult != nil {
+		return usertasks.AutoDiscoverAzureVMIssueEnrollmentError
+	}
+	return classifyAzureVMEnrollmentError(installResult.APIError)
 }

--- a/lib/srv/discovery/discovery_test.go
+++ b/lib/srv/discovery/discovery_test.go
@@ -3220,7 +3220,7 @@ type mockAzureRunCommandClient struct {
 	attemptedVMs map[string]struct{}
 }
 
-func (m *mockAzureRunCommandClient) Run(_ context.Context, req azure.RunCommandRequest) (*azure.RunCommandResult, error) {
+func (m *mockAzureRunCommandClient) Run(_ context.Context, req azure.RunCommandRequest) (azure.RunCommandResultPoller, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
@@ -3243,19 +3243,23 @@ func (m *mockAzureRunCommandClient) Run(_ context.Context, req azure.RunCommandR
 	}
 
 	if strings.HasPrefix(req.VMName, azureInstallErrorPrefix) {
-		return &azure.RunCommandResult{
-			ExecutionState: string(armcompute.ExecutionStateFailed),
-			StdErr:         "This is failure stderr",
-			StdOut:         "This is failure stdout",
-			ExitCode:       int32(installstatus.InsufficientDiskSpace),
+		return &mockAzureRunCommandPoller{
+			result: &azure.RunCommandResult{
+				ExecutionState: string(armcompute.ExecutionStateFailed),
+				StdErr:         "This is failure stderr",
+				StdOut:         "This is failure stdout",
+				ExitCode:       int32(installstatus.InsufficientDiskSpace),
+			},
 		}, nil
 	}
 
-	return &azure.RunCommandResult{
-		ExecutionState: string(armcompute.ExecutionStateSucceeded),
-		StdErr:         "This is success stderr",
-		StdOut:         "This is success stdout",
-		ExitCode:       0,
+	return &mockAzureRunCommandPoller{
+		result: &azure.RunCommandResult{
+			ExecutionState: string(armcompute.ExecutionStateSucceeded),
+			StdErr:         "This is success stderr",
+			StdOut:         "This is success stdout",
+			ExitCode:       0,
+		},
 	}, nil
 }
 
@@ -3264,6 +3268,23 @@ func (m *mockAzureRunCommandClient) getAttempted() []string {
 	elems := slices.Sorted(maps.Keys(m.attemptedVMs))
 	m.mu.Unlock()
 	return elems
+}
+
+type mockAzureRunCommandPoller struct {
+	result *azure.RunCommandResult
+	err    error
+}
+
+func (m *mockAzureRunCommandPoller) Poll(context.Context) error {
+	return nil
+}
+
+func (m *mockAzureRunCommandPoller) Done() bool {
+	return true
+}
+
+func (m *mockAzureRunCommandPoller) Result(context.Context) (*azure.RunCommandResult, error) {
+	return m.result, m.err
 }
 
 type mockAzureClient struct {

--- a/lib/srv/discovery/result_polling.go
+++ b/lib/srv/discovery/result_polling.go
@@ -1,0 +1,148 @@
+/*
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package discovery
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+	"time"
+
+	"github.com/jonboulle/clockwork"
+	"golang.org/x/sync/errgroup"
+
+	"github.com/gravitational/teleport/lib/cloud/azure"
+)
+
+const (
+	// azureResultPollingFrequency is how often Azure install results are polled.
+	azureResultPollingFrequency = 30 * time.Second
+	// azureResultPollingParallelism is the upper limit of the number of
+	// goroutines that poll Azure install command results.
+	azureResultPollingParallelism = 100
+)
+
+var (
+	// azureResultPollingTimeout is the amount of time given to collect all
+	// pending Azure install results.
+	azureResultPollingTimeout = max(
+		azure.GetRunCommandTimeout()+(5*time.Minute),
+		10*time.Minute,
+	)
+)
+
+// poller represents an operation that can be polled.
+type poller interface {
+	// Poll polls for a result. It returns true when polling is complete, either
+	// because the result is ready or the poller reached a terminal failure.
+	Poll(ctx context.Context) bool
+}
+
+// newPollerManager makes a new [pollerManager].
+func newPollerManager(log *slog.Logger, clock clockwork.Clock, pollers ...poller) *pollerManager {
+	return &pollerManager{
+		log:     log,
+		clock:   clock,
+		pending: pollers,
+	}
+}
+
+// pollerManager manages a queue of pollers, polling each one in parallel
+// batches.
+type pollerManager struct {
+	log   *slog.Logger
+	clock clockwork.Clock
+
+	// pending is the list of results to poll next.
+	pending []poller
+	// doneCount is the count of pollers that completed.
+	doneCount int
+}
+
+// runWithTimeout calls run with a timeout.
+func (m *pollerManager) runWithTimeout(ctx context.Context, timeout time.Duration) {
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	m.run(ctx)
+}
+
+// run polls all pending pollers until either all of the results have been
+// resolved or the context is canceled.
+func (m *pollerManager) run(ctx context.Context) {
+	ticker := m.clock.NewTicker(azureResultPollingFrequency)
+	defer ticker.Stop()
+
+	for m.pollOnce(ctx) {
+		select {
+		case <-ctx.Done():
+			m.log.DebugContext(ctx, "Aborted installation result collection",
+				"error", ctx.Err(),
+				"results", m.resultsLogValue(),
+			)
+			return
+		case <-ticker.Chan():
+		}
+	}
+	m.log.DebugContext(ctx, "Successfully completed installation result collection",
+		"results", m.resultsLogValue(),
+	)
+}
+
+// pollOnce iterates over all enqueued items, polls each item once for a result,
+// and returns true if there are items remaining its queue.
+func (m *pollerManager) pollOnce(ctx context.Context) bool {
+	if len(m.pending) == 0 {
+		return false
+	}
+
+	m.log.DebugContext(ctx, "Polling pending installation results",
+		"results", m.resultsLogValue(),
+	)
+	g, ctx := errgroup.WithContext(ctx)
+	g.SetLimit(azureResultPollingParallelism)
+
+	pollers := m.pending
+	m.pending = nil
+	var mu sync.Mutex
+	for _, poller := range pollers {
+		g.Go(func() error {
+			done := poller.Poll(ctx)
+			mu.Lock()
+			defer mu.Unlock()
+			if !done {
+				m.pending = append(m.pending, poller)
+				return nil
+			}
+			m.doneCount++
+			return nil
+		})
+	}
+	_ = g.Wait()
+	return len(m.pending) > 0
+}
+
+// resultsLogValue returns a [slog.Value] summarizing the poller results.
+// The caller of this func must hold the poller state mutex.
+func (m *pollerManager) resultsLogValue() slog.Value {
+	return slog.GroupValue(
+		slog.Int("done", m.doneCount),
+		slog.Int("pending", len(m.pending)),
+		slog.Int("total", m.doneCount+len(m.pending)),
+	)
+}

--- a/lib/srv/discovery/result_polling_test.go
+++ b/lib/srv/discovery/result_polling_test.go
@@ -1,0 +1,204 @@
+/*
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package discovery
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"testing/synctest"
+	"time"
+
+	"github.com/jonboulle/clockwork"
+	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport/lib/utils/log/logtest"
+)
+
+func TestPollerManagerPollOnce(t *testing.T) {
+	tests := []struct {
+		name           string
+		pollers        []*testPoller
+		wantPending    bool
+		wantDoneCount  int
+		wantPendingLen int
+	}{
+		{
+			name: "empty queue",
+		},
+		{
+			name: "completed poller",
+			pollers: []*testPoller{
+				{doneAfterPolls: 1},
+			},
+			wantDoneCount: 1,
+		},
+		{
+			name: "pending poller",
+			pollers: []*testPoller{
+				{doneAfterPolls: 2},
+			},
+			wantPending:    true,
+			wantPendingLen: 1,
+		},
+		{
+			name: "poll error is terminal",
+			pollers: []*testPoller{
+				{
+					doneAfterPolls: 2,
+					pollErrors:     []error{errors.New("transient error")},
+				},
+			},
+			wantDoneCount: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			pollers := make([]poller, 0, len(tt.pollers))
+			for _, poller := range tt.pollers {
+				pollers = append(pollers, poller)
+			}
+			manager := newPollerManager(logtest.NewLogger(), clockwork.NewFakeClock(), pollers...)
+
+			require.Equal(t, tt.wantPending, manager.pollOnce(context.Background()))
+			require.Equal(t, tt.wantDoneCount, manager.doneCount)
+			require.Len(t, manager.pending, tt.wantPendingLen)
+
+			for _, poller := range tt.pollers {
+				require.Equal(t, 1, poller.pollCount())
+			}
+		})
+	}
+
+	t.Run("retries pending pollers", func(t *testing.T) {
+		poller := &testPoller{
+			doneAfterPolls: 2,
+		}
+		manager := newPollerManager(logtest.NewLogger(), clockwork.NewFakeClock(), poller)
+
+		require.True(t, manager.pollOnce(context.Background()))
+		require.Len(t, manager.pending, 1)
+		require.Zero(t, manager.doneCount)
+		require.Equal(t, 1, poller.pollCount())
+
+		require.False(t, manager.pollOnce(context.Background()))
+		require.Empty(t, manager.pending)
+		require.Equal(t, 1, manager.doneCount)
+		require.Equal(t, 2, poller.pollCount())
+	})
+}
+
+func TestPollerManagerRun(t *testing.T) {
+	t.Run("polls until all pollers are done", func(t *testing.T) {
+		synctest.Test(t, func(t *testing.T) {
+			poller := &testPoller{doneAfterPolls: 3}
+			manager := newPollerManager(logtest.NewLogger(), clockwork.NewRealClock(), poller)
+
+			manager.run(t.Context())
+
+			require.Equal(t, 3, poller.pollCount())
+			require.Empty(t, manager.pending)
+			require.Equal(t, 1, manager.doneCount)
+		})
+	})
+
+	t.Run("stops when context is canceled", func(t *testing.T) {
+		synctest.Test(t, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(t.Context())
+			defer cancel()
+
+			poller := &testPoller{
+				onPoll: func(polls int) {
+					if polls == 2 {
+						cancel()
+					}
+				},
+			}
+			manager := newPollerManager(logtest.NewLogger(), clockwork.NewRealClock(), poller)
+
+			manager.run(ctx)
+
+			require.Equal(t, 2, poller.pollCount())
+			require.Len(t, manager.pending, 1)
+			require.Zero(t, manager.doneCount)
+		})
+	})
+}
+
+func TestPollerManagerRunWithTimeout(t *testing.T) {
+	t.Run("polls until all pollers are done before timeout", func(t *testing.T) {
+		synctest.Test(t, func(t *testing.T) {
+			poller := &testPoller{doneAfterPolls: 2}
+			manager := newPollerManager(logtest.NewLogger(), clockwork.NewRealClock(), poller)
+
+			manager.runWithTimeout(t.Context(), 2*azureResultPollingFrequency)
+
+			require.Equal(t, 2, poller.pollCount())
+			require.Empty(t, manager.pending)
+			require.Equal(t, 1, manager.doneCount)
+		})
+	})
+
+	t.Run("stops when timeout expires", func(t *testing.T) {
+		synctest.Test(t, func(t *testing.T) {
+			poller := &testPoller{}
+			manager := newPollerManager(logtest.NewLogger(), clockwork.NewRealClock(), poller)
+
+			manager.runWithTimeout(t.Context(), azureResultPollingFrequency-time.Nanosecond)
+
+			require.Equal(t, 1, poller.pollCount())
+			require.Len(t, manager.pending, 1)
+			require.Zero(t, manager.doneCount)
+		})
+	})
+}
+
+type testPoller struct {
+	mu sync.Mutex
+
+	doneAfterPolls int
+	pollErrors     []error
+	onPoll         func(polls int)
+	polls          int
+}
+
+func (p *testPoller) Poll(context.Context) bool {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	p.polls++
+	if p.onPoll != nil {
+		p.onPoll(p.polls)
+	}
+	if p.polls <= len(p.pollErrors) {
+		return true
+	}
+	return p.doneAfterPolls > 0 && p.polls >= p.doneAfterPolls
+}
+
+func (p *testPoller) pollCount() int {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	return p.polls
+}

--- a/lib/srv/discovery/status.go
+++ b/lib/srv/discovery/status.go
@@ -1071,66 +1071,71 @@ func (s *taskUpdater) mergeAzure(oldSpec *usertasksv1.UserTaskSpec, newSpec *use
 	mergeExistingInstances(s, oldSpec.DiscoverAzureVm.Instances, newSpec.DiscoverAzureVm.Instances)
 }
 
-type statusType int
-
-const (
-	statusFound statusType = iota
-	statusEnrolled
-	statusFailed
-)
-
-type fetcherGroupKey struct {
+type discoveryGroupStatusKey struct {
 	discoveryConfigName string
 	integration         string
 }
 
-// resourceStatusMap tracks discovery status (found/enrolled/failed counts)
-// per fetcher group key (discovery config + integration combination).
-type resourceStatusMap struct {
+type discoveryGroupStatus struct {
+	found    int
+	enrolled int
+	failed   int
+	pending  []pendingInstall
+}
+
+// pendingInstall is a pending result of running install commands for a group of
+// fetched instances.
+type pendingInstall struct {
+	md server.AzureInstancesMetadata
+	// pollers are the pending results of commands sent to machines.
+	// Each collector corresponds to a single VM command.
+	// Results are collected after sending all commands to efficiently pipeline
+	// installs rather than performing the installs and collections serially.
+	pollers []server.AzureInstallResultPoller
+}
+
+// discoveryStatus tracks discovery status (found/enrolled/failed counts) per
+// discovery group key (discovery config + integration combination).
+type discoveryStatus struct {
 	resourceType string
-	results      map[fetcherGroupKey]map[statusType]int
+	statuses     map[discoveryGroupStatusKey]*discoveryGroupStatus
 	syncStart    *time.Time
 	syncEnd      *time.Time
 }
 
-func newStatusMap(resourceType string, syncStart time.Time) *resourceStatusMap {
-	return &resourceStatusMap{
+func newStatusMap(resourceType string, syncStart time.Time) *discoveryStatus {
+	return &discoveryStatus{
 		resourceType: resourceType,
-		results:      make(map[fetcherGroupKey]map[statusType]int),
+		statuses:     make(map[discoveryGroupStatusKey]*discoveryGroupStatus),
 		syncStart:    &syncStart,
 	}
 }
 
-func (s *resourceStatusMap) syncEnded(syncEnd time.Time) {
+func (s *discoveryStatus) syncEnded(syncEnd time.Time) {
 	s.syncEnd = &syncEnd
 }
 
-func (s *resourceStatusMap) add(key fetcherGroupKey, results map[statusType]int) {
-	if s.results[key] == nil {
-		s.results[key] = make(map[statusType]int)
-	}
-	for k, v := range results {
-		s.results[key][k] += v
-	}
+func (s *discoveryStatus) set(key discoveryGroupStatusKey, status *discoveryGroupStatus) {
+	s.statuses[key] = status
 }
 
-func (s *resourceStatusMap) mergeIntoGlobalStatus(discoveryConfigName string, existingStatus discoveryconfig.Status) discoveryconfig.Status {
+func (s *discoveryStatus) get(key discoveryGroupStatusKey) *discoveryGroupStatus {
+	return s.statuses[key]
+}
+
+func (s *discoveryStatus) mergeIntoGlobalStatus(discoveryConfigName string, existingStatus discoveryconfig.Status) discoveryconfig.Status {
 	if s == nil {
 		// nil resourceStatusMap is valid, just empty.
 		return existingStatus
 	}
 
-	for key, results := range s.results {
+	for key, group := range s.statuses {
 		if key.discoveryConfigName != discoveryConfigName {
 			continue
 		}
 
-		if results == nil {
-			continue
-		}
-
 		// Update global discovered resources count.
-		existingStatus.DiscoveredResources = existingStatus.DiscoveredResources + uint64(results[statusFound])
+		existingStatus.DiscoveredResources += uint64(group.found)
 
 		// Initialize map if needed.
 		if existingStatus.IntegrationDiscoveredResources == nil {
@@ -1153,9 +1158,9 @@ func (s *resourceStatusMap) mergeIntoGlobalStatus(discoveryConfigName string, ex
 		}
 
 		resourcesSummary := &discoveryconfigv1.ResourcesDiscoveredSummary{
-			Found:     uint64(results[statusFound]),
-			Enrolled:  uint64(results[statusEnrolled]),
-			Failed:    uint64(results[statusFailed]),
+			Found:     uint64(group.found),
+			Enrolled:  uint64(group.enrolled),
+			Failed:    uint64(group.failed),
 			SyncStart: syncStart,
 			SyncEnd:   syncEnd,
 		}
@@ -1168,13 +1173,13 @@ func (s *resourceStatusMap) mergeIntoGlobalStatus(discoveryConfigName string, ex
 	return existingStatus
 }
 
-func (s *resourceStatusMap) discoveryConfigs() []string {
+func (s *discoveryStatus) discoveryConfigs() []string {
 	if s == nil {
 		return nil
 	}
 
 	names := map[string]struct{}{}
-	for key := range s.results {
+	for key := range s.statuses {
 		names[key.discoveryConfigName] = struct{}{}
 	}
 	return slices.Collect(maps.Keys(names))

--- a/lib/srv/server/azure_installer.go
+++ b/lib/srv/server/azure_installer.go
@@ -20,6 +20,7 @@ package server
 
 import (
 	"context"
+	"sync"
 
 	"github.com/gravitational/trace"
 	"golang.org/x/sync/errgroup"
@@ -54,9 +55,18 @@ func (r AzureInstallResult) Failure() bool {
 	return r.APIError != nil || (r.CommandResult != nil && r.CommandResult.Failure())
 }
 
-// Run initiates Teleport installation on a set of virtual machines and then blocks until the
-// commands have completed.
-func (req *AzureInstallRequest) Run(ctx context.Context, client azure.RunCommandClient) error {
+// AzureInstallResultPoller polls the result of an Azure VM installation.
+type AzureInstallResultPoller interface {
+	// Poll polls for a result. It returns true when polling is complete, either
+	// because the result is ready or the poller reached a terminal failure.
+	Poll(ctx context.Context) bool
+	// Result returns an [AzureInstallResult]. The result may contain an API error
+	// if the install command failed to run or the result is not yet ready.
+	Result(ctx context.Context) AzureInstallResult
+}
+
+// Run initiates Teleport installation on a set of virtual machines without waiting for the commands to complete.
+func (req *AzureInstallRequest) Run(ctx context.Context, client azure.RunCommandClient) ([]AzureInstallResultPoller, error) {
 	// Azure treats scripts with the same content as the same invocation and
 	// won't run them more than once. This is fine when the installer script
 	// succeeds, but it makes troubleshooting much harder when it fails. To
@@ -64,7 +74,7 @@ func (req *AzureInstallRequest) Run(ctx context.Context, client azure.RunCommand
 	// to the script, forcing Azure to see each invocation as unique.
 	script, err := installerScript(ctx, req.InstallerParams, withNonceComment(), withProxyAddrGetter(req.ProxyAddrGetter))
 	if err != nil {
-		return trace.Wrap(err)
+		return nil, trace.Wrap(err)
 	}
 	g, ctx := errgroup.WithContext(ctx)
 
@@ -74,6 +84,8 @@ func (req *AzureInstallRequest) Run(ctx context.Context, client azure.RunCommand
 	const azureParallelInstallLimit = 10
 	g.SetLimit(azureParallelInstallLimit)
 
+	var resultPollers []AzureInstallResultPoller
+	var mu sync.Mutex
 	for _, inst := range req.Instances {
 		g.Go(func() error {
 			// If the caller cancels, stop trying to run more commands.
@@ -90,19 +102,67 @@ func (req *AzureInstallRequest) Run(ctx context.Context, client azure.RunCommand
 				UniformScaleSetVMInstanceID: inst.UniformScaleSetVMInstanceID,
 			}
 
-			commandResult, apiError := client.Run(ctx, runRequest)
-			if req.OnRunCommandFinished != nil {
-				req.OnRunCommandFinished(AzureInstallResult{
-					Instance:      inst,
-					APIError:      apiError,
-					CommandResult: commandResult,
-				})
-			}
+			runCommandPoller, err := client.Run(ctx, runRequest)
+			mu.Lock()
+			resultPollers = append(resultPollers, &azureInstallResultPoller{
+				instance: inst,
+				poller:   runCommandPoller,
+				apiError: err,
+			})
+			mu.Unlock()
 
 			// local failure should not affect other runs.
 			return nil
 		})
 	}
 
-	return trace.Wrap(g.Wait())
+	if err := g.Wait(); err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return resultPollers, nil
+}
+
+// azureInstallResultPoller polls a run command result.
+type azureInstallResultPoller struct {
+	instance *azure.VirtualMachine
+	poller   azure.RunCommandResultPoller
+	apiError error
+}
+
+// Poll polls for a result.
+func (p *azureInstallResultPoller) Poll(ctx context.Context) bool {
+	if p.apiError != nil || p.poller == nil {
+		return true
+	}
+
+	err := trace.Wrap(p.poller.Poll(ctx))
+	if err != nil {
+		p.apiError = err
+		return true
+	}
+	return p.poller.Done()
+}
+
+// Result returns an [AzureInstallResult]. The result may contain an API error
+// if the install command failed to run or the result is not yet ready.
+func (p *azureInstallResultPoller) Result(ctx context.Context) AzureInstallResult {
+	if p.apiError != nil {
+		return AzureInstallResult{
+			Instance: p.instance,
+			APIError: p.apiError,
+		}
+	}
+	if p.poller == nil {
+		return AzureInstallResult{
+			Instance: p.instance,
+			APIError: trace.BadParameter("missing Azure run command poller"),
+		}
+	}
+
+	result, err := p.poller.Result(ctx)
+	return AzureInstallResult{
+		APIError:      err,
+		Instance:      p.instance,
+		CommandResult: result,
+	}
 }

--- a/lib/srv/server/azure_installer_test.go
+++ b/lib/srv/server/azure_installer_test.go
@@ -21,7 +21,6 @@ import (
 	"errors"
 	"slices"
 	"strings"
-	"sync"
 	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v6"
@@ -35,17 +34,39 @@ import (
 type mockRunCommandClient struct {
 }
 
-func (m *mockRunCommandClient) Run(ctx context.Context, req azure.RunCommandRequest) (*azure.RunCommandResult, error) {
+func (m *mockRunCommandClient) Run(_ context.Context, req azure.RunCommandRequest) (azure.RunCommandResultPoller, error) {
 	if strings.HasPrefix(req.VMName, "bad") {
 		return nil, trace.BadParameter("VM is bad: %v", req.VMName)
 	}
 
-	return &azure.RunCommandResult{
-		ExecutionState: string(armcompute.ExecutionStateSucceeded),
-		ExitCode:       0,
-		StdOut:         "Mock stdout",
-		StdErr:         "Mock stderr",
+	return &fakeRunCommandPoller{
+		result: &azure.RunCommandResult{
+			ExecutionState: string(armcompute.ExecutionStateSucceeded),
+			ExitCode:       0,
+			StdOut:         "Mock stdout",
+			StdErr:         "Mock stderr",
+		},
+		done: true,
 	}, nil
+}
+
+type fakeRunCommandPoller struct {
+	result  *azure.RunCommandResult
+	err     error
+	pollErr error
+	done    bool
+}
+
+func (f *fakeRunCommandPoller) Poll(context.Context) error {
+	return f.pollErr
+}
+
+func (f *fakeRunCommandPoller) Done() bool {
+	return f.done
+}
+
+func (f *fakeRunCommandPoller) Result(context.Context) (*azure.RunCommandResult, error) {
+	return f.result, f.err
 }
 
 func TestAzureInstallRequestRun(t *testing.T) {
@@ -110,7 +131,6 @@ func TestAzureInstallRequestRun(t *testing.T) {
 				}
 			}
 
-			var mu sync.Mutex
 			var failed []string
 			var good []string
 
@@ -123,18 +143,23 @@ func TestAzureInstallRequestRun(t *testing.T) {
 				ProxyAddrGetter: proxyAddrGetter,
 				Region:          "eastus",
 				ResourceGroup:   "test-rg",
-				OnRunCommandFinished: func(result AzureInstallResult) {
-					mu.Lock()
-					defer mu.Unlock()
-					if result.Failure() {
-						failed = append(failed, result.Instance.ID)
-					} else {
-						good = append(good, result.Instance.ID)
-					}
-				},
+			}
+			pollers, err := req.Run(t.Context(), client)
+			if tt.wantErr != "" {
+				require.ErrorContains(t, err, tt.wantErr)
+			} else {
+				require.NoError(t, err)
 			}
 
-			err := req.Run(t.Context(), client)
+			for _, p := range pollers {
+				require.True(t, p.Poll(t.Context()))
+				result := p.Result(t.Context())
+				if result.Failure() {
+					failed = append(failed, result.Instance.ID)
+				} else {
+					good = append(good, result.Instance.ID)
+				}
+			}
 
 			slices.Sort(failed)
 			slices.Sort(good)
@@ -142,11 +167,27 @@ func TestAzureInstallRequestRun(t *testing.T) {
 			require.Equal(t, tt.wantFailed, failed)
 			require.Equal(t, tt.wantOK, good)
 
-			if tt.wantErr != "" {
-				require.ErrorContains(t, err, tt.wantErr)
-			} else {
-				require.NoError(t, err)
-			}
 		})
 	}
+}
+
+func TestAzureInstallResultPollerPollError(t *testing.T) {
+	instance := &azure.VirtualMachine{
+		ID:   "vm-1",
+		Name: "vm-1",
+	}
+	pollErr := trace.AccessDenied("poll failed")
+	poller := &azureInstallResultPoller{
+		instance: instance,
+		poller: &fakeRunCommandPoller{
+			pollErr: pollErr,
+		},
+	}
+
+	require.True(t, poller.Poll(t.Context()))
+
+	result := poller.Result(t.Context())
+	require.Same(t, instance, result.Instance)
+	require.Nil(t, result.CommandResult)
+	require.ErrorContains(t, result.APIError, "poll failed")
 }

--- a/lib/srv/server/azure_watcher.go
+++ b/lib/srv/server/azure_watcher.go
@@ -38,8 +38,8 @@ import (
 
 const azureEventPrefix = "azure/"
 
-// AzureInstances contains information about discovered Azure virtual machines.
-type AzureInstances struct {
+// AzureInstancesMetadata contains information about discovered Azure virtual machines.
+type AzureInstancesMetadata struct {
 	// DiscoveryConfigName is the name of discovery config.
 	DiscoveryConfigName string
 	// Integration is the optional name of the integration to use for auth.
@@ -54,43 +54,40 @@ type AzureInstances struct {
 
 	// InstallerParams are the installer parameters used for installation.
 	InstallerParams *types.InstallerParams
-	// Instances is a list of discovered Azure virtual machines.
-	Instances []*azure.VirtualMachine
 }
 
-func (instances *AzureInstances) LogValue() slog.Value {
-	if instances == nil {
-		return slog.StringValue("<nil>")
+func (md *AzureInstancesMetadata) LogValue() slog.Value {
+	if md == nil {
+		return slog.Value{}
 	}
 	return slog.GroupValue(
-		slog.Int("total_instances", len(instances.Instances)),
-		slog.String("discovery_config", instances.DiscoveryConfigName),
-		slog.String("integration", instances.Integration),
-		slog.String("region", instances.Region),
-		slog.String("resource_group", instances.ResourceGroup),
-		slog.String("subscription_id", instances.SubscriptionID),
+		slog.String("discovery_config", md.DiscoveryConfigName),
+		slog.String("integration", md.Integration),
+		slog.String("region", md.Region),
+		slog.String("resource_group", md.ResourceGroup),
+		slog.String("subscription_id", md.SubscriptionID),
 	)
 }
 
-func (instances *AzureInstances) resourceType() string {
-	if instances.InstallerParams != nil && instances.InstallerParams.ScriptName == installers.InstallerScriptNameAgentless {
+func (md *AzureInstancesMetadata) resourceType() string {
+	if md.InstallerParams != nil && md.InstallerParams.ScriptName == installers.InstallerScriptNameAgentless {
 		return types.DiscoveredResourceAgentlessNode
 	}
 	return types.DiscoveredResourceNode
 }
 
 // MakeUsageEvent builds usage event for a single installation result.
-func (instances *AzureInstances) MakeUsageEvent(instance *azure.VirtualMachine) (string, *usageeventsv1.ResourceCreateEvent) {
+func (md *AzureInstancesMetadata) MakeUsageEvent(instance *azure.VirtualMachine) (string, *usageeventsv1.ResourceCreateEvent) {
 	return azureEventPrefix + instance.ID, &usageeventsv1.ResourceCreateEvent{
-		ResourceType:        instances.resourceType(),
+		ResourceType:        md.resourceType(),
 		ResourceOrigin:      types.OriginCloud,
 		CloudProvider:       types.CloudAzure,
-		DiscoveryConfigName: instances.DiscoveryConfigName,
+		DiscoveryConfigName: md.DiscoveryConfigName,
 	}
 }
 
 // MakeRunEvent builds run event for a single command run.
-func (instances *AzureInstances) MakeRunEvent(result AzureInstallResult) *apievents.AzureRun {
+func (md *AzureInstancesMetadata) MakeRunEvent(result AzureInstallResult) *apievents.AzureRun {
 	eventCode := libevents.AzureRunSuccessCode
 
 	if result.Failure() {
@@ -110,10 +107,10 @@ func (instances *AzureInstances) MakeRunEvent(result AzureInstallResult) *apieve
 			Code: eventCode,
 		},
 		AzureMetadata: apievents.AzureMetadata{
-			SubscriptionID: instances.SubscriptionID,
-			ResourceGroup:  instances.ResourceGroup,
+			SubscriptionID: md.SubscriptionID,
+			ResourceGroup:  md.ResourceGroup,
 			ResourceID:     resourceID,
-			Region:         instances.Region,
+			Region:         md.Region,
 		},
 		AzureVMMetadata: apievents.AzureVMMetadata{
 			VMID:   vmID,
@@ -141,6 +138,14 @@ func (instances *AzureInstances) MakeRunEvent(result AzureInstallResult) *apieve
 	}
 
 	return evt
+}
+
+// AzureInstances contains information about discovered Azure virtual machines.
+type AzureInstances struct {
+	AzureInstancesMetadata
+
+	// Instances is a list of discovered Azure virtual machines.
+	Instances []*azure.VirtualMachine
 }
 
 // FilterExistingNodes removes instances matching existing nodes in place.
@@ -320,13 +325,15 @@ func (f *azureInstanceFetcher) GetInstances(ctx context.Context, _ bool) ([]*Azu
 	var instances []*AzureInstances
 	for batchGroup, vms := range instanceGroups {
 		instances = append(instances, &AzureInstances{
-			SubscriptionID:      f.Subscription,
-			Region:              batchGroup.location,
-			ResourceGroup:       batchGroup.resourceGroup,
-			Instances:           vms,
-			Integration:         f.Integration,
-			InstallerParams:     f.InstallerParams,
-			DiscoveryConfigName: f.DiscoveryConfigName,
+			AzureInstancesMetadata: AzureInstancesMetadata{
+				SubscriptionID:      f.Subscription,
+				Region:              batchGroup.location,
+				ResourceGroup:       batchGroup.resourceGroup,
+				Integration:         f.Integration,
+				InstallerParams:     f.InstallerParams,
+				DiscoveryConfigName: f.DiscoveryConfigName,
+			},
+			Instances: vms,
 		})
 	}
 

--- a/lib/srv/server/azure_watcher_test.go
+++ b/lib/srv/server/azure_watcher_test.go
@@ -300,7 +300,9 @@ func TestAzureInstances_FilterExistingNodes(t *testing.T) {
 		{
 			name: "no existing nodes",
 			instances: &AzureInstances{
-				SubscriptionID: "sub-1",
+				AzureInstancesMetadata: AzureInstancesMetadata{
+					SubscriptionID: "sub-1",
+				},
 				Instances: []*azure.VirtualMachine{
 					{
 						ID:   "/subscriptions/sub-1/resourceGroups/rg1/providers/Microsoft.Compute/virtualMachines/vm1",
@@ -318,7 +320,9 @@ func TestAzureInstances_FilterExistingNodes(t *testing.T) {
 		{
 			name: "filter out matching node",
 			instances: &AzureInstances{
-				SubscriptionID: "sub-1",
+				AzureInstancesMetadata: AzureInstancesMetadata{
+					SubscriptionID: "sub-1",
+				},
 				Instances: []*azure.VirtualMachine{
 					{
 						ID:   "/subscriptions/sub-1/resourceGroups/rg1/providers/Microsoft.Compute/virtualMachines/vm1",
@@ -338,7 +342,9 @@ func TestAzureInstances_FilterExistingNodes(t *testing.T) {
 		{
 			name: "filter out all matching nodes",
 			instances: &AzureInstances{
-				SubscriptionID: "sub-1",
+				AzureInstancesMetadata: AzureInstancesMetadata{
+					SubscriptionID: "sub-1",
+				},
 				Instances: []*azure.VirtualMachine{
 					{
 						ID:   "/subscriptions/sub-1/resourceGroups/rg1/providers/Microsoft.Compute/virtualMachines/vm1",
@@ -359,7 +365,9 @@ func TestAzureInstances_FilterExistingNodes(t *testing.T) {
 		{
 			name: "different subscription is not filtered",
 			instances: &AzureInstances{
-				SubscriptionID: "sub-1",
+				AzureInstancesMetadata: AzureInstancesMetadata{
+					SubscriptionID: "sub-1",
+				},
 				Instances: []*azure.VirtualMachine{
 					{
 						ID:   "/subscriptions/sub-1/resourceGroups/rg1/providers/Microsoft.Compute/virtualMachines/vm1",
@@ -375,7 +383,9 @@ func TestAzureInstances_FilterExistingNodes(t *testing.T) {
 		{
 			name: "node without vm id is not used for filtering",
 			instances: &AzureInstances{
-				SubscriptionID: "sub-1",
+				AzureInstancesMetadata: AzureInstancesMetadata{
+					SubscriptionID: "sub-1",
+				},
 				Instances: []*azure.VirtualMachine{
 					{
 						ID:   "/subscriptions/sub-1/resourceGroups/rg1/providers/Microsoft.Compute/virtualMachines/vm1",
@@ -391,7 +401,9 @@ func TestAzureInstances_FilterExistingNodes(t *testing.T) {
 		{
 			name: "instance without properties is not filtered",
 			instances: &AzureInstances{
-				SubscriptionID: "sub-1",
+				AzureInstancesMetadata: AzureInstancesMetadata{
+					SubscriptionID: "sub-1",
+				},
 				Instances: []*azure.VirtualMachine{
 					{
 						ID: "/subscriptions/sub-1/resourceGroups/rg1/providers/Microsoft.Compute/virtualMachines/vm1",
@@ -612,9 +624,11 @@ func TestMakeRunEvent(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			instances := &AzureInstances{
-				SubscriptionID: subscriptionID,
-				ResourceGroup:  resourceGroup,
-				Region:         region,
+				AzureInstancesMetadata: AzureInstancesMetadata{
+					SubscriptionID: subscriptionID,
+					ResourceGroup:  resourceGroup,
+					Region:         region,
+				},
 			}
 			evt := instances.MakeRunEvent(tc.result)
 			require.Equal(t, tc.want, evt)
@@ -643,7 +657,9 @@ func TestMakeUsageEvent(t *testing.T) {
 		{
 			name: "node",
 			instances: &AzureInstances{
-				DiscoveryConfigName: discoveryConfig,
+				AzureInstancesMetadata: AzureInstancesMetadata{
+					DiscoveryConfigName: discoveryConfig,
+				},
 			},
 			wantKey: azureEventPrefix + resourceID,
 			want: &usageeventsv1.ResourceCreateEvent{
@@ -656,9 +672,11 @@ func TestMakeUsageEvent(t *testing.T) {
 		{
 			name: "agentless node",
 			instances: &AzureInstances{
-				DiscoveryConfigName: discoveryConfig,
-				InstallerParams: &types.InstallerParams{
-					ScriptName: installers.InstallerScriptNameAgentless,
+				AzureInstancesMetadata: AzureInstancesMetadata{
+					DiscoveryConfigName: discoveryConfig,
+					InstallerParams: &types.InstallerParams{
+						ScriptName: installers.InstallerScriptNameAgentless,
+					},
 				},
 			},
 			wantKey: azureEventPrefix + resourceID,


### PR DESCRIPTION
Issue: https://github.com/gravitational/teleport/issues/67402
- https://github.com/gravitational/teleport/issues/67402

Send all VM installer commands without waiting for results. After all commands have been sent, poll the results in batches in parallel with a timeout.

<!-- Provide a descriptive entry for the changelog of the next release. -->

Changelog: Reduced the time it takes to run Azure VM discovery.


<!-- Include manual testing efforts to verify the change. -->
<!-- Detail where the tests where run and what configurations were used. -->
<!-- Include all the test cases which were run to validate the change. -->

## Manual Test Plan
### Test Environment
- cloud staging tenant
- multiple Azure VMs:
  - standalone VMs
  - uniform scaleset VMs

### Test Cases
- [ ] discovers all VMs that match discovery config
- [ ] installs teleport on expected VM (no issues with the run-command agent or networking)
- [ ] scripts that take longer than 5 minutes to run still timeout
- [ ] run-commands that never progress to a terminal state (`systemctl stop walinuxagent` for example) only block the discovery scan for up to 10 minutes
