### PR TITLE
Show User Display Names in tctl User Command Text Output

### DIFF
--- a/tool/tctl/common/resources/user.go
+++ b/tool/tctl/common/resources/user.go
@@ -27,6 +27,7 @@ import (
 	"github.com/gravitational/teleport/lib/asciitable"
 	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/services"
+	"github.com/gravitational/teleport/tool/common"
 )
 
 type userCollection struct {
@@ -49,10 +50,13 @@ func (u *userCollection) Resources() []types.Resource {
 func (u *userCollection) WriteText(w io.Writer, verbose bool) error {
 	t := asciitable.MakeTable([]string{"User"})
 	for _, user := range u.users {
-		t.AddRow([]string{user.GetName()})
+		display := user.GetDisplay()
+		t.AddRow([]string{
+			common.FormatUserDisplay(display.Primary, display.Secondary, user.GetName()),
+		})
 	}
-	fmt.Println(t.AsBuffer().String())
-	return nil
+	_, err := t.AsBuffer().WriteTo(w)
+	return trace.Wrap(err)
 }
 
 func userHandler() Handler {

--- a/tool/tctl/common/resources/user_test.go
+++ b/tool/tctl/common/resources/user_test.go
@@ -1,0 +1,71 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/asciitable"
+)
+
+const (
+	testDisplayNameTrait = "displayName"
+	testEmailTrait       = "email"
+)
+
+func TestUserCollectionWriteTextDisplaysUserIdentity(t *testing.T) {
+	users := []types.User{
+		newUserWithDisplayTraits(t, "display-both", "Alice Adams", "alice@example.com"),
+		newUserWithDisplayTraits(t, "display-primary", "Bob Baker", ""),
+		newUserWithDisplayTraits(t, "display-secondary", "", "secondary@example.com"),
+		newUserWithDisplayTraits(t, "display-none", "", ""),
+		newUserWithDisplayTraits(t, "alice@example.com", "alice@example.com", "alice@example.com"),
+		newUserWithDisplayTraits(t, "display-sanitized", "Eve\x1b[31m\nAdmin", "eve@example.com\r\n"),
+	}
+	table := asciitable.MakeTable(
+		[]string{"User"},
+		[]string{"display-both (Alice Adams) <alice@example.com>"},
+		[]string{"display-primary (Bob Baker)"},
+		[]string{"display-secondary <secondary@example.com>"},
+		[]string{"display-none"},
+		[]string{"alice@example.com"},
+		[]string{"display-sanitized (Eve Admin) <eve@example.com>"},
+	)
+	formatted := table.AsBuffer().String()
+
+	collectionFormatTest(t, &userCollection{users: users}, formatted, formatted)
+}
+
+func newUserWithDisplayTraits(t *testing.T, username, primary, secondary string) types.User {
+	t.Helper()
+
+	user, err := types.NewUser(username)
+	require.NoError(t, err)
+
+	traits := make(map[string][]string)
+	if primary != "" {
+		traits[testDisplayNameTrait] = []string{primary}
+	}
+	if secondary != "" {
+		traits[testEmailTrait] = []string{secondary}
+	}
+	user.SetTraits(traits)
+	return user
+}

--- a/tool/tctl/common/user_command.go
+++ b/tool/tctl/common/user_command.go
@@ -45,6 +45,7 @@ import (
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/utils"
 	"github.com/gravitational/teleport/lib/utils/gcp"
+	toolcommon "github.com/gravitational/teleport/tool/common"
 	commonclient "github.com/gravitational/teleport/tool/tctl/common/client"
 	tctlcfg "github.com/gravitational/teleport/tool/tctl/common/config"
 )
@@ -541,9 +542,11 @@ func (u *UserCommand) List(ctx context.Context, client *authclient.Client) error
 			return nil
 		}
 		t := asciitable.MakeTable([]string{"User", "Roles"})
-		for _, u := range users {
+		for _, user := range users {
+			display := user.GetDisplay()
 			t.AddRow([]string{
-				u.GetName(), strings.Join(u.GetRoles(), ","),
+				toolcommon.FormatUserDisplay(display.Primary, display.Secondary, user.GetName()),
+				strings.Join(user.GetRoles(), ","),
 			})
 		}
 		fmt.Println(t.AsBuffer().String())

--- a/tool/tctl/common/user_command.go
+++ b/tool/tctl/common/user_command.go
@@ -23,6 +23,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"log/slog"
 	"net/url"
 	"os"
@@ -78,6 +79,9 @@ type UserCommand struct {
 
 	// format is the output format, e.g. text, json, or yaml.
 	format string
+
+	// stdout allows switching the standard output source. Useful in tests.
+	stdout io.Writer
 
 	userAdd           *kingpin.CmdClause
 	userUpdate        *kingpin.CmdClause
@@ -161,6 +165,10 @@ func (u *UserCommand) Initialize(app *kingpin.Application, _ *tctlcfg.GlobalCLIF
 		defaults.ChangePasswordTokenTTL, defaults.MaxChangePasswordTokenTTL)).
 		Default(fmt.Sprintf("%v", defaults.ChangePasswordTokenTTL)).DurationVar(&u.ttl)
 	u.userResetPassword.Flag("format", "Output format.").Default(teleport.Text).EnumVar(&u.format, teleport.Text, teleport.JSON, teleport.YAML)
+
+	if u.stdout == nil {
+		u.stdout = os.Stdout
+	}
 }
 
 // TryRun takes the CLI command as an argument (like "users add") and executes it.
@@ -233,15 +241,22 @@ func (u *UserCommand) PrintResetPasswordTokenAsInvite(token types.UserToken) err
 	return nil
 }
 
+func (u *UserCommand) outputWriter() io.Writer {
+	if u.stdout != nil {
+		return u.stdout
+	}
+	return os.Stdout
+}
+
 // PrintResetPasswordToken prints ResetPasswordToken
 func (u *UserCommand) printResetPasswordToken(token types.UserToken, messageFormat string) (err error) {
 	switch strings.ToLower(u.format) {
 	case teleport.JSON:
-		err = printTokenAsJSON(token)
+		err = printTokenAsJSON(u.outputWriter(), token)
 	case teleport.YAML:
-		err = printTokenAsYAML(token)
+		err = printTokenAsYAML(u.outputWriter(), token)
 	case teleport.Text:
-		err = printTokenAsText(token, messageFormat)
+		err = printTokenAsText(u.outputWriter(), token, messageFormat)
 	default:
 		err = trace.BadParameter("unknown format %q", u.format)
 	}
@@ -333,7 +348,7 @@ func (u *UserCommand) Add(ctx context.Context, client *authclient.Client) error 
 
 	if _, err := client.CreateUser(ctx, user); err != nil {
 		if trace.IsAlreadyExists(err) {
-			fmt.Printf(`NOTE: To update an existing local user:
+			fmt.Fprintf(u.outputWriter(), `NOTE: To update an existing local user:
 > tctl users update %v --set-roles %v # replace roles
 
 `, u.login, strings.Join(u.allowedRoles, ","))
@@ -368,28 +383,34 @@ func flattenSlice(slice []string) (retval []string) {
 	return retval
 }
 
-func printTokenAsJSON(token types.UserToken) error {
+func printTokenAsJSON(w io.Writer, token types.UserToken) error {
 	out, err := json.MarshalIndent(token, "", "  ")
 	if err != nil {
 		return trace.Wrap(err, "failed to marshal reset password token")
 	}
-	fmt.Print(string(out))
+	if _, err := fmt.Fprint(w, string(out)); err != nil {
+		return trace.Wrap(err)
+	}
 	return nil
 }
 
-func printTokenAsYAML(token types.UserToken) error {
-	return trace.Wrap(utils.WriteYAML(os.Stdout, token), "failed to marshal reset password token")
+func printTokenAsYAML(w io.Writer, token types.UserToken) error {
+	return trace.Wrap(utils.WriteYAML(w, token), "failed to marshal reset password token")
 }
 
-func printTokenAsText(token types.UserToken, messageFormat string) error {
+func printTokenAsText(w io.Writer, token types.UserToken, messageFormat string) error {
 	url, err := url.Parse(token.GetURL())
 	if err != nil {
 		return trace.Wrap(err, "failed to parse reset password token url")
 	}
 
 	ttl := trimDurationZeroSuffix(token.Expiry().Sub(time.Now().UTC()))
-	fmt.Printf(messageFormat, token.GetUser(), ttl, url)
-	fmt.Printf("NOTE: Make sure %v points at a Teleport proxy which users can access.\n", url.Host)
+	if _, err := fmt.Fprintf(w, messageFormat, token.GetUser(), ttl, url); err != nil {
+		return trace.Wrap(err)
+	}
+	if _, err := fmt.Fprintf(w, "NOTE: Make sure %v points at a Teleport proxy which users can access.\n", url.Host); err != nil {
+		return trace.Wrap(err)
+	}
 	return nil
 }
 
@@ -521,9 +542,9 @@ func (u *UserCommand) Update(ctx context.Context, client *authclient.Client) err
 	if _, err := client.UpsertUser(ctx, user); err != nil {
 		return trace.Wrap(err)
 	}
-	fmt.Printf("User %v has been updated:\n", user.GetName())
+	fmt.Fprintf(u.outputWriter(), "User %v has been updated:\n", user.GetName())
 	for field, values := range updateMessages {
-		fmt.Printf("\tNew %v: %v\n", field, strings.Join(values, ","))
+		fmt.Fprintf(u.outputWriter(), "\tNew %v: %v\n", field, strings.Join(values, ","))
 	}
 	return nil
 }
@@ -538,7 +559,7 @@ func (u *UserCommand) List(ctx context.Context, client *authclient.Client) error
 	switch u.format {
 	case teleport.Text:
 		if len(users) == 0 {
-			fmt.Println("No users found")
+			fmt.Fprintln(u.outputWriter(), "No users found")
 			return nil
 		}
 		t := asciitable.MakeTable([]string{"User", "Roles"})
@@ -549,14 +570,14 @@ func (u *UserCommand) List(ctx context.Context, client *authclient.Client) error
 				strings.Join(user.GetRoles(), ","),
 			})
 		}
-		fmt.Println(t.AsBuffer().String())
+		fmt.Fprintln(u.outputWriter(), t.AsBuffer().String())
 	case teleport.JSON:
-		err := utils.WriteJSONArray(os.Stdout, users)
+		err := utils.WriteJSONArray(u.outputWriter(), users)
 		if err != nil {
 			return trace.Wrap(err, "failed to marshal users")
 		}
 	case teleport.YAML:
-		err := utils.WriteYAML(os.Stdout, users)
+		err := utils.WriteYAML(u.outputWriter(), users)
 		if err != nil {
 			return trace.Wrap(err, "failed to marshal users")
 		}
@@ -573,7 +594,7 @@ func (u *UserCommand) Delete(ctx context.Context, client *authclient.Client) err
 		if err := client.DeleteUser(ctx, l); err != nil {
 			return trace.Wrap(err)
 		}
-		fmt.Printf("User %q has been deleted\n", l)
+		fmt.Fprintf(u.outputWriter(), "User %q has been deleted\n", l)
 	}
 	return nil
 }

--- a/tool/tctl/common/user_command_test.go
+++ b/tool/tctl/common/user_command_test.go
@@ -21,17 +21,25 @@ package common
 import (
 	"context"
 	"fmt"
+	"io"
+	"os"
 	"testing"
 	"time"
 
 	"github.com/gravitational/trace"
 	"github.com/stretchr/testify/require"
 
+	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/constants"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/integration/helpers"
 	"github.com/gravitational/teleport/lib/config"
 	"github.com/gravitational/teleport/tool/teleport/testenv"
+)
+
+const (
+	testDisplayNameTrait = "displayName"
+	testEmailTrait       = "email"
 )
 
 func TestTrimDurationSuffix(t *testing.T) {
@@ -425,4 +433,110 @@ func TestUserUpdate(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestUserListDisplaysUserIdentity(t *testing.T) {
+	dynAddr := helpers.NewDynamicServiceAddr(t)
+	fileConfig := &config.FileConfig{
+		Global: config.Global{
+			DataDir: t.TempDir(),
+		},
+		Auth: config.Auth{
+			Service: config.Service{
+				EnabledFlag:   "true",
+				ListenAddress: dynAddr.AuthAddr,
+			},
+		},
+	}
+	process := makeAndRunTestAuthServer(t, withFileConfig(fileConfig), withFileDescriptors(dynAddr.Descriptors))
+	ctx := context.Background()
+	client, err := testenv.NewDefaultAuthClient(process)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = client.Close() })
+
+	command := &UserCommand{format: teleport.Text}
+	stdout, err := captureStdout(t, func() error {
+		return command.List(ctx, client)
+	})
+	require.NoError(t, err)
+	require.Equal(t, "No users found\n", stdout)
+
+	users := []types.User{
+		newUserWithDisplayTraits(t, "display-both", "Alice Adams", "alice@example.com", "access", "editor"),
+		newUserWithDisplayTraits(t, "display-primary", "Bob Baker", "", "access"),
+		newUserWithDisplayTraits(t, "display-secondary", "", "secondary@example.com", "auditor"),
+		newUserWithDisplayTraits(t, "display-none", "", "", "access"),
+		newUserWithDisplayTraits(t, "alice@example.com", "alice@example.com", "alice@example.com", "access"),
+		newUserWithDisplayTraits(t, "display-sanitized", "Eve\x1b[31m\nAdmin", "eve@example.com\r\n", "access"),
+	}
+	for _, user := range users {
+		_, err := client.UpsertUser(ctx, user)
+		require.NoError(t, err)
+	}
+
+	stdout, err = captureStdout(t, func() error {
+		return command.List(ctx, client)
+	})
+	require.NoError(t, err)
+
+	for _, want := range []string{
+		"User",
+		"Roles",
+		"access,editor",
+		"display-both (Alice Adams) <alice@example.com>",
+		"display-primary (Bob Baker)",
+		"display-secondary <secondary@example.com>",
+		"display-none",
+		"alice@example.com",
+		"display-sanitized (Eve Admin) <eve@example.com>",
+	} {
+		require.Contains(t, stdout, want)
+	}
+
+	for _, notWant := range []string{
+		"alice@example.com (alice@example.com)",
+		"\x1b",
+		"\r",
+		"Eve\nAdmin",
+	} {
+		require.NotContains(t, stdout, notWant)
+	}
+}
+
+func newUserWithDisplayTraits(t *testing.T, username, primary, secondary string, roles ...string) types.User {
+	t.Helper()
+
+	user, err := types.NewUser(username)
+	require.NoError(t, err)
+	user.SetRoles(roles)
+
+	traits := make(map[string][]string)
+	if primary != "" {
+		traits[testDisplayNameTrait] = []string{primary}
+	}
+	if secondary != "" {
+		traits[testEmailTrait] = []string{secondary}
+	}
+	user.SetTraits(traits)
+	return user
+}
+
+func captureStdout(t *testing.T, fn func() error) (string, error) {
+	t.Helper()
+
+	oldStdout := os.Stdout
+	reader, writer, err := os.Pipe()
+	require.NoError(t, err)
+	defer func() {
+		os.Stdout = oldStdout
+	}()
+	os.Stdout = writer
+
+	fnErr := fn()
+	require.NoError(t, writer.Close())
+	output, err := io.ReadAll(reader)
+	require.NoError(t, err)
+	require.NoError(t, reader.Close())
+
+	return string(output), fnErr
 }

--- a/tool/tctl/common/user_command_test.go
+++ b/tool/tctl/common/user_command_test.go
@@ -19,10 +19,9 @@
 package common
 
 import (
+	"bytes"
 	"context"
 	"fmt"
-	"io"
-	"os"
 	"testing"
 	"time"
 
@@ -449,17 +448,19 @@ func TestUserListDisplaysUserIdentity(t *testing.T) {
 		},
 	}
 	process := makeAndRunTestAuthServer(t, withFileConfig(fileConfig), withFileDescriptors(dynAddr.Descriptors))
-	ctx := context.Background()
+	ctx := t.Context()
 	client, err := testenv.NewDefaultAuthClient(process)
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = client.Close() })
 
-	command := &UserCommand{format: teleport.Text}
-	stdout, err := captureStdout(t, func() error {
-		return command.List(ctx, client)
-	})
+	var stdout bytes.Buffer
+	command := &UserCommand{
+		format: teleport.Text,
+		stdout: &stdout,
+	}
+	err = command.List(ctx, client)
 	require.NoError(t, err)
-	require.Equal(t, "No users found\n", stdout)
+	require.Equal(t, "No users found\n", stdout.String())
 
 	users := []types.User{
 		newUserWithDisplayTraits(t, "display-both", "Alice Adams", "alice@example.com", "access", "editor"),
@@ -474,9 +475,8 @@ func TestUserListDisplaysUserIdentity(t *testing.T) {
 		require.NoError(t, err)
 	}
 
-	stdout, err = captureStdout(t, func() error {
-		return command.List(ctx, client)
-	})
+	stdout.Reset()
+	err = command.List(ctx, client)
 	require.NoError(t, err)
 
 	for _, want := range []string{
@@ -490,7 +490,7 @@ func TestUserListDisplaysUserIdentity(t *testing.T) {
 		"alice@example.com",
 		"display-sanitized (Eve Admin) <eve@example.com>",
 	} {
-		require.Contains(t, stdout, want)
+		require.Contains(t, stdout.String(), want)
 	}
 
 	for _, notWant := range []string{
@@ -499,7 +499,7 @@ func TestUserListDisplaysUserIdentity(t *testing.T) {
 		"\r",
 		"Eve\nAdmin",
 	} {
-		require.NotContains(t, stdout, notWant)
+		require.NotContains(t, stdout.String(), notWant)
 	}
 }
 
@@ -519,24 +519,4 @@ func newUserWithDisplayTraits(t *testing.T, username, primary, secondary string,
 	}
 	user.SetTraits(traits)
 	return user
-}
-
-func captureStdout(t *testing.T, fn func() error) (string, error) {
-	t.Helper()
-
-	oldStdout := os.Stdout
-	reader, writer, err := os.Pipe()
-	require.NoError(t, err)
-	defer func() {
-		os.Stdout = oldStdout
-	}()
-	os.Stdout = writer
-
-	fnErr := fn()
-	require.NoError(t, writer.Close())
-	output, err := io.ReadAll(reader)
-	require.NoError(t, err)
-	require.NoError(t, reader.Close())
-
-	return string(output), fnErr
 }


### PR DESCRIPTION
This PR addresses [#66993](https://github.com/gravitational/teleport/issues/66993) (part of the [RFD 302](https://github.com/gravitational/rfd/blob/main/rfd/0302-user-display-name-configuration.md) user display names effort) by rendering configured user display names in the human-readable text output of the `tctl` user commands, so operators see meaningful names instead of bare (possibly numeric) usernames.

The following changes were made:

- **`tctl users ls`:** `UserCommand.List` now renders the `User` column combining the user's display values with the username. 

- **`tctl get user[/<name>] --format=text`:** `userCollection.WriteText` renders the `User` column through the same formatter. 



## Manual Test Plan
### Test Environment

- local cluster

### Test Cases

- [x] verify that `tctl users ls` works as intended
   1. run `tctl users ls` and verify the output like the following:
  <img width="847" height="545" alt="Screenshot 2026-06-16 at 3 34 54 PM" src="https://github.com/user-attachments/assets/c813d27d-807c-4fed-8837-8614d01867fa" />

- [x] verify that `tctl get user[/<name>] --format=text` works as intended
   1. run `tctl get user/<username> --format=text` and verify the output like the following:
  <img width="383" height="42" alt="Screenshot 2026-06-16 at 3 37 23 PM" src="https://github.com/user-attachments/assets/a3ffae57-847e-46c6-860a-d8c55a197202" />

changelog: tctl users ls and tctl get user text output now show configured user display names alongside the username
