### PR TITLE
Fix flaky backend batch tests

### DIFF
--- a/lib/backend/test/atomicwrite.go
+++ b/lib/backend/test/atomicwrite.go
@@ -62,6 +62,7 @@ func RunAtomicWriteComplianceSuite(t *testing.T, newBackend Constructor) {
 func testAtomicWriteMove(t *testing.T, newBackend Constructor) {
 	bk, _, err := newBackend()
 	require.NoError(t, err)
+	defer bk.Close()
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -124,6 +125,7 @@ func testAtomicWriteMove(t *testing.T, newBackend Constructor) {
 func testAtomicWriteLock(t *testing.T, newBackend Constructor) {
 	bk, _, err := newBackend()
 	require.NoError(t, err)
+	defer bk.Close()
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -278,6 +280,7 @@ func testAtomicWriteLock(t *testing.T, newBackend Constructor) {
 func testAtomicWriteMax(t *testing.T, newBackend Constructor) {
 	bk, _, err := newBackend()
 	require.NoError(t, err)
+	defer bk.Close()
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -368,6 +371,7 @@ func testAtomicWriteConcurrent(t *testing.T, newBackend Constructor) {
 	)
 	bk, _, err := newBackend()
 	require.NoError(t, err)
+	defer bk.Close()
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -459,6 +463,7 @@ func testAtomicWriteNonConflicting(t *testing.T, newBackend Constructor) {
 
 	bk, _, err := newBackend()
 	require.NoError(t, err)
+	defer bk.Close()
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -524,6 +529,7 @@ func testAtomicWriteNonConflicting(t *testing.T, newBackend Constructor) {
 func testAtomicWriteOther(t *testing.T, newBackend Constructor) {
 	bk, _, err := newBackend()
 	require.NoError(t, err)
+	defer bk.Close()
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/lib/backend/test/delete_batch.go
+++ b/lib/backend/test/delete_batch.go
@@ -19,6 +19,7 @@
 package test
 
 import (
+	"slices"
 	"testing"
 	"time"
 
@@ -40,10 +41,6 @@ func runDeleteBatch(t *testing.T, newBackend Constructor) {
 		t.Skip("backend does not implement DeleteBatch; skipping DeleteBatch suite")
 	}
 
-	prefix := MakePrefix()
-	rangeStart := prefix("")
-	rangeEnd := backend.RangeEnd(prefix(""))
-
 	putItems := func(t *testing.T, items []backend.Item) {
 		t.Helper()
 		for _, item := range items {
@@ -52,7 +49,7 @@ func runDeleteBatch(t *testing.T, newBackend Constructor) {
 		}
 	}
 
-	newTestItems := func() []backend.Item {
+	newTestItems := func(prefix func(components ...string) backend.Key) []backend.Item {
 		return []backend.Item{
 			{Key: prefix("a"), Value: []byte("A"), Expires: time.Now().Add(1 * time.Hour)},
 			{Key: prefix("b"), Value: []byte("B")},
@@ -61,7 +58,11 @@ func runDeleteBatch(t *testing.T, newBackend Constructor) {
 	}
 
 	t.Run("delete batch items should be propagated in event stream", func(t *testing.T) {
-		items := newTestItems()
+		prefix := MakePrefix()
+		rangeStart := prefix("")
+		rangeEnd := backend.RangeEnd(prefix(""))
+
+		items := newTestItems(prefix)
 		putItems(t, items)
 
 		w, err := bk.NewWatcher(t.Context(), backend.Watch{})
@@ -83,7 +84,8 @@ func runDeleteBatch(t *testing.T, newBackend Constructor) {
 		err = deleter.DeleteBatch(t.Context(), keys)
 		require.NoError(t, err)
 
-		got := waitForDeleteEvents(t, w, len(keys), watchEventTimeout)
+		got := waitForDeleteEvents(t, w, len(keys), rangeStart, rangeEnd, watchEventTimeout)
+		slices.SortFunc(got, backend.Key.Compare)
 		require.Len(t, got, len(keys))
 		for i, key := range keys {
 			require.Equal(t, 0, key.Compare(got[i]))
@@ -96,7 +98,11 @@ func runDeleteBatch(t *testing.T, newBackend Constructor) {
 	})
 
 	t.Run("delete-then-verify-empty", func(t *testing.T) {
-		items := newTestItems()
+		prefix := MakePrefix()
+		rangeStart := prefix("")
+		rangeEnd := backend.RangeEnd(prefix(""))
+
+		items := newTestItems(prefix)
 		putItems(t, items)
 
 		// Verify items exist.
@@ -119,6 +125,8 @@ func runDeleteBatch(t *testing.T, newBackend Constructor) {
 	})
 
 	t.Run("delete-nonexistent-keys", func(t *testing.T) {
+		prefix := MakePrefix()
+
 		keys := []backend.Key{
 			prefix("nonexistent1"),
 			prefix("nonexistent2"),
@@ -139,7 +147,11 @@ func runDeleteBatch(t *testing.T, newBackend Constructor) {
 	})
 
 	t.Run("delete-partial-existing", func(t *testing.T) {
-		items := newTestItems()
+		prefix := MakePrefix()
+		rangeStart := prefix("")
+		rangeEnd := backend.RangeEnd(prefix(""))
+
+		items := newTestItems(prefix)
 		putItems(t, items)
 
 		// Delete a mix of existing and non-existing keys.
@@ -162,7 +174,7 @@ func runDeleteBatch(t *testing.T, newBackend Constructor) {
 	})
 }
 
-func waitForDeleteEvents(t *testing.T, w backend.Watcher, wantCount int, timeout time.Duration) []backend.Key {
+func waitForDeleteEvents(t *testing.T, w backend.Watcher, wantCount int, rangeStart backend.Key, rangeEnd backend.Key, timeout time.Duration) []backend.Key {
 	t.Helper()
 
 	var out []backend.Key
@@ -171,11 +183,8 @@ func waitForDeleteEvents(t *testing.T, w backend.Watcher, wantCount int, timeout
 
 	for len(out) < wantCount {
 		select {
-		case ev, ok := <-w.Events():
-			if !ok {
-				t.Fatalf("watcher closed before receiving all events: got=%d want=%d", len(out), wantCount)
-			}
-			if ev.Type == types.OpDelete {
+		case ev := <-w.Events():
+			if ev.Type == types.OpDelete && rangeStart.Compare(ev.Item.Key) <= 0 && ev.Item.Key.Compare(rangeEnd) <= 0 {
 				out = append(out, ev.Item.Key)
 			}
 		case <-deadline.C:

--- a/lib/backend/test/put_batch.go
+++ b/lib/backend/test/put_batch.go
@@ -21,6 +21,7 @@ package test
 import (
 	"bytes"
 	"fmt"
+	"slices"
 	"testing"
 	"time"
 
@@ -36,8 +37,6 @@ const (
 )
 
 func runPutBatch(t *testing.T, newBackend Constructor) {
-	t.Helper()
-
 	bk, _, err := newBackend()
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = bk.Close() })
@@ -47,15 +46,11 @@ func runPutBatch(t *testing.T, newBackend Constructor) {
 		t.Skip("backend does not implement PutBatch; skipping PutBatch suite")
 	}
 
-	prefix := MakePrefix()
-	rangeStart := prefix("")
-	rangeEnd := backend.RangeEnd(prefix(""))
-
 	itemEqual := func(a, b backend.Item) bool {
 		return a.Key.Compare(b.Key) == 0 &&
 			a.Revision == b.Revision &&
 			bytes.Equal(a.Value, b.Value) &&
-			a.Expires.Equal(b.Expires)
+			a.Expires.Sub(b.Expires) < time.Second && b.Expires.Sub(a.Expires) < time.Second
 	}
 
 	assertItemsEqual := func(t *testing.T, want, got []backend.Item) {
@@ -79,7 +74,7 @@ func runPutBatch(t *testing.T, newBackend Constructor) {
 		return out
 	}
 
-	newTestItems := func() []backend.Item {
+	newTestItems := func(prefix func(components ...string) backend.Key) []backend.Item {
 		return []backend.Item{
 			{Key: prefix("a"), Value: []byte("A"), Expires: time.Now().Add(1 * time.Hour)},
 			{Key: prefix("b"), Value: []byte("B")},
@@ -87,6 +82,10 @@ func runPutBatch(t *testing.T, newBackend Constructor) {
 		}
 	}
 	t.Run("put batch items should be propagated in event stream", func(t *testing.T) {
+		prefix := MakePrefix()
+		rangeStart := prefix("")
+		rangeEnd := backend.RangeEnd(rangeStart)
+
 		w, err := bk.NewWatcher(t.Context(), backend.Watch{})
 		require.NoError(t, err)
 		t.Cleanup(func() { w.Close() })
@@ -98,19 +97,25 @@ func runPutBatch(t *testing.T, newBackend Constructor) {
 			require.Equal(t, types.OpInit, ev.Type)
 		}
 
-		items := newTestItems()
+		items := newTestItems(prefix)
+		slices.SortFunc(items, func(a, b backend.Item) int { return a.Key.Compare(b.Key) })
 		rev, err := batcher.PutBatch(t.Context(), items)
 		require.NoError(t, err)
 		require.NotEmpty(t, rev)
 
-		got := waitForEvents(t, w, len(items), watchEventTimeout)
+		got := waitForEvents(t, w, len(items), rangeStart, rangeEnd, watchEventTimeout)
+		slices.SortFunc(got, func(a, b backend.Item) int { return a.Key.Compare(b.Key) })
 		want := buildWant(items, rev)
 		assertItemsEqual(t, want, got)
 		require.NoError(t, bk.DeleteRange(t.Context(), rangeStart, rangeEnd))
 	})
 
 	t.Run("put-create-update", func(t *testing.T) {
-		items := newTestItems()
+		prefix := MakePrefix()
+		rangeStart := prefix("")
+		rangeEnd := backend.RangeEnd(rangeStart)
+
+		items := newTestItems(prefix)
 		rev1, err := batcher.PutBatch(t.Context(), items)
 		require.NoError(t, err)
 		require.NotEmpty(t, rev1)
@@ -142,6 +147,10 @@ func runPutBatch(t *testing.T, newBackend Constructor) {
 	})
 
 	t.Run("over-chunk-size", func(t *testing.T) {
+		prefix := MakePrefix()
+		rangeStart := prefix("")
+		rangeEnd := backend.RangeEnd(prefix(""))
+
 		const itemCount = 1000
 		const payloadSize = 300 * 1024 // 300 KiB
 		items := make([]backend.Item, 0, itemCount)
@@ -168,7 +177,7 @@ func runPutBatch(t *testing.T, newBackend Constructor) {
 	})
 }
 
-func waitForEvents(t *testing.T, w backend.Watcher, wantCount int, timeout time.Duration) []backend.Item {
+func waitForEvents(t *testing.T, w backend.Watcher, wantCount int, rangeStart backend.Key, rangeEnd backend.Key, timeout time.Duration) []backend.Item {
 	t.Helper()
 
 	var out []backend.Item
@@ -177,15 +186,14 @@ func waitForEvents(t *testing.T, w backend.Watcher, wantCount int, timeout time.
 
 	for len(out) < wantCount {
 		select {
-		case ev, ok := <-w.Events():
-			if !ok {
-				t.Fatalf("watcher closed before receiving all events: got=%d want=%d", len(out), wantCount)
-			}
-			if ev.Type == types.OpPut {
+		case ev := <-w.Events():
+			if ev.Type == types.OpPut && rangeStart.Compare(ev.Item.Key) <= 0 && ev.Item.Key.Compare(rangeEnd) <= 0 {
 				out = append(out, ev.Item)
 			}
 		case <-w.Done():
 			t.Fatalf("watcher done before receiving all events: got=%d want=%d", len(out), wantCount)
+		case <-deadline.C:
+			t.Fatalf("hit timeout before receiving all events: got=%d want=%d", len(out), wantCount)
 		}
 	}
 	return out


### PR DESCRIPTION
This PR fixes some flakiness in the PutBatch and DeleteBatch backend test suite caused by events potentially being still delivered from other subtests or being delivered out of order, and from expiration times being potentially rounded (the current fix allows for up to one second of discrepancy). It also fixes some resource leaks in the AtomicWrite test suite which didn't close the created backends on exit.