### PR TITLE
Fix MFA flags

### DIFF
--- a/docs/pages/zero-trust-access/authentication/per-session-mfa.mdx
+++ b/docs/pages/zero-trust-access/authentication/per-session-mfa.mdx
@@ -215,7 +215,7 @@ Use the following command to connect to the database or to the address above usi
   $ psql postgres://my-prod-user@localhost:65282/my-prod-db
 MFA is required to access Database "prod-postgres-instance"
 Available MFA methods [WEBAUTHN, BROWSER]. Continuing with WEBAUTHN.
-If you wish to perform MFA with another method, specify with flag --mfa-mode=<webauthn,browser> or environment variable TELEPORT_MFA_MODE=<webauthn,browser>.
+If you wish to perform MFA with another method, specify with flag --mfa-mode=<cross-platform,platform,browser> or environment variable TELEPORT_MFA_MODE=<cross-platform,platform,browser>.
 
 Tap any security key <tap>
 Detected security key tap
@@ -248,7 +248,10 @@ prod-mysql-instance-2             mysql    env=prod
 Do you want to proceed with 2 database(s)? [y/N]: y
 Executing command for "prod-mysql-instance-1". Output will be saved at "logs/prod-mysql-instance-1.output".
 MFA is required to access Database "prod-mysql-instance-1"
-Tap any security key
+Available MFA methods [WEBAUTHN, BROWSER]. Continuing with WEBAUTHN.
+If you wish to perform MFA with another method, specify with flag --mfa-mode=<cross-platform,platform,browser> or environment variable TELEPORT_MFA_MODE=<cross-platform,platform,browser>.
+
+Tap any security key <tap>
 Detected security key tap
 Executing command for "prod-mysql-instance-2". Output will be saved at "logs/prod-mysql-instance-2.output".
 
@@ -273,7 +276,7 @@ Logged into Kubernetes cluster "prod-kube-cluster". Try 'kubectl version' to tes
 $ kubectl version
 MFA is required to access Kubernetes cluster "prod-kube-cluster"
 Available MFA methods [WEBAUTHN, BROWSER]. Continuing with WEBAUTHN.
-If you wish to perform MFA with another method, specify with flag --mfa-mode=<webauthn,browser> or environment variable TELEPORT_MFA_MODE=<webauthn,browser>.
+If you wish to perform MFA with another method, specify with flag --mfa-mode=<cross-platform,platform,browser> or environment variable TELEPORT_MFA_MODE=<cross-platform,platform,browser>.
 
 Tap any security key <tap>
 Detected security key tap
@@ -295,7 +298,7 @@ example.com           prod-kube-cluster example.com-prod-kube-cluster
 
 MFA is required to access Kubernetes cluster "prod-kube-cluster"
 Available MFA methods [WEBAUTHN, BROWSER]. Continuing with WEBAUTHN.
-If you wish to perform MFA with another method, specify with flag --mfa-mode=<webauthn,browser> or environment variable TELEPORT_MFA_MODE=<webauthn,browser>.
+If you wish to perform MFA with another method, specify with flag --mfa-mode=<cross-platform,platform,browser> or environment variable TELEPORT_MFA_MODE=<cross-platform,platform,browser>.
 
 Tap any security key <tap>
 Detected security key tap

--- a/lib/client/mfa/cli.go
+++ b/lib/client/mfa/cli.go
@@ -182,14 +182,31 @@ func (c *CLIPrompt) filterMFAMethods(state mfaPromptState, isPerSessionMFA bool,
 	// If there are multiple options and we chose fewer without explicit user preference,
 	// notify the user about the available methods and how to select a specific one.
 	if len(availableMethods) > len(chosenMethods) && len(chosenMethods) > 0 && !userSpecifiedMethod {
-		availableMethodsString := strings.ToLower(strings.Join(availableMethods, ","))
+		chosenMethodsString := strings.Join(chosenMethods, " and ")
+		modeValuesString := strings.ToLower(strings.Join(expandMFAMethods(availableMethods), ","))
+
 		const msg = "" +
 			"Available MFA methods [%v]. Continuing with %v.\r\n" +
 			"If you wish to perform MFA with another method, specify with flag --mfa-mode=<%v> or environment variable TELEPORT_MFA_MODE=<%v>.\r\n\r\n"
-		fmt.Fprintf(c.writer(), msg, strings.Join(availableMethods, ", "), strings.Join(chosenMethods, " and "), availableMethodsString, availableMethodsString)
+		fmt.Fprintf(c.writer(), msg, modeValuesString, chosenMethodsString, modeValuesString, modeValuesString)
 	}
 
 	return state, userSpecifiedMethod
+}
+
+// expandMFAMethods replaces the WEBAUTHN method name with the valid --mfa-mode
+// values it maps to ("cross-platform" and "platform"), since "webauthn" is not
+// itself a valid mode.
+func expandMFAMethods(methods []string) []string {
+	expanded := make([]string, 0, len(methods)+1)
+	for _, m := range methods {
+		if m == cliMFATypeWebauthn {
+			expanded = append(expanded, "cross-platform", "platform")
+			continue
+		}
+		expanded = append(expanded, m)
+	}
+	return expanded
 }
 
 // Run prompts the user to complete an MFA authentication challenge.
@@ -298,7 +315,7 @@ func (c *CLIPrompt) promptWithFallback(ctx context.Context, chal *proto.MFAAuthe
 			if lastErr != nil {
 				return nil, trace.Wrap(lastErr)
 			}
-			return nil, trace.BadParameter("client does not support any available MFA methods [%v], see debug logs for details", strings.Join(availableMethods, ", "))
+			return nil, trace.BadParameter("client does not support any available MFA methods [%v], see debug logs for details", strings.ToLower(strings.Join(expandMFAMethods(availableMethods), ", ")))
 		}
 
 		// If we're retrying after a failure, inform the user.

--- a/lib/client/mfa/cli.go
+++ b/lib/client/mfa/cli.go
@@ -182,14 +182,14 @@ func (c *CLIPrompt) filterMFAMethods(state mfaPromptState, isPerSessionMFA bool,
 	// If there are multiple options and we chose fewer without explicit user preference,
 	// notify the user about the available methods and how to select a specific one.
 	if len(availableMethods) > len(chosenMethods) && len(chosenMethods) > 0 && !userSpecifiedMethod {
-		chosenMethodsString := strings.Join(chosenMethods, " and ")
-		availableMethodsString := strings.ToLower(strings.Join(availableMethods, ","))
-		flagModeValuesString := strings.ToLower(strings.Join(expandMFAMethods(availableMethods), ","))
+		joinedChosenMethods := strings.Join(chosenMethods, " and ")
+		joinedAvailableMethods := strings.Join(availableMethods, ", ")
+		joinedFlags := strings.ToLower(strings.Join(expandMFAMethods(availableMethods), ","))
 
 		const msg = "" +
 			"Available MFA methods [%v]. Continuing with %v.\r\n" +
 			"If you wish to perform MFA with another method, specify with flag --mfa-mode=<%v> or environment variable TELEPORT_MFA_MODE=<%v>.\r\n\r\n"
-		fmt.Fprintf(c.writer(), msg, availableMethodsString, chosenMethodsString, flagModeValuesString, flagModeValuesString)
+		fmt.Fprintf(c.writer(), msg, joinedAvailableMethods, joinedChosenMethods, joinedFlags, joinedFlags)
 	}
 
 	return state, userSpecifiedMethod

--- a/lib/client/mfa/cli.go
+++ b/lib/client/mfa/cli.go
@@ -183,19 +183,21 @@ func (c *CLIPrompt) filterMFAMethods(state mfaPromptState, isPerSessionMFA bool,
 	// notify the user about the available methods and how to select a specific one.
 	if len(availableMethods) > len(chosenMethods) && len(chosenMethods) > 0 && !userSpecifiedMethod {
 		chosenMethodsString := strings.Join(chosenMethods, " and ")
-		modeValuesString := strings.ToLower(strings.Join(expandMFAMethods(availableMethods), ","))
+		availableMethodsString := strings.ToLower(strings.Join(availableMethods, ","))
+		flagModeValuesString := strings.ToLower(strings.Join(expandMFAMethods(availableMethods), ","))
 
 		const msg = "" +
 			"Available MFA methods [%v]. Continuing with %v.\r\n" +
 			"If you wish to perform MFA with another method, specify with flag --mfa-mode=<%v> or environment variable TELEPORT_MFA_MODE=<%v>.\r\n\r\n"
-		fmt.Fprintf(c.writer(), msg, modeValuesString, chosenMethodsString, modeValuesString, modeValuesString)
+		fmt.Fprintf(c.writer(), msg, availableMethodsString, chosenMethodsString, flagModeValuesString, flagModeValuesString)
 	}
 
 	return state, userSpecifiedMethod
 }
 
-// expandMFAMethods replaces the WEBAUTHN method name with the valid --mfa-mode
-// values it maps to ("cross-platform" and "platform"), since "webauthn" is not
+// expandMFAMethods replaces the MFA type with the appropriate --mfa-mode.
+// Currently this is only a concern for the WEBAUTHN MFA type name which maps to
+// "cross-platform" and "platform", since "webauthn" is not
 // itself a valid mode.
 func expandMFAMethods(methods []string) []string {
 	expanded := make([]string, 0, len(methods)+1)
@@ -315,7 +317,7 @@ func (c *CLIPrompt) promptWithFallback(ctx context.Context, chal *proto.MFAAuthe
 			if lastErr != nil {
 				return nil, trace.Wrap(lastErr)
 			}
-			return nil, trace.BadParameter("client does not support any available MFA methods [%v], see debug logs for details", strings.ToLower(strings.Join(expandMFAMethods(availableMethods), ", ")))
+			return nil, trace.BadParameter("client does not support any available MFA methods [%v], see debug logs for details", strings.Join(availableMethods, ", "))
 		}
 
 		// If we're retrying after a failure, inform the user.

--- a/lib/client/mfa/cli_test.go
+++ b/lib/client/mfa/cli_test.go
@@ -186,7 +186,7 @@ func TestCLIPrompt(t *testing.T) {
 		{
 			name: "OK prefer webauthn over sso",
 			expectStdOut: "" +
-				"Available MFA methods [webauthn,sso]. Continuing with WEBAUTHN.\r\n" +
+				"Available MFA methods [WEBAUTHN, SSO]. Continuing with WEBAUTHN.\r\n" +
 				"If you wish to perform MFA with another method, specify with flag --mfa-mode=<cross-platform,platform,sso> or environment variable TELEPORT_MFA_MODE=<cross-platform,platform,sso>.\r\n\r\n" +
 				"Tap any security key\n",
 			challenge: &proto.MFAAuthenticateChallenge{
@@ -202,7 +202,7 @@ func TestCLIPrompt(t *testing.T) {
 		{
 			name: "OK prefer webauthn+otp over sso",
 			expectStdOut: "" +
-				"Available MFA methods [webauthn,sso,otp]. Continuing with WEBAUTHN and OTP.\r\n" +
+				"Available MFA methods [WEBAUTHN, SSO, OTP]. Continuing with WEBAUTHN and OTP.\r\n" +
 				"If you wish to perform MFA with another method, specify with flag --mfa-mode=<cross-platform,platform,sso,otp> or environment variable TELEPORT_MFA_MODE=<cross-platform,platform,sso,otp>.\r\n\r\n" +
 				"Tap any security key or enter a code from a OTP device\r\n",
 			challenge: &proto.MFAAuthenticateChallenge{
@@ -222,7 +222,7 @@ func TestCLIPrompt(t *testing.T) {
 		{
 			name: "OK prefer sso over otp",
 			expectStdOut: "" +
-				"Available MFA methods [sso,otp]. Continuing with SSO.\r\n" +
+				"Available MFA methods [SSO, OTP]. Continuing with SSO.\r\n" +
 				"If you wish to perform MFA with another method, specify with flag --mfa-mode=<sso,otp> or environment variable TELEPORT_MFA_MODE=<sso,otp>.\r\n\r\n",
 			challenge: &proto.MFAAuthenticateChallenge{
 				TOTP:         &proto.TOTPChallenge{},
@@ -240,7 +240,7 @@ func TestCLIPrompt(t *testing.T) {
 		{
 			name: "OK prefer webauthn over otp when stdin hijack disallowed",
 			expectStdOut: "" +
-				"Available MFA methods [webauthn,otp]. Continuing with WEBAUTHN.\r\n" +
+				"Available MFA methods [WEBAUTHN, OTP]. Continuing with WEBAUTHN.\r\n" +
 				"If you wish to perform MFA with another method, specify with flag --mfa-mode=<cross-platform,platform,otp> or environment variable TELEPORT_MFA_MODE=<cross-platform,platform,otp>.\r\n\r\n" +
 				"Tap any security key\n",
 			challenge: &proto.MFAAuthenticateChallenge{
@@ -256,7 +256,7 @@ func TestCLIPrompt(t *testing.T) {
 		{
 			name: "OK webauthn or otp with stdin hijack allowed, choose webauthn",
 			expectStdOut: "" +
-				"Available MFA methods [webauthn,sso,otp]. Continuing with WEBAUTHN and OTP.\r\n" +
+				"Available MFA methods [WEBAUTHN, SSO, OTP]. Continuing with WEBAUTHN and OTP.\r\n" +
 				"If you wish to perform MFA with another method, specify with flag --mfa-mode=<cross-platform,platform,sso,otp> or environment variable TELEPORT_MFA_MODE=<cross-platform,platform,sso,otp>.\r\n\r\n" +
 				"Tap any security key or enter a code from a OTP device\r\n",
 			challenge: &proto.MFAAuthenticateChallenge{
@@ -276,7 +276,7 @@ func TestCLIPrompt(t *testing.T) {
 		{
 			name: "OK webauthn or otp with stdin hijack allowed, choose otp",
 			expectStdOut: "" +
-				"Available MFA methods [webauthn,sso,otp]. Continuing with WEBAUTHN and OTP.\r\n" +
+				"Available MFA methods [WEBAUTHN, SSO, OTP]. Continuing with WEBAUTHN and OTP.\r\n" +
 				"If you wish to perform MFA with another method, specify with flag --mfa-mode=<cross-platform,platform,sso,otp> or environment variable TELEPORT_MFA_MODE=<cross-platform,platform,sso,otp>.\r\n\r\n" +
 				"Tap any security key or enter a code from a OTP device\r\n",
 			stdin: "123456",
@@ -440,7 +440,7 @@ Enter your security key PIN:
 				cfg.WebauthnSupported = false
 				cfg.CallbackCeremony = nil
 			},
-			expectErr: trace.BadParameter("client does not support any available MFA methods [webauthn, sso], see debug logs for details"),
+			expectErr: trace.BadParameter("client does not support any available MFA methods [WEBAUTHN, SSO], see debug logs for details"),
 		},
 		{
 			name: "NOK otp with per-session MFA",
@@ -530,7 +530,7 @@ Enter your security key PIN:
 		{
 			name: "NOK browser fallback skipped on windows when not preferred",
 			expectStdOut: "" +
-				"Available MFA methods [webauthn,browser]. Continuing with WEBAUTHN.\r\n" +
+				"Available MFA methods [WEBAUTHN, BROWSER]. Continuing with WEBAUTHN.\r\n" +
 				"If you wish to perform MFA with another method, specify with flag --mfa-mode=<cross-platform,platform,browser> or environment variable TELEPORT_MFA_MODE=<cross-platform,platform,browser>.\r\n\r\n" +
 				"Tap any security key\n" +
 				"MFA authentication with WEBAUTHN failed, check logs for details\r\n",
@@ -563,7 +563,7 @@ Enter your security key PIN:
 		{
 			name: "OK prompt fallback webauthn > SSO > browser MFA",
 			expectStdOut: "" +
-				"Available MFA methods [webauthn,browser]. Continuing with WEBAUTHN.\r\n" +
+				"Available MFA methods [WEBAUTHN, BROWSER]. Continuing with WEBAUTHN.\r\n" +
 				"If you wish to perform MFA with another method, specify with flag --mfa-mode=<cross-platform,platform,browser> or environment variable TELEPORT_MFA_MODE=<cross-platform,platform,browser>.\r\n\r\n" +
 				"Tap any security key\n" +
 				"MFA authentication with WEBAUTHN failed, check logs for details\r\n" +

--- a/lib/client/mfa/cli_test.go
+++ b/lib/client/mfa/cli_test.go
@@ -186,8 +186,8 @@ func TestCLIPrompt(t *testing.T) {
 		{
 			name: "OK prefer webauthn over sso",
 			expectStdOut: "" +
-				"Available MFA methods [WEBAUTHN, SSO]. Continuing with WEBAUTHN.\r\n" +
-				"If you wish to perform MFA with another method, specify with flag --mfa-mode=<webauthn,sso> or environment variable TELEPORT_MFA_MODE=<webauthn,sso>.\r\n\r\n" +
+				"Available MFA methods [cross-platform,platform,sso]. Continuing with WEBAUTHN.\r\n" +
+				"If you wish to perform MFA with another method, specify with flag --mfa-mode=<cross-platform,platform,sso> or environment variable TELEPORT_MFA_MODE=<cross-platform,platform,sso>.\r\n\r\n" +
 				"Tap any security key\n",
 			challenge: &proto.MFAAuthenticateChallenge{
 				WebauthnChallenge: &webauthnpb.CredentialAssertion{},
@@ -202,8 +202,8 @@ func TestCLIPrompt(t *testing.T) {
 		{
 			name: "OK prefer webauthn+otp over sso",
 			expectStdOut: "" +
-				"Available MFA methods [WEBAUTHN, SSO, OTP]. Continuing with WEBAUTHN and OTP.\r\n" +
-				"If you wish to perform MFA with another method, specify with flag --mfa-mode=<webauthn,sso,otp> or environment variable TELEPORT_MFA_MODE=<webauthn,sso,otp>.\r\n\r\n" +
+				"Available MFA methods [cross-platform,platform,sso,otp]. Continuing with WEBAUTHN and OTP.\r\n" +
+				"If you wish to perform MFA with another method, specify with flag --mfa-mode=<cross-platform,platform,sso,otp> or environment variable TELEPORT_MFA_MODE=<cross-platform,platform,sso,otp>.\r\n\r\n" +
 				"Tap any security key or enter a code from a OTP device\r\n",
 			challenge: &proto.MFAAuthenticateChallenge{
 				WebauthnChallenge: &webauthnpb.CredentialAssertion{},
@@ -222,7 +222,7 @@ func TestCLIPrompt(t *testing.T) {
 		{
 			name: "OK prefer sso over otp",
 			expectStdOut: "" +
-				"Available MFA methods [SSO, OTP]. Continuing with SSO.\r\n" +
+				"Available MFA methods [sso,otp]. Continuing with SSO.\r\n" +
 				"If you wish to perform MFA with another method, specify with flag --mfa-mode=<sso,otp> or environment variable TELEPORT_MFA_MODE=<sso,otp>.\r\n\r\n",
 			challenge: &proto.MFAAuthenticateChallenge{
 				TOTP:         &proto.TOTPChallenge{},
@@ -240,8 +240,8 @@ func TestCLIPrompt(t *testing.T) {
 		{
 			name: "OK prefer webauthn over otp when stdin hijack disallowed",
 			expectStdOut: "" +
-				"Available MFA methods [WEBAUTHN, OTP]. Continuing with WEBAUTHN.\r\n" +
-				"If you wish to perform MFA with another method, specify with flag --mfa-mode=<webauthn,otp> or environment variable TELEPORT_MFA_MODE=<webauthn,otp>.\r\n\r\n" +
+				"Available MFA methods [cross-platform,platform,otp]. Continuing with WEBAUTHN.\r\n" +
+				"If you wish to perform MFA with another method, specify with flag --mfa-mode=<cross-platform,platform,otp> or environment variable TELEPORT_MFA_MODE=<cross-platform,platform,otp>.\r\n\r\n" +
 				"Tap any security key\n",
 			challenge: &proto.MFAAuthenticateChallenge{
 				WebauthnChallenge: &webauthnpb.CredentialAssertion{},
@@ -256,8 +256,8 @@ func TestCLIPrompt(t *testing.T) {
 		{
 			name: "OK webauthn or otp with stdin hijack allowed, choose webauthn",
 			expectStdOut: "" +
-				"Available MFA methods [WEBAUTHN, SSO, OTP]. Continuing with WEBAUTHN and OTP.\r\n" +
-				"If you wish to perform MFA with another method, specify with flag --mfa-mode=<webauthn,sso,otp> or environment variable TELEPORT_MFA_MODE=<webauthn,sso,otp>.\r\n\r\n" +
+				"Available MFA methods [cross-platform,platform,sso,otp]. Continuing with WEBAUTHN and OTP.\r\n" +
+				"If you wish to perform MFA with another method, specify with flag --mfa-mode=<cross-platform,platform,sso,otp> or environment variable TELEPORT_MFA_MODE=<cross-platform,platform,sso,otp>.\r\n\r\n" +
 				"Tap any security key or enter a code from a OTP device\r\n",
 			challenge: &proto.MFAAuthenticateChallenge{
 				WebauthnChallenge: &webauthnpb.CredentialAssertion{},
@@ -276,8 +276,8 @@ func TestCLIPrompt(t *testing.T) {
 		{
 			name: "OK webauthn or otp with stdin hijack allowed, choose otp",
 			expectStdOut: "" +
-				"Available MFA methods [WEBAUTHN, SSO, OTP]. Continuing with WEBAUTHN and OTP.\r\n" +
-				"If you wish to perform MFA with another method, specify with flag --mfa-mode=<webauthn,sso,otp> or environment variable TELEPORT_MFA_MODE=<webauthn,sso,otp>.\r\n\r\n" +
+				"Available MFA methods [cross-platform,platform,sso,otp]. Continuing with WEBAUTHN and OTP.\r\n" +
+				"If you wish to perform MFA with another method, specify with flag --mfa-mode=<cross-platform,platform,sso,otp> or environment variable TELEPORT_MFA_MODE=<cross-platform,platform,sso,otp>.\r\n\r\n" +
 				"Tap any security key or enter a code from a OTP device\r\n",
 			stdin: "123456",
 			challenge: &proto.MFAAuthenticateChallenge{
@@ -440,7 +440,7 @@ Enter your security key PIN:
 				cfg.WebauthnSupported = false
 				cfg.CallbackCeremony = nil
 			},
-			expectErr: trace.BadParameter("client does not support any available MFA methods [WEBAUTHN, SSO], see debug logs for details"),
+			expectErr: trace.BadParameter("client does not support any available MFA methods [cross-platform, platform, sso], see debug logs for details"),
 		},
 		{
 			name: "NOK otp with per-session MFA",
@@ -530,8 +530,8 @@ Enter your security key PIN:
 		{
 			name: "NOK browser fallback skipped on windows when not preferred",
 			expectStdOut: "" +
-				"Available MFA methods [WEBAUTHN, BROWSER]. Continuing with WEBAUTHN.\r\n" +
-				"If you wish to perform MFA with another method, specify with flag --mfa-mode=<webauthn,browser> or environment variable TELEPORT_MFA_MODE=<webauthn,browser>.\r\n\r\n" +
+				"Available MFA methods [cross-platform,platform,browser]. Continuing with WEBAUTHN.\r\n" +
+				"If you wish to perform MFA with another method, specify with flag --mfa-mode=<cross-platform,platform,browser> or environment variable TELEPORT_MFA_MODE=<cross-platform,platform,browser>.\r\n\r\n" +
 				"Tap any security key\n" +
 				"MFA authentication with WEBAUTHN failed, check logs for details\r\n",
 			challenge: &proto.MFAAuthenticateChallenge{
@@ -563,8 +563,8 @@ Enter your security key PIN:
 		{
 			name: "OK prompt fallback webauthn > SSO > browser MFA",
 			expectStdOut: "" +
-				"Available MFA methods [WEBAUTHN, BROWSER]. Continuing with WEBAUTHN.\r\n" +
-				"If you wish to perform MFA with another method, specify with flag --mfa-mode=<webauthn,browser> or environment variable TELEPORT_MFA_MODE=<webauthn,browser>.\r\n\r\n" +
+				"Available MFA methods [cross-platform,platform,browser]. Continuing with WEBAUTHN.\r\n" +
+				"If you wish to perform MFA with another method, specify with flag --mfa-mode=<cross-platform,platform,browser> or environment variable TELEPORT_MFA_MODE=<cross-platform,platform,browser>.\r\n\r\n" +
 				"Tap any security key\n" +
 				"MFA authentication with WEBAUTHN failed, check logs for details\r\n" +
 				"Attempting MFA authentication with BROWSER\r\n",

--- a/lib/client/mfa/cli_test.go
+++ b/lib/client/mfa/cli_test.go
@@ -186,7 +186,7 @@ func TestCLIPrompt(t *testing.T) {
 		{
 			name: "OK prefer webauthn over sso",
 			expectStdOut: "" +
-				"Available MFA methods [cross-platform,platform,sso]. Continuing with WEBAUTHN.\r\n" +
+				"Available MFA methods [webauthn,sso]. Continuing with WEBAUTHN.\r\n" +
 				"If you wish to perform MFA with another method, specify with flag --mfa-mode=<cross-platform,platform,sso> or environment variable TELEPORT_MFA_MODE=<cross-platform,platform,sso>.\r\n\r\n" +
 				"Tap any security key\n",
 			challenge: &proto.MFAAuthenticateChallenge{
@@ -202,7 +202,7 @@ func TestCLIPrompt(t *testing.T) {
 		{
 			name: "OK prefer webauthn+otp over sso",
 			expectStdOut: "" +
-				"Available MFA methods [cross-platform,platform,sso,otp]. Continuing with WEBAUTHN and OTP.\r\n" +
+				"Available MFA methods [webauthn,sso,otp]. Continuing with WEBAUTHN and OTP.\r\n" +
 				"If you wish to perform MFA with another method, specify with flag --mfa-mode=<cross-platform,platform,sso,otp> or environment variable TELEPORT_MFA_MODE=<cross-platform,platform,sso,otp>.\r\n\r\n" +
 				"Tap any security key or enter a code from a OTP device\r\n",
 			challenge: &proto.MFAAuthenticateChallenge{
@@ -240,7 +240,7 @@ func TestCLIPrompt(t *testing.T) {
 		{
 			name: "OK prefer webauthn over otp when stdin hijack disallowed",
 			expectStdOut: "" +
-				"Available MFA methods [cross-platform,platform,otp]. Continuing with WEBAUTHN.\r\n" +
+				"Available MFA methods [webauthn,otp]. Continuing with WEBAUTHN.\r\n" +
 				"If you wish to perform MFA with another method, specify with flag --mfa-mode=<cross-platform,platform,otp> or environment variable TELEPORT_MFA_MODE=<cross-platform,platform,otp>.\r\n\r\n" +
 				"Tap any security key\n",
 			challenge: &proto.MFAAuthenticateChallenge{
@@ -256,7 +256,7 @@ func TestCLIPrompt(t *testing.T) {
 		{
 			name: "OK webauthn or otp with stdin hijack allowed, choose webauthn",
 			expectStdOut: "" +
-				"Available MFA methods [cross-platform,platform,sso,otp]. Continuing with WEBAUTHN and OTP.\r\n" +
+				"Available MFA methods [webauthn,sso,otp]. Continuing with WEBAUTHN and OTP.\r\n" +
 				"If you wish to perform MFA with another method, specify with flag --mfa-mode=<cross-platform,platform,sso,otp> or environment variable TELEPORT_MFA_MODE=<cross-platform,platform,sso,otp>.\r\n\r\n" +
 				"Tap any security key or enter a code from a OTP device\r\n",
 			challenge: &proto.MFAAuthenticateChallenge{
@@ -276,7 +276,7 @@ func TestCLIPrompt(t *testing.T) {
 		{
 			name: "OK webauthn or otp with stdin hijack allowed, choose otp",
 			expectStdOut: "" +
-				"Available MFA methods [cross-platform,platform,sso,otp]. Continuing with WEBAUTHN and OTP.\r\n" +
+				"Available MFA methods [webauthn,sso,otp]. Continuing with WEBAUTHN and OTP.\r\n" +
 				"If you wish to perform MFA with another method, specify with flag --mfa-mode=<cross-platform,platform,sso,otp> or environment variable TELEPORT_MFA_MODE=<cross-platform,platform,sso,otp>.\r\n\r\n" +
 				"Tap any security key or enter a code from a OTP device\r\n",
 			stdin: "123456",
@@ -440,7 +440,7 @@ Enter your security key PIN:
 				cfg.WebauthnSupported = false
 				cfg.CallbackCeremony = nil
 			},
-			expectErr: trace.BadParameter("client does not support any available MFA methods [cross-platform, platform, sso], see debug logs for details"),
+			expectErr: trace.BadParameter("client does not support any available MFA methods [webauthn, sso], see debug logs for details"),
 		},
 		{
 			name: "NOK otp with per-session MFA",
@@ -530,7 +530,7 @@ Enter your security key PIN:
 		{
 			name: "NOK browser fallback skipped on windows when not preferred",
 			expectStdOut: "" +
-				"Available MFA methods [cross-platform,platform,browser]. Continuing with WEBAUTHN.\r\n" +
+				"Available MFA methods [webauthn,browser]. Continuing with WEBAUTHN.\r\n" +
 				"If you wish to perform MFA with another method, specify with flag --mfa-mode=<cross-platform,platform,browser> or environment variable TELEPORT_MFA_MODE=<cross-platform,platform,browser>.\r\n\r\n" +
 				"Tap any security key\n" +
 				"MFA authentication with WEBAUTHN failed, check logs for details\r\n",
@@ -563,7 +563,7 @@ Enter your security key PIN:
 		{
 			name: "OK prompt fallback webauthn > SSO > browser MFA",
 			expectStdOut: "" +
-				"Available MFA methods [cross-platform,platform,browser]. Continuing with WEBAUTHN.\r\n" +
+				"Available MFA methods [webauthn,browser]. Continuing with WEBAUTHN.\r\n" +
 				"If you wish to perform MFA with another method, specify with flag --mfa-mode=<cross-platform,platform,browser> or environment variable TELEPORT_MFA_MODE=<cross-platform,platform,browser>.\r\n\r\n" +
 				"Tap any security key\n" +
 				"MFA authentication with WEBAUTHN failed, check logs for details\r\n" +


### PR DESCRIPTION
This changes drops `webauthn` for `cross-platform, platform` as an `--mfa-mode` option when informing users of their MFA options. For example:

```diff
$ tsh login --proxy ...

...
-If you wish to perform MFA with another method, specify with flag --mfa-mode=<webauthn,sso> or environment variable TELEPORT_MFA_MODE=<webauthn,sso>.
+If you wish to perform MFA with another method, specify with flag --mfa-mode=<cross-platform,platform,sso> or environment variable TELEPORT_MFA_MODE=<cross-platform,platform,sso>.
...
```

Changelog: Fix MFA prompts to show correct --mfa-mode values for webauthn authenticators.

## Manual Test Plan
### Test Environment
tsh against a self-hosted cluster
### Test Cases
- [x] `tsh` no longer suggested `webauthn` as a MFA mode
