### PR TITLE
[v18] Bump which from 6.0.1 to 7.0.0

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -437,8 +437,8 @@ importers:
         specifier: ^3.1.2
         version: 3.1.2
       which:
-        specifier: ^6.0.1
-        version: 6.0.1
+        specifier: ^7.0.0
+        version: 7.0.0
       winston:
         specifier: ^3.19.0
         version: 3.19.0
@@ -6850,9 +6850,9 @@ packages:
     engines: {node: ^18.17.0 || >=20.5.0}
     hasBin: true
 
-  which@6.0.1:
-    resolution: {integrity: sha512-oGLe46MIrCRqX7ytPUf66EAYvdeMIZYn3WaocqqKZAxrBpkqHfL/qvTyJ/bTk5+AqHCjXmrv3CEWgy368zhRUg==}
-    engines: {node: ^20.17.0 || >=22.9.0}
+  which@7.0.0:
+    resolution: {integrity: sha512-RancgH2dmbLdHl6LRhEqvklWMgl/Hdnun0Y90KhBOLkMefg8Qa7/Zel8Sm+8HEcP6DEjzsWzpkuBQEZok58isA==}
+    engines: {node: ^22.22.2 || ^24.15.0 || >=26.0.0}
     hasBin: true
 
   winston-transport@4.9.0:
@@ -13884,7 +13884,7 @@ snapshots:
     dependencies:
       isexe: 3.1.1
 
-  which@6.0.1:
+  which@7.0.0:
     dependencies:
       isexe: 4.0.0
 

--- a/web/packages/teleterm/package.json
+++ b/web/packages/teleterm/package.json
@@ -33,7 +33,7 @@
     "split2": "4.2.0",
     "strip-ansi": "^7.2.0",
     "tar-fs": "^3.1.2",
-    "which": "^6.0.1",
+    "which": "^7.0.0",
     "winston": "^3.19.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Backport https://github.com/gravitational/teleport/pull/67249 to branch/v18

<!-- Include manual testing efforts to verify the change. -->
<!-- Detail where the tests where run and what configurations were used. -->
<!-- Include all the test cases which were run to validate the change. -->

## Manual Test Plan
### Test Environment
Locally built app.

### Test Cases
- [x] Spawning a PTY process works in Connect. 
