### PR TITLE
[terraform] Exclude `created_at` and `created_by` from `teleport_lock`

### DIFF
--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/lock.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/lock.mdx
@@ -42,8 +42,6 @@ Optional:
 
 Optional:
 
-- `created_at` (String) CreatedAt is the date time that the lock was created.
-- `created_by` (String) CreatedBy is the username of the author of the lock.
 - `expires` (String) Expires if set specifies when the lock ceases to be in force.
 - `message` (String) Message is the message displayed to locked-out users.
 - `target` (Attributes) Target describes the set of interactions that the lock applies to. (see [below for nested schema](#nested-schema-for-spectarget))

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/lock.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/lock.mdx
@@ -61,8 +61,6 @@ Optional:
 
 Optional:
 
-- `created_at` (String) CreatedAt is the date time that the lock was created.
-- `created_by` (String) CreatedBy is the username of the author of the lock.
 - `expires` (String) Expires if set specifies when the lock ceases to be in force.
 - `message` (String) Message is the message displayed to locked-out users.
 - `target` (Attributes) Target describes the set of interactions that the lock applies to. (see [below for nested schema](#nested-schema-for-spectarget))

--- a/integrations/terraform/protoc-gen-terraform-teleport.yaml
+++ b/integrations/terraform/protoc-gen-terraform-teleport.yaml
@@ -238,6 +238,10 @@ exclude_fields:
     # credentials is excluded intentionally so that we dont have to handle plugin credentials, which are stored separately.
     - "IntegrationV1.Spec.credentials"
     - "IntegrationV1.Spec.GitHub"
+
+    # Lock
+    - "LockV2.Spec.CreatedAt"
+    - "LockV2.Spec.CreatedBy"
     
 name_overrides:
 

--- a/integrations/terraform/testlib/fixtures/lock_1_update.tf
+++ b/integrations/terraform/testlib/fixtures/lock_1_update.tf
@@ -6,8 +6,20 @@ resource "teleport_lock" "test" {
   }
 
   spec = {
+    expires = "2026-12-31T00:00:00Z"
+    message = "example_message"
     target = {
-      user = "eve"
+      access_request  = "example_uuid"
+      bot_instance_id = "example_bot_instance_id"
+      device          = "example_device_id"
+      join_token      = "example_join_token"
+      linux_desktop   = "example_linux_desktop"
+      login           = "example_login"
+      mfa_device      = "example_uuid"
+      role            = "example_role"
+      server_id       = "example_server_id"
+      user            = "eve"
+      windows_desktop = "example_windows_desktop"
     }
   }
 }

--- a/integrations/terraform/testlib/lock_test.go
+++ b/integrations/terraform/testlib/lock_test.go
@@ -29,9 +29,6 @@ import (
 )
 
 func (s *TerraformSuiteOSS) TestLock() {
-	// TODO: `spec.created_at` and `spec.created_by` should be excluded from spec.
-	s.T().Skip("After applying this test step, the plan was not empty")
-
 	ctx, cancel := context.WithCancel(context.Background())
 	s.T().Cleanup(cancel)
 
@@ -55,7 +52,24 @@ func (s *TerraformSuiteOSS) TestLock() {
 				Config: s.getFixture("lock_0_create.tf"),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(name, "kind", "lock"),
+					resource.TestCheckResourceAttr(name, "metadata.name", "test"),
+					resource.TestCheckResourceAttr(name, "metadata.namespace", "default"),
+					resource.TestCheckResourceAttr(name, "metadata.description", "Ongoing incident investigation."),
+					resource.TestCheckResourceAttr(name, "spec.message", ""),
+					resource.TestCheckResourceAttr(name, "spec.target.access_request", ""),
+					resource.TestCheckResourceAttr(name, "spec.target.bot_instance_id", ""),
+					resource.TestCheckResourceAttr(name, "spec.target.device", ""),
+					resource.TestCheckResourceAttr(name, "spec.target.join_token", ""),
+					resource.TestCheckResourceAttr(name, "spec.target.linux_desktop", ""),
+					resource.TestCheckResourceAttr(name, "spec.target.login", ""),
+					resource.TestCheckResourceAttr(name, "spec.target.mfa_device", ""),
+					resource.TestCheckResourceAttr(name, "spec.target.role", ""),
+					resource.TestCheckResourceAttr(name, "spec.target.server_id", ""),
 					resource.TestCheckResourceAttr(name, "spec.target.user", "john"),
+					resource.TestCheckResourceAttr(name, "spec.target.windows_desktop", ""),
+
+					resource.TestCheckNoResourceAttr(name, "spec.created_at"),
+					resource.TestCheckNoResourceAttr(name, "spec.created_by"),
 				),
 			},
 			{
@@ -66,7 +80,19 @@ func (s *TerraformSuiteOSS) TestLock() {
 				Config: s.getFixture("lock_1_update.tf"),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(name, "kind", "lock"),
+					resource.TestCheckResourceAttr(name, "spec.expires", "2026-12-31T00:00:00Z"),
+					resource.TestCheckResourceAttr(name, "spec.message", "example_message"),
+					resource.TestCheckResourceAttr(name, "spec.target.access_request", "example_uuid"),
+					resource.TestCheckResourceAttr(name, "spec.target.bot_instance_id", "example_bot_instance_id"),
+					resource.TestCheckResourceAttr(name, "spec.target.device", "example_device_id"),
+					resource.TestCheckResourceAttr(name, "spec.target.join_token", "example_join_token"),
+					resource.TestCheckResourceAttr(name, "spec.target.linux_desktop", "example_linux_desktop"),
+					resource.TestCheckResourceAttr(name, "spec.target.login", "example_login"),
+					resource.TestCheckResourceAttr(name, "spec.target.mfa_device", "example_uuid"),
+					resource.TestCheckResourceAttr(name, "spec.target.role", "example_role"),
+					resource.TestCheckResourceAttr(name, "spec.target.server_id", "example_server_id"),
 					resource.TestCheckResourceAttr(name, "spec.target.user", "eve"),
+					resource.TestCheckResourceAttr(name, "spec.target.windows_desktop", "example_windows_desktop"),
 				),
 			},
 			{
@@ -131,9 +157,6 @@ func (s *TerraformSuiteOSS) TestImportLock() {
 }
 
 func (s *TerraformSuiteOSSWithCache) TestLockWithCache() {
-	// TODO: `spec.created_at` and `spec.created_by` should be excluded from spec.
-	s.T().Skip("After applying this test step, the plan was not empty")
-
 	ctx, cancel := context.WithCancel(context.Background())
 	s.T().Cleanup(cancel)
 	checkDestroyed := func(state *terraform.State) error {

--- a/integrations/terraform/tfschema/types_terraform.go
+++ b/integrations/terraform/tfschema/types_terraform.go
@@ -6908,20 +6908,6 @@ func GenSchemaLockV2(ctx context.Context) (github_com_hashicorp_terraform_plugin
 		},
 		"spec": {
 			Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.SingleNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
-				"created_at": {
-					Computed:      true,
-					Description:   "CreatedAt is the date time that the lock was created.",
-					Optional:      true,
-					PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributePlanModifier{github_com_hashicorp_terraform_plugin_framework_tfsdk.UseStateForUnknown()},
-					Type:          UseRFC3339Time(),
-				},
-				"created_by": {
-					Computed:      true,
-					Description:   "CreatedBy is the username of the author of the lock.",
-					Optional:      true,
-					PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributePlanModifier{github_com_hashicorp_terraform_plugin_framework_tfsdk.UseStateForUnknown()},
-					Type:          github_com_hashicorp_terraform_plugin_framework_types.StringType,
-				},
 				"expires": {
 					Description: "Expires if set specifies when the lock ceases to be in force.",
 					Optional:    true,
@@ -57597,40 +57583,6 @@ func CopyLockV2FromTerraform(_ context.Context, tf github_com_hashicorp_terrafor
 							}
 						}
 					}
-					{
-						a, ok := tf.Attrs["created_at"]
-						if !ok {
-							diags.Append(attrReadMissingDiag{"LockV2.Spec.CreatedAt"})
-						} else {
-							v, ok := a.(TimeValue)
-							if !ok {
-								diags.Append(attrReadConversionFailureDiag{"LockV2.Spec.CreatedAt", "TimeValue"})
-							} else {
-								var t time.Time
-								if !v.Null && !v.Unknown {
-									t = time.Time(v.Value)
-								}
-								obj.CreatedAt = t
-							}
-						}
-					}
-					{
-						a, ok := tf.Attrs["created_by"]
-						if !ok {
-							diags.Append(attrReadMissingDiag{"LockV2.Spec.CreatedBy"})
-						} else {
-							v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.String)
-							if !ok {
-								diags.Append(attrReadConversionFailureDiag{"LockV2.Spec.CreatedBy", "github.com/hashicorp/terraform-plugin-framework/types.String"})
-							} else {
-								var t string
-								if !v.Null && !v.Unknown {
-									t = string(v.Value)
-								}
-								obj.CreatedBy = t
-							}
-						}
-					}
 				}
 			}
 		}
@@ -58309,58 +58261,6 @@ func CopyLockV2ToTerraform(ctx context.Context, obj *github_com_gravitational_te
 							}
 							v.Unknown = false
 							tf.Attrs["expires"] = v
-						}
-					}
-					{
-						t, ok := tf.AttrTypes["created_at"]
-						if !ok {
-							diags.Append(attrWriteMissingDiag{"LockV2.Spec.CreatedAt"})
-						} else {
-							v, ok := tf.Attrs["created_at"].(TimeValue)
-							if !ok {
-								if tf.Attrs["created_at"] != nil {
-									diags.Append(attrWriteUnexpectedExistingTypeDiag{"LockV2.Spec.CreatedAt", "TimeValue"})
-								}
-								i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
-								if err != nil {
-									diags.Append(attrWriteGeneralError{"LockV2.Spec.CreatedAt", err})
-								}
-								v, ok = i.(TimeValue)
-								if !ok {
-									diags.Append(attrWriteConversionFailureDiag{"LockV2.Spec.CreatedAt", "TimeValue"})
-								}
-							}
-
-							v.Null = false
-							v.Value = time.Time(obj.CreatedAt)
-							v.Unknown = false
-							tf.Attrs["created_at"] = v
-						}
-					}
-					{
-						t, ok := tf.AttrTypes["created_by"]
-						if !ok {
-							diags.Append(attrWriteMissingDiag{"LockV2.Spec.CreatedBy"})
-						} else {
-							v, ok := tf.Attrs["created_by"].(github_com_hashicorp_terraform_plugin_framework_types.String)
-							if !ok {
-								if tf.Attrs["created_by"] != nil {
-									diags.Append(attrWriteUnexpectedExistingTypeDiag{"LockV2.Spec.CreatedBy", "github.com/hashicorp/terraform-plugin-framework/types.String"})
-								}
-								i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
-								if err != nil {
-									diags.Append(attrWriteGeneralError{"LockV2.Spec.CreatedBy", err})
-								}
-								v, ok = i.(github_com_hashicorp_terraform_plugin_framework_types.String)
-								if !ok {
-									diags.Append(attrWriteConversionFailureDiag{"LockV2.Spec.CreatedBy", "github.com/hashicorp/terraform-plugin-framework/types.String"})
-								}
-							}
-
-							v.Null = false
-							v.Value = string(obj.CreatedBy)
-							v.Unknown = false
-							tf.Attrs["created_by"] = v
 						}
 					}
 				}


### PR DESCRIPTION
Supports https://github.com/gravitational/teleport/issues/66912

This is a follow up to https://github.com/gravitational/teleport/pull/67294. `spec.created_at` and `spec.created_by` are managed by Teleport and cannot be configured by users. This makes them incompatible with the new plan modifier and results in perpetual drift if left as is.

To address the issue, this PR excludes `spec.created_at` and `spec.created_by` from the `teleport_lock` resource.

Note that after updating the TF provider users may see a "unsupported attribute" error when reading the state. 
The error will go away once TF state is refreshed the next time `terraform apply` or `terraform refresh` is run.

```sh
❯ terraform show
Failed to marshal state to json: unsupported attribute "created_at"%
```

<!-- Provide a descriptive entry for the changelog of the next release. -->

Changelog: The `spec.created_by` and `spec.created_by` attributes are now excluded from the `teleport_lock` Terraform resource.

<!-- Include manual testing efforts to verify the change. -->
<!-- Detail where the tests where run and what configurations were used. -->
<!-- Include all the test cases which were run to validate the change. -->

## Manual Test Plan
### Test Environment
Local cluster environment

### Test Cases
- [x] Create `teleport_lock` and verify `spec.created_at` and `spec.created_by` are excluded from TF state.
- [x] Test TF provider update by running `terraform plan`, `terraform apply` and `terraform show` after updating the provider with a `teleport_lock` in state.
