### PR TITLE
[v18] Update IaCOverview page with per-configuration cards (#66641)

### DIFF
--- a/lib/web/integrations.go
+++ b/lib/web/integrations.go
@@ -369,35 +369,58 @@ func collectIntegrationStats(ctx context.Context, req collectIntegrationStatsReq
 	}
 	ret.UnresolvedUserTasks = len(ret.UserTasks)
 
+	// Track whether any resource type is currently being scanned.
+	// If any are scanning, we set SyncEnd to nil after all iterations.
+	// TODO (avatus) might need to make this a bit more scalable in the
+	// future if we have a bunch of types but this is ok for now
+	var ec2Scanning, rdsScanning, eksScanning, azureVMScanning bool
+
 	for cfg, err := range allDiscoveryConfigs(ctx, req.discoveryConfigLister) {
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
 
-		discoveredResources, ok := cfg.Status.IntegrationDiscoveredResources[req.integration.GetName()]
-		if !ok {
+		summary := integrationSummaryForConfig(cfg, req.integration.GetName())
+		if summary == nil {
 			continue
 		}
 
-		if matchers := rulesWithIntegration(cfg, types.AWSMatcherEC2, req.integration.GetName()); matchers != 0 {
-			ret.AWSEC2.RulesCount += matchers
-			mergeResourceTypeSummary(&ret.AWSEC2, cfg.Status.LastSyncTime, discoveredResources.AwsEc2)
-		}
+		ec2Matchers := rulesWithIntegration(cfg, types.AWSMatcherEC2, req.integration.GetName())
+		rdsMatchers := rulesWithIntegration(cfg, types.AWSMatcherRDS, req.integration.GetName())
+		eksMatchers := rulesWithIntegration(cfg, types.AWSMatcherEKS, req.integration.GetName())
+		azureVMMatchers := rulesWithIntegration(cfg, types.AzureMatcherVM, req.integration.GetName())
 
-		if matchers := rulesWithIntegration(cfg, types.AWSMatcherRDS, req.integration.GetName()); matchers != 0 {
-			ret.AWSRDS.RulesCount += matchers
-			mergeResourceTypeSummary(&ret.AWSRDS, cfg.Status.LastSyncTime, discoveredResources.AwsRds)
-		}
+		ret.AWSEC2.RulesCount += ec2Matchers
+		ret.AWSRDS.RulesCount += rdsMatchers
+		ret.AWSEKS.RulesCount += eksMatchers
+		ret.AzureVM.RulesCount += azureVMMatchers
 
-		if matchers := rulesWithIntegration(cfg, types.AWSMatcherEKS, req.integration.GetName()); matchers != 0 {
-			ret.AWSEKS.RulesCount += matchers
-			mergeResourceTypeSummary(&ret.AWSEKS, cfg.Status.LastSyncTime, discoveredResources.AwsEks)
+		if ec2Matchers != 0 {
+			ec2Scanning = mergeResourceTypeSummary(&ret.AWSEC2, summary.summary.GetAwsEc2(), summary.pollInterval) || ec2Scanning
 		}
+		if rdsMatchers != 0 {
+			rdsScanning = mergeResourceTypeSummary(&ret.AWSRDS, summary.summary.GetAwsRds(), summary.pollInterval) || rdsScanning
+		}
+		if eksMatchers != 0 {
+			eksScanning = mergeResourceTypeSummary(&ret.AWSEKS, summary.summary.GetAwsEks(), summary.pollInterval) || eksScanning
+		}
+		if azureVMMatchers != 0 {
+			azureVMScanning = mergeResourceTypeSummary(&ret.AzureVM, summary.summary.GetAzureVms(), summary.pollInterval) || azureVMScanning
+		}
+	}
 
-		if matchers := rulesWithIntegration(cfg, types.AzureMatcherVM, req.integration.GetName()); matchers != 0 {
-			ret.AzureVM.RulesCount += matchers
-			mergeResourceTypeSummary(&ret.AzureVM, cfg.Status.LastSyncTime, discoveredResources.AzureVms)
-		}
+	// If any resource type is currently scanning, set SyncEnd to nil.
+	if ec2Scanning {
+		ret.AWSEC2.SyncEnd = nil
+	}
+	if rdsScanning {
+		ret.AWSRDS.SyncEnd = nil
+	}
+	if eksScanning {
+		ret.AWSEKS.SyncEnd = nil
+	}
+	if azureVMScanning {
+		ret.AzureVM.SyncEnd = nil
 	}
 
 	switch req.integration.GetSubKind() {
@@ -533,18 +556,87 @@ func countAWSOIDCDeployedDatabaseServices(ctx context.Context, req collectIntegr
 	return len(services), nil
 }
 
-func mergeResourceTypeSummary(in *ui.ResourceTypeSummary, lastSyncTime time.Time, new *discoveryconfigv1.ResourcesDiscoveredSummary) {
-	if new == nil {
-		return
-	}
-
-	in.DiscoverLastSync = lastSync(in.DiscoverLastSync, lastSyncTime)
-	in.ResourcesFound += int(new.Found)
-	in.ResourcesEnrollmentSuccess += int(new.Enrolled)
-	in.ResourcesEnrollmentFailed += int(new.Failed)
+type integrationSummaryWithPollInterval struct {
+	summary      *discoveryconfigv1.DiscoverSummary
+	pollInterval time.Duration
 }
 
-func lastSync(current *time.Time, new time.Time) *time.Time {
+// integrationSummaryForConfig returns the most recently updated server's summary
+// for the given integration. In HA deployments, multiple Discovery Services may
+// report summaries for the same resources, so we use only the most recent one
+// to avoid double-counting.
+func integrationSummaryForConfig(cfg *discoveryconfig.DiscoveryConfig, integrationName string) *integrationSummaryWithPollInterval {
+	var mostRecent *integrationSummaryWithPollInterval
+	var mostRecentTime time.Time
+
+	for _, serverStatus := range cfg.Status.ServerStatus {
+		if serverStatus == nil || serverStatus.DiscoveryStatusServer == nil {
+			continue
+		}
+		discoverSummary, ok := serverStatus.GetIntegrationSummaries()[integrationName]
+		if !ok {
+			continue
+		}
+
+		lastUpdate := serverStatus.GetLastUpdate().AsTime()
+		if mostRecent == nil || lastUpdate.After(mostRecentTime) {
+			mostRecent = &integrationSummaryWithPollInterval{
+				summary:      discoverSummary,
+				pollInterval: serverStatus.GetPollInterval().AsDuration(),
+			}
+			mostRecentTime = lastUpdate
+		}
+	}
+	return mostRecent
+}
+
+// mergeResourceTypeSummary merges resource summary data into the aggregated summary.
+// It returns true if the resource is currently being scanned (has no SyncEnd time yet).
+func mergeResourceTypeSummary(in *ui.ResourceTypeSummary, resourceSummary *discoveryconfigv1.ResourceSummary, pollInterval time.Duration) bool {
+	if resourceSummary == nil {
+		return false
+	}
+
+	previous := resourceSummary.GetPrevious()
+	if previous != nil {
+		in.ResourcesFound += int(previous.GetFound())
+		in.ResourcesEnrollmentSuccess += int(previous.GetEnrolled())
+		in.ResourcesEnrollmentFailed += int(previous.GetFailed())
+
+		in.DiscoverLastSync = latestTime(in.DiscoverLastSync, previous.GetSyncEnd().AsTime())
+	}
+
+	isScanning := false
+	syncEndUpdated := false
+	current := resourceSummary.GetCurrent()
+	if current != nil {
+		in.SyncStart = latestTime(in.SyncStart, current.GetSyncStart().AsTime())
+		if current.GetSyncEnd().AsTime().IsZero() {
+			isScanning = true
+		} else {
+			prevSyncEnd := in.SyncEnd
+			in.SyncEnd = latestTime(in.SyncEnd, current.GetSyncEnd().AsTime())
+			syncEndUpdated = in.SyncEnd != prevSyncEnd
+		}
+	} else if previous != nil {
+		in.SyncStart = latestTime(in.SyncStart, previous.GetSyncStart().AsTime())
+		prevSyncEnd := in.SyncEnd
+		in.SyncEnd = latestTime(in.SyncEnd, previous.GetSyncEnd().AsTime())
+		syncEndUpdated = in.SyncEnd != prevSyncEnd
+	}
+
+	if pollInterval > 0 && (in.PollIntervalSeconds == 0 || syncEndUpdated) {
+		in.PollIntervalSeconds = int(pollInterval.Seconds())
+	}
+
+	return isScanning
+}
+
+func latestTime(current *time.Time, new time.Time) *time.Time {
+	if new.IsZero() {
+		return current
+	}
+
 	if current == nil {
 		return &new
 	}

--- a/lib/web/integrations_test.go
+++ b/lib/web/integrations_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/gravitational/trace"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/timestamppb"
 
 	"github.com/gravitational/teleport/api/client/proto"
 	discoveryconfigv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/discoveryconfig/v1"
@@ -363,7 +364,8 @@ func TestCollectIntegrationStats(t *testing.T) {
 	})
 
 	t.Run("collects multiple discovery configs", func(t *testing.T) {
-		syncTime := time.Now()
+		syncTime := time.Now().UTC()
+		syncEnd := timestamppb.New(syncTime)
 		dcForEC2 := &discoveryconfig.DiscoveryConfig{
 			Spec: discoveryconfig.Spec{AWS: []types.AWSMatcher{{
 				Integration: integrationName,
@@ -373,10 +375,16 @@ func TestCollectIntegrationStats(t *testing.T) {
 			Status: discoveryconfig.Status{
 				LastSyncTime:        syncTime,
 				DiscoveredResources: 2,
-				IntegrationDiscoveredResources: map[string]*discoveryconfig.IntegrationDiscoveredSummary{
-					integrationName: {
-						IntegrationDiscoveredSummary: &discoveryconfigv1.IntegrationDiscoveredSummary{
-							AwsEc2: &discoveryconfigv1.ResourcesDiscoveredSummary{Found: 2, Enrolled: 1, Failed: 1},
+				ServerStatus: map[string]*discoveryconfig.DiscoveryStatusServer{
+					"server-1": {
+						DiscoveryStatusServer: &discoveryconfigv1.DiscoveryStatusServer{
+							IntegrationSummaries: map[string]*discoveryconfigv1.DiscoverSummary{
+								integrationName: {
+									AwsEc2: &discoveryconfigv1.ResourceSummary{
+										Previous: &discoveryconfigv1.ResourcesDiscoveredSummary{Found: 2, Enrolled: 1, Failed: 1, SyncStart: syncEnd, SyncEnd: syncEnd},
+									},
+								},
+							},
 						},
 					},
 				},
@@ -391,10 +399,16 @@ func TestCollectIntegrationStats(t *testing.T) {
 			Status: discoveryconfig.Status{
 				LastSyncTime:        syncTime,
 				DiscoveredResources: 2,
-				IntegrationDiscoveredResources: map[string]*discoveryconfig.IntegrationDiscoveredSummary{
-					integrationName: {
-						IntegrationDiscoveredSummary: &discoveryconfigv1.IntegrationDiscoveredSummary{
-							AwsRds: &discoveryconfigv1.ResourcesDiscoveredSummary{Found: 2, Enrolled: 1, Failed: 1},
+				ServerStatus: map[string]*discoveryconfig.DiscoveryStatusServer{
+					"server-1": {
+						DiscoveryStatusServer: &discoveryconfigv1.DiscoveryStatusServer{
+							IntegrationSummaries: map[string]*discoveryconfigv1.DiscoverSummary{
+								integrationName: {
+									AwsRds: &discoveryconfigv1.ResourceSummary{
+										Previous: &discoveryconfigv1.ResourcesDiscoveredSummary{Found: 2, Enrolled: 1, Failed: 1, SyncStart: syncEnd, SyncEnd: syncEnd},
+									},
+								},
+							},
 						},
 					},
 				},
@@ -409,10 +423,16 @@ func TestCollectIntegrationStats(t *testing.T) {
 			Status: discoveryconfig.Status{
 				LastSyncTime:        syncTime,
 				DiscoveredResources: 2,
-				IntegrationDiscoveredResources: map[string]*discoveryconfig.IntegrationDiscoveredSummary{
-					integrationName: {
-						IntegrationDiscoveredSummary: &discoveryconfigv1.IntegrationDiscoveredSummary{
-							AwsEks: &discoveryconfigv1.ResourcesDiscoveredSummary{Found: 4, Enrolled: 0, Failed: 0},
+				ServerStatus: map[string]*discoveryconfig.DiscoveryStatusServer{
+					"server-1": {
+						DiscoveryStatusServer: &discoveryconfigv1.DiscoveryStatusServer{
+							IntegrationSummaries: map[string]*discoveryconfigv1.DiscoverSummary{
+								integrationName: {
+									AwsEks: &discoveryconfigv1.ResourceSummary{
+										Previous: &discoveryconfigv1.ResourcesDiscoveredSummary{Found: 4, Enrolled: 0, Failed: 0, SyncStart: syncEnd, SyncEnd: syncEnd},
+									},
+								},
+							},
 						},
 					},
 				},
@@ -450,6 +470,8 @@ func TestCollectIntegrationStats(t *testing.T) {
 				ResourcesEnrollmentFailed:  1,
 				ResourcesEnrollmentSuccess: 1,
 				DiscoverLastSync:           &syncTime,
+				SyncStart:                  &syncTime,
+				SyncEnd:                    &syncTime,
 			},
 			AWSRDS: ui.ResourceTypeSummary{
 				RulesCount:                 3,
@@ -458,6 +480,8 @@ func TestCollectIntegrationStats(t *testing.T) {
 				ResourcesEnrollmentSuccess: 1,
 				ECSDatabaseServiceCount:    1,
 				DiscoverLastSync:           &syncTime,
+				SyncStart:                  &syncTime,
+				SyncEnd:                    &syncTime,
 			},
 			AWSEKS: ui.ResourceTypeSummary{
 				RulesCount:                 1,
@@ -465,12 +489,15 @@ func TestCollectIntegrationStats(t *testing.T) {
 				ResourcesEnrollmentFailed:  0,
 				ResourcesEnrollmentSuccess: 0,
 				DiscoverLastSync:           &syncTime,
+				SyncStart:                  &syncTime,
+				SyncEnd:                    &syncTime,
 			},
 		}
 		require.Equal(t, expectedSummary, gotSummary)
 	})
 	t.Run("returns 0 ECS DatabaseServices if listing deployed database services returns AccessDenied", func(t *testing.T) {
-		syncTime := time.Now()
+		syncTime := time.Now().UTC()
+		syncEnd := timestamppb.New(syncTime)
 		dcForRDS := &discoveryconfig.DiscoveryConfig{
 			Spec: discoveryconfig.Spec{AWS: []types.AWSMatcher{{
 				Integration: integrationName,
@@ -480,10 +507,16 @@ func TestCollectIntegrationStats(t *testing.T) {
 			Status: discoveryconfig.Status{
 				LastSyncTime:        syncTime,
 				DiscoveredResources: 2,
-				IntegrationDiscoveredResources: map[string]*discoveryconfig.IntegrationDiscoveredSummary{
-					integrationName: {
-						IntegrationDiscoveredSummary: &discoveryconfigv1.IntegrationDiscoveredSummary{
-							AwsRds: &discoveryconfigv1.ResourcesDiscoveredSummary{Found: 2, Enrolled: 1, Failed: 1},
+				ServerStatus: map[string]*discoveryconfig.DiscoveryStatusServer{
+					"server-1": {
+						DiscoveryStatusServer: &discoveryconfigv1.DiscoveryStatusServer{
+							IntegrationSummaries: map[string]*discoveryconfigv1.DiscoverSummary{
+								integrationName: {
+									AwsRds: &discoveryconfigv1.ResourceSummary{
+										Previous: &discoveryconfigv1.ResourcesDiscoveredSummary{Found: 2, Enrolled: 1, Failed: 1, SyncStart: syncEnd, SyncEnd: syncEnd},
+									},
+								},
+							},
 						},
 					},
 				},
@@ -523,6 +556,8 @@ func TestCollectIntegrationStats(t *testing.T) {
 				ResourcesEnrollmentSuccess: 1,
 				ECSDatabaseServiceCount:    0,
 				DiscoverLastSync:           &syncTime,
+				SyncStart:                  &syncTime,
+				SyncEnd:                    &syncTime,
 			},
 		}
 		require.Equal(t, expectedSummary, gotSummary)
@@ -677,7 +712,8 @@ func TestCollectIntegrationStats(t *testing.T) {
 	t.Run("collects Azure discovery configs", func(t *testing.T) {
 		mockInt := newMockAzureOIDCIntegration(t, integrationName)
 
-		syncTime := time.Now()
+		syncTime := time.Now().UTC()
+		syncEnd := timestamppb.New(syncTime)
 		azureConfig := &discoveryconfig.DiscoveryConfig{
 			Spec: discoveryconfig.Spec{Azure: []types.AzureMatcher{{
 				Integration: integrationName,
@@ -686,13 +722,21 @@ func TestCollectIntegrationStats(t *testing.T) {
 			}}},
 			Status: discoveryconfig.Status{
 				LastSyncTime: syncTime,
-				IntegrationDiscoveredResources: map[string]*discoveryconfig.IntegrationDiscoveredSummary{
-					integrationName: {
-						IntegrationDiscoveredSummary: &discoveryconfigv1.IntegrationDiscoveredSummary{
-							AzureVms: &discoveryconfigv1.ResourcesDiscoveredSummary{
-								Found:    5,
-								Enrolled: 3,
-								Failed:   1,
+				ServerStatus: map[string]*discoveryconfig.DiscoveryStatusServer{
+					"server-1": {
+						DiscoveryStatusServer: &discoveryconfigv1.DiscoveryStatusServer{
+							IntegrationSummaries: map[string]*discoveryconfigv1.DiscoverSummary{
+								integrationName: {
+									AzureVms: &discoveryconfigv1.ResourceSummary{
+										Previous: &discoveryconfigv1.ResourcesDiscoveredSummary{
+											Found:     5,
+											Enrolled:  3,
+											Failed:    1,
+											SyncStart: syncEnd,
+											SyncEnd:   syncEnd,
+										},
+									},
+								},
 							},
 						},
 					},
@@ -738,6 +782,8 @@ func TestCollectIntegrationStats(t *testing.T) {
 				ResourcesEnrollmentSuccess: 3,
 				ResourcesEnrollmentFailed:  1,
 				DiscoverLastSync:           &syncTime,
+				SyncStart:                  &syncTime,
+				SyncEnd:                    &syncTime,
 				UnresolvedUserTasks:        10,
 			},
 		}

--- a/lib/web/ui/integration.go
+++ b/lib/web/ui/integration.go
@@ -191,6 +191,12 @@ type ResourceTypeSummary struct {
 	ResourcesEnrollmentSuccess int `json:"resourcesEnrollmentSuccess,omitempty"`
 	// DiscoverLastSync contains the time when this integration tried to auto-enroll resources.
 	DiscoverLastSync *time.Time `json:"discoverLastSync,omitempty"`
+	// SyncStart is when the current or most recent discovery scan started.
+	SyncStart *time.Time `json:"syncStart,omitempty"`
+	// SyncEnd is when the most recent discovery scan ended.
+	SyncEnd *time.Time `json:"syncEnd,omitempty"`
+	// PollIntervalSeconds is the interval in seconds between discovery scans.
+	PollIntervalSeconds int `json:"pollIntervalSeconds,omitempty"`
 	// UnresolvedUserTasks contains the count of unresolved user tasks related to this integration and resource type.
 	UnresolvedUserTasks int `json:"unresolvedUserTasks,omitempty"`
 	// ECSDatabaseServiceCount is the total number of DatabaseServices that were deployed into Amazon ECS.

--- a/web/packages/teleport/src/Discover/Overview/IaCIntegrationOverview.story.tsx
+++ b/web/packages/teleport/src/Discover/Overview/IaCIntegrationOverview.story.tsx
@@ -53,7 +53,8 @@ function Component({
 
 const statsHandler = (overrides = {}) =>
   http.get(cfg.getIntegrationStatsUrl(integrationName), () => {
-    const lastSync = Date.now() - 2 * 60 * 1000;
+    const syncEnd = new Date(Date.now() - 2 * 60 * 1000).toISOString();
+    const syncStart = new Date(Date.now() - 3 * 60 * 1000).toISOString();
 
     return HttpResponse.json({
       name: integrationName,
@@ -84,9 +85,30 @@ const statsHandler = (overrides = {}) =>
       awsoidc: {
         roleArn: 'arn:aws:iam::123456789012:role/TeleportRole',
       },
-      awsec2: { enrolled: 5, failed: 1, discoverLastSync: lastSync },
-      awsrds: { enrolled: 3, failed: 0, discoverLastSync: lastSync },
-      awseks: { enrolled: 2, failed: 0, discoverLastSync: lastSync },
+      awsec2: {
+        rulesCount: 1,
+        resourcesFound: 10,
+        resourcesEnrollmentSuccess: 10,
+        resourcesEnrollmentFailed: 0,
+        syncStart,
+        syncEnd,
+        pollIntervalSeconds: 300,
+      },
+      awsrds: {
+        rulesCount: 1,
+        resourcesFound: 5,
+        resourcesEnrollmentSuccess: 1,
+        resourcesEnrollmentFailed: 0,
+        syncStart,
+        syncEnd,
+        pollIntervalSeconds: 300,
+      },
+      awseks: {
+        rulesCount: 0,
+        resourcesFound: 0,
+        resourcesEnrollmentSuccess: 0,
+        resourcesEnrollmentFailed: 0,
+      },
       isManagedByTerraform: true,
       ...overrides,
     });
@@ -218,19 +240,66 @@ Healthy.parameters = {
         unresolvedUserTasks: 0,
         userTasks: [],
         awsec2: {
-          enrolled: 10,
-          failed: 0,
-          discoverLastSync: Date.now() - 2 * 60 * 1000,
+          rulesCount: 1,
+          resourcesFound: 10,
+          resourcesEnrollmentSuccess: 10,
+          resourcesEnrollmentFailed: 0,
+          syncStart: new Date(Date.now() - 3 * 60 * 1000).toISOString(),
+          syncEnd: new Date(Date.now() - 2 * 60 * 1000).toISOString(),
+          pollIntervalSeconds: 300,
         },
         awsrds: {
-          enrolled: 5,
-          failed: 0,
-          discoverLastSync: Date.now() - 2 * 60 * 1000,
+          rulesCount: 1,
+          resourcesFound: 5,
+          resourcesEnrollmentSuccess: 5,
+          resourcesEnrollmentFailed: 0,
+          syncStart: new Date(Date.now() - 3 * 60 * 1000).toISOString(),
+          syncEnd: new Date(Date.now() - 2 * 60 * 1000).toISOString(),
+          pollIntervalSeconds: 300,
         },
         awseks: {
-          enrolled: 3,
-          failed: 0,
-          discoverLastSync: Date.now() - 2 * 60 * 1000,
+          rulesCount: 1,
+          resourcesFound: 3,
+          resourcesEnrollmentSuccess: 3,
+          resourcesEnrollmentFailed: 0,
+          syncStart: new Date(Date.now() - 3 * 60 * 1000).toISOString(),
+          syncEnd: new Date(Date.now() - 2 * 60 * 1000).toISOString(),
+          pollIntervalSeconds: 300,
+        },
+      }),
+      rulesHandler,
+    ],
+  },
+};
+
+export function CurrentlyScanning() {
+  return <Component />;
+}
+CurrentlyScanning.parameters = {
+  msw: {
+    handlers: [
+      statsHandler({
+        unresolvedUserTasks: 0,
+        userTasks: [],
+        awsec2: {
+          rulesCount: 1,
+          resourcesFound: 10,
+          resourcesEnrollmentSuccess: 10,
+          resourcesEnrollmentFailed: 0,
+          syncStart: new Date(Date.now() - 3 * 60 * 1000).toISOString(),
+          syncEnd: new Date(Date.now() - 2 * 60 * 1000).toISOString(),
+          pollIntervalSeconds: 300,
+        },
+        awsrds: {
+          rulesCount: 1,
+          resourcesFound: 5,
+          resourcesEnrollmentSuccess: 1,
+          resourcesEnrollmentFailed: 0,
+          syncStart: new Date(Date.now() - 30 * 1000).toISOString(),
+          pollIntervalSeconds: 300,
+        },
+        awseks: {
+          rulesCount: 0,
         },
       }),
       rulesHandler,
@@ -280,8 +349,13 @@ AzureWithWildcardSubscription.parameters = {
           unresolvedUserTasks: 0,
           userTasks: [],
           azurevm: {
-            resourcesFound: 3,
-            discoverLastSync: Date.now() - 2 * 60 * 1000,
+            rulesCount: 1,
+            resourcesFound: 8,
+            resourcesEnrollmentSuccess: 6,
+            resourcesEnrollmentFailed: 0,
+            syncStart: new Date(Date.now() - 3 * 60 * 1000).toISOString(),
+            syncEnd: new Date(Date.now() - 2 * 60 * 1000).toISOString(),
+            pollIntervalSeconds: 300,
           },
           isManagedByTerraform: true,
         })

--- a/web/packages/teleport/src/Discover/Overview/IaCIntegrationOverview.tsx
+++ b/web/packages/teleport/src/Discover/Overview/IaCIntegrationOverview.tsx
@@ -18,48 +18,33 @@
 
 import { useQuery } from '@tanstack/react-query';
 import { formatDistanceStrict, formatDistanceToNowStrict } from 'date-fns';
-import { useEffect, useState, type ReactNode } from 'react';
+import { useEffect, useState } from 'react';
 import { useParams } from 'react-router';
 import { Link as RouterLink } from 'react-router-dom';
+import styled, { keyframes } from 'styled-components';
 
-import { Box, Card, Flex, H2, Indicator, Text } from 'design';
+import { Card, Flex, H2, Indicator, Text } from 'design';
 import { Danger } from 'design/Alert';
-import { ButtonPrimaryBorder, ButtonText } from 'design/Button';
+import { ButtonPrimary } from 'design/Button';
 import ButtonIcon from 'design/ButtonIcon';
 import { displayDateTime } from 'design/datetime';
-import {
-  ArrowLeft,
-  ArrowRight,
-  ChevronRight,
-  CircleCross,
-  Warning,
-} from 'design/Icon';
-import { TabBorder, useSlidingBottomBorderTabs } from 'design/Tabs';
+import { ArrowLeft, CircleCheck, Clock, SyncAlt } from 'design/Icon';
+import { ResourceIcon, ResourceIconName } from 'design/ResourceIcon';
+import { Status as StatusBadge } from 'design/Status';
 import { HoverTooltip } from 'design/Tooltip';
 import { pluralize } from 'shared/utils/text';
 
 import { FeatureBox } from 'teleport/components/Layout';
 import cfg from 'teleport/config';
-import {
-  ContentWithSidePanel,
-  InfoGuideSwitch,
-  useTerraformInfoGuide,
-} from 'teleport/Integrations/Enroll/Cloud/Shared/InfoGuide';
-import {
-  latestSyncDate,
-  SummaryStatusLabel,
-} from 'teleport/Integrations/shared/StatusLabel';
 import { useNoMinWidth } from 'teleport/Main';
 import {
-  INTEGRATION_DISCOVERY_SCAN_INTERVAL_MS,
   IntegrationKind,
   integrationService,
   IntegrationWithSummary,
+  ResourceTypeSummary,
 } from 'teleport/services/integrations';
 
 import { ActivityTab } from './ActivityTab';
-import { SettingsTab } from './SettingsTab';
-import { SmallTab, SmallTabsContainer } from './SmallTabs';
 
 export function formatRelativeDate(value?: string | Date): string {
   if (!value) {
@@ -77,18 +62,10 @@ export function formatRelativeDate(value?: string | Date): string {
     return displayDateTime(date);
   }
 }
-type TabId = 'overview' | 'activity' | 'settings';
-
-const TABS = [
-  { id: 'overview', label: 'Overview' },
-  { id: 'activity', label: 'Issues' },
-  { id: 'settings', label: 'Settings' },
-] as const;
-
 const OVERDUE_REFETCH_INTERVAL_MS = 10 * 1000;
 
 export function IaCIntegrationOverview() {
-  const { name } = useParams<{ name: string }>();
+  const { name, type } = useParams<{ name: string; type: string }>();
 
   const {
     data: stats,
@@ -102,9 +79,6 @@ export function IaCIntegrationOverview() {
     refetchInterval: query => getStatsRefetchIntervalMs(query.state.data),
   });
 
-  const [activeTab, setActiveTab] = useState<TabId>('overview');
-  const { activeInfoGuideTab, setActiveInfoGuideTab } = useTerraformInfoGuide();
-  const { borderRef, parentRef } = useSlidingBottomBorderTabs({ activeTab });
   useNoMinWidth();
 
   if (isLoading) {
@@ -125,92 +99,50 @@ export function IaCIntegrationOverview() {
     );
   }
 
-  const isPanelOpen = activeTab === 'settings' && !!activeInfoGuideTab;
+  const settingsPath = cfg.getIaCIntegrationSettingsRoute(
+    type as IntegrationKind,
+    name
+  );
+
+  const roleArn = stats.awsoidc?.roleArn;
 
   return (
     <FeatureBox maxWidth="1400px" pt={3}>
-      <ContentWithSidePanel isPanelOpen={isPanelOpen}>
-        <Flex alignItems="center" justifyContent="space-between" mb={3}>
-          <Flex alignItems="center">
-            <HoverTooltip placement="bottom" tipContent="Back to Integrations">
-              <ButtonIcon as={RouterLink} to={cfg.routes.integrations} mr={2}>
-                <ArrowLeft size="medium" />
-              </ButtonIcon>
-            </HoverTooltip>
-            <Text bold fontSize={6} mr={2}>
+      <Flex alignItems="center" justifyContent="space-between" mb={4}>
+        <Flex alignItems="center">
+          <HoverTooltip placement="bottom" tipContent="Back to Integrations">
+            <ButtonIcon as={RouterLink} to={cfg.routes.integrations} mr={2}>
+              <ArrowLeft size="medium" />
+            </ButtonIcon>
+          </HoverTooltip>
+          <Flex flexDirection="column">
+            <Text bold fontSize={6}>
               {stats.name}
             </Text>
+            {roleArn && (
+              <Text typography="body3" color="text.slightlyMuted">
+                {roleArn}
+              </Text>
+            )}
           </Flex>
-          {activeTab === 'settings' && (
-            <InfoGuideSwitch
-              isPanelOpen={isPanelOpen}
-              activeTab={activeInfoGuideTab}
-              onSwitch={setActiveInfoGuideTab}
-            />
-          )}
         </Flex>
-        <SmallTabsContainer ref={parentRef} mb={4}>
-          {TABS.map(t => (
-            <SmallTab
-              key={t.id}
-              data-tab-id={t.id}
-              selected={activeTab === t.id}
-              onClick={() => setActiveTab(t.id)}
-            >
-              {t.label}
-            </SmallTab>
-          ))}
-          <TabBorder ref={borderRef} />
-        </SmallTabsContainer>
+        <ButtonPrimary as={RouterLink} to={settingsPath} size="small">
+          Edit configuration
+        </ButtonPrimary>
+      </Flex>
 
-        {activeTab === 'overview' && (
-          <OverviewTab
-            stats={stats}
-            onViewIssues={() => setActiveTab('activity')}
-          />
-        )}
-        {activeTab === 'activity' && <ActivityTab stats={stats} />}
-        {activeTab === 'settings' && (
-          <SettingsTab
-            stats={stats}
-            activeInfoGuideTab={activeInfoGuideTab}
-            onInfoGuideTabChange={setActiveInfoGuideTab}
-          />
-        )}
-      </ContentWithSidePanel>
+      <OverviewContent stats={stats} />
     </FeatureBox>
   );
 }
 
-function OverviewTab({
-  stats,
-  onViewIssues,
-}: {
-  stats: IntegrationWithSummary;
-  onViewIssues: () => void;
-}) {
-  return (
-    <Flex flexDirection="column" gap={4}>
-      <IntegrationHealthCard stats={stats} onViewIssues={onViewIssues} />
-      <IssuesCard stats={stats} onViewIssues={onViewIssues} />
-    </Flex>
-  );
-}
-
-function IntegrationHealthCard({
-  stats,
-  onViewIssues,
-}: {
-  stats: IntegrationWithSummary;
-  onViewIssues: () => void;
-}) {
-  const [isConfigOpen, setIsConfigOpen] = useState(false);
+function OverviewContent({ stats }: { stats: IntegrationWithSummary }) {
   const [nowMs, setNowMs] = useState(Date.now);
 
   useEffect(() => {
     const interval = window.setInterval(() => {
       setNowMs(Date.now());
-    }, 1000);
+    }, 30_000);
 
     return () => {
       window.clearInterval(interval);
@@ -218,266 +150,375 @@ function IntegrationHealthCard({
   }, []);
 
   const hasIssues = stats.unresolvedUserTasks > 0;
-  const lastScanDate = latestSyncDate(stats);
-  const lastScanText = formatRelativeDate(lastScanDate);
-  const nextScanText = formatTimeUntilNextScan(lastScanDate, nowMs);
-  const configDetails = getIntegrationConfigDetails(stats);
+  const isAzure = stats.subKind === IntegrationKind.AzureOidc;
 
+  return (
+    <Flex flexDirection="column" gap={4}>
+      <CardsContainer>
+        {isAzure ? (
+          <ResourceTypeCard
+            resourceType="azurevm"
+            summary={stats.azurevm}
+            nowMs={nowMs}
+          />
+        ) : (
+          <>
+            <ResourceTypeCard
+              resourceType="ec2"
+              summary={stats.awsec2}
+              nowMs={nowMs}
+            />
+            <ResourceTypeCard
+              resourceType="rds"
+              summary={stats.awsrds}
+              nowMs={nowMs}
+            />
+            <ResourceTypeCard
+              resourceType="eks"
+              summary={stats.awseks}
+              nowMs={nowMs}
+            />
+          </>
+        )}
+      </CardsContainer>
+      <IntegrationHealthCard stats={stats} hasIssues={hasIssues} />
+    </Flex>
+  );
+}
+
+function IntegrationHealthCard({
+  stats,
+  hasIssues,
+}: {
+  stats: IntegrationWithSummary;
+  hasIssues: boolean;
+}) {
   return (
     <Card p={4}>
       <Flex alignItems="center" justifyContent="space-between" mb={3}>
         <H2>Integration Health</H2>
       </Flex>
 
-      <Flex flexDirection="column" gap={2}>
-        <StatusRow label="Status:">
-          <Flex alignItems="center" gap={2} flexWrap="wrap">
-            <SummaryStatusLabel summary={stats} />
-            {hasIssues && (
-              <>
-                <Text typography="body3">
-                  ({stats.unresolvedUserTasks}{' '}
-                  {pluralize(stats.unresolvedUserTasks, 'Issue')} detected)
-                </Text>
-                <ButtonText
-                  intent="primary"
-                  size="small"
-                  onClick={onViewIssues}
-                >
-                  <Flex alignItems="center" gap={1}>
-                    View Issues <ArrowRight color="text.brand" size={16} />
-                  </Flex>
-                </ButtonText>
-              </>
-            )}
+      <Flex alignItems="center" gap={2} mb={hasIssues ? 4 : 0}>
+        <Text typography="body2">Status:</Text>
+        {hasIssues ? (
+          <Flex alignItems="center" gap={2}>
+            <StatusBadge kind="warning" variant="filled-tonal">
+              Needs review
+            </StatusBadge>
+            <StatusBadge kind="danger" variant="filled-tonal">
+              {stats.unresolvedUserTasks}{' '}
+              {pluralize(stats.unresolvedUserTasks, 'issue')} detected
+            </StatusBadge>
           </Flex>
-        </StatusRow>
-
-        <StatusRow label="Last verified:">
-          <Flex alignItems="center" gap={2} flexWrap="wrap">
-            <Text typography="body3">{lastScanText}</Text>
-            {lastScanDate && nextScanText && (
-              <Text typography="body3" color="text.slightlyMuted">
-                {nextScanText}
-              </Text>
-            )}
+        ) : (
+          <Flex alignItems="center" gap={2}>
+            <StatusBadge kind="success" variant="filled-tonal">
+              Healthy
+            </StatusBadge>
+            <Text typography="body3" color="text.slightlyMuted">
+              No issues detected
+            </Text>
           </Flex>
-        </StatusRow>
-
-        <StatusRow label="Resources:">
-          <Text typography="body3">{formatResourceCounts(stats)}</Text>
-        </StatusRow>
+        )}
       </Flex>
 
-      <Box mt={3} ml={-2}>
-        <Flex
-          alignItems="center"
-          onClick={() => setIsConfigOpen(v => !v)}
-          role="button"
-          tabIndex={0}
-          style={{ cursor: 'pointer' }}
-        >
-          <ButtonIcon
-            aria-label={
-              isConfigOpen
-                ? 'Collapse configuration details'
-                : 'Expand configuration details'
-            }
-            onClick={e => {
-              e.stopPropagation();
-              setIsConfigOpen(v => !v);
-            }}
-          >
-            <ChevronRight
-              size={16}
-              style={{
-                // point right for closed, down for open
-                transform: isConfigOpen ? 'rotate(90deg)' : undefined,
-                transition: 'transform 150ms ease',
-              }}
-            />
-          </ButtonIcon>
-          <Text typography="body3">Configuration details</Text>
-        </Flex>
-
-        {isConfigOpen && (
-          <Box mt={1} ml={5}>
-            {configDetails.map(detail => (
-              <KeyValue
-                key={`${detail.label}-${detail.value}`}
-                label={detail.label}
-                value={detail.value}
-              />
-            ))}
-            <KeyValue label="Last scan:" value={lastScanText} />
-          </Box>
-        )}
-      </Box>
+      {hasIssues && <ActivityTab stats={stats} />}
     </Card>
   );
 }
 
-function IssuesCard({
-  stats,
-  onViewIssues,
+type ResourceType = 'ec2' | 'rds' | 'eks' | 'azurevm';
+
+const RESOURCE_TYPE_CONFIG: Record<
+  ResourceType,
+  { icon: ResourceIconName; label: string; instanceLabel: string }
+> = {
+  ec2: {
+    icon: 'awsec2',
+    label: 'EC2 Discovered Instances',
+    instanceLabel: 'instances',
+  },
+  rds: {
+    icon: 'awsrds',
+    label: 'RDS Discovered Instances',
+    instanceLabel: 'instances',
+  },
+  azurevm: {
+    icon: 'azure',
+    label: 'Azure Discovered VMs',
+    instanceLabel: 'VMs',
+  },
+  eks: {
+    icon: 'eks',
+    label: 'EKS Discovered Clusters',
+    instanceLabel: 'clusters',
+  },
+};
+
+function getResourceScanState(
+  summary: ResourceTypeSummary | undefined
+): ScanState {
+  if (!summary) {
+    return { state: 'waiting' };
+  }
+
+  // Check for valid dates - protobuf zero timestamps convert to Unix epoch (1970)
+  const parsedStart = summary.syncStart ? new Date(summary.syncStart) : null;
+  const parsedEnd = summary.syncEnd ? new Date(summary.syncEnd) : null;
+  const syncStart = parsedStart?.getTime() > 0 ? parsedStart : null;
+  const syncEnd = parsedEnd?.getTime() > 0 ? parsedEnd : null;
+
+  if (!syncStart) {
+    return { state: 'waiting' };
+  }
+
+  if (!syncEnd) {
+    return { state: 'scanning', startedAt: syncStart };
+  }
+
+  const pollIntervalMs = (summary.pollIntervalSeconds || 0) * 1000;
+  const nextScanAt = new Date(syncEnd.getTime() + pollIntervalMs);
+  return { state: 'completed', lastScan: syncEnd, nextScanAt };
+}
+
+function ResourceTypeCard({
+  resourceType,
+  summary,
+  nowMs,
 }: {
-  stats: IntegrationWithSummary;
-  onViewIssues: () => void;
+  resourceType: ResourceType;
+  summary: ResourceTypeSummary | undefined;
+  nowMs: number;
 }) {
-  const issueCount = stats.unresolvedUserTasks;
-  const issues = stats.userTasks ?? [];
+  const config = RESOURCE_TYPE_CONFIG[resourceType];
+  const isConfigured = summary && summary.rulesCount > 0;
+  const scanState = getResourceScanState(summary);
+
+  if (!isConfigured) {
+    return (
+      <ResourceCard style={{ opacity: 0.6 }}>
+        <Flex alignItems="center" gap={2} mb={3}>
+          <ResourceIcon name={config.icon} size={24} />
+          <Text bold typography="body1">
+            {config.label}
+          </Text>
+        </Flex>
+        <Flex
+          flex="1"
+          alignItems="center"
+          justifyContent="center"
+          color="text.muted"
+        >
+          <Text typography="body3">
+            {resourceType.toUpperCase()} not configured.
+          </Text>
+        </Flex>
+      </ResourceCard>
+    );
+  }
+
+  const discovered = summary.resourcesFound || 0;
+  const enrolled = summary.resourcesEnrollmentSuccess || 0;
+  const enrollmentPercent = discovered > 0 ? (enrolled / discovered) * 100 : 0;
+  const isFullyEnrolled = discovered > 0 && enrolled === discovered;
+
+  const renderScanBadge = () => {
+    switch (scanState.state) {
+      case 'waiting':
+        return null;
+      case 'scanning':
+        return (
+          <StatusBadge
+            kind="info"
+            variant="filled-tonal"
+            icon={SpinningSyncIcon}
+          >
+            Rescanning now...
+          </StatusBadge>
+        );
+      case 'completed': {
+        const remainingMs = scanState.nextScanAt.getTime() - nowMs;
+        if (remainingMs > 0) {
+          return (
+            <Flex alignItems="center" gap={1} color="text.slightlyMuted">
+              <Clock size="small" />
+              <Text typography="body3">
+                Next scan in{' '}
+                {formatDistanceStrict(0, remainingMs, {
+                  unit: 'minute',
+                  roundingMethod: 'ceil',
+                })}
+              </Text>
+            </Flex>
+          );
+        }
+        // Countdown expired, show rescanning state while waiting for backend to confirm
+        return (
+          <StatusBadge
+            kind="info"
+            variant="filled-tonal"
+            icon={SpinningSyncIcon}
+          >
+            Rescanning now...
+          </StatusBadge>
+        );
+      }
+    }
+  };
 
   return (
-    <Card p={4}>
+    <ResourceCard>
       <Flex alignItems="center" justifyContent="space-between" mb={3}>
         <Flex alignItems="center" gap={2}>
-          <Warning size={18} color="text.slightlyMuted" />
-          <H2>Issues ({issueCount})</H2>
+          <ResourceIcon name={config.icon} size={24} />
+          <Text bold typography="body1">
+            {config.label}
+          </Text>
         </Flex>
-        {issueCount > 0 && (
-          <ButtonPrimaryBorder size="small" onClick={onViewIssues}>
-            View Issues
-          </ButtonPrimaryBorder>
+        {renderScanBadge()}
+      </Flex>
+
+      <CardDivider />
+
+      <Text fontSize={6} bold mb={1} mt={3}>
+        {discovered}
+      </Text>
+      <Text typography="body3" color="text.slightlyMuted" mb={3}>
+        Discovered {config.instanceLabel}
+      </Text>
+
+      <Flex alignItems="center" gap={2} mb={2}>
+        {isFullyEnrolled && <CircleCheck size="small" color="success.main" />}
+        <Text typography="body3">
+          {Math.round(enrollmentPercent)}% enrolled ({enrolled} of {discovered})
+        </Text>
+      </Flex>
+
+      <ProgressBar>
+        <ProgressFill
+          $percent={enrollmentPercent}
+          $isComplete={isFullyEnrolled}
+        />
+      </ProgressBar>
+
+      {scanState.state === 'completed' &&
+        scanState.nextScanAt.getTime() - nowMs > 0 && (
+          <Text typography="body3" color="text.slightlyMuted" mt={2}>
+            Last scan {formatRelativeDate(scanState.lastScan)}
+          </Text>
         )}
-      </Flex>
-
-      <Flex flexDirection="column" gap={2}>
-        {issues.map(issue => (
-          <IssueItem key={issue.name} text={issue.title} />
-        ))}
-      </Flex>
-    </Card>
+    </ResourceCard>
   );
 }
 
-function StatusRow(props: { label: string; children: ReactNode }) {
-  return (
-    <Flex gap={2} flexWrap="wrap" alignItems="center">
-      <Text typography="body2">{props.label}</Text>
-      {props.children}
-    </Flex>
-  );
-}
+const CardsContainer = styled.div`
+  display: flex;
+  gap: ${props => props.theme.space[3]}px;
 
-function KeyValue(props: { label: string; value: string }) {
-  return (
-    <Flex gap={2} flexWrap="wrap" mb={1}>
-      <Text typography="body3">{props.label}</Text>
-      <Text typography="body3">{props.value}</Text>
-    </Flex>
-  );
-}
+  @media (max-width: 744px) {
+    flex-direction: column;
+  }
+`;
 
-function IssueItem(props: { text: string }) {
-  return (
-    <Flex gap={2} alignItems="flex-start">
-      <Box mt="2px">
-        <CircleCross size={18} color="error.main" />
-      </Box>
-      <Text typography="body3">{props.text}</Text>
-    </Flex>
-  );
-}
+const ResourceCard = styled(Card)`
+  flex: 1;
+  padding: ${props => props.theme.space[3]}px;
+  display: flex;
+  flex-direction: column;
+`;
 
-function getIntegrationConfigDetails(
-  stats: IntegrationWithSummary
-): Array<{ label: string; value: string }> {
-  if (stats.subKind === IntegrationKind.AwsOidc) {
-    const details = [
-      { label: 'Role ARN:', value: stats.awsoidc?.roleArn || '-' },
-      { label: 'Issuer S3 bucket:', value: stats.awsoidc?.issuerS3Bucket },
-      { label: 'Issuer S3 prefix:', value: stats.awsoidc?.issuerS3Prefix },
-      { label: 'Audience:', value: stats.awsoidc?.audience },
-    ];
+const CardDivider = styled.hr`
+  width: 100%;
+  height: 1px;
+  border: none;
+  background-color: ${props => props.theme.colors.interactive.tonal.neutral[0]};
+  margin: 0;
+`;
 
-    return details.filter(detail => detail.value);
+const ProgressBar = styled.div`
+  width: 100%;
+  height: 8px;
+  background-color: ${props => props.theme.colors.levels.sunken};
+  border-radius: 4px;
+  overflow: hidden;
+`;
+
+const ProgressFill = styled.div<{ $percent: number; $isComplete: boolean }>`
+  height: 100%;
+  width: ${props => props.$percent}%;
+  background-color: ${props =>
+    props.$isComplete
+      ? props.theme.colors.success.main
+      : props.theme.colors.info};
+  border-radius: 4px;
+  transition: width 0.3s ease;
+`;
+
+const spin = keyframes`
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
+  }
+`;
+
+const SpinningSyncIcon = styled(SyncAlt)`
+  animation: ${spin} 1s linear infinite;
+`;
+
+type ScanState =
+  | { state: 'waiting' }
+  | { state: 'scanning'; startedAt: Date }
+  | { state: 'completed'; lastScan: Date; nextScanAt: Date };
+
+function getScanState(stats: IntegrationWithSummary): ScanState {
+  const summaries: ResourceTypeSummary[] = [
+    stats.awsec2,
+    stats.awsrds,
+    stats.awseks,
+    stats.azurevm,
+  ].filter(Boolean);
+
+  let latestCompleted: (ScanState & { state: 'completed' }) | null = null;
+  let latestScanning: (ScanState & { state: 'scanning' }) | null = null;
+
+  for (const summary of summaries) {
+    const state = getResourceScanState(summary);
+    if (state.state === 'completed') {
+      if (!latestCompleted || state.lastScan > latestCompleted.lastScan) {
+        latestCompleted = state;
+      }
+    } else if (state.state === 'scanning') {
+      if (!latestScanning || state.startedAt > latestScanning.startedAt) {
+        latestScanning = state;
+      }
+    }
   }
 
-  if (stats.subKind === IntegrationKind.AwsRa) {
-    const profileSync = stats.awsra?.profileSyncConfig;
-    const details = [
-      { label: 'Trust anchor ARN:', value: stats.awsra?.trustAnchorARN || '-' },
-      {
-        label: 'Profile sync enabled:',
-        value: profileSync ? (profileSync.enabled ? 'Yes' : 'No') : '-',
-      },
-      { label: 'Profile ARN:', value: profileSync?.profileArn },
-      { label: 'Role ARN:', value: profileSync?.roleArn },
-      {
-        label: 'Profile name filters:',
-        value: profileSync?.filters?.length
-          ? profileSync.filters.join(', ')
-          : undefined,
-      },
-    ];
-
-    return details.filter(detail => detail.value);
+  if (latestScanning) {
+    return latestScanning;
   }
 
-  return [];
-}
-
-function formatResourceCounts(stats: IntegrationWithSummary): string {
-  const ec2Count = stats.awsec2?.resourcesFound || 0;
-  const rdsCount = stats.awsrds?.resourcesFound || 0;
-  const eksCount = stats.awseks?.resourcesFound || 0;
-  const azureVmCount = stats.azurevm?.resourcesFound || 0;
-  const total = ec2Count + rdsCount + eksCount + azureVmCount;
-
-  if (total === 0) {
-    return 'No resources discovered';
+  if (latestCompleted) {
+    return latestCompleted;
   }
 
-  const parts: string[] = [];
-  if (ec2Count > 0) {
-    parts.push(`EC2: ${ec2Count}`);
-  }
-  if (rdsCount > 0) {
-    parts.push(`RDS: ${rdsCount}`);
-  }
-  if (eksCount > 0) {
-    parts.push(`EKS: ${eksCount}`);
-  }
-  if (azureVmCount > 0) {
-    parts.push(`Azure VMs: ${azureVmCount}`);
-  }
-
-  return `${total} Discovered (${parts.join(', ')})`;
-}
-
-function formatTimeUntilNextScan(
-  lastScanDate: Date | undefined,
-  nowMs: number
-): string {
-  if (!lastScanDate) {
-    return '';
-  }
-
-  const nextScanAt =
-    lastScanDate.getTime() + INTEGRATION_DISCOVERY_SCAN_INTERVAL_MS;
-  const remainingMs = nextScanAt - nowMs;
-
-  if (remainingMs <= 0) {
-    return '';
-  }
-
-  return `Next scan expected in ${formatDistanceStrict(0, remainingMs, {
-    unit: 'minute',
-    roundingMethod: 'ceil',
-  })}`;
+  return { state: 'waiting' };
 }
 
 function getStatsRefetchIntervalMs(stats: IntegrationWithSummary | undefined) {
-  const lastScanDate = stats ? latestSyncDate(stats) : undefined;
-
-  if (!lastScanDate) {
+  if (!stats) {
     return OVERDUE_REFETCH_INTERVAL_MS;
   }
 
-  const remainingMs =
-    lastScanDate.getTime() +
-    INTEGRATION_DISCOVERY_SCAN_INTERVAL_MS -
-    Date.now();
+  const scanState = getScanState(stats);
 
+  if (scanState.state !== 'completed') {
+    return OVERDUE_REFETCH_INTERVAL_MS;
+  }
+
+  const remainingMs = scanState.nextScanAt.getTime() - Date.now();
   return remainingMs <= 0 ? OVERDUE_REFETCH_INTERVAL_MS : remainingMs;
 }

--- a/web/packages/teleport/src/Discover/Overview/IaCIntegrationSettings.tsx
+++ b/web/packages/teleport/src/Discover/Overview/IaCIntegrationSettings.tsx
@@ -1,0 +1,116 @@
+/**
+ * Teleport
+ * Copyright (C) 2026 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { useQuery } from '@tanstack/react-query';
+import { useParams } from 'react-router';
+import { Link as RouterLink } from 'react-router-dom';
+
+import { Flex, Indicator, Text } from 'design';
+import { Danger } from 'design/Alert';
+import ButtonIcon from 'design/ButtonIcon';
+import { ArrowLeft } from 'design/Icon';
+import { HoverTooltip } from 'design/Tooltip';
+
+import { FeatureBox } from 'teleport/components/Layout';
+import cfg from 'teleport/config';
+import {
+  ContentWithSidePanel,
+  InfoGuideSwitch,
+  useTerraformInfoGuide,
+} from 'teleport/Integrations/Enroll/Cloud/Shared/InfoGuide';
+import { useNoMinWidth } from 'teleport/Main';
+import {
+  IntegrationKind,
+  integrationService,
+  IntegrationWithSummary,
+} from 'teleport/services/integrations';
+
+import { SettingsTab } from './SettingsTab';
+
+export function IaCIntegrationSettings() {
+  const { name, type } = useParams<{ name: string; type: string }>();
+
+  const {
+    data: stats,
+    error,
+    isLoading,
+    isError,
+  } = useQuery<IntegrationWithSummary>({
+    queryKey: ['integrationStats', name],
+    queryFn: () => integrationService.fetchIntegrationStats(name),
+    enabled: !!name,
+  });
+
+  const { activeInfoGuideTab, setActiveInfoGuideTab } = useTerraformInfoGuide();
+  useNoMinWidth();
+
+  const overviewPath = cfg.getIaCIntegrationRoute(
+    type as IntegrationKind,
+    name
+  );
+
+  if (isLoading) {
+    return (
+      <FeatureBox pt={3}>
+        <Flex justifyContent="center" mt={6}>
+          <Indicator delay="long" />
+        </Flex>
+      </FeatureBox>
+    );
+  }
+
+  if (isError) {
+    return (
+      <FeatureBox maxWidth="1400px" pt={3}>
+        <Danger>{error?.message || 'Failed to load integration stats'}</Danger>
+      </FeatureBox>
+    );
+  }
+
+  const isPanelOpen = !!activeInfoGuideTab;
+
+  return (
+    <FeatureBox maxWidth="1400px" pt={3}>
+      <ContentWithSidePanel isPanelOpen={isPanelOpen}>
+        <Flex alignItems="center" justifyContent="space-between" mb={3}>
+          <Flex alignItems="center">
+            <HoverTooltip placement="bottom" tipContent="Back to Overview">
+              <ButtonIcon as={RouterLink} to={overviewPath} mr={2}>
+                <ArrowLeft size="medium" />
+              </ButtonIcon>
+            </HoverTooltip>
+            <Text bold fontSize={6} mr={2}>
+              {stats.name}: Edit configuration
+            </Text>
+          </Flex>
+          <InfoGuideSwitch
+            isPanelOpen={isPanelOpen}
+            activeTab={activeInfoGuideTab}
+            onSwitch={setActiveInfoGuideTab}
+          />
+        </Flex>
+
+        <SettingsTab
+          stats={stats}
+          activeInfoGuideTab={activeInfoGuideTab}
+          onInfoGuideTabChange={setActiveInfoGuideTab}
+        />
+      </ContentWithSidePanel>
+    </FeatureBox>
+  );
+}

--- a/web/packages/teleport/src/config.ts
+++ b/web/packages/teleport/src/config.ts
@@ -235,6 +235,8 @@ const cfg = {
     browserMfa: `/web/mfa/browser/:requestId?`,
     integrations: '/web/integrations',
     integrationOverview: '/web/integrations/overview/:type/:name',
+    integrationOverviewSettings:
+      '/web/integrations/overview/:type/:name/settings',
     integrationStatus: '/web/integrations/status/:type/:name/:subPage?',
     integrationTasks: '/web/integrations/status/:type/:name/tasks',
     integrationStatusResources:
@@ -803,6 +805,13 @@ const cfg = {
 
   getIaCIntegrationRoute(type: PluginKind | IntegrationKind, name: string) {
     return generatePath(cfg.routes.integrationOverview, { type, name });
+  },
+
+  getIaCIntegrationSettingsRoute(
+    type: PluginKind | IntegrationKind,
+    name: string
+  ) {
+    return generatePath(cfg.routes.integrationOverviewSettings, { type, name });
   },
 
   getIntegrationStatusResourcesRoute(

--- a/web/packages/teleport/src/features.tsx
+++ b/web/packages/teleport/src/features.tsx
@@ -44,6 +44,7 @@ import {
 import { IntegrationEnroll } from '@gravitational/teleport/src/Integrations/Enroll';
 import cfg, { Cfg } from 'teleport/config';
 import { IaCIntegrationOverview } from 'teleport/Discover/Overview/IaCIntegrationOverview';
+import { IaCIntegrationSettings } from 'teleport/Discover/Overview/IaCIntegrationSettings';
 import { IntegrationStatus } from 'teleport/Integrations/IntegrationStatus';
 import {
   NavigationCategory,
@@ -865,7 +866,22 @@ export class FeatureIntegrationOverview implements TeleportFeature {
   route = {
     title: 'Integration Overview',
     path: cfg.routes.integrationOverview,
+    exact: true,
     component: IaCIntegrationOverview,
+  };
+
+  hasAccess() {
+    return true;
+  }
+}
+
+export class FeatureIntegrationOverviewSettings implements TeleportFeature {
+  parent = FeatureIntegrations;
+
+  route = {
+    title: 'Integration Settings',
+    path: cfg.routes.integrationOverviewSettings,
+    component: IaCIntegrationSettings,
   };
 
   hasAccess() {
@@ -961,6 +977,7 @@ export function getOSSFeatures(): TeleportFeature[] {
     new FeatureTrust(),
     new FeatureIntegrationStatus(),
     new FeatureIntegrationOverview(),
+    new FeatureIntegrationOverviewSettings(),
 
     // - Identity
     new AccessRequests(),

--- a/web/packages/teleport/src/services/integrations/types.ts
+++ b/web/packages/teleport/src/services/integrations/types.ts
@@ -855,6 +855,12 @@ export type ResourceTypeSummary = {
   resourcesEnrollmentSuccess: number;
   // discoverLastSync contains the time when this integration tried to auto-enroll resources.
   discoverLastSync: number;
+  // syncStart is when the current or most recent discovery scan started.
+  syncStart?: string;
+  // syncEnd is when the most recent discovery scan ended.
+  syncEnd?: string;
+  // pollIntervalSeconds is the interval in seconds between discovery scans.
+  pollIntervalSeconds?: number;
   // unresolvedUserTasks contains the count of unresolved user tasks related to this integration and resource type.
   unresolvedUserTasks?: number;
   // ecsDatabaseServiceCount is the total number of DatabaseServices that were deployed into Amazon ECS.


### PR DESCRIPTION
We can now track individual configurations and per-server status for discovery, so this updates the overview page with that information. https://github.com/gravitational/teleport/pull/64956 https://github.com/gravitational/teleport/pull/65233

some slight manual tweaks because v18 is still on react-router v5


## Manual Test Plan
### Test Environment
local + cloud

### Test Cases
- [x] Ensure integrations for each type of ec2, eks, rds, azureVM properly show their cards
- [x] Ensure that the integrations properly "count down" and show when an integration is scanning
- [x] The "edit configuration" button works and goes to the settings page   
