### PR TITLE
Connect: Fix progress reporting for empty file uploads

### DIFF
--- a/lib/teleterm/clusters/cluster_file_transfer.go
+++ b/lib/teleterm/clusters/cluster_file_transfer.go
@@ -122,7 +122,7 @@ func (p *fileTransferProgress) maybeUpdateProgress(bytes []byte) (int, error) {
 	defer p.lock.Unlock()
 
 	p.sentSize += int64(bytesLength)
-	percentage := uint32(p.sentSize * 100 / p.fileSize)
+	percentage := calculatePercentage(p.sentSize, p.fileSize)
 
 	if p.shouldSendProgress(percentage) {
 		err := p.sendProgress(api.FileTransferProgress_builder{Percentage: percentage}.Build())
@@ -134,6 +134,13 @@ func (p *fileTransferProgress) maybeUpdateProgress(bytes []byte) (int, error) {
 	}
 
 	return bytesLength, nil
+}
+
+func calculatePercentage(part, total int64) uint32 {
+	if total <= 0 {
+		return 100
+	}
+	return uint32(part * 100 / total)
 }
 
 func (p *fileTransferProgress) shouldSendProgress(percentage uint32) bool {

--- a/web/packages/teleport/src/Console/DocumentSsh/Terminal/Terminal.tsx
+++ b/web/packages/teleport/src/Console/DocumentSsh/Terminal/Terminal.tsx
@@ -153,7 +153,8 @@ const TerminalAddonsContainer = styled.div`
   flex-direction: column;
   align-items: flex-end;
   gap: 8px;
-  min-width: 500px;
+  width: 100%;
+  max-width: 500px;
 `;
 
 export interface TerminalRef {

--- a/web/packages/teleport/src/SessionRecordings/view/Xterm/Xterm.tsx
+++ b/web/packages/teleport/src/SessionRecordings/view/Xterm/Xterm.tsx
@@ -143,5 +143,6 @@ const TerminalAddonsContainer = styled.div`
   flex-direction: column;
   align-items: flex-end;
   gap: ${p => p.theme.space[2]}px;
-  min-width: 500px;
+  width: 100%;
+  max-width: 500px;
 `;

--- a/web/packages/teleterm/src/ui/DocumentTerminal/Terminal/Terminal.tsx
+++ b/web/packages/teleterm/src/ui/DocumentTerminal/Terminal/Terminal.tsx
@@ -166,7 +166,8 @@ const TerminalAddonsContainer = styled.div`
   flex-direction: column;
   align-items: flex-end;
   gap: 8px;
-  min-width: 500px;
+  width: 100%;
+  max-width: 500px;
 `;
 
 const StyledXterm = styled(Box)`


### PR DESCRIPTION
When an empty file is uploaded, we perform a divide by zero in calculating the progress which results in a panic. 
Previously it would crash the tsh daemon, after https://github.com/gravitational/teleport/pull/66899 it only returns `handler panic` error.

I also noticed that the file container width isn’t limited, so it can grow as much as it wants:
<img width="1194" height="692" alt="image" src="https://github.com/user-attachments/assets/d724b952-4c8d-4e5d-994a-85f9a3da4e4a" />

I added `max-width: 500px` to `TerminalAddonsContainer` to fix this. We currently have three copies of this component, so it could probably be unified, but I chose to keep things as-is for now.

<!-- Provide a descriptive entry for the changelog of the next release. -->

Changelog: Fixed Teleport Connect file uploads for empty files


<!-- Include manual testing efforts to verify the change. -->
<!-- Detail where the tests where run and what configurations were used. -->
<!-- Include all the test cases which were run to validate the change. -->

## Manual Test Plan
### Test Environment
Locally built app.

### Test Cases
- [x] Uploading zero-length files don't cause handler panic.
- [x] The file transfer container doesn't exceeds expected width in Connect.
- [x] Terminal search and file transfer look the same as before in the Web UI.
