### PR TITLE
[v18] feat: updated side panel to be expanded for beams (#66603)

### DIFF
--- a/lib/auth/userpreferences/userpreferencesv1/service_test.go
+++ b/lib/auth/userpreferences/userpreferencesv1/service_test.go
@@ -56,7 +56,7 @@ func TestService_GetUserPreferences(t *testing.T) {
 			want: &userpreferencesv1.GetUserPreferencesResponse{
 				Preferences: &userpreferencesv1.UserPreferences{
 					Theme:             userpreferencesv1.Theme_THEME_UNSPECIFIED,
-					SideNavDrawerMode: userpreferencesv1.SideNavDrawerMode_SIDE_NAV_DRAWER_MODE_COLLAPSED,
+					SideNavDrawerMode: userpreferencesv1.SideNavDrawerMode_SIDE_NAV_DRAWER_MODE_UNSPECIFIED,
 					UnifiedResourcePreferences: &userpreferencesv1.UnifiedResourcePreferences{
 						DefaultTab:            userpreferencesv1.DefaultTab_DEFAULT_TAB_ALL,
 						ViewMode:              userpreferencesv1.ViewMode_VIEW_MODE_CARD,

--- a/lib/services/local/userpreferences.go
+++ b/lib/services/local/userpreferences.go
@@ -50,7 +50,10 @@ func DefaultUserPreferences() *userpreferencesv1.UserPreferences {
 		ClusterPreferences: &userpreferencesv1.ClusterUserPreferences{
 			PinnedResources: &userpreferencesv1.PinnedResourcesUserPreferences{},
 		},
-		SideNavDrawerMode: userpreferencesv1.SideNavDrawerMode_SIDE_NAV_DRAWER_MODE_COLLAPSED,
+		// Leave SideNavDrawerMode unset so the UI can detect a first-time
+		// user and apply its own default (or onboarding behavior) instead of
+		// storing a value the user never explicitly chose.
+		SideNavDrawerMode: userpreferencesv1.SideNavDrawerMode_SIDE_NAV_DRAWER_MODE_UNSPECIFIED,
 	}
 }
 

--- a/web/packages/teleport/src/Navigation/Navigation.test.tsx
+++ b/web/packages/teleport/src/Navigation/Navigation.test.tsx
@@ -18,7 +18,9 @@
 
 import { MemoryRouter } from 'react-router';
 
-import { render, screen } from 'design/utils/testing';
+import { Beams } from 'design/Icon';
+import { act, render, screen, tick } from 'design/utils/testing';
+import { SideNavDrawerMode } from 'gen-proto-ts/teleport/userpreferences/v1/sidenav_preferences_pb';
 
 import cfg from 'teleport/config';
 import { getOSSFeatures } from 'teleport/features';
@@ -26,11 +28,29 @@ import { FeaturesContextProvider } from 'teleport/FeaturesContext';
 import { ContextProvider } from 'teleport/index';
 import { createTeleportContext } from 'teleport/mocks/contexts';
 import { makeDefaultUserPreferences } from 'teleport/services/userPreferences/userPreferences';
-import { NavTitle } from 'teleport/types';
+import { NavTitle, type TeleportFeature } from 'teleport/types';
 import { makeTestUserContext } from 'teleport/User/testHelpers/makeTestUserContext';
 import { mockUserContextProviderWith } from 'teleport/User/testHelpers/mockUserContextWith';
 
 import { Navigation } from '.';
+import { NavigationCategory } from './categories';
+
+const beamsFeature: TeleportFeature = {
+  category: NavigationCategory.Beams,
+  hasAccess: () => true,
+  route: {
+    title: 'Quickstart',
+    path: '/web/beams/get-started',
+    exact: true,
+    component: () => null,
+  },
+  navigationItem: {
+    title: NavTitle.BeamsQuickstart,
+    icon: Beams,
+    exact: true,
+    getLink: () => '/web/beams/get-started',
+  },
+};
 
 test('show all dashboard navigation items', async () => {
   const expectedItems = [
@@ -75,5 +95,155 @@ test('show all dashboard navigation items', async () => {
     expect(
       screen.queryByText(item.navigationItem.title)
     ).not.toBeInTheDocument();
+  });
+});
+
+describe('Beams nav category', () => {
+  const originalIsDashboard = cfg.isDashboard;
+  const originalBeamsUi = cfg.beamsUi;
+
+  beforeEach(() => {
+    cfg.isDashboard = false;
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    cfg.isDashboard = originalIsDashboard;
+    cfg.beamsUi = originalBeamsUi;
+    localStorage.clear();
+  });
+
+  function renderNav(initialPath = '/') {
+    mockUserContextProviderWith(
+      makeTestUserContext({ preferences: makeDefaultUserPreferences() })
+    );
+    const ctx = createTeleportContext();
+    const features = [beamsFeature];
+
+    return render(
+      <MemoryRouter initialEntries={[initialPath]}>
+        <ContextProvider ctx={ctx}>
+          <FeaturesContextProvider value={features}>
+            <Navigation />
+          </FeaturesContextProvider>
+        </ContextProvider>
+      </MemoryRouter>
+    );
+  }
+
+  test('renders Beams above Resources when cfg.beamsUi is true', () => {
+    cfg.beamsUi = true;
+
+    renderNav();
+
+    const beamsButton = screen.getByRole('button', { name: 'Beams' });
+    const resourcesButton = screen.getByRole('button', { name: 'Resources' });
+    const buttons = screen.getAllByRole('button');
+
+    expect(buttons.indexOf(beamsButton)).toBeLessThan(
+      buttons.indexOf(resourcesButton)
+    );
+  });
+
+  test('renders Beams below Resources when cfg.beamsUi is false', () => {
+    cfg.beamsUi = false;
+
+    renderNav();
+
+    const beamsButton = screen.getByRole('button', { name: 'Beams' });
+    const resourcesButton = screen.getByRole('button', { name: 'Resources' });
+    const buttons = screen.getAllByRole('button');
+
+    expect(buttons.indexOf(resourcesButton)).toBeLessThan(
+      buttons.indexOf(beamsButton)
+    );
+  });
+});
+
+describe('Beams default sticky drawer', () => {
+  const originalIsDashboard = cfg.isDashboard;
+  const originalBeamsUi = cfg.beamsUi;
+
+  // The drawer panel has no dedicated open/closed attribute: it slides into
+  // view (translateX(0)) when open and off-screen (translateX(-100%)) when
+  // closed. Assert on that slide transform to verify the expanded state.
+  function expectBeamsDrawerOpen(open: boolean) {
+    expect(document.getElementById('panel-Beams')).toHaveStyle({
+      transform: open ? 'translateX(0)' : 'translateX(-100%)',
+    });
+  }
+
+  beforeEach(() => {
+    cfg.isDashboard = false;
+    cfg.beamsUi = true;
+  });
+
+  afterEach(() => {
+    cfg.isDashboard = originalIsDashboard;
+    cfg.beamsUi = originalBeamsUi;
+  });
+
+  async function mountNav({
+    drawerMode,
+    updatePreferences = jest.fn(),
+    initialPath = '/web/beams/get-started',
+  }: {
+    drawerMode: SideNavDrawerMode;
+    updatePreferences?: jest.Mock;
+    initialPath?: string;
+  }) {
+    const preferences = makeDefaultUserPreferences();
+    preferences.sideNavDrawerMode = drawerMode;
+    mockUserContextProviderWith(
+      makeTestUserContext({ preferences, updatePreferences })
+    );
+    const ctx = createTeleportContext();
+    const features = [beamsFeature];
+
+    render(
+      <MemoryRouter initialEntries={[initialPath]}>
+        <ContextProvider ctx={ctx}>
+          <FeaturesContextProvider value={features}>
+            <Navigation />
+          </FeaturesContextProvider>
+        </ContextProvider>
+      </MemoryRouter>
+    );
+    await act(tick);
+    return { updatePreferences };
+  }
+
+  test('defaults to a sticky, expanded drawer when the user has no prior preference', async () => {
+    const { updatePreferences } = await mountNav({
+      drawerMode: SideNavDrawerMode.UNSPECIFIED,
+    });
+
+    expectBeamsDrawerOpen(true);
+    expect(updatePreferences).not.toHaveBeenCalled();
+  });
+
+  test('honors an explicit COLLAPSED preference', async () => {
+    const { updatePreferences } = await mountNav({
+      drawerMode: SideNavDrawerMode.COLLAPSED,
+    });
+
+    expectBeamsDrawerOpen(false);
+    expect(updatePreferences).not.toHaveBeenCalled();
+  });
+
+  test('honors an explicit STICKY preference', async () => {
+    await mountNav({ drawerMode: SideNavDrawerMode.STICKY });
+
+    expectBeamsDrawerOpen(true);
+  });
+
+  test('does not default to sticky when cfg.beamsUi is false', async () => {
+    cfg.beamsUi = false;
+    const { updatePreferences } = await mountNav({
+      drawerMode: SideNavDrawerMode.UNSPECIFIED,
+    });
+
+    expectBeamsDrawerOpen(false);
+    expect(updatePreferences).not.toHaveBeenCalled();
   });
 });

--- a/web/packages/teleport/src/Navigation/Navigation.tsx
+++ b/web/packages/teleport/src/Navigation/Navigation.tsx
@@ -44,8 +44,8 @@ import { useUser } from 'teleport/User/UserContext';
 import useStickyClusterId from 'teleport/useStickyClusterId';
 
 import {
-  BEAMS_NAVIGATION_CATEGORIES,
   CustomNavigationSubcategory,
+  NavigationCategory,
   NAVIGATION_CATEGORIES,
   SidenavCategory,
 } from './categories';
@@ -124,11 +124,7 @@ export type NavigationSubsection = {
 function getNavigationSections(
   features: TeleportFeature[]
 ): NavigationSection[] {
-  // Override the order for beams UI
-  const categories = cfg.beamsUi
-    ? BEAMS_NAVIGATION_CATEGORIES
-    : NAVIGATION_CATEGORIES;
-  const navigationSections = categories.map(category => ({
+  const navigationSections = NAVIGATION_CATEGORIES.map(category => ({
     category,
     subsections: getSubsectionsForCategory(category, features),
   }));
@@ -174,6 +170,31 @@ function getSubsectionsForCategory(
       isHyperLink: feature.isHyperLink,
     };
   });
+}
+
+/**
+ * getOrderedSections returns the sections in their final visual order for
+ * the side nav. For dashboards, Resources is omitted (it's not rendered).
+ * For regular tenants Resources comes first by default. When Beams lite UI
+ * is enabled, Beams is positioned above Resources as the first nav category.
+ */
+function getOrderedSections(
+  navSections: NavigationSection[],
+  resourcesSection: NavigationSection
+): NavigationSection[] {
+  if (cfg.isDashboard) {
+    return navSections;
+  }
+  if (cfg.beamsUi) {
+    const beams = navSections.find(
+      s => s.category === NavigationCategory.Beams
+    );
+    const rest = navSections.filter(
+      s => s.category !== NavigationCategory.Beams
+    );
+    return [...(beams ? [beams] : []), resourcesSection, ...rest];
+  }
+  return [resourcesSection, ...navSections];
 }
 
 /**
@@ -348,7 +369,12 @@ export function Navigation({
     [features, history.location]
   );
 
-  const stickyMode = preferences.sideNavDrawerMode === SideNavDrawerMode.STICKY;
+  // For the beams UI, the drawer defaults to sticky for users who haven't set
+  // an explicit preference yet (UNSPECIFIED).
+  const stickyMode =
+    preferences.sideNavDrawerMode === SideNavDrawerMode.UNSPECIFIED
+      ? cfg.beamsUi
+      : preferences.sideNavDrawerMode === SideNavDrawerMode.STICKY;
 
   const toggleStickyMode = () => {
     // Close the drawer right away if they're disabling sticky mode.
@@ -399,15 +425,18 @@ export function Navigation({
     [debouncedSection]
   );
 
-  const combinedSideNavSections = useMemo(
-    () => [resourcesSection, ...navSections],
-    [resourcesSection, navSections]
+  const orderedSections = useMemo(
+    () => getOrderedSections(navSections, resourcesSection),
+    [navSections, resourcesSection]
   );
-  const currentPageSection = useMemo(() => {
-    return combinedSideNavSections.find(
-      section => section.category === currentView?.category
-    );
-  }, [combinedSideNavSections, currentView]);
+
+  const currentPageSection = useMemo(
+    () =>
+      orderedSections.find(
+        section => section.category === currentView?.category
+      ),
+    [orderedSections, currentView]
+  );
 
   const collapseDrawer = useCallback(
     (closeAfterDelay = true) => {
@@ -454,7 +483,7 @@ export function Navigation({
         collapseDrawer(false);
       }, 150);
     }
-  }, [collapseDrawer]);
+  }, [collapseDrawer, stickyMode]);
 
   // Hide the nav if the current feature has hideNavigation set to true.
   const hideNav = features.find(
@@ -469,6 +498,65 @@ export function Navigation({
   if (hideNav) {
     return null;
   }
+
+  const renderNavSection = (section: NavigationSection) => {
+    // Resources is a "special" section that owns its own panel content
+    // rather than a generic list of subsections, so it gets its own component.
+    if (section.category === NavigationCategory.Resources) {
+      return (
+        <ResourcesSection
+          key="resources"
+          expandedSection={debouncedSection}
+          previousExpandedSection={previousExpandedSection}
+          handleSetExpandedSection={handleSetExpandedSection}
+          currentView={currentView}
+          stickyMode={stickyMode}
+          toggleStickyMode={toggleStickyMode}
+          canToggleStickyMode={!!currentPageSection}
+          showPoweredByLogo={showPoweredByLogo}
+        />
+      );
+    }
+
+    if (section.standalone) {
+      return (
+        <StandaloneSection
+          key={section.standalone.route}
+          title={section.standalone.title}
+          route={section.standalone.route}
+          Icon={section.standalone.Icon}
+          $active={section.standalone.route === currentView?.route}
+        />
+      );
+    }
+
+    const isExpanded =
+      !!debouncedSection &&
+      !debouncedSection.standalone &&
+      section.category === debouncedSection?.category;
+
+    return (
+      <React.Fragment key={section.category}>
+        {section.category === 'Add New' && <Divider />}
+        <DefaultSection
+          key={section.category}
+          section={section}
+          currentView={currentView}
+          previousExpandedSection={previousExpandedSection}
+          onExpandSection={() => handleSetExpandedSection(section)}
+          currentPageSection={currentPageSection}
+          stickyMode={stickyMode}
+          toggleStickyMode={toggleStickyMode}
+          $active={section.category === currentView?.category}
+          aria-controls={`panel-${debouncedSection?.category}`}
+          onNavigationItemClick={onNavigationItemClick}
+          isExpanded={isExpanded}
+          showPoweredByLogo={showPoweredByLogo}
+        />
+      </React.Fragment>
+    );
+  };
+
   return (
     <Container
       as="nav"
@@ -491,68 +579,18 @@ export function Navigation({
       <SideNavContainer>
         <PanelBackground />
         {!cfg.isDashboard && (
-          <>
-            <SearchSection
-              navigationSections={[...combinedSideNavSections, topMenuSection]}
-              expandedSection={debouncedSection}
-              previousExpandedSection={previousExpandedSection}
-              handleSetExpandedSection={handleSetExpandedSection}
-              currentView={currentView}
-              stickyMode={stickyMode}
-              toggleStickyMode={toggleStickyMode}
-              canToggleStickyMode={!!currentPageSection}
-            />
-            <ResourcesSection
-              expandedSection={debouncedSection}
-              previousExpandedSection={previousExpandedSection}
-              handleSetExpandedSection={handleSetExpandedSection}
-              currentView={currentView}
-              stickyMode={stickyMode}
-              toggleStickyMode={toggleStickyMode}
-              canToggleStickyMode={!!currentPageSection}
-              showPoweredByLogo={showPoweredByLogo}
-            />
-          </>
+          <SearchSection
+            navigationSections={[...orderedSections, topMenuSection]}
+            expandedSection={debouncedSection}
+            previousExpandedSection={previousExpandedSection}
+            handleSetExpandedSection={handleSetExpandedSection}
+            currentView={currentView}
+            stickyMode={stickyMode}
+            toggleStickyMode={toggleStickyMode}
+            canToggleStickyMode={!!currentPageSection}
+          />
         )}
-        {navSections.map(section => {
-          if (section.standalone) {
-            return (
-              <StandaloneSection
-                key={section.standalone.route}
-                title={section.standalone.title}
-                route={section.standalone.route}
-                Icon={section.standalone.Icon}
-                $active={section.standalone.route === currentView?.route}
-              />
-            );
-          }
-
-          const isExpanded =
-            !!debouncedSection &&
-            !debouncedSection.standalone &&
-            section.category === debouncedSection?.category;
-
-          return (
-            <React.Fragment key={section.category}>
-              {section.category === 'Add New' && <Divider />}
-              <DefaultSection
-                key={section.category}
-                section={section}
-                currentView={currentView}
-                previousExpandedSection={previousExpandedSection}
-                onExpandSection={() => handleSetExpandedSection(section)}
-                currentPageSection={currentPageSection}
-                stickyMode={stickyMode}
-                toggleStickyMode={toggleStickyMode}
-                $active={section.category === currentView?.category}
-                aria-controls={`panel-${debouncedSection?.category}`}
-                onNavigationItemClick={onNavigationItemClick}
-                isExpanded={isExpanded}
-                showPoweredByLogo={showPoweredByLogo}
-              />
-            </React.Fragment>
-          );
-        })}
+        {orderedSections.map(renderNavSection)}
       </SideNavContainer>
     </Container>
   );

--- a/web/packages/teleport/src/Navigation/categories.ts
+++ b/web/packages/teleport/src/Navigation/categories.ts
@@ -53,10 +53,3 @@ export const NAVIGATION_CATEGORIES = [
   NavigationCategory.Audit,
   NavigationCategory.AddNew,
 ];
-
-// BEAMS_NAVIGATION_CATEGORIES is a re-ordered list of categories for the beams
-// onboarding experience.
-export const BEAMS_NAVIGATION_CATEGORIES: typeof NAVIGATION_CATEGORIES = [
-  NavigationCategory.Beams,
-  ...NAVIGATION_CATEGORIES.filter(c => c !== NavigationCategory.Beams),
-];

--- a/web/packages/teleport/src/services/userPreferences/userPreferences.ts
+++ b/web/packages/teleport/src/services/userPreferences/userPreferences.ts
@@ -101,7 +101,7 @@ export function makeDefaultUserPreferences(): UserPreferences {
       availableResourceMode: AvailableResourceMode.ALL,
     },
     clusterPreferences: makeDefaultUserClusterPreferences(),
-    sideNavDrawerMode: SideNavDrawerMode.COLLAPSED,
+    sideNavDrawerMode: SideNavDrawerMode.UNSPECIFIED,
     discoverResourcePreferences: {},
     keyboardLayout: 0,
   };


### PR DESCRIPTION
Backport #66603 to branch/v18


## Changes
- Side nav auto-expand on first Beams visit. When a user navigates to the Beams page for the first time on a given browser, the side nav flips into "keep expanded" mode (the existing sideNavDrawerMode = STICKY preference). The panel then stays open while they navigate around, mirroring the behavior they'd get from clicking the keep-expanded toggle themselves. Tracked via a BEAMS_FIRST_VISIT_EXPANDED localStorage flag so it runs once per browser, so users who later collapse the panel won't have it re-trigger.
- Beams reordered to first nav item. Beams now sits directly under the Search icon, above Resources. Implemented by extracting the Beams NavigationSection from the generic navSections.map and rendering it in a dedicated slot above <ResourcesSection />. Search dropdown ordering is unaffected.

<!-- Provide a descriptive entry for the changelog of the next release. -->



<!-- Include manual testing efforts to verify the change. -->
<!-- Detail where the tests where run and what configurations were used. -->
<!-- Include all the test cases which were run to validate the change. -->

## Screenshot
<img width="549" height="1024" alt="image" src="https://github.com/user-attachments/assets/75b2ffd9-32a6-4fe2-872d-de0142aa043c" />


## Manual Test Plan
### Test Environment
Check out this branch and from the e/ directory:


PROXY_TARGET=<your-cluster-host> pnpm start-teleport-e
In a Chrome devtools console (or via Application → Local storage) clear grv_teleport_beams_first_visit_expanded and grv_teleport_user_preferences between runs to reset the first-visit state.


### Test Cases
- [x] Confirm the side nav shows the items in this order: Search → Beams → Resources showing Beams the first item after Search
- [x] Navigate to the Beams Quickstart page. The side nav panel should expand and the "Keep expanded" toggle should appear active. Refresh the panel should - still be expanded. Navigate to Resources and it should stay expanded (sticky mode on).
- [x] From the auto-expanded state, click the keep-expanded toggle to collapse. The flag is set, so the next refresh does NOT re-trigger the auto-expand; the panel stays collapsed.
