### PR TITLE
Fix double prefix bug in kube remote cluster participants in audit event

### DIFF
--- a/lib/kube/proxy/sess.go
+++ b/lib/kube/proxy/sess.go
@@ -1359,14 +1359,7 @@ func (s *session) unlockedLeave(ctx context.Context, id uuid.UUID) (bool, error)
 func (s *session) allParticipants() []string {
 	var participants []string
 	for _, p := range s.partiesHistorical {
-		username := services.UsernameForCluster(
-			services.UsernameForClusterConfig{
-				User:              p.Ctx.Identity.GetIdentity().Username,
-				OriginClusterName: p.Ctx.Identity.GetIdentity().OriginClusterName,
-				LocalClusterName:  p.Ctx.Identity.GetIdentity().TeleportCluster,
-			},
-		)
-		participants = append(participants, username)
+		participants = append(participants, p.Ctx.Identity.GetIdentity().Username)
 	}
 
 	return participants

--- a/lib/srv/db/common/audit.go
+++ b/lib/srv/db/common/audit.go
@@ -30,7 +30,6 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/types/events"
 	libevents "github.com/gravitational/teleport/lib/events"
-	"github.com/gravitational/teleport/lib/services"
 )
 
 // Audit defines an interface for database access audit events logger.
@@ -187,13 +186,7 @@ func (a *audit) OnSessionEnd(ctx context.Context, session *Session) {
 		DatabaseMetadata:   MakeDatabaseMetadata(session),
 		StartTime:          session.StartTime,
 		Participants: []string{
-			services.UsernameForCluster(
-				services.UsernameForClusterConfig{
-					User:              session.Identity.Username,
-					OriginClusterName: session.Identity.OriginClusterName,
-					LocalClusterName:  session.Identity.TeleportCluster,
-				},
-			),
+			session.Identity.Username,
 		},
 	}
 	endTime := a.cfg.Clock.Now()

--- a/lib/srv/desktop/audit.go
+++ b/lib/srv/desktop/audit.go
@@ -29,7 +29,6 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/types/events"
 	libevents "github.com/gravitational/teleport/lib/events"
-	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/srv/desktop/tdp/protocol/legacy"
 	"github.com/gravitational/teleport/lib/srv/desktop/tdp/protocol/tdpb"
 	"github.com/gravitational/teleport/lib/tlsca"
@@ -158,13 +157,8 @@ func (d *desktopSessionAuditor) makeSessionEnd(recorded bool) *events.WindowsDes
 
 		// There can only be 1 participant, desktop sessions are not join-able.
 		Participants: []string{
-			services.UsernameForCluster(
-				services.UsernameForClusterConfig{
-					User:              d.identity.Username,
-					OriginClusterName: d.identity.OriginClusterName,
-					LocalClusterName:  d.clusterName,
-				},
-			)},
+			d.identity.Username,
+		},
 	}
 }
 


### PR DESCRIPTION
Changelog: fix a typo in kube/db/desktop `session.end` events for remote cluster participants.

Removes redundant `UsernameForCluster` call - `RemoteUser.Username` is [already set using `UsernameForRemoteCluster`](https://github.com/gravitational/teleport/blob/45a427eedc07ba47352c9fc2de56d02e73e24042/lib/authz/permissions.go#L771).

Before:
```
{
  "event": "session.end",
  "participants": [
    "remote-remote-dev-root.example.com-root.example.com"
  ],
```

After:
```
{
  "event": "session.end",
  "participants": [
    "remote-dev-root.example.com"
  ],
```

## Manual Test Plan
Trusted cluster setup with a leaf kube cluster.

### Test Environment

### Test Cases
- [ ] Start a kube session as a remote user. The `session.end` event is populated correctly
- [ ] Start a db session as a remote user. The `session.end` event is populated correctly
- [ ] Start a desktop session as a remote user. The `session.end` event is populated correctly