### PR TITLE
Add tctl acl update for access list

### DIFF
--- a/api/types/accesslist/preset.go
+++ b/api/types/accesslist/preset.go
@@ -17,6 +17,7 @@ limitations under the License.
 package accesslist
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/gravitational/teleport/api/types"
@@ -39,6 +40,17 @@ const (
 	AccessListPresetRoleInfix = "acl-preset"
 )
 
+// PresetType defines the type of access list preset.
+type PresetType string
+
+// LongTermPresetType grants members access roles directly.
+// Owners receive the reviewer role.
+const LongTermPresetType PresetType = "long-term"
+
+// ShortTermPresetType grants members a requester role for on-demand access.
+// Members receive the requester role to request access, owners receive the reviewer role.
+const ShortTermPresetType PresetType = "short-term"
+
 // PresetRoleNames returns the role names recorded on this access list's
 // label or nil if the label is unset.
 func (a *AccessList) PresetRoleNames() []string {
@@ -47,4 +59,17 @@ func (a *AccessList) PresetRoleNames() []string {
 		return nil
 	}
 	return strings.Split(rolesStr, ",")
+}
+
+// IsPreset returns true if the access list was created via a preset, identified
+// by the preset label the backend sets at create time.
+func (a *AccessList) IsPreset() bool {
+	return a.GetAllLabels()[AccessListPresetLabel] != ""
+}
+
+// RoleName generates a role name for preset access list roles.
+// The format is: {prefix}-acl-preset-{accessListName}.
+// For example: "reviewer-acl-preset-my-access-list".
+func RoleName(prefix, accessListName string) string {
+	return fmt.Sprintf("%s-%s-%s", prefix, AccessListPresetRoleInfix, accessListName)
 }

--- a/api/types/role.go
+++ b/api/types/role.go
@@ -2875,3 +2875,12 @@ func (a IdentityCenterAccountAssignment) GetAccount() string {
 func IsLegacySAMLRBAC(roleVersion string) bool {
 	return slices.Contains([]string{V7, V6, V5, V4, V3, V2, V1}, roleVersion)
 }
+
+// ToLabels converts a map (map[string][]string) into Labels.
+func ToLabels(m map[string][]string) Labels {
+	out := make(Labels, len(m))
+	for k, v := range m {
+		out[k] = v
+	}
+	return out
+}

--- a/docs/pages/reference/cli/tctl.mdx
+++ b/docs/pages/reference/cli/tctl.mdx
@@ -212,6 +212,67 @@ Arguments:
 |---|---|---|
 |access-list-name|*no default* (optional)|The access list name to show summary for. If not provided, shows summary for all access lists.|
 
+## tctl acl update
+
+Update an existing access list. Each flag you pass replaces that field (no merge
+or append), so list-valued flags like --members or --logins overwrite the whole
+list; anything you omit is left unchanged.
+
+For an access list created with an access type, resource flags (--node-labels,
+etc.) edit the supporting roles.
+
+Usage:
+
+```code
+$ tctl acl update [<flags>] <access-list-name>
+```
+
+Flags:
+
+|Flag|Default|Description|
+|---|---|---|
+|`--app-labels`|*no default*|Selects web apps members may access by label match. For AWS Identity Center apps, use --aws-ic-assignments instead.|
+|`--audit-day`|*no default*|Day of month for audit (1, 15, or 31). Changing this resets the next audit date to now + frequency.|
+|`--audit-frequency`|*no default*|Audit recurrence in months (1, 3, 6, or 12). Changing this resets the next audit date to now + frequency.|
+|`--aws-ic-assignments`|*no default*|Selects AWS Identity Center apps members may access by AWS account ID + permission set ARN ('accountID:permissionSetARN' pairs).|
+|`--aws-role-arns`|*no default*|AWS role ARNs members may assume via matched apps.|
+|`--azure-identities`|*no default*|Azure managed identities members may assume via matched apps.|
+|`--db-labels`|*no default*|Selects databases members may access by label match.|
+|`--db-names`|*no default*|Database names members may connect to on matched databases.|
+|`--db-users`|*no default*|Database users members may connect as on matched databases.|
+|`--description`|*no default*|New description.|
+|`--format`|`text` (one of: `text`, `json`)|Output format.|
+|`--gcp-service-accounts`|*no default*|GCP service accounts members may assume via matched apps.|
+|`--github-orgs`|*no default*|Selects git servers members may access by GitHub organization name.|
+|`--kubernetes-groups`|*no default*|Kubernetes groups members may impersonate on matched clusters.|
+|`--kubernetes-labels`|*no default*|Selects Kubernetes clusters members may access by label match.|
+|`--kubernetes-users`|*no default*|Kubernetes users members may impersonate on matched clusters.|
+|`--logins`|*no default*|OS logins members may use to connect to matched SSH servers.|
+|`--mcp-tools`|*no default*|MCP tools members may call on matched MCP apps.|
+|`--member-access-lists`|*no default*|Replace the nested access-list members with this list of access list names. Not combinable with non-member update flags.|
+|`--member-grant-roles`|*no default*|Roles granted to members of this access list.|
+|`--member-grant-traits`|*no default*|Traits granted to members of this access list.|
+|`--member-required-roles`|*no default*|Roles a user must already have to be a member of this access list.|
+|`--member-required-traits`|*no default*|Traits a user must already have to be a member of this access list.|
+|`--members`|*no default*|Replace the user members with this list of usernames or emails. Not combinable with non-member update flags.|
+|`--node-labels`|*no default*|Selects SSH servers members may access by label match.|
+|`--[no-]remove-access`|`false`|Remove resource access from an access-typed list. Detaches the resource-access roles from the list's grants and from the supporting reviewer/requester roles.|
+|`--owner-access-lists`|*no default*|Replace the access-list owners with this list of access list names.|
+|`--owner-grant-roles`|*no default*|Roles granted to owners of this access list.|
+|`--owner-grant-traits`|*no default*|Traits granted to owners of this access list.|
+|`--owner-required-roles`|*no default*|Roles a user must already have to be an owner of this access list.|
+|`--owner-required-traits`|*no default*|Traits a user must already have to be an owner of this access list.|
+|`--owners`|*no default*|Replace the user owners with this list of usernames or emails.|
+|`--title`|*no default*|New display name for the access list.|
+|`--windows-labels`|*no default*|Selects Windows desktops members may access by label match.|
+|`--windows-logins`|*no default*|Logins members may use to connect to matched Windows desktops.|
+
+Arguments:
+
+|Argument|Default|Description|
+|---|---|---|
+|access-list-name|*no default* (required)|The Access List name.|
+
 ## tctl acl users add
 
 Add a user to an Access List.

--- a/tool/tctl/common/accesslist/accesslist.go
+++ b/tool/tctl/common/accesslist/accesslist.go
@@ -1,20 +1,18 @@
-/*
- * Teleport
- * Copyright (C) 2026  Gravitational, Inc.
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
- *
- * You should have received a copy of the GNU Affero General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
- */
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 package accesslist
 

--- a/tool/tctl/common/accesslist/accesslist.go
+++ b/tool/tctl/common/accesslist/accesslist.go
@@ -1,0 +1,55 @@
+/*
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package accesslist
+
+import (
+	"github.com/gravitational/trace"
+
+	"github.com/gravitational/teleport/api/types/accesslist"
+	"github.com/gravitational/teleport/api/types/header"
+)
+
+func newMember(listName, name, kind string) (*accesslist.AccessListMember, error) {
+	return accesslist.NewAccessListMember(
+		header.Metadata{Name: name},
+		accesslist.AccessListMemberSpec{
+			AccessList:     listName,
+			Name:           name,
+			MembershipKind: kind,
+		},
+	)
+}
+
+func getReviewFrequency(months int) (accesslist.ReviewFrequency, error) {
+	f := accesslist.ReviewFrequency(months)
+	switch f {
+	case accesslist.OneMonth, accesslist.ThreeMonths, accesslist.SixMonths, accesslist.OneYear:
+		return f, nil
+	}
+	return 0, trace.BadParameter("--audit-frequency must be one of 1, 3, 6, 12 (got %d)", months)
+}
+
+func getReviewDayOfMonth(day int) (accesslist.ReviewDayOfMonth, error) {
+	d := accesslist.ReviewDayOfMonth(day)
+	switch d {
+	case accesslist.FirstDayOfMonth, accesslist.FifteenthDayOfMonth, accesslist.LastDayOfMonth:
+		return d, nil
+	}
+	return 0, trace.BadParameter("--audit-day must be one of 1, 15, 31 (got %d)", day)
+}

--- a/tool/tctl/common/accesslist/command.go
+++ b/tool/tctl/common/accesslist/command.go
@@ -165,6 +165,12 @@ const (
 	memberKindList = "list"
 )
 
+const updateHelpText = "Update an existing access list. Each flag you pass replaces that field (no\n" +
+	"merge or append), so list-valued flags like --members or --logins overwrite\n" +
+	"the whole list; anything you omit is left unchanged.\n\n" +
+	"For an access list created with an access type, resource flags (--node-labels, etc.) edit the\n" +
+	"supporting roles."
+
 // Initialize allows Command to plug itself into the CLI parser
 func (c *Command) Initialize(app *kingpin.Application, _ *tctlcfg.GlobalCLIFlags, _ *servicecfg.Config) {
 	acl := app.Command("acl", "Manage Access Lists.").Alias("access-lists")
@@ -216,7 +222,7 @@ func (c *Command) Initialize(app *kingpin.Application, _ *tctlcfg.GlobalCLIFlags
 	c.remove.Arg("access-list-name", "The Access List name.").Required().StringVar(&c.accessListName)
 	c.remove.Flag("format", "Output format.").Default(teleport.Text).EnumVar(&c.format, teleport.Text, teleport.JSON)
 
-	c.update = acl.Command("update", "Update an existing access list. Only flags you pass are changed; everything else is left as-is. For an access list created with an access type, resource flags edit the supporting roles.")
+	c.update = acl.Command("update", updateHelpText)
 	c.update.Arg("access-list-name", "The Access List name.").Required().StringVar(&c.accessListName)
 	c.update.Flag("format", "Output format.").Default(teleport.Text).EnumVar(&c.format, teleport.Text, teleport.JSON)
 	// Access list metadata:

--- a/tool/tctl/common/accesslist/command.go
+++ b/tool/tctl/common/accesslist/command.go
@@ -58,6 +58,7 @@ type Command struct {
 	reviewsCreate *kingpin.CmdClause
 	reviewsList   *kingpin.CmdClause
 	remove        *kingpin.CmdClause
+	update        *kingpin.CmdClause
 
 	// Used for managing a particular access list.
 	accessListName string
@@ -75,6 +76,85 @@ type Command struct {
 
 	// Some extra options that control output.
 	reviewOnly bool // lists only access lists due for review
+
+	// Used to hold access list metadata.
+	title                string
+	description          string
+	auditFrequency       int
+	auditDay             int
+	owners               string
+	ownerAccessLists     string
+	ownerRequiredRoles   string
+	ownerRequiredTraits  string
+	ownerGrantRoles      string
+	ownerGrantTraits     string
+	members              string
+	memberAccessLists    string
+	memberRequiredRoles  string
+	memberRequiredTraits string
+	memberGrantRoles     string
+	memberGrantTraits    string
+
+	// Used to hold resource access related fields.
+	nodeLabels         string
+	logins             string
+	dbLabels           string
+	dbUsers            string
+	dbNames            string
+	kubeLabels         string
+	kubeUsers          string
+	kubeGroups         string
+	appLabels          string
+	awsRoleARNs        string
+	azureIdentities    string
+	gcpServiceAccounts string
+	mcpTools           string
+	windowsLabels      string
+	windowsLogins      string
+	gitHubOrgs         string
+	awsicAssignments   string
+
+	// removeAccess, when set, removes all resource-access roles from
+	// access list grants or supporting roles (requester/reviewer).
+	// Only applicable to access list created with an access type.
+	removeAccess bool
+
+	// Flags to determine if user set resource access related fields.
+	nodeLabelsSet         bool
+	loginsSet             bool
+	dbLabelsSet           bool
+	dbUsersSet            bool
+	dbNamesSet            bool
+	kubeLabelsSet         bool
+	kubeUsersSet          bool
+	kubeGroupsSet         bool
+	appLabelsSet          bool
+	awsRoleARNsSet        bool
+	azureIdentitiesSet    bool
+	gcpServiceAccountsSet bool
+	mcpToolsSet           bool
+	windowsLabelsSet      bool
+	windowsLoginsSet      bool
+	gitHubOrgsSet         bool
+	awsicAssignmentsSet   bool
+
+	// Flags to determine if user set these access list metadata fields.
+	titleSet                bool
+	descriptionSet          bool
+	auditFrequencySet       bool
+	auditDaySet             bool
+	ownersSet               bool
+	ownerAccessListsSet     bool
+	ownerGrantRolesSet      bool
+	ownerGrantTraitsSet     bool
+	ownerRequiredRolesSet   bool
+	ownerRequiredTraitsSet  bool
+	membersSet              bool
+	memberAccessListsSet    bool
+	memberGrantRolesSet     bool
+	memberGrantTraitsSet    bool
+	memberRequiredRolesSet  bool
+	memberRequiredTraitsSet bool
 
 	// Stdout allows to switch the standard output source. Used in tests.
 	Stdout io.Writer
@@ -136,6 +216,59 @@ func (c *Command) Initialize(app *kingpin.Application, _ *tctlcfg.GlobalCLIFlags
 	c.remove.Arg("access-list-name", "The Access List name.").Required().StringVar(&c.accessListName)
 	c.remove.Flag("format", "Output format.").Default(teleport.Text).EnumVar(&c.format, teleport.Text, teleport.JSON)
 
+	c.update = acl.Command("update", "Update an existing access list. Only flags you pass are changed; everything else is left as-is. For an access list created with an access type, resource flags edit the supporting roles.")
+	c.update.Arg("access-list-name", "The Access List name.").Required().StringVar(&c.accessListName)
+	c.update.Flag("format", "Output format.").Default(teleport.Text).EnumVar(&c.format, teleport.Text, teleport.JSON)
+	// Access list metadata:
+	c.update.Flag("title", "New display name for the access list.").IsSetByUser(&c.titleSet).StringVar(&c.title)
+	c.update.Flag("description", "New description.").IsSetByUser(&c.descriptionSet).StringVar(&c.description)
+	c.update.Flag("audit-frequency", "Audit recurrence in months (1, 3, 6, or 12).").PlaceHolder("6").IsSetByUser(&c.auditFrequencySet).IntVar(&c.auditFrequency)
+	c.update.Flag("audit-day", "Day of month for audit (1, 15, or 31).").PlaceHolder("1").IsSetByUser(&c.auditDaySet).IntVar(&c.auditDay)
+	// Access list owners:
+	c.update.Flag("owners", "Replace the user owners with this list of usernames or emails.").PlaceHolder("user1,user2,...").IsSetByUser(&c.ownersSet).StringVar(&c.owners)
+	c.update.Flag("owner-access-lists", "Replace the access-list owners with this list of access list names.").PlaceHolder("name1,name2,...").IsSetByUser(&c.ownerAccessListsSet).StringVar(&c.ownerAccessLists)
+	c.update.Flag("owner-grant-roles", "Roles granted to owners of this access list.").PlaceHolder("role1,role2,...").IsSetByUser(&c.ownerGrantRolesSet).StringVar(&c.ownerGrantRoles)
+	c.update.Flag("owner-grant-traits", "Traits granted to owners of this access list.").PlaceHolder("key=value,...").IsSetByUser(&c.ownerGrantTraitsSet).StringVar(&c.ownerGrantTraits)
+	c.update.Flag("owner-required-roles", "Roles a user must already have to be an owner of this access list.").PlaceHolder("role1,role2,...").IsSetByUser(&c.ownerRequiredRolesSet).StringVar(&c.ownerRequiredRoles)
+	c.update.Flag("owner-required-traits", "Traits a user must already have to be an owner of this access list.").PlaceHolder("key=value,...").IsSetByUser(&c.ownerRequiredTraitsSet).StringVar(&c.ownerRequiredTraits)
+	// Access list members:
+	c.update.Flag("members", "Replace the user members with this list of usernames or emails.").PlaceHolder("user1,user2,...").IsSetByUser(&c.membersSet).StringVar(&c.members)
+	c.update.Flag("member-access-lists", "Replace the nested access-list members with this list of access list names.").PlaceHolder("name1,name2,...").IsSetByUser(&c.memberAccessListsSet).StringVar(&c.memberAccessLists)
+	c.update.Flag("member-grant-roles", "Roles granted to members of this access list.").PlaceHolder("role1,role2,...").IsSetByUser(&c.memberGrantRolesSet).StringVar(&c.memberGrantRoles)
+	c.update.Flag("member-grant-traits", "Traits granted to members of this access list.").PlaceHolder("key=value,...").IsSetByUser(&c.memberGrantTraitsSet).StringVar(&c.memberGrantTraits)
+	c.update.Flag("member-required-roles", "Roles a user must already have to be a member of this access list.").PlaceHolder("role1,role2,...").IsSetByUser(&c.memberRequiredRolesSet).StringVar(&c.memberRequiredRoles)
+	c.update.Flag("member-required-traits", "Traits a user must already have to be a member of this access list.").PlaceHolder("key=value,...").IsSetByUser(&c.memberRequiredTraitsSet).StringVar(&c.memberRequiredTraits)
+
+	// Resource access flags (only valid for access lists created with an access type):
+	// Nodes
+	c.update.Flag("node-labels", "Selects SSH servers members may access by label match.").PlaceHolder("key=value,...").IsSetByUser(&c.nodeLabelsSet).StringVar(&c.nodeLabels)
+	c.update.Flag("logins", "OS logins members may use to connect to matched SSH servers.").PlaceHolder("login1,login2,...").IsSetByUser(&c.loginsSet).StringVar(&c.logins)
+	// Dbs
+	c.update.Flag("db-labels", "Selects databases members may access by label match.").PlaceHolder("key=value,...").IsSetByUser(&c.dbLabelsSet).StringVar(&c.dbLabels)
+	c.update.Flag("db-users", "Database users members may connect as on matched databases.").PlaceHolder("user1,user2,...").IsSetByUser(&c.dbUsersSet).StringVar(&c.dbUsers)
+	c.update.Flag("db-names", "Database names members may connect to on matched databases.").PlaceHolder("name1,name2,...").IsSetByUser(&c.dbNamesSet).StringVar(&c.dbNames)
+	// Kubes
+	c.update.Flag("kubernetes-labels", "Selects Kubernetes clusters members may access by label match.").PlaceHolder("key=value,...").IsSetByUser(&c.kubeLabelsSet).StringVar(&c.kubeLabels)
+	c.update.Flag("kubernetes-users", "Kubernetes users members may impersonate on matched clusters.").PlaceHolder("user1,user2,...").IsSetByUser(&c.kubeUsersSet).StringVar(&c.kubeUsers)
+	c.update.Flag("kubernetes-groups", "Kubernetes groups members may impersonate on matched clusters.").PlaceHolder("group1,group2,...").IsSetByUser(&c.kubeGroupsSet).StringVar(&c.kubeGroups)
+	// Apps
+	c.update.Flag("app-labels", "Selects web apps members may access by label match. For AWS Identity Center apps, use --aws-ic-assignments instead.").PlaceHolder("key=value,...").IsSetByUser(&c.appLabelsSet).StringVar(&c.appLabels)
+	c.update.Flag("aws-role-arns", "AWS role ARNs members may assume via matched apps.").PlaceHolder("arn1,arn2,...").IsSetByUser(&c.awsRoleARNsSet).StringVar(&c.awsRoleARNs)
+	c.update.Flag("azure-identities", "Azure managed identities members may assume via matched apps.").PlaceHolder("id1,id2,...").IsSetByUser(&c.azureIdentitiesSet).StringVar(&c.azureIdentities)
+	c.update.Flag("gcp-service-accounts", "GCP service accounts members may assume via matched apps.").PlaceHolder("email1,email2,...").IsSetByUser(&c.gcpServiceAccountsSet).StringVar(&c.gcpServiceAccounts)
+	c.update.Flag("mcp-tools", "MCP tools members may call on matched MCP apps.").PlaceHolder("pattern1,pattern2,...").IsSetByUser(&c.mcpToolsSet).StringVar(&c.mcpTools)
+	// Windows
+	c.update.Flag("windows-labels", "Selects Windows desktops members may access by label match.").PlaceHolder("key=value,...").IsSetByUser(&c.windowsLabelsSet).StringVar(&c.windowsLabels)
+	c.update.Flag("windows-logins", "Logins members may use to connect to matched Windows desktops.").PlaceHolder("login1,login2,...").IsSetByUser(&c.windowsLoginsSet).StringVar(&c.windowsLogins)
+	// GitHub
+	c.update.Flag("github-orgs", "Selects git servers members may access by GitHub organization name.").PlaceHolder("org1,org2,...").IsSetByUser(&c.gitHubOrgsSet).StringVar(&c.gitHubOrgs)
+
+	// AWS IC
+	c.update.Flag("aws-ic-assignments", "Selects AWS Identity Center apps members may access by AWS account ID + permission set ARN ('accountID:permissionSetARN' pairs).").PlaceHolder("accountID:permSetARN,...").IsSetByUser(&c.awsicAssignmentsSet).StringVar(&c.awsicAssignments)
+
+	// Removes all resource access from an access list created with an access type:
+	c.update.Flag("remove-access", "Remove all resource-access roles (and their grants) from an access list created with an access type. No-op if the list has none. Cannot be combined with the resource access flags above.").BoolVar(&c.removeAccess)
+
 	if c.Stdout == nil {
 		c.Stdout = os.Stdout
 	}
@@ -163,6 +296,8 @@ func (c *Command) TryRun(ctx context.Context, cmd string, clientFunc commonclien
 		commandFunc = c.ReviewsList
 	case c.remove.FullCommand():
 		commandFunc = c.Remove
+	case c.update.FullCommand():
+		commandFunc = c.Update
 	default:
 		return false, nil
 	}

--- a/tool/tctl/common/accesslist/command.go
+++ b/tool/tctl/common/accesslist/command.go
@@ -114,9 +114,10 @@ type Command struct {
 	gitHubOrgs         string
 	awsicAssignments   string
 
-	// removeAccess, when set, removes all resource-access roles from
-	// access list grants or supporting roles (requester/reviewer).
-	// Only applicable to access list created with an access type.
+	// Removes "access related roles" from an access list created with an access type:
+	// - reviewer/requester role specs get emptied
+	// - for long-term access lists, the members grant gets removed
+	// - for short-term access lists, no grants are changed (but their allow specs gets emptied)
 	removeAccess bool
 
 	// Flags to determine if user set resource access related fields.
@@ -228,8 +229,8 @@ func (c *Command) Initialize(app *kingpin.Application, _ *tctlcfg.GlobalCLIFlags
 	// Access list metadata:
 	c.update.Flag("title", "New display name for the access list.").IsSetByUser(&c.titleSet).StringVar(&c.title)
 	c.update.Flag("description", "New description.").IsSetByUser(&c.descriptionSet).StringVar(&c.description)
-	c.update.Flag("audit-frequency", "Audit recurrence in months (1, 3, 6, or 12).").PlaceHolder("6").IsSetByUser(&c.auditFrequencySet).IntVar(&c.auditFrequency)
-	c.update.Flag("audit-day", "Day of month for audit (1, 15, or 31).").PlaceHolder("1").IsSetByUser(&c.auditDaySet).IntVar(&c.auditDay)
+	c.update.Flag("audit-frequency", "Audit recurrence in months (1, 3, 6, or 12). Changing this resets the next audit date to now + frequency.").PlaceHolder("6").IsSetByUser(&c.auditFrequencySet).IntVar(&c.auditFrequency)
+	c.update.Flag("audit-day", "Day of month for audit (1, 15, or 31). Changing this resets the next audit date to now + frequency.").PlaceHolder("1").IsSetByUser(&c.auditDaySet).IntVar(&c.auditDay)
 	// Access list owners:
 	c.update.Flag("owners", "Replace the user owners with this list of usernames or emails.").PlaceHolder("user1,user2,...").IsSetByUser(&c.ownersSet).StringVar(&c.owners)
 	c.update.Flag("owner-access-lists", "Replace the access-list owners with this list of access list names.").PlaceHolder("name1,name2,...").IsSetByUser(&c.ownerAccessListsSet).StringVar(&c.ownerAccessLists)
@@ -238,8 +239,8 @@ func (c *Command) Initialize(app *kingpin.Application, _ *tctlcfg.GlobalCLIFlags
 	c.update.Flag("owner-required-roles", "Roles a user must already have to be an owner of this access list.").PlaceHolder("role1,role2,...").IsSetByUser(&c.ownerRequiredRolesSet).StringVar(&c.ownerRequiredRoles)
 	c.update.Flag("owner-required-traits", "Traits a user must already have to be an owner of this access list.").PlaceHolder("key=value,...").IsSetByUser(&c.ownerRequiredTraitsSet).StringVar(&c.ownerRequiredTraits)
 	// Access list members:
-	c.update.Flag("members", "Replace the user members with this list of usernames or emails.").PlaceHolder("user1,user2,...").IsSetByUser(&c.membersSet).StringVar(&c.members)
-	c.update.Flag("member-access-lists", "Replace the nested access-list members with this list of access list names.").PlaceHolder("name1,name2,...").IsSetByUser(&c.memberAccessListsSet).StringVar(&c.memberAccessLists)
+	c.update.Flag("members", "Replace the user members with this list of usernames or emails. Not combinable with non-member update flags.").PlaceHolder("user1,user2,...").IsSetByUser(&c.membersSet).StringVar(&c.members)
+	c.update.Flag("member-access-lists", "Replace the nested access-list members with this list of access list names. Not combinable with non-member update flags.").PlaceHolder("name1,name2,...").IsSetByUser(&c.memberAccessListsSet).StringVar(&c.memberAccessLists)
 	c.update.Flag("member-grant-roles", "Roles granted to members of this access list.").PlaceHolder("role1,role2,...").IsSetByUser(&c.memberGrantRolesSet).StringVar(&c.memberGrantRoles)
 	c.update.Flag("member-grant-traits", "Traits granted to members of this access list.").PlaceHolder("key=value,...").IsSetByUser(&c.memberGrantTraitsSet).StringVar(&c.memberGrantTraits)
 	c.update.Flag("member-required-roles", "Roles a user must already have to be a member of this access list.").PlaceHolder("role1,role2,...").IsSetByUser(&c.memberRequiredRolesSet).StringVar(&c.memberRequiredRoles)
@@ -272,8 +273,7 @@ func (c *Command) Initialize(app *kingpin.Application, _ *tctlcfg.GlobalCLIFlags
 	// AWS IC
 	c.update.Flag("aws-ic-assignments", "Selects AWS Identity Center apps members may access by AWS account ID + permission set ARN ('accountID:permissionSetARN' pairs).").PlaceHolder("accountID:permSetARN,...").IsSetByUser(&c.awsicAssignmentsSet).StringVar(&c.awsicAssignments)
 
-	// Removes all resource access from an access list created with an access type:
-	c.update.Flag("remove-access", "Remove all resource-access roles (and their grants) from an access list created with an access type. No-op if the list has none. Cannot be combined with the resource access flags above.").BoolVar(&c.removeAccess)
+	c.update.Flag("remove-access", "Remove resource access from an access-typed list. Detaches the resource-access roles from the list's grants and from the supporting reviewer/requester roles.").BoolVar(&c.removeAccess)
 
 	if c.Stdout == nil {
 		c.Stdout = os.Stdout

--- a/tool/tctl/common/accesslist/command.go
+++ b/tool/tctl/common/accesslist/command.go
@@ -255,8 +255,8 @@ func (c *Command) Initialize(app *kingpin.Application, _ *tctlcfg.GlobalCLIFlags
 	c.update.Flag("app-labels", "Selects web apps members may access by label match. For AWS Identity Center apps, use --aws-ic-assignments instead.").PlaceHolder("key=value,...").IsSetByUser(&c.appLabelsSet).StringVar(&c.appLabels)
 	c.update.Flag("aws-role-arns", "AWS role ARNs members may assume via matched apps.").PlaceHolder("arn1,arn2,...").IsSetByUser(&c.awsRoleARNsSet).StringVar(&c.awsRoleARNs)
 	c.update.Flag("azure-identities", "Azure managed identities members may assume via matched apps.").PlaceHolder("id1,id2,...").IsSetByUser(&c.azureIdentitiesSet).StringVar(&c.azureIdentities)
-	c.update.Flag("gcp-service-accounts", "GCP service accounts members may assume via matched apps.").PlaceHolder("email1,email2,...").IsSetByUser(&c.gcpServiceAccountsSet).StringVar(&c.gcpServiceAccounts)
-	c.update.Flag("mcp-tools", "MCP tools members may call on matched MCP apps.").PlaceHolder("pattern1,pattern2,...").IsSetByUser(&c.mcpToolsSet).StringVar(&c.mcpTools)
+	c.update.Flag("gcp-service-accounts", "GCP service accounts members may assume via matched apps.").PlaceHolder("account1,account2,...").IsSetByUser(&c.gcpServiceAccountsSet).StringVar(&c.gcpServiceAccounts)
+	c.update.Flag("mcp-tools", "MCP tools members may call on matched MCP apps.").PlaceHolder("tool1,tool2,...").IsSetByUser(&c.mcpToolsSet).StringVar(&c.mcpTools)
 	// Windows
 	c.update.Flag("windows-labels", "Selects Windows desktops members may access by label match.").PlaceHolder("key=value,...").IsSetByUser(&c.windowsLabelsSet).StringVar(&c.windowsLabels)
 	c.update.Flag("windows-logins", "Logins members may use to connect to matched Windows desktops.").PlaceHolder("login1,login2,...").IsSetByUser(&c.windowsLoginsSet).StringVar(&c.windowsLogins)

--- a/tool/tctl/common/accesslist/flags.go
+++ b/tool/tctl/common/accesslist/flags.go
@@ -1,20 +1,18 @@
-/*
- * Teleport
- * Copyright (C) 2026  Gravitational, Inc.
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
- *
- * You should have received a copy of the GNU Affero General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
- */
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 package accesslist
 
@@ -52,9 +50,17 @@ func (c *Command) anyGrantsSet() bool {
 
 // anyUpdateFlagSet returns true if the user passed any update-able flag.
 func (c *Command) anyUpdateFlagSet() bool {
+	return c.anyMemberUpdateFlagSet() || c.anyNonMemberUpdateFlagSet()
+}
+
+func (c *Command) anyMemberUpdateFlagSet() bool {
+	return c.membersSet || c.memberAccessListsSet
+}
+
+func (c *Command) anyNonMemberUpdateFlagSet() bool {
 	return c.titleSet || c.descriptionSet || c.auditFrequencySet || c.auditDaySet ||
 		c.ownersSet || c.ownerAccessListsSet || c.ownerRequiredRolesSet || c.ownerRequiredTraitsSet ||
-		c.membersSet || c.memberAccessListsSet || c.memberRequiredRolesSet || c.memberRequiredTraitsSet ||
+		c.memberRequiredRolesSet || c.memberRequiredTraitsSet ||
 		c.removeAccess ||
 		c.anyGrantsSet() ||
 		c.anyAccessFlagsSet()

--- a/tool/tctl/common/accesslist/flags.go
+++ b/tool/tctl/common/accesslist/flags.go
@@ -1,0 +1,61 @@
+/*
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package accesslist
+
+// anyStandardResourceVisibilityFlagsSet returns true if any standard (non awsic)
+// labels or github is set.
+func (c *Command) anyStandardResourceVisibilityFlagsSet() bool {
+	return c.nodeLabelsSet ||
+		c.dbLabelsSet ||
+		c.kubeLabelsSet ||
+		c.appLabelsSet ||
+		c.windowsLabelsSet ||
+		c.gitHubOrgsSet
+}
+
+// anyStandardIdentityFlagsSet returns true if any access related to a user
+// connecting "as" to a resource is set.
+func (c *Command) anyStandardIdentityFlagsSet() bool {
+	return c.loginsSet || c.awsRoleARNsSet || c.azureIdentitiesSet ||
+		c.gcpServiceAccountsSet || c.mcpToolsSet || c.dbNamesSet || c.dbUsersSet ||
+		c.kubeGroupsSet || c.kubeUsersSet || c.windowsLoginsSet
+}
+
+func (c *Command) anyStandardAccessFlagsSet() bool {
+	return c.anyStandardResourceVisibilityFlagsSet() || c.anyStandardIdentityFlagsSet()
+}
+
+func (c *Command) anyAccessFlagsSet() bool {
+	return c.anyStandardAccessFlagsSet() || c.awsicAssignmentsSet
+}
+
+func (c *Command) anyGrantsSet() bool {
+	return c.ownerGrantRolesSet || c.ownerGrantTraitsSet ||
+		c.memberGrantRolesSet || c.memberGrantTraitsSet
+}
+
+// anyUpdateFlagSet returns true if the user passed any update-able flag.
+func (c *Command) anyUpdateFlagSet() bool {
+	return c.titleSet || c.descriptionSet || c.auditFrequencySet || c.auditDaySet ||
+		c.ownersSet || c.ownerAccessListsSet || c.ownerRequiredRolesSet || c.ownerRequiredTraitsSet ||
+		c.membersSet || c.memberAccessListsSet || c.memberRequiredRolesSet || c.memberRequiredTraitsSet ||
+		c.removeAccess ||
+		c.anyGrantsSet() ||
+		c.anyAccessFlagsSet()
+}

--- a/tool/tctl/common/accesslist/preset.go
+++ b/tool/tctl/common/accesslist/preset.go
@@ -1,0 +1,97 @@
+/*
+ * Teleport
+ * Copyright (C) 2023  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package accesslist
+
+import (
+	"strings"
+
+	"github.com/gravitational/trace"
+
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/api/types/accesslist"
+	"github.com/gravitational/teleport/api/types/common"
+	"github.com/gravitational/teleport/lib/utils"
+)
+
+const (
+	// CLI-facing access type values (what the user sees and uses,
+	// which aligns with terms used in docs).
+	accessTypeLongTerm  = "standing"
+	accessTypeShortTerm = "request-based"
+
+	standardRolePrefixName = "access-standard"
+	awsicRolePrefixName    = "access-awsic"
+)
+
+var awsIcAppLabel = types.Labels{types.OriginLabel: []string{common.OriginAWSIdentityCenter}}
+
+func buildAWSICAccountAssignments(awsicAssignments string) ([]types.IdentityCenterAccountAssignment, error) {
+	var aa []types.IdentityCenterAccountAssignment
+	for _, a := range utils.SplitIdentifiers(awsicAssignments) {
+		account, permSet, ok := strings.Cut(a, ":")
+		if !ok {
+			return nil, trace.BadParameter("--aws-ic-assignments: %q is not in 'accountID:permissionSetARN' format", a)
+		}
+		aa = append(aa, types.IdentityCenterAccountAssignment{
+			Account:       strings.TrimSpace(account),
+			PermissionSet: strings.TrimSpace(permSet),
+		})
+	}
+	return aa, nil
+}
+
+// buildRole returns a roleV6. "roleName" is overwritten in the backend by appending
+// the role name with the access list ID, making these roles unique e.g.:
+// "access-standard" becomes access-standard-acl-preset-<access-list-uuid>
+func buildRole(roleName string, allow types.RoleConditions) (*types.RoleV6, error) {
+	spec := types.RoleSpecV6{
+		Allow: allow,
+	}
+	role, err := types.NewRole(roleName, spec)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	r, ok := role.(*types.RoleV6)
+	if !ok {
+		return nil, trace.BadParameter("unexpected role type %T", role)
+	}
+	return r, nil
+}
+
+// presetType converts user facing accessType value to the expected backend value.
+func presetType(accessType string) string {
+	switch accessType {
+	case accessTypeLongTerm:
+		return string(accesslist.LongTermPresetType)
+	case accessTypeShortTerm:
+		return string(accesslist.ShortTermPresetType)
+	}
+	return ""
+}
+
+// accessType maps the backend value into the user facing accessType value.
+func accessType(preset string) string {
+	switch preset {
+	case string(accesslist.LongTermPresetType):
+		return accessTypeLongTerm
+	case string(accesslist.ShortTermPresetType):
+		return accessTypeShortTerm
+	}
+	return ""
+}

--- a/tool/tctl/common/accesslist/preset.go
+++ b/tool/tctl/common/accesslist/preset.go
@@ -1,20 +1,18 @@
-/*
- * Teleport
- * Copyright (C) 2023  Gravitational, Inc.
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
- *
- * You should have received a copy of the GNU Affero General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
- */
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 package accesslist
 
@@ -72,17 +70,6 @@ func buildRole(roleName string, allow types.RoleConditions) (*types.RoleV6, erro
 		return nil, trace.BadParameter("unexpected role type %T", role)
 	}
 	return r, nil
-}
-
-// presetType converts user facing accessType value to the expected backend value.
-func presetType(accessType string) string {
-	switch accessType {
-	case accessTypeLongTerm:
-		return string(accesslist.LongTermPresetType)
-	case accessTypeShortTerm:
-		return string(accesslist.ShortTermPresetType)
-	}
-	return ""
 }
 
 // accessType maps the backend value into the user facing accessType value.

--- a/tool/tctl/common/accesslist/remove.go
+++ b/tool/tctl/common/accesslist/remove.go
@@ -60,19 +60,26 @@ func (c *Command) Remove(ctx context.Context, client *authclient.Client) error {
 	}
 
 	fmt.Fprintf(c.Stdout, "Deleted access list %q\n", c.accessListName)
-	if len(resp.RolesToDelete) == 0 {
-		return nil
+	c.printRolesToBeDeleted(resp.RolesToDelete)
+	return nil
+}
+
+// printRolesToBeDeleted prints the guidance block listing preset roles that are
+// no longer used by an access list, shared by `acl rm` and `acl update` so the
+// output is identical. No-op when there are no such roles.
+func (c *Command) printRolesToBeDeleted(roles []string) {
+	if len(roles) == 0 {
+		return
 	}
 	fmt.Fprintln(c.Stdout)
 	fmt.Fprintln(c.Stdout, "The following roles are no longer used by this access list:")
-	for _, name := range resp.RolesToDelete {
+	for _, name := range roles {
 		fmt.Fprintf(c.Stdout, "  - %s\n", name)
 	}
 	fmt.Fprintln(c.Stdout)
 	fmt.Fprintln(c.Stdout, "These roles may still be assigned to users or referenced by other roles.")
 	fmt.Fprintln(c.Stdout, "Verify each role is unused before deleting it with:")
 	fmt.Fprintln(c.Stdout, "  tctl rm roles/<name>")
-	return nil
 }
 
 // RemoveJSONResponse is a structured response when `format=json`

--- a/tool/tctl/common/accesslist/update.go
+++ b/tool/tctl/common/accesslist/update.go
@@ -1,0 +1,563 @@
+/*
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package accesslist
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/gravitational/trace"
+
+	"github.com/gravitational/teleport"
+	accesslistv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/accesslist/v1"
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/api/types/accesslist"
+	conv "github.com/gravitational/teleport/api/types/accesslist/convert/v1"
+	"github.com/gravitational/teleport/lib/auth/authclient"
+	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/parse"
+)
+
+// Update handles `tctl acl update`.
+func (c *Command) Update(ctx context.Context, client *authclient.Client) error {
+	if !c.anyUpdateFlagSet() {
+		return trace.BadParameter("no update flags are set")
+	}
+
+	if c.titleSet && c.title == "" {
+		return trace.BadParameter("cannot unset title")
+	}
+
+	al, err := client.AccessListClient().GetAccessList(ctx, c.accessListName)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	if !al.IsPreset() {
+		if c.anyAccessFlagsSet() {
+			return trace.BadParameter("resource access flags (--node-labels, --logins, --aws-ic-assignments, etc.) cannot be applied; access list %q was not created with an access type", c.accessListName)
+		}
+		if c.removeAccess {
+			return trace.BadParameter("--remove-access cannot be applied; access list %q was not created with an access type, so it has no resource access to remove", c.accessListName)
+		}
+	} else { // Is preset.
+		if c.anyGrantsSet() {
+			return trace.BadParameter("grant flags (--member-grant-*, --owner-grant-*) cannot be applied; access list %q was created with an access type where grants are automatically assigned by Teleport", c.accessListName)
+		}
+		if c.removeAccess && c.anyAccessFlagsSet() {
+			return trace.BadParameter("--remove-access removes all resource access and cannot be combined with resource access flags (--node-labels, --logins, etc.)")
+		}
+	}
+
+	// Apply al metadata/specs
+	if err := c.applySpecFlags(al); err != nil {
+		return trace.Wrap(err)
+	}
+
+	// Apply list of owners
+	var removedOwners []string
+	if c.ownersSet || c.ownerAccessListsSet {
+		var updatedOwners []accesslist.Owner
+		updatedOwners, removedOwners = c.buildOwnersForUpdate(al)
+		if len(updatedOwners) == 0 {
+			return trace.BadParameter("an access list must have at least one owner")
+		}
+		al.Spec.Owners = updatedOwners
+	}
+
+	// Apply list of members
+	var updatedMembers []*accesslist.AccessListMember
+	var removedMembers []string
+	membersChanged := c.membersSet || c.memberAccessListsSet
+	if membersChanged {
+		updatedMembers, removedMembers, err = c.buildMembersForUpdate(ctx, client, al.GetName())
+		if err != nil {
+			return trace.Wrap(err)
+		}
+	}
+
+	var updatedAccessList *accesslist.AccessList
+	var updatedRoles []*types.RoleV6
+	var rolesToDelete []string
+
+	if al.IsPreset() && (c.anyAccessFlagsSet() || c.removeAccess) {
+		// Updates al, access roles, and members (if any members)
+		updatedAccessList, updatedRoles, rolesToDelete, err = c.updateAccessListWithPreset(ctx, client, al, updatedMembers, membersChanged)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+	} else if membersChanged {
+		// Updates al and members
+		updatedAccessList, _, err = client.AccessListClient().UpsertAccessListWithMembers(ctx, al, updatedMembers)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+	} else {
+		// Metadata only update: don't touch members or access roles (preset).
+		updatedAccessList, err = client.AccessListClient().UpsertAccessList(ctx, al)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+	}
+
+	resp := UpdateJSONResponse{
+		AccessList:            updatedAccessList,
+		AccessType:            accessType(updatedAccessList.GetAllLabels()[accesslist.AccessListPresetLabel]),
+		UpdatedOrCreatedRoles: updatedRoles,
+		RolesToDelete:         rolesToDelete,
+		OwnersRemoved:         removedOwners,
+		MembersRemoved:        removedMembers,
+	}
+	if c.format == teleport.JSON {
+		return trace.Wrap(utils.WriteJSON(c.Stdout, resp), "failed to marshal access list update response")
+	}
+	c.printUpdateText(resp)
+	return nil
+}
+
+func (c *Command) applySpecFlags(al *accesslist.AccessList) error {
+	// Metadata
+	if c.titleSet {
+		al.Spec.Title = c.title
+	}
+	if c.descriptionSet {
+		al.Metadata.Description = c.description
+	}
+	if c.auditFrequencySet {
+		freq, err := getReviewFrequency(c.auditFrequency)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+		al.Spec.Audit.Recurrence.Frequency = freq
+	}
+	if c.auditDaySet {
+		day, err := getReviewDayOfMonth(c.auditDay)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+		al.Spec.Audit.Recurrence.DayOfMonth = day
+	}
+
+	// Owner grants and requirements
+	if c.ownerGrantRolesSet {
+		al.Spec.OwnerGrants.Roles = utils.SplitIdentifiers(c.ownerGrantRoles)
+	}
+	if c.ownerGrantTraitsSet {
+		traits, err := parse.MultiValueLabelSelectorSpec(c.ownerGrantTraits)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+		al.Spec.OwnerGrants.Traits = traits
+	}
+	if c.ownerRequiredRolesSet {
+		al.Spec.OwnershipRequires.Roles = utils.SplitIdentifiers(c.ownerRequiredRoles)
+	}
+	if c.ownerRequiredTraitsSet {
+		traits, err := parse.MultiValueLabelSelectorSpec(c.ownerRequiredTraits)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+		al.Spec.OwnershipRequires.Traits = traits
+	}
+
+	// Member grants and requirements
+	if c.memberGrantRolesSet {
+		al.Spec.Grants.Roles = utils.SplitIdentifiers(c.memberGrantRoles)
+	}
+	if c.memberGrantTraitsSet {
+		traits, err := parse.MultiValueLabelSelectorSpec(c.memberGrantTraits)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+		al.Spec.Grants.Traits = traits
+	}
+	if c.memberRequiredRolesSet {
+		al.Spec.MembershipRequires.Roles = utils.SplitIdentifiers(c.memberRequiredRoles)
+	}
+	if c.memberRequiredTraitsSet {
+		traits, err := parse.MultiValueLabelSelectorSpec(c.memberRequiredTraits)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+		al.Spec.MembershipRequires.Traits = traits
+	}
+
+	return nil
+}
+
+type applyAccessFlagsToRole func(allow *types.RoleConditions) error
+
+// applyAWSICFlagsToRole modifies the AWS IC role's allow block.
+// Empty values clear the whole allow spec since this role is specific to awsic,
+// unset flags leave fields alone.
+func (c *Command) applyAWSICFlagsToRole(allow *types.RoleConditions) error {
+	if c.awsicAssignments == "" {
+		*allow = types.RoleConditions{}
+	} else {
+		allow.AppLabels = awsIcAppLabel
+		aa, err := buildAWSICAccountAssignments(c.awsicAssignments)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+		allow.AccountAssignments = aa
+	}
+	return nil
+}
+
+// applyStandardAccessFlagsToRole modifies the standard role's allow block.
+// Empty values clear the field, unset flags leave field alone.
+func (c *Command) applyStandardAccessFlagsToRole(allow *types.RoleConditions) error {
+	// Nodes
+	if c.nodeLabelsSet {
+		labels, err := parse.MultiValueLabelSelectorSpec(c.nodeLabels)
+		if err != nil {
+			return trace.Wrap(err, "--node-labels")
+		}
+		allow.NodeLabels = types.ToLabels(labels)
+	}
+	if c.loginsSet {
+		allow.Logins = utils.SplitIdentifiers(c.logins)
+	}
+
+	// Dbs
+	if c.dbLabelsSet {
+		labels, err := parse.MultiValueLabelSelectorSpec(c.dbLabels)
+		if err != nil {
+			return trace.Wrap(err, "--db-labels")
+		}
+		allow.DatabaseLabels = types.ToLabels(labels)
+	}
+	if c.dbUsersSet {
+		allow.DatabaseUsers = utils.SplitIdentifiers(c.dbUsers)
+	}
+	if c.dbNamesSet {
+		allow.DatabaseNames = utils.SplitIdentifiers(c.dbNames)
+	}
+
+	// Kubes
+	if c.kubeLabelsSet {
+		labels, err := parse.MultiValueLabelSelectorSpec(c.kubeLabels)
+		if err != nil {
+			return trace.Wrap(err, "--kubernetes-labels")
+		}
+		allow.KubernetesLabels = types.ToLabels(labels)
+	}
+	if c.kubeUsersSet {
+		allow.KubeUsers = utils.SplitIdentifiers(c.kubeUsers)
+	}
+	if c.kubeGroupsSet {
+		allow.KubeGroups = utils.SplitIdentifiers(c.kubeGroups)
+	}
+
+	// Apps
+	if c.appLabelsSet {
+		labels, err := parse.MultiValueLabelSelectorSpec(c.appLabels)
+		if err != nil {
+			return trace.Wrap(err, "--app-labels")
+		}
+		allow.AppLabels = types.ToLabels(labels)
+	}
+	if c.awsRoleARNsSet {
+		allow.AWSRoleARNs = utils.SplitIdentifiers(c.awsRoleARNs)
+	}
+	if c.azureIdentitiesSet {
+		allow.AzureIdentities = utils.SplitIdentifiers(c.azureIdentities)
+	}
+	if c.gcpServiceAccountsSet {
+		allow.GCPServiceAccounts = utils.SplitIdentifiers(c.gcpServiceAccounts)
+	}
+	if c.mcpToolsSet {
+		tools := utils.SplitIdentifiers(c.mcpTools)
+		if len(tools) == 0 {
+			allow.MCP = nil
+		} else {
+			allow.MCP = &types.MCPPermissions{Tools: tools}
+		}
+	}
+
+	// Windows
+	if c.windowsLabelsSet {
+		labels, err := parse.MultiValueLabelSelectorSpec(c.windowsLabels)
+		if err != nil {
+			return trace.Wrap(err, "--windows-labels")
+		}
+		allow.WindowsDesktopLabels = types.ToLabels(labels)
+	}
+	if c.windowsLoginsSet {
+		allow.WindowsDesktopLogins = utils.SplitIdentifiers(c.windowsLogins)
+	}
+
+	// GitHub
+	if c.gitHubOrgsSet {
+		orgs := utils.SplitIdentifiers(c.gitHubOrgs)
+		if len(orgs) == 0 {
+			allow.GitHubPermissions = nil
+		} else {
+			allow.GitHubPermissions = []types.GitHubPermission{{Organizations: orgs}}
+		}
+	}
+	return nil
+}
+
+func reconcileOwners(wantUpdate bool, ownersStr string, memberKind string, currOwners map[string]accesslist.Owner) (newOwners []accesslist.Owner, removedOwners []string) {
+	if !wantUpdate {
+		// return owners as is.
+		for _, o := range currOwners {
+			newOwners = append(newOwners, o)
+		}
+		return newOwners, nil
+	}
+
+	newOwnerLookup := make(map[string]struct{}, len(currOwners))
+	for _, owner := range utils.SplitIdentifiers(ownersStr) {
+		newOwnerLookup[owner] = struct{}{}
+		newOwners = append(newOwners, accesslist.Owner{Name: owner, MembershipKind: memberKind})
+	}
+
+	for currOwner := range currOwners {
+		if _, found := newOwnerLookup[currOwner]; !found {
+			removedOwners = append(removedOwners, currOwner)
+		}
+	}
+
+	return newOwners, removedOwners
+}
+
+func reconcileMembers(listName string, wantUpdate bool, membersStr string, memberKind string, currMembers map[string]*accesslist.AccessListMember) (newMembers []*accesslist.AccessListMember, removedMembers []string, err error) {
+	if !wantUpdate {
+		// return members as is.
+		for _, m := range currMembers {
+			newMembers = append(newMembers, m)
+		}
+		return newMembers, nil, nil
+	}
+
+	newMemberLookup := make(map[string]struct{}, len(currMembers))
+	for _, name := range utils.SplitIdentifiers(membersStr) {
+		newMemberLookup[name] = struct{}{}
+		m, err := newMember(listName, name, memberKind)
+		if err != nil {
+			return nil, nil, trace.Wrap(err)
+		}
+		newMembers = append(newMembers, m)
+	}
+
+	for currMember := range currMembers {
+		if _, found := newMemberLookup[currMember]; !found {
+			removedMembers = append(removedMembers, currMember)
+		}
+	}
+
+	return newMembers, removedMembers, nil
+}
+
+// buildMembersForUpdate returns new member list and all members removed from previous list.
+// It separates users and access list from members so that flags "--members" and "--member-access-lists"
+// updates only the specified member kinds.
+// E.g.: if only "--member-access-lists" was specified, only member kind "access list" is updated
+// and member kind "user" is still preserved.
+func (c *Command) buildMembersForUpdate(ctx context.Context, client *authclient.Client, listName string) ([]*accesslist.AccessListMember, []string, error) {
+	currentMembers, err := c.collectAllMembers(ctx, client, listName)
+	if err != nil {
+		return nil, nil, trace.Wrap(err)
+	}
+
+	currentUsers := make(map[string]*accesslist.AccessListMember)
+	currentLists := make(map[string]*accesslist.AccessListMember)
+	for _, m := range currentMembers {
+		if m.Spec.MembershipKind == accesslist.MembershipKindList {
+			currentLists[m.Spec.Name] = m
+		} else {
+			currentUsers[m.Spec.Name] = m
+		}
+	}
+
+	users, userRemoved, err := reconcileMembers(listName, c.membersSet, c.members, accesslist.MembershipKindUser, currentUsers)
+	if err != nil {
+		return nil, nil, trace.Wrap(err)
+	}
+	lists, listRemoved, err := reconcileMembers(listName, c.memberAccessListsSet, c.memberAccessLists, accesslist.MembershipKindList, currentLists)
+	if err != nil {
+		return nil, nil, trace.Wrap(err)
+	}
+
+	return append(users, lists...), append(userRemoved, listRemoved...), nil
+}
+
+// buildOwnersForUpdate returns new owner list and all owners removed from previous list.
+// It separates users and access list from owner so that flags "--owners" and "--owner-access-lists"
+// updates only the specified owner kinds.
+// E.g.: if only "--owner-access-lists" was specified, only owner kind "access list" is updated
+// and owner kind "user" is still preserved.
+func (c *Command) buildOwnersForUpdate(al *accesslist.AccessList) ([]accesslist.Owner, []string) {
+	currentUserOwners := make(map[string]accesslist.Owner)
+	currentListOwners := make(map[string]accesslist.Owner)
+	for _, o := range al.Spec.Owners {
+		if o.MembershipKind == accesslist.MembershipKindList {
+			currentListOwners[o.Name] = o
+		} else {
+			currentUserOwners[o.Name] = o
+		}
+	}
+
+	userOwners, userRemoved := reconcileOwners(c.ownersSet, c.owners, accesslist.MembershipKindUser, currentUserOwners)
+	listOwners, listRemoved := reconcileOwners(c.ownerAccessListsSet, c.ownerAccessLists, accesslist.MembershipKindList, currentListOwners)
+	newOwners := append(userOwners, listOwners...)
+	removedOwners := append(userRemoved, listRemoved...)
+
+	return newOwners, removedOwners
+}
+
+// updateAccessListWithPreset updates an access list, any related access roles, and members.
+func (c *Command) updateAccessListWithPreset(ctx context.Context, client *authclient.Client, al *accesslist.AccessList, newMembers []*accesslist.AccessListMember, membersChanged bool) (*accesslist.AccessList, []*types.RoleV6, []string, error) {
+	var updatedAccessRoles []*types.RoleV6
+	if !c.removeAccess {
+		var standardRoleUpdateFn applyAccessFlagsToRole
+		if c.anyStandardAccessFlagsSet() {
+			standardRoleUpdateFn = c.applyStandardAccessFlagsToRole
+		}
+		standardRole, err := resolveAccessRole(ctx, client, al, standardRolePrefixName, standardRoleUpdateFn)
+		if err != nil {
+			return nil, nil, nil, trace.Wrap(err)
+		}
+
+		var awsicRoleUpdateFn applyAccessFlagsToRole
+		if c.awsicAssignmentsSet {
+			awsicRoleUpdateFn = c.applyAWSICFlagsToRole
+		}
+		awsicRole, err := resolveAccessRole(ctx, client, al, awsicRolePrefixName, awsicRoleUpdateFn)
+		if err != nil {
+			return nil, nil, nil, trace.Wrap(err)
+		}
+
+		if standardRole != nil {
+			updatedAccessRoles = append(updatedAccessRoles, standardRole)
+		}
+		if awsicRole != nil {
+			updatedAccessRoles = append(updatedAccessRoles, awsicRole)
+		}
+	} // else, no roles appended means "remove these access roles from al grants"
+
+	grpcClient := accesslistv1.NewAccessListServiceClient(client.GetConnection())
+	resp, err := grpcClient.UpdateAccessListWithPreset(ctx, &accesslistv1.UpdateAccessListWithPresetRequest{
+		AccessList: conv.ToProto(al),
+		Roles:      updatedAccessRoles,
+	})
+	if err != nil {
+		return nil, nil, nil, trace.Wrap(err)
+	}
+	updatedAccessList, err := conv.FromProto(resp.AccessList)
+	if err != nil {
+		return nil, nil, nil, trace.Wrap(err)
+	}
+
+	finalAccessList := updatedAccessList
+	if membersChanged {
+		finalAccessList, _, err = client.AccessListClient().UpsertAccessListWithMembers(ctx, updatedAccessList, newMembers)
+		if err != nil {
+			return nil, nil, nil, trace.Wrap(err)
+		}
+	}
+	return finalAccessList, resp.GetRoles(), resp.GetRolesToBeDeleted(), nil
+}
+
+// printUpdateText renders the human-readable summary of an update.
+func (c *Command) printUpdateText(r UpdateJSONResponse) {
+	fmt.Fprintf(c.Stdout, "Updated access list %q (%s)\n", r.AccessList.Spec.Title, r.AccessList.GetName())
+
+	if len(r.OwnersRemoved) > 0 {
+		fmt.Fprintf(c.Stdout, "Owners removed: %s\n", strings.Join(r.OwnersRemoved, ", "))
+	}
+
+	if len(r.MembersRemoved) > 0 {
+		fmt.Fprintf(c.Stdout, "Members removed: %s\n", strings.Join(r.MembersRemoved, ", "))
+	}
+
+	if len(r.UpdatedOrCreatedRoles) > 0 {
+		names := make([]string, 0, len(r.UpdatedOrCreatedRoles))
+		for _, role := range r.UpdatedOrCreatedRoles {
+			names = append(names, role.GetMetadata().Name)
+		}
+		fmt.Fprintf(c.Stdout, "Roles updated or created: %s\n", strings.Join(names, ", "))
+	}
+
+	c.printRolesToBeDeleted(r.RolesToDelete)
+}
+
+// resolveAccessRole first queries for any existing role by "prefix" and return either:
+// - an existing role regardless if changes are needed (if changes, it will be applied)
+// - a new role resource with any changes applied if no role exist
+// - nil if no role exists and no changes need to be applied
+func resolveAccessRole(ctx context.Context, client *authclient.Client, al *accesslist.AccessList, prefix string, applyUpdates applyAccessFlagsToRole) (*types.RoleV6, error) {
+	roleName := accesslist.RoleName(prefix, al.GetName())
+	role, err := getAccessRoleByName(ctx, client, roleName)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	// Role doesn't exist, and no role building is required.
+	if role == nil && applyUpdates == nil {
+		return nil, nil
+	}
+
+	// Role doesn't exist, but role building is required.
+	if role == nil {
+		role, err = buildRole(prefix, types.RoleConditions{})
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+	}
+
+	if applyUpdates != nil {
+		if err := applyUpdates(&role.Spec.Allow); err != nil {
+			return nil, trace.Wrap(err)
+		}
+	}
+
+	return role, nil
+}
+
+// getAccessRoleByName fetches a role, returning nil if the role doesn't exist.
+func getAccessRoleByName(ctx context.Context, client *authclient.Client, roleName string) (*types.RoleV6, error) {
+	role, err := client.GetRole(ctx, roleName)
+	// If a role didn't exist yet, it meant no access was defined.
+	if trace.IsNotFound(err) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	roleV6, ok := role.(*types.RoleV6)
+	if !ok {
+		return nil, trace.BadParameter("role %q has unexpected type %T", roleName, role)
+	}
+	return roleV6, nil
+}
+
+// UpdateJSONResponse is the structured response for `tctl acl update
+// --format=json`.
+type UpdateJSONResponse struct {
+	AccessList            *accesslist.AccessList `json:"access_list"`
+	AccessType            string                 `json:"access_type,omitempty"`
+	UpdatedOrCreatedRoles []*types.RoleV6        `json:"updated_or_created_roles,omitempty"`
+	RolesToDelete         []string               `json:"roles_to_delete,omitempty"`
+	OwnersRemoved         []string               `json:"owners_removed,omitempty"`
+	MembersRemoved        []string               `json:"members_removed,omitempty"`
+}

--- a/tool/tctl/common/accesslist/update.go
+++ b/tool/tctl/common/accesslist/update.go
@@ -1,27 +1,27 @@
-/*
- * Teleport
- * Copyright (C) 2026  Gravitational, Inc.
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
- *
- * You should have received a copy of the GNU Affero General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
- */
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 package accesslist
 
 import (
 	"context"
 	"fmt"
+	"slices"
 	"strings"
+	"time"
 
 	"github.com/gravitational/trace"
 
@@ -39,6 +39,14 @@ import (
 func (c *Command) Update(ctx context.Context, client *authclient.Client) error {
 	if !c.anyUpdateFlagSet() {
 		return trace.BadParameter("no update flags are set")
+	}
+
+	// To avoid non-atomic partial writes, member updates are to be run
+	// separately from updates to access list meta/spec. Combining
+	// both means there will be partial failures where grants may be
+	// unintentionally given b/c member update operation failed.
+	if c.anyMemberUpdateFlagSet() && c.anyNonMemberUpdateFlagSet() {
+		return trace.BadParameter("--members/--member-access-lists replaces membership only; run a separate `tctl acl update` to change access list settings")
 	}
 
 	if c.titleSet && c.title == "" {
@@ -66,54 +74,50 @@ func (c *Command) Update(ctx context.Context, client *authclient.Client) error {
 		}
 	}
 
-	// Apply al metadata/specs
-	if err := c.applySpecFlags(al); err != nil {
-		return trace.Wrap(err)
-	}
-
-	// Apply list of owners
+	var updatedAccessList *accesslist.AccessList
+	var updatedRoles []*types.RoleV6
+	var rolesToDelete []string
 	var removedOwners []string
-	if c.ownersSet || c.ownerAccessListsSet {
-		var updatedOwners []accesslist.Owner
-		updatedOwners, removedOwners = c.buildOwnersForUpdate(al)
-		if len(updatedOwners) == 0 {
-			return trace.BadParameter("an access list must have at least one owner")
-		}
-		al.Spec.Owners = updatedOwners
-	}
-
-	// Apply list of members
-	var updatedMembers []*accesslist.AccessListMember
 	var removedMembers []string
-	membersChanged := c.membersSet || c.memberAccessListsSet
-	if membersChanged {
+
+	switch {
+	case c.anyMemberUpdateFlagSet():
+		// Member-only update: replace the membership list without touching
+		// the access list spec.
+		var updatedMembers []*accesslist.AccessListMember
 		updatedMembers, removedMembers, err = c.buildMembersForUpdate(ctx, client, al.GetName())
 		if err != nil {
 			return trace.Wrap(err)
 		}
-	}
-
-	var updatedAccessList *accesslist.AccessList
-	var updatedRoles []*types.RoleV6
-	var rolesToDelete []string
-
-	if al.IsPreset() && (c.anyAccessFlagsSet() || c.removeAccess) {
-		// Updates al, access roles, and members (if any members)
-		updatedAccessList, updatedRoles, rolesToDelete, err = c.updateAccessListWithPreset(ctx, client, al, updatedMembers, membersChanged)
-		if err != nil {
-			return trace.Wrap(err)
-		}
-	} else if membersChanged {
-		// Updates al and members
 		updatedAccessList, _, err = client.AccessListClient().UpsertAccessListWithMembers(ctx, al, updatedMembers)
 		if err != nil {
 			return trace.Wrap(err)
 		}
-	} else {
-		// Metadata only update: don't touch members or access roles (preset).
-		updatedAccessList, err = client.AccessListClient().UpsertAccessList(ctx, al)
-		if err != nil {
+
+	// Access list spec/meta only update:
+	default:
+		if err := c.applySpecFlags(al); err != nil {
 			return trace.Wrap(err)
+		}
+		if c.ownersSet || c.ownerAccessListsSet {
+			var updatedOwners []accesslist.Owner
+			updatedOwners, removedOwners = c.buildOwnersForUpdate(al)
+			if len(updatedOwners) == 0 {
+				return trace.BadParameter("an access list must have at least one owner")
+			}
+			al.Spec.Owners = updatedOwners
+		}
+
+		if al.IsPreset() && (c.anyAccessFlagsSet() || c.removeAccess) {
+			updatedAccessList, updatedRoles, rolesToDelete, err = c.updateAccessListWithPreset(ctx, client, al)
+			if err != nil {
+				return trace.Wrap(err)
+			}
+		} else {
+			updatedAccessList, err = client.AccessListClient().UpdateAccessList(ctx, al)
+			if err != nil {
+				return trace.Wrap(err)
+			}
 		}
 	}
 
@@ -153,6 +157,11 @@ func (c *Command) applySpecFlags(al *accesslist.AccessList) error {
 			return trace.Wrap(err)
 		}
 		al.Spec.Audit.Recurrence.DayOfMonth = day
+	}
+	// Zero out NextAuditDate so the backend can re-compute this field
+	// automatically.
+	if c.auditFrequencySet || c.auditDaySet {
+		al.Spec.Audit.NextAuditDate = time.Time{}
 	}
 
 	// Owner grants and requirements
@@ -425,8 +434,8 @@ func (c *Command) buildOwnersForUpdate(al *accesslist.AccessList) ([]accesslist.
 	return newOwners, removedOwners
 }
 
-// updateAccessListWithPreset updates an access list, any related access roles, and members.
-func (c *Command) updateAccessListWithPreset(ctx context.Context, client *authclient.Client, al *accesslist.AccessList, newMembers []*accesslist.AccessListMember, membersChanged bool) (*accesslist.AccessList, []*types.RoleV6, []string, error) {
+// updateAccessListWithPreset updates an access list spec/meta and its related access roles.
+func (c *Command) updateAccessListWithPreset(ctx context.Context, client *authclient.Client, al *accesslist.AccessList) (*accesslist.AccessList, []*types.RoleV6, []string, error) {
 	var updatedAccessRoles []*types.RoleV6
 	if !c.removeAccess {
 		var standardRoleUpdateFn applyAccessFlagsToRole
@@ -456,26 +465,18 @@ func (c *Command) updateAccessListWithPreset(ctx context.Context, client *authcl
 	} // else, no roles appended means "remove these access roles from al grants"
 
 	grpcClient := accesslistv1.NewAccessListServiceClient(client.GetConnection())
-	resp, err := grpcClient.UpdateAccessListWithPreset(ctx, &accesslistv1.UpdateAccessListWithPresetRequest{
+	resp, err := grpcClient.UpdateAccessListWithPreset(ctx, accesslistv1.UpdateAccessListWithPresetRequest_builder{
 		AccessList: conv.ToProto(al),
 		Roles:      updatedAccessRoles,
-	})
+	}.Build())
 	if err != nil {
 		return nil, nil, nil, trace.Wrap(err)
 	}
-	updatedAccessList, err := conv.FromProto(resp.AccessList)
+	updatedAcl, err := conv.FromProto(resp.GetAccessList())
 	if err != nil {
 		return nil, nil, nil, trace.Wrap(err)
 	}
-
-	finalAccessList := updatedAccessList
-	if membersChanged {
-		finalAccessList, _, err = client.AccessListClient().UpsertAccessListWithMembers(ctx, updatedAccessList, newMembers)
-		if err != nil {
-			return nil, nil, nil, trace.Wrap(err)
-		}
-	}
-	return finalAccessList, resp.GetRoles(), resp.GetRolesToBeDeleted(), nil
+	return updatedAcl, resp.GetRoles(), resp.GetRolesToBeDeleted(), nil
 }
 
 // printUpdateText renders the human-readable summary of an update.
@@ -501,10 +502,13 @@ func (c *Command) printUpdateText(r UpdateJSONResponse) {
 	c.printRolesToBeDeleted(r.RolesToDelete)
 }
 
-// resolveAccessRole first queries for any existing role by "prefix" and return either:
-// - an existing role regardless if changes are needed (if changes, it will be applied)
-// - a new role resource with any changes applied if no role exist
-// - nil if no role exists and no changes need to be applied
+// resolveAccessRole returns the access role to send for upsert. A role is
+// "attached" when it exists and is listed in al.PresetRoleNames(); "not
+// attached" covers both missing roles and roles not currently referenced
+// by the access list.
+// - attached: return existing role (with updates applied if requested)
+// - not attached + updates requested: return a fresh role with updates applied
+// - not attached + no updates: return nil
 func resolveAccessRole(ctx context.Context, client *authclient.Client, al *accesslist.AccessList, prefix string, applyUpdates applyAccessFlagsToRole) (*types.RoleV6, error) {
 	roleName := accesslist.RoleName(prefix, al.GetName())
 	role, err := getAccessRoleByName(ctx, client, roleName)
@@ -513,25 +517,26 @@ func resolveAccessRole(ctx context.Context, client *authclient.Client, al *acces
 	}
 	roleExists := err == nil
 
-	// Role doesn't exist, and no role building is required.
-	if !roleExists && applyUpdates == nil {
+	// If an update is required and this existing role is attached to the list already,
+	// update the existing role, else assume a fresh role.
+	isAttachedToList := roleExists && slices.Contains(al.PresetRoleNames(), roleName)
+
+	if applyUpdates == nil {
+		if isAttachedToList {
+			return role, nil
+		}
 		return nil, nil
 	}
 
-	// Role doesn't exist, but role building is required.
-	if !roleExists {
+	if !isAttachedToList {
 		role, err = buildRole(prefix, types.RoleConditions{})
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
 	}
-
-	if applyUpdates != nil {
-		if err := applyUpdates(&role.Spec.Allow); err != nil {
-			return nil, trace.Wrap(err)
-		}
+	if err := applyUpdates(&role.Spec.Allow); err != nil {
+		return nil, trace.Wrap(err)
 	}
-
 	return role, nil
 }
 

--- a/tool/tctl/common/accesslist/update.go
+++ b/tool/tctl/common/accesslist/update.go
@@ -138,7 +138,7 @@ func (c *Command) applySpecFlags(al *accesslist.AccessList) error {
 		al.Spec.Title = c.title
 	}
 	if c.descriptionSet {
-		al.Metadata.Description = c.description
+		al.Spec.Description = c.description
 	}
 	if c.auditFrequencySet {
 		freq, err := getReviewFrequency(c.auditFrequency)
@@ -508,17 +508,18 @@ func (c *Command) printUpdateText(r UpdateJSONResponse) {
 func resolveAccessRole(ctx context.Context, client *authclient.Client, al *accesslist.AccessList, prefix string, applyUpdates applyAccessFlagsToRole) (*types.RoleV6, error) {
 	roleName := accesslist.RoleName(prefix, al.GetName())
 	role, err := getAccessRoleByName(ctx, client, roleName)
-	if err != nil {
+	if err != nil && !trace.IsNotFound(err) {
 		return nil, trace.Wrap(err)
 	}
+	roleExists := err == nil
 
 	// Role doesn't exist, and no role building is required.
-	if role == nil && applyUpdates == nil {
+	if !roleExists && applyUpdates == nil {
 		return nil, nil
 	}
 
 	// Role doesn't exist, but role building is required.
-	if role == nil {
+	if !roleExists {
 		role, err = buildRole(prefix, types.RoleConditions{})
 		if err != nil {
 			return nil, trace.Wrap(err)
@@ -534,13 +535,9 @@ func resolveAccessRole(ctx context.Context, client *authclient.Client, al *acces
 	return role, nil
 }
 
-// getAccessRoleByName fetches a role, returning nil if the role doesn't exist.
+// getAccessRoleByName fetches a role by given name.
 func getAccessRoleByName(ctx context.Context, client *authclient.Client, roleName string) (*types.RoleV6, error) {
 	role, err := client.GetRole(ctx, roleName)
-	// If a role didn't exist yet, it meant no access was defined.
-	if trace.IsNotFound(err) {
-		return nil, nil
-	}
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/tool/tctl/common/accesslist/update_test.go
+++ b/tool/tctl/common/accesslist/update_test.go
@@ -1,20 +1,18 @@
-/*
- * Teleport
- * Copyright (C) 2026  Gravitational, Inc.
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
- *
- * You should have received a copy of the GNU Affero General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
- */
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 package accesslist
 

--- a/tool/tctl/common/accesslist/update_test.go
+++ b/tool/tctl/common/accesslist/update_test.go
@@ -44,7 +44,7 @@ func TestApplySpecFlags(t *testing.T) {
 			name: "description",
 			cmd:  Command{descriptionSet: true, description: "New Desc"},
 			assert: func(t *testing.T, al *accesslist.AccessList) {
-				require.Equal(t, "New Desc", al.Metadata.Description)
+				require.Equal(t, "New Desc", al.Spec.Description)
 			},
 		},
 		{

--- a/tool/tctl/common/accesslist/update_test.go
+++ b/tool/tctl/common/accesslist/update_test.go
@@ -1,0 +1,311 @@
+/*
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package accesslist
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/api/types/accesslist"
+)
+
+func TestApplySpecFlags(t *testing.T) {
+	tests := []struct {
+		name   string
+		cmd    Command
+		assert func(t *testing.T, al *accesslist.AccessList)
+	}{
+		{
+			name: "title",
+			cmd:  Command{titleSet: true, title: "New Title"},
+			assert: func(t *testing.T, al *accesslist.AccessList) {
+				require.Equal(t, "New Title", al.Spec.Title)
+			},
+		},
+		{
+			name: "description",
+			cmd:  Command{descriptionSet: true, description: "New Desc"},
+			assert: func(t *testing.T, al *accesslist.AccessList) {
+				require.Equal(t, "New Desc", al.Metadata.Description)
+			},
+		},
+		{
+			name: "audit-frequency",
+			cmd:  Command{auditFrequencySet: true, auditFrequency: 6},
+			assert: func(t *testing.T, al *accesslist.AccessList) {
+				require.Equal(t, accesslist.SixMonths, al.Spec.Audit.Recurrence.Frequency)
+			},
+		},
+		{
+			name: "audit-day",
+			cmd:  Command{auditDaySet: true, auditDay: 15},
+			assert: func(t *testing.T, al *accesslist.AccessList) {
+				require.Equal(t, accesslist.FifteenthDayOfMonth, al.Spec.Audit.Recurrence.DayOfMonth)
+			},
+		},
+		{
+			name: "owner-grant-roles",
+			cmd:  Command{ownerGrantRolesSet: true, ownerGrantRoles: "role1,role2"},
+			assert: func(t *testing.T, al *accesslist.AccessList) {
+				require.Equal(t, []string{"role1", "role2"}, al.Spec.OwnerGrants.Roles)
+			},
+		},
+		{
+			name: "owner-grant-traits",
+			cmd:  Command{ownerGrantTraitsSet: true, ownerGrantTraits: "team=apple,team=banana"},
+			assert: func(t *testing.T, al *accesslist.AccessList) {
+				require.Equal(t, []string{"apple", "banana"}, al.Spec.OwnerGrants.Traits["team"])
+			},
+		},
+		{
+			name: "owner-required-roles",
+			cmd:  Command{ownerRequiredRolesSet: true, ownerRequiredRoles: "role1,role2"},
+			assert: func(t *testing.T, al *accesslist.AccessList) {
+				require.Equal(t, []string{"role1", "role2"}, al.Spec.OwnershipRequires.Roles)
+			},
+		},
+		{
+			name: "owner-required-traits",
+			cmd:  Command{ownerRequiredTraitsSet: true, ownerRequiredTraits: "team=apple,team=banana"},
+			assert: func(t *testing.T, al *accesslist.AccessList) {
+				require.Equal(t, []string{"apple", "banana"}, al.Spec.OwnershipRequires.Traits["team"])
+			},
+		},
+		{
+			name: "member-grant-roles",
+			cmd:  Command{memberGrantRolesSet: true, memberGrantRoles: "role1,role2"},
+			assert: func(t *testing.T, al *accesslist.AccessList) {
+				require.Equal(t, []string{"role1", "role2"}, al.Spec.Grants.Roles)
+			},
+		},
+		{
+			name: "member-grant-traits",
+			cmd:  Command{memberGrantTraitsSet: true, memberGrantTraits: "team=apple,team=banana"},
+			assert: func(t *testing.T, al *accesslist.AccessList) {
+				require.Equal(t, []string{"apple", "banana"}, al.Spec.Grants.Traits["team"])
+			},
+		},
+		{
+			name: "member-required-roles",
+			cmd:  Command{memberRequiredRolesSet: true, memberRequiredRoles: "role1,role2"},
+			assert: func(t *testing.T, al *accesslist.AccessList) {
+				require.Equal(t, []string{"role1", "role2"}, al.Spec.MembershipRequires.Roles)
+			},
+		},
+		{
+			name: "member-required-traits",
+			cmd:  Command{memberRequiredTraitsSet: true, memberRequiredTraits: "team=apple,team=banana"},
+			assert: func(t *testing.T, al *accesslist.AccessList) {
+				require.Equal(t, []string{"apple", "banana"}, al.Spec.MembershipRequires.Traits["team"])
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			al := &accesslist.AccessList{}
+			require.NoError(t, tt.cmd.applySpecFlags(al))
+			tt.assert(t, al)
+		})
+	}
+}
+
+func TestApplyStandardAccessFlagsToRole(t *testing.T) {
+	tests := []struct {
+		name   string
+		cmd    Command
+		assert func(t *testing.T, allow types.RoleConditions)
+	}{
+		// Nodes
+		{
+			name: "node-labels",
+			cmd:  Command{nodeLabelsSet: true, nodeLabels: "env=staging,env=test"},
+			assert: func(t *testing.T, a types.RoleConditions) {
+				require.Equal(t, []string{"staging", "test"}, []string(a.NodeLabels["env"]))
+			},
+		},
+		{
+			name: "logins",
+			cmd:  Command{loginsSet: true, logins: "root,ubuntu"},
+			assert: func(t *testing.T, a types.RoleConditions) {
+				require.Equal(t, []string{"root", "ubuntu"}, a.Logins)
+			},
+		},
+		// Dbs
+		{
+			name: "db-labels",
+			cmd:  Command{dbLabelsSet: true, dbLabels: "env=staging,env=test"},
+			assert: func(t *testing.T, a types.RoleConditions) {
+				require.Equal(t, []string{"staging", "test"}, []string(a.DatabaseLabels["env"]))
+			},
+		},
+		{
+			name: "db-users",
+			cmd:  Command{dbUsersSet: true, dbUsers: "user1,user2"},
+			assert: func(t *testing.T, a types.RoleConditions) {
+				require.Equal(t, []string{"user1", "user2"}, a.DatabaseUsers)
+			},
+		},
+		{
+			name: "db-names",
+			cmd:  Command{dbNamesSet: true, dbNames: "postgres,sql"},
+			assert: func(t *testing.T, a types.RoleConditions) {
+				require.Equal(t, []string{"postgres", "sql"}, a.DatabaseNames)
+			},
+		},
+		// Kubes
+		{
+			name: "kubernetes-labels",
+			cmd:  Command{kubeLabelsSet: true, kubeLabels: "env=staging,env=test"},
+			assert: func(t *testing.T, a types.RoleConditions) {
+				require.Equal(t, []string{"staging", "test"}, []string(a.KubernetesLabels["env"]))
+			},
+		},
+		{
+			name: "kubernetes-users",
+			cmd:  Command{kubeUsersSet: true, kubeUsers: "user1,user2"},
+			assert: func(t *testing.T, a types.RoleConditions) {
+				require.Equal(t, []string{"user1", "user2"}, a.KubeUsers)
+			},
+		},
+		{
+			name: "kubernetes-groups",
+			cmd:  Command{kubeGroupsSet: true, kubeGroups: "group1,group2"},
+			assert: func(t *testing.T, a types.RoleConditions) {
+				require.Equal(t, []string{"group1", "group2"}, a.KubeGroups)
+			},
+		},
+		// Apps
+		{
+			name: "app-labels",
+			cmd:  Command{appLabelsSet: true, appLabels: "env=staging,env=test"},
+			assert: func(t *testing.T, a types.RoleConditions) {
+				require.Equal(t, []string{"staging", "test"}, []string(a.AppLabels["env"]))
+			},
+		},
+		{
+			name: "aws-role-arns",
+			cmd:  Command{awsRoleARNsSet: true, awsRoleARNs: "arn1,arn2"},
+			assert: func(t *testing.T, a types.RoleConditions) {
+				require.Equal(t, []string{"arn1", "arn2"}, a.AWSRoleARNs)
+			},
+		},
+		{
+			name: "azure-identities",
+			cmd:  Command{azureIdentitiesSet: true, azureIdentities: "azure1,azure2"},
+			assert: func(t *testing.T, a types.RoleConditions) {
+				require.Equal(t, []string{"azure1", "azure2"}, a.AzureIdentities)
+			},
+		},
+		{
+			name: "gcp-service-accounts",
+			cmd:  Command{gcpServiceAccountsSet: true, gcpServiceAccounts: "gcp1,gpc2"},
+			assert: func(t *testing.T, a types.RoleConditions) {
+				require.Equal(t, []string{"gcp1", "gpc2"}, a.GCPServiceAccounts)
+			},
+		},
+		{
+			name: "mcp-tools",
+			cmd:  Command{mcpToolsSet: true, mcpTools: "tool1,tool2"},
+			assert: func(t *testing.T, a types.RoleConditions) {
+				require.NotNil(t, a.MCP)
+				require.Equal(t, []string{"tool1", "tool2"}, a.MCP.Tools)
+			},
+		},
+		// Windows
+		{
+			name: "windows-labels",
+			cmd:  Command{windowsLabelsSet: true, windowsLabels: "env=staging,env=test"},
+			assert: func(t *testing.T, a types.RoleConditions) {
+				require.Equal(t, []string{"staging", "test"}, []string(a.WindowsDesktopLabels["env"]))
+			},
+		},
+		{
+			name: "windows-logins",
+			cmd:  Command{windowsLoginsSet: true, windowsLogins: "login1,login2"},
+			assert: func(t *testing.T, a types.RoleConditions) {
+				require.Equal(t, []string{"login1", "login2"}, a.WindowsDesktopLogins)
+			},
+		},
+		// GitHub
+		{
+			name: "github-orgs",
+			cmd:  Command{gitHubOrgsSet: true, gitHubOrgs: "apple,banana"},
+			assert: func(t *testing.T, a types.RoleConditions) {
+				require.Equal(t, []types.GitHubPermission{{Organizations: []string{"apple", "banana"}}}, a.GitHubPermissions)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var allow types.RoleConditions
+			require.NoError(t, tt.cmd.applyStandardAccessFlagsToRole(&allow))
+			tt.assert(t, allow)
+		})
+	}
+}
+
+func TestApplyStandardAccessFlagsToRole_ClearingFields(t *testing.T) {
+	t.Run("clears when mcp-tools is set to empty", func(t *testing.T) {
+		allow := types.RoleConditions{MCP: &types.MCPPermissions{Tools: []string{"apple"}}}
+		cmd := Command{mcpToolsSet: true, mcpTools: ""}
+		require.NoError(t, cmd.applyStandardAccessFlagsToRole(&allow))
+		require.Nil(t, allow.MCP)
+	})
+	t.Run("clears when github-orgs is set to empty", func(t *testing.T) {
+		allow := types.RoleConditions{GitHubPermissions: []types.GitHubPermission{{Organizations: []string{"apple"}}}}
+		cmd := Command{gitHubOrgsSet: true, gitHubOrgs: ""}
+		require.NoError(t, cmd.applyStandardAccessFlagsToRole(&allow))
+		require.Nil(t, allow.GitHubPermissions)
+	})
+}
+
+func TestApplyAWSICFlagsToRole(t *testing.T) {
+	t.Run("sets assignments", func(t *testing.T) {
+		cmd := Command{awsicAssignments: "1234:arn:aws:sso:::permissionSet/test,5678:arn:aws:sso:::permissionSet/test2"}
+		var allow types.RoleConditions
+		require.NoError(t, cmd.applyAWSICFlagsToRole(&allow))
+		require.Equal(t, awsIcAppLabel, allow.AppLabels)
+		require.Len(t, allow.AccountAssignments, 2)
+		require.Equal(t,
+			types.IdentityCenterAccountAssignment{
+				PermissionSet: "arn:aws:sso:::permissionSet/test",
+				Account:       "1234",
+			},
+			allow.AccountAssignments[0])
+		require.Equal(t,
+			types.IdentityCenterAccountAssignment{
+				PermissionSet: "arn:aws:sso:::permissionSet/test2",
+				Account:       "5678",
+			},
+			allow.AccountAssignments[1])
+	})
+	t.Run("clears when empty", func(t *testing.T) {
+		allow := types.RoleConditions{
+			AppLabels:          awsIcAppLabel,
+			AccountAssignments: []types.IdentityCenterAccountAssignment{{}},
+		}
+		cmd := Command{awsicAssignments: ""}
+		require.NoError(t, cmd.applyAWSICFlagsToRole(&allow))
+		require.Empty(t, allow)
+	})
+}


### PR DESCRIPTION
part of https://github.com/gravitational/teleport.e/issues/8271 and RFD: https://github.com/gravitational/rfd/pull/29

Changelog: Added `tctl acl update` for updating an access list.


This PR adds a `tctl acl update` command to update an access list.

Updating an access list is already possible eg `tctl create -f <filename>`, but the new command goes a step further (handles access roles), more user friendly (see --help), and should be more discoverable (e.g. agents) since it's under the `tctl acl` namespace

Integration tests are written in the enterprise repo: https://github.com/gravitational/teleport.e/pull/8881

Example outputs:

with `tctl acl update --help` output

```bash
usage: tctl acl update [<flags>] <access-list-name>

Update an existing access list. Each flag you pass replaces that field (no merge or append), so list-valued flags like
--members or --logins overwrite the whole list; anything you omit is left unchanged.

For an access list created with an access type, resource flags (--node-labels, etc.) edit the supporting roles.

Flags:
  ...<other unrelated commands>
      --format=text              Output format. (one of: text, json)
      --title=TITLE              New display name for the access list.
      --description=DESCRIPTION  New description.
      --audit-frequency=6        Audit recurrence in months (1, 3, 6, or 12). Changing this resets the next audit date to now + frequency.
      --audit-day=1              Day of month for audit (1, 15, or 31). Changing this resets the next audit date to now + frequency.
      --owners=user1,user2,...   Replace the user owners with this list of usernames or emails.
      --owner-access-lists=name1,name2,...  
                                 Replace the access-list owners with this list of access list names.
      --owner-grant-roles=role1,role2,...  
                                 Roles granted to owners of this access list.
      --owner-grant-traits=key=value,...  
                                 Traits granted to owners of this access list.
      --owner-required-roles=role1,role2,...  
                                 Roles a user must already have to be an owner of this access list.
      --owner-required-traits=key=value,...  
                                 Traits a user must already have to be an owner of this access list.
      --members=user1,user2,...  Replace the user members with this list of usernames or emails. Not combinable with non-member update flags.
      --member-access-lists=name1,name2,...  
                                 Replace the nested access-list members with this list of access list names. Not combinable with non-member update
                                 flags.
      --member-grant-roles=role1,role2,...  
                                 Roles granted to members of this access list.
      --member-grant-traits=key=value,...  
                                 Traits granted to members of this access list.
      --member-required-roles=role1,role2,...  
                                 Roles a user must already have to be a member of this access list.
      --member-required-traits=key=value,...  
                                 Traits a user must already have to be a member of this access list.
      --node-labels=key=value,...  
                                 Selects SSH servers members may access by label match.
      --logins=login1,login2,...  
                                 OS logins members may use to connect to matched SSH servers.
      --db-labels=key=value,...  Selects databases members may access by label match.
      --db-users=user1,user2,...  
                                 Database users members may connect as on matched databases.
      --db-names=name1,name2,...  
                                 Database names members may connect to on matched databases.
      --kubernetes-labels=key=value,...  
                                 Selects Kubernetes clusters members may access by label match.
      --kubernetes-users=user1,user2,...  
                                 Kubernetes users members may impersonate on matched clusters.
      --kubernetes-groups=group1,group2,...  
                                 Kubernetes groups members may impersonate on matched clusters.
      --app-labels=key=value,...  
                                 Selects web apps members may access by label match. For AWS Identity Center apps, use --aws-ic-assignments
                                 instead.
      --aws-role-arns=arn1,arn2,...  
                                 AWS role ARNs members may assume via matched apps.
      --azure-identities=id1,id2,...  
                                 Azure managed identities members may assume via matched apps.
      --gcp-service-accounts=account1,account2,...  
                                 GCP service accounts members may assume via matched apps.
      --mcp-tools=tool1,tool2,...  
                                 MCP tools members may call on matched MCP apps.
      --windows-labels=key=value,...  
                                 Selects Windows desktops members may access by label match.
      --windows-logins=login1,login2,...  
                                 Logins members may use to connect to matched Windows desktops.
      --github-orgs=org1,org2,...  
                                 Selects git servers members may access by GitHub organization name.
      --aws-ic-assignments=accountID:permSetARN,...  
                                 Selects AWS Identity Center apps members may access by AWS account ID + permission set ARN
                                 ('accountID:permissionSetARN' pairs).
      --[no-]remove-access       Remove resource access from an access-typed list. Detaches the resource-access roles from the list's grants and
                                 from the supporting reviewer/requester roles.

Args:
  <access-list-name>  The Access List name.
```

when updating an access list created with a preset:
```bash
$ tctl acl update ABC --node-labels=env=staging
Updated access list "another short term" (ABC)
Roles updated or created: access-standard-acl-preset-ABC
```

when removing access to an access list created with a preset:
```
$ tctl acl update ABC --remove-access
Updated access list "another short term" (b9f614ce-9bf7-40de-af2d-57b4310bda94)

The following roles are no longer used by this access list:
  - access-standard-acl-preset-b9f614ce-9bf7-40de-af2d-57b4310bda94

These roles may still be assigned to users or referenced by other roles.
Verify each role is unused before deleting it with:
  tctl rm roles/<name>
```

when updating a regular access list:
```bash
$ tctl acl update ABC --title="changing title"
Updated access list "changing title" (ABC)
```





<!-- Provide a descriptive entry for the changelog of the next release. -->

<!-- Include manual testing efforts to verify the change. -->
<!-- Detail where the tests where run and what configurations were used. -->
<!-- Include all the test cases which were run to validate the change. -->

## Manual Test Plan
### Test Environment
local

### Test Cases

- [x] `format=json` prints json object instead of text summary
- [x] error when unsetting title
- [x] error when removing all owners (at least one is required)

Plain access list
- [x] update metadata fields (title, desc, audit, required roles, required traits, 
- [x] updating members kind `user` only replaces users, but keeps kind `accesslist` and vice versa
- [x] updating owners kind `user` only replaces users, but keeps kind `accesslist` and vice versa
- [x] can update member grant roles and traits
- [x] can update owner grant roles and traits
- [x] error on `--remove-access` or `any resource flags like --logins`

Preset access list (short term | long term)
- [x] update metadata fields (title, desc, audit, required roles, required traits) -- access roles remain
- [x] updating members kind `user` only replaces users, but keeps kind `accesslist` and vice versa -- access roles remain
- [x] `--remove-access` unassigns the access related roles from grants with long-term or from supporting roles with short-term (the reviewers/requesters role -- these roles remain assigned as grants), prints roles to delete
- [x] can update on resource related flags (e.g. --logins)
- [x] create missing access roles (if an access list is created without resource access)
- [x] error on update member grant roles and traits (teleport controls it)
- [x] error on update owner grant roles and traits (teleport controls it)
