### PR TITLE
Porting `GetUser`, `GetRole`, `EmitAuditEvent`, `CreateAuditStream`, and `ResumeAuditStream` RPCs to support scoped authZ

### DIFF
--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -5169,16 +5169,17 @@ func (a *ServerWithRoles) ValidateGithubAuthCallback(ctx context.Context, q url.
 }
 
 // EmitAuditEvent emits a single audit event
-func (a *ServerWithRoles) EmitAuditEvent(ctx context.Context, event apievents.AuditEvent) error {
+func (a *ScopedServerWithRoles) EmitAuditEvent(ctx context.Context, event apievents.AuditEvent) error {
 	ctx = context.WithoutCancel(ctx)
-	if err := a.authorizeAction(types.KindEvent, types.VerbCreate); err != nil {
+	ruleCtx := a.scopedContext.RuleContext()
+	if err := a.scopedContext.CheckerContext.RiskyAuthorizeUnpinnedEmitEvent(ctx, &ruleCtx); err != nil {
 		return trace.Wrap(err)
 	}
-	role, ok := a.context.Identity.(authz.BuiltinRole)
-	if !ok || !role.IsServer() {
+	serverID, isServer := getBuiltinServerID(a.scopedContext.Identity)
+	if !isServer {
 		return trace.AccessDenied("this request can be only executed by a teleport built-in server")
 	}
-	err := events.ValidateServerMetadata(event, role.GetServerID(), a.hasBuiltinRole(types.RoleProxy))
+	err := events.ValidateServerMetadata(event, serverID, a.hasBuiltinRole(types.RoleProxy))
 	if err != nil {
 		// TODO: this should be a proper audit event
 		// notifying about access violation
@@ -5187,7 +5188,7 @@ func (a *ServerWithRoles) EmitAuditEvent(ctx context.Context, event apievents.Au
 		a.authServer.logger.WarnContext(ctx, msg,
 			"event_type", event.GetType(),
 			"event_id", event.GetID(),
-			"server_id", role.GetServerID(),
+			"server_id", serverID,
 			"error", err)
 		// this message is sparse on purpose to avoid conveying extra data to an attacker
 		return trace.AccessDenied("failed to validate event metadata")
@@ -5196,12 +5197,13 @@ func (a *ServerWithRoles) EmitAuditEvent(ctx context.Context, event apievents.Au
 }
 
 // CreateAuditStream creates audit event stream
-func (a *ServerWithRoles) CreateAuditStream(ctx context.Context, sid session.ID) (apievents.Stream, error) {
-	if err := a.authorizeAction(types.KindEvent, types.VerbCreate, types.VerbUpdate); err != nil {
+func (a *ScopedServerWithRoles) CreateAuditStream(ctx context.Context, sid session.ID) (apievents.Stream, error) {
+	ruleCtx := a.scopedContext.RuleContext()
+	if err := a.scopedContext.CheckerContext.RiskyAuthorizeUnpinnedWriteEvent(ctx, &ruleCtx); err != nil {
 		return nil, trace.Wrap(err)
 	}
-	role, ok := a.context.Identity.(authz.BuiltinRole)
-	if !ok || !role.IsServer() {
+	serverID, isServer := getBuiltinServerID(a.scopedContext.Identity)
+	if !isServer {
 		return nil, trace.AccessDenied("this request can be only executed by a Teleport server")
 	}
 	stream, err := a.authServer.CreateAuditStream(ctx, sid)
@@ -5211,17 +5213,18 @@ func (a *ServerWithRoles) CreateAuditStream(ctx context.Context, sid session.ID)
 	return &streamWithRoles{
 		stream:   stream,
 		a:        a,
-		serverID: role.GetServerID(),
+		serverID: serverID,
 	}, nil
 }
 
 // ResumeAuditStream resumes the stream that has been created
-func (a *ServerWithRoles) ResumeAuditStream(ctx context.Context, sid session.ID, uploadID string) (apievents.Stream, error) {
-	if err := a.authorizeAction(types.KindEvent, types.VerbCreate, types.VerbUpdate); err != nil {
+func (a *ScopedServerWithRoles) ResumeAuditStream(ctx context.Context, sid session.ID, uploadID string) (apievents.Stream, error) {
+	ruleCtx := a.scopedContext.RuleContext()
+	if err := a.scopedContext.CheckerContext.RiskyAuthorizeUnpinnedWriteEvent(ctx, &ruleCtx); err != nil {
 		return nil, trace.Wrap(err)
 	}
-	role, ok := a.context.Identity.(authz.BuiltinRole)
-	if !ok || !role.IsServer() {
+	serverID, isServer := getBuiltinServerID(a.scopedContext.Identity)
+	if !isServer {
 		return nil, trace.AccessDenied("this request can be only executed by a Teleport server")
 	}
 	stream, err := a.authServer.ResumeAuditStream(ctx, sid, uploadID)
@@ -5231,12 +5234,12 @@ func (a *ServerWithRoles) ResumeAuditStream(ctx context.Context, sid session.ID,
 	return &streamWithRoles{
 		stream:   stream,
 		a:        a,
-		serverID: role.GetServerID(),
+		serverID: serverID,
 	}, nil
 }
 
 type streamWithRoles struct {
-	a        *ServerWithRoles
+	a        *ScopedServerWithRoles
 	serverID string
 	stream   apievents.Stream
 }
@@ -5589,6 +5592,19 @@ func checkRoleFeatureSupport(mod modules.Modules, role types.Role) error {
 	default:
 		return nil
 	}
+}
+
+// GetRole returns a role by name, supporting both scoped and unscoped callers.
+func (a *ScopedServerWithRoles) GetRole(ctx context.Context, name string) (types.Role, error) {
+	if unscoped, ok := a.UnscopedServerWithRoles(); ok {
+		return unscoped.GetRole(ctx, name)
+	}
+
+	ruleCtx := a.scopedContext.RuleContext()
+	if err := a.scopedContext.CheckerContext.RiskyAuthorizeUnpinnedRead(ctx, services.UnpinnedReadRole, &ruleCtx); err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return a.authServer.GetRole(ctx, name)
 }
 
 // GetRole returns role by name

--- a/lib/auth/auth_with_roles_test.go
+++ b/lib/auth/auth_with_roles_test.go
@@ -9150,7 +9150,7 @@ func TestLocalServiceRolesHavePermissionsForUploaderService(t *testing.T) {
 					*authContext,
 				)
 
-				err := s.EmitAuditEvent(ctx, &apievents.UserLogin{
+				err := s.ScopedServerWithRoles().EmitAuditEvent(ctx, &apievents.UserLogin{
 					Metadata: apievents.Metadata{
 						Type: events.UserLoginEvent,
 						Code: events.UserLocalLoginFailureCode,
@@ -9168,7 +9168,7 @@ func TestLocalServiceRolesHavePermissionsForUploaderService(t *testing.T) {
 					*authContext,
 				)
 
-				stream, err := s.CreateAuditStream(ctx, session.ID("streamer"))
+				stream, err := s.ScopedServerWithRoles().CreateAuditStream(ctx, session.ID("streamer"))
 				require.NoError(t, err)
 				require.NoError(t, stream.Close(ctx))
 			})
@@ -9180,7 +9180,7 @@ func TestLocalServiceRolesHavePermissionsForUploaderService(t *testing.T) {
 					*authContext,
 				)
 
-				stream, err := s.ResumeAuditStream(ctx, session.ID("streamer"), "upload")
+				stream, err := s.ScopedServerWithRoles().ResumeAuditStream(ctx, session.ID("streamer"), "upload")
 				require.NoError(t, err)
 				require.NoError(t, stream.Close(ctx))
 			})
@@ -13350,4 +13350,80 @@ func TestScopedUserCertGeneration(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestScopePinnedEmitAuditEvent verifies that an agent with a scope pin is able to emit an audit event.
+func TestScopePinnedEmitAuditEvent(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+	srv, err := authtest.NewTestServer(authtest.ServerConfig{
+		Auth: authtest.AuthServerConfig{
+			Dir: t.TempDir(),
+			ScopesFeatures: scopes.Features{
+				Enabled:         true,
+				AgentPinEnabled: true,
+			},
+		},
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { srv.Close() })
+
+	const (
+		hostID   = "test-host"
+		username = "test-user"
+		scope    = "/test"
+	)
+	// setup auth with scope pinned host
+	scopedHostAuth := newScopePinnedTestServerForHost(t, srv.AuthServer, hostID, scope, types.RoleNode)
+
+	// create user to test scope pinned users
+	_, err = authtest.CreateUser(ctx, srv.Auth(), username)
+	require.NoError(t, err)
+	// create a scoped role assigning perms to create events
+	_, err = srv.Auth().ScopedAccess().CreateScopedRole(ctx, scopedaccessv1.CreateScopedRoleRequest_builder{
+		Role: scopedaccessv1.ScopedRole_builder{
+			Kind:    scopedaccess.KindScopedRole,
+			Version: types.V1,
+			Metadata: headerv1.Metadata_builder{
+				Name: username + "-role",
+			}.Build(),
+			Scope: scope,
+			Spec: scopedaccessv1.ScopedRoleSpec_builder{
+				AssignableScopes: []string{scope},
+				Rules: []*scopedaccessv1.ScopedRule{
+					scopedaccessv1.ScopedRule_builder{
+						Resources: []string{types.KindEvent},
+						Verbs:     []string{types.VerbCreate},
+					}.Build(),
+				},
+			}.Build(),
+		}.Build(),
+	}.Build())
+	// NOTE (etate): if scoped role validation ever permits VerbCreate on KindEvent, then this test either needs to be updated
+	// to assert that EmitAuditEvent still fails for scoped user pins, or EmitAuditEvent needs to be updated to permit
+	// identities with scoped user pins
+	require.Error(t, err)
+	require.True(t, trace.IsBadParameter(err), "expected trace.BadParameterError")
+
+	// ensure that scope pinned agents are able to emit events
+	err = scopedHostAuth.EmitAuditEvent(ctx, &apievents.SessionConnect{
+		Metadata: apievents.Metadata{
+			Type: events.SessionConnectEvent,
+			Code: events.SessionConnectCode,
+		},
+		ServerMetadata: apievents.ServerMetadata{
+			ServerID: hostID,
+		},
+	})
+	require.NoError(t, err)
+
+	// ensure that scope pinned agents are able to create and resume audit streams
+	sessionID := session.ID("streamer")
+	stream, err := scopedHostAuth.CreateAuditStream(ctx, sessionID)
+	require.NoError(t, err)
+	require.NoError(t, stream.Close(ctx))
+
+	stream, err = scopedHostAuth.ResumeAuditStream(ctx, sessionID, "upload")
+	require.NoError(t, err)
+	require.NoError(t, stream.Close(ctx))
 }

--- a/lib/auth/grpcserver.go
+++ b/lib/auth/grpcserver.go
@@ -285,7 +285,7 @@ func (g *GRPCServer) GetServer() (*grpc.Server, error) {
 
 // EmitAuditEvent emits audit event
 func (g *GRPCServer) EmitAuditEvent(ctx context.Context, req *apievents.OneOf) (*emptypb.Empty, error) {
-	auth, err := g.authenticate(ctx)
+	auth, err := g.scopedAuthenticate(ctx)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -355,7 +355,7 @@ func (g *GRPCServer) SendKeepAlives(stream authpb.AuthService_SendKeepAlivesServ
 
 // CreateAuditStream creates or resumes audit event stream
 func (g *GRPCServer) CreateAuditStream(stream authpb.AuthService_CreateAuditStreamServer) error {
-	auth, err := g.authenticate(stream.Context())
+	auth, err := g.scopedAuthenticate(stream.Context())
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -377,7 +377,7 @@ func (g *GRPCServer) CreateAuditStream(stream authpb.AuthService_CreateAuditStre
 
 	var eventStream apievents.Stream
 	var sessionID session.ID
-	g.logger.DebugContext(stream.Context(), "CreateAuditStream connection", "identity", auth.User.GetName())
+	g.logger.DebugContext(stream.Context(), "CreateAuditStream connection", "identity", auth.scopedContext.DisplayName())
 	streamStart := time.Now()
 	processed := int64(0)
 	counter := 0
@@ -2504,11 +2504,11 @@ func maybeDowngradeRoleSSHPortForwarding(role *types.RoleV6, clientVersion *semv
 
 // GetRole retrieves a role by name.
 func (g *GRPCServer) GetRole(ctx context.Context, req *authpb.GetRoleRequest) (*types.RoleV6, error) {
-	auth, err := g.authenticate(ctx)
+	auth, err := g.scopedAuthenticate(ctx)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	roleI, err := auth.ServerWithRoles.GetRole(ctx, req.Name)
+	roleI, err := auth.GetRole(ctx, req.Name)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -6059,13 +6059,14 @@ func NewGRPCServer(cfg GRPCServerConfig) (*GRPCServer, error) {
 	)
 
 	usersService, err := usersv1.NewService(usersv1.ServiceConfig{
-		Authorizer: cfg.Authorizer,
-		Cache:      cfg.AuthServer.Cache,
-		Backend:    cfg.AuthServer.Services,
-		Emitter:    cfg.Emitter,
-		Reporter:   cfg.AuthServer.Services.UsageReporter,
-		Clock:      cfg.AuthServer.GetClock(),
-		Logger:     cfg.AuthServer.logger.With(teleport.ComponentKey, "users.service"),
+		Authorizer:       cfg.Authorizer,
+		ScopedAuthorizer: cfg.ScopedAuthorizer,
+		Cache:            cfg.AuthServer.Cache,
+		Backend:          cfg.AuthServer.Services,
+		Emitter:          cfg.Emitter,
+		Reporter:         cfg.AuthServer.Services.UsageReporter,
+		Clock:            cfg.AuthServer.GetClock(),
+		Logger:           cfg.AuthServer.logger.With(teleport.ComponentKey, "users.service"),
 	})
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/auth/users/usersv1/service.go
+++ b/lib/auth/users/usersv1/service.go
@@ -67,26 +67,28 @@ type Backend interface {
 // ServiceConfig holds configuration options for
 // the users gRPC service.
 type ServiceConfig struct {
-	Authorizer authz.Authorizer
-	Cache      Cache
-	Backend    Backend
-	Logger     *slog.Logger
-	Emitter    apievents.Emitter
-	Reporter   usagereporter.UsageReporter
-	Clock      clockwork.Clock
+	Authorizer       authz.Authorizer
+	ScopedAuthorizer authz.ScopedAuthorizer
+	Cache            Cache
+	Backend          Backend
+	Logger           *slog.Logger
+	Emitter          apievents.Emitter
+	Reporter         usagereporter.UsageReporter
+	Clock            clockwork.Clock
 }
 
 // Service implements the teleport.users.v1.UsersService RPC service.
 type Service struct {
 	userspb.UnimplementedUsersServiceServer
 
-	authorizer authz.Authorizer
-	cache      Cache
-	backend    Backend
-	logger     *slog.Logger
-	emitter    apievents.Emitter
-	reporter   usagereporter.UsageReporter
-	clock      clockwork.Clock
+	authorizer       authz.Authorizer
+	scopedAuthorizer authz.ScopedAuthorizer
+	cache            Cache
+	backend          Backend
+	logger           *slog.Logger
+	emitter          apievents.Emitter
+	reporter         usagereporter.UsageReporter
+	clock            clockwork.Clock
 }
 
 // NewService returns a new users gRPC service.
@@ -98,6 +100,8 @@ func NewService(cfg ServiceConfig) (*Service, error) {
 		return nil, trace.BadParameter("backend service is required")
 	case cfg.Authorizer == nil:
 		return nil, trace.BadParameter("authorizer is required")
+	case cfg.ScopedAuthorizer == nil:
+		return nil, trace.BadParameter("scoped authorizer is required")
 	case cfg.Emitter == nil:
 		return nil, trace.BadParameter("emitter is required")
 	case cfg.Reporter == nil:
@@ -112,37 +116,53 @@ func NewService(cfg ServiceConfig) (*Service, error) {
 	}
 
 	return &Service{
-		logger:     cfg.Logger,
-		authorizer: cfg.Authorizer,
-		cache:      cfg.Cache,
-		backend:    cfg.Backend,
-		emitter:    cfg.Emitter,
-		reporter:   cfg.Reporter,
-		clock:      cfg.Clock,
+		logger:           cfg.Logger,
+		authorizer:       cfg.Authorizer,
+		scopedAuthorizer: cfg.ScopedAuthorizer,
+		cache:            cfg.Cache,
+		backend:          cfg.Backend,
+		emitter:          cfg.Emitter,
+		reporter:         cfg.Reporter,
+		clock:            cfg.Clock,
 	}, nil
 }
 
 // currentUserAction is a special checker that allows certain actions for users
 // even if they are not admins, e.g. update their own passwords,
 // or generate certificates, otherwise it will require admin privileges
-func currentUserAction(authzContext authz.Context, username string) error {
-	if authz.IsLocalUser(authzContext) && username == authzContext.User.GetName() {
+func currentUserAction(scopedCtx *authz.ScopedContext, username string) error {
+	if authz.ScopedIsCurrentUser(scopedCtx, username) {
 		return nil
 	}
-	return authzContext.Checker.CheckAccessToRule(&services.Context{User: authzContext.User},
+
+	unscopedCtx, isUnscoped := scopedCtx.UnscopedContext()
+	if !isUnscoped {
+		return trace.AccessDenied("scoped users can not create other users")
+	}
+
+	if authz.IsCurrentUser(*unscopedCtx, username) {
+		return nil
+	}
+
+	return unscopedCtx.Checker.CheckAccessToRule(&services.Context{User: unscopedCtx.User},
 		apidefaults.Namespace, types.KindUser, types.VerbCreate)
 }
 
-func (s *Service) getCurrentUser(ctx context.Context, authCtx *authz.Context) (*types.UserV2, error) {
+func (s *Service) getCurrentUser(ctx context.Context, scopedCtx *authz.ScopedContext) (*types.UserV2, error) {
+	// scopedCtx.User can be nil in the case of a scopedCtx built on authz.ScopedBuiltinRole
+	if scopedCtx.User == nil {
+		return nil, trace.BadParameter("expected a current authenticated user, identity likely a builtin system role")
+	}
+
 	// check access to roles
-	for _, role := range authCtx.User.GetRoles() {
+	for _, role := range scopedCtx.User.GetRoles() {
 		_, err := s.cache.GetRole(ctx, role)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
 	}
 
-	withoutSecrets := authCtx.User.WithoutSecrets()
+	withoutSecrets := scopedCtx.User.WithoutSecrets()
 	user, ok := withoutSecrets.(types.User)
 	if !ok {
 		return nil, trace.BadParameter("expected types.User when fetching current user information, got %T", withoutSecrets)
@@ -157,21 +177,25 @@ func (s *Service) getCurrentUser(ctx context.Context, authCtx *authz.Context) (*
 }
 
 func (s *Service) GetUser(ctx context.Context, req *userspb.GetUserRequest) (*userspb.GetUserResponse, error) {
-	authCtx, err := s.authorizer.Authorize(ctx)
+	scopedCtx, err := s.scopedAuthorizer.AuthorizeScoped(ctx)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
 	if req.GetName() == "" && req.GetCurrentUser() {
-		user, err := s.getCurrentUser(ctx, authCtx)
+		user, err := s.getCurrentUser(ctx, scopedCtx)
 		return userspb.GetUserResponse_builder{User: user}.Build(), trace.Wrap(err)
 	}
 
+	unscopedCtx, isUnscoped := scopedCtx.UnscopedContext()
 	if req.GetWithSecrets() {
+		if !isUnscoped {
+			return nil, trace.AccessDenied("this request can only be executed by an unscoped admin")
+		}
 		// TODO(fspmarshall): replace admin requirement with VerbReadWithSecrets once we've
 		// migrated to that model.
-		if !authz.HasBuiltinRole(*authCtx, string(types.RoleAdmin)) {
-			err := trace.AccessDenied("user %q requested access to user %q with secrets", authCtx.User.GetName(), req.GetName())
+		if !authz.HasBuiltinRole(*unscopedCtx, string(types.RoleAdmin)) {
+			err := trace.AccessDenied("user %q requested access to user %q with secrets", unscopedCtx.User.GetName(), req.GetName())
 			s.logger.WarnContext(ctx, "user does not have permission to read user with secrets", "error", err)
 			if err := s.emitter.EmitAuditEvent(ctx, &apievents.UserLogin{
 				Metadata: apievents.Metadata{
@@ -187,14 +211,14 @@ func (s *Service) GetUser(ctx context.Context, req *userspb.GetUserRequest) (*us
 			}); err != nil {
 				s.logger.WarnContext(ctx, "Failed to emit local login failure event", "error", err)
 			}
-			return nil, trace.AccessDenied("this request can be only executed by an admin")
+			return nil, trace.AccessDenied("this request can only be executed by an admin")
 		}
 	} else {
 		// if secrets are not being accessed, let users always read
 		// their own info.
-		if err := currentUserAction(*authCtx, req.GetName()); err != nil {
-			// not current user, perform normal permission check.
-			if err := authCtx.CheckAccessToKind(types.KindUser, types.VerbRead); err != nil {
+		if err := currentUserAction(scopedCtx, req.GetName()); err != nil {
+			ruleCtx := scopedCtx.RuleContext()
+			if err := scopedCtx.CheckerContext.RiskyAuthorizeUnpinnedRead(ctx, services.UnpinnedReadUser, &ruleCtx); err != nil {
 				return nil, trace.Wrap(err)
 			}
 		}

--- a/lib/auth/users/usersv1/service_test.go
+++ b/lib/auth/users/usersv1/service_test.go
@@ -35,6 +35,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"golang.org/x/crypto/bcrypt"
 
+	scopesv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/v1"
 	userspb "github.com/gravitational/teleport/api/gen/proto/go/teleport/users/v1"
 	"github.com/gravitational/teleport/api/types"
 	apievents "github.com/gravitational/teleport/api/types/events"
@@ -54,6 +55,7 @@ type fakeAuthorizer struct {
 	authorize bool
 
 	authzContext *authz.Context
+	checkerMap   map[string]*services.ScopedAccessChecker
 }
 
 // Authorize implements authz.Authorizer
@@ -76,6 +78,7 @@ func (a fakeAuthorizer) Authorize(ctx context.Context) (*authz.Context, error) {
 				},
 			},
 			Identity:             identity,
+			UnmappedIdentity:     identity,
 			AdminActionAuthState: authz.AdminActionAuthNotRequired,
 		}, nil
 	}
@@ -88,6 +91,13 @@ func (a fakeAuthorizer) Authorize(ctx context.Context) (*authz.Context, error) {
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
+	identity = &authz.LocalUser{
+		Username: "alice",
+		Identity: tlsca.Identity{
+			Groups:   []string{"dev"},
+			Username: "alice",
+		},
+	}
 	return &authz.Context{
 		User: user,
 		Checker: &fakeChecker{
@@ -98,14 +108,34 @@ func (a fakeAuthorizer) Authorize(ctx context.Context) (*authz.Context, error) {
 				},
 			},
 		},
-		Identity: &authz.LocalUser{
-			Username: "alice",
-			Identity: tlsca.Identity{
-				Groups:   []string{"dev"},
-				Username: "alice",
-			},
-		},
+		Identity:             identity,
+		UnmappedIdentity:     identity,
 		AdminActionAuthState: authz.AdminActionAuthNotRequired,
+	}, nil
+}
+
+func (a fakeAuthorizer) AuthorizeScoped(ctx context.Context) (*authz.ScopedContext, error) {
+	identity, err := authz.UserFromContext(ctx)
+	if err != nil || identity.GetIdentity().ScopePin == nil {
+		authCtx, err := a.Authorize(ctx)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		return authz.ScopedContextFromUnscopedContext(authCtx), nil
+	}
+
+	scopedBuiltin, ok := identity.(authz.ScopedBuiltinRole)
+	if !ok {
+		return nil, trace.AccessDenied("expected scoped builtin role")
+	}
+
+	checkerCtx, err := services.NewScopedAccessCheckerContextForAgentPin(scopedBuiltin.ScopePin, a.checkerMap)
+	if err != nil {
+		return nil, err
+	}
+	return &authz.ScopedContext{
+		Identity:       identity,
+		CheckerContext: checkerCtx,
 	}, nil
 }
 
@@ -145,6 +175,12 @@ func withAuthorizer(authz authz.Authorizer) serviceOpt {
 	}
 }
 
+func withScopedAuthorizer(scopedAuthz authz.ScopedAuthorizer) serviceOpt {
+	return func(config *usersv1.ServiceConfig) {
+		config.ScopedAuthorizer = scopedAuthz
+	}
+}
+
 func withEmitter(emitter apievents.Emitter) serviceOpt {
 	return func(config *usersv1.ServiceConfig) {
 		config.Emitter = emitter
@@ -179,11 +215,12 @@ func newTestEnv(opts ...serviceOpt) (*env, error) {
 	emitter := eventstest.NewChannelEmitter(10)
 
 	cfg := usersv1.ServiceConfig{
-		Authorizer: fakeAuthorizer{authorize: true},
-		Cache:      service,
-		Backend:    service,
-		Emitter:    emitter,
-		Reporter:   usagereporter.DiscardUsageReporter{},
+		Authorizer:       fakeAuthorizer{authorize: true},
+		ScopedAuthorizer: fakeAuthorizer{authorize: true},
+		Cache:            service,
+		Backend:          service,
+		Emitter:          emitter,
+		Reporter:         usagereporter.DiscardUsageReporter{},
 	}
 
 	for _, opt := range opts {
@@ -300,10 +337,12 @@ func TestGetUser(t *testing.T) {
 	}, &types.SessionRecordingConfigV2{})
 	require.NoError(t, err, "creating authorization context")
 
-	env, err := newTestEnv(withAuthorizer(fakeAuthorizer{authzContext: authzContext}))
+	env, err := newTestEnv(
+		withScopedAuthorizer(fakeAuthorizer{authzContext: authzContext}),
+	)
 	require.NoError(t, err, "creating test service")
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	llama, err := types.NewUser("llama")
 	require.NoError(t, err, "creating new user llama")
@@ -611,7 +650,7 @@ func generateUserSecrets(u types.User) error {
 func TestRBAC(t *testing.T) {
 	t.Parallel()
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	llama, err := types.NewUser("llama")
 	require.NoError(t, err, "creating new user llama")
@@ -674,11 +713,27 @@ func TestRBAC(t *testing.T) {
 			expectChecks: []check{},
 		},
 		{
-			desc: "get",
+			desc: "get self with explicit access",
 			f: func(t *testing.T, service *usersv1.Service) {
 				resp, err := service.GetUser(ctx, userspb.GetUserRequest_builder{Name: "llama"}.Build())
 				assert.NoError(t, err, "expected RBAC to allow getting user")
 				assert.Empty(t, cmp.Diff(llama, resp.GetUser(), cmpopts.IgnoreFields(types.Metadata{}, "Revision")))
+			},
+			checker: &fakeChecker{
+				rules: []types.Rule{
+					{
+						Resources: []string{types.KindUser},
+					},
+				},
+			},
+			expectChecks: []check{},
+		},
+		{
+			desc: "get other user",
+			f: func(t *testing.T, service *usersv1.Service) {
+				_, err := service.GetUser(ctx, userspb.GetUserRequest_builder{Name: "alice"}.Build())
+				assert.Error(t, err, "expected error getting non-existing user")
+				assert.True(t, trace.IsNotFound(err), "expected trace.NotFoundError")
 			},
 			checker: &fakeChecker{
 				rules: []types.Rule{
@@ -689,8 +744,8 @@ func TestRBAC(t *testing.T) {
 				},
 			},
 			expectChecks: []check{
-				{kind: types.KindUser, verb: types.VerbCreate},
 				{kind: types.KindUser, verb: types.VerbRead},
+				{kind: types.KindUser, verb: types.VerbCreate},
 			},
 		},
 		{
@@ -930,17 +985,22 @@ func TestRBAC(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.desc, func(t *testing.T) {
-			env, err := newTestEnv(withAuthorizer(&fakeAuthorizer{authzContext: &authz.Context{
-				User:    llama,
-				Checker: test.checker,
-				Identity: authz.LocalUser{
-					Username: "alice",
-					Identity: tlsca.Identity{
-						Groups: []string{"dev"},
-					},
+			ident := authz.LocalUser{
+				Username: "llama",
+				Identity: tlsca.Identity{
+					Username: "llama",
+					Groups:   []string{"dev"},
 				},
+			}
+
+			authorizer := fakeAuthorizer{authzContext: &authz.Context{
+				User:                 llama,
+				Checker:              test.checker,
+				Identity:             ident,
+				UnmappedIdentity:     ident,
 				AdminActionAuthState: authz.AdminActionAuthNotRequired,
-			}}))
+			}}
+			env, err := newTestEnv(withAuthorizer(authorizer), withScopedAuthorizer(authorizer))
 			require.NoError(t, err, "creating test service")
 
 			// Create the user directly on the backend to bypass RBAC enforced by the test cases.
@@ -952,4 +1012,64 @@ func TestRBAC(t *testing.T) {
 			require.ElementsMatch(t, test.expectChecks, test.checker.checks)
 		})
 	}
+}
+
+func TestScopePinnedAgentGetUser(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+
+	userChecker := &fakeChecker{
+		rules: []types.Rule{
+			{
+				Resources: []string{types.KindUser},
+				Verbs:     []string{types.VerbRead},
+			},
+		},
+	}
+	// Build a fake authorizer with a scoped checker map allowing node system roles access to users but
+	// denying kube system roles. We need both to test access granted and denied
+	authorizer := fakeAuthorizer{
+		checkerMap: map[string]*services.ScopedAccessChecker{
+			string(types.RoleNode): services.NewScopedAccessCheckerForSystemRole(string(types.RoleNode), userChecker),
+			string(types.RoleKube): services.NewScopedAccessCheckerForSystemRole(string(types.RoleKube), &fakeChecker{}),
+		},
+	}
+
+	// build a scoped agent identity
+	pin := scopesv1.Pin_builder{
+		Kind:  scopesv1.PinKind_PIN_KIND_AGENT,
+		Scope: "/test",
+		SystemRoles: scopesv1.SystemRoles_builder{
+			Primary: types.RoleNode.String(),
+		}.Build(),
+	}.Build()
+	agent := authz.ScopedBuiltinRole{
+		ServerFQDN: "test-server.local",
+		ScopePin:   pin,
+		Identity: tlsca.Identity{
+			ScopePin: pin,
+		},
+	}
+
+	// configure test env with a scoped authorizer
+	env, err := newTestEnv(withScopedAuthorizer(authorizer))
+	require.NoError(t, err, "creating test service")
+
+	// create test user to try and fetch
+	llama, err := types.NewUser("llama")
+	require.NoError(t, err, "creating new user llama")
+	_, err = env.backend.CreateUser(ctx, llama.(*types.UserV2))
+	require.NoError(t, err, "creating test user")
+
+	// verify we can fetch the user with the node system role
+	res, err := env.Service.GetUser(authz.ContextWithUser(ctx, agent), userspb.GetUserRequest_builder{Name: "llama"}.Build())
+	require.NoError(t, err, "expected no error getting user as scoped agent")
+	assert.Empty(t, cmp.Diff(llama, res.GetUser(), cmpopts.IgnoreFields(types.Metadata{}, "Revision")))
+
+	// verify we can't fetch the user with the kube system role
+	pin.GetSystemRoles().SetPrimary(types.RoleKube.String())
+	_, err = env.Service.GetUser(authz.ContextWithUser(ctx, agent), userspb.GetUserRequest_builder{Name: "llama"}.Build())
+	require.Error(t, err, "expected error getting user as scoped agent")
+	require.True(t, trace.IsAccessDenied(err), "expected trace.AccessDeniedError")
 }

--- a/lib/services/scoped_access_checker_context.go
+++ b/lib/services/scoped_access_checker_context.go
@@ -452,6 +452,48 @@ func (c *ScopedAccessCheckerContext) RiskyAuthorizeUnpinnedReadWithScope(
 	return c.RiskyAuthorizeUnpinnedRead(ctx, authz, ruleCtx)
 }
 
+// RiskyAuthorizeUnpinnedEmitEvent authorizes a create-only access check that bypasses
+// enforcement of the identity's pinned scope specifically for emitting audit events.
+// It is special-cased to avoid misuse of unpinned writes.
+func (c *ScopedAccessCheckerContext) RiskyAuthorizeUnpinnedEmitEvent(
+	ctx context.Context,
+	ruleCtx RuleContext,
+) error {
+	if pin, ok := c.ScopePin(); ok {
+		if pin.GetKind() != scopesv1.PinKind_PIN_KIND_AGENT {
+			return trace.AccessDenied("unpinned authorization for audit event emission is only supported for agent pins")
+		}
+	}
+
+	return c.decision(
+		c.riskyUnpinnedCheckersForResourceScope(ctx, scopes.Root),
+		func(checker *ScopedAccessChecker) error {
+			return checker.CheckAccessToRules(ruleCtx, types.KindEvent, types.VerbCreate)
+		},
+	)
+}
+
+// RiskyAuthorizeUnpinnedWriteEvent authorizes a write-only access check that bypasses
+// enforcement of the identity's pinned scope specifically for creating and updating audit events.
+// It is special-cased to avoid misuse of unpinned writes.
+func (c *ScopedAccessCheckerContext) RiskyAuthorizeUnpinnedWriteEvent(
+	ctx context.Context,
+	ruleCtx RuleContext,
+) error {
+	if pin, ok := c.ScopePin(); ok {
+		if pin.GetKind() != scopesv1.PinKind_PIN_KIND_AGENT {
+			return trace.AccessDenied("unpinned authorization for audit event emission is only supported for agent pins")
+		}
+	}
+
+	return c.decision(
+		c.riskyUnpinnedCheckersForResourceScope(ctx, scopes.Root),
+		func(checker *ScopedAccessChecker) error {
+			return checker.CheckAccessToRules(ruleCtx, types.KindEvent, types.VerbCreate, types.VerbUpdate)
+		},
+	)
+}
+
 // UnpinnedReadAuthorization is a special authorization to complete an unscoped
 // read-only access check. This is meant to be used for access checks on
 // typically cluster-wide resources that need to be readable by identities with
@@ -560,12 +602,25 @@ var (
 		kind:          types.KindSessionRecordingConfig,
 		verbs:         []string{types.VerbRead},
 	}
-
 	// UnpinnedReadScopedRole is a special authorization to complete an
 	// unscoped access check to read a scoped role.
 	UnpinnedReadScopedRole = UnpinnedReadAuthorization{
 		resourceScope: scopes.Root,
 		kind:          scopedaccess.KindScopedRole,
+		verbs:         []string{types.VerbRead},
+	}
+	// UnpinnedReadUser is a special authorization to complete a unscoped access check
+	// to read a user.
+	UnpinnedReadUser = UnpinnedReadAuthorization{
+		resourceScope: scopes.Root,
+		kind:          types.KindUser,
+		verbs:         []string{types.VerbRead},
+	}
+	// UnpinnedReadRole is a special authorization to complete an unscoped access check
+	// to read a role.
+	UnpinnedReadRole = UnpinnedReadAuthorization{
+		resourceScope: scopes.Root,
+		kind:          types.KindRole,
 		verbs:         []string{types.VerbRead},
 	}
 )

--- a/lib/services/scoped_access_checker_context_test.go
+++ b/lib/services/scoped_access_checker_context_test.go
@@ -145,21 +145,22 @@ func newAgentPinCheckerContext(t *testing.T, pin *scopesv1.Pin) *ScopedAccessChe
 	return ctx
 }
 
+// newAgentPin is a test helper that builds a [*scopesv1.Pin] for an agent.
+func newAgentPin(scope string, role types.SystemRole) *scopesv1.Pin {
+	return scopesv1.Pin_builder{
+		Kind:  scopesv1.PinKind_PIN_KIND_AGENT,
+		Scope: scope,
+		SystemRoles: scopesv1.SystemRoles_builder{
+			Primary: role.String(),
+		}.Build(),
+	}.Build()
+}
+
 // TestScopedAccessCheckerContextAgentPin covers the agent-pin mode of ScopedAccessCheckerContext.
 func TestScopedAccessCheckerContextAgentPin(t *testing.T) {
 	t.Parallel()
 
 	const pinScope = "/test/scope"
-
-	newAgentPin := func(scope string, role types.SystemRole) *scopesv1.Pin {
-		return scopesv1.Pin_builder{
-			Kind:  scopesv1.PinKind_PIN_KIND_AGENT,
-			Scope: scope,
-			SystemRoles: scopesv1.SystemRoles_builder{
-				Primary: role.String(),
-			}.Build(),
-		}.Build()
-	}
 
 	t.Run("constructor rejects nil pin", func(t *testing.T) {
 		t.Parallel()
@@ -257,6 +258,39 @@ func TestScopedAccessCheckerContextAgentPin(t *testing.T) {
 		require.NoError(t, err, "RiskyAuthorizeUnpinnedRead should bypass pin enforcement and succeed")
 	})
 
+	t.Run("RiskyAuthorizeUnpinnedEmitEvent bypasses pin enforcement", func(t *testing.T) {
+		t.Parallel()
+		pin := newAgentPin(pinScope, types.RoleNode)
+		checkerCtx := newAgentPinCheckerContext(t, pin)
+
+		// A normal decision for a root-scoped resource is denied because the identity
+		// is pinned away from root before any checker, including the default implicit
+		// role checker, is evaluated.
+		err := checkerCtx.Decision(t.Context(), scopes.Root, func(checker *ScopedAccessChecker) error {
+			return checker.CheckAccessToRules(&Context{}, types.KindEvent, types.VerbCreate)
+		})
+		require.ErrorAs(t, err, new(*trace.AccessDeniedError))
+
+		err = checkerCtx.RiskyAuthorizeUnpinnedEmitEvent(t.Context(), &Context{})
+		require.NoError(t, err, "RiskyAuthorizeUnpinnedEmitEvent should bypass pin enforcement and succeed")
+	})
+	t.Run("RiskyAuthorizeUnpinnedWriteEvent bypasses pin enforcement", func(t *testing.T) {
+		t.Parallel()
+		pin := newAgentPin(pinScope, types.RoleNode)
+		checkerCtx := newAgentPinCheckerContext(t, pin)
+
+		// A normal decision for a root-scoped resource is denied because the identity
+		// is pinned away from root before any checker, including the default implicit
+		// role checker, is evaluated.
+		err := checkerCtx.Decision(t.Context(), scopes.Root, func(checker *ScopedAccessChecker) error {
+			return checker.CheckAccessToRules(&Context{}, types.KindEvent, types.VerbCreate, types.VerbUpdate)
+		})
+		require.ErrorAs(t, err, new(*trace.AccessDeniedError))
+
+		err = checkerCtx.RiskyAuthorizeUnpinnedWriteEvent(t.Context(), &Context{})
+		require.NoError(t, err, "RiskyAuthorizeUnpinnedWriteEvent should bypass pin enforcement and succeed")
+	})
+
 	t.Run("riskyEnumerateScopedCheckers panics for agent pin context", func(t *testing.T) {
 		t.Parallel()
 		pin := newAgentPin(pinScope, types.RoleNode)
@@ -268,4 +302,36 @@ func TestScopedAccessCheckerContextAgentPin(t *testing.T) {
 			}
 		}, "riskyEnumerateScopedCheckers should panic for agent pin contexts")
 	})
+}
+
+func TestScopedAccessCheckerContextUnpinnedUserEventWrites(t *testing.T) {
+	ctx := t.Context()
+	userCheckerContext, err := NewScopedAccessCheckerContext(ctx, &AccessInfo{
+		Username: "alice",
+		ScopePin: scopesv1.Pin_builder{
+			Kind:  scopesv1.PinKind_PIN_KIND_USER,
+			Scope: "/test/scope",
+		}.Build(),
+	}, "test-cluster", emptyScopedRoleReader{})
+	require.NoError(t, err)
+
+	ruleCtx := &Context{}
+
+	// A normal decision for a root-scoped resource is denied because the identity
+	// is pinned away from root before any checker, including the default implicit
+	// role checker, is evaluated.
+	err = userCheckerContext.Decision(ctx, scopes.Root, func(checker *ScopedAccessChecker) error {
+		return checker.CheckAccessToRules(ruleCtx, types.KindEvent, types.VerbCreate)
+	})
+	require.ErrorAs(t, err, new(*trace.AccessDeniedError))
+
+	// RiskyAuthorizeUnpinnedEmitEvent bypasses pin enforcement but should explicitly fail for scoped
+	// user pins.
+	err = userCheckerContext.RiskyAuthorizeUnpinnedEmitEvent(ctx, ruleCtx)
+	require.ErrorContains(t, err, "unpinned authorization for audit event emission is only supported for agent pins")
+
+	// RiskyAuthorizeUnpinneWriteEvent bypasses pin enforcement but should explicitly fail for scoped
+	// user pins.
+	err = userCheckerContext.RiskyAuthorizeUnpinnedWriteEvent(ctx, ruleCtx)
+	require.ErrorContains(t, err, "unpinned authorization for audit event emission is only supported for agent pins")
 }


### PR DESCRIPTION
Ports the `GetUser`, `GetRole`, `EmitAuditEvent`, `CreateAuditStream`, and `ResumeAuditStream` RPCs to support scoped authZ. This allows scoped kube agents to foward  requests, restores unencrypted session recordings, and removes a lot of error log spam.

There were a couple of things in the user service tests I changed because they seemed slightly off. I call them out in comments below, so please let me know if my assessment is incorrect so I can revert them.

Related to https://github.com/gravitational/teleport/issues/67205
<!-- Include manual testing efforts to verify the change. -->
<!-- Detail where the tests where run and what configurations were used. -->
<!-- Include all the test cases which were run to validate the change. -->

## Manual Test Plan
### Test Environment
Local teleport cluster with `TELEPORT_UNSTABLE_SCOPES=yes` and `TELEPORT_UNSTABLE_AGENT_SCOPE_PIN=yes`
### Test Cases
- [x] `kubectl` forwarding works with scoped kube agents
- [x] No errors logged for emitting events during scoped SSH sessions or kubectl forwarding.
- [x] Unencrypted session recordings are captured and replayable
- [x] Unscoped SSH and kube still work as expected
- [x] Unscoped and Scoped SSH Access to openssh node still works
