### PR TITLE
Add BeamCreate and BeamDestroy usage events

### DIFF
--- a/gen/proto/go/prehog/v1alpha/teleport.pb.go
+++ b/gen/proto/go/prehog/v1alpha/teleport.pb.go
@@ -258,6 +258,58 @@ func (UserKind) EnumDescriptor() ([]byte, []int) {
 	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{2}
 }
 
+// BeamDestroyReason is the reason a beam was destroyed.
+type BeamDestroyReason int32
+
+const (
+	BeamDestroyReason_BEAM_DESTROY_REASON_UNSPECIFIED BeamDestroyReason = 0
+	// the user explicitly deleted the beam
+	BeamDestroyReason_BEAM_DESTROY_REASON_USER_DELETED BeamDestroyReason = 1
+	// the beam was deleted by the garbage collector after expiry
+	BeamDestroyReason_BEAM_DESTROY_REASON_GC_EXPIRED BeamDestroyReason = 2
+)
+
+// Enum value maps for BeamDestroyReason.
+var (
+	BeamDestroyReason_name = map[int32]string{
+		0: "BEAM_DESTROY_REASON_UNSPECIFIED",
+		1: "BEAM_DESTROY_REASON_USER_DELETED",
+		2: "BEAM_DESTROY_REASON_GC_EXPIRED",
+	}
+	BeamDestroyReason_value = map[string]int32{
+		"BEAM_DESTROY_REASON_UNSPECIFIED":  0,
+		"BEAM_DESTROY_REASON_USER_DELETED": 1,
+		"BEAM_DESTROY_REASON_GC_EXPIRED":   2,
+	}
+)
+
+func (x BeamDestroyReason) Enum() *BeamDestroyReason {
+	p := new(BeamDestroyReason)
+	*p = x
+	return p
+}
+
+func (x BeamDestroyReason) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (BeamDestroyReason) Descriptor() protoreflect.EnumDescriptor {
+	return file_prehog_v1alpha_teleport_proto_enumTypes[3].Descriptor()
+}
+
+func (BeamDestroyReason) Type() protoreflect.EnumType {
+	return &file_prehog_v1alpha_teleport_proto_enumTypes[3]
+}
+
+func (x BeamDestroyReason) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use BeamDestroyReason.Descriptor instead.
+func (BeamDestroyReason) EnumDescriptor() ([]byte, []int) {
+	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{3}
+}
+
 // DiscoverResource represents a resource type.
 type DiscoverResource int32
 
@@ -418,11 +470,11 @@ func (x DiscoverResource) String() string {
 }
 
 func (DiscoverResource) Descriptor() protoreflect.EnumDescriptor {
-	return file_prehog_v1alpha_teleport_proto_enumTypes[3].Descriptor()
+	return file_prehog_v1alpha_teleport_proto_enumTypes[4].Descriptor()
 }
 
 func (DiscoverResource) Type() protoreflect.EnumType {
-	return &file_prehog_v1alpha_teleport_proto_enumTypes[3]
+	return &file_prehog_v1alpha_teleport_proto_enumTypes[4]
 }
 
 func (x DiscoverResource) Number() protoreflect.EnumNumber {
@@ -431,7 +483,7 @@ func (x DiscoverResource) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use DiscoverResource.Descriptor instead.
 func (DiscoverResource) EnumDescriptor() ([]byte, []int) {
-	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{3}
+	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{4}
 }
 
 // DiscoverStatus represents a Discover Step outcome.
@@ -481,11 +533,11 @@ func (x DiscoverStatus) String() string {
 }
 
 func (DiscoverStatus) Descriptor() protoreflect.EnumDescriptor {
-	return file_prehog_v1alpha_teleport_proto_enumTypes[4].Descriptor()
+	return file_prehog_v1alpha_teleport_proto_enumTypes[5].Descriptor()
 }
 
 func (DiscoverStatus) Type() protoreflect.EnumType {
-	return &file_prehog_v1alpha_teleport_proto_enumTypes[4]
+	return &file_prehog_v1alpha_teleport_proto_enumTypes[5]
 }
 
 func (x DiscoverStatus) Number() protoreflect.EnumNumber {
@@ -494,7 +546,7 @@ func (x DiscoverStatus) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use DiscoverStatus.Descriptor instead.
 func (DiscoverStatus) EnumDescriptor() ([]byte, []int) {
-	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{4}
+	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{5}
 }
 
 // CTA represents teleport web UI's call to action buttons
@@ -567,11 +619,11 @@ func (x CTA) String() string {
 }
 
 func (CTA) Descriptor() protoreflect.EnumDescriptor {
-	return file_prehog_v1alpha_teleport_proto_enumTypes[5].Descriptor()
+	return file_prehog_v1alpha_teleport_proto_enumTypes[6].Descriptor()
 }
 
 func (CTA) Type() protoreflect.EnumType {
-	return &file_prehog_v1alpha_teleport_proto_enumTypes[5]
+	return &file_prehog_v1alpha_teleport_proto_enumTypes[6]
 }
 
 func (x CTA) Number() protoreflect.EnumNumber {
@@ -580,7 +632,7 @@ func (x CTA) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use CTA.Descriptor instead.
 func (CTA) EnumDescriptor() ([]byte, []int) {
-	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{5}
+	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{6}
 }
 
 // IntegrationEnrollKind represents the types of integration that
@@ -708,11 +760,11 @@ func (x IntegrationEnrollKind) String() string {
 }
 
 func (IntegrationEnrollKind) Descriptor() protoreflect.EnumDescriptor {
-	return file_prehog_v1alpha_teleport_proto_enumTypes[6].Descriptor()
+	return file_prehog_v1alpha_teleport_proto_enumTypes[7].Descriptor()
 }
 
 func (IntegrationEnrollKind) Type() protoreflect.EnumType {
-	return &file_prehog_v1alpha_teleport_proto_enumTypes[6]
+	return &file_prehog_v1alpha_teleport_proto_enumTypes[7]
 }
 
 func (x IntegrationEnrollKind) Number() protoreflect.EnumNumber {
@@ -721,7 +773,7 @@ func (x IntegrationEnrollKind) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use IntegrationEnrollKind.Descriptor instead.
 func (IntegrationEnrollKind) EnumDescriptor() ([]byte, []int) {
-	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{6}
+	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{7}
 }
 
 // IntegrationEnrollStep defines inner configuration steps
@@ -796,11 +848,11 @@ func (x IntegrationEnrollStep) String() string {
 }
 
 func (IntegrationEnrollStep) Descriptor() protoreflect.EnumDescriptor {
-	return file_prehog_v1alpha_teleport_proto_enumTypes[7].Descriptor()
+	return file_prehog_v1alpha_teleport_proto_enumTypes[8].Descriptor()
 }
 
 func (IntegrationEnrollStep) Type() protoreflect.EnumType {
-	return &file_prehog_v1alpha_teleport_proto_enumTypes[7]
+	return &file_prehog_v1alpha_teleport_proto_enumTypes[8]
 }
 
 func (x IntegrationEnrollStep) Number() protoreflect.EnumNumber {
@@ -809,7 +861,7 @@ func (x IntegrationEnrollStep) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use IntegrationEnrollStep.Descriptor instead.
 func (IntegrationEnrollStep) EnumDescriptor() ([]byte, []int) {
-	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{7}
+	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{8}
 }
 
 // IntegrationEnrollStatusCode defines status code for an integration enroll step.
@@ -859,11 +911,11 @@ func (x IntegrationEnrollStatusCode) String() string {
 }
 
 func (IntegrationEnrollStatusCode) Descriptor() protoreflect.EnumDescriptor {
-	return file_prehog_v1alpha_teleport_proto_enumTypes[8].Descriptor()
+	return file_prehog_v1alpha_teleport_proto_enumTypes[9].Descriptor()
 }
 
 func (IntegrationEnrollStatusCode) Type() protoreflect.EnumType {
-	return &file_prehog_v1alpha_teleport_proto_enumTypes[8]
+	return &file_prehog_v1alpha_teleport_proto_enumTypes[9]
 }
 
 func (x IntegrationEnrollStatusCode) Number() protoreflect.EnumNumber {
@@ -872,7 +924,7 @@ func (x IntegrationEnrollStatusCode) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use IntegrationEnrollStatusCode.Descriptor instead.
 func (IntegrationEnrollStatusCode) EnumDescriptor() ([]byte, []int) {
-	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{8}
+	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{9}
 }
 
 // IntegrationEnrollSection identifies a section the user opened or expanded in
@@ -917,11 +969,11 @@ func (x IntegrationEnrollSection) String() string {
 }
 
 func (IntegrationEnrollSection) Descriptor() protoreflect.EnumDescriptor {
-	return file_prehog_v1alpha_teleport_proto_enumTypes[9].Descriptor()
+	return file_prehog_v1alpha_teleport_proto_enumTypes[10].Descriptor()
 }
 
 func (IntegrationEnrollSection) Type() protoreflect.EnumType {
-	return &file_prehog_v1alpha_teleport_proto_enumTypes[9]
+	return &file_prehog_v1alpha_teleport_proto_enumTypes[10]
 }
 
 func (x IntegrationEnrollSection) Number() protoreflect.EnumNumber {
@@ -930,7 +982,7 @@ func (x IntegrationEnrollSection) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use IntegrationEnrollSection.Descriptor instead.
 func (IntegrationEnrollSection) EnumDescriptor() ([]byte, []int) {
-	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{9}
+	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{10}
 }
 
 // IntegrationEnrollField identifies a field the user completed in an integration
@@ -999,11 +1051,11 @@ func (x IntegrationEnrollField) String() string {
 }
 
 func (IntegrationEnrollField) Descriptor() protoreflect.EnumDescriptor {
-	return file_prehog_v1alpha_teleport_proto_enumTypes[10].Descriptor()
+	return file_prehog_v1alpha_teleport_proto_enumTypes[11].Descriptor()
 }
 
 func (IntegrationEnrollField) Type() protoreflect.EnumType {
-	return &file_prehog_v1alpha_teleport_proto_enumTypes[10]
+	return &file_prehog_v1alpha_teleport_proto_enumTypes[11]
 }
 
 func (x IntegrationEnrollField) Number() protoreflect.EnumNumber {
@@ -1012,7 +1064,7 @@ func (x IntegrationEnrollField) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use IntegrationEnrollField.Descriptor instead.
 func (IntegrationEnrollField) EnumDescriptor() ([]byte, []int) {
-	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{10}
+	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{11}
 }
 
 // IntegrationEnrollCodeType identifies the type of code that was copied in an
@@ -1050,11 +1102,11 @@ func (x IntegrationEnrollCodeType) String() string {
 }
 
 func (IntegrationEnrollCodeType) Descriptor() protoreflect.EnumDescriptor {
-	return file_prehog_v1alpha_teleport_proto_enumTypes[11].Descriptor()
+	return file_prehog_v1alpha_teleport_proto_enumTypes[12].Descriptor()
 }
 
 func (IntegrationEnrollCodeType) Type() protoreflect.EnumType {
-	return &file_prehog_v1alpha_teleport_proto_enumTypes[11]
+	return &file_prehog_v1alpha_teleport_proto_enumTypes[12]
 }
 
 func (x IntegrationEnrollCodeType) Number() protoreflect.EnumNumber {
@@ -1063,7 +1115,7 @@ func (x IntegrationEnrollCodeType) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use IntegrationEnrollCodeType.Descriptor instead.
 func (IntegrationEnrollCodeType) EnumDescriptor() ([]byte, []int) {
-	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{11}
+	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{12}
 }
 
 // EditorChangeStatus is the possible value of an EditorChangeEvent event status
@@ -1102,11 +1154,11 @@ func (x EditorChangeStatus) String() string {
 }
 
 func (EditorChangeStatus) Descriptor() protoreflect.EnumDescriptor {
-	return file_prehog_v1alpha_teleport_proto_enumTypes[12].Descriptor()
+	return file_prehog_v1alpha_teleport_proto_enumTypes[13].Descriptor()
 }
 
 func (EditorChangeStatus) Type() protoreflect.EnumType {
-	return &file_prehog_v1alpha_teleport_proto_enumTypes[12]
+	return &file_prehog_v1alpha_teleport_proto_enumTypes[13]
 }
 
 func (x EditorChangeStatus) Number() protoreflect.EnumNumber {
@@ -1115,7 +1167,7 @@ func (x EditorChangeStatus) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use EditorChangeStatus.Descriptor instead.
 func (EditorChangeStatus) EnumDescriptor() ([]byte, []int) {
-	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{12}
+	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{13}
 }
 
 // Feature is name of Teleport feature
@@ -1149,11 +1201,11 @@ func (x Feature) String() string {
 }
 
 func (Feature) Descriptor() protoreflect.EnumDescriptor {
-	return file_prehog_v1alpha_teleport_proto_enumTypes[13].Descriptor()
+	return file_prehog_v1alpha_teleport_proto_enumTypes[14].Descriptor()
 }
 
 func (Feature) Type() protoreflect.EnumType {
-	return &file_prehog_v1alpha_teleport_proto_enumTypes[13]
+	return &file_prehog_v1alpha_teleport_proto_enumTypes[14]
 }
 
 func (x Feature) Number() protoreflect.EnumNumber {
@@ -1162,7 +1214,7 @@ func (x Feature) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use Feature.Descriptor instead.
 func (Feature) EnumDescriptor() ([]byte, []int) {
-	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{13}
+	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{14}
 }
 
 // FeatureRecommendationStatus is feature recommendation status.
@@ -1201,11 +1253,11 @@ func (x FeatureRecommendationStatus) String() string {
 }
 
 func (FeatureRecommendationStatus) Descriptor() protoreflect.EnumDescriptor {
-	return file_prehog_v1alpha_teleport_proto_enumTypes[14].Descriptor()
+	return file_prehog_v1alpha_teleport_proto_enumTypes[15].Descriptor()
 }
 
 func (FeatureRecommendationStatus) Type() protoreflect.EnumType {
-	return &file_prehog_v1alpha_teleport_proto_enumTypes[14]
+	return &file_prehog_v1alpha_teleport_proto_enumTypes[15]
 }
 
 func (x FeatureRecommendationStatus) Number() protoreflect.EnumNumber {
@@ -1214,7 +1266,7 @@ func (x FeatureRecommendationStatus) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use FeatureRecommendationStatus.Descriptor instead.
 func (FeatureRecommendationStatus) EnumDescriptor() ([]byte, []int) {
-	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{14}
+	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{15}
 }
 
 // LicenseLimit indicates event type that triggered LicenseLimitEvent.
@@ -1261,11 +1313,11 @@ func (x LicenseLimit) String() string {
 }
 
 func (LicenseLimit) Descriptor() protoreflect.EnumDescriptor {
-	return file_prehog_v1alpha_teleport_proto_enumTypes[15].Descriptor()
+	return file_prehog_v1alpha_teleport_proto_enumTypes[16].Descriptor()
 }
 
 func (LicenseLimit) Type() protoreflect.EnumType {
-	return &file_prehog_v1alpha_teleport_proto_enumTypes[15]
+	return &file_prehog_v1alpha_teleport_proto_enumTypes[16]
 }
 
 func (x LicenseLimit) Number() protoreflect.EnumNumber {
@@ -1274,7 +1326,7 @@ func (x LicenseLimit) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use LicenseLimit.Descriptor instead.
 func (LicenseLimit) EnumDescriptor() ([]byte, []int) {
-	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{15}
+	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{16}
 }
 
 // DiscoveryConfigAction is the action performed on a DiscoveryConfig.
@@ -1314,11 +1366,11 @@ func (x DiscoveryConfigAction) String() string {
 }
 
 func (DiscoveryConfigAction) Descriptor() protoreflect.EnumDescriptor {
-	return file_prehog_v1alpha_teleport_proto_enumTypes[16].Descriptor()
+	return file_prehog_v1alpha_teleport_proto_enumTypes[17].Descriptor()
 }
 
 func (DiscoveryConfigAction) Type() protoreflect.EnumType {
-	return &file_prehog_v1alpha_teleport_proto_enumTypes[16]
+	return &file_prehog_v1alpha_teleport_proto_enumTypes[17]
 }
 
 func (x DiscoveryConfigAction) Number() protoreflect.EnumNumber {
@@ -1327,7 +1379,7 @@ func (x DiscoveryConfigAction) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use DiscoveryConfigAction.Descriptor instead.
 func (DiscoveryConfigAction) EnumDescriptor() ([]byte, []int) {
-	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{16}
+	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{17}
 }
 
 // AccessListStatus represents a access list wizard step outcome.
@@ -1375,11 +1427,11 @@ func (x AccessListStatus) String() string {
 }
 
 func (AccessListStatus) Descriptor() protoreflect.EnumDescriptor {
-	return file_prehog_v1alpha_teleport_proto_enumTypes[17].Descriptor()
+	return file_prehog_v1alpha_teleport_proto_enumTypes[18].Descriptor()
 }
 
 func (AccessListStatus) Type() protoreflect.EnumType {
-	return &file_prehog_v1alpha_teleport_proto_enumTypes[17]
+	return &file_prehog_v1alpha_teleport_proto_enumTypes[18]
 }
 
 func (x AccessListStatus) Number() protoreflect.EnumNumber {
@@ -1388,7 +1440,7 @@ func (x AccessListStatus) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use AccessListStatus.Descriptor instead.
 func (AccessListStatus) EnumDescriptor() ([]byte, []int) {
-	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{17}
+	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{18}
 }
 
 // AccessListPreset represents the access list preset type.
@@ -1425,11 +1477,11 @@ func (x AccessListPreset) String() string {
 }
 
 func (AccessListPreset) Descriptor() protoreflect.EnumDescriptor {
-	return file_prehog_v1alpha_teleport_proto_enumTypes[18].Descriptor()
+	return file_prehog_v1alpha_teleport_proto_enumTypes[19].Descriptor()
 }
 
 func (AccessListPreset) Type() protoreflect.EnumType {
-	return &file_prehog_v1alpha_teleport_proto_enumTypes[18]
+	return &file_prehog_v1alpha_teleport_proto_enumTypes[19]
 }
 
 func (x AccessListPreset) Number() protoreflect.EnumNumber {
@@ -1438,7 +1490,7 @@ func (x AccessListPreset) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use AccessListPreset.Descriptor instead.
 func (AccessListPreset) EnumDescriptor() ([]byte, []int) {
-	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{18}
+	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{19}
 }
 
 // AccessListIntegrate describes what integration user
@@ -1474,11 +1526,11 @@ func (x AccessListIntegrate) String() string {
 }
 
 func (AccessListIntegrate) Descriptor() protoreflect.EnumDescriptor {
-	return file_prehog_v1alpha_teleport_proto_enumTypes[19].Descriptor()
+	return file_prehog_v1alpha_teleport_proto_enumTypes[20].Descriptor()
 }
 
 func (AccessListIntegrate) Type() protoreflect.EnumType {
-	return &file_prehog_v1alpha_teleport_proto_enumTypes[19]
+	return &file_prehog_v1alpha_teleport_proto_enumTypes[20]
 }
 
 func (x AccessListIntegrate) Number() protoreflect.EnumNumber {
@@ -1487,7 +1539,7 @@ func (x AccessListIntegrate) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use AccessListIntegrate.Descriptor instead.
 func (AccessListIntegrate) EnumDescriptor() ([]byte, []int) {
-	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{19}
+	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{20}
 }
 
 // DeployMethod describes the method used to deploy a service.
@@ -1528,11 +1580,11 @@ func (x UIDiscoverDeployServiceEvent_DeployMethod) String() string {
 }
 
 func (UIDiscoverDeployServiceEvent_DeployMethod) Descriptor() protoreflect.EnumDescriptor {
-	return file_prehog_v1alpha_teleport_proto_enumTypes[20].Descriptor()
+	return file_prehog_v1alpha_teleport_proto_enumTypes[21].Descriptor()
 }
 
 func (UIDiscoverDeployServiceEvent_DeployMethod) Type() protoreflect.EnumType {
-	return &file_prehog_v1alpha_teleport_proto_enumTypes[20]
+	return &file_prehog_v1alpha_teleport_proto_enumTypes[21]
 }
 
 func (x UIDiscoverDeployServiceEvent_DeployMethod) Number() protoreflect.EnumNumber {
@@ -1541,7 +1593,7 @@ func (x UIDiscoverDeployServiceEvent_DeployMethod) Number() protoreflect.EnumNum
 
 // Deprecated: Use UIDiscoverDeployServiceEvent_DeployMethod.Descriptor instead.
 func (UIDiscoverDeployServiceEvent_DeployMethod) EnumDescriptor() ([]byte, []int) {
-	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{33, 0}
+	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{35, 0}
 }
 
 // DeployType describes the type of deployment.
@@ -1584,11 +1636,11 @@ func (x UIDiscoverDeployServiceEvent_DeployType) String() string {
 }
 
 func (UIDiscoverDeployServiceEvent_DeployType) Descriptor() protoreflect.EnumDescriptor {
-	return file_prehog_v1alpha_teleport_proto_enumTypes[21].Descriptor()
+	return file_prehog_v1alpha_teleport_proto_enumTypes[22].Descriptor()
 }
 
 func (UIDiscoverDeployServiceEvent_DeployType) Type() protoreflect.EnumType {
-	return &file_prehog_v1alpha_teleport_proto_enumTypes[21]
+	return &file_prehog_v1alpha_teleport_proto_enumTypes[22]
 }
 
 func (x UIDiscoverDeployServiceEvent_DeployType) Number() protoreflect.EnumNumber {
@@ -1597,7 +1649,7 @@ func (x UIDiscoverDeployServiceEvent_DeployType) Number() protoreflect.EnumNumbe
 
 // Deprecated: Use UIDiscoverDeployServiceEvent_DeployType.Descriptor instead.
 func (UIDiscoverDeployServiceEvent_DeployType) EnumDescriptor() ([]byte, []int) {
-	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{33, 1}
+	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{35, 1}
 }
 
 // ConfigMethod describes how the discovery config is configured.
@@ -1645,11 +1697,11 @@ func (x UIDiscoverCreateDiscoveryConfigEvent_ConfigMethod) String() string {
 }
 
 func (UIDiscoverCreateDiscoveryConfigEvent_ConfigMethod) Descriptor() protoreflect.EnumDescriptor {
-	return file_prehog_v1alpha_teleport_proto_enumTypes[22].Descriptor()
+	return file_prehog_v1alpha_teleport_proto_enumTypes[23].Descriptor()
 }
 
 func (UIDiscoverCreateDiscoveryConfigEvent_ConfigMethod) Type() protoreflect.EnumType {
-	return &file_prehog_v1alpha_teleport_proto_enumTypes[22]
+	return &file_prehog_v1alpha_teleport_proto_enumTypes[23]
 }
 
 func (x UIDiscoverCreateDiscoveryConfigEvent_ConfigMethod) Number() protoreflect.EnumNumber {
@@ -1658,7 +1710,7 @@ func (x UIDiscoverCreateDiscoveryConfigEvent_ConfigMethod) Number() protoreflect
 
 // Deprecated: Use UIDiscoverCreateDiscoveryConfigEvent_ConfigMethod.Descriptor instead.
 func (UIDiscoverCreateDiscoveryConfigEvent_ConfigMethod) EnumDescriptor() ([]byte, []int) {
-	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{34, 0}
+	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{36, 0}
 }
 
 // ProposedState specifies the proposed state of an access request review.
@@ -1698,11 +1750,11 @@ func (x AccessRequestReviewEvent_ProposedState) String() string {
 }
 
 func (AccessRequestReviewEvent_ProposedState) Descriptor() protoreflect.EnumDescriptor {
-	return file_prehog_v1alpha_teleport_proto_enumTypes[23].Descriptor()
+	return file_prehog_v1alpha_teleport_proto_enumTypes[24].Descriptor()
 }
 
 func (AccessRequestReviewEvent_ProposedState) Type() protoreflect.EnumType {
-	return &file_prehog_v1alpha_teleport_proto_enumTypes[23]
+	return &file_prehog_v1alpha_teleport_proto_enumTypes[24]
 }
 
 func (x AccessRequestReviewEvent_ProposedState) Number() protoreflect.EnumNumber {
@@ -1711,7 +1763,7 @@ func (x AccessRequestReviewEvent_ProposedState) Number() protoreflect.EnumNumber
 
 // Deprecated: Use AccessRequestReviewEvent_ProposedState.Descriptor instead.
 func (AccessRequestReviewEvent_ProposedState) EnumDescriptor() ([]byte, []int) {
-	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{111, 0}
+	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{113, 0}
 }
 
 // a successful user login
@@ -2696,6 +2748,150 @@ func (x *SessionStartBeamMetadata) GetBeamId() string {
 	return ""
 }
 
+// BeamsCreatedEvent is emitted when a beam VM is created and becomes ready.
+//
+// PostHog event: tp.beams.created
+type BeamsCreatedEvent struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// anonymized beam ID
+	//
+	// PostHog property: tp.beam.beam_id
+	BeamId string `protobuf:"bytes,1,opt,name=beam_id,json=beamId,proto3" json:"beam_id,omitempty"`
+	// the region where the beam was created
+	//
+	// PostHog property: tp.beam.region
+	Region string `protobuf:"bytes,2,opt,name=region,proto3" json:"region,omitempty"`
+	// time in milliseconds from CreateBeam call to VM ready
+	//
+	// PostHog property: tp.beam.startup_duration_ms
+	StartupDurationMs int64 `protobuf:"varint,3,opt,name=startup_duration_ms,json=startupDurationMs,proto3" json:"startup_duration_ms,omitempty"`
+	unknownFields     protoimpl.UnknownFields
+	sizeCache         protoimpl.SizeCache
+}
+
+func (x *BeamsCreatedEvent) Reset() {
+	*x = BeamsCreatedEvent{}
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[13]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *BeamsCreatedEvent) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*BeamsCreatedEvent) ProtoMessage() {}
+
+func (x *BeamsCreatedEvent) ProtoReflect() protoreflect.Message {
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[13]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use BeamsCreatedEvent.ProtoReflect.Descriptor instead.
+func (*BeamsCreatedEvent) Descriptor() ([]byte, []int) {
+	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{13}
+}
+
+func (x *BeamsCreatedEvent) GetBeamId() string {
+	if x != nil {
+		return x.BeamId
+	}
+	return ""
+}
+
+func (x *BeamsCreatedEvent) GetRegion() string {
+	if x != nil {
+		return x.Region
+	}
+	return ""
+}
+
+func (x *BeamsCreatedEvent) GetStartupDurationMs() int64 {
+	if x != nil {
+		return x.StartupDurationMs
+	}
+	return 0
+}
+
+// BeamsDestroyedEvent is emitted when a beam VM is destroyed.
+//
+// PostHog event: tp.beams.destroyed
+type BeamsDestroyedEvent struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// anonymized beam ID
+	//
+	// PostHog property: tp.beam.beam_id
+	BeamId string `protobuf:"bytes,1,opt,name=beam_id,json=beamId,proto3" json:"beam_id,omitempty"`
+	// the reason the beam was destroyed
+	//
+	// PostHog property: tp.beam.destroy_reason
+	Reason BeamDestroyReason `protobuf:"varint,2,opt,name=reason,proto3,enum=prehog.v1alpha.BeamDestroyReason" json:"reason,omitempty"`
+	// the region where the beam was running
+	//
+	// PostHog property: tp.beam.region
+	Region        string `protobuf:"bytes,3,opt,name=region,proto3" json:"region,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *BeamsDestroyedEvent) Reset() {
+	*x = BeamsDestroyedEvent{}
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[14]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *BeamsDestroyedEvent) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*BeamsDestroyedEvent) ProtoMessage() {}
+
+func (x *BeamsDestroyedEvent) ProtoReflect() protoreflect.Message {
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[14]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use BeamsDestroyedEvent.ProtoReflect.Descriptor instead.
+func (*BeamsDestroyedEvent) Descriptor() ([]byte, []int) {
+	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{14}
+}
+
+func (x *BeamsDestroyedEvent) GetBeamId() string {
+	if x != nil {
+		return x.BeamId
+	}
+	return ""
+}
+
+func (x *BeamsDestroyedEvent) GetReason() BeamDestroyReason {
+	if x != nil {
+		return x.Reason
+	}
+	return BeamDestroyReason_BEAM_DESTROY_REASON_UNSPECIFIED
+}
+
+func (x *BeamsDestroyedEvent) GetRegion() string {
+	if x != nil {
+		return x.Region
+	}
+	return ""
+}
+
 // the issuance of a user certificate from the user CA
 //
 // PostHog event: tp.certificate.issued
@@ -2736,7 +2932,7 @@ type UserCertificateIssuedEvent struct {
 
 func (x *UserCertificateIssuedEvent) Reset() {
 	*x = UserCertificateIssuedEvent{}
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[13]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[15]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2748,7 +2944,7 @@ func (x *UserCertificateIssuedEvent) String() string {
 func (*UserCertificateIssuedEvent) ProtoMessage() {}
 
 func (x *UserCertificateIssuedEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[13]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[15]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2761,7 +2957,7 @@ func (x *UserCertificateIssuedEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UserCertificateIssuedEvent.ProtoReflect.Descriptor instead.
 func (*UserCertificateIssuedEvent) Descriptor() ([]byte, []int) {
-	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{13}
+	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{15}
 }
 
 func (x *UserCertificateIssuedEvent) GetUserName() string {
@@ -2862,7 +3058,7 @@ type SPIFFESVIDIssuedEvent struct {
 
 func (x *SPIFFESVIDIssuedEvent) Reset() {
 	*x = SPIFFESVIDIssuedEvent{}
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[14]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[16]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2874,7 +3070,7 @@ func (x *SPIFFESVIDIssuedEvent) String() string {
 func (*SPIFFESVIDIssuedEvent) ProtoMessage() {}
 
 func (x *SPIFFESVIDIssuedEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[14]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[16]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2887,7 +3083,7 @@ func (x *SPIFFESVIDIssuedEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SPIFFESVIDIssuedEvent.ProtoReflect.Descriptor instead.
 func (*SPIFFESVIDIssuedEvent) Descriptor() ([]byte, []int) {
-	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{14}
+	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{16}
 }
 
 func (x *SPIFFESVIDIssuedEvent) GetUserName() string {
@@ -2953,7 +3149,7 @@ type UIBannerClickEvent struct {
 
 func (x *UIBannerClickEvent) Reset() {
 	*x = UIBannerClickEvent{}
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[15]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[17]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2965,7 +3161,7 @@ func (x *UIBannerClickEvent) String() string {
 func (*UIBannerClickEvent) ProtoMessage() {}
 
 func (x *UIBannerClickEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[15]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[17]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2978,7 +3174,7 @@ func (x *UIBannerClickEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UIBannerClickEvent.ProtoReflect.Descriptor instead.
 func (*UIBannerClickEvent) Descriptor() ([]byte, []int) {
-	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{15}
+	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{17}
 }
 
 func (x *UIBannerClickEvent) GetUserName() string {
@@ -3007,7 +3203,7 @@ type UIOnboardCompleteGoToDashboardClickEvent struct {
 
 func (x *UIOnboardCompleteGoToDashboardClickEvent) Reset() {
 	*x = UIOnboardCompleteGoToDashboardClickEvent{}
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[16]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[18]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3019,7 +3215,7 @@ func (x *UIOnboardCompleteGoToDashboardClickEvent) String() string {
 func (*UIOnboardCompleteGoToDashboardClickEvent) ProtoMessage() {}
 
 func (x *UIOnboardCompleteGoToDashboardClickEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[16]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[18]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3032,7 +3228,7 @@ func (x *UIOnboardCompleteGoToDashboardClickEvent) ProtoReflect() protoreflect.M
 
 // Deprecated: Use UIOnboardCompleteGoToDashboardClickEvent.ProtoReflect.Descriptor instead.
 func (*UIOnboardCompleteGoToDashboardClickEvent) Descriptor() ([]byte, []int) {
-	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{16}
+	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{18}
 }
 
 func (x *UIOnboardCompleteGoToDashboardClickEvent) GetUserName() string {
@@ -3054,7 +3250,7 @@ type UIOnboardAddFirstResourceClickEvent struct {
 
 func (x *UIOnboardAddFirstResourceClickEvent) Reset() {
 	*x = UIOnboardAddFirstResourceClickEvent{}
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[17]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[19]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3066,7 +3262,7 @@ func (x *UIOnboardAddFirstResourceClickEvent) String() string {
 func (*UIOnboardAddFirstResourceClickEvent) ProtoMessage() {}
 
 func (x *UIOnboardAddFirstResourceClickEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[17]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[19]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3079,7 +3275,7 @@ func (x *UIOnboardAddFirstResourceClickEvent) ProtoReflect() protoreflect.Messag
 
 // Deprecated: Use UIOnboardAddFirstResourceClickEvent.ProtoReflect.Descriptor instead.
 func (*UIOnboardAddFirstResourceClickEvent) Descriptor() ([]byte, []int) {
-	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{17}
+	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{19}
 }
 
 func (x *UIOnboardAddFirstResourceClickEvent) GetUserName() string {
@@ -3101,7 +3297,7 @@ type UIOnboardAddFirstResourceLaterClickEvent struct {
 
 func (x *UIOnboardAddFirstResourceLaterClickEvent) Reset() {
 	*x = UIOnboardAddFirstResourceLaterClickEvent{}
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[18]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[20]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3113,7 +3309,7 @@ func (x *UIOnboardAddFirstResourceLaterClickEvent) String() string {
 func (*UIOnboardAddFirstResourceLaterClickEvent) ProtoMessage() {}
 
 func (x *UIOnboardAddFirstResourceLaterClickEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[18]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[20]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3126,7 +3322,7 @@ func (x *UIOnboardAddFirstResourceLaterClickEvent) ProtoReflect() protoreflect.M
 
 // Deprecated: Use UIOnboardAddFirstResourceLaterClickEvent.ProtoReflect.Descriptor instead.
 func (*UIOnboardAddFirstResourceLaterClickEvent) Descriptor() ([]byte, []int) {
-	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{18}
+	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{20}
 }
 
 func (x *UIOnboardAddFirstResourceLaterClickEvent) GetUserName() string {
@@ -3148,7 +3344,7 @@ type UIOnboardSetCredentialSubmitEvent struct {
 
 func (x *UIOnboardSetCredentialSubmitEvent) Reset() {
 	*x = UIOnboardSetCredentialSubmitEvent{}
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[19]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[21]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3160,7 +3356,7 @@ func (x *UIOnboardSetCredentialSubmitEvent) String() string {
 func (*UIOnboardSetCredentialSubmitEvent) ProtoMessage() {}
 
 func (x *UIOnboardSetCredentialSubmitEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[19]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[21]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3173,7 +3369,7 @@ func (x *UIOnboardSetCredentialSubmitEvent) ProtoReflect() protoreflect.Message 
 
 // Deprecated: Use UIOnboardSetCredentialSubmitEvent.ProtoReflect.Descriptor instead.
 func (*UIOnboardSetCredentialSubmitEvent) Descriptor() ([]byte, []int) {
-	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{19}
+	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{21}
 }
 
 func (x *UIOnboardSetCredentialSubmitEvent) GetUserName() string {
@@ -3197,7 +3393,7 @@ type UIOnboardRegisterChallengeSubmitEvent struct {
 
 func (x *UIOnboardRegisterChallengeSubmitEvent) Reset() {
 	*x = UIOnboardRegisterChallengeSubmitEvent{}
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[20]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[22]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3209,7 +3405,7 @@ func (x *UIOnboardRegisterChallengeSubmitEvent) String() string {
 func (*UIOnboardRegisterChallengeSubmitEvent) ProtoMessage() {}
 
 func (x *UIOnboardRegisterChallengeSubmitEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[20]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[22]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3222,7 +3418,7 @@ func (x *UIOnboardRegisterChallengeSubmitEvent) ProtoReflect() protoreflect.Mess
 
 // Deprecated: Use UIOnboardRegisterChallengeSubmitEvent.ProtoReflect.Descriptor instead.
 func (*UIOnboardRegisterChallengeSubmitEvent) Descriptor() ([]byte, []int) {
-	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{20}
+	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{22}
 }
 
 func (x *UIOnboardRegisterChallengeSubmitEvent) GetUserName() string {
@@ -3258,7 +3454,7 @@ type UIOnboardQuestionnaireSubmitEvent struct {
 
 func (x *UIOnboardQuestionnaireSubmitEvent) Reset() {
 	*x = UIOnboardQuestionnaireSubmitEvent{}
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[21]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[23]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3270,7 +3466,7 @@ func (x *UIOnboardQuestionnaireSubmitEvent) String() string {
 func (*UIOnboardQuestionnaireSubmitEvent) ProtoMessage() {}
 
 func (x *UIOnboardQuestionnaireSubmitEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[21]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[23]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3283,7 +3479,7 @@ func (x *UIOnboardQuestionnaireSubmitEvent) ProtoReflect() protoreflect.Message 
 
 // Deprecated: Use UIOnboardQuestionnaireSubmitEvent.ProtoReflect.Descriptor instead.
 func (*UIOnboardQuestionnaireSubmitEvent) Descriptor() ([]byte, []int) {
-	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{21}
+	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{23}
 }
 
 func (x *UIOnboardQuestionnaireSubmitEvent) GetUserName() string {
@@ -3305,7 +3501,7 @@ type UIRecoveryCodesContinueClickEvent struct {
 
 func (x *UIRecoveryCodesContinueClickEvent) Reset() {
 	*x = UIRecoveryCodesContinueClickEvent{}
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[22]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[24]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3317,7 +3513,7 @@ func (x *UIRecoveryCodesContinueClickEvent) String() string {
 func (*UIRecoveryCodesContinueClickEvent) ProtoMessage() {}
 
 func (x *UIRecoveryCodesContinueClickEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[22]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[24]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3330,7 +3526,7 @@ func (x *UIRecoveryCodesContinueClickEvent) ProtoReflect() protoreflect.Message 
 
 // Deprecated: Use UIRecoveryCodesContinueClickEvent.ProtoReflect.Descriptor instead.
 func (*UIRecoveryCodesContinueClickEvent) Descriptor() ([]byte, []int) {
-	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{22}
+	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{24}
 }
 
 func (x *UIRecoveryCodesContinueClickEvent) GetUserName() string {
@@ -3352,7 +3548,7 @@ type UIRecoveryCodesCopyClickEvent struct {
 
 func (x *UIRecoveryCodesCopyClickEvent) Reset() {
 	*x = UIRecoveryCodesCopyClickEvent{}
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[23]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[25]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3364,7 +3560,7 @@ func (x *UIRecoveryCodesCopyClickEvent) String() string {
 func (*UIRecoveryCodesCopyClickEvent) ProtoMessage() {}
 
 func (x *UIRecoveryCodesCopyClickEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[23]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[25]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3377,7 +3573,7 @@ func (x *UIRecoveryCodesCopyClickEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UIRecoveryCodesCopyClickEvent.ProtoReflect.Descriptor instead.
 func (*UIRecoveryCodesCopyClickEvent) Descriptor() ([]byte, []int) {
-	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{23}
+	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{25}
 }
 
 func (x *UIRecoveryCodesCopyClickEvent) GetUserName() string {
@@ -3399,7 +3595,7 @@ type UIRecoveryCodesPrintClickEvent struct {
 
 func (x *UIRecoveryCodesPrintClickEvent) Reset() {
 	*x = UIRecoveryCodesPrintClickEvent{}
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[24]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[26]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3411,7 +3607,7 @@ func (x *UIRecoveryCodesPrintClickEvent) String() string {
 func (*UIRecoveryCodesPrintClickEvent) ProtoMessage() {}
 
 func (x *UIRecoveryCodesPrintClickEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[24]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[26]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3424,7 +3620,7 @@ func (x *UIRecoveryCodesPrintClickEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UIRecoveryCodesPrintClickEvent.ProtoReflect.Descriptor instead.
 func (*UIRecoveryCodesPrintClickEvent) Descriptor() ([]byte, []int) {
-	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{24}
+	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{26}
 }
 
 func (x *UIRecoveryCodesPrintClickEvent) GetUserName() string {
@@ -3450,7 +3646,7 @@ type DiscoverMetadata struct {
 
 func (x *DiscoverMetadata) Reset() {
 	*x = DiscoverMetadata{}
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[25]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[27]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3462,7 +3658,7 @@ func (x *DiscoverMetadata) String() string {
 func (*DiscoverMetadata) ProtoMessage() {}
 
 func (x *DiscoverMetadata) ProtoReflect() protoreflect.Message {
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[25]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[27]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3475,7 +3671,7 @@ func (x *DiscoverMetadata) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DiscoverMetadata.ProtoReflect.Descriptor instead.
 func (*DiscoverMetadata) Descriptor() ([]byte, []int) {
-	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{25}
+	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{27}
 }
 
 func (x *DiscoverMetadata) GetId() string {
@@ -3510,7 +3706,7 @@ type DiscoverResourceMetadata struct {
 
 func (x *DiscoverResourceMetadata) Reset() {
 	*x = DiscoverResourceMetadata{}
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[26]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[28]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3522,7 +3718,7 @@ func (x *DiscoverResourceMetadata) String() string {
 func (*DiscoverResourceMetadata) ProtoMessage() {}
 
 func (x *DiscoverResourceMetadata) ProtoReflect() protoreflect.Message {
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[26]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[28]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3535,7 +3731,7 @@ func (x *DiscoverResourceMetadata) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DiscoverResourceMetadata.ProtoReflect.Descriptor instead.
 func (*DiscoverResourceMetadata) Descriptor() ([]byte, []int) {
-	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{26}
+	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{28}
 }
 
 func (x *DiscoverResourceMetadata) GetResource() DiscoverResource {
@@ -3560,7 +3756,7 @@ type DiscoverStepStatus struct {
 
 func (x *DiscoverStepStatus) Reset() {
 	*x = DiscoverStepStatus{}
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[27]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[29]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3572,7 +3768,7 @@ func (x *DiscoverStepStatus) String() string {
 func (*DiscoverStepStatus) ProtoMessage() {}
 
 func (x *DiscoverStepStatus) ProtoReflect() protoreflect.Message {
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[27]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[29]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3585,7 +3781,7 @@ func (x *DiscoverStepStatus) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DiscoverStepStatus.ProtoReflect.Descriptor instead.
 func (*DiscoverStepStatus) Descriptor() ([]byte, []int) {
-	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{27}
+	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{29}
 }
 
 func (x *DiscoverStepStatus) GetStatus() DiscoverStatus {
@@ -3613,7 +3809,7 @@ type UIDiscoverStartedEvent struct {
 
 func (x *UIDiscoverStartedEvent) Reset() {
 	*x = UIDiscoverStartedEvent{}
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[28]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[30]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3625,7 +3821,7 @@ func (x *UIDiscoverStartedEvent) String() string {
 func (*UIDiscoverStartedEvent) ProtoMessage() {}
 
 func (x *UIDiscoverStartedEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[28]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[30]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3638,7 +3834,7 @@ func (x *UIDiscoverStartedEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UIDiscoverStartedEvent.ProtoReflect.Descriptor instead.
 func (*UIDiscoverStartedEvent) Descriptor() ([]byte, []int) {
-	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{28}
+	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{30}
 }
 
 func (x *UIDiscoverStartedEvent) GetMetadata() *DiscoverMetadata {
@@ -3668,7 +3864,7 @@ type UIDiscoverResourceSelectionEvent struct {
 
 func (x *UIDiscoverResourceSelectionEvent) Reset() {
 	*x = UIDiscoverResourceSelectionEvent{}
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[29]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[31]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3680,7 +3876,7 @@ func (x *UIDiscoverResourceSelectionEvent) String() string {
 func (*UIDiscoverResourceSelectionEvent) ProtoMessage() {}
 
 func (x *UIDiscoverResourceSelectionEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[29]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[31]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3693,7 +3889,7 @@ func (x *UIDiscoverResourceSelectionEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UIDiscoverResourceSelectionEvent.ProtoReflect.Descriptor instead.
 func (*UIDiscoverResourceSelectionEvent) Descriptor() ([]byte, []int) {
-	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{29}
+	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{31}
 }
 
 func (x *UIDiscoverResourceSelectionEvent) GetMetadata() *DiscoverMetadata {
@@ -3731,7 +3927,7 @@ type UIDiscoverIntegrationAWSOIDCConnectEvent struct {
 
 func (x *UIDiscoverIntegrationAWSOIDCConnectEvent) Reset() {
 	*x = UIDiscoverIntegrationAWSOIDCConnectEvent{}
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[30]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[32]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3743,7 +3939,7 @@ func (x *UIDiscoverIntegrationAWSOIDCConnectEvent) String() string {
 func (*UIDiscoverIntegrationAWSOIDCConnectEvent) ProtoMessage() {}
 
 func (x *UIDiscoverIntegrationAWSOIDCConnectEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[30]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[32]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3756,7 +3952,7 @@ func (x *UIDiscoverIntegrationAWSOIDCConnectEvent) ProtoReflect() protoreflect.M
 
 // Deprecated: Use UIDiscoverIntegrationAWSOIDCConnectEvent.ProtoReflect.Descriptor instead.
 func (*UIDiscoverIntegrationAWSOIDCConnectEvent) Descriptor() ([]byte, []int) {
-	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{30}
+	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{32}
 }
 
 func (x *UIDiscoverIntegrationAWSOIDCConnectEvent) GetMetadata() *DiscoverMetadata {
@@ -3794,7 +3990,7 @@ type UIDiscoverDatabaseRDSEnrollEvent struct {
 
 func (x *UIDiscoverDatabaseRDSEnrollEvent) Reset() {
 	*x = UIDiscoverDatabaseRDSEnrollEvent{}
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[31]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[33]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3806,7 +4002,7 @@ func (x *UIDiscoverDatabaseRDSEnrollEvent) String() string {
 func (*UIDiscoverDatabaseRDSEnrollEvent) ProtoMessage() {}
 
 func (x *UIDiscoverDatabaseRDSEnrollEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[31]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[33]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3819,7 +4015,7 @@ func (x *UIDiscoverDatabaseRDSEnrollEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UIDiscoverDatabaseRDSEnrollEvent.ProtoReflect.Descriptor instead.
 func (*UIDiscoverDatabaseRDSEnrollEvent) Descriptor() ([]byte, []int) {
-	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{31}
+	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{33}
 }
 
 func (x *UIDiscoverDatabaseRDSEnrollEvent) GetMetadata() *DiscoverMetadata {
@@ -3863,7 +4059,7 @@ type UIDiscoverKubeEKSEnrollEvent struct {
 
 func (x *UIDiscoverKubeEKSEnrollEvent) Reset() {
 	*x = UIDiscoverKubeEKSEnrollEvent{}
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[32]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[34]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3875,7 +4071,7 @@ func (x *UIDiscoverKubeEKSEnrollEvent) String() string {
 func (*UIDiscoverKubeEKSEnrollEvent) ProtoMessage() {}
 
 func (x *UIDiscoverKubeEKSEnrollEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[32]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[34]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3888,7 +4084,7 @@ func (x *UIDiscoverKubeEKSEnrollEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UIDiscoverKubeEKSEnrollEvent.ProtoReflect.Descriptor instead.
 func (*UIDiscoverKubeEKSEnrollEvent) Descriptor() ([]byte, []int) {
-	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{32}
+	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{34}
 }
 
 func (x *UIDiscoverKubeEKSEnrollEvent) GetMetadata() *DiscoverMetadata {
@@ -3932,7 +4128,7 @@ type UIDiscoverDeployServiceEvent struct {
 
 func (x *UIDiscoverDeployServiceEvent) Reset() {
 	*x = UIDiscoverDeployServiceEvent{}
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[33]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[35]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3944,7 +4140,7 @@ func (x *UIDiscoverDeployServiceEvent) String() string {
 func (*UIDiscoverDeployServiceEvent) ProtoMessage() {}
 
 func (x *UIDiscoverDeployServiceEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[33]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[35]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3957,7 +4153,7 @@ func (x *UIDiscoverDeployServiceEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UIDiscoverDeployServiceEvent.ProtoReflect.Descriptor instead.
 func (*UIDiscoverDeployServiceEvent) Descriptor() ([]byte, []int) {
-	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{33}
+	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{35}
 }
 
 func (x *UIDiscoverDeployServiceEvent) GetMetadata() *DiscoverMetadata {
@@ -4008,7 +4204,7 @@ type UIDiscoverCreateDiscoveryConfigEvent struct {
 
 func (x *UIDiscoverCreateDiscoveryConfigEvent) Reset() {
 	*x = UIDiscoverCreateDiscoveryConfigEvent{}
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[34]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[36]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4020,7 +4216,7 @@ func (x *UIDiscoverCreateDiscoveryConfigEvent) String() string {
 func (*UIDiscoverCreateDiscoveryConfigEvent) ProtoMessage() {}
 
 func (x *UIDiscoverCreateDiscoveryConfigEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[34]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[36]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4033,7 +4229,7 @@ func (x *UIDiscoverCreateDiscoveryConfigEvent) ProtoReflect() protoreflect.Messa
 
 // Deprecated: Use UIDiscoverCreateDiscoveryConfigEvent.ProtoReflect.Descriptor instead.
 func (*UIDiscoverCreateDiscoveryConfigEvent) Descriptor() ([]byte, []int) {
-	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{34}
+	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{36}
 }
 
 func (x *UIDiscoverCreateDiscoveryConfigEvent) GetMetadata() *DiscoverMetadata {
@@ -4076,7 +4272,7 @@ type UIDiscoverDatabaseRegisterEvent struct {
 
 func (x *UIDiscoverDatabaseRegisterEvent) Reset() {
 	*x = UIDiscoverDatabaseRegisterEvent{}
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[35]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[37]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4088,7 +4284,7 @@ func (x *UIDiscoverDatabaseRegisterEvent) String() string {
 func (*UIDiscoverDatabaseRegisterEvent) ProtoMessage() {}
 
 func (x *UIDiscoverDatabaseRegisterEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[35]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[37]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4101,7 +4297,7 @@ func (x *UIDiscoverDatabaseRegisterEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UIDiscoverDatabaseRegisterEvent.ProtoReflect.Descriptor instead.
 func (*UIDiscoverDatabaseRegisterEvent) Descriptor() ([]byte, []int) {
-	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{35}
+	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{37}
 }
 
 func (x *UIDiscoverDatabaseRegisterEvent) GetMetadata() *DiscoverMetadata {
@@ -4137,7 +4333,7 @@ type UIDiscoverDatabaseConfigureMTLSEvent struct {
 
 func (x *UIDiscoverDatabaseConfigureMTLSEvent) Reset() {
 	*x = UIDiscoverDatabaseConfigureMTLSEvent{}
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[36]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[38]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4149,7 +4345,7 @@ func (x *UIDiscoverDatabaseConfigureMTLSEvent) String() string {
 func (*UIDiscoverDatabaseConfigureMTLSEvent) ProtoMessage() {}
 
 func (x *UIDiscoverDatabaseConfigureMTLSEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[36]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[38]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4162,7 +4358,7 @@ func (x *UIDiscoverDatabaseConfigureMTLSEvent) ProtoReflect() protoreflect.Messa
 
 // Deprecated: Use UIDiscoverDatabaseConfigureMTLSEvent.ProtoReflect.Descriptor instead.
 func (*UIDiscoverDatabaseConfigureMTLSEvent) Descriptor() ([]byte, []int) {
-	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{36}
+	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{38}
 }
 
 func (x *UIDiscoverDatabaseConfigureMTLSEvent) GetMetadata() *DiscoverMetadata {
@@ -4198,7 +4394,7 @@ type UIDiscoverDesktopActiveDirectoryToolsInstallEvent struct {
 
 func (x *UIDiscoverDesktopActiveDirectoryToolsInstallEvent) Reset() {
 	*x = UIDiscoverDesktopActiveDirectoryToolsInstallEvent{}
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[37]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[39]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4210,7 +4406,7 @@ func (x *UIDiscoverDesktopActiveDirectoryToolsInstallEvent) String() string {
 func (*UIDiscoverDesktopActiveDirectoryToolsInstallEvent) ProtoMessage() {}
 
 func (x *UIDiscoverDesktopActiveDirectoryToolsInstallEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[37]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[39]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4223,7 +4419,7 @@ func (x *UIDiscoverDesktopActiveDirectoryToolsInstallEvent) ProtoReflect() proto
 
 // Deprecated: Use UIDiscoverDesktopActiveDirectoryToolsInstallEvent.ProtoReflect.Descriptor instead.
 func (*UIDiscoverDesktopActiveDirectoryToolsInstallEvent) Descriptor() ([]byte, []int) {
-	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{37}
+	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{39}
 }
 
 func (x *UIDiscoverDesktopActiveDirectoryToolsInstallEvent) GetMetadata() *DiscoverMetadata {
@@ -4259,7 +4455,7 @@ type UIDiscoverDesktopActiveDirectoryConfigureEvent struct {
 
 func (x *UIDiscoverDesktopActiveDirectoryConfigureEvent) Reset() {
 	*x = UIDiscoverDesktopActiveDirectoryConfigureEvent{}
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[38]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[40]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4271,7 +4467,7 @@ func (x *UIDiscoverDesktopActiveDirectoryConfigureEvent) String() string {
 func (*UIDiscoverDesktopActiveDirectoryConfigureEvent) ProtoMessage() {}
 
 func (x *UIDiscoverDesktopActiveDirectoryConfigureEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[38]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[40]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4284,7 +4480,7 @@ func (x *UIDiscoverDesktopActiveDirectoryConfigureEvent) ProtoReflect() protoref
 
 // Deprecated: Use UIDiscoverDesktopActiveDirectoryConfigureEvent.ProtoReflect.Descriptor instead.
 func (*UIDiscoverDesktopActiveDirectoryConfigureEvent) Descriptor() ([]byte, []int) {
-	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{38}
+	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{40}
 }
 
 func (x *UIDiscoverDesktopActiveDirectoryConfigureEvent) GetMetadata() *DiscoverMetadata {
@@ -4322,7 +4518,7 @@ type UIDiscoverAutoDiscoveredResourcesEvent struct {
 
 func (x *UIDiscoverAutoDiscoveredResourcesEvent) Reset() {
 	*x = UIDiscoverAutoDiscoveredResourcesEvent{}
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[39]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[41]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4334,7 +4530,7 @@ func (x *UIDiscoverAutoDiscoveredResourcesEvent) String() string {
 func (*UIDiscoverAutoDiscoveredResourcesEvent) ProtoMessage() {}
 
 func (x *UIDiscoverAutoDiscoveredResourcesEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[39]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[41]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4347,7 +4543,7 @@ func (x *UIDiscoverAutoDiscoveredResourcesEvent) ProtoReflect() protoreflect.Mes
 
 // Deprecated: Use UIDiscoverAutoDiscoveredResourcesEvent.ProtoReflect.Descriptor instead.
 func (*UIDiscoverAutoDiscoveredResourcesEvent) Descriptor() ([]byte, []int) {
-	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{39}
+	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{41}
 }
 
 func (x *UIDiscoverAutoDiscoveredResourcesEvent) GetMetadata() *DiscoverMetadata {
@@ -4390,7 +4586,7 @@ type UIDiscoverEC2InstanceSelectionEvent struct {
 
 func (x *UIDiscoverEC2InstanceSelectionEvent) Reset() {
 	*x = UIDiscoverEC2InstanceSelectionEvent{}
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[40]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[42]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4402,7 +4598,7 @@ func (x *UIDiscoverEC2InstanceSelectionEvent) String() string {
 func (*UIDiscoverEC2InstanceSelectionEvent) ProtoMessage() {}
 
 func (x *UIDiscoverEC2InstanceSelectionEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[40]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[42]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4415,7 +4611,7 @@ func (x *UIDiscoverEC2InstanceSelectionEvent) ProtoReflect() protoreflect.Messag
 
 // Deprecated: Use UIDiscoverEC2InstanceSelectionEvent.ProtoReflect.Descriptor instead.
 func (*UIDiscoverEC2InstanceSelectionEvent) Descriptor() ([]byte, []int) {
-	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{40}
+	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{42}
 }
 
 func (x *UIDiscoverEC2InstanceSelectionEvent) GetMetadata() *DiscoverMetadata {
@@ -4451,7 +4647,7 @@ type UIDiscoverDeployEICEEvent struct {
 
 func (x *UIDiscoverDeployEICEEvent) Reset() {
 	*x = UIDiscoverDeployEICEEvent{}
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[41]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[43]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4463,7 +4659,7 @@ func (x *UIDiscoverDeployEICEEvent) String() string {
 func (*UIDiscoverDeployEICEEvent) ProtoMessage() {}
 
 func (x *UIDiscoverDeployEICEEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[41]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[43]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4476,7 +4672,7 @@ func (x *UIDiscoverDeployEICEEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UIDiscoverDeployEICEEvent.ProtoReflect.Descriptor instead.
 func (*UIDiscoverDeployEICEEvent) Descriptor() ([]byte, []int) {
-	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{41}
+	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{43}
 }
 
 func (x *UIDiscoverDeployEICEEvent) GetMetadata() *DiscoverMetadata {
@@ -4512,7 +4708,7 @@ type UIDiscoverCreateNodeEvent struct {
 
 func (x *UIDiscoverCreateNodeEvent) Reset() {
 	*x = UIDiscoverCreateNodeEvent{}
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[42]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[44]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4524,7 +4720,7 @@ func (x *UIDiscoverCreateNodeEvent) String() string {
 func (*UIDiscoverCreateNodeEvent) ProtoMessage() {}
 
 func (x *UIDiscoverCreateNodeEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[42]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[44]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4537,7 +4733,7 @@ func (x *UIDiscoverCreateNodeEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UIDiscoverCreateNodeEvent.ProtoReflect.Descriptor instead.
 func (*UIDiscoverCreateNodeEvent) Descriptor() ([]byte, []int) {
-	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{42}
+	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{44}
 }
 
 func (x *UIDiscoverCreateNodeEvent) GetMetadata() *DiscoverMetadata {
@@ -4573,7 +4769,7 @@ type UIDiscoverCreateAppServerEvent struct {
 
 func (x *UIDiscoverCreateAppServerEvent) Reset() {
 	*x = UIDiscoverCreateAppServerEvent{}
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[43]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[45]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4585,7 +4781,7 @@ func (x *UIDiscoverCreateAppServerEvent) String() string {
 func (*UIDiscoverCreateAppServerEvent) ProtoMessage() {}
 
 func (x *UIDiscoverCreateAppServerEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[43]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[45]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4598,7 +4794,7 @@ func (x *UIDiscoverCreateAppServerEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UIDiscoverCreateAppServerEvent.ProtoReflect.Descriptor instead.
 func (*UIDiscoverCreateAppServerEvent) Descriptor() ([]byte, []int) {
-	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{43}
+	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{45}
 }
 
 func (x *UIDiscoverCreateAppServerEvent) GetMetadata() *DiscoverMetadata {
@@ -4634,7 +4830,7 @@ type UIDiscoverDatabaseConfigureIAMPolicyEvent struct {
 
 func (x *UIDiscoverDatabaseConfigureIAMPolicyEvent) Reset() {
 	*x = UIDiscoverDatabaseConfigureIAMPolicyEvent{}
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[44]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[46]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4646,7 +4842,7 @@ func (x *UIDiscoverDatabaseConfigureIAMPolicyEvent) String() string {
 func (*UIDiscoverDatabaseConfigureIAMPolicyEvent) ProtoMessage() {}
 
 func (x *UIDiscoverDatabaseConfigureIAMPolicyEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[44]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[46]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4659,7 +4855,7 @@ func (x *UIDiscoverDatabaseConfigureIAMPolicyEvent) ProtoReflect() protoreflect.
 
 // Deprecated: Use UIDiscoverDatabaseConfigureIAMPolicyEvent.ProtoReflect.Descriptor instead.
 func (*UIDiscoverDatabaseConfigureIAMPolicyEvent) Descriptor() ([]byte, []int) {
-	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{44}
+	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{46}
 }
 
 func (x *UIDiscoverDatabaseConfigureIAMPolicyEvent) GetMetadata() *DiscoverMetadata {
@@ -4695,7 +4891,7 @@ type UIDiscoverPrincipalsConfigureEvent struct {
 
 func (x *UIDiscoverPrincipalsConfigureEvent) Reset() {
 	*x = UIDiscoverPrincipalsConfigureEvent{}
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[45]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[47]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4707,7 +4903,7 @@ func (x *UIDiscoverPrincipalsConfigureEvent) String() string {
 func (*UIDiscoverPrincipalsConfigureEvent) ProtoMessage() {}
 
 func (x *UIDiscoverPrincipalsConfigureEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[45]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[47]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4720,7 +4916,7 @@ func (x *UIDiscoverPrincipalsConfigureEvent) ProtoReflect() protoreflect.Message
 
 // Deprecated: Use UIDiscoverPrincipalsConfigureEvent.ProtoReflect.Descriptor instead.
 func (*UIDiscoverPrincipalsConfigureEvent) Descriptor() ([]byte, []int) {
-	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{45}
+	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{47}
 }
 
 func (x *UIDiscoverPrincipalsConfigureEvent) GetMetadata() *DiscoverMetadata {
@@ -4757,7 +4953,7 @@ type UIDiscoverTestConnectionEvent struct {
 
 func (x *UIDiscoverTestConnectionEvent) Reset() {
 	*x = UIDiscoverTestConnectionEvent{}
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[46]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[48]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4769,7 +4965,7 @@ func (x *UIDiscoverTestConnectionEvent) String() string {
 func (*UIDiscoverTestConnectionEvent) ProtoMessage() {}
 
 func (x *UIDiscoverTestConnectionEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[46]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[48]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4782,7 +4978,7 @@ func (x *UIDiscoverTestConnectionEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UIDiscoverTestConnectionEvent.ProtoReflect.Descriptor instead.
 func (*UIDiscoverTestConnectionEvent) Descriptor() ([]byte, []int) {
-	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{46}
+	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{48}
 }
 
 func (x *UIDiscoverTestConnectionEvent) GetMetadata() *DiscoverMetadata {
@@ -4818,7 +5014,7 @@ type UIDiscoverCompletedEvent struct {
 
 func (x *UIDiscoverCompletedEvent) Reset() {
 	*x = UIDiscoverCompletedEvent{}
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[47]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[49]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4830,7 +5026,7 @@ func (x *UIDiscoverCompletedEvent) String() string {
 func (*UIDiscoverCompletedEvent) ProtoMessage() {}
 
 func (x *UIDiscoverCompletedEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[47]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[49]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4843,7 +5039,7 @@ func (x *UIDiscoverCompletedEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UIDiscoverCompletedEvent.ProtoReflect.Descriptor instead.
 func (*UIDiscoverCompletedEvent) Descriptor() ([]byte, []int) {
-	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{47}
+	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{49}
 }
 
 func (x *UIDiscoverCompletedEvent) GetMetadata() *DiscoverMetadata {
@@ -4880,7 +5076,7 @@ type RoleCreateEvent struct {
 
 func (x *RoleCreateEvent) Reset() {
 	*x = RoleCreateEvent{}
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[48]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[50]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4892,7 +5088,7 @@ func (x *RoleCreateEvent) String() string {
 func (*RoleCreateEvent) ProtoMessage() {}
 
 func (x *RoleCreateEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[48]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[50]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4905,7 +5101,7 @@ func (x *RoleCreateEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RoleCreateEvent.ProtoReflect.Descriptor instead.
 func (*RoleCreateEvent) Descriptor() ([]byte, []int) {
-	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{48}
+	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{50}
 }
 
 func (x *RoleCreateEvent) GetUserName() string {
@@ -4945,7 +5141,7 @@ type BotCreateEvent struct {
 
 func (x *BotCreateEvent) Reset() {
 	*x = BotCreateEvent{}
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[49]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[51]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4957,7 +5153,7 @@ func (x *BotCreateEvent) String() string {
 func (*BotCreateEvent) ProtoMessage() {}
 
 func (x *BotCreateEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[49]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[51]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4970,7 +5166,7 @@ func (x *BotCreateEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use BotCreateEvent.ProtoReflect.Descriptor instead.
 func (*BotCreateEvent) Descriptor() ([]byte, []int) {
-	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{49}
+	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{51}
 }
 
 func (x *BotCreateEvent) GetUserName() string {
@@ -5036,7 +5232,7 @@ type BotJoinEvent struct {
 
 func (x *BotJoinEvent) Reset() {
 	*x = BotJoinEvent{}
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[50]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[52]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5048,7 +5244,7 @@ func (x *BotJoinEvent) String() string {
 func (*BotJoinEvent) ProtoMessage() {}
 
 func (x *BotJoinEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[50]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[52]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5061,7 +5257,7 @@ func (x *BotJoinEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use BotJoinEvent.ProtoReflect.Descriptor instead.
 func (*BotJoinEvent) Descriptor() ([]byte, []int) {
-	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{50}
+	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{52}
 }
 
 func (x *BotJoinEvent) GetBotName() string {
@@ -5110,7 +5306,7 @@ type UICreateNewRoleClickEvent struct {
 
 func (x *UICreateNewRoleClickEvent) Reset() {
 	*x = UICreateNewRoleClickEvent{}
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[51]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[53]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5122,7 +5318,7 @@ func (x *UICreateNewRoleClickEvent) String() string {
 func (*UICreateNewRoleClickEvent) ProtoMessage() {}
 
 func (x *UICreateNewRoleClickEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[51]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[53]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5135,7 +5331,7 @@ func (x *UICreateNewRoleClickEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UICreateNewRoleClickEvent.ProtoReflect.Descriptor instead.
 func (*UICreateNewRoleClickEvent) Descriptor() ([]byte, []int) {
-	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{51}
+	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{53}
 }
 
 func (x *UICreateNewRoleClickEvent) GetUserName() string {
@@ -5171,7 +5367,7 @@ type UICreateNewRoleSaveClickEvent struct {
 
 func (x *UICreateNewRoleSaveClickEvent) Reset() {
 	*x = UICreateNewRoleSaveClickEvent{}
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[52]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[54]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5183,7 +5379,7 @@ func (x *UICreateNewRoleSaveClickEvent) String() string {
 func (*UICreateNewRoleSaveClickEvent) ProtoMessage() {}
 
 func (x *UICreateNewRoleSaveClickEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[52]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[54]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5196,7 +5392,7 @@ func (x *UICreateNewRoleSaveClickEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UICreateNewRoleSaveClickEvent.ProtoReflect.Descriptor instead.
 func (*UICreateNewRoleSaveClickEvent) Descriptor() ([]byte, []int) {
-	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{52}
+	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{54}
 }
 
 func (x *UICreateNewRoleSaveClickEvent) GetUserName() string {
@@ -5245,7 +5441,7 @@ type UICreateNewRoleCancelClickEvent struct {
 
 func (x *UICreateNewRoleCancelClickEvent) Reset() {
 	*x = UICreateNewRoleCancelClickEvent{}
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[53]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[55]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5257,7 +5453,7 @@ func (x *UICreateNewRoleCancelClickEvent) String() string {
 func (*UICreateNewRoleCancelClickEvent) ProtoMessage() {}
 
 func (x *UICreateNewRoleCancelClickEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[53]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[55]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5270,7 +5466,7 @@ func (x *UICreateNewRoleCancelClickEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UICreateNewRoleCancelClickEvent.ProtoReflect.Descriptor instead.
 func (*UICreateNewRoleCancelClickEvent) Descriptor() ([]byte, []int) {
-	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{53}
+	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{55}
 }
 
 func (x *UICreateNewRoleCancelClickEvent) GetUserName() string {
@@ -5291,7 +5487,7 @@ type UICreateNewRoleViewDocumentationClickEvent struct {
 
 func (x *UICreateNewRoleViewDocumentationClickEvent) Reset() {
 	*x = UICreateNewRoleViewDocumentationClickEvent{}
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[54]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[56]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5303,7 +5499,7 @@ func (x *UICreateNewRoleViewDocumentationClickEvent) String() string {
 func (*UICreateNewRoleViewDocumentationClickEvent) ProtoMessage() {}
 
 func (x *UICreateNewRoleViewDocumentationClickEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[54]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[56]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5316,7 +5512,7 @@ func (x *UICreateNewRoleViewDocumentationClickEvent) ProtoReflect() protoreflect
 
 // Deprecated: Use UICreateNewRoleViewDocumentationClickEvent.ProtoReflect.Descriptor instead.
 func (*UICreateNewRoleViewDocumentationClickEvent) Descriptor() ([]byte, []int) {
-	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{54}
+	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{56}
 }
 
 func (x *UICreateNewRoleViewDocumentationClickEvent) GetUserName() string {
@@ -5338,7 +5534,7 @@ type UICallToActionClickEvent struct {
 
 func (x *UICallToActionClickEvent) Reset() {
 	*x = UICallToActionClickEvent{}
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[55]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[57]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5350,7 +5546,7 @@ func (x *UICallToActionClickEvent) String() string {
 func (*UICallToActionClickEvent) ProtoMessage() {}
 
 func (x *UICallToActionClickEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[55]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[57]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5363,7 +5559,7 @@ func (x *UICallToActionClickEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UICallToActionClickEvent.ProtoReflect.Descriptor instead.
 func (*UICallToActionClickEvent) Descriptor() ([]byte, []int) {
-	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{55}
+	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{57}
 }
 
 func (x *UICallToActionClickEvent) GetUserName() string {
@@ -5398,7 +5594,7 @@ type KubeRequestEvent struct {
 
 func (x *KubeRequestEvent) Reset() {
 	*x = KubeRequestEvent{}
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[56]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[58]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5410,7 +5606,7 @@ func (x *KubeRequestEvent) String() string {
 func (*KubeRequestEvent) ProtoMessage() {}
 
 func (x *KubeRequestEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[56]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[58]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5423,7 +5619,7 @@ func (x *KubeRequestEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use KubeRequestEvent.ProtoReflect.Descriptor instead.
 func (*KubeRequestEvent) Descriptor() ([]byte, []int) {
-	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{56}
+	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{58}
 }
 
 func (x *KubeRequestEvent) GetUserName() string {
@@ -5459,7 +5655,7 @@ type SFTPEvent struct {
 
 func (x *SFTPEvent) Reset() {
 	*x = SFTPEvent{}
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[57]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[59]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5471,7 +5667,7 @@ func (x *SFTPEvent) String() string {
 func (*SFTPEvent) ProtoMessage() {}
 
 func (x *SFTPEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[57]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[59]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5484,7 +5680,7 @@ func (x *SFTPEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SFTPEvent.ProtoReflect.Descriptor instead.
 func (*SFTPEvent) Descriptor() ([]byte, []int) {
-	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{57}
+	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{59}
 }
 
 func (x *SFTPEvent) GetUserName() string {
@@ -5530,7 +5726,7 @@ type AgentMetadataEvent struct {
 
 func (x *AgentMetadataEvent) Reset() {
 	*x = AgentMetadataEvent{}
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[58]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[60]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5542,7 +5738,7 @@ func (x *AgentMetadataEvent) String() string {
 func (*AgentMetadataEvent) ProtoMessage() {}
 
 func (x *AgentMetadataEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[58]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[60]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5555,7 +5751,7 @@ func (x *AgentMetadataEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AgentMetadataEvent.ProtoReflect.Descriptor instead.
 func (*AgentMetadataEvent) Descriptor() ([]byte, []int) {
-	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{58}
+	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{60}
 }
 
 func (x *AgentMetadataEvent) GetVersion() string {
@@ -5663,7 +5859,7 @@ type AssistCompletionEvent struct {
 
 func (x *AssistCompletionEvent) Reset() {
 	*x = AssistCompletionEvent{}
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[59]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[61]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5675,7 +5871,7 @@ func (x *AssistCompletionEvent) String() string {
 func (*AssistCompletionEvent) ProtoMessage() {}
 
 func (x *AssistCompletionEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[59]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[61]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5688,7 +5884,7 @@ func (x *AssistCompletionEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AssistCompletionEvent.ProtoReflect.Descriptor instead.
 func (*AssistCompletionEvent) Descriptor() ([]byte, []int) {
-	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{59}
+	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{61}
 }
 
 func (x *AssistCompletionEvent) GetUserName() string {
@@ -5748,7 +5944,7 @@ type AssistExecutionEvent struct {
 
 func (x *AssistExecutionEvent) Reset() {
 	*x = AssistExecutionEvent{}
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[60]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[62]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5760,7 +5956,7 @@ func (x *AssistExecutionEvent) String() string {
 func (*AssistExecutionEvent) ProtoMessage() {}
 
 func (x *AssistExecutionEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[60]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[62]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5773,7 +5969,7 @@ func (x *AssistExecutionEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AssistExecutionEvent.ProtoReflect.Descriptor instead.
 func (*AssistExecutionEvent) Descriptor() ([]byte, []int) {
-	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{60}
+	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{62}
 }
 
 func (x *AssistExecutionEvent) GetUserName() string {
@@ -5833,7 +6029,7 @@ type AssistNewConversationEvent struct {
 
 func (x *AssistNewConversationEvent) Reset() {
 	*x = AssistNewConversationEvent{}
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[61]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[63]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5845,7 +6041,7 @@ func (x *AssistNewConversationEvent) String() string {
 func (*AssistNewConversationEvent) ProtoMessage() {}
 
 func (x *AssistNewConversationEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[61]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[63]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5858,7 +6054,7 @@ func (x *AssistNewConversationEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AssistNewConversationEvent.ProtoReflect.Descriptor instead.
 func (*AssistNewConversationEvent) Descriptor() ([]byte, []int) {
-	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{61}
+	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{63}
 }
 
 func (x *AssistNewConversationEvent) GetUserName() string {
@@ -5895,7 +6091,7 @@ type AssistAccessRequestEvent struct {
 
 func (x *AssistAccessRequestEvent) Reset() {
 	*x = AssistAccessRequestEvent{}
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[62]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[64]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5907,7 +6103,7 @@ func (x *AssistAccessRequestEvent) String() string {
 func (*AssistAccessRequestEvent) ProtoMessage() {}
 
 func (x *AssistAccessRequestEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[62]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[64]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5920,7 +6116,7 @@ func (x *AssistAccessRequestEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AssistAccessRequestEvent.ProtoReflect.Descriptor instead.
 func (*AssistAccessRequestEvent) Descriptor() ([]byte, []int) {
-	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{62}
+	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{64}
 }
 
 func (x *AssistAccessRequestEvent) GetUserName() string {
@@ -5978,7 +6174,7 @@ type AssistActionEvent struct {
 
 func (x *AssistActionEvent) Reset() {
 	*x = AssistActionEvent{}
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[63]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[65]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5990,7 +6186,7 @@ func (x *AssistActionEvent) String() string {
 func (*AssistActionEvent) ProtoMessage() {}
 
 func (x *AssistActionEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[63]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[65]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6003,7 +6199,7 @@ func (x *AssistActionEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AssistActionEvent.ProtoReflect.Descriptor instead.
 func (*AssistActionEvent) Descriptor() ([]byte, []int) {
-	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{63}
+	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{65}
 }
 
 func (x *AssistActionEvent) GetUserName() string {
@@ -6056,7 +6252,7 @@ type AccessListMetadata struct {
 
 func (x *AccessListMetadata) Reset() {
 	*x = AccessListMetadata{}
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[64]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[66]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6068,7 +6264,7 @@ func (x *AccessListMetadata) String() string {
 func (*AccessListMetadata) ProtoMessage() {}
 
 func (x *AccessListMetadata) ProtoReflect() protoreflect.Message {
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[64]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[66]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6081,7 +6277,7 @@ func (x *AccessListMetadata) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AccessListMetadata.ProtoReflect.Descriptor instead.
 func (*AccessListMetadata) Descriptor() ([]byte, []int) {
-	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{64}
+	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{66}
 }
 
 func (x *AccessListMetadata) GetId() string {
@@ -6117,7 +6313,7 @@ type AccessListCreateEvent struct {
 
 func (x *AccessListCreateEvent) Reset() {
 	*x = AccessListCreateEvent{}
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[65]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[67]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6129,7 +6325,7 @@ func (x *AccessListCreateEvent) String() string {
 func (*AccessListCreateEvent) ProtoMessage() {}
 
 func (x *AccessListCreateEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[65]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[67]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6142,7 +6338,7 @@ func (x *AccessListCreateEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AccessListCreateEvent.ProtoReflect.Descriptor instead.
 func (*AccessListCreateEvent) Descriptor() ([]byte, []int) {
-	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{65}
+	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{67}
 }
 
 func (x *AccessListCreateEvent) GetUserName() string {
@@ -6171,7 +6367,7 @@ type AccessListUpdateEvent struct {
 
 func (x *AccessListUpdateEvent) Reset() {
 	*x = AccessListUpdateEvent{}
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[66]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[68]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6183,7 +6379,7 @@ func (x *AccessListUpdateEvent) String() string {
 func (*AccessListUpdateEvent) ProtoMessage() {}
 
 func (x *AccessListUpdateEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[66]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[68]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6196,7 +6392,7 @@ func (x *AccessListUpdateEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AccessListUpdateEvent.ProtoReflect.Descriptor instead.
 func (*AccessListUpdateEvent) Descriptor() ([]byte, []int) {
-	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{66}
+	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{68}
 }
 
 func (x *AccessListUpdateEvent) GetUserName() string {
@@ -6225,7 +6421,7 @@ type AccessListDeleteEvent struct {
 
 func (x *AccessListDeleteEvent) Reset() {
 	*x = AccessListDeleteEvent{}
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[67]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[69]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6237,7 +6433,7 @@ func (x *AccessListDeleteEvent) String() string {
 func (*AccessListDeleteEvent) ProtoMessage() {}
 
 func (x *AccessListDeleteEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[67]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[69]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6250,7 +6446,7 @@ func (x *AccessListDeleteEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AccessListDeleteEvent.ProtoReflect.Descriptor instead.
 func (*AccessListDeleteEvent) Descriptor() ([]byte, []int) {
-	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{67}
+	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{69}
 }
 
 func (x *AccessListDeleteEvent) GetUserName() string {
@@ -6281,7 +6477,7 @@ type AccessListMemberCreateEvent struct {
 
 func (x *AccessListMemberCreateEvent) Reset() {
 	*x = AccessListMemberCreateEvent{}
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[68]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[70]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6293,7 +6489,7 @@ func (x *AccessListMemberCreateEvent) String() string {
 func (*AccessListMemberCreateEvent) ProtoMessage() {}
 
 func (x *AccessListMemberCreateEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[68]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[70]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6306,7 +6502,7 @@ func (x *AccessListMemberCreateEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AccessListMemberCreateEvent.ProtoReflect.Descriptor instead.
 func (*AccessListMemberCreateEvent) Descriptor() ([]byte, []int) {
-	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{68}
+	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{70}
 }
 
 func (x *AccessListMemberCreateEvent) GetUserName() string {
@@ -6344,7 +6540,7 @@ type AccessListMemberUpdateEvent struct {
 
 func (x *AccessListMemberUpdateEvent) Reset() {
 	*x = AccessListMemberUpdateEvent{}
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[69]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[71]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6356,7 +6552,7 @@ func (x *AccessListMemberUpdateEvent) String() string {
 func (*AccessListMemberUpdateEvent) ProtoMessage() {}
 
 func (x *AccessListMemberUpdateEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[69]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[71]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6369,7 +6565,7 @@ func (x *AccessListMemberUpdateEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AccessListMemberUpdateEvent.ProtoReflect.Descriptor instead.
 func (*AccessListMemberUpdateEvent) Descriptor() ([]byte, []int) {
-	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{69}
+	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{71}
 }
 
 func (x *AccessListMemberUpdateEvent) GetUserName() string {
@@ -6407,7 +6603,7 @@ type AccessListMemberDeleteEvent struct {
 
 func (x *AccessListMemberDeleteEvent) Reset() {
 	*x = AccessListMemberDeleteEvent{}
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[70]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[72]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6419,7 +6615,7 @@ func (x *AccessListMemberDeleteEvent) String() string {
 func (*AccessListMemberDeleteEvent) ProtoMessage() {}
 
 func (x *AccessListMemberDeleteEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[70]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[72]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6432,7 +6628,7 @@ func (x *AccessListMemberDeleteEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AccessListMemberDeleteEvent.ProtoReflect.Descriptor instead.
 func (*AccessListMemberDeleteEvent) Descriptor() ([]byte, []int) {
-	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{70}
+	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{72}
 }
 
 func (x *AccessListMemberDeleteEvent) GetUserName() string {
@@ -6476,7 +6672,7 @@ type AccessListGrantsToUserEvent struct {
 
 func (x *AccessListGrantsToUserEvent) Reset() {
 	*x = AccessListGrantsToUserEvent{}
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[71]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[73]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6488,7 +6684,7 @@ func (x *AccessListGrantsToUserEvent) String() string {
 func (*AccessListGrantsToUserEvent) ProtoMessage() {}
 
 func (x *AccessListGrantsToUserEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[71]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[73]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6501,7 +6697,7 @@ func (x *AccessListGrantsToUserEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AccessListGrantsToUserEvent.ProtoReflect.Descriptor instead.
 func (*AccessListGrantsToUserEvent) Descriptor() ([]byte, []int) {
-	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{71}
+	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{73}
 }
 
 func (x *AccessListGrantsToUserEvent) GetUserName() string {
@@ -6561,7 +6757,7 @@ type AccessListReviewCreateEvent struct {
 
 func (x *AccessListReviewCreateEvent) Reset() {
 	*x = AccessListReviewCreateEvent{}
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[72]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[74]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6573,7 +6769,7 @@ func (x *AccessListReviewCreateEvent) String() string {
 func (*AccessListReviewCreateEvent) ProtoMessage() {}
 
 func (x *AccessListReviewCreateEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[72]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[74]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6586,7 +6782,7 @@ func (x *AccessListReviewCreateEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AccessListReviewCreateEvent.ProtoReflect.Descriptor instead.
 func (*AccessListReviewCreateEvent) Descriptor() ([]byte, []int) {
-	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{72}
+	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{74}
 }
 
 func (x *AccessListReviewCreateEvent) GetUserName() string {
@@ -6652,7 +6848,7 @@ type AccessListReviewDeleteEvent struct {
 
 func (x *AccessListReviewDeleteEvent) Reset() {
 	*x = AccessListReviewDeleteEvent{}
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[73]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[75]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6664,7 +6860,7 @@ func (x *AccessListReviewDeleteEvent) String() string {
 func (*AccessListReviewDeleteEvent) ProtoMessage() {}
 
 func (x *AccessListReviewDeleteEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[73]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[75]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6677,7 +6873,7 @@ func (x *AccessListReviewDeleteEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AccessListReviewDeleteEvent.ProtoReflect.Descriptor instead.
 func (*AccessListReviewDeleteEvent) Descriptor() ([]byte, []int) {
-	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{73}
+	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{75}
 }
 
 func (x *AccessListReviewDeleteEvent) GetUserName() string {
@@ -6715,7 +6911,7 @@ type AccessListReviewComplianceEvent struct {
 
 func (x *AccessListReviewComplianceEvent) Reset() {
 	*x = AccessListReviewComplianceEvent{}
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[74]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[76]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6727,7 +6923,7 @@ func (x *AccessListReviewComplianceEvent) String() string {
 func (*AccessListReviewComplianceEvent) ProtoMessage() {}
 
 func (x *AccessListReviewComplianceEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[74]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[76]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6740,7 +6936,7 @@ func (x *AccessListReviewComplianceEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AccessListReviewComplianceEvent.ProtoReflect.Descriptor instead.
 func (*AccessListReviewComplianceEvent) Descriptor() ([]byte, []int) {
-	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{74}
+	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{76}
 }
 
 func (x *AccessListReviewComplianceEvent) GetTotalAccessLists() int32 {
@@ -6774,7 +6970,7 @@ type IntegrationEnrollMetadata struct {
 
 func (x *IntegrationEnrollMetadata) Reset() {
 	*x = IntegrationEnrollMetadata{}
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[75]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[77]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6786,7 +6982,7 @@ func (x *IntegrationEnrollMetadata) String() string {
 func (*IntegrationEnrollMetadata) ProtoMessage() {}
 
 func (x *IntegrationEnrollMetadata) ProtoReflect() protoreflect.Message {
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[75]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[77]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6799,7 +6995,7 @@ func (x *IntegrationEnrollMetadata) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use IntegrationEnrollMetadata.ProtoReflect.Descriptor instead.
 func (*IntegrationEnrollMetadata) Descriptor() ([]byte, []int) {
-	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{75}
+	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{77}
 }
 
 func (x *IntegrationEnrollMetadata) GetId() string {
@@ -6834,7 +7030,7 @@ type UIIntegrationEnrollStartEvent struct {
 
 func (x *UIIntegrationEnrollStartEvent) Reset() {
 	*x = UIIntegrationEnrollStartEvent{}
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[76]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[78]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6846,7 +7042,7 @@ func (x *UIIntegrationEnrollStartEvent) String() string {
 func (*UIIntegrationEnrollStartEvent) ProtoMessage() {}
 
 func (x *UIIntegrationEnrollStartEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[76]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[78]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6859,7 +7055,7 @@ func (x *UIIntegrationEnrollStartEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UIIntegrationEnrollStartEvent.ProtoReflect.Descriptor instead.
 func (*UIIntegrationEnrollStartEvent) Descriptor() ([]byte, []int) {
-	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{76}
+	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{78}
 }
 
 func (x *UIIntegrationEnrollStartEvent) GetMetadata() *IntegrationEnrollMetadata {
@@ -6880,7 +7076,7 @@ type UIIntegrationEnrollCompleteEvent struct {
 
 func (x *UIIntegrationEnrollCompleteEvent) Reset() {
 	*x = UIIntegrationEnrollCompleteEvent{}
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[77]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[79]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6892,7 +7088,7 @@ func (x *UIIntegrationEnrollCompleteEvent) String() string {
 func (*UIIntegrationEnrollCompleteEvent) ProtoMessage() {}
 
 func (x *UIIntegrationEnrollCompleteEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[77]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[79]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6905,7 +7101,7 @@ func (x *UIIntegrationEnrollCompleteEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UIIntegrationEnrollCompleteEvent.ProtoReflect.Descriptor instead.
 func (*UIIntegrationEnrollCompleteEvent) Descriptor() ([]byte, []int) {
-	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{77}
+	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{79}
 }
 
 func (x *UIIntegrationEnrollCompleteEvent) GetMetadata() *IntegrationEnrollMetadata {
@@ -6931,7 +7127,7 @@ type IntegrationEnrollStepStatus struct {
 
 func (x *IntegrationEnrollStepStatus) Reset() {
 	*x = IntegrationEnrollStepStatus{}
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[78]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[80]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6943,7 +7139,7 @@ func (x *IntegrationEnrollStepStatus) String() string {
 func (*IntegrationEnrollStepStatus) ProtoMessage() {}
 
 func (x *IntegrationEnrollStepStatus) ProtoReflect() protoreflect.Message {
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[78]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[80]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6956,7 +7152,7 @@ func (x *IntegrationEnrollStepStatus) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use IntegrationEnrollStepStatus.ProtoReflect.Descriptor instead.
 func (*IntegrationEnrollStepStatus) Descriptor() ([]byte, []int) {
-	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{78}
+	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{80}
 }
 
 func (x *IntegrationEnrollStepStatus) GetCode() IntegrationEnrollStatusCode {
@@ -6989,7 +7185,7 @@ type UIIntegrationEnrollStepEvent struct {
 
 func (x *UIIntegrationEnrollStepEvent) Reset() {
 	*x = UIIntegrationEnrollStepEvent{}
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[79]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[81]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7001,7 +7197,7 @@ func (x *UIIntegrationEnrollStepEvent) String() string {
 func (*UIIntegrationEnrollStepEvent) ProtoMessage() {}
 
 func (x *UIIntegrationEnrollStepEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[79]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[81]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7014,7 +7210,7 @@ func (x *UIIntegrationEnrollStepEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UIIntegrationEnrollStepEvent.ProtoReflect.Descriptor instead.
 func (*UIIntegrationEnrollStepEvent) Descriptor() ([]byte, []int) {
-	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{79}
+	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{81}
 }
 
 func (x *UIIntegrationEnrollStepEvent) GetMetadata() *IntegrationEnrollMetadata {
@@ -7054,7 +7250,7 @@ type UIIntegrationEnrollSectionOpenEvent struct {
 
 func (x *UIIntegrationEnrollSectionOpenEvent) Reset() {
 	*x = UIIntegrationEnrollSectionOpenEvent{}
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[80]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[82]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7066,7 +7262,7 @@ func (x *UIIntegrationEnrollSectionOpenEvent) String() string {
 func (*UIIntegrationEnrollSectionOpenEvent) ProtoMessage() {}
 
 func (x *UIIntegrationEnrollSectionOpenEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[80]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[82]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7079,7 +7275,7 @@ func (x *UIIntegrationEnrollSectionOpenEvent) ProtoReflect() protoreflect.Messag
 
 // Deprecated: Use UIIntegrationEnrollSectionOpenEvent.ProtoReflect.Descriptor instead.
 func (*UIIntegrationEnrollSectionOpenEvent) Descriptor() ([]byte, []int) {
-	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{80}
+	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{82}
 }
 
 func (x *UIIntegrationEnrollSectionOpenEvent) GetMetadata() *IntegrationEnrollMetadata {
@@ -7119,7 +7315,7 @@ type UIIntegrationEnrollFieldCompleteEvent struct {
 
 func (x *UIIntegrationEnrollFieldCompleteEvent) Reset() {
 	*x = UIIntegrationEnrollFieldCompleteEvent{}
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[81]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[83]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7131,7 +7327,7 @@ func (x *UIIntegrationEnrollFieldCompleteEvent) String() string {
 func (*UIIntegrationEnrollFieldCompleteEvent) ProtoMessage() {}
 
 func (x *UIIntegrationEnrollFieldCompleteEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[81]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[83]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7144,7 +7340,7 @@ func (x *UIIntegrationEnrollFieldCompleteEvent) ProtoReflect() protoreflect.Mess
 
 // Deprecated: Use UIIntegrationEnrollFieldCompleteEvent.ProtoReflect.Descriptor instead.
 func (*UIIntegrationEnrollFieldCompleteEvent) Descriptor() ([]byte, []int) {
-	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{81}
+	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{83}
 }
 
 func (x *UIIntegrationEnrollFieldCompleteEvent) GetMetadata() *IntegrationEnrollMetadata {
@@ -7184,7 +7380,7 @@ type UIIntegrationEnrollCodeCopyEvent struct {
 
 func (x *UIIntegrationEnrollCodeCopyEvent) Reset() {
 	*x = UIIntegrationEnrollCodeCopyEvent{}
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[82]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[84]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7196,7 +7392,7 @@ func (x *UIIntegrationEnrollCodeCopyEvent) String() string {
 func (*UIIntegrationEnrollCodeCopyEvent) ProtoMessage() {}
 
 func (x *UIIntegrationEnrollCodeCopyEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[82]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[84]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7209,7 +7405,7 @@ func (x *UIIntegrationEnrollCodeCopyEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UIIntegrationEnrollCodeCopyEvent.ProtoReflect.Descriptor instead.
 func (*UIIntegrationEnrollCodeCopyEvent) Descriptor() ([]byte, []int) {
-	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{82}
+	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{84}
 }
 
 func (x *UIIntegrationEnrollCodeCopyEvent) GetMetadata() *IntegrationEnrollMetadata {
@@ -7249,7 +7445,7 @@ type UIIntegrationEnrollLinkClickEvent struct {
 
 func (x *UIIntegrationEnrollLinkClickEvent) Reset() {
 	*x = UIIntegrationEnrollLinkClickEvent{}
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[83]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[85]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7261,7 +7457,7 @@ func (x *UIIntegrationEnrollLinkClickEvent) String() string {
 func (*UIIntegrationEnrollLinkClickEvent) ProtoMessage() {}
 
 func (x *UIIntegrationEnrollLinkClickEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[83]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[85]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7274,7 +7470,7 @@ func (x *UIIntegrationEnrollLinkClickEvent) ProtoReflect() protoreflect.Message 
 
 // Deprecated: Use UIIntegrationEnrollLinkClickEvent.ProtoReflect.Descriptor instead.
 func (*UIIntegrationEnrollLinkClickEvent) Descriptor() ([]byte, []int) {
-	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{83}
+	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{85}
 }
 
 func (x *UIIntegrationEnrollLinkClickEvent) GetMetadata() *IntegrationEnrollMetadata {
@@ -7311,7 +7507,7 @@ type EditorChangeEvent struct {
 
 func (x *EditorChangeEvent) Reset() {
 	*x = EditorChangeEvent{}
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[84]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[86]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7323,7 +7519,7 @@ func (x *EditorChangeEvent) String() string {
 func (*EditorChangeEvent) ProtoMessage() {}
 
 func (x *EditorChangeEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[84]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[86]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7336,7 +7532,7 @@ func (x *EditorChangeEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use EditorChangeEvent.ProtoReflect.Descriptor instead.
 func (*EditorChangeEvent) Descriptor() ([]byte, []int) {
-	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{84}
+	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{86}
 }
 
 func (x *EditorChangeEvent) GetUserName() string {
@@ -7374,7 +7570,7 @@ type DeviceAuthenticateEvent struct {
 
 func (x *DeviceAuthenticateEvent) Reset() {
 	*x = DeviceAuthenticateEvent{}
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[85]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[87]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7386,7 +7582,7 @@ func (x *DeviceAuthenticateEvent) String() string {
 func (*DeviceAuthenticateEvent) ProtoMessage() {}
 
 func (x *DeviceAuthenticateEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[85]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[87]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7399,7 +7595,7 @@ func (x *DeviceAuthenticateEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeviceAuthenticateEvent.ProtoReflect.Descriptor instead.
 func (*DeviceAuthenticateEvent) Descriptor() ([]byte, []int) {
-	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{85}
+	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{87}
 }
 
 func (x *DeviceAuthenticateEvent) GetDeviceId() string {
@@ -7450,7 +7646,7 @@ type DeviceEnrollEvent struct {
 
 func (x *DeviceEnrollEvent) Reset() {
 	*x = DeviceEnrollEvent{}
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[86]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[88]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7462,7 +7658,7 @@ func (x *DeviceEnrollEvent) String() string {
 func (*DeviceEnrollEvent) ProtoMessage() {}
 
 func (x *DeviceEnrollEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[86]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[88]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7475,7 +7671,7 @@ func (x *DeviceEnrollEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeviceEnrollEvent.ProtoReflect.Descriptor instead.
 func (*DeviceEnrollEvent) Descriptor() ([]byte, []int) {
-	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{86}
+	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{88}
 }
 
 func (x *DeviceEnrollEvent) GetDeviceId() string {
@@ -7531,7 +7727,7 @@ type FeatureRecommendationEvent struct {
 
 func (x *FeatureRecommendationEvent) Reset() {
 	*x = FeatureRecommendationEvent{}
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[87]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[89]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7543,7 +7739,7 @@ func (x *FeatureRecommendationEvent) String() string {
 func (*FeatureRecommendationEvent) ProtoMessage() {}
 
 func (x *FeatureRecommendationEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[87]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[89]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7556,7 +7752,7 @@ func (x *FeatureRecommendationEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use FeatureRecommendationEvent.ProtoReflect.Descriptor instead.
 func (*FeatureRecommendationEvent) Descriptor() ([]byte, []int) {
-	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{87}
+	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{89}
 }
 
 func (x *FeatureRecommendationEvent) GetUserName() string {
@@ -7594,7 +7790,7 @@ type LicenseLimitEvent struct {
 
 func (x *LicenseLimitEvent) Reset() {
 	*x = LicenseLimitEvent{}
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[88]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[90]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7606,7 +7802,7 @@ func (x *LicenseLimitEvent) String() string {
 func (*LicenseLimitEvent) ProtoMessage() {}
 
 func (x *LicenseLimitEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[88]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[90]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7619,7 +7815,7 @@ func (x *LicenseLimitEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LicenseLimitEvent.ProtoReflect.Descriptor instead.
 func (*LicenseLimitEvent) Descriptor() ([]byte, []int) {
-	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{88}
+	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{90}
 }
 
 func (x *LicenseLimitEvent) GetLicenseLimit() LicenseLimit {
@@ -7651,7 +7847,7 @@ type DesktopDirectoryShareEvent struct {
 
 func (x *DesktopDirectoryShareEvent) Reset() {
 	*x = DesktopDirectoryShareEvent{}
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[89]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[91]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7663,7 +7859,7 @@ func (x *DesktopDirectoryShareEvent) String() string {
 func (*DesktopDirectoryShareEvent) ProtoMessage() {}
 
 func (x *DesktopDirectoryShareEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[89]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[91]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7676,7 +7872,7 @@ func (x *DesktopDirectoryShareEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DesktopDirectoryShareEvent.ProtoReflect.Descriptor instead.
 func (*DesktopDirectoryShareEvent) Descriptor() ([]byte, []int) {
-	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{89}
+	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{91}
 }
 
 func (x *DesktopDirectoryShareEvent) GetDesktop() string {
@@ -7718,7 +7914,7 @@ type DesktopClipboardEvent struct {
 
 func (x *DesktopClipboardEvent) Reset() {
 	*x = DesktopClipboardEvent{}
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[90]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[92]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7730,7 +7926,7 @@ func (x *DesktopClipboardEvent) String() string {
 func (*DesktopClipboardEvent) ProtoMessage() {}
 
 func (x *DesktopClipboardEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[90]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[92]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7743,7 +7939,7 @@ func (x *DesktopClipboardEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DesktopClipboardEvent.ProtoReflect.Descriptor instead.
 func (*DesktopClipboardEvent) Descriptor() ([]byte, []int) {
-	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{90}
+	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{92}
 }
 
 func (x *DesktopClipboardEvent) GetDesktop() string {
@@ -7780,7 +7976,7 @@ type TAGExecuteQueryEvent struct {
 
 func (x *TAGExecuteQueryEvent) Reset() {
 	*x = TAGExecuteQueryEvent{}
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[91]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[93]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7792,7 +7988,7 @@ func (x *TAGExecuteQueryEvent) String() string {
 func (*TAGExecuteQueryEvent) ProtoMessage() {}
 
 func (x *TAGExecuteQueryEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[91]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[93]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7805,7 +8001,7 @@ func (x *TAGExecuteQueryEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TAGExecuteQueryEvent.ProtoReflect.Descriptor instead.
 func (*TAGExecuteQueryEvent) Descriptor() ([]byte, []int) {
-	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{91}
+	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{93}
 }
 
 func (x *TAGExecuteQueryEvent) GetUserName() string {
@@ -7850,7 +8046,7 @@ type AccessGraphSecretsScanAuthorizedKeysEvent struct {
 
 func (x *AccessGraphSecretsScanAuthorizedKeysEvent) Reset() {
 	*x = AccessGraphSecretsScanAuthorizedKeysEvent{}
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[92]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[94]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7862,7 +8058,7 @@ func (x *AccessGraphSecretsScanAuthorizedKeysEvent) String() string {
 func (*AccessGraphSecretsScanAuthorizedKeysEvent) ProtoMessage() {}
 
 func (x *AccessGraphSecretsScanAuthorizedKeysEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[92]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[94]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7875,7 +8071,7 @@ func (x *AccessGraphSecretsScanAuthorizedKeysEvent) ProtoReflect() protoreflect.
 
 // Deprecated: Use AccessGraphSecretsScanAuthorizedKeysEvent.ProtoReflect.Descriptor instead.
 func (*AccessGraphSecretsScanAuthorizedKeysEvent) Descriptor() ([]byte, []int) {
-	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{92}
+	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{94}
 }
 
 func (x *AccessGraphSecretsScanAuthorizedKeysEvent) GetHostId() string {
@@ -7908,7 +8104,7 @@ type AccessGraphSecretsScanSSHPrivateKeysEvent struct {
 
 func (x *AccessGraphSecretsScanSSHPrivateKeysEvent) Reset() {
 	*x = AccessGraphSecretsScanSSHPrivateKeysEvent{}
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[93]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[95]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7920,7 +8116,7 @@ func (x *AccessGraphSecretsScanSSHPrivateKeysEvent) String() string {
 func (*AccessGraphSecretsScanSSHPrivateKeysEvent) ProtoMessage() {}
 
 func (x *AccessGraphSecretsScanSSHPrivateKeysEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[93]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[95]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7933,7 +8129,7 @@ func (x *AccessGraphSecretsScanSSHPrivateKeysEvent) ProtoReflect() protoreflect.
 
 // Deprecated: Use AccessGraphSecretsScanSSHPrivateKeysEvent.ProtoReflect.Descriptor instead.
 func (*AccessGraphSecretsScanSSHPrivateKeysEvent) Descriptor() ([]byte, []int) {
-	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{93}
+	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{95}
 }
 
 func (x *AccessGraphSecretsScanSSHPrivateKeysEvent) GetDeviceId() string {
@@ -7973,7 +8169,7 @@ type AccessGraphGitlabScanEvent struct {
 
 func (x *AccessGraphGitlabScanEvent) Reset() {
 	*x = AccessGraphGitlabScanEvent{}
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[94]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[96]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7985,7 +8181,7 @@ func (x *AccessGraphGitlabScanEvent) String() string {
 func (*AccessGraphGitlabScanEvent) ProtoMessage() {}
 
 func (x *AccessGraphGitlabScanEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[94]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[96]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7998,7 +8194,7 @@ func (x *AccessGraphGitlabScanEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AccessGraphGitlabScanEvent.ProtoReflect.Descriptor instead.
 func (*AccessGraphGitlabScanEvent) Descriptor() ([]byte, []int) {
-	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{94}
+	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{96}
 }
 
 func (x *AccessGraphGitlabScanEvent) GetTotalProjects() uint64 {
@@ -8054,7 +8250,7 @@ type AccessGraphAWSScanEvent struct {
 
 func (x *AccessGraphAWSScanEvent) Reset() {
 	*x = AccessGraphAWSScanEvent{}
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[95]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[97]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8066,7 +8262,7 @@ func (x *AccessGraphAWSScanEvent) String() string {
 func (*AccessGraphAWSScanEvent) ProtoMessage() {}
 
 func (x *AccessGraphAWSScanEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[95]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[97]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8079,7 +8275,7 @@ func (x *AccessGraphAWSScanEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AccessGraphAWSScanEvent.ProtoReflect.Descriptor instead.
 func (*AccessGraphAWSScanEvent) Descriptor() ([]byte, []int) {
-	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{95}
+	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{97}
 }
 
 func (x *AccessGraphAWSScanEvent) GetTotalEc2Instances() uint64 {
@@ -8173,7 +8369,7 @@ type AccessGraphAccessPathChangedEvent struct {
 
 func (x *AccessGraphAccessPathChangedEvent) Reset() {
 	*x = AccessGraphAccessPathChangedEvent{}
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[96]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[98]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8185,7 +8381,7 @@ func (x *AccessGraphAccessPathChangedEvent) String() string {
 func (*AccessGraphAccessPathChangedEvent) ProtoMessage() {}
 
 func (x *AccessGraphAccessPathChangedEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[96]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[98]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8198,7 +8394,7 @@ func (x *AccessGraphAccessPathChangedEvent) ProtoReflect() protoreflect.Message 
 
 // Deprecated: Use AccessGraphAccessPathChangedEvent.ProtoReflect.Descriptor instead.
 func (*AccessGraphAccessPathChangedEvent) Descriptor() ([]byte, []int) {
-	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{96}
+	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{98}
 }
 
 func (x *AccessGraphAccessPathChangedEvent) GetAffectedResourceSource() string {
@@ -8228,7 +8424,7 @@ type UIAccessGraphCrownJewelDiffViewEvent struct {
 
 func (x *UIAccessGraphCrownJewelDiffViewEvent) Reset() {
 	*x = UIAccessGraphCrownJewelDiffViewEvent{}
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[97]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[99]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8240,7 +8436,7 @@ func (x *UIAccessGraphCrownJewelDiffViewEvent) String() string {
 func (*UIAccessGraphCrownJewelDiffViewEvent) ProtoMessage() {}
 
 func (x *UIAccessGraphCrownJewelDiffViewEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[97]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[99]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8253,7 +8449,7 @@ func (x *UIAccessGraphCrownJewelDiffViewEvent) ProtoReflect() protoreflect.Messa
 
 // Deprecated: Use UIAccessGraphCrownJewelDiffViewEvent.ProtoReflect.Descriptor instead.
 func (*UIAccessGraphCrownJewelDiffViewEvent) Descriptor() ([]byte, []int) {
-	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{97}
+	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{99}
 }
 
 func (x *UIAccessGraphCrownJewelDiffViewEvent) GetAffectedResourceSource() string {
@@ -8287,7 +8483,7 @@ type UIPageViewEvent struct {
 
 func (x *UIPageViewEvent) Reset() {
 	*x = UIPageViewEvent{}
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[98]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[100]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8299,7 +8495,7 @@ func (x *UIPageViewEvent) String() string {
 func (*UIPageViewEvent) ProtoMessage() {}
 
 func (x *UIPageViewEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[98]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[100]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8312,7 +8508,7 @@ func (x *UIPageViewEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UIPageViewEvent.ProtoReflect.Descriptor instead.
 func (*UIPageViewEvent) Descriptor() ([]byte, []int) {
-	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{98}
+	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{100}
 }
 
 func (x *UIPageViewEvent) GetUserName() string {
@@ -8361,7 +8557,7 @@ type UIUsageReportingAlertCtaClickEvent struct {
 
 func (x *UIUsageReportingAlertCtaClickEvent) Reset() {
 	*x = UIUsageReportingAlertCtaClickEvent{}
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[99]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[101]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8373,7 +8569,7 @@ func (x *UIUsageReportingAlertCtaClickEvent) String() string {
 func (*UIUsageReportingAlertCtaClickEvent) ProtoMessage() {}
 
 func (x *UIUsageReportingAlertCtaClickEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[99]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[101]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8386,7 +8582,7 @@ func (x *UIUsageReportingAlertCtaClickEvent) ProtoReflect() protoreflect.Message
 
 // Deprecated: Use UIUsageReportingAlertCtaClickEvent.ProtoReflect.Descriptor instead.
 func (*UIUsageReportingAlertCtaClickEvent) Descriptor() ([]byte, []int) {
-	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{99}
+	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{101}
 }
 
 func (x *UIUsageReportingAlertCtaClickEvent) GetUserName() string {
@@ -8427,7 +8623,7 @@ type AccessGraphCrownJewelCreateEvent struct {
 
 func (x *AccessGraphCrownJewelCreateEvent) Reset() {
 	*x = AccessGraphCrownJewelCreateEvent{}
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[100]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[102]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8439,7 +8635,7 @@ func (x *AccessGraphCrownJewelCreateEvent) String() string {
 func (*AccessGraphCrownJewelCreateEvent) ProtoMessage() {}
 
 func (x *AccessGraphCrownJewelCreateEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[100]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[102]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8452,7 +8648,7 @@ func (x *AccessGraphCrownJewelCreateEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AccessGraphCrownJewelCreateEvent.ProtoReflect.Descriptor instead.
 func (*AccessGraphCrownJewelCreateEvent) Descriptor() ([]byte, []int) {
-	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{100}
+	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{102}
 }
 
 // ExternalAuditStorageAuthenticateEvent is emitted when the External Audit
@@ -8467,7 +8663,7 @@ type ExternalAuditStorageAuthenticateEvent struct {
 
 func (x *ExternalAuditStorageAuthenticateEvent) Reset() {
 	*x = ExternalAuditStorageAuthenticateEvent{}
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[101]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[103]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8479,7 +8675,7 @@ func (x *ExternalAuditStorageAuthenticateEvent) String() string {
 func (*ExternalAuditStorageAuthenticateEvent) ProtoMessage() {}
 
 func (x *ExternalAuditStorageAuthenticateEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[101]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[103]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8492,7 +8688,7 @@ func (x *ExternalAuditStorageAuthenticateEvent) ProtoReflect() protoreflect.Mess
 
 // Deprecated: Use ExternalAuditStorageAuthenticateEvent.ProtoReflect.Descriptor instead.
 func (*ExternalAuditStorageAuthenticateEvent) Descriptor() ([]byte, []int) {
-	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{101}
+	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{103}
 }
 
 // SecurityReportGetResultEvent is emitted when the user requests a security report.
@@ -8510,7 +8706,7 @@ type SecurityReportGetResultEvent struct {
 
 func (x *SecurityReportGetResultEvent) Reset() {
 	*x = SecurityReportGetResultEvent{}
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[102]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[104]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8522,7 +8718,7 @@ func (x *SecurityReportGetResultEvent) String() string {
 func (*SecurityReportGetResultEvent) ProtoMessage() {}
 
 func (x *SecurityReportGetResultEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[102]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[104]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8535,7 +8731,7 @@ func (x *SecurityReportGetResultEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SecurityReportGetResultEvent.ProtoReflect.Descriptor instead.
 func (*SecurityReportGetResultEvent) Descriptor() ([]byte, []int) {
-	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{102}
+	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{104}
 }
 
 func (x *SecurityReportGetResultEvent) GetUserName() string {
@@ -8574,7 +8770,7 @@ type AuditQueryRunEvent struct {
 
 func (x *AuditQueryRunEvent) Reset() {
 	*x = AuditQueryRunEvent{}
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[103]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[105]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8586,7 +8782,7 @@ func (x *AuditQueryRunEvent) String() string {
 func (*AuditQueryRunEvent) ProtoMessage() {}
 
 func (x *AuditQueryRunEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[103]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[105]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8599,7 +8795,7 @@ func (x *AuditQueryRunEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AuditQueryRunEvent.ProtoReflect.Descriptor instead.
 func (*AuditQueryRunEvent) Descriptor() ([]byte, []int) {
-	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{103}
+	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{105}
 }
 
 func (x *AuditQueryRunEvent) GetUserName() string {
@@ -8643,7 +8839,7 @@ type DiscoveryFetchEvent struct {
 
 func (x *DiscoveryFetchEvent) Reset() {
 	*x = DiscoveryFetchEvent{}
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[104]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[106]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8655,7 +8851,7 @@ func (x *DiscoveryFetchEvent) String() string {
 func (*DiscoveryFetchEvent) ProtoMessage() {}
 
 func (x *DiscoveryFetchEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[104]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[106]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8668,7 +8864,7 @@ func (x *DiscoveryFetchEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DiscoveryFetchEvent.ProtoReflect.Descriptor instead.
 func (*DiscoveryFetchEvent) Descriptor() ([]byte, []int) {
-	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{104}
+	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{106}
 }
 
 func (x *DiscoveryFetchEvent) GetCloudProvider() string {
@@ -8709,7 +8905,7 @@ type OktaAccessListSyncEvent struct {
 
 func (x *OktaAccessListSyncEvent) Reset() {
 	*x = OktaAccessListSyncEvent{}
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[105]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[107]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8721,7 +8917,7 @@ func (x *OktaAccessListSyncEvent) String() string {
 func (*OktaAccessListSyncEvent) ProtoMessage() {}
 
 func (x *OktaAccessListSyncEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[105]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[107]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8734,7 +8930,7 @@ func (x *OktaAccessListSyncEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use OktaAccessListSyncEvent.ProtoReflect.Descriptor instead.
 func (*OktaAccessListSyncEvent) Descriptor() ([]byte, []int) {
-	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{105}
+	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{107}
 }
 
 func (x *OktaAccessListSyncEvent) GetNumAppFilters() int32 {
@@ -8801,7 +8997,7 @@ type DatabaseUserCreatedEvent struct {
 
 func (x *DatabaseUserCreatedEvent) Reset() {
 	*x = DatabaseUserCreatedEvent{}
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[106]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[108]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8813,7 +9009,7 @@ func (x *DatabaseUserCreatedEvent) String() string {
 func (*DatabaseUserCreatedEvent) ProtoMessage() {}
 
 func (x *DatabaseUserCreatedEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[106]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[108]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8826,7 +9022,7 @@ func (x *DatabaseUserCreatedEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DatabaseUserCreatedEvent.ProtoReflect.Descriptor instead.
 func (*DatabaseUserCreatedEvent) Descriptor() ([]byte, []int) {
-	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{106}
+	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{108}
 }
 
 func (x *DatabaseUserCreatedEvent) GetDatabase() *SessionStartDatabaseMetadata {
@@ -8868,7 +9064,7 @@ type DatabaseUserPermissionsUpdateEvent struct {
 
 func (x *DatabaseUserPermissionsUpdateEvent) Reset() {
 	*x = DatabaseUserPermissionsUpdateEvent{}
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[107]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[109]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8880,7 +9076,7 @@ func (x *DatabaseUserPermissionsUpdateEvent) String() string {
 func (*DatabaseUserPermissionsUpdateEvent) ProtoMessage() {}
 
 func (x *DatabaseUserPermissionsUpdateEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[107]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[109]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8893,7 +9089,7 @@ func (x *DatabaseUserPermissionsUpdateEvent) ProtoReflect() protoreflect.Message
 
 // Deprecated: Use DatabaseUserPermissionsUpdateEvent.ProtoReflect.Descriptor instead.
 func (*DatabaseUserPermissionsUpdateEvent) Descriptor() ([]byte, []int) {
-	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{107}
+	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{109}
 }
 
 func (x *DatabaseUserPermissionsUpdateEvent) GetDatabase() *SessionStartDatabaseMetadata {
@@ -8952,7 +9148,7 @@ type SessionRecordingAccessEvent struct {
 
 func (x *SessionRecordingAccessEvent) Reset() {
 	*x = SessionRecordingAccessEvent{}
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[108]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[110]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8964,7 +9160,7 @@ func (x *SessionRecordingAccessEvent) String() string {
 func (*SessionRecordingAccessEvent) ProtoMessage() {}
 
 func (x *SessionRecordingAccessEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[108]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[110]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8977,7 +9173,7 @@ func (x *SessionRecordingAccessEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SessionRecordingAccessEvent.ProtoReflect.Descriptor instead.
 func (*SessionRecordingAccessEvent) Descriptor() ([]byte, []int) {
-	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{108}
+	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{110}
 }
 
 func (x *SessionRecordingAccessEvent) GetSessionType() string {
@@ -9040,7 +9236,7 @@ type UserTaskStateEvent struct {
 
 func (x *UserTaskStateEvent) Reset() {
 	*x = UserTaskStateEvent{}
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[109]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[111]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9052,7 +9248,7 @@ func (x *UserTaskStateEvent) String() string {
 func (*UserTaskStateEvent) ProtoMessage() {}
 
 func (x *UserTaskStateEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[109]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[111]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9065,7 +9261,7 @@ func (x *UserTaskStateEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UserTaskStateEvent.ProtoReflect.Descriptor instead.
 func (*UserTaskStateEvent) Descriptor() ([]byte, []int) {
-	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{109}
+	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{111}
 }
 
 func (x *UserTaskStateEvent) GetTaskType() string {
@@ -9120,7 +9316,7 @@ type AccessRequestCreateEvent struct {
 
 func (x *AccessRequestCreateEvent) Reset() {
 	*x = AccessRequestCreateEvent{}
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[110]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[112]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9132,7 +9328,7 @@ func (x *AccessRequestCreateEvent) String() string {
 func (*AccessRequestCreateEvent) ProtoMessage() {}
 
 func (x *AccessRequestCreateEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[110]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[112]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9145,7 +9341,7 @@ func (x *AccessRequestCreateEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AccessRequestCreateEvent.ProtoReflect.Descriptor instead.
 func (*AccessRequestCreateEvent) Descriptor() ([]byte, []int) {
-	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{110}
+	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{112}
 }
 
 func (x *AccessRequestCreateEvent) GetUserName() string {
@@ -9188,7 +9384,7 @@ type AccessRequestReviewEvent struct {
 
 func (x *AccessRequestReviewEvent) Reset() {
 	*x = AccessRequestReviewEvent{}
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[111]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[113]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9200,7 +9396,7 @@ func (x *AccessRequestReviewEvent) String() string {
 func (*AccessRequestReviewEvent) ProtoMessage() {}
 
 func (x *AccessRequestReviewEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[111]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[113]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9213,7 +9409,7 @@ func (x *AccessRequestReviewEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AccessRequestReviewEvent.ProtoReflect.Descriptor instead.
 func (*AccessRequestReviewEvent) Descriptor() ([]byte, []int) {
-	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{111}
+	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{113}
 }
 
 func (x *AccessRequestReviewEvent) GetUserName() string {
@@ -9274,7 +9470,7 @@ type SessionSummaryAccessEvent struct {
 
 func (x *SessionSummaryAccessEvent) Reset() {
 	*x = SessionSummaryAccessEvent{}
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[112]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[114]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9286,7 +9482,7 @@ func (x *SessionSummaryAccessEvent) String() string {
 func (*SessionSummaryAccessEvent) ProtoMessage() {}
 
 func (x *SessionSummaryAccessEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[112]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[114]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9299,7 +9495,7 @@ func (x *SessionSummaryAccessEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SessionSummaryAccessEvent.ProtoReflect.Descriptor instead.
 func (*SessionSummaryAccessEvent) Descriptor() ([]byte, []int) {
-	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{112}
+	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{114}
 }
 
 func (x *SessionSummaryAccessEvent) GetSessionType() string {
@@ -9378,7 +9574,7 @@ type SessionSummaryCreateEvent struct {
 
 func (x *SessionSummaryCreateEvent) Reset() {
 	*x = SessionSummaryCreateEvent{}
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[113]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[115]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9390,7 +9586,7 @@ func (x *SessionSummaryCreateEvent) String() string {
 func (*SessionSummaryCreateEvent) ProtoMessage() {}
 
 func (x *SessionSummaryCreateEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[113]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[115]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9403,7 +9599,7 @@ func (x *SessionSummaryCreateEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SessionSummaryCreateEvent.ProtoReflect.Descriptor instead.
 func (*SessionSummaryCreateEvent) Descriptor() ([]byte, []int) {
-	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{113}
+	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{115}
 }
 
 func (x *SessionSummaryCreateEvent) GetSessionType() string {
@@ -9490,7 +9686,7 @@ type SessionSummarySearchEvent struct {
 
 func (x *SessionSummarySearchEvent) Reset() {
 	*x = SessionSummarySearchEvent{}
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[114]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[116]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9502,7 +9698,7 @@ func (x *SessionSummarySearchEvent) String() string {
 func (*SessionSummarySearchEvent) ProtoMessage() {}
 
 func (x *SessionSummarySearchEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[114]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[116]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9515,7 +9711,7 @@ func (x *SessionSummarySearchEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SessionSummarySearchEvent.ProtoReflect.Descriptor instead.
 func (*SessionSummarySearchEvent) Descriptor() ([]byte, []int) {
-	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{114}
+	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{116}
 }
 
 func (x *SessionSummarySearchEvent) GetUserName() string {
@@ -9567,7 +9763,7 @@ type DiscoveryConfigEvent struct {
 
 func (x *DiscoveryConfigEvent) Reset() {
 	*x = DiscoveryConfigEvent{}
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[115]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[117]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9579,7 +9775,7 @@ func (x *DiscoveryConfigEvent) String() string {
 func (*DiscoveryConfigEvent) ProtoMessage() {}
 
 func (x *DiscoveryConfigEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[115]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[117]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9592,7 +9788,7 @@ func (x *DiscoveryConfigEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DiscoveryConfigEvent.ProtoReflect.Descriptor instead.
 func (*DiscoveryConfigEvent) Descriptor() ([]byte, []int) {
-	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{115}
+	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{117}
 }
 
 func (x *DiscoveryConfigEvent) GetAction() DiscoveryConfigAction {
@@ -9647,7 +9843,7 @@ type IdentitySecurityGraphSizeEvent struct {
 
 func (x *IdentitySecurityGraphSizeEvent) Reset() {
 	*x = IdentitySecurityGraphSizeEvent{}
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[116]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[118]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9659,7 +9855,7 @@ func (x *IdentitySecurityGraphSizeEvent) String() string {
 func (*IdentitySecurityGraphSizeEvent) ProtoMessage() {}
 
 func (x *IdentitySecurityGraphSizeEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[116]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[118]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9672,7 +9868,7 @@ func (x *IdentitySecurityGraphSizeEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use IdentitySecurityGraphSizeEvent.ProtoReflect.Descriptor instead.
 func (*IdentitySecurityGraphSizeEvent) Descriptor() ([]byte, []int) {
-	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{116}
+	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{118}
 }
 
 func (x *IdentitySecurityGraphSizeEvent) GetProvider() string {
@@ -9711,7 +9907,7 @@ type IdentitySecurityAuditLogsIngestedEvent struct {
 
 func (x *IdentitySecurityAuditLogsIngestedEvent) Reset() {
 	*x = IdentitySecurityAuditLogsIngestedEvent{}
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[117]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[119]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9723,7 +9919,7 @@ func (x *IdentitySecurityAuditLogsIngestedEvent) String() string {
 func (*IdentitySecurityAuditLogsIngestedEvent) ProtoMessage() {}
 
 func (x *IdentitySecurityAuditLogsIngestedEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[117]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[119]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9736,7 +9932,7 @@ func (x *IdentitySecurityAuditLogsIngestedEvent) ProtoReflect() protoreflect.Mes
 
 // Deprecated: Use IdentitySecurityAuditLogsIngestedEvent.ProtoReflect.Descriptor instead.
 func (*IdentitySecurityAuditLogsIngestedEvent) Descriptor() ([]byte, []int) {
-	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{117}
+	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{119}
 }
 
 func (x *IdentitySecurityAuditLogsIngestedEvent) GetProvider() string {
@@ -9766,7 +9962,7 @@ type AccessListStepStatus struct {
 
 func (x *AccessListStepStatus) Reset() {
 	*x = AccessListStepStatus{}
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[118]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[120]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9778,7 +9974,7 @@ func (x *AccessListStepStatus) String() string {
 func (*AccessListStepStatus) ProtoMessage() {}
 
 func (x *AccessListStepStatus) ProtoReflect() protoreflect.Message {
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[118]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[120]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9791,7 +9987,7 @@ func (x *AccessListStepStatus) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AccessListStepStatus.ProtoReflect.Descriptor instead.
 func (*AccessListStepStatus) Descriptor() ([]byte, []int) {
-	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{118}
+	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{120}
 }
 
 func (x *AccessListStepStatus) GetStatus() AccessListStatus {
@@ -9820,7 +10016,7 @@ type UIAccessListDefineAccessEvent struct {
 
 func (x *UIAccessListDefineAccessEvent) Reset() {
 	*x = UIAccessListDefineAccessEvent{}
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[119]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[121]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9832,7 +10028,7 @@ func (x *UIAccessListDefineAccessEvent) String() string {
 func (*UIAccessListDefineAccessEvent) ProtoMessage() {}
 
 func (x *UIAccessListDefineAccessEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[119]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[121]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9845,7 +10041,7 @@ func (x *UIAccessListDefineAccessEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UIAccessListDefineAccessEvent.ProtoReflect.Descriptor instead.
 func (*UIAccessListDefineAccessEvent) Descriptor() ([]byte, []int) {
-	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{119}
+	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{121}
 }
 
 func (x *UIAccessListDefineAccessEvent) GetMetadata() *AccessListMetadata {
@@ -9874,7 +10070,7 @@ type UIAccessListDefineIdentitiesEvent struct {
 
 func (x *UIAccessListDefineIdentitiesEvent) Reset() {
 	*x = UIAccessListDefineIdentitiesEvent{}
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[120]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[122]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9886,7 +10082,7 @@ func (x *UIAccessListDefineIdentitiesEvent) String() string {
 func (*UIAccessListDefineIdentitiesEvent) ProtoMessage() {}
 
 func (x *UIAccessListDefineIdentitiesEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[120]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[122]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9899,7 +10095,7 @@ func (x *UIAccessListDefineIdentitiesEvent) ProtoReflect() protoreflect.Message 
 
 // Deprecated: Use UIAccessListDefineIdentitiesEvent.ProtoReflect.Descriptor instead.
 func (*UIAccessListDefineIdentitiesEvent) Descriptor() ([]byte, []int) {
-	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{120}
+	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{122}
 }
 
 func (x *UIAccessListDefineIdentitiesEvent) GetMetadata() *AccessListMetadata {
@@ -9928,7 +10124,7 @@ type UIAccessListDefineBasicInfoEvent struct {
 
 func (x *UIAccessListDefineBasicInfoEvent) Reset() {
 	*x = UIAccessListDefineBasicInfoEvent{}
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[121]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[123]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9940,7 +10136,7 @@ func (x *UIAccessListDefineBasicInfoEvent) String() string {
 func (*UIAccessListDefineBasicInfoEvent) ProtoMessage() {}
 
 func (x *UIAccessListDefineBasicInfoEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[121]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[123]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9953,7 +10149,7 @@ func (x *UIAccessListDefineBasicInfoEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UIAccessListDefineBasicInfoEvent.ProtoReflect.Descriptor instead.
 func (*UIAccessListDefineBasicInfoEvent) Descriptor() ([]byte, []int) {
-	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{121}
+	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{123}
 }
 
 func (x *UIAccessListDefineBasicInfoEvent) GetMetadata() *AccessListMetadata {
@@ -9982,7 +10178,7 @@ type UIAccessListDefineMembersEvent struct {
 
 func (x *UIAccessListDefineMembersEvent) Reset() {
 	*x = UIAccessListDefineMembersEvent{}
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[122]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[124]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9994,7 +10190,7 @@ func (x *UIAccessListDefineMembersEvent) String() string {
 func (*UIAccessListDefineMembersEvent) ProtoMessage() {}
 
 func (x *UIAccessListDefineMembersEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[122]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[124]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10007,7 +10203,7 @@ func (x *UIAccessListDefineMembersEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UIAccessListDefineMembersEvent.ProtoReflect.Descriptor instead.
 func (*UIAccessListDefineMembersEvent) Descriptor() ([]byte, []int) {
-	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{122}
+	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{124}
 }
 
 func (x *UIAccessListDefineMembersEvent) GetMetadata() *AccessListMetadata {
@@ -10036,7 +10232,7 @@ type UIAccessListDefineOwnersEvent struct {
 
 func (x *UIAccessListDefineOwnersEvent) Reset() {
 	*x = UIAccessListDefineOwnersEvent{}
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[123]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[125]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10048,7 +10244,7 @@ func (x *UIAccessListDefineOwnersEvent) String() string {
 func (*UIAccessListDefineOwnersEvent) ProtoMessage() {}
 
 func (x *UIAccessListDefineOwnersEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[123]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[125]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10061,7 +10257,7 @@ func (x *UIAccessListDefineOwnersEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UIAccessListDefineOwnersEvent.ProtoReflect.Descriptor instead.
 func (*UIAccessListDefineOwnersEvent) Descriptor() ([]byte, []int) {
-	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{123}
+	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{125}
 }
 
 func (x *UIAccessListDefineOwnersEvent) GetMetadata() *AccessListMetadata {
@@ -10090,7 +10286,7 @@ type UIAccessListStartEvent struct {
 
 func (x *UIAccessListStartEvent) Reset() {
 	*x = UIAccessListStartEvent{}
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[124]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[126]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10102,7 +10298,7 @@ func (x *UIAccessListStartEvent) String() string {
 func (*UIAccessListStartEvent) ProtoMessage() {}
 
 func (x *UIAccessListStartEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[124]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[126]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10115,7 +10311,7 @@ func (x *UIAccessListStartEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UIAccessListStartEvent.ProtoReflect.Descriptor instead.
 func (*UIAccessListStartEvent) Descriptor() ([]byte, []int) {
-	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{124}
+	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{126}
 }
 
 func (x *UIAccessListStartEvent) GetMetadata() *AccessListMetadata {
@@ -10144,7 +10340,7 @@ type UIAccessListCustomEvent struct {
 
 func (x *UIAccessListCustomEvent) Reset() {
 	*x = UIAccessListCustomEvent{}
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[125]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[127]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10156,7 +10352,7 @@ func (x *UIAccessListCustomEvent) String() string {
 func (*UIAccessListCustomEvent) ProtoMessage() {}
 
 func (x *UIAccessListCustomEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[125]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[127]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10169,7 +10365,7 @@ func (x *UIAccessListCustomEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UIAccessListCustomEvent.ProtoReflect.Descriptor instead.
 func (*UIAccessListCustomEvent) Descriptor() ([]byte, []int) {
-	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{125}
+	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{127}
 }
 
 func (x *UIAccessListCustomEvent) GetMetadata() *AccessListMetadata {
@@ -10201,7 +10397,7 @@ type UIAccessListCompleteEvent struct {
 
 func (x *UIAccessListCompleteEvent) Reset() {
 	*x = UIAccessListCompleteEvent{}
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[126]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[128]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10213,7 +10409,7 @@ func (x *UIAccessListCompleteEvent) String() string {
 func (*UIAccessListCompleteEvent) ProtoMessage() {}
 
 func (x *UIAccessListCompleteEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[126]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[128]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10226,7 +10422,7 @@ func (x *UIAccessListCompleteEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UIAccessListCompleteEvent.ProtoReflect.Descriptor instead.
 func (*UIAccessListCompleteEvent) Descriptor() ([]byte, []int) {
-	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{126}
+	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{128}
 }
 
 func (x *UIAccessListCompleteEvent) GetMetadata() *AccessListMetadata {
@@ -10262,7 +10458,7 @@ type UIAccessListIntegrateEvent struct {
 
 func (x *UIAccessListIntegrateEvent) Reset() {
 	*x = UIAccessListIntegrateEvent{}
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[127]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[129]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10274,7 +10470,7 @@ func (x *UIAccessListIntegrateEvent) String() string {
 func (*UIAccessListIntegrateEvent) ProtoMessage() {}
 
 func (x *UIAccessListIntegrateEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[127]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[129]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10287,7 +10483,7 @@ func (x *UIAccessListIntegrateEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UIAccessListIntegrateEvent.ProtoReflect.Descriptor instead.
 func (*UIAccessListIntegrateEvent) Descriptor() ([]byte, []int) {
-	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{127}
+	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{129}
 }
 
 func (x *UIAccessListIntegrateEvent) GetMetadata() *AccessListMetadata {
@@ -10334,7 +10530,7 @@ type UIInteractionEvent struct {
 
 func (x *UIInteractionEvent) Reset() {
 	*x = UIInteractionEvent{}
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[128]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[130]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10346,7 +10542,7 @@ func (x *UIInteractionEvent) String() string {
 func (*UIInteractionEvent) ProtoMessage() {}
 
 func (x *UIInteractionEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[128]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[130]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10359,7 +10555,7 @@ func (x *UIInteractionEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UIInteractionEvent.ProtoReflect.Descriptor instead.
 func (*UIInteractionEvent) Descriptor() ([]byte, []int) {
-	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{128}
+	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{130}
 }
 
 func (x *UIInteractionEvent) GetUserName() string {
@@ -10526,6 +10722,8 @@ type SubmitEventRequest struct {
 	//	*SubmitEventRequest_UiUsageReportingAlertCtaClick
 	//	*SubmitEventRequest_SessionSummarySearchEvent
 	//	*SubmitEventRequest_UiInteraction
+	//	*SubmitEventRequest_BeamsCreated
+	//	*SubmitEventRequest_BeamsDestroyed
 	Event         isSubmitEventRequest_Event `protobuf_oneof:"event"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
@@ -10533,7 +10731,7 @@ type SubmitEventRequest struct {
 
 func (x *SubmitEventRequest) Reset() {
 	*x = SubmitEventRequest{}
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[129]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[131]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10545,7 +10743,7 @@ func (x *SubmitEventRequest) String() string {
 func (*SubmitEventRequest) ProtoMessage() {}
 
 func (x *SubmitEventRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[129]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[131]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10558,7 +10756,7 @@ func (x *SubmitEventRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SubmitEventRequest.ProtoReflect.Descriptor instead.
 func (*SubmitEventRequest) Descriptor() ([]byte, []int) {
-	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{129}
+	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{131}
 }
 
 func (x *SubmitEventRequest) GetClusterName() string {
@@ -11633,6 +11831,24 @@ func (x *SubmitEventRequest) GetUiInteraction() *UIInteractionEvent {
 	return nil
 }
 
+func (x *SubmitEventRequest) GetBeamsCreated() *BeamsCreatedEvent {
+	if x != nil {
+		if x, ok := x.Event.(*SubmitEventRequest_BeamsCreated); ok {
+			return x.BeamsCreated
+		}
+	}
+	return nil
+}
+
+func (x *SubmitEventRequest) GetBeamsDestroyed() *BeamsDestroyedEvent {
+	if x != nil {
+		if x, ok := x.Event.(*SubmitEventRequest_BeamsDestroyed); ok {
+			return x.BeamsDestroyed
+		}
+	}
+	return nil
+}
+
 type isSubmitEventRequest_Event interface {
 	isSubmitEventRequest_Event()
 }
@@ -12106,6 +12322,14 @@ type SubmitEventRequest_UiInteraction struct {
 	UiInteraction *UIInteractionEvent `protobuf:"bytes,122,opt,name=ui_interaction,json=uiInteraction,proto3,oneof"`
 }
 
+type SubmitEventRequest_BeamsCreated struct {
+	BeamsCreated *BeamsCreatedEvent `protobuf:"bytes,123,opt,name=beams_created,json=beamsCreated,proto3,oneof"`
+}
+
+type SubmitEventRequest_BeamsDestroyed struct {
+	BeamsDestroyed *BeamsDestroyedEvent `protobuf:"bytes,124,opt,name=beams_destroyed,json=beamsDestroyed,proto3,oneof"`
+}
+
 func (*SubmitEventRequest_UserLogin) isSubmitEventRequest_Event() {}
 
 func (*SubmitEventRequest_SsoCreate) isSubmitEventRequest_Event() {}
@@ -12340,6 +12564,10 @@ func (*SubmitEventRequest_SessionSummarySearchEvent) isSubmitEventRequest_Event(
 
 func (*SubmitEventRequest_UiInteraction) isSubmitEventRequest_Event() {}
 
+func (*SubmitEventRequest_BeamsCreated) isSubmitEventRequest_Event() {}
+
+func (*SubmitEventRequest_BeamsDestroyed) isSubmitEventRequest_Event() {}
+
 type SubmitEventResponse struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	unknownFields protoimpl.UnknownFields
@@ -12348,7 +12576,7 @@ type SubmitEventResponse struct {
 
 func (x *SubmitEventResponse) Reset() {
 	*x = SubmitEventResponse{}
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[130]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[132]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -12360,7 +12588,7 @@ func (x *SubmitEventResponse) String() string {
 func (*SubmitEventResponse) ProtoMessage() {}
 
 func (x *SubmitEventResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[130]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[132]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -12373,7 +12601,7 @@ func (x *SubmitEventResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SubmitEventResponse.ProtoReflect.Descriptor instead.
 func (*SubmitEventResponse) Descriptor() ([]byte, []int) {
-	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{130}
+	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{132}
 }
 
 type SubmitEventsRequest struct {
@@ -12386,7 +12614,7 @@ type SubmitEventsRequest struct {
 
 func (x *SubmitEventsRequest) Reset() {
 	*x = SubmitEventsRequest{}
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[131]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[133]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -12398,7 +12626,7 @@ func (x *SubmitEventsRequest) String() string {
 func (*SubmitEventsRequest) ProtoMessage() {}
 
 func (x *SubmitEventsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[131]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[133]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -12411,7 +12639,7 @@ func (x *SubmitEventsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SubmitEventsRequest.ProtoReflect.Descriptor instead.
 func (*SubmitEventsRequest) Descriptor() ([]byte, []int) {
-	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{131}
+	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{133}
 }
 
 func (x *SubmitEventsRequest) GetEvents() []*SubmitEventRequest {
@@ -12429,7 +12657,7 @@ type SubmitEventsResponse struct {
 
 func (x *SubmitEventsResponse) Reset() {
 	*x = SubmitEventsResponse{}
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[132]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[134]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -12441,7 +12669,7 @@ func (x *SubmitEventsResponse) String() string {
 func (*SubmitEventsResponse) ProtoMessage() {}
 
 func (x *SubmitEventsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[132]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[134]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -12454,7 +12682,7 @@ func (x *SubmitEventsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SubmitEventsResponse.ProtoReflect.Descriptor instead.
 func (*SubmitEventsResponse) Descriptor() ([]byte, []int) {
-	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{132}
+	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{134}
 }
 
 type HelloTeleportRequest struct {
@@ -12465,7 +12693,7 @@ type HelloTeleportRequest struct {
 
 func (x *HelloTeleportRequest) Reset() {
 	*x = HelloTeleportRequest{}
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[133]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[135]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -12477,7 +12705,7 @@ func (x *HelloTeleportRequest) String() string {
 func (*HelloTeleportRequest) ProtoMessage() {}
 
 func (x *HelloTeleportRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[133]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[135]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -12490,7 +12718,7 @@ func (x *HelloTeleportRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use HelloTeleportRequest.ProtoReflect.Descriptor instead.
 func (*HelloTeleportRequest) Descriptor() ([]byte, []int) {
-	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{133}
+	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{135}
 }
 
 type HelloTeleportResponse struct {
@@ -12501,7 +12729,7 @@ type HelloTeleportResponse struct {
 
 func (x *HelloTeleportResponse) Reset() {
 	*x = HelloTeleportResponse{}
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[134]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[136]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -12513,7 +12741,7 @@ func (x *HelloTeleportResponse) String() string {
 func (*HelloTeleportResponse) ProtoMessage() {}
 
 func (x *HelloTeleportResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[134]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[136]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -12526,7 +12754,7 @@ func (x *HelloTeleportResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use HelloTeleportResponse.ProtoReflect.Descriptor instead.
 func (*HelloTeleportResponse) Descriptor() ([]byte, []int) {
-	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{134}
+	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{136}
 }
 
 var File_prehog_v1alpha_teleport_proto protoreflect.FileDescriptor
@@ -12602,7 +12830,15 @@ const file_prehog_v1alpha_teleport_proto_rawDesc = "" +
 	"\x11ingress_auth_type\x18\x05 \x01(\tR\x0fingressAuthType\x12(\n" +
 	"\x10egress_auth_type\x18\x06 \x01(\tR\x0eegressAuthType\"3\n" +
 	"\x18SessionStartBeamMetadata\x12\x17\n" +
-	"\abeam_id\x18\x01 \x01(\tR\x06beamId\"\xe7\x02\n" +
+	"\abeam_id\x18\x01 \x01(\tR\x06beamId\"t\n" +
+	"\x11BeamsCreatedEvent\x12\x17\n" +
+	"\abeam_id\x18\x01 \x01(\tR\x06beamId\x12\x16\n" +
+	"\x06region\x18\x02 \x01(\tR\x06region\x12.\n" +
+	"\x13startup_duration_ms\x18\x03 \x01(\x03R\x11startupDurationMs\"\x81\x01\n" +
+	"\x13BeamsDestroyedEvent\x12\x17\n" +
+	"\abeam_id\x18\x01 \x01(\tR\x06beamId\x129\n" +
+	"\x06reason\x18\x02 \x01(\x0e2!.prehog.v1alpha.BeamDestroyReasonR\x06reason\x12\x16\n" +
+	"\x06region\x18\x03 \x01(\tR\x06region\"\xe7\x02\n" +
 	"\x1aUserCertificateIssuedEvent\x12\x1b\n" +
 	"\tuser_name\x18\x01 \x01(\tR\buserName\x12+\n" +
 	"\x03ttl\x18\x02 \x01(\v2\x19.google.protobuf.DurationR\x03ttl\x12\x15\n" +
@@ -13127,7 +13363,7 @@ const file_prehog_v1alpha_teleport_proto_rawDesc = "" +
 	"\x06params\x18\x04 \x03(\v2..prehog.v1alpha.UIInteractionEvent.ParamsEntryR\x06params\x1a9\n" +
 	"\vParamsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
-	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"\xddf\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"\xf7g\n" +
 	"\x12SubmitEventRequest\x12!\n" +
 	"\fcluster_name\x18\x01 \x01(\tR\vclusterName\x128\n" +
 	"\ttimestamp\x18\x02 \x01(\v2\x1a.google.protobuf.TimestampR\ttimestamp\x12)\n" +
@@ -13253,7 +13489,9 @@ const file_prehog_v1alpha_teleport_proto_rawDesc = "" +
 	"uiPageView\x12\x7f\n" +
 	"\"ui_usage_reporting_alert_cta_click\x18x \x01(\v22.prehog.v1alpha.UIUsageReportingAlertCtaClickEventH\x00R\x1duiUsageReportingAlertCtaClick\x12l\n" +
 	"\x1csession_summary_search_event\x18y \x01(\v2).prehog.v1alpha.SessionSummarySearchEventH\x00R\x19sessionSummarySearchEvent\x12K\n" +
-	"\x0eui_interaction\x18z \x01(\v2\".prehog.v1alpha.UIInteractionEventH\x00R\ruiInteractionB\a\n" +
+	"\x0eui_interaction\x18z \x01(\v2\".prehog.v1alpha.UIInteractionEventH\x00R\ruiInteraction\x12H\n" +
+	"\rbeams_created\x18{ \x01(\v2!.prehog.v1alpha.BeamsCreatedEventH\x00R\fbeamsCreated\x12N\n" +
+	"\x0fbeams_destroyed\x18| \x01(\v2#.prehog.v1alpha.BeamsDestroyedEventH\x00R\x0ebeamsDestroyedB\a\n" +
 	"\x05eventJ\x04\b\b\x10\tJ\x04\ba\x10bJ\x04\bb\x10cR\x1cui_onboard_get_started_clickR\x1baccess_request_create_eventR\x1baccess_request_review_event\"\x15\n" +
 	"\x13SubmitEventResponse\"Q\n" +
 	"\x13SubmitEventsRequest\x12:\n" +
@@ -13282,7 +13520,11 @@ const file_prehog_v1alpha_teleport_proto_rawDesc = "" +
 	"\x15USER_KIND_UNSPECIFIED\x10\x00\x12\x13\n" +
 	"\x0fUSER_KIND_HUMAN\x10\x01\x12\x11\n" +
 	"\rUSER_KIND_BOT\x10\x02\x12\x14\n" +
-	"\x10USER_KIND_SYSTEM\x10\x03*\xab\x10\n" +
+	"\x10USER_KIND_SYSTEM\x10\x03*\x82\x01\n" +
+	"\x11BeamDestroyReason\x12#\n" +
+	"\x1fBEAM_DESTROY_REASON_UNSPECIFIED\x10\x00\x12$\n" +
+	" BEAM_DESTROY_REASON_USER_DELETED\x10\x01\x12\"\n" +
+	"\x1eBEAM_DESTROY_REASON_GC_EXPIRED\x10\x02*\xab\x10\n" +
 	"\x10DiscoverResource\x12!\n" +
 	"\x1dDISCOVER_RESOURCE_UNSPECIFIED\x10\x00\x12\x1c\n" +
 	"\x18DISCOVER_RESOURCE_SERVER\x10\x01\x12 \n" +
@@ -13486,438 +13728,444 @@ func file_prehog_v1alpha_teleport_proto_rawDescGZIP() []byte {
 	return file_prehog_v1alpha_teleport_proto_rawDescData
 }
 
-var file_prehog_v1alpha_teleport_proto_enumTypes = make([]protoimpl.EnumInfo, 24)
-var file_prehog_v1alpha_teleport_proto_msgTypes = make([]protoimpl.MessageInfo, 136)
+var file_prehog_v1alpha_teleport_proto_enumTypes = make([]protoimpl.EnumInfo, 25)
+var file_prehog_v1alpha_teleport_proto_msgTypes = make([]protoimpl.MessageInfo, 138)
 var file_prehog_v1alpha_teleport_proto_goTypes = []any{
 	(UserOrigin)(0),                                           // 0: prehog.v1alpha.UserOrigin
 	(ResourceKind)(0),                                         // 1: prehog.v1alpha.ResourceKind
 	(UserKind)(0),                                             // 2: prehog.v1alpha.UserKind
-	(DiscoverResource)(0),                                     // 3: prehog.v1alpha.DiscoverResource
-	(DiscoverStatus)(0),                                       // 4: prehog.v1alpha.DiscoverStatus
-	(CTA)(0),                                                  // 5: prehog.v1alpha.CTA
-	(IntegrationEnrollKind)(0),                                // 6: prehog.v1alpha.IntegrationEnrollKind
-	(IntegrationEnrollStep)(0),                                // 7: prehog.v1alpha.IntegrationEnrollStep
-	(IntegrationEnrollStatusCode)(0),                          // 8: prehog.v1alpha.IntegrationEnrollStatusCode
-	(IntegrationEnrollSection)(0),                             // 9: prehog.v1alpha.IntegrationEnrollSection
-	(IntegrationEnrollField)(0),                               // 10: prehog.v1alpha.IntegrationEnrollField
-	(IntegrationEnrollCodeType)(0),                            // 11: prehog.v1alpha.IntegrationEnrollCodeType
-	(EditorChangeStatus)(0),                                   // 12: prehog.v1alpha.EditorChangeStatus
-	(Feature)(0),                                              // 13: prehog.v1alpha.Feature
-	(FeatureRecommendationStatus)(0),                          // 14: prehog.v1alpha.FeatureRecommendationStatus
-	(LicenseLimit)(0),                                         // 15: prehog.v1alpha.LicenseLimit
-	(DiscoveryConfigAction)(0),                                // 16: prehog.v1alpha.DiscoveryConfigAction
-	(AccessListStatus)(0),                                     // 17: prehog.v1alpha.AccessListStatus
-	(AccessListPreset)(0),                                     // 18: prehog.v1alpha.AccessListPreset
-	(AccessListIntegrate)(0),                                  // 19: prehog.v1alpha.AccessListIntegrate
-	(UIDiscoverDeployServiceEvent_DeployMethod)(0),            // 20: prehog.v1alpha.UIDiscoverDeployServiceEvent.DeployMethod
-	(UIDiscoverDeployServiceEvent_DeployType)(0),              // 21: prehog.v1alpha.UIDiscoverDeployServiceEvent.DeployType
-	(UIDiscoverCreateDiscoveryConfigEvent_ConfigMethod)(0),    // 22: prehog.v1alpha.UIDiscoverCreateDiscoveryConfigEvent.ConfigMethod
-	(AccessRequestReviewEvent_ProposedState)(0),               // 23: prehog.v1alpha.AccessRequestReviewEvent.ProposedState
-	(*UserLoginEvent)(nil),                                    // 24: prehog.v1alpha.UserLoginEvent
-	(*MFAAuthenticationEvent)(nil),                            // 25: prehog.v1alpha.MFAAuthenticationEvent
-	(*SSOCreateEvent)(nil),                                    // 26: prehog.v1alpha.SSOCreateEvent
-	(*ResourceCreateEvent)(nil),                               // 27: prehog.v1alpha.ResourceCreateEvent
-	(*DiscoveredDatabaseMetadata)(nil),                        // 28: prehog.v1alpha.DiscoveredDatabaseMetadata
-	(*ResourceHeartbeatEvent)(nil),                            // 29: prehog.v1alpha.ResourceHeartbeatEvent
-	(*SessionStartEvent)(nil),                                 // 30: prehog.v1alpha.SessionStartEvent
-	(*SessionStartDatabaseMetadata)(nil),                      // 31: prehog.v1alpha.SessionStartDatabaseMetadata
-	(*SessionStartDesktopMetadata)(nil),                       // 32: prehog.v1alpha.SessionStartDesktopMetadata
-	(*SessionStartAppMetadata)(nil),                           // 33: prehog.v1alpha.SessionStartAppMetadata
-	(*SessionStartGitMetadata)(nil),                           // 34: prehog.v1alpha.SessionStartGitMetadata
-	(*SessionStartMCPMetadata)(nil),                           // 35: prehog.v1alpha.SessionStartMCPMetadata
-	(*SessionStartBeamMetadata)(nil),                          // 36: prehog.v1alpha.SessionStartBeamMetadata
-	(*UserCertificateIssuedEvent)(nil),                        // 37: prehog.v1alpha.UserCertificateIssuedEvent
-	(*SPIFFESVIDIssuedEvent)(nil),                             // 38: prehog.v1alpha.SPIFFESVIDIssuedEvent
-	(*UIBannerClickEvent)(nil),                                // 39: prehog.v1alpha.UIBannerClickEvent
-	(*UIOnboardCompleteGoToDashboardClickEvent)(nil),          // 40: prehog.v1alpha.UIOnboardCompleteGoToDashboardClickEvent
-	(*UIOnboardAddFirstResourceClickEvent)(nil),               // 41: prehog.v1alpha.UIOnboardAddFirstResourceClickEvent
-	(*UIOnboardAddFirstResourceLaterClickEvent)(nil),          // 42: prehog.v1alpha.UIOnboardAddFirstResourceLaterClickEvent
-	(*UIOnboardSetCredentialSubmitEvent)(nil),                 // 43: prehog.v1alpha.UIOnboardSetCredentialSubmitEvent
-	(*UIOnboardRegisterChallengeSubmitEvent)(nil),             // 44: prehog.v1alpha.UIOnboardRegisterChallengeSubmitEvent
-	(*UIOnboardQuestionnaireSubmitEvent)(nil),                 // 45: prehog.v1alpha.UIOnboardQuestionnaireSubmitEvent
-	(*UIRecoveryCodesContinueClickEvent)(nil),                 // 46: prehog.v1alpha.UIRecoveryCodesContinueClickEvent
-	(*UIRecoveryCodesCopyClickEvent)(nil),                     // 47: prehog.v1alpha.UIRecoveryCodesCopyClickEvent
-	(*UIRecoveryCodesPrintClickEvent)(nil),                    // 48: prehog.v1alpha.UIRecoveryCodesPrintClickEvent
-	(*DiscoverMetadata)(nil),                                  // 49: prehog.v1alpha.DiscoverMetadata
-	(*DiscoverResourceMetadata)(nil),                          // 50: prehog.v1alpha.DiscoverResourceMetadata
-	(*DiscoverStepStatus)(nil),                                // 51: prehog.v1alpha.DiscoverStepStatus
-	(*UIDiscoverStartedEvent)(nil),                            // 52: prehog.v1alpha.UIDiscoverStartedEvent
-	(*UIDiscoverResourceSelectionEvent)(nil),                  // 53: prehog.v1alpha.UIDiscoverResourceSelectionEvent
-	(*UIDiscoverIntegrationAWSOIDCConnectEvent)(nil),          // 54: prehog.v1alpha.UIDiscoverIntegrationAWSOIDCConnectEvent
-	(*UIDiscoverDatabaseRDSEnrollEvent)(nil),                  // 55: prehog.v1alpha.UIDiscoverDatabaseRDSEnrollEvent
-	(*UIDiscoverKubeEKSEnrollEvent)(nil),                      // 56: prehog.v1alpha.UIDiscoverKubeEKSEnrollEvent
-	(*UIDiscoverDeployServiceEvent)(nil),                      // 57: prehog.v1alpha.UIDiscoverDeployServiceEvent
-	(*UIDiscoverCreateDiscoveryConfigEvent)(nil),              // 58: prehog.v1alpha.UIDiscoverCreateDiscoveryConfigEvent
-	(*UIDiscoverDatabaseRegisterEvent)(nil),                   // 59: prehog.v1alpha.UIDiscoverDatabaseRegisterEvent
-	(*UIDiscoverDatabaseConfigureMTLSEvent)(nil),              // 60: prehog.v1alpha.UIDiscoverDatabaseConfigureMTLSEvent
-	(*UIDiscoverDesktopActiveDirectoryToolsInstallEvent)(nil), // 61: prehog.v1alpha.UIDiscoverDesktopActiveDirectoryToolsInstallEvent
-	(*UIDiscoverDesktopActiveDirectoryConfigureEvent)(nil),    // 62: prehog.v1alpha.UIDiscoverDesktopActiveDirectoryConfigureEvent
-	(*UIDiscoverAutoDiscoveredResourcesEvent)(nil),            // 63: prehog.v1alpha.UIDiscoverAutoDiscoveredResourcesEvent
-	(*UIDiscoverEC2InstanceSelectionEvent)(nil),               // 64: prehog.v1alpha.UIDiscoverEC2InstanceSelectionEvent
-	(*UIDiscoverDeployEICEEvent)(nil),                         // 65: prehog.v1alpha.UIDiscoverDeployEICEEvent
-	(*UIDiscoverCreateNodeEvent)(nil),                         // 66: prehog.v1alpha.UIDiscoverCreateNodeEvent
-	(*UIDiscoverCreateAppServerEvent)(nil),                    // 67: prehog.v1alpha.UIDiscoverCreateAppServerEvent
-	(*UIDiscoverDatabaseConfigureIAMPolicyEvent)(nil),         // 68: prehog.v1alpha.UIDiscoverDatabaseConfigureIAMPolicyEvent
-	(*UIDiscoverPrincipalsConfigureEvent)(nil),                // 69: prehog.v1alpha.UIDiscoverPrincipalsConfigureEvent
-	(*UIDiscoverTestConnectionEvent)(nil),                     // 70: prehog.v1alpha.UIDiscoverTestConnectionEvent
-	(*UIDiscoverCompletedEvent)(nil),                          // 71: prehog.v1alpha.UIDiscoverCompletedEvent
-	(*RoleCreateEvent)(nil),                                   // 72: prehog.v1alpha.RoleCreateEvent
-	(*BotCreateEvent)(nil),                                    // 73: prehog.v1alpha.BotCreateEvent
-	(*BotJoinEvent)(nil),                                      // 74: prehog.v1alpha.BotJoinEvent
-	(*UICreateNewRoleClickEvent)(nil),                         // 75: prehog.v1alpha.UICreateNewRoleClickEvent
-	(*UICreateNewRoleSaveClickEvent)(nil),                     // 76: prehog.v1alpha.UICreateNewRoleSaveClickEvent
-	(*UICreateNewRoleCancelClickEvent)(nil),                   // 77: prehog.v1alpha.UICreateNewRoleCancelClickEvent
-	(*UICreateNewRoleViewDocumentationClickEvent)(nil),        // 78: prehog.v1alpha.UICreateNewRoleViewDocumentationClickEvent
-	(*UICallToActionClickEvent)(nil),                          // 79: prehog.v1alpha.UICallToActionClickEvent
-	(*KubeRequestEvent)(nil),                                  // 80: prehog.v1alpha.KubeRequestEvent
-	(*SFTPEvent)(nil),                                         // 81: prehog.v1alpha.SFTPEvent
-	(*AgentMetadataEvent)(nil),                                // 82: prehog.v1alpha.AgentMetadataEvent
-	(*AssistCompletionEvent)(nil),                             // 83: prehog.v1alpha.AssistCompletionEvent
-	(*AssistExecutionEvent)(nil),                              // 84: prehog.v1alpha.AssistExecutionEvent
-	(*AssistNewConversationEvent)(nil),                        // 85: prehog.v1alpha.AssistNewConversationEvent
-	(*AssistAccessRequestEvent)(nil),                          // 86: prehog.v1alpha.AssistAccessRequestEvent
-	(*AssistActionEvent)(nil),                                 // 87: prehog.v1alpha.AssistActionEvent
-	(*AccessListMetadata)(nil),                                // 88: prehog.v1alpha.AccessListMetadata
-	(*AccessListCreateEvent)(nil),                             // 89: prehog.v1alpha.AccessListCreateEvent
-	(*AccessListUpdateEvent)(nil),                             // 90: prehog.v1alpha.AccessListUpdateEvent
-	(*AccessListDeleteEvent)(nil),                             // 91: prehog.v1alpha.AccessListDeleteEvent
-	(*AccessListMemberCreateEvent)(nil),                       // 92: prehog.v1alpha.AccessListMemberCreateEvent
-	(*AccessListMemberUpdateEvent)(nil),                       // 93: prehog.v1alpha.AccessListMemberUpdateEvent
-	(*AccessListMemberDeleteEvent)(nil),                       // 94: prehog.v1alpha.AccessListMemberDeleteEvent
-	(*AccessListGrantsToUserEvent)(nil),                       // 95: prehog.v1alpha.AccessListGrantsToUserEvent
-	(*AccessListReviewCreateEvent)(nil),                       // 96: prehog.v1alpha.AccessListReviewCreateEvent
-	(*AccessListReviewDeleteEvent)(nil),                       // 97: prehog.v1alpha.AccessListReviewDeleteEvent
-	(*AccessListReviewComplianceEvent)(nil),                   // 98: prehog.v1alpha.AccessListReviewComplianceEvent
-	(*IntegrationEnrollMetadata)(nil),                         // 99: prehog.v1alpha.IntegrationEnrollMetadata
-	(*UIIntegrationEnrollStartEvent)(nil),                     // 100: prehog.v1alpha.UIIntegrationEnrollStartEvent
-	(*UIIntegrationEnrollCompleteEvent)(nil),                  // 101: prehog.v1alpha.UIIntegrationEnrollCompleteEvent
-	(*IntegrationEnrollStepStatus)(nil),                       // 102: prehog.v1alpha.IntegrationEnrollStepStatus
-	(*UIIntegrationEnrollStepEvent)(nil),                      // 103: prehog.v1alpha.UIIntegrationEnrollStepEvent
-	(*UIIntegrationEnrollSectionOpenEvent)(nil),               // 104: prehog.v1alpha.UIIntegrationEnrollSectionOpenEvent
-	(*UIIntegrationEnrollFieldCompleteEvent)(nil),             // 105: prehog.v1alpha.UIIntegrationEnrollFieldCompleteEvent
-	(*UIIntegrationEnrollCodeCopyEvent)(nil),                  // 106: prehog.v1alpha.UIIntegrationEnrollCodeCopyEvent
-	(*UIIntegrationEnrollLinkClickEvent)(nil),                 // 107: prehog.v1alpha.UIIntegrationEnrollLinkClickEvent
-	(*EditorChangeEvent)(nil),                                 // 108: prehog.v1alpha.EditorChangeEvent
-	(*DeviceAuthenticateEvent)(nil),                           // 109: prehog.v1alpha.DeviceAuthenticateEvent
-	(*DeviceEnrollEvent)(nil),                                 // 110: prehog.v1alpha.DeviceEnrollEvent
-	(*FeatureRecommendationEvent)(nil),                        // 111: prehog.v1alpha.FeatureRecommendationEvent
-	(*LicenseLimitEvent)(nil),                                 // 112: prehog.v1alpha.LicenseLimitEvent
-	(*DesktopDirectoryShareEvent)(nil),                        // 113: prehog.v1alpha.DesktopDirectoryShareEvent
-	(*DesktopClipboardEvent)(nil),                             // 114: prehog.v1alpha.DesktopClipboardEvent
-	(*TAGExecuteQueryEvent)(nil),                              // 115: prehog.v1alpha.TAGExecuteQueryEvent
-	(*AccessGraphSecretsScanAuthorizedKeysEvent)(nil),         // 116: prehog.v1alpha.AccessGraphSecretsScanAuthorizedKeysEvent
-	(*AccessGraphSecretsScanSSHPrivateKeysEvent)(nil),         // 117: prehog.v1alpha.AccessGraphSecretsScanSSHPrivateKeysEvent
-	(*AccessGraphGitlabScanEvent)(nil),                        // 118: prehog.v1alpha.AccessGraphGitlabScanEvent
-	(*AccessGraphAWSScanEvent)(nil),                           // 119: prehog.v1alpha.AccessGraphAWSScanEvent
-	(*AccessGraphAccessPathChangedEvent)(nil),                 // 120: prehog.v1alpha.AccessGraphAccessPathChangedEvent
-	(*UIAccessGraphCrownJewelDiffViewEvent)(nil),              // 121: prehog.v1alpha.UIAccessGraphCrownJewelDiffViewEvent
-	(*UIPageViewEvent)(nil),                                   // 122: prehog.v1alpha.UIPageViewEvent
-	(*UIUsageReportingAlertCtaClickEvent)(nil),                // 123: prehog.v1alpha.UIUsageReportingAlertCtaClickEvent
-	(*AccessGraphCrownJewelCreateEvent)(nil),                  // 124: prehog.v1alpha.AccessGraphCrownJewelCreateEvent
-	(*ExternalAuditStorageAuthenticateEvent)(nil),             // 125: prehog.v1alpha.ExternalAuditStorageAuthenticateEvent
-	(*SecurityReportGetResultEvent)(nil),                      // 126: prehog.v1alpha.SecurityReportGetResultEvent
-	(*AuditQueryRunEvent)(nil),                                // 127: prehog.v1alpha.AuditQueryRunEvent
-	(*DiscoveryFetchEvent)(nil),                               // 128: prehog.v1alpha.DiscoveryFetchEvent
-	(*OktaAccessListSyncEvent)(nil),                           // 129: prehog.v1alpha.OktaAccessListSyncEvent
-	(*DatabaseUserCreatedEvent)(nil),                          // 130: prehog.v1alpha.DatabaseUserCreatedEvent
-	(*DatabaseUserPermissionsUpdateEvent)(nil),                // 131: prehog.v1alpha.DatabaseUserPermissionsUpdateEvent
-	(*SessionRecordingAccessEvent)(nil),                       // 132: prehog.v1alpha.SessionRecordingAccessEvent
-	(*UserTaskStateEvent)(nil),                                // 133: prehog.v1alpha.UserTaskStateEvent
-	(*AccessRequestCreateEvent)(nil),                          // 134: prehog.v1alpha.AccessRequestCreateEvent
-	(*AccessRequestReviewEvent)(nil),                          // 135: prehog.v1alpha.AccessRequestReviewEvent
-	(*SessionSummaryAccessEvent)(nil),                         // 136: prehog.v1alpha.SessionSummaryAccessEvent
-	(*SessionSummaryCreateEvent)(nil),                         // 137: prehog.v1alpha.SessionSummaryCreateEvent
-	(*SessionSummarySearchEvent)(nil),                         // 138: prehog.v1alpha.SessionSummarySearchEvent
-	(*DiscoveryConfigEvent)(nil),                              // 139: prehog.v1alpha.DiscoveryConfigEvent
-	(*IdentitySecurityGraphSizeEvent)(nil),                    // 140: prehog.v1alpha.IdentitySecurityGraphSizeEvent
-	(*IdentitySecurityAuditLogsIngestedEvent)(nil),            // 141: prehog.v1alpha.IdentitySecurityAuditLogsIngestedEvent
-	(*AccessListStepStatus)(nil),                              // 142: prehog.v1alpha.AccessListStepStatus
-	(*UIAccessListDefineAccessEvent)(nil),                     // 143: prehog.v1alpha.UIAccessListDefineAccessEvent
-	(*UIAccessListDefineIdentitiesEvent)(nil),                 // 144: prehog.v1alpha.UIAccessListDefineIdentitiesEvent
-	(*UIAccessListDefineBasicInfoEvent)(nil),                  // 145: prehog.v1alpha.UIAccessListDefineBasicInfoEvent
-	(*UIAccessListDefineMembersEvent)(nil),                    // 146: prehog.v1alpha.UIAccessListDefineMembersEvent
-	(*UIAccessListDefineOwnersEvent)(nil),                     // 147: prehog.v1alpha.UIAccessListDefineOwnersEvent
-	(*UIAccessListStartEvent)(nil),                            // 148: prehog.v1alpha.UIAccessListStartEvent
-	(*UIAccessListCustomEvent)(nil),                           // 149: prehog.v1alpha.UIAccessListCustomEvent
-	(*UIAccessListCompleteEvent)(nil),                         // 150: prehog.v1alpha.UIAccessListCompleteEvent
-	(*UIAccessListIntegrateEvent)(nil),                        // 151: prehog.v1alpha.UIAccessListIntegrateEvent
-	(*UIInteractionEvent)(nil),                                // 152: prehog.v1alpha.UIInteractionEvent
-	(*SubmitEventRequest)(nil),                                // 153: prehog.v1alpha.SubmitEventRequest
-	(*SubmitEventResponse)(nil),                               // 154: prehog.v1alpha.SubmitEventResponse
-	(*SubmitEventsRequest)(nil),                               // 155: prehog.v1alpha.SubmitEventsRequest
-	(*SubmitEventsResponse)(nil),                              // 156: prehog.v1alpha.SubmitEventsResponse
-	(*HelloTeleportRequest)(nil),                              // 157: prehog.v1alpha.HelloTeleportRequest
-	(*HelloTeleportResponse)(nil),                             // 158: prehog.v1alpha.HelloTeleportResponse
-	nil,                                                       // 159: prehog.v1alpha.UIInteractionEvent.ParamsEntry
-	(*durationpb.Duration)(nil),                               // 160: google.protobuf.Duration
-	(*timestamppb.Timestamp)(nil),                             // 161: google.protobuf.Timestamp
+	(BeamDestroyReason)(0),                                    // 3: prehog.v1alpha.BeamDestroyReason
+	(DiscoverResource)(0),                                     // 4: prehog.v1alpha.DiscoverResource
+	(DiscoverStatus)(0),                                       // 5: prehog.v1alpha.DiscoverStatus
+	(CTA)(0),                                                  // 6: prehog.v1alpha.CTA
+	(IntegrationEnrollKind)(0),                                // 7: prehog.v1alpha.IntegrationEnrollKind
+	(IntegrationEnrollStep)(0),                                // 8: prehog.v1alpha.IntegrationEnrollStep
+	(IntegrationEnrollStatusCode)(0),                          // 9: prehog.v1alpha.IntegrationEnrollStatusCode
+	(IntegrationEnrollSection)(0),                             // 10: prehog.v1alpha.IntegrationEnrollSection
+	(IntegrationEnrollField)(0),                               // 11: prehog.v1alpha.IntegrationEnrollField
+	(IntegrationEnrollCodeType)(0),                            // 12: prehog.v1alpha.IntegrationEnrollCodeType
+	(EditorChangeStatus)(0),                                   // 13: prehog.v1alpha.EditorChangeStatus
+	(Feature)(0),                                              // 14: prehog.v1alpha.Feature
+	(FeatureRecommendationStatus)(0),                          // 15: prehog.v1alpha.FeatureRecommendationStatus
+	(LicenseLimit)(0),                                         // 16: prehog.v1alpha.LicenseLimit
+	(DiscoveryConfigAction)(0),                                // 17: prehog.v1alpha.DiscoveryConfigAction
+	(AccessListStatus)(0),                                     // 18: prehog.v1alpha.AccessListStatus
+	(AccessListPreset)(0),                                     // 19: prehog.v1alpha.AccessListPreset
+	(AccessListIntegrate)(0),                                  // 20: prehog.v1alpha.AccessListIntegrate
+	(UIDiscoverDeployServiceEvent_DeployMethod)(0),            // 21: prehog.v1alpha.UIDiscoverDeployServiceEvent.DeployMethod
+	(UIDiscoverDeployServiceEvent_DeployType)(0),              // 22: prehog.v1alpha.UIDiscoverDeployServiceEvent.DeployType
+	(UIDiscoverCreateDiscoveryConfigEvent_ConfigMethod)(0),    // 23: prehog.v1alpha.UIDiscoverCreateDiscoveryConfigEvent.ConfigMethod
+	(AccessRequestReviewEvent_ProposedState)(0),               // 24: prehog.v1alpha.AccessRequestReviewEvent.ProposedState
+	(*UserLoginEvent)(nil),                                    // 25: prehog.v1alpha.UserLoginEvent
+	(*MFAAuthenticationEvent)(nil),                            // 26: prehog.v1alpha.MFAAuthenticationEvent
+	(*SSOCreateEvent)(nil),                                    // 27: prehog.v1alpha.SSOCreateEvent
+	(*ResourceCreateEvent)(nil),                               // 28: prehog.v1alpha.ResourceCreateEvent
+	(*DiscoveredDatabaseMetadata)(nil),                        // 29: prehog.v1alpha.DiscoveredDatabaseMetadata
+	(*ResourceHeartbeatEvent)(nil),                            // 30: prehog.v1alpha.ResourceHeartbeatEvent
+	(*SessionStartEvent)(nil),                                 // 31: prehog.v1alpha.SessionStartEvent
+	(*SessionStartDatabaseMetadata)(nil),                      // 32: prehog.v1alpha.SessionStartDatabaseMetadata
+	(*SessionStartDesktopMetadata)(nil),                       // 33: prehog.v1alpha.SessionStartDesktopMetadata
+	(*SessionStartAppMetadata)(nil),                           // 34: prehog.v1alpha.SessionStartAppMetadata
+	(*SessionStartGitMetadata)(nil),                           // 35: prehog.v1alpha.SessionStartGitMetadata
+	(*SessionStartMCPMetadata)(nil),                           // 36: prehog.v1alpha.SessionStartMCPMetadata
+	(*SessionStartBeamMetadata)(nil),                          // 37: prehog.v1alpha.SessionStartBeamMetadata
+	(*BeamsCreatedEvent)(nil),                                 // 38: prehog.v1alpha.BeamsCreatedEvent
+	(*BeamsDestroyedEvent)(nil),                               // 39: prehog.v1alpha.BeamsDestroyedEvent
+	(*UserCertificateIssuedEvent)(nil),                        // 40: prehog.v1alpha.UserCertificateIssuedEvent
+	(*SPIFFESVIDIssuedEvent)(nil),                             // 41: prehog.v1alpha.SPIFFESVIDIssuedEvent
+	(*UIBannerClickEvent)(nil),                                // 42: prehog.v1alpha.UIBannerClickEvent
+	(*UIOnboardCompleteGoToDashboardClickEvent)(nil),          // 43: prehog.v1alpha.UIOnboardCompleteGoToDashboardClickEvent
+	(*UIOnboardAddFirstResourceClickEvent)(nil),               // 44: prehog.v1alpha.UIOnboardAddFirstResourceClickEvent
+	(*UIOnboardAddFirstResourceLaterClickEvent)(nil),          // 45: prehog.v1alpha.UIOnboardAddFirstResourceLaterClickEvent
+	(*UIOnboardSetCredentialSubmitEvent)(nil),                 // 46: prehog.v1alpha.UIOnboardSetCredentialSubmitEvent
+	(*UIOnboardRegisterChallengeSubmitEvent)(nil),             // 47: prehog.v1alpha.UIOnboardRegisterChallengeSubmitEvent
+	(*UIOnboardQuestionnaireSubmitEvent)(nil),                 // 48: prehog.v1alpha.UIOnboardQuestionnaireSubmitEvent
+	(*UIRecoveryCodesContinueClickEvent)(nil),                 // 49: prehog.v1alpha.UIRecoveryCodesContinueClickEvent
+	(*UIRecoveryCodesCopyClickEvent)(nil),                     // 50: prehog.v1alpha.UIRecoveryCodesCopyClickEvent
+	(*UIRecoveryCodesPrintClickEvent)(nil),                    // 51: prehog.v1alpha.UIRecoveryCodesPrintClickEvent
+	(*DiscoverMetadata)(nil),                                  // 52: prehog.v1alpha.DiscoverMetadata
+	(*DiscoverResourceMetadata)(nil),                          // 53: prehog.v1alpha.DiscoverResourceMetadata
+	(*DiscoverStepStatus)(nil),                                // 54: prehog.v1alpha.DiscoverStepStatus
+	(*UIDiscoverStartedEvent)(nil),                            // 55: prehog.v1alpha.UIDiscoverStartedEvent
+	(*UIDiscoverResourceSelectionEvent)(nil),                  // 56: prehog.v1alpha.UIDiscoverResourceSelectionEvent
+	(*UIDiscoverIntegrationAWSOIDCConnectEvent)(nil),          // 57: prehog.v1alpha.UIDiscoverIntegrationAWSOIDCConnectEvent
+	(*UIDiscoverDatabaseRDSEnrollEvent)(nil),                  // 58: prehog.v1alpha.UIDiscoverDatabaseRDSEnrollEvent
+	(*UIDiscoverKubeEKSEnrollEvent)(nil),                      // 59: prehog.v1alpha.UIDiscoverKubeEKSEnrollEvent
+	(*UIDiscoverDeployServiceEvent)(nil),                      // 60: prehog.v1alpha.UIDiscoverDeployServiceEvent
+	(*UIDiscoverCreateDiscoveryConfigEvent)(nil),              // 61: prehog.v1alpha.UIDiscoverCreateDiscoveryConfigEvent
+	(*UIDiscoverDatabaseRegisterEvent)(nil),                   // 62: prehog.v1alpha.UIDiscoverDatabaseRegisterEvent
+	(*UIDiscoverDatabaseConfigureMTLSEvent)(nil),              // 63: prehog.v1alpha.UIDiscoverDatabaseConfigureMTLSEvent
+	(*UIDiscoverDesktopActiveDirectoryToolsInstallEvent)(nil), // 64: prehog.v1alpha.UIDiscoverDesktopActiveDirectoryToolsInstallEvent
+	(*UIDiscoverDesktopActiveDirectoryConfigureEvent)(nil),    // 65: prehog.v1alpha.UIDiscoverDesktopActiveDirectoryConfigureEvent
+	(*UIDiscoverAutoDiscoveredResourcesEvent)(nil),            // 66: prehog.v1alpha.UIDiscoverAutoDiscoveredResourcesEvent
+	(*UIDiscoverEC2InstanceSelectionEvent)(nil),               // 67: prehog.v1alpha.UIDiscoverEC2InstanceSelectionEvent
+	(*UIDiscoverDeployEICEEvent)(nil),                         // 68: prehog.v1alpha.UIDiscoverDeployEICEEvent
+	(*UIDiscoverCreateNodeEvent)(nil),                         // 69: prehog.v1alpha.UIDiscoverCreateNodeEvent
+	(*UIDiscoverCreateAppServerEvent)(nil),                    // 70: prehog.v1alpha.UIDiscoverCreateAppServerEvent
+	(*UIDiscoverDatabaseConfigureIAMPolicyEvent)(nil),         // 71: prehog.v1alpha.UIDiscoverDatabaseConfigureIAMPolicyEvent
+	(*UIDiscoverPrincipalsConfigureEvent)(nil),                // 72: prehog.v1alpha.UIDiscoverPrincipalsConfigureEvent
+	(*UIDiscoverTestConnectionEvent)(nil),                     // 73: prehog.v1alpha.UIDiscoverTestConnectionEvent
+	(*UIDiscoverCompletedEvent)(nil),                          // 74: prehog.v1alpha.UIDiscoverCompletedEvent
+	(*RoleCreateEvent)(nil),                                   // 75: prehog.v1alpha.RoleCreateEvent
+	(*BotCreateEvent)(nil),                                    // 76: prehog.v1alpha.BotCreateEvent
+	(*BotJoinEvent)(nil),                                      // 77: prehog.v1alpha.BotJoinEvent
+	(*UICreateNewRoleClickEvent)(nil),                         // 78: prehog.v1alpha.UICreateNewRoleClickEvent
+	(*UICreateNewRoleSaveClickEvent)(nil),                     // 79: prehog.v1alpha.UICreateNewRoleSaveClickEvent
+	(*UICreateNewRoleCancelClickEvent)(nil),                   // 80: prehog.v1alpha.UICreateNewRoleCancelClickEvent
+	(*UICreateNewRoleViewDocumentationClickEvent)(nil),        // 81: prehog.v1alpha.UICreateNewRoleViewDocumentationClickEvent
+	(*UICallToActionClickEvent)(nil),                          // 82: prehog.v1alpha.UICallToActionClickEvent
+	(*KubeRequestEvent)(nil),                                  // 83: prehog.v1alpha.KubeRequestEvent
+	(*SFTPEvent)(nil),                                         // 84: prehog.v1alpha.SFTPEvent
+	(*AgentMetadataEvent)(nil),                                // 85: prehog.v1alpha.AgentMetadataEvent
+	(*AssistCompletionEvent)(nil),                             // 86: prehog.v1alpha.AssistCompletionEvent
+	(*AssistExecutionEvent)(nil),                              // 87: prehog.v1alpha.AssistExecutionEvent
+	(*AssistNewConversationEvent)(nil),                        // 88: prehog.v1alpha.AssistNewConversationEvent
+	(*AssistAccessRequestEvent)(nil),                          // 89: prehog.v1alpha.AssistAccessRequestEvent
+	(*AssistActionEvent)(nil),                                 // 90: prehog.v1alpha.AssistActionEvent
+	(*AccessListMetadata)(nil),                                // 91: prehog.v1alpha.AccessListMetadata
+	(*AccessListCreateEvent)(nil),                             // 92: prehog.v1alpha.AccessListCreateEvent
+	(*AccessListUpdateEvent)(nil),                             // 93: prehog.v1alpha.AccessListUpdateEvent
+	(*AccessListDeleteEvent)(nil),                             // 94: prehog.v1alpha.AccessListDeleteEvent
+	(*AccessListMemberCreateEvent)(nil),                       // 95: prehog.v1alpha.AccessListMemberCreateEvent
+	(*AccessListMemberUpdateEvent)(nil),                       // 96: prehog.v1alpha.AccessListMemberUpdateEvent
+	(*AccessListMemberDeleteEvent)(nil),                       // 97: prehog.v1alpha.AccessListMemberDeleteEvent
+	(*AccessListGrantsToUserEvent)(nil),                       // 98: prehog.v1alpha.AccessListGrantsToUserEvent
+	(*AccessListReviewCreateEvent)(nil),                       // 99: prehog.v1alpha.AccessListReviewCreateEvent
+	(*AccessListReviewDeleteEvent)(nil),                       // 100: prehog.v1alpha.AccessListReviewDeleteEvent
+	(*AccessListReviewComplianceEvent)(nil),                   // 101: prehog.v1alpha.AccessListReviewComplianceEvent
+	(*IntegrationEnrollMetadata)(nil),                         // 102: prehog.v1alpha.IntegrationEnrollMetadata
+	(*UIIntegrationEnrollStartEvent)(nil),                     // 103: prehog.v1alpha.UIIntegrationEnrollStartEvent
+	(*UIIntegrationEnrollCompleteEvent)(nil),                  // 104: prehog.v1alpha.UIIntegrationEnrollCompleteEvent
+	(*IntegrationEnrollStepStatus)(nil),                       // 105: prehog.v1alpha.IntegrationEnrollStepStatus
+	(*UIIntegrationEnrollStepEvent)(nil),                      // 106: prehog.v1alpha.UIIntegrationEnrollStepEvent
+	(*UIIntegrationEnrollSectionOpenEvent)(nil),               // 107: prehog.v1alpha.UIIntegrationEnrollSectionOpenEvent
+	(*UIIntegrationEnrollFieldCompleteEvent)(nil),             // 108: prehog.v1alpha.UIIntegrationEnrollFieldCompleteEvent
+	(*UIIntegrationEnrollCodeCopyEvent)(nil),                  // 109: prehog.v1alpha.UIIntegrationEnrollCodeCopyEvent
+	(*UIIntegrationEnrollLinkClickEvent)(nil),                 // 110: prehog.v1alpha.UIIntegrationEnrollLinkClickEvent
+	(*EditorChangeEvent)(nil),                                 // 111: prehog.v1alpha.EditorChangeEvent
+	(*DeviceAuthenticateEvent)(nil),                           // 112: prehog.v1alpha.DeviceAuthenticateEvent
+	(*DeviceEnrollEvent)(nil),                                 // 113: prehog.v1alpha.DeviceEnrollEvent
+	(*FeatureRecommendationEvent)(nil),                        // 114: prehog.v1alpha.FeatureRecommendationEvent
+	(*LicenseLimitEvent)(nil),                                 // 115: prehog.v1alpha.LicenseLimitEvent
+	(*DesktopDirectoryShareEvent)(nil),                        // 116: prehog.v1alpha.DesktopDirectoryShareEvent
+	(*DesktopClipboardEvent)(nil),                             // 117: prehog.v1alpha.DesktopClipboardEvent
+	(*TAGExecuteQueryEvent)(nil),                              // 118: prehog.v1alpha.TAGExecuteQueryEvent
+	(*AccessGraphSecretsScanAuthorizedKeysEvent)(nil),         // 119: prehog.v1alpha.AccessGraphSecretsScanAuthorizedKeysEvent
+	(*AccessGraphSecretsScanSSHPrivateKeysEvent)(nil),         // 120: prehog.v1alpha.AccessGraphSecretsScanSSHPrivateKeysEvent
+	(*AccessGraphGitlabScanEvent)(nil),                        // 121: prehog.v1alpha.AccessGraphGitlabScanEvent
+	(*AccessGraphAWSScanEvent)(nil),                           // 122: prehog.v1alpha.AccessGraphAWSScanEvent
+	(*AccessGraphAccessPathChangedEvent)(nil),                 // 123: prehog.v1alpha.AccessGraphAccessPathChangedEvent
+	(*UIAccessGraphCrownJewelDiffViewEvent)(nil),              // 124: prehog.v1alpha.UIAccessGraphCrownJewelDiffViewEvent
+	(*UIPageViewEvent)(nil),                                   // 125: prehog.v1alpha.UIPageViewEvent
+	(*UIUsageReportingAlertCtaClickEvent)(nil),                // 126: prehog.v1alpha.UIUsageReportingAlertCtaClickEvent
+	(*AccessGraphCrownJewelCreateEvent)(nil),                  // 127: prehog.v1alpha.AccessGraphCrownJewelCreateEvent
+	(*ExternalAuditStorageAuthenticateEvent)(nil),             // 128: prehog.v1alpha.ExternalAuditStorageAuthenticateEvent
+	(*SecurityReportGetResultEvent)(nil),                      // 129: prehog.v1alpha.SecurityReportGetResultEvent
+	(*AuditQueryRunEvent)(nil),                                // 130: prehog.v1alpha.AuditQueryRunEvent
+	(*DiscoveryFetchEvent)(nil),                               // 131: prehog.v1alpha.DiscoveryFetchEvent
+	(*OktaAccessListSyncEvent)(nil),                           // 132: prehog.v1alpha.OktaAccessListSyncEvent
+	(*DatabaseUserCreatedEvent)(nil),                          // 133: prehog.v1alpha.DatabaseUserCreatedEvent
+	(*DatabaseUserPermissionsUpdateEvent)(nil),                // 134: prehog.v1alpha.DatabaseUserPermissionsUpdateEvent
+	(*SessionRecordingAccessEvent)(nil),                       // 135: prehog.v1alpha.SessionRecordingAccessEvent
+	(*UserTaskStateEvent)(nil),                                // 136: prehog.v1alpha.UserTaskStateEvent
+	(*AccessRequestCreateEvent)(nil),                          // 137: prehog.v1alpha.AccessRequestCreateEvent
+	(*AccessRequestReviewEvent)(nil),                          // 138: prehog.v1alpha.AccessRequestReviewEvent
+	(*SessionSummaryAccessEvent)(nil),                         // 139: prehog.v1alpha.SessionSummaryAccessEvent
+	(*SessionSummaryCreateEvent)(nil),                         // 140: prehog.v1alpha.SessionSummaryCreateEvent
+	(*SessionSummarySearchEvent)(nil),                         // 141: prehog.v1alpha.SessionSummarySearchEvent
+	(*DiscoveryConfigEvent)(nil),                              // 142: prehog.v1alpha.DiscoveryConfigEvent
+	(*IdentitySecurityGraphSizeEvent)(nil),                    // 143: prehog.v1alpha.IdentitySecurityGraphSizeEvent
+	(*IdentitySecurityAuditLogsIngestedEvent)(nil),            // 144: prehog.v1alpha.IdentitySecurityAuditLogsIngestedEvent
+	(*AccessListStepStatus)(nil),                              // 145: prehog.v1alpha.AccessListStepStatus
+	(*UIAccessListDefineAccessEvent)(nil),                     // 146: prehog.v1alpha.UIAccessListDefineAccessEvent
+	(*UIAccessListDefineIdentitiesEvent)(nil),                 // 147: prehog.v1alpha.UIAccessListDefineIdentitiesEvent
+	(*UIAccessListDefineBasicInfoEvent)(nil),                  // 148: prehog.v1alpha.UIAccessListDefineBasicInfoEvent
+	(*UIAccessListDefineMembersEvent)(nil),                    // 149: prehog.v1alpha.UIAccessListDefineMembersEvent
+	(*UIAccessListDefineOwnersEvent)(nil),                     // 150: prehog.v1alpha.UIAccessListDefineOwnersEvent
+	(*UIAccessListStartEvent)(nil),                            // 151: prehog.v1alpha.UIAccessListStartEvent
+	(*UIAccessListCustomEvent)(nil),                           // 152: prehog.v1alpha.UIAccessListCustomEvent
+	(*UIAccessListCompleteEvent)(nil),                         // 153: prehog.v1alpha.UIAccessListCompleteEvent
+	(*UIAccessListIntegrateEvent)(nil),                        // 154: prehog.v1alpha.UIAccessListIntegrateEvent
+	(*UIInteractionEvent)(nil),                                // 155: prehog.v1alpha.UIInteractionEvent
+	(*SubmitEventRequest)(nil),                                // 156: prehog.v1alpha.SubmitEventRequest
+	(*SubmitEventResponse)(nil),                               // 157: prehog.v1alpha.SubmitEventResponse
+	(*SubmitEventsRequest)(nil),                               // 158: prehog.v1alpha.SubmitEventsRequest
+	(*SubmitEventsResponse)(nil),                              // 159: prehog.v1alpha.SubmitEventsResponse
+	(*HelloTeleportRequest)(nil),                              // 160: prehog.v1alpha.HelloTeleportRequest
+	(*HelloTeleportResponse)(nil),                             // 161: prehog.v1alpha.HelloTeleportResponse
+	nil,                                                       // 162: prehog.v1alpha.UIInteractionEvent.ParamsEntry
+	(*durationpb.Duration)(nil),                               // 163: google.protobuf.Duration
+	(*timestamppb.Timestamp)(nil),                             // 164: google.protobuf.Timestamp
 }
 var file_prehog_v1alpha_teleport_proto_depIdxs = []int32{
 	0,   // 0: prehog.v1alpha.UserLoginEvent.user_origin:type_name -> prehog.v1alpha.UserOrigin
-	28,  // 1: prehog.v1alpha.ResourceCreateEvent.database:type_name -> prehog.v1alpha.DiscoveredDatabaseMetadata
+	29,  // 1: prehog.v1alpha.ResourceCreateEvent.database:type_name -> prehog.v1alpha.DiscoveredDatabaseMetadata
 	1,   // 2: prehog.v1alpha.ResourceHeartbeatEvent.resource_kind:type_name -> prehog.v1alpha.ResourceKind
-	31,  // 3: prehog.v1alpha.SessionStartEvent.database:type_name -> prehog.v1alpha.SessionStartDatabaseMetadata
-	32,  // 4: prehog.v1alpha.SessionStartEvent.desktop:type_name -> prehog.v1alpha.SessionStartDesktopMetadata
+	32,  // 3: prehog.v1alpha.SessionStartEvent.database:type_name -> prehog.v1alpha.SessionStartDatabaseMetadata
+	33,  // 4: prehog.v1alpha.SessionStartEvent.desktop:type_name -> prehog.v1alpha.SessionStartDesktopMetadata
 	2,   // 5: prehog.v1alpha.SessionStartEvent.user_kind:type_name -> prehog.v1alpha.UserKind
-	33,  // 6: prehog.v1alpha.SessionStartEvent.app:type_name -> prehog.v1alpha.SessionStartAppMetadata
-	34,  // 7: prehog.v1alpha.SessionStartEvent.git:type_name -> prehog.v1alpha.SessionStartGitMetadata
-	35,  // 8: prehog.v1alpha.SessionStartEvent.mcp:type_name -> prehog.v1alpha.SessionStartMCPMetadata
-	36,  // 9: prehog.v1alpha.SessionStartEvent.beam:type_name -> prehog.v1alpha.SessionStartBeamMetadata
-	160, // 10: prehog.v1alpha.UserCertificateIssuedEvent.ttl:type_name -> google.protobuf.Duration
-	2,   // 11: prehog.v1alpha.SPIFFESVIDIssuedEvent.user_kind:type_name -> prehog.v1alpha.UserKind
-	3,   // 12: prehog.v1alpha.DiscoverResourceMetadata.resource:type_name -> prehog.v1alpha.DiscoverResource
-	4,   // 13: prehog.v1alpha.DiscoverStepStatus.status:type_name -> prehog.v1alpha.DiscoverStatus
-	49,  // 14: prehog.v1alpha.UIDiscoverStartedEvent.metadata:type_name -> prehog.v1alpha.DiscoverMetadata
-	51,  // 15: prehog.v1alpha.UIDiscoverStartedEvent.status:type_name -> prehog.v1alpha.DiscoverStepStatus
-	49,  // 16: prehog.v1alpha.UIDiscoverResourceSelectionEvent.metadata:type_name -> prehog.v1alpha.DiscoverMetadata
-	50,  // 17: prehog.v1alpha.UIDiscoverResourceSelectionEvent.resource:type_name -> prehog.v1alpha.DiscoverResourceMetadata
-	51,  // 18: prehog.v1alpha.UIDiscoverResourceSelectionEvent.status:type_name -> prehog.v1alpha.DiscoverStepStatus
-	49,  // 19: prehog.v1alpha.UIDiscoverIntegrationAWSOIDCConnectEvent.metadata:type_name -> prehog.v1alpha.DiscoverMetadata
-	50,  // 20: prehog.v1alpha.UIDiscoverIntegrationAWSOIDCConnectEvent.resource:type_name -> prehog.v1alpha.DiscoverResourceMetadata
-	51,  // 21: prehog.v1alpha.UIDiscoverIntegrationAWSOIDCConnectEvent.status:type_name -> prehog.v1alpha.DiscoverStepStatus
-	49,  // 22: prehog.v1alpha.UIDiscoverDatabaseRDSEnrollEvent.metadata:type_name -> prehog.v1alpha.DiscoverMetadata
-	50,  // 23: prehog.v1alpha.UIDiscoverDatabaseRDSEnrollEvent.resource:type_name -> prehog.v1alpha.DiscoverResourceMetadata
-	51,  // 24: prehog.v1alpha.UIDiscoverDatabaseRDSEnrollEvent.status:type_name -> prehog.v1alpha.DiscoverStepStatus
-	49,  // 25: prehog.v1alpha.UIDiscoverKubeEKSEnrollEvent.metadata:type_name -> prehog.v1alpha.DiscoverMetadata
-	50,  // 26: prehog.v1alpha.UIDiscoverKubeEKSEnrollEvent.resource:type_name -> prehog.v1alpha.DiscoverResourceMetadata
-	51,  // 27: prehog.v1alpha.UIDiscoverKubeEKSEnrollEvent.status:type_name -> prehog.v1alpha.DiscoverStepStatus
-	49,  // 28: prehog.v1alpha.UIDiscoverDeployServiceEvent.metadata:type_name -> prehog.v1alpha.DiscoverMetadata
-	50,  // 29: prehog.v1alpha.UIDiscoverDeployServiceEvent.resource:type_name -> prehog.v1alpha.DiscoverResourceMetadata
-	51,  // 30: prehog.v1alpha.UIDiscoverDeployServiceEvent.status:type_name -> prehog.v1alpha.DiscoverStepStatus
-	20,  // 31: prehog.v1alpha.UIDiscoverDeployServiceEvent.deploy_method:type_name -> prehog.v1alpha.UIDiscoverDeployServiceEvent.DeployMethod
-	21,  // 32: prehog.v1alpha.UIDiscoverDeployServiceEvent.deploy_type:type_name -> prehog.v1alpha.UIDiscoverDeployServiceEvent.DeployType
-	49,  // 33: prehog.v1alpha.UIDiscoverCreateDiscoveryConfigEvent.metadata:type_name -> prehog.v1alpha.DiscoverMetadata
-	50,  // 34: prehog.v1alpha.UIDiscoverCreateDiscoveryConfigEvent.resource:type_name -> prehog.v1alpha.DiscoverResourceMetadata
-	51,  // 35: prehog.v1alpha.UIDiscoverCreateDiscoveryConfigEvent.status:type_name -> prehog.v1alpha.DiscoverStepStatus
-	22,  // 36: prehog.v1alpha.UIDiscoverCreateDiscoveryConfigEvent.config_method:type_name -> prehog.v1alpha.UIDiscoverCreateDiscoveryConfigEvent.ConfigMethod
-	49,  // 37: prehog.v1alpha.UIDiscoverDatabaseRegisterEvent.metadata:type_name -> prehog.v1alpha.DiscoverMetadata
-	50,  // 38: prehog.v1alpha.UIDiscoverDatabaseRegisterEvent.resource:type_name -> prehog.v1alpha.DiscoverResourceMetadata
-	51,  // 39: prehog.v1alpha.UIDiscoverDatabaseRegisterEvent.status:type_name -> prehog.v1alpha.DiscoverStepStatus
-	49,  // 40: prehog.v1alpha.UIDiscoverDatabaseConfigureMTLSEvent.metadata:type_name -> prehog.v1alpha.DiscoverMetadata
-	50,  // 41: prehog.v1alpha.UIDiscoverDatabaseConfigureMTLSEvent.resource:type_name -> prehog.v1alpha.DiscoverResourceMetadata
-	51,  // 42: prehog.v1alpha.UIDiscoverDatabaseConfigureMTLSEvent.status:type_name -> prehog.v1alpha.DiscoverStepStatus
-	49,  // 43: prehog.v1alpha.UIDiscoverDesktopActiveDirectoryToolsInstallEvent.metadata:type_name -> prehog.v1alpha.DiscoverMetadata
-	50,  // 44: prehog.v1alpha.UIDiscoverDesktopActiveDirectoryToolsInstallEvent.resource:type_name -> prehog.v1alpha.DiscoverResourceMetadata
-	51,  // 45: prehog.v1alpha.UIDiscoverDesktopActiveDirectoryToolsInstallEvent.status:type_name -> prehog.v1alpha.DiscoverStepStatus
-	49,  // 46: prehog.v1alpha.UIDiscoverDesktopActiveDirectoryConfigureEvent.metadata:type_name -> prehog.v1alpha.DiscoverMetadata
-	50,  // 47: prehog.v1alpha.UIDiscoverDesktopActiveDirectoryConfigureEvent.resource:type_name -> prehog.v1alpha.DiscoverResourceMetadata
-	51,  // 48: prehog.v1alpha.UIDiscoverDesktopActiveDirectoryConfigureEvent.status:type_name -> prehog.v1alpha.DiscoverStepStatus
-	49,  // 49: prehog.v1alpha.UIDiscoverAutoDiscoveredResourcesEvent.metadata:type_name -> prehog.v1alpha.DiscoverMetadata
-	50,  // 50: prehog.v1alpha.UIDiscoverAutoDiscoveredResourcesEvent.resource:type_name -> prehog.v1alpha.DiscoverResourceMetadata
-	51,  // 51: prehog.v1alpha.UIDiscoverAutoDiscoveredResourcesEvent.status:type_name -> prehog.v1alpha.DiscoverStepStatus
-	49,  // 52: prehog.v1alpha.UIDiscoverEC2InstanceSelectionEvent.metadata:type_name -> prehog.v1alpha.DiscoverMetadata
-	50,  // 53: prehog.v1alpha.UIDiscoverEC2InstanceSelectionEvent.resource:type_name -> prehog.v1alpha.DiscoverResourceMetadata
-	51,  // 54: prehog.v1alpha.UIDiscoverEC2InstanceSelectionEvent.status:type_name -> prehog.v1alpha.DiscoverStepStatus
-	49,  // 55: prehog.v1alpha.UIDiscoverDeployEICEEvent.metadata:type_name -> prehog.v1alpha.DiscoverMetadata
-	50,  // 56: prehog.v1alpha.UIDiscoverDeployEICEEvent.resource:type_name -> prehog.v1alpha.DiscoverResourceMetadata
-	51,  // 57: prehog.v1alpha.UIDiscoverDeployEICEEvent.status:type_name -> prehog.v1alpha.DiscoverStepStatus
-	49,  // 58: prehog.v1alpha.UIDiscoverCreateNodeEvent.metadata:type_name -> prehog.v1alpha.DiscoverMetadata
-	50,  // 59: prehog.v1alpha.UIDiscoverCreateNodeEvent.resource:type_name -> prehog.v1alpha.DiscoverResourceMetadata
-	51,  // 60: prehog.v1alpha.UIDiscoverCreateNodeEvent.status:type_name -> prehog.v1alpha.DiscoverStepStatus
-	49,  // 61: prehog.v1alpha.UIDiscoverCreateAppServerEvent.metadata:type_name -> prehog.v1alpha.DiscoverMetadata
-	50,  // 62: prehog.v1alpha.UIDiscoverCreateAppServerEvent.resource:type_name -> prehog.v1alpha.DiscoverResourceMetadata
-	51,  // 63: prehog.v1alpha.UIDiscoverCreateAppServerEvent.status:type_name -> prehog.v1alpha.DiscoverStepStatus
-	49,  // 64: prehog.v1alpha.UIDiscoverDatabaseConfigureIAMPolicyEvent.metadata:type_name -> prehog.v1alpha.DiscoverMetadata
-	50,  // 65: prehog.v1alpha.UIDiscoverDatabaseConfigureIAMPolicyEvent.resource:type_name -> prehog.v1alpha.DiscoverResourceMetadata
-	51,  // 66: prehog.v1alpha.UIDiscoverDatabaseConfigureIAMPolicyEvent.status:type_name -> prehog.v1alpha.DiscoverStepStatus
-	49,  // 67: prehog.v1alpha.UIDiscoverPrincipalsConfigureEvent.metadata:type_name -> prehog.v1alpha.DiscoverMetadata
-	50,  // 68: prehog.v1alpha.UIDiscoverPrincipalsConfigureEvent.resource:type_name -> prehog.v1alpha.DiscoverResourceMetadata
-	51,  // 69: prehog.v1alpha.UIDiscoverPrincipalsConfigureEvent.status:type_name -> prehog.v1alpha.DiscoverStepStatus
-	49,  // 70: prehog.v1alpha.UIDiscoverTestConnectionEvent.metadata:type_name -> prehog.v1alpha.DiscoverMetadata
-	50,  // 71: prehog.v1alpha.UIDiscoverTestConnectionEvent.resource:type_name -> prehog.v1alpha.DiscoverResourceMetadata
-	51,  // 72: prehog.v1alpha.UIDiscoverTestConnectionEvent.status:type_name -> prehog.v1alpha.DiscoverStepStatus
-	49,  // 73: prehog.v1alpha.UIDiscoverCompletedEvent.metadata:type_name -> prehog.v1alpha.DiscoverMetadata
-	50,  // 74: prehog.v1alpha.UIDiscoverCompletedEvent.resource:type_name -> prehog.v1alpha.DiscoverResourceMetadata
-	51,  // 75: prehog.v1alpha.UIDiscoverCompletedEvent.status:type_name -> prehog.v1alpha.DiscoverStepStatus
-	5,   // 76: prehog.v1alpha.UICallToActionClickEvent.cta:type_name -> prehog.v1alpha.CTA
-	2,   // 77: prehog.v1alpha.KubeRequestEvent.user_kind:type_name -> prehog.v1alpha.UserKind
-	2,   // 78: prehog.v1alpha.SFTPEvent.user_kind:type_name -> prehog.v1alpha.UserKind
-	18,  // 79: prehog.v1alpha.AccessListMetadata.preset:type_name -> prehog.v1alpha.AccessListPreset
-	88,  // 80: prehog.v1alpha.AccessListCreateEvent.metadata:type_name -> prehog.v1alpha.AccessListMetadata
-	88,  // 81: prehog.v1alpha.AccessListUpdateEvent.metadata:type_name -> prehog.v1alpha.AccessListMetadata
-	88,  // 82: prehog.v1alpha.AccessListDeleteEvent.metadata:type_name -> prehog.v1alpha.AccessListMetadata
-	88,  // 83: prehog.v1alpha.AccessListMemberCreateEvent.metadata:type_name -> prehog.v1alpha.AccessListMetadata
-	88,  // 84: prehog.v1alpha.AccessListMemberUpdateEvent.metadata:type_name -> prehog.v1alpha.AccessListMetadata
-	88,  // 85: prehog.v1alpha.AccessListMemberDeleteEvent.metadata:type_name -> prehog.v1alpha.AccessListMetadata
-	88,  // 86: prehog.v1alpha.AccessListReviewCreateEvent.metadata:type_name -> prehog.v1alpha.AccessListMetadata
-	88,  // 87: prehog.v1alpha.AccessListReviewDeleteEvent.metadata:type_name -> prehog.v1alpha.AccessListMetadata
-	6,   // 88: prehog.v1alpha.IntegrationEnrollMetadata.kind:type_name -> prehog.v1alpha.IntegrationEnrollKind
-	99,  // 89: prehog.v1alpha.UIIntegrationEnrollStartEvent.metadata:type_name -> prehog.v1alpha.IntegrationEnrollMetadata
-	99,  // 90: prehog.v1alpha.UIIntegrationEnrollCompleteEvent.metadata:type_name -> prehog.v1alpha.IntegrationEnrollMetadata
-	8,   // 91: prehog.v1alpha.IntegrationEnrollStepStatus.code:type_name -> prehog.v1alpha.IntegrationEnrollStatusCode
-	99,  // 92: prehog.v1alpha.UIIntegrationEnrollStepEvent.metadata:type_name -> prehog.v1alpha.IntegrationEnrollMetadata
-	7,   // 93: prehog.v1alpha.UIIntegrationEnrollStepEvent.step:type_name -> prehog.v1alpha.IntegrationEnrollStep
-	102, // 94: prehog.v1alpha.UIIntegrationEnrollStepEvent.status:type_name -> prehog.v1alpha.IntegrationEnrollStepStatus
-	99,  // 95: prehog.v1alpha.UIIntegrationEnrollSectionOpenEvent.metadata:type_name -> prehog.v1alpha.IntegrationEnrollMetadata
-	7,   // 96: prehog.v1alpha.UIIntegrationEnrollSectionOpenEvent.step:type_name -> prehog.v1alpha.IntegrationEnrollStep
-	9,   // 97: prehog.v1alpha.UIIntegrationEnrollSectionOpenEvent.section:type_name -> prehog.v1alpha.IntegrationEnrollSection
-	99,  // 98: prehog.v1alpha.UIIntegrationEnrollFieldCompleteEvent.metadata:type_name -> prehog.v1alpha.IntegrationEnrollMetadata
-	7,   // 99: prehog.v1alpha.UIIntegrationEnrollFieldCompleteEvent.step:type_name -> prehog.v1alpha.IntegrationEnrollStep
-	10,  // 100: prehog.v1alpha.UIIntegrationEnrollFieldCompleteEvent.field:type_name -> prehog.v1alpha.IntegrationEnrollField
-	99,  // 101: prehog.v1alpha.UIIntegrationEnrollCodeCopyEvent.metadata:type_name -> prehog.v1alpha.IntegrationEnrollMetadata
-	7,   // 102: prehog.v1alpha.UIIntegrationEnrollCodeCopyEvent.step:type_name -> prehog.v1alpha.IntegrationEnrollStep
-	11,  // 103: prehog.v1alpha.UIIntegrationEnrollCodeCopyEvent.type:type_name -> prehog.v1alpha.IntegrationEnrollCodeType
-	99,  // 104: prehog.v1alpha.UIIntegrationEnrollLinkClickEvent.metadata:type_name -> prehog.v1alpha.IntegrationEnrollMetadata
-	7,   // 105: prehog.v1alpha.UIIntegrationEnrollLinkClickEvent.step:type_name -> prehog.v1alpha.IntegrationEnrollStep
-	12,  // 106: prehog.v1alpha.EditorChangeEvent.status:type_name -> prehog.v1alpha.EditorChangeStatus
-	13,  // 107: prehog.v1alpha.FeatureRecommendationEvent.feature:type_name -> prehog.v1alpha.Feature
-	14,  // 108: prehog.v1alpha.FeatureRecommendationEvent.feature_recommendation_status:type_name -> prehog.v1alpha.FeatureRecommendationStatus
-	15,  // 109: prehog.v1alpha.LicenseLimitEvent.license_limit:type_name -> prehog.v1alpha.LicenseLimit
-	31,  // 110: prehog.v1alpha.DatabaseUserCreatedEvent.database:type_name -> prehog.v1alpha.SessionStartDatabaseMetadata
-	31,  // 111: prehog.v1alpha.DatabaseUserPermissionsUpdateEvent.database:type_name -> prehog.v1alpha.SessionStartDatabaseMetadata
-	23,  // 112: prehog.v1alpha.AccessRequestReviewEvent.proposed_state:type_name -> prehog.v1alpha.AccessRequestReviewEvent.ProposedState
-	2,   // 113: prehog.v1alpha.SessionSummaryAccessEvent.user_kind:type_name -> prehog.v1alpha.UserKind
-	2,   // 114: prehog.v1alpha.SessionSummarySearchEvent.user_kind:type_name -> prehog.v1alpha.UserKind
-	16,  // 115: prehog.v1alpha.DiscoveryConfigEvent.action:type_name -> prehog.v1alpha.DiscoveryConfigAction
-	17,  // 116: prehog.v1alpha.AccessListStepStatus.status:type_name -> prehog.v1alpha.AccessListStatus
-	88,  // 117: prehog.v1alpha.UIAccessListDefineAccessEvent.metadata:type_name -> prehog.v1alpha.AccessListMetadata
-	142, // 118: prehog.v1alpha.UIAccessListDefineAccessEvent.status:type_name -> prehog.v1alpha.AccessListStepStatus
-	88,  // 119: prehog.v1alpha.UIAccessListDefineIdentitiesEvent.metadata:type_name -> prehog.v1alpha.AccessListMetadata
-	142, // 120: prehog.v1alpha.UIAccessListDefineIdentitiesEvent.status:type_name -> prehog.v1alpha.AccessListStepStatus
-	88,  // 121: prehog.v1alpha.UIAccessListDefineBasicInfoEvent.metadata:type_name -> prehog.v1alpha.AccessListMetadata
-	142, // 122: prehog.v1alpha.UIAccessListDefineBasicInfoEvent.status:type_name -> prehog.v1alpha.AccessListStepStatus
-	88,  // 123: prehog.v1alpha.UIAccessListDefineMembersEvent.metadata:type_name -> prehog.v1alpha.AccessListMetadata
-	142, // 124: prehog.v1alpha.UIAccessListDefineMembersEvent.status:type_name -> prehog.v1alpha.AccessListStepStatus
-	88,  // 125: prehog.v1alpha.UIAccessListDefineOwnersEvent.metadata:type_name -> prehog.v1alpha.AccessListMetadata
-	142, // 126: prehog.v1alpha.UIAccessListDefineOwnersEvent.status:type_name -> prehog.v1alpha.AccessListStepStatus
-	88,  // 127: prehog.v1alpha.UIAccessListStartEvent.metadata:type_name -> prehog.v1alpha.AccessListMetadata
-	142, // 128: prehog.v1alpha.UIAccessListStartEvent.status:type_name -> prehog.v1alpha.AccessListStepStatus
-	88,  // 129: prehog.v1alpha.UIAccessListCustomEvent.metadata:type_name -> prehog.v1alpha.AccessListMetadata
-	142, // 130: prehog.v1alpha.UIAccessListCustomEvent.status:type_name -> prehog.v1alpha.AccessListStepStatus
-	88,  // 131: prehog.v1alpha.UIAccessListCompleteEvent.metadata:type_name -> prehog.v1alpha.AccessListMetadata
-	142, // 132: prehog.v1alpha.UIAccessListCompleteEvent.status:type_name -> prehog.v1alpha.AccessListStepStatus
-	88,  // 133: prehog.v1alpha.UIAccessListIntegrateEvent.metadata:type_name -> prehog.v1alpha.AccessListMetadata
-	19,  // 134: prehog.v1alpha.UIAccessListIntegrateEvent.integrate:type_name -> prehog.v1alpha.AccessListIntegrate
-	159, // 135: prehog.v1alpha.UIInteractionEvent.params:type_name -> prehog.v1alpha.UIInteractionEvent.ParamsEntry
-	161, // 136: prehog.v1alpha.SubmitEventRequest.timestamp:type_name -> google.protobuf.Timestamp
-	24,  // 137: prehog.v1alpha.SubmitEventRequest.user_login:type_name -> prehog.v1alpha.UserLoginEvent
-	26,  // 138: prehog.v1alpha.SubmitEventRequest.sso_create:type_name -> prehog.v1alpha.SSOCreateEvent
-	27,  // 139: prehog.v1alpha.SubmitEventRequest.resource_create:type_name -> prehog.v1alpha.ResourceCreateEvent
-	30,  // 140: prehog.v1alpha.SubmitEventRequest.session_start:type_name -> prehog.v1alpha.SessionStartEvent
-	39,  // 141: prehog.v1alpha.SubmitEventRequest.ui_banner_click:type_name -> prehog.v1alpha.UIBannerClickEvent
-	40,  // 142: prehog.v1alpha.SubmitEventRequest.ui_onboard_complete_go_to_dashboard_click:type_name -> prehog.v1alpha.UIOnboardCompleteGoToDashboardClickEvent
-	41,  // 143: prehog.v1alpha.SubmitEventRequest.ui_onboard_add_first_resource_click:type_name -> prehog.v1alpha.UIOnboardAddFirstResourceClickEvent
-	42,  // 144: prehog.v1alpha.SubmitEventRequest.ui_onboard_add_first_resource_later_click:type_name -> prehog.v1alpha.UIOnboardAddFirstResourceLaterClickEvent
-	43,  // 145: prehog.v1alpha.SubmitEventRequest.ui_onboard_set_credential_submit:type_name -> prehog.v1alpha.UIOnboardSetCredentialSubmitEvent
-	44,  // 146: prehog.v1alpha.SubmitEventRequest.ui_onboard_register_challenge_submit:type_name -> prehog.v1alpha.UIOnboardRegisterChallengeSubmitEvent
-	46,  // 147: prehog.v1alpha.SubmitEventRequest.ui_recovery_codes_continue_click:type_name -> prehog.v1alpha.UIRecoveryCodesContinueClickEvent
-	47,  // 148: prehog.v1alpha.SubmitEventRequest.ui_recovery_codes_copy_click:type_name -> prehog.v1alpha.UIRecoveryCodesCopyClickEvent
-	48,  // 149: prehog.v1alpha.SubmitEventRequest.ui_recovery_codes_print_click:type_name -> prehog.v1alpha.UIRecoveryCodesPrintClickEvent
-	52,  // 150: prehog.v1alpha.SubmitEventRequest.ui_discover_started_event:type_name -> prehog.v1alpha.UIDiscoverStartedEvent
-	53,  // 151: prehog.v1alpha.SubmitEventRequest.ui_discover_resource_selection_event:type_name -> prehog.v1alpha.UIDiscoverResourceSelectionEvent
-	37,  // 152: prehog.v1alpha.SubmitEventRequest.user_certificate_issued_event:type_name -> prehog.v1alpha.UserCertificateIssuedEvent
-	30,  // 153: prehog.v1alpha.SubmitEventRequest.session_start_v2:type_name -> prehog.v1alpha.SessionStartEvent
-	57,  // 154: prehog.v1alpha.SubmitEventRequest.ui_discover_deploy_service_event:type_name -> prehog.v1alpha.UIDiscoverDeployServiceEvent
-	59,  // 155: prehog.v1alpha.SubmitEventRequest.ui_discover_database_register_event:type_name -> prehog.v1alpha.UIDiscoverDatabaseRegisterEvent
-	60,  // 156: prehog.v1alpha.SubmitEventRequest.ui_discover_database_configure_mtls_event:type_name -> prehog.v1alpha.UIDiscoverDatabaseConfigureMTLSEvent
-	61,  // 157: prehog.v1alpha.SubmitEventRequest.ui_discover_desktop_active_directory_tools_install_event:type_name -> prehog.v1alpha.UIDiscoverDesktopActiveDirectoryToolsInstallEvent
-	62,  // 158: prehog.v1alpha.SubmitEventRequest.ui_discover_desktop_active_directory_configure_event:type_name -> prehog.v1alpha.UIDiscoverDesktopActiveDirectoryConfigureEvent
-	63,  // 159: prehog.v1alpha.SubmitEventRequest.ui_discover_auto_discovered_resources_event:type_name -> prehog.v1alpha.UIDiscoverAutoDiscoveredResourcesEvent
-	68,  // 160: prehog.v1alpha.SubmitEventRequest.ui_discover_database_configure_iam_policy_event:type_name -> prehog.v1alpha.UIDiscoverDatabaseConfigureIAMPolicyEvent
-	69,  // 161: prehog.v1alpha.SubmitEventRequest.ui_discover_principals_configure_event:type_name -> prehog.v1alpha.UIDiscoverPrincipalsConfigureEvent
-	70,  // 162: prehog.v1alpha.SubmitEventRequest.ui_discover_test_connection_event:type_name -> prehog.v1alpha.UIDiscoverTestConnectionEvent
-	71,  // 163: prehog.v1alpha.SubmitEventRequest.ui_discover_completed_event:type_name -> prehog.v1alpha.UIDiscoverCompletedEvent
-	72,  // 164: prehog.v1alpha.SubmitEventRequest.role_create:type_name -> prehog.v1alpha.RoleCreateEvent
-	75,  // 165: prehog.v1alpha.SubmitEventRequest.ui_create_new_role_click:type_name -> prehog.v1alpha.UICreateNewRoleClickEvent
-	76,  // 166: prehog.v1alpha.SubmitEventRequest.ui_create_new_role_save_click:type_name -> prehog.v1alpha.UICreateNewRoleSaveClickEvent
-	77,  // 167: prehog.v1alpha.SubmitEventRequest.ui_create_new_role_cancel_click:type_name -> prehog.v1alpha.UICreateNewRoleCancelClickEvent
-	78,  // 168: prehog.v1alpha.SubmitEventRequest.ui_create_new_role_view_documentation_click:type_name -> prehog.v1alpha.UICreateNewRoleViewDocumentationClickEvent
-	80,  // 169: prehog.v1alpha.SubmitEventRequest.kube_request:type_name -> prehog.v1alpha.KubeRequestEvent
-	81,  // 170: prehog.v1alpha.SubmitEventRequest.sftp:type_name -> prehog.v1alpha.SFTPEvent
-	82,  // 171: prehog.v1alpha.SubmitEventRequest.agent_metadata_event:type_name -> prehog.v1alpha.AgentMetadataEvent
-	29,  // 172: prehog.v1alpha.SubmitEventRequest.resource_heartbeat:type_name -> prehog.v1alpha.ResourceHeartbeatEvent
-	54,  // 173: prehog.v1alpha.SubmitEventRequest.ui_discover_integration_aws_oidc_connect_event:type_name -> prehog.v1alpha.UIDiscoverIntegrationAWSOIDCConnectEvent
-	55,  // 174: prehog.v1alpha.SubmitEventRequest.ui_discover_database_rds_enroll_event:type_name -> prehog.v1alpha.UIDiscoverDatabaseRDSEnrollEvent
-	79,  // 175: prehog.v1alpha.SubmitEventRequest.ui_call_to_action_click_event:type_name -> prehog.v1alpha.UICallToActionClickEvent
-	83,  // 176: prehog.v1alpha.SubmitEventRequest.assist_completion:type_name -> prehog.v1alpha.AssistCompletionEvent
-	100, // 177: prehog.v1alpha.SubmitEventRequest.ui_integration_enroll_start_event:type_name -> prehog.v1alpha.UIIntegrationEnrollStartEvent
-	101, // 178: prehog.v1alpha.SubmitEventRequest.ui_integration_enroll_complete_event:type_name -> prehog.v1alpha.UIIntegrationEnrollCompleteEvent
-	108, // 179: prehog.v1alpha.SubmitEventRequest.editor_change_event:type_name -> prehog.v1alpha.EditorChangeEvent
-	73,  // 180: prehog.v1alpha.SubmitEventRequest.bot_create:type_name -> prehog.v1alpha.BotCreateEvent
-	45,  // 181: prehog.v1alpha.SubmitEventRequest.ui_onboard_questionnaire_submit:type_name -> prehog.v1alpha.UIOnboardQuestionnaireSubmitEvent
-	74,  // 182: prehog.v1alpha.SubmitEventRequest.bot_join:type_name -> prehog.v1alpha.BotJoinEvent
-	84,  // 183: prehog.v1alpha.SubmitEventRequest.assist_execution:type_name -> prehog.v1alpha.AssistExecutionEvent
-	85,  // 184: prehog.v1alpha.SubmitEventRequest.assist_new_conversation:type_name -> prehog.v1alpha.AssistNewConversationEvent
-	109, // 185: prehog.v1alpha.SubmitEventRequest.device_authenticate_event:type_name -> prehog.v1alpha.DeviceAuthenticateEvent
-	111, // 186: prehog.v1alpha.SubmitEventRequest.feature_recommendation_event:type_name -> prehog.v1alpha.FeatureRecommendationEvent
-	86,  // 187: prehog.v1alpha.SubmitEventRequest.assist_access_request:type_name -> prehog.v1alpha.AssistAccessRequestEvent
-	87,  // 188: prehog.v1alpha.SubmitEventRequest.assist_action:type_name -> prehog.v1alpha.AssistActionEvent
-	110, // 189: prehog.v1alpha.SubmitEventRequest.device_enroll_event:type_name -> prehog.v1alpha.DeviceEnrollEvent
-	112, // 190: prehog.v1alpha.SubmitEventRequest.license_limit_event:type_name -> prehog.v1alpha.LicenseLimitEvent
-	89,  // 191: prehog.v1alpha.SubmitEventRequest.access_list_create:type_name -> prehog.v1alpha.AccessListCreateEvent
-	90,  // 192: prehog.v1alpha.SubmitEventRequest.access_list_update:type_name -> prehog.v1alpha.AccessListUpdateEvent
-	91,  // 193: prehog.v1alpha.SubmitEventRequest.access_list_delete:type_name -> prehog.v1alpha.AccessListDeleteEvent
-	92,  // 194: prehog.v1alpha.SubmitEventRequest.access_list_member_create:type_name -> prehog.v1alpha.AccessListMemberCreateEvent
-	93,  // 195: prehog.v1alpha.SubmitEventRequest.access_list_member_update:type_name -> prehog.v1alpha.AccessListMemberUpdateEvent
-	94,  // 196: prehog.v1alpha.SubmitEventRequest.access_list_member_delete:type_name -> prehog.v1alpha.AccessListMemberDeleteEvent
-	95,  // 197: prehog.v1alpha.SubmitEventRequest.access_list_grants_to_user:type_name -> prehog.v1alpha.AccessListGrantsToUserEvent
-	64,  // 198: prehog.v1alpha.SubmitEventRequest.ui_discover_ec2_instance_selection:type_name -> prehog.v1alpha.UIDiscoverEC2InstanceSelectionEvent
-	65,  // 199: prehog.v1alpha.SubmitEventRequest.ui_discover_deploy_eice:type_name -> prehog.v1alpha.UIDiscoverDeployEICEEvent
-	66,  // 200: prehog.v1alpha.SubmitEventRequest.ui_discover_create_node:type_name -> prehog.v1alpha.UIDiscoverCreateNodeEvent
-	113, // 201: prehog.v1alpha.SubmitEventRequest.desktop_directory_share:type_name -> prehog.v1alpha.DesktopDirectoryShareEvent
-	114, // 202: prehog.v1alpha.SubmitEventRequest.desktop_clipboard_transfer:type_name -> prehog.v1alpha.DesktopClipboardEvent
-	115, // 203: prehog.v1alpha.SubmitEventRequest.tag_execute_query:type_name -> prehog.v1alpha.TAGExecuteQueryEvent
-	125, // 204: prehog.v1alpha.SubmitEventRequest.external_audit_storage_authenticate:type_name -> prehog.v1alpha.ExternalAuditStorageAuthenticateEvent
-	126, // 205: prehog.v1alpha.SubmitEventRequest.security_report_get_result:type_name -> prehog.v1alpha.SecurityReportGetResultEvent
-	127, // 206: prehog.v1alpha.SubmitEventRequest.audit_query_run:type_name -> prehog.v1alpha.AuditQueryRunEvent
-	128, // 207: prehog.v1alpha.SubmitEventRequest.discovery_fetch_event:type_name -> prehog.v1alpha.DiscoveryFetchEvent
-	96,  // 208: prehog.v1alpha.SubmitEventRequest.access_list_review_create:type_name -> prehog.v1alpha.AccessListReviewCreateEvent
-	97,  // 209: prehog.v1alpha.SubmitEventRequest.access_list_review_delete:type_name -> prehog.v1alpha.AccessListReviewDeleteEvent
-	98,  // 210: prehog.v1alpha.SubmitEventRequest.access_list_review_compliance:type_name -> prehog.v1alpha.AccessListReviewComplianceEvent
-	25,  // 211: prehog.v1alpha.SubmitEventRequest.mfa_authentication_event:type_name -> prehog.v1alpha.MFAAuthenticationEvent
-	38,  // 212: prehog.v1alpha.SubmitEventRequest.spiffe_svid_issued:type_name -> prehog.v1alpha.SPIFFESVIDIssuedEvent
-	129, // 213: prehog.v1alpha.SubmitEventRequest.okta_access_list_sync:type_name -> prehog.v1alpha.OktaAccessListSyncEvent
-	130, // 214: prehog.v1alpha.SubmitEventRequest.database_user_created:type_name -> prehog.v1alpha.DatabaseUserCreatedEvent
-	131, // 215: prehog.v1alpha.SubmitEventRequest.database_user_permissions_updated:type_name -> prehog.v1alpha.DatabaseUserPermissionsUpdateEvent
-	58,  // 216: prehog.v1alpha.SubmitEventRequest.ui_discover_create_discovery_config:type_name -> prehog.v1alpha.UIDiscoverCreateDiscoveryConfigEvent
-	56,  // 217: prehog.v1alpha.SubmitEventRequest.ui_discover_kube_eks_enroll_event:type_name -> prehog.v1alpha.UIDiscoverKubeEKSEnrollEvent
-	67,  // 218: prehog.v1alpha.SubmitEventRequest.ui_discover_create_app_server_event:type_name -> prehog.v1alpha.UIDiscoverCreateAppServerEvent
-	118, // 219: prehog.v1alpha.SubmitEventRequest.access_graph_gitlab_scan:type_name -> prehog.v1alpha.AccessGraphGitlabScanEvent
-	116, // 220: prehog.v1alpha.SubmitEventRequest.access_graph_secrets_scan_authorized_keys:type_name -> prehog.v1alpha.AccessGraphSecretsScanAuthorizedKeysEvent
-	117, // 221: prehog.v1alpha.SubmitEventRequest.access_graph_secrets_scan_ssh_private_keys:type_name -> prehog.v1alpha.AccessGraphSecretsScanSSHPrivateKeysEvent
-	119, // 222: prehog.v1alpha.SubmitEventRequest.access_graph_aws_scan:type_name -> prehog.v1alpha.AccessGraphAWSScanEvent
-	120, // 223: prehog.v1alpha.SubmitEventRequest.access_graph_access_path_changed:type_name -> prehog.v1alpha.AccessGraphAccessPathChangedEvent
-	124, // 224: prehog.v1alpha.SubmitEventRequest.access_graph_crown_jewel_create:type_name -> prehog.v1alpha.AccessGraphCrownJewelCreateEvent
-	121, // 225: prehog.v1alpha.SubmitEventRequest.ui_access_graph_crown_jewel_diff_view:type_name -> prehog.v1alpha.UIAccessGraphCrownJewelDiffViewEvent
-	132, // 226: prehog.v1alpha.SubmitEventRequest.session_recording_access:type_name -> prehog.v1alpha.SessionRecordingAccessEvent
-	133, // 227: prehog.v1alpha.SubmitEventRequest.user_task_state:type_name -> prehog.v1alpha.UserTaskStateEvent
-	103, // 228: prehog.v1alpha.SubmitEventRequest.ui_integration_enroll_step_event:type_name -> prehog.v1alpha.UIIntegrationEnrollStepEvent
-	134, // 229: prehog.v1alpha.SubmitEventRequest.access_request_create:type_name -> prehog.v1alpha.AccessRequestCreateEvent
-	135, // 230: prehog.v1alpha.SubmitEventRequest.access_request_review:type_name -> prehog.v1alpha.AccessRequestReviewEvent
-	104, // 231: prehog.v1alpha.SubmitEventRequest.ui_integration_enroll_section_open_event:type_name -> prehog.v1alpha.UIIntegrationEnrollSectionOpenEvent
-	105, // 232: prehog.v1alpha.SubmitEventRequest.ui_integration_enroll_field_complete_event:type_name -> prehog.v1alpha.UIIntegrationEnrollFieldCompleteEvent
-	106, // 233: prehog.v1alpha.SubmitEventRequest.ui_integration_enroll_code_copy_event:type_name -> prehog.v1alpha.UIIntegrationEnrollCodeCopyEvent
-	107, // 234: prehog.v1alpha.SubmitEventRequest.ui_integration_enroll_link_click_event:type_name -> prehog.v1alpha.UIIntegrationEnrollLinkClickEvent
-	137, // 235: prehog.v1alpha.SubmitEventRequest.session_summary_create_event:type_name -> prehog.v1alpha.SessionSummaryCreateEvent
-	136, // 236: prehog.v1alpha.SubmitEventRequest.session_summary_access_event:type_name -> prehog.v1alpha.SessionSummaryAccessEvent
-	139, // 237: prehog.v1alpha.SubmitEventRequest.discovery_config:type_name -> prehog.v1alpha.DiscoveryConfigEvent
-	140, // 238: prehog.v1alpha.SubmitEventRequest.identity_security_graph_size_event:type_name -> prehog.v1alpha.IdentitySecurityGraphSizeEvent
-	141, // 239: prehog.v1alpha.SubmitEventRequest.identity_security_audit_logs_ingested_event:type_name -> prehog.v1alpha.IdentitySecurityAuditLogsIngestedEvent
-	143, // 240: prehog.v1alpha.SubmitEventRequest.ui_access_list_define_access_event:type_name -> prehog.v1alpha.UIAccessListDefineAccessEvent
-	144, // 241: prehog.v1alpha.SubmitEventRequest.ui_access_list_define_identities_event:type_name -> prehog.v1alpha.UIAccessListDefineIdentitiesEvent
-	145, // 242: prehog.v1alpha.SubmitEventRequest.ui_access_list_define_basic_info_event:type_name -> prehog.v1alpha.UIAccessListDefineBasicInfoEvent
-	146, // 243: prehog.v1alpha.SubmitEventRequest.ui_access_list_define_members_event:type_name -> prehog.v1alpha.UIAccessListDefineMembersEvent
-	147, // 244: prehog.v1alpha.SubmitEventRequest.ui_access_list_define_owners_event:type_name -> prehog.v1alpha.UIAccessListDefineOwnersEvent
-	148, // 245: prehog.v1alpha.SubmitEventRequest.ui_access_list_start_event:type_name -> prehog.v1alpha.UIAccessListStartEvent
-	150, // 246: prehog.v1alpha.SubmitEventRequest.ui_access_list_complete_event:type_name -> prehog.v1alpha.UIAccessListCompleteEvent
-	151, // 247: prehog.v1alpha.SubmitEventRequest.ui_access_list_integrate_event:type_name -> prehog.v1alpha.UIAccessListIntegrateEvent
-	149, // 248: prehog.v1alpha.SubmitEventRequest.ui_access_list_custom_event:type_name -> prehog.v1alpha.UIAccessListCustomEvent
-	122, // 249: prehog.v1alpha.SubmitEventRequest.ui_page_view:type_name -> prehog.v1alpha.UIPageViewEvent
-	123, // 250: prehog.v1alpha.SubmitEventRequest.ui_usage_reporting_alert_cta_click:type_name -> prehog.v1alpha.UIUsageReportingAlertCtaClickEvent
-	138, // 251: prehog.v1alpha.SubmitEventRequest.session_summary_search_event:type_name -> prehog.v1alpha.SessionSummarySearchEvent
-	152, // 252: prehog.v1alpha.SubmitEventRequest.ui_interaction:type_name -> prehog.v1alpha.UIInteractionEvent
-	153, // 253: prehog.v1alpha.SubmitEventsRequest.events:type_name -> prehog.v1alpha.SubmitEventRequest
-	153, // 254: prehog.v1alpha.TeleportReportingService.SubmitEvent:input_type -> prehog.v1alpha.SubmitEventRequest
-	155, // 255: prehog.v1alpha.TeleportReportingService.SubmitEvents:input_type -> prehog.v1alpha.SubmitEventsRequest
-	157, // 256: prehog.v1alpha.TeleportReportingService.HelloTeleport:input_type -> prehog.v1alpha.HelloTeleportRequest
-	154, // 257: prehog.v1alpha.TeleportReportingService.SubmitEvent:output_type -> prehog.v1alpha.SubmitEventResponse
-	156, // 258: prehog.v1alpha.TeleportReportingService.SubmitEvents:output_type -> prehog.v1alpha.SubmitEventsResponse
-	158, // 259: prehog.v1alpha.TeleportReportingService.HelloTeleport:output_type -> prehog.v1alpha.HelloTeleportResponse
-	257, // [257:260] is the sub-list for method output_type
-	254, // [254:257] is the sub-list for method input_type
-	254, // [254:254] is the sub-list for extension type_name
-	254, // [254:254] is the sub-list for extension extendee
-	0,   // [0:254] is the sub-list for field type_name
+	34,  // 6: prehog.v1alpha.SessionStartEvent.app:type_name -> prehog.v1alpha.SessionStartAppMetadata
+	35,  // 7: prehog.v1alpha.SessionStartEvent.git:type_name -> prehog.v1alpha.SessionStartGitMetadata
+	36,  // 8: prehog.v1alpha.SessionStartEvent.mcp:type_name -> prehog.v1alpha.SessionStartMCPMetadata
+	37,  // 9: prehog.v1alpha.SessionStartEvent.beam:type_name -> prehog.v1alpha.SessionStartBeamMetadata
+	3,   // 10: prehog.v1alpha.BeamsDestroyedEvent.reason:type_name -> prehog.v1alpha.BeamDestroyReason
+	163, // 11: prehog.v1alpha.UserCertificateIssuedEvent.ttl:type_name -> google.protobuf.Duration
+	2,   // 12: prehog.v1alpha.SPIFFESVIDIssuedEvent.user_kind:type_name -> prehog.v1alpha.UserKind
+	4,   // 13: prehog.v1alpha.DiscoverResourceMetadata.resource:type_name -> prehog.v1alpha.DiscoverResource
+	5,   // 14: prehog.v1alpha.DiscoverStepStatus.status:type_name -> prehog.v1alpha.DiscoverStatus
+	52,  // 15: prehog.v1alpha.UIDiscoverStartedEvent.metadata:type_name -> prehog.v1alpha.DiscoverMetadata
+	54,  // 16: prehog.v1alpha.UIDiscoverStartedEvent.status:type_name -> prehog.v1alpha.DiscoverStepStatus
+	52,  // 17: prehog.v1alpha.UIDiscoverResourceSelectionEvent.metadata:type_name -> prehog.v1alpha.DiscoverMetadata
+	53,  // 18: prehog.v1alpha.UIDiscoverResourceSelectionEvent.resource:type_name -> prehog.v1alpha.DiscoverResourceMetadata
+	54,  // 19: prehog.v1alpha.UIDiscoverResourceSelectionEvent.status:type_name -> prehog.v1alpha.DiscoverStepStatus
+	52,  // 20: prehog.v1alpha.UIDiscoverIntegrationAWSOIDCConnectEvent.metadata:type_name -> prehog.v1alpha.DiscoverMetadata
+	53,  // 21: prehog.v1alpha.UIDiscoverIntegrationAWSOIDCConnectEvent.resource:type_name -> prehog.v1alpha.DiscoverResourceMetadata
+	54,  // 22: prehog.v1alpha.UIDiscoverIntegrationAWSOIDCConnectEvent.status:type_name -> prehog.v1alpha.DiscoverStepStatus
+	52,  // 23: prehog.v1alpha.UIDiscoverDatabaseRDSEnrollEvent.metadata:type_name -> prehog.v1alpha.DiscoverMetadata
+	53,  // 24: prehog.v1alpha.UIDiscoverDatabaseRDSEnrollEvent.resource:type_name -> prehog.v1alpha.DiscoverResourceMetadata
+	54,  // 25: prehog.v1alpha.UIDiscoverDatabaseRDSEnrollEvent.status:type_name -> prehog.v1alpha.DiscoverStepStatus
+	52,  // 26: prehog.v1alpha.UIDiscoverKubeEKSEnrollEvent.metadata:type_name -> prehog.v1alpha.DiscoverMetadata
+	53,  // 27: prehog.v1alpha.UIDiscoverKubeEKSEnrollEvent.resource:type_name -> prehog.v1alpha.DiscoverResourceMetadata
+	54,  // 28: prehog.v1alpha.UIDiscoverKubeEKSEnrollEvent.status:type_name -> prehog.v1alpha.DiscoverStepStatus
+	52,  // 29: prehog.v1alpha.UIDiscoverDeployServiceEvent.metadata:type_name -> prehog.v1alpha.DiscoverMetadata
+	53,  // 30: prehog.v1alpha.UIDiscoverDeployServiceEvent.resource:type_name -> prehog.v1alpha.DiscoverResourceMetadata
+	54,  // 31: prehog.v1alpha.UIDiscoverDeployServiceEvent.status:type_name -> prehog.v1alpha.DiscoverStepStatus
+	21,  // 32: prehog.v1alpha.UIDiscoverDeployServiceEvent.deploy_method:type_name -> prehog.v1alpha.UIDiscoverDeployServiceEvent.DeployMethod
+	22,  // 33: prehog.v1alpha.UIDiscoverDeployServiceEvent.deploy_type:type_name -> prehog.v1alpha.UIDiscoverDeployServiceEvent.DeployType
+	52,  // 34: prehog.v1alpha.UIDiscoverCreateDiscoveryConfigEvent.metadata:type_name -> prehog.v1alpha.DiscoverMetadata
+	53,  // 35: prehog.v1alpha.UIDiscoverCreateDiscoveryConfigEvent.resource:type_name -> prehog.v1alpha.DiscoverResourceMetadata
+	54,  // 36: prehog.v1alpha.UIDiscoverCreateDiscoveryConfigEvent.status:type_name -> prehog.v1alpha.DiscoverStepStatus
+	23,  // 37: prehog.v1alpha.UIDiscoverCreateDiscoveryConfigEvent.config_method:type_name -> prehog.v1alpha.UIDiscoverCreateDiscoveryConfigEvent.ConfigMethod
+	52,  // 38: prehog.v1alpha.UIDiscoverDatabaseRegisterEvent.metadata:type_name -> prehog.v1alpha.DiscoverMetadata
+	53,  // 39: prehog.v1alpha.UIDiscoverDatabaseRegisterEvent.resource:type_name -> prehog.v1alpha.DiscoverResourceMetadata
+	54,  // 40: prehog.v1alpha.UIDiscoverDatabaseRegisterEvent.status:type_name -> prehog.v1alpha.DiscoverStepStatus
+	52,  // 41: prehog.v1alpha.UIDiscoverDatabaseConfigureMTLSEvent.metadata:type_name -> prehog.v1alpha.DiscoverMetadata
+	53,  // 42: prehog.v1alpha.UIDiscoverDatabaseConfigureMTLSEvent.resource:type_name -> prehog.v1alpha.DiscoverResourceMetadata
+	54,  // 43: prehog.v1alpha.UIDiscoverDatabaseConfigureMTLSEvent.status:type_name -> prehog.v1alpha.DiscoverStepStatus
+	52,  // 44: prehog.v1alpha.UIDiscoverDesktopActiveDirectoryToolsInstallEvent.metadata:type_name -> prehog.v1alpha.DiscoverMetadata
+	53,  // 45: prehog.v1alpha.UIDiscoverDesktopActiveDirectoryToolsInstallEvent.resource:type_name -> prehog.v1alpha.DiscoverResourceMetadata
+	54,  // 46: prehog.v1alpha.UIDiscoverDesktopActiveDirectoryToolsInstallEvent.status:type_name -> prehog.v1alpha.DiscoverStepStatus
+	52,  // 47: prehog.v1alpha.UIDiscoverDesktopActiveDirectoryConfigureEvent.metadata:type_name -> prehog.v1alpha.DiscoverMetadata
+	53,  // 48: prehog.v1alpha.UIDiscoverDesktopActiveDirectoryConfigureEvent.resource:type_name -> prehog.v1alpha.DiscoverResourceMetadata
+	54,  // 49: prehog.v1alpha.UIDiscoverDesktopActiveDirectoryConfigureEvent.status:type_name -> prehog.v1alpha.DiscoverStepStatus
+	52,  // 50: prehog.v1alpha.UIDiscoverAutoDiscoveredResourcesEvent.metadata:type_name -> prehog.v1alpha.DiscoverMetadata
+	53,  // 51: prehog.v1alpha.UIDiscoverAutoDiscoveredResourcesEvent.resource:type_name -> prehog.v1alpha.DiscoverResourceMetadata
+	54,  // 52: prehog.v1alpha.UIDiscoverAutoDiscoveredResourcesEvent.status:type_name -> prehog.v1alpha.DiscoverStepStatus
+	52,  // 53: prehog.v1alpha.UIDiscoverEC2InstanceSelectionEvent.metadata:type_name -> prehog.v1alpha.DiscoverMetadata
+	53,  // 54: prehog.v1alpha.UIDiscoverEC2InstanceSelectionEvent.resource:type_name -> prehog.v1alpha.DiscoverResourceMetadata
+	54,  // 55: prehog.v1alpha.UIDiscoverEC2InstanceSelectionEvent.status:type_name -> prehog.v1alpha.DiscoverStepStatus
+	52,  // 56: prehog.v1alpha.UIDiscoverDeployEICEEvent.metadata:type_name -> prehog.v1alpha.DiscoverMetadata
+	53,  // 57: prehog.v1alpha.UIDiscoverDeployEICEEvent.resource:type_name -> prehog.v1alpha.DiscoverResourceMetadata
+	54,  // 58: prehog.v1alpha.UIDiscoverDeployEICEEvent.status:type_name -> prehog.v1alpha.DiscoverStepStatus
+	52,  // 59: prehog.v1alpha.UIDiscoverCreateNodeEvent.metadata:type_name -> prehog.v1alpha.DiscoverMetadata
+	53,  // 60: prehog.v1alpha.UIDiscoverCreateNodeEvent.resource:type_name -> prehog.v1alpha.DiscoverResourceMetadata
+	54,  // 61: prehog.v1alpha.UIDiscoverCreateNodeEvent.status:type_name -> prehog.v1alpha.DiscoverStepStatus
+	52,  // 62: prehog.v1alpha.UIDiscoverCreateAppServerEvent.metadata:type_name -> prehog.v1alpha.DiscoverMetadata
+	53,  // 63: prehog.v1alpha.UIDiscoverCreateAppServerEvent.resource:type_name -> prehog.v1alpha.DiscoverResourceMetadata
+	54,  // 64: prehog.v1alpha.UIDiscoverCreateAppServerEvent.status:type_name -> prehog.v1alpha.DiscoverStepStatus
+	52,  // 65: prehog.v1alpha.UIDiscoverDatabaseConfigureIAMPolicyEvent.metadata:type_name -> prehog.v1alpha.DiscoverMetadata
+	53,  // 66: prehog.v1alpha.UIDiscoverDatabaseConfigureIAMPolicyEvent.resource:type_name -> prehog.v1alpha.DiscoverResourceMetadata
+	54,  // 67: prehog.v1alpha.UIDiscoverDatabaseConfigureIAMPolicyEvent.status:type_name -> prehog.v1alpha.DiscoverStepStatus
+	52,  // 68: prehog.v1alpha.UIDiscoverPrincipalsConfigureEvent.metadata:type_name -> prehog.v1alpha.DiscoverMetadata
+	53,  // 69: prehog.v1alpha.UIDiscoverPrincipalsConfigureEvent.resource:type_name -> prehog.v1alpha.DiscoverResourceMetadata
+	54,  // 70: prehog.v1alpha.UIDiscoverPrincipalsConfigureEvent.status:type_name -> prehog.v1alpha.DiscoverStepStatus
+	52,  // 71: prehog.v1alpha.UIDiscoverTestConnectionEvent.metadata:type_name -> prehog.v1alpha.DiscoverMetadata
+	53,  // 72: prehog.v1alpha.UIDiscoverTestConnectionEvent.resource:type_name -> prehog.v1alpha.DiscoverResourceMetadata
+	54,  // 73: prehog.v1alpha.UIDiscoverTestConnectionEvent.status:type_name -> prehog.v1alpha.DiscoverStepStatus
+	52,  // 74: prehog.v1alpha.UIDiscoverCompletedEvent.metadata:type_name -> prehog.v1alpha.DiscoverMetadata
+	53,  // 75: prehog.v1alpha.UIDiscoverCompletedEvent.resource:type_name -> prehog.v1alpha.DiscoverResourceMetadata
+	54,  // 76: prehog.v1alpha.UIDiscoverCompletedEvent.status:type_name -> prehog.v1alpha.DiscoverStepStatus
+	6,   // 77: prehog.v1alpha.UICallToActionClickEvent.cta:type_name -> prehog.v1alpha.CTA
+	2,   // 78: prehog.v1alpha.KubeRequestEvent.user_kind:type_name -> prehog.v1alpha.UserKind
+	2,   // 79: prehog.v1alpha.SFTPEvent.user_kind:type_name -> prehog.v1alpha.UserKind
+	19,  // 80: prehog.v1alpha.AccessListMetadata.preset:type_name -> prehog.v1alpha.AccessListPreset
+	91,  // 81: prehog.v1alpha.AccessListCreateEvent.metadata:type_name -> prehog.v1alpha.AccessListMetadata
+	91,  // 82: prehog.v1alpha.AccessListUpdateEvent.metadata:type_name -> prehog.v1alpha.AccessListMetadata
+	91,  // 83: prehog.v1alpha.AccessListDeleteEvent.metadata:type_name -> prehog.v1alpha.AccessListMetadata
+	91,  // 84: prehog.v1alpha.AccessListMemberCreateEvent.metadata:type_name -> prehog.v1alpha.AccessListMetadata
+	91,  // 85: prehog.v1alpha.AccessListMemberUpdateEvent.metadata:type_name -> prehog.v1alpha.AccessListMetadata
+	91,  // 86: prehog.v1alpha.AccessListMemberDeleteEvent.metadata:type_name -> prehog.v1alpha.AccessListMetadata
+	91,  // 87: prehog.v1alpha.AccessListReviewCreateEvent.metadata:type_name -> prehog.v1alpha.AccessListMetadata
+	91,  // 88: prehog.v1alpha.AccessListReviewDeleteEvent.metadata:type_name -> prehog.v1alpha.AccessListMetadata
+	7,   // 89: prehog.v1alpha.IntegrationEnrollMetadata.kind:type_name -> prehog.v1alpha.IntegrationEnrollKind
+	102, // 90: prehog.v1alpha.UIIntegrationEnrollStartEvent.metadata:type_name -> prehog.v1alpha.IntegrationEnrollMetadata
+	102, // 91: prehog.v1alpha.UIIntegrationEnrollCompleteEvent.metadata:type_name -> prehog.v1alpha.IntegrationEnrollMetadata
+	9,   // 92: prehog.v1alpha.IntegrationEnrollStepStatus.code:type_name -> prehog.v1alpha.IntegrationEnrollStatusCode
+	102, // 93: prehog.v1alpha.UIIntegrationEnrollStepEvent.metadata:type_name -> prehog.v1alpha.IntegrationEnrollMetadata
+	8,   // 94: prehog.v1alpha.UIIntegrationEnrollStepEvent.step:type_name -> prehog.v1alpha.IntegrationEnrollStep
+	105, // 95: prehog.v1alpha.UIIntegrationEnrollStepEvent.status:type_name -> prehog.v1alpha.IntegrationEnrollStepStatus
+	102, // 96: prehog.v1alpha.UIIntegrationEnrollSectionOpenEvent.metadata:type_name -> prehog.v1alpha.IntegrationEnrollMetadata
+	8,   // 97: prehog.v1alpha.UIIntegrationEnrollSectionOpenEvent.step:type_name -> prehog.v1alpha.IntegrationEnrollStep
+	10,  // 98: prehog.v1alpha.UIIntegrationEnrollSectionOpenEvent.section:type_name -> prehog.v1alpha.IntegrationEnrollSection
+	102, // 99: prehog.v1alpha.UIIntegrationEnrollFieldCompleteEvent.metadata:type_name -> prehog.v1alpha.IntegrationEnrollMetadata
+	8,   // 100: prehog.v1alpha.UIIntegrationEnrollFieldCompleteEvent.step:type_name -> prehog.v1alpha.IntegrationEnrollStep
+	11,  // 101: prehog.v1alpha.UIIntegrationEnrollFieldCompleteEvent.field:type_name -> prehog.v1alpha.IntegrationEnrollField
+	102, // 102: prehog.v1alpha.UIIntegrationEnrollCodeCopyEvent.metadata:type_name -> prehog.v1alpha.IntegrationEnrollMetadata
+	8,   // 103: prehog.v1alpha.UIIntegrationEnrollCodeCopyEvent.step:type_name -> prehog.v1alpha.IntegrationEnrollStep
+	12,  // 104: prehog.v1alpha.UIIntegrationEnrollCodeCopyEvent.type:type_name -> prehog.v1alpha.IntegrationEnrollCodeType
+	102, // 105: prehog.v1alpha.UIIntegrationEnrollLinkClickEvent.metadata:type_name -> prehog.v1alpha.IntegrationEnrollMetadata
+	8,   // 106: prehog.v1alpha.UIIntegrationEnrollLinkClickEvent.step:type_name -> prehog.v1alpha.IntegrationEnrollStep
+	13,  // 107: prehog.v1alpha.EditorChangeEvent.status:type_name -> prehog.v1alpha.EditorChangeStatus
+	14,  // 108: prehog.v1alpha.FeatureRecommendationEvent.feature:type_name -> prehog.v1alpha.Feature
+	15,  // 109: prehog.v1alpha.FeatureRecommendationEvent.feature_recommendation_status:type_name -> prehog.v1alpha.FeatureRecommendationStatus
+	16,  // 110: prehog.v1alpha.LicenseLimitEvent.license_limit:type_name -> prehog.v1alpha.LicenseLimit
+	32,  // 111: prehog.v1alpha.DatabaseUserCreatedEvent.database:type_name -> prehog.v1alpha.SessionStartDatabaseMetadata
+	32,  // 112: prehog.v1alpha.DatabaseUserPermissionsUpdateEvent.database:type_name -> prehog.v1alpha.SessionStartDatabaseMetadata
+	24,  // 113: prehog.v1alpha.AccessRequestReviewEvent.proposed_state:type_name -> prehog.v1alpha.AccessRequestReviewEvent.ProposedState
+	2,   // 114: prehog.v1alpha.SessionSummaryAccessEvent.user_kind:type_name -> prehog.v1alpha.UserKind
+	2,   // 115: prehog.v1alpha.SessionSummarySearchEvent.user_kind:type_name -> prehog.v1alpha.UserKind
+	17,  // 116: prehog.v1alpha.DiscoveryConfigEvent.action:type_name -> prehog.v1alpha.DiscoveryConfigAction
+	18,  // 117: prehog.v1alpha.AccessListStepStatus.status:type_name -> prehog.v1alpha.AccessListStatus
+	91,  // 118: prehog.v1alpha.UIAccessListDefineAccessEvent.metadata:type_name -> prehog.v1alpha.AccessListMetadata
+	145, // 119: prehog.v1alpha.UIAccessListDefineAccessEvent.status:type_name -> prehog.v1alpha.AccessListStepStatus
+	91,  // 120: prehog.v1alpha.UIAccessListDefineIdentitiesEvent.metadata:type_name -> prehog.v1alpha.AccessListMetadata
+	145, // 121: prehog.v1alpha.UIAccessListDefineIdentitiesEvent.status:type_name -> prehog.v1alpha.AccessListStepStatus
+	91,  // 122: prehog.v1alpha.UIAccessListDefineBasicInfoEvent.metadata:type_name -> prehog.v1alpha.AccessListMetadata
+	145, // 123: prehog.v1alpha.UIAccessListDefineBasicInfoEvent.status:type_name -> prehog.v1alpha.AccessListStepStatus
+	91,  // 124: prehog.v1alpha.UIAccessListDefineMembersEvent.metadata:type_name -> prehog.v1alpha.AccessListMetadata
+	145, // 125: prehog.v1alpha.UIAccessListDefineMembersEvent.status:type_name -> prehog.v1alpha.AccessListStepStatus
+	91,  // 126: prehog.v1alpha.UIAccessListDefineOwnersEvent.metadata:type_name -> prehog.v1alpha.AccessListMetadata
+	145, // 127: prehog.v1alpha.UIAccessListDefineOwnersEvent.status:type_name -> prehog.v1alpha.AccessListStepStatus
+	91,  // 128: prehog.v1alpha.UIAccessListStartEvent.metadata:type_name -> prehog.v1alpha.AccessListMetadata
+	145, // 129: prehog.v1alpha.UIAccessListStartEvent.status:type_name -> prehog.v1alpha.AccessListStepStatus
+	91,  // 130: prehog.v1alpha.UIAccessListCustomEvent.metadata:type_name -> prehog.v1alpha.AccessListMetadata
+	145, // 131: prehog.v1alpha.UIAccessListCustomEvent.status:type_name -> prehog.v1alpha.AccessListStepStatus
+	91,  // 132: prehog.v1alpha.UIAccessListCompleteEvent.metadata:type_name -> prehog.v1alpha.AccessListMetadata
+	145, // 133: prehog.v1alpha.UIAccessListCompleteEvent.status:type_name -> prehog.v1alpha.AccessListStepStatus
+	91,  // 134: prehog.v1alpha.UIAccessListIntegrateEvent.metadata:type_name -> prehog.v1alpha.AccessListMetadata
+	20,  // 135: prehog.v1alpha.UIAccessListIntegrateEvent.integrate:type_name -> prehog.v1alpha.AccessListIntegrate
+	162, // 136: prehog.v1alpha.UIInteractionEvent.params:type_name -> prehog.v1alpha.UIInteractionEvent.ParamsEntry
+	164, // 137: prehog.v1alpha.SubmitEventRequest.timestamp:type_name -> google.protobuf.Timestamp
+	25,  // 138: prehog.v1alpha.SubmitEventRequest.user_login:type_name -> prehog.v1alpha.UserLoginEvent
+	27,  // 139: prehog.v1alpha.SubmitEventRequest.sso_create:type_name -> prehog.v1alpha.SSOCreateEvent
+	28,  // 140: prehog.v1alpha.SubmitEventRequest.resource_create:type_name -> prehog.v1alpha.ResourceCreateEvent
+	31,  // 141: prehog.v1alpha.SubmitEventRequest.session_start:type_name -> prehog.v1alpha.SessionStartEvent
+	42,  // 142: prehog.v1alpha.SubmitEventRequest.ui_banner_click:type_name -> prehog.v1alpha.UIBannerClickEvent
+	43,  // 143: prehog.v1alpha.SubmitEventRequest.ui_onboard_complete_go_to_dashboard_click:type_name -> prehog.v1alpha.UIOnboardCompleteGoToDashboardClickEvent
+	44,  // 144: prehog.v1alpha.SubmitEventRequest.ui_onboard_add_first_resource_click:type_name -> prehog.v1alpha.UIOnboardAddFirstResourceClickEvent
+	45,  // 145: prehog.v1alpha.SubmitEventRequest.ui_onboard_add_first_resource_later_click:type_name -> prehog.v1alpha.UIOnboardAddFirstResourceLaterClickEvent
+	46,  // 146: prehog.v1alpha.SubmitEventRequest.ui_onboard_set_credential_submit:type_name -> prehog.v1alpha.UIOnboardSetCredentialSubmitEvent
+	47,  // 147: prehog.v1alpha.SubmitEventRequest.ui_onboard_register_challenge_submit:type_name -> prehog.v1alpha.UIOnboardRegisterChallengeSubmitEvent
+	49,  // 148: prehog.v1alpha.SubmitEventRequest.ui_recovery_codes_continue_click:type_name -> prehog.v1alpha.UIRecoveryCodesContinueClickEvent
+	50,  // 149: prehog.v1alpha.SubmitEventRequest.ui_recovery_codes_copy_click:type_name -> prehog.v1alpha.UIRecoveryCodesCopyClickEvent
+	51,  // 150: prehog.v1alpha.SubmitEventRequest.ui_recovery_codes_print_click:type_name -> prehog.v1alpha.UIRecoveryCodesPrintClickEvent
+	55,  // 151: prehog.v1alpha.SubmitEventRequest.ui_discover_started_event:type_name -> prehog.v1alpha.UIDiscoverStartedEvent
+	56,  // 152: prehog.v1alpha.SubmitEventRequest.ui_discover_resource_selection_event:type_name -> prehog.v1alpha.UIDiscoverResourceSelectionEvent
+	40,  // 153: prehog.v1alpha.SubmitEventRequest.user_certificate_issued_event:type_name -> prehog.v1alpha.UserCertificateIssuedEvent
+	31,  // 154: prehog.v1alpha.SubmitEventRequest.session_start_v2:type_name -> prehog.v1alpha.SessionStartEvent
+	60,  // 155: prehog.v1alpha.SubmitEventRequest.ui_discover_deploy_service_event:type_name -> prehog.v1alpha.UIDiscoverDeployServiceEvent
+	62,  // 156: prehog.v1alpha.SubmitEventRequest.ui_discover_database_register_event:type_name -> prehog.v1alpha.UIDiscoverDatabaseRegisterEvent
+	63,  // 157: prehog.v1alpha.SubmitEventRequest.ui_discover_database_configure_mtls_event:type_name -> prehog.v1alpha.UIDiscoverDatabaseConfigureMTLSEvent
+	64,  // 158: prehog.v1alpha.SubmitEventRequest.ui_discover_desktop_active_directory_tools_install_event:type_name -> prehog.v1alpha.UIDiscoverDesktopActiveDirectoryToolsInstallEvent
+	65,  // 159: prehog.v1alpha.SubmitEventRequest.ui_discover_desktop_active_directory_configure_event:type_name -> prehog.v1alpha.UIDiscoverDesktopActiveDirectoryConfigureEvent
+	66,  // 160: prehog.v1alpha.SubmitEventRequest.ui_discover_auto_discovered_resources_event:type_name -> prehog.v1alpha.UIDiscoverAutoDiscoveredResourcesEvent
+	71,  // 161: prehog.v1alpha.SubmitEventRequest.ui_discover_database_configure_iam_policy_event:type_name -> prehog.v1alpha.UIDiscoverDatabaseConfigureIAMPolicyEvent
+	72,  // 162: prehog.v1alpha.SubmitEventRequest.ui_discover_principals_configure_event:type_name -> prehog.v1alpha.UIDiscoverPrincipalsConfigureEvent
+	73,  // 163: prehog.v1alpha.SubmitEventRequest.ui_discover_test_connection_event:type_name -> prehog.v1alpha.UIDiscoverTestConnectionEvent
+	74,  // 164: prehog.v1alpha.SubmitEventRequest.ui_discover_completed_event:type_name -> prehog.v1alpha.UIDiscoverCompletedEvent
+	75,  // 165: prehog.v1alpha.SubmitEventRequest.role_create:type_name -> prehog.v1alpha.RoleCreateEvent
+	78,  // 166: prehog.v1alpha.SubmitEventRequest.ui_create_new_role_click:type_name -> prehog.v1alpha.UICreateNewRoleClickEvent
+	79,  // 167: prehog.v1alpha.SubmitEventRequest.ui_create_new_role_save_click:type_name -> prehog.v1alpha.UICreateNewRoleSaveClickEvent
+	80,  // 168: prehog.v1alpha.SubmitEventRequest.ui_create_new_role_cancel_click:type_name -> prehog.v1alpha.UICreateNewRoleCancelClickEvent
+	81,  // 169: prehog.v1alpha.SubmitEventRequest.ui_create_new_role_view_documentation_click:type_name -> prehog.v1alpha.UICreateNewRoleViewDocumentationClickEvent
+	83,  // 170: prehog.v1alpha.SubmitEventRequest.kube_request:type_name -> prehog.v1alpha.KubeRequestEvent
+	84,  // 171: prehog.v1alpha.SubmitEventRequest.sftp:type_name -> prehog.v1alpha.SFTPEvent
+	85,  // 172: prehog.v1alpha.SubmitEventRequest.agent_metadata_event:type_name -> prehog.v1alpha.AgentMetadataEvent
+	30,  // 173: prehog.v1alpha.SubmitEventRequest.resource_heartbeat:type_name -> prehog.v1alpha.ResourceHeartbeatEvent
+	57,  // 174: prehog.v1alpha.SubmitEventRequest.ui_discover_integration_aws_oidc_connect_event:type_name -> prehog.v1alpha.UIDiscoverIntegrationAWSOIDCConnectEvent
+	58,  // 175: prehog.v1alpha.SubmitEventRequest.ui_discover_database_rds_enroll_event:type_name -> prehog.v1alpha.UIDiscoverDatabaseRDSEnrollEvent
+	82,  // 176: prehog.v1alpha.SubmitEventRequest.ui_call_to_action_click_event:type_name -> prehog.v1alpha.UICallToActionClickEvent
+	86,  // 177: prehog.v1alpha.SubmitEventRequest.assist_completion:type_name -> prehog.v1alpha.AssistCompletionEvent
+	103, // 178: prehog.v1alpha.SubmitEventRequest.ui_integration_enroll_start_event:type_name -> prehog.v1alpha.UIIntegrationEnrollStartEvent
+	104, // 179: prehog.v1alpha.SubmitEventRequest.ui_integration_enroll_complete_event:type_name -> prehog.v1alpha.UIIntegrationEnrollCompleteEvent
+	111, // 180: prehog.v1alpha.SubmitEventRequest.editor_change_event:type_name -> prehog.v1alpha.EditorChangeEvent
+	76,  // 181: prehog.v1alpha.SubmitEventRequest.bot_create:type_name -> prehog.v1alpha.BotCreateEvent
+	48,  // 182: prehog.v1alpha.SubmitEventRequest.ui_onboard_questionnaire_submit:type_name -> prehog.v1alpha.UIOnboardQuestionnaireSubmitEvent
+	77,  // 183: prehog.v1alpha.SubmitEventRequest.bot_join:type_name -> prehog.v1alpha.BotJoinEvent
+	87,  // 184: prehog.v1alpha.SubmitEventRequest.assist_execution:type_name -> prehog.v1alpha.AssistExecutionEvent
+	88,  // 185: prehog.v1alpha.SubmitEventRequest.assist_new_conversation:type_name -> prehog.v1alpha.AssistNewConversationEvent
+	112, // 186: prehog.v1alpha.SubmitEventRequest.device_authenticate_event:type_name -> prehog.v1alpha.DeviceAuthenticateEvent
+	114, // 187: prehog.v1alpha.SubmitEventRequest.feature_recommendation_event:type_name -> prehog.v1alpha.FeatureRecommendationEvent
+	89,  // 188: prehog.v1alpha.SubmitEventRequest.assist_access_request:type_name -> prehog.v1alpha.AssistAccessRequestEvent
+	90,  // 189: prehog.v1alpha.SubmitEventRequest.assist_action:type_name -> prehog.v1alpha.AssistActionEvent
+	113, // 190: prehog.v1alpha.SubmitEventRequest.device_enroll_event:type_name -> prehog.v1alpha.DeviceEnrollEvent
+	115, // 191: prehog.v1alpha.SubmitEventRequest.license_limit_event:type_name -> prehog.v1alpha.LicenseLimitEvent
+	92,  // 192: prehog.v1alpha.SubmitEventRequest.access_list_create:type_name -> prehog.v1alpha.AccessListCreateEvent
+	93,  // 193: prehog.v1alpha.SubmitEventRequest.access_list_update:type_name -> prehog.v1alpha.AccessListUpdateEvent
+	94,  // 194: prehog.v1alpha.SubmitEventRequest.access_list_delete:type_name -> prehog.v1alpha.AccessListDeleteEvent
+	95,  // 195: prehog.v1alpha.SubmitEventRequest.access_list_member_create:type_name -> prehog.v1alpha.AccessListMemberCreateEvent
+	96,  // 196: prehog.v1alpha.SubmitEventRequest.access_list_member_update:type_name -> prehog.v1alpha.AccessListMemberUpdateEvent
+	97,  // 197: prehog.v1alpha.SubmitEventRequest.access_list_member_delete:type_name -> prehog.v1alpha.AccessListMemberDeleteEvent
+	98,  // 198: prehog.v1alpha.SubmitEventRequest.access_list_grants_to_user:type_name -> prehog.v1alpha.AccessListGrantsToUserEvent
+	67,  // 199: prehog.v1alpha.SubmitEventRequest.ui_discover_ec2_instance_selection:type_name -> prehog.v1alpha.UIDiscoverEC2InstanceSelectionEvent
+	68,  // 200: prehog.v1alpha.SubmitEventRequest.ui_discover_deploy_eice:type_name -> prehog.v1alpha.UIDiscoverDeployEICEEvent
+	69,  // 201: prehog.v1alpha.SubmitEventRequest.ui_discover_create_node:type_name -> prehog.v1alpha.UIDiscoverCreateNodeEvent
+	116, // 202: prehog.v1alpha.SubmitEventRequest.desktop_directory_share:type_name -> prehog.v1alpha.DesktopDirectoryShareEvent
+	117, // 203: prehog.v1alpha.SubmitEventRequest.desktop_clipboard_transfer:type_name -> prehog.v1alpha.DesktopClipboardEvent
+	118, // 204: prehog.v1alpha.SubmitEventRequest.tag_execute_query:type_name -> prehog.v1alpha.TAGExecuteQueryEvent
+	128, // 205: prehog.v1alpha.SubmitEventRequest.external_audit_storage_authenticate:type_name -> prehog.v1alpha.ExternalAuditStorageAuthenticateEvent
+	129, // 206: prehog.v1alpha.SubmitEventRequest.security_report_get_result:type_name -> prehog.v1alpha.SecurityReportGetResultEvent
+	130, // 207: prehog.v1alpha.SubmitEventRequest.audit_query_run:type_name -> prehog.v1alpha.AuditQueryRunEvent
+	131, // 208: prehog.v1alpha.SubmitEventRequest.discovery_fetch_event:type_name -> prehog.v1alpha.DiscoveryFetchEvent
+	99,  // 209: prehog.v1alpha.SubmitEventRequest.access_list_review_create:type_name -> prehog.v1alpha.AccessListReviewCreateEvent
+	100, // 210: prehog.v1alpha.SubmitEventRequest.access_list_review_delete:type_name -> prehog.v1alpha.AccessListReviewDeleteEvent
+	101, // 211: prehog.v1alpha.SubmitEventRequest.access_list_review_compliance:type_name -> prehog.v1alpha.AccessListReviewComplianceEvent
+	26,  // 212: prehog.v1alpha.SubmitEventRequest.mfa_authentication_event:type_name -> prehog.v1alpha.MFAAuthenticationEvent
+	41,  // 213: prehog.v1alpha.SubmitEventRequest.spiffe_svid_issued:type_name -> prehog.v1alpha.SPIFFESVIDIssuedEvent
+	132, // 214: prehog.v1alpha.SubmitEventRequest.okta_access_list_sync:type_name -> prehog.v1alpha.OktaAccessListSyncEvent
+	133, // 215: prehog.v1alpha.SubmitEventRequest.database_user_created:type_name -> prehog.v1alpha.DatabaseUserCreatedEvent
+	134, // 216: prehog.v1alpha.SubmitEventRequest.database_user_permissions_updated:type_name -> prehog.v1alpha.DatabaseUserPermissionsUpdateEvent
+	61,  // 217: prehog.v1alpha.SubmitEventRequest.ui_discover_create_discovery_config:type_name -> prehog.v1alpha.UIDiscoverCreateDiscoveryConfigEvent
+	59,  // 218: prehog.v1alpha.SubmitEventRequest.ui_discover_kube_eks_enroll_event:type_name -> prehog.v1alpha.UIDiscoverKubeEKSEnrollEvent
+	70,  // 219: prehog.v1alpha.SubmitEventRequest.ui_discover_create_app_server_event:type_name -> prehog.v1alpha.UIDiscoverCreateAppServerEvent
+	121, // 220: prehog.v1alpha.SubmitEventRequest.access_graph_gitlab_scan:type_name -> prehog.v1alpha.AccessGraphGitlabScanEvent
+	119, // 221: prehog.v1alpha.SubmitEventRequest.access_graph_secrets_scan_authorized_keys:type_name -> prehog.v1alpha.AccessGraphSecretsScanAuthorizedKeysEvent
+	120, // 222: prehog.v1alpha.SubmitEventRequest.access_graph_secrets_scan_ssh_private_keys:type_name -> prehog.v1alpha.AccessGraphSecretsScanSSHPrivateKeysEvent
+	122, // 223: prehog.v1alpha.SubmitEventRequest.access_graph_aws_scan:type_name -> prehog.v1alpha.AccessGraphAWSScanEvent
+	123, // 224: prehog.v1alpha.SubmitEventRequest.access_graph_access_path_changed:type_name -> prehog.v1alpha.AccessGraphAccessPathChangedEvent
+	127, // 225: prehog.v1alpha.SubmitEventRequest.access_graph_crown_jewel_create:type_name -> prehog.v1alpha.AccessGraphCrownJewelCreateEvent
+	124, // 226: prehog.v1alpha.SubmitEventRequest.ui_access_graph_crown_jewel_diff_view:type_name -> prehog.v1alpha.UIAccessGraphCrownJewelDiffViewEvent
+	135, // 227: prehog.v1alpha.SubmitEventRequest.session_recording_access:type_name -> prehog.v1alpha.SessionRecordingAccessEvent
+	136, // 228: prehog.v1alpha.SubmitEventRequest.user_task_state:type_name -> prehog.v1alpha.UserTaskStateEvent
+	106, // 229: prehog.v1alpha.SubmitEventRequest.ui_integration_enroll_step_event:type_name -> prehog.v1alpha.UIIntegrationEnrollStepEvent
+	137, // 230: prehog.v1alpha.SubmitEventRequest.access_request_create:type_name -> prehog.v1alpha.AccessRequestCreateEvent
+	138, // 231: prehog.v1alpha.SubmitEventRequest.access_request_review:type_name -> prehog.v1alpha.AccessRequestReviewEvent
+	107, // 232: prehog.v1alpha.SubmitEventRequest.ui_integration_enroll_section_open_event:type_name -> prehog.v1alpha.UIIntegrationEnrollSectionOpenEvent
+	108, // 233: prehog.v1alpha.SubmitEventRequest.ui_integration_enroll_field_complete_event:type_name -> prehog.v1alpha.UIIntegrationEnrollFieldCompleteEvent
+	109, // 234: prehog.v1alpha.SubmitEventRequest.ui_integration_enroll_code_copy_event:type_name -> prehog.v1alpha.UIIntegrationEnrollCodeCopyEvent
+	110, // 235: prehog.v1alpha.SubmitEventRequest.ui_integration_enroll_link_click_event:type_name -> prehog.v1alpha.UIIntegrationEnrollLinkClickEvent
+	140, // 236: prehog.v1alpha.SubmitEventRequest.session_summary_create_event:type_name -> prehog.v1alpha.SessionSummaryCreateEvent
+	139, // 237: prehog.v1alpha.SubmitEventRequest.session_summary_access_event:type_name -> prehog.v1alpha.SessionSummaryAccessEvent
+	142, // 238: prehog.v1alpha.SubmitEventRequest.discovery_config:type_name -> prehog.v1alpha.DiscoveryConfigEvent
+	143, // 239: prehog.v1alpha.SubmitEventRequest.identity_security_graph_size_event:type_name -> prehog.v1alpha.IdentitySecurityGraphSizeEvent
+	144, // 240: prehog.v1alpha.SubmitEventRequest.identity_security_audit_logs_ingested_event:type_name -> prehog.v1alpha.IdentitySecurityAuditLogsIngestedEvent
+	146, // 241: prehog.v1alpha.SubmitEventRequest.ui_access_list_define_access_event:type_name -> prehog.v1alpha.UIAccessListDefineAccessEvent
+	147, // 242: prehog.v1alpha.SubmitEventRequest.ui_access_list_define_identities_event:type_name -> prehog.v1alpha.UIAccessListDefineIdentitiesEvent
+	148, // 243: prehog.v1alpha.SubmitEventRequest.ui_access_list_define_basic_info_event:type_name -> prehog.v1alpha.UIAccessListDefineBasicInfoEvent
+	149, // 244: prehog.v1alpha.SubmitEventRequest.ui_access_list_define_members_event:type_name -> prehog.v1alpha.UIAccessListDefineMembersEvent
+	150, // 245: prehog.v1alpha.SubmitEventRequest.ui_access_list_define_owners_event:type_name -> prehog.v1alpha.UIAccessListDefineOwnersEvent
+	151, // 246: prehog.v1alpha.SubmitEventRequest.ui_access_list_start_event:type_name -> prehog.v1alpha.UIAccessListStartEvent
+	153, // 247: prehog.v1alpha.SubmitEventRequest.ui_access_list_complete_event:type_name -> prehog.v1alpha.UIAccessListCompleteEvent
+	154, // 248: prehog.v1alpha.SubmitEventRequest.ui_access_list_integrate_event:type_name -> prehog.v1alpha.UIAccessListIntegrateEvent
+	152, // 249: prehog.v1alpha.SubmitEventRequest.ui_access_list_custom_event:type_name -> prehog.v1alpha.UIAccessListCustomEvent
+	125, // 250: prehog.v1alpha.SubmitEventRequest.ui_page_view:type_name -> prehog.v1alpha.UIPageViewEvent
+	126, // 251: prehog.v1alpha.SubmitEventRequest.ui_usage_reporting_alert_cta_click:type_name -> prehog.v1alpha.UIUsageReportingAlertCtaClickEvent
+	141, // 252: prehog.v1alpha.SubmitEventRequest.session_summary_search_event:type_name -> prehog.v1alpha.SessionSummarySearchEvent
+	155, // 253: prehog.v1alpha.SubmitEventRequest.ui_interaction:type_name -> prehog.v1alpha.UIInteractionEvent
+	38,  // 254: prehog.v1alpha.SubmitEventRequest.beams_created:type_name -> prehog.v1alpha.BeamsCreatedEvent
+	39,  // 255: prehog.v1alpha.SubmitEventRequest.beams_destroyed:type_name -> prehog.v1alpha.BeamsDestroyedEvent
+	156, // 256: prehog.v1alpha.SubmitEventsRequest.events:type_name -> prehog.v1alpha.SubmitEventRequest
+	156, // 257: prehog.v1alpha.TeleportReportingService.SubmitEvent:input_type -> prehog.v1alpha.SubmitEventRequest
+	158, // 258: prehog.v1alpha.TeleportReportingService.SubmitEvents:input_type -> prehog.v1alpha.SubmitEventsRequest
+	160, // 259: prehog.v1alpha.TeleportReportingService.HelloTeleport:input_type -> prehog.v1alpha.HelloTeleportRequest
+	157, // 260: prehog.v1alpha.TeleportReportingService.SubmitEvent:output_type -> prehog.v1alpha.SubmitEventResponse
+	159, // 261: prehog.v1alpha.TeleportReportingService.SubmitEvents:output_type -> prehog.v1alpha.SubmitEventsResponse
+	161, // 262: prehog.v1alpha.TeleportReportingService.HelloTeleport:output_type -> prehog.v1alpha.HelloTeleportResponse
+	260, // [260:263] is the sub-list for method output_type
+	257, // [257:260] is the sub-list for method input_type
+	257, // [257:257] is the sub-list for extension type_name
+	257, // [257:257] is the sub-list for extension extendee
+	0,   // [0:257] is the sub-list for field type_name
 }
 
 func init() { file_prehog_v1alpha_teleport_proto_init() }
@@ -13925,7 +14173,7 @@ func file_prehog_v1alpha_teleport_proto_init() {
 	if File_prehog_v1alpha_teleport_proto != nil {
 		return
 	}
-	file_prehog_v1alpha_teleport_proto_msgTypes[129].OneofWrappers = []any{
+	file_prehog_v1alpha_teleport_proto_msgTypes[131].OneofWrappers = []any{
 		(*SubmitEventRequest_UserLogin)(nil),
 		(*SubmitEventRequest_SsoCreate)(nil),
 		(*SubmitEventRequest_ResourceCreate)(nil),
@@ -14042,14 +14290,16 @@ func file_prehog_v1alpha_teleport_proto_init() {
 		(*SubmitEventRequest_UiUsageReportingAlertCtaClick)(nil),
 		(*SubmitEventRequest_SessionSummarySearchEvent)(nil),
 		(*SubmitEventRequest_UiInteraction)(nil),
+		(*SubmitEventRequest_BeamsCreated)(nil),
+		(*SubmitEventRequest_BeamsDestroyed)(nil),
 	}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_prehog_v1alpha_teleport_proto_rawDesc), len(file_prehog_v1alpha_teleport_proto_rawDesc)),
-			NumEnums:      24,
-			NumMessages:   136,
+			NumEnums:      25,
+			NumMessages:   138,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/gen/proto/ts/prehog/v1alpha/teleport_pb.ts
+++ b/gen/proto/ts/prehog/v1alpha/teleport_pb.ts
@@ -481,6 +481,72 @@ export interface SessionStartBeamMetadata {
     beamId: string;
 }
 /**
+ * BeamsCreatedEvent is emitted when a beam VM is created and becomes ready.
+ *
+ * PostHog event: tp.beams.created
+ *
+ * @generated from protobuf message prehog.v1alpha.BeamsCreatedEvent
+ */
+export interface BeamsCreatedEvent {
+    /**
+     * anonymized beam ID
+     *
+     * PostHog property: tp.beam.beam_id
+     *
+     * @generated from protobuf field: string beam_id = 1;
+     */
+    beamId: string;
+    /**
+     * the region where the beam was created
+     *
+     * PostHog property: tp.beam.region
+     *
+     * @generated from protobuf field: string region = 2;
+     */
+    region: string;
+    /**
+     * time in milliseconds from CreateBeam call to VM ready
+     *
+     * PostHog property: tp.beam.startup_duration_ms
+     *
+     * @generated from protobuf field: int64 startup_duration_ms = 3;
+     */
+    startupDurationMs: bigint;
+}
+/**
+ * BeamsDestroyedEvent is emitted when a beam VM is destroyed.
+ *
+ * PostHog event: tp.beams.destroyed
+ *
+ * @generated from protobuf message prehog.v1alpha.BeamsDestroyedEvent
+ */
+export interface BeamsDestroyedEvent {
+    /**
+     * anonymized beam ID
+     *
+     * PostHog property: tp.beam.beam_id
+     *
+     * @generated from protobuf field: string beam_id = 1;
+     */
+    beamId: string;
+    /**
+     * the reason the beam was destroyed
+     *
+     * PostHog property: tp.beam.destroy_reason
+     *
+     * @generated from protobuf field: prehog.v1alpha.BeamDestroyReason reason = 2;
+     */
+    reason: BeamDestroyReason;
+    /**
+     * the region where the beam was running
+     *
+     * PostHog property: tp.beam.region
+     *
+     * @generated from protobuf field: string region = 3;
+     */
+    region: string;
+}
+/**
  * the issuance of a user certificate from the user CA
  *
  * PostHog event: tp.certificate.issued
@@ -4366,6 +4432,18 @@ export interface SubmitEventRequest {
          */
         uiInteraction: UIInteractionEvent;
     } | {
+        oneofKind: "beamsCreated";
+        /**
+         * @generated from protobuf field: prehog.v1alpha.BeamsCreatedEvent beams_created = 123;
+         */
+        beamsCreated: BeamsCreatedEvent;
+    } | {
+        oneofKind: "beamsDestroyed";
+        /**
+         * @generated from protobuf field: prehog.v1alpha.BeamsDestroyedEvent beams_destroyed = 124;
+         */
+        beamsDestroyed: BeamsDestroyedEvent;
+    } | {
         oneofKind: undefined;
     };
 }
@@ -4550,6 +4628,29 @@ export enum UserKind {
      * @generated from protobuf enum value: USER_KIND_SYSTEM = 3;
      */
     SYSTEM = 3
+}
+/**
+ * BeamDestroyReason is the reason a beam was destroyed.
+ *
+ * @generated from protobuf enum prehog.v1alpha.BeamDestroyReason
+ */
+export enum BeamDestroyReason {
+    /**
+     * @generated from protobuf enum value: BEAM_DESTROY_REASON_UNSPECIFIED = 0;
+     */
+    UNSPECIFIED = 0,
+    /**
+     * the user explicitly deleted the beam
+     *
+     * @generated from protobuf enum value: BEAM_DESTROY_REASON_USER_DELETED = 1;
+     */
+    USER_DELETED = 1,
+    /**
+     * the beam was deleted by the garbage collector after expiry
+     *
+     * @generated from protobuf enum value: BEAM_DESTROY_REASON_GC_EXPIRED = 2;
+     */
+    GC_EXPIRED = 2
 }
 /**
  * DiscoverResource represents a resource type.
@@ -6279,6 +6380,132 @@ class SessionStartBeamMetadata$Type extends MessageType<SessionStartBeamMetadata
  * @generated MessageType for protobuf message prehog.v1alpha.SessionStartBeamMetadata
  */
 export const SessionStartBeamMetadata = new SessionStartBeamMetadata$Type();
+// @generated message type with reflection information, may provide speed optimized methods
+class BeamsCreatedEvent$Type extends MessageType<BeamsCreatedEvent> {
+    constructor() {
+        super("prehog.v1alpha.BeamsCreatedEvent", [
+            { no: 1, name: "beam_id", kind: "scalar", T: 9 /*ScalarType.STRING*/ },
+            { no: 2, name: "region", kind: "scalar", T: 9 /*ScalarType.STRING*/ },
+            { no: 3, name: "startup_duration_ms", kind: "scalar", T: 3 /*ScalarType.INT64*/, L: 0 /*LongType.BIGINT*/ }
+        ]);
+    }
+    create(value?: PartialMessage<BeamsCreatedEvent>): BeamsCreatedEvent {
+        const message = globalThis.Object.create((this.messagePrototype!));
+        message.beamId = "";
+        message.region = "";
+        message.startupDurationMs = 0n;
+        if (value !== undefined)
+            reflectionMergePartial<BeamsCreatedEvent>(this, message, value);
+        return message;
+    }
+    internalBinaryRead(reader: IBinaryReader, length: number, options: BinaryReadOptions, target?: BeamsCreatedEvent): BeamsCreatedEvent {
+        let message = target ?? this.create(), end = reader.pos + length;
+        while (reader.pos < end) {
+            let [fieldNo, wireType] = reader.tag();
+            switch (fieldNo) {
+                case /* string beam_id */ 1:
+                    message.beamId = reader.string();
+                    break;
+                case /* string region */ 2:
+                    message.region = reader.string();
+                    break;
+                case /* int64 startup_duration_ms */ 3:
+                    message.startupDurationMs = reader.int64().toBigInt();
+                    break;
+                default:
+                    let u = options.readUnknownField;
+                    if (u === "throw")
+                        throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
+                    let d = reader.skip(wireType);
+                    if (u !== false)
+                        (u === true ? UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            }
+        }
+        return message;
+    }
+    internalBinaryWrite(message: BeamsCreatedEvent, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
+        /* string beam_id = 1; */
+        if (message.beamId !== "")
+            writer.tag(1, WireType.LengthDelimited).string(message.beamId);
+        /* string region = 2; */
+        if (message.region !== "")
+            writer.tag(2, WireType.LengthDelimited).string(message.region);
+        /* int64 startup_duration_ms = 3; */
+        if (message.startupDurationMs !== 0n)
+            writer.tag(3, WireType.Varint).int64(message.startupDurationMs);
+        let u = options.writeUnknownFields;
+        if (u !== false)
+            (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+        return writer;
+    }
+}
+/**
+ * @generated MessageType for protobuf message prehog.v1alpha.BeamsCreatedEvent
+ */
+export const BeamsCreatedEvent = new BeamsCreatedEvent$Type();
+// @generated message type with reflection information, may provide speed optimized methods
+class BeamsDestroyedEvent$Type extends MessageType<BeamsDestroyedEvent> {
+    constructor() {
+        super("prehog.v1alpha.BeamsDestroyedEvent", [
+            { no: 1, name: "beam_id", kind: "scalar", T: 9 /*ScalarType.STRING*/ },
+            { no: 2, name: "reason", kind: "enum", T: () => ["prehog.v1alpha.BeamDestroyReason", BeamDestroyReason, "BEAM_DESTROY_REASON_"] },
+            { no: 3, name: "region", kind: "scalar", T: 9 /*ScalarType.STRING*/ }
+        ]);
+    }
+    create(value?: PartialMessage<BeamsDestroyedEvent>): BeamsDestroyedEvent {
+        const message = globalThis.Object.create((this.messagePrototype!));
+        message.beamId = "";
+        message.reason = 0;
+        message.region = "";
+        if (value !== undefined)
+            reflectionMergePartial<BeamsDestroyedEvent>(this, message, value);
+        return message;
+    }
+    internalBinaryRead(reader: IBinaryReader, length: number, options: BinaryReadOptions, target?: BeamsDestroyedEvent): BeamsDestroyedEvent {
+        let message = target ?? this.create(), end = reader.pos + length;
+        while (reader.pos < end) {
+            let [fieldNo, wireType] = reader.tag();
+            switch (fieldNo) {
+                case /* string beam_id */ 1:
+                    message.beamId = reader.string();
+                    break;
+                case /* prehog.v1alpha.BeamDestroyReason reason */ 2:
+                    message.reason = reader.int32();
+                    break;
+                case /* string region */ 3:
+                    message.region = reader.string();
+                    break;
+                default:
+                    let u = options.readUnknownField;
+                    if (u === "throw")
+                        throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
+                    let d = reader.skip(wireType);
+                    if (u !== false)
+                        (u === true ? UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            }
+        }
+        return message;
+    }
+    internalBinaryWrite(message: BeamsDestroyedEvent, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
+        /* string beam_id = 1; */
+        if (message.beamId !== "")
+            writer.tag(1, WireType.LengthDelimited).string(message.beamId);
+        /* prehog.v1alpha.BeamDestroyReason reason = 2; */
+        if (message.reason !== 0)
+            writer.tag(2, WireType.Varint).int32(message.reason);
+        /* string region = 3; */
+        if (message.region !== "")
+            writer.tag(3, WireType.LengthDelimited).string(message.region);
+        let u = options.writeUnknownFields;
+        if (u !== false)
+            (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+        return writer;
+    }
+}
+/**
+ * @generated MessageType for protobuf message prehog.v1alpha.BeamsDestroyedEvent
+ */
+export const BeamsDestroyedEvent = new BeamsDestroyedEvent$Type();
 // @generated message type with reflection information, may provide speed optimized methods
 class UserCertificateIssuedEvent$Type extends MessageType<UserCertificateIssuedEvent> {
     constructor() {
@@ -13690,7 +13917,9 @@ class SubmitEventRequest$Type extends MessageType<SubmitEventRequest> {
             { no: 119, name: "ui_page_view", kind: "message", oneof: "event", T: () => UIPageViewEvent },
             { no: 120, name: "ui_usage_reporting_alert_cta_click", kind: "message", oneof: "event", T: () => UIUsageReportingAlertCtaClickEvent },
             { no: 121, name: "session_summary_search_event", kind: "message", oneof: "event", T: () => SessionSummarySearchEvent },
-            { no: 122, name: "ui_interaction", kind: "message", oneof: "event", T: () => UIInteractionEvent }
+            { no: 122, name: "ui_interaction", kind: "message", oneof: "event", T: () => UIInteractionEvent },
+            { no: 123, name: "beams_created", kind: "message", oneof: "event", T: () => BeamsCreatedEvent },
+            { no: 124, name: "beams_destroyed", kind: "message", oneof: "event", T: () => BeamsDestroyedEvent }
         ]);
     }
     create(value?: PartialMessage<SubmitEventRequest>): SubmitEventRequest {
@@ -14412,6 +14641,18 @@ class SubmitEventRequest$Type extends MessageType<SubmitEventRequest> {
                         uiInteraction: UIInteractionEvent.internalBinaryRead(reader, reader.uint32(), options, (message.event as any).uiInteraction)
                     };
                     break;
+                case /* prehog.v1alpha.BeamsCreatedEvent beams_created */ 123:
+                    message.event = {
+                        oneofKind: "beamsCreated",
+                        beamsCreated: BeamsCreatedEvent.internalBinaryRead(reader, reader.uint32(), options, (message.event as any).beamsCreated)
+                    };
+                    break;
+                case /* prehog.v1alpha.BeamsDestroyedEvent beams_destroyed */ 124:
+                    message.event = {
+                        oneofKind: "beamsDestroyed",
+                        beamsDestroyed: BeamsDestroyedEvent.internalBinaryRead(reader, reader.uint32(), options, (message.event as any).beamsDestroyed)
+                    };
+                    break;
                 default:
                     let u = options.readUnknownField;
                     if (u === "throw")
@@ -14781,6 +15022,12 @@ class SubmitEventRequest$Type extends MessageType<SubmitEventRequest> {
         /* prehog.v1alpha.UIInteractionEvent ui_interaction = 122; */
         if (message.event.oneofKind === "uiInteraction")
             UIInteractionEvent.internalBinaryWrite(message.event.uiInteraction, writer.tag(122, WireType.LengthDelimited).fork(), options).join();
+        /* prehog.v1alpha.BeamsCreatedEvent beams_created = 123; */
+        if (message.event.oneofKind === "beamsCreated")
+            BeamsCreatedEvent.internalBinaryWrite(message.event.beamsCreated, writer.tag(123, WireType.LengthDelimited).fork(), options).join();
+        /* prehog.v1alpha.BeamsDestroyedEvent beams_destroyed = 124; */
+        if (message.event.oneofKind === "beamsDestroyed")
+            BeamsDestroyedEvent.internalBinaryWrite(message.event.beamsDestroyed, writer.tag(124, WireType.LengthDelimited).fork(), options).join();
         let u = options.writeUnknownFields;
         if (u !== false)
             (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);

--- a/lib/usagereporter/teleport/types.go
+++ b/lib/usagereporter/teleport/types.go
@@ -2348,3 +2348,35 @@ func (e *IdentitySecurityAuditLogsIngestedEvent) Anonymize(a utils.Anonymizer) *
 		},
 	}
 }
+
+// BeamsCreatedEvent is emitted when a beam VM is created and becomes ready.
+type BeamsCreatedEvent prehogv1a.BeamsCreatedEvent
+
+// Anonymize anonymizes the event.
+func (e *BeamsCreatedEvent) Anonymize(a utils.Anonymizer) *prehogv1a.SubmitEventRequest {
+	return &prehogv1a.SubmitEventRequest{
+		Event: &prehogv1a.SubmitEventRequest_BeamsCreated{
+			BeamsCreated: &prehogv1a.BeamsCreatedEvent{
+				BeamId:            a.AnonymizeString(e.BeamId),
+				Region:            e.Region,
+				StartupDurationMs: e.StartupDurationMs,
+			},
+		},
+	}
+}
+
+// BeamsDestroyedEvent is emitted when a beam VM is destroyed.
+type BeamsDestroyedEvent prehogv1a.BeamsDestroyedEvent
+
+// Anonymize anonymizes the event.
+func (e *BeamsDestroyedEvent) Anonymize(a utils.Anonymizer) *prehogv1a.SubmitEventRequest {
+	return &prehogv1a.SubmitEventRequest{
+		Event: &prehogv1a.SubmitEventRequest_BeamsDestroyed{
+			BeamsDestroyed: &prehogv1a.BeamsDestroyedEvent{
+				BeamId: a.AnonymizeString(e.BeamId),
+				Reason: e.Reason,
+				Region: e.Region,
+			},
+		},
+	}
+}

--- a/proto/prehog/v1alpha/teleport.proto
+++ b/proto/prehog/v1alpha/teleport.proto
@@ -342,6 +342,55 @@ message SessionStartBeamMetadata {
   string beam_id = 1;
 }
 
+// BeamsCreatedEvent is emitted when a beam VM is created and becomes ready.
+//
+// PostHog event: tp.beams.created
+message BeamsCreatedEvent {
+  // anonymized beam ID
+  //
+  // PostHog property: tp.beam.beam_id
+  string beam_id = 1;
+
+  // the region where the beam was created
+  //
+  // PostHog property: tp.beam.region
+  string region = 2;
+
+  // time in milliseconds from CreateBeam call to VM ready
+  //
+  // PostHog property: tp.beam.startup_duration_ms
+  int64 startup_duration_ms = 3;
+}
+
+// BeamDestroyReason is the reason a beam was destroyed.
+enum BeamDestroyReason {
+  BEAM_DESTROY_REASON_UNSPECIFIED = 0;
+  // the user explicitly deleted the beam
+  BEAM_DESTROY_REASON_USER_DELETED = 1;
+  // the beam was deleted by the garbage collector after expiry
+  BEAM_DESTROY_REASON_GC_EXPIRED = 2;
+}
+
+// BeamsDestroyedEvent is emitted when a beam VM is destroyed.
+//
+// PostHog event: tp.beams.destroyed
+message BeamsDestroyedEvent {
+  // anonymized beam ID
+  //
+  // PostHog property: tp.beam.beam_id
+  string beam_id = 1;
+
+  // the reason the beam was destroyed
+  //
+  // PostHog property: tp.beam.destroy_reason
+  BeamDestroyReason reason = 2;
+
+  // the region where the beam was running
+  //
+  // PostHog property: tp.beam.region
+  string region = 3;
+}
+
 // the issuance of a user certificate from the user CA
 //
 // PostHog event: tp.certificate.issued
@@ -2307,6 +2356,9 @@ message SubmitEventRequest {
 
     SessionSummarySearchEvent session_summary_search_event = 121;
     UIInteractionEvent ui_interaction = 122;
+
+    BeamsCreatedEvent beams_created = 123;
+    BeamsDestroyedEvent beams_destroyed = 124;
   }
 
   reserved 8; // UIOnboardGetStartedClickEvent


### PR DESCRIPTION
Add BeamCreate and BeamDestroy usage events


https://github.com/gravitational/teleport.e/pull/8931

https://github.com/gravitational/cloud/pull/17773
https://github.com/gravitational/cloud/pull/17792


Add BeamCreate and BeamDestroy usage events


https://github.com/gravitational/teleport.e/pull/8931/

https://github.com/gravitational/cloud/pull/17773
https://github.com/gravitational/cloud/pull/17792


## Manual Test Plan
### Test Environment
dev/orange 

### Test Cases

#### test - orange 🟧 

- [x] patch tenant with this and https://github.com/gravitational/teleport.e/pull/8931/
- [x] create and destroy a beam on a beam tenant
- [x] create and destroy beam events should end up in s3
- [x] destroy beam event ends up in redshift
- [x] beam id matches the beam id in the session create event

```
 aws s3api select-object-content \
    --bucket tc-dev-orange-management-prehog-events \
    --key "v1/event_date=2026-06-10/event_type=tp.beams.destroyed/019eb335-bf1b-7eba-ad44-4d143f9a342a.parquet" \
    --expression "SELECT * FROM S3Object" \
    --expression-type SQL \
    --input-serialization '{"Parquet":{}}' \
    --output-serialization '{"JSON":{}}' \
    /dev/stdout \
    --profile tc-dev-orange --region us-west-2 | jq '.event_data | fromjson | .properties'
{
  "tp.account_id": "c46e9e7d-fc4b-4aac-8ccd-9c4d86c01811",
  "tp.beam.beam_id": "GhAiSSk+voDQCIcpL0PdhjoSSa2SNI7WtTOjYUwXvm8=",
  "tp.cluster_name": "HXDzOCrA7G/w7rn0km2cf58IYLO0+Rc913QzQgHmp70=",
  "tp.is_cloud": true,
  "tp.license_authority": "localhost",
  "tp.license_name": "68ec4881-92f7-4682-80a8-556185db7529",
  "tp.teleport_version": "19.0.0-prealpha.2"
}
```

All three events share the same beam_id and session.start has session_type=beam. 

- tp.beams.created beam_id ✅
- tp.beams.destroyed same beam_id ✅
- tp.session.start.v2same beam_id, session_type=beam ✅
- tp.beam.destroy_reason: BEAM_DESTROY_REASON_USER_DELETED ✅
- tp.beam.region: us-west-2 ✅

figure out beam time by subtracting, destroy time - create time :
```sql
SELECT
      c.tp_beam_beam_id AS beam_id,
      c.account_id,
      c.event_time AS created_at,
      d.event_time AS destroyed_at,
      datediff('minute', c.event_time, d.event_time) AS uptime_minutes
  FROM analytics.event c
  JOIN analytics.event d
      ON c.tp_beam_beam_id = d.tp_beam_beam_id
      AND c.account_id = d.account_id
  WHERE c.event_name = 'tp.beams.created'
    AND d.event_name = 'tp.beams.destroyed'
  ORDER BY c.event_time DESC;
```

