### PR TITLE
tsh: add app logins command.

### DIFF
--- a/docs/pages/enroll-resources/application-access/cloud-apis/aws-console-roles-anywhere.mdx
+++ b/docs/pages/enroll-resources/application-access/cloud-apis/aws-console-roles-anywhere.mdx
@@ -470,6 +470,18 @@ Logged into AWS app "example-read-only-access".
     AWS_PROFILE=example-read-only-access aws s3 ls
 ```
 
+To list the AWS roles that you can provide to the `--aws-role` flag, run the following command:
+`tsh apps logins [--format=text|json|yaml] <app>`.
+
+```code
+$ tsh apps logins aws-console
+Available AWS roles:
+Role Name             Role ARN
+--------------------- ----------------------------------------------------
+ExampleAdminAccess    arn:aws:iam::123456789012:role/ExampleReadOnlyAccess
+ExampleReadOnlyAccess arn:aws:iam::123456789012:role/ExampleAdminAccess
+```
+
 Alternatively, if the `--aws-role` is not provided, the aws role will be prompted interactively.
 
 ```code

--- a/docs/pages/enroll-resources/application-access/cloud-apis/aws-console.mdx
+++ b/docs/pages/enroll-resources/application-access/cloud-apis/aws-console.mdx
@@ -34,7 +34,7 @@ assume one or more target IAM roles. Teleport users access the AWS Management
 Console and APIs through the Teleport Web UI and `tsh`. When a user visits the
 AWS Management Console or executes a command with an AWS client application, the
 Teleport Application Service checks the user's RBAC permissions and, if they are
-authorized, forwards the user's requests to AWS. 
+authorized, forwards the user's requests to AWS.
 
 ## Prerequisites
 
@@ -98,7 +98,7 @@ Application Service to assume other IAM roles in order to proxy user traffic to
 AWS APIs.
 
 1. Define a trust policy to enable the Teleport Application Service to assume
-   the role you will create. 
+   the role you will create.
 
    <Tabs>
    <TabItem label="EC2">
@@ -110,7 +110,7 @@ AWS APIs.
      "Version": "2012-10-17",
      "Statement": [
        {
-         "Effect": "Allow", 
+         "Effect": "Allow",
          "Principal": {
            "Service": "ec2.amazonaws.com"
          },
@@ -126,18 +126,18 @@ AWS APIs.
    Retrieve your OIDC issuer ID, assigning <Var name="cluster-name" /> to the name
    of your EKS cluster and <Var name="eks-region" /> to the AWS region where your
    EKS cluster is running:
-   
+
    ```code
    $ aws --region=<Var name="eks-region" /> eks describe-cluster --name <Var name="cluster-name"/> --query "cluster.identity.oidc.issuer" --output text | grep -Eo "[A-Z0-9]+$"
 
    AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
    ```
-   
+
    Create a file called `app-service-tp.json` with the following content,
    assigning <Var name="OIDC_ISSUER" /> to the issuer string you retrieved and
    <Var name="EKS_ACCOUNT" /> to the ID of the AWS account that belongs to your
    EKS cluster:
-   
+
    ```json
    {
        "Version": "2012-10-17",
@@ -229,10 +229,10 @@ this role when proxying requests:
            "AWS": "arn:aws:iam::<Var name="AWS_ACCESS_ACCOUNT" />:role/TeleportAWSAccess"
          },
          "Action": "sts:AssumeRole",
-         "Condition": { 
-           "StringEquals": { 
-             "sts:ExternalId": "<Var name="EXTERNAL_ID" />" 
-           } 
+         "Condition": {
+           "StringEquals": {
+             "sts:ExternalId": "<Var name="EXTERNAL_ID" />"
+           }
          }
        }
      ]
@@ -295,7 +295,7 @@ this role when proxying requests:
 ### Associate a role with the Teleport Application Service
 
 Now that you have created a role for the Teleport Application Service, associate
-the role with the service. 
+the role with the service.
 
 <Tabs>
 <TabItem label="EC2">
@@ -322,7 +322,7 @@ Service.
    Application Service.
 
 1. Run the following command to associate the new instance profile with your
-   instance, assigning <Var name="INSTANCE_ID" /> to your instance ID and 
+   instance, assigning <Var name="INSTANCE_ID" /> to your instance ID and
    <Var name="AWS_REGION" /> to your AWS region:
 
    ```code
@@ -366,7 +366,7 @@ In this step, you will define a Teleport role that confers access to the
        aws_role_arns:
        - arn:aws:iam::<Var name="AWS_ACCOUNT" />:role/ExampleReadOnlyAccess
    ```
-   
+
    The Teleport role called `aws-ro-access` enables users to visit the AWS
    Management Console or make requests to AWS APIs with the `ExampleReadOnlyAccess`
    role.
@@ -400,7 +400,7 @@ $ tctl tokens add --type=app --ttl=1h --format=text
 <TabItem label="EC2">
 
 On the host where you will install the Teleport Application Service, create a
-file called `/tmp/token` that consists only of your token, assigning 
+file called `/tmp/token` that consists only of your token, assigning
 <Var name="join-token" /> to the value of the token:
 
 ```code
@@ -447,7 +447,7 @@ Application Service:
    The `app_service` field configures the Teleport Application Service. Each
    item within `app_service.apps` is an application configuration. If self-hosting
    the Teleport cluster, you must have [DNS and a TLS certificate](../getting-started.mdx#subdomains-and-applications)
-   configured for the application domain name associated with the Teleport 
+   configured for the application domain name associated with the Teleport
    Proxy Service, e.g., `awsconsole.teleport.example.com`.
 
 </TabItem>
@@ -594,13 +594,13 @@ to AWS, users can access AWS resources through Teleport.
    ```code
    $ tsh apps login --aws-role ExampleReadOnlyAccess awsconsole
    Logged into AWS app "awsconsole".
-   
+
    Your IAM role:
      arn:aws:iam::000000000000:role/ExampleReadOnlyAccess
-   
+
    Example AWS CLI command:
      tsh aws s3 ls
-   
+
    Or start a local proxy:
      tsh proxy aws --app awsconsole
    ```
@@ -609,6 +609,18 @@ to AWS, users can access AWS resources through Teleport.
    accessing AWS APIs. You can either provide a role name like `--aws-role
    ExampleReadOnlyAccess` or a full role ARN like
    `arn:aws:iam::0000000000:role/ExampleReadOnlyAccess`.
+
+   To list the AWS roles that you can provide to the `--aws-role` flag, run the following command:
+   `tsh apps logins [--format=text|json|yaml] <app>`.
+
+   ```code
+   $ tsh apps logins aws-console
+   Available AWS roles:
+   Role Name             Role ARN
+   --------------------- ----------------------------------------------------
+   ExampleAdminAccess    arn:aws:iam::123456789012:role/ExampleReadOnlyAccess
+   ExampleReadOnlyAccess arn:aws:iam::123456789012:role/ExampleAdminAccess
+   ```
 
    Alternatively, if the `--aws-role` is not provided, the aws role will be
    prompted interactively.
@@ -656,7 +668,7 @@ to AWS, users can access AWS resources through Teleport.
    ```code
    $ tsh proxy aws -p 23456
    Started AWS proxy on http://127.0.0.1:23456.
-   
+
    Use the following credentials and HTTPS proxy setting to connect to the proxy:
      export AWS_ACCESS_KEY_ID=(=aws.aws_access_key=)
      export AWS_SECRET_ACCESS_KEY=(=aws.aws_secret_access_key=)
@@ -676,14 +688,14 @@ to AWS, users can access AWS resources through Teleport.
    >>> ec2 = boto3.resource('ec2')
    >>> for instance in ec2.instances.all():
    ...   print(instance.id)
-   ...   
+   ...
    ```
 
    It is important to check how AWS credentials and HTTPS proxy setting can be
    configured for your application. For example, command line tools like
    `terraform` and `eksctl` support setting AWS credentials and the HTTPS proxy
    using environment variables, as shown above.
-   
+
    However, some AWS SDKs may require extra environment variables (e.g.
    `AWS_SDK_LOAD_CONFIG=true` for AWS SDK for Go v2) or require configuring the
    HTTPS proxy through code (e.g. AWS SDK for JavaScript).
@@ -712,7 +724,7 @@ Read this section if you run into issues while following this guide.
 
 When visiting the AWS Management Console from the Teleport Web UI, you may see
 an `InternalServer Error` message or other connection issues instead of the
-AWS Management Console. 
+AWS Management Console.
 
 If this happens, check the Teleport Application Service logs:
 
@@ -755,7 +767,7 @@ AccessDenied: User: arn:aws:sts::000000000000:assumed-role/ROLE_NAME is not auth
 ```
 
 The `AccessDenied` message contains the principal assumed by the Teleport
-Application Service in order to execute the `sts:AssumeRole` action. 
+Application Service in order to execute the `sts:AssumeRole` action.
 
 If the principal is the `TeleportAWSAccess` role, check the trust policy of the
 `ExampleReadOnlyAccess` role to ensure that it contains that principal.

--- a/docs/pages/reference/cli/tsh.mdx
+++ b/docs/pages/reference/cli/tsh.mdx
@@ -122,6 +122,28 @@ Arguments:
 |---|---|---|
 |app|*no default* (required)|App name to retrieve credentials for. Can be obtained from `tsh apps ls` output.|
 
+## tsh apps logins
+
+List available logins for a Cloud console application.
+
+Usage:
+
+```code
+$ tsh apps logins [<flags>] <app>
+```
+
+Flags:
+
+|Flag|Default|Description|
+|---|---|---|
+|`-f`, `--format`|`text` (one of: `text`, `json`, `yaml`)|Format output (text, json, yaml).|
+
+Arguments:
+
+|Argument|Default|Description|
+|---|---|---|
+|app|*no default* (required)|App name to list logins for. Currently only AWS is supported.|
+
 ## tsh apps logout
 
 Remove app certificate.

--- a/lib/utils/aws/aws.go
+++ b/lib/utils/aws/aws.go
@@ -335,16 +335,16 @@ func FilterAWSRoles(arns []string, accountID string) (result Roles) {
 // Role describes an AWS IAM role for AWS console access.
 type Role struct {
 	// Name is the full role name with the entire path.
-	Name string `json:"name"`
+	Name string `yaml:"name" json:"name"`
 	// Display is the role display name.
-	Display string `json:"display"`
+	Display string `yaml:"display" json:"display"`
 	// ARN is the full role ARN.
-	ARN string `json:"arn"`
+	ARN string `yaml:"arn" json:"arn"`
 	// AccountID is the AWS Account ID this role refers to.
-	AccountID string `json:"accountId"`
+	AccountID string `yaml:"accountId" json:"accountId"`
 	// RequiresRequest indicates whether this role requires an access request
 	// to be used.
-	RequiresRequest bool `json:"requiresRequest,omitempty"`
+	RequiresRequest bool `yaml:"requiresRequest,omitempty" json:"requiresRequest,omitempty"`
 }
 
 // Roles is a slice of roles.

--- a/tool/tsh/common/app.go
+++ b/tool/tsh/common/app.go
@@ -750,6 +750,7 @@ func (a *appInfo) pickCloudAppLogin(cf *CLIConf, logins []string) error {
 		if err != nil {
 			return trace.Wrap(err)
 		}
+		logger.DebugContext(cf.Context, "Retrieved AWS role ARN", "aws_role_arn", awsRoleARN)
 		a.AWSRoleARN = awsRoleARN
 
 	case a.app.IsAzureCloud():
@@ -872,4 +873,48 @@ func tlscaRouteToAppToProto(route tlsca.RouteToApp) proto.RouteToApp {
 		GCPServiceAccount:               route.GCPServiceAccount,
 		URI:                             route.URI,
 	}
+}
+
+// onAppLogins implements "tsh app logins" command for listing AWS roles.
+func onAppLogins(cf *CLIConf) error {
+	tc, err := makeClient(cf)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	var (
+		app    types.Application
+		logins []string
+	)
+	if err := client.RetryWithRelogin(cf.Context, tc, func() error {
+		clusterClient, err := tc.ConnectToCluster(cf.Context)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+		defer clusterClient.Close()
+
+		app, logins, err = getApp(cf.Context, clusterClient.AuthClient, cf.AppName)
+		return trace.Wrap(err)
+	}); err != nil {
+		return trace.Wrap(err)
+	}
+
+	err = printCloudAppLogins(cf, app, logins)
+	return trace.Wrap(err)
+}
+
+// printCloudAppLogins prints the available logins for cloud apps based on provided CLI
+// flags and/or available logins of the Teleport user.
+func printCloudAppLogins(cf *CLIConf, app types.Application, logins []string) error {
+	switch {
+	case app.IsAWSConsole():
+		if err := printAWSAppLogins(cf, app, logins); err != nil {
+			return trace.Wrap(err)
+		}
+
+	default:
+		return trace.BadParameter("only AWS apps are supported at the moment")
+	}
+
+	return nil
 }

--- a/tool/tsh/common/app_aws.go
+++ b/tool/tsh/common/app_aws.go
@@ -31,13 +31,16 @@ import (
 	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/google/uuid"
 	"github.com/gravitational/trace"
+	"gopkg.in/yaml.v3"
 
+	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/asciitable"
 	"github.com/gravitational/teleport/lib/client"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/srv/alpnproxy"
 	"github.com/gravitational/teleport/lib/tlsca"
+	"github.com/gravitational/teleport/lib/utils"
 	awsutils "github.com/gravitational/teleport/lib/utils/aws"
 	logutils "github.com/gravitational/teleport/lib/utils/log"
 	"github.com/gravitational/teleport/lib/utils/prompt"
@@ -280,6 +283,80 @@ func getARNFromFlags(cf *CLIConf, app types.Application, logins []string) (strin
 		printAWSRoles(cf.Stdout(), rolesMatched)
 		return "", trace.BadParameter("provided role name %q is ambiguous, please specify full role ARN", cf.AWSRole)
 	}
+}
+
+// awsRole is a mirror of awsutils.Role for maintaining the schema consistency (snake case for
+// JSON and YAML keys).
+type awsRole struct {
+	Name            string `yaml:"name" json:"name"`
+	Display         string `yaml:"display" json:"display"`
+	AccountID       string `yaml:"account_id" json:"account_id"`
+	ARN             string `yaml:"arn" json:"arn"`
+	RequiresRequest bool   `yaml:"requires_request,omitempty" json:"requires_request,omitempty"`
+}
+
+type cloudAppLogins struct {
+	AWSRoles []awsRole `yaml:"aws_roles,omitempty" json:"aws_roles,omitempty"`
+}
+
+// cloudAppInfo is a json/yaml schema for the "apps logins" command.
+type cloudAppInfo struct {
+	AppName string         `yaml:"app_name" json:"app_name"`
+	Logins  cloudAppLogins `yaml:"logins" json:"logins"`
+}
+
+func serializeAWSLogins(app types.Application, roles awsutils.Roles) cloudAppInfo {
+	roles.Sort()
+
+	awsRoles := make([]awsRole, 0, len(roles))
+	for _, role := range roles {
+		awsRoles = append(awsRoles, awsRole{
+			Name:            role.Name,
+			Display:         role.Display,
+			AccountID:       role.AccountID,
+			ARN:             role.ARN,
+			RequiresRequest: role.RequiresRequest,
+		})
+	}
+
+	return cloudAppInfo{
+		AppName: app.GetName(),
+		Logins: cloudAppLogins{
+			AWSRoles: awsRoles,
+		},
+	}
+}
+
+func printAWSAppLogins(cf *CLIConf, app types.Application, logins []string) error {
+	// Filter AWS roles by AWS account ID.
+	roles := awsutils.FilterAWSRoles(logins, app.GetAWSAccountID())
+
+	if len(roles) == 0 {
+		return trace.NotFound("there are no roles configured for the AWS app %q", app.GetName())
+	}
+
+	// Output based on format.
+	switch cf.Format {
+	case teleport.Text, "":
+		// Use existing printAWSRoles function for table output.
+		printAWSRoles(cf.Stdout(), roles)
+	case teleport.JSON:
+		out, err := utils.FastMarshalIndent(serializeAWSLogins(app, roles), "", "  ")
+		if err != nil {
+			return trace.Wrap(err)
+		}
+		fmt.Fprintln(cf.Stdout(), string(out))
+	case teleport.YAML:
+		out, err := yaml.Marshal(serializeAWSLogins(app, roles))
+		if err != nil {
+			return trace.Wrap(err)
+		}
+		fmt.Fprint(cf.Stdout(), string(out))
+	default:
+		return trace.BadParameter("unsupported format %q", cf.Format)
+	}
+
+	return nil
 }
 
 // getARNFromRoles fetches the available AWS ARNs logins for given app.

--- a/tool/tsh/common/app_aws_test.go
+++ b/tool/tsh/common/app_aws_test.go
@@ -22,6 +22,7 @@ import (
 	"bytes"
 	"context"
 	"crypto/tls"
+	"encoding/json"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -29,8 +30,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/gravitational/trace"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
 
 	"github.com/gravitational/teleport/api/constants"
 	"github.com/gravitational/teleport/api/types"
@@ -677,4 +680,204 @@ func SetupTrustedCluster(ctx context.Context, t *testing.T, rootServer, leafServ
 
 		require.Equal(t, 1, rts.GetTunnelsCount())
 	}, time.Second*10, time.Second)
+}
+
+// TestAppLogins tests the "tsh app logins" command.
+func TestAppLogins(t *testing.T) {
+	ctx := t.Context()
+
+	tmpHomePath := t.TempDir()
+	connector := mockConnector(t)
+
+	// Create user with multiple AWS roles
+	userARNs := []string{
+		"arn:aws:iam::123456789012:role/admin-role",
+		"arn:aws:iam::123456789012:role/readonly-role",
+	}
+	user, err := types.NewUser("alice@example.com")
+	require.NoError(t, err)
+
+	awsRole, err := types.NewRole("aws", types.RoleSpecV6{
+		Allow: types.RoleConditions{
+			AppLabels:   types.Labels{"env": apiutils.Strings{"dev"}},
+			AWSRoleARNs: userARNs,
+		},
+	})
+	require.NoError(t, err)
+
+	user.SetRoles([]string{"access", awsRole.GetName()})
+
+	// Create Teleport server with AWS Console app
+	authProcess, err := testserver.NewTeleportProcess(
+		t.TempDir(),
+		testserver.WithBootstrap(connector, user, awsRole),
+		testserver.WithConfig(func(cfg *servicecfg.Config) {
+			cfg.Auth.NetworkingConfig.SetProxyListenerMode(types.ProxyListenerMode_Multiplex)
+			cfg.Apps.Enabled = true
+			cfg.Apps.Apps = []servicecfg.App{
+				{
+					Name: "aws-console",
+					URI:  constants.AWSConsoleURL,
+					StaticLabels: map[string]string{
+						"env": "dev",
+					},
+				},
+				{
+					Name: "aws-console-special",
+					URI:  constants.AWSConsoleURL,
+					StaticLabels: map[string]string{
+						"env": "special",
+					},
+				},
+				{
+					Name: "not-aws-app",
+					URI:  "http://localhost:8080",
+				},
+			}
+		}),
+	)
+
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, authProcess.Close())
+		require.NoError(t, authProcess.Wait())
+	})
+
+	authServer := authProcess.GetAuthServer()
+	require.NotNil(t, authServer)
+
+	proxyAddr, err := authProcess.ProxyWebAddr()
+	require.NoError(t, err)
+
+	// Log into Teleport cluster
+	err = Run(ctx, []string{
+		"login", "--insecure", "--debug", "--proxy", proxyAddr.String(),
+	}, setHomePath(tmpHomePath), setMockSSOLogin(authServer, user, connector.GetName()))
+	require.NoError(t, err)
+
+	t.Run("show logins for AWS app (text format)", func(t *testing.T) {
+		commandOutput := new(bytes.Buffer)
+		err := Run(
+			ctx,
+			[]string{"app", "logins", "aws-console"},
+			setCopyStdout(commandOutput),
+			setHomePath(tmpHomePath),
+		)
+		require.NoError(t, err)
+
+		output := commandOutput.String()
+		require.Contains(t, output, "Available AWS roles:")
+		require.Contains(t, output, "admin-role")
+		require.Contains(t, output, "readonly-role")
+		require.Contains(t, output, "arn:aws:iam::123456789012:role/admin-role")
+		require.Contains(t, output, "arn:aws:iam::123456789012:role/readonly-role")
+	})
+
+	t.Run("show logins for AWS app (JSON format)", func(t *testing.T) {
+		commandOutput := new(bytes.Buffer)
+		err := Run(
+			ctx,
+			[]string{"app", "logins", "--format", "json", "aws-console"},
+			setCopyStdout(commandOutput),
+			setHomePath(tmpHomePath),
+		)
+		require.NoError(t, err)
+
+		want := map[string]any{
+			"app_name": "aws-console",
+			"logins": map[string][]map[string]string{
+				"aws_roles": {
+					{
+						"name":       "admin-role",
+						"display":    "admin-role",
+						"arn":        "arn:aws:iam::123456789012:role/admin-role",
+						"account_id": "123456789012",
+					},
+					{
+						"name":       "readonly-role",
+						"display":    "readonly-role",
+						"arn":        "arn:aws:iam::123456789012:role/readonly-role",
+						"account_id": "123456789012",
+					},
+				},
+			},
+		}
+
+		wantBytes, err := json.Marshal(want)
+		require.NoError(t, err)
+		require.JSONEq(t, string(wantBytes), commandOutput.String())
+	})
+
+	t.Run("show logins for AWS app (YAML format)", func(t *testing.T) {
+		commandOutput := new(bytes.Buffer)
+		err := Run(
+			ctx,
+			[]string{"app", "logins", "--format", "yaml", "aws-console"},
+			setCopyStdout(commandOutput),
+			setHomePath(tmpHomePath),
+		)
+		require.NoError(t, err)
+
+		want := map[string]any{
+			"app_name": "aws-console",
+			"logins": map[string][]map[string]string{
+				"aws_roles": {
+					{
+						"name":       "admin-role",
+						"display":    "admin-role",
+						"arn":        "arn:aws:iam::123456789012:role/admin-role",
+						"account_id": "123456789012",
+					},
+					{
+						"name":       "readonly-role",
+						"display":    "readonly-role",
+						"arn":        "arn:aws:iam::123456789012:role/readonly-role",
+						"account_id": "123456789012",
+					},
+				},
+			},
+		}
+
+		wantBytes, err := yaml.Marshal(want)
+		require.NoError(t, err)
+		require.YAMLEq(t, string(wantBytes), commandOutput.String())
+	})
+
+	t.Run("no AWS roles for non-AWS app", func(t *testing.T) {
+		commandOutput := new(bytes.Buffer)
+		err := Run(
+			ctx,
+			[]string{"app", "logins", "not-aws-app"},
+			setCopyStdout(commandOutput),
+			setHomePath(tmpHomePath),
+		)
+		require.Error(t, err)
+		require.ErrorContains(t, err, "only AWS apps are supported at the moment")
+		require.NotContains(t, commandOutput.String(), "Available AWS roles:")
+	})
+
+	t.Run("no AWS roles for AWS app", func(t *testing.T) {
+		commandOutput := new(bytes.Buffer)
+		err := Run(
+			ctx,
+			[]string{"app", "logins", "aws-console-special"},
+			setCopyStdout(commandOutput),
+			setHomePath(tmpHomePath),
+		)
+		require.Error(t, err)
+		require.ErrorContains(t, err, "there are no roles configured for the AWS app \"aws-console-special\"")
+		require.True(t, trace.IsNotFound(err))
+	})
+
+	t.Run("error for non-existent app", func(t *testing.T) {
+		commandOutput := new(bytes.Buffer)
+		err := Run(
+			ctx,
+			[]string{"app", "logins", "non-existent-app"},
+			setCopyStdout(commandOutput),
+			setHomePath(tmpHomePath),
+		)
+		require.Error(t, err)
+		require.True(t, trace.IsNotFound(err))
+	})
 }

--- a/tool/tsh/common/tsh.go
+++ b/tool/tsh/common/tsh.go
@@ -1106,6 +1106,9 @@ func Run(ctx context.Context, args []string, opts ...CliOption) error {
 	appConfig.Flag("format", fmt.Sprintf("Optional print format, one of: %q to print app address, %q to print CA cert path, %q to print cert path, %q print key path, %q to print example curl command, %q or %q to print everything as JSON or YAML.",
 		appFormatURI, appFormatCA, appFormatCert, appFormatKey, appFormatCURL, appFormatJSON, appFormatYAML),
 	).Short('f').StringVar(&cf.Format)
+	appLogins := apps.Command("logins", "List available logins for a Cloud console application.")
+	appLogins.Arg("app", "App name to list logins for. Currently only AWS is supported.").Required().StringVar(&cf.AppName)
+	appLogins.Flag("format", defaults.FormatFlagDescription(defaults.DefaultFormats...)).Short('f').Default(teleport.Text).EnumVar(&cf.Format, defaults.DefaultFormats...)
 
 	// Recordings.
 	recordings := app.Command("recordings", "View and control session recordings.").Alias("recording")
@@ -1878,6 +1881,8 @@ func Run(ctx context.Context, args []string, opts ...CliOption) error {
 		err = onAppLogout(&cf)
 	case appConfig.FullCommand():
 		err = onAppConfig(&cf)
+	case appLogins.FullCommand():
+		err = onAppLogins(&cf)
 	case kube.credentials.FullCommand():
 		err = kube.credentials.run(&cf)
 	case kube.ls.FullCommand():


### PR DESCRIPTION
Closes: https://github.com/gravitational/teleport/issues/60151 -> Add ability to list AWS roles for apps without requiring login

## What

Add a way to query available AWS roles for an AWS Console application without having to trigger the tsh app login error.

Introduce a generic alternative that standardises application metadata retrieval and supports structured output for automation:
```
$ tsh apps logins <app> --format=text|json|yaml
```

This syntax cleanly accommodates GCP and Azure use cases by adapting the output contextually, rather than forcing AWS nomenclature onto other clouds.

AWS Example:
```bash
$ tsh apps logins aws-console
Available AWS roles:
Role Name        Role ARN
---------------- -----------------------------------------------
example-admin    arn:aws:iam::123456789012:role/example-admin
example-readonly arn:aws:iam::123456789012:role/example-readonly
```
JSON output:
```
$ tsh apps logins aws-console --format=json
{
  "app_name": "aws-console",
  "logins": {
    "aws_roles": [
      {
        "name": "example-readonly",
        "display": "example-readonly",
        "arn": "arn:aws:iam::123456789012:role/example-readonly",
        "account_id": "123456789012"
      },
      {
        "name": "example-admin",
        "display": "example-admin",
        "arn": "arn:aws:iam::123456789012:role/example-admin",
        "account_id": "123456789012"
      }
    ]
  }
}
```

GCP Example:
```bash
$ tsh apps logins gcp-console
Available GCP service accounts:
Service Account ID  Service Account Resource Name
------------------- ---------------------------------------------------------------------------------------------
example-admin       projects/example-project/serviceAccounts/example-admin@company-dev.iam.gserviceaccount.com
example-readonly    projects/example-project/serviceAccounts/example-readonly@company-dev.iam.gserviceaccount.com
```

**Advantages:**

1. Multi-Cloud Consistency: Aligns the user experience across AWS, GCP, and Azure.
2. Automation Friendly: The inclusion of --format flags allows for seamless parsing in CI/CD pipelines and scripts via jq.
3. Future Extensibility: A generic logins command can safely be expanded in the future to include other application-specific details (e.g., routing, policies, or status) without breaking the CLI command structure.


## Why

Currently, to script AWS app login with role selection (e.g., using `fzf` for interactive selection), users must intentionally trigger a login error to see available roles.

```bash
$ tsh apps login
ERROR: --aws-role flag is required
Available AWS roles:
Role Name                    Role ARN
---------------------------  -------------------------------------------
example-admin-role           arn:aws:iam::123456789012:role/example-admin
example-readonly-role        arn:aws:iam::123456789012:role/example-readonly
```

This makes automation workflows unnecessarily complex and error-prone because:
- Users must parse stderr to extract role information
- The workflow relies on error message formatting remaining consistent
- Users cannot preview which roles they have access to before attempting login
- It's not discoverable - users have to know this "trick" exists

changelog: add "tsh apps logins" command to query available logins for the given cloud application (currently only AWS is supported).

## Manual Test Plan

request for `aws-console` should be filed and approved before testing.

- [x] test interactive workflow (good path)
```bash
$ tsh apps logins aws-console
Available AWS roles:
Role Name        Role ARN
---------------- -----------------------------------------------
example-admin    arn:aws:iam::123456789012:role/example-admin
example-readonly arn:aws:iam::123456789012:role/example-readonly
```
JSON:
```bash
$ tsh apps logins aws-console --format=json
{
  "app_name": "aws-console",
  "logins": {
    "aws_roles": [
      {
        "name": "example-readonly",
        "display": "example-readonly",
        "arn": "arn:aws:iam::123456789012:role/example-readonly",
        "account_id": "123456789012"
      },
      {
        "name": "example-admin",
        "display": "example-admin",
        "arn": "arn:aws:iam::123456789012:role/example-admin",
        "account_id": "123456789012"
      }
    ]
  }
}
```

YAML:
```
$ tsh apps logins aws-console --format=yaml
app_name: aws-console
logins:
  aws_roles:
  - account_id: "123456789012"
    arn: arn:aws:iam::123456789012:role/example-admin
    display: example-admin
    name: example-admin
  - account_id: "123456789012"
    arn: arn:aws:iam::123456789012:role/example-readonly
    display: example-readonly
    name: example-readonly
```

### Test Environment

- Teleport instance with configured aws-console app.
```yaml
app_service:
  enabled: "yes"
  apps:
    - name: "aws-console"
      description: "Local Teleport Access to AWS Management Console"
      uri: "https://console.aws.amazon.com"
      aws:
        external_id: ""
```
- The active user should aws role assigned. Eg. something like below:

```yaml
kind: role
version: v7
metadata:
  name: aws-teleport-access
  labels:
    team: platform
spec:
  allow:
    app_labels:
      aws-account:
      '*': '*'
    aws_role_arns:
    - arn:aws:iam::123456789012:role/example-admin
    - arn:aws:iam::123456789012:role/example-readonly
    request:
      roles:
      - aws-teleport-access
      search_as_roles:
      - aws-teleport-access
```


### Test Cases

1. The tests cases check the correctness of the output.


There are also some unit tests that test the interactive mode.

Resolves: [this](https://github.com/gravitational/customer-sensitive-requests/issues/657)