### PR TITLE
Add skip inactivity and timeline time updates to the desktop session player

### DIFF
--- a/web/packages/teleport/src/SessionRecordings/view/DesktopPlayer.test.tsx
+++ b/web/packages/teleport/src/SessionRecordings/view/DesktopPlayer.test.tsx
@@ -1,0 +1,210 @@
+/**
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { EventEmitter } from 'events';
+
+import { act, createRef } from 'react';
+
+import { fireEvent, render, screen } from 'design/utils/testing';
+
+import type { PlayerTimeAnchor } from 'teleport/lib/tdp';
+import {
+  SessionRecordingEventType,
+  type SessionRecordingEvent,
+} from 'teleport/services/recordings';
+import type { PlayerHandle } from 'teleport/SessionRecordings/view/SshPlayer';
+
+import { DesktopPlayer } from './DesktopPlayer';
+
+class FakePlayerClient {
+  private events = new EventEmitter();
+
+  connect = jest.fn().mockResolvedValue(undefined);
+  shutdown = jest.fn();
+  togglePlayPause = jest.fn();
+  setPlaySpeed = jest.fn();
+  seekTo = jest.fn((pos: number) => {
+    this.emitAnchor({ ms: pos, speed: 1, paused: false });
+  });
+
+  onTimeUpdate = this.listenerFor<[PlayerTimeAnchor]>('time');
+  onPlayerStatus = this.listenerFor('status');
+  onError = this.listenerFor('error');
+  onInfo = this.listenerFor('info');
+  onTransportOpen = this.listenerFor('open');
+  onTransportClose = this.listenerFor('close');
+  onPngFrame = this.listenerFor('png');
+  onBmpFrame = this.listenerFor('bmp');
+  onScreenSpec = this.listenerFor('spec');
+
+  emitTransportOpen() {
+    this.events.emit('open');
+  }
+
+  emitAnchor(anchor: PlayerTimeAnchor) {
+    this.events.emit('time', anchor);
+  }
+
+  private listenerFor<T extends unknown[]>(event: string) {
+    return (listener: (...args: T) => void) => {
+      this.events.on(event, listener);
+      return () => this.events.off(event, listener);
+    };
+  }
+}
+
+let mockPlayerClient: FakePlayerClient;
+
+jest.mock('teleport/lib/tdp', () => ({
+  PlayerClient: jest.fn().mockImplementation(() => mockPlayerClient),
+}));
+
+beforeEach(() => {
+  jest.useFakeTimers();
+  mockPlayerClient = new FakePlayerClient();
+});
+
+afterEach(() => {
+  jest.useRealTimers();
+});
+
+const INACTIVITY_EVENT: SessionRecordingEvent = {
+  type: SessionRecordingEventType.Inactivity,
+  startTime: 1000,
+  endTime: 5000,
+};
+
+function renderPlayer(
+  props: Partial<React.ComponentProps<typeof DesktopPlayer>> = {}
+) {
+  return render(
+    <DesktopPlayer
+      sid="test-session"
+      clusterId="test-cluster"
+      durationMs={60_000}
+      {...props}
+    />
+  );
+}
+
+function startPlayback() {
+  act(() => {
+    mockPlayerClient.emitTransportOpen();
+  });
+}
+
+function advance(ms: number) {
+  act(() => {
+    jest.advanceTimersByTime(ms);
+  });
+}
+
+test('emits rAF-smoothed time updates from time anchors', () => {
+  const onTimeChange = jest.fn();
+  renderPlayer({ onTimeChange });
+  startPlayback();
+
+  act(() => {
+    mockPlayerClient.emitAnchor({ ms: 1000, speed: 1, paused: false });
+  });
+  advance(500);
+
+  const times = onTimeChange.mock.calls.map(call => call[0] as number);
+  const last = times.at(-1);
+
+  expect(last).toBeGreaterThanOrEqual(1400);
+  expect(last).toBeLessThanOrEqual(1600);
+  // time advances monotonically across frames
+  expect(times).toEqual([...times].sort((a, b) => a - b));
+});
+
+test('interpolates at the anchor speed', () => {
+  const onTimeChange = jest.fn();
+  renderPlayer({ onTimeChange });
+  startPlayback();
+
+  act(() => {
+    mockPlayerClient.emitAnchor({ ms: 1000, speed: 4, paused: false });
+  });
+  advance(500);
+
+  const last = onTimeChange.mock.calls.at(-1)[0] as number;
+
+  expect(last).toBeGreaterThanOrEqual(2600);
+  expect(last).toBeLessThanOrEqual(3400);
+});
+
+test('holds the time while paused', () => {
+  const onTimeChange = jest.fn();
+  renderPlayer({ onTimeChange });
+  startPlayback();
+
+  act(() => {
+    mockPlayerClient.emitAnchor({ ms: 2000, speed: 1, paused: true });
+  });
+  advance(500);
+
+  expect(onTimeChange.mock.calls.at(-1)[0]).toBe(2000);
+});
+
+test('shows the skip button during an inactivity period and seeks past it', () => {
+  renderPlayer({ events: [INACTIVITY_EVENT] });
+  startPlayback();
+
+  act(() => {
+    mockPlayerClient.emitAnchor({ ms: 2000, speed: 1, paused: true });
+  });
+  advance(100);
+
+  fireEvent.click(screen.getByText(/of inactivity/));
+
+  expect(mockPlayerClient.seekTo).toHaveBeenCalledWith(5001);
+});
+
+test('does not show the skip button outside inactivity periods', () => {
+  renderPlayer({ events: [INACTIVITY_EVENT] });
+  startPlayback();
+
+  act(() => {
+    mockPlayerClient.emitAnchor({ ms: 8000, speed: 1, paused: true });
+  });
+  advance(100);
+
+  expect(screen.queryByText(/of inactivity/)).not.toBeInTheDocument();
+});
+
+test('seeks the player through the moveToTime handle', () => {
+  const ref = createRef<PlayerHandle>();
+  renderPlayer({ ref });
+  startPlayback();
+
+  act(() => {
+    ref.current.moveToTime(10_000);
+  });
+
+  expect(mockPlayerClient.seekTo).toHaveBeenCalledWith(10_000);
+});
+
+test('renders without metadata props', () => {
+  renderPlayer();
+  startPlayback();
+  advance(100);
+
+  expect(mockPlayerClient.connect).toHaveBeenCalled();
+  expect(screen.queryByText(/of inactivity/)).not.toBeInTheDocument();
+});

--- a/web/packages/teleport/src/SessionRecordings/view/DesktopPlayer.tsx
+++ b/web/packages/teleport/src/SessionRecordings/view/DesktopPlayer.tsx
@@ -288,10 +288,14 @@ const useDesktopPlayer = ({
         durationMs
       );
 
-      currentTimeRef.current = current;
+      // Skip while the time is unchanged (paused, loading, complete) to avoid
+      // redrawing the timeline and rescanning events every frame.
+      if (current !== currentTimeRef.current) {
+        currentTimeRef.current = current;
 
-      onTimeChange?.(current);
-      eventInfoRef.current?.setTime(current);
+        onTimeChange?.(current);
+        eventInfoRef.current?.setTime(current);
+      }
 
       if (
         !progressSuspendedRef.current &&

--- a/web/packages/teleport/src/SessionRecordings/view/DesktopPlayer.tsx
+++ b/web/packages/teleport/src/SessionRecordings/view/DesktopPlayer.tsx
@@ -16,7 +16,16 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import {
+  useCallback,
+  useEffect,
+  useImperativeHandle,
+  useMemo,
+  useRef,
+  useState,
+  type Ref,
+  type RefObject,
+} from 'react';
 import styled from 'styled-components';
 
 import { Alert, Box, Flex, Indicator } from 'design';
@@ -28,52 +37,73 @@ import { useListener } from 'shared/libs/tdp';
 
 import cfg from 'teleport/config';
 import { formatDisplayTime, StatusEnum } from 'teleport/lib/player';
-import { PlayerClient } from 'teleport/lib/tdp';
+import { PlayerClient, type PlayerTimeAnchor } from 'teleport/lib/tdp';
 import { getHostName } from 'teleport/services/api';
+import type { SessionRecordingEvent } from 'teleport/services/recordings';
 
+import {
+  CurrentEventInfo,
+  type CurrentEventInfoHandle,
+} from './CurrentEventInfo';
 import ProgressBar from './ProgressBar';
+import type { PlayerHandle } from './SshPlayer';
 
 const reload = () => window.location.reload();
+
+// how often the React-rendered ProgressBar is updated (instead of every animation frame)
+const PROGRESS_UPDATE_INTERVAL_MS = 50;
+
+interface DesktopPlayerProps {
+  clusterId: string;
+  durationMs: number;
+  /** Enables the current event overlay (e.g. the skip inactivity button). */
+  events?: SessionRecordingEvent[];
+  onTimeChange?: (time: number) => void;
+  ref?: Ref<PlayerHandle>;
+  sid: string;
+}
 
 export const DesktopPlayer = ({
   sid,
   clusterId,
   durationMs,
-}: {
-  sid: string;
-  clusterId: string;
-  durationMs: number;
-}) => {
+  events,
+  onTimeChange,
+  ref,
+}: DesktopPlayerProps) => {
+  const canvasRendererRef = useRef<CanvasRendererRef>(null);
+  const eventInfoRef = useRef<CurrentEventInfoHandle>(null);
+
   const {
     playerClient,
     playerStatus,
     statusText,
     time,
 
-    clientOnTransportOpen,
-    clientOnTransportClose,
-    clientOnError,
-    clientOnTdpInfo,
+    seekTo,
+    setPlaySpeed,
+    suspendProgressUpdates,
+    togglePlayPause,
   } = useDesktopPlayer({
     sid,
     clusterId,
+    durationMs,
+    eventInfoRef,
+    onTimeChange,
   });
-  const canvasRendererRef = useRef<CanvasRendererRef>(null);
 
-  useListener(playerClient?.onError, clientOnError);
-  useListener(playerClient?.onInfo, clientOnTdpInfo);
-  useListener(playerClient?.onTransportOpen, clientOnTransportOpen);
-  useListener(playerClient?.onTransportClose, clientOnTransportClose);
+  useImperativeHandle(ref, () => ({ moveToTime: seekTo }), [seekTo]);
+
   useListener(
-    playerClient?.onPngFrame,
+    playerClient.onPngFrame,
     canvasRendererRef.current?.renderPngFrame
   );
   useListener(
-    playerClient?.onBmpFrame,
+    playerClient.onBmpFrame,
     canvasRendererRef.current?.renderBitmapFrame
   );
   useListener(
-    playerClient?.onScreenSpec,
+    playerClient.onScreenSpec,
     canvasRendererRef.current?.setResolution
   );
 
@@ -98,6 +128,14 @@ export const DesktopPlayer = ({
       <StyledContainer>
         <CanvasRenderer ref={canvasRendererRef} />
 
+        {events && (
+          <CurrentEventInfo
+            events={events}
+            onSeek={seekTo}
+            ref={eventInfoRef}
+          />
+        )}
+
         <ProgressBar
           min={0}
           max={durationMs}
@@ -106,41 +144,96 @@ export const DesktopPlayer = ({
           isPlaying={isPlaying}
           time={formatDisplayTime(t)}
           onRestart={reload}
-          onStartMove={() => playerClient.suspendTimeUpdates()}
-          move={pos => {
-            playerClient.resumeTimeUpdates();
-            playerClient.seekTo(pos);
-          }}
-          onPlaySpeedChange={s => playerClient.setPlaySpeed(s)}
-          toggle={() => playerClient.togglePlayPause()}
+          onStartMove={suspendProgressUpdates}
+          move={seekTo}
+          onPlaySpeedChange={setPlaySpeed}
+          toggle={togglePlayPause}
         />
       </StyledContainer>
     </StyledPlayer>
   );
 };
 
-const useDesktopPlayer = ({ clusterId, sid }) => {
+interface TimeAnchor extends PlayerTimeAnchor {
+  receivedAt: number;
+}
+
+const useDesktopPlayer = ({
+  clusterId,
+  durationMs,
+  eventInfoRef,
+  onTimeChange,
+  sid,
+}: {
+  clusterId: string;
+  durationMs: number;
+  eventInfoRef: RefObject<CurrentEventInfoHandle | null>;
+  onTimeChange?: (time: number) => void;
+  sid: string;
+}) => {
   const [time, setTime] = useState(0);
   const [playerStatus, setPlayerStatus] = useState(StatusEnum.LOADING);
   const [statusText, setStatusText] = useState('');
+
+  // latest authoritative playback position, interpolated between by the rAF loop
+  const anchorRef = useRef<TimeAnchor>({
+    ms: 0,
+    speed: 1,
+    paused: true,
+    receivedAt: 0,
+  });
+  // interpolated time as of the last frame, used to rebase on pause/play/speed changes
+  const currentTimeRef = useRef(0);
+  const lastProgressUpdateRef = useRef(0);
+  // progress bar updates are suspended while the user drags the slider
+  const progressSuspendedRef = useRef(false);
 
   const playerClient = useMemo(() => {
     const url = cfg.api.desktopPlaybackWsAddr
       .replace(':fqdn', getHostName())
       .replace(':clusterId', clusterId)
       .replace(':sid', sid);
-    return new PlayerClient({ url, setTime, setPlayerStatus, setStatusText });
+    return new PlayerClient({ url });
   }, [clusterId, sid]);
+
+  const rebaseAnchor = useCallback((changes: Partial<PlayerTimeAnchor>) => {
+    anchorRef.current = {
+      ...anchorRef.current,
+      ms: currentTimeRef.current,
+      receivedAt: performance.now(),
+      ...changes,
+    };
+  }, []);
+
+  const handleTimeUpdate = useCallback((anchor: PlayerTimeAnchor) => {
+    anchorRef.current = { ...anchor, receivedAt: performance.now() };
+  }, []);
+
+  const handlePlayerStatus = useCallback(
+    (status: StatusEnum) => {
+      setPlayerStatus(status);
+
+      if (status === StatusEnum.PLAYING || status === StatusEnum.PAUSED) {
+        rebaseAnchor({ paused: status === StatusEnum.PAUSED });
+      }
+    },
+    [rebaseAnchor]
+  );
 
   const clientOnTransportOpen = useCallback(() => {
     setPlayerStatus(StatusEnum.PLAYING);
+    anchorRef.current = {
+      ms: 0,
+      speed: anchorRef.current.speed,
+      paused: false,
+      receivedAt: performance.now(),
+    };
   }, []);
 
   const clientOnTransportClose = useCallback(() => {
-    if (playerClient) {
-      playerClient.cancelTimeUpdate();
-    }
-  }, [playerClient]);
+    // freeze the clock, there will be no more authoritative positions
+    rebaseAnchor({ paused: true });
+  }, [rebaseAnchor]);
 
   const clientOnError = useCallback((error: Error) => {
     setPlayerStatus(StatusEnum.ERROR);
@@ -152,15 +245,76 @@ const useDesktopPlayer = ({ clusterId, sid }) => {
     setStatusText(info);
   }, []);
 
+  useListener(playerClient.onTimeUpdate, handleTimeUpdate);
+  useListener(playerClient.onPlayerStatus, handlePlayerStatus);
+  useListener(playerClient.onError, clientOnError);
+  useListener(playerClient.onInfo, clientOnTdpInfo);
+  useListener(playerClient.onTransportOpen, clientOnTransportOpen);
+  useListener(playerClient.onTransportClose, clientOnTransportClose);
+
+  const seekTo = useCallback(
+    (pos: number) => {
+      progressSuspendedRef.current = false;
+      playerClient.seekTo(pos);
+      setTime(pos);
+    },
+    [playerClient]
+  );
+
+  const setPlaySpeed = useCallback(
+    (speed: number) => {
+      rebaseAnchor({ speed });
+      playerClient.setPlaySpeed(speed);
+    },
+    [playerClient, rebaseAnchor]
+  );
+
+  const suspendProgressUpdates = useCallback(() => {
+    progressSuspendedRef.current = true;
+  }, []);
+
+  const togglePlayPause = useCallback(() => {
+    playerClient.togglePlayPause();
+  }, [playerClient]);
+
   useEffect(() => {
-    if (!playerClient) {
-      return;
-    }
+    let handle = 0;
+
+    const update = () => {
+      const { ms, speed, paused, receivedAt } = anchorRef.current;
+      const now = performance.now();
+      const current = Math.min(
+        paused ? ms : ms + (now - receivedAt) * speed,
+        durationMs
+      );
+
+      currentTimeRef.current = current;
+
+      onTimeChange?.(current);
+      eventInfoRef.current?.setTime(current);
+
+      if (
+        !progressSuspendedRef.current &&
+        now - lastProgressUpdateRef.current >= PROGRESS_UPDATE_INTERVAL_MS
+      ) {
+        lastProgressUpdateRef.current = now;
+        setTime(current);
+      }
+
+      handle = requestAnimationFrame(update);
+    };
+
+    handle = requestAnimationFrame(update);
+
+    return () => cancelAnimationFrame(handle);
+  }, [durationMs, onTimeChange, eventInfoRef]);
+
+  useEffect(() => {
     playerClient.connect().catch(clientOnError);
     return () => {
       playerClient.shutdown();
     };
-  }, [playerClient]);
+  }, [playerClient, clientOnError]);
 
   return {
     time,
@@ -168,10 +322,10 @@ const useDesktopPlayer = ({ clusterId, sid }) => {
     playerStatus,
     statusText,
 
-    clientOnTransportOpen,
-    clientOnTransportClose,
-    clientOnError,
-    clientOnTdpInfo,
+    seekTo,
+    setPlaySpeed,
+    suspendProgressUpdates,
+    togglePlayPause,
   };
 };
 
@@ -191,6 +345,7 @@ const DesktopPlayerAlert = styled(Alert)`
 `;
 
 const StyledContainer = styled(Flex)`
+  position: relative;
   flex-direction: column;
   justify-content: center;
   width: 100%;

--- a/web/packages/teleport/src/SessionRecordings/view/DesktopPlayer.tsx
+++ b/web/packages/teleport/src/SessionRecordings/view/DesktopPlayer.tsx
@@ -175,7 +175,7 @@ const useDesktopPlayer = ({
   const [playerStatus, setPlayerStatus] = useState(StatusEnum.LOADING);
   const [statusText, setStatusText] = useState('');
 
-  // latest authoritative playback position, interpolated between by the rAF loop
+  // latest authoritative playback position, interpolated between by the requestAnimationFrame loop
   const anchorRef = useRef<TimeAnchor>({
     ms: 0,
     speed: 1,

--- a/web/packages/teleport/src/SessionRecordings/view/RecordingPlayer.tsx
+++ b/web/packages/teleport/src/SessionRecordings/view/RecordingPlayer.tsx
@@ -89,6 +89,9 @@ export function RecordingPlayer({
           sid={sessionId}
           clusterId={clusterId}
           durationMs={durationMs}
+          events={events}
+          onTimeChange={onTimeChange}
+          ref={ref}
         />
       </Container>
     );

--- a/web/packages/teleport/src/lib/tdp/index.ts
+++ b/web/packages/teleport/src/lib/tdp/index.ts
@@ -16,5 +16,5 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-export { PlayerClient } from './playerClient';
+export { PlayerClient, type PlayerTimeAnchor } from './playerClient';
 export { adaptWebSocketToTdpTransport } from './webSocketTransportAdapter';

--- a/web/packages/teleport/src/lib/tdp/playerClient.test.ts
+++ b/web/packages/teleport/src/lib/tdp/playerClient.test.ts
@@ -1,0 +1,168 @@
+/**
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { TdpCodec } from 'shared/libs/tdp';
+
+import { StatusEnum } from 'teleport/lib/player';
+
+import { PlayerClient, type PlayerTimeAnchor } from './playerClient';
+
+const encoder = new TextEncoder();
+const codec = new TdpCodec();
+
+function makeClient() {
+  const client = new PlayerClient({ url: 'wss://localhost/playback' });
+  // connect() is what normally initializes the codec and transport
+  (client as unknown as { codec: TdpCodec }).codec = new TdpCodec();
+  const send = jest.fn();
+  jest
+    .spyOn(client as unknown as { send: (data: string) => void }, 'send')
+    .mockImplementation(send);
+
+  const anchors: PlayerTimeAnchor[] = [];
+  const statuses: StatusEnum[] = [];
+  client.onTimeUpdate(anchor => anchors.push(anchor));
+  client.onPlayerStatus(status => statuses.push(status));
+
+  return { client, anchors, statuses, send };
+}
+
+function toBase64(buffer: ArrayBufferLike) {
+  return btoa(String.fromCharCode(...new Uint8Array(buffer)));
+}
+
+// recordingMessage builds a playback message as sent by the server: a JSON wrapper
+// with the playback timestamp and a base64-encoded TDP message (a real client screen
+// spec, the simplest message that round-trips without a transport).
+function recordingMessage(ms: number) {
+  const screenSpec = codec.encodeClientScreenSpec({
+    width: 1920,
+    height: 1080,
+    scale: 1,
+  });
+
+  return encoder.encode(JSON.stringify({ ms, message: toBase64(screenSpec) }))
+    .buffer as ArrayBuffer;
+}
+
+function controlMessage(json: object) {
+  return encoder.encode(JSON.stringify(json)).buffer as ArrayBuffer;
+}
+
+test('emits a time anchor for every server message', async () => {
+  const { client, anchors } = makeClient();
+
+  await client.processMessage(recordingMessage(1000));
+  await client.processMessage(recordingMessage(2000));
+
+  expect(anchors).toEqual([
+    { ms: 1000, speed: 1, paused: false },
+    { ms: 2000, speed: 1, paused: false },
+  ]);
+});
+
+test('emits an optimistic anchor on seek and suppresses anchors until the replay catches up', async () => {
+  const { client, anchors } = makeClient();
+
+  await client.processMessage(recordingMessage(1000));
+
+  client.seekTo(5000);
+
+  await client.processMessage(recordingMessage(2000));
+  await client.processMessage(recordingMessage(5000));
+  await client.processMessage(recordingMessage(6000));
+
+  expect(anchors.map(a => a.ms)).toEqual([1000, 5000, 5000, 6000]);
+});
+
+test('suppresses anchors during a backwards seek until the replay reaches the target', async () => {
+  const { client, anchors } = makeClient();
+
+  await client.processMessage(recordingMessage(5000));
+
+  client.seekTo(2000);
+
+  await client.processMessage(recordingMessage(100));
+  await client.processMessage(recordingMessage(2000));
+
+  expect(anchors.map(a => a.ms)).toEqual([5000, 2000, 2000]);
+});
+
+test('emits player status instead of time anchors on play/pause', () => {
+  const { client, anchors, statuses } = makeClient();
+
+  client.togglePlayPause();
+  client.togglePlayPause();
+
+  expect(statuses).toEqual([StatusEnum.PAUSED, StatusEnum.PLAYING]);
+  expect(anchors).toHaveLength(0);
+});
+
+test('does not emit time anchors on speed changes', () => {
+  const { client, anchors } = makeClient();
+
+  client.setPlaySpeed(2);
+
+  expect(anchors).toHaveLength(0);
+});
+
+test('reflects the paused state and speed in subsequent anchors', async () => {
+  const { client, anchors } = makeClient();
+
+  client.togglePlayPause();
+  client.setPlaySpeed(2);
+
+  await client.processMessage(recordingMessage(1000));
+
+  expect(anchors).toEqual([{ ms: 1000, speed: 2, paused: true }]);
+});
+
+test('emits a complete status on the end message', async () => {
+  const { client, statuses } = makeClient();
+
+  await client.processMessage(controlMessage({ message: 'end' }));
+
+  expect(statuses).toEqual([StatusEnum.COMPLETE]);
+});
+
+test('emits an error on the error message', async () => {
+  const { client } = makeClient();
+
+  const errors: Error[] = [];
+  client.onError(error => errors.push(error));
+
+  await client.processMessage(
+    controlMessage({ message: 'error', errorText: 'playback failed' })
+  );
+
+  expect(errors).toEqual([new Error('playback failed')]);
+});
+
+test('sends actions over the transport', () => {
+  const { client, send } = makeClient();
+
+  client.togglePlayPause();
+  client.setPlaySpeed(2);
+  client.seekTo(1000);
+
+  expect(send.mock.calls.map(call => JSON.parse(call[0]))).toEqual([
+    { action: 'play/pause' },
+    { action: 'speed', speed: 2 },
+    { action: 'seek', pos: 1000 },
+  ]);
+});

--- a/web/packages/teleport/src/lib/tdp/playerClient.ts
+++ b/web/packages/teleport/src/lib/tdp/playerClient.ts
@@ -16,6 +16,8 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+import { EventEmitter } from 'events';
+
 import {
   ClientScreenSpec,
   selectDirectoryInBrowser,
@@ -24,17 +26,11 @@ import {
   TdpClientEvent,
 } from 'shared/libs/tdp';
 import { base64ToArrayBuffer } from 'shared/utils/base64';
-import { throttle } from 'shared/utils/highbar';
 
 import { AuthenticatedWebSocket } from 'teleport/lib/AuthenticatedWebSocket';
 import { StatusEnum } from 'teleport/lib/player';
 
 import { adaptWebSocketToTdpTransport } from './webSocketTransportAdapter';
-
-// we update the time every time we receive data, or
-// at this interval (which ensures that the progress
-// bar updates even when we aren't receiving data)
-const PROGRESS_UPDATE_INTERVAL_MS = 50;
 
 enum Action {
   TOGGLE_PLAY_PAUSE = 'play/pause',
@@ -42,94 +38,73 @@ enum Action {
   SEEK = 'seek',
 }
 
+enum PlayerClientEvent {
+  TIME_UPDATE = 'time update',
+  PLAYER_STATUS = 'player status',
+}
+
+/**
+ * PlayerTimeAnchor is an authoritative playback position. Anchors are only emitted
+ * when the client learns the real position (a server message or a seek) - consumers
+ * are expected to interpolate between anchors using the speed and paused flags.
+ */
+export interface PlayerTimeAnchor {
+  ms: number;
+  speed: number;
+  paused: boolean;
+}
+
+type PlayerEventMap = {
+  [PlayerClientEvent.TIME_UPDATE]: [PlayerTimeAnchor];
+  [PlayerClientEvent.PLAYER_STATUS]: [StatusEnum];
+};
+
 export class PlayerClient extends TdpClient {
   private textDecoder = new TextDecoder();
-  private setPlayerStatus: React.Dispatch<React.SetStateAction<StatusEnum>>;
-  private setStatusText: React.Dispatch<React.SetStateAction<string>>;
-  private _setTime: React.Dispatch<React.SetStateAction<number>>;
-  private setTime: React.Dispatch<React.SetStateAction<number>>;
+  private playerEvents = new EventEmitter<PlayerEventMap>();
 
   private speed = 1.0;
   private paused = false;
 
   private lastPlayedTimestamp = 0;
-  private skipTimeUpdatesUntil = null;
-  private lastTimestamp = 0;
-  private sendTimeUpdates = true;
-  private lastUpdateTime = 0;
-  private timeout = null;
+  private skipTimeUpdatesUntil: number | null = null;
   private tdpbCodec = new TdpbCodec();
 
-  constructor({ url, setTime, setPlayerStatus, setStatusText }) {
+  constructor({ url }: { url: string }) {
     super(
       signal =>
         adaptWebSocketToTdpTransport(new AuthenticatedWebSocket(url), signal),
       selectDirectoryInBrowser
     );
-    this.setPlayerStatus = setPlayerStatus;
-    this.setStatusText = setStatusText;
-    this._setTime = setTime;
-    this.setTime = throttle(t => {
-      // time updates are suspended when a user is dragging the slider to
-      // a new position (it's very disruptive if we're updating the slider
-      // position every few milliseconds while the user is trying to
-      // reposition it)
-      if (this.sendTimeUpdates) {
-        this._setTime(t);
-      }
-      this.lastTimestamp = t;
-      this.lastUpdateTime = Date.now();
-    }, PROGRESS_UPDATE_INTERVAL_MS);
   }
 
-  scheduleNextUpdate(current: number) {
-    this.timeout = setTimeout(() => {
-      const delta = Date.now() - this.lastUpdateTime;
-      const next = current + delta * this.speed;
+  onTimeUpdate = (listener: (anchor: PlayerTimeAnchor) => void) => {
+    this.playerEvents.on(PlayerClientEvent.TIME_UPDATE, listener);
+    return () => this.playerEvents.off(PlayerClientEvent.TIME_UPDATE, listener);
+  };
 
-      this.setTime(next);
-      this.lastUpdateTime = Date.now();
+  onPlayerStatus = (listener: (status: StatusEnum) => void) => {
+    this.playerEvents.on(PlayerClientEvent.PLAYER_STATUS, listener);
+    return () =>
+      this.playerEvents.off(PlayerClientEvent.PLAYER_STATUS, listener);
+  };
 
-      this.scheduleNextUpdate(next);
-    }, PROGRESS_UPDATE_INTERVAL_MS);
-  }
-
-  cancelTimeUpdate() {
-    if (this.timeout != null) {
-      clearTimeout(this.timeout);
-      this.timeout = null;
-    }
-  }
-
-  suspendTimeUpdates() {
-    this.sendTimeUpdates = false;
-  }
-
-  resumeTimeUpdates() {
-    this.sendTimeUpdates = true;
+  private emitTimeAnchor(ms: number) {
+    this.playerEvents.emit(PlayerClientEvent.TIME_UPDATE, {
+      ms,
+      speed: this.speed,
+      paused: this.paused,
+    });
   }
 
   // togglePlayPause toggles the playback system between "playing" and "paused" states.
   togglePlayPause() {
     this.paused = !this.paused;
-    this.setPlayerStatus(this.paused ? StatusEnum.PAUSED : StatusEnum.PLAYING);
-    if (this.paused) {
-      this.cancelTimeUpdate();
-    }
-
-    this.lastUpdateTime = Date.now();
+    this.playerEvents.emit(
+      PlayerClientEvent.PLAYER_STATUS,
+      this.paused ? StatusEnum.PAUSED : StatusEnum.PLAYING
+    );
     this.send(JSON.stringify({ action: Action.TOGGLE_PLAY_PAUSE }));
-
-    if (this.paused) {
-      return;
-    }
-
-    if (this.isSeekingForward()) {
-      const next = Math.max(this.skipTimeUpdatesUntil, this.lastTimestamp);
-      this.scheduleNextUpdate(next);
-    } else {
-      this.scheduleNextUpdate(this.lastTimestamp);
-    }
   }
 
   // setPlaySpeed sets the playback speed of the recording.
@@ -143,15 +118,14 @@ export class PlayerClient extends TdpClient {
     const json = JSON.parse(this.textDecoder.decode(buffer));
 
     if (json.message === 'end') {
-      this.setPlayerStatus(StatusEnum.COMPLETE);
+      this.playerEvents.emit(
+        PlayerClientEvent.PLAYER_STATUS,
+        StatusEnum.COMPLETE
+      );
     } else if (json.message === 'error') {
-      this.setPlayerStatus(StatusEnum.ERROR);
-      this.setStatusText(json.errorText);
+      this.emit(TdpClientEvent.ERROR, new Error(json.errorText));
     } else {
-      this.cancelTimeUpdate();
       this.lastPlayedTimestamp = json.ms;
-      this.lastUpdateTime = Date.now();
-      this.setTime(json.ms);
 
       // clear seek state if we caught up to the seek point
       if (
@@ -161,19 +135,9 @@ export class PlayerClient extends TdpClient {
         this.skipTimeUpdatesUntil = null;
       }
 
-      if (!this.isSeekingForward()) {
-        this.cancelTimeUpdate();
-      }
-
-      // schedule the next time update, which ensures that
-      // the progress bar continues to update even if this
-      // section of the recording is idle time
-      //
-      // note: we don't schedule an update if we're currently
-      // seeking forward in time, as we're trying to get there
-      // as quickly as possible
-      if (!this.paused && !this.isSeekingForward()) {
-        this.scheduleNextUpdate(json.ms);
+      // no time anchors while catching up to a seek (seekTo already emitted the target)
+      if (this.skipTimeUpdatesUntil === null) {
+        this.emitTimeAnchor(json.ms);
       }
 
       // Handle TDPB recordings by switching to the TDPB codec
@@ -190,26 +154,10 @@ export class PlayerClient extends TdpClient {
   }
 
   seekTo(pos: number) {
-    this.cancelTimeUpdate();
-
     this.send(JSON.stringify({ action: Action.SEEK, pos }));
 
-    this._setTime(pos);
-    this.lastUpdateTime = Date.now();
     this.skipTimeUpdatesUntil = pos;
-
-    if (pos < this.lastPlayedTimestamp) {
-      // TODO: clear canvas
-    } else if (!this.paused) {
-      this.scheduleNextUpdate(pos);
-    }
-  }
-
-  isSeekingForward(): boolean {
-    return (
-      this.skipTimeUpdatesUntil !== null &&
-      this.skipTimeUpdatesUntil > this.lastPlayedTimestamp
-    );
+    this.emitTimeAnchor(pos);
   }
 
   // Overrides Client implementation.


### PR DESCRIPTION
This updates the desktop player to emit time updates that the timeline can use (smoothed out through `rAF`) so the timeline player head scrolls as the desktop session is played.

I opted to move all the React state callbacks out of the player instead of just doing it for time, so we're consistent in how the player emits events.

Adds the "Skip inactivity" button that the SSH player has.

Changelog: Long periods of inactivity can now be skipped when playing back new desktop sessions

## Manual Test Plan
### Test Environment
Cloud

### Test Cases
- [x] Desktop sessions playback correctly
- [x] Timeline head moves as the session plays
- [x] Periods of inactivity show the skip button and can be skipped
