### PR TITLE
Adjust `provision.Token` interface to unsplit Bot accessor in prep for SQN

### DIFF
--- a/api/types/provisioning.go
+++ b/api/types/provisioning.go
@@ -178,9 +178,6 @@ type ProvisionToken interface {
 	GetJoinMethod() JoinMethod
 	// GetBotName returns the BotName field which must be set for joining bots.
 	GetBotName() string
-	// GetBotScope returns the BotScope field which must be set for bots joining
-	// with a scoped token. It is empty for unscoped bots.
-	GetBotScope() string
 	// IsStatic returns true if the token is statically configured
 	IsStatic() bool
 	// GetSuggestedLabels returns the set of labels that the resource should add when adding itself to the cluster
@@ -612,13 +609,6 @@ func (p *ProvisionTokenV2) IsStatic() bool {
 // GetBotName returns the BotName field which must be set for joining bots.
 func (p *ProvisionTokenV2) GetBotName() string {
 	return p.Spec.BotName
-}
-
-// GetBotScope returns the BotScope field which must be set for bots joining
-// with a scoped token. It is empty for unscoped bots.
-func (p *ProvisionTokenV2) GetBotScope() string {
-	// Always empty for ProvisionTokenV2
-	return ""
 }
 
 // GetKind returns resource kind

--- a/lib/auth/join.go
+++ b/lib/auth/join.go
@@ -69,7 +69,7 @@ func (a *Server) checkTokenJoinRequestCommon(ctx context.Context, req *types.Reg
 		return nil, trace.AccessDenied("%q can not join the cluster with role %q, %s", req.NodeName, req.Role, msg)
 	}
 
-	if err := join.TokenAllowsRole(provisionToken, req.Role); err != nil {
+	if err := join.TokenAllowsRole(provision.UnscopedToken{ProvisionToken: provisionToken}, req.Role); err != nil {
 		return nil, trace.Wrap(err)
 	}
 	return provisionToken, nil
@@ -136,11 +136,6 @@ func (a *Server) handleJoinFailure(
 			botJoinEvent.Method = string(pt.GetJoinMethod())
 			botJoinEvent.TokenName = pt.GetSafeName()
 			botJoinEvent.BotName = pt.GetBotName()
-
-			// We don't want to perform a backend fetch here, so we'll use the
-			// bot scope indicated in the token rather than the one embedded in
-			// the user.
-			botJoinEvent.Scope = pt.GetBotScope()
 		}
 		evt = botJoinEvent
 	} else {
@@ -318,9 +313,9 @@ func (a *Server) RegisterUsingToken(ctx context.Context, req *types.RegisterUsin
 	// With all elements of the token validated, we can now generate & return
 	// certificates.
 	if req.Role == types.RoleBot {
-		certs, _, err = a.GenerateBotCertsForJoin(ctx, provisionToken, makeBotCertsParams(req, rawClaims, attrs))
+		certs, _, err = a.GenerateBotCertsForJoin(ctx, provision.UnscopedToken{ProvisionToken: provisionToken}, makeBotCertsParams(req, rawClaims, attrs))
 	} else {
-		certs, err = a.GenerateHostCertsForJoin(ctx, provisionToken, makeHostCertsParams(req, rawClaims))
+		certs, err = a.GenerateHostCertsForJoin(ctx, provision.UnscopedToken{ProvisionToken: provisionToken}, makeHostCertsParams(req, rawClaims))
 	}
 	return certs, trace.Wrap(err)
 }
@@ -361,7 +356,7 @@ func (a *Server) GenerateBotCertsForJoin(
 ) (*proto.Certs, string, error) {
 	// bots use this endpoint but get a user cert
 	// botResourceName must be set, enforced in CheckAndSetDefaults
-	botName := token.GetBotName()
+	botName := token.GetBot().Name
 	joinMethod := token.GetJoinMethod()
 
 	// Check this is a join method for bots we support.
@@ -463,7 +458,7 @@ func (a *Server) GenerateBotCertsForJoin(
 			return nil, "", trace.AccessDenied("scoped token usage mode must be 'bot' for bot joining")
 		}
 
-		tokenBotScope := scoped.GetScoped().GetSpec().GetBotScope()
+		tokenBotScope := scoped.GetBot().Scope
 		if botScope != tokenBotScope {
 			a.logger.WarnContext(ctx, "bot scope must match token scope",
 				"token_scope", tokenBotScope,

--- a/lib/auth/join_azure_devops.go
+++ b/lib/auth/join_azure_devops.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/join/azuredevops"
+	"github.com/gravitational/teleport/lib/join/provision"
 )
 
 func (a *Server) checkAzureDevopsJoinRequest(
@@ -41,7 +42,7 @@ func (a *Server) checkAzureDevopsJoinRequest(
 	}
 
 	claims, err := azuredevops.CheckIDToken(ctx, &azuredevops.CheckIDTokenParams{
-		ProvisionToken: token,
+		ProvisionToken: provision.UnscopedToken{ProvisionToken: token},
 		IDToken:        req.IDToken,
 		Validator:      a.azureDevopsIDTokenValidator,
 	})

--- a/lib/auth/join_azure_legacy.go
+++ b/lib/auth/join_azure_legacy.go
@@ -29,6 +29,7 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/join/azurejoin"
 	"github.com/gravitational/teleport/lib/join/legacyjoin"
+	"github.com/gravitational/teleport/lib/join/provision"
 )
 
 // RegisterUsingAzureMethod registers the caller using the Azure join method
@@ -85,7 +86,7 @@ func (a *Server) RegisterUsingAzureMethod(
 
 	joinAttrs, err := azurejoin.CheckAzureRequest(ctx, azurejoin.CheckAzureRequestParams{
 		AzureJoinConfig: a.GetAzureJoinConfig(),
-		Token:           ptv2,
+		Token:           provision.UnscopedToken{ProvisionToken: ptv2},
 		Challenge:       challenge,
 		AttestedData:    req.AttestedData,
 		AccessToken:     req.AccessToken,
@@ -100,11 +101,11 @@ func (a *Server) RegisterUsingAzureMethod(
 		params := makeBotCertsParams(req.RegisterUsingTokenRequest, nil /*rawClaims*/, workloadidentityv1pb.JoinAttrs_builder{
 			Azure: joinAttrs,
 		}.Build())
-		certs, _, err := a.GenerateBotCertsForJoin(ctx, provisionToken, params)
+		certs, _, err := a.GenerateBotCertsForJoin(ctx, provision.UnscopedToken{ProvisionToken: provisionToken}, params)
 		return certs, trace.Wrap(err)
 	}
 	params := makeHostCertsParams(req.RegisterUsingTokenRequest, nil /*rawClaims*/)
-	certs, err = a.GenerateHostCertsForJoin(ctx, provisionToken, params)
+	certs, err = a.GenerateHostCertsForJoin(ctx, provision.UnscopedToken{ProvisionToken: provisionToken}, params)
 	return certs, trace.Wrap(err)
 }
 

--- a/lib/auth/join_bitbucket.go
+++ b/lib/auth/join_bitbucket.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/join/bitbucket"
+	"github.com/gravitational/teleport/lib/join/provision"
 )
 
 // GetBitbucketIDTokenValidator returns the currently configured token validator
@@ -45,7 +46,7 @@ func (a *Server) checkBitbucketJoinRequest(
 	pt types.ProvisionToken,
 ) (*bitbucket.IDTokenClaims, error) {
 	claims, err := bitbucket.CheckIDToken(ctx, &bitbucket.CheckIDTokenParams{
-		ProvisionToken: pt,
+		ProvisionToken: provision.UnscopedToken{ProvisionToken: pt},
 		IDToken:        []byte(req.IDToken),
 		Clock:          a.GetClock(),
 		Validator:      a.bitbucketIDTokenValidator,

--- a/lib/auth/join_bound_keypair_test.go
+++ b/lib/auth/join_bound_keypair_test.go
@@ -41,6 +41,7 @@ import (
 	"github.com/gravitational/teleport/lib/boundkeypair"
 	"github.com/gravitational/teleport/lib/cryptosuites"
 	joinboundkeypair "github.com/gravitational/teleport/lib/join/boundkeypair"
+	"github.com/gravitational/teleport/lib/join/provision"
 	"github.com/gravitational/teleport/lib/sshutils"
 	"github.com/gravitational/teleport/lib/tlsca"
 )
@@ -223,7 +224,7 @@ func TestServer_RegisterUsingBoundKeypairMethod(t *testing.T) {
 	withToken := func(mutators ...func(v2 *types.ProvisionTokenV2)) func(*boundkeypair.JoinStateParams) {
 		return func(jsp *boundkeypair.JoinStateParams) {
 			token := makeToken(mutators...)
-			jsp.Token = &token
+			jsp.Token = provision.UnscopedToken{ProvisionToken: &token}
 		}
 	}
 

--- a/lib/auth/join_circleci.go
+++ b/lib/auth/join_circleci.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/join/circleci"
+	"github.com/gravitational/teleport/lib/join/provision"
 )
 
 // GetCircleCITokenValidate returns the currently configured CircleCI OIDC token
@@ -45,7 +46,7 @@ func (a *Server) checkCircleCIJoinRequest(
 	pt types.ProvisionToken,
 ) (*circleci.IDTokenClaims, error) {
 	claims, err := circleci.CheckIDToken(ctx, &circleci.CheckIDTokenParams{
-		ProvisionToken: pt,
+		ProvisionToken: provision.UnscopedToken{ProvisionToken: pt},
 		IDToken:        []byte(req.IDToken),
 		Validator:      a.circleCITokenValidate,
 	})

--- a/lib/auth/join_ec2.go
+++ b/lib/auth/join_ec2.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/join/ec2join"
+	"github.com/gravitational/teleport/lib/join/provision"
 )
 
 // SetEC2ClientForEC2JoinMethod sets an AWS EC2 client that will be used to
@@ -68,7 +69,7 @@ func (a *Server) checkEC2JoinRequest(ctx context.Context, req *types.RegisterUsi
 	}
 
 	_, err = ec2join.CheckEC2Request(ctx, &ec2join.CheckEC2RequestParams{
-		ProvisionToken:  provisionToken,
+		ProvisionToken:  provision.UnscopedToken{ProvisionToken: provisionToken},
 		Role:            req.Role,
 		Document:        req.EC2IdentityDocument,
 		RequestedHostID: &req.HostID,

--- a/lib/auth/join_gcp.go
+++ b/lib/auth/join_gcp.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/join/gcp"
+	"github.com/gravitational/teleport/lib/join/provision"
 )
 
 // GetGCPIDTokenValidator returns the server's configured GCP ID token
@@ -44,7 +45,7 @@ func (a *Server) checkGCPJoinRequest(
 	pt types.ProvisionToken,
 ) (*gcp.IDTokenClaims, error) {
 	claims, err := gcp.CheckIDToken(ctx, &gcp.CheckIDTokenParams{
-		ProvisionToken: pt,
+		ProvisionToken: provision.UnscopedToken{ProvisionToken: pt},
 		IDToken:        []byte(req.IDToken),
 		Validator:      a.gcpIDTokenValidator,
 	})

--- a/lib/auth/join_github.go
+++ b/lib/auth/join_github.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/join/githubactions"
+	"github.com/gravitational/teleport/lib/join/provision"
 )
 
 // GetGHAIDTokenValidator returns the validator implementation for GitHub
@@ -61,7 +62,7 @@ func (a *Server) checkGitHubJoinRequest(
 	pt types.ProvisionToken,
 ) (*githubactions.IDTokenClaims, error) {
 	claims, err := githubactions.CheckGithubIDToken(ctx, a.modules, &githubactions.CheckGithubIDTokenParams{
-		ProvisionToken: pt,
+		ProvisionToken: provision.UnscopedToken{ProvisionToken: pt},
 		IDToken:        []byte(req.IDToken),
 		Clock:          a.GetClock(),
 		Validator:      a.ghaIDTokenValidator,

--- a/lib/auth/join_gitlab.go
+++ b/lib/auth/join_gitlab.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/join/gitlab"
+	"github.com/gravitational/teleport/lib/join/provision"
 )
 
 // GetGitlabIDTokenValidator returns the currently configured gitlab OIDC token
@@ -45,7 +46,7 @@ func (a *Server) checkGitLabJoinRequest(
 	pt types.ProvisionToken,
 ) (*gitlab.IDTokenClaims, error) {
 	claims, err := gitlab.CheckIDToken(ctx, &gitlab.CheckIDTokenParams{
-		ProvisionToken: pt,
+		ProvisionToken: provision.UnscopedToken{ProvisionToken: pt},
 		IDToken:        []byte(req.IDToken),
 		Validator:      a.gitlabIDTokenValidator,
 	})

--- a/lib/auth/join_iam.go
+++ b/lib/auth/join_iam.go
@@ -29,6 +29,7 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/join/iamjoin"
 	"github.com/gravitational/teleport/lib/join/legacyjoin"
+	"github.com/gravitational/teleport/lib/join/provision"
 	"github.com/gravitational/teleport/lib/utils"
 )
 
@@ -102,7 +103,7 @@ func (a *Server) RegisterUsingIAMMethod(
 	verifiedIdentity, err := iamjoin.CheckIAMRequest(ctx, &iamjoin.CheckIAMRequestParams{
 		Logger:                   a.logger,
 		Challenge:                challenge,
-		ProvisionToken:           provisionToken,
+		ProvisionToken:           provision.UnscopedToken{ProvisionToken: provisionToken},
 		STSIdentityRequest:       req.StsIdentityRequest,
 		HTTPClient:               a.GetHTTPClientForAWSSTS(),
 		FIPS:                     a.fips,
@@ -120,10 +121,10 @@ func (a *Server) RegisterUsingIAMMethod(
 		params := makeBotCertsParams(req.RegisterUsingTokenRequest, verifiedIdentity, workloadidentityv1pb.JoinAttrs_builder{
 			Iam: verifiedIdentity.JoinAttrs(),
 		}.Build())
-		certs, _, err := a.GenerateBotCertsForJoin(ctx, provisionToken, params)
+		certs, _, err := a.GenerateBotCertsForJoin(ctx, provision.UnscopedToken{ProvisionToken: provisionToken}, params)
 		return certs, trace.Wrap(err, "generating bot certs")
 	}
 	params := makeHostCertsParams(req.RegisterUsingTokenRequest, verifiedIdentity)
-	certs, err = a.GenerateHostCertsForJoin(ctx, provisionToken, params)
+	certs, err = a.GenerateHostCertsForJoin(ctx, provision.UnscopedToken{ProvisionToken: provisionToken}, params)
 	return certs, trace.Wrap(err, "generating certs")
 }

--- a/lib/auth/join_kubernetes.go
+++ b/lib/auth/join_kubernetes.go
@@ -24,6 +24,7 @@ import (
 	"github.com/gravitational/trace"
 
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/join/provision"
 	kubetoken "github.com/gravitational/teleport/lib/kube/token"
 )
 
@@ -68,7 +69,7 @@ func (a *Server) checkKubernetesJoinRequest(
 	}
 
 	result, err := kubetoken.CheckIDToken(ctx, &kubetoken.CheckIDTokenParams{
-		ProvisionToken:     unversionedToken,
+		ProvisionToken:     provision.UnscopedToken{ProvisionToken: unversionedToken},
 		Clock:              a.GetClock(),
 		ClusterName:        clusterName,
 		IDToken:            []byte(req.IDToken),

--- a/lib/auth/join_oracle.go
+++ b/lib/auth/join_oracle.go
@@ -35,6 +35,7 @@ import (
 	"github.com/gravitational/teleport/lib/join/joinutils"
 	"github.com/gravitational/teleport/lib/join/legacyjoin"
 	"github.com/gravitational/teleport/lib/join/oraclejoin"
+	"github.com/gravitational/teleport/lib/join/provision"
 )
 
 // RegisterUsingOracleMethod registers the caller using the legacy Oracle join
@@ -95,11 +96,11 @@ func (a *Server) registerUsingOracleMethod(
 		params := makeBotCertsParams(tokenReq, claims, workloadidentityv1pb.JoinAttrs_builder{
 			Oracle: claims.JoinAttrs(),
 		}.Build())
-		certs, _, err := a.GenerateBotCertsForJoin(ctx, provisionToken, params)
+		certs, _, err := a.GenerateBotCertsForJoin(ctx, provision.UnscopedToken{ProvisionToken: provisionToken}, params)
 		return certs, trace.Wrap(err, "generating bot certs")
 	}
 	params := makeHostCertsParams(tokenReq, claims)
-	certs, err = a.GenerateHostCertsForJoin(ctx, provisionToken, params)
+	certs, err = a.GenerateHostCertsForJoin(ctx, provision.UnscopedToken{ProvisionToken: provisionToken}, params)
 	return certs, trace.Wrap(err, "generating certs")
 }
 
@@ -207,7 +208,7 @@ func (a *Server) checkOracleRequest(
 	}
 
 	// Check allow rules.
-	if err := oraclejoin.CheckOracleAllowRules(&claims, provisionToken); err != nil {
+	if err := oraclejoin.CheckOracleAllowRules(&claims, provision.UnscopedToken{ProvisionToken: provisionToken}); err != nil {
 		return claims, trace.Wrap(err)
 	}
 

--- a/lib/auth/join_spacelift.go
+++ b/lib/auth/join_spacelift.go
@@ -24,6 +24,7 @@ import (
 	"github.com/gravitational/trace"
 
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/join/provision"
 	"github.com/gravitational/teleport/lib/join/spacelift"
 )
 
@@ -45,7 +46,7 @@ func (a *Server) checkSpaceliftJoinRequest(
 	pt types.ProvisionToken,
 ) (*spacelift.IDTokenClaims, error) {
 	claims, err := spacelift.CheckIDToken(ctx, a.modules, &spacelift.CheckIDTokenParams{
-		ProvisionToken: pt,
+		ProvisionToken: provision.UnscopedToken{ProvisionToken: pt},
 		IDToken:        []byte(req.IDToken),
 		Validator:      a.spaceliftIDTokenValidator,
 	})

--- a/lib/auth/join_terraformcloud.go
+++ b/lib/auth/join_terraformcloud.go
@@ -24,6 +24,7 @@ import (
 	"github.com/gravitational/trace"
 
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/join/provision"
 	"github.com/gravitational/teleport/lib/join/terraformcloud"
 )
 
@@ -50,7 +51,7 @@ func (a *Server) checkTerraformCloudJoinRequest(
 	}
 
 	claims, err := terraformcloud.CheckIDToken(ctx, a.modules, &terraformcloud.CheckIDTokenParams{
-		ProvisionToken: pt,
+		ProvisionToken: provision.UnscopedToken{ProvisionToken: pt},
 		IDToken:        []byte(req.IDToken),
 		Validator:      a.terraformIDTokenValidator,
 		ClusterName:    clusterName.GetClusterName(),

--- a/lib/auth/join_tpm.go
+++ b/lib/auth/join_tpm.go
@@ -29,6 +29,7 @@ import (
 	workloadidentityv1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/workloadidentity/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/join/legacyjoin"
+	"github.com/gravitational/teleport/lib/join/provision"
 	"github.com/gravitational/teleport/lib/join/tpmjoin"
 	"github.com/gravitational/teleport/lib/tpm"
 )
@@ -96,11 +97,11 @@ func (a *Server) RegisterUsingTPMMethod(
 		params := makeBotCertsParams(initReq.JoinRequest, validatedEK, workloadidentityv1pb.JoinAttrs_builder{
 			Tpm: validatedEK.JoinAttrs(),
 		}.Build())
-		certs, _, err := a.GenerateBotCertsForJoin(ctx, ptv2, params)
+		certs, _, err := a.GenerateBotCertsForJoin(ctx, provision.UnscopedToken{ProvisionToken: ptv2}, params)
 		return certs, trace.Wrap(err, "generating certs for bot")
 	}
 	params := makeHostCertsParams(initReq.JoinRequest, validatedEK)
-	certs, err := a.GenerateHostCertsForJoin(ctx, ptv2, params)
+	certs, err := a.GenerateHostCertsForJoin(ctx, provision.UnscopedToken{ProvisionToken: ptv2}, params)
 	return certs, trace.Wrap(err, "generating certs for host")
 }
 

--- a/lib/boundkeypair/join_state.go
+++ b/lib/boundkeypair/join_state.go
@@ -87,8 +87,11 @@ type JoinStateParams struct {
 
 func (p *JoinStateParams) GetSubject() (string, error) {
 	switch {
-	case p.Token.GetBotName() != "":
-		return p.Token.GetBotName(), nil
+	case p.Token.GetBot().Name != "":
+		// TODO(scopes): the bare bot name is only a unique identifier while
+		// bots are globally namespaced. Revisit the subject for scoped bots
+		// once bot users are namespaced by scope.
+		return p.Token.GetBot().Name, nil
 	case p.HostID != "":
 		return p.HostID, nil
 	case p.Token.GetBoundKeypairStatus().BoundHostID != "":

--- a/lib/boundkeypair/join_state_test.go
+++ b/lib/boundkeypair/join_state_test.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/utils/keys"
+	"github.com/gravitational/teleport/lib/join/provision"
 )
 
 type mockCA struct {
@@ -94,7 +95,7 @@ func TestIssueAndVerifyJoinState(t *testing.T) {
 		params := &JoinStateParams{
 			Clock:       clock,
 			ClusterName: "example.com",
-			Token:       token,
+			Token:       provision.UnscopedToken{ProvisionToken: token},
 		}
 
 		for _, mutator := range mutators {
@@ -209,7 +210,7 @@ func TestIssueAndVerifyJoinState(t *testing.T) {
 		{
 			name: "subject must match",
 			issue: makeIssuer(activeSigner, makeParams(withRecovery(0, 1), func(jsp *JoinStateParams) {
-				ptv2, ok := jsp.Token.(*types.ProvisionTokenV2)
+				ptv2, ok := provision.AsProvisionTokenV2(jsp.Token)
 				require.True(t, ok)
 
 				ptv2.Spec.BotName = "invalid"

--- a/lib/join/bitbucket/bitbucket.go
+++ b/lib/join/bitbucket/bitbucket.go
@@ -132,7 +132,7 @@ func CheckIDToken(
 		return nil, trace.AccessDenied("%s", err.Error())
 	}
 
-	token, ok := params.ProvisionToken.(*types.ProvisionTokenV2)
+	token, ok := provision.AsProvisionTokenV2(params.ProvisionToken)
 	if !ok {
 		return nil, trace.BadParameter("bitbucket join method only supports ProvisionTokenV2, '%T' was provided", params.ProvisionToken)
 	}

--- a/lib/join/boundkeypair/boundkeypair.go
+++ b/lib/join/boundkeypair/boundkeypair.go
@@ -515,7 +515,7 @@ func patchToken(ctx context.Context, params *JoinParams, mutators ...boundKeypai
 	token := params.ProvisionToken
 
 	switch token.(type) {
-	case *types.ProvisionTokenV2:
+	case provision.UnscopedToken:
 		patched, err := params.AuthService.PatchToken(ctx, token.GetName(), func(pt types.ProvisionToken) (types.ProvisionToken, error) {
 			if pt.GetBoundKeypairStatus() == nil {
 				return nil, trace.BadParameter("bound keypair tokens must have non-nil status.bound_keypair")
@@ -537,7 +537,7 @@ func patchToken(ctx context.Context, params *JoinParams, mutators ...boundKeypai
 			return nil, trace.Wrap(err, "committing updated token state, please try again")
 		}
 
-		return patched, nil
+		return provision.UnscopedToken{ProvisionToken: patched}, nil
 	case *joining.Token:
 		patched, err := params.ScopedTokenService.PatchScopedToken(ctx, token.GetName(), func(st *joiningv1.ScopedToken) (*joiningv1.ScopedToken, error) {
 			if st.GetStatus().GetUsage().GetBoundKeypair() == nil {
@@ -620,7 +620,7 @@ func emitBoundKeypairRecoveryEvent(
 			RemoteAddr: params.Diag.Get().RemoteAddr,
 		},
 		TokenName:     token.GetName(),
-		BotName:       token.GetBotName(),
+		BotName:       token.GetBot().Name,
 		PublicKey:     boundPublicKey,
 		RecoveryCount: recoveryCount,
 		RecoveryMode:  token.GetBoundKeypair().Recovery.Mode,
@@ -660,7 +660,7 @@ func emitBoundKeypairRotationEvent(
 			RemoteAddr: params.Diag.Get().RemoteAddr,
 		},
 		TokenName:         token.GetName(),
-		BotName:           token.GetBotName(),
+		BotName:           token.GetBot().Name,
 		PreviousPublicKey: prevPublicKey,
 		NewPublicKey:      newPublicKey,
 	}); err != nil {
@@ -689,7 +689,7 @@ func tryLockTokenInvalidJoinState(
 			RemoteAddr: params.Diag.Get().RemoteAddr,
 		},
 		TokenName: token.GetName(),
-		BotName:   token.GetBotName(),
+		BotName:   token.GetBot().Name,
 	}); auditErr != nil {
 		log.WarnContext(ctx, "Failed to emit failed join state verification event", "error", auditErr)
 	}
@@ -700,7 +700,7 @@ func tryLockTokenInvalidJoinState(
 			"The join token %q has been locked by bot %q after a client "+
 				"failed to verify its join state, possibly indicating a "+
 				"stolen keypair.",
-			token.GetName(), token.GetBotName(),
+			token.GetName(), token.GetBot().Name,
 		)
 	} else {
 		message = fmt.Sprintf(

--- a/lib/join/circleci/circleci.go
+++ b/lib/join/circleci/circleci.go
@@ -120,7 +120,7 @@ func CheckIDToken(
 		return nil, trace.AccessDenied("%s", err.Error())
 	}
 
-	token, ok := params.ProvisionToken.(*types.ProvisionTokenV2)
+	token, ok := provision.AsProvisionTokenV2(params.ProvisionToken)
 	if !ok {
 		return nil, trace.BadParameter("circleci join method only supports ProvisionTokenV2, '%T' was provided", params.ProvisionToken)
 	}

--- a/lib/join/githubactions/githubactions.go
+++ b/lib/join/githubactions/githubactions.go
@@ -195,7 +195,7 @@ func CheckGithubIDToken(ctx context.Context, m modules.Modules, params *CheckGit
 		return nil, trace.AccessDenied("%s", err.Error())
 	}
 
-	token, ok := params.ProvisionToken.(*types.ProvisionTokenV2)
+	token, ok := provision.AsProvisionTokenV2(params.ProvisionToken)
 	if !ok {
 		return nil, trace.BadParameter("github join method only supports ProvisionTokenV2, '%T' was provided", params.ProvisionToken)
 	}

--- a/lib/join/gitlab/gitlab.go
+++ b/lib/join/gitlab/gitlab.go
@@ -190,7 +190,7 @@ func CheckIDToken(ctx context.Context, params *CheckIDTokenParams) (*IDTokenClai
 		return nil, trace.AccessDenied("%s", err.Error())
 	}
 
-	token, ok := params.ProvisionToken.(*types.ProvisionTokenV2)
+	token, ok := provision.AsProvisionTokenV2(params.ProvisionToken)
 	if !ok {
 		return nil, trace.BadParameter("gitlab join method only supports ProvisionTokenV2, '%T' was provided", params.ProvisionToken)
 	}

--- a/lib/join/iamjoin/iam_test.go
+++ b/lib/join/iamjoin/iam_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/join/provision"
 	"github.com/gravitational/teleport/lib/utils/log/logtest"
 )
 
@@ -207,9 +208,9 @@ func TestAccountOUIsAllowed(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			params := &CheckIAMRequestParams{
 				Logger: logtest.NewLogger(),
-				ProvisionToken: &types.ProvisionTokenV2{
+				ProvisionToken: provision.UnscopedToken{ProvisionToken: &types.ProvisionTokenV2{
 					Metadata: types.Metadata{Name: "test-token"},
-				},
+				}},
 			}
 			identity := &AWSIdentity{Account: accountID}
 			account := &accountDetails{

--- a/lib/join/join_bound_keypair_test.go
+++ b/lib/join/join_bound_keypair_test.go
@@ -51,6 +51,7 @@ import (
 	"github.com/gravitational/teleport/lib/boundkeypair"
 	"github.com/gravitational/teleport/lib/cryptosuites"
 	"github.com/gravitational/teleport/lib/join/joinclient"
+	"github.com/gravitational/teleport/lib/join/provision"
 	"github.com/gravitational/teleport/lib/scopes"
 	scopedaccess "github.com/gravitational/teleport/lib/scopes/access"
 	"github.com/gravitational/teleport/lib/scopes/joining"
@@ -403,7 +404,7 @@ func TestJoinBoundKeypair(t *testing.T) {
 	withToken := func(mutators ...func(v2 *types.ProvisionTokenV2)) func(*boundkeypair.JoinStateParams) {
 		return func(jsp *boundkeypair.JoinStateParams) {
 			token := makeToken(mutators...)
-			jsp.Token = &token
+			jsp.Token = provision.UnscopedToken{ProvisionToken: &token}
 		}
 	}
 

--- a/lib/join/oraclejoin/join_test.go
+++ b/lib/join/oraclejoin/join_test.go
@@ -58,6 +58,7 @@ import (
 	"github.com/gravitational/teleport/lib/join/jointest"
 	"github.com/gravitational/teleport/lib/join/joinutils"
 	"github.com/gravitational/teleport/lib/join/oraclejoin"
+	"github.com/gravitational/teleport/lib/join/provision"
 	"github.com/gravitational/teleport/lib/scopes/joining"
 	"github.com/gravitational/teleport/lib/tlsca"
 	"github.com/gravitational/teleport/lib/utils"
@@ -566,7 +567,7 @@ func TestInstanceKeyAlgorithms(t *testing.T) {
 			params := &oraclejoin.CheckChallengeSolutionParams{
 				Challenge:      challenge,
 				Solution:       solution,
-				ProvisionToken: token,
+				ProvisionToken: provision.UnscopedToken{ProvisionToken: token},
 				HTTPClient:     fakeOracleAPIClient,
 				RootCACache:    rootCACache,
 			}

--- a/lib/join/oraclejoin/rules_test.go
+++ b/lib/join/oraclejoin/rules_test.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/join/oraclejoin"
+	"github.com/gravitational/teleport/lib/join/provision"
 )
 
 func makeOCID(resourceType, region, id string) string {
@@ -246,7 +247,7 @@ func TestCheckOracleAllowRules(t *testing.T) {
 				},
 			})
 			require.NoError(t, err)
-			tc.assert(t, oraclejoin.CheckOracleAllowRules(&tc.claims, token))
+			tc.assert(t, oraclejoin.CheckOracleAllowRules(&tc.claims, provision.UnscopedToken{ProvisionToken: token}))
 		})
 	}
 }

--- a/lib/join/provision/token.go
+++ b/lib/join/provision/token.go
@@ -21,6 +21,7 @@ import (
 
 	joiningv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/joining/v1"
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/scopes"
 )
 
 // A Token is used in the join service to facilitate provisioning.
@@ -43,11 +44,12 @@ type Token interface {
 	GetRoles() types.SystemRoles
 	// Expiry returns the token's expiration time.
 	Expiry() time.Time
-	// GetBotName returns the BotName field which must be set for joining bots.
-	GetBotName() string
-	// GetBotScope returns the BotScope field which must be set for bots joining
-	// with a scoped token. It is empty for unscoped bots.
-	GetBotScope() string
+	// GetBot returns a reference to the bot that this token can join. The zero
+	// value indicates that this is not a bot token. A value with an empty Scope
+	// refers to an unscoped bot; such a value is not a valid scope-qualified
+	// name, so it must not be rendered with [scopes.QualifiedName.String] or
+	// re-validated — read the Name and Scope fields individually instead.
+	GetBot() scopes.QualifiedName
 	// GetAssignedScope returns the scope that will be assigned to provisioned resources
 	// provisioned using the wrapped [joiningv1.ScopedToken].
 	GetAssignedScope() string

--- a/lib/join/provision/unscoped.go
+++ b/lib/join/provision/unscoped.go
@@ -1,0 +1,48 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package provision
+
+import (
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/scopes"
+)
+
+// UnscopedToken adapts a legacy [types.ProvisionToken] to the [Token]
+// interface. [types.ProvisionToken] lives in the api module, which cannot
+// depend on the scopes package, so it cannot implement [Token.GetBot] itself.
+type UnscopedToken struct {
+	types.ProvisionToken
+}
+
+// GetBot returns a reference to the bot that this token can join. Legacy
+// provision tokens can only refer to unscoped bots, so the Scope component is
+// always empty. The zero value indicates that this is not a bot token.
+func (t UnscopedToken) GetBot() scopes.QualifiedName {
+	return scopes.QualifiedName{Name: t.GetBotName()}
+}
+
+// AsProvisionTokenV2 attempts to return the [*types.ProvisionTokenV2] backing
+// a [Token]. Returns false if the token is not an [UnscopedToken] wrapping a
+// [*types.ProvisionTokenV2].
+func AsProvisionTokenV2(token Token) (*types.ProvisionTokenV2, bool) {
+	unscoped, ok := token.(UnscopedToken)
+	if !ok {
+		return nil, false
+	}
+	v2, ok := unscoped.ProvisionToken.(*types.ProvisionTokenV2)
+	return v2, ok
+}

--- a/lib/join/provision/unscoped_test.go
+++ b/lib/join/provision/unscoped_test.go
@@ -1,0 +1,90 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package provision_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
+	joiningv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/joining/v1"
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/join/provision"
+	"github.com/gravitational/teleport/lib/scopes"
+	"github.com/gravitational/teleport/lib/scopes/joining"
+)
+
+func newProvisionTokenV2(t *testing.T, spec types.ProvisionTokenSpecV2) *types.ProvisionTokenV2 {
+	t.Helper()
+	tok, err := types.NewProvisionTokenFromSpec("test-token", time.Time{}, spec)
+	require.NoError(t, err)
+	ptv2, ok := tok.(*types.ProvisionTokenV2)
+	require.True(t, ok)
+	return ptv2
+}
+
+func TestUnscopedTokenGetBot(t *testing.T) {
+	botToken := newProvisionTokenV2(t, types.ProvisionTokenSpecV2{
+		Roles:      types.SystemRoles{types.RoleBot},
+		JoinMethod: types.JoinMethodIAM,
+		BotName:    "test-bot",
+		Allow:      []*types.TokenRule{{AWSAccount: "1234"}},
+	})
+	require.Equal(t,
+		scopes.QualifiedName{Name: "test-bot"},
+		provision.UnscopedToken{ProvisionToken: botToken}.GetBot(),
+	)
+
+	nonBotToken := newProvisionTokenV2(t, types.ProvisionTokenSpecV2{
+		Roles:      types.SystemRoles{types.RoleNode},
+		JoinMethod: types.JoinMethodToken,
+	})
+	require.Zero(t, provision.UnscopedToken{ProvisionToken: nonBotToken}.GetBot())
+}
+
+func TestAsProvisionTokenV2(t *testing.T) {
+	ptv2 := newProvisionTokenV2(t, types.ProvisionTokenSpecV2{
+		Roles:      types.SystemRoles{types.RoleNode},
+		JoinMethod: types.JoinMethodToken,
+	})
+
+	unwrapped, ok := provision.AsProvisionTokenV2(provision.UnscopedToken{ProvisionToken: ptv2})
+	require.True(t, ok)
+	require.Same(t, ptv2, unwrapped)
+
+	scoped, err := joining.NewToken(joiningv1.ScopedToken_builder{
+		Kind:    types.KindScopedToken,
+		Scope:   "/aa",
+		Version: types.V1,
+		Metadata: headerv1.Metadata_builder{
+			Name: "test-scoped-token",
+		}.Build(),
+		Spec: joiningv1.ScopedTokenSpec_builder{
+			Roles:         []string{types.RoleNode.String()},
+			AssignedScope: "/aa",
+			JoinMethod:    string(types.JoinMethodToken),
+			UsageMode:     string(joining.TokenUsageModeUnlimited),
+		}.Build(),
+	}.Build())
+	require.NoError(t, err)
+
+	unwrapped, ok = provision.AsProvisionTokenV2(scoped)
+	require.False(t, ok)
+	require.Nil(t, unwrapped)
+}

--- a/lib/join/server.go
+++ b/lib/join/server.go
@@ -188,7 +188,12 @@ func (s *Server) getProvisionToken(ctx context.Context, name string) (provision.
 	})
 	wg.Go(func() {
 		// Fetch the provision token and validate that it is not expired.
-		classic, classicErr = s.cfg.AuthService.ValidateToken(ctx, name)
+		tok, err := s.cfg.AuthService.ValidateToken(ctx, name)
+		if err != nil {
+			classicErr = err
+			return
+		}
+		classic = provision.UnscopedToken{ProvisionToken: tok}
 	})
 	wg.Wait()
 
@@ -278,11 +283,12 @@ func (s *Server) Join(stream messages.ServerStream) (err error) {
 		i.SafeTokenName = token.GetSafeName()
 		i.TokenJoinMethod = string(configuredJoinMethod(token))
 		i.TokenExpires = token.Expiry()
-		i.BotName = token.GetBotName()
+		bot := token.GetBot()
+		i.BotName = bot.Name
 
 		// It's not worth fetching the true bot scope here (via bot user label)
 		// so we'll just include the one embedded in the token.
-		i.BotScope = token.GetBotScope()
+		i.BotScope = bot.Scope
 	})
 
 	// Validate that the requested join method matches the join method

--- a/lib/join/server_boundkeypair.go
+++ b/lib/join/server_boundkeypair.go
@@ -198,16 +198,17 @@ func AdaptRegisterUsingBoundKeypairMethod(
 		authCtx.HostID = ""
 	}
 
-	provisionToken, err := a.ValidateToken(ctx, req.JoinRequest.Token)
+	unscopedToken, err := a.ValidateToken(ctx, req.JoinRequest.Token)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
+	provisionToken := provision.UnscopedToken{ProvisionToken: unscopedToken}
 	// Set any diagnostic info we can get from the token.
 	diag.Set(func(i *diagnostic.Info) {
 		i.SafeTokenName = provisionToken.GetSafeName()
 		i.TokenJoinMethod = string(provisionToken.GetJoinMethod())
 		i.TokenExpires = provisionToken.Expiry()
-		i.BotName = provisionToken.GetBotName()
+		i.BotName = provisionToken.GetBot().Name
 	})
 	if provisionToken.GetJoinMethod() != types.JoinMethodBoundKeypair {
 		return nil, trace.BadParameter("specified join token is not for `%s` method", types.JoinMethodBoundKeypair)

--- a/lib/join/server_env0.go
+++ b/lib/join/server_env0.go
@@ -46,7 +46,7 @@ func (s *Server) validateEnv0Token(
 		return nil, nil, trace.Wrap(err, "validating Env0 OIDC token")
 	}
 
-	ptv2, ok := provisionToken.(*types.ProvisionTokenV2)
+	ptv2, ok := provision.AsProvisionTokenV2(provisionToken)
 	if !ok {
 		return nil, nil, trace.BadParameter("expected *types.ProvisionTokenV2, got %T", provisionToken)
 	}

--- a/lib/join/server_tpm.go
+++ b/lib/join/server_tpm.go
@@ -21,7 +21,6 @@ import (
 	"github.com/gravitational/trace"
 
 	workloadidentityv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/workloadidentity/v1"
-	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/join/internal/authz"
 	"github.com/gravitational/teleport/lib/join/internal/diagnostic"
 	"github.com/gravitational/teleport/lib/join/internal/messages"
@@ -49,7 +48,7 @@ func (s *Server) handleTPMJoin(
 	clientInit *messages.ClientInit,
 	provisionToken provision.Token,
 ) (messages.Response, error) {
-	ptv2, ok := provisionToken.(*types.ProvisionTokenV2)
+	ptv2, ok := provision.AsProvisionTokenV2(provisionToken)
 	if !ok {
 		return nil, trace.BadParameter("TPM joining only supports types.ProvisionTokenV2, got %T", provisionToken)
 	}

--- a/lib/join/spacelift/spacelift.go
+++ b/lib/join/spacelift/spacelift.go
@@ -120,7 +120,7 @@ func CheckIDToken(
 		return nil, trace.Wrap(err)
 	}
 
-	token, ok := params.ProvisionToken.(*types.ProvisionTokenV2)
+	token, ok := provision.AsProvisionTokenV2(params.ProvisionToken)
 	if !ok {
 		return nil, trace.BadParameter("spacelift join method only supports ProvisionTokenV2, '%T' was provided", params.ProvisionToken)
 	}

--- a/lib/join/terraformcloud/terraform.go
+++ b/lib/join/terraformcloud/terraform.go
@@ -124,7 +124,7 @@ func CheckIDToken(
 		return nil, trace.AccessDenied("%s", err.Error())
 	}
 
-	token, ok := params.ProvisionToken.(*types.ProvisionTokenV2)
+	token, ok := provision.AsProvisionTokenV2(params.ProvisionToken)
 	if !ok {
 		return nil, trace.BadParameter("terraform_cloud join method only supports ProvisionTokenV2, '%T' was provided", params.ProvisionToken)
 	}

--- a/lib/scopes/joining/token.go
+++ b/lib/scopes/joining/token.go
@@ -548,13 +548,16 @@ type Token struct {
 	scoped     *joiningv1.ScopedToken
 	joinMethod types.JoinMethod
 	roles      types.SystemRoles
+	bot        scopes.QualifiedName
 }
 
 // NewToken returns the wrapped version of the given [joiningv1.ScopedToken].
 // It will return an error if the configured join method is not a valid
-// [types.JoinMethod] or if any of the configured roles are not a valid
-// [types.SystemRole]. The validated join method and roles are cached on the
-// [Scoped] wrapper itself so they can be read without repeating validation.
+// [types.JoinMethod], if any of the configured roles are not a valid
+// [types.SystemRole], or if the bot_name/bot_scope fields are inconsistent
+// with the configured roles. The validated join method, roles, and bot
+// reference are cached on the [Token] wrapper itself so they can be read
+// without repeating validation.
 func NewToken(token *joiningv1.ScopedToken) (*Token, error) {
 	joinMethod := types.JoinMethod(token.GetSpec().GetJoinMethod())
 	if err := types.ValidateJoinMethod(joinMethod); err != nil {
@@ -566,7 +569,43 @@ func NewToken(token *joiningv1.ScopedToken) (*Token, error) {
 		return nil, trace.Wrap(err)
 	}
 
-	return &Token{scoped: token, joinMethod: joinMethod, roles: roles}, nil
+	bot, err := botRefFromSpec(token.GetSpec(), roles)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return &Token{scoped: token, joinMethod: joinMethod, roles: roles, bot: bot}, nil
+}
+
+// botRefFromSpec derives a scoped token's bot reference from the split
+// bot_name/bot_scope spec fields. Bot tokens must carry both components;
+// non-bot tokens must carry neither.
+func botRefFromSpec(spec *joiningv1.ScopedTokenSpec, roles types.SystemRoles) (scopes.QualifiedName, error) {
+	if !roles.Include(types.RoleBot) {
+		if spec.GetBotName() != "" {
+			return scopes.QualifiedName{}, trace.BadParameter("bot_name cannot be set for a non-bot token")
+		}
+		if spec.GetBotScope() != "" {
+			return scopes.QualifiedName{}, trace.BadParameter("bot_scope cannot be set for a non-bot token")
+		}
+		return scopes.QualifiedName{}, nil
+	}
+
+	bot := scopes.QualifiedName{
+		Scope: spec.GetBotScope(),
+		Name:  spec.GetBotName(),
+	}
+	if bot.Name == "" {
+		return scopes.QualifiedName{}, trace.BadParameter("expected non-empty bot_name for a scoped bot token")
+	}
+	if bot.Scope == "" {
+		return scopes.QualifiedName{}, trace.BadParameter("expected non-empty bot_scope for a scoped bot token")
+	}
+	if err := scopes.WeakValidate(bot.Scope); err != nil {
+		return scopes.QualifiedName{}, trace.Wrap(err, "validating scoped token bot_scope")
+	}
+
+	return bot, nil
 }
 
 // GetName returns the name of a [joiningv1.ScopedToken].
@@ -614,16 +653,16 @@ func (t *Token) Expiry() time.Time {
 	return expiry.AsTime()
 }
 
-// GetBotName returns an empty string because scoped tokens do not currently
-// support configuring a bot name.
-func (t *Token) GetBotName() string {
-	return t.scoped.GetSpec().GetBotName()
-}
+// GetBot returns the cached reference to the bot that this token can join,
+// derived from the bot_name/bot_scope spec fields when the
+// [joiningv1.ScopedToken] was wrapped. The zero value indicates that this is
+// not a bot token; otherwise both components are non-empty.
+func (t *Token) GetBot() scopes.QualifiedName {
+	if t == nil {
+		return scopes.QualifiedName{}
+	}
 
-// GetBotScope returns the BotScope field which must be set for bots joining
-// with a scoped token. It is empty for unscoped bots.
-func (t *Token) GetBotScope() string {
-	return t.scoped.GetSpec().GetBotScope()
+	return t.bot
 }
 
 // GetAssignedScope returns the scope that will be assigned to resources

--- a/lib/scopes/joining/token_test.go
+++ b/lib/scopes/joining/token_test.go
@@ -30,6 +30,7 @@ import (
 	joiningv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/joining/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/join/jointest"
+	"github.com/gravitational/teleport/lib/scopes"
 	"github.com/gravitational/teleport/lib/scopes/joining"
 )
 
@@ -1113,6 +1114,117 @@ func TestScopedTokenAzureRoundTrip(t *testing.T) {
 			},
 		},
 	}, token.GetAzure())
+}
+
+func TestNewTokenGetBot(t *testing.T) {
+	t.Parallel()
+
+	newBotToken := func() *joiningv1.ScopedToken {
+		return joiningv1.ScopedToken_builder{
+			Kind:    types.KindScopedToken,
+			Scope:   "/aa/bb",
+			Version: types.V1,
+			Metadata: headerv1.Metadata_builder{
+				Name: "testtoken",
+			}.Build(),
+			Spec: joiningv1.ScopedTokenSpec_builder{
+				Roles:      []string{types.RoleBot.String()},
+				BotScope:   "/aa/bb",
+				BotName:    "test-bot",
+				JoinMethod: string(types.JoinMethodBoundKeypair),
+				UsageMode:  joining.TokenUsageModeBot,
+			}.Build(),
+		}.Build()
+	}
+	newNonBotToken := func() *joiningv1.ScopedToken {
+		return joiningv1.ScopedToken_builder{
+			Kind:    types.KindScopedToken,
+			Scope:   "/aa/bb",
+			Version: types.V1,
+			Metadata: headerv1.Metadata_builder{
+				Name: "testtoken",
+			}.Build(),
+			Spec: joiningv1.ScopedTokenSpec_builder{
+				Roles:         []string{types.RoleNode.String()},
+				AssignedScope: "/aa/bb",
+				JoinMethod:    string(types.JoinMethodToken),
+				UsageMode:     string(joining.TokenUsageModeUnlimited),
+			}.Build(),
+		}.Build()
+	}
+
+	cases := []struct {
+		name        string
+		token       *joiningv1.ScopedToken
+		modFn       func(*joiningv1.ScopedToken)
+		expectedBot scopes.QualifiedName
+		expectedErr string
+	}{
+		{
+			name:        "bot token",
+			token:       newBotToken(),
+			expectedBot: scopes.QualifiedName{Scope: "/aa/bb", Name: "test-bot"},
+		},
+		{
+			name:  "non-bot token",
+			token: newNonBotToken(),
+		},
+		{
+			name:  "non-bot token with bot_name",
+			token: newNonBotToken(),
+			modFn: func(tok *joiningv1.ScopedToken) {
+				tok.GetSpec().SetBotName("test-bot")
+			},
+			expectedErr: "bot_name cannot be set for a non-bot token",
+		},
+		{
+			name:  "non-bot token with bot_scope",
+			token: newNonBotToken(),
+			modFn: func(tok *joiningv1.ScopedToken) {
+				tok.GetSpec().SetBotScope("/aa/bb")
+			},
+			expectedErr: "bot_scope cannot be set for a non-bot token",
+		},
+		{
+			name:  "bot token without bot_name",
+			token: newBotToken(),
+			modFn: func(tok *joiningv1.ScopedToken) {
+				tok.GetSpec().SetBotName("")
+			},
+			expectedErr: "expected non-empty bot_name",
+		},
+		{
+			name:  "bot token without bot_scope",
+			token: newBotToken(),
+			modFn: func(tok *joiningv1.ScopedToken) {
+				tok.GetSpec().SetBotScope("")
+			},
+			expectedErr: "expected non-empty bot_scope",
+		},
+		{
+			name:  "bot token with malformed bot_scope",
+			token: newBotToken(),
+			modFn: func(tok *joiningv1.ScopedToken) {
+				tok.GetSpec().SetBotScope("aa/bb}")
+			},
+			expectedErr: "validating scoped token bot_scope",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.modFn != nil {
+				tc.modFn(tc.token)
+			}
+			token, err := joining.NewToken(tc.token)
+			if tc.expectedErr != "" {
+				require.ErrorContains(t, err, tc.expectedErr)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tc.expectedBot, token.GetBot())
+		})
+	}
 }
 
 func TestImmutableLabelHashing(t *testing.T) {


### PR DESCRIPTION
Variant A: Using scopes.QualifiedName, which necessitates wrapping the unscoped ProvisionTokenV2 type to avoid `api/` depending on `lib/`.



<!-- Provide a descriptive entry for the changelog of the next release. -->

Changelog:


<!-- Include manual testing efforts to verify the change. -->
<!-- Detail where the tests where run and what configurations were used. -->
<!-- Include all the test cases which were run to validate the change. -->

## Manual Test Plan
### Test Environment

### Test Cases
- [ ] 
