### PR TITLE
Add Slack review helm chart config

### DIFF
--- a/docs/pages/includes/helm-reference/zz_generated.access-slack.mdx
+++ b/docs/pages/includes/helm-reference/zz_generated.access-slack.mdx
@@ -102,13 +102,24 @@ containing the Slack Bot OAuth token. The secret name is set via `slack.tokenFro
 
 `review` configures native review of Teleport Access Requests within Slack.
 
-Important: enabling this feature reduces the security of the Teleport cluster.
+Native review is by default disabled.
+
+<Admonition type="danger">
+Enabling this feature reduces the security of the Teleport cluster.
 Access Request reviews submitted through Slack are bound to a Slack identity rather than
 the reviewer's Teleport identity, and bypass Teleport authentication
 (and MFA for admin actions if enabled on cluster).
 As a result, a compromised Slack account can approve requests from Slack and escalate privileges in Teleport.
+</Admonition>
 
-Native review is by default disabled.
+<Admonition type="note">
+There are two identity binding models for Slack reviewers:
+- binding based on Teleport username and Slack email, toggled with `review.allowEmailUsernameMatch`
+- binding based on Teleport trait and Slack user ID, set by `review.slackUserIdTrait`
+
+The binding based on Teleport trait is stronger, but requires a Teleport user to be given a trait with
+their Slack user ID, often coming from the Identity Provider/SSO connector.
+</Admonition>
 
 You can pass the Slack App-level token:
 - via the chart Values by setting `review.appToken`
@@ -156,6 +167,16 @@ Secret before creating the chart release.
 `review.appTokenSecretPath` is the Kubernetes Secret key
 containing the Slack App-level token. The secret name is set via `review.appTokenFromSecret`.
 
+### `review.allowEmailUsernameMatch`
+
+| Type | Default |
+|------|---------|
+| `bool` | `false` |
+
+`review.allowEmailUsernameMatch` allows binding between Teleport username and Slack email.
+This should only be set to true if `review.slackUserIdTrait` is not configured in Teleport.
+We recommend configuring a trait for stronger identity binding. Default is false.
+
 ### `review.slackUserIdTrait`
 
 | Type | Default |
@@ -163,18 +184,8 @@ containing the Slack App-level token. The secret name is set via `review.appToke
 | `string` | `""` |
 
 `review.slackUserIdTrait` is the name of the Teleport trait
-to resolve Slack user to Teleport user.
+to bind Teleport user and Slack user.
 The trait should hold value of Slack user ID.
-
-### `review.allowEmailUsernameMatch`
-
-| Type | Default |
-|------|---------|
-| `bool` | `false` |
-
-`review.allowEmailUsernameMatch` allows exact Slack email to Teleport username match.
-This should only be true if `review.slackUserIdTrait` is not configured in Teleport.
-We recommend configuring a trait for stronger identity binding. Default is false.
 
 ## `roleToRecipients`
 

--- a/docs/pages/includes/helm-reference/zz_generated.access-slack.mdx
+++ b/docs/pages/includes/helm-reference/zz_generated.access-slack.mdx
@@ -64,7 +64,7 @@ the connection to your Teleport cluster. If the secret has the path,
 
 `slack` contains the configuration used by the plugin to authenticate to Slack.
 
-You can pass the Slack token:
+You can pass the Slack Bot OAuth token:
 - via the chart Values by setting `slack.token`
 - via an existing Kubernetes Secret by setting `slack.tokenFromSecret`
 
@@ -74,7 +74,7 @@ You can pass the Slack token:
 |------|---------|
 | `string` | `""` |
 
-`slack.token` is the Slack token used by the plugin to interact
+`slack.token` is the Slack Bot OAuth token used by the plugin to interact
 with Slack. When set, the Chart creates a Kubernetes Secret for you.
 
 This value has no effect if `slack.tokenFromSecret` is set.
@@ -86,7 +86,7 @@ This value has no effect if `slack.tokenFromSecret` is set.
 | `string` | `""` |
 
 `slack.tokenFromSecret` is the name of the Kubernetes Secret
-containing the Slack token. When this value is set, you must create the
+containing the Slack Bot OAuth token. When this value is set, you must create the
 Secret before creating the chart release.
 
 ### `slack.tokenSecretPath`
@@ -96,7 +96,85 @@ Secret before creating the chart release.
 | `string` | `"slackToken"` |
 
 `slack.tokenSecretPath` is the Kubernetes Secret key
-containing the Slack token. The secret name is set via `slack.tokenFromSecret`.
+containing the Slack Bot OAuth token. The secret name is set via `slack.tokenFromSecret`.
+
+## `review`
+
+`review` configures native review of Teleport Access Requests within Slack.
+
+Important: enabling this feature reduces the security of the Teleport cluster.
+Access Request reviews submitted through Slack are bound to a Slack identity rather than
+the reviewer's Teleport identity, and bypass Teleport authentication
+(and MFA for admin actions if enabled on cluster).
+As a result, a compromised Slack account can approve requests from Slack and escalate privileges in Teleport.
+
+Native review is by default disabled.
+
+You can pass the Slack App-level token:
+- via the chart Values by setting `review.appToken`
+- via an existing Kubernetes Secret by setting `review.appTokenFromSecret`
+
+### `review.enabled`
+
+| Type | Default |
+|------|---------|
+| `bool` | `false` |
+
+`review.enabled` toggles native review feature. Default is false.
+
+### `review.appToken`
+
+| Type | Default |
+|------|---------|
+| `string` | `""` |
+
+`review.appToken` is the Slack App-level token used by the plugin
+to receive user interactions from Slack.
+This is different from the Bot OAuth token, and must be set up separately.
+Set this up under "Basic Information" in your Slack app settings.
+
+When set, the Chart creates a Kubernetes Secret for you.
+
+This value has no effect if `review.appTokenFromSecret` is set.
+
+### `review.appTokenFromSecret`
+
+| Type | Default |
+|------|---------|
+| `string` | `""` |
+
+`review.appTokenFromSecret` is the name of the Kubernetes Secret
+containing the Slack App-level token. When this value is set, you must create the
+Secret before creating the chart release.
+
+### `review.appTokenSecretPath`
+
+| Type | Default |
+|------|---------|
+| `string` | `"slackAppToken"` |
+
+`review.appTokenSecretPath` is the Kubernetes Secret key
+containing the Slack App-level token. The secret name is set via `review.appTokenFromSecret`.
+
+### `review.slackUserIdTrait`
+
+| Type | Default |
+|------|---------|
+| `string` | `""` |
+
+`review.slackUserIdTrait` is the name of the Teleport trait
+to resolve Slack user to Teleport user.
+The trait should hold value of Slack user ID.
+
+### `review.allowEmailUsernameMatch`
+
+| Type | Default |
+|------|---------|
+| `bool` | `false` |
+
+`review.allowEmailUsernameMatch` allows exact Slack email to Teleport username match.
+This should only be true if `review.slackUserIdTrait` is not configured in Teleport.
+We recommend configuring a trait for stronger identity binding. Default is false.
 
 ## `roleToRecipients`
 

--- a/examples/chart/access/slack/.lint/review-enabled.yaml
+++ b/examples/chart/access/slack/.lint/review-enabled.yaml
@@ -1,0 +1,5 @@
+review:
+  enabled: true
+  appToken: test-app-token
+  slackUserIdTrait: "slack_uid"
+  allowEmailUsernameMatch: false

--- a/examples/chart/access/slack/templates/configmap.yaml
+++ b/examples/chart/access/slack/templates/configmap.yaml
@@ -18,6 +18,14 @@ data:
     [slack]
     token = "/var/lib/teleport/plugins/slack/slack-token"
 
+    [review]
+    enabled = {{ .Values.review.enabled }}
+    {{- if .Values.review.enabled }}
+    app_token = "/var/lib/teleport/plugins/slack/slack-app-token"
+    slack_user_id_trait = "{{ .Values.review.slackUserIdTrait }}"
+    allow_email_username_match = {{ .Values.review.allowEmailUsernameMatch }}
+    {{- end }}
+
     [role_to_recipients]
     {{- range $role, $recipients := .Values.roleToRecipients }}
     {{ $role | toJson }} = {{ $recipients | toJson }}

--- a/examples/chart/access/slack/templates/deployment.yaml
+++ b/examples/chart/access/slack/templates/deployment.yaml
@@ -50,9 +50,14 @@ spec:
               subPath: teleport-slack.toml
             - name: teleport-identity
               mountPath: /var/lib/teleport/plugins/slack/teleport-identity
-            - name: {{ .Values.secretVolumeName }}
+            - name: {{ .Values.secretVolumeName }}-bot-token
               mountPath: /var/lib/teleport/plugins/slack/slack-token
               subPath: {{ .Values.slack.tokenSecretPath }}
+            {{- if .Values.review.enabled }}
+            - name: {{ .Values.secretVolumeName }}-app-token
+              mountPath: /var/lib/teleport/plugins/slack/slack-app-token
+              subPath: {{ .Values.review.appTokenSecretPath }}
+            {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
@@ -74,7 +79,13 @@ spec:
           secret:
             secretName: {{ include "slack.identitySecretName" . | quote }}
             defaultMode: 0600
-        - name: {{ .Values.secretVolumeName }}
+        - name: {{ .Values.secretVolumeName }}-bot-token
           secret:
             secretName: "{{ coalesce .Values.slack.tokenFromSecret (printf "%s-secret" (include "slack.fullname" .)) }}"
             defaultMode: 0600
+        {{- if .Values.review.enabled }}
+        - name: {{ .Values.secretVolumeName }}-app-token
+          secret:
+            secretName: "{{ coalesce .Values.review.appTokenFromSecret (printf "%s-app-token-secret" (include "slack.fullname" .)) }}"
+            defaultMode: 0600
+        {{- end }}

--- a/examples/chart/access/slack/templates/secret.yaml
+++ b/examples/chart/access/slack/templates/secret.yaml
@@ -11,3 +11,17 @@ metadata:
 data:
   slackToken: {{ .Values.slack.token | b64enc }}
 {{- end }}
+{{- if (and .Values.review.enabled (not .Values.review.appTokenFromSecret)) }}
+---
+apiVersion: v1
+kind: Secret
+type: Opaque
+metadata:
+  name: {{ include "slack.fullname" . }}-app-token-secret
+  {{- with .Values.annotations.secret }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+data:
+  slackAppToken: {{ .Values.review.appToken | b64enc }}
+{{- end }}

--- a/examples/chart/access/slack/tests/__snapshot__/configmap_test.yaml.snap
+++ b/examples/chart/access/slack/tests/__snapshot__/configmap_test.yaml.snap
@@ -11,6 +11,44 @@ should match the snapshot:
         [slack]
         token = "/var/lib/teleport/plugins/slack/slack-token"
 
+        [review]
+        enabled = false
+
+        [role_to_recipients]
+        "*" = ["dev-access-requests"]
+        "dev" = ["dev-access-requests","example-user@example.com"]
+
+        [log]
+        output = "/var/log/teleport-slack.log"
+        severity = "DEBUG"
+    kind: ConfigMap
+    metadata:
+      labels:
+        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: teleport-plugin-slack
+        app.kubernetes.io/version: 19.0.0-prealpha.2
+        helm.sh/chart: teleport-plugin-slack-19.0.0-prealpha.2
+      name: RELEASE-NAME-teleport-plugin-slack
+should match the snapshot (review.enabled is true):
+  1: |
+    apiVersion: v1
+    data:
+      teleport-slack.toml: |
+        [teleport]
+        addr = "teleport.example.com:1234"
+        identity = "/var/lib/teleport/plugins/slack/teleport-identity/auth_id"
+        refresh_identity = true
+
+        [slack]
+        token = "/var/lib/teleport/plugins/slack/slack-token"
+
+        [review]
+        enabled = true
+        app_token = "/var/lib/teleport/plugins/slack/slack-app-token"
+        slack_user_id_trait = "slack_uid"
+        allow_email_username_match = false
+
         [role_to_recipients]
         "*" = ["dev-access-requests"]
         "dev" = ["dev-access-requests","example-user@example.com"]

--- a/examples/chart/access/slack/tests/__snapshot__/deployment_test.yaml.snap
+++ b/examples/chart/access/slack/tests/__snapshot__/deployment_test.yaml.snap
@@ -1,3 +1,74 @@
+should contain app token secret volume if review.enabled is true:
+  1: |
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      labels:
+        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: teleport-plugin-slack
+        app.kubernetes.io/version: 19.0.0-prealpha.2
+        helm.sh/chart: teleport-plugin-slack-19.0.0-prealpha.2
+      name: RELEASE-NAME-teleport-plugin-slack
+    spec:
+      replicas: 1
+      selector:
+        matchLabels:
+          app.kubernetes.io/instance: RELEASE-NAME
+          app.kubernetes.io/name: teleport-plugin-slack
+      template:
+        metadata:
+          labels:
+            app.kubernetes.io/instance: RELEASE-NAME
+            app.kubernetes.io/managed-by: Helm
+            app.kubernetes.io/name: teleport-plugin-slack
+            app.kubernetes.io/version: 19.0.0-prealpha.2
+            helm.sh/chart: teleport-plugin-slack-19.0.0-prealpha.2
+        spec:
+          containers:
+          - command:
+            - /usr/local/bin/teleport-plugin
+            - start
+            - --config
+            - /etc/teleport-slack.toml
+            env:
+            - name: TELEPORT_PLUGIN_FAIL_FAST
+              value: "true"
+            image: public.ecr.aws/gravitational/teleport-plugin-slack:19.0.0-prealpha.2
+            imagePullPolicy: IfNotPresent
+            name: teleport-plugin-slack
+            resources: {}
+            securityContext: {}
+            volumeMounts:
+            - mountPath: /etc/teleport-slack.toml
+              name: config
+              subPath: teleport-slack.toml
+            - mountPath: /var/lib/teleport/plugins/slack/teleport-identity
+              name: teleport-identity
+            - mountPath: /var/lib/teleport/plugins/slack/slack-token
+              name: password-file-bot-token
+              subPath: slackToken
+            - mountPath: /var/lib/teleport/plugins/slack/slack-app-token
+              name: password-file-app-token
+              subPath: slackAppToken
+          securityContext: {}
+          volumes:
+          - configMap:
+              defaultMode: 384
+              name: RELEASE-NAME-teleport-plugin-slack
+            name: config
+          - name: teleport-identity
+            secret:
+              defaultMode: 384
+              secretName: ""
+          - name: password-file-bot-token
+            secret:
+              defaultMode: 384
+              secretName: RELEASE-NAME-teleport-plugin-slack-secret
+          - name: password-file-app-token
+            secret:
+              defaultMode: 384
+              secretName: RELEASE-NAME-teleport-plugin-slack-app-token-secret
 should match the snapshot:
   1: |
     apiVersion: apps/v1
@@ -46,7 +117,7 @@ should match the snapshot:
             - mountPath: /var/lib/teleport/plugins/slack/teleport-identity
               name: teleport-identity
             - mountPath: /var/lib/teleport/plugins/slack/slack-token
-              name: password-file
+              name: password-file-bot-token
               subPath: slackToken
           securityContext: {}
           volumes:
@@ -58,7 +129,7 @@ should match the snapshot:
             secret:
               defaultMode: 384
               secretName: ""
-          - name: password-file
+          - name: password-file-bot-token
             secret:
               defaultMode: 384
               secretName: RELEASE-NAME-teleport-plugin-slack-secret

--- a/examples/chart/access/slack/tests/__snapshot__/secret_test.yaml.snap
+++ b/examples/chart/access/slack/tests/__snapshot__/secret_test.yaml.snap
@@ -1,4 +1,21 @@
-should contain the api key:
+should create app token if review.enabled is true:
+  1: |
+    apiVersion: v1
+    data:
+      slackToken: null
+    kind: Secret
+    metadata:
+      name: RELEASE-NAME-teleport-plugin-slack-secret
+    type: Opaque
+  2: |
+    apiVersion: v1
+    data:
+      slackAppToken: dGVzdC1hcHAtdG9rZW4=
+    kind: Secret
+    metadata:
+      name: RELEASE-NAME-teleport-plugin-slack-app-token-secret
+    type: Opaque
+should create bot oauth token with api key:
   1: |
     apiVersion: v1
     data:

--- a/examples/chart/access/slack/tests/configmap_test.yaml
+++ b/examples/chart/access/slack/tests/configmap_test.yaml
@@ -37,3 +37,24 @@ tests:
           value:
             keyA: valA
             keyB: valB
+
+  - it: should match the snapshot (review.enabled is true)
+    values:
+      - ../.lint/review-enabled.yaml
+    set:
+      teleport:
+        address: teleport.example.com:1234
+      slack:
+        token: test-api-key
+      roleToRecipients:
+        dev:
+          - dev-access-requests
+          - example-user@example.com
+        "*":
+          - dev-access-requests
+      log:
+        output: /var/log/teleport-slack.log
+        severity: DEBUG
+    asserts:
+      - matchSnapshot: {}
+

--- a/examples/chart/access/slack/tests/deployment_test.yaml
+++ b/examples/chart/access/slack/tests/deployment_test.yaml
@@ -67,3 +67,22 @@ tests:
           value:
             keyA: valA'
             keyC: valC
+
+  - it: should contain app token secret volume if review.enabled is true
+    values:
+      - ../.lint/review-enabled.yaml
+    asserts:
+      - matchSnapshot: {}
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: password-file-app-token
+            secret:
+              secretName: RELEASE-NAME-teleport-plugin-slack-app-token-secret
+              defaultMode: 0600
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: password-file-app-token
+            mountPath: /var/lib/teleport/plugins/slack/slack-app-token
+            subPath: slackAppToken

--- a/examples/chart/access/slack/tests/secret_test.yaml
+++ b/examples/chart/access/slack/tests/secret_test.yaml
@@ -2,14 +2,14 @@ suite: Test secret
 templates:
   - secret.yaml
 tests:
-  - it: should contain the api key
+  - it: should create bot oauth token with api key
     set:
       slack:
         token: myslacktoken
     asserts:
       - matchSnapshot: {}
 
-  - it: should not exist when using external secret
+  - it: should not create bot oauth token when using external secret
     set:
       slack:
         tokenFromSecret: my-slack-secret
@@ -23,6 +23,50 @@ tests:
           path: metadata.annotations
 
   - it: should contain annotations when defined
+    set:
+      annotations:
+        secret:
+          keyA: valA
+          keyB: valB
+    asserts:
+      - equal:
+          path: metadata.annotations
+          value:
+            keyA: valA
+            keyB: valB
+
+  - it: should create app token if review.enabled is true
+    values:
+      - ../.lint/review-enabled.yaml
+    asserts:
+      - matchSnapshot: {}
+      - hasDocuments:
+          count: 2
+      - containsDocument:
+          kind: Secret
+          apiVersion: v1
+          name: RELEASE-NAME-teleport-plugin-slack-app-token-secret
+
+  - it: should not create app token if review.enabled is true and using external secret
+    values:
+      - ../.lint/review-enabled.yaml
+    set:
+      review:
+        appTokenFromSecret: my-slack-app-token-secret
+    asserts:
+      - hasDocuments:
+          count: 1
+
+  - it: should not set annotations on app token when not defined
+    values:
+      - ../.lint/review-enabled.yaml
+    asserts:
+      - isNull:
+          path: metadata.annotations
+
+  - it: should set annotations on app token when defined
+    values:
+      - ../.lint/review-enabled.yaml
     set:
       annotations:
         secret:

--- a/examples/chart/access/slack/values.yaml
+++ b/examples/chart/access/slack/values.yaml
@@ -63,13 +63,24 @@ slack:
 
 # review -- configures native review of Teleport Access Requests within Slack.
 #
-# Important: enabling this feature reduces the security of the Teleport cluster.
+# Native review is by default disabled.
+#
+# <Admonition type="danger">
+# Enabling this feature reduces the security of the Teleport cluster.
 # Access Request reviews submitted through Slack are bound to a Slack identity rather than
 # the reviewer's Teleport identity, and bypass Teleport authentication
 # (and MFA for admin actions if enabled on cluster).
 # As a result, a compromised Slack account can approve requests from Slack and escalate privileges in Teleport.
+# </Admonition>
 #
-# Native review is by default disabled.
+# <Admonition type="note">
+# There are two identity binding models for Slack reviewers:
+# - binding based on Teleport username and Slack email, toggled with `review.allowEmailUsernameMatch`
+# - binding based on Teleport trait and Slack user ID, set by `review.slackUserIdTrait`
+#
+# The binding based on Teleport trait is stronger, but requires a Teleport user to be given a trait with
+# their Slack user ID, often coming from the Identity Provider/SSO connector.
+# </Admonition>
 #
 # You can pass the Slack App-level token:
 # - via the chart Values by setting `review.appToken`
@@ -93,14 +104,14 @@ review:
   # review.appTokenSecretPath(string) -- is the Kubernetes Secret key
   # containing the Slack App-level token. The secret name is set via `review.appTokenFromSecret`.
   appTokenSecretPath: "slackAppToken"
-  # review.slackUserIdTrait(string) -- is the name of the Teleport trait
-  # to resolve Slack user to Teleport user.
-  # The trait should hold value of Slack user ID.
-  slackUserIdTrait: ""
-  # review.allowEmailUsernameMatch(bool) -- allows exact Slack email to Teleport username match.
-  # This should only be true if `review.slackUserIdTrait` is not configured in Teleport.
+  # review.allowEmailUsernameMatch(bool) -- allows binding between Teleport username and Slack email.
+  # This should only be set to true if `review.slackUserIdTrait` is not configured in Teleport.
   # We recommend configuring a trait for stronger identity binding. Default is false.
   allowEmailUsernameMatch: false
+  # review.slackUserIdTrait(string) -- is the name of the Teleport trait
+  # to bind Teleport user and Slack user.
+  # The trait should hold value of Slack user ID.
+  slackUserIdTrait: ""
 
 # roleToRecipients(object) -- is mapping the requested role name to a list of
 # recipients the plugin will notify.

--- a/examples/chart/access/slack/values.yaml
+++ b/examples/chart/access/slack/values.yaml
@@ -44,22 +44,63 @@ teleport:
 
 # slack -- contains the configuration used by the plugin to authenticate to Slack.
 #
-# You can pass the Slack token:
+# You can pass the Slack Bot OAuth token:
 # - via the chart Values by setting `slack.token`
 # - via an existing Kubernetes Secret by setting `slack.tokenFromSecret`
 slack:
-  # slack.token(string) -- is the Slack token used by the plugin to interact
+  # slack.token(string) -- is the Slack Bot OAuth token used by the plugin to interact
   # with Slack. When set, the Chart creates a Kubernetes Secret for you.
   #
   # This value has no effect if `slack.tokenFromSecret` is set.
   token: ""
   # slack.tokenFromSecret(string) -- is the name of the Kubernetes Secret
-  # containing the Slack token. When this value is set, you must create the
+  # containing the Slack Bot OAuth token. When this value is set, you must create the
   # Secret before creating the chart release.
   tokenFromSecret: ""
   # slack.tokenSecretPath(string) -- is the Kubernetes Secret key
-  # containing the Slack token. The secret name is set via `slack.tokenFromSecret`.
+  # containing the Slack Bot OAuth token. The secret name is set via `slack.tokenFromSecret`.
   tokenSecretPath: "slackToken"
+
+# review -- configures native review of Teleport Access Requests within Slack.
+#
+# Important: enabling this feature reduces the security of the Teleport cluster.
+# Access Request reviews submitted through Slack are bound to a Slack identity rather than
+# the reviewer's Teleport identity, and bypass Teleport authentication
+# (and MFA for admin actions if enabled on cluster).
+# As a result, a compromised Slack account can approve requests from Slack and escalate privileges in Teleport.
+#
+# Native review is by default disabled.
+#
+# You can pass the Slack App-level token:
+# - via the chart Values by setting `review.appToken`
+# - via an existing Kubernetes Secret by setting `review.appTokenFromSecret`
+review:
+  # review.enabled(bool) -- toggles native review feature. Default is false.
+  enabled: false
+  # review.appToken(string) -- is the Slack App-level token used by the plugin
+  # to receive user interactions from Slack.
+  # This is different from the Bot OAuth token, and must be set up separately.
+  # Set this up under "Basic Information" in your Slack app settings.
+  #
+  # When set, the Chart creates a Kubernetes Secret for you.
+  #
+  # This value has no effect if `review.appTokenFromSecret` is set.
+  appToken: ""
+  # review.appTokenFromSecret(string) -- is the name of the Kubernetes Secret
+  # containing the Slack App-level token. When this value is set, you must create the
+  # Secret before creating the chart release.
+  appTokenFromSecret: ""
+  # review.appTokenSecretPath(string) -- is the Kubernetes Secret key
+  # containing the Slack App-level token. The secret name is set via `review.appTokenFromSecret`.
+  appTokenSecretPath: "slackAppToken"
+  # review.slackUserIdTrait(string) -- is the name of the Teleport trait
+  # to resolve Slack user to Teleport user.
+  # The trait should hold value of Slack user ID.
+  slackUserIdTrait: ""
+  # review.allowEmailUsernameMatch(bool) -- allows exact Slack email to Teleport username match.
+  # This should only be true if `review.slackUserIdTrait` is not configured in Teleport.
+  # We recommend configuring a trait for stronger identity binding. Default is false.
+  allowEmailUsernameMatch: false
 
 # roleToRecipients(object) -- is mapping the requested role name to a list of
 # recipients the plugin will notify.

--- a/integrations/access/slack/cmd/teleport-slack/example_config.toml
+++ b/integrations/access/slack/cmd/teleport-slack/example_config.toml
@@ -29,14 +29,23 @@ token = "xoxb-11xx"
 
 [review]
 # Allows for native review of Teleport Access Requests within Slack.
+#
 # Important: enabling this feature reduces the security of the Teleport cluster.
 # Access Request reviews submitted through Slack are bound to a Slack identity rather than
 # the reviewer's Teleport identity, and bypass Teleport authentication
 # (and MFA for admin actions if enabled on cluster).
 # As a result, a compromised Slack account can approve requests from Slack and escalate privileges in Teleport.
 #
+# There are two identity binding models for Slack reviewers:
+# - binding based on Teleport username and Slack email, toggled with `allow_email_username_match`
+# - binding based on Teleport trait and Slack user ID, set by `slack_user_id_trait`
+#
+# The binding based on Teleport trait is stronger, but requires a Teleport user to be given a trait with
+# their Slack user ID, often coming from the Identity Provider/SSO connector.
+
 # Toggles native review feature. Default is false.
 enabled = false
+
 # Slack App-level token.
 # Provides the plugin permissions to receive user interactions from Slack.
 # This is different from the Bot OAuth token, and must be set up separately.
@@ -45,15 +54,15 @@ enabled = false
 # You can also use an absolute path to a token file, e.g.,
 # "/var/lib/teleport/appToken"
 # app_token = "xapp-..."
-#
-# Name of the Teleport trait to resolve Slack user to Teleport user.
-# The trait should hold value of Slack user ID.
-# slack_user_id_trait = "slack_uid"
-#
-# Allows exact Slack email to Teleport username match.
-# This should only be true if `slack_user_id_trait` is not configured in Teleport.
+
+# Allows binding between Teleport username and Slack email.
+# This should only be set to true if `slack_user_id_trait` is not configured in Teleport.
 # We recommend configuring a trait for stronger identity binding. Default is false.
 # allow_email_username_match = false
+
+# Name of the Teleport trait to bind Teleport user and Slack user.
+# The trait should hold value of Slack user ID.
+# slack_user_id_trait = "slack_uid"
 
 [role_to_recipients]
 # Map roles to recipients.

--- a/integrations/access/slack/cmd/teleport-slack/example_config.toml
+++ b/integrations/access/slack/cmd/teleport-slack/example_config.toml
@@ -31,14 +31,15 @@ token = "xoxb-11xx"
 # Allows for native review of Teleport Access Requests within Slack.
 # Important: enabling this feature reduces the security of the Teleport cluster.
 # Access Request reviews submitted through Slack are bound to a Slack identity rather than
-# the reviewer's Teleport identity, and bypass Teleport authentication (and MFA for admin actions if enabled on the cluster).
+# the reviewer's Teleport identity, and bypass Teleport authentication
+# (and MFA for admin actions if enabled on cluster).
 # As a result, a compromised Slack account can approve requests from Slack and escalate privileges in Teleport.
 #
 # Toggles native review feature. Default is false.
 enabled = false
 # Slack App-level token.
+# Provides the plugin permissions to receive user interactions from Slack.
 # This is different from the Bot OAuth token, and must be set up separately.
-# The App-level token provides the plugin permissions to receive user interactions from Slack.
 # Set this up under "Basic Information" in your Slack app settings.
 #
 # You can also use an absolute path to a token file, e.g.,


### PR DESCRIPTION
Adds the Helm chart config for Slack native review feature.

Important note: review config will be enforced, particularly "review.enabled" checks, in final PR. Also saved changelog for final PR.

## Manual Test Plan
### Test Environment

Teleport Cloud. Local Helm chart and local Slack plugin image.

### Test Cases
- [x] When `review.enabled` is true:
	- [x] Kubernetes secret is created `teleport-plugin-slack-app-token-secret`
	- [x] Successfully deploy Slack plugin chart to Teleport cluster
- [x] When `review.enabled` is false
	- [x] Original behavior is preserved, no app-token secret created
