### PR TITLE
[v18] kube: disable client-go rate limiter on agent's kube client

### DIFF
--- a/lib/kube/proxy/auth.go
+++ b/lib/kube/proxy/auth.go
@@ -168,6 +168,11 @@ func (f *Forwarder) getKubeDetails(ctx context.Context) error {
 func extractKubeCreds(ctx context.Context, component string, cluster string, clientCfg *rest.Config, log *slog.Logger, checkPermissions servicecfg.ImpersonationPermissionsChecker) (*staticKubeCreds, error) {
 	log = log.With("cluster", cluster)
 
+	// Disable client-go's client-side rate limiter (default 5 QPS).
+	// The kube exec path fetches pod metadata through this client,
+	// so the default limit caps exec throughput at ~5 QPS per agent.
+	clientCfg.QPS = -1
+
 	log.DebugContext(ctx, "Checking Kubernetes impersonation permissions")
 	client, err := kubernetes.NewForConfig(clientCfg)
 	if err != nil {


### PR DESCRIPTION
Backport of #67658 to `branch/v18`.

Disables client-go's default 5 QPS client-side rate limiter in `extractKubeCreds`, which capped kube exec throughput at ~5 QPS per agent. 