### PR TITLE
[v18] [Web] Add notification informing users with `web_terminal_clipboard_mode: no-copy` that they can't copy terminal content

### DIFF
--- a/web/packages/shared/components/ToastNotification/ToastNotificationContext.tsx
+++ b/web/packages/shared/components/ToastNotification/ToastNotificationContext.tsx
@@ -44,9 +44,9 @@ type ToastNotificationContextState = {
   remove(id: string): void;
   /**
    * adds new notification to the beginning of
-   * an existing list of notifications.
+   * an existing list of notifications and returns its id.
    */
-  add(entry: NotificationEntry): void;
+  add(entry: NotificationEntry): string;
 };
 
 const ToastNotificationContext =
@@ -67,14 +67,16 @@ export const ToastNotificationProvider: FC<PropsWithChildren> = ({
   }, []);
 
   const add = useCallback((entry: NotificationEntry) => {
+    const id = crypto.randomUUID();
     setNotifications(n => [
       {
-        id: crypto.randomUUID(),
+        id,
         content: entry.content,
         severity: entry.severity,
       },
       ...n,
     ]);
+    return id;
   }, []);
 
   return (

--- a/web/packages/teleport/src/Console/Console.tsx
+++ b/web/packages/teleport/src/Console/Console.tsx
@@ -21,6 +21,7 @@ import styled from 'styled-components';
 
 import { Box, Flex, Indicator } from 'design';
 import { Danger } from 'design/Alert';
+import { ToastNotifications } from 'shared/components/ToastNotification';
 import useAttempt from 'shared/hooks/useAttemptNext';
 
 import AjaxPoller from 'teleport/components/AjaxPoller';
@@ -119,6 +120,7 @@ export default function Console() {
               }
             />
           </Flex>
+          <ToastNotifications />
           {$docs}
           {hasSshSessions && (
             <AjaxPoller time={POLL_INTERVAL} onFetch={onRefresh} />

--- a/web/packages/teleport/src/Console/DocumentKubeExec/DocumentKubeExec.test.tsx
+++ b/web/packages/teleport/src/Console/DocumentKubeExec/DocumentKubeExec.test.tsx
@@ -19,6 +19,7 @@ import { screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
 
 import { act, render } from 'design/utils/testing';
+import { ToastNotificationProvider } from 'shared/components/ToastNotification';
 
 import { ContextProvider } from 'teleport';
 import { TestLayout } from 'teleport/Console/Console.story';
@@ -57,9 +58,11 @@ describe('DocumentKubeExec', () => {
 
     render(
       <ContextProvider ctx={ctx}>
-        <TestLayout ctx={consoleCtx}>
-          <DocumentKubeExec doc={baseDoc} visible={true} />
-        </TestLayout>
+        <ToastNotificationProvider>
+          <TestLayout ctx={consoleCtx}>
+            <DocumentKubeExec doc={baseDoc} visible={true} />
+          </TestLayout>
+        </ToastNotificationProvider>
       </ContextProvider>
     );
   };

--- a/web/packages/teleport/src/Console/DocumentSsh/DocumentSsh.test.tsx
+++ b/web/packages/teleport/src/Console/DocumentSsh/DocumentSsh.test.tsx
@@ -19,6 +19,7 @@
 import { MemoryRouter } from 'react-router';
 
 import { render, screen } from 'design/utils/testing';
+import { ToastNotificationProvider } from 'shared/components/ToastNotification';
 
 import { allAccessAcl } from 'teleport/mocks/contexts';
 
@@ -47,21 +48,23 @@ test('file transfer buttons are enabled if user has access', async () => {
 function Component({ ctx }: { ctx: ConsoleContext }) {
   return (
     <MemoryRouter>
-      <ConsoleContextProvider value={ctx}>
-        <DocumentSsh
-          doc={{
-            id: 123,
-            status: 'connected',
-            kind: 'terminal',
-            serverId: '123',
-            login: 'tester',
-            latency: { client: 123, server: 2 },
-            url: 'http://localhost',
-            created: new Date(),
-          }}
-          visible={true}
-        />
-      </ConsoleContextProvider>
+      <ToastNotificationProvider>
+        <ConsoleContextProvider value={ctx}>
+          <DocumentSsh
+            doc={{
+              id: 123,
+              status: 'connected',
+              kind: 'terminal',
+              serverId: '123',
+              login: 'tester',
+              latency: { client: 123, server: 2 },
+              url: 'http://localhost',
+              created: new Date(),
+            }}
+            visible={true}
+          />
+        </ConsoleContextProvider>
+      </ToastNotificationProvider>
     </MemoryRouter>
   );
 }

--- a/web/packages/teleport/src/Console/DocumentSsh/Terminal/Terminal.tsx
+++ b/web/packages/teleport/src/Console/DocumentSsh/Terminal/Terminal.tsx
@@ -27,6 +27,7 @@ import styled from 'styled-components';
 
 import { Flex } from 'design';
 import { getPlatformType } from 'design/platform';
+import { useToastNotifications } from 'shared/components/ToastNotification';
 
 import { getMappedAction } from 'teleport/Console/useKeyboardNav';
 import XTermCtrl from 'teleport/lib/term/terminal';
@@ -52,6 +53,10 @@ export interface TerminalProps {
 export const Terminal = forwardRef<TerminalRef, TerminalProps>((props, ref) => {
   const termCtrlRef = useRef<XTermCtrl>(undefined);
   const elementRef = useRef<HTMLDivElement>(null);
+  const toastNotifications = useToastNotifications();
+  // Keeps track of whether we've already notified the user that copying is blocked, so
+  // that the notification is only shown on the first attempt.
+  const copyBlockedNotifiedRef = useRef(false);
 
   useImperativeHandle(
     ref,
@@ -72,6 +77,21 @@ export const Terminal = forwardRef<TerminalRef, TerminalProps>((props, ref) => {
       theme: props.theme,
       convertEol: props.convertEol,
       disableCopy: props.disableCopy,
+      onCopyBlocked: () => {
+        if (copyBlockedNotifiedRef.current) {
+          return;
+        }
+        copyBlockedNotifiedRef.current = true;
+        toastNotifications.add({
+          severity: 'warn',
+          content: {
+            title: "Copy attempt blocked.",
+            description:
+              "Your role doesn't permit you to copy content from the terminal.",
+            isAutoRemovable: true,
+          },
+        });
+      },
     });
     termCtrlRef.current = termCtrl;
 

--- a/web/packages/teleport/src/Console/DocumentSsh/Terminal/Terminal.tsx
+++ b/web/packages/teleport/src/Console/DocumentSsh/Terminal/Terminal.tsx
@@ -54,9 +54,8 @@ export const Terminal = forwardRef<TerminalRef, TerminalProps>((props, ref) => {
   const termCtrlRef = useRef<XTermCtrl>(undefined);
   const elementRef = useRef<HTMLDivElement>(null);
   const toastNotifications = useToastNotifications();
-  // Keeps track of whether we've already notified the user that copying is blocked, so
-  // that the notification is only shown on the first attempt.
-  const copyBlockedNotifiedRef = useRef(false);
+  // Keeps track of the notification id so that we can ensure there is only maximum one copy block notification showing at a time.
+  const copyBlockedToastIdRef = useRef<string>(undefined);
 
   useImperativeHandle(
     ref,
@@ -78,14 +77,14 @@ export const Terminal = forwardRef<TerminalRef, TerminalProps>((props, ref) => {
       convertEol: props.convertEol,
       disableCopy: props.disableCopy,
       onCopyBlocked: () => {
-        if (copyBlockedNotifiedRef.current) {
-          return;
+        // Remove the previous notification before creating the new one so there's only one showing at at time.
+        if (copyBlockedToastIdRef.current) {
+          toastNotifications.remove(copyBlockedToastIdRef.current);
         }
-        copyBlockedNotifiedRef.current = true;
-        toastNotifications.add({
+        copyBlockedToastIdRef.current = toastNotifications.add({
           severity: 'warn',
           content: {
-            title: "Copy attempt blocked.",
+            title: 'Copy attempt blocked',
             description:
               "Your role doesn't permit you to copy content from the terminal.",
             isAutoRemovable: true,

--- a/web/packages/teleport/src/lib/term/terminal.ts
+++ b/web/packages/teleport/src/lib/term/terminal.ts
@@ -62,17 +62,26 @@ export default class TtyTerminal implements TerminalSearcher {
   private customKeyEventHandlers = new Set<(event: KeyboardEvent) => boolean>();
 
   private _disableCopy: boolean;
+  private _onCopyBlocked?: () => void;
   private _blockCopy = (e: ClipboardEvent) => {
     e.preventDefault();
     e.stopImmediatePropagation();
+    this._onCopyBlocked?.();
   };
 
   constructor(
     tty: Tty,
     private options: Options
   ) {
-    const { el, scrollBack, fontFamily, fontSize, convertEol, disableCopy } =
-      options;
+    const {
+      el,
+      scrollBack,
+      fontFamily,
+      fontSize,
+      convertEol,
+      disableCopy,
+      onCopyBlocked,
+    } = options;
     this._el = el;
     this._fontFamily = fontFamily || undefined;
     this._fontSize = fontSize || 14;
@@ -81,6 +90,7 @@ export default class TtyTerminal implements TerminalSearcher {
     this._scrollBack = scrollBack || cfg.ui.scrollbackLines;
     this._convertEol = convertEol || false;
     this._disableCopy = !!disableCopy;
+    this._onCopyBlocked = onCopyBlocked;
     this.tty = tty;
     this.term = null;
 
@@ -323,4 +333,6 @@ type Options = {
   convertEol?: boolean;
   // disableCopy blocks copying terminal text to clipboard.
   disableCopy?: boolean;
+  // onCopyBlocked is called whenever a copy attempt is blocked because disableCopy is true.
+  onCopyBlocked?: () => void;
 };


### PR DESCRIPTION
Backport #67514 to branch/v18

## Manual Test Plan

### Test Environment

Local teleport running version `18.8.3`

### Test Cases
- [x] Verify that the notification shows up when someone with `web_terminal_clipboard_mode: no-copy` attempts to copy content from the SSH terminal.
- [x] Verify that the notification does not show up if the user _is_ allowed to copy from the terminal.
- [x] Verify that the notification auto-dismisses after 5 seconds.