### PR TITLE
[v18] Add page_type and outcome statements to 46 guides

### DIFF
--- a/docs/pages/enroll-resources/database-access/auto-user-provisioning/aws-redshift.mdx
+++ b/docs/pages/enroll-resources/database-access/auto-user-provisioning/aws-redshift.mdx
@@ -7,11 +7,12 @@ tags:
  - zero-trust
  - infrastructure-identity
  - aws
+page_type: how-to
 ---
 
-{/* lint disable page-structure remark-lint */}
-
 (!docs/pages/includes/database-access/auto-user-provisioning/intro.mdx!)
+
+{/* lint ignore page-structure remark-lint */}
 
 ## Prerequisites
 

--- a/docs/pages/enroll-resources/database-access/auto-user-provisioning/mariadb.mdx
+++ b/docs/pages/enroll-resources/database-access/auto-user-provisioning/mariadb.mdx
@@ -6,6 +6,7 @@ tags:
  - how-to
  - zero-trust
  - infrastructure-identity
+page_type: how-to
 ---
 
 {/* lint disable page-structure remark-lint */}

--- a/docs/pages/enroll-resources/database-access/auto-user-provisioning/mongodb.mdx
+++ b/docs/pages/enroll-resources/database-access/auto-user-provisioning/mongodb.mdx
@@ -6,6 +6,7 @@ tags:
  - how-to
  - zero-trust
  - infrastructure-identity
+page_type: how-to
 ---
 
 {/* lint disable page-structure remark-lint */}

--- a/docs/pages/enroll-resources/database-access/auto-user-provisioning/postgres.mdx
+++ b/docs/pages/enroll-resources/database-access/auto-user-provisioning/postgres.mdx
@@ -6,6 +6,7 @@ tags:
  - how-to
  - zero-trust
  - infrastructure-identity
+page_type: how-to
 ---
 
 {/* lint disable page-structure remark-lint */}

--- a/docs/pages/enroll-resources/database-access/enrollment/aws/aws-cassandra-keyspaces.mdx
+++ b/docs/pages/enroll-resources/database-access/enrollment/aws/aws-cassandra-keyspaces.mdx
@@ -7,6 +7,7 @@ tags:
  - zero-trust
  - infrastructure-identity
  - aws
+page_type: how-to
 ---
 
 (!docs/pages/includes/database-access/db-introduction.mdx dbType="Amazon Keyspaces (Apache Cassandra)" dbConfigure="with IAM authentication"!)

--- a/docs/pages/enroll-resources/database-access/enrollment/aws/aws-docdb.mdx
+++ b/docs/pages/enroll-resources/database-access/enrollment/aws/aws-docdb.mdx
@@ -7,6 +7,7 @@ tags:
  - zero-trust
  - infrastructure-identity
  - aws
+page_type: how-to
 ---
 
 (!docs/pages/includes/database-access/db-introduction.mdx dbType="Amazon DocumentDB" dbConfigure="with IAM authentication"!)

--- a/docs/pages/enroll-resources/database-access/enrollment/aws/aws-dynamodb.mdx
+++ b/docs/pages/enroll-resources/database-access/enrollment/aws/aws-dynamodb.mdx
@@ -7,6 +7,7 @@ tags:
  - zero-trust
  - infrastructure-identity
  - aws
+page_type: how-to
 ---
 
 (!docs/pages/includes/database-access/db-introduction.mdx dbType="Amazon DynamoDB" dbConfigure="with IAM authentication"!)

--- a/docs/pages/enroll-resources/database-access/enrollment/aws/aws-memorydb.mdx
+++ b/docs/pages/enroll-resources/database-access/enrollment/aws/aws-memorydb.mdx
@@ -7,6 +7,7 @@ tags:
  - zero-trust
  - infrastructure-identity
  - aws
+page_type: how-to
 ---
 
 (!docs/pages/includes/database-access/db-introduction.mdx dbType="Amazon MemoryDB for Redis and Valkey" dbConfigure="with IAM authentication"!)

--- a/docs/pages/enroll-resources/database-access/enrollment/aws/aws-opensearch.mdx
+++ b/docs/pages/enroll-resources/database-access/enrollment/aws/aws-opensearch.mdx
@@ -7,6 +7,7 @@ tags:
  - zero-trust
  - infrastructure-identity
  - aws
+page_type: how-to
 ---
 
 (!docs/pages/includes/database-access/db-introduction.mdx dbType="Amazon OpenSearch" dbConfigure="via REST API with IAM Authentication"!)

--- a/docs/pages/enroll-resources/database-access/enrollment/aws/elasticache-serverless.mdx
+++ b/docs/pages/enroll-resources/database-access/enrollment/aws/elasticache-serverless.mdx
@@ -5,6 +5,7 @@ description: How to configure Teleport database access with Amazon ElastiCache S
 tags:
  - how-to
  - zero-trust
+page_type: how-to
 ---
 
 (!docs/pages/includes/database-access/db-introduction.mdx dbType="Amazon ElastiCache Serverless" dbConfigure="with IAM authentication"!)

--- a/docs/pages/enroll-resources/database-access/enrollment/aws/postgres-redshift.mdx
+++ b/docs/pages/enroll-resources/database-access/enrollment/aws/postgres-redshift.mdx
@@ -8,6 +8,7 @@ tags:
  - zero-trust
  - infrastructure-identity
  - aws
+page_type: how-to
 ---
 
 (!docs/pages/includes/database-access/db-introduction.mdx dbType="Amazon Redshift" dbConfigure="with IAM authentication"!)

--- a/docs/pages/enroll-resources/database-access/enrollment/aws/rds/mysql-postgres-mariadb.mdx
+++ b/docs/pages/enroll-resources/database-access/enrollment/aws/rds/mysql-postgres-mariadb.mdx
@@ -7,6 +7,7 @@ tags:
  - zero-trust
  - infrastructure-identity
  - aws
+page_type: how-to
 ---
 
 (!docs/pages/includes/database-access/db-introduction.mdx dbType="Amazon RDS or Aurora" dbConfigure="with IAM authentication"!)

--- a/docs/pages/enroll-resources/database-access/enrollment/aws/rds/rds-oracle.mdx
+++ b/docs/pages/enroll-resources/database-access/enrollment/aws/rds/rds-oracle.mdx
@@ -7,6 +7,7 @@ tags:
  - zero-trust
  - infrastructure-identity
  - aws
+page_type: how-to
 ---
 
 (!docs/pages/includes/database-access/db-introduction.mdx dbType="Amazon RDS for Oracle" dbConfigure="with Kerberos authentication"!)

--- a/docs/pages/enroll-resources/database-access/enrollment/aws/rds/sql-server-ad.mdx
+++ b/docs/pages/enroll-resources/database-access/enrollment/aws/rds/sql-server-ad.mdx
@@ -8,6 +8,7 @@ tags:
  - zero-trust
  - infrastructure-identity
  - aws
+page_type: how-to
 ---
 
 (!docs/pages/includes/database-access/db-introduction.mdx dbType="Microsoft SQL Server" dbConfigure="with Active Directory authentication"!)

--- a/docs/pages/enroll-resources/database-access/enrollment/aws/redis-aws.mdx
+++ b/docs/pages/enroll-resources/database-access/enrollment/aws/redis-aws.mdx
@@ -7,6 +7,7 @@ tags:
  - zero-trust
  - infrastructure-identity
  - aws
+page_type: how-to
 ---
 
 (!docs/pages/includes/database-access/db-introduction.mdx dbType="Amazon ElastiCache" dbConfigure="with IAM authentication"!)

--- a/docs/pages/enroll-resources/database-access/enrollment/aws/redshift-serverless.mdx
+++ b/docs/pages/enroll-resources/database-access/enrollment/aws/redshift-serverless.mdx
@@ -7,6 +7,7 @@ tags:
  - zero-trust
  - infrastructure-identity
  - aws
+page_type: how-to
 ---
 
 (!docs/pages/includes/database-access/db-introduction.mdx dbType="Amazon Redshift Serverless" dbConfigure="with IAM authentication"!)

--- a/docs/pages/enroll-resources/database-access/enrollment/azure/azure-postgres-mysql.mdx
+++ b/docs/pages/enroll-resources/database-access/enrollment/azure/azure-postgres-mysql.mdx
@@ -7,6 +7,7 @@ tags:
  - zero-trust
  - infrastructure-identity
  - azure
+page_type: how-to
 ---
 
 (!docs/pages/includes/database-access/db-introduction.mdx dbType="Azure PostgreSQL or MySQL" dbConfigure="with Microsoft Entra ID-based authentication"!)

--- a/docs/pages/enroll-resources/database-access/enrollment/azure/azure-redis.mdx
+++ b/docs/pages/enroll-resources/database-access/enrollment/azure/azure-redis.mdx
@@ -7,6 +7,7 @@ tags:
  - zero-trust
  - infrastructure-identity
  - azure
+page_type: how-to
 ---
 
 (!docs/pages/includes/database-access/db-introduction.mdx dbType="Azure Cache for Redis" dbConfigure="with Microsoft Entra ID-based authentication"!)

--- a/docs/pages/enroll-resources/database-access/enrollment/azure/azure-sql-server-ad.mdx
+++ b/docs/pages/enroll-resources/database-access/enrollment/azure/azure-sql-server-ad.mdx
@@ -7,6 +7,7 @@ tags:
  - zero-trust
  - infrastructure-identity
  - azure
+page_type: how-to
 ---
 
 (!docs/pages/includes/database-access/db-introduction.mdx dbType="Azure SQL Server" dbConfigure="with Microsoft Entra ID-based authentication"!)

--- a/docs/pages/enroll-resources/database-access/enrollment/google-cloud/alloydb.mdx
+++ b/docs/pages/enroll-resources/database-access/enrollment/google-cloud/alloydb.mdx
@@ -7,6 +7,7 @@ tags:
  - zero-trust
  - infrastructure-identity
  - google-cloud
+page_type: how-to
 ---
 
 (!docs/pages/includes/database-access/db-introduction.mdx dbType="AlloyDB" dbConfigure="with a service account"!)

--- a/docs/pages/enroll-resources/database-access/enrollment/google-cloud/mysql-cloudsql.mdx
+++ b/docs/pages/enroll-resources/database-access/enrollment/google-cloud/mysql-cloudsql.mdx
@@ -7,6 +7,7 @@ tags:
  - zero-trust
  - infrastructure-identity
  - google-cloud
+page_type: how-to
 ---
 
 (!docs/pages/includes/database-access/db-introduction.mdx dbType="MySQL on Google Cloud SQL" dbConfigure="with a service account"!)

--- a/docs/pages/enroll-resources/database-access/enrollment/google-cloud/postgres-cloudsql.mdx
+++ b/docs/pages/enroll-resources/database-access/enrollment/google-cloud/postgres-cloudsql.mdx
@@ -8,6 +8,7 @@ tags:
  - zero-trust
  - infrastructure-identity
  - google-cloud
+page_type: how-to
 ---
 
 (!docs/pages/includes/database-access/db-introduction.mdx dbType="PostgreSQL on Google Cloud SQL" dbConfigure="with a service account"!)

--- a/docs/pages/enroll-resources/database-access/enrollment/google-cloud/spanner.mdx
+++ b/docs/pages/enroll-resources/database-access/enrollment/google-cloud/spanner.mdx
@@ -7,6 +7,7 @@ tags:
  - zero-trust
  - infrastructure-identity
  - google-cloud
+page_type: how-to
 ---
 
 (!docs/pages/includes/database-access/db-introduction.mdx dbType="Cloud Spanner" dbConfigure="with a service account"!)

--- a/docs/pages/enroll-resources/database-access/enrollment/managed/mongodb-atlas.mdx
+++ b/docs/pages/enroll-resources/database-access/enrollment/managed/mongodb-atlas.mdx
@@ -7,6 +7,7 @@ tags:
  - how-to
  - zero-trust
  - infrastructure-identity
+page_type: how-to
 ---
 
 (!docs/pages/includes/database-access/db-introduction.mdx dbType="MongoDB Atlas" dbConfigure="with either mutual TLS or AWS IAM authentication"!)

--- a/docs/pages/enroll-resources/database-access/enrollment/managed/oracle-exadata.mdx
+++ b/docs/pages/enroll-resources/database-access/enrollment/managed/oracle-exadata.mdx
@@ -6,6 +6,7 @@ tags:
  - how-to
  - zero-trust
  - infrastructure-identity
+page_type: how-to
 ---
 
 (!docs/pages/includes/database-access/db-introduction.mdx dbType="Oracle Exadata" dbConfigure="with mTLS authentication"!)

--- a/docs/pages/enroll-resources/database-access/enrollment/managed/snowflake.mdx
+++ b/docs/pages/enroll-resources/database-access/enrollment/managed/snowflake.mdx
@@ -6,6 +6,7 @@ tags:
  - how-to
  - zero-trust
  - infrastructure-identity
+page_type: how-to
 ---
 
 (!docs/pages/includes/database-access/db-introduction.mdx dbType="Snowflake" dbConfigure="with key pair authentication"!)

--- a/docs/pages/enroll-resources/database-access/enrollment/self-hosted/cassandra-self-hosted.mdx
+++ b/docs/pages/enroll-resources/database-access/enrollment/self-hosted/cassandra-self-hosted.mdx
@@ -6,6 +6,7 @@ tags:
  - how-to
  - zero-trust
  - infrastructure-identity
+page_type: how-to
 ---
 
 (!docs/pages/includes/database-access/self-hosted-introduction.mdx dbType="Cassandra or ScyllaDB"!)

--- a/docs/pages/enroll-resources/database-access/enrollment/self-hosted/clickhouse-self-hosted.mdx
+++ b/docs/pages/enroll-resources/database-access/enrollment/self-hosted/clickhouse-self-hosted.mdx
@@ -6,14 +6,15 @@ tags:
  - how-to
  - zero-trust
  - infrastructure-identity
+page_type: how-to
 ---
 
 The Teleport Clickhouse integration allows you to enroll ClickHouse databases
 with Teleport.
 
-This guide will help you to:
+In this guide, you will:
 
-- Install and configure a Teleport database agent.
+- Install and configure a Teleport Database Service agent.
 - Set up Teleport to access your self-hosted ClickHouse database.
 - Connect to your database through Teleport.
 

--- a/docs/pages/enroll-resources/database-access/enrollment/self-hosted/cockroachdb-self-hosted.mdx
+++ b/docs/pages/enroll-resources/database-access/enrollment/self-hosted/cockroachdb-self-hosted.mdx
@@ -6,6 +6,7 @@ tags:
  - how-to
  - zero-trust
  - infrastructure-identity
+page_type: how-to
 ---
 
 (!docs/pages/includes/database-access/self-hosted-introduction.mdx dbType="CockroachDB"!)

--- a/docs/pages/enroll-resources/database-access/enrollment/self-hosted/elastic.mdx
+++ b/docs/pages/enroll-resources/database-access/enrollment/self-hosted/elastic.mdx
@@ -6,6 +6,7 @@ tags:
  - how-to
  - zero-trust
  - infrastructure-identity
+page_type: how-to
 ---
 
 (!docs/pages/includes/database-access/self-hosted-introduction.mdx dbType="Elasticsearch"!)

--- a/docs/pages/enroll-resources/database-access/enrollment/self-hosted/mongodb-self-hosted.mdx
+++ b/docs/pages/enroll-resources/database-access/enrollment/self-hosted/mongodb-self-hosted.mdx
@@ -7,6 +7,7 @@ tags:
  - how-to
  - zero-trust
  - infrastructure-identity
+page_type: how-to
 ---
 
 (!docs/pages/includes/database-access/self-hosted-introduction.mdx dbType="MongoDB"!)

--- a/docs/pages/enroll-resources/database-access/enrollment/self-hosted/mysql-self-hosted.mdx
+++ b/docs/pages/enroll-resources/database-access/enrollment/self-hosted/mysql-self-hosted.mdx
@@ -6,6 +6,7 @@ tags:
  - how-to
  - zero-trust
  - infrastructure-identity
+page_type: how-to
 ---
 
 (!docs/pages/includes/database-access/self-hosted-introduction.mdx dbType="MySQL or MariaDB"!)

--- a/docs/pages/enroll-resources/database-access/enrollment/self-hosted/oracle-self-hosted.mdx
+++ b/docs/pages/enroll-resources/database-access/enrollment/self-hosted/oracle-self-hosted.mdx
@@ -6,6 +6,7 @@ tags:
  - how-to
  - zero-trust
  - infrastructure-identity
+page_type: how-to
 ---
 
 (!docs/pages/includes/database-access/self-hosted-introduction.mdx dbType="Oracle"!)

--- a/docs/pages/enroll-resources/database-access/enrollment/self-hosted/postgres-self-hosted.mdx
+++ b/docs/pages/enroll-resources/database-access/enrollment/self-hosted/postgres-self-hosted.mdx
@@ -6,6 +6,7 @@ tags:
  - how-to
  - zero-trust
  - infrastructure-identity
+page_type: how-to
 ---
 
 (!docs/pages/includes/database-access/self-hosted-introduction.mdx dbType="PostgreSQL"!)

--- a/docs/pages/enroll-resources/database-access/enrollment/self-hosted/redis-cluster.mdx
+++ b/docs/pages/enroll-resources/database-access/enrollment/self-hosted/redis-cluster.mdx
@@ -6,6 +6,7 @@ tags:
  - how-to
  - zero-trust
  - infrastructure-identity
+page_type: how-to
 ---
 
 {/* vale messaging.protocol-products = NO */}

--- a/docs/pages/enroll-resources/database-access/enrollment/self-hosted/redis.mdx
+++ b/docs/pages/enroll-resources/database-access/enrollment/self-hosted/redis.mdx
@@ -6,6 +6,7 @@ tags:
  - how-to
  - zero-trust
  - infrastructure-identity
+page_type: how-to
 ---
 
 {/* vale messaging.protocol-products = NO */}

--- a/docs/pages/enroll-resources/database-access/enrollment/self-hosted/sql-server-ad-pkinit.mdx
+++ b/docs/pages/enroll-resources/database-access/enrollment/self-hosted/sql-server-ad-pkinit.mdx
@@ -6,6 +6,7 @@ tags:
  - how-to
  - zero-trust
  - infrastructure-identity
+page_type: how-to
 ---
 
 (!docs/pages/includes/database-access/db-introduction.mdx dbType="Microsoft SQL Server" dbConfigure="with PKINIT authentication"!)

--- a/docs/pages/enroll-resources/database-access/enrollment/self-hosted/vitess.mdx
+++ b/docs/pages/enroll-resources/database-access/enrollment/self-hosted/vitess.mdx
@@ -6,6 +6,7 @@ tags:
  - how-to
  - zero-trust
  - infrastructure-identity
+page_type: how-to
 ---
 
 (!docs/pages/includes/database-access/self-hosted-introduction.mdx dbType="Vitess (MySQL)"!)

--- a/docs/pages/enroll-resources/database-access/getting-started.mdx
+++ b/docs/pages/enroll-resources/database-access/getting-started.mdx
@@ -6,6 +6,7 @@ tags:
  - get-started
  - zero-trust
  - infrastructure-identity
+page_type: how-to
 ---
 
 (!docs/pages/includes/database-access/db-introduction.mdx dbType="PostgreSQL Amazon Aurora" dbConfigure="with IAM authentication"!)

--- a/docs/pages/enroll-resources/server-access/guides/auditd.mdx
+++ b/docs/pages/enroll-resources/server-access/guides/auditd.mdx
@@ -6,6 +6,7 @@ tags:
  - how-to
  - zero-trust
  - audit
+page_type: how-to
 ---
 
 {/* lint disable page-structure remark-lint */}

--- a/docs/pages/enroll-resources/server-access/guides/bpf-session-recording.mdx
+++ b/docs/pages/enroll-resources/server-access/guides/bpf-session-recording.mdx
@@ -7,6 +7,7 @@ tags:
  - how-to
  - zero-trust
  - infrastructure-identity
+page_type: how-to
 ---
 
 {/* lint disable page-structure remark-lint */}

--- a/docs/pages/enroll-resources/server-access/guides/encrypted-session-recordings/encrypted-session-recordings.mdx
+++ b/docs/pages/enroll-resources/server-access/guides/encrypted-session-recordings/encrypted-session-recordings.mdx
@@ -6,10 +6,13 @@ tags:
  - how-to
  - zero-trust
  - resiliency
+page_type: how-to
 ---
 
 Encrypted session recordings allow Teleport users to enable at-rest encryption
-of their session recording data. This guide explains how to setup encrypted
+of their session recording data. 
+
+In this guide, you will configure the Teleport Auth Service to enable encrypted
 session recordings.
 
 ## How it works

--- a/docs/pages/enroll-resources/server-access/guides/encrypted-session-recordings/rotating-keys.mdx
+++ b/docs/pages/enroll-resources/server-access/guides/encrypted-session-recordings/rotating-keys.mdx
@@ -7,11 +7,15 @@ tags:
   - how-to
   - zero-trust
   - resiliency
+page_type: how-to
 ---
 
-This guide explains how to rotate encryption keys for session recordings using
-the automatic method. In this approach, the Teleport Auth Service manages the
-selection and labeling of encryption keys for you.
+In the automatic approach for rotating session recording encryption keys, the
+Teleport Auth Service manages the selection and labeling of encryption keys for
+you.
+
+In this guide, you will use the `tctl` admin tool to rotate encryption keys for
+session recordings with the automatic method. 
 
 For instructions on manually rotating encryption keys for session recordings,
 see [Rotating Manual Session Recording Encryption

--- a/docs/pages/enroll-resources/server-access/guides/encrypted-session-recordings/rotating-manual-keys.mdx
+++ b/docs/pages/enroll-resources/server-access/guides/encrypted-session-recordings/rotating-manual-keys.mdx
@@ -7,9 +7,15 @@ tags:
   - how-to
   - zero-trust
   - resiliency
+page_type: how-to
 ---
 
-This guide explains how to rotate encryption keys for session recordings.
+In the manual approach to rotating keys for session recordings, you configure
+the encryption keys that the Teleport Auth Service uses for encrypted session
+recordings.
+
+In this guide, you will perform a single key rotation by configuring the
+Teleport Auth Service.
 
 For instructions on using the automatic approach, see [Rotating Session
 Recording Encryption Keys](rotating-keys.mdx).

--- a/docs/pages/enroll-resources/server-access/guides/host-user-creation.mdx
+++ b/docs/pages/enroll-resources/server-access/guides/host-user-creation.mdx
@@ -6,6 +6,7 @@ tags:
  - how-to
  - zero-trust
  - infrastructure-identity
+page_type: how-to
 ---
 
 Teleport's SSH Service can be configured to automatically create local Unix users
@@ -15,6 +16,17 @@ This saves you from having to manually create users for each member of an
 organization and provides more fine-grained control of permissions on a given
 host. Host users created by Teleport are transient and will be deleted at the
 end of an SSH session.
+
+In this guide, you will:
+- Choose between enabling automatic host user creation, which takes place during
+  an SSH session, and static host user creation, which takes place independently
+  of an SSH session.
+- Configure Teleport roles to enable your chosen host user creation mode.
+- For automatic host user creation, configure your target server to support the
+  created host users.
+- For static host user creation, apply a dynamic Teleport resource that
+  configures the created host user.
+- Test host user creation on a Teleport-protected server.
 
 ## Prerequisites
 

--- a/docs/pages/includes/database-access/auto-user-provisioning/intro.mdx
+++ b/docs/pages/includes/database-access/auto-user-provisioning/intro.mdx
@@ -1,3 +1,10 @@
 Teleport can automatically create users in your database, removing the need for
 creating individual user accounts in advance or using the same set of shared
 database accounts for all users.
+
+In this guide, you will:
+- Configure a database user for the Teleport Database Service that can provision
+  new users on your target database.
+- Configure a Teleport role to enable automatic user provisioning.
+- Connect to your database and verify that the Teleport Database Service has
+  automatically provisioned a user.


### PR DESCRIPTION
Backports #67064

We are standardizing docs guides to add a page_type frontmatter field, with values for how-to guides, references, etc. We can then use this field to apply linting rules that ensure each guide type follows type-specific docs site conventions. The first convention is that each docs page must have an outcome statement, the structure of which depends on the guide's type. Human and AI agent readers can determine from the outcome statement whether to continue reading the guide or not.

This change applies a `page_type` frontmatter field to 46 guides in the `enroll-resources` section of the docs. Most of these guides already include the expected outcome statement. For those that do not, this change adds one:
- Automatic user provisioning introduction partial
- Host user creation
- Encrypted session recording guide
- ClickHouse guide (rewording the existing outcome statement to match the standard structure we are rolling out).
- Automatic session recording key rotation
- Manual session recording key rotation
- macOS launchd guide
