### PR TITLE
Fix tctl recordings search pagination and surface fetch errors

### DIFF
--- a/api/gen/proto/go/teleport/sessionsearch/v1/session_search.pb.go
+++ b/api/gen/proto/go/teleport/sessionsearch/v1/session_search.pb.go
@@ -223,8 +223,10 @@ type SearchSessionSummariesRequest struct {
 	// batch_token resumes a previous search from a known cursor position.
 	// Set this to the next_batch_token returned in a prior BatchComplete message
 	// to continue from where an earlier stream left off.
-	// The token encodes the complete search state of the original request;
-	// all other filter fields in this message are ignored when batch_token is set.
+	// The token is only a cursor: it does not encode the search filters, so all
+	// other filter fields (start_time, end_time, ...) must be set to the same
+	// values as the original request when batch_token is set. Resuming with a
+	// different time range than the original search is rejected.
 	// An empty value starts a new search from the beginning.
 	BatchToken string `protobuf:"bytes,14,opt,name=batch_token,json=batchToken,proto3" json:"batch_token,omitempty"`
 	// search_mode controls which search strategy to apply when search_queries
@@ -558,8 +560,10 @@ type SearchSessionSummariesRequest_builder struct {
 	// batch_token resumes a previous search from a known cursor position.
 	// Set this to the next_batch_token returned in a prior BatchComplete message
 	// to continue from where an earlier stream left off.
-	// The token encodes the complete search state of the original request;
-	// all other filter fields in this message are ignored when batch_token is set.
+	// The token is only a cursor: it does not encode the search filters, so all
+	// other filter fields (start_time, end_time, ...) must be set to the same
+	// values as the original request when batch_token is set. Resuming with a
+	// different time range than the original search is rejected.
 	// An empty value starts a new search from the beginning.
 	BatchToken string
 	// search_mode controls which search strategy to apply when search_queries

--- a/api/gen/proto/go/teleport/sessionsearch/v1/session_search_protoopaque.pb.go
+++ b/api/gen/proto/go/teleport/sessionsearch/v1/session_search_protoopaque.pb.go
@@ -533,8 +533,10 @@ type SearchSessionSummariesRequest_builder struct {
 	// batch_token resumes a previous search from a known cursor position.
 	// Set this to the next_batch_token returned in a prior BatchComplete message
 	// to continue from where an earlier stream left off.
-	// The token encodes the complete search state of the original request;
-	// all other filter fields in this message are ignored when batch_token is set.
+	// The token is only a cursor: it does not encode the search filters, so all
+	// other filter fields (start_time, end_time, ...) must be set to the same
+	// values as the original request when batch_token is set. Resuming with a
+	// different time range than the original search is rejected.
 	// An empty value starts a new search from the beginning.
 	BatchToken string
 	// search_mode controls which search strategy to apply when search_queries

--- a/api/proto/teleport/sessionsearch/v1/session_search.proto
+++ b/api/proto/teleport/sessionsearch/v1/session_search.proto
@@ -157,8 +157,10 @@ message SearchSessionSummariesRequest {
   // batch_token resumes a previous search from a known cursor position.
   // Set this to the next_batch_token returned in a prior BatchComplete message
   // to continue from where an earlier stream left off.
-  // The token encodes the complete search state of the original request;
-  // all other filter fields in this message are ignored when batch_token is set.
+  // The token is only a cursor: it does not encode the search filters, so all
+  // other filter fields (start_time, end_time, ...) must be set to the same
+  // values as the original request when batch_token is set. Resuming with a
+  // different time range than the original search is rejected.
   // An empty value starts a new search from the beginning.
   string batch_token = 14;
 

--- a/tool/tctl/common/recordings/error_popup.go
+++ b/tool/tctl/common/recordings/error_popup.go
@@ -1,0 +1,134 @@
+/*
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package recordings
+
+import (
+	"github.com/charmbracelet/bubbles/key"
+	"github.com/charmbracelet/bubbles/viewport"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+)
+
+// errorPopupModel is a dismissible popup that displays an error in red. It is
+// used to surface failures such as a "load more" fetch error.
+type errorPopupModel struct {
+	err      error
+	viewport viewport.Model
+	keys     summaryKeyMap
+	palette  palette
+	width    int
+	height   int
+}
+
+func newErrorPopupModel(err error, p palette, width, height int) *errorPopupModel {
+	m := &errorPopupModel{
+		err:     err,
+		keys:    defaultSummaryKeyMap(),
+		palette: p,
+		width:   width,
+		height:  height,
+	}
+	m.resize()
+	m.refresh()
+	return m
+}
+
+func (m *errorPopupModel) Init() tea.Cmd { return nil }
+
+func (m *errorPopupModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.WindowSizeMsg:
+		m.width = msg.Width
+		m.height = msg.Height
+		m.resize()
+		m.refresh()
+	case tea.KeyMsg:
+		if key.Matches(msg, m.keys.Close) {
+			return m, func() tea.Msg { return closePopupMsg{} }
+		}
+	}
+
+	var cmd tea.Cmd
+	m.viewport, cmd = m.viewport.Update(msg)
+	return m, cmd
+}
+
+func (m *errorPopupModel) View() string {
+	titleStyle := lipgloss.NewStyle().Bold(true).Foreground(m.palette.danger)
+	frameStyle := lipgloss.NewStyle().
+		Width(m.popupWidth()).
+		Height(m.popupHeight()).
+		Border(lipgloss.RoundedBorder()).
+		BorderForeground(m.palette.danger).
+		Padding(0, 1)
+
+	header := titleStyle.Render("Failed to load more sessions")
+	footer := lipgloss.NewStyle().
+		Faint(true).
+		Render("q/esc: close")
+
+	bodyHeight := m.popupHeight() - lipgloss.Height(header) - lipgloss.Height(footer) - 2
+	if bodyHeight < 1 {
+		bodyHeight = 1
+	}
+	m.viewport.Height = bodyHeight
+
+	content := lipgloss.JoinVertical(lipgloss.Left,
+		header,
+		"",
+		m.viewport.View(),
+		"",
+		footer,
+	)
+
+	return lipgloss.Place(
+		m.width,
+		m.height,
+		lipgloss.Center,
+		lipgloss.Center,
+		frameStyle.Render(content),
+	)
+}
+
+func (m *errorPopupModel) popupWidth() int  { return clampPopupWidth(m.width) }
+func (m *errorPopupModel) popupHeight() int { return clampPopupHeight(m.height) }
+
+func (m *errorPopupModel) resize() {
+	bodyWidth := m.popupWidth() - 4
+	if bodyWidth < 20 {
+		bodyWidth = 20
+	}
+	bodyHeight := m.popupHeight() - 6
+	if bodyHeight < 1 {
+		bodyHeight = 1
+	}
+	m.viewport.Width = bodyWidth
+	m.viewport.Height = bodyHeight
+}
+
+func (m *errorPopupModel) refresh() {
+	// The header is rendered red in View; the error text itself is shown as
+	// code (matching the markdown renderer's inline-code style) so it stands
+	// out as a verbatim server message rather than prose.
+	codeStyle := lipgloss.NewStyle().
+		Foreground(lipgloss.Color("252")).
+		Background(lipgloss.AdaptiveColor{Light: "236", Dark: "236"}).
+		Padding(0, 1)
+	m.viewport.SetContent(codeStyle.Render(sanitize(m.err.Error())))
+}

--- a/tool/tctl/common/recordings/model.go
+++ b/tool/tctl/common/recordings/model.go
@@ -43,6 +43,7 @@ type palette struct {
 	accent  lipgloss.TerminalColor
 	section lipgloss.TerminalColor
 	faint   lipgloss.TerminalColor
+	danger  lipgloss.TerminalColor
 }
 
 func buildPalette() palette {
@@ -50,6 +51,7 @@ func buildPalette() palette {
 		accent:  lipgloss.AdaptiveColor{Light: "#512FC9", Dark: "#9F85FF"},
 		section: lipgloss.AdaptiveColor{Light: "#512FC9", Dark: "#9F85FF"},
 		faint:   lipgloss.AdaptiveColor{Light: "243", Dark: "240"},
+		danger:  lipgloss.AdaptiveColor{Light: "#CC0000", Dark: "#FF6B6B"},
 	}
 }
 
@@ -98,8 +100,8 @@ type model struct {
 	help   help.Model
 	keys   keyMap
 
-	// popup is non-nil while the summary popup is active.
-	popup *summaryPopupModel
+	// popup is non-nil while a popup (summary or error) is active.
+	popup tea.Model
 
 	// summaryGetter is forwarded to the popup on Enter.
 	summaryGetter SummaryGetter
@@ -173,12 +175,12 @@ func (m *model) Init() tea.Cmd {
 func (m *model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	if m.popup != nil {
 		switch msg.(type) {
-		case closeSummaryMsg:
+		case closePopupMsg:
 			m.popup = nil
 			return m, nil
 		}
 		updated, cmd := m.popup.Update(msg)
-		m.popup = updated.(*summaryPopupModel)
+		m.popup = updated
 		return m, cmd
 	}
 
@@ -196,6 +198,9 @@ func (m *model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.loadingMore = false
 		if msg.err != nil {
 			m.setLoadMoreItem(loadMoreItem{fetchErr: true})
+			// Surface the error in a popup; the sentinel keeps its "(retry)"
+			// label so the user can retry after dismissing the popup.
+			m.popup = newErrorPopupModel(msg.err, m.palette, m.width, m.height)
 			return m, nil
 		}
 		// Rebuild item list: all current items except the loadMoreItem sentinel.

--- a/tool/tctl/common/recordings/model_test.go
+++ b/tool/tctl/common/recordings/model_test.go
@@ -1,0 +1,71 @@
+/*
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package recordings
+
+import (
+	"context"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/gravitational/trace"
+	"github.com/stretchr/testify/require"
+
+	sessionsearchv1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/sessionsearch/v1"
+)
+
+// TestLoadMoreFetchErrorIsShown verifies that when the "load more" fetch fails,
+// the underlying error is surfaced to the user rather than silently swallowed.
+func TestLoadMoreFetchErrorIsShown(t *testing.T) {
+	const errText = "permission denied: cannot list more sessions"
+
+	sessions := []*sessionsearchv1pb.SessionSummary{
+		sessionsearchv1pb.SessionSummary_builder{SessionId: "abc-123"}.Build(),
+	}
+	fetcher := func(context.Context, string) ([]*sessionsearchv1pb.SessionSummary, string, error) {
+		return nil, "", trace.BadParameter("%s", errText)
+	}
+
+	m := newModel(context.Background(), sessions, "next-token", nil, BatchFetcher(fetcher))
+
+	// Give the model a size so the detail viewport renders content.
+	updated, _ := m.Update(tea.WindowSizeMsg{Width: 120, Height: 40})
+	m = updated.(*model)
+
+	// Move selection down onto the load-more sentinel.
+	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyDown})
+	m = updated.(*model)
+	_, ok := m.list.SelectedItem().(loadMoreItem)
+	require.True(t, ok, "expected load-more item to be selected")
+
+	// Press Enter to trigger the fetch, then run the returned command to obtain
+	// the resulting message.
+	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = updated.(*model)
+	require.NotNil(t, cmd, "expected a fetch command")
+
+	msg := cmd()
+	updated, _ = m.Update(msg)
+	m = updated.(*model)
+
+	// The error must be surfaced in a popup, not silently swallowed.
+	require.IsType(t, &errorPopupModel{}, m.popup,
+		"a failed load-more fetch should open an error popup")
+	require.Contains(t, m.View(), errText,
+		"the load-more fetch error should be displayed to the user")
+}

--- a/tool/tctl/common/recordings/summary_popup.go
+++ b/tool/tctl/common/recordings/summary_popup.go
@@ -38,7 +38,7 @@ type summaryLoadedMsg struct {
 	err     error
 }
 
-type closeSummaryMsg struct{}
+type closePopupMsg struct{}
 
 type summaryPopupModel struct {
 	session       *sessionsearchv1pb.SessionSummary
@@ -109,7 +109,7 @@ func (m *summaryPopupModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		switch {
 		case key.Matches(msg, m.keys.Close):
 			m.close()
-			return m, func() tea.Msg { return closeSummaryMsg{} }
+			return m, func() tea.Msg { return closePopupMsg{} }
 		}
 	}
 
@@ -155,13 +155,17 @@ func (m *summaryPopupModel) View() string {
 	)
 }
 
-func (m *summaryPopupModel) popupWidth() int {
-	width := m.width * 70 / 100
+func (m *summaryPopupModel) popupWidth() int  { return clampPopupWidth(m.width) }
+func (m *summaryPopupModel) popupHeight() int { return clampPopupHeight(m.height) }
+
+// clampPopupWidth returns the popup width for the given terminal width.
+func clampPopupWidth(total int) int {
+	width := total * 70 / 100
 	if width > 100 {
 		width = 100
 	}
 	if width < 48 {
-		width = min(m.width-2, 48)
+		width = min(total-2, 48)
 	}
 	if width < 24 {
 		width = 24
@@ -169,13 +173,14 @@ func (m *summaryPopupModel) popupWidth() int {
 	return width
 }
 
-func (m *summaryPopupModel) popupHeight() int {
-	height := m.height * 70 / 100
+// clampPopupHeight returns the popup height for the given terminal height.
+func clampPopupHeight(total int) int {
+	height := total * 70 / 100
 	if height > 32 {
 		height = 32
 	}
 	if height < 12 {
-		height = min(m.height-2, 12)
+		height = min(total-2, 12)
 	}
 	if height < 8 {
 		height = 8

--- a/tool/tctl/common/recordings_command.go
+++ b/tool/tctl/common/recordings_command.go
@@ -30,6 +30,7 @@ import (
 	"github.com/alecthomas/kingpin/v2"
 	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
+	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	"github.com/gravitational/teleport"
@@ -285,26 +286,6 @@ func (c *RecordingsCommand) SearchRecordings(ctx context.Context, tc *authclient
 		return trace.Wrap(err)
 	}
 
-	// fetcher is defined early so it can be used both for resume and for normal pagination.
-	fetcher := recordingstui.BatchFetcher(func(ctx context.Context, token string) ([]*sessionsearchv1pb.SessionSummary, string, error) {
-		// When BatchToken is set the server ignores all other filter fields per the proto contract.
-		batchStream, err := searchClient.SearchSessionSummaries(ctx, sessionsearchv1pb.SearchSessionSummariesRequest_builder{
-			BatchToken: token,
-		}.Build())
-		if err != nil {
-			return nil, "", trace.Wrap(err)
-		}
-		return collectStream(batchStream)
-	})
-
-	if c.searchResumeToken != "" {
-		sessions, nextToken, err := fetcher(ctx, c.searchResumeToken)
-		if err != nil {
-			return trace.Wrap(err)
-		}
-		return trace.Wrap(showSessionSummaries(ctx, sessions, nextToken, c.searchFormat, c.stdout, tc.SummarizerServiceClient(), fetcher))
-	}
-
 	fromUTC, toUTC, err := defaults.SearchSessionRange(clockwork.NewRealClock(), c.searchFromUTC, c.searchToUTC, "")
 	if err != nil {
 		return trace.Wrap(err)
@@ -360,23 +341,37 @@ func (c *RecordingsCommand) SearchRecordings(ctx context.Context, tc *authclient
 		req.SetSearchMode(mode)
 	}
 
-	stream, err := searchClient.SearchSessionSummaries(ctx, req)
-	if err != nil {
-		return trace.Wrap(err)
-	}
-	sessions, nextToken, err := collectStream(stream)
+	// fetcher resends the full request with the batch token set. It is used for
+	// both the first page (empty or resume token) and subsequent "load more"
+	// pages. The batch token is only a cursor: the server requires and applies
+	// the filter fields (start_time, end_time, ...) on every request, so the
+	// original request must be replayed each time rather than sending the token
+	// alone.
+	fetcher := recordingstui.BatchFetcher(func(ctx context.Context, token string) ([]*sessionsearchv1pb.SessionSummary, string, error) {
+		pageReq := proto.CloneOf(req)
+		pageReq.SetBatchToken(token)
+		stream, err := searchClient.SearchSessionSummaries(ctx, pageReq)
+		if err != nil {
+			return nil, "", trace.Wrap(err)
+		}
+		return collectStream(stream)
+	})
+
+	// c.searchResumeToken is empty for a fresh search and set when resuming a
+	// previous one; either way the first page is just a fetch with that token.
+	sessions, nextToken, err := fetcher(ctx, c.searchResumeToken)
 	if err != nil {
 		return trace.Wrap(err)
 	}
 
-	return trace.Wrap(showSessionSummaries(ctx, sessions, nextToken, c.searchFormat, c.stdout, tc.SummarizerServiceClient(), fetcher))
+	return trace.Wrap(showSessionSummaries(ctx, sessions, nextToken, c.searchFormat, c.stdout, tc.SummarizerServiceClient(), fetcher, resumeCommand))
 }
 
 // maxJSONYAMLSessions is the maximum number of sessions collected before truncating
 // structured (JSON/YAML) output and printing a --resume-token hint to stderr.
-const maxJSONYAMLSessions = 500
+const maxJSONYAMLSessions = 100
 
-func showSessionSummaries(ctx context.Context, sessions []*sessionsearchv1pb.SessionSummary, nextToken, format string, w io.Writer, summaryGetter recordingstui.SummaryGetter, fetcher recordingstui.BatchFetcher) error {
+func showSessionSummaries(ctx context.Context, sessions []*sessionsearchv1pb.SessionSummary, nextToken, format string, w io.Writer, summaryGetter recordingstui.SummaryGetter, fetcher recordingstui.BatchFetcher, resumeCmd func(token string) string) error {
 	switch format {
 	case teleport.JSON, teleport.YAML:
 		// Paginate automatically up to maxJSONYAMLSessions for structured output.
@@ -390,7 +385,7 @@ func showSessionSummaries(ctx context.Context, sessions []*sessionsearchv1pb.Ses
 			nextToken = tok
 		}
 		if nextToken != "" {
-			fmt.Fprintf(os.Stderr, "Showing %d sessions (more available). Resume with: --resume-token %q\n", len(all), nextToken)
+			fmt.Fprintf(os.Stderr, "Showing %d sessions (more available). Resume with:\n  %s\n", len(all), resumeCmd(nextToken))
 		}
 		if format == teleport.JSON {
 			return trace.Wrap(utils.WriteJSONArray(w, all))
@@ -403,6 +398,68 @@ func showSessionSummaries(ctx context.Context, sessions []*sessionsearchv1pb.Ses
 		}
 		return recordingstui.RunSearchTUI(ctx, sessions, nextToken, summaryGetter, fetcher)
 	}
+}
+
+// resumeCommand renders a replayable command for the given resume token by
+// reusing the exact arguments of the current invocation (os.Args) and rewriting
+// only the resume token, replaced in place when already present or appended
+// otherwise. All other flags (including any time range the user passed) are
+// preserved verbatim.
+func resumeCommand(token string) string {
+	args := append([]string(nil), os.Args...)
+	if len(args) > 0 {
+		args[0] = filepath.Base(args[0])
+	}
+	args = replaceOrAppendFlag(args, []string{"--resume-token"}, "--resume-token", token)
+
+	quoted := make([]string, len(args))
+	for i, a := range args {
+		quoted[i] = shellQuote(a)
+	}
+	return strings.Join(quoted, " ")
+}
+
+// replaceOrAppendFlag removes every occurrence of the given flag names (in both
+// "--flag value" and "--flag=value" forms) from args, then appends
+// "canonical value" so the flag ends up set exactly once to value. The multiple
+// names allow collapsing aliases (e.g. --from and --from-utc) onto a single
+// canonical flag.
+func replaceOrAppendFlag(args, names []string, canonical, value string) []string {
+	match := func(arg string) (isFlag, inlineValue bool) {
+		for _, n := range names {
+			if arg == n {
+				return true, false
+			}
+			if strings.HasPrefix(arg, n+"=") {
+				return true, true
+			}
+		}
+		return false, false
+	}
+	out := make([]string, 0, len(args)+2)
+	for i := 0; i < len(args); i++ {
+		isFlag, inline := match(args[i])
+		if !isFlag {
+			out = append(out, args[i])
+			continue
+		}
+		if !inline {
+			i++ // skip the value token that follows "--flag value"
+		}
+	}
+	return append(out, canonical, value)
+}
+
+// shellQuote wraps s in single quotes when it contains characters that a shell
+// would otherwise interpret, so the rendered resume command can be pasted as-is.
+func shellQuote(s string) string {
+	if s == "" {
+		return "''"
+	}
+	if !strings.ContainsAny(s, " \t\n'\"\\$`*?(){}[]|&;<>~#!") {
+		return s
+	}
+	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
 }
 
 func (c *RecordingsCommand) buildSearchResourceProperties() (*sessionsearchv1pb.ResourceProperties, error) {

--- a/tool/tctl/common/recordings_command_test.go
+++ b/tool/tctl/common/recordings_command_test.go
@@ -19,6 +19,8 @@
 package common
 
 import (
+	"os"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -99,4 +101,66 @@ func TestBuildSearchResourceProperties(t *testing.T) {
 		require.ErrorContains(t, err, "resource property filters can only target one session kind")
 		require.Nil(t, got)
 	})
+}
+
+// TestResumeCommand verifies that the rendered resume hint reuses the original
+// invocation's arguments verbatim and only sets the resume token.
+func TestResumeCommand(t *testing.T) {
+	defer func(orig []string) { os.Args = orig }(os.Args)
+
+	t.Run("appends token and preserves flags", func(t *testing.T) {
+		os.Args = []string{
+			"/usr/local/bin/tctl", "recordings", "search", "data exfiltration",
+			"--kind", "ssh",
+			"--from-utc", "2026-06-07",
+			"--limit", "250",
+			"--format", "json",
+		}
+
+		cmd := resumeCommand("tok-123")
+
+		// The program name is shortened and every original flag is preserved.
+		require.True(t, strings.HasPrefix(cmd, "tctl recordings search "))
+		require.Contains(t, cmd, "--kind ssh")
+		require.Contains(t, cmd, "--from-utc 2026-06-07")
+		require.Contains(t, cmd, "--limit 250")
+		require.Contains(t, cmd, "--format json")
+		require.Contains(t, cmd, "'data exfiltration'") // space-containing arg quoted
+
+		// The token is appended since it was not present originally.
+		require.Contains(t, cmd, "--resume-token tok-123")
+	})
+
+	t.Run("replaces an existing token", func(t *testing.T) {
+		os.Args = []string{"tctl", "recordings", "search", "--resume-token", "old", "--format", "yaml"}
+
+		cmd := resumeCommand("new")
+
+		require.Contains(t, cmd, "--resume-token new")
+		require.NotContains(t, cmd, "old")
+		require.Equal(t, 1, strings.Count(cmd, "--resume-token"))
+	})
+}
+
+func TestReplaceOrAppendFlag(t *testing.T) {
+	t.Run("replaces space-separated value", func(t *testing.T) {
+		got := replaceOrAppendFlag([]string{"search", "--limit", "10"}, []string{"--limit"}, "--limit", "20")
+		require.Equal(t, []string{"search", "--limit", "20"}, got)
+	})
+	t.Run("replaces inline value", func(t *testing.T) {
+		got := replaceOrAppendFlag([]string{"search", "--limit=10"}, []string{"--limit"}, "--limit", "20")
+		require.Equal(t, []string{"search", "--limit", "20"}, got)
+	})
+	t.Run("appends when absent", func(t *testing.T) {
+		got := replaceOrAppendFlag([]string{"search"}, []string{"--resume-token"}, "--resume-token", "tok")
+		require.Equal(t, []string{"search", "--resume-token", "tok"}, got)
+	})
+}
+
+func TestShellQuote(t *testing.T) {
+	require.Equal(t, "env=prod", shellQuote("env=prod"))
+	require.Equal(t, "ssh", shellQuote("ssh"))
+	require.Equal(t, "''", shellQuote(""))
+	require.Equal(t, "'data exfiltration'", shellQuote("data exfiltration"))
+	require.Equal(t, `'it'\''s'`, shellQuote("it's"))
 }


### PR DESCRIPTION
"Load more" in the recordings search TUI (and --resume-token) failed with "start_time is required" after the latest access graph update. Follow-up pages were sent with only the batch_token, relying on the proto comment that claimed all other filter fields are ignored once batch_token is set. That contract is wrong: the server validates and applies start_time/end_time and every other filter on each request, and the access graph re-checks that the checkpoint falls within the requested time range.

The batch token is intentionally only a cursor and does not carry the full search state - encoding every filter into the token would let it grow to very large sizes. So the original request must be replayed with the batch_token set on each page. Build the request once and have the fetcher clone it and attach the token for the initial page, resume, and load-more, fixing both the TUI and --resume-token.

Also surface the fetch error back to the user: a failed "load more" now opens a popup with a red header and the server message rendered as code, instead of silently swallowing the error behind a "(retry)" label.

<img width="850" height="402" alt="image" src="https://github.com/user-attachments/assets/b3dd89c8-78fd-486a-8a6c-15cac5ff0dd4" />


## Manual Test Plan
### Test Environment

local

### Test Cases
- [x] Load more works with new access graph versions
- [x] Load more works with old access graph versions
- [x] Load more error is surfaced  
