### PR TITLE
[v18] Bump react-day-picker from 9.14.0 to 10.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "immer": "^11.1.8",
     "prop-types": "^15.8.1",
     "react": "^19.2.6",
-    "react-day-picker": "^9.14.0",
+    "react-day-picker": "^10.0.1",
     "react-dom": "^19.2.6",
     "react-error-boundary": "^6.1.2",
     "react-hook-form": "^7.76.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -77,8 +77,8 @@ importers:
         specifier: ^19.2.6
         version: 19.2.6
       react-day-picker:
-        specifier: ^9.14.0
-        version: 9.14.0(react@19.2.6)
+        specifier: ^10.0.1
+        version: 10.0.1(@types/react@19.2.15)(react@19.2.6)
       react-dom:
         specifier: ^19.2.6
         version: 19.2.6(react@19.2.6)
@@ -3154,10 +3154,6 @@ packages:
     resolution: {integrity: sha512-4BAffykYOgO+5nzBWYwE3W90sBgLJoUPRWWcL8wlyiM8IB8ipJz3UMJ9KXQd1RKQXpKp8Tutn80HZtWsu2u76w==}
     engines: {node: '>=10'}
 
-  '@tabby_ai/hijri-converter@1.0.5':
-    resolution: {integrity: sha512-r5bClKrcIusDoo049dSL8CawnHR6mRdDwhlQuIgZRNty68q0x8k3Lf1BtPAMxRf/GgnHBnIO4ujd3+GQdLWzxQ==}
-    engines: {node: '>=16.0.0'}
-
   '@tanstack/query-core@5.100.14':
     resolution: {integrity: sha512-5X41dGpxgeaHISCRW2oYwcSycZeULZzAunaudXT9ov1KOTj9xwt0CH6hbwqP1/z74ZWF7rYFnDpyYH07XFcZew==}
 
@@ -4276,9 +4272,6 @@ packages:
   data-urls@7.0.0:
     resolution: {integrity: sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
-
-  date-fns-jalali@4.1.0-0:
-    resolution: {integrity: sha512-hTIP/z+t+qKwBDcmmsnmjWTduxCg+5KfdqWQvb2X/8C9+knYY6epN/pfxdDuyVlSVeFz0sM5eEfwIUQ70U4ckg==}
 
   date-fns@4.3.0:
     resolution: {integrity: sha512-OYcL+3N/jyWbYdFGqoMAhytDgxP9pbYPUUiRCOgn4Fewaadk9l/Wam4Avciiyp2BgkpfQyBV9B+ehnVJych+eQ==}
@@ -5971,11 +5964,15 @@ packages:
     resolution: {integrity: sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==}
     engines: {node: '>=10'}
 
-  react-day-picker@9.14.0:
-    resolution: {integrity: sha512-tBaoDWjPwe0M5pGrum4H0SR6Lyk+BO9oHnp9JbKpGKW2mlraNPgP9BMfsg5pWpwrssARmeqk7YBl2oXutZTaHA==}
+  react-day-picker@10.0.1:
+    resolution: {integrity: sha512-eNh6BlwcYInWaJtRv18mXQ06Ys/H6rdTZAnTaSdOYJuTpwP1JMCHNd1FDRadA+gbeinq+psdULN5Xnowy9mV8w==}
     engines: {node: '>=18'}
     peerDependencies:
+      '@types/react': '>=16.8.0'
       react: '>=16.8.0'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
 
   react-dnd-html5-backend@14.1.0:
     resolution: {integrity: sha512-6ONeqEC3XKVf4eVmMTe0oPds+c5B9Foyj8p/ZKLb7kL2qh9COYxiBHv3szd6gztqi/efkmriywLUVlPotqoJyw==}
@@ -9729,8 +9726,6 @@ snapshots:
     dependencies:
       defer-to-connect: 2.0.1
 
-  '@tabby_ai/hijri-converter@1.0.5': {}
-
   '@tanstack/query-core@5.100.14': {}
 
   '@tanstack/react-query@5.100.14(react@19.2.6)':
@@ -10973,8 +10968,6 @@ snapshots:
       whatwg-url: 16.0.1
     transitivePeerDependencies:
       - '@noble/hashes'
-
-  date-fns-jalali@4.1.0-0: {}
 
   date-fns@4.3.0: {}
 
@@ -12985,13 +12978,13 @@ snapshots:
 
   quick-lru@5.1.1: {}
 
-  react-day-picker@9.14.0(react@19.2.6):
+  react-day-picker@10.0.1(@types/react@19.2.15)(react@19.2.6):
     dependencies:
       '@date-fns/tz': 1.5.0
-      '@tabby_ai/hijri-converter': 1.0.5
       date-fns: 4.3.0
-      date-fns-jalali: 4.1.0-0
       react: 19.2.6
+    optionalDependencies:
+      '@types/react': 19.2.15
 
   react-dnd-html5-backend@14.1.0:
     dependencies:

--- a/web/packages/shared/components/AccessRequests/AssumeStartTime/AssumeStartTime.tsx
+++ b/web/packages/shared/components/AccessRequests/AssumeStartTime/AssumeStartTime.tsx
@@ -19,7 +19,7 @@
 import { addMonths } from 'date-fns';
 import { useState } from 'react';
 import { DayPicker } from 'react-day-picker';
-import 'react-day-picker/dist/style.css';
+import 'react-day-picker/style.css';
 import styled from 'styled-components';
 
 import { Box, ButtonIcon, Flex, LabelInput } from 'design';
@@ -153,8 +153,10 @@ export function AssumeStartTime({
                 padding: ${p => p.theme.space[1]}px;
                 height: auto;
                 .rdp {
-                  --rdp-cell-size: 30px; /* Size of the day cells. */
-                  --rdp-caption-font-size: 14px; /* Font size for the caption labels. */
+                  --rdp-day-height: 30px;
+                  --rdp-day-width: 30px;
+                  --rdp-day_button-height: 28px;
+                  --rdp-day_button-width: 28px;
                 }
               `}
             >
@@ -163,11 +165,11 @@ export function AssumeStartTime({
                 onDayClick={updateStartDate}
                 defaultMonth={startDate}
                 selected={startOrRequestedDate}
-                fromMonth={startDate}
+                startMonth={startDate}
                 // Incase part of 7 days falls to the next month.
                 // Allows user to select day from next month
                 // and disables navigating rest of month.
-                toMonth={addMonths(startDate, 1)}
+                endMonth={addMonths(startDate, 1)}
                 // Disables before today, and after 7th day.
                 disabled={[
                   {

--- a/web/packages/teleport/src/components/EventRangePicker/Custom/Custom.tsx
+++ b/web/packages/teleport/src/components/EventRangePicker/Custom/Custom.tsx
@@ -19,7 +19,7 @@
 import { endOfDay, isAfter, startOfDay, subMonths } from 'date-fns';
 import { forwardRef, useState } from 'react';
 import { DateRange, DayPicker } from 'react-day-picker';
-import 'react-day-picker/dist/style.css';
+import 'react-day-picker/style.css';
 
 import { StyledDateRange } from 'design/DatePicker';
 

--- a/web/packages/teleport/src/components/EventRangePicker/EventRangePicker.tsx
+++ b/web/packages/teleport/src/components/EventRangePicker/EventRangePicker.tsx
@@ -18,7 +18,7 @@
 
 import { useState } from 'react';
 import { components, ValueContainerProps } from 'react-select';
-import 'react-day-picker/dist/style.css';
+import 'react-day-picker/style.css';
 import styled from 'styled-components';
 
 import { Box, Text } from 'design';


### PR DESCRIPTION
Backport #67254

* ent counterpart: https://github.com/gravitational/teleport.e/pull/8955

## Manual Test Plan
### Test Environment

My laptop.

### Test Cases
- [x] The range picker in the audit logs and in the access request checkout works.
