### PR TITLE
Add Okta assignment target status to tctl resource output

### DIFF
--- a/tool/tctl/common/oktaassignment/resource.go
+++ b/tool/tctl/common/oktaassignment/resource.go
@@ -46,8 +46,16 @@ type spec struct {
 
 // target holds an Okta assignment target.
 type target struct {
-	ID         string `json:"id"`
-	TargetType string `json:"type"`
+	ID         string       `json:"id"`
+	TargetType string       `json:"type"`
+	Status     targetStatus `json:"status,omitzero"`
+}
+
+type targetStatus struct {
+	Op            string    `json:"op"`
+	Outcome       string    `json:"outcome"`
+	LastProcessed time.Time `json:"last_processed"`
+	FailureCount  int       `json:"failure_count"`
 }
 
 // ToResource converts an OktaAssignment into a *Resource which
@@ -61,6 +69,14 @@ func ToResource(assignment types.OktaAssignment) *Resource {
 		resourceTargets[i] = target{
 			ID:         sourceTarget.GetID(),
 			TargetType: sourceTarget.GetTargetType(),
+		}
+		if status := sourceTarget.GetStatus(); status != nil {
+			resourceTargets[i].Status = targetStatus{
+				Op:            status.Op,
+				Outcome:       status.Outcome,
+				LastProcessed: status.LastProcessed,
+				FailureCount:  int(status.FailureCount),
+			}
 		}
 	}
 

--- a/tool/tctl/common/oktaassignment/resource_test.go
+++ b/tool/tctl/common/oktaassignment/resource_test.go
@@ -21,6 +21,7 @@ package oktaassignment
 import (
 	"bytes"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v3"
@@ -34,6 +35,8 @@ import (
 // and make a best effort to ensuring there are no missing fields from the Okta assignment
 // that have not yet been added to this resource.
 func TestToResource(t *testing.T) {
+	now := time.Now().UTC()
+
 	assignment, err := types.NewOktaAssignment(types.Metadata{
 		Name: "assignment",
 	}, types.OktaAssignmentSpecV1{
@@ -43,10 +46,17 @@ func TestToResource(t *testing.T) {
 			{
 				Id:   "1",
 				Type: types.OktaAssignmentTargetV1_APPLICATION,
+				Status: &types.OktaAssignmentTargetStatus{
+					Op:            string(constants.OktaAssignmentTargetOpProvision),
+					Outcome:       string(constants.OktaAssignmentTargetOutcomeFailed),
+					LastProcessed: now,
+					FailureCount:  3,
+				},
 			},
 			{
 				Id:   "2",
 				Type: types.OktaAssignmentTargetV1_GROUP,
+				// No Status field to verify it's omitted from output.
 			},
 		},
 	})
@@ -85,10 +95,18 @@ func TestToResource(t *testing.T) {
 	require.Equal(t, constants.OktaAssignmentTargetApplication, resourceTarget1["type"])
 	resourceTarget1["type"] = int(types.OktaAssignmentTargetV1_APPLICATION)
 
+	target1Status, ok := resourceTarget1["status"].(map[string]any)
+	require.True(t, ok, target1Status)
+	require.Equal(t, string(constants.OktaAssignmentTargetOpProvision), target1Status["op"])
+	require.Equal(t, string(constants.OktaAssignmentTargetOutcomeFailed), target1Status["outcome"])
+	require.Equal(t, now.Format(time.RFC3339Nano), target1Status["last_processed"])
+	require.Equal(t, 3, target1Status["failure_count"])
+
 	resourceTarget2, ok := resourceTargets[1].(map[string]any)
 	require.True(t, ok)
 	require.Equal(t, constants.OktaAssignmentTargetGroup, resourceTarget2["type"])
 	resourceTarget2["type"] = int(types.OktaAssignmentTargetV1_GROUP)
+	require.Nil(t, resourceTarget2["status"])
 
 	require.Equal(t, assignmentMap, resourceMap)
 }


### PR DESCRIPTION
This change updates the Okta assignment resource for `tctl` to output target statuses when targets have a status. 

Assignment target status types/API: https://github.com/gravitational/teleport/pull/67303
Assignments updated to store target status: https://github.com/gravitational/teleport.e/pull/8874



<!-- Provide a descriptive entry for the changelog of the next release. -->

Changelog: Okta assignment targets output by `tctl` now include their provisioning status when available


<!-- Include manual testing efforts to verify the change. -->
<!-- Detail where the tests where run and what configurations were used. -->
<!-- Include all the test cases which were run to validate the change. -->

## Manual Test Plan
### Test Environment

Deploy local build to cloud environment. 

Okta plugin configured for bi-directional sync with multiple apps and groups, and users assigned to them. Allow sync to run and verify scenarios using `tctl get okta_assignment/...`. 

### Test Cases
- [x] Resources synced prior to upgrade have no status
- [x] Provisioning target transitions from unknown (new) to successful - outcome set to successful, op set to provisioning, timestamp set, count set to 0
- [x] Provisioning target transitions from unknown (new) to failed - outcome set to failed, op set to provisioning, timestamp set, count set to 1
- [x] Provisioning target transitions from failed to failed - outcome set to failed, op set to provisioning, timestamp set, count incremented by 1
- [x] Provisioning target transitions from failed to successful - outcome set to successful, op set to provisioning, timestamp set, count reset to 0
- [x] Provisioning target transitions from successful to successful - outcome set to successful, op set to provisioning, timestamp set, count set to 0
- [x] Provisioning target transitions from successful to failed - outcome set to failed, op set to provisioning, timestamp set, count set to 1
- [x] Cleanup target transitions from unknown (new) to failed - outcome set to failed, op set to cleanup, timestamp set, count set to 1
- [x] Cleanup target transitions from failed to failed - outcome set to failed, op set to cleanup, timestamp set, count incremented by 1
- [x] Cleanup target transitions from failed to successful - outcome set to successful, op set to cleanup, timestamp set, count reset to 0
- [x] Target status persists across finalized false->true
