### PR TITLE
Refactor Azure VM discovery metadata and status

### DIFF
--- a/lib/cloud/azure/vm.go
+++ b/lib/cloud/azure/vm.go
@@ -484,6 +484,13 @@ func (c *runCommandClient) Run(ctx context.Context, req RunCommandRequest) (*Run
 	runCommand := armcompute.VirtualMachineRunCommand{
 		Location: to.Ptr(req.Region),
 		Properties: &armcompute.VirtualMachineRunCommandProperties{
+			// NOTE: The AsyncExecution option can be very misleading.
+			// It has no effect on whether BeginCreateOrUpdate blocks.
+			// Instead, it affects poller.PollUntilDone.
+			// If set to true, then calling poller.PollUntilDone will actually
+			// return as soon as the script is "provisioned" even if
+			// the script execution state is still "running".
+			// We always want this option set to false.
 			AsyncExecution: to.Ptr(false),
 			Source: &armcompute.VirtualMachineRunCommandScriptSource{
 				Script: to.Ptr(req.Script),

--- a/lib/srv/discovery/azure_vm_error_parser.go
+++ b/lib/srv/discovery/azure_vm_error_parser.go
@@ -23,7 +23,15 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 
 	"github.com/gravitational/teleport/api/types/usertasks"
+	"github.com/gravitational/teleport/lib/srv/server"
 )
+
+func classifyAzureInstallResultIssue(installResult server.AzureInstallResult) string {
+	if installResult.CommandResult != nil {
+		return usertasks.AutoDiscoverAzureVMIssueEnrollmentError
+	}
+	return classifyAzureVMEnrollmentError(installResult.APIError)
+}
 
 // classifyAzureVMEnrollmentError classifies Azure API errors into user-facing
 // messages for VM auto-discovery. This is best-effort based on error strings

--- a/lib/srv/discovery/discovery.go
+++ b/lib/srv/discovery/discovery.go
@@ -1698,8 +1698,6 @@ func (s *Server) installAzureServers(instances *server.AzureInstances, vmTasks *
 		return status
 	}
 	instances.FilterExistingNodes(nodes)
-	// re-evaluate the instances log value after filtering
-	log = s.Log.With("group", instances)
 
 	// count machines that have already been enrolled in previous cycles.
 	needInstall := len(instances.Instances)
@@ -1709,6 +1707,8 @@ func (s *Server) installAzureServers(instances *server.AzureInstances, vmTasks *
 		log.DebugContext(s.ctx, "Filtered out Azure instances that have already been enrolled",
 			"enrolled", enrolled,
 		)
+		// re-evaluate the instances log value after filtering
+		log = s.Log.With("group", instances)
 	}
 
 	if len(instances.Instances) == 0 {

--- a/lib/srv/discovery/discovery.go
+++ b/lib/srv/discovery/discovery.go
@@ -1533,12 +1533,12 @@ func (e *limitedErrorReporter) summary(ctx context.Context) {
 }
 
 func (s *Server) enrollAzureVirtualMachines(log *slog.Logger, instances *server.AzureInstances) ([]server.AzureInstallResult, error) {
-	azureClients, err := s.getAzureClients(s.ctx, instances.Integration)
+	azureClients, err := s.getAzureClients(s.ctx, instances.Metadata.Integration)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
-	runClient, err := azureClients.GetRunCommandClient(s.ctx, instances.SubscriptionID)
+	runClient, err := azureClients.GetRunCommandClient(s.ctx, instances.Metadata.SubscriptionID)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -1554,12 +1554,12 @@ func (s *Server) enrollAzureVirtualMachines(log *slog.Logger, instances *server.
 
 	req := server.AzureInstallRequest{
 		Instances:       instances.Instances,
-		Region:          instances.Region,
-		ResourceGroup:   instances.ResourceGroup,
-		InstallerParams: instances.InstallerParams,
+		Region:          instances.Metadata.Region,
+		ResourceGroup:   instances.Metadata.ResourceGroup,
+		InstallerParams: instances.Metadata.InstallerParams,
 		ProxyAddrGetter: s.publicProxyAddress,
 		OnRunCommandFinished: func(result server.AzureInstallResult) {
-			s.emitAzureInstallEvents(log, instances.AzureInstancesMetadata, result)
+			s.emitAzureInstallEvents(log, instances.Metadata, result)
 			if result.Failure() {
 				reporter.report(s.ctx, result)
 
@@ -1650,8 +1650,8 @@ func (s *Server) startAzureServerDiscovery() {
 		server.WithPerInstanceHookFn(func(instanceGroups []*server.AzureInstances) {
 			for _, group := range instanceGroups {
 				key := discoveryGroupStatusKey{
-					discoveryConfigName: group.DiscoveryConfigName,
-					integration:         group.Integration,
+					discoveryConfigName: group.Metadata.DiscoveryConfigName,
+					integration:         group.Metadata.Integration,
 				}
 				status := s.installAzureServers(group, vmTasks)
 				sm.add(key, status)
@@ -1725,7 +1725,7 @@ func (s *Server) installAzureServers(instances *server.AzureInstances, vmTasks *
 
 		issueType := classifyAzureVMEnrollmentError(err)
 		for _, vm := range instances.Instances {
-			s.addFailedAzureEnrollment(instances.AzureInstancesMetadata, vmTasks, vm, issueType)
+			s.addFailedAzureEnrollment(instances.Metadata, vmTasks, vm, issueType)
 		}
 		return status
 	}
@@ -1740,7 +1740,7 @@ func (s *Server) installAzureServers(instances *server.AzureInstances, vmTasks *
 	// Record failures as user tasks.
 	for _, result := range failures {
 		// TODO (Tener): check exit codes and create more detailed user tasks.
-		s.addFailedAzureEnrollment(instances.AzureInstancesMetadata, vmTasks, result.Instance, classifyAzureInstallResultIssue(result))
+		s.addFailedAzureEnrollment(instances.Metadata, vmTasks, result.Instance, classifyAzureInstallResultIssue(result))
 	}
 
 	pendingCount := len(instances.Instances) - len(failures)

--- a/lib/srv/discovery/discovery.go
+++ b/lib/srv/discovery/discovery.go
@@ -1716,6 +1716,35 @@ func (s *Server) installAzureServers(instances *server.AzureInstances, vmTasks *
 		return status
 	}
 
+	addFailedAzureEnrollment := func(vm *azure.VirtualMachine, issueType string) {
+		// Static matchers don't have a discovery config resource, so skip creating user tasks
+		// because validation requires a discovery config name.
+		if instances.Metadata.DiscoveryConfigName == noDiscoveryConfig {
+			return
+		}
+
+		tg := usertasks.TaskGroup{
+			Integration: instances.Metadata.Integration,
+			IssueType:   issueType,
+		}
+		vmTasks.addFailedEnrollment(
+			tg,
+			azureVMTaskKey{
+				subscriptionID: instances.Metadata.SubscriptionID,
+				resourceGroup:  instances.Metadata.ResourceGroup,
+				region:         instances.Metadata.Region,
+			},
+			usertasksv1.DiscoverAzureVMInstance_builder{
+				VmId:            vm.VMID,
+				ResourceId:      vm.ID,
+				Name:            vm.Name,
+				DiscoveryConfig: instances.Metadata.DiscoveryConfigName,
+				DiscoveryGroup:  s.DiscoveryGroup,
+				SyncTime:        timestamppb.New(s.clock.Now()),
+			}.Build(),
+		)
+	}
+
 	log.DebugContext(s.ctx, "Running Teleport installation on virtual machines", "vms", genAzureInstancesLogStr(instances.Instances))
 	failures, err := s.enrollAzureVirtualMachines(log, instances)
 	if err != nil {
@@ -1725,7 +1754,7 @@ func (s *Server) installAzureServers(instances *server.AzureInstances, vmTasks *
 
 		issueType := classifyAzureVMEnrollmentError(err)
 		for _, vm := range instances.Instances {
-			s.addFailedAzureEnrollment(instances.Metadata, vmTasks, vm, issueType)
+			addFailedAzureEnrollment(vm, issueType)
 		}
 		return status
 	}
@@ -1740,7 +1769,7 @@ func (s *Server) installAzureServers(instances *server.AzureInstances, vmTasks *
 	// Record failures as user tasks.
 	for _, result := range failures {
 		// TODO (Tener): check exit codes and create more detailed user tasks.
-		s.addFailedAzureEnrollment(instances.Metadata, vmTasks, result.Instance, classifyAzureInstallResultIssue(result))
+		addFailedAzureEnrollment(result.Instance, classifyAzureInstallResultIssue(result))
 	}
 
 	pendingCount := len(instances.Instances) - len(failures)
@@ -2354,33 +2383,4 @@ func (s *Server) resolveCreateErr(createErr error, discoveryOrigin string, gette
 	}
 
 	return nil
-}
-
-func (s *Server) addFailedAzureEnrollment(md server.AzureInstancesMetadata, vmTasks *azureVMTasks, vm *azure.VirtualMachine, issueType string) {
-	// Static matchers don't have a discovery config resource, so skip creating user tasks
-	// because validation requires a discovery config name.
-	if md.DiscoveryConfigName == noDiscoveryConfig {
-		return
-	}
-
-	tg := usertasks.TaskGroup{
-		Integration: md.Integration,
-		IssueType:   issueType,
-	}
-	vmTasks.addFailedEnrollment(
-		tg,
-		azureVMTaskKey{
-			subscriptionID: md.SubscriptionID,
-			resourceGroup:  md.ResourceGroup,
-			region:         md.Region,
-		},
-		usertasksv1.DiscoverAzureVMInstance_builder{
-			VmId:            vm.VMID,
-			ResourceId:      vm.ID,
-			Name:            vm.Name,
-			DiscoveryConfig: md.DiscoveryConfigName,
-			DiscoveryGroup:  s.DiscoveryGroup,
-			SyncTime:        timestamppb.New(s.clock.Now()),
-		}.Build(),
-	)
 }

--- a/lib/srv/discovery/discovery.go
+++ b/lib/srv/discovery/discovery.go
@@ -455,7 +455,7 @@ type Server struct {
 	awsEC2Tasks           awsEC2Tasks
 	awsEKSTasks           awsEKSTasks
 	awsRDSTasks           awsRDSTasks
-	azureVMStatus         atomic.Pointer[resourceStatusMap]
+	azureVMStatus         atomic.Pointer[discoveryStatus]
 
 	// caRotationCh receives nodes that need to have their CAs rotated.
 	caRotationCh chan []types.Server
@@ -1456,9 +1456,9 @@ func (s *Server) startAWSServerDiscovery() {
 	go s.watchCARotation(s.ctx)
 }
 
-func (s *Server) emitAzureInstallEvents(log *slog.Logger, instances *server.AzureInstances, result server.AzureInstallResult) {
+func (s *Server) emitAzureInstallEvents(log *slog.Logger, md server.AzureInstancesMetadata, result server.AzureInstallResult) {
 	// emit run event.
-	runEvent := instances.MakeRunEvent(result)
+	runEvent := md.MakeRunEvent(result)
 	err := s.Emitter.EmitAuditEvent(s.ctx, runEvent)
 	if err != nil {
 		log.WarnContext(s.ctx, "Failed to emit audit event", "error", err)
@@ -1469,7 +1469,7 @@ func (s *Server) emitAzureInstallEvents(log *slog.Logger, instances *server.Azur
 	}
 
 	// on success, emit usage event.
-	vmKey, usageEvent := instances.MakeUsageEvent(result.Instance)
+	vmKey, usageEvent := md.MakeUsageEvent(result.Instance)
 	err = s.emitUsageEvent(vmKey, usageEvent)
 	if err != nil {
 		log.WarnContext(s.ctx, "Failed to emit usage event", "error", err)
@@ -1559,7 +1559,7 @@ func (s *Server) enrollAzureVirtualMachines(log *slog.Logger, instances *server.
 		InstallerParams: instances.InstallerParams,
 		ProxyAddrGetter: s.publicProxyAddress,
 		OnRunCommandFinished: func(result server.AzureInstallResult) {
-			s.emitAzureInstallEvents(log, instances, result)
+			s.emitAzureInstallEvents(log, instances.AzureInstancesMetadata, result)
 			if result.Failure() {
 				reporter.report(s.ctx, result)
 
@@ -1616,7 +1616,7 @@ func (s *Server) startAzureServerDiscovery() {
 		azureWatcher.ReplaceFetchers(replaceMap)
 	}
 
-	var sm *resourceStatusMap
+	var sm *discoveryStatus
 	var vmTasks *azureVMTasks
 	var runStart time.Time
 
@@ -1639,22 +1639,22 @@ func (s *Server) startAzureServerDiscovery() {
 			// "0 found/enrolled/failed" update instead of leaving stale non-zero status from a
 			// previous iteration.
 			for _, fetcher := range fetchers {
-				fgKey := fetcherGroupKey{
+				key := discoveryGroupStatusKey{
 					discoveryConfigName: fetcher.GetDiscoveryConfigName(),
 					integration:         fetcher.IntegrationName(),
 				}
-				sm.add(fgKey, make(map[statusType]int))
+				sm.add(key, discoveryGroupStatus{})
 			}
 			s.updateDiscoveryConfigStatus(sm.discoveryConfigs()...)
 		}),
 		server.WithPerInstanceHookFn(func(instanceGroups []*server.AzureInstances) {
 			for _, group := range instanceGroups {
-				fgKey := fetcherGroupKey{
+				key := discoveryGroupStatusKey{
 					discoveryConfigName: group.DiscoveryConfigName,
 					integration:         group.Integration,
 				}
-				results := s.installAzureServers(group, vmTasks)
-				sm.add(fgKey, results)
+				status := s.installAzureServers(group, vmTasks)
+				sm.add(key, status)
 			}
 		}),
 		server.WithPostFetchHookFn[*server.AzureInstances](func() {
@@ -1681,94 +1681,66 @@ func (s *Server) startAzureServerDiscovery() {
 	go azureWatcher.Run()
 }
 
-func (s *Server) installAzureServers(instances *server.AzureInstances, vmTasks *azureVMTasks) (results map[statusType]int) {
-	results = make(map[statusType]int)
-
+func (s *Server) installAzureServers(instances *server.AzureInstances, vmTasks *azureVMTasks) discoveryGroupStatus {
+	var status discoveryGroupStatus
 	log := s.Log.With("group", instances)
 	log.DebugContext(s.ctx, "Processing instance group")
-
-	allFound := len(instances.Instances)
-	results[statusFound] = allFound
-
-	if allFound == 0 {
+	found := len(instances.Instances)
+	if found == 0 {
 		log.DebugContext(s.ctx, "No Azure instances found, skipping installation")
-		return
+		return status
 	}
+	status.found += found
 
 	nodes, err := s.nodeWatcher.CurrentResources(s.ctx)
 	if err != nil {
 		log.WarnContext(s.ctx, "Failed to get current node resources", "error", err)
-		return
+		return status
 	}
 	instances.FilterExistingNodes(nodes)
+	// re-evaluate the instances log value after filtering
+	log = s.Log.With("group", instances)
 
 	// count machines that have already been enrolled in previous cycles.
 	needInstall := len(instances.Instances)
-	results[statusEnrolled] = allFound - needInstall
-
-	if len(instances.Instances) == 0 {
-		log.DebugContext(s.ctx, "No Azure instances remain to enroll, skipping installation")
-		return
-	}
-
-	addFailedEnrollment := func(vm *azure.VirtualMachine, issueType string) {
-		// Static matchers don't have a discovery config resource, so skip creating user tasks
-		// because validation requires a discovery config name.
-		if instances.DiscoveryConfigName == noDiscoveryConfig {
-			return
-		}
-
-		tg := usertasks.TaskGroup{
-			Integration: instances.Integration,
-			IssueType:   issueType,
-		}
-		vmTasks.addFailedEnrollment(
-			tg,
-			azureVMTaskKey{
-				subscriptionID: instances.SubscriptionID,
-				resourceGroup:  instances.ResourceGroup,
-				region:         instances.Region,
-			},
-			usertasksv1.DiscoverAzureVMInstance_builder{
-				VmId:            vm.VMID,
-				ResourceId:      vm.ID,
-				Name:            vm.Name,
-				DiscoveryConfig: instances.DiscoveryConfigName,
-				DiscoveryGroup:  s.DiscoveryGroup,
-				SyncTime:        timestamppb.New(s.clock.Now()),
-			}.Build(),
+	enrolled := found - needInstall
+	if enrolled > 0 {
+		status.enrolled += enrolled
+		log.DebugContext(s.ctx, "Filtered out Azure instances that have already been enrolled",
+			"enrolled", enrolled,
 		)
 	}
 
-	log.DebugContext(s.ctx, "Running Teleport installation on virtual machines", "group", instances, "vms", genAzureInstancesLogStr(instances.Instances))
+	if len(instances.Instances) == 0 {
+		log.DebugContext(s.ctx, "No Azure instances remain to enroll, skipping installation")
+		return status
+	}
+
+	log.DebugContext(s.ctx, "Running Teleport installation on virtual machines", "vms", genAzureInstancesLogStr(instances.Instances))
 	failures, err := s.enrollAzureVirtualMachines(log, instances)
 	if err != nil {
 		// treat non-nil err as deployment failure affecting all machines.
-		log.WarnContext(s.ctx, "Failed to enroll discovered Azure VMs", "error", err, "count", len(instances.Instances))
-		results[statusFailed] = len(instances.Instances)
+		log.WarnContext(s.ctx, "Failed to enroll all discovered Azure VMs", "error", err)
+		status.failed += len(instances.Instances)
 
 		issueType := classifyAzureVMEnrollmentError(err)
 		for _, vm := range instances.Instances {
-			addFailedEnrollment(vm, issueType)
+			s.addFailedAzureEnrollment(instances.AzureInstancesMetadata, vmTasks, vm, issueType)
 		}
-		return
+		return status
 	}
 
 	if len(failures) > 0 {
-		log.WarnContext(s.ctx, "Failed to enroll some discovered Azure VMs", "count", len(failures))
+		log.WarnContext(s.ctx, "Failed to enroll some discovered Azure VMs", "failures", len(failures))
 	}
 
 	// count individual failed enrollments.
-	results[statusFailed] = len(failures)
+	status.failed += len(failures)
 
 	// Record failures as user tasks.
 	for _, result := range failures {
-		if result.CommandResult != nil {
-			// TODO (Tener): check exit codes and create more detailed user tasks.
-			addFailedEnrollment(result.Instance, usertasks.AutoDiscoverAzureVMIssueEnrollmentError)
-		} else {
-			addFailedEnrollment(result.Instance, classifyAzureVMEnrollmentError(result.APIError))
-		}
+		// TODO (Tener): check exit codes and create more detailed user tasks.
+		s.addFailedAzureEnrollment(instances.AzureInstancesMetadata, vmTasks, result.Instance, classifyAzureInstallResultIssue(result))
 	}
 
 	pendingCount := len(instances.Instances) - len(failures)
@@ -1780,8 +1752,7 @@ func (s *Server) installAzureServers(instances *server.AzureInstances, vmTasks *
 		// There is no easy way to close that gap in the current architecture.
 		log.DebugContext(s.ctx, "Installation attempt finished. If the machines have joined the cluster successfully, they will be counted as enrolled during the next iteration.", "pending", pendingCount)
 	}
-
-	return
+	return status
 }
 
 func (s *Server) filterExistingGCPNodes(instances *server.GCPInstances) error {
@@ -2383,4 +2354,33 @@ func (s *Server) resolveCreateErr(createErr error, discoveryOrigin string, gette
 	}
 
 	return nil
+}
+
+func (s *Server) addFailedAzureEnrollment(md server.AzureInstancesMetadata, vmTasks *azureVMTasks, vm *azure.VirtualMachine, issueType string) {
+	// Static matchers don't have a discovery config resource, so skip creating user tasks
+	// because validation requires a discovery config name.
+	if md.DiscoveryConfigName == noDiscoveryConfig {
+		return
+	}
+
+	tg := usertasks.TaskGroup{
+		Integration: md.Integration,
+		IssueType:   issueType,
+	}
+	vmTasks.addFailedEnrollment(
+		tg,
+		azureVMTaskKey{
+			subscriptionID: md.SubscriptionID,
+			resourceGroup:  md.ResourceGroup,
+			region:         md.Region,
+		},
+		usertasksv1.DiscoverAzureVMInstance_builder{
+			VmId:            vm.VMID,
+			ResourceId:      vm.ID,
+			Name:            vm.Name,
+			DiscoveryConfig: md.DiscoveryConfigName,
+			DiscoveryGroup:  s.DiscoveryGroup,
+			SyncTime:        timestamppb.New(s.clock.Now()),
+		}.Build(),
+	)
 }

--- a/lib/srv/discovery/status.go
+++ b/lib/srv/discovery/status.go
@@ -1071,66 +1071,62 @@ func (s *taskUpdater) mergeAzure(oldSpec *usertasksv1.UserTaskSpec, newSpec *use
 	mergeExistingInstances(s, oldSpec.GetDiscoverAzureVm().GetInstances(), newSpec.GetDiscoverAzureVm().GetInstances())
 }
 
-type statusType int
-
-const (
-	statusFound statusType = iota
-	statusEnrolled
-	statusFailed
-)
-
-type fetcherGroupKey struct {
+type discoveryGroupStatusKey struct {
 	discoveryConfigName string
 	integration         string
 }
 
-// resourceStatusMap tracks discovery status (found/enrolled/failed counts)
-// per fetcher group key (discovery config + integration combination).
-type resourceStatusMap struct {
+type discoveryGroupStatus struct {
+	found    int
+	enrolled int
+	failed   int
+}
+
+// discoveryStatus tracks discovery status (found/enrolled/failed counts) per
+// discovery group key (discovery config + integration combination).
+type discoveryStatus struct {
 	resourceType string
-	results      map[fetcherGroupKey]map[statusType]int
+	statuses     map[discoveryGroupStatusKey]*discoveryGroupStatus
 	syncStart    *time.Time
 	syncEnd      *time.Time
 }
 
-func newStatusMap(resourceType string, syncStart time.Time) *resourceStatusMap {
-	return &resourceStatusMap{
+func newStatusMap(resourceType string, syncStart time.Time) *discoveryStatus {
+	return &discoveryStatus{
 		resourceType: resourceType,
-		results:      make(map[fetcherGroupKey]map[statusType]int),
+		statuses:     make(map[discoveryGroupStatusKey]*discoveryGroupStatus),
 		syncStart:    &syncStart,
 	}
 }
 
-func (s *resourceStatusMap) syncEnded(syncEnd time.Time) {
+func (s *discoveryStatus) syncEnded(syncEnd time.Time) {
 	s.syncEnd = &syncEnd
 }
 
-func (s *resourceStatusMap) add(key fetcherGroupKey, results map[statusType]int) {
-	if s.results[key] == nil {
-		s.results[key] = make(map[statusType]int)
+func (s *discoveryStatus) add(key discoveryGroupStatusKey, update discoveryGroupStatus) {
+	if s.statuses[key] == nil {
+		s.statuses[key] = &update
+		return
 	}
-	for k, v := range results {
-		s.results[key][k] += v
-	}
+	status := s.statuses[key]
+	status.found += update.found
+	status.enrolled += update.enrolled
+	status.failed += update.failed
 }
 
-func (s *resourceStatusMap) mergeIntoGlobalStatus(discoveryConfigName string, existingStatus discoveryconfig.Status) discoveryconfig.Status {
+func (s *discoveryStatus) mergeIntoGlobalStatus(discoveryConfigName string, existingStatus discoveryconfig.Status) discoveryconfig.Status {
 	if s == nil {
 		// nil resourceStatusMap is valid, just empty.
 		return existingStatus
 	}
 
-	for key, results := range s.results {
+	for key, group := range s.statuses {
 		if key.discoveryConfigName != discoveryConfigName {
 			continue
 		}
 
-		if results == nil {
-			continue
-		}
-
 		// Update global discovered resources count.
-		existingStatus.DiscoveredResources = existingStatus.DiscoveredResources + uint64(results[statusFound])
+		existingStatus.DiscoveredResources += uint64(group.found)
 
 		// Initialize map if needed.
 		if existingStatus.IntegrationDiscoveredResources == nil {
@@ -1153,9 +1149,9 @@ func (s *resourceStatusMap) mergeIntoGlobalStatus(discoveryConfigName string, ex
 		}
 
 		resourcesSummary := discoveryconfigv1.ResourcesDiscoveredSummary_builder{
-			Found:     uint64(results[statusFound]),
-			Enrolled:  uint64(results[statusEnrolled]),
-			Failed:    uint64(results[statusFailed]),
+			Found:     uint64(group.found),
+			Enrolled:  uint64(group.enrolled),
+			Failed:    uint64(group.failed),
 			SyncStart: syncStart,
 			SyncEnd:   syncEnd,
 		}.Build()
@@ -1168,13 +1164,13 @@ func (s *resourceStatusMap) mergeIntoGlobalStatus(discoveryConfigName string, ex
 	return existingStatus
 }
 
-func (s *resourceStatusMap) discoveryConfigs() []string {
+func (s *discoveryStatus) discoveryConfigs() []string {
 	if s == nil {
 		return nil
 	}
 
 	names := map[string]struct{}{}
-	for key := range s.results {
+	for key := range s.statuses {
 		names[key.discoveryConfigName] = struct{}{}
 	}
 	return slices.Collect(maps.Keys(names))

--- a/lib/srv/discovery/status.go
+++ b/lib/srv/discovery/status.go
@@ -1120,13 +1120,13 @@ func (s *discoveryStatus) mergeIntoGlobalStatus(discoveryConfigName string, exis
 		return existingStatus
 	}
 
-	for key, group := range s.statuses {
+	for key, status := range s.statuses {
 		if key.discoveryConfigName != discoveryConfigName {
 			continue
 		}
 
 		// Update global discovered resources count.
-		existingStatus.DiscoveredResources += uint64(group.found)
+		existingStatus.DiscoveredResources += uint64(status.found)
 
 		// Initialize map if needed.
 		if existingStatus.IntegrationDiscoveredResources == nil {
@@ -1149,9 +1149,9 @@ func (s *discoveryStatus) mergeIntoGlobalStatus(discoveryConfigName string, exis
 		}
 
 		resourcesSummary := discoveryconfigv1.ResourcesDiscoveredSummary_builder{
-			Found:     uint64(group.found),
-			Enrolled:  uint64(group.enrolled),
-			Failed:    uint64(group.failed),
+			Found:     uint64(status.found),
+			Enrolled:  uint64(status.enrolled),
+			Failed:    uint64(status.failed),
 			SyncStart: syncStart,
 			SyncEnd:   syncEnd,
 		}.Build()

--- a/lib/srv/server/azure_watcher.go
+++ b/lib/srv/server/azure_watcher.go
@@ -137,7 +137,8 @@ func (md *AzureInstancesMetadata) MakeRunEvent(result AzureInstallResult) *apiev
 	return evt
 }
 
-// AzureInstances contains information about discovered Azure virtual machines.
+// AzureInstances contains a list of discovered Azure virtual machines and
+// metadata.
 type AzureInstances struct {
 	AzureInstancesMetadata
 

--- a/lib/srv/server/azure_watcher.go
+++ b/lib/srv/server/azure_watcher.go
@@ -140,7 +140,7 @@ func (md *AzureInstancesMetadata) MakeRunEvent(result AzureInstallResult) *apiev
 // AzureInstances contains a list of discovered Azure virtual machines and
 // metadata.
 type AzureInstances struct {
-	AzureInstancesMetadata
+	Metadata AzureInstancesMetadata
 
 	// Instances is a list of discovered Azure virtual machines.
 	Instances []*azure.VirtualMachine
@@ -150,7 +150,7 @@ type AzureInstances struct {
 func (instances *AzureInstances) LogValue() slog.Value {
 	return slog.GroupValue(
 		slog.Int("count", len(instances.Instances)),
-		slog.Any("metadata", instances.AzureInstancesMetadata),
+		slog.Any("metadata", instances.Metadata),
 	)
 }
 
@@ -160,7 +160,7 @@ func (instances *AzureInstances) FilterExistingNodes(existingNodes []types.Serve
 	for _, node := range existingNodes {
 		labels := node.GetAllLabels()
 		subscriptionID := labels[types.SubscriptionIDLabelInternal]
-		if subscriptionID != instances.SubscriptionID {
+		if subscriptionID != instances.Metadata.SubscriptionID {
 			continue
 		}
 		vmID := labels[types.VMIDLabelInternal]
@@ -331,7 +331,7 @@ func (f *azureInstanceFetcher) GetInstances(ctx context.Context, _ bool) ([]*Azu
 	var instances []*AzureInstances
 	for batchGroup, vms := range instanceGroups {
 		instances = append(instances, &AzureInstances{
-			AzureInstancesMetadata: AzureInstancesMetadata{
+			Metadata: AzureInstancesMetadata{
 				SubscriptionID:      f.Subscription,
 				Region:              batchGroup.location,
 				ResourceGroup:       batchGroup.resourceGroup,

--- a/lib/srv/server/azure_watcher.go
+++ b/lib/srv/server/azure_watcher.go
@@ -38,8 +38,8 @@ import (
 
 const azureEventPrefix = "azure/"
 
-// AzureInstances contains information about discovered Azure virtual machines.
-type AzureInstances struct {
+// AzureInstancesMetadata contains information about discovered Azure virtual machines.
+type AzureInstancesMetadata struct {
 	// DiscoveryConfigName is the name of discovery config.
 	DiscoveryConfigName string
 	// Integration is the optional name of the integration to use for auth.
@@ -54,43 +54,37 @@ type AzureInstances struct {
 
 	// InstallerParams are the installer parameters used for installation.
 	InstallerParams *types.InstallerParams
-	// Instances is a list of discovered Azure virtual machines.
-	Instances []*azure.VirtualMachine
 }
 
-func (instances *AzureInstances) LogValue() slog.Value {
-	if instances == nil {
-		return slog.StringValue("<nil>")
-	}
+func (md AzureInstancesMetadata) LogValue() slog.Value {
 	return slog.GroupValue(
-		slog.Int("total_instances", len(instances.Instances)),
-		slog.String("discovery_config", instances.DiscoveryConfigName),
-		slog.String("integration", instances.Integration),
-		slog.String("region", instances.Region),
-		slog.String("resource_group", instances.ResourceGroup),
-		slog.String("subscription_id", instances.SubscriptionID),
+		slog.String("discovery_config", md.DiscoveryConfigName),
+		slog.String("integration", md.Integration),
+		slog.String("region", md.Region),
+		slog.String("resource_group", md.ResourceGroup),
+		slog.String("subscription_id", md.SubscriptionID),
 	)
 }
 
-func (instances *AzureInstances) resourceType() string {
-	if instances.InstallerParams != nil && instances.InstallerParams.ScriptName == installers.InstallerScriptNameAgentless {
+func (md *AzureInstancesMetadata) resourceType() string {
+	if md.InstallerParams != nil && md.InstallerParams.ScriptName == installers.InstallerScriptNameAgentless {
 		return types.DiscoveredResourceAgentlessNode
 	}
 	return types.DiscoveredResourceNode
 }
 
 // MakeUsageEvent builds usage event for a single installation result.
-func (instances *AzureInstances) MakeUsageEvent(instance *azure.VirtualMachine) (string, *usageeventsv1.ResourceCreateEvent) {
+func (md *AzureInstancesMetadata) MakeUsageEvent(instance *azure.VirtualMachine) (string, *usageeventsv1.ResourceCreateEvent) {
 	return azureEventPrefix + instance.ID, &usageeventsv1.ResourceCreateEvent{
-		ResourceType:        instances.resourceType(),
+		ResourceType:        md.resourceType(),
 		ResourceOrigin:      types.OriginCloud,
 		CloudProvider:       types.CloudAzure,
-		DiscoveryConfigName: instances.DiscoveryConfigName,
+		DiscoveryConfigName: md.DiscoveryConfigName,
 	}
 }
 
 // MakeRunEvent builds run event for a single command run.
-func (instances *AzureInstances) MakeRunEvent(result AzureInstallResult) *apievents.AzureRun {
+func (md *AzureInstancesMetadata) MakeRunEvent(result AzureInstallResult) *apievents.AzureRun {
 	eventCode := libevents.AzureRunSuccessCode
 
 	if result.Failure() {
@@ -110,10 +104,10 @@ func (instances *AzureInstances) MakeRunEvent(result AzureInstallResult) *apieve
 			Code: eventCode,
 		},
 		AzureMetadata: apievents.AzureMetadata{
-			SubscriptionID: instances.SubscriptionID,
-			ResourceGroup:  instances.ResourceGroup,
+			SubscriptionID: md.SubscriptionID,
+			ResourceGroup:  md.ResourceGroup,
 			ResourceID:     resourceID,
-			Region:         instances.Region,
+			Region:         md.Region,
 		},
 		AzureVMMetadata: apievents.AzureVMMetadata{
 			VMID:   vmID,
@@ -141,6 +135,22 @@ func (instances *AzureInstances) MakeRunEvent(result AzureInstallResult) *apieve
 	}
 
 	return evt
+}
+
+// AzureInstances contains information about discovered Azure virtual machines.
+type AzureInstances struct {
+	AzureInstancesMetadata
+
+	// Instances is a list of discovered Azure virtual machines.
+	Instances []*azure.VirtualMachine
+}
+
+// LogValue implements [slog.LogValuer].
+func (instances *AzureInstances) LogValue() slog.Value {
+	return slog.GroupValue(
+		slog.Int("count", len(instances.Instances)),
+		slog.Any("metadata", instances.AzureInstancesMetadata),
+	)
 }
 
 // FilterExistingNodes removes instances matching existing nodes in place.
@@ -320,13 +330,15 @@ func (f *azureInstanceFetcher) GetInstances(ctx context.Context, _ bool) ([]*Azu
 	var instances []*AzureInstances
 	for batchGroup, vms := range instanceGroups {
 		instances = append(instances, &AzureInstances{
-			SubscriptionID:      f.Subscription,
-			Region:              batchGroup.location,
-			ResourceGroup:       batchGroup.resourceGroup,
-			Instances:           vms,
-			Integration:         f.Integration,
-			InstallerParams:     f.InstallerParams,
-			DiscoveryConfigName: f.DiscoveryConfigName,
+			AzureInstancesMetadata: AzureInstancesMetadata{
+				SubscriptionID:      f.Subscription,
+				Region:              batchGroup.location,
+				ResourceGroup:       batchGroup.resourceGroup,
+				Integration:         f.Integration,
+				InstallerParams:     f.InstallerParams,
+				DiscoveryConfigName: f.DiscoveryConfigName,
+			},
+			Instances: vms,
 		})
 	}
 

--- a/lib/srv/server/azure_watcher_test.go
+++ b/lib/srv/server/azure_watcher_test.go
@@ -300,7 +300,9 @@ func TestAzureInstances_FilterExistingNodes(t *testing.T) {
 		{
 			name: "no existing nodes",
 			instances: &AzureInstances{
-				SubscriptionID: "sub-1",
+				AzureInstancesMetadata: AzureInstancesMetadata{
+					SubscriptionID: "sub-1",
+				},
 				Instances: []*azure.VirtualMachine{
 					{
 						ID:   "/subscriptions/sub-1/resourceGroups/rg1/providers/Microsoft.Compute/virtualMachines/vm1",
@@ -318,7 +320,9 @@ func TestAzureInstances_FilterExistingNodes(t *testing.T) {
 		{
 			name: "filter out matching node",
 			instances: &AzureInstances{
-				SubscriptionID: "sub-1",
+				AzureInstancesMetadata: AzureInstancesMetadata{
+					SubscriptionID: "sub-1",
+				},
 				Instances: []*azure.VirtualMachine{
 					{
 						ID:   "/subscriptions/sub-1/resourceGroups/rg1/providers/Microsoft.Compute/virtualMachines/vm1",
@@ -338,7 +342,9 @@ func TestAzureInstances_FilterExistingNodes(t *testing.T) {
 		{
 			name: "filter out all matching nodes",
 			instances: &AzureInstances{
-				SubscriptionID: "sub-1",
+				AzureInstancesMetadata: AzureInstancesMetadata{
+					SubscriptionID: "sub-1",
+				},
 				Instances: []*azure.VirtualMachine{
 					{
 						ID:   "/subscriptions/sub-1/resourceGroups/rg1/providers/Microsoft.Compute/virtualMachines/vm1",
@@ -359,7 +365,9 @@ func TestAzureInstances_FilterExistingNodes(t *testing.T) {
 		{
 			name: "different subscription is not filtered",
 			instances: &AzureInstances{
-				SubscriptionID: "sub-1",
+				AzureInstancesMetadata: AzureInstancesMetadata{
+					SubscriptionID: "sub-1",
+				},
 				Instances: []*azure.VirtualMachine{
 					{
 						ID:   "/subscriptions/sub-1/resourceGroups/rg1/providers/Microsoft.Compute/virtualMachines/vm1",
@@ -375,7 +383,9 @@ func TestAzureInstances_FilterExistingNodes(t *testing.T) {
 		{
 			name: "node without vm id is not used for filtering",
 			instances: &AzureInstances{
-				SubscriptionID: "sub-1",
+				AzureInstancesMetadata: AzureInstancesMetadata{
+					SubscriptionID: "sub-1",
+				},
 				Instances: []*azure.VirtualMachine{
 					{
 						ID:   "/subscriptions/sub-1/resourceGroups/rg1/providers/Microsoft.Compute/virtualMachines/vm1",
@@ -391,7 +401,9 @@ func TestAzureInstances_FilterExistingNodes(t *testing.T) {
 		{
 			name: "instance without properties is not filtered",
 			instances: &AzureInstances{
-				SubscriptionID: "sub-1",
+				AzureInstancesMetadata: AzureInstancesMetadata{
+					SubscriptionID: "sub-1",
+				},
 				Instances: []*azure.VirtualMachine{
 					{
 						ID: "/subscriptions/sub-1/resourceGroups/rg1/providers/Microsoft.Compute/virtualMachines/vm1",
@@ -612,9 +624,11 @@ func TestMakeRunEvent(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			instances := &AzureInstances{
-				SubscriptionID: subscriptionID,
-				ResourceGroup:  resourceGroup,
-				Region:         region,
+				AzureInstancesMetadata: AzureInstancesMetadata{
+					SubscriptionID: subscriptionID,
+					ResourceGroup:  resourceGroup,
+					Region:         region,
+				},
 			}
 			evt := instances.MakeRunEvent(tc.result)
 			require.Equal(t, tc.want, evt)
@@ -643,7 +657,9 @@ func TestMakeUsageEvent(t *testing.T) {
 		{
 			name: "node",
 			instances: &AzureInstances{
-				DiscoveryConfigName: discoveryConfig,
+				AzureInstancesMetadata: AzureInstancesMetadata{
+					DiscoveryConfigName: discoveryConfig,
+				},
 			},
 			wantKey: azureEventPrefix + resourceID,
 			want: &usageeventsv1.ResourceCreateEvent{
@@ -656,9 +672,11 @@ func TestMakeUsageEvent(t *testing.T) {
 		{
 			name: "agentless node",
 			instances: &AzureInstances{
-				DiscoveryConfigName: discoveryConfig,
-				InstallerParams: &types.InstallerParams{
-					ScriptName: installers.InstallerScriptNameAgentless,
+				AzureInstancesMetadata: AzureInstancesMetadata{
+					DiscoveryConfigName: discoveryConfig,
+					InstallerParams: &types.InstallerParams{
+						ScriptName: installers.InstallerScriptNameAgentless,
+					},
 				},
 			},
 			wantKey: azureEventPrefix + resourceID,

--- a/lib/srv/server/azure_watcher_test.go
+++ b/lib/srv/server/azure_watcher_test.go
@@ -276,8 +276,8 @@ func TestAzureWatcher(t *testing.T) {
 						vmID := parsedResource.Name
 						vmIDs = append(vmIDs, vmID)
 					}
-					require.NotEqual(t, "*", results.ResourceGroup, "Discovered VM's ResourceGroup should never be the wildcard")
-					require.NotEqual(t, "*", results.SubscriptionID, "Discovered VM's SubscriptionID should never be the wildcard")
+					require.NotEqual(t, "*", results.Metadata.ResourceGroup, "Discovered VM's ResourceGroup should never be the wildcard")
+					require.NotEqual(t, "*", results.Metadata.SubscriptionID, "Discovered VM's SubscriptionID should never be the wildcard")
 				case <-ctx.Done():
 					require.ElementsMatch(t, tc.wantVMs, vmIDs, "timed out while waiting for expected VMs")
 				}
@@ -300,7 +300,7 @@ func TestAzureInstances_FilterExistingNodes(t *testing.T) {
 		{
 			name: "no existing nodes",
 			instances: &AzureInstances{
-				AzureInstancesMetadata: AzureInstancesMetadata{
+				Metadata: AzureInstancesMetadata{
 					SubscriptionID: "sub-1",
 				},
 				Instances: []*azure.VirtualMachine{
@@ -320,7 +320,7 @@ func TestAzureInstances_FilterExistingNodes(t *testing.T) {
 		{
 			name: "filter out matching node",
 			instances: &AzureInstances{
-				AzureInstancesMetadata: AzureInstancesMetadata{
+				Metadata: AzureInstancesMetadata{
 					SubscriptionID: "sub-1",
 				},
 				Instances: []*azure.VirtualMachine{
@@ -342,7 +342,7 @@ func TestAzureInstances_FilterExistingNodes(t *testing.T) {
 		{
 			name: "filter out all matching nodes",
 			instances: &AzureInstances{
-				AzureInstancesMetadata: AzureInstancesMetadata{
+				Metadata: AzureInstancesMetadata{
 					SubscriptionID: "sub-1",
 				},
 				Instances: []*azure.VirtualMachine{
@@ -365,7 +365,7 @@ func TestAzureInstances_FilterExistingNodes(t *testing.T) {
 		{
 			name: "different subscription is not filtered",
 			instances: &AzureInstances{
-				AzureInstancesMetadata: AzureInstancesMetadata{
+				Metadata: AzureInstancesMetadata{
 					SubscriptionID: "sub-1",
 				},
 				Instances: []*azure.VirtualMachine{
@@ -383,7 +383,7 @@ func TestAzureInstances_FilterExistingNodes(t *testing.T) {
 		{
 			name: "node without vm id is not used for filtering",
 			instances: &AzureInstances{
-				AzureInstancesMetadata: AzureInstancesMetadata{
+				Metadata: AzureInstancesMetadata{
 					SubscriptionID: "sub-1",
 				},
 				Instances: []*azure.VirtualMachine{
@@ -401,7 +401,7 @@ func TestAzureInstances_FilterExistingNodes(t *testing.T) {
 		{
 			name: "instance without properties is not filtered",
 			instances: &AzureInstances{
-				AzureInstancesMetadata: AzureInstancesMetadata{
+				Metadata: AzureInstancesMetadata{
 					SubscriptionID: "sub-1",
 				},
 				Instances: []*azure.VirtualMachine{
@@ -624,13 +624,13 @@ func TestMakeRunEvent(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			instances := &AzureInstances{
-				AzureInstancesMetadata: AzureInstancesMetadata{
+				Metadata: AzureInstancesMetadata{
 					SubscriptionID: subscriptionID,
 					ResourceGroup:  resourceGroup,
 					Region:         region,
 				},
 			}
-			evt := instances.MakeRunEvent(tc.result)
+			evt := instances.Metadata.MakeRunEvent(tc.result)
 			require.Equal(t, tc.want, evt)
 		})
 	}
@@ -657,7 +657,7 @@ func TestMakeUsageEvent(t *testing.T) {
 		{
 			name: "node",
 			instances: &AzureInstances{
-				AzureInstancesMetadata: AzureInstancesMetadata{
+				Metadata: AzureInstancesMetadata{
 					DiscoveryConfigName: discoveryConfig,
 				},
 			},
@@ -672,7 +672,7 @@ func TestMakeUsageEvent(t *testing.T) {
 		{
 			name: "agentless node",
 			instances: &AzureInstances{
-				AzureInstancesMetadata: AzureInstancesMetadata{
+				Metadata: AzureInstancesMetadata{
 					DiscoveryConfigName: discoveryConfig,
 					InstallerParams: &types.InstallerParams{
 						ScriptName: installers.InstallerScriptNameAgentless,
@@ -691,7 +691,7 @@ func TestMakeUsageEvent(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			key, evt := tc.instances.MakeUsageEvent(vm)
+			key, evt := tc.instances.Metadata.MakeUsageEvent(vm)
 			require.Equal(t, tc.wantKey, key)
 			require.Equal(t, tc.want, evt)
 		})


### PR DESCRIPTION
Issue: https://github.com/gravitational/teleport/issues/67402
- https://github.com/gravitational/teleport/issues/67402

Extracted from https://github.com/gravitational/teleport/pull/67487
- https://github.com/gravitational/teleport/pull/67487

As I rework the Azure performance PR to cap the number of parallel installations, I extracted this change into its own PR.

Move immutable Azure VM discovery metadata into a dedicated embedded AzureInstancesMetadata type. This lets enrollment, status, audit, usage event, and user-task paths pass metadata separately from the mutable Instances slice, which is filtered during enrollment.

Change the resource status from a primitive map type into a struct. This will make the status map more flexible for further changes that introduce parallel installation and status updates.

This also logs the instance count after filtering enrolled instances.


<!-- Include manual testing efforts to verify the change. -->
<!-- Detail where the tests where run and what configurations were used. -->
<!-- Include all the test cases which were run to validate the change. -->

## Manual Test Plan
### Test Environment
- cloud staging tenant
- Azure VM

### Test Cases
- [x] discovers all VMs that match discovery config
- [x] installs teleport on expected VM (no issues with the run-command agent or networking)
- [x] expected logs are output

<details><summary>Example log when enrolled instances are filtered out</summary>
<p>

```
{
  "timestamp": "2026-06-10T16:29:12-07:00",
  "level": "debug",
  "caller": "discovery/discovery.go:1758",
  "message": "Filtered out Azure instances that have already been enrolled",
  "component": "discovery:service",
  "pid": "68329.1",
  "group": {
    "count": 1,
    "metadata": {
      "discovery_config": "gavin-tf-azure-discover-test-1",
      "integration": "gavin-tf-azure-discover-test-1",
      "region": "westus",
      "resource_group": "GAVIN-TF-VM-RG",
      "subscription_id": "060a97ea-3a57-4218-9be5-dba3f19ff2b5"
    }
  },
  "enrolled": 1
}
```

</p>
</details> 
<details><summary>Example installation log</summary>
<p>

```
{
  "timestamp": "2026-06-09T09:28:16-07:00",
  "level": "debug",
  "caller": "discovery/discovery.go:1713",
  "message": "Running Teleport installation on virtual machines",
  "component": "discovery:service",
  "pid": "11924.1",
  "group": {
    "count": 1,
    "metadata": {
      "discovery_config": "gavin-tf-azure-discover-test-1",
      "integration": "gavin-tf-azure-discover-test-1",
      "region": "westus",
      "resource_group": "GAVIN-TF-VM-RG",
      "subscription_id": "060a97ea-3a57-4218-9be5-dba3f19ff2b5"
    }
  },
  "vms": "[gavin-tf-vm]"
}
```

</p>
</details> 
