### PR TITLE
Set global setup to always resolve from OSS

### DIFF
--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -16,6 +16,8 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+import { fileURLToPath } from 'node:url';
+
 import { defineConfig, devices } from '@playwright/test';
 
 // Default to localhost:3080/web/login if START_URL is not defined.
@@ -36,7 +38,7 @@ export default defineConfig({
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 1 : 0,
   workers: process.env.CI ? 1 : undefined,
-  globalSetup: './global-setup.ts',
+  globalSetup: fileURLToPath(new URL('global-setup.ts', import.meta.url)),
   reporter: [
     ['html', { open: 'never' }],
     ['json', { outputFile: 'test-results/results.json' }],


### PR DESCRIPTION
Otherwise enterprise tries to resolve it from `e/e2e`.