### PR TITLE
Updates to the list session recordings page

### DIFF
--- a/web/packages/teleport/src/SessionRecordings/list/ListSessionRecordingsRoute.tsx
+++ b/web/packages/teleport/src/SessionRecordings/list/ListSessionRecordingsRoute.tsx
@@ -49,12 +49,17 @@ import useStickyClusterId from 'teleport/useStickyClusterId';
 import useTeleport from 'teleport/useTeleport';
 
 import type { RecordingActionProps } from './RecordingItem';
-import { RecordingsList } from './RecordingsList';
+import {
+  RecordingsList,
+  type RecordingsDecoratorProps,
+} from './RecordingsList';
 import { useRecordingsListState, type RecordingsListFilterKey } from './state';
 
 interface ListSessionRecordingsRouteProps {
   actionComponent?: ComponentType<RecordingActionProps>;
+  badgeComponent?: ComponentType<RecordingActionProps>;
   headerElement?: ReactNode;
+  recordingsDecorator?: ComponentType<RecordingsDecoratorProps>;
 }
 
 export function ListSessionRecordingsRoute() {
@@ -63,7 +68,9 @@ export function ListSessionRecordingsRoute() {
 
 export function ListSessionRecordings({
   actionComponent,
+  badgeComponent,
   headerElement,
+  recordingsDecorator,
 }: ListSessionRecordingsRouteProps) {
   const ranges = useMemo(() => getRangeOptions(), []);
 
@@ -137,10 +144,12 @@ export function ListSessionRecordings({
         >
           <RecordingsList
             actionComponent={actionComponent}
+            badgeComponent={badgeComponent}
             onFilterChange={handleFilterChange}
             onPageChange={handlePageChange}
             onSearchChange={handleSearchChange}
             onSortChange={handleSortChange}
+            recordingsDecorator={recordingsDecorator}
             state={state}
           />
         </ErrorSuspenseWrapper>

--- a/web/packages/teleport/src/SessionRecordings/list/RecordingItem.test.tsx
+++ b/web/packages/teleport/src/SessionRecordings/list/RecordingItem.test.tsx
@@ -58,6 +58,7 @@ async function setupTest({
   viewMode = ViewMode.List,
   density = Density.Comfortable,
   actionComponent,
+  badgeComponent,
 }: Partial<RecordingItemProps>) {
   const ctx = createTeleportContext();
 
@@ -66,6 +67,7 @@ async function setupTest({
       <ContextProvider ctx={ctx}>
         <RecordingItem
           actionComponent={actionComponent}
+          badgeComponent={badgeComponent}
           recording={recording}
           viewMode={viewMode}
           density={density}
@@ -123,6 +125,18 @@ test('renders with comfortable density', async () => {
 
   expect(screen.getByTestId('recording-item')).toBeInTheDocument();
   expect(screen.getByText('SSH Session')).toBeInTheDocument();
+});
+
+test('renders the badge component with the recording details', async () => {
+  await setupTest({
+    badgeComponent: ({ sessionId }) => (
+      <div data-testid="badge-component">{sessionId}</div>
+    ),
+  });
+
+  expect(screen.getByTestId('badge-component')).toHaveTextContent(
+    'test-session'
+  );
 });
 
 test('renders SSH recording type correctly', async () => {

--- a/web/packages/teleport/src/SessionRecordings/list/RecordingItem.tsx
+++ b/web/packages/teleport/src/SessionRecordings/list/RecordingItem.tsx
@@ -18,11 +18,11 @@
 
 import { format } from 'date-fns';
 import {
-  Suspense,
-  useMemo,
   type ComponentType,
   type MouseEventHandler,
   type PropsWithChildren,
+  Suspense,
+  useMemo,
 } from 'react';
 import { ErrorBoundary } from 'react-error-boundary';
 import { Link } from 'react-router';
@@ -67,6 +67,7 @@ export interface RecordingActionProps {
 
 export interface RecordingItemProps {
   actionComponent?: ComponentType<RecordingActionProps>;
+  badgeComponent?: ComponentType<RecordingActionProps>;
   density: Density;
   recording: Recording;
   thumbnailStyles: string;
@@ -75,6 +76,7 @@ export interface RecordingItemProps {
 
 export function RecordingItem({
   actionComponent: ActionComponent,
+  badgeComponent: BadgeComponent,
   density,
   recording,
   thumbnailStyles,
@@ -120,6 +122,27 @@ export function RecordingItem({
       viewMode={viewMode}
       onClick={handleClick}
     >
+      {BadgeComponent && (
+        <RecordingItemHeader>
+          {BadgeComponent && (
+            <BadgeContainer viewMode={viewMode}>
+              <BadgeComponent
+                durationMs={recording.duration}
+                createdDate={recording.createdDate}
+                recordingType={recording.recordingType}
+                sessionId={recording.sid}
+                username={recording.user}
+                hostname={recording.hostname}
+              />
+            </BadgeContainer>
+          )}
+
+          <div style={{ flex: 1 }} />
+
+          <Duration viewMode={viewMode}>{duration}</Duration>
+        </RecordingItemHeader>
+      )}
+
       <ThumbnailContainer density={density} viewMode={viewMode}>
         {recording.playable ? (
           hasThumbnail ? (
@@ -145,7 +168,9 @@ export function RecordingItem({
           </ThumbnailError>
         )}
 
-        <Duration viewMode={viewMode}>{duration}</Duration>
+        {!BadgeComponent && (
+          <FloatingDuration viewMode={viewMode}>{duration}</FloatingDuration>
+        )}
       </ThumbnailContainer>
 
       <Flex width="100%">
@@ -236,6 +261,15 @@ export const RecordingItemContainer = styled(Link).withConfig({
   `
 );
 
+export const RecordingItemHeader = styled(Flex)`
+  background: ${p => p.theme.colors.levels.sunken};
+  flex: 0 0 40px;
+  align-items: center;
+  padding: 0 ${p => p.theme.space[2]}px;
+  justify-content: space-between;
+  border-bottom: 1px solid ${p => p.theme.colors.interactive.tonal.neutral[0]};
+`;
+
 export const ThumbnailContainer = styled.div<
   Pick<RecordingItemProps, 'viewMode' | 'density'>
 >(
@@ -294,16 +328,13 @@ export const RecordingDetails = styled.div<
   `
 );
 
-export const Duration = styled.div<Pick<RecordingItemProps, 'viewMode'>>(
+// BadgeContainer overlays the badge slot on the thumbnail, mirroring the
+// Duration placement on the opposite side, so badges appearing after the
+// initial render never shift the item layout.
+export const BadgeContainer = styled.div<Pick<RecordingItemProps, 'viewMode'>>(
   p => css`
-    background: rgba(0, 0, 0, 0.5);
-    border-radius: ${p.theme.radii[3]}px;
-    color: white;
-    font-weight: bold;
-    position: absolute;
-    line-height: 1;
-    padding: ${p.theme.space[1]}px ${p.theme.space[2]}px;
-    right: ${p.theme.space[2]}px;
+    display: flex;
+    gap: ${p.theme.space[1]}px;
 
     ${p.viewMode === ViewMode.List
       ? css`
@@ -314,6 +345,30 @@ export const Duration = styled.div<Pick<RecordingItemProps, 'viewMode'>>(
         `}
   `
 );
+
+export const Duration = styled.div<Pick<RecordingItemProps, 'viewMode'>>(
+  p => css`
+    background: rgba(0, 0, 0, 0.5);
+    border-radius: ${p.theme.radii[3]}px;
+    color: white;
+    font-weight: bold;
+    line-height: 1;
+    padding: ${p.theme.space[1]}px ${p.theme.space[2]}px;
+
+    ${p.viewMode === ViewMode.List
+      ? css`
+          bottom: ${p.theme.space[2]}px;
+        `
+      : css`
+          top: ${p.theme.space[2]}px;
+        `}
+  `
+);
+
+const FloatingDuration = styled(Duration)`
+  position: absolute;
+  right: ${p => p.theme.space[2]}px;
+`;
 
 export const ItemSpan = styled.span`
   background: ${p => p.theme.colors.spotBackground[0]};

--- a/web/packages/teleport/src/SessionRecordings/list/RecordingItem.tsx
+++ b/web/packages/teleport/src/SessionRecordings/list/RecordingItem.tsx
@@ -124,20 +124,16 @@ export function RecordingItem({
     >
       {BadgeComponent && (
         <RecordingItemHeader>
-          {BadgeComponent && (
-            <BadgeContainer viewMode={viewMode}>
-              <BadgeComponent
-                durationMs={recording.duration}
-                createdDate={recording.createdDate}
-                recordingType={recording.recordingType}
-                sessionId={recording.sid}
-                username={recording.user}
-                hostname={recording.hostname}
-              />
-            </BadgeContainer>
-          )}
-
-          <div style={{ flex: 1 }} />
+          <BadgeContainer viewMode={viewMode}>
+            <BadgeComponent
+              durationMs={recording.duration}
+              createdDate={recording.createdDate}
+              recordingType={recording.recordingType}
+              sessionId={recording.sid}
+              username={recording.user}
+              hostname={recording.hostname}
+            />
+          </BadgeContainer>
 
           <Duration viewMode={viewMode}>{duration}</Duration>
         </RecordingItemHeader>

--- a/web/packages/teleport/src/SessionRecordings/list/RecordingsList.test.tsx
+++ b/web/packages/teleport/src/SessionRecordings/list/RecordingsList.test.tsx
@@ -40,7 +40,11 @@ import {
   MOCK_EVENTS,
   MOCK_THUMBNAIL,
 } from './mock';
-import { RecordingsList } from './RecordingsList';
+import {
+  RecordingsList,
+  type RecordingsDecoratorProps,
+  type RecordingsListProps,
+} from './RecordingsList';
 import type { RecordingsListState } from './state';
 import { Density, ViewMode } from './ViewSwitcher';
 
@@ -107,7 +111,10 @@ function withListRecordings(events = MOCK_EVENTS) {
   );
 }
 
-function setupTest(state: RecordingsListState = defaultState) {
+function setupTest(
+  state: RecordingsListState = defaultState,
+  extraProps: Partial<RecordingsListProps> = {}
+) {
   const ctx = createTeleportContext();
 
   mockHandlers.onFilterChange.mockClear();
@@ -124,11 +131,51 @@ function setupTest(state: RecordingsListState = defaultState) {
           onPageChange={mockHandlers.onPageChange}
           onSearchChange={mockHandlers.onSearchChange}
           onSortChange={mockHandlers.onSortChange}
+          {...extraProps}
         />
       </ContextProvider>
     </MemoryRouter>
   );
 }
+
+describe('decorator and badge slots', () => {
+  it('wraps the visible page with the decorator and passes it the page recordings', async () => {
+    withListRecordings();
+
+    const seenPages: string[][] = [];
+    function Decorator({ recordings, children }: RecordingsDecoratorProps) {
+      seenPages.push(recordings.map(recording => recording.sid));
+      return <div data-testid="decorator">{children}</div>;
+    }
+
+    setupTest(defaultState, { recordingsDecorator: Decorator });
+
+    expect(await screen.findByText('server-01')).toBeInTheDocument();
+
+    expect(screen.getByTestId('decorator')).toBeInTheDocument();
+    expect(seenPages.at(-1)?.toSorted()).toEqual([
+      'session-001',
+      'session-002',
+      'session-003',
+      'session-004',
+      'session-005',
+    ]);
+  });
+
+  it('renders the badge component for every recording on the page', async () => {
+    withListRecordings();
+
+    setupTest(defaultState, {
+      badgeComponent: ({ sessionId }) => (
+        <div data-testid="badge-component">{sessionId}</div>
+      ),
+    });
+
+    expect(await screen.findByText('server-01')).toBeInTheDocument();
+
+    expect(screen.getAllByTestId('badge-component')).toHaveLength(5);
+  });
+});
 
 describe('rendering', () => {
   it('renders recordings list with all items', async () => {

--- a/web/packages/teleport/src/SessionRecordings/list/RecordingsList.tsx
+++ b/web/packages/teleport/src/SessionRecordings/list/RecordingsList.tsx
@@ -23,6 +23,7 @@ import {
   useState,
   type ComponentType,
   type CSSProperties,
+  type PropsWithChildren,
 } from 'react';
 import styled, { useTheme } from 'styled-components';
 
@@ -59,8 +60,13 @@ import type {
 } from './state';
 import { Density, ViewMode, ViewSwitcher } from './ViewSwitcher';
 
-interface RecordingsListProps {
+export interface RecordingsDecoratorProps extends PropsWithChildren {
+  recordings: Recording[];
+}
+
+export interface RecordingsListProps {
   actionComponent?: ComponentType<RecordingActionProps>;
+  badgeComponent?: ComponentType<RecordingActionProps>;
   onFilterChange: (
     key: RecordingsListFilterKey,
     value: string[] | boolean
@@ -68,6 +74,7 @@ interface RecordingsListProps {
   onPageChange: (page: number) => void;
   onSearchChange: (search: string) => void;
   onSortChange: (key: string, dir: SortOrder) => void;
+  recordingsDecorator?: ComponentType<RecordingsDecoratorProps>;
   state: RecordingsListState;
 }
 
@@ -136,10 +143,12 @@ const ScrollContainer = styled.div`
 
 export function RecordingsList({
   actionComponent,
+  badgeComponent,
   onFilterChange,
   onPageChange,
   onSearchChange,
   onSortChange,
+  recordingsDecorator: RecordingsDecorator,
   state,
 }: RecordingsListProps) {
   const ctx = useTeleport();
@@ -236,27 +245,30 @@ export function RecordingsList({
     [theme]
   );
 
+  const pageRecordings = useMemo(
+    () => recordings.slice(startIndex, endIndex),
+    [recordings, startIndex, endIndex]
+  );
+
   const items = useMemo(
     () =>
-      recordings
-        .slice(startIndex, endIndex)
-        .map(recording => (
-          <RecordingItem
-            actionComponent={actionComponent}
-            key={recording.sid}
-            recording={recording}
-            thumbnailStyles={thumbnailStyles}
-            viewMode={viewMode}
-            density={density}
-          />
-        )),
+      pageRecordings.map(recording => (
+        <RecordingItem
+          actionComponent={actionComponent}
+          badgeComponent={badgeComponent}
+          key={recording.sid}
+          recording={recording}
+          thumbnailStyles={thumbnailStyles}
+          viewMode={viewMode}
+          density={density}
+        />
+      )),
     [
       actionComponent,
-      recordings,
+      badgeComponent,
+      pageRecordings,
       viewMode,
       density,
-      startIndex,
-      endIndex,
       thumbnailStyles,
     ]
   );
@@ -346,6 +358,12 @@ export function RecordingsList({
               No Recordings Found
             </Text>
           </Flex>
+        ) : RecordingsDecorator ? (
+          <RecordingsDecorator recordings={pageRecordings}>
+            <RecordingsGrid viewMode={viewMode} density={density}>
+              {items}
+            </RecordingsGrid>
+          </RecordingsDecorator>
         ) : (
           <RecordingsGrid viewMode={viewMode} density={density}>
             {items}

--- a/web/packages/teleport/src/SessionRecordings/list/state.test.tsx
+++ b/web/packages/teleport/src/SessionRecordings/list/state.test.tsx
@@ -58,7 +58,7 @@ describe('searchParamsToState', () => {
         types: [],
         resources: [],
         users: [],
-        hideNonInteractive: false,
+        hideNonInteractive: true,
       },
       page: 0,
       range: mockRanges[0],
@@ -119,7 +119,7 @@ describe('searchParamsToState', () => {
       resources: ['server-01', 'server-02'],
       types: ['ssh', 'desktop'],
       users: ['alice', 'bob'],
-      hideNonInteractive: false,
+      hideNonInteractive: true,
     });
   });
 
@@ -196,10 +196,10 @@ describe('searchParamsToState', () => {
     const params = new URLSearchParams('?hide_non_interactive=invalid');
     const state = searchParamsToState(mockRanges, params);
 
-    expect(state.filters.hideNonInteractive).toBe(false);
+    expect(state.filters.hideNonInteractive).toBe(true);
   });
 
-  it('ignores hideNonInteractive when set to false', () => {
+  it('parses hideNonInteractive parameter when false', () => {
     const params = new URLSearchParams('?hide_non_interactive=false');
     const state = searchParamsToState(mockRanges, params);
 
@@ -248,7 +248,7 @@ describe('stateToSearchParams', () => {
         types: [],
         resources: [],
         users: [],
-        hideNonInteractive: false,
+        hideNonInteractive: true,
       },
       page: 0,
       range: mockRanges[0],
@@ -337,7 +337,7 @@ describe('stateToSearchParams', () => {
         types: [],
         resources: [],
         users: [],
-        hideNonInteractive: false,
+        hideNonInteractive: true,
       },
       page: 3,
       range: mockRanges[0],
@@ -382,7 +382,7 @@ describe('stateToSearchParams', () => {
     expect(urlParams.get('page')).toBe('2');
   });
 
-  it('includes hideNonInteractive when true', () => {
+  it('omits hideNonInteractive when true', () => {
     const state: RecordingsListState = {
       filters: {
         types: [],
@@ -400,10 +400,10 @@ describe('stateToSearchParams', () => {
     const params = stateToSearchParams(state);
     const urlParams = new URLSearchParams(params);
 
-    expect(urlParams.get('hide_non_interactive')).toBe('true');
+    expect(urlParams.has('hide_non_interactive')).toBe(false);
   });
 
-  it('omits hideNonInteractive when false', () => {
+  it('includes hideNonInteractive when false', () => {
     const state: RecordingsListState = {
       filters: {
         types: [],
@@ -421,7 +421,7 @@ describe('stateToSearchParams', () => {
     const params = stateToSearchParams(state);
     const urlParams = new URLSearchParams(params);
 
-    expect(urlParams.has('hide_non_interactive')).toBe(false);
+    expect(urlParams.get('hide_non_interactive')).toBe('false');
   });
 
   it('includes hideNonInteractive with other filters', () => {
@@ -430,7 +430,7 @@ describe('stateToSearchParams', () => {
         resources: ['server-01'],
         types: ['ssh'],
         users: ['alice'],
-        hideNonInteractive: true,
+        hideNonInteractive: false,
       },
       page: 1,
       range: mockRanges[0],
@@ -442,7 +442,7 @@ describe('stateToSearchParams', () => {
     const params = stateToSearchParams(state);
     const urlParams = new URLSearchParams(params);
 
-    expect(urlParams.get('hide_non_interactive')).toBe('true');
+    expect(urlParams.get('hide_non_interactive')).toBe('false');
     expect(urlParams.getAll('resources')).toEqual(['server-01']);
     expect(urlParams.getAll('types')).toEqual(['ssh']);
     expect(urlParams.getAll('users')).toEqual(['alice']);
@@ -499,7 +499,7 @@ describe('stateToSearchParams', () => {
         resources: ['server-01'],
         types: ['ssh'],
         users: ['alice'],
-        hideNonInteractive: true,
+        hideNonInteractive: false,
       },
       page: 1,
       range: mockRanges[0],
@@ -515,7 +515,7 @@ describe('stateToSearchParams', () => {
     expect(urlParams.getAll('resources')).toEqual(['server-01']);
     expect(urlParams.getAll('types')).toEqual(['ssh']);
     expect(urlParams.getAll('users')).toEqual(['alice']);
-    expect(urlParams.get('hide_non_interactive')).toBe('true');
+    expect(urlParams.get('hide_non_interactive')).toBe('false');
     expect(urlParams.get('page')).toBe('1');
     expect(urlParams.get('sort')).toBe('type');
     expect(urlParams.get('direction')).toBe('ASC');
@@ -827,7 +827,7 @@ describe('useRecordingsListState', () => {
 
   it('handles hideNonInteractive filter in URL params', () => {
     const wrapper = createWrapper([
-      '/session-recordings?hide_non_interactive=true',
+      '/session-recordings?hide_non_interactive=false',
     ]);
 
     const { result } = renderHook(() => useRecordingsListState(mockRanges), {
@@ -836,7 +836,7 @@ describe('useRecordingsListState', () => {
 
     const [state] = result.current;
 
-    expect(state.filters.hideNonInteractive).toBe(true);
+    expect(state.filters.hideNonInteractive).toBe(false);
   });
 
   it('updates URL when hideNonInteractive filter changes', () => {
@@ -851,13 +851,13 @@ describe('useRecordingsListState', () => {
         ...prev,
         filters: {
           ...prev.filters,
-          hideNonInteractive: true,
+          hideNonInteractive: false,
         },
       }));
     });
 
     expect(result.current.location.search).toContain(
-      'hide_non_interactive=true'
+      'hide_non_interactive=false'
     );
   });
 

--- a/web/packages/teleport/src/SessionRecordings/list/state.test.tsx
+++ b/web/packages/teleport/src/SessionRecordings/list/state.test.tsx
@@ -185,11 +185,11 @@ describe('searchParamsToState', () => {
     expect(state.filters.hideNonInteractive).toBe(true);
   });
 
-  it('defaults hideNonInteractive to false when not provided', () => {
+  it('defaults hideNonInteractive to true when not provided', () => {
     const params = new URLSearchParams();
     const state = searchParamsToState(mockRanges, params);
 
-    expect(state.filters.hideNonInteractive).toBe(false);
+    expect(state.filters.hideNonInteractive).toBe(true);
   });
 
   it('ignores invalid hideNonInteractive values', () => {

--- a/web/packages/teleport/src/SessionRecordings/list/state.ts
+++ b/web/packages/teleport/src/SessionRecordings/list/state.ts
@@ -198,8 +198,8 @@ export function stateToSearchParams(state: RecordingsListState) {
     urlParams.set('page', state.page.toString());
   }
 
-  if (state.filters.hideNonInteractive) {
-    urlParams.set('hide_non_interactive', 'true');
+  if (!state.filters.hideNonInteractive) {
+    urlParams.set('hide_non_interactive', 'false');
   }
 
   if (state.search) {

--- a/web/packages/teleport/src/SessionRecordings/list/state.ts
+++ b/web/packages/teleport/src/SessionRecordings/list/state.ts
@@ -62,7 +62,7 @@ export function searchParamsToState(
 ) {
   const state: RecordingsListState = {
     filters: {
-      hideNonInteractive: false,
+      hideNonInteractive: true,
       types: [],
       resources: [],
       users: [],

--- a/web/packages/teleport/src/SessionRecordings/list/state.ts
+++ b/web/packages/teleport/src/SessionRecordings/list/state.ts
@@ -122,8 +122,8 @@ export function searchParamsToState(
   }
 
   const hideNonInteractive = params.get('hide_non_interactive');
-  if (hideNonInteractive === 'true') {
-    state.filters.hideNonInteractive = true;
+  if (hideNonInteractive === 'false') {
+    state.filters.hideNonInteractive = false;
   }
 
   const sortKey = params.get('sort');


### PR DESCRIPTION
This adds a `badge` slot and `decorator` to the list session recordings page. The badge slot is where a session summary risk level will go, and the decorator is for wrapping the entire recordings list. This is so we can have a context that batch fetches session summaries in enterprise, in order to display them above the thumbnail.

If there is a badge component, we render a recording item header with a border, moving the duration there. If there isn't (OSS), we keep the duration floating in the top right.

Example of what enterprise will look like utilising these new abilities:

<img width="1471" height="654" alt="Screenshot 2026-06-12 at 13 22 24" src="https://github.com/user-attachments/assets/e324ae66-0b83-4b7f-84c4-9ed9d0c5b0d8" />

Also changes the default search state to hide non-interactive sessions.

Changelog: Non-interactive sessions are now hidden by default on the session recordings page

## Manual Test Plan
### Test Environment
Local

### Test Cases
- [x] Session recordings list as normal
- [x] The default search state hides non-interactive sessions