### PR TITLE
[v18] Refactor ListWorkloadIdentities to RangeWorkloadIdentities (#67504)

### DIFF
--- a/lib/auth/authclient/api.go
+++ b/lib/auth/authclient/api.go
@@ -1440,9 +1440,9 @@ type Cache interface {
 
 	// GetWorkloadIdentity gets a WorkloadIdentity by name.
 	GetWorkloadIdentity(ctx context.Context, name string) (*workloadidentityv1pb.WorkloadIdentity, error)
-	// ListWorkloadIdentities lists all SPIFFE Federations using Google style
-	// pagination.
-	ListWorkloadIdentities(ctx context.Context, pageSize int, lastToken string, options *services.ListWorkloadIdentitiesRequestOptions) ([]*workloadidentityv1pb.WorkloadIdentity, string, error)
+	// RangeWorkloadIdentities returns WorkloadIdentity resources within the
+	// range [start, end), ordered by the given sort field and direction.
+	RangeWorkloadIdentities(ctx context.Context, start, end string, sortField services.WorkloadIdentitySortField, sortDesc bool) iter.Seq2[*workloadidentityv1pb.WorkloadIdentity, error]
 
 	// ListStaticHostUsers lists static host users.
 	ListStaticHostUsers(ctx context.Context, pageSize int, startKey string) ([]*userprovisioningpb.StaticHostUser, string, error)

--- a/lib/auth/machineid/workloadidentityv1/issuer_service.go
+++ b/lib/auth/machineid/workloadidentityv1/issuer_service.go
@@ -23,6 +23,7 @@ import (
 	"crypto/rand"
 	"crypto/x509"
 	"encoding/json"
+	"iter"
 	"log/slog"
 	"math/big"
 	"net/url"
@@ -318,21 +319,20 @@ func (s *IssuanceService) IssueWorkloadIdentities(
 		return nil, trace.Wrap(err, "deriving attributes")
 	}
 
-	// Fetch all workload identities that match the label selectors AND the
-	// principal can access.
-	workloadIdentities, err := s.matchingAndAuthorizedWorkloadIdentities(
+	// Evaluate rules/templating for each workload identity that matches the
+	// label selectors and the principal can access, filtering out those that
+	// should not be issued. The matching identities are streamed and filtered
+	// lazily, so we stop as soon as the issue limit is exceeded.
+	shouldIssue := []*workloadidentityv1pb.WorkloadIdentity{}
+	for wi, err := range s.matchingAndAuthorizedWorkloadIdentities(
 		ctx,
 		authCtx,
-		convertLabels(req.LabelSelectors),
-	)
+		convertLabels(req.GetLabelSelectors()),
+	) {
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
-	// Evaluate rules/templating for each worklaod identity, filtering out those
-	// that should not be issued.
-	shouldIssue := []*workloadidentityv1pb.WorkloadIdentity{}
-	for _, wi := range workloadIdentities {
 		decision := decide(ctx, wi, attrs, s.getSigstorePolicyEvaluator())
 		if decision.shouldIssue {
 			shouldIssue = append(shouldIssue, decision.templatedWorkloadIdentity)
@@ -870,63 +870,47 @@ func (s *IssuanceService) issueJWTSVID(ctx context.Context, params issueJWTSVIDP
 	}, nil
 }
 
-func (s *IssuanceService) getAllWorkloadIdentities(
-	ctx context.Context,
-) ([]*workloadidentityv1pb.WorkloadIdentity, error) {
-	workloadIdentities := []*workloadidentityv1pb.WorkloadIdentity{}
-	page := ""
-	for {
-		pageItems, nextPage, err := s.cache.ListWorkloadIdentities(ctx, 0, page, nil)
-		if err != nil {
-			return nil, trace.Wrap(err)
-		}
-		workloadIdentities = append(workloadIdentities, pageItems...)
-		if nextPage == "" {
-			break
-		}
-		page = nextPage
-	}
-	return workloadIdentities, nil
-}
-
-// matchingAndAuthorizedWorkloadIdentities returns the workload identities that
-// match the provided labels and the principal has access to.
+// matchingAndAuthorizedWorkloadIdentities returns a stream of the workload
+// identities that match the provided labels and that the principal has access
+// to.
 func (s *IssuanceService) matchingAndAuthorizedWorkloadIdentities(
 	ctx context.Context,
 	authCtx *authz.Context,
 	labels types.Labels,
-) ([]*workloadidentityv1pb.WorkloadIdentity, error) {
-	allWorkloadIdentities, err := s.getAllWorkloadIdentities(ctx)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
+) iter.Seq2[*workloadidentityv1pb.WorkloadIdentity, error] {
+	return func(yield func(*workloadidentityv1pb.WorkloadIdentity, error) bool) {
+		for wid, err := range s.cache.RangeWorkloadIdentities(ctx, "", "", "", false) {
+			if err != nil {
+				yield(nil, trace.Wrap(err))
+				return
+			}
 
-	canAccess := []*workloadidentityv1pb.WorkloadIdentity{}
-	// Filter out identities user cannot access.
-	for _, wid := range allWorkloadIdentities {
-		if err := authCtx.Checker.CheckAccess(
-			types.Resource153ToResourceWithLabels(wid),
-			services.AccessState{},
-		); err == nil {
-			canAccess = append(canAccess, wid)
+			// Filter out WI the principal cannot access.
+			if err := authCtx.Checker.CheckAccess(
+				types.Resource153ToResourceWithLabels(wid),
+				services.AccessState{},
+			); err != nil {
+				continue
+			}
+
+			// Filter out WI that do not match the label selector.
+			match, _, err := services.MatchLabelGetter(
+				labels, types.Resource153ToResourceWithLabels(wid),
+			)
+			if err != nil {
+				// Maybe log and skip rather than returning an error?
+				yield(nil, trace.Wrap(err))
+				return
+			}
+			if !match {
+				continue
+			}
+
+			if !yield(wid, nil) {
+				return
+			}
 		}
 	}
-
-	canAccessAndInSearch := []*workloadidentityv1pb.WorkloadIdentity{}
-	for _, wid := range canAccess {
-		match, _, err := services.MatchLabelGetter(
-			labels, types.Resource153ToResourceWithLabels(wid),
-		)
-		if err != nil {
-			// Maybe log and skip rather than returning an error?
-			return nil, trace.Wrap(err)
-		}
-		if match {
-			canAccessAndInSearch = append(canAccessAndInSearch, wid)
-		}
-	}
-
-	return canAccessAndInSearch, nil
 }
 
 func convertLabels(selectors []*workloadidentityv1pb.LabelSelector) types.Labels {

--- a/lib/auth/machineid/workloadidentityv1/issuer_service.go
+++ b/lib/auth/machineid/workloadidentityv1/issuer_service.go
@@ -329,9 +329,9 @@ func (s *IssuanceService) IssueWorkloadIdentities(
 		authCtx,
 		convertLabels(req.GetLabelSelectors()),
 	) {
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
 
 		decision := decide(ctx, wi, attrs, s.getSigstorePolicyEvaluator())
 		if decision.shouldIssue {

--- a/lib/auth/machineid/workloadidentityv1/resource_service.go
+++ b/lib/auth/machineid/workloadidentityv1/resource_service.go
@@ -18,7 +18,10 @@ package workloadidentityv1
 
 import (
 	"context"
+	"iter"
 	"log/slog"
+	"slices"
+	"strings"
 
 	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
@@ -31,12 +34,14 @@ import (
 	apievents "github.com/gravitational/teleport/api/types/events"
 	"github.com/gravitational/teleport/lib/authz"
 	"github.com/gravitational/teleport/lib/events"
+	"github.com/gravitational/teleport/lib/itertools/stream"
 	"github.com/gravitational/teleport/lib/services"
+	"github.com/gravitational/teleport/lib/services/local/generic"
 )
 
 type workloadIdentityReader interface {
 	GetWorkloadIdentity(ctx context.Context, name string) (*workloadidentityv1pb.WorkloadIdentity, error)
-	ListWorkloadIdentities(ctx context.Context, pageSize int, token string, options *services.ListWorkloadIdentitiesRequestOptions) ([]*workloadidentityv1pb.WorkloadIdentity, string, error)
+	RangeWorkloadIdentities(ctx context.Context, start, end string, sortField services.WorkloadIdentitySortField, sortDesc bool) iter.Seq2[*workloadidentityv1pb.WorkloadIdentity, error]
 }
 
 type workloadIdentityReadWriter interface {
@@ -152,16 +157,30 @@ func (s *ResourceService) ListWorkloadIdentitiesV2(
 		return nil, trace.Wrap(err)
 	}
 
-	resources, nextToken, err := s.cache.ListWorkloadIdentities(
-		ctx,
-		int(req.PageSize),
-		req.PageToken,
-		&services.ListWorkloadIdentitiesRequestOptions{
-			SortField:        req.GetSortField(),
-			SortDesc:         req.GetSortDesc(),
-			FilterSearchTerm: req.GetFilterSearchTerm(),
-		},
-	)
+	sortField := services.WorkloadIdentitySortField(req.GetSortField())
+	keyFn, err := services.WorkloadIdentityKey(sortField)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	// Iterate the cache in sorted order, applying any filtering here at the gRPC
+	// layer rather than pushing it down, then collect a single page.
+	items := s.cache.RangeWorkloadIdentities(ctx, req.GetPageToken(), "", sortField, req.GetSortDesc())
+	if searchTerm := req.GetFilterSearchTerm(); searchTerm != "" {
+		items = stream.FilterMap(items, func(wi *workloadidentityv1pb.WorkloadIdentity) (*workloadidentityv1pb.WorkloadIdentity, bool) {
+			values := []string{
+				wi.GetMetadata().GetName(),
+				wi.GetSpec().GetSpiffe().GetId(),
+				wi.GetSpec().GetSpiffe().GetHint(),
+			}
+
+			return wi, slices.ContainsFunc(values, func(val string) bool {
+				return strings.Contains(strings.ToLower(val), strings.ToLower(searchTerm))
+			})
+		})
+	}
+
+	resources, nextToken, err := generic.CollectPageAndCursor(items, int(req.GetPageSize()), keyFn)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/auth/machineid/workloadidentityv1/workloadidentityv1_test.go
+++ b/lib/auth/machineid/workloadidentityv1/workloadidentityv1_test.go
@@ -2117,7 +2117,7 @@ func TestResourceService_GetWorkloadIdentity(t *testing.T) {
 func TestResourceService_ListWorkloadIdentities(t *testing.T) {
 	t.Parallel()
 	srv, _ := newTestTLSServer(t)
-	ctx := context.Background()
+	ctx := t.Context()
 
 	authorizedUser, _, err := authtest.CreateUserAndRole(
 		srv.Auth(),
@@ -2143,23 +2143,25 @@ func TestResourceService_ListWorkloadIdentities(t *testing.T) {
 	require.NoError(t, err)
 
 	// Create a pre-existing workload identities
-	// Two complete pages of ten, plus one incomplete page of nine
+	// Two complete pages of ten, plus one incomplete page of nine.
+	// SPIFFE IDs alternate between /test/0/ and /test/1/ so the search-filter
+	// subtest can match on a field other than name.
 	created := []*workloadidentityv1pb.WorkloadIdentity{}
 	for i := 0; i < 29; i++ {
 		r, err := srv.Auth().CreateWorkloadIdentity(
 			ctx,
-			&workloadidentityv1pb.WorkloadIdentity{
+			workloadidentityv1pb.WorkloadIdentity_builder{
 				Kind:    types.KindWorkloadIdentity,
 				Version: types.V1,
-				Metadata: &headerv1.Metadata{
+				Metadata: headerv1.Metadata_builder{
 					Name: fmt.Sprintf("preexisting-%d", i),
-				},
-				Spec: &workloadidentityv1pb.WorkloadIdentitySpec{
-					Spiffe: &workloadidentityv1pb.WorkloadIdentitySPIFFE{
-						Id: "/example",
-					},
-				},
-			})
+				}.Build(),
+				Spec: workloadidentityv1pb.WorkloadIdentitySpec_builder{
+					Spiffe: workloadidentityv1pb.WorkloadIdentitySPIFFE_builder{
+						Id: fmt.Sprintf("/test/%d/id%d", i%2, i),
+					}.Build(),
+				}.Build(),
+			}.Build())
 		require.NoError(t, err)
 		created = append(created, r)
 	}
@@ -2218,6 +2220,32 @@ func TestResourceService_ListWorkloadIdentities(t *testing.T) {
 			require.True(t, slices.ContainsFunc(fetched, func(resource *workloadidentityv1pb.WorkloadIdentity) bool {
 				return proto.Equal(created, resource)
 			}))
+		}
+	})
+
+	t.Run("success - search filter", func(t *testing.T) {
+		client := workloadidentityv1pb.NewWorkloadIdentityResourceServiceClient(
+			authorizedClient.GetConnection(),
+		)
+
+		// The filter is applied at the gRPC layer over the ranged results. The
+		// "test/1" term matches on SPIFFE ID, selecting the odd-indexed
+		// preexisting identities (/test/1/...).
+		var want []*workloadidentityv1pb.WorkloadIdentity
+		for _, wi := range created {
+			if strings.Contains(wi.GetSpec().GetSpiffe().GetId(), "/test/1/") {
+				want = append(want, wi)
+			}
+		}
+		require.NotEmpty(t, want)
+
+		res, err := client.ListWorkloadIdentitiesV2(ctx, &workloadidentityv1pb.ListWorkloadIdentitiesV2Request{
+			FilterSearchTerm: "test/1",
+		})
+		require.NoError(t, err)
+		require.Len(t, res.WorkloadIdentities, len(want))
+		for _, wi := range res.WorkloadIdentities {
+			require.Contains(t, wi.GetSpec().GetSpiffe().GetId(), "/test/1/")
 		}
 	})
 }

--- a/lib/cache/workload_identity.go
+++ b/lib/cache/workload_identity.go
@@ -19,18 +19,17 @@ package cache
 
 import (
 	"context"
-	"encoding/base32"
+	"iter"
 
 	"github.com/gravitational/trace"
-	"golang.org/x/text/cases"
 	"google.golang.org/protobuf/proto"
 
 	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
 	workloadidentityv1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/workloadidentity/v1"
 	"github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/teleport/api/utils/clientutils"
 	"github.com/gravitational/teleport/lib/itertools/stream"
 	"github.com/gravitational/teleport/lib/services"
+	"github.com/gravitational/teleport/lib/services/local/generic"
 )
 
 type workloadIdentityIndex string
@@ -45,19 +44,25 @@ func newWorkloadIdentityCollection(upstream services.WorkloadIdentities, w types
 		return nil, trace.BadParameter("missing parameter WorkloadIdentities")
 	}
 
+	nameKey, err := services.WorkloadIdentityKey(services.WorkloadIdentitySortFieldName)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	spiffeIDKey, err := services.WorkloadIdentityKey(services.WorkloadIdentitySortFieldSPIFFEID)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
 	return &collection[*workloadidentityv1pb.WorkloadIdentity, workloadIdentityIndex]{
 		store: newStore(
 			types.KindWorkloadIdentity,
 			proto.CloneOf[*workloadidentityv1pb.WorkloadIdentity],
 			map[workloadIdentityIndex]func(*workloadidentityv1pb.WorkloadIdentity) string{
-				workloadIdentityNameIndex:     keyForWorkloadIdentityNameIndex,
-				workloadIdentitySpiffeIDIndex: keyForWorkloadIdentitySpiffeIDIndex,
+				workloadIdentityNameIndex:     nameKey,
+				workloadIdentitySpiffeIDIndex: spiffeIDKey,
 			}),
 		fetcher: func(ctx context.Context, loadSecrets bool) ([]*workloadidentityv1pb.WorkloadIdentity, error) {
-			out, err := stream.Collect(clientutils.Resources(ctx,
-				func(ctx context.Context, pageSize int, currentToken string) ([]*workloadidentityv1pb.WorkloadIdentity, string, error) {
-					return upstream.ListWorkloadIdentities(ctx, pageSize, currentToken, nil)
-				}))
+			out, err := stream.Collect(upstream.RangeWorkloadIdentities(ctx, "", "", "", false))
 			return out, trace.Wrap(err)
 		},
 		headerTransform: func(hdr *types.ResourceHeader) *workloadidentityv1pb.WorkloadIdentity {
@@ -73,47 +78,53 @@ func newWorkloadIdentityCollection(upstream services.WorkloadIdentities, w types
 	}, nil
 }
 
-// ListWorkloadIdentities returns a paginated list of WorkloadIdentity resources.
-func (c *Cache) ListWorkloadIdentities(
+// RangeWorkloadIdentities returns WorkloadIdentity resources within the range
+// [start, end), ordered by the given sort field and direction. Supported sort
+// fields are "name" (the default) and "spiffe_id".
+func (c *Cache) RangeWorkloadIdentities(
 	ctx context.Context,
-	pageSize int,
-	nextToken string,
-	options *services.ListWorkloadIdentitiesRequestOptions,
-) ([]*workloadidentityv1pb.WorkloadIdentity, string, error) {
-	ctx, span := c.Tracer.Start(ctx, "cache/ListWorkloadIdentities")
-	defer span.End()
-
-	index := workloadIdentityNameIndex
-	keyFn := keyForWorkloadIdentityNameIndex
-	isDesc := options.GetSortDesc()
-	switch options.GetSortField() {
-	case "name":
-		index = workloadIdentityNameIndex
-		keyFn = keyForWorkloadIdentityNameIndex
-	case "spiffe_id":
-		index = workloadIdentitySpiffeIDIndex
-		keyFn = keyForWorkloadIdentitySpiffeIDIndex
-	case "":
-		// default ordering as defined above
-	default:
-		return nil, "", trace.BadParameter("unsupported sort %q but expected name or spiffe_id", options.GetSortField())
+	start, end string,
+	sortField services.WorkloadIdentitySortField,
+	sortDesc bool,
+) iter.Seq2[*workloadidentityv1pb.WorkloadIdentity, error] {
+	index, keyFn, err := workloadIdentitySortIndex(sortField)
+	if err != nil {
+		return stream.Fail[*workloadidentityv1pb.WorkloadIdentity](trace.Wrap(err))
 	}
 
 	lister := genericLister[*workloadidentityv1pb.WorkloadIdentity, workloadIdentityIndex]{
 		cache:      c,
 		collection: c.collections.workloadIdentity,
 		index:      index,
-		isDesc:     isDesc,
+		isDesc:     sortDesc,
 		upstreamList: func(ctx context.Context, pageSize int, nextToken string) ([]*workloadidentityv1pb.WorkloadIdentity, string, error) {
-			return c.Config.WorkloadIdentity.ListWorkloadIdentities(ctx, pageSize, nextToken, options)
-		},
-		filter: func(b *workloadidentityv1pb.WorkloadIdentity) bool {
-			return services.MatchWorkloadIdentity(b, options.GetFilterSearchTerm())
+			// When the cache is unhealthy, fall back to collecting a page from
+			// the upstream backend's range. The backend only supports
+			// name-ordered ascending iteration, so a spiffe_id or descending
+			// range surfaces an error here.
+			return generic.CollectPageAndCursor(
+				c.Config.WorkloadIdentity.RangeWorkloadIdentities(ctx, nextToken, "", sortField, sortDesc),
+				pageSize,
+				keyFn,
+			)
 		},
 		nextToken: keyFn,
 	}
-	out, next, err := lister.list(ctx, pageSize, nextToken)
-	return out, next, trace.Wrap(err)
+
+	return func(yield func(*workloadidentityv1pb.WorkloadIdentity, error) bool) {
+		ctx, span := c.Tracer.Start(ctx, "cache/RangeWorkloadIdentities")
+		defer span.End()
+
+		for wi, err := range lister.Range(ctx, start, end) {
+			if !yield(wi, err) {
+				return
+			}
+
+			if err != nil {
+				return
+			}
+		}
+	}
 }
 
 // GetWorkloadIdentity returns a single WorkloadIdentity by name
@@ -131,17 +142,21 @@ func (c *Cache) GetWorkloadIdentity(ctx context.Context, name string) (*workload
 	return out, trace.Wrap(err)
 }
 
-func keyForWorkloadIdentityNameIndex(r *workloadidentityv1pb.WorkloadIdentity) string {
-	return r.GetMetadata().GetName()
-}
-
-func keyForWorkloadIdentitySpiffeIDIndex(r *workloadidentityv1pb.WorkloadIdentity) string {
-	name := keyForWorkloadIdentityNameIndex(r)
-	// Sort case-insensitively to keep /spiffe-1 and /Spiffe-1 together
-	spiffeID := cases.Fold().String(r.GetSpec().GetSpiffe().GetId())
-	// Encode the id avoid; "a/b" + "/" + "c" vs. "a" + "/" + "b/c". Base32 hex
-	// maintains original ordering.
-	spiffeID = base32.HexEncoding.WithPadding(base32.NoPadding).EncodeToString([]byte(spiffeID))
-	// SPIFFE IDs may not be unique, so append the resource name
-	return spiffeID + "/" + name
+// workloadIdentitySortIndex maps a sort field to its store index and key
+// function.
+func workloadIdentitySortIndex(sortField services.WorkloadIdentitySortField) (workloadIdentityIndex, func(*workloadidentityv1pb.WorkloadIdentity) string, error) {
+	keyFn, err := services.WorkloadIdentityKey(sortField)
+	if err != nil {
+		return "", nil, trace.Wrap(err)
+	}
+	switch sortField {
+	case "", services.WorkloadIdentitySortFieldName:
+		return workloadIdentityNameIndex, keyFn, nil
+	case services.WorkloadIdentitySortFieldSPIFFEID:
+		return workloadIdentitySpiffeIDIndex, keyFn, nil
+	default:
+		// This branch is technically unreachable as WorkloadIdentityKey has
+		// already checked.
+		return "", nil, trace.BadParameter("unsupported sort %q", sortField)
+	}
 }

--- a/lib/cache/workload_identity_test.go
+++ b/lib/cache/workload_identity_test.go
@@ -18,7 +18,10 @@ package cache
 
 import (
 	"context"
-	"strconv"
+	"fmt"
+	"iter"
+	"slices"
+	"strings"
 	"testing"
 	"time"
 
@@ -29,8 +32,32 @@ import (
 	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
 	workloadidentityv1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/workloadidentity/v1"
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/itertools/stream"
 	"github.com/gravitational/teleport/lib/services"
+	"github.com/gravitational/teleport/lib/services/local/generic"
 )
+
+// collectWorkloadIdentities drains a WorkloadIdentity range into a slice,
+// failing the test on error.
+func collectWorkloadIdentities(t require.TestingT, it iter.Seq2[*workloadidentityv1pb.WorkloadIdentity, error]) []*workloadidentityv1pb.WorkloadIdentity {
+	out, err := stream.Collect(it)
+	require.NoError(t, err)
+	return out
+}
+
+// workloadIdentityPageFunc adapts RangeWorkloadIdentities to the paginated list
+// signature expected by the generic cache test harness.
+func workloadIdentityPageFunc(
+	rangeFn func(ctx context.Context, start, end string, sortField services.WorkloadIdentitySortField, sortDesc bool) iter.Seq2[*workloadidentityv1pb.WorkloadIdentity, error],
+) func(ctx context.Context, pageSize int, pageToken string) ([]*workloadidentityv1pb.WorkloadIdentity, string, error) {
+	return func(ctx context.Context, pageSize int, pageToken string) ([]*workloadidentityv1pb.WorkloadIdentity, string, error) {
+		return generic.CollectPageAndCursor(
+			rangeFn(ctx, pageToken, "", "", false),
+			pageSize,
+			func(wi *workloadidentityv1pb.WorkloadIdentity) string { return wi.GetMetadata().GetName() },
+		)
+	}
+}
 
 func newWorkloadIdentity(name string) *workloadidentityv1pb.WorkloadIdentity {
 	return &workloadidentityv1pb.WorkloadIdentity{
@@ -47,6 +74,34 @@ func newWorkloadIdentity(name string) *workloadidentityv1pb.WorkloadIdentity {
 	}
 }
 
+// createWorkloadIdentities creates the given identities (keyed by name, valued
+// by SPIFFE ID) in the backend and blocks until the cache has observed all of
+// them. Names must be unique.
+func createWorkloadIdentities(t *testing.T, ctx context.Context, p *testPack, ids map[string]string) {
+	t.Helper()
+	for name, spiffeID := range ids {
+		wid := workloadidentityv1pb.WorkloadIdentity_builder{
+			Kind:    types.KindWorkloadIdentity,
+			Version: types.V1,
+			Metadata: headerv1.Metadata_builder{
+				Name: name,
+			}.Build(),
+			Spec: workloadidentityv1pb.WorkloadIdentitySpec_builder{
+				Spiffe: workloadidentityv1pb.WorkloadIdentitySPIFFE_builder{
+					Id: spiffeID,
+				}.Build(),
+			}.Build(),
+		}.Build()
+		_, err := p.workloadIdentity.CreateWorkloadIdentity(ctx, wid)
+		require.NoError(t, err, "failed to create WorkloadIdentity %q", name)
+	}
+
+	require.EventuallyWithT(t, func(t *assert.CollectT) {
+		results := collectWorkloadIdentities(t, p.cache.RangeWorkloadIdentities(ctx, "", "", "", false))
+		require.Len(t, results, len(ids))
+	}, 10*time.Second, 100*time.Millisecond)
+}
+
 func TestWorkloadIdentity(t *testing.T) {
 	t.Parallel()
 
@@ -61,21 +116,18 @@ func TestWorkloadIdentity(t *testing.T) {
 			_, err := p.workloadIdentity.CreateWorkloadIdentity(ctx, item)
 			return trace.Wrap(err)
 		},
-		list: func(ctx context.Context, pageSize int, pageToken string) ([]*workloadidentityv1pb.WorkloadIdentity, string, error) {
-			return p.workloadIdentity.ListWorkloadIdentities(ctx, pageSize, pageToken, nil)
-		},
+		list: workloadIdentityPageFunc(p.workloadIdentity.RangeWorkloadIdentities),
 		deleteAll: func(ctx context.Context) error {
 			return p.workloadIdentity.DeleteAllWorkloadIdentities(ctx)
 		},
-		cacheList: func(ctx context.Context, pageSize int, pageToken string) ([]*workloadidentityv1pb.WorkloadIdentity, string, error) {
-			return p.cache.ListWorkloadIdentities(ctx, pageSize, pageToken, nil)
-		},
-		cacheGet: p.cache.GetWorkloadIdentity,
+		cacheList: workloadIdentityPageFunc(p.cache.RangeWorkloadIdentities),
+		cacheGet:  p.cache.GetWorkloadIdentity,
 	})
 }
 
-// TestWorkloadIdentityCacheSorting tests that cache items are sorted.
-func TestWorkloadIdentityCacheSorting(t *testing.T) {
+// TestWorkloadIdentityCacheRange tests that RangeWorkloadIdentities iterates in
+// the requested order and honors range bounds.
+func TestWorkloadIdentityCacheRange(t *testing.T) {
 	t.Parallel()
 
 	ctx := t.Context()
@@ -83,99 +135,188 @@ func TestWorkloadIdentityCacheSorting(t *testing.T) {
 	p := newTestPack(t, ForAuth)
 	t.Cleanup(p.Close)
 
-	rs := []struct {
-		name     string
-		spiffeID string
-	}{
-		{"test-workload-identity-1", "/test/spiffe/2"},
-		{"test-workload-identity-3", "/test/spiffe/1"},
-		{"test-workload-identity-2", "/test/spiffe/3"},
-		{"Test-workload-identity-4", "/Test/spiffe/2"},
-		{"Test-workload-identity-5", "/Test/spiffe/1"},
-		{"Test-workload-identity-6", "/Test/spiffe/3"},
+	createWorkloadIdentities(t, ctx, p, map[string]string{
+		"test-workload-identity-1": "/test/spiffe/2",
+		"test-workload-identity-3": "/test/spiffe/1",
+		"test-workload-identity-2": "/test/spiffe/3",
+		"Test-workload-identity-4": "/Test/spiffe/2",
+		"Test-workload-identity-5": "/Test/spiffe/1",
+		"Test-workload-identity-6": "/Test/spiffe/3",
+	})
+
+	collectRange := func(t *testing.T, start, end string, sortField services.WorkloadIdentitySortField, sortDesc bool) []*workloadidentityv1pb.WorkloadIdentity {
+		return collectWorkloadIdentities(t, p.cache.RangeWorkloadIdentities(ctx, start, end, sortField, sortDesc))
 	}
 
-	for _, r := range rs {
-		id := &workloadidentityv1pb.WorkloadIdentity{
-			Kind:    types.KindWorkloadIdentity,
-			Version: types.V1,
-			Metadata: &headerv1.Metadata{
-				Name: r.name,
-			},
-			Spec: &workloadidentityv1pb.WorkloadIdentitySpec{
-				Spiffe: &workloadidentityv1pb.WorkloadIdentitySPIFFE{
-					Id: r.spiffeID,
-				},
-			},
+	names := func(in []*workloadidentityv1pb.WorkloadIdentity) []string {
+		out := make([]string, len(in))
+		for i, wi := range in {
+			out[i] = wi.GetMetadata().GetName()
 		}
-
-		_, err := p.workloadIdentity.CreateWorkloadIdentity(ctx, id)
-		require.NoError(t, err, "failed to create WorkloadIdentity %q", r.name)
+		return out
+	}
+	spiffeIDs := func(in []*workloadidentityv1pb.WorkloadIdentity) []string {
+		out := make([]string, len(in))
+		for i, wi := range in {
+			out[i] = wi.GetSpec().GetSpiffe().GetId()
+		}
+		return out
 	}
 
-	// Let the cache catch up
-	require.EventuallyWithT(t, func(t *assert.CollectT) {
-		results, _, err := p.cache.ListWorkloadIdentities(ctx, 0, "", nil)
-		require.NoError(t, err)
-		require.Len(t, results, 6)
-	}, 10*time.Second, 100*time.Millisecond)
+	t.Run("full range ascending by name", func(t *testing.T) {
+		got := collectRange(t, "", "", "name", false)
+		require.Equal(t, []string{
+			"Test-workload-identity-4",
+			"Test-workload-identity-5",
+			"Test-workload-identity-6",
+			"test-workload-identity-1",
+			"test-workload-identity-2",
+			"test-workload-identity-3",
+		}, names(got))
+	})
 
-	t.Run("sort ascending by spiffe_id", func(t *testing.T) {
-		results, _, err := p.cache.ListWorkloadIdentities(ctx, 0, "", &services.ListWorkloadIdentitiesRequestOptions{
-			SortField: "spiffe_id",
-			SortDesc:  false,
+	t.Run("full range descending by name", func(t *testing.T) {
+		got := collectRange(t, "", "", "name", true)
+		require.Equal(t, []string{
+			"test-workload-identity-3",
+			"test-workload-identity-2",
+			"test-workload-identity-1",
+			"Test-workload-identity-6",
+			"Test-workload-identity-5",
+			"Test-workload-identity-4",
+		}, names(got))
+	})
+
+	t.Run("empty sort field defaults to ascending by name", func(t *testing.T) {
+		got := collectRange(t, "", "", "", false)
+		require.Equal(t, []string{
+			"Test-workload-identity-4",
+			"Test-workload-identity-5",
+			"Test-workload-identity-6",
+			"test-workload-identity-1",
+			"test-workload-identity-2",
+			"test-workload-identity-3",
+		}, names(got))
+	})
+
+	t.Run("full range ascending by spiffe_id", func(t *testing.T) {
+		got := collectRange(t, "", "", "spiffe_id", false)
+		require.Equal(t, []string{
+			"/Test/spiffe/1",
+			"/test/spiffe/1",
+			"/Test/spiffe/2",
+			"/test/spiffe/2",
+			"/Test/spiffe/3",
+			"/test/spiffe/3",
+		}, spiffeIDs(got))
+	})
+
+	t.Run("full range descending by spiffe_id", func(t *testing.T) {
+		got := collectRange(t, "", "", "spiffe_id", true)
+		require.Equal(t, []string{
+			"/test/spiffe/3",
+			"/Test/spiffe/3",
+			"/test/spiffe/2",
+			"/Test/spiffe/2",
+			"/test/spiffe/1",
+			"/Test/spiffe/1",
+		}, spiffeIDs(got))
+	})
+
+	t.Run("bounded name range is exclusive of end", func(t *testing.T) {
+		got := collectRange(t, "Test-workload-identity-5", "test-workload-identity-2", "name", false)
+		require.Equal(t, []string{
+			"Test-workload-identity-5",
+			"Test-workload-identity-6",
+			"test-workload-identity-1",
+		}, names(got))
+	})
+
+	t.Run("unsupported sort field yields an error", func(t *testing.T) {
+		var err error
+		for _, iterErr := range p.cache.RangeWorkloadIdentities(ctx, "", "", "blah", false) {
+			err = iterErr
+		}
+		require.ErrorContains(t, err, `unsupported sort "blah" but expected name or spiffe_id`)
+	})
+}
+
+// TestWorkloadIdentityCacheRangePagination exercises multi-page pagination
+// round-trips across every sort field and direction, mirroring how the gRPC
+// handler threads the page cursor when ranging over the cache
+// (CollectPageAndCursor over RangeWorkloadIdentities).
+func TestWorkloadIdentityCacheRangePagination(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+
+	p := newTestPack(t, ForAuth)
+	t.Cleanup(p.Close)
+
+	// Create identities whose spiffe_id ordering deliberately differs from their
+	// name ordering (a permutation), so spiffe_id sorting is genuinely tested.
+	const n = 12
+	ids := make(map[string]string, n)
+	for i := range n {
+		ids[fmt.Sprintf("wi-%02d", i)] = fmt.Sprintf("/id-%02d", (i*7)%n)
+	}
+	createWorkloadIdentities(t, ctx, p, ids)
+
+	paginate := func(t *testing.T, sortField services.WorkloadIdentitySortField, sortDesc bool) []*workloadidentityv1pb.WorkloadIdentity {
+		var fetched []*workloadidentityv1pb.WorkloadIdentity
+		token := ""
+		keyFn, err := services.WorkloadIdentityKey(sortField)
+		require.NoError(t, err)
+		for {
+			page, next, err := generic.CollectPageAndCursor(
+				p.cache.RangeWorkloadIdentities(ctx, token, "", sortField, sortDesc),
+				5,
+				keyFn,
+			)
+			require.NoError(t, err)
+			fetched = append(fetched, page...)
+			if next == "" {
+				break
+			}
+			token = next
+		}
+		return fetched
+	}
+
+	for _, tc := range []struct {
+		name      string
+		sortField services.WorkloadIdentitySortField
+		sortDesc  bool
+	}{
+		{"name asc", services.WorkloadIdentitySortFieldName, false},
+		{"name desc", services.WorkloadIdentitySortFieldName, true},
+		{"spiffe_id asc", services.WorkloadIdentitySortFieldSPIFFEID, false},
+		{"spiffe_id desc", services.WorkloadIdentitySortFieldSPIFFEID, true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := paginate(t, tc.sortField, tc.sortDesc)
+
+			// Every identity is returned exactly once across page boundaries.
+			seen := map[string]int{}
+			for _, wi := range got {
+				seen[wi.GetMetadata().GetName()]++
+			}
+			require.Len(t, seen, n)
+			for name, count := range seen {
+				require.Equalf(t, 1, count, "identity %q returned %d times", name, count)
+			}
+
+			// The global ordering across pages matches the canonical sort key.
+			keyFn, err := services.WorkloadIdentityKey(tc.sortField)
+			require.NoError(t, err)
+			require.True(t, slices.IsSortedFunc(got, func(a, b *workloadidentityv1pb.WorkloadIdentity) int {
+				if tc.sortDesc {
+					return strings.Compare(keyFn(b), keyFn(a))
+				}
+				return strings.Compare(keyFn(a), keyFn(b))
+			}))
 		})
-		require.NoError(t, err)
-		require.Len(t, results, 6)
-		assert.Equal(t, "/Test/spiffe/1", results[0].GetSpec().GetSpiffe().GetId())
-		assert.Equal(t, "/test/spiffe/1", results[1].GetSpec().GetSpiffe().GetId())
-		assert.Equal(t, "/Test/spiffe/2", results[2].GetSpec().GetSpiffe().GetId())
-		assert.Equal(t, "/test/spiffe/2", results[3].GetSpec().GetSpiffe().GetId())
-		assert.Equal(t, "/Test/spiffe/3", results[4].GetSpec().GetSpiffe().GetId())
-		assert.Equal(t, "/test/spiffe/3", results[5].GetSpec().GetSpiffe().GetId())
-	})
-
-	t.Run("sort descending by spiffe_id", func(t *testing.T) {
-		results, _, err := p.cache.ListWorkloadIdentities(ctx, 0, "", &services.ListWorkloadIdentitiesRequestOptions{
-			SortField: "spiffe_id",
-			SortDesc:  true,
-		})
-		require.NoError(t, err)
-		require.Len(t, results, 6)
-		assert.Equal(t, "/test/spiffe/3", results[0].GetSpec().GetSpiffe().GetId())
-		assert.Equal(t, "/Test/spiffe/3", results[1].GetSpec().GetSpiffe().GetId())
-		assert.Equal(t, "/test/spiffe/2", results[2].GetSpec().GetSpiffe().GetId())
-		assert.Equal(t, "/Test/spiffe/2", results[3].GetSpec().GetSpiffe().GetId())
-		assert.Equal(t, "/test/spiffe/1", results[4].GetSpec().GetSpiffe().GetId())
-		assert.Equal(t, "/Test/spiffe/1", results[5].GetSpec().GetSpiffe().GetId())
-	})
-
-	t.Run("sort ascending by name", func(t *testing.T) {
-		results, _, err := p.cache.ListWorkloadIdentities(ctx, 0, "", nil) // empty sort should default to `name:asc`
-		require.NoError(t, err)
-		require.Len(t, results, 6)
-		assert.Equal(t, "Test-workload-identity-4", results[0].GetMetadata().GetName())
-		assert.Equal(t, "Test-workload-identity-5", results[1].GetMetadata().GetName())
-		assert.Equal(t, "Test-workload-identity-6", results[2].GetMetadata().GetName())
-		assert.Equal(t, "test-workload-identity-1", results[3].GetMetadata().GetName())
-		assert.Equal(t, "test-workload-identity-2", results[4].GetMetadata().GetName())
-		assert.Equal(t, "test-workload-identity-3", results[5].GetMetadata().GetName())
-	})
-
-	t.Run("sort descending by name", func(t *testing.T) {
-		results, _, err := p.cache.ListWorkloadIdentities(ctx, 0, "", &services.ListWorkloadIdentitiesRequestOptions{
-			SortField: "name",
-			SortDesc:  true,
-		})
-		require.NoError(t, err)
-		require.Len(t, results, 6)
-		assert.Equal(t, "test-workload-identity-3", results[0].GetMetadata().GetName())
-		assert.Equal(t, "test-workload-identity-2", results[1].GetMetadata().GetName())
-		assert.Equal(t, "test-workload-identity-1", results[2].GetMetadata().GetName())
-		assert.Equal(t, "Test-workload-identity-6", results[3].GetMetadata().GetName())
-		assert.Equal(t, "Test-workload-identity-5", results[4].GetMetadata().GetName())
-		assert.Equal(t, "Test-workload-identity-4", results[5].GetMetadata().GetName())
-	})
+	}
 }
 
 // TestWorkloadIdentityCacheFallback tests that requests fallback to the upstream when the cache is unhealthy.
@@ -190,89 +331,32 @@ func TestWorkloadIdentityCacheFallback(t *testing.T) {
 	})
 	t.Cleanup(p.Close)
 
-	_, err := p.workloadIdentity.CreateWorkloadIdentity(ctx, &workloadidentityv1pb.WorkloadIdentity{
-		Kind:    types.KindWorkloadIdentity,
-		Version: types.V1,
-		Metadata: &headerv1.Metadata{
-			Name: "test-workload-identity-1",
-		},
-		Spec: &workloadidentityv1pb.WorkloadIdentitySpec{
-			Spiffe: &workloadidentityv1pb.WorkloadIdentitySPIFFE{
-				Id: "/test/spiffe/1",
-			},
-		},
+	createWorkloadIdentities(t, ctx, p, map[string]string{
+		"test-workload-identity-1": "/test/spiffe/1",
 	})
-	require.NoError(t, err)
 
-	// Let the cache catch up
-	require.EventuallyWithT(t, func(t *assert.CollectT) {
-		results, _, err := p.cache.ListWorkloadIdentities(ctx, 0, "", nil)
-		require.NoError(t, err)
-		require.Len(t, results, 1)
-	}, 10*time.Second, 100*time.Millisecond)
-
+	// The upstream backend only supports name-ascending iteration, so a range
+	// served from the unhealthy cache is constrained to that ordering.
 	t.Run("supported sort", func(t *testing.T) {
-		results, _, err := p.cache.ListWorkloadIdentities(ctx, 0, "", &services.ListWorkloadIdentitiesRequestOptions{
-			SortField: "name",
-			SortDesc:  false,
-		})
-		require.NoError(t, err) // asc by name is the only sort supported by the upstream
-		require.Len(t, results, 1)
+		got := collectWorkloadIdentities(t, p.cache.RangeWorkloadIdentities(ctx, "", "", "name", false))
+		require.Len(t, got, 1)
 	})
 
 	t.Run("unsupported sort field", func(t *testing.T) {
-		_, _, err = p.cache.ListWorkloadIdentities(ctx, 0, "", &services.ListWorkloadIdentitiesRequestOptions{
-			SortField: "spiffe_id",
-		})
+		var err error
+		for _, iterErr := range p.cache.RangeWorkloadIdentities(ctx, "", "", "spiffe_id", false) {
+			err = iterErr
+		}
 		require.ErrorContains(t, err, `unsupported sort, only name field is supported, but got "spiffe_id"`)
 	})
 
 	t.Run("unsupported sort dir", func(t *testing.T) {
-		_, _, err = p.cache.ListWorkloadIdentities(ctx, 0, "", &services.ListWorkloadIdentitiesRequestOptions{
-			SortDesc: true,
-		})
+		var err error
+		for _, iterErr := range p.cache.RangeWorkloadIdentities(ctx, "", "", "name", true) {
+			err = iterErr
+		}
 		require.ErrorContains(t, err, "unsupported sort, only ascending order is supported")
 	})
-}
-
-// TestWorkloadIdentityCacheSearchFilter tests that cache items are filtered by search query.
-func TestWorkloadIdentityCacheSearchFilter(t *testing.T) {
-	t.Parallel()
-
-	ctx := t.Context()
-
-	p := newTestPack(t, ForAuth)
-	t.Cleanup(p.Close)
-
-	for n := range 10 {
-		name := "test-workload-identity-" + strconv.Itoa(n)
-		_, err := p.workloadIdentity.CreateWorkloadIdentity(ctx, &workloadidentityv1pb.WorkloadIdentity{
-			Kind:    types.KindWorkloadIdentity,
-			Version: types.V1,
-			Metadata: &headerv1.Metadata{
-				Name: name,
-			},
-			Spec: &workloadidentityv1pb.WorkloadIdentitySpec{
-				Spiffe: &workloadidentityv1pb.WorkloadIdentitySPIFFE{
-					Id: "/test/" + strconv.Itoa(n%2) + "/id" + strconv.Itoa(n),
-				},
-			},
-		})
-		require.NoError(t, err, "failed to create WorkloadIdentity %q", name)
-	}
-
-	// Let the cache catch up
-	require.EventuallyWithT(t, func(t *assert.CollectT) {
-		results, _, err := p.cache.ListWorkloadIdentities(ctx, 0, "", nil)
-		require.NoError(t, err)
-		require.Len(t, results, 10)
-	}, 10*time.Second, 100*time.Millisecond)
-
-	results, _, err := p.cache.ListWorkloadIdentities(ctx, 0, "", &services.ListWorkloadIdentitiesRequestOptions{
-		FilterSearchTerm: "test/1",
-	})
-	require.NoError(t, err)
-	require.Len(t, results, 5)
 }
 
 // TestWorkloadIdentityCaseSensitiveName tests that workload identity name index keys remain case sensitive.
@@ -281,53 +365,18 @@ func TestWorkloadIdentityCaseSensitiveName(t *testing.T) {
 
 	ctx := t.Context()
 
-	p := newTestPack(t, func(cfg Config) Config {
-		return ForAuth(cfg)
-	})
+	p := newTestPack(t, ForAuth)
 	t.Cleanup(p.Close)
 
-	{
-		_, err := p.workloadIdentity.CreateWorkloadIdentity(ctx, &workloadidentityv1pb.WorkloadIdentity{
-			Kind:    types.KindWorkloadIdentity,
-			Version: types.V1,
-			Metadata: &headerv1.Metadata{
-				Name: "TEST-WORKLOAD-IDENTITY-1",
-			},
-			Spec: &workloadidentityv1pb.WorkloadIdentitySpec{
-				Spiffe: &workloadidentityv1pb.WorkloadIdentitySPIFFE{
-					Id: "/test/spiffe/1",
-				},
-			},
-		})
-		require.NoError(t, err)
-	}
+	createWorkloadIdentities(t, ctx, p, map[string]string{
+		"TEST-WORKLOAD-IDENTITY-1": "/test/spiffe/1",
+		"test-workload-identity-1": "/test/spiffe/1",
+	})
 
-	{
-		_, err := p.workloadIdentity.CreateWorkloadIdentity(ctx, &workloadidentityv1pb.WorkloadIdentity{
-			Kind:    types.KindWorkloadIdentity,
-			Version: types.V1,
-			Metadata: &headerv1.Metadata{
-				Name: "test-workload-identity-1",
-			},
-			Spec: &workloadidentityv1pb.WorkloadIdentitySpec{
-				Spiffe: &workloadidentityv1pb.WorkloadIdentitySPIFFE{
-					Id: "/test/spiffe/1",
-				},
-			},
-		})
-		require.NoError(t, err)
-	}
-
-	// Let the cache catch up
-	require.EventuallyWithT(t, func(t *assert.CollectT) {
-		results, _, err := p.cache.ListWorkloadIdentities(ctx, 0, "", &services.ListWorkloadIdentitiesRequestOptions{
-			SortField: "name",
-			SortDesc:  true,
-		})
-		require.NoError(t, err)
-		require.Len(t, results, 2)
-
-		require.Equal(t, "test-workload-identity-1", results[0].Metadata.Name)
-		require.Equal(t, "TEST-WORKLOAD-IDENTITY-1", results[1].Metadata.Name)
-	}, 10*time.Second, 100*time.Millisecond)
+	// Name index keys are case sensitive: in descending order the lowercase
+	// name sorts before the uppercase one.
+	results := collectWorkloadIdentities(t, p.cache.RangeWorkloadIdentities(ctx, "", "", "name", true))
+	require.Len(t, results, 2)
+	require.Equal(t, "test-workload-identity-1", results[0].Metadata.Name)
+	require.Equal(t, "TEST-WORKLOAD-IDENTITY-1", results[1].Metadata.Name)
 }

--- a/lib/services/local/workload_identity.go
+++ b/lib/services/local/workload_identity.go
@@ -18,6 +18,7 @@ package local
 
 import (
 	"context"
+	"iter"
 	"strings"
 
 	"github.com/gravitational/trace"
@@ -26,6 +27,7 @@ import (
 	workloadidentityv1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/workloadidentity/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/backend"
+	"github.com/gravitational/teleport/lib/itertools/stream"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/services/local/generic"
 )
@@ -75,35 +77,23 @@ func (b *WorkloadIdentityService) GetWorkloadIdentity(
 	return resource, trace.Wrap(err)
 }
 
-// ListWorkloadIdentities lists all WorkloadIdentities using a given page size
-// and last key.
-func (b *WorkloadIdentityService) ListWorkloadIdentities(
-	ctx context.Context,
-	pageSize int,
-	currentToken string,
-	options *services.ListWorkloadIdentitiesRequestOptions,
-) ([]*workloadidentityv1pb.WorkloadIdentity, string, error) {
-	if options.GetSortField() != "" && options.GetSortField() != "name" {
-		return nil, "", trace.CompareFailed("unsupported sort, only name field is supported, but got %q", options.GetSortField())
+// RangeWorkloadIdentities returns WorkloadIdentity resources within the range
+// [start, end). The backend only supports ordering by name in ascending order;
+// any other sort field or a descending order returns an error.
+func (b *WorkloadIdentityService) RangeWorkloadIdentities(
+	ctx context.Context, start, end string, sortField services.WorkloadIdentitySortField, sortDesc bool,
+) iter.Seq2[*workloadidentityv1pb.WorkloadIdentity, error] {
+	if sortField != "" && sortField != services.WorkloadIdentitySortFieldName {
+		return stream.Fail[*workloadidentityv1pb.WorkloadIdentity](
+			trace.BadParameter("unsupported sort, only name field is supported, but got %q", sortField),
+		)
 	}
-	if options.GetSortDesc() {
-		return nil, "", trace.CompareFailed("unsupported sort, only ascending order is supported")
+	if sortDesc {
+		return stream.Fail[*workloadidentityv1pb.WorkloadIdentity](
+			trace.BadParameter("unsupported sort, only ascending order is supported"),
+		)
 	}
-
-	if options.GetFilterSearchTerm() == "" {
-		r, nextToken, err := b.service.ListResources(ctx, pageSize, currentToken)
-		return r, nextToken, trace.Wrap(err)
-	}
-
-	r, nextToken, err := b.service.ListResourcesWithFilter(
-		ctx,
-		pageSize,
-		currentToken,
-		func(item *workloadidentityv1pb.WorkloadIdentity) bool {
-			return services.MatchWorkloadIdentity(item, options.GetFilterSearchTerm())
-		},
-	)
-	return r, nextToken, trace.Wrap(err)
+	return b.service.Resources(ctx, start, end)
 }
 
 // DeleteWorkloadIdentity deletes a specific WorkloadIdentity.

--- a/lib/services/local/workload_identity_test.go
+++ b/lib/services/local/workload_identity_test.go
@@ -18,14 +18,11 @@ package local
 
 import (
 	"context"
-	"fmt"
-	"slices"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/testing/protocmp"
@@ -35,7 +32,6 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/backend"
 	"github.com/gravitational/teleport/lib/backend/memory"
-	"github.com/gravitational/teleport/lib/services"
 )
 
 func setupWorkloadIdentityServiceTest(
@@ -146,100 +142,62 @@ func TestWorkloadIdentityService_UpsertWorkloadIdentity(t *testing.T) {
 	})
 }
 
-func TestWorkloadIdentityService_ListWorkloadIdentities(t *testing.T) {
+func TestWorkloadIdentityService_RangeWorkloadIdentities(t *testing.T) {
 	ctx, service := setupWorkloadIdentityServiceTest(t)
-	// Create entities to list
-	createdObjects := []*workloadidentityv1pb.WorkloadIdentity{}
-	// Create 49 entities to test an incomplete page at the end.
-	for i := 0; i < 49; i++ {
-		created, err := service.CreateWorkloadIdentity(
-			ctx,
-			newValidWorkloadIdentity(fmt.Sprintf("%d", i)),
-		)
+
+	// Create entities to range over, in non-sorted insertion order to confirm
+	// the range returns them ordered by name.
+	names := []string{"c", "a", "e", "b", "d"}
+	for _, name := range names {
+		_, err := service.CreateWorkloadIdentity(ctx, newValidWorkloadIdentity(name))
 		require.NoError(t, err)
-		createdObjects = append(createdObjects, created)
 	}
-	t.Run("default page size", func(t *testing.T) {
-		page, nextToken, err := service.ListWorkloadIdentities(ctx, 0, "", nil)
-		require.NoError(t, err)
-		require.Len(t, page, 49)
-		require.Empty(t, nextToken)
 
-		// Expect that we get all the things we have created
-		for _, created := range createdObjects {
-			require.True(t, slices.ContainsFunc(page, func(resource *workloadidentityv1pb.WorkloadIdentity) bool {
-				return proto.Equal(created, resource)
-			}))
-		}
-	})
-	t.Run("pagination", func(t *testing.T) {
-		fetched := []*workloadidentityv1pb.WorkloadIdentity{}
-		token := ""
-		iterations := 0
-		for {
-			iterations++
-			page, nextToken, err := service.ListWorkloadIdentities(ctx, 10, token, nil)
+	collect := func(start, end string) []string {
+		var got []string
+		for wi, err := range service.RangeWorkloadIdentities(ctx, start, end, "", false) {
 			require.NoError(t, err)
-			fetched = append(fetched, page...)
-			if nextToken == "" {
-				break
-			}
-			token = nextToken
+			got = append(got, wi.GetMetadata().GetName())
 		}
-		require.Equal(t, 5, iterations)
+		return got
+	}
 
-		require.Len(t, fetched, 49)
-		// Expect that we get all the things we have created
-		for _, created := range createdObjects {
-			require.True(t, slices.ContainsFunc(fetched, func(resource *workloadidentityv1pb.WorkloadIdentity) bool {
-				return proto.Equal(created, resource)
-			}))
+	t.Run("full range is ordered by name", func(t *testing.T) {
+		require.Equal(t, []string{"a", "b", "c", "d", "e"}, collect("", ""))
+	})
+	t.Run("bounded range is exclusive of end", func(t *testing.T) {
+		require.Equal(t, []string{"b", "c"}, collect("b", "d"))
+	})
+	t.Run("open start", func(t *testing.T) {
+		require.Equal(t, []string{"a", "b"}, collect("", "c"))
+	})
+	t.Run("open end", func(t *testing.T) {
+		require.Equal(t, []string{"d", "e"}, collect("d", ""))
+	})
+	t.Run("empty range", func(t *testing.T) {
+		require.Empty(t, collect("f", ""))
+	})
+	t.Run("explicit name sort", func(t *testing.T) {
+		var got []string
+		for wi, err := range service.RangeWorkloadIdentities(ctx, "", "", "name", false) {
+			require.NoError(t, err)
+			got = append(got, wi.GetMetadata().GetName())
 		}
+		require.Equal(t, []string{"a", "b", "c", "d", "e"}, got)
 	})
-	t.Run("default sort", func(t *testing.T) {
-		page, nextToken, err := service.ListWorkloadIdentities(ctx, 0, "", nil)
-		require.NoError(t, err)
-		require.Len(t, page, 49)
-		require.Empty(t, nextToken)
-
-		prevName := ""
-		for i := range len(page) {
-			assert.Greater(t, page[i].GetMetadata().GetName(), prevName)
-			prevName = page[i].GetMetadata().GetName()
+	t.Run("unsupported sort field errors", func(t *testing.T) {
+		var err error
+		for _, iterErr := range service.RangeWorkloadIdentities(ctx, "", "", "spiffe_id", false) {
+			err = iterErr
 		}
+		require.ErrorContains(t, err, `unsupported sort, only name field is supported, but got "spiffe_id"`)
 	})
-	t.Run("unsupported sort field error", func(t *testing.T) {
-		_, _, err := service.ListWorkloadIdentities(ctx, 0, "", &services.ListWorkloadIdentitiesRequestOptions{
-			SortField: "blah",
-		})
-		require.ErrorContains(t, err, `unsupported sort, only name field is supported, but got "blah"`)
-	})
-	t.Run("unsupported sort order error", func(t *testing.T) {
-		_, _, err := service.ListWorkloadIdentities(ctx, 0, "", &services.ListWorkloadIdentitiesRequestOptions{
-			SortDesc: true,
-		})
+	t.Run("descending sort errors", func(t *testing.T) {
+		var err error
+		for _, iterErr := range service.RangeWorkloadIdentities(ctx, "", "", "name", true) {
+			err = iterErr
+		}
 		require.ErrorContains(t, err, "unsupported sort, only ascending order is supported")
-	})
-	t.Run("search filter match on name", func(t *testing.T) {
-		page, _, err := service.ListWorkloadIdentities(ctx, 0, "", &services.ListWorkloadIdentitiesRequestOptions{
-			FilterSearchTerm: "9",
-		})
-		require.NoError(t, err)
-		assert.Len(t, page, 4)
-	})
-	t.Run("search filter match on spiffe id", func(t *testing.T) {
-		page, _, err := service.ListWorkloadIdentities(ctx, 0, "", &services.ListWorkloadIdentitiesRequestOptions{
-			FilterSearchTerm: "test/22",
-		})
-		require.NoError(t, err)
-		assert.Len(t, page, 1)
-	})
-	t.Run("search filter match on spiffe hint", func(t *testing.T) {
-		page, _, err := service.ListWorkloadIdentities(ctx, 0, "", &services.ListWorkloadIdentitiesRequestOptions{
-			FilterSearchTerm: "hint 13",
-		})
-		require.NoError(t, err)
-		assert.Len(t, page, 1)
 	})
 }
 
@@ -311,16 +269,21 @@ func TestWorkloadIdentityService_DeleteAllWorkloadIdentities(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	page, _, err := service.ListWorkloadIdentities(ctx, 0, "", nil)
-	require.NoError(t, err)
-	require.Len(t, page, 2)
+	collect := func() []*workloadidentityv1pb.WorkloadIdentity {
+		var out []*workloadidentityv1pb.WorkloadIdentity
+		for wi, err := range service.RangeWorkloadIdentities(ctx, "", "", "", false) {
+			require.NoError(t, err)
+			out = append(out, wi)
+		}
+		return out
+	}
+
+	require.Len(t, collect(), 2)
 
 	err = service.DeleteAllWorkloadIdentities(ctx)
 	require.NoError(t, err)
 
-	page, _, err = service.ListWorkloadIdentities(ctx, 0, "", nil)
-	require.NoError(t, err)
-	require.Empty(t, page)
+	require.Empty(t, collect())
 }
 
 func TestWorkloadIdentityService_UpdateWorkloadIdentity(t *testing.T) {

--- a/lib/services/workload_identity.go
+++ b/lib/services/workload_identity.go
@@ -18,11 +18,13 @@ package services
 
 import (
 	"context"
-	"slices"
+	"encoding/base32"
+	"iter"
 	"strings"
 	"time"
 
 	"github.com/gravitational/trace"
+	"golang.org/x/text/cases"
 
 	workloadidentityv1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/workloadidentity/v1"
 	"github.com/gravitational/teleport/api/types"
@@ -38,14 +40,14 @@ type WorkloadIdentities interface {
 	GetWorkloadIdentity(
 		ctx context.Context, name string,
 	) (*workloadidentityv1pb.WorkloadIdentity, error)
-	// ListWorkloadIdentities lists all WorkloadIdentities using Google style
-	// pagination.
-	ListWorkloadIdentities(
+	// RangeWorkloadIdentities returns WorkloadIdentity resources within the
+	// range [start, end), ordered by the given sort field and direction.
+	RangeWorkloadIdentities(
 		ctx context.Context,
-		pageSize int,
-		lastToken string,
-		options *ListWorkloadIdentitiesRequestOptions,
-	) ([]*workloadidentityv1pb.WorkloadIdentity, string, error)
+		start, end string,
+		sortField WorkloadIdentitySortField,
+		sortDesc bool,
+	) iter.Seq2[*workloadidentityv1pb.WorkloadIdentity, error]
 	// CreateWorkloadIdentity creates a new WorkloadIdentity.
 	CreateWorkloadIdentity(
 		ctx context.Context, workloadIdentity *workloadidentityv1pb.WorkloadIdentity,
@@ -155,51 +157,49 @@ func ValidateWorkloadIdentity(s *workloadidentityv1pb.WorkloadIdentity) error {
 	return nil
 }
 
-type ListWorkloadIdentitiesRequestOptions struct {
-	// The sort field to use for the results. If empty, the default sort field is used.
-	SortField string
-	// The sort order to use for the results. If empty, the default sort order is used.
-	SortDesc bool
-	// A search term used to filter the results. If non-empty, it's used to match against supported fields.
-	FilterSearchTerm string
+// WorkloadIdentitySortField identifies a field that WorkloadIdentities may be
+// sorted (and ranged) by. An empty value defaults to
+// [WorkloadIdentitySortFieldName].
+type WorkloadIdentitySortField string
+
+const (
+	// WorkloadIdentitySortFieldName sorts WorkloadIdentities by name. It is the
+	// default when no sort field is specified.
+	WorkloadIdentitySortFieldName WorkloadIdentitySortField = "name"
+	// WorkloadIdentitySortFieldSPIFFEID sorts WorkloadIdentities by SPIFFE ID.
+	WorkloadIdentitySortFieldSPIFFEID WorkloadIdentitySortField = "spiffe_id"
+)
+
+// WorkloadIdentityKey returns a function deriving the canonical ordering key for
+// a WorkloadIdentity for the given sort field. It is the single source of truth
+// for both the order in which WorkloadIdentities are iterated and the pagination
+// cursor used to resume iteration. Supported sort fields are "" (defaults to
+// name), [WorkloadIdentitySortFieldName] and [WorkloadIdentitySortFieldSPIFFEID];
+// any other sort field returns an error.
+//
+// The sort field is validated once, when the key function is obtained, so
+// callers do not have to handle an error per resource.
+func WorkloadIdentityKey(sortField WorkloadIdentitySortField) (func(*workloadidentityv1pb.WorkloadIdentity) string, error) {
+	switch sortField {
+	case "", WorkloadIdentitySortFieldName:
+		return func(wi *workloadidentityv1pb.WorkloadIdentity) string {
+			return wi.GetMetadata().GetName()
+		}, nil
+	case WorkloadIdentitySortFieldSPIFFEID:
+		return workloadIdentitySPIFFEIDKey, nil
+	default:
+		return nil, trace.BadParameter("unsupported sort %q but expected %s or %s", sortField, WorkloadIdentitySortFieldName, WorkloadIdentitySortFieldSPIFFEID)
+	}
 }
 
-func (o *ListWorkloadIdentitiesRequestOptions) GetSortField() string {
-	if o == nil {
-		return ""
-	}
-	return o.SortField
-}
-
-func (o *ListWorkloadIdentitiesRequestOptions) GetSortDesc() bool {
-	if o == nil {
-		return false
-	}
-	return o.SortDesc
-}
-
-func (o *ListWorkloadIdentitiesRequestOptions) GetFilterSearchTerm() string {
-	if o == nil {
-		return ""
-	}
-	return o.FilterSearchTerm
-}
-
-func MatchWorkloadIdentity(item *workloadidentityv1pb.WorkloadIdentity, filterSearchTerm string) bool {
-	if item == nil {
-		return false
-	}
-	if filterSearchTerm == "" {
-		return true
-	}
-
-	values := []string{
-		item.GetMetadata().GetName(),
-		item.GetSpec().GetSpiffe().GetId(),
-		item.GetSpec().GetSpiffe().GetHint(),
-	}
-
-	return slices.ContainsFunc(values, func(val string) bool {
-		return strings.Contains(strings.ToLower(val), strings.ToLower(filterSearchTerm))
-	})
+// workloadIdentitySPIFFEIDKey returns the ordering key for the spiffe_id sort.
+func workloadIdentitySPIFFEIDKey(wi *workloadidentityv1pb.WorkloadIdentity) string {
+	name := wi.GetMetadata().GetName()
+	// Sort case-insensitively to keep /spiffe-1 and /Spiffe-1 together.
+	spiffeID := cases.Fold().String(wi.GetSpec().GetSpiffe().GetId())
+	// Encode to avoid ambiguity; "a/b" + "/" + "c" vs. "a" + "/" + "b/c". Base32
+	// hex maintains the original ordering.
+	spiffeID = base32.HexEncoding.WithPadding(base32.NoPadding).EncodeToString([]byte(spiffeID))
+	// SPIFFE IDs may not be unique, so append the resource name.
+	return spiffeID + "/" + name
 }


### PR DESCRIPTION
Backports https://github.com/gravitational/teleport/pull/67504

This work is in preparation of work on https://github.com/gravitational/teleport/issues/66349

## Manual Test Plan
### Test Environment

Local cluster.

### Test Cases

- [x] Web UI (with sufficient numbered resources to trigger pagination)
  - [x] Search
  - [x] Sort order (name and SPIFFE ID, asc and desc)
  - [x] Pagination
- [x] tctl get workload_identity
- [x] Issue SPIFFE SVID using `tbot` using name selector
- [x] Issue SPIFFE SVID using `tbot` using label selector 
- [x] Fails to issue SPIFFE SVIDs when role label selectors do not permit it.
