### PR TITLE
Remove some sources of AI agent friction

### DIFF
--- a/docs/pages/enroll-resources/server-access/getting-started.mdx
+++ b/docs/pages/enroll-resources/server-access/getting-started.mdx
@@ -104,8 +104,9 @@ This helps to minimize the direct sharing of tokens even when they are dynamical
 ### Join your server to the cluster
 
 On your server, save `token.file` to an appropriate, secure, directory you have
-the rights and access to read. Next, generate a configuration file enabling
-Teleport's SSH Service.
+the rights and access to read. Next, generate a configuration file that enables
+the Teleport SSH Service. This also assigns the protected server the
+`env=example` label so you can search for it later:
 
 <Tabs>
 <TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
@@ -116,6 +117,7 @@ the `--token` flag to the path where you saved `token.file`.
 ```code
 # Generate config
 $ sudo teleport node configure \
+   --labels=env=example \
    --output=file:///etc/teleport.yaml \
    --token=/path/to/token.file \
    --proxy=tele.example.com:443
@@ -130,6 +132,7 @@ $ sudo teleport node configure \
 ```code
 # Generate config
 $ sudo teleport node configure \
+   --labels=env=example \
    --output=file:///etc/teleport.yaml \
    --token=/path/to/token.file \
    --proxy=mytenant.teleport.sh:443

--- a/docs/pages/includes/install-linux.mdx
+++ b/docs/pages/includes/install-linux.mdx
@@ -2,6 +2,12 @@ To install Teleport binaries on your Linux server, the recommended installation
 method is the cluster install script. It will select the correct version,
 edition, and installation mode for your cluster.
 
+1. Remove any existing Teleport binaries on your system:
+
+   ```code
+   $ sudo rm -f /usr/local/bin/{tsh,teleport,tctl,tbot,fdpass-teleport,teleport-update}
+   ```
+
 1. Assign <Var name="teleport.example.com:443"/> to your Teleport cluster
    hostname and port, but not the scheme (https://).
 

--- a/docs/pages/includes/start-teleport.mdx
+++ b/docs/pages/includes/start-teleport.mdx
@@ -1,24 +1,30 @@
 {{ service="your Teleport instance" }}
 
-Configure {{ service }} to start automatically when the host boots up by
-creating a systemd service for it. The instructions depend on how you installed
-{{ service }}.
+Start {{ service }}. The instructions depend on how you installed {{ service }}
+and whether your system supports systemd:
 
 <Tabs>
 <TabItem label="Package Manager">
 
-On the host where you will run {{ service }}, enable and start Teleport:
+Configure {{ service }} to start automatically when the host boots up by
+creating a systemd service for it. On the host where you will run {{ service }},
+enable and start Teleport:
 
 ```code
 $ sudo systemctl enable teleport
 $ sudo systemctl start teleport
 ```
 
+You can check the status of {{ service }} with `systemctl status teleport`
+and view its logs with `journalctl -fu teleport`.
+
 </TabItem>
 <TabItem label="TAR Archive">
 
-On the host where you will run {{ service }}, create a systemd service
-configuration for Teleport, enable the Teleport service, and start Teleport:
+Configure {{ service }} to start automatically when the host boots up by
+creating a systemd service for it. On the host where you will run {{ service }},
+create a systemd service configuration for Teleport, enable the Teleport
+service, and start Teleport:
 
 ```code
 $ sudo teleport install systemd -o /etc/systemd/system/teleport.service
@@ -26,8 +32,19 @@ $ sudo systemctl enable teleport
 $ sudo systemctl start teleport
 ```
 
-</TabItem>
-</Tabs>
-
 You can check the status of {{ service }} with `systemctl status teleport`
 and view its logs with `journalctl -fu teleport`.
+
+</TabItem>
+<TabItem label="No systemd">
+
+On the host where you will run {{ service }}, start Teleport:
+
+```code
+$ sudo teleport start --config=/etc/teleport.yaml
+```
+
+Teleport runs in the foreground and outputs logs for the services it is running.
+
+</TabItem>
+</Tabs>

--- a/docs/pages/includes/tctl.mdx
+++ b/docs/pages/includes/tctl.mdx
@@ -1,7 +1,7 @@
-To check that you can connect to your Teleport cluster, sign in with `tsh login`, then 
-verify that you can run `tctl` commands using your current credentials. 
+To check that you can connect to your Teleport cluster, sign in with `tsh login`, then
+verify that you can run `tctl` commands using your current credentials.
 
-For example, run the following command, assigning 
+For example, run the following command, assigning
 <Var name="teleport.example.com" /> to the domain name of the Teleport Proxy Service
 in your cluster and <Var name="email@example.com" /> to your Teleport username:
 
@@ -15,7 +15,7 @@ $ tctl status
 
 If you can connect to the cluster and run the `tctl status` command, you can use your
 current credentials to run subsequent `tctl` commands from your workstation.
-If you host your own Teleport cluster, you can also run `tctl` commands on the computer that 
+If you host your own Teleport cluster, you can also run `tctl` commands on the computer that
 hosts the Teleport Auth Service for full permissions.
 
 <details>
@@ -24,15 +24,20 @@ hosts the Teleport Auth Service for full permissions.
 In some environments, for example on a Teleport beam, Teleport authentication
 must take place through a local identity file. On a Teleport beam, the identity
 file is available automatically, and `tctl` reads the file path from the
-`TELEPORT_IDENTITY_FILE` environment variable. You must pass the `--auth-server`
-flag to provide the Teleport Auth Service address, which is not included in the
-identity file:
+`TELEPORT_IDENTITY_FILE` environment variable.
+
+When executing `tctl` commands with an identity file, you  must pass the
+`--auth-server` flag to provide the Teleport Auth Service address, which is not
+included in the identity file. If you provide the Proxy Service address, `tctl`
+connects to the Proxy Service, which forwards traffic to and from the Teleport
+Auth Service.
+
+On a beam, you must use the Proxy Service address, as the Auth Service is not
+exposed to the public internet. You can do so by using the `TELEPORT_PROXY`
+environment variable:
 
 ```code
 $ tctl status --auth-server=${TELEPORT_PROXY}
 ```
-
-On a Teleport beam, `TELEPORT_PROXY` points to the Teleport Proxy Service
-address.
 
 </details>

--- a/docs/pages/includes/tctl.mdx
+++ b/docs/pages/includes/tctl.mdx
@@ -17,3 +17,22 @@ If you can connect to the cluster and run the `tctl status` command, you can use
 current credentials to run subsequent `tctl` commands from your workstation.
 If you host your own Teleport cluster, you can also run `tctl` commands on the computer that 
 hosts the Teleport Auth Service for full permissions.
+
+<details>
+<summary>Running `tctl` on a Teleport beam</summary>
+
+In some environments, for example on a Teleport beam, Teleport authentication
+must take place through a local identity file. On a Teleport beam, the identity
+file is available automatically, and `tctl` reads the file path from the
+`TELEPORT_IDENTITY_FILE` environment variable. You must pass the `--auth-server`
+flag to provide the Teleport Auth Service address, which is not included in the
+identity file:
+
+```code
+$ tctl status --auth-server=${TELEPORT_PROXY}
+```
+
+On a Teleport beam, `TELEPORT_PROXY` points to the Teleport Proxy Service
+address.
+
+</details>


### PR DESCRIPTION
Edit widely used partials and the Enroll Servers Getting Started guide to address situations in which an AI agent ran into friction while attempting to follow a how-to guide.

- Edit `install-linux.mdx` to add a removal command for existing binaries before installing Teleport, similar to the Go installation docs for Linux (https://go.dev/doc/install). This way, an agent working from a system with Teleport binaries installed (e.g., a beam) does not encounter an error.

- Edit tctl.mdx to mention Teleport authentiation from a beam.

- Edit start-teleport.mdx to include instructions for environments without systemd, like a Teleport beam.

- Edit the Enroll Servers Getting Started guide. Step 4 refers to a label that we didn't introduce earlier in the guide.  Fix that by editing the `configure` command.