### PR TITLE
Add page_type and outcome statements to 47 guides

### DIFF
--- a/docs/pages/enroll-resources/auto-discovery/auto-discovery.mdx
+++ b/docs/pages/enroll-resources/auto-discovery/auto-discovery.mdx
@@ -6,6 +6,7 @@ tags:
  - zero-trust
  - infrastructure-identity
 sidebar_position: 1
+page_type: landing
 ---
 
 import DocHero from "@site/src/components/Pages/Landing/DocHero";

--- a/docs/pages/enroll-resources/auto-discovery/databases/databases.mdx
+++ b/docs/pages/enroll-resources/auto-discovery/databases/databases.mdx
@@ -6,10 +6,15 @@ tags:
  - conceptual
  - zero-trust
  - infrastructure-identity
+page_type: conceptual
 ---
 
 Teleport can be configured to discover databases automatically and register
 them with your Teleport cluster.
+
+This page describes the architecture of database discovery and the options you
+can use to configure database discovery on the Teleport Discovery Service and
+Teleport Database Service.
 
 ## Supported clouds
 

--- a/docs/pages/enroll-resources/auto-discovery/kubernetes-applications/kubernetes-applications.mdx
+++ b/docs/pages/enroll-resources/auto-discovery/kubernetes-applications/kubernetes-applications.mdx
@@ -5,6 +5,7 @@ description: "Teleport can automatically detect applications running in your Kub
 tags:
  - zero-trust
  - infrastructure-identity
+page_type: landing
 ---
 
 Teleport can automatically detect applications running in your Kubernetes

--- a/docs/pages/enroll-resources/auto-discovery/kubernetes/aks-discovery.mdx
+++ b/docs/pages/enroll-resources/auto-discovery/kubernetes/aks-discovery.mdx
@@ -7,11 +7,15 @@ tags:
  - zero-trust
  - infrastructure-identity
  - azure
+page_type: how-to
 ---
 
 AKS Auto-Discovery can automatically
 discover any AKS cluster and enroll it in Teleport if its tags match the
 configured labels.
+
+In this guide, you will set up your Azure account to support AKS auto-discovery
+and deploy a Teleport Agent in your cluster that enables this feature.
 
 ## How it works
 

--- a/docs/pages/enroll-resources/auto-discovery/kubernetes/eks-discovery/eks-discovery-manual.mdx
+++ b/docs/pages/enroll-resources/auto-discovery/kubernetes/eks-discovery/eks-discovery-manual.mdx
@@ -2,6 +2,7 @@
 title: Manual EKS Auto-Discovery Configuration
 sidebar_label: Manual
 description: How to configure Teleport EKS auto-discovery manually.
+page_type: how-to
 tags:
  - how-to
  - zero-trust

--- a/docs/pages/enroll-resources/auto-discovery/kubernetes/eks-discovery/eks-discovery-terraform.mdx
+++ b/docs/pages/enroll-resources/auto-discovery/kubernetes/eks-discovery/eks-discovery-terraform.mdx
@@ -2,6 +2,7 @@
 title: Terraform EKS Auto-Discovery Configuration
 sidebar_label: Terraform
 description: How to configure Teleport EKS auto-discovery with Terraform
+page_type: how-to
 tags:
  - how-to
  - zero-trust

--- a/docs/pages/enroll-resources/auto-discovery/kubernetes/eks-discovery/eks-discovery.mdx
+++ b/docs/pages/enroll-resources/auto-discovery/kubernetes/eks-discovery/eks-discovery.mdx
@@ -2,6 +2,7 @@
 title: Kubernetes Auto-Discovery for Amazon EKS
 sidebar_label: Amazon EKS
 description: How to configure Teleport to automatically enroll EKS clusters.
+page_type: how-to
 tags:
  - how-to
  - zero-trust

--- a/docs/pages/enroll-resources/auto-discovery/kubernetes/kubernetes.mdx
+++ b/docs/pages/enroll-resources/auto-discovery/kubernetes/kubernetes.mdx
@@ -6,6 +6,7 @@ tags:
  - conceptual
  - zero-trust
  - infrastructure-identity
+page_type: conceptual
 ---
 
 Kubernetes Clusters Discovery allows Kubernetes clusters
@@ -14,6 +15,8 @@ hosted on cloud providers to be discovered and enrolled automatically.
 While discovering a new Kubernetes cluster, Teleport does not install any component
 on the cluster. Instead, it requires direct access to the cluster's API and
 minimal access permissions.
+
+This page describes the architecture of Kubernetes cluster discovery.
 
 ## Supported clouds
 

--- a/docs/pages/enroll-resources/auto-discovery/reference/aws-iam.mdx
+++ b/docs/pages/enroll-resources/auto-discovery/reference/aws-iam.mdx
@@ -6,6 +6,7 @@ tags:
  - reference
  - zero-trust
  - infrastructure-identity
+page_type: reference
 ---
 
 The Teleport Discovery Service requires AWS IAM permissions to discover AWS
@@ -13,8 +14,8 @@ resources.
 These permissions must be attached to an AWS IAM identity that the Discovery
 Service instance can use.
 
-Each section below describes the IAM permissions used to discover a specific
-type of AWS resource.
+This page lists the IAM permissions that the Teleport Discovery Service uses to
+discover a specific type of AWS resource.
 
 ## EC2
 

--- a/docs/pages/enroll-resources/auto-discovery/reference/labels.mdx
+++ b/docs/pages/enroll-resources/auto-discovery/reference/labels.mdx
@@ -2,12 +2,16 @@
 title: Labels
 sidebar_label: Labels
 description: Learn about resource labels applied during auto-discovery
+page_type: reference
 ---
 
 Cloud resources such as AWS EC2 instances, EKS clusters, RDS databases and similar
 resources in Azure and Google Cloud enrolled in a Teleport cluster during
 auto-discovery get a set of default labels applied to them which can then be
 used in RBAC.
+
+This page lists the default labels that Teleport applies to auto-discovered
+resources.
 
 ## AWS
 

--- a/docs/pages/enroll-resources/auto-discovery/reference/reference.mdx
+++ b/docs/pages/enroll-resources/auto-discovery/reference/reference.mdx
@@ -3,6 +3,7 @@ title: Auto-Discovery Reference
 sidebar_label: Reference
 description: Configuration reference for the Teleport Discovery Service.
 sidebar_position: 5
+page_type: landing
 tags:
  - zero-trust
  - infrastructure-identity

--- a/docs/pages/enroll-resources/auto-discovery/servers/azure-vm-discovery/azure-vm-discovery-manual.mdx
+++ b/docs/pages/enroll-resources/auto-discovery/servers/azure-vm-discovery/azure-vm-discovery-manual.mdx
@@ -2,6 +2,7 @@
 title: Manual Azure VM Auto-Discovery Configuration
 sidebar_label: Manual
 description: How to manually configure Teleport to automatically enroll Azure virtual machines.
+page_type: how-to
 tags:
  - how-to
  - zero-trust

--- a/docs/pages/enroll-resources/auto-discovery/servers/azure-vm-discovery/azure-vm-discovery-terraform.mdx
+++ b/docs/pages/enroll-resources/auto-discovery/servers/azure-vm-discovery/azure-vm-discovery-terraform.mdx
@@ -2,6 +2,7 @@
 title: Terraform Azure VM Auto-Discovery Configuration
 sidebar_label: Terraform
 description: How to configure Teleport Azure VM auto-discovery with Terraform
+page_type: how-to
 tags:
  - how-to
  - zero-trust

--- a/docs/pages/enroll-resources/auto-discovery/servers/azure-vm-discovery/azure-vm-discovery.mdx
+++ b/docs/pages/enroll-resources/auto-discovery/servers/azure-vm-discovery/azure-vm-discovery.mdx
@@ -2,6 +2,7 @@
 title: Server Auto-Discovery for Azure Virtual Machines
 sidebar_label: Azure Virtual Machines
 description: How to configure Teleport to automatically enroll Azure virtual machines.
+page_type: how-to
 tags:
  - how-to
  - zero-trust

--- a/docs/pages/enroll-resources/auto-discovery/servers/ec2-discovery/ec2-discovery-guided.mdx
+++ b/docs/pages/enroll-resources/auto-discovery/servers/ec2-discovery/ec2-discovery-guided.mdx
@@ -2,6 +2,7 @@
 title: Guided EC2 Auto-Discovery Configuration
 sidebar_label: Guided
 description: How to configure Teleport EC2 auto-discovery using Teleport to configure permissions
+page_type: how-to
 tags:
  - how-to
  - zero-trust

--- a/docs/pages/enroll-resources/auto-discovery/servers/ec2-discovery/ec2-discovery-manual.mdx
+++ b/docs/pages/enroll-resources/auto-discovery/servers/ec2-discovery/ec2-discovery-manual.mdx
@@ -2,6 +2,7 @@
 title: Manual EC2 Auto-Discovery Configuration
 sidebar_label: Manual
 description: How to configure Teleport EC2 auto-discovery with manually configured permissions
+page_type: how-to
 tags:
  - how-to
  - zero-trust

--- a/docs/pages/enroll-resources/auto-discovery/servers/ec2-discovery/ec2-discovery-terraform.mdx
+++ b/docs/pages/enroll-resources/auto-discovery/servers/ec2-discovery/ec2-discovery-terraform.mdx
@@ -2,6 +2,7 @@
 title: Terraform EC2 Auto-Discovery Configuration
 sidebar_label: Terraform
 description: How to configure Teleport EC2 auto-discovery with Terraform
+page_type: how-to
 tags:
  - how-to
  - zero-trust

--- a/docs/pages/enroll-resources/auto-discovery/servers/ec2-discovery/ec2-discovery.mdx
+++ b/docs/pages/enroll-resources/auto-discovery/servers/ec2-discovery/ec2-discovery.mdx
@@ -2,6 +2,7 @@
 title: Server Auto-Discovery for Amazon EC2
 sidebar_label: Amazon EC2
 description: How to configure Teleport to automatically enroll EC2 instances.
+page_type: how-to
 tags:
  - how-to
  - zero-trust

--- a/docs/pages/enroll-resources/auto-discovery/servers/gcp-discovery.mdx
+++ b/docs/pages/enroll-resources/auto-discovery/servers/gcp-discovery.mdx
@@ -2,6 +2,7 @@
 title: Automatically Discover GCP Compute Instances
 sidebar_label: Google Compute Engine
 description: How to configure Teleport to automatically enroll GCP compute instances.
+page_type: how-to
 tags:
  - how-to
  - zero-trust

--- a/docs/pages/enroll-resources/auto-discovery/servers/servers.mdx
+++ b/docs/pages/enroll-resources/auto-discovery/servers/servers.mdx
@@ -5,6 +5,7 @@ description: You can set up the Teleport Discovery Service to automatically enro
 tags:
  - zero-trust
  - infrastructure-identity
+page_type: landing
 ---
 
 The Teleport Discovery Service can connect to your cloud provider and

--- a/docs/pages/enroll-resources/auto-discovery/servers/troubleshooting.mdx
+++ b/docs/pages/enroll-resources/auto-discovery/servers/troubleshooting.mdx
@@ -6,9 +6,11 @@ tags:
  - how-to
  - zero-trust
  - infrastructure-identity
+page_type: troubleshooting
 ---
 
-Common issues and diagnostic steps for server auto-discovery.
+This page describes common issues you may encounter when setting up server
+auto-discovery and how to work around or resolve them.
 
 The `tctl discovery nodes` command lists Teleport's recent attempts to enroll
 cloud instances and reports whether each succeeded. It reads enrollment audit

--- a/docs/pages/enroll-resources/automatic-labels/automatic-labels.mdx
+++ b/docs/pages/enroll-resources/automatic-labels/automatic-labels.mdx
@@ -3,6 +3,7 @@ title: Automatically Label Teleport Agents
 sidebar_label: Automatic Labels
 sidebar_position: 8
 description: Provides information on labeling Teleport Agents automatically by integrating with your cloud provider.
+page_type: landing
 ---
 
 When running on a virtual machine in your cloud provider, Teleport will

--- a/docs/pages/enroll-resources/automatic-labels/ec2-tags.mdx
+++ b/docs/pages/enroll-resources/automatic-labels/ec2-tags.mdx
@@ -7,7 +7,11 @@ tags:
  - zero-trust
  - infrastructure-identity
  - aws
+page_type: how-to
 ---
+
+In this guide, you will configure your Teleport cluster to assign labels to
+Teleport Agents running on Amazon EC2 based on their tags.
 
 When running on an AWS EC2 instance, Teleport will automatically detect and import EC2 tags as
 Teleport labels for SSH nodes, Applications, Databases, and Kubernetes clusters. Labels created

--- a/docs/pages/enroll-resources/automatic-labels/gcp-tags.mdx
+++ b/docs/pages/enroll-resources/automatic-labels/gcp-tags.mdx
@@ -7,7 +7,12 @@ tags:
  - zero-trust
  - infrastructure-identity
  - google-cloud
+page_type: how-to
 ---
+
+In this guide, you will configure your Teleport cluster to assign labels to
+Teleport Agents running on Google Compute Engine based on their Google Cloud
+tags.
 
 When running on an Google Compute Engine instance, Teleport will automatically detect and import GCP
 [tags](https://cloud.google.com/resource-manager/docs/tags/tags-overview) (key-value pairs that are

--- a/docs/pages/enroll-resources/automatic-labels/oracle-tags.mdx
+++ b/docs/pages/enroll-resources/automatic-labels/oracle-tags.mdx
@@ -6,9 +6,13 @@ tags:
  - conceptual
  - zero-trust
  - infrastructure-identity
+page_type: how-to
 ---
 
-When running on an Oracle Cloud (OCI) Compute instance, Teleport will
+In this guide, you will configure your Teleport cluster to assign labels to
+Teleport Agents running on Oracle Cloud (OCI) based on their tags.
+
+When running on an Oracle Cloud  Compute instance, Teleport will
 automatically detect and import the instance's freeform and defined tags
 as Teleport labels for SSH servers, applications, databases, and Kubernetes clusters.
 Tags imported this way will have the `oracle/` prefix.

--- a/docs/pages/enroll-resources/database-access/guides/dynamic-registration.mdx
+++ b/docs/pages/enroll-resources/database-access/guides/dynamic-registration.mdx
@@ -6,11 +6,15 @@ tags:
  - conceptual
  - zero-trust
  - infrastructure-identity
+page_type: conceptual
 ---
 
 Dynamic database registration allows Teleport administrators to register new
 databases (or update/unregister existing ones) without having to update the
 static configuration and restart Teleport Database Service instances. 
+
+This page describes the Teleport configuration options that allow you to enable
+and customize dynamic database registration.
 
 Dynamic registration also enables administrators to deploy multiple Database
 Service instances for [high availability](../../../installation/agents/high-availability.mdx) by

--- a/docs/pages/enroll-resources/desktop-access/desktop-access.mdx
+++ b/docs/pages/enroll-resources/desktop-access/desktop-access.mdx
@@ -3,6 +3,7 @@ title: Windows Desktops
 description: Protect Windows Resources with Teleport's passwordless access and other features.
 sidebar_position: 7
 template: doc-page
+page_type: landing
 tags:
  - zero-trust
  - infrastructure-identity

--- a/docs/pages/enroll-resources/desktop-access/directory-sharing.mdx
+++ b/docs/pages/enroll-resources/desktop-access/directory-sharing.mdx
@@ -5,11 +5,16 @@ tags:
  - how-to
  - zero-trust
  - infrastructure-identity
+page_type: how-to
 ---
 
 Directory Sharing is a Teleport feature that makes it easy to move files
 between a local machine and a remote desktop—and apply changes to those
 files—without compromising security.
+
+In this guide, you will share a directory on your connected Windows desktop,
+edit files in the directory, and configure a Teleport role to disable Directory
+Sharing.
 
 ## How it works
 

--- a/docs/pages/enroll-resources/desktop-access/dynamic-registration.mdx
+++ b/docs/pages/enroll-resources/desktop-access/dynamic-registration.mdx
@@ -6,6 +6,7 @@ tags:
  - conceptual
  - zero-trust
  - infrastructure-identity
+page_type: conceptual
 ---
 
 Dynamic Windows desktop registration allows Teleport administrators to register
@@ -17,6 +18,9 @@ Windows Desktop Service instances watch for updates from the Teleport Auth
 Service for `dynamic_windows_desktop` resources, each of which includes the
 information that the Windows Desktop Service needs to connect to a Windows
 desktop.
+
+This page describes the Teleport settings you can modify in order to configure
+dynamic registration for Windows desktops.
 
 ## Required permissions
 

--- a/docs/pages/enroll-resources/desktop-access/introduction.mdx
+++ b/docs/pages/enroll-resources/desktop-access/introduction.mdx
@@ -9,9 +9,9 @@ tags:
  - privileged-access
 ---
 
-The topics in this guide describe how to configure Teleport to provide secure, passwordless
-access to Microsoft Windows desktops and servers. For Windows, Teleport provides the
-following key features:
+You can configure Teleport to provide secure, passwordless access to Microsoft
+Windows desktops and servers. For Windows, Teleport provides the following key
+features:
 
 - Passwordless access to Windows hosts backed by secure cryptographic
   authentication and short-lived certificates.
@@ -20,6 +20,9 @@ following key features:
   from remote Windows hosts.
 - Session recording for all desktop activity.
 - Audit logs that track user activity.
+
+This page describes the architecture of Windows desktop enrollment with
+Teleport.
 
 ## How it works
 

--- a/docs/pages/enroll-resources/desktop-access/rbac.mdx
+++ b/docs/pages/enroll-resources/desktop-access/rbac.mdx
@@ -6,7 +6,11 @@ tags:
  - conceptual
  - zero-trust
  - privileged-access
+page_type: conceptual
 ---
+
+This page describes the capabilities that Teleport provides for managing
+role-based access controls for protected remote desktops.
 
 Teleport's RBAC allows administrators to set up granular access policies for
 Windows desktops connected to Teleport.

--- a/docs/pages/enroll-resources/desktop-access/reference/reference.mdx
+++ b/docs/pages/enroll-resources/desktop-access/reference/reference.mdx
@@ -4,6 +4,7 @@ sidebar_label: Reference
 description: Comprehensive guides to configuring and auditing desktop access.
 sidebar_position: 8
 template: "no-toc"
+page_type: landing
 tags:
  - zero-trust
  - infrastructure-identity

--- a/docs/pages/enroll-resources/desktop-access/troubleshooting.mdx
+++ b/docs/pages/enroll-resources/desktop-access/troubleshooting.mdx
@@ -6,9 +6,11 @@ tags:
  - how-to
  - zero-trust
  - infrastructure-identity
+page_type: troubleshooting
 ---
 
-Common issues and resolution steps.
+This page describes common issues you may run into when enrolling remote
+desktops with Teleport and how to work around or resolve them.
 
 ## Certificate expired or not yet valid
 

--- a/docs/pages/enroll-resources/enroll-resources.mdx
+++ b/docs/pages/enroll-resources/enroll-resources.mdx
@@ -2,6 +2,7 @@
 title: Enrolling Teleport Resources
 description: Provides step-by-step instructions for enrolling servers, databases, and other infrastructure resources with your Teleport cluster.
 template: "landing-page"
+page_type: landing
 tags:
  - conceptual
  - zero-trust

--- a/docs/pages/enroll-resources/kubernetes-access/health-checks.mdx
+++ b/docs/pages/enroll-resources/kubernetes-access/health-checks.mdx
@@ -7,9 +7,13 @@ tags:
 - conceptual
 - zero-trust
 - infrastructure-identity
+page_type: conceptual
 ---
 
-This documentation provides an overview of Kubernetes cluster health checks with Teleport. Teleport Kubernetes Service instances periodically check the connectivity and permissions of enrolled Kubernetes clusters. 
+With Teleport Kubernetes health checks, Teleport Kubernetes Service instances
+periodically check the connectivity and permissions of enrolled Kubernetes
+clusters. This page describes how Kubernetes health checks work and how you can
+configure them for your cluster.
 
 Kubernetes cluster health checks are available in Teleport version (= kubernetes.health_check_min_version =) and later.
 

--- a/docs/pages/enroll-resources/kubernetes-access/introduction.mdx
+++ b/docs/pages/enroll-resources/kubernetes-access/introduction.mdx
@@ -2,6 +2,7 @@
 title: Introduction to Enrolling Kubernetes Clusters
 sidebar_label: Introduction
 description: Learn how Teleport can protect your Kubernetes clusters with RBAC, audit logging, and more.
+page_type: landing
 tags:
  - conceptual
  - zero-trust

--- a/docs/pages/enroll-resources/kubernetes-access/kubernetes-access.mdx
+++ b/docs/pages/enroll-resources/kubernetes-access/kubernetes-access.mdx
@@ -2,6 +2,7 @@
 title: Kubernetes Clusters
 description: Protect Kubernetes clusters with granular role-based access controls, audit logging, and session recording.
 template: doc-page
+page_type: landing
 tags:
  - zero-trust
  - infrastructure-identity

--- a/docs/pages/enroll-resources/kubernetes-access/register-clusters/dynamic-registration.mdx
+++ b/docs/pages/enroll-resources/kubernetes-access/register-clusters/dynamic-registration.mdx
@@ -5,6 +5,7 @@ tags:
  - how-to
  - zero-trust
  - infrastructure-identity
+page_type: how-to
 ---
 
 With dynamic Kubernetes cluster registration, you can manage the Kubernetes
@@ -15,9 +16,8 @@ Dynamic Kubernetes cluster registration is useful when you have deployed
 multiple Kubernetes Service instances or need to regularly reconfigure access to
 Kubernetes clusters in your infrastructure.
 
-In this guide, we will show you how to set up dynamic Kubernetes cluster
-registration, then create, list, update, and delete Kubernetes clusters via
-`tctl`.
+In this guide, you will set up dynamic Kubernetes cluster registration, then
+create, list, update, and delete Kubernetes clusters via `tctl`.
 
 ## How it works
 

--- a/docs/pages/enroll-resources/kubernetes-access/register-clusters/register-clusters.mdx
+++ b/docs/pages/enroll-resources/kubernetes-access/register-clusters/register-clusters.mdx
@@ -4,6 +4,7 @@ sidebar_label: Registering Clusters
 sidebar_position: 3
 description: How to manually add a Kubernetes cluster to Teleport after creating it.
 template: "no-toc"
+page_type: landing
 tags:
  - zero-trust
  - infrastructure-identity

--- a/docs/pages/enroll-resources/kubernetes-access/register-clusters/static-kubeconfig.mdx
+++ b/docs/pages/enroll-resources/kubernetes-access/register-clusters/static-kubeconfig.mdx
@@ -5,6 +5,7 @@ tags:
  - how-to
  - zero-trust
  - infrastructure-identity
+page_type: how-to
 ---
 
 While you can register a Kubernetes cluster with Teleport by running the
@@ -12,6 +13,9 @@ Teleport Kubernetes Service [on that cluster](../getting-started.mdx), you can
 also run the Teleport Kubernetes Service on a Linux host outside the cluster.
 This is useful if you want to decouple your Teleport deployment from the
 Kubernetes clusters you want to manage access to.
+
+In this guide, you will enroll the Teleport Kubernetes Service with Teleport and
+configure the service to proxy a Kubernetes cluster with a static `kubeconfig`.
 
 ## How it works
 

--- a/docs/pages/enroll-resources/kubernetes-access/troubleshooting.mdx
+++ b/docs/pages/enroll-resources/kubernetes-access/troubleshooting.mdx
@@ -6,9 +6,11 @@ tags:
  - how-to
  - zero-trust
  - infrastructure-identity
+page_type: troubleshooting
 ---
 
-This page describes common issues with Kubernetes and how to resolve them.
+This page describes common issues with Kubernetes and how to work around or
+resolve them.
 
 ## An agent failed to join a cluster due to "no authorities for hostname"
 

--- a/docs/pages/enroll-resources/server-access/guides/guides.mdx
+++ b/docs/pages/enroll-resources/server-access/guides/guides.mdx
@@ -3,6 +3,7 @@ title: Server Access Configuration Guides
 sidebar_label: Configuration Guides
 description: Teleport server access guides.
 template: "no-toc"
+page_type: landing
 tags:
  - zero-trust
  - infrastructure-identity

--- a/docs/pages/enroll-resources/server-access/guides/ssh-pam.mdx
+++ b/docs/pages/enroll-resources/server-access/guides/ssh-pam.mdx
@@ -5,10 +5,12 @@ description: How to configure Teleport SSH with PAM (Pluggable Authentication Mo
 tags:
  - conceptual
  - zero-trust
+page_type: conceptual
 ---
 
-Teleport's SSH Service can be configured to integrate with
-Pluggable Authentication Modules (PAM).
+Teleport's SSH Service can be configured to integrate with Pluggable
+Authentication Modules (PAM). This page describes the available features for
+integrating Teleport with PAM.
 
 Teleport currently supports the `auth`, `account`, and `session` PAM modules. The `auth`
 stack is optional and not used by default.

--- a/docs/pages/enroll-resources/server-access/openssh/openssh.mdx
+++ b/docs/pages/enroll-resources/server-access/openssh/openssh.mdx
@@ -3,6 +3,7 @@ title: Enrolling OpenSSH Servers with Teleport
 sidebar_label: OpenSSH Servers
 description: Teleport Agentless OpenSSH integration guides.
 template: "no-toc"
+page_type: landing
 tags:
  - zero-trust
  - infrastructure-identity

--- a/docs/pages/enroll-resources/server-access/rbac.mdx
+++ b/docs/pages/enroll-resources/server-access/rbac.mdx
@@ -6,6 +6,7 @@ tags:
  - conceptual
  - zero-trust
  - privileged-access
+page_type: conceptual
 ---
 
 You can use Teleport's role-based access control (RBAC) system to set up
@@ -15,6 +16,9 @@ An example of a policy could be, *Server administrators have access to
 everything, the QA team and engineers have full access to staging servers, and
 engineers can gain temporary access to production servers in case of
 emergency.*
+
+This page describes the configuration options available in Teleport roles for
+configuring access to Teleport-protected servers.
 
 For a more general description of Teleport roles and examples see our [Access Controls guides](../../zero-trust-access/authentication/authentication.mdx), as
 this section focuses on configuring RBAC for servers connected to Teleport.

--- a/docs/pages/enroll-resources/server-access/server-access.mdx
+++ b/docs/pages/enroll-resources/server-access/server-access.mdx
@@ -2,6 +2,7 @@
 title: Linux Servers
 description: Securely connect to Linux servers via SSH
 template: "doc-page"
+page_type: landing
 tags:
  - zero-trust
  - infrastructure-identity

--- a/docs/pages/enroll-resources/server-access/troubleshooting-server.mdx
+++ b/docs/pages/enroll-resources/server-access/troubleshooting-server.mdx
@@ -6,9 +6,10 @@ tags:
  - how-to
  - zero-trust
  - infrastructure-identity
+page_type: troubleshooting
 ---
 
-This section describes common issues that you might encounter in managing access to servers
+This page describes common issues that you might encounter in managing access to servers
 with Teleport and how to work around or resolve them.
 
 ## Starting SSH sessions fails


### PR DESCRIPTION
Continues the work from the previous batch (#67723).

We are standardizing docs guides to add a `page_type` frontmatter field, with values for how-to guides, references, etc. We can then use this field to apply linting rules that ensure each guide type follows type-specific docs site conventions. The first convention is that each docs page must have an outcome statement, the structure of which depends on the guide's type. Human and AI agent readers can determine from the outcome statement whether to continue reading the guide or not.

This change assigns the `page_type` frontmatter field to 47 guides in the enroll-resources section of the docs. Where an outcome statement is missing or incorrect, this change adds or corrects it.

Of the 47 guides:
- 14 guides were landing pages that needed only `page_type: landing` (landing pages do not have outcome statements).
- 11 guides already included the expected outcome statement, but needed a `page_type` frontmatter field.
- 17 guides had no outcome statement at all.
- 5 guides included outcome statements but required minor tweaks so they followed the expected structure.