### PR TITLE
Server Discovery: fix sudo->sudo-rs migration for ubuntu 25.10+

### DIFF
--- a/lib/srv/server/installer/defaultinstallers.go
+++ b/lib/srv/server/installer/defaultinstallers.go
@@ -39,7 +39,8 @@ curl -sSf "$INSTALL_SCRIPT_URL" -o "$TEMP_INSTALLER_SCRIPT"
 
 chmod +x "$TEMP_INSTALLER_SCRIPT"
 
-sudo -E "$TEMP_INSTALLER_SCRIPT" || (echo "The install script ($TEMP_INSTALLER_SCRIPT) returned a non-zero exit code" && exit 1)
+envs=$(awk 'BEGIN { for (name in ENVIRON) if (name ~ /^[A-Za-z_][A-Za-z0-9_]*$/) { list = list sep name; sep = "," } print list }')
+sudo --preserve-env="$envs" "$TEMP_INSTALLER_SCRIPT" || (echo "The install script ($TEMP_INSTALLER_SCRIPT) returned a non-zero exit code" && exit 1)
 rm "$TEMP_INSTALLER_SCRIPT"`
 )
 
@@ -67,7 +68,8 @@ set +x
 TELEPORT_BINARY=/usr/local/bin/teleport
 [ -z "${TELEPORT_INSTALL_SUFFIX:-}" ] || TELEPORT_BINARY=/opt/teleport/${TELEPORT_INSTALL_SUFFIX}/bin/teleport
 
-sudo -E "$TELEPORT_BINARY" ` + strings.Join(argsList, " ") + " $@"
+envs=$(awk 'BEGIN { for (name in ENVIRON) if (name ~ /^[A-Za-z_][A-Za-z0-9_]*$/) { list = list sep name; sep = "," } print list }')
+sudo --preserve-env="$envs" "$TELEPORT_BINARY" ` + strings.Join(argsList, " ") + " $@"
 
 	argsList = []string{
 		"install", "autodiscover-node",

--- a/lib/srv/server/installer/defaultinstallers_test.go
+++ b/lib/srv/server/installer/defaultinstallers_test.go
@@ -42,7 +42,8 @@ curl -sSf "$INSTALL_SCRIPT_URL" -o "$TEMP_INSTALLER_SCRIPT"
 
 chmod +x "$TEMP_INSTALLER_SCRIPT"
 
-sudo -E "$TEMP_INSTALLER_SCRIPT" || (echo "The install script ($TEMP_INSTALLER_SCRIPT) returned a non-zero exit code" && exit 1)
+envs=$(awk 'BEGIN { for (name in ENVIRON) if (name ~ /^[A-Za-z_][A-Za-z0-9_]*$/) { list = list sep name; sep = "," } print list }')
+sudo --preserve-env="$envs" "$TEMP_INSTALLER_SCRIPT" || (echo "The install script ($TEMP_INSTALLER_SCRIPT) returned a non-zero exit code" && exit 1)
 rm "$TEMP_INSTALLER_SCRIPT"
 
 
@@ -52,7 +53,8 @@ set +x
 TELEPORT_BINARY=/usr/local/bin/teleport
 [ -z "${TELEPORT_INSTALL_SUFFIX:-}" ] || TELEPORT_BINARY=/opt/teleport/${TELEPORT_INSTALL_SUFFIX}/bin/teleport
 
-sudo -E "$TELEPORT_BINARY" install autodiscover-node --public-proxy-addr=teleport.example.com:443 --teleport-package=teleport-ent --repo-channel=stable/cloud --auto-upgrade=true --azure-client-id= $@`
+envs=$(awk 'BEGIN { for (name in ENVIRON) if (name ~ /^[A-Za-z_][A-Za-z0-9_]*$/) { list = list sep name; sep = "," } print list }')
+sudo --preserve-env="$envs" "$TELEPORT_BINARY" install autodiscover-node --public-proxy-addr=teleport.example.com:443 --teleport-package=teleport-ent --repo-channel=stable/cloud --auto-upgrade=true --azure-client-id= $@`
 
 // TestNewDefaultInstaller is a minimal
 func TestNewDefaultInstaller(t *testing.T) {


### PR DESCRIPTION
[Ubuntu 25.10+ is now using](https://discourse.ubuntu.com/t/adopting-sudo-rs-by-default-in-ubuntu-25-10/60583) [`sudo-rs`](https://github.com/trifectatechfoundation/sudo-rs).
In particular, Ubuntu 26.04, **which is an LTS version**, is also impacted by this change.
There are a couple of changes but the most impacting one for us is the absence of the `-E/--preserve-env` (without explicit list) flag:
`sudo: preserving the entire environment is not supported, '-E' is ignored`

`sudo-rs` requires an explicit list of envs, and just ignores the `-E` flag.

If you search for that error message, you will find tons of issues open in github and other places reporting this breaking change.
A couple of projects are fixing this by preserving every env var, something like:
```
sudo --preserve-env="$(env|cut -f1 -d=|tr '\n' ,)" <cmd>
```
Or similar approaches.

Being explicit about which envs we expose to the command, with elevated privs, seems to be a good security measure, but this effectively breaks a couple of things during server auto-discovery:
- non-global/suffix installations
- update groups
- proxy settings propagation


Our approach will be to only expose the ones we actually care about (or expose everything, WIP).

<!-- Provide a descriptive entry for the changelog of the next release. -->

Changelog: Fixed an issue in Server Discovery that would prevent suffixed installations in VMs using Ubuntu 25.10 or Ubuntu 26.04.


<!-- Include manual testing efforts to verify the change. -->
<!-- Detail where the tests where run and what configurations were used. -->
<!-- Include all the test cases which were run to validate the change. -->

## Manual Test Plan
### Test Environment

### Test Cases
- [x] Auto Discover in AWS w/ suffix installation using Ubuntu 26.04
- [x] Auto Discover in AWS w/ suffix installation using Ubuntu 24.04
- [x] Auto Discover in AWS w/ suffix installation using Amazon Linux

<img width="1394" height="401" alt="image" src="https://github.com/user-attachments/assets/2d5ae0c9-a546-4e48-9b64-f28d69a2ec16" />

```
> curl --silent https://proxy.example.com/v1/webapi/scripts/installer/default-installer | grep envs
envs=$(awk 'BEGIN { for (name in ENVIRON) { list = list sep name; sep = "," } print list }')
sudo --preserve-env="$envs" "$TEMP_INSTALLER_SCRIPT" || (echo "The install script ($TEMP_INSTALLER_SCRIPT) returned a non-zero exit code" && exit 1)
envs=$(awk 'BEGIN { for (name in ENVIRON) { list = list sep name; sep = "," } print list }')
sudo --preserve-env="$envs" "$TELEPORT_BINARY" install autodiscover-node --public-proxy-addr=proxy.example.com --teleport-package=teleport --repo-channel=stable/v18 --auto-upgrade=false --azure-client-id= $@
```