### PR TITLE
Capture inactivity periods when processing desktop sessions

### DIFF
--- a/lib/auth/recordingmetadata/recordingmetadatav1/desktopprocessor.go
+++ b/lib/auth/recordingmetadata/recordingmetadatav1/desktopprocessor.go
@@ -31,14 +31,20 @@ import (
 
 type desktopProcessor struct {
 	baseRecordingProcessor
+	gen               *desktopThumbnailGenerator
 	thumbnailInterval time.Duration
+
+	lastCursorX, lastCursorY uint16
+	cursorInitialized        bool
 }
 
 func newDesktopProcessor(base baseRecordingProcessor, duration time.Duration) *desktopProcessor {
-	base.thumbnailGenerator = newDesktopThumbnailGenerator()
+	gen := newDesktopThumbnailGenerator()
+	base.thumbnailGenerator = gen
 
 	return &desktopProcessor{
 		baseRecordingProcessor: base,
+		gen:                    gen,
 		thumbnailInterval:      calculateThumbnailInterval(duration, maxThumbnails, desktopMinThumbnailInterval),
 	}
 }
@@ -62,6 +68,7 @@ func (d *desktopProcessor) handleEvent(evt apievents.AuditEvent) error {
 
 func (d *desktopProcessor) handleWindowsDesktopSessionStart(evt *apievents.WindowsDesktopSessionStart) error {
 	d.startTime = evt.GetTime()
+	d.lastActivityTime = evt.GetTime()
 
 	d.metadata.SetClusterName(evt.ClusterName)
 	d.metadata.SetUser(evt.User)
@@ -76,9 +83,41 @@ func (d *desktopProcessor) handleDesktopRecording(evt *apievents.DesktopRecordin
 		return trace.Wrap(err)
 	}
 
+	d.trackActivity(evt.GetTime())
 	d.captureThumbnailIfNeeded(evt.GetTime(), d.thumbnailInterval)
 
 	return nil
+}
+
+// trackActivity classifies the frame just handled as activity or incidental noise and, when it is activity,
+// closes out any preceding inactivity gap and advances lastActivityTime.
+func (d *desktopProcessor) trackActivity(eventTime time.Time) {
+	fa := d.gen.consumeFrameActivity()
+	if fa.screenW == 0 || fa.screenH == 0 {
+		// Decoder not initialized yet (or disabled in nop builds): we can't measure activity, so skip.
+		return
+	}
+
+	cursorMoved := d.cursorInitialized && (fa.cursorX != d.lastCursorX || fa.cursorY != d.lastCursorY)
+	d.lastCursorX, d.lastCursorY = fa.cursorX, fa.cursorY
+	d.cursorInitialized = true
+
+	if fa.changedPixels < desktopActivityMinPixels(fa.screenW, fa.screenH) && !cursorMoved {
+		// Incidental change (clock tick, blinking caret) with a static cursor — not activity.
+		return
+	}
+
+	if !d.lastActivityTime.IsZero() && eventTime.Sub(d.lastActivityTime) > inactivityThreshold {
+		d.addInactivityEvent(d.lastActivityTime, eventTime)
+	}
+	d.lastActivityTime = eventTime
+}
+
+// desktopActivityMinPixels is the minimum changed-pixel area for a frame to count as activity on a screen of
+// the given size, derived from desktopActivityAreaFraction. Clamped to at least 1px so tiny screens still have
+// a positive threshold.
+func desktopActivityMinPixels(screenW, screenH uint16) int {
+	return max(1, int(float64(int(screenW)*int(screenH))*desktopActivityAreaFraction))
 }
 
 func (d *desktopProcessor) handleWindowsDesktopSessionEnd(evt *apievents.WindowsDesktopSessionEnd) error {
@@ -87,6 +126,10 @@ func (d *desktopProcessor) handleWindowsDesktopSessionEnd(evt *apievents.Windows
 		d.metadata.SetUser(evt.User)
 		d.metadata.SetResourceName(evt.DesktopName)
 		d.metadata.SetType(pb.SessionRecordingType_SESSION_RECORDING_TYPE_WINDOWS_DESKTOP)
+	}
+
+	if !d.lastActivityTime.IsZero() && evt.GetTime().Sub(d.lastActivityTime) > inactivityThreshold {
+		d.addInactivityEvent(d.lastActivityTime, evt.GetTime())
 	}
 
 	d.captureThumbnailIfNeeded(evt.GetTime(), d.thumbnailInterval)

--- a/lib/auth/recordingmetadata/recordingmetadatav1/desktopprocessor.go
+++ b/lib/auth/recordingmetadata/recordingmetadatav1/desktopprocessor.go
@@ -19,6 +19,7 @@
 package recordingmetadatav1
 
 import (
+	"image"
 	"time"
 
 	"github.com/gravitational/trace"
@@ -36,6 +37,12 @@ type desktopProcessor struct {
 
 	lastCursorX, lastCursorY uint16
 	cursorInitialized        bool
+
+	// activityFootprint holds the distinct regions changed since the last activity; distinctActivityFrames
+	// counts the frames that added a new one. A clock or caret repaints one spot so its count stays low;
+	// typing keeps moving to new spots. Both reset when a frame counts as activity.
+	activityFootprint      []image.Rectangle
+	distinctActivityFrames int
 }
 
 func newDesktopProcessor(base baseRecordingProcessor, duration time.Duration) *desktopProcessor {
@@ -101,8 +108,22 @@ func (d *desktopProcessor) trackActivity(eventTime time.Time) {
 	d.lastCursorX, d.lastCursorY = fa.cursorX, fa.cursorY
 	d.cursorInitialized = true
 
-	if fa.changedPixels < desktopActivityMinPixels(fa.screenW, fa.screenH) && !cursorMoved {
-		// Incidental change (clock tick, blinking caret) with a static cursor — not activity.
+	frameAddedLocation := false
+	for _, r := range fa.regions {
+		if !overlapsAny(d.activityFootprint, r) {
+			d.activityFootprint = append(d.activityFootprint, r)
+			frameAddedLocation = true
+		}
+	}
+	if frameAddedLocation {
+		d.distinctActivityFrames++
+	}
+
+	bigRepaint := fa.changedPixels >= desktopActivityMinPixels(fa.screenW, fa.screenH)
+	spreadAcrossScreen := d.distinctActivityFrames >= desktopActivityMinLocations
+
+	if !cursorMoved && !bigRepaint && !spreadAcrossScreen {
+		// Incidental change (clock tick, blinking caret) confined to a static spot, not activity.
 		return
 	}
 
@@ -110,6 +131,19 @@ func (d *desktopProcessor) trackActivity(eventTime time.Time) {
 		d.addInactivityEvent(d.lastActivityTime, eventTime)
 	}
 	d.lastActivityTime = eventTime
+	d.activityFootprint = d.activityFootprint[:0]
+	d.distinctActivityFrames = 0
+}
+
+// overlapsAny reports whether r intersects any region in the footprint. Edge-adjacent repaints (e.g.
+// consecutive glyphs while typing) don't intersect, so they count as new places.
+func overlapsAny(footprint []image.Rectangle, r image.Rectangle) bool {
+	for _, existing := range footprint {
+		if existing.Overlaps(r) {
+			return true
+		}
+	}
+	return false
 }
 
 // desktopActivityMinPixels is the minimum changed-pixel area for a frame to count as activity on a screen of

--- a/lib/auth/recordingmetadata/recordingmetadatav1/desktopprocessor.go
+++ b/lib/auth/recordingmetadata/recordingmetadatav1/desktopprocessor.go
@@ -38,11 +38,12 @@ type desktopProcessor struct {
 	lastCursorX, lastCursorY uint16
 	cursorInitialized        bool
 
-	// activityFootprint holds the distinct regions changed since the last activity; distinctActivityFrames
-	// counts the frames that added a new one. A clock or caret repaints one spot so its count stays low;
-	// typing keeps moving to new spots. Both reset when a frame counts as activity.
-	activityFootprint      []image.Rectangle
-	distinctActivityFrames int
+	// The current run of repaints landing in new places, used to tell typing (new places, frame after
+	// frame) from a clock or caret (one place repainted over and over).
+	activityFootprint  []image.Rectangle
+	activityFrames     int       // frames that changed a place not already in activityFootprint
+	activityStartedAt  time.Time // first such frame in the run
+	activityLastSeenAt time.Time // most recent such frame
 }
 
 func newDesktopProcessor(base baseRecordingProcessor, duration time.Duration) *desktopProcessor {
@@ -108,31 +109,54 @@ func (d *desktopProcessor) trackActivity(eventTime time.Time) {
 	d.lastCursorX, d.lastCursorY = fa.cursorX, fa.cursorY
 	d.cursorInitialized = true
 
-	frameAddedLocation := false
+	// Abandon a stale run so a later typing burst dates from its own first repaint, not earlier
+	// incidental noise like a clock tick.
+	if !d.activityLastSeenAt.IsZero() && eventTime.Sub(d.activityLastSeenAt) > inactivityThreshold {
+		d.resetActivityRun()
+	}
+
+	addedLocation := false
 	for _, r := range fa.regions {
 		if !overlapsAny(d.activityFootprint, r) {
 			d.activityFootprint = append(d.activityFootprint, r)
-			frameAddedLocation = true
+			addedLocation = true
 		}
 	}
-	if frameAddedLocation {
-		d.distinctActivityFrames++
+	if addedLocation {
+		if d.activityStartedAt.IsZero() {
+			d.activityStartedAt = eventTime
+		}
+		d.activityLastSeenAt = eventTime
+		d.activityFrames++
 	}
 
 	bigRepaint := fa.changedPixels >= desktopActivityMinPixels(fa.screenW, fa.screenH)
-	spreadAcrossScreen := d.distinctActivityFrames >= desktopActivityMinLocations
+	typing := d.activityFrames >= desktopActivityMinLocations
 
-	if !cursorMoved && !bigRepaint && !spreadAcrossScreen {
+	if !cursorMoved && !bigRepaint && !typing {
 		// Incidental change (clock tick, blinking caret) confined to a static spot, not activity.
 		return
 	}
 
-	if !d.lastActivityTime.IsZero() && eventTime.Sub(d.lastActivityTime) > inactivityThreshold {
-		d.addInactivityEvent(d.lastActivityTime, eventTime)
+	// Date typing from its first repaint, not the keystroke that crossed the threshold, so the inactive
+	// span ends when the user resumed.
+	activityTime := eventTime
+	if typing {
+		activityTime = d.activityStartedAt
+	}
+
+	if !d.lastActivityTime.IsZero() && activityTime.Sub(d.lastActivityTime) > inactivityThreshold {
+		d.addInactivityEvent(d.lastActivityTime, activityTime)
 	}
 	d.lastActivityTime = eventTime
+	d.resetActivityRun()
+}
+
+func (d *desktopProcessor) resetActivityRun() {
 	d.activityFootprint = d.activityFootprint[:0]
-	d.distinctActivityFrames = 0
+	d.activityFrames = 0
+	d.activityStartedAt = time.Time{}
+	d.activityLastSeenAt = time.Time{}
 }
 
 // overlapsAny reports whether r intersects any region in the footprint. Edge-adjacent repaints (e.g.

--- a/lib/auth/recordingmetadata/recordingmetadatav1/desktopprocessor.go
+++ b/lib/auth/recordingmetadata/recordingmetadatav1/desktopprocessor.go
@@ -94,7 +94,6 @@ func (d *desktopProcessor) handleDesktopRecording(evt *apievents.DesktopRecordin
 func (d *desktopProcessor) trackActivity(eventTime time.Time) {
 	fa := d.gen.consumeFrameActivity()
 	if fa.screenW == 0 || fa.screenH == 0 {
-		// Decoder not initialized yet (or disabled in nop builds): we can't measure activity, so skip.
 		return
 	}
 

--- a/lib/auth/recordingmetadata/recordingmetadatav1/desktopprocessor.go
+++ b/lib/auth/recordingmetadata/recordingmetadatav1/desktopprocessor.go
@@ -133,7 +133,7 @@ func (d *desktopProcessor) trackActivity(eventTime time.Time) {
 	bigRepaint := fa.changedPixels >= desktopActivityMinPixels(fa.screenW, fa.screenH)
 	typing := d.activityFrames >= desktopActivityMinLocations
 
-	if !cursorMoved && !bigRepaint && !typing {
+	if !cursorMoved && !fa.mouseButton && !bigRepaint && !typing {
 		// Incidental change (clock tick, blinking caret) confined to a static spot, not activity.
 		return
 	}

--- a/lib/auth/recordingmetadata/recordingmetadatav1/desktopprocessor.go
+++ b/lib/auth/recordingmetadata/recordingmetadatav1/desktopprocessor.go
@@ -185,7 +185,9 @@ func (d *desktopProcessor) handleWindowsDesktopSessionEnd(evt *apievents.Windows
 		d.metadata.SetType(pb.SessionRecordingType_SESSION_RECORDING_TYPE_WINDOWS_DESKTOP)
 	}
 
-	if !d.lastActivityTime.IsZero() && evt.GetTime().Sub(d.lastActivityTime) > inactivityThreshold {
+	// Without the decoder, lastActivityTime never advances past the session start, so this would mark the whole
+	// recording inactive even when the user was active.
+	if d.gen.decoderAvailable() && !d.lastActivityTime.IsZero() && evt.GetTime().Sub(d.lastActivityTime) > inactivityThreshold {
 		d.addInactivityEvent(d.lastActivityTime, evt.GetTime())
 	}
 

--- a/lib/auth/recordingmetadata/recordingmetadatav1/desktopprocessor_test.go
+++ b/lib/auth/recordingmetadata/recordingmetadatav1/desktopprocessor_test.go
@@ -216,6 +216,125 @@ func desktopRecoveredSessionEndEvent(sessionStart, eventTime time.Time) *apieven
 	}
 }
 
+// inactivityEvents returns just the inactivity events from the metadata, in order.
+func inactivityEvents(metadata *pb.SessionRecordingMetadata) []*pb.SessionRecordingEvent {
+	var out []*pb.SessionRecordingEvent
+	for _, e := range metadata.Events {
+		if e.GetInactivity() != nil {
+			out = append(out, e)
+		}
+	}
+	return out
+}
+
+// desktopMouseMoveEvent builds a DesktopRecording carrying a cursor move to (x, y) at eventTime. A mouse move
+// repositions the cursor without painting the framebuffer, so it produces no changed-region area.
+func desktopMouseMoveEvent(t *testing.T, eventTime time.Time, x, y uint32) *apievents.DesktopRecording {
+	t.Helper()
+
+	evt, err := rdpstatetest.LegacyMouseMove(x, y)
+	require.NoError(t, err)
+
+	evt.Metadata.Time = eventTime
+
+	return evt
+}
+
+func TestDesktopRecordingProcessor_InactivityEvents(t *testing.T) {
+	startTime := time.Now()
+
+	// bigFrame paints a 64x64 region (~4096px), far above the 256x256 activity threshold (~65px).
+	bigFrame := func(at time.Time, color uint16) *apievents.DesktopRecording {
+		return desktopFastPathEvent(t, at, rdpstatetest.BuildBitmapPDU(0, 0, 64, 64, color))
+	}
+	// smallFrame paints a 2x2 region (~4px), far below the threshold — clock/caret-scale noise.
+	smallFrame := func(at time.Time) *apievents.DesktopRecording {
+		return desktopFastPathEvent(t, at, rdpstatetest.BuildBitmapPDU(0, 0, 2, 2, rdpstatetest.RGB565Red))
+	}
+
+	type offsets struct{ start, end time.Duration }
+
+	tests := []struct {
+		name     string
+		events   []apievents.AuditEvent
+		expected []offsets
+	}{
+		{
+			name: "idle gap between activity frames produces one inactivity event",
+			events: []apievents.AuditEvent{
+				desktopSessionStartEvent(startTime),
+				desktopServerHelloEvent(t, startTime.Add(100*time.Millisecond), 256, 256),
+				bigFrame(startTime.Add(1*time.Second), rdpstatetest.RGB565White),
+				bigFrame(startTime.Add(15*time.Second), rdpstatetest.RGB565Red),
+				desktopSessionEndEvent(startTime.Add(16 * time.Second)),
+			},
+			expected: []offsets{{start: 1 * time.Second, end: 15 * time.Second}},
+		},
+		{
+			name: "incidental small changes do not interrupt inactivity",
+			events: []apievents.AuditEvent{
+				desktopSessionStartEvent(startTime),
+				desktopServerHelloEvent(t, startTime.Add(100*time.Millisecond), 256, 256),
+				bigFrame(startTime.Add(1*time.Second), rdpstatetest.RGB565White),
+				smallFrame(startTime.Add(5 * time.Second)),
+				smallFrame(startTime.Add(9 * time.Second)),
+				smallFrame(startTime.Add(13 * time.Second)),
+				desktopSessionEndEvent(startTime.Add(20 * time.Second)),
+			},
+			expected: []offsets{{start: 1 * time.Second, end: 20 * time.Second}},
+		},
+		{
+			name: "consecutive activity frames produce no inactivity events",
+			events: []apievents.AuditEvent{
+				desktopSessionStartEvent(startTime),
+				desktopServerHelloEvent(t, startTime.Add(100*time.Millisecond), 256, 256),
+				bigFrame(startTime.Add(1*time.Second), rdpstatetest.RGB565White),
+				bigFrame(startTime.Add(5*time.Second), rdpstatetest.RGB565Red),
+				bigFrame(startTime.Add(8*time.Second), rdpstatetest.RGB565White),
+				desktopSessionEndEvent(startTime.Add(9 * time.Second)),
+			},
+			expected: nil,
+		},
+		{
+			name: "cursor movement counts as activity; a no-op move does not",
+			events: []apievents.AuditEvent{
+				desktopSessionStartEvent(startTime),
+				desktopServerHelloEvent(t, startTime.Add(100*time.Millisecond), 256, 256),
+				bigFrame(startTime.Add(1*time.Second), rdpstatetest.RGB565White),
+				desktopMouseMoveEvent(t, startTime.Add(15*time.Second), 100, 100),
+				desktopMouseMoveEvent(t, startTime.Add(30*time.Second), 100, 100),
+				desktopSessionEndEvent(startTime.Add(40 * time.Second)),
+			},
+			expected: []offsets{
+				{start: 1 * time.Second, end: 15 * time.Second},
+				{start: 15 * time.Second, end: 40 * time.Second},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			lastEventTime := tt.events[len(tt.events)-1].GetTime()
+			processor := newTestDesktopProcessor(startTime, lastEventTime.Sub(startTime))
+			defer processor.release()
+
+			for _, evt := range tt.events {
+				require.NoError(t, processor.handleEvent(evt))
+			}
+
+			metadata, _ := processor.collect()
+			require.NotNil(t, metadata)
+
+			got := inactivityEvents(metadata)
+			require.Len(t, got, len(tt.expected))
+			for i, want := range tt.expected {
+				require.Equal(t, want.start, got[i].StartOffset.AsDuration(), "event %d start", i)
+				require.Equal(t, want.end, got[i].EndOffset.AsDuration(), "event %d end", i)
+			}
+		})
+	}
+}
+
 func TestDesktopThumbnailGenerator_ConsumeFrameActivity(t *testing.T) {
 	startTime := time.Now()
 

--- a/lib/auth/recordingmetadata/recordingmetadatav1/desktopprocessor_test.go
+++ b/lib/auth/recordingmetadata/recordingmetadatav1/desktopprocessor_test.go
@@ -291,6 +291,39 @@ func TestDesktopRecordingProcessor_InactivityEvents(t *testing.T) {
 			},
 			expected: []offsets{{start: 1 * time.Second, end: 14 * time.Second}},
 		},
+		{
+			// Typing resumes after a long idle. The inactive span must end when the user resumed (20s),
+			// not a few keystrokes later when the run crosses the threshold.
+			name: "typing after idle ends the inactive span at the first repaint",
+			events: []apievents.AuditEvent{
+				desktopSessionStartEvent(startTime),
+				desktopServerHelloEvent(t, startTime.Add(100*time.Millisecond), 256, 256),
+				bigFrame(startTime.Add(1*time.Second), rdpstatetest.RGB565White),
+				typingFrame(startTime.Add(20*time.Second), 0),
+				typingFrame(startTime.Add(22*time.Second), 4),
+				typingFrame(startTime.Add(24*time.Second), 8),
+				typingFrame(startTime.Add(26*time.Second), 12),
+				desktopSessionEndEvent(startTime.Add(30 * time.Second)),
+			},
+			expected: []offsets{{start: 1 * time.Second, end: 20 * time.Second}},
+		},
+		{
+			// A clock ticks once early in a long idle, then typing resumes much later. The stale tick must
+			// not be folded into the run, or the span would end at the tick (3s) not at the typing (20s).
+			name: "clock tick during idle does not shorten a later typing run's inactive span",
+			events: []apievents.AuditEvent{
+				desktopSessionStartEvent(startTime),
+				desktopServerHelloEvent(t, startTime.Add(100*time.Millisecond), 256, 256),
+				bigFrame(startTime.Add(1*time.Second), rdpstatetest.RGB565White),
+				smallFrame(startTime.Add(3 * time.Second)),
+				typingFrame(startTime.Add(20*time.Second), 10),
+				typingFrame(startTime.Add(21*time.Second), 14),
+				typingFrame(startTime.Add(22*time.Second), 18),
+				typingFrame(startTime.Add(23*time.Second), 22),
+				desktopSessionEndEvent(startTime.Add(30 * time.Second)),
+			},
+			expected: []offsets{{start: 1 * time.Second, end: 20 * time.Second}},
+		},
 	}
 
 	for _, tt := range tests {

--- a/lib/auth/recordingmetadata/recordingmetadatav1/desktopprocessor_test.go
+++ b/lib/auth/recordingmetadata/recordingmetadatav1/desktopprocessor_test.go
@@ -158,6 +158,139 @@ func TestDesktopRecordingProcessor_ThumbnailsWrittenToWriter(t *testing.T) {
 	require.NotEmpty(t, buf.Bytes(), "thumbnails should have been written to the writer")
 }
 
+
+func TestDesktopRecordingProcessor_InactivityEvents(t *testing.T) {
+	startTime := time.Now()
+
+	// bigFrame paints a 64x64 region (~4096px), far above the 256x256 activity threshold (~65px).
+	bigFrame := func(at time.Time, color uint16) *apievents.DesktopRecording {
+		return desktopFastPathEvent(t, at, rdpstatetest.BuildBitmapPDU(0, 0, 64, 64, color))
+	}
+	// smallFrame paints a 2x2 region (~4px), far below the threshold — clock/caret-scale noise.
+	smallFrame := func(at time.Time) *apievents.DesktopRecording {
+		return desktopFastPathEvent(t, at, rdpstatetest.BuildBitmapPDU(0, 0, 2, 2, rdpstatetest.RGB565Red))
+	}
+
+	type offsets struct{ start, end time.Duration }
+
+	tests := []struct {
+		name     string
+		events   []apievents.AuditEvent
+		expected []offsets
+	}{
+		{
+			name: "idle gap between activity frames produces one inactivity event",
+			events: []apievents.AuditEvent{
+				desktopSessionStartEvent(startTime),
+				desktopServerHelloEvent(t, startTime.Add(100*time.Millisecond), 256, 256),
+				bigFrame(startTime.Add(1*time.Second), rdpstatetest.RGB565White),
+				bigFrame(startTime.Add(15*time.Second), rdpstatetest.RGB565Red),
+				desktopSessionEndEvent(startTime.Add(16 * time.Second)),
+			},
+			expected: []offsets{{start: 1 * time.Second, end: 15 * time.Second}},
+		},
+		{
+			name: "incidental small changes do not interrupt inactivity",
+			events: []apievents.AuditEvent{
+				desktopSessionStartEvent(startTime),
+				desktopServerHelloEvent(t, startTime.Add(100*time.Millisecond), 256, 256),
+				bigFrame(startTime.Add(1*time.Second), rdpstatetest.RGB565White),
+				smallFrame(startTime.Add(5 * time.Second)),
+				smallFrame(startTime.Add(9 * time.Second)),
+				smallFrame(startTime.Add(13 * time.Second)),
+				desktopSessionEndEvent(startTime.Add(20 * time.Second)),
+			},
+			expected: []offsets{{start: 1 * time.Second, end: 20 * time.Second}},
+		},
+		{
+			name: "consecutive activity frames produce no inactivity events",
+			events: []apievents.AuditEvent{
+				desktopSessionStartEvent(startTime),
+				desktopServerHelloEvent(t, startTime.Add(100*time.Millisecond), 256, 256),
+				bigFrame(startTime.Add(1*time.Second), rdpstatetest.RGB565White),
+				bigFrame(startTime.Add(5*time.Second), rdpstatetest.RGB565Red),
+				bigFrame(startTime.Add(8*time.Second), rdpstatetest.RGB565White),
+				desktopSessionEndEvent(startTime.Add(9 * time.Second)),
+			},
+			expected: nil,
+		},
+		{
+			name: "cursor movement counts as activity; a no-op move does not",
+			events: []apievents.AuditEvent{
+				desktopSessionStartEvent(startTime),
+				desktopServerHelloEvent(t, startTime.Add(100*time.Millisecond), 256, 256),
+				bigFrame(startTime.Add(1*time.Second), rdpstatetest.RGB565White),
+				desktopMouseMoveEvent(t, startTime.Add(15*time.Second), 100, 100),
+				desktopMouseMoveEvent(t, startTime.Add(30*time.Second), 100, 100),
+				desktopSessionEndEvent(startTime.Add(40 * time.Second)),
+			},
+			expected: []offsets{
+				{start: 1 * time.Second, end: 15 * time.Second},
+				{start: 15 * time.Second, end: 40 * time.Second},
+			},
+		},
+		{
+			name: "session with no activity is fully inactive",
+			events: []apievents.AuditEvent{
+				desktopSessionStartEvent(startTime),
+				desktopServerHelloEvent(t, startTime.Add(100*time.Millisecond), 256, 256),
+				smallFrame(startTime.Add(5 * time.Second)),
+				smallFrame(startTime.Add(11 * time.Second)),
+				desktopSessionEndEvent(startTime.Add(20 * time.Second)),
+			},
+			expected: []offsets{{start: 0, end: 20 * time.Second}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			lastEventTime := tt.events[len(tt.events)-1].GetTime()
+			processor := newTestDesktopProcessor(startTime, lastEventTime.Sub(startTime))
+			defer processor.release()
+
+			for _, evt := range tt.events {
+				require.NoError(t, processor.handleEvent(evt))
+			}
+
+			metadata, _ := processor.collect()
+			require.NotNil(t, metadata)
+
+			got := inactivityEvents(metadata)
+			require.Len(t, got, len(tt.expected))
+			for i, want := range tt.expected {
+				require.Equal(t, want.start, got[i].StartOffset.AsDuration(), "event %d start", i)
+				require.Equal(t, want.end, got[i].EndOffset.AsDuration(), "event %d end", i)
+			}
+		})
+	}
+}
+
+func TestDesktopThumbnailGenerator_ConsumeFrameActivity(t *testing.T) {
+	startTime := time.Now()
+
+	gen := newDesktopThumbnailGenerator()
+	defer gen.release()
+
+	// ServerHello initializes the decoder: dimensions are set, nothing has changed yet.
+	require.NoError(t, gen.handleEvent(desktopServerHelloEvent(t, startTime, 256, 256)))
+
+	fa := gen.consumeFrameActivity()
+	require.Equal(t, uint16(256), fa.screenW)
+	require.Equal(t, uint16(256), fa.screenH)
+	require.Zero(t, fa.changedPixels)
+
+	// A 32x32 bitmap update marks a changed region well above zero.
+	require.NoError(t, gen.handleEvent(desktopFastPathEvent(t, startTime.Add(time.Second),
+		rdpstatetest.BuildBitmapPDU(0, 0, 32, 32, rdpstatetest.RGB565White))))
+
+	fa = gen.consumeFrameActivity()
+	require.Positive(t, fa.changedPixels)
+
+	// consumeFrameActivity reset the accumulator, so a subsequent call with no new frame reports zero.
+	fa = gen.consumeFrameActivity()
+	require.Zero(t, fa.changedPixels)
+}
+
 func newTestDesktopProcessor(startTime time.Time, duration time.Duration) recordingProcessor {
 	return newRecordingProcessor(&nopCloser{io.Discard}, slog.Default(), recordingmetadata.SessionTypeDesktop, startTime, duration)
 }
@@ -238,125 +371,4 @@ func desktopMouseMoveEvent(t *testing.T, eventTime time.Time, x, y uint32) *apie
 	evt.Metadata.Time = eventTime
 
 	return evt
-}
-
-func TestDesktopRecordingProcessor_InactivityEvents(t *testing.T) {
-	startTime := time.Now()
-
-	// bigFrame paints a 64x64 region (~4096px), far above the 256x256 activity threshold (~65px).
-	bigFrame := func(at time.Time, color uint16) *apievents.DesktopRecording {
-		return desktopFastPathEvent(t, at, rdpstatetest.BuildBitmapPDU(0, 0, 64, 64, color))
-	}
-	// smallFrame paints a 2x2 region (~4px), far below the threshold — clock/caret-scale noise.
-	smallFrame := func(at time.Time) *apievents.DesktopRecording {
-		return desktopFastPathEvent(t, at, rdpstatetest.BuildBitmapPDU(0, 0, 2, 2, rdpstatetest.RGB565Red))
-	}
-
-	type offsets struct{ start, end time.Duration }
-
-	tests := []struct {
-		name     string
-		events   []apievents.AuditEvent
-		expected []offsets
-	}{
-		{
-			name: "idle gap between activity frames produces one inactivity event",
-			events: []apievents.AuditEvent{
-				desktopSessionStartEvent(startTime),
-				desktopServerHelloEvent(t, startTime.Add(100*time.Millisecond), 256, 256),
-				bigFrame(startTime.Add(1*time.Second), rdpstatetest.RGB565White),
-				bigFrame(startTime.Add(15*time.Second), rdpstatetest.RGB565Red),
-				desktopSessionEndEvent(startTime.Add(16 * time.Second)),
-			},
-			expected: []offsets{{start: 1 * time.Second, end: 15 * time.Second}},
-		},
-		{
-			name: "incidental small changes do not interrupt inactivity",
-			events: []apievents.AuditEvent{
-				desktopSessionStartEvent(startTime),
-				desktopServerHelloEvent(t, startTime.Add(100*time.Millisecond), 256, 256),
-				bigFrame(startTime.Add(1*time.Second), rdpstatetest.RGB565White),
-				smallFrame(startTime.Add(5 * time.Second)),
-				smallFrame(startTime.Add(9 * time.Second)),
-				smallFrame(startTime.Add(13 * time.Second)),
-				desktopSessionEndEvent(startTime.Add(20 * time.Second)),
-			},
-			expected: []offsets{{start: 1 * time.Second, end: 20 * time.Second}},
-		},
-		{
-			name: "consecutive activity frames produce no inactivity events",
-			events: []apievents.AuditEvent{
-				desktopSessionStartEvent(startTime),
-				desktopServerHelloEvent(t, startTime.Add(100*time.Millisecond), 256, 256),
-				bigFrame(startTime.Add(1*time.Second), rdpstatetest.RGB565White),
-				bigFrame(startTime.Add(5*time.Second), rdpstatetest.RGB565Red),
-				bigFrame(startTime.Add(8*time.Second), rdpstatetest.RGB565White),
-				desktopSessionEndEvent(startTime.Add(9 * time.Second)),
-			},
-			expected: nil,
-		},
-		{
-			name: "cursor movement counts as activity; a no-op move does not",
-			events: []apievents.AuditEvent{
-				desktopSessionStartEvent(startTime),
-				desktopServerHelloEvent(t, startTime.Add(100*time.Millisecond), 256, 256),
-				bigFrame(startTime.Add(1*time.Second), rdpstatetest.RGB565White),
-				desktopMouseMoveEvent(t, startTime.Add(15*time.Second), 100, 100),
-				desktopMouseMoveEvent(t, startTime.Add(30*time.Second), 100, 100),
-				desktopSessionEndEvent(startTime.Add(40 * time.Second)),
-			},
-			expected: []offsets{
-				{start: 1 * time.Second, end: 15 * time.Second},
-				{start: 15 * time.Second, end: 40 * time.Second},
-			},
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			lastEventTime := tt.events[len(tt.events)-1].GetTime()
-			processor := newTestDesktopProcessor(startTime, lastEventTime.Sub(startTime))
-			defer processor.release()
-
-			for _, evt := range tt.events {
-				require.NoError(t, processor.handleEvent(evt))
-			}
-
-			metadata, _ := processor.collect()
-			require.NotNil(t, metadata)
-
-			got := inactivityEvents(metadata)
-			require.Len(t, got, len(tt.expected))
-			for i, want := range tt.expected {
-				require.Equal(t, want.start, got[i].StartOffset.AsDuration(), "event %d start", i)
-				require.Equal(t, want.end, got[i].EndOffset.AsDuration(), "event %d end", i)
-			}
-		})
-	}
-}
-
-func TestDesktopThumbnailGenerator_ConsumeFrameActivity(t *testing.T) {
-	startTime := time.Now()
-
-	gen := newDesktopThumbnailGenerator()
-	defer gen.release()
-
-	// ServerHello initializes the decoder: dimensions are set, nothing has changed yet.
-	require.NoError(t, gen.handleEvent(desktopServerHelloEvent(t, startTime, 256, 256)))
-
-	fa := gen.consumeFrameActivity()
-	require.Equal(t, uint16(256), fa.screenW)
-	require.Equal(t, uint16(256), fa.screenH)
-	require.Zero(t, fa.changedPixels)
-
-	// A 32x32 bitmap update marks a changed region well above zero.
-	require.NoError(t, gen.handleEvent(desktopFastPathEvent(t, startTime.Add(time.Second),
-		rdpstatetest.BuildBitmapPDU(0, 0, 32, 32, rdpstatetest.RGB565White))))
-
-	fa = gen.consumeFrameActivity()
-	require.Positive(t, fa.changedPixels)
-
-	// consumeFrameActivity reset the accumulator, so a subsequent call with no new frame reports zero.
-	fa = gen.consumeFrameActivity()
-	require.Zero(t, fa.changedPixels)
 }

--- a/lib/auth/recordingmetadata/recordingmetadatav1/desktopprocessor_test.go
+++ b/lib/auth/recordingmetadata/recordingmetadatav1/desktopprocessor_test.go
@@ -158,7 +158,6 @@ func TestDesktopRecordingProcessor_ThumbnailsWrittenToWriter(t *testing.T) {
 	require.NotEmpty(t, buf.Bytes(), "thumbnails should have been written to the writer")
 }
 
-
 func TestDesktopRecordingProcessor_InactivityEvents(t *testing.T) {
 	startTime := time.Now()
 
@@ -166,9 +165,15 @@ func TestDesktopRecordingProcessor_InactivityEvents(t *testing.T) {
 	bigFrame := func(at time.Time, color uint16) *apievents.DesktopRecording {
 		return desktopFastPathEvent(t, at, rdpstatetest.BuildBitmapPDU(0, 0, 64, 64, color))
 	}
-	// smallFrame paints a 2x2 region (~4px), far below the threshold — clock/caret-scale noise.
+	// smallFrame paints a 2x2 region (~4px) at a fixed position, far below the threshold: a ticking
+	// clock or blinking caret that keeps repainting the same spot.
 	smallFrame := func(at time.Time) *apievents.DesktopRecording {
 		return desktopFastPathEvent(t, at, rdpstatetest.BuildBitmapPDU(0, 0, 2, 2, rdpstatetest.RGB565Red))
+	}
+	// typingFrame paints a 2x2 region at an advancing x offset: a glyph repaint marching across the
+	// screen as the user types. Below the per-frame threshold, but always in a new place.
+	typingFrame := func(at time.Time, x int) *apievents.DesktopRecording {
+		return desktopFastPathEvent(t, at, rdpstatetest.BuildBitmapPDU(x, 0, 2, 2, rdpstatetest.RGB565Red))
 	}
 
 	type offsets struct{ start, end time.Duration }
@@ -239,6 +244,52 @@ func TestDesktopRecordingProcessor_InactivityEvents(t *testing.T) {
 				desktopSessionEndEvent(startTime.Add(20 * time.Second)),
 			},
 			expected: []offsets{{start: 0, end: 20 * time.Second}},
+		},
+		{
+			// Typing without the mouse reaches the processor only as small repaints that land in new
+			// places frame after frame. Each is below the area threshold, but together they're activity.
+			name: "continuous typing without mouse movement is not inactive",
+			events: []apievents.AuditEvent{
+				desktopSessionStartEvent(startTime),
+				desktopServerHelloEvent(t, startTime.Add(100*time.Millisecond), 256, 256),
+				typingFrame(startTime.Add(1*time.Second), 0),
+				typingFrame(startTime.Add(2*time.Second), 4),
+				typingFrame(startTime.Add(3*time.Second), 8),
+				typingFrame(startTime.Add(4*time.Second), 12),
+				typingFrame(startTime.Add(5*time.Second), 16),
+				typingFrame(startTime.Add(6*time.Second), 20),
+				typingFrame(startTime.Add(7*time.Second), 24),
+				typingFrame(startTime.Add(8*time.Second), 28),
+				typingFrame(startTime.Add(9*time.Second), 32),
+				typingFrame(startTime.Add(10*time.Second), 36),
+				typingFrame(startTime.Add(11*time.Second), 40),
+				typingFrame(startTime.Add(12*time.Second), 44),
+				desktopSessionEndEvent(startTime.Add(13 * time.Second)),
+			},
+			expected: nil,
+		},
+		{
+			// A taskbar clock repaints the same spot once per second while the user is away. It stays in
+			// one place, so the whole span remains inactive.
+			name: "clock ticking in a fixed position stays inactive",
+			events: []apievents.AuditEvent{
+				desktopSessionStartEvent(startTime),
+				desktopServerHelloEvent(t, startTime.Add(100*time.Millisecond), 256, 256),
+				bigFrame(startTime.Add(1*time.Second), rdpstatetest.RGB565White),
+				smallFrame(startTime.Add(3 * time.Second)),
+				smallFrame(startTime.Add(4 * time.Second)),
+				smallFrame(startTime.Add(5 * time.Second)),
+				smallFrame(startTime.Add(6 * time.Second)),
+				smallFrame(startTime.Add(7 * time.Second)),
+				smallFrame(startTime.Add(8 * time.Second)),
+				smallFrame(startTime.Add(9 * time.Second)),
+				smallFrame(startTime.Add(10 * time.Second)),
+				smallFrame(startTime.Add(11 * time.Second)),
+				smallFrame(startTime.Add(12 * time.Second)),
+				smallFrame(startTime.Add(13 * time.Second)),
+				desktopSessionEndEvent(startTime.Add(14 * time.Second)),
+			},
+			expected: []offsets{{start: 1 * time.Second, end: 14 * time.Second}},
 		},
 	}
 

--- a/lib/auth/recordingmetadata/recordingmetadatav1/desktopprocessor_test.go
+++ b/lib/auth/recordingmetadata/recordingmetadatav1/desktopprocessor_test.go
@@ -324,6 +324,22 @@ func TestDesktopRecordingProcessor_InactivityEvents(t *testing.T) {
 			},
 			expected: []offsets{{start: 1 * time.Second, end: 20 * time.Second}},
 		},
+		{
+			// A mouse click is recorded as input but doesn't move the cursor or repaint; it must still
+			// count as activity.
+			name: "mouse click without a repaint counts as activity",
+			events: []apievents.AuditEvent{
+				desktopSessionStartEvent(startTime),
+				desktopServerHelloEvent(t, startTime.Add(100*time.Millisecond), 256, 256),
+				bigFrame(startTime.Add(1*time.Second), rdpstatetest.RGB565White),
+				desktopMouseButtonEvent(t, startTime.Add(15*time.Second)),
+				desktopSessionEndEvent(startTime.Add(40 * time.Second)),
+			},
+			expected: []offsets{
+				{start: 1 * time.Second, end: 15 * time.Second},
+				{start: 15 * time.Second, end: 40 * time.Second},
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -450,6 +466,18 @@ func desktopMouseMoveEvent(t *testing.T, eventTime time.Time, x, y uint32) *apie
 	t.Helper()
 
 	evt, err := rdpstatetest.LegacyMouseMove(x, y)
+	require.NoError(t, err)
+
+	evt.Metadata.Time = eventTime
+
+	return evt
+}
+
+// desktopMouseButtonEvent builds a DesktopRecording carrying a mouse button press at eventTime.
+func desktopMouseButtonEvent(t *testing.T, eventTime time.Time) *apievents.DesktopRecording {
+	t.Helper()
+
+	evt, err := rdpstatetest.EncodeTDPBMouseButton(true)
 	require.NoError(t, err)
 
 	evt.Metadata.Time = eventTime

--- a/lib/auth/recordingmetadata/recordingmetadatav1/desktopprocessor_test.go
+++ b/lib/auth/recordingmetadata/recordingmetadatav1/desktopprocessor_test.go
@@ -215,3 +215,29 @@ func desktopRecoveredSessionEndEvent(sessionStart, eventTime time.Time) *apieven
 		StartTime:   sessionStart,
 	}
 }
+
+func TestDesktopThumbnailGenerator_ConsumeFrameActivity(t *testing.T) {
+	startTime := time.Now()
+
+	gen := newDesktopThumbnailGenerator()
+	defer gen.release()
+
+	// ServerHello initializes the decoder: dimensions are set, nothing has changed yet.
+	require.NoError(t, gen.handleEvent(desktopServerHelloEvent(t, startTime, 256, 256)))
+
+	fa := gen.consumeFrameActivity()
+	require.Equal(t, uint16(256), fa.screenW)
+	require.Equal(t, uint16(256), fa.screenH)
+	require.Zero(t, fa.changedPixels)
+
+	// A 32x32 bitmap update marks a changed region well above zero.
+	require.NoError(t, gen.handleEvent(desktopFastPathEvent(t, startTime.Add(time.Second),
+		rdpstatetest.BuildBitmapPDU(0, 0, 32, 32, rdpstatetest.RGB565White))))
+
+	fa = gen.consumeFrameActivity()
+	require.Positive(t, fa.changedPixels)
+
+	// consumeFrameActivity reset the accumulator, so a subsequent call with no new frame reports zero.
+	fa = gen.consumeFrameActivity()
+	require.Zero(t, fa.changedPixels)
+}

--- a/lib/auth/recordingmetadata/recordingmetadatav1/desktopthumbnail.go
+++ b/lib/auth/recordingmetadata/recordingmetadatav1/desktopthumbnail.go
@@ -160,6 +160,41 @@ func (d *desktopThumbnailGenerator) release() {
 	d.rdpstate.Release()
 }
 
+// frameActivity captures the per-frame signals the desktop processor uses to decide whether a frame
+// represents real user activity: how much of the screen changed, where the cursor is, and the screen size.
+type frameActivity struct {
+	changedPixels    int
+	cursorX, cursorY uint16
+	screenW, screenH uint16
+}
+
+// consumeFrameActivity returns the activity signals for the frame just handled and resets the decoder's
+// updated-region accumulator so the next call reflects only the next frame. It returns the zero value when
+// the generator is disabled (e.g. nop builds without the RDP decoder), in which case screenW/screenH are 0
+// and the caller skips activity tracking.
+func (d *desktopThumbnailGenerator) consumeFrameActivity() frameActivity {
+	if d.disabled {
+		return frameActivity{}
+	}
+
+	var changed int
+	for _, r := range d.rdpstate.UpdatedRegions() {
+		changed += r.Dx() * r.Dy()
+	}
+	d.rdpstate.ResetUpdatedRegions()
+
+	cursor := d.rdpstate.CursorState()
+	w, h := d.rdpstate.Dimensions()
+
+	return frameActivity{
+		changedPixels: changed,
+		cursorX:       cursor.X,
+		cursorY:       cursor.Y,
+		screenW:       w,
+		screenH:       h,
+	}
+}
+
 func calculateCropBounds(bounds image.Rectangle, cursor decoder.CursorState) image.Rectangle {
 	screenW := float64(bounds.Dx())
 	screenH := float64(bounds.Dy())

--- a/lib/auth/recordingmetadata/recordingmetadatav1/desktopthumbnail.go
+++ b/lib/auth/recordingmetadata/recordingmetadatav1/desktopthumbnail.go
@@ -163,7 +163,10 @@ func (d *desktopThumbnailGenerator) release() {
 // frameActivity captures the per-frame signals the desktop processor uses to decide whether a frame represents real user
 // activity: how much of the screen changed, where the cursor is, and the screen size.
 type frameActivity struct {
-	changedPixels    int
+	changedPixels int
+	// regions are the rectangles that changed this frame; their positions let the processor tell typing
+	// apart from a fixed clock or caret.
+	regions          []image.Rectangle
 	cursorX, cursorY uint16
 	screenW, screenH uint16
 }
@@ -177,8 +180,13 @@ func (d *desktopThumbnailGenerator) consumeFrameActivity() frameActivity {
 	}
 	defer d.rdpstate.ResetUpdatedRegions()
 
+	regions := d.rdpstate.UpdatedRegions()
+
+	// UpdatedRegions can overlap, so a pixel changed twice is counted twice and changed
+	// can exceed the true changed area. We accept the overcount as a worthwhile trade-off
+	// for keeping the comparison simple, rather than computing the exact union area.
 	var changed int
-	for _, r := range d.rdpstate.UpdatedRegions() {
+	for _, r := range regions {
 		changed += r.Dx() * r.Dy()
 	}
 
@@ -187,6 +195,7 @@ func (d *desktopThumbnailGenerator) consumeFrameActivity() frameActivity {
 
 	return frameActivity{
 		changedPixels: changed,
+		regions:       regions,
 		cursorX:       cursor.X,
 		cursorY:       cursor.Y,
 		screenW:       w,

--- a/lib/auth/recordingmetadata/recordingmetadatav1/desktopthumbnail.go
+++ b/lib/auth/recordingmetadata/recordingmetadatav1/desktopthumbnail.go
@@ -175,12 +175,12 @@ func (d *desktopThumbnailGenerator) consumeFrameActivity() frameActivity {
 	if d.disabled {
 		return frameActivity{}
 	}
+	defer d.rdpstate.ResetUpdatedRegions()
 
 	var changed int
 	for _, r := range d.rdpstate.UpdatedRegions() {
 		changed += r.Dx() * r.Dy()
 	}
-	d.rdpstate.ResetUpdatedRegions()
 
 	cursor := d.rdpstate.CursorState()
 	w, h := d.rdpstate.Dimensions()

--- a/lib/auth/recordingmetadata/recordingmetadatav1/desktopthumbnail.go
+++ b/lib/auth/recordingmetadata/recordingmetadatav1/desktopthumbnail.go
@@ -160,18 +160,17 @@ func (d *desktopThumbnailGenerator) release() {
 	d.rdpstate.Release()
 }
 
-// frameActivity captures the per-frame signals the desktop processor uses to decide whether a frame
-// represents real user activity: how much of the screen changed, where the cursor is, and the screen size.
+// frameActivity captures the per-frame signals the desktop processor uses to decide whether a frame represents real user
+// activity: how much of the screen changed, where the cursor is, and the screen size.
 type frameActivity struct {
 	changedPixels    int
 	cursorX, cursorY uint16
 	screenW, screenH uint16
 }
 
-// consumeFrameActivity returns the activity signals for the frame just handled and resets the decoder's
-// updated-region accumulator so the next call reflects only the next frame. It returns the zero value when
-// the generator is disabled (e.g. nop builds without the RDP decoder), in which case screenW/screenH are 0
-// and the caller skips activity tracking.
+// consumeFrameActivity returns the activity signals for the frame just handled and resets the decoder's updated-region
+// accumulator so the next call reflects only the next frame.
+// It returns the zero value when the generator is disabled.
 func (d *desktopThumbnailGenerator) consumeFrameActivity() frameActivity {
 	if d.disabled {
 		return frameActivity{}

--- a/lib/auth/recordingmetadata/recordingmetadatav1/desktopthumbnail.go
+++ b/lib/auth/recordingmetadata/recordingmetadatav1/desktopthumbnail.go
@@ -166,7 +166,9 @@ type frameActivity struct {
 	changedPixels int
 	// regions are the rectangles that changed this frame; their positions let the processor tell typing
 	// apart from a fixed clock or caret.
-	regions          []image.Rectangle
+	regions []image.Rectangle
+	// mouseButton is set when this frame carried a mouse button press or release.
+	mouseButton      bool
 	cursorX, cursorY uint16
 	screenW, screenH uint16
 }
@@ -179,6 +181,7 @@ func (d *desktopThumbnailGenerator) consumeFrameActivity() frameActivity {
 		return frameActivity{}
 	}
 	defer d.rdpstate.ResetUpdatedRegions()
+	defer d.rdpstate.ResetMouseButtonInput()
 
 	regions := d.rdpstate.UpdatedRegions()
 
@@ -196,6 +199,7 @@ func (d *desktopThumbnailGenerator) consumeFrameActivity() frameActivity {
 	return frameActivity{
 		changedPixels: changed,
 		regions:       regions,
+		mouseButton:   d.rdpstate.MouseButtonInput(),
 		cursorX:       cursor.X,
 		cursorY:       cursor.Y,
 		screenW:       w,

--- a/lib/auth/recordingmetadata/recordingmetadatav1/desktopthumbnail.go
+++ b/lib/auth/recordingmetadata/recordingmetadatav1/desktopthumbnail.go
@@ -87,6 +87,12 @@ func (d *desktopThumbnailGenerator) handleDesktopRecording(evt *apievents.Deskto
 	return err
 }
 
+// decoderAvailable reports whether the RDP decoder is present. It is false in nop builds, where the decoder returns
+// NotImplemented and the generator disables itself, leaving no frame activity to analyze.
+func (d *desktopThumbnailGenerator) decoderAvailable() bool {
+	return !d.disabled
+}
+
 // produceThumbnail generates a thumbnail from the current RDP state. If the cursor is visible, the thumbnail is zoomed
 // to the area around the cursor. maxDim caps the longer side (in pixels) of the encoded PNG.
 // NOTE: If the decoder is not available (e.g. in nop builds without desktop_access_rdp), this will return nil without

--- a/lib/auth/recordingmetadata/recordingmetadatav1/processor.go
+++ b/lib/auth/recordingmetadata/recordingmetadatav1/processor.go
@@ -138,6 +138,16 @@ func (b *baseRecordingProcessor) captureThumbnailIfNeeded(eventTime time.Time, i
 	b.thumbnail = representative
 }
 
+// addInactivityEvent appends an inactivity event spanning [start, end] (expressed as offsets from the session
+// start) to the metadata. Shared by the TTY and desktop processors.
+func (b *baseRecordingProcessor) addInactivityEvent(start, end time.Time) {
+	b.metadata.SetEvents(append(b.metadata.GetEvents(), pb.SessionRecordingEvent_builder{
+		StartOffset: durationpb.New(start.Sub(b.startTime)),
+		EndOffset:   durationpb.New(end.Sub(b.startTime)),
+		Inactivity:  &pb.SessionRecordingInactivityEvent{},
+	}.Build()))
+}
+
 func (b *baseRecordingProcessor) release() {
 	b.thumbnailGenerator.release()
 }

--- a/lib/auth/recordingmetadata/recordingmetadatav1/recordingmetadata.go
+++ b/lib/auth/recordingmetadata/recordingmetadatav1/recordingmetadata.go
@@ -104,6 +104,11 @@ const (
 	// real recordings.
 	desktopActivityAreaFraction = 0.001 // 0.1%
 
+	// desktopActivityMinLocations is how many distinct places must change since the last activity for a
+	// run of small, sub-threshold repaints to count as activity. A clock or caret repaints one fixed
+	// spot; typing keeps moving to new ones. Validate against real recordings.
+	desktopActivityMinLocations = 4
+
 	// concurrencyLimit limits the number of concurrent processing operations (matches the session summarizer).
 	concurrencyLimit = 150
 

--- a/lib/auth/recordingmetadata/recordingmetadatav1/recordingmetadata.go
+++ b/lib/auth/recordingmetadata/recordingmetadatav1/recordingmetadata.go
@@ -97,6 +97,13 @@ const (
 	// hits the maxThumbnails cap.
 	desktopMinThumbnailInterval = 7 * time.Second
 
+	// desktopActivityAreaFraction is the fraction of the screen area that must change between desktop
+	// recording frames for the change to count as user activity (resetting the inactivity timer).
+	// Smaller incidental updates — a ticking taskbar clock, a blinking text caret — fall below this
+	// and are treated as inactivity. Tuned to sit above glyph/caret-scale noise; validate against
+	// real recordings.
+	desktopActivityAreaFraction = 0.001 // 0.1%
+
 	// concurrencyLimit limits the number of concurrent processing operations (matches the session summarizer).
 	concurrencyLimit = 150
 

--- a/lib/auth/recordingmetadata/recordingmetadatav1/ttyprocessor.go
+++ b/lib/auth/recordingmetadata/recordingmetadatav1/ttyprocessor.go
@@ -183,17 +183,6 @@ func (t *ttyRecordingProcessor) handleSessionEnd(evt *apievents.SessionEnd) erro
 	return nil
 }
 
-func (t *ttyRecordingProcessor) addInactivityEvent(start, end time.Time) {
-	inactivityStart := durationpb.New(start.Sub(t.startTime))
-	inactivityEnd := durationpb.New(end.Sub(t.startTime))
-
-	t.metadata.SetEvents(append(t.metadata.GetEvents(), pb.SessionRecordingEvent_builder{
-		StartOffset: inactivityStart,
-		EndOffset:   inactivityEnd,
-		Inactivity:  &pb.SessionRecordingInactivityEvent{},
-	}.Build()))
-}
-
 func (t *ttyRecordingProcessor) collect() (*pb.SessionRecordingMetadata, *pb.SessionRecordingThumbnail) {
 	if t.lastEvent == nil {
 		return nil, nil

--- a/lib/srv/desktop/rdpstate/rdpstate.go
+++ b/lib/srv/desktop/rdpstate/rdpstate.go
@@ -57,6 +57,9 @@ const (
 // Subsequent FastPathPDU messages are fed to the decoder, which maintains the screen framebuffer and cursor state.
 type RDPState struct {
 	decoder *decoder.Decoder
+
+	// mouseButtonInput is set when a mouse button message is processed; the decoder keeps no button state.
+	mouseButtonInput bool
 }
 
 // New creates a new RDPState.
@@ -153,6 +156,16 @@ func (s *RDPState) ResetUpdatedRegions() {
 	}
 }
 
+// MouseButtonInput reports whether a mouse button message has been processed since the last reset.
+func (s *RDPState) MouseButtonInput() bool {
+	return s.mouseButtonInput
+}
+
+// ResetMouseButtonInput clears the mouse button input flag.
+func (s *RDPState) ResetMouseButtonInput() {
+	s.mouseButtonInput = false
+}
+
 type connectionActivated struct {
 	IOChannelID, UserChannelID, ScreenWidth, ScreenHeight uint16
 }
@@ -240,6 +253,9 @@ func (s *RDPState) processTDPBMessage(data []byte) error {
 		return s.handleFastPathPDU(env.GetFastPathPdu())
 	case tdpbv1.Envelope_MouseMove_case:
 		return s.handleMouseMove(env.GetMouseMove())
+	case tdpbv1.Envelope_MouseButton_case:
+		s.mouseButtonInput = true
+		return nil
 	}
 
 	return nil

--- a/lib/srv/desktop/rdpstate/rdpstatetest/events.go
+++ b/lib/srv/desktop/rdpstate/rdpstatetest/events.go
@@ -64,6 +64,16 @@ func EncodeTDPBFastPathPDU(pdu []byte) (*apievents.DesktopRecording, error) {
 	return TDPBEvent(data), nil
 }
 
+// EncodeTDPBMouseButton creates a DesktopRecording event containing a TDPB MouseButton message.
+func EncodeTDPBMouseButton(pressed bool) (*apievents.DesktopRecording, error) {
+	data, err := (&tdpb.MouseButton{Pressed: pressed}).Encode()
+	if err != nil {
+		return nil, err
+	}
+
+	return TDPBEvent(data), nil
+}
+
 // LegacyConnectionActivated creates a DesktopRecording event containing a legacy ConnectionActivated message with the
 // given screen dimensions.
 func LegacyConnectionActivated(width, height uint16) (*apievents.DesktopRecording, error) {


### PR DESCRIPTION
This updates the recording metadata processing to detect inactivity periods for desktop sessions. To do this, we use a combination of mouse events and checking the percentage of the screen that has changed (so we don't see a clock update as activity).

## Manual Test Plan
### Test Environment
Cloud

### Test Cases
- [x] A desktop session left alone for a while creates an inactivity event
