### PR TITLE
Attempt to drain the audit queue on shutdown.

### DIFF
--- a/lib/events/auditqueue/auditqueue.go
+++ b/lib/events/auditqueue/auditqueue.go
@@ -112,6 +112,12 @@ type Queue interface {
 	// Run is the single consumer that drains the queue and forwards the audit
 	// log events to `handler`.
 	Run(ctx context.Context, handler Handler) error
+	// Drain blocks until the queue is drained. It makes a best-effort attempt
+	// to forward all pending events to the consumer before shutdown. It stops
+	// adopting new orphans and waits for both the main queue and the
+	// dead-letter queue to empty or for ctx to be done, whichever comes first.
+	// Callers must still call Close.
+	Drain(ctx context.Context) error
 	// Close releases resources held by the queue.
 	Close() error
 }

--- a/lib/events/auditqueue/drain_test.go
+++ b/lib/events/auditqueue/drain_test.go
@@ -1,0 +1,263 @@
+/*
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package auditqueue
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestDrain_DrainsMainQueue(t *testing.T) {
+	t.Parallel()
+
+	for _, kind := range allKinds {
+		t.Run(string(kind), func(t *testing.T) {
+			t.Parallel()
+			ctx := t.Context()
+			q := newTestQueue(t, kind)
+
+			const n = 25
+			for i := int64(0); i < n; i++ {
+				require.NoError(t, q.Enqueue(newTestEvent(i)))
+			}
+
+			runCtx, cancel := context.WithCancel(ctx)
+			t.Cleanup(cancel)
+
+			release := make(chan struct{})
+			entered := make(chan struct{}, 1)
+			var delivered atomic.Int64
+			handler := func(_ context.Context, items []Item) []Item {
+				select {
+				case entered <- struct{}{}:
+				default:
+				}
+				<-release
+				delivered.Add(int64(len(items)))
+				return items
+			}
+			runErr := make(chan error, 1)
+			go func() { runErr <- q.Run(runCtx, handler) }()
+
+			<-entered
+
+			drainCtx, drainCancel := context.WithTimeout(ctx, testDefaultTimeout)
+			t.Cleanup(drainCancel)
+
+			drainDone := make(chan error, 1)
+			go func() { drainDone <- q.Drain(drainCtx) }()
+
+			select {
+			case <-drainDone:
+				t.Fatal("Drain returned before the queue was drained")
+			case <-time.After(100 * time.Millisecond):
+			}
+
+			close(release)
+			select {
+			case err := <-drainDone:
+				require.NoError(t, err)
+			case <-time.After(testDefaultTimeout):
+				t.Fatal("Drain did not return after the queue drained")
+			}
+			require.Equal(t, int64(n), delivered.Load())
+
+			cancel()
+			require.ErrorIs(t, <-runErr, context.Canceled)
+		})
+	}
+}
+
+func TestDrain_FlushesDeadLetter(t *testing.T) {
+	t.Parallel()
+
+	for _, kind := range allKinds {
+		t.Run(string(kind), func(t *testing.T) {
+			t.Parallel()
+			ctx := t.Context()
+			q := newTestQueueWithConfig(t, kind, Config{
+				MaxAttempts:             1,
+				DeadLetterSweepInterval: time.Hour, // only Drain may trigger sweeps
+			})
+
+			require.NoError(t, q.Enqueue(newTestEvent(0)))
+
+			var failing atomic.Bool
+			failing.Store(true)
+			var delivered atomic.Int64
+			handler := func(_ context.Context, items []Item) []Item {
+				if failing.Load() {
+					return nil
+				}
+				delivered.Add(int64(len(items)))
+				return items
+			}
+
+			runCtx, cancel := context.WithCancel(ctx)
+			t.Cleanup(cancel)
+			runErr := make(chan error, 1)
+			go func() { runErr <- q.Run(runCtx, handler) }()
+
+			// Wait for the event to exhaust its attempts and land in the
+			// dead-letter queue, emptying the main queue.
+			sq := underlyingQueue(t, q)
+			require.Eventually(t, func() bool {
+				dl, err := fetchDeadLetter(ctx, sq.db, 10)
+				return err == nil && len(dl) == 1
+			}, testDefaultTimeout, 10*time.Millisecond)
+
+			drainCtx, drainCancel := context.WithTimeout(ctx, testDefaultTimeout)
+			t.Cleanup(drainCancel)
+
+			drainDone := make(chan error, 1)
+			go func() { drainDone <- q.Drain(drainCtx) }()
+
+			select {
+			case <-drainDone:
+				t.Fatal("Drain returned while dead-letter events were pending")
+			case <-time.After(100 * time.Millisecond):
+			}
+
+			failing.Store(false)
+			select {
+			case err := <-drainDone:
+				require.NoError(t, err)
+			case <-time.After(testDefaultTimeout):
+				t.Fatal("Drain did not return after the dead-letter queue drained")
+			}
+			require.Equal(t, int64(1), delivered.Load())
+
+			cancel()
+			require.ErrorIs(t, <-runErr, context.Canceled)
+		})
+	}
+}
+
+func TestDrainKickPolicy(t *testing.T) {
+	t.Parallel()
+
+	// ticksUntilKick advances the policy until shouldKick reports true and
+	// returns how many ticks that took.
+	ticksUntilKick := func(t *testing.T, p *drainKickPolicy, deadLetterCount int64, maxTicks int) int {
+		t.Helper()
+		for i := 0; i <= maxTicks; i++ {
+			if p.shouldKick(deadLetterCount) {
+				return i
+			}
+			p.tick()
+		}
+		t.Fatalf("no kick after %d ticks", maxTicks)
+		return 0
+	}
+
+	t.Run("no kick before first tick", func(t *testing.T) {
+		t.Parallel()
+		p := newDrainKickPolicy()
+		require.False(t, p.shouldKick(10), "must not kick immediately after the initial synchronous sweep")
+		p.tick()
+		require.True(t, p.shouldKick(10))
+	})
+
+	t.Run("backoff doubles without progress", func(t *testing.T) {
+		t.Parallel()
+		p := newDrainKickPolicy()
+		ticksUntilKick(t, p, 10, 1)
+		require.Equal(t, 2, ticksUntilKick(t, p, 10, 10))
+		require.Equal(t, 4, ticksUntilKick(t, p, 10, 10))
+		require.Equal(t, 8, ticksUntilKick(t, p, 10, 10))
+	})
+
+	t.Run("backoff caps at maxDrainKickBackoff", func(t *testing.T) {
+		t.Parallel()
+		p := newDrainKickPolicy()
+		maxTicks := int(maxDrainKickBackoff/pollInterval) + 1
+		for range 20 {
+			ticksUntilKick(t, p, 10, maxTicks)
+		}
+		require.Equal(t, int(maxDrainKickBackoff/pollInterval), ticksUntilKick(t, p, 10, maxTicks))
+	})
+
+	t.Run("progress kicks immediately and resets backoff", func(t *testing.T) {
+		t.Parallel()
+		p := newDrainKickPolicy()
+		ticksUntilKick(t, p, 10, 1)
+		ticksUntilKick(t, p, 10, 10)
+		ticksUntilKick(t, p, 10, 10)
+		require.True(t, p.shouldKick(9), "shrinking dead-letter queue must kick immediately")
+		require.Equal(t, 1, ticksUntilKick(t, p, 9, 10), "backoff must reset after progress")
+	})
+
+	t.Run("growing count is not progress", func(t *testing.T) {
+		t.Parallel()
+		p := newDrainKickPolicy()
+		ticksUntilKick(t, p, 10, 1)
+		require.False(t, p.shouldKick(15), "new dead-letter promotions must not bypass the backoff")
+		require.Equal(t, 2, ticksUntilKick(t, p, 15, 10))
+	})
+}
+
+func TestDrain_RespectsContextDeadline(t *testing.T) {
+	t.Parallel()
+
+	for _, kind := range allKinds {
+		t.Run(string(kind), func(t *testing.T) {
+			t.Parallel()
+			ctx := t.Context()
+			q := newTestQueue(t, kind)
+
+			const n = 5
+			for i := int64(0); i < n; i++ {
+				require.NoError(t, q.Enqueue(newTestEvent(i)))
+			}
+
+			drainCtx, drainCancel := context.WithTimeout(ctx, 100*time.Millisecond)
+			t.Cleanup(drainCancel)
+
+			drainDone := make(chan error, 1)
+			go func() { drainDone <- q.Drain(drainCtx) }()
+			select {
+			case err := <-drainDone:
+				require.ErrorIs(t, err, context.DeadlineExceeded)
+			case <-time.After(testDefaultTimeout):
+				t.Fatal("Drain did not return after its deadline expired")
+			}
+
+			runCtx, cancel := context.WithCancel(ctx)
+			t.Cleanup(cancel)
+			var delivered atomic.Int64
+			handler := func(_ context.Context, items []Item) []Item {
+				delivered.Add(int64(len(items)))
+				return items
+			}
+			runErr := make(chan error, 1)
+			go func() { runErr <- q.Run(runCtx, handler) }()
+
+			require.Eventually(t, func() bool {
+				return delivered.Load() == int64(n)
+			}, testDefaultTimeout, 10*time.Millisecond)
+
+			cancel()
+			require.ErrorIs(t, <-runErr, context.Canceled)
+		})
+	}
+}

--- a/lib/events/auditqueue/sqlite.go
+++ b/lib/events/auditqueue/sqlite.go
@@ -47,6 +47,7 @@ const (
 	defaultMaxAttempts             = 10
 	defaultDeadLetterSweepInterval = 10 * time.Minute
 	defaultDeadLetterTTL           = 30 * 24 * time.Hour // 30 days
+	maxDrainKickBackoff            = 30 * time.Second
 
 	// We've run benchmarks and found a batch size of 25 to be a good middle
 	// ground between insertion performance and memory overhead of
@@ -117,6 +118,10 @@ type writeRequest struct {
 	resp    chan error
 }
 
+type sweepRequest struct {
+	done chan struct{}
+}
+
 type sqliteQueue struct {
 	db   *sql.DB
 	path string
@@ -130,6 +135,9 @@ type sqliteQueue struct {
 	cancel                  context.CancelFunc
 	wg                      sync.WaitGroup
 	closeOnce               sync.Once
+	drainOnce               sync.Once
+	drainCh                 chan struct{}
+	sweepCh                 chan sweepRequest
 	parentDir               string
 	selfStat                os.FileInfo
 	unlock                  func() error
@@ -192,6 +200,8 @@ func newBaseQueue(db *sql.DB, cfg Config) (*sqliteQueue, error) {
 	q := &sqliteQueue{
 		db:                      db,
 		toBeWritten:             make(chan writeRequest),
+		drainCh:                 make(chan struct{}),
+		sweepCh:                 make(chan sweepRequest),
 		maxBatch:                defaultMaxBatch,
 		ctx:                     ctx,
 		cancel:                  cancel,
@@ -471,6 +481,102 @@ func (q *sqliteQueue) ackWithRetry(ctx context.Context, items []Item) error {
 	}
 }
 
+// Drain exits when both the main audit queue and the dead-letter queue are
+// empty. It allows one to await the draining of the queue on shutdown. Run is
+// executed in the background and will continue to drain the queue. Corrupt
+// events are excluded. They cannot be delivered, so waiting on them would
+// stall every shutdown until the drain deadline.
+func (q *sqliteQueue) Drain(ctx context.Context) error {
+	q.drainOnce.Do(func() { close(q.drainCh) })
+
+	// Trigger and wait for a dead letter sweep.
+	req := sweepRequest{done: make(chan struct{})}
+	select {
+	case q.sweepCh <- req:
+	case <-ctx.Done():
+		return trace.Wrap(ctx.Err())
+	case <-q.ctx.Done():
+		return trace.Wrap(q.ctx.Err())
+	}
+	select {
+	case <-req.done:
+	case <-ctx.Done():
+		return trace.Wrap(ctx.Err())
+	case <-q.ctx.Done():
+		return trace.Wrap(q.ctx.Err())
+	}
+
+	ticker := time.NewTicker(pollInterval)
+	defer ticker.Stop()
+	policy := newDrainKickPolicy()
+	var lastErr error
+	for {
+		mainEmpty, deadLetterCount, err := drainQueueState(ctx, q.db)
+		lastErr = err
+		if err != nil {
+			slog.ErrorContext(ctx,
+				"Failed to check whether audit queue is empty while draining.",
+				"error", err,
+			)
+		} else if mainEmpty && deadLetterCount == 0 {
+			return nil
+		} else if mainEmpty && policy.shouldKick(deadLetterCount) {
+			q.kickDeadLetterSweep()
+		}
+
+		select {
+		case <-ctx.Done():
+			return trace.NewAggregate(ctx.Err(), lastErr)
+		case <-q.ctx.Done():
+			return trace.NewAggregate(q.ctx.Err(), lastErr)
+		case <-ticker.C:
+		}
+		policy.tick()
+	}
+}
+
+type drainKickPolicy struct {
+	backoff       time.Duration
+	sinceLastKick time.Duration
+	lastCount     int64
+}
+
+func newDrainKickPolicy() *drainKickPolicy {
+	return &drainKickPolicy{
+		backoff:   pollInterval,
+		lastCount: -1,
+	}
+}
+
+func (p *drainKickPolicy) shouldKick(deadLetterCount int64) bool {
+	progressed := p.lastCount >= 0 && deadLetterCount < p.lastCount
+	p.lastCount = deadLetterCount
+	if progressed {
+		p.backoff = pollInterval
+	} else if p.sinceLastKick < p.backoff {
+		return false
+	} else {
+		p.backoff = min(p.backoff*2, maxDrainKickBackoff)
+	}
+	p.sinceLastKick = 0
+	return true
+}
+
+func (p *drainKickPolicy) tick() {
+	p.sinceLastKick += pollInterval
+}
+
+const drainQueueStateQuery = `SELECT
+	NOT EXISTS(SELECT 1 FROM audit_queue),
+	(SELECT COUNT(*) FROM audit_dead_letter)`
+
+func drainQueueState(ctx context.Context, db *sql.DB) (mainEmpty bool, deadLetterCount int64, _ error) {
+	if err := db.QueryRowContext(ctx, drainQueueStateQuery).Scan(&mainEmpty, &deadLetterCount); err != nil {
+		return false, 0, trace.Wrap(err)
+	}
+	return mainEmpty, deadLetterCount, nil
+}
+
 func (q *sqliteQueue) handleDeliveryFailures(ctx context.Context, items []Item, successfullyDelivered []Item) {
 	failed := itemsNotIn(items, successfullyDelivered)
 	if len(failed) == 0 {
@@ -597,14 +703,20 @@ func (q *sqliteQueue) deadLetterSweepLoop(ctx context.Context, handler Handler) 
 			return
 		case <-q.ctx.Done():
 			return
+		case req := <-q.sweepCh:
+			// Trigger a sweep on-demand.
+			q.runSweeps(ctx, handler)
+			close(req.done)
+			timer.Reset(q.deadLetterSweepInterval)
 		case <-timer.C:
+			// Trigger a sweep on a timer.
+			q.runSweeps(ctx, handler)
+			timer.Reset(q.deadLetterSweepInterval)
 		case <-q.deadLetterKick:
+			// Trigger a sweep when delivery recovers after failing.
+			q.runSweeps(ctx, handler)
+			timer.Reset(q.deadLetterSweepInterval)
 		}
-		q.sweepDeadLetter(ctx, handler)
-		q.expireDeadLetter()
-		q.recoverCorruptEvents()
-		q.expireCorruptEvents()
-		timer.Reset(q.deadLetterSweepInterval)
 	}
 }
 
@@ -615,6 +727,13 @@ func (q *sqliteQueue) kickDeadLetterSweep() {
 	case q.deadLetterKick <- struct{}{}:
 	default:
 	}
+}
+
+func (q *sqliteQueue) runSweeps(ctx context.Context, handler Handler) {
+	q.sweepDeadLetter(ctx, handler)
+	q.expireDeadLetter()
+	q.recoverCorruptEvents()
+	q.expireCorruptEvents()
 }
 
 func (q *sqliteQueue) sweepDeadLetter(ctx context.Context, handler Handler) {
@@ -673,22 +792,6 @@ func (q *sqliteQueue) fetchDeadLetterRange(afterID, maxID int64, limit int) ([]I
 	rows, err := q.db.QueryContext(q.ctx,
 		"SELECT id, payload FROM audit_dead_letter WHERE id > ? AND id <= ? ORDER BY id ASC LIMIT ?",
 		afterID, maxID, limit)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	items, corrupt, err := scanItems(rows)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	handleCorrupt(q.ctx, q.db, auditDeadLetterTable, corrupt)
-	return items, nil
-}
-
-// fetchDeadLetter reads up to `limit` oldest items from the audit_dead_letter
-// table, quarantining any rows whose payload fails to deserialize.
-func (q *sqliteQueue) fetchDeadLetter(limit int) ([]Item, error) {
-	rows, err := q.db.QueryContext(q.ctx,
-		"SELECT id, payload FROM audit_dead_letter ORDER BY id ASC LIMIT ?", limit)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/events/auditqueue/sqlite_disk.go
+++ b/lib/events/auditqueue/sqlite_disk.go
@@ -307,7 +307,7 @@ func (q *sqliteQueue) Run(ctx context.Context, handler Handler) error {
 func (q *sqliteQueue) orphanScanLoop(ctx context.Context) {
 	ticker := time.NewTicker(q.orphanScanInterval)
 	defer ticker.Stop()
-	for {
+	for !q.isDraining() {
 		q.sweepStaleTmp()
 		q.adoptOrphans(ctx)
 
@@ -316,8 +316,19 @@ func (q *sqliteQueue) orphanScanLoop(ctx context.Context) {
 			return
 		case <-q.ctx.Done():
 			return
+		case <-q.drainCh:
+			return
 		case <-ticker.C:
 		}
+	}
+}
+
+func (q *sqliteQueue) isDraining() bool {
+	select {
+	case <-q.drainCh:
+		return true
+	default:
+		return false
 	}
 }
 

--- a/lib/events/auditqueue/sqlite_memory.go
+++ b/lib/events/auditqueue/sqlite_memory.go
@@ -131,6 +131,12 @@ func (m *sqliteInMemoryQueue) Run(ctx context.Context, handler Handler) error {
 	return m.inner.runPollLoop(ctx, handler)
 }
 
+// Drain makes a best-effort attempt to flush pending events upstream before
+// shutdown. See Queue.Drain.
+func (m *sqliteInMemoryQueue) Drain(ctx context.Context) error {
+	return m.inner.Drain(ctx)
+}
+
 // Close shuts down the in-memory queue.
 func (m *sqliteInMemoryQueue) Close() error {
 	var err error

--- a/lib/events/auditqueue/sqlite_test.go
+++ b/lib/events/auditqueue/sqlite_test.go
@@ -1254,7 +1254,9 @@ func TestFetchDeadLetter_QuarantinesCorrupt(t *testing.T) {
 		corruptPayload, time.Now().Unix())
 	require.NoError(t, err)
 
-	items, err := q.fetchDeadLetter(10)
+	maxID, err := q.maxDeadLetterID()
+	require.NoError(t, err)
+	items, err := q.fetchDeadLetterRange(0, maxID, 10)
 	require.NoError(t, err)
 	require.Empty(t, items)
 

--- a/lib/events/emitter.go
+++ b/lib/events/emitter.go
@@ -169,6 +169,22 @@ func (a *AsyncEmitter) Close() error {
 	return nil
 }
 
+// Shutdown makes a best effort attempt to flush pending audit events to the
+// inner emitter before closing.
+func (a *AsyncEmitter) Shutdown(ctx context.Context) error {
+	if a.queue != nil {
+		if err := a.queue.Drain(ctx); err != nil {
+			slog.WarnContext(ctx,
+				"Audit queue drain returned an error during graceful shutdown.",
+				"error", err,
+			)
+		}
+		return trace.Wrap(a.Close())
+	}
+
+	return trace.Wrap(a.Close())
+}
+
 func (a *AsyncEmitter) forward() {
 	for {
 		select {
@@ -198,15 +214,26 @@ func (a *AsyncEmitter) deliver(ctx context.Context, items []auditqueue.Item) []a
 	// interface. I suspect that having first-class batching will have a greater
 	// improvement on performance over parallelism alone. It will also have less
 	// overhead than parallelism over multiple events.
+	var failed int
+	var firstErr error
 	for _, item := range items {
 		if ctx.Err() != nil {
-			return successfullyDelivered
+			break
 		}
 		if err := a.cfg.Inner.EmitAuditEvent(ctx, item.Event); err != nil {
-			slog.ErrorContext(ctx, "Failed to emit audit event.", "error", err)
+			failed++
+			if firstErr == nil {
+				firstErr = err
+			}
 			continue
 		}
 		successfullyDelivered = append(successfullyDelivered, item)
+	}
+	if failed > 0 && ctx.Err() == nil {
+		slog.ErrorContext(ctx, "Failed to emit audit events.",
+			"count", failed,
+			"error", firstErr,
+		)
 	}
 	return successfullyDelivered
 }
@@ -332,6 +359,12 @@ func NewCheckingAsyncEmitter(checkingCfg CheckingEmitterConfig, asyncCfg AsyncEm
 // Close closes the underlying AsyncEmitter.
 func (c *CheckingAsyncEmitter) Close() error {
 	return c.asyncEmitter.Close()
+}
+
+// Shutdown attempts to drain the underlying AsyncEmitter before closing.
+// See AsyncEmitter.Shutdown.
+func (c *CheckingAsyncEmitter) Shutdown(ctx context.Context) error {
+	return c.asyncEmitter.Shutdown(ctx)
 }
 
 // checkAndSetEventFields updates passed event fields with additional information

--- a/lib/events/emitter_test.go
+++ b/lib/events/emitter_test.go
@@ -378,3 +378,26 @@ func TestAsyncEmitterAuditQueueBackends(t *testing.T) {
 		}
 	})
 }
+
+func TestAsyncEmitterShutdownDrainsQueue(t *testing.T) {
+	ctx := t.Context()
+	counter := eventstest.NewCountingEmitter()
+	emitter, err := events.NewAsyncEmitter(events.AsyncEmitterConfig{
+		Inner:              counter,
+		EnableAuditQueue:   true,
+		AuditQueueBackends: []auditqueue.Kind{auditqueue.KindSQLiteMemory},
+	})
+	require.NoError(t, err)
+
+	evts := eventstest.GenerateTestSession(eventstest.SessionParams{PrintEvents: 20})
+	for _, e := range evts {
+		require.NoError(t, emitter.EmitAuditEvent(ctx, e))
+	}
+
+	shutdownCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	t.Cleanup(cancel)
+	require.NoError(t, emitter.Shutdown(shutdownCtx))
+
+	require.EqualValues(t, len(evts), counter.Count(),
+		"Shutdown should drain every enqueued event to the inner emitter")
+}

--- a/lib/events/fallback_emitter.go
+++ b/lib/events/fallback_emitter.go
@@ -187,3 +187,17 @@ func (f *FallbackEmitter) Close() error {
 	}
 	return nil
 }
+
+// Shutdown makes a best effort attempt to flush pending audit events to the
+// inner emitter before closing.
+func (f *FallbackEmitter) Shutdown(ctx context.Context) error {
+	if f.queue != nil {
+		if err := f.queue.Drain(ctx); err != nil {
+			slog.WarnContext(ctx,
+				"Audit fallback queue drain returned an error during graceful shutdown.",
+				"error", err,
+			)
+		}
+	}
+	return trace.Wrap(f.Close())
+}

--- a/lib/events/fallback_emitter_test.go
+++ b/lib/events/fallback_emitter_test.go
@@ -139,6 +139,50 @@ func TestFallbackEmitter_QueueDisabled(t *testing.T) {
 	require.Equal(t, 1, primary.count())
 }
 
+func TestFallbackEmitter_ShutdownDrains(t *testing.T) {
+	t.Parallel()
+	primary := &fakePrimary{}
+	primary.setFail(true)
+
+	e, err := events.NewFallbackEmitter(events.FallbackEmitterConfig{
+		Primary:            primary,
+		DataDir:            t.TempDir(),
+		EnableAuditQueue:   true,
+		AuditQueueCfg:      auditqueue.Config{MaxAttempts: 1_000_000},
+		AuditQueueBackends: []auditqueue.Kind{auditqueue.KindSQLiteMemory},
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = e.Close() })
+
+	const n = 5
+	for range n {
+		require.NoError(t, e.EmitAuditEvent(t.Context(), testEvent()))
+	}
+	require.Equal(t, 0, primary.count(), "events should be queued while the backend is down")
+
+	primary.setFail(false)
+	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
+	t.Cleanup(cancel)
+	require.NoError(t, e.Shutdown(ctx))
+	require.Equal(t, n, primary.count(), "Shutdown should flush all queued events to the primary")
+}
+
+func TestFallbackEmitter_CloseDoesNotDrain(t *testing.T) {
+	t.Parallel()
+	primary := &fakePrimary{}
+	primary.setFail(true)
+	e := newFallbackTestEmitter(t, primary, true)
+
+	require.NoError(t, e.EmitAuditEvent(t.Context(), testEvent()))
+	require.Equal(t, 0, primary.count())
+
+	require.NoError(t, e.Close())
+	primary.setFail(false)
+	require.Never(t, func() bool {
+		return primary.count() > 0
+	}, time.Second, 50*time.Millisecond, "Close must not drain queued events")
+}
+
 type authBoundary struct {
 	fallback apievents.Emitter
 }

--- a/lib/service/db.go
+++ b/lib/service/db.go
@@ -227,12 +227,10 @@ func (process *TeleportProcess) initDatabaseService() (retErr error) {
 				warnOnErr(process.ExitContext(), dbService.Shutdown(payloadContext(payload)), logger)
 			}
 		}
-		if asyncEmitter != nil {
-			warnOnErr(process.ExitContext(), asyncEmitter.Close(), logger)
-		}
 		if agentPool != nil {
 			agentPool.Stop()
 		}
+		shutdownEmitter(process, asyncEmitter, payload, logger)
 		warnOnErr(process.ExitContext(), conn.Close(), logger)
 		logger.InfoContext(process.ExitContext(), "Exited.")
 	})

--- a/lib/service/discovery.go
+++ b/lib/service/discovery.go
@@ -103,9 +103,7 @@ func (process *TeleportProcess) initDiscoveryService() error {
 		if discoveryService != nil {
 			discoveryService.Stop()
 		}
-		if asyncEmitter != nil {
-			warnOnErr(process.ExitContext(), asyncEmitter.Close(), logger)
-		}
+		shutdownEmitter(process, asyncEmitter, payload, logger)
 		warnOnErr(process.ExitContext(), conn.Close(), logger)
 		logger.InfoContext(process.ExitContext(), "Exited.")
 	})

--- a/lib/service/kubernetes.go
+++ b/lib/service/kubernetes.go
@@ -362,9 +362,7 @@ func (process *TeleportProcess) initKubernetesService(logger *slog.Logger, conn 
 		if relayTunnelClient != nil {
 			relayTunnelClient.Close()
 		}
-		if asyncEmitter != nil {
-			warnOnErr(process.ExitContext(), asyncEmitter.Close(), logger)
-		}
+		shutdownEmitter(process, asyncEmitter, payload, logger)
 		if healthCheckManager != nil {
 			warnOnErr(process.ExitContext(), healthCheckManager.Close(), logger)
 		}

--- a/lib/service/relay.go
+++ b/lib/service/relay.go
@@ -473,6 +473,8 @@ func (process *TeleportProcess) runRelayService() error {
 	})
 	warnOnErr(egCtx, eg.Wait(), log)
 
+	shutdownEmitter(process, asyncEmitter, exitEvent.Payload, log)
+
 	warnOnErr(ctx, hb.Close(), log)
 	warnOnErr(ctx, conn.Close(), log)
 

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -3118,6 +3118,9 @@ func (process *TeleportProcess) initAuthService() error {
 				}
 			}
 		}
+		if fallbackEmitter != nil {
+			shutdownEmitter(process, fallbackEmitter, payload, logger)
+		}
 		logger.InfoContext(process.ExitContext(), "Exited.")
 	})
 
@@ -3966,6 +3969,8 @@ func (process *TeleportProcess) initSSH() error {
 		if relayTunnelClient != nil {
 			relayTunnelClient.Close()
 		}
+
+		shutdownEmitter(process, asyncEmitter, event.Payload, logger)
 
 		logger.InfoContext(process.ExitContext(), "Exited.")
 		return nil
@@ -5458,7 +5463,7 @@ func (process *TeleportProcess) initProxyEndpoint(conn *Connector) error {
 			_ = peerQUICTransport.Close()
 			_ = peerQUICTransport.Conn.Close()
 		}
-		warnOnErr(process.ExitContext(), asyncEmitter.Close(), logger)
+		shutdownEmitter(process, asyncEmitter, payload, logger)
 		warnOnErr(process.ExitContext(), conn.Close(), logger)
 		logger.InfoContext(process.ExitContext(), "Exited")
 	})
@@ -7273,11 +7278,8 @@ func (process *TeleportProcess) initApps() {
 				logger.InfoContext(process.ExitContext(), "Shutting down gracefully.")
 				warnOnErr(process.ExitContext(), appServer.Shutdown(payloadContext(payload)), logger)
 			}
-			if asyncEmitter != nil {
-				warnOnErr(process.ExitContext(), asyncEmitter.Close(), logger)
-			}
 			agentPool.Stop()
-			warnOnErr(process.ExitContext(), asyncEmitter.Close(), logger)
+			shutdownEmitter(process, asyncEmitter, payload, logger)
 			warnOnErr(process.ExitContext(), conn.Close(), logger)
 			logger.InfoContext(process.ExitContext(), "Exited.")
 		})
@@ -7289,6 +7291,27 @@ func (process *TeleportProcess) initApps() {
 		agentPool.Wait()
 		return nil
 	})
+}
+
+// drainableEmitter is an audit emitter whose queue can be drained on shutdown.
+type drainableEmitter interface {
+	Shutdown(context.Context) error
+	Close() error
+}
+
+const emitterDrainTimeout = time.Hour
+
+// shutdownEmitter drains the emitter's queue to the audit backend when payload
+// carries a graceful shutdown context, otherwise it closes the emitter
+// immediately.
+func shutdownEmitter(process *TeleportProcess, emitter drainableEmitter, payload any, logger *slog.Logger) {
+	if payload == nil {
+		warnOnErr(process.ExitContext(), emitter.Close(), logger)
+		return
+	}
+	drainCtx, cancel := context.WithTimeout(payloadContext(payload), emitterDrainTimeout)
+	defer cancel()
+	warnOnErr(process.ExitContext(), emitter.Shutdown(drainCtx), logger)
 }
 
 // TODO(williamo/scopes): Update this validate function when we add support for these features.


### PR DESCRIPTION
Changelog: Attempt to drain the audit queue on shutdown.

This PR is the seventh in what will be multiple PRs that implement [RFD 254](https://github.com/gravitational/teleport.e/pull/8641)

This PR attempts to drain the queue during a graceful shutdown. It adds the method `Drain()` to the `Queue` interface, which blocks while the queue still has events in it.

## Previous PRs in this project:
1. https://github.com/gravitational/teleport/pull/66883 
2. https://github.com/gravitational/teleport/pull/67019
3. https://github.com/gravitational/teleport/pull/67095
4. https://github.com/gravitational/teleport/pull/67212
5. https://github.com/gravitational/teleport/pull/67638
6. https://github.com/gravitational/teleport/pull/67696

## Features in this PR

- During shutdown, attempt to drain queue during the grace period.

## Features that will be included in future PRs

Outstanding items that will be implemented in follow-up PR(s) include:
- tctl additions for audit queue observability.
- Protobuf changes.
- Encryption at rest (deferred to v19)
- Integration tests.

## Manual Test Plan

TBD

### Test Environment

This has been tested on a Linux AMD64 machine.

### Test Cases

TBD

### Test Description

TBD