### PR TITLE
RFD 229C: Add `scope` field to WorkloadIdentity resource and validation rules (2/5)

### DIFF
--- a/api/gen/proto/go/teleport/workloadidentity/v1/resource.pb.go
+++ b/api/gen/proto/go/teleport/workloadidentity/v1/resource.pb.go
@@ -55,7 +55,13 @@ type WorkloadIdentity struct {
 	// Common metadata that all resources share.
 	Metadata *v1.Metadata `protobuf:"bytes,4,opt,name=metadata,proto3" json:"metadata,omitempty"`
 	// The configured properties of the WorkloadIdentity
-	Spec          *WorkloadIdentitySpec `protobuf:"bytes,5,opt,name=spec,proto3" json:"spec,omitempty"`
+	Spec *WorkloadIdentitySpec `protobuf:"bytes,5,opt,name=spec,proto3" json:"spec,omitempty"`
+	// The scope of the WorkloadIdentity. If unset, the WorkloadIdentity is
+	// unscoped (classic behavior). If set, the WorkloadIdentity is scoped and the
+	// SPIFFE ID defined in spec.spiffe.id must be a scoped SPIFFE ID prefixed
+	// with this scope. The scope of a WorkloadIdentity cannot be changed after
+	// creation.
+	Scope         string `protobuf:"bytes,6,opt,name=scope,proto3" json:"scope,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -120,6 +126,13 @@ func (x *WorkloadIdentity) GetSpec() *WorkloadIdentitySpec {
 	return nil
 }
 
+func (x *WorkloadIdentity) GetScope() string {
+	if x != nil {
+		return x.Scope
+	}
+	return ""
+}
+
 func (x *WorkloadIdentity) SetKind(v string) {
 	x.Kind = v
 }
@@ -138,6 +151,10 @@ func (x *WorkloadIdentity) SetMetadata(v *v1.Metadata) {
 
 func (x *WorkloadIdentity) SetSpec(v *WorkloadIdentitySpec) {
 	x.Spec = v
+}
+
+func (x *WorkloadIdentity) SetScope(v string) {
+	x.Scope = v
 }
 
 func (x *WorkloadIdentity) HasMetadata() bool {
@@ -176,6 +193,12 @@ type WorkloadIdentity_builder struct {
 	Metadata *v1.Metadata
 	// The configured properties of the WorkloadIdentity
 	Spec *WorkloadIdentitySpec
+	// The scope of the WorkloadIdentity. If unset, the WorkloadIdentity is
+	// unscoped (classic behavior). If set, the WorkloadIdentity is scoped and the
+	// SPIFFE ID defined in spec.spiffe.id must be a scoped SPIFFE ID prefixed
+	// with this scope. The scope of a WorkloadIdentity cannot be changed after
+	// creation.
+	Scope string
 }
 
 func (b0 WorkloadIdentity_builder) Build() *WorkloadIdentity {
@@ -187,6 +210,7 @@ func (b0 WorkloadIdentity_builder) Build() *WorkloadIdentity {
 	x.Version = b.Version
 	x.Metadata = b.Metadata
 	x.Spec = b.Spec
+	x.Scope = b.Scope
 	return m0
 }
 
@@ -1473,13 +1497,14 @@ var File_teleport_workloadidentity_v1_resource_proto protoreflect.FileDescriptor
 
 const file_teleport_workloadidentity_v1_resource_proto_rawDesc = "" +
 	"\n" +
-	"+teleport/workloadidentity/v1/resource.proto\x12\x1cteleport.workloadidentity.v1\x1a\x1egoogle/protobuf/duration.proto\x1a\x1cgoogle/protobuf/struct.proto\x1a!teleport/header/v1/metadata.proto\"\xdd\x01\n" +
+	"+teleport/workloadidentity/v1/resource.proto\x12\x1cteleport.workloadidentity.v1\x1a\x1egoogle/protobuf/duration.proto\x1a\x1cgoogle/protobuf/struct.proto\x1a!teleport/header/v1/metadata.proto\"\xf3\x01\n" +
 	"\x10WorkloadIdentity\x12\x12\n" +
 	"\x04kind\x18\x01 \x01(\tR\x04kind\x12\x19\n" +
 	"\bsub_kind\x18\x02 \x01(\tR\asubKind\x12\x18\n" +
 	"\aversion\x18\x03 \x01(\tR\aversion\x128\n" +
 	"\bmetadata\x18\x04 \x01(\v2\x1c.teleport.header.v1.MetadataR\bmetadata\x12F\n" +
-	"\x04spec\x18\x05 \x01(\v22.teleport.workloadidentity.v1.WorkloadIdentitySpecR\x04spec\"3\n" +
+	"\x04spec\x18\x05 \x01(\v22.teleport.workloadidentity.v1.WorkloadIdentitySpecR\x04spec\x12\x14\n" +
+	"\x05scope\x18\x06 \x01(\tR\x05scope\"3\n" +
 	"\x1bWorkloadIdentityConditionEq\x12\x14\n" +
 	"\x05value\x18\x01 \x01(\tR\x05value\"6\n" +
 	"\x1eWorkloadIdentityConditionNotEq\x12\x14\n" +

--- a/api/gen/proto/go/teleport/workloadidentity/v1/resource_protoopaque.pb.go
+++ b/api/gen/proto/go/teleport/workloadidentity/v1/resource_protoopaque.pb.go
@@ -50,6 +50,7 @@ type WorkloadIdentity struct {
 	xxx_hidden_Version  string                 `protobuf:"bytes,3,opt,name=version,proto3"`
 	xxx_hidden_Metadata *v1.Metadata           `protobuf:"bytes,4,opt,name=metadata,proto3"`
 	xxx_hidden_Spec     *WorkloadIdentitySpec  `protobuf:"bytes,5,opt,name=spec,proto3"`
+	xxx_hidden_Scope    string                 `protobuf:"bytes,6,opt,name=scope,proto3"`
 	unknownFields       protoimpl.UnknownFields
 	sizeCache           protoimpl.SizeCache
 }
@@ -114,6 +115,13 @@ func (x *WorkloadIdentity) GetSpec() *WorkloadIdentitySpec {
 	return nil
 }
 
+func (x *WorkloadIdentity) GetScope() string {
+	if x != nil {
+		return x.xxx_hidden_Scope
+	}
+	return ""
+}
+
 func (x *WorkloadIdentity) SetKind(v string) {
 	x.xxx_hidden_Kind = v
 }
@@ -132,6 +140,10 @@ func (x *WorkloadIdentity) SetMetadata(v *v1.Metadata) {
 
 func (x *WorkloadIdentity) SetSpec(v *WorkloadIdentitySpec) {
 	x.xxx_hidden_Spec = v
+}
+
+func (x *WorkloadIdentity) SetScope(v string) {
+	x.xxx_hidden_Scope = v
 }
 
 func (x *WorkloadIdentity) HasMetadata() bool {
@@ -170,6 +182,12 @@ type WorkloadIdentity_builder struct {
 	Metadata *v1.Metadata
 	// The configured properties of the WorkloadIdentity
 	Spec *WorkloadIdentitySpec
+	// The scope of the WorkloadIdentity. If unset, the WorkloadIdentity is
+	// unscoped (classic behavior). If set, the WorkloadIdentity is scoped and the
+	// SPIFFE ID defined in spec.spiffe.id must be a scoped SPIFFE ID prefixed
+	// with this scope. The scope of a WorkloadIdentity cannot be changed after
+	// creation.
+	Scope string
 }
 
 func (b0 WorkloadIdentity_builder) Build() *WorkloadIdentity {
@@ -181,6 +199,7 @@ func (b0 WorkloadIdentity_builder) Build() *WorkloadIdentity {
 	x.xxx_hidden_Version = b.Version
 	x.xxx_hidden_Metadata = b.Metadata
 	x.xxx_hidden_Spec = b.Spec
+	x.xxx_hidden_Scope = b.Scope
 	return m0
 }
 
@@ -1400,13 +1419,14 @@ var File_teleport_workloadidentity_v1_resource_proto protoreflect.FileDescriptor
 
 const file_teleport_workloadidentity_v1_resource_proto_rawDesc = "" +
 	"\n" +
-	"+teleport/workloadidentity/v1/resource.proto\x12\x1cteleport.workloadidentity.v1\x1a\x1egoogle/protobuf/duration.proto\x1a\x1cgoogle/protobuf/struct.proto\x1a!teleport/header/v1/metadata.proto\"\xdd\x01\n" +
+	"+teleport/workloadidentity/v1/resource.proto\x12\x1cteleport.workloadidentity.v1\x1a\x1egoogle/protobuf/duration.proto\x1a\x1cgoogle/protobuf/struct.proto\x1a!teleport/header/v1/metadata.proto\"\xf3\x01\n" +
 	"\x10WorkloadIdentity\x12\x12\n" +
 	"\x04kind\x18\x01 \x01(\tR\x04kind\x12\x19\n" +
 	"\bsub_kind\x18\x02 \x01(\tR\asubKind\x12\x18\n" +
 	"\aversion\x18\x03 \x01(\tR\aversion\x128\n" +
 	"\bmetadata\x18\x04 \x01(\v2\x1c.teleport.header.v1.MetadataR\bmetadata\x12F\n" +
-	"\x04spec\x18\x05 \x01(\v22.teleport.workloadidentity.v1.WorkloadIdentitySpecR\x04spec\"3\n" +
+	"\x04spec\x18\x05 \x01(\v22.teleport.workloadidentity.v1.WorkloadIdentitySpecR\x04spec\x12\x14\n" +
+	"\x05scope\x18\x06 \x01(\tR\x05scope\"3\n" +
 	"\x1bWorkloadIdentityConditionEq\x12\x14\n" +
 	"\x05value\x18\x01 \x01(\tR\x05value\"6\n" +
 	"\x1eWorkloadIdentityConditionNotEq\x12\x14\n" +

--- a/api/proto/teleport/workloadidentity/v1/resource.proto
+++ b/api/proto/teleport/workloadidentity/v1/resource.proto
@@ -38,6 +38,12 @@ message WorkloadIdentity {
   teleport.header.v1.Metadata metadata = 4;
   // The configured properties of the WorkloadIdentity
   WorkloadIdentitySpec spec = 5;
+  // The scope of the WorkloadIdentity. If unset, the WorkloadIdentity is
+  // unscoped (classic behavior). If set, the WorkloadIdentity is scoped and the
+  // SPIFFE ID defined in spec.spiffe.id must be a scoped SPIFFE ID prefixed
+  // with this scope. The scope of a WorkloadIdentity cannot be changed after
+  // creation.
+  string scope = 6;
 }
 
 // The attribute casted to a string must be equal to the value.

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/workload_identity.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/workload_identity.mdx
@@ -24,6 +24,7 @@ Teleport Terraform provider.
 ### Optional
 
 - `metadata` (Attributes) Common metadata that all resources share. (see [below for nested schema](#nested-schema-for-metadata))
+- `scope` (String) The scope of the WorkloadIdentity. If unset, the WorkloadIdentity is unscoped (classic behavior). If set, the WorkloadIdentity is scoped and the SPIFFE ID defined in spec.spiffe.id must be a scoped SPIFFE ID prefixed with this scope. The scope of a WorkloadIdentity cannot be changed after creation.
 - `spec` (Attributes) The configured properties of the WorkloadIdentity (see [below for nested schema](#nested-schema-for-spec))
 - `sub_kind` (String) Differentiates variations of the same kind. All resources should contain one, even if it is never populated.
 - `version` (String) The version of the resource being represented.

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/workload_identity.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/workload_identity.mdx
@@ -51,6 +51,7 @@ resource "teleport_workload_identity" "example" {
 ### Optional
 
 - `metadata` (Attributes) Common metadata that all resources share. (see [below for nested schema](#nested-schema-for-metadata))
+- `scope` (String) The scope of the WorkloadIdentity. If unset, the WorkloadIdentity is unscoped (classic behavior). If set, the WorkloadIdentity is scoped and the SPIFFE ID defined in spec.spiffe.id must be a scoped SPIFFE ID prefixed with this scope. The scope of a WorkloadIdentity cannot be changed after creation.
 - `spec` (Attributes) The configured properties of the WorkloadIdentity (see [below for nested schema](#nested-schema-for-spec))
 - `sub_kind` (String) Differentiates variations of the same kind. All resources should contain one, even if it is never populated.
 - `version` (String) The version of the resource being represented.

--- a/integrations/terraform/tfschema/workloadidentity/v1/resource_terraform.go
+++ b/integrations/terraform/tfschema/workloadidentity/v1/resource_terraform.go
@@ -98,6 +98,11 @@ func GenSchemaWorkloadIdentity(ctx context.Context) (github_com_hashicorp_terraf
 			Description: "Common metadata that all resources share.",
 			Optional:    true,
 		},
+		"scope": {
+			Description: "The scope of the WorkloadIdentity. If unset, the WorkloadIdentity is unscoped (classic behavior). If set, the WorkloadIdentity is scoped and the SPIFFE ID defined in spec.spiffe.id must be a scoped SPIFFE ID prefixed with this scope. The scope of a WorkloadIdentity cannot be changed after creation.",
+			Optional:    true,
+			Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
+		},
 		"spec": {
 			Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.SingleNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
 				"rules": {
@@ -897,6 +902,23 @@ func CopyWorkloadIdentityFromTerraform(_ context.Context, tf github_com_hashicor
 						}
 					}
 				}
+			}
+		}
+	}
+	{
+		a, ok := tf.Attrs["scope"]
+		if !ok {
+			diags.Append(attrReadMissingDiag{"WorkloadIdentity.scope"})
+		} else {
+			v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.String)
+			if !ok {
+				diags.Append(attrReadConversionFailureDiag{"WorkloadIdentity.scope", "github.com/hashicorp/terraform-plugin-framework/types.String"})
+			} else {
+				var t string
+				if !v.Null && !v.Unknown {
+					t = string(v.Value)
+				}
+				obj.Scope = t
 			}
 		}
 	}
@@ -1981,6 +2003,28 @@ func CopyWorkloadIdentityToTerraform(ctx context.Context, obj *github_com_gravit
 				v.Unknown = false
 				tf.Attrs["spec"] = v
 			}
+		}
+	}
+	{
+		t, ok := tf.AttrTypes["scope"]
+		if !ok {
+			diags.Append(attrWriteMissingDiag{"WorkloadIdentity.scope"})
+		} else {
+			v, ok := tf.Attrs["scope"].(github_com_hashicorp_terraform_plugin_framework_types.String)
+			if !ok {
+				i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
+				if err != nil {
+					diags.Append(attrWriteGeneralError{"WorkloadIdentity.scope", err})
+				}
+				v, ok = i.(github_com_hashicorp_terraform_plugin_framework_types.String)
+				if !ok {
+					diags.Append(attrWriteConversionFailureDiag{"WorkloadIdentity.scope", "github.com/hashicorp/terraform-plugin-framework/types.String"})
+				}
+				v.Null = string(obj.Scope) == ""
+			}
+			v.Value = string(obj.Scope)
+			v.Unknown = false
+			tf.Attrs["scope"] = v
 		}
 	}
 	return diags

--- a/lib/services/workload_identity.go
+++ b/lib/services/workload_identity.go
@@ -30,6 +30,7 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/auth/machineid/workloadidentityv1/expression"
 	"github.com/gravitational/teleport/lib/backend"
+	"github.com/gravitational/teleport/lib/scopes"
 )
 
 // WorkloadIdentities is an interface over the WorkloadIdentities service. This
@@ -130,6 +131,20 @@ func ValidateWorkloadIdentity(s *workloadidentityv1pb.WorkloadIdentity) error {
 		return trace.BadParameter("spec.spiffe.jwt.maximum_ttl: must be less than %s", maxMaxJWTSVIDTTL)
 	}
 
+	// When the WorkloadIdentity is scoped, the scope itself must be valid and
+	// the SPIFFE ID must conform to the scoped SPIFFE ID structure (RFD 0229c).
+	if s.GetScope() != "" {
+		if err := scopes.StrongValidate(s.GetScope()); err != nil {
+			return trace.Wrap(err, "scope")
+		}
+		if scopes.Compare(s.GetScope(), scopes.Root) == scopes.Equivalent {
+			return trace.BadParameter("scope: must not be the root scope")
+		}
+		if err := validateScopedSPIFFEID(s.GetScope(), s.GetSpec().GetSpiffe().GetId()); err != nil {
+			return trace.Wrap(err)
+		}
+	}
+
 	for i, rule := range s.GetSpec().GetRules().GetAllow() {
 		if rule.GetExpression() == "" {
 			if len(rule.GetConditions()) == 0 {
@@ -155,6 +170,90 @@ func ValidateWorkloadIdentity(s *workloadidentityv1pb.WorkloadIdentity) error {
 	}
 
 	return nil
+}
+
+// scopedSPIFFEIDSeparator is the path segment that separates the scope-derived
+// section of a scoped SPIFFE ID from the administratively-defined section. A
+// scoped SPIFFE ID for a WorkloadIdentity defined in scope /security/eu looks
+// like /security/eu/_/k8s/cluster-a. See RFD 0229c.
+//
+// The separator is a valid SPIFFE ID path segment but is deliberately not a
+// valid scope segment (scope segments require at least two characters), which
+// keeps the boundary between the two sections unambiguous.
+const scopedSPIFFEIDSeparator = "_"
+
+// validateScopedSPIFFEID validates that the given SPIFFE ID path conforms to
+// the scoped SPIFFE ID structure for the given scope, as defined in RFD 0229c.
+//
+// A scoped SPIFFE ID path consists of three sections:
+//   - the scope section: segments that strictly match the scope of origin
+//   - the separator segment ("/_/")
+//   - the administratively-defined section: one or more freely-defined segments
+//
+// For example, for scope /security/eu, /security/eu/_/k8s/cluster-a is valid.
+//
+// The check is performed on segments (not raw string prefixes) so that, e.g., a
+// scope of /foo matches an ID beginning /foo/... but not /foo-buzz/.... The
+// scope section must match the scope of origin exactly: it may not be an
+// ancestor or descendant of it.
+func validateScopedSPIFFEID(scope, id string) error {
+	if !strings.HasPrefix(id, "/") {
+		return trace.BadParameter("spec.spiffe.id: must begin with a forward slash")
+	}
+
+	scopeSegments := splitPathSegments(scope)
+	idSegments := splitPathSegments(id)
+
+	// The ID must contain the scope section, the separator, and at least one
+	// administratively-defined segment.
+	if len(idSegments) < len(scopeSegments)+2 {
+		return trace.BadParameter(
+			"spec.spiffe.id %q must be prefixed with the scope %q, followed by the %q separator and at least one further segment",
+			id, scope, scopedSPIFFEIDSeparator,
+		)
+	}
+
+	// The scope section must strictly match the scope of origin segment-by-segment.
+	for i, seg := range scopeSegments {
+		if idSegments[i] != seg {
+			return trace.BadParameter(
+				"spec.spiffe.id %q must be prefixed with the scope %q", id, scope,
+			)
+		}
+	}
+
+	// The separator must immediately follow the scope section.
+	if idSegments[len(scopeSegments)] != scopedSPIFFEIDSeparator {
+		return trace.BadParameter(
+			"spec.spiffe.id %q must contain the %q separator segment immediately after the scope %q",
+			id, scopedSPIFFEIDSeparator, scope,
+		)
+	}
+
+	// The administratively-defined section must not contain the separator. This
+	// ensures a scoped SPIFFE ID contains exactly one separator segment so the
+	// boundary between sections is unambiguous.
+	for _, seg := range idSegments[len(scopeSegments)+1:] {
+		if seg == scopedSPIFFEIDSeparator {
+			return trace.BadParameter(
+				"spec.spiffe.id %q must not contain the %q separator segment in its administratively-defined section",
+				id, scopedSPIFFEIDSeparator,
+			)
+		}
+	}
+
+	return nil
+}
+
+// splitPathSegments splits a slash-delimited path (a scope or a SPIFFE ID path)
+// into its non-empty segments. A leading slash is expected; empty input or "/"
+// yields no segments.
+func splitPathSegments(path string) []string {
+	trimmed := strings.Trim(path, "/")
+	if trimmed == "" {
+		return nil
+	}
+	return strings.Split(trimmed, "/")
 }
 
 // WorkloadIdentitySortField identifies a field that WorkloadIdentities may be

--- a/lib/services/workload_identity.go
+++ b/lib/services/workload_identity.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"encoding/base32"
 	"iter"
+	"slices"
 	"strings"
 	"time"
 
@@ -200,46 +201,45 @@ func validateScopedSPIFFEID(scope, id string) error {
 	if !strings.HasPrefix(id, "/") {
 		return trace.BadParameter("spec.spiffe.id: must begin with a forward slash")
 	}
+	// Reject empty path segments (e.g. a trailing slash or "//"), which
+	// splitPathSegments would otherwise silently trim or mishandle.
+	if strings.HasSuffix(id, "/") || strings.Contains(id, "//") {
+		return trace.BadParameter("spec.spiffe.id %q must not contain empty path segments", id)
+	}
 
 	scopeSegments := splitPathSegments(scope)
 	idSegments := splitPathSegments(id)
 
-	// The ID must contain the scope section, the separator, and at least one
-	// administratively-defined segment.
-	if len(idSegments) < len(scopeSegments)+2 {
+	separatorIndex := slices.Index(idSegments, scopedSPIFFEIDSeparator)
+	if separatorIndex < 0 {
 		return trace.BadParameter(
-			"spec.spiffe.id %q must be prefixed with the scope %q, followed by the %q separator and at least one further segment",
+			"spec.spiffe.id %q is missing the %q separator segment that delimits the scope from the administratively-defined section",
+			id, scopedSPIFFEIDSeparator,
+		)
+	}
+
+	scopeSection := idSegments[:separatorIndex]
+	adminSection := idSegments[separatorIndex+1:]
+
+	if !slices.Equal(scopeSection, scopeSegments) {
+		return trace.BadParameter(
+			"spec.spiffe.id %q must be prefixed with the scope %q, immediately followed by the %q separator segment",
 			id, scope, scopedSPIFFEIDSeparator,
 		)
 	}
 
-	// The scope section must strictly match the scope of origin segment-by-segment.
-	for i, seg := range scopeSegments {
-		if idSegments[i] != seg {
-			return trace.BadParameter(
-				"spec.spiffe.id %q must be prefixed with the scope %q", id, scope,
-			)
-		}
-	}
-
-	// The separator must immediately follow the scope section.
-	if idSegments[len(scopeSegments)] != scopedSPIFFEIDSeparator {
+	if len(adminSection) == 0 {
 		return trace.BadParameter(
-			"spec.spiffe.id %q must contain the %q separator segment immediately after the scope %q",
-			id, scopedSPIFFEIDSeparator, scope,
+			"spec.spiffe.id %q must have at least one segment after the %q separator",
+			id, scopedSPIFFEIDSeparator,
 		)
 	}
 
-	// The administratively-defined section must not contain the separator. This
-	// ensures a scoped SPIFFE ID contains exactly one separator segment so the
-	// boundary between sections is unambiguous.
-	for _, seg := range idSegments[len(scopeSegments)+1:] {
-		if seg == scopedSPIFFEIDSeparator {
-			return trace.BadParameter(
-				"spec.spiffe.id %q must not contain the %q separator segment in its administratively-defined section",
-				id, scopedSPIFFEIDSeparator,
-			)
-		}
+	if slices.Contains(adminSection, scopedSPIFFEIDSeparator) {
+		return trace.BadParameter(
+			"spec.spiffe.id %q must not contain the %q separator segment in its administratively-defined section",
+			id, scopedSPIFFEIDSeparator,
+		)
 	}
 
 	return nil

--- a/lib/services/workload_identity_test.go
+++ b/lib/services/workload_identity_test.go
@@ -443,6 +443,12 @@ func TestValidateWorkloadIdentity(t *testing.T) {
 func TestValidateScopedSPIFFEID(t *testing.T) {
 	t.Parallel()
 
+	var errContains = func(contains string) require.ErrorAssertionFunc {
+		return func(t require.TestingT, err error, msgAndArgs ...any) {
+			require.ErrorContains(t, err, contains, msgAndArgs...)
+		}
+	}
+
 	tests := []struct {
 		name      string
 		scope     string
@@ -468,76 +474,70 @@ func TestValidateScopedSPIFFEID(t *testing.T) {
 			assertErr: require.NoError,
 		},
 		{
-			name:  "missing leading slash",
-			scope: "/security",
-			id:    "security/_/foo",
-			assertErr: func(t require.TestingT, err error, _ ...any) {
-				require.ErrorContains(t, err, "must begin with a forward slash")
-			},
+			name:      "missing leading slash",
+			scope:     "/security",
+			id:        "security/_/foo",
+			assertErr: errContains("must begin with a forward slash"),
 		},
 		{
-			name:  "id not prefixed with scope",
-			scope: "/security",
-			id:    "/other/_/foo",
-			assertErr: func(t require.TestingT, err error, _ ...any) {
-				require.ErrorContains(t, err, "must be prefixed with the scope")
-			},
+			name:      "id not prefixed with scope",
+			scope:     "/security",
+			id:        "/other/_/foo",
+			assertErr: errContains("must be prefixed with the scope"),
 		},
 		{
-			name:  "segment-aware prefix - not a string prefix match",
-			scope: "/foo",
-			id:    "/foo-buzz/_/svc",
-			assertErr: func(t require.TestingT, err error, _ ...any) {
-				require.ErrorContains(t, err, "must be prefixed with the scope")
-			},
+			name:      "segment-aware prefix - not a string prefix match",
+			scope:     "/foo",
+			id:        "/foo-buzz/_/svc",
+			assertErr: errContains("must be prefixed with the scope"),
 		},
 		{
-			name:  "scope section is ancestor of scope",
-			scope: "/foo/bar",
-			id:    "/foo/_/svc",
-			assertErr: func(t require.TestingT, err error, _ ...any) {
-				require.ErrorContains(t, err, "must be prefixed with the scope")
-			},
+			name:      "scope section is ancestor of scope",
+			scope:     "/foo/bar",
+			id:        "/foo/_/svc",
+			assertErr: errContains("must be prefixed with the scope"),
 		},
 		{
-			name:  "scope section is descendant of scope",
-			scope: "/foo/bar",
-			id:    "/foo/bar/baz/_/svc",
-			assertErr: func(t require.TestingT, err error, _ ...any) {
-				require.ErrorContains(t, err, "separator segment immediately after the scope")
-			},
+			name:      "scope section is descendant of scope",
+			scope:     "/foo/bar",
+			id:        "/foo/bar/baz/_/svc",
+			assertErr: errContains("must be prefixed with the scope"),
 		},
 		{
-			name:  "missing separator - too short",
-			scope: "/security",
-			id:    "/security/foo",
-			assertErr: func(t require.TestingT, err error, _ ...any) {
-				require.ErrorContains(t, err, "followed by the")
-			},
+			name:      "missing separator - too short",
+			scope:     "/security",
+			id:        "/security/foo",
+			assertErr: errContains("is missing the"),
 		},
 		{
-			name:  "missing separator - long enough",
-			scope: "/security",
-			id:    "/security/foo/bar",
-			assertErr: func(t require.TestingT, err error, _ ...any) {
-				require.ErrorContains(t, err, "separator segment immediately after the scope")
-			},
+			name:      "missing separator - long enough",
+			scope:     "/security",
+			id:        "/security/foo/bar",
+			assertErr: errContains("is missing the"),
 		},
 		{
-			name:  "separator is last segment - no admin section",
-			scope: "/security/eu",
-			id:    "/security/eu/_",
-			assertErr: func(t require.TestingT, err error, _ ...any) {
-				require.ErrorContains(t, err, "followed by the")
-			},
+			name:      "separator is last segment - no admin section",
+			scope:     "/security/eu",
+			id:        "/security/eu/_",
+			assertErr: errContains("at least one segment after"),
 		},
 		{
-			name:  "separator in admin section",
-			scope: "/security/eu",
-			id:    "/security/eu/_/k8s/_/probes/liveness",
-			assertErr: func(t require.TestingT, err error, _ ...any) {
-				require.ErrorContains(t, err, "administratively-defined section")
-			},
+			name:      "separator in admin section",
+			scope:     "/security/eu",
+			id:        "/security/eu/_/k8s/_/probes/liveness",
+			assertErr: errContains("administratively-defined section"),
+		},
+		{
+			name:      "trailing slash",
+			scope:     "/security",
+			id:        "/security/_/foo/",
+			assertErr: errContains("empty path segments"),
+		},
+		{
+			name:      "empty segment in admin section",
+			scope:     "/security",
+			id:        "/security/_/foo//bar",
+			assertErr: errContains("empty path segments"),
 		},
 		// Templated SPIFFE IDs are validated in their unrendered form at
 		// create/update time; the rendered form is re-validated at issuance.
@@ -555,20 +555,16 @@ func TestValidateScopedSPIFFEID(t *testing.T) {
 			assertErr: require.NoError,
 		},
 		{
-			name:  "template cannot substitute for a scope segment",
-			scope: "/security",
-			id:    "/{{ user.name }}/_/svc",
-			assertErr: func(t require.TestingT, err error, _ ...any) {
-				require.ErrorContains(t, err, "must be prefixed with the scope")
-			},
+			name:      "template cannot substitute for a scope segment",
+			scope:     "/security",
+			id:        "/{{ user.name }}/_/svc",
+			assertErr: errContains("must be prefixed with the scope"),
 		},
 		{
-			name:  "template cannot substitute for the separator",
-			scope: "/security",
-			id:    "/security/{{ user.name }}/svc",
-			assertErr: func(t require.TestingT, err error, _ ...any) {
-				require.ErrorContains(t, err, "separator segment immediately after the scope")
-			},
+			name:      "template cannot substitute for the separator",
+			scope:     "/security",
+			id:        "/security/{{ user.name }}/svc",
+			assertErr: errContains("is missing the"),
 		},
 	}
 	for _, tt := range tests {

--- a/lib/services/workload_identity_test.go
+++ b/lib/services/workload_identity_test.go
@@ -345,12 +345,235 @@ func TestValidateWorkloadIdentity(t *testing.T) {
 			}.Build(),
 			requireErr: errContains(`spec.spiffe.jwt.maximum_ttl: must be less than 24h0m0s`),
 		},
+		{
+			name: "scoped success",
+			in: workloadidentityv1pb.WorkloadIdentity_builder{
+				Kind:    types.KindWorkloadIdentity,
+				Version: types.V1,
+				Metadata: headerv1.Metadata_builder{
+					Name: "example",
+				}.Build(),
+				Scope: "/security/eu",
+				Spec: workloadidentityv1pb.WorkloadIdentitySpec_builder{
+					Spiffe: workloadidentityv1pb.WorkloadIdentitySPIFFE_builder{
+						Id: "/security/eu/_/k8s/cluster-a",
+					}.Build(),
+				}.Build(),
+			}.Build(),
+			requireErr: require.NoError,
+		},
+		{
+			name: "scoped success with templated spiffe id",
+			in: workloadidentityv1pb.WorkloadIdentity_builder{
+				Kind:    types.KindWorkloadIdentity,
+				Version: types.V1,
+				Metadata: headerv1.Metadata_builder{
+					Name: "example",
+				}.Build(),
+				Scope: "/security/eu",
+				Spec: workloadidentityv1pb.WorkloadIdentitySpec_builder{
+					Spiffe: workloadidentityv1pb.WorkloadIdentitySPIFFE_builder{
+						Id: "/security/eu/_/k8s/{{ workload.kubernetes.namespace }}/{{ workload.kubernetes.pod_name }}",
+					}.Build(),
+				}.Build(),
+			}.Build(),
+			requireErr: require.NoError,
+		},
+		{
+			name: "scoped templated spiffe id cannot escape scope prefix",
+			in: workloadidentityv1pb.WorkloadIdentity_builder{
+				Kind:    types.KindWorkloadIdentity,
+				Version: types.V1,
+				Metadata: headerv1.Metadata_builder{
+					Name: "example",
+				}.Build(),
+				Scope: "/security",
+				Spec: workloadidentityv1pb.WorkloadIdentitySpec_builder{
+					Spiffe: workloadidentityv1pb.WorkloadIdentitySPIFFE_builder{
+						Id: "/{{ user.name }}/_/svc",
+					}.Build(),
+				}.Build(),
+			}.Build(),
+			requireErr: errContains("must be prefixed with the scope"),
+		},
+		{
+			name: "scoped spiffe id not prefixed with scope",
+			in: workloadidentityv1pb.WorkloadIdentity_builder{
+				Kind:    types.KindWorkloadIdentity,
+				Version: types.V1,
+				Metadata: headerv1.Metadata_builder{
+					Name: "example",
+				}.Build(),
+				Scope: "/security",
+				Spec: workloadidentityv1pb.WorkloadIdentitySpec_builder{
+					Spiffe: workloadidentityv1pb.WorkloadIdentitySPIFFE_builder{
+						Id: "/other/_/svc",
+					}.Build(),
+				}.Build(),
+			}.Build(),
+			requireErr: errContains("must be prefixed with the scope"),
+		},
+		{
+			name: "scoped root scope rejected",
+			in: workloadidentityv1pb.WorkloadIdentity_builder{
+				Kind:    types.KindWorkloadIdentity,
+				Version: types.V1,
+				Metadata: headerv1.Metadata_builder{
+					Name: "example",
+				}.Build(),
+				Scope: "/",
+				Spec: workloadidentityv1pb.WorkloadIdentitySpec_builder{
+					Spiffe: workloadidentityv1pb.WorkloadIdentitySPIFFE_builder{
+						Id: "/_/svc",
+					}.Build(),
+				}.Build(),
+			}.Build(),
+			requireErr: errContains("must not be the root scope"),
+		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			err := ValidateWorkloadIdentity(tc.in)
 			tc.requireErr(t, err)
+		})
+	}
+}
+
+func TestValidateScopedSPIFFEID(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		scope     string
+		id        string
+		assertErr require.ErrorAssertionFunc
+	}{
+		{
+			name:      "valid single segment scope",
+			scope:     "/security",
+			id:        "/security/_/foo-svc",
+			assertErr: require.NoError,
+		},
+		{
+			name:      "valid multi segment scope",
+			scope:     "/security/eu",
+			id:        "/security/eu/_/k8s/cluster-a/default/default",
+			assertErr: require.NoError,
+		},
+		{
+			name:      "valid multi segment admin section",
+			scope:     "/security",
+			id:        "/security/_/k8s/cluster-a",
+			assertErr: require.NoError,
+		},
+		{
+			name:  "missing leading slash",
+			scope: "/security",
+			id:    "security/_/foo",
+			assertErr: func(t require.TestingT, err error, _ ...any) {
+				require.ErrorContains(t, err, "must begin with a forward slash")
+			},
+		},
+		{
+			name:  "id not prefixed with scope",
+			scope: "/security",
+			id:    "/other/_/foo",
+			assertErr: func(t require.TestingT, err error, _ ...any) {
+				require.ErrorContains(t, err, "must be prefixed with the scope")
+			},
+		},
+		{
+			name:  "segment-aware prefix - not a string prefix match",
+			scope: "/foo",
+			id:    "/foo-buzz/_/svc",
+			assertErr: func(t require.TestingT, err error, _ ...any) {
+				require.ErrorContains(t, err, "must be prefixed with the scope")
+			},
+		},
+		{
+			name:  "scope section is ancestor of scope",
+			scope: "/foo/bar",
+			id:    "/foo/_/svc",
+			assertErr: func(t require.TestingT, err error, _ ...any) {
+				require.ErrorContains(t, err, "must be prefixed with the scope")
+			},
+		},
+		{
+			name:  "scope section is descendant of scope",
+			scope: "/foo/bar",
+			id:    "/foo/bar/baz/_/svc",
+			assertErr: func(t require.TestingT, err error, _ ...any) {
+				require.ErrorContains(t, err, "separator segment immediately after the scope")
+			},
+		},
+		{
+			name:  "missing separator - too short",
+			scope: "/security",
+			id:    "/security/foo",
+			assertErr: func(t require.TestingT, err error, _ ...any) {
+				require.ErrorContains(t, err, "followed by the")
+			},
+		},
+		{
+			name:  "missing separator - long enough",
+			scope: "/security",
+			id:    "/security/foo/bar",
+			assertErr: func(t require.TestingT, err error, _ ...any) {
+				require.ErrorContains(t, err, "separator segment immediately after the scope")
+			},
+		},
+		{
+			name:  "separator is last segment - no admin section",
+			scope: "/security/eu",
+			id:    "/security/eu/_",
+			assertErr: func(t require.TestingT, err error, _ ...any) {
+				require.ErrorContains(t, err, "followed by the")
+			},
+		},
+		{
+			name:  "separator in admin section",
+			scope: "/security/eu",
+			id:    "/security/eu/_/k8s/_/probes/liveness",
+			assertErr: func(t require.TestingT, err error, _ ...any) {
+				require.ErrorContains(t, err, "administratively-defined section")
+			},
+		},
+		// Templated SPIFFE IDs are validated in their unrendered form at
+		// create/update time; the rendered form is re-validated at issuance.
+		// Templates are only permitted in the administratively-defined section.
+		{
+			name:      "template in admin section",
+			scope:     "/security/eu",
+			id:        "/security/eu/_/k8s/{{ workload.kubernetes.namespace }}/{{ workload.kubernetes.pod_name }}",
+			assertErr: require.NoError,
+		},
+		{
+			name:      "template as sole admin segment",
+			scope:     "/security",
+			id:        "/security/_/{{ workload.kubernetes.pod_name }}",
+			assertErr: require.NoError,
+		},
+		{
+			name:  "template cannot substitute for a scope segment",
+			scope: "/security",
+			id:    "/{{ user.name }}/_/svc",
+			assertErr: func(t require.TestingT, err error, _ ...any) {
+				require.ErrorContains(t, err, "must be prefixed with the scope")
+			},
+		},
+		{
+			name:  "template cannot substitute for the separator",
+			scope: "/security",
+			id:    "/security/{{ user.name }}/svc",
+			assertErr: func(t require.TestingT, err error, _ ...any) {
+				require.ErrorContains(t, err, "separator segment immediately after the scope")
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.assertErr(t, validateScopedSPIFFEID(tt.scope, tt.id))
 		})
 	}
 }


### PR DESCRIPTION
Updates https://github.com/gravitational/teleport/issues/66349

PR 2 of 5

Depends on https://github.com/gravitational/teleport/pull/67889

Introduces the proto changes to the WorkloadIdentity resource and the accompanying validation suite. This PR does not adjust the services - so - it is technically left in a weird state where scoped RBAC is not yet enforced but it is possible to create scoped Workload Identities. I will not backport this PR without PR 3 which updates the RPCs.

## Manual Test Plan
### Test Environment

Local cluster

### Test Cases

- [x] Regression: Create and fetch unscoped workload identity
- [x] Create and fetch scoped workload identity.
