### PR TITLE
[v18] MWI: Ignore `user_login_state` for bots

### DIFF
--- a/lib/auth/bot_test.go
+++ b/lib/auth/bot_test.go
@@ -1204,16 +1204,16 @@ func TestRegisterBotWithInvalidUserLoginState(t *testing.T) {
 	_, err = authtest.CreateRole(ctx, a, roleName, types.RoleSpecV6{})
 	require.NoError(t, err)
 
-	_, err = machineidv1.UpsertBot(ctx, a, machineidv1pb.Bot_builder{
+	_, err = machineidv1.UpsertBot(ctx, a, &machineidv1pb.Bot{
 		Kind:    types.KindBot,
 		Version: types.V1,
-		Metadata: headerv1.Metadata_builder{
+		Metadata: &headerv1.Metadata{
 			Name: botName,
-		}.Build(),
-		Spec: machineidv1pb.BotSpec_builder{
+		},
+		Spec: &machineidv1pb.BotSpec{
 			Roles: []string{roleName},
-		}.Build(),
-	}.Build(), a.GetClock().Now(), "", scopes.Features{})
+		},
+	}, a.GetClock().Now(), "")
 	require.NoError(t, err)
 
 	client, err := srv.NewClient(authtest.TestAdmin())

--- a/lib/auth/bot_test.go
+++ b/lib/auth/bot_test.go
@@ -1204,16 +1204,16 @@ func TestRegisterBotWithInvalidUserLoginState(t *testing.T) {
 	_, err = authtest.CreateRole(ctx, a, roleName, types.RoleSpecV6{})
 	require.NoError(t, err)
 
-	_, err = machineidv1.UpsertBot(ctx, a, &machineidv1pb.Bot{
+	_, err = machineidv1.UpsertBot(ctx, a, machineidv1pb.Bot_builder{
 		Kind:    types.KindBot,
 		Version: types.V1,
-		Metadata: &headerv1.Metadata{
+		Metadata: headerv1.Metadata_builder{
 			Name: botName,
-		},
-		Spec: &machineidv1pb.BotSpec{
+		}.Build(),
+		Spec: machineidv1pb.BotSpec_builder{
 			Roles: []string{roleName},
-		},
-	}, a.GetClock().Now(), "")
+		}.Build(),
+	}.Build(), a.GetClock().Now(), "", scopes.Features{})
 	require.NoError(t, err)
 
 	client, err := srv.NewClient(authtest.TestAdmin())

--- a/lib/auth/bot_test.go
+++ b/lib/auth/bot_test.go
@@ -55,6 +55,8 @@ import (
 	"github.com/gravitational/teleport/api/metadata"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/types/events"
+	"github.com/gravitational/teleport/api/types/header"
+	"github.com/gravitational/teleport/api/types/userloginstate"
 	"github.com/gravitational/teleport/api/utils/keys"
 	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/auth/authtest"
@@ -1158,6 +1160,113 @@ func TestRegisterBotWithInvalidInstanceID(t *testing.T) {
 	require.NotEmpty(t, id)
 	require.NotEqual(t, "foo", id)
 	require.Equal(t, uint64(1), generation)
+}
+
+// TestRegisterBotWithInvalidUserLoginState ensures bots can register and
+// receive sane certificates even if they have an invalid UserLoginState entry
+// in the backend.
+func TestRegisterBotWithInvalidUserLoginState(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	srv := newTestTLSServer(t)
+	a := srv.Auth()
+
+	botName := "bot"
+	k8sTokenName := "jwks-matching-service-account"
+	a.SetK8sJWKSValidator(func(_ time.Time, _ []byte, _ string, tkn string) (*token.ValidationResult, error) {
+		if tkn == k8sTokenName {
+			return &token.ValidationResult{Username: "system:serviceaccount:static-jwks:matching"}, nil
+		}
+
+		return nil, errMockInvalidToken
+	})
+	token, err := types.NewProvisionTokenFromSpec("static-jwks", time.Now().Add(10*time.Minute), types.ProvisionTokenSpecV2{
+		JoinMethod: types.JoinMethodKubernetes,
+		Roles:      []types.SystemRole{types.RoleBot},
+		BotName:    botName,
+		Kubernetes: &types.ProvisionTokenSpecV2Kubernetes{
+			Type: types.KubernetesJoinTypeStaticJWKS,
+			Allow: []*types.ProvisionTokenSpecV2Kubernetes_Rule{
+				{ServiceAccount: "static-jwks:matching"},
+			},
+			StaticJWKS: &types.ProvisionTokenSpecV2Kubernetes_StaticJWKSConfig{
+				JWKS: "fake-jwks",
+			},
+		},
+	})
+	require.NoError(t, err)
+	require.NoError(t, a.CreateToken(ctx, token))
+
+	roleName := "test-role"
+	_, err = authtest.CreateRole(ctx, a, roleName, types.RoleSpecV6{})
+	require.NoError(t, err)
+
+	_, err = machineidv1.UpsertBot(ctx, a, &machineidv1pb.Bot{
+		Kind:    types.KindBot,
+		Version: types.V1,
+		Metadata: &headerv1.Metadata{
+			Name: botName,
+		},
+		Spec: &machineidv1pb.BotSpec{
+			Roles: []string{roleName},
+		},
+	}, a.GetClock().Now(), "")
+	require.NoError(t, err)
+
+	client, err := srv.NewClient(authtest.TestAdmin())
+	require.NoError(t, err)
+
+	// Create an invalid ULS with no labels or roles.
+	_, err = client.UserLoginStateClient().UpsertUserLoginState(ctx, &userloginstate.UserLoginState{
+		ResourceHeader: header.ResourceHeaderFromMetadata(header.Metadata{
+			Name: "bot-" + botName,
+		}),
+		Spec: userloginstate.Spec{},
+	})
+	require.NoError(t, err)
+
+	privateKey, sshPublicKey, err := testauthority.GenerateKeyPair()
+	require.NoError(t, err)
+	sshPrivateKey, err := ssh.ParseRawPrivateKey(privateKey)
+	require.NoError(t, err)
+	tlsPublicKey, err := tlsca.MarshalPublicKeyFromPrivateKeyPEM(sshPrivateKey)
+	require.NoError(t, err)
+
+	certs, err := srv.Auth().RegisterUsingToken(ctx, &types.RegisterUsingTokenRequest{
+		Token:        token.GetName(),
+		HostID:       "test-bot",
+		Role:         types.RoleBot,
+		PublicSSHKey: sshPublicKey,
+		PublicTLSKey: tlsPublicKey,
+		IDToken:      k8sTokenName,
+	})
+
+	// Should not generate any errors, especially some variety of "instance not
+	// found" which might indicate improper behavior when encountering a
+	// nonexistent token.
+	require.NoError(t, err)
+
+	// Parse the cert and extract the identity.
+	cert, err := tlsca.ParseCertificatePEM(certs.TLS)
+	require.NoError(t, err)
+	ident, err := tlsca.FromSubject(cert.Subject, cert.NotAfter)
+	require.NoError(t, err)
+
+	// Groups should not be empty - if GetUserOrLoginState() returns the corrupt
+	// ULS, we'd otherwise return unusable certs.
+	require.ElementsMatch(t, []string{"bot-" + botName}, ident.Groups)
+
+	// Delete the bot; it should delete the invalid ULS.
+	_, err = client.BotServiceClient().DeleteBot(ctx, &machineidv1pb.DeleteBotRequest{
+		BotName: botName,
+	})
+	require.NoError(t, err)
+
+	_, err = client.UserLoginStateClient().GetUserLoginState(ctx, "bot-"+botName)
+	require.True(t, trace.IsNotFound(err))
 }
 
 func TestRegisterBotMultipleTokens(t *testing.T) {

--- a/lib/auth/machineid/machineidv1/bot_service.go
+++ b/lib/auth/machineid/machineidv1/bot_service.go
@@ -109,6 +109,8 @@ type Backend interface {
 	GetRole(ctx context.Context, name string) (types.Role, error)
 	// GetToken returns a token by name.
 	GetToken(ctx context.Context, name string) (types.ProvisionToken, error)
+	// DeleteUserLoginState deletes a user login state.
+	DeleteUserLoginState(ctx context.Context, name string) error
 }
 
 // BotServiceConfig holds configuration options for
@@ -763,6 +765,23 @@ func (bs *BotService) deleteBotUser(
 			"user missing bot label matching bot name; consider manually deleting user",
 		)
 	}
+
+	// Try to delete any ULS for this bot user. The Okta usermonitor could
+	// occasionally create invalid ULS entries for bots which are otherwise
+	// impossible to remove. This at least ensures they can be manually deleted,
+	// as ULS cannot be managed otherwise (not available via tctl, etc).
+	// `NotFound` is normal/expected with this bug fixed in the usermonitor,
+	// but at worst treat any other errors as a warning.
+	if err := bs.backend.DeleteUserLoginState(ctx, user.GetName()); err != nil {
+		if !trace.IsNotFound(err) {
+			bs.logger.WarnContext(
+				ctx, "failed to delete user login state for bot",
+				"user", user.GetName(),
+				"error", err,
+			)
+		}
+	}
+
 	return bs.backend.DeleteUser(ctx, user.GetName())
 }
 

--- a/lib/services/bot_instance.go
+++ b/lib/services/bot_instance.go
@@ -29,6 +29,12 @@ import (
 	"github.com/gravitational/teleport/lib/utils/typical"
 )
 
+// BotUserPrefix is the prefix appended to bot users. Users with this prefix are
+// plausibly bots, but this prefix is not sufficient to establish that a given
+// user actually is a bot user. The existence of [types.BotLabel] in the user
+// labels is the definitive indicator that a user is a bot.
+const BotUserPrefix = "bot-"
+
 // BotInstance is an interface for the BotInstance service.
 type BotInstance interface {
 	// CreateBotInstance
@@ -207,5 +213,5 @@ func (o *ListBotInstancesRequestOptions) GetFilterFn() func(*machineidv1.BotInst
 // BotResourceName returns the default name for resources associated with the
 // given named bot.
 func BotResourceName(botName string) string {
-	return "bot-" + strings.ReplaceAll(botName, " ", "-")
+	return BotUserPrefix + strings.ReplaceAll(botName, " ", "-")
 }

--- a/lib/services/user_login_state.go
+++ b/lib/services/user_login_state.go
@@ -20,6 +20,7 @@ package services
 
 import (
 	"context"
+	"strings"
 
 	"github.com/gravitational/trace"
 
@@ -110,6 +111,27 @@ func GetUserOrLoginState(ctx context.Context, getter UserOrLoginStateGetter, use
 	}
 
 	if err == nil {
+		if strings.HasPrefix(username, BotUserPrefix) {
+			// Bots should never have ULS, but bugs elsewhere can mistakenly
+			// introduce it. If ULS happens to exist for a user with the bot
+			// label, we need to ignore it and return the user instead.
+			// Unfortunately, that means we can't trust the labels of the ULS we
+			// just fetched - they might be invalid/empty and missing the bot
+			// label.
+			// However, if the user has the `bot-` prefix, we know the user is
+			// plausibly a bot, so we can fetch the user early and check
+			// directly.
+			botUser, botErr := getter.GetUser(ctx, username, false)
+			if botErr == nil && botUser.IsBot() {
+				// User was fetchable and has the bot label, return it
+				// immediately.
+				return botUser, nil
+			}
+
+			// If the user was not fetchable or wasn't a bot, fall back to the
+			// standard logic.
+		}
+
 		return uls, nil
 	}
 

--- a/lib/services/user_login_state_test.go
+++ b/lib/services/user_login_state_test.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/types/header"
 	"github.com/gravitational/teleport/api/types/userloginstate"
 	"github.com/gravitational/teleport/lib/utils"
@@ -95,4 +96,153 @@ func TestUserLoginStateMarshal(t *testing.T) {
 	actual, err := UnmarshalUserLoginState(data)
 	require.NoError(t, err)
 	require.Equal(t, expected, actual)
+}
+
+// TestGetUserOrLoginStateIgnoresBots ensures ULS is never returned for bots,
+// only the actual user.
+func TestGetUserOrLoginStateIgnoresBots(t *testing.T) {
+	tests := []struct {
+		name     string
+		populate func(t *testing.T, m *mockGetter)
+		username string
+
+		assertError require.ErrorAssertionFunc
+		assertState func(t *testing.T, state UserState)
+	}{
+		{
+			name:     "standard user with state returns the login state",
+			username: "example",
+			populate: func(t *testing.T, m *mockGetter) {
+				user, err := types.NewUser("example")
+				require.NoError(t, err)
+				user.AddRole("access")
+				m.users["example"] = user
+
+				uls, err := userloginstate.New(
+					header.Metadata{
+						Name:   "example",
+						Labels: map[string]string{},
+					},
+					userloginstate.Spec{
+						Roles: []string{"access"},
+					},
+				)
+				require.NoError(t, err)
+				m.userStates["example"] = uls
+			},
+			assertError: require.NoError,
+			assertState: func(t *testing.T, state UserState) {
+				require.IsType(t, &userloginstate.UserLoginState{}, state)
+			},
+		},
+		{
+			name:     "standard user without state returns the user",
+			username: "example",
+			populate: func(t *testing.T, m *mockGetter) {
+				user, err := types.NewUser("example")
+				require.NoError(t, err)
+				user.AddRole("access")
+				m.users["example"] = user
+			},
+			assertError: require.NoError,
+			assertState: func(t *testing.T, state UserState) {
+				require.IsType(t, &types.UserV2{}, state)
+			},
+		},
+		{
+			name:     "bot user without state returns the user",
+			username: "bot-example",
+			populate: func(t *testing.T, m *mockGetter) {
+				user, err := types.NewUser("bot-example")
+				require.NoError(t, err)
+				meta := user.GetMetadata()
+				meta.Labels = map[string]string{
+					types.BotLabel: "example",
+				}
+				user.SetMetadata(meta)
+				user.AddRole("access")
+				m.users["bot-example"] = user
+			},
+			assertError: require.NoError,
+			assertState: func(t *testing.T, state UserState) {
+				require.IsType(t, &types.UserV2{}, state)
+			},
+		},
+		{
+			name:     "bot user with user login state still returns the user",
+			username: "bot-example",
+			populate: func(t *testing.T, m *mockGetter) {
+				user, err := types.NewUser("bot-example")
+				require.NoError(t, err)
+				meta := user.GetMetadata()
+				meta.Labels = map[string]string{
+					types.BotLabel: "example",
+				}
+				user.SetMetadata(meta)
+				user.AddRole("access")
+				m.users["bot-example"] = user
+
+				uls, err := userloginstate.New(
+					header.Metadata{
+						Name: "bot-example",
+						Labels: map[string]string{
+							types.BotLabel: "example",
+						},
+					},
+					userloginstate.Spec{
+						Roles: []string{"access"},
+					},
+				)
+				require.NoError(t, err)
+				m.userStates["bot-example"] = uls
+			},
+			assertError: require.NoError,
+			assertState: func(t *testing.T, state UserState) {
+				require.IsType(t, &types.UserV2{}, state)
+			},
+		},
+		{
+			name:     "bot user with corrupt user login state still returns the user",
+			username: "bot-example",
+			populate: func(t *testing.T, m *mockGetter) {
+				user, err := types.NewUser("bot-example")
+				require.NoError(t, err)
+				meta := user.GetMetadata()
+				meta.Labels = map[string]string{
+					types.BotLabel: "example",
+				}
+				user.SetMetadata(meta)
+				user.AddRole("access")
+				m.users["bot-example"] = user
+
+				// Note missing labels and roles.
+				uls, err := userloginstate.New(
+					header.Metadata{
+						Name: "bot-example",
+					},
+					userloginstate.Spec{},
+				)
+				require.NoError(t, err)
+				m.userStates["bot-example"] = uls
+			},
+			assertError: require.NoError,
+			assertState: func(t *testing.T, state UserState) {
+				require.IsType(t, &types.UserV2{}, state)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			getter := &mockGetter{
+				userStates: map[string]*userloginstate.UserLoginState{},
+				users:      map[string]types.User{},
+			}
+			tt.populate(t, getter)
+
+			state, err := GetUserOrLoginState(t.Context(), getter, tt.username)
+			tt.assertError(t, err)
+			tt.assertState(t, state)
+		})
+	}
 }


### PR DESCRIPTION
Backport #66737 to branch/v18

changelog: Fixed an issue where bots could fail to join with `missing identity groups or scope pin` when deleted and recreated quickly

---

This change is part of a fix for gravitational/teleport#63920, where the Okta usermonitor will inadvertently create unneccessary ULS entries for bots when they are deleted. Normally, these ULS entries are sane, but if the bot is deleted and recreated too quickly, there's a race.

Here's the sequence of events:
1. The user creates a bot (`tctl bots add` or similar)
2. The usermonitor watcher catches the OpPut and creates a sane ULS entry
3. The user deletes the bot (`tctl bots rm ...`)
4. The usermonitor watcher catches the OpDelete and replaces the sane ULS with an empty variant, with no roles or labels.
5. The user recreates the bot (`tctl bots add ...`)
6. One of two events happens first:
   1. The usermonitor watcher catches the OpPut and replaces the bad ULS with a sane variant.
   2. The bot joins and receives certificates

If 6.1 occurs before 6.2, the bot joins normally and receives valid certificates. If 6.2 occurs before 6.1, the bot is issued certs with roles derived from the bad ULS (i.e. empty list) and fails to start due to the invalid cert bundle.

In my testing, the race window is ~1 second. I see a ~10% failure rate if the bot is joined within 0.5 seconds of being recreated, and a 50% failure rate if the bot is joined immediately (well, as immediately as tbot can start after `tctl bot add ...` returns). Bot joins generally succeed if there's >= 1 second between recreate and join.

I also found a workaround while testing: you can just keep trying the delete + create + join cycle, it should repair itself eventually. Inserting a `sleep 1` between your `tctl bots add ...` and `tbot start ...` is sufficient to both repair the issue and avoid future instances.

The associated teleport.e makes the usermonitor ignore bots so new invalid ULS entries won't be created. However, this isn't sufficient to fix the bug for existing clusters. This PR adds 2 additional fixes:
- `GetUserOrLoginState()` always returns the user variant for bots, ignoring any potential ULS
- Deleting a bot now deletes any ULS entry for the bot

See also: https://github.com/gravitational/teleport.e/pull/8899

Changelog: Fixed an issue where bots could fail to join with `missing identity groups or scope pin` when deleted and recreated quickly

## Manual Test Plan
### Test Environment

A Teleport cluster with the Okta usermonitor enabled. My testing cluster doesn't have Okta sync configured, so I had Claude create a hacked build that always enables it. See also: https://github.com/gravitational/teleport/tree/timothyb89/v18/user-login-state-debug (make sure to check out the linked `e/`)

That branch includes a repro script, since you need to recreate and join the bot within ~0.5 seconds 5+ times to consistently reproduce the bug. The tool and an AI slop README can be found here: https://github.com/gravitational/teleport/tree/timothyb89/v18/user-login-state-debug/repro-usermonitor

The invalid ULS can be viewed by inspecting the backend:
```
$ sqlite3 /var/lib/teleport/backend/sqlite.db   "SELECT key, value FROM kv WHERE key like '%user_login_state%bot-repro-victim-0-0%';"
/user_login_state/bot-repro-victim-0-0|{"kind":"user_login_state","version":"v1","metadata":{"name":"bot-repro-victim-0-0","expires":"0001-01-01T00:00:00Z"},"spec":{"original_roles":null,"original_traits":null,"roles":null,"traits":null,"access_list_traits":null,"user_type":"local"}}
```

I cherry-picked the fixes into this branch, so you should _not_ be able to reproduce the error.

### Test Cases
- [x] Bot with invalid ULS can join (revert or otherwise remove the fix .e commit from the debug branch)
- [x] Invalid ULS is deleted with `tctl bots rm <bot>`

