### PR TITLE
reject null bytes in backend keys when sanitizing them

### DIFF
--- a/lib/backend/backend.go
+++ b/lib/backend/backend.go
@@ -262,9 +262,8 @@ func (p Params) GetString(key string) string {
 // NoLimit specifies no limits
 const NoLimit = 0
 
-const noEnd = "\x00"
-
-// RangeEnd returns end of the range for given key.
+// RangeEnd returns end of the range for given key. It returns a zero
+// key if no end exists which backends will reject as invalid.
 func RangeEnd(key Key) Key {
 	end := make([]byte, len(key.s))
 	copy(end, key.s)
@@ -276,7 +275,7 @@ func RangeEnd(key Key) Key {
 		}
 	}
 	// next key does not exist (e.g., 0xffff);
-	return Key{noEnd: true}
+	return Key{}
 }
 
 // HostID is a derivation of a KeyedItem that allows the host id

--- a/lib/backend/backend_test.go
+++ b/lib/backend/backend_test.go
@@ -65,6 +65,15 @@ func TestRangeEnd(t *testing.T) {
 			key:      NewKey("\xFF\xFF\xFF"),
 			expected: Key{s: "0", components: []string{"0"}},
 		},
+		// KeyFromString does not add any separators
+		{
+			key:      KeyFromString("\xFF"),
+			expected: Key{},
+		},
+		{
+			key:      KeyFromString("\xFF\xFF\xFF"),
+			expected: Key{},
+		},
 	} {
 		t.Run(test.key.String(), func(t *testing.T) {
 			end := RangeEnd(test.key)

--- a/lib/backend/key.go
+++ b/lib/backend/key.go
@@ -27,8 +27,11 @@ import (
 type Key struct {
 	s          string
 	components []string
-	exactKey   bool
-	noEnd      bool
+	// exactKey is true if the key ends in a [Separator] and will only
+	// match child paths.
+	exactKey bool
+	// noEnd is true if there is is no end to the range of this key.
+	noEnd bool
 }
 
 const (

--- a/lib/backend/key.go
+++ b/lib/backend/key.go
@@ -30,8 +30,6 @@ type Key struct {
 	// exactKey is true if the key ends in a [Separator] and will only
 	// match child paths.
 	exactKey bool
-	// noEnd is true if there is is no end to the range of this key.
-	noEnd bool
 }
 
 const (
@@ -81,7 +79,6 @@ func KeyFromString(s string) Key {
 		components: components,
 		s:          s,
 		exactKey:   s == SeparatorString || (s != "" && s[len(s)-1] == Separator),
-		noEnd:      s == noEnd,
 	}
 }
 
@@ -104,10 +101,6 @@ func (k Key) ExactKey() Key {
 // String returns the textual representation of the key with
 // each component concatenated together via the [Separator].
 func (k Key) String() string {
-	if k.noEnd {
-		return noEnd
-	}
-
 	return k.s
 }
 

--- a/lib/backend/sanitize.go
+++ b/lib/backend/sanitize.go
@@ -57,8 +57,6 @@ func isValidKeyByte(b byte) bool {
 func IsKeySafe(key Key) bool {
 	for i, k := range key.components {
 		switch k {
-		case noEnd:
-			continue
 		case ".", "..":
 			return false
 		case "":

--- a/lib/backend/sanitize_test.go
+++ b/lib/backend/sanitize_test.go
@@ -109,6 +109,18 @@ func TestSanitize(t *testing.T) {
 			inKey:  NewKey("xyz"),
 			assert: require.NoError,
 		},
+		{
+			inKey:  NewKey("\x00"),
+			assert: require.Error,
+		},
+		{
+			inKey:  NewKey("\x00\x00"),
+			assert: require.Error,
+		},
+		{
+			inKey:  NewKey("test\x00key"),
+			assert: require.Error,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Fixes https://github.com/gravitational/pressure-washing/issues/135.
