### PR TITLE
Unskip classifier enterprise tests

### DIFF
--- a/integrations/terraform/testlib/classifier_test.go
+++ b/integrations/terraform/testlib/classifier_test.go
@@ -31,9 +31,6 @@ import (
 
 func (s *TerraformSuiteEnterprise) TestClassifier() {
 	t := s.T()
-	// TODO(ryan): unskip once the enterprise SummarizerService implements the
-	// Classifier RPCs.
-	t.Skip("the enterprise SummarizerService does not implement Classifier RPCs yet")
 	ctx := t.Context()
 
 	checkDestroyed := func(state *terraform.State) error {
@@ -86,9 +83,6 @@ func (s *TerraformSuiteEnterprise) TestClassifier() {
 
 func (s *TerraformSuiteEnterprise) TestClassifierDataSource() {
 	t := s.T()
-	// TODO(ryan): unskip once the enterprise SummarizerService implements the
-	// Classifier RPCs.
-	t.Skip("the enterprise SummarizerService does not implement Classifier RPCs yet")
 	ctx := t.Context()
 
 	checkDestroyed := func(state *terraform.State) error {
@@ -131,9 +125,6 @@ func (s *TerraformSuiteEnterprise) TestClassifierDataSource() {
 
 func (s *TerraformSuiteEnterprise) TestImportClassifier() {
 	t := s.T()
-	// TODO(ryan): unskip once the enterprise SummarizerService implements the
-	// Classifier RPCs.
-	t.Skip("the enterprise SummarizerService does not implement Classifier RPCs yet")
 	ctx := t.Context()
 
 	r := "teleport_classifier"


### PR DESCRIPTION
Requires #67884 and https://github.com/gravitational/teleport.e/pull/8971

Unskips the terraform enterprise tests for classifiers now that the RPCs are implemented