### PR TITLE
operator: Only deploy scoped CRDs when running in scoped mode

### DIFF
--- a/examples/chart/teleport-cluster/charts/teleport-operator/operator-crds/resources.teleport.dev_accesslists.yaml
+++ b/examples/chart/teleport-cluster/charts/teleport-operator/operator-crds/resources.teleport.dev_accesslists.yaml
@@ -1,6 +1,8 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
+  annotations:
+    resources.teleport.dev/scoped: "false"
   name: teleportaccesslists.resources.teleport.dev
 spec:
   group: resources.teleport.dev

--- a/examples/chart/teleport-cluster/charts/teleport-operator/operator-crds/resources.teleport.dev_accessmonitoringrulesv1.yaml
+++ b/examples/chart/teleport-cluster/charts/teleport-operator/operator-crds/resources.teleport.dev_accessmonitoringrulesv1.yaml
@@ -1,6 +1,8 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
+  annotations:
+    resources.teleport.dev/scoped: "false"
   name: teleportaccessmonitoringrulesv1.resources.teleport.dev
 spec:
   group: resources.teleport.dev

--- a/examples/chart/teleport-cluster/charts/teleport-operator/operator-crds/resources.teleport.dev_appsv3.yaml
+++ b/examples/chart/teleport-cluster/charts/teleport-operator/operator-crds/resources.teleport.dev_appsv3.yaml
@@ -1,6 +1,8 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
+  annotations:
+    resources.teleport.dev/scoped: "false"
   name: teleportappsv3.resources.teleport.dev
 spec:
   group: resources.teleport.dev

--- a/examples/chart/teleport-cluster/charts/teleport-operator/operator-crds/resources.teleport.dev_autoupdateconfigsv1.yaml
+++ b/examples/chart/teleport-cluster/charts/teleport-operator/operator-crds/resources.teleport.dev_autoupdateconfigsv1.yaml
@@ -1,6 +1,8 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
+  annotations:
+    resources.teleport.dev/scoped: "false"
   name: teleportautoupdateconfigsv1.resources.teleport.dev
 spec:
   group: resources.teleport.dev

--- a/examples/chart/teleport-cluster/charts/teleport-operator/operator-crds/resources.teleport.dev_autoupdateversionsv1.yaml
+++ b/examples/chart/teleport-cluster/charts/teleport-operator/operator-crds/resources.teleport.dev_autoupdateversionsv1.yaml
@@ -1,6 +1,8 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
+  annotations:
+    resources.teleport.dev/scoped: "false"
   name: teleportautoupdateversionsv1.resources.teleport.dev
 spec:
   group: resources.teleport.dev

--- a/examples/chart/teleport-cluster/charts/teleport-operator/operator-crds/resources.teleport.dev_botsv1.yaml
+++ b/examples/chart/teleport-cluster/charts/teleport-operator/operator-crds/resources.teleport.dev_botsv1.yaml
@@ -1,6 +1,8 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
+  annotations:
+    resources.teleport.dev/scoped: "true"
   name: teleportbotsv1.resources.teleport.dev
 spec:
   group: resources.teleport.dev

--- a/examples/chart/teleport-cluster/charts/teleport-operator/operator-crds/resources.teleport.dev_databasesv3.yaml
+++ b/examples/chart/teleport-cluster/charts/teleport-operator/operator-crds/resources.teleport.dev_databasesv3.yaml
@@ -1,6 +1,8 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
+  annotations:
+    resources.teleport.dev/scoped: "false"
   name: teleportdatabasesv3.resources.teleport.dev
 spec:
   group: resources.teleport.dev

--- a/examples/chart/teleport-cluster/charts/teleport-operator/operator-crds/resources.teleport.dev_githubconnectors.yaml
+++ b/examples/chart/teleport-cluster/charts/teleport-operator/operator-crds/resources.teleport.dev_githubconnectors.yaml
@@ -1,6 +1,8 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
+  annotations:
+    resources.teleport.dev/scoped: "false"
   name: teleportgithubconnectors.resources.teleport.dev
 spec:
   group: resources.teleport.dev

--- a/examples/chart/teleport-cluster/charts/teleport-operator/operator-crds/resources.teleport.dev_inferencemodels.yaml
+++ b/examples/chart/teleport-cluster/charts/teleport-operator/operator-crds/resources.teleport.dev_inferencemodels.yaml
@@ -1,6 +1,8 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
+  annotations:
+    resources.teleport.dev/scoped: "false"
   name: teleportinferencemodels.resources.teleport.dev
 spec:
   group: resources.teleport.dev

--- a/examples/chart/teleport-cluster/charts/teleport-operator/operator-crds/resources.teleport.dev_inferencepolicies.yaml
+++ b/examples/chart/teleport-cluster/charts/teleport-operator/operator-crds/resources.teleport.dev_inferencepolicies.yaml
@@ -1,6 +1,8 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
+  annotations:
+    resources.teleport.dev/scoped: "false"
   name: teleportinferencepolicies.resources.teleport.dev
 spec:
   group: resources.teleport.dev

--- a/examples/chart/teleport-cluster/charts/teleport-operator/operator-crds/resources.teleport.dev_inferencesecrets.yaml
+++ b/examples/chart/teleport-cluster/charts/teleport-operator/operator-crds/resources.teleport.dev_inferencesecrets.yaml
@@ -1,6 +1,8 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
+  annotations:
+    resources.teleport.dev/scoped: "false"
   name: teleportinferencesecrets.resources.teleport.dev
 spec:
   group: resources.teleport.dev

--- a/examples/chart/teleport-cluster/charts/teleport-operator/operator-crds/resources.teleport.dev_locksv2.yaml
+++ b/examples/chart/teleport-cluster/charts/teleport-operator/operator-crds/resources.teleport.dev_locksv2.yaml
@@ -1,6 +1,8 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
+  annotations:
+    resources.teleport.dev/scoped: "false"
   name: teleportlocksv2.resources.teleport.dev
 spec:
   group: resources.teleport.dev

--- a/examples/chart/teleport-cluster/charts/teleport-operator/operator-crds/resources.teleport.dev_loginrules.yaml
+++ b/examples/chart/teleport-cluster/charts/teleport-operator/operator-crds/resources.teleport.dev_loginrules.yaml
@@ -1,6 +1,8 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
+  annotations:
+    resources.teleport.dev/scoped: "false"
   name: teleportloginrules.resources.teleport.dev
 spec:
   group: resources.teleport.dev

--- a/examples/chart/teleport-cluster/charts/teleport-operator/operator-crds/resources.teleport.dev_oidcconnectors.yaml
+++ b/examples/chart/teleport-cluster/charts/teleport-operator/operator-crds/resources.teleport.dev_oidcconnectors.yaml
@@ -1,6 +1,8 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
+  annotations:
+    resources.teleport.dev/scoped: "false"
   name: teleportoidcconnectors.resources.teleport.dev
 spec:
   group: resources.teleport.dev

--- a/examples/chart/teleport-cluster/charts/teleport-operator/operator-crds/resources.teleport.dev_oktaimportrules.yaml
+++ b/examples/chart/teleport-cluster/charts/teleport-operator/operator-crds/resources.teleport.dev_oktaimportrules.yaml
@@ -1,6 +1,8 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
+  annotations:
+    resources.teleport.dev/scoped: "false"
   name: teleportoktaimportrules.resources.teleport.dev
 spec:
   group: resources.teleport.dev

--- a/examples/chart/teleport-cluster/charts/teleport-operator/operator-crds/resources.teleport.dev_openssheiceserversv2.yaml
+++ b/examples/chart/teleport-cluster/charts/teleport-operator/operator-crds/resources.teleport.dev_openssheiceserversv2.yaml
@@ -1,6 +1,8 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
+  annotations:
+    resources.teleport.dev/scoped: "false"
   name: teleportopenssheiceserversv2.resources.teleport.dev
 spec:
   group: resources.teleport.dev

--- a/examples/chart/teleport-cluster/charts/teleport-operator/operator-crds/resources.teleport.dev_opensshserversv2.yaml
+++ b/examples/chart/teleport-cluster/charts/teleport-operator/operator-crds/resources.teleport.dev_opensshserversv2.yaml
@@ -1,6 +1,8 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
+  annotations:
+    resources.teleport.dev/scoped: "false"
   name: teleportopensshserversv2.resources.teleport.dev
 spec:
   group: resources.teleport.dev

--- a/examples/chart/teleport-cluster/charts/teleport-operator/operator-crds/resources.teleport.dev_provisiontokens.yaml
+++ b/examples/chart/teleport-cluster/charts/teleport-operator/operator-crds/resources.teleport.dev_provisiontokens.yaml
@@ -1,6 +1,8 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
+  annotations:
+    resources.teleport.dev/scoped: "false"
   name: teleportprovisiontokens.resources.teleport.dev
 spec:
   group: resources.teleport.dev

--- a/examples/chart/teleport-cluster/charts/teleport-operator/operator-crds/resources.teleport.dev_retrievalmodelsv1.yaml
+++ b/examples/chart/teleport-cluster/charts/teleport-operator/operator-crds/resources.teleport.dev_retrievalmodelsv1.yaml
@@ -1,6 +1,8 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
+  annotations:
+    resources.teleport.dev/scoped: "false"
   name: teleportretrievalmodelsv1.resources.teleport.dev
 spec:
   group: resources.teleport.dev

--- a/examples/chart/teleport-cluster/charts/teleport-operator/operator-crds/resources.teleport.dev_roles.yaml
+++ b/examples/chart/teleport-cluster/charts/teleport-operator/operator-crds/resources.teleport.dev_roles.yaml
@@ -1,6 +1,8 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
+  annotations:
+    resources.teleport.dev/scoped: "false"
   name: teleportroles.resources.teleport.dev
 spec:
   group: resources.teleport.dev

--- a/examples/chart/teleport-cluster/charts/teleport-operator/operator-crds/resources.teleport.dev_rolesv6.yaml
+++ b/examples/chart/teleport-cluster/charts/teleport-operator/operator-crds/resources.teleport.dev_rolesv6.yaml
@@ -1,6 +1,8 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
+  annotations:
+    resources.teleport.dev/scoped: "false"
   name: teleportrolesv6.resources.teleport.dev
 spec:
   group: resources.teleport.dev

--- a/examples/chart/teleport-cluster/charts/teleport-operator/operator-crds/resources.teleport.dev_rolesv7.yaml
+++ b/examples/chart/teleport-cluster/charts/teleport-operator/operator-crds/resources.teleport.dev_rolesv7.yaml
@@ -1,6 +1,8 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
+  annotations:
+    resources.teleport.dev/scoped: "false"
   name: teleportrolesv7.resources.teleport.dev
 spec:
   group: resources.teleport.dev

--- a/examples/chart/teleport-cluster/charts/teleport-operator/operator-crds/resources.teleport.dev_rolesv8.yaml
+++ b/examples/chart/teleport-cluster/charts/teleport-operator/operator-crds/resources.teleport.dev_rolesv8.yaml
@@ -1,6 +1,8 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
+  annotations:
+    resources.teleport.dev/scoped: "false"
   name: teleportrolesv8.resources.teleport.dev
 spec:
   group: resources.teleport.dev

--- a/examples/chart/teleport-cluster/charts/teleport-operator/operator-crds/resources.teleport.dev_samlconnectors.yaml
+++ b/examples/chart/teleport-cluster/charts/teleport-operator/operator-crds/resources.teleport.dev_samlconnectors.yaml
@@ -1,6 +1,8 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
+  annotations:
+    resources.teleport.dev/scoped: "false"
   name: teleportsamlconnectors.resources.teleport.dev
 spec:
   group: resources.teleport.dev

--- a/examples/chart/teleport-cluster/charts/teleport-operator/operator-crds/resources.teleport.dev_samlidpserviceprovidersv1.yaml
+++ b/examples/chart/teleport-cluster/charts/teleport-operator/operator-crds/resources.teleport.dev_samlidpserviceprovidersv1.yaml
@@ -1,6 +1,8 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
+  annotations:
+    resources.teleport.dev/scoped: "false"
   name: teleportsamlidpserviceprovidersv1.resources.teleport.dev
 spec:
   group: resources.teleport.dev

--- a/examples/chart/teleport-cluster/charts/teleport-operator/operator-crds/resources.teleport.dev_scopedroleassignmentsv1.yaml
+++ b/examples/chart/teleport-cluster/charts/teleport-operator/operator-crds/resources.teleport.dev_scopedroleassignmentsv1.yaml
@@ -1,6 +1,8 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
+  annotations:
+    resources.teleport.dev/scoped: "true"
   name: teleportscopedroleassignmentsv1.resources.teleport.dev
 spec:
   group: resources.teleport.dev

--- a/examples/chart/teleport-cluster/charts/teleport-operator/operator-crds/resources.teleport.dev_scopedrolesv1.yaml
+++ b/examples/chart/teleport-cluster/charts/teleport-operator/operator-crds/resources.teleport.dev_scopedrolesv1.yaml
@@ -1,6 +1,8 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
+  annotations:
+    resources.teleport.dev/scoped: "true"
   name: teleportscopedrolesv1.resources.teleport.dev
 spec:
   group: resources.teleport.dev

--- a/examples/chart/teleport-cluster/charts/teleport-operator/operator-crds/resources.teleport.dev_scopedtokensv1.yaml
+++ b/examples/chart/teleport-cluster/charts/teleport-operator/operator-crds/resources.teleport.dev_scopedtokensv1.yaml
@@ -1,6 +1,8 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
+  annotations:
+    resources.teleport.dev/scoped: "true"
   name: teleportscopedtokensv1.resources.teleport.dev
 spec:
   group: resources.teleport.dev

--- a/examples/chart/teleport-cluster/charts/teleport-operator/operator-crds/resources.teleport.dev_trustedclustersv2.yaml
+++ b/examples/chart/teleport-cluster/charts/teleport-operator/operator-crds/resources.teleport.dev_trustedclustersv2.yaml
@@ -1,6 +1,8 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
+  annotations:
+    resources.teleport.dev/scoped: "false"
   name: teleporttrustedclustersv2.resources.teleport.dev
 spec:
   group: resources.teleport.dev

--- a/examples/chart/teleport-cluster/charts/teleport-operator/operator-crds/resources.teleport.dev_users.yaml
+++ b/examples/chart/teleport-cluster/charts/teleport-operator/operator-crds/resources.teleport.dev_users.yaml
@@ -1,6 +1,8 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
+  annotations:
+    resources.teleport.dev/scoped: "false"
   name: teleportusers.resources.teleport.dev
 spec:
   group: resources.teleport.dev

--- a/examples/chart/teleport-cluster/charts/teleport-operator/operator-crds/resources.teleport.dev_workloadidentitiesv1.yaml
+++ b/examples/chart/teleport-cluster/charts/teleport-operator/operator-crds/resources.teleport.dev_workloadidentitiesv1.yaml
@@ -1,6 +1,8 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
+  annotations:
+    resources.teleport.dev/scoped: "false"
   name: teleportworkloadidentitiesv1.resources.teleport.dev
 spec:
   group: resources.teleport.dev

--- a/examples/chart/teleport-cluster/charts/teleport-operator/templates/_helpers.tpl
+++ b/examples/chart/teleport-cluster/charts/teleport-operator/templates/_helpers.tpl
@@ -105,7 +105,8 @@ So we check if there's a CRD already deployed, it that's the case, we keep the C
 the release. As CRDs are not namespaced, we must use a custom annotation to avoid
 a conflict when two releases are deployed with the same name in different namespaces. */ -}}
 {{- define "teleport-cluster.operator.checkExistingCRDs" -}}
-  {{ $existingCRD := lookup "apiextensions.k8s.io/v1" "CustomResourceDefinition" "" "teleportrolesv7.resources.teleport.dev"}}
+  {{ $sentinelCRD := ternary  "teleportscopedrolesv1.resources.teleport.dev" "teleportrolesv7.resources.teleport.dev" .Values.scoped }}
+  {{ $existingCRD := lookup "apiextensions.k8s.io/v1" "CustomResourceDefinition" "" $sentinelCRD}}
   {{- if not $existingCRD -}}
     false
   {{- else -}}

--- a/examples/chart/teleport-cluster/charts/teleport-operator/templates/crds.yaml
+++ b/examples/chart/teleport-cluster/charts/teleport-operator/templates/crds.yaml
@@ -12,18 +12,24 @@ have everything functional in a single "helm install", hence the rube goldberg
 mechanism to try to guess what to do with the CRDs (see the implementation of
 shouldInstallCRDs in _helpers.yaml for more details). */ -}}
 {{- if eq (include "teleport-cluster.operator.shouldInstallCRDs" . ) "true" -}}
-{{ $currentScope := .}}
+{{ $ctx := . }}
 {{- $crdValidationSupport := semverCompare ">=1.25.0-0" .Capabilities.KubeVersion.Version -}}
 {{ range $path, $_ :=  .Files.Glob  "operator-crds/*" }}
-  {{- with $currentScope}}
+  {{- with $ctx }}
     {{- $raw := (.Files.Get $path | fromYaml) -}}
-    {{- if not $crdValidationSupport -}}
-      {{- range $version := $raw.spec.versions -}}
+    {{- range $version := $raw.spec.versions -}}
+      {{- if not $crdValidationSupport -}}
         {{- $_ := unset $version.schema.openAPIV3Schema "x-kubernetes-validations" -}}
       {{- end -}}
     {{- end -}}
-    {{- $injectedCRD := mustMergeOverwrite $raw (include "teleport-cluster.operator.crdOverrides" $currentScope | fromYaml) -}}
-    {{- toYaml $injectedCRD -}}
+    {{- $injectedCRD := mustMergeOverwrite $raw (include "teleport-cluster.operator.crdOverrides" $ctx | fromYaml) -}}
+    {{/* Only render the CRD if the operator deployment is unscoped, or if the CRD is scoped.
+         This makes sure we don't deploy unscoped CRDs on a scoped operator.
+         Note: scopedCRD is a string. */}}
+    {{- $scopedCRD := (dig "metadata" "annotations" "resources.teleport.dev/scoped" "unknown" $raw) -}}
+    {{- if or (not .Values.scoped) (eq $scopedCRD "true") -}}
+      {{- toYaml $injectedCRD -}}
+    {{- end }}
   {{- end }}
 ---
 {{ end }}

--- a/examples/chart/teleport-cluster/charts/teleport-operator/templates/crds.yaml
+++ b/examples/chart/teleport-cluster/charts/teleport-operator/templates/crds.yaml
@@ -17,8 +17,8 @@ shouldInstallCRDs in _helpers.yaml for more details). */ -}}
 {{ range $path, $_ :=  .Files.Glob  "operator-crds/*" }}
   {{- with $ctx }}
     {{- $raw := (.Files.Get $path | fromYaml) -}}
-    {{- range $version := $raw.spec.versions -}}
-      {{- if not $crdValidationSupport -}}
+    {{- if not $crdValidationSupport -}}
+      {{- range $version := $raw.spec.versions -}}
         {{- $_ := unset $version.schema.openAPIV3Schema "x-kubernetes-validations" -}}
       {{- end -}}
     {{- end -}}
@@ -28,9 +28,9 @@ shouldInstallCRDs in _helpers.yaml for more details). */ -}}
          Note: scopedCRD is a string. */}}
     {{- $scopedCRD := (dig "metadata" "annotations" "resources.teleport.dev/scoped" "unknown" $raw) -}}
     {{- if or (not .Values.scoped) (eq $scopedCRD "true") -}}
-      {{- toYaml $injectedCRD -}}
+      {{- toYaml $injectedCRD }}
+---
     {{- end }}
   {{- end }}
----
 {{ end }}
 {{- end -}}

--- a/integrations/operator/config/crd/bases/resources.teleport.dev_accesslists.yaml
+++ b/integrations/operator/config/crd/bases/resources.teleport.dev_accesslists.yaml
@@ -1,6 +1,8 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
+  annotations:
+    resources.teleport.dev/scoped: "false"
   name: teleportaccesslists.resources.teleport.dev
 spec:
   group: resources.teleport.dev

--- a/integrations/operator/config/crd/bases/resources.teleport.dev_accessmonitoringrulesv1.yaml
+++ b/integrations/operator/config/crd/bases/resources.teleport.dev_accessmonitoringrulesv1.yaml
@@ -1,6 +1,8 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
+  annotations:
+    resources.teleport.dev/scoped: "false"
   name: teleportaccessmonitoringrulesv1.resources.teleport.dev
 spec:
   group: resources.teleport.dev

--- a/integrations/operator/config/crd/bases/resources.teleport.dev_appsv3.yaml
+++ b/integrations/operator/config/crd/bases/resources.teleport.dev_appsv3.yaml
@@ -1,6 +1,8 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
+  annotations:
+    resources.teleport.dev/scoped: "false"
   name: teleportappsv3.resources.teleport.dev
 spec:
   group: resources.teleport.dev

--- a/integrations/operator/config/crd/bases/resources.teleport.dev_autoupdateconfigsv1.yaml
+++ b/integrations/operator/config/crd/bases/resources.teleport.dev_autoupdateconfigsv1.yaml
@@ -1,6 +1,8 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
+  annotations:
+    resources.teleport.dev/scoped: "false"
   name: teleportautoupdateconfigsv1.resources.teleport.dev
 spec:
   group: resources.teleport.dev

--- a/integrations/operator/config/crd/bases/resources.teleport.dev_autoupdateversionsv1.yaml
+++ b/integrations/operator/config/crd/bases/resources.teleport.dev_autoupdateversionsv1.yaml
@@ -1,6 +1,8 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
+  annotations:
+    resources.teleport.dev/scoped: "false"
   name: teleportautoupdateversionsv1.resources.teleport.dev
 spec:
   group: resources.teleport.dev

--- a/integrations/operator/config/crd/bases/resources.teleport.dev_botsv1.yaml
+++ b/integrations/operator/config/crd/bases/resources.teleport.dev_botsv1.yaml
@@ -1,6 +1,8 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
+  annotations:
+    resources.teleport.dev/scoped: "true"
   name: teleportbotsv1.resources.teleport.dev
 spec:
   group: resources.teleport.dev

--- a/integrations/operator/config/crd/bases/resources.teleport.dev_databasesv3.yaml
+++ b/integrations/operator/config/crd/bases/resources.teleport.dev_databasesv3.yaml
@@ -1,6 +1,8 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
+  annotations:
+    resources.teleport.dev/scoped: "false"
   name: teleportdatabasesv3.resources.teleport.dev
 spec:
   group: resources.teleport.dev

--- a/integrations/operator/config/crd/bases/resources.teleport.dev_githubconnectors.yaml
+++ b/integrations/operator/config/crd/bases/resources.teleport.dev_githubconnectors.yaml
@@ -1,6 +1,8 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
+  annotations:
+    resources.teleport.dev/scoped: "false"
   name: teleportgithubconnectors.resources.teleport.dev
 spec:
   group: resources.teleport.dev

--- a/integrations/operator/config/crd/bases/resources.teleport.dev_inferencemodels.yaml
+++ b/integrations/operator/config/crd/bases/resources.teleport.dev_inferencemodels.yaml
@@ -1,6 +1,8 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
+  annotations:
+    resources.teleport.dev/scoped: "false"
   name: teleportinferencemodels.resources.teleport.dev
 spec:
   group: resources.teleport.dev

--- a/integrations/operator/config/crd/bases/resources.teleport.dev_inferencepolicies.yaml
+++ b/integrations/operator/config/crd/bases/resources.teleport.dev_inferencepolicies.yaml
@@ -1,6 +1,8 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
+  annotations:
+    resources.teleport.dev/scoped: "false"
   name: teleportinferencepolicies.resources.teleport.dev
 spec:
   group: resources.teleport.dev

--- a/integrations/operator/config/crd/bases/resources.teleport.dev_inferencesecrets.yaml
+++ b/integrations/operator/config/crd/bases/resources.teleport.dev_inferencesecrets.yaml
@@ -1,6 +1,8 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
+  annotations:
+    resources.teleport.dev/scoped: "false"
   name: teleportinferencesecrets.resources.teleport.dev
 spec:
   group: resources.teleport.dev

--- a/integrations/operator/config/crd/bases/resources.teleport.dev_locksv2.yaml
+++ b/integrations/operator/config/crd/bases/resources.teleport.dev_locksv2.yaml
@@ -1,6 +1,8 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
+  annotations:
+    resources.teleport.dev/scoped: "false"
   name: teleportlocksv2.resources.teleport.dev
 spec:
   group: resources.teleport.dev

--- a/integrations/operator/config/crd/bases/resources.teleport.dev_loginrules.yaml
+++ b/integrations/operator/config/crd/bases/resources.teleport.dev_loginrules.yaml
@@ -1,6 +1,8 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
+  annotations:
+    resources.teleport.dev/scoped: "false"
   name: teleportloginrules.resources.teleport.dev
 spec:
   group: resources.teleport.dev

--- a/integrations/operator/config/crd/bases/resources.teleport.dev_oidcconnectors.yaml
+++ b/integrations/operator/config/crd/bases/resources.teleport.dev_oidcconnectors.yaml
@@ -1,6 +1,8 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
+  annotations:
+    resources.teleport.dev/scoped: "false"
   name: teleportoidcconnectors.resources.teleport.dev
 spec:
   group: resources.teleport.dev

--- a/integrations/operator/config/crd/bases/resources.teleport.dev_oktaimportrules.yaml
+++ b/integrations/operator/config/crd/bases/resources.teleport.dev_oktaimportrules.yaml
@@ -1,6 +1,8 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
+  annotations:
+    resources.teleport.dev/scoped: "false"
   name: teleportoktaimportrules.resources.teleport.dev
 spec:
   group: resources.teleport.dev

--- a/integrations/operator/config/crd/bases/resources.teleport.dev_openssheiceserversv2.yaml
+++ b/integrations/operator/config/crd/bases/resources.teleport.dev_openssheiceserversv2.yaml
@@ -1,6 +1,8 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
+  annotations:
+    resources.teleport.dev/scoped: "false"
   name: teleportopenssheiceserversv2.resources.teleport.dev
 spec:
   group: resources.teleport.dev

--- a/integrations/operator/config/crd/bases/resources.teleport.dev_opensshserversv2.yaml
+++ b/integrations/operator/config/crd/bases/resources.teleport.dev_opensshserversv2.yaml
@@ -1,6 +1,8 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
+  annotations:
+    resources.teleport.dev/scoped: "false"
   name: teleportopensshserversv2.resources.teleport.dev
 spec:
   group: resources.teleport.dev

--- a/integrations/operator/config/crd/bases/resources.teleport.dev_provisiontokens.yaml
+++ b/integrations/operator/config/crd/bases/resources.teleport.dev_provisiontokens.yaml
@@ -1,6 +1,8 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
+  annotations:
+    resources.teleport.dev/scoped: "false"
   name: teleportprovisiontokens.resources.teleport.dev
 spec:
   group: resources.teleport.dev

--- a/integrations/operator/config/crd/bases/resources.teleport.dev_retrievalmodelsv1.yaml
+++ b/integrations/operator/config/crd/bases/resources.teleport.dev_retrievalmodelsv1.yaml
@@ -1,6 +1,8 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
+  annotations:
+    resources.teleport.dev/scoped: "false"
   name: teleportretrievalmodelsv1.resources.teleport.dev
 spec:
   group: resources.teleport.dev

--- a/integrations/operator/config/crd/bases/resources.teleport.dev_roles.yaml
+++ b/integrations/operator/config/crd/bases/resources.teleport.dev_roles.yaml
@@ -1,6 +1,8 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
+  annotations:
+    resources.teleport.dev/scoped: "false"
   name: teleportroles.resources.teleport.dev
 spec:
   group: resources.teleport.dev

--- a/integrations/operator/config/crd/bases/resources.teleport.dev_rolesv6.yaml
+++ b/integrations/operator/config/crd/bases/resources.teleport.dev_rolesv6.yaml
@@ -1,6 +1,8 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
+  annotations:
+    resources.teleport.dev/scoped: "false"
   name: teleportrolesv6.resources.teleport.dev
 spec:
   group: resources.teleport.dev

--- a/integrations/operator/config/crd/bases/resources.teleport.dev_rolesv7.yaml
+++ b/integrations/operator/config/crd/bases/resources.teleport.dev_rolesv7.yaml
@@ -1,6 +1,8 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
+  annotations:
+    resources.teleport.dev/scoped: "false"
   name: teleportrolesv7.resources.teleport.dev
 spec:
   group: resources.teleport.dev

--- a/integrations/operator/config/crd/bases/resources.teleport.dev_rolesv8.yaml
+++ b/integrations/operator/config/crd/bases/resources.teleport.dev_rolesv8.yaml
@@ -1,6 +1,8 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
+  annotations:
+    resources.teleport.dev/scoped: "false"
   name: teleportrolesv8.resources.teleport.dev
 spec:
   group: resources.teleport.dev

--- a/integrations/operator/config/crd/bases/resources.teleport.dev_samlconnectors.yaml
+++ b/integrations/operator/config/crd/bases/resources.teleport.dev_samlconnectors.yaml
@@ -1,6 +1,8 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
+  annotations:
+    resources.teleport.dev/scoped: "false"
   name: teleportsamlconnectors.resources.teleport.dev
 spec:
   group: resources.teleport.dev

--- a/integrations/operator/config/crd/bases/resources.teleport.dev_samlidpserviceprovidersv1.yaml
+++ b/integrations/operator/config/crd/bases/resources.teleport.dev_samlidpserviceprovidersv1.yaml
@@ -1,6 +1,8 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
+  annotations:
+    resources.teleport.dev/scoped: "false"
   name: teleportsamlidpserviceprovidersv1.resources.teleport.dev
 spec:
   group: resources.teleport.dev

--- a/integrations/operator/config/crd/bases/resources.teleport.dev_scopedroleassignmentsv1.yaml
+++ b/integrations/operator/config/crd/bases/resources.teleport.dev_scopedroleassignmentsv1.yaml
@@ -1,6 +1,8 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
+  annotations:
+    resources.teleport.dev/scoped: "true"
   name: teleportscopedroleassignmentsv1.resources.teleport.dev
 spec:
   group: resources.teleport.dev

--- a/integrations/operator/config/crd/bases/resources.teleport.dev_scopedrolesv1.yaml
+++ b/integrations/operator/config/crd/bases/resources.teleport.dev_scopedrolesv1.yaml
@@ -1,6 +1,8 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
+  annotations:
+    resources.teleport.dev/scoped: "true"
   name: teleportscopedrolesv1.resources.teleport.dev
 spec:
   group: resources.teleport.dev

--- a/integrations/operator/config/crd/bases/resources.teleport.dev_scopedtokensv1.yaml
+++ b/integrations/operator/config/crd/bases/resources.teleport.dev_scopedtokensv1.yaml
@@ -1,6 +1,8 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
+  annotations:
+    resources.teleport.dev/scoped: "true"
   name: teleportscopedtokensv1.resources.teleport.dev
 spec:
   group: resources.teleport.dev

--- a/integrations/operator/config/crd/bases/resources.teleport.dev_trustedclustersv2.yaml
+++ b/integrations/operator/config/crd/bases/resources.teleport.dev_trustedclustersv2.yaml
@@ -1,6 +1,8 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
+  annotations:
+    resources.teleport.dev/scoped: "false"
   name: teleporttrustedclustersv2.resources.teleport.dev
 spec:
   group: resources.teleport.dev

--- a/integrations/operator/config/crd/bases/resources.teleport.dev_users.yaml
+++ b/integrations/operator/config/crd/bases/resources.teleport.dev_users.yaml
@@ -1,6 +1,8 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
+  annotations:
+    resources.teleport.dev/scoped: "false"
   name: teleportusers.resources.teleport.dev
 spec:
   group: resources.teleport.dev

--- a/integrations/operator/config/crd/bases/resources.teleport.dev_workloadidentitiesv1.yaml
+++ b/integrations/operator/config/crd/bases/resources.teleport.dev_workloadidentitiesv1.yaml
@@ -1,6 +1,8 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
+  annotations:
+    resources.teleport.dev/scoped: "false"
   name: teleportworkloadidentitiesv1.resources.teleport.dev
 spec:
   group: resources.teleport.dev

--- a/integrations/operator/crdgen/schemagen.go
+++ b/integrations/operator/crdgen/schemagen.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"regexp"
 	"slices"
+	"strconv"
 	"strings"
 
 	"github.com/dustin/go-humanize/english"
@@ -71,6 +72,7 @@ type RootSchema struct {
 	// different kinds. At some point we will suffix all kinds by the version
 	// and deprecate the old resources.
 	kubernetesKind string
+	scoped         bool
 }
 
 type SchemaVersion struct {
@@ -302,6 +304,8 @@ func (generator *SchemaGenerator) addResource(file *File, name string, opts ...r
 			Rule:    "has(self.scope) == has(oldSelf.scope)",
 			Message: immutableScopeMessage,
 		})
+		// One scoped version is enough to mark the whole resource as scoped.
+		root.scoped = true
 	}
 
 	root.versions = append(root.versions, SchemaVersion{
@@ -560,6 +564,11 @@ func (root RootSchema) CustomResourceDefinition() (apiextv1.CustomResourceDefini
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name: fmt.Sprintf("%s.%s", strings.ToLower(k8sKindPrefix+root.pluralName), root.groupName),
+			Annotations: map[string]string{
+				// The scoped annotation is used to mark resources that are scoped so that Helm can select them
+				// when the operator is deployed in scoped mode.
+				"resources.teleport.dev/scoped": strconv.FormatBool(root.scoped),
+			},
 		},
 		Spec: apiextv1.CustomResourceDefinitionSpec{
 			Group: root.groupName,


### PR DESCRIPTION
Changelog: Changed the `teleport-operator` chart so non-scoped CRDs are not deployed anymore when running in scoped mode.

I initially made a change where Helm looked for the `scope` field in the schema but this proved a bit ugly. Instead I annotated the CRDs with the scoped status and looked for specific annotation values in the Helm chart.

I renamed the "scope" variable in Helm that was misleading as it was not about Teleport scopes.

The CRD detection relied on roles which are not deployed anymore. I switched CRD detection to scoped roles when running in scoped mode.

## Manual Test Plan
### Test Environment

Local k3s cluster

### Test Cases
- [x] Run operator in unscoped mode: all CRDs are here
- [x] Run operator in scoped mode: only scoped CRDs are here
