### PR TITLE
Add ConditionalDelete to CA overrides and generic.Service

### DIFF
--- a/lib/services/local/generic/generic.go
+++ b/lib/services/local/generic/generic.go
@@ -482,6 +482,27 @@ func (s *Service[T]) DeleteAllResources(ctx context.Context) error {
 	return trace.Wrap(s.backend.DeleteRange(ctx, startKey, backend.RangeEnd(startKey)))
 }
 
+// ConditionalDeleteResource conditionally deletes the resource based on its
+// revision.
+// Returns a trace.CompareFailedError if the item is not found or the revision
+// is incorrect.
+func (s *Service[T]) ConditionalDeleteResource(ctx context.Context, name, revision string) error {
+	if revision == "" {
+		return trace.BadParameter("revision required")
+	}
+	err := s.backend.ConditionalDelete(ctx, s.resourceKey(name), revision)
+	if trace.IsCompareFailed(err) {
+		// Specialize the message from backend.ErrIncorrectRevision so we mention
+		// the resource name and don't mention --force. Deletes often don't have a
+		// --force flag.
+		return trace.CompareFailed(
+			"%s %q does not exist or revision does not match, it may have been concurrently created|modified|deleted; please work from the latest state",
+			s.resourceKind, name,
+		)
+	}
+	return trace.Wrap(err)
+}
+
 // UpdateAndSwapResource will get the resource from the backend, modify it, and swap the new value into the backend.
 func (s *Service[T]) UpdateAndSwapResource(ctx context.Context, name string, modify func(T) error) (T, error) {
 	var t T

--- a/lib/services/local/generic/generic_test.go
+++ b/lib/services/local/generic/generic_test.go
@@ -371,6 +371,105 @@ func TestGenericCRUD(t *testing.T) {
 	require.Equal(t, uint(0), count)
 }
 
+func TestGenericConditionalDelete(t *testing.T) {
+	t.Parallel()
+
+	memBackend, err := memory.New(memory.Config{})
+	require.NoError(t, err)
+
+	service, err := NewService(&ServiceConfig[*testResource]{
+		Backend:       memBackend,
+		ResourceKind:  "generic resource",
+		PageLimit:     200,
+		BackendPrefix: backend.NewKey("generic_prefix"),
+		UnmarshalFunc: unmarshalResource,
+		MarshalFunc:   marshalResource,
+	})
+	require.NoError(t, err)
+
+	// services methods modify their inputs. Take a defensive copy before calling.
+	cloneResource := func(r *testResource) *testResource {
+		r2 := *r
+		return &r2
+	}
+
+	// Create a couple revisions of a resource.
+	res := newTestResource("myresource")
+	res.Metadata.Expires = nil
+	res.Spec = testResourceSpec{PropA: "1"}
+	rev1, err := service.CreateResource(t.Context(), cloneResource(res))
+	require.NoError(t, err)
+
+	res.SetRevision(rev1.GetRevision())
+	rev2, err := service.ConditionalUpdateResource(t.Context(), cloneResource(res))
+	require.NoError(t, err)
+	// Sanity check.
+	require.NotEqual(t, rev1.GetRevision(), rev2.GetRevision())
+
+	const errNotFoundOrRevision = "does not exist or revision does not match"
+	tests := []struct {
+		desc        string
+		name        string
+		revision    string
+		wantErr     string
+		wantErrType any
+	}{
+		{
+			desc:        "unknown resource",
+			name:        "unknown-resource",
+			revision:    rev2.GetRevision(),
+			wantErr:     errNotFoundOrRevision,
+			wantErrType: new(*trace.CompareFailedError),
+		},
+		{
+			desc:        "unknown revision",
+			name:        rev2.GetName(),
+			revision:    rev1.GetRevision(),
+			wantErr:     errNotFoundOrRevision,
+			wantErrType: new(*trace.CompareFailedError),
+		},
+		{
+			desc:        "empty name", // same as unknown resource
+			revision:    rev2.GetRevision(),
+			wantErr:     errNotFoundOrRevision,
+			wantErrType: new(*trace.CompareFailedError),
+		},
+		{
+			desc:        "empty revision",
+			name:        rev2.GetName(),
+			wantErr:     "revision required",
+			wantErrType: new(*trace.BadParameterError),
+		},
+		{
+			desc:     "ok",
+			name:     rev2.GetName(),
+			revision: rev2.GetRevision(),
+			// success: no error wanted.
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.desc, func(t *testing.T) {
+			t.Parallel()
+
+			err := service.ConditionalDeleteResource(t.Context(), test.name, test.revision)
+			if test.wantErr != "" {
+				assert.ErrorContains(t, err, test.wantErr, "ConditionalDeleteResource error mismatch")
+			}
+			if test.wantErrType != nil {
+				assert.ErrorAs(t, err, test.wantErrType, "ConditionalDeleteResource error type mismatch")
+			}
+			if test.wantErr != "" && test.wantErrType != nil {
+				return // Asserted above.
+			}
+			require.NoError(t, err)
+
+			// Verify effective deletion.
+			_, err = service.GetResource(t.Context(), test.name)
+			assert.ErrorAs(t, err, new(*trace.NotFoundError), "Get error mismatch after ConditionalDelete")
+		})
+	}
+}
+
 // TestResourcesSkipsUnmarshalErrors guards against a regression where a single
 // malformed backend item would terminate iteration over Resources rather than
 // being skipped.

--- a/lib/services/local/generic/generic_wrapper.go
+++ b/lib/services/local/generic/generic_wrapper.go
@@ -131,6 +131,14 @@ func (s *ServiceWrapper[T]) DeleteAllResources(ctx context.Context) error {
 	return trace.Wrap(s.service.backend.DeleteRange(ctx, startKey, backend.RangeEnd(startKey)))
 }
 
+// ConditionalDeleteResource conditionally deletes the resource based on its
+// revision.
+// Returns a trace.CompareFailedError if the item is not found or the revision
+// is incorrect.
+func (s *ServiceWrapper[T]) ConditionalDeleteResource(ctx context.Context, name, revision string) error {
+	return trace.Wrap(s.service.ConditionalDeleteResource(ctx, name, revision))
+}
+
 // ListResources returns a paginated list of resources.
 func (s *ServiceWrapper[T]) ListResources(ctx context.Context, pageSize int, pageToken string) ([]T, string, error) {
 	adapters, nextToken, err := s.service.ListResources(ctx, pageSize, pageToken)

--- a/lib/services/local/generic/generic_wrapper_test.go
+++ b/lib/services/local/generic/generic_wrapper_test.go
@@ -25,7 +25,9 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/testing/protocmp"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
@@ -264,6 +266,63 @@ func TestGenericWrapperCRUD(t *testing.T) {
 	// Try to delete a resource that doesn't exist.
 	err = service.DeleteResource(ctx, "doesnotexist")
 	require.True(t, trace.IsNotFound(err))
+}
+
+func TestGenericWrapperConditionalDelete(t *testing.T) {
+	t.Parallel()
+
+	memBackend, err := memory.New(memory.Config{})
+	require.NoError(t, err)
+
+	service, err := NewServiceWrapper(
+		ServiceConfig[*testResource153]{
+			Backend:       memBackend,
+			ResourceKind:  "generic resource",
+			BackendPrefix: backend.NewKey("generic_prefix"),
+			MarshalFunc:   marshalResource153,
+			UnmarshalFunc: unmarshalResource153,
+		})
+	require.NoError(t, err)
+
+	// services methods modify their inputs. Take a defensive copy before calling.
+	cloneResource := func(r *testResource153) *testResource153 {
+		return &testResource153{
+			Metadata: proto.Clone(r.Metadata).(*headerv1.Metadata),
+		}
+	}
+
+	// Create a couple revisions of a resource.
+	res := newTestResource153("myresource")
+	res.Metadata.SetExpires(nil)
+	res.Metadata.SetDescription("r1")
+	rev1, err := service.CreateResource(t.Context(), cloneResource(res))
+	require.NoError(t, err)
+
+	res.Metadata.SetDescription("r2")
+	res.Metadata.SetRevision(rev1.Metadata.GetRevision())
+	rev2, err := service.ConditionalUpdateResource(t.Context(), cloneResource(res))
+	require.NoError(t, err)
+
+	t.Run("unknown revision errors", func(t *testing.T) {
+		err := service.ConditionalDeleteResource(
+			t.Context(),
+			rev2.Metadata.GetName(),
+			rev1.Metadata.GetRevision(),
+		)
+		assert.ErrorAs(t, err, new(*trace.CompareFailedError))
+	})
+
+	t.Run("ok", func(t *testing.T) {
+		err := service.ConditionalDeleteResource(
+			t.Context(),
+			rev2.Metadata.GetName(),
+			rev2.Metadata.GetRevision(),
+		)
+		require.NoError(t, err)
+
+		_, err = service.GetResource(t.Context(), rev2.Metadata.GetName())
+		assert.ErrorAs(t, err, new(*trace.NotFoundError), "Get error mismatch after ConditionalDelete")
+	})
 }
 
 // TestGenericWrapperWithPrefix tests the withPrefix method of the generic service wrapper.

--- a/lib/services/local/subca_service.go
+++ b/lib/services/local/subca_service.go
@@ -71,7 +71,6 @@ type SubCAServiceParams struct {
 //
 // Follows RFD 153 / generic.Service semantics.
 type SubCAService struct {
-	backend backend.Backend
 	service *generic.ServiceWrapper[*subcav1.CertAuthorityOverride]
 }
 
@@ -96,7 +95,6 @@ func NewSubCAService(p SubCAServiceParams) (*SubCAService, error) {
 	}
 
 	return &SubCAService{
-		backend: p.Backend,
 		service: service,
 	}, nil
 }
@@ -198,24 +196,23 @@ func (s *SubCAService) DeleteCertAuthorityOverride(
 
 // ConditionalDeleteCertAuthorityOverride conditionally deletes a CA override
 // based on its revision.
-//
-// Returns backend.ErrIncorrectRevision if the item is not found or the revision
+// Returns a trace.CompareFailedError if the item is not found or the revision
 // is incorrect.
 func (s *SubCAService) ConditionalDeleteCertAuthorityOverride(
 	ctx context.Context,
 	id CertAuthorityOverrideID,
 	revision string,
 ) error {
-	switch {
-	case id.ClusterName == "":
-		return trace.BadParameter("id.ClusterName required")
-	case id.CAType == "":
-		return trace.BadParameter("id.CAType required")
-	case revision == "":
-		return trace.BadParameter("revision required")
+	service, err := s.serviceForClusterAndType(id.ClusterName, id.CAType)
+	if err != nil {
+		return trace.Wrap(err)
 	}
-	key := newCAOverridesPrefix().AppendKey(backend.NewKey(id.ClusterName, id.CAType))
-	return trace.Wrap(s.backend.ConditionalDelete(ctx, key, revision))
+
+	// Name has no effect on the delete, it's only used for errors.
+	// See serviceForClusterAndType() / generic.Service.WithNameKeyFunc().
+	name := id.FullName()
+
+	return trace.Wrap(service.ConditionalDeleteResource(ctx, name, revision))
 }
 
 func (s *SubCAService) serviceForResource(

--- a/lib/services/local/subca_service.go
+++ b/lib/services/local/subca_service.go
@@ -71,6 +71,7 @@ type SubCAServiceParams struct {
 //
 // Follows RFD 153 / generic.Service semantics.
 type SubCAService struct {
+	backend backend.Backend
 	service *generic.ServiceWrapper[*subcav1.CertAuthorityOverride]
 }
 
@@ -95,6 +96,7 @@ func NewSubCAService(p SubCAServiceParams) (*SubCAService, error) {
 	}
 
 	return &SubCAService{
+		backend: p.Backend,
 		service: service,
 	}, nil
 }
@@ -176,6 +178,8 @@ func (s *SubCAService) ListCertAuthorityOverrides(
 // DeleteCertAuthorityOverride unconditionally deletes a CA override from the
 // backend.
 // Returns a trace.NotFoundError if the resource cannot be found.
+//
+// Prefer [SubCAService.ConditionalDeleteCertAuthorityOverride].
 func (s *SubCAService) DeleteCertAuthorityOverride(
 	ctx context.Context,
 	id CertAuthorityOverrideID,
@@ -190,6 +194,28 @@ func (s *SubCAService) DeleteCertAuthorityOverride(
 	name := id.FullName()
 
 	return trace.Wrap(service.DeleteResource(ctx, name))
+}
+
+// ConditionalDeleteCertAuthorityOverride conditionally deletes a CA override
+// based on its revision.
+//
+// Returns backend.ErrIncorrectRevision if the item is not found or the revision
+// is incorrect.
+func (s *SubCAService) ConditionalDeleteCertAuthorityOverride(
+	ctx context.Context,
+	id CertAuthorityOverrideID,
+	revision string,
+) error {
+	switch {
+	case id.ClusterName == "":
+		return trace.BadParameter("id.ClusterName required")
+	case id.CAType == "":
+		return trace.BadParameter("id.CAType required")
+	case revision == "":
+		return trace.BadParameter("revision required")
+	}
+	key := newCAOverridesPrefix().AppendKey(backend.NewKey(id.ClusterName, id.CAType))
+	return trace.Wrap(s.backend.ConditionalDelete(ctx, key, revision))
 }
 
 func (s *SubCAService) serviceForResource(

--- a/lib/services/local/subca_service_test.go
+++ b/lib/services/local/subca_service_test.go
@@ -399,16 +399,16 @@ func TestSubCAService_ConditionalDeleteCertAuthorityOverride(t *testing.T) {
 	validID := local.CertAuthorityOverrideIDFromResource(caOverride)
 
 	tests := []struct {
-		name      string
-		id        local.CertAuthorityOverrideID
-		revision  string
-		wantErr   string
-		wantErrIs error
+		name        string
+		id          local.CertAuthorityOverrideID
+		revision    string
+		wantErr     string
+		wantErrType any
 	}{
 		{
 			name:     "id empty",
 			revision: rev2,
-			wantErr:  "ClusterName required",
+			wantErr:  "clusterName required",
 		},
 		{
 			name: "id.ClusterName empty",
@@ -418,7 +418,7 @@ func TestSubCAService_ConditionalDeleteCertAuthorityOverride(t *testing.T) {
 				return id
 			}(),
 			revision: rev2,
-			wantErr:  "ClusterName required",
+			wantErr:  "clusterName required",
 		},
 		{
 			name: "id.CAType empty",
@@ -428,7 +428,7 @@ func TestSubCAService_ConditionalDeleteCertAuthorityOverride(t *testing.T) {
 				return id
 			}(),
 			revision: rev2,
-			wantErr:  "CAType required",
+			wantErr:  "caType required",
 		},
 		{
 			name: "CA override not found",
@@ -437,8 +437,9 @@ func TestSubCAService_ConditionalDeleteCertAuthorityOverride(t *testing.T) {
 				id.CAType = string(caTypeOther)
 				return id
 			}(),
-			revision:  rev2,
-			wantErrIs: backend.ErrIncorrectRevision,
+			revision:    rev2,
+			wantErr:     "does not exist or revision does not match",
+			wantErrType: new(*trace.CompareFailedError),
 		},
 		{
 			name:    "revision empty",
@@ -446,10 +447,11 @@ func TestSubCAService_ConditionalDeleteCertAuthorityOverride(t *testing.T) {
 			wantErr: "revision required",
 		},
 		{
-			name:      "revision not found",
-			id:        validID,
-			revision:  rev1, // current revision is rev2
-			wantErrIs: backend.ErrIncorrectRevision,
+			name:        "revision not found",
+			id:          validID,
+			revision:    rev1, // current revision is rev2
+			wantErr:     "does not exist or revision does not match",
+			wantErrType: new(*trace.CompareFailedError),
 		},
 		{
 			name:     "ok",
@@ -464,11 +466,12 @@ func TestSubCAService_ConditionalDeleteCertAuthorityOverride(t *testing.T) {
 			err := service.ConditionalDeleteCertAuthorityOverride(t.Context(), test.id, test.revision)
 			if test.wantErr != "" {
 				assert.ErrorContains(t, err, test.wantErr, "ConditionalDeleteCertAuthorityOverride error mismatch")
-				return
 			}
-			if test.wantErrIs != nil {
-				assert.ErrorIs(t, err, test.wantErrIs, "ConditionalDeleteCertAuthorityOverride error mismatch")
-				return
+			if test.wantErrType != nil {
+				assert.ErrorAs(t, err, test.wantErrType, "ConditionalDeleteCertAuthorityOverride error type mismatch")
+			}
+			if test.wantErr != "" || test.wantErrType != nil {
+				return // Asserted above.
 			}
 			require.NoError(t, err)
 

--- a/lib/services/local/subca_service_test.go
+++ b/lib/services/local/subca_service_test.go
@@ -371,6 +371,114 @@ func TestSubCAService_GetDeleteNotFoundError(t *testing.T) {
 	})
 }
 
+func TestSubCAService_ConditionalDeleteCertAuthorityOverride(t *testing.T) {
+	t.Parallel()
+
+	const caType = types.DatabaseClientCA
+	const caTypeOther = types.WindowsCA
+	env := subcaenv.New(t, subcaenv.EnvParams{
+		CATypesToCreate: []types.CertAuthType{caType},
+	})
+	service := env.SubCA
+
+	// Create CA override "rev1".
+	caOverride := env.NewOverrideForCAType(t, caType)
+	caOverride.GetMetadata().SetDescription("rev1")
+	caOverride.GetSpec().SetCertificateOverrides(nil) // not needed for this test
+	caOverride1, err := service.CreateCertAuthorityOverride(t.Context(), caOverride)
+	require.NoError(t, err)
+	rev1 := caOverride1.GetMetadata().GetRevision()
+
+	// "rev2" (current).
+	caOverride.GetMetadata().SetDescription("rev2")
+	caOverride.GetMetadata().SetRevision(rev1)
+	caOverride2, err := service.UpdateCertAuthorityOverride(t.Context(), caOverride)
+	require.NoError(t, err)
+	rev2 := caOverride2.GetMetadata().GetRevision()
+
+	validID := local.CertAuthorityOverrideIDFromResource(caOverride)
+
+	tests := []struct {
+		name      string
+		id        local.CertAuthorityOverrideID
+		revision  string
+		wantErr   string
+		wantErrIs error
+	}{
+		{
+			name:     "id empty",
+			revision: rev2,
+			wantErr:  "ClusterName required",
+		},
+		{
+			name: "id.ClusterName empty",
+			id: func() local.CertAuthorityOverrideID {
+				id := validID
+				id.ClusterName = ""
+				return id
+			}(),
+			revision: rev2,
+			wantErr:  "ClusterName required",
+		},
+		{
+			name: "id.CAType empty",
+			id: func() local.CertAuthorityOverrideID {
+				id := validID
+				id.CAType = ""
+				return id
+			}(),
+			revision: rev2,
+			wantErr:  "CAType required",
+		},
+		{
+			name: "CA override not found",
+			id: func() local.CertAuthorityOverrideID {
+				id := validID
+				id.CAType = string(caTypeOther)
+				return id
+			}(),
+			revision:  rev2,
+			wantErrIs: backend.ErrIncorrectRevision,
+		},
+		{
+			name:    "revision empty",
+			id:      validID,
+			wantErr: "revision required",
+		},
+		{
+			name:      "revision not found",
+			id:        validID,
+			revision:  rev1, // current revision is rev2
+			wantErrIs: backend.ErrIncorrectRevision,
+		},
+		{
+			name:     "ok",
+			id:       validID,
+			revision: rev2,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := service.ConditionalDeleteCertAuthorityOverride(t.Context(), test.id, test.revision)
+			if test.wantErr != "" {
+				assert.ErrorContains(t, err, test.wantErr, "ConditionalDeleteCertAuthorityOverride error mismatch")
+				return
+			}
+			if test.wantErrIs != nil {
+				assert.ErrorIs(t, err, test.wantErrIs, "ConditionalDeleteCertAuthorityOverride error mismatch")
+				return
+			}
+			require.NoError(t, err)
+
+			// Verify successful deletion.
+			_, err = service.GetCertAuthorityOverride(t.Context(), test.id)
+			assert.ErrorAs(t, err, new(*trace.NotFoundError), "Get error mismatch after ConditionalDelete")
+		})
+	}
+}
+
 func TestCreateResource_CertAuthorityOverride(t *testing.T) {
 	t.Parallel()
 

--- a/lib/services/subca.go
+++ b/lib/services/subca.go
@@ -46,6 +46,14 @@ type SubCAService interface {
 	// DeleteCertAuthorityOverride hard-deletes a CA override.
 	DeleteCertAuthorityOverride(ctx context.Context, id types.CertAuthorityOverrideID) error
 
+	// ConditionalDeleteCertAuthorityOverride conditionally deletes a CA override
+	// based on its revision.
+	ConditionalDeleteCertAuthorityOverride(
+		ctx context.Context,
+		id types.CertAuthorityOverrideID,
+		revision string,
+	) error
+
 	// UpdateCertAuthorityOverride conditionally updates a CA override.
 	UpdateCertAuthorityOverride(ctx context.Context, resource *subcav1.CertAuthorityOverride) (*subcav1.CertAuthorityOverride, error)
 


### PR DESCRIPTION
Add a conditional delete operation to generic.Service, generic.ServiceWrapper and to CA overrides.

Conditional deletes are useful for both DeleteCertAuthorityOverride and [RemoveCertificateOverride][1] RPCs.

[1]: https://github.com/gravitational/teleport.e/pull/8951

https://github.com/gravitational/teleport.e/issues/7675