### PR TITLE
tctl recordings search: rename time flags and add JSON/YAML pagination

### DIFF
--- a/docs/pages/reference/cli/tctl.mdx
+++ b/docs/pages/reference/cli/tctl.mdx
@@ -1849,7 +1849,7 @@ Flags:
 |`--access-request`|*no default*|Filter by access request ID. Can be specified multiple times.|
 |`--database-name`|*no default*|Filter database sessions by database name.|
 |`--format`|`text`|Format output (text, json, yaml).. Defaults to 'text'.|
-|`--from`|*no default*|Start of time range. Format 2006-01-02. Defaults to 24 hours ago.|
+|`--from-utc`|*no default*|Start of time range. Format 2006-01-02. Defaults to 24 hours ago.|
 |`--kind`|*no default*|Filter by session kind (ssh, db, k8s, desktop). Can be specified multiple times.|
 |`--label`|*no default*|Filter by resource labels (key=value pairs), e.g. env/prod=true,db/type=postgres.|
 |`--limit`|`50`|Maximum number of results to return.|
@@ -1857,12 +1857,13 @@ Flags:
 |`--pod-namespace`|*no default*|Filter Kubernetes sessions by pod namespace.|
 |`--resource-kind`|*no default*|Filter by Teleport resource type (node, kube_cluster, db).|
 |`--resource-name`|*no default*|Filter by resource name.|
+|`--resume-token`|*no default*|Resume a previous JSON/YAML search from a truncated result set (token printed to stderr when results are truncated).|
 |`--role`|*no default*|Filter by role held during the session. Can be specified multiple times.|
 |`--search-mode`|`hybrid` (one of: `hybrid`, `keyword`, `embeddings`)|Search strategy to use when search queries are provided.|
 |`--server-addr`|*no default*|Filter SSH sessions by server address.|
 |`--server-hostname`|*no default*|Filter SSH sessions by server hostname.|
 |`--severity`|*no default*|Minimum severity level to include (low, medium, high, critical).|
-|`--to`|*no default*|End of time range. Format 2006-01-02. Defaults to current time.|
+|`--to-utc`|*no default*|End of time range. Format 2006-01-02. Defaults to current time.|
 |`--username`|*no default*|Filter by the Teleport username that initiated the session.|
 
 Arguments:

--- a/tool/tctl/common/recordings_command.go
+++ b/tool/tctl/common/recordings_command.go
@@ -124,6 +124,8 @@ type RecordingsCommand struct {
 	searchSeverity string
 	// searchMode controls which search strategy to use: hybrid (default), keyword, or embedding.
 	searchMode string
+	// searchResumeToken resumes a previous JSON/YAML search from a truncated result set.
+	searchResumeToken string
 
 	// stdout allows to switch standard output source for resource command. Used in tests.
 	stdout io.Writer
@@ -145,8 +147,10 @@ func (c *RecordingsCommand) Initialize(app *kingpin.Application, t *tctlcfg.Glob
 	c.recordingsList.Flag("last", "Duration into the past from which session recordings should be listed. Format 5h30m40s").StringVar(&c.recordingsSince)
 	c.recordingsSearch = recordings.Command("search", "Search session recordings using semantic and keyword queries.")
 	c.recordingsSearch.Arg("query", `Natural language description of the sessions to find (e.g. "SSH sessions exfiltrating data to external endpoints").`).StringsVar(&c.searchQuery)
-	c.recordingsSearch.Flag("from", fmt.Sprintf("Start of time range. Format %s. Defaults to 24 hours ago.", defaults.TshTctlSessionListTimeFormat)).StringVar(&c.searchFromUTC)
-	c.recordingsSearch.Flag("to", fmt.Sprintf("End of time range. Format %s. Defaults to current time.", defaults.TshTctlSessionListTimeFormat)).StringVar(&c.searchToUTC)
+	c.recordingsSearch.Flag("from", fmt.Sprintf("Start of time range. Format %s. Defaults to 24 hours ago.", defaults.TshTctlSessionListTimeFormat)).Hidden().StringVar(&c.searchFromUTC)
+	c.recordingsSearch.Flag("to", fmt.Sprintf("End of time range. Format %s. Defaults to current time.", defaults.TshTctlSessionListTimeFormat)).Hidden().StringVar(&c.searchToUTC)
+	c.recordingsSearch.Flag("from-utc", fmt.Sprintf("Start of time range. Format %s. Defaults to 24 hours ago.", defaults.TshTctlSessionListTimeFormat)).StringVar(&c.searchFromUTC)
+	c.recordingsSearch.Flag("to-utc", fmt.Sprintf("End of time range. Format %s. Defaults to current time.", defaults.TshTctlSessionListTimeFormat)).StringVar(&c.searchToUTC)
 	c.recordingsSearch.Flag("label", "Filter by resource labels (key=value pairs), e.g. env/prod=true,db/type=postgres.").StringVar(&c.searchLabel)
 	c.recordingsSearch.Flag("access-request", "Filter by access request ID. Can be specified multiple times.").StringsVar(&c.searchAccessRequests)
 	c.recordingsSearch.Flag("kind", "Filter by session kind (ssh, db, k8s, desktop). Can be specified multiple times.").StringsVar(&c.searchKinds)
@@ -163,6 +167,7 @@ func (c *RecordingsCommand) Initialize(app *kingpin.Application, t *tctlcfg.Glob
 	c.recordingsSearch.Flag("search-mode", "Search strategy to use when search queries are provided.").Default(searchModeHybrid).EnumVar(&c.searchMode, searchModeHybrid, searchModeKeyword, searchModeEmbedding)
 	c.recordingsSearch.Flag("limit", "Maximum number of results to return.").Default(defaults.TshTctlSessionListLimit).Uint32Var(&c.searchLimit)
 	c.recordingsSearch.Flag("format", defaults.FormatFlagDescription(defaults.DefaultFormats...)+". Defaults to 'text'.").Default(teleport.Text).StringVar(&c.searchFormat)
+	c.recordingsSearch.Flag("resume-token", "Resume a previous JSON/YAML search from a truncated result set (token printed to stderr when results are truncated).").StringVar(&c.searchResumeToken)
 
 	c.recordingsEncryption.Initialize(recordings, c.stdout)
 
@@ -275,13 +280,33 @@ loop:
 
 // SearchRecordings implements "tctl recordings search <query>".
 func (c *RecordingsCommand) SearchRecordings(ctx context.Context, tc *authclient.Client) error {
-	fromUTC, toUTC, err := defaults.SearchSessionRange(clockwork.NewRealClock(), c.searchFromUTC, c.searchToUTC, "")
-	if err != nil {
+	searchClient := tc.SessionSearchServiceClient()
+	if err := checkSessionSearchEnabled(ctx, searchClient); err != nil {
 		return trace.Wrap(err)
 	}
 
-	searchClient := tc.SessionSearchServiceClient()
-	if err := checkSessionSearchEnabled(ctx, searchClient); err != nil {
+	// fetcher is defined early so it can be used both for resume and for normal pagination.
+	fetcher := recordingstui.BatchFetcher(func(ctx context.Context, token string) ([]*sessionsearchv1pb.SessionSummary, string, error) {
+		// When BatchToken is set the server ignores all other filter fields per the proto contract.
+		batchStream, err := searchClient.SearchSessionSummaries(ctx, &sessionsearchv1pb.SearchSessionSummariesRequest{
+			BatchToken: token,
+		})
+		if err != nil {
+			return nil, "", trace.Wrap(err)
+		}
+		return collectStream(batchStream)
+	})
+
+	if c.searchResumeToken != "" {
+		sessions, nextToken, err := fetcher(ctx, c.searchResumeToken)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+		return trace.Wrap(showSessionSummaries(ctx, sessions, nextToken, c.searchFormat, c.stdout, tc.SummarizerServiceClient(), fetcher))
+	}
+
+	fromUTC, toUTC, err := defaults.SearchSessionRange(clockwork.NewRealClock(), c.searchFromUTC, c.searchToUTC, "")
+	if err != nil {
 		return trace.Wrap(err)
 	}
 
@@ -344,28 +369,33 @@ func (c *RecordingsCommand) SearchRecordings(ctx context.Context, tc *authclient
 		return trace.Wrap(err)
 	}
 
-	fetcher := recordingstui.BatchFetcher(func(ctx context.Context, token string) ([]*sessionsearchv1pb.SessionSummary, string, error) {
-		// When BatchToken is set the server ignores all other filter fields per the proto contract.
-		batchStream, err := searchClient.SearchSessionSummaries(ctx, &sessionsearchv1pb.SearchSessionSummariesRequest{
-			BatchToken: token,
-		})
-		if err != nil {
-			return nil, "", trace.Wrap(err)
-		}
-		return collectStream(batchStream)
-	})
-
 	return trace.Wrap(showSessionSummaries(ctx, sessions, nextToken, c.searchFormat, c.stdout, tc.SummarizerServiceClient(), fetcher))
 }
 
+// maxJSONYAMLSessions is the maximum number of sessions collected before truncating
+// structured (JSON/YAML) output and printing a --resume-token hint to stderr.
+const maxJSONYAMLSessions = 500
+
 func showSessionSummaries(ctx context.Context, sessions []*sessionsearchv1pb.SessionSummary, nextToken, format string, w io.Writer, summaryGetter recordingstui.SummaryGetter, fetcher recordingstui.BatchFetcher) error {
 	switch format {
-	case teleport.JSON:
-		// Only the first batch is output; nextToken and fetcher are unused for
-		// non-interactive formats.
-		return trace.Wrap(utils.WriteJSONArray(w, sessions))
-	case teleport.YAML:
-		return trace.Wrap(utils.WriteYAML(w, sessions))
+	case teleport.JSON, teleport.YAML:
+		// Paginate automatically up to maxJSONYAMLSessions for structured output.
+		all := sessions
+		for nextToken != "" && len(all) < maxJSONYAMLSessions {
+			more, tok, err := fetcher(ctx, nextToken)
+			if err != nil {
+				return trace.Wrap(err)
+			}
+			all = append(all, more...)
+			nextToken = tok
+		}
+		if nextToken != "" {
+			fmt.Fprintf(os.Stderr, "Showing %d sessions (more available). Resume with: --resume-token %q\n", len(all), nextToken)
+		}
+		if format == teleport.JSON {
+			return trace.Wrap(utils.WriteJSONArray(w, all))
+		}
+		return trace.Wrap(utils.WriteYAML(w, all))
 	default:
 		if len(sessions) == 0 {
 			fmt.Fprintln(w, "No sessions found.")


### PR DESCRIPTION
Rename --from/--to to --from-utc/--to-utc on `recordings search` to match the `recordings ls` flag naming convention. The old names are kept as hidden aliases for backward compatibility.

For JSON and YAML output formats, automatically paginate through result batches until up to 500 sessions are collected rather than stopping after the first batch. When results are truncated, a --resume-token hint is printed to stderr so the caller can continue from where the previous run left off.


Changelog: Rename --from/--to to --from-utc/--to-utc on `recordings search` to match the `recordings ls` flag naming convention.


## Manual Test Plan
### Test Environment
local
### Test Cases
- [x] TUI iterates through sessions
- [x] tctl recordings search -json prints sessions and writes the continue token to stderr
