### PR TITLE
[v18] Fix copy-paste bug in proxy  cluster dialer

### DIFF
--- a/lib/web/sessions.go
+++ b/lib/web/sessions.go
@@ -316,7 +316,7 @@ func clusterDialer(remoteCluster reversetunnelclient.Cluster, src, dst net.Addr)
 			dialParams.From = clientSrcAddr
 		}
 		if dialParams.OriginalClientDstAddr == nil && clientDstAddr != nil {
-			dialParams.OriginalClientDstAddr = clientSrcAddr
+			dialParams.OriginalClientDstAddr = clientDstAddr
 		}
 
 		return remoteCluster.DialAuthServer(dialParams)

--- a/lib/web/sessions_test.go
+++ b/lib/web/sessions_test.go
@@ -19,8 +19,10 @@
 package web
 
 import (
+	"cmp"
 	"context"
 	"errors"
+	"net"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -32,6 +34,7 @@ import (
 
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/auth/authclient"
+	"github.com/gravitational/teleport/lib/authz"
 	"github.com/gravitational/teleport/lib/modules"
 	"github.com/gravitational/teleport/lib/modules/modulestest"
 	"github.com/gravitational/teleport/lib/reversetunnelclient"
@@ -79,6 +82,49 @@ type mockCluster struct {
 
 func (m *mockCluster) GetName() string {
 	return m.name
+}
+
+type fakeTunnelClient struct {
+	reversetunnelclient.Cluster
+	gotParams reversetunnelclient.DialParams
+}
+
+func (m *fakeTunnelClient) DialAuthServer(params reversetunnelclient.DialParams) (net.Conn, error) {
+	m.gotParams = params
+	return nil, errors.New("not dialing in test")
+}
+
+func TestClusterDialer(t *testing.T) {
+	t.Parallel()
+
+	srcAddr := &utils.NetAddr{Addr: "10.0.0.1:1111", AddrNetwork: "tcp"}
+	dstAddr := &utils.NetAddr{Addr: "10.0.0.2:2222", AddrNetwork: "tcp"}
+
+	for _, tc := range []struct {
+		desc    string
+		dialSrc net.Addr
+		dialDst net.Addr
+		dialCtx context.Context
+	}{
+		{
+			desc:    "explicit addrs",
+			dialSrc: srcAddr,
+			dialDst: dstAddr,
+		},
+		{
+			desc:    "context addrs",
+			dialCtx: authz.ContextWithClientAddrs(t.Context(), srcAddr, dstAddr),
+		},
+	} {
+		t.Run(tc.desc, func(t *testing.T) {
+			cluster := &fakeTunnelClient{}
+			dialer := clusterDialer(cluster, tc.dialSrc, tc.dialDst)
+			dialer.DialContext(cmp.Or(tc.dialCtx, t.Context()), "tcp", "")
+
+			require.Equal(t, srcAddr, cluster.gotParams.From)
+			require.Equal(t, dstAddr, cluster.gotParams.OriginalClientDstAddr)
+		})
+	}
 }
 
 func newMockClientI(openCount *atomic.Int32, closeErr error) authclient.ClientI {


### PR DESCRIPTION
In the fallback path when addresses are pulled from the context, we were incorrectly setting the destination address to the source address, which results in incorrect auditing.
