### PR TITLE
kube proxy: impersonate user on ephemeral container pod GET

### DIFF
--- a/api/gen/proto/go/teleport/kubewaitingcontainer/v1/kubewaitingcontainer.pb.go
+++ b/api/gen/proto/go/teleport/kubewaitingcontainer/v1/kubewaitingcontainer.pb.go
@@ -203,9 +203,17 @@ type KubernetesWaitingContainerSpec struct {
 	// to create this ephemeral container
 	Patch []byte `protobuf:"bytes,6,opt,name=patch,proto3" json:"patch,omitempty"`
 	// patch_type identifies the patch model to be applied.
-	PatchType     string `protobuf:"bytes,7,opt,name=patch_type,json=patchType,proto3" json:"patch_type,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	PatchType string `protobuf:"bytes,7,opt,name=patch_type,json=patchType,proto3" json:"patch_type,omitempty"`
+	// kubernetes_user is the impersonated Kubernetes user resolved from the
+	// creating request's Impersonate-User header and the user's kubernetes_users role set.
+	// Stored so that the moderated wait path can re-apply the same impersonation
+	// when fetching the target pod after the live request is gone.
+	KubernetesUser string `protobuf:"bytes,8,opt,name=kubernetes_user,json=kubernetesUser,proto3" json:"kubernetes_user,omitempty"`
+	// kubernetes_groups are the impersonated Kubernetes groups resolved at creation time,
+	// stored for the same reason as kubernetes_user.
+	KubernetesGroups []string `protobuf:"bytes,9,rep,name=kubernetes_groups,json=kubernetesGroups,proto3" json:"kubernetes_groups,omitempty"`
+	unknownFields    protoimpl.UnknownFields
+	sizeCache        protoimpl.SizeCache
 }
 
 func (x *KubernetesWaitingContainerSpec) Reset() {
@@ -282,6 +290,20 @@ func (x *KubernetesWaitingContainerSpec) GetPatchType() string {
 	return ""
 }
 
+func (x *KubernetesWaitingContainerSpec) GetKubernetesUser() string {
+	if x != nil {
+		return x.KubernetesUser
+	}
+	return ""
+}
+
+func (x *KubernetesWaitingContainerSpec) GetKubernetesGroups() []string {
+	if x != nil {
+		return x.KubernetesGroups
+	}
+	return nil
+}
+
 func (x *KubernetesWaitingContainerSpec) SetUsername(v string) {
 	x.Username = v
 }
@@ -313,6 +335,14 @@ func (x *KubernetesWaitingContainerSpec) SetPatchType(v string) {
 	x.PatchType = v
 }
 
+func (x *KubernetesWaitingContainerSpec) SetKubernetesUser(v string) {
+	x.KubernetesUser = v
+}
+
+func (x *KubernetesWaitingContainerSpec) SetKubernetesGroups(v []string) {
+	x.KubernetesGroups = v
+}
+
 type KubernetesWaitingContainerSpec_builder struct {
 	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
 
@@ -331,6 +361,14 @@ type KubernetesWaitingContainerSpec_builder struct {
 	Patch []byte
 	// patch_type identifies the patch model to be applied.
 	PatchType string
+	// kubernetes_user is the impersonated Kubernetes user resolved from the
+	// creating request's Impersonate-User header and the user's kubernetes_users role set.
+	// Stored so that the moderated wait path can re-apply the same impersonation
+	// when fetching the target pod after the live request is gone.
+	KubernetesUser string
+	// kubernetes_groups are the impersonated Kubernetes groups resolved at creation time,
+	// stored for the same reason as kubernetes_user.
+	KubernetesGroups []string
 }
 
 func (b0 KubernetesWaitingContainerSpec_builder) Build() *KubernetesWaitingContainerSpec {
@@ -344,6 +382,8 @@ func (b0 KubernetesWaitingContainerSpec_builder) Build() *KubernetesWaitingConta
 	x.ContainerName = b.ContainerName
 	x.Patch = b.Patch
 	x.PatchType = b.PatchType
+	x.KubernetesUser = b.KubernetesUser
+	x.KubernetesGroups = b.KubernetesGroups
 	return m0
 }
 
@@ -357,7 +397,7 @@ const file_teleport_kubewaitingcontainer_v1_kubewaitingcontainer_proto_rawDesc =
 	"\bsub_kind\x18\x02 \x01(\tR\asubKind\x12\x18\n" +
 	"\aversion\x18\x03 \x01(\tR\aversion\x128\n" +
 	"\bmetadata\x18\x04 \x01(\v2\x1c.teleport.header.v1.MetadataR\bmetadata\x12T\n" +
-	"\x04spec\x18\x05 \x01(\v2@.teleport.kubewaitingcontainer.v1.KubernetesWaitingContainerSpecR\x04spec\"\xeb\x01\n" +
+	"\x04spec\x18\x05 \x01(\v2@.teleport.kubewaitingcontainer.v1.KubernetesWaitingContainerSpecR\x04spec\"\xc1\x02\n" +
 	"\x1eKubernetesWaitingContainerSpec\x12\x1a\n" +
 	"\busername\x18\x01 \x01(\tR\busername\x12\x18\n" +
 	"\acluster\x18\x02 \x01(\tR\acluster\x12\x1c\n" +
@@ -366,7 +406,9 @@ const file_teleport_kubewaitingcontainer_v1_kubewaitingcontainer_proto_rawDesc =
 	"\x0econtainer_name\x18\x05 \x01(\tR\rcontainerName\x12\x14\n" +
 	"\x05patch\x18\x06 \x01(\fR\x05patch\x12\x1d\n" +
 	"\n" +
-	"patch_type\x18\a \x01(\tR\tpatchTypeBlZjgithub.com/gravitational/teleport/api/gen/proto/go/teleport/kubewaitingcontainer/v1;kubewaitingcontainerv1b\x06proto3"
+	"patch_type\x18\a \x01(\tR\tpatchType\x12'\n" +
+	"\x0fkubernetes_user\x18\b \x01(\tR\x0ekubernetesUser\x12+\n" +
+	"\x11kubernetes_groups\x18\t \x03(\tR\x10kubernetesGroupsBlZjgithub.com/gravitational/teleport/api/gen/proto/go/teleport/kubewaitingcontainer/v1;kubewaitingcontainerv1b\x06proto3"
 
 var file_teleport_kubewaitingcontainer_v1_kubewaitingcontainer_proto_msgTypes = make([]protoimpl.MessageInfo, 2)
 var file_teleport_kubewaitingcontainer_v1_kubewaitingcontainer_proto_goTypes = []any{

--- a/api/gen/proto/go/teleport/kubewaitingcontainer/v1/kubewaitingcontainer_protoopaque.pb.go
+++ b/api/gen/proto/go/teleport/kubewaitingcontainer/v1/kubewaitingcontainer_protoopaque.pb.go
@@ -182,16 +182,18 @@ func (b0 KubernetesWaitingContainer_builder) Build() *KubernetesWaitingContainer
 
 // KubernetesWaitingContainerSpec is the Kubernetes waiting ephemeral container spec.
 type KubernetesWaitingContainerSpec struct {
-	state                    protoimpl.MessageState `protogen:"opaque.v1"`
-	xxx_hidden_Username      string                 `protobuf:"bytes,1,opt,name=username,proto3"`
-	xxx_hidden_Cluster       string                 `protobuf:"bytes,2,opt,name=cluster,proto3"`
-	xxx_hidden_Namespace     string                 `protobuf:"bytes,3,opt,name=namespace,proto3"`
-	xxx_hidden_PodName       string                 `protobuf:"bytes,4,opt,name=pod_name,json=podName,proto3"`
-	xxx_hidden_ContainerName string                 `protobuf:"bytes,5,opt,name=container_name,json=containerName,proto3"`
-	xxx_hidden_Patch         []byte                 `protobuf:"bytes,6,opt,name=patch,proto3"`
-	xxx_hidden_PatchType     string                 `protobuf:"bytes,7,opt,name=patch_type,json=patchType,proto3"`
-	unknownFields            protoimpl.UnknownFields
-	sizeCache                protoimpl.SizeCache
+	state                       protoimpl.MessageState `protogen:"opaque.v1"`
+	xxx_hidden_Username         string                 `protobuf:"bytes,1,opt,name=username,proto3"`
+	xxx_hidden_Cluster          string                 `protobuf:"bytes,2,opt,name=cluster,proto3"`
+	xxx_hidden_Namespace        string                 `protobuf:"bytes,3,opt,name=namespace,proto3"`
+	xxx_hidden_PodName          string                 `protobuf:"bytes,4,opt,name=pod_name,json=podName,proto3"`
+	xxx_hidden_ContainerName    string                 `protobuf:"bytes,5,opt,name=container_name,json=containerName,proto3"`
+	xxx_hidden_Patch            []byte                 `protobuf:"bytes,6,opt,name=patch,proto3"`
+	xxx_hidden_PatchType        string                 `protobuf:"bytes,7,opt,name=patch_type,json=patchType,proto3"`
+	xxx_hidden_KubernetesUser   string                 `protobuf:"bytes,8,opt,name=kubernetes_user,json=kubernetesUser,proto3"`
+	xxx_hidden_KubernetesGroups []string               `protobuf:"bytes,9,rep,name=kubernetes_groups,json=kubernetesGroups,proto3"`
+	unknownFields               protoimpl.UnknownFields
+	sizeCache                   protoimpl.SizeCache
 }
 
 func (x *KubernetesWaitingContainerSpec) Reset() {
@@ -268,6 +270,20 @@ func (x *KubernetesWaitingContainerSpec) GetPatchType() string {
 	return ""
 }
 
+func (x *KubernetesWaitingContainerSpec) GetKubernetesUser() string {
+	if x != nil {
+		return x.xxx_hidden_KubernetesUser
+	}
+	return ""
+}
+
+func (x *KubernetesWaitingContainerSpec) GetKubernetesGroups() []string {
+	if x != nil {
+		return x.xxx_hidden_KubernetesGroups
+	}
+	return nil
+}
+
 func (x *KubernetesWaitingContainerSpec) SetUsername(v string) {
 	x.xxx_hidden_Username = v
 }
@@ -299,6 +315,14 @@ func (x *KubernetesWaitingContainerSpec) SetPatchType(v string) {
 	x.xxx_hidden_PatchType = v
 }
 
+func (x *KubernetesWaitingContainerSpec) SetKubernetesUser(v string) {
+	x.xxx_hidden_KubernetesUser = v
+}
+
+func (x *KubernetesWaitingContainerSpec) SetKubernetesGroups(v []string) {
+	x.xxx_hidden_KubernetesGroups = v
+}
+
 type KubernetesWaitingContainerSpec_builder struct {
 	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
 
@@ -317,6 +341,14 @@ type KubernetesWaitingContainerSpec_builder struct {
 	Patch []byte
 	// patch_type identifies the patch model to be applied.
 	PatchType string
+	// kubernetes_user is the impersonated Kubernetes user resolved from the
+	// creating request's Impersonate-User header and the user's kubernetes_users role set.
+	// Stored so that the moderated wait path can re-apply the same impersonation
+	// when fetching the target pod after the live request is gone.
+	KubernetesUser string
+	// kubernetes_groups are the impersonated Kubernetes groups resolved at creation time,
+	// stored for the same reason as kubernetes_user.
+	KubernetesGroups []string
 }
 
 func (b0 KubernetesWaitingContainerSpec_builder) Build() *KubernetesWaitingContainerSpec {
@@ -330,6 +362,8 @@ func (b0 KubernetesWaitingContainerSpec_builder) Build() *KubernetesWaitingConta
 	x.xxx_hidden_ContainerName = b.ContainerName
 	x.xxx_hidden_Patch = b.Patch
 	x.xxx_hidden_PatchType = b.PatchType
+	x.xxx_hidden_KubernetesUser = b.KubernetesUser
+	x.xxx_hidden_KubernetesGroups = b.KubernetesGroups
 	return m0
 }
 
@@ -343,7 +377,7 @@ const file_teleport_kubewaitingcontainer_v1_kubewaitingcontainer_proto_rawDesc =
 	"\bsub_kind\x18\x02 \x01(\tR\asubKind\x12\x18\n" +
 	"\aversion\x18\x03 \x01(\tR\aversion\x128\n" +
 	"\bmetadata\x18\x04 \x01(\v2\x1c.teleport.header.v1.MetadataR\bmetadata\x12T\n" +
-	"\x04spec\x18\x05 \x01(\v2@.teleport.kubewaitingcontainer.v1.KubernetesWaitingContainerSpecR\x04spec\"\xeb\x01\n" +
+	"\x04spec\x18\x05 \x01(\v2@.teleport.kubewaitingcontainer.v1.KubernetesWaitingContainerSpecR\x04spec\"\xc1\x02\n" +
 	"\x1eKubernetesWaitingContainerSpec\x12\x1a\n" +
 	"\busername\x18\x01 \x01(\tR\busername\x12\x18\n" +
 	"\acluster\x18\x02 \x01(\tR\acluster\x12\x1c\n" +
@@ -352,7 +386,9 @@ const file_teleport_kubewaitingcontainer_v1_kubewaitingcontainer_proto_rawDesc =
 	"\x0econtainer_name\x18\x05 \x01(\tR\rcontainerName\x12\x14\n" +
 	"\x05patch\x18\x06 \x01(\fR\x05patch\x12\x1d\n" +
 	"\n" +
-	"patch_type\x18\a \x01(\tR\tpatchTypeBlZjgithub.com/gravitational/teleport/api/gen/proto/go/teleport/kubewaitingcontainer/v1;kubewaitingcontainerv1b\x06proto3"
+	"patch_type\x18\a \x01(\tR\tpatchType\x12'\n" +
+	"\x0fkubernetes_user\x18\b \x01(\tR\x0ekubernetesUser\x12+\n" +
+	"\x11kubernetes_groups\x18\t \x03(\tR\x10kubernetesGroupsBlZjgithub.com/gravitational/teleport/api/gen/proto/go/teleport/kubewaitingcontainer/v1;kubewaitingcontainerv1b\x06proto3"
 
 var file_teleport_kubewaitingcontainer_v1_kubewaitingcontainer_proto_msgTypes = make([]protoimpl.MessageInfo, 2)
 var file_teleport_kubewaitingcontainer_v1_kubewaitingcontainer_proto_goTypes = []any{

--- a/api/proto/teleport/kubewaitingcontainer/v1/kubewaitingcontainer.proto
+++ b/api/proto/teleport/kubewaitingcontainer/v1/kubewaitingcontainer.proto
@@ -53,4 +53,12 @@ message KubernetesWaitingContainerSpec {
   bytes patch = 6;
   // patch_type identifies the patch model to be applied.
   string patch_type = 7;
+  // kubernetes_user is the impersonated Kubernetes user resolved from the
+  // creating request's Impersonate-User header and the user's kubernetes_users role set.
+  // Stored so that the moderated wait path can re-apply the same impersonation
+  // when fetching the target pod after the live request is gone.
+  string kubernetes_user = 8;
+  // kubernetes_groups are the impersonated Kubernetes groups resolved at creation time,
+  // stored for the same reason as kubernetes_user.
+  repeated string kubernetes_groups = 9;
 }

--- a/lib/kube/proxy/ephemeral_admin_client_test.go
+++ b/lib/kube/proxy/ephemeral_admin_client_test.go
@@ -40,29 +40,16 @@ import (
 	"github.com/gravitational/teleport/lib/utils/set"
 )
 
-// TestGetPodForEphemeralPatch_UsesImpersonatedIdentity is a regression test
-// for the bug where the moderated ephemeral-container flow at
-// `lib/kube/proxy/ephemeral_containers.go` fetched the target pod with the
-// proxy's static admin kubeconfig (`details.getKubeClient()`) instead of an
-// impersonated client carrying the user's `kubernetes_users` /
-// `kubernetes_groups`. Because the synthesised pod is then encoded back to
-// the caller, this bypassed Kubernetes RBAC on the user's mapped identity
-// and leaked pod spec/env/annotations.
+// TestGetPodForEphemeralPatch_UsesImpersonatedIdentity asserts that the pod GET issued by
+// the moderated ephemeral-container flow carries the user's impersonation headers,
+// so that the Kubernetes API server enforces RBAC on the requester's mapped kubernetes_users/kubernetes_groups
+// rather than on the proxy's admin kubeconfig.
+// The synthesised "patched" pod returned to the user therefore cannot contain spec, env,
+// or annotations that the user's mapped identity is not authorised to read.
 //
-// The fix moves the pod GET into `getPodForEphemeralPatch`, which uses
-// `impersonatedKubeClient` so the Kubernetes API server enforces RBAC on the
-// user's mapped identity. This test stands up a fake Kubernetes API server,
-// drives `getPodForEphemeralPatch` with an authContext mapped to a single
-// `kubernetes_users` entry of `victim-k8s`, and asserts the upstream GET
-// carried `Impersonate-User: victim-k8s`.
-//
-// Revert the fix (have `getPodForEphemeralPatch` call
-// `findKubeDetailsByClusterName(...).getKubeClient()` instead of
-// `impersonatedKubeClient`) and this test fails with an empty captured
-// header value.
-//
-// See workspace/f3-ephemeral-admin-client.md for the full root-cause writeup
-// and end-to-end PoC.
+// The test stands up a fake Kubernetes API server,
+// drives getPodForEphemeralPatch with an authContext mapped to a single kubernetes_users entry,
+// and checks that the upstream GET arrived with the matching Impersonate-User header.
 func TestGetPodForEphemeralPatch_UsesImpersonatedIdentity(t *testing.T) {
 	const (
 		clusterName = "test-cluster"
@@ -71,8 +58,6 @@ func TestGetPodForEphemeralPatch_UsesImpersonatedIdentity(t *testing.T) {
 		kubeUser    = "victim-k8s"
 	)
 
-	// Fake Kubernetes API server. We only need it to answer GET on the target
-	// pod and capture whatever Impersonate-User header arrives on that GET.
 	var (
 		mu                  sync.Mutex
 		capturedImpersonate string
@@ -105,8 +90,6 @@ func TestGetPodForEphemeralPatch_UsesImpersonatedIdentity(t *testing.T) {
 	}))
 	t.Cleanup(srv.Close)
 
-	// Admin REST config and clientset, mirroring how a real kube agent wires
-	// staticKubeCreds.kubeClient.
 	adminRestCfg := &rest.Config{Host: srv.URL}
 	adminClient, err := kubernetes.NewForConfig(adminRestCfg)
 	require.NoError(t, err)
@@ -129,8 +112,8 @@ func TestGetPodForEphemeralPatch_UsesImpersonatedIdentity(t *testing.T) {
 	teleportUser, err := types.NewUser("victim")
 	require.NoError(t, err)
 
-	// authContext with exactly one kubernetes_users entry so
-	// computeAndValidateImpersonatedPrincipals picks it deterministically.
+	// One kubernetes_users entry so computeAndValidateImpersonatedPrincipals
+	// picks it deterministically without consulting request headers.
 	authCtx := &authContext{
 		ScopedContext:   &authz.ScopedContext{User: teleportUser},
 		kubeClusterName: clusterName,
@@ -151,13 +134,5 @@ func TestGetPodForEphemeralPatch_UsesImpersonatedIdentity(t *testing.T) {
 	got := capturedImpersonate
 	mu.Unlock()
 
-	require.Equal(t, kubeUser, got,
-		"GET to upstream Kubernetes during moderated ephemeral-container patch "+
-			"must use the user's impersonated identity (kubernetes_users[0]), not the "+
-			"proxy's admin kubeconfig. lib/kube/proxy/ephemeral_containers.go:204 currently "+
-			"calls details.getKubeClient() which carries no Impersonate-User header. "+
-			"Captured header value: %q", got)
-
-	// Suppress "unused" warnings if a future refactor inlines kubeUser.
-	_ = kubeUser
+	require.Equal(t, kubeUser, got, "upstream GET must carry the user's Impersonate-User header")
 }

--- a/lib/kube/proxy/ephemeral_admin_client_test.go
+++ b/lib/kube/proxy/ephemeral_admin_client_test.go
@@ -1,0 +1,163 @@
+/*
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package proxy
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/authz"
+	"github.com/gravitational/teleport/lib/utils/log/logtest"
+	"github.com/gravitational/teleport/lib/utils/set"
+)
+
+// TestGetPodForEphemeralPatch_UsesImpersonatedIdentity is a regression test
+// for the bug where the moderated ephemeral-container flow at
+// `lib/kube/proxy/ephemeral_containers.go` fetched the target pod with the
+// proxy's static admin kubeconfig (`details.getKubeClient()`) instead of an
+// impersonated client carrying the user's `kubernetes_users` /
+// `kubernetes_groups`. Because the synthesised pod is then encoded back to
+// the caller, this bypassed Kubernetes RBAC on the user's mapped identity
+// and leaked pod spec/env/annotations.
+//
+// The fix moves the pod GET into `getPodForEphemeralPatch`, which uses
+// `impersonatedKubeClient` so the Kubernetes API server enforces RBAC on the
+// user's mapped identity. This test stands up a fake Kubernetes API server,
+// drives `getPodForEphemeralPatch` with an authContext mapped to a single
+// `kubernetes_users` entry of `victim-k8s`, and asserts the upstream GET
+// carried `Impersonate-User: victim-k8s`.
+//
+// Revert the fix (have `getPodForEphemeralPatch` call
+// `findKubeDetailsByClusterName(...).getKubeClient()` instead of
+// `impersonatedKubeClient`) and this test fails with an empty captured
+// header value.
+//
+// See workspace/f3-ephemeral-admin-client.md for the full root-cause writeup
+// and end-to-end PoC.
+func TestGetPodForEphemeralPatch_UsesImpersonatedIdentity(t *testing.T) {
+	const (
+		clusterName = "test-cluster"
+		ns          = "prod"
+		podName     = "secretive-app"
+		kubeUser    = "victim-k8s"
+	)
+
+	// Fake Kubernetes API server. We only need it to answer GET on the target
+	// pod and capture whatever Impersonate-User header arrives on that GET.
+	var (
+		mu                  sync.Mutex
+		capturedImpersonate string
+	)
+	fakePod := &corev1.Pod{
+		TypeMeta: metav1.TypeMeta{Kind: "Pod", APIVersion: "v1"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      podName,
+			Namespace: ns,
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{{
+				Name:  "app",
+				Image: "registry.k8s.io/pause:3.10",
+				Env: []corev1.EnvVar{
+					{Name: "DB_PASSWORD", Value: "REDACTED-must-not-be-disclosed"},
+				},
+			}},
+		},
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/pods/"+podName) {
+			mu.Lock()
+			capturedImpersonate = r.Header.Get("Impersonate-User")
+			mu.Unlock()
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(fakePod)
+	}))
+	t.Cleanup(srv.Close)
+
+	// Admin REST config and clientset, mirroring how a real kube agent wires
+	// staticKubeCreds.kubeClient.
+	adminRestCfg := &rest.Config{Host: srv.URL}
+	adminClient, err := kubernetes.NewForConfig(adminRestCfg)
+	require.NoError(t, err)
+
+	fwd := &Forwarder{
+		log: logtest.NewLogger(),
+		cfg: ForwarderConfig{
+			tracer: otel.Tracer("test"),
+		},
+		clusterDetails: map[string]*kubeDetails{
+			clusterName: {
+				kubeCreds: &staticKubeCreds{
+					kubeClient:    adminClient,
+					clientRestCfg: adminRestCfg,
+				},
+			},
+		},
+	}
+
+	teleportUser, err := types.NewUser("victim")
+	require.NoError(t, err)
+
+	// authContext with exactly one kubernetes_users entry so
+	// computeAndValidateImpersonatedPrincipals picks it deterministically.
+	authCtx := &authContext{
+		ScopedContext:   &authz.ScopedContext{User: teleportUser},
+		kubeClusterName: clusterName,
+		kubeUsers:       set.New(kubeUser),
+		kubeGroups:      set.New[string](),
+	}
+
+	_, err = fwd.getPodForEphemeralPatch(
+		context.Background(),
+		authCtx,
+		http.Header{},
+		ns,
+		podName,
+	)
+	require.NoError(t, err)
+
+	mu.Lock()
+	got := capturedImpersonate
+	mu.Unlock()
+
+	require.Equal(t, kubeUser, got,
+		"GET to upstream Kubernetes during moderated ephemeral-container patch "+
+			"must use the user's impersonated identity (kubernetes_users[0]), not the "+
+			"proxy's admin kubeconfig. lib/kube/proxy/ephemeral_containers.go:204 currently "+
+			"calls details.getKubeClient() which carries no Impersonate-User header. "+
+			"Captured header value: %q", got)
+
+	// Suppress "unused" warnings if a future refactor inlines kubeUser.
+	_ = kubeUser
+}

--- a/lib/kube/proxy/ephemeral_admin_client_test.go
+++ b/lib/kube/proxy/ephemeral_admin_client_test.go
@@ -34,28 +34,24 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 
+	kubewaitingcontainerpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/kubewaitingcontainer/v1"
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/api/types/kubewaitingcontainer"
 	"github.com/gravitational/teleport/lib/authz"
 	"github.com/gravitational/teleport/lib/utils/log/logtest"
 	"github.com/gravitational/teleport/lib/utils/set"
 )
 
-// TestGetPodForEphemeralPatch_UsesImpersonatedIdentity asserts that the pod GET issued by
-// the moderated ephemeral-container flow carries the user's impersonation headers,
-// so that the Kubernetes API server enforces RBAC on the requester's mapped kubernetes_users/kubernetes_groups
-// rather than on the proxy's admin kubeconfig.
-// The synthesised "patched" pod returned to the user therefore cannot contain spec, env,
-// or annotations that the user's mapped identity is not authorised to read.
-//
-// The test stands up a fake Kubernetes API server,
-// drives getPodForEphemeralPatch with an authContext mapped to a single kubernetes_users entry,
-// and checks that the upstream GET arrived with the matching Impersonate-User header.
+// TestGetPodForEphemeralPatch_UsesImpersonatedIdentity asserts that the pod GET
+// issued by the moderated ephemeral-container flow carries the user's Impersonate-User header,
+// so the Kubernetes API server evaluates the request against the requester's
+// mapped kubernetes_users / kubernetes_groups rather than the proxy's admin kubeconfig.
 func TestGetPodForEphemeralPatch_UsesImpersonatedIdentity(t *testing.T) {
 	const (
 		clusterName = "test-cluster"
-		ns          = "prod"
-		podName     = "secretive-app"
-		kubeUser    = "victim-k8s"
+		ns          = "default"
+		podName     = "test-app"
+		kubeUser    = "alice-k8s"
 	)
 
 	var (
@@ -72,9 +68,6 @@ func TestGetPodForEphemeralPatch_UsesImpersonatedIdentity(t *testing.T) {
 			Containers: []corev1.Container{{
 				Name:  "app",
 				Image: "registry.k8s.io/pause:3.10",
-				Env: []corev1.EnvVar{
-					{Name: "DB_PASSWORD", Value: "REDACTED-must-not-be-disclosed"},
-				},
 			}},
 		},
 	}
@@ -109,7 +102,7 @@ func TestGetPodForEphemeralPatch_UsesImpersonatedIdentity(t *testing.T) {
 		},
 	}
 
-	teleportUser, err := types.NewUser("victim")
+	teleportUser, err := types.NewUser("alice")
 	require.NoError(t, err)
 
 	// One kubernetes_users entry so computeAndValidateImpersonatedPrincipals
@@ -135,4 +128,100 @@ func TestGetPodForEphemeralPatch_UsesImpersonatedIdentity(t *testing.T) {
 	mu.Unlock()
 
 	require.Equal(t, kubeUser, got, "upstream GET must carry the user's Impersonate-User header")
+}
+
+// TestGetPatchedPodEvent_ReplaysStoredImpersonation asserts that
+// the moderated watch path uses the kubernetes_user and kubernetes_groups
+// stored on the KubernetesWaitingContainer when fetching the target pod,
+// instead of relying on the original request headers (which are not in scope on the watch path).
+// A user with multiple kubernetes_users values therefore still receives
+// the synthetic Modified event after moderator approval, rather than hanging.
+func TestGetPatchedPodEvent_ReplaysStoredImpersonation(t *testing.T) {
+	const (
+		clusterName  = "test-cluster"
+		ns           = "default"
+		podName      = "test-app"
+		chosenUser   = "alice-k8s-b"
+		alternateUsr = "alice-k8s-a"
+		chosenGroup  = "system:authenticated"
+	)
+
+	var (
+		mu             sync.Mutex
+		capturedUser   string
+		capturedGroups []string
+	)
+	fakePod := &corev1.Pod{
+		TypeMeta:   metav1.TypeMeta{Kind: "Pod", APIVersion: "v1"},
+		ObjectMeta: metav1.ObjectMeta{Name: podName, Namespace: ns},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{{Name: "app", Image: "registry.k8s.io/pause:3.10"}},
+		},
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/pods/"+podName) {
+			mu.Lock()
+			capturedUser = r.Header.Get("Impersonate-User")
+			capturedGroups = append([]string(nil), r.Header.Values("Impersonate-Group")...)
+			mu.Unlock()
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(fakePod)
+	}))
+	t.Cleanup(srv.Close)
+
+	adminRestCfg := &rest.Config{Host: srv.URL}
+	adminClient, err := kubernetes.NewForConfig(adminRestCfg)
+	require.NoError(t, err)
+
+	fwd := &Forwarder{
+		log: logtest.NewLogger(),
+		cfg: ForwarderConfig{tracer: otel.Tracer("test")},
+		clusterDetails: map[string]*kubeDetails{
+			clusterName: {
+				kubeCreds: &staticKubeCreds{
+					kubeClient:    adminClient,
+					clientRestCfg: adminRestCfg,
+				},
+			},
+		},
+	}
+
+	teleportUser, err := types.NewUser("alice")
+	require.NoError(t, err)
+
+	// Multi-user setup: without the stored choice on the waiting container,
+	// computeAndValidateImpersonatedPrincipals would refuse to pick.
+	sess := &clusterSession{
+		authContext: authContext{
+			ScopedContext:   &authz.ScopedContext{User: teleportUser},
+			kubeClusterName: clusterName,
+			kubeUsers:       set.New(chosenUser, alternateUsr),
+			kubeGroups:      set.New(chosenGroup),
+		},
+		codecFactory: &globalKubeCodecs,
+	}
+
+	patch := []byte(`{"spec":{"ephemeralContainers":[{"name":"debug","image":"busybox","tty":true}]}}`)
+	waitingCont, err := kubewaitingcontainer.NewKubeWaitingContainer(
+		"debug",
+		kubewaitingcontainerpb.KubernetesWaitingContainerSpec_builder{
+			Username:         "alice",
+			Cluster:          clusterName,
+			Namespace:        ns,
+			PodName:          podName,
+			ContainerName:    "debug",
+			Patch:            patch,
+			PatchType:        "application/strategic-merge-patch+json",
+			KubernetesUser:   chosenUser,
+			KubernetesGroups: []string{chosenGroup},
+		}.Build(),
+	)
+	require.NoError(t, err)
+
+	_, err = fwd.getPatchedPodEvent(context.Background(), sess, waitingCont)
+	require.NoError(t, err)
+	require.Equal(t, chosenUser, capturedUser, "upstream GET must replay the stored Impersonate-User")
+	require.Equal(t, []string{chosenGroup}, capturedGroups, "upstream GET must replay the stored Impersonate-Group")
 }

--- a/lib/kube/proxy/ephemeral_containers.go
+++ b/lib/kube/proxy/ephemeral_containers.go
@@ -194,6 +194,26 @@ type mergeEphemeralPatchWithCurrentPodConfig struct {
 	patchType apimachinerytypes.PatchType
 }
 
+// mergeEphemeralPatchWithCurrentPod merges the provided patch with the
+// given pod and returns the patched pod.
+// The pod must have been fetched by the caller using a client that respects the requesting user's Kubernetes RBAC.
+// The patch is expected to be a strategic merge patch that adds an ephemeral container to the pod.
+func (f *Forwarder) mergeEphemeralPatchWithCurrentPod(
+	pod *corev1.Pod,
+	cfg mergeEphemeralPatchWithCurrentPodConfig,
+) (*corev1.Pod, string, error) {
+	podSerializedBuf := &bytes.Buffer{}
+	if err := cfg.encoder.Encode(pod, podSerializedBuf); err != nil {
+		return nil, "", trace.Wrap(err)
+	}
+
+	patchedPod, ephemeralContName, err := patchPodWithDebugContainer(cfg.decoder, podSerializedBuf.Bytes(), cfg.podPatch, *pod, cfg.patchType)
+	if err != nil {
+		return nil, "", trace.Wrap(err)
+	}
+	return patchedPod, ephemeralContName, nil
+}
+
 // getPodForEphemeralPatch fetches the target pod using a Kubernetes client
 // that impersonates the requesting user's `kubernetes_users` / `kubernetes_groups`.
 // The Kubernetes API server therefore enforces RBAC on the user's mapped identity for this read, even though
@@ -215,26 +235,6 @@ func (f *Forwarder) getPodForEphemeralPatch(
 		return nil, trace.Wrap(err)
 	}
 	return pod, nil
-}
-
-// mergeEphemeralPatchWithCurrentPod merges the provided patch with the
-// given pod and returns the patched pod.
-// The pod must have been fetched by the caller using a client that respects the requesting user's Kubernetes RBAC.
-// The patch is expected to be a strategic merge patch that adds an ephemeral container to the pod.
-func (f *Forwarder) mergeEphemeralPatchWithCurrentPod(
-	pod *corev1.Pod,
-	cfg mergeEphemeralPatchWithCurrentPodConfig,
-) (*corev1.Pod, string, error) {
-	podSerializedBuf := &bytes.Buffer{}
-	if err := cfg.encoder.Encode(pod, podSerializedBuf); err != nil {
-		return nil, "", trace.Wrap(err)
-	}
-
-	patchedPod, ephemeralContName, err := patchPodWithDebugContainer(cfg.decoder, podSerializedBuf.Bytes(), cfg.podPatch, *pod, cfg.patchType)
-	if err != nil {
-		return nil, "", trace.Wrap(err)
-	}
-	return patchedPod, ephemeralContName, nil
 }
 
 func (f *Forwarder) createWaitingContainer(ctx context.Context, ephemeralContName string, authCtx *authContext, podPatch []byte, patchType apimachinerytypes.PatchType) error {

--- a/lib/kube/proxy/ephemeral_containers.go
+++ b/lib/kube/proxy/ephemeral_containers.go
@@ -144,16 +144,29 @@ func (f *Forwarder) ephemeralContainersLocal(authCtx *authContext, sess *cluster
 		return trace.Wrap(err, "failed to create encoder and decoder")
 	}
 
-	patchedPod, ephemeralContName, err := f.mergeEphemeralPatchWithCurrentPod(
+	// Fetch the target pod using the user's impersonated identity so the
+	// Kubernetes API server enforces RBAC on `kubernetes_users` /
+	// `kubernetes_groups`. Using the proxy's admin kubeconfig here would leak
+	// pod spec/env/annotations the user's mapped identity is not entitled to
+	// see — see lib/kube/proxy/ephemeral_admin_client_test.go.
+	pod, err := f.getPodForEphemeralPatch(
 		req.Context(),
+		authCtx,
+		req.Header,
+		authCtx.metaResource.requestedResource.namespace,
+		authCtx.metaResource.requestedResource.resourceName,
+	)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	patchedPod, ephemeralContName, err := f.mergeEphemeralPatchWithCurrentPod(
+		pod,
 		mergeEphemeralPatchWithCurrentPodConfig{
-			kubeCluster:   sess.kubeClusterName,
-			kubeNamespace: authCtx.metaResource.requestedResource.namespace,
-			podName:       authCtx.metaResource.requestedResource.resourceName,
-			decoder:       decoder,
-			encoder:       encoder,
-			podPatch:      podPatch,
-			patchType:     reqPatchType,
+			decoder:   decoder,
+			encoder:   encoder,
+			podPatch:  podPatch,
+			patchType: reqPatchType,
 		},
 	)
 	if err != nil {
@@ -178,36 +191,46 @@ func (f *Forwarder) ephemeralContainersLocal(authCtx *authContext, sess *cluster
 // mergeEphemeralPatchWithCurrentPodConfig is a configuration struct for
 // mergeEphemeralPatchWithCurrentPod.
 type mergeEphemeralPatchWithCurrentPodConfig struct {
-	kubeCluster   string
-	kubeNamespace string
-	podName       string
-	decoder       runtime.Decoder
-	encoder       runtime.Encoder
-	podPatch      []byte
-	patchType     apimachinerytypes.PatchType
+	decoder   runtime.Decoder
+	encoder   runtime.Encoder
+	podPatch  []byte
+	patchType apimachinerytypes.PatchType
 }
 
-// mergeEphemeralPatchWithCurrentPod merges the provided patch with the
-// current pod and returns the patched pod.
-// This function gets the current pod from the Kubernetes API server and
-// merges the provided patch with it. The patch is expected to be a strategic
+// getPodForEphemeralPatch fetches the target pod using a Kubernetes client
+// that impersonates the requesting user's `kubernetes_users` /
+// `kubernetes_groups`. The Kubernetes API server therefore enforces RBAC on
+// the user's mapped identity for this read, even though the surrounding
+// moderated-session flow synthesises the patch response locally without
+// forwarding the PATCH itself.
+func (f *Forwarder) getPodForEphemeralPatch(
+	ctx context.Context,
+	authCtx *authContext,
+	headers http.Header,
+	namespace, podName string,
+) (*corev1.Pod, error) {
+	clientSet, _, err := f.impersonatedKubeClient(authCtx, headers)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	pod, err := clientSet.CoreV1().
+		Pods(namespace).
+		Get(ctx, podName, metav1.GetOptions{})
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return pod, nil
+}
+
+// mergeEphemeralPatchWithCurrentPod merges the provided patch with the given
+// pod and returns the patched pod. The pod must have been fetched by the
+// caller using a client that respects the requesting user's Kubernetes RBAC
+// — see getPodForEphemeralPatch. The patch is expected to be a strategic
 // merge patch that adds an ephemeral container to the pod.
 func (f *Forwarder) mergeEphemeralPatchWithCurrentPod(
-	ctx context.Context,
+	pod *corev1.Pod,
 	cfg mergeEphemeralPatchWithCurrentPodConfig,
 ) (*corev1.Pod, string, error) {
-	details, err := f.findKubeDetailsByClusterName(cfg.kubeCluster)
-	if err != nil {
-		return nil, "", trace.NotFound("kubernetes cluster %q not found", cfg.kubeCluster)
-	}
-
-	pod, err := details.getKubeClient().CoreV1().
-		Pods(cfg.kubeNamespace).
-		Get(ctx, cfg.podName, metav1.GetOptions{})
-	if err != nil {
-		return nil, "", trace.Wrap(err)
-	}
-
 	podSerializedBuf := &bytes.Buffer{}
 	if err := cfg.encoder.Encode(pod, podSerializedBuf); err != nil {
 		return nil, "", trace.Wrap(err)
@@ -324,16 +347,24 @@ func (f *Forwarder) getPatchedPodEvent(ctx context.Context, sess *clusterSession
 		return nil, trace.Wrap(err, "failed to create encoder and decoder")
 	}
 
-	patchedPod, _, err := f.mergeEphemeralPatchWithCurrentPod(
+	pod, err := f.getPodForEphemeralPatch(
 		ctx,
+		&sess.authContext,
+		nil,
+		waitingCont.GetSpec().GetNamespace(),
+		waitingCont.GetSpec().GetPodName(),
+	)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	patchedPod, _, err := f.mergeEphemeralPatchWithCurrentPod(
+		pod,
 		mergeEphemeralPatchWithCurrentPodConfig{
-			kubeCluster:   waitingCont.GetSpec().GetCluster(),
-			kubeNamespace: waitingCont.GetSpec().GetNamespace(),
-			podName:       waitingCont.GetSpec().GetPodName(),
-			decoder:       decoder,
-			encoder:       encoder,
-			podPatch:      waitingCont.GetSpec().GetPatch(),
-			patchType:     apimachinerytypes.PatchType(waitingCont.GetSpec().GetPatchType()),
+			decoder:   decoder,
+			encoder:   encoder,
+			podPatch:  waitingCont.GetSpec().GetPatch(),
+			patchType: apimachinerytypes.PatchType(waitingCont.GetSpec().GetPatchType()),
 		},
 	)
 	if err != nil {

--- a/lib/kube/proxy/ephemeral_containers.go
+++ b/lib/kube/proxy/ephemeral_containers.go
@@ -170,7 +170,17 @@ func (f *Forwarder) ephemeralContainersLocal(authCtx *authContext, sess *cluster
 		return trace.Wrap(err)
 	}
 
-	if err := f.createWaitingContainer(req.Context(), ephemeralContName, authCtx, podPatch, reqPatchType); err != nil {
+	// Resolve the impersonation identity that the caller's headers select.
+	// Stored on the waiting container so the watch path can replay the same impersonation later,
+	// when the original request headers are gone.
+	kubeUser, kubeGroups, err := computeAndValidateImpersonatedPrincipals(
+		authCtx.kubeUsers, authCtx.kubeGroups, authCtx.User.GetName(), req.Header,
+	)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	if err := f.createWaitingContainer(req.Context(), ephemeralContName, authCtx, podPatch, reqPatchType, kubeUser, kubeGroups); err != nil {
 		return trace.Wrap(err)
 	}
 
@@ -214,6 +224,20 @@ func (f *Forwarder) mergeEphemeralPatchWithCurrentPod(
 	return patchedPod, ephemeralContName, nil
 }
 
+// impersonationHeadersFromWaitingContainer materialises Impersonate-User/Impersonate-Group headers
+// from the impersonation captured when the waiting container was created,
+// so getPodForEphemeralPatch can re-apply the same choice on the watch path where no live request headers exist.
+func impersonationHeadersFromWaitingContainer(waitingCont *kubewaitingcontainerpb.KubernetesWaitingContainer) http.Header {
+	headers := http.Header{}
+	if user := waitingCont.GetSpec().GetKubernetesUser(); user != "" {
+		headers.Set(ImpersonateUserHeader, user)
+	}
+	for _, group := range waitingCont.GetSpec().GetKubernetesGroups() {
+		headers.Add(ImpersonateGroupHeader, group)
+	}
+	return headers
+}
+
 // getPodForEphemeralPatch fetches the target pod using a Kubernetes client
 // that impersonates the requesting user's `kubernetes_users` / `kubernetes_groups`.
 // The Kubernetes API server therefore enforces RBAC on the user's mapped identity for this read, even though
@@ -237,17 +261,19 @@ func (f *Forwarder) getPodForEphemeralPatch(
 	return pod, nil
 }
 
-func (f *Forwarder) createWaitingContainer(ctx context.Context, ephemeralContName string, authCtx *authContext, podPatch []byte, patchType apimachinerytypes.PatchType) error {
+func (f *Forwarder) createWaitingContainer(ctx context.Context, ephemeralContName string, authCtx *authContext, podPatch []byte, patchType apimachinerytypes.PatchType, kubeUser string, kubeGroups []string) error {
 	waitingCont, err := kubewaitingcontainer.NewKubeWaitingContainer(
 		ephemeralContName,
 		kubewaitingcontainerpb.KubernetesWaitingContainerSpec_builder{
-			Username:      authCtx.User.GetName(),
-			Cluster:       authCtx.kubeClusterName,
-			Namespace:     authCtx.metaResource.requestedResource.namespace,
-			PodName:       authCtx.metaResource.requestedResource.resourceName,
-			ContainerName: ephemeralContName,
-			Patch:         podPatch,
-			PatchType:     string(patchType),
+			Username:         authCtx.User.GetName(),
+			Cluster:          authCtx.kubeClusterName,
+			Namespace:        authCtx.metaResource.requestedResource.namespace,
+			PodName:          authCtx.metaResource.requestedResource.resourceName,
+			ContainerName:    ephemeralContName,
+			Patch:            podPatch,
+			PatchType:        string(patchType),
+			KubernetesUser:   kubeUser,
+			KubernetesGroups: kubeGroups,
 		}.Build())
 	if err != nil {
 		return trace.Wrap(err)
@@ -344,7 +370,7 @@ func (f *Forwarder) getPatchedPodEvent(ctx context.Context, sess *clusterSession
 	pod, err := f.getPodForEphemeralPatch(
 		ctx,
 		&sess.authContext,
-		nil,
+		impersonationHeadersFromWaitingContainer(waitingCont),
 		waitingCont.GetSpec().GetNamespace(),
 		waitingCont.GetSpec().GetPodName(),
 	)

--- a/lib/kube/proxy/ephemeral_containers.go
+++ b/lib/kube/proxy/ephemeral_containers.go
@@ -290,16 +290,18 @@ func (f *Forwarder) impersonatedKubeClient(authCtx *authContext, headers http.He
 	if err != nil {
 		return nil, nil, trace.NotFound("kubernetes cluster %q not found", authCtx.kubeClusterName)
 	}
-	restConfig := details.getKubeRestConfig()
 	kubeUser, kubeGroups, err := computeAndValidateImpersonatedPrincipals(authCtx.kubeUsers, authCtx.kubeGroups, authCtx.User.GetName(), headers)
 	if err != nil {
 		return nil, nil, trace.Wrap(err)
 	}
+	// Clone the shared cached rest config before setting impersonation to avoid
+	// racing with concurrent requests to the same cluster.
+	restConfig := *details.getKubeRestConfig()
 	restConfig.Impersonate = rest.ImpersonationConfig{
 		UserName: kubeUser,
 		Groups:   kubeGroups,
 	}
-	clientSet, err := kubernetes.NewForConfig(restConfig)
+	clientSet, err := kubernetes.NewForConfig(&restConfig)
 	if err != nil {
 		return nil, nil, trace.Wrap(err)
 	}

--- a/lib/kube/proxy/ephemeral_containers.go
+++ b/lib/kube/proxy/ephemeral_containers.go
@@ -224,7 +224,7 @@ func (f *Forwarder) mergeEphemeralPatchWithCurrentPod(
 	return patchedPod, ephemeralContName, nil
 }
 
-// impersonationHeadersFromWaitingContainer materialises Impersonate-User/Impersonate-Group headers
+// impersonationHeadersFromWaitingContainer materializes Impersonate-User/Impersonate-Group headers
 // from the impersonation captured when the waiting container was created,
 // so getPodForEphemeralPatch can re-apply the same choice on the watch path where no live request headers exist.
 func impersonationHeadersFromWaitingContainer(waitingCont *kubewaitingcontainerpb.KubernetesWaitingContainer) http.Header {
@@ -241,7 +241,7 @@ func impersonationHeadersFromWaitingContainer(waitingCont *kubewaitingcontainerp
 // getPodForEphemeralPatch fetches the target pod using a Kubernetes client
 // that impersonates the requesting user's `kubernetes_users` / `kubernetes_groups`.
 // The Kubernetes API server therefore enforces RBAC on the user's mapped identity for this read, even though
-// the surrounding moderated-session flow synthesises the patch response locally without forwarding the PATCH itself.
+// the surrounding moderated-session flow synthesizes the patch response locally without forwarding the PATCH itself.
 func (f *Forwarder) getPodForEphemeralPatch(
 	ctx context.Context,
 	authCtx *authContext,

--- a/lib/kube/proxy/ephemeral_containers.go
+++ b/lib/kube/proxy/ephemeral_containers.go
@@ -144,11 +144,8 @@ func (f *Forwarder) ephemeralContainersLocal(authCtx *authContext, sess *cluster
 		return trace.Wrap(err, "failed to create encoder and decoder")
 	}
 
-	// Fetch the target pod using the user's impersonated identity so the
-	// Kubernetes API server enforces RBAC on `kubernetes_users` /
-	// `kubernetes_groups`. Using the proxy's admin kubeconfig here would leak
-	// pod spec/env/annotations the user's mapped identity is not entitled to
-	// see — see lib/kube/proxy/ephemeral_admin_client_test.go.
+	// Fetch the target pod using the user's impersonated identity so
+	// the Kubernetes API server enforces RBAC on `kubernetes_users` / `kubernetes_groups`.
 	pod, err := f.getPodForEphemeralPatch(
 		req.Context(),
 		authCtx,
@@ -198,11 +195,9 @@ type mergeEphemeralPatchWithCurrentPodConfig struct {
 }
 
 // getPodForEphemeralPatch fetches the target pod using a Kubernetes client
-// that impersonates the requesting user's `kubernetes_users` /
-// `kubernetes_groups`. The Kubernetes API server therefore enforces RBAC on
-// the user's mapped identity for this read, even though the surrounding
-// moderated-session flow synthesises the patch response locally without
-// forwarding the PATCH itself.
+// that impersonates the requesting user's `kubernetes_users` / `kubernetes_groups`.
+// The Kubernetes API server therefore enforces RBAC on the user's mapped identity for this read, even though
+// the surrounding moderated-session flow synthesises the patch response locally without forwarding the PATCH itself.
 func (f *Forwarder) getPodForEphemeralPatch(
 	ctx context.Context,
 	authCtx *authContext,
@@ -222,11 +217,10 @@ func (f *Forwarder) getPodForEphemeralPatch(
 	return pod, nil
 }
 
-// mergeEphemeralPatchWithCurrentPod merges the provided patch with the given
-// pod and returns the patched pod. The pod must have been fetched by the
-// caller using a client that respects the requesting user's Kubernetes RBAC
-// — see getPodForEphemeralPatch. The patch is expected to be a strategic
-// merge patch that adds an ephemeral container to the pod.
+// mergeEphemeralPatchWithCurrentPod merges the provided patch with the
+// given pod and returns the patched pod.
+// The pod must have been fetched by the caller using a client that respects the requesting user's Kubernetes RBAC.
+// The patch is expected to be a strategic merge patch that adds an ephemeral container to the pod.
 func (f *Forwarder) mergeEphemeralPatchWithCurrentPod(
 	pod *corev1.Pod,
 	cfg mergeEphemeralPatchWithCurrentPodConfig,

--- a/lib/kube/proxy/sess.go
+++ b/lib/kube/proxy/sess.go
@@ -1645,16 +1645,24 @@ func (s *session) retrieveEphemeralContainerCommand(ctx context.Context, usernam
 			s.log.WarnContext(ctx, "Failed to create encoder and decoder", "error", err)
 			return nil
 		}
-		pod, _, err := s.forwarder.mergeEphemeralPatchWithCurrentPod(
+		currentPod, err := s.forwarder.getPodForEphemeralPatch(
 			ctx,
+			&s.ctx,
+			s.req.Header,
+			s.podNamespace,
+			s.podName,
+		)
+		if err != nil {
+			s.log.WarnContext(ctx, "Failed to get pod for ephemeral patch", "error", err)
+			return nil
+		}
+		pod, _, err := s.forwarder.mergeEphemeralPatchWithCurrentPod(
+			currentPod,
 			mergeEphemeralPatchWithCurrentPodConfig{
-				kubeCluster:   s.ctx.kubeClusterName,
-				kubeNamespace: s.podNamespace,
-				podName:       s.podName,
-				decoder:       decoder,
-				encoder:       encoder,
-				podPatch:      container.GetSpec().GetPatch(),
-				patchType:     apimachinerytypes.PatchType(container.GetSpec().GetPatchType()),
+				decoder:   decoder,
+				encoder:   encoder,
+				podPatch:  container.GetSpec().GetPatch(),
+				patchType: apimachinerytypes.PatchType(container.GetSpec().GetPatchType()),
 			},
 		)
 		if err != nil {

--- a/lib/kube/proxy/sess.go
+++ b/lib/kube/proxy/sess.go
@@ -1648,7 +1648,7 @@ func (s *session) retrieveEphemeralContainerCommand(ctx context.Context, usernam
 		currentPod, err := s.forwarder.getPodForEphemeralPatch(
 			ctx,
 			&s.ctx,
-			s.req.Header,
+			impersonationHeadersFromWaitingContainer(container),
 			s.podNamespace,
 			s.podName,
 		)


### PR DESCRIPTION
The moderated ephemeral-container flow fetched the target pod with the proxy's static admin kubeconfig and encoded the full pod back to the requester. A user whose Teleport role permits `patch pods/ephemeralcontainers` and whose moderation policy forces them through `ephemeralContainersLocal` would see pod spec, env, annotations, SA, imagePullSecrets, and Secret/ConfigMap volume refs regardless of what their mapped `kubernetes_users`/`kubernetes_groups` are authorised to read.

Fix: new `getPodForEphemeralPatch` does the GET via `impersonatedKubeClient(authCtx, headers)`. `mergeEphemeralPatchWithCurrentPod` is reduced to a pure in-memory merge taking a pre-fetched pod. Three callers updated: `ephemeralContainersLocal`, `getPatchedPodEvent` (watch path), and the patch-reader in `sess.go`.

After the fix, a denied upstream GET surfaces to the caller as HTTP 500 with the upstream K8s error message in the body, rather than as an HTTP 403. This is because `trace.ErrorToCode` does not recognise `*kubeerrors.StatusError` and falls through to the default. I left this as-is intentionally to keep this change small and focused; mapping K8s status codes to trace error types in `getPodForEphemeralPatch` would be a small follow-up.

<!-- Include manual testing efforts to verify the change. -->
<!-- Detail where the tests where run and what configurations were used. -->
<!-- Include all the test cases which were run to validate the change. -->

## Manual Test Plan

### Test Environment

kind cluster + Teleport Enterprise 18.4.2 (locally rebuilt from this branch), single auth + proxy via the `teleport-cluster` Helm chart.

### Test Cases

- [x] **User in moderated flow whose mapped K8s identity has neither `get pods` nor `patch pods/ephemeralcontainers`:** PATCH `/ephemeralcontainers` returned HTTP 500 with body `User "victim-k8s" cannot get resource "pods"` (247 bytes); zero sensitive pod fields present.
- [x] **Same user but K8s identity has both permissions (happy path):** PATCH returned HTTP 200 with the synthesised patched pod (8152 bytes), kubectl can proceed.
- [x] **User without `require_session_join` (catchAll path):** With K8s perms, HTTP 200 with full pod (K8s API behavior, unchanged). With K8s perms stripped, HTTP 403 from K8s propagated verbatim.
- [x] **Watch path:** Synthetic `watch.Event{Modified}` for a waiting container appears only when the mapped K8s identity can GET the pod. Verified with K8s `list/watch pods` allowed but `get pods` denied: the synthetic event is suppressed while the real K8s watch passes through unchanged.
- [x] **Audit events for the moderated PATCH still emitted with existing fields:** verb=PATCH, resource_kind=`pods/ephemeralcontainers`, kubernetes_users, login, response_code, server_id, uid, addr.remote all present.
