### PR TITLE
[v18] Server Discovery: fix sudo->sudo-rs migration for ubuntu 25.10+ 

### DIFF
--- a/lib/srv/server/installer/defaultinstallers.go
+++ b/lib/srv/server/installer/defaultinstallers.go
@@ -39,7 +39,8 @@ curl -sSf "$INSTALL_SCRIPT_URL" -o "$TEMP_INSTALLER_SCRIPT"
 
 chmod +x "$TEMP_INSTALLER_SCRIPT"
 
-sudo -E "$TEMP_INSTALLER_SCRIPT" || (echo "The install script ($TEMP_INSTALLER_SCRIPT) returned a non-zero exit code" && exit 1)
+envs=$(awk 'BEGIN { for (name in ENVIRON) if (name ~ /^[A-Za-z_][A-Za-z0-9_]*$/) { list = list sep name; sep = "," } print list }')
+sudo --preserve-env="$envs" "$TEMP_INSTALLER_SCRIPT" || (echo "The install script ($TEMP_INSTALLER_SCRIPT) returned a non-zero exit code" && exit 1)
 rm "$TEMP_INSTALLER_SCRIPT"`
 )
 
@@ -67,7 +68,8 @@ set +x
 TELEPORT_BINARY=/usr/local/bin/teleport
 [ -z "${TELEPORT_INSTALL_SUFFIX:-}" ] || TELEPORT_BINARY=/opt/teleport/${TELEPORT_INSTALL_SUFFIX}/bin/teleport
 
-sudo -E "$TELEPORT_BINARY" ` + strings.Join(argsList, " ") + " $@"
+envs=$(awk 'BEGIN { for (name in ENVIRON) if (name ~ /^[A-Za-z_][A-Za-z0-9_]*$/) { list = list sep name; sep = "," } print list }')
+sudo --preserve-env="$envs" "$TELEPORT_BINARY" ` + strings.Join(argsList, " ") + " $@"
 
 	argsList = []string{
 		"install", "autodiscover-node",

--- a/lib/srv/server/installer/defaultinstallers_test.go
+++ b/lib/srv/server/installer/defaultinstallers_test.go
@@ -42,7 +42,8 @@ curl -sSf "$INSTALL_SCRIPT_URL" -o "$TEMP_INSTALLER_SCRIPT"
 
 chmod +x "$TEMP_INSTALLER_SCRIPT"
 
-sudo -E "$TEMP_INSTALLER_SCRIPT" || (echo "The install script ($TEMP_INSTALLER_SCRIPT) returned a non-zero exit code" && exit 1)
+envs=$(awk 'BEGIN { for (name in ENVIRON) if (name ~ /^[A-Za-z_][A-Za-z0-9_]*$/) { list = list sep name; sep = "," } print list }')
+sudo --preserve-env="$envs" "$TEMP_INSTALLER_SCRIPT" || (echo "The install script ($TEMP_INSTALLER_SCRIPT) returned a non-zero exit code" && exit 1)
 rm "$TEMP_INSTALLER_SCRIPT"
 
 
@@ -52,7 +53,8 @@ set +x
 TELEPORT_BINARY=/usr/local/bin/teleport
 [ -z "${TELEPORT_INSTALL_SUFFIX:-}" ] || TELEPORT_BINARY=/opt/teleport/${TELEPORT_INSTALL_SUFFIX}/bin/teleport
 
-sudo -E "$TELEPORT_BINARY" install autodiscover-node --public-proxy-addr=teleport.example.com:443 --teleport-package=teleport-ent --repo-channel=stable/cloud --auto-upgrade=true --azure-client-id= $@`
+envs=$(awk 'BEGIN { for (name in ENVIRON) if (name ~ /^[A-Za-z_][A-Za-z0-9_]*$/) { list = list sep name; sep = "," } print list }')
+sudo --preserve-env="$envs" "$TELEPORT_BINARY" install autodiscover-node --public-proxy-addr=teleport.example.com:443 --teleport-package=teleport-ent --repo-channel=stable/cloud --auto-upgrade=true --azure-client-id= $@`
 
 // TestNewDefaultInstaller is a minimal
 func TestNewDefaultInstaller(t *testing.T) {


### PR DESCRIPTION
Backport #67522 to v18

<!-- Provide a descriptive entry for the changelog of the next release. -->

Changelog: Fixed an issue in Server Discovery that would prevent suffixed installations in VMs using Ubuntu 25.10 or Ubuntu 26.04.


<!-- Include manual testing efforts to verify the change. -->
<!-- Detail where the tests where run and what configurations were used. -->
<!-- Include all the test cases which were run to validate the change. -->

## Manual Test Plan
### Test Environment

Local env with AWS EC2 instances

### Test Cases
- [x] Auto Discover in AWS w/ suffix installation using Ubuntu 26.04
- [x] Auto Discover in AWS w/ suffix installation using Ubuntu 24.04

```
> curl --silent https://proxy.example.com:443/v1/webapi/scripts/installer/default-installer | grep envs
envs=$(awk 'BEGIN { for (name in ENVIRON) if (name ~ /^[A-Za-z_][A-Za-z0-9_]*$/) { list = list sep name; sep = "," } print list }')
sudo --preserve-env="$envs" "$TEMP_INSTALLER_SCRIPT" || (echo "The install script ($TEMP_INSTALLER_SCRIPT) returned a non-zero exit code" && exit 1)
envs=$(awk 'BEGIN { for (name in ENVIRON) if (name ~ /^[A-Za-z_][A-Za-z0-9_]*$/) { list = list sep name; sep = "," } print list }')
sudo --preserve-env="$envs" "$TELEPORT_BINARY" install autodiscover-node --public-proxy-addr=proxy.example.com:443 --teleport-package=teleport --repo-channel=stable/v18 --auto-upgrade=false --azure-client-id= $@
```