### PR TITLE
docs: Bound keypair fixes

### DIFF
--- a/docs/pages/reference/machine-workload-identity/bound-keypair/admin-guide.mdx
+++ b/docs/pages/reference/machine-workload-identity/bound-keypair/admin-guide.mdx
@@ -367,7 +367,8 @@ but the general steps are:
    * If passing the private key via an environment variable, copy the value directly
    * If passing the private key via file, decode the base64-encoded private key first:
      ```code
-     $ tbot keypair create --proxy-server example.teleport.sh:443 --static --format json | jq -r .private_key | base64 -d
+     $ tbot keypair create --proxy-server example.teleport.sh:443 --static --format json > bound_keypair.json
+     $ cat bound_keypair.json | jq -r .private_key | base64 -d
      ```
      ...and store the result as needed.
 

--- a/docs/pages/reference/machine-workload-identity/bound-keypair/concepts.mdx
+++ b/docs/pages/reference/machine-workload-identity/bound-keypair/concepts.mdx
@@ -93,8 +93,8 @@ values:
   their tolerance for automatic bot recovery attempts.
 
   [Join state verification](#join-state-verification) is enabled, which helps
-  prevent keypair reuse, but does require clients to store additional on each
-  join.
+  prevent keypair reuse, but does require clients to store additional state
+  on each join.
 
   Note that as the initial join counts as a recovery attempt, `limit` must
   always be at least `1` for the initial join to succeed.

--- a/docs/pages/reference/machine-workload-identity/bound-keypair/getting-started.mdx
+++ b/docs/pages/reference/machine-workload-identity/bound-keypair/getting-started.mdx
@@ -70,7 +70,7 @@ method works and how to use it in production.
 - The `tsh` and `tctl` clients.
 - (!docs/pages/includes/tctl.mdx!)
 - This guide assumes the bot host has mutable persistent storage for internal
-  bot data. While it is possible to use Bound Keypair Joining can on immutable
+  bot data. While it is possible to use Bound Keypair Joining on immutable
   hosts (like CI runs), doing so will reduce security guarantees; see the
   [reference page][reference] for further information.
 

--- a/docs/pages/reference/machine-workload-identity/bound-keypair/static-keys.mdx
+++ b/docs/pages/reference/machine-workload-identity/bound-keypair/static-keys.mdx
@@ -165,11 +165,11 @@ metadata:
 spec:
   bot_name: example
   bound_keypair:
-  onboarding:
-    initial_public_key: <Var name="public key"/>
-  recovery:
-    limit: 0
-    mode: insecure
+    onboarding:
+      initial_public_key: <Var name="public key"/>
+     recovery:
+       limit: 0
+       mode: insecure
   join_method: bound_keypair
   roles:
   - Bot

--- a/docs/pages/reference/machine-workload-identity/bound-keypair/static-keys.mdx
+++ b/docs/pages/reference/machine-workload-identity/bound-keypair/static-keys.mdx
@@ -167,9 +167,9 @@ spec:
   bound_keypair:
     onboarding:
       initial_public_key: <Var name="public key"/>
-     recovery:
-       limit: 0
-       mode: insecure
+    recovery:
+      limit: 0
+      mode: insecure
   join_method: bound_keypair
   roles:
   - Bot


### PR DESCRIPTION
docs/pages/reference/machine-workload-identity/bound-keypair/admin-guide.mdx:
- update to capture the whole bound-keypair, then pass to decode the private key pair. Otherwise you only get the private key

docs/pages/reference/machine-workload-identity/bound-keypair/concepts.mdx:
- grammar fix

docs/pages/reference/machine-workload-identity/bound-keypair/getting-started.mdx:
- grammar fix

docs/pages/reference/machine-workload-identity/bound-keypair/static-keys.mdx:
- fix token yaml indentation