### PR TITLE
[scopes] stub scope encoding for inclusion in backend keys

### DIFF
--- a/lib/scopes/encoding.go
+++ b/lib/scopes/encoding.go
@@ -1,0 +1,122 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package scopes
+
+import (
+	"strings"
+
+	"github.com/gravitational/trace"
+)
+
+const (
+	// + sorts before all characters that can appear in a scope (see
+	// segmentRegexp), is allowed in backend keys, and is not the backend key
+	// separator.
+	encodedSeparator       = '+'
+	encodedSeparatorString = string(encodedSeparator)
+)
+
+// EncodeForKey encodes a scope so that it will be valid for use in a single
+// backend key segment, preserving sort order. If given an empty string, it
+// will return a non-empty encoding that sorts before all valid encoded
+// scopes.
+//
+// This implementation is a placeholder to unblock development, it is intended
+// to be replaced with a better implementation.
+func EncodeForKey(scope string) (string, error) {
+	// The empty scope is encoded as a single encoded separator.
+	//
+	// All other scopes are encoded with an extra separator at the beginning so
+	// that the root scope sorts after the empty scope.
+	// They also have an extra separator added at the end to support prefix and
+	// exact matches.
+	if scope == "" {
+		return encodedSeparatorString, nil
+	}
+
+	if err := WeakValidate(scope); err != nil {
+		return "", trace.Wrap(err)
+	}
+
+	// Enforce that the scope does not contain any byte that would sort before
+	// or equal to the encoded separator, which would break sorting.
+	// StrongValidate would prevent this, WeakValidate may not.
+	for _, b := range []byte(scope) {
+		if b <= encodedSeparator {
+			return "", trace.BadParameter("scope contains invalid byte %d which would break sorting", b)
+		}
+	}
+
+	// Enforce that the scope does not contain empty segments, which can also
+	// break sorting of composed keys. For example / and /// could encode to:
+	//
+	//   +++/resource
+	//   +++++/resource
+	//
+	// and the sort order would invert depending on whether the /resource
+	// suffix was present.
+	//
+	// Also enforce that each segment does not start with a byte that would
+	// sort before the backend separator, which could break sorting of composed
+	// keys. For example /a and /a/.b could encode to:
+	//
+	//   ++a+/resource
+	//   ++a+.b+/resource
+	//
+	// and the sort order would be inverted because '.' sorts before '/'
+	// This is only an issue at the first byte of a segment.
+	for segment := range DescendingSegments(scope) {
+		if len(segment) == 0 {
+			return "", trace.BadParameter("scope contains empty segment which would break sorting")
+		}
+		if segment[0] < '/' {
+			return "", trace.BadParameter("scope segment starts with invalid byte %d which would break sorting", segment[0])
+		}
+	}
+
+	// NormalizeForEquality will trim a trailing separator, which may be
+	// necessary for prefix/exact match queries on encoded scopes.
+	encoded := NormalizeForEquality(scope)
+	encoded = strings.ReplaceAll(encoded, separator, encodedSeparatorString)
+
+	encoded = encodedSeparatorString + encoded + encodedSeparatorString
+	return encoded, nil
+}
+
+// DecodeFromKey decodes a scope encoded by EncodeForKey.
+func DecodeFromKey(encodedScope string) (string, error) {
+	if encodedScope == encodedSeparatorString {
+		return "", nil
+	}
+
+	decoded, ok := strings.CutPrefix(encodedScope, encodedSeparatorString)
+	if !ok {
+		return "", trace.BadParameter("encoded scope did not begin with separator")
+	}
+	decoded, ok = strings.CutSuffix(decoded, encodedSeparatorString)
+	if !ok {
+		return "", trace.BadParameter("encoded scope did not end with separator")
+	}
+
+	decoded = strings.ReplaceAll(decoded, encodedSeparatorString, separator)
+
+	if err := WeakValidate(decoded); err != nil {
+		return "", trace.Wrap(err)
+	}
+
+	return decoded, nil
+}

--- a/lib/scopes/encoding_test.go
+++ b/lib/scopes/encoding_test.go
@@ -1,0 +1,211 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package scopes
+
+import (
+	"math/rand/v2"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport/lib/backend"
+)
+
+// TestEncodeDecode tests that encoded scopes are valid backend keys and than
+// an encode-decode round-trip preserves with scope.
+func TestEncodeDecode(t *testing.T) {
+	t.Parallel()
+
+	testCases := []string{
+		"",
+		"/",
+		"/example/basic",
+		"/ops/west/vancouver",
+		"/some/really/long/scope/with/many/segments",
+		"/a/b/c",
+		"/a/b/",
+		"/a",
+	}
+
+	seenEncodings := make(map[string]struct{}, len(testCases))
+
+	for _, tc := range testCases {
+		t.Run(tc, func(t *testing.T) {
+			encoded, err := EncodeForKey(tc)
+			require.NoError(t, err)
+
+			require.NotEmpty(t, encoded)
+
+			require.NotContains(t, seenEncodings, encoded)
+			seenEncodings[encoded] = struct{}{}
+
+			require.True(t, backend.IsKeySafe(backend.NewKey(encoded)))
+
+			decoded, err := DecodeFromKey(encoded)
+			require.NoError(t, err)
+
+			require.Equal(t, NormalizeForEquality(tc), decoded)
+		})
+	}
+}
+
+// TestEncodeForKeyErrors asserts that EncodeForKeys returns an error in expected cases.
+func TestEncodeForKeyErrors(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []string{
+		"//",
+		"/aa//",
+		"/.a",
+		"/aa/.b",
+		"/aa/.b",
+		string([]byte{0, 1, 2, 3}),
+	} {
+		_, err := EncodeForKey(tc)
+		require.Error(t, err, "expected an error encoding %s", tc)
+	}
+}
+
+// TestEncodedSort asserts that a basic string sort over encoded scopes
+// produces the same ordering as sorting real scopes with [Sort].
+func TestEncodedSort(t *testing.T) {
+	t.Parallel()
+
+	const numScopes = 1000
+	var generatedScopes [numScopes]string
+	for i := range numScopes {
+		generatedScopes[i] = generateScope()
+	}
+
+	unencoded := generatedScopes[:]
+	encoded, err := encodeScopes(unencoded)
+	require.NoError(t, err)
+
+	slices.SortFunc(unencoded, Sort)
+	slices.Sort(encoded)
+
+	decoded, err := decodeScopes(encoded)
+	require.NoError(t, err)
+
+	require.Equal(t, unencoded, decoded)
+
+	// Encoded scopes are not only compared as standalone values. They are also
+	// commonly used as a key component before a resource name, e.g.
+	//
+	//	<encoded-scope>/<resource-name>
+	//
+	// Verify that adding this suffix doesn't change the relative ordering of the
+	// encoded scopes.
+	composed := make([]string, 0, len(encoded))
+	for _, encodedScope := range encoded {
+		composed = append(composed, encodedScope+backend.SeparatorString+"resource")
+	}
+	slices.Sort(composed)
+	for i, key := range composed {
+		// Split the composed key back into the encoded scope component so we can
+		// compare the resulting scope order with the canonical scope sort order.
+		encodedScope, _, ok := strings.Cut(key, backend.SeparatorString)
+		require.True(t, ok)
+		decodedScope, err := DecodeFromKey(encodedScope)
+		require.NoError(t, err)
+		require.Equal(t, NormalizeForEquality(unencoded[i]), decodedScope)
+	}
+
+	// [Sort] does not support empty scopes, so generatedScope does not
+	// generate any empty scopes. Manually test that empty encoded scopes sort
+	// to the beginning.
+	const numEmptyScopes = 10
+	encodedEmptyScope, err := EncodeForKey("")
+	require.NoError(t, err)
+	// Add some encoded empty scopes at the end.
+	for range numEmptyScopes {
+		encoded = append(encoded, encodedEmptyScope)
+	}
+	// Make sure they sort to the beginning.
+	slices.Sort(encoded)
+	for i := range numEmptyScopes {
+		require.Equal(t, encodedEmptyScope, encoded[i])
+	}
+}
+
+func generateScope() string {
+	targetLen := 1 + rand.IntN(maxScopeSize)
+	var scope strings.Builder
+	for scope.Len() <= targetLen-2 {
+		scope.WriteString(separator)
+		segmentLen := 1 + rand.IntN(targetLen-scope.Len())
+		scope.WriteString(generateSegment(segmentLen))
+	}
+	if scope.Len() == 0 {
+		return Root
+	}
+	return scope.String()
+}
+
+// generateSegment generates a scope segment considered valid by EncodeForKey,
+// meaning it must be weakly valid and start with a byte that sorts after '/'.
+func generateSegment(segmentLen int) string {
+	const (
+		minStartingByte = '/' + 1
+		minByte         = encodedSeparator + 1
+		maxByte         = 126
+	)
+	b := make([]byte, segmentLen)
+	for i := range segmentLen {
+		if i == 0 {
+			b[i] = randomValidByteInRange(minStartingByte, maxByte)
+		} else {
+			b[i] = randomValidByteInRange(minByte, maxByte)
+		}
+	}
+	return string(b)
+}
+
+func randomValidByteInRange(min, max int) byte {
+	for {
+		candidate := byte(min + rand.IntN(max-min+1))
+		if !strings.ContainsRune(breakingChars, rune(candidate)) {
+			return candidate
+		}
+	}
+}
+
+func encodeScopes(scopes []string) ([]string, error) {
+	encoded := make([]string, len(scopes))
+	for i, scope := range scopes {
+		var err error
+		encoded[i], err = EncodeForKey(scope)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return encoded, nil
+}
+
+func decodeScopes(encodedScopes []string) ([]string, error) {
+	scopes := make([]string, len(encodedScopes))
+	for i, encodedScope := range encodedScopes {
+		var err error
+		scopes[i], err = DecodeFromKey(encodedScope)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return scopes, nil
+}


### PR DESCRIPTION
The design for scope namespacing requires an encoding of scopes suitable for inclusion in backend keys https://github.com/gravitational/rfd/pull/36/changes#diff-b58d6cae8289d86d32bcb88ac22fd7e20e8fba7b7e61b06f10c7a09c3cfcff71

This design is in progress and there is not yet an implementation. I wrote this simple version to unblock my work prototyping scoped access lists. In discussion with the scopes team, we determined this may be useful for others in the interim until we have the "real" implementation, hence I have raised this PR.