### PR TITLE
app access: improve handling of overlapping public addrs

### DIFF
--- a/integration/appaccess/appaccess_test.go
+++ b/integration/appaccess/appaccess_test.go
@@ -26,6 +26,7 @@ import (
 	"io"
 	"net"
 	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 	"time"
@@ -96,6 +97,63 @@ func TestAppAccess(t *testing.T) {
 
 	// This test should go last because it stops/starts app servers.
 	t.Run("TestAppServersHA", bind(pack, testServersHA))
+}
+
+// TestAppAccessRoutingByName tests the scenario where two apps share a
+// public address but have distinct names. A session routed (by name) to one app
+// must always reach that app and never the other.
+func TestAppAccessRoutingByName(t *testing.T) {
+	const sharedPublicAddr = "dup.example.com"
+
+	appOneMessage := "app-one-" + uuid.NewString()
+	appTwoMessage := "app-two-" + uuid.NewString()
+
+	appOneServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprintln(w, appOneMessage)
+	}))
+	t.Cleanup(appOneServer.Close)
+	appTwoServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprintln(w, appTwoMessage)
+	}))
+	t.Cleanup(appTwoServer.Close)
+
+	// Both apps share a public address but have different names and labels.
+	pack := SetupWithOptions(t, AppTestOptions{
+		ExtraRootApps: []servicecfg.App{
+			{
+				Name:         "dup-app-1",
+				URI:          appOneServer.URL,
+				PublicAddr:   sharedPublicAddr,
+				StaticLabels: map[string]string{"app_name": "dup-app-1"},
+			},
+			{
+				Name:         "dup-app-2",
+				URI:          appTwoServer.URL,
+				PublicAddr:   sharedPublicAddr,
+				StaticLabels: map[string]string{"app_name": "dup-app-2"},
+			},
+		},
+	})
+
+	for _, tc := range []struct {
+		appName     string
+		wantMessage string
+	}{
+		{appName: "dup-app-1", wantMessage: appOneMessage},
+		{appName: "dup-app-2", wantMessage: appTwoMessage},
+	} {
+		t.Run(tc.appName, func(t *testing.T) {
+			cookies := pack.CreateAppSessionCookiesForApp(t, tc.appName, sharedPublicAddr, pack.rootAppClusterName)
+
+			for range 20 {
+				status, body, err := pack.MakeRequest(cookies, http.MethodGet, "/")
+				require.NoError(t, err)
+				require.Equal(t, http.StatusOK, status)
+				require.Equal(t, tc.wantMessage, strings.TrimSpace(body),
+					"request must only ever be routed to %q", tc.appName)
+			}
+		})
+	}
 }
 
 // testForward tests that requests get forwarded to the target application

--- a/integration/appaccess/appaccess_test.go
+++ b/integration/appaccess/appaccess_test.go
@@ -155,6 +155,63 @@ func TestAppAccessRoutingByName(t *testing.T) {
 	}
 }
 
+// TestAppAccessRoutingByNameLeafCluster is the trusted-cluster version of
+// TestAppAccessRoutingByName. It registers two distinct apps in a leaf cluster with
+// the same public address and verifies that requests are routed to the correct app.
+func TestAppAccessRoutingByNameLeafCluster(t *testing.T) {
+	const sharedPublicAddr = "leaf-dup.example.com"
+
+	appOneMessage := "leaf-app-one-" + uuid.NewString()
+	appTwoMessage := "leaf-app-two-" + uuid.NewString()
+
+	appOneServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprintln(w, appOneMessage)
+	}))
+	t.Cleanup(appOneServer.Close)
+	appTwoServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprintln(w, appTwoMessage)
+	}))
+	t.Cleanup(appTwoServer.Close)
+
+	pack := SetupWithOptions(t, AppTestOptions{
+		ExtraLeafApps: []servicecfg.App{
+			{
+				Name:         "leaf-dup-1",
+				URI:          appOneServer.URL,
+				PublicAddr:   sharedPublicAddr,
+				StaticLabels: map[string]string{"app_name": "leaf-dup-1"},
+			},
+			{
+				Name:         "leaf-dup-2",
+				URI:          appTwoServer.URL,
+				PublicAddr:   sharedPublicAddr,
+				StaticLabels: map[string]string{"app_name": "leaf-dup-2"},
+			},
+		},
+	})
+
+	for _, tc := range []struct {
+		appName     string
+		wantMessage string
+	}{
+		{appName: "leaf-dup-1", wantMessage: appOneMessage},
+		{appName: "leaf-dup-2", wantMessage: appTwoMessage},
+	} {
+		t.Run(tc.appName, func(t *testing.T) {
+			// Resolve within the leaf cluster (note the leaf cluster name).
+			cookies := pack.CreateAppSessionCookiesForApp(t, tc.appName, sharedPublicAddr, pack.leafAppClusterName)
+
+			for range 20 {
+				status, body, err := pack.MakeRequest(cookies, http.MethodGet, "/")
+				require.NoError(t, err)
+				require.Equal(t, http.StatusOK, status)
+				require.Equal(t, tc.wantMessage, strings.TrimSpace(body),
+					"request must only ever be routed to %q in the leaf cluster", tc.appName)
+			}
+		})
+	}
+}
+
 // testForward tests that requests get forwarded to the target application
 // within a single cluster and trusted cluster.
 func testForward(p *Pack, t *testing.T) {

--- a/integration/appaccess/appaccess_test.go
+++ b/integration/appaccess/appaccess_test.go
@@ -100,8 +100,7 @@ func TestAppAccess(t *testing.T) {
 }
 
 // TestAppAccessRoutingByName tests the scenario where two apps share a
-// public address but have distinct names. A session routed (by name) to one app
-// must always reach that app and never the other.
+// public address but have distinct names.
 func TestAppAccessRoutingByName(t *testing.T) {
 	const sharedPublicAddr = "dup.example.com"
 

--- a/integration/appaccess/pack.go
+++ b/integration/appaccess/pack.go
@@ -419,6 +419,41 @@ func (p *Pack) CreateAppSessionCookies(t *testing.T, publicAddr, clusterName str
 	}
 }
 
+// CreateAppSessionCookiesForApp is like CreateAppSessionCookies but routes the
+// session to a specific app by name, which is required to disambiguate apps
+// that share a public address.
+func (p *Pack) CreateAppSessionCookiesForApp(t *testing.T, appName, publicAddr, clusterName string) []*http.Cookie {
+	require.NotEmpty(t, p.webCookie)
+	require.NotEmpty(t, p.webToken)
+
+	casReq, err := json.Marshal(web.CreateAppSessionRequest{
+		ResolveAppParams: web.ResolveAppParams{
+			AppName:     appName,
+			PublicAddr:  publicAddr,
+			ClusterName: clusterName,
+		},
+	})
+	require.NoError(t, err)
+	statusCode, body, err := p.makeWebapiRequest(http.MethodPost, "sessions/app", casReq)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, statusCode)
+
+	var casResp *web.CreateAppSessionResponse
+	err = json.Unmarshal(body, &casResp)
+	require.NoError(t, err)
+
+	return []*http.Cookie{
+		{
+			Name:  app.CookieName,
+			Value: casResp.CookieValue,
+		},
+		{
+			Name:  app.SubjectCookieName,
+			Value: casResp.SubjectCookieValue,
+		},
+	}
+}
+
 // CreateAppSessionWithClientCert creates an application session with the root
 // cluster and returns the client cert that can be used for an application
 // request.

--- a/lib/auth/grpcserver_test.go
+++ b/lib/auth/grpcserver_test.go
@@ -979,6 +979,57 @@ func TestCreateAppSession_deviceExtensions(t *testing.T) {
 	}
 }
 
+func TestCreateAppSession_routesByName(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+	testServer := newTestTLSServer(t)
+	authServer := testServer.Auth()
+
+	user, _, err := authtest.CreateUserAndRole(authServer, "llama", []string{"llama"}, nil)
+	require.NoError(t, err, "CreateUserAndRole failed")
+
+	app, err := types.NewAppV3(
+		types.Metadata{
+			Name: "llamaapp",
+		}, types.AppSpecV3{
+			URI:        "http://localhost:8080",
+			PublicAddr: "llamaapp.example.com",
+		})
+	require.NoError(t, err)
+
+	appServer, err := types.NewAppServerV3FromApp(app, "host", uuid.New().String())
+	require.NoError(t, err)
+
+	_, err = authServer.UpsertApplicationServer(ctx, appServer)
+	require.NoError(t, err)
+
+	userClient, err := testServer.NewClient(authtest.TestUser(user.GetName()))
+	require.NoError(t, err)
+	t.Cleanup(func() { userClient.Close() })
+
+	session, err := userClient.CreateAppSession(ctx, &proto.CreateAppSessionRequest{
+		Username:    user.GetName(),
+		AppName:     app.GetName(),
+		PublicAddr:  app.GetPublicAddr(),
+		ClusterName: testServer.ClusterName(),
+	})
+	require.NoError(t, err)
+
+	// Make sure that the app name is encoded into the app session cert.
+	// The app name is used to disambiguate when mutiple apps share
+	// the same public address.
+	block, _ := pem.Decode(session.GetTLSCert())
+	require.NotNil(t, block, "PEM decode failed")
+	gotCert, err := x509.ParseCertificate(block.Bytes)
+	require.NoError(t, err)
+
+	gotIdentity, err := tlsca.FromSubject(gotCert.Subject, gotCert.NotAfter)
+	require.NoError(t, err)
+
+	require.Equal(t, app.GetName(), gotIdentity.RouteToApp.Name)
+	require.Equal(t, app.GetPublicAddr(), gotIdentity.RouteToApp.PublicAddr)
+}
+
 func TestCreateAppSession_allowedResourceAccessIDs(t *testing.T) {
 	t.Parallel()
 	ctx := t.Context()

--- a/lib/auth/grpcserver_test.go
+++ b/lib/auth/grpcserver_test.go
@@ -1016,7 +1016,7 @@ func TestCreateAppSession_routesByName(t *testing.T) {
 	require.NoError(t, err)
 
 	// Make sure that the app name is encoded into the app session cert.
-	// The app name is used to disambiguate when mutiple apps share
+	// The app name is used to disambiguate when multiple apps share
 	// the same public address.
 	block, _ := pem.Decode(session.GetTLSCert())
 	require.NotNil(t, block, "PEM decode failed")

--- a/lib/auth/sessions.go
+++ b/lib/auth/sessions.go
@@ -526,6 +526,7 @@ func (a *Server) CreateAppSessionFromReq(ctx context.Context, req NewAppSessionR
 		AppSessionID: sessionID,
 		// Only allow this certificate to be used for applications.
 		Usage:             []string{teleport.UsageAppsOnly},
+		AppName:           req.AppName,
 		AppPublicAddr:     req.PublicAddr,
 		AppClusterName:    req.ClusterName,
 		AppTargetPort:     req.AppTargetPort,

--- a/lib/reversetunnelclient/api.go
+++ b/lib/reversetunnelclient/api.go
@@ -150,6 +150,8 @@ type ClusterGetter interface {
 	// Clusters returns all connected clusters
 	Clusters(ctx context.Context) ([]Cluster, error)
 	// Cluster returns the cluster matching the provided name or a trace.NotFoundError.
+	// The cluster's lifecycle is owned by the reverse tunnel server. Callers should not
+	// close the returned cluster.
 	Cluster(ctx context.Context, clusterName string) (Cluster, error)
 }
 

--- a/lib/service/acme.go
+++ b/lib/service/acme.go
@@ -58,7 +58,9 @@ func (h *hostPolicyChecker) checkHost(ctx context.Context, host string) error {
 		return nil
 	}
 
-	_, _, err := app.ResolveFQDN(ctx, h.cfg.clusterGetter, h.cfg.clusterName, h.dnsNames, host)
+	// Note: canAccess is nil here. For cert provisioning we only need to
+	// know that some app with the specified FQDN exists.
+	_, _, err := app.ResolveFQDN(ctx, h.cfg.clusterGetter, h.cfg.clusterName, h.dnsNames, host, nil /* canAccess */)
 	if err == nil {
 		return nil
 	}

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -5587,17 +5587,19 @@ func (process *TeleportProcess) initProxyEndpoint(conn *Connector) error {
 		if err != nil {
 			return trace.Wrap(err)
 		}
-		connectionsHandler.SetApplicationsProvider(func(ctx context.Context, publicAddr string) (types.Application, error) {
-			allAppServers, err := appServerWatcher.CurrentResourcesWithFilter(ctx, webapp.MatchPublicAddr(publicAddr))
-			if err != nil {
-				return nil, trace.Wrap(err)
-			}
-			if len(allAppServers) == 0 {
-				return nil, trace.NotFound("no app found for endpoint %q", publicAddr)
-			}
-			// TODO(okraport): determine if we should shuffle app servers here.
-			return allAppServers[0].GetApp(), nil
-		})
+		connectionsHandler.SetApplicationsProvider(
+			func(ctx context.Context, appName, publicAddr string) (types.Application, error) {
+				allAppServers, err := appServerWatcher.CurrentResourcesWithFilter(
+					ctx, webapp.MatchAppServerForRoute(appName, publicAddr))
+				if err != nil {
+					return nil, trace.Wrap(err)
+				}
+				if len(allAppServers) == 0 {
+					return nil, trace.NotFound("no app %s found for endpoint %q", appName, publicAddr)
+				}
+				// TODO(okraport): determine if we should shuffle app servers here.
+				return allAppServers[0].GetApp(), nil
+			})
 
 		if !cfg.Proxy.DisableTLS && cfg.Proxy.DisableALPNSNIListener {
 			listeners.tls, err = multiplexer.NewWebListener(multiplexer.WebListenerConfig{

--- a/lib/srv/app/connections_handler.go
+++ b/lib/srv/app/connections_handler.go
@@ -211,8 +211,8 @@ type ConnectionsHandler struct {
 	proxyPort   string
 	clusterName string
 
-	// getAppByPublicAddress returns a types.Application using the public address as matcher.
-	getAppByPublicAddress func(context.Context, string) (types.Application, error)
+	// resolveApp returns a types.Application using the name and public address as matchers.
+	resolveApp func(ctx context.Context, name, addr string) (types.Application, error)
 }
 
 // NewConnectionsHandler returns a new ConnectionsHandler.
@@ -260,7 +260,7 @@ func NewConnectionsHandler(closeContext context.Context, cfg *ConnectionsHandler
 		connAuth:     make(map[net.Conn]error),
 		log:          slog.With(teleport.ComponentKey, cfg.ServiceComponent),
 		clusterName:  clusterName.GetClusterName(),
-		getAppByPublicAddress: func(ctx context.Context, s string) (types.Application, error) {
+		resolveApp: func(context.Context, string, string) (types.Application, error) {
 			return nil, trace.NotFound("no applications are being proxied")
 		},
 	}
@@ -324,8 +324,9 @@ func NewConnectionsHandler(closeContext context.Context, cfg *ConnectionsHandler
 
 // SetApplicationsProvider sets the internal state for the monitored applications.
 // This method must be called before the ConnectionsHandler is able to handle connections.
-func (c *ConnectionsHandler) SetApplicationsProvider(fn func(context.Context, string) (types.Application, error)) {
-	c.getAppByPublicAddress = fn
+func (c *ConnectionsHandler) SetApplicationsProvider(
+	fn func(context.Context, string, string) (types.Application, error)) {
+	c.resolveApp = fn
 }
 
 func (c *ConnectionsHandler) expireSessions() {
@@ -563,7 +564,11 @@ func (c *ConnectionsHandler) authorizeContext(ctx context.Context) (*authz.Conte
 	identity := authContext.Identity.GetIdentity()
 
 	// Fetch the application and check if the identity has access.
-	app, err := c.getAppByPublicAddress(ctx, identity.RouteToApp.PublicAddr)
+	app, err := c.resolveApp(
+		ctx,
+		identity.RouteToApp.Name,
+		identity.RouteToApp.PublicAddr,
+	)
 	if err != nil {
 		return nil, nil, trace.Wrap(err)
 	}
@@ -865,7 +870,11 @@ func (c *ConnectionsHandler) getConnectionInfo(ctx context.Context, conn net.Con
 		return nil, nil, nil, trace.Wrap(err)
 	}
 
-	app, err := c.getAppByPublicAddress(ctx, user.GetIdentity().RouteToApp.PublicAddr)
+	app, err := c.resolveApp(
+		ctx,
+		user.GetIdentity().RouteToApp.Name,
+		user.GetIdentity().RouteToApp.PublicAddr,
+	)
 	if err != nil {
 		return nil, nil, nil, trace.Wrap(err)
 	}

--- a/lib/srv/app/server.go
+++ b/lib/srv/app/server.go
@@ -224,7 +224,7 @@ func New(ctx context.Context, c *Config) (*Server, error) {
 		closeContext:  closeContext,
 	}
 
-	s.c.ConnectionsHandler.SetApplicationsProvider(s.GetAppByPublicAddress)
+	s.c.ConnectionsHandler.SetApplicationsProvider(s.GetApp)
 
 	callClose = false
 	return s, nil
@@ -654,21 +654,22 @@ func (s *Server) HandleConnection(conn net.Conn) {
 	s.c.ConnectionsHandler.HandleConnection(conn)
 }
 
-// GetAppByPublicAddress returns an application matching the public address. If multiple
-// matching applications exist, the first one is returned. Random selection
-// (or round robin) does not need to occur here because they will all point
-// to the same target address. Random selection (or round robin) occurs at the
-// web proxy to load balance requests to the application service.
-func (s *Server) GetAppByPublicAddress(ctx context.Context, publicAddr string) (types.Application, error) {
+// GetApp returns an application matching the name and public address.
+// The app name, when present, disambiguates apps that share a public address.
+func (s *Server) GetApp(ctx context.Context, appName, publicAddr string) (types.Application, error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
-	// don't call s.getApps() as this will call RLock and potentially deadlock.
-	for _, a := range s.apps {
-		if publicAddr == a.GetPublicAddr() {
-			return s.appWithUpdatedLabelsLocked(a), nil
+
+	for _, app := range s.apps {
+		if app.GetPublicAddr() != publicAddr {
+			continue
 		}
+		if appName != "" && app.GetName() != appName {
+			continue
+		}
+		return s.appWithUpdatedLabelsLocked(app), nil
 	}
-	return nil, trace.NotFound("no application at %v found", publicAddr)
+	return nil, trace.NotFound("no application %s at %s found", appName, publicAddr)
 }
 
 // appWithUpdatedLabelsLocked will inject updated dynamic and cloud labels into

--- a/lib/srv/app/server_test.go
+++ b/lib/srv/app/server_test.go
@@ -43,6 +43,7 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
 	"github.com/gorilla/websocket"
+	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -735,6 +736,69 @@ func TestAppWithUpdatedLabels(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestGetApp(t *testing.T) {
+	t.Parallel()
+
+	const sharedAddr = "demoqa.com"
+
+	mustNewApp := func(t *testing.T, name, addr string) types.Application {
+		app, err := types.NewAppV3(types.Metadata{
+			Name:   name,
+			Labels: map[string]string{"app_name": name},
+		}, types.AppSpecV3{
+			URI:        "http://localhost:8080",
+			PublicAddr: addr,
+		})
+		require.NoError(t, err)
+		return app
+	}
+
+	appOne := mustNewApp(t, "test-app-1", sharedAddr)
+	appTwo := mustNewApp(t, "test-app-2", sharedAddr)
+	appOther := mustNewApp(t, "other-app", "other.example.com")
+
+	s := &Server{
+		c: &Config{},
+		apps: map[string]types.Application{
+			appOne.GetName():   appOne,
+			appTwo.GetName():   appTwo,
+			appOther.GetName(): appOther,
+		},
+		dynamicLabels: map[string]*labels.Dynamic{},
+	}
+
+	t.Run("disambiguates shared public addr by name", func(t *testing.T) {
+		// s.apps is a map, so iteration order is randomized. Repeat the lookup
+		// to ensure the result is deterministic and never resolves to the other
+		// app sharing the address (the bug being fixed).
+		for range 100 {
+			got, err := s.GetApp(t.Context(), "test-app-1", sharedAddr)
+			require.NoError(t, err)
+			require.Equal(t, "test-app-1", got.GetName())
+
+			got, err = s.GetApp(t.Context(), "test-app-2", sharedAddr)
+			require.NoError(t, err)
+			require.Equal(t, "test-app-2", got.GetName())
+		}
+	})
+
+	t.Run("legacy cert without name falls back to public addr", func(t *testing.T) {
+		got, err := s.GetApp(t.Context(), "", sharedAddr)
+		require.NoError(t, err)
+		require.Equal(t, sharedAddr, got.GetPublicAddr())
+	})
+
+	t.Run("name and addr must both match", func(t *testing.T) {
+		_, err := s.GetApp(t.Context(), "test-app-1", "other.example.com")
+		require.True(t, trace.IsNotFound(err), "expected NotFound, got %v", err)
+	})
+
+	t.Run("unknown app", func(t *testing.T) {
+		_, err := s.GetApp(t.Context(), "nope", "nope.example.com")
+		require.True(t, trace.IsNotFound(err), "expected NotFound, got %v", err)
+	})
 }
 
 // testIMClient is a test instance metadata client for exercising cloud labels.

--- a/lib/srv/app/server_test.go
+++ b/lib/srv/app/server_test.go
@@ -770,9 +770,8 @@ func TestGetApp(t *testing.T) {
 	}
 
 	t.Run("disambiguates shared public addr by name", func(t *testing.T) {
-		// s.apps is a map, so iteration order is randomized. Repeat the lookup
-		// to ensure the result is deterministic and never resolves to the other
-		// app sharing the address (the bug being fixed).
+		// Repeat the lookup to ensure the result is deterministic and always
+		// hits the correct app.
 		for range 100 {
 			got, err := s.GetApp(t.Context(), "test-app-1", sharedAddr)
 			require.NoError(t, err)

--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -155,7 +155,7 @@ const (
 // healthCheckAppServerFunc defines a function used to perform a health check
 // to AppServer that can handle application requests (based on cluster name and
 // public address).
-type healthCheckAppServerFunc func(ctx context.Context, publicAddr string, clusterName string) error
+type healthCheckAppServerFunc func(ctx context.Context, appName, publicAddr, clusterName string) error
 
 // Handler is HTTP web proxy handler
 type Handler struct {

--- a/lib/web/apiserver_test.go
+++ b/lib/web/apiserver_test.go
@@ -607,7 +607,7 @@ func newWebSuiteWithConfig(t *testing.T, cfg webSuiteConfig) *WebSuite {
 	}
 
 	if handlerConfig.HealthCheckAppServer == nil {
-		handlerConfig.HealthCheckAppServer = func(context.Context, string, string) error { return nil }
+		handlerConfig.HealthCheckAppServer = func(context.Context, string, string, string) error { return nil }
 	}
 
 	handler, err := NewHandler(handlerConfig, SetClock(s.clock))
@@ -6065,7 +6065,7 @@ func TestCreateAppSessionHealthCheckAppServer(t *testing.T) {
 	require.NoError(t, err)
 
 	s := newWebSuiteWithConfig(t, webSuiteConfig{
-		HealthCheckAppServer: func(_ context.Context, publicAddr string, _ string) error {
+		HealthCheckAppServer: func(_ context.Context, _, publicAddr, _ string) error {
 			// Can only serve "validApp".
 			if publicAddr == validApp.GetPublicAddr() {
 				return nil
@@ -9325,7 +9325,7 @@ func createProxy(ctx context.Context, t *testing.T, proxyID string, node *regula
 			return ctx, trace.Wrap(err)
 		}),
 		Router:                         router,
-		HealthCheckAppServer:           func(context.Context, string, string) error { return nil },
+		HealthCheckAppServer:           func(context.Context, string, string, string) error { return nil },
 		MinimalReverseTunnelRoutesOnly: cfg.minimalHandler,
 		GetProxyClientCertificate: func() (*tls.Certificate, error) {
 			return &proxyClientCert, nil

--- a/lib/web/apiserver_test.go
+++ b/lib/web/apiserver_test.go
@@ -5014,6 +5014,74 @@ func TestGetAppDetails(t *testing.T) {
 	}
 }
 
+// TestCreateAppSessionRBACAware verifies that when a user navigates directly to
+// a public address shared by multiple apps (the FQDN-only flow, with no app name),
+// the resulting session is pinned to an app the user can actually access.
+func TestCreateAppSessionRBACAware(t *testing.T) {
+	s := newWebSuite(t)
+
+	const sharedPublicAddr = "dup.example.com"
+
+	// Two apps share a public address but have distinct names and labels.
+	for _, app := range []struct{ name, label string }{
+		{"dup-app-1", "dup-app-1"},
+		{"dup-app-2", "dup-app-2"},
+	} {
+		a, err := types.NewAppV3(types.Metadata{
+			Name:   app.name,
+			Labels: map[string]string{"app_name": app.label},
+		}, types.AppSpecV3{
+			URI:        "http://127.0.0.1:8080",
+			PublicAddr: sharedPublicAddr,
+		})
+		require.NoError(t, err)
+		server, err := types.NewAppServerV3FromApp(a, "host-"+app.name, uuid.New().String())
+		require.NoError(t, err)
+		_, err = s.server.Auth().UpsertApplicationServer(s.ctx, server)
+		require.NoError(t, err)
+	}
+
+	// The default user role grants wildcard app access, so deny dup-app-2 to
+	// ensure the user can reach dup-app-1 but not dup-app-2.
+	denyRole, err := types.NewRole("deny-dup-app-2", types.RoleSpecV6{
+		Deny: types.RoleConditions{
+			AppLabels: types.Labels{"app_name": []string{"dup-app-2"}},
+		},
+	})
+	require.NoError(t, err)
+	_, err = s.server.Auth().UpsertRole(s.ctx, denyRole)
+	require.NoError(t, err)
+
+	pack := s.authPack(t, "foo@example.com", denyRole.GetName())
+
+	// Create an app session with FQDN hint only (no app name).
+	// Repeat this multiple times to make sure we always get the correct app
+	// in the app session's cert.
+	endpoint := pack.clt.Endpoint("webapi", "sessions", "app")
+	for range 20 {
+		resp, err := pack.clt.PostJSON(s.ctx, endpoint, &CreateAppSessionRequest{
+			ResolveAppParams: ResolveAppParams{FQDNHint: sharedPublicAddr},
+		})
+		require.NoError(t, err)
+
+		var response CreateAppSessionResponse
+		require.NoError(t, json.Unmarshal(resp.Bytes(), &response))
+
+		sess, err := s.server.Auth().GetAppSession(s.ctx, types.GetAppSessionRequest{
+			SessionID: response.CookieValue,
+		})
+		require.NoError(t, err)
+
+		certificate, err := tlsca.ParseCertificatePEM(sess.GetTLSCert())
+		require.NoError(t, err)
+		identity, err := tlsca.FromSubject(certificate.Subject, certificate.NotAfter)
+		require.NoError(t, err)
+
+		require.Equal(t, "dup-app-1", identity.RouteToApp.Name)
+		require.Equal(t, sharedPublicAddr, identity.RouteToApp.PublicAddr)
+	}
+}
+
 // connRemoteAddrOverride wraps a net.Conn for the sole purpose of
 // specifying a remote address with a valid hostport. This is meant
 // to be used with bufconn.Listeners which hardcode addresses to "bufconn"

--- a/lib/web/app/handler.go
+++ b/lib/web/app/handler.go
@@ -224,13 +224,13 @@ func (h *Handler) HandleConnection(ctx context.Context, clientConn net.Conn) err
 // HealthCheckAppServer establishes a connection to a AppServer that can handle
 // application requests. Can be used to ensure the proxy can handle application
 // requests before they arrive.
-func (h *Handler) HealthCheckAppServer(ctx context.Context, publicAddr string, clusterName string) error {
+func (h *Handler) HealthCheckAppServer(ctx context.Context, appName, publicAddr, clusterName string) error {
 	clusterClient, err := h.c.ClusterGetter.Cluster(ctx, clusterName)
 	if err != nil {
 		return trace.Wrap(err)
 	}
 
-	servers, err := MatchUnshuffled(ctx, clusterClient, MatchPublicAddr(publicAddr))
+	servers, err := MatchUnshuffled(ctx, clusterClient, MatchAppServerForRoute(appName, publicAddr))
 	if err != nil {
 		return trace.Wrap(err)
 	}

--- a/lib/web/app/handler_test.go
+++ b/lib/web/app/handler_test.go
@@ -329,12 +329,12 @@ func TestMatchApplicationServers(t *testing.T) {
 	authClient := &mockAuthClient{
 		clusterName: clusterName,
 		appSession:  createAppSession(t, fakeClock, key, cert, clusterName, publicAddr, "testapp"),
-		// Three app servers with same public addr from our session, and three
-		// that won't match.
+		// Three app servers (HA replicas of the same app, so same name and
+		// public addr) that match our session, and three that won't match.
 		appServers: []types.AppServer{
-			createAppServer(t, publicAddr),
-			createAppServer(t, publicAddr),
-			createAppServer(t, publicAddr),
+			createNamedAppServer(t, "testapp", publicAddr),
+			createNamedAppServer(t, "testapp", publicAddr),
+			createNamedAppServer(t, "testapp", publicAddr),
 			createAppServer(t, "random.example.com"),
 			createAppServer(t, "random2.example.com"),
 			createAppServer(t, "random3.example.com"),
@@ -373,6 +373,63 @@ func TestMatchApplicationServers(t *testing.T) {
 	require.Equal(t, expectedContent, content)
 }
 
+func TestNewSessionRoutesByAppName(t *testing.T) {
+	ctx := t.Context()
+	clusterName := "test-cluster"
+	const sharedAddr = "demoqa.com"
+
+	key, cert, err := tlsca.GenerateSelfSignedCA(
+		pkix.Name{CommonName: clusterName},
+		[]string{sharedAddr, apiutils.EncodeClusterName(clusterName)},
+		defaults.CATTL,
+	)
+	require.NoError(t, err)
+
+	fakeClock := clockwork.NewFakeClock()
+
+	// Two app servers share a public address but have different names. The
+	// session certificate is routed to "test-app-1".
+	authClient := &mockAuthClient{
+		clusterName: clusterName,
+		appSession:  createAppSession(t, fakeClock, key, cert, clusterName, sharedAddr, "test-app-1"),
+		appServers: []types.AppServer{
+			createNamedAppServer(t, "test-app-1", sharedAddr),
+			createNamedAppServer(t, "test-app-2", sharedAddr),
+		},
+		caKey:  key,
+		caCert: cert,
+	}
+
+	fakeCluster := startFakeAppServerOnCluster(t, clusterName, authClient, cert, key)
+	tunnel := &reversetunnelclient.FakeServer{
+		FakeClusters: []reversetunnelclient.Cluster{fakeCluster},
+	}
+
+	appHandler, err := NewHandler(ctx, &HandlerConfig{
+		Clock:                 fakeClock,
+		AuthClient:            authClient,
+		AccessPoint:           authClient,
+		ClusterGetter:         tunnel,
+		CipherSuites:          utils.DefaultCipherSuites(),
+		IntegrationAppHandler: &mockIntegrationAppHandler{},
+	})
+	require.NoError(t, err)
+
+	// newSession shuffles the matched servers, so run a bunch of iterations
+	// to verify that we're always routed to the app encoded in the cert
+	for range 100 {
+		session, err := appHandler.newSession(ctx, authClient.appSession)
+		require.NoError(t, err)
+
+		var routedNames []string
+		for _, s := range session.tr.c.servers {
+			routedNames = append(routedNames, s.GetApp().GetName())
+		}
+		require.Equal(t, []string{"test-app-1"}, routedNames,
+			"session must only route to the app named in the certificate")
+	}
+}
+
 func TestHealthCheckAppServer(t *testing.T) {
 	ctx := context.Background()
 	clusterName := "test-cluster"
@@ -396,7 +453,7 @@ func TestHealthCheckAppServer(t *testing.T) {
 			desc:       "match and online services",
 			publicAddr: "valid.example.com",
 			appServersFunc: func(t *testing.T, _ *reversetunnelclient.FakeCluster) []types.AppServer {
-				return []types.AppServer{createAppServer(t, "valid.example.com")}
+				return []types.AppServer{createNamedAppServer(t, "testapp", "valid.example.com")}
 			},
 			expectedTunnelCalls: 1,
 			expectErr:           require.NoError,
@@ -405,7 +462,7 @@ func TestHealthCheckAppServer(t *testing.T) {
 			desc:       "match and but no online services",
 			publicAddr: "valid.example.com",
 			appServersFunc: func(t *testing.T, cluster *reversetunnelclient.FakeCluster) []types.AppServer {
-				appServer := createAppServer(t, "valid.example.com")
+				appServer := createNamedAppServer(t, "testapp", "valid.example.com")
 				cluster.OfflineTunnels = map[string]struct{}{
 					fmt.Sprintf("%s.%s", appServer.GetHostID(), clusterName): {},
 				}
@@ -451,7 +508,7 @@ func TestHealthCheckAppServer(t *testing.T) {
 			})
 			require.NoError(t, err)
 
-			err = appHandler.HealthCheckAppServer(ctx, tc.publicAddr, clusterName)
+			err = appHandler.HealthCheckAppServer(ctx, "testapp", tc.publicAddr, clusterName)
 			tc.expectErr(t, err)
 			require.Equal(t, int64(tc.expectedTunnelCalls), fakeCluster.DialCount())
 		})
@@ -759,6 +816,30 @@ func createAppKeyCertPair(t *testing.T, clock *clockwork.FakeClock, caKey, caCer
 	return privateKey, cert
 }
 
+// createNamedAppServer is like createAppServer but lets the caller pick the app
+// name, which is required to exercise routing between multiple apps that share a
+// public address.
+func createNamedAppServer(t *testing.T, appName, publicAddr string) types.AppServer {
+	appServer, err := types.NewAppServerV3(
+		types.Metadata{Name: appName},
+		types.AppServerSpecV3{
+			HostID: uuid.New().String(),
+			App: &types.AppV3{
+				Metadata: types.Metadata{
+					Name:   appName,
+					Labels: map[string]string{"app_name": appName},
+				},
+				Spec: types.AppSpecV3{
+					URI:        "localhost",
+					PublicAddr: publicAddr,
+				},
+			},
+		},
+	)
+	require.NoError(t, err)
+	return appServer
+}
+
 func createAppServer(t *testing.T, publicAddr string) types.AppServer {
 	appName := uuid.New().String()
 	appServer, err := types.NewAppServerV3(
@@ -953,7 +1034,7 @@ func TestHandlerAuthenticate(t *testing.T) {
 		clusterName: clusterName,
 		appSession:  createAppSession(t, fakeClock, key, cert, clusterName, publicAddr, "testapp"),
 		appServers: []types.AppServer{
-			createAppServer(t, publicAddr),
+			createNamedAppServer(t, "testapp", publicAddr),
 		},
 		caKey:  key,
 		caCert: cert,

--- a/lib/web/app/handler_test.go
+++ b/lib/web/app/handler_test.go
@@ -329,8 +329,7 @@ func TestMatchApplicationServers(t *testing.T) {
 	authClient := &mockAuthClient{
 		clusterName: clusterName,
 		appSession:  createAppSession(t, fakeClock, key, cert, clusterName, publicAddr, "testapp"),
-		// Three app servers (HA replicas of the same app, so same name and
-		// public addr) that match our session, and three that won't match.
+		// Three replicas of the same app, and three that won't match.
 		appServers: []types.AppServer{
 			createNamedAppServer(t, "testapp", publicAddr),
 			createNamedAppServer(t, "testapp", publicAddr),

--- a/lib/web/app/match.go
+++ b/lib/web/app/match.go
@@ -48,6 +48,29 @@ func MatchUnshuffled(ctx context.Context, cluster reversetunnelclient.Cluster, f
 // Matcher allows matching on different properties of an app server.
 type Matcher func(readonly.AppServer) bool
 
+// MatchAppServerForRoute matches an app server against routing information,
+// typically from a certificate. It matches on whichever of name and public
+// address are provided:
+//
+//   - When both are set both must match. This is what disambiguates multiple apps
+//     that share a public address: the app name uniquely identifies an app within
+//     the cluster, and the public address is also verified as a safety check.
+//   - An empty field is not checked, so this both supports name-only and addr-only
+//     resolution.
+//   - If both are empty, nothing matches.
+func MatchAppServerForRoute(name, publicAddr string) Matcher {
+	return func(appServer readonly.AppServer) bool {
+		app := appServer.GetApp()
+		if publicAddr != "" && app.GetPublicAddr() != publicAddr {
+			return false
+		}
+		if name != "" && app.GetName() != name {
+			return false
+		}
+		return name != "" || publicAddr != ""
+	}
+}
+
 // MatchPublicAddr matches on the public address of an application.
 func MatchPublicAddr(publicAddr string) Matcher {
 	return func(appServer readonly.AppServer) bool {

--- a/lib/web/app/match.go
+++ b/lib/web/app/match.go
@@ -88,12 +88,25 @@ func MatchName(name string) Matcher {
 // ResolveFQDN makes a best effort attempt to resolve FQDN to an application
 // running a root or leaf cluster.
 //
+// canAccess, when specified, reports whether the requesting user is permitted to
+// access a given application. It is used to disambiguate when an FQDN matches
+// more than one application. When no match is accessible, or canAccess is nil,
+// it falls back to a plain best-effort pick and leaves the final access decision
+// to the application service.
+//
 // Note: This function can incorrectly resolve application names. For example,
 // if you have an application named "acme" within both the root and leaf
 // cluster, this method will always return "acme" running within the root
 // cluster. Always supply public address and cluster name to deterministically
 // resolve an application.
-func ResolveFQDN(ctx context.Context, clusterGetter reversetunnelclient.ClusterGetter, localClusterName string, proxyDNSNames []string, fqdn string) (types.AppServer, string, error) {
+func ResolveFQDN(
+	ctx context.Context,
+	clusterGetter reversetunnelclient.ClusterGetter,
+	localClusterName string,
+	proxyDNSNames []string,
+	fqdn string,
+	canAccess func(types.Application) bool,
+) (types.AppServer, string, error) {
 	clusterClient, err := clusterGetter.Cluster(ctx, localClusterName)
 	if err != nil {
 		return nil, "", trace.Wrap(err)
@@ -102,7 +115,7 @@ func ResolveFQDN(ctx context.Context, clusterGetter reversetunnelclient.ClusterG
 	// Try and match FQDN to public address of application within cluster.
 	servers, err := MatchUnshuffled(ctx, clusterClient, MatchPublicAddr(fqdn))
 	if err == nil && len(servers) > 0 {
-		return servers[rand.N(len(servers))], localClusterName, nil
+		return pickAppServer(servers, canAccess), localClusterName, nil
 	}
 
 	proxyPublicAddr := utils.FindMatchingProxyDNS(fqdn, proxyDNSNames)
@@ -120,9 +133,29 @@ func ResolveFQDN(ctx context.Context, clusterGetter reversetunnelclient.ClusterG
 	for _, clusterClient := range clusterClients {
 		servers, err = MatchUnshuffled(ctx, clusterClient, MatchName(appName))
 		if err == nil && len(servers) > 0 {
-			return servers[rand.N(len(servers))], clusterClient.GetName(), nil
+			return pickAppServer(servers, canAccess), clusterClient.GetName(), nil
 		}
 	}
 
 	return nil, "", trace.NotFound("failed to resolve %v to any application within any cluster", fqdn)
+}
+
+// pickAppServer chooses one app server from a set of matches. When canAccess is
+// provided it prefers servers the user is allowed to access.
+//
+// If no apps are accessible or canAccess is nil it falls back to a random match,
+// leaving the final access decision to the app_service.
+func pickAppServer(servers []types.AppServer, canAccess func(types.Application) bool) types.AppServer {
+	if canAccess != nil {
+		accessible := make([]types.AppServer, 0, len(servers))
+		for _, s := range servers {
+			if canAccess(s.GetApp()) {
+				accessible = append(accessible, s)
+			}
+		}
+		if len(accessible) > 0 {
+			return accessible[rand.N(len(accessible))]
+		}
+	}
+	return servers[rand.N(len(servers))]
 }

--- a/lib/web/app/match_test.go
+++ b/lib/web/app/match_test.go
@@ -19,71 +19,112 @@
 package app
 
 import (
-	"context"
-	"net"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/gravitational/teleport/api/defaults"
 	"github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/teleport/lib/reversetunnelclient"
 )
 
-func mustNewAppServer(t *testing.T, origin string) func() types.AppServer {
-	t.Helper()
-	return func() types.AppServer {
-		app, err := types.NewAppV3(
-			types.Metadata{
-				Name:      "test-app",
-				Namespace: defaults.Namespace,
-				Labels: map[string]string{
-					types.OriginLabel: origin,
+func TestMatchAppServerForRoute(t *testing.T) {
+	t.Parallel()
+	for _, test := range []struct {
+		desc string
+
+		appName string
+		appAddr string
+
+		name string
+		addr string
+
+		wantMatch bool
+	}{
+		{
+			desc:      "all match",
+			appName:   "foo",
+			appAddr:   "foo.example.com",
+			name:      "foo",
+			addr:      "foo.example.com",
+			wantMatch: true,
+		},
+		{
+			desc:      "fallback no name (match)",
+			appName:   "foo",
+			appAddr:   "foo.example.com",
+			name:      "",
+			addr:      "foo.example.com",
+			wantMatch: true,
+		},
+		{
+			desc:      "fallback no name (mismatch)",
+			appName:   "foo",
+			appAddr:   "foo.example.com",
+			name:      "",
+			addr:      "bar.example.com",
+			wantMatch: false,
+		},
+		{
+			desc:      "different name",
+			appName:   "foo",
+			appAddr:   "foo.example.com",
+			name:      "bar",
+			addr:      "foo.example.com",
+			wantMatch: false,
+		},
+		{
+			desc:      "different addr",
+			appName:   "foo",
+			appAddr:   "foo.example.com",
+			name:      "foo",
+			addr:      "bar.example.com",
+			wantMatch: false,
+		},
+		{
+			desc:      "name only (match)",
+			appName:   "foo",
+			appAddr:   "foo.example.com",
+			name:      "foo",
+			addr:      "",
+			wantMatch: true,
+		},
+		{
+			desc:      "name only (mismatch)",
+			appName:   "foo",
+			appAddr:   "foo.example.com",
+			name:      "bar",
+			addr:      "",
+			wantMatch: false,
+		},
+		{
+			desc:      "neither name nor addr matches nothing",
+			appName:   "foo",
+			appAddr:   "foo.example.com",
+			name:      "",
+			addr:      "",
+			wantMatch: false,
+		},
+	} {
+		t.Run(test.desc, func(t *testing.T) {
+			appServer, err := types.NewAppServerV3(
+				types.Metadata{Name: test.appName},
+				types.AppServerSpecV3{
+					HostID: "test-host-id",
+					App: &types.AppV3{
+						Metadata: types.Metadata{Name: test.appName},
+						Spec: types.AppSpecV3{
+							PublicAddr: test.appAddr,
+							URI:        "http://localhost:12345",
+						},
+					},
 				},
-			},
-			types.AppSpecV3{
-				URI: "https://app.localhost",
-			},
-		)
-		require.NoError(t, err)
+			)
+			require.NoError(t, err)
 
-		appServer, err := types.NewAppServerV3FromApp(app, "localhost", "123")
-		require.NoError(t, err)
-
-		return appServer
+			require.Equal(
+				t,
+				test.wantMatch,
+				MatchAppServerForRoute(test.name, test.addr)(appServer),
+			)
+		})
 	}
-}
-
-type mockClusterGetter struct {
-	reversetunnelclient.ClusterGetter
-	cluster *mockCluster
-}
-
-func (p *mockClusterGetter) Cluster(context.Context, string) (reversetunnelclient.Cluster, error) {
-	return p.cluster, nil
-}
-
-type mockCluster struct {
-	reversetunnelclient.Cluster
-	dialErr error
-}
-
-func (r *mockCluster) Dial(_ reversetunnelclient.DialParams) (net.Conn, error) {
-	if r.dialErr != nil {
-		return nil, r.dialErr
-	}
-
-	return &mockDialConn{}, nil
-}
-
-func (r *mockCluster) GetName() string {
-	return "mockCluster"
-}
-
-type mockDialConn struct {
-	net.Conn
-}
-
-func (c *mockDialConn) Close() error {
-	return nil
 }

--- a/lib/web/app/match_test.go
+++ b/lib/web/app/match_test.go
@@ -128,3 +128,44 @@ func TestMatchAppServerForRoute(t *testing.T) {
 		})
 	}
 }
+
+func TestPickAppServer(t *testing.T) {
+	t.Parallel()
+
+	mustMakeAppServer := func(name string) types.AppServer {
+		s, err := types.NewAppServerV3(
+			types.Metadata{Name: name},
+			types.AppServerSpecV3{
+				HostID: "host-" + name,
+				App: &types.AppV3{
+					Metadata: types.Metadata{Name: name},
+					Spec:     types.AppSpecV3{PublicAddr: "dup.example.com", URI: "http://localhost:1"},
+				},
+			},
+		)
+		require.NoError(t, err)
+		return s
+	}
+
+	app1, app2 := mustMakeAppServer("dup-app-1"), mustMakeAppServer("dup-app-2")
+	servers := []types.AppServer{app1, app2}
+	onlyApp1 := func(a types.Application) bool { return a.GetName() == "dup-app-1" }
+	none := func(types.Application) bool { return false }
+
+	t.Run("prefers the accessible app", func(t *testing.T) {
+		for range 100 {
+			require.Equal(t, "dup-app-1", pickAppServer(servers, onlyApp1).GetApp().GetName())
+		}
+	})
+
+	t.Run("nil filter picks among all (legacy behavior)", func(t *testing.T) {
+		got := pickAppServer(servers, nil)
+		require.Contains(t, []string{"dup-app-1", "dup-app-2"}, got.GetApp().GetName())
+	})
+
+	t.Run("no accessible match falls back to all", func(t *testing.T) {
+		got := pickAppServer(servers, none)
+		require.NotNil(t, got)
+		require.Contains(t, []string{"dup-app-1", "dup-app-2"}, got.GetApp().GetName())
+	})
+}

--- a/lib/web/app/session.go
+++ b/lib/web/app/session.go
@@ -68,10 +68,14 @@ func (h *Handler) newSession(ctx context.Context, ws types.WebSession) (*session
 		return nil, trace.Wrap(err)
 	}
 
+	// Build a list of candidate app servers by name/addr.
 	servers, err := MatchUnshuffled(
 		ctx,
 		clusterClient,
-		MatchPublicAddr(identity.RouteToApp.PublicAddr),
+		MatchAppServerForRoute(
+			identity.RouteToApp.Name,
+			identity.RouteToApp.PublicAddr,
+		),
 	)
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/web/app/transport_test.go
+++ b/lib/web/app/transport_test.go
@@ -39,6 +39,7 @@ import (
 	"github.com/jonboulle/clockwork"
 	"github.com/stretchr/testify/require"
 
+	apidefaults "github.com/gravitational/teleport/api/defaults"
 	"github.com/gravitational/teleport/api/types"
 	apiutils "github.com/gravitational/teleport/api/utils"
 	"github.com/gravitational/teleport/api/utils/keys"
@@ -577,4 +578,62 @@ func Test_isAppServerDialable(t *testing.T) {
 			require.Equal(t, tt.match, got, tt.app())
 		})
 	}
+}
+
+func mustNewAppServer(t *testing.T, origin string) func() types.AppServer {
+	t.Helper()
+	return func() types.AppServer {
+		app, err := types.NewAppV3(
+			types.Metadata{
+				Name:      "test-app",
+				Namespace: apidefaults.Namespace,
+				Labels: map[string]string{
+					types.OriginLabel: origin,
+				},
+			},
+			types.AppSpecV3{
+				URI: "https://app.localhost",
+			},
+		)
+		require.NoError(t, err)
+
+		appServer, err := types.NewAppServerV3FromApp(app, "localhost", "123")
+		require.NoError(t, err)
+
+		return appServer
+	}
+}
+
+type mockClusterGetter struct {
+	reversetunnelclient.ClusterGetter
+	cluster *mockCluster
+}
+
+func (p *mockClusterGetter) Cluster(context.Context, string) (reversetunnelclient.Cluster, error) {
+	return p.cluster, nil
+}
+
+type mockCluster struct {
+	reversetunnelclient.Cluster
+	dialErr error
+}
+
+func (r *mockCluster) Dial(_ reversetunnelclient.DialParams) (net.Conn, error) {
+	if r.dialErr != nil {
+		return nil, r.dialErr
+	}
+
+	return &mockDialConn{}, nil
+}
+
+func (r *mockCluster) GetName() string {
+	return "mockCluster"
+}
+
+type mockDialConn struct {
+	net.Conn
+}
+
+func (c *mockDialConn) Close() error {
+	return nil
 }

--- a/lib/web/apps.go
+++ b/lib/web/apps.go
@@ -149,7 +149,7 @@ func (h *Handler) createAppSession(w http.ResponseWriter, r *http.Request, p htt
 	// coming from the WebUI.
 	if h.healthCheckAppServer != nil && !app.HasClientCert(r) {
 		h.logger.DebugContext(r.Context(), "Ensuring proxy can handle requests for application", "app", result.App.GetName())
-		err := h.healthCheckAppServer(r.Context(), result.App.GetPublicAddr(), result.ClusterName)
+		err := h.healthCheckAppServer(r.Context(), result.App.GetName(), result.App.GetPublicAddr(), result.ClusterName)
 		if err != nil {
 			return nil, trace.ConnectionProblem(err, "Unable to serve application requests. Please try again. If the issue persists, verify if the Application Services are connected to Teleport.")
 		}
@@ -247,10 +247,8 @@ func (h *Handler) resolveApp(ctx context.Context, scx *SessionContext, params Re
 	// from the application launcher in the Web UI) then directly exactly resolve the
 	// application that the caller is requesting. If it does not, do best effort FQDN resolution.
 	switch {
-	case params.AppName != "" && params.ClusterName != "":
-		server, appClusterName, err = h.resolveAppByName(ctx, proxy, params.AppName, params.ClusterName)
-	case params.PublicAddr != "" && params.ClusterName != "":
-		server, appClusterName, err = h.resolveDirect(ctx, proxy, params.PublicAddr, params.ClusterName)
+	case params.ClusterName != "" && (params.AppName != "" || params.PublicAddr != ""):
+		server, appClusterName, err = h.resolveAppByName(ctx, proxy, params.AppName, params.PublicAddr, params.ClusterName)
 	case params.FQDNHint != "":
 		server, appClusterName, err = app.ResolveFQDN(ctx, proxy, h.auth.clusterName, h.proxyDNSNames(), params.FQDNHint)
 	default:
@@ -274,41 +272,22 @@ func (h *Handler) resolveApp(ctx context.Context, scx *SessionContext, params Re
 	}, nil
 }
 
-// resolveAppByName will take an application name and cluster name and exactly resolves
-// the application and the server on which it is running.
-func (h *Handler) resolveAppByName(ctx context.Context, clusterGetter reversetunnelclient.ClusterGetter, appName string, clusterName string) (types.AppServer, string, error) {
+// resolveAppByName will take a cluster name, public address, and optional app name in order to
+// locate the application and the server on which it is running.
+// The app name, if provided, is used to disambiguate multiple apps with the same public addr.
+func (h *Handler) resolveAppByName(ctx context.Context, clusterGetter reversetunnelclient.ClusterGetter, appName, publicAddr, clusterName string) (types.AppServer, string, error) {
 	clusterClient, err := clusterGetter.Cluster(ctx, clusterName)
 	if err != nil {
 		return nil, "", trace.Wrap(err)
 	}
 
-	servers, err := app.MatchUnshuffled(ctx, clusterClient, app.MatchName(appName))
+	servers, err := app.MatchUnshuffled(ctx, clusterClient, app.MatchAppServerForRoute(appName, publicAddr))
 	if err != nil {
 		return nil, "", trace.Wrap(err)
 	}
 
 	if len(servers) == 0 {
-		return nil, "", trace.NotFound("failed to match applications with name %s", appName)
-	}
-
-	return servers[rand.N(len(servers))], clusterName, nil
-}
-
-// resolveDirect takes a public address and cluster name and exactly resolves
-// the application and the server on which it is running.
-func (h *Handler) resolveDirect(ctx context.Context, clusterGetter reversetunnelclient.ClusterGetter, publicAddr string, clusterName string) (types.AppServer, string, error) {
-	clusterClient, err := clusterGetter.Cluster(ctx, clusterName)
-	if err != nil {
-		return nil, "", trace.Wrap(err)
-	}
-
-	servers, err := app.MatchUnshuffled(ctx, clusterClient, app.MatchPublicAddr(publicAddr))
-	if err != nil {
-		return nil, "", trace.Wrap(err)
-	}
-
-	if len(servers) == 0 {
-		return nil, "", trace.NotFound("failed to match applications with public addr %s", publicAddr)
+		return nil, "", trace.NotFound("failed to match applications with addr %s and name %q", publicAddr, appName)
 	}
 
 	return servers[rand.N(len(servers))], clusterName, nil

--- a/lib/web/apps.go
+++ b/lib/web/apps.go
@@ -22,6 +22,7 @@ package web
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math/rand/v2"
 	"net/http"
@@ -34,6 +35,7 @@ import (
 	"github.com/gravitational/teleport/lib/client"
 	"github.com/gravitational/teleport/lib/httplib"
 	"github.com/gravitational/teleport/lib/reversetunnelclient"
+	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/utils"
 	"github.com/gravitational/teleport/lib/web/app"
 )
@@ -248,9 +250,14 @@ func (h *Handler) resolveApp(ctx context.Context, scx *SessionContext, params Re
 	// application that the caller is requesting. If it does not, do best effort FQDN resolution.
 	switch {
 	case params.ClusterName != "" && (params.AppName != "" || params.PublicAddr != ""):
-		server, appClusterName, err = h.resolveAppByName(ctx, proxy, params.AppName, params.PublicAddr, params.ClusterName)
+		server, appClusterName, err = h.resolveAppForCluster(ctx, proxy, params.AppName, params.PublicAddr, params.ClusterName)
 	case params.FQDNHint != "":
-		server, appClusterName, err = app.ResolveFQDN(ctx, proxy, h.auth.clusterName, h.proxyDNSNames(), params.FQDNHint)
+		// Multiple apps can have the same FQDN - prefer those the user
+		// can actually access.
+		var canAccess func(types.Application) bool
+		if canAccess, err = h.userAppAccessFilter(ctx, scx); err == nil {
+			server, appClusterName, err = app.ResolveFQDN(ctx, proxy, h.auth.clusterName, h.proxyDNSNames(), params.FQDNHint, canAccess)
+		}
 	default:
 		err = trace.BadParameter("no inputs to resolve application")
 	}
@@ -272,10 +279,38 @@ func (h *Handler) resolveApp(ctx context.Context, scx *SessionContext, params Re
 	}, nil
 }
 
-// resolveAppByName will take a cluster name, public address, and optional app name in order to
+// userAppAccessFilter returns a filter that checks whether the current user session
+// is allowed to access an application.
+//
+// Per-session MFA and device trust requirements are treated as "accessible" here
+// since the user is allowed, they'll just be asked for an extra factor when the connection
+// is actually established.
+func (h *Handler) userAppAccessFilter(ctx context.Context, scx *SessionContext) (func(types.Application) bool, error) {
+	checker, err := scx.GetUserAccessChecker()
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	authPref, err := h.cfg.AccessPoint.GetAuthPreference(ctx)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	state := checker.GetAccessState(authPref)
+	return func(app types.Application) bool {
+		err := checker.CheckAccess(app, state)
+		return err == nil ||
+			errors.Is(err, services.ErrSessionMFARequired) ||
+			errors.Is(err, services.ErrTrustedDeviceRequired)
+	}, nil
+}
+
+// resolveAppForCluster will take a cluster name, public address, and optional app name in order to
 // locate the application and the server on which it is running.
 // The app name, if provided, is used to disambiguate multiple apps with the same public addr.
-func (h *Handler) resolveAppByName(ctx context.Context, clusterGetter reversetunnelclient.ClusterGetter, appName, publicAddr, clusterName string) (types.AppServer, string, error) {
+func (h *Handler) resolveAppForCluster(
+	ctx context.Context,
+	clusterGetter reversetunnelclient.ClusterGetter,
+	appName, publicAddr, clusterName string,
+) (types.AppServer, string, error) {
 	clusterClient, err := clusterGetter.Cluster(ctx, clusterName)
 	if err != nil {
 		return nil, "", trace.Wrap(err)


### PR DESCRIPTION
This change improves Teleport's handling of multiple apps with the same public address by selecting apps based on both the app name and its public address (rather than the public address alone).

This selection happens both at the proxy (in order to select an app_service), and at the app service (in order to select the right app from the set of apps the agent serves).

The change is backwards compatible, if the app name is not provided then the selection happens based on public address alone, matching the prior behavior.

It's worth noting that Teleport has always encoded the app name in certificates for the CLI-based (tsh apps login) flow, but the web UI's browser flow has not been including the app's name until now. As a result, users will need to update auth, proxy, and app agents to get the full set of fixes.

Additionally, update the app selection algorithm for the FQDN-only case (when a user opens their browser directly to an app's public address without an existing Teleport session) such that only apps the user has access to are considered.

Fixes #67462

Changelog: Prevent misrouting when multiple apps share the same public address.

## Manual Test Plan

### Test Environment

Local cluster.

### Test Cases

#### Single app

- [x] Standalone app agent with one app, `tsh proxy app` + curl test. Send 50 requests, verify all 50 hit the target app.
- [x] Standalone app that's not allowed by RBAC: `tsh apps login` fails.

#### Conflicting apps

Deployed multiple app agents each serving an app with the same public address.

- [x] `tsh apps login app1` + `tsh proxy app` + `curl`: all requests go to app 1
- [x] Repeat the test for app2 
- [x] Log in as a user with permission for both apps, `tsh apps login app1`, then `tsh proxy app` + curl and verify that no requests hit app2.
- [x] Repeat the test with a user who has permission for 1 but not both apps. Expect all successful requests and no access denied errors.
- [x] Log in as a user with no standing access to either app. Use an access request to grant permission to only one of the apps. Verify that all requests succeed and hit the correct app.

I also went through steps of our major release manual test plan, verifying:
- [x] Dynamic registration (create, edit, rm)
- [x] Debug app functions correctly
- [x] UI displays correct apps and can connect to them  
