### PR TITLE
Migrate subca protos using `open2opaque`

### DIFF
--- a/api/client/client.go
+++ b/api/client/client.go
@@ -6311,11 +6311,11 @@ func (c *Client) GetCertAuthorityOverride(
 	ctx context.Context,
 	id types.CertAuthorityOverrideID,
 ) (*subcav1.CertAuthorityOverride, error) {
-	resp, err := c.SubCAClient().GetCertAuthorityOverride(ctx, &subcav1.GetCertAuthorityOverrideRequest{
-		CaId: &subcav1.CertAuthorityOverrideID{
+	resp, err := c.SubCAClient().GetCertAuthorityOverride(ctx, subcav1.GetCertAuthorityOverrideRequest_builder{
+		CaId: subcav1.CertAuthorityOverrideID_builder{
 			CaType: id.CAType,
-		},
-	})
+		}.Build(),
+	}.Build())
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -6326,7 +6326,7 @@ func (c *Client) GetCertAuthorityOverride(
 		return nil, trace.NotFound("%s %s/%s not found", types.KindCertAuthorityOverride, id.CAType, id.ClusterName)
 	}
 
-	return resp.CaOverride, nil
+	return resp.GetCaOverride(), nil
 }
 
 // ListCertAuthorityOverrides lists all CA overrides.
@@ -6337,14 +6337,14 @@ func (c *Client) ListCertAuthorityOverrides(
 	pageSize int,
 	pageToken string,
 ) (_ []*subcav1.CertAuthorityOverride, nextPageToken string, _ error) {
-	resp, err := c.SubCAClient().ListCertAuthorityOverride(ctx, &subcav1.ListCertAuthorityOverrideRequest{
+	resp, err := c.SubCAClient().ListCertAuthorityOverride(ctx, subcav1.ListCertAuthorityOverrideRequest_builder{
 		PageSize:  int32(pageSize),
 		PageToken: pageToken,
-	})
+	}.Build())
 	if err != nil {
 		return nil, "", trace.Wrap(err)
 	}
-	return resp.CaOverrides, resp.NextPageToken, nil
+	return resp.GetCaOverrides(), resp.GetNextPageToken(), nil
 }
 
 // IssuanceClient returns an [issuancev1pb.IssuanceServiceClient].

--- a/api/client/client_subca_test.go
+++ b/api/client/client_subca_test.go
@@ -42,8 +42,8 @@ func TestClient_GetCertAuthorityOverride(t *testing.T) {
 
 	override := caOverrides[0]
 	overrideID := types.CertAuthorityOverrideID{
-		ClusterName: override.Metadata.Name,
-		CAType:      override.SubKind,
+		ClusterName: override.GetMetadata().Name,
+		CAType:      override.GetSubKind(),
 	}
 
 	tests := []struct {
@@ -166,7 +166,7 @@ func newClientForSubCATesting(t *testing.T) *Client {
 }
 
 var caOverrides = []*subcav1.CertAuthorityOverride{
-	{
+	subcav1.CertAuthorityOverride_builder{
 		Kind:    types.KindCertAuthorityOverride,
 		SubKind: string(types.DatabaseClientCA),
 		Version: types.V1,
@@ -175,8 +175,8 @@ var caOverrides = []*subcav1.CertAuthorityOverride{
 			Revision: "1774a27d-977e-45a1-ac6a-dd8b7a8e0d8d",
 		},
 		Spec: &subcav1.CertAuthorityOverrideSpec{},
-	},
-	{
+	}.Build(),
+	subcav1.CertAuthorityOverride_builder{
 		Kind:    types.KindCertAuthorityOverride,
 		SubKind: string(types.WindowsCA),
 		Version: types.V1,
@@ -185,7 +185,7 @@ var caOverrides = []*subcav1.CertAuthorityOverride{
 			Revision: "511c8c23-03ea-44b2-81e5-62ddcd4d3445",
 		},
 		Spec: &subcav1.CertAuthorityOverrideSpec{},
-	},
+	}.Build(),
 }
 
 // fakeSubCAService is a fake SubCAService implementation that returns
@@ -202,10 +202,10 @@ func (s *fakeSubCAService) GetCertAuthorityOverride(
 ) (*subcav1.GetCertAuthorityOverrideResponse, error) {
 	// Implement a simplistic Get. Input validation not performed.
 	for _, o := range s.overrides {
-		if o.SubKind == req.GetCaId().GetCaType() {
-			return &subcav1.GetCertAuthorityOverrideResponse{
+		if o.GetSubKind() == req.GetCaId().GetCaType() {
+			return subcav1.GetCertAuthorityOverrideResponse_builder{
 				CaOverride: o,
-			}, nil
+			}.Build(), nil
 		}
 	}
 	return nil, trace.NotFound("ca override not found")
@@ -216,7 +216,7 @@ func (s *fakeSubCAService) ListCertAuthorityOverride(
 	req *subcav1.ListCertAuthorityOverrideRequest,
 ) (*subcav1.ListCertAuthorityOverrideResponse, error) {
 	// Input filters are completely disregarded.
-	return &subcav1.ListCertAuthorityOverrideResponse{
+	return subcav1.ListCertAuthorityOverrideResponse_builder{
 		CaOverrides: s.overrides,
-	}, nil
+	}.Build(), nil
 }


### PR DESCRIPTION
Run `open2opaque -levels=green`, targeting only Sub CA protos.

Migrates a few occurrences not present in #67279.

https://github.com/gravitational/teleport.e/issues/7675