### PR TITLE
Add `TestLoginShell` to avoid lib/web tests polluting shell history

### DIFF
--- a/lib/srv/ctx.go
+++ b/lib/srv/ctx.go
@@ -372,6 +372,10 @@ type ServerContext struct {
 	// IsTestStub is set to true by tests.
 	IsTestStub bool
 
+	// TestLoginShell overrides the shell used for the session. It is only set by
+	// tests to avoid running the real user's shell and polluting shell history.
+	TestLoginShell string
+
 	// execRequest is the command to be executed within this session context. Do
 	// not get or set this field directly, use (Get|Set)ExecRequest.
 	execRequest Exec
@@ -1123,6 +1127,7 @@ func (c *ServerContext) ExecCommand() (*reexec.ExecCommand, error) {
 		Environment:           buildEnvironment(c),
 		PAMConfig:             pamConfig,
 		IsTestStub:            c.IsTestStub,
+		TestLoginShell:        c.TestLoginShell,
 		UaccMetadata:          *uaccMetadata,
 		SetSELinuxContext:     c.srv.GetSELinuxEnabled(),
 		RecordWithBPF:         c.recordWithBPF(),

--- a/lib/srv/regular/sshserver.go
+++ b/lib/srv/regular/sshserver.go
@@ -126,6 +126,10 @@ type Server struct {
 	// this gets set to true for unit testing
 	isTestStub bool
 
+	// testLoginShell overrides the shell used for sessions. It is only set by
+	// tests to avoid running the real user's shell and polluting shell history.
+	testLoginShell string
+
 	// cancel cancels all operations
 	cancel context.CancelFunc
 	// ctx is broadcasting context closure
@@ -868,6 +872,16 @@ func SetChildLogConfig(cfg *servicecfg.Config) ServerOption {
 func SetPresenceMaxDuration(maxDuration time.Duration) ServerOption {
 	return func(s *Server) error {
 		s.presenceMaxDuration = maxDuration
+		return nil
+	}
+}
+
+// SetTestLoginShell overrides the shell used for sessions instead of resolving
+// the login shell of the OS user. This is intended for tests only to avoid
+// running the real user's shell and polluting shell history.
+func SetTestLoginShell(shell string) ServerOption {
+	return func(s *Server) error {
+		s.testLoginShell = shell
 		return nil
 	}
 }
@@ -1698,6 +1712,7 @@ func (s *Server) handleDirectTCPIPRequest(ctx context.Context, ccx *sshutils.Con
 		return
 	}
 	scx.IsTestStub = s.isTestStub
+	scx.TestLoginShell = s.testLoginShell
 	scx.AddCloser(channel)
 	scx.SessionRecordingConfig.SetMode(types.RecordOff)
 	scx.ExecType = teleport.ChanDirectTCPIP
@@ -1773,6 +1788,7 @@ func (s *Server) handleSessionRequests(ctx context.Context, ccx *sshutils.Connec
 		return
 	}
 	scx.IsTestStub = s.isTestStub
+	scx.TestLoginShell = s.testLoginShell
 	scx.AddCloser(ch)
 	scx.ExecType = teleport.ChanSession
 	scx.SetAllowFileCopying(s.allowFileCopying)
@@ -2280,6 +2296,7 @@ func (s *Server) handleProxyJump(ctx context.Context, ccx *sshutils.ConnectionCo
 		return
 	}
 	scx.IsTestStub = s.isTestStub
+	scx.TestLoginShell = s.testLoginShell
 	scx.AddCloser(ch)
 	scx.SetAllowFileCopying(s.allowFileCopying)
 	defer scx.Close()
@@ -2411,6 +2428,7 @@ func (s *Server) createForwardingContext(ctx context.Context, ccx *sshutils.Conn
 
 	listenAddr := sshutils.JoinHostPort(req.Addr, req.Port)
 	scx.IsTestStub = s.isTestStub
+	scx.TestLoginShell = s.testLoginShell
 	scx.ExecType = teleport.TCPIPForwardRequest
 	scx.SrcAddr = listenAddr
 	scx.DstAddr = ccx.NetConn.RemoteAddr().String()

--- a/lib/web/apiserver_test.go
+++ b/lib/web/apiserver_test.go
@@ -203,6 +203,20 @@ func TestMain(m *testing.M) {
 	os.Exit(code)
 }
 
+// noHistoryShell returns the absolute path to a committed wrapper shell script
+// (testdata/no-history-shell.sh) that disables history.
+//
+// Tests in this package open interactive shell sessions on a local node service
+// running as the current OS user. Pointing the node at this shell via
+// [regular.SetTestLoginShell] keeps those sessions from polluting the shell
+// history.
+func noHistoryShell(t *testing.T) string {
+	t.Helper()
+	shell, err := filepath.Abs(filepath.Join("testdata", "no-history-shell.sh"))
+	require.NoError(t, err)
+	return shell
+}
+
 func newWebSuite(t *testing.T) *WebSuite {
 	return newWebSuiteWithConfig(t, webSuiteConfig{})
 }
@@ -396,6 +410,7 @@ func newWebSuiteWithConfig(t *testing.T, cfg webSuiteConfig) *WebSuite {
 		regular.SetNamespace(apidefaults.Namespace),
 		regular.SetEmitter(nodeClient),
 		regular.SetPAMConfig(&pamcfg.PAMConfig{Enabled: false}),
+		regular.SetTestLoginShell(noHistoryShell(t)),
 		regular.SetBPF(&bpf.NOP{}),
 		regular.SetClock(s.clock),
 		regular.SetLockWatcher(nodeLockWatcher),
@@ -735,6 +750,7 @@ func (s *WebSuite) addNode(t *testing.T, uuid string, hostname string, address s
 		regular.SetNamespace(apidefaults.Namespace),
 		regular.SetEmitter(nodeClient),
 		regular.SetPAMConfig(&pamcfg.PAMConfig{Enabled: false}),
+		regular.SetTestLoginShell(noHistoryShell(t)),
 		regular.SetBPF(&bpf.NOP{}),
 		regular.SetClock(s.clock),
 		regular.SetLockWatcher(nodeLockWatcher),
@@ -8946,6 +8962,7 @@ func newWebPack(t *testing.T, numProxies int, opts ...webPackOptions) *webPack {
 		regular.SetNamespace(apidefaults.Namespace),
 		regular.SetEmitter(nodeClient),
 		regular.SetPAMConfig(&pamcfg.PAMConfig{Enabled: false}),
+		regular.SetTestLoginShell(noHistoryShell(t)),
 		regular.SetBPF(&bpf.NOP{}),
 		regular.SetClock(clock),
 		regular.SetLockWatcher(nodeLockWatcher),

--- a/lib/web/apiserver_test.go
+++ b/lib/web/apiserver_test.go
@@ -2723,6 +2723,29 @@ func TestTerminalRequireSessionMFANoRegisteredDevice(t *testing.T) {
 	waitForOutput(t, term, "no supported MFA devices enrolled")
 }
 
+// TestTerminalNoHistoryShell verifies that interactive sessions opened by tests
+// that use [newWebSuite] don't record shell history thanks to [noHistoryShell].
+func TestTerminalNoHistoryShell(t *testing.T) {
+	t.Parallel()
+	s := newWebSuite(t)
+
+	ctx, cancel := context.WithCancel(s.ctx)
+	t.Cleanup(cancel)
+
+	term, err := connectToHost(ctx, connectConfig{
+		pack:  s.authPack(t, "foo"),
+		host:  s.node.ID(),
+		proxy: s.webServer.Listener.Addr().String(),
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, term.Close()) })
+
+	_, err = io.WriteString(term, `echo "histfile=[$HISTFILE]"`+"\r\n")
+	require.NoError(t, err)
+	// Verify that noHistoryShell ended up making $HISTFILE empty.
+	waitForOutput(t, term, "histfile=[]", "noHistoryShell failed to unset HISTFILE")
+}
+
 type windowsDesktopServiceMock struct {
 	listener net.Listener
 }

--- a/lib/web/apiserver_test.go
+++ b/lib/web/apiserver_test.go
@@ -2742,7 +2742,6 @@ func TestTerminalNoHistoryShell(t *testing.T) {
 
 	_, err = io.WriteString(term, `echo "histfile=[$HISTFILE]"`+"\r\n")
 	require.NoError(t, err)
-	// Verify that noHistoryShell ended up making $HISTFILE empty.
 	waitForOutput(t, term, "histfile=[]", "noHistoryShell failed to unset HISTFILE")
 }
 

--- a/lib/web/apiserver_test.go
+++ b/lib/web/apiserver_test.go
@@ -28,6 +28,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"crypto/x509/pkix"
+	_ "embed"
 	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
@@ -203,17 +204,21 @@ func TestMain(m *testing.M) {
 	os.Exit(code)
 }
 
-// noHistoryShell returns the absolute path to a committed wrapper shell script
-// (testdata/no-history-shell.sh) that disables history.
+//go:embed testdata/no-history-shell.sh
+var noHistoryShellScript []byte
+
+// noHistoryShell writes a wrapper shell script that disables history to a temp
+// file and returns its path.
 //
 // Tests in this package open interactive shell sessions on a local node service
 // running as the current OS user. Pointing the node at this shell via
 // [regular.SetTestLoginShell] keeps those sessions from polluting the shell
-// history.
+// history. The script is embedded rather than referenced on disk so the path
+// doesn't depend on the working directory.
 func noHistoryShell(t *testing.T) string {
 	t.Helper()
-	shell, err := filepath.Abs(filepath.Join("testdata", "no-history-shell.sh"))
-	require.NoError(t, err)
+	shell := filepath.Join(t.TempDir(), "no-history-shell.sh")
+	require.NoError(t, os.WriteFile(shell, noHistoryShellScript, 0o700))
 	return shell
 }
 

--- a/lib/web/testdata/no-history-shell.sh
+++ b/lib/web/testdata/no-history-shell.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# Shell wrapper for lib/web tests. Disables history so that tests don't pollute the user's
+# shell history, and skips profile so they don't depend on the user's shell config.
+exec bash --noprofile --rcfile <(echo 'unset HISTFILE')

--- a/session/reexec/reexec.go
+++ b/session/reexec/reexec.go
@@ -199,6 +199,10 @@ type ExecCommand struct {
 	// IsTestStub is used by tests to mock the shell.
 	IsTestStub bool `json:"is_test_stub"`
 
+	// TestLoginShell overrides the shell used for the session. It is only set by
+	// tests to avoid running the real user's shell and polluting shell history.
+	TestLoginShell string `json:"test_login_shell"`
+
 	// UserCreatedByTeleport is true when the system user was created by Teleport user auto-provision.
 	UserCreatedByTeleport bool
 
@@ -1263,6 +1267,11 @@ func BuildCommand(c *ExecCommand, localUser *user.User, pamEnvironment []string)
 	}
 	if c.IsTestStub {
 		shellPath = "/bin/sh"
+	}
+	// Tests may override the login shell so they don't run the real user's shell,
+	// which has side effects such as polluting the user's shell history.
+	if c.TestLoginShell != "" {
+		shellPath = c.TestLoginShell
 	}
 
 	// If a subsystem was requested, handle the known subsystems or error out;


### PR DESCRIPTION
I noticed that my zsh history gets polluted after running lib/web tests. This is because the tests connect to a local node service and run an SSH session as the current user and then execute a couple of commands.

We've already ran into this problem in e2e Connect tests which also start a local shell session. The solution was to use [a shell wrapper](https://github.com/gravitational/teleport/blob/5c925211cc43e713665f097f37a0f832fedc67eb/e2e/scripts/connect-e2e-shell.sh) which disables history. This PR uses the same approach for lib/web tests.

To make it possible to use a custom shell wrapper rather than the login shell of the user, I had to add `TestLoginShell` which mirrors how `IsTestStub` is implemented. `IsTestStub` itself couldn't be used because it affects more than just which shell is used in tests.

## Manual Test Plan
### Test Environment

A local run of `go test ./lib/web`.

### Test Cases
- [x] Running lib/web tests doesn't modify the history file of the current OS user.