### PR TITLE
Add missing `type` modifier to `ResourceIconName` import

### DIFF
--- a/web/packages/design/src/ResourceIcon/index.tsx
+++ b/web/packages/design/src/ResourceIcon/index.tsx
@@ -24,7 +24,7 @@ import { IconProps } from 'design/Icon/Icon';
 
 import {
   iconNames,
-  ResourceIconName,
+  type ResourceIconName,
   resourceIconSpecs,
 } from './resourceIconSpecs';
 


### PR DESCRIPTION
You might have noticed that when running `pnpm test`, there would be this warning printed a couple of times:

```
The exported identifier "ResourceIconName" is not declared in Babel's scope tracker
as a JavaScript value binding, and "@babel/plugin-transform-typescript"
never encountered it as a TypeScript type declaration.
It will be treated as a JavaScript value.

This problem is likely caused by another plugin injecting
"ResourceIconName" without registering it in the scope tracker. If you are the author
 of that plugin, please use "scope.registerDeclaration(declarationPath)".
```

I asked Claude to find the root cause and it correctly identified it to be a missing `type` modifier when re-exporting the type in `web/packages/design/src/ResourceIcon/index.tsx` which was causing `@babel/plugin-transform-typescript` to trip up there.

After adding the modifier, the warning is gone.