### PR TITLE
Initial LLM access handler (Anthropic)

### DIFF
--- a/api/types/events/events.go
+++ b/api/types/events/events.go
@@ -3023,6 +3023,8 @@ func (m *AppSessionLLMRequest) TrimToMaxSize(maxSize int) AuditEvent {
 			newStrTrimmer(m.Path, &out.Path),
 			newStrTrimmer(m.Method, &out.Method),
 			newStrTrimmer(m.RequestedModel, &out.RequestedModel),
+			newStrTrimmer(m.Model, &out.Model),
+			newGenericTrimmer(&m.Status, &out.Status),
 		}
 	})
 }

--- a/api/types/events/events_test.go
+++ b/api/types/events/events_test.go
@@ -347,24 +347,31 @@ func TestTrimToMaxSize(t *testing.T) {
 					Code: "T2014I",
 					Type: "app.session.llm.request.success",
 				},
+				Status: Status{
+					Error:       strings.Repeat("A", 200),
+					UserMessage: strings.Repeat("B", 200),
+				},
 				Path:           strings.Repeat("/path", 20),
 				Method:         strings.Repeat("POST", 20),
 				RequestedModel: strings.Repeat("requested-model", 20),
-				// Models and provider comes from the app config and should not
-				// be trimmed.
+				Model:          strings.Repeat("model", 20),
+				// Provider comes from the app config and should not be trimmed.
 				Provider: "a-long-provider-name-not-trimmed",
-				Model:    "a-long-model-name-not-trimmed",
 			},
 			want: &AppSessionLLMRequest{
 				Metadata: Metadata{
 					Code: "T2014I",
 					Type: "app.session.llm.request.success",
 				},
-				Path:           "/path/path/path/",
-				Method:         "POSTPOSTPOSTPOST",
-				RequestedModel: "requested-modelr",
+				Status: Status{
+					Error:       "AAAAAAAAAAAA",
+					UserMessage: "BBBBBBBBBBBB",
+				},
+				Path:           "/path/path/p",
+				Method:         "POSTPOSTPOST",
+				RequestedModel: "requested-mo",
+				Model:          "modelmodelmo",
 				Provider:       "a-long-provider-name-not-trimmed",
-				Model:          "a-long-model-name-not-trimmed",
 			},
 		},
 	}

--- a/constants.go
+++ b/constants.go
@@ -302,6 +302,9 @@ const (
 	// ComponentMCP represents the MCP server handler.
 	ComponentMCP = "mcp"
 
+	// ComponentLLM represents the LLM server handler.
+	ComponentLLM = "llm"
+
 	// ComponentRecordingEncryption represents recording encryption
 	ComponentRecordingEncryption = "recording-encryption"
 

--- a/lib/events/emitter.go
+++ b/lib/events/emitter.go
@@ -269,7 +269,13 @@ func (l *LoggingEmitter) EmitAuditEvent(ctx context.Context, event apievents.Aud
 	}
 
 	switch event.GetType() {
-	case ResizeEvent, SessionDiskEvent, SessionPrintEvent, AppSessionRequestEvent, "":
+	case ResizeEvent,
+		SessionDiskEvent,
+		SessionPrintEvent,
+		AppSessionRequestEvent,
+		AppSessionLLMRequestSuccessEvent,
+		AppSessionLLMRequestFailureEvent,
+		"":
 		return nil
 	}
 

--- a/lib/srv/app/common/audit.go
+++ b/lib/srv/app/common/audit.go
@@ -46,6 +46,8 @@ type Audit interface {
 	OnRequest(ctx context.Context, sessionCtx *SessionContext, req *http.Request, status uint32, re *AWSResolvedEndpoint) error
 	// OnDynamoDBRequest is called when app request for a DynamoDB API is sent and a response is received.
 	OnDynamoDBRequest(ctx context.Context, sessionCtx *SessionContext, req *http.Request, status uint32, re *AWSResolvedEndpoint) error
+	// OnLLMRequest is called when app request for LLM inference endpoint is sent and a response is received.
+	OnLLMRequest(ctx context.Context, sessionCtx *SessionContext, req *http.Request, llmReq LLMRequest, llmResp LLMResponse) error
 	// EmitEvent emits the provided audit event.
 	EmitEvent(ctx context.Context, event apievents.AuditEvent) error
 }
@@ -179,6 +181,8 @@ func (a *audit) OnSessionChunk(ctx context.Context, serverID, chunkID string, id
 }
 
 // OnRequest is called when an app request is sent during the session and a response is received.
+//
+// This event only goes to app session recording (chunk).
 func (a *audit) OnRequest(ctx context.Context, sessionCtx *SessionContext, req *http.Request, status uint32, re *AWSResolvedEndpoint) error {
 	event := &apievents.AppSessionRequest{
 		Metadata: apievents.Metadata{
@@ -192,7 +196,7 @@ func (a *audit) OnRequest(ctx context.Context, sessionCtx *SessionContext, req *
 		StatusCode:         status,
 		AWSRequestMetadata: *MakeAWSRequestMetadata(req, re),
 	}
-	return trace.Wrap(a.EmitEvent(ctx, event))
+	return trace.Wrap(a.recordEvent(ctx, event))
 }
 
 // OnDynamoDBRequest is called when a DynamoDB app request is sent during the session.
@@ -225,22 +229,56 @@ func (a *audit) OnDynamoDBRequest(ctx context.Context, sessionCtx *SessionContex
 	return trace.Wrap(a.EmitEvent(ctx, event))
 }
 
-// EmitEvent emits the provided audit event.
+// OnLLMRequest is called when app request for LLM inference endpoint is sent and a response is received.
+//
+// This event only goes to app session recording (chunk).
+func (a *audit) OnLLMRequest(ctx context.Context, sessionCtx *SessionContext, req *http.Request, llmReq LLMRequest, llmResp LLMResponse) error {
+	event := &apievents.AppSessionLLMRequest{
+		Metadata: apievents.Metadata{
+			Type: events.AppSessionLLMRequestSuccessEvent,
+			Code: events.AppSessionLLMRequestSuccessCode,
+		},
+		Status: apievents.Status{
+			Success: true,
+		},
+		AppMetadata:      *MakeAppMetadata(sessionCtx.App),
+		Method:           req.Method,
+		Path:             req.URL.Path,
+		Provider:         llmReq.Provider,
+		Model:            llmReq.Model,
+		RequestedModel:   llmReq.RequestedModel,
+		InputTokenCount:  int64(llmResp.InputTokenCount),
+		OutputTokenCount: int64(llmResp.OutputTokenCount),
+	}
+	if llmResp.Error != nil {
+		event.Metadata.Type = events.AppSessionLLMRequestFailureEvent
+		event.Metadata.Code = events.AppSessionLLMRequestFailureCode
+		event.Status.Success = false
+		event.Status.Error = llmResp.Error.Error()
+	}
+	return trace.Wrap(a.recordEvent(ctx, event))
+}
+
+// EmitEvent emits and records the provided audit event.
 func (a *audit) EmitEvent(ctx context.Context, e apievents.AuditEvent) error {
 	preparedEvent, err := a.cfg.Recorder.PrepareSessionEvent(e)
 	if err != nil {
 		return trace.Wrap(err)
 	}
 
-	recErr := a.cfg.Recorder.RecordEvent(ctx, preparedEvent)
-	event := preparedEvent.GetAuditEvent()
-	var emitErr error
-	// AppSessionRequest events should only go to session recording
-	if event.GetType() != events.AppSessionRequestEvent {
-		emitErr = a.cfg.Emitter.EmitAuditEvent(ctx, event)
+	return trace.NewAggregate(
+		a.cfg.Recorder.RecordEvent(ctx, preparedEvent),
+		a.cfg.Emitter.EmitAuditEvent(ctx, preparedEvent.GetAuditEvent()),
+	)
+}
+
+func (a *audit) recordEvent(ctx context.Context, e apievents.AuditEvent) error {
+	preparedEvent, err := a.cfg.Recorder.PrepareSessionEvent(e)
+	if err != nil {
+		return trace.Wrap(err)
 	}
 
-	return trace.NewAggregate(recErr, emitErr)
+	return trace.Wrap(a.cfg.Recorder.RecordEvent(ctx, preparedEvent))
 }
 
 // MakeAppMetadata returns common server metadata for database session.

--- a/lib/srv/app/common/llm.go
+++ b/lib/srv/app/common/llm.go
@@ -1,0 +1,43 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package common
+
+import (
+	"github.com/gravitational/teleport/api/types"
+)
+
+// LLMRequest describes an inbound LLM API request being proxied to a provider.
+type LLMRequest struct {
+	// Format identifies the LLM format used on the request.
+	Format types.LLMFormat
+	// Provider identifies the LLM provider handling the request.
+	Provider types.LLMProvider
+	// Model is the resolved model name sent to the provider.
+	Model string
+	// RequestedModel is the original model name as specified by the client.
+	RequestedModel string
+}
+
+// LLMResponse describes the outcome of a proxied LLM API request.
+type LLMResponse struct {
+	// Error is the error encountered while handling the request, if any.
+	Error error
+	// InputTokenCount is the number of tokens consumed by the request input.
+	InputTokenCount int
+	// OutputTokenCount is the number of tokens produced in the response.
+	OutputTokenCount int
+}

--- a/lib/srv/app/connections_handler.go
+++ b/lib/srv/app/connections_handler.go
@@ -56,6 +56,7 @@ import (
 	appazure "github.com/gravitational/teleport/lib/srv/app/azure"
 	"github.com/gravitational/teleport/lib/srv/app/common"
 	appgcp "github.com/gravitational/teleport/lib/srv/app/gcp"
+	appllm "github.com/gravitational/teleport/lib/srv/app/llm"
 	"github.com/gravitational/teleport/lib/srv/mcp"
 	"github.com/gravitational/teleport/lib/tlsca"
 	"github.com/gravitational/teleport/lib/utils"
@@ -204,6 +205,7 @@ type ConnectionsHandler struct {
 	awsHandler   http.Handler
 	azureHandler http.Handler
 	gcpHandler   http.Handler
+	llmHandler   http.Handler
 
 	// authMiddleware allows wrapping connections with identity information.
 	authMiddleware *authz.Middleware
@@ -246,6 +248,14 @@ func NewConnectionsHandler(closeContext context.Context, cfg *ConnectionsHandler
 		return nil, trace.Wrap(err)
 	}
 
+	llmHandler, err := appllm.NewHandler(closeContext, appllm.HandlerConfig{
+		Log:               cfg.Logger.With(teleport.ComponentKey, teleport.ComponentLLM),
+		AWSConfigProvider: awsConfigProvider,
+	})
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
 	clusterName, err := cfg.AccessPoint.GetClusterName(closeContext)
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -257,6 +267,7 @@ func NewConnectionsHandler(closeContext context.Context, cfg *ConnectionsHandler
 		awsHandler:   awsHandler,
 		azureHandler: azureHandler,
 		gcpHandler:   gcpHandler,
+		llmHandler:   llmHandler,
 		connAuth:     make(map[net.Conn]error),
 		log:          slog.With(teleport.ComponentKey, cfg.ServiceComponent),
 		clusterName:  clusterName.GetClusterName(),
@@ -484,9 +495,8 @@ func (c *ConnectionsHandler) serveHTTP(w http.ResponseWriter, r *http.Request) e
 	case app.IsGCP():
 		return c.serveSession(w, r, &identity, app, c.withGCPHandler)
 
-	// TODO(gabrielcorado): implement inference endpoint handler.
 	case app.IsLLM():
-		return trace.NotImplemented("LLM access is not implemented")
+		return c.serveSession(w, r, &identity, app, c.withLLMHandler)
 
 	default:
 		return c.serveSession(w, r, &identity, app, c.withJWTTokenForwarder)

--- a/lib/srv/app/llm/anthropic/anthropic.go
+++ b/lib/srv/app/llm/anthropic/anthropic.go
@@ -30,46 +30,13 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	llmerrors "github.com/gravitational/teleport/lib/srv/app/llm/errors"
 	"github.com/gravitational/teleport/lib/srv/app/llm/models"
+	llmrequest "github.com/gravitational/teleport/lib/srv/app/llm/request"
 	"github.com/gravitational/teleport/lib/utils"
 )
 
-// NewRequestConfig is config used to create a new provide request.
-type NewRequestConfig struct {
-	// LLM inference endpoint configuration.
-	LLM *types.LLM
-	// DownstreamRequest is the received downstream request.
-	DownstreamRequest *http.Request
-	// ProviderURL is the provider URL address.
-	ProviderURL *url.URL
-	// GetAPIKeyFunc is the function used to retrieve Anthropic API keys.
-	GetAPIKeyFunc func() string
-}
-
-func (c *NewRequestConfig) CheckAndSetDefaults() error {
-	if c.LLM == nil {
-		return trace.BadParameter("llm information is required")
-	}
-	if c.DownstreamRequest == nil {
-		return trace.BadParameter("downstream request is required")
-	}
-	if c.GetAPIKeyFunc == nil {
-		return trace.BadParameter("get api key function is required")
-	}
-
-	// Default URL address.
-	//
-	// https://platform.claude.com/docs/en/api/overview
-	c.ProviderURL = cmp.Or(c.ProviderURL, &url.URL{
-		Scheme: "https",
-		Host:   "api.anthropic.com",
-		Path:   "/v1",
-	})
-	return nil
-}
-
 // NewRequest creates a new provider request based on the downstream request,
 // and inference endpoint configuration.
-func NewRequest(cfg *NewRequestConfig) (*http.Request, *RequestInfo, error) {
+func NewRequest(cfg *llmrequest.Config) (*http.Request, *RequestInfo, error) {
 	var (
 		info            = &RequestInfo{}
 		providerPath    string
@@ -80,6 +47,15 @@ func NewRequest(cfg *NewRequestConfig) (*http.Request, *RequestInfo, error) {
 	if err := cfg.CheckAndSetDefaults(); err != nil {
 		return nil, info, trace.Wrap(err)
 	}
+
+	// Default URL address.
+	//
+	// https://platform.claude.com/docs/en/api/overview
+	cfg.ProviderURL = cmp.Or(cfg.ProviderURL, &url.URL{
+		Scheme: "https",
+		Host:   "api.anthropic.com",
+		Path:   "/v1",
+	})
 
 	// TODO(gabrielcorado): add support for bedrock provider.
 	switch cfg.LLM.Provider {

--- a/lib/srv/app/llm/anthropic/anthropic_test.go
+++ b/lib/srv/app/llm/anthropic/anthropic_test.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/types"
+	llmrequest "github.com/gravitational/teleport/lib/srv/app/llm/request"
 )
 
 func TestNewRequest(t *testing.T) {
@@ -242,7 +243,7 @@ func TestNewRequest(t *testing.T) {
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
-			req, info, err := NewRequest(&NewRequestConfig{
+			req, info, err := NewRequest(&llmrequest.Config{
 				LLM:               tc.llm,
 				DownstreamRequest: tc.request(),
 				GetAPIKeyFunc: func() string {
@@ -299,7 +300,7 @@ func BenchmarkNewRequest(b *testing.B) {
 
 			for b.Loop() {
 				r.Body = io.NopCloser(bytes.NewReader(bc.body))
-				if _, _, err := NewRequest(&NewRequestConfig{
+				if _, _, err := NewRequest(&llmrequest.Config{
 					LLM:               llm,
 					DownstreamRequest: r,
 					GetAPIKeyFunc:     func() string { return "" },

--- a/lib/srv/app/llm/handler.go
+++ b/lib/srv/app/llm/handler.go
@@ -1,0 +1,349 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package llm
+
+import (
+	"context"
+	"log/slog"
+	"net/http"
+	"net/url"
+	"os"
+	"strconv"
+	"time"
+
+	"github.com/gravitational/trace"
+
+	"github.com/gravitational/teleport"
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/cloud/awsconfig"
+	"github.com/gravitational/teleport/lib/defaults"
+	"github.com/gravitational/teleport/lib/httplib/reverseproxy"
+	"github.com/gravitational/teleport/lib/observability/metrics"
+	"github.com/gravitational/teleport/lib/srv/app/common"
+	"github.com/gravitational/teleport/lib/srv/app/llm/anthropic"
+	llmerrors "github.com/gravitational/teleport/lib/srv/app/llm/errors"
+	llmrequest "github.com/gravitational/teleport/lib/srv/app/llm/request"
+)
+
+// Handler proxies LLM API requests for authorized app sessions.
+type Handler struct {
+	cfg          HandlerConfig
+	closeContext context.Context
+	metrics      *llmMetrics
+
+	anthropicProviderURL *url.URL
+	anthropicApiKey      string
+}
+
+// HandlerConfig configures dependencies for the LLM proxy handler.
+type HandlerConfig struct {
+	// Log is the logger used by the handler.
+	Log *slog.Logger
+	// MetricsRegistry configures where metrics should be registered.
+	// When nil, metrics are created but not registered.
+	MetricsRegistry *metrics.Registry
+	// AWSConfigProvider is the AWS config provider used by the handler.
+	AWSConfigProvider awsconfig.Provider
+	// Transport is the transport used to issue requests to the upstream
+	// LLM provider.
+	Transport *http.Transport
+}
+
+// CheckAndSetDefaults validates required dependencies and sets defaults.
+func (c *HandlerConfig) CheckAndSetDefaults() error {
+	if c.Log == nil {
+		c.Log = slog.With(teleport.ComponentKey, teleport.ComponentLLM)
+	}
+	if c.MetricsRegistry == nil {
+		c.MetricsRegistry = metrics.NoopRegistry()
+	}
+	if c.AWSConfigProvider == nil {
+		var err error
+		c.AWSConfigProvider, err = awsconfig.NewCache()
+		if err != nil {
+			return trace.Wrap(err)
+		}
+	}
+	if c.Transport == nil {
+		tr, err := defaults.Transport()
+		if err != nil {
+			return trace.Wrap(err)
+		}
+		c.Transport = tr
+	}
+	return nil
+}
+
+// NewHandler creates a configured LLM proxy handler.
+func NewHandler(ctx context.Context, cfg HandlerConfig) (*Handler, error) {
+	if err := cfg.CheckAndSetDefaults(); err != nil {
+		return nil, trace.Wrap(err)
+	}
+	m, err := newMetrics(cfg.MetricsRegistry)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	h := &Handler{
+		closeContext: ctx,
+		cfg:          cfg,
+		metrics:      m,
+		// Not much validation can be applied here since some providers might
+		// not require an actual API key.
+		anthropicApiKey: os.Getenv(anthropicApiKeyEnvVarName),
+	}
+
+	// It ok to leave this value as `nil`, the value receivers must implement a
+	// default value for it.
+	if rawAnthropicURL := os.Getenv(anthropicAddressEnvVarName); rawAnthropicURL != "" {
+		var err error
+		h.anthropicProviderURL, err = url.Parse(rawAnthropicURL)
+		if err != nil {
+			// Hard failure.
+			return nil, trace.Wrap(err)
+		}
+	}
+
+	return h, nil
+}
+
+// ServeHTTP handles an authorized client connection.
+func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if err := h.serveHTTP(w, r); err != nil {
+		h.cfg.Log.ErrorContext(r.Context(), "failed to handle LLM request", "error", err)
+		trace.WriteError(w, err)
+	}
+}
+
+// serveHTTP routes requests to the configured LLM provider handler.
+func (h *Handler) serveHTTP(w http.ResponseWriter, r *http.Request) error {
+	sessionCtx, err := common.GetSessionContext(r)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	llm := sessionCtx.App.GetLLM()
+	start := time.Now()
+	defer func() {
+		h.metrics.requestDuration.WithLabelValues(
+			teleport.ComponentLLM,
+			llm.Format,
+			llm.Provider,
+		).Observe(time.Since(start).Seconds())
+	}()
+
+	// TODO(gabrielcorado): implement OpenAI handler.
+	switch llm.Format {
+	case types.LLMFormatAnthropic:
+		h.handleRequest(
+			sessionCtx, w, r,
+			func(llm *types.LLM, r *http.Request) (*http.Request, RequestInfo, error) {
+				return anthropic.NewRequest(&llmrequest.Config{
+					LLM:               llm,
+					DownstreamRequest: r,
+					ProviderURL:       h.anthropicProviderURL,
+					GetAPIKeyFunc: func() string {
+						return h.anthropicApiKey
+					},
+				})
+			},
+			func(l *slog.Logger, w http.ResponseWriter) (UpstreamRecorder, error) {
+				return anthropic.NewResponseRecorder(l, w)
+			},
+			anthropic.WriteError,
+		)
+	default:
+		return trace.NotImplemented("llm format %q not supported", llm.Format)
+	}
+
+	return nil
+}
+
+// WriteErrorFunc is function used to write an error into the downstream request.
+type WriteErrorFunc func(http.ResponseWriter, error) error
+
+// RequestInfo interface that contains the request information.
+type RequestInfo interface {
+	// RequestedModel returns the requested model name.
+	RequestedModel() string
+	// ProviderModel returns the model name sent to the provider.
+	ProviderModel() string
+	// IsStream indicates if the request uses streaming.
+	IsStream() bool
+	// RequestSize contains the total request size in bytes.
+	RequestSize() int
+}
+
+// NewUpstreamRequestFunc function used to create a new upstream request.
+type NewUpstreamRequestFunc func(llm *types.LLM, r *http.Request) (*http.Request, RequestInfo, error)
+
+// NewUpstreamRecoderFunc function used to initialize a upstream response
+// recorder.
+type NewUpstreamRecoderFunc func(*slog.Logger, http.ResponseWriter) (UpstreamRecorder, error)
+
+// UpstreamRecorder records upstream results.
+type UpstreamRecorder interface {
+	http.ResponseWriter
+
+	// Written is the number of bytes written in the downstream connection.
+	Written() int
+	// Err is the error returned to the downstream connection.
+	Err() error
+	// InputTokensCount is the number of input tokens that were used on the
+	// request.
+	InputTokensCount() int
+	// OutputTokensCount is the number of output tokens generated by the
+	// request.
+	OutputTokensCount() int
+	// Close closes the recorder.
+	Close() error
+}
+
+// handleRequest handles an LLM request.
+func (h *Handler) handleRequest(
+	sessionCtx *common.SessionContext,
+	w http.ResponseWriter,
+	r *http.Request,
+	newRequestFunc NewUpstreamRequestFunc,
+	newRecorderFunc NewUpstreamRecoderFunc,
+	writeErrorFunc WriteErrorFunc,
+) {
+	llm := sessionCtx.App.GetLLM()
+	log := h.cfg.Log.With(
+		"app", sessionCtx.App.GetName(),
+		"format", llm.Format,
+		"provider", llm.Provider,
+	)
+
+	var (
+		err  error
+		info RequestInfo
+		rec  UpstreamRecorder
+	)
+
+	defer func() {
+		req := common.LLMRequest{Format: llm.Format, Provider: llm.Provider}
+		if info != nil {
+			req.Model = info.ProviderModel()
+			req.RequestedModel = info.RequestedModel()
+		}
+		resp := common.LLMResponse{Error: err}
+		if rec != nil {
+			resp.InputTokenCount = rec.InputTokensCount()
+			resp.OutputTokenCount = rec.OutputTokensCount()
+		}
+		if err := sessionCtx.Audit.OnLLMRequest(h.closeContext, sessionCtx, r, req, resp); err != nil {
+			log.ErrorContext(h.closeContext, "failed to emit audit event", "error", err)
+		}
+	}()
+
+	var req *http.Request
+	req, info, err = newRequestFunc(llm, r)
+	if err != nil {
+		log.ErrorContext(r.Context(), "failed to rewrite request", "error", err)
+		if werr := writeErrorFunc(w, err); werr != nil {
+			log.ErrorContext(h.closeContext, "failed to write error", "error", werr)
+		}
+		return
+	}
+
+	rec, err = newRecorderFunc(log, w)
+	if err != nil {
+		log.ErrorContext(r.Context(), "failed to initialize recorder", "error", err)
+		// This is considered an "internal" error. For downstream connections,
+		// just return a generic error.
+		if werr := writeErrorFunc(w, llmerrors.ErrUnknown); werr != nil {
+			log.ErrorContext(h.closeContext, "failed to write error", "error", werr)
+		}
+		return
+	}
+
+	h.metrics.requestSize.WithLabelValues(
+		teleport.ComponentLLM,
+		llm.Format,
+		llm.Provider,
+	).Observe(float64(info.RequestSize()))
+
+	fwd, err := reverseproxy.New(
+		// TODO(gabrielcorado): revisit this flush interval to reduce time to first token (TTFT).
+		reverseproxy.WithFlushInterval(50*time.Millisecond),
+		reverseproxy.WithRoundTripper(h.cfg.Transport),
+		reverseproxy.WithLogger(log),
+		reverseproxy.WithErrorHandler(func(_ http.ResponseWriter, r *http.Request, fwdErr error) {
+			// reverseproxy already logs this error, so no need to log it here.
+			if werr := writeErrorFunc(w, fwdErr); werr != nil {
+				log.ErrorContext(h.closeContext, "failed to write error", "error", werr)
+			}
+			err = fwdErr
+		}),
+	)
+	if err != nil {
+		log.ErrorContext(h.closeContext, "failed to initialize provider forwarder", "error", err)
+		if werr := writeErrorFunc(w, err); werr != nil {
+			log.ErrorContext(h.closeContext, "failed to write error", "error", werr)
+		}
+		return
+	}
+
+	start := time.Now()
+	fwd.ServeHTTP(rec, req)
+	if err := rec.Close(); err != nil {
+		log.ErrorContext(h.closeContext, "failed to close llm recorder", "error", err)
+	}
+
+	// In case a forwarder error happens, we must keep that.
+	if err == nil {
+		err = rec.Err()
+	}
+
+	h.metrics.providerRequestDuration.WithLabelValues(
+		teleport.ComponentLLM,
+		llm.Format,
+		llm.Provider,
+		strconv.FormatBool(info.IsStream()),
+	).Observe(time.Since(start).Seconds())
+
+	h.metrics.providerResponseSize.WithLabelValues(
+		teleport.ComponentLLM,
+		llm.Format,
+		llm.Provider,
+		strconv.FormatBool(info.IsStream()),
+	).Observe(float64(rec.Written()))
+
+	h.metrics.inputTokens.WithLabelValues(
+		teleport.ComponentLLM,
+		llm.Format,
+	).Add(float64(rec.InputTokensCount()))
+
+	h.metrics.outputTokens.WithLabelValues(
+		teleport.ComponentLLM,
+		llm.Format,
+	).Add(float64(rec.OutputTokensCount()))
+}
+
+const (
+	// anthropicAddressEnvVarName is the Anthropic's default environment
+	// variable used to set base API address.
+	//
+	// https://code.claude.com/docs/en/env-vars#variables
+	anthropicAddressEnvVarName = "ANTHROPIC_BASE_URL"
+	// anthropicApiKeyEnvVarName is the Anthropic's default environment variable
+	// used to set API keys.
+	//
+	// https://code.claude.com/docs/en/env-vars#variables
+	anthropicApiKeyEnvVarName = "ANTHROPIC_API_KEY"
+)

--- a/lib/srv/app/llm/handler_test.go
+++ b/lib/srv/app/llm/handler_test.go
@@ -27,13 +27,13 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"github.com/gravitational/trace"
 
 	"github.com/gravitational/teleport/api/types"
 	apievents "github.com/gravitational/teleport/api/types/events"
 	"github.com/gravitational/teleport/lib/events"
 	"github.com/gravitational/teleport/lib/session"
 	"github.com/gravitational/teleport/lib/srv/app/common"
-	"github.com/gravitational/trace"
 )
 
 // TestHandleRequest covers `handleRequest` function which is responsible for

--- a/lib/srv/app/llm/handler_test.go
+++ b/lib/srv/app/llm/handler_test.go
@@ -26,8 +26,8 @@ import (
 	"net/url"
 	"testing"
 
-	"github.com/stretchr/testify/require"
 	"github.com/gravitational/trace"
+	"github.com/stretchr/testify/require"
 
 	"github.com/gravitational/teleport/api/types"
 	apievents "github.com/gravitational/teleport/api/types/events"

--- a/lib/srv/app/llm/handler_test.go
+++ b/lib/srv/app/llm/handler_test.go
@@ -1,0 +1,373 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package llm
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport/api/types"
+	apievents "github.com/gravitational/teleport/api/types/events"
+	"github.com/gravitational/teleport/lib/events"
+	"github.com/gravitational/teleport/lib/session"
+	"github.com/gravitational/teleport/lib/srv/app/common"
+	"github.com/gravitational/trace"
+)
+
+// TestHandleRequest covers `handleRequest` function which is responsible for
+// "orchestrating" the LLM handling. Instead of verifying provider-specific
+// implementations (which are covered on their respective package) we test with
+// mocks, ensure the flow is correct and that it generates audit events
+// correctly.
+func TestHandleRequest(t *testing.T) {
+	expectString := func(str string) require.ValueAssertionFunc {
+		return func(tt require.TestingT, i1 any, i2 ...any) {
+			require.Equal(tt, str, i1, i2...)
+		}
+	}
+
+	for name, tc := range map[string]struct {
+		transport            *http.Transport
+		newRequestFunc       func(http.ResponseWriter, *httptest.Server) NewUpstreamRequestFunc
+		modifyRecorderFunc   func(*mockUpstreamRecorder)
+		writeErrorFunc       WriteErrorFunc
+		upstreamBody         string
+		expectUpstreamCalled bool
+		expectAuditEvent     require.ValueAssertionFunc
+		expectedResponse     require.ValueAssertionFunc
+	}{
+		"success request": {
+			newRequestFunc: func(w http.ResponseWriter, s *httptest.Server) NewUpstreamRequestFunc {
+				return func(llm *types.LLM, r *http.Request) (*http.Request, RequestInfo, error) {
+					req, err := http.NewRequest(http.MethodPost, s.URL, nil)
+					if err != nil {
+						return nil, nil, trace.Wrap(err)
+					}
+
+					return req, &mockRequestInfo{
+						requestedModel: "requested",
+						providerModel:  "provider",
+					}, nil
+				}
+			},
+			modifyRecorderFunc: func(r *mockUpstreamRecorder) {
+				r.err = nil
+				r.inputTokensCount = 10
+				r.outputTokensCount = 20
+			},
+			writeErrorFunc: func(w http.ResponseWriter, err error) error {
+				return nil
+			},
+			upstreamBody:         "REPLY",
+			expectUpstreamCalled: true,
+			expectAuditEvent: func(tt require.TestingT, i1 any, i2 ...any) {
+				require.NotNil(tt, i1, i2...)
+				evt := i1.(*apievents.AppSessionLLMRequest)
+				require.True(tt, evt.Status.Success, i2...)
+				require.Equal(tt, "requested", evt.RequestedModel, i2...)
+				require.Equal(tt, "provider", evt.Model, i2...)
+				require.Equal(tt, int64(10), evt.InputTokenCount, i2...)
+				require.Equal(tt, int64(20), evt.OutputTokenCount, i2...)
+			},
+			expectedResponse: expectString("REPLY"),
+		},
+		"new request error": {
+			newRequestFunc: func(w http.ResponseWriter, s *httptest.Server) NewUpstreamRequestFunc {
+				return func(llm *types.LLM, r *http.Request) (*http.Request, RequestInfo, error) {
+					return nil, nil, trace.BadParameter("invalid request")
+				}
+			},
+			writeErrorFunc: func(w http.ResponseWriter, err error) error {
+				_, werr := io.WriteString(w, err.Error())
+				return trace.Wrap(werr)
+			},
+			expectUpstreamCalled: false,
+			expectAuditEvent: func(tt require.TestingT, i1 any, i2 ...any) {
+				require.NotNil(tt, i1, i2...)
+				evt := i1.(*apievents.AppSessionLLMRequest)
+				require.False(tt, evt.Status.Success, i2...)
+				require.Empty(tt, evt.RequestedModel, i2...)
+				require.Empty(tt, evt.Model, i2...)
+				require.Empty(tt, evt.InputTokenCount, i2...)
+				require.Empty(tt, evt.OutputTokenCount, i2...)
+			},
+			expectedResponse: expectString("invalid request"),
+		},
+		"new request error with partial info": {
+			newRequestFunc: func(w http.ResponseWriter, s *httptest.Server) NewUpstreamRequestFunc {
+				return func(llm *types.LLM, r *http.Request) (*http.Request, RequestInfo, error) {
+					return nil, &mockRequestInfo{
+						requestedModel: "requested",
+						providerModel:  "provider",
+					}, trace.BadParameter("invalid request")
+				}
+			},
+			writeErrorFunc: func(w http.ResponseWriter, err error) error {
+				_, werr := io.WriteString(w, err.Error())
+				return trace.Wrap(werr)
+			},
+			expectUpstreamCalled: false,
+			expectAuditEvent: func(tt require.TestingT, i1 any, i2 ...any) {
+				require.NotNil(tt, i1, i2...)
+				evt := i1.(*apievents.AppSessionLLMRequest)
+				require.False(tt, evt.Status.Success, i2...)
+				require.Equal(tt, "requested", evt.RequestedModel, i2...)
+				require.Equal(tt, "provider", evt.Model, i2...)
+				require.Empty(tt, evt.InputTokenCount, i2...)
+				require.Empty(tt, evt.OutputTokenCount, i2...)
+			},
+			expectedResponse: expectString("invalid request"),
+		},
+		"successful request with recorder error": {
+			newRequestFunc: func(w http.ResponseWriter, s *httptest.Server) NewUpstreamRequestFunc {
+				return func(llm *types.LLM, r *http.Request) (*http.Request, RequestInfo, error) {
+					req, err := http.NewRequest(http.MethodPost, s.URL, nil)
+					if err != nil {
+						return nil, nil, trace.Wrap(err)
+					}
+
+					return req, &mockRequestInfo{
+						requestedModel: "requested",
+						providerModel:  "provider",
+					}, nil
+				}
+			},
+			modifyRecorderFunc: func(r *mockUpstreamRecorder) {
+				r.err = trace.AccessDenied("model denied")
+			},
+			writeErrorFunc: func(w http.ResponseWriter, err error) error {
+				return nil
+			},
+			upstreamBody:         "REPLY",
+			expectUpstreamCalled: true,
+			expectAuditEvent: func(tt require.TestingT, i1 any, i2 ...any) {
+				require.NotNil(tt, i1, i2...)
+				evt := i1.(*apievents.AppSessionLLMRequest)
+				require.False(tt, evt.Status.Success, i2...)
+				require.Equal(tt, "requested", evt.RequestedModel, i2...)
+				require.Equal(tt, "provider", evt.Model, i2...)
+				require.Empty(tt, evt.InputTokenCount, i2...)
+				require.Empty(tt, evt.OutputTokenCount, i2...)
+			},
+			expectedResponse: expectString("REPLY"),
+		},
+		// This case covers scenarios where upstream is not reachable.
+		"upstream forward error": {
+			newRequestFunc: func(w http.ResponseWriter, s *httptest.Server) NewUpstreamRequestFunc {
+				return func(llm *types.LLM, r *http.Request) (*http.Request, RequestInfo, error) {
+					req, err := http.NewRequest(http.MethodPost, s.URL, nil)
+					if err != nil {
+						return nil, nil, trace.Wrap(err)
+					}
+
+					return req, &mockRequestInfo{
+						requestedModel: "requested",
+						providerModel:  "provider",
+					}, nil
+				}
+			},
+			modifyRecorderFunc: func(r *mockUpstreamRecorder) {
+				r.err = nil
+				r.inputTokensCount = 10
+				r.outputTokensCount = 20
+			},
+			writeErrorFunc: func(w http.ResponseWriter, err error) error {
+				_, werr := io.WriteString(w, err.Error())
+				return trace.Wrap(werr)
+			},
+			transport: &http.Transport{
+				DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
+					return nil, trace.ConnectionProblem(nil, "failed to connect to upstream")
+				},
+			},
+			expectUpstreamCalled: false,
+			expectAuditEvent: func(tt require.TestingT, i1 any, i2 ...any) {
+				require.NotNil(tt, i1, i2...)
+				evt := i1.(*apievents.AppSessionLLMRequest)
+				require.False(tt, evt.Status.Success, i2...)
+				require.Equal(tt, "requested", evt.RequestedModel, i2...)
+				require.Equal(tt, "provider", evt.Model, i2...)
+				require.Equal(tt, int64(10), evt.InputTokenCount, i2...)
+				require.Equal(tt, int64(20), evt.OutputTokenCount, i2...)
+			},
+			expectedResponse: expectString("failed to connect to upstream"),
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			var upstreamCalled bool
+			mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusOK)
+				io.WriteString(w, tc.upstreamBody)
+				upstreamCalled = true
+			}))
+			t.Cleanup(mockServer.Close)
+
+			var auditEvent *apievents.AppSessionLLMRequest
+			audit := newTestAudit(t, func(pe apievents.PreparedSessionEvent) {
+				if evt, ok := pe.GetAuditEvent().(*apievents.AppSessionLLMRequest); ok {
+					auditEvent = evt
+				}
+			})
+
+			h := newTestHandler(t, tc.transport)
+			app := newTestApp(t, &types.LLM{Format: types.LLMFormatAnthropic, Provider: types.LLMProviderAnthropic})
+			sessionCtx := &common.SessionContext{App: app, Audit: audit}
+			req := newTestSessionRequest(
+				t,
+				http.MethodPost,
+				mockServer.URL,
+				"/",
+				nil,
+				sessionCtx,
+			)
+
+			w := httptest.NewRecorder()
+			h.handleRequest(
+				sessionCtx,
+				w,
+				req,
+				tc.newRequestFunc(w, mockServer),
+				func(_ *slog.Logger, w http.ResponseWriter) (UpstreamRecorder, error) {
+					rec := &mockUpstreamRecorder{ResponseWriter: w}
+					tc.modifyRecorderFunc(rec)
+					return rec, nil
+				},
+				tc.writeErrorFunc,
+			)
+			require.Equal(t, tc.expectUpstreamCalled, upstreamCalled)
+			require.NotNil(t, auditEvent)
+			tc.expectAuditEvent(t, auditEvent)
+			tc.expectedResponse(t, w.Body.String())
+		})
+	}
+}
+
+type mockUpstreamRecorder struct {
+	http.ResponseWriter
+
+	err               error
+	inputTokensCount  int
+	outputTokensCount int
+	written           int
+}
+
+// Close implements [UpstreamRecorder].
+func (m *mockUpstreamRecorder) Close() error {
+	return nil
+}
+
+// Err implements [UpstreamRecorder].
+func (m *mockUpstreamRecorder) Err() error {
+	return m.err
+}
+
+// InputTokensCount implements [UpstreamRecorder].
+func (m *mockUpstreamRecorder) InputTokensCount() int {
+	return m.inputTokensCount
+}
+
+// OutputTokensCount implements [UpstreamRecorder].
+func (m *mockUpstreamRecorder) OutputTokensCount() int {
+	return m.outputTokensCount
+}
+
+// Written implements [UpstreamRecorder].
+func (m *mockUpstreamRecorder) Written() int {
+	return m.written
+}
+
+type mockRequestInfo struct {
+	RequestInfo
+
+	requestedModel string
+	providerModel  string
+	stream         bool
+	requestSize    int
+}
+
+func (r *mockRequestInfo) RequestedModel() string { return r.requestedModel }
+func (r *mockRequestInfo) ProviderModel() string  { return r.providerModel }
+func (r *mockRequestInfo) IsStream() bool         { return r.stream }
+func (r *mockRequestInfo) RequestSize() int       { return r.requestSize }
+
+// streamRecorder adapts an apievents.Stream to an events.SessionRecorder
+// by adding a no-op io.Writer (required by the interface).
+type streamRecorder struct {
+	apievents.Stream
+}
+
+func (s *streamRecorder) Write(p []byte) (int, error) { return len(p), nil }
+
+// newTestAudit creates a common.Audit that calls onRecord for each recorded event.
+func newTestAudit(t *testing.T, onRecord func(apievents.PreparedSessionEvent)) common.Audit {
+	t.Helper()
+	streamer, err := events.NewCallbackStreamer(events.CallbackStreamerConfig{
+		Inner: events.NewDiscardStreamer(),
+		OnRecordEvent: func(_ context.Context, _ session.ID, pe apievents.PreparedSessionEvent) error {
+			onRecord(pe)
+			return nil
+		},
+	})
+	require.NoError(t, err)
+	stream, err := streamer.CreateAuditStream(t.Context(), "test-session")
+	require.NoError(t, err)
+	audit, err := common.NewAudit(common.AuditConfig{
+		Emitter:  events.NewDiscardEmitter(),
+		Recorder: events.WithNoOpPreparer(&streamRecorder{stream}),
+	})
+	require.NoError(t, err)
+	return audit
+}
+
+// newTestApp creates a types.Application configured with the given LLM options.
+func newTestApp(t *testing.T, llm *types.LLM) types.Application {
+	t.Helper()
+	app, err := types.NewAppV3(types.Metadata{
+		Name: "test-llm-app",
+	}, types.AppSpecV3{
+		LLM: llm,
+	})
+	require.NoError(t, err)
+	return app
+}
+
+// newTestSessionRequest creates an *http.Request with a SessionContext attached.
+func newTestSessionRequest(t *testing.T, method, addr string, path string, body io.Reader, sessionCtx *common.SessionContext) *http.Request {
+	t.Helper()
+	target, err := url.JoinPath(addr, path)
+	require.NoError(t, err)
+	req := httptest.NewRequest(method, target, body)
+	return common.WithSessionContext(req, sessionCtx)
+}
+
+func newTestHandler(t *testing.T, tr *http.Transport) *Handler {
+	t.Helper()
+	h, err := NewHandler(t.Context(), HandlerConfig{
+		Log:       slog.Default(),
+		Transport: tr,
+	})
+	require.NoError(t, err)
+	return h
+}

--- a/lib/srv/app/llm/metrics.go
+++ b/lib/srv/app/llm/metrics.go
@@ -17,11 +17,11 @@
 package llm
 
 import (
+	"github.com/gravitational/trace"
 	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/lib/observability/metrics"
-	"github.com/gravitational/trace"
 )
 
 const (

--- a/lib/srv/app/llm/metrics.go
+++ b/lib/srv/app/llm/metrics.go
@@ -1,0 +1,128 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package llm
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/gravitational/teleport"
+	"github.com/gravitational/teleport/lib/observability/metrics"
+	"github.com/gravitational/trace"
+)
+
+const (
+	// llmSubsystem is used to prefix Prometheus metrics for this subsystem.
+	//
+	// See https://prometheus.io/docs/practices/naming/#subsystem-name
+	llmSubsystem = "llm"
+)
+
+// llmMetrics contains all metrics related to LLM access.
+type llmMetrics struct {
+	// requestDuration keeps track of the request duration, in seconds.
+	requestDuration *prometheus.HistogramVec
+	// requestSize keeps track of the request size, in bytes.
+	requestSize *prometheus.HistogramVec
+	// providerRequestDuration keeps track of the provider request duration, in
+	// seconds.
+	providerRequestDuration *prometheus.HistogramVec
+	// providerRequestDuration keeps track of the provider response size, in
+	// bytes.
+	providerResponseSize *prometheus.HistogramVec
+	// inputTokens keeps track of the LLM input token count.
+	inputTokens *prometheus.CounterVec
+	// outputTokens keeps track of the LLM output token count.
+	outputTokens *prometheus.CounterVec
+}
+
+func newMetrics(reg *metrics.Registry) (*llmMetrics, error) {
+	m := &llmMetrics{
+		requestDuration: prometheus.NewHistogramVec(
+			prometheus.HistogramOpts{
+				Namespace: reg.Namespace(),
+				Subsystem: llmSubsystem,
+				Name:      "request_duration_seconds",
+				Help:      "Latency distribution of the total request time.",
+				Buckets:   prometheus.DefBuckets,
+			},
+			[]string{teleport.ComponentLabel, "format", "provider"},
+		),
+		requestSize: prometheus.NewHistogramVec(
+			prometheus.HistogramOpts{
+				Namespace: reg.Namespace(),
+				Subsystem: llmSubsystem,
+				Name:      "request_size_bytes",
+				Help:      "Distribution of the request size.",
+				// 1KiB ... 32MiB
+				Buckets: prometheus.ExponentialBuckets(1024, 2, 16),
+			},
+			[]string{teleport.ComponentLabel, "format", "provider"},
+		),
+		providerRequestDuration: prometheus.NewHistogramVec(
+			prometheus.HistogramOpts{
+				Namespace: reg.Namespace(),
+				Subsystem: llmSubsystem,
+				Name:      "provider_request_duration_seconds",
+				Help:      "Latency distribution of the provider request time.",
+				Buckets:   prometheus.DefBuckets,
+			},
+			[]string{teleport.ComponentLabel, "format", "provider", "streaming"},
+		),
+		providerResponseSize: prometheus.NewHistogramVec(
+			prometheus.HistogramOpts{
+				Namespace: reg.Namespace(),
+				Subsystem: llmSubsystem,
+				Name:      "provider_response_size_bytes",
+				Help:      "Distribution of the provider response size.",
+				// Responses doesn't have a hard limit, meaning they can go up to
+				// any size. We might need to tweak the bucket sizes in the future
+				// to better match the actual response sizes.
+				//
+				// 1KiB ... 32MiB
+				Buckets: prometheus.ExponentialBuckets(1024, 2, 16),
+			},
+			[]string{teleport.ComponentLabel, "format", "provider", "streaming"},
+		),
+		inputTokens: prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Namespace: reg.Namespace(),
+				Subsystem: llmSubsystem,
+				Name:      "input_tokens_count",
+				Help:      "Number of input tokens sent by clients.",
+			},
+			[]string{teleport.ComponentLabel, "format"},
+		),
+		outputTokens: prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Namespace: reg.Namespace(),
+				Subsystem: llmSubsystem,
+				Name:      "output_tokens_count",
+				Help:      "Number of output tokens sent by providers.",
+			},
+			[]string{teleport.ComponentLabel, "format"},
+		),
+	}
+
+	return m, trace.NewAggregate(
+		reg.Register(m.requestDuration),
+		reg.Register(m.requestSize),
+		reg.Register(m.providerRequestDuration),
+		reg.Register(m.providerResponseSize),
+		reg.Register(m.inputTokens),
+		reg.Register(m.outputTokens),
+	)
+}

--- a/lib/srv/app/llm/request/request.go
+++ b/lib/srv/app/llm/request/request.go
@@ -20,8 +20,9 @@ import (
 	"net/http"
 	"net/url"
 
-	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/trace"
+
+	"github.com/gravitational/teleport/api/types"
 )
 
 // Config is config used to create a new provide request.

--- a/lib/srv/app/llm/request/request.go
+++ b/lib/srv/app/llm/request/request.go
@@ -1,0 +1,51 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package request
+
+import (
+	"net/http"
+	"net/url"
+
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/trace"
+)
+
+// Config is config used to create a new provide request.
+type Config struct {
+	// LLM inference endpoint configuration.
+	LLM *types.LLM
+	// DownstreamRequest is the received downstream request.
+	DownstreamRequest *http.Request
+	// ProviderURL is the provider URL address.
+	ProviderURL *url.URL
+	// GetAPIKeyFunc is the function used to retrieve Anthropic API keys.
+	GetAPIKeyFunc func() string
+}
+
+func (c *Config) CheckAndSetDefaults() error {
+	if c.LLM == nil {
+		return trace.BadParameter("llm information is required")
+	}
+	if c.DownstreamRequest == nil {
+		return trace.BadParameter("downstream request is required")
+	}
+	if c.GetAPIKeyFunc == nil {
+		return trace.BadParameter("get api key function is required")
+	}
+
+	return nil
+}

--- a/lib/srv/app/session.go
+++ b/lib/srv/app/session.go
@@ -204,6 +204,11 @@ func (c *ConnectionsHandler) withGCPHandler(ctx context.Context, sess *sessionCh
 	return nil
 }
 
+func (c *ConnectionsHandler) withLLMHandler(ctx context.Context, sess *sessionChunk, identity *tlsca.Identity, app types.Application) error {
+	sess.handler = c.llmHandler
+	return nil
+}
+
 // acquire() increments in-flight request count by 1.
 // It is supposed to be paired with a `release()` call,
 // after the chunk is done with for the individual request

--- a/lib/srv/app/transport_test.go
+++ b/lib/srv/app/transport_test.go
@@ -266,6 +266,10 @@ func (noopAudit) OnDynamoDBRequest(context.Context, *common.SessionContext, *htt
 	return nil
 }
 
+func (noopAudit) OnLLMRequest(context.Context, *common.SessionContext, *http.Request, common.LLMRequest, common.LLMResponse) error {
+	return nil
+}
+
 func (noopAudit) EmitEvent(context.Context, apievents.AuditEvent) error {
 	return nil
 }


### PR DESCRIPTION
Related to [RFD 0038e - LLM Access](https://github.com/gravitational/teleport.e/blob/rfd/0038e-llm-access/rfd/0038e-llm-access.md).

> [!NOTE]
> This doesn't include the actual Anthropic logic. This was done in a previous PR.

This PR includes:
- App service LLM apps handler.
- Instance metrics.
- Audit events for LLM requests (recording).

## Manual Test Plan
### Test Environment

Local cluster with dedicated app service instance.

### Test Cases
- [x] Access using `curl` and `claude` (provider: `anthropic`) 
  - [x] Mapped model.
  - [x] Streaming requests.
  - [x] Fallback model.
  - [x] Invalid messages/errors returned are from Teleport.
  - [x] Audit events are included in the app session recording. `tsh play -f json <chunk-id>`
  - [x] Prometheus metrics generated.
