### PR TITLE
tctl-investigate[3]: Geo filters added to the stats endpoint

### DIFF
--- a/lib/accessgraph/apiclient/client.gen.go
+++ b/lib/accessgraph/apiclient/client.gen.go
@@ -461,6 +461,15 @@ type ExecuteLogsStatsQueryV1Params struct {
 	// Query Query to execute
 	Query *string `form:"query,omitempty" json:"query,omitempty"`
 
+	// Latitude Center latitude for the logs
+	Latitude *float32 `form:"latitude,omitempty" json:"latitude,omitempty"`
+
+	// Longitude Center longitude for the logs
+	Longitude *float32 `form:"longitude,omitempty" json:"longitude,omitempty"`
+
+	// Radius Radius for the logs
+	Radius *float32 `form:"radius,omitempty" json:"radius,omitempty"`
+
 	// StartTime Start time for the logs
 	StartTime *time.Time `form:"start_time,omitempty" json:"start_time,omitempty"`
 
@@ -1661,6 +1670,21 @@ func NewExecuteLogsStatsQueryV1Request(server string, params *ExecuteLogsStatsQu
 
 		}
 
+		if params.Latitude != nil {
+			queryValues.Add("latitude", strconv.FormatFloat(float64(*params.Latitude), 'f', -1, 32))
+
+		}
+
+		if params.Longitude != nil {
+			queryValues.Add("longitude", strconv.FormatFloat(float64(*params.Longitude), 'f', -1, 32))
+
+		}
+
+		if params.Radius != nil {
+			queryValues.Add("radius", strconv.FormatFloat(float64(*params.Radius), 'f', -1, 32))
+
+		}
+
 		if params.StartTime != nil {
 			queryValues.Add("start_time", (*params.StartTime).Format(time.RFC3339Nano))
 
@@ -1990,6 +2014,7 @@ type ListAlertStatsV1Response struct {
 	JSON200      *GetAlertsStatsResponse
 	JSON400      *BadRequest
 	JSON404      *BadRequest
+	JSON501      *BadRequest
 }
 
 // Status returns HTTPResponse.Status
@@ -2019,6 +2044,7 @@ type ListAlertsV1Response struct {
 	JSON200      *ListAlertsResponse
 	JSON400      *BadRequest
 	JSON404      *BadRequest
+	JSON501      *BadRequest
 }
 
 // Status returns HTTPResponse.Status
@@ -2048,6 +2074,7 @@ type GetAlertV1Response struct {
 	JSON200      *GetAlertResponse
 	JSON400      *BadRequest
 	JSON404      *BadRequest
+	JSON501      *BadRequest
 }
 
 // Status returns HTTPResponse.Status
@@ -2076,6 +2103,7 @@ type UpdateAlertStatusV1Response struct {
 	HTTPResponse *http.Response
 	JSON400      *BadRequest
 	JSON404      *BadRequest
+	JSON501      *BadRequest
 }
 
 // Status returns HTTPResponse.Status
@@ -2329,6 +2357,7 @@ type ExecuteLogsQueryV1Response struct {
 	JSON400      *BadRequest
 	JSON404      *BadRequest
 	JSON500      *BadRequest
+	JSON501      *BadRequest
 }
 
 // Status returns HTTPResponse.Status
@@ -2358,6 +2387,7 @@ type GetEventCountSinceResponse struct {
 	JSON200      *NewLogEntriesResponse
 	JSON400      *BadRequest
 	JSON404      *BadRequest
+	JSON501      *BadRequest
 }
 
 // Status returns HTTPResponse.Status
@@ -2387,6 +2417,7 @@ type ExecuteLogsStatsQueryV1Response struct {
 	JSON200      *GetLogsStatsResponse
 	JSON400      *BadRequest
 	JSON404      *BadRequest
+	JSON501      *BadRequest
 }
 
 // Status returns HTTPResponse.Status
@@ -2853,6 +2884,13 @@ func ParseListAlertStatsV1Response(rsp *http.Response) (*ListAlertStatsV1Respons
 		}
 		response.JSON404 = &dest
 
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 501:
+		var dest BadRequest
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON501 = &dest
+
 	}
 
 	return response, nil
@@ -2892,6 +2930,13 @@ func ParseListAlertsV1Response(rsp *http.Response) (*ListAlertsV1Response, error
 			return nil, err
 		}
 		response.JSON404 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 501:
+		var dest BadRequest
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON501 = &dest
 
 	}
 
@@ -2933,6 +2978,13 @@ func ParseGetAlertV1Response(rsp *http.Response) (*GetAlertV1Response, error) {
 		}
 		response.JSON404 = &dest
 
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 501:
+		var dest BadRequest
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON501 = &dest
+
 	}
 
 	return response, nil
@@ -2965,6 +3017,13 @@ func ParseUpdateAlertStatusV1Response(rsp *http.Response) (*UpdateAlertStatusV1R
 			return nil, err
 		}
 		response.JSON404 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 501:
+		var dest BadRequest
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON501 = &dest
 
 	}
 
@@ -3270,6 +3329,13 @@ func ParseExecuteLogsQueryV1Response(rsp *http.Response) (*ExecuteLogsQueryV1Res
 		}
 		response.JSON500 = &dest
 
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 501:
+		var dest BadRequest
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON501 = &dest
+
 	}
 
 	return response, nil
@@ -3310,6 +3376,13 @@ func ParseGetEventCountSinceResponse(rsp *http.Response) (*GetEventCountSinceRes
 		}
 		response.JSON404 = &dest
 
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 501:
+		var dest BadRequest
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON501 = &dest
+
 	}
 
 	return response, nil
@@ -3349,6 +3422,13 @@ func ParseExecuteLogsStatsQueryV1Response(rsp *http.Response) (*ExecuteLogsStats
 			return nil, err
 		}
 		response.JSON404 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 501:
+		var dest BadRequest
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON501 = &dest
 
 	}
 

--- a/skills/teleport-investigate/references/EXPERIENCE.md
+++ b/skills/teleport-investigate/references/EXPERIENCE.md
@@ -269,12 +269,6 @@ start with low-cost searches and refine until the result set is narrow.
 - **Empty `data`** — broaden the time window, or add `--show-unmatched` to a
   `--facets-only` run to discover which filter values actually exist in the
   window, then adjust the filter.
-<!-- TODO: Remove Geo filter restriction after stats endpoint adds support -->
-- **Geo filters apply to events only.** `--latitude`/`--longitude`/`--radius`
-  (all three required together) restrict the `data` array but **not** `total` or
-  the facet counts — those come from a stats endpoint that ignores geo. Expect
-  `total` to exceed `len(data)` with geo set even without `--limit` truncation;
-  explain this, don't report it as an inconsistency.
 - **Negative coordinates need the equals form.** A negative `--latitude` or
   `--longitude` is misread as a flag (`expected argument for flag '--latitude'`);
   pass it as `--latitude=-26.2309 --longitude=28.0583`.

--- a/tool/tctl/common/accessgraph/investigate_command.go
+++ b/tool/tctl/common/accessgraph/investigate_command.go
@@ -267,11 +267,13 @@ func (c *AccessGraphCommand) Investigate(ctx context.Context, client *accessgrap
 	g, gctx := errgroup.WithContext(ctx)
 	g.Go(func() error {
 		var err error
-		// TODO(ghassanachi): when gravitational/access-graph#2006 update the params to take in geo filters
 		facets, total, err = fetchLogsFacets(gctx, client, accessgraph.ExecuteLogsStatsQueryV1Params{
 			StartTime: &fromUTC,
 			EndTime:   &toUTC,
 			Query:     params.Query,
+			Latitude:  args.latitude,
+			Longitude: args.longitude,
+			Radius:    args.radius,
 		}, args.luceneToFlagMap())
 		return trace.Wrap(err)
 	})
@@ -304,11 +306,8 @@ func (c *AccessGraphCommand) Investigate(ctx context.Context, client *accessgrap
 
 	// --facets-only implies --all-facets in text output
 	allFacets := args.allFacets || args.facetsOnly
-	// Geo applies to events only; stats has no geo params.
-	geoActive := args.latitude != nil || args.longitude != nil || args.radius != nil
-
 	return writeOutput(c.stdout, output, args.format, func(w io.Writer) error {
-		return displayInvestigateText(w, output, args.from, args.to, args.limit, truncated, allFacets, args.facetsOnly, geoActive)
+		return displayInvestigateText(w, output, args.from, args.to, args.limit, truncated, allFacets, args.facetsOnly)
 	})
 }
 
@@ -459,11 +458,7 @@ func (a *investigateArgs) validateGeo() error {
 		// No geo flags set.
 		return nil
 	case 0:
-		// Geo filters events only, so --facets-only would silently do nothing.
-		// TODO(ghassanachi): when gravitational/access-graph#2006 is merged remove this condition
-		if a.facetsOnly {
-			return trace.BadParameter("--facets-only cannot be combined with geo filters (--latitude/--longitude/--radius); geo applies to events, which --facets-only skips")
-		}
+		// All geo flags set.
 		return nil
 	default:
 		return trace.BadParameter("geo filter requires all of --latitude, --longitude, and --radius; missing: %s", strings.Join(missing, ", "))
@@ -471,7 +466,7 @@ func (a *investigateArgs) validateGeo() error {
 }
 
 // displayInvestigateText renders the period header, the facet panel and the events table
-func displayInvestigateText(out io.Writer, output investigateOutput, from, to time.Time, limit int, truncated, allFacets, facetsOnly, geoActive bool) error {
+func displayInvestigateText(out io.Writer, output investigateOutput, from, to time.Time, limit int, truncated, allFacets, facetsOnly bool) error {
 	if _, err := fmt.Fprintf(out, "Period: %s → %s\n", from.Format(time.RFC3339), to.Format(time.RFC3339)); err != nil {
 		return trace.Wrap(err)
 	}
@@ -483,12 +478,6 @@ func displayInvestigateText(out io.Writer, output investigateOutput, from, to ti
 	}
 	if _, err := fmt.Fprintf(out, "%s\n", matches); err != nil {
 		return trace.Wrap(err)
-	}
-	// TODO(ghassanachi): when gravitational/access-graph#2006 is merged remove this condition
-	if geoActive {
-		if _, err := fmt.Fprintln(out, warningStyle.Render("Note: geo filters apply to events only; total and facet counts cover the window+query without these filters.")); err != nil {
-			return trace.Wrap(err)
-		}
 	}
 	if _, err := fmt.Fprintln(out); err != nil {
 		return trace.Wrap(err)

--- a/tool/tctl/common/accessgraph/investigate_command_test.go
+++ b/tool/tctl/common/accessgraph/investigate_command_test.go
@@ -147,13 +147,6 @@ func TestInvestigateValidateGeo(t *testing.T) {
 		_, missing, _ := strings.Cut(err.Error(), "missing: ")
 		require.Equal(t, "--longitude, --radius", missing)
 	})
-
-	t.Run("geo with --facets-only → BadParameter", func(t *testing.T) {
-		a := &investigateArgs{latitude: f(37.7), longitude: f(-122.4), radius: f(10), facetsOnly: true}
-		err := a.validateGeo()
-		require.True(t, trace.IsBadParameter(err), "want BadParameter, got %v", err)
-		require.Contains(t, err.Error(), "--facets-only cannot be combined with geo filters")
-	})
 }
 
 // TestStripUnmatchedFacets covers the count<0 sentinel: the backend uses
@@ -322,20 +315,23 @@ func newInvestigateCommand(t *testing.T, format string) (*AccessGraphCommand, *b
 // investigateHandler serves the AG stats and logs endpoints; nil logsPages
 // asserts the logs route is never hit.
 type investigateHandler struct {
-	stats         map[string]any
-	statsCalls    atomic.Int64
-	statsQuery    string
-	statsStart    string
-	statsEnd      string
-	logsPages     []fetchAllLogsPage
-	logsCalls     atomic.Int64
-	logsQuery     string
-	logsStart     string
-	logsEnd       string
-	logsOrder     string
-	logsLatitude  string
-	logsLongitude string
-	logsRadius    string
+	stats          map[string]any
+	statsCalls     atomic.Int64
+	statsQuery     string
+	statsStart     string
+	statsEnd       string
+	statsLatitude  string
+	statsLongitude string
+	statsRadius    string
+	logsPages      []fetchAllLogsPage
+	logsCalls      atomic.Int64
+	logsQuery      string
+	logsStart      string
+	logsEnd        string
+	logsOrder      string
+	logsLatitude   string
+	logsLongitude  string
+	logsRadius     string
 }
 
 func (h *investigateHandler) serve(t *testing.T) http.Handler {
@@ -348,6 +344,9 @@ func (h *investigateHandler) serve(t *testing.T) http.Handler {
 			h.statsQuery = r.URL.Query().Get("query")
 			h.statsStart = r.URL.Query().Get("start_time")
 			h.statsEnd = r.URL.Query().Get("end_time")
+			h.statsLatitude = r.URL.Query().Get("latitude")
+			h.statsLongitude = r.URL.Query().Get("longitude")
+			h.statsRadius = r.URL.Query().Get("radius")
 			_ = json.NewEncoder(w).Encode(h.stats)
 		case logsQueryPath:
 			idx := int(h.logsCalls.Add(1) - 1)
@@ -681,7 +680,7 @@ func TestInvestigate(t *testing.T) {
 		require.Equal(t, "stats kaput", agErr.Message)
 	})
 
-	t.Run("geo filter parameters are forwarded to the logs endpoint", func(t *testing.T) {
+	t.Run("geo filter parameters are forwarded to the logs and stats endpoint", func(t *testing.T) {
 		h := &investigateHandler{
 			stats:     statsResponse(statsColumn{name: "event_type", values: []statsValue{{value: "x", count: 1}}}),
 			logsPages: []fetchAllLogsPage{{data: nil}},
@@ -698,23 +697,9 @@ func TestInvestigate(t *testing.T) {
 		require.Equal(t, "37.7", h.logsLatitude)
 		require.Equal(t, "-122.4", h.logsLongitude)
 		require.Equal(t, "10", h.logsRadius)
-	})
-
-	t.Run("text format prints the geo note when geo is active", func(t *testing.T) {
-		h := &investigateHandler{
-			stats:     statsResponse(statsColumn{name: "event_type", values: []statsValue{{value: "x", count: 1}}}),
-			logsPages: []fetchAllLogsPage{{data: nil}},
-		}
-		ag := newAccessGraphTestClient(t, h.serve(t))
-
-		c, buf := newInvestigateCommand(t, teleport.Text)
-		lat, lon, rad := float32(37.7), float32(-122.4), float32(10)
-		c.investigate.latitude = &lat
-		c.investigate.longitude = &lon
-		c.investigate.radius = &rad
-
-		require.NoError(t, c.Investigate(context.Background(), ag))
-		require.Contains(t, buf.String(), "geo filters apply to events only")
+		require.Equal(t, "37.7", h.statsLatitude)
+		require.Equal(t, "-122.4", h.statsLongitude)
+		require.Equal(t, "10", h.statsRadius)
 	})
 }
 


### PR DESCRIPTION
This PR finishes the geo work part 2 deferred: it forwards the geo filter to the stats/facets endpoint, so `total` and the facet counts now respect `--latitude`/`--longitude`/`--radius` just like the events do.

**Backwards compatibility:** the geo params are sent as query parameters, so an Access Graph that predates #2006 simply ignores them on the stats endpoint — the command still works, it just falls back to the part 2 behavior where `total`/facet counts cover the window+query without geo (so they won't match the geo-filtered `data`). Nothing breaks; the worst case is the same count mismatch that existed prior to this change. 


| #   | PR                                                            | What it does                                                                                     |
| --- | ------------------------------------------------------------ | ------------------------------------------------------------------------------------------------ |
| 1   | [Core](https://github.com/gravitational/teleport/pull/67219) | `tctl investigate` — search activity logs with structured filters and a time window (JSON/YAML). |
| 2   | [Text, Geo Filters, Skill](https://github.com/gravitational/teleport/pull/67220) | Adds human-readable text output, geo filters (events only), and an embedded `teleport-investigate` skill. |
| 3   | **Geo in Stats**    (This PR)      | Forwards geo filters to the stats/facets endpoint so `total` and facet counts respect geo.       |

## What changed

- Regenerates the Access Graph API client to pick up the new geo params (`latitude`/`longitude`/`radius`) on the stats endpoint.
- Forwards the geo filter to the stats/facets query, not just the logs query.
- Drops the events-only stopgaps from part 2: the `--facets-only` + geo guard, the "geo applies to events only" warning note, and the matching caveat in the `teleport-investigate` skill.

## Why

This is the follow-up promised in [part 2](https://github.com/gravitational/teleport/pull/67220), now unblocked by gravitational/access-graph#2006 (merged). With the stats endpoint accepting geo, `total` and facet counts should line up more closely with the geo-filtered `data` instead of overcounting, so `--facets-only` is now meaningful alongside a geo filter.

##

## Manual Test Plan

### Test Environment

- Local dev cluster (current branch for `teleport` + local Access Graph), with `GeoLite2-City.mmdb` and patched event IPs as in part 2.

### Test Cases

- [X] Geo filter applied to a normal run: `total`/facet counts shrink to match the geo-filtered events instead of covering the whole window.
- [X] `--facets-only` combined with geo is accepted (no longer rejected) and returns geo-scoped facet counts.
- [X] No "geo applies to events only" warning is printed in text output anymore.
- [X] `--format json`/`yaml` still render correctly with geo set.
- [X] Backwards compatibility: against an Access Graph without gravitational/access-graph#2006, a geo run still succeeds — the stats endpoint ignores the geo params, so facet counts/`total` don't reflect geo, but the command returns correct logs without erroring. 

