### PR TITLE
Add support for `internal.linux_desktop_logins` trait

### DIFF
--- a/api/constants/constants.go
+++ b/api/constants/constants.go
@@ -422,6 +422,10 @@ const (
 	// to store allowed Windows logins.
 	TraitWindowsLogins = "windows_logins"
 
+	// TraitLinuxDesktopLogins is the name of the role variable used
+	// to store allowed Linux desktop logins.
+	TraitLinuxDesktopLogins = "linux_desktop_logins"
+
 	// TraitKubeGroups is the name the role variable used to store
 	// allowed kubernetes groups
 	TraitKubeGroups = "kubernetes_groups"

--- a/api/types/user.go
+++ b/api/types/user.go
@@ -95,6 +95,8 @@ type User interface {
 	GetKubeGroups() []string
 	// GetWindowsLogins gets the list of Windows Logins for the user
 	GetWindowsLogins() []string
+	// GetLinuxDesktopLogins gets the list of Linux desktop logins for the user
+	GetLinuxDesktopLogins() []string
 	// GetAWSRoleARNs gets the list of AWS role ARNs for the user
 	GetAWSRoleARNs() []string
 	// GetAzureIdentities gets a list of Azure identities for the user
@@ -127,6 +129,8 @@ type User interface {
 	SetKubeGroups(kubeGroups []string)
 	// SetWindowsLogins sets a list of Windows Logins for user
 	SetWindowsLogins(logins []string)
+	// SetLinuxDesktopLogins sets a list of Linux desktop logins for user
+	SetLinuxDesktopLogins(logins []string)
 	// SetAWSRoleARNs sets a list of AWS role ARNs for user
 	SetAWSRoleARNs(awsRoleARNs []string)
 	// SetAzureIdentities sets a list of Azure identities for the user
@@ -487,6 +491,11 @@ func (u *UserV2) SetWindowsLogins(logins []string) {
 	u.setTrait(constants.TraitWindowsLogins, logins)
 }
 
+// SetLinuxDesktopLogins sets the LinuxLogins trait for the user
+func (u *UserV2) SetLinuxDesktopLogins(logins []string) {
+	u.setTrait(constants.TraitLinuxDesktopLogins, logins)
+}
+
 // SetAWSRoleARNs sets the AWSRoleARNs trait for the user
 func (u *UserV2) SetAWSRoleARNs(awsRoleARNs []string) {
 	u.setTrait(constants.TraitAWSRoleARNs, awsRoleARNs)
@@ -619,6 +628,11 @@ func (u UserV2) GetKubeGroups() []string {
 // GetWindowsLogins gets the list of Windows Logins for the user
 func (u UserV2) GetWindowsLogins() []string {
 	return u.getTrait(constants.TraitWindowsLogins)
+}
+
+// GetLinuxDesktopLogins gets the list of Linux desktop logins for the user
+func (u UserV2) GetLinuxDesktopLogins() []string {
+	return u.getTrait(constants.TraitLinuxDesktopLogins)
 }
 
 // GetAWSRoleARNs gets the list of AWS role ARNs for the user

--- a/docs/pages/reference/cli/tctl.mdx
+++ b/docs/pages/reference/cli/tctl.mdx
@@ -2787,6 +2787,7 @@ Flags:
 |`--host-user-uid`|*no default*|UID for auto provisioned host users to use|
 |`--kubernetes-groups`|*no default*|List of allowed Kubernetes groups for the new user|
 |`--kubernetes-users`|*no default*|List of allowed Kubernetes users for the new user|
+|`--linux-desktop-logins`|*no default*|List of allowed Linux desktop logins for the new user|
 |`--logins`|*no default*|List of allowed SSH logins for the new user|
 |`--mcp-tools`|*no default*|List of allowed MCP tools for the new user|
 |`--roles`|*no default*|List of roles for the new user to assume|
@@ -2879,6 +2880,7 @@ Flags:
 |`--set-host-user-uid`|*no default*|UID for auto provisioned host users to use. Value can be reset by providing an empty string|
 |`--set-kubernetes-groups`|*no default*|List of allowed Kubernetes groups for the user, replaces current Kubernetes groups|
 |`--set-kubernetes-users`|*no default*|List of allowed Kubernetes users for the user, replaces current Kubernetes users|
+|`--set-linux-desktop-logins`|*no default*|List of allowed Linux desktop logins for the user, replaces current Linux logins|
 |`--set-logins`|*no default*|List of allowed SSH logins for the user, replaces current logins|
 |`--set-mcp-tools`|*no default*|List of allowed MCP tools for the user, replaces current allowed MCP tools.|
 |`--set-roles`|*no default*|List of roles for the user to assume, replaces current roles|

--- a/lib/services/role.go
+++ b/lib/services/role.go
@@ -913,7 +913,7 @@ func ApplyValueTraitsWithContext(val string, ctx RoleTemplateContext) ([]string,
 		// verify that internal traits match the supported variables
 		if namespace == teleport.TraitInternalPrefix {
 			switch name {
-			case constants.TraitLogins, constants.TraitWindowsLogins,
+			case constants.TraitLogins, constants.TraitWindowsLogins, constants.TraitLinuxDesktopLogins,
 				constants.TraitKubeGroups, constants.TraitKubeUsers,
 				constants.TraitDBNames, constants.TraitDBUsers, constants.TraitDBRoles,
 				constants.TraitAWSRoleARNs, constants.TraitAzureIdentities,

--- a/lib/srv/desktop/x11/xsession_test.go
+++ b/lib/srv/desktop/x11/xsession_test.go
@@ -181,7 +181,8 @@ func TestStartTeleportExecXSession(t *testing.T) {
 				ExecLogConfig: config,
 				Writer:        os.Stderr,
 			},
-			Display: ":0",
+			Display:        ":0",
+			SessionWrapper: "sh -c",
 		}
 	}
 	t.Run("valid command", func(t *testing.T) {

--- a/tool/tctl/common/user_command.go
+++ b/tool/tctl/common/user_command.go
@@ -56,6 +56,7 @@ type UserCommand struct {
 	login                     string
 	allowedLogins             []string
 	allowedWindowsLogins      []string
+	allowedLinuxDesktopLogins []string
 	allowedKubeUsers          []string
 	allowedKubeGroups         []string
 	allowedDatabaseUsers      []string
@@ -97,6 +98,7 @@ func (u *UserCommand) Initialize(app *kingpin.Application, _ *tctlcfg.GlobalCLIF
 
 	u.userAdd.Flag("logins", "List of allowed SSH logins for the new user").StringsVar(&u.allowedLogins)
 	u.userAdd.Flag("windows-logins", "List of allowed Windows logins for the new user").StringsVar(&u.allowedWindowsLogins)
+	u.userAdd.Flag("linux-desktop-logins", "List of allowed Linux desktop logins for the new user").StringsVar(&u.allowedLinuxDesktopLogins)
 	u.userAdd.Flag("kubernetes-users", "List of allowed Kubernetes users for the new user").StringsVar(&u.allowedKubeUsers)
 	u.userAdd.Flag("kubernetes-groups", "List of allowed Kubernetes groups for the new user").StringsVar(&u.allowedKubeGroups)
 	u.userAdd.Flag("db-users", "List of allowed database users for the new user").StringsVar(&u.allowedDatabaseUsers)
@@ -126,6 +128,8 @@ func (u *UserCommand) Initialize(app *kingpin.Application, _ *tctlcfg.GlobalCLIF
 		StringsVar(&u.allowedLogins)
 	u.userUpdate.Flag("set-windows-logins", "List of allowed Windows logins for the user, replaces current Windows logins").
 		StringsVar(&u.allowedWindowsLogins)
+	u.userUpdate.Flag("set-linux-desktop-logins", "List of allowed Linux desktop logins for the user, replaces current Linux logins").
+		StringsVar(&u.allowedLinuxDesktopLogins)
 	u.userUpdate.Flag("set-kubernetes-users", "List of allowed Kubernetes users for the user, replaces current Kubernetes users").
 		StringsVar(&u.allowedKubeUsers)
 	u.userUpdate.Flag("set-kubernetes-groups", "List of allowed Kubernetes groups for the user, replaces current Kubernetes groups").
@@ -258,6 +262,7 @@ func (u *UserCommand) Add(ctx context.Context, client *authclient.Client) error 
 	u.allowedRoles = flattenSlice(u.allowedRoles)
 	u.allowedLogins = flattenSlice(u.allowedLogins)
 	u.allowedWindowsLogins = flattenSlice(u.allowedWindowsLogins)
+	u.allowedLinuxDesktopLogins = flattenSlice(u.allowedLinuxDesktopLogins)
 
 	// Validate roles (server does not do this yet).
 	for _, roleName := range u.allowedRoles {
@@ -297,6 +302,7 @@ func (u *UserCommand) Add(ctx context.Context, client *authclient.Client) error 
 	traits := map[string][]string{
 		constants.TraitLogins:             u.allowedLogins,
 		constants.TraitWindowsLogins:      u.allowedWindowsLogins,
+		constants.TraitLinuxDesktopLogins: u.allowedLinuxDesktopLogins,
 		constants.TraitKubeUsers:          flattenSlice(u.allowedKubeUsers),
 		constants.TraitKubeGroups:         flattenSlice(u.allowedKubeGroups),
 		constants.TraitDBUsers:            flattenSlice(u.allowedDatabaseUsers),
@@ -419,6 +425,11 @@ func (u *UserCommand) Update(ctx context.Context, client *authclient.Client) err
 		windowsLogins := flattenSlice(u.allowedWindowsLogins)
 		user.SetWindowsLogins(windowsLogins)
 		updateMessages["Windows logins"] = windowsLogins
+	}
+	if len(u.allowedLinuxDesktopLogins) > 0 {
+		linuxDesktopLogins := flattenSlice(u.allowedLinuxDesktopLogins)
+		user.SetLinuxDesktopLogins(linuxDesktopLogins)
+		updateMessages["Linux desktop logins"] = linuxDesktopLogins
 	}
 	if len(u.allowedKubeUsers) > 0 {
 		kubeUsers := flattenSlice(u.allowedKubeUsers)


### PR DESCRIPTION
This PR adds support for internal.linux_desktop_logins trait that can be used for Linux desktop RBAC.

<!-- Provide a descriptive entry for the changelog of the next release. -->

<!-- Include manual testing efforts to verify the change. -->
<!-- Detail where the tests where run and what configurations were used. -->
<!-- Include all the test cases which were run to validate the change. -->

## Manual Test Plan
### Test Environment

Local cluster

### Test Cases
- [x] `tctl users add --linux-desktop-logins aaa --roles access,editor  xyz`
- [x] `tctl users update --set-linux-desktop-logins aaa xyz`
- [x] `{{internal.linux_desktop_logins}}` can be used as one of `linux_desktop_logins` 
- [x] Logins from trait are displayed in Linux desktop login selection 
