### PR TITLE
Add filter state to unified resources CTA slot

### DIFF
--- a/web/packages/teleport/src/UnifiedResources/UnifiedResources.tsx
+++ b/web/packages/teleport/src/UnifiedResources/UnifiedResources.tsx
@@ -147,11 +147,15 @@ export function ClusterResources({
   bulkActions?: BulkAction[];
   availabilityFilter?: ResourceAvailabilityFilter;
   /**
-   * Optional render-prop, given the number of currently displayed resources,
-   * for rendering content (such as a CTA) that depends on whether any
-   * resources are present.
+   * Optional render-prop for rendering content (such as a CTA) that depends on
+   * the current resource list. It's given the number of currently displayed
+   * resources along with whether any filter or search is active, so the content
+   * can tell a genuinely empty cluster apart from a list emptied by filtering.
    */
-  ctaSlot?: (resourceCount: number) => ReactNode;
+  ctaSlot?: (props: {
+    resourceCount: number;
+    isFilterApplied: boolean;
+  }) => ReactNode;
 }) {
   const teleCtx = useTeleport();
   const flags = teleCtx.getFeatureFlags();
@@ -288,6 +292,13 @@ export function ClusterResources({
     });
   }
 
+  const isFilterApplied =
+    !!params.search ||
+    !!params.query ||
+    !!params.pinnedOnly ||
+    !!params.kinds?.length ||
+    !!params.statuses?.length;
+
   return (
     <>
       {loadClusterError && <Danger>{loadClusterError}</Danger>}
@@ -353,7 +364,7 @@ export function ClusterResources({
           </>
         }
       />
-      {ctaSlot?.(resources.length)}
+      {ctaSlot?.({ resourceCount: resources.length, isFilterApplied })}
     </>
   );
 }


### PR DESCRIPTION
This is so the CTA can decide to only show when landing on the resources page, and not suddenly appear when going from a filtered resource page to an empty filtered resource page (i.e. clicking on a specific resource type in the sidebar, getting 0 results, and then clearing that filter and getting results)