### PR TITLE
MCP: Set idle connection timeout

### DIFF
--- a/lib/srv/mcp/http.go
+++ b/lib/srv/mcp/http.go
@@ -23,6 +23,7 @@ import (
 	"context"
 	"encoding/json"
 	"io"
+	"log"
 	"net"
 	"net/http"
 	"net/url"
@@ -32,6 +33,8 @@ import (
 	"github.com/gravitational/trace"
 	"github.com/mark3labs/mcp-go/mcp"
 
+	apidefaults "github.com/gravitational/teleport/api/defaults"
+	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/httplib/reverseproxy"
 	appcommon "github.com/gravitational/teleport/lib/srv/app/common"
 	"github.com/gravitational/teleport/lib/utils"
@@ -53,6 +56,11 @@ func (s *Server) serveHTTPConn(ctx context.Context, conn net.Conn, handler http.
 	httpServer := &http.Server{
 		Handler:     handler,
 		BaseContext: func(net.Listener) context.Context { return ctx },
+		// Note: ReadTimeout/WriteTimeout *should not* be set here because it will break
+		// application access.
+		ReadHeaderTimeout: defaults.ReadHeadersTimeout,
+		IdleTimeout:       apidefaults.DefaultIdleTimeout,
+		ErrorLog:          log.Default(),
 	}
 
 	listener := listenerutils.NewSingleUseListener(waitConn)

--- a/lib/srv/mcp/http.go
+++ b/lib/srv/mcp/http.go
@@ -46,7 +46,7 @@ const (
 	mcpSessionIDHeader = "Mcp-Session-Id"
 )
 
-func (s *Server) serveHTTPConn(ctx context.Context, conn net.Conn, handler http.Handler) error {
+func (*Server) serveHTTPConn(ctx context.Context, conn net.Conn, handler http.Handler) error {
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 

--- a/lib/srv/mcp/http_test.go
+++ b/lib/srv/mcp/http_test.go
@@ -19,13 +19,16 @@
 package mcp
 
 import (
+	"bufio"
 	"context"
 	"fmt"
+	"io"
 	"net"
 	"net/http"
 	"net/http/httptest"
 	"sync"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/gravitational/trace"
@@ -36,9 +39,11 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	apidefaults "github.com/gravitational/teleport/api/defaults"
 	"github.com/gravitational/teleport/api/types"
 	apievents "github.com/gravitational/teleport/api/types/events"
 	apiutils "github.com/gravitational/teleport/api/utils"
+	"github.com/gravitational/teleport/lib/defaults"
 	libevents "github.com/gravitational/teleport/lib/events"
 	"github.com/gravitational/teleport/lib/events/eventstest"
 	"github.com/gravitational/teleport/lib/utils"
@@ -499,5 +504,76 @@ func Test_handleAuthErrHTTP(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, resp.Error)
 		require.Equal(t, "access denied", resp.Error.Message)
+	})
+}
+
+func Test_Server_serveHTTPCon_closes_idle_connections(t *testing.T) {
+	t.Parallel()
+
+	acceptedHandler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusAccepted)
+	})
+
+	t.Run("Verify ReadHeaderTimeout", func(t *testing.T) {
+		synctest.Test(t, func(t *testing.T) {
+			ctx := t.Context()
+			clientConn, serverConn := net.Pipe()
+
+			go new(Server).serveHTTPConn(ctx, serverConn, acceptedHandler)
+
+			// Idling without sending anything.
+			readConnErrCh := make(chan error)
+			go func() {
+				_, err := clientConn.Read(make([]byte, 1))
+				readConnErrCh <- err
+			}()
+
+			time.Sleep(defaults.ReadHeadersTimeout + 1*time.Nanosecond)
+
+			// Check closed.
+			select {
+			case err := <-readConnErrCh:
+				require.ErrorIs(t, err, io.EOF)
+			default:
+				t.Error("Expected the connection to be closed by idle timeout")
+			}
+		})
+	})
+
+	t.Run("Verify IdleTimeout", func(t *testing.T) {
+		synctest.Test(t, func(t *testing.T) {
+			ctx := t.Context()
+			clientConn, serverConn := net.Pipe()
+
+			go new(Server).serveHTTPConn(ctx, serverConn, acceptedHandler)
+
+			// Establish the connection by sending a request.
+			req, err := http.NewRequest(http.MethodGet, "https://mcp.test", nil)
+			require.NoError(t, err)
+			err = req.Write(clientConn)
+			require.NoError(t, err)
+
+			resp, err := http.ReadResponse(bufio.NewReader(clientConn), req)
+			require.NoError(t, err)
+			defer resp.Body.Close()
+			require.Equal(t, http.StatusAccepted, resp.StatusCode)
+
+			// Idling now.
+			readConnErrCh := make(chan error)
+			go func() {
+				_, err := clientConn.Read(make([]byte, 1))
+				readConnErrCh <- err
+			}()
+
+			time.Sleep(apidefaults.DefaultIdleTimeout + 1*time.Nanosecond)
+
+			// Check closed.
+			select {
+			case err := <-readConnErrCh:
+				require.ErrorIs(t, err, io.EOF)
+			default:
+				t.Error("Expected the connection to be closed by idle timeout")
+			}
+		})
 	})
 }

--- a/lib/srv/mcp/http_test.go
+++ b/lib/srv/mcp/http_test.go
@@ -507,7 +507,7 @@ func Test_handleAuthErrHTTP(t *testing.T) {
 	})
 }
 
-func Test_Server_serveHTTPCon_closes_idle_connections(t *testing.T) {
+func Test_Server_serveHTTPConn_closes_idle_connections(t *testing.T) {
 	t.Parallel()
 
 	acceptedHandler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
@@ -518,24 +518,43 @@ func Test_Server_serveHTTPCon_closes_idle_connections(t *testing.T) {
 		synctest.Test(t, func(t *testing.T) {
 			ctx := t.Context()
 			clientConn, serverConn := net.Pipe()
+			t.Cleanup(func() { _ = clientConn.Close() })
 
-			go new(Server).serveHTTPConn(ctx, serverConn, acceptedHandler)
+			serveHTTPConnErrCh := make(chan error, 1)
+			go func() {
+				serveHTTPConnErrCh <- new(Server).serveHTTPConn(ctx, serverConn, acceptedHandler)
+			}()
 
 			// Idling without sending anything.
-			readConnErrCh := make(chan error)
+			readConnErrCh := make(chan error, 1)
 			go func() {
 				_, err := clientConn.Read(make([]byte, 1))
 				readConnErrCh <- err
 			}()
 
-			time.Sleep(defaults.ReadHeadersTimeout + 1*time.Nanosecond)
+			synctest.Wait()
 
-			// Check closed.
+			select {
+			case err := <-readConnErrCh:
+				t.Fatalf("Connection closed before read header timeout: %v", err)
+			default:
+			}
+
+			time.Sleep(defaults.ReadHeadersTimeout)
+			synctest.Wait()
+
 			select {
 			case err := <-readConnErrCh:
 				require.ErrorIs(t, err, io.EOF)
 			default:
-				t.Error("Expected the connection to be closed by idle timeout")
+				t.Error("Expected the connection to be closed by read header timeout")
+			}
+
+			select {
+			case err := <-serveHTTPConnErrCh:
+				require.NoError(t, err)
+			default:
+				t.Error("Expected server to return after closing connection")
 			}
 		})
 	})
@@ -544,35 +563,53 @@ func Test_Server_serveHTTPCon_closes_idle_connections(t *testing.T) {
 		synctest.Test(t, func(t *testing.T) {
 			ctx := t.Context()
 			clientConn, serverConn := net.Pipe()
+			t.Cleanup(func() { _ = clientConn.Close() })
 
-			go new(Server).serveHTTPConn(ctx, serverConn, acceptedHandler)
+			serveHTTPConnErrCh := make(chan error, 1)
+			go func() {
+				serveHTTPConnErrCh <- new(Server).serveHTTPConn(ctx, serverConn, acceptedHandler)
+			}()
 
 			// Establish the connection by sending a request.
-			req, err := http.NewRequest(http.MethodGet, "https://mcp.test", nil)
+			req, err := http.NewRequest(http.MethodGet, "http://mcp.test", nil)
 			require.NoError(t, err)
-			err = req.Write(clientConn)
-			require.NoError(t, err)
+			require.NoError(t, req.Write(clientConn))
 
 			resp, err := http.ReadResponse(bufio.NewReader(clientConn), req)
 			require.NoError(t, err)
-			defer resp.Body.Close()
 			require.Equal(t, http.StatusAccepted, resp.StatusCode)
+			require.NoError(t, resp.Body.Close())
 
 			// Idling now.
-			readConnErrCh := make(chan error)
+			readConnErrCh := make(chan error, 1)
 			go func() {
 				_, err := clientConn.Read(make([]byte, 1))
 				readConnErrCh <- err
 			}()
 
-			time.Sleep(apidefaults.DefaultIdleTimeout + 1*time.Nanosecond)
+			synctest.Wait()
 
-			// Check closed.
+			select {
+			case err := <-readConnErrCh:
+				t.Fatalf("Connection closed before idle timeout: %v", err)
+			default:
+			}
+
+			time.Sleep(apidefaults.DefaultIdleTimeout)
+			synctest.Wait()
+
 			select {
 			case err := <-readConnErrCh:
 				require.ErrorIs(t, err, io.EOF)
 			default:
 				t.Error("Expected the connection to be closed by idle timeout")
+			}
+
+			select {
+			case err := <-serveHTTPConnErrCh:
+				require.NoError(t, err)
+			default:
+				t.Error("Expected server to return after closing connection")
 			}
 		})
 	})


### PR DESCRIPTION
## Backports

- https://github.com/gravitational/teleport/pull/68659

## Manual Test Plan
### Test Environment

- streamable HTTP MCP server serving:
  - fastRespondingTool responding immediately to tools/call
  - slowRespondingTool sending a single progress notification immediately, and then sleeping for 5m and responding to tools/call

MCP server configured with: `uri: "mcp+http://127.0.0.1:9000"`

### Test Cases

- [x] Test MCP flow:
   1. Initialize message and notification
   2. tools/list call
   3. call fastRespondingTool and verify response
   4. Wait 28s.
   5. Call fastRespondingTool again and verify response
   6. Wait 31s.
   7. Call slowRespondingTool and verify the notification arrives; then verify the response arrives after 5m
- [x] Check metrics and closing server with the debugger as described in [this comment](https://github.com/gravitational/teleport/pull/67628#issuecomment-4974144891).
