### PR TITLE
kube: require exec and patch for pods/ephemeralcontainers

### DIFF
--- a/lib/kube/proxy/ephemeralcontainers_verb_test.go
+++ b/lib/kube/proxy/ephemeralcontainers_verb_test.go
@@ -1,0 +1,97 @@
+/*
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package proxy
+
+import (
+	"net/http"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/gravitational/teleport/api/types"
+)
+
+// TestEphemeralContainersRequiredVerbs asserts the set of kubernetes_resources verbs that gate each pods request.
+// Adding an ephemeral container (PATCH/PUT to pods/{name}/ephemeralcontainers) runs code in the target pod
+// the same way exec does, and also mutates the pod,
+// so it must require both the exec verb and the mutation verb the HTTP method maps to.
+// A plain pod patch and pods/exec must each require only their own single verb,
+// so that neither verb on its own is enough to add an ephemeral container.
+func TestEphemeralContainersRequiredVerbs(t *testing.T) {
+	// Minimal kubeDetails with just the "pods" resource registered for RBAC.
+	// Mirrors what newClusterSchemaBuilder populates from real cluster
+	// discovery for the core/v1 pods resource.
+	kd := &kubeDetails{
+		rbacSupportedTypes: rbacSupportedResources{
+			allowedResourcesKey{apiGroup: "", resourceKind: "pods"}: metav1.APIResource{
+				Name:       "pods",
+				Namespaced: true,
+				Kind:       "Pod",
+			},
+		},
+	}
+
+	verbsFor := func(t *testing.T, method, path string) []string {
+		u, err := url.Parse(path)
+		require.NoError(t, err)
+		mr, err := getResourceFromRequest(&http.Request{Method: method, URL: u}, kd)
+		require.NoError(t, err)
+
+		var verbs []string
+		for _, r := range mr.requiredRBACResources() {
+			verbs = append(verbs, r.Verbs...)
+		}
+		return verbs
+	}
+
+	// Control: pods/exec requires only the exec verb.
+	t.Run("pods/exec requires only exec", func(t *testing.T) {
+		verbs := verbsFor(t, http.MethodPost, "/api/v1/namespaces/default/pods/foo/exec")
+		require.Equal(t, []string{types.KubeVerbExec}, verbs)
+	})
+
+	// Control: a patch to the pod itself (e.g. a label update) requires only
+	// the patch verb. It must not pull in exec, otherwise a label patch and an
+	// ephemeral container would be indistinguishable in RBAC.
+	t.Run("pod patch requires only patch", func(t *testing.T) {
+		verbs := verbsFor(t, http.MethodPatch, "/api/v1/namespaces/default/pods/foo")
+		require.Equal(t, []string{types.KubeVerbPatch}, verbs)
+		require.NotContains(t, verbs, types.KubeVerbExec)
+	})
+
+	t.Run("ephemeralcontainers patch requires exec and patch", func(t *testing.T) {
+		verbs := verbsFor(t, http.MethodPatch,
+			"/api/v1/namespaces/default/pods/foo/ephemeralcontainers")
+		require.Contains(t, verbs, types.KubeVerbExec,
+			"adding an ephemeral container must require the exec verb")
+		require.Contains(t, verbs, types.KubeVerbPatch,
+			"adding an ephemeral container must require the mutation verb")
+	})
+
+	t.Run("ephemeralcontainers put requires exec and update", func(t *testing.T) {
+		verbs := verbsFor(t, http.MethodPut,
+			"/api/v1/namespaces/default/pods/foo/ephemeralcontainers")
+		require.Contains(t, verbs, types.KubeVerbExec,
+			"adding an ephemeral container must require the exec verb")
+		require.Contains(t, verbs, types.KubeVerbUpdate,
+			"adding an ephemeral container must require the mutation verb")
+	})
+}

--- a/lib/kube/proxy/ephemeralcontainers_verb_test.go
+++ b/lib/kube/proxy/ephemeralcontainers_verb_test.go
@@ -19,148 +19,79 @@
 package proxy
 
 import (
-	"context"
+	"net/http"
+	"net/url"
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	kubeerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	kubetypes "k8s.io/apimachinery/pkg/types"
 
 	"github.com/gravitational/teleport/api/types"
-	tkm "github.com/gravitational/teleport/lib/kube/proxy/testing/kube_server"
 )
 
-// TestEphemeralContainersRequiresExecAndPatch verifies that a PATCH to
-// pods/{name}/ephemeralcontainers (what `kubectl debug` issues) is admitted
-// only when the user is granted both the exec verb and the patch/update
-// mutation verb on pods. The two verbs are checked independently, so they may
-// be granted by different roles: Teleport RBAC is additive and permissions
-// union across roles. Neither verb on its own is enough.
-func TestEphemeralContainersRequiresExecAndPatch(t *testing.T) {
-	t.Parallel()
-
-	kubeMock, err := tkm.NewKubeAPIMock()
-	require.NoError(t, err)
-	t.Cleanup(func() { kubeMock.Close() })
-
-	testCtx := SetupTestContext(
-		context.Background(),
-		t,
-		TestConfig{
-			Clusters: []KubeClusterConfig{{Name: kubeCluster, APIEndpoint: kubeMock.URL}},
-		},
-	)
-	t.Cleanup(func() { require.NoError(t, testCtx.Close()) })
-
-	// podVerbs returns a SetupRoleFunc granting the given verbs on all pods.
-	podVerbs := func(verbs ...string) func(types.Role) {
-		return func(r types.Role) {
-			r.SetKubeResources(types.Allow, []types.KubernetesResource{{
-				Kind:      "pods",
-				Name:      types.Wildcard,
-				Namespace: types.Wildcard,
-				Verbs:     verbs,
-				APIGroup:  types.Wildcard,
-			}})
-		}
-	}
-
-	patchOnlyUser, _ := testCtx.CreateUserAndRole(testCtx.Context, t, "eph_patch_only", RoleSpec{
-		Name:          "eph_patch_only",
-		KubeUsers:     roleKubeUsers,
-		KubeGroups:    roleKubeGroups,
-		SetupRoleFunc: podVerbs("get", "list", "watch", "patch", "update"),
-	})
-	execOnlyUser, _ := testCtx.CreateUserAndRole(testCtx.Context, t, "eph_exec_only", RoleSpec{
-		Name:          "eph_exec_only",
-		KubeUsers:     roleKubeUsers,
-		KubeGroups:    roleKubeGroups,
-		SetupRoleFunc: podVerbs("get", "list", "watch", "exec"),
-	})
-	execPatchUser, _ := testCtx.CreateUserAndRole(testCtx.Context, t, "eph_exec_patch", RoleSpec{
-		Name:          "eph_exec_patch",
-		KubeUsers:     roleKubeUsers,
-		KubeGroups:    roleKubeGroups,
-		SetupRoleFunc: podVerbs("get", "list", "watch", "exec", "patch", "update"),
-	})
-
-	// splitUser has exec from one role and patch from another. Under additive
-	// RBAC the user effectively has both, so the request must be admitted.
-	splitUser := createUserWithRoles(t, testCtx, "eph_split",
-		podVerbs("get", "list", "watch", "exec"),
-		podVerbs("get", "list", "watch", "patch", "update"),
-	)
-
-	tests := []struct {
-		name    string
-		user    types.User
-		admit   bool
-		message string
-	}{
-		{name: "patch only is denied", user: patchOnlyUser, admit: false},
-		{name: "exec only is denied", user: execOnlyUser, admit: false},
-		{name: "exec and patch in one role is admitted", user: execPatchUser, admit: true},
-		{name: "exec and patch split across roles is admitted", user: splitUser, admit: true},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-			client, _ := testCtx.GenTestKubeClientTLSCert(t, tt.user.GetName(), kubeCluster)
-
-			// PATCH /api/v1/namespaces/default/pods/test/ephemeralcontainers.
-			err := client.CoreV1().RESTClient().
-				Patch(kubetypes.StrategicMergePatchType).
-				Namespace(metav1.NamespaceDefault).
-				Resource("pods").
-				Name("test").
-				SubResource("ephemeralcontainers").
-				Body([]byte(`{"spec":{"ephemeralContainers":[{"name":"debugger","image":"busybox"}]}}`)).
-				Do(testCtx.Context).
-				Error()
-
-			if tt.admit {
-				// Teleport forwards the request. The mock has no
-				// ephemeralcontainers route, so the upstream answers
-				// not-found rather than Teleport answering forbidden.
-				require.False(t, kubeerrors.IsForbidden(err),
-					"request should be admitted by Teleport, got %v", err)
-			} else {
-				require.True(t, kubeerrors.IsForbidden(err),
-					"request should be denied by Teleport, got %v", err)
-			}
-		})
-	}
-}
-
-// createUserWithRoles creates a user assigned multiple Teleport roles, each
-// with the given pod verbs, so a single user can draw different verbs from
-// different roles. Returns the created user.
-func createUserWithRoles(t *testing.T, testCtx *TestContext, prefix string, setups ...func(types.Role)) types.User {
-	t.Helper()
-	auth := testCtx.TLSServer.Auth()
-
-	var roleNames []string
-	for i, setup := range setups {
-		roleName := prefix + "_role_" + string(rune('a'+i))
-		role, err := types.NewRole(roleName, types.RoleSpecV6{
-			Allow: types.RoleConditions{
-				KubernetesLabels: types.Labels{types.Wildcard: []string{types.Wildcard}},
-				KubeGroups:       roleKubeGroups,
-				KubeUsers:        roleKubeUsers,
+// TestEphemeralContainersRequiredVerbs asserts the set of kubernetes_resources verbs that gate each pods request.
+// Adding an ephemeral container (PATCH/PUT to pods/{name}/ephemeralcontainers) runs code in the target pod
+// the same way exec does, and also mutates the pod,
+// so it must require both the exec verb and the mutation verb the HTTP method maps to.
+// A plain pod patch and pods/exec must each require only their own single verb,
+// so that neither verb on its own is enough to add an ephemeral container.
+func TestEphemeralContainersRequiredVerbs(t *testing.T) {
+	// Minimal kubeDetails with just the "pods" resource registered for RBAC.
+	// Mirrors what newClusterSchemaBuilder populates from real cluster
+	// discovery for the core/v1 pods resource.
+	kd := &kubeDetails{
+		rbacSupportedTypes: rbacSupportedResources{
+			allowedResourcesKey{apiGroup: "", resourceKind: "pods"}: metav1.APIResource{
+				Name:       "pods",
+				Namespaced: true,
+				Kind:       "Pod",
 			},
-		})
-		require.NoError(t, err)
-		setup(role)
-		_, err = auth.UpsertRole(testCtx.Context, role)
-		require.NoError(t, err)
-		roleNames = append(roleNames, roleName)
+		},
 	}
 
-	user, err := types.NewUser(prefix + "_user")
-	require.NoError(t, err)
-	user.SetRoles(roleNames)
-	user, err = auth.UpsertUser(testCtx.Context, user)
-	require.NoError(t, err)
-	return user
+	verbsFor := func(t *testing.T, method, path string) []string {
+		u, err := url.Parse(path)
+		require.NoError(t, err)
+		mr, err := getResourceFromRequest(&http.Request{Method: method, URL: u}, kd)
+		require.NoError(t, err)
+
+		var verbs []string
+		for _, r := range mr.requiredRBACResources() {
+			verbs = append(verbs, r.Verbs...)
+		}
+		return verbs
+	}
+
+	// Control: pods/exec requires only the exec verb.
+	t.Run("pods/exec requires only exec", func(t *testing.T) {
+		verbs := verbsFor(t, http.MethodPost, "/api/v1/namespaces/default/pods/foo/exec")
+		require.Equal(t, []string{types.KubeVerbExec}, verbs)
+	})
+
+	// Control: a patch to the pod itself (e.g. a label update) requires only
+	// the patch verb. It must not pull in exec, otherwise a label patch and an
+	// ephemeral container would be indistinguishable in RBAC.
+	t.Run("pod patch requires only patch", func(t *testing.T) {
+		verbs := verbsFor(t, http.MethodPatch, "/api/v1/namespaces/default/pods/foo")
+		require.Equal(t, []string{types.KubeVerbPatch}, verbs)
+		require.NotContains(t, verbs, types.KubeVerbExec)
+	})
+
+	t.Run("ephemeralcontainers patch requires exec and patch", func(t *testing.T) {
+		verbs := verbsFor(t, http.MethodPatch,
+			"/api/v1/namespaces/default/pods/foo/ephemeralcontainers")
+		require.Contains(t, verbs, types.KubeVerbExec,
+			"adding an ephemeral container must require the exec verb")
+		require.Contains(t, verbs, types.KubeVerbPatch,
+			"adding an ephemeral container must require the mutation verb")
+	})
+
+	t.Run("ephemeralcontainers put requires exec and update", func(t *testing.T) {
+		verbs := verbsFor(t, http.MethodPut,
+			"/api/v1/namespaces/default/pods/foo/ephemeralcontainers")
+		require.Contains(t, verbs, types.KubeVerbExec,
+			"adding an ephemeral container must require the exec verb")
+		require.Contains(t, verbs, types.KubeVerbUpdate,
+			"adding an ephemeral container must require the mutation verb")
+	})
 }

--- a/lib/kube/proxy/ephemeralcontainers_verb_test.go
+++ b/lib/kube/proxy/ephemeralcontainers_verb_test.go
@@ -19,79 +19,148 @@
 package proxy
 
 import (
-	"net/http"
-	"net/url"
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	kubeerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kubetypes "k8s.io/apimachinery/pkg/types"
 
 	"github.com/gravitational/teleport/api/types"
+	tkm "github.com/gravitational/teleport/lib/kube/proxy/testing/kube_server"
 )
 
-// TestEphemeralContainersRequiredVerbs asserts the set of kubernetes_resources verbs that gate each pods request.
-// Adding an ephemeral container (PATCH/PUT to pods/{name}/ephemeralcontainers) runs code in the target pod
-// the same way exec does, and also mutates the pod,
-// so it must require both the exec verb and the mutation verb the HTTP method maps to.
-// A plain pod patch and pods/exec must each require only their own single verb,
-// so that neither verb on its own is enough to add an ephemeral container.
-func TestEphemeralContainersRequiredVerbs(t *testing.T) {
-	// Minimal kubeDetails with just the "pods" resource registered for RBAC.
-	// Mirrors what newClusterSchemaBuilder populates from real cluster
-	// discovery for the core/v1 pods resource.
-	kd := &kubeDetails{
-		rbacSupportedTypes: rbacSupportedResources{
-			allowedResourcesKey{apiGroup: "", resourceKind: "pods"}: metav1.APIResource{
-				Name:       "pods",
-				Namespaced: true,
-				Kind:       "Pod",
-			},
+// TestEphemeralContainersRequiresExecAndPatch verifies that a PATCH to
+// pods/{name}/ephemeralcontainers (what `kubectl debug` issues) is admitted
+// only when the user is granted both the exec verb and the patch/update
+// mutation verb on pods. The two verbs are checked independently, so they may
+// be granted by different roles: Teleport RBAC is additive and permissions
+// union across roles. Neither verb on its own is enough.
+func TestEphemeralContainersRequiresExecAndPatch(t *testing.T) {
+	t.Parallel()
+
+	kubeMock, err := tkm.NewKubeAPIMock()
+	require.NoError(t, err)
+	t.Cleanup(func() { kubeMock.Close() })
+
+	testCtx := SetupTestContext(
+		context.Background(),
+		t,
+		TestConfig{
+			Clusters: []KubeClusterConfig{{Name: kubeCluster, APIEndpoint: kubeMock.URL}},
 		},
-	}
+	)
+	t.Cleanup(func() { require.NoError(t, testCtx.Close()) })
 
-	verbsFor := func(t *testing.T, method, path string) []string {
-		u, err := url.Parse(path)
-		require.NoError(t, err)
-		mr, err := getResourceFromRequest(&http.Request{Method: method, URL: u}, kd)
-		require.NoError(t, err)
-
-		var verbs []string
-		for _, r := range mr.requiredRBACResources() {
-			verbs = append(verbs, r.Verbs...)
+	// podVerbs returns a SetupRoleFunc granting the given verbs on all pods.
+	podVerbs := func(verbs ...string) func(types.Role) {
+		return func(r types.Role) {
+			r.SetKubeResources(types.Allow, []types.KubernetesResource{{
+				Kind:      "pods",
+				Name:      types.Wildcard,
+				Namespace: types.Wildcard,
+				Verbs:     verbs,
+				APIGroup:  types.Wildcard,
+			}})
 		}
-		return verbs
 	}
 
-	// Control: pods/exec requires only the exec verb.
-	t.Run("pods/exec requires only exec", func(t *testing.T) {
-		verbs := verbsFor(t, http.MethodPost, "/api/v1/namespaces/default/pods/foo/exec")
-		require.Equal(t, []string{types.KubeVerbExec}, verbs)
+	patchOnlyUser, _ := testCtx.CreateUserAndRole(testCtx.Context, t, "eph_patch_only", RoleSpec{
+		Name:          "eph_patch_only",
+		KubeUsers:     roleKubeUsers,
+		KubeGroups:    roleKubeGroups,
+		SetupRoleFunc: podVerbs("get", "list", "watch", "patch", "update"),
+	})
+	execOnlyUser, _ := testCtx.CreateUserAndRole(testCtx.Context, t, "eph_exec_only", RoleSpec{
+		Name:          "eph_exec_only",
+		KubeUsers:     roleKubeUsers,
+		KubeGroups:    roleKubeGroups,
+		SetupRoleFunc: podVerbs("get", "list", "watch", "exec"),
+	})
+	execPatchUser, _ := testCtx.CreateUserAndRole(testCtx.Context, t, "eph_exec_patch", RoleSpec{
+		Name:          "eph_exec_patch",
+		KubeUsers:     roleKubeUsers,
+		KubeGroups:    roleKubeGroups,
+		SetupRoleFunc: podVerbs("get", "list", "watch", "exec", "patch", "update"),
 	})
 
-	// Control: a patch to the pod itself (e.g. a label update) requires only
-	// the patch verb. It must not pull in exec, otherwise a label patch and an
-	// ephemeral container would be indistinguishable in RBAC.
-	t.Run("pod patch requires only patch", func(t *testing.T) {
-		verbs := verbsFor(t, http.MethodPatch, "/api/v1/namespaces/default/pods/foo")
-		require.Equal(t, []string{types.KubeVerbPatch}, verbs)
-		require.NotContains(t, verbs, types.KubeVerbExec)
-	})
+	// splitUser has exec from one role and patch from another. Under additive
+	// RBAC the user effectively has both, so the request must be admitted.
+	splitUser := createUserWithRoles(t, testCtx, "eph_split",
+		podVerbs("get", "list", "watch", "exec"),
+		podVerbs("get", "list", "watch", "patch", "update"),
+	)
 
-	t.Run("ephemeralcontainers patch requires exec and patch", func(t *testing.T) {
-		verbs := verbsFor(t, http.MethodPatch,
-			"/api/v1/namespaces/default/pods/foo/ephemeralcontainers")
-		require.Contains(t, verbs, types.KubeVerbExec,
-			"adding an ephemeral container must require the exec verb")
-		require.Contains(t, verbs, types.KubeVerbPatch,
-			"adding an ephemeral container must require the mutation verb")
-	})
+	tests := []struct {
+		name    string
+		user    types.User
+		admit   bool
+		message string
+	}{
+		{name: "patch only is denied", user: patchOnlyUser, admit: false},
+		{name: "exec only is denied", user: execOnlyUser, admit: false},
+		{name: "exec and patch in one role is admitted", user: execPatchUser, admit: true},
+		{name: "exec and patch split across roles is admitted", user: splitUser, admit: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			client, _ := testCtx.GenTestKubeClientTLSCert(t, tt.user.GetName(), kubeCluster)
 
-	t.Run("ephemeralcontainers put requires exec and update", func(t *testing.T) {
-		verbs := verbsFor(t, http.MethodPut,
-			"/api/v1/namespaces/default/pods/foo/ephemeralcontainers")
-		require.Contains(t, verbs, types.KubeVerbExec,
-			"adding an ephemeral container must require the exec verb")
-		require.Contains(t, verbs, types.KubeVerbUpdate,
-			"adding an ephemeral container must require the mutation verb")
-	})
+			// PATCH /api/v1/namespaces/default/pods/test/ephemeralcontainers.
+			err := client.CoreV1().RESTClient().
+				Patch(kubetypes.StrategicMergePatchType).
+				Namespace(metav1.NamespaceDefault).
+				Resource("pods").
+				Name("test").
+				SubResource("ephemeralcontainers").
+				Body([]byte(`{"spec":{"ephemeralContainers":[{"name":"debugger","image":"busybox"}]}}`)).
+				Do(testCtx.Context).
+				Error()
+
+			if tt.admit {
+				// Teleport forwards the request. The mock has no
+				// ephemeralcontainers route, so the upstream answers
+				// not-found rather than Teleport answering forbidden.
+				require.False(t, kubeerrors.IsForbidden(err),
+					"request should be admitted by Teleport, got %v", err)
+			} else {
+				require.True(t, kubeerrors.IsForbidden(err),
+					"request should be denied by Teleport, got %v", err)
+			}
+		})
+	}
+}
+
+// createUserWithRoles creates a user assigned multiple Teleport roles, each
+// with the given pod verbs, so a single user can draw different verbs from
+// different roles. Returns the created user.
+func createUserWithRoles(t *testing.T, testCtx *TestContext, prefix string, setups ...func(types.Role)) types.User {
+	t.Helper()
+	auth := testCtx.TLSServer.Auth()
+
+	var roleNames []string
+	for i, setup := range setups {
+		roleName := prefix + "_role_" + string(rune('a'+i))
+		role, err := types.NewRole(roleName, types.RoleSpecV6{
+			Allow: types.RoleConditions{
+				KubernetesLabels: types.Labels{types.Wildcard: []string{types.Wildcard}},
+				KubeGroups:       roleKubeGroups,
+				KubeUsers:        roleKubeUsers,
+			},
+		})
+		require.NoError(t, err)
+		setup(role)
+		_, err = auth.UpsertRole(testCtx.Context, role)
+		require.NoError(t, err)
+		roleNames = append(roleNames, roleName)
+	}
+
+	user, err := types.NewUser(prefix + "_user")
+	require.NoError(t, err)
+	user.SetRoles(roleNames)
+	user, err = auth.UpsertUser(testCtx.Context, user)
+	require.NoError(t, err)
+	return user
 }

--- a/lib/kube/proxy/forwarder.go
+++ b/lib/kube/proxy/forwarder.go
@@ -1252,15 +1252,8 @@ func (f *Forwarder) authorize(ctx context.Context, actx *authContext) error {
 			// results in the intersection of roles that match the "kubernetes_labels" and
 			// roles that allow access to the desired "kubernetes_resource".
 			// If from the intersection results an empty set, the request is denied.
-			//
-			// requiredRBACResources returns one tuple per (resource, verb) the request needs.
-			// Most requests need exactly one, adding an ephemeral container needs both exec and the mutation verb.
-			isClusterWideResource := actx.metaResource.isClusterWideResource()
-			required := actx.metaResource.requiredRBACResources()
-			roleMatchers = make(services.RoleMatchers, 0, len(required))
-			for i := range required {
-				roleMatchers = append(roleMatchers,
-					services.NewKubernetesResourceMatcher(required[i], isClusterWideResource))
+			roleMatchers = services.RoleMatchers{
+				services.NewKubernetesResourceMatcher(*rbacResource, actx.metaResource.isClusterWideResource()),
 			}
 		}
 	}
@@ -1289,6 +1282,26 @@ func (f *Forwarder) authorize(ctx context.Context, actx *authContext) error {
 		}
 		if !errors.Is(err, errNoMatchingCluster) {
 			return trace.AccessDenied("%s", accessDeniedMsg)
+		}
+	}
+
+	// Adding an ephemeral container (e.g. `kubectl debug`) executes code in the
+	// pod like exec, and also mutates it. The matcher above required the
+	// mutation verb; also require exec. A separate check keeps it additive: the
+	// two verbs may come from different roles.
+	if !isScoped && !actx.metaResource.isList &&
+		actx.metaResource.requestedResource.resourceKind == ephemeralContainersResourceKind {
+		if rbacResource := actx.metaResource.rbacResource(); rbacResource != nil {
+			execResource := *rbacResource
+			execResource.Verbs = []string{types.KubeVerbExec}
+			execMatcher := services.NewKubernetesResourceMatcher(execResource, actx.metaResource.isClusterWideResource())
+			if _, err := f.getKubeAccessDetails(ctx, actx, execMatcher); err != nil {
+				return trace.AccessDenied("%s", f.kubeResourceDeniedAccessMsg(
+					actx.User.GetName(),
+					types.KubeVerbExec,
+					actx.metaResource.requestedResource,
+				))
+			}
 		}
 	}
 

--- a/lib/kube/proxy/forwarder.go
+++ b/lib/kube/proxy/forwarder.go
@@ -1252,8 +1252,15 @@ func (f *Forwarder) authorize(ctx context.Context, actx *authContext) error {
 			// results in the intersection of roles that match the "kubernetes_labels" and
 			// roles that allow access to the desired "kubernetes_resource".
 			// If from the intersection results an empty set, the request is denied.
-			roleMatchers = services.RoleMatchers{
-				services.NewKubernetesResourceMatcher(*rbacResource, actx.metaResource.isClusterWideResource()),
+			//
+			// requiredRBACResources returns one tuple per (resource, verb) the request needs.
+			// Most requests need exactly one, adding an ephemeral container needs both exec and the mutation verb.
+			isClusterWideResource := actx.metaResource.isClusterWideResource()
+			required := actx.metaResource.requiredRBACResources()
+			roleMatchers = make(services.RoleMatchers, 0, len(required))
+			for i := range required {
+				roleMatchers = append(roleMatchers,
+					services.NewKubernetesResourceMatcher(required[i], isClusterWideResource))
 			}
 		}
 	}

--- a/lib/kube/proxy/forwarder.go
+++ b/lib/kube/proxy/forwarder.go
@@ -1252,8 +1252,15 @@ func (f *Forwarder) authorize(ctx context.Context, actx *authContext) error {
 			// results in the intersection of roles that match the "kubernetes_labels" and
 			// roles that allow access to the desired "kubernetes_resource".
 			// If from the intersection results an empty set, the request is denied.
-			roleMatchers = services.RoleMatchers{
-				services.NewKubernetesResourceMatcher(*rbacResource, actx.metaResource.isClusterWideResource()),
+			//
+			// requiredRBACResources returns one tuple per (resource, verb) the request needs.
+			// Most requests need exactly one, adding an ephemeral container needs both exec and the mutation verb.
+			isClusterWideResource := actx.metaResource.isClusterWideResource()
+			required := actx.metaResource.requiredRBACResources()
+			roleMatchers = make(services.RoleMatchers, 0, len(required))
+			for i := range required {
+				roleMatchers = append(roleMatchers,
+					services.NewKubernetesResourceMatcher(required[i], isClusterWideResource))
 			}
 		}
 	}
@@ -1282,26 +1289,6 @@ func (f *Forwarder) authorize(ctx context.Context, actx *authContext) error {
 		}
 		if !errors.Is(err, errNoMatchingCluster) {
 			return trace.AccessDenied("%s", accessDeniedMsg)
-		}
-	}
-
-	// Adding an ephemeral container (e.g. `kubectl debug`) executes code in the
-	// pod like exec, and also mutates it. The matcher above required the
-	// mutation verb; also require exec. A separate check keeps it additive: the
-	// two verbs may come from different roles.
-	if !isScoped && !actx.metaResource.isList &&
-		actx.metaResource.requestedResource.resourceKind == ephemeralContainersResourceKind {
-		if rbacResource := actx.metaResource.rbacResource(); rbacResource != nil {
-			execResource := *rbacResource
-			execResource.Verbs = []string{types.KubeVerbExec}
-			execMatcher := services.NewKubernetesResourceMatcher(execResource, actx.metaResource.isClusterWideResource())
-			if _, err := f.getKubeAccessDetails(ctx, actx, execMatcher); err != nil {
-				return trace.AccessDenied("%s", f.kubeResourceDeniedAccessMsg(
-					actx.User.GetName(),
-					types.KubeVerbExec,
-					actx.metaResource.requestedResource,
-				))
-			}
 		}
 	}
 

--- a/lib/kube/proxy/url.go
+++ b/lib/kube/proxy/url.go
@@ -67,25 +67,6 @@ func (mr *metaResource) rbacResource() *types.KubernetesResource {
 // ephemeral container to a running pod (the endpoint `kubectl debug` targets).
 const ephemeralContainersResourceKind = "pods/ephemeralcontainers"
 
-// requiredRBACResources returns the set of Kubernetes resources the caller must be granted to perform this request.
-// Most requests need a single (resource, verb) tuple, the one returned by rbacResource.
-// Adding an ephemeral container runs code in the target pod the same way exec does,
-// and the request also mutates the pod object (it is a patch/update),
-// so it requires both the exec verb and the mutation verb the HTTP method maps to.
-// Returning both keeps either verb on its own from being enough to add an ephemeral container.
-func (mr *metaResource) requiredRBACResources() []types.KubernetesResource {
-	base := mr.rbacResource()
-	if base == nil {
-		return nil
-	}
-	if mr.requestedResource.resourceKind != ephemeralContainersResourceKind {
-		return []types.KubernetesResource{*base}
-	}
-	execResource := *base
-	execResource.Verbs = []string{types.KubeVerbExec}
-	return []types.KubernetesResource{*base, execResource}
-}
-
 // apiResource represents the resource requested by the user.
 type apiResource struct {
 	apiGroup        string

--- a/lib/kube/proxy/url.go
+++ b/lib/kube/proxy/url.go
@@ -63,6 +63,29 @@ func (mr *metaResource) rbacResource() *types.KubernetesResource {
 	}
 }
 
+// ephemeralContainersResourceKind is the pods subresource used to add an
+// ephemeral container to a running pod (the endpoint `kubectl debug` targets).
+const ephemeralContainersResourceKind = "pods/ephemeralcontainers"
+
+// requiredRBACResources returns the set of Kubernetes resources the caller must be granted to perform this request.
+// Most requests need a single (resource, verb) tuple, the one returned by rbacResource.
+// Adding an ephemeral container runs code in the target pod the same way exec does,
+// and the request also mutates the pod object (it is a patch/update),
+// so it requires both the exec verb and the mutation verb the HTTP method maps to.
+// Returning both keeps either verb on its own from being enough to add an ephemeral container.
+func (mr *metaResource) requiredRBACResources() []types.KubernetesResource {
+	base := mr.rbacResource()
+	if base == nil {
+		return nil
+	}
+	if mr.requestedResource.resourceKind != ephemeralContainersResourceKind {
+		return []types.KubernetesResource{*base}
+	}
+	execResource := *base
+	execResource.Verbs = []string{types.KubeVerbExec}
+	return []types.KubernetesResource{*base, execResource}
+}
+
 // apiResource represents the resource requested by the user.
 type apiResource struct {
 	apiGroup        string

--- a/lib/kube/proxy/url.go
+++ b/lib/kube/proxy/url.go
@@ -67,6 +67,25 @@ func (mr *metaResource) rbacResource() *types.KubernetesResource {
 // ephemeral container to a running pod (the endpoint `kubectl debug` targets).
 const ephemeralContainersResourceKind = "pods/ephemeralcontainers"
 
+// requiredRBACResources returns the set of Kubernetes resources the caller must be granted to perform this request.
+// Most requests need a single (resource, verb) tuple, the one returned by rbacResource.
+// Adding an ephemeral container runs code in the target pod the same way exec does,
+// and the request also mutates the pod object (it is a patch/update),
+// so it requires both the exec verb and the mutation verb the HTTP method maps to.
+// Returning both keeps either verb on its own from being enough to add an ephemeral container.
+func (mr *metaResource) requiredRBACResources() []types.KubernetesResource {
+	base := mr.rbacResource()
+	if base == nil {
+		return nil
+	}
+	if mr.requestedResource.resourceKind != ephemeralContainersResourceKind {
+		return []types.KubernetesResource{*base}
+	}
+	execResource := *base
+	execResource.Verbs = []string{types.KubeVerbExec}
+	return []types.KubernetesResource{*base, execResource}
+}
+
 // apiResource represents the resource requested by the user.
 type apiResource struct {
 	apiGroup        string


### PR DESCRIPTION
Adding an ephemeral container to a running pod (`PATCH`/`PUT pods/{name}/ephemeralcontainers`, the endpoint `kubectl debug` uses) runs a command inside the target pod the same way `exec` does, and it also mutates the pod object. Teleport's `kubernetes_resources` matching gates that request on `patch`/`update` alone, so a role with `patch` but no `exec` can add a debug container. Mapping it to `exec` alone would have the opposite problem: `exec` would let a user mutate the pod by bringing their own container.

This change requires a role to grant **both** the `exec` verb and the request's `patch`/`update` verb on the pod. Both must come from the same role, which is the coupling already used between `kubernetes_labels` and `kubernetes_resources`. Roles using a wildcard verb are unaffected. A role granting only one of the two no longer allows adding an ephemeral container.

Implementation: `metaResource.requiredRBACResources` returns the `(resource, verb)` tuples a request needs; for `pods/ephemeralcontainers` it returns both the mutation verb the HTTP method maps to and `exec`. `authorize` turns each tuple into a `KubernetesResourceMatcher`, and `CheckKubeGroupsAndUsers` requires a single role to satisfy all matchers.

<!-- Provide a descriptive entry for the changelog of the next release. -->

Changelog: Kubernetes: adding an ephemeral container to a pod (`pods/ephemeralcontainers`) now requires both the `exec` and `patch`/`update` verbs in the same role's `kubernetes_resources`. Previously only `patch`/`update` was required.

<!-- Include manual testing efforts to verify the change. -->
<!-- Detail where the tests where run and what configurations were used. -->
<!-- Include all the test cases which were run to validate the change. -->

## Manual Test Plan

### Test Environment

Self-hosted Teleport on AWS EKS, Helm chart `teleport-cluster` in `standalone` mode with `kubernetes_service` on the auth pod (kube cluster `eks-self-hosted`). Auth pod running this branch. One Teleport role + user per case, kubeconfig minted via `tctl auth sign --format=kubernetes`. `kubectl debug app --target=app` issues the PATCH to `pods/{name}/ephemeralcontainers`.

### Test Cases

Role with `kubernetes_resources: [{kind: pods, verbs: [get,list,watch,patch,update]}]` (no `exec`):

- [x] `kubectl debug` / PATCH to `pods/{name}/ephemeralcontainers` is denied. Observed: `Error from server (Forbidden): pods "app" is forbidden: User "eph-patch" cannot patch resource "pods" in API group "" in the namespace "eph-test"`, with the hint to add `pods/ephemeralcontainers` to `kubernetes_resources`. No ephemeral container created.
- [x] `kubectl patch pod <name> -p '{"metadata":{"labels":{"probe":"1"}}}'` still succeeds. Observed: `pod/app patched`.

Role with `kubernetes_resources: [{kind: pods, verbs: [get,list,watch,exec]}]` (no `patch`):

- [x] `kubectl exec` on a matching pod is admitted (unchanged). Observed: command ran, returned `hello-from-exec`.
- [x] `kubectl debug` / PATCH to `pods/{name}/ephemeralcontainers` is denied. Observed: `Error from server (Forbidden): pods "app" is forbidden: User "eph-exec" cannot patch resource "pods" ...`. No ephemeral container created.

Role with `kubernetes_resources: [{kind: pods, verbs: [get,list,watch,exec,patch,update]}]`:

- [x] `kubectl debug` / PATCH to `pods/{name}/ephemeralcontainers` is admitted. Observed: command returned cleanly; ephemeral container `debugger-8frd5` present in `pod/app` `spec.ephemeralContainers`.

Role with `kubernetes_resources: [{kind: pods, verbs: [*]}]`:

- [x] `kubectl debug` / PATCH to `pods/{name}/ephemeralcontainers` is admitted (unchanged). Observed: command returned cleanly; ephemeral container `debugger-6kpw8` present in `pod/app`.

