### PR TITLE
Bump github.com/oracle/oci-go-sdk/v65 to v65.117.1

### DIFF
--- a/build.assets/tooling/go.sum
+++ b/build.assets/tooling/go.sum
@@ -667,8 +667,8 @@ github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/opencontainers/image-spec v1.1.1 h1:y0fUlFfIZhPF1W537XOLg0/fcx6zcHCJwooC2xJA040=
 github.com/opencontainers/image-spec v1.1.1/go.mod h1:qpqAh3Dmcf36wStyyWU+kCeDgrGnAve2nCC8+7h8Q0M=
-github.com/oracle/oci-go-sdk/v65 v65.107.0 h1:ZBnDn495o4beF+bidJuIDYubwEVypiOhtVrmIQd0kWY=
-github.com/oracle/oci-go-sdk/v65 v65.107.0/go.mod h1:8ZzvzuEG/cFLFZhxg/Mg1w19KqyXBKO3c17QIc5PkGs=
+github.com/oracle/oci-go-sdk/v65 v65.117.1 h1:DurEtbj8xEuF2B6K73uifNqWJ4dh6CJPADVmNzclrGU=
+github.com/oracle/oci-go-sdk/v65 v65.117.1/go.mod h1:oo33NDf2XPqx3/N6oLG4jFlrqJ0xu4Rlt9SfuAbtDFs=
 github.com/patrickmn/go-cache v2.1.1-0.20191004192108-46f407853014+incompatible h1:IWzUvJ72xMjmrjR9q3H1PF+jwdN0uNQiR2t1BLNalyo=
 github.com/patrickmn/go-cache v2.1.1-0.20191004192108-46f407853014+incompatible/go.mod h1:3Qf8kWWT7OJRJbdiICTKqZju1ZixQ/KpMGzzAfe6+WQ=
 github.com/pborman/getopt v0.0.0-20170112200414-7148bc3a4c30/go.mod h1:85jBQOZwpVEaDAr341tbn15RS4fCAsIst0qp7i8ex1o=
@@ -754,8 +754,8 @@ github.com/sijms/go-ora/v2 v2.9.0 h1:+iQbUeTeCOFMb5BsOMgUhV8KWyrv9yjKpcK4x7+MFrg
 github.com/sijms/go-ora/v2 v2.9.0/go.mod h1:QgFInVi3ZWyqAiJwzBQA+nbKYKH77tdp1PYoCqhR2dU=
 github.com/sirupsen/logrus v1.9.4 h1:TsZE7l11zFCLZnZ+teH4Umoq5BhEIfIzfRDZ1Uzql2w=
 github.com/sirupsen/logrus v1.9.4/go.mod h1:ftWc9WdOfJ0a92nsE2jF5u5ZwH8Bv2zdeOC42RjbV2g=
-github.com/sony/gobreaker v0.5.0 h1:dRCvqm0P490vZPmy7ppEk2qCnCieBooFJ+YoXGYB+yg=
-github.com/sony/gobreaker v0.5.0/go.mod h1:ZKptC7FHNvhBz7dN2LGjPVBz2sZJmc0/PkyDJOjmxWY=
+github.com/sony/gobreaker/v2 v2.4.0 h1:g2KJRW1Ubty3+ZOcSEUN7K+REQJdN6yo6XvaML+jptg=
+github.com/sony/gobreaker/v2 v2.4.0/go.mod h1:pTyFJgcZ3h2tdQVLZZruK2C0eoFL1fb/G83wK1ZQl+s=
 github.com/spf13/cast v1.10.0 h1:h2x0u2shc1QuLHfxi+cTJvs30+ZAHOGRic8uyGTDWxY=
 github.com/spf13/cast v1.10.0/go.mod h1:jNfB8QC9IA6ZuY2ZjDp0KtFO2LZZlg4S/7bzP6qqeHo=
 github.com/spf13/cobra v1.10.2 h1:DMTTonx5m65Ic0GOoRY2c16WCbHxOOw6xxezuLaBpcU=

--- a/e2e/runner/go.sum
+++ b/e2e/runner/go.sum
@@ -677,8 +677,8 @@ github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/opencontainers/image-spec v1.1.1 h1:y0fUlFfIZhPF1W537XOLg0/fcx6zcHCJwooC2xJA040=
 github.com/opencontainers/image-spec v1.1.1/go.mod h1:qpqAh3Dmcf36wStyyWU+kCeDgrGnAve2nCC8+7h8Q0M=
-github.com/oracle/oci-go-sdk/v65 v65.107.0 h1:ZBnDn495o4beF+bidJuIDYubwEVypiOhtVrmIQd0kWY=
-github.com/oracle/oci-go-sdk/v65 v65.107.0/go.mod h1:8ZzvzuEG/cFLFZhxg/Mg1w19KqyXBKO3c17QIc5PkGs=
+github.com/oracle/oci-go-sdk/v65 v65.117.1 h1:DurEtbj8xEuF2B6K73uifNqWJ4dh6CJPADVmNzclrGU=
+github.com/oracle/oci-go-sdk/v65 v65.117.1/go.mod h1:oo33NDf2XPqx3/N6oLG4jFlrqJ0xu4Rlt9SfuAbtDFs=
 github.com/patrickmn/go-cache v2.1.1-0.20191004192108-46f407853014+incompatible h1:IWzUvJ72xMjmrjR9q3H1PF+jwdN0uNQiR2t1BLNalyo=
 github.com/patrickmn/go-cache v2.1.1-0.20191004192108-46f407853014+incompatible/go.mod h1:3Qf8kWWT7OJRJbdiICTKqZju1ZixQ/KpMGzzAfe6+WQ=
 github.com/pborman/getopt v0.0.0-20170112200414-7148bc3a4c30/go.mod h1:85jBQOZwpVEaDAr341tbn15RS4fCAsIst0qp7i8ex1o=
@@ -763,8 +763,8 @@ github.com/sijms/go-ora/v2 v2.9.0 h1:+iQbUeTeCOFMb5BsOMgUhV8KWyrv9yjKpcK4x7+MFrg
 github.com/sijms/go-ora/v2 v2.9.0/go.mod h1:QgFInVi3ZWyqAiJwzBQA+nbKYKH77tdp1PYoCqhR2dU=
 github.com/sirupsen/logrus v1.9.4 h1:TsZE7l11zFCLZnZ+teH4Umoq5BhEIfIzfRDZ1Uzql2w=
 github.com/sirupsen/logrus v1.9.4/go.mod h1:ftWc9WdOfJ0a92nsE2jF5u5ZwH8Bv2zdeOC42RjbV2g=
-github.com/sony/gobreaker v0.5.0 h1:dRCvqm0P490vZPmy7ppEk2qCnCieBooFJ+YoXGYB+yg=
-github.com/sony/gobreaker v0.5.0/go.mod h1:ZKptC7FHNvhBz7dN2LGjPVBz2sZJmc0/PkyDJOjmxWY=
+github.com/sony/gobreaker/v2 v2.4.0 h1:g2KJRW1Ubty3+ZOcSEUN7K+REQJdN6yo6XvaML+jptg=
+github.com/sony/gobreaker/v2 v2.4.0/go.mod h1:pTyFJgcZ3h2tdQVLZZruK2C0eoFL1fb/G83wK1ZQl+s=
 github.com/spf13/cast v1.10.0 h1:h2x0u2shc1QuLHfxi+cTJvs30+ZAHOGRic8uyGTDWxY=
 github.com/spf13/cast v1.10.0/go.mod h1:jNfB8QC9IA6ZuY2ZjDp0KtFO2LZZlg4S/7bzP6qqeHo=
 github.com/spf13/cobra v1.10.2 h1:DMTTonx5m65Ic0GOoRY2c16WCbHxOOw6xxezuLaBpcU=

--- a/go.mod
+++ b/go.mod
@@ -194,7 +194,7 @@ require (
 	github.com/opencontainers/go-digest v1.0.0
 	github.com/opencontainers/selinux v1.13.1
 	github.com/opensearch-project/opensearch-go/v2 v2.3.0
-	github.com/oracle/oci-go-sdk/v65 v65.107.0
+	github.com/oracle/oci-go-sdk/v65 v65.117.1
 	github.com/parquet-go/parquet-go v0.25.1
 	github.com/patrickmn/go-cache v2.1.1-0.20191004192108-46f407853014+incompatible
 	github.com/pavlo-v-chernykh/keystore-go/v4 v4.5.0
@@ -556,7 +556,7 @@ require (
 	github.com/sigstore/rekor-tiles/v2 v2.2.0 // indirect
 	github.com/sigstore/timestamp-authority/v2 v2.0.6 // indirect
 	github.com/sirupsen/logrus v1.9.4 // indirect
-	github.com/sony/gobreaker v0.5.0 // indirect
+	github.com/sony/gobreaker/v2 v2.4.0 // indirect
 	github.com/spf13/cast v1.10.0 // indirect
 	github.com/spf13/pflag v1.0.10 // indirect
 	github.com/stretchr/objx v0.5.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1127,8 +1127,8 @@ github.com/opencontainers/image-spec v1.1.1 h1:y0fUlFfIZhPF1W537XOLg0/fcx6zcHCJw
 github.com/opencontainers/image-spec v1.1.1/go.mod h1:qpqAh3Dmcf36wStyyWU+kCeDgrGnAve2nCC8+7h8Q0M=
 github.com/opensearch-project/opensearch-go/v2 v2.3.0 h1:nQIEMr+A92CkhHrZgUhcfsrZjibvB3APXf2a1VwCmMQ=
 github.com/opensearch-project/opensearch-go/v2 v2.3.0/go.mod h1:8LDr9FCgUTVoT+5ESjc2+iaZuldqE+23Iq0r1XeNue8=
-github.com/oracle/oci-go-sdk/v65 v65.107.0 h1:ZBnDn495o4beF+bidJuIDYubwEVypiOhtVrmIQd0kWY=
-github.com/oracle/oci-go-sdk/v65 v65.107.0/go.mod h1:8ZzvzuEG/cFLFZhxg/Mg1w19KqyXBKO3c17QIc5PkGs=
+github.com/oracle/oci-go-sdk/v65 v65.117.1 h1:DurEtbj8xEuF2B6K73uifNqWJ4dh6CJPADVmNzclrGU=
+github.com/oracle/oci-go-sdk/v65 v65.117.1/go.mod h1:oo33NDf2XPqx3/N6oLG4jFlrqJ0xu4Rlt9SfuAbtDFs=
 github.com/parquet-go/parquet-go v0.25.1 h1:l7jJwNM0xrk0cnIIptWMtnSnuxRkwq53S+Po3KG8Xgo=
 github.com/parquet-go/parquet-go v0.25.1/go.mod h1:AXBuotO1XiBtcqJb/FKFyjBG4aqa3aQAAWF3ZPzCanY=
 github.com/pascaldekloe/name v1.0.1 h1:9lnXOHeqeHHnWLbKfH6X98+4+ETVqFqxN09UXSjcMb0=
@@ -1281,8 +1281,8 @@ github.com/sirupsen/logrus v1.9.4 h1:TsZE7l11zFCLZnZ+teH4Umoq5BhEIfIzfRDZ1Uzql2w
 github.com/sirupsen/logrus v1.9.4/go.mod h1:ftWc9WdOfJ0a92nsE2jF5u5ZwH8Bv2zdeOC42RjbV2g=
 github.com/snowflakedb/gosnowflake v1.17.0 h1:be50vC0buiOitvneyRHiqNkvPMcunGD3EcTnL2zYATg=
 github.com/snowflakedb/gosnowflake v1.17.0/go.mod h1:TaHvQGh9MA2lopZZMm1AvvENDfwcnKtuskIr1e6Fpic=
-github.com/sony/gobreaker v0.5.0 h1:dRCvqm0P490vZPmy7ppEk2qCnCieBooFJ+YoXGYB+yg=
-github.com/sony/gobreaker v0.5.0/go.mod h1:ZKptC7FHNvhBz7dN2LGjPVBz2sZJmc0/PkyDJOjmxWY=
+github.com/sony/gobreaker/v2 v2.4.0 h1:g2KJRW1Ubty3+ZOcSEUN7K+REQJdN6yo6XvaML+jptg=
+github.com/sony/gobreaker/v2 v2.4.0/go.mod h1:pTyFJgcZ3h2tdQVLZZruK2C0eoFL1fb/G83wK1ZQl+s=
 github.com/spf13/afero v1.15.0 h1:b/YBCLWAJdFWJTN9cLhiXXcD7mzKn9Dm86dNnfyQw1I=
 github.com/spf13/afero v1.15.0/go.mod h1:NC2ByUVxtQs4b3sIUphxK0NioZnmxgyCrfzeuq8lxMg=
 github.com/spf13/cast v1.10.0 h1:h2x0u2shc1QuLHfxi+cTJvs30+ZAHOGRic8uyGTDWxY=

--- a/integrations/event-handler/go.mod
+++ b/integrations/event-handler/go.mod
@@ -274,7 +274,7 @@ require (
 	github.com/openai/openai-go/v3 v3.8.1 // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.1.1 // indirect
-	github.com/oracle/oci-go-sdk/v65 v65.107.0 // indirect
+	github.com/oracle/oci-go-sdk/v65 v65.117.1 // indirect
 	github.com/patrickmn/go-cache v2.1.1-0.20191004192108-46f407853014+incompatible // indirect
 	github.com/peterbourgon/diskv v2.0.1+incompatible // indirect
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c // indirect
@@ -307,7 +307,7 @@ require (
 	github.com/sigstore/timestamp-authority/v2 v2.0.6 // indirect
 	github.com/sijms/go-ora/v2 v2.9.0 // indirect
 	github.com/sirupsen/logrus v1.9.4 // indirect
-	github.com/sony/gobreaker v0.5.0 // indirect
+	github.com/sony/gobreaker/v2 v2.4.0 // indirect
 	github.com/spf13/cast v1.10.0 // indirect
 	github.com/spf13/cobra v1.10.2 // indirect
 	github.com/spf13/pflag v1.0.10 // indirect

--- a/integrations/event-handler/go.sum
+++ b/integrations/event-handler/go.sum
@@ -741,8 +741,8 @@ github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/opencontainers/image-spec v1.1.1 h1:y0fUlFfIZhPF1W537XOLg0/fcx6zcHCJwooC2xJA040=
 github.com/opencontainers/image-spec v1.1.1/go.mod h1:qpqAh3Dmcf36wStyyWU+kCeDgrGnAve2nCC8+7h8Q0M=
-github.com/oracle/oci-go-sdk/v65 v65.107.0 h1:ZBnDn495o4beF+bidJuIDYubwEVypiOhtVrmIQd0kWY=
-github.com/oracle/oci-go-sdk/v65 v65.107.0/go.mod h1:8ZzvzuEG/cFLFZhxg/Mg1w19KqyXBKO3c17QIc5PkGs=
+github.com/oracle/oci-go-sdk/v65 v65.117.1 h1:DurEtbj8xEuF2B6K73uifNqWJ4dh6CJPADVmNzclrGU=
+github.com/oracle/oci-go-sdk/v65 v65.117.1/go.mod h1:oo33NDf2XPqx3/N6oLG4jFlrqJ0xu4Rlt9SfuAbtDFs=
 github.com/patrickmn/go-cache v2.1.1-0.20191004192108-46f407853014+incompatible h1:IWzUvJ72xMjmrjR9q3H1PF+jwdN0uNQiR2t1BLNalyo=
 github.com/patrickmn/go-cache v2.1.1-0.20191004192108-46f407853014+incompatible/go.mod h1:3Qf8kWWT7OJRJbdiICTKqZju1ZixQ/KpMGzzAfe6+WQ=
 github.com/pavlo-v-chernykh/keystore-go/v4 v4.5.0 h1:2nosf3P75OZv2/ZO/9Px5ZgZ5gbKrzA3joN1QMfOGMQ=
@@ -863,8 +863,8 @@ github.com/sijms/go-ora/v2 v2.9.0 h1:+iQbUeTeCOFMb5BsOMgUhV8KWyrv9yjKpcK4x7+MFrg
 github.com/sijms/go-ora/v2 v2.9.0/go.mod h1:QgFInVi3ZWyqAiJwzBQA+nbKYKH77tdp1PYoCqhR2dU=
 github.com/sirupsen/logrus v1.9.4 h1:TsZE7l11zFCLZnZ+teH4Umoq5BhEIfIzfRDZ1Uzql2w=
 github.com/sirupsen/logrus v1.9.4/go.mod h1:ftWc9WdOfJ0a92nsE2jF5u5ZwH8Bv2zdeOC42RjbV2g=
-github.com/sony/gobreaker v0.5.0 h1:dRCvqm0P490vZPmy7ppEk2qCnCieBooFJ+YoXGYB+yg=
-github.com/sony/gobreaker v0.5.0/go.mod h1:ZKptC7FHNvhBz7dN2LGjPVBz2sZJmc0/PkyDJOjmxWY=
+github.com/sony/gobreaker/v2 v2.4.0 h1:g2KJRW1Ubty3+ZOcSEUN7K+REQJdN6yo6XvaML+jptg=
+github.com/sony/gobreaker/v2 v2.4.0/go.mod h1:pTyFJgcZ3h2tdQVLZZruK2C0eoFL1fb/G83wK1ZQl+s=
 github.com/spf13/cast v1.10.0 h1:h2x0u2shc1QuLHfxi+cTJvs30+ZAHOGRic8uyGTDWxY=
 github.com/spf13/cast v1.10.0/go.mod h1:jNfB8QC9IA6ZuY2ZjDp0KtFO2LZZlg4S/7bzP6qqeHo=
 github.com/spf13/cobra v1.10.2 h1:DMTTonx5m65Ic0GOoRY2c16WCbHxOOw6xxezuLaBpcU=

--- a/integrations/terraform-mwi/go.mod
+++ b/integrations/terraform-mwi/go.mod
@@ -363,7 +363,7 @@ require (
 	github.com/opencontainers/image-spec v1.1.1 // indirect
 	github.com/opencontainers/selinux v1.13.1 // indirect
 	github.com/opensearch-project/opensearch-go/v2 v2.3.0 // indirect
-	github.com/oracle/oci-go-sdk/v65 v65.107.0 // indirect
+	github.com/oracle/oci-go-sdk/v65 v65.117.1 // indirect
 	github.com/parquet-go/parquet-go v0.25.1 // indirect
 	github.com/patrickmn/go-cache v2.1.1-0.20191004192108-46f407853014+incompatible // indirect
 	github.com/paulmach/orb v0.11.1 // indirect
@@ -415,7 +415,7 @@ require (
 	github.com/sigstore/timestamp-authority/v2 v2.0.6 // indirect
 	github.com/sijms/go-ora/v2 v2.9.0 // indirect
 	github.com/sirupsen/logrus v1.9.4 // indirect
-	github.com/sony/gobreaker v0.5.0 // indirect
+	github.com/sony/gobreaker/v2 v2.4.0 // indirect
 	github.com/spf13/cast v1.10.0 // indirect
 	github.com/spf13/cobra v1.10.2 // indirect
 	github.com/spf13/pflag v1.0.10 // indirect

--- a/integrations/terraform-mwi/go.sum
+++ b/integrations/terraform-mwi/go.sum
@@ -1065,8 +1065,8 @@ github.com/opencontainers/image-spec v1.1.1 h1:y0fUlFfIZhPF1W537XOLg0/fcx6zcHCJw
 github.com/opencontainers/image-spec v1.1.1/go.mod h1:qpqAh3Dmcf36wStyyWU+kCeDgrGnAve2nCC8+7h8Q0M=
 github.com/opensearch-project/opensearch-go/v2 v2.3.0 h1:nQIEMr+A92CkhHrZgUhcfsrZjibvB3APXf2a1VwCmMQ=
 github.com/opensearch-project/opensearch-go/v2 v2.3.0/go.mod h1:8LDr9FCgUTVoT+5ESjc2+iaZuldqE+23Iq0r1XeNue8=
-github.com/oracle/oci-go-sdk/v65 v65.107.0 h1:ZBnDn495o4beF+bidJuIDYubwEVypiOhtVrmIQd0kWY=
-github.com/oracle/oci-go-sdk/v65 v65.107.0/go.mod h1:8ZzvzuEG/cFLFZhxg/Mg1w19KqyXBKO3c17QIc5PkGs=
+github.com/oracle/oci-go-sdk/v65 v65.117.1 h1:DurEtbj8xEuF2B6K73uifNqWJ4dh6CJPADVmNzclrGU=
+github.com/oracle/oci-go-sdk/v65 v65.117.1/go.mod h1:oo33NDf2XPqx3/N6oLG4jFlrqJ0xu4Rlt9SfuAbtDFs=
 github.com/parquet-go/parquet-go v0.25.1 h1:l7jJwNM0xrk0cnIIptWMtnSnuxRkwq53S+Po3KG8Xgo=
 github.com/parquet-go/parquet-go v0.25.1/go.mod h1:AXBuotO1XiBtcqJb/FKFyjBG4aqa3aQAAWF3ZPzCanY=
 github.com/pascaldekloe/name v1.0.1 h1:9lnXOHeqeHHnWLbKfH6X98+4+ETVqFqxN09UXSjcMb0=
@@ -1216,8 +1216,8 @@ github.com/skeema/knownhosts v1.3.1 h1:X2osQ+RAjK76shCbvhHHHVl3ZlgDm8apHEHFqRjnB
 github.com/skeema/knownhosts v1.3.1/go.mod h1:r7KTdC8l4uxWRyK2TpQZ/1o5HaSzh06ePQNxPwTcfiY=
 github.com/snowflakedb/gosnowflake v1.17.0 h1:be50vC0buiOitvneyRHiqNkvPMcunGD3EcTnL2zYATg=
 github.com/snowflakedb/gosnowflake v1.17.0/go.mod h1:TaHvQGh9MA2lopZZMm1AvvENDfwcnKtuskIr1e6Fpic=
-github.com/sony/gobreaker v0.5.0 h1:dRCvqm0P490vZPmy7ppEk2qCnCieBooFJ+YoXGYB+yg=
-github.com/sony/gobreaker v0.5.0/go.mod h1:ZKptC7FHNvhBz7dN2LGjPVBz2sZJmc0/PkyDJOjmxWY=
+github.com/sony/gobreaker/v2 v2.4.0 h1:g2KJRW1Ubty3+ZOcSEUN7K+REQJdN6yo6XvaML+jptg=
+github.com/sony/gobreaker/v2 v2.4.0/go.mod h1:pTyFJgcZ3h2tdQVLZZruK2C0eoFL1fb/G83wK1ZQl+s=
 github.com/spf13/cast v1.10.0 h1:h2x0u2shc1QuLHfxi+cTJvs30+ZAHOGRic8uyGTDWxY=
 github.com/spf13/cast v1.10.0/go.mod h1:jNfB8QC9IA6ZuY2ZjDp0KtFO2LZZlg4S/7bzP6qqeHo=
 github.com/spf13/cobra v1.10.2 h1:DMTTonx5m65Ic0GOoRY2c16WCbHxOOw6xxezuLaBpcU=

--- a/integrations/terraform/go.mod
+++ b/integrations/terraform/go.mod
@@ -365,7 +365,7 @@ require (
 	github.com/opencontainers/image-spec v1.1.1 // indirect
 	github.com/opencontainers/selinux v1.13.1 // indirect
 	github.com/opensearch-project/opensearch-go/v2 v2.3.0 // indirect
-	github.com/oracle/oci-go-sdk/v65 v65.107.0 // indirect
+	github.com/oracle/oci-go-sdk/v65 v65.117.1 // indirect
 	github.com/parquet-go/parquet-go v0.25.1 // indirect
 	github.com/patrickmn/go-cache v2.1.1-0.20191004192108-46f407853014+incompatible // indirect
 	github.com/paulmach/orb v0.11.1 // indirect
@@ -417,7 +417,7 @@ require (
 	github.com/sigstore/timestamp-authority/v2 v2.0.6 // indirect
 	github.com/sijms/go-ora/v2 v2.9.0 // indirect
 	github.com/sirupsen/logrus v1.9.4 // indirect
-	github.com/sony/gobreaker v0.5.0 // indirect
+	github.com/sony/gobreaker/v2 v2.4.0 // indirect
 	github.com/spf13/cast v1.10.0 // indirect
 	github.com/spf13/cobra v1.10.2 // indirect
 	github.com/spf13/pflag v1.0.10 // indirect

--- a/integrations/terraform/go.sum
+++ b/integrations/terraform/go.sum
@@ -1220,8 +1220,8 @@ github.com/opencontainers/image-spec v1.1.1 h1:y0fUlFfIZhPF1W537XOLg0/fcx6zcHCJw
 github.com/opencontainers/image-spec v1.1.1/go.mod h1:qpqAh3Dmcf36wStyyWU+kCeDgrGnAve2nCC8+7h8Q0M=
 github.com/opensearch-project/opensearch-go/v2 v2.3.0 h1:nQIEMr+A92CkhHrZgUhcfsrZjibvB3APXf2a1VwCmMQ=
 github.com/opensearch-project/opensearch-go/v2 v2.3.0/go.mod h1:8LDr9FCgUTVoT+5ESjc2+iaZuldqE+23Iq0r1XeNue8=
-github.com/oracle/oci-go-sdk/v65 v65.107.0 h1:ZBnDn495o4beF+bidJuIDYubwEVypiOhtVrmIQd0kWY=
-github.com/oracle/oci-go-sdk/v65 v65.107.0/go.mod h1:8ZzvzuEG/cFLFZhxg/Mg1w19KqyXBKO3c17QIc5PkGs=
+github.com/oracle/oci-go-sdk/v65 v65.117.1 h1:DurEtbj8xEuF2B6K73uifNqWJ4dh6CJPADVmNzclrGU=
+github.com/oracle/oci-go-sdk/v65 v65.117.1/go.mod h1:oo33NDf2XPqx3/N6oLG4jFlrqJ0xu4Rlt9SfuAbtDFs=
 github.com/parquet-go/parquet-go v0.25.1 h1:l7jJwNM0xrk0cnIIptWMtnSnuxRkwq53S+Po3KG8Xgo=
 github.com/parquet-go/parquet-go v0.25.1/go.mod h1:AXBuotO1XiBtcqJb/FKFyjBG4aqa3aQAAWF3ZPzCanY=
 github.com/pascaldekloe/name v1.0.1 h1:9lnXOHeqeHHnWLbKfH6X98+4+ETVqFqxN09UXSjcMb0=
@@ -1378,8 +1378,8 @@ github.com/skeema/knownhosts v1.3.1 h1:X2osQ+RAjK76shCbvhHHHVl3ZlgDm8apHEHFqRjnB
 github.com/skeema/knownhosts v1.3.1/go.mod h1:r7KTdC8l4uxWRyK2TpQZ/1o5HaSzh06ePQNxPwTcfiY=
 github.com/snowflakedb/gosnowflake v1.17.0 h1:be50vC0buiOitvneyRHiqNkvPMcunGD3EcTnL2zYATg=
 github.com/snowflakedb/gosnowflake v1.17.0/go.mod h1:TaHvQGh9MA2lopZZMm1AvvENDfwcnKtuskIr1e6Fpic=
-github.com/sony/gobreaker v0.5.0 h1:dRCvqm0P490vZPmy7ppEk2qCnCieBooFJ+YoXGYB+yg=
-github.com/sony/gobreaker v0.5.0/go.mod h1:ZKptC7FHNvhBz7dN2LGjPVBz2sZJmc0/PkyDJOjmxWY=
+github.com/sony/gobreaker/v2 v2.4.0 h1:g2KJRW1Ubty3+ZOcSEUN7K+REQJdN6yo6XvaML+jptg=
+github.com/sony/gobreaker/v2 v2.4.0/go.mod h1:pTyFJgcZ3h2tdQVLZZruK2C0eoFL1fb/G83wK1ZQl+s=
 github.com/spf13/cast v1.10.0 h1:h2x0u2shc1QuLHfxi+cTJvs30+ZAHOGRic8uyGTDWxY=
 github.com/spf13/cast v1.10.0/go.mod h1:jNfB8QC9IA6ZuY2ZjDp0KtFO2LZZlg4S/7bzP6qqeHo=
 github.com/spf13/cobra v1.10.2 h1:DMTTonx5m65Ic0GOoRY2c16WCbHxOOw6xxezuLaBpcU=


### PR DESCRIPTION
This pulls in the latest OCI SDK in order to interact with recently introduced regions.

This includes the following regions:

- ap-kulai-2
- sa-riodejaneiro-1
- af-casablanca-1
- me-alrayyan-1






<!-- Provide a descriptive entry for the changelog of the next release. -->

Changelog: Added support for the following Oracle Cloud regions: ap-kulai-2, sa-riodejaneiro-1, af-casablanca-1, and me-alrayyan-1.


<!-- Include manual testing efforts to verify the change. -->
<!-- Detail where the tests where run and what configurations were used. -->
<!-- Include all the test cases which were run to validate the change. -->

## Manual Test Plan
### Test Environment

Locally built teleport

### Test Cases
- [x] The regions are present in the build. 

```console

strings build/teleport | rg "ap-kulai-2|sa-riodejaneiro-1|af-casablanca-1|me-alrayyan-1"

MSI_SECRET2017-09-01AppServiceCloudShell2019-08-012018-02-012020-06-01algorithm localKeyIdRegistered2019-05-01bytes */%vFreshness:multipleOffileSchemapolicyName&ParamRef{ValidationParamKind:Variables:&Variable{Mutations:&Mutation{PatchType:JSONPatch:whenScaledrollbackToAudiences:&UserInfo{Tolerance:ScaleDown:MetricSpec[]CronJob{ManagedBy:Succeeded:NotBefore:RenewTime:LeaseName:&Eviction{&Endpoint{[]ForZone{[]ForNode{Endpoints:Regarding:[]Ingress{IngressTLSFlowSchema[]Subject{ParentRef:&Overhead{SchedulingPolicyRule&RoleList{validRangecounterSetallocationSelectors:CounterSet&PodGroup{&Workload{PodGroups:driverName[]CSINode{ErrorCode:empty dataempty bodyversioning" to int (primitivesReplaceCAsCONNECTINGDisableKeyListGrantsImportTypeGrantTokenGetTagKeysTagFiltersGetKeyRingRawEncryptRawDecryptCkaPrivateCkaTrustedCkaKeyTypeCkaSubjectCkaEncryptCkaDecryptCkaEndDateCkaModulusCkaEcPointCkaOtpTimeCKR_CANCELdockerfileErrorType=updateKeysssh.ClientNewSessionssh.Run/%sSubChannelServer #%droundrobin[{%q: %v}][{%q: %s}]image: Newap-osaka-1ap-seoul-1ap-tokyo-1me-dubai-1eu-milan-1eu-paris-1ap-delhi-1ap-batam-1eu-turin-1ap-kulai-2me-alain-1ap-seoul-2ap-suwon-1%x%x%x%x%xOwnerWriteGlobalLockPolicyReadReadLockeddelay_timehttp:proxyBackslash;CenterDot;CircleDot;Congruent;Coproduct;DoubleDot;DownArrow;DownBreve;Downarrow;HumpEqual;LeftArrow;LeftFloor;Leftarrow;LessTilde;Mellintrf;MinusPlus;NotCupCap;NotExists;OverBrace;PlusMinus;Therefore;ThinSpace;TripleDot;UnionPlus;backprime;backsimeq;bigotimes;centerdot;checkmark;complexes;dotsquare;downarrow;gtrapprox;gtreqless;heartsuit;leftarrow;lesseqgtr;nparallel;nshortmid;nsubseteq;nsupseteq;pitchfork;rationals;spadesuit;subseteqq;subsetneq;supseteqq;supsetneq;therefore;triangleq;varpropto;NotSubset;gvertneqq;lvertneqq;ngeqslant;nleqslant;Copying %sCALL %s(?)%v($1, $2)REFERENCEScall %s.%ssend_errorcloud_type$elemMatchcreateUsercustomDataupdateUserorig_errorfirstBatchobject_ttlredis: nilBF.MEXISTSBF.RESERVENONSCALINGCF.MEXISTSCF.RESERVEBUCKETSIZEsaveconfigevalsha_roexpiretimehrandfieldwithvaluesJSON.CLEARJSON.MERGEsdiffstorezdiffstorewithscoresBatchWrite,sspi=warncss_heightX-Go-PprofListQueuesPurgeQueueUntagQueueTaskHandlePostalCodeWebsiteUrlaccess_arnno-commandcommand_idTHIRTY_MINCloudTrailSuppressedSUPPRESSEDTimestamp:PodMetricsactualTypetotalItemssampleRateservice_idpath_probequicv2 keyerror_codelatest_rtttimer_typeframe_typefinal_sizeecho replydynamodbavbinary setnumber setmap key %qstring setsdk#RegionDeleteItemListTablesUpdateItemProjectionHeaderListPutRequestStatementsBackupNameTableClassExportTimeExportTypeScanFilterQueryInputAWS_BACKUPMetricStatReturnDatacomprehendworkspacesGetRecords%s://%p/%sUnknown opqueue-sizeUnknown Oprepeatable/documents__vector__index_modedescendingmap_removecollectionadd_fieldsfield.nameListFieldsOPTIMISTICCOLLECTIONSPARSE_ALLSPARSE_ANYread write{%s,%s,%s}unknown %d_daterange_int4range_int8range_timestamp_tstzrangeCLIENT_SSLkrbsrvnamePGDATABASEPGPASSWORDPGPASSFILEdial errorDeallocateBYTE_ARRAYBIT_PACKEDINT(%d,%t)2010-03-31AppendBlobGenerationKMSKeyNameCustomTimekmsKeyNamecustomTimeACL.DeleteCopier.Runprojectionpeer_group
durationSlice (default %q) (default %s)stringToInt64XDG_DATA_HOMEPOD_NAMESPACEcache expiredZoneRedundantprimaryKeyUriPrimaryKeyURIstorageSizeGBStorageSizeGBcreatedByTypeCreatedByType%s://%s%s%s%supdateChannelUpdateChannellinkedServersLinkedServers{clusterName}resourceStateResourceStategroupNicknameGroupNicknamesmalldatetimeretentionDaysRetentionDayszoneRedundantproxyOverrideProxyOverridePrincipalNameResponseErrorIMDS_ENDPOINTServiceFabricDefaultToIMDSbytes %v-%v/*/runtime/asm_ResponseKind:Subresources:bodyParameterjsonReferencediscriminatormaxPropertiesminPropertiesfailurePolicyClientConfig:[]Validation{TypeChecking:rollingUpdateDaemonSetSpec[]Deployment{[]ReplicaSet{&StatefulSet{lastScaleTimeCurrentValue:AverageValue:&ScaleStatus{DaemonSetListauthenticated&TokenReview{SelectPolicy:[]MetricSpec{successPolicyfailedIndexesCronJobStatus&CronJobList{&CronJobSpec{SuccessPolicyBackoffLimit:batch/v1beta1pkixPublicKeybinaryVersiondeleteOptionsdisruptedPodsDeleteOptionsMinAvailable:ExpectedPods:EndpointHintsIngressStatus&IngressList{&IngressRule{[]IngressTLS{&IngressSpec{limitResponse[]FlowSchema{LimitResponseClusterScope:&UserSubject{IPAddressSpec&ServiceCIDR{[]PolicyRule{&ClusterRole{&RoleBinding{requestPolicyinterfaceNameVersionValue:DeviceRequest&DeviceClaim{&DeviceClass{ResourceSlice[]CounterSet{&BasicDevice{globalDefaultcontrollerReffsGroupPolicytokenRequestsreclaimPolicyCSIDriverSpecSELinuxMount:TopologyKeys:&CSINodeList{CSINodeDriver&CSINodeSpec{NodeTopology:&VolumeError{CSIDriverListGroupResourceInvalid type simple value  for CBOR map (default %v)"<panic: %s>"INVALID_STATEKeyMaterialIdNumberOfBytesReplicaRegionPrimaryRegionDISCONNECTINGECC_NIST_P384ECC_NIST_P521ReEncryptFromPendingImportKEY_AGREEMENTECDSA_SHA_384RegionFiltersTagKeyFiltersRESOURCE_TYPECreateKeyRingUNINITIALIZEDC_Encrypt: %vC_Decrypt: %vCkaCheckValueCkaModifiableCkaOtpCounterCkaResolutionCKR_CANT_LOCKCKR_MUTEX_BAD^[1-9][0-9]*$kubernetes-%stoken_expires Description=session_stateoidc.Time: %wagent: lockedssh.Setenv/%sssh.Signal/%sssh.Output/%sGrpc-Encodingclient_secretgrpc-encodingtransport: %vunix-abstractplayer closed#%02x%02x%02xca-montreal-1sa-saopaulo-1sa-santiago-1me-abudhabi-1us-saltlake-2me-dcc-doha-1me-alrayyan-1us-somerset-1eu-crissier-1me-abudhabi-3me-abudhabi-2me-abudhabi-4eu-budapest-1Oracle-GoSDK/contributesToecLogf failedno such claimsubject_token%s is invaliddefinitionurldefinitionURLDownArrowBar;DownTeeArrow;ExponentialE;GreaterEqual;GreaterTilde;HilbertSpace;HumpDownHump;Intersection;LeftArrowBar;LeftTeeArrow;LeftTriangle;LeftUpVector;NotCongruent;NotLessEqual;NotLessTilde;Proportional;RightCeiling;RoundImplies;ShortUpArrow;SquareSubset;UnderBracket;VerticalLine;blacklozenge;exponentiale;risingdotseq;triangledown;triangleleft;NotHumpEqual;varsubsetneq;varsupsetneq;credential_idinvalid flagsSSH_TELEPORT_packet_lengthdb-auto-usersCALL %s(?, ?)database_typescan_intervalMAXITERATIONSCMS.INITBYDIMgetkeysinslotJSON.ARRINDEXshardchannelsTDIGEST.RESETTS.DELETERULETS.QUERYINDEXzrangebyscoreerror_messageSNOWFLAKE_JWTPartitionReadStreamingReadio_channel_idAddPermissionDeleteMessageListQueueTagsReceiptHandleAWSAccountIdsTagQueueInputRedrivePolicyDisableRegion/enableRegionStateOrRegionprincipal_arnassumed-role/InvalidEntityLogStreamNameLastEventTime&NodeMetrics{[]PodMetrics{<unspecified>SyncWith donestream closedreset by peerurl parse: %wprofile.pprofX-Scope-OrgIDINVALID_TOKENpto (Initial)remote_updateinvalid_tokenpacket_numbermax_ack_delayreliable_sizebidirectionalpath_responseack_frequencyimmediate_ackkey_phase_bittime exceededDescribeTableAttributeTypeS3BucketOwnerStreamEnabledDeleteRequestS3SseKmsKeyIdKeyConditionsTransactItemsReplicaUpdateWriteRequestsDuplicateItemDYNAMODB_JSONResourceLabelExactCapacityShardIteratornonRepeatablefirestore: %vnot_equal_anytimestamp_addarray_reversestring_concatvector_lengthcollection_idremove_fieldsfirestore: %wDocumentAddedTargetCurrentdatabase.nameListUserCredsCloneDatabasedescribe execsavepoint sp_nummultirangeBad handshakeUnknown errorDivision by 0SCRAM-SHA-256postgresql://PGSSLROOTCERTPGSSLPASSWORDPGSERVICEFILEoutside rangeQueryPreparedcannot apply parquet-valuePublishResultKMSThrottlingazblob.UploadTemporaryHoldtemporaryHoldtimeFinalizedstorage_classcache_controlfinalize_timeBucket.CreateBucket.DeleteBucket.UpdateRequesterPayspredefinedAclnextPageTokencopySourceAclgeneration=%dObject.Readercontent-type:Object.UpdateObject.DeleteObject.Writerbad auth typeCancelRequestCloseCompleteErrorResponseGSSEncRequestParseCompleteReadyForQueryprogressTokendefer_loadingpropertyNameselicitationIdresource_linklastUpdatedAtnot supportedRunner failedenvelope_typeInvalid user.{resource_id}manifest.jsonca-client.crtimport_pkcs12-trusted_certIsPlaceholderReservedNamesunknown fieldempty messageinvalid valueOBSERVABILITYHKDF-SHA2-256OP_COMPRESSEDoctal literaljwtbundle: %wWaitOperationsaml_responseERROR_MESSAGEAGREE_UNIX_FDprimary owneralready ownerunmatched '{'unmatched ')'Dependencies:ExternalDocs:XIntOrString:XListMapKeys:XValidations:definitions/*contentSchemauri-referenceiri-referenceleading zerosmissing colonends with dotmissing slash$recursiveRefError help:
<tspan x="%.1f"sa-valparaiso-1af-casablanca-1uk-gov-london-1me-dcc-muscat-1eu-dcc-dublin-2eu-dcc-rating-2eu-dcc-rating-1eu-dcc-dublin-1eu-dcc-zurich-1oraclecloud.comDump Request %sopc-client-infoecDebugf failedDiacriticalDot;DoubleRightTee;DownLeftVector;GreaterGreater;HorizontalLine;InvisibleComma;InvisibleTimes;LeftDownVector;LeftRightArrow;Leftrightarrow;LessSlantEqual;LongRightArrow;Longrightarrow;LowerLeftArrow;NestedLessLess;NotGreaterLess;NotLessGreater;NotSubsetEqual;NotVerticalBar;OpenCurlyQuote;ReverseElement;RightTeeVector;RightVectorBar;ShortDownArrow;ShortLeftArrow;SquareSuperset;TildeFullEqual;UpperLeftArrow;ZeroWidthSpace;curvearrowleft;doublebarwedge;downdownarrows;hookrightarrow;leftleftarrows;leftrightarrow;leftthreetimes;longrightarrow;looparrowright;nshortparallel;ntriangleright;rightarrowtail;rightharpoonup;trianglelefteq;upharpoonright;origin requiredpicker requiredmissing sourcesDone copying %snext reader: %wSameSite=Strictsigning requestsending requestIgnored requestmissing user IDServerlessCachegcp-mysql-tokenmissing secretsdynamodbstreamsdb:obj_importerinvalid commandcountkeysinslotgetkeysandflagszremrangebyranksnowflake errorExecuteBatchDmlkeyboard_layoutGot ClientHellouser_channel_idnum_symbols: 1
FieldValueTooLongFieldValueTooManyUnsupported value is unimplementedunexpected state text/x-ecmascripttext/x-javascriptClientStreaming: ServerStreaming: ObjcClassPrefix: CsharpNamespace: IdentifierValue: LeadingComments: Object IdentifierObject Descriptorincorrect NR formHostUser is unsetPrivateKey is nilDeviceId is unsetinvalid lock mode%smaxStaleness=%v%shedgeEnabled=%vtlsprivatekeyfileUsername is unsetcomposite literalswitch expressionmissing scope pin\{\{([^{}]+?)\}\}bad character %#Uiam.amazonaws.comiam-govcloud-fipsGetRandomPasswordRotationLambdaARNAddReplicaRegionsExcludeCharactersRotateImmediatelyCreateSecretInputDeleteSecretInputRotateSecretInputUpdateSecretInputcontext error: %v&NonResourceRule{NonResourceRules:NOTE_EXIT_CSERRORx-goog-api-clientSwitchoverClusterGetConnectionInfoCA_SOURCE_MANAGEDSCOPE_UNSPECIFIEDSTAGE_UNSPECIFIED%s=%v&%s=%v&%s=%vSetLoggingServiceADVANCED_DATAPATHGENERATE_PASSWORDNO_MINOR_UPGRADESUPGRADE_LIFECYCLEPOD_PDB_VIOLATIONsql.databases.getsql/v1beta4/flagsenableFinalBackupsql.instances.getsql.sslCerts.listSetSecurityPolicySetDiskAutoDeleteSetMinCpuPlatformSetServiceAccountdestinationPrefixUSE_EXISTING_DISKREAD_WRITE_SINGLEUNDEFINED_SUBZONEUNDEFINED_BGP_MD5IT_PARTIAL_OUTAGECLOUD_NAT_ALLOWEDCLOUD_NAT_BLOCKEDMULTICAST_ALLOWEDMULTICAST_BLOCKEDUNDEFINED_UNICASTHIGH_AVAILABILITYENDPOINT_TYPE_SWGTRANSLATIONS_ONLYRESERVATION_BOUNDSPECIFIC_PROJECTSUNDEFINED_PROFILEALLOCATE_PER_WIREListEffectiveTagsmessage not foundgcloud-golang/0.1instance/hostnameGCE_METADATA_HOSTmetadata responseread response, %wpartition not setservice is not %sregion is not set%s region not setca-central-1-fipsrds.us-iso-east-1rds.us-iso-west-1rds.us-gov-east-1rds.us-gov-west-1no matches for %v%q is not a table%q is not a valuejob %s failed: %sPodSecurityPolicyPlaceholderFormat%s is equal to %sgenSelfSignedCert (DEPRECATED: %s)KUBERNETES_MASTERPlease enter %s: servergroups.jsoncache invalidatedmaintenanceWindowServersClient.GetprovisioningStateProvisioningStateMaxmemoryReservedminimumTlsVersionreplicasPerMasterMinimumTLSVersionReplicasPerMasterobservationMetricadministratorTypeAdministratorTypefederatedClientIdFederatedClientIDminimalTlsVersionMinimalTLSVersionintervalStartTimeIntervalStartTimeObservationMetricskipping Azure VMMSAL_FORCE_REGIONIDENTITY_ENDPOINT is not supported[^A-Za-z0-9\-._~]X-Goog-Api-Client%%!%c(dec.Dec=%s)APIGroupDiscoverySingularResource:validationActionsmessageExpression&AuditAnnotation{[]MatchCondition{&MutatingWebhook{ExpressionWarningMatchConstraints:AuditAnnotations:ValidatingWebhookdecodableVersions[]StorageVersion{numberUnavailable&DaemonSetStatus{StatefulSetStatus&StatefulSetList{&StatefulSetSpec{containerResourceTokenReviewStatus&TokenReviewSpec{MetricValueStatus&HPAScalingRules{concurrencyPolicyLastScheduleTime:PodFailurePolicy:MaxFailedIndexes:CompletedIndexes:&JobTemplateSpec{SuccessPolicyRuleSucceededIndexes:serviceAccountUIDproofOfPossessionCertificateChain:LeaseTransitions:[]LeaseCandidate{EmulationVersion:DeprecatedSource:&HTTPIngressPath{IngressPortStatusIngressRuleValue:IngressClassName:NetworkPolicySpecNetworkPolicyPortNetworkPolicyPeerNetworkPolicyListQueueLengthLimit:&ParentReference{ServiceCIDRStatus&ServiceCIDRList{&ServiceCIDRSpec{&AggregationRule{&ClusterRoleList{&RoleBindingList{distinctAttributebindingConditionsNetworkDeviceDataConsumesCounters:&DeviceAttribute{&DeviceClassList{[]DeviceSelector{&DeviceClassSpec{ConsumedCapacity:CELDeviceSelectorResourceClaimSpecResourceSliceSpec&DeviceTaintRule{scheduling.k8s.ioPriorityClassListmaximumVolumeSizerequiresRepublishvolumeBindingModeallowedTopologiesInlineVolumeSpec:storage.k8s.io/v1UTF-8 text stringcbor: cannot set not simple valuesEntraEventsStreamAzureEventsStreamNetIQEventsStreamTRANSIENT_FAILUREmissing NamespaceCancelKeyDeletionEnableKeyRotationImportKeyMaterialRotateKeyOnDemandDisabledExceptionCloudHsmClusterIdRetiringPrincipalSigningAlgorithmsParametersValidTohttps://kms-fips.TrentService.SignEncryptionContextWrappingAlgorithmGetKeyPolicyInputGetPublicKeyInputPutKeyPolicyInputReplicateKeyInputCLUSTER_NOT_FOUNDSYMMETRIC_DEFAULTIGNORE_CIPHERTEXTComplianceDetailsGetTagValuesInputTagResourcesInputAsymmetricDecryptHSM_SINGLE_TENANTC_EncryptInit: %vC_DecryptInit: %vCkaPublicExponentckfArrayAttributeCkaUnwrapTemplateCkaOtpServiceLogonot a PKCS#11 keyCKR_GENERAL_ERRORCKR_ARGUMENTS_BADCKR_DEVICE_MEMORYCKR_PIN_INCORRECTCKR_PIN_LEN_RANGECKR_SESSION_COUNTCKR_RANDOM_NO_RNGtoken_join_methodtoken has expiredredirect_disabledagent: not lockedunknown opcode %dssh.RequestPty/%s%s SubChannel #%dgrpc-message-typereading TDPB bodymissing SessionIDaf-johannesburg-1ap-dcc-canberra-1sa-riodejaneiro-1oraclegovcloud.ukoraclecloud10.comoraclecloud14.comoraclecloud15.comoraclecloud20.comoraclecloud21.comoraclecloud23.comoraclecloud24.comoraclecloud26.comoraclecloud29.comoraclecloud35.comoraclecloud42.comoraclecloud51.comoraclecloud52.comOCI_DEFAULT_REALMunknown state: %dValidateEnumValueheader-collection/identity/key.pemencoding Sign: %vdecoding Sign: %vdecoding Hash: %vdecoding Name: %vcreating seed: %vDiacriticalAcute;DiacriticalGrave;DiacriticalTilde;DoubleRightArrow;DownArrowUpArrow;EmptySmallSquare;GreaterEqualLess;GreaterFullEqual;LeftAngleBracket;LeftUpDownVector;LessEqualGreater;NonBreakingSpace;NotRightTriangle;NotSupersetEqual;RightTriangleBar;RightUpTeeVector;RightUpVectorBar;UnderParenthesis;UpArrowDownArrow;circlearrowright;downharpoonright;ntrianglerighteq;rightharpoondown;rightrightarrows;twoheadleftarrow;vartriangleright;NotPrecedesEqual;NotSucceedsEqual;NotSucceedsTilde;webauthncli/Loginavailable_methodstransferring file/opc/v2/identity/ssh.ForwardServer%v($1, $2::jsonb)Context canceled.X-ClickHouse-Userdatabase_protocolapplication/smilemissing adminUserisWritablePrimaryrefresh_thresholdObjects to deleteObjects to updateSnowflake Token="MFA_TYPE_WEBAUTHNuser cert was nilQueueDoesNotExistEmptyBatchRequestMessageAttributeshttps://sqs-fips.X-Amzn-Query-ModeVisibilityTimeout/subscriptions/%sStandardAccountIdEnableRegionInputteleport.dev/portInvalidAttributesINFREQUENT_ACCESS&NodeMetricsList{Objects extractedstreams exhaustedkeepalive timeoutQUIC_GO_LOG_LEVELAPPLICATION_ERRORnot a QUIC packet, MinAckDelay: %sUnknown EventKindapplication_errorcongestion_windowpackets_in_flightpreferred_addressnew_connection_idinvalid conn typeno such interfaceparameter problemCreateGlobalTableDescribeEndpointsUpdateGlobalTableArchivalBackupArnReadCapacityUnitsGlobalTableStatusImportedItemCountItemCollectionKeyDestinationStatusThrottlingReasonsRestoreInProgressStreamDescriptionLatestStreamLabelTableClassSummarythrottlingReasonsBackupDescriptionExportDescriptionImportSummaryListhttps://dynamodb.ReplicaTableClassExclusiveStartKeyKeysAndAttributesReplicaUpdateListTransactWriteItemBatchGetItemInputCreateBackupInputDeleteBackupInputMetricDataQueriesMaxCapacityBufferScalableDimensionScalableTargetARNScalingAdjustmentPredictiveScalingNextShardIteratorShardIteratorTypeUnknown result opbad compare valueETCD_CLIENT_DEBUGGetPartitions: %wDocumentChange %qResetUserPasswordGetBackupScheduleORDER_UNSPECIFIEDselect %s from %s= ANY($1::text[]) isolation level invalid array: %winvalid net.IPNetexpected 2 digits[(%s,%s),(%s,%s)]Failed on fseek()WSAStartup FailedFailed to drop %sIndex corrupt: %sERROR %d (%s): %sCLIENT_FOUND_ROWSinvalid packet %xinvalid ok packetPGCONNECT_TIMEOUTinvalid backslash to parquet valueBYTE_STREAM_SPLIT to node of type https://sns-fips.x-ms-or-policy-idCustomerKeySHA256X-Goog-Generationx-goog-credentialGOOG4-RSA-SHA256

```

- [x] Regions are not present in 18.8.2
```console

strings ./releases/18.8.2/teleport | rg "ap-kulai-2|sa-riodejaneiro-1|af-casablanca-1|me-alrayyan-1" 

```
