### PR TITLE
Helm: Support firestore databaseID in teleport-cluster

### DIFF
--- a/examples/chart/teleport-cluster/.lint/gcp-database-id.yaml
+++ b/examples/chart/teleport-cluster/.lint/gcp-database-id.yaml
@@ -1,0 +1,12 @@
+clusterName: test-gcp-cluster
+chartMode: gcp
+gcp:
+  projectId: gcpproj-123456
+  databaseId: customdb
+  backendTable: test-teleport-firestore-storage-collection
+  auditLogTable: test-teleport-firestore-auditlog-collection
+  sessionRecordingBucket: test-gcp-session-storage-bucket
+acme: true
+acmeEmail: test@email.com
+labels:
+  env: gcp

--- a/examples/chart/teleport-cluster/templates/auth/_config.gcp.tpl
+++ b/examples/chart/teleport-cluster/templates/auth/_config.gcp.tpl
@@ -1,17 +1,39 @@
 {{- define "teleport-cluster.auth.config.gcp" -}}
-{{- $auth := mustMergeOverwrite (mustDeepCopy .Values) .Values.auth -}}
-{{ include "teleport-cluster.auth.config.common" . }}
+{{- $auth := mustMergeOverwrite (mustDeepCopy .Values) .Values.auth }}
+{{/* Building the firestore query. Always set the project ID, and optionally the database ID and the credentials path. */}}
+{{- $firestoreParams := dict
+    "projectID" (required "gcp.projectId is required in chart values" $auth.gcp.projectId)
+}}
+{{- if $auth.gcp.credentialSecretName }}
+{{- $_ := set $firestoreParams "credentialsPath" "/etc/teleport-secrets/gcp-credentials.json" }}
+{{- end }}
+{{- if $auth.gcp.databaseId }}
+{{- $_ := set $firestoreParams "databaseID" $auth.gcp.databaseId }}
+{{- end }}
+{{- $firestoreQueryParts := list }}
+{{- range $key, $value := $firestoreParams }}
+  {{- $firestoreQueryParts = append $firestoreQueryParts (printf "%s=%s" $key $value) }}
+{{- end }}
+{{- $firestoreURL := urlJoin (dict
+    "scheme" "firestore"
+    "host" (required "gcp.auditLogTable is required in chart values" $auth.gcp.auditLogTable)
+    "query" (join "&" $firestoreQueryParts))
+}}
+{{- include "teleport-cluster.auth.config.common" . }}
   storage:
     type: firestore
     project_id: {{ required "gcp.projectId is required in chart values" $auth.gcp.projectId }}
     collection_name: {{ required "gcp.backendTable is required in chart values" $auth.gcp.backendTable }}
+    {{- if $auth.gcp.databaseId }}
+    database_id: {{ $auth.gcp.databaseId }}
+    {{- end }}
     {{- if $auth.gcp.credentialSecretName }}
     credentials_path: /etc/teleport-secrets/gcp-credentials.json
     {{- end }}
     {{- if $auth.gcp.auditLogMirrorOnStdout }}
-    audit_events_uri: ['firestore://{{ required "gcp.auditLogTable is required in chart values" $auth.gcp.auditLogTable }}?projectID={{ required "gcp.projectId is required in chart values" $auth.gcp.projectId }}{{ empty $auth.gcp.credentialSecretName | ternary "" "&credentialsPath=/etc/teleport-secrets/gcp-credentials.json"}}', 'stdout://']
+    audit_events_uri: ['{{$firestoreURL}}', 'stdout://']
     {{- else }}
-    audit_events_uri: ['firestore://{{ required "gcp.auditLogTable is required in chart values" $auth.gcp.auditLogTable }}?projectID={{ required "gcp.projectId is required in chart values" $auth.gcp.projectId }}{{ empty $auth.gcp.credentialSecretName | ternary "" "&credentialsPath=/etc/teleport-secrets/gcp-credentials.json"}}']
+    audit_events_uri: ['{{ $firestoreURL }}']
     {{- end }}
     audit_sessions_uri: "gs://{{ required "gcp.sessionRecordingBucket is required in chart values" $auth.gcp.sessionRecordingBucket }}?projectID={{ required "gcp.projectId is required in chart values" $auth.gcp.projectId }}{{ empty $auth.gcp.credentialSecretName | ternary "" "&credentialsPath=/etc/teleport-secrets/gcp-credentials.json"}}"
 {{- end -}}

--- a/examples/chart/teleport-cluster/tests/__snapshot__/auth_config_test.yaml.snap
+++ b/examples/chart/teleport-cluster/tests/__snapshot__/auth_config_test.yaml.snap
@@ -1076,6 +1076,54 @@ matches snapshot for existing-tls-secret.yaml:
           output: stderr
           severity: INFO
       version: v3
+matches snapshot for gcp-database-id.yaml:
+  1: |
+    |-
+      auth_service:
+        authentication:
+          local_auth: true
+          second_factors:
+          - otp
+          - webauthn
+          type: local
+          webauthn:
+            rp_id: test-gcp-cluster
+        cluster_name: test-gcp-cluster
+        enabled: true
+        proxy_listener_mode: separate
+      kubernetes_service:
+        enabled: true
+        kube_cluster_name: test-gcp-cluster
+        labels:
+          env: gcp
+        listen_addr: 0.0.0.0:3026
+        public_addr: RELEASE-NAME-auth.NAMESPACE.svc.cluster.local:3026
+      proxy_service:
+        enabled: false
+      ssh_service:
+        enabled: false
+      teleport:
+        auth_server: 127.0.0.1:3025
+        log:
+          format:
+            extra_fields:
+            - timestamp
+            - level
+            - component
+            - caller
+            output: text
+          output: stderr
+          severity: INFO
+        storage:
+          audit_events_uri:
+          - firestore://test-teleport-firestore-auditlog-collection?credentialsPath=/etc/teleport-secrets/gcp-credentials.json&databaseID=customdb&projectID=gcpproj-123456
+          audit_sessions_uri: gs://test-gcp-session-storage-bucket?projectID=gcpproj-123456&credentialsPath=/etc/teleport-secrets/gcp-credentials.json
+          collection_name: test-teleport-firestore-storage-collection
+          credentials_path: /etc/teleport-secrets/gcp-credentials.json
+          database_id: customdb
+          project_id: gcpproj-123456
+          type: firestore
+      version: v3
 matches snapshot for gcp-ha-acme.yaml:
   1: |
     |-
@@ -1116,7 +1164,7 @@ matches snapshot for gcp-ha-acme.yaml:
           severity: INFO
         storage:
           audit_events_uri:
-          - firestore://test-teleport-firestore-auditlog-collection?projectID=gcpproj-123456&credentialsPath=/etc/teleport-secrets/gcp-credentials.json
+          - firestore://test-teleport-firestore-auditlog-collection?credentialsPath=/etc/teleport-secrets/gcp-credentials.json&projectID=gcpproj-123456
           audit_sessions_uri: gs://test-gcp-session-storage-bucket?projectID=gcpproj-123456&credentialsPath=/etc/teleport-secrets/gcp-credentials.json
           collection_name: test-teleport-firestore-storage-collection
           credentials_path: /etc/teleport-secrets/gcp-credentials.json
@@ -1163,7 +1211,7 @@ matches snapshot for gcp-ha-antiaffinity.yaml:
           severity: INFO
         storage:
           audit_events_uri:
-          - firestore://test-teleport-firestore-auditlog-collection?projectID=gcpproj-123456&credentialsPath=/etc/teleport-secrets/gcp-credentials.json
+          - firestore://test-teleport-firestore-auditlog-collection?credentialsPath=/etc/teleport-secrets/gcp-credentials.json&projectID=gcpproj-123456
           audit_sessions_uri: gs://test-gcp-session-storage-bucket?projectID=gcpproj-123456&credentialsPath=/etc/teleport-secrets/gcp-credentials.json
           collection_name: test-teleport-firestore-storage-collection
           credentials_path: /etc/teleport-secrets/gcp-credentials.json
@@ -1210,7 +1258,7 @@ matches snapshot for gcp-ha-log.yaml:
           severity: DEBUG
         storage:
           audit_events_uri:
-          - firestore://test-teleport-firestore-auditlog-collection?projectID=gcpproj-123456&credentialsPath=/etc/teleport-secrets/gcp-credentials.json
+          - firestore://test-teleport-firestore-auditlog-collection?credentialsPath=/etc/teleport-secrets/gcp-credentials.json&projectID=gcpproj-123456
           - stdout://
           audit_sessions_uri: gs://test-gcp-session-storage-bucket?projectID=gcpproj-123456&credentialsPath=/etc/teleport-secrets/gcp-credentials.json
           collection_name: test-teleport-firestore-storage-collection
@@ -1258,7 +1306,7 @@ matches snapshot for gcp.yaml:
           severity: INFO
         storage:
           audit_events_uri:
-          - firestore://test-teleport-firestore-auditlog-collection?projectID=gcpproj-123456&credentialsPath=/etc/teleport-secrets/gcp-credentials.json
+          - firestore://test-teleport-firestore-auditlog-collection?credentialsPath=/etc/teleport-secrets/gcp-credentials.json&projectID=gcpproj-123456
           audit_sessions_uri: gs://test-gcp-session-storage-bucket?projectID=gcpproj-123456&credentialsPath=/etc/teleport-secrets/gcp-credentials.json
           collection_name: test-teleport-firestore-storage-collection
           credentials_path: /etc/teleport-secrets/gcp-credentials.json

--- a/examples/chart/teleport-cluster/tests/auth_config_test.yaml
+++ b/examples/chart/teleport-cluster/tests/auth_config_test.yaml
@@ -270,6 +270,17 @@ tests:
       - matchSnapshot:
           path: data.teleport\.yaml
 
+  - it: matches snapshot for gcp-database-id.yaml
+    values:
+      - ../.lint/gcp-database-id.yaml
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: ConfigMap
+      - matchSnapshot:
+          path: data.teleport\.yaml
+
   - it: matches snapshot for initcontainers.yaml
     values:
       - ../.lint/initcontainers.yaml

--- a/examples/chart/teleport-cluster/values.yaml
+++ b/examples/chart/teleport-cluster/values.yaml
@@ -466,6 +466,8 @@ gcp:
   # - The container will need an appropriately-provisioned IAM role/service account with permissions to create Firestore collections
   # - The service account credentials provided via 'credentialSecretName' will need permissions to create Firestore collections.
   backendTable: ""
+  # databaseId is the optional Firestore database ID. When empty, uses the default firestore database.
+  databaseId: ""
   # The Firestore collection to use for audit log storage. Teleport will attempt to create this collection automatically if it does not exist.
   # Either of the following must be true:
   # - The container will need an appropriately-provisioned IAM role/service account with permissions to create Firestore collections


### PR DESCRIPTION
Note for reviewers: I cleaned up the firestore URL crafting so this inflates the changeset a bit, but this is more readable than the 400-char-long line.

Fixes: https://github.com/gravitational/teleport/issues/67301
Changelog: Added non-default Firestore database support to the `teleport-cluster` Helm chart.

## Manual Test Plan
### Test Environment

GKE cluster

### Test Cases
- [ ] empty value: deploys in default firestore
- [ ] set value: deploys in non-default firestore
