### PR TITLE
[v17] Add missing `type` modifier to `ResourceIconName` import

### DIFF
--- a/web/packages/design/src/ResourceIcon/index.tsx
+++ b/web/packages/design/src/ResourceIcon/index.tsx
@@ -24,7 +24,7 @@ import { IconProps } from 'design/Icon/Icon';
 
 import {
   iconNames,
-  ResourceIconName,
+  type ResourceIconName,
   resourceIconSpecs,
 } from './resourceIconSpecs';
 


### PR DESCRIPTION
Backport #67554 to branch/v17