### PR TITLE
Make use of new 'share_id' connection parameter in the Windows desktop client

### DIFF
--- a/api/gen/proto/go/teleport/desktop/v1/tdpb_protohybrid.pb.go
+++ b/api/gen/proto/go/teleport/desktop/v1/tdpb_protohybrid.pb.go
@@ -904,6 +904,7 @@ type ConnectionActivated struct {
 	UserChannelId uint32                 `protobuf:"varint,2,opt,name=user_channel_id,json=userChannelId,proto3" json:"user_channel_id,omitempty"`
 	ScreenWidth   uint32                 `protobuf:"varint,3,opt,name=screen_width,json=screenWidth,proto3" json:"screen_width,omitempty"`
 	ScreenHeight  uint32                 `protobuf:"varint,4,opt,name=screen_height,json=screenHeight,proto3" json:"screen_height,omitempty"`
+	ShareId       uint32                 `protobuf:"varint,5,opt,name=share_id,json=shareId,proto3" json:"share_id,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -961,6 +962,13 @@ func (x *ConnectionActivated) GetScreenHeight() uint32 {
 	return 0
 }
 
+func (x *ConnectionActivated) GetShareId() uint32 {
+	if x != nil {
+		return x.ShareId
+	}
+	return 0
+}
+
 func (x *ConnectionActivated) SetIoChannelId(v uint32) {
 	x.IoChannelId = v
 }
@@ -977,6 +985,10 @@ func (x *ConnectionActivated) SetScreenHeight(v uint32) {
 	x.ScreenHeight = v
 }
 
+func (x *ConnectionActivated) SetShareId(v uint32) {
+	x.ShareId = v
+}
+
 type ConnectionActivated_builder struct {
 	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
 
@@ -984,6 +996,7 @@ type ConnectionActivated_builder struct {
 	UserChannelId uint32
 	ScreenWidth   uint32
 	ScreenHeight  uint32
+	ShareId       uint32
 }
 
 func (b0 ConnectionActivated_builder) Build() *ConnectionActivated {
@@ -994,6 +1007,7 @@ func (b0 ConnectionActivated_builder) Build() *ConnectionActivated {
 	x.UserChannelId = b.UserChannelId
 	x.ScreenWidth = b.ScreenWidth
 	x.ScreenHeight = b.ScreenHeight
+	x.ShareId = b.ShareId
 	return m0
 }
 
@@ -5862,12 +5876,13 @@ const file_teleport_desktop_v1_tdpb_proto_rawDesc = "" +
 	"\vFastPathPDU\x12\x10\n" +
 	"\x03pdu\x18\x01 \x01(\fR\x03pdu\",\n" +
 	"\x0eRDPResponsePDU\x12\x1a\n" +
-	"\bresponse\x18\x01 \x01(\fR\bresponse\"\xa9\x01\n" +
+	"\bresponse\x18\x01 \x01(\fR\bresponse\"\xc4\x01\n" +
 	"\x13ConnectionActivated\x12\"\n" +
 	"\rio_channel_id\x18\x01 \x01(\rR\vioChannelId\x12&\n" +
 	"\x0fuser_channel_id\x18\x02 \x01(\rR\ruserChannelId\x12!\n" +
 	"\fscreen_width\x18\x03 \x01(\rR\vscreenWidth\x12#\n" +
-	"\rscreen_height\x18\x04 \x01(\rR\fscreenHeight\"\xb0\x01\n" +
+	"\rscreen_height\x18\x04 \x01(\rR\fscreenHeight\x12\x19\n" +
+	"\bshare_id\x18\x05 \x01(\rR\ashareId\"\xb0\x01\n" +
 	"\bSyncKeys\x12.\n" +
 	"\x13scroll_lock_pressed\x18\x01 \x01(\bR\x11scrollLockPressed\x12$\n" +
 	"\x0enum_lock_state\x18\x02 \x01(\bR\fnumLockState\x12&\n" +

--- a/api/gen/proto/go/teleport/desktop/v1/tdpb_protoopaque.pb.go
+++ b/api/gen/proto/go/teleport/desktop/v1/tdpb_protoopaque.pb.go
@@ -906,6 +906,7 @@ type ConnectionActivated struct {
 	xxx_hidden_UserChannelId uint32                 `protobuf:"varint,2,opt,name=user_channel_id,json=userChannelId,proto3"`
 	xxx_hidden_ScreenWidth   uint32                 `protobuf:"varint,3,opt,name=screen_width,json=screenWidth,proto3"`
 	xxx_hidden_ScreenHeight  uint32                 `protobuf:"varint,4,opt,name=screen_height,json=screenHeight,proto3"`
+	xxx_hidden_ShareId       uint32                 `protobuf:"varint,5,opt,name=share_id,json=shareId,proto3"`
 	unknownFields            protoimpl.UnknownFields
 	sizeCache                protoimpl.SizeCache
 }
@@ -963,6 +964,13 @@ func (x *ConnectionActivated) GetScreenHeight() uint32 {
 	return 0
 }
 
+func (x *ConnectionActivated) GetShareId() uint32 {
+	if x != nil {
+		return x.xxx_hidden_ShareId
+	}
+	return 0
+}
+
 func (x *ConnectionActivated) SetIoChannelId(v uint32) {
 	x.xxx_hidden_IoChannelId = v
 }
@@ -979,6 +987,10 @@ func (x *ConnectionActivated) SetScreenHeight(v uint32) {
 	x.xxx_hidden_ScreenHeight = v
 }
 
+func (x *ConnectionActivated) SetShareId(v uint32) {
+	x.xxx_hidden_ShareId = v
+}
+
 type ConnectionActivated_builder struct {
 	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
 
@@ -986,6 +998,7 @@ type ConnectionActivated_builder struct {
 	UserChannelId uint32
 	ScreenWidth   uint32
 	ScreenHeight  uint32
+	ShareId       uint32
 }
 
 func (b0 ConnectionActivated_builder) Build() *ConnectionActivated {
@@ -996,6 +1009,7 @@ func (b0 ConnectionActivated_builder) Build() *ConnectionActivated {
 	x.xxx_hidden_UserChannelId = b.UserChannelId
 	x.xxx_hidden_ScreenWidth = b.ScreenWidth
 	x.xxx_hidden_ScreenHeight = b.ScreenHeight
+	x.xxx_hidden_ShareId = b.ShareId
 	return m0
 }
 
@@ -5768,12 +5782,13 @@ const file_teleport_desktop_v1_tdpb_proto_rawDesc = "" +
 	"\vFastPathPDU\x12\x10\n" +
 	"\x03pdu\x18\x01 \x01(\fR\x03pdu\",\n" +
 	"\x0eRDPResponsePDU\x12\x1a\n" +
-	"\bresponse\x18\x01 \x01(\fR\bresponse\"\xa9\x01\n" +
+	"\bresponse\x18\x01 \x01(\fR\bresponse\"\xc4\x01\n" +
 	"\x13ConnectionActivated\x12\"\n" +
 	"\rio_channel_id\x18\x01 \x01(\rR\vioChannelId\x12&\n" +
 	"\x0fuser_channel_id\x18\x02 \x01(\rR\ruserChannelId\x12!\n" +
 	"\fscreen_width\x18\x03 \x01(\rR\vscreenWidth\x12#\n" +
-	"\rscreen_height\x18\x04 \x01(\rR\fscreenHeight\"\xb0\x01\n" +
+	"\rscreen_height\x18\x04 \x01(\rR\fscreenHeight\x12\x19\n" +
+	"\bshare_id\x18\x05 \x01(\rR\ashareId\"\xb0\x01\n" +
 	"\bSyncKeys\x12.\n" +
 	"\x13scroll_lock_pressed\x18\x01 \x01(\bR\x11scrollLockPressed\x12$\n" +
 	"\x0enum_lock_state\x18\x02 \x01(\bR\fnumLockState\x12&\n" +

--- a/api/proto/teleport/desktop/v1/tdpb.proto
+++ b/api/proto/teleport/desktop/v1/tdpb.proto
@@ -80,6 +80,7 @@ message ConnectionActivated {
   uint32 user_channel_id = 2;
   uint32 screen_width = 3;
   uint32 screen_height = 4;
+  uint32 share_id = 5;
 }
 
 // Conveys the current state of keyboard buttons with persistent state.

--- a/gen/proto/ts/teleport/desktop/v1/tdpb_pb.ts
+++ b/gen/proto/ts/teleport/desktop/v1/tdpb_pb.ts
@@ -185,6 +185,10 @@ export interface ConnectionActivated {
      * @generated from protobuf field: uint32 screen_height = 4;
      */
     screenHeight: number;
+    /**
+     * @generated from protobuf field: uint32 share_id = 5;
+     */
+    shareId: number;
 }
 /**
  * Conveys the current state of keyboard buttons with persistent state.
@@ -1559,7 +1563,8 @@ class ConnectionActivated$Type extends MessageType<ConnectionActivated> {
             { no: 1, name: "io_channel_id", kind: "scalar", T: 13 /*ScalarType.UINT32*/ },
             { no: 2, name: "user_channel_id", kind: "scalar", T: 13 /*ScalarType.UINT32*/ },
             { no: 3, name: "screen_width", kind: "scalar", T: 13 /*ScalarType.UINT32*/ },
-            { no: 4, name: "screen_height", kind: "scalar", T: 13 /*ScalarType.UINT32*/ }
+            { no: 4, name: "screen_height", kind: "scalar", T: 13 /*ScalarType.UINT32*/ },
+            { no: 5, name: "share_id", kind: "scalar", T: 13 /*ScalarType.UINT32*/ }
         ]);
     }
     create(value?: PartialMessage<ConnectionActivated>): ConnectionActivated {
@@ -1568,6 +1573,7 @@ class ConnectionActivated$Type extends MessageType<ConnectionActivated> {
         message.userChannelId = 0;
         message.screenWidth = 0;
         message.screenHeight = 0;
+        message.shareId = 0;
         if (value !== undefined)
             reflectionMergePartial<ConnectionActivated>(this, message, value);
         return message;
@@ -1588,6 +1594,9 @@ class ConnectionActivated$Type extends MessageType<ConnectionActivated> {
                     break;
                 case /* uint32 screen_height */ 4:
                     message.screenHeight = reader.uint32();
+                    break;
+                case /* uint32 share_id */ 5:
+                    message.shareId = reader.uint32();
                     break;
                 default:
                     let u = options.readUnknownField;
@@ -1613,6 +1622,9 @@ class ConnectionActivated$Type extends MessageType<ConnectionActivated> {
         /* uint32 screen_height = 4; */
         if (message.screenHeight !== 0)
             writer.tag(4, WireType.Varint).uint32(message.screenHeight);
+        /* uint32 share_id = 5; */
+        if (message.shareId !== 0)
+            writer.tag(5, WireType.Varint).uint32(message.shareId);
         let u = options.writeUnknownFields;
         if (u !== false)
             (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);

--- a/lib/srv/desktop/rdp/rdpclient/client.go
+++ b/lib/srv/desktop/rdp/rdpclient/client.go
@@ -1071,7 +1071,7 @@ func cgo_handle_rdp_connection_activated(
 }
 
 func (c *Client) handleRDPConnectionActivated(ioChannelID, userChannelID, screenWidth, screenHeight C.uint16_t, shareID C.uint32_t) C.CGOErrCode {
-	c.cfg.Logger.DebugContext(context.Background(), "Received RDP channel IDs", "io_channel_id", ioChannelID, "user_channel_id", userChannelID)
+	c.cfg.Logger.DebugContext(context.Background(), "Received RDP channel IDs", "io_channel_id", ioChannelID, "user_channel_id", userChannelID, "share_id", shareID)
 
 	// Note: RDP doesn't always use the resolution we asked for.
 	// This is especially true when we request dimensions that are not a multiple of 4.

--- a/lib/srv/desktop/rdp/rdpclient/client.go
+++ b/lib/srv/desktop/rdp/rdpclient/client.go
@@ -1061,15 +1061,16 @@ func cgo_handle_rdp_connection_activated(
 	user_channel_id C.uint16_t,
 	screen_width C.uint16_t,
 	screen_height C.uint16_t,
+	share_id C.uint32_t,
 ) C.CGOErrCode {
 	client, err := toClient(handle)
 	if err != nil {
 		return C.ErrCodeFailure
 	}
-	return client.handleRDPConnectionActivated(io_channel_id, user_channel_id, screen_width, screen_height)
+	return client.handleRDPConnectionActivated(io_channel_id, user_channel_id, screen_width, screen_height, share_id)
 }
 
-func (c *Client) handleRDPConnectionActivated(ioChannelID, userChannelID, screenWidth, screenHeight C.uint16_t) C.CGOErrCode {
+func (c *Client) handleRDPConnectionActivated(ioChannelID, userChannelID, screenWidth, screenHeight C.uint16_t, shareID C.uint32_t) C.CGOErrCode {
 	c.cfg.Logger.DebugContext(context.Background(), "Received RDP channel IDs", "io_channel_id", ioChannelID, "user_channel_id", userChannelID)
 
 	// Note: RDP doesn't always use the resolution we asked for.
@@ -1082,6 +1083,7 @@ func (c *Client) handleRDPConnectionActivated(ioChannelID, userChannelID, screen
 			UserChannelId: uint32(userChannelID),
 			ScreenWidth:   uint32(screenWidth),
 			ScreenHeight:  uint32(screenHeight),
+			ShareId:       uint32(shareID),
 		},
 		ClipboardEnabled:               true,
 		DirectoryRemoveSupported:       false,

--- a/lib/srv/desktop/rdp/rdpclient/src/client.rs
+++ b/lib/srv/desktop/rdp/rdpclient/src/client.rs
@@ -256,6 +256,7 @@ impl Client {
             connection_result.io_channel_id,
             connection_result.user_channel_id,
             connection_result.desktop_size,
+            connection_result.share_id,
         )
         .await?;
 
@@ -400,6 +401,7 @@ impl Client {
                                         io_channel_id,
                                         user_channel_id,
                                         desktop_size,
+                                        share_id,
                                         ..
                                     } = sequence.connection_activation_state()
                                     {
@@ -411,6 +413,7 @@ impl Client {
                                             io_channel_id,
                                             user_channel_id,
                                             desktop_size,
+                                            share_id,
                                         )
                                         .await?;
                                         break;
@@ -562,6 +565,7 @@ impl Client {
         io_channel_id: u16,
         user_channel_id: u16,
         desktop_size: DesktopSize,
+        share_id: u32,
     ) -> ClientResult<()> {
         task::spawn_blocking(move || unsafe {
             ClientResult::from(cgo_handle_rdp_connection_activated(
@@ -570,6 +574,7 @@ impl Client {
                 user_channel_id,
                 desktop_size.width,
                 desktop_size.height,
+                share_id,
             ))
         })
         .await?

--- a/lib/srv/desktop/rdp/rdpclient/src/lib.rs
+++ b/lib/srv/desktop/rdp/rdpclient/src/lib.rs
@@ -796,6 +796,7 @@ extern "C" {
         user_channel_id: u16,
         screen_width: u16,
         screen_height: u16,
+        share_id: u32,
     ) -> CGOErrCode;
     fn cgo_tdp_sd_acknowledge(
         cgo_handle: CgoHandle,

--- a/web/packages/shared/components/DesktopSession/DesktopSession.test.tsx
+++ b/web/packages/shared/components/DesktopSession/DesktopSession.test.tsx
@@ -94,6 +94,7 @@ function encodeServerHello(canRemoveDirectory: boolean): ArrayBuffer {
             userChannelId: 2,
             screenHeight: 100,
             screenWidth: 100,
+            shareId: 1,
           },
           clipboardEnabled: true,
           directoryRemoveSupported: canRemoveDirectory,

--- a/web/packages/shared/libs/ironrdp/src/lib.rs
+++ b/web/packages/shared/libs/ironrdp/src/lib.rs
@@ -116,20 +116,22 @@ pub struct FastPathProcessor {
 #[wasm_bindgen]
 impl FastPathProcessor {
     #[wasm_bindgen(constructor)]
-    pub fn new(width: u16, height: u16, io_channel_id: u16, user_channel_id: u16) -> Self {
+    pub fn new(
+        width: u16,
+        height: u16,
+        io_channel_id: u16,
+        user_channel_id: u16,
+        share_id: u32,
+    ) -> Self {
         Self {
             fast_path_processor: IronRdpFastPathProcessorBuilder {
                 io_channel_id,
                 user_channel_id,
+                share_id,
                 // These should be set to the same values as they're set to in the
                 // `Config` object in lib/srv/desktop/rdp/rdpclient/src/client.rs.
                 enable_server_pointer: true,
                 pointer_software_rendering: false,
-                // TODO (rhammonds): Update our ServerHello TDPB message to
-                // report the share_id so that we can set it here. This may
-                // fix a known resize bug.
-                // https://github.com/Devolutions/IronRDP/pull/1147
-                share_id: 0,
                 bulk_decompressor: None,
             }
             .build(),

--- a/web/packages/shared/libs/tdp/client.ts
+++ b/web/packages/shared/libs/tdp/client.ts
@@ -396,6 +396,7 @@ export class TdpClient extends EventEmitter<EventMap> {
   private initFastPathProcessor(
     ioChannelId: number,
     userChannelId: number,
+    shareId: number,
     spec: ClientScreenSpec
   ) {
     this.logger.info(
@@ -406,7 +407,8 @@ export class TdpClient extends EventEmitter<EventMap> {
       spec.width,
       spec.height,
       ioChannelId,
-      userChannelId
+      userChannelId,
+      shareId
     );
   }
 
@@ -584,7 +586,8 @@ export class TdpClient extends EventEmitter<EventMap> {
   }
 
   handleRdpConnectionActivated(activated: RdpConnectionActivated) {
-    const { ioChannelId, userChannelId, screenWidth, screenHeight } = activated;
+    const { ioChannelId, userChannelId, screenWidth, screenHeight, shareId } =
+      activated;
     // Scale is not relevant for the server's response; use 100 (1x) as default.
     const spec: ClientScreenSpec = {
       width: screenWidth,
@@ -595,7 +598,7 @@ export class TdpClient extends EventEmitter<EventMap> {
       `screen spec received from server ${spec.width} x ${spec.height}`
     );
 
-    this.initFastPathProcessor(ioChannelId, userChannelId, {
+    this.initFastPathProcessor(ioChannelId, userChannelId, shareId, {
       width: screenWidth,
       height: screenHeight,
       scale: 100,

--- a/web/packages/shared/libs/tdp/codec.ts
+++ b/web/packages/shared/libs/tdp/codec.ts
@@ -148,6 +148,8 @@ export type RdpConnectionActivated = {
   userChannelId: number;
   screenWidth: number;
   screenHeight: number;
+  // TDPB exclusive field
+  shareId: number;
 };
 
 export enum Severity {
@@ -1887,7 +1889,14 @@ export class TdpCodec implements Codec {
     const screenHeight = dv.getUint16(offset);
     offset += UINT_16_LEN;
 
-    return { ioChannelId, userChannelId, screenWidth, screenHeight };
+    // shareId is not supported by legacy TDP. Hardcode to zero.
+    return {
+      ioChannelId,
+      userChannelId,
+      screenWidth,
+      screenHeight,
+      shareId: 0,
+    };
   }
 
   // | message type (12) | err_code error | directory_id uint32 |


### PR DESCRIPTION
A recent upgrade of IronRDP (#66162) introduced a [potential fix](https://github.com/Devolutions/IronRDP/pull/1147) for a known [resize bug](https://github.com/Devolutions/IronRDP/issues/447) that has plagued us for some time. The `share_id` is assigned to us by the server during connection setup, and is used to initialize the `FastPathProcessor` so that its outbound data PDUs contain the correct value in the `ShareID` field. Since our client has a "split" architecture where the `FastPathProcessor` lives in the browser, this value needs to be plumbed through TDP for proper initialization.


<!-- Provide a descriptive entry for the changelog of the next release. -->

Changelog: Fix potential performance degradation in Windows desktop connections after resizing the client window.


<!-- Include manual testing efforts to verify the change. -->
<!-- Detail where the tests where run and what configurations were used. -->
<!-- Include all the test cases which were run to validate the change. -->

## Manual Test Plan

### Test Environment
Local test cluster with both AD and non-AD desktop resources.
### Test Cases
- AD
  - [x] Initial connection succeeds.
  - [x] Resizing the window a handful of times does not caused performance degradation or unexpected visual artifacts.
- non-AD
  - [x] Initial connection succeeds.
  - [x] Resizing the window a handful of times does not caused performance degradation or unexpected  visual artifacts.
