### PR TITLE
Quarantine corrupt events

### DIFF
--- a/lib/events/auditqueue/metrics.go
+++ b/lib/events/auditqueue/metrics.go
@@ -97,6 +97,30 @@ var eventsDelivered = prometheus.NewCounter(
 	},
 )
 
+var corruptEvents = prometheus.NewCounter(
+	prometheus.CounterOpts{
+		Namespace: teleport.MetricNamespace,
+		Name:      "audit_queue_corrupt_events_total",
+		Help:      "Total number of audit events quarantined after failing to deserialize.",
+	},
+)
+
+var corruptRecovered = prometheus.NewCounter(
+	prometheus.CounterOpts{
+		Namespace: teleport.MetricNamespace,
+		Name:      "audit_queue_corrupt_events_recovered_total",
+		Help:      "Total number of quarantined audit events that later deserialized and were re-queued for delivery.",
+	},
+)
+
+var corruptExpired = prometheus.NewCounter(
+	prometheus.CounterOpts{
+		Namespace: teleport.MetricNamespace,
+		Name:      "audit_queue_corrupt_events_expired_total",
+		Help:      "Total number of corrupt audit events permanently dropped after exceeding the retention TTL.",
+	},
+)
+
 var prometheusCollectors = []prometheus.Collector{
 	batchSize,
 	orphansAdopted,
@@ -107,4 +131,7 @@ var prometheusCollectors = []prometheus.Collector{
 	deadLetterExpired,
 	eventsEnqueued,
 	eventsDelivered,
+	corruptEvents,
+	corruptRecovered,
+	corruptExpired,
 }

--- a/lib/events/auditqueue/sqlite.go
+++ b/lib/events/auditqueue/sqlite.go
@@ -43,6 +43,7 @@ const (
 	sqlitePageSize                 = 4096 // Bytes
 	auditQueueTable                = "audit_queue"
 	auditDeadLetterTable           = "audit_dead_letter"
+	corruptEventsTable             = "corrupt_events"
 	defaultMaxAttempts             = 10
 	defaultDeadLetterSweepInterval = 10 * time.Minute
 	defaultDeadLetterTTL           = 30 * 24 * time.Hour // 30 days
@@ -96,8 +97,7 @@ CREATE TABLE IF NOT EXISTS teleport_info (
 
 -- We need AUTOINCREMENT here to ensure the recoveryWatermark has a
 -- monotonically incrementing id. We need to ensure that the 'id' is never
--- re-used for this table. Other tables do not have this requirement.
--- See: https://sqlite.org/autoinc.html
+-- re-used for this table.
 CREATE TABLE IF NOT EXISTS corrupt_events (
     id        INTEGER PRIMARY KEY AUTOINCREMENT,
     payload   BLOB    NOT NULL,
@@ -139,6 +139,12 @@ type sqliteQueue struct {
 	deadLetterSweepInterval time.Duration
 	deadLetterTTL           time.Duration
 	synchronous             SynchronousMode
+
+	// recoveryWatermark is the highest corrupt_events id that
+	// recoverCorruptEvents has already examined in this process. It only ever
+	// climbs, so each pass skips rows it has already tried.
+	recoveryWatermark int64
+
 	// deadLetterKick wakes the dead-letter sweeper ahead of its timer. It has
 	// capacity 1 so pending kicks coalesce into a single sweep.
 	deadLetterKick chan struct{}
@@ -596,6 +602,8 @@ func (q *sqliteQueue) deadLetterSweepLoop(ctx context.Context, handler Handler) 
 		}
 		q.sweepDeadLetter(ctx, handler)
 		q.expireDeadLetter()
+		q.recoverCorruptEvents()
+		q.expireCorruptEvents()
 		timer.Reset(q.deadLetterSweepInterval)
 	}
 }
@@ -668,7 +676,28 @@ func (q *sqliteQueue) fetchDeadLetterRange(afterID, maxID int64, limit int) ([]I
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	return scanItems(rows)
+	items, corrupt, err := scanItems(rows)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	handleCorrupt(q.ctx, q.db, auditDeadLetterTable, corrupt)
+	return items, nil
+}
+
+// fetchDeadLetter reads up to `limit` oldest items from the audit_dead_letter
+// table, quarantining any rows whose payload fails to deserialize.
+func (q *sqliteQueue) fetchDeadLetter(limit int) ([]Item, error) {
+	rows, err := q.db.QueryContext(q.ctx,
+		"SELECT id, payload FROM audit_dead_letter ORDER BY id ASC LIMIT ?", limit)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	items, corrupt, err := scanItems(rows)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	handleCorrupt(q.ctx, q.db, auditDeadLetterTable, corrupt)
+	return items, nil
 }
 
 // ackDeadLetter deletes successfully re-delivered items from audit_dead_letter.
@@ -709,6 +738,143 @@ func (q *sqliteQueue) expireDeadLetter() {
 	}
 }
 
+func (q *sqliteQueue) expireCorruptEvents() {
+	cutoff := time.Now().Add(-q.deadLetterTTL).Unix()
+	res, err := q.db.ExecContext(q.ctx,
+		"DELETE FROM corrupt_events WHERE failed_at < ?", cutoff)
+	if err != nil {
+		if q.ctx.Err() == nil {
+			slog.ErrorContext(q.ctx,
+				"Failed to expire corrupt audit events.",
+				"error", err,
+			)
+		}
+		return
+	}
+	n, err := res.RowsAffected()
+	if err != nil || n == 0 {
+		return
+	}
+	corruptExpired.Add(float64(n))
+	slog.WarnContext(q.ctx,
+		"Permanently dropped corrupt audit events that exceeded the retention TTL.",
+		"count", n,
+		"ttl", q.deadLetterTTL,
+	)
+}
+
+func (q *sqliteQueue) recoverCorruptEvents() {
+	var total int
+	for {
+		if q.ctx.Err() != nil {
+			return
+		}
+		batch, err := fetchCorruptForRecovery(q.ctx, q.db, q.recoveryWatermark, dequeueBatchSize)
+		if err != nil {
+			if q.ctx.Err() == nil {
+				slog.ErrorContext(q.ctx,
+					"Failed to read corrupt audit events for recovery.",
+					"error", err,
+				)
+			}
+			return
+		}
+		if len(batch) == 0 {
+			break
+		}
+
+		var recovered []recoveredEvent
+		for _, r := range batch {
+			var oneOf apievents.OneOf
+			if err := oneOf.Unmarshal(r.payload); err != nil {
+				continue
+			}
+			if _, err := apievents.FromOneOf(oneOf); err != nil {
+				continue
+			}
+			// The event deserializes, so it is no longer corrupt and can be
+			// re-sent.
+			recovered = append(recovered, r)
+		}
+		if len(recovered) > 0 {
+			if err := q.reinjectRecovered(recovered); err != nil {
+				if q.ctx.Err() == nil {
+					slog.ErrorContext(q.ctx,
+						"Failed to re-queue recovered audit events.",
+						"error", err,
+						"count", len(recovered),
+					)
+				}
+				// Leave the watermark unmoved so this batch is retried next pass
+				// rather than skipped until the next process restart.
+				return
+			}
+			corruptRecovered.Add(float64(len(recovered)))
+			total += len(recovered)
+		}
+		// Advance only after the batch is fully handled.
+		q.recoveryWatermark = batch[len(batch)-1].id
+	}
+	if total > 0 {
+		slog.InfoContext(q.ctx,
+			"Recovered previously-corrupt audit events and re-queued them for delivery.",
+			"count", total,
+		)
+	}
+}
+
+type recoveredEvent struct {
+	id      int64
+	payload []byte
+}
+
+func fetchCorruptForRecovery(ctx context.Context, db *sql.DB, afterID int64, limit int) ([]recoveredEvent, error) {
+	rows, err := db.QueryContext(ctx,
+		"SELECT id, payload FROM corrupt_events WHERE id > ? ORDER BY id ASC LIMIT ?", afterID, limit)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	defer rows.Close()
+	var out []recoveredEvent
+	for rows.Next() {
+		var r recoveredEvent
+		if err := rows.Scan(&r.id, &r.payload); err != nil {
+			return nil, trace.Wrap(err)
+		}
+		out = append(out, r)
+	}
+	return out, trace.Wrap(rows.Err())
+}
+
+// reinjectRecovered atomically moves recovered events back into audit_queue and
+// removes them from corrupt_events.
+func (q *sqliteQueue) reinjectRecovered(events []recoveredEvent) error {
+	tx, err := q.db.BeginTx(q.ctx, nil)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	defer tx.Rollback()
+
+	insertStmt, err := tx.PrepareContext(q.ctx, "INSERT INTO audit_queue (payload) VALUES (?)")
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	defer insertStmt.Close()
+
+	ids := make([]int64, 0, len(events))
+	for _, e := range events {
+		if _, err := insertStmt.ExecContext(q.ctx, e.payload); err != nil {
+			return trace.Wrap(err)
+		}
+		ids = append(ids, e.id)
+	}
+
+	if err := deleteIDsFromTable(q.ctx, tx, corruptEventsTable, ids); err != nil {
+		return trace.Wrap(err)
+	}
+	return trace.Wrap(tx.Commit())
+}
+
 func (q *sqliteQueue) fetch(limit int) ([]Item, error) {
 	return fetchDB(q.ctx, q.db, limit)
 }
@@ -723,6 +889,100 @@ func (q *sqliteQueue) ack(items []Item) error {
 	return trace.Wrap(err)
 }
 
+// corruptRow is a queue row whose payload failed to deserialize. Such rows are
+// moved to the corrupt_events table so they do not clog the queue.
+type corruptRow struct {
+	id      int64
+	payload []byte
+	err     error
+}
+
+func scanItems(rows *sql.Rows) (items []Item, corrupt []corruptRow, err error) {
+	defer rows.Close()
+	for rows.Next() {
+		var (
+			id      int64
+			payload []byte
+		)
+		if err := rows.Scan(&id, &payload); err != nil {
+			return nil, nil, trace.Wrap(err)
+		}
+
+		var oneOf apievents.OneOf
+		if err := oneOf.Unmarshal(payload); err != nil {
+			corrupt = append(corrupt, corruptRow{id: id, payload: payload, err: err})
+			continue
+		}
+		event, err := apievents.FromOneOf(oneOf)
+		if err != nil {
+			corrupt = append(corrupt, corruptRow{id: id, payload: payload, err: err})
+			continue
+		}
+		items = append(items, Item{id: id, Event: event})
+	}
+	return items, corrupt, trace.Wrap(rows.Err())
+}
+
+func quarantineCorrupt(ctx context.Context, db *sql.DB, sourceTable string, corrupt []corruptRow) error {
+	if len(corrupt) == 0 {
+		return nil
+	}
+	switch sourceTable {
+	case auditQueueTable, auditDeadLetterTable:
+	default:
+		return trace.BadParameter("unknown table %q", sourceTable)
+	}
+
+	tx, err := db.BeginTx(ctx, nil)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	defer tx.Rollback()
+
+	insertStmt, err := tx.PrepareContext(ctx,
+		"INSERT INTO corrupt_events (payload, error, source, failed_at) VALUES (?, ?, ?, ?)")
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	defer insertStmt.Close()
+
+	ids := make([]int64, 0, len(corrupt))
+	failedAt := time.Now().Unix()
+	for _, c := range corrupt {
+		if _, err := insertStmt.ExecContext(ctx, c.payload, c.err.Error(), sourceTable, failedAt); err != nil {
+			return trace.Wrap(err)
+		}
+		ids = append(ids, c.id)
+	}
+
+	if err := deleteIDsFromTable(ctx, tx, sourceTable, ids); err != nil {
+		return trace.Wrap(err)
+	}
+	return trace.Wrap(tx.Commit())
+}
+
+func handleCorrupt(ctx context.Context, db *sql.DB, sourceTable string, corrupt []corruptRow) {
+	if len(corrupt) == 0 {
+		return
+	}
+	if err := quarantineCorrupt(ctx, db, sourceTable, corrupt); err != nil {
+		slog.ErrorContext(ctx,
+			"Failed to quarantine corrupt audit events.",
+			"error", err,
+			"source_table", sourceTable,
+			"count", len(corrupt),
+		)
+		return
+	}
+	corruptEvents.Add(float64(len(corrupt)))
+	slog.WarnContext(ctx,
+		"Quarantined corrupt audit events that failed to deserialize.",
+		"source_table", sourceTable,
+		"count", len(corrupt),
+		"first_error", corrupt[0].err.Error(),
+	)
+}
+
 // fetchDB reads up to `limit` oldest items from the table `audit_queue`.
 func fetchDB(ctx context.Context, db *sql.DB, limit int) ([]Item, error) {
 	if limit <= 0 {
@@ -733,31 +993,12 @@ func fetchDB(ctx context.Context, db *sql.DB, limit int) ([]Item, error) {
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	return scanItems(rows)
-}
-
-func scanItems(rows *sql.Rows) ([]Item, error) {
-	defer rows.Close()
-	var items []Item
-	for rows.Next() {
-		var (
-			id      int64
-			payload []byte
-		)
-		if err := rows.Scan(&id, &payload); err != nil {
-			return nil, trace.Wrap(err)
-		}
-		var oneOf apievents.OneOf
-		if err := oneOf.Unmarshal(payload); err != nil {
-			return nil, trace.Wrap(err)
-		}
-		event, err := apievents.FromOneOf(oneOf)
-		if err != nil {
-			return nil, trace.Wrap(err)
-		}
-		items = append(items, Item{id: id, Event: event})
+	items, corrupt, err := scanItems(rows)
+	if err != nil {
+		return nil, trace.Wrap(err)
 	}
-	return items, trace.Wrap(rows.Err())
+	handleCorrupt(ctx, db, auditQueueTable, corrupt)
+	return items, nil
 }
 
 func placeholders(n int) string {
@@ -767,21 +1008,27 @@ func placeholders(n int) string {
 	return strings.Repeat("?,", n-1) + "?"
 }
 
-func deleteIDsFromTable(ctx context.Context, db *sql.DB, table string, ids []int64) error {
+// execer is satisfied by both *sql.DB and *sql.Tx, so deleteIDsFromTable can
+// run standalone or inside a caller's transaction.
+type execer interface {
+	ExecContext(ctx context.Context, query string, args ...any) (sql.Result, error)
+}
+
+func deleteIDsFromTable(ctx context.Context, e execer, table string, ids []int64) error {
 	if len(ids) == 0 {
 		return nil
 	}
 	switch table {
-	case auditQueueTable, auditDeadLetterTable:
+	case auditQueueTable, auditDeadLetterTable, corruptEventsTable:
 	default:
 		return trace.BadParameter("unknown table %q", table)
 	}
-	query := "DELETE FROM " + table + " WHERE id IN (" + placeholders(len(ids)) + ")"
 	args := make([]any, len(ids))
 	for i, id := range ids {
 		args[i] = id
 	}
-	_, err := db.ExecContext(ctx, query, args...)
+	_, err := e.ExecContext(ctx,
+		"DELETE FROM "+table+" WHERE id IN ("+placeholders(len(ids))+")", args...)
 	return trace.Wrap(err)
 }
 

--- a/lib/events/auditqueue/sqlite_disk.go
+++ b/lib/events/auditqueue/sqlite_disk.go
@@ -540,7 +540,10 @@ func (q *sqliteQueue) migrateOrphanDB(ctx context.Context, db *sql.DB, name stri
 	if err := q.migrateOrphanQueue(ctx, db, name); err != nil {
 		return trace.Wrap(err)
 	}
-	return trace.Wrap(q.migrateOrphanDeadLetter(ctx, db, name))
+	if err := q.migrateOrphanDeadLetter(ctx, db, name); err != nil {
+		return trace.Wrap(err)
+	}
+	return trace.Wrap(q.migrateOrphanCorruptEvents(ctx, db, name))
 }
 
 func (q *sqliteQueue) migrateOrphanQueue(ctx context.Context, orphan *sql.DB, name string) error {
@@ -614,9 +617,10 @@ func (q *sqliteQueue) readOrphanWatermark(ctx context.Context, key string) (int6
 
 func (q *sqliteQueue) clearOrphanWatermarks(ctx context.Context, name string) {
 	if _, err := q.db.ExecContext(ctx,
-		"DELETE FROM teleport_info WHERE key IN (?, ?)",
+		"DELETE FROM teleport_info WHERE key IN (?, ?, ?)",
 		orphanWatermarkKey(name, auditQueueTable),
 		orphanWatermarkKey(name, auditDeadLetterTable),
+		orphanWatermarkKey(name, corruptEventsTable),
 	); err != nil {
 		slog.ErrorContext(q.ctx,
 			"Failed to clear orphan migration watermarks.",
@@ -682,6 +686,13 @@ func (q *sqliteQueue) insertMigratedBatch(ctx context.Context, insertSQL string,
 	return trace.Wrap(tx.Commit())
 }
 
+func (q *sqliteQueue) migrateOrphanCorruptEvents(ctx context.Context, orphan *sql.DB, name string) error {
+	return q.migrateOrphanTable(ctx, orphan, name, corruptEventsTable,
+		"SELECT id, payload, error, source, failed_at FROM corrupt_events WHERE id > ? ORDER BY id ASC LIMIT ?",
+		"INSERT INTO corrupt_events (payload, error, source, failed_at) VALUES (?, ?, ?, ?)",
+	)
+}
+
 func (q *sqliteQueue) Close() error {
 	var errs []error
 	q.closeOnce.Do(func() {
@@ -727,11 +738,13 @@ func (q *sqliteQueue) Close() error {
 	return trace.NewAggregate(errs...)
 }
 
+const isEmptyQuery = `SELECT EXISTS(SELECT 1 FROM audit_queue)
+	OR EXISTS(SELECT 1 FROM audit_dead_letter)
+	OR EXISTS(SELECT 1 FROM corrupt_events)`
+
 func isQueueEmpty(db *sql.DB) (bool, error) {
 	var hasRows int
-	err := db.QueryRow(
-		"SELECT EXISTS(SELECT 1 FROM audit_queue) OR EXISTS(SELECT 1 FROM audit_dead_letter)",
-	).Scan(&hasRows)
+	err := db.QueryRow(isEmptyQuery).Scan(&hasRows)
 	if err != nil {
 		return false, trace.Wrap(err)
 	}

--- a/lib/events/auditqueue/sqlite_test.go
+++ b/lib/events/auditqueue/sqlite_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/gravitational/teleport"
+	apievents "github.com/gravitational/teleport/api/types/events"
 )
 
 const queueDir = "test-queue"
@@ -71,7 +72,8 @@ func fetchDeadLetter(ctx context.Context, db *sql.DB, limit int) ([]Item, error)
 	if err != nil {
 		return nil, err
 	}
-	return scanItems(rows)
+	items, _, err := scanItems(rows)
+	return items, err
 }
 
 func TestEnqueueDequeue_FIFO(t *testing.T) {
@@ -867,7 +869,7 @@ func TestIsSQLiteFullError(t *testing.T) {
 	t.Parallel()
 
 	dbPath := filepath.Join(t.TempDir(), "test.db")
-	db, err := sql.Open("sqlite", getDSN(dbPath, 10*sqlitePageSize, SynchronousNormal))
+	db, err := sql.Open("sqlite", getDSN(dbPath, 50*sqlitePageSize, SynchronousNormal))
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = db.Close() })
 
@@ -1169,6 +1171,283 @@ func TestDeadLetterTTL_ExpiresOldRows(t *testing.T) {
 	dlItems, err = fetchDeadLetter(q.ctx, q.db, 10)
 	require.NoError(t, err)
 	require.Empty(t, dlItems, "row should have been deleted by expireDeadLetter")
+}
+
+var corruptPayload = []byte{0xff, 0xff, 0xff}
+
+func countRows(t *testing.T, q *sqliteQueue, table string) int {
+	t.Helper()
+	var n int
+	require.NoError(t, q.db.QueryRow("SELECT COUNT(*) FROM "+table).Scan(&n))
+	return n
+}
+
+func TestFetch_QuarantinesCorruptEvent(t *testing.T) {
+	t.Parallel()
+	q := newSqliteTestQueue(t)
+
+	_, err := q.db.Exec("INSERT INTO audit_queue (payload) VALUES (?)", corruptPayload)
+	require.NoError(t, err)
+	for i := int64(0); i < 3; i++ {
+		require.NoError(t, q.Enqueue(newTestEvent(i)))
+	}
+
+	require.Equal(t, 1, countRows(t, q, "audit_queue WHERE payload = x'ffffff'"),
+		"corrupt row should be removed from audit_queue")
+
+	items, err := q.fetch(10)
+	require.NoError(t, err)
+	require.Len(t, items, 3, "the three good events should still be returned")
+	for i, item := range items {
+		require.Equal(t, int64(i), item.Event.GetIndex())
+	}
+
+	require.Zero(t, countRows(t, q, "audit_queue WHERE payload = x'ffffff'"),
+		"corrupt row should be removed from audit_queue")
+
+	var (
+		payload []byte
+		errMsg  string
+		source  string
+	)
+	require.NoError(t, q.db.QueryRow(
+		"SELECT payload, error, source FROM corrupt_events").Scan(&payload, &errMsg, &source))
+	require.Equal(t, corruptPayload, payload)
+	require.NotEmpty(t, errMsg, "the deserialization error should be recorded")
+	require.Equal(t, auditQueueTable, source)
+}
+
+func TestFetch_CorruptDoesNotBlockQueue(t *testing.T) {
+	t.Parallel()
+	q := newSqliteTestQueue(t)
+
+	_, err := q.db.Exec("INSERT INTO audit_queue (payload) VALUES (?)", corruptPayload)
+	require.NoError(t, err)
+	for i := range int64(3) {
+		require.NoError(t, q.Enqueue(newTestEvent(i)))
+	}
+
+	var delivered []int64
+	for {
+		items, err := q.fetch(10)
+		require.NoError(t, err)
+		if len(items) == 0 {
+			break
+		}
+		for _, item := range items {
+			delivered = append(delivered, item.Event.GetIndex())
+		}
+		require.NoError(t, q.ack(items))
+	}
+
+	require.Equal(t, []int64{0, 1, 2}, delivered, "all good events should drain")
+	require.Zero(t, countRows(t, q, auditQueueTable), "queue should be fully drained")
+	require.Equal(t, 1, countRows(t, q, "corrupt_events"))
+}
+
+func TestFetchDeadLetter_QuarantinesCorrupt(t *testing.T) {
+	t.Parallel()
+	q := newSqliteTestQueue(t)
+
+	_, err := q.db.Exec(
+		"INSERT INTO audit_dead_letter (payload, failed_at) VALUES (?, ?)",
+		corruptPayload, time.Now().Unix())
+	require.NoError(t, err)
+
+	items, err := q.fetchDeadLetter(10)
+	require.NoError(t, err)
+	require.Empty(t, items)
+
+	require.Zero(t, countRows(t, q, auditDeadLetterTable),
+		"corrupt row should be removed from audit_dead_letter")
+
+	var source string
+	require.NoError(t, q.db.QueryRow("SELECT source FROM corrupt_events").Scan(&source))
+	require.Equal(t, auditDeadLetterTable, source)
+}
+
+func TestExpireCorruptEvents(t *testing.T) {
+	t.Parallel()
+
+	q, err := newSQLiteQueue(Config{
+		Path:          filepath.Join(t.TempDir(), queueDir),
+		DeadLetterTTL: time.Hour,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = q.Close() })
+
+	old := time.Now().Add(-2 * time.Hour).Unix()
+	recent := time.Now().Unix()
+	_, err = q.db.Exec(
+		"INSERT INTO corrupt_events (payload, error, source, failed_at) VALUES (?, 'boom', 'audit_queue', ?), (?, 'boom', 'audit_queue', ?)",
+		corruptPayload, old, corruptPayload, recent)
+	require.NoError(t, err)
+
+	q.expireCorruptEvents()
+
+	require.Equal(t, 1, countRows(t, q, "corrupt_events"), "only the recent corrupt row should remain")
+}
+
+func TestRecoverCorruptEvents(t *testing.T) {
+	t.Parallel()
+	q := newSqliteTestQueue(t)
+
+	// A genuinely corrupt payload that will never deserialize.
+	_, err := q.db.Exec(
+		"INSERT INTO corrupt_events (payload, error, source, failed_at) VALUES (?, 'boom', 'audit_queue', ?)",
+		corruptPayload, time.Now().Unix())
+	require.NoError(t, err)
+
+	// A valid payload that now deserializes, as if written by a newer binary
+	// and quarantined before an upgrade made it readable.
+	oneOf, err := apievents.ToOneOf(newTestEvent(7))
+	require.NoError(t, err)
+	validPayload, err := oneOf.Marshal()
+	require.NoError(t, err)
+	_, err = q.db.Exec(
+		"INSERT INTO corrupt_events (payload, error, source, failed_at) VALUES (?, 'was unknown event type', 'audit_queue', ?)",
+		validPayload, time.Now().Unix())
+	require.NoError(t, err)
+
+	q.recoverCorruptEvents()
+
+	// The recoverable event is back in audit_queue and deliverable.
+	items, err := q.fetch(10)
+	require.NoError(t, err)
+	require.Len(t, items, 1)
+	require.Equal(t, int64(7), items[0].Event.GetIndex())
+
+	// The genuinely corrupt row is retained for a future attempt.
+	require.Equal(t, 1, countRows(t, q, "corrupt_events"))
+}
+
+func TestRecoverCorruptEvents_PagesLargeBacklog(t *testing.T) {
+	t.Parallel()
+	q := newSqliteTestQueue(t)
+
+	const validCount = dequeueBatchSize*2 + 10 // spans multiple recovery pages
+	const corruptCount = 5
+
+	insert := func(payload []byte) {
+		_, err := q.db.Exec(
+			"INSERT INTO corrupt_events (payload, error, source, failed_at) VALUES (?, 'x', 'audit_queue', 0)",
+			payload)
+		require.NoError(t, err)
+	}
+
+	for i := 0; i < validCount; i++ {
+		oneOf, err := apievents.ToOneOf(newTestEvent(int64(i)))
+		require.NoError(t, err)
+		payload, err := oneOf.Marshal()
+		require.NoError(t, err)
+		insert(payload)
+		// Interleave corrupt rows so the cursor must page past them.
+		if i < corruptCount {
+			insert(corruptPayload)
+		}
+	}
+
+	q.recoverCorruptEvents()
+
+	require.Equal(t, validCount, countRows(t, q, "audit_queue"),
+		"all recoverable events should be re-queued across pages")
+	require.Equal(t, corruptCount, countRows(t, q, "corrupt_events"),
+		"only the genuinely corrupt rows should remain")
+}
+
+func TestRecoverCorruptEvents_WatermarkAdvances(t *testing.T) {
+	t.Parallel()
+	q := newSqliteTestQueue(t)
+
+	// An un-recoverable row examined by the first pass.
+	_, err := q.db.Exec(
+		"INSERT INTO corrupt_events (payload, error, source, failed_at) VALUES (?, 'boom', 'audit_queue', 0)",
+		corruptPayload)
+	require.NoError(t, err)
+
+	q.recoverCorruptEvents()
+	require.Positive(t, q.recoveryWatermark, "watermark should advance past the examined row")
+	require.Zero(t, countRows(t, q, "audit_queue"))
+	require.Equal(t, 1, countRows(t, q, "corrupt_events"))
+
+	// A recoverable row inserted after the first pass gets a higher id, so it
+	// lands above the watermark and is picked up on the next pass.
+	oneOf, err := apievents.ToOneOf(newTestEvent(7))
+	require.NoError(t, err)
+	validPayload, err := oneOf.Marshal()
+	require.NoError(t, err)
+	_, err = q.db.Exec(
+		"INSERT INTO corrupt_events (payload, error, source, failed_at) VALUES (?, 'was unknown', 'audit_queue', 0)",
+		validPayload)
+	require.NoError(t, err)
+
+	q.recoverCorruptEvents()
+
+	items, err := q.fetch(10)
+	require.NoError(t, err)
+	require.Len(t, items, 1)
+	require.Equal(t, int64(7), items[0].Event.GetIndex())
+	require.Equal(t, 1, countRows(t, q, "corrupt_events"),
+		"the un-recoverable row should remain, skipped by the watermark")
+}
+
+func TestOrphanAdoption_MigratesCorruptEvents(t *testing.T) {
+	t.Parallel()
+	parent := t.TempDir()
+	ctx := t.Context()
+
+	aPath := filepath.Join(parent, "a")
+	a, err := newSQLiteQueue(Config{Path: aPath})
+	require.NoError(t, err)
+
+	failedAt := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC).Unix()
+	_, err = a.db.Exec(
+		"INSERT INTO corrupt_events (payload, error, source, failed_at) VALUES (?, 'boom', 'audit_queue', ?)",
+		corruptPayload, failedAt)
+	require.NoError(t, err)
+	require.NoError(t, a.Close())
+
+	_, err = os.Stat(aPath)
+	require.NoError(t, err, "expected A's directory to remain after Close due to non-empty corrupt_events")
+
+	b, err := newSQLiteQueue(Config{
+		Path:               filepath.Join(parent, "b"),
+		OrphanScanInterval: 50 * time.Millisecond,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = b.Close() })
+
+	bRunCtx, cancelB := context.WithCancel(ctx)
+	t.Cleanup(cancelB)
+	bRunErr := make(chan error, 1)
+	go func() {
+		bRunErr <- b.Run(bRunCtx, func(_ context.Context, items []Item) []Item { return items })
+	}()
+
+	require.Eventually(t, func() bool {
+		return countRows(t, b, "corrupt_events") == 1
+	}, 5*time.Second, 50*time.Millisecond, "expected B to migrate A's corrupt row")
+
+	var (
+		payload    []byte
+		errMsg     string
+		source     string
+		gotFaildAt int64
+	)
+	require.NoError(t, b.db.QueryRow(
+		"SELECT payload, error, source, failed_at FROM corrupt_events").Scan(&payload, &errMsg, &source, &gotFaildAt))
+	require.Equal(t, corruptPayload, payload)
+	require.Equal(t, "boom", errMsg)
+	require.Equal(t, "audit_queue", source)
+	require.Equal(t, failedAt, gotFaildAt, "failed_at should be preserved across migration")
+
+	require.Eventually(t, func() bool {
+		_, err := os.Stat(aPath)
+		return os.IsNotExist(err)
+	}, 5*time.Second, 50*time.Millisecond, "expected A's directory to be removed after migration")
+
+	cancelB()
+	require.ErrorIs(t, <-bRunErr, context.Canceled)
 }
 
 func TestItemsNotIn(t *testing.T) {


### PR DESCRIPTION
Changelog: Quarantine corrupt events from audit log queue.

This PR is the fifth in what will be multiple PRs that implement [RFD 254](https://github.com/gravitational/teleport.e/pull/8641)

This implements a mechanism that will move events that fail to deserialize from the `audit_queue` into the `corrupt_events` table. This will ensure that events that fail to deserialize don't "clog" the main queue. These events do not belong in the dead-letter table because if they fail to deserialize, then there is no point in retrying them.

Between process restarts, we will attempt to re-send `corrupt_events` in case the failed deserialization was due to a version mismatch from a Teleport downgrade and upgrade.

## Previous PRs in this project:
1. https://github.com/gravitational/teleport/pull/66883 
2. https://github.com/gravitational/teleport/pull/67019
3. https://github.com/gravitational/teleport/pull/67095
4. https://github.com/gravitational/teleport/pull/67212

## Features in this PR

This PR implements a subset of the RFD. The rest of the RFD will be implemented in future PRs. This PR implements the following feature set as described in the RFD:
- Skipping events that fail to deserialize.

## Features that will be included in future PRs

Outstanding items that will be implemented in follow-up PR(s) include:
- tctl additions for audit queue observability.
- Protobuf changes.
- Encryption at rest (deferred to v19)
- Integration tests.
- Graceful shutdown drain.

## Manual Test Plan

I have tested this feature by running an enterprise build of the binary, verifying audit log events are being displayed correctly in the web UI, then I ran benchmarks using `tsh bench`.

### Test Environment

This has been tested on a Linux AMD64 machine.

### Test Cases

- [x] Verify audit log events show up in web UI as expected.
- [x] Benchmark that SQLite based queue can handle at least the level of traffic as in-memory version.
- [x] Verify we we don't see warnings of dropped audit log events.

### Test Description

This has been tested by running an enterprise binary like so:
```sh
TELEPORT_UNSTABLE_AUDIT_LOG_RELIABILITY=true ./e/build/teleport start --config="/etc/teleport.yaml"
```

From there, I observed that audit log events get propagated to the web UI as expected.

Next, I ran the following benchmark. Running the following `tsh` bench on the legacy audit log queue causes events to be dropped.

```sh
tsh bench --duration=60s --rate=224 ssh root@<TEST_MACHINE> "echo hi"
```

Running with the SQLite based audit log queue enabled results in the following count of audit log events being emitted:

```sh
$ curl -s localhost:3000/metrics | grep teleport_audit_emit_events
# HELP teleport_audit_emit_events Number of audit events emitted
# TYPE teleport_audit_emit_events counter
teleport_audit_emit_events 134179
```
