### PR TITLE
Add Display Fields to the Access List Member and Owner API Surface

### DIFF
--- a/api/client/accesslist/accesslist.go
+++ b/api/client/accesslist/accesslist.go
@@ -50,7 +50,7 @@ func (c *Client) GetAccessLists(ctx context.Context) ([]*accesslist.AccessList, 
 		var err error
 		accessLists[i], err = conv.FromProto(
 			accessList,
-			conv.WithOwnersIneligibleStatusField(accessList.GetSpec().GetOwners()))
+			accessListReadOptions(accessList.GetSpec().GetOwners())...)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
@@ -76,7 +76,7 @@ func (c *Client) ListAccessLists(ctx context.Context, pageSize int, nextToken st
 	accessLists := make([]*accesslist.AccessList, len(resp.AccessLists))
 	for i, accessList := range resp.AccessLists {
 		var err error
-		accessLists[i], err = conv.FromProto(accessList, conv.WithOwnersIneligibleStatusField(accessList.GetSpec().GetOwners()))
+		accessLists[i], err = conv.FromProto(accessList, accessListReadOptions(accessList.GetSpec().GetOwners())...)
 		if err != nil {
 			return nil, "", trace.Wrap(err)
 		}
@@ -94,7 +94,7 @@ func (c *Client) ListAccessListsV2(ctx context.Context, req *accesslistv1.ListAc
 
 	accessLists := make([]*accesslist.AccessList, len(resp.AccessLists))
 	for i, accessList := range resp.AccessLists {
-		accessLists[i], err = conv.FromProto(accessList, conv.WithOwnersIneligibleStatusField(accessList.GetSpec().GetOwners()))
+		accessLists[i], err = conv.FromProto(accessList, accessListReadOptions(accessList.GetSpec().GetOwners())...)
 		if err != nil {
 			return nil, "", trace.Wrap(err)
 		}
@@ -112,7 +112,7 @@ func (c *Client) GetAccessList(ctx context.Context, name string) (*accesslist.Ac
 		return nil, trace.Wrap(err)
 	}
 
-	accessList, err := conv.FromProto(resp, conv.WithOwnersIneligibleStatusField(resp.GetSpec().GetOwners()))
+	accessList, err := conv.FromProto(resp, accessListReadOptions(resp.GetSpec().GetOwners())...)
 	return accessList, trace.Wrap(err)
 }
 
@@ -126,7 +126,7 @@ func (c *Client) GetAccessListsToReview(ctx context.Context) ([]*accesslist.Acce
 	accessLists := make([]*accesslist.AccessList, len(resp.AccessLists))
 	for i, accessList := range resp.AccessLists {
 		var err error
-		accessLists[i], err = conv.FromProto(accessList, conv.WithOwnersIneligibleStatusField(accessList.GetSpec().GetOwners()))
+		accessLists[i], err = conv.FromProto(accessList, accessListReadOptions(accessList.GetSpec().GetOwners())...)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
@@ -156,7 +156,7 @@ func (c *Client) UpsertAccessList(ctx context.Context, accessList *accesslist.Ac
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	responseAccessList, err := conv.FromProto(resp, conv.WithOwnersIneligibleStatusField(resp.GetSpec().GetOwners()))
+	responseAccessList, err := conv.FromProto(resp, accessListReadOptions(resp.GetSpec().GetOwners())...)
 	return responseAccessList, trace.Wrap(err)
 }
 
@@ -168,7 +168,7 @@ func (c *Client) UpdateAccessList(ctx context.Context, accessList *accesslist.Ac
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	responseAccessList, err := conv.FromProto(resp, conv.WithOwnersIneligibleStatusField(resp.GetSpec().GetOwners()))
+	responseAccessList, err := conv.FromProto(resp, accessListReadOptions(resp.GetSpec().GetOwners())...)
 	return responseAccessList, trace.Wrap(err)
 }
 
@@ -206,7 +206,7 @@ func (c *Client) ListAccessListMembers(ctx context.Context, accessList string, p
 	members = make([]*accesslist.AccessListMember, len(resp.Members))
 	for i, member := range resp.Members {
 		var err error
-		members[i], err = conv.FromMemberProto(member, conv.WithMemberIneligibleStatusField(member))
+		members[i], err = conv.FromMemberProto(member, memberReadOptions(member)...)
 		if err != nil {
 			return nil, "", trace.Wrap(err)
 		}
@@ -228,7 +228,7 @@ func (c *Client) ListAllAccessListMembers(ctx context.Context, pageSize int, pag
 	members = make([]*accesslist.AccessListMember, len(resp.Members))
 	for i, member := range resp.Members {
 		var err error
-		members[i], err = conv.FromMemberProto(member, conv.WithMemberIneligibleStatusField(member))
+		members[i], err = conv.FromMemberProto(member, memberReadOptions(member)...)
 		if err != nil {
 			return nil, "", trace.Wrap(err)
 		}
@@ -247,7 +247,7 @@ func (c *Client) GetAccessListMember(ctx context.Context, accessList, memberName
 		return nil, trace.Wrap(err)
 	}
 
-	member, err := conv.FromMemberProto(resp, conv.WithMemberIneligibleStatusField(resp))
+	member, err := conv.FromMemberProto(resp, memberReadOptions(resp)...)
 	return member, trace.Wrap(err)
 }
 
@@ -262,7 +262,7 @@ func (c *Client) GetStaticAccessListMember(ctx context.Context, accessList, memb
 		return nil, trace.Wrap(err)
 	}
 
-	member, err := conv.FromMemberProto(resp.Member, conv.WithMemberIneligibleStatusField(resp.Member))
+	member, err := conv.FromMemberProto(resp.Member, memberReadOptions(resp.Member)...)
 	return member, trace.Wrap(err)
 }
 
@@ -294,7 +294,7 @@ func (c *Client) UpsertAccessListMember(ctx context.Context, member *accesslist.
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	responseMember, err := conv.FromMemberProto(resp, conv.WithMemberIneligibleStatusField(resp))
+	responseMember, err := conv.FromMemberProto(resp, memberReadOptions(resp)...)
 	return responseMember, trace.Wrap(err)
 }
 
@@ -307,7 +307,7 @@ func (c *Client) UpsertStaticAccessListMember(ctx context.Context, member *acces
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	m, err := conv.FromMemberProto(resp.Member, conv.WithMemberIneligibleStatusField(resp.Member))
+	m, err := conv.FromMemberProto(resp.Member, memberReadOptions(resp.Member)...)
 	return m, trace.Wrap(err)
 }
 
@@ -319,7 +319,7 @@ func (c *Client) UpdateAccessListMember(ctx context.Context, member *accesslist.
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	responseMember, err := conv.FromMemberProto(resp, conv.WithMemberIneligibleStatusField(resp))
+	responseMember, err := conv.FromMemberProto(resp, memberReadOptions(resp)...)
 	return responseMember, trace.Wrap(err)
 }
 
@@ -360,7 +360,7 @@ func (c *Client) UpsertAccessListWithMembers(ctx context.Context, list *accessli
 		return nil, nil, trace.Wrap(err)
 	}
 
-	accessList, err := conv.FromProto(resp.AccessList, conv.WithOwnersIneligibleStatusField(resp.AccessList.GetSpec().GetOwners()))
+	accessList, err := conv.FromProto(resp.AccessList, accessListReadOptions(resp.AccessList.GetSpec().GetOwners())...)
 	if err != nil {
 		return nil, nil, trace.Wrap(err)
 	}
@@ -368,7 +368,7 @@ func (c *Client) UpsertAccessListWithMembers(ctx context.Context, list *accessli
 	updatedMembers := make([]*accesslist.AccessListMember, len(resp.Members))
 	for i, member := range resp.Members {
 		var err error
-		updatedMembers[i], err = conv.FromMemberProto(member, conv.WithMemberIneligibleStatusField(member))
+		updatedMembers[i], err = conv.FromMemberProto(member, memberReadOptions(member)...)
 		if err != nil {
 			return nil, nil, trace.Wrap(err)
 		}
@@ -483,11 +483,25 @@ func (c *Client) ListUserAccessLists(ctx context.Context, req *accesslistv1.List
 
 	accessLists := make([]*accesslist.AccessList, len(resp.AccessLists))
 	for i, accessList := range resp.AccessLists {
-		accessLists[i], err = conv.FromProto(accessList, conv.WithOwnersIneligibleStatusField(accessList.GetSpec().GetOwners()))
+		accessLists[i], err = conv.FromProto(accessList, accessListReadOptions(accessList.GetSpec().GetOwners())...)
 		if err != nil {
 			return nil, "", trace.Wrap(err)
 		}
 	}
 
 	return accessLists, resp.GetNextPageToken(), nil
+}
+
+func accessListReadOptions(owners []*accesslistv1.AccessListOwner) []conv.AccessListOption {
+	return []conv.AccessListOption{
+		conv.WithOwnersIneligibleStatusField(owners),
+		conv.WithOwnersDisplayField(owners),
+	}
+}
+
+func memberReadOptions(member *accesslistv1.Member) []conv.MemberOption {
+	return []conv.MemberOption{
+		conv.WithMemberIneligibleStatusField(member),
+		conv.WithMemberDisplayField(member),
+	}
 }

--- a/api/client/accesslist/accesslist_test.go
+++ b/api/client/accesslist/accesslist_test.go
@@ -1,0 +1,149 @@
+// Copyright 2026 Gravitational, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package accesslist
+
+import (
+	"context"
+	"net"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/test/bufconn"
+
+	accesslistv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/accesslist/v1"
+	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
+	"github.com/gravitational/teleport/api/types"
+)
+
+func TestClientPreservesDisplayFields(t *testing.T) {
+	t.Parallel()
+
+	client := newAccessListClientForTesting(t)
+
+	accessList, err := client.GetAccessList(t.Context(), "access-list")
+	require.NoError(t, err)
+	require.Equal(t, types.UserDisplay{
+		Primary:   "Owner One",
+		Secondary: "owner@example.com",
+	}, accessList.Spec.Owners[0].Display)
+
+	members, nextToken, err := client.ListAccessListMembers(t.Context(), "access-list", 100, "")
+	require.NoError(t, err)
+	require.Empty(t, nextToken)
+	require.Equal(t, types.UserDisplay{
+		Primary:   "Member One",
+		Secondary: "member@example.com",
+	}, members[0].Spec.Display)
+	require.Equal(t, types.UserDisplay{
+		Primary:   "Adder One",
+		Secondary: "adder@example.com",
+	}, members[0].Spec.AddedByDisplay)
+}
+
+func newAccessListClientForTesting(t *testing.T) *Client {
+	t.Helper()
+
+	lis := bufconn.Listen(1024)
+	t.Cleanup(func() {
+		assert.NoError(t, lis.Close())
+	})
+
+	server := grpc.NewServer()
+	accesslistv1.RegisterAccessListServiceServer(server, &fakeAccessListService{})
+
+	var wg sync.WaitGroup
+	wg.Go(func() {
+		assert.NoError(t, server.Serve(lis))
+	})
+	t.Cleanup(func() {
+		server.GracefulStop()
+		wg.Wait()
+	})
+
+	conn, err := grpc.NewClient("passthrough:///bufconn",
+		grpc.WithContextDialer(func(ctx context.Context, _ string) (net.Conn, error) {
+			return lis.DialContext(ctx)
+		}),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		assert.NoError(t, conn.Close())
+	})
+
+	return NewClient(accesslistv1.NewAccessListServiceClient(conn))
+}
+
+type fakeAccessListService struct {
+	accesslistv1.UnimplementedAccessListServiceServer
+}
+
+func (fakeAccessListService) GetAccessList(context.Context, *accesslistv1.GetAccessListRequest) (*accesslistv1.AccessList, error) {
+	return &accesslistv1.AccessList{
+		Header: accessListHeader(types.KindAccessList, "access-list"),
+		Spec: &accesslistv1.AccessListSpec{
+			Title:              "Access List",
+			MembershipRequires: &accesslistv1.AccessListRequires{},
+			OwnershipRequires:  &accesslistv1.AccessListRequires{},
+			Owners: []*accesslistv1.AccessListOwner{
+				{
+					Name: "owner",
+					Display: &accesslistv1.UserDisplay{
+						Primary:   "Owner One",
+						Secondary: "owner@example.com",
+					},
+				},
+			},
+			Audit: &accesslistv1.AccessListAudit{},
+		},
+	}, nil
+}
+
+func (fakeAccessListService) ListAccessListMembers(context.Context, *accesslistv1.ListAccessListMembersRequest) (*accesslistv1.ListAccessListMembersResponse, error) {
+	return &accesslistv1.ListAccessListMembersResponse{
+		Members: []*accesslistv1.Member{
+			{
+				Header: accessListHeader(types.KindAccessListMember, "access-list/member"),
+				Spec: &accesslistv1.MemberSpec{
+					AccessList: "access-list",
+					Name:       "member",
+					AddedBy:    "adder",
+					Display: &accesslistv1.UserDisplay{
+						Primary:   "Member One",
+						Secondary: "member@example.com",
+					},
+					AddedByDisplay: &accesslistv1.UserDisplay{
+						Primary:   "Adder One",
+						Secondary: "adder@example.com",
+					},
+				},
+			},
+		},
+	}, nil
+}
+
+func accessListHeader(kind, name string) *headerv1.ResourceHeader {
+	return &headerv1.ResourceHeader{
+		Kind:    kind,
+		Version: types.V1,
+		Metadata: &headerv1.Metadata{
+			Name: name,
+		},
+	}
+}

--- a/api/gen/proto/go/teleport/accesslist/v1/accesslist.pb.go
+++ b/api/gen/proto/go/teleport/accesslist/v1/accesslist.pb.go
@@ -23,15 +23,14 @@
 package accesslistv1
 
 import (
-	reflect "reflect"
-	unsafe "unsafe"
-
 	v1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
 	v11 "github.com/gravitational/teleport/api/gen/proto/go/teleport/trait/v1"
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	durationpb "google.golang.org/protobuf/types/known/durationpb"
 	timestamppb "google.golang.org/protobuf/types/known/timestamppb"
+	reflect "reflect"
+	unsafe "unsafe"
 )
 
 const (

--- a/api/gen/proto/go/teleport/accesslist/v1/accesslist.pb.go
+++ b/api/gen/proto/go/teleport/accesslist/v1/accesslist.pb.go
@@ -23,14 +23,15 @@
 package accesslistv1
 
 import (
+	reflect "reflect"
+	unsafe "unsafe"
+
 	v1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
 	v11 "github.com/gravitational/teleport/api/gen/proto/go/teleport/trait/v1"
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	durationpb "google.golang.org/protobuf/types/known/durationpb"
 	timestamppb "google.golang.org/protobuf/types/known/timestamppb"
-	reflect "reflect"
-	unsafe "unsafe"
 )
 
 const (
@@ -1713,7 +1714,7 @@ type UserDisplay struct {
 	state protoimpl.MessageState `protogen:"hybrid.v1"`
 	// primary is a display name when distinct from the username.
 	Primary string `protobuf:"bytes,1,opt,name=primary,proto3" json:"primary,omitempty"`
-	// secondary is extra context, usually email, when distinct from the username.
+	// secondary is extra context, when distinct from the username.
 	Secondary     string `protobuf:"bytes,2,opt,name=secondary,proto3" json:"secondary,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
@@ -1771,7 +1772,7 @@ type UserDisplay_builder struct {
 
 	// primary is a display name when distinct from the username.
 	Primary string
-	// secondary is extra context, usually email, when distinct from the username.
+	// secondary is extra context, when distinct from the username.
 	Secondary string
 }
 

--- a/api/gen/proto/go/teleport/accesslist/v1/accesslist.pb.go
+++ b/api/gen/proto/go/teleport/accesslist/v1/accesslist.pb.go
@@ -697,8 +697,10 @@ type AccessListOwner struct {
 	// membership_kind describes the type of membership, either
 	// `MEMBERSHIP_KIND_USER` or `MEMBERSHIP_KIND_LIST`.
 	MembershipKind MembershipKind `protobuf:"varint,4,opt,name=membership_kind,json=membershipKind,proto3,enum=teleport.accesslist.v1.MembershipKind" json:"membership_kind,omitempty"`
-	unknownFields  protoimpl.UnknownFields
-	sizeCache      protoimpl.SizeCache
+	// display holds read-time display values for the owner.
+	Display       *UserDisplay `protobuf:"bytes,5,opt,name=display,proto3" json:"display,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
 }
 
 func (x *AccessListOwner) Reset() {
@@ -754,6 +756,13 @@ func (x *AccessListOwner) GetMembershipKind() MembershipKind {
 	return MembershipKind_MEMBERSHIP_KIND_UNSPECIFIED
 }
 
+func (x *AccessListOwner) GetDisplay() *UserDisplay {
+	if x != nil {
+		return x.Display
+	}
+	return nil
+}
+
 func (x *AccessListOwner) SetName(v string) {
 	x.Name = v
 }
@@ -770,6 +779,21 @@ func (x *AccessListOwner) SetMembershipKind(v MembershipKind) {
 	x.MembershipKind = v
 }
 
+func (x *AccessListOwner) SetDisplay(v *UserDisplay) {
+	x.Display = v
+}
+
+func (x *AccessListOwner) HasDisplay() bool {
+	if x == nil {
+		return false
+	}
+	return x.Display != nil
+}
+
+func (x *AccessListOwner) ClearDisplay() {
+	x.Display = nil
+}
+
 type AccessListOwner_builder struct {
 	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
 
@@ -784,6 +808,8 @@ type AccessListOwner_builder struct {
 	// membership_kind describes the type of membership, either
 	// `MEMBERSHIP_KIND_USER` or `MEMBERSHIP_KIND_LIST`.
 	MembershipKind MembershipKind
+	// display holds read-time display values for the owner.
+	Display *UserDisplay
 }
 
 func (b0 AccessListOwner_builder) Build() *AccessListOwner {
@@ -794,6 +820,7 @@ func (b0 AccessListOwner_builder) Build() *AccessListOwner {
 	x.Description = b.Description
 	x.IneligibleStatus = b.IneligibleStatus
 	x.MembershipKind = b.MembershipKind
+	x.Display = b.Display
 	return m0
 }
 
@@ -1447,6 +1474,11 @@ type MemberSpec struct {
 	// membership_kind describes the type of membership, either
 	// `MEMBERSHIP_KIND_USER` or `MEMBERSHIP_KIND_LIST`.
 	MembershipKind MembershipKind `protobuf:"varint,9,opt,name=membership_kind,json=membershipKind,proto3,enum=teleport.accesslist.v1.MembershipKind" json:"membership_kind,omitempty"`
+	// display holds read-time display values for the member.
+	Display *UserDisplay `protobuf:"bytes,10,opt,name=display,proto3" json:"display,omitempty"`
+	// added_by_display holds read-time display values for the user that added
+	// this member.
+	AddedByDisplay *UserDisplay `protobuf:"bytes,11,opt,name=added_by_display,json=addedByDisplay,proto3" json:"added_by_display,omitempty"`
 	unknownFields  protoimpl.UnknownFields
 	sizeCache      protoimpl.SizeCache
 }
@@ -1532,6 +1564,20 @@ func (x *MemberSpec) GetMembershipKind() MembershipKind {
 	return MembershipKind_MEMBERSHIP_KIND_UNSPECIFIED
 }
 
+func (x *MemberSpec) GetDisplay() *UserDisplay {
+	if x != nil {
+		return x.Display
+	}
+	return nil
+}
+
+func (x *MemberSpec) GetAddedByDisplay() *UserDisplay {
+	if x != nil {
+		return x.AddedByDisplay
+	}
+	return nil
+}
+
 func (x *MemberSpec) SetAccessList(v string) {
 	x.AccessList = v
 }
@@ -1564,6 +1610,14 @@ func (x *MemberSpec) SetMembershipKind(v MembershipKind) {
 	x.MembershipKind = v
 }
 
+func (x *MemberSpec) SetDisplay(v *UserDisplay) {
+	x.Display = v
+}
+
+func (x *MemberSpec) SetAddedByDisplay(v *UserDisplay) {
+	x.AddedByDisplay = v
+}
+
 func (x *MemberSpec) HasJoined() bool {
 	if x == nil {
 		return false
@@ -1578,12 +1632,34 @@ func (x *MemberSpec) HasExpires() bool {
 	return x.Expires != nil
 }
 
+func (x *MemberSpec) HasDisplay() bool {
+	if x == nil {
+		return false
+	}
+	return x.Display != nil
+}
+
+func (x *MemberSpec) HasAddedByDisplay() bool {
+	if x == nil {
+		return false
+	}
+	return x.AddedByDisplay != nil
+}
+
 func (x *MemberSpec) ClearJoined() {
 	x.Joined = nil
 }
 
 func (x *MemberSpec) ClearExpires() {
 	x.Expires = nil
+}
+
+func (x *MemberSpec) ClearDisplay() {
+	x.Display = nil
+}
+
+func (x *MemberSpec) ClearAddedByDisplay() {
+	x.AddedByDisplay = nil
 }
 
 type MemberSpec_builder struct {
@@ -1607,6 +1683,11 @@ type MemberSpec_builder struct {
 	// membership_kind describes the type of membership, either
 	// `MEMBERSHIP_KIND_USER` or `MEMBERSHIP_KIND_LIST`.
 	MembershipKind MembershipKind
+	// display holds read-time display values for the member.
+	Display *UserDisplay
+	// added_by_display holds read-time display values for the user that added
+	// this member.
+	AddedByDisplay *UserDisplay
 }
 
 func (b0 MemberSpec_builder) Build() *MemberSpec {
@@ -1621,6 +1702,85 @@ func (b0 MemberSpec_builder) Build() *MemberSpec {
 	x.AddedBy = b.AddedBy
 	x.IneligibleStatus = b.IneligibleStatus
 	x.MembershipKind = b.MembershipKind
+	x.Display = b.Display
+	x.AddedByDisplay = b.AddedByDisplay
+	return m0
+}
+
+// UserDisplay holds read-time display values for a user, derived from the user
+// resource.
+type UserDisplay struct {
+	state protoimpl.MessageState `protogen:"hybrid.v1"`
+	// primary is a display name when distinct from the username.
+	Primary string `protobuf:"bytes,1,opt,name=primary,proto3" json:"primary,omitempty"`
+	// secondary is extra context, usually email, when distinct from the username.
+	Secondary     string `protobuf:"bytes,2,opt,name=secondary,proto3" json:"secondary,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *UserDisplay) Reset() {
+	*x = UserDisplay{}
+	mi := &file_teleport_accesslist_v1_accesslist_proto_msgTypes[11]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *UserDisplay) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*UserDisplay) ProtoMessage() {}
+
+func (x *UserDisplay) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_accesslist_v1_accesslist_proto_msgTypes[11]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+func (x *UserDisplay) GetPrimary() string {
+	if x != nil {
+		return x.Primary
+	}
+	return ""
+}
+
+func (x *UserDisplay) GetSecondary() string {
+	if x != nil {
+		return x.Secondary
+	}
+	return ""
+}
+
+func (x *UserDisplay) SetPrimary(v string) {
+	x.Primary = v
+}
+
+func (x *UserDisplay) SetSecondary(v string) {
+	x.Secondary = v
+}
+
+type UserDisplay_builder struct {
+	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
+
+	// primary is a display name when distinct from the username.
+	Primary string
+	// secondary is extra context, usually email, when distinct from the username.
+	Secondary string
+}
+
+func (b0 UserDisplay_builder) Build() *UserDisplay {
+	m0 := &UserDisplay{}
+	b, x := &b0, m0
+	_, _ = b, x
+	x.Primary = b.Primary
+	x.Secondary = b.Secondary
 	return m0
 }
 
@@ -1637,7 +1797,7 @@ type Review struct {
 
 func (x *Review) Reset() {
 	*x = Review{}
-	mi := &file_teleport_accesslist_v1_accesslist_proto_msgTypes[11]
+	mi := &file_teleport_accesslist_v1_accesslist_proto_msgTypes[12]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1649,7 +1809,7 @@ func (x *Review) String() string {
 func (*Review) ProtoMessage() {}
 
 func (x *Review) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_accesslist_v1_accesslist_proto_msgTypes[11]
+	mi := &file_teleport_accesslist_v1_accesslist_proto_msgTypes[12]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1742,7 +1902,7 @@ type ReviewSpec struct {
 
 func (x *ReviewSpec) Reset() {
 	*x = ReviewSpec{}
-	mi := &file_teleport_accesslist_v1_accesslist_proto_msgTypes[12]
+	mi := &file_teleport_accesslist_v1_accesslist_proto_msgTypes[13]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1754,7 +1914,7 @@ func (x *ReviewSpec) String() string {
 func (*ReviewSpec) ProtoMessage() {}
 
 func (x *ReviewSpec) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_accesslist_v1_accesslist_proto_msgTypes[12]
+	mi := &file_teleport_accesslist_v1_accesslist_proto_msgTypes[13]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1890,7 +2050,7 @@ type ReviewChanges struct {
 
 func (x *ReviewChanges) Reset() {
 	*x = ReviewChanges{}
-	mi := &file_teleport_accesslist_v1_accesslist_proto_msgTypes[13]
+	mi := &file_teleport_accesslist_v1_accesslist_proto_msgTypes[14]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1902,7 +2062,7 @@ func (x *ReviewChanges) String() string {
 func (*ReviewChanges) ProtoMessage() {}
 
 func (x *ReviewChanges) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_accesslist_v1_accesslist_proto_msgTypes[13]
+	mi := &file_teleport_accesslist_v1_accesslist_proto_msgTypes[14]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2008,7 +2168,7 @@ type CurrentUserAssignments struct {
 
 func (x *CurrentUserAssignments) Reset() {
 	*x = CurrentUserAssignments{}
-	mi := &file_teleport_accesslist_v1_accesslist_proto_msgTypes[14]
+	mi := &file_teleport_accesslist_v1_accesslist_proto_msgTypes[15]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2020,7 +2180,7 @@ func (x *CurrentUserAssignments) String() string {
 func (*CurrentUserAssignments) ProtoMessage() {}
 
 func (x *CurrentUserAssignments) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_accesslist_v1_accesslist_proto_msgTypes[14]
+	mi := &file_teleport_accesslist_v1_accesslist_proto_msgTypes[15]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2084,7 +2244,7 @@ type UserAssignments struct {
 
 func (x *UserAssignments) Reset() {
 	*x = UserAssignments{}
-	mi := &file_teleport_accesslist_v1_accesslist_proto_msgTypes[15]
+	mi := &file_teleport_accesslist_v1_accesslist_proto_msgTypes[16]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2096,7 +2256,7 @@ func (x *UserAssignments) String() string {
 func (*UserAssignments) ProtoMessage() {}
 
 func (x *UserAssignments) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_accesslist_v1_accesslist_proto_msgTypes[15]
+	mi := &file_teleport_accesslist_v1_accesslist_proto_msgTypes[16]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2168,7 +2328,7 @@ type AccessListStatus struct {
 
 func (x *AccessListStatus) Reset() {
 	*x = AccessListStatus{}
-	mi := &file_teleport_accesslist_v1_accesslist_proto_msgTypes[16]
+	mi := &file_teleport_accesslist_v1_accesslist_proto_msgTypes[17]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2180,7 +2340,7 @@ func (x *AccessListStatus) String() string {
 func (*AccessListStatus) ProtoMessage() {}
 
 func (x *AccessListStatus) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_accesslist_v1_accesslist_proto_msgTypes[16]
+	mi := &file_teleport_accesslist_v1_accesslist_proto_msgTypes[17]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2353,12 +2513,13 @@ const file_teleport_accesslist_v1_accesslist_proto_rawDesc = "" +
 	"\x04type\x18\f \x01(\tR\x04typeJ\x04\b\a\x10\bJ\x04\b\t\x10\n" +
 	"J\x04\b\n" +
 	"\x10\vR\amembersR\n" +
-	"membershipR\townership\"\xef\x01\n" +
+	"membershipR\townership\"\xae\x02\n" +
 	"\x0fAccessListOwner\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12 \n" +
 	"\vdescription\x18\x02 \x01(\tR\vdescription\x12U\n" +
 	"\x11ineligible_status\x18\x03 \x01(\x0e2(.teleport.accesslist.v1.IneligibleStatusR\x10ineligibleStatus\x12O\n" +
-	"\x0fmembership_kind\x18\x04 \x01(\x0e2&.teleport.accesslist.v1.MembershipKindR\x0emembershipKind\"\xf7\x01\n" +
+	"\x0fmembership_kind\x18\x04 \x01(\x0e2&.teleport.accesslist.v1.MembershipKindR\x0emembershipKind\x12=\n" +
+	"\adisplay\x18\x05 \x01(\v2#.teleport.accesslist.v1.UserDisplayR\adisplay\"\xf7\x01\n" +
 	"\x0fAccessListAudit\x12B\n" +
 	"\x0fnext_audit_date\x18\x02 \x01(\v2\x1a.google.protobuf.TimestampR\rnextAuditDate\x12B\n" +
 	"\n" +
@@ -2384,7 +2545,7 @@ const file_teleport_accesslist_v1_accesslist_proto_rawDesc = "" +
 	"\x05scope\x18\x02 \x01(\tR\x05scope\"|\n" +
 	"\x06Member\x12:\n" +
 	"\x06header\x18\x01 \x01(\v2\".teleport.header.v1.ResourceHeaderR\x06header\x126\n" +
-	"\x04spec\x18\x02 \x01(\v2\".teleport.accesslist.v1.MemberSpecR\x04spec\"\x98\x03\n" +
+	"\x04spec\x18\x02 \x01(\v2\".teleport.accesslist.v1.MemberSpecR\x04spec\"\xa6\x04\n" +
 	"\n" +
 	"MemberSpec\x12\x1f\n" +
 	"\vaccess_list\x18\x01 \x01(\tR\n" +
@@ -2395,8 +2556,14 @@ const file_teleport_accesslist_v1_accesslist_proto_rawDesc = "" +
 	"\x06reason\x18\x05 \x01(\tR\x06reason\x12\x19\n" +
 	"\badded_by\x18\x06 \x01(\tR\aaddedBy\x12U\n" +
 	"\x11ineligible_status\x18\a \x01(\x0e2(.teleport.accesslist.v1.IneligibleStatusR\x10ineligibleStatus\x12O\n" +
-	"\x0fmembership_kind\x18\t \x01(\x0e2&.teleport.accesslist.v1.MembershipKindR\x0emembershipKindJ\x04\b\b\x10\tR\n" +
-	"membership\"|\n" +
+	"\x0fmembership_kind\x18\t \x01(\x0e2&.teleport.accesslist.v1.MembershipKindR\x0emembershipKind\x12=\n" +
+	"\adisplay\x18\n" +
+	" \x01(\v2#.teleport.accesslist.v1.UserDisplayR\adisplay\x12M\n" +
+	"\x10added_by_display\x18\v \x01(\v2#.teleport.accesslist.v1.UserDisplayR\x0eaddedByDisplayJ\x04\b\b\x10\tR\n" +
+	"membership\"E\n" +
+	"\vUserDisplay\x12\x18\n" +
+	"\aprimary\x18\x01 \x01(\tR\aprimary\x12\x1c\n" +
+	"\tsecondary\x18\x02 \x01(\tR\tsecondary\"|\n" +
 	"\x06Review\x12:\n" +
 	"\x06header\x18\x01 \x01(\v2\".teleport.header.v1.ResourceHeaderR\x06header\x126\n" +
 	"\x04spec\x18\x02 \x01(\v2\".teleport.accesslist.v1.ReviewSpecR\x04spec\"\xdf\x01\n" +
@@ -2456,7 +2623,7 @@ const file_teleport_accesslist_v1_accesslist_proto_rawDesc = "" +
 	"*ACCESS_LIST_USER_ASSIGNMENT_TYPE_INHERITED\x10\x02BXZVgithub.com/gravitational/teleport/api/gen/proto/go/teleport/accesslist/v1;accesslistv1b\x06proto3"
 
 var file_teleport_accesslist_v1_accesslist_proto_enumTypes = make([]protoimpl.EnumInfo, 5)
-var file_teleport_accesslist_v1_accesslist_proto_msgTypes = make([]protoimpl.MessageInfo, 17)
+var file_teleport_accesslist_v1_accesslist_proto_msgTypes = make([]protoimpl.MessageInfo, 18)
 var file_teleport_accesslist_v1_accesslist_proto_goTypes = []any{
 	(ReviewFrequency)(0),              // 0: teleport.accesslist.v1.ReviewFrequency
 	(ReviewDayOfMonth)(0),             // 1: teleport.accesslist.v1.ReviewDayOfMonth
@@ -2474,21 +2641,22 @@ var file_teleport_accesslist_v1_accesslist_proto_goTypes = []any{
 	(*ScopedRoleGrant)(nil),           // 13: teleport.accesslist.v1.ScopedRoleGrant
 	(*Member)(nil),                    // 14: teleport.accesslist.v1.Member
 	(*MemberSpec)(nil),                // 15: teleport.accesslist.v1.MemberSpec
-	(*Review)(nil),                    // 16: teleport.accesslist.v1.Review
-	(*ReviewSpec)(nil),                // 17: teleport.accesslist.v1.ReviewSpec
-	(*ReviewChanges)(nil),             // 18: teleport.accesslist.v1.ReviewChanges
-	(*CurrentUserAssignments)(nil),    // 19: teleport.accesslist.v1.CurrentUserAssignments
-	(*UserAssignments)(nil),           // 20: teleport.accesslist.v1.UserAssignments
-	(*AccessListStatus)(nil),          // 21: teleport.accesslist.v1.AccessListStatus
-	(*v1.ResourceHeader)(nil),         // 22: teleport.header.v1.ResourceHeader
-	(*timestamppb.Timestamp)(nil),     // 23: google.protobuf.Timestamp
-	(*durationpb.Duration)(nil),       // 24: google.protobuf.Duration
-	(*v11.Trait)(nil),                 // 25: teleport.trait.v1.Trait
+	(*UserDisplay)(nil),               // 16: teleport.accesslist.v1.UserDisplay
+	(*Review)(nil),                    // 17: teleport.accesslist.v1.Review
+	(*ReviewSpec)(nil),                // 18: teleport.accesslist.v1.ReviewSpec
+	(*ReviewChanges)(nil),             // 19: teleport.accesslist.v1.ReviewChanges
+	(*CurrentUserAssignments)(nil),    // 20: teleport.accesslist.v1.CurrentUserAssignments
+	(*UserAssignments)(nil),           // 21: teleport.accesslist.v1.UserAssignments
+	(*AccessListStatus)(nil),          // 22: teleport.accesslist.v1.AccessListStatus
+	(*v1.ResourceHeader)(nil),         // 23: teleport.header.v1.ResourceHeader
+	(*timestamppb.Timestamp)(nil),     // 24: google.protobuf.Timestamp
+	(*durationpb.Duration)(nil),       // 25: google.protobuf.Duration
+	(*v11.Trait)(nil),                 // 26: teleport.trait.v1.Trait
 }
 var file_teleport_accesslist_v1_accesslist_proto_depIdxs = []int32{
-	22, // 0: teleport.accesslist.v1.AccessList.header:type_name -> teleport.header.v1.ResourceHeader
+	23, // 0: teleport.accesslist.v1.AccessList.header:type_name -> teleport.header.v1.ResourceHeader
 	6,  // 1: teleport.accesslist.v1.AccessList.spec:type_name -> teleport.accesslist.v1.AccessListSpec
-	21, // 2: teleport.accesslist.v1.AccessList.status:type_name -> teleport.accesslist.v1.AccessListStatus
+	22, // 2: teleport.accesslist.v1.AccessList.status:type_name -> teleport.accesslist.v1.AccessListStatus
 	7,  // 3: teleport.accesslist.v1.AccessListSpec.owners:type_name -> teleport.accesslist.v1.AccessListOwner
 	8,  // 4: teleport.accesslist.v1.AccessListSpec.audit:type_name -> teleport.accesslist.v1.AccessListAudit
 	11, // 5: teleport.accesslist.v1.AccessListSpec.membership_requires:type_name -> teleport.accesslist.v1.AccessListRequires
@@ -2497,39 +2665,42 @@ var file_teleport_accesslist_v1_accesslist_proto_depIdxs = []int32{
 	12, // 8: teleport.accesslist.v1.AccessListSpec.owner_grants:type_name -> teleport.accesslist.v1.AccessListGrants
 	3,  // 9: teleport.accesslist.v1.AccessListOwner.ineligible_status:type_name -> teleport.accesslist.v1.IneligibleStatus
 	2,  // 10: teleport.accesslist.v1.AccessListOwner.membership_kind:type_name -> teleport.accesslist.v1.MembershipKind
-	23, // 11: teleport.accesslist.v1.AccessListAudit.next_audit_date:type_name -> google.protobuf.Timestamp
-	9,  // 12: teleport.accesslist.v1.AccessListAudit.recurrence:type_name -> teleport.accesslist.v1.Recurrence
-	10, // 13: teleport.accesslist.v1.AccessListAudit.notifications:type_name -> teleport.accesslist.v1.Notifications
-	0,  // 14: teleport.accesslist.v1.Recurrence.frequency:type_name -> teleport.accesslist.v1.ReviewFrequency
-	1,  // 15: teleport.accesslist.v1.Recurrence.day_of_month:type_name -> teleport.accesslist.v1.ReviewDayOfMonth
-	24, // 16: teleport.accesslist.v1.Notifications.start:type_name -> google.protobuf.Duration
-	25, // 17: teleport.accesslist.v1.AccessListRequires.traits:type_name -> teleport.trait.v1.Trait
-	25, // 18: teleport.accesslist.v1.AccessListGrants.traits:type_name -> teleport.trait.v1.Trait
-	13, // 19: teleport.accesslist.v1.AccessListGrants.scoped_roles:type_name -> teleport.accesslist.v1.ScopedRoleGrant
-	22, // 20: teleport.accesslist.v1.Member.header:type_name -> teleport.header.v1.ResourceHeader
-	15, // 21: teleport.accesslist.v1.Member.spec:type_name -> teleport.accesslist.v1.MemberSpec
-	23, // 22: teleport.accesslist.v1.MemberSpec.joined:type_name -> google.protobuf.Timestamp
-	23, // 23: teleport.accesslist.v1.MemberSpec.expires:type_name -> google.protobuf.Timestamp
-	3,  // 24: teleport.accesslist.v1.MemberSpec.ineligible_status:type_name -> teleport.accesslist.v1.IneligibleStatus
-	2,  // 25: teleport.accesslist.v1.MemberSpec.membership_kind:type_name -> teleport.accesslist.v1.MembershipKind
-	22, // 26: teleport.accesslist.v1.Review.header:type_name -> teleport.header.v1.ResourceHeader
-	17, // 27: teleport.accesslist.v1.Review.spec:type_name -> teleport.accesslist.v1.ReviewSpec
-	23, // 28: teleport.accesslist.v1.ReviewSpec.review_date:type_name -> google.protobuf.Timestamp
-	18, // 29: teleport.accesslist.v1.ReviewSpec.changes:type_name -> teleport.accesslist.v1.ReviewChanges
-	11, // 30: teleport.accesslist.v1.ReviewChanges.membership_requirements_changed:type_name -> teleport.accesslist.v1.AccessListRequires
-	0,  // 31: teleport.accesslist.v1.ReviewChanges.review_frequency_changed:type_name -> teleport.accesslist.v1.ReviewFrequency
-	1,  // 32: teleport.accesslist.v1.ReviewChanges.review_day_of_month_changed:type_name -> teleport.accesslist.v1.ReviewDayOfMonth
-	4,  // 33: teleport.accesslist.v1.CurrentUserAssignments.ownership_type:type_name -> teleport.accesslist.v1.AccessListUserAssignmentType
-	4,  // 34: teleport.accesslist.v1.CurrentUserAssignments.membership_type:type_name -> teleport.accesslist.v1.AccessListUserAssignmentType
-	4,  // 35: teleport.accesslist.v1.UserAssignments.ownership_type:type_name -> teleport.accesslist.v1.AccessListUserAssignmentType
-	4,  // 36: teleport.accesslist.v1.UserAssignments.membership_type:type_name -> teleport.accesslist.v1.AccessListUserAssignmentType
-	19, // 37: teleport.accesslist.v1.AccessListStatus.current_user_assignments:type_name -> teleport.accesslist.v1.CurrentUserAssignments
-	20, // 38: teleport.accesslist.v1.AccessListStatus.user_assignments:type_name -> teleport.accesslist.v1.UserAssignments
-	39, // [39:39] is the sub-list for method output_type
-	39, // [39:39] is the sub-list for method input_type
-	39, // [39:39] is the sub-list for extension type_name
-	39, // [39:39] is the sub-list for extension extendee
-	0,  // [0:39] is the sub-list for field type_name
+	16, // 11: teleport.accesslist.v1.AccessListOwner.display:type_name -> teleport.accesslist.v1.UserDisplay
+	24, // 12: teleport.accesslist.v1.AccessListAudit.next_audit_date:type_name -> google.protobuf.Timestamp
+	9,  // 13: teleport.accesslist.v1.AccessListAudit.recurrence:type_name -> teleport.accesslist.v1.Recurrence
+	10, // 14: teleport.accesslist.v1.AccessListAudit.notifications:type_name -> teleport.accesslist.v1.Notifications
+	0,  // 15: teleport.accesslist.v1.Recurrence.frequency:type_name -> teleport.accesslist.v1.ReviewFrequency
+	1,  // 16: teleport.accesslist.v1.Recurrence.day_of_month:type_name -> teleport.accesslist.v1.ReviewDayOfMonth
+	25, // 17: teleport.accesslist.v1.Notifications.start:type_name -> google.protobuf.Duration
+	26, // 18: teleport.accesslist.v1.AccessListRequires.traits:type_name -> teleport.trait.v1.Trait
+	26, // 19: teleport.accesslist.v1.AccessListGrants.traits:type_name -> teleport.trait.v1.Trait
+	13, // 20: teleport.accesslist.v1.AccessListGrants.scoped_roles:type_name -> teleport.accesslist.v1.ScopedRoleGrant
+	23, // 21: teleport.accesslist.v1.Member.header:type_name -> teleport.header.v1.ResourceHeader
+	15, // 22: teleport.accesslist.v1.Member.spec:type_name -> teleport.accesslist.v1.MemberSpec
+	24, // 23: teleport.accesslist.v1.MemberSpec.joined:type_name -> google.protobuf.Timestamp
+	24, // 24: teleport.accesslist.v1.MemberSpec.expires:type_name -> google.protobuf.Timestamp
+	3,  // 25: teleport.accesslist.v1.MemberSpec.ineligible_status:type_name -> teleport.accesslist.v1.IneligibleStatus
+	2,  // 26: teleport.accesslist.v1.MemberSpec.membership_kind:type_name -> teleport.accesslist.v1.MembershipKind
+	16, // 27: teleport.accesslist.v1.MemberSpec.display:type_name -> teleport.accesslist.v1.UserDisplay
+	16, // 28: teleport.accesslist.v1.MemberSpec.added_by_display:type_name -> teleport.accesslist.v1.UserDisplay
+	23, // 29: teleport.accesslist.v1.Review.header:type_name -> teleport.header.v1.ResourceHeader
+	18, // 30: teleport.accesslist.v1.Review.spec:type_name -> teleport.accesslist.v1.ReviewSpec
+	24, // 31: teleport.accesslist.v1.ReviewSpec.review_date:type_name -> google.protobuf.Timestamp
+	19, // 32: teleport.accesslist.v1.ReviewSpec.changes:type_name -> teleport.accesslist.v1.ReviewChanges
+	11, // 33: teleport.accesslist.v1.ReviewChanges.membership_requirements_changed:type_name -> teleport.accesslist.v1.AccessListRequires
+	0,  // 34: teleport.accesslist.v1.ReviewChanges.review_frequency_changed:type_name -> teleport.accesslist.v1.ReviewFrequency
+	1,  // 35: teleport.accesslist.v1.ReviewChanges.review_day_of_month_changed:type_name -> teleport.accesslist.v1.ReviewDayOfMonth
+	4,  // 36: teleport.accesslist.v1.CurrentUserAssignments.ownership_type:type_name -> teleport.accesslist.v1.AccessListUserAssignmentType
+	4,  // 37: teleport.accesslist.v1.CurrentUserAssignments.membership_type:type_name -> teleport.accesslist.v1.AccessListUserAssignmentType
+	4,  // 38: teleport.accesslist.v1.UserAssignments.ownership_type:type_name -> teleport.accesslist.v1.AccessListUserAssignmentType
+	4,  // 39: teleport.accesslist.v1.UserAssignments.membership_type:type_name -> teleport.accesslist.v1.AccessListUserAssignmentType
+	20, // 40: teleport.accesslist.v1.AccessListStatus.current_user_assignments:type_name -> teleport.accesslist.v1.CurrentUserAssignments
+	21, // 41: teleport.accesslist.v1.AccessListStatus.user_assignments:type_name -> teleport.accesslist.v1.UserAssignments
+	42, // [42:42] is the sub-list for method output_type
+	42, // [42:42] is the sub-list for method input_type
+	42, // [42:42] is the sub-list for extension type_name
+	42, // [42:42] is the sub-list for extension extendee
+	0,  // [0:42] is the sub-list for field type_name
 }
 
 func init() { file_teleport_accesslist_v1_accesslist_proto_init() }
@@ -2537,14 +2708,14 @@ func file_teleport_accesslist_v1_accesslist_proto_init() {
 	if File_teleport_accesslist_v1_accesslist_proto != nil {
 		return
 	}
-	file_teleport_accesslist_v1_accesslist_proto_msgTypes[16].OneofWrappers = []any{}
+	file_teleport_accesslist_v1_accesslist_proto_msgTypes[17].OneofWrappers = []any{}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_teleport_accesslist_v1_accesslist_proto_rawDesc), len(file_teleport_accesslist_v1_accesslist_proto_rawDesc)),
 			NumEnums:      5,
-			NumMessages:   17,
+			NumMessages:   18,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/api/gen/proto/go/teleport/accesslist/v1/accesslist_protoopaque.pb.go
+++ b/api/gen/proto/go/teleport/accesslist/v1/accesslist_protoopaque.pb.go
@@ -23,14 +23,15 @@
 package accesslistv1
 
 import (
+	reflect "reflect"
+	unsafe "unsafe"
+
 	v1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
 	v11 "github.com/gravitational/teleport/api/gen/proto/go/teleport/trait/v1"
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	durationpb "google.golang.org/protobuf/types/known/durationpb"
 	timestamppb "google.golang.org/protobuf/types/known/timestamppb"
-	reflect "reflect"
-	unsafe "unsafe"
 )
 
 const (
@@ -1715,7 +1716,7 @@ type UserDisplay_builder struct {
 
 	// primary is a display name when distinct from the username.
 	Primary string
-	// secondary is extra context, usually email, when distinct from the username.
+	// secondary is extra context, when distinct from the username.
 	Secondary string
 }
 

--- a/api/gen/proto/go/teleport/accesslist/v1/accesslist_protoopaque.pb.go
+++ b/api/gen/proto/go/teleport/accesslist/v1/accesslist_protoopaque.pb.go
@@ -672,6 +672,7 @@ type AccessListOwner struct {
 	xxx_hidden_Description      string                 `protobuf:"bytes,2,opt,name=description,proto3"`
 	xxx_hidden_IneligibleStatus IneligibleStatus       `protobuf:"varint,3,opt,name=ineligible_status,json=ineligibleStatus,proto3,enum=teleport.accesslist.v1.IneligibleStatus"`
 	xxx_hidden_MembershipKind   MembershipKind         `protobuf:"varint,4,opt,name=membership_kind,json=membershipKind,proto3,enum=teleport.accesslist.v1.MembershipKind"`
+	xxx_hidden_Display          *UserDisplay           `protobuf:"bytes,5,opt,name=display,proto3"`
 	unknownFields               protoimpl.UnknownFields
 	sizeCache                   protoimpl.SizeCache
 }
@@ -729,6 +730,13 @@ func (x *AccessListOwner) GetMembershipKind() MembershipKind {
 	return MembershipKind_MEMBERSHIP_KIND_UNSPECIFIED
 }
 
+func (x *AccessListOwner) GetDisplay() *UserDisplay {
+	if x != nil {
+		return x.xxx_hidden_Display
+	}
+	return nil
+}
+
 func (x *AccessListOwner) SetName(v string) {
 	x.xxx_hidden_Name = v
 }
@@ -745,6 +753,21 @@ func (x *AccessListOwner) SetMembershipKind(v MembershipKind) {
 	x.xxx_hidden_MembershipKind = v
 }
 
+func (x *AccessListOwner) SetDisplay(v *UserDisplay) {
+	x.xxx_hidden_Display = v
+}
+
+func (x *AccessListOwner) HasDisplay() bool {
+	if x == nil {
+		return false
+	}
+	return x.xxx_hidden_Display != nil
+}
+
+func (x *AccessListOwner) ClearDisplay() {
+	x.xxx_hidden_Display = nil
+}
+
 type AccessListOwner_builder struct {
 	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
 
@@ -759,6 +782,8 @@ type AccessListOwner_builder struct {
 	// membership_kind describes the type of membership, either
 	// `MEMBERSHIP_KIND_USER` or `MEMBERSHIP_KIND_LIST`.
 	MembershipKind MembershipKind
+	// display holds read-time display values for the owner.
+	Display *UserDisplay
 }
 
 func (b0 AccessListOwner_builder) Build() *AccessListOwner {
@@ -769,6 +794,7 @@ func (b0 AccessListOwner_builder) Build() *AccessListOwner {
 	x.xxx_hidden_Description = b.Description
 	x.xxx_hidden_IneligibleStatus = b.IneligibleStatus
 	x.xxx_hidden_MembershipKind = b.MembershipKind
+	x.xxx_hidden_Display = b.Display
 	return m0
 }
 
@@ -1397,6 +1423,8 @@ type MemberSpec struct {
 	xxx_hidden_AddedBy          string                 `protobuf:"bytes,6,opt,name=added_by,json=addedBy,proto3"`
 	xxx_hidden_IneligibleStatus IneligibleStatus       `protobuf:"varint,7,opt,name=ineligible_status,json=ineligibleStatus,proto3,enum=teleport.accesslist.v1.IneligibleStatus"`
 	xxx_hidden_MembershipKind   MembershipKind         `protobuf:"varint,9,opt,name=membership_kind,json=membershipKind,proto3,enum=teleport.accesslist.v1.MembershipKind"`
+	xxx_hidden_Display          *UserDisplay           `protobuf:"bytes,10,opt,name=display,proto3"`
+	xxx_hidden_AddedByDisplay   *UserDisplay           `protobuf:"bytes,11,opt,name=added_by_display,json=addedByDisplay,proto3"`
 	unknownFields               protoimpl.UnknownFields
 	sizeCache                   protoimpl.SizeCache
 }
@@ -1482,6 +1510,20 @@ func (x *MemberSpec) GetMembershipKind() MembershipKind {
 	return MembershipKind_MEMBERSHIP_KIND_UNSPECIFIED
 }
 
+func (x *MemberSpec) GetDisplay() *UserDisplay {
+	if x != nil {
+		return x.xxx_hidden_Display
+	}
+	return nil
+}
+
+func (x *MemberSpec) GetAddedByDisplay() *UserDisplay {
+	if x != nil {
+		return x.xxx_hidden_AddedByDisplay
+	}
+	return nil
+}
+
 func (x *MemberSpec) SetAccessList(v string) {
 	x.xxx_hidden_AccessList = v
 }
@@ -1514,6 +1556,14 @@ func (x *MemberSpec) SetMembershipKind(v MembershipKind) {
 	x.xxx_hidden_MembershipKind = v
 }
 
+func (x *MemberSpec) SetDisplay(v *UserDisplay) {
+	x.xxx_hidden_Display = v
+}
+
+func (x *MemberSpec) SetAddedByDisplay(v *UserDisplay) {
+	x.xxx_hidden_AddedByDisplay = v
+}
+
 func (x *MemberSpec) HasJoined() bool {
 	if x == nil {
 		return false
@@ -1528,12 +1578,34 @@ func (x *MemberSpec) HasExpires() bool {
 	return x.xxx_hidden_Expires != nil
 }
 
+func (x *MemberSpec) HasDisplay() bool {
+	if x == nil {
+		return false
+	}
+	return x.xxx_hidden_Display != nil
+}
+
+func (x *MemberSpec) HasAddedByDisplay() bool {
+	if x == nil {
+		return false
+	}
+	return x.xxx_hidden_AddedByDisplay != nil
+}
+
 func (x *MemberSpec) ClearJoined() {
 	x.xxx_hidden_Joined = nil
 }
 
 func (x *MemberSpec) ClearExpires() {
 	x.xxx_hidden_Expires = nil
+}
+
+func (x *MemberSpec) ClearDisplay() {
+	x.xxx_hidden_Display = nil
+}
+
+func (x *MemberSpec) ClearAddedByDisplay() {
+	x.xxx_hidden_AddedByDisplay = nil
 }
 
 type MemberSpec_builder struct {
@@ -1557,6 +1629,11 @@ type MemberSpec_builder struct {
 	// membership_kind describes the type of membership, either
 	// `MEMBERSHIP_KIND_USER` or `MEMBERSHIP_KIND_LIST`.
 	MembershipKind MembershipKind
+	// display holds read-time display values for the member.
+	Display *UserDisplay
+	// added_by_display holds read-time display values for the user that added
+	// this member.
+	AddedByDisplay *UserDisplay
 }
 
 func (b0 MemberSpec_builder) Build() *MemberSpec {
@@ -1571,6 +1648,83 @@ func (b0 MemberSpec_builder) Build() *MemberSpec {
 	x.xxx_hidden_AddedBy = b.AddedBy
 	x.xxx_hidden_IneligibleStatus = b.IneligibleStatus
 	x.xxx_hidden_MembershipKind = b.MembershipKind
+	x.xxx_hidden_Display = b.Display
+	x.xxx_hidden_AddedByDisplay = b.AddedByDisplay
+	return m0
+}
+
+// UserDisplay holds read-time display values for a user, derived from the user
+// resource.
+type UserDisplay struct {
+	state                protoimpl.MessageState `protogen:"opaque.v1"`
+	xxx_hidden_Primary   string                 `protobuf:"bytes,1,opt,name=primary,proto3"`
+	xxx_hidden_Secondary string                 `protobuf:"bytes,2,opt,name=secondary,proto3"`
+	unknownFields        protoimpl.UnknownFields
+	sizeCache            protoimpl.SizeCache
+}
+
+func (x *UserDisplay) Reset() {
+	*x = UserDisplay{}
+	mi := &file_teleport_accesslist_v1_accesslist_proto_msgTypes[11]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *UserDisplay) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*UserDisplay) ProtoMessage() {}
+
+func (x *UserDisplay) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_accesslist_v1_accesslist_proto_msgTypes[11]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+func (x *UserDisplay) GetPrimary() string {
+	if x != nil {
+		return x.xxx_hidden_Primary
+	}
+	return ""
+}
+
+func (x *UserDisplay) GetSecondary() string {
+	if x != nil {
+		return x.xxx_hidden_Secondary
+	}
+	return ""
+}
+
+func (x *UserDisplay) SetPrimary(v string) {
+	x.xxx_hidden_Primary = v
+}
+
+func (x *UserDisplay) SetSecondary(v string) {
+	x.xxx_hidden_Secondary = v
+}
+
+type UserDisplay_builder struct {
+	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
+
+	// primary is a display name when distinct from the username.
+	Primary string
+	// secondary is extra context, usually email, when distinct from the username.
+	Secondary string
+}
+
+func (b0 UserDisplay_builder) Build() *UserDisplay {
+	m0 := &UserDisplay{}
+	b, x := &b0, m0
+	_, _ = b, x
+	x.xxx_hidden_Primary = b.Primary
+	x.xxx_hidden_Secondary = b.Secondary
 	return m0
 }
 
@@ -1585,7 +1739,7 @@ type Review struct {
 
 func (x *Review) Reset() {
 	*x = Review{}
-	mi := &file_teleport_accesslist_v1_accesslist_proto_msgTypes[11]
+	mi := &file_teleport_accesslist_v1_accesslist_proto_msgTypes[12]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1597,7 +1751,7 @@ func (x *Review) String() string {
 func (*Review) ProtoMessage() {}
 
 func (x *Review) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_accesslist_v1_accesslist_proto_msgTypes[11]
+	mi := &file_teleport_accesslist_v1_accesslist_proto_msgTypes[12]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1684,7 +1838,7 @@ type ReviewSpec struct {
 
 func (x *ReviewSpec) Reset() {
 	*x = ReviewSpec{}
-	mi := &file_teleport_accesslist_v1_accesslist_proto_msgTypes[12]
+	mi := &file_teleport_accesslist_v1_accesslist_proto_msgTypes[13]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1696,7 +1850,7 @@ func (x *ReviewSpec) String() string {
 func (*ReviewSpec) ProtoMessage() {}
 
 func (x *ReviewSpec) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_accesslist_v1_accesslist_proto_msgTypes[12]
+	mi := &file_teleport_accesslist_v1_accesslist_proto_msgTypes[13]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1825,7 +1979,7 @@ type ReviewChanges struct {
 
 func (x *ReviewChanges) Reset() {
 	*x = ReviewChanges{}
-	mi := &file_teleport_accesslist_v1_accesslist_proto_msgTypes[13]
+	mi := &file_teleport_accesslist_v1_accesslist_proto_msgTypes[14]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1837,7 +1991,7 @@ func (x *ReviewChanges) String() string {
 func (*ReviewChanges) ProtoMessage() {}
 
 func (x *ReviewChanges) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_accesslist_v1_accesslist_proto_msgTypes[13]
+	mi := &file_teleport_accesslist_v1_accesslist_proto_msgTypes[14]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1941,7 +2095,7 @@ type CurrentUserAssignments struct {
 
 func (x *CurrentUserAssignments) Reset() {
 	*x = CurrentUserAssignments{}
-	mi := &file_teleport_accesslist_v1_accesslist_proto_msgTypes[14]
+	mi := &file_teleport_accesslist_v1_accesslist_proto_msgTypes[15]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1953,7 +2107,7 @@ func (x *CurrentUserAssignments) String() string {
 func (*CurrentUserAssignments) ProtoMessage() {}
 
 func (x *CurrentUserAssignments) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_accesslist_v1_accesslist_proto_msgTypes[14]
+	mi := &file_teleport_accesslist_v1_accesslist_proto_msgTypes[15]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2015,7 +2169,7 @@ type UserAssignments struct {
 
 func (x *UserAssignments) Reset() {
 	*x = UserAssignments{}
-	mi := &file_teleport_accesslist_v1_accesslist_proto_msgTypes[15]
+	mi := &file_teleport_accesslist_v1_accesslist_proto_msgTypes[16]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2027,7 +2181,7 @@ func (x *UserAssignments) String() string {
 func (*UserAssignments) ProtoMessage() {}
 
 func (x *UserAssignments) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_accesslist_v1_accesslist_proto_msgTypes[15]
+	mi := &file_teleport_accesslist_v1_accesslist_proto_msgTypes[16]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2095,7 +2249,7 @@ type AccessListStatus struct {
 
 func (x *AccessListStatus) Reset() {
 	*x = AccessListStatus{}
-	mi := &file_teleport_accesslist_v1_accesslist_proto_msgTypes[16]
+	mi := &file_teleport_accesslist_v1_accesslist_proto_msgTypes[17]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2107,7 +2261,7 @@ func (x *AccessListStatus) String() string {
 func (*AccessListStatus) ProtoMessage() {}
 
 func (x *AccessListStatus) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_accesslist_v1_accesslist_proto_msgTypes[16]
+	mi := &file_teleport_accesslist_v1_accesslist_proto_msgTypes[17]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2290,12 +2444,13 @@ const file_teleport_accesslist_v1_accesslist_proto_rawDesc = "" +
 	"\x04type\x18\f \x01(\tR\x04typeJ\x04\b\a\x10\bJ\x04\b\t\x10\n" +
 	"J\x04\b\n" +
 	"\x10\vR\amembersR\n" +
-	"membershipR\townership\"\xef\x01\n" +
+	"membershipR\townership\"\xae\x02\n" +
 	"\x0fAccessListOwner\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12 \n" +
 	"\vdescription\x18\x02 \x01(\tR\vdescription\x12U\n" +
 	"\x11ineligible_status\x18\x03 \x01(\x0e2(.teleport.accesslist.v1.IneligibleStatusR\x10ineligibleStatus\x12O\n" +
-	"\x0fmembership_kind\x18\x04 \x01(\x0e2&.teleport.accesslist.v1.MembershipKindR\x0emembershipKind\"\xf7\x01\n" +
+	"\x0fmembership_kind\x18\x04 \x01(\x0e2&.teleport.accesslist.v1.MembershipKindR\x0emembershipKind\x12=\n" +
+	"\adisplay\x18\x05 \x01(\v2#.teleport.accesslist.v1.UserDisplayR\adisplay\"\xf7\x01\n" +
 	"\x0fAccessListAudit\x12B\n" +
 	"\x0fnext_audit_date\x18\x02 \x01(\v2\x1a.google.protobuf.TimestampR\rnextAuditDate\x12B\n" +
 	"\n" +
@@ -2321,7 +2476,7 @@ const file_teleport_accesslist_v1_accesslist_proto_rawDesc = "" +
 	"\x05scope\x18\x02 \x01(\tR\x05scope\"|\n" +
 	"\x06Member\x12:\n" +
 	"\x06header\x18\x01 \x01(\v2\".teleport.header.v1.ResourceHeaderR\x06header\x126\n" +
-	"\x04spec\x18\x02 \x01(\v2\".teleport.accesslist.v1.MemberSpecR\x04spec\"\x98\x03\n" +
+	"\x04spec\x18\x02 \x01(\v2\".teleport.accesslist.v1.MemberSpecR\x04spec\"\xa6\x04\n" +
 	"\n" +
 	"MemberSpec\x12\x1f\n" +
 	"\vaccess_list\x18\x01 \x01(\tR\n" +
@@ -2332,8 +2487,14 @@ const file_teleport_accesslist_v1_accesslist_proto_rawDesc = "" +
 	"\x06reason\x18\x05 \x01(\tR\x06reason\x12\x19\n" +
 	"\badded_by\x18\x06 \x01(\tR\aaddedBy\x12U\n" +
 	"\x11ineligible_status\x18\a \x01(\x0e2(.teleport.accesslist.v1.IneligibleStatusR\x10ineligibleStatus\x12O\n" +
-	"\x0fmembership_kind\x18\t \x01(\x0e2&.teleport.accesslist.v1.MembershipKindR\x0emembershipKindJ\x04\b\b\x10\tR\n" +
-	"membership\"|\n" +
+	"\x0fmembership_kind\x18\t \x01(\x0e2&.teleport.accesslist.v1.MembershipKindR\x0emembershipKind\x12=\n" +
+	"\adisplay\x18\n" +
+	" \x01(\v2#.teleport.accesslist.v1.UserDisplayR\adisplay\x12M\n" +
+	"\x10added_by_display\x18\v \x01(\v2#.teleport.accesslist.v1.UserDisplayR\x0eaddedByDisplayJ\x04\b\b\x10\tR\n" +
+	"membership\"E\n" +
+	"\vUserDisplay\x12\x18\n" +
+	"\aprimary\x18\x01 \x01(\tR\aprimary\x12\x1c\n" +
+	"\tsecondary\x18\x02 \x01(\tR\tsecondary\"|\n" +
 	"\x06Review\x12:\n" +
 	"\x06header\x18\x01 \x01(\v2\".teleport.header.v1.ResourceHeaderR\x06header\x126\n" +
 	"\x04spec\x18\x02 \x01(\v2\".teleport.accesslist.v1.ReviewSpecR\x04spec\"\xdf\x01\n" +
@@ -2393,7 +2554,7 @@ const file_teleport_accesslist_v1_accesslist_proto_rawDesc = "" +
 	"*ACCESS_LIST_USER_ASSIGNMENT_TYPE_INHERITED\x10\x02BXZVgithub.com/gravitational/teleport/api/gen/proto/go/teleport/accesslist/v1;accesslistv1b\x06proto3"
 
 var file_teleport_accesslist_v1_accesslist_proto_enumTypes = make([]protoimpl.EnumInfo, 5)
-var file_teleport_accesslist_v1_accesslist_proto_msgTypes = make([]protoimpl.MessageInfo, 17)
+var file_teleport_accesslist_v1_accesslist_proto_msgTypes = make([]protoimpl.MessageInfo, 18)
 var file_teleport_accesslist_v1_accesslist_proto_goTypes = []any{
 	(ReviewFrequency)(0),              // 0: teleport.accesslist.v1.ReviewFrequency
 	(ReviewDayOfMonth)(0),             // 1: teleport.accesslist.v1.ReviewDayOfMonth
@@ -2411,21 +2572,22 @@ var file_teleport_accesslist_v1_accesslist_proto_goTypes = []any{
 	(*ScopedRoleGrant)(nil),           // 13: teleport.accesslist.v1.ScopedRoleGrant
 	(*Member)(nil),                    // 14: teleport.accesslist.v1.Member
 	(*MemberSpec)(nil),                // 15: teleport.accesslist.v1.MemberSpec
-	(*Review)(nil),                    // 16: teleport.accesslist.v1.Review
-	(*ReviewSpec)(nil),                // 17: teleport.accesslist.v1.ReviewSpec
-	(*ReviewChanges)(nil),             // 18: teleport.accesslist.v1.ReviewChanges
-	(*CurrentUserAssignments)(nil),    // 19: teleport.accesslist.v1.CurrentUserAssignments
-	(*UserAssignments)(nil),           // 20: teleport.accesslist.v1.UserAssignments
-	(*AccessListStatus)(nil),          // 21: teleport.accesslist.v1.AccessListStatus
-	(*v1.ResourceHeader)(nil),         // 22: teleport.header.v1.ResourceHeader
-	(*timestamppb.Timestamp)(nil),     // 23: google.protobuf.Timestamp
-	(*durationpb.Duration)(nil),       // 24: google.protobuf.Duration
-	(*v11.Trait)(nil),                 // 25: teleport.trait.v1.Trait
+	(*UserDisplay)(nil),               // 16: teleport.accesslist.v1.UserDisplay
+	(*Review)(nil),                    // 17: teleport.accesslist.v1.Review
+	(*ReviewSpec)(nil),                // 18: teleport.accesslist.v1.ReviewSpec
+	(*ReviewChanges)(nil),             // 19: teleport.accesslist.v1.ReviewChanges
+	(*CurrentUserAssignments)(nil),    // 20: teleport.accesslist.v1.CurrentUserAssignments
+	(*UserAssignments)(nil),           // 21: teleport.accesslist.v1.UserAssignments
+	(*AccessListStatus)(nil),          // 22: teleport.accesslist.v1.AccessListStatus
+	(*v1.ResourceHeader)(nil),         // 23: teleport.header.v1.ResourceHeader
+	(*timestamppb.Timestamp)(nil),     // 24: google.protobuf.Timestamp
+	(*durationpb.Duration)(nil),       // 25: google.protobuf.Duration
+	(*v11.Trait)(nil),                 // 26: teleport.trait.v1.Trait
 }
 var file_teleport_accesslist_v1_accesslist_proto_depIdxs = []int32{
-	22, // 0: teleport.accesslist.v1.AccessList.header:type_name -> teleport.header.v1.ResourceHeader
+	23, // 0: teleport.accesslist.v1.AccessList.header:type_name -> teleport.header.v1.ResourceHeader
 	6,  // 1: teleport.accesslist.v1.AccessList.spec:type_name -> teleport.accesslist.v1.AccessListSpec
-	21, // 2: teleport.accesslist.v1.AccessList.status:type_name -> teleport.accesslist.v1.AccessListStatus
+	22, // 2: teleport.accesslist.v1.AccessList.status:type_name -> teleport.accesslist.v1.AccessListStatus
 	7,  // 3: teleport.accesslist.v1.AccessListSpec.owners:type_name -> teleport.accesslist.v1.AccessListOwner
 	8,  // 4: teleport.accesslist.v1.AccessListSpec.audit:type_name -> teleport.accesslist.v1.AccessListAudit
 	11, // 5: teleport.accesslist.v1.AccessListSpec.membership_requires:type_name -> teleport.accesslist.v1.AccessListRequires
@@ -2434,39 +2596,42 @@ var file_teleport_accesslist_v1_accesslist_proto_depIdxs = []int32{
 	12, // 8: teleport.accesslist.v1.AccessListSpec.owner_grants:type_name -> teleport.accesslist.v1.AccessListGrants
 	3,  // 9: teleport.accesslist.v1.AccessListOwner.ineligible_status:type_name -> teleport.accesslist.v1.IneligibleStatus
 	2,  // 10: teleport.accesslist.v1.AccessListOwner.membership_kind:type_name -> teleport.accesslist.v1.MembershipKind
-	23, // 11: teleport.accesslist.v1.AccessListAudit.next_audit_date:type_name -> google.protobuf.Timestamp
-	9,  // 12: teleport.accesslist.v1.AccessListAudit.recurrence:type_name -> teleport.accesslist.v1.Recurrence
-	10, // 13: teleport.accesslist.v1.AccessListAudit.notifications:type_name -> teleport.accesslist.v1.Notifications
-	0,  // 14: teleport.accesslist.v1.Recurrence.frequency:type_name -> teleport.accesslist.v1.ReviewFrequency
-	1,  // 15: teleport.accesslist.v1.Recurrence.day_of_month:type_name -> teleport.accesslist.v1.ReviewDayOfMonth
-	24, // 16: teleport.accesslist.v1.Notifications.start:type_name -> google.protobuf.Duration
-	25, // 17: teleport.accesslist.v1.AccessListRequires.traits:type_name -> teleport.trait.v1.Trait
-	25, // 18: teleport.accesslist.v1.AccessListGrants.traits:type_name -> teleport.trait.v1.Trait
-	13, // 19: teleport.accesslist.v1.AccessListGrants.scoped_roles:type_name -> teleport.accesslist.v1.ScopedRoleGrant
-	22, // 20: teleport.accesslist.v1.Member.header:type_name -> teleport.header.v1.ResourceHeader
-	15, // 21: teleport.accesslist.v1.Member.spec:type_name -> teleport.accesslist.v1.MemberSpec
-	23, // 22: teleport.accesslist.v1.MemberSpec.joined:type_name -> google.protobuf.Timestamp
-	23, // 23: teleport.accesslist.v1.MemberSpec.expires:type_name -> google.protobuf.Timestamp
-	3,  // 24: teleport.accesslist.v1.MemberSpec.ineligible_status:type_name -> teleport.accesslist.v1.IneligibleStatus
-	2,  // 25: teleport.accesslist.v1.MemberSpec.membership_kind:type_name -> teleport.accesslist.v1.MembershipKind
-	22, // 26: teleport.accesslist.v1.Review.header:type_name -> teleport.header.v1.ResourceHeader
-	17, // 27: teleport.accesslist.v1.Review.spec:type_name -> teleport.accesslist.v1.ReviewSpec
-	23, // 28: teleport.accesslist.v1.ReviewSpec.review_date:type_name -> google.protobuf.Timestamp
-	18, // 29: teleport.accesslist.v1.ReviewSpec.changes:type_name -> teleport.accesslist.v1.ReviewChanges
-	11, // 30: teleport.accesslist.v1.ReviewChanges.membership_requirements_changed:type_name -> teleport.accesslist.v1.AccessListRequires
-	0,  // 31: teleport.accesslist.v1.ReviewChanges.review_frequency_changed:type_name -> teleport.accesslist.v1.ReviewFrequency
-	1,  // 32: teleport.accesslist.v1.ReviewChanges.review_day_of_month_changed:type_name -> teleport.accesslist.v1.ReviewDayOfMonth
-	4,  // 33: teleport.accesslist.v1.CurrentUserAssignments.ownership_type:type_name -> teleport.accesslist.v1.AccessListUserAssignmentType
-	4,  // 34: teleport.accesslist.v1.CurrentUserAssignments.membership_type:type_name -> teleport.accesslist.v1.AccessListUserAssignmentType
-	4,  // 35: teleport.accesslist.v1.UserAssignments.ownership_type:type_name -> teleport.accesslist.v1.AccessListUserAssignmentType
-	4,  // 36: teleport.accesslist.v1.UserAssignments.membership_type:type_name -> teleport.accesslist.v1.AccessListUserAssignmentType
-	19, // 37: teleport.accesslist.v1.AccessListStatus.current_user_assignments:type_name -> teleport.accesslist.v1.CurrentUserAssignments
-	20, // 38: teleport.accesslist.v1.AccessListStatus.user_assignments:type_name -> teleport.accesslist.v1.UserAssignments
-	39, // [39:39] is the sub-list for method output_type
-	39, // [39:39] is the sub-list for method input_type
-	39, // [39:39] is the sub-list for extension type_name
-	39, // [39:39] is the sub-list for extension extendee
-	0,  // [0:39] is the sub-list for field type_name
+	16, // 11: teleport.accesslist.v1.AccessListOwner.display:type_name -> teleport.accesslist.v1.UserDisplay
+	24, // 12: teleport.accesslist.v1.AccessListAudit.next_audit_date:type_name -> google.protobuf.Timestamp
+	9,  // 13: teleport.accesslist.v1.AccessListAudit.recurrence:type_name -> teleport.accesslist.v1.Recurrence
+	10, // 14: teleport.accesslist.v1.AccessListAudit.notifications:type_name -> teleport.accesslist.v1.Notifications
+	0,  // 15: teleport.accesslist.v1.Recurrence.frequency:type_name -> teleport.accesslist.v1.ReviewFrequency
+	1,  // 16: teleport.accesslist.v1.Recurrence.day_of_month:type_name -> teleport.accesslist.v1.ReviewDayOfMonth
+	25, // 17: teleport.accesslist.v1.Notifications.start:type_name -> google.protobuf.Duration
+	26, // 18: teleport.accesslist.v1.AccessListRequires.traits:type_name -> teleport.trait.v1.Trait
+	26, // 19: teleport.accesslist.v1.AccessListGrants.traits:type_name -> teleport.trait.v1.Trait
+	13, // 20: teleport.accesslist.v1.AccessListGrants.scoped_roles:type_name -> teleport.accesslist.v1.ScopedRoleGrant
+	23, // 21: teleport.accesslist.v1.Member.header:type_name -> teleport.header.v1.ResourceHeader
+	15, // 22: teleport.accesslist.v1.Member.spec:type_name -> teleport.accesslist.v1.MemberSpec
+	24, // 23: teleport.accesslist.v1.MemberSpec.joined:type_name -> google.protobuf.Timestamp
+	24, // 24: teleport.accesslist.v1.MemberSpec.expires:type_name -> google.protobuf.Timestamp
+	3,  // 25: teleport.accesslist.v1.MemberSpec.ineligible_status:type_name -> teleport.accesslist.v1.IneligibleStatus
+	2,  // 26: teleport.accesslist.v1.MemberSpec.membership_kind:type_name -> teleport.accesslist.v1.MembershipKind
+	16, // 27: teleport.accesslist.v1.MemberSpec.display:type_name -> teleport.accesslist.v1.UserDisplay
+	16, // 28: teleport.accesslist.v1.MemberSpec.added_by_display:type_name -> teleport.accesslist.v1.UserDisplay
+	23, // 29: teleport.accesslist.v1.Review.header:type_name -> teleport.header.v1.ResourceHeader
+	18, // 30: teleport.accesslist.v1.Review.spec:type_name -> teleport.accesslist.v1.ReviewSpec
+	24, // 31: teleport.accesslist.v1.ReviewSpec.review_date:type_name -> google.protobuf.Timestamp
+	19, // 32: teleport.accesslist.v1.ReviewSpec.changes:type_name -> teleport.accesslist.v1.ReviewChanges
+	11, // 33: teleport.accesslist.v1.ReviewChanges.membership_requirements_changed:type_name -> teleport.accesslist.v1.AccessListRequires
+	0,  // 34: teleport.accesslist.v1.ReviewChanges.review_frequency_changed:type_name -> teleport.accesslist.v1.ReviewFrequency
+	1,  // 35: teleport.accesslist.v1.ReviewChanges.review_day_of_month_changed:type_name -> teleport.accesslist.v1.ReviewDayOfMonth
+	4,  // 36: teleport.accesslist.v1.CurrentUserAssignments.ownership_type:type_name -> teleport.accesslist.v1.AccessListUserAssignmentType
+	4,  // 37: teleport.accesslist.v1.CurrentUserAssignments.membership_type:type_name -> teleport.accesslist.v1.AccessListUserAssignmentType
+	4,  // 38: teleport.accesslist.v1.UserAssignments.ownership_type:type_name -> teleport.accesslist.v1.AccessListUserAssignmentType
+	4,  // 39: teleport.accesslist.v1.UserAssignments.membership_type:type_name -> teleport.accesslist.v1.AccessListUserAssignmentType
+	20, // 40: teleport.accesslist.v1.AccessListStatus.current_user_assignments:type_name -> teleport.accesslist.v1.CurrentUserAssignments
+	21, // 41: teleport.accesslist.v1.AccessListStatus.user_assignments:type_name -> teleport.accesslist.v1.UserAssignments
+	42, // [42:42] is the sub-list for method output_type
+	42, // [42:42] is the sub-list for method input_type
+	42, // [42:42] is the sub-list for extension type_name
+	42, // [42:42] is the sub-list for extension extendee
+	0,  // [0:42] is the sub-list for field type_name
 }
 
 func init() { file_teleport_accesslist_v1_accesslist_proto_init() }
@@ -2474,14 +2639,14 @@ func file_teleport_accesslist_v1_accesslist_proto_init() {
 	if File_teleport_accesslist_v1_accesslist_proto != nil {
 		return
 	}
-	file_teleport_accesslist_v1_accesslist_proto_msgTypes[16].OneofWrappers = []any{}
+	file_teleport_accesslist_v1_accesslist_proto_msgTypes[17].OneofWrappers = []any{}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_teleport_accesslist_v1_accesslist_proto_rawDesc), len(file_teleport_accesslist_v1_accesslist_proto_rawDesc)),
 			NumEnums:      5,
-			NumMessages:   17,
+			NumMessages:   18,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/api/gen/proto/go/teleport/accesslist/v1/accesslist_protoopaque.pb.go
+++ b/api/gen/proto/go/teleport/accesslist/v1/accesslist_protoopaque.pb.go
@@ -23,15 +23,14 @@
 package accesslistv1
 
 import (
-	reflect "reflect"
-	unsafe "unsafe"
-
 	v1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
 	v11 "github.com/gravitational/teleport/api/gen/proto/go/teleport/trait/v1"
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	durationpb "google.golang.org/protobuf/types/known/durationpb"
 	timestamppb "google.golang.org/protobuf/types/known/timestamppb"
+	reflect "reflect"
+	unsafe "unsafe"
 )
 
 const (

--- a/api/proto/teleport/accesslist/v1/accesslist.proto
+++ b/api/proto/teleport/accesslist/v1/accesslist.proto
@@ -94,6 +94,9 @@ message AccessListOwner {
   // membership_kind describes the type of membership, either
   // `MEMBERSHIP_KIND_USER` or `MEMBERSHIP_KIND_LIST`.
   MembershipKind membership_kind = 4;
+
+  // display holds read-time display values for the owner.
+  UserDisplay display = 5;
 }
 
 // AccessListAudit describes the audit configuration for an Access List.
@@ -220,6 +223,23 @@ message MemberSpec {
   // membership_kind describes the type of membership, either
   // `MEMBERSHIP_KIND_USER` or `MEMBERSHIP_KIND_LIST`.
   MembershipKind membership_kind = 9;
+
+  // display holds read-time display values for the member.
+  UserDisplay display = 10;
+
+  // added_by_display holds read-time display values for the user that added
+  // this member.
+  UserDisplay added_by_display = 11;
+}
+
+// UserDisplay holds read-time display values for a user, derived from the user
+// resource.
+message UserDisplay {
+  // primary is a display name when distinct from the username.
+  string primary = 1;
+
+  // secondary is extra context, when distinct from the username.
+  string secondary = 2;
 }
 
 // MembershipKind represents the different kinds of list membership

--- a/api/types/accesslist/accesslist.go
+++ b/api/types/accesslist/accesslist.go
@@ -224,6 +224,9 @@ type Owner struct {
 	// Description is the plaintext description of the owner and why they are an owner.
 	Description string `json:"description" yaml:"description"`
 
+	// Display contains read-time display values for this owner.
+	Display types.UserDisplay `json:"display" yaml:"display"`
+
 	// IneligibleStatus describes the reason why this owner is not eligible.
 	IneligibleStatus string `json:"ineligible_status" yaml:"ineligible_status"`
 

--- a/api/types/accesslist/accesslist.go
+++ b/api/types/accesslist/accesslist.go
@@ -700,6 +700,7 @@ func WithSkipClone() EqualAccessListsOption {
 //   - Metadata.Revision: Managed by the backend
 //   - Status: Contains dynamically calculated fields (member counts, assignments, etc.)
 //   - Owner.IneligibleStatus: Managed by the IneligibleStatusReconciler
+//   - Owner.Display: Read-time display values derived from the user resource
 //
 // Note: This option causes the input access lists to be cloned (unless WithSkipClone
 // is also used) to avoid modifying the originals.
@@ -781,5 +782,6 @@ func resetEphemeralFieldsAccessList(a *AccessList) {
 	a.Status = Status{}
 	for i := range a.Spec.Owners {
 		a.Spec.Owners[i].IneligibleStatus = ""
+		a.Spec.Owners[i].Display = types.UserDisplay{}
 	}
 }

--- a/api/types/accesslist/accesslist_test.go
+++ b/api/types/accesslist/accesslist_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/jonboulle/clockwork"
 	"github.com/stretchr/testify/require"
 
+	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/types/header"
 	"github.com/gravitational/teleport/api/utils/testutils/structfill"
 )
@@ -539,6 +540,16 @@ func TestEqualIgnoreEphemeralFields(t *testing.T) {
 		require.True(t, result)
 	})
 
+	t.Run("different owner display is ignored", func(t *testing.T) {
+		al1 := createAccessList("test1")
+		al2 := createAccessList("test1")
+		al2.Spec.Owners[0].Display = types.UserDisplay{Primary: "Alice Anderson", Secondary: "alice@example.com"}
+		al2.Spec.Owners[1].Display = types.UserDisplay{Primary: "Bob Brown"}
+
+		result := EqualAccessLists(al1, al2, WithIgnoreEphemeralFields())
+		require.True(t, result)
+	})
+
 	t.Run("all ignored fields different at once", func(t *testing.T) {
 		al1 := createAccessList("test1")
 		al2 := createAccessList("test1")
@@ -548,6 +559,8 @@ func TestEqualIgnoreEphemeralFields(t *testing.T) {
 		al2.Status.OwnerOf = []string{"completely", "different", "lists"}
 		al2.Spec.Owners[0].IneligibleStatus = "new-reason-1"
 		al2.Spec.Owners[1].IneligibleStatus = "new-reason-2"
+		al2.Spec.Owners[0].Display = types.UserDisplay{Primary: "Alice Anderson"}
+		al2.Spec.Owners[1].Display = types.UserDisplay{Secondary: "bob@example.com"}
 
 		result := EqualAccessLists(al1, al2, WithIgnoreEphemeralFields())
 		require.True(t, result)

--- a/api/types/accesslist/convert/v1/accesslist.go
+++ b/api/types/accesslist/convert/v1/accesslist.go
@@ -24,6 +24,7 @@ import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	accesslistv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/accesslist/v1"
+	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/types/accesslist"
 	headerv1 "github.com/gravitational/teleport/api/types/header/convert/v1"
 	traitv1 "github.com/gravitational/teleport/api/types/trait/convert/v1"
@@ -134,7 +135,8 @@ func convertOwnersFromProto(protoOwners []*accesslistv1.AccessListOwner) []acces
 	owners := make([]accesslist.Owner, len(protoOwners))
 	for i, owner := range protoOwners {
 		owners[i] = FromOwnerProto(owner)
-		owners[i].IneligibleStatus = "" // default, overridden via option if needed
+		owners[i].IneligibleStatus = ""         // default, overridden via option if needed
+		owners[i].Display = types.UserDisplay{} // default, overridden via option if needed
 	}
 	return owners
 }
@@ -189,6 +191,7 @@ func ToOwnerProto(owner accesslist.Owner) *accesslistv1.AccessListOwner {
 		Description:      owner.Description,
 		IneligibleStatus: ineligibleStatus,
 		MembershipKind:   kind,
+		Display:          toProtoUserDisplay(owner.Display),
 	}
 }
 
@@ -205,6 +208,7 @@ func FromOwnerProto(protoOwner *accesslistv1.AccessListOwner) accesslist.Owner {
 	return accesslist.Owner{
 		Name:             protoOwner.GetName(),
 		Description:      protoOwner.GetDescription(),
+		Display:          fromProtoUserDisplay(protoOwner.GetDisplay()),
 		IneligibleStatus: ineligibleStatus,
 		MembershipKind:   protoOwner.GetMembershipKind().String(),
 	}
@@ -224,6 +228,38 @@ func WithOwnersIneligibleStatusField(protoOwners []*accesslistv1.AccessListOwner
 			updatedOwners[i] = owner
 		}
 		a.SetOwners(updatedOwners)
+	}
+}
+
+// WithOwnersDisplayField sets owner display fields to the provided proto values.
+func WithOwnersDisplayField(protoOwners []*accesslistv1.AccessListOwner) AccessListOption {
+	return func(a *accesslist.AccessList) {
+		updatedOwners := make([]accesslist.Owner, len(a.GetOwners()))
+		for i, owner := range a.GetOwners() {
+			owner.Display = fromProtoUserDisplay(protoOwners[i].GetDisplay())
+			updatedOwners[i] = owner
+		}
+		a.SetOwners(updatedOwners)
+	}
+}
+
+func toProtoUserDisplay(display types.UserDisplay) *accesslistv1.UserDisplay {
+	if display == (types.UserDisplay{}) {
+		return nil
+	}
+	return &accesslistv1.UserDisplay{
+		Primary:   display.Primary,
+		Secondary: display.Secondary,
+	}
+}
+
+func fromProtoUserDisplay(display *accesslistv1.UserDisplay) types.UserDisplay {
+	if display == nil {
+		return types.UserDisplay{}
+	}
+	return types.UserDisplay{
+		Primary:   display.GetPrimary(),
+		Secondary: display.GetSecondary(),
 	}
 }
 

--- a/api/types/accesslist/convert/v1/accesslist_test.go
+++ b/api/types/accesslist/convert/v1/accesslist_test.go
@@ -91,6 +91,62 @@ func TestWithOwnersIneligibleStatusField(t *testing.T) {
 	}))
 }
 
+func TestWithOwnersDisplayField(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name    string
+		display types.UserDisplay
+	}{
+		{
+			name:    "both values",
+			display: types.UserDisplay{Primary: "Alice Anderson", Secondary: "alice@example.com"},
+		},
+		{
+			name:    "primary only",
+			display: types.UserDisplay{Primary: "Alice Anderson"},
+		},
+		{
+			name:    "secondary only",
+			display: types.UserDisplay{Secondary: "alice@example.com"},
+		},
+		{
+			name: "empty",
+		},
+	}
+
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			accessList := newAccessList(t, "access-list")
+			accessList.Spec.Owners = []accesslist.Owner{
+				{Name: "owner", Display: tt.display},
+			}
+			proto := ToProto(accessList)
+
+			converted, err := FromProto(proto, WithOwnersDisplayField(proto.GetSpec().GetOwners()))
+			require.NoError(t, err)
+			require.Equal(t, tt.display, converted.Spec.Owners[0].Display)
+
+			converted, err = FromProto(proto)
+			require.NoError(t, err)
+			require.Empty(t, converted.Spec.Owners[0].Display)
+		})
+	}
+}
+
+func TestWithOwnersDisplayFieldNils(t *testing.T) {
+	t.Parallel()
+
+	proto := ToProto(newAccessList(t, "access-list"))
+	proto.Spec.Owners[0].Display = nil
+
+	converted, err := FromProto(proto, WithOwnersDisplayField(proto.GetSpec().GetOwners()))
+	require.NoError(t, err)
+	require.Empty(t, converted.Spec.Owners[0].Display)
+}
+
 func TestRoundtrip(t *testing.T) {
 	t.Parallel()
 

--- a/api/types/accesslist/convert/v1/member.go
+++ b/api/types/accesslist/convert/v1/member.go
@@ -65,7 +65,7 @@ func FromMembersProto(msgs []*accesslistv1.Member) ([]*accesslist.AccessListMemb
 	members := make([]*accesslist.AccessListMember, len(msgs))
 	for i, msg := range msgs {
 		var err error
-		members[i], err = FromMemberProto(msg, WithMemberIneligibleStatusField(msg))
+		members[i], err = FromMemberProto(msg, WithMemberIneligibleStatusField(msg), WithMemberDisplayField(msg))
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
@@ -96,6 +96,8 @@ func ToMemberProto(member *accesslist.AccessListMember) *accesslistv1.Member {
 			AddedBy:          member.Spec.AddedBy,
 			IneligibleStatus: ineligibleStatus,
 			MembershipKind:   membershipKind,
+			Display:          toProtoUserDisplay(member.Spec.Display),
+			AddedByDisplay:   toProtoUserDisplay(member.Spec.AddedByDisplay),
 		},
 	}
 }
@@ -118,5 +120,13 @@ func WithMemberIneligibleStatusField(protoMember *accesslistv1.Member) MemberOpt
 			ineligibleStatus = protoIneligibleStatus.String()
 		}
 		m.Spec.IneligibleStatus = ineligibleStatus
+	}
+}
+
+// WithMemberDisplayField sets the display fields to the provided proto values.
+func WithMemberDisplayField(protoMember *accesslistv1.Member) MemberOption {
+	return func(m *accesslist.AccessListMember) {
+		m.Spec.Display = fromProtoUserDisplay(protoMember.GetSpec().GetDisplay())
+		m.Spec.AddedByDisplay = fromProtoUserDisplay(protoMember.GetSpec().GetAddedByDisplay())
 	}
 }

--- a/api/types/accesslist/convert/v1/member_test.go
+++ b/api/types/accesslist/convert/v1/member_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	accesslistv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/accesslist/v1"
+	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/types/accesslist"
 	"github.com/gravitational/teleport/api/types/header"
 )
@@ -53,6 +54,69 @@ func TestWithMemberIneligibleStatusField(t *testing.T) {
 	fn(alMember)
 
 	require.Equal(t, accesslistv1.IneligibleStatus_INELIGIBLE_STATUS_EXPIRED.Enum().String(), alMember.Spec.IneligibleStatus)
+}
+
+func TestWithMemberDisplayField(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name           string
+		display        types.UserDisplay
+		addedByDisplay types.UserDisplay
+	}{
+		{
+			name:           "both values",
+			display:        types.UserDisplay{Primary: "Alice Anderson", Secondary: "alice@example.com"},
+			addedByDisplay: types.UserDisplay{Primary: "Bob Brown", Secondary: "bob@example.com"},
+		},
+		{
+			name:           "primary only",
+			display:        types.UserDisplay{Primary: "Alice Anderson"},
+			addedByDisplay: types.UserDisplay{Primary: "Bob Brown"},
+		},
+		{
+			name:           "secondary only",
+			display:        types.UserDisplay{Secondary: "alice@example.com"},
+			addedByDisplay: types.UserDisplay{Secondary: "bob@example.com"},
+		},
+		{
+			name: "empty",
+		},
+	}
+
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			member := newAccessListMember(t, "access-list-member")
+			member.Spec.Display = tt.display
+			member.Spec.AddedByDisplay = tt.addedByDisplay
+			proto := ToMemberProto(member)
+
+			converted, err := FromMemberProto(proto, WithMemberDisplayField(proto))
+			require.NoError(t, err)
+			require.Equal(t, tt.display, converted.Spec.Display)
+			require.Equal(t, tt.addedByDisplay, converted.Spec.AddedByDisplay)
+
+			converted, err = FromMemberProto(proto)
+			require.NoError(t, err)
+			require.Empty(t, converted.Spec.Display)
+			require.Empty(t, converted.Spec.AddedByDisplay)
+		})
+	}
+}
+
+func TestWithMemberDisplayFieldNils(t *testing.T) {
+	t.Parallel()
+
+	proto := ToMemberProto(newAccessListMember(t, "access-list-member"))
+	proto.Spec.Display = nil
+	proto.Spec.AddedByDisplay = nil
+
+	converted, err := FromMemberProto(proto, WithMemberDisplayField(proto))
+	require.NoError(t, err)
+	require.Empty(t, converted.Spec.Display)
+	require.Empty(t, converted.Spec.AddedByDisplay)
 }
 
 // Make sure that we don't panic if any of the message fields are missing.

--- a/api/types/accesslist/derived.gen.go
+++ b/api/types/accesslist/derived.gen.go
@@ -106,6 +106,8 @@ func deriveTeleportEqual_1(this, that *AccessListMemberSpec) bool {
 			this.Expires.Equal(that.Expires) &&
 			this.Reason == that.Reason &&
 			this.AddedBy == that.AddedBy &&
+			this.Display == that.Display &&
+			this.AddedByDisplay == that.AddedByDisplay &&
 			this.IneligibleStatus == that.IneligibleStatus &&
 			this.MembershipKind == that.MembershipKind
 }
@@ -253,6 +255,8 @@ func deriveDeepCopy_2(dst, src *AccessListMemberSpec) {
 	}()
 	dst.Reason = src.Reason
 	dst.AddedBy = src.AddedBy
+	dst.Display = src.Display
+	dst.AddedByDisplay = src.AddedByDisplay
 	dst.IneligibleStatus = src.IneligibleStatus
 	dst.MembershipKind = src.MembershipKind
 }

--- a/api/types/accesslist/member.go
+++ b/api/types/accesslist/member.go
@@ -62,6 +62,12 @@ type AccessListMemberSpec struct {
 	// added_by is the user that added this user to the access list.
 	AddedBy string `json:"added_by" yaml:"added_by"`
 
+	// Display contains read-time display values for this member.
+	Display types.UserDisplay `json:"display" yaml:"display"`
+
+	// AddedByDisplay contains read-time display values for AddedBy.
+	AddedByDisplay types.UserDisplay `json:"added_by_display" yaml:"added_by_display"`
+
 	// IneligibleStatus describes the reason why this member is not eligible.
 	IneligibleStatus string `json:"ineligible_status" yaml:"ineligible_status"`
 

--- a/api/types/user_display.go
+++ b/api/types/user_display.go
@@ -57,9 +57,9 @@ const (
 // UserDisplay contains display values derived from the user.
 type UserDisplay struct {
 	// Primary is a human-readable display name when distinct from username.
-	Primary string
+	Primary string `json:"primary"`
 	// Secondary is supporting display context when distinct from username.
-	Secondary string
+	Secondary string `json:"secondary"`
 }
 
 // GetDisplay returns display values derived from the user.

--- a/gen/proto/ts/teleport/accesslist/v1/accesslist_pb.ts
+++ b/gen/proto/ts/teleport/accesslist/v1/accesslist_pb.ts
@@ -160,6 +160,12 @@ export interface AccessListOwner {
      * @generated from protobuf field: teleport.accesslist.v1.MembershipKind membership_kind = 4;
      */
     membershipKind: MembershipKind;
+    /**
+     * display holds read-time display values for the owner.
+     *
+     * @generated from protobuf field: teleport.accesslist.v1.UserDisplay display = 5;
+     */
+    display?: UserDisplay;
 }
 /**
  * AccessListAudit describes the audit configuration for an Access List.
@@ -365,6 +371,39 @@ export interface MemberSpec {
      * @generated from protobuf field: teleport.accesslist.v1.MembershipKind membership_kind = 9;
      */
     membershipKind: MembershipKind;
+    /**
+     * display holds read-time display values for the member.
+     *
+     * @generated from protobuf field: teleport.accesslist.v1.UserDisplay display = 10;
+     */
+    display?: UserDisplay;
+    /**
+     * added_by_display holds read-time display values for the user that added
+     * this member.
+     *
+     * @generated from protobuf field: teleport.accesslist.v1.UserDisplay added_by_display = 11;
+     */
+    addedByDisplay?: UserDisplay;
+}
+/**
+ * UserDisplay holds read-time display values for a user, derived from the user
+ * resource.
+ *
+ * @generated from protobuf message teleport.accesslist.v1.UserDisplay
+ */
+export interface UserDisplay {
+    /**
+     * primary is a display name when distinct from the username.
+     *
+     * @generated from protobuf field: string primary = 1;
+     */
+    primary: string;
+    /**
+     * secondary is extra context, usually email, when distinct from the username.
+     *
+     * @generated from protobuf field: string secondary = 2;
+     */
+    secondary: string;
 }
 /**
  * Review is a review of an Access List.
@@ -854,7 +893,8 @@ class AccessListOwner$Type extends MessageType<AccessListOwner> {
             { no: 1, name: "name", kind: "scalar", T: 9 /*ScalarType.STRING*/ },
             { no: 2, name: "description", kind: "scalar", T: 9 /*ScalarType.STRING*/ },
             { no: 3, name: "ineligible_status", kind: "enum", T: () => ["teleport.accesslist.v1.IneligibleStatus", IneligibleStatus, "INELIGIBLE_STATUS_"] },
-            { no: 4, name: "membership_kind", kind: "enum", T: () => ["teleport.accesslist.v1.MembershipKind", MembershipKind, "MEMBERSHIP_KIND_"] }
+            { no: 4, name: "membership_kind", kind: "enum", T: () => ["teleport.accesslist.v1.MembershipKind", MembershipKind, "MEMBERSHIP_KIND_"] },
+            { no: 5, name: "display", kind: "message", T: () => UserDisplay }
         ]);
     }
     create(value?: PartialMessage<AccessListOwner>): AccessListOwner {
@@ -884,6 +924,9 @@ class AccessListOwner$Type extends MessageType<AccessListOwner> {
                 case /* teleport.accesslist.v1.MembershipKind membership_kind */ 4:
                     message.membershipKind = reader.int32();
                     break;
+                case /* teleport.accesslist.v1.UserDisplay display */ 5:
+                    message.display = UserDisplay.internalBinaryRead(reader, reader.uint32(), options, message.display);
+                    break;
                 default:
                     let u = options.readUnknownField;
                     if (u === "throw")
@@ -908,6 +951,9 @@ class AccessListOwner$Type extends MessageType<AccessListOwner> {
         /* teleport.accesslist.v1.MembershipKind membership_kind = 4; */
         if (message.membershipKind !== 0)
             writer.tag(4, WireType.Varint).int32(message.membershipKind);
+        /* teleport.accesslist.v1.UserDisplay display = 5; */
+        if (message.display)
+            UserDisplay.internalBinaryWrite(message.display, writer.tag(5, WireType.LengthDelimited).fork(), options).join();
         let u = options.writeUnknownFields;
         if (u !== false)
             (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
@@ -1316,7 +1362,9 @@ class MemberSpec$Type extends MessageType<MemberSpec> {
             { no: 5, name: "reason", kind: "scalar", T: 9 /*ScalarType.STRING*/ },
             { no: 6, name: "added_by", kind: "scalar", T: 9 /*ScalarType.STRING*/ },
             { no: 7, name: "ineligible_status", kind: "enum", T: () => ["teleport.accesslist.v1.IneligibleStatus", IneligibleStatus, "INELIGIBLE_STATUS_"] },
-            { no: 9, name: "membership_kind", kind: "enum", T: () => ["teleport.accesslist.v1.MembershipKind", MembershipKind, "MEMBERSHIP_KIND_"] }
+            { no: 9, name: "membership_kind", kind: "enum", T: () => ["teleport.accesslist.v1.MembershipKind", MembershipKind, "MEMBERSHIP_KIND_"] },
+            { no: 10, name: "display", kind: "message", T: () => UserDisplay },
+            { no: 11, name: "added_by_display", kind: "message", T: () => UserDisplay }
         ]);
     }
     create(value?: PartialMessage<MemberSpec>): MemberSpec {
@@ -1360,6 +1408,12 @@ class MemberSpec$Type extends MessageType<MemberSpec> {
                 case /* teleport.accesslist.v1.MembershipKind membership_kind */ 9:
                     message.membershipKind = reader.int32();
                     break;
+                case /* teleport.accesslist.v1.UserDisplay display */ 10:
+                    message.display = UserDisplay.internalBinaryRead(reader, reader.uint32(), options, message.display);
+                    break;
+                case /* teleport.accesslist.v1.UserDisplay added_by_display */ 11:
+                    message.addedByDisplay = UserDisplay.internalBinaryRead(reader, reader.uint32(), options, message.addedByDisplay);
+                    break;
                 default:
                     let u = options.readUnknownField;
                     if (u === "throw")
@@ -1396,6 +1450,12 @@ class MemberSpec$Type extends MessageType<MemberSpec> {
         /* teleport.accesslist.v1.MembershipKind membership_kind = 9; */
         if (message.membershipKind !== 0)
             writer.tag(9, WireType.Varint).int32(message.membershipKind);
+        /* teleport.accesslist.v1.UserDisplay display = 10; */
+        if (message.display)
+            UserDisplay.internalBinaryWrite(message.display, writer.tag(10, WireType.LengthDelimited).fork(), options).join();
+        /* teleport.accesslist.v1.UserDisplay added_by_display = 11; */
+        if (message.addedByDisplay)
+            UserDisplay.internalBinaryWrite(message.addedByDisplay, writer.tag(11, WireType.LengthDelimited).fork(), options).join();
         let u = options.writeUnknownFields;
         if (u !== false)
             (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
@@ -1406,6 +1466,61 @@ class MemberSpec$Type extends MessageType<MemberSpec> {
  * @generated MessageType for protobuf message teleport.accesslist.v1.MemberSpec
  */
 export const MemberSpec = new MemberSpec$Type();
+// @generated message type with reflection information, may provide speed optimized methods
+class UserDisplay$Type extends MessageType<UserDisplay> {
+    constructor() {
+        super("teleport.accesslist.v1.UserDisplay", [
+            { no: 1, name: "primary", kind: "scalar", T: 9 /*ScalarType.STRING*/ },
+            { no: 2, name: "secondary", kind: "scalar", T: 9 /*ScalarType.STRING*/ }
+        ]);
+    }
+    create(value?: PartialMessage<UserDisplay>): UserDisplay {
+        const message = globalThis.Object.create((this.messagePrototype!));
+        message.primary = "";
+        message.secondary = "";
+        if (value !== undefined)
+            reflectionMergePartial<UserDisplay>(this, message, value);
+        return message;
+    }
+    internalBinaryRead(reader: IBinaryReader, length: number, options: BinaryReadOptions, target?: UserDisplay): UserDisplay {
+        let message = target ?? this.create(), end = reader.pos + length;
+        while (reader.pos < end) {
+            let [fieldNo, wireType] = reader.tag();
+            switch (fieldNo) {
+                case /* string primary */ 1:
+                    message.primary = reader.string();
+                    break;
+                case /* string secondary */ 2:
+                    message.secondary = reader.string();
+                    break;
+                default:
+                    let u = options.readUnknownField;
+                    if (u === "throw")
+                        throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
+                    let d = reader.skip(wireType);
+                    if (u !== false)
+                        (u === true ? UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            }
+        }
+        return message;
+    }
+    internalBinaryWrite(message: UserDisplay, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
+        /* string primary = 1; */
+        if (message.primary !== "")
+            writer.tag(1, WireType.LengthDelimited).string(message.primary);
+        /* string secondary = 2; */
+        if (message.secondary !== "")
+            writer.tag(2, WireType.LengthDelimited).string(message.secondary);
+        let u = options.writeUnknownFields;
+        if (u !== false)
+            (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+        return writer;
+    }
+}
+/**
+ * @generated MessageType for protobuf message teleport.accesslist.v1.UserDisplay
+ */
+export const UserDisplay = new UserDisplay$Type();
 // @generated message type with reflection information, may provide speed optimized methods
 class Review$Type extends MessageType<Review> {
     constructor() {

--- a/gen/proto/ts/teleport/accesslist/v1/accesslist_pb.ts
+++ b/gen/proto/ts/teleport/accesslist/v1/accesslist_pb.ts
@@ -399,7 +399,7 @@ export interface UserDisplay {
      */
     primary: string;
     /**
-     * secondary is extra context, usually email, when distinct from the username.
+     * secondary is extra context, when distinct from the username.
      *
      * @generated from protobuf field: string secondary = 2;
      */

--- a/integrations/operator/crdgen/ignored.go
+++ b/integrations/operator/crdgen/ignored.go
@@ -49,4 +49,11 @@ var ignoredFields = map[string]stringSet{
 	"TrustedClusterSpecV2": {
 		"Roles": struct{}{}, // Deprecated, use RoleMap instead.
 	},
+	"AccessListOwner": {
+		"display": struct{}{},
+	},
+	"MemberSpec": {
+		"display":          struct{}{},
+		"added_by_display": struct{}{},
+	},
 }

--- a/integrations/terraform/protoc-gen-terraform-accesslist.yaml
+++ b/integrations/terraform/protoc-gen-terraform-accesslist.yaml
@@ -44,11 +44,14 @@ exclude_fields:
     - "AccessList.header.metadata.id"
     # Read only field
     - "AccessList.spec.owners.ineligible_status"
+    - "AccessList.spec.owners.display"
     - "AccessList.status"
     # Metadata (we id resources by name on our side)
     - "Member.header.metadata.id"
     # Read only field
     - "Member.spec.ineligible_status"
+    - "Member.spec.display"
+    - "Member.spec.added_by_display"
 
 # These fields will be marked as Computed: true
 computed_fields:

--- a/lib/tfgen/tfgen_test.go
+++ b/lib/tfgen/tfgen_test.go
@@ -231,7 +231,9 @@ func TestGenerate_AccessList(t *testing.T) {
 	require.NoError(t, err)
 
 	alProto := tfgen.WrapHeaderResource(accesslistconv.ToProto(al))
-	goldenTest(t, alProto)
+	goldenTest(t, alProto,
+		tfgen.WithOmitField("spec.owners.display"),
+	)
 }
 
 func TestGenerate_AccessListMember(t *testing.T) {
@@ -253,6 +255,8 @@ func TestGenerate_AccessListMember(t *testing.T) {
 
 	goldenTest(t,
 		tfgen.WrapHeaderResource(memberProto),
+		tfgen.WithOmitField("spec.display"),
+		tfgen.WithOmitField("spec.added_by_display"),
 	)
 }
 
@@ -314,6 +318,8 @@ func TestGenerate_AccessListMemberOmitField(t *testing.T) {
 	goldenTest(t,
 		tfgen.WrapHeaderResource(memberProto),
 		tfgen.WithOmitField("spec.ineligible_status"),
+		tfgen.WithOmitField("spec.display"),
+		tfgen.WithOmitField("spec.added_by_display"),
 		tfgen.WithOmitField("spec.reason"),
 		tfgen.WithOmitField("spec.added_by"),
 		tfgen.WithOmitField("header.metadata.description"),
@@ -393,6 +399,7 @@ func TestGenerate_AccessListOmitFields(t *testing.T) {
 		tfgen.WithOmitField("spec.owners.description"),
 		tfgen.WithOmitField("spec.audit.recurrence"),
 		tfgen.WithOmitField("spec.owners.ineligible_status"),
+		tfgen.WithOmitField("spec.owners.display"),
 		tfgen.WithOmitField("spec.grants"),
 	)
 }


### PR DESCRIPTION
This PR addresses [#66993](https://github.com/gravitational/teleport/issues/66993) by adding the data-shape plumbing so Access List **member**, member **`added_by`**, and **owner** responses can carry read-time `display`/`added_by_display` values (`{primary, secondary}` derived from the user resource). This lets the Web UI and CLI render human-friendly names. The whole design mirrors the existing `ineligible_status` field on these same messages, end-to-end.

This is the OSS half of the work and is dorment on its own — a follow-up in `gravitational/teleport.e` populates the new fields at read time. 


The following changes were made:

- **Proto (`accesslist.proto`):** Added a reusable `UserDisplay` message (`primary`, `secondary`), `display` and `added_by_display` on `MemberSpec`, and `display` on `AccessListOwner`. Regenerated the Go and TypeScript artifacts.

- **Go domain types (`api/types/accesslist`):** Added json-tagged `Display`/`AddedByDisplay` to `AccessListMemberSpec` and `Display` to `Owner`, reusing `types.UserDisplay`. 

- **Converters (`convert/v1`):** `To*Proto`/`From*Proto` map display values both directions. Display defaults to empty on read and is populated only via the explicit opt-in options `WithMemberDisplayField` / `WithOwnersDisplayField`, so writes never persist display.

- **Client (`api/client/accesslist`):** Read methods now pass the new display options alongside the existing ineligible-status options, so the converted Go types (and thus Web UI JSON) preserve display values returned by the auth server.

- **Terraform/K8s CRD schema:** Excluded the new display fields from the generated tfschema (read-only output, treated like `ineligible_status`). Same fields added in CRD ignore list. 

[Downstream usage in e](https://github.com/gravitational/teleport.e/pull/8932/changes).



