### PR TITLE
ensure remote SFTP FIleInfo names are basenames and not paths

### DIFF
--- a/lib/sshutils/sftp/remote.go
+++ b/lib/sshutils/sftp/remote.go
@@ -125,6 +125,10 @@ func (r *RemoteFS) ReadDir(path string) ([]os.FileInfo, error) {
 		return nil, err
 	}
 	for i := range fileInfos {
+		if err := sftputils.CheckFileInfoName(fileInfos[i]); err != nil {
+			return nil, err
+		}
+
 		// If the file is a valid symlink, return the info of the linked file.
 		if fileInfos[i].Mode()&os.ModeSymlink != 0 {
 			resolvedInfo, err := r.Stat(portablepath.Join(path, fileInfos[i].Name()))
@@ -135,6 +139,18 @@ func (r *RemoteFS) ReadDir(path string) ([]os.FileInfo, error) {
 	}
 
 	return fileInfos, nil
+}
+
+func (r *RemoteFS) Stat(path string) (os.FileInfo, error) {
+	fi, err := r.Client.Stat(path)
+	if err != nil {
+		return nil, err
+	}
+	if err := sftputils.CheckFileInfoName(fi); err != nil {
+		return nil, err
+	}
+
+	return fi, nil
 }
 
 func (r *RemoteFS) Open(path string) (sftputils.File, error) {

--- a/lib/sshutils/sftp/sftp.go
+++ b/lib/sshutils/sftp/sftp.go
@@ -279,7 +279,7 @@ func transfer(ctx context.Context, req *FileTransferRequest) error {
 		// clean match paths to ensure they are separated by backslashes, as
 		// SFTP requires that
 		for i := range matches {
-			matches[i] = path.Clean(matches[i])
+			matches[i] = sftputils.CleanPath(matches[i])
 		}
 		matchedPaths = append(matchedPaths, matches...)
 
@@ -299,7 +299,7 @@ func transfer(ctx context.Context, req *FileTransferRequest) error {
 
 	// validate destination path and create it if necessary
 	var dstIsDir bool
-	req.Destination.Path = path.Clean(req.Destination.Path)
+	req.Destination.Path = sftputils.CleanPath(req.Destination.Path)
 	dstInfo, err := req.dstFS.Stat(req.Destination.Path)
 	if err != nil {
 		if !errors.Is(err, os.ErrNotExist) {

--- a/session/sftputils/local.go
+++ b/session/sftputils/local.go
@@ -67,7 +67,6 @@ func (l LocalFS) ReadDir(path string) ([]os.FileInfo, error) {
 }
 
 func (l LocalFS) Open(path string) (File, error) {
-
 	f, err := os.Open(path)
 	if err != nil {
 		return nil, err

--- a/session/sftputils/utils.go
+++ b/session/sftputils/utils.go
@@ -23,12 +23,37 @@ import (
 	"io"
 	"io/fs"
 	"os"
+	"path"
+	"strings"
 	"sync/atomic"
 	"time"
 
 	"github.com/gravitational/trace"
 	"github.com/pkg/sftp"
 )
+
+// CheckFileInfoName verifies that the Name of the FileInfo is in fact
+// a base name and not a path.
+func CheckFileInfoName(fi os.FileInfo) error {
+	name := fi.Name()
+	if name == "" {
+		return trace.BadParameter("name is empty")
+	}
+	if name == "." || name == ".." || strings.ContainsRune(name, '/') || strings.ContainsRune(name, '\\') {
+		return trace.BadParameter("invalid file name %q", name)
+	}
+
+	return nil
+}
+
+// CleanPath is like path.Clean, but replaces all backslashes with forward
+// slashes.
+func CleanPath(p string) string {
+	// replace backslashes first as path's package docs state only paths
+	// with forward slashes are supported
+	replaced := strings.ReplaceAll(p, "\\", "/")
+	return path.Clean(replaced)
+}
 
 // fileWrapper is a wrapper for *os.File that implements the WriteTo() method
 // required for concurrent data transfer.

--- a/session/sftputils/utils_test.go
+++ b/session/sftputils/utils_test.go
@@ -1,0 +1,89 @@
+/*
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package sftputils
+
+import (
+	"os"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCheckFileInfoName(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		shouldFail bool
+	}{
+		{"", true},
+		{".", true},
+		{"..", true},
+		{"foo", false},
+		{"foo/", true},
+		{"foo\\", true},
+		{"foo/bar", true},
+		{"foo\\bar", true},
+		{"../foo", true},
+		{"..\\foo", true},
+		{"foo/../bar", true},
+		{"foo\\..\\bar", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fileInfo := &mockFileInfo{name: tt.name}
+			err := CheckFileInfoName(fileInfo)
+			if tt.shouldFail {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+type mockFileInfo struct {
+	name string
+}
+
+func (f *mockFileInfo) Name() string {
+	return f.name
+}
+
+func (f *mockFileInfo) Size() int64 {
+	return 0
+}
+
+func (f *mockFileInfo) Mode() os.FileMode {
+	return 0
+}
+
+func (f *mockFileInfo) ModTime() time.Time {
+	return time.Now()
+}
+
+func (f *mockFileInfo) IsDir() bool {
+	return false
+}
+
+func (f *mockFileInfo) Sys() interface{} {
+	return nil
+}


### PR DESCRIPTION
Very similar to https://github.com/gravitational/teleport/pull/67604, just for SFTP instead of scp.

While I was there I noticed when I original wrote this code I thought that `path.Clean` replaced backslashes with forward slashes when it does not so I fixed that as well. The SFTP protocol requires forward slashes as separators in paths.

Fixes https://github.com/gravitational/pressure-washing/issues/368.

<!-- Provide a descriptive entry for the changelog of the next release. -->

Changelog: Fixed an issue where path separators could be included in SFTP file names during upload.


<!-- Include manual testing efforts to verify the change. -->
<!-- Detail where the tests where run and what configurations were used. -->
<!-- Include all the test cases which were run to validate the change. -->

## Manual Test Plan
### Test Environment
Cluster on MacOS
### Test Cases
- [x] Downloading file succeeds
- [x] Downloading dir recursively succeeds 
- [x] Uploading file succeeds
- [x] Uploading dir recursively succeeds
