### PR TITLE
kube/token: prevent panic on join JWT missing service account claim

### DIFF
--- a/lib/kube/token/validator.go
+++ b/lib/kube/token/validator.go
@@ -300,7 +300,8 @@ func ValidateTokenWithJWKS(
 	}
 
 	// Ensure this is a pod-bound service account token
-	if claims.Kubernetes == nil || claims.Kubernetes.Pod == nil || claims.Kubernetes.Pod.Name == "" {
+	if claims.Kubernetes == nil || claims.Kubernetes.Pod == nil || claims.Kubernetes.Pod.Name == "" ||
+		claims.Kubernetes.ServiceAccount == nil || claims.Kubernetes.ServiceAccount.Name == "" {
 		return nil, trace.BadParameter("static_jwks joining requires the use of projected pod bound service account token")
 	}
 
@@ -376,7 +377,8 @@ func (v *KubernetesOIDCTokenValidator) ValidateToken(
 	}
 
 	// Ensure this is a pod-bound service account token
-	if claims.Kubernetes == nil || claims.Kubernetes.Pod == nil || claims.Kubernetes.Pod.Name == "" {
+	if claims.Kubernetes == nil || claims.Kubernetes.Pod == nil || claims.Kubernetes.Pod.Name == "" ||
+		claims.Kubernetes.ServiceAccount == nil || claims.Kubernetes.ServiceAccount.Name == "" {
 		return nil, trace.BadParameter("oidc joining requires the use of a projected pod bound service account token")
 	}
 

--- a/lib/kube/token/validator_test.go
+++ b/lib/kube/token/validator_test.go
@@ -548,6 +548,28 @@ func TestValidateTokenWithJWKS(t *testing.T) {
 			wantErr: "static_jwks joining requires the use of projected pod bound service account token",
 		},
 		{
+			// A token with a pod claim but no service account claim must be rejected, not panic.
+			name:   "missing service account claim",
+			signer: signer,
+			claims: claims.ServiceAccountClaims{
+				Claims: jwt.Claims{
+					Subject:   "system:serviceaccount:default:my-service-account",
+					Audience:  jwt.Audience{clusterName},
+					IssuedAt:  jwt.NewNumericDate(now.Add(-1 * time.Minute)),
+					NotBefore: jwt.NewNumericDate(now.Add(-1 * time.Minute)),
+					Expiry:    jwt.NewNumericDate(now.Add(10 * time.Minute)),
+				},
+				Kubernetes: &claims.KubernetesSubClaim{
+					Pod: &claims.PodSubClaim{
+						Name: "my-pod-797959fdf-wptbj",
+						UID:  "413b22ca-4833-48d9-b6db-76219d583173",
+					},
+					Namespace: "default",
+				},
+			},
+			wantErr: "static_jwks joining requires the use of projected pod bound service account token",
+		},
+		{
 			name:   "signed by unknown key",
 			signer: wrongSigner,
 			claims: claims.ServiceAccountClaims{
@@ -848,6 +870,29 @@ func TestValidateTokenWithOIDC(t *testing.T) {
 			)),
 			assertError: func(t require.TestingT, err error, i ...any) {
 				require.ErrorContains(t, err, "signature verification failed")
+			},
+			want: nil,
+		},
+		{
+			// A token with a pod claim but no service account claim must be rejected, not panic.
+			name:     "missing-service-account",
+			audience: idpAudience,
+			token: mustIssueToken(idp.IssueToken(
+				idp.IssuerURL(),
+				idpAudience,
+				"example",
+				time.Now().Add(-5*time.Minute),
+				time.Now().Add(5*time.Minute),
+				&claims.KubernetesSubClaim{
+					Namespace: "default",
+					Pod: &claims.PodSubClaim{
+						Name: "example-pod",
+						UID:  "zxcv-1234",
+					},
+				},
+			)),
+			assertError: func(t require.TestingT, err error, i ...any) {
+				require.ErrorContains(t, err, "requires the use of a projected pod")
 			},
 			want: nil,
 		},


### PR DESCRIPTION
Both Kubernetes join validators (`static_jwks` and `oidc`) dereferenced `claims.Kubernetes.ServiceAccount.Name` after a guard that only checked `Kubernetes`/`Pod`. Because `ServiceAccount` is a pointer, a signed JWT with a pod claim but no `serviceaccount` claim passed the guard and panicked the `RegisterUsingToken` handler.

The guard now also requires a non-empty `ServiceAccount.Name`, returning `BadParameter` instead. A real kube-apiserver projected service account token always populates this claim.