### PR TITLE
Resolve auth credentials from the E2E_DIR in CI

### DIFF
--- a/e2e/global-setup.ts
+++ b/e2e/global-setup.ts
@@ -20,7 +20,8 @@ import { mkdirSync, writeFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 
-const authDir = join(dirname(fileURLToPath(import.meta.url)), '.auth');
+const e2eDir = process.env.E2E_DIR ?? dirname(fileURLToPath(import.meta.url));
+const authDir = join(e2eDir, '.auth');
 
 async function globalSetup() {
   const browser = process.env.E2E_BROWSER;


### PR DESCRIPTION
This should be the final issue to fix to get enterprise tests running.. not sure why it was passing locally without this, but it's needed to write the auth credentials into `e/e2e/.auth`