### PR TITLE
Adjust ScopedToken to refer to scoped Bot using SQN

### DIFF
--- a/api/gen/proto/go/teleport/scopes/joining/v1/token.pb.go
+++ b/api/gen/proto/go/teleport/scopes/joining/v1/token.pb.go
@@ -266,7 +266,7 @@ type ScopedTokenSpec struct {
 	// Configuration specific to the "bound_keypair" join method.
 	BoundKeypair *BoundKeypairSpec `protobuf:"bytes,12,opt,name=bound_keypair,json=boundKeypair,proto3" json:"bound_keypair,omitempty"`
 	// The bot associated with this join token, if any, as a scope-qualified name
-	// of the form "<scope>::<bot-name>" (e.g. "/staging/west::mybot"). The scope
+	// of the form `<scope>::<bot-name>` (e.g. "/staging/west::mybot"). The scope
 	// component must be a descendant of or equivalent to the token's resource
 	// scope.
 	//
@@ -568,7 +568,7 @@ type ScopedTokenSpec_builder struct {
 	// Configuration specific to the "bound_keypair" join method.
 	BoundKeypair *BoundKeypairSpec
 	// The bot associated with this join token, if any, as a scope-qualified name
-	// of the form "<scope>::<bot-name>" (e.g. "/staging/west::mybot"). The scope
+	// of the form `<scope>::<bot-name>` (e.g. "/staging/west::mybot"). The scope
 	// component must be a descendant of or equivalent to the token's resource
 	// scope.
 	//

--- a/api/gen/proto/go/teleport/scopes/joining/v1/token.pb.go
+++ b/api/gen/proto/go/teleport/scopes/joining/v1/token.pb.go
@@ -265,11 +265,13 @@ type ScopedTokenSpec struct {
 	Kubernetes *Kubernetes `protobuf:"bytes,11,opt,name=kubernetes,proto3" json:"kubernetes,omitempty"`
 	// Configuration specific to the "bound_keypair" join method.
 	BoundKeypair *BoundKeypairSpec `protobuf:"bytes,12,opt,name=bound_keypair,json=boundKeypair,proto3" json:"bound_keypair,omitempty"`
-	// Name of the bot associated with this join token, if any.
-	BotName string `protobuf:"bytes,13,opt,name=bot_name,json=botName,proto3" json:"bot_name,omitempty"`
-	// Scope of the bot associated with this join token. Required if bot_name is
-	// set, and mutually exclusive with assigned_scope.
-	BotScope      string `protobuf:"bytes,14,opt,name=bot_scope,json=botScope,proto3" json:"bot_scope,omitempty"`
+	// The bot associated with this join token, if any, as a scope-qualified name
+	// of the form "<scope>::<bot-name>" (e.g. "/staging/west::mybot"). The scope
+	// component must be a descendant of or equivalent to the token's resource
+	// scope.
+	//
+	// Mutually exclusive with assigned_scope.
+	Bot           string `protobuf:"bytes,15,opt,name=bot,proto3" json:"bot,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -383,16 +385,9 @@ func (x *ScopedTokenSpec) GetBoundKeypair() *BoundKeypairSpec {
 	return nil
 }
 
-func (x *ScopedTokenSpec) GetBotName() string {
+func (x *ScopedTokenSpec) GetBot() string {
 	if x != nil {
-		return x.BotName
-	}
-	return ""
-}
-
-func (x *ScopedTokenSpec) GetBotScope() string {
-	if x != nil {
-		return x.BotScope
+		return x.Bot
 	}
 	return ""
 }
@@ -445,12 +440,8 @@ func (x *ScopedTokenSpec) SetBoundKeypair(v *BoundKeypairSpec) {
 	x.BoundKeypair = v
 }
 
-func (x *ScopedTokenSpec) SetBotName(v string) {
-	x.BotName = v
-}
-
-func (x *ScopedTokenSpec) SetBotScope(v string) {
-	x.BotScope = v
+func (x *ScopedTokenSpec) SetBot(v string) {
+	x.Bot = v
 }
 
 func (x *ScopedTokenSpec) HasImmutableLabels() bool {
@@ -576,11 +567,13 @@ type ScopedTokenSpec_builder struct {
 	Kubernetes *Kubernetes
 	// Configuration specific to the "bound_keypair" join method.
 	BoundKeypair *BoundKeypairSpec
-	// Name of the bot associated with this join token, if any.
-	BotName string
-	// Scope of the bot associated with this join token. Required if bot_name is
-	// set, and mutually exclusive with assigned_scope.
-	BotScope string
+	// The bot associated with this join token, if any, as a scope-qualified name
+	// of the form "<scope>::<bot-name>" (e.g. "/staging/west::mybot"). The scope
+	// component must be a descendant of or equivalent to the token's resource
+	// scope.
+	//
+	// Mutually exclusive with assigned_scope.
+	Bot string
 }
 
 func (b0 ScopedTokenSpec_builder) Build() *ScopedTokenSpec {
@@ -599,8 +592,7 @@ func (b0 ScopedTokenSpec_builder) Build() *ScopedTokenSpec {
 	x.Oracle = b.Oracle
 	x.Kubernetes = b.Kubernetes
 	x.BoundKeypair = b.BoundKeypair
-	x.BotName = b.BotName
-	x.BotScope = b.BotScope
+	x.Bot = b.Bot
 	return m0
 }
 
@@ -3457,7 +3449,7 @@ const file_teleport_scopes_joining_v1_token_proto_rawDesc = "" +
 	"\bmetadata\x18\x04 \x01(\v2\x1c.teleport.header.v1.MetadataR\bmetadata\x12\x14\n" +
 	"\x05scope\x18\x05 \x01(\tR\x05scope\x12?\n" +
 	"\x04spec\x18\x06 \x01(\v2+.teleport.scopes.joining.v1.ScopedTokenSpecR\x04spec\x12E\n" +
-	"\x06status\x18\a \x01(\v2-.teleport.scopes.joining.v1.ScopedTokenStatusR\x06status\"\xe0\x05\n" +
+	"\x06status\x18\a \x01(\v2-.teleport.scopes.joining.v1.ScopedTokenStatusR\x06status\"\xdb\x05\n" +
 	"\x0fScopedTokenSpec\x12%\n" +
 	"\x0eassigned_scope\x18\x01 \x01(\tR\rassignedScope\x12\x14\n" +
 	"\x05roles\x18\x02 \x03(\tR\x05roles\x12\x1f\n" +
@@ -3475,9 +3467,8 @@ const file_teleport_scopes_joining_v1_token_proto_rawDesc = "" +
 	"\n" +
 	"kubernetes\x18\v \x01(\v2&.teleport.scopes.joining.v1.KubernetesR\n" +
 	"kubernetes\x12Q\n" +
-	"\rbound_keypair\x18\f \x01(\v2,.teleport.scopes.joining.v1.BoundKeypairSpecR\fboundKeypair\x12\x19\n" +
-	"\bbot_name\x18\r \x01(\tR\abotName\x12\x1b\n" +
-	"\tbot_scope\x18\x0e \x01(\tR\bbotScope\"\xb6\x01\n" +
+	"\rbound_keypair\x18\f \x01(\v2,.teleport.scopes.joining.v1.BoundKeypairSpecR\fboundKeypair\x12\x10\n" +
+	"\x03bot\x18\x0f \x01(\tR\x03botJ\x04\b\r\x10\x0eJ\x04\b\x0e\x10\x0fR\bbot_nameR\tbot_scope\"\xb6\x01\n" +
 	"\x0eHostCertParams\x12\x17\n" +
 	"\ahost_id\x18\x01 \x01(\tR\x06hostId\x12\x1b\n" +
 	"\tnode_name\x18\x02 \x01(\tR\bnodeName\x12\x12\n" +

--- a/api/gen/proto/go/teleport/scopes/joining/v1/token_protoopaque.pb.go
+++ b/api/gen/proto/go/teleport/scopes/joining/v1/token_protoopaque.pb.go
@@ -535,7 +535,7 @@ type ScopedTokenSpec_builder struct {
 	// Configuration specific to the "bound_keypair" join method.
 	BoundKeypair *BoundKeypairSpec
 	// The bot associated with this join token, if any, as a scope-qualified name
-	// of the form "<scope>::<bot-name>" (e.g. "/staging/west::mybot"). The scope
+	// of the form `<scope>::<bot-name>` (e.g. "/staging/west::mybot"). The scope
 	// component must be a descendant of or equivalent to the token's resource
 	// scope.
 	//

--- a/api/gen/proto/go/teleport/scopes/joining/v1/token_protoopaque.pb.go
+++ b/api/gen/proto/go/teleport/scopes/joining/v1/token_protoopaque.pb.go
@@ -238,8 +238,7 @@ type ScopedTokenSpec struct {
 	xxx_hidden_Oracle          *Oracle                `protobuf:"bytes,10,opt,name=oracle,proto3"`
 	xxx_hidden_Kubernetes      *Kubernetes            `protobuf:"bytes,11,opt,name=kubernetes,proto3"`
 	xxx_hidden_BoundKeypair    *BoundKeypairSpec      `protobuf:"bytes,12,opt,name=bound_keypair,json=boundKeypair,proto3"`
-	xxx_hidden_BotName         string                 `protobuf:"bytes,13,opt,name=bot_name,json=botName,proto3"`
-	xxx_hidden_BotScope        string                 `protobuf:"bytes,14,opt,name=bot_scope,json=botScope,proto3"`
+	xxx_hidden_Bot             string                 `protobuf:"bytes,15,opt,name=bot,proto3"`
 	unknownFields              protoimpl.UnknownFields
 	sizeCache                  protoimpl.SizeCache
 }
@@ -353,16 +352,9 @@ func (x *ScopedTokenSpec) GetBoundKeypair() *BoundKeypairSpec {
 	return nil
 }
 
-func (x *ScopedTokenSpec) GetBotName() string {
+func (x *ScopedTokenSpec) GetBot() string {
 	if x != nil {
-		return x.xxx_hidden_BotName
-	}
-	return ""
-}
-
-func (x *ScopedTokenSpec) GetBotScope() string {
-	if x != nil {
-		return x.xxx_hidden_BotScope
+		return x.xxx_hidden_Bot
 	}
 	return ""
 }
@@ -415,12 +407,8 @@ func (x *ScopedTokenSpec) SetBoundKeypair(v *BoundKeypairSpec) {
 	x.xxx_hidden_BoundKeypair = v
 }
 
-func (x *ScopedTokenSpec) SetBotName(v string) {
-	x.xxx_hidden_BotName = v
-}
-
-func (x *ScopedTokenSpec) SetBotScope(v string) {
-	x.xxx_hidden_BotScope = v
+func (x *ScopedTokenSpec) SetBot(v string) {
+	x.xxx_hidden_Bot = v
 }
 
 func (x *ScopedTokenSpec) HasImmutableLabels() bool {
@@ -546,11 +534,13 @@ type ScopedTokenSpec_builder struct {
 	Kubernetes *Kubernetes
 	// Configuration specific to the "bound_keypair" join method.
 	BoundKeypair *BoundKeypairSpec
-	// Name of the bot associated with this join token, if any.
-	BotName string
-	// Scope of the bot associated with this join token. Required if bot_name is
-	// set, and mutually exclusive with assigned_scope.
-	BotScope string
+	// The bot associated with this join token, if any, as a scope-qualified name
+	// of the form "<scope>::<bot-name>" (e.g. "/staging/west::mybot"). The scope
+	// component must be a descendant of or equivalent to the token's resource
+	// scope.
+	//
+	// Mutually exclusive with assigned_scope.
+	Bot string
 }
 
 func (b0 ScopedTokenSpec_builder) Build() *ScopedTokenSpec {
@@ -569,8 +559,7 @@ func (b0 ScopedTokenSpec_builder) Build() *ScopedTokenSpec {
 	x.xxx_hidden_Oracle = b.Oracle
 	x.xxx_hidden_Kubernetes = b.Kubernetes
 	x.xxx_hidden_BoundKeypair = b.BoundKeypair
-	x.xxx_hidden_BotName = b.BotName
-	x.xxx_hidden_BotScope = b.BotScope
+	x.xxx_hidden_Bot = b.Bot
 	return m0
 }
 
@@ -3241,7 +3230,7 @@ const file_teleport_scopes_joining_v1_token_proto_rawDesc = "" +
 	"\bmetadata\x18\x04 \x01(\v2\x1c.teleport.header.v1.MetadataR\bmetadata\x12\x14\n" +
 	"\x05scope\x18\x05 \x01(\tR\x05scope\x12?\n" +
 	"\x04spec\x18\x06 \x01(\v2+.teleport.scopes.joining.v1.ScopedTokenSpecR\x04spec\x12E\n" +
-	"\x06status\x18\a \x01(\v2-.teleport.scopes.joining.v1.ScopedTokenStatusR\x06status\"\xe0\x05\n" +
+	"\x06status\x18\a \x01(\v2-.teleport.scopes.joining.v1.ScopedTokenStatusR\x06status\"\xdb\x05\n" +
 	"\x0fScopedTokenSpec\x12%\n" +
 	"\x0eassigned_scope\x18\x01 \x01(\tR\rassignedScope\x12\x14\n" +
 	"\x05roles\x18\x02 \x03(\tR\x05roles\x12\x1f\n" +
@@ -3259,9 +3248,8 @@ const file_teleport_scopes_joining_v1_token_proto_rawDesc = "" +
 	"\n" +
 	"kubernetes\x18\v \x01(\v2&.teleport.scopes.joining.v1.KubernetesR\n" +
 	"kubernetes\x12Q\n" +
-	"\rbound_keypair\x18\f \x01(\v2,.teleport.scopes.joining.v1.BoundKeypairSpecR\fboundKeypair\x12\x19\n" +
-	"\bbot_name\x18\r \x01(\tR\abotName\x12\x1b\n" +
-	"\tbot_scope\x18\x0e \x01(\tR\bbotScope\"\xb6\x01\n" +
+	"\rbound_keypair\x18\f \x01(\v2,.teleport.scopes.joining.v1.BoundKeypairSpecR\fboundKeypair\x12\x10\n" +
+	"\x03bot\x18\x0f \x01(\tR\x03botJ\x04\b\r\x10\x0eJ\x04\b\x0e\x10\x0fR\bbot_nameR\tbot_scope\"\xb6\x01\n" +
 	"\x0eHostCertParams\x12\x17\n" +
 	"\ahost_id\x18\x01 \x01(\tR\x06hostId\x12\x1b\n" +
 	"\tnode_name\x18\x02 \x01(\tR\bnodeName\x12\x12\n" +

--- a/api/proto/teleport/scopes/joining/v1/token.proto
+++ b/api/proto/teleport/scopes/joining/v1/token.proto
@@ -94,12 +94,16 @@ message ScopedTokenSpec {
   // Configuration specific to the "bound_keypair" join method.
   BoundKeypairSpec bound_keypair = 12;
 
-  // Name of the bot associated with this join token, if any.
-  string bot_name = 13;
+  reserved 13, 14;
+  reserved "bot_name", "bot_scope";
 
-  // Scope of the bot associated with this join token. Required if bot_name is
-  // set, and mutually exclusive with assigned_scope.
-  string bot_scope = 14;
+  // The bot associated with this join token, if any, as a scope-qualified name
+  // of the form "<scope>::<bot-name>" (e.g. "/staging/west::mybot"). The scope
+  // component must be a descendant of or equivalent to the token's resource
+  // scope.
+  //
+  // Mutually exclusive with assigned_scope.
+  string bot = 15;
 }
 
 // The host certificate parameters that should be cached and leveraged for

--- a/api/proto/teleport/scopes/joining/v1/token.proto
+++ b/api/proto/teleport/scopes/joining/v1/token.proto
@@ -98,7 +98,7 @@ message ScopedTokenSpec {
   reserved "bot_name", "bot_scope";
 
   // The bot associated with this join token, if any, as a scope-qualified name
-  // of the form "<scope>::<bot-name>" (e.g. "/staging/west::mybot"). The scope
+  // of the form `<scope>::<bot-name>` (e.g. "/staging/west::mybot"). The scope
   // component must be a descendant of or equivalent to the token's resource
   // scope.
   //

--- a/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-scopedtokensv1.mdx
+++ b/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-scopedtokensv1.mdx
@@ -34,8 +34,7 @@ resource, which you can apply after installing the Teleport Kubernetes operator.
 |aws|[object](#specaws)|The AWS-specific configuration used with the "ec2" and "iam" join methods.|
 |azure|[object](#specazure)|The Azure-specific configuration used with the "azure" join method.|
 |azure_devops|[object](#specazure_devops)|The Azure Devops-specific configuration used with the "azure_devops" join method.|
-|bot_name|string|Name of the bot associated with this join token, if any.|
-|bot_scope|string|Scope of the bot associated with this join token. Required if bot_name is set, and mutually exclusive with assigned_scope.|
+|bot|string|The bot associated with this join token, if any, as a scope-qualified name of the form "<scope>::<bot-name>" (e.g. "/staging/west::mybot"). The scope component must be a descendant of or equivalent to the token's resource scope.  Mutually exclusive with assigned_scope.|
 |bound_keypair|[object](#specbound_keypair)|Configuration specific to the "bound_keypair" join method.|
 |gcp|[object](#specgcp)|The GCP-specific configuration used with the "gcp" join method.|
 |immutable_labels|[object](#specimmutable_labels)|Immutable labels that should be applied to any resulting resources provisioned using this token.|

--- a/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-scopedtokensv1.mdx
+++ b/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-scopedtokensv1.mdx
@@ -34,7 +34,7 @@ resource, which you can apply after installing the Teleport Kubernetes operator.
 |aws|[object](#specaws)|The AWS-specific configuration used with the "ec2" and "iam" join methods.|
 |azure|[object](#specazure)|The Azure-specific configuration used with the "azure" join method.|
 |azure_devops|[object](#specazure_devops)|The Azure Devops-specific configuration used with the "azure_devops" join method.|
-|bot|string|The bot associated with this join token, if any, as a scope-qualified name of the form "<scope>::<bot-name>" (e.g. "/staging/west::mybot"). The scope component must be a descendant of or equivalent to the token's resource scope.  Mutually exclusive with assigned_scope.|
+|bot|string|The bot associated with this join token, if any, as a scope-qualified name of the form `<scope>::<bot-name>` (e.g. "/staging/west::mybot"). The scope component must be a descendant of or equivalent to the token's resource scope.  Mutually exclusive with assigned_scope.|
 |bound_keypair|[object](#specbound_keypair)|Configuration specific to the "bound_keypair" join method.|
 |gcp|[object](#specgcp)|The GCP-specific configuration used with the "gcp" join method.|
 |immutable_labels|[object](#specimmutable_labels)|Immutable labels that should be applied to any resulting resources provisioned using this token.|

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/scoped_token.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/scoped_token.mdx
@@ -59,7 +59,7 @@ Optional:
 - `aws` (Attributes) The AWS-specific configuration used with the "ec2" and "iam" join methods. (see [below for nested schema](#nested-schema-for-specaws))
 - `azure` (Attributes) The Azure-specific configuration used with the "azure" join method. (see [below for nested schema](#nested-schema-for-specazure))
 - `azure_devops` (Attributes) The Azure Devops-specific configuration used with the "azure_devops" join method. (see [below for nested schema](#nested-schema-for-specazure_devops))
-- `bot` (String) The bot associated with this join token, if any, as a scope-qualified name of the form "<scope>::<bot-name>" (e.g. "/staging/west::mybot"). The scope component must be a descendant of or equivalent to the token's resource scope.  Mutually exclusive with assigned_scope.
+- `bot` (String) The bot associated with this join token, if any, as a scope-qualified name of the form `<scope>::<bot-name>` (e.g. "/staging/west::mybot"). The scope component must be a descendant of or equivalent to the token's resource scope.  Mutually exclusive with assigned_scope.
 - `bound_keypair` (Attributes) Configuration specific to the "bound_keypair" join method. (see [below for nested schema](#nested-schema-for-specbound_keypair))
 - `gcp` (Attributes) The GCP-specific configuration used with the "gcp" join method. (see [below for nested schema](#nested-schema-for-specgcp))
 - `immutable_labels` (Attributes) Immutable labels that should be applied to any resulting resources provisioned using this token. (see [below for nested schema](#nested-schema-for-specimmutable_labels))

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/scoped_token.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/scoped_token.mdx
@@ -59,8 +59,7 @@ Optional:
 - `aws` (Attributes) The AWS-specific configuration used with the "ec2" and "iam" join methods. (see [below for nested schema](#nested-schema-for-specaws))
 - `azure` (Attributes) The Azure-specific configuration used with the "azure" join method. (see [below for nested schema](#nested-schema-for-specazure))
 - `azure_devops` (Attributes) The Azure Devops-specific configuration used with the "azure_devops" join method. (see [below for nested schema](#nested-schema-for-specazure_devops))
-- `bot_name` (String) Name of the bot associated with this join token, if any.
-- `bot_scope` (String) Scope of the bot associated with this join token. Required if bot_name is set, and mutually exclusive with assigned_scope.
+- `bot` (String) The bot associated with this join token, if any, as a scope-qualified name of the form "<scope>::<bot-name>" (e.g. "/staging/west::mybot"). The scope component must be a descendant of or equivalent to the token's resource scope.  Mutually exclusive with assigned_scope.
 - `bound_keypair` (Attributes) Configuration specific to the "bound_keypair" join method. (see [below for nested schema](#nested-schema-for-specbound_keypair))
 - `gcp` (Attributes) The GCP-specific configuration used with the "gcp" join method. (see [below for nested schema](#nested-schema-for-specgcp))
 - `immutable_labels` (Attributes) Immutable labels that should be applied to any resulting resources provisioned using this token. (see [below for nested schema](#nested-schema-for-specimmutable_labels))

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/scoped_token.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/scoped_token.mdx
@@ -103,8 +103,7 @@ Optional:
 - `aws` (Attributes) The AWS-specific configuration used with the "ec2" and "iam" join methods. (see [below for nested schema](#nested-schema-for-specaws))
 - `azure` (Attributes) The Azure-specific configuration used with the "azure" join method. (see [below for nested schema](#nested-schema-for-specazure))
 - `azure_devops` (Attributes) The Azure Devops-specific configuration used with the "azure_devops" join method. (see [below for nested schema](#nested-schema-for-specazure_devops))
-- `bot_name` (String) Name of the bot associated with this join token, if any.
-- `bot_scope` (String) Scope of the bot associated with this join token. Required if bot_name is set, and mutually exclusive with assigned_scope.
+- `bot` (String) The bot associated with this join token, if any, as a scope-qualified name of the form "<scope>::<bot-name>" (e.g. "/staging/west::mybot"). The scope component must be a descendant of or equivalent to the token's resource scope.  Mutually exclusive with assigned_scope.
 - `bound_keypair` (Attributes) Configuration specific to the "bound_keypair" join method. (see [below for nested schema](#nested-schema-for-specbound_keypair))
 - `gcp` (Attributes) The GCP-specific configuration used with the "gcp" join method. (see [below for nested schema](#nested-schema-for-specgcp))
 - `immutable_labels` (Attributes) Immutable labels that should be applied to any resulting resources provisioned using this token. (see [below for nested schema](#nested-schema-for-specimmutable_labels))

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/scoped_token.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/scoped_token.mdx
@@ -103,7 +103,7 @@ Optional:
 - `aws` (Attributes) The AWS-specific configuration used with the "ec2" and "iam" join methods. (see [below for nested schema](#nested-schema-for-specaws))
 - `azure` (Attributes) The Azure-specific configuration used with the "azure" join method. (see [below for nested schema](#nested-schema-for-specazure))
 - `azure_devops` (Attributes) The Azure Devops-specific configuration used with the "azure_devops" join method. (see [below for nested schema](#nested-schema-for-specazure_devops))
-- `bot` (String) The bot associated with this join token, if any, as a scope-qualified name of the form "<scope>::<bot-name>" (e.g. "/staging/west::mybot"). The scope component must be a descendant of or equivalent to the token's resource scope.  Mutually exclusive with assigned_scope.
+- `bot` (String) The bot associated with this join token, if any, as a scope-qualified name of the form `<scope>::<bot-name>` (e.g. "/staging/west::mybot"). The scope component must be a descendant of or equivalent to the token's resource scope.  Mutually exclusive with assigned_scope.
 - `bound_keypair` (Attributes) Configuration specific to the "bound_keypair" join method. (see [below for nested schema](#nested-schema-for-specbound_keypair))
 - `gcp` (Attributes) The GCP-specific configuration used with the "gcp" join method. (see [below for nested schema](#nested-schema-for-specgcp))
 - `immutable_labels` (Attributes) Immutable labels that should be applied to any resulting resources provisioned using this token. (see [below for nested schema](#nested-schema-for-specimmutable_labels))

--- a/docs/pages/zero-trust-access/rbac-get-started/scopes.mdx
+++ b/docs/pages/zero-trust-access/rbac-get-started/scopes.mdx
@@ -710,8 +710,7 @@ spec:
   roles: [Bot]
   join_method: bound_keypair
   usage_mode: bot
-  bot_name: my-scoped-bot
-  bot_scope: /staging
+  bot: /staging::my-scoped-bot
   bound_keypair: {}
 ```
 

--- a/examples/chart/teleport-cluster/charts/teleport-operator/operator-crds/resources.teleport.dev_scopedtokensv1.yaml
+++ b/examples/chart/teleport-cluster/charts/teleport-operator/operator-crds/resources.teleport.dev_scopedtokensv1.yaml
@@ -155,7 +155,7 @@ spec:
                 type: object
               bot:
                 description: The bot associated with this join token, if any, as a
-                  scope-qualified name of the form "<scope>::<bot-name>" (e.g. "/staging/west::mybot").
+                  scope-qualified name of the form `<scope>::<bot-name>` (e.g. "/staging/west::mybot").
                   The scope component must be a descendant of or equivalent to the
                   token's resource scope.  Mutually exclusive with assigned_scope.
                 type: string

--- a/examples/chart/teleport-cluster/charts/teleport-operator/operator-crds/resources.teleport.dev_scopedtokensv1.yaml
+++ b/examples/chart/teleport-cluster/charts/teleport-operator/operator-crds/resources.teleport.dev_scopedtokensv1.yaml
@@ -153,12 +153,11 @@ spec:
                       field.
                     type: string
                 type: object
-              bot_name:
-                description: Name of the bot associated with this join token, if any.
-                type: string
-              bot_scope:
-                description: Scope of the bot associated with this join token. Required
-                  if bot_name is set, and mutually exclusive with assigned_scope.
+              bot:
+                description: The bot associated with this join token, if any, as a
+                  scope-qualified name of the form "<scope>::<bot-name>" (e.g. "/staging/west::mybot").
+                  The scope component must be a descendant of or equivalent to the
+                  token's resource scope.  Mutually exclusive with assigned_scope.
                 type: string
               bound_keypair:
                 description: Configuration specific to the "bound_keypair" join method.

--- a/integrations/lib/embeddedtbot/bot_test.go
+++ b/integrations/lib/embeddedtbot/bot_test.go
@@ -405,9 +405,8 @@ func TestScopedBotJoinAuth(t *testing.T) {
 				Type:       string(types.KubernetesJoinTypeStaticJWKS),
 				StaticJwks: scopedjoiningv1.Kubernetes_StaticJWKSConfig_builder{Jwks: jwks}.Build(),
 			}.Build(),
-			BotName:  testBotName,
-			BotScope: testRootScope,
-			Roles:    []string{string(types.RoleBot)},
+			Bot:   scopes.QualifiedName{Scope: testRootScope, Name: testBotName}.String(),
+			Roles: []string{string(types.RoleBot)},
 		}.Build(),
 	}.Build()
 	// Somehow the admin client interface doesn't expose CreateScopedToken ¯\_(ツ)_/¯

--- a/integrations/operator/config/crd/bases/resources.teleport.dev_scopedtokensv1.yaml
+++ b/integrations/operator/config/crd/bases/resources.teleport.dev_scopedtokensv1.yaml
@@ -155,7 +155,7 @@ spec:
                 type: object
               bot:
                 description: The bot associated with this join token, if any, as a
-                  scope-qualified name of the form "<scope>::<bot-name>" (e.g. "/staging/west::mybot").
+                  scope-qualified name of the form `<scope>::<bot-name>` (e.g. "/staging/west::mybot").
                   The scope component must be a descendant of or equivalent to the
                   token's resource scope.  Mutually exclusive with assigned_scope.
                 type: string

--- a/integrations/operator/config/crd/bases/resources.teleport.dev_scopedtokensv1.yaml
+++ b/integrations/operator/config/crd/bases/resources.teleport.dev_scopedtokensv1.yaml
@@ -153,12 +153,11 @@ spec:
                       field.
                     type: string
                 type: object
-              bot_name:
-                description: Name of the bot associated with this join token, if any.
-                type: string
-              bot_scope:
-                description: Scope of the bot associated with this join token. Required
-                  if bot_name is set, and mutually exclusive with assigned_scope.
+              bot:
+                description: The bot associated with this join token, if any, as a
+                  scope-qualified name of the form "<scope>::<bot-name>" (e.g. "/staging/west::mybot").
+                  The scope component must be a descendant of or equivalent to the
+                  token's resource scope.  Mutually exclusive with assigned_scope.
                 type: string
               bound_keypair:
                 description: Configuration specific to the "bound_keypair" join method.

--- a/integrations/terraform/tfschema/scopes/joining/v1/token_terraform.go
+++ b/integrations/terraform/tfschema/scopes/joining/v1/token_terraform.go
@@ -243,13 +243,8 @@ func GenSchemaScopedToken(ctx context.Context) (github_com_hashicorp_terraform_p
 					Description: "The Azure Devops-specific configuration used with the \"azure_devops\" join method.",
 					Optional:    true,
 				},
-				"bot_name": {
-					Description: "Name of the bot associated with this join token, if any.",
-					Optional:    true,
-					Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
-				},
-				"bot_scope": {
-					Description: "Scope of the bot associated with this join token. Required if bot_name is set, and mutually exclusive with assigned_scope.",
+				"bot": {
+					Description: "The bot associated with this join token, if any, as a scope-qualified name of the form \"<scope>::<bot-name>\" (e.g. \"/staging/west::mybot\"). The scope component must be a descendant of or equivalent to the token's resource scope.  Mutually exclusive with assigned_scope.",
 					Optional:    true,
 					Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
 				},
@@ -1877,36 +1872,19 @@ func CopyScopedTokenFromTerraform(_ context.Context, tf github_com_hashicorp_ter
 						}
 					}
 					{
-						a, ok := tf.Attrs["bot_name"]
+						a, ok := tf.Attrs["bot"]
 						if !ok {
-							diags.Append(attrReadMissingDiag{"ScopedToken.spec.bot_name"})
+							diags.Append(attrReadMissingDiag{"ScopedToken.spec.bot"})
 						} else {
 							v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.String)
 							if !ok {
-								diags.Append(attrReadConversionFailureDiag{"ScopedToken.spec.bot_name", "github.com/hashicorp/terraform-plugin-framework/types.String"})
+								diags.Append(attrReadConversionFailureDiag{"ScopedToken.spec.bot", "github.com/hashicorp/terraform-plugin-framework/types.String"})
 							} else {
 								var t string
 								if !v.Null && !v.Unknown {
 									t = string(v.Value)
 								}
-								obj.BotName = t
-							}
-						}
-					}
-					{
-						a, ok := tf.Attrs["bot_scope"]
-						if !ok {
-							diags.Append(attrReadMissingDiag{"ScopedToken.spec.bot_scope"})
-						} else {
-							v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.String)
-							if !ok {
-								diags.Append(attrReadConversionFailureDiag{"ScopedToken.spec.bot_scope", "github.com/hashicorp/terraform-plugin-framework/types.String"})
-							} else {
-								var t string
-								if !v.Null && !v.Unknown {
-									t = string(v.Value)
-								}
-								obj.BotScope = t
+								obj.Bot = t
 							}
 						}
 					}
@@ -4200,47 +4178,25 @@ func CopyScopedTokenToTerraform(ctx context.Context, obj *github_com_gravitation
 						}
 					}
 					{
-						t, ok := tf.AttrTypes["bot_name"]
+						t, ok := tf.AttrTypes["bot"]
 						if !ok {
-							diags.Append(attrWriteMissingDiag{"ScopedToken.spec.bot_name"})
+							diags.Append(attrWriteMissingDiag{"ScopedToken.spec.bot"})
 						} else {
-							v, ok := tf.Attrs["bot_name"].(github_com_hashicorp_terraform_plugin_framework_types.String)
+							v, ok := tf.Attrs["bot"].(github_com_hashicorp_terraform_plugin_framework_types.String)
 							if !ok {
 								i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 								if err != nil {
-									diags.Append(attrWriteGeneralError{"ScopedToken.spec.bot_name", err})
+									diags.Append(attrWriteGeneralError{"ScopedToken.spec.bot", err})
 								}
 								v, ok = i.(github_com_hashicorp_terraform_plugin_framework_types.String)
 								if !ok {
-									diags.Append(attrWriteConversionFailureDiag{"ScopedToken.spec.bot_name", "github.com/hashicorp/terraform-plugin-framework/types.String"})
+									diags.Append(attrWriteConversionFailureDiag{"ScopedToken.spec.bot", "github.com/hashicorp/terraform-plugin-framework/types.String"})
 								}
-								v.Null = string(obj.BotName) == ""
+								v.Null = string(obj.Bot) == ""
 							}
-							v.Value = string(obj.BotName)
+							v.Value = string(obj.Bot)
 							v.Unknown = false
-							tf.Attrs["bot_name"] = v
-						}
-					}
-					{
-						t, ok := tf.AttrTypes["bot_scope"]
-						if !ok {
-							diags.Append(attrWriteMissingDiag{"ScopedToken.spec.bot_scope"})
-						} else {
-							v, ok := tf.Attrs["bot_scope"].(github_com_hashicorp_terraform_plugin_framework_types.String)
-							if !ok {
-								i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
-								if err != nil {
-									diags.Append(attrWriteGeneralError{"ScopedToken.spec.bot_scope", err})
-								}
-								v, ok = i.(github_com_hashicorp_terraform_plugin_framework_types.String)
-								if !ok {
-									diags.Append(attrWriteConversionFailureDiag{"ScopedToken.spec.bot_scope", "github.com/hashicorp/terraform-plugin-framework/types.String"})
-								}
-								v.Null = string(obj.BotScope) == ""
-							}
-							v.Value = string(obj.BotScope)
-							v.Unknown = false
-							tf.Attrs["bot_scope"] = v
+							tf.Attrs["bot"] = v
 						}
 					}
 				}

--- a/integrations/terraform/tfschema/scopes/joining/v1/token_terraform.go
+++ b/integrations/terraform/tfschema/scopes/joining/v1/token_terraform.go
@@ -244,7 +244,7 @@ func GenSchemaScopedToken(ctx context.Context) (github_com_hashicorp_terraform_p
 					Optional:    true,
 				},
 				"bot": {
-					Description: "The bot associated with this join token, if any, as a scope-qualified name of the form \"<scope>::<bot-name>\" (e.g. \"/staging/west::mybot\"). The scope component must be a descendant of or equivalent to the token's resource scope.  Mutually exclusive with assigned_scope.",
+					Description: "The bot associated with this join token, if any, as a scope-qualified name of the form `<scope>::<bot-name>` (e.g. \"/staging/west::mybot\"). The scope component must be a descendant of or equivalent to the token's resource scope.  Mutually exclusive with assigned_scope.",
 					Optional:    true,
 					Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
 				},

--- a/lib/auth/bot_test.go
+++ b/lib/auth/bot_test.go
@@ -1470,8 +1470,7 @@ func TestRegisterBotWithScopedKubernetesToken(t *testing.T) {
 			JoinMethod: string(types.JoinMethodKubernetes),
 			Roles:      []string{string(types.RoleBot)},
 			UsageMode:  joining.TokenUsageModeBot,
-			BotName:    "test-scoped",
-			BotScope:   "/test",
+			Bot:        scopes.QualifiedName{Scope: "/test", Name: "test-scoped"}.String(),
 			Kubernetes: joiningv1.Kubernetes_builder{
 				Type: string(types.KubernetesJoinTypeStaticJWKS),
 				StaticJwks: joiningv1.Kubernetes_StaticJWKSConfig_builder{

--- a/lib/auth/join.go
+++ b/lib/auth/join.go
@@ -442,6 +442,10 @@ func (a *Server) GenerateBotCertsForJoin(
 		a.logger.WarnContext(ctx, "Unable to encode struct value for join metadata", "error", err)
 	}
 
+	// TODO(strideynet): scoped bots are currently looked up by their bare name
+	// and scope-checked via the BotScopeLabel below. Once scoped bots are
+	// namespaced by scope in the backend, the bare name is no longer a unique
+	// identifier and this lookup must key on the scope-qualified name instead.
 	user, err := a.GetUserOrLoginState(ctx, machineidv1.BotResourceName(botName))
 	if err != nil {
 		return nil, "", trace.Wrap(err)
@@ -466,7 +470,7 @@ func (a *Server) GenerateBotCertsForJoin(
 				"token_scope", tokenBotScope,
 				"bot_scope", botScope,
 			)
-			return nil, "", trace.AccessDenied("bot scope must match token's spec.bot_scope")
+			return nil, "", trace.AccessDenied("bot scope must match token's spec.bot")
 		}
 
 		if !scopes.ResourceScope(botScope).IsSubjectToScopeOfEffect(scoped.GetScoped().GetScope()) {

--- a/lib/join/join_bound_keypair_test.go
+++ b/lib/join/join_bound_keypair_test.go
@@ -1937,8 +1937,7 @@ func TestJoinBoundKeypair_ScopedToken(t *testing.T) {
 			JoinMethod: string(types.JoinMethodBoundKeypair),
 			Roles:      []string{string(types.RoleBot)},
 			UsageMode:  joining.TokenUsageModeBot,
-			BotName:    "test-scoped",
-			BotScope:   "/test",
+			Bot:        scopes.QualifiedName{Scope: "/test", Name: "test-scoped"}.String(),
 			BoundKeypair: joiningv1.BoundKeypairSpec_builder{
 				Onboarding: joiningv1.BoundKeypairSpec_OnboardingSpec_builder{
 					InitialPublicKey: correctPublicKey,

--- a/lib/scopes/joining/token.go
+++ b/lib/scopes/joining/token.go
@@ -299,16 +299,17 @@ func validateJoinMethod(token *joiningv1.ScopedToken) error {
 func strongValidateBotToken(token *joiningv1.ScopedToken, roles types.SystemRoles) error {
 	spec := token.GetSpec()
 
-	if spec.GetBotName() == "" {
-		return trace.BadParameter("expected non-empty bot_name for a scoped bot token")
+	if spec.GetBot() == "" {
+		return trace.BadParameter("expected non-empty bot for a scoped bot token")
 	}
 
-	if spec.GetBotScope() == "" {
-		return trace.BadParameter("expected non-empty bot_scope for a scoped bot token")
+	bot, err := scopes.ParseQualifiedName(spec.GetBot())
+	if err != nil {
+		return trace.Wrap(err, "validating scoped token bot")
 	}
 
-	if err := scopes.StrongValidate(spec.GetBotScope()); err != nil {
-		return trace.Wrap(err, "validating scoped token bot_scope")
+	if err := bot.StrongValidate(); err != nil {
+		return trace.Wrap(err, "validating scoped token bot")
 	}
 
 	if spec.GetUsageMode() != TokenUsageModeBot {
@@ -319,8 +320,8 @@ func strongValidateBotToken(token *joiningv1.ScopedToken, roles types.SystemRole
 		return trace.BadParameter("roles must only be '[Bot]' for a scoped bot token")
 	}
 
-	if !scopes.ScopeOfOrigin(token.GetScope()).IsAssignableToScopeOfEffect(spec.GetBotScope()) {
-		return trace.BadParameter("scoped token bot_scope must be a descendant of or equivalent to its resource scope")
+	if !scopes.ScopeOfOrigin(token.GetScope()).IsAssignableToScopeOfEffect(bot.Scope) {
+		return trace.BadParameter("scoped token bot scope must be a descendant of or equivalent to its resource scope")
 	}
 
 	if spec.GetAssignedScope() != "" {
@@ -339,12 +340,8 @@ func strongValidateBotToken(token *joiningv1.ScopedToken, roles types.SystemRole
 func validateNonBotToken(token *joiningv1.ScopedToken) error {
 	spec := token.GetSpec()
 
-	if spec.GetBotName() != "" {
-		return trace.BadParameter("bot_name cannot be set for a non-bot token")
-	}
-
-	if spec.GetBotScope() != "" {
-		return trace.BadParameter("bot_scope cannot be set for a non-bot token")
+	if spec.GetBot() != "" {
+		return trace.BadParameter("bot cannot be set for a non-bot token")
 	}
 
 	if spec.GetUsageMode() == TokenUsageModeBot {
@@ -362,10 +359,11 @@ func validateNonBotToken(token *joiningv1.ScopedToken) error {
 	return nil
 }
 
-// validateBotRef weak-validates the bot reference fields of a scoped token
-// spec and returns the referenced bot's name and scope. Bot tokens must carry
-// both components. For non-bot tokens the bot fields are ignored and empty
-// values are returned: stray bot fields on a non-bot token are rejected by
+// validateBotRef weak-validates the bot reference of a scoped token spec and
+// returns the referenced bot's name and scope, parsed from the
+// scope-qualified name in the bot field. Bot tokens must carry a well-formed
+// scope-qualified name. For non-bot tokens the bot field is ignored and empty
+// values are returned: a stray bot field on a non-bot token is rejected by
 // strong validation at write time, but tolerated here to match weak
 // validation's posture toward existing resources.
 func validateBotRef(spec *joiningv1.ScopedTokenSpec, isBotToken bool) (name, scope string, err error) {
@@ -373,17 +371,18 @@ func validateBotRef(spec *joiningv1.ScopedTokenSpec, isBotToken bool) (name, sco
 		return "", "", nil
 	}
 
-	if spec.GetBotName() == "" {
-		return "", "", trace.BadParameter("expected non-empty bot_name for a scoped bot token")
+	if spec.GetBot() == "" {
+		return "", "", trace.BadParameter("expected non-empty bot for a scoped bot token")
 	}
-	if spec.GetBotScope() == "" {
-		return "", "", trace.BadParameter("expected non-empty bot_scope for a scoped bot token")
+	bot, err := scopes.ParseQualifiedName(spec.GetBot())
+	if err != nil {
+		return "", "", trace.Wrap(err, "validating scoped token bot")
 	}
-	if err := scopes.WeakValidate(spec.GetBotScope()); err != nil {
-		return "", "", trace.Wrap(err, "validating scoped token bot_scope")
+	if err := bot.WeakValidate(); err != nil {
+		return "", "", trace.Wrap(err, "validating scoped token bot")
 	}
 
-	return spec.GetBotName(), spec.GetBotScope(), nil
+	return bot.Name, bot.Scope, nil
 }
 
 // StrongValidateToken checks if the scoped token is well-formed according to
@@ -570,10 +569,10 @@ type Token struct {
 // NewToken returns the wrapped version of the given [joiningv1.ScopedToken].
 // It will return an error if the configured join method is not a valid
 // [types.JoinMethod], if any of the configured roles are not a valid
-// [types.SystemRole], or if the bot_name/bot_scope fields are inconsistent
-// with the configured roles. The validated join method, roles, and bot
-// reference are cached on the [Token] wrapper itself so they can be read
-// without repeating validation.
+// [types.SystemRole], or if the bot field is inconsistent with the configured
+// roles. The validated join method, roles, and bot reference are cached on
+// the [Token] wrapper itself so they can be read without repeating
+// validation.
 func NewToken(token *joiningv1.ScopedToken) (*Token, error) {
 	joinMethod := types.JoinMethod(token.GetSpec().GetJoinMethod())
 	if err := types.ValidateJoinMethod(joinMethod); err != nil {

--- a/lib/scopes/joining/token_test.go
+++ b/lib/scopes/joining/token_test.go
@@ -71,8 +71,7 @@ func TestValidateScopedToken(t *testing.T) {
 		}.Build(),
 		Spec: joiningv1.ScopedTokenSpec_builder{
 			Roles:      []string{types.RoleBot.String()},
-			BotScope:   "/aa/bb",
-			BotName:    "test-bot",
+			Bot:        "/aa/bb::test-bot",
 			JoinMethod: string(types.JoinMethodBoundKeypair),
 			UsageMode:  joining.TokenUsageModeBot,
 		}.Build(),
@@ -955,18 +954,11 @@ func TestValidateScopedToken(t *testing.T) {
 			},
 		},
 		{
-			name: "non-bot token with bot_scope",
+			name: "non-bot token with bot",
 			modFn: func(tok *joiningv1.ScopedToken) {
-				tok.GetSpec().SetBotScope("/aa/bb")
+				tok.GetSpec().SetBot("/aa/bb::foo")
 			},
-			expectedStrongErr: "bot_scope cannot be set",
-		},
-		{
-			name: "non-bot token with bot_name",
-			modFn: func(tok *joiningv1.ScopedToken) {
-				tok.GetSpec().SetBotName("foo")
-			},
-			expectedStrongErr: "bot_name cannot be set",
+			expectedStrongErr: "bot cannot be set",
 		},
 		{
 			name: "non-bot token with bot usage mode",
@@ -980,31 +972,31 @@ func TestValidateScopedToken(t *testing.T) {
 			baseToken: baseBotToken,
 		},
 		{
-			name:      "bot token without a bot_name",
+			name:      "bot token without a bot",
 			baseToken: baseBotToken,
 			modFn: func(tok *joiningv1.ScopedToken) {
-				tok.GetSpec().SetBotName("")
+				tok.GetSpec().SetBot("")
 			},
-			expectedStrongErr: "expected non-empty bot_name",
-			expectedWeakErr:   "expected non-empty bot_name",
+			expectedStrongErr: "expected non-empty bot",
+			expectedWeakErr:   "expected non-empty bot",
 		},
 		{
-			name:      "bot token without a bot_scope",
+			name:      "bot token with bot missing scope qualification",
 			baseToken: baseBotToken,
 			modFn: func(tok *joiningv1.ScopedToken) {
-				tok.GetSpec().SetBotScope("")
+				tok.GetSpec().SetBot("test-bot")
 			},
-			expectedStrongErr: "expected non-empty bot_scope",
-			expectedWeakErr:   "expected non-empty bot_scope",
+			expectedStrongErr: "validating scoped token bot",
+			expectedWeakErr:   "validating scoped token bot",
 		},
 		{
 			name:      "bot token with an invalid bot scope",
 			baseToken: baseBotToken,
 			modFn: func(tok *joiningv1.ScopedToken) {
-				tok.GetSpec().SetBotScope("aa/bb}")
+				tok.GetSpec().SetBot("aa/bb}::test-bot")
 			},
-			expectedStrongErr: "validating scoped token bot_scope",
-			expectedWeakErr:   "validating scoped token bot_scope",
+			expectedStrongErr: "validating scoped token bot",
+			expectedWeakErr:   "validating scoped token bot",
 		},
 		{
 			name:      "bot token with invalid usage mode",
@@ -1027,9 +1019,9 @@ func TestValidateScopedToken(t *testing.T) {
 			baseToken: baseBotToken,
 			modFn: func(tok *joiningv1.ScopedToken) {
 				tok.SetScope("/aa/bb")
-				tok.GetSpec().SetBotScope("/aa/cc")
+				tok.GetSpec().SetBot("/aa/cc::test-bot")
 			},
-			expectedStrongErr: "scoped token bot_scope must be a descendant of",
+			expectedStrongErr: "scoped token bot scope must be a descendant of",
 		},
 		{
 			name:      "bot token with assigned_scope",
@@ -1128,8 +1120,7 @@ func TestNewTokenGetBot(t *testing.T) {
 			}.Build(),
 			Spec: joiningv1.ScopedTokenSpec_builder{
 				Roles:      []string{types.RoleBot.String()},
-				BotScope:   "/aa/bb",
-				BotName:    "test-bot",
+				Bot:        "/aa/bb::test-bot",
 				JoinMethod: string(types.JoinMethodBoundKeypair),
 				UsageMode:  joining.TokenUsageModeBot,
 			}.Build(),
@@ -1171,39 +1162,38 @@ func TestNewTokenGetBot(t *testing.T) {
 			token: newNonBotToken(),
 		},
 		{
-			// Stray bot fields on a non-bot token are rejected by strong
+			// A stray bot field on a non-bot token is rejected by strong
 			// validation at write time but tolerated when wrapping, matching
 			// weak validation; the bot reference is empty.
-			name:  "non-bot token with stray bot fields",
+			name:  "non-bot token with stray bot field",
 			token: newNonBotToken(),
 			modFn: func(tok *joiningv1.ScopedToken) {
-				tok.GetSpec().SetBotName("test-bot")
-				tok.GetSpec().SetBotScope("/aa/bb")
+				tok.GetSpec().SetBot("/aa/bb::test-bot")
 			},
 		},
 		{
-			name:  "bot token without bot_name",
+			name:  "bot token without bot",
 			token: newBotToken(),
 			modFn: func(tok *joiningv1.ScopedToken) {
-				tok.GetSpec().SetBotName("")
+				tok.GetSpec().SetBot("")
 			},
-			expectedErr: "expected non-empty bot_name",
+			expectedErr: "expected non-empty bot",
 		},
 		{
-			name:  "bot token without bot_scope",
+			name:  "bot token with bot missing scope qualification",
 			token: newBotToken(),
 			modFn: func(tok *joiningv1.ScopedToken) {
-				tok.GetSpec().SetBotScope("")
+				tok.GetSpec().SetBot("test-bot")
 			},
-			expectedErr: "expected non-empty bot_scope",
+			expectedErr: "validating scoped token bot",
 		},
 		{
-			name:  "bot token with malformed bot_scope",
+			name:  "bot token with malformed bot scope",
 			token: newBotToken(),
 			modFn: func(tok *joiningv1.ScopedToken) {
-				tok.GetSpec().SetBotScope("aa/bb}")
+				tok.GetSpec().SetBot("aa/bb}::test-bot")
 			},
-			expectedErr: "validating scoped token bot_scope",
+			expectedErr: "validating scoped token bot",
 		},
 	}
 

--- a/lib/services/local/scoped_tokens_test.go
+++ b/lib/services/local/scoped_tokens_test.go
@@ -42,6 +42,7 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/backend"
 	"github.com/gravitational/teleport/lib/backend/memory"
+	"github.com/gravitational/teleport/lib/scopes"
 	"github.com/gravitational/teleport/lib/scopes/joining"
 	"github.com/gravitational/teleport/lib/services/local"
 )
@@ -606,8 +607,7 @@ func newBoundKeypairToken() *joiningv1.ScopedToken {
 		Scope: "/test",
 		Spec: joiningv1.ScopedTokenSpec_builder{
 			AssignedScope: "",
-			BotName:       "example",
-			BotScope:      "/test",
+			Bot:           scopes.QualifiedName{Scope: "/test", Name: "example"}.String(),
 			JoinMethod:    string(types.JoinMethodBoundKeypair),
 			Roles:         []string{types.RoleBot.String()},
 			UsageMode:     string(joining.TokenUsageModeBot),

--- a/lib/tbot/tbot_test.go
+++ b/lib/tbot/tbot_test.go
@@ -1911,8 +1911,7 @@ func createScopedBot(
 				Roles:      []string{types.RoleBot.String()},
 				JoinMethod: string(types.JoinMethodBoundKeypair),
 				UsageMode:  jointoken.TokenUsageModeBot,
-				BotName:    botName,
-				BotScope:   scopeName,
+				Bot:        scopes.QualifiedName{Scope: scopeName, Name: botName}.String(),
 				BoundKeypair: joiningv1.BoundKeypairSpec_builder{
 					Onboarding: joiningv1.BoundKeypairSpec_OnboardingSpec_builder{
 						InitialPublicKey: botPublicKey,


### PR DESCRIPTION
Depends on https://github.com/gravitational/teleport/pull/67746

Part of SQN introduction work. Similar to https://github.com/gravitational/teleport/pull/67728

BREAKING!

This PR adjusts the ScopedToken to refer to a scoped Bot using a single bot field that contains a SQN. Support for the prior bot_scope/bot_name fields is dropped.

STs pointed to Bots prior to this PR will become invalid.

I'll likely hold off backporting this until the other PRs related to the ST resource are going back so we can try and land them together.

## Manual Test Plan
### Test Environment

Local cluster

### Test Cases

- [x] Smoke test: Created SB, ST, SRA, SR, join `tbot` using ST
- [x] Smoke test: Use tbot to do SSH to scoped node.
