### PR TITLE
[v17] Key remote port forwards by cluster

### DIFF
--- a/lib/srv/regular/sshserver.go
+++ b/lib/srv/regular/sshserver.go
@@ -248,12 +248,14 @@ type Server struct {
 
 type remoteForwardingMapKey struct {
 	user    string
+	cluster string
 	srcAddr string
 }
 
 func getRemoteForwardingMapKey(scx *srv.ServerContext) remoteForwardingMapKey {
 	return remoteForwardingMapKey{
 		user:    scx.Identity.TeleportUser,
+		cluster: scx.Identity.CertAuthority.GetClusterName(),
 		srcAddr: scx.SrcAddr,
 	}
 }


### PR DESCRIPTION
Backport #67525 to branch/v17

Changelog: Prevented users with the same name in different clusters from being able to cancel each others' remote port forwards

## Manual Test Plan
### Test Environment

Local root and leaf cluster, where the leaf cluster has at least one node. Create a user (alice) with the same name in each cluster, both able to access the node (hereafter referred to as `aliceA` and `aliceB`, it doesn't matter which is which).

### Test Cases
- [x] Verify that the following scenario works:
  - Start a local http server (e.g. `python3 -m http.server 8000`)
  - aliceA connects to the node with `tsh ssh -R localhost:9000:localhost:8000 <node>`
  - Verify that aliceA can reach the http server from her session with `curl http://localhost:9000`
  - aliceB generates an ssh config with `tsh config > ssh_config_teleport`. aliceB connects to the node with `ssh -F ssh_config_teleport -t -o EnableEscapeCommandline=yes <node-name>.<cluster-name>` (this allows aliceB to escape to the ssh command line)
  - aliceB attempts to create a remote port forward by typing `~C-Rlocalhost:9000` (`ssh` won't send a cancel-tcpip-forward if it didn't previously send tcpip-forward)
  - aliceB attempts to cancel the remote port forward by typing `~C-KRlocalhost:9000`
  - Verify that the node reports an error, and that aliceA can still access the http server with `curl http://localhost:9000`