### PR TITLE
Correct TTL Comment in lib/limiter

### DIFF
--- a/lib/limiter/internal/ratelimit/ratelimit.go
+++ b/lib/limiter/internal/ratelimit/ratelimit.go
@@ -127,7 +127,7 @@ func (tl *TokenLimiter) consumeRates(source string, amount int64) error {
 	defer tl.mutex.Unlock()
 
 	// We set the TTL as 10 times the rate period. E.g. if rate is 100 requests/second
-	// per client IP, the counters for this IP will expire after 10 seconds of inactivity.
+	// per client IP, the counters for this IP will expire after 10 seconds.
 	ttl := tl.defaultRates.MaxPeriod()*10 + 1
 	bucketSet, err := utils.FnCacheGetWithTTL(context.TODO(), tl.bucketSets, source, ttl,
 		func(ctx context.Context) (*TokenBucketSet, error) {

--- a/lib/limiter/ratelimiter.go
+++ b/lib/limiter/ratelimiter.go
@@ -125,7 +125,7 @@ func (l *RateLimiter) RegisterRequest(token string) error {
 	defer l.mu.Unlock()
 
 	// We set the TTL as 10 times the rate period. E.g. if rate is 100 requests/second
-	// per client IP, the counters for this IP will expire after 10 seconds of inactivity.
+	// per client IP, the counters for this IP will expire after 10 seconds.
 	ttl := l.rates.MaxPeriod()*10 + 1
 	bucketSet, err := utils.FnCacheGetWithTTL(context.TODO(), l.rateLimits, token, ttl,
 		func(ctx context.Context) (*ratelimit.TokenBucketSet, error) {


### PR DESCRIPTION
Correct a misleading comment that some models keep bringing up in pressure washing runs

Fixes: https://github.com/gravitational/pressure-washing/issues/181