### PR TITLE
[v18] Fix SSO MFA not working for reusable Admin Action MFA requests in the WebUI when it's the only second factor

### DIFF
--- a/api/client/webclient/webconfig.go
+++ b/api/client/webclient/webconfig.go
@@ -18,6 +18,7 @@ package webclient
 
 import (
 	"github.com/gravitational/teleport/api/constants"
+	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/utils/keys"
 )
 
@@ -203,7 +204,10 @@ type WebConfigAuthProvider struct {
 // WebConfigAuthSettings describes auth configuration
 type WebConfigAuthSettings struct {
 	// SecondFactor is the type of second factor to use in authentication.
+	// TODO(Joerger): DELETE IN v20 - v19 webui prefers SecondFactors.
 	SecondFactor constants.SecondFactorType `json:"second_factor,omitempty"`
+	// SecondFactors is the list of allowed second factor types.
+	SecondFactors []types.SecondFactorType `json:"second_factors,omitempty"`
 	// Providers contains a list of configured auth providers
 	Providers []WebConfigAuthProvider `json:"providers,omitempty"`
 	// LocalAuthEnabled is a flag that enables local authentication

--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -1967,6 +1967,7 @@ func (h *Handler) getWebConfig(w http.ResponseWriter, r *http.Request, p httprou
 		authSettings = webclient.WebConfigAuthSettings{
 			Providers:                   authProviders,
 			SecondFactor:                types.LegacySecondFactorFromSecondFactors(cap.GetSecondFactors()),
+			SecondFactors:               cap.GetSecondFactors(),
 			LocalAuthEnabled:            cap.GetAllowLocalAuth(),
 			AllowPasswordless:           cap.GetAllowPasswordless(),
 			AuthType:                    authType,

--- a/lib/web/apiserver_test.go
+++ b/lib/web/apiserver_test.go
@@ -4979,6 +4979,10 @@ func TestGetWebConfig_WithEntitlements(t *testing.T) {
 	expectedCfg := webclient.WebConfig{
 		Auth: webclient.WebConfigAuthSettings{
 			SecondFactor: constants.SecondFactorOn,
+			SecondFactors: []types.SecondFactorType{
+				types.SecondFactorType_SECOND_FACTOR_TYPE_OTP,
+				types.SecondFactorType_SECOND_FACTOR_TYPE_WEBAUTHN,
+			},
 			Providers: []webclient.WebConfigAuthProvider{{
 				Name:      "test-github",
 				Type:      constants.Github,

--- a/web/packages/shared/services/types.ts
+++ b/web/packages/shared/services/types.ts
@@ -29,6 +29,57 @@ export type AuthProviderType = 'oidc' | 'saml' | 'github';
 
 export type Auth2faType = 'otp' | 'off' | 'optional' | 'on' | 'webauthn';
 
+export type SecondFactor = 'otp' | 'webauthn' | 'sso';
+
+// legacySecondFactorToSecondFactors converts the legacy second_factor field into the
+// equivalent list of second_factors.
+// TODO(Joerger): DELETE IN v20 - v19 server sets second_factors.
+export function legacySecondFactorToSecondFactors(
+  secondFactor: Auth2faType
+): SecondFactor[] {
+  switch (secondFactor) {
+    case 'otp':
+      return ['otp'];
+    case 'webauthn':
+      return ['webauthn'];
+    case 'on':
+    case 'optional':
+      return ['otp', 'webauthn'];
+    default:
+      return [];
+  }
+}
+
+// secondFactorsToLegacySecondFactor converts a list of second_factors into the
+// equivalent legacy second_factor field.
+//
+// The conversion is lossy:
+// - [sso] -> "off"
+// - [sso, x] -> "otp" | "webauthn" | "on"
+// - No combination of second_factors can result in "optional"
+//
+// TODO(Joerger): the 'optional' auth2faType is currently never sent by v17+ servers
+// due to a bug - https://github.com/gravitational/teleport/issues/67274. As a result,
+// we can accept the loss of "optional" in this conversion for the time being. If we decide
+// to fix "optional", this conversion can be updated to check an 'is_mfa_optional' field.
+export function secondFactorsToLegacySecondFactor(
+  secondFactors: SecondFactor[]
+): Auth2faType {
+  const otp = secondFactors.includes('otp');
+  const webauthn = secondFactors.includes('webauthn');
+
+  if (otp && webauthn) {
+    return 'on';
+  }
+  if (webauthn) {
+    return 'webauthn';
+  }
+  if (otp) {
+    return 'otp';
+  }
+  return 'off';
+}
+
 export type AuthType = 'local' | 'github' | 'oidc' | 'saml';
 
 // PrimaryAuthType defines types where if:

--- a/web/packages/teleport/src/Account/Account.tsx
+++ b/web/packages/teleport/src/Account/Account.tsx
@@ -64,7 +64,7 @@ export function AccountPage({
   const manageDevicesState = useManageDevices(ctx);
 
   const canAddPasskeys = cfg.isPasswordlessEnabled();
-  const canAddMfa = cfg.isMfaEnabled();
+  const canAddMfa = cfg.isMfaUserConfigurable();
 
   function onPasswordChange() {
     storeUser.setState({ passwordState: PasswordState.PASSWORD_STATE_SET });

--- a/web/packages/teleport/src/Account/SecuritySettings.test.tsx
+++ b/web/packages/teleport/src/Account/SecuritySettings.test.tsx
@@ -49,7 +49,7 @@ function SecuritySettingsWrapper({ ctx }: { ctx: TeleportContext }) {
   const manageDevicesState = useManageDevices(ctx);
 
   const canAddPasskeys = cfg.isPasswordlessEnabled();
-  const canAddMfa = cfg.isMfaEnabled();
+  const canAddMfa = cfg.isMfaUserConfigurable();
 
   function onPasswordChange() {
     storeUser.setState({ passwordState: PasswordState.PASSWORD_STATE_SET });

--- a/web/packages/teleport/src/Bots/Add/GitHubActionsSsh/GitHubActionsSsh.test.tsx
+++ b/web/packages/teleport/src/Bots/Add/GitHubActionsSsh/GitHubActionsSsh.test.tsx
@@ -22,6 +22,7 @@ import { render, screen, userEvent } from 'design/utils/testing';
 
 import { ContextProvider } from 'teleport';
 import { allAccessAcl, noAccess } from 'teleport/mocks/contexts';
+import auth from 'teleport/services/auth';
 import * as botService from 'teleport/services/bot/bot';
 import TeleportContext from 'teleport/teleportContext';
 
@@ -41,6 +42,9 @@ describe('gitHub component', () => {
   };
 
   const setup = ({ hasAccess = true }: SetupProps) => {
+    jest
+      .spyOn(auth, 'getMfaChallengeResponseForAdminAction')
+      .mockResolvedValue(undefined);
     const ctx = new TeleportContext();
     ctx.storeUser.setState({
       username: 'joe@example.com',

--- a/web/packages/teleport/src/Discover/Server/DiscoveryConfigSsm/DiscoveryConfigSsm.test.tsx
+++ b/web/packages/teleport/src/Discover/Server/DiscoveryConfigSsm/DiscoveryConfigSsm.test.tsx
@@ -25,6 +25,7 @@ import {
   resourceSpecAwsEc2Ssm,
 } from 'teleport/Discover/Fixtures/fixtures';
 import { AgentMeta, AutoDiscovery } from 'teleport/Discover/useDiscover';
+import auth from 'teleport/services/auth';
 import * as discoveryService from 'teleport/services/discovery/discovery';
 import {
   IntegrationKind,
@@ -70,6 +71,9 @@ describe('DiscoveryConfigSsm', () => {
     jest
       .spyOn(userEventService, 'captureDiscoverEvent')
       .mockResolvedValue(undefined as never);
+    jest
+      .spyOn(auth, 'getMfaChallengeResponseForAdminAction')
+      .mockResolvedValue(undefined);
     jest.spyOn(discoveryService, 'createDiscoveryConfig').mockResolvedValue({
       name: '',
       discoveryGroup: '',

--- a/web/packages/teleport/src/JoinTokens/JoinTokens.test.tsx
+++ b/web/packages/teleport/src/JoinTokens/JoinTokens.test.tsx
@@ -23,11 +23,22 @@ import { InfoGuidePanelProvider } from 'shared/components/SlidingSidePanel/InfoG
 
 import { ContextProvider } from 'teleport';
 import { createTeleportContext } from 'teleport/mocks/contexts';
+import auth from 'teleport/services/auth';
 import makeJoinToken from 'teleport/services/joinToken/makeJoinToken';
 
 import { JoinTokens } from './JoinTokens';
 
 describe('JoinTokens', () => {
+  beforeEach(() => {
+    jest
+      .spyOn(auth, 'getMfaChallengeResponseForAdminAction')
+      .mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
   test('create dialog opens', async () => {
     render(<Component />);
     await userEvent.click(

--- a/web/packages/teleport/src/Users/UserReset/UserReset.tsx
+++ b/web/packages/teleport/src/Users/UserReset/UserReset.tsx
@@ -70,7 +70,7 @@ export function UserReset({
           . This will generate a&nbsp;temporary URL which can be used to set up
           new authentication.
         </P2>
-        {cfg.isMfaEnabled() && (
+        {cfg.isMfaUserConfigurable() && (
           <P2>
             All{' '}
             {cfg.isPasswordlessEnabled()

--- a/web/packages/teleport/src/config.test.ts
+++ b/web/packages/teleport/src/config.test.ts
@@ -104,3 +104,98 @@ test('getSsoUrl', () => {
     'http://localhost/v1/webapi/oidc/login/web?connector_id=keycloak&login_hint=user@example.com&redirect_url=example.com%3Fa=b&c=d'
   );
 });
+
+describe('MFA helpers', () => {
+  const original = {
+    second_factor: cfg.auth.second_factor,
+    second_factors: cfg.auth.second_factors,
+  };
+  afterEach(() => {
+    cfg.auth.second_factor = original.second_factor;
+    cfg.auth.second_factors = original.second_factors;
+  });
+
+  describe('secondFactors()', () => {
+    test.each`
+      second_factors                | expected
+      ${['webauthn']}               | ${['webauthn']}
+      ${['sso']}                    | ${['sso']}
+      ${['otp', 'webauthn', 'sso']} | ${['otp', 'webauthn', 'sso']}
+    `('returns $second_factors directly', ({ second_factors, expected }) => {
+      cfg.auth.second_factors = second_factors;
+      expect(cfg.secondFactors()).toEqual(expected);
+    });
+
+    test.each`
+      second_factor | expected
+      ${'webauthn'} | ${['webauthn']}
+      ${'otp'}      | ${['otp']}
+      ${'on'}       | ${['otp', 'webauthn']}
+      ${'optional'} | ${['otp', 'webauthn']}
+      ${'off'}      | ${[]}
+    `(
+      'derives from legacy second_factor=$second_factor when second_factors is empty',
+      ({ second_factor, expected }) => {
+        cfg.auth.second_factors = [];
+        cfg.auth.second_factor = second_factor;
+        expect(cfg.secondFactors()).toEqual(expected);
+      }
+    );
+  });
+
+  describe('isAdminActionMfaEnforced()', () => {
+    test.each`
+      second_factors         | expected
+      ${['webauthn']}        | ${true}
+      ${['sso']}             | ${true}
+      ${['webauthn', 'sso']} | ${true}
+      ${['otp']}             | ${false}
+      ${['otp', 'webauthn']} | ${false}
+    `(
+      'second_factors=$second_factors → $expected',
+      ({ second_factors, expected }) => {
+        cfg.auth.second_factors = second_factors;
+        expect(cfg.isAdminActionMfaEnforced()).toBe(expected);
+      }
+    );
+
+    test.each`
+      second_factor | expected
+      ${'webauthn'} | ${true}
+      ${'otp'}      | ${false}
+      ${'on'}       | ${false}
+      ${'optional'} | ${false}
+    `(
+      'legacy second_factor=$second_factor with empty second_factors → $expected',
+      ({ second_factor, expected }) => {
+        cfg.auth.second_factors = [];
+        cfg.auth.second_factor = second_factor;
+        expect(cfg.isAdminActionMfaEnforced()).toBe(expected);
+      }
+    );
+
+    test('legacy second_factor=off with empty second_factors is undefined (SSO-only ambiguous)', () => {
+      cfg.auth.second_factors = [];
+      cfg.auth.second_factor = 'off';
+      expect(cfg.isAdminActionMfaEnforced()).toBeUndefined();
+    });
+  });
+
+  describe('isMfaUserConfigurable()', () => {
+    test.each`
+      second_factors                | expected
+      ${['webauthn']}               | ${true}
+      ${['otp']}                    | ${true}
+      ${['otp', 'webauthn', 'sso']} | ${true}
+      ${['sso']}                    | ${false}
+      ${[]}                         | ${false}
+    `(
+      'second_factors=$second_factors → $expected',
+      ({ second_factors, expected }) => {
+        cfg.auth.second_factors = second_factors;
+        cfg.auth.second_factor = 'off';
+        expect(cfg.isMfaUserConfigurable()).toBe(expected);
+      }
+    );
+  });
+});

--- a/web/packages/teleport/src/config.ts
+++ b/web/packages/teleport/src/config.ts
@@ -25,6 +25,11 @@ import type {
   AuthType,
   PreferredMfaType,
   PrimaryAuthType,
+  SecondFactor,
+} from 'shared/services';
+import {
+  legacySecondFactorToSecondFactors,
+  secondFactorsToLegacySecondFactor,
 } from 'shared/services';
 import { mergeDeep } from 'shared/utils/highbar';
 
@@ -33,11 +38,11 @@ import { TaskState } from 'teleport/Integrations/status/AwsOidc/Tasks/constants'
 import type { SortType } from 'teleport/services/agents';
 import {
   AwsOidcPolicyPreset,
+  AzureResource,
   IntegrationDeleteRequest,
   IntegrationKind,
   PluginKind,
   Regions,
-  AzureResource,
 } from 'teleport/services/integrations';
 import type { KubeResourceKind } from 'teleport/services/kube/types';
 import type { GroupAction } from 'teleport/services/managedUpdates';
@@ -147,6 +152,7 @@ const cfg = {
     localConnectorName: '',
     providers: [] as AuthProvider[],
     second_factor: 'off' as Auth2faType,
+    second_factors: [] as SecondFactor[],
     authType: 'local' as AuthType,
     /** defaultConnectorName is the name of the default connector from the cluster's auth preferences. This will empty if the auth type is "local" */
     defaultConnectorName: '',
@@ -662,8 +668,33 @@ const cfg = {
     return cfg.auth && cfg.auth.providers ? cfg.auth.providers : [];
   },
 
+  // auth2faType is derived from second_factors. Prefer calling secondFactors directly.
   getAuth2faType() {
-    return cfg.auth ? cfg.auth.second_factor : null;
+    if (!cfg.auth) {
+      return null;
+    }
+
+    // If second_factors isn't set, use second_factor to determine the auth2faType.
+    // TODO(Joerger): DELETE in v20 - v19 server sets second_factors.
+    if (!cfg.auth.second_factors?.length) {
+      return cfg.auth.second_factor;
+    }
+
+    return secondFactorsToLegacySecondFactor(cfg.auth.second_factors);
+  },
+
+  secondFactors(): SecondFactor[] {
+    if (!cfg.auth) {
+      return null;
+    }
+
+    if (cfg.auth.second_factors?.length) {
+      return cfg.auth.second_factors;
+    }
+
+    // If second_factors isn't set, use second_factor to populate it.
+    // TODO(Joerger): DELETE IN v20 - v19 server sets second_factors.
+    return legacySecondFactorToSecondFactors(cfg.auth.second_factor);
   },
 
   getDefaultConnectorName() {
@@ -686,12 +717,28 @@ const cfg = {
     return cfg.auth.allowPasswordless;
   },
 
-  isMfaEnabled() {
-    return cfg.auth.second_factor !== 'off';
+  isMfaUserConfigurable() {
+    // Users can add/remove MFA devices when at least one non-SSO factor is allowed.
+    // (SSO MFA is managed by the auth connector, not by the user.)
+    return cfg.secondFactors().some(f => f !== 'sso');
   },
 
-  isAdminActionMfaEnforced() {
-    return cfg.auth.second_factor === 'webauthn';
+  // Mirrors authpref.IsAdminActionMFAEnforced server-side. Returns undefined
+  // when the answer is unknowable from the webcfg (older proxy/auth with an
+  // SSO-only cluster), signaling callers to fall back to a server-side check.
+  isAdminActionMfaEnforced(): boolean | undefined {
+    const factors = cfg.secondFactors();
+
+    // If second_factors is empty, it could mean that `second_factors: ["sso"]`,
+    // but the old server only sent us `second_factor: "off"`.
+    // TODO(Joerger): DELETE IN v20 - v19 server sets second_factors.
+    if (factors.length === 0) {
+      return undefined;
+    }
+
+    // OTP is not supported for admin actions, so admin MFA is only enforced
+    // when every configured factor can satisfy an admin action.
+    return !factors.includes('otp');
   },
 
   getPrimaryAuthType(): PrimaryAuthType {

--- a/web/packages/teleport/src/services/auth/auth.test.ts
+++ b/web/packages/teleport/src/services/auth/auth.test.ts
@@ -52,6 +52,54 @@ describe('services/auth', () => {
     expect(api.post).toHaveBeenCalledWith(cfg.api.webSessionPath, data);
   });
 
+  describe('getMfaChallengeResponseForAdminAction', () => {
+    const original = {
+      second_factor: cfg.auth.second_factor,
+      second_factors: cfg.auth.second_factors,
+    };
+    afterEach(() => {
+      cfg.auth.second_factor = original.second_factor;
+      cfg.auth.second_factors = original.second_factors;
+    });
+
+    test('skips the challenge when admin MFA is not enforced', async () => {
+      cfg.auth.second_factors = ['otp', 'webauthn'];
+      const getMfaChallenge = jest.spyOn(auth, 'getMfaChallenge');
+
+      const result = await auth.getMfaChallengeResponseForAdminAction(true);
+
+      expect(result).toBeUndefined();
+      expect(getMfaChallenge).not.toHaveBeenCalled();
+    });
+
+    test('falls back to server-side check when enforcement is unknown', async () => {
+      // Older proxy/auth: second_factors empty and legacy field collapses to off.
+      cfg.auth.second_factors = [];
+      cfg.auth.second_factor = 'off';
+      const getMfaChallenge = jest
+        .spyOn(auth, 'getMfaChallenge')
+        .mockResolvedValue(undefined);
+
+      await auth.getMfaChallengeResponseForAdminAction(true);
+
+      expect(getMfaChallenge).toHaveBeenCalled();
+    });
+
+    test('SSO-only cluster fetches the challenge with allowReuse', async () => {
+      cfg.auth.second_factors = ['sso'];
+      cfg.auth.second_factor = 'off';
+      const getMfaChallenge = jest
+        .spyOn(auth, 'getMfaChallenge')
+        .mockResolvedValue(undefined);
+
+      await auth.getMfaChallengeResponseForAdminAction(true);
+
+      expect(getMfaChallenge).toHaveBeenCalledWith(
+        expect.objectContaining({ allowReuse: true })
+      );
+    });
+  });
+
   test('resetPassword()', async () => {
     jest.spyOn(api, 'put').mockResolvedValue({});
     const submitData = {

--- a/web/packages/teleport/src/services/auth/auth.ts
+++ b/web/packages/teleport/src/services/auth/auth.ts
@@ -399,22 +399,23 @@ const auth = {
     return api.post(cfg.api.createPrivilegeTokenPath, {});
   },
 
-  getMfaChallengeResponseForAdminAction(allowReuse?: boolean) {
-    // If the client is checking if MFA is required for an admin action,
-    // but we know admin action MFA is not enforced, return early.
-    if (!cfg.isAdminActionMfaEnforced()) {
+  async getMfaChallengeResponseForAdminAction(allowReuse?: boolean) {
+    // Skip the challenge if we know it's not enforced.
+    if (cfg.isAdminActionMfaEnforced() === false) {
       return;
     }
 
-    return auth
-      .getMfaChallenge({
-        scope: MfaChallengeScope.ADMIN_ACTION,
-        allowReuse: allowReuse,
-        isMfaRequiredRequest: {
-          admin_action: {},
-        },
-      })
-      .then(auth.getMfaChallengeResponse);
+    const challenge = await auth.getMfaChallenge({
+      scope: MfaChallengeScope.ADMIN_ACTION,
+      allowReuse: allowReuse,
+      isMfaRequiredRequest: {
+        admin_action: {},
+      },
+    });
+    if (!challenge) {
+      return;
+    }
+    return auth.getMfaChallengeResponse(challenge);
   },
 };
 


### PR DESCRIPTION
Backport https://github.com/gravitational/teleport/pull/67142 to branch/v18

Changelog: Fix an issue where the WebUI would prompt for MFA multiple times for admin actions (or outright fail for select commands) when `sso` is the only allowed second factor on the cluster.

## Manual Test Plan
### Test Environment

[Configures SSO MFA](https://goteleport.com/docs/zero-trust-access/sso/sso-for-mfa/) as the only second factor for the cluster - `cap.second_factors: ["sso"]`.

### Test Cases
- [x] new proxy, new UI
  - [x] /web/tokens prompts mfa and loads 
  - [x] /web/sso prompts mfa and loads 
  - [x] Adding a user in the UI prompts for MFA just once.
- [x] old proxy, new UI
  - [x] /web/tokens prompts mfa once and loads
  - [x] /web/sso prompts mfa once and loads 
  - [x] Adding a user in the UI prompts for MFA just once.