### PR TITLE
reject path separators in scp received file names

### DIFF
--- a/lib/sshutils/scp/scp.go
+++ b/lib/sshutils/scp/scp.go
@@ -648,7 +648,8 @@ func parseNewFile(line string) (*newFileCmd, error) {
 	//   * https://sintonen.fi/advisories/scp-client-multiple-vulnerabilities.txt
 	//   * https://github.com/openssh/openssh-portable/commit/6010c03
 	c.Name = parts[2]
-	if len(c.Name) == 0 || strings.HasPrefix(c.Name, string(filepath.Separator)) || c.Name == "." || c.Name == ".." {
+	if len(c.Name) == 0 || c.Name == "." || c.Name == ".." ||
+		strings.ContainsRune(c.Name, '/') || strings.ContainsRune(c.Name, '\\') {
 		return nil, trace.BadParameter("invalid name")
 	}
 

--- a/lib/sshutils/scp/scp_test.go
+++ b/lib/sshutils/scp/scp_test.go
@@ -852,3 +852,26 @@ var testNow = time.Date(1984, time.April, 4, 0, 0, 0, 0, time.UTC)
 func args(params ...string) []string {
 	return params
 }
+
+func TestParseNewFileRejectsPathComponents(t *testing.T) {
+	t.Parallel()
+
+	rejected := []string{
+		"",
+		".",
+		"..",
+		"/etc/passwd",
+		"../../../tmp/evil",
+		"sub/../../etc/passwd",
+		"sub/evil",
+		`sub\evil`,
+	}
+	for _, name := range rejected {
+		_, err := parseNewFile("0644 10 " + name)
+		require.Error(t, err, "name %q must be rejected", name)
+	}
+
+	c, err := parseNewFile("0644 10 file.txt")
+	require.NoError(t, err)
+	require.Equal(t, "file.txt", c.Name)
+}


### PR DESCRIPTION
Fixes https://github.com/gravitational/pressure-washing/issues/367.

Signed-off-by: Erik Tate <erik.tate@goteleport.com>

changelog: Fixed an issue where path separators could be included in scp file names during upload.

## Manual Test Plan
### Test Environment
Local teleport cluster
### Test Cases
- [x] Upload file with valid name succeeds
- [x] Download file with valid name succeeds
- [x] Upload file with invalid name containing path separators fails