### PR TITLE
[v18] kube: cap TLS handshake to 15s on kube proxy listener

### DIFF
--- a/lib/kube/grpc/utils_test.go
+++ b/lib/kube/grpc/utils_test.go
@@ -56,6 +56,7 @@ import (
 	"github.com/gravitational/teleport/lib/auth/keygen"
 	"github.com/gravitational/teleport/lib/authz"
 	"github.com/gravitational/teleport/lib/cryptosuites"
+	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/events"
 	"github.com/gravitational/teleport/lib/events/eventstest"
 	"github.com/gravitational/teleport/lib/healthcheck"
@@ -388,8 +389,8 @@ func SetupTestContext(ctx context.Context, t *testing.T, cfg TestConfig) *TestCo
 		HealthCheckManager: healthCheckManager,
 	})
 	require.NoError(t, err)
-	require.Equal(t, testCtx.KubeServer.Server.ReadTimeout, time.Duration(0), "kube server write timeout must be 0")
-	require.Equal(t, testCtx.KubeServer.Server.WriteTimeout, time.Duration(0), "kube server write timeout must be 0")
+	require.Equal(t, time.Duration(0), testCtx.KubeServer.Server.ReadTimeout, "kube server read timeout must be 0 to keep long-running watch streams alive")
+	require.Equal(t, defaults.HandshakeReadDeadline, testCtx.KubeServer.Server.WriteTimeout, "kube server write timeout must be HandshakeReadDeadline; it caps the TLS handshake while the outer handler resets the per-request write deadline")
 
 	testCtx.startKubeServices(t)
 	// Explicitly send a heartbeat for any configured clusters.

--- a/lib/kube/proxy/server.go
+++ b/lib/kube/proxy/server.go
@@ -43,6 +43,7 @@ import (
 	"github.com/gravitational/teleport/lib/cloud/awsconfig"
 	"github.com/gravitational/teleport/lib/cloud/azure"
 	"github.com/gravitational/teleport/lib/cloud/gcp"
+	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/healthcheck"
 	"github.com/gravitational/teleport/lib/httplib"
 	"github.com/gravitational/teleport/lib/inventory"
@@ -273,25 +274,13 @@ func NewTLSServer(cfg TLSServerConfig) (*TLSServer, error) {
 	// force client auth if given
 	cfg.TLS.ClientAuth = tls.VerifyClientCertIfGiven
 
+	tracingHandler := httplib.MakeTracingHandler(limiter, teleport.ComponentKube)
+	kubeHTTPserver := newKubeHTTPServer(tracingHandler, log, cfg.TLS, cfg.IngressReporter)
 	server := &TLSServer{
 		fwd:             fwd,
 		TLSServerConfig: cfg,
-		Server: &http.Server{
-			Handler:           httplib.MakeTracingHandler(limiter, teleport.ComponentKube),
-			ReadHeaderTimeout: apidefaults.DefaultIOTimeout * 2,
-			// Setting ReadTimeout and WriteTimeout will cause the server to
-			// terminate long running requests. This will cause issues with
-			// long running watch streams. The server will close the connection
-			// and the client will receive incomplete data and will fail to
-			// parse it.
-			IdleTimeout: apidefaults.DefaultIdleTimeout,
-			TLSConfig:   cfg.TLS,
-			ConnState:   ingress.HTTPConnStateReporter(ingress.Kube, cfg.IngressReporter),
-			ConnContext: func(ctx context.Context, c net.Conn) context.Context {
-				return authz.ContextWithClientAddrs(ctx, c.RemoteAddr(), c.LocalAddr())
-			},
-		},
-		heartbeats: make(map[string]*srv.HeartbeatV2),
+		Server:          kubeHTTPserver,
+		heartbeats:      make(map[string]*srv.HeartbeatV2),
 		monitoredKubeClusters: monitoredKubeClusters{
 			static: fwd.kubeClusters(),
 		},
@@ -307,6 +296,35 @@ func NewTLSServer(cfg TLSServerConfig) (*TLSServer, error) {
 	}
 
 	return server, nil
+}
+
+// newKubeHTTPServer builds the kube proxy's *http.Server.
+func newKubeHTTPServer(inner http.Handler, log *slog.Logger, tlsCfg *tls.Config, reporter *ingress.Reporter) *http.Server {
+	return &http.Server{
+		Handler:           newTimeoutResetHandler(inner, log),
+		ReadHeaderTimeout: apidefaults.DefaultIOTimeout * 2,
+		// WriteTimeout drives the TLS handshake deadline via net/http's
+		// tlsHandshakeTimeout = min(ReadHeaderTimeout, ReadTimeout, WriteTimeout) formula,
+		// bounding the pre-authentication goroutine hold time.
+		WriteTimeout: defaults.HandshakeReadDeadline,
+		IdleTimeout:  apidefaults.DefaultIdleTimeout,
+		TLSConfig:    tlsCfg,
+		ConnState:    ingress.HTTPConnStateReporter(ingress.Kube, reporter),
+		ConnContext: func(ctx context.Context, c net.Conn) context.Context {
+			return authz.ContextWithClientAddrs(ctx, c.RemoteAddr(), c.LocalAddr())
+		},
+	}
+}
+
+// newTimeoutResetHandler wraps next so that the per-request write deadline
+// (set by net/http from Server.WriteTimeout) is cleared before next runs.
+func newTimeoutResetHandler(next http.Handler, log *slog.Logger) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := http.NewResponseController(w).SetWriteDeadline(time.Time{}); err != nil {
+			log.ErrorContext(r.Context(), "failed to reset response write deadline", "error", err)
+		}
+		next.ServeHTTP(w, r)
+	})
 }
 
 // ServeOption is a functional option for the multiplexer.

--- a/lib/kube/proxy/server_timeout_test.go
+++ b/lib/kube/proxy/server_timeout_test.go
@@ -1,0 +1,200 @@
+/*
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package proxy
+
+import (
+	"bufio"
+	"crypto/tls"
+	"io"
+	stdlog "log"
+	"log/slog"
+	"net"
+	"net/http"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"testing/synctest"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport/lib/defaults"
+	"github.com/gravitational/teleport/lib/tlscatest"
+)
+
+// TestKubeHTTPServer_StalledHandshakeClosed asserts a connection that completes the TCP handshake
+// but never sends a ClientHello is closed by the server within the configured WriteTimeout.
+func TestKubeHTTPServer_StalledHandshakeClosed(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		tlsCfg := newSelfSignedTLSConfig(t)
+		client, server := net.Pipe()
+		t.Cleanup(func() { _ = client.Close() })
+
+		var handlerRan atomic.Bool
+		h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { handlerRan.Store(true) })
+		srv := newKubeHTTPServer(h, slog.Default(), tlsCfg, nil)
+		srv.ErrorLog = stdlog.New(io.Discard, "", 0)
+
+		serveDone := make(chan error, 1)
+		go func() {
+			l := tls.NewListener(newSingleConnListener(server), tlsCfg)
+			serveDone <- srv.Serve(l)
+		}()
+
+		// Read in a goroutine so we can probe non-blockingly.
+		// Without this, a synchronous Read here would let synctest fast-forward past any later deadline,
+		// hiding the case where the handshake bound is wrong.
+		readDone := make(chan error, 1)
+		go func() {
+			buf := make([]byte, 1)
+			_, err := client.Read(buf)
+			readDone <- err
+		}()
+
+		time.Sleep(defaults.HandshakeReadDeadline + 1) // Connection stalled more than WriteTimeout
+		synctest.Wait()
+
+		require.False(t, handlerRan.Load(), "handler must not run for stalled connection")
+
+		select {
+		case err := <-readDone:
+			require.Error(t, err, "server should have closed the stalled connection")
+		default:
+			t.Fatalf("server did not close stalled connection within %s", defaults.HandshakeReadDeadline+time.Second)
+		}
+
+		require.NoError(t, srv.Close())
+		synctest.Wait()
+
+		select {
+		case err := <-serveDone:
+			require.ErrorIs(t, err, http.ErrServerClosed)
+		default:
+			t.Fatal("Serve did not return after Close")
+		}
+	})
+}
+
+// TestKubeHTTPServer_LongHandlerSurvivesWriteTimeout asserts
+// a handler that runs longer than WriteTimeout still delivers its response.
+// This is the invariant the outer timeout-reset handler protects:
+// WriteTimeout caps the TLS handshake but must not bound watch/exec/portforward streams.
+func TestKubeHTTPServer_LongHandlerSurvivesWriteTimeout(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		tlsCfg := newSelfSignedTLSConfig(t)
+		client, server := net.Pipe()
+		t.Cleanup(func() { _ = client.Close() })
+
+		h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			time.Sleep(defaults.HandshakeReadDeadline + 1)
+			_, _ = w.Write([]byte("OK"))
+		})
+		srv := newKubeHTTPServer(h, slog.Default(), tlsCfg, nil)
+		srv.ErrorLog = stdlog.New(io.Discard, "", 0)
+
+		tlsClient := tls.Client(client, &tls.Config{
+			InsecureSkipVerify: true,
+			ServerName:         "localhost",
+		})
+
+		serveDone := make(chan error, 1)
+		go func() {
+			l := tls.NewListener(newSingleConnListener(server), tlsCfg)
+			serveDone <- srv.Serve(l)
+		}()
+
+		handshakeDone := make(chan error, 1)
+		go func() { handshakeDone <- tlsClient.Handshake() }()
+		synctest.Wait()
+
+		select {
+		case err := <-handshakeDone:
+			require.NoError(t, err)
+		default:
+			t.Fatal("TLS handshake did not complete")
+		}
+
+		req, err := http.NewRequest(http.MethodGet, "https://localhost/", nil)
+		require.NoError(t, err)
+		require.NoError(t, req.Write(tlsClient))
+
+		// ReadResponse blocks until the handler returns.
+		// synctest advances fake time across the handler's sleep.
+		resp, err := http.ReadResponse(bufio.NewReader(tlsClient), req)
+		require.NoError(t, err)
+		t.Cleanup(func() { _ = resp.Body.Close() })
+
+		body, err := io.ReadAll(resp.Body)
+		require.NoError(t, err)
+		require.Equal(t, "OK", string(body))
+
+		require.NoError(t, client.Close())
+		require.NoError(t, srv.Close())
+		synctest.Wait()
+
+		select {
+		case err := <-serveDone:
+			require.ErrorIs(t, err, http.ErrServerClosed)
+		default:
+			t.Fatal("Serve did not return after Close")
+		}
+	})
+}
+
+func newSelfSignedTLSConfig(t *testing.T) *tls.Config {
+	t.Helper()
+	keyPEM, certPEM, err := tlscatest.GenerateSelfSignedCA(tlscatest.GenerateCAConfig{ClusterName: "test"})
+	require.NoError(t, err)
+	cert, err := tls.X509KeyPair(certPEM, keyPEM)
+	require.NoError(t, err)
+	return &tls.Config{Certificates: []tls.Certificate{cert}}
+}
+
+// singleConnListener is a minimal net.Listener serving a single pre-built conn.
+// In tests we feed it a net.Pipe conn because synctest can't advance fake time across goroutines blocked on syscall-level I/O.
+type singleConnListener struct {
+	conn   chan net.Conn
+	closed chan struct{}
+	once   sync.Once
+}
+
+func newSingleConnListener(c net.Conn) *singleConnListener {
+	l := &singleConnListener{
+		conn:   make(chan net.Conn, 1),
+		closed: make(chan struct{}),
+	}
+	l.conn <- c
+	return l
+}
+
+func (l *singleConnListener) Accept() (net.Conn, error) {
+	select {
+	case c := <-l.conn:
+		return c, nil
+	case <-l.closed:
+		return nil, net.ErrClosed
+	}
+}
+
+func (l *singleConnListener) Close() error {
+	l.once.Do(func() { close(l.closed) })
+	return nil
+}
+
+func (*singleConnListener) Addr() net.Addr { return nil }

--- a/lib/kube/proxy/utils_test.go
+++ b/lib/kube/proxy/utils_test.go
@@ -57,6 +57,7 @@ import (
 	"github.com/gravitational/teleport/lib/auth/keygen"
 	"github.com/gravitational/teleport/lib/authz"
 	"github.com/gravitational/teleport/lib/cryptosuites"
+	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/events"
 	"github.com/gravitational/teleport/lib/events/eventstest"
 	"github.com/gravitational/teleport/lib/healthcheck"
@@ -403,8 +404,8 @@ func SetupTestContext(ctx context.Context, t *testing.T, cfg TestConfig) *TestCo
 		HealthCheckManager: healthCheckManager,
 	})
 	require.NoError(t, err)
-	require.Equal(t, testCtx.KubeServer.Server.ReadTimeout, time.Duration(0), "kube server write timeout must be 0")
-	require.Equal(t, testCtx.KubeServer.Server.WriteTimeout, time.Duration(0), "kube server write timeout must be 0")
+	require.Zero(t, testCtx.KubeServer.Server.ReadTimeout, "kube server read timeout must be 0 to keep long-running watch streams alive")
+	require.Equal(t, defaults.HandshakeReadDeadline, testCtx.KubeServer.Server.WriteTimeout, "kube server write timeout must be HandshakeReadDeadline; it caps the TLS handshake while the outer handler resets the per-request write deadline")
 
 	testCtx.startKubeServices(t)
 	// Explicitly send a heartbeat for any configured clusters.


### PR DESCRIPTION
Backport of #67158 to branch/v18.

Clean cherry-pick — no manual conflict resolution required.