### PR TITLE
[v18] scoped agent pins

### DIFF
--- a/api/gen/proto/go/teleport/scopes/v1/scopes.pb.go
+++ b/api/gen/proto/go/teleport/scopes/v1/scopes.pb.go
@@ -36,6 +36,56 @@ const (
 	_ = protoimpl.EnforceVersion(protoimpl.MaxVersion - 20)
 )
 
+// PinKind expresses the kind of scope pin associated with a certificate/identity. User (and bot) certificates are kind USER,
+// while agent certificates are kind AGENT. The pin kind determines whether the privileges associated with an identity are
+// derived from scoped user roles (USER) or from system roles (AGENT).
+type PinKind int32
+
+const (
+	// PIN_KIND_UNSPECIFIED indicates that no pin kind has been specified.
+	PinKind_PIN_KIND_UNSPECIFIED PinKind = 0
+	// PIN_KIND_USER indicates that the pin is associated with a user certificate/identity.
+	PinKind_PIN_KIND_USER PinKind = 1
+	// PIN_KIND_AGENT indicates that the pin is associated with an agent certificate/identity.
+	PinKind_PIN_KIND_AGENT PinKind = 2
+)
+
+// Enum value maps for PinKind.
+var (
+	PinKind_name = map[int32]string{
+		0: "PIN_KIND_UNSPECIFIED",
+		1: "PIN_KIND_USER",
+		2: "PIN_KIND_AGENT",
+	}
+	PinKind_value = map[string]int32{
+		"PIN_KIND_UNSPECIFIED": 0,
+		"PIN_KIND_USER":        1,
+		"PIN_KIND_AGENT":       2,
+	}
+)
+
+func (x PinKind) Enum() *PinKind {
+	p := new(PinKind)
+	*p = x
+	return p
+}
+
+func (x PinKind) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (PinKind) Descriptor() protoreflect.EnumDescriptor {
+	return file_teleport_scopes_v1_scopes_proto_enumTypes[0].Descriptor()
+}
+
+func (PinKind) Type() protoreflect.EnumType {
+	return &file_teleport_scopes_v1_scopes_proto_enumTypes[0]
+}
+
+func (x PinKind) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
 // Mode determines the mode of scoping when a query specifies a scope. When a query specifies a scope,
 // one of two questions is typically trying to be answered.  Either, what resources are "in" and/or "subject to"
 // a given scope, or what policies are "applicable to" a given scope.
@@ -81,11 +131,11 @@ func (x Mode) String() string {
 }
 
 func (Mode) Descriptor() protoreflect.EnumDescriptor {
-	return file_teleport_scopes_v1_scopes_proto_enumTypes[0].Descriptor()
+	return file_teleport_scopes_v1_scopes_proto_enumTypes[1].Descriptor()
 }
 
 func (Mode) Type() protoreflect.EnumType {
-	return &file_teleport_scopes_v1_scopes_proto_enumTypes[0]
+	return &file_teleport_scopes_v1_scopes_proto_enumTypes[1]
 }
 
 func (x Mode) Number() protoreflect.EnumNumber {
@@ -100,17 +150,17 @@ type Pin struct {
 	// pinned to. Any resources in parent/orthogonal scopes are not necessarily subject to the privileges/policies
 	// conveyed by this pin.
 	Scope string `protobuf:"bytes,1,opt,name=scope,proto3" json:"scope,omitempty"`
-	// assignments encodes the scoped role assignments relevant to access-control decisions about the pinned identity. This may
-	// include assignments to parents of the pinned scope as well as assignments to equivalent/child scopes. Effectively, this
-	// means all assignments that are not orthogonal to the pinned scope.
-	//
-	// Deprecated: Marked as deprecated in teleport/scopes/v1/scopes.proto.
-	Assignments map[string]*PinnedAssignments `protobuf:"bytes,2,rep,name=assignments,proto3" json:"assignments,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	// kind indicates the pin kind (USER or AGENT). Pin kind determines whether this identity's privileges are conveyed
+	// via scoped user roles or system roles (note: bots use USER kind pins, rather than a separate BOT kind).
+	Kind PinKind `protobuf:"varint,4,opt,name=kind,proto3,enum=teleport.scopes.v1.PinKind" json:"kind,omitempty"`
 	// assignment_tree encodes the full tree of scoped privilege assignments, organized by *Scope of Origin*. Policies/privileges
-	// assigned from higher scopes of origin take precedence over those assigned from lower scopes of origin.
+	// assigned from higher scopes of origin take precedence over those assigned from lower scopes of origin. Only specified
+	// for USER kind pins.
 	AssignmentTree *AssignmentNode `protobuf:"bytes,3,opt,name=assignment_tree,json=assignmentTree,proto3" json:"assignment_tree,omitempty"`
-	unknownFields  protoimpl.UnknownFields
-	sizeCache      protoimpl.SizeCache
+	// system_roles encodes the system roles held by the pinned identity. Only specified for AGENT kind pins.
+	SystemRoles   *SystemRoles `protobuf:"bytes,5,opt,name=system_roles,json=systemRoles,proto3" json:"system_roles,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
 }
 
 func (x *Pin) Reset() {
@@ -145,12 +195,11 @@ func (x *Pin) GetScope() string {
 	return ""
 }
 
-// Deprecated: Marked as deprecated in teleport/scopes/v1/scopes.proto.
-func (x *Pin) GetAssignments() map[string]*PinnedAssignments {
+func (x *Pin) GetKind() PinKind {
 	if x != nil {
-		return x.Assignments
+		return x.Kind
 	}
-	return nil
+	return PinKind_PIN_KIND_UNSPECIFIED
 }
 
 func (x *Pin) GetAssignmentTree() *AssignmentNode {
@@ -160,17 +209,27 @@ func (x *Pin) GetAssignmentTree() *AssignmentNode {
 	return nil
 }
 
+func (x *Pin) GetSystemRoles() *SystemRoles {
+	if x != nil {
+		return x.SystemRoles
+	}
+	return nil
+}
+
 func (x *Pin) SetScope(v string) {
 	x.Scope = v
 }
 
-// Deprecated: Marked as deprecated in teleport/scopes/v1/scopes.proto.
-func (x *Pin) SetAssignments(v map[string]*PinnedAssignments) {
-	x.Assignments = v
+func (x *Pin) SetKind(v PinKind) {
+	x.Kind = v
 }
 
 func (x *Pin) SetAssignmentTree(v *AssignmentNode) {
 	x.AssignmentTree = v
+}
+
+func (x *Pin) SetSystemRoles(v *SystemRoles) {
+	x.SystemRoles = v
 }
 
 func (x *Pin) HasAssignmentTree() bool {
@@ -180,8 +239,19 @@ func (x *Pin) HasAssignmentTree() bool {
 	return x.AssignmentTree != nil
 }
 
+func (x *Pin) HasSystemRoles() bool {
+	if x == nil {
+		return false
+	}
+	return x.SystemRoles != nil
+}
+
 func (x *Pin) ClearAssignmentTree() {
 	x.AssignmentTree = nil
+}
+
+func (x *Pin) ClearSystemRoles() {
+	x.SystemRoles = nil
 }
 
 type Pin_builder struct {
@@ -191,15 +261,15 @@ type Pin_builder struct {
 	// pinned to. Any resources in parent/orthogonal scopes are not necessarily subject to the privileges/policies
 	// conveyed by this pin.
 	Scope string
-	// assignments encodes the scoped role assignments relevant to access-control decisions about the pinned identity. This may
-	// include assignments to parents of the pinned scope as well as assignments to equivalent/child scopes. Effectively, this
-	// means all assignments that are not orthogonal to the pinned scope.
-	//
-	// Deprecated: Marked as deprecated in teleport/scopes/v1/scopes.proto.
-	Assignments map[string]*PinnedAssignments
+	// kind indicates the pin kind (USER or AGENT). Pin kind determines whether this identity's privileges are conveyed
+	// via scoped user roles or system roles (note: bots use USER kind pins, rather than a separate BOT kind).
+	Kind PinKind
 	// assignment_tree encodes the full tree of scoped privilege assignments, organized by *Scope of Origin*. Policies/privileges
-	// assigned from higher scopes of origin take precedence over those assigned from lower scopes of origin.
+	// assigned from higher scopes of origin take precedence over those assigned from lower scopes of origin. Only specified
+	// for USER kind pins.
 	AssignmentTree *AssignmentNode
+	// system_roles encodes the system roles held by the pinned identity. Only specified for AGENT kind pins.
+	SystemRoles *SystemRoles
 }
 
 func (b0 Pin_builder) Build() *Pin {
@@ -207,8 +277,9 @@ func (b0 Pin_builder) Build() *Pin {
 	b, x := &b0, m0
 	_, _ = b, x
 	x.Scope = b.Scope
-	x.Assignments = b.Assignments
+	x.Kind = b.Kind
 	x.AssignmentTree = b.AssignmentTree
+	x.SystemRoles = b.SystemRoles
 	return m0
 }
 
@@ -438,6 +509,86 @@ func (b0 PinnedAssignments_builder) Build() *PinnedAssignments {
 	return m0
 }
 
+// SystemRoles is a collection of system roles held by an agent identity.
+type SystemRoles struct {
+	state protoimpl.MessageState `protogen:"hybrid.v1"`
+	// primary is the primary system role associated with the certificate. For per-service agent certificates, this will
+	// be an ordinary system role (e.g. "Node") and the additional system roles will be empty. If the primary is "Instance"
+	// then the additional system roles will contain all system roles held by the agent.
+	Primary string `protobuf:"bytes,1,opt,name=primary,proto3" json:"primary,omitempty"`
+	// additional is the list of all system roles held by the agent identity. Only populated for "Instance" certificates.
+	Additional    []string `protobuf:"bytes,2,rep,name=additional,proto3" json:"additional,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *SystemRoles) Reset() {
+	*x = SystemRoles{}
+	mi := &file_teleport_scopes_v1_scopes_proto_msgTypes[4]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *SystemRoles) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*SystemRoles) ProtoMessage() {}
+
+func (x *SystemRoles) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_scopes_v1_scopes_proto_msgTypes[4]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+func (x *SystemRoles) GetPrimary() string {
+	if x != nil {
+		return x.Primary
+	}
+	return ""
+}
+
+func (x *SystemRoles) GetAdditional() []string {
+	if x != nil {
+		return x.Additional
+	}
+	return nil
+}
+
+func (x *SystemRoles) SetPrimary(v string) {
+	x.Primary = v
+}
+
+func (x *SystemRoles) SetAdditional(v []string) {
+	x.Additional = v
+}
+
+type SystemRoles_builder struct {
+	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
+
+	// primary is the primary system role associated with the certificate. For per-service agent certificates, this will
+	// be an ordinary system role (e.g. "Node") and the additional system roles will be empty. If the primary is "Instance"
+	// then the additional system roles will contain all system roles held by the agent.
+	Primary string
+	// additional is the list of all system roles held by the agent identity. Only populated for "Instance" certificates.
+	Additional []string
+}
+
+func (b0 SystemRoles_builder) Build() *SystemRoles {
+	m0 := &SystemRoles{}
+	b, x := &b0, m0
+	_, _ = b, x
+	x.Primary = b.Primary
+	x.Additional = b.Additional
+	return m0
+}
+
 // Filter is a query parameter that matches other scopes based on a specified scope and mode. Used for
 // filtering resources that are subject to or policies that apply to a given scope.
 type Filter struct {
@@ -452,7 +603,7 @@ type Filter struct {
 
 func (x *Filter) Reset() {
 	*x = Filter{}
-	mi := &file_teleport_scopes_v1_scopes_proto_msgTypes[4]
+	mi := &file_teleport_scopes_v1_scopes_proto_msgTypes[5]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -464,7 +615,7 @@ func (x *Filter) String() string {
 func (*Filter) ProtoMessage() {}
 
 func (x *Filter) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_scopes_v1_scopes_proto_msgTypes[4]
+	mi := &file_teleport_scopes_v1_scopes_proto_msgTypes[5]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -519,14 +670,12 @@ var File_teleport_scopes_v1_scopes_proto protoreflect.FileDescriptor
 
 const file_teleport_scopes_v1_scopes_proto_rawDesc = "" +
 	"\n" +
-	"\x1fteleport/scopes/v1/scopes.proto\x12\x12teleport.scopes.v1\"\x9f\x02\n" +
+	"\x1fteleport/scopes/v1/scopes.proto\x12\x12teleport.scopes.v1\"\xf0\x01\n" +
 	"\x03Pin\x12\x14\n" +
-	"\x05scope\x18\x01 \x01(\tR\x05scope\x12N\n" +
-	"\vassignments\x18\x02 \x03(\v2(.teleport.scopes.v1.Pin.AssignmentsEntryB\x02\x18\x01R\vassignments\x12K\n" +
-	"\x0fassignment_tree\x18\x03 \x01(\v2\".teleport.scopes.v1.AssignmentNodeR\x0eassignmentTree\x1ae\n" +
-	"\x10AssignmentsEntry\x12\x10\n" +
-	"\x03key\x18\x01 \x01(\tR\x03key\x12;\n" +
-	"\x05value\x18\x02 \x01(\v2%.teleport.scopes.v1.PinnedAssignmentsR\x05value:\x028\x01\"\xfa\x01\n" +
+	"\x05scope\x18\x01 \x01(\tR\x05scope\x12/\n" +
+	"\x04kind\x18\x04 \x01(\x0e2\x1b.teleport.scopes.v1.PinKindR\x04kind\x12K\n" +
+	"\x0fassignment_tree\x18\x03 \x01(\v2\".teleport.scopes.v1.AssignmentNodeR\x0eassignmentTree\x12B\n" +
+	"\fsystem_roles\x18\x05 \x01(\v2\x1f.teleport.scopes.v1.SystemRolesR\vsystemRolesJ\x04\b\x02\x10\x03R\vassignments\"\xfa\x01\n" +
 	"\x0eAssignmentNode\x12L\n" +
 	"\bchildren\x18\x01 \x03(\v20.teleport.scopes.v1.AssignmentNode.ChildrenEntryR\bchildren\x129\n" +
 	"\trole_tree\x18\x02 \x01(\v2\x1c.teleport.scopes.v1.RoleNodeR\broleTree\x1a_\n" +
@@ -540,38 +689,48 @@ const file_teleport_scopes_v1_scopes_proto_rawDesc = "" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x122\n" +
 	"\x05value\x18\x02 \x01(\v2\x1c.teleport.scopes.v1.RoleNodeR\x05value:\x028\x01\")\n" +
 	"\x11PinnedAssignments\x12\x14\n" +
-	"\x05roles\x18\x01 \x03(\tR\x05roles\"L\n" +
+	"\x05roles\x18\x01 \x03(\tR\x05roles\"G\n" +
+	"\vSystemRoles\x12\x18\n" +
+	"\aprimary\x18\x01 \x01(\tR\aprimary\x12\x1e\n" +
+	"\n" +
+	"additional\x18\x02 \x03(\tR\n" +
+	"additional\"L\n" +
 	"\x06Filter\x12\x14\n" +
 	"\x05scope\x18\x01 \x01(\tR\x05scope\x12,\n" +
-	"\x04mode\x18\x02 \x01(\x0e2\x18.teleport.scopes.v1.ModeR\x04mode*h\n" +
+	"\x04mode\x18\x02 \x01(\x0e2\x18.teleport.scopes.v1.ModeR\x04mode*J\n" +
+	"\aPinKind\x12\x18\n" +
+	"\x14PIN_KIND_UNSPECIFIED\x10\x00\x12\x11\n" +
+	"\rPIN_KIND_USER\x10\x01\x12\x12\n" +
+	"\x0ePIN_KIND_AGENT\x10\x02*h\n" +
 	"\x04Mode\x12\x14\n" +
 	"\x10MODE_UNSPECIFIED\x10\x00\x12#\n" +
 	"\x1fMODE_RESOURCES_SUBJECT_TO_SCOPE\x10\x01\x12%\n" +
 	"!MODE_POLICIES_APPLICABLE_TO_SCOPE\x10\x02BPZNgithub.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/v1;scopesv1b\x06proto3"
 
-var file_teleport_scopes_v1_scopes_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
+var file_teleport_scopes_v1_scopes_proto_enumTypes = make([]protoimpl.EnumInfo, 2)
 var file_teleport_scopes_v1_scopes_proto_msgTypes = make([]protoimpl.MessageInfo, 8)
 var file_teleport_scopes_v1_scopes_proto_goTypes = []any{
-	(Mode)(0),                 // 0: teleport.scopes.v1.Mode
-	(*Pin)(nil),               // 1: teleport.scopes.v1.Pin
-	(*AssignmentNode)(nil),    // 2: teleport.scopes.v1.AssignmentNode
-	(*RoleNode)(nil),          // 3: teleport.scopes.v1.RoleNode
-	(*PinnedAssignments)(nil), // 4: teleport.scopes.v1.PinnedAssignments
-	(*Filter)(nil),            // 5: teleport.scopes.v1.Filter
-	nil,                       // 6: teleport.scopes.v1.Pin.AssignmentsEntry
-	nil,                       // 7: teleport.scopes.v1.AssignmentNode.ChildrenEntry
-	nil,                       // 8: teleport.scopes.v1.RoleNode.ChildrenEntry
+	(PinKind)(0),              // 0: teleport.scopes.v1.PinKind
+	(Mode)(0),                 // 1: teleport.scopes.v1.Mode
+	(*Pin)(nil),               // 2: teleport.scopes.v1.Pin
+	(*AssignmentNode)(nil),    // 3: teleport.scopes.v1.AssignmentNode
+	(*RoleNode)(nil),          // 4: teleport.scopes.v1.RoleNode
+	(*PinnedAssignments)(nil), // 5: teleport.scopes.v1.PinnedAssignments
+	(*SystemRoles)(nil),       // 6: teleport.scopes.v1.SystemRoles
+	(*Filter)(nil),            // 7: teleport.scopes.v1.Filter
+	nil,                       // 8: teleport.scopes.v1.AssignmentNode.ChildrenEntry
+	nil,                       // 9: teleport.scopes.v1.RoleNode.ChildrenEntry
 }
 var file_teleport_scopes_v1_scopes_proto_depIdxs = []int32{
-	6, // 0: teleport.scopes.v1.Pin.assignments:type_name -> teleport.scopes.v1.Pin.AssignmentsEntry
-	2, // 1: teleport.scopes.v1.Pin.assignment_tree:type_name -> teleport.scopes.v1.AssignmentNode
-	7, // 2: teleport.scopes.v1.AssignmentNode.children:type_name -> teleport.scopes.v1.AssignmentNode.ChildrenEntry
-	3, // 3: teleport.scopes.v1.AssignmentNode.role_tree:type_name -> teleport.scopes.v1.RoleNode
-	8, // 4: teleport.scopes.v1.RoleNode.children:type_name -> teleport.scopes.v1.RoleNode.ChildrenEntry
-	0, // 5: teleport.scopes.v1.Filter.mode:type_name -> teleport.scopes.v1.Mode
-	4, // 6: teleport.scopes.v1.Pin.AssignmentsEntry.value:type_name -> teleport.scopes.v1.PinnedAssignments
-	2, // 7: teleport.scopes.v1.AssignmentNode.ChildrenEntry.value:type_name -> teleport.scopes.v1.AssignmentNode
-	3, // 8: teleport.scopes.v1.RoleNode.ChildrenEntry.value:type_name -> teleport.scopes.v1.RoleNode
+	0, // 0: teleport.scopes.v1.Pin.kind:type_name -> teleport.scopes.v1.PinKind
+	3, // 1: teleport.scopes.v1.Pin.assignment_tree:type_name -> teleport.scopes.v1.AssignmentNode
+	6, // 2: teleport.scopes.v1.Pin.system_roles:type_name -> teleport.scopes.v1.SystemRoles
+	8, // 3: teleport.scopes.v1.AssignmentNode.children:type_name -> teleport.scopes.v1.AssignmentNode.ChildrenEntry
+	4, // 4: teleport.scopes.v1.AssignmentNode.role_tree:type_name -> teleport.scopes.v1.RoleNode
+	9, // 5: teleport.scopes.v1.RoleNode.children:type_name -> teleport.scopes.v1.RoleNode.ChildrenEntry
+	1, // 6: teleport.scopes.v1.Filter.mode:type_name -> teleport.scopes.v1.Mode
+	3, // 7: teleport.scopes.v1.AssignmentNode.ChildrenEntry.value:type_name -> teleport.scopes.v1.AssignmentNode
+	4, // 8: teleport.scopes.v1.RoleNode.ChildrenEntry.value:type_name -> teleport.scopes.v1.RoleNode
 	9, // [9:9] is the sub-list for method output_type
 	9, // [9:9] is the sub-list for method input_type
 	9, // [9:9] is the sub-list for extension type_name
@@ -589,7 +748,7 @@ func file_teleport_scopes_v1_scopes_proto_init() {
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_teleport_scopes_v1_scopes_proto_rawDesc), len(file_teleport_scopes_v1_scopes_proto_rawDesc)),
-			NumEnums:      1,
+			NumEnums:      2,
 			NumMessages:   8,
 			NumExtensions: 0,
 			NumServices:   0,

--- a/api/gen/proto/go/teleport/scopes/v1/scopes_protoopaque.pb.go
+++ b/api/gen/proto/go/teleport/scopes/v1/scopes_protoopaque.pb.go
@@ -36,6 +36,56 @@ const (
 	_ = protoimpl.EnforceVersion(protoimpl.MaxVersion - 20)
 )
 
+// PinKind expresses the kind of scope pin associated with a certificate/identity. User (and bot) certificates are kind USER,
+// while agent certificates are kind AGENT. The pin kind determines whether the privileges associated with an identity are
+// derived from scoped user roles (USER) or from system roles (AGENT).
+type PinKind int32
+
+const (
+	// PIN_KIND_UNSPECIFIED indicates that no pin kind has been specified.
+	PinKind_PIN_KIND_UNSPECIFIED PinKind = 0
+	// PIN_KIND_USER indicates that the pin is associated with a user certificate/identity.
+	PinKind_PIN_KIND_USER PinKind = 1
+	// PIN_KIND_AGENT indicates that the pin is associated with an agent certificate/identity.
+	PinKind_PIN_KIND_AGENT PinKind = 2
+)
+
+// Enum value maps for PinKind.
+var (
+	PinKind_name = map[int32]string{
+		0: "PIN_KIND_UNSPECIFIED",
+		1: "PIN_KIND_USER",
+		2: "PIN_KIND_AGENT",
+	}
+	PinKind_value = map[string]int32{
+		"PIN_KIND_UNSPECIFIED": 0,
+		"PIN_KIND_USER":        1,
+		"PIN_KIND_AGENT":       2,
+	}
+)
+
+func (x PinKind) Enum() *PinKind {
+	p := new(PinKind)
+	*p = x
+	return p
+}
+
+func (x PinKind) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (PinKind) Descriptor() protoreflect.EnumDescriptor {
+	return file_teleport_scopes_v1_scopes_proto_enumTypes[0].Descriptor()
+}
+
+func (PinKind) Type() protoreflect.EnumType {
+	return &file_teleport_scopes_v1_scopes_proto_enumTypes[0]
+}
+
+func (x PinKind) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
 // Mode determines the mode of scoping when a query specifies a scope. When a query specifies a scope,
 // one of two questions is typically trying to be answered.  Either, what resources are "in" and/or "subject to"
 // a given scope, or what policies are "applicable to" a given scope.
@@ -81,11 +131,11 @@ func (x Mode) String() string {
 }
 
 func (Mode) Descriptor() protoreflect.EnumDescriptor {
-	return file_teleport_scopes_v1_scopes_proto_enumTypes[0].Descriptor()
+	return file_teleport_scopes_v1_scopes_proto_enumTypes[1].Descriptor()
 }
 
 func (Mode) Type() protoreflect.EnumType {
-	return &file_teleport_scopes_v1_scopes_proto_enumTypes[0]
+	return &file_teleport_scopes_v1_scopes_proto_enumTypes[1]
 }
 
 func (x Mode) Number() protoreflect.EnumNumber {
@@ -95,10 +145,11 @@ func (x Mode) Number() protoreflect.EnumNumber {
 // Pin is a marker that identifies a certificate/identity as being "pinned" to a target scope, and encodes relevant
 // information for access-control evaluation at that scope.
 type Pin struct {
-	state                     protoimpl.MessageState        `protogen:"opaque.v1"`
-	xxx_hidden_Scope          string                        `protobuf:"bytes,1,opt,name=scope,proto3"`
-	xxx_hidden_Assignments    map[string]*PinnedAssignments `protobuf:"bytes,2,rep,name=assignments,proto3" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
-	xxx_hidden_AssignmentTree *AssignmentNode               `protobuf:"bytes,3,opt,name=assignment_tree,json=assignmentTree,proto3"`
+	state                     protoimpl.MessageState `protogen:"opaque.v1"`
+	xxx_hidden_Scope          string                 `protobuf:"bytes,1,opt,name=scope,proto3"`
+	xxx_hidden_Kind           PinKind                `protobuf:"varint,4,opt,name=kind,proto3,enum=teleport.scopes.v1.PinKind"`
+	xxx_hidden_AssignmentTree *AssignmentNode        `protobuf:"bytes,3,opt,name=assignment_tree,json=assignmentTree,proto3"`
+	xxx_hidden_SystemRoles    *SystemRoles           `protobuf:"bytes,5,opt,name=system_roles,json=systemRoles,proto3"`
 	unknownFields             protoimpl.UnknownFields
 	sizeCache                 protoimpl.SizeCache
 }
@@ -135,12 +186,11 @@ func (x *Pin) GetScope() string {
 	return ""
 }
 
-// Deprecated: Marked as deprecated in teleport/scopes/v1/scopes.proto.
-func (x *Pin) GetAssignments() map[string]*PinnedAssignments {
+func (x *Pin) GetKind() PinKind {
 	if x != nil {
-		return x.xxx_hidden_Assignments
+		return x.xxx_hidden_Kind
 	}
-	return nil
+	return PinKind_PIN_KIND_UNSPECIFIED
 }
 
 func (x *Pin) GetAssignmentTree() *AssignmentNode {
@@ -150,17 +200,27 @@ func (x *Pin) GetAssignmentTree() *AssignmentNode {
 	return nil
 }
 
+func (x *Pin) GetSystemRoles() *SystemRoles {
+	if x != nil {
+		return x.xxx_hidden_SystemRoles
+	}
+	return nil
+}
+
 func (x *Pin) SetScope(v string) {
 	x.xxx_hidden_Scope = v
 }
 
-// Deprecated: Marked as deprecated in teleport/scopes/v1/scopes.proto.
-func (x *Pin) SetAssignments(v map[string]*PinnedAssignments) {
-	x.xxx_hidden_Assignments = v
+func (x *Pin) SetKind(v PinKind) {
+	x.xxx_hidden_Kind = v
 }
 
 func (x *Pin) SetAssignmentTree(v *AssignmentNode) {
 	x.xxx_hidden_AssignmentTree = v
+}
+
+func (x *Pin) SetSystemRoles(v *SystemRoles) {
+	x.xxx_hidden_SystemRoles = v
 }
 
 func (x *Pin) HasAssignmentTree() bool {
@@ -170,8 +230,19 @@ func (x *Pin) HasAssignmentTree() bool {
 	return x.xxx_hidden_AssignmentTree != nil
 }
 
+func (x *Pin) HasSystemRoles() bool {
+	if x == nil {
+		return false
+	}
+	return x.xxx_hidden_SystemRoles != nil
+}
+
 func (x *Pin) ClearAssignmentTree() {
 	x.xxx_hidden_AssignmentTree = nil
+}
+
+func (x *Pin) ClearSystemRoles() {
+	x.xxx_hidden_SystemRoles = nil
 }
 
 type Pin_builder struct {
@@ -181,15 +252,15 @@ type Pin_builder struct {
 	// pinned to. Any resources in parent/orthogonal scopes are not necessarily subject to the privileges/policies
 	// conveyed by this pin.
 	Scope string
-	// assignments encodes the scoped role assignments relevant to access-control decisions about the pinned identity. This may
-	// include assignments to parents of the pinned scope as well as assignments to equivalent/child scopes. Effectively, this
-	// means all assignments that are not orthogonal to the pinned scope.
-	//
-	// Deprecated: Marked as deprecated in teleport/scopes/v1/scopes.proto.
-	Assignments map[string]*PinnedAssignments
+	// kind indicates the pin kind (USER or AGENT). Pin kind determines whether this identity's privileges are conveyed
+	// via scoped user roles or system roles (note: bots use USER kind pins, rather than a separate BOT kind).
+	Kind PinKind
 	// assignment_tree encodes the full tree of scoped privilege assignments, organized by *Scope of Origin*. Policies/privileges
-	// assigned from higher scopes of origin take precedence over those assigned from lower scopes of origin.
+	// assigned from higher scopes of origin take precedence over those assigned from lower scopes of origin. Only specified
+	// for USER kind pins.
 	AssignmentTree *AssignmentNode
+	// system_roles encodes the system roles held by the pinned identity. Only specified for AGENT kind pins.
+	SystemRoles *SystemRoles
 }
 
 func (b0 Pin_builder) Build() *Pin {
@@ -197,8 +268,9 @@ func (b0 Pin_builder) Build() *Pin {
 	b, x := &b0, m0
 	_, _ = b, x
 	x.xxx_hidden_Scope = b.Scope
-	x.xxx_hidden_Assignments = b.Assignments
+	x.xxx_hidden_Kind = b.Kind
 	x.xxx_hidden_AssignmentTree = b.AssignmentTree
+	x.xxx_hidden_SystemRoles = b.SystemRoles
 	return m0
 }
 
@@ -423,6 +495,82 @@ func (b0 PinnedAssignments_builder) Build() *PinnedAssignments {
 	return m0
 }
 
+// SystemRoles is a collection of system roles held by an agent identity.
+type SystemRoles struct {
+	state                 protoimpl.MessageState `protogen:"opaque.v1"`
+	xxx_hidden_Primary    string                 `protobuf:"bytes,1,opt,name=primary,proto3"`
+	xxx_hidden_Additional []string               `protobuf:"bytes,2,rep,name=additional,proto3"`
+	unknownFields         protoimpl.UnknownFields
+	sizeCache             protoimpl.SizeCache
+}
+
+func (x *SystemRoles) Reset() {
+	*x = SystemRoles{}
+	mi := &file_teleport_scopes_v1_scopes_proto_msgTypes[4]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *SystemRoles) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*SystemRoles) ProtoMessage() {}
+
+func (x *SystemRoles) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_scopes_v1_scopes_proto_msgTypes[4]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+func (x *SystemRoles) GetPrimary() string {
+	if x != nil {
+		return x.xxx_hidden_Primary
+	}
+	return ""
+}
+
+func (x *SystemRoles) GetAdditional() []string {
+	if x != nil {
+		return x.xxx_hidden_Additional
+	}
+	return nil
+}
+
+func (x *SystemRoles) SetPrimary(v string) {
+	x.xxx_hidden_Primary = v
+}
+
+func (x *SystemRoles) SetAdditional(v []string) {
+	x.xxx_hidden_Additional = v
+}
+
+type SystemRoles_builder struct {
+	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
+
+	// primary is the primary system role associated with the certificate. For per-service agent certificates, this will
+	// be an ordinary system role (e.g. "Node") and the additional system roles will be empty. If the primary is "Instance"
+	// then the additional system roles will contain all system roles held by the agent.
+	Primary string
+	// additional is the list of all system roles held by the agent identity. Only populated for "Instance" certificates.
+	Additional []string
+}
+
+func (b0 SystemRoles_builder) Build() *SystemRoles {
+	m0 := &SystemRoles{}
+	b, x := &b0, m0
+	_, _ = b, x
+	x.xxx_hidden_Primary = b.Primary
+	x.xxx_hidden_Additional = b.Additional
+	return m0
+}
+
 // Filter is a query parameter that matches other scopes based on a specified scope and mode. Used for
 // filtering resources that are subject to or policies that apply to a given scope.
 type Filter struct {
@@ -435,7 +583,7 @@ type Filter struct {
 
 func (x *Filter) Reset() {
 	*x = Filter{}
-	mi := &file_teleport_scopes_v1_scopes_proto_msgTypes[4]
+	mi := &file_teleport_scopes_v1_scopes_proto_msgTypes[5]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -447,7 +595,7 @@ func (x *Filter) String() string {
 func (*Filter) ProtoMessage() {}
 
 func (x *Filter) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_scopes_v1_scopes_proto_msgTypes[4]
+	mi := &file_teleport_scopes_v1_scopes_proto_msgTypes[5]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -502,14 +650,12 @@ var File_teleport_scopes_v1_scopes_proto protoreflect.FileDescriptor
 
 const file_teleport_scopes_v1_scopes_proto_rawDesc = "" +
 	"\n" +
-	"\x1fteleport/scopes/v1/scopes.proto\x12\x12teleport.scopes.v1\"\x9f\x02\n" +
+	"\x1fteleport/scopes/v1/scopes.proto\x12\x12teleport.scopes.v1\"\xf0\x01\n" +
 	"\x03Pin\x12\x14\n" +
-	"\x05scope\x18\x01 \x01(\tR\x05scope\x12N\n" +
-	"\vassignments\x18\x02 \x03(\v2(.teleport.scopes.v1.Pin.AssignmentsEntryB\x02\x18\x01R\vassignments\x12K\n" +
-	"\x0fassignment_tree\x18\x03 \x01(\v2\".teleport.scopes.v1.AssignmentNodeR\x0eassignmentTree\x1ae\n" +
-	"\x10AssignmentsEntry\x12\x10\n" +
-	"\x03key\x18\x01 \x01(\tR\x03key\x12;\n" +
-	"\x05value\x18\x02 \x01(\v2%.teleport.scopes.v1.PinnedAssignmentsR\x05value:\x028\x01\"\xfa\x01\n" +
+	"\x05scope\x18\x01 \x01(\tR\x05scope\x12/\n" +
+	"\x04kind\x18\x04 \x01(\x0e2\x1b.teleport.scopes.v1.PinKindR\x04kind\x12K\n" +
+	"\x0fassignment_tree\x18\x03 \x01(\v2\".teleport.scopes.v1.AssignmentNodeR\x0eassignmentTree\x12B\n" +
+	"\fsystem_roles\x18\x05 \x01(\v2\x1f.teleport.scopes.v1.SystemRolesR\vsystemRolesJ\x04\b\x02\x10\x03R\vassignments\"\xfa\x01\n" +
 	"\x0eAssignmentNode\x12L\n" +
 	"\bchildren\x18\x01 \x03(\v20.teleport.scopes.v1.AssignmentNode.ChildrenEntryR\bchildren\x129\n" +
 	"\trole_tree\x18\x02 \x01(\v2\x1c.teleport.scopes.v1.RoleNodeR\broleTree\x1a_\n" +
@@ -523,38 +669,48 @@ const file_teleport_scopes_v1_scopes_proto_rawDesc = "" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x122\n" +
 	"\x05value\x18\x02 \x01(\v2\x1c.teleport.scopes.v1.RoleNodeR\x05value:\x028\x01\")\n" +
 	"\x11PinnedAssignments\x12\x14\n" +
-	"\x05roles\x18\x01 \x03(\tR\x05roles\"L\n" +
+	"\x05roles\x18\x01 \x03(\tR\x05roles\"G\n" +
+	"\vSystemRoles\x12\x18\n" +
+	"\aprimary\x18\x01 \x01(\tR\aprimary\x12\x1e\n" +
+	"\n" +
+	"additional\x18\x02 \x03(\tR\n" +
+	"additional\"L\n" +
 	"\x06Filter\x12\x14\n" +
 	"\x05scope\x18\x01 \x01(\tR\x05scope\x12,\n" +
-	"\x04mode\x18\x02 \x01(\x0e2\x18.teleport.scopes.v1.ModeR\x04mode*h\n" +
+	"\x04mode\x18\x02 \x01(\x0e2\x18.teleport.scopes.v1.ModeR\x04mode*J\n" +
+	"\aPinKind\x12\x18\n" +
+	"\x14PIN_KIND_UNSPECIFIED\x10\x00\x12\x11\n" +
+	"\rPIN_KIND_USER\x10\x01\x12\x12\n" +
+	"\x0ePIN_KIND_AGENT\x10\x02*h\n" +
 	"\x04Mode\x12\x14\n" +
 	"\x10MODE_UNSPECIFIED\x10\x00\x12#\n" +
 	"\x1fMODE_RESOURCES_SUBJECT_TO_SCOPE\x10\x01\x12%\n" +
 	"!MODE_POLICIES_APPLICABLE_TO_SCOPE\x10\x02BPZNgithub.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/v1;scopesv1b\x06proto3"
 
-var file_teleport_scopes_v1_scopes_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
+var file_teleport_scopes_v1_scopes_proto_enumTypes = make([]protoimpl.EnumInfo, 2)
 var file_teleport_scopes_v1_scopes_proto_msgTypes = make([]protoimpl.MessageInfo, 8)
 var file_teleport_scopes_v1_scopes_proto_goTypes = []any{
-	(Mode)(0),                 // 0: teleport.scopes.v1.Mode
-	(*Pin)(nil),               // 1: teleport.scopes.v1.Pin
-	(*AssignmentNode)(nil),    // 2: teleport.scopes.v1.AssignmentNode
-	(*RoleNode)(nil),          // 3: teleport.scopes.v1.RoleNode
-	(*PinnedAssignments)(nil), // 4: teleport.scopes.v1.PinnedAssignments
-	(*Filter)(nil),            // 5: teleport.scopes.v1.Filter
-	nil,                       // 6: teleport.scopes.v1.Pin.AssignmentsEntry
-	nil,                       // 7: teleport.scopes.v1.AssignmentNode.ChildrenEntry
-	nil,                       // 8: teleport.scopes.v1.RoleNode.ChildrenEntry
+	(PinKind)(0),              // 0: teleport.scopes.v1.PinKind
+	(Mode)(0),                 // 1: teleport.scopes.v1.Mode
+	(*Pin)(nil),               // 2: teleport.scopes.v1.Pin
+	(*AssignmentNode)(nil),    // 3: teleport.scopes.v1.AssignmentNode
+	(*RoleNode)(nil),          // 4: teleport.scopes.v1.RoleNode
+	(*PinnedAssignments)(nil), // 5: teleport.scopes.v1.PinnedAssignments
+	(*SystemRoles)(nil),       // 6: teleport.scopes.v1.SystemRoles
+	(*Filter)(nil),            // 7: teleport.scopes.v1.Filter
+	nil,                       // 8: teleport.scopes.v1.AssignmentNode.ChildrenEntry
+	nil,                       // 9: teleport.scopes.v1.RoleNode.ChildrenEntry
 }
 var file_teleport_scopes_v1_scopes_proto_depIdxs = []int32{
-	6, // 0: teleport.scopes.v1.Pin.assignments:type_name -> teleport.scopes.v1.Pin.AssignmentsEntry
-	2, // 1: teleport.scopes.v1.Pin.assignment_tree:type_name -> teleport.scopes.v1.AssignmentNode
-	7, // 2: teleport.scopes.v1.AssignmentNode.children:type_name -> teleport.scopes.v1.AssignmentNode.ChildrenEntry
-	3, // 3: teleport.scopes.v1.AssignmentNode.role_tree:type_name -> teleport.scopes.v1.RoleNode
-	8, // 4: teleport.scopes.v1.RoleNode.children:type_name -> teleport.scopes.v1.RoleNode.ChildrenEntry
-	0, // 5: teleport.scopes.v1.Filter.mode:type_name -> teleport.scopes.v1.Mode
-	4, // 6: teleport.scopes.v1.Pin.AssignmentsEntry.value:type_name -> teleport.scopes.v1.PinnedAssignments
-	2, // 7: teleport.scopes.v1.AssignmentNode.ChildrenEntry.value:type_name -> teleport.scopes.v1.AssignmentNode
-	3, // 8: teleport.scopes.v1.RoleNode.ChildrenEntry.value:type_name -> teleport.scopes.v1.RoleNode
+	0, // 0: teleport.scopes.v1.Pin.kind:type_name -> teleport.scopes.v1.PinKind
+	3, // 1: teleport.scopes.v1.Pin.assignment_tree:type_name -> teleport.scopes.v1.AssignmentNode
+	6, // 2: teleport.scopes.v1.Pin.system_roles:type_name -> teleport.scopes.v1.SystemRoles
+	8, // 3: teleport.scopes.v1.AssignmentNode.children:type_name -> teleport.scopes.v1.AssignmentNode.ChildrenEntry
+	4, // 4: teleport.scopes.v1.AssignmentNode.role_tree:type_name -> teleport.scopes.v1.RoleNode
+	9, // 5: teleport.scopes.v1.RoleNode.children:type_name -> teleport.scopes.v1.RoleNode.ChildrenEntry
+	1, // 6: teleport.scopes.v1.Filter.mode:type_name -> teleport.scopes.v1.Mode
+	3, // 7: teleport.scopes.v1.AssignmentNode.ChildrenEntry.value:type_name -> teleport.scopes.v1.AssignmentNode
+	4, // 8: teleport.scopes.v1.RoleNode.ChildrenEntry.value:type_name -> teleport.scopes.v1.RoleNode
 	9, // [9:9] is the sub-list for method output_type
 	9, // [9:9] is the sub-list for method input_type
 	9, // [9:9] is the sub-list for extension type_name
@@ -572,7 +728,7 @@ func file_teleport_scopes_v1_scopes_proto_init() {
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_teleport_scopes_v1_scopes_proto_rawDesc), len(file_teleport_scopes_v1_scopes_proto_rawDesc)),
-			NumEnums:      1,
+			NumEnums:      2,
 			NumMessages:   8,
 			NumExtensions: 0,
 			NumServices:   0,

--- a/api/proto/teleport/scopes/v1/scopes.proto
+++ b/api/proto/teleport/scopes/v1/scopes.proto
@@ -21,19 +21,38 @@ option go_package = "github.com/gravitational/teleport/api/gen/proto/go/teleport
 // Pin is a marker that identifies a certificate/identity as being "pinned" to a target scope, and encodes relevant
 // information for access-control evaluation at that scope.
 message Pin {
+  reserved 2;
+  reserved "assignments";
   // scope is the target scope that this pin is associated with. This is the scope that the certificate/identity is
   // pinned to. Any resources in parent/orthogonal scopes are not necessarily subject to the privileges/policies
   // conveyed by this pin.
   string scope = 1;
 
-  // assignments encodes the scoped role assignments relevant to access-control decisions about the pinned identity. This may
-  // include assignments to parents of the pinned scope as well as assignments to equivalent/child scopes. Effectively, this
-  // means all assignments that are not orthogonal to the pinned scope.
-  map<string, PinnedAssignments> assignments = 2 [deprecated = true];
+  // kind indicates the pin kind (USER or AGENT). Pin kind determines whether this identity's privileges are conveyed
+  // via scoped user roles or system roles (note: bots use USER kind pins, rather than a separate BOT kind).
+  PinKind kind = 4;
 
   // assignment_tree encodes the full tree of scoped privilege assignments, organized by *Scope of Origin*. Policies/privileges
-  // assigned from higher scopes of origin take precedence over those assigned from lower scopes of origin.
+  // assigned from higher scopes of origin take precedence over those assigned from lower scopes of origin. Only specified
+  // for USER kind pins.
   AssignmentNode assignment_tree = 3;
+
+  // system_roles encodes the system roles held by the pinned identity. Only specified for AGENT kind pins.
+  SystemRoles system_roles = 5;
+}
+
+// PinKind expresses the kind of scope pin associated with a certificate/identity. User (and bot) certificates are kind USER,
+// while agent certificates are kind AGENT. The pin kind determines whether the privileges associated with an identity are
+// derived from scoped user roles (USER) or from system roles (AGENT).
+enum PinKind {
+  // PIN_KIND_UNSPECIFIED indicates that no pin kind has been specified.
+  PIN_KIND_UNSPECIFIED = 0;
+
+  // PIN_KIND_USER indicates that the pin is associated with a user certificate/identity.
+  PIN_KIND_USER = 1;
+
+  // PIN_KIND_AGENT indicates that the pin is associated with an agent certificate/identity.
+  PIN_KIND_AGENT = 2;
 }
 
 // AssignmentNode represents a node in the assignment tree. In addition to containing its own children as is standard for tree nodes,
@@ -60,6 +79,17 @@ message RoleNode {
 message PinnedAssignments {
   // roles is a list of scoped roles that are assigned to the pinned identity at the target scope.
   repeated string roles = 1;
+}
+
+// SystemRoles is a collection of system roles held by an agent identity.
+message SystemRoles {
+  // primary is the primary system role associated with the certificate. For per-service agent certificates, this will
+  // be an ordinary system role (e.g. "Node") and the additional system roles will be empty. If the primary is "Instance"
+  // then the additional system roles will contain all system roles held by the agent.
+  string primary = 1;
+
+  // additional is the list of all system roles held by the agent identity. Only populated for "Instance" certificates.
+  repeated string additional = 2;
 }
 
 // Mode determines the mode of scoping when a query specifies a scope. When a query specifies a scope,

--- a/constants.go
+++ b/constants.go
@@ -470,6 +470,9 @@ const (
 	// This constrains other identities' access to the agent itself as well as the agent's
 	// access to other resources based on scoping rules.
 	CertExtensionAgentScope = "agent-scope@goteleport.com"
+	// CertExtensionAgentScopePin encodes an agent's scope pin, including the pinned scope and system roles.
+	// Supersedes CertExtensionAgentScope for scoped agents.
+	CertExtensionAgentScopePin = "agent-scope-pin@goteleport.com"
 	// CertExtensionPermitX11Forwarding allows X11 forwarding for certificate
 	CertExtensionPermitX11Forwarding = "permit-X11-forwarding"
 	// CertExtensionPermitAgentForwarding allows agent forwarding for certificate

--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -5564,22 +5564,12 @@ func (a *Server) GenerateHostCerts(ctx context.Context, params HostCertsParams) 
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	// generate host SSH certificate
-	hostSSHCert, err := a.generateHostCert(ctx, sshca.HostCertificateRequest{
-		CASigner:      caSigner,
-		PublicHostKey: req.PublicSSHKey,
-		HostID:        req.HostID,
-		NodeName:      req.NodeName,
-		Identity: sshca.Identity{
-			ClusterName:        clusterName.GetClusterName(),
-			SystemRole:         req.Role,
-			Principals:         req.AdditionalPrincipals,
-			AgentScope:         params.AgentScope,
-			ImmutableLabelHash: params.ImmutableLabelHash,
-		},
-	})
-	if err != nil {
-		return nil, trace.Wrap(err)
+
+	var useAgentPin bool
+	if params.AgentScope != "" {
+		// We are in the process of switching over the format of scoped agent certificates. Until the
+		// transition is complete, the new agent pin format is behind a feature flag.
+		useAgentPin = scopes.AgentPinEnabled()
 	}
 
 	if req.Role == types.RoleInstance && len(req.SystemRoles) == 0 {
@@ -5591,15 +5581,71 @@ func (a *Server) GenerateHostCerts(ctx context.Context, params HostCertsParams) 
 		systemRoles = append(systemRoles, string(r))
 	}
 
+	var agentScopePin *scopesv1.Pin
+	if useAgentPin {
+		agentScopePin = &scopesv1.Pin{
+			Kind:  scopesv1.PinKind_PIN_KIND_AGENT,
+			Scope: params.AgentScope,
+			SystemRoles: &scopesv1.SystemRoles{
+				Primary:    req.Role.String(),
+				Additional: systemRoles,
+			},
+		}
+	}
+
+	// Agent scope pins encode role and scope solely via ScopePin; setting the
+	// legacy fields alongside the pin would let old infrastructure treat the cert
+	// as unscoped. Only populate them for the legacy (non-pin) path.
+	var sshRole types.SystemRole
+	var sshAgentScope string
+	if !useAgentPin {
+		sshRole = req.Role
+		sshAgentScope = params.AgentScope
+	}
+
+	// generate host SSH certificate
+	hostSSHCert, err := a.generateHostCert(ctx, sshca.HostCertificateRequest{
+		CASigner:      caSigner,
+		PublicHostKey: req.PublicSSHKey,
+		HostID:        req.HostID,
+		NodeName:      req.NodeName,
+		Identity: sshca.Identity{
+			ClusterName:        clusterName.GetClusterName(),
+			SystemRole:         sshRole,
+			Principals:         req.AdditionalPrincipals,
+			AgentScope:         sshAgentScope,
+			ScopePin:           agentScopePin,
+			ImmutableLabelHash: params.ImmutableLabelHash,
+		},
+	})
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
 	// generate host TLS certificate
-	identity := tlsca.Identity{
-		Username:           utils.HostFQDN(req.HostID, clusterName.GetClusterName()),
-		Groups:             []string{req.Role.String()},
-		TeleportCluster:    clusterName.GetClusterName(),
-		SystemRoles:        systemRoles,
-		AgentScope:         params.AgentScope,
-		ImmutableLabelHash: params.ImmutableLabelHash,
-		JoinToken:          params.JoinToken,
+	var identity tlsca.Identity
+	if useAgentPin {
+		identity = tlsca.Identity{
+			Username:           utils.HostFQDN(req.HostID, clusterName.GetClusterName()),
+			Groups:             nil, // omitted in agent pin case
+			TeleportCluster:    clusterName.GetClusterName(),
+			SystemRoles:        nil, // omitted in agent pin case
+			AgentScope:         "",  // omitted in agent pin case
+			ScopePin:           agentScopePin,
+			ImmutableLabelHash: params.ImmutableLabelHash,
+			JoinToken:          params.JoinToken,
+		}
+	} else {
+		identity = tlsca.Identity{
+			Username:           utils.HostFQDN(req.HostID, clusterName.GetClusterName()),
+			Groups:             []string{req.Role.String()},
+			TeleportCluster:    clusterName.GetClusterName(),
+			SystemRoles:        systemRoles,
+			AgentScope:         params.AgentScope,
+			ScopePin:           nil, // omitted when not in agent pin case
+			ImmutableLabelHash: params.ImmutableLabelHash,
+			JoinToken:          params.JoinToken,
+		}
 	}
 	subject, err := identity.Subject()
 	if err != nil {

--- a/lib/auth/auth_login_test.go
+++ b/lib/auth/auth_login_test.go
@@ -1098,6 +1098,7 @@ func TestBasicSSHScopedLogin(t *testing.T) {
 
 	// verify that the expected scope pin is applied to ssh and tls certificates
 	expectedPin := &scopesv1.Pin{
+		Kind:  scopesv1.PinKind_PIN_KIND_USER,
 		Scope: "/aa/bb",
 		AssignmentTree: pinning.AssignmentTreeFromMap(map[string]map[string][]string{
 			"/aa":       {"/aa": {"role-a"}},

--- a/lib/auth/auth_test.go
+++ b/lib/auth/auth_test.go
@@ -3007,7 +3007,7 @@ func TestGenerateOpenSSHCertScoped(t *testing.T) {
 		},
 	})
 	require.NoError(t, err)
-	pin := &scopesv1pb.Pin{Scope: "/staging"}
+	pin := &scopesv1pb.Pin{Kind: scopesv1pb.PinKind_PIN_KIND_USER, Scope: "/staging"}
 
 	// Wait for scoped access cache to see the assignment.
 	require.EventuallyWithT(t, func(ct *assert.CollectT) {

--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -711,7 +711,7 @@ func (a *ServerWithRoles) GenerateHostCerts(ctx context.Context, req *proto.Host
 	identity := a.context.Identity.GetIdentity()
 	return a.authServer.GenerateHostCerts(ctx, HostCertsParams{
 		Req:                req,
-		AgentScope:         identity.AgentScope,
+		AgentScope:         identity.GetAgentScope(),
 		ImmutableLabelHash: identity.ImmutableLabelHash,
 		JoinToken:          identity.JoinToken,
 	})
@@ -849,7 +849,7 @@ func (a *ServerWithRoles) RegisterInventoryControlStream(ics client.UpstreamInve
 	// If the hello message's scope is non-empty, we can verify that it matches the authenticated
 	// scope in the identity. Otherwise, in order to support agents unaware of scopes, we fall back
 	// to the authenticated identity's scope.
-	agentScope := a.context.Identity.GetIdentity().AgentScope
+	agentScope := a.context.Identity.GetIdentity().GetAgentScope()
 	if hello.Scope != "" && hello.Scope != agentScope {
 		return nil, trace.AccessDenied("provided scope %q does not match agent identity %q", hello.Scope, agentScope)
 	}
@@ -1058,7 +1058,7 @@ func (a *ServerWithRoles) UpsertNode(ctx context.Context, s types.Server) (*type
 		return nil, trace.Wrap(err)
 	}
 
-	agentScope := a.context.Identity.GetIdentity().AgentScope
+	agentScope := a.context.Identity.GetIdentity().GetAgentScope()
 	if nodeScope := s.GetScope(); agentScope != "" {
 		if nodeScope != agentScope {
 			return nil, trace.AccessDenied("node scope %q does not match agent identity scope %q", nodeScope, agentScope)

--- a/lib/auth/auth_with_roles_test.go
+++ b/lib/auth/auth_with_roles_test.go
@@ -8734,9 +8734,9 @@ func TestGenerateHostCert(t *testing.T) {
 }
 
 // newScopedTestServerForHost creates a self-cleaning `ServerWithRoles`, configured
-// for a given host
-func newScopedTestServerForHost(t *testing.T, srv *authtest.AuthServer, hostID, scope string, role types.SystemRole) *auth.ServerWithRoles {
-	authzContext := authz.ContextWithUser(t.Context(), authtest.TestScopedHost(srv.ClusterName, hostID, scope, role).I)
+// for a given host. One or more roles must be provided.
+func newScopedTestServerForHost(t *testing.T, srv *authtest.AuthServer, hostID, scope string, roles ...types.SystemRole) *auth.ServerWithRoles {
+	authzContext := authz.ContextWithUser(t.Context(), authtest.TestScopedHost(srv.ClusterName, hostID, scope, roles...).I)
 	ctxIdentity, err := srv.Authorizer.Authorize(authzContext)
 	require.NoError(t, err)
 
@@ -8867,6 +8867,170 @@ func TestUpsertNode(t *testing.T) {
 			require.NoError(t, err)
 		})
 	}
+}
+
+// TestGenerateHostCertsAgentScopePin verifies that GenerateHostCerts handles agent scope pins
+// correctly. As agent scope pins are still in development, this test currently covers the behavior
+// of the associated feature flag and verifies the old format is still the default behavior. This
+// test will be simplified once the agent scope pin feature is complete.
+func TestGenerateHostCertsAgentScopePin(t *testing.T) {
+	t.Setenv("TELEPORT_UNSTABLE_SCOPES", "yes")
+	ctx := t.Context()
+
+	const scope = "/aa/bb"
+	const hostID = "testhost"
+
+	as, err := authtest.NewAuthServer(authtest.AuthServerConfig{Dir: t.TempDir()})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, as.Close()) })
+
+	type certIdents struct {
+		tls *tlsca.Identity
+		ssh *sshca.Identity
+	}
+
+	parseIdents := func(t *testing.T, certs *proto.Certs) certIdents {
+		t.Helper()
+		tlsCert, err := tlsca.ParseCertificatePEM(certs.TLS)
+		require.NoError(t, err)
+		tlsIdent, err := tlsca.FromSubject(tlsCert.Subject, tlsCert.NotAfter)
+		require.NoError(t, err)
+		sshCert, err := sshutils.ParseCertificate(certs.SSH)
+		require.NoError(t, err)
+		sshIdent, err := sshca.DecodeIdentity(sshCert)
+		require.NoError(t, err)
+		return certIdents{tls: tlsIdent, ssh: sshIdent}
+	}
+
+	generateCerts := func(t *testing.T, role types.SystemRole) certIdents {
+		t.Helper()
+		s := newScopedTestServerForHost(t, as, hostID, scope, role)
+
+		_, sshPub, err := testauthority.GenerateKeyPair()
+		require.NoError(t, err)
+		tlsKey, err := cryptosuites.GenerateKeyWithAlgorithm(cryptosuites.ECDSAP256)
+		require.NoError(t, err)
+		tlsPubPEM, err := keys.MarshalPublicKey(tlsKey.Public())
+		require.NoError(t, err)
+
+		certs, err := s.GenerateHostCerts(ctx, &proto.HostCertsRequest{
+			PublicTLSKey: tlsPubPEM,
+			PublicSSHKey: sshPub,
+			HostID:       hostID,
+			Role:         role,
+		})
+		require.NoError(t, err)
+		return parseIdents(t, certs)
+	}
+
+	generateInstanceCerts := func(t *testing.T, systemRoles types.SystemRoles) certIdents {
+		t.Helper()
+		s := newScopedTestServerForHost(t, as, hostID, scope, systemRoles...)
+
+		_, sshPub, err := testauthority.GenerateKeyPair()
+		require.NoError(t, err)
+		tlsKey, err := cryptosuites.GenerateKeyWithAlgorithm(cryptosuites.ECDSAP256)
+		require.NoError(t, err)
+		tlsPubPEM, err := keys.MarshalPublicKey(tlsKey.Public())
+		require.NoError(t, err)
+
+		certs, err := s.GenerateHostCerts(ctx, &proto.HostCertsRequest{
+			PublicTLSKey: tlsPubPEM,
+			PublicSSHKey: sshPub,
+			HostID:       hostID,
+			Role:         types.RoleInstance,
+			SystemRoles:  systemRoles,
+		})
+		require.NoError(t, err)
+		return parseIdents(t, certs)
+	}
+
+	// verify that the legacy scoped agent cert format is still the one generated when
+	// the agent scope pin feature is not enabled
+	t.Run("legacy format", func(t *testing.T) {
+		idents := generateCerts(t, types.RoleNode)
+
+		// Legacy path: Groups contains the role, AgentScope is set, ScopePin is nil.
+		require.Contains(t, idents.tls.Groups, types.RoleNode.String())
+		require.Equal(t, scope, idents.tls.AgentScope)
+		require.Nil(t, idents.tls.ScopePin)
+
+		// SSH cert: legacy AgentScope set, no pin.
+		require.Equal(t, scope, idents.ssh.AgentScope)
+		require.Nil(t, idents.ssh.ScopePin)
+	})
+
+	// verify agent pin created correctly for service certs
+	t.Run("agent pin service cert", func(t *testing.T) {
+		t.Setenv("TELEPORT_UNSTABLE_AGENT_SCOPE_PIN", "yes")
+
+		idents := generateCerts(t, types.RoleNode)
+		require.Empty(t, idents.tls.Groups)
+		require.Empty(t, idents.tls.AgentScope)
+		require.NotNil(t, idents.tls.ScopePin)
+		require.Equal(t, scope, idents.tls.ScopePin.GetScope())
+		require.Equal(t, types.RoleNode.String(), idents.tls.ScopePin.GetSystemRoles().GetPrimary())
+
+		require.NotNil(t, idents.ssh.ScopePin)
+		require.Equal(t, scope, idents.ssh.ScopePin.GetScope())
+		require.Equal(t, types.RoleNode.String(), idents.ssh.ScopePin.GetSystemRoles().GetPrimary())
+	})
+
+	// verify agent pin created correctly for instance certs
+	t.Run("agent pin instance cert", func(t *testing.T) {
+		t.Setenv("TELEPORT_UNSTABLE_AGENT_SCOPE_PIN", "yes")
+
+		systemRoles := types.SystemRoles{types.RoleNode, types.RoleKube}
+		idents := generateInstanceCerts(t, systemRoles)
+
+		require.Empty(t, idents.tls.Groups)
+		require.NotNil(t, idents.tls.ScopePin)
+		require.Equal(t, scope, idents.tls.ScopePin.GetScope())
+		require.Equal(t, types.RoleInstance.String(), idents.tls.ScopePin.GetSystemRoles().GetPrimary())
+		tlsAdditional := idents.tls.ScopePin.GetSystemRoles().GetAdditional()
+		for _, role := range systemRoles {
+			require.Contains(t, tlsAdditional, role.String())
+		}
+
+		require.NotNil(t, idents.ssh.ScopePin)
+		require.Equal(t, scope, idents.ssh.ScopePin.GetScope())
+		require.Equal(t, types.RoleInstance.String(), idents.ssh.ScopePin.GetSystemRoles().GetPrimary())
+		sshAdditional := idents.ssh.ScopePin.GetSystemRoles().GetAdditional()
+		for _, role := range systemRoles {
+			require.Contains(t, sshAdditional, role.String())
+		}
+	})
+
+	// verify that scope pins are not set for unscoped agents
+	t.Run("unscoped agent has no pin", func(t *testing.T) {
+		t.Setenv("TELEPORT_UNSTABLE_AGENT_SCOPE_PIN", "yes")
+
+		_, sshPub, err := testauthority.GenerateKeyPair()
+		require.NoError(t, err)
+		tlsKey, err := cryptosuites.GenerateKeyWithAlgorithm(cryptosuites.ECDSAP256)
+		require.NoError(t, err)
+		tlsPubPEM, err := keys.MarshalPublicKey(tlsKey.Public())
+		require.NoError(t, err)
+
+		certs, err := as.AuthServer.GenerateHostCerts(ctx, auth.HostCertsParams{
+			Req: &proto.HostCertsRequest{
+				PublicTLSKey: tlsPubPEM,
+				PublicSSHKey: sshPub,
+				HostID:       hostID,
+				NodeName:     hostID,
+				Role:         types.RoleNode,
+			},
+		})
+		require.NoError(t, err)
+
+		idents := parseIdents(t, certs)
+		require.Contains(t, idents.tls.Groups, types.RoleNode.String())
+		require.Empty(t, idents.tls.AgentScope)
+		require.Nil(t, idents.tls.ScopePin)
+
+		require.Empty(t, idents.ssh.AgentScope)
+		require.Nil(t, idents.ssh.ScopePin)
+	})
 }
 
 // TestLocalServiceRolesHavePermissionsForUploaderService verifies that all of Teleport's

--- a/lib/auth/authtest/authtest.go
+++ b/lib/auth/authtest/authtest.go
@@ -1225,8 +1225,9 @@ func TestUnauthenticated(role types.UnauthenticatedRole) TestIdentity {
 	}
 }
 
-// TestScopedHost returns TestIdentity for a scoped host
-func TestScopedHost(clusterName, hostID, scope string, role types.SystemRole) TestIdentity {
+// TestScopedHost returns TestIdentity for a scoped host. One or more roles may be provided;
+// all are included as AdditionalSystemRoles on an instance cert identity.
+func TestScopedHost(clusterName, hostID, scope string, roles ...types.SystemRole) TestIdentity {
 	username := hostID
 	if clusterName != "" {
 		username = utils.HostFQDN(hostID, clusterName)
@@ -1235,7 +1236,7 @@ func TestScopedHost(clusterName, hostID, scope string, role types.SystemRole) Te
 		I: authz.BuiltinRole{
 			Role:                  types.RoleInstance,
 			Username:              username,
-			AdditionalSystemRoles: types.SystemRoles{role},
+			AdditionalSystemRoles: types.SystemRoles(roles),
 			Identity: tlsca.Identity{
 				AgentScope: scope,
 			},

--- a/lib/auth/machineid/machineidv1/bot_instance_service_test.go
+++ b/lib/auth/machineid/machineidv1/bot_instance_service_test.go
@@ -430,7 +430,7 @@ func TestBotInstanceServiceSubmitHeartbeat(t *testing.T) {
 			identity: tlsca.Identity{
 				BotName:       botName,
 				BotInstanceID: botInstanceID,
-				ScopePin:      &scopesv1.Pin{Scope: "/scopes/test"},
+				ScopePin:      &scopesv1.Pin{Kind: scopesv1.PinKind_PIN_KIND_USER, Scope: "/scopes/test"},
 				BotInternal:   false,
 			},
 			assertErr: func(t assert.TestingT, err error, i ...any) bool {
@@ -448,7 +448,7 @@ func TestBotInstanceServiceSubmitHeartbeat(t *testing.T) {
 			identity: tlsca.Identity{
 				BotName:       botName,
 				BotInstanceID: botInstanceID,
-				ScopePin:      &scopesv1.Pin{Scope: "/scopes/test"},
+				ScopePin:      &scopesv1.Pin{Kind: scopesv1.PinKind_PIN_KIND_USER, Scope: "/scopes/test"},
 				BotInternal:   true,
 			},
 			assertErr:     assert.NoError,

--- a/lib/auth/methods.go
+++ b/lib/auth/methods.go
@@ -90,6 +90,7 @@ func (a *Server) AccessCheckerForScope(ctx context.Context, scope string, userSt
 
 	// set up scope pin (invalid until populated)
 	scopePin := &scopesv1.Pin{
+		Kind:  scopesv1.PinKind_PIN_KIND_USER,
 		Scope: scope,
 	}
 

--- a/lib/auth/middleware.go
+++ b/lib/auth/middleware.go
@@ -45,6 +45,7 @@ import (
 
 	"github.com/gravitational/teleport"
 	apidefaults "github.com/gravitational/teleport/api/defaults"
+	scopesv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/v1"
 	"github.com/gravitational/teleport/api/metadata"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/utils/grpc/interceptors"
@@ -745,6 +746,11 @@ func (a *Middleware) GetUser(connState tls.ConnectionState) (authz.IdentityGette
 				Identity:    *identity,
 			}, nil
 		}
+
+		if identity.ScopePin != nil {
+			return nil, trace.AccessDenied("access denied: scoped identities cannot interact with remote clusters")
+		}
+
 		return newRemoteUserFromIdentity(*identity, certClusterName), nil
 	}
 	// code below expects user or service from local cluster, to distinguish between
@@ -762,6 +768,23 @@ func (a *Middleware) GetUser(connState tls.ConnectionState) (authz.IdentityGette
 			Identity:              *identity,
 		}, nil
 	}
+
+	if identity.ScopePin != nil {
+		switch identity.ScopePin.GetKind() {
+		case scopesv1.PinKind_PIN_KIND_AGENT:
+			return authz.ScopedBuiltinRole{
+				ScopePin:    identity.ScopePin,
+				ServerFQDN:  identity.Username,
+				ClusterName: a.ClusterName,
+				Identity:    *identity,
+			}, nil
+		case scopesv1.PinKind_PIN_KIND_USER:
+			// valid user scope pin, fall through to LocalUser
+		default:
+			return nil, trace.AccessDenied("access denied: identity has scope pin with unrecognized kind %v", identity.ScopePin.GetKind())
+		}
+	}
+
 	// otherwise assume that is a local role, no need to pass the roles
 	// as it will be fetched from the local database
 	return newLocalUserFromIdentity(*identity), nil

--- a/lib/auth/middleware_test.go
+++ b/lib/auth/middleware_test.go
@@ -41,9 +41,11 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc/metadata"
+	"google.golang.org/protobuf/testing/protocmp"
 
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api"
+	scopesv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/auth"
 	"github.com/gravitational/teleport/lib/auth/authtest"
@@ -336,6 +338,51 @@ func subject(t *testing.T, id tlsca.Identity) pkix.Name {
 	// Since we're just mimicking certs in memory, move manually.
 	s.Names = s.ExtraNames
 	return s
+}
+
+// TestMiddlewareGetUserAgentScopePin verifies that GetUser returns a
+// ScopedBuiltinRole when the TLS certificate carries an AgentScopePin.
+func TestMiddlewareGetUserAgentScopePin(t *testing.T) {
+	t.Parallel()
+	const (
+		localClusterName = "local"
+		serverFQDN       = "node-uuid.local"
+	)
+
+	now := time.Now().UTC()
+
+	agentPin := &scopesv1.Pin{
+		Kind:  scopesv1.PinKind_PIN_KIND_AGENT,
+		Scope: "/",
+		SystemRoles: &scopesv1.SystemRoles{
+			Primary: string(types.RoleNode),
+		},
+	}
+
+	identity := tlsca.Identity{
+		Username:          serverFQDN,
+		TeleportCluster:   localClusterName,
+		OriginClusterName: localClusterName,
+		ScopePin:          agentPin,
+		Expires:           now,
+	}
+
+	m := &auth.Middleware{ClusterName: localClusterName}
+	id, err := m.GetUser(tls.ConnectionState{
+		PeerCertificates: []*x509.Certificate{{
+			Subject:  subject(t, identity),
+			NotAfter: now,
+			Issuer:   pkix.Name{Organization: []string{localClusterName}},
+		}},
+	})
+	require.NoError(t, err)
+
+	got, ok := id.(authz.ScopedBuiltinRole)
+	require.True(t, ok, "expected ScopedBuiltinRole, got %T", id)
+	require.Empty(t, cmp.Diff(agentPin, got.ScopePin, protocmp.Transform()))
+	require.Equal(t, serverFQDN, got.ServerFQDN)
+	require.Equal(t, localClusterName, got.ClusterName)
+	require.Empty(t, cmp.Diff(identity, got.Identity, cmpopts.EquateEmpty(), protocmp.Transform()))
 }
 
 func TestMiddleware_ServeHTTP(t *testing.T) {

--- a/lib/auth/scopes/access/service_test.go
+++ b/lib/auth/scopes/access/service_test.go
@@ -231,6 +231,7 @@ func TestRoleBasics(t *testing.T) {
 	// set up server pinned to a staging admin identity
 	srv := newServerForIdentity(t, bk, &services.AccessInfo{
 		ScopePin: &scopesv1.Pin{
+			Kind:  scopesv1.PinKind_PIN_KIND_USER,
 			Scope: "/staging",
 			AssignmentTree: pinning.AssignmentTreeFromMap(map[string]map[string][]string{
 				"/staging": {"/staging": {"staging-admin"}},
@@ -561,6 +562,7 @@ func TestAssignmentBasics(t *testing.T) {
 	// set up server pinned to a staging admin identity
 	srv := newServerForIdentity(t, bk, &services.AccessInfo{
 		ScopePin: &scopesv1.Pin{
+			Kind:  scopesv1.PinKind_PIN_KIND_USER,
 			Scope: "/staging",
 			AssignmentTree: pinning.AssignmentTreeFromMap(map[string]map[string][]string{
 				"/staging": {"/staging": {"staging-admin"}},
@@ -1157,6 +1159,7 @@ func TestAccessChecksSkipInconsistentAssignments(t *testing.T) {
 	// even after we make staging-admin inconsistent below).
 	aliceAccessInfo := &services.AccessInfo{
 		ScopePin: &scopesv1.Pin{
+			Kind:  scopesv1.PinKind_PIN_KIND_USER,
 			Scope: "/staging",
 			AssignmentTree: pinning.AssignmentTreeFromMap(map[string]map[string][]string{
 				"/staging": {"/staging": {"staging-reader", "staging-admin"}},

--- a/lib/auth/scopes/joining/service_test.go
+++ b/lib/auth/scopes/joining/service_test.go
@@ -69,6 +69,7 @@ func TestScopedJoiningService(t *testing.T) {
 	t.Run("basic", func(t *testing.T) {
 		service := newServerForIdentity(t, pack, &services.AccessInfo{
 			ScopePin: &scopesv1.Pin{
+				Kind:  scopesv1.PinKind_PIN_KIND_USER,
 				Scope: "/staging",
 				AssignmentTree: pinning.AssignmentTreeFromMap(map[string]map[string][]string{
 					"/staging": {"/staging": {"staging-admin"}},
@@ -177,6 +178,7 @@ func TestScopedJoiningService(t *testing.T) {
 	t.Run("auth", func(t *testing.T) {
 		admin := newServerForIdentity(t, pack, &services.AccessInfo{
 			ScopePin: &scopesv1.Pin{
+				Kind:  scopesv1.PinKind_PIN_KIND_USER,
 				Scope: "/staging",
 				AssignmentTree: pinning.AssignmentTreeFromMap(map[string]map[string][]string{
 					"/staging": {"/staging": {"staging-admin"}},
@@ -186,6 +188,7 @@ func TestScopedJoiningService(t *testing.T) {
 
 		writer := newServerForIdentity(t, pack, &services.AccessInfo{
 			ScopePin: &scopesv1.Pin{
+				Kind:  scopesv1.PinKind_PIN_KIND_USER,
 				Scope: "/staging/aa",
 				AssignmentTree: pinning.AssignmentTreeFromMap(map[string]map[string][]string{
 					"/staging/aa": {"/staging/aa": {"staging-create"}},
@@ -195,6 +198,7 @@ func TestScopedJoiningService(t *testing.T) {
 
 		reader := newServerForIdentity(t, pack, &services.AccessInfo{
 			ScopePin: &scopesv1.Pin{
+				Kind:  scopesv1.PinKind_PIN_KIND_USER,
 				Scope: "/staging/aa",
 				AssignmentTree: pinning.AssignmentTreeFromMap(map[string]map[string][]string{
 					"/staging/aa": {"/staging/aa": {"staging-read"}},
@@ -204,6 +208,7 @@ func TestScopedJoiningService(t *testing.T) {
 
 		readerNoSecrets := newServerForIdentity(t, pack, &services.AccessInfo{
 			ScopePin: &scopesv1.Pin{
+				Kind:  scopesv1.PinKind_PIN_KIND_USER,
 				Scope: "/staging/aa",
 				AssignmentTree: pinning.AssignmentTreeFromMap(map[string]map[string][]string{
 					"/staging/aa": {"/staging/aa": {"staging-readnosecrets"}},
@@ -213,6 +218,7 @@ func TestScopedJoiningService(t *testing.T) {
 
 		deleter := newServerForIdentity(t, pack, &services.AccessInfo{
 			ScopePin: &scopesv1.Pin{
+				Kind:  scopesv1.PinKind_PIN_KIND_USER,
 				Scope: "/staging/aa",
 				AssignmentTree: pinning.AssignmentTreeFromMap(map[string]map[string][]string{
 					"/staging/aa": {"/staging/aa": {"staging-delete"}},
@@ -222,6 +228,7 @@ func TestScopedJoiningService(t *testing.T) {
 
 		updater := newServerForIdentity(t, pack, &services.AccessInfo{
 			ScopePin: &scopesv1.Pin{
+				Kind:  scopesv1.PinKind_PIN_KIND_USER,
 				Scope: "/staging/aa",
 				AssignmentTree: pinning.AssignmentTreeFromMap(map[string]map[string][]string{
 					"/staging/aa": {"/staging/aa": {"staging-upserter"}},

--- a/lib/auth/state/identity.go
+++ b/lib/auth/state/identity.go
@@ -31,10 +31,12 @@ import (
 	"github.com/gravitational/teleport/api/client/proto"
 	apidefaults "github.com/gravitational/teleport/api/defaults"
 	joiningv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/joining/v1"
+	scopesv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/v1"
 	"github.com/gravitational/teleport/api/types"
 	apiutils "github.com/gravitational/teleport/api/utils"
 	"github.com/gravitational/teleport/api/utils/keys"
 	apisshutils "github.com/gravitational/teleport/api/utils/sshutils"
+	"github.com/gravitational/teleport/lib/scopes/pinning"
 	"github.com/gravitational/teleport/lib/tlsca"
 	"github.com/gravitational/teleport/lib/utils"
 	"github.com/gravitational/teleport/lib/utils/set"
@@ -87,6 +89,8 @@ type Identity struct {
 	ClusterName string
 	// SystemRoles is a list of additional system roles.
 	SystemRoles []string
+	// ScopePin pins a scoped agent to a specific scope and encodes the agent's system roles.
+	ScopePin *scopesv1.Pin
 	// AgentScope is the scope an identity is constrained to.
 	AgentScope string
 	// ImmutableLabelHash is the hash used to verify immutable labels against
@@ -94,6 +98,19 @@ type Identity struct {
 	ImmutableLabelHash string
 	// ImmutableLabels are the immutable labels assigned to this identity at join time.
 	ImmutableLabels *joiningv1.ImmutableLabels
+}
+
+// GetAgentScope returns the effective agent scope for this identity. Returns empty string
+// for unscoped agents and non-agent certs.
+// TODO(fspmarshall/scopes): remove this helper once we've fully transitioned to pinned agents.
+func (i *Identity) GetAgentScope() string {
+	if i.AgentScope != "" {
+		return i.AgentScope
+	}
+	if i.ScopePin.GetKind() == scopesv1.PinKind_PIN_KIND_AGENT {
+		return i.ScopePin.GetScope()
+	}
+	return ""
 }
 
 // HasSystemRole checks if this identity encompasses the supplied system role.
@@ -270,14 +287,35 @@ func ReadTLSIdentityFromKeyPair(keyBytes, certBytes []byte, caCertsBytes [][]byt
 	if clusterName == "" {
 		return nil, trace.BadParameter("missing cluster name")
 	}
+	// Agent pin TLS certs omit Groups and SystemRoles for fail-closed compatibility;
+	// role and additional roles are carried exclusively in ScopePin.
+	var role types.SystemRole
+	var systemRoles []string
+	if id.ScopePin.GetKind() == scopesv1.PinKind_PIN_KIND_AGENT {
+		primary := id.ScopePin.GetSystemRoles().GetPrimary()
+		if primary == "" {
+			return nil, trace.BadParameter("agent scope pin in TLS certificate is missing primary system role")
+		}
+		role = types.SystemRole(primary)
+		systemRoles = id.ScopePin.GetSystemRoles().GetAdditional()
+	} else {
+		if len(id.Groups) == 0 {
+			return nil, trace.BadParameter("missing identity groups (roles) in TLS certificate")
+		}
+		role = types.SystemRole(id.Groups[0])
+		systemRoles = id.SystemRoles
+	}
+
 	identity := &Identity{
-		ID:              IdentityID{HostUUID: id.Username, Role: types.SystemRole(id.Groups[0])},
+		ID:              IdentityID{HostUUID: id.Username, Role: role},
 		ClusterName:     clusterName,
 		KeyBytes:        keyBytes,
 		TLSCertBytes:    certBytes,
 		TLSCACertsBytes: caCertsBytes,
 		XCert:           cert,
-		SystemRoles:     id.SystemRoles,
+		SystemRoles:     systemRoles,
+		ScopePin:        id.ScopePin,
+		AgentScope:      id.AgentScope,
 	}
 	// The passed in ciphersuites don't appear to matter here since the returned
 	// *tls.Config is never actually used?
@@ -329,19 +367,40 @@ func ReadSSHIdentityFromKeyPair(keyBytes, certBytes []byte) (*Identity, error) {
 		return nil, trace.BadParameter("extensions: missing needed extensions for host roles")
 	}
 	roleString := cert.Permissions.Extensions[utils.CertExtensionRole]
-	if roleString == "" {
+
+	// Decode the agent scope pin first: it may carry the primary role for
+	// agent-pin certs, which deliberately omit the legacy SystemRole extension.
+	var scopePin *scopesv1.Pin
+	if encoded, ok := cert.Permissions.Extensions[teleport.CertExtensionAgentScopePin]; ok {
+		pin, err := pinning.Decode(encoded)
+		if err != nil {
+			return nil, trace.BadParameter("failed to decode agent scope pin: %v", err)
+		}
+		scopePin = pin
+	}
+
+	var role types.SystemRole
+	if roleString != "" {
+		roles, err := types.ParseTeleportRoles(roleString)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		foundRoles := len(roles)
+		if foundRoles != 1 {
+			return nil, trace.Errorf("expected one role per certificate. found %d: '%s'",
+				foundRoles, roles.String())
+		}
+		role = roles[0]
+	} else if scopePin.GetKind() == scopesv1.PinKind_PIN_KIND_AGENT {
+		primary := scopePin.GetSystemRoles().GetPrimary()
+		if primary == "" {
+			return nil, trace.BadParameter("agent scope pin is missing primary system role")
+		}
+		role = types.SystemRole(primary)
+	} else {
 		return nil, trace.BadParameter("missing cert extension %v", utils.CertExtensionRole)
 	}
-	roles, err := types.ParseTeleportRoles(roleString)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	foundRoles := len(roles)
-	if foundRoles != 1 {
-		return nil, trace.Errorf("expected one role per certificate. found %d: '%s'",
-			foundRoles, roles.String())
-	}
-	role := roles[0]
+
 	clusterName := cert.Permissions.Extensions[utils.CertExtensionAuthority]
 	if clusterName == "" {
 		return nil, trace.BadParameter("missing cert extension %v", utils.CertExtensionAuthority)
@@ -357,6 +416,7 @@ func ReadSSHIdentityFromKeyPair(keyBytes, certBytes []byte) (*Identity, error) {
 		CertBytes:          certBytes,
 		KeySigner:          certSigner,
 		Cert:               cert,
+		ScopePin:           scopePin,
 		AgentScope:         agentScope,
 		ImmutableLabelHash: labelHash,
 	}, nil

--- a/lib/auth/state/identity_test.go
+++ b/lib/auth/state/identity_test.go
@@ -20,9 +20,91 @@ import (
 	"crypto/x509"
 	"net"
 	"testing"
+	"time"
 
+	"github.com/jonboulle/clockwork"
 	"github.com/stretchr/testify/require"
+
+	scopesv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/v1"
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/api/utils/keys"
+	"github.com/gravitational/teleport/lib/cryptosuites"
+	"github.com/gravitational/teleport/lib/fixtures"
+	"github.com/gravitational/teleport/lib/tlsca"
 )
+
+// TestReadTLSIdentityFromKeyPairAgentPin verifies that ReadTLSIdentityFromKeyPair correctly handles
+// agent pin TLS certs.
+func TestReadTLSIdentityFromKeyPairAgentPin(t *testing.T) {
+	clock := clockwork.NewFakeClock()
+
+	ca, err := tlsca.FromKeys([]byte(fixtures.TLSCACertPEM), []byte(fixtures.TLSCAKeyPEM))
+	require.NoError(t, err)
+
+	key, err := cryptosuites.GenerateKeyWithAlgorithm(cryptosuites.ECDSAP256)
+	require.NoError(t, err)
+	keyPEM, err := keys.MarshalPrivateKey(key)
+	require.NoError(t, err)
+	caCertPEM := []byte(fixtures.TLSCACertPEM)
+
+	tests := []struct {
+		desc            string
+		pin             *scopesv1.Pin
+		wantRole        types.SystemRole
+		wantSystemRoles []string
+	}{
+		{
+			desc: "single-role agent pin",
+			pin: &scopesv1.Pin{
+				Kind:  scopesv1.PinKind_PIN_KIND_AGENT,
+				Scope: "/staging",
+				SystemRoles: &scopesv1.SystemRoles{
+					Primary: string(types.RoleNode),
+				},
+			},
+			wantRole: types.RoleNode,
+		},
+		{
+			desc: "multi-role instance agent pin",
+			pin: &scopesv1.Pin{
+				Kind:  scopesv1.PinKind_PIN_KIND_AGENT,
+				Scope: "/staging",
+				SystemRoles: &scopesv1.SystemRoles{
+					Primary:    string(types.RoleInstance),
+					Additional: []string{string(types.RoleNode), string(types.RoleKube)},
+				},
+			},
+			wantRole:        types.RoleInstance,
+			wantSystemRoles: []string{string(types.RoleNode), string(types.RoleKube)},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			tlsID := tlsca.Identity{
+				Username: "node-uuid.test-cluster",
+				ScopePin: tt.pin,
+			}
+			subj, err := tlsID.Subject()
+			require.NoError(t, err)
+
+			certPEM, err := ca.GenerateCertificate(tlsca.CertificateRequest{
+				Clock:     clock,
+				PublicKey: key.Public(),
+				Subject:   subj,
+				NotAfter:  clock.Now().Add(time.Hour),
+			})
+			require.NoError(t, err)
+
+			identity, err := ReadTLSIdentityFromKeyPair(keyPEM, certPEM, [][]byte{caCertPEM})
+			require.NoError(t, err)
+
+			require.Equal(t, tt.wantRole, identity.ID.Role)
+			require.Equal(t, tt.wantSystemRoles, identity.SystemRoles)
+			require.True(t, identity.HasSystemRole(tt.wantRole))
+		})
+	}
+}
 
 func TestHasDNSNames(t *testing.T) {
 	require.False(t, (&Identity{XCert: nil}).HasDNSNames(nil))

--- a/lib/auth/vnetconfig/vnetconfigv1/service_test.go
+++ b/lib/auth/vnetconfig/vnetconfigv1/service_test.go
@@ -390,6 +390,7 @@ func newFakeScopedAuthorizer(t *testing.T) fakeScopedAuthorizer {
 	checkerContext, err := services.NewScopedAccessCheckerContext(t.Context(), &services.AccessInfo{
 		Username: "alice",
 		ScopePin: &scopesv1.Pin{
+			Kind:  scopesv1.PinKind_PIN_KIND_USER,
 			Scope: "/test",
 		},
 	}, "test-cluster", fakeScopedRoleReader{})

--- a/lib/authz/permissions.go
+++ b/lib/authz/permissions.go
@@ -38,6 +38,7 @@ import (
 	"github.com/gravitational/teleport/api/defaults"
 	clusterconfigpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/clusterconfig/v1"
 	mfav1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/mfa/v1"
+	scopesv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/v1"
 	"github.com/gravitational/teleport/api/mfa"
 	"github.com/gravitational/teleport/api/types"
 	apievents "github.com/gravitational/teleport/api/types/events"
@@ -438,6 +439,10 @@ func (a *authorizer) Authorize(ctx context.Context) (authCtx *Context, err error
 	}
 
 	if user, ok := userI.(LocalUser); ok && user.Identity.ScopePin != nil {
+		return nil, trace.Errorf("cannot perform standard authz: %w", services.ErrScopedIdentity)
+	}
+
+	if _, ok := userI.(ScopedBuiltinRole); ok {
 		return nil, trace.Errorf("cannot perform standard authz: %w", services.ErrScopedIdentity)
 	}
 
@@ -1876,6 +1881,33 @@ func (r BuiltinRole) GetServerID() string {
 
 // GetIdentity returns client identity
 func (r BuiltinRole) GetIdentity() tlsca.Identity {
+	return r.Identity
+}
+
+// ScopedBuiltinRole is the role of a scoped Teleport service — one whose access is constrained to a specific
+// scope via a scope pin. It is intentionally a distinct type from [BuiltinRole] so that code paths
+// handling builtin roles must explicitly opt into supporting scoped agents.
+type ScopedBuiltinRole struct {
+	// ScopePin is the agent scope pin, encoding the target scope and the agent's system roles.
+	ScopePin *scopesv1.Pin
+
+	// ServerFQDN is the host FQDN of the agent, of the form <host-uuid>.<cluster-name>.
+	ServerFQDN string
+
+	// ClusterName is the name of the local cluster.
+	ClusterName string
+
+	// Identity is source x509 used to build this role.
+	Identity tlsca.Identity
+}
+
+// GetServerID extracts the server UUID from the agent's ServerFQDN.
+func (r ScopedBuiltinRole) GetServerID() string {
+	return strings.TrimSuffix(r.ServerFQDN, "."+r.ClusterName)
+}
+
+// GetIdentity returns the client identity.
+func (r ScopedBuiltinRole) GetIdentity() tlsca.Identity {
 	return r.Identity
 }
 

--- a/lib/authz/permissions_test.go
+++ b/lib/authz/permissions_test.go
@@ -38,6 +38,8 @@ import (
 	"github.com/gravitational/teleport/api/constants"
 	"github.com/gravitational/teleport/api/defaults"
 	mfav1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/mfa/v1"
+	scopedaccessv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/access/v1"
+	scopesv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/v1"
 	"github.com/gravitational/teleport/api/mfa"
 	"github.com/gravitational/teleport/api/types"
 	apievents "github.com/gravitational/teleport/api/types/events"
@@ -1618,4 +1620,274 @@ func resourceDiff(res1, res2 types.Resource) string {
 	return cmp.Diff(res1, res2,
 		cmpopts.IgnoreFields(types.Metadata{}, "Revision", "Namespace"),
 		cmpopts.EquateEmpty())
+}
+
+// TestAuthorizeRejectsScopedAgents verifies that Authorize returns the
+// services.ErrScopedIdentity sentinel when called with a ScopedBuiltinRole.
+func TestAuthorizeRejectsScopedAgents(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+
+	_, _, authorizer := newTestResources(t)
+
+	scopedRole := authz.ScopedBuiltinRole{
+		ScopePin: &scopesv1.Pin{
+			Kind:  scopesv1.PinKind_PIN_KIND_AGENT,
+			Scope: "/some/scope",
+			SystemRoles: &scopesv1.SystemRoles{
+				Primary: string(types.RoleNode),
+			},
+		},
+		ServerFQDN:  "node-uuid." + clusterName,
+		ClusterName: clusterName,
+		Identity: tlsca.Identity{
+			Username: "node-uuid." + clusterName,
+		},
+	}
+
+	_, err := authorizer.Authorize(authz.ContextWithUser(ctx, scopedRole))
+	require.ErrorIs(t, err, services.ErrScopedIdentity)
+}
+
+// TestScopedContextLockTargets verifies that ScopedContext.LockTargets() returns the correct
+// set of targets for scoped agent and scoped user identities.
+func TestScopedContextLockTargets(t *testing.T) {
+	t.Parallel()
+
+	t.Run("ScopedBuiltinRole", func(t *testing.T) {
+		scopedCtx := &authz.ScopedContext{
+			Identity: authz.ScopedBuiltinRole{
+				ScopePin: &scopesv1.Pin{
+					Kind:  scopesv1.PinKind_PIN_KIND_AGENT,
+					Scope: "/test",
+					SystemRoles: &scopesv1.SystemRoles{
+						Primary: string(types.RoleNode),
+					},
+				},
+				ServerFQDN:  "node-uuid." + clusterName,
+				ClusterName: clusterName,
+				Identity: tlsca.Identity{
+					Username:  "node-uuid." + clusterName,
+					JoinToken: "test-token",
+				},
+			},
+		}
+
+		want := []types.LockTarget{
+			{ServerID: "node-uuid"},
+			{ServerID: "node-uuid." + clusterName},
+			{JoinToken: "test-token"},
+		}
+		require.ElementsMatch(t, want, scopedCtx.LockTargets())
+	})
+
+	t.Run("ScopedLocalUser", func(t *testing.T) {
+		scopedCtx := &authz.ScopedContext{
+			Identity: authz.LocalUser{
+				Username: "alice",
+				Identity: tlsca.Identity{
+					Username:    "alice",
+					MFAVerified: "mfa-device-id",
+					ScopePin: &scopesv1.Pin{
+						Kind:  scopesv1.PinKind_PIN_KIND_USER,
+						Scope: "/test",
+					},
+				},
+			},
+		}
+
+		want := []types.LockTarget{
+			{User: "alice"},
+			{MFADevice: "mfa-device-id"},
+		}
+		require.ElementsMatch(t, want, scopedCtx.LockTargets())
+	})
+}
+
+// brokenScopedRoleReader is a minimal ScopedRoleReader for use in tests that need a non-nil reader
+// but aren't expected to actually need any scoped roles.
+type brokenScopedRoleReader struct{}
+
+func (f *brokenScopedRoleReader) GetScopedRole(_ context.Context, _ *scopedaccessv1.GetScopedRoleRequest) (*scopedaccessv1.GetScopedRoleResponse, error) {
+	return nil, trace.NotFound("get scoped role failed due to test")
+}
+
+func (f *brokenScopedRoleReader) ListScopedRoles(_ context.Context, _ *scopedaccessv1.ListScopedRolesRequest) (*scopedaccessv1.ListScopedRolesResponse, error) {
+	return nil, trace.NotFound("list scoped roles failed due to test")
+}
+
+// TestAuthorizeScopedWithLocksForScopedBuiltinRole verifies that a server lock blocks
+// a scoped agent from calling AuthorizeScoped.
+func TestAuthorizeScopedWithLocksForScopedBuiltinRole(t *testing.T) {
+	t.Setenv("TELEPORT_UNSTABLE_SCOPES", "yes")
+	ctx := t.Context()
+
+	client, watcher, _ := newTestResources(t)
+	authorizer, err := authz.NewScopedAuthorizer(authz.AuthorizerOpts{
+		ClusterName:      clusterName,
+		AccessPoint:      client,
+		LockWatcher:      watcher,
+		ScopedRoleReader: &brokenScopedRoleReader{},
+	})
+	require.NoError(t, err)
+
+	scopedRole := authz.ScopedBuiltinRole{
+		ScopePin: &scopesv1.Pin{
+			Kind:  scopesv1.PinKind_PIN_KIND_AGENT,
+			Scope: "/test/scope",
+			SystemRoles: &scopesv1.SystemRoles{
+				Primary: string(types.RoleNode),
+			},
+		},
+		ServerFQDN:  "node-uuid." + clusterName,
+		ClusterName: clusterName,
+		Identity: tlsca.Identity{
+			Username: "node-uuid." + clusterName,
+		},
+	}
+
+	// Apply a server lock targeting the node UUID.
+	serverLock, err := types.NewLock("server-lock", types.LockSpecV2{
+		Target: types.LockTarget{ServerID: "node-uuid"},
+	})
+	require.NoError(t, err)
+	upsertLockWithPutEvent(ctx, t, client, watcher, serverLock)
+
+	_, err = authorizer.AuthorizeScoped(authz.ContextWithUser(ctx, scopedRole))
+	require.Error(t, err)
+	require.True(t, trace.IsAccessDenied(err))
+
+	// A different node is not affected by the lock.
+	otherRole := scopedRole
+	otherRole.ServerFQDN = "other-node-uuid." + clusterName
+	otherRole.Identity.Username = "other-node-uuid." + clusterName
+	_, err = authorizer.AuthorizeScoped(authz.ContextWithUser(ctx, otherRole))
+	require.NoError(t, err)
+}
+
+// TestAuthorizeScopedBuiltinRolePartialSkip verifies that AuthorizeScoped succeeds when a scoped agent
+// pin contains a mix of known and unrecognized system roles.
+func TestAuthorizeScopedBuiltinRolePartialSkip(t *testing.T) {
+	t.Setenv("TELEPORT_UNSTABLE_SCOPES", "yes")
+	ctx := t.Context()
+
+	client, watcher, _ := newTestResources(t)
+	authorizer, err := authz.NewScopedAuthorizer(authz.AuthorizerOpts{
+		ClusterName:      clusterName,
+		AccessPoint:      client,
+		LockWatcher:      watcher,
+		ScopedRoleReader: &brokenScopedRoleReader{},
+	})
+	require.NoError(t, err)
+
+	tests := []struct {
+		desc    string
+		roles   []string
+		wantErr bool
+	}{
+		{
+			desc:  "known role only",
+			roles: []string{string(types.RoleNode)},
+		},
+		{
+			desc:  "known + role unsupported for scoped identities",
+			roles: []string{string(types.RoleNode), string(types.RoleProxy)},
+		},
+		{
+			desc:  "known + truly unknown role",
+			roles: []string{string(types.RoleNode), "Foo"},
+		},
+		{
+			desc:  "known + both types of unknown",
+			roles: []string{string(types.RoleNode), string(types.RoleProxy), "Foo"},
+		},
+		{
+			desc:    "only role unsupported for scoped identities",
+			roles:   []string{string(types.RoleProxy)},
+			wantErr: true,
+		},
+		{
+			desc:    "only truly unknown roles",
+			roles:   []string{"Foo"},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			pin := &scopesv1.Pin{
+				Kind:  scopesv1.PinKind_PIN_KIND_AGENT,
+				Scope: "/test/scope",
+				SystemRoles: &scopesv1.SystemRoles{
+					Primary:    string(types.RoleInstance),
+					Additional: tt.roles,
+				},
+			}
+			role := authz.ScopedBuiltinRole{
+				ScopePin:    pin,
+				ServerFQDN:  "node-uuid." + clusterName,
+				ClusterName: clusterName,
+				Identity: tlsca.Identity{
+					Username: "node-uuid." + clusterName,
+				},
+			}
+			_, err := authorizer.AuthorizeScoped(authz.ContextWithUser(ctx, role))
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+// TestAuthorizeScopedWithLocksForScopedLocalUser verifies that a user lock blocks
+// a scoped user from calling AuthorizeScoped.
+func TestAuthorizeScopedWithLocksForScopedLocalUser(t *testing.T) {
+	t.Setenv("TELEPORT_UNSTABLE_SCOPES", "yes")
+	ctx := t.Context()
+
+	client, watcher, _ := newTestResources(t)
+	authorizer, err := authz.NewScopedAuthorizer(authz.AuthorizerOpts{
+		ClusterName:      clusterName,
+		AccessPoint:      client,
+		LockWatcher:      watcher,
+		ScopedRoleReader: &brokenScopedRoleReader{},
+	})
+	require.NoError(t, err)
+
+	user, _, err := authtest.CreateUserAndRole(client, "test-scoped-user", []string{}, nil)
+	require.NoError(t, err)
+
+	scopedPin := &scopesv1.Pin{
+		Kind:  scopesv1.PinKind_PIN_KIND_USER,
+		Scope: "/test/scope",
+	}
+	localUser := authz.LocalUser{
+		Username: user.GetName(),
+		Identity: tlsca.Identity{
+			Username: user.GetName(),
+			ScopePin: scopedPin,
+		},
+	}
+
+	// Apply a user lock.
+	userLock, err := types.NewLock("user-lock", types.LockSpecV2{
+		Target: types.LockTarget{User: user.GetName()},
+	})
+	require.NoError(t, err)
+	upsertLockWithPutEvent(ctx, t, client, watcher, userLock)
+
+	_, err = authorizer.AuthorizeScoped(authz.ContextWithUser(ctx, localUser))
+	require.Error(t, err)
+	require.True(t, trace.IsAccessDenied(err))
+
+	// A different user is not affected by the lock.
+	user2, _, err := authtest.CreateUserAndRole(client, "test-scoped-user-2", []string{}, nil)
+	require.NoError(t, err)
+	otherUser := localUser
+	otherUser.Username = user2.GetName()
+	otherUser.Identity.Username = user2.GetName()
+	_, err = authorizer.AuthorizeScoped(authz.ContextWithUser(ctx, otherUser))
+	require.NoError(t, err)
 }

--- a/lib/authz/scoped.go
+++ b/lib/authz/scoped.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/scopes"
+	"github.com/gravitational/teleport/lib/scopes/pinning"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/services/readonly"
 )
@@ -102,28 +103,79 @@ func (a *authorizer) authorizeScoped(ctx context.Context) (scopedCtx *ScopedCont
 		return nil, trace.Wrap(err)
 	}
 
-	user, ok := userI.(LocalUser)
-	if !ok {
-		return nil, trace.AccessDenied("scoped authorization is only supported for local users, got %T", userI)
+	switch user := userI.(type) {
+	case LocalUser:
+		if user.Identity.ScopePin == nil {
+			return nil, trace.AccessDenied("scoped authorization is not supported for unscoped identities")
+		}
+		if a.scopedRoleReader == nil {
+			return nil, trace.AccessDenied("authorizer not configured for scoped authorization")
+		}
+		scopedCtx, err = scopedContextForLocalUser(ctx, user, a.accessPoint, a.scopedRoleReader, a.clusterName)
+	case ScopedBuiltinRole:
+		scopedCtx, err = a.scopedContextForBuiltinRole(ctx, user)
+	default:
+		return nil, trace.AccessDenied("scoped authorization is not supported for identity of type %T", userI)
 	}
-
-	if user.Identity.ScopePin == nil {
-		return nil, trace.AccessDenied("scoped authorization is not supported for unscoped identities")
-	}
-
-	if a.scopedRoleReader == nil {
-		return nil, trace.AccessDenied("authorizer not configured for scoped authorization")
-	}
-
-	scopedCtx, err = scopedContextForLocalUser(ctx, user, a.accessPoint, a.scopedRoleReader, a.clusterName)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
-	// TODO(fspmarshall/scopes): include controls like locks/device enforcement here or (better), refactor to
+	// Enforce applicable locks. Scoped identities do not have a means of expressing identity-level locking
+	// mode (though they *can* express locking modes specific to resource access decisions). Since this logic
+	// is dealing with global locks and not specific to any resource access decision, we always use the global
+	// locking mode here.
+	authPref, err := a.readOnlyAccessPoint.GetReadOnlyAuthPreference(ctx)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	if lockErr := a.lockWatcher.CheckLockInForce(authPref.GetLockingMode(), scopedCtx.LockTargets()...); lockErr != nil {
+		return nil, trace.Wrap(lockErr)
+	}
+
+	// TODO(fspmarshall/scopes): add device enforcement and other controls here or (better), refactor to
 	// have enforcement use a common implementation across scoped/unscoped authorize variants.
 
 	return scopedCtx, nil
+}
+
+// scopedContextForBuiltinRole builds a ScopedContext for a scoped agent identity.
+func (a *authorizer) scopedContextForBuiltinRole(ctx context.Context, role ScopedBuiltinRole) (*ScopedContext, error) {
+	recConfig, err := a.readOnlyAccessPoint.GetReadOnlySessionRecordingConfig(ctx)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	// scoped agent authorization mirrors scoped user authorization in that it treats each role as an individual
+	// checker. building a scoped access checker context for a scoped agent requires providing per-role checkers
+	// organized by system role name, as they appear in the pin.
+	checkersByRole := make(map[string]*services.ScopedAccessChecker)
+	for sr := range pinning.SystemRoles(role.ScopePin) {
+		// TODO(fspmarshall/scopes): investigate the possibility of initializing checkers lazily.
+		roleSet, err := RoleSetForBuiltinRoles(role.ClusterName, recConfig, true /* isScoped */, sr)
+		if err != nil {
+			// skip system roles we cannot build a checker for. in theory this aught to only happen for unrecognized
+			// roles (e.g. due to the certificate having been issued by a teleport version which supports a system role
+			// that we do not).
+			a.logger.WarnContext(ctx, "skipping system role in scoped agent pin, role will confer no privileges",
+				"role", sr, "error", err)
+			continue
+		}
+		checker := services.NewAccessCheckerWithRoleSet(&services.AccessInfo{
+			Roles: []string{string(sr)},
+		}, role.ClusterName, roleSet)
+		checkersByRole[string(sr)] = services.NewScopedAccessCheckerForSystemRole(string(sr), checker)
+	}
+
+	checkerContext, err := services.NewScopedAccessCheckerContextForAgentPin(role.ScopePin, checkersByRole)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return &ScopedContext{
+		Identity:       role,
+		CheckerContext: checkerContext,
+	}, nil
 }
 
 func scopedContextForLocalUser(ctx context.Context, u LocalUser, accessPoint AuthorizerAccessPoint, reader services.ScopedRoleReader, clusterName string) (*ScopedContext, error) {
@@ -171,7 +223,8 @@ func (s *ScopedContext) UnscopedContext() (*Context, bool) {
 }
 
 // RuleContext returns the standard services.Context used for resource-independent rule
-// evaluation.
+// evaluation. For agent pin identities, User is nil and rule evaluation will rely on
+// system-role permissions which do not use user traits in their where-clauses.
 func (s *ScopedContext) RuleContext() services.Context {
 	return services.Context{
 		User: s.User,
@@ -205,7 +258,7 @@ func (s *ScopedContext) GetDisconnectCertExpiryTime() time.Time {
 // LockTargets returns a list of [types.LockTarget] for scoped and unscoped identities.
 // For unscoped identities, the result is unchanged from [AuthContext.LockTargets()] and relies on
 // assigned roles in addition to identity attributes.
-// For scoped identities, the result is nearly identical to [services.LockTargetsFromTLSIdentity].
+// For scoped user identities, the result is nearly identical to [services.LockTargetsFromTLSIdentity].
 // The only difference is that the Groups and AccessRequests are not considered
 // when generating the lock targets.
 func (s *ScopedContext) LockTargets() []types.LockTarget {
@@ -213,8 +266,17 @@ func (s *ScopedContext) LockTargets() []types.LockTarget {
 		return unscopedCtx.LockTargets()
 	}
 	id := s.Identity.GetIdentity()
-	lockTargets := []types.LockTarget{
-		{User: id.Username},
+
+	var lockTargets []types.LockTarget
+	if r, ok := s.Identity.(ScopedBuiltinRole); ok {
+		// Scoped agents are locked via ServerID, not User. This mirrors Context.LockTargets()
+		// for BuiltinRole. Two targets are added for compatibility: the bare UUID and the FQDN.
+		lockTargets = append(lockTargets,
+			types.LockTarget{ServerID: r.GetServerID()},
+			types.LockTarget{ServerID: id.Username},
+		)
+	} else {
+		lockTargets = append(lockTargets, types.LockTarget{User: id.Username})
 	}
 
 	if id.MFAVerified != "" {

--- a/lib/client/api_login_test.go
+++ b/lib/client/api_login_test.go
@@ -363,6 +363,7 @@ func TestTeleportClient_Login_local(t *testing.T) {
 
 				require.NotNil(t, sshIdent.ScopePin)
 				require.Empty(t, cmp.Diff(&scopesv1.Pin{
+					Kind:  scopesv1.PinKind_PIN_KIND_USER,
 					Scope: "/aa",
 					AssignmentTree: pinning.AssignmentTreeFromMap(map[string]map[string][]string{
 						"/aa": {"/aa": {"role-a"}},

--- a/lib/client/client_store.go
+++ b/lib/client/client_store.go
@@ -270,7 +270,7 @@ func (s *Store) ReadProfileStatus(proxyAddressOrProfile string) (*ProfileStatus,
 
 	var scopePin *scopesv1.Pin
 	if profile.Scope != "" {
-		scopePin = &scopesv1.Pin{Scope: profile.Scope}
+		scopePin = &scopesv1.Pin{Kind: scopesv1.PinKind_PIN_KIND_USER, Scope: profile.Scope}
 	}
 
 	// If we can't find a keyRing to match the profile, connect to the keyRing (hardware key),

--- a/lib/decision/ssh_identity_test.go
+++ b/lib/decision/ssh_identity_test.go
@@ -46,10 +46,15 @@ func TestSSHIdentityConversion(t *testing.T) {
 		SystemRole:  types.RoleNode,
 		Username:    "user",
 		ScopePin: &scopesv1.Pin{
+			Kind:  scopesv1.PinKind_PIN_KIND_USER,
 			Scope: "/foo",
 			AssignmentTree: pinning.AssignmentTreeFromMap(map[string]map[string][]string{
 				"/": {"/": {"role1", "role2"}},
 			}),
+			SystemRoles: &scopesv1.SystemRoles{
+				Primary:    string(types.RoleNode),
+				Additional: []string{string(types.RoleProxy)},
+			},
 		},
 		Impersonator:            "impersonator",
 		Principals:              []string{"login1", "login2"},
@@ -130,6 +135,9 @@ func TestSSHIdentityConversion(t *testing.T) {
 		"Pin.XXX_unrecognized",
 		"Pin.XXX_sizecache",
 		"Pin.Assignments", // TODO(fspamrshall/scopes): deprecate & remove assignments field
+		"SystemRoles.XXX_NoUnkeyedLiteral",
+		"SystemRoles.XXX_unrecognized",
+		"SystemRoles.XXX_sizecache",
 		"PinnedAssignments.XXX_NoUnkeyedLiteral",
 		"PinnedAssignments.XXX_unrecognized",
 		"PinnedAssignments.XXX_sizecache",

--- a/lib/decision/tls_identity_test.go
+++ b/lib/decision/tls_identity_test.go
@@ -47,6 +47,7 @@ func TestTLSIdentity_roundtrip(t *testing.T) {
 	fullIdentity := &decisionpb.TLSIdentity{
 		Username: "user",
 		ScopePin: &scopesv1.Pin{
+			Kind:  scopesv1.PinKind_PIN_KIND_USER,
 			Scope: "/foo",
 			AssignmentTree: pinning.AssignmentTreeFromMap(map[string]map[string][]string{
 				"/": {"/": {"role1", "role2"}},

--- a/lib/join/server.go
+++ b/lib/join/server.go
@@ -459,7 +459,7 @@ func (s *Server) authenticate(ctx context.Context, diag *diagnostic.Diagnostic, 
 		HostID:        hostID,
 		BotInstanceID: botInstanceID,
 		BotGeneration: botGeneration,
-		Scope:         id.AgentScope,
+		Scope:         id.GetAgentScope(),
 	}, nil
 }
 

--- a/lib/kube/proxy/forwarder_test.go
+++ b/lib/kube/proxy/forwarder_test.go
@@ -1653,7 +1653,7 @@ func newScopedKubeAuthorizer(t *testing.T, cfg scopedKubeAuthorizerConfig) mockA
 		role: role,
 	}
 
-	pin := &scopesv1.Pin{Scope: scopedTestScope}
+	pin := &scopesv1.Pin{Kind: scopesv1.PinKind_PIN_KIND_USER, Scope: scopedTestScope}
 	pin.AssignmentTree = pinning.AssignmentTreeFromMap(map[string]map[string][]string{
 		"/": {
 			scopedTestScope: {scopedTestRole},

--- a/lib/proxy/router_test.go
+++ b/lib/proxy/router_test.go
@@ -182,45 +182,45 @@ func TestScopePinning(t *testing.T) {
 		{
 			name:      "unscoped node unreachable when pinned",
 			host:      "unscoped.example.com",
-			pin:       &scopesv1.Pin{Scope: "/staging"},
+			pin:       &scopesv1.Pin{Kind: scopesv1.PinKind_PIN_KIND_USER, Scope: "/staging"},
 			unmatched: true,
 		},
 		{
 			name: "parent scoped node reachable when pinned to exact scope",
 			host: "unique-parent.example.com",
-			pin:  &scopesv1.Pin{Scope: "/staging"},
+			pin:  &scopesv1.Pin{Kind: scopesv1.PinKind_PIN_KIND_USER, Scope: "/staging"},
 		},
 		{
 			name:      "parent scoped node unreachable when pinned to child scope",
 			host:      "unique-parent.example.com",
-			pin:       &scopesv1.Pin{Scope: "/staging/west"},
+			pin:       &scopesv1.Pin{Kind: scopesv1.PinKind_PIN_KIND_USER, Scope: "/staging/west"},
 			unmatched: true,
 		},
 		{
 			name: "child scoped node reachable when pinned to child scope",
 			host: "unique-child.example.com",
-			pin:  &scopesv1.Pin{Scope: "/staging/west"},
+			pin:  &scopesv1.Pin{Kind: scopesv1.PinKind_PIN_KIND_USER, Scope: "/staging/west"},
 		},
 		{
 			name: "child scoped node reachable when pinned to parent scope",
 			host: "unique-child.example.com",
-			pin:  &scopesv1.Pin{Scope: "/staging"},
+			pin:  &scopesv1.Pin{Kind: scopesv1.PinKind_PIN_KIND_USER, Scope: "/staging"},
 		},
 		{
 			name: "no collisions from orthogonal scopes when pinned",
 			host: "orthogonal.example.com",
-			pin:  &scopesv1.Pin{Scope: "/staging"},
+			pin:  &scopesv1.Pin{Kind: scopesv1.PinKind_PIN_KIND_USER, Scope: "/staging"},
 		},
 		{
 			name:      "parent/child conflict when pinned to parent",
 			host:      "parent-child.example.com",
-			pin:       &scopesv1.Pin{Scope: "/staging"},
+			pin:       &scopesv1.Pin{Kind: scopesv1.PinKind_PIN_KIND_USER, Scope: "/staging"},
 			ambiguous: true,
 		},
 		{
 			name: "parent/child doesn't conflict when pinned to child",
 			host: "parent-child.example.com",
-			pin:  &scopesv1.Pin{Scope: "/staging/west"},
+			pin:  &scopesv1.Pin{Kind: scopesv1.PinKind_PIN_KIND_USER, Scope: "/staging/west"},
 		},
 		{
 			name:      "parent/child conflict when unpinned",

--- a/lib/reversetunnel/srv.go
+++ b/lib/reversetunnel/srv.go
@@ -37,6 +37,7 @@ import (
 	"github.com/gravitational/teleport/api/breaker"
 	"github.com/gravitational/teleport/api/constants"
 	apidefaults "github.com/gravitational/teleport/api/defaults"
+	scopesv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/utils/retryutils"
 	apisshutils "github.com/gravitational/teleport/api/utils/sshutils"
@@ -930,7 +931,7 @@ func (s *server) keyAuth(conn ssh.ConnMetadata, key ssh.PublicKey) (perm *ssh.Pe
 		return nil, trace.Wrap(err)
 	}
 
-	var clusterName, certRole, certType string
+	var clusterName, certRole, certType, certScope string
 	var caType types.CertAuthType
 	switch ident.CertType {
 	case ssh.HostCert:
@@ -939,10 +940,21 @@ func (s *server) keyAuth(conn ssh.ConnMetadata, key ssh.PublicKey) (perm *ssh.Pe
 		}
 		clusterName = ident.ClusterName
 
-		if ident.SystemRole == "" {
+		if ident.SystemRole != "" {
+			// Legacy format: role and scope in separate extensions.
+			certRole = string(ident.SystemRole)
+			certScope = ident.AgentScope
+		} else if ident.ScopePin.GetKind() == scopesv1.PinKind_PIN_KIND_AGENT {
+			// Agent scope pin certs omit the legacy SystemRole and AgentScope extensions;
+			// role and scope are carried inside the pin itself.
+			certRole = ident.ScopePin.GetSystemRoles().GetPrimary()
+			if certRole == "" {
+				return nil, trace.BadParameter("agent scope pin is missing primary system role")
+			}
+			certScope = ident.ScopePin.GetScope()
+		} else {
 			return nil, trace.BadParameter("certificate missing %q extension; this SSH host certificate was not issued by Teleport or issued by an older version of Teleport; try upgrading your Teleport nodes/proxies", utils.CertExtensionRole)
 		}
-		certRole = string(ident.SystemRole)
 		certType = utils.ExtIntCertTypeHost
 		caType = types.HostCA
 	case ssh.UserCert:
@@ -977,7 +989,7 @@ func (s *server) keyAuth(conn ssh.ConnMetadata, key ssh.PublicKey) (perm *ssh.Pe
 			utils.ExtIntCertType: certType,
 			extCertRole:          certRole,
 			extAuthority:         clusterName,
-			extScope:             ident.AgentScope,
+			extScope:             certScope, // TODO(fsparshall/scopes): should agent scoping be propagated pin-encapsulated like we do for users?
 		},
 	}, nil
 }

--- a/lib/reversetunnel/srv_test.go
+++ b/lib/reversetunnel/srv_test.go
@@ -196,7 +196,7 @@ func TestServerKeyAuth(t *testing.T) {
 						Username:   con.User(),
 						Principals: []string{con.User()},
 						Roles:      []string{"dev", "admin"},
-						ScopePin:   &scopesv1.Pin{Scope: "test"},
+						ScopePin:   &scopesv1.Pin{Kind: scopesv1.PinKind_PIN_KIND_USER, Scope: "test"},
 					},
 				})
 				require.NoError(t, err)
@@ -328,6 +328,39 @@ func TestServerKeyAuth(t *testing.T) {
 			}(),
 			// principal mismatch should result in cert validation failure
 			wantErr: require.Error,
+		},
+		{
+			desc: "agent scope pin host cert",
+			key: func() ssh.PublicKey {
+				rawCert, err := ta.GenerateHostCert(sshca.HostCertificateRequest{
+					CASigner:      hostCASigner,
+					PublicHostKey: newPubKey(t),
+					HostID:        "root-host-id",
+					NodeName:      con.User(),
+					Identity: sshca.Identity{
+						ClusterName: "root",
+						ScopePin: &scopesv1.Pin{
+							Kind:  scopesv1.PinKind_PIN_KIND_AGENT,
+							Scope: "test-scope",
+							SystemRoles: &scopesv1.SystemRoles{
+								Primary: string(types.RoleNode),
+							},
+						},
+					},
+				})
+				require.NoError(t, err)
+				key, _, _, _, err := ssh.ParseAuthorizedKey(rawCert)
+				require.NoError(t, err)
+				return key
+			}(),
+			wantExtensions: map[string]string{
+				extHost:              con.User(),
+				utils.ExtIntCertType: utils.ExtIntCertTypeHost,
+				extCertRole:          string(types.RoleNode),
+				extAuthority:         "root",
+				extScope:             "test-scope",
+			},
+			wantErr: require.NoError,
 		},
 		{
 			desc: "not a cert",

--- a/lib/scopes/cache/assignments/pinning.go
+++ b/lib/scopes/cache/assignments/pinning.go
@@ -94,6 +94,7 @@ func (c *AssignmentCache) PopulatePinnedAssignmentsForUser(ctx context.Context, 
 				// write the role assignment to the pin's assignment tree. the write function will automatically handle
 				// deduplication and maintain proper tree structure for evaluation ordering.
 				if err := pinning.WriteRoleAssignment(pin, pinning.RoleAssignment{
+					RoleKind:      pinning.RoleKindUser,
 					ScopeOfOrigin: scopeOfOrigin,
 					ScopeOfEffect: scopeOfEffect,
 					RoleName:      subAssignment.GetRole(),
@@ -238,6 +239,7 @@ func (c *AssignmentCache) PopulatePinnedAssignmentsForBot(
 				// write the role assignment to the pin's assignment tree. the write function will automatically handle
 				// deduplication and maintain proper tree structure for evaluation ordering.
 				if err := pinning.WriteRoleAssignment(pin, pinning.RoleAssignment{
+					RoleKind:      pinning.RoleKindUser,
 					ScopeOfOrigin: scopeOfOrigin,
 					ScopeOfEffect: scopeOfEffect,
 					RoleName:      subAssignment.GetRole(),

--- a/lib/scopes/cache/assignments/pinning_test.go
+++ b/lib/scopes/cache/assignments/pinning_test.go
@@ -226,10 +226,12 @@ func TestPopulatePinnedAssignmentsForUser(t *testing.T) {
 			name: "descendant",
 			user: "bob",
 			pin: &scopesv1.Pin{
+				Kind:  scopesv1.PinKind_PIN_KIND_USER,
 				Scope: "/aa/bb",
 			},
 			ok: true,
 			expect: &scopesv1.Pin{
+				Kind:  scopesv1.PinKind_PIN_KIND_USER,
 				Scope: "/aa/bb",
 				AssignmentTree: pinning.AssignmentTreeFromMap(map[string]map[string][]string{
 					"/":   {"/aa": {"role-01"}},
@@ -241,10 +243,12 @@ func TestPopulatePinnedAssignmentsForUser(t *testing.T) {
 			name: "ancestral",
 			user: "alice",
 			pin: &scopesv1.Pin{
+				Kind:  scopesv1.PinKind_PIN_KIND_USER,
 				Scope: "/",
 			},
 			ok: true,
 			expect: &scopesv1.Pin{
+				Kind:  scopesv1.PinKind_PIN_KIND_USER,
 				Scope: "/",
 				AssignmentTree: pinning.AssignmentTreeFromMap(map[string]map[string][]string{
 					"/":      {"/aa": {"role-01"}, "/bb": {"role-02"}},
@@ -257,6 +261,7 @@ func TestPopulatePinnedAssignmentsForUser(t *testing.T) {
 			name: "orthogonal",
 			user: "carol",
 			pin: &scopesv1.Pin{
+				Kind:  scopesv1.PinKind_PIN_KIND_USER,
 				Scope: "/xx",
 			},
 			ok: false,
@@ -345,6 +350,7 @@ func TestAssignmentTreePruning(t *testing.T) {
 	}
 
 	pin := &scopesv1.Pin{
+		Kind:  scopesv1.PinKind_PIN_KIND_USER,
 		Scope: "/staging/west",
 	}
 	err := cache.PopulatePinnedAssignmentsForUser(t.Context(), "alice", pin)
@@ -530,9 +536,11 @@ func TestPopulatePinnedAssignmentsForBot(t *testing.T) {
 			botName:  "bernard",
 			botScope: bernardScope,
 			pin: &scopesv1.Pin{
+				Kind:  scopesv1.PinKind_PIN_KIND_USER,
 				Scope: bernardScope,
 			},
 			expect: &scopesv1.Pin{
+				Kind:  scopesv1.PinKind_PIN_KIND_USER,
 				Scope: bernardScope,
 				AssignmentTree: pinning.AssignmentTreeFromMap(map[string]map[string][]string{
 					"/":          {bernardScope: {"role-03"}, bernardScope + "/child": {"role-04"}},
@@ -545,9 +553,11 @@ func TestPopulatePinnedAssignmentsForBot(t *testing.T) {
 			botName:  "bernard",
 			botScope: bernardScope,
 			pin: &scopesv1.Pin{
+				Kind:  scopesv1.PinKind_PIN_KIND_USER,
 				Scope: bernardScope + "/child",
 			},
 			expect: &scopesv1.Pin{
+				Kind:  scopesv1.PinKind_PIN_KIND_USER,
 				Scope: bernardScope + "/child",
 				AssignmentTree: pinning.AssignmentTreeFromMap(map[string]map[string][]string{
 					"/":          {bernardScope: {"role-03"}, bernardScope + "/child": {"role-04"}},
@@ -560,6 +570,7 @@ func TestPopulatePinnedAssignmentsForBot(t *testing.T) {
 			botName:  "bernard",
 			botScope: bernardScope,
 			pin: &scopesv1.Pin{
+				Kind:  scopesv1.PinKind_PIN_KIND_USER,
 				Scope: "/bb",
 			},
 			errContains: "is not subject to bot scope",
@@ -569,6 +580,7 @@ func TestPopulatePinnedAssignmentsForBot(t *testing.T) {
 			botName:  "no-such-bot",
 			botScope: "/aa",
 			pin: &scopesv1.Pin{
+				Kind:  scopesv1.PinKind_PIN_KIND_USER,
 				Scope: "/aa",
 			},
 			errContains: "no scoped role assignments found",
@@ -577,6 +589,7 @@ func TestPopulatePinnedAssignmentsForBot(t *testing.T) {
 			name:     "empty bot name",
 			botScope: "/aa",
 			pin: &scopesv1.Pin{
+				Kind:  scopesv1.PinKind_PIN_KIND_USER,
 				Scope: "/aa",
 			},
 			errContains: "missing bot name",
@@ -585,6 +598,7 @@ func TestPopulatePinnedAssignmentsForBot(t *testing.T) {
 			name:    "empty bot scope",
 			botName: "bernard",
 			pin: &scopesv1.Pin{
+				Kind:  scopesv1.PinKind_PIN_KIND_USER,
 				Scope: "/aa",
 			},
 			errContains: "missing bot scope",
@@ -594,6 +608,7 @@ func TestPopulatePinnedAssignmentsForBot(t *testing.T) {
 			botName:  "bernard",
 			botScope: bernardScope,
 			pin: &scopesv1.Pin{
+				Kind:  scopesv1.PinKind_PIN_KIND_USER,
 				Scope: bernardScope,
 				AssignmentTree: pinning.AssignmentTreeFromMap(map[string]map[string][]string{
 					"/": {bernardScope: {"role-03"}},

--- a/lib/scopes/pinning/encoding_test.go
+++ b/lib/scopes/pinning/encoding_test.go
@@ -178,6 +178,52 @@ func TestEncodeDecodeErrors(t *testing.T) {
 	})
 }
 
+// TestEncodeDecodeAgentPin tests that encoding and then decoding an agent scope Pin returns the original pin.
+func TestEncodeDecodeAgentPin(t *testing.T) {
+	t.Parallel()
+
+	tts := []struct {
+		name string
+		pin  *scopesv1.Pin
+	}{
+		{
+			name: "scope and primary system role only",
+			pin: &scopesv1.Pin{
+				Kind:  scopesv1.PinKind_PIN_KIND_AGENT,
+				Scope: "/foo",
+				SystemRoles: &scopesv1.SystemRoles{
+					Primary: "Node",
+				},
+			},
+		},
+		{
+			name: "with additional system roles",
+			pin: &scopesv1.Pin{
+				Kind:  scopesv1.PinKind_PIN_KIND_AGENT,
+				Scope: "/staging/west",
+				SystemRoles: &scopesv1.SystemRoles{
+					Primary:    "Instance",
+					Additional: []string{"Node", "Proxy", "KubeProxy"},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tts {
+		t.Run(tt.name, func(t *testing.T) {
+			encoded, err := Encode(tt.pin)
+			require.NoError(t, err)
+			require.NotEmpty(t, encoded)
+
+			decoded, err := Decode(encoded)
+			require.NoError(t, err)
+			require.NotNil(t, decoded)
+
+			require.Empty(t, cmp.Diff(tt.pin, decoded, protocmp.Transform()))
+		})
+	}
+}
+
 // TestDecodeKnown tests that decoding a known encoding returns the expected Pin. This includes
 // verification that Decode correctly handles json input.  As a rule we don't *need* decode to
 // continue to handle json input as the scopes feature was still highly unstable at the time we

--- a/lib/scopes/pinning/pinning.go
+++ b/lib/scopes/pinning/pinning.go
@@ -28,6 +28,7 @@ import (
 	"google.golang.org/protobuf/proto"
 
 	scopesv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/v1"
+	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/scopes"
 )
 
@@ -44,45 +45,62 @@ func StrongValidate(pin *scopesv1.Pin) error {
 		return trace.Errorf("invalid pinned scope: %w", err)
 	}
 
-	if pin.GetAssignmentTree() == nil {
-		// in theory there isn't any harm in allowing pins to be created without any assignments, but we're choosing to err
-		// on the side of caution for now. this limitation may be lifted later.
-		// NOTE: if lifting this restriction, the equivalent check in the pin building logic must also be lifted.
-		return trace.BadParameter("scope pin at %q contains no assignment tree", pin.GetScope())
-	}
-
-	if len(pin.GetAssignments()) != 0 { //nolint:staticcheck // SA1019.
-		return trace.BadParameter("scope pin uses outdated format, plase ensure all teleport components are upgraded and relogin")
-	}
-
-	// Validate all assignments in the tree by enumerating them
-	hasAssignments := false
-	for assignment := range EnumerateAllAssignments(pin) {
-		hasAssignments = true
-
-		if err := scopes.StrongValidate(assignment.ScopeOfOrigin); err != nil {
-			return trace.Errorf("invalid scope of origin %q in pinned assignment: %w", assignment.ScopeOfOrigin, err)
+	switch pin.GetKind() {
+	case scopesv1.PinKind_PIN_KIND_USER:
+		if pin.GetSystemRoles() != nil {
+			return trace.BadParameter("user scope pin must not have system_roles set")
+		}
+		if pin.GetAssignmentTree() == nil {
+			// in theory there isn't any harm in allowing pins to be created without any assignments, but we're choosing to err
+			// on the side of caution for now. this limitation may be lifted later.
+			// NOTE: if lifting this restriction, the equivalent check in the pin building logic must also be lifted.
+			return trace.BadParameter("scope pin at %q contains no assignment tree", pin.GetScope())
 		}
 
-		if err := scopes.StrongValidate(assignment.ScopeOfEffect); err != nil {
-			return trace.Errorf("invalid scope of effect %q in pinned assignment: %w", assignment.ScopeOfEffect, err)
+		// Validate all assignments in the tree by enumerating them
+		hasAssignments := false
+		for assignment := range EnumerateAllAssignments(pin) {
+			hasAssignments = true
+
+			if err := scopes.StrongValidate(assignment.ScopeOfOrigin); err != nil {
+				return trace.Errorf("invalid scope of origin %q in pinned assignment: %w", assignment.ScopeOfOrigin, err)
+			}
+
+			if err := scopes.StrongValidate(assignment.ScopeOfEffect); err != nil {
+				return trace.Errorf("invalid scope of effect %q in pinned assignment: %w", assignment.ScopeOfEffect, err)
+			}
+
+			if assignment.RoleName == "" {
+				return trace.BadParameter("scope pin at %q contains assignment with empty role name", pin.GetScope())
+			}
+
+			if !PinCompatibleWithPolicyScope(pin, assignment.ScopeOfOrigin) {
+				return trace.BadParameter("scope pin at %q contains assignment with incompatible scope of origin %q", pin.GetScope(), assignment.ScopeOfOrigin)
+			}
+
+			if !PinCompatibleWithPolicyScope(pin, assignment.ScopeOfEffect) {
+				return trace.BadParameter("scope pin at %q contains assignment with incompatible scope of effect %q", pin.GetScope(), assignment.ScopeOfEffect)
+			}
 		}
 
-		if assignment.RoleName == "" {
-			return trace.BadParameter("scope pin at %q contains assignment with empty role name", pin.GetScope())
+		if !hasAssignments {
+			return trace.BadParameter("scope pin at %q contains no assignments", pin.GetScope())
 		}
 
-		if !PinCompatibleWithPolicyScope(pin, assignment.ScopeOfOrigin) {
-			return trace.BadParameter("scope pin at %q contains assignment with incompatible scope of origin %q", pin.GetScope(), assignment.ScopeOfOrigin)
+	case scopesv1.PinKind_PIN_KIND_AGENT:
+		if pin.GetAssignmentTree() != nil {
+			return trace.BadParameter("agent scope pin must not have assignment_tree set")
+		}
+		sr := pin.GetSystemRoles()
+		if sr == nil {
+			return trace.BadParameter("agent scope pin must have system_roles set")
+		}
+		if sr.GetPrimary() == "" {
+			return trace.BadParameter("agent scope pin system_roles must have primary role set")
 		}
 
-		if !PinCompatibleWithPolicyScope(pin, assignment.ScopeOfEffect) {
-			return trace.BadParameter("scope pin at %q contains assignment with incompatible scope of effect %q", pin.GetScope(), assignment.ScopeOfEffect)
-		}
-	}
-
-	if !hasAssignments {
-		return trace.BadParameter("scope pin at %q contains no assignments", pin.GetScope())
+	default:
+		return trace.BadParameter("unknown scope pin kind %v", pin.GetKind())
 	}
 
 	return nil
@@ -91,7 +109,7 @@ func StrongValidate(pin *scopesv1.Pin) error {
 // WeakValidate performs a weak form of validation on a scope pin. This function is intended to catch
 // bugs/incompatibilities that might have resulted in a scope pin too malformed for us to safely reason
 // about (e.g. due to significant version drift). Use this function to validate scope pins extracted from
-// certificates or otherwsie propagated from the control plane. Prefer using [StrongValidate] when building
+// certificates or otherwise propagated from the control plane. Prefer using [StrongValidate] when building
 // a new scope pin from scratch.
 func WeakValidate(pin *scopesv1.Pin) error {
 	if pin == nil {
@@ -102,16 +120,52 @@ func WeakValidate(pin *scopesv1.Pin) error {
 		return trace.Errorf("invalid pinned scope: %w", err)
 	}
 
-	if len(pin.GetAssignments()) != 0 { //nolint:staticcheck // SA1019.
-		return trace.BadParameter("scope pin uses outdated format, plase ensure all teleport components are upgraded and relogin")
+	switch pin.GetKind() {
+	case scopesv1.PinKind_PIN_KIND_USER:
+		// Note that we do not validate the assignment tree here. Scoped access checks are designed to omit
+		// any assignments that are malformed. This is allowable because the scoped role model promises to
+		// never apply deny rules or cross-role side effects via roles. This makes it safe to simply skip
+		// anything we don't understand.
+	case scopesv1.PinKind_PIN_KIND_AGENT:
+		// we generally try to make weak validation as unopinionated as possible barring issues that would
+		// lead to very bad behavior.  However, missing primary system role is likely to lead to confusing and
+		// inconsistent error messages so its preferable to catch it here.
+		if pin.GetSystemRoles().GetPrimary() == "" {
+			return trace.BadParameter("agent scope pin missing primary system role")
+		}
+	default:
+		// we can never handle a scope pin with an unknown kind, as we will not know how to confer privileges
+		// from the pin. It is best to catch unknown scope pin kinds immediately and return a clear error. Note
+		// that adding new scope pin kinds *is* a sensible way to introduce new scope pin features that might
+		// otherwise cause incorrect behavior in outdated agents, so hitting this may not indicate a bug. It
+		// may simply mean that the error-ing teleport isntance is outdated and back-compat safety is working
+		// as intended.
+		return trace.BadParameter("unsupported scope pin kind %v", pin.GetKind())
 	}
 
-	// Note that we do not valdiate the assignment tree here. Scoped access checks are designed to omit
-	// any assignments that are malformed. This is allowable because the scoped role model promises to
-	// never apply deny rules or cross-role side effects via roles. This makes it safe to simply skip
-	// anything we don't understand.
-
 	return nil
+}
+
+// SystemRoles returns an iterator over the effective system roles encoded in an agent scope pin.
+// For instance certs the primary role is Instance (which carries no privileges of its own),
+// so the real roles come from the additional list. For per-service certs the primary role
+// is the sole role.
+func SystemRoles(pin *scopesv1.Pin) iter.Seq[types.SystemRole] {
+	return func(yield func(types.SystemRole) bool) {
+		sr := pin.GetSystemRoles()
+		primary := types.SystemRole(sr.GetPrimary())
+		if primary == types.RoleInstance {
+			for _, r := range sr.GetAdditional() {
+				if !yield(types.SystemRole(r)) {
+					return
+				}
+			}
+			return
+		}
+		if primary != "" {
+			yield(primary)
+		}
+	}
 }
 
 // PinCompatibleWithPolicyScope checks if a given policy scope might affect access subject to the pin. When building a
@@ -172,9 +226,13 @@ func AssignmentTreeIntoMap(tree *scopesv1.AssignmentNode) map[string]map[string]
 	return out
 }
 
-// RoleAssignment contains the details of a pinned role assignment. This type is used when building and iterating the assignment
-// tree structure within a scope pin.
+// RoleAssignment contains the details of a pinned role assignment. This type is used when building, iterating, and
+// resolving role assignments within a scope pin. Note that some packages use the zero value as a sentinel, but
+// general-purpose helpers should treat a zero value RoleAssignment as meaningless or invalid.
 type RoleAssignment struct {
+	// RoleKind distinguishes user-assigned scoped roles from system roles.
+	RoleKind RoleKind
+
 	// ScopeOfOrigin is the scope that the role was assigned *from* (i.e. the scope of the assignment resource that specified the
 	// role assignment). Roles with a more ancestral Scope of Origin take precedence over roles with a more descendant Scope of Origin.
 	ScopeOfOrigin string
@@ -190,6 +248,12 @@ type RoleAssignment struct {
 // WriteRoleAssignment encodes a role assignment into the given scope pin's assignment tree. The pin must be compatible
 // with both the scope of origin and scope of effect of the assignment, and the scopes must be valid.
 func WriteRoleAssignment(pin *scopesv1.Pin, assignment RoleAssignment) error {
+	if pin.GetKind() != scopesv1.PinKind_PIN_KIND_USER {
+		return trace.BadParameter("cannot write role assignment to scope pin of kind %v, expected %v", pin.GetKind(), scopesv1.PinKind_PIN_KIND_USER)
+	}
+	if assignment.RoleKind != RoleKindUser {
+		return trace.BadParameter("cannot write non-user role assignment (kind %q) to scope pin assignment tree", assignment.RoleKind)
+	}
 	// verify that the assignment's scopes look like valid scopes.
 	if err := scopes.WeakValidate(assignment.ScopeOfOrigin); err != nil {
 		return trace.Errorf("cannot write role assignment to scope pin, invalid scope of origin %q for role %q: %w", assignment.ScopeOfOrigin, assignment.RoleName, err)
@@ -340,6 +404,7 @@ func yeildRoleNode(node *scopesv1.RoleNode, scopeOfOrigin string, resourceScopeS
 	scopeOfEffect := scopes.Join(resourceScopeSegments[:depth]...)
 	for _, roleName := range node.Roles {
 		if !yield(RoleAssignment{
+			RoleKind:      RoleKindUser,
 			ScopeOfOrigin: scopeOfOrigin,
 			ScopeOfEffect: scopeOfEffect,
 			RoleName:      roleName,
@@ -351,8 +416,19 @@ func yeildRoleNode(node *scopesv1.RoleNode, scopeOfOrigin string, resourceScopeS
 	return true
 }
 
-// GetRolesAtEnforcementPoint returns an iterator over role names assigned at the specified enforcement point
-// within the assignment tree. Returns an empty iterator if no roles are assigned at that combination.
+// RoleKind distinguishes user-assigned scoped roles from built-in system roles.
+type RoleKind string
+
+const (
+	// RoleKindUser identifies a user-assigned scoped role sourced from the pin's assignment tree.
+	RoleKindUser RoleKind = "user"
+	// RoleKindSystem identifies a built-in system role sourced from the pin's system_roles field.
+	RoleKindSystem RoleKind = "system"
+)
+
+// GetRolesAtEnforcementPoint returns an iterator over RoleAssignments at the specified enforcement point,
+// dispatching on pin kind. For user pins, assignments are sourced from the assignment tree with RoleKind=user.
+// For agent pins, assignments are sourced from system_roles with RoleKind=system.
 //
 // This function is intended to be composed with [scopes.EnforcementPointsForResourceScope] to allow callers to fetch roles
 // at each hierarchy level as they evaluate access. Note that it would be more efficient to build an iterator that
@@ -363,48 +439,86 @@ func yeildRoleNode(node *scopesv1.RoleNode, scopeOfOrigin string, resourceScopeS
 // NOTE: the order in which roles are evaluated is *extremely important* for correct scoped role behavior. Before calling
 // this function in an access evaluation context, ensure that the enforcement points are being processed in the correct
 // order as described in the scopes RFD.
-func GetRolesAtEnforcementPoint(pin *scopesv1.Pin, point scopes.EnforcementPoint) iter.Seq[string] {
-	return func(yield func(string) bool) {
-		if pin == nil || pin.AssignmentTree == nil {
+func GetRolesAtEnforcementPoint(pin *scopesv1.Pin, point scopes.EnforcementPoint) iter.Seq[RoleAssignment] {
+	return func(yield func(RoleAssignment) bool) {
+		if pin == nil {
 			return
 		}
+		switch pin.GetKind() {
+		case scopesv1.PinKind_PIN_KIND_AGENT:
+			getSystemRolesAtEnforcementPoint(pin, point, yield)
+		default:
+			getUserRolesAtEnforcementPoint(pin, point, yield)
+		}
+	}
+}
 
-		if point.ScopeOfOrigin == "" || point.ScopeOfEffect == "" {
+// getUserRolesAtEnforcementPoint yields user-assigned role assignments from the pin's assignment tree at
+// the given enforcement point.
+func getUserRolesAtEnforcementPoint(pin *scopesv1.Pin, point scopes.EnforcementPoint, yield func(RoleAssignment) bool) {
+	if pin.AssignmentTree == nil {
+		return
+	}
+
+	if point.ScopeOfOrigin == "" || point.ScopeOfEffect == "" {
+		return
+	}
+
+	// navigate to the assignment node for the Scope of Origin
+	assignmentNode := pin.AssignmentTree
+	for segment := range scopes.DescendingSegments(point.ScopeOfOrigin) {
+		child, ok := assignmentNode.Children[segment]
+		if !ok {
+			// the scope of origin doesn't exist in the tree
 			return
 		}
+		assignmentNode = child
+	}
 
-		// navigate to the assignment node for the Scope of Origin
-		assignmentNode := pin.AssignmentTree
-		for segment := range scopes.DescendingSegments(point.ScopeOfOrigin) {
-			child, ok := assignmentNode.Children[segment]
-			if !ok {
-				// the scope of origin doesn't exist in the tree
-				return
-			}
-			assignmentNode = child
-		}
+	// navigate to the role node for the Scope of Effect within this assignment node
+	if assignmentNode.RoleTree == nil {
+		return
+	}
 
-		// navigate to the role node for the Scope of Effect within this assignment node
-		if assignmentNode.RoleTree == nil {
+	roleNode := assignmentNode.RoleTree
+	for segment := range scopes.DescendingSegments(point.ScopeOfEffect) {
+		child, ok := roleNode.Children[segment]
+		if !ok {
+			// the scope of effect doesn't exist in the tree
 			return
 		}
+		roleNode = child
+	}
 
-		roleNode := assignmentNode.RoleTree
-		for segment := range scopes.DescendingSegments(point.ScopeOfEffect) {
-			child, ok := roleNode.Children[segment]
-			if !ok {
-				// the scope of effect doesn't exist in the tree
-				return
-			}
-			roleNode = child
+	// yield each role in the order that they are stored. it is the responsibility
+	// of pin construction logic to ensure deterministic ordering.
+	for _, roleName := range roleNode.Roles {
+		if !yield(RoleAssignment{
+			RoleKind:      RoleKindUser,
+			ScopeOfOrigin: point.ScopeOfOrigin,
+			ScopeOfEffect: point.ScopeOfEffect,
+			RoleName:      roleName,
+		}) {
+			return
 		}
+	}
+}
 
-		// yield each role name in the order that they are stored. it is the responsibility
-		// of pin construction logic to ensure deterministic ordering.
-		for _, roleName := range roleNode.Roles {
-			if !yield(roleName) {
-				return
-			}
+// getSystemRolesAtEnforcementPoint yields system role assignments for agent pins. System roles are only
+// present at the (root, root) enforcement point currently. Future work may break up system roles into
+// smaller subsets of privileges assigned at root and agent scope.
+func getSystemRolesAtEnforcementPoint(pin *scopesv1.Pin, point scopes.EnforcementPoint, yield func(RoleAssignment) bool) {
+	if point.ScopeOfOrigin != scopes.Root || point.ScopeOfEffect != scopes.Root {
+		return
+	}
+	for sr := range SystemRoles(pin) {
+		if !yield(RoleAssignment{
+			RoleKind:      RoleKindSystem,
+			ScopeOfOrigin: scopes.Root,
+			ScopeOfEffect: scopes.Root,
+			RoleName:      string(sr),
+		}) {
+			return
 		}
 	}
 }
@@ -459,6 +573,7 @@ func enumerateRoleNode(node *scopesv1.RoleNode, scopeOfOrigin string, effectSegm
 	// Yield all roles at this node
 	for _, roleName := range node.Roles {
 		if !yield(RoleAssignment{
+			RoleKind:      RoleKindUser,
 			ScopeOfOrigin: scopeOfOrigin,
 			ScopeOfEffect: scopeOfEffect,
 			RoleName:      roleName,

--- a/lib/scopes/pinning/pinning_test.go
+++ b/lib/scopes/pinning/pinning_test.go
@@ -42,6 +42,7 @@ func TestValidate(t *testing.T) {
 		{
 			name: "basic",
 			pin: &scopesv1.Pin{
+				Kind:  scopesv1.PinKind_PIN_KIND_USER,
 				Scope: "/foo",
 				AssignmentTree: AssignmentTreeFromMap(map[string]map[string][]string{
 					"/": {"/": {"r1"}, "/foo": {"r2"}, "/foo/bar": {"r3"}},
@@ -63,6 +64,7 @@ func TestValidate(t *testing.T) {
 		{
 			name: "missing assignments",
 			pin: &scopesv1.Pin{
+				Kind:  scopesv1.PinKind_PIN_KIND_USER,
 				Scope: "/foo",
 			},
 			strongOk: false,
@@ -71,6 +73,7 @@ func TestValidate(t *testing.T) {
 		{
 			name: "orthogonal assignment",
 			pin: &scopesv1.Pin{
+				Kind:  scopesv1.PinKind_PIN_KIND_USER,
 				Scope: "/foo",
 				AssignmentTree: AssignmentTreeFromMap(map[string]map[string][]string{
 					"/": {"/": {"r1"}, "/bar": {"r2"}},
@@ -82,6 +85,7 @@ func TestValidate(t *testing.T) {
 		{
 			name: "empty assignments",
 			pin: &scopesv1.Pin{
+				Kind:  scopesv1.PinKind_PIN_KIND_USER,
 				Scope: "/foo",
 			},
 			strongOk: false,
@@ -90,6 +94,7 @@ func TestValidate(t *testing.T) {
 		{
 			name: "malformed assignment scope",
 			pin: &scopesv1.Pin{
+				Kind:  scopesv1.PinKind_PIN_KIND_USER,
 				Scope: "/foo",
 				AssignmentTree: AssignmentTreeFromMap(map[string]map[string][]string{
 					"/":             {"/": {"r1"}},
@@ -158,6 +163,7 @@ func TestDescendAssignmentTree(t *testing.T) {
 			ok:    true,
 			expect: []RoleAssignment{
 				{
+					RoleKind:      RoleKindUser,
 					ScopeOfOrigin: "/foo",
 					ScopeOfEffect: "/foo",
 					RoleName:      "r1",
@@ -184,11 +190,13 @@ func TestDescendAssignmentTree(t *testing.T) {
 			ok:    true,
 			expect: []RoleAssignment{
 				{
+					RoleKind:      RoleKindUser,
 					ScopeOfOrigin: "/",
 					ScopeOfEffect: "/",
 					RoleName:      "r1",
 				},
 				{
+					RoleKind:      RoleKindUser,
 					ScopeOfOrigin: "/foo",
 					ScopeOfEffect: "/foo",
 					RoleName:      "r2",
@@ -211,11 +219,13 @@ func TestDescendAssignmentTree(t *testing.T) {
 			ok:    true,
 			expect: []RoleAssignment{
 				{
+					RoleKind:      RoleKindUser,
 					ScopeOfOrigin: "/",
 					ScopeOfEffect: "/foo",
 					RoleName:      "r2",
 				},
 				{
+					RoleKind:      RoleKindUser,
 					ScopeOfOrigin: "/",
 					ScopeOfEffect: "/",
 					RoleName:      "r1",
@@ -242,11 +252,13 @@ func TestDescendAssignmentTree(t *testing.T) {
 			ok:    true,
 			expect: []RoleAssignment{
 				{
+					RoleKind:      RoleKindUser,
 					ScopeOfOrigin: "/",
 					ScopeOfEffect: "/",
 					RoleName:      "r1",
 				},
 				{
+					RoleKind:      RoleKindUser,
 					ScopeOfOrigin: "/foo/bar",
 					ScopeOfEffect: "/foo/bar",
 					RoleName:      "r2",
@@ -281,26 +293,31 @@ func TestDescendAssignmentTree(t *testing.T) {
 			ok:    true,
 			expect: []RoleAssignment{
 				{
+					RoleKind:      RoleKindUser,
 					ScopeOfOrigin: "/foo",
 					ScopeOfEffect: "/foo",
 					RoleName:      "a",
 				},
 				{
+					RoleKind:      RoleKindUser,
 					ScopeOfOrigin: "/foo",
 					ScopeOfEffect: "/foo",
 					RoleName:      "b",
 				},
 				{
+					RoleKind:      RoleKindUser,
 					ScopeOfOrigin: "/foo",
 					ScopeOfEffect: "/foo",
 					RoleName:      "c",
 				},
 				{
+					RoleKind:      RoleKindUser,
 					ScopeOfOrigin: "/foo",
 					ScopeOfEffect: "/foo",
 					RoleName:      "q",
 				},
 				{
+					RoleKind:      RoleKindUser,
 					ScopeOfOrigin: "/foo",
 					ScopeOfEffect: "/foo",
 					RoleName:      "x",
@@ -331,31 +348,37 @@ func TestDescendAssignmentTree(t *testing.T) {
 			ok:    true,
 			expect: []RoleAssignment{
 				{
+					RoleKind:      RoleKindUser,
 					ScopeOfOrigin: "/",
 					ScopeOfEffect: "/foo/bar",
 					RoleName:      "rr2",
 				},
 				{
+					RoleKind:      RoleKindUser,
 					ScopeOfOrigin: "/",
 					ScopeOfEffect: "/",
 					RoleName:      "rr1",
 				},
 				{
+					RoleKind:      RoleKindUser,
 					ScopeOfOrigin: "/foo",
 					ScopeOfEffect: "/foo/bar",
 					RoleName:      "rf2",
 				},
 				{
+					RoleKind:      RoleKindUser,
 					ScopeOfOrigin: "/foo",
 					ScopeOfEffect: "/foo/bar",
 					RoleName:      "rf3",
 				},
 				{
+					RoleKind:      RoleKindUser,
 					ScopeOfOrigin: "/foo",
 					ScopeOfEffect: "/foo",
 					RoleName:      "rf1",
 				},
 				{
+					RoleKind:      RoleKindUser,
 					ScopeOfOrigin: "/foo/bar",
 					ScopeOfEffect: "/foo/bar",
 					RoleName:      "rb1",
@@ -537,11 +560,11 @@ func TestGetRolesAtEnforcementPoint(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			var got []string
-			for role := range GetRolesAtEnforcementPoint(tt.pin, scopes.EnforcementPoint{
+			for ref := range GetRolesAtEnforcementPoint(tt.pin, scopes.EnforcementPoint{
 				ScopeOfOrigin: tt.scopeOfOrigin,
 				ScopeOfEffect: tt.scopeOfEffect,
 			}) {
-				got = append(got, role)
+				got = append(got, ref.RoleName)
 			}
 
 			if tt.expect == nil {
@@ -589,12 +612,8 @@ func TestRolesAtEnforcementPointComposition(t *testing.T) {
 	// Collect assignments using EnforcementPointsForResourceScope + GetRolesAtEnforcementPoint
 	var gotAssignments []RoleAssignment
 	for point := range scopes.EnforcementPointsForResourceScope(resourceScope) {
-		for role := range GetRolesAtEnforcementPoint(pin, point) {
-			gotAssignments = append(gotAssignments, RoleAssignment{
-				ScopeOfOrigin: point.ScopeOfOrigin,
-				ScopeOfEffect: point.ScopeOfEffect,
-				RoleName:      role,
-			})
+		for ref := range GetRolesAtEnforcementPoint(pin, point) {
+			gotAssignments = append(gotAssignments, ref)
 		}
 	}
 
@@ -631,7 +650,7 @@ func TestEnumerateAllAssignments(t *testing.T) {
 				}),
 			},
 			expect: []RoleAssignment{
-				{ScopeOfOrigin: "/", ScopeOfEffect: "/", RoleName: "role1"},
+				{RoleKind: RoleKindUser, ScopeOfOrigin: "/", ScopeOfEffect: "/", RoleName: "role1"},
 			},
 		},
 		{
@@ -654,12 +673,12 @@ func TestEnumerateAllAssignments(t *testing.T) {
 				}),
 			},
 			expect: []RoleAssignment{
-				{ScopeOfOrigin: "/", ScopeOfEffect: "/", RoleName: "root-root"},
-				{ScopeOfOrigin: "/", ScopeOfEffect: "/staging", RoleName: "root-staging"},
-				{ScopeOfOrigin: "/", ScopeOfEffect: "/staging/west", RoleName: "root-west"},
-				{ScopeOfOrigin: "/staging", ScopeOfEffect: "/staging", RoleName: "staging-staging"},
-				{ScopeOfOrigin: "/staging", ScopeOfEffect: "/staging/west", RoleName: "staging-west"},
-				{ScopeOfOrigin: "/staging/west", ScopeOfEffect: "/staging/west", RoleName: "west-west"},
+				{RoleKind: RoleKindUser, ScopeOfOrigin: "/", ScopeOfEffect: "/", RoleName: "root-root"},
+				{RoleKind: RoleKindUser, ScopeOfOrigin: "/", ScopeOfEffect: "/staging", RoleName: "root-staging"},
+				{RoleKind: RoleKindUser, ScopeOfOrigin: "/", ScopeOfEffect: "/staging/west", RoleName: "root-west"},
+				{RoleKind: RoleKindUser, ScopeOfOrigin: "/staging", ScopeOfEffect: "/staging", RoleName: "staging-staging"},
+				{RoleKind: RoleKindUser, ScopeOfOrigin: "/staging", ScopeOfEffect: "/staging/west", RoleName: "staging-west"},
+				{RoleKind: RoleKindUser, ScopeOfOrigin: "/staging/west", ScopeOfEffect: "/staging/west", RoleName: "west-west"},
 			},
 		},
 		{
@@ -682,12 +701,12 @@ func TestEnumerateAllAssignments(t *testing.T) {
 				}),
 			},
 			expect: []RoleAssignment{
-				{ScopeOfOrigin: "/", ScopeOfEffect: "/staging", RoleName: "root-staging"},
-				{ScopeOfOrigin: "/", ScopeOfEffect: "/staging/west", RoleName: "root-west"},
-				{ScopeOfOrigin: "/", ScopeOfEffect: "/staging/west/rack", RoleName: "root-rack"},
-				{ScopeOfOrigin: "/staging", ScopeOfEffect: "/staging/west", RoleName: "staging-west"},
-				{ScopeOfOrigin: "/staging", ScopeOfEffect: "/staging/west/rack", RoleName: "staging-rack"},
-				{ScopeOfOrigin: "/staging/west", ScopeOfEffect: "/staging/west/rack", RoleName: "west-rack"},
+				{RoleKind: RoleKindUser, ScopeOfOrigin: "/", ScopeOfEffect: "/staging", RoleName: "root-staging"},
+				{RoleKind: RoleKindUser, ScopeOfOrigin: "/", ScopeOfEffect: "/staging/west", RoleName: "root-west"},
+				{RoleKind: RoleKindUser, ScopeOfOrigin: "/", ScopeOfEffect: "/staging/west/rack", RoleName: "root-rack"},
+				{RoleKind: RoleKindUser, ScopeOfOrigin: "/staging", ScopeOfEffect: "/staging/west", RoleName: "staging-west"},
+				{RoleKind: RoleKindUser, ScopeOfOrigin: "/staging", ScopeOfEffect: "/staging/west/rack", RoleName: "staging-rack"},
+				{RoleKind: RoleKindUser, ScopeOfOrigin: "/staging/west", ScopeOfEffect: "/staging/west/rack", RoleName: "west-rack"},
 			},
 		},
 		{
@@ -704,11 +723,11 @@ func TestEnumerateAllAssignments(t *testing.T) {
 				}),
 			},
 			expect: []RoleAssignment{
-				{ScopeOfOrigin: "/", ScopeOfEffect: "/foo", RoleName: "admin"},
-				{ScopeOfOrigin: "/", ScopeOfEffect: "/foo", RoleName: "developer"},
-				{ScopeOfOrigin: "/", ScopeOfEffect: "/foo", RoleName: "viewer"},
-				{ScopeOfOrigin: "/foo", ScopeOfEffect: "/foo", RoleName: "owner"},
-				{ScopeOfOrigin: "/foo", ScopeOfEffect: "/foo", RoleName: "user"},
+				{RoleKind: RoleKindUser, ScopeOfOrigin: "/", ScopeOfEffect: "/foo", RoleName: "admin"},
+				{RoleKind: RoleKindUser, ScopeOfOrigin: "/", ScopeOfEffect: "/foo", RoleName: "developer"},
+				{RoleKind: RoleKindUser, ScopeOfOrigin: "/", ScopeOfEffect: "/foo", RoleName: "viewer"},
+				{RoleKind: RoleKindUser, ScopeOfOrigin: "/foo", ScopeOfEffect: "/foo", RoleName: "owner"},
+				{RoleKind: RoleKindUser, ScopeOfOrigin: "/foo", ScopeOfEffect: "/foo", RoleName: "user"},
 			},
 		},
 		{
@@ -732,13 +751,13 @@ func TestEnumerateAllAssignments(t *testing.T) {
 				}),
 			},
 			expect: []RoleAssignment{
-				{ScopeOfOrigin: "/", ScopeOfEffect: "/", RoleName: "global"},
-				{ScopeOfOrigin: "/", ScopeOfEffect: "/prod", RoleName: "prod-policy"},
-				{ScopeOfOrigin: "/", ScopeOfEffect: "/staging", RoleName: "staging-policy"},
-				{ScopeOfOrigin: "/prod", ScopeOfEffect: "/prod/eu", RoleName: "eu-admin"},
-				{ScopeOfOrigin: "/prod", ScopeOfEffect: "/prod/us", RoleName: "us-admin"},
-				{ScopeOfOrigin: "/staging", ScopeOfEffect: "/staging/east", RoleName: "east-admin"},
-				{ScopeOfOrigin: "/staging", ScopeOfEffect: "/staging/west", RoleName: "west-admin"},
+				{RoleKind: RoleKindUser, ScopeOfOrigin: "/", ScopeOfEffect: "/", RoleName: "global"},
+				{RoleKind: RoleKindUser, ScopeOfOrigin: "/", ScopeOfEffect: "/prod", RoleName: "prod-policy"},
+				{RoleKind: RoleKindUser, ScopeOfOrigin: "/", ScopeOfEffect: "/staging", RoleName: "staging-policy"},
+				{RoleKind: RoleKindUser, ScopeOfOrigin: "/prod", ScopeOfEffect: "/prod/eu", RoleName: "eu-admin"},
+				{RoleKind: RoleKindUser, ScopeOfOrigin: "/prod", ScopeOfEffect: "/prod/us", RoleName: "us-admin"},
+				{RoleKind: RoleKindUser, ScopeOfOrigin: "/staging", ScopeOfEffect: "/staging/east", RoleName: "east-admin"},
+				{RoleKind: RoleKindUser, ScopeOfOrigin: "/staging", ScopeOfEffect: "/staging/west", RoleName: "west-admin"},
 			},
 		},
 	}

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -372,7 +372,7 @@ func newConnector(clientIdentity, serverIdentity *state.Identity) (*Connector, e
 	c := &Connector{
 		clusterName: clientIdentity.ClusterName,
 		hostID:      clientIdentity.ID.HostUUID,
-		scope:       clientIdentity.AgentScope,
+		scope:       clientIdentity.GetAgentScope(),
 		role:        clientIdentity.ID.Role,
 	}
 	c.clientState.Store(clientState)

--- a/lib/services/scoped_access_checker.go
+++ b/lib/services/scoped_access_checker.go
@@ -78,13 +78,16 @@ func (b *scopedAccessCheckerBuilder) Check() error {
 	return nil
 }
 
-func (b *scopedAccessCheckerBuilder) newCheckerForRole(ctx context.Context, key roleCheckerKey) (*ScopedAccessChecker, error) {
-	if key == defaultImplicitRoleKey {
+func (b *scopedAccessCheckerBuilder) newCheckerForRole(ctx context.Context, key pinning.RoleAssignment) (*ScopedAccessChecker, error) {
+	if key == (pinning.RoleAssignment{}) {
 		return b.newDefaultImplicitChecker(ctx), nil
+	}
+	if key.RoleKind != pinning.RoleKindUser {
+		return nil, trace.BadParameter("cannot build checker for non-user role kind %q (this is a bug)", key.RoleKind)
 	}
 
 	rsp, err := b.reader.GetScopedRole(ctx, &scopedaccessv1.GetScopedRoleRequest{
-		Name: key.roleName,
+		Name: key.RoleName,
 	})
 	if err != nil {
 		if trace.IsNotFound(err) {
@@ -97,15 +100,15 @@ func (b *scopedAccessCheckerBuilder) newCheckerForRole(ctx context.Context, key 
 	// skipped. this check is a critical part of the scopes security model and must always be
 	// performed prior to any enforcement logic related to a scoped role.
 	if !scopedaccess.RoleIsEnforceableAt(rsp.Role, scopes.EnforcementPoint{
-		ScopeOfOrigin: key.scopeOfOrigin,
-		ScopeOfEffect: key.scopeOfEffect,
+		ScopeOfOrigin: key.ScopeOfOrigin,
+		ScopeOfEffect: key.ScopeOfEffect,
 	}) {
 		return nil, errUnenforcceableAssignment
 	}
 
 	// Convert the scoped role to a classic role using the scope of effect.
 	// The scope of effect determines which resources this role's privileges apply to.
-	role, err := scopedaccess.ScopedRoleToRole(rsp.Role, key.scopeOfEffect)
+	role, err := scopedaccess.ScopedRoleToRole(rsp.Role, key.ScopeOfEffect)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -118,8 +121,8 @@ func (b *scopedAccessCheckerBuilder) newCheckerForRole(ctx context.Context, key 
 	checker := newAccessChecker(b.info, b.localCluster, NewRoleSet(role))
 
 	return &ScopedAccessChecker{
-		scopeOfOrigin:       key.scopeOfOrigin,
-		scopeOfEffect:       key.scopeOfEffect,
+		scopeOfOrigin:       key.ScopeOfOrigin,
+		scopeOfEffect:       key.ScopeOfEffect,
 		role:                rsp.Role,
 		scopedCompatChecker: checker,
 	}, nil
@@ -186,6 +189,32 @@ func NewScopedAccessCheckerFromUnscoped(checker AccessChecker) *ScopedAccessChec
 	return &ScopedAccessChecker{unscopedChecker: checker}
 }
 
+// NewScopedAccessCheckerForSystemRole creates a ScopedAccessChecker for a single system role. Currently
+// the checker masquerades as a scoped role checker but pulls all meaningful functionality from the provided
+// unscoped access checker. This is the simplest way to achieve our desired effect of having scoped agent
+// system roles act like scoped roles, but is somewhat brittle. It only works right now because we happen
+// to still defer to the scopedCompatChecker for resource access checks. In the long run we may want to
+// consider providing true scoped role representations of system roles, or more likely representing the
+// system role presets in a format suitable for representation as a scoped or unscoped role.
+// TODO(fspmarshall/scopes): revisit our scoped system role strateg as described above.
+func NewScopedAccessCheckerForSystemRole(roleName string, checker AccessChecker) *ScopedAccessChecker {
+	return &ScopedAccessChecker{
+		scopeOfOrigin: scopes.Root,
+		scopeOfEffect: scopes.Root,
+		role: &scopedaccessv1.ScopedRole{
+			Metadata: &headerv1.Metadata{
+				Name: "system/" + roleName,
+			},
+			Scope:   scopes.Root,
+			Version: types.V1,
+			Spec: &scopedaccessv1.ScopedRoleSpec{
+				AssignableScopes: []string{scopes.Root},
+			},
+		},
+		scopedCompatChecker: checker,
+	}
+}
+
 // isScoped reports whether this checker operates on a scoped identity.
 func (c *ScopedAccessChecker) isScoped() bool {
 	return c.role != nil
@@ -226,6 +255,9 @@ func (c *ScopedAccessChecker) CheckAccessToRules(ctx RuleContext, resource strin
 	if !c.isScoped() {
 		return checkAccessToRulesImpl(c.unscopedChecker, ctx, resource, verbs...)
 	}
+	// XXX: the sanity of [NewScopedAccessCheckerForSystemRole] depends upon us continuing to defer to
+	// scopedCompatChecker for resource permission checks. Any revisiting of this strategy must take
+	// our scoped system role strategy into account.
 	return checkAccessToRulesImpl(c.scopedCompatChecker, ctx, resource, verbs...)
 }
 

--- a/lib/services/scoped_access_checker_context.go
+++ b/lib/services/scoped_access_checker_context.go
@@ -36,31 +36,34 @@ import (
 	"github.com/gravitational/teleport/lib/utils/once"
 )
 
-// roleCheckerKey identifies a unique single-role checker configuration by the combination of
-// scope of origin, scope of effect, and role name.
-type roleCheckerKey struct {
-	scopeOfOrigin string
-	scopeOfEffect string
-	roleName      string
-}
-
-// defaultImplicitRoleKey is a sentinel key used to identify the default implicit role checker in caches.
-var defaultImplicitRoleKey = roleCheckerKey{}
-
 // ScopedAccessCheckerContext is the top-level access checker state, abstracting over scoped and unscoped
-// identities. For scoped identities it builds and caches per-role checkers based on the user's scope pin
-// and role assignments. For unscoped identities it wraps a standard AccessChecker.
+// identities. For scoped identities it builds and caches per-role checkers based on the scope pin and role
+// assignments or system roles. For unscoped identities it wraps a standard AccessChecker.
+//
+// User-vs-agent differences are fully captured at construction time in the checkersAtPoint closure.
+// Once constructed, this type is uniform across both scoped identity kinds.
 type ScopedAccessCheckerContext struct {
-	// scoped path — populated when isScoped()
-	builder              scopedAccessCheckerBuilder
-	cachedCheckerForRole func(ctx context.Context, key roleCheckerKey) (*ScopedAccessChecker, error)
+	// pin is the scope pin for this identity. Non-nil iff isScoped().
+	pin *scopesv1.Pin
 
-	// unscoped path — populated when !isScoped()
+	// traits are the user traits for this context. Nil for agent pin identities.
+	traits wrappers.Traits
+
+	// resolveRef resolves a RoleAssignment to a ScopedAccessChecker. The zero-value RoleAssignment is
+	// the preamble sentinel: user pins return the default implicit role checker, agent pins return nil.
+	// Non-nil iff isScoped().
+	resolveRef func(ctx context.Context, ref pinning.RoleAssignment) (*ScopedAccessChecker, error)
+
+	// enumerateAll enumerates checkers across all role assignments, for cert parameter aggregation.
+	// Non-nil only for user pins; nil for agent pins (cert param aggregation is not supported).
+	enumerateAll func(ctx context.Context) stream.Stream[*ScopedAccessChecker]
+
+	// unscopedChecker wraps a standard AccessChecker for unscoped identities.
+	// Non-nil iff !isScoped().
 	unscopedChecker AccessChecker
 }
 
-// NewScopedAccessCheckerContext builds a ScopedAccessCheckerContext for a scoped identity. The supplied
-// context.Context is captured for propagating cancellation during role loading.
+// NewScopedAccessCheckerContext builds a ScopedAccessCheckerContext for a scoped user identity.
 func NewScopedAccessCheckerContext(ctx context.Context, info *AccessInfo, localCluster string, reader ScopedRoleReader) (*ScopedAccessCheckerContext, error) {
 	builder := scopedAccessCheckerBuilder{
 		info:         info,
@@ -72,11 +75,48 @@ func NewScopedAccessCheckerContext(ctx context.Context, info *AccessInfo, localC
 		return nil, trace.Wrap(err)
 	}
 
+	pin := info.ScopePin
+	if pin.GetKind() != scopesv1.PinKind_PIN_KIND_USER {
+		return nil, trace.BadParameter("cannot create user pin checker context for pin of kind %v", pin.GetKind())
+	}
+
 	cachedCheckerForRole, _ := once.KeyedValue(builder.newCheckerForRole)
 
+	resolveRef := func(ctx context.Context, ref pinning.RoleAssignment) (*ScopedAccessChecker, error) {
+		if ref == (pinning.RoleAssignment{}) {
+			// preamble sentinel: return the default implicit role checker
+			return cachedCheckerForRole(ctx, pinning.RoleAssignment{})
+		}
+		return cachedCheckerForRole(ctx, ref)
+	}
+
+	enumerateAll := func(ctx context.Context) stream.Stream[*ScopedAccessChecker] {
+		return func(yield func(*ScopedAccessChecker, error) bool) {
+			var yielded int
+			var lastErr error
+			for assignment := range pinning.EnumerateAllAssignments(pin) {
+				checker, err := cachedCheckerForRole(ctx, assignment)
+				if err != nil {
+					slog.WarnContext(ctx, "skipping role evaluation due to error", "role_name", assignment.RoleName, "scope_of_origin", assignment.ScopeOfOrigin, "scope_of_effect", assignment.ScopeOfEffect, "error", err)
+					lastErr = err
+					continue
+				}
+				if !yield(checker, nil) {
+					return
+				}
+				yielded++
+			}
+			if yielded == 0 && lastErr != nil {
+				yield(nil, lastErr)
+			}
+		}
+	}
+
 	return &ScopedAccessCheckerContext{
-		builder:              builder,
-		cachedCheckerForRole: cachedCheckerForRole,
+		pin:          pin,
+		traits:       info.Traits,
+		resolveRef:   resolveRef,
+		enumerateAll: enumerateAll,
 	}, nil
 }
 
@@ -85,17 +125,60 @@ func NewScopedAccessCheckerContextFromUnscoped(checker AccessChecker) *ScopedAcc
 	return &ScopedAccessCheckerContext{unscopedChecker: checker}
 }
 
+// NewScopedAccessCheckerContextForAgentPin builds a ScopedAccessCheckerContext for a scoped agent identity.
+// Each entry in checkersByRole maps a system role name to its [ScopedAccessChecker], which must have been
+// built via [NewScopedAccessCheckerForSystemRole].
+//
+// System role checkers are resolved at the (root, root) enforcement point, reflecting that system role
+// permissions are treated as assigned at root scope. Note that this is not necessarily a permanent design
+// choice. Future iterations may choose to represent system role permissions as a combination of root assigned
+// permissions and agent scope assigned permissions. There are pros and cons to either appoach, but we've opted
+// to start with the simpler model for now.
+func NewScopedAccessCheckerContextForAgentPin(pin *scopesv1.Pin, checkersByRole map[string]*ScopedAccessChecker) (*ScopedAccessCheckerContext, error) {
+	if pin == nil {
+		return nil, trace.BadParameter("cannot create scoped access checker context without agent pin")
+	}
+	if pin.GetKind() != scopesv1.PinKind_PIN_KIND_AGENT {
+		return nil, trace.BadParameter("cannot create scoped access checker context for unexpected pin kind %v, expected %v", pin.GetKind(), scopesv1.PinKind_PIN_KIND_AGENT)
+	}
+	if len(checkersByRole) == 0 {
+		return nil, trace.BadParameter("cannot create scoped access checker context without any system role checkers")
+	}
+
+	if err := pinning.WeakValidate(pin); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	resolveRef := func(ctx context.Context, ref pinning.RoleAssignment) (*ScopedAccessChecker, error) {
+		if ref == (pinning.RoleAssignment{}) {
+			// preamble sentinel: agent pins have no implicit role preamble
+			return nil, nil
+		}
+		if ref.RoleKind != pinning.RoleKindSystem {
+			return nil, trace.BadParameter("agent pin resolver received non-system role kind %q (this is a bug)", ref.RoleKind)
+		}
+		checker, ok := checkersByRole[ref.RoleName]
+		if !ok {
+			return nil, trace.BadParameter("no checker found for system role %q", ref.RoleName)
+		}
+		return checker, nil
+	}
+
+	return &ScopedAccessCheckerContext{
+		pin:        pin,
+		resolveRef: resolveRef,
+	}, nil
+}
+
 // isScoped reports whether this context operates on a scoped identity.
 func (c *ScopedAccessCheckerContext) isScoped() bool {
 	return c.unscopedChecker == nil
 }
 
-// ScopePin returns the scope pin for the identity, if the identity is scoped.
+// ScopePin returns the scope pin for the identity, if the identity is scoped (user or agent).
+// Returns (nil, false) for unscoped identities.
 func (c *ScopedAccessCheckerContext) ScopePin() (*scopesv1.Pin, bool) {
-	if !c.isScoped() {
-		return nil, false
-	}
-	return c.builder.info.ScopePin, true
+	return c.pin, c.pin != nil
 }
 
 // CheckersForResourceScope returns a stream of ScopedAccessCheckers in evaluation order for the given resource
@@ -139,43 +222,41 @@ func (c *ScopedAccessCheckerContext) checkersForResourceScope(ctx context.Contex
 		// particular role. For example, if a user has a scoped role assigned at /foo which grants access to all ssh
 		// nodes, but they are pinned to scope /foo/bar, even if a role at /foo permits access, the pin restricts
 		// access to only resources subject to /foo/bar.
-		if enforcePin && !pinning.PinAppliesToResourceScope(c.builder.info.ScopePin, scope) {
-			yield(nil, trace.AccessDenied("scope pin %q does not apply to resource scope %q", c.builder.info.ScopePin.GetScope(), scope))
+		if enforcePin && !pinning.PinAppliesToResourceScope(c.pin, scope) {
+			yield(nil, trace.AccessDenied("scope pin %q does not apply to resource scope %q", c.pin.GetScope(), scope))
 			return
 		}
 
 		var successfullyResolved int
 		var lastErr error
 
-		defaultImplicitChecker, err := c.cachedCheckerForRole(ctx, defaultImplicitRoleKey)
-		if err != nil {
+		// resolve and yield preamble checker if one exists. this step is necessary for user identities in order to
+		// ensure that default implicit role permissions are always evaluated first and always priority equivalent
+		// to a root scope of origin. agent identities do not require this step as they always have checkers with
+		// a root scope of origin. Note that the preamble checker does not count toward successfullyResolved.
+		if preambleChecker, err := c.resolveRef(ctx, pinning.RoleAssignment{}); err != nil {
 			slog.WarnContext(ctx, "skipping default implicit role evaluation due to error", "error", err)
 			lastErr = err
-		} else {
-			// yield the default implicit role checker first. This simulates the presence of the default implicit
-			// role at root scope, ensuring that its privileges are always considered first in evaluation.
-			if !yield(defaultImplicitChecker, nil) {
+		} else if preambleChecker != nil {
+			if !yield(preambleChecker, nil) {
 				return
 			}
-			// note that we are not incrementing successfullyResolved here. the default implicit role doesn't
-			// really count from the perspective of deciding whether or not we're hitting a systemic failure.
 		}
 
 		// iterate through the ordered enforcement points for this resource scope. policy evaluation by scope is ordered first by
 		// Scope of Origin (ancestral to descendant) and then by Scope of Effect (descendant to ancestral within each origin).
 		// We proceed through each permutation in order, evaluating any roles assigned at that specific point.
 		for point := range scopes.EnforcementPointsForResourceScope(scope) {
-			for roleName := range pinning.GetRolesAtEnforcementPoint(c.builder.info.ScopePin, point) {
-				key := roleCheckerKey{
-					scopeOfOrigin: point.ScopeOfOrigin,
-					scopeOfEffect: point.ScopeOfEffect,
-					roleName:      roleName,
-				}
-				checker, err := c.cachedCheckerForRole(ctx, key)
+			for ref := range pinning.GetRolesAtEnforcementPoint(c.pin, point) {
+				checker, err := c.resolveRef(ctx, ref)
 				if err != nil {
 					// in classic teleport access checking skipping a role would be unacceptable due to side effects and deny rules. the scoped model
 					// however relies on cross-role isolation and explicitly allows omission of roles.
-					slog.WarnContext(ctx, "skipping role evaluation due to error", "role_name", roleName, "scope_of_origin", point.ScopeOfOrigin, "scope_of_effect", point.ScopeOfEffect, "error", err)
+					slog.WarnContext(ctx, "skipping role evaluation due to error",
+						"role_name", ref.RoleName,
+						"scope_of_origin", ref.ScopeOfOrigin,
+						"scope_of_effect", ref.ScopeOfEffect,
+						"error", err)
 					lastErr = err
 					continue
 				}
@@ -196,8 +277,8 @@ func (c *ScopedAccessCheckerContext) checkersForResourceScope(ctx context.Contex
 
 // riskyEnumerateScopedCheckers returns a stream of all possible scoped access checkers for the identity,
 // enumerating every role assignment in the pin's assignment tree. The order is undefined and must not be
-// relied upon for access control decisions. This method panics if called on an unscoped context — it is
-// only meaningful for scoped identities.
+// relied upon for access control decisions. This method panics if called on an unscoped context or an agent
+// pin context — it is only meaningful for scoped user identities.
 //
 // Note that use of this method should be treated with extreme caution. Accidental misuse could easily
 // result in a scope isolation violation.
@@ -205,30 +286,10 @@ func (c *ScopedAccessCheckerContext) riskyEnumerateScopedCheckers(ctx context.Co
 	if !c.isScoped() {
 		panic("riskyEnumerateScopedCheckers called on an unscoped access checker context (this is a bug)")
 	}
-	return func(yield func(*ScopedAccessChecker, error) bool) {
-		var yielded int
-		var lastErr error
-		for assignment := range pinning.EnumerateAllAssignments(c.builder.info.ScopePin) {
-			key := roleCheckerKey{
-				scopeOfOrigin: assignment.ScopeOfOrigin,
-				scopeOfEffect: assignment.ScopeOfEffect,
-				roleName:      assignment.RoleName,
-			}
-			checker, err := c.cachedCheckerForRole(ctx, key)
-			if err != nil {
-				slog.WarnContext(ctx, "skipping role evaluation due to error", "role_name", assignment.RoleName, "scope_of_origin", assignment.ScopeOfOrigin, "scope_of_effect", assignment.ScopeOfEffect, "error", err)
-				lastErr = err
-				continue
-			}
-			if !yield(checker, nil) {
-				return
-			}
-			yielded++
-		}
-		if yielded == 0 && lastErr != nil {
-			yield(nil, lastErr)
-		}
+	if c.enumerateAll == nil {
+		panic("riskyEnumerateScopedCheckers called on an agent pin context (this is a bug)")
 	}
+	return c.enumerateAll(ctx)
 }
 
 // CheckMaybeHasAccessToRules returns an error if the context definitely does not have access to the provided
@@ -328,12 +389,12 @@ func (c *ScopedAccessCheckerContext) AccessStateFromTLSIdentity(ctx context.Cont
 	}, nil
 }
 
-// Traits returns the user traits for this context.
+// Traits returns the user traits for this context. Agent pin identities have no traits.
 func (c *ScopedAccessCheckerContext) Traits() wrappers.Traits {
 	if !c.isScoped() {
 		return c.unscopedChecker.Traits()
 	}
-	return c.builder.info.Traits
+	return c.traits
 }
 
 // CertParams returns a sub-context for resolving certificate parameters during certificate generation.

--- a/lib/services/scoped_access_checker_context_test.go
+++ b/lib/services/scoped_access_checker_context_test.go
@@ -30,10 +30,11 @@ import (
 )
 
 func TestScopedAccessCheckerContextRiskyAuthorizeUnpinnedRead(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	checkerContext, err := NewScopedAccessCheckerContext(ctx, &AccessInfo{
 		Username: "alice",
 		ScopePin: &scopesv1.Pin{
+			Kind:  scopesv1.PinKind_PIN_KIND_USER,
 			Scope: "/test/scope",
 		},
 	}, "test-cluster", emptyScopedRoleReader{})
@@ -68,4 +69,149 @@ func (emptyScopedRoleReader) GetScopedRole(context.Context, *scopedaccessv1.GetS
 
 func (emptyScopedRoleReader) ListScopedRoles(context.Context, *scopedaccessv1.ListScopedRolesRequest) (*scopedaccessv1.ListScopedRolesResponse, error) {
 	return &scopedaccessv1.ListScopedRolesResponse{}, nil
+}
+
+// newAgentPinCheckerContext is a test helper that builds a ScopedAccessCheckerContext for an agent pin
+// using an allow-all role set for the given system role.
+func newAgentPinCheckerContext(t *testing.T, pin *scopesv1.Pin) *ScopedAccessCheckerContext {
+	t.Helper()
+	roleName := pin.GetSystemRoles().GetPrimary()
+	roleSet, err := RoleSetFromSpec("test-role", types.RoleSpecV6{
+		Allow: types.RoleConditions{
+			Rules: []types.Rule{types.NewRule(types.Wildcard, RW())},
+		},
+	})
+	require.NoError(t, err)
+	checker := NewAccessCheckerWithRoleSet(&AccessInfo{}, "local-cluster", roleSet)
+	checkersByRole := map[string]*ScopedAccessChecker{
+		roleName: NewScopedAccessCheckerForSystemRole(roleName, checker),
+	}
+	ctx, err := NewScopedAccessCheckerContextForAgentPin(pin, checkersByRole)
+	require.NoError(t, err)
+	return ctx
+}
+
+// TestScopedAccessCheckerContextAgentPin covers the agent-pin mode of ScopedAccessCheckerContext.
+func TestScopedAccessCheckerContextAgentPin(t *testing.T) {
+	t.Parallel()
+
+	const pinScope = "/test/scope"
+
+	newAgentPin := func(scope string, role types.SystemRole) *scopesv1.Pin {
+		return &scopesv1.Pin{
+			Kind:  scopesv1.PinKind_PIN_KIND_AGENT,
+			Scope: scope,
+			SystemRoles: &scopesv1.SystemRoles{
+				Primary: role.String(),
+			},
+		}
+	}
+
+	t.Run("constructor rejects nil pin", func(t *testing.T) {
+		t.Parallel()
+		roleSet, err := RoleSetFromSpec("test-role", types.RoleSpecV6{
+			Allow: types.RoleConditions{
+				Rules: []types.Rule{types.NewRule(types.Wildcard, RW())},
+			},
+		})
+		require.NoError(t, err)
+		checker := NewAccessCheckerWithRoleSet(&AccessInfo{}, "local-cluster", roleSet)
+		scopedChecker := NewScopedAccessCheckerForSystemRole(types.RoleNode.String(), checker)
+
+		_, err = NewScopedAccessCheckerContextForAgentPin(nil, map[string]*ScopedAccessChecker{types.RoleNode.String(): scopedChecker})
+		require.Error(t, err)
+		require.True(t, trace.IsBadParameter(err))
+	})
+
+	t.Run("constructor rejects empty checkers", func(t *testing.T) {
+		t.Parallel()
+		pin := newAgentPin(pinScope, types.RoleNode)
+
+		_, err := NewScopedAccessCheckerContextForAgentPin(pin, nil)
+		require.Error(t, err)
+		require.True(t, trace.IsBadParameter(err))
+	})
+
+	t.Run("successful construction and accessors", func(t *testing.T) {
+		t.Parallel()
+		pin := newAgentPin(pinScope, types.RoleNode)
+		checkerCtx := newAgentPinCheckerContext(t, pin)
+
+		// ScopePin returns the pin for agent pin identities.
+		gotPin, ok := checkerCtx.ScopePin()
+		require.True(t, ok, "ScopePin should return true for agent pin context")
+		require.Equal(t, pin, gotPin)
+
+		// Traits returns nil for agent pin identities.
+		require.Nil(t, checkerCtx.Traits(), "Traits should be nil for agent pin context")
+	})
+
+	t.Run("Decision at pin scope allows access", func(t *testing.T) {
+		t.Parallel()
+		pin := newAgentPin(pinScope, types.RoleNode)
+		checkerCtx := newAgentPinCheckerContext(t, pin)
+
+		called := false
+		err := checkerCtx.Decision(t.Context(), pinScope, func(c *ScopedAccessChecker) error {
+			called = true
+			return c.CheckAccessToRules(&Context{}, types.KindNode, types.VerbRead)
+		})
+		require.NoError(t, err, "Decision at pin scope should succeed")
+		require.True(t, called, "fn should have been called")
+	})
+
+	t.Run("Decision at child of pin scope allows access", func(t *testing.T) {
+		t.Parallel()
+		pin := newAgentPin(pinScope, types.RoleNode)
+		checkerCtx := newAgentPinCheckerContext(t, pin)
+
+		childScope := pinScope + "/child"
+		called := false
+		err := checkerCtx.Decision(t.Context(), childScope, func(c *ScopedAccessChecker) error {
+			called = true
+			return c.CheckAccessToRules(&Context{}, types.KindNode, types.VerbRead)
+		})
+		require.NoError(t, err, "Decision at child scope should succeed")
+		require.True(t, called, "fn should have been called for child scope")
+	})
+
+	t.Run("Decision at root scope is denied when pin is non-root", func(t *testing.T) {
+		t.Parallel()
+		pin := newAgentPin(pinScope, types.RoleNode)
+		checkerCtx := newAgentPinCheckerContext(t, pin)
+
+		called := false
+		err := checkerCtx.Decision(t.Context(), "/", func(c *ScopedAccessChecker) error {
+			called = true
+			return nil
+		})
+		require.Error(t, err, "Decision at root scope should be denied when pin is non-root")
+		require.True(t, trace.IsAccessDenied(err))
+		require.False(t, called, "fn should NOT have been called when pin excludes the scope")
+	})
+
+	t.Run("RiskyAuthorizeUnpinnedRead bypasses pin enforcement", func(t *testing.T) {
+		t.Parallel()
+		pin := newAgentPin(pinScope, types.RoleNode)
+		checkerCtx := newAgentPinCheckerContext(t, pin)
+
+		err := checkerCtx.RiskyAuthorizeUnpinnedRead(t.Context(), UnpinnedReadAuthorization{
+			resourceScope: scopes.Root,
+			kind:          types.KindNode,
+			verbs:         []string{types.VerbRead},
+		}, &Context{})
+		require.NoError(t, err, "RiskyAuthorizeUnpinnedRead should bypass pin enforcement and succeed")
+	})
+
+	t.Run("riskyEnumerateScopedCheckers panics for agent pin context", func(t *testing.T) {
+		t.Parallel()
+		pin := newAgentPin(pinScope, types.RoleNode)
+		checkerCtx := newAgentPinCheckerContext(t, pin)
+
+		require.Panics(t, func() {
+			// Drain the stream to trigger the panic.
+			for range checkerCtx.riskyEnumerateScopedCheckers(t.Context()) {
+			}
+		}, "riskyEnumerateScopedCheckers should panic for agent pin contexts")
+	})
 }

--- a/lib/srv/authhandlers_test.go
+++ b/lib/srv/authhandlers_test.go
@@ -314,6 +314,7 @@ func TestRBAC(t *testing.T) {
 		Version: types.V1,
 	}
 	scopePin := &scopesv1.Pin{
+		Kind:  scopesv1.PinKind_PIN_KIND_USER,
 		Scope: "/test",
 		AssignmentTree: pinning.AssignmentTreeFromMap(map[string]map[string][]string{
 			nodeScope: {nodeScope: {scopedRole.Metadata.Name}},
@@ -526,6 +527,7 @@ func TestScopedRBAC(t *testing.T) {
 		{
 			name: "basic allow",
 			pin: &scopesv1.Pin{
+				Kind:  scopesv1.PinKind_PIN_KIND_USER,
 				Scope: "/staging",
 				AssignmentTree: pinning.AssignmentTreeFromMap(map[string]map[string][]string{
 					"/staging/west": {"/staging/west": {"staging-west-red"}},
@@ -536,6 +538,7 @@ func TestScopedRBAC(t *testing.T) {
 		{
 			name: "too narrow scope",
 			pin: &scopesv1.Pin{
+				Kind:  scopesv1.PinKind_PIN_KIND_USER,
 				Scope: "/staging/west/narrow",
 				AssignmentTree: pinning.AssignmentTreeFromMap(map[string]map[string][]string{
 					"/staging/west": {"/staging/west": {"staging-west-red"}},
@@ -546,6 +549,7 @@ func TestScopedRBAC(t *testing.T) {
 		{
 			name: "label mismatch",
 			pin: &scopesv1.Pin{
+				Kind:  scopesv1.PinKind_PIN_KIND_USER,
 				Scope: "/staging",
 				AssignmentTree: pinning.AssignmentTreeFromMap(map[string]map[string][]string{
 					"/staging/west": {"/staging/west": {"staging-west-blue"}},
@@ -556,6 +560,7 @@ func TestScopedRBAC(t *testing.T) {
 		{
 			name: "scope permission mismatch",
 			pin: &scopesv1.Pin{
+				Kind:  scopesv1.PinKind_PIN_KIND_USER,
 				Scope: "/staging",
 				AssignmentTree: pinning.AssignmentTreeFromMap(map[string]map[string][]string{
 					"/staging/east": {"/staging/east": {"staging-east-red"}},
@@ -566,6 +571,7 @@ func TestScopedRBAC(t *testing.T) {
 		{
 			name: "orthogonal scope",
 			pin: &scopesv1.Pin{
+				Kind:  scopesv1.PinKind_PIN_KIND_USER,
 				Scope: "/prod",
 				AssignmentTree: pinning.AssignmentTreeFromMap(map[string]map[string][]string{
 					"/prod/west": {"/prod/west": {"prod-west-red"}},
@@ -576,6 +582,7 @@ func TestScopedRBAC(t *testing.T) {
 		{
 			name: "no labels",
 			pin: &scopesv1.Pin{
+				Kind:  scopesv1.PinKind_PIN_KIND_USER,
 				Scope: "/staging",
 				AssignmentTree: pinning.AssignmentTreeFromMap(map[string]map[string][]string{
 					"/staging/west": {"/staging/west": {"staging-west-no-labels"}},
@@ -586,6 +593,7 @@ func TestScopedRBAC(t *testing.T) {
 		{
 			name: "wrong login",
 			pin: &scopesv1.Pin{
+				Kind:  scopesv1.PinKind_PIN_KIND_USER,
 				Scope: "/staging",
 				AssignmentTree: pinning.AssignmentTreeFromMap(map[string]map[string][]string{
 					"/staging/west": {"/staging/west": {"staging-west-wrong-login"}},
@@ -1510,6 +1518,7 @@ func TestScopedClientIdleTimeout(t *testing.T) {
 		{
 			name: "no role timeout uses global default",
 			pin: &scopesv1.Pin{
+				Kind:  scopesv1.PinKind_PIN_KIND_USER,
 				Scope: "/staging",
 				AssignmentTree: pinning.AssignmentTreeFromMap(map[string]map[string][]string{
 					"/staging/west": {"/staging/west": {"no-timeout"}},
@@ -1520,6 +1529,7 @@ func TestScopedClientIdleTimeout(t *testing.T) {
 		{
 			name: "role timeout more restrictive than global",
 			pin: &scopesv1.Pin{
+				Kind:  scopesv1.PinKind_PIN_KIND_USER,
 				Scope: "/staging",
 				AssignmentTree: pinning.AssignmentTreeFromMap(map[string]map[string][]string{
 					"/staging/west": {"/staging/west": {"10m-timeout"}},
@@ -1530,6 +1540,7 @@ func TestScopedClientIdleTimeout(t *testing.T) {
 		{
 			name: "role timeout less restrictive than global",
 			pin: &scopesv1.Pin{
+				Kind:  scopesv1.PinKind_PIN_KIND_USER,
 				Scope: "/staging",
 				AssignmentTree: pinning.AssignmentTreeFromMap(map[string]map[string][]string{
 					"/staging/west": {"/staging/west": {"1h-timeout"}},
@@ -1540,6 +1551,7 @@ func TestScopedClientIdleTimeout(t *testing.T) {
 		{
 			name: "winning role determines timeout (single-role evaluation)",
 			pin: &scopesv1.Pin{
+				Kind:  scopesv1.PinKind_PIN_KIND_USER,
 				Scope: "/staging",
 				AssignmentTree: pinning.AssignmentTreeFromMap(map[string]map[string][]string{
 					"/staging":      {"/staging/west": {"25m-timeout"}},
@@ -1551,6 +1563,7 @@ func TestScopedClientIdleTimeout(t *testing.T) {
 		{
 			name: "more specific scope of effect wins (same origin)",
 			pin: &scopesv1.Pin{
+				Kind:  scopesv1.PinKind_PIN_KIND_USER,
 				Scope: "/staging",
 				AssignmentTree: pinning.AssignmentTreeFromMap(map[string]map[string][]string{
 					"/staging": {
@@ -1564,6 +1577,7 @@ func TestScopedClientIdleTimeout(t *testing.T) {
 		{
 			name: "label selector mismatch causes fallback to next role",
 			pin: &scopesv1.Pin{
+				Kind:  scopesv1.PinKind_PIN_KIND_USER,
 				Scope: "/staging",
 				AssignmentTree: pinning.AssignmentTreeFromMap(map[string]map[string][]string{
 					"/staging":      {"/staging/west": {"12m-timeout-team-blue"}},
@@ -1575,6 +1589,7 @@ func TestScopedClientIdleTimeout(t *testing.T) {
 		{
 			name: "login mismatch causes fallback to next role",
 			pin: &scopesv1.Pin{
+				Kind:  scopesv1.PinKind_PIN_KIND_USER,
 				Scope: "/staging",
 				AssignmentTree: pinning.AssignmentTreeFromMap(map[string]map[string][]string{
 					"/staging":      {"/staging/west": {"18m-timeout-wrong-login"}},
@@ -1637,6 +1652,7 @@ func newScopedSSHPermitTestPack(t *testing.T, roles []*scopedaccessv1.ScopedRole
 
 func pinForRole(roleName string) *scopesv1.Pin {
 	return &scopesv1.Pin{
+		Kind:  scopesv1.PinKind_PIN_KIND_USER,
 		Scope: "/staging",
 		AssignmentTree: pinning.AssignmentTreeFromMap(map[string]map[string][]string{
 			"/staging/west": {"/staging/west": {roleName}},

--- a/lib/sshca/identity.go
+++ b/lib/sshca/identity.go
@@ -176,6 +176,18 @@ func (i *Identity) Encode(certFormat string) (*ssh.Certificate, error) {
 		return nil, trace.BadParameter("cannot encode ssh identity missing required field CertType")
 	}
 
+	// Agent scope pins encode role and scope exclusively via the ScopePin field.
+	// Mixing in the legacy SystemRole or AgentScope fields would allow outdated
+	// infrastructure to misinterpret a scoped-agent cert as an unscoped one.
+	if i.ScopePin.GetKind() == scopesv1.PinKind_PIN_KIND_AGENT {
+		if i.SystemRole != "" {
+			return nil, trace.BadParameter("cannot encode ssh certificate for agent scope pin with SystemRole set; encode roles via ScopePin.SystemRoles")
+		}
+		if i.AgentScope != "" {
+			return nil, trace.BadParameter("cannot encode ssh certificate for agent scope pin with AgentScope set; encode scope via ScopePin.Scope")
+		}
+	}
+
 	cert := &ssh.Certificate{
 		// we have to use key id to identify teleport user
 		KeyId:           i.Username,
@@ -212,11 +224,20 @@ func (i *Identity) Encode(certFormat string) (*ssh.Certificate, error) {
 	// --- user extensions ---
 
 	if i.ScopePin != nil {
-		pin, err := pinning.Encode(i.ScopePin)
+		encoded, err := pinning.Encode(i.ScopePin)
 		if err != nil {
-			return nil, trace.Errorf("failed to marshal scope pin for ssh cert encoding: %w", err)
+			return nil, trace.Errorf("failed to encode scope pin for ssh cert: %w", err)
 		}
-		cert.Permissions.Extensions[teleport.CertExtensionScopePin] = pin
+		var ext string
+		switch i.ScopePin.GetKind() {
+		case scopesv1.PinKind_PIN_KIND_USER:
+			ext = teleport.CertExtensionScopePin
+		case scopesv1.PinKind_PIN_KIND_AGENT:
+			ext = teleport.CertExtensionAgentScopePin
+		default:
+			return nil, trace.BadParameter("cannot encode scope pin with unknown or unspecified kind %v", i.ScopePin.GetKind())
+		}
+		cert.Permissions.Extensions[ext] = encoded
 	}
 
 	if i.PermitX11Forwarding {
@@ -458,6 +479,19 @@ func DecodeIdentity(cert *ssh.Certificate) (*Identity, error) {
 		pin, err := pinning.Decode(v)
 		if err != nil {
 			return nil, trace.BadParameter("failed to decode value %q for extension %q as scope pin: %v", v, teleport.CertExtensionScopePin, err)
+		}
+		// Certs issued before PinKind was introduced will have UNSPECIFIED here.
+		// Pins decoded from the user OID are always user pins.
+		if pin.Kind == scopesv1.PinKind_PIN_KIND_UNSPECIFIED {
+			pin.Kind = scopesv1.PinKind_PIN_KIND_USER
+		}
+		ident.ScopePin = pin
+	}
+
+	if v, ok := takeExtension(teleport.CertExtensionAgentScopePin); ok {
+		pin, err := pinning.Decode(v)
+		if err != nil {
+			return nil, trace.BadParameter("failed to decode value %q for extension %q as agent scope pin: %v", v, teleport.CertExtensionAgentScopePin, err)
 		}
 		ident.ScopePin = pin
 	}

--- a/lib/sshca/identity_test.go
+++ b/lib/sshca/identity_test.go
@@ -49,7 +49,12 @@ func TestIdentityConversion(t *testing.T) {
 		SystemRole:  types.RoleNode,
 		Username:    "user",
 		ScopePin: &scopesv1.Pin{
+			Kind:  scopesv1.PinKind_PIN_KIND_USER,
 			Scope: "/foo",
+			SystemRoles: &scopesv1.SystemRoles{
+				Primary:    "node",
+				Additional: []string{"proxy"},
+			},
 			AssignmentTree: pinning.AssignmentTreeFromMap(map[string]map[string][]string{
 				"/": {"/": {"role1", "role2"}},
 			}),

--- a/lib/tbot/tbot_test.go
+++ b/lib/tbot/tbot_test.go
@@ -1622,6 +1622,7 @@ func TestScopedBotSSH(t *testing.T) {
 
 	t.Run("identity certificates have scope pins", func(t *testing.T) {
 		expectedPin := &scopesv1.Pin{
+			Kind:  scopesv1.PinKind_PIN_KIND_USER,
 			Scope: scopeName,
 			AssignmentTree: pinning.AssignmentTreeFromMap(map[string]map[string][]string{
 				scopeName: {scopeName: {scopedRoleName}},

--- a/lib/tlsca/ca.go
+++ b/lib/tlsca/ca.go
@@ -121,8 +121,9 @@ type Identity struct {
 	// Username is the name of the user (for end-users/bots) or the Host ID (for
 	// Teleport processes).
 	Username string
-	// ScopePin is an optional pin that ties the certificate to a specific scope and set of scoped roles. When
-	// set, the Groups field must not be set.
+	// ScopePin is an optional pin that ties the certificate to a specific scope. For user identities it
+	// encodes scoped role assignments (PIN_KIND_USER); for agent identities it encodes system roles
+	// (PIN_KIND_AGENT). When set, the Groups field must not be set.
 	ScopePin *scopesv1.Pin
 	// AgentScope is the scope this identity belongs to.
 	AgentScope string
@@ -656,6 +657,10 @@ var (
 	// identifier of the Delegation Session this certificate was created for.
 	DelegationSessionIDASN1ExtensionOID = asn1.ObjectIdentifier{1, 3, 9999, 2, 30}
 
+	// AgentScopePinASN1ExtensionOID is an extension OID that contains the agent scope pin,
+	// encoding the agent's pinned scope and system roles.
+	AgentScopePinASN1ExtensionOID = asn1.ObjectIdentifier{1, 3, 9999, 2, 31}
+
 	// CAClusterNameExtensionOID records the cluster name in a Teleport CA
 	// certificate.
 	//
@@ -686,6 +691,21 @@ var (
 
 // Subject converts identity to X.509 subject name
 func (id *Identity) Subject() (pkix.Name, error) {
+	// Agent scope pins encode role and scope exclusively via the ScopePin field.
+	// Mixing in the legacy Groups, SystemRoles, or AgentScope fields would allow
+	// outdated infrastructure to misinterpret a scoped-agent cert as an unscoped one.
+	if id.ScopePin.GetKind() == scopesv1.PinKind_PIN_KIND_AGENT {
+		if len(id.Groups) > 0 {
+			return pkix.Name{}, trace.BadParameter("cannot encode tls certificate for agent scope pin with Groups set; encode roles via ScopePin.SystemRoles")
+		}
+		if len(id.SystemRoles) > 0 {
+			return pkix.Name{}, trace.BadParameter("cannot encode tls certificate for agent scope pin with SystemRoles set; encode roles via ScopePin.SystemRoles")
+		}
+		if id.AgentScope != "" {
+			return pkix.Name{}, trace.BadParameter("cannot encode tls certificate for agent scope pin with AgentScope set; encode scope via ScopePin.Scope")
+		}
+	}
+
 	rawTraits, err := wrappers.MarshalTraits(&id.Traits)
 	if err != nil {
 		return pkix.Name{}, trace.Wrap(err)
@@ -990,15 +1010,25 @@ func (id *Identity) Subject() (pkix.Name, error) {
 	}
 
 	if id.ScopePin != nil {
-		pin, err := pinning.Encode(id.ScopePin)
+		// User pins go in the user OID; agent pins go in the agent OID. The OID separation
+		// ensures fail-closed behavior on older auth servers that only know about user pins.
+		var oid asn1.ObjectIdentifier
+		switch id.ScopePin.GetKind() {
+		case scopesv1.PinKind_PIN_KIND_USER:
+			oid = ScopePinASN1ExtensionOID
+		case scopesv1.PinKind_PIN_KIND_AGENT:
+			oid = AgentScopePinASN1ExtensionOID
+		default:
+			return pkix.Name{}, trace.BadParameter("cannot encode scope pin with unknown or unspecified kind %v", id.ScopePin.GetKind())
+		}
+		encoded, err := pinning.Encode(id.ScopePin)
 		if err != nil {
 			return pkix.Name{}, trace.Errorf("failed to encode scope pin: %w", err)
 		}
-
 		subject.ExtraNames = append(subject.ExtraNames,
 			pkix.AttributeTypeAndValue{
-				Type:  ScopePinASN1ExtensionOID,
-				Value: pin,
+				Type:  oid,
+				Value: encoded,
 			})
 	}
 
@@ -1367,6 +1397,20 @@ func FromSubject(subject pkix.Name, expires time.Time) (*Identity, error) {
 				if err != nil {
 					return nil, trace.Errorf("failed to decode scope pin: %w", err)
 				}
+				// Certs issued before PinKind was introduced will have UNSPECIFIED here.
+				// Pins decoded from the user OID are always user pins.
+				if pin.Kind == scopesv1.PinKind_PIN_KIND_UNSPECIFIED {
+					pin.Kind = scopesv1.PinKind_PIN_KIND_USER
+				}
+				id.ScopePin = pin
+			}
+		case attr.Type.Equal(AgentScopePinASN1ExtensionOID):
+			val, ok := attr.Value.(string)
+			if ok {
+				pin, err := pinning.Decode(val)
+				if err != nil {
+					return nil, trace.Errorf("failed to decode agent scope pin: %w", err)
+				}
 				id.ScopePin = pin
 			}
 		case attr.Type.Equal(AgentScopeASN1ExtensionOID):
@@ -1545,6 +1589,19 @@ func (id *Identity) IsBot() bool {
 // IsDelegationSession returns whether this identity was created for a Delegation Session.
 func (id *Identity) IsDelegationSession() bool {
 	return id.DelegationSessionID != ""
+}
+
+// GetAgentScope returns the effective agent scope for this identity. Returns empty string
+// for unscoped agents and non-agent certs.
+// TODO(fspmarshall/scopes): remove this helper once we've fully transitioned to pinned agents.
+func (id Identity) GetAgentScope() string {
+	if id.AgentScope != "" {
+		return id.AgentScope
+	}
+	if id.ScopePin.GetKind() == scopesv1.PinKind_PIN_KIND_AGENT {
+		return id.ScopePin.GetScope()
+	}
+	return ""
 }
 
 // CertificateRequest is a X.509 signing certificate request

--- a/lib/tlsca/ca_test.go
+++ b/lib/tlsca/ca_test.go
@@ -135,6 +135,7 @@ func TestScopePin(t *testing.T) {
 	identity := Identity{
 		Username: "alice@example.com",
 		ScopePin: &scopesv1.Pin{
+			Kind:  scopesv1.PinKind_PIN_KIND_USER,
 			Scope: "/foo",
 			AssignmentTree: pinning.AssignmentTreeFromMap(map[string]map[string][]string{
 				"/": {"/": {"r1"}, "/foo": {"r2"}},


### PR DESCRIPTION
Backport #66590 to branch/v18

Depends on: https://github.com/gravitational/teleport/pull/66345, https://github.com/gravitational/teleport/pull/67271

*NOTE*: This PR will require being rebuilt from 87f8a28487c54366a6a9610776e780106eb06a94 again after dependencies are merged.  Upon further investigation, there isn't really a sensible way to backport these changes until those merge, as it has some tricky dependence on both.

## Manual Test Plan
### Test Environment

Local env

### Test Cases
- [x] General verification that scoped joining and scoped agent identities continue to function as expected when scoped agent pin flag is not set.
