### PR TITLE
Use klauspost/compress/gzip for events session recording writer

### DIFF
--- a/lib/events/sessionlog.go
+++ b/lib/events/sessionlog.go
@@ -19,31 +19,31 @@
 package events
 
 import (
-	"compress/gzip"
 	"io"
 	"sync"
 
 	"github.com/gravitational/trace"
-	kgzip "github.com/klauspost/compress/gzip"
+	"github.com/klauspost/compress/gzip"
 )
 
 // gzipWriter wraps file, on close close both gzip writer and file.
 //
-// The writer uses github.com/klauspost/compress/gzip rather than the standard
-// library's compress/gzip. At gzip.BestSpeed the stdlib flate compressor embeds
-// two fixed arrays by value (hashHead [1<<17]uint32 and hashPrev [1<<15]uint32,
-// ~640KB total) that the BestSpeed code path never uses. A writer is pooled and
-// held for the lifetime of each open recording slice, so that overhead is
-// retained per concurrent slice. The klauspost encoder only allocates those
-// arrays for levels 7-9, so at BestSpeed each writer retains ~380KB less (see
-// BenchmarkNewGzipWriter) while emitting standard gzip that the reader below
-// decodes unchanged.
+// Session recording uses github.com/klauspost/compress/gzip (imported here as
+// gzip) for both the writer and the reader instead of the standard library's
+// compress/gzip. Both emit and read standard gzip, so the on-disk recording
+// format is unchanged and recordings written by older (stdlib) versions still
+// decode.
 //
-// The underlying stdlib behavior is tracked upstream in
-// https://github.com/golang/go/issues/32371; if it is fixed we can reevaluate
-// whether the standard library compressor is sufficient here.
+// Writer: at gzip.BestSpeed the stdlib flate compressor embeds two fixed arrays
+// by value (hashHead [1<<17]uint32 and hashPrev [1<<15]uint32, ~640KB total)
+// that the BestSpeed code path never uses. A writer is pooled and held for the
+// lifetime of each open recording slice, so a process with many concurrent
+// recordings retains that unused memory per recording. klauspost only allocates
+// those arrays for levels 7-9 and retains ~380KB less per writer (see
+// BenchmarkNewGzipWriter). The stdlib behavior is tracked upstream in
+// https://github.com/golang/go/issues/32371.
 type gzipWriter struct {
-	*kgzip.Writer
+	*gzip.Writer
 	inner io.WriteCloser
 }
 
@@ -69,13 +69,13 @@ func (f *gzipWriter) Close() error {
 // internal buffers to avoid too many objects on the heap
 var writerPool = sync.Pool{
 	New: func() any {
-		w, _ := kgzip.NewWriterLevel(io.Discard, kgzip.BestSpeed)
+		w, _ := gzip.NewWriterLevel(io.Discard, gzip.BestSpeed)
 		return w
 	},
 }
 
 func newGzipWriter(writer io.WriteCloser) *gzipWriter {
-	g := writerPool.Get().(*kgzip.Writer)
+	g := writerPool.Get().(*gzip.Writer)
 	g.Reset(writer)
 	return &gzipWriter{
 		Writer: g,
@@ -103,6 +103,10 @@ func (f *gzipReader) Close() error {
 	return trace.NewAggregate(errors...)
 }
 
+// newGzipReader creates a reader for session recordings. Like the writer it uses
+// klauspost/compress/gzip: it reads standard gzip (so recordings written by older
+// stdlib-based versions decode unchanged) and is faster with fewer allocations
+// than the stdlib reader (see BenchmarkGzipReader).
 func newGzipReader(reader io.ReadCloser) (*gzipReader, error) {
 	gzReader, err := gzip.NewReader(reader)
 	if err != nil {

--- a/lib/events/sessionlog.go
+++ b/lib/events/sessionlog.go
@@ -24,11 +24,26 @@ import (
 	"sync"
 
 	"github.com/gravitational/trace"
+	kgzip "github.com/klauspost/compress/gzip"
 )
 
-// gzipWriter wraps file, on close close both gzip writer and file
+// gzipWriter wraps file, on close close both gzip writer and file.
+//
+// The writer uses github.com/klauspost/compress/gzip rather than the standard
+// library's compress/gzip. At gzip.BestSpeed the stdlib flate compressor embeds
+// two fixed arrays by value (hashHead [1<<17]uint32 and hashPrev [1<<15]uint32,
+// ~640KB total) that the BestSpeed code path never uses. A writer is pooled and
+// held for the lifetime of each open recording slice, so that overhead is
+// retained per concurrent slice. The klauspost encoder only allocates those
+// arrays for levels 7-9, so at BestSpeed each writer retains ~380KB less (see
+// BenchmarkNewGzipWriter) while emitting standard gzip that the reader below
+// decodes unchanged.
+//
+// The underlying stdlib behavior is tracked upstream in
+// https://github.com/golang/go/issues/32371; if it is fixed we can reevaluate
+// whether the standard library compressor is sufficient here.
 type gzipWriter struct {
-	*gzip.Writer
+	*kgzip.Writer
 	inner io.WriteCloser
 }
 
@@ -54,13 +69,13 @@ func (f *gzipWriter) Close() error {
 // internal buffers to avoid too many objects on the heap
 var writerPool = sync.Pool{
 	New: func() any {
-		w, _ := gzip.NewWriterLevel(io.Discard, gzip.BestSpeed)
+		w, _ := kgzip.NewWriterLevel(io.Discard, kgzip.BestSpeed)
 		return w
 	},
 }
 
 func newGzipWriter(writer io.WriteCloser) *gzipWriter {
-	g := writerPool.Get().(*gzip.Writer)
+	g := writerPool.Get().(*kgzip.Writer)
 	g.Reset(writer)
 	return &gzipWriter{
 		Writer: g,

--- a/lib/events/sessionlog_test.go
+++ b/lib/events/sessionlog_test.go
@@ -1,6 +1,6 @@
 /*
  * Teleport
- * Copyright (C) 2025  Gravitational, Inc.
+ * Copyright (C) 2026  Gravitational, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/lib/events/sessionlog_test.go
+++ b/lib/events/sessionlog_test.go
@@ -1,0 +1,129 @@
+/*
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package events
+
+import (
+	"bytes"
+	stdgzip "compress/gzip"
+	"io"
+	"testing"
+
+	kgzip "github.com/klauspost/compress/gzip"
+	"github.com/stretchr/testify/require"
+)
+
+// nopWriteCloser adapts a bytes.Buffer to io.WriteCloser for the gzipWriter.
+type nopWriteCloser struct{ io.Writer }
+
+func (nopWriteCloser) Close() error { return nil }
+
+// TestGzipWriterRoundTrip ensures recordings written by the (klauspost) writer
+// are still readable by the stdlib-based reader, including the multistream
+// padding workaround. This guards the compress/gzip -> klauspost writer swap.
+func TestGzipWriterRoundTrip(t *testing.T) {
+	payload := bytes.Repeat([]byte("session recording chunk payload 0123456789\n"), 4096)
+
+	var compressed bytes.Buffer
+	w := newGzipWriter(nopWriteCloser{&compressed})
+	_, err := w.Write(payload)
+	require.NoError(t, err)
+	require.NoError(t, w.Close())
+
+	// The reader path (stdlib gzip + Multistream(false)) must decode it.
+	r, err := newGzipReader(io.NopCloser(bytes.NewReader(compressed.Bytes())))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = r.Close() })
+
+	got, err := io.ReadAll(r)
+	require.NoError(t, err)
+	require.Equal(t, payload, got, "decoded recording must match original")
+	require.Less(t, compressed.Len(), len(payload), "payload should actually be compressed")
+}
+
+// TestGzipReaderToleratesTrailingPadding guards the Teleport-specific reason the
+// reader disables multistream: older versions sometimes wrote stray padding bytes
+// after the gzip member, and the reader must still decode the recording instead of
+// failing when it encounters them. This is our contract, not the gzip libraries'.
+func TestGzipReaderToleratesTrailingPadding(t *testing.T) {
+	payload := []byte("session recording payload")
+
+	var buf bytes.Buffer
+	w := newGzipWriter(nopWriteCloser{&buf})
+	_, err := w.Write(payload)
+	require.NoError(t, err)
+	require.NoError(t, w.Close())
+
+	// Simulate the stray bytes appended after the gzip member by old versions.
+	buf.Write([]byte{0, 0, 0, 0})
+
+	r, err := newGzipReader(io.NopCloser(bytes.NewReader(buf.Bytes())))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = r.Close() })
+
+	got, err := io.ReadAll(r)
+	require.NoError(t, err, "reader must not choke on trailing padding")
+	require.Equal(t, payload, got)
+}
+
+// TestGzipWriterPoolReuse exercises the Get/Reset/Put pool cycle that the
+// recording hot path relies on, ensuring a recycled writer still round-trips.
+func TestGzipWriterPoolReuse(t *testing.T) {
+	for i := range 3 {
+		var buf bytes.Buffer
+		w := newGzipWriter(nopWriteCloser{&buf})
+		msg := []byte("reuse iteration payload")
+		_, err := w.Write(msg)
+		require.NoError(t, err)
+		require.NoError(t, w.Close()) // returns the writer to writerPool
+
+		r, err := newGzipReader(io.NopCloser(bytes.NewReader(buf.Bytes())))
+		require.NoError(t, err)
+		got, err := io.ReadAll(r)
+		require.NoError(t, err, "iteration %d", i)
+		require.NoError(t, r.Close())
+		require.Equal(t, msg, got)
+	}
+}
+
+// BenchmarkNewGzipWriter compares per-writer allocation between the klauspost
+// and stdlib gzip writers at BestSpeed. The Stdlib sub-benchmark is the baseline
+// for comparison.
+// Run: go test -run=^$ -bench=BenchmarkNewGzipWriter -benchmem ./lib/events/
+func BenchmarkNewGzipWriter(b *testing.B) {
+	// Write+Flush forces the underlying flate compressor to materialize, since
+	// both libraries allocate it lazily on first write rather than at
+	// construction. This is what the real recording path does.
+	payload := []byte("session recording event payload")
+	b.Run("Klauspost", func(b *testing.B) {
+		b.ReportAllocs()
+		for b.Loop() {
+			w, _ := kgzip.NewWriterLevel(io.Discard, kgzip.BestSpeed)
+			_, _ = w.Write(payload)
+			_ = w.Flush()
+		}
+	})
+	b.Run("Stdlib", func(b *testing.B) {
+		b.ReportAllocs()
+		for b.Loop() {
+			w, _ := stdgzip.NewWriterLevel(io.Discard, stdgzip.BestSpeed)
+			_, _ = w.Write(payload)
+			_ = w.Flush()
+		}
+	})
+}

--- a/lib/events/sessionlog_test.go
+++ b/lib/events/sessionlog_test.go
@@ -21,6 +21,7 @@ package events
 import (
 	"bytes"
 	stdgzip "compress/gzip"
+	"fmt"
 	"io"
 	"testing"
 
@@ -28,82 +29,97 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// These tests lock in Teleport's contract around the gzip library (the wrapper
+// plumbing, backward compatibility with existing recordings, and the
+// Multistream(false) padding workaround). They intentionally do not sweep
+// payload shapes or otherwise re-verify that gzip compresses correctly — that is
+// the gzip library's responsibility, exercised by its own tests.
+
 // nopWriteCloser adapts a bytes.Buffer to io.WriteCloser for the gzipWriter.
 type nopWriteCloser struct{ io.Writer }
 
 func (nopWriteCloser) Close() error { return nil }
 
-// TestGzipWriterRoundTrip ensures recordings written by the (klauspost) writer
-// are still readable by the stdlib-based reader, including the multistream
-// padding workaround. This guards the compress/gzip -> klauspost writer swap.
-func TestGzipWriterRoundTrip(t *testing.T) {
-	payload := bytes.Repeat([]byte("session recording chunk payload 0123456789\n"), 4096)
-
-	var compressed bytes.Buffer
-	w := newGzipWriter(nopWriteCloser{&compressed})
-	_, err := w.Write(payload)
-	require.NoError(t, err)
-	require.NoError(t, w.Close())
-
-	// The reader path (stdlib gzip + Multistream(false)) must decode it.
-	r, err := newGzipReader(io.NopCloser(bytes.NewReader(compressed.Bytes())))
-	require.NoError(t, err)
-	t.Cleanup(func() { _ = r.Close() })
-
-	got, err := io.ReadAll(r)
-	require.NoError(t, err)
-	require.Equal(t, payload, got, "decoded recording must match original")
-	require.Less(t, compressed.Len(), len(payload), "payload should actually be compressed")
-}
-
-// TestGzipReaderToleratesTrailingPadding guards the Teleport-specific reason the
-// reader disables multistream: older versions sometimes wrote stray padding bytes
-// after the gzip member, and the reader must still decode the recording instead of
-// failing when it encounters them. This is our contract, not the gzip libraries'.
-func TestGzipReaderToleratesTrailingPadding(t *testing.T) {
-	payload := []byte("session recording payload")
-
+// compressGzip compresses payload into a standard gzip member. kind selects the
+// implementation: "klauspost" exercises the production writer (newGzipWriter);
+// "stdlib" simulates a recording written by an older Teleport version.
+func compressGzip(t *testing.T, kind string, payload []byte) []byte {
+	t.Helper()
 	var buf bytes.Buffer
-	w := newGzipWriter(nopWriteCloser{&buf})
-	_, err := w.Write(payload)
-	require.NoError(t, err)
-	require.NoError(t, w.Close())
-
-	// Simulate the stray bytes appended after the gzip member by old versions.
-	buf.Write([]byte{0, 0, 0, 0})
-
-	r, err := newGzipReader(io.NopCloser(bytes.NewReader(buf.Bytes())))
-	require.NoError(t, err)
-	t.Cleanup(func() { _ = r.Close() })
-
-	got, err := io.ReadAll(r)
-	require.NoError(t, err, "reader must not choke on trailing padding")
-	require.Equal(t, payload, got)
+	switch kind {
+	case "klauspost":
+		w := newGzipWriter(nopWriteCloser{&buf})
+		_, err := w.Write(payload)
+		require.NoError(t, err)
+		require.NoError(t, w.Close())
+	case "stdlib":
+		w, err := stdgzip.NewWriterLevel(&buf, stdgzip.BestSpeed)
+		require.NoError(t, err)
+		_, err = w.Write(payload)
+		require.NoError(t, err)
+		require.NoError(t, w.Close())
+	default:
+		t.Fatalf("unknown writer kind %q", kind)
+	}
+	return buf.Bytes()
 }
 
-// TestGzipWriterPoolReuse exercises the Get/Reset/Put pool cycle that the
-// recording hot path relies on, ensuring a recycled writer still round-trips.
-func TestGzipWriterPoolReuse(t *testing.T) {
-	for i := range 3 {
-		var buf bytes.Buffer
-		w := newGzipWriter(nopWriteCloser{&buf})
-		msg := []byte("reuse iteration payload")
-		_, err := w.Write(msg)
-		require.NoError(t, err)
-		require.NoError(t, w.Close()) // returns the writer to writerPool
+// decodeGzip decodes data through the production reader path (newGzipReader).
+func decodeGzip(t *testing.T, data []byte) ([]byte, error) {
+	t.Helper()
+	r, err := newGzipReader(io.NopCloser(bytes.NewReader(data)))
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = r.Close() }()
+	return io.ReadAll(r)
+}
 
-		r, err := newGzipReader(io.NopCloser(bytes.NewReader(buf.Bytes())))
-		require.NoError(t, err)
-		got, err := io.ReadAll(r)
+// TestGzipWriterReaderRoundTrip checks the Teleport plumbing around the gzip
+// library: a recording written by the production writer decodes through the
+// production reader, and a writer survives the writerPool Get/Reset/Put cycle
+// (the loop, since each Close returns the writer to the pool).
+func TestGzipWriterReaderRoundTrip(t *testing.T) {
+	payload := bytes.Repeat([]byte("session recording event 0123456789\n"), 4096)
+	for i := range 3 {
+		data := compressGzip(t, "klauspost", payload)
+		got, err := decodeGzip(t, data)
 		require.NoError(t, err, "iteration %d", i)
-		require.NoError(t, r.Close())
-		require.Equal(t, msg, got)
+		require.Equal(t, payload, got)
 	}
 }
 
-// BenchmarkNewGzipWriter compares per-writer allocation between the klauspost
-// and stdlib gzip writers at BestSpeed. The Stdlib sub-benchmark is the baseline
-// for comparison.
+// TestGzipReaderReadsLegacyRecordings is the backward-compatibility guard for the
+// gzip swap: recordings written by older Teleport versions (standard library
+// compress/gzip) must still decode through the current reader.
+func TestGzipReaderReadsLegacyRecordings(t *testing.T) {
+	payload := bytes.Repeat([]byte("session recording event 0123456789\n"), 4096)
+	data := compressGzip(t, "stdlib", payload)
+	got, err := decodeGzip(t, data)
+	require.NoError(t, err)
+	require.Equal(t, payload, got)
+}
+
+// TestGzipReaderToleratesTrailingPadding guards the one reader behavior Teleport
+// configures itself, Multistream(false): older versions sometimes wrote stray
+// bytes after the gzip member, and the reader must decode the recording rather
+// than fail on them. The stdlib case is the historically relevant one (the bug
+// shipped in stdlib-writer versions); the klauspost case guards new recordings.
+func TestGzipReaderToleratesTrailingPadding(t *testing.T) {
+	payload := []byte("session recording payload")
+	for _, kind := range []string{"klauspost", "stdlib"} {
+		t.Run(kind, func(t *testing.T) {
+			data := compressGzip(t, kind, payload)
+			padded := append(bytes.Clone(data), 0, 0, 0, 0) // stray bytes after the member
+			got, err := decodeGzip(t, padded)
+			require.NoError(t, err, "reader must tolerate trailing padding")
+			require.Equal(t, payload, got)
+		})
+	}
+}
+
+// BenchmarkNewGzipWriter compares per-writer allocation between the klauspost and
+// stdlib gzip writers at BestSpeed (the memory justification for the writer).
 // Run: go test -run=^$ -bench=BenchmarkNewGzipWriter -benchmem ./lib/events/
 func BenchmarkNewGzipWriter(b *testing.B) {
 	// Write+Flush forces the underlying flate compressor to materialize, since
@@ -124,6 +140,46 @@ func BenchmarkNewGzipWriter(b *testing.B) {
 			w, _ := stdgzip.NewWriterLevel(io.Discard, stdgzip.BestSpeed)
 			_, _ = w.Write(payload)
 			_ = w.Flush()
+		}
+	})
+}
+
+// BenchmarkGzipReader compares decode time and allocations between the klauspost
+// and stdlib gzip readers (the performance justification for the reader).
+// Run: go test -run=^$ -bench=BenchmarkGzipReader -benchmem ./lib/events/
+func BenchmarkGzipReader(b *testing.B) {
+	// A few MB of varied, recording-like text. Varied (not a single repeated
+	// string, which compresses unrealistically well) so decode does real work
+	// and the stdlib reader's per-block allocation cost shows.
+	var raw bytes.Buffer
+	for i := 0; raw.Len() < 2<<20; i++ {
+		fmt.Fprintf(&raw, "2026-06-16T12:%02d:%02d user=admin action=exec cmd=\"ls -la /var/log/app-%d\" status=ok bytes=%d\n", i%60, (i*7)%60, i, i*131)
+	}
+	var gz bytes.Buffer
+	w, _ := stdgzip.NewWriterLevel(&gz, stdgzip.BestSpeed)
+	_, _ = w.Write(raw.Bytes())
+	_ = w.Close()
+	data := gz.Bytes()
+
+	uncompressed := int64(raw.Len()) // for MB/s decode throughput (bytes produced per op)
+	b.Run("Klauspost", func(b *testing.B) {
+		b.ReportAllocs()
+		b.SetBytes(uncompressed)
+		for b.Loop() {
+			r, _ := kgzip.NewReader(bytes.NewReader(data))
+			r.Multistream(false)
+			_, _ = io.Copy(io.Discard, r)
+			_ = r.Close()
+		}
+	})
+	b.Run("Stdlib", func(b *testing.B) {
+		b.ReportAllocs()
+		b.SetBytes(uncompressed)
+		for b.Loop() {
+			r, _ := stdgzip.NewReader(bytes.NewReader(data))
+			r.Multistream(false)
+			_, _ = io.Copy(io.Discard, r)
+			_ = r.Close()
 		}
 	})
 }


### PR DESCRIPTION
## What

Switch session recording in `lib/events/sessionlog.go` from the standard library's `compress/gzip` to `github.com/klauspost/compress/gzip` (already a direct dependency), for both the writer and the reader. Both emit and read standard gzip, so the on-disk format is unchanged and existing recordings still decode. The writer change reduces memory; the reader change speeds up decode.

## Why

Session recording compresses every slice with a pooled `gzip.Writer` created at `gzip.BestSpeed`. At that level the stdlib `compress/flate` compressor embeds two fixed arrays **by value** — `hashHead [1<<17]uint32` (512KB) and `hashPrev [1<<15]uint32` (128KB), ~640KB total — that the `BestSpeed`/`deflateFast` code path never reads, writes, or even clears on reset.

One writer is checked out of the pool for the lifetime of each open recording slice, so a busy agent holds one per concurrently-open recording. Multiplied across many simultaneous sessions, these writers become the single largest consumer of agent heap: in a profile from a customer's app agents, gzip/flate writer state was ~62% of the ~2 GB live heap.

`klauspost/compress` allocates the large hash arrays only at levels 7-9; at `BestSpeed` it uses a smaller fast encoder, so each writer drops from ~1.2 MB to ~0.8 MB (**~390 KB saved**). At ~1,700 concurrent writers observed in the customer profile that is ~660 MB/agent — roughly a third off total agent heap (~2.0 GB down to ~1.3 GB).

This affects all session recording that flows through the shared writer pool (SSH, Kubernetes, database, desktop, app), but is particularly pressing for any service that may have a high number of concurrent sessions (e.g. app access).

The reader is swapped to the same library too. There it is a decode-speed win rather than a memory one (a reader retains ~40 KB and is not held per recording). It reads standard gzip, so recordings written by older stdlib-based versions decode unchanged.

### Measurements

Writer — `BenchmarkNewGzipWriter` (BestSpeed, write+flush):

| | bytes/op | allocs/op | ns/op |
|---|---|---|---|
| stdlib `compress/gzip` | ~1,205 KB | 18 | ~89 µs |
| `klauspost/compress/gzip` | ~814 KB | 14 | ~64 µs |
| **delta** | **~390 KB** | −4 | **~28% faster** |

Reader — `BenchmarkGzipReader` (decode ~2 MB of recording-like text):

| | throughput | bytes/op | allocs/op | ns/op |
|---|---|---|---|---|
| stdlib `compress/gzip` | ~1,036 MB/s | ~55 KB | 260 | ~2.02 ms |
| `klauspost/compress/gzip` | ~1,498 MB/s | ~40 KB | 50 | ~1.40 ms |
| **delta** | **+45%** | −27% | **−80%** | **~31% faster** |

### Prior art

- **golang/go#32371** ("compress/flate: very memory intensive", open) documents the same behaviour upstream, reporting ~1.2 MB per writer at `BestSpeed` — the same figure measured here.
- klauspost/compress specifically reduced memory usage of the lower compression levels (the levels we use), and is already used directly elsewhere in the tree (`session/reexec/embed_linux.go`).
- The same swap was independently prototyped in `lib/events/sessionlog.go` on an internal POC branch (commit `699a6a0ca54`), which also flags grpc gzip as a follow-up.

<!-- Provide a descriptive entry for the changelog of the next release. -->

Changelog: Reduced session-recording memory usage on agents and sped up recording playback by switching to a more efficient gzip implementation.

<!-- Include manual testing efforts to verify the change. -->
<!-- Detail where the tests where run and what configurations were used. -->
<!-- Include all the test cases which were run to validate the change. -->

## Manual Test Plan

### Test Cases

Automated (run locally, `go test ./lib/events/...`):
- [x] `TestGzipWriterReaderRoundTrip` — production writer→reader round-trips and survives the writerPool Get/Reset/Put cycle.
- [x] `TestGzipReaderReadsLegacyRecordings` — backward compatibility: recordings written by older stdlib-based versions decode through the new reader.
- [x] `TestGzipReaderToleratesTrailingPadding` — the reader's `Multistream(false)` tolerates the historical trailing-padding quirk, for both stdlib- and klauspost-written data.
- [x] Existing `lib/events` and `lib/events/filesessions` (upload + playback round-trip) tests pass; `go vet` clean.

Manual (record, then play back / export, confirm no corruption):
- [x] **SSH** session — record, then `tsh play <session-id>` reproduces the session. The writer pool is shared across all recording types, so this validates the change for all of them.
