### PR TITLE
On Auth: don't enqueue events that originate from agents

### DIFF
--- a/lib/auth/audit_fallback_grpc_test.go
+++ b/lib/auth/audit_fallback_grpc_test.go
@@ -1,0 +1,159 @@
+/*
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package auth_test
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/gravitational/trace"
+	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport/api/types"
+	apievents "github.com/gravitational/teleport/api/types/events"
+	"github.com/gravitational/teleport/lib/auth/authtest"
+	"github.com/gravitational/teleport/lib/events"
+	"github.com/gravitational/teleport/lib/events/auditqueue"
+)
+
+// toggleBackend is a controllable audit backend that records delivered events
+// and can be switched to fail, standing in for an SQS outage.
+type toggleBackend struct {
+	mu   sync.Mutex
+	fail bool                   // Simulate backend failures.
+	got  []apievents.AuditEvent // All events that we received.
+}
+
+func (b *toggleBackend) setFail(fail bool) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.fail = fail
+}
+
+func (b *toggleBackend) count() int {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return len(b.got)
+}
+
+func (b *toggleBackend) EmitAuditEvent(_ context.Context, event apievents.AuditEvent) error {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.fail {
+		return trace.ConnectionProblem(nil, "backend unavailable")
+	}
+	b.got = append(b.got, event)
+	return nil
+}
+
+func newAuthFallback(t *testing.T, backend *toggleBackend) *events.FallbackEmitter {
+	t.Helper()
+	fe, err := events.NewFallbackEmitter(events.FallbackEmitterConfig{
+		Primary:          backend,
+		DataDir:          t.TempDir(),
+		EnableAuditQueue: true,
+		AuditQueueCfg: auditqueue.Config{
+			MaxAttempts:             3,
+			DeadLetterSweepInterval: 50 * time.Millisecond,
+		},
+		AuditQueueBackends: []auditqueue.Kind{auditqueue.KindSQLiteMemory},
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, fe.Close()) })
+	return fe
+}
+
+func userLoginEvent() apievents.AuditEvent {
+	return &apievents.UserLogin{
+		Metadata: apievents.Metadata{
+			Type: events.UserLoginEvent,
+			Code: events.UserLocalLoginCode,
+		},
+		Status: apievents.Status{Success: true},
+	}
+}
+
+func TestEmitAuditEvent_ForwardedNotAdopted_GRPC(t *testing.T) {
+	ctx := context.Background()
+	backend := &toggleBackend{}
+	backend.setFail(true)
+
+	srv := newTestTLSServer(t)
+	srv.Auth().SetEmitter(newAuthFallback(t, backend))
+
+	client, err := srv.NewClient(authtest.TestServerID(types.RoleNode, "test-node"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, client.Close()) })
+
+	require.Error(t, client.EmitAuditEvent(ctx, userLoginEvent()),
+		"forwarded event delivery error must propagate to the client")
+
+	require.NoError(t, srv.Auth().EmitAuditEvent(ctx, userLoginEvent()),
+		"auth server must queue its own event on backend failure")
+
+	backend.setFail(false)
+	require.Eventually(t, func() bool {
+		return backend.count() >= 1
+	}, 5*time.Second, 50*time.Millisecond,
+		"auth server should re-deliver its own queued event after recovery")
+}
+
+func TestEmitAuditEvent_AgentRetriesEndToEnd_GRPC(t *testing.T) {
+	ctx := context.Background()
+	backend := &toggleBackend{}
+	backend.setFail(true)
+
+	srv := newTestTLSServer(t)
+	srv.Auth().SetEmitter(newAuthFallback(t, backend))
+
+	client, err := srv.NewClient(authtest.TestServerID(types.RoleNode, "test-node"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, client.Close()) })
+
+	agent, err := events.NewCheckingAsyncEmitter(
+		events.CheckingEmitterConfig{},
+		events.AsyncEmitterConfig{
+			Inner:            client,
+			DataDir:          t.TempDir(),
+			EnableAuditQueue: true,
+			AuditQueueCfg: auditqueue.Config{
+				MaxAttempts:             3,
+				DeadLetterSweepInterval: 50 * time.Millisecond,
+			},
+			AuditQueueBackends: []auditqueue.Kind{auditqueue.KindSQLiteMemory},
+		},
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, agent.Close()) })
+
+	require.NoError(t, agent.EmitAuditEvent(ctx, userLoginEvent()))
+
+	require.Never(t, func() bool {
+		return backend.count() > 0
+	}, 500*time.Millisecond, 50*time.Millisecond,
+		"event must not be delivered while the backend is down")
+
+	backend.setFail(false)
+	require.Eventually(t, func() bool {
+		return backend.count() >= 1
+	}, 5*time.Second, 50*time.Millisecond,
+		"agent should re-deliver the forwarded event through gRPC after recovery")
+}

--- a/lib/auth/grpcserver.go
+++ b/lib/auth/grpcserver.go
@@ -295,6 +295,10 @@ func (g *GRPCServer) EmitAuditEvent(ctx context.Context, req *apievents.OneOf) (
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
+	// Mark this event as forwarded from a remote instance so the auth server's
+	// fallback queue does not take ownership of it on a delivery failure. The
+	// originating instance retries from its own queue.
+	ctx = events.WithForwardedEmit(ctx)
 	err = auth.EmitAuditEvent(ctx, event)
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/events/emitter.go
+++ b/lib/events/emitter.go
@@ -56,9 +56,9 @@ type AsyncEmitterConfig struct {
 	// DataDir is the Teleport data directory. This is required for sqlite
 	// backed queues.
 	DataDir string
-	// EnableSQLiteQueue enables the SQLite-backed audit queue. When false,
+	// EnableAuditQueue enables the audit queue subsystem. When false,
 	// the legacy in-memory channel is used.
-	EnableSQLiteQueue bool
+	EnableAuditQueue bool
 	// AuditQueueCfg holds the options from the Teleport yaml config.
 	AuditQueueCfg auditqueue.Config
 	// AuditQueueBackends is the ordered list of backends to try on startup.
@@ -85,17 +85,17 @@ func NewAsyncEmitter(cfg AsyncEmitterConfig) (*AsyncEmitter, error) {
 	}
 
 	var queue auditqueue.Queue
-	if cfg.EnableSQLiteQueue {
+	if cfg.EnableAuditQueue {
 		var err error
-		queue, err = makeQueue(cfg)
+		queue, err = makeQueue(cfg.DataDir, cfg.AuditQueueCfg, cfg.AuditQueueBackends)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
 	}
 	if queue == nil {
-		slog.InfoContext(context.TODO(), "Using default in-memory audit event channel. SQLite-backed audit queue is disabled.")
+		slog.InfoContext(context.TODO(), "Using default in-memory audit event channel. Audit queue is disabled.")
 	} else {
-		slog.InfoContext(context.TODO(), "SQLite-backed audit queue is enabled.")
+		slog.InfoContext(context.TODO(), "Audit queue is enabled.")
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -119,11 +119,9 @@ func NewAsyncEmitter(cfg AsyncEmitterConfig) (*AsyncEmitter, error) {
 	return a, nil
 }
 
-func makeQueue(cfg AsyncEmitterConfig) (auditqueue.Queue, error) {
-	queueCfg := cfg.AuditQueueCfg
-	queueCfg.Path = filepath.Join(cfg.DataDir, auditQueueDir, uuid.NewString())
+func makeQueue(dataDir string, queueCfg auditqueue.Config, backends []auditqueue.Kind) (auditqueue.Queue, error) {
+	queueCfg.Path = filepath.Join(dataDir, auditQueueDir, uuid.NewString())
 
-	backends := cfg.AuditQueueBackends
 	if len(backends) == 0 {
 		backends = []auditqueue.Kind{auditqueue.KindSQLiteDisk}
 	}

--- a/lib/events/emitter_test.go
+++ b/lib/events/emitter_test.go
@@ -319,7 +319,7 @@ func TestAsyncEmitterAuditQueueBackends(t *testing.T) {
 	t.Run("in-memory backend", func(t *testing.T) {
 		emitter, err := events.NewAsyncEmitter(events.AsyncEmitterConfig{
 			Inner:              eventstest.NewChannelEmitter(10),
-			EnableSQLiteQueue:  true,
+			EnableAuditQueue:   true,
 			AuditQueueBackends: []auditqueue.Kind{auditqueue.KindSQLiteMemory},
 		})
 		require.NoError(t, err)
@@ -336,7 +336,7 @@ func TestAsyncEmitterAuditQueueBackends(t *testing.T) {
 	t.Run("fallback to in-memory", func(t *testing.T) {
 		emitter, err := events.NewAsyncEmitter(events.AsyncEmitterConfig{
 			Inner:              eventstest.NewChannelEmitter(10),
-			EnableSQLiteQueue:  true,
+			EnableAuditQueue:   true,
 			AuditQueueBackends: []auditqueue.Kind{"invalid_backend", auditqueue.KindSQLiteMemory},
 		})
 		require.NoError(t, err)
@@ -346,7 +346,7 @@ func TestAsyncEmitterAuditQueueBackends(t *testing.T) {
 	t.Run("all backends fail", func(t *testing.T) {
 		_, err := events.NewAsyncEmitter(events.AsyncEmitterConfig{
 			Inner:              eventstest.NewChannelEmitter(10),
-			EnableSQLiteQueue:  true,
+			EnableAuditQueue:   true,
 			AuditQueueBackends: []auditqueue.Kind{"invalid_backend"},
 		})
 		require.Error(t, err)
@@ -356,7 +356,7 @@ func TestAsyncEmitterAuditQueueBackends(t *testing.T) {
 		inner := eventstest.NewChannelEmitter(1)
 		emitter, err := events.NewAsyncEmitter(events.AsyncEmitterConfig{
 			Inner:              inner,
-			EnableSQLiteQueue:  true,
+			EnableAuditQueue:   true,
 			AuditQueueBackends: []auditqueue.Kind{auditqueue.KindSQLiteMemory},
 		})
 		require.NoError(t, err)

--- a/lib/events/fallback_emitter.go
+++ b/lib/events/fallback_emitter.go
@@ -1,0 +1,189 @@
+/*
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package events
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+
+	"github.com/gravitational/trace"
+	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/gravitational/teleport"
+	apievents "github.com/gravitational/teleport/api/types/events"
+	"github.com/gravitational/teleport/lib/events/auditqueue"
+	"github.com/gravitational/teleport/lib/observability/metrics"
+)
+
+// auditFallbackQueuedEvents counts locally-originated audit events diverted to
+// the fallback queue after the primary backend rejected them.
+var auditFallbackQueuedEvents = prometheus.NewCounter(
+	prometheus.CounterOpts{
+		Namespace: teleport.MetricNamespace,
+		Name:      "audit_fallback_queued_events_total",
+		Help:      "Total number of locally-originated audit events diverted to the fallback queue after the primary audit backend rejected them.",
+	},
+)
+
+type forwardedEmitKey struct{}
+
+// WithForwardedEmit marks ctx as carrying an audit event forwarded from an
+// agent. A FallbackEmitter does not queue such events when delivery fails. The
+// originating instance owns their durability and will retry from its own queue,
+// so the delivery error is returned to it instead.
+func WithForwardedEmit(ctx context.Context) context.Context {
+	return context.WithValue(ctx, forwardedEmitKey{}, struct{}{})
+}
+
+// isForwardedEmit reports whether ctx was marked by WithForwardedEmit.
+func isForwardedEmit(ctx context.Context) bool {
+	return ctx.Value(forwardedEmitKey{}) != nil
+}
+
+// FallbackEmitterConfig configures a FallbackEmitter.
+type FallbackEmitterConfig struct {
+	// Primary is the audit backend that events are emitted to.
+	Primary apievents.Emitter
+	// DataDir is the Teleport data directory, used for the fallback queue.
+	DataDir string
+	// EnableAuditQueue enables the fallback queue. When false, the
+	// FallbackEmitter simply delegates to Primary with no fallback behavior.
+	EnableAuditQueue bool
+	// AuditQueueCfg holds the queue options from the Teleport yaml config.
+	AuditQueueCfg auditqueue.Config
+	// AuditQueueBackends is the ordered list of queue backends to try.
+	AuditQueueBackends []auditqueue.Kind
+}
+
+// CheckAndSetDefaults checks and sets default values.
+func (c *FallbackEmitterConfig) CheckAndSetDefaults() error {
+	if c.Primary == nil {
+		return trace.BadParameter("missing parameter Primary")
+	}
+	return nil
+}
+
+// FallbackEmitter emits audit events directly to a primary backend. When the
+// primary backend fails to accept a locally-originated event, the event is
+// enqueued to the Audit Queue so it can be retried later. This behavior was
+// requested during drafting the RFD found below:
+//
+// See: https://github.com/gravitational/teleport.e/blob/rfd/0254-sqlite-audit-log-event-queue/rfd/0254-sqlite-audit-log-event-queue.md#auth-server--kubernetes-and-cloud-considerations
+type FallbackEmitter struct {
+	cfg    FallbackEmitterConfig
+	queue  auditqueue.Queue
+	ctx    context.Context
+	cancel context.CancelFunc
+	wg     sync.WaitGroup
+}
+
+// NewFallbackEmitter returns a FallbackEmitter wrapping cfg.Primary.
+func NewFallbackEmitter(cfg FallbackEmitterConfig) (*FallbackEmitter, error) {
+	if err := cfg.CheckAndSetDefaults(); err != nil {
+		return nil, trace.Wrap(err)
+	}
+	if err := metrics.RegisterPrometheusCollectors(auditFallbackQueuedEvents); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	var queue auditqueue.Queue
+	if cfg.EnableAuditQueue {
+		var err error
+		queue, err = makeQueue(cfg.DataDir, cfg.AuditQueueCfg, cfg.AuditQueueBackends)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	f := &FallbackEmitter{
+		cfg:    cfg,
+		queue:  queue,
+		ctx:    ctx,
+		cancel: cancel,
+	}
+	if queue != nil {
+		slog.InfoContext(ctx, "Audit fallback queue is enabled.")
+		f.wg.Go(func() {
+			if err := queue.Run(ctx, f.deliver); err != nil && ctx.Err() == nil {
+				slog.ErrorContext(ctx, "Audit fallback queue Run returned error.", "error", err)
+			}
+		})
+	}
+	return f, nil
+}
+
+// EmitAuditEvent emits the event to the primary backend. On failure, a
+// locally-originated event is enqueued to the fallback queue and a nil error is
+// returned.
+func (f *FallbackEmitter) EmitAuditEvent(ctx context.Context, event apievents.AuditEvent) error {
+	err := f.cfg.Primary.EmitAuditEvent(ctx, event)
+	if err == nil {
+		return nil
+	}
+	if f.queue == nil || isForwardedEmit(ctx) {
+		return trace.Wrap(err)
+	}
+
+	slog.WarnContext(ctx,
+		"Failed to emit audit event to the audit backend, falling back to the local queue.",
+		"event_type", event.GetType(),
+		"event_code", event.GetCode(),
+		"error", err,
+	)
+	if qerr := f.queue.Enqueue(event); qerr != nil {
+		slog.ErrorContext(ctx,
+			"Failed to enqueue audit event to the local fallback queue.",
+			"event_type", event.GetType(),
+			"event_code", event.GetCode(),
+			"error", qerr,
+		)
+		return trace.Wrap(qerr)
+	}
+	auditFallbackQueuedEvents.Inc()
+	return nil
+}
+
+// deliver is the queue.Run handler. It emits queued events to the primary
+// backend and returns the subset that were successfully delivered.
+func (f *FallbackEmitter) deliver(ctx context.Context, items []auditqueue.Item) []auditqueue.Item {
+	var delivered []auditqueue.Item
+	for _, item := range items {
+		if ctx.Err() != nil {
+			return delivered
+		}
+		if err := f.cfg.Primary.EmitAuditEvent(ctx, item.Event); err != nil {
+			slog.ErrorContext(ctx, "Failed to re-emit queued audit event.", "error", err)
+			continue
+		}
+		delivered = append(delivered, item)
+	}
+	return delivered
+}
+
+// Close shuts down the background consumer and releases the queue.
+func (f *FallbackEmitter) Close() error {
+	f.cancel()
+	f.wg.Wait()
+	if f.queue != nil {
+		return trace.Wrap(f.queue.Close())
+	}
+	return nil
+}

--- a/lib/events/fallback_emitter_test.go
+++ b/lib/events/fallback_emitter_test.go
@@ -1,0 +1,216 @@
+/*
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package events_test
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/gravitational/trace"
+	"github.com/stretchr/testify/require"
+
+	apievents "github.com/gravitational/teleport/api/types/events"
+	"github.com/gravitational/teleport/lib/events"
+	"github.com/gravitational/teleport/lib/events/auditqueue"
+)
+
+// fakePrimary mocks an audit backend and can be toggled to simulate failures.
+type fakePrimary struct {
+	mu   sync.Mutex
+	fail bool
+	got  []apievents.AuditEvent
+}
+
+func (f *fakePrimary) setFail(fail bool) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.fail = fail
+}
+
+func (f *fakePrimary) count() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return len(f.got)
+}
+
+func (f *fakePrimary) EmitAuditEvent(_ context.Context, event apievents.AuditEvent) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.fail {
+		return trace.ConnectionProblem(nil, "backend unavailable")
+	}
+	f.got = append(f.got, event)
+	return nil
+}
+
+func newFallbackTestEmitter(t *testing.T, primary apievents.Emitter, enableQueue bool) *events.FallbackEmitter {
+	t.Helper()
+	e, err := events.NewFallbackEmitter(events.FallbackEmitterConfig{
+		Primary:            primary,
+		DataDir:            t.TempDir(),
+		EnableAuditQueue:   enableQueue,
+		AuditQueueBackends: []auditqueue.Kind{auditqueue.KindSQLiteMemory},
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, e.Close()) })
+	return e
+}
+
+func testEvent() apievents.AuditEvent {
+	return &apievents.UserLogin{
+		Metadata: apievents.Metadata{
+			Type: events.UserLoginEvent,
+			Code: events.UserLocalLoginCode,
+		},
+	}
+}
+
+func TestFallbackEmitter_PrimarySucceeds(t *testing.T) {
+	t.Parallel()
+	primary := &fakePrimary{}
+	e := newFallbackTestEmitter(t, primary, true)
+
+	require.NoError(t, e.EmitAuditEvent(t.Context(), testEvent()))
+	require.Equal(t, 1, primary.count())
+}
+
+func TestFallbackEmitter_QueuesAndRecovers(t *testing.T) {
+	t.Parallel()
+	primary := &fakePrimary{}
+	primary.setFail(true)
+	e := newFallbackTestEmitter(t, primary, true)
+
+	// Backend is down. The event is queued, not lost, and emit reports success.
+	require.NoError(t, e.EmitAuditEvent(t.Context(), testEvent()))
+	require.Equal(t, 0, primary.count())
+
+	// Backend recovers. The background consumer re-delivers the queued event.
+	primary.setFail(false)
+	require.Eventually(t, func() bool {
+		return primary.count() == 1
+	}, 5*time.Second, 50*time.Millisecond, "queued event should be re-delivered after recovery")
+}
+
+func TestFallbackEmitter_ForwardedNotQueued(t *testing.T) {
+	t.Parallel()
+	primary := &fakePrimary{}
+	primary.setFail(true)
+	e := newFallbackTestEmitter(t, primary, true)
+
+	ctx := events.WithForwardedEmit(t.Context())
+	require.Error(t, e.EmitAuditEvent(ctx, testEvent()), "forwarded event delivery error must propagate")
+
+	// Even after the backend recovers, the forwarded event must never appear,
+	// because it was never queued.
+	primary.setFail(false)
+	require.Never(t, func() bool {
+		return primary.count() > 0
+	}, time.Second, 50*time.Millisecond, "forwarded event must not be queued/re-delivered")
+}
+
+func TestFallbackEmitter_QueueDisabled(t *testing.T) {
+	t.Parallel()
+	primary := &fakePrimary{}
+	primary.setFail(true)
+	e := newFallbackTestEmitter(t, primary, false)
+
+	require.Error(t, e.EmitAuditEvent(t.Context(), testEvent()))
+
+	primary.setFail(false)
+	require.NoError(t, e.EmitAuditEvent(t.Context(), testEvent()))
+	require.Equal(t, 1, primary.count())
+}
+
+type authBoundary struct {
+	fallback apievents.Emitter
+}
+
+func (a authBoundary) EmitAuditEvent(ctx context.Context, event apievents.AuditEvent) error {
+	return a.fallback.EmitAuditEvent(events.WithForwardedEmit(ctx), event)
+}
+
+func newQueuedAsyncEmitter(t *testing.T, inner apievents.Emitter) *events.AsyncEmitter {
+	t.Helper()
+	a, err := events.NewAsyncEmitter(events.AsyncEmitterConfig{
+		Inner:            inner,
+		DataDir:          t.TempDir(),
+		EnableAuditQueue: true,
+		// A short dead-letter sweep keeps recovery fast. If an event exhausts
+		// its retries during the outage, the sweeper re-delivers it promptly
+		// once the backend is healthy again.
+		AuditQueueCfg: auditqueue.Config{
+			MaxAttempts:             3,
+			DeadLetterSweepInterval: 50 * time.Millisecond,
+		},
+		AuditQueueBackends: []auditqueue.Kind{auditqueue.KindSQLiteMemory},
+	})
+	require.NoError(t, err)
+	return a
+}
+
+func TestForwardedEvent_RetriedByAgent(t *testing.T) {
+	t.Parallel()
+	backend := &fakePrimary{}
+	backend.setFail(true)
+
+	authFallback := newFallbackTestEmitter(t, backend, true)
+	agent := newQueuedAsyncEmitter(t, authBoundary{fallback: authFallback})
+	t.Cleanup(func() { require.NoError(t, agent.Close()) })
+
+	require.NoError(t, agent.EmitAuditEvent(t.Context(), testEvent()))
+
+	// Backend is down. The event is not delivered, but it is not lost. The
+	// agent retries from its own queue.
+	require.Never(t, func() bool {
+		return backend.count() > 0
+	}, 500*time.Millisecond, 50*time.Millisecond, "event must not be delivered while the backend is down")
+
+	// Backend recovers. The agent's retry loop delivers the event end-to-end.
+	backend.setFail(false)
+	require.Eventually(t, func() bool {
+		return backend.count() >= 1
+	}, 5*time.Second, 50*time.Millisecond, "agent should re-deliver the forwarded event after recovery")
+}
+
+func TestForwardedEvent_NotAdoptedByAuth(t *testing.T) {
+	t.Parallel()
+	backend := &fakePrimary{}
+	backend.setFail(true)
+
+	authFallback := newFallbackTestEmitter(t, backend, true)
+	agent := newQueuedAsyncEmitter(t, authBoundary{fallback: authFallback})
+
+	require.NoError(t, agent.EmitAuditEvent(t.Context(), testEvent()))
+	require.Never(t, func() bool {
+		return backend.count() > 0
+	}, 500*time.Millisecond, 50*time.Millisecond, "event must not be delivered while the backend is down")
+
+	// Stop the only queue that owns the forwarded event while the backend is
+	// still down.
+	require.NoError(t, agent.Close())
+
+	// The auth server never queued the forwarded event, so recovery delivers
+	// nothing. It was the agent's responsibility and its queue is gone.
+	backend.setFail(false)
+	require.Never(t, func() bool {
+		return backend.count() > 0
+	}, time.Second, 50*time.Millisecond, "auth server must not have adopted the forwarded event")
+}

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -2442,6 +2442,21 @@ func (process *TeleportProcess) initAuthService() error {
 		}
 	}
 
+	// When the audit queue is enabled, wrap the audit backend so that audit
+	// events this auth server originates are queued to disk if the backend
+	// rejects them, and re-delivered later. Events forwarded from
+	// agents/proxies are not queued here (see GRPCServer.EmitAuditEvent). Their
+	// originating instance retries them from its own queue.
+	var fallbackEmitter *events.FallbackEmitter
+	if isAuditQueueEnabled() {
+		fe, err := process.newAuthFallbackEmitter(emitter)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+		fallbackEmitter = fe
+		emitter = fe
+	}
+
 	checkingEmitter, err := events.NewCheckingEmitter(events.CheckingEmitterConfig{
 		Inner:       events.NewMultiEmitter(events.NewLoggingEmitter(process.GetClusterFeatures().Cloud), emitter),
 		Clock:       process.Clock,
@@ -3070,6 +3085,9 @@ func (process *TeleportProcess) initAuthService() error {
 
 	// execute this when process is asked to exit:
 	process.OnExit("auth.shutdown", func(payload any) {
+		if fallbackEmitter != nil {
+			warnOnErr(process.ExitContext(), fallbackEmitter.Close(), logger)
+		}
 		// The listeners have to be closed here, because if shutdown
 		// was called before the start of the http server,
 		// the http server would have not started tracking the listeners
@@ -3471,7 +3489,7 @@ func (process *TeleportProcess) proxyPublicAddr() utils.NetAddr {
 	return process.Config.Proxy.PublicAddrs[0]
 }
 
-func isSQLiteQueueEnabled() bool {
+func isAuditQueueEnabled() bool {
 	enabled, _ := strconv.ParseBool(os.Getenv("TELEPORT_UNSTABLE_AUDIT_LOG_RELIABILITY"))
 	return enabled
 }
@@ -3479,11 +3497,6 @@ func isSQLiteQueueEnabled() bool {
 // NewAsyncEmitter wraps client and returns emitter that never blocks, logs some events and checks values.
 // It is caller's responsibility to call Close on the emitter once done.
 func (process *TeleportProcess) NewAsyncEmitter(clt apievents.Emitter) (*events.CheckingAsyncEmitter, error) {
-	var backends []auditqueue.Kind
-	for _, backend := range process.Config.AuditQueue.Backends {
-		backends = append(backends, auditqueue.Kind(backend))
-	}
-
 	// Wrap the AsyncEmitter in a CheckingEmitter to ensure event fields are
 	// properly set before inserting events into the queue.
 	return events.NewCheckingAsyncEmitter(
@@ -3491,21 +3504,43 @@ func (process *TeleportProcess) NewAsyncEmitter(clt apievents.Emitter) (*events.
 			Clock: process.Clock,
 		},
 		events.AsyncEmitterConfig{
-			Inner:             events.NewMultiEmitter(events.NewLoggingEmitter(process.GetClusterFeatures().Cloud), clt),
-			DataDir:           process.Config.DataDir,
-			EnableSQLiteQueue: isSQLiteQueueEnabled(),
-			AuditQueueCfg: auditqueue.Config{
-				SoftLimit:               process.Config.AuditQueue.SoftLimit,
-				MaxBytes:                process.Config.AuditQueue.MaxBytes,
-				MaxAttempts:             process.Config.AuditQueue.MaxAttempts,
-				DeadLetterTTL:           process.Config.AuditQueue.DeadLetterTTL,
-				DeadLetterSweepInterval: process.Config.AuditQueue.DeadLetterSweepInterval,
-				OrphanScanInterval:      process.Config.AuditQueue.OrphanScanInterval,
-				Synchronous:             process.Config.AuditQueue.Synchronous,
-			},
-			AuditQueueBackends: backends,
+			Inner:              events.NewMultiEmitter(events.NewLoggingEmitter(process.GetClusterFeatures().Cloud), clt),
+			DataDir:            process.Config.DataDir,
+			EnableAuditQueue:   isAuditQueueEnabled(),
+			AuditQueueCfg:      process.auditQueueConfig(),
+			AuditQueueBackends: process.auditQueueBackends(),
 		},
 	)
+}
+
+func (process *TeleportProcess) newAuthFallbackEmitter(primary apievents.Emitter) (*events.FallbackEmitter, error) {
+	return events.NewFallbackEmitter(events.FallbackEmitterConfig{
+		Primary:            primary,
+		DataDir:            process.Config.DataDir,
+		EnableAuditQueue:   isAuditQueueEnabled(),
+		AuditQueueCfg:      process.auditQueueConfig(),
+		AuditQueueBackends: process.auditQueueBackends(),
+	})
+}
+
+func (process *TeleportProcess) auditQueueConfig() auditqueue.Config {
+	return auditqueue.Config{
+		SoftLimit:               process.Config.AuditQueue.SoftLimit,
+		MaxBytes:                process.Config.AuditQueue.MaxBytes,
+		MaxAttempts:             process.Config.AuditQueue.MaxAttempts,
+		DeadLetterTTL:           process.Config.AuditQueue.DeadLetterTTL,
+		DeadLetterSweepInterval: process.Config.AuditQueue.DeadLetterSweepInterval,
+		OrphanScanInterval:      process.Config.AuditQueue.OrphanScanInterval,
+		Synchronous:             process.Config.AuditQueue.Synchronous,
+	}
+}
+
+func (process *TeleportProcess) auditQueueBackends() []auditqueue.Kind {
+	var backends []auditqueue.Kind
+	for _, backend := range process.Config.AuditQueue.Backends {
+		backends = append(backends, auditqueue.Kind(backend))
+	}
+	return backends
 }
 
 // ServerTLSConfig returns a new server-side [*tls.Config] that presents the


### PR DESCRIPTION
Changelog: On the Auth server, don't enqueue events that originate from agents.

This PR is the sixth in what will be multiple PRs that implement [RFD 254](https://github.com/gravitational/teleport.e/pull/8641)

This implements a part of the cloud considerations that require the Auth server does not `Enqueue` events that Agents originate, but it must `Enqueue` events that the Auth server originates.

## Previous PRs in this project:
1. https://github.com/gravitational/teleport/pull/66883 
2. https://github.com/gravitational/teleport/pull/67019
3. https://github.com/gravitational/teleport/pull/67095
4. https://github.com/gravitational/teleport/pull/67212
5. https://github.com/gravitational/teleport/pull/67638

## Features in this PR

This PR implements a subset of the RFD. The rest of the RFD will be implemented in future PRs. This PR implements the following feature set as described in the RFD:
- For Auth, only `Enqueue` events that originate from Auth *not* from Agents.

## Features that will be included in future PRs

Outstanding items that will be implemented in follow-up PR(s) include:
- tctl additions for audit queue observability.
- Protobuf changes.
- Encryption at rest (deferred to v19)
- Integration tests.
- Graceful shutdown drain.

## Manual Test Plan

TBD

### Test Environment

This has been tested on a Linux AMD64 machine.

### Test Cases

TBD

### Test Description

TBD
