### PR TITLE
Detect and optionally block cross-site WebSocket hijacking (CSWSH) on app access

### DIFF
--- a/lib/web/app/handler.go
+++ b/lib/web/app/handler.go
@@ -29,6 +29,7 @@ import (
 	"net"
 	"net/http"
 	"net/url"
+	"os"
 	"slices"
 	"strings"
 	"time"
@@ -104,6 +105,11 @@ type Handler struct {
 	clusterName string
 
 	logger *slog.Logger
+
+	// cswshAction controls the response to a detected cross-origin WebSocket
+	// upgrade, configured via TELEPORT_UNSTABLE_APP_CSWSH_ACTION. Defaults to
+	// no-op.
+	cswshAction cswshAction
 }
 
 // NewHandler returns a new application handler.
@@ -117,6 +123,11 @@ func NewHandler(ctx context.Context, c *HandlerConfig) (*Handler, error) {
 		c:            c,
 		closeContext: ctx,
 		logger:       slog.With(teleport.ComponentKey, teleport.ComponentAppProxy),
+		cswshAction:  parseCSWSHAction(os.Getenv(cswshActionEnv)),
+	}
+	if h.cswshAction.enabled() {
+		h.logger.InfoContext(ctx, "Application access cross-site WebSocket (CSWSH) guard enabled",
+			"report", h.cswshAction.report, "block", h.cswshAction.block)
 	}
 
 	// Create a new session cache, this holds sessions that can be used to
@@ -254,6 +265,12 @@ func (h *Handler) HealthCheckAppServer(ctx context.Context, appName, publicAddr,
 // handleHttp forwards the request to the application service or redirects
 // to the application directly.
 func (h *Handler) handleHttp(w http.ResponseWriter, r *http.Request, session *session) error {
+	// Reject (or, in report-only mode, log) cross-site WebSocket upgrades
+	// before forwarding to the application (CSWSH protection).
+	if err := h.guardCrossSiteWebSocket(r); err != nil {
+		return trace.Wrap(err)
+	}
+
 	var redirectURI string
 
 	session.tr.mu.Lock()

--- a/lib/web/app/handler_test.go
+++ b/lib/web/app/handler_test.go
@@ -429,6 +429,93 @@ func TestNewSessionRoutesByAppName(t *testing.T) {
 	}
 }
 
+// TestCrossSiteWebSocketProtection verifies the CSWSH guard is wired into the
+// cookie-authenticated app forward path end-to-end: under block, a cross-origin
+// WebSocket upgrade is rejected with 403, while a non-WebSocket request is still
+// forwarded. The guard's full decision matrix (action modes, origin
+// classification) is unit-tested in TestGuardCrossSiteWebSocket; this test covers
+// the wiring and status propagation through the real handler and middleware.
+//
+// Requests use a realistic handshake (Connection: Upgrade + Origin), matching
+// what a browser actually sends — Chrome attaches no Sec-Fetch-* to a WebSocket
+// upgrade, so Origin is the signal that drives detection.
+func TestCrossSiteWebSocketProtection(t *testing.T) {
+	clusterName := "test-cluster"
+	publicAddr := "app.example.com"
+
+	key, cert, err := tlsca.GenerateSelfSignedCA(
+		pkix.Name{CommonName: clusterName},
+		[]string{publicAddr, apiutils.EncodeClusterName(clusterName)},
+		defaults.CATTL,
+	)
+	require.NoError(t, err)
+
+	fakeClock := clockwork.NewFakeClock()
+	authClient := &mockAuthClient{
+		clusterName: clusterName,
+		appSession:  createAppSession(t, fakeClock, key, cert, clusterName, publicAddr, "testapp"),
+		appServers:  []types.AppServer{createAppServer(t, publicAddr)},
+		caKey:       key,
+		caCert:      cert,
+	}
+
+	fakeCluster := startFakeAppServerOnCluster(t, clusterName, authClient, cert, key)
+	tunnel := &reversetunnelclient.FakeServer{
+		FakeClusters: []reversetunnelclient.Cluster{fakeCluster},
+	}
+
+	// Valid victim session cookies. In the real attack the browser attaches
+	// these automatically on cross-site requests because they are SameSite=None.
+	cookies := []http.Cookie{
+		{Name: CookieName, Value: "abc"},
+		{Name: SubjectCookieName, Value: authClient.appSession.GetBearerToken()},
+	}
+	// A cross-origin WebSocket handshake: the Origin host differs from the app's,
+	// and there is no Sec-Fetch-Site (as on a real browser WebSocket upgrade).
+	crossOriginWS := map[string]string{
+		"Connection": "Upgrade",
+		"Upgrade":    "websocket",
+		"Origin":     "https://attacker.example",
+	}
+
+	for _, tc := range []struct {
+		name       string
+		action     string // TELEPORT_UNSTABLE_APP_CSWSH_ACTION
+		method     string
+		headers    map[string]string
+		wantStatus int
+	}{
+		{
+			name:       "block rejects cross-origin WebSocket",
+			action:     "block",
+			method:     "GET",
+			headers:    crossOriginWS,
+			wantStatus: http.StatusForbidden,
+		},
+		{
+			name:       "report-and-block rejects cross-origin WebSocket",
+			action:     "report-and-block",
+			method:     "GET",
+			headers:    crossOriginWS,
+			wantStatus: http.StatusForbidden,
+		},
+		{
+			name:       "cross-origin non-WebSocket request is forwarded under block (HTTP CSRF out of scope)",
+			action:     "block",
+			method:     "POST",
+			headers:    map[string]string{"Origin": "https://attacker.example"},
+			wantStatus: http.StatusOK,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv(cswshActionEnv, tc.action)
+			p := setup(t, fakeClock, authClient, tunnel)
+			status, _, _ := p.makeRequestWithHeaders(t, tc.method, "/", []byte{}, cookies, tc.headers)
+			require.Equal(t, tc.wantStatus, status)
+		})
+	}
+}
+
 func TestHealthCheckAppServer(t *testing.T) {
 	ctx := context.Background()
 	clusterName := "test-cluster"

--- a/lib/web/app/handler_test.go
+++ b/lib/web/app/handler_test.go
@@ -454,7 +454,7 @@ func TestCrossSiteWebSocketProtection(t *testing.T) {
 	authClient := &mockAuthClient{
 		clusterName: clusterName,
 		appSession:  createAppSession(t, fakeClock, key, cert, clusterName, publicAddr, "testapp"),
-		appServers:  []types.AppServer{createAppServer(t, publicAddr)},
+		appServers:  []types.AppServer{createNamedAppServer(t, "testapp", publicAddr)},
 		caKey:       key,
 		caCert:      cert,
 	}

--- a/lib/web/app/websocket.go
+++ b/lib/web/app/websocket.go
@@ -125,7 +125,10 @@ func isCrossOriginWebSocketUpgrade(r *http.Request) bool {
 	if err != nil {
 		return true // unparseable Origin: treat as foreign
 	}
-	return !strings.EqualFold(u.Host, r.Host)
+	// An origin is (scheme, host, port), so compare scheme too (port is part of
+	// Host). App access is always TLS, so a plain-HTTP page on the same host is a
+	// foreign origin whose wss:// handshake still carries the Secure cookies.
+	return !strings.EqualFold(u.Scheme, "https") || !strings.EqualFold(u.Host, r.Host)
 }
 
 // isWebSocketUpgrade reports whether r is a WebSocket upgrade handshake. A

--- a/lib/web/app/websocket.go
+++ b/lib/web/app/websocket.go
@@ -1,0 +1,150 @@
+/*
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package app
+
+import (
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/gravitational/trace"
+)
+
+// cswshActionEnv is the environment variable that controls how the app proxy
+// responds to a detected cross-origin WebSocket upgrade (cross-site WebSocket
+// hijacking, CSWSH). Recognized values: "report", "block", "report-and-block".
+// Any other value, including unset, does nothing.
+const cswshActionEnv = "TELEPORT_UNSTABLE_APP_CSWSH_ACTION"
+
+// cswshDetectedMarker is a stable, unique token included in the log line emitted
+// when a cross-origin WebSocket upgrade is detected, so detections can be grepped
+// out of proxy logs.
+const cswshDetectedMarker = "app_access_cswsh_detected"
+
+// cswshAction is the parsed TELEPORT_UNSTABLE_APP_CSWSH_ACTION behavior. report
+// and block are independent: unset of both is the default no-op.
+type cswshAction struct {
+	report bool
+	block  bool
+}
+
+// enabled reports whether the action does anything (report and/or block). The
+// zero value is disabled, which is the safe default.
+func (a cswshAction) enabled() bool { return a.report || a.block }
+
+// parseCSWSHAction parses the TELEPORT_UNSTABLE_APP_CSWSH_ACTION value. Unknown
+// or empty values disable the guard (do nothing) so the default is always safe.
+func parseCSWSHAction(v string) cswshAction {
+	switch strings.ToLower(strings.TrimSpace(v)) {
+	case "report":
+		return cswshAction{report: true}
+	case "block":
+		return cswshAction{block: true}
+	case "report-and-block", "report_and_block":
+		return cswshAction{report: true, block: true}
+	default:
+		return cswshAction{}
+	}
+}
+
+// guardCrossSiteWebSocket detects cross-origin WebSocket upgrades on the app
+// forward path and reacts per the configured action (report, block, both, or —
+// by default — nothing).
+//
+// Scope: only a browser attaches the victim's ambient cookies, so CSWSH is
+// inherently a browser attack, and we police it using signals a browser is forced
+// to send and a script cannot forge (the Origin header — see
+// isCrossOriginWebSocketUpgrade). Non-browser clients carry no such cookies and no
+// Origin, so they pass through. Same-origin upgrades (the app's own page) always
+// pass. Plain HTTP CSRF is out of scope.
+func (h *Handler) guardCrossSiteWebSocket(r *http.Request) error {
+	if !h.cswshAction.enabled() {
+		return nil
+	}
+	if !isWebSocketUpgrade(r) {
+		return nil
+	}
+	if !isCrossOriginWebSocketUpgrade(r) {
+		return nil
+	}
+
+	if h.cswshAction.report {
+		h.logger.WarnContext(r.Context(), "Detected cross-origin WebSocket upgrade to application",
+			"marker", cswshDetectedMarker,
+			"blocked", h.cswshAction.block,
+			"sec_fetch_site", r.Header.Get("Sec-Fetch-Site"),
+			"origin", r.Header.Get("Origin"),
+			"host", r.Host,
+			"path", r.URL.Path,
+		)
+	}
+
+	if h.cswshAction.block {
+		return trace.AccessDenied("cross-origin WebSocket upgrade rejected")
+	}
+	return nil
+}
+
+// isCrossOriginWebSocketUpgrade reports whether a WebSocket upgrade was initiated
+// from an origin other than the app's own. r must already be a WebSocket upgrade
+// (callers check isWebSocketUpgrade first).
+//
+// Origin is the signal: RFC 6455 §4.1 requires browser clients to send it on the
+// handshake and §10.2 sanctions rejecting on it; OWASP's WebSocket Security Cheat
+// Sheet likewise makes Origin validation the primary CSWSH defense. A script
+// cannot forge it, and non-browser clients (which carry no ambient cookies to
+// abuse) may omit it. A present Origin whose host differs from the app's is
+// cross-origin.
+//
+// We do not consult Sec-Fetch-Site: browsers don't attach it to WebSocket
+// handshakes, and where it is present it agrees with the Origin comparison. We
+// also do not distinguish same-site from cross-site — that would need the Public
+// Suffix List and is deferred; today any foreign origin is cross-origin.
+func isCrossOriginWebSocketUpgrade(r *http.Request) bool {
+	origin := r.Header.Get("Origin")
+	if origin == "" {
+		return false
+	}
+	u, err := url.Parse(origin)
+	if err != nil {
+		return true // unparseable Origin: treat as foreign
+	}
+	return !strings.EqualFold(u.Host, r.Host)
+}
+
+// isWebSocketUpgrade reports whether r is a WebSocket upgrade handshake. A
+// handshake is an HTTP GET carrying Connection: Upgrade and Upgrade: websocket
+// (RFC 6455). Both are forbidden header names, so a script cannot forge them on a
+// non-WebSocket request. Both are RFC 7230 comma-separated token lists, so match
+// each as a token rather than by exact value.
+func isWebSocketUpgrade(r *http.Request) bool {
+	return headerListContainsToken(r.Header.Get("Connection"), "upgrade") &&
+		headerListContainsToken(r.Header.Get("Upgrade"), "websocket")
+}
+
+// headerListContainsToken reports whether a comma-separated header value
+// contains the given token, case-insensitively.
+func headerListContainsToken(headerValue, token string) bool {
+	for part := range strings.SplitSeq(headerValue, ",") {
+		if strings.EqualFold(strings.TrimSpace(part), token) {
+			return true
+		}
+	}
+	return false
+}

--- a/lib/web/app/websocket.go
+++ b/lib/web/app/websocket.go
@@ -32,11 +32,6 @@ import (
 // Any other value, including unset, does nothing.
 const cswshActionEnv = "TELEPORT_UNSTABLE_APP_CSWSH_ACTION"
 
-// cswshDetectedMarker is a stable, unique token included in the log line emitted
-// when a cross-origin WebSocket upgrade is detected, so detections can be grepped
-// out of proxy logs.
-const cswshDetectedMarker = "app_access_cswsh_detected"
-
 // cswshAction is the parsed TELEPORT_UNSTABLE_APP_CSWSH_ACTION behavior. report
 // and block are independent: unset of both is the default no-op.
 type cswshAction struct {
@@ -86,7 +81,6 @@ func (h *Handler) guardCrossSiteWebSocket(r *http.Request) error {
 
 	if h.cswshAction.report {
 		h.logger.WarnContext(r.Context(), "Detected cross-origin WebSocket upgrade to application",
-			"marker", cswshDetectedMarker,
 			"blocked", h.cswshAction.block,
 			"sec_fetch_site", r.Header.Get("Sec-Fetch-Site"),
 			"origin", r.Header.Get("Origin"),

--- a/lib/web/app/websocket.go
+++ b/lib/web/app/websocket.go
@@ -133,6 +133,12 @@ func isCrossOriginWebSocketUpgrade(r *http.Request) bool {
 // (RFC 6455). Both are forbidden header names, so a script cannot forge them on a
 // non-WebSocket request. Both are RFC 7230 comma-separated token lists, so match
 // each as a token rather than by exact value.
+//
+// This detects HTTP/1.1 upgrades only, which is all the app forward path relays
+// (httputil.ReverseProxy switches protocols on a 101 response). HTTP/2 WebSockets
+// (RFC 8441 Extended CONNECT) carry no Connection/Upgrade headers; if WebSocket
+// forwarding over HTTP/2 is ever added, extend this to also match :method=CONNECT
+// with :protocol=websocket.
 func isWebSocketUpgrade(r *http.Request) bool {
 	return headerListContainsToken(r.Header.Get("Connection"), "upgrade") &&
 		headerListContainsToken(r.Header.Get("Upgrade"), "websocket")

--- a/lib/web/app/websocket_test.go
+++ b/lib/web/app/websocket_test.go
@@ -1,0 +1,280 @@
+/*
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package app
+
+import (
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gravitational/trace"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseCSWSHAction(t *testing.T) {
+	for _, tc := range []struct {
+		in            string
+		report, block bool
+	}{
+		{"", false, false},
+		{"off", false, false},
+		{"none", false, false},
+		{"garbage", false, false},
+		{"report", true, false},
+		{"REPORT", true, false},
+		{" report ", true, false},
+		{"block", false, true},
+		{"Block", false, true},
+		{"report-and-block", true, true},
+		{"report_and_block", true, true},
+		{"REPORT-AND-BLOCK", true, true},
+		// Unknown combinations are not parsed loosely; only the exact tokens.
+		{"block,report", false, false},
+		{"report block", false, false},
+	} {
+		t.Run(tc.in, func(t *testing.T) {
+			got := parseCSWSHAction(tc.in)
+			require.Equal(t, tc.report, got.report, "report")
+			require.Equal(t, tc.block, got.block, "block")
+		})
+	}
+}
+
+func TestCSWSHActionEnabled(t *testing.T) {
+	require.False(t, cswshAction{}.enabled())
+	require.True(t, cswshAction{report: true}.enabled())
+	require.True(t, cswshAction{block: true}.enabled())
+	require.True(t, cswshAction{report: true, block: true}.enabled())
+}
+
+func TestHeaderListContainsToken(t *testing.T) {
+	for _, tc := range []struct {
+		header string
+		token  string
+		want   bool
+	}{
+		{"", "upgrade", false},
+		{"upgrade", "upgrade", true},
+		{"Upgrade", "upgrade", true},
+		{"UPGRADE", "upgrade", true},
+		{"keep-alive, Upgrade", "upgrade", true},
+		{"keep-alive,Upgrade", "upgrade", true},
+		{"  upgrade  ", "upgrade", true},
+		{"keep-alive", "upgrade", false},
+		// Token match, not substring.
+		{"upgradeable", "upgrade", false},
+		{"a, b, c", "b", true},
+		{"a, b, c", "d", false},
+	} {
+		t.Run(tc.header+"|"+tc.token, func(t *testing.T) {
+			require.Equal(t, tc.want, headerListContainsToken(tc.header, tc.token))
+		})
+	}
+}
+
+func TestIsWebSocketUpgrade(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		headers map[string]string
+		want    bool
+	}{
+		{
+			name:    "no relevant headers",
+			headers: nil,
+			want:    false,
+		},
+		{
+			name:    "connection upgrade and upgrade websocket",
+			headers: map[string]string{"Connection": "Upgrade", "Upgrade": "websocket"},
+			want:    true,
+		},
+		{
+			name:    "connection list with upgrade",
+			headers: map[string]string{"Connection": "keep-alive, Upgrade", "Upgrade": "websocket"},
+			want:    true,
+		},
+		{
+			name:    "upgrade websocket mixed case",
+			headers: map[string]string{"Connection": "Upgrade", "Upgrade": "WebSocket"},
+			want:    true,
+		},
+		{
+			name:    "connection upgrade without upgrade header",
+			headers: map[string]string{"Connection": "Upgrade"},
+			want:    false,
+		},
+		{
+			name:    "upgrade header without connection",
+			headers: map[string]string{"Upgrade": "websocket"},
+			want:    false,
+		},
+		{
+			name:    "upgrade to non-websocket protocol",
+			headers: map[string]string{"Connection": "Upgrade", "Upgrade": "h2c"},
+			want:    false,
+		},
+		{
+			name:    "upgrade list with websocket first",
+			headers: map[string]string{"Connection": "Upgrade", "Upgrade": "websocket, foo"},
+			want:    true,
+		},
+		{
+			name:    "upgrade list with websocket later",
+			headers: map[string]string{"Connection": "Upgrade", "Upgrade": "foo, websocket"},
+			want:    true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, isWebSocketUpgrade(newWSTestRequest(tc.headers)))
+		})
+	}
+}
+
+func TestIsCrossOriginWebSocketUpgrade(t *testing.T) {
+	originWS := func(origin string) map[string]string {
+		if origin == "" {
+			return nil
+		}
+		return map[string]string{"Origin": origin}
+	}
+
+	for _, tc := range []struct {
+		name    string
+		headers map[string]string
+		want    bool
+	}{
+		{
+			name:    "no origin (non-browser)",
+			headers: originWS(""),
+			want:    false,
+		},
+		{
+			name:    "origin matches host",
+			headers: originWS("https://app.example.com"),
+			want:    false,
+		},
+		{
+			name:    "origin host differs",
+			headers: originWS("https://attacker.example"),
+			want:    true,
+		},
+		{
+			name:    "origin host differs by port",
+			headers: originWS("https://app.example.com:8443"),
+			want:    true,
+		},
+		{
+			name:    "origin scheme differs but host matches",
+			headers: originWS("http://app.example.com"),
+			want:    false,
+		},
+		{
+			name:    "unparseable origin",
+			headers: originWS("://://"),
+			want:    true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, isCrossOriginWebSocketUpgrade(newWSTestRequest(tc.headers)))
+		})
+	}
+}
+
+// TestGuardCrossSiteWebSocket exercises the end-to-end guard decision (detect a
+// WebSocket upgrade, classify its origin, act per the configured action) using
+// realistic handshake headers. It tests the guard directly rather than through
+// the HTTP pipeline because Go's http.Client manages the hop-by-hop Connection
+// header itself and won't deliver a verbatim "Connection: Upgrade".
+func TestGuardCrossSiteWebSocket(t *testing.T) {
+	// A realistic browser WebSocket handshake (Connection/Upgrade, no Sec-Fetch),
+	// carrying the given Origin.
+	ws := func(origin string) map[string]string {
+		h := map[string]string{"Connection": "Upgrade", "Upgrade": "websocket"}
+		if origin != "" {
+			h["Origin"] = origin
+		}
+		return h
+	}
+
+	for _, tc := range []struct {
+		name        string
+		action      cswshAction
+		headers     map[string]string
+		wantBlocked bool
+	}{
+		{
+			name:    "default no-op leaves cross-origin WebSocket alone",
+			action:  cswshAction{},
+			headers: ws("https://attacker.example"),
+		},
+		{
+			name:    "report allows cross-origin WebSocket",
+			action:  cswshAction{report: true},
+			headers: ws("https://attacker.example"),
+		},
+		{
+			name:        "block rejects cross-origin WebSocket",
+			action:      cswshAction{block: true},
+			headers:     ws("https://attacker.example"),
+			wantBlocked: true,
+		},
+		{
+			name:        "report-and-block rejects cross-origin WebSocket",
+			action:      cswshAction{report: true, block: true},
+			headers:     ws("https://attacker.example"),
+			wantBlocked: true,
+		},
+		{
+			name:    "block allows same-origin WebSocket",
+			action:  cswshAction{block: true},
+			headers: ws("https://app.example.com"),
+		},
+		{
+			name:    "block allows non-browser WebSocket with no Origin",
+			action:  cswshAction{block: true},
+			headers: ws(""),
+		},
+		{
+			name:    "block leaves cross-origin non-WebSocket request alone",
+			action:  cswshAction{block: true},
+			headers: map[string]string{"Origin": "https://attacker.example"},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			h := &Handler{logger: slog.Default(), cswshAction: tc.action}
+			err := h.guardCrossSiteWebSocket(newWSTestRequest(tc.headers))
+			if tc.wantBlocked {
+				require.True(t, trace.IsAccessDenied(err), "want AccessDenied, got %v", err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+// newWSTestRequest builds a request to https://app.example.com with the given
+// headers (so r.Host is "app.example.com" for Origin/Host comparisons).
+func newWSTestRequest(headers map[string]string) *http.Request {
+	r := httptest.NewRequest(http.MethodGet, "https://app.example.com/socket", nil)
+	for k, v := range headers {
+		r.Header.Set(k, v)
+	}
+	return r
+}

--- a/lib/web/app/websocket_test.go
+++ b/lib/web/app/websocket_test.go
@@ -181,8 +181,21 @@ func TestIsCrossOriginWebSocketUpgrade(t *testing.T) {
 			want:    true,
 		},
 		{
-			name:    "origin scheme differs but host matches",
+			// A plain-HTTP page on the same host is a foreign origin: its
+			// wss:// handshake still carries the Secure session cookies, so the
+			// scheme mismatch must be treated as cross-origin.
+			name:    "origin scheme differs (http) but host matches",
 			headers: originWS("http://app.example.com"),
+			want:    true,
+		},
+		{
+			name:    "origin scheme differs (ws) but host matches",
+			headers: originWS("ws://app.example.com"),
+			want:    true,
+		},
+		{
+			name:    "origin scheme uppercase https matches",
+			headers: originWS("HTTPS://app.example.com"),
 			want:    false,
 		},
 		{
@@ -245,6 +258,14 @@ func TestGuardCrossSiteWebSocket(t *testing.T) {
 			name:    "block allows same-origin WebSocket",
 			action:  cswshAction{block: true},
 			headers: ws("https://app.example.com"),
+		},
+		{
+			// Plain-HTTP page on the same host (e.g. injected before HSTS is
+			// effective) is a foreign origin and must be blocked.
+			name:        "block rejects same-host cross-scheme (http) WebSocket",
+			action:      cswshAction{block: true},
+			headers:     ws("http://app.example.com"),
+			wantBlocked: true,
 		},
 		{
 			name:    "block allows non-browser WebSocket with no Origin",


### PR DESCRIPTION
<!-- Provide a descriptive entry for the changelog of the next release. -->

Changelog: Added an opt-in guard (`TELEPORT_UNSTABLE_APP_CSWSH_ACTION`) to detect and block cross-site WebSocket hijacking (CSWSH) on the application-access forward path.

Supersedes https://github.com/gravitational/teleport-private/pull/2593

Related: https://github.com/gravitational/pressure-washing/issues/353.

## What

Adds an opt-in guard on the cookie-authenticated application-access forward path that detects cross-origin WebSocket upgrade handshakes and, depending on configuration, logs and/or rejects them.

App session cookies are `SameSite=None`, so a browser attaches them to a cross-site WebSocket handshake. Because the handshake is an HTTP `GET`, it slips past CSRF middleware that exempts safe methods, and unlike a cross-site HTTP read (blocked by the same-origin policy) a hijacked WebSocket is bidirectional — a malicious page could open an authenticated, read/write socket to any Teleport proxied app the victim is logged into. This is cross-site WebSocket hijacking (CSWSH).

## How

Behavior is driven by a single env var, `TELEPORT_UNSTABLE_APP_CSWSH_ACTION`:

| Value | Effect |
| --- | --- |
| unset / unknown | **No-op** (default) — nothing changes |
| `report` | Log cross-origin upgrades, forward as normal |
| `block` | Reject cross-origin upgrades with 403 |
| `report-and-block` | Log and reject |

- **Detection is `Origin`-based.** RFC 6455 §4.1 requires browser clients to send `Origin` on the handshake and §10.2 sanctions rejecting on it; OWASP's WebSocket Security Cheat Sheet likewise makes `Origin` validation the primary CSWSH defense. A script cannot forge it. An upgrade whose `Origin` host differs from the app's host is cross-origin; a non-browser client (no ambient cookies to abuse) sends no `Origin` and passes through. We rely on `Origin` rather than `Sec-Fetch-Site` because browsers do **not** attach `Sec-Fetch-*` to WebSocket handshakes (verified in current Chrome).
- **Any foreign origin is treated as cross-origin.** We do not yet distinguish same-site from cross-site — without `Sec-Fetch-Site` that needs the Public Suffix List, and it's deferred. Practically this means `block` also rejects a legitimate same-site upgrade to a *different host* (e.g. `dashboard.app` → `realtime.app`). That's safe by process: default is no-op, you run `report` first and review the logged `origin`/`host` pairs, and only enable `block` once the set is confirmed hostile (or after a future same-site allowlist lands). Cross-tenant isolation on Teleport Cloud is covered either way — a different tenant is a different host, hence cross-origin.
- **Report emits a greppable marker**, `app_access_cswsh_detected`, with `blocked` (whether the request was rejected — distinguishes `report` from `report-and-block`), `origin`, `host`, `path`, and the raw `sec_fetch_site` (kept as forensic data; usually empty on a browser WebSocket).

Scope is intentionally the cookie/browser forward path (`handleHttp`); the cert- and TCP-based paths carry no ambient browser cookies and are not CSWSH-exposed. Default is a true no-op, so this is zero-risk to ship and can be rolled out report → report-and-block → block.

<!-- Include manual testing efforts to verify the change. -->
<!-- Detail where the tests where run and what configurations were used. -->
<!-- Include all the test cases which were run to validate the change. -->

## Manual Test Plan

### Test Environment

- Teleport cluster with Application Access enabled.
- A proxied app that exposes a WebSocket endpoint (e.g. `app.<proxy>`), reached via the cookie/browser path.
- A victim browser with an active app session (the `__Host-grv_app_session*` cookies set).
- An attacker page served from a **different site/origin** that runs `new WebSocket("wss://app.<proxy>/...")` (the demo POC).
- Proxy run with `TELEPORT_UNSTABLE_APP_CSWSH_ACTION` set per case below; tail proxy logs and grep for `app_access_cswsh_detected`.

### Test Cases

- [x] **Baseline / vuln repro** — unset: attacker-page cross-origin WebSocket handshake completes and messages flow as the victim.
- [x] **`report`** — cross-origin handshake still completes, and a log line with marker `app_access_cswsh_detected`, `blocked=false`, and the attacker `origin` / app `host` is emitted.
- [x] **`block`** — attacker-page cross-origin handshake is rejected (403); the socket never opens; nothing is logged (silent enforcement).
- [x] **`report-and-block`** — handshake rejected (403) **and** the marker is logged with `blocked=true`.
- [x] **Same-origin not broken** — the app's own page opening a WebSocket to its own backend still works under `block`.
- [x] **HTTP CSRF out of scope** — a cross-origin non-WebSocket request (e.g. a `POST`) is still forwarded under `block`.
- [x] **Report data review** — under `report`, confirm the logged `origin`/`host` pairs are all genuinely cross-origin before considering `block` (watch for legitimate same-site different-host apps).
