### PR TITLE
[v17] Fix error in List calls terminating iteration too early on failure

### DIFF
--- a/lib/services/local/access.go
+++ b/lib/services/local/access.go
@@ -33,6 +33,7 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/backend"
 	"github.com/gravitational/teleport/lib/services"
+	logutils "github.com/gravitational/teleport/lib/utils/log"
 )
 
 // AccessService manages roles
@@ -351,34 +352,45 @@ func (s *AccessService) ListLocks(ctx context.Context, limit int, start string, 
 
 	startKey := backend.NewKey(locksPrefix, start)
 	endKey := backend.RangeEnd(backend.NewKey(locksPrefix))
-	result, err := s.GetRange(ctx, startKey, endKey, limit+1)
-	if err != nil {
+
+	out := make([]types.Lock, 0, limit)
+	var nextPage string
+
+	if err := backend.IterateRange(
+		ctx,
+		s,
+		startKey,
+		endKey,
+		limit+1,
+		func(items []backend.Item) (bool, error) {
+			for _, item := range items {
+				lock, err := services.UnmarshalLock(item.Value,
+					services.WithRevision(item.Revision),
+					services.WithExpires(item.Expires))
+				if err != nil {
+					slog.WarnContext(ctx, "Failed to unmarshal lock",
+						"key", logutils.StringerAttr(item.Key),
+						"error", err)
+					continue
+				}
+
+				if _, match := matchLock(lock, filter, s.Clock().Now()); !match {
+					continue
+				}
+
+				if len(out) >= limit {
+					nextPage = lock.GetName()
+					return true, nil
+				} else {
+					out = append(out, lock)
+				}
+			}
+			return false, nil
+		}); err != nil {
 		return nil, "", trace.Wrap(err)
 	}
 
-	out := make([]types.Lock, 0, len(result.Items))
-	for _, item := range result.Items {
-		lock, err := services.UnmarshalLock(item.Value,
-			services.WithExpires(item.Expires),
-			services.WithRevision(item.Revision))
-		if err != nil {
-			slog.WarnContext(ctx, "Failed to unmarshal lock",
-				"key", item.Key,
-				"error", err)
-			continue
-		}
-
-		if len(out) >= limit {
-			return out, lock.GetName(), nil
-		}
-
-		if _, match := matchLock(lock, filter, s.Clock().Now()); !match {
-			continue
-		}
-
-		out = append(out, lock)
-	}
-	return out, "", nil
+	return out, nextPage, nil
 }
 
 // UpsertLock upserts a lock.

--- a/lib/services/local/access_test.go
+++ b/lib/services/local/access_test.go
@@ -20,6 +20,7 @@ package local
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -31,6 +32,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/backend"
 	"github.com/gravitational/teleport/lib/backend/memory"
 )
 
@@ -482,4 +484,77 @@ func Test_matchLock(t *testing.T) {
 			require.Equal(t, tt.want, got)
 		})
 	}
+}
+
+// TestListLocks_SkipsUnmarshalErrorsHittingPageBoundary guards against a regression where hitting a page boundary with a malformed backend item would
+// return less items than the page limit and no next token. This would cause callers to miss resources and fail to paginate properly when malformed items are present in the backend.
+func TestListLocks_SkipsUnmarshalErrorsHittingPageBoundary(t *testing.T) {
+	ctx := t.Context()
+
+	const pageLimit = 64
+	const numberOfPages = 5
+
+	clock := clockwork.NewFakeClock()
+	mem, err := memory.New(memory.Config{
+		Context: t.Context(),
+		Clock:   clock,
+	})
+	require.NoError(t, err)
+
+	service := NewAccessService(mem)
+	expireTime := clock.Now().Add(1 * time.Hour)
+
+	var allExpected []types.Lock
+
+	createResource := func(name string) {
+		lock, err := types.NewLock(name, types.LockSpecV2{
+			Target: types.LockTarget{
+				User: "user-A",
+			},
+			Expires: &expireTime,
+		})
+		require.NoError(t, err)
+		err = service.UpsertLock(ctx, lock)
+		require.NoError(t, err)
+		allExpected = append(allExpected, lock)
+
+	}
+
+	createMalformedEntry := func(name string) {
+		_, err := mem.Put(ctx, backend.Item{
+			Key:   backend.NewKey(locksPrefix, name),
+			Value: []byte("not-valid-json"),
+		})
+		require.NoError(t, err)
+	}
+
+	for i := range pageLimit * numberOfPages {
+		key := fmt.Sprintf("r%d", i)
+		if i%2 == 0 {
+			createMalformedEntry(key)
+		} else {
+			createResource(key)
+		}
+	}
+
+	page1, next, err := service.ListLocks(ctx, pageLimit, "", nil)
+	require.NoError(t, err)
+	require.Len(t, page1, pageLimit)
+	require.NotEmpty(t, next)
+
+	page2, next, err := service.ListLocks(ctx, pageLimit, next, nil)
+	require.NoError(t, err)
+	require.Len(t, page2, pageLimit)
+	require.NotEmpty(t, next)
+
+	page3, next, err := service.ListLocks(ctx, pageLimit, next, nil)
+	require.NoError(t, err)
+	require.Len(t, page3, pageLimit/2)
+	require.Empty(t, next)
+
+	allActual := append(append(page1, page2...), page3...)
+	require.Empty(t, cmp.Diff(allExpected, allActual,
+		cmpopts.IgnoreFields(types.Metadata{}, "Revision"),
+		cmpopts.SortSlices(func(a, b types.Lock) bool { return a.GetName() < b.GetName() }),
+	))
 }

--- a/lib/services/local/apps.go
+++ b/lib/services/local/apps.go
@@ -20,6 +20,7 @@ package local
 
 import (
 	"context"
+	"log/slog"
 
 	"github.com/gravitational/trace"
 
@@ -27,6 +28,7 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/backend"
 	"github.com/gravitational/teleport/lib/services"
+	logutils "github.com/gravitational/teleport/lib/utils/log"
 )
 
 // AppService manages application resources in the backend.
@@ -40,34 +42,50 @@ func NewAppService(backend backend.Backend) *AppService {
 }
 
 // ListApps returns a page of application resources.
-func (s *AppService) ListApps(ctx context.Context, limit int, startKey string) ([]types.Application, string, error) {
+func (s *AppService) ListApps(ctx context.Context, limit int, pageToken string) ([]types.Application, string, error) {
 	// Adjust page size, so it can't be too large.
 	if limit <= 0 || limit > defaults.DefaultChunkSize {
 		limit = defaults.DefaultChunkSize
 	}
 
 	appKey := backend.NewKey(appPrefix)
-	var out []types.Application
-	result, err := s.Backend.GetRange(ctx, appKey.AppendKey(backend.KeyFromString(startKey)), backend.RangeEnd(appKey), limit+1)
-	if err != nil {
+	startKey := appKey.AppendKey(backend.KeyFromString(pageToken))
+	endKey := backend.RangeEnd(appKey)
+
+	out := make([]types.Application, 0, limit)
+	var nextPage string
+
+	if err := backend.IterateRange(
+		ctx,
+		s.Backend,
+		startKey,
+		endKey,
+		limit+1,
+		func(items []backend.Item) (bool, error) {
+			for _, item := range items {
+				app, err := services.UnmarshalApp(item.Value,
+					services.WithRevision(item.Revision),
+					services.WithExpires(item.Expires))
+				if err != nil {
+					slog.WarnContext(ctx, "Failed to unmarshal app",
+						"key", logutils.StringerAttr(item.Key),
+						"error", err)
+					continue
+				}
+
+				if len(out) >= limit {
+					nextPage = app.GetName()
+					return true, nil
+				} else {
+					out = append(out, app)
+				}
+			}
+			return false, nil
+		}); err != nil {
 		return nil, "", trace.Wrap(err)
 	}
 
-	for _, item := range result.Items {
-		app, err := services.UnmarshalApp(item.Value,
-			services.WithExpires(item.Expires), services.WithRevision(item.Revision))
-		if err != nil {
-			continue
-		}
-
-		if len(out) >= limit {
-			return out, app.GetName(), nil
-		}
-
-		out = append(out, app)
-	}
-
-	return out, "", nil
+	return out, nextPage, nil
 }
 
 // GetApps returns all application resources.

--- a/lib/services/local/apps_test.go
+++ b/lib/services/local/apps_test.go
@@ -21,6 +21,7 @@ package local
 import (
 	"cmp"
 	"context"
+	"fmt"
 	"slices"
 	"strconv"
 	"testing"
@@ -33,6 +34,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/backend"
 	"github.com/gravitational/teleport/lib/backend/memory"
 )
 
@@ -188,5 +190,76 @@ func TestAppsCRUD(t *testing.T) {
 	listed := append(page1, page2...)
 	assert.Empty(t, gocmp.Diff(expected, listed,
 		cmpopts.IgnoreFields(types.Metadata{}, "Revision"),
+	))
+}
+
+// TestListApps_SkipsUnmarshalErrorsHittingPageBoundary guards against a regression where hitting a page boundary with a malformed backend item would
+// return less items than the page limit and no next token. This would cause callers to miss resources and fail to paginate properly when malformed items are present in the backend.
+func TestListApps_SkipsUnmarshalErrorsHittingPageBoundary(t *testing.T) {
+	ctx := t.Context()
+
+	const pageLimit = 64
+	const numberOfPages = 5
+
+	clock := clockwork.NewFakeClock()
+	mem, err := memory.New(memory.Config{
+		Context: t.Context(),
+		Clock:   clock,
+	})
+	require.NoError(t, err)
+
+	service := NewAppService(mem)
+
+	var allExpected []types.Application
+
+	createResource := func(name string) {
+		app, err := types.NewAppV3(types.Metadata{
+			Name: name,
+		}, types.AppSpecV3{
+			URI: "localhost1",
+		})
+		require.NoError(t, err)
+		err = service.CreateApp(ctx, app)
+		require.NoError(t, err)
+		allExpected = append(allExpected, app)
+
+	}
+
+	createMalformedEntry := func(name string) {
+		_, err := mem.Put(ctx, backend.Item{
+			Key:   backend.NewKey(appPrefix, name),
+			Value: []byte("not-valid-json"),
+		})
+		require.NoError(t, err)
+	}
+
+	for i := range pageLimit * numberOfPages {
+		key := fmt.Sprintf("r%d", i)
+		if i%2 == 0 {
+			createMalformedEntry(key)
+		} else {
+			createResource(key)
+		}
+	}
+
+	page1, next, err := service.ListApps(ctx, pageLimit, "")
+	require.NoError(t, err)
+	require.Len(t, page1, pageLimit)
+	require.NotEmpty(t, next)
+
+	page2, next, err := service.ListApps(ctx, pageLimit, next)
+	require.NoError(t, err)
+	require.Len(t, page2, pageLimit)
+	require.NotEmpty(t, next)
+
+	page3, next, err := service.ListApps(ctx, pageLimit, next)
+	require.NoError(t, err)
+	require.Len(t, page3, pageLimit/2)
+	require.Empty(t, next)
+
+	allActual := append(append(page1, page2...), page3...)
+	require.Empty(t, gocmp.Diff(allExpected, allActual,
+		cmpopts.IgnoreFields(types.Metadata{}, "Revision"),
+		cmpopts.SortSlices(func(a, b types.Application) bool { return a.GetName() < b.GetName() }),
 	))
 }

--- a/lib/services/local/databases.go
+++ b/lib/services/local/databases.go
@@ -29,6 +29,7 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/backend"
 	"github.com/gravitational/teleport/lib/services"
+	logutils "github.com/gravitational/teleport/lib/utils/log"
 )
 
 // DatabaseService manages database resources in the backend.
@@ -65,39 +66,49 @@ func (s *DatabaseService) GetDatabases(ctx context.Context) ([]types.Database, e
 }
 
 // ListDatabases returns a page of database resources.
-func (s *DatabaseService) ListDatabases(ctx context.Context, limit int, startKey string) ([]types.Database, string, error) {
+func (s *DatabaseService) ListDatabases(ctx context.Context, limit int, pageToken string) ([]types.Database, string, error) {
 	// Adjust page size, so it can't be too large.
 	if limit <= 0 || limit > defaults.DefaultChunkSize {
 		limit = defaults.DefaultChunkSize
 	}
 
 	dbKey := backend.NewKey(databasesPrefix)
-	var out []types.Database
-	result, err := s.Backend.GetRange(ctx, dbKey.AppendKey(backend.KeyFromString(startKey)), backend.RangeEnd(dbKey), limit+1)
-	if err != nil {
+	startKey := dbKey.AppendKey(backend.KeyFromString(pageToken))
+	endKey := backend.RangeEnd(dbKey)
+	out := make([]types.Database, 0, limit)
+	var nextPage string
+
+	if err := backend.IterateRange(
+		ctx,
+		s.Backend,
+		startKey,
+		endKey,
+		limit+1,
+		func(items []backend.Item) (bool, error) {
+			for _, item := range items {
+				db, err := services.UnmarshalDatabase(item.Value,
+					services.WithRevision(item.Revision),
+					services.WithExpires(item.Expires))
+				if err != nil {
+					s.logger.WarnContext(ctx, "Failed to unmarshal database",
+						"key", logutils.StringerAttr(item.Key),
+						"error", err)
+					continue
+				}
+
+				if len(out) >= limit {
+					nextPage = db.GetName()
+					return true, nil
+				} else {
+					out = append(out, db)
+				}
+			}
+			return false, nil
+		}); err != nil {
 		return nil, "", trace.Wrap(err)
 	}
 
-	for _, item := range result.Items {
-		db, err := services.UnmarshalDatabase(item.Value,
-			services.WithExpires(item.Expires),
-			services.WithRevision(item.Revision))
-		if err != nil {
-			s.logger.WarnContext(ctx, "Failed to unmarshal database",
-				"key", item.Key,
-				"error", err,
-			)
-			continue
-		}
-
-		if len(out) >= limit {
-			return out, db.GetName(), nil
-		}
-
-		out = append(out, db)
-	}
-
-	return out, "", nil
+	return out, nextPage, nil
 }
 
 // GetDatabase returns the specified database resource.

--- a/lib/services/local/databases_test.go
+++ b/lib/services/local/databases_test.go
@@ -21,6 +21,7 @@ package local
 import (
 	"cmp"
 	"context"
+	"fmt"
 	"slices"
 	"strconv"
 	"testing"
@@ -33,6 +34,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/backend"
 	"github.com/gravitational/teleport/lib/backend/memory"
 	"github.com/gravitational/teleport/lib/defaults"
 )
@@ -201,4 +203,76 @@ func TestDatabasesCRUD(t *testing.T) {
 		cmpopts.IgnoreFields(types.Metadata{}, "Revision"),
 	))
 
+}
+
+// TestListDatabases_SkipsUnmarshalErrorsHittingPageBoundary guards against a regression where hitting a page boundary with a malformed backend item would
+// return less items than the page limit and no next token. This would cause callers to miss resources and fail to paginate properly when malformed items are present in the backend.
+func TestListDatabases_SkipsUnmarshalErrorsHittingPageBoundary(t *testing.T) {
+	ctx := t.Context()
+
+	const pageLimit = 64
+	const numberOfPages = 5
+
+	clock := clockwork.NewFakeClock()
+	mem, err := memory.New(memory.Config{
+		Context: t.Context(),
+		Clock:   clock,
+	})
+	require.NoError(t, err)
+
+	service := NewDatabasesService(mem)
+
+	var allExpected []types.Database
+
+	createResource := func(name string) {
+		db, err := types.NewDatabaseV3(types.Metadata{
+			Name: name,
+		}, types.DatabaseSpecV3{
+			Protocol: defaults.ProtocolPostgres,
+			URI:      "localhost:5432",
+		})
+		require.NoError(t, err)
+		err = service.CreateDatabase(ctx, db)
+		require.NoError(t, err)
+		allExpected = append(allExpected, db)
+
+	}
+
+	createMalformedEntry := func(name string) {
+		_, err := mem.Put(ctx, backend.Item{
+			Key:   backend.NewKey(databasesPrefix, name),
+			Value: []byte("not-valid-json"),
+		})
+		require.NoError(t, err)
+	}
+
+	for i := range pageLimit * numberOfPages {
+		key := fmt.Sprintf("r%d", i)
+		if i%2 == 0 {
+			createMalformedEntry(key)
+		} else {
+			createResource(key)
+		}
+	}
+
+	page1, next, err := service.ListDatabases(ctx, pageLimit, "")
+	require.NoError(t, err)
+	require.Len(t, page1, pageLimit)
+	require.NotEmpty(t, next)
+
+	page2, next, err := service.ListDatabases(ctx, pageLimit, next)
+	require.NoError(t, err)
+	require.Len(t, page2, pageLimit)
+	require.NotEmpty(t, next)
+
+	page3, next, err := service.ListDatabases(ctx, pageLimit, next)
+	require.NoError(t, err)
+	require.Len(t, page3, pageLimit/2)
+	require.Empty(t, next)
+
+	allActual := append(append(page1, page2...), page3...)
+	require.Empty(t, gocmp.Diff(allExpected, allActual,
+		cmpopts.IgnoreFields(types.Metadata{}, "Revision"),
+		cmpopts.SortSlices(func(a, b types.Database) bool { return a.GetName() < b.GetName() }),
+	))
 }

--- a/lib/services/local/generic/generic.go
+++ b/lib/services/local/generic/generic.go
@@ -20,6 +20,7 @@ package generic
 
 import (
 	"context"
+	"log/slog"
 	"strings"
 	"time"
 
@@ -29,6 +30,7 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/backend"
 	"github.com/gravitational/teleport/lib/services"
+	logutils "github.com/gravitational/teleport/lib/utils/log"
 )
 
 // Resource represents a Teleport resource that may be generically
@@ -211,36 +213,37 @@ func (s *Service[T]) listResourcesReturnNextResourceWithKey(ctx context.Context,
 		pageSize = int(s.pageLimit)
 	}
 
-	limit := pageSize + 1
+	out := make([]T, 0, pageSize)
+	var next *T
+	var nextKey string
 
-	// no filter provided get the range directly
-	result, err := s.backend.GetRange(ctx, rangeStart, rangeEnd, limit)
-	if err != nil {
+	if err := backend.IterateRange(
+		ctx,
+		s.backend,
+		rangeStart,
+		rangeEnd,
+		pageSize+1,
+		func(items []backend.Item) (bool, error) {
+			for _, item := range items {
+				resource, err := s.unmarshalFunc(item.Value,
+					services.WithRevision(item.Revision),
+					services.WithExpires(item.Expires))
+				if err != nil {
+					slog.WarnContext(ctx, "skipping resource due to unmarshal error", "error", err, "key", logutils.StringerAttr(item.Key))
+					continue
+				}
+
+				if len(out) >= pageSize {
+					next = &resource
+					nextKey = strings.TrimPrefix(item.Key.TrimPrefix(s.backendPrefix).String(), string(backend.Separator))
+					return true, nil
+				} else {
+					out = append(out, resource)
+				}
+			}
+			return false, nil
+		}); err != nil {
 		return nil, nil, "", trace.Wrap(err)
-	}
-
-	out := make([]T, 0, len(result.Items))
-	var lastKey backend.Key
-	for _, item := range result.Items {
-		resource, err := s.unmarshalFunc(item.Value,
-			services.WithRevision(item.Revision),
-			services.WithExpires(item.Expires))
-		if err != nil {
-			return nil, nil, "", trace.Wrap(err)
-		}
-		out = append(out, resource)
-		lastKey = item.Key
-	}
-
-	var (
-		next    *T
-		nextKey string
-	)
-	if len(out) > pageSize {
-		next = &out[pageSize]
-		// Truncate the last item that was used to determine next row existence.
-		out = out[:pageSize]
-		nextKey = strings.TrimPrefix(lastKey.TrimPrefix(s.backendPrefix).String(), string(backend.Separator))
 	}
 
 	return out, next, nextKey, nil
@@ -264,13 +267,14 @@ func (s *Service[T]) ListResourcesWithFilter(ctx context.Context, pageSize int, 
 		rangeStart,
 		rangeEnd,
 		pageSize+1,
-		func(items []backend.Item) (stop bool, err error) {
+		func(items []backend.Item) (bool, error) {
 			for _, item := range items {
 				resource, err := s.unmarshalFunc(item.Value,
 					services.WithRevision(item.Revision),
 					services.WithExpires(item.Expires))
 				if err != nil {
-					return false, trace.Wrap(err)
+					slog.WarnContext(ctx, "skipping resource due to unmarshal error", "error", err, "key", logutils.StringerAttr(item.Key))
+					continue
 				}
 				if matcher(resource) {
 					lastKey = item.Key

--- a/lib/services/local/generic/generic_test.go
+++ b/lib/services/local/generic/generic_test.go
@@ -687,3 +687,83 @@ func TestGenericKeyOverride(t *testing.T) {
 	_, err = memBackend.Get(ctx, backend.NewKey("generic_prefix", "llama"))
 	require.ErrorAs(t, err, new(*trace.NotFoundError))
 }
+
+// TestResourcesSkipsUnmarshalErrorsHittingPageBoundary guards against a regression where hitting a page boundary with a malformed backend item would
+// return less items than the page limit and no next token. This would cause callers to miss resources and fail to paginate properly when malformed items are present in the backend.
+func TestResourcesSkipsUnmarshalErrorsHittingPageBoundary(t *testing.T) {
+	ctx := t.Context()
+
+	memBackend, err := memory.New(memory.Config{
+		Context: ctx,
+		Clock:   clockwork.NewFakeClock(),
+	})
+	require.NoError(t, err)
+
+	const pageLimit = 64
+	const numberOfPages = 5
+	service, err := NewService(&ServiceConfig[*testResource]{
+		Backend:       memBackend,
+		ResourceKind:  "generic resource",
+		PageLimit:     pageLimit,
+		BackendPrefix: backend.NewKey("generic_prefix"),
+		UnmarshalFunc: unmarshalResource,
+		MarshalFunc:   marshalResource,
+	})
+	require.NoError(t, err)
+	var allExpected []*testResource
+	for i := range pageLimit * numberOfPages {
+		key := fmt.Sprintf("r%05d", i)
+		if i%2 == 0 {
+			_, err = memBackend.Put(ctx, backend.Item{
+				Key:   service.MakeKey(backend.NewKey(key)),
+				Value: []byte("not-valid-json"),
+			})
+			require.NoError(t, err)
+		} else {
+			r := newTestResource(key)
+			_, err = service.CreateResource(ctx, r)
+			require.NoError(t, err)
+			allExpected = append(allExpected, r)
+		}
+	}
+
+	page1, next, err := service.ListResources(ctx, pageLimit, "")
+	require.NoError(t, err)
+	require.Len(t, page1, pageLimit)
+	require.NotEmpty(t, next)
+
+	page2, next, err := service.ListResources(ctx, pageLimit, next)
+	require.NoError(t, err)
+	require.Len(t, page2, pageLimit)
+	require.NotEmpty(t, next)
+
+	page3, next, err := service.ListResources(ctx, pageLimit, next)
+	require.NoError(t, err)
+	require.Len(t, page3, pageLimit/2)
+	require.Empty(t, next)
+
+	// Ensure pagination with unmarshal fails works the same way for ListResourcesWithFilter
+	allActual := append(append(page1, page2...), page3...)
+	require.Empty(t, cmp.Diff(allExpected, allActual, cmpopts.IgnoreFields(types.Metadata{}, "Revision")))
+
+	matchAll := func(tr *testResource) bool { return true }
+	page1, next, err = service.ListResourcesWithFilter(ctx, pageLimit, "", matchAll)
+	require.NoError(t, err)
+	require.Len(t, page1, pageLimit)
+	require.NotEmpty(t, next)
+
+	page2, next, err = service.ListResourcesWithFilter(ctx, pageLimit, next, matchAll)
+	require.NoError(t, err)
+	require.Len(t, page2, pageLimit)
+	require.NotEmpty(t, next)
+
+	page3, next, err = service.ListResourcesWithFilter(ctx, pageLimit, next, matchAll)
+	require.NoError(t, err)
+	require.Len(t, page3, pageLimit/2)
+	require.Empty(t, next)
+
+	allActual = append(append(page1, page2...), page3...)
+	require.Empty(t, cmp.Diff(allExpected, allActual,
+		cmpopts.IgnoreFields(types.Metadata{}, "Revision"),
+	))
+}

--- a/lib/services/local/kube.go
+++ b/lib/services/local/kube.go
@@ -29,6 +29,7 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/backend"
 	"github.com/gravitational/teleport/lib/services"
+	logutils "github.com/gravitational/teleport/lib/utils/log"
 )
 
 // KubernetesService manages kubernetes resources in the backend.
@@ -75,35 +76,40 @@ func (s *KubernetesService) ListKubernetesClusters(ctx context.Context, limit in
 	startKey := kubernetesKey.AppendKey(backend.KeyFromString(start))
 	endKey := backend.RangeEnd(kubernetesKey)
 
-	result, err := s.Backend.GetRange(ctx, startKey, endKey, limit+1)
-	if err != nil {
+	out := make([]types.KubeCluster, 0, limit)
+	var nextPage string
+
+	if err := backend.IterateRange(
+		ctx,
+		s.Backend,
+		startKey,
+		endKey,
+		limit+1,
+		func(items []backend.Item) (bool, error) {
+			for _, item := range items {
+				kube, err := services.UnmarshalKubeCluster(item.Value,
+					services.WithRevision(item.Revision),
+					services.WithExpires(item.Expires))
+				if err != nil {
+					slog.WarnContext(ctx, "Failed to unmarshal kubernetes cluster",
+						"key", logutils.StringerAttr(item.Key),
+						"error", err)
+					continue
+				}
+
+				if len(out) >= limit {
+					nextPage = kube.GetName()
+					return true, nil
+				} else {
+					out = append(out, kube)
+				}
+			}
+			return false, nil
+		}); err != nil {
 		return nil, "", trace.Wrap(err)
 	}
 
-	out := make([]types.KubeCluster, 0, len(result.Items))
-
-	for _, item := range result.Items {
-		cluster, err := services.UnmarshalKubeCluster(item.Value,
-			services.WithExpires(item.Expires),
-			services.WithRevision(item.Revision))
-
-		if err != nil {
-			s.logger.WarnContext(ctx, "Failed to unmarshal kubernetes cluster",
-				"key", item.Key,
-				"error", err,
-			)
-
-			continue
-		}
-
-		if len(out) >= limit {
-			return out, cluster.GetName(), nil
-		}
-
-		out = append(out, cluster)
-	}
-
-	return out, "", nil
+	return out, nextPage, nil
 }
 
 // GetKubernetesCluster returns the specified kubernetes cluster resource.

--- a/lib/services/local/kube_test.go
+++ b/lib/services/local/kube_test.go
@@ -20,6 +20,7 @@ package local
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -29,6 +30,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/backend"
 	"github.com/gravitational/teleport/lib/backend/memory"
 )
 
@@ -132,4 +134,73 @@ func TestKubernetesCRUD(t *testing.T) {
 	out, err = service.GetKubernetesClusters(ctx)
 	require.NoError(t, err)
 	require.Empty(t, out)
+}
+
+// TestListKubernetesClusters_SkipsUnmarshalErrorsHittingPageBoundary guards against a regression where hitting a page boundary with a malformed backend item would
+// return less items than the page limit and no next token. This would cause callers to miss resources and fail to paginate properly when malformed items are present in the backend.
+func TestListKubernetesClusters_SkipsUnmarshalErrorsHittingPageBoundary(t *testing.T) {
+	ctx := t.Context()
+
+	const pageLimit = 64
+	const numberOfPages = 5
+
+	clock := clockwork.NewFakeClock()
+	mem, err := memory.New(memory.Config{
+		Context: t.Context(),
+		Clock:   clock,
+	})
+	require.NoError(t, err)
+
+	service := NewKubernetesService(mem)
+
+	var allExpected []types.KubeCluster
+
+	createResource := func(name string) {
+		kube, err := types.NewKubernetesClusterV3(types.Metadata{
+			Name: name,
+		}, types.KubernetesClusterSpecV3{})
+		require.NoError(t, err)
+		err = service.CreateKubernetesCluster(ctx, kube)
+		require.NoError(t, err)
+		allExpected = append(allExpected, kube)
+
+	}
+
+	createMalformedEntry := func(name string) {
+		_, err := mem.Put(ctx, backend.Item{
+			Key:   backend.NewKey(kubernetesPrefix, name),
+			Value: []byte("not-valid-json"),
+		})
+		require.NoError(t, err)
+	}
+
+	for i := range pageLimit * numberOfPages {
+		key := fmt.Sprintf("r%d", i)
+		if i%2 == 0 {
+			createMalformedEntry(key)
+		} else {
+			createResource(key)
+		}
+	}
+
+	page1, next, err := service.ListKubernetesClusters(ctx, pageLimit, "")
+	require.NoError(t, err)
+	require.Len(t, page1, pageLimit)
+	require.NotEmpty(t, next)
+
+	page2, next, err := service.ListKubernetesClusters(ctx, pageLimit, next)
+	require.NoError(t, err)
+	require.Len(t, page2, pageLimit)
+	require.NotEmpty(t, next)
+
+	page3, next, err := service.ListKubernetesClusters(ctx, pageLimit, next)
+	require.NoError(t, err)
+	require.Len(t, page3, pageLimit/2)
+	require.Empty(t, next)
+
+	allActual := append(append(page1, page2...), page3...)
+	require.Empty(t, cmp.Diff(allExpected, allActual,
+		cmpopts.IgnoreFields(types.Metadata{}, "Revision"),
+		cmpopts.SortSlices(func(a, b types.KubeCluster) bool { return a.GetName() < b.GetName() }),
+	))
 }

--- a/lib/services/local/presence_test.go
+++ b/lib/services/local/presence_test.go
@@ -1571,3 +1571,90 @@ func TestPresenceService_ListSemaphores(t *testing.T) {
 	})
 
 }
+
+// TestListSemaphores_SkipsUnmarshalErrorsHittingPageBoundary guards against a regression where hitting a page boundary with a malformed backend item would
+// return less items than the page limit and no next token. This would cause callers to miss resources and fail to paginate properly when malformed items are present in the backend.
+func TestListSemaphores_SkipsUnmarshalErrorsHittingPageBoundary(t *testing.T) {
+	ctx := t.Context()
+
+	const pageLimit = 64
+	const numberOfPages = 5
+
+	clock := clockwork.NewFakeClock()
+	mem, err := memory.New(memory.Config{
+		Context: t.Context(),
+		Clock:   clock,
+	})
+	require.NoError(t, err)
+
+	service := NewPresenceService(mem)
+
+	var allExpected []types.Semaphore
+
+	createResource := func(name string) {
+		request := types.AcquireSemaphoreRequest{
+			SemaphoreKind: "test",
+			SemaphoreName: name,
+			MaxLeases:     5,
+			Expires:       time.Now().Add(time.Hour),
+			Holder:        "test",
+		}
+		lease, err := service.AcquireSemaphore(ctx, request)
+		require.NoError(t, err)
+
+		sem := &types.SemaphoreV3{
+			SubKind: request.SemaphoreKind,
+			Metadata: types.Metadata{
+				Name: request.SemaphoreName,
+			},
+			Spec: types.SemaphoreSpecV3{
+				Leases: []types.SemaphoreLeaseRef{{
+					LeaseID: lease.LeaseID,
+					Expires: lease.Expires,
+					Holder:  request.Holder,
+				}},
+			}}
+		sem.CheckAndSetDefaults()
+
+		allExpected = append(allExpected, sem)
+	}
+
+	createMalformedEntry := func(name string) {
+		_, err := mem.Put(ctx, backend.Item{
+			Key:   backend.NewKey(semaphoresPrefix, name),
+			Value: []byte("not-valid-json"),
+		})
+		require.NoError(t, err)
+	}
+
+	for i := range pageLimit * numberOfPages {
+		key := fmt.Sprintf("r%d", i)
+		if i%2 == 0 {
+			createMalformedEntry(key)
+		} else {
+			createResource(key)
+		}
+	}
+
+	page1, next, err := service.ListSemaphores(ctx, pageLimit, "", nil)
+	require.NoError(t, err)
+	require.Len(t, page1, pageLimit)
+	require.NotEmpty(t, next)
+
+	page2, next, err := service.ListSemaphores(ctx, pageLimit, next, nil)
+	require.NoError(t, err)
+	require.Len(t, page2, pageLimit)
+	require.NotEmpty(t, next)
+
+	page3, next, err := service.ListSemaphores(ctx, pageLimit, next, nil)
+	require.NoError(t, err)
+	require.Len(t, page3, pageLimit/2)
+	require.Empty(t, next)
+
+	allActual := append(append(page1, page2...), page3...)
+	require.Empty(t, cmp.Diff(allExpected, allActual,
+		cmpopts.IgnoreFields(types.Metadata{}, "Revision"),
+		cmpopts.IgnoreFields(types.Metadata{}, "Expires"),
+		cmpopts.SortSlices(func(a, b types.Semaphore) bool { return a.GetName() < b.GetName() }),
+	))
+}

--- a/lib/services/local/session.go
+++ b/lib/services/local/session.go
@@ -20,6 +20,7 @@ package local
 
 import (
 	"context"
+	"log/slog"
 	"slices"
 
 	"github.com/gravitational/trace"
@@ -30,6 +31,7 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/backend"
 	"github.com/gravitational/teleport/lib/services"
+	logutils "github.com/gravitational/teleport/lib/utils/log"
 )
 
 // GetAppSession gets an application web session.
@@ -476,27 +478,40 @@ func (r *IdentityService) ListWebTokens(ctx context.Context, limit int, start st
 	startKey := tokenKey.AppendKey(backend.KeyFromString(start))
 	endKey := backend.RangeEnd(tokenKey)
 
-	var out []types.WebToken
-	result, err := r.Backend.GetRange(ctx, startKey, endKey, limit+1)
-	if err != nil {
+	out := make([]types.WebToken, 0, limit)
+	var nextPage string
+
+	if err := backend.IterateRange(
+		ctx,
+		r.Backend,
+		startKey,
+		endKey,
+		limit+1,
+		func(items []backend.Item) (bool, error) {
+			for _, item := range items {
+				token, err := services.UnmarshalWebToken(item.Value,
+					services.WithRevision(item.Revision),
+					services.WithExpires(item.Expires))
+				if err != nil {
+					slog.WarnContext(ctx, "Failed to web token",
+						"key", logutils.StringerAttr(item.Key),
+						"error", err)
+					continue
+				}
+
+				if len(out) >= limit {
+					nextPage = token.GetToken()
+					return true, nil
+				} else {
+					out = append(out, token)
+				}
+			}
+			return false, nil
+		}); err != nil {
 		return nil, "", trace.Wrap(err)
 	}
 
-	for _, item := range result.Items {
-		token, err := services.UnmarshalWebToken(item.Value, services.WithRevision(item.Revision))
-
-		if err != nil {
-			continue
-		}
-
-		if len(out) >= limit {
-			return out, token.GetToken(), nil
-		}
-
-		out = append(out, token)
-	}
-
-	return out, "", nil
+	return out, nextPage, nil
 }
 
 // UpsertWebToken updates the existing or inserts a new web token.

--- a/lib/services/local/session_test.go
+++ b/lib/services/local/session_test.go
@@ -35,6 +35,7 @@ import (
 	"github.com/gravitational/teleport/api/client/proto"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/utils/clientutils"
+	"github.com/gravitational/teleport/lib/backend"
 	"github.com/gravitational/teleport/lib/backend/memory"
 	"github.com/gravitational/teleport/lib/itertools/stream"
 )
@@ -534,4 +535,76 @@ func TestWebTokenCRUD(t *testing.T) {
 	require.Empty(t, out)
 	require.Empty(t, next)
 
+}
+
+// TestListWebTokens_SkipsUnmarshalErrorsHittingPageBoundary guards against a regression where hitting a page boundary with a malformed backend item would
+// return less items than the page limit and no next token. This would cause callers to miss resources and fail to paginate properly when malformed items are present in the backend.
+func TestListWebTokens_SkipsUnmarshalErrorsHittingPageBoundary(t *testing.T) {
+	ctx := t.Context()
+
+	const pageLimit = 64
+	const numberOfPages = 5
+
+	clock := clockwork.NewFakeClock()
+	mem, err := memory.New(memory.Config{
+		Context: t.Context(),
+		Clock:   clock,
+	})
+	require.NoError(t, err)
+
+	service, err := NewTestIdentityService(mem)
+	require.NoError(t, err)
+
+	var allExpected []types.WebToken
+
+	createResource := func(name string) {
+		expires := clock.Now().Add(time.Hour)
+		token, err := types.NewWebToken(expires, types.WebTokenSpecV3{
+			Token: name,
+			User:  "foo",
+		})
+		require.NoError(t, err)
+		err = service.UpsertWebToken(ctx, token)
+		require.NoError(t, err)
+		allExpected = append(allExpected, token)
+
+	}
+
+	createMalformedEntry := func(name string) {
+		_, err := mem.Put(ctx, backend.Item{
+			Key:   backend.NewKey(webPrefix, tokensPrefix, name),
+			Value: []byte("not-valid-json"),
+		})
+		require.NoError(t, err)
+	}
+
+	for i := range pageLimit * numberOfPages {
+		key := fmt.Sprintf("r%d", i)
+		if i%2 == 0 {
+			createMalformedEntry(key)
+		} else {
+			createResource(key)
+		}
+	}
+
+	page1, next, err := service.ListWebTokens(ctx, pageLimit, "")
+	require.NoError(t, err)
+	require.Len(t, page1, pageLimit)
+	require.NotEmpty(t, next)
+
+	page2, next, err := service.ListWebTokens(ctx, pageLimit, next)
+	require.NoError(t, err)
+	require.Len(t, page2, pageLimit)
+	require.NotEmpty(t, next)
+
+	page3, next, err := service.ListWebTokens(ctx, pageLimit, next)
+	require.NoError(t, err)
+	require.Len(t, page3, pageLimit/2)
+	require.Empty(t, next)
+
+	allActual := append(append(page1, page2...), page3...)
+	require.Empty(t, cmp.Diff(allExpected, allActual,
+		cmpopts.IgnoreFields(types.Metadata{}, "Revision"),
+		cmpopts.SortSlices(func(a, b types.WebToken) bool { return a.GetName() < b.GetName() }),
+	))
 }

--- a/lib/services/local/suite_test.go
+++ b/lib/services/local/suite_test.go
@@ -46,6 +46,7 @@ import (
 	"github.com/gravitational/teleport/api/utils"
 	"github.com/gravitational/teleport/api/utils/keys"
 	"github.com/gravitational/teleport/lib/backend"
+	"github.com/gravitational/teleport/lib/backend/memory"
 	"github.com/gravitational/teleport/lib/cryptosuites"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/fixtures"
@@ -1121,6 +1122,94 @@ func (s *ServicesTestSuite) OIDCPagination(t *testing.T) {
 
 		require.Empty(t, cmp.Diff(want, append(page1, page2...), cmpopts.IgnoreFields(types.Metadata{}, "Revision")))
 	})
+}
+
+// TestListOIDCConnectors_SkipsUnmarshalErrorsHittingPageBoundary guards against a regression where hitting a page boundary with a malformed backend item would
+// return less items than the page limit and no next token. This would cause callers to miss resources and fail to paginate properly when malformed items are present in the backend.
+func TestListOIDCConnectors_SkipsUnmarshalErrorsHittingPageBoundary(t *testing.T) {
+	ctx := t.Context()
+
+	const pageLimit = 64
+	const numberOfPages = 5
+
+	clock := clockwork.NewFakeClock()
+	mem, err := memory.New(memory.Config{
+		Context: t.Context(),
+		Clock:   clock,
+	})
+	require.NoError(t, err)
+
+	service, err := NewTestIdentityService(mem)
+	require.NoError(t, err)
+
+	var allExpected []types.OIDCConnector
+
+	createResource := func(name string) {
+		connector := &types.OIDCConnectorV3{
+			Kind:    types.KindOIDC,
+			Version: types.V2,
+			Metadata: types.Metadata{
+				Name:      name,
+				Namespace: apidefaults.Namespace,
+			},
+			Spec: types.OIDCConnectorSpecV3{
+				Display:      "SAML",
+				IssuerURL:    "http://example.com",
+				ClientID:     "aaa",
+				ClientSecret: "bbb",
+				RedirectURLs: []string{"https://localhost:3080/v1/webapi/github/callback"},
+				ClaimsToRoles: []types.ClaimMapping{
+					{
+						Claim: "abc",
+						Value: "xyz",
+						Roles: []string{"admin"},
+					},
+				},
+			},
+		}
+		_, err = service.UpsertOIDCConnector(ctx, connector)
+		require.NoError(t, err)
+		allExpected = append(allExpected, connector)
+
+	}
+
+	createMalformedEntry := func(name string) {
+		_, err := mem.Put(ctx, backend.Item{
+			Key:   backend.NewKey(webPrefix, connectorsPrefix, oidcPrefix, connectorsPrefix, name),
+			Value: []byte("not-valid-json"),
+		})
+		require.NoError(t, err)
+	}
+
+	for i := range pageLimit * numberOfPages {
+		key := fmt.Sprintf("r%d", i)
+		if i%2 == 0 {
+			createMalformedEntry(key)
+		} else {
+			createResource(key)
+		}
+	}
+
+	page1, next, err := service.ListOIDCConnectors(ctx, pageLimit, "", true)
+	require.NoError(t, err)
+	require.Len(t, page1, pageLimit)
+	require.NotEmpty(t, next)
+
+	page2, next, err := service.ListOIDCConnectors(ctx, pageLimit, next, true)
+	require.NoError(t, err)
+	require.Len(t, page2, pageLimit)
+	require.NotEmpty(t, next)
+
+	page3, next, err := service.ListOIDCConnectors(ctx, pageLimit, next, true)
+	require.NoError(t, err)
+	require.Len(t, page3, pageLimit/2)
+	require.Empty(t, next)
+
+	allActual := append(append(page1, page2...), page3...)
+	require.Empty(t, cmp.Diff(allExpected, allActual,
+		cmpopts.IgnoreFields(types.Metadata{}, "Revision"),
+		cmpopts.SortSlices(func(a, b types.OIDCConnector) bool { return a.GetName() < b.GetName() }),
+	))
 }
 
 func (s *ServicesTestSuite) TunnelConnectionsCRUD(t *testing.T) {

--- a/lib/services/local/trust.go
+++ b/lib/services/local/trust.go
@@ -33,6 +33,7 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/backend"
 	"github.com/gravitational/teleport/lib/services"
+	logutils "github.com/gravitational/teleport/lib/utils/log"
 )
 
 // CA is local implementation of Trust service that
@@ -726,45 +727,50 @@ func (s *CA) GetTrustedClusters(ctx context.Context) ([]types.TrustedCluster, er
 }
 
 // ListTrustedClusters returns a page of Trusted Cluster resources.
-func (s *CA) ListTrustedClusters(ctx context.Context, limit int, startKey string) ([]types.TrustedCluster, string, error) {
+func (s *CA) ListTrustedClusters(ctx context.Context, limit int, pageToken string) ([]types.TrustedCluster, string, error) {
 	// Adjust page size, so it can't be too large.
 	if limit <= 0 || limit > defaults.DefaultChunkSize {
 		limit = defaults.DefaultChunkSize
 	}
 
 	clusterKey := backend.NewKey(trustedClustersPrefix)
-	var out []types.TrustedCluster
-	result, err := s.Backend.GetRange(
+	startKey := clusterKey.AppendKey(backend.KeyFromString(pageToken))
+	endKey := backend.RangeEnd(clusterKey)
+
+	out := make([]types.TrustedCluster, 0, limit)
+	var nextPage string
+
+	if err := backend.IterateRange(
 		ctx,
-		clusterKey.AppendKey(backend.KeyFromString(startKey)),
-		backend.RangeEnd(clusterKey),
+		s.Backend,
+		startKey,
+		endKey,
 		limit+1,
-	)
-	if err != nil {
+		func(items []backend.Item) (bool, error) {
+			for _, item := range items {
+				tc, err := services.UnmarshalTrustedCluster(item.Value,
+					services.WithRevision(item.Revision),
+					services.WithExpires(item.Expires))
+				if err != nil {
+					slog.WarnContext(ctx, "Failed to unmarshal TrustedCluster",
+						"key", logutils.StringerAttr(item.Key),
+						"error", err)
+					continue
+				}
+
+				if len(out) >= limit {
+					nextPage = tc.GetName()
+					return true, nil
+				} else {
+					out = append(out, tc)
+				}
+			}
+			return false, nil
+		}); err != nil {
 		return nil, "", trace.Wrap(err)
 	}
 
-	for _, item := range result.Items {
-		tc, err := services.UnmarshalTrustedCluster(item.Value,
-			services.WithExpires(item.Expires),
-			services.WithRevision(item.Revision))
-		if err != nil {
-			s.logger.WarnContext(ctx, "Failed to unmarshal TrustedCluster",
-				"key", item.Key,
-				"error", err,
-			)
-			continue
-		}
-
-		if len(out) >= limit {
-			return out, tc.GetName(), nil
-		}
-
-		out = append(out, tc)
-	}
-
-	return out, "", nil
-
+	return out, nextPage, nil
 }
 
 // DeleteTrustedCluster removes a TrustedCluster from the backend by name.

--- a/lib/services/local/trust_test.go
+++ b/lib/services/local/trust_test.go
@@ -645,3 +645,76 @@ func newCertAuthority(t *testing.T, caType types.CertAuthType, domain string) ty
 
 	return ca
 }
+
+// TestListTrustedClusters_SkipsUnmarshalErrorsHittingPageBoundary guards against a regression where hitting a page boundary with a malformed backend item would
+// return less items than the page limit and no next token. This would cause callers to miss resources and fail to paginate properly when malformed items are present in the backend.
+func TestListTrustedClusters_SkipsUnmarshalErrorsHittingPageBoundary(t *testing.T) {
+	ctx := t.Context()
+
+	const pageLimit = 64
+	const numberOfPages = 5
+
+	clock := clockwork.NewFakeClock()
+	mem, err := memory.New(memory.Config{
+		Context: t.Context(),
+		Clock:   clock,
+	})
+	require.NoError(t, err)
+
+	service := NewCAService(mem)
+
+	var allExpected []types.TrustedCluster
+
+	createResource := func(name string) {
+		ca := newCertAuthority(t, types.HostCA, name)
+		tc, err := types.NewTrustedCluster(name, types.TrustedClusterSpecV2{
+			Enabled:              true,
+			Roles:                []string{"bar", "baz"},
+			Token:                "qux",
+			ProxyAddress:         "quux",
+			ReverseTunnelAddress: "quuz",
+		})
+		require.NoError(t, err)
+		_, err = service.CreateTrustedCluster(ctx, tc, []types.CertAuthority{ca})
+		require.NoError(t, err)
+		allExpected = append(allExpected, tc)
+	}
+
+	createMalformedEntry := func(name string) {
+		_, err := mem.Put(ctx, backend.Item{
+			Key:   backend.NewKey(trustedClustersPrefix, name),
+			Value: []byte("not-valid-json"),
+		})
+		require.NoError(t, err)
+	}
+
+	for i := range pageLimit * numberOfPages {
+		key := fmt.Sprintf("r%d", i)
+		if i%2 == 0 {
+			createMalformedEntry(key)
+		} else {
+			createResource(key)
+		}
+	}
+
+	page1, next, err := service.ListTrustedClusters(ctx, pageLimit, "")
+	require.NoError(t, err)
+	require.Len(t, page1, pageLimit)
+	require.NotEmpty(t, next)
+
+	page2, next, err := service.ListTrustedClusters(ctx, pageLimit, next)
+	require.NoError(t, err)
+	require.Len(t, page2, pageLimit)
+	require.NotEmpty(t, next)
+
+	page3, next, err := service.ListTrustedClusters(ctx, pageLimit, next)
+	require.NoError(t, err)
+	require.Len(t, page3, pageLimit/2)
+	require.Empty(t, next)
+
+	allActual := append(append(page1, page2...), page3...)
+	require.Empty(t, cmp.Diff(allExpected, allActual,
+		cmpopts.IgnoreFields(types.Metadata{}, "Revision"),
+		cmpopts.SortSlices(func(a, b types.TrustedCluster) bool { return a.GetName() < b.GetName() }),
+	))
+}

--- a/lib/services/local/users.go
+++ b/lib/services/local/users.go
@@ -26,6 +26,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"io"
+	"log/slog"
 	"sort"
 	"strings"
 	"sync"
@@ -51,6 +52,7 @@ import (
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/utils"
+	logutils "github.com/gravitational/teleport/lib/utils/log"
 )
 
 // GlobalSessionDataMaxEntries represents the maximum number of in-flight
@@ -1627,37 +1629,45 @@ func (s *IdentityService) ListOIDCConnectors(ctx context.Context, limit int, sta
 	startKey := connectorKey.AppendKey(backend.KeyFromString(start))
 	endKey := backend.RangeEnd(connectorKey)
 
-	var out []types.OIDCConnector
-	result, err := s.Backend.GetRange(ctx, startKey, endKey, limit+1)
-	if err != nil {
+	out := make([]types.OIDCConnector, 0, limit)
+	var nextPage string
+
+	if err := backend.IterateRange(
+		ctx,
+		s.Backend,
+		startKey,
+		endKey,
+		limit+1,
+		func(items []backend.Item) (bool, error) {
+			for _, item := range items {
+				connector, err := services.UnmarshalOIDCConnector(item.Value,
+					services.WithRevision(item.Revision),
+					services.WithExpires(item.Expires))
+				if err != nil {
+					slog.WarnContext(ctx, "Failed to unmarshal OIDC Connector",
+						"key", logutils.StringerAttr(item.Key),
+						"error", err)
+					continue
+				}
+
+				if !withSecrets {
+					connector.SetClientSecret("")
+					connector.SetGoogleServiceAccount("")
+				}
+
+				if len(out) >= limit {
+					nextPage = connector.GetName()
+					return true, nil
+				} else {
+					out = append(out, connector)
+				}
+			}
+			return false, nil
+		}); err != nil {
 		return nil, "", trace.Wrap(err)
 	}
 
-	for _, item := range result.Items {
-		conn, err := services.UnmarshalOIDCConnector(item.Value,
-			services.WithExpires(item.Expires),
-			services.WithRevision(item.Revision))
-		if err != nil {
-			logrus.
-				WithError(err).
-				WithField("key", item.Key).
-				Errorf("Error unmarshaling SAML Connector")
-			continue
-		}
-
-		if len(out) >= limit {
-			return out, conn.GetName(), nil
-		}
-
-		if !withSecrets {
-			conn.SetClientSecret("")
-			conn.SetGoogleServiceAccount("")
-		}
-
-		out = append(out, conn)
-	}
-
-	return out, "", nil
+	return out, nextPage, nil
 }
 
 // CreateOIDCAuthRequest creates new auth request


### PR DESCRIPTION
Backport #67466 to branch/v17

Note: v17 differs quite a bit from v18 onwards, it does not have the iter.Seq2 based API for backend. As such the changes have had to be reworked to match.

Notable exceptions:
- ListSemaphores uses backend.NoLimit and as such does not suffer from this bug. Added coverage.
- Generic ListResources now logs unmarshal failures but continues to iterate to prevent loss of access to remaining potentially valid resources. 
- ListWebTokens will now unmarshal expiry field.
- Switched from logrus to slog where relevant. 


