### PR TITLE
[v18] backport dockerfile cent os kaniko compatible

### DIFF
--- a/build.assets/Dockerfile-centos7
+++ b/build.assets/Dockerfile-centos7
@@ -16,6 +16,7 @@ ENV BUILDARCH=${BUILDARCH} \
     DEVTOOLSET=${DEVTOOLSET}
 
 RUN if [ "${BUILDARCH}" = "arm64" ]; then export BUILDARCH="aarch64"; fi && \
+    if [ "${BUILDARCH}" = "amd64" ]; then export BUILDARCH="x86_64"; fi && \
     printf '%s\n' \
       "[${DEVTOOLSET}-build]" \
       "name=${DEVTOOLSET} - Build" \

--- a/build.assets/Dockerfile-centos7
+++ b/build.assets/Dockerfile-centos7
@@ -30,18 +30,6 @@ RUN if [ "${BUILDARCH}" = "arm64" ]; then export BUILDARCH="aarch64"; fi && \
 # Make the fixup a script as it needs to be run multiple times as installing
 # and updating centos-release-scl-rh leaves the old unavailable URLs.
 # https://serverfault.com/a/1161847
-<<<<<<< HEAD
-RUN cat <<EOF > /tmp/fix-yum-repo-list.sh
-#!/bin/sh
-sed -e 's/mirror.centos.org/vault.centos.org/g' \
-    -e 's/^#.*baseurl=http/baseurl=http/g' \
-    -e 's/^mirrorlist=http/#mirrorlist=http/g' \
-    -i /etc/yum.repos.d/*.repo
-if [ "$(uname -m)" = 'aarch64' ]; then
-    sed 's|centos/7/sclo|altarch/7/sclo|' -i /etc/yum.repos.d/*.repo
-fi
-EOF
-=======
 RUN printf '%s\n' \
     '#!/bin/sh' \
     "sed -e 's/mirror.centos.org/vault.centos.org/g' \\" \
@@ -52,7 +40,6 @@ RUN printf '%s\n' \
     "    sed 's|centos/7/sclo|altarch/7/sclo|' -i /etc/yum.repos.d/*.repo" \
     'fi' \
     > /tmp/fix-yum-repo-list.sh
->>>>>>> 1cf13634daf (make CentOS 7 Dockerfiles Kaniko-compatible)
 RUN chmod 755 /tmp/fix-yum-repo-list.sh && \
     /tmp/fix-yum-repo-list.sh
 

--- a/build.assets/Dockerfile-centos7
+++ b/build.assets/Dockerfile-centos7
@@ -16,19 +16,20 @@ ENV BUILDARCH=${BUILDARCH} \
     DEVTOOLSET=${DEVTOOLSET}
 
 RUN if [ "${BUILDARCH}" = "arm64" ]; then export BUILDARCH="aarch64"; fi && \
-    cat <<EOF > /etc/yum.repos.d/${DEVTOOLSET}-build.repo
-[${DEVTOOLSET}-build]
-name=${DEVTOOLSET} - Build
-baseurl=https://buildlogs.centos.org/c7-${DEVTOOLSET}.${BUILDARCH}/
-gpgcheck=0
-enabled=1
-EOF
+    printf '%s\n' \
+      "[${DEVTOOLSET}-build]" \
+      "name=${DEVTOOLSET} - Build" \
+      "baseurl=https://buildlogs.centos.org/c7-${DEVTOOLSET}.${BUILDARCH}/" \
+      "gpgcheck=0" \
+      "enabled=1" \
+      > /etc/yum.repos.d/${DEVTOOLSET}-build.repo
 
 # mirrorlist is no longer available since CentOS 7 EOL. The software collection
 # stuff for arm64 (aarch64) is in /altarch not /centos on vault.centos.org.
 # Make the fixup a script as it needs to be run multiple times as installing
 # and updating centos-release-scl-rh leaves the old unavailable URLs.
 # https://serverfault.com/a/1161847
+<<<<<<< HEAD
 RUN cat <<EOF > /tmp/fix-yum-repo-list.sh
 #!/bin/sh
 sed -e 's/mirror.centos.org/vault.centos.org/g' \
@@ -39,6 +40,18 @@ if [ "$(uname -m)" = 'aarch64' ]; then
     sed 's|centos/7/sclo|altarch/7/sclo|' -i /etc/yum.repos.d/*.repo
 fi
 EOF
+=======
+RUN printf '%s\n' \
+    '#!/bin/sh' \
+    "sed -e 's/mirror.centos.org/vault.centos.org/g' \\" \
+    "    -e 's/^#.*baseurl=http/baseurl=https/g' \\" \
+    "    -e 's/^mirrorlist=http/#mirrorlist=http/g' \\" \
+    "    -i /etc/yum.repos.d/*.repo" \
+    "if [ \"\$(uname -m)\" = 'aarch64' ]; then" \
+    "    sed 's|centos/7/sclo|altarch/7/sclo|' -i /etc/yum.repos.d/*.repo" \
+    'fi' \
+    > /tmp/fix-yum-repo-list.sh
+>>>>>>> 1cf13634daf (make CentOS 7 Dockerfiles Kaniko-compatible)
 RUN chmod 755 /tmp/fix-yum-repo-list.sh && \
     /tmp/fix-yum-repo-list.sh
 
@@ -46,7 +59,7 @@ RUN chmod 755 /tmp/fix-yum-repo-list.sh && \
 RUN yum groupinstall -y 'Development Tools' && \
     yum install -y epel-release && \
     yum install -y centos-release-scl-rh && \
-    /tmp/fix-yum-repo-list.sh \
+    /tmp/fix-yum-repo-list.sh && \
     yum update -y && \
     yum install -y \
       ca-certificates \

--- a/build.assets/Dockerfile-centos7-assets
+++ b/build.assets/Dockerfile-centos7-assets
@@ -8,6 +8,7 @@ ARG DEVTOOLSET
 # devtoolset-12 is only in CentOS buildlogs. The rpms are unsigned since they never were
 # published to the official CentOS SCL repos.
 RUN if [ "${BUILDARCH}" = "arm64" ]; then export BUILDARCH="aarch64"; fi && \
+    if [ "${BUILDARCH}" = "amd64" ]; then export BUILDARCH="x86_64"; fi && \
     printf '%s\n' \
     "[${DEVTOOLSET}-build]" \
     "name=${DEVTOOLSET} - Build" \

--- a/build.assets/Dockerfile-centos7-assets
+++ b/build.assets/Dockerfile-centos7-assets
@@ -8,19 +8,20 @@ ARG DEVTOOLSET
 # devtoolset-12 is only in CentOS buildlogs. The rpms are unsigned since they never were
 # published to the official CentOS SCL repos.
 RUN if [ "${BUILDARCH}" = "arm64" ]; then export BUILDARCH="aarch64"; fi && \
-    cat <<EOF > /etc/yum.repos.d/${DEVTOOLSET}-build.repo
-[${DEVTOOLSET}-build]
-name=${DEVTOOLSET} - Build
-baseurl=https://buildlogs.centos.org/c7-${DEVTOOLSET}.${BUILDARCH}/
-gpgcheck=0
-enabled=1
-EOF
+    printf '%s\n' \
+    "[${DEVTOOLSET}-build]" \
+    "name=${DEVTOOLSET} - Build" \
+    "baseurl=https://buildlogs.centos.org/c7-${DEVTOOLSET}.${BUILDARCH}/" \
+    "gpgcheck=0" \
+    "enabled=1" \
+    > /etc/yum.repos.d/${DEVTOOLSET}-build.repo
 
 # mirrorlist is no longer available since CentOS 7 EOL. The software collection
 # stuff for arm64 (aarch64) is in /altarch not /centos on vault.centos.org.
 # Make the fixup a script as it needs to be run multiple times as installing
 # and updating centos-release-scl-rh leaves the old unavailable URLs.
 # https://serverfault.com/a/1161847
+<<<<<<< HEAD
 RUN cat <<EOF > /tmp/fix-yum-repo-list.sh
 #!/bin/sh
 sed -e 's/mirror.centos.org/vault.centos.org/g' \
@@ -31,6 +32,18 @@ if [ "$(uname -m)" = 'aarch64' ]; then
     sed 's|centos/7/sclo|altarch/7/sclo|' -i /etc/yum.repos.d/*.repo
 fi
 EOF
+=======
+RUN printf '%s\n' \
+    '#!/bin/sh' \
+    "sed -e 's/mirror.centos.org/vault.centos.org/g' \\" \
+    "    -e 's/^#.*baseurl=http/baseurl=https/g' \\" \
+    "    -e 's/^mirrorlist=http/#mirrorlist=http/g' \\" \
+    "    -i /etc/yum.repos.d/*.repo" \
+    "if [ \"\$(uname -m)\" = 'aarch64' ]; then" \
+    "    sed 's|centos/7/sclo|altarch/7/sclo|' -i /etc/yum.repos.d/*.repo" \
+    'fi' \
+    > /tmp/fix-yum-repo-list.sh
+>>>>>>> 1cf13634daf (make CentOS 7 Dockerfiles Kaniko-compatible)
 RUN chmod 755 /tmp/fix-yum-repo-list.sh && \
     /tmp/fix-yum-repo-list.sh
 
@@ -38,7 +51,7 @@ RUN chmod 755 /tmp/fix-yum-repo-list.sh && \
 RUN yum groupinstall -y 'Development Tools' && \
     yum install -y epel-release && \
     yum install -y centos-release-scl-rh && \
-    /tmp/fix-yum-repo-list.sh \
+    /tmp/fix-yum-repo-list.sh && \
     yum update -y && \
     yum install -y \
     centos-release-scl \

--- a/build.assets/Dockerfile-centos7-assets
+++ b/build.assets/Dockerfile-centos7-assets
@@ -22,18 +22,6 @@ RUN if [ "${BUILDARCH}" = "arm64" ]; then export BUILDARCH="aarch64"; fi && \
 # Make the fixup a script as it needs to be run multiple times as installing
 # and updating centos-release-scl-rh leaves the old unavailable URLs.
 # https://serverfault.com/a/1161847
-<<<<<<< HEAD
-RUN cat <<EOF > /tmp/fix-yum-repo-list.sh
-#!/bin/sh
-sed -e 's/mirror.centos.org/vault.centos.org/g' \
-    -e 's/^#.*baseurl=http/baseurl=http/g' \
-    -e 's/^mirrorlist=http/#mirrorlist=http/g' \
-    -i /etc/yum.repos.d/*.repo
-if [ "$(uname -m)" = 'aarch64' ]; then
-    sed 's|centos/7/sclo|altarch/7/sclo|' -i /etc/yum.repos.d/*.repo
-fi
-EOF
-=======
 RUN printf '%s\n' \
     '#!/bin/sh' \
     "sed -e 's/mirror.centos.org/vault.centos.org/g' \\" \
@@ -44,7 +32,6 @@ RUN printf '%s\n' \
     "    sed 's|centos/7/sclo|altarch/7/sclo|' -i /etc/yum.repos.d/*.repo" \
     'fi' \
     > /tmp/fix-yum-repo-list.sh
->>>>>>> 1cf13634daf (make CentOS 7 Dockerfiles Kaniko-compatible)
 RUN chmod 755 /tmp/fix-yum-repo-list.sh && \
     /tmp/fix-yum-repo-list.sh
 


### PR DESCRIPTION
Backport: https://github.com/gravitational/teleport/pull/67272

## Manual Test Plan
### Test Environment
Local

### Test Cases
- [x] verified building image using temporal workflow
