### PR TITLE
[v18] Add go.uber.org/goleak dependency and restore goroutine-leak test

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -244,6 +244,7 @@ require (
 	go.opentelemetry.io/otel/sdk v1.43.0
 	go.opentelemetry.io/otel/trace v1.43.0
 	go.opentelemetry.io/proto/otlp v1.10.0
+	go.uber.org/goleak v1.3.0
 	golang.org/x/crypto v0.51.0
 	golang.org/x/exp v0.0.0-20260410095643-746e56fc9e2f
 	golang.org/x/mod v0.35.0

--- a/lib/kube/proxy/spdy_stream_dedup_repro_test.go
+++ b/lib/kube/proxy/spdy_stream_dedup_repro_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"go.uber.org/goleak"
 )
 
 // On a request with tty=true, stdin=true, stdout=true, expectedStreams==4 (error + stdin + stdout + resize).
@@ -51,6 +52,37 @@ func TestRegression_WaitForStreams_RejectsDuplicateStream(t *testing.T) {
 
 	_, err := handler.waitForStreams(t.Context(), streams, expectedStreams, nil)
 	require.Error(t, err, "waitForStreams should return an error when a duplicate stream type arrives")
+}
+
+// When waitForStreams returns early on a duplicate stream, every waitStreamReply
+// goroutine it spawned must exit. Otherwise repeated malformed requests
+// accumulate goroutines parked on the unbuffered notify send.
+func TestRegression_WaitForStreams_DuplicateStream_NoGoroutineLeak(t *testing.T) {
+	ignore := goleak.IgnoreCurrent()
+	defer goleak.VerifyNone(t, ignore)
+
+	handler := &v4ProtocolHandler{}
+
+	const expectedStreams = 4
+	streams := make(chan streamAndReply, expectedStreams)
+	for _, st := range []string{
+		StreamTypeError,
+		StreamTypeStdin,
+		StreamTypeStdout,
+		StreamTypeStdin,
+	} {
+		hdr := http.Header{}
+		hdr.Set(StreamType, st)
+		reply := make(chan struct{})
+		close(reply)
+		streams <- streamAndReply{
+			Stream:    &fakeSPDYStream{headers: hdr},
+			replySent: reply,
+		}
+	}
+
+	_, err := handler.waitForStreams(t.Context(), streams, expectedStreams, nil)
+	require.Error(t, err)
 }
 
 // Calling kubeProxyClientStreams.resizeQueue() with a nil sizeQueue must not panic.


### PR DESCRIPTION
The goroutine-leak test from #67157 was dropped in the v18 backport (#67339) to avoid adding `go.uber.org/goleak` as a direct dependency. goleak is already direct on master, and v18 tests need it.

- Add `go.uber.org/goleak v1.3.0` to `go.mod` (go.sum already had the hashes).
- Restore `TestRegression_WaitForStreams_DuplicateStream_NoGoroutineLeak` so the dependency is genuinely used, keeping `go mod tidy` clean.