### PR TITLE
strip setuid/setgid bits from extracted tarball files

### DIFF
--- a/lib/utils/unpack.go
+++ b/lib/utils/unpack.go
@@ -135,7 +135,7 @@ func extractFile(tarball *tar.Reader, header *tar.Header, dir string, dirMode os
 	case tar.TypeDir:
 		return withDir(filepath.Join(dir, header.Name), dirMode, nil)
 	case tar.TypeBlock, tar.TypeChar, tar.TypeReg, tar.TypeFifo:
-		return writeFile(filepath.Join(dir, header.Name), tarball, header.FileInfo().Mode(), dirMode)
+		return writeFile(filepath.Join(dir, header.Name), tarball, header.FileInfo().Mode().Perm(), dirMode)
 	case tar.TypeLink:
 		return writeHardLink(filepath.Join(dir, header.Name), filepath.Join(dir, header.Linkname), dirMode)
 	case tar.TypeSymlink:

--- a/lib/utils/unpack_test.go
+++ b/lib/utils/unpack_test.go
@@ -20,7 +20,10 @@ package utils
 
 import (
 	"archive/tar"
+	"bytes"
 	"fmt"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -146,4 +149,28 @@ func TestSanitizeTarPath(t *testing.T) {
 		err := sanitizeTarPath(tt.header, "/tmp")
 		require.Equal(t, err != nil, tt.expectError, comment)
 	}
+}
+
+func TestExtractStripsSetuid(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	tw := tar.NewWriter(&buf)
+	require.NoError(t, tw.WriteHeader(&tar.Header{
+		Name:     "evil",
+		Mode:     0o6755, // setuid + setgid + rwxr-xr-x
+		Size:     3,
+		Typeflag: tar.TypeReg,
+	}))
+	_, err := tw.Write([]byte("abc"))
+	require.NoError(t, err)
+	require.NoError(t, tw.Close())
+
+	dir := t.TempDir()
+	require.NoError(t, Extract(&buf, dir))
+
+	info, err := os.Stat(filepath.Join(dir, "evil"))
+	require.NoError(t, err)
+	require.Zero(t, info.Mode()&(os.ModeSetuid|os.ModeSetgid|os.ModeSticky),
+		"extracted file must not carry setuid/setgid/sticky bits from the archive, got %v", info.Mode())
 }


### PR DESCRIPTION
Repro: extract a tarball whose regular-file entry has the setuid/setgid bit set (e.g. `Mode: 0o6755`) via `utils.Extract`, then `stat` the result on Linux.
Expected: the created file keeps only the permission bits.
Actual: `extractFile` passes `header.FileInfo().Mode()` (which carries `ModeSetuid`/`ModeSetgid`/`ModeSticky`) straight to `CreateExclusiveFile` -> `os.OpenFile`, so the file lands setuid. The agent auto-updater extracts a downloaded teleport tarball into a system dir as root, and the download hash is integrity-only from the same server, so a malicious or MITM'd CDN can plant a setuid-root binary.
Fix: mask with `.Perm()` before writing, the same thing the sibling extractor in `integrations/lib/tar/extract.go` already does with `os.FileMode(header.Mode).Perm()`.
