### PR TITLE
mask setuid/setgid/sticky bits when transferring files via SFTP

### DIFF
--- a/lib/sshutils/sftp/remote.go
+++ b/lib/sshutils/sftp/remote.go
@@ -157,6 +157,12 @@ func (r *RemoteFS) Readlink(name string) (string, error) {
 	return r.Client.ReadLink(name)
 }
 
+func (r *RemoteFS) Chmod(path string, mode os.FileMode) error {
+	// Prevent setuid/setgid/sticky bits from being set.
+	mode = mode & os.ModePerm
+	return r.Client.Chmod(path, mode)
+}
+
 func (r *RemoteFS) Close() error {
 	var sessionErr error
 	if r.session != nil {

--- a/lib/sshutils/sftp/sftp_test.go
+++ b/lib/sshutils/sftp/sftp_test.go
@@ -20,7 +20,6 @@ package sftp
 
 import (
 	"bytes"
-	"context"
 	cryptorand "crypto/rand"
 	"fmt"
 	"io"
@@ -445,8 +444,7 @@ func TestTransferFiles(t *testing.T) {
 			}
 			tt.req.Destination.Path = filepath.Join(tempDir, tt.req.Destination.Path)
 
-			ctx := context.Background()
-			err := TransferFiles(ctx, tt.req)
+			err := TransferFiles(t.Context(), tt.req)
 			if tt.errCheck == nil {
 				require.NoError(t, err)
 				srcPaths := tt.req.Sources.Paths
@@ -702,6 +700,35 @@ func TestTransferUnexpectedLargerFile(t *testing.T) {
 	dstFileData, err := os.ReadFile(dstFile)
 	require.NoError(t, err)
 	require.Equal(t, "original file data\nextra data\n", string(dstFileData))
+}
+
+func TestTransferModeMask(t *testing.T) {
+	t.Parallel()
+
+	tempDir := t.TempDir()
+	srcFile := filepath.Join(tempDir, "in")
+	require.NoError(t, os.WriteFile(srcFile, []byte("the source"), 0o7755))
+	dstFile := filepath.Join(tempDir, "out")
+	f, err := os.Create(srcFile)
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+
+	req := &FileTransferRequest{
+		Sources: Sources{
+			Paths: []string{srcFile},
+		},
+		Destination: Target{
+			Path: dstFile,
+		},
+		ProgressWriter: io.Discard,
+	}
+
+	err = TransferFiles(t.Context(), req)
+	require.NoError(t, err)
+
+	dstInfo, err := os.Stat(dstFile)
+	require.NoError(t, err)
+	require.Equal(t, os.FileMode(0o755), dstInfo.Mode())
 }
 
 func createFile(t *testing.T, path string) {

--- a/session/reexec/reexecsftp/sftp.go
+++ b/session/reexec/reexecsftp/sftp.go
@@ -528,7 +528,9 @@ func setstatNoFollow(file string, attrFlags sftp.FileAttrFlags, attrs *sftp.File
 		}
 	}
 	if attrFlags.Permissions {
-		if err := f.Chmod(attrs.FileMode()); err != nil {
+		// Prevent setuid/setgid/sticky bits from being set.
+		mode := attrs.FileMode() & os.ModePerm
+		if err := f.Chmod(mode); err != nil {
 			return err
 		}
 	}

--- a/session/reexec/reexecsftp/sftp_test.go
+++ b/session/reexec/reexecsftp/sftp_test.go
@@ -222,7 +222,7 @@ func TestNoFollowFileOperations(t *testing.T) {
 			Acmodtime:   true,
 		}, &sftp.FileStat{
 			Size:  uint64(len(fileData) / 2),
-			Mode:  0o604,
+			Mode:  0o7604, // with setuid/setgid/sticky bits
 			Atime: uint32(updatedTime.Unix()),
 			Mtime: uint32(updatedTime.Unix()),
 		})

--- a/session/sftputils/local.go
+++ b/session/sftputils/local.go
@@ -94,6 +94,8 @@ func (l LocalFS) Mkdir(path string) error {
 }
 
 func (l LocalFS) Chmod(path string, mode os.FileMode) error {
+	// Prevent setuid/setgid/sticky bits from being set.
+	mode = mode & os.ModePerm
 	return os.Chmod(path, mode)
 }
 

--- a/session/sftputils/sftp.go
+++ b/session/sftputils/sftp.go
@@ -253,12 +253,12 @@ func HandleFilecmd(req *sftp.Request, filesys FileSystem) error {
 		if req.Target == "" {
 			return os.ErrInvalid
 		}
-		return filesys.Link(req.Target, req.Filepath)
+		return filesys.Link(req.Filepath, req.Target)
 	case MethodSymlink:
 		if req.Target == "" {
 			return os.ErrInvalid
 		}
-		return filesys.Symlink(req.Target, req.Filepath)
+		return filesys.Symlink(req.Filepath, req.Target)
 	case MethodRemove:
 		fi, err := filesys.Lstat(req.Filepath)
 		if err != nil {

--- a/session/sftputils/sftp_test.go
+++ b/session/sftputils/sftp_test.go
@@ -212,7 +212,7 @@ func TestHandleFilecmd(t *testing.T) {
 		target := filepath.Join(root, "bar.txt")
 		require.NoError(t, os.WriteFile(file, []byte("test"), 0o644))
 
-		assert.NoError(t, clt.Link(target, file))
+		assert.NoError(t, clt.Link(file, target))
 		fi, err := os.Lstat(target)
 		if assert.NoError(t, err) {
 			assert.Zero(t, fi.Mode()&os.ModeSymlink)
@@ -224,7 +224,7 @@ func TestHandleFilecmd(t *testing.T) {
 		file := filepath.Join(root, "foo.txt")
 		target := filepath.Join(root, "bar.txt")
 
-		assert.Error(t, clt.Link(target, file))
+		assert.Error(t, clt.Link(file, target))
 		assert.NoFileExists(t, target)
 	})
 
@@ -241,7 +241,7 @@ func TestHandleFilecmd(t *testing.T) {
 		target := filepath.Join(root, "bar.txt")
 		require.NoError(t, os.WriteFile(file, []byte("test"), 0o644))
 
-		assert.NoError(t, clt.Symlink(target, file))
+		assert.NoError(t, clt.Symlink(file, target))
 		fi, err := os.Lstat(target)
 		assert.NoError(t, err)
 		assert.NotZero(t, fi.Mode()&os.ModeSymlink)


### PR DESCRIPTION
Fixes https://github.com/gravitational/pressure-washing/issues/375.
Also fixed https://github.com/gravitational/pressure-washing/issues/393 while I was here.


<!-- Provide a descriptive entry for the changelog of the next release. -->

Changelog: Prevent setuid/setgid/sticky bits from being set on files uploaded or downloaded via SFTP


<!-- Include manual testing efforts to verify the change. -->
<!-- Detail where the tests where run and what configurations were used. -->
<!-- Include all the test cases which were run to validate the change. -->

## Manual Test Plan
### Test Environment
Local cluster on MacOS
### Test Cases
- [x] Creating a file with 7777 perms is created with 0777 perms
- [x] Creating a hardlink to an existing file creates the link at the correct path
- [x] Creating a symlink to an existing file creates the link at the correct path