### PR TITLE
Increase the timeout for TestTeleportClient_Login_local

### DIFF
--- a/lib/client/api_login_test.go
+++ b/lib/client/api_login_test.go
@@ -334,7 +334,7 @@ func TestTeleportClient_Login_local(t *testing.T) {
 				return test.hasTouchIDCredentials
 			}
 
-			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 			defer cancel()
 
 			// Only enable BrowserAuthentication for tests that explicitly request it


### PR DESCRIPTION
This keeps kicking my PRs out of the merge queue. Not sure if this is the best solution.