### PR TITLE
validate session id as uuid before building file paths in filesessions

### DIFF
--- a/lib/events/filesessions/filestream.go
+++ b/lib/events/filesessions/filestream.go
@@ -387,6 +387,9 @@ func (h *Handler) GetUploadMetadata(s session.ID) events.UploadMetadata {
 
 // ReserveUploadPart reserves an upload part.
 func (h *Handler) ReserveUploadPart(ctx context.Context, upload events.StreamUpload, partNumber int64) error {
+	if err := checkUpload(upload); err != nil {
+		return trace.Wrap(err)
+	}
 	reservationPath := h.reservationPath(upload, partNumber)
 	if err := h.fileRecorder.ReservePart(ctx, reservationPath, reservationSize); err != nil {
 		return trace.Wrap(err)

--- a/lib/events/filesessions/filestream.go
+++ b/lib/events/filesessions/filestream.go
@@ -120,6 +120,9 @@ func NewStreamer(cfg StreamerConfig) (*events.ProtoStreamer, error) {
 
 // CreateUpload creates a multipart upload
 func (h *Handler) CreateUpload(ctx context.Context, sessionID session.ID) (*events.StreamUpload, error) {
+	if err := sessionID.Check(); err != nil {
+		return nil, trace.Wrap(err)
+	}
 	if err := os.MkdirAll(h.uploadsPath(), teleport.PrivateDirMode); err != nil {
 		return nil, trace.ConvertSystemError(err)
 	}
@@ -434,13 +437,16 @@ func partFromFileName(fileName string) (int64, error) {
 }
 
 // checkUpload checks that upload IDs are valid
-// and in addition verifies that upload ID is a valid UUID
-// to avoid file scanning by passing bogus upload ID file paths
+// and in addition verifies that the upload ID and session ID are valid UUIDs
+// to avoid file scanning by passing bogus IDs as file paths
 func checkUpload(upload events.StreamUpload) error {
 	if err := upload.CheckAndSetDefaults(); err != nil {
 		return trace.Wrap(err)
 	}
 	if err := checkUploadID(upload.ID); err != nil {
+		return trace.Wrap(err)
+	}
+	if err := upload.SessionID.Check(); err != nil {
 		return trace.Wrap(err)
 	}
 	return nil

--- a/lib/events/filesessions/filestream.go
+++ b/lib/events/filesessions/filestream.go
@@ -356,6 +356,11 @@ func (h *Handler) ListUploads(ctx context.Context) ([]events.StreamUpload, error
 			h.logger.WarnContext(ctx, "Skipping upload, not a directory.", "upload_id", uploadID)
 			continue
 		}
+		sessionID := session.ID(filepath.Base(files[0].Name()))
+		if err := sessionID.Check(); err != nil {
+			h.logger.WarnContext(ctx, "Skipping upload with bad session ID format", "upload_id", uploadID, "error", err)
+			continue
+		}
 
 		info, err := dir.Info()
 		if err != nil {
@@ -364,7 +369,7 @@ func (h *Handler) ListUploads(ctx context.Context) ([]events.StreamUpload, error
 		}
 
 		uploads = append(uploads, events.StreamUpload{
-			SessionID: session.ID(filepath.Base(files[0].Name())),
+			SessionID: sessionID,
 			ID:        uploadID,
 			Initiated: info.ModTime(),
 		})

--- a/lib/events/filesessions/filestream_test.go
+++ b/lib/events/filesessions/filestream_test.go
@@ -23,6 +23,7 @@ import (
 	"context"
 	"io"
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/gravitational/trace"
@@ -77,6 +78,38 @@ func TestReserveUploadPartPathTraversal(t *testing.T) {
 	err = handler.ReserveUploadPart(ctx, *upload, int64(1))
 	require.Error(t, err)
 	require.True(t, trace.IsBadParameter(err), "expected BadParameter, got %T: %v", err, err)
+}
+
+// TestListUploadsSkipsInvalidSessionDir verifies that an on-disk upload whose
+// session subdirectory is not a valid UUID is skipped by ListUploads instead
+// of being returned, so a stale or corrupt directory cannot make the upload
+// completer fail on every pass.
+func TestListUploadsSkipsInvalidSessionDir(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+
+	handler, err := NewHandler(Config{
+		Directory: dir,
+		OpenFile:  os.OpenFile,
+	})
+	require.NoError(t, err)
+
+	upload, err := handler.CreateUpload(ctx, session.NewID())
+	require.NoError(t, err)
+
+	// Plant an upload directory with a valid upload ID but a non-UUID
+	// session subdirectory.
+	badUpload, err := handler.CreateUpload(ctx, session.NewID())
+	require.NoError(t, err)
+	require.NoError(t, os.Rename(
+		handler.uploadPath(*badUpload),
+		filepath.Join(handler.uploadRootPath(*badUpload), "not-a-uuid"),
+	))
+
+	uploads, err := handler.ListUploads(ctx)
+	require.NoError(t, err)
+	require.Len(t, uploads, 1)
+	require.Equal(t, upload.ID, uploads[0].ID)
 }
 
 func TestUploadPart(t *testing.T) {

--- a/lib/events/filesessions/filestream_test.go
+++ b/lib/events/filesessions/filestream_test.go
@@ -25,6 +25,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/gravitational/trace"
 	"github.com/stretchr/testify/require"
 
 	"github.com/gravitational/teleport/lib/events"
@@ -51,6 +52,31 @@ func TestReserveUploadPart(t *testing.T) {
 	fi, err := os.Stat(handler.reservationPath(*upload, partNumber))
 	require.NoError(t, err)
 	require.GreaterOrEqual(t, fi.Size(), int64(minUploadBytes))
+}
+
+// TestReserveUploadPartPathTraversal verifies that a crafted upload whose
+// session ID contains path separators cannot reserve a part outside the
+// upload directory.
+func TestReserveUploadPartPathTraversal(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+
+	handler, err := NewHandler(Config{
+		Directory: dir,
+		OpenFile:  os.OpenFile,
+	})
+	require.NoError(t, err)
+
+	upload, err := handler.CreateUpload(ctx, session.NewID())
+	require.NoError(t, err)
+
+	// reservationPath joins the upload dir with string(upload.SessionID), so
+	// "../outside" would escape the upload directory before any validation.
+	upload.SessionID = session.ID("../outside")
+
+	err = handler.ReserveUploadPart(ctx, *upload, int64(1))
+	require.Error(t, err)
+	require.True(t, trace.IsBadParameter(err), "expected BadParameter, got %T: %v", err, err)
 }
 
 func TestUploadPart(t *testing.T) {

--- a/lib/events/filesessions/fileuploader.go
+++ b/lib/events/filesessions/fileuploader.go
@@ -118,11 +118,17 @@ func (l *Handler) Close() error {
 
 // StreamSessionRecording reads a session recording from a local directory.
 func (l *Handler) StreamSessionRecording(ctx context.Context, sessionID session.ID) (io.ReadCloser, error) {
+	if err := sessionID.Check(); err != nil {
+		return nil, trace.Wrap(err)
+	}
 	return openFile(l.recordingPath(sessionID))
 }
 
 // StreamSessionSummary reads a session summary from a local directory.
 func (l *Handler) StreamSessionSummary(ctx context.Context, sessionID session.ID) (io.ReadCloser, error) {
+	if err := sessionID.Check(); err != nil {
+		return nil, trace.Wrap(err)
+	}
 	filePathsToTest := [3]string{
 		l.summaryPath(sessionID),
 		l.pendingSummaryPath(sessionID),
@@ -144,16 +150,25 @@ func (l *Handler) StreamSessionSummary(ctx context.Context, sessionID session.ID
 
 // StreamSessionMetadata reads session metadata from a local directory.
 func (l *Handler) StreamSessionMetadata(ctx context.Context, sessionID session.ID) (io.ReadCloser, error) {
+	if err := sessionID.Check(); err != nil {
+		return nil, trace.Wrap(err)
+	}
 	return openFile(l.metadataPath(sessionID))
 }
 
 // StreamSessionThumbnail reads a session thumbnail from a local directory.
 func (l *Handler) StreamSessionThumbnail(ctx context.Context, sessionID session.ID) (io.ReadCloser, error) {
+	if err := sessionID.Check(); err != nil {
+		return nil, trace.Wrap(err)
+	}
 	return openFile(l.thumbnailPath(sessionID))
 }
 
 // Upload writes a session recording to a local directory.
 func (l *Handler) Upload(ctx context.Context, sessionID session.ID, reader io.Reader) (string, error) {
+	if err := sessionID.Check(); err != nil {
+		return "", trace.Wrap(err)
+	}
 	s, err := uploadFile(l.recordingPath(sessionID), reader)
 	return s, trace.Wrap(err)
 }
@@ -162,6 +177,9 @@ func (l *Handler) Upload(ctx context.Context, sessionID session.ID, reader io.Re
 // This function can be called multiple times for a given sessionID to update
 // the state.
 func (l *Handler) UploadPendingSummary(ctx context.Context, sessionID session.ID, reader io.Reader) (string, error) {
+	if err := sessionID.Check(); err != nil {
+		return "", trace.Wrap(err)
+	}
 	return uploadFile(l.pendingSummaryPath(sessionID), reader, withOverwrite())
 }
 
@@ -169,6 +187,9 @@ func (l *Handler) UploadPendingSummary(ctx context.Context, sessionID session.ID
 // pending one. This function can be called only once for a given sessionID;
 // subsequent calls will return an error.
 func (l *Handler) UploadSummary(ctx context.Context, sessionID session.ID, reader io.Reader) (string, error) {
+	if err := sessionID.Check(); err != nil {
+		return "", trace.Wrap(err)
+	}
 	name, err := uploadFile(l.summaryPath(sessionID), reader)
 	if err != nil {
 		return "", trace.Wrap(err)
@@ -184,11 +205,17 @@ func (l *Handler) UploadSummary(ctx context.Context, sessionID session.ID, reade
 
 // UploadMetadata writes session metadata to a local directory.
 func (l *Handler) UploadMetadata(ctx context.Context, sessionID session.ID, reader io.Reader) (string, error) {
+	if err := sessionID.Check(); err != nil {
+		return "", trace.Wrap(err)
+	}
 	return uploadFile(l.metadataPath(sessionID), reader)
 }
 
 // UploadThumbnail writes a session thumbnail to a local directory.
 func (l *Handler) UploadThumbnail(ctx context.Context, sessionID session.ID, reader io.Reader) (string, error) {
+	if err := sessionID.Check(); err != nil {
+		return "", trace.Wrap(err)
+	}
 	return uploadFile(l.thumbnailPath(sessionID), reader)
 }
 

--- a/lib/events/filesessions/fileuploader_test.go
+++ b/lib/events/filesessions/fileuploader_test.go
@@ -21,6 +21,7 @@ package filesessions
 import (
 	"context"
 	"os"
+	"path/filepath"
 	"sync/atomic"
 	"testing"
 
@@ -29,6 +30,7 @@ import (
 
 	"github.com/gravitational/teleport/lib/events"
 	"github.com/gravitational/teleport/lib/events/test"
+	"github.com/gravitational/teleport/lib/session"
 	"github.com/gravitational/teleport/lib/utils/log/logtest"
 )
 
@@ -77,4 +79,30 @@ func TestStreams(t *testing.T) {
 	t.Run("DownloadNotFound", func(t *testing.T) {
 		test.DownloadNotFound(t, handler)
 	})
+}
+
+// TestStreamSessionPathTraversal verifies that session IDs containing path
+// separators cannot be used to read files outside the recordings directory.
+func TestStreamSessionPathTraversal(t *testing.T) {
+	dir := t.TempDir()
+
+	handler, err := NewHandler(Config{
+		Directory: dir,
+		OpenFile:  os.OpenFile,
+	})
+	require.NoError(t, err)
+	defer handler.Close()
+
+	// Plant a .tar file in the parent of the recordings directory.
+	secret := filepath.Join(filepath.Dir(dir), "secret.tar")
+	require.NoError(t, os.WriteFile(secret, []byte("top secret"), 0o600))
+
+	// recordingPath joins l.Directory with string(sessionID)+".tar", so
+	// "../secret" resolves to the planted file outside l.Directory.
+	rc, err := handler.StreamSessionRecording(context.Background(), session.ID("../secret"))
+	if rc != nil {
+		rc.Close()
+	}
+	require.Error(t, err)
+	require.True(t, trace.IsBadParameter(err), "expected BadParameter, got %T: %v", err, err)
 }


### PR DESCRIPTION
Changelog: Validate that session IDs are valid UUIDs before they are used as file paths in the file-based session recording backend, preventing path traversal outside the recordings directory.

The file audit backend locates recordings, summaries, metadata and thumbnails by joining the configured directory with `string(sessionID)+ext`. The package already validates the multipart upload ID as a UUID (`checkUploadID`, "to avoid path scanning") and validates IDs read back out of filenames (`sessionIDFromPath`), but the `Handler` methods that turn an inbound `session.ID` into a path never check it. A caller with `session:read` reaches `Handler.StreamSessionRecording` through the gRPC `StreamSessionEvents` API, where `ServerWithRoles.StreamSessionEvents` runs an RBAC check but no format check, so a session ID is passed through verbatim.

1. The `StreamSession*` readers and the matching `Upload*` writers build a path from an unvalidated `session.ID`.
2. `CreateUpload`/`checkUpload` build the multipart upload path from `upload.SessionID`, which `checkUpload` left unchecked next to its existing `checkUploadID` guard.
Added `sessionID.Check()` at each site, reusing the package's own UUID validator.

Repro: with a file backend, call `StreamSessionRecording(ctx, session.ID("../secret"))`.
Expected: `BadParameter`.
Actual (before): `recordingPath` resolves to `<dir>/../secret.tar` and the file outside the recordings directory is opened and returned.
Fix: reject session IDs that are not valid UUIDs before the path is built.

## Manual Test Plan
### Test Environment
`go test ./lib/events/filesessions/`

### Test Cases
- [x] `TestStreamSessionPathTraversal` opens a file outside the recordings directory before the change and returns `BadParameter` after it; the existing `filesessions` suite stays green.