### PR TITLE
Fix logging in `accessrequest` plugin app

### DIFF
--- a/integrations/access/accessrequest/app.go
+++ b/integrations/access/accessrequest/app.go
@@ -477,8 +477,11 @@ func (a *App) updateMessages(ctx context.Context, reqID string, tag pd.Resolutio
 		}
 
 		// If resolution field is not empty then we already resolved the incident before. In this case we just quit.
-		if existing.AccessRequestData.ResolutionTag != pd.Unresolved {
-			return PluginData{}, trace.AlreadyExists("request is already resolved")
+		if existing.ResolutionTag != pd.Unresolved {
+			return PluginData{},
+				trace.WrapWithMessage(trace.AlreadyExists("request is already resolved"),
+					"cannot change the resolution tag of an already resolved request, existing: %s, event: %s",
+					existing.ResolutionTag, tag)
 		}
 
 		// Mark plugin data as resolved.
@@ -492,11 +495,6 @@ func (a *App) updateMessages(ctx context.Context, reqID string, tag pd.Resolutio
 		return nil
 	}
 	if trace.IsAlreadyExists(err) {
-		if tag != pluginData.ResolutionTag {
-			return trace.WrapWithMessage(err,
-				"cannot change the resolution tag of an already resolved request, existing: %s, event: %s",
-				pluginData.ResolutionTag, tag)
-		}
 		log.DebugContext(ctx, "Request is already resolved, ignoring event")
 		return nil
 	}


### PR DESCRIPTION
The previous error check falsely returns true, because the CAS callback returns an empty `PluginData` (and an empty tag). Only impact is a noisy, incorrect error log; messages still get updated correctly.

Moved the error message into the CAS callback to properly capture the logic, and we preserve the graceful ignore on already resolved events:
<img width="825" height="98" alt="Screenshot 2026-06-12 at 12 45 44 PM" src="https://github.com/user-attachments/assets/d326577d-01bf-4e01-83f5-bb14a1d149ce" />


## Manual Test Plan
### Test Environment

Teleport Cloud. Cloud Slack plugin.

### Test Cases
- [x] Auth logs don't show noisy error log
