### PR TITLE
Change classifier terraform/YAML handling to accept friendly values

### DIFF
--- a/tool/tctl/common/resources/classifier.go
+++ b/tool/tctl/common/resources/classifier.go
@@ -18,11 +18,13 @@ package resources
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"strings"
 
 	"github.com/gravitational/trace"
+	"google.golang.org/protobuf/encoding/protojson"
 
 	summarizerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/summarizer/v1"
 	"github.com/gravitational/teleport/api/types"
@@ -40,9 +42,31 @@ type classifierCollection []*summarizerv1.Classifier
 func (c classifierCollection) Resources() []types.Resource {
 	out := make([]types.Resource, 0, len(c))
 	for _, item := range c {
-		out = append(out, types.ProtoResource153ToLegacy(item))
+		out = append(out, classifierResource{
+			Resource:   types.ProtoResource153ToLegacy(item),
+			classifier: item,
+		})
 	}
 	return out
+}
+
+// classifierResource renders a Classifier with the tri-state ClassifierActionMode
+// fields (emit_audit_event, flag_for_review) presented as booleans in "tctl get"
+// YAML/JSON output.
+type classifierResource struct {
+	types.Resource
+	classifier *summarizerv1.Classifier
+}
+
+// MarshalJSON renders the wrapped Classifier, converting the tri-state action
+// mode enums into booleans. It mirrors the protojson options used by the generic
+// RFD 153 adapter so that every other field is encoded identically.
+func (r classifierResource) MarshalJSON() ([]byte, error) {
+	data, err := protojson.MarshalOptions{UseProtoNames: true}.Marshal(r.classifier)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return classifierActionsToBool(data)
 }
 
 func (c classifierCollection) WriteText(w io.Writer, verbose bool) error {
@@ -85,8 +109,12 @@ func classifierHandler() Handler {
 func createClassifier(
 	ctx context.Context, clt *authclient.Client, raw services.UnknownResource, opts CreateOpts,
 ) error {
+	rawJSON, err := classifierActionsFromBool(raw.Raw)
+	if err != nil {
+		return trace.Wrap(err)
+	}
 	classifier, err := services.UnmarshalProtoResource[*summarizerv1.Classifier](
-		raw.Raw, services.DisallowUnknown())
+		rawJSON, services.DisallowUnknown())
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -114,8 +142,12 @@ func createClassifier(
 func updateClassifier(
 	ctx context.Context, clt *authclient.Client, raw services.UnknownResource, opts CreateOpts,
 ) error {
+	rawJSON, err := classifierActionsFromBool(raw.Raw)
+	if err != nil {
+		return trace.Wrap(err)
+	}
 	classifier, err := services.UnmarshalProtoResource[*summarizerv1.Classifier](
-		raw.Raw, services.DisallowUnknown())
+		rawJSON, services.DisallowUnknown())
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -173,4 +205,82 @@ func deleteClassifier(
 	}
 	fmt.Printf("classifier %q has been deleted\n", ref.Name)
 	return nil
+}
+
+const (
+	classifierActionModeEnabled  = "CLASSIFIER_ACTION_MODE_ENABLED"
+	classifierActionModeDisabled = "CLASSIFIER_ACTION_MODE_DISABLED"
+)
+
+// classifierActionBoolFields are the spec.actions ClassifierActionMode toggles
+// that tctl renders as booleans. risk_level_floor is a level rather than a
+// toggle, so it is intentionally left as its enum value.
+var classifierActionBoolFields = []string{"emit_audit_event", "flag_for_review"}
+
+// classifierActionsToBool rewrites the ClassifierActionMode fields of a
+// protojson-encoded Classifier from their enum string form into booleans.
+// CLASSIFIER_ACTION_MODE_UNSPECIFIED is omitted by protojson, so it stays absent.
+func classifierActionsToBool(data []byte) ([]byte, error) {
+	return rewriteClassifierActions(data, func(v any) (any, bool) {
+		switch v {
+		case classifierActionModeEnabled:
+			return true, true
+		case classifierActionModeDisabled:
+			return false, true
+		default:
+			return nil, false
+		}
+	})
+}
+
+// classifierActionsFromBool rewrites boolean ClassifierActionMode fields of a
+// JSON-encoded Classifier into their enum string form so protojson can decode
+// them. Non-boolean values (enum strings or numbers) are left untouched so
+// existing manifests keep working.
+func classifierActionsFromBool(data []byte) ([]byte, error) {
+	return rewriteClassifierActions(data, func(v any) (any, bool) {
+		b, ok := v.(bool)
+		if !ok {
+			return nil, false
+		}
+		if b {
+			return classifierActionModeEnabled, true
+		}
+		return classifierActionModeDisabled, true
+	})
+}
+
+// rewriteClassifierActions applies convert to each ClassifierActionMode field
+// under spec.actions, replacing a value only when convert reports a change. The
+// input and output are JSON. If the document has no spec.actions, or no fields
+// change, the original bytes are returned unmodified.
+func rewriteClassifierActions(data []byte, convert func(any) (any, bool)) ([]byte, error) {
+	var root map[string]any
+	if err := json.Unmarshal(data, &root); err != nil {
+		return nil, trace.Wrap(err)
+	}
+	spec, ok := root["spec"].(map[string]any)
+	if !ok {
+		return data, nil
+	}
+	actions, ok := spec["actions"].(map[string]any)
+	if !ok {
+		return data, nil
+	}
+	changed := false
+	for _, field := range classifierActionBoolFields {
+		v, ok := actions[field]
+		if !ok {
+			continue
+		}
+		if nv, ok := convert(v); ok {
+			actions[field] = nv
+			changed = true
+		}
+	}
+	if !changed {
+		return data, nil
+	}
+	out, err := json.Marshal(root)
+	return out, trace.Wrap(err)
 }

--- a/tool/tctl/common/resources/classifier.go
+++ b/tool/tctl/common/resources/classifier.go
@@ -50,23 +50,18 @@ func (c classifierCollection) Resources() []types.Resource {
 	return out
 }
 
-// classifierResource renders a Classifier with the tri-state ClassifierActionMode
-// fields (emit_audit_event, flag_for_review) presented as booleans in "tctl get"
-// YAML/JSON output.
+// classifierResource renders a Classifier's spec.actions in friendly form for "tctl get".
 type classifierResource struct {
 	types.Resource
 	classifier *summarizerv1.Classifier
 }
 
-// MarshalJSON renders the wrapped Classifier, converting the tri-state action
-// mode enums into booleans. It mirrors the protojson options used by the generic
-// RFD 153 adapter so that every other field is encoded identically.
 func (r classifierResource) MarshalJSON() ([]byte, error) {
 	data, err := protojson.MarshalOptions{UseProtoNames: true}.Marshal(r.classifier)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	return classifierActionsToBool(data)
+	return classifierActionsToFriendly(data)
 }
 
 func (c classifierCollection) WriteText(w io.Writer, verbose bool) error {
@@ -109,7 +104,7 @@ func classifierHandler() Handler {
 func createClassifier(
 	ctx context.Context, clt *authclient.Client, raw services.UnknownResource, opts CreateOpts,
 ) error {
-	rawJSON, err := classifierActionsFromBool(raw.Raw)
+	rawJSON, err := classifierActionsFromFriendly(raw.Raw)
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -142,7 +137,7 @@ func createClassifier(
 func updateClassifier(
 	ctx context.Context, clt *authclient.Client, raw services.UnknownResource, opts CreateOpts,
 ) error {
-	rawJSON, err := classifierActionsFromBool(raw.Raw)
+	rawJSON, err := classifierActionsFromFriendly(raw.Raw)
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -212,49 +207,71 @@ const (
 	classifierActionModeDisabled = "CLASSIFIER_ACTION_MODE_DISABLED"
 )
 
-// classifierActionBoolFields are the spec.actions ClassifierActionMode toggles
-// that tctl renders as booleans. risk_level_floor is a level rather than a
-// toggle, so it is intentionally left as its enum value.
-var classifierActionBoolFields = []string{"emit_audit_event", "flag_for_review"}
+var classifierActionFields = []string{"emit_audit_event", "flag_for_review", "risk_level_floor"}
 
-// classifierActionsToBool rewrites the ClassifierActionMode fields of a
-// protojson-encoded Classifier from their enum string form into booleans.
-// CLASSIFIER_ACTION_MODE_UNSPECIFIED is omitted by protojson, so it stays absent.
-func classifierActionsToBool(data []byte) ([]byte, error) {
-	return rewriteClassifierActions(data, func(v any) (any, bool) {
-		switch v {
-		case classifierActionModeEnabled:
-			return true, true
-		case classifierActionModeDisabled:
-			return false, true
-		default:
-			return nil, false
+var riskLevelToShort = map[string]string{
+	"RISK_LEVEL_LOW":      "low",
+	"RISK_LEVEL_MEDIUM":   "medium",
+	"RISK_LEVEL_HIGH":     "high",
+	"RISK_LEVEL_CRITICAL": "critical",
+}
+
+var riskLevelFromShort = map[string]string{
+	"low":      "RISK_LEVEL_LOW",
+	"medium":   "RISK_LEVEL_MEDIUM",
+	"high":     "RISK_LEVEL_HIGH",
+	"critical": "RISK_LEVEL_CRITICAL",
+}
+
+// classifierActionsToFriendly converts spec.actions enums to booleans and a short risk level.
+func classifierActionsToFriendly(data []byte) ([]byte, error) {
+	return rewriteClassifierActions(data, func(field string, v any) (any, error) {
+		switch field {
+		case "emit_audit_event", "flag_for_review":
+			switch v {
+			case classifierActionModeEnabled:
+				return true, nil
+			case classifierActionModeDisabled:
+				return false, nil
+			}
+		case "risk_level_floor":
+			if s, ok := v.(string); ok {
+				if short, ok := riskLevelToShort[s]; ok {
+					return short, nil
+				}
+			}
 		}
+		return v, nil
 	})
 }
 
-// classifierActionsFromBool rewrites boolean ClassifierActionMode fields of a
-// JSON-encoded Classifier into their enum string form so protojson can decode
-// them. Non-boolean values (enum strings or numbers) are left untouched so
-// existing manifests keep working.
-func classifierActionsFromBool(data []byte) ([]byte, error) {
-	return rewriteClassifierActions(data, func(v any) (any, bool) {
-		b, ok := v.(bool)
-		if !ok {
-			return nil, false
+// classifierActionsFromFriendly converts spec.actions booleans and short risk levels back to enums, rejecting any other value.
+func classifierActionsFromFriendly(data []byte) ([]byte, error) {
+	return rewriteClassifierActions(data, func(field string, v any) (any, error) {
+		switch field {
+		case "emit_audit_event", "flag_for_review":
+			b, ok := v.(bool)
+			if !ok {
+				return nil, trace.BadParameter("spec.actions.%s must be true or false", field)
+			}
+			if b {
+				return classifierActionModeEnabled, nil
+			}
+			return classifierActionModeDisabled, nil
+		case "risk_level_floor":
+			if s, ok := v.(string); ok {
+				if enum, ok := riskLevelFromShort[strings.ToLower(s)]; ok {
+					return enum, nil
+				}
+			}
+			return nil, trace.BadParameter(
+				`spec.actions.risk_level_floor must be one of "low", "medium", "high", "critical"`)
 		}
-		if b {
-			return classifierActionModeEnabled, true
-		}
-		return classifierActionModeDisabled, true
+		return v, nil
 	})
 }
 
-// rewriteClassifierActions applies convert to each ClassifierActionMode field
-// under spec.actions, replacing a value only when convert reports a change. The
-// input and output are JSON. If the document has no spec.actions, or no fields
-// change, the original bytes are returned unmodified.
-func rewriteClassifierActions(data []byte, convert func(any) (any, bool)) ([]byte, error) {
+func rewriteClassifierActions(data []byte, convert func(field string, v any) (any, error)) ([]byte, error) {
 	var root map[string]any
 	if err := json.Unmarshal(data, &root); err != nil {
 		return nil, trace.Wrap(err)
@@ -268,12 +285,16 @@ func rewriteClassifierActions(data []byte, convert func(any) (any, bool)) ([]byt
 		return data, nil
 	}
 	changed := false
-	for _, field := range classifierActionBoolFields {
+	for _, field := range classifierActionFields {
 		v, ok := actions[field]
 		if !ok {
 			continue
 		}
-		if nv, ok := convert(v); ok {
+		nv, err := convert(field, v)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		if nv != v {
 			actions[field] = nv
 			changed = true
 		}

--- a/tool/tctl/common/resources/classifier_test.go
+++ b/tool/tctl/common/resources/classifier_test.go
@@ -35,10 +35,8 @@ func makeClassifierWithActions(actions *summarizerv1.ClassifierActions) *summari
 	}.Build())
 }
 
-// TestClassifierActionsMarshalBooleans verifies that "tctl get" renders the
-// tri-state ClassifierActionMode toggles as booleans, leaves risk_level_floor as
-// its enum, and omits unspecified toggles entirely.
-func TestClassifierActionsMarshalBooleans(t *testing.T) {
+// "tctl get" renders toggles as booleans and risk_level_floor as a short string.
+func TestClassifierActionsMarshalFriendly(t *testing.T) {
 	c := makeClassifierWithActions(summarizerv1.ClassifierActions_builder{
 		EmitAuditEvent: summarizerv1.ClassifierActionMode_CLASSIFIER_ACTION_MODE_ENABLED,
 		FlagForReview:  summarizerv1.ClassifierActionMode_CLASSIFIER_ACTION_MODE_DISABLED,
@@ -51,14 +49,13 @@ func TestClassifierActionsMarshalBooleans(t *testing.T) {
 	actions := unmarshalActions(t, data)
 	require.Equal(t, true, actions["emit_audit_event"])
 	require.Equal(t, false, actions["flag_for_review"])
-	// risk_level_floor is a level, not a toggle, so it stays an enum string.
-	require.Equal(t, "RISK_LEVEL_HIGH", actions["risk_level_floor"])
+	require.Equal(t, "high", actions["risk_level_floor"])
 }
 
 func TestClassifierActionsUnspecifiedOmitted(t *testing.T) {
 	c := makeClassifierWithActions(summarizerv1.ClassifierActions_builder{
 		EmitAuditEvent: summarizerv1.ClassifierActionMode_CLASSIFIER_ACTION_MODE_ENABLED,
-		// FlagForReview is left unspecified.
+		// flag_for_review and risk_level_floor are left unspecified.
 	}.Build())
 
 	data, err := classifierResource{classifier: c}.MarshalJSON()
@@ -66,49 +63,62 @@ func TestClassifierActionsUnspecifiedOmitted(t *testing.T) {
 
 	actions := unmarshalActions(t, data)
 	require.Equal(t, true, actions["emit_audit_event"])
-	_, ok := actions["flag_for_review"]
-	require.False(t, ok, "an unspecified action toggle should be omitted, not printed")
+	_, hasFlag := actions["flag_for_review"]
+	require.False(t, hasFlag, "an unspecified toggle should be omitted, not printed")
+	_, hasRisk := actions["risk_level_floor"]
+	require.False(t, hasRisk, "an unspecified risk level should be omitted, not printed")
 }
 
-// TestClassifierActionsRoundTrip verifies booleans survive a get -> create
-// round-trip, and that the legacy enum-string form is still accepted on input.
+// Friendly values survive a get -> create round-trip across every risk level.
 func TestClassifierActionsRoundTrip(t *testing.T) {
-	c := makeClassifierWithActions(summarizerv1.ClassifierActions_builder{
-		EmitAuditEvent: summarizerv1.ClassifierActionMode_CLASSIFIER_ACTION_MODE_ENABLED,
-		FlagForReview:  summarizerv1.ClassifierActionMode_CLASSIFIER_ACTION_MODE_DISABLED,
-		RiskLevelFloor: summarizerv1.RiskLevel_RISK_LEVEL_HIGH,
-	}.Build())
+	for _, level := range []summarizerv1.RiskLevel{
+		summarizerv1.RiskLevel_RISK_LEVEL_LOW,
+		summarizerv1.RiskLevel_RISK_LEVEL_MEDIUM,
+		summarizerv1.RiskLevel_RISK_LEVEL_HIGH,
+		summarizerv1.RiskLevel_RISK_LEVEL_CRITICAL,
+	} {
+		t.Run(level.String(), func(t *testing.T) {
+			c := makeClassifierWithActions(summarizerv1.ClassifierActions_builder{
+				EmitAuditEvent: summarizerv1.ClassifierActionMode_CLASSIFIER_ACTION_MODE_ENABLED,
+				FlagForReview:  summarizerv1.ClassifierActionMode_CLASSIFIER_ACTION_MODE_DISABLED,
+				RiskLevelFloor: level,
+			}.Build())
 
-	// "get" renders booleans...
-	data, err := classifierResource{classifier: c}.MarshalJSON()
-	require.NoError(t, err)
+			data, err := classifierResource{classifier: c}.MarshalJSON()
+			require.NoError(t, err)
 
-	// ...and "create" accepts them back.
-	back, err := classifierActionsFromBool(data)
-	require.NoError(t, err)
-	got, err := services.UnmarshalProtoResource[*summarizerv1.Classifier](back, services.DisallowUnknown())
-	require.NoError(t, err)
+			back, err := classifierActionsFromFriendly(data)
+			require.NoError(t, err)
+			got, err := services.UnmarshalProtoResource[*summarizerv1.Classifier](back, services.DisallowUnknown())
+			require.NoError(t, err)
 
-	gotActions := got.GetSpec().GetActions()
-	require.Equal(t, summarizerv1.ClassifierActionMode_CLASSIFIER_ACTION_MODE_ENABLED, gotActions.GetEmitAuditEvent())
-	require.Equal(t, summarizerv1.ClassifierActionMode_CLASSIFIER_ACTION_MODE_DISABLED, gotActions.GetFlagForReview())
-	require.Equal(t, summarizerv1.RiskLevel_RISK_LEVEL_HIGH, gotActions.GetRiskLevelFloor())
+			gotActions := got.GetSpec().GetActions()
+			require.Equal(t, summarizerv1.ClassifierActionMode_CLASSIFIER_ACTION_MODE_ENABLED, gotActions.GetEmitAuditEvent())
+			require.Equal(t, summarizerv1.ClassifierActionMode_CLASSIFIER_ACTION_MODE_DISABLED, gotActions.GetFlagForReview())
+			require.Equal(t, level, gotActions.GetRiskLevelFloor())
+		})
+	}
 }
 
-// TestClassifierActionsFromBoolAcceptsEnumStrings verifies backward
-// compatibility: a manifest still using the enum string form decodes unchanged.
-func TestClassifierActionsFromBoolAcceptsEnumStrings(t *testing.T) {
-	in := []byte(`{"kind":"classifier","version":"v1","metadata":{"name":"test"},` +
-		`"spec":{"kinds":["ssh"],"criteria":"c",` +
-		`"actions":{"emit_audit_event":"CLASSIFIER_ACTION_MODE_ENABLED"}}}`)
-
-	out, err := classifierActionsFromBool(in)
-	require.NoError(t, err)
-	got, err := services.UnmarshalProtoResource[*summarizerv1.Classifier](out, services.DisallowUnknown())
-	require.NoError(t, err)
-	require.Equal(t,
-		summarizerv1.ClassifierActionMode_CLASSIFIER_ACTION_MODE_ENABLED,
-		got.GetSpec().GetActions().GetEmitAuditEvent())
+// Raw enum names, integers, and unknown values are rejected on input.
+func TestClassifierActionsFromFriendlyRejectsInvalid(t *testing.T) {
+	for _, tt := range []struct {
+		name    string
+		actions string
+	}{
+		{"toggle as enum string", `{"emit_audit_event":"CLASSIFIER_ACTION_MODE_ENABLED"}`},
+		{"toggle as integer", `{"flag_for_review":1}`},
+		{"risk level as enum string", `{"risk_level_floor":"RISK_LEVEL_HIGH"}`},
+		{"risk level as integer", `{"risk_level_floor":3}`},
+		{"risk level unknown", `{"risk_level_floor":"severe"}`},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			in := []byte(`{"kind":"classifier","version":"v1","metadata":{"name":"t"},` +
+				`"spec":{"kinds":["ssh"],"criteria":"c","actions":` + tt.actions + `}}`)
+			_, err := classifierActionsFromFriendly(in)
+			require.Error(t, err)
+		})
+	}
 }
 
 func unmarshalActions(t *testing.T, data []byte) map[string]any {

--- a/tool/tctl/common/resources/classifier_test.go
+++ b/tool/tctl/common/resources/classifier_test.go
@@ -1,0 +1,123 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package resources
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	summarizerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/summarizer/v1"
+	"github.com/gravitational/teleport/api/types/summarizer"
+	"github.com/gravitational/teleport/lib/services"
+)
+
+func makeClassifierWithActions(actions *summarizerv1.ClassifierActions) *summarizerv1.Classifier {
+	return summarizer.NewClassifier("test", summarizerv1.ClassifierSpec_builder{
+		Kinds:    []string{"ssh"},
+		Criteria: "test criteria",
+		Actions:  actions,
+	}.Build())
+}
+
+// TestClassifierActionsMarshalBooleans verifies that "tctl get" renders the
+// tri-state ClassifierActionMode toggles as booleans, leaves risk_level_floor as
+// its enum, and omits unspecified toggles entirely.
+func TestClassifierActionsMarshalBooleans(t *testing.T) {
+	c := makeClassifierWithActions(summarizerv1.ClassifierActions_builder{
+		EmitAuditEvent: summarizerv1.ClassifierActionMode_CLASSIFIER_ACTION_MODE_ENABLED,
+		FlagForReview:  summarizerv1.ClassifierActionMode_CLASSIFIER_ACTION_MODE_DISABLED,
+		RiskLevelFloor: summarizerv1.RiskLevel_RISK_LEVEL_HIGH,
+	}.Build())
+
+	data, err := classifierResource{classifier: c}.MarshalJSON()
+	require.NoError(t, err)
+
+	actions := unmarshalActions(t, data)
+	require.Equal(t, true, actions["emit_audit_event"])
+	require.Equal(t, false, actions["flag_for_review"])
+	// risk_level_floor is a level, not a toggle, so it stays an enum string.
+	require.Equal(t, "RISK_LEVEL_HIGH", actions["risk_level_floor"])
+}
+
+func TestClassifierActionsUnspecifiedOmitted(t *testing.T) {
+	c := makeClassifierWithActions(summarizerv1.ClassifierActions_builder{
+		EmitAuditEvent: summarizerv1.ClassifierActionMode_CLASSIFIER_ACTION_MODE_ENABLED,
+		// FlagForReview is left unspecified.
+	}.Build())
+
+	data, err := classifierResource{classifier: c}.MarshalJSON()
+	require.NoError(t, err)
+
+	actions := unmarshalActions(t, data)
+	require.Equal(t, true, actions["emit_audit_event"])
+	_, ok := actions["flag_for_review"]
+	require.False(t, ok, "an unspecified action toggle should be omitted, not printed")
+}
+
+// TestClassifierActionsRoundTrip verifies booleans survive a get -> create
+// round-trip, and that the legacy enum-string form is still accepted on input.
+func TestClassifierActionsRoundTrip(t *testing.T) {
+	c := makeClassifierWithActions(summarizerv1.ClassifierActions_builder{
+		EmitAuditEvent: summarizerv1.ClassifierActionMode_CLASSIFIER_ACTION_MODE_ENABLED,
+		FlagForReview:  summarizerv1.ClassifierActionMode_CLASSIFIER_ACTION_MODE_DISABLED,
+		RiskLevelFloor: summarizerv1.RiskLevel_RISK_LEVEL_HIGH,
+	}.Build())
+
+	// "get" renders booleans...
+	data, err := classifierResource{classifier: c}.MarshalJSON()
+	require.NoError(t, err)
+
+	// ...and "create" accepts them back.
+	back, err := classifierActionsFromBool(data)
+	require.NoError(t, err)
+	got, err := services.UnmarshalProtoResource[*summarizerv1.Classifier](back, services.DisallowUnknown())
+	require.NoError(t, err)
+
+	gotActions := got.GetSpec().GetActions()
+	require.Equal(t, summarizerv1.ClassifierActionMode_CLASSIFIER_ACTION_MODE_ENABLED, gotActions.GetEmitAuditEvent())
+	require.Equal(t, summarizerv1.ClassifierActionMode_CLASSIFIER_ACTION_MODE_DISABLED, gotActions.GetFlagForReview())
+	require.Equal(t, summarizerv1.RiskLevel_RISK_LEVEL_HIGH, gotActions.GetRiskLevelFloor())
+}
+
+// TestClassifierActionsFromBoolAcceptsEnumStrings verifies backward
+// compatibility: a manifest still using the enum string form decodes unchanged.
+func TestClassifierActionsFromBoolAcceptsEnumStrings(t *testing.T) {
+	in := []byte(`{"kind":"classifier","version":"v1","metadata":{"name":"test"},` +
+		`"spec":{"kinds":["ssh"],"criteria":"c",` +
+		`"actions":{"emit_audit_event":"CLASSIFIER_ACTION_MODE_ENABLED"}}}`)
+
+	out, err := classifierActionsFromBool(in)
+	require.NoError(t, err)
+	got, err := services.UnmarshalProtoResource[*summarizerv1.Classifier](out, services.DisallowUnknown())
+	require.NoError(t, err)
+	require.Equal(t,
+		summarizerv1.ClassifierActionMode_CLASSIFIER_ACTION_MODE_ENABLED,
+		got.GetSpec().GetActions().GetEmitAuditEvent())
+}
+
+func unmarshalActions(t *testing.T, data []byte) map[string]any {
+	t.Helper()
+	var doc map[string]any
+	require.NoError(t, json.Unmarshal(data, &doc))
+	spec, ok := doc["spec"].(map[string]any)
+	require.True(t, ok, "spec missing from marshaled classifier")
+	actions, ok := spec["actions"].(map[string]any)
+	require.True(t, ok, "spec.actions missing from marshaled classifier")
+	return actions
+}


### PR DESCRIPTION
Requires https://github.com/gravitational/teleport/pull/67765

This changes the handling of the classifier resource so terraform/tctl accept `true`/`false` instead of the tri-state mode enum (unspecified/enabled/disabled), and for risk level flooring, it accepts `"critical" | "high" | "medium" | "low"` instead of the enum number