### PR TITLE
[v18] Compute componentfeatures for agentless resources

### DIFF
--- a/lib/componentfeatures/utils.go
+++ b/lib/componentfeatures/utils.go
@@ -209,13 +209,23 @@ type versionedComponent interface {
 }
 
 // GetEffectiveServerFeatures computes a server's effective feature support.
-// Servers between v18.6.4 and v18.7.5 advertise FeatureResourceConstraintsV1
-// but predate the constraint parsing implementation; for those versions, the
-// advertisement should be stripped prior to intersection so clients don't show
-// constraints UI flows.
 //
-// TODO(kiosion): DELETE in 20.0.0
+// "Agentless" resources with no backing agent process to heartbeat
+// ComponentFeatures to presence have features computed from their type
+// instead of read from their spec field:
+//   - AppServer with integration set (served directly by Proxy, not an
+//     app agent; see lib/web/app/transport.go).
+//
+// Agent-backed resources use the field from spec set by presence heartbeat,
+// with version-gating applied to strip premature advertisements from servers <18.7.6.
+//
+// TODO(kiosion): DELETE version-gating logic in 20.0.0
 func GetEffectiveServerFeatures(component versionedComponent) *componentfeaturesv1.ComponentFeatures {
+	// Agentless app servers: no heartbeat, compute from app type.
+	if appServer, ok := component.(types.AppServer); ok && appServer.GetApp().GetIntegration() != "" {
+		return ForAppServer(appServer)
+	}
+	// Agent-backed: read stored field with version-gating.
 	f := component.GetComponentFeatures()
 	if f == nil {
 		return f

--- a/lib/componentfeatures/utils_test.go
+++ b/lib/componentfeatures/utils_test.go
@@ -339,7 +339,9 @@ func TestGetEffectiveServerFeatures(t *testing.T) {
 	t.Parallel()
 	rcv1 := FeatureResourceConstraintsV1
 	otherFeature := FeatureID(9999)
-	makeAppServer := func(t *testing.T, version string, features *componentfeaturesv1.ComponentFeatures) types.AppServer {
+
+	makeVersionedAppServer := func(t *testing.T, version string, features *componentfeaturesv1.ComponentFeatures) types.AppServer {
+		t.Helper()
 		app, err := types.NewAppV3(types.Metadata{Name: "aws-app"}, types.AppSpecV3{URI: "https://console.aws.amazon.com", Cloud: "AWS"})
 		require.NoError(t, err)
 		srv, err := types.NewAppServerV3FromApp(app, "localhost", "host-1")
@@ -350,19 +352,60 @@ func TestGetEffectiveServerFeatures(t *testing.T) {
 	}
 
 	t.Run("old app server has ResourceConstraintsV1 stripped", func(t *testing.T) {
-		srv := makeAppServer(t, "18.7.5", New(rcv1, otherFeature))
+		srv := makeVersionedAppServer(t, "18.7.5", New(rcv1, otherFeature))
 		result := GetEffectiveServerFeatures(srv)
 		require.ElementsMatch(t, New(otherFeature).GetFeatures(), result.GetFeatures())
 	})
 	t.Run("new app server keeps ResourceConstraintsV1", func(t *testing.T) {
-		srv := makeAppServer(t, "18.7.6", New(rcv1, otherFeature))
+		srv := makeVersionedAppServer(t, "18.7.6", New(rcv1, otherFeature))
 		result := GetEffectiveServerFeatures(srv)
 		require.ElementsMatch(t, New(rcv1, otherFeature).GetFeatures(), result.GetFeatures())
 	})
 	t.Run("nil features on old app server returns empty", func(t *testing.T) {
-		srv := makeAppServer(t, "18.6.4", nil)
+		srv := makeVersionedAppServer(t, "18.6.4", nil)
 		result := GetEffectiveServerFeatures(srv)
 		require.Empty(t, result.GetFeatures())
+	})
+
+	makeAppServer := func(t *testing.T, uri, integration string, features *componentfeaturesv1.ComponentFeatures) types.AppServer {
+		t.Helper()
+		app, err := types.NewAppV3(types.Metadata{Name: "test-app"}, types.AppSpecV3{
+			URI:         uri,
+			Cloud:       "AWS",
+			Integration: integration,
+		})
+		require.NoError(t, err)
+		srv, err := types.NewAppServerV3FromApp(app, "localhost", "host-1")
+		require.NoError(t, err)
+		srv.SetComponentFeatures(features)
+		return srv
+	}
+
+	t.Run("agentless AWS Console app computes features from type", func(t *testing.T) {
+		srv := makeAppServer(t, "https://console.aws.amazon.com", "some-integration", nil)
+		result := GetEffectiveServerFeatures(srv)
+		require.ElementsMatch(t, New(rcv1).GetFeatures(), result.GetFeatures())
+	})
+	t.Run("agentless non-AWS app gets no Resource Constraints feature", func(t *testing.T) {
+		app, err := types.NewAppV3(types.Metadata{Name: "non-aws-app"}, types.AppSpecV3{
+			URI:         "https://example.com",
+			Integration: "some-integration",
+		})
+		require.NoError(t, err)
+		srv, err := types.NewAppServerV3FromApp(app, "localhost", "host-1")
+		require.NoError(t, err)
+		result := GetEffectiveServerFeatures(srv)
+		require.Empty(t, result.GetFeatures())
+	})
+	t.Run("agent-backed app uses features from presence heartbeat", func(t *testing.T) {
+		srv := makeAppServer(t, "https://console.aws.amazon.com", "", New(rcv1))
+		result := GetEffectiveServerFeatures(srv)
+		require.ElementsMatch(t, New(rcv1).GetFeatures(), result.GetFeatures())
+	})
+	t.Run("agent-backed app with nil features returns nil", func(t *testing.T) {
+		srv := makeAppServer(t, "https://console.aws.amazon.com", "", nil)
+		result := GetEffectiveServerFeatures(srv)
+		require.Nil(t, result)
 	})
 }
 

--- a/lib/services/unified_resource.go
+++ b/lib/services/unified_resource.go
@@ -1084,7 +1084,7 @@ func (a *aggregatedAppServer) GetComponentFeatures() *componentfeaturesv1.Compon
 func intersectComponentFeaturesForAppServers(servers map[string]types.AppServer) *componentfeaturesv1.ComponentFeatures {
 	allFeatures := make([]*componentfeaturesv1.ComponentFeatures, 0, len(servers))
 	for _, s := range servers {
-		allFeatures = append(allFeatures, s.GetComponentFeatures())
+		allFeatures = append(allFeatures, componentfeatures.GetEffectiveServerFeatures(s))
 	}
 	return componentfeatures.Intersect(allFeatures...)
 }


### PR DESCRIPTION
## Context
Backport #67489 to branch/v18

changelog: Fixed Resource Constraints UI visibility for AWS Console app resources created via integrations or tctl.

## Manual Test Plan
### Test Environment
- Cloud staging tenant with either its Auth or Proxy servers patched with these changes
- AWS OIDC integration configured with IAM roles
- Teleport role with aws_role_arns, requestable via search_as_roles

### Test Cases
- [x] Create an agentless AWS Console app server (via integration flow or tctl) with integration set and component_features omitted. Verify that:
  - [x] `component_features` is not stored on the resource
  - [x] The unified resources API response includes `supportedFeatureIds: [1]` for the app
  - [x] The Resource Constraints per-ARN scoping is visible in the web UI request flow
- [x] Verify that an agent-backed AWS Console app server continues to work as before