### PR TITLE
[v17] Add `mobile/.gitignore`

### DIFF
--- a/mobile/.gitignore
+++ b/mobile/.gitignore
@@ -1,0 +1,18 @@
+## User settings
+xcuserdata
+
+## Obj-C/Swift specific
+*.hmap
+
+## App packaging
+*.ipa
+*.dSYM.zip
+*.dSYM
+
+## Playgrounds
+timeline.xctimeline
+playground.xcworkspace
+
+.build/
+
+**/gen/*.xcframework/


### PR DESCRIPTION
Just a copy of `mobile/.gitignore` from #67750 to avoid leaving dirty files when you do `make mobile/Verify/Verify/gen/Enroll.xcframework` and then switch to a release branch.