### PR TITLE
kube: enforce kubernetes_resources RBAC for unknown resource kinds

### DIFF
--- a/lib/kube/proxy/auth_test.go
+++ b/lib/kube/proxy/auth_test.go
@@ -342,7 +342,7 @@ current-context: foo
 			require.Empty(t, cmp.Diff(fwd.clusterDetails, tt.want,
 				cmp.AllowUnexported(staticKubeCreds{}),
 				cmp.AllowUnexported(kubeDetails{}),
-				cmpopts.IgnoreFields(kubeDetails{}, "rwMu", "kubeCodecs", "wg", "cancelFunc", "gvkSupportedResources"),
+				cmpopts.IgnoreFields(kubeDetails{}, "rwMu", "kubeCodecs", "wg", "cancelFunc", "gvkSupportedResources", "refreshGroup"),
 				cmp.Comparer(func(a, b *transport.Config) bool { return (a == nil) == (b == nil) }),
 				cmp.Comparer(func(a, b *tls.Config) bool { return true }),
 				cmp.Comparer(func(a, b *kubernetes.Clientset) bool { return (a == nil) == (b == nil) }),

--- a/lib/kube/proxy/cluster_details.go
+++ b/lib/kube/proxy/cluster_details.go
@@ -22,6 +22,7 @@ import (
 	"context"
 	"encoding/base64"
 	"log/slog"
+	"maps"
 	"net/http"
 	"strings"
 	"sync"
@@ -31,6 +32,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/eks"
 	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
+	"golang.org/x/sync/singleflight"
 	authzapi "k8s.io/api/authorization/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -76,6 +78,8 @@ type kubeDetails struct {
 	// gvkSupportedResources is the list of registered API path resources and their
 	// GVK definition.
 	gvkSupportedResources gvkSupportedResources
+	// refreshGroup is used to coalesce concurrent discovery of the same API group-version into one request.
+	refreshGroup singleflight.Group
 	// isClusterOffline is true if the cluster is offline.
 	// An offline cluster will not be able to serve any requests until it comes back online.
 	// The cluster is marked as offline if the cluster schema cannot be created
@@ -254,6 +258,84 @@ func (k *kubeDetails) getClusterSupportedResources() (*serializer.CodecFactory, 
 		return nil, nil, trace.ConnectionProblem(nil, "kubernetes cluster %q is offline", k.kubeCluster.GetName())
 	}
 	return k.kubeCodecs, k.rbacSupportedTypes, nil
+}
+
+// resolveResource looks up a resource kind in the discovery-backed cache.
+// On a miss it discovers just that API group-version (a single request) to catch recently-installed CRDs,
+// then retries, and returns the definition and whether it was found.
+func (k *kubeDetails) resolveResource(apiGroup, apiGroupVersion, resourceKind string) (res metav1.APIResource, found bool) {
+	k.rwMu.RLock()
+	res, found = k.rbacSupportedTypes.getResource(apiGroup, resourceKind)
+	k.rwMu.RUnlock()
+	if found {
+		return res, true
+	}
+
+	k.refreshGroupVersion(apiGroup, apiGroupVersion)
+
+	k.rwMu.RLock()
+	defer k.rwMu.RUnlock()
+	return k.rbacSupportedTypes.getResource(apiGroup, resourceKind)
+}
+
+// refreshGroupVersion discovers a single API group-version and merges any new resources into the cache.
+// Concurrent calls for the same group-version are coalesced.
+// A discovery error leaves the kind absent (and thus denied).
+func (k *kubeDetails) refreshGroupVersion(apiGroup, apiGroupVersion string) {
+	if k.kubeCreds == nil || apiGroupVersion == "" {
+		return
+	}
+	gv := schema.GroupVersion{Group: apiGroup, Version: apiGroupVersion}
+
+	_, _, _ = k.refreshGroup.Do(gv.String(), func() (any, error) {
+		list, err := k.getKubeClient().Discovery().ServerResourcesForGroupVersion(gv.String())
+		if err != nil {
+			return nil, nil
+		}
+		k.mergeGroupVersion(gv, list)
+		return nil, nil
+	})
+}
+
+// mergeGroupVersion merges a group-version's resources into the cached RBAC types, GVK map, and codec scheme,
+// swapping in fresh copies so existing readers keep a consistent snapshot.
+// It only rebuilds when there are new kinds.
+func (k *kubeDetails) mergeGroupVersion(gv schema.GroupVersion, list *metav1.APIResourceList) {
+	k.rwMu.Lock()
+	defer k.rwMu.Unlock()
+
+	hasNew := false
+	for _, apiResource := range list.APIResources {
+		if _, ok := k.rbacSupportedTypes[allowedResourcesKey{apiGroup: gv.Group, resourceKind: apiResource.Name}]; !ok {
+			hasNew = true
+			break
+		}
+	}
+	if !hasNew {
+		return
+	}
+
+	rbac := maps.Clone(k.rbacSupportedTypes)
+	gvk := maps.Clone(k.gvkSupportedResources)
+	for _, apiResource := range list.APIResources {
+		apiResource.Group = gv.Group
+		apiResource.Version = gv.Version
+		rbac[allowedResourcesKey{apiGroup: gv.Group, resourceKind: apiResource.Name}] = apiResource
+		gvk[gvkSupportedResourcesKey{name: apiResource.Name, apiGroup: gv.Group, version: gv.Version}] = &schema.GroupVersionKind{
+			Group:   gv.Group,
+			Version: gv.Version,
+			Kind:    apiResource.Kind,
+		}
+	}
+
+	codecs, err := buildCodecsForGVKs(gvk)
+	if err != nil {
+		return
+	}
+
+	k.rbacSupportedTypes = rbac
+	k.gvkSupportedResources = gvk
+	k.kubeCodecs = codecs
 }
 
 // getObjectGVK returns the default GVK (if any) registered for the specified request path.

--- a/lib/kube/proxy/cluster_details.go
+++ b/lib/kube/proxy/cluster_details.go
@@ -279,15 +279,22 @@ func (k *kubeDetails) resolveResource(apiGroup, apiGroupVersion, resourceKind st
 }
 
 // refreshGroupVersion discovers a single API group-version and merges any new resources into the cache.
-// Concurrent calls for the same group-version are coalesced.
-// A discovery error leaves the kind absent (and thus denied).
+// When the version is empty (SelfSubjectAccessReview requests often omit it) it resolves the group's
+// preferred version first. Concurrent calls for the same group(-version) are coalesced — including the
+// preferred-version lookup — so version-less requests don't each hit discovery. A discovery error leaves
+// the kind absent (and thus denied).
 func (k *kubeDetails) refreshGroupVersion(apiGroup, apiGroupVersion string) {
-	if k.kubeCreds == nil || apiGroupVersion == "" {
+	if k.kubeCreds == nil {
 		return
 	}
-	gv := schema.GroupVersion{Group: apiGroup, Version: apiGroupVersion}
-
-	_, _, _ = k.refreshGroup.Do(gv.String(), func() (any, error) {
+	_, _, _ = k.refreshGroup.Do(apiGroup+"/"+apiGroupVersion, func() (any, error) {
+		version := apiGroupVersion
+		if version == "" {
+			if version = k.preferredVersionForGroup(apiGroup); version == "" {
+				return nil, nil
+			}
+		}
+		gv := schema.GroupVersion{Group: apiGroup, Version: version}
 		list, err := k.getKubeClient().Discovery().ServerResourcesForGroupVersion(gv.String())
 		if err != nil {
 			return nil, nil
@@ -295,6 +302,21 @@ func (k *kubeDetails) refreshGroupVersion(apiGroup, apiGroupVersion string) {
 		k.mergeGroupVersion(gv, list)
 		return nil, nil
 	})
+}
+
+// preferredVersionForGroup returns the cluster's preferred version for an API group, or "" if the
+// group can't be resolved. Lets resolveResource discover a group whose version the caller didn't supply.
+func (k *kubeDetails) preferredVersionForGroup(apiGroup string) string {
+	groups, err := k.getKubeClient().Discovery().ServerGroups()
+	if err != nil {
+		return ""
+	}
+	for _, g := range groups.Groups {
+		if g.Name == apiGroup {
+			return g.PreferredVersion.Version
+		}
+	}
+	return ""
 }
 
 // mergeGroupVersion merges a group-version's resources into the cached RBAC types, GVK map, and codec scheme,

--- a/lib/kube/proxy/forwarder.go
+++ b/lib/kube/proxy/forwarder.go
@@ -1226,6 +1226,19 @@ func (f *Forwarder) authorize(ctx context.Context, actx *authContext) error {
 		return nil
 	}
 
+	// A kind unknown to the cluster's discovery can't be matched against the
+	// role's kubernetes_resources rules, so reject it rather than forward it unenforced.
+	// It's reported as NotFound because the kind isn't served by the cluster,
+	// the same result a client would get talking to the API server.
+	if actx.metaResource.unsupportedResource {
+		return trace.NotFound(
+			"Kubernetes resource kind %q in API group %q is not known to cluster %q",
+			actx.metaResource.requestedResource.resourceKind,
+			actx.metaResource.requestedResource.apiGroup,
+			actx.kubeClusterName,
+		)
+	}
+
 	identity := actx.Identity.GetIdentity()
 	var err error
 	actx.accessState, err = actx.CheckerContext.AccessStateFromTLSIdentity(ctx, &identity, f.cfg.CachingAuthClient)

--- a/lib/kube/proxy/kube_unknown_resource_test.go
+++ b/lib/kube/proxy/kube_unknown_resource_test.go
@@ -84,6 +84,22 @@ func TestKubeDetails_ResolveResourceTargetedDiscoveryOnMiss(t *testing.T) {
 	require.Equal(t, calls, client.calls)
 }
 
+// A SelfSubjectAccessReview (kubectl auth can-i) often omits the API version. A miss still
+// discovers the kind by resolving the group's preferred version, matching the data path.
+func TestKubeDetails_ResolveResourceWithoutVersion(t *testing.T) {
+	t.Parallel()
+	client := &fakeDiscoveryClientSet{resources: []*metav1.APIResourceList{coreList()}}
+	codecs, rbac, gvk, err := newClusterSchemaBuilder(logtest.NewLogger(), client)
+	require.NoError(t, err)
+	details := &kubeDetails{kubeCreds: &staticKubeCreds{kubeClient: client}, kubeCodecs: codecs, rbacSupportedTypes: rbac, gvkSupportedResources: gvk}
+
+	// Install the CRD after startup, then resolve it without a version.
+	client.resources = []*metav1.APIResourceList{coreList(), argoList()}
+	res, found := details.resolveResource("argoproj.io", "", "applications")
+	require.True(t, found)
+	require.Equal(t, "applications", res.Name)
+}
+
 // fakeDiscoveryClientSet serves a swappable set of API resources and counts
 // discovery calls. Not safe for concurrent use.
 type fakeDiscoveryClientSet struct {
@@ -108,6 +124,17 @@ func (c *fakeDiscoveryClientSet) ServerResourcesForGroupVersion(gv string) (*met
 		}
 	}
 	return nil, apierrors.NewNotFound(schema.GroupResource{Group: gv}, "")
+}
+
+func (c *fakeDiscoveryClientSet) ServerGroups() (*metav1.APIGroupList, error) {
+	c.calls++
+	out := &metav1.APIGroupList{}
+	for _, l := range c.resources {
+		group, version := getKubeAPIGroupAndVersion(l.GroupVersion)
+		gvfd := metav1.GroupVersionForDiscovery{GroupVersion: l.GroupVersion, Version: version}
+		out.Groups = append(out.Groups, metav1.APIGroup{Name: group, Versions: []metav1.GroupVersionForDiscovery{gvfd}, PreferredVersion: gvfd})
+	}
+	return out, nil
 }
 
 func coreList() *metav1.APIResourceList {

--- a/lib/kube/proxy/kube_unknown_resource_test.go
+++ b/lib/kube/proxy/kube_unknown_resource_test.go
@@ -1,0 +1,119 @@
+/*
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package proxy
+
+import (
+	"net/http"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/kubernetes"
+
+	"github.com/gravitational/teleport/lib/utils/log/logtest"
+)
+
+const (
+	unknownKindPath = "/apis/argoproj.io/v1alpha1/namespaces/team-x/applications/prod-billing"
+	knownKindPath   = "/api/v1/namespaces/default/pods/foo"
+)
+
+// A kind absent from the discovery cache is flagged unsupportedResource
+// so the forwarder denies it. A known kind resolves normally.
+func TestGetResourceFromRequest_UnknownKindIsDenied(t *testing.T) {
+	details := &kubeDetails{kubeCodecs: &globalKubeCodecs, rbacSupportedTypes: getRBACSupportedTypes(t)}
+
+	t.Run("known kind", func(t *testing.T) {
+		got, err := getResourceFromRequest(&http.Request{Method: http.MethodGet, URL: &url.URL{Path: knownKindPath}}, details)
+		require.NoError(t, err)
+		require.NotNil(t, got.rbacResource())
+		require.Equal(t, "pods", got.rbacResource().Kind)
+		require.False(t, got.unsupportedResource)
+	})
+
+	t.Run("unknown kind", func(t *testing.T) {
+		got, err := getResourceFromRequest(&http.Request{Method: http.MethodGet, URL: &url.URL{Path: unknownKindPath}}, details)
+		require.NoError(t, err)
+		require.Nil(t, got.rbacResource())
+		require.True(t, got.unsupportedResource)
+	})
+}
+
+// A miss discovers the kind's group-version (picking up a freshly-installed CRD),
+// then serves it from cache without re-discovering.
+func TestKubeDetails_ResolveResourceTargetedDiscoveryOnMiss(t *testing.T) {
+	t.Parallel()
+	client := &fakeDiscoveryClientSet{resources: []*metav1.APIResourceList{coreList()}}
+	codecs, rbac, gvk, err := newClusterSchemaBuilder(logtest.NewLogger(), client)
+	require.NoError(t, err)
+	details := &kubeDetails{kubeCreds: &staticKubeCreds{kubeClient: client}, kubeCodecs: codecs, rbacSupportedTypes: rbac, gvkSupportedResources: gvk}
+
+	_, found := details.resolveResource("argoproj.io", "v1alpha1", "applications")
+	require.False(t, found)
+
+	// Install the CRD. The next miss discovers and merges it.
+	client.resources = []*metav1.APIResourceList{coreList(), argoList()}
+	res, found := details.resolveResource("argoproj.io", "v1alpha1", "applications")
+	require.True(t, found)
+	require.Equal(t, "applications", res.Name)
+
+	// Once merged, lookups are cache hits and trigger no further discovery.
+	calls := client.calls
+	_, found = details.resolveResource("argoproj.io", "v1alpha1", "applications")
+	require.True(t, found)
+	require.Equal(t, calls, client.calls)
+}
+
+// fakeDiscoveryClientSet serves a swappable set of API resources and counts
+// discovery calls. Not safe for concurrent use.
+type fakeDiscoveryClientSet struct {
+	kubernetes.Interface
+	discovery.DiscoveryInterface
+	resources []*metav1.APIResourceList
+	calls     int
+}
+
+func (c *fakeDiscoveryClientSet) Discovery() discovery.DiscoveryInterface { return c }
+
+func (c *fakeDiscoveryClientSet) ServerGroupsAndResources() ([]*metav1.APIGroup, []*metav1.APIResourceList, error) {
+	c.calls++
+	return nil, c.resources, nil
+}
+
+func (c *fakeDiscoveryClientSet) ServerResourcesForGroupVersion(gv string) (*metav1.APIResourceList, error) {
+	c.calls++
+	for _, l := range c.resources {
+		if l.GroupVersion == gv {
+			return l, nil
+		}
+	}
+	return nil, apierrors.NewNotFound(schema.GroupResource{Group: gv}, "")
+}
+
+func coreList() *metav1.APIResourceList {
+	return &metav1.APIResourceList{GroupVersion: "v1", APIResources: []metav1.APIResource{{Name: "pods", Kind: "Pod", Namespaced: true}}}
+}
+
+func argoList() *metav1.APIResourceList {
+	return &metav1.APIResourceList{GroupVersion: "argoproj.io/v1alpha1", APIResources: []metav1.APIResource{{Name: "applications", Kind: "Application", Namespaced: true}}}
+}

--- a/lib/kube/proxy/scheme.go
+++ b/lib/kube/proxy/scheme.go
@@ -211,6 +211,30 @@ func newClusterSchemaBuilder(log *slog.Logger, client kubernetes.Interface) (*se
 	return &kubeCodecs, supportedResources, gvkSupportedRes, nil
 }
 
+// buildCodecsForGVKs builds a codec factory whose scheme knows the well-known
+// Kubernetes types plus the given discovered GVKs (as unstructured). It mirrors
+// newClusterSchemaBuilder's registration and is used to rebuild the codecs after
+// a targeted, single-group-version discovery, without re-discovering the cluster.
+func buildCodecsForGVKs(gvks gvkSupportedResources) (*serializer.CodecFactory, error) {
+	kubeScheme := runtime.NewScheme()
+	if err := registerDefaultKubeTypes(kubeScheme); err != nil {
+		return nil, trace.Wrap(err)
+	}
+	for _, gvk := range gvks {
+		if gvk == nil {
+			continue
+		}
+		// Skip well-known types already registered by registerDefaultKubeTypes.
+		if _, err := kubeScheme.New(*gvk); err == nil {
+			continue
+		}
+		kubeScheme.AddKnownTypeWithName(*gvk, &unstructured.Unstructured{})
+		kubeScheme.AddKnownTypeWithName(gvk.GroupVersion().WithKind(gvk.Kind+listSuffix), &unstructured.Unstructured{})
+	}
+	kubeCodecs := serializer.NewCodecFactory(kubeScheme)
+	return &kubeCodecs, nil
+}
+
 // getKubeAPIGroupAndVersion returns the API group and version from the given
 // groupVersion string.
 // The groupVersion string can be in the following formats:

--- a/lib/kube/proxy/self_subject_reviews.go
+++ b/lib/kube/proxy/self_subject_reviews.go
@@ -147,7 +147,9 @@ func (f *Forwarder) validateSelfSubjectAccessReview(sess *clusterSession, w http
 			if encodeErr := encoder.Encode(accessReview, w); encodeErr != nil {
 				return trace.Wrap(encodeErr)
 			}
-			return nil
+			// The denied response is already written; signal the caller to stop
+			// forwarding, like the other denial branches below.
+			return trace.AccessDenied("Kubernetes resource kind %q in API group %q is not known to this cluster", resourceKind, group)
 		}
 	}
 	name := accessReview.Spec.ResourceAttributes.Name

--- a/lib/kube/proxy/self_subject_reviews.go
+++ b/lib/kube/proxy/self_subject_reviews.go
@@ -121,12 +121,34 @@ func (f *Forwarder) validateSelfSubjectAccessReview(sess *clusterSession, w http
 	}
 
 	namespace := accessReview.Spec.ResourceAttributes.Namespace
-	resource, ok := sess.rbacSupportedResources.getResource(accessReview.Spec.ResourceAttributes.Group, accessReview.Spec.ResourceAttributes.Resource)
-	// If the request is for a resource that Teleport does not support, return
-	// nil and let the Kubernetes API server handle the request.
-	// TODO(@creack): Remove this as part of the RBAC RFC. It grants excessive permissions.
+	group := accessReview.Spec.ResourceAttributes.Group
+	version := accessReview.Spec.ResourceAttributes.Version
+	resourceKind := accessReview.Spec.ResourceAttributes.Resource
+	resource, ok := sess.rbacSupportedResources.getResource(group, resourceKind)
 	if !ok {
-		return nil
+		// Mirror the data path so `kubectl auth can-i` matches a real request:
+		// discover the kind's group-version and, if it's still unknown, report denied.
+		details, derr := f.findKubeDetailsByClusterName(sess.kubeClusterName)
+		if derr != nil {
+			return nil
+		}
+		var found bool
+		resource, found = details.resolveResource(group, version, resourceKind)
+		if !found {
+			accessReview.Status = authv1.SubjectAccessReviewStatus{
+				Allowed: false,
+				Denied:  true,
+				Reason: fmt.Sprintf(
+					"Kubernetes resource kind %q in API group %q is not known to this cluster",
+					resourceKind, group,
+				),
+			}
+			responsewriters.SetContentTypeHeader(w, req.Header)
+			if encodeErr := encoder.Encode(accessReview, w); encodeErr != nil {
+				return trace.Wrap(encodeErr)
+			}
+			return nil
+		}
 	}
 	name := accessReview.Spec.ResourceAttributes.Name
 

--- a/lib/kube/proxy/url.go
+++ b/lib/kube/proxy/url.go
@@ -41,6 +41,10 @@ type metaResource struct {
 	requestedResource  apiResource         // User input, based on URL.
 	verb               string              // Verb of the user request.
 	isList             bool
+	// unsupportedResource is set when the requested kind is unknown to a healthy
+	// discovery cache and so can't be matched against kubernetes_resources rules.
+	// The forwarder denies such requests instead of forwarding them unenforced.
+	unsupportedResource bool
 }
 
 func (mr *metaResource) isClusterWideResource() bool {
@@ -226,15 +230,26 @@ func getResourceFromRequest(req *http.Request, kubeDetails *kubeDetails) (metaRe
 		return out, nil
 	}
 
-	codecFactory, rbacSupportedTypes, err := kubeDetails.getClusterSupportedResources()
+	// Surfaces an offline-cluster error and provides the codec factory used below
+	// for create requests.
+	codecFactory, _, err := kubeDetails.getClusterSupportedResources()
 	if err != nil {
 		return out, trace.Wrap(err)
 	}
 
-	resource, ok := rbacSupportedTypes.getResource(apiResource.apiGroup, apiResource.resourceKind)
-	if !ok {
-		// TODO(@creack): Change this behavior, unsupported resource should be rejected.
-		// If the resource is not supported, return nil.
+	// Discovery / health endpoints (e.g. /api, /apis/<group>/<version>) carry no
+	// concrete resource kind and aren't subject to kubernetes_resources rules;
+	// let them through so clients can complete API discovery.
+	if apiResource.resourceKind == "" {
+		return out, nil
+	}
+
+	resource, found := kubeDetails.resolveResource(apiResource.apiGroup, apiResource.apiGroupVersion, apiResource.resourceKind)
+	if !found {
+		// Still unknown after a targeted discovery: the kind isn't served by the
+		// cluster. Flag it so the forwarder denies the request rather than
+		// forwarding it with kubernetes_resources rules unenforced.
+		out.unsupportedResource = true
 		return out, nil
 	}
 	out.resourceDefinition = &resource

--- a/lib/kube/proxy/url.go
+++ b/lib/kube/proxy/url.go
@@ -230,10 +230,8 @@ func getResourceFromRequest(req *http.Request, kubeDetails *kubeDetails) (metaRe
 		return out, nil
 	}
 
-	// Surfaces an offline-cluster error and provides the codec factory used below
-	// for create requests.
-	codecFactory, _, err := kubeDetails.getClusterSupportedResources()
-	if err != nil {
+	// Surface an offline-cluster error before doing any work.
+	if _, _, err := kubeDetails.getClusterSupportedResources(); err != nil {
 		return out, trace.Wrap(err)
 	}
 
@@ -263,6 +261,12 @@ func getResourceFromRequest(req *http.Request, kubeDetails *kubeDetails) (metaRe
 
 	if apiResource.resourceName == "" && out.verb == types.KubeVerbCreate {
 		// If the request is a create request, extract the resource name from the request body.
+		// Re-read the codecs: resolveResource above may have just discovered this CRD and
+		// rebuilt them, so decode against a scheme that knows the new kind.
+		codecFactory, _, err := kubeDetails.getClusterSupportedResources()
+		if err != nil {
+			return out, trace.Wrap(err)
+		}
 		resourceName, err := extractResourceNameFromPostRequest(req, codecFactory, kubeDetails.getObjectGVK(apiResource))
 		if err != nil {
 			return out, trace.Wrap(err)

--- a/lib/web/apiserver_test.go
+++ b/lib/web/apiserver_test.go
@@ -7657,6 +7657,17 @@ func TestDiagnoseKubeConnection(t *testing.T) {
 	)
 
 	rt := http.NewServeMux()
+	// Serve core API discovery so the proxy can resolve the "pods" kind it probes.
+	// Otherwise the proxy treats pods as an unknown resource kind.
+	rt.HandleFunc("/api/v1", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		require.NoError(t, json.NewEncoder(w).Encode(&metav1.APIResourceList{
+			GroupVersion: "v1",
+			APIResources: []metav1.APIResource{
+				{Name: "pods", SingularName: "pod", Namespaced: true, Kind: "Pod", Verbs: metav1.Verbs{"get", "list"}},
+			},
+		}))
+	})
 	rt.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		if slices.Contains(r.Header.Values("Impersonate-Group"), invalidKubeGroups[0]) {
 			marshalRBACError(t, w)


### PR DESCRIPTION
The Kubernetes proxy did not enforce a role's `kubernetes_resources` allow/deny rules for resource kinds missing from its discovery cache (e.g. a CRD installed since the last ~5-min refresh): those requests were forwarded with the rules unenforced.

Now, on a cache miss the proxy discovers just that API group-version (a single request) and merges it. If the kind is still unknown, the request is rejected with `NotFound` (404) - what the API server itself returns for a kind it doesn't serve - instead of being forwarded unenforced. `kubectl auth can-i` answers are aligned with real requests.

## Manual Test Plan

Local Kind cluster, **Teleport Enterprise v19 built from this branch**, with an `applications.argoproj.io` CRD installed **after** proxy startup (so it is absent from the startup discovery cache - the bypass condition). Test user carries a single v8 role. All cases passed:

- [x] `deny.kubernetes_resources` on the CRD → `kubectl get applications` is denied (allowed on master).
- [x] `allow.kubernetes_resources` scoped to a different kind → `kubectl get applications` is denied (allowed on master).
- [x] role allows the CRD → `kubectl get applications` succeeds immediately, no proxy restart.
- [x] kind the cluster doesn't serve → `Error from server (NotFound): ... is not known to cluster ...` (404).
- [x] `kubectl auth can-i` matches the actual request outcome.
- [x] well-known kinds (`pods`) and API discovery (`kubectl api-resources`) are unaffected.