### PR TITLE
[v17] docs: machine-id updates

### DIFF
--- a/docs/pages/includes/machine-id/postgresql/postgresql.go
+++ b/docs/pages/includes/machine-id/postgresql/postgresql.go
@@ -15,7 +15,7 @@ func main() {
 	// Open connection to database.
 	db, err := sql.Open("pgx", fmt.Sprint(
 		"host=localhost ",
-		"port=1234 ",
+		"port=12345 ",
 		"dbname=example ",
 		"user=alice ",
 		// The next four options should be omitted if the local proxy has been

--- a/docs/pages/machine-workload-identity/troubleshooting.mdx
+++ b/docs/pages/machine-workload-identity/troubleshooting.mdx
@@ -215,7 +215,7 @@ reload signal:
 
 ```code
 ## If using systemd, you can restart the process:
-$ systemctl restart machine-id
+$ systemctl restart tbot
 ## Alternatively, you can send `tbot` a reload signal directly:
 $ pkill -sigusr1 tbot
 ```


### PR DESCRIPTION
backport #67745 to branch/v17
