### PR TITLE
Add page_type and outcome statements to 46 guides

### DIFF
--- a/docs/pages/connect-your-client/connect-your-client.mdx
+++ b/docs/pages/connect-your-client/connect-your-client.mdx
@@ -5,6 +5,7 @@ description: Learn how to access infrastructure resources protected by Teleport.
 template: doc-page
 tags:
  - platform-wide
+page_type: landing
 ---
 import Resources from '@site/src/components/Pages/Homepage/Resources';
 import UseCasesList from '@site/src/components/Pages/Landing/UseCasesList';

--- a/docs/pages/connect-your-client/model-context-protocol/database-access.mdx
+++ b/docs/pages/connect-your-client/model-context-protocol/database-access.mdx
@@ -7,6 +7,7 @@ tags:
  - infrastructure-identity
  - zero-trust
  - how-to
+page_type: how-to
 ---
 
 <Callout
@@ -20,7 +21,8 @@ tags:
   }}
 />
 
-This guide explains how to connect to your **PostgreSQL** Teleport databases with MCP clients.
+This guide shows you how to connect to your **PostgreSQL** Teleport databases
+with MCP clients.
 
 {/* lint ignore page-structure remark-lint */}
 

--- a/docs/pages/connect-your-client/model-context-protocol/kube-access.mdx
+++ b/docs/pages/connect-your-client/model-context-protocol/kube-access.mdx
@@ -7,6 +7,7 @@ tags:
  - infrastructure-identity
  - zero-trust
  - how-to
+page_type: how-to
 ---
 
 <Callout
@@ -20,7 +21,7 @@ tags:
   }}
 />
 
-This guide explains how to connect to Teleport Kubernetes Clusters with MCP clients.
+This guide shows you how to connect to Teleport Kubernetes clusters with MCP clients.
 
 {/* lint ignore page-structure remark-lint */}
 

--- a/docs/pages/connect-your-client/model-context-protocol/mcp-access.mdx
+++ b/docs/pages/connect-your-client/model-context-protocol/mcp-access.mdx
@@ -8,6 +8,7 @@ tags:
  - how-to
  - zero-trust
  - infrastructure-identity
+page_type: how-to
 ---
 
 <Callout
@@ -21,8 +22,8 @@ tags:
   }}
 />
 
-This guide explains how to configure MCP clients to access MCP servers served by
-Teleport.
+This guide shows you how to configure MCP clients to access MCP servers served
+by Teleport.
 
 {/* lint ignore page-structure remark-lint */}
 

--- a/docs/pages/connect-your-client/model-context-protocol/model-context-protocol.mdx
+++ b/docs/pages/connect-your-client/model-context-protocol/model-context-protocol.mdx
@@ -6,6 +6,7 @@ tags:
  - conceptual
  - zero-trust
  - ai
+page_type: landing
 ---
 
 Secure Large Language Model (LLM) interactions with infrastructure using Teleport's secure 

--- a/docs/pages/connect-your-client/teleport-clients/notifications.mdx
+++ b/docs/pages/connect-your-client/teleport-clients/notifications.mdx
@@ -5,11 +5,13 @@ tags:
  - conceptual
  - platform-wide
  - resiliency
+page_type: conceptual
 ---
 
-Teleport's notification system allows users to be notified of various events, updates, and warnings in real time.
-
-This guide explains how to interact with notifications in the Web UI and how cluster administrators can create custom notifications for their users.
+This page describes the Teleport notification system, which allows cluster
+administrators to send custom notifications to their users in real time.
+Administrators can use the notification system to broadcast events, updates, and
+warnings as needed.
 
 ## Interacting with notifications in the Web UI
 

--- a/docs/pages/connect-your-client/teleport-clients/request-access.mdx
+++ b/docs/pages/connect-your-client/teleport-clients/request-access.mdx
@@ -7,13 +7,15 @@ tags:
  - identity-governance
  - privileged-access
  - conceptual
+page_type: conceptual
 ---
 
 If you cannot access a Teleport role or resource with your current Teleport
 permissions, you can create an Access Request to obtain elevated permissions for
 a limited time.
 
-This guide explains to you how to use `tsh` to create Teleport Access Requests. 
+This page describes the `tsh` commands that allow you create Teleport Access
+Requests. 
 
 <Admonition type="tip">
 

--- a/docs/pages/connect-your-client/teleport-clients/teleport-clients.mdx
+++ b/docs/pages/connect-your-client/teleport-clients/teleport-clients.mdx
@@ -6,11 +6,12 @@ description: The basics of connecting to resources with Teleport
 tags:
  - conceptual
  - platform-wide
+page_type: conceptual
 ---
 
-This guide covers the basics of authenticating to Teleport and
-accessing resources. It's written for end-users of resources protected by
-Teleport, and includes links to more detailed documentation at the end.
+This page describes how to authenticate to Teleport and access resources. It's
+written for end-users of resources protected by Teleport, and includes links to
+more detailed documentation at the end.
 
 ## Choosing a client
 

--- a/docs/pages/connect-your-client/teleport-clients/teleport-connect.mdx
+++ b/docs/pages/connect-your-client/teleport-clients/teleport-connect.mdx
@@ -6,10 +6,15 @@ description: Using Teleport Connect
 tags:
  - conceptual
  - platform-wide
+page_type: conceptual
 ---
 
 Teleport Connect provides easy and secure access to SSH servers, databases,
 applications, MCP servers, Windows desktops, and Kubernetes clusters.
+
+This page describes the installation and features of Teleport Connect,
+including how to connect to Teleport-protected resources and enroll your own
+computer as a Teleport-protected server.
 
 ![resources tab in Teleport Connect](../../../img/use-teleport/connect-cluster@2x.png)
 

--- a/docs/pages/connect-your-client/teleport-clients/tsh.mdx
+++ b/docs/pages/connect-your-client/teleport-clients/tsh.mdx
@@ -6,6 +6,7 @@ description: This reference shows you how to use Teleport's tsh tool to authenti
 tags:
  - conceptual
  - zero-trust
+page_type: how-to
 ---
 
 <EnterpriseFeatureWidget title="Did you know?">

--- a/docs/pages/connect-your-client/teleport-clients/vnet.mdx
+++ b/docs/pages/connect-your-client/teleport-clients/vnet.mdx
@@ -6,9 +6,10 @@ tags:
  - how-to
  - zero-trust
  - infrastructure-identity
+page_type: how-to
 ---
 
-This guide explains how to use VNet to connect to TCP applications and SSH
+This guide shows you how to use VNet to connect to TCP applications and SSH
 servers available through Teleport.
 
 ## How it works

--- a/docs/pages/connect-your-client/teleport-clients/web-ui.mdx
+++ b/docs/pages/connect-your-client/teleport-clients/web-ui.mdx
@@ -6,12 +6,14 @@ description: Using the Teleport Web UI
 tags:
  - conceptual
  - platform-wide
+page_type: conceptual
 ---
+
 The Teleport Web UI is a web-based visual interface from which you can access resources,
 view active sessions and recordings, create and review Access Requests,
 manage users and roles, and more.
 
-This page serves a reference on Web UI features and their usage.
+This page describes the features of the Teleport Web UI and how to use them.
 
 ## Joining an active session
 

--- a/docs/pages/connect-your-client/third-party/ansible.mdx
+++ b/docs/pages/connect-your-client/third-party/ansible.mdx
@@ -5,13 +5,14 @@ tags:
  - how-to
  - zero-trust
  - infrastructure-identity
+page_type: how-to
 ---
 
 Ansible uses the OpenSSH client by default. Teleport supports SSH protocol and
 works as SSH jumphost.
 
-In this guide we will configure OpenSSH client to work with Teleport Proxy
-and run a sample ansible playbook.
+In this guide, you will configure OpenSSH client to work with Teleport Proxy and
+run a sample ansible playbook.
 
 ## How it works
 

--- a/docs/pages/connect-your-client/third-party/gui-clients.mdx
+++ b/docs/pages/connect-your-client/third-party/gui-clients.mdx
@@ -5,10 +5,11 @@ tags:
  - how-to
  - zero-trust
  - infrastructure-identity
+page_type: how-to
 ---
 
-This guide describes how to configure popular graphical database clients to
-work with Teleport.
+This guide shows you how to configure popular graphical database clients to work
+with Teleport.
 
 If you are using Teleport Connect to access your database, you can follow the
 instructions in the app to connect your GUI client. See [Using Teleport

--- a/docs/pages/connect-your-client/third-party/jetbrains-sftp.mdx
+++ b/docs/pages/connect-your-client/third-party/jetbrains-sftp.mdx
@@ -5,13 +5,15 @@ tags:
  - how-to
  - zero-trust
  - infrastructure-identity
+page_type: how-to
 ---
 
 JetBrain's IDEs, like PyCharm, GoLand, and IntelliJ, allow browsing, copying, and editing files on a remote server
 using the SFTP protocol. You can integrate Teleport with your IDE so you can copy files to and from a remote
 machine without using a third-party client.
 
-This guide explains how to use Teleport and a JetBrains IDE to access files with SFTP.
+This guide shows you how to use Teleport and a JetBrains IDE to access files
+with SFTP.
 
 ## How it works
 

--- a/docs/pages/connect-your-client/third-party/putty-winscp.mdx
+++ b/docs/pages/connect-your-client/third-party/putty-winscp.mdx
@@ -7,10 +7,12 @@ tags:
  - platform-wide
  - zero-trust
  - infrastructure-identity
+page_type: how-to
 ---
 
-This guide will show you how to use the Teleport client tool `tsh` to add saved sessions for use
-with [PuTTY](https://putty.software/), and then how to use PuTTY as a client to connect to SSH nodes.
+This guide shows you how to use the Teleport client tool `tsh` to add saved
+sessions for use with [PuTTY](https://putty.software/), and then how to use
+PuTTY as a client to connect to SSH nodes.
 
 It will also show you how to optionally use these saved sessions with [WinSCP](https://winscp.net) to transfer
 files from SSH nodes using SFTP.

--- a/docs/pages/connect-your-client/third-party/third-party.mdx
+++ b/docs/pages/connect-your-client/third-party/third-party.mdx
@@ -2,6 +2,7 @@
 title: Connect Third-Party Clients with Teleport
 sidebar_label: Third-Party Tooling
 description: Explains how to use the third-party client tools you are already familiar with to access infrastructure protected by Teleport.
+page_type: landing
 ---
 
 Teleport works with the tooling that you already use to access infrastructure.

--- a/docs/pages/connect-your-client/third-party/vscode.mdx
+++ b/docs/pages/connect-your-client/third-party/vscode.mdx
@@ -5,9 +5,11 @@ tags:
  - how-to
  - zero-trust
  - infrastructure-identity
+page_type: how-to
 ---
 
-This guide explains how to use Teleport and Visual Studio Code's remote SSH extension.
+This guide shows you how to use Teleport and Visual Studio Code's remote SSH
+extension.
 
 ## How it works
 

--- a/docs/pages/get-started/access.mdx
+++ b/docs/pages/get-started/access.mdx
@@ -4,6 +4,7 @@ description: "Configure identity-based access controls in your Teleport cluster.
 toc_max_heading_level: 2
 tags:
   - get-started
+page_type: how-to
 ---
 
 import Button from '@site/src/components/Button';
@@ -22,6 +23,10 @@ permissions, such as:
 - Whether they can edit cluster settings or view session recordings
 
 You can assign roles when creating users or manage them later in the Teleport Web UI.
+
+In this guide, you will review Teleport's preset roles and explore the
+documentation for setting up custom roles to support your organization's access
+policies.
 
 ## Preset roles
 

--- a/docs/pages/get-started/audit.mdx
+++ b/docs/pages/get-started/audit.mdx
@@ -4,6 +4,7 @@ description: "Explore audit logging features in your Teleport cluster."
 toc_max_heading_level: 2
 tags:
   - get-started
+page_type: how-to
 ---
 
 import Icon from '@site/src/components/Icon';
@@ -15,6 +16,9 @@ This can be viewed in the Teleport Web UI by clicking on **Audit** > **Audit Log
 Here you'll see events like successful logins along with metadata such as event type, remote IP address, timestamp, and the identity involved. Click on **Details** to see the complete event information in JSON format.
 
 ![View audit log](../../img/get-started/get-started-audit-log@2x.png)
+
+In this guide, you will view the recording of the SSH session you began in Step
+2, and plan your next steps as you set up Teleport.
 
 ## View your SSH session recording
 

--- a/docs/pages/get-started/connect.mdx
+++ b/docs/pages/get-started/connect.mdx
@@ -4,6 +4,7 @@ description: "Enroll the resources you want to protect with your Teleport cluste
 toc_max_heading_level: 2
 tags:
   - get-started
+page_type: how-to
 ---
 
 import Button from '@site/src/components/Button';
@@ -12,6 +13,9 @@ import Icon from '@site/src/components/Icon';
 After deploying your Teleport cluster, the next step is to enroll the infrastructure resources you want to secure.
 
 Teleport supports a wide range of resource types, including Linux servers, MCP servers, Kubernetes clusters, databases, internal web apps, and cloud provider APIs. You can enroll these through the Teleport Web UI's guided setup workflows.
+
+In this guide, you will enroll a local Docker container with Teleport and
+explore the Teleport documentation to enroll other resource types.
 
 ## Demo: Enroll an Ubuntu server
 

--- a/docs/pages/get-started/deploy-cloud.mdx
+++ b/docs/pages/get-started/deploy-cloud.mdx
@@ -4,6 +4,7 @@ description: "Sign up for Teleport Enterprise Cloud and deploy your hosted clust
 tags:
   - get-started
   - platform-wide
+page_type: how-to
 ---
 
 import Button from '@site/src/components/Button';
@@ -12,7 +13,10 @@ Teleport Enterprise Cloud is the **fastest and easiest way to get started**.
 
 Infrastructure and certificates are managed for you. All that's left is deploying agents to enroll your resources.
 
-To get started, simply sign up for a 14-day free trial. We'll automatically provision and manage a fully featured Teleport cluster in a dedicated tenant with a unique `example.teleport.sh` domain.
+To get started, you simply sign up for a 14-day free trial. We'll automatically provision and manage a fully featured Teleport cluster in a dedicated tenant with a unique `example.teleport.sh` domain.
+
+In this guide, you will sign up for a Teleport Cloud trial, create a backup
+user, and save your recovery codes.
 
 ## Deploy your cluster
 

--- a/docs/pages/get-started/deploy-community.mdx
+++ b/docs/pages/get-started/deploy-community.mdx
@@ -4,6 +4,7 @@ description: "Deploy a self-hosted Teleport Community Edition cluster using the 
 tags:
   - get-started
   - platform-wide
+page_type: how-to
 ---
 
 import Button from '@site/src/components/Button';
@@ -12,7 +13,7 @@ import Button from '@site/src/components/Button';
    You can try out Teleport Enterprise capabilities like SSO, session recording summaries, and just-in-time Access Requests for free. No payment information required.
 </EnterpriseFeatureWidget>
 
-This guide will walk you through deploying Teleport Community Edition. 
+In this guide, you will deploy Teleport Community Edition. 
 
 You'll spin up a single-instance Teleport cluster on a Linux server, ideal for small-scale demos or home lab environments. Once deployed, you can move ahead in the guide to connecting your infrastructure, setting up role-based access control (RBAC), and auditing your access.
 

--- a/docs/pages/get-started/get-started.mdx
+++ b/docs/pages/get-started/get-started.mdx
@@ -4,6 +4,7 @@ description: "Learn how to deploy a cluster, connect infrastructure, set up acce
 template: no-toc
 tags:
   - get-started
+page_type: landing
 ---
 
 import Button from '@site/src/components/Button';

--- a/docs/pages/identity-governance/locking.mdx
+++ b/docs/pages/identity-governance/locking.mdx
@@ -6,6 +6,7 @@ tags:
  - identity-governance
  - resiliency
 enterprise: Identity Governance
+page_type: how-to
 ---
 
 System administrators can disable a compromised user or Teleport Agent—or
@@ -29,6 +30,9 @@ A lock can target the following objects or attributes:
 - an [Access Request](access-requests/access-requests.mdx) by UUID
 - a bot instance ID (for Machine & Workload Identity bots)
 - a join token name (for Machine & Workload Identity bots using a [delegated join method](../reference/deployment/join-methods.mdx#delegated-join-methods))
+
+In this guide, you will create a lock, list active locks, and delete a lock you
+no longer need.
 
 ## How it works
 

--- a/docs/pages/identity-security/access-graph/access-graph.mdx
+++ b/docs/pages/identity-security/access-graph/access-graph.mdx
@@ -7,6 +7,7 @@ tags:
  - access-risks
 sidebar_position: 4
 enterprise: Identity Security
+page_type: landing
 ---
 
 If you run a self-hosted Teleport cluster, using Teleport Identity Security

--- a/docs/pages/identity-security/access-graph/identity-activity-center.mdx
+++ b/docs/pages/identity-security/access-graph/identity-activity-center.mdx
@@ -8,6 +8,7 @@ tags:
  - aws
  - access-risks
 enterprise: Identity Security
+page_type: how-to
 ---
 
 In this guide, you will set up the infrastructure required

--- a/docs/pages/identity-security/access-graph/self-hosted-helm.mdx
+++ b/docs/pages/identity-security/access-graph/self-hosted-helm.mdx
@@ -7,6 +7,7 @@ tags:
  - identity-security
  - access-risks
 enterprise: Identity Security
+page_type: how-to
 ---
 
 Using Teleport Identity Security with Access Graph on a self-hosted Teleport cluster requires
@@ -14,7 +15,7 @@ setting up the Access Graph, a dedicated service which uses PostgreSQL
 as its backing storage and communicates with Auth Service and Proxy Service
 to collect information about resources and access.
 
-This guide will help you set up the Access Graph service in a Kubernetes cluster using a Helm Chart,
+In this guide, you will you set up the Access Graph service in a Kubernetes cluster using a Helm Chart,
 and enable the Access Graph feature in your Teleport cluster.
 
 The full listing of supported parameters can be found in the [Helm chart reference](../../reference/helm-reference/teleport-access-graph.mdx).

--- a/docs/pages/identity-security/access-graph/self-hosted.mdx
+++ b/docs/pages/identity-security/access-graph/self-hosted.mdx
@@ -7,6 +7,7 @@ tags:
  - identity-security
  - access-risks
 enterprise: Identity Security
+page_type: how-to
 ---
 
 This guide shows you how to set up Teleport Access Graph in a self-hosted

--- a/docs/pages/identity-security/identity-security.mdx
+++ b/docs/pages/identity-security/identity-security.mdx
@@ -6,6 +6,7 @@ tags:
  - identity-security
  - access-risks
 enterprise: Identity Security
+page_type: landing
 ---
 
 import LandingHero from '@site/src/components/Pages/Landing/LandingHero';

--- a/docs/pages/identity-security/integrations/aws-sync.mdx
+++ b/docs/pages/identity-security/integrations/aws-sync.mdx
@@ -3,11 +3,12 @@ title: Discover AWS Access Patterns with Teleport Identity Security
 sidebar_label: AWS
 description: Describes how to import and visualize AWS accounts access patterns using Identity Security.
 tags:
- - conceptual
+ - how-to
  - identity-security
  - aws
  - access-risks
 enterprise: Identity Security
+page_type: how-to
 ---
 
 Identity Security streamlines and centralizes access management across your entire infrastructure. You can view access relationships in seconds,
@@ -26,6 +27,9 @@ threats and correlation with other services such as Okta and GitHub Actions.
 
 Utilizing the Access Graph to analyze IAM permissions within an AWS account necessitates the setup of the Access Graph
 service, a Discovery Service, and integration with your AWS account.
+
+This guide shows you how to set up commonly used Teleport Access Graph
+integrations.
 
 (!docs/pages/includes/policy/access-graph.mdx!)
 

--- a/docs/pages/identity-security/integrations/azure-sync.mdx
+++ b/docs/pages/identity-security/integrations/azure-sync.mdx
@@ -8,6 +8,7 @@ tags:
  - azure
  - access-risks
 enterprise: Identity Security
+page_type: how-to
 ---
 
 Identity Security streamlines and centralizes access management across your entire infrastructure. You can view access
@@ -24,6 +25,8 @@ within your Azure environment. This functionality enables you to address queries
 
 Utilizing the Access Graph to analyze permissions within an Azure subscription necessitates the setup of the Access
 Graph service, a Discovery Service, and integration with your Azure subscription.
+
+In this guide, you will set up Azure sync with Teleport Access Graph.
 
 (!docs/pages/includes/policy/access-graph.mdx!)
 

--- a/docs/pages/identity-security/integrations/entra-id.mdx
+++ b/docs/pages/identity-security/integrations/entra-id.mdx
@@ -8,6 +8,7 @@ tags:
  - azure
  - access-risks
 enterprise: Identity Security
+page_type: how-to
 ---
 
 The Microsoft Entra ID integration in Teleport Identity Governance synchronizes your Entra ID directory into your Teleport cluster,
@@ -21,6 +22,9 @@ and AWS accounts are set up as relying parties using AWS IAM role federation.
 
 Support for additional relying parties will be added in the future.
 </Admonition>
+
+In this guide, you will set up the Microsoft Entra ID integration with Teleport
+Access Graph and analyze access patterns within an Entra ID directory.
 
 ## How it works
 

--- a/docs/pages/identity-security/integrations/github.mdx
+++ b/docs/pages/identity-security/integrations/github.mdx
@@ -7,10 +7,12 @@ tags:
  - identity-security
  - access-risks
 enterprise: Identity Security
+page_type: how-to
 ---
 
-This guide walks you through configuring Identity Security to import
-GitHub Audit Logs, providing enhanced visibility and alerts for suspicious activities.
+This guide shows you how to configure Teleport Identity Security to import
+GitHub Audit Logs, providing enhanced visibility and alerts for suspicious
+activities.
 
 (!docs/pages/includes/policy/identity-activity-center.mdx!)
 

--- a/docs/pages/identity-security/integrations/gitlab.mdx
+++ b/docs/pages/identity-security/integrations/gitlab.mdx
@@ -7,6 +7,7 @@ tags:
  - identity-security
  - access-risks
 enterprise: Identity Security
+page_type: how-to
 ---
 
 Gain insights into access patterns within your GitLab account using Identity Security with Access Graph. By scanning all
@@ -15,6 +16,9 @@ your GitLab environment. This functionality enables you to answer queries such a
 
 - What projects are accessible to users?
 - Which users have write permissions to projects?
+
+In this guide, you will set up the GitLab integration with Teleport Access Graph
+and analyze GitLab access patterns.
 
 (!docs/pages/includes/policy/access-graph.mdx!)
 

--- a/docs/pages/identity-security/integrations/integrations.mdx
+++ b/docs/pages/identity-security/integrations/integrations.mdx
@@ -7,6 +7,7 @@ tags:
  - identity-security
  - access-risks
 enterprise: Identity Security
+page_type: landing
 ---
 
 Teleport can integrate with identity providers (IdPs) like Okta and AWS OIDC

--- a/docs/pages/identity-security/integrations/netiq.mdx
+++ b/docs/pages/identity-security/integrations/netiq.mdx
@@ -7,6 +7,7 @@ tags:
  - identity-security
  - access-risks
 enterprise: Identity Security
+page_type: how-to
 ---
 
 Gain insights into your NetIQ organization
@@ -22,6 +23,9 @@ Access Graph helps answer key questions such as:
 Access Graph is a feature of the [Identity Security](https://goteleport.com/platform/identity-security/) product, available to **Teleport Enterprise edition** customers.  
 
 If enabled, Identity Security options can be found under the **Policy** section in the left navigation menu.  
+
+In this guide, you will set up the NetIQ integration with Teleport Access Graph
+and analyze NetIQ access patterns.
 
 ## How it works
 

--- a/docs/pages/identity-security/integrations/okta.mdx
+++ b/docs/pages/identity-security/integrations/okta.mdx
@@ -7,6 +7,7 @@ tags:
  - identity-security
  - access-risks
 enterprise: Identity Security
+page_type: how-to
 ---
 
 Understand access patterns within your Okta organization using Teleport Identity Security. 
@@ -20,6 +21,9 @@ for audit and investigation. This functionality enables you to answer queries su
 - Which API tokens exist and who owns them?
 - What admin actions have been performed recently?
 - Is my upstream IDP being comprised, and are there any suspicious login patterns?
+
+In this guide, you will set up the Okta integration with Teleport Access Graph
+and use it to analyze Okta access patterns.
 
 (!docs/pages/includes/policy/access-graph.mdx!)
 

--- a/docs/pages/identity-security/integrations/ssh-keys-scan.mdx
+++ b/docs/pages/identity-security/integrations/ssh-keys-scan.mdx
@@ -7,6 +7,7 @@ tags:
  - identity-security
  - access-risks
 enterprise: Identity Security
+page_type: how-to
 ---
 
 Using Identity Security with Access Graph, you can gain insights on how SSH keys are used within your environment. By scanning
@@ -18,6 +19,9 @@ This functionality gives you insights into the following areas:
 - Which servers have SSH authorized keys that could be used to bypass Teleport?
 - Which users have SSH private keys that grant access to SSH servers?
 - Which laptops have unprotected SSH private keys?
+
+In this guide, you will set up the SSH key integration with Teleport Access
+Graph and analyze SSH access patterns.
 
 (!docs/pages/includes/policy/access-graph.mdx!)
 

--- a/docs/pages/identity-security/integrations/teleport.mdx
+++ b/docs/pages/identity-security/integrations/teleport.mdx
@@ -7,6 +7,7 @@ tags:
  - identity-security
  - access-risks
 enterprise: Identity Security
+page_type: how-to
 ---
 
 In this guide, you will configure your Teleport cluster to forward

--- a/docs/pages/identity-security/session-summaries/session-search.mdx
+++ b/docs/pages/identity-security/session-summaries/session-search.mdx
@@ -5,10 +5,10 @@ description: Configure and use Teleport Identity Security Session Recording Sear
 tags:
   - session-recording
   - how-to
-  - conceptual
   - identity-security
   - ai
 enterprise: Identity Security
+page_type: how-to
 ---
 
 Session Recording Search lets you find relevant session recordings by searching their
@@ -20,6 +20,10 @@ Session Recording Search searches session summaries, not raw recording data. A
 recording appears in search results only after Teleport has generated a
 successful [session recording summary](./session-summaries.mdx) for that
 session.
+
+In this guide, you will configure Teleport session summaries, generate summaries
+from sessions, and use Session Recording Search to find the summaries you
+generated.
 
 ## How it works
 

--- a/docs/pages/identity-security/session-summaries/session-summaries.mdx
+++ b/docs/pages/identity-security/session-summaries/session-summaries.mdx
@@ -6,16 +6,19 @@ description: Describes how to use Teleport Identity security to summarize sessio
 videoBanner: AW5DVLVNf6A
 tags:
   - session-recording
-  - conceptual
+  - how-to
   - identity-security
   - ai
 enterprise: Identity Security
+page_type: how-to
 ---
 
 Teleport Identity Security allows you to generate and view session recording
 summaries for shell and database sessions. This allows you to see at a glance
 what your users do and estimate legitimacy of their actions before digging
 deeper and reviewing the entire recording.
+
+In this guide, you will configure session recording summaries for your cluster.
 
 <Admonition type="note">
 **Session Recording Summaries and AI Usage**

--- a/docs/pages/identity-security/usage/alerts.mdx
+++ b/docs/pages/identity-security/usage/alerts.mdx
@@ -5,6 +5,7 @@ description: Describes the pre-built security detections that trigger alerts in 
 tags:
  - identity-security
 enterprise: Identity Security
+page_type: conceptual
 ---
 
 Teleport Identity Security provides pre-built security detections that automatically create alerts for suspicious identity-related activities across your infrastructure. These detections monitor events from Teleport and integrated services like AWS, GitHub, and Okta to identify potential security risks.
@@ -15,6 +16,9 @@ Teleport Identity Security alerts help you detect and respond to security threat
 - Configuration changes that affect security
 - Account compromises
 - Policy violations
+
+This page describes the available detection categories for Identity Security
+alerts and covers frequently asked questions.
 
 All detections are pre-configured and currently cannot be modified. The severity levels (Critical, High, Medium, Low) are defined by the Identity Security team based on the potential impact of each detection.
 

--- a/docs/pages/identity-security/usage/crown-jewels.mdx
+++ b/docs/pages/identity-security/usage/crown-jewels.mdx
@@ -3,10 +3,11 @@ title: See Permission Changes with Access Graph Crown Jewels
 sidebar_label: Crown Jewels
 description: Describes how to use Access Graph Crown Jewels to see permission changes in Teleport.
 tags:
- - conceptual
+ - how-to
  - identity-security
  - access-risks
 enterprise: Identity Security
+page_type: how-to
 ---
 
 Access Graph's Crown Jewels feature allows you to track changes to access for

--- a/docs/pages/identity-security/usage/graph-explorer.mdx
+++ b/docs/pages/identity-security/usage/graph-explorer.mdx
@@ -7,6 +7,7 @@ tags:
  - access-risks
  - conceptual
 enterprise: Identity Security
+page_type: conceptual
 ---
 
 The Graph Explorer view in Teleport Access Graph reveals access patterns within
@@ -19,6 +20,8 @@ against identity-based attacks.
 The Graph Explorer displays access controls from multiple systems in a single
 view, including Teleport roles and access controls from cloud providers, code
 repositories, and other [integrations](../integrations/integrations.mdx).
+
+This page describes the features of the Graph Explorer view.
 
 ## Using Graph Explorer
 

--- a/docs/pages/identity-security/usage/usage.mdx
+++ b/docs/pages/identity-security/usage/usage.mdx
@@ -6,6 +6,7 @@ tags:
  - identity-security
  - access-risks
 enterprise: Identity Security
+page_type: landing
 ---
 
 <Callout


### PR DESCRIPTION
Continues the work from the previous batch (#67674).

We are standardizing docs guides to add a `page_type` frontmatter field, with values for how-to guides, references, etc. We can then use this field to apply linting rules that ensure each guide type follows type-specific docs site conventions. The first convention is that each docs page must have an outcome statement, the structure of which depends on the guide's type. Human and AI agent readers can determine from the outcome statement whether to continue reading the guide or not.

This change assigns the `page_type` frontmatter field to 46 guides. Where an outcome statement is missing, it adds one. Where an outcome statement exists, it ensures that the statement matches the standard structure so we can add a linter later on.

Of the 46 guides:
- 12 guides already included the expected outcome statement, but needed a `page_type` frontmatter field.
- 19 guides included an outcome statement but required minor tweaks so they followed the expected structure.
- 15 guides had no outcome statement at all.