### PR TITLE
Add a Teleport resource conversion script

### DIFF
--- a/build.assets/tooling/cmd/convert-resource/.gitignore
+++ b/build.assets/tooling/cmd/convert-resource/.gitignore
@@ -1,0 +1,2 @@
+# compiled binary
+convert-resource

--- a/build.assets/tooling/cmd/convert-resource/README.md
+++ b/build.assets/tooling/cmd/convert-resource/README.md
@@ -1,0 +1,60 @@
+# Teleport resource converter
+
+The Teleport resource converter is a small utility for transforming `tctl`
+resource documents into Terraform resource configurations and Kubernetes
+resource manifests. 
+
+The converter is intended for hand-authored resource documents, and not those
+returned directly from the Teleport Auth Service backend, since it does not
+contain logic for handling fields that track a resource's internal state.
+
+## How to build
+
+You will need Go installed on your system. In this directory, run the following
+command:
+
+```sh
+$ go build .
+```
+
+## Basic usage
+
+This is a CLI that reads a `tctl` resource YAML document from stdin (potentially
+including multiple resources, divided by YAML document separators) and returns
+the converted HCL configuration or Kubernetes YAML to stdout.
+
+The `-format` flag indicates which infrastructure as code tool format to use.
+Valid values are:
+
+- `hcl`
+- `kube`
+
+For example, you could convert a role to HCL using a heredoc:
+
+```sh
+cat<<EOF | ./convert-resource -format=hcl
+kind: role
+version: v8
+metadata:
+  name: example
+spec:
+  allow:
+    logins: [ubuntu]
+EOF
+```
+
+## Exit codes
+
+The program uses exit codes to help invoking shells determine whether a given
+`tctl` resource has no corresponding Terraform or Kubernetes resource, or
+whether the conversion failed for some other reason (e.g., malformed YAML):
+
+| Code | Purpose                                           |
+|------|---------------------------------------------------|
+| 2    | The resource is not supported in the given format |
+| 1    | All other errors                                  |
+| 0    | The conversion took place successfully
+
+## Supported kinds
+
+The `resourceConfig` map configures the resources supported for conversion.

--- a/build.assets/tooling/cmd/convert-resource/main.go
+++ b/build.assets/tooling/cmd/convert-resource/main.go
@@ -1,0 +1,927 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"regexp"
+	"strings"
+
+	"github.com/gravitational/trace"
+	"google.golang.org/protobuf/encoding/protojson"
+	yaml "gopkg.in/yaml.v3"
+
+	accessmonitoringrulesv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/accessmonitoringrules/v1"
+	appauthconfigv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/appauthconfig/v1"
+	autoupdatev1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/autoupdate/v1"
+	dbobjectimportrulev1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/dbobjectimportrule/v1"
+	healthcheckconfigv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/healthcheckconfig/v1"
+	machineidv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/machineid/v1"
+	summarizerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/summarizer/v1"
+	userprovisioningpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/userprovisioning/v2"
+	vnet "github.com/gravitational/teleport/api/gen/proto/go/teleport/vnet/v1"
+	workloadcluster "github.com/gravitational/teleport/api/gen/proto/go/teleport/workloadcluster/v1"
+	workloadidentityv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/workloadidentity/v1"
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/api/types/accesslist"
+	convertv1 "github.com/gravitational/teleport/api/types/accesslist/convert/v1"
+	"github.com/gravitational/teleport/api/types/discoveryconfig"
+	discoveryConfigConvertv1 "github.com/gravitational/teleport/api/types/discoveryconfig/convert/v1"
+	"github.com/gravitational/teleport/lib/tfgen"
+	"github.com/gravitational/teleport/lib/tfgen/transform"
+	"github.com/gravitational/teleport/lib/utils"
+)
+
+// kindVersionObject is used for unmarshaling Teleport resources so we can branch on
+// their kinds and/or versions.
+type kindVersionObject struct {
+	Kind    string
+	Version string
+}
+
+// jsonConverter is a function that transforms JSON bytes into a Teleport
+// Terraform resource. The input is JSON because the script converts resource
+// representations (e.g., gogo-proto and RFD 153) into JSON before converting.
+type jsonConverter func(data []byte) (tfgen.Resource, error)
+
+// kubeConversionAttributes configures the way the converter transforms a tctl
+// resource into a Kubernetes resource.
+type kubeConversionAttributes struct {
+	// subKindToResourceKind is a map of sub_kind values that, if present on
+	// a tctl resource, determine the kind of a matching Kubernetes CRD.
+	subKindToResourceKind map[string]string
+	// apiVersion specifies the apiVersion value in a Kubernetes resource.
+	apiVersion string
+	// kind specifies the value of kind in a Kubernetes resource.
+	kind string
+	// ignoredSpecFields are fields in a tctl resource spec that the
+	// converter removes from the final Kubernetes resource.
+	ignoredSpecFields []string
+	// requiredVersion is an optional version to require tctl resources to
+	// have for conversion. We use this for CRDs that are pinned to a
+	// specific resource version.
+	requiredVersion string
+	// scopeNotInCRD indicates whether a top-level scope field is absent in
+	// the Kubernetes resource while present in the tctl equivalent.
+	scopeNotInCRD bool
+}
+
+// conversionRule is a configuration for how to transform a given kind of tctl
+// resource into a Terraform provider and Kubernetes operator resource.
+type conversionRule struct {
+	// toTerraformResource converts JSON bytes (returned by normalizing resource
+	// YAML) into a Teleport Terraform resource.
+	toTerraformResource jsonConverter
+	// kubernetes is a set of configuration options for converting a tctl
+	// resource into a Kubernetes resource.
+	kubernetes kubeConversionAttributes
+	// terraformResourceType is the type of the Terraform resource if it
+	// differs from the value of kind in the corresponding tctl resource.
+	terraformResourceType string
+	// generateOpts are applied when converting to HCL.
+	generateOpts []tfgen.GenerateOpt
+}
+
+// unsupportedResource is an error indicating that a tctl resource does not have
+// a corresponding resource for a particular infrastructure as code tool. Errors
+// for unsupported resources must use this type for consistency.
+type unsupportedResource struct {
+	kind    string // Resource kind, e.g., "role".
+	version string // Optional resource version for printing.
+	tool    string // Infrastructure as code tool. Used for error messages.
+}
+
+// Error prints the error message for unsupportedResource.
+func (r unsupportedResource) Error() string {
+	var verSuffix string
+	if r.version != "" {
+		verSuffix = " (" + r.version + ")"
+	}
+	return fmt.Sprintf(`%v does not support resource kind %v%v`, r.tool, r.kind, verSuffix)
+}
+
+// resourceConfig maps the kind values of resources supported by the Terraform
+// provider to functions for converting JSON to HCL, as well as to functions for
+// converting Teleport resource types to Kubernetes resources. There are three
+// patterns for applying the conversion:
+//  1. For legacy gogo-proto types, the YAML/JSON type directly maps to the
+//     Protobuf-generated type, which includes json struct tags, so we can
+//     unmarshal directly using utils.FastUnmarshal.
+//  2. For types based on non-gogo Protobuf messages, unmarshal using
+//     protojson.Unmarshal.
+//  3. For resources that include a header, call utils.FastUnmarshal into the
+//     internal representation of the type, then convert to a Protobuf-based type
+//     and wrap with a header.
+var resourceConfig = map[string]conversionRule{
+	"role": {
+		toTerraformResource: func(data []byte) (tfgen.Resource, error) {
+			var r types.RoleV6
+			if err := utils.FastUnmarshal(data, &r); err != nil {
+				return nil, trace.Errorf("invalid Teleport role: %w", err)
+			}
+			return &r, nil
+		},
+		kubernetes: kubeConversionAttributes{
+			apiVersion:      "resources.teleport.dev/v1",
+			kind:            "TeleportRoleV8",
+			requiredVersion: "v8",
+		},
+	},
+	"user": {
+		toTerraformResource: func(data []byte) (tfgen.Resource, error) {
+			var r types.UserV2
+			if err := utils.FastUnmarshal(data, &r); err != nil {
+				return nil, trace.Errorf("invalid user: %w", err)
+			}
+			return &r, nil
+		},
+		kubernetes: kubeConversionAttributes{
+			apiVersion:        "resources.teleport.dev/v2",
+			kind:              "TeleportUser",
+			ignoredSpecFields: []string{"local_auth", "expires", "created_by", "status"},
+		},
+	},
+	"trusted_cluster": {
+		toTerraformResource: func(data []byte) (tfgen.Resource, error) {
+			var r types.TrustedClusterV2
+			if err := utils.FastUnmarshal(data, &r); err != nil {
+				return nil, trace.Errorf("invalid trusted_cluster: %w", err)
+			}
+			return &r, nil
+		},
+		kubernetes: kubeConversionAttributes{
+			apiVersion:        "resources.teleport.dev/v1",
+			kind:              "TeleportTrustedClusterV2",
+			ignoredSpecFields: []string{"roles"},
+		},
+	},
+	"github": {
+		toTerraformResource: func(data []byte) (tfgen.Resource, error) {
+			var r types.GithubConnectorV3
+			if err := utils.FastUnmarshal(data, &r); err != nil {
+				return nil, trace.Errorf("invalid github connector: %w", err)
+			}
+			return &r, nil
+		},
+		kubernetes: kubeConversionAttributes{
+			apiVersion:        "resources.teleport.dev/v3",
+			kind:              "TeleportGithubConnector",
+			ignoredSpecFields: []string{"teams_to_logins"},
+		},
+		terraformResourceType: "teleport_github_connector",
+	},
+	"saml": {
+		toTerraformResource: func(data []byte) (tfgen.Resource, error) {
+			var r types.SAMLConnectorV2
+			if err := utils.FastUnmarshal(data, &r); err != nil {
+				return nil, trace.Errorf("invalid saml connector: %w", err)
+			}
+			return &r, nil
+		},
+		kubernetes: kubeConversionAttributes{
+			apiVersion: "resources.teleport.dev/v2",
+			kind:       "TeleportSAMLConnector",
+		},
+		terraformResourceType: "teleport_saml_connector",
+	},
+	"oidc": {
+		toTerraformResource: func(data []byte) (tfgen.Resource, error) {
+			var r types.OIDCConnectorV3
+			if err := utils.FastUnmarshal(data, &r); err != nil {
+				return nil, trace.Errorf("invalid oidc connector: %w", err)
+			}
+			return &r, nil
+		},
+		kubernetes: kubeConversionAttributes{
+			apiVersion: "resources.teleport.dev/v3",
+			kind:       "TeleportOIDCConnector",
+		},
+		terraformResourceType: "teleport_oidc_connector",
+	},
+	"token": {
+		toTerraformResource: func(data []byte) (tfgen.Resource, error) {
+			var r types.ProvisionTokenV2
+			if err := utils.FastUnmarshal(data, &r); err != nil {
+				return nil, trace.Errorf("invalid token: %w", err)
+			}
+			return &r, nil
+		},
+		kubernetes: kubeConversionAttributes{
+			apiVersion: "resources.teleport.dev/v2",
+			kind:       "TeleportProvisionToken",
+		},
+		terraformResourceType: "teleport_provision_token",
+	},
+	"lock": {
+		toTerraformResource: func(data []byte) (tfgen.Resource, error) {
+			var r types.LockV2
+			if err := utils.FastUnmarshal(data, &r); err != nil {
+				return nil, trace.Errorf("invalid lock: %w", err)
+			}
+			return &r, nil
+		},
+		kubernetes: kubeConversionAttributes{
+			apiVersion: "resources.teleport.dev/v1",
+			kind:       "TeleportLockV2",
+		},
+	},
+	"cluster_networking_config": {
+		toTerraformResource: func(data []byte) (tfgen.Resource, error) {
+			var r types.ClusterNetworkingConfigV2
+			if err := utils.FastUnmarshal(data, &r); err != nil {
+				return nil, trace.Errorf("invalid cluster_networking_config: %w", err)
+			}
+			return &r, nil
+		},
+	},
+	"cluster_auth_preference": {
+		toTerraformResource: func(data []byte) (tfgen.Resource, error) {
+			var r types.AuthPreferenceV2
+			if err := utils.FastUnmarshal(data, &r); err != nil {
+				return nil, trace.Errorf("invalid cluster_auth_preference: %w", err)
+			}
+			return &r, nil
+		},
+		terraformResourceType: "teleport_auth_preference",
+	},
+	"bot": {
+		toTerraformResource: func(data []byte) (tfgen.Resource, error) {
+			var r machineidv1.Bot
+			if err := (protojson.UnmarshalOptions{DiscardUnknown: true}).Unmarshal(data, &r); err != nil {
+				return nil, trace.Errorf("invalid bot: %w", err)
+			}
+			// tfgen.Generate silently drops the scope.
+			if r.Scope != "" {
+				return nil, trace.Errorf("converting tctl resources to HCL does not yet support scoped bot resources")
+			}
+
+			return &r, nil
+		},
+		kubernetes: kubeConversionAttributes{
+			apiVersion: "resources.teleport.dev/v1",
+			kind:       "TeleportBotV1",
+		},
+		generateOpts: []tfgen.GenerateOpt{tfgen.WithFieldTransform("spec.traits", transform.BotTraits)},
+	},
+	"autoupdate_config": {
+		toTerraformResource: func(data []byte) (tfgen.Resource, error) {
+			var r autoupdatev1pb.AutoUpdateConfig
+			if err := (protojson.UnmarshalOptions{DiscardUnknown: true}).Unmarshal(data, &r); err != nil {
+				return nil, trace.Errorf("invalid autoupdate_config: %w", err)
+			}
+			return &r, nil
+		},
+		kubernetes: kubeConversionAttributes{
+			apiVersion: "resources.teleport.dev/v1",
+			kind:       "TeleportAutoupdateConfigV1",
+		},
+	},
+	"autoupdate_version": {
+		toTerraformResource: func(data []byte) (tfgen.Resource, error) {
+			var r autoupdatev1pb.AutoUpdateVersion
+			if err := (protojson.UnmarshalOptions{DiscardUnknown: true}).Unmarshal(data, &r); err != nil {
+				return nil, trace.Errorf("invalid autoupdate_version: %w", err)
+			}
+			return &r, nil
+		},
+		kubernetes: kubeConversionAttributes{
+			apiVersion: "resources.teleport.dev/v1",
+			kind:       "TeleportAutoupdateVersionV1",
+		},
+	},
+	"health_check_config": {
+		toTerraformResource: func(data []byte) (tfgen.Resource, error) {
+			var r healthcheckconfigv1.HealthCheckConfig
+			if err := (protojson.UnmarshalOptions{DiscardUnknown: true}).Unmarshal(data, &r); err != nil {
+				return nil, trace.Errorf("invalid health_check_config: %w", err)
+			}
+			return &r, nil
+		},
+	},
+	"workload_identity": {
+		toTerraformResource: func(data []byte) (tfgen.Resource, error) {
+			var r workloadidentityv1.WorkloadIdentity
+			if err := (protojson.UnmarshalOptions{DiscardUnknown: true}).Unmarshal(data, &r); err != nil {
+				return nil, trace.Errorf("invalid workload_identity: %w", err)
+			}
+			// tfgen.Generate silently drops the scope.
+			if r.Scope != "" {
+				return nil, trace.Errorf("converting tctl resources to HCL does not yet support scoped workload_identity resources")
+			}
+
+			return &r, nil
+		},
+		kubernetes: kubeConversionAttributes{
+			apiVersion:    "resources.teleport.dev/v1",
+			kind:          "TeleportWorkloadIdentityV1",
+			scopeNotInCRD: true,
+		},
+	},
+	"app": {
+		toTerraformResource: func(data []byte) (tfgen.Resource, error) {
+			var r types.AppV3
+			if err := utils.FastUnmarshal(data, &r); err != nil {
+				return nil, trace.Errorf("invalid app: %w", err)
+			}
+			return &r, nil
+		},
+		kubernetes: kubeConversionAttributes{
+			apiVersion: "resources.teleport.dev/v1",
+			kind:       "TeleportAppV3",
+		},
+	},
+	"db": {
+		toTerraformResource: func(data []byte) (tfgen.Resource, error) {
+			var r types.DatabaseV3
+			if err := utils.FastUnmarshal(data, &r); err != nil {
+				return nil, trace.Errorf("invalid db: %w", err)
+			}
+			return &r, nil
+		},
+		kubernetes: kubeConversionAttributes{
+			apiVersion: "resources.teleport.dev/v1",
+			kind:       "TeleportDatabaseV3",
+		},
+		terraformResourceType: "teleport_database",
+	},
+	"kube_cluster": {
+		toTerraformResource: func(data []byte) (tfgen.Resource, error) {
+			var r types.KubernetesClusterV3
+			if err := utils.FastUnmarshal(data, &r); err != nil {
+				return nil, trace.Errorf("invalid kube_cluster: %w", err)
+			}
+			return &r, nil
+		},
+	},
+	"node": {
+		toTerraformResource: func(data []byte) (tfgen.Resource, error) {
+			var r types.ServerV2
+			if err := utils.FastUnmarshal(data, &r); err != nil {
+				return nil, trace.Errorf("invalid node: %w", err)
+			}
+			return &r, nil
+		},
+		kubernetes: kubeConversionAttributes{
+			apiVersion: "resources.teleport.dev/v1",
+			subKindToResourceKind: map[string]string{
+				"openssh":         "TeleportOpenSSHServerV2",
+				"openssh-ec2-ice": "TeleportOpenSSHEICEServerV2",
+			},
+			ignoredSpecFields: []string{"cmd_labels", "component_features"},
+		},
+		terraformResourceType: "teleport_server",
+	},
+	"saml_idp_service_provider": {
+		toTerraformResource: func(data []byte) (tfgen.Resource, error) {
+			var r types.SAMLIdPServiceProviderV1
+			if err := utils.FastUnmarshal(data, &r); err != nil {
+				return nil, trace.Errorf("invalid saml_idp_service_provider: %w", err)
+			}
+			return &r, nil
+		},
+		kubernetes: kubeConversionAttributes{
+			apiVersion: "resources.teleport.dev/v1",
+			kind:       "TeleportSAMLIdPServiceProviderV1",
+		},
+	},
+	"access_list": {
+		toTerraformResource: func(data []byte) (tfgen.Resource, error) {
+			var al accesslist.AccessList
+			if err := utils.FastUnmarshal(data, &al); err != nil {
+				return nil, trace.Errorf("invalid access_list: %w", err)
+			}
+			// tfgen.Generate silently drops the scope.
+			if al.Scope != "" {
+				return nil, trace.Errorf("converting tctl resources to HCL does not yet support scoped access_list resources")
+			}
+
+			return tfgen.WrapHeaderResource(convertv1.ToProto(&al)), nil
+		},
+		kubernetes: kubeConversionAttributes{
+			apiVersion:    "resources.teleport.dev/v1",
+			kind:          "TeleportAccessList",
+			scopeNotInCRD: true,
+		},
+	},
+	"access_list_member": {
+		toTerraformResource: func(data []byte) (tfgen.Resource, error) {
+			var m accesslist.AccessListMember
+			if err := utils.FastUnmarshal(data, &m); err != nil {
+				return nil, trace.Errorf("invalid access_list_member: %w", err)
+			}
+			// tfgen.Generate silently drops the scope.
+			if m.Scope != "" {
+				return nil, trace.Errorf("converting tctl resources to HCL does not yet support scoped workload_identity resources")
+			}
+
+			return tfgen.WrapHeaderResource(convertv1.ToMemberProto(&m)), nil
+		},
+	},
+	"access_monitoring_rule": {
+		toTerraformResource: func(data []byte) (tfgen.Resource, error) {
+			var r accessmonitoringrulesv1.AccessMonitoringRule
+			if err := (protojson.UnmarshalOptions{DiscardUnknown: true}).Unmarshal(data, &r); err != nil {
+				return nil, trace.Errorf("invalid access_monitoring_rule: %w", err)
+			}
+			return &r, nil
+		},
+		kubernetes: kubeConversionAttributes{
+			apiVersion: "resources.teleport.dev/v1",
+			kind:       "TeleportAccessMonitoringRuleV1",
+		},
+	},
+	"discovery_config": {
+		toTerraformResource: func(data []byte) (tfgen.Resource, error) {
+			var dc discoveryconfig.DiscoveryConfig
+			if err := utils.FastUnmarshal(data, &dc); err != nil {
+				return nil, trace.Errorf("invalid discovery_config: %w", err)
+			}
+			return tfgen.WrapHeaderResource(discoveryConfigConvertv1.ToProto(&dc)), nil
+		},
+	},
+	"integration": {
+		toTerraformResource: func(data []byte) (tfgen.Resource, error) {
+			var r types.IntegrationV1
+			if err := utils.FastUnmarshal(data, &r); err != nil {
+				return nil, trace.Errorf("invalid integration: %w", err)
+			}
+			return &r, nil
+		},
+	},
+	"okta_import_rule": {
+		toTerraformResource: func(data []byte) (tfgen.Resource, error) {
+			var r types.OktaImportRuleV1
+			if err := utils.FastUnmarshal(data, &r); err != nil {
+				return nil, trace.Errorf("invalid okta_import_rule: %w", err)
+			}
+			return &r, nil
+		},
+		kubernetes: kubeConversionAttributes{
+			apiVersion: "resources.teleport.dev/v1",
+			kind:       "TeleportOktaImportRule",
+		},
+	},
+	"device": {
+		toTerraformResource: func(data []byte) (tfgen.Resource, error) {
+			var r types.DeviceV1
+			if err := utils.FastUnmarshal(data, &r); err != nil {
+				return nil, trace.Errorf("invalid device: %w", err)
+			}
+			return &r, nil
+		},
+		terraformResourceType: "teleport_trusted_device",
+	},
+	"installer": {
+		toTerraformResource: func(data []byte) (tfgen.Resource, error) {
+			var r types.InstallerV1
+			if err := utils.FastUnmarshal(data, &r); err != nil {
+				return nil, trace.Errorf("invalid installer: %w", err)
+			}
+			return &r, nil
+		},
+	},
+	"session_recording_config": {
+		toTerraformResource: func(data []byte) (tfgen.Resource, error) {
+			var r types.SessionRecordingConfigV2
+			if err := utils.FastUnmarshal(data, &r); err != nil {
+				return nil, trace.Errorf("invalid session_recording_config: %w", err)
+			}
+			return &r, nil
+		},
+	},
+	"ui_config": {
+		toTerraformResource: func(data []byte) (tfgen.Resource, error) {
+			var r types.UIConfigV1
+			if err := utils.FastUnmarshal(data, &r); err != nil {
+				return nil, trace.Errorf("invalid ui_config: %w", err)
+			}
+			return &r, nil
+		},
+	},
+	"cluster_maintenance_config": {
+		toTerraformResource: func(data []byte) (tfgen.Resource, error) {
+			var r types.ClusterMaintenanceConfigV1
+			if err := utils.FastUnmarshal(data, &r); err != nil {
+				return nil, trace.Errorf("invalid cluster_maintenance_config: %w", err)
+			}
+			return &r, nil
+		},
+	},
+	"dynamic_windows_desktop": {
+		toTerraformResource: func(data []byte) (tfgen.Resource, error) {
+			var r types.DynamicWindowsDesktopV1
+			if err := utils.FastUnmarshal(data, &r); err != nil {
+				return nil, trace.Errorf("invalid dynamic_windows_desktop: %w", err)
+			}
+			return &r, nil
+		},
+	},
+	"static_host_user": {
+		toTerraformResource: func(data []byte) (tfgen.Resource, error) {
+			var r userprovisioningpb.StaticHostUser
+			if err := (protojson.UnmarshalOptions{DiscardUnknown: true}).Unmarshal(data, &r); err != nil {
+				return nil, trace.Errorf("invalid static_host_user: %w", err)
+			}
+			return &r, nil
+		},
+	},
+	"vnet_config": {
+		toTerraformResource: func(data []byte) (tfgen.Resource, error) {
+			var r vnet.VnetConfig
+			if err := (protojson.UnmarshalOptions{DiscardUnknown: true}).Unmarshal(data, &r); err != nil {
+				return nil, trace.Errorf("invalid vnet_config: %w", err)
+			}
+			return &r, nil
+		},
+	},
+	"app_auth_config": {
+		toTerraformResource: func(data []byte) (tfgen.Resource, error) {
+			var r appauthconfigv1.AppAuthConfig
+			if err := (protojson.UnmarshalOptions{DiscardUnknown: true}).Unmarshal(data, &r); err != nil {
+				return nil, trace.Errorf("invalid app_auth_config: %w", err)
+			}
+			return &r, nil
+		},
+	},
+	"db_object_import_rule": {
+		toTerraformResource: func(data []byte) (tfgen.Resource, error) {
+			var r dbobjectimportrulev1.DatabaseObjectImportRule
+			if err := (protojson.UnmarshalOptions{DiscardUnknown: true}).Unmarshal(data, &r); err != nil {
+				return nil, trace.Errorf("invalid db_object_import_rule: %w", err)
+			}
+			return &r, nil
+		},
+	},
+	"workload_cluster": {
+		toTerraformResource: func(data []byte) (tfgen.Resource, error) {
+			var r workloadcluster.WorkloadCluster
+			if err := (protojson.UnmarshalOptions{DiscardUnknown: true}).Unmarshal(data, &r); err != nil {
+				return nil, trace.Errorf("invalid workload_cluster: %w", err)
+			}
+			return &r, nil
+		},
+	},
+	"inference_model": {
+		toTerraformResource: func(data []byte) (tfgen.Resource, error) {
+			var r summarizerv1.InferenceModel
+			if err := (protojson.UnmarshalOptions{DiscardUnknown: true}).Unmarshal(data, &r); err != nil {
+				return nil, trace.Errorf("invalid inference_model: %w", err)
+			}
+			return &r, nil
+		},
+		kubernetes: kubeConversionAttributes{
+			apiVersion: "resources.teleport.dev/v1",
+			kind:       "TeleportInferenceModel",
+		},
+	},
+	"inference_secret": {
+		toTerraformResource: func(data []byte) (tfgen.Resource, error) {
+			var r summarizerv1.InferenceSecret
+			if err := (protojson.UnmarshalOptions{DiscardUnknown: true}).Unmarshal(data, &r); err != nil {
+				return nil, trace.Errorf("invalid inference_secret: %w", err)
+			}
+			return &r, nil
+		},
+		kubernetes: kubeConversionAttributes{
+			apiVersion: "resources.teleport.dev/v1",
+			kind:       "TeleportInferenceSecret",
+		},
+	},
+	"inference_policy": {
+		toTerraformResource: func(data []byte) (tfgen.Resource, error) {
+			var r summarizerv1.InferencePolicy
+			if err := (protojson.UnmarshalOptions{DiscardUnknown: true}).Unmarshal(data, &r); err != nil {
+				return nil, trace.Errorf("invalid inference_policy: %w", err)
+			}
+			return &r, nil
+		},
+		kubernetes: kubeConversionAttributes{
+			apiVersion: "resources.teleport.dev/v1",
+			kind:       "TeleportInferencePolicy",
+		},
+	},
+	"retrieval_model": {
+		toTerraformResource: func(data []byte) (tfgen.Resource, error) {
+			var r summarizerv1.RetrievalModel
+			if err := (protojson.UnmarshalOptions{DiscardUnknown: true}).Unmarshal(data, &r); err != nil {
+				return nil, trace.Errorf("invalid retrieval_model: %w", err)
+			}
+			return &r, nil
+		},
+		kubernetes: kubeConversionAttributes{
+			apiVersion: "resources.teleport.dev/v1",
+			kind:       "TeleportRetrievalModelV1",
+		},
+	},
+}
+
+// fieldPathsWithPrefix recursively traverses m and outputs a slice of field
+// paths separated by dots. All returned field paths begin with prefix.
+func fieldPathsWithPrefix(m map[string]any, prefix string) []string {
+	out := []string{}
+	for k, v := range m {
+		newPrefix := k
+		if prefix != "" {
+			newPrefix = prefix + "." + k
+		}
+		out = append(out, newPrefix)
+		if a, ok := v.(map[string]any); ok {
+			out = append(out, fieldPathsWithPrefix(a, newPrefix)...)
+		}
+	}
+	return out
+}
+
+// fieldPaths traverses m and outputs a slice of dot-separated field paths
+func fieldPaths(m map[string]any) []string {
+	return fieldPathsWithPrefix(m, "")
+}
+
+const hclComment = "#"
+
+// convertYAMLToHCL takes a single tctl resource YAML document, converts it to
+// an HCL resource configuration, writing out the resulting HCL object to w.
+func convertYAMLToHCL(w io.Writer, r io.Reader) error {
+	yamlBytes, err := io.ReadAll(r)
+	if err != nil {
+		return trace.Errorf("unable to read input YAML: %w", err)
+	}
+
+	jsonbytes, err := utils.ToJSON(yamlBytes)
+	if err != nil {
+		return trace.Errorf("unable to process input YAML as JSON (which we need to do to convert it to a Teleport resource type): %w", err)
+	}
+
+	var o kindVersionObject
+	if err = json.Unmarshal(jsonbytes, &o); err != nil {
+		return trace.Errorf("unable to detect a kind in the input resource: %w", err)
+	}
+
+	convert, ok := resourceConfig[o.Kind]
+	if !ok {
+		return unsupportedResource{
+			kind: o.Kind,
+			tool: "Terraform",
+		}
+	}
+
+	res, err := convert.toTerraformResource(jsonbytes)
+	if err != nil {
+		return err
+	}
+
+	var m map[string]any
+	if err = json.Unmarshal(jsonbytes, &m); err != nil {
+		return trace.Errorf("unable to read JSON from the input resource: %w", err)
+	}
+
+	var opts []tfgen.GenerateOpt
+	if convert.terraformResourceType != "" {
+		opts = append(opts, tfgen.WithResourceType(convert.terraformResourceType))
+	}
+
+	if convert.generateOpts != nil {
+		opts = append(opts, convert.generateOpts...)
+	}
+
+	// We need to preserve fields listed in the original resource that have
+	// zero values. tfgen.Generate omits zeroed values by default. The
+	// tfgen.GenerateOpt WithFieldComment is the only one that instructs the
+	// generator to preserve a zeroed field. We retrieve a slice of field
+	// paths by traversing all fields in the original JSON resource object.
+	// Then we pass each field path to a WithFieldComment option to preserve
+	// all fields from the original resource.
+	for _, p := range fieldPaths(m) {
+		opts = append(opts, tfgen.WithFieldComment(p, ""))
+	}
+
+	outbytes, err := tfgen.Generate(res, opts...)
+	if err != nil {
+		return trace.Errorf("unable to convert the provided YAML manifest into HCL: %w", err)
+	}
+
+	// At this point, fields in the output that we passed to
+	// WithFieldComment include an empty HCL comment marker.  Write out the
+	// result line by line, ignoring the empty comment markers.
+	scanner := bufio.NewScanner(strings.NewReader(string(outbytes)))
+	for scanner.Scan() {
+		if strings.TrimSpace(scanner.Text()) != hclComment {
+			w.Write(scanner.Bytes())
+			w.Write([]byte("\n"))
+		}
+	}
+
+	return nil
+}
+
+// sepPattern represents a YAML document separator. Used for splitting YAML
+// documents to convert individual resources.
+var sepPattern = regexp.MustCompile(`(?m)^---\s*$`)
+
+// convertAllYAMLToHCL takes one or more tctl resource YAML documents with
+// possible document separators in r, converts them to HCL resource
+// configurations in a single document, writing out the document to w.
+func convertAllYAMLToHCL(w io.Writer, r io.Reader) error {
+	var buf bytes.Buffer
+	if _, err := buf.ReadFrom(r); err != nil {
+		return trace.Errorf("could not read input document: %w", err)
+	}
+
+	docs := sepPattern.Split(buf.String(), -1)
+	for i, doc := range docs {
+		if doc == "" {
+			// Skip empty documents, e.g., because of leading separator
+			continue
+		}
+		if err := convertYAMLToHCL(w, strings.NewReader(doc)); err != nil {
+			return err
+		}
+
+		if i+1 == len(docs) {
+			break
+		}
+		if _, err := w.Write([]byte("\n")); err != nil {
+			return trace.Errorf("unable to write out a document separator: %w", err)
+		}
+	}
+
+	return nil
+}
+
+// convertAllYAMLToKubernetes takes one or more tctl resource YAML documents
+// with possible document separators in r, converts them to Kubernetes resource
+// manifests in a single document, writing out the document to w.
+func convertAllYAMLToKubernetes(w io.Writer, r io.Reader) error {
+	var buf bytes.Buffer
+	if _, err := buf.ReadFrom(r); err != nil {
+		return trace.Errorf("could not read input document: %w", err)
+	}
+
+	docs := sepPattern.Split(buf.String(), -1)
+	for i, doc := range docs {
+		if doc == "" {
+			// Skip empty documents, e.g., because of leading separator
+			continue
+		}
+		if err := convertYAMLToKubernetes(w, strings.NewReader(doc)); err != nil {
+			return err
+		}
+
+		if i+1 == len(docs) {
+			break
+		}
+		if _, err := w.Write([]byte("---\n")); err != nil {
+			return trace.Errorf("unable to write out a document separator: %w", err)
+		}
+	}
+
+	return nil
+}
+
+// convertYAMLToKubernetes takes a single tctl resource YAML document and
+// converts it to a Kubernetes manifest, writing out the resulting HCL to w.
+func convertYAMLToKubernetes(w io.Writer, r io.Reader) error {
+	yamlBytes, err := io.ReadAll(r)
+	if err != nil {
+		return trace.Errorf("unable to read input YAML: %w", err)
+	}
+
+	jsonbytes, err := utils.ToJSON(yamlBytes)
+	if err != nil {
+		return trace.Errorf("unable to process input YAML as JSON (which we need to do to convert it to a Teleport resource type): %w", err)
+	}
+
+	var original map[string]any
+	if err = json.Unmarshal(jsonbytes, &original); err != nil {
+		return trace.Errorf("unable to convert the input resource to a mapping: %w", err)
+	}
+
+	var o kindVersionObject
+	if err = yaml.Unmarshal(jsonbytes, &o); err != nil {
+		return trace.Errorf("unable to detect a kind in the input resource: %w", err)
+	}
+
+	convert, ok := resourceConfig[o.Kind]
+	if !ok || (convert.kubernetes.apiVersion == "" && convert.kubernetes.kind == "") {
+		return unsupportedResource{
+			kind: o.Kind,
+			tool: "Kubernetes",
+		}
+	}
+
+	// If there's a version requirement, reject the resource as unsupported.
+	if convert.kubernetes.requiredVersion != "" && o.Version != convert.kubernetes.requiredVersion {
+		return unsupportedResource{
+			kind:    o.Kind,
+			tool:    "Kubernetes",
+			version: o.Version,
+		}
+	}
+
+	if _, hasScope := original["scope"]; convert.kubernetes.scopeNotInCRD && hasScope {
+		return trace.Errorf("converting tctl resources to Kubernetes does not yet support scoped %v resources", o.Kind)
+	}
+
+	// Kubernetes resources have the same structure as tctl resources with a
+	// few exceptions. To convert a tctl resource to a Kubernetes resource,
+	// we add an apiVersion and kind suitable for Kubernetes, remove the
+	// version (which is encoded in the kind), and handle two edge cases:
+	//  - Some have a sub-kind that determines the CRD kind
+	//  - Some have fields that the Teleport Kubernetes operator ignores
+
+	original["kind"] = convert.kubernetes.kind
+	original["apiVersion"] = convert.kubernetes.apiVersion
+	delete(original, "version")
+
+	if convert.kubernetes.subKindToResourceKind != nil {
+		sk, ok := original["sub_kind"]
+		if !ok || sk == "" {
+			return trace.Errorf("resource %v needs a sub_kind", o.Kind)
+		}
+		skval, ok := convert.kubernetes.subKindToResourceKind[sk.(string)]
+		if !ok {
+			return trace.Errorf("unrecognized sub_kind in resource %v", o.Kind)
+		}
+		original["kind"] = skval
+	}
+	delete(original, "sub_kind")
+
+	if specmap, ok := original["spec"].(map[string]any); ok {
+		for _, f := range convert.kubernetes.ignoredSpecFields {
+			delete(specmap, f)
+		}
+	}
+
+	// Kubernetes resources move the metadata.description in the tctl
+	// resource to metadata.annotations.description
+	if meta, ok := original["metadata"].(map[string]any); ok {
+		if desc, ok := meta["description"]; ok {
+			annotations, _ := meta["annotations"].(map[string]any)
+			if annotations == nil {
+				annotations = make(map[string]any)
+			}
+			annotations["description"] = desc
+			meta["annotations"] = annotations
+			delete(meta, "description")
+		}
+	}
+
+	enc := yaml.NewEncoder(w)
+	enc.SetIndent(2)
+	if err := enc.Encode(&original); err != nil {
+		return trace.Errorf("unable to convert %v to Kubernetes YAML: %w", o.Kind, err)
+	}
+
+	return nil
+}
+
+func main() {
+	format := flag.String("format", "", "hcl or kube")
+	flag.Parse()
+
+	var err error
+	switch *format {
+	case "kube":
+		err = convertAllYAMLToKubernetes(os.Stdout, os.Stdin)
+
+	case "hcl":
+		err = convertAllYAMLToHCL(os.Stdout, os.Stdin)
+	default:
+		fmt.Fprintf(os.Stderr, `The format flag must be hcl or kube. Got: %v`, *format)
+		os.Exit(1)
+	}
+
+	if err == nil {
+		os.Exit(0)
+	}
+
+	fmt.Fprintf(os.Stderr, "Cannot convert resource(s): %v", err)
+	if errors.As(err, &unsupportedResource{}) {
+		// We reserve 2 for unsupported resources so the invoking shell
+		// knows that execution otherwise took place as expected.
+		os.Exit(2)
+	}
+
+	os.Exit(1)
+}

--- a/build.assets/tooling/cmd/convert-resource/main_test.go
+++ b/build.assets/tooling/cmd/convert-resource/main_test.go
@@ -1,0 +1,474 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package main
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_fieldPaths(t *testing.T) {
+	type testCase struct {
+		description string
+		input       map[string]any
+		expected    []string
+	}
+
+	cases := []testCase{
+		{
+			description: "two levels of scalars",
+			input: map[string]any{
+				"number":  0,
+				"boolean": false,
+				"string":  "",
+				"object": map[string]any{
+					"number":  0,
+					"boolean": false,
+					"string":  "",
+				},
+			},
+			expected: []string{
+				"number",
+				"boolean",
+				"string",
+				"object",
+				"object.number",
+				"object.boolean",
+				"object.string",
+			},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.description, func(t *testing.T) {
+			actual := fieldPaths(c.input)
+			assert.ElementsMatch(t, c.expected, actual)
+		})
+	}
+}
+
+func Test_convertYAMLToHCL(t *testing.T) {
+	type testCase struct {
+		description string
+		input       string
+		expected    string
+	}
+
+	cases := []testCase{
+		{
+			description: "simple role",
+			input: `kind: role
+version: v8
+metadata:
+  name: manager
+spec:
+  allow:
+    rules:
+      - resources: ['user', 'role']
+        verbs: ['list','read']
+`,
+			expected: `resource "teleport_role" "manager" {
+  version = "v8"
+
+  metadata = {
+    name = "manager"
+  }
+
+  spec = {
+    allow = {
+      rules = [{
+        resources = ["user", "role"]
+        verbs     = ["list", "read"]
+      }]
+    }
+  }
+}
+`,
+		},
+		{
+			description: "access list",
+			input: `version: v1
+kind: access_list
+metadata:
+  name: support-engineers
+spec:
+  title: "Production access for support engineers"
+  owners:
+    - name: alice
+  grants:
+    roles:
+      - support-engineer
+`,
+			expected: `resource "teleport_access_list" "support-engineers" {
+  header = {
+    kind    = "access_list"
+    version = "v1"
+    metadata = {
+      name = "support-engineers"
+    }
+  }
+
+  spec = {
+    owners = [{
+      ineligible_status = "0"
+      membership_kind   = "0"
+      name              = "alice"
+    }]
+    audit = {
+      recurrence = {
+        frequency    = "0"
+        day_of_month = "0"
+      }
+    }
+    grants = {
+      roles = ["support-engineer"]
+    }
+    title = "Production access for support engineers"
+  }
+}
+`,
+		},
+		{
+			description: "rfd 153 resource",
+			input: `kind: bot
+version: v1
+metadata:
+  name: example
+spec:
+  traits:
+  - name: logins
+    values:
+    - root
+`,
+			expected: `resource "teleport_bot" "example" {
+  version = "v1"
+
+  metadata = {
+    name = "example"
+  }
+
+  spec = {
+    traits = {
+      logins = ["root"]
+    }
+  }
+}
+`,
+		},
+		{
+			description: "false boolean",
+			input: `kind: role
+version: v8
+metadata:
+  name: myrole
+spec:
+  options:
+    forward_agent: false`,
+			expected: `resource "teleport_role" "myrole" {
+  version = "v8"
+
+  metadata = {
+    name = "myrole"
+  }
+
+  spec = {
+    options = {
+      forward_agent = false
+    }
+  }
+}
+`,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.description, func(t *testing.T) {
+			var buf bytes.Buffer
+			err := convertYAMLToHCL(&buf, strings.NewReader(c.input))
+			assert.NoError(t, err)
+			assert.Equal(t, c.expected, buf.String())
+		})
+	}
+}
+func Test_convertAllYAMLToHCL(t *testing.T) {
+	type testCase struct {
+		description string
+		input       string
+		expected    string
+	}
+
+	cases := []testCase{
+		{
+			description: "two roles",
+			input: `---
+kind: role
+version: v8
+metadata:
+  name: manager1
+---
+kind: role
+version: v8
+metadata:
+  name: manager2
+`,
+			expected: `resource "teleport_role" "manager1" {
+  version = "v8"
+
+  metadata = {
+    name = "manager1"
+  }
+
+}
+
+resource "teleport_role" "manager2" {
+  version = "v8"
+
+  metadata = {
+    name = "manager2"
+  }
+
+}
+`,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.description, func(t *testing.T) {
+			var buf bytes.Buffer
+			err := convertAllYAMLToHCL(&buf, strings.NewReader(c.input))
+			assert.NoError(t, err)
+			assert.Equal(t, c.expected, buf.String())
+		})
+	}
+}
+
+func Test_convertYAMLToKubernetes(t *testing.T) {
+	type testCase struct {
+		description string
+		input       string
+		expected    string
+	}
+
+	cases := []testCase{
+		{
+			description: "simple role",
+			input: `kind: role
+version: v8
+metadata:
+  name: manager
+spec:
+  allow:
+    rules:
+      - resources: ['user', 'role']
+        verbs: ['list','read']
+      - resources: ['session', 'event']
+        verbs: ['list', 'read']
+`,
+			expected: `apiVersion: resources.teleport.dev/v1
+kind: TeleportRoleV8
+metadata:
+  name: manager
+spec:
+  allow:
+    rules:
+      - resources:
+          - user
+          - role
+        verbs:
+          - list
+          - read
+      - resources:
+          - session
+          - event
+        verbs:
+          - list
+          - read
+`,
+		},
+		{
+			description: "openssh server",
+			input: `kind: node
+version: v2
+sub_kind: openssh
+metadata:
+  name: a100fdd0-52db-4eca-a7ab-c3afa7a1564a
+  labels:
+    env: test
+    team: engineering
+spec:
+  addr: <Var name="198.51.100.1:22" />
+  hostname: <Var name="ssh-server-hostname" />
+`,
+			expected: `apiVersion: resources.teleport.dev/v1
+kind: TeleportOpenSSHServerV2
+metadata:
+  labels:
+    env: test
+    team: engineering
+  name: a100fdd0-52db-4eca-a7ab-c3afa7a1564a
+spec:
+  addr: <Var name="198.51.100.1:22" />
+  hostname: <Var name="ssh-server-hostname" />
+`,
+		},
+		{
+			description: "github",
+			input: `kind: github
+metadata:
+  name: github
+spec:
+  client_id: <client-id>
+  client_secret: <client-secret>
+  display: GitHub
+  endpoint_url: ""
+  redirect_url: https://<proxy-address>/v1/webapi/github/callback
+  teams_to_logins: null
+  teams_to_roles:
+    - organization: ORG-NAME
+      roles:
+        - access
+        - editor
+      team: github-team
+version: v3
+`,
+			expected: `apiVersion: resources.teleport.dev/v3
+kind: TeleportGithubConnector
+metadata:
+  name: github
+spec:
+  client_id: <client-id>
+  client_secret: <client-secret>
+  display: GitHub
+  endpoint_url: ""
+  redirect_url: https://<proxy-address>/v1/webapi/github/callback
+  teams_to_roles:
+    - organization: ORG-NAME
+      roles:
+        - access
+        - editor
+      team: github-team
+`,
+		},
+		{
+			description: "description field",
+			input: `kind: db
+version: v3
+metadata:
+  name: example
+  description: "Example database"
+  labels:
+    env: prod
+    engine: postgres
+spec:
+  protocol: "postgres"
+  uri: "localhost:5432"
+`,
+			expected: `apiVersion: resources.teleport.dev/v1
+kind: TeleportDatabaseV3
+metadata:
+  annotations:
+    description: Example database
+  labels:
+    engine: postgres
+    env: prod
+  name: example
+spec:
+  protocol: postgres
+  uri: localhost:5432
+`,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.description, func(t *testing.T) {
+			var buf bytes.Buffer
+			err := convertYAMLToKubernetes(&buf, strings.NewReader(c.input))
+			assert.NoError(t, err)
+			assert.Equal(t, c.expected, buf.String())
+		})
+	}
+}
+
+func Test_convertYAMLToKubernetes_errors(t *testing.T) {
+	type testCase struct {
+		description       string
+		input             string
+		expectedErrString string
+	}
+
+	cases := []testCase{
+		{
+			description: "outdated role version",
+			input: `kind: role
+version: v7
+metadata:
+  name: manager
+`,
+			expectedErrString: `Kubernetes does not support resource kind role (v7)`,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.description, func(t *testing.T) {
+			var buf bytes.Buffer
+			err := convertYAMLToKubernetes(&buf, strings.NewReader(c.input))
+			assert.ErrorContains(t, err, c.expectedErrString)
+		})
+	}
+}
+func Test_convertAllYAMLToKubernetes(t *testing.T) {
+	type testCase struct {
+		description string
+		input       string
+		expected    string
+	}
+
+	cases := []testCase{
+		{
+			description: "two roles",
+			input: `---
+kind: role
+version: v8
+metadata:
+  name: manager1
+---
+kind: role
+version: v8
+metadata:
+  name: manager2
+`,
+			expected: `apiVersion: resources.teleport.dev/v1
+kind: TeleportRoleV8
+metadata:
+  name: manager1
+---
+apiVersion: resources.teleport.dev/v1
+kind: TeleportRoleV8
+metadata:
+  name: manager2
+`,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.description, func(t *testing.T) {
+			var buf bytes.Buffer
+			err := convertAllYAMLToKubernetes(&buf, strings.NewReader(c.input))
+			assert.NoError(t, err)
+			assert.Equal(t, c.expected, buf.String())
+		})
+	}
+}

--- a/build.assets/tooling/go.mod
+++ b/build.assets/tooling/go.mod
@@ -31,7 +31,10 @@ require (
 	k8s.io/apiextensions-apiserver v0.36.2
 )
 
-require github.com/google/go-cmp v0.7.0
+require (
+	github.com/google/go-cmp v0.7.0
+	github.com/gravitational/teleport/api v0.0.0-00010101000000-000000000000
+)
 
 require (
 	buf.build/gen/go/bufbuild/bufplugin/protocolbuffers/go v1.36.11-20250718181942-e35f9b667443.1 // indirect
@@ -54,8 +57,10 @@ require (
 	github.com/BurntSushi/toml v1.6.0 // indirect
 	github.com/Masterminds/goutils v1.1.1 // indirect
 	github.com/Masterminds/semver/v3 v3.5.0 // indirect
+	github.com/agext/levenshtein v1.2.1 // indirect
 	github.com/alecthomas/units v0.0.0-20240927000941-0f3dac36c52b // indirect
 	github.com/antlr4-go/antlr/v4 v4.13.1 // indirect
+	github.com/apparentlymart/go-textseg/v15 v15.0.0 // indirect
 	github.com/armon/go-radix v1.0.0 // indirect
 	github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2 // indirect
 	github.com/aws/aws-sdk-go-v2 v1.42.0 // indirect
@@ -168,12 +173,12 @@ require (
 	github.com/gorilla/securecookie v1.1.2 // indirect
 	github.com/gravitational/license v0.0.0-20250329001817-070456fa8ec1 // indirect
 	github.com/gravitational/roundtrip v1.0.3 // indirect
-	github.com/gravitational/teleport/api v0.0.0-00010101000000-000000000000 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
 	github.com/hashicorp/go-retryablehttp v0.7.8 // indirect
 	github.com/hashicorp/go-uuid v1.0.3 // indirect
 	github.com/hashicorp/golang-lru/v2 v2.0.7 // indirect
+	github.com/hashicorp/hcl/v2 v2.24.0 // indirect
 	github.com/hinshun/vt10x v0.0.0-20220301184237-5011da428d02 // indirect
 	github.com/huandu/xstrings v1.5.0 // indirect
 	github.com/in-toto/attestation v1.2.0 // indirect
@@ -199,6 +204,7 @@ require (
 	github.com/mattermost/xml-roundtrip-validator v0.1.0 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/mitchellh/copystructure v1.2.0 // indirect
+	github.com/mitchellh/go-wordwrap v1.0.1 // indirect
 	github.com/mitchellh/mapstructure v1.5.1-0.20231216201459-8508981c8b6c // indirect
 	github.com/mitchellh/reflectwalk v1.0.2 // indirect
 	github.com/moby/term v0.5.2 // indirect
@@ -257,6 +263,7 @@ require (
 	github.com/xdg-go/stringprep v1.0.4 // indirect
 	github.com/xhit/go-str2duration/v2 v2.1.0 // indirect
 	github.com/youmark/pkcs8 v0.0.0-20240726163527-a2c0da244d78 // indirect
+	github.com/zclconf/go-cty v1.16.3 // indirect
 	github.com/zitadel/logging v0.6.2 // indirect
 	github.com/zitadel/oidc/v3 v3.45.0 // indirect
 	github.com/zitadel/schema v1.3.1 // indirect

--- a/build.assets/tooling/go.sum
+++ b/build.assets/tooling/go.sum
@@ -116,10 +116,14 @@ github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERo
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
 github.com/ThalesIgnite/crypto11 v1.2.5 h1:1IiIIEqYmBvUYFeMnHqRft4bwf/O36jryEUpY+9ef8E=
 github.com/ThalesIgnite/crypto11 v1.2.5/go.mod h1:ILDKtnCKiQ7zRoNxcp36Y1ZR8LBPmR2E23+wTQe/MlE=
+github.com/agext/levenshtein v1.2.1 h1:QmvMAjj2aEICytGiWzmxoE0x2KZvE0fvmqMOfy2tjT8=
+github.com/agext/levenshtein v1.2.1/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
 github.com/alecthomas/units v0.0.0-20240927000941-0f3dac36c52b h1:mimo19zliBX/vSQ6PWWSL9lK8qwHozUj03+zLoEB8O0=
 github.com/alecthomas/units v0.0.0-20240927000941-0f3dac36c52b/go.mod h1:fvzegU4vN3H1qMT+8wDmzjAcDONcgo2/SZ/TyfdUOFs=
 github.com/antlr4-go/antlr/v4 v4.13.1 h1:SqQKkuVZ+zWkMMNkjy5FZe5mr5WURWnlpmOuzYWrPrQ=
 github.com/antlr4-go/antlr/v4 v4.13.1/go.mod h1:GKmUxMtwp6ZgGwZSva4eWPC5mS6vUAmOABFgjdkM7Nw=
+github.com/apparentlymart/go-textseg/v15 v15.0.0 h1:uYvfpb3DyLSCGWnctWKGj857c6ew1u1fNQOlOtuGxQY=
+github.com/apparentlymart/go-textseg/v15 v15.0.0/go.mod h1:K8XmNZdhEBkdlyDdvbmmsvpAG721bKi0joRfFdHIWJ4=
 github.com/armon/go-radix v1.0.0 h1:F4z6KzEeeQIMeLFa97iZU6vupzoecKdU5TX24SNppXI=
 github.com/armon/go-radix v1.0.0/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
 github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2 h1:DklsrG3dyBCFEj5IhUbnKptjxatkF07cF2ak3yi77so=
@@ -531,6 +535,8 @@ github.com/hashicorp/golang-lru/v2 v2.0.7 h1:a+bsQ5rvGLjzHuww6tVxozPZFVghXaHOwFs
 github.com/hashicorp/golang-lru/v2 v2.0.7/go.mod h1:QeFd9opnmA6QUJc5vARoKUSoFhyfM2/ZepoAG6RGpeM=
 github.com/hashicorp/hcl v1.0.1-vault-7 h1:ag5OxFVy3QYTFTJODRzTKVZ6xvdfLLCA1cy/Y6xGI0I=
 github.com/hashicorp/hcl v1.0.1-vault-7/go.mod h1:XYhtn6ijBSAj6n4YqAaf7RBPS4I06AItNorpy+MoQNM=
+github.com/hashicorp/hcl/v2 v2.24.0 h1:2QJdZ454DSsYGoaE6QheQZjtKZSUs9Nh2izTWiwQxvE=
+github.com/hashicorp/hcl/v2 v2.24.0/go.mod h1:oGoO1FIQYfn/AgyOhlg9qLC6/nOJPX3qGbkZpYAcqfM=
 github.com/hashicorp/vault/api v1.22.0 h1:+HYFquE35/B74fHoIeXlZIP2YADVboaPjaSicHEZiH0=
 github.com/hashicorp/vault/api v1.22.0/go.mod h1:IUZA2cDvr4Ok3+NtK2Oq/r+lJeXkeCrHRmqdyWfpmGM=
 github.com/howeyc/gopass v0.0.0-20210920133722-c8aef6fb66ef h1:A9HsByNhogrvm9cWb28sjiS3i7tcKCkflWFEkHfuAgM=
@@ -826,6 +832,10 @@ github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9dec
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
 github.com/zalando/go-keyring v0.2.6 h1:r7Yc3+H+Ux0+M72zacZoItR3UDxeWfKTcabvkI8ua9s=
 github.com/zalando/go-keyring v0.2.6/go.mod h1:2TCrxYrbUNYfNS/Kgy/LSrkSQzZ5UPVH85RwfczwvcI=
+github.com/zclconf/go-cty v1.16.3 h1:osr++gw2T61A8KVYHoQiFbFd1Lh3JOCXc/jFLJXKTxk=
+github.com/zclconf/go-cty v1.16.3/go.mod h1:VvMs5i0vgZdhYawQNq5kePSpLAoz8u1xvZgrPIxfnZE=
+github.com/zclconf/go-cty-debug v0.0.0-20240509010212-0d6042c53940 h1:4r45xpDWB6ZMSMNJFMOjqrGHynW3DIBuR2H9j0ug+Mo=
+github.com/zclconf/go-cty-debug v0.0.0-20240509010212-0d6042c53940/go.mod h1:CmBdvvj3nqzfzJ6nTCIwDTPZ56aVGvDrmztiO5g3qrM=
 github.com/zitadel/logging v0.6.2 h1:MW2kDDR0ieQynPZ0KIZPrh9ote2WkxfBif5QoARDQcU=
 github.com/zitadel/logging v0.6.2/go.mod h1:z6VWLWUkJpnNVDSLzrPSQSQyttysKZ6bCRongw0ROK4=
 github.com/zitadel/oidc/v3 v3.45.0 h1:SaVJ2kdcJi/zdEWWlAns+81VxmfdYX4E+2mWFVIH7Ec=

--- a/docs/pages/zero-trust-access/rbac-get-started/role-demo.mdx
+++ b/docs/pages/zero-trust-access/rbac-get-started/role-demo.mdx
@@ -210,7 +210,7 @@ Create a role that can access servers with the `env:local-dev` label but not the
 
 1. Create a file called `role.yaml` with the following content:
 
-   ```yaml
+   ```teleport-resource
    kind: role
    version: v7
    metadata:


### PR DESCRIPTION
Add a Go script to `build.assets/tooling/cmd` that transforms a Teleport `tctl` resource document into either a Terraform HCL config or a Kubernetes manifest.

The script is intended for manually composed examples in the docs, rather than resources pulled from the Auth Service API, and retains all (and only) the fields that are in the original resource when performing the conversion.

The plan is for a `remark` plugin on the docs engine to shell out to this script and transform any code fence with the `teleport-resource` label into a `Tabs` component with separate tabs for `tctl` the Teleport operator, and Teleport Terraform provider. So the plugin can distinguish between a conversion failure due to an unsupported resource and any other kind of failure, the script returns `2` if there is no resource to convert to.

The script requires slightly different conversion logic for each kind of resource, and uses inversion of control for Terraform and, since Kubernetes CRD conversion is more consistent across resources, a set of configuration options.