### PR TITLE
Fix checkSCPAllowed() whitespace parsing

### DIFF
--- a/lib/srv/exec.go
+++ b/lib/srv/exec.go
@@ -35,6 +35,7 @@ import (
 	"time"
 
 	"github.com/gravitational/trace"
+	"github.com/mattn/go-shellwords"
 	"golang.org/x/crypto/ssh"
 
 	"github.com/gravitational/teleport"
@@ -377,7 +378,10 @@ func (e *localExec) transformSecureCopy() error {
 func checkSCPAllowed(scx *ServerContext, command string) (bool, error) {
 	// split up command by space to grab the first word. if we don't have anything
 	// it's an interactive shell the user requested and not scp, return
-	args := strings.Split(command, " ")
+	args, err := shellwords.Parse(command)
+	if err != nil {
+		return false, trace.Wrap(err)
+	}
 	if len(args) == 0 {
 		return false, nil
 	}

--- a/lib/srv/exec_test.go
+++ b/lib/srv/exec_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"golang.org/x/crypto/ssh"
 
+	decisionpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/decision/v1alpha1"
 	"github.com/gravitational/teleport/api/types"
 	apievents "github.com/gravitational/teleport/api/types/events"
 	"github.com/gravitational/teleport/lib/events"
@@ -164,4 +165,44 @@ func newExecServerContext(t *testing.T, srv Server) *ServerContext {
 	t.Cleanup(func() { require.NoError(t, scx.party.s.term.Close()) })
 
 	return scx
+}
+
+func TestCheckSCPAllowed(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		command string
+		assert  require.BoolAssertionFunc
+	}{
+		{
+			name:    "scp command",
+			command: "scp foo bar",
+			assert:  require.True,
+		},
+		{
+			name:    "other command",
+			command: "some other command",
+			assert:  require.False,
+		},
+		{
+			name:    "no command",
+			command: "",
+			assert:  require.False,
+		},
+		{
+			name:    "scp command with whitespace",
+			command: "\tscp foo bar",
+			assert:  require.True,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			scx := newTestServerContext(t, nil, nil, nil)
+			scx.AllowFileCopying = true
+			scx.Identity.AccessPermit = decisionpb.SSHAccessPermit_builder{SshFileCopy: true}.Build()
+			ok, err := checkSCPAllowed(scx, tc.command)
+			require.NoError(t, err)
+			tc.assert(t, ok)
+		})
+	}
 }


### PR DESCRIPTION
This change fixes a bug where `srv.checkSCPAllowed()`, which checks if a command is `scp` and should be affected by file copying permissions, would not correctly split whitespace around commands, in particular not recognizing " scp" as an invocation of scp where the shell would accept it.

Fixes gravitational/pressure-washing#206.

Changelog: Fixed file copying permissions not recognizing scp commands when surrounded by non-space whitespace

## Manual Test Plan
### Test Environment

Local cluster with a user and a note. File copying must be disabled either in the user's role or the ssh_service config.

### Test Cases
- [x] Verify that running `echo -n 'C0644 8 foo.txt\nabcdefgh\0' | tsh ssh node " scp -t $PWD/foo.txt"` does *not* create the file `foo.txt` in the current directory.
