### PR TITLE
Hook up desktop sessions to summarisation

### DIFF
--- a/api/types/summarizer/summarizer.go
+++ b/api/types/summarizer/summarizer.go
@@ -214,6 +214,7 @@ func ValidateInferencePolicy(p *summarizerv1.InferencePolicy) error {
 		string(types.SSHSessionKind),
 		string(types.KubernetesSessionKind),
 		string(types.DatabaseSessionKind),
+		string(types.WindowsDesktopSessionKind),
 	}
 	for _, kind := range kinds {
 		if !slices.Contains(supportedKinds, kind) {

--- a/api/types/summarizer/summarizer_test.go
+++ b/api/types/summarizer/summarizer_test.go
@@ -226,7 +226,7 @@ func TestValidateInferenceSecret(t *testing.T) {
 func TestValidateInferencePolicy(t *testing.T) {
 	t.Parallel()
 	valid := NewInferencePolicy("my-policy", &summarizerv1.InferencePolicySpec{
-		Kinds:  []string{"ssh", "k8s", "db"},
+		Kinds:  []string{"ssh", "k8s", "db", "desktop"},
 		Filter: `equals(resource.metadata.labels["env"], "prod") || equals(user.metadata.name, "admin")`,
 		Model:  "my-model",
 	})
@@ -273,7 +273,7 @@ func TestValidateInferencePolicy(t *testing.T) {
 		},
 		{
 			fn:  func(p *summarizerv1.InferencePolicy) { p.Spec.Kinds = []string{"foo"} },
-			msg: "unsupported kind in spec.kinds: foo, supported: ssh, k8s, db",
+			msg: "unsupported kind in spec.kinds: foo, supported: ssh, k8s, db, desktop",
 		},
 		{
 			fn:  func(p *summarizerv1.InferencePolicy) { p.Spec.Model = "" },

--- a/docs/pages/identity-security/session-summaries/session-summaries.mdx
+++ b/docs/pages/identity-security/session-summaries/session-summaries.mdx
@@ -413,11 +413,13 @@ summarize (Kubernetes, Database, SSH), give the policy a name, and click
      name: all-sessions
      description: Summarize all sessions
    spec:
-     # Session kinds affected by this policy. Allowed values: "ssh", "k8s", "db".
+     # Session kinds affected by this policy. Allowed values: "ssh", "k8s",
+     # "db", "desktop".
      kinds:
      - ssh
      - k8s
      - db
+     - desktop
      # Name of the pre-provisioned Teleport-managed inference model.
      model: teleport-cloud-default
    ```
@@ -432,11 +434,13 @@ summarize (Kubernetes, Database, SSH), give the policy a name, and click
      name: shell-sessions
      description: Summarize all sessions
    spec:
-     # Session kinds affected by this policy. Allowed values: "ssh", "k8s", "db".
+     # Session kinds affected by this policy. Allowed values: "ssh", "k8s",
+     # "db", "desktop".
      kinds:
      - ssh
      - k8s
      - db
+     - desktop
      # Name of the `inference_model` resource that will be used for summarizing
      # these sessions.
      model: shell-summary-model

--- a/lib/auth/recordingencryption/recordingencryptionv1/service_test.go
+++ b/lib/auth/recordingencryption/recordingencryptionv1/service_test.go
@@ -371,6 +371,11 @@ func (f *fakeSummarizer) SummarizeDatabase(ctx context.Context, sessionEndEvent 
 	return args.Error(0)
 }
 
+func (f *fakeSummarizer) SummarizeWindowsDesktop(ctx context.Context, sessionEndEvent *apievents.WindowsDesktopSessionEnd) error {
+	args := f.Called(ctx, sessionEndEvent)
+	return args.Error(0)
+}
+
 func (f *fakeSummarizer) SummarizeWithoutEndEvent(ctx context.Context, sessionID session.ID) error {
 	args := f.Called(ctx, sessionID)
 	return args.Error(0)

--- a/lib/auth/summarizer/provider.go
+++ b/lib/auth/summarizer/provider.go
@@ -91,6 +91,10 @@ func (n NoopSummarizer) SummarizeDatabase(ctx context.Context, sessionEndEvent *
 	return nil
 }
 
+func (n NoopSummarizer) SummarizeWindowsDesktop(ctx context.Context, sessionEndEvent *events.WindowsDesktopSessionEnd) error {
+	return nil
+}
+
 func (NoopSummarizer) SummarizeWithoutEndEvent(ctx context.Context, sessionID session.ID) error {
 	return nil
 }

--- a/lib/auth/summarizer/provider_test.go
+++ b/lib/auth/summarizer/provider_test.go
@@ -54,6 +54,10 @@ func (m dummySummarizer) SummarizeDatabase(ctx context.Context, sessionEndEvent 
 	return nil
 }
 
+func (m dummySummarizer) SummarizeWindowsDesktop(ctx context.Context, sessionEndEvent *events.WindowsDesktopSessionEnd) error {
+	return nil
+}
+
 func (m dummySummarizer) SummarizeWithoutEndEvent(ctx context.Context, sessionID session.ID) error {
 	return nil
 }

--- a/lib/auth/summarizer/summarizer.go
+++ b/lib/auth/summarizer/summarizer.go
@@ -32,10 +32,14 @@ type SessionSummarizer interface {
 	// SummarizeDatabase summarizes the database session recording associated
 	// with the provided [events.DatabaseSessionEnd] event.
 	SummarizeDatabase(ctx context.Context, sessionEndEvent *events.DatabaseSessionEnd) error
+	// SummarizeWindowsDesktop summarizes the Windows desktop session recording
+	// associated with the provided [events.WindowsDesktopSessionEnd] event.
+	SummarizeWindowsDesktop(ctx context.Context, sessionEndEvent *events.WindowsDesktopSessionEnd) error
 	// SummarizeWithoutEndEvent summarizes a session recording with a given ID.
 	// This is used for cases where the session ID is known, but there is no end
-	// event available. [SessionSummarizer.SummarizeSSH] and
-	// [SessionSummarizer.SummarizeDatabase] should be used instead of this
-	// method whenever possible, as they are more efficient.
+	// event available. [SessionSummarizer.SummarizeSSH],
+	// [SessionSummarizer.SummarizeDatabase], and
+	// [SessionSummarizer.SummarizeWindowsDesktop] should be used instead of
+	// this method whenever possible, as they are more efficient.
 	SummarizeWithoutEndEvent(ctx context.Context, sessionID session.ID) error
 }

--- a/lib/events/auditlog_test.go
+++ b/lib/events/auditlog_test.go
@@ -466,6 +466,11 @@ func (f *fakeSummarizer) SummarizeDatabase(ctx context.Context, sessionEndEvent 
 	return args.Error(0)
 }
 
+func (f *fakeSummarizer) SummarizeWindowsDesktop(ctx context.Context, sessionEndEvent *apievents.WindowsDesktopSessionEnd) error {
+	args := f.Called(ctx, sessionEndEvent)
+	return args.Error(0)
+}
+
 func (f *fakeSummarizer) SummarizeWithoutEndEvent(ctx context.Context, sessionID session.ID) error {
 	args := f.Called(ctx, sessionID)
 	return args.Error(0)

--- a/lib/events/complete.go
+++ b/lib/events/complete.go
@@ -382,6 +382,8 @@ func (u *UploadCompleter) ensureSessionEndEvent(ctx context.Context, uploadData 
 		err = summarizer.SummarizeSSH(ctx, o)
 	case *apievents.DatabaseSessionEnd:
 		err = summarizer.SummarizeDatabase(ctx, o)
+	case *apievents.WindowsDesktopSessionEnd:
+		err = summarizer.SummarizeWindowsDesktop(ctx, o)
 	}
 	if err != nil {
 		slog.WarnContext(ctx, "Failed to summarize upload", "error", err)

--- a/lib/events/sessionpostprocessing/postprocessing.go
+++ b/lib/events/sessionpostprocessing/postprocessing.go
@@ -76,6 +76,9 @@ func Process(ctx context.Context, cfg Config) error {
 			summarizerErr = trace.Wrap(err, "failed to summarize upload")
 		}
 	case *apievents.WindowsDesktopSessionEnd:
+		if err := summarizer.SummarizeWindowsDesktop(ctx, o); err != nil {
+			summarizerErr = trace.Wrap(err, "failed to summarize upload")
+		}
 		metadataSvc := cfg.RecordingMetadataProvider.Service()
 		if !o.EndTime.IsZero() && !o.StartTime.IsZero() {
 			duration := o.EndTime.Sub(o.StartTime)

--- a/lib/events/sessionpostprocessing/postprocessing_test.go
+++ b/lib/events/sessionpostprocessing/postprocessing_test.go
@@ -99,6 +99,13 @@ func TestSessionPostProcessor_Desktop(t *testing.T) {
 
 	summarizerProvider := summarizer.NewSessionSummarizerProvider()
 	sessionSummarizer := &fakeSummarizer{}
+	sessionSummarizer.On(
+		"SummarizeWindowsDesktop",
+		mock.Anything,
+		mock.MatchedBy(func(e *apievents.WindowsDesktopSessionEnd) bool {
+			return e.GetSessionID() == string(sessionID)
+		}),
+	).Return(nil).Once()
 	summarizerProvider.SetSummarizer(sessionSummarizer)
 
 	cfg := sessionpostprocessing.Config{
@@ -138,6 +145,11 @@ func (f *fakeSummarizer) SummarizeSSH(ctx context.Context, sessionEndEvent *apie
 }
 
 func (f *fakeSummarizer) SummarizeDatabase(ctx context.Context, sessionEndEvent *apievents.DatabaseSessionEnd) error {
+	args := f.Called(ctx, sessionEndEvent)
+	return args.Error(0)
+}
+
+func (f *fakeSummarizer) SummarizeWindowsDesktop(ctx context.Context, sessionEndEvent *apievents.WindowsDesktopSessionEnd) error {
 	args := f.Called(ctx, sessionEndEvent)
 	return args.Error(0)
 }

--- a/lib/events/stream.go
+++ b/lib/events/stream.go
@@ -597,9 +597,6 @@ type sliceWriter struct {
 	// by the recording metadata service (currently, this is true if the session
 	// is a SSH, k8s or desktop session).
 	shouldProcessMetadata bool
-	// shouldSkipSummarize is set to true for session types that should not
-	// be summarized (e.g. desktop sessions).
-	shouldSkipSummarize bool
 	// sshSessionEndEvent is an event that marked the end of this session if it was
 	// an SSH one. It may be nil if the stream hasn't ended yet, and it may also
 	// be nil if the stream picked up after an auth server start from a point
@@ -612,6 +609,12 @@ type sliceWriter struct {
 	// point where the session end event has already been uploaded. If captured,
 	// it will be passed to the summarizer.
 	dbSessionEndEvent *apievents.DatabaseSessionEnd
+	// desktopSessionEndEvent is an event that marked the end of this session if
+	// it was a Windows desktop one. It may be nil if the stream hasn't ended
+	// yet, and it may also be nil if the stream picked up after an auth server
+	// start from a point where the session end event has already been uploaded.
+	// If captured, it will be passed to the summarizer.
+	desktopSessionEndEvent *apievents.WindowsDesktopSessionEnd
 
 	// hasSessionEnd indicates if the session end event is present.
 	hasSessionEnd bool
@@ -729,11 +732,9 @@ func (w *sliceWriter) receiveAndUpload() error {
 				w.sessionStartTime = e.WindowsDesktopSessionStart.Time
 				w.sessionType = recordingmetadata.SessionTypeDesktop
 				w.shouldProcessMetadata = true
-				w.shouldSkipSummarize = true
 
 			case *apievents.OneOf_DesktopRecording:
 				w.sessionEndTime = e.DesktopRecording.Time
-				w.shouldSkipSummarize = true
 
 			case *apievents.OneOf_SessionPrint:
 				w.sessionEndTime = e.SessionPrint.Time
@@ -750,10 +751,10 @@ func (w *sliceWriter) receiveAndUpload() error {
 				w.dbSessionEndEvent = e.DatabaseSessionEnd
 				w.hasSessionEnd = true
 			case *apievents.OneOf_WindowsDesktopSessionEnd:
+				w.desktopSessionEndEvent = e.WindowsDesktopSessionEnd
 				w.sessionEndTime = e.WindowsDesktopSessionEnd.Time
 				w.hasSessionEnd = true
 				w.shouldProcessMetadata = true
-				w.shouldSkipSummarize = true
 				w.sessionType = recordingmetadata.SessionTypeDesktop
 				if w.sessionStartTime.IsZero() {
 					w.sessionStartTime = e.WindowsDesktopSessionEnd.StartTime
@@ -904,8 +905,8 @@ func (w *sliceWriter) completeStream() {
 			case *apievents.DatabaseSessionEnd:
 				w.dbSessionEndEvent = o
 			case *apievents.WindowsDesktopSessionEnd:
+				w.desktopSessionEndEvent = o
 				w.shouldProcessMetadata = true
-				w.shouldSkipSummarize = true
 				w.sessionType = recordingmetadata.SessionTypeDesktop
 				if w.sessionStartTime.IsZero() {
 					w.sessionStartTime = o.StartTime
@@ -930,20 +931,20 @@ func (w *sliceWriter) completeStream() {
 			}
 		}
 
-		if !w.shouldSkipSummarize {
-			summarizer := w.proto.cfg.SessionSummarizerProvider.SessionSummarizer()
-			switch {
-			case w.sshSessionEndEvent != nil:
-				err = summarizer.SummarizeSSH(w.proto.cancelCtx, w.sshSessionEndEvent)
-			case w.dbSessionEndEvent != nil:
-				err = summarizer.SummarizeDatabase(w.proto.cancelCtx, w.dbSessionEndEvent)
-			default:
-				err = summarizer.SummarizeWithoutEndEvent(w.proto.cancelCtx, w.proto.cfg.Upload.SessionID)
-			}
-			if err != nil {
-				slog.WarnContext(w.proto.cancelCtx, "Failed to summarize upload", "error", err)
-				return
-			}
+		summarizer := w.proto.cfg.SessionSummarizerProvider.SessionSummarizer()
+		switch {
+		case w.sshSessionEndEvent != nil:
+			err = summarizer.SummarizeSSH(w.proto.cancelCtx, w.sshSessionEndEvent)
+		case w.dbSessionEndEvent != nil:
+			err = summarizer.SummarizeDatabase(w.proto.cancelCtx, w.dbSessionEndEvent)
+		case w.desktopSessionEndEvent != nil:
+			err = summarizer.SummarizeWindowsDesktop(w.proto.cancelCtx, w.desktopSessionEndEvent)
+		default:
+			err = summarizer.SummarizeWithoutEndEvent(w.proto.cancelCtx, w.proto.cfg.Upload.SessionID)
+		}
+		if err != nil {
+			slog.WarnContext(w.proto.cancelCtx, "Failed to summarize upload", "error", err)
+			return
 		}
 	}
 }

--- a/lib/events/stream_test.go
+++ b/lib/events/stream_test.go
@@ -683,6 +683,11 @@ func (m *MockSummarizer) SummarizeDatabase(ctx context.Context, sessionEndEvent 
 	return args.Error(0)
 }
 
+func (m *MockSummarizer) SummarizeWindowsDesktop(ctx context.Context, sessionEndEvent *apievents.WindowsDesktopSessionEnd) error {
+	args := m.Called(ctx, sessionEndEvent)
+	return args.Error(0)
+}
+
 func (m *MockSummarizer) SummarizeWithoutEndEvent(ctx context.Context, sessionID session.ID) error {
 	args := m.Called(ctx, sessionID)
 	return args.Error(0)
@@ -754,6 +759,74 @@ func TestOnUploadComplete_MissingSessionEnd(t *testing.T) {
 	mockSummarizer.AssertExpectations(t)
 }
 
+// TestOnUploadComplete_MissingWindowsDesktopSessionEnd verifies that when a
+// desktop session stream is completed without a session end event, the end
+// event recovered by the OnUploadComplete callback is passed to
+// SummarizeWindowsDesktop.
+func TestOnUploadComplete_MissingWindowsDesktopSessionEnd(t *testing.T) {
+	uploader := eventstest.NewMemoryUploader()
+	summarizerProvider := &summarizer.SessionSummarizerProvider{}
+	mockSummarizer := &MockSummarizer{}
+	summarizerProvider.SetSummarizer(mockSummarizer)
+
+	sid := session.NewID()
+
+	startTime := time.Date(2024, 1, 15, 10, 0, 0, 0, time.UTC)
+	endTime := startTime.Add(15 * time.Minute)
+
+	// Build the session end that OnUploadComplete will return.
+	recoveredEnd := &apievents.WindowsDesktopSessionEnd{
+		Metadata: apievents.Metadata{
+			Type: events.WindowsDesktopSessionEndEvent,
+			Code: events.DesktopSessionEndCode,
+			Time: endTime,
+		},
+		SessionMetadata: apievents.SessionMetadata{SessionID: sid.String()},
+		StartTime:       startTime,
+		EndTime:         endTime,
+	}
+
+	called := false
+	streamer, err := events.NewProtoStreamer(events.ProtoStreamerConfig{
+		Uploader:                  uploader,
+		SessionSummarizerProvider: summarizerProvider,
+	})
+	require.NoError(t, err)
+	streamer.SetOnUploadComplete(func(_ context.Context, gotSID session.ID) (apievents.AuditEvent, error) {
+		called = true
+		require.Equal(t, sid, gotSID)
+		return recoveredEnd, nil
+	})
+
+	mockSummarizer.On("SummarizeWindowsDesktop", mock.Anything, mock.MatchedBy(func(e *apievents.WindowsDesktopSessionEnd) bool {
+		return e.GetSessionID() == sid.String()
+	})).Return(nil).Once()
+
+	stream, err := streamer.CreateAuditStream(t.Context(), sid)
+	require.NoError(t, err)
+
+	preparer, err := events.NewPreparer(events.PreparerConfig{
+		SessionID:   sid,
+		Namespace:   apidefaults.Namespace,
+		ClusterName: "cluster",
+	})
+	require.NoError(t, err)
+
+	// Emit a desktop recording frame but deliberately omit the session end.
+	rec := &apievents.DesktopRecording{
+		Metadata: apievents.Metadata{Type: events.DesktopRecordingEvent, Time: startTime.Add(5 * time.Minute)},
+	}
+	prepared, err := preparer.PrepareSessionEvent(rec)
+	require.NoError(t, err)
+	require.NoError(t, stream.RecordEvent(t.Context(), prepared))
+
+	require.NoError(t, stream.Complete(t.Context()))
+
+	require.True(t, called, "OnUploadComplete must be called when session end is missing")
+	mockSummarizer.AssertNotCalled(t, "SummarizeWithoutEndEvent", mock.Anything, mock.Anything)
+	mockSummarizer.AssertExpectations(t)
+}
+
 // MockRecordingMetadataService is a mock implementation of recordingmetadata.Service.
 type MockRecordingMetadataService struct {
 	mock.Mock
@@ -769,7 +842,8 @@ func (m *MockRecordingMetadataService) ProcessSessionRecording(ctx context.Conte
 // observe DesktopRecording followed by an in-band WindowsDesktopSessionEnd.
 // In this case OnUploadComplete is not invoked (hasSessionEnd is true), so
 // the in-band end branch must populate the desktop session metadata flags
-// itself, and SummarizeWithoutEndEvent must not be called.
+// itself and pass the captured end event to SummarizeWindowsDesktop rather
+// than falling back to SummarizeWithoutEndEvent.
 func TestInBandWindowsDesktopSessionEnd(t *testing.T) {
 	startTime := time.Date(2024, 1, 15, 10, 0, 0, 0, time.UTC)
 	endTime := startTime.Add(15 * time.Minute)
@@ -792,11 +866,9 @@ func TestInBandWindowsDesktopSessionEnd(t *testing.T) {
 
 	sid := session.NewID()
 
-	// Fail loudly if SummarizeWithoutEndEvent (or any summarize call) is
-	// invoked. shouldSkipSummarize must be set on the in-band desktop events.
-	mockSummarizer.AssertNotCalled(t, "SummarizeWithoutEndEvent", mock.Anything, mock.Anything)
-	mockSummarizer.AssertNotCalled(t, "SummarizeSSH", mock.Anything, mock.Anything)
-	mockSummarizer.AssertNotCalled(t, "SummarizeDatabase", mock.Anything, mock.Anything)
+	mockSummarizer.On("SummarizeWindowsDesktop", mock.Anything, mock.MatchedBy(func(e *apievents.WindowsDesktopSessionEnd) bool {
+		return e.GetSessionID() == sid.String()
+	})).Return(nil).Once()
 
 	mockMetadata.
 		On("ProcessSessionRecording", mock.Anything, sid, recordingmetadata.SessionTypeDesktop, startTime, endTime.Sub(startTime)).
@@ -832,6 +904,11 @@ func TestInBandWindowsDesktopSessionEnd(t *testing.T) {
 
 	require.NoError(t, stream.Complete(t.Context()))
 
+	// The captured end event must be used directly; the fallback lookup and
+	// the summarizers for other session kinds must not be involved.
+	mockSummarizer.AssertNotCalled(t, "SummarizeWithoutEndEvent", mock.Anything, mock.Anything)
+	mockSummarizer.AssertNotCalled(t, "SummarizeSSH", mock.Anything, mock.Anything)
+	mockSummarizer.AssertNotCalled(t, "SummarizeDatabase", mock.Anything, mock.Anything)
 	mockMetadata.AssertExpectations(t)
 	mockSummarizer.AssertExpectations(t)
 }

--- a/lib/services/summarizer.go
+++ b/lib/services/summarizer.go
@@ -171,6 +171,7 @@ func (ctx *InferencePolicyMatchingContext) GetIdentifier(fields []string) (any, 
 		// returned.
 		for _, dummyResource := range []types.Resource{
 			&types.ServerV2{}, &types.KubernetesClusterV3{}, &types.DatabaseV3{},
+			&types.WindowsDesktopV3{},
 		} {
 			zeroVal, err := predicate.GetFieldByTag(dummyResource, teleport.JSON, fields[1:])
 			if err == nil {
@@ -187,7 +188,7 @@ func (ctx *InferencePolicyMatchingContext) GetIdentifier(fields []string) (any, 
 		// First, try to fetch field value from the session in the context.
 		var session events.AuditEvent = &events.SessionEnd{}
 		switch ctx.Session.(type) {
-		case *events.SessionEnd, *events.DatabaseSessionEnd:
+		case *events.SessionEnd, *events.DatabaseSessionEnd, *events.WindowsDesktopSessionEnd:
 			session = ctx.Session
 		}
 		val, origErr := predicate.GetFieldByTag(session, teleport.JSON, fields[1:])

--- a/lib/services/summarizer_test.go
+++ b/lib/services/summarizer_test.go
@@ -53,12 +53,23 @@ func TestInferencePolicyMatchingContext(t *testing.T) {
 	)
 	require.NoError(t, err)
 
+	desktop, err := types.NewWindowsDesktopV3(
+		"desktop-1", nil,
+		types.WindowsDesktopSpecV3{Addr: "10.0.0.1:3389", Domain: "example.com"},
+	)
+	require.NoError(t, err)
+
 	kubeSessionEnd := &events.SessionEnd{
 		KubernetesPodMetadata: events.KubernetesPodMetadata{KubernetesPodName: "pod-1"},
 	}
 
 	dbSessionEnd := &events.DatabaseSessionEnd{
 		DatabaseMetadata: events.DatabaseMetadata{DatabaseProtocol: types.DatabaseProtocolPostgreSQL},
+	}
+
+	desktopSessionEnd := &events.WindowsDesktopSessionEnd{
+		Metadata:    events.Metadata{ClusterName: "cluster-1"},
+		DesktopName: "desktop-1",
 	}
 
 	cases := []struct {
@@ -119,6 +130,18 @@ func TestInferencePolicyMatchingContext(t *testing.T) {
 			notFound:   true,
 		},
 		{
+			name:       "known desktop field",
+			resource:   desktop,
+			expression: "resource.spec.domain",
+			expected:   "example.com",
+		},
+		{
+			name:       "unknown desktop field",
+			resource:   desktop,
+			expression: "resource.spec.unknown",
+			notFound:   true,
+		},
+		{
 			name:       "known shell session field",
 			session:    kubeSessionEnd,
 			expression: "session.kubernetes_pod_name",
@@ -139,6 +162,24 @@ func TestInferencePolicyMatchingContext(t *testing.T) {
 		{
 			name:       "unknown database session field",
 			session:    dbSessionEnd,
+			expression: "session.unknown",
+			notFound:   true,
+		},
+		{
+			name:       "known desktop session field",
+			session:    desktopSessionEnd,
+			expression: "session.desktop_name",
+			expected:   "desktop-1",
+		},
+		{
+			name:       "desktop session field shared with shell sessions",
+			session:    desktopSessionEnd,
+			expression: "session.cluster_name",
+			expected:   "cluster-1",
+		},
+		{
+			name:       "unknown desktop session field",
+			session:    desktopSessionEnd,
 			expression: "session.unknown",
 			notFound:   true,
 		},
@@ -211,7 +252,7 @@ func TestInferencePolicyMatchingContext_MixedTypeBooleanExpressions(t *testing.T
 func TestValidateInferencePolicy(t *testing.T) {
 	t.Parallel()
 
-	allKinds := []string{"ssh", "k8s", "db"}
+	allKinds := []string{"ssh", "k8s", "db", "desktop"}
 
 	cases := []struct {
 		name         string
@@ -224,8 +265,10 @@ func TestValidateInferencePolicy(t *testing.T) {
 		{name: "valid server filter", kinds: allKinds, filter: `equals(resource.spec.hostname, "node1")`},
 		{name: "valid db filter", kinds: allKinds, filter: `equals(resource.spec.protocol, "postgres")`},
 		{name: "valid kube filter", kinds: allKinds, filter: `resource.metadata.labels["env"] == "prod"`},
+		{name: "valid desktop filter", kinds: allKinds, filter: `equals(resource.spec.domain, "example.com")`},
 		{name: "valid shell session filter", kinds: allKinds, filter: `contains(session.participants, "joe")`},
 		{name: "valid db session filter", kinds: allKinds, filter: `session.db_protocol == "postgres"`},
+		{name: "valid desktop session filter", kinds: allKinds, filter: `session.desktop_name == "desktop-1"`},
 
 		{
 			name:         "invalid kinds",


### PR DESCRIPTION
This does the final wiring of desktop sessions through to the session summariser.

Manual test plan is in https://github.com/gravitational/teleport.e/pull/8678