### PR TITLE
docs: Helm fixes

### DIFF
--- a/docs/pages/includes/kubernetes-access/helm/kubernetes-externaladdress.mdx
+++ b/docs/pages/includes/kubernetes-access/helm/kubernetes-externaladdress.mdx
@@ -4,14 +4,14 @@ Whether an IP or hostname is provided as an external address for the load balanc
     <TabItem label="EKS (hostname)">
       EKS uses a hostname:
       ```code
-      $ kubectl --namespace teleport-cluster get service/teleport -o jsonpath='{.status.loadBalancer.ingress[*].hostname}'
+      $ kubectl --namespace teleport get service/teleport -o jsonpath='{.status.loadBalancer.ingress[*].hostname}'
       # a5f22a02798f541e58c6641c1b158ea3-1989279894.us-east-1.elb.amazonaws.com
       ```
     </TabItem>
     <TabItem label="GKE (IP address)">
       GKE uses an IP address:
       ```code
-      $ kubectl --namespace teleport-cluster get service/teleport -o jsonpath='{.status.loadBalancer.ingress[*].ip}'
+      $ kubectl --namespace teleport get service/teleport -o jsonpath='{.status.loadBalancer.ingress[*].ip}'
       # 35.203.56.38
       ```
     </TabItem>

--- a/docs/pages/installation/self-hosted/helm-deployments/disaster-recovery.mdx
+++ b/docs/pages/installation/self-hosted/helm-deployments/disaster-recovery.mdx
@@ -85,7 +85,7 @@ to plan your backup procedure.
 If the Teleport Auth Service in your cluster uses AWS Key Management Service for
 certificate authority private keys, you must replicate your keys to the new AWS
 region before reinstalling the `teleport-cluster` Helm chart. See the [AWS
-documentation](https://docs.aws.amazon.com/kms/latest/developerguide/multi-region-keys-overview.html")
+documentation](https://docs.aws.amazon.com/kms/latest/developerguide/multi-region-keys-overview.html)
 for information about using KMS keys in multiple regions. 
 
 Note that KMS support is only possible in the `teleport-cluster` Helm chart
@@ -196,6 +196,7 @@ Teleport](./aws.mdx#step-47-configure-tls-certificates-for-teleport).
 
    ```code
    $ helm install teleport-cluster teleport/teleport-cluster \
+     --namespace teleport \
      --version (=teleport.version=) \
      --values teleport-cluster-values.yaml
    ```
@@ -319,7 +320,7 @@ group-access
 
 Teleport grants access to certificate authority rotations using the
 `spec.allow.rules` field - on the `cert_authority` resource - so using role
-locking to impose a change freeze will also unintended certificate authority
+locking to impose a change freeze will also prevent unintended certificate authority
 rotations during the disaster recovery procedure.
 
 Create a lock using a `tctl lock` command. The following example locks the


### PR DESCRIPTION
docs/pages/includes/kubernetes-access/helm/kubernetes-externaladdress.mdx:
- namespace this was included from uses `teleport`, not `teleport-cluster`

docs/pages/installation/self-hosted/helm-deployments/disaster-recovery.mdx:
- fix bad link
- include namespace in helm install
- grammar fix
