### PR TITLE
Remove CreateWebSession HTTP RPC pathway

### DIFF
--- a/lib/auth/apiserver.go
+++ b/lib/auth/apiserver.go
@@ -127,7 +127,7 @@ func NewAPIServer(config *APIConfig) (http.Handler, error) {
 	srv.Router.UseRawPath = true
 
 	// Passwords and sessions
-	srv.POST("/:version/users/:user/web/sessions", srv.WithAuth(srv.createWebSession))
+	srv.POST("/:version/users/:user/web/sessions", srv.WithAuth(srv.extendWebSession))
 	srv.POST("/:version/users/:user/web/authenticate", srv.WithAuth(srv.authenticateWebUser))
 	srv.POST("/:version/users/:user/ssh/authenticate", srv.WithAuth(srv.authenticateSSHUser))
 
@@ -399,18 +399,20 @@ func (s *APIServer) validateTrustedCluster(auth *ServerWithRoles, w http.Respons
 	return validateResponseRaw, nil
 }
 
-// nb(strideynet): This RPC no longer creates web sessions, it only extends
-// existing ones.
-func (s *APIServer) createWebSession(auth *ServerWithRoles, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (any, error) {
+func (s *APIServer) extendWebSession(auth *ServerWithRoles, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (any, error) {
+	// nb(strideynet): Historically this handler/endpoint provided both
+	// Create and Extend WebSession functionality, and was known as
+	// CreateWebSession. The web session creation functionality was unused for
+	// a long time and hence removed and this handler "renamed".
+
 	var req authclient.WebSessionReq
 	if err := httplib.ReadJSON(r, &req); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
-	// Prohibit the use of this RPC for the creation of new web sessions. For
-	// quite some time, this RPC has only been used for the extension of web
-	// sessions. Creation of new web sessions occurs only through RPCs designed
-	// for initial authentication.
+	// Requires that PrevSessionID is set. Historically, the lack of this field
+	// indicated that the caller wanted to create (rather than extend) a web
+	// session.
 	if req.PrevSessionID == "" {
 		return nil, trace.BadParameter("RPC cannot be used to create new web sessions")
 	}

--- a/lib/auth/apiserver.go
+++ b/lib/auth/apiserver.go
@@ -399,30 +399,27 @@ func (s *APIServer) validateTrustedCluster(auth *ServerWithRoles, w http.Respons
 	return validateResponseRaw, nil
 }
 
+// nb(strideynet): This RPC no longer creates web sessions, it only extends
+// existing ones.
 func (s *APIServer) createWebSession(auth *ServerWithRoles, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (any, error) {
-	// nb(strideynet): Whilst CreateWebSession seems not to be invoked for the
-	// purposes of creation anymore - it does appear that this RPC is still
-	// in the hot-path for the Extend behavior.
-
 	var req authclient.WebSessionReq
 	if err := httplib.ReadJSON(r, &req); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
-	if req.PrevSessionID != "" {
-		sess, err := auth.ExtendWebSession(r.Context(), req)
-		if err != nil {
-			return nil, trace.Wrap(err)
-		}
-		return sess, nil
+	// Prohibit the use of this RPC for the creation of new web sessions. For
+	// quite some time, this RPC has only been used for the extension of web
+	// sessions. Creation of new web sessions occurs only through RPCs designed
+	// for initial authentication.
+	if req.PrevSessionID == "" {
+		return nil, trace.BadParameter("RPC cannot be used to create new web sessions")
 	}
 
-	sess, err := auth.CreateWebSession(r.Context(), req.User)
+	sess, err := auth.ExtendWebSession(r.Context(), req)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-
-	return rawMessage(services.MarshalWebSession(sess, services.WithVersion(version)))
+	return sess, nil
 }
 
 func (s *APIServer) authenticateWebUser(auth *ServerWithRoles, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (any, error) {

--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -5373,22 +5373,6 @@ func (a *Server) getValidatedAccessRequest(ctx context.Context, identity tlsca.I
 	return req, nil
 }
 
-// CreateWebSession creates a new web session for user without any
-// checks, is used by admins
-func (a *Server) CreateWebSession(ctx context.Context, user string) (types.WebSession, error) {
-	u, err := a.GetUserOrLoginState(ctx, user)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	session, err := a.CreateWebSessionFromReq(ctx, NewWebSessionRequest{
-		User:      user,
-		Roles:     u.GetRoles(),
-		Traits:    u.GetTraits(),
-		LoginTime: a.clock.Now().UTC(),
-	})
-	return session, trace.Wrap(err)
-}
-
 // ExtractHostID returns host id based on the hostname
 func ExtractHostID(hostName string, clusterName string) (string, error) {
 	suffix := "." + clusterName

--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -2957,14 +2957,6 @@ func (a *ServerWithRoles) ChangePassword(
 	return a.authServer.ChangePassword(ctx, req)
 }
 
-// CreateWebSession creates a new web session for the specified user
-func (a *ServerWithRoles) CreateWebSession(ctx context.Context, user string) (types.WebSession, error) {
-	if err := a.currentUserAction(user); err != nil {
-		return nil, trace.Wrap(err)
-	}
-	return a.authServer.CreateWebSession(ctx, user)
-}
-
 // ExtendWebSession creates a new web session for a user based on a valid previous session.
 // Additional roles are appended to initial roles if there is an approved access request.
 // The new session expiration time will not exceed the expiration time of the old session.

--- a/lib/auth/authclient/clt.go
+++ b/lib/auth/authclient/clt.go
@@ -868,8 +868,6 @@ type WebService interface {
 	// ExtendWebSession creates a new web session for a user based on another
 	// valid web session
 	ExtendWebSession(ctx context.Context, req WebSessionReq) (types.WebSession, error)
-	// CreateWebSession creates a new web session for a user
-	CreateWebSession(ctx context.Context, user string) (types.WebSession, error)
 
 	// AppSessionReader defines application session features available to remote clients.
 	services.AppSessionReader

--- a/lib/auth/authclient/http_client.go
+++ b/lib/auth/authclient/http_client.go
@@ -375,19 +375,6 @@ func (c *HTTPClient) ExtendWebSession(ctx context.Context, req WebSessionReq) (t
 	return services.UnmarshalWebSession(out.Bytes())
 }
 
-// CreateWebSession creates a new web session for a user
-func (c *HTTPClient) CreateWebSession(ctx context.Context, user string) (types.WebSession, error) {
-	out, err := c.PostJSON(
-		ctx,
-		c.Endpoint("users", url.PathEscape(user), "web", "sessions"),
-		WebSessionReq{User: user},
-	)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	return services.UnmarshalWebSession(out.Bytes())
-}
-
 // AuthenticateWebUser authenticates web user, creates and  returns web session
 // in case if authentication is successful
 func (c *HTTPClient) AuthenticateWebUser(ctx context.Context, req AuthenticateUserRequest) (types.WebSession, error) {


### PR DESCRIPTION
Removes functionality from the CreateWebSession HTTP RPC for uh, creating a WebSession, and preserves only the functionality related to extending a WebSession. Looking back through history, at least as far back as v16.0.0, we have not used this RPC to create new web sessions and have only ever used it for extending web sessions. The creation of web sessions almost always happens through authentication RPCs.

## Manual Test Plan
### Test Environment

Local cluster

### Test Cases

- [x] Assume access request, validate extendWebSession is called and results in new web session.
- [x] Switchback from access request, validate extendWebSession is called and results in new web session.