### PR TITLE
[v18] Re-add /tokens/register HTTP route with an explicit "too old" error

### DIFF
--- a/lib/auth/apiserver.go
+++ b/lib/auth/apiserver.go
@@ -30,6 +30,7 @@ import (
 	"github.com/jonboulle/clockwork"
 	"github.com/julienschmidt/httprouter"
 
+	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/defaults"
 	"github.com/gravitational/teleport/api/types"
 	apievents "github.com/gravitational/teleport/api/types/events"
@@ -171,6 +172,17 @@ func NewAPIServer(config *APIConfig) (http.Handler, error) {
 	srv.POST("/:version/reversetunnels", httpMigratedHandler)
 	srv.GET("/:version/reversetunnels", httpMigratedHandler)
 	srv.DELETE("/:version/reversetunnels/:domain", httpMigratedHandler)
+
+	// Return an explicit "too old" error rather than a 404, so that outdated clients
+	// using the deprecated legacy join endpoint get an actionable message.
+	srv.POST("/:version/tokens/register", httplib.MakeHandler(func(
+		w http.ResponseWriter, r *http.Request, p httprouter.Params,
+	) (any, error) {
+		return nil, trace.AccessDenied(
+			"this client is too old to join the cluster, please upgrade to at least v%d.0.0",
+			teleport.MinClientSemVer().Major,
+		)
+	}))
 
 	if config.PluginRegistry != nil {
 		if err := config.PluginRegistry.RegisterAuthWebHandlers(&srv); err != nil {

--- a/lib/auth/apiserver_test.go
+++ b/lib/auth/apiserver_test.go
@@ -143,3 +143,20 @@ func TestUpsertServer(t *testing.T) {
 		})
 	}
 }
+
+// TestTokensRegisterReturnsTooOldError verifies that the re-added /tokens/register
+// route returns an explicit "too old" error rather than a 404, so that outdated
+// clients using the deprecated legacy join endpoint get an actionable message.
+func TestTokensRegisterReturnsTooOldError(t *testing.T) {
+	t.Parallel()
+
+	handler, err := auth.NewAPIServer(&auth.APIConfig{})
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/tokens/register", nil)
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusForbidden, rr.Code)
+	require.Contains(t, rr.Body.String(), "this client is too old to join the cluster")
+}


### PR DESCRIPTION
Backport #67524 to branch/v18

changelog: Outdated agents joining via the legacy Auth HTTP endpoint now receive an explicit "client too old" error instead of a confusing 404.

## Manual Test Plan
### Test Environment

Auth-only cluster (this change only affects direct-to-auth joins)

### Test Cases
- [x] Attempt join with a <= v16 agent and verify join error (e.g. `this client is too old to join the cluster, please upgrade to at least v17.0.0`)
- [x] Curl the endpoint against the auth server
    ```sh
    curl -sk --http1.1 -X POST https://127.0.0.1:3025/v1/tokens/register
    {
        "error": {
            "message": "this client is too old to join the cluster, please upgrade to at least v17.0.0"
        }
    }
    ```
