### PR TITLE
Mention mobile device sync in Device Trust MDM integration docs

### DIFF
--- a/docs/cspell.json
+++ b/docs/cspell.json
@@ -62,6 +62,7 @@
     "Dfumu",
     "Distroless",
     "Divio's",
+    "DXXXXXXXXX",
     "EBSCSI",
     "ECCP",
     "ECMWF",

--- a/docs/pages/includes/config-reference/jamf-service.yaml
+++ b/docs/pages/includes/config-reference/jamf-service.yaml
@@ -77,10 +77,19 @@ jamf_service:
     # Default is 'NOOP'.
     on_missing: NOOP
 
+    # Device type to sync. Each inventory entry syncs a single device type.
+    # Add additional entries to sync more than one.
+    # Valid options are:
+    # 'computers' - macOS computers.
+    # 'mobile_devices' - iOS & iPadOS devices.
+    # Default is 'computers'.
+    device_type: computers
+
     # Device filters forwarded to the Jamf Pro API queries.
-    # Refer to https://developer.jamf.com/jamf-pro/reference/get_v1-computers-inventory
-    # for the possible filter values.
-    # Default is ''
+    # Refer to the following doc pages depending on device_type for the possible filter values:
+    # - 'computers': https://developer.jamf.com/jamf-pro/reference/get_v1-computers-inventory
+    # - 'mobile_devices': https://developer.jamf.com/jamf-pro/reference/get_v2-mobile-devices-detail
+    # Default is ''.
     filter_rsql: ''
 
     # Custom page size for inventory queries.

--- a/docs/pages/zero-trust-access/device-trust/intune-integration.mdx
+++ b/docs/pages/zero-trust-access/device-trust/intune-integration.mdx
@@ -13,7 +13,8 @@ enterprise: Device Trust
 ---
 
 The Device Trust Microsoft Intune integration lets you automatically sync your managed devices from
-Intune into Teleport. This guide explains how to set up the integration.
+Intune into Teleport, including macOS, Windows, Linux, iOS, and iPadOS devices. This guide explains
+how to set up the integration.
 
 ## How it works
 
@@ -119,7 +120,7 @@ syncs.
 ### Device requirements
 
 For a device to be synced, it must have a serial number, its device registration state must be set
-to "registered" and its operating system must be either macOS, Windows, or Linux.
+to "registered" and its operating system must be either macOS, Windows, Linux, iOS, or iPadOS.
 
 ### Device ownership and removal
 
@@ -177,8 +178,8 @@ Asset Tag    OS      Source Enroll Status Owner Device ID
 CXXXXXXXXX17 macOS   Intune not enrolled        20ec6373-9e8e-46e0-8f1c-47ad6b06a768
 CXXXXXXXXX2T macOS   Intune not enrolled        79755778-7cbe-4e2c-83ec-7eaa3d4d7e36
 CXXXXXXXXX3T Windows Intune not enrolled        665e59d5-393a-4894-841d-edad06329717
-CXXXXXXXXX4T macOS   Intune not enrolled        dd032e90-bfb0-47d5-bce5-e57545f6788f
-CXXXXXXXXX5T Windows Intune not enrolled        bf189863-a94a-40dc-9013-d96f8dada2f1
+DXXXXXXXXX01 iPadOS  Intune not enrolled        dd032e90-bfb0-47d5-bce5-e57545f6788f
+DXXXXXXXXX02 iOS     Intune not enrolled        bf189863-a94a-40dc-9013-d96f8dada2f1
 (...)
 ```
 

--- a/docs/pages/zero-trust-access/device-trust/jamf-integration.mdx
+++ b/docs/pages/zero-trust-access/device-trust/jamf-integration.mdx
@@ -215,7 +215,14 @@ by the [Jamf Pro API](
 https://developer.jamf.com/jamf-pro/reference/get_v1-computers-inventory).
 Jamf recommends a full sync no more than once every 24 hours.
 
-The default "inventory" configuration is roughly equivalent to the one below:
+Where you apply the customization depends on your deployment. The default
+"inventory" configuration is roughly equivalent to:
+
+<Tabs>
+<TabItem label="Self-Hosted">
+
+Edit the `jamf_service.inventory` list in your `teleport.yaml` and restart the
+`teleport` process:
 
 ```yaml
 jamf_service:
@@ -228,6 +235,38 @@ jamf_service:
     on_missing: DELETE
     filter_rsql: general.remoteManagement.managed==true
 ```
+
+</TabItem>
+<TabItem label="Teleport Cloud">
+
+The hosted Jamf plugin stores the same configuration on the plugin resource.
+Open it for editing with `tctl edit plugins/jamf` and update
+`spec.Settings.jamf.jamf_spec.inventory`. Updating the config restarts the
+plugin immediately with the changes applied.
+
+```yaml
+kind: plugin
+metadata:
+  name: jamf
+spec:
+  Settings:
+    jamf:
+      jamf_spec:
+        inventory:
+        - device_type: computers
+          sync_period_partial: 6h
+          sync_period_full: 24h
+          on_missing: DELETE
+          filter_rsql: general.remoteManagement.managed==true
+version: v1
+```
+
+</TabItem>
+</Tabs>
+
+Subsequent examples in this section show the self-hosted form for brevity. To
+apply them to the hosted plugin, copy the `inventory` entries into
+`spec.Settings.jamf.jamf_spec.inventory` on the plugin resource.
 
 Each inventory entry syncs a single device type. To also sync iOS and iPadOS
 mobile devices, add a second entry with `device_type: mobile_devices`:

--- a/docs/pages/zero-trust-access/device-trust/jamf-integration.mdx
+++ b/docs/pages/zero-trust-access/device-trust/jamf-integration.mdx
@@ -56,8 +56,8 @@ https://learn.jamf.com/en-US/bundle/jamf-pro-documentation-current/page/API_Role
 to create a role and an API client. We recommend creating a role and API client
 specific for Teleport.
 
-Make sure that your Jamf role has the "Read Computers" and "Read Mobile Devices"
-privileges.
+Make sure that your Jamf role has the "Read Computers" privilege. Select "Read
+Mobile Devices" too if you plan to sync iOS and iPadOS devices.
 
 You can test your client credentials using the following Jamf query, replacing
 <Var name="(=jamf.api_endpoint=)" description="Jamf API URL" /> with your Jamf

--- a/docs/pages/zero-trust-access/device-trust/jamf-integration.mdx
+++ b/docs/pages/zero-trust-access/device-trust/jamf-integration.mdx
@@ -215,14 +215,16 @@ by the [Jamf Pro API](
 https://developer.jamf.com/jamf-pro/reference/get_v1-computers-inventory).
 Jamf recommends a full sync no more than once every 24 hours.
 
-Where you apply the customization depends on your deployment. The default
-"inventory" configuration is roughly equivalent to:
+Where you apply the customization depends on how you run Jamf sync. The snippets
+under each option below spell out the default "inventory" configuration which
+the Jamf service and plugin use implicitly. Edit them to customize the sync
+schedule or the set of synced devices.
 
-<Tabs>
-<TabItem label="Self-Hosted">
+### In the `jamf_service` configuration file
 
-Edit the `jamf_service.inventory` list in your `teleport.yaml` and restart the
-`teleport` process:
+If you run Jamf sync as a self-hosted `jamf_service`, edit the
+`jamf_service.inventory` list in your `teleport.yaml` and restart the `teleport`
+process:
 
 ```yaml
 jamf_service:
@@ -236,13 +238,13 @@ jamf_service:
     filter_rsql: general.remoteManagement.managed==true
 ```
 
-</TabItem>
-<TabItem label="Teleport Cloud">
+### On the Jamf plugin resource
 
-The hosted Jamf plugin stores the same configuration on the plugin resource.
-Open it for editing with `tctl edit plugins/jamf` and update
-`spec.Settings.jamf.jamf_spec.inventory`. Updating the config restarts the
-plugin immediately with the changes applied.
+If you manage Jamf sync through the hosted Jamf plugin instead, the same
+configuration is stored on the plugin resource. This is the case for Teleport
+Cloud users who set up the plugin through the Web UI. Open it for editing with
+`tctl edit plugins/jamf` and update `spec.Settings.jamf.jamf_spec.inventory`.
+Updating the config restarts the plugin immediately with the changes applied.
 
 ```yaml
 kind: plugin
@@ -261,12 +263,9 @@ spec:
 version: v1
 ```
 
-</TabItem>
-</Tabs>
-
-Subsequent examples in this section show the self-hosted form for brevity. To
-apply them to the hosted plugin, copy the `inventory` entries into
-`spec.Settings.jamf.jamf_spec.inventory` on the plugin resource.
+Subsequent examples in this section show the `jamf_service` configuration file
+form for brevity. To apply them to the hosted plugin, copy the `inventory`
+entries into `spec.Settings.jamf.jamf_spec.inventory` on the plugin resource.
 
 Each inventory entry syncs a single device type. To also sync iOS and iPadOS
 mobile devices, add a second entry with `device_type: mobile_devices`:

--- a/docs/pages/zero-trust-access/device-trust/jamf-integration.mdx
+++ b/docs/pages/zero-trust-access/device-trust/jamf-integration.mdx
@@ -11,15 +11,18 @@ tags:
 enterprise: Device Trust
 ---
 
-The Device Trust Jamf Pro integration lets you automatically sync your Jamf Pro computer
-inventory into Teleport.
+The Device Trust Jamf Pro integration lets you automatically sync your Jamf Pro
+device inventory into Teleport. It supports macOS computers and iOS & iPadOS
+mobile devices. By default only macOS computers are synced. See
+[Optional: Customize the sync schedule](#optional-customize-the-sync-schedule)
+for enabling iOS and iPadOS sync.
 
 ## How it works
 
 The Teleport Jamf Pro service is a distinct `teleport` process that periodically
-reads your computer inventory from Jamf Pro and syncs it to Teleport. It performs
+reads your device inventory from Jamf Pro and syncs it to Teleport. It performs
 both incremental (called "partial") and full syncs, as well as removals from
-Teleport if a computer is removed from Jamf Pro.
+Teleport if a device is removed from Jamf Pro.
 
 Syncing devices from Jamf Pro is an **inventory management** step, equivalent to
 automatically running the corresponding `tctl devices add` commands.
@@ -53,7 +56,8 @@ https://learn.jamf.com/en-US/bundle/jamf-pro-documentation-current/page/API_Role
 to create a role and an API client. We recommend creating a role and API client
 specific for Teleport.
 
-Make sure that your Jamf role has the "Read Computers" privilege.
+Make sure that your Jamf role has the "Read Computers" and "Read Mobile Devices"
+privileges.
 
 You can test your client credentials using the following Jamf query, replacing
 <Var name="(=jamf.api_endpoint=)" description="Jamf API URL" /> with your Jamf
@@ -192,13 +196,13 @@ devices ls`:
 
 ```code
 $ tctl devices ls
-Asset Tag    OS    Source Enroll Status Owner Device ID
------------- ----- ------ ------------- ----- ------------------------------------
-CXXXXXXXXX17 macOS Jamf   not enrolled        20ec6373-9e8e-46e0-8f1c-47ad6b06a768
-CXXXXXXXXX2T macOS Jamf   not enrolled        79755778-7cbe-4e2c-83ec-7eaa3d4d7e36
-CXXXXXXXXX3T macOS Jamf   not enrolled        665e59d5-393a-4894-841d-edad06329717
-CXXXXXXXXX4T macOS Jamf   not enrolled        dd032e90-bfb0-47d5-bce5-e57545f6788f
-CXXXXXXXXX5T macOS Jamf   not enrolled        bf189863-a94a-40dc-9013-d96f8dada2f1
+Asset Tag    OS     Source Enroll Status Owner Device ID
+------------ ------ ------ ------------- ----- ------------------------------------
+CXXXXXXXXX17 macOS  Jamf   not enrolled        20ec6373-9e8e-46e0-8f1c-47ad6b06a768
+CXXXXXXXXX2T macOS  Jamf   not enrolled        79755778-7cbe-4e2c-83ec-7eaa3d4d7e36
+CXXXXXXXXX3T macOS  Jamf   not enrolled        665e59d5-393a-4894-841d-edad06329717
+DXXXXXXXXX01 iPadOS Jamf   not enrolled        dd032e90-bfb0-47d5-bce5-e57545f6788f
+DXXXXXXXXX02 iOS    Jamf   not enrolled        bf189863-a94a-40dc-9013-d96f8dada2f1
 (...)
 ```
 
@@ -218,13 +222,46 @@ jamf_service:
   enabled: true
   # ...
   inventory:
-  - sync_period_partial: 6h
+  - device_type: computers
+    sync_period_partial: 6h
     sync_period_full: 24h
     on_missing: DELETE
     filter_rsql: general.remoteManagement.managed==true
 ```
 
+Each inventory entry syncs a single device type. To also sync iOS and iPadOS
+mobile devices, add a second entry with `device_type: mobile_devices`:
+
+```yaml
+jamf_service:
+  enabled: true
+  # ...
+  inventory:
+  - device_type: computers
+    sync_period_partial: 6h
+    sync_period_full: 24h
+    on_missing: DELETE
+    filter_rsql: general.remoteManagement.managed==true
+  - device_type: mobile_devices
+    sync_period_partial: 6h
+    sync_period_full: 24h
+    on_missing: DELETE
+    filter_rsql: managed==true
+```
+
 Unpacking the configuration, we have the following keys:
+
+### `device_type`
+
+The `device_type` key specifies which Jamf device type the entry syncs. Valid
+values are:
+
+- `computers`: macOS computers (synced via the Jamf Pro computers inventory API).
+- `mobile_devices`: iOS and iPadOS devices (synced via the Jamf Pro mobile
+  devices API).
+
+If `device_type` is not specified, the entry syncs `computers`. To sync more
+than one device type, add additional inventory entries.
 
 ### `sync_period_*`
 
@@ -265,9 +302,12 @@ still in the Jamf inventory, it'll be recreated during the next sync.
 ### `filter_rsql`
 
 The `filter_rsql` key applies a Jamf Pro API filter when querying for devices.
-Refer to
-https://developer.jamf.com/jamf-pro/reference/get_v1-computers-inventory for the
-possible filter values.
+The set of filterable fields depends on `device_type`:
+
+- For `computers`, refer to
+  https://developer.jamf.com/jamf-pro/reference/get_v1-computers-inventory.
+- For `mobile_devices`, refer to
+  https://developer.jamf.com/jamf-pro/reference/get_v2-mobile-devices-detail.
 
 ## Optional: Sync multiple sources
 


### PR DESCRIPTION
https://github.com/gravitational/teleport.e/issues/8253 is implemented and the only missing piece is docs.

This PR updates the MDM integration docs to mention the new mobile device sync capabilities. The Intune plugin doesn't support inventory config at the moment, so there's little updates that need to be done there.

The Jamf service/plugin got one new field which this PR documents. Since enabling mobile device sync is opt-in in the case of the Jamf integration, I added:

* Instructions on how to update the config when using the plugin rather than the service.
  * This would be the case for Cloud customers, though they can use the service too. But the plugin can be set up through the Web UI.
* Instructions on how to enable mobile device sync.