### PR TITLE
Clarify `tsh request create` and OSS Teleport

### DIFF
--- a/docs/pages/identity-governance/access-requests/access-requests.mdx
+++ b/docs/pages/identity-governance/access-requests/access-requests.mdx
@@ -73,5 +73,10 @@ requesting a role via the Teleport CLI. Full Access Request functionality,
 including Resource Access Requests managing Access Requests via the Web UI are
 available in Teleport Enterprise.
 
-For information on how to use Just-in-time Access Requests with Teleport Community
-Edition, see [Teleport Community Access Requests](oss-role-requests.mdx).
+For information on how to use Just-in-time Access Requests with Teleport
+Community Edition, see [Teleport Community Access
+Requests](oss-role-requests.mdx). This guide describes CLI workflows that are
+available in all Teleport editions, but are the only available option for
+Teleport Community Edition users. For Teleport Enterprise, we recommend using an
+Access Request plugin so reviewers receive notifications via the communication
+tools your organization already uses.

--- a/docs/pages/identity-governance/access-requests/oss-role-requests.mdx
+++ b/docs/pages/identity-governance/access-requests/oss-role-requests.mdx
@@ -17,6 +17,12 @@ requesting a role using the Teleport CLI. Full Access Request functionality,
 including Resource Access Requests and an intuitive and searchable UI are
 available in Teleport Enterprise.
 
+This guide describes CLI workflows that are available in all Teleport editions,
+but are the only available option for Teleport Community Edition users. For
+Teleport Enterprise, we recommend using an Access Request plugin so reviewers
+receive notifications via the communication tools your organization already
+uses. See [Access Request plugins](./plugins/plugins.mdx) for guidance.
+
 ## RBAC security setup
 
 Teleport's role-based access control (RBAC) allows you to configure what roles

--- a/docs/pages/identity-governance/access-requests/role-requests.mdx
+++ b/docs/pages/identity-governance/access-requests/role-requests.mdx
@@ -87,9 +87,6 @@ running `tctl` on the Auth Service.
 
 ## Requesting Access
 
-While Teleport Enterprise supports the same CLI-based workflows for requesting
-access to roles, most users will prefer to request access via the web UI.
-
 To request access to one or more roles, navigate to the Access Requests page.
 You can find this page by selecting **Resources** on the side bar, expanding the
 *Access Requests* menu, and selecting **New Request**.
@@ -111,6 +108,11 @@ When all desired roles have been added, click **PROCEED TO REQUEST**, where you
 can review and submit the request.
 
 ![Submit Request](../../../img/access-requests/submit-request.png)
+
+While we recommend using the web UI to create Access Requests, users can also
+request access with the `tsh` CLI:
+- Using the [`tsh request create`](../../reference/cli/tsh.mdx#tsh-request-create) command
+- Adding the `--request-roles` flag when authenticating with [`tsh login`](../../reference/cli/tsh.mdx#tsh-login)
 
 ## Reviewing Access Requests via the Web UI
 


### PR DESCRIPTION
Closes #67378

Clarify the relationship between Teleport Community Edition and CLI-based Access Request creation:

- In the Access Requests landing page and OSS Role Requests page, indicate that using `tsh` is available to all editions, but add an explicit recommendation for using plugins.
- In Role Requests, indicate that the CLI is also an option for creating Access Requests. Link to CLI reference guide entries for relevant commands rather than the OSS Guide.

Note that, while the issue also calls for a link to the Single Machine guide from the Enterprise section, self-hosting Teleport Enterprise on a single machine is not the recommend approach, so this change does not address this request.