### PR TITLE
Avoid storing SAML connector private keys in Terraform state

### DIFF
--- a/integrations/terraform/gen/main.go
+++ b/integrations/terraform/gen/main.go
@@ -55,6 +55,14 @@ type payload struct {
 	UpsertMethodArity int
 	// WithSecrets value for a withSecrets param of Get method (empty means no param used)
 	WithSecrets string
+	// SchemaFunc optionally overrides the generated schema function.
+	SchemaFunc string
+	// StateUpgradeFunc optionally adds a ResourceWithUpgradeState implementation.
+	StateUpgradeFunc string
+	// PreserveConfiguredStateFunc optionally restores configured values into post-apply state.
+	PreserveConfiguredStateFunc string
+	// PreserveStateFunc optionally restores values from prior state into read state.
+	PreserveStateFunc string
 	// ID id value on create and import
 	ID string
 	// IDPrefix is optional for resources which are stored with an prefix in the backend.
@@ -420,20 +428,24 @@ var (
 	}
 
 	samlConnector = payload{
-		Name:                   "SAMLConnector",
-		TypeName:               "SAMLConnectorV2",
-		VarName:                "samlConnector",
-		GetMethod:              "GetSAMLConnector",
-		CreateMethod:           "CreateSAMLConnector",
-		UpdateMethod:           "UpsertSAMLConnector",
-		UpsertMethodArity:      2,
-		DeleteMethod:           "DeleteSAMLConnector",
-		WithSecrets:            "true",
-		ID:                     "samlConnector.Metadata.Name",
-		Kind:                   "saml",
-		HasStaticID:            true,
-		TerraformResourceType:  "teleport_saml_connector",
-		HasCheckAndSetDefaults: true,
+		Name:                        "SAMLConnector",
+		TypeName:                    "SAMLConnectorV2",
+		VarName:                     "samlConnector",
+		GetMethod:                   "GetSAMLConnector",
+		CreateMethod:                "CreateSAMLConnector",
+		UpdateMethod:                "UpsertSAMLConnector",
+		UpsertMethodArity:           2,
+		DeleteMethod:                "DeleteSAMLConnector",
+		WithSecrets:                 "false",
+		SchemaFunc:                  "samlConnectorSchema",
+		StateUpgradeFunc:            "upgradeSAMLConnectorState",
+		PreserveConfiguredStateFunc: "preserveSAMLConnectorConfiguredSecrets",
+		PreserveStateFunc:           "preserveSAMLConnectorStateSecrets",
+		ID:                          "samlConnector.Metadata.Name",
+		Kind:                        "saml",
+		HasStaticID:                 true,
+		TerraformResourceType:       "teleport_saml_connector",
+		HasCheckAndSetDefaults:      true,
 	}
 
 	samlIdPServiceProvider = payload{

--- a/integrations/terraform/gen/plural_resource.go.tpl
+++ b/integrations/terraform/gen/plural_resource.go.tpl
@@ -66,7 +66,11 @@ type resourceTeleport{{.Name}} struct {
 
 // GetSchema returns the resource schema
 func (r resourceTeleport{{.Name}}Type) GetSchema(ctx context.Context) (tfsdk.Schema, diag.Diagnostics) {
+{{- if .SchemaFunc }}
+	return {{.SchemaFunc}}(ctx)
+{{- else }}
 	return {{.SchemaPackage}}.GenSchema{{.TypeName}}(ctx)
+{{- end }}
 }
 
 // NewResource creates the empty resource
@@ -75,6 +79,12 @@ func (r resourceTeleport{{.Name}}Type) NewResource(_ context.Context, p tfsdk.Pr
 		p: *(p.(*Provider)),
 	}, nil
 }
+
+{{ if .StateUpgradeFunc }}
+func (r resourceTeleport{{.Name}}) UpgradeState(ctx context.Context) map[int64]tfsdk.ResourceStateUpgrader {
+	return {{.StateUpgradeFunc}}(ctx)
+}
+{{- end }}
 
 // Create creates the {{.Name}}
 func (r resourceTeleport{{.Name}}) Create(ctx context.Context, req tfsdk.CreateResourceRequest, resp *tfsdk.CreateResourceResponse) {
@@ -89,6 +99,14 @@ func (r resourceTeleport{{.Name}}) Create(ctx context.Context, req tfsdk.CreateR
 	if resp.Diagnostics.HasError() {
 		return
 	}
+	{{- if .PreserveConfiguredStateFunc}}
+	var config types.Object
+	diags = req.Config.Get(ctx, &config)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	{{- end}}
 
 	{{- if .SaveSpecStateFromPlan}}
 	specFromPlan, ok := plan.Attrs["spec"]
@@ -275,6 +293,9 @@ func (r resourceTeleport{{.Name}}) Create(ctx context.Context, req tfsdk.CreateR
 		return
 	}
 	{{- end}}
+	{{- if .PreserveConfiguredStateFunc }}
+	{{.PreserveConfiguredStateFunc}}(config, plan, {{.VarName}}Resource)
+	{{- end}}
 
 	{{- if .ConvertPackagePath}}
 	{{.VarName}} = convert.{{ if .ConvertToProtoFunc }}{{.ConvertToProtoFunc}}{{ else }}ToProto{{ end }}({{.VarName}}Resource)
@@ -453,6 +474,9 @@ func (r resourceTeleport{{.Name}}) Read(ctx context.Context, req tfsdk.ReadResou
 	{{ else }}
 	{{.VarName}} := {{.VarName}}I.(*{{.ProtoPackage}}.{{.TypeName}})
 	{{end -}}
+{{ if .PreserveStateFunc -}}
+	{{.PreserveStateFunc}}(state, {{.VarName}})
+{{ end -}}
 	diags = {{.SchemaPackage}}.Copy{{.TypeName}}ToTerraform(ctx, {{.VarName}}, &state)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
@@ -479,6 +503,14 @@ func (r resourceTeleport{{.Name}}) Update(ctx context.Context, req tfsdk.UpdateR
 	if resp.Diagnostics.HasError() {
 		return
 	}
+	{{- if .PreserveConfiguredStateFunc}}
+	var config types.Object
+	diags = req.Config.Get(ctx, &config)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	{{- end}}
 
 	{{.VarName}} := &{{.ProtoPackage}}.{{.TypeName}}{}
 	diags = {{.SchemaPackage}}.Copy{{.TypeName}}FromTerraform(ctx, plan, {{.VarName}})
@@ -637,7 +669,10 @@ func (r resourceTeleport{{.Name}}) Update(ctx context.Context, req tfsdk.UpdateR
 		return
 	}
 	{{- end}}
-	diags = {{.SchemaPackage}}.Copy{{.TypeName}}ToTerraform(ctx, {{.VarName}}, &plan)
+	{{- if .PreserveConfiguredStateFunc }}
+	{{.PreserveConfiguredStateFunc}}(config, plan, {{.VarName}}Resource)
+	{{- end}}
+	diags = {{.SchemaPackage}}.Copy{{.TypeName}}ToTerraform(ctx, {{.VarName}}Resource, &plan)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/integrations/terraform/provider/data_source_teleport_saml_connector.go
+++ b/integrations/terraform/provider/data_source_teleport_saml_connector.go
@@ -59,7 +59,7 @@ func (r dataSourceTeleportSAMLConnector) Read(ctx context.Context, req tfsdk.Rea
 		return
 	}
 
-	samlConnectorI, err := r.p.Client.GetSAMLConnector(ctx, id.Value, true)
+	samlConnectorI, err := r.p.Client.GetSAMLConnector(ctx, id.Value, false)
 	if err != nil {
 		resp.Diagnostics.Append(diagFromWrappedErr("Error reading SAMLConnector", trace.Wrap(err), "saml"))
 		return

--- a/integrations/terraform/provider/resource_teleport_saml_connector.go
+++ b/integrations/terraform/provider/resource_teleport_saml_connector.go
@@ -43,7 +43,7 @@ type resourceTeleportSAMLConnector struct {
 
 // GetSchema returns the resource schema
 func (r resourceTeleportSAMLConnectorType) GetSchema(ctx context.Context) (tfsdk.Schema, diag.Diagnostics) {
-	return tfschema.GenSchemaSAMLConnectorV2(ctx)
+	return samlConnectorSchema(ctx)
 }
 
 // NewResource creates the empty resource
@@ -51,6 +51,10 @@ func (r resourceTeleportSAMLConnectorType) NewResource(_ context.Context, p tfsd
 	return resourceTeleportSAMLConnector{
 		p: *(p.(*Provider)),
 	}, nil
+}
+
+func (r resourceTeleportSAMLConnector) UpgradeState(ctx context.Context) map[int64]tfsdk.ResourceStateUpgrader {
+	return upgradeSAMLConnectorState(ctx)
 }
 
 // Create creates the SAMLConnector
@@ -62,6 +66,12 @@ func (r resourceTeleportSAMLConnector) Create(ctx context.Context, req tfsdk.Cre
 
 	var plan types.Object
 	diags := req.Plan.Get(ctx, &plan)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	var config types.Object
+	diags = req.Config.Get(ctx, &config)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -85,7 +95,7 @@ func (r resourceTeleportSAMLConnector) Create(ctx context.Context, req tfsdk.Cre
 
 	id := samlConnectorResource.Metadata.Name
 
-	_, err = r.p.Client.GetSAMLConnector(ctx, id, true)
+	_, err = r.p.Client.GetSAMLConnector(ctx, id, false)
 	if !trace.IsNotFound(err) {
 		if err == nil {
 			existErr := fmt.Sprintf("SAMLConnector exists in Teleport. Either remove it (tctl rm saml/%v)"+
@@ -120,7 +130,7 @@ func (r resourceTeleportSAMLConnector) Create(ctx context.Context, req tfsdk.Cre
 	}
 	for {
 		tries = tries + 1
-		samlConnectorI, err = r.p.Client.GetSAMLConnector(ctx, id, true)
+		samlConnectorI, err = r.p.Client.GetSAMLConnector(ctx, id, false)
 		if trace.IsNotFound(err) {
 		    select {
 			case <-ctx.Done():
@@ -148,6 +158,7 @@ func (r resourceTeleportSAMLConnector) Create(ctx context.Context, req tfsdk.Cre
 		resp.Diagnostics.Append(diagFromWrappedErr("Error reading SAMLConnector", trace.Errorf("Can not convert %T to SAMLConnectorV2", samlConnectorI), "saml"))
 		return
 	}
+	preserveSAMLConnectorConfiguredSecrets(config, plan, samlConnectorResource)
 	samlConnector = samlConnectorResource
 
 	diags = tfschema.CopySAMLConnectorV2ToTerraform(ctx, samlConnector, &plan)
@@ -181,7 +192,7 @@ func (r resourceTeleportSAMLConnector) Read(ctx context.Context, req tfsdk.ReadR
 		return
 	}
 
-	samlConnectorI, err := r.p.Client.GetSAMLConnector(ctx, id.Value, true)
+	samlConnectorI, err := r.p.Client.GetSAMLConnector(ctx, id.Value, false)
 	if trace.IsNotFound(err) {
 		resp.State.RemoveResource(ctx)
 		return
@@ -193,6 +204,7 @@ func (r resourceTeleportSAMLConnector) Read(ctx context.Context, req tfsdk.ReadR
 	}
 	
 	samlConnector := samlConnectorI.(*apitypes.SAMLConnectorV2)
+	preserveSAMLConnectorStateSecrets(state, samlConnector)
 	diags = tfschema.CopySAMLConnectorV2ToTerraform(ctx, samlConnector, &state)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
@@ -219,6 +231,12 @@ func (r resourceTeleportSAMLConnector) Update(ctx context.Context, req tfsdk.Upd
 	if resp.Diagnostics.HasError() {
 		return
 	}
+	var config types.Object
+	diags = req.Config.Get(ctx, &config)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
 
 	samlConnector := &apitypes.SAMLConnectorV2{}
 	diags = tfschema.CopySAMLConnectorV2FromTerraform(ctx, plan, samlConnector)
@@ -235,7 +253,7 @@ func (r resourceTeleportSAMLConnector) Update(ctx context.Context, req tfsdk.Upd
 	}
 	name := samlConnectorResource.Metadata.Name
 
-	samlConnectorBefore, err := r.p.Client.GetSAMLConnector(ctx, name, true)
+	samlConnectorBefore, err := r.p.Client.GetSAMLConnector(ctx, name, false)
 	if err != nil {
 		resp.Diagnostics.Append(diagFromWrappedErr("Error reading SAMLConnector", err, "saml"))
 		return
@@ -262,7 +280,7 @@ func (r resourceTeleportSAMLConnector) Update(ctx context.Context, req tfsdk.Upd
 	}
 	for {
 		tries = tries + 1
-		samlConnectorI, err = r.p.Client.GetSAMLConnector(ctx, name, true)
+		samlConnectorI, err = r.p.Client.GetSAMLConnector(ctx, name, false)
 		if err != nil {
 			resp.Diagnostics.Append(diagFromWrappedErr("Error reading SAMLConnector", err, "saml"))
 			return
@@ -289,7 +307,8 @@ func (r resourceTeleportSAMLConnector) Update(ctx context.Context, req tfsdk.Upd
 		resp.Diagnostics.Append(diagFromWrappedErr("Error reading SAMLConnector", trace.Errorf("Can not convert %T to SAMLConnectorV2", samlConnectorI), "saml"))
 		return
 	}
-	diags = tfschema.CopySAMLConnectorV2ToTerraform(ctx, samlConnector, &plan)
+	preserveSAMLConnectorConfiguredSecrets(config, plan, samlConnectorResource)
+	diags = tfschema.CopySAMLConnectorV2ToTerraform(ctx, samlConnectorResource, &plan)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -322,7 +341,7 @@ func (r resourceTeleportSAMLConnector) Delete(ctx context.Context, req tfsdk.Del
 
 // ImportState imports SAMLConnector state
 func (r resourceTeleportSAMLConnector) ImportState(ctx context.Context, req tfsdk.ImportResourceStateRequest, resp *tfsdk.ImportResourceStateResponse) {
-	samlConnector, err := r.p.Client.GetSAMLConnector(ctx, req.ID, true)
+	samlConnector, err := r.p.Client.GetSAMLConnector(ctx, req.ID, false)
 	if err != nil {
 		resp.Diagnostics.Append(diagFromWrappedErr("Error reading SAMLConnector", trace.Wrap(err), "saml"))
 		return

--- a/integrations/terraform/provider/resource_teleport_saml_connector_helpers.go
+++ b/integrations/terraform/provider/resource_teleport_saml_connector_helpers.go
@@ -1,0 +1,171 @@
+/*
+Copyright 2026 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package provider
+
+import (
+	"context"
+
+	apitypes "github.com/gravitational/teleport/api/types"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+
+	"github.com/gravitational/teleport/integrations/terraform/tfschema"
+)
+
+const samlConnectorSchemaVersion int64 = 1
+
+func samlConnectorSchema(ctx context.Context) (tfsdk.Schema, diag.Diagnostics) {
+	schema, diags := tfschema.GenSchemaSAMLConnectorV2(ctx)
+	schema.Version = samlConnectorSchemaVersion
+	return schema, diags
+}
+
+func upgradeSAMLConnectorState(ctx context.Context) map[int64]tfsdk.ResourceStateUpgrader {
+	schema, _ := tfschema.GenSchemaSAMLConnectorV2(ctx)
+	return map[int64]tfsdk.ResourceStateUpgrader{
+		0: {
+			PriorSchema:   &schema,
+			StateUpgrader: upgradeSAMLConnectorStateV0,
+		},
+	}
+}
+
+func upgradeSAMLConnectorStateV0(ctx context.Context, req tfsdk.UpgradeResourceStateRequest, resp *tfsdk.UpgradeResourceStateResponse) {
+	if req.State == nil {
+		resp.Diagnostics.AddError("Unable to Upgrade SAMLConnector State", "Prior SAMLConnector state is unavailable.")
+		return
+	}
+
+	var state types.Object
+	diags := req.State.Get(ctx, &state)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	clearSAMLConnectorStatePrivateKeys(&state)
+	diags = resp.State.Set(ctx, &state)
+	resp.Diagnostics.Append(diags...)
+}
+
+func clearSAMLConnectorStatePrivateKeys(state *types.Object) {
+	clearSAMLConnectorStateString(state, "spec", "signing_key_pair", "private_key")
+	clearSAMLConnectorStateString(state, "spec", "assertion_key_pair", "private_key")
+}
+
+func clearSAMLConnectorStateString(root *types.Object, path ...string) {
+	if len(path) == 0 || root.Attrs == nil {
+		return
+	}
+	if len(path) == 1 {
+		if _, ok := root.Attrs[path[0]].(types.String); ok {
+			root.Attrs[path[0]] = types.String{Null: true}
+		}
+		return
+	}
+
+	current, ok := root.Attrs[path[0]].(types.Object)
+	if !ok || current.Null {
+		return
+	}
+
+	clearSAMLConnectorStateString(&current, path[1:]...)
+	root.Attrs[path[0]] = current
+}
+
+func preserveSAMLConnectorConfiguredSecrets(config, plan types.Object, target *apitypes.SAMLConnectorV2) {
+	preserveSAMLConnectorConfiguredString(config, plan, target, setSAMLSigningPrivateKey, "spec", "signing_key_pair", "private_key")
+	preserveSAMLConnectorConfiguredString(config, plan, target, setSAMLEncryptionPrivateKey, "spec", "assertion_key_pair", "private_key")
+	preserveSAMLConnectorConfiguredString(config, plan, target, setSAMLOAuthClientSecret, "spec", "credentials", "oauth", "client_secret")
+}
+
+func preserveSAMLConnectorStateSecrets(state types.Object, target *apitypes.SAMLConnectorV2) {
+	if value, ok := samlConnectorTerraformStringValue(state, "spec", "signing_key_pair", "private_key"); ok {
+		setSAMLSigningPrivateKey(target, value)
+	}
+	if value, ok := samlConnectorTerraformStringValue(state, "spec", "assertion_key_pair", "private_key"); ok {
+		setSAMLEncryptionPrivateKey(target, value)
+	}
+	if value, ok := samlConnectorTerraformStringValue(state, "spec", "credentials", "oauth", "client_secret"); ok {
+		setSAMLOAuthClientSecret(target, value)
+	}
+}
+
+func preserveSAMLConnectorConfiguredString(config, plan types.Object, target *apitypes.SAMLConnectorV2, set func(*apitypes.SAMLConnectorV2, string), path ...string) {
+	value, configured := samlConnectorTerraformStringValue(config, path...)
+	if !configured {
+		return
+	}
+	// Unknown config values are still configured; use the resolved planned
+	// value before writing post-apply state.
+	if value == "" {
+		var ok bool
+		value, ok = samlConnectorTerraformStringValue(plan, path...)
+		if !ok {
+			return
+		}
+	}
+	set(target, value)
+}
+
+func samlConnectorTerraformStringValue(root types.Object, path ...string) (string, bool) {
+	if len(path) == 0 {
+		return "", false
+	}
+
+	current := root
+	for _, name := range path[:len(path)-1] {
+		value, ok := current.Attrs[name].(types.Object)
+		if !ok || value.Null {
+			return "", false
+		}
+		current = value
+	}
+
+	value, ok := current.Attrs[path[len(path)-1]].(types.String)
+	if !ok || value.Null {
+		return "", false
+	}
+	if value.Unknown {
+		return "", true
+	}
+	return value.Value, value.Value != ""
+}
+
+func setSAMLSigningPrivateKey(connector *apitypes.SAMLConnectorV2, privateKey string) {
+	if connector.Spec.SigningKeyPair == nil {
+		connector.Spec.SigningKeyPair = &apitypes.AsymmetricKeyPair{}
+	}
+	connector.Spec.SigningKeyPair.PrivateKey = privateKey
+}
+
+func setSAMLEncryptionPrivateKey(connector *apitypes.SAMLConnectorV2, privateKey string) {
+	if connector.Spec.EncryptionKeyPair == nil {
+		connector.Spec.EncryptionKeyPair = &apitypes.AsymmetricKeyPair{}
+	}
+	connector.Spec.EncryptionKeyPair.PrivateKey = privateKey
+}
+
+func setSAMLOAuthClientSecret(connector *apitypes.SAMLConnectorV2, clientSecret string) {
+	credentials := connector.GetOAuthClientCredentials()
+	if credentials == nil {
+		credentials = &apitypes.OAuthClientCredentials{}
+	}
+	credentials.ClientSecret = clientSecret
+	connector.SetOAuthClientCredentials(credentials)
+}

--- a/integrations/terraform/provider/resource_teleport_saml_connector_test.go
+++ b/integrations/terraform/provider/resource_teleport_saml_connector_test.go
@@ -1,0 +1,215 @@
+/*
+Copyright 2026 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package provider
+
+import (
+	"context"
+	"testing"
+
+	apitypes "github.com/gravitational/teleport/api/types"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport/integrations/terraform/tfschema"
+)
+
+func TestPreserveSAMLConnectorConfiguredSecrets(t *testing.T) {
+	target := &apitypes.SAMLConnectorV2{
+		Spec: apitypes.SAMLConnectorSpecV2{
+			SigningKeyPair:    &apitypes.AsymmetricKeyPair{Cert: "signing-cert"},
+			EncryptionKeyPair: &apitypes.AsymmetricKeyPair{Cert: "assertion-cert"},
+			Credentials: &apitypes.SAMLConnectorCredentials{
+				Oauth: &apitypes.OAuthClientCredentials{ClientId: "client-id"},
+			},
+		},
+	}
+
+	config := samlConnectorSecretsObject("signing-key", "assertion-key", "client-secret")
+	preserveSAMLConnectorConfiguredSecrets(config, types.Object{}, target)
+
+	require.Equal(t, "signing-key", target.Spec.SigningKeyPair.PrivateKey)
+	require.Equal(t, "assertion-key", target.Spec.EncryptionKeyPair.PrivateKey)
+	require.Equal(t, "client-secret", target.Spec.Credentials.Oauth.ClientSecret)
+}
+
+func TestPreserveSAMLConnectorConfiguredSecretsIgnoresUnconfiguredPlanSecrets(t *testing.T) {
+	target := &apitypes.SAMLConnectorV2{
+		Spec: apitypes.SAMLConnectorSpecV2{
+			SigningKeyPair:    &apitypes.AsymmetricKeyPair{Cert: "signing-cert"},
+			EncryptionKeyPair: &apitypes.AsymmetricKeyPair{Cert: "assertion-cert"},
+			Credentials: &apitypes.SAMLConnectorCredentials{
+				Oauth: &apitypes.OAuthClientCredentials{ClientId: "client-id"},
+			},
+		},
+	}
+
+	preserveSAMLConnectorConfiguredSecrets(types.Object{}, samlConnectorSecretsObject("signing-key", "assertion-key", "client-secret"), target)
+
+	require.Empty(t, target.Spec.SigningKeyPair.PrivateKey)
+	require.Empty(t, target.Spec.EncryptionKeyPair.PrivateKey)
+	require.Empty(t, target.Spec.Credentials.Oauth.ClientSecret)
+}
+
+func TestPreserveSAMLConnectorConfiguredSecretsFallsBackToResolvedPlan(t *testing.T) {
+	target := &apitypes.SAMLConnectorV2{
+		Spec: apitypes.SAMLConnectorSpecV2{
+			SigningKeyPair: &apitypes.AsymmetricKeyPair{Cert: "signing-cert"},
+		},
+	}
+
+	config := samlConnectorSecretsObject("", "", "")
+	configSpec := config.Attrs["spec"].(types.Object)
+	signingKeyPair := configSpec.Attrs["signing_key_pair"].(types.Object)
+	signingKeyPair.Attrs["private_key"] = types.String{Unknown: true}
+	configSpec.Attrs["signing_key_pair"] = signingKeyPair
+	config.Attrs["spec"] = configSpec
+
+	preserveSAMLConnectorConfiguredSecrets(config, samlConnectorSecretsObject("resolved-signing-key", "", ""), target)
+
+	require.Equal(t, "resolved-signing-key", target.Spec.SigningKeyPair.PrivateKey)
+}
+
+func TestSAMLConnectorSchemaUpgradeState(t *testing.T) {
+	ctx := context.Background()
+	schema, diags := samlConnectorSchema(ctx)
+	require.False(t, diags.HasError(), diags)
+	require.Equal(t, samlConnectorSchemaVersion, schema.Version)
+
+	upgraders := upgradeSAMLConnectorState(ctx)
+	require.Contains(t, upgraders, int64(0))
+	require.NotNil(t, upgraders[0].PriorSchema)
+	require.NotNil(t, upgraders[0].StateUpgrader)
+}
+
+func TestUpgradeSAMLConnectorStateV0ClearsPriorPrivateKeys(t *testing.T) {
+	state := samlConnectorSecretsObject("old-signing-key", "old-assertion-key", "old-client-secret")
+
+	clearSAMLConnectorStatePrivateKeys(&state)
+
+	requireSAMLConnectorSecretValue(t, state, "", "spec", "signing_key_pair", "private_key")
+	requireSAMLConnectorSecretValue(t, state, "", "spec", "assertion_key_pair", "private_key")
+	requireSAMLConnectorSecretValue(t, state, "old-client-secret", "spec", "credentials", "oauth", "client_secret")
+}
+
+func TestSAMLConnectorReadbackPreservesPriorStateSecrets(t *testing.T) {
+	ctx := context.Background()
+	state := samlConnectorSecretsObject("old-signing-key", "old-assertion-key", "old-client-secret")
+	setSAMLConnectorStateTypes(t, ctx, &state)
+
+	samlConnector := &apitypes.SAMLConnectorV2{
+		Spec: apitypes.SAMLConnectorSpecV2{
+			SigningKeyPair:    &apitypes.AsymmetricKeyPair{Cert: "signing-cert"},
+			EncryptionKeyPair: &apitypes.AsymmetricKeyPair{Cert: "assertion-cert"},
+			Credentials: &apitypes.SAMLConnectorCredentials{
+				Oauth: &apitypes.OAuthClientCredentials{ClientId: "client-id"},
+			},
+		},
+	}
+
+	preserveSAMLConnectorStateSecrets(state, samlConnector)
+	diags := tfschema.CopySAMLConnectorV2ToTerraform(ctx, samlConnector, &state)
+	require.False(t, diags.HasError(), diags)
+	requireSAMLConnectorSecretValue(t, state, "old-signing-key", "spec", "signing_key_pair", "private_key")
+	requireSAMLConnectorSecretValue(t, state, "old-assertion-key", "spec", "assertion_key_pair", "private_key")
+	requireSAMLConnectorSecretValue(t, state, "old-client-secret", "spec", "credentials", "oauth", "client_secret")
+}
+
+func samlConnectorSecretsObject(signingPrivateKey, assertionPrivateKey, clientSecret string) types.Object {
+	return types.Object{
+		Attrs: map[string]attr.Value{
+			"spec": types.Object{
+				Attrs: map[string]attr.Value{
+					"signing_key_pair": types.Object{
+						Attrs: map[string]attr.Value{
+							"private_key": types.String{Value: signingPrivateKey},
+						},
+					},
+					"assertion_key_pair": types.Object{
+						Attrs: map[string]attr.Value{
+							"private_key": types.String{Value: assertionPrivateKey},
+						},
+					},
+					"credentials": types.Object{
+						Attrs: map[string]attr.Value{
+							"oauth": types.Object{
+								Attrs: map[string]attr.Value{
+									"client_secret": types.String{Value: clientSecret},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func setSAMLConnectorStateTypes(t *testing.T, ctx context.Context, state *types.Object) {
+	schema, diags := tfschema.GenSchemaSAMLConnectorV2(ctx)
+	require.False(t, diags.HasError(), diags)
+
+	rootType, ok := schema.AttributeType().(types.ObjectType)
+	require.True(t, ok)
+	state.AttrTypes = rootType.AttrTypes
+
+	specType := requireObjectType(t, rootType.AttrTypes["spec"])
+	spec := state.Attrs["spec"].(types.Object)
+	spec.AttrTypes = specType.AttrTypes
+
+	signingKeyPair := spec.Attrs["signing_key_pair"].(types.Object)
+	signingKeyPair.AttrTypes = requireObjectType(t, specType.AttrTypes["signing_key_pair"]).AttrTypes
+	spec.Attrs["signing_key_pair"] = signingKeyPair
+
+	assertionKeyPair := spec.Attrs["assertion_key_pair"].(types.Object)
+	assertionKeyPair.AttrTypes = requireObjectType(t, specType.AttrTypes["assertion_key_pair"]).AttrTypes
+	spec.Attrs["assertion_key_pair"] = assertionKeyPair
+
+	credentials := spec.Attrs["credentials"].(types.Object)
+	credentials.AttrTypes = requireObjectType(t, specType.AttrTypes["credentials"]).AttrTypes
+
+	oauth := credentials.Attrs["oauth"].(types.Object)
+	oauth.AttrTypes = requireObjectType(t, credentials.AttrTypes["oauth"]).AttrTypes
+	credentials.Attrs["oauth"] = oauth
+
+	spec.Attrs["credentials"] = credentials
+	state.Attrs["spec"] = spec
+}
+
+func requireObjectType(t *testing.T, value attr.Type) types.ObjectType {
+	t.Helper()
+	objectType, ok := value.(types.ObjectType)
+	require.True(t, ok)
+	return objectType
+}
+
+func requireSAMLConnectorSecretValue(t *testing.T, root types.Object, expected string, path ...string) {
+	t.Helper()
+	require.NotEmpty(t, path)
+
+	current := root
+	for _, name := range path[:len(path)-1] {
+		value, ok := current.Attrs[name].(types.Object)
+		require.True(t, ok)
+		current = value
+	}
+
+	value, ok := current.Attrs[path[len(path)-1]].(types.String)
+	require.True(t, ok)
+	require.Equal(t, expected, value.Value)
+	require.False(t, value.Unknown)
+}

--- a/lib/services/local/suite_test.go
+++ b/lib/services/local/suite_test.go
@@ -719,6 +719,10 @@ func (s *ServicesTestSuite) SAMLCRUD(t *testing.T) {
 				PrivateKey: fixtures.TLSCAKeyPEM,
 				Cert:       fixtures.TLSCACertPEM,
 			},
+			EncryptionKeyPair: &types.AsymmetricKeyPair{
+				PrivateKey: fixtures.TLSCAKeyPEM,
+				Cert:       fixtures.TLSCACertPEM,
+			},
 			Credentials: &types.SAMLConnectorCredentials{
 				Oauth: &types.OAuthClientCredentials{
 					ClientId:     "test-id",
@@ -743,16 +747,17 @@ func (s *ServicesTestSuite) SAMLCRUD(t *testing.T) {
 
 	out2, err := s.WebS.GetSAMLConnector(ctx, connector.GetName(), false)
 	require.NoError(t, err)
-	connectorNoSecrets := *connector
+	connectorNoSecrets := utils.CloneProtoMsg(connector)
 	connectorNoSecrets.Spec.SigningKeyPair.PrivateKey = ""
+	connectorNoSecrets.Spec.EncryptionKeyPair.PrivateKey = ""
 	oauthNoSecrets := *connectorNoSecrets.GetOAuthClientCredentials()
 	oauthNoSecrets.ClientSecret = ""
 	connectorNoSecrets.SetOAuthClientCredentials(&oauthNoSecrets)
-	require.Empty(t, cmp.Diff(out2, &connectorNoSecrets, cmpopts.IgnoreFields(types.Metadata{}, "Revision")))
+	require.Empty(t, cmp.Diff(out2, connectorNoSecrets, cmpopts.IgnoreFields(types.Metadata{}, "Revision")))
 
 	connectorsNoSecrets, err := s.WebS.GetSAMLConnectors(ctx, false)
 	require.NoError(t, err)
-	require.Empty(t, cmp.Diff([]types.SAMLConnector{&connectorNoSecrets}, connectorsNoSecrets, cmpopts.IgnoreFields(types.Metadata{}, "Revision")))
+	require.Empty(t, cmp.Diff([]types.SAMLConnector{connectorNoSecrets}, connectorsNoSecrets, cmpopts.IgnoreFields(types.Metadata{}, "Revision")))
 
 	err = s.WebS.DeleteSAMLConnector(ctx, connector.GetName())
 	require.NoError(t, err)

--- a/lib/services/local/users.go
+++ b/lib/services/local/users.go
@@ -25,6 +25,7 @@ import (
 	"crypto/x509"
 	"encoding/base64"
 	"encoding/json"
+	"fmt"
 	"io"
 	"iter"
 	"log/slog"
@@ -1816,16 +1817,11 @@ func (s *IdentityService) GetSAMLConnectorWithValidationOptions(ctx context.Cont
 		return nil, trace.Wrap(err)
 	}
 	if !withSecrets {
-		keyPair := conn.GetSigningKeyPair()
-		if keyPair != nil {
-			keyPair.PrivateKey = ""
-			conn.SetSigningKeyPair(keyPair)
+		connWithoutSecrets, ok := conn.WithoutSecrets().(types.SAMLConnector)
+		if !ok {
+			return nil, trace.BadParameter("unknown SAMLConnector type, expected types.SAMLConnector got %T", conn)
 		}
-		oauthCreds := conn.GetOAuthClientCredentials()
-		if oauthCreds != nil {
-			oauthCreds.ClientSecret = ""
-			conn.SetOAuthClientCredentials(oauthCreds)
-		}
+		conn = connWithoutSecrets
 	}
 	return conn, nil
 }
@@ -1867,16 +1863,15 @@ func (s *IdentityService) RangeSAMLConnectorsWithOptions(ctx context.Context, st
 		}
 
 		if !withSecrets {
-			keyPair := conn.GetSigningKeyPair()
-			if keyPair != nil {
-				keyPair.PrivateKey = ""
-				conn.SetSigningKeyPair(keyPair)
+			connWithoutSecrets, ok := conn.WithoutSecrets().(types.SAMLConnector)
+			if !ok {
+				s.logger.ErrorContext(ctx, "Failed to strip secrets from SAML Connector",
+					"key", item.Key,
+					"connector_type", fmt.Sprintf("%T", conn),
+				)
+				return nil, false
 			}
-			oauthCreds := conn.GetOAuthClientCredentials()
-			if oauthCreds != nil {
-				oauthCreds.ClientSecret = ""
-				conn.SetOAuthClientCredentials(oauthCreds)
-			}
+			conn = connWithoutSecrets
 		}
 
 		return conn, true

--- a/lib/services/saml.go
+++ b/lib/services/saml.go
@@ -478,6 +478,10 @@ func FillSAMLSecretFieldsFromExistingConnector(ctx context.Context, connector ty
 		return trace.Wrap(err)
 	}
 
+	if err := fillSAMLEncryptionKeyFromExisting(connector, getExisting); err != nil {
+		return trace.Wrap(err)
+	}
+
 	if err := fillSAMLOAuthClientSecretFromExisting(connector, getExisting); err != nil {
 		return trace.Wrap(err)
 	}
@@ -512,6 +516,37 @@ func fillSAMLSigningKeyFromExisting(connector types.SAMLConnector, getExisting s
 	}
 
 	connector.SetSigningKeyPair(keyPair)
+
+	return nil
+}
+
+// fillSAMLEncryptionKeyFromExisting populates the assertion encryption key on the given connector
+// if it's missing with the assertion encryption key from the connector returned by getExisting.
+func fillSAMLEncryptionKeyFromExisting(connector types.SAMLConnector, getExisting samlConnectorGetter) error {
+	connectorEKP := connector.GetEncryptionKeyPair()
+	if connectorEKP == nil {
+		return nil
+	}
+
+	if connectorEKP.PrivateKey != "" {
+		return nil
+	}
+
+	existing, err := getExisting()
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	keyPair := existing.GetEncryptionKeyPair()
+	if keyPair == nil {
+		return trace.BadParameter("the SAML connector has no assertion key pair and none was provided. " + ErrMsgHowToFixMissingPrivateKey)
+	}
+
+	if keyPair.Cert != connectorEKP.Cert {
+		return trace.BadParameter("the SAML connector assertion key cert does not match the existing one. " + ErrMsgHowToFixMissingPrivateKey)
+	}
+
+	connector.SetEncryptionKeyPair(keyPair)
 
 	return nil
 }

--- a/lib/services/saml_test.go
+++ b/lib/services/saml_test.go
@@ -250,6 +250,102 @@ func TestFillSAMLSigningKeyFromExisting(t *testing.T) {
 	}
 }
 
+func TestFillSAMLEncryptionKeyFromExisting(t *testing.T) {
+	t.Parallel()
+
+	existingKeyPEM, existingCertPEM, err := utils.GenerateSelfSignedSigningCert(pkix.Name{
+		Organization: []string{"Teleport OSS"},
+		CommonName:   "teleport.localhost.localdomain",
+	}, nil, 10*365*24*time.Hour)
+	require.NoError(t, err)
+
+	existingEKP := &types.AsymmetricKeyPair{
+		PrivateKey: string(existingKeyPEM),
+		Cert:       string(existingCertPEM),
+	}
+
+	existingConnectorName := "existing"
+	existingConnectors := mockSAMLGetter{
+		existingConnectorName: &types.SAMLConnectorV2{
+			Spec: types.SAMLConnectorSpecV2{
+				EncryptionKeyPair: existingEKP,
+			},
+		},
+	}
+
+	_, unrelatedCertPEM, err := utils.GenerateSelfSignedSigningCert(pkix.Name{
+		Organization: []string{"Teleport OSS"},
+		CommonName:   "teleport.localhost.localdomain",
+	}, nil, 10*365*24*time.Hour)
+	require.NoError(t, err)
+
+	testCases := []struct {
+		name          string
+		connectorName string
+		connectorSpec types.SAMLConnectorSpecV2
+		assertErr     require.ErrorAssertionFunc
+		assertResult  require.ValueAssertionFunc
+	}{
+		{
+			name:          "should read assertion key from existing connector with matching cert",
+			connectorName: existingConnectorName,
+			connectorSpec: types.SAMLConnectorSpecV2{
+				EncryptionKeyPair: &types.AsymmetricKeyPair{
+					PrivateKey: "",
+					Cert:       string(existingCertPEM),
+				},
+			},
+			assertErr: require.NoError,
+			assertResult: func(t require.TestingT, value any, args ...any) {
+				require.Implements(t, (*types.SAMLConnector)(nil), value)
+				connector := value.(types.SAMLConnector)
+				ekp := connector.GetEncryptionKeyPair()
+				require.Equal(t, existingEKP, ekp)
+			},
+		},
+		{
+			name:          "should error when there's no existing connector",
+			connectorName: "non-existing",
+			connectorSpec: types.SAMLConnectorSpecV2{
+				EncryptionKeyPair: &types.AsymmetricKeyPair{
+					PrivateKey: "",
+					Cert:       string(unrelatedCertPEM),
+				},
+			},
+			assertErr: require.Error,
+		},
+		{
+			name:          "should error when existing connector cert is not matching",
+			connectorName: existingConnectorName,
+			connectorSpec: types.SAMLConnectorSpecV2{
+				EncryptionKeyPair: &types.AsymmetricKeyPair{
+					PrivateKey: "",
+					Cert:       string(unrelatedCertPEM),
+				},
+			},
+			assertErr: require.Error,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			connector := &types.SAMLConnectorV2{
+				Metadata: types.Metadata{
+					Name: tc.connectorName,
+				},
+				Spec: tc.connectorSpec,
+			}
+
+			err := FillSAMLSecretFieldsFromExistingConnector(ctx, connector, existingConnectors)
+			tc.assertErr(t, err)
+			if tc.assertResult != nil {
+				tc.assertResult(t, connector)
+			}
+		})
+	}
+}
+
 func TestFillSAMLOAuthClientSecretFromExisting(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## What changed

This PR fixes [#67647](https://github.com/gravitational/teleport/issues/67647) by changing the Terraform `teleport_saml_connector` resource and data source to read SAML connectors without secrets for refresh, import, and data-source reads. API-generated SAML signing/assertion private keys are no longer copied back into Terraform state.

The local `GetSAMLConnector(..., false)` path now uses `WithoutSecrets()` consistently, so signing private keys, assertion/encryption private keys, and OAuth client secrets are scrubbed in one place.

The SAML resource now has a v0-to-v1 state upgrader that removes previously stored signing/assertion private keys from old Terraform state. After that one-time scrub, read/refresh preserves state secrets so explicitly configured private keys and OAuth client secrets do not produce permanent diffs.

SAML update/upsert secret preservation now also handles assertion/encryption key pairs, matching the existing behavior for signing key pairs and OAuth client secrets.

## Review guide

This PR is split into two commits for easier review:

1. [`9c5685e725`](https://github.com/gravitational/teleport/pull/67882/commits/9c5685e725) - service-layer SAML secret handling
   1. centralizes `withSecrets=false` behavior through `WithoutSecrets()`
   2. preserves existing signing/assertion/OAuth secrets during SAML updates

2. [`bea61704ea`](https://github.com/gravitational/teleport/pull/67882/commits/bea61704ea) - Terraform provider state behavior
   1. reads SAML connectors without secrets in Terraform paths
   2. adds the SAML state upgrader and provider-side state preservation
   3. adds generator hooks and provider regression tests

## What we found

Issue [#67647](https://github.com/gravitational/teleport/issues/67647) is valid: `teleport_saml_connector` marked private key fields as `Sensitive`, but all provider CRUD/import/data-source reads called `GetSAMLConnector(..., true)`. Terraform therefore masked these values in CLI output but still stored the raw private keys in state.

There was also a service-layer gap: `SAMLConnectorV2.WithoutSecrets()` already knew how to remove the assertion/encryption private key, but `GetSAMLConnector(..., false)` manually stripped only the signing private key and OAuth client secret. Routing through `WithoutSecrets()` keeps the no-secrets behavior centralized.

The state handling has to balance two Terraform provider constraints. Configured attributes must round-trip after create/update/read to avoid inconsistent apply results or permanent diffs. At the same time, `Read` in the current framework version sees prior state but not config, so it cannot tell whether an existing signing/assertion private key in state was user-configured or API-generated by an older provider. This PR handles that by scrubbing old private-key state once through a schema version upgrade, then preserving state secrets during normal read/refresh afterward.

## Modern Terraform guidance

HashiCorp's current guidance is that [`sensitive` values are redacted but still stored in state and plan files](https://developer.hashicorp.com/terraform/language/manage-sensitive-data#hide-sensitive-variables-and-outputs). Terraform's modern state-avoidance pattern for user-supplied secrets is [ephemeral/write-only arguments](https://developer.hashicorp.com/terraform/language/manage-sensitive-data#omit-values-from-state-and-plan-files), usually with [`_wo` and `_wo_version` fields](https://developer.hashicorp.com/terraform/plugin/framework/resources/write-only-arguments#best-practices), so the provider can consume a secret during an operation without Terraform persisting it.

This PR avoids reading API-generated private keys into state now. A future enhancement could add write-only alternatives for user-supplied SAML private keys and OAuth client secrets, then migrate users away from storing those configured secrets in state.

## Versioning note

This provider currently uses [`github.com/hashicorp/terraform-plugin-framework v0.10.0`](https://github.com/gravitational/teleport/blob/8b955844e156965d3c11ce4853affca1c484faac/integrations/terraform/go.mod#L15). Terraform write-only arguments require [Terraform 1.11+](https://developer.hashicorp.com/terraform/language/manage-sensitive-data#requirements), and the Plugin Framework write-only resource docs begin at [framework v1.15](https://developer.hashicorp.com/terraform/plugin/framework/resources/write-only-arguments). Supporting `_wo` arguments would therefore require a framework/runtime compatibility upgrade and a schema migration plan. This PR avoids that larger compatibility change.