### PR TITLE
Fix flaky tests in `lib/kube/proxy/resource_rbac_test.go`

### DIFF
--- a/lib/kube/proxy/resource_rbac_test.go
+++ b/lib/kube/proxy/resource_rbac_test.go
@@ -123,7 +123,7 @@ func TestListPodRBAC(t *testing.T) {
 		},
 	)
 
-	scopedUserWithFullAccess, _ := testCtx.CreateUserAndScopedRole(
+	scopedUserWithFullAccess, scopedRoleWithFullAccess := testCtx.CreateUserAndScopedRole(
 		t,
 		"scoped-"+usernameWithFullAccess,
 		scope,
@@ -140,6 +140,7 @@ func TestListPodRBAC(t *testing.T) {
 				},
 			},
 		})
+	waitForSRACache(t, testCtx.TLSServer, scopedRoleWithFullAccess)
 
 	// create a user with full access to kubernetes Pods.
 	// (kubernetes_user and kubernetes_groups specified)
@@ -1182,7 +1183,7 @@ func TestDeletePodCollectionRBAC(t *testing.T) {
 		},
 	)
 
-	scopedUserWithFullAccess, _ := testCtx.CreateUserAndScopedRole(
+	scopedUserWithFullAccess, scopedRoleWithFullAccess := testCtx.CreateUserAndScopedRole(
 		t,
 		"scoped-"+usernameWithFullAccess,
 		scope,
@@ -1199,6 +1200,7 @@ func TestDeletePodCollectionRBAC(t *testing.T) {
 				},
 			},
 		})
+	waitForSRACache(t, testCtx.TLSServer, scopedRoleWithFullAccess)
 
 	// create a user with full access to kubernetes Pods.
 	// (kubernetes_user and kubernetes_groups specified)
@@ -1421,7 +1423,7 @@ func TestDeleteCRDCollectionRBAC(t *testing.T) {
 
 	// create a scoped user with full access to kubernetes Pods.
 	// (kubernetes_user and kubernetes_groups specified)
-	scopedUserWithFullAccess, _ := testCtx.CreateUserAndScopedRole(
+	scopedUserWithFullAccess, scopedRoleWithFullAccess := testCtx.CreateUserAndScopedRole(
 		t,
 		"scoped-"+usernameWithFullAccess,
 		scope,
@@ -1438,6 +1440,7 @@ func TestDeleteCRDCollectionRBAC(t *testing.T) {
 				},
 			},
 		})
+	waitForSRACache(t, testCtx.TLSServer, scopedRoleWithFullAccess)
 
 	// create a user with full access to kubernetes Pods.
 	// (kubernetes_user and kubernetes_groups specified)
@@ -1665,7 +1668,7 @@ func TestListClusterRoleRBAC(t *testing.T) {
 
 	// create a scoped user with full access to kubernetes Pods.
 	// (kubernetes_user and kubernetes_groups specified)
-	scopedUserWithFullAccess, _ := testCtx.CreateUserAndScopedRole(
+	scopedUserWithFullAccess, scopedRoleWithFullAccess := testCtx.CreateUserAndScopedRole(
 		t,
 		"scoped-"+usernameWithFullAccess,
 		scope,
@@ -1682,6 +1685,7 @@ func TestListClusterRoleRBAC(t *testing.T) {
 				},
 			},
 		})
+	waitForSRACache(t, testCtx.TLSServer, scopedRoleWithFullAccess)
 
 	// Create a moderator user with access to kubernetes
 	// (kubernetes_user and kubernetes_groups specified).
@@ -1901,7 +1905,7 @@ func TestGenericCustomResourcesRBAC(t *testing.T) {
 
 	// create a scoped user with full access to all namespaces.
 	// (kubernetes_user and kubernetes_groups specified)
-	scopedUserWithFullAccess, _ := testCtx.CreateUserAndScopedRole(
+	scopedUserWithFullAccess, scopedRoleWithFullAccess := testCtx.CreateUserAndScopedRole(
 		t,
 		"scoped-"+usernameWithFullAccess,
 		scope,
@@ -1918,6 +1922,7 @@ func TestGenericCustomResourcesRBAC(t *testing.T) {
 				},
 			},
 		})
+	waitForSRACache(t, testCtx.TLSServer, scopedRoleWithFullAccess)
 
 	// create a user with limited access to kubernetes namespaces.
 	userWithLimitedAccess, _ := testCtx.CreateUserAndRoleVersion(


### PR DESCRIPTION
Adds missing `waitForSRACache` for these test cases so that the scoped role assignments are guaranteed to be available before they're needed.
