### PR TITLE
Enable Slack native review with UI and app

### DIFF
--- a/integrations/access/slack/bot.go
+++ b/integrations/access/slack/bot.go
@@ -102,10 +102,15 @@ func onAfterResponseSlack(sink common.StatusSink) func(_ *resty.Client, resp *re
 
 // SupportedApps are the apps supported by this bot.
 func (b Bot) SupportedApps() []common.App {
-	return []common.App{
+	apps := []common.App{
 		accessrequest.NewApp(),
 		appAccesslist.NewApp(),
 	}
+
+	if b.reviewConfig.Enabled {
+		apps = append(apps, NewReviewApp(b.reviewConfig))
+	}
+	return apps
 }
 
 func (b Bot) CheckHealth(ctx context.Context) error {
@@ -427,12 +432,20 @@ func (b Bot) slackAccessRequestMsgSections(reqID string, reqData pd.AccessReques
 		}),
 	}
 
+	// Only expose Approve/Deny review buttons if "native review" is enabled.
+	if b.reviewConfig.Enabled {
+		// We should not expose buttons for long-term access requests, and only
+		// show buttons if the request is still unresolved.
+		if reqData.RequestKind != types.AccessRequestKind_LONG_TERM.String() && reqData.ResolutionTag == pd.Unresolved {
+			sections = append(sections, b.slackAccessReviewMsgSection(reqID)...)
+		}
+	}
 	return sections
 }
 
 // slackAccessReviewMsgSection builds an access review Slack message section.
 // This should only be returned when native review is enabled.
-func (b Bot) slackAccessReviewMsgSection(reqID string) []BlockItem { //nolint:unused // TODO(kshi36): used in follow-up PR.
+func (b Bot) slackAccessReviewMsgSection(reqID string) []BlockItem {
 	return []BlockItem{
 		NewBlockItem(ActionsBlock{
 			ElementItems: []ActionElementItem{

--- a/integrations/access/slack/review_test.go
+++ b/integrations/access/slack/review_test.go
@@ -129,7 +129,6 @@ func TestResolveTeleportUser(t *testing.T) {
 		teleportTraits:   map[string][]string{"slack_uid": {"U_eve"}},
 	}
 
-	// Link some emails to Slack users
 	mockBot := &mockReviewBot{}
 	createUserInSlackAndTeleport(t, mockBot, authServer, aliceUser)
 	createUserInSlackAndTeleport(t, mockBot, authServer, bobUser)


### PR DESCRIPTION
Depends on:
- https://github.com/gravitational/teleport/pull/67217
- https://github.com/gravitational/teleport/pull/67222

This PR enables the UI elements and plugin app to support Slack native Access Request reviews.

Changelog: Added opt-in feature for Slack plugin for native Access Request reviews within Slack

<details><summary>Some demos</summary>
<p>

### Review UI
<img width="586" height="334" alt="Screenshot 2026-06-16 at 1 10 29 PM" src="https://github.com/user-attachments/assets/3e40669d-e4b1-4c8b-a7b0-3c27d9655464" />

### After review
<img width="601" height="351" alt="Screenshot 2026-06-16 at 1 12 16 PM" src="https://github.com/user-attachments/assets/c40c713e-828c-4d8e-acce-366d430c3119" />

### Multi-threshold review, remains PENDING
<img width="427" height="475" alt="Screenshot 2026-06-16 at 1 13 27 PM" src="https://github.com/user-attachments/assets/9d9c8699-f2cc-4cc3-8893-126c8d585485" />

### No buttons for long-term access requests
<img width="608" height="320" alt="Screenshot 2026-06-16 at 1 09 35 PM" src="https://github.com/user-attachments/assets/aecf0f3b-731f-4482-8720-8b780ddbe77a" />

### Review error replies
<img width="569" height="57" alt="Screenshot 2026-06-16 at 1 11 20 PM" src="https://github.com/user-attachments/assets/e2dd5e41-06ad-460f-8c80-0af40babda65" />
<img width="566" height="52" alt="Screenshot 2026-06-16 at 1 11 51 PM" src="https://github.com/user-attachments/assets/93b41875-144d-49c2-9d08-5d26595857f4" />

### Audit log with plugin identity
<img width="452" height="329" alt="Screenshot 2026-06-17 at 4 44 27 PM" src="https://github.com/user-attachments/assets/97c8c5ea-0b44-4d4a-ae3c-0559d029c109" />

</p>
</details> 

## Manual Test Plan
### Test Environment

Teleport Cloud. Local self-hosted Slack plugin (binary and helm chart)

### Test Cases
- [x] When native review is disabled (default):
	- [x] Only Web UI link is provided, no Approve/Deny buttons
	- [x] Review app is not started
- [x] When native review is enabled:
	- [x] Slack notification will be sent to channel with Approve/Deny buttons
	- [x] Review app starts
	- [x] When a Slack user without proper Teleport review permissions clicks the "Approve" button, they receive an error reply message
	- [x] When a Slack user with proper Teleport review permissions clicks the "Approve" button, the Access Request gets 1 approval in Teleport
	- [x] Slack notification is updated with Access Request’s result, and a reply is sent (original behavior)
	- [x] A resolved Access Request message removes Approve/Deny buttons
	- [x] A long-term Access Request message hides Approve/Deny buttons
- [x] When native review is enabled, and an Access Request requires multiple approvals:
    - [x] Slack notification remains PENDING
    - [x] Access Request on Teleport is not fully approved after 1 Slack approval
    - [x] When approval threshold is met, Access Request is approved in Teleport and Slack notification updated to APPROVED