### PR TITLE
Add a CTA slot to unified resources component

### DIFF
--- a/web/packages/teleport/src/UnifiedResources/UnifiedResources.tsx
+++ b/web/packages/teleport/src/UnifiedResources/UnifiedResources.tsx
@@ -16,7 +16,13 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { useCallback, useMemo, useState, type JSX } from 'react';
+import {
+  useCallback,
+  useMemo,
+  useState,
+  type JSX,
+  type ReactNode,
+} from 'react';
 import styled from 'styled-components';
 
 import { Box, Flex } from 'design';
@@ -128,6 +134,7 @@ export function ClusterResources({
   showCheckout = false,
   availabilityFilter,
   bulkActions = [],
+  ctaSlot,
 }: {
   clusterId: string;
   isLeafCluster: boolean;
@@ -139,6 +146,12 @@ export function ClusterResources({
   /** A list of actions that can be performed on the selected items. */
   bulkActions?: BulkAction[];
   availabilityFilter?: ResourceAvailabilityFilter;
+  /**
+   * Optional render-prop, given the number of currently displayed resources,
+   * for rendering content (such as a CTA) that depends on whether any
+   * resources are present.
+   */
+  ctaSlot?: (resourceCount: number) => ReactNode;
 }) {
   const teleCtx = useTeleport();
   const flags = teleCtx.getFeatureFlags();
@@ -340,6 +353,7 @@ export function ClusterResources({
           </>
         }
       />
+      {ctaSlot?.(resources.length)}
     </>
   );
 }


### PR DESCRIPTION
Adds a `ctaSlot` to the unified resources page that gets the resources count, so a CTA that wants to only show when there are resources in the cluster can do so