### PR TITLE
kube: disable client-go rate limiter on agent's kube client

### DIFF
--- a/lib/kube/proxy/auth.go
+++ b/lib/kube/proxy/auth.go
@@ -168,6 +168,11 @@ func (f *Forwarder) getKubeDetails(ctx context.Context) error {
 func extractKubeCreds(ctx context.Context, component string, cluster string, clientCfg *rest.Config, log *slog.Logger, checkPermissions servicecfg.ImpersonationPermissionsChecker) (*staticKubeCreds, error) {
 	log = log.With("cluster", cluster)
 
+	// Disable client-go's client-side rate limiter (default 5 QPS).
+	// The kube exec path fetches pod metadata through this client,
+	// so the default limit caps exec throughput at ~5 QPS per agent.
+	clientCfg.QPS = -1
+
 	log.DebugContext(ctx, "Checking Kubernetes impersonation permissions")
 	client, err := kubernetes.NewForConfig(clientCfg)
 	if err != nil {


### PR DESCRIPTION
The kube exec audit path fetches pod metadata through the agent's client-go clientset. That clientset uses client-go's default 5 QPS rate limiter, which caps kube exec at about 5 QPS per agent. This disables the limiter in `extractKubeCreds` (covering both static and dynamic creds) and relies on the API server's own API Priority and Fairness.

Fixes #67644.

<!-- Include manual testing efforts to verify the change. -->
<!-- Detail where the tests where run and what configurations were used. -->
<!-- Include all the test cases which were run to validate the change. -->

## Manual Test Plan

### Test Environment

- Teleport v19 enterprise built from this branch, deployed to a local Kind cluster via the `teleport-cluster` Helm chart.
- Single Kubernetes agent (`kubernetes_service`, 1 replica) so the `5 QPS * #agents` cap is unambiguous.
- Load generator run from inside the cluster (talking to the proxy's ClusterIP service) to avoid `kubectl port-forward` becoming the bottleneck.
- A/B controlled on the auth pod's binary (where `kubernetes_service` / `extractKubeCreds` runs); identical method both sides: 120 `kubectl exec` calls, concurrency 30.

Results:

| Auth binary | Run 1 | Run 2 | All completed |
| --- | --- | --- | --- |
| Bug (default client-go limiter, 5 QPS / 10 burst) | 5.40 exec/s | 1.13 exec/s (55/120) | no — backlog + client timeouts |
| Fix (`clientCfg.QPS = -1`) | 56.93 exec/s | 61.97 exec/s | yes (120/120) |

~10-12x improvement; the fix decisively clears the 5 QPS ceiling. The bug's second run reproduces the degradation described in the issue: under sustained load the limiter builds a backlog and exec calls start timing out.

### Test Cases
- [x] With a single kube agent, raw `kubectl exec` through Teleport exceeds the `5 * #agents` cap (5.4 -> 57-62 exec/s).
- [x] Confirmed it is not an artifact of `tsh bench` — measured with plain `kubectl exec` (issue recreation step 3).
- [x] Exec audit events still include pod metadata (`kubernetes_node_name`, `kubernetes_container_image`, `kubernetes_container_name`, `kubernetes_pod_name`, `kubernetes_pod_namespace`).
- [x] Other kube verbs (`kubectl get pods`) work through Teleport — no regression.