### PR TITLE
Quote VERSION in docs make recipe

### DIFF
--- a/integrations/terraform-modules/Makefile
+++ b/integrations/terraform-modules/Makefile
@@ -16,7 +16,7 @@ README_FILES := $(addsuffix /README.md,$(MODULE_DIRS))
 
 .PHONY: docs
 docs: $(README_FILES)
-	./gen/docs.sh $(VERSION) $(PUBLISHED_TF_MODULES)
+	./gen/docs.sh "$(VERSION)" $(PUBLISHED_TF_MODULES)
 
 %/README.md: force
 	terraform-docs markdown table --config .terraform-docs.yml $*


### PR DESCRIPTION
VERSION can be empty if there is an error running get-version. Quote the arg so that empty VERSION is detected and returns an error when running make docs.

I noticed this when I had a misconfigured go.work locally, which prevented get-version from returning a version.
The script should have returned an error but instead it treated the first module name arg as the version, which then skipped generating the docs for AWS.
