### PR TITLE
Fix command name in debug logs

### DIFF
--- a/lib/devicetrust/native/device_linux.go
+++ b/lib/devicetrust/native/device_linux.go
@@ -227,7 +227,7 @@ func readDMIInfoAccordingToMode(mode CollectDataMode) (*linux.DMIInfo, error) {
 		fallthrough
 
 	case CollectedDataAlwaysEscalate:
-		logger.DebugContext(ctx, "Running escalated `tsh device dmi-info`")
+		logger.DebugContext(ctx, "Running escalated `tsh device dmi-read`")
 
 		dmiInfo, err = cddFuncs.readDMIInfoEscalated()
 		if err != nil {


### PR DESCRIPTION
The correct command is `tsh device dmi-read`, `dmi-info` does not exist.