### PR TITLE
Improve Azure VM discovery performance

### DIFF
--- a/lib/cloud/azure/vm.go
+++ b/lib/cloud/azure/vm.go
@@ -39,6 +39,9 @@ import (
 // virtual scale set VMs.
 const virtualScaleSetUniformVMResourceType = "virtualMachineScaleSets/virtualMachines"
 
+// runCommandResultPollingFrequency is the time to wait between polling for Azure run-command completion.
+const runCommandResultPollingFrequency = 30 * time.Second
+
 // virtualMachinesLister provides an interface for an Azure virtual machine client.
 type virtualMachinesLister interface {
 	// Get retrieves information about an Azure virtual machine.
@@ -528,7 +531,7 @@ func (c *runCommandClient) regularVirtualMachineRunCommand(ctx context.Context, 
 		return nil, trace.Wrap(ConvertResponseError(err))
 	}
 
-	_, err = poller.PollUntilDone(ctx, &runtime.PollUntilDoneOptions{Frequency: 10 * time.Second})
+	_, err = poller.PollUntilDone(ctx, &runtime.PollUntilDoneOptions{Frequency: runCommandResultPollingFrequency})
 	if err != nil {
 		return nil, trace.Wrap(ConvertResponseError(err))
 	}
@@ -551,7 +554,7 @@ func (c *runCommandClient) uniformScaleSetVirtualMachineRunCommand(ctx context.C
 		return nil, trace.Wrap(ConvertResponseError(err))
 	}
 
-	_, err = poller.PollUntilDone(ctx, &runtime.PollUntilDoneOptions{Frequency: 10 * time.Second})
+	_, err = poller.PollUntilDone(ctx, &runtime.PollUntilDoneOptions{Frequency: runCommandResultPollingFrequency})
 	if err != nil {
 		return nil, trace.Wrap(ConvertResponseError(err))
 	}

--- a/lib/srv/discovery/discovery.go
+++ b/lib/srv/discovery/discovery.go
@@ -40,6 +40,8 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/sts"
 	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
+	"golang.org/x/sync/errgroup"
+	"golang.org/x/sync/semaphore"
 	"google.golang.org/protobuf/types/known/timestamppb"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
@@ -1532,7 +1534,7 @@ func (e *limitedErrorReporter) summary(ctx context.Context) {
 	}
 }
 
-func (s *Server) enrollAzureVirtualMachines(log *slog.Logger, instances *server.AzureInstances) ([]server.AzureInstallResult, error) {
+func (s *Server) enrollAzureVirtualMachines(log *slog.Logger, instances *server.AzureInstances, sem *semaphore.Weighted) ([]server.AzureInstallResult, error) {
 	azureClients, err := s.getAzureClients(s.ctx, instances.Metadata.Integration)
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -1558,6 +1560,12 @@ func (s *Server) enrollAzureVirtualMachines(log *slog.Logger, instances *server.
 		ResourceGroup:   instances.Metadata.ResourceGroup,
 		InstallerParams: instances.Metadata.InstallerParams,
 		ProxyAddrGetter: s.publicProxyAddress,
+		AcquireLease: func(ctx context.Context) (release func(), err error) {
+			if err := sem.Acquire(ctx, 1); err != nil {
+				return nil, trace.Wrap(err)
+			}
+			return func() { sem.Release(1) }, nil
+		},
 		OnRunCommandFinished: func(result server.AzureInstallResult) {
 			s.emitAzureInstallEvents(log, instances.Metadata, result)
 			if result.Failure() {
@@ -1619,7 +1627,28 @@ func (s *Server) startAzureServerDiscovery() {
 	var sm *discoveryStatus
 	var vmTasks *azureVMTasks
 	var runStart time.Time
+	var eg *errgroup.Group
 
+	const (
+		// Limit the number of concurrent Azure VM installations, where each
+		// installation sends a command and then polls it until it's done and
+		// then collects the result.
+		azureVMInstallerConcurrencyLimit = 500
+		// Set an arbitrary limit on the number of goroutines that process VM
+		// groups. The concurrency semaphore still bounds in-flight parallel
+		// installations, but we process VMs in groups of fetched VMs.
+		// The main purpose of this limit is to bound memory usage and the
+		// number of running goroutines for discovered VMs that are pending
+		// installation.
+		// Also, in theory, a single fetcher could fetch many thousands of VMs,
+		// for which this limit does not bound the memory usage, but addressing
+		// that concern properly would require an extensive refactor to process
+		// discovered VMs one page of API results at a time.
+		// Memory usage for thousands of VMs is not much anyway, so in practice
+		// that is not an issue.
+		azureVMGroupProcessingConcurrencyLimit = 250
+	)
+	sem := semaphore.NewWeighted(azureVMInstallerConcurrencyLimit)
 	azureWatcher = server.NewWatcher(
 		s.ctx,
 		s.Log.With("cloud", "Azure"),
@@ -1631,6 +1660,8 @@ func (s *Server) startAzureServerDiscovery() {
 			}
 			sm = newStatusMap(types.AzureMatcherVM, runStart)
 			vmTasks = &azureVMTasks{}
+			eg = &errgroup.Group{}
+			eg.SetLimit(azureVMGroupProcessingConcurrencyLimit)
 
 			// Initialize the status map with an entry per fetcher (discoveryConfig + integration).
 			// The per-instance hook only receives the slice of instance groups; when a fetcher
@@ -1643,7 +1674,7 @@ func (s *Server) startAzureServerDiscovery() {
 					discoveryConfigName: fetcher.GetDiscoveryConfigName(),
 					integration:         fetcher.IntegrationName(),
 				}
-				sm.add(key, discoveryGroupStatus{})
+				sm.add(key)
 			}
 			s.updateDiscoveryConfigStatus(sm.discoveryConfigs()...)
 		}),
@@ -1653,14 +1684,26 @@ func (s *Server) startAzureServerDiscovery() {
 					discoveryConfigName: group.Metadata.DiscoveryConfigName,
 					integration:         group.Metadata.Integration,
 				}
-				status := s.installAzureServers(group, vmTasks)
-				sm.add(key, status)
+				status, err := s.reconcileAzureServers(group)
+				if err != nil {
+					s.Log.WarnContext(s.ctx, "Failed to reconcile discovered Azure instances with current Teleport nodes, skipping installation",
+						"group", group,
+						"error", err,
+					)
+					continue
+				}
+				eg.Go(func() error {
+					status := s.installAzureServers(group, vmTasks, status, sem)
+					sm.updateConcurrently(key, status)
+					return nil
+				})
 			}
 		}),
 		server.WithPostFetchHookFn[*server.AzureInstances](func() {
 			// refresh the fetchers after every iteration to avoid stale config
 			defer fullRefresh()
 
+			_ = eg.Wait()
 			sm.syncEnded(s.clock.Now())
 			// update statuses of relevant discovery configs.
 			s.azureVMStatus.Store(sm)
@@ -1681,21 +1724,20 @@ func (s *Server) startAzureServerDiscovery() {
 	go azureWatcher.Run()
 }
 
-func (s *Server) installAzureServers(instances *server.AzureInstances, vmTasks *azureVMTasks) discoveryGroupStatus {
+func (s *Server) reconcileAzureServers(instances *server.AzureInstances) (discoveryGroupStatus, error) {
 	var status discoveryGroupStatus
 	log := s.Log.With("group", instances)
 	log.DebugContext(s.ctx, "Processing instance group")
 	found := len(instances.Instances)
 	if found == 0 {
-		log.DebugContext(s.ctx, "No Azure instances found, skipping installation")
-		return status
+		log.DebugContext(s.ctx, "No Azure instances found")
+		return status, nil
 	}
 	status.found += found
 
 	nodes, err := s.nodeWatcher.CurrentResources(s.ctx)
 	if err != nil {
-		log.WarnContext(s.ctx, "Failed to get current node resources", "error", err)
-		return status
+		return status, trace.Wrap(err, "get current resources")
 	}
 	instances.FilterExistingNodes(nodes)
 
@@ -1707,10 +1749,12 @@ func (s *Server) installAzureServers(instances *server.AzureInstances, vmTasks *
 		log.DebugContext(s.ctx, "Filtered out Azure instances that have already been enrolled",
 			"enrolled", enrolled,
 		)
-		// re-evaluate the instances log value after filtering
-		log = s.Log.With("group", instances)
 	}
+	return status, nil
+}
 
+func (s *Server) installAzureServers(instances *server.AzureInstances, vmTasks *azureVMTasks, status discoveryGroupStatus, sem *semaphore.Weighted) discoveryGroupStatus {
+	log := s.Log.With("group", instances)
 	if len(instances.Instances) == 0 {
 		log.DebugContext(s.ctx, "No Azure instances remain to enroll, skipping installation")
 		return status
@@ -1746,7 +1790,7 @@ func (s *Server) installAzureServers(instances *server.AzureInstances, vmTasks *
 	}
 
 	log.DebugContext(s.ctx, "Running Teleport installation on virtual machines", "vms", genAzureInstancesLogStr(instances.Instances))
-	failures, err := s.enrollAzureVirtualMachines(log, instances)
+	failures, err := s.enrollAzureVirtualMachines(log, instances, sem)
 	if err != nil {
 		// treat non-nil err as deployment failure affecting all machines.
 		log.WarnContext(s.ctx, "Failed to enroll all discovered Azure VMs", "error", err)

--- a/lib/srv/discovery/status.go
+++ b/lib/srv/discovery/status.go
@@ -930,6 +930,7 @@ type azureVMTaskKey struct {
 
 // azureVMTasks contains the Discover Azure VM User Tasks that must be reported to the user.
 type azureVMTasks struct {
+	mu         sync.Mutex
 	taskGroups map[usertasks.TaskGroup]map[azureVMTaskKey]*usertasksv1.DiscoverAzureVM
 }
 
@@ -942,6 +943,9 @@ func (t *azureVMTasks) addFailedEnrollment(tg usertasks.TaskGroup, key azureVMTa
 	if tg.IssueType == "" {
 		return
 	}
+
+	t.mu.Lock()
+	defer t.mu.Unlock()
 
 	if t.taskGroups == nil {
 		t.taskGroups = make(map[usertasks.TaskGroup]map[azureVMTaskKey]*usertasksv1.DiscoverAzureVM)
@@ -971,6 +975,8 @@ func (t *azureVMTasks) addFailedEnrollment(tg usertasks.TaskGroup, key azureVMTa
 func (t *azureVMTasks) upsertAll(s *taskUpdater) {
 	expiryTime := s.clock.Now().Add(2 * s.PollInterval)
 
+	t.mu.Lock()
+	defer t.mu.Unlock()
 	for taskGroup, group := range t.taskGroups {
 		for azureKey, vmData := range group {
 			// skip empty entries
@@ -1086,6 +1092,7 @@ type discoveryGroupStatus struct {
 // discovery group key (discovery config + integration combination).
 type discoveryStatus struct {
 	resourceType string
+	statusesMu   sync.Mutex
 	statuses     map[discoveryGroupStatusKey]*discoveryGroupStatus
 	syncStart    *time.Time
 	syncEnd      *time.Time
@@ -1103,12 +1110,20 @@ func (s *discoveryStatus) syncEnded(syncEnd time.Time) {
 	s.syncEnd = &syncEnd
 }
 
-func (s *discoveryStatus) add(key discoveryGroupStatusKey, update discoveryGroupStatus) {
-	if s.statuses[key] == nil {
+func (s *discoveryStatus) add(key discoveryGroupStatusKey) {
+	if status := s.statuses[key]; status == nil {
+		s.statuses[key] = &discoveryGroupStatus{}
+	}
+}
+
+func (s *discoveryStatus) updateConcurrently(key discoveryGroupStatusKey, update discoveryGroupStatus) {
+	s.statusesMu.Lock()
+	defer s.statusesMu.Unlock()
+	status := s.statuses[key]
+	if status == nil {
 		s.statuses[key] = &update
 		return
 	}
-	status := s.statuses[key]
 	status.found += update.found
 	status.enrolled += update.enrolled
 	status.failed += update.failed

--- a/lib/srv/server/azure_installer.go
+++ b/lib/srv/server/azure_installer.go
@@ -31,11 +31,14 @@ import (
 // AzureInstallRequest combines parameters for running commands on a set of Azure
 // virtual machines.
 type AzureInstallRequest struct {
-	Instances            []*azure.VirtualMachine
-	InstallerParams      *types.InstallerParams
-	ProxyAddrGetter      func(context.Context) (string, error)
-	Region               string
-	ResourceGroup        string
+	Instances       []*azure.VirtualMachine
+	InstallerParams *types.InstallerParams
+	ProxyAddrGetter func(context.Context) (string, error)
+	Region          string
+	ResourceGroup   string
+	// AcquireLease acquires a lease before the install request runs a command.
+	// This limits the number of installers that are run and polled concurrently.
+	AcquireLease         func(ctx context.Context) (release func(), err error)
 	OnRunCommandFinished func(result AzureInstallResult)
 }
 
@@ -66,19 +69,27 @@ func (req *AzureInstallRequest) Run(ctx context.Context, client azure.RunCommand
 	if err != nil {
 		return trace.Wrap(err)
 	}
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
 	g, ctx := errgroup.WithContext(ctx)
 
-	// Somewhat arbitrary limit to make sure Teleport doesn't have to install
-	// hundreds of nodes at once.
-	// TODO (Tener): increase limit/make it configurable.
-	const azureParallelInstallLimit = 10
-	g.SetLimit(azureParallelInstallLimit)
+	if req.AcquireLease == nil {
+		// enforce an arbitrary limit if the caller didn't provide a lease func.
+		g.SetLimit(10)
+	}
 
 	for _, inst := range req.Instances {
 		g.Go(func() error {
 			// If the caller cancels, stop trying to run more commands.
 			if err := ctx.Err(); err != nil {
 				return err
+			}
+			if req.AcquireLease != nil {
+				release, err := req.AcquireLease(ctx)
+				if err != nil {
+					return trace.Wrap(err)
+				}
+				defer release()
 			}
 
 			runRequest := azure.RunCommandRequest{

--- a/lib/srv/server/azure_installer_test.go
+++ b/lib/srv/server/azure_installer_test.go
@@ -19,10 +19,12 @@ package server
 import (
 	"context"
 	"errors"
+	"maps"
 	"slices"
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v6"
 	"github.com/gravitational/trace"
@@ -32,8 +34,7 @@ import (
 	"github.com/gravitational/teleport/lib/cloud/azure"
 )
 
-type mockRunCommandClient struct {
-}
+type mockRunCommandClient struct{}
 
 func (m *mockRunCommandClient) Run(ctx context.Context, req azure.RunCommandRequest) (*azure.RunCommandResult, error) {
 	if strings.HasPrefix(req.VMName, "bad") {
@@ -46,6 +47,114 @@ func (m *mockRunCommandClient) Run(ctx context.Context, req azure.RunCommandRequ
 		StdOut:         "Mock stdout",
 		StdErr:         "Mock stderr",
 	}, nil
+}
+
+type blockingFakeRunCommandClient struct {
+	started     chan struct{}
+	unblockOnce sync.Once
+	unblockCh   chan struct{}
+
+	mu      sync.Mutex
+	blocked map[string]struct{}
+}
+
+func newBlockingRunCommandClient(instanceCount int) *blockingFakeRunCommandClient {
+	return &blockingFakeRunCommandClient{
+		started:   make(chan struct{}, instanceCount),
+		unblockCh: make(chan struct{}),
+		blocked:   make(map[string]struct{}),
+	}
+}
+
+func (m *blockingFakeRunCommandClient) Run(ctx context.Context, req azure.RunCommandRequest) (*azure.RunCommandResult, error) {
+	m.mu.Lock()
+	m.blocked[req.VMName] = struct{}{}
+	m.mu.Unlock()
+	defer func() {
+		m.mu.Lock()
+		delete(m.blocked, req.VMName)
+		m.mu.Unlock()
+	}()
+
+	select {
+	case m.started <- struct{}{}:
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+
+	// block so other installs can enter Run. If the installer becomes
+	// sequential, blockUntil will time out waiting for the later starts instead
+	// of observing the full instance set.
+	select {
+	case <-m.unblockCh:
+		return &azure.RunCommandResult{
+			ExecutionState: string(armcompute.ExecutionStateSucceeded),
+			ExitCode:       0,
+			StdOut:         "Mock stdout",
+			StdErr:         "Mock stderr",
+		}, nil
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+}
+
+func (m *blockingFakeRunCommandClient) blockUntil(count int) []string {
+	for len(m.blockedVMs()) < count {
+		select {
+		case <-m.started:
+		case <-time.After(5 * time.Second):
+			return m.blockedVMs()
+		}
+	}
+	return m.blockedVMs()
+}
+
+func (m *blockingFakeRunCommandClient) unblock() {
+	m.unblockOnce.Do(func() {
+		close(m.unblockCh)
+	})
+}
+
+func (m *blockingFakeRunCommandClient) blockedVMs() []string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	return slices.Collect(maps.Keys(m.blocked))
+}
+
+func newFakeSemaphore(maxLeases int) *fakeSemaphore {
+	return &fakeSemaphore{
+		sem:    make(chan struct{}, maxLeases),
+		closed: make(chan struct{}),
+	}
+}
+
+type fakeSemaphore struct {
+	sem    chan struct{}
+	closed chan struct{}
+}
+
+func (f *fakeSemaphore) acquire(ctx context.Context) (func(), error) {
+	select {
+	case f.sem <- struct{}{}:
+	case <-f.closed:
+		return nil, errors.New("fake semaphore closed")
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+	return f.release, nil
+}
+
+func (f *fakeSemaphore) release() {
+	<-f.sem
+}
+
+func (f *fakeSemaphore) getActive() int {
+	return len(f.sem)
+}
+
+func (f *fakeSemaphore) close() {
+	close(f.closed)
 }
 
 func TestAzureInstallRequestRun(t *testing.T) {
@@ -149,4 +258,81 @@ func TestAzureInstallRequestRun(t *testing.T) {
 			}
 		})
 	}
+
+	runAzureInstallRequest := func(t *testing.T, req *AzureInstallRequest, client azure.RunCommandClient) <-chan error {
+		t.Helper()
+		errCh := make(chan error, 1)
+		go func() { errCh <- req.Run(t.Context(), client) }()
+		return errCh
+	}
+	makeTestAzureInstallRequest := func(instances []*azure.VirtualMachine) *AzureInstallRequest {
+		return &AzureInstallRequest{
+			Instances: instances,
+			InstallerParams: &types.InstallerParams{
+				JoinMethod: types.JoinMethodAzure,
+				JoinToken:  "test-token",
+			},
+			ProxyAddrGetter: func(ctx context.Context) (string, error) {
+				return "proxy.example.com:443", nil
+			},
+			Region:        "eastus",
+			ResourceGroup: "test-rg",
+			AcquireLease: func(context.Context) (func(), error) {
+				return func() {}, nil
+			},
+		}
+	}
+
+	t.Run("runs installations in parallel", func(t *testing.T) {
+		t.Parallel()
+
+		instances := makeVMs("vm-1", "vm-2", "vm-3")
+		client := newBlockingRunCommandClient(len(instances))
+		defer client.unblock()
+		req := makeTestAzureInstallRequest(instances)
+
+		runErrCh := runAzureInstallRequest(t, req, client)
+		require.ElementsMatch(t, []string{"vm-1", "vm-2", "vm-3"}, client.blockUntil(len(instances)))
+
+		client.unblock()
+		require.NoError(t, <-runErrCh)
+	})
+
+	t.Run("acquires and releases lease", func(t *testing.T) {
+		t.Parallel()
+
+		instances := makeVMs("vm-1", "vm-2", "vm-3")
+		client := newBlockingRunCommandClient(len(instances))
+		defer client.unblock()
+		leases := newFakeSemaphore(3)
+		req := makeTestAzureInstallRequest(instances)
+		req.AcquireLease = leases.acquire
+
+		runErrCh := runAzureInstallRequest(t, req, client)
+
+		require.ElementsMatch(t, []string{"vm-1", "vm-2", "vm-3"}, client.blockUntil(len(instances)))
+		require.Equal(t, len(instances), leases.getActive())
+		client.unblock()
+		require.NoError(t, <-runErrCh)
+		require.Zero(t, leases.getActive())
+	})
+
+	t.Run("returns acquire lease error", func(t *testing.T) {
+		t.Parallel()
+
+		instances := makeVMs("vm-1", "vm-2")
+		client := newBlockingRunCommandClient(len(instances))
+		defer client.unblock()
+		leases := newFakeSemaphore(1)
+		req := makeTestAzureInstallRequest(instances)
+		req.AcquireLease = leases.acquire
+
+		runErrCh := runAzureInstallRequest(t, req, client)
+		_ = client.blockUntil(1)
+		require.Equal(t, 1, leases.getActive())
+		leases.close()
+		require.ErrorContains(t, <-runErrCh, "fake semaphore closed")
+		require.Empty(t, client.blockedVMs())
+		require.Zero(t, leases.getActive())
+	})
 }


### PR DESCRIPTION
Issue: https://github.com/gravitational/teleport/issues/67402
- https://github.com/gravitational/teleport/issues/67402

* run Azure VM discovery installers in parallel
* run Azure VM fetchers concurrent with installations

<!-- Provide a descriptive entry for the changelog of the next release. -->

Changelog: Improved the rate of Azure VM auto-discovery and enrollment.


## Manual Test Plan
### Test Environment
- cloud staging tenant patched to a dev build
- local discovery agent running a dev build with `-race` flag added
- multiple VMs in multiple subscriptions
- terraform the azure discovery config and integration to discover all VMs

### Test Cases
- [x] expected VMs are discovered
- [x] expected VMs are enrolled
- [x] extremely slow installer scripts timeout and collect stdout/stderr
- [x] installer scripts that never provision (e.g., no run-command agent on the VM running) also timeout
- [x] all VMs are discovered and processed concurrently. Elapsed time for the entire set of VMs is roughly the length of a single timeout (~5 mins + overhead), not a cumulative sum of timeouts for all the VMs that timed out.

I also manually tested with artificial duplication (deep copies) of the VM groups and no limits to get an idea of the memory usage when setting limits.
Even with >30 thousand groups of a single VM each (thus each group launches in a separate goroutine), the additional memory usage was measured in only 10s of MB. 
Thus the generous limits that I set are actually conservative limits as far as memory usage and goroutines is concerned. 
It's important to note for anyone who tries to reproduce this that goroutine memory overhead is substantially greater if you build with `-race`, so I did not build with `-race` while testing memory usage with unbounded goroutines.

