### PR TITLE
[v18] Rework scopes feature flags

### DIFF
--- a/api/client/webclient/webclient.go
+++ b/api/client/webclient/webclient.go
@@ -524,7 +524,7 @@ type ProxySettings struct {
 	// TLSRoutingEnabled indicates that proxy supports ALPN SNI server where
 	// all proxy services are exposed on a single TLS listener (Proxy Web Listener).
 	TLSRoutingEnabled bool `json:"tls_routing_enabled"`
-	// ScopesEnabled determines if the TELEPORT_UNSTABLE_SCOPES env var is set to yes or not.
+	// ScopesEnabled determines if the scoped rbac feature set is enabled.
 	ScopesEnabled bool `json:"scopes_enabled"`
 }
 

--- a/integrations/operator/controllers/resources/scopedrole_controller_test.go
+++ b/integrations/operator/controllers/resources/scopedrole_controller_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/gravitational/teleport/integrations/operator/controllers/reconcilers"
 	"github.com/gravitational/teleport/integrations/operator/controllers/resources"
 	"github.com/gravitational/teleport/integrations/operator/controllers/resources/testlib"
+	"github.com/gravitational/teleport/lib/scopes"
 	"github.com/gravitational/teleport/lib/scopes/access"
 )
 
@@ -151,19 +152,16 @@ func (g *scopedRoleTestingPrimitives) CompareTeleportAndKubernetesResource(
 }
 
 func TestScopedRoleCreation(t *testing.T) {
-	t.Setenv("TELEPORT_UNSTABLE_SCOPES", "yes")
 	test := &scopedRoleTestingPrimitives{}
-	testlib.ResourceCreationSynchronousTest(t, resources.NewScopedRoleV1Reconciler, test)
+	testlib.ResourceCreationSynchronousTest(t, resources.NewScopedRoleV1Reconciler, test, testlib.WithScopesFeatures(scopes.Features{Enabled: true}))
 }
 
 func TestScopedRoleDeletionDrift(t *testing.T) {
-	t.Setenv("TELEPORT_UNSTABLE_SCOPES", "yes")
 	test := &scopedRoleTestingPrimitives{}
-	testlib.ResourceDeletionDriftSynchronousTest(t, resources.NewScopedRoleV1Reconciler, test)
+	testlib.ResourceDeletionDriftSynchronousTest(t, resources.NewScopedRoleV1Reconciler, test, testlib.WithScopesFeatures(scopes.Features{Enabled: true}))
 }
 
 func TestScopedRoleUpdate(t *testing.T) {
-	t.Setenv("TELEPORT_UNSTABLE_SCOPES", "yes")
 	test := &scopedRoleTestingPrimitives{}
-	testlib.ResourceUpdateTestSynchronous(t, resources.NewScopedRoleV1Reconciler, test)
+	testlib.ResourceUpdateTestSynchronous(t, resources.NewScopedRoleV1Reconciler, test, testlib.WithScopesFeatures(scopes.Features{Enabled: true}))
 }

--- a/integrations/operator/controllers/resources/scopedroleassignment_controller_test.go
+++ b/integrations/operator/controllers/resources/scopedroleassignment_controller_test.go
@@ -35,6 +35,7 @@ import (
 	"github.com/gravitational/teleport/integrations/operator/controllers/reconcilers"
 	"github.com/gravitational/teleport/integrations/operator/controllers/resources"
 	"github.com/gravitational/teleport/integrations/operator/controllers/resources/testlib"
+	"github.com/gravitational/teleport/lib/scopes"
 	"github.com/gravitational/teleport/lib/scopes/access"
 )
 
@@ -157,19 +158,16 @@ func (g *scopedRoleAssignmentTestingPrimitives) CompareTeleportAndKubernetesReso
 }
 
 func TestScopedRoleAssignmentCreation(t *testing.T) {
-	t.Setenv("TELEPORT_UNSTABLE_SCOPES", "yes")
 	test := &scopedRoleAssignmentTestingPrimitives{}
-	testlib.ResourceCreationSynchronousTest(t, resources.NewScopedRoleAssignmentV1Reconciler, test, testlib.WithResourceName(uuid.New().String()))
+	testlib.ResourceCreationSynchronousTest(t, resources.NewScopedRoleAssignmentV1Reconciler, test, testlib.WithResourceName(uuid.New().String()), testlib.WithScopesFeatures(scopes.Features{Enabled: true}))
 }
 
 func TestScopedRoleAssignmentDeletionDrift(t *testing.T) {
-	t.Setenv("TELEPORT_UNSTABLE_SCOPES", "yes")
 	test := &scopedRoleAssignmentTestingPrimitives{}
-	testlib.ResourceDeletionDriftSynchronousTest(t, resources.NewScopedRoleAssignmentV1Reconciler, test, testlib.WithResourceName(uuid.New().String()))
+	testlib.ResourceDeletionDriftSynchronousTest(t, resources.NewScopedRoleAssignmentV1Reconciler, test, testlib.WithResourceName(uuid.New().String()), testlib.WithScopesFeatures(scopes.Features{Enabled: true}))
 }
 
 func TestScopedRoleAssignmentUpdate(t *testing.T) {
-	t.Setenv("TELEPORT_UNSTABLE_SCOPES", "yes")
 	test := &scopedRoleAssignmentTestingPrimitives{}
-	testlib.ResourceUpdateTestSynchronous(t, resources.NewScopedRoleAssignmentV1Reconciler, test, testlib.WithResourceName(uuid.New().String()))
+	testlib.ResourceUpdateTestSynchronous(t, resources.NewScopedRoleAssignmentV1Reconciler, test, testlib.WithResourceName(uuid.New().String()), testlib.WithScopesFeatures(scopes.Features{Enabled: true}))
 }

--- a/integrations/operator/controllers/resources/testlib/env.go
+++ b/integrations/operator/controllers/resources/testlib/env.go
@@ -54,6 +54,7 @@ import (
 	"github.com/gravitational/teleport/integrations/operator/controllers/resources"
 	"github.com/gravitational/teleport/lib/modules"
 	"github.com/gravitational/teleport/lib/modules/modulestest"
+	"github.com/gravitational/teleport/lib/scopes"
 	"github.com/gravitational/teleport/lib/scopes/access"
 	"github.com/gravitational/teleport/lib/service/servicecfg"
 	"github.com/gravitational/teleport/lib/utils/log/logtest"
@@ -88,7 +89,7 @@ func ValidRandomResourceName(prefix string) string {
 	return prefix + string(b)
 }
 
-func defaultTeleportServiceConfig(t *testing.T) (*helpers.TeleInstance, string) {
+func defaultTeleportServiceConfig(t *testing.T, scopesFeatures scopes.Features) (*helpers.TeleInstance, string) {
 	modulestest.SetTestModules(t, modulestest.Modules{
 		TestBuildType: modules.BuildEnterprise,
 		TestFeatures: modules.Features{
@@ -107,6 +108,7 @@ func defaultTeleportServiceConfig(t *testing.T) (*helpers.TeleInstance, string) 
 	})
 
 	rcConf := servicecfg.MakeDefaultConfig()
+	rcConf.ScopesFeatures = scopesFeatures
 	rcConf.DataDir = t.TempDir()
 	rcConf.Auth.Enabled = true
 	rcConf.Proxy.Enabled = true
@@ -199,6 +201,7 @@ type TestSetup struct {
 	TeleportServer           *helpers.TeleInstance
 	ResourceName             string
 	Context                  context.Context
+	ScopesFeatures           scopes.Features
 }
 
 // StartKubernetesOperator creates and start a new operator
@@ -234,6 +237,7 @@ func (s *TestSetup) StartKubernetesOperator(t *testing.T) {
 
 	pong, err := s.TeleportClient.Ping(context.Background())
 	require.NoError(t, err)
+
 	err = resources.SetupAllControllers(setupLog, k8sManager, s.TeleportClient, pong.ServerFeatures)
 	require.NoError(t, err)
 
@@ -268,7 +272,7 @@ func setupTeleportClient(t *testing.T, setup *TestSetup) {
 
 	// Start a Teleport server for the test and set up a client connected to
 	// that server.
-	teleportServer, operatorName := defaultTeleportServiceConfig(t)
+	teleportServer, operatorName := defaultTeleportServiceConfig(t, setup.ScopesFeatures)
 	setup.TeleportServer = teleportServer
 	require.NoError(t, teleportServer.Start())
 	setup.TeleportClient = clientForTeleport(t, teleportServer, operatorName)
@@ -289,6 +293,12 @@ type TestOption func(*TestSetup)
 func WithTeleportClient(clt *client.Client) TestOption {
 	return func(setup *TestSetup) {
 		setup.TeleportClient = clt
+	}
+}
+
+func WithScopesFeatures(features scopes.Features) TestOption {
+	return func(setup *TestSetup) {
+		setup.ScopesFeatures = features
 	}
 }
 

--- a/integrations/terraform/testlib/main_test.go
+++ b/integrations/terraform/testlib/main_test.go
@@ -72,6 +72,9 @@ type TerraformSuiteOSSWithCache struct {
 type TerraformSuiteOSS struct {
 	TerraformBaseSuite
 }
+type TerraformSuiteOSSScopedResources struct {
+	TerraformBaseSuite
+}
 type TerraformSuiteEnterprise struct {
 	TerraformBaseSuite
 }

--- a/integrations/terraform/testlib/scoped_role_assignment_test.go
+++ b/integrations/terraform/testlib/scoped_role_assignment_test.go
@@ -32,10 +32,9 @@ import (
 	"github.com/gravitational/teleport/lib/scopes/access"
 )
 
-func (s *TerraformSuiteOSS) TestScopedRoleAssignment() {
+func (s *TerraformSuiteOSSScopedResources) TestScopedRoleAssignment() {
 	t := s.T()
 	ctx := t.Context()
-	t.Setenv("TELEPORT_UNSTABLE_SCOPES", "yes")
 
 	checkDestroyed := func(state *terraform.State) error {
 		accessClient := s.client.ScopedAccessServiceClient()
@@ -84,10 +83,9 @@ func (s *TerraformSuiteOSS) TestScopedRoleAssignment() {
 	})
 }
 
-func (s *TerraformSuiteOSS) TestImportScopedRoleAssignment() {
+func (s *TerraformSuiteOSSScopedResources) TestImportScopedRoleAssignment() {
 	t := s.T()
 	ctx := t.Context()
-	t.Setenv("TELEPORT_UNSTABLE_SCOPES", "yes")
 	accessClient := s.client.ScopedAccessServiceClient()
 
 	r := "teleport_scoped_role_assignment"

--- a/integrations/terraform/testlib/scoped_role_test.go
+++ b/integrations/terraform/testlib/scoped_role_test.go
@@ -32,10 +32,9 @@ import (
 	"github.com/gravitational/teleport/lib/scopes/access"
 )
 
-func (s *TerraformSuiteOSS) TestScopedRole() {
+func (s *TerraformSuiteOSSScopedResources) TestScopedRole() {
 	t := s.T()
 	ctx := t.Context()
-	t.Setenv("TELEPORT_UNSTABLE_SCOPES", "yes")
 
 	checkDestroyed := func(state *terraform.State) error {
 		accessClient := s.client.ScopedAccessServiceClient()
@@ -88,10 +87,9 @@ func (s *TerraformSuiteOSS) TestScopedRole() {
 	})
 }
 
-func (s *TerraformSuiteOSS) TestImportScopedRole() {
+func (s *TerraformSuiteOSSScopedResources) TestImportScopedRole() {
 	t := s.T()
 	ctx := t.Context()
-	t.Setenv("TELEPORT_UNSTABLE_SCOPES", "yes")
 	accessClient := s.client.ScopedAccessServiceClient()
 
 	r := "teleport_scoped_role"

--- a/integrations/terraform/testlib/terraform_oss_test.go
+++ b/integrations/terraform/testlib/terraform_oss_test.go
@@ -23,12 +23,25 @@ import (
 
 	"github.com/gravitational/teleport/integrations/lib/testing/integration"
 	"github.com/gravitational/teleport/lib/auth/authtest"
+	"github.com/gravitational/teleport/lib/scopes"
 )
 
 func TestTerraformOSS(t *testing.T) {
 	suite.Run(t, &TerraformSuiteOSS{
 		TerraformBaseSuite: TerraformBaseSuite{
 			AuthHelper: &integration.MinimalAuthHelper{},
+		},
+	})
+}
+
+func TestTerraformOSSScopedResources(t *testing.T) {
+	suite.Run(t, &TerraformSuiteOSSScopedResources{
+		TerraformBaseSuite: TerraformBaseSuite{
+			AuthHelper: &integration.MinimalAuthHelper{
+				AuthConfig: authtest.AuthServerConfig{
+					ScopesFeatures: scopes.Features{Enabled: true},
+				},
+			},
 		},
 	})
 }

--- a/lib/auth/access_test.go
+++ b/lib/auth/access_test.go
@@ -48,7 +48,7 @@ func TestUpsertDeleteRoleEventsEmitted(t *testing.T) {
 	t.Parallel()
 	clientAddr := &net.TCPAddr{IP: net.IPv4(10, 255, 0, 0)}
 	ctx := authz.ContextWithClientSrcAddr(context.Background(), clientAddr)
-	p, err := newTestPack(ctx, t.TempDir())
+	p, err := newTestPack(t.Context(), testPackOptions{DataDir: t.TempDir()})
 	require.NoError(t, err)
 
 	// test create new role
@@ -104,7 +104,7 @@ func TestUpsertDeleteRoleEventsEmitted(t *testing.T) {
 func TestUpsertDeleteDependentRoles(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
-	p, err := newTestPack(ctx, t.TempDir())
+	p, err := newTestPack(ctx, testPackOptions{DataDir: t.TempDir()})
 	require.NoError(t, err)
 
 	// test create new role
@@ -1127,7 +1127,7 @@ func TestDeleteRole(t *testing.T) {
 func TestUpsertDeleteLockEventsEmitted(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
-	p, err := newTestPack(ctx, t.TempDir())
+	p, err := newTestPack(ctx, testPackOptions{DataDir: t.TempDir()})
 	require.NoError(t, err)
 
 	lock, err := types.NewLock("test-lock", types.LockSpecV2{

--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -424,6 +424,7 @@ func NewServer(cfg *InitConfig, opts ...ServerOption) (as *Server, err error) {
 			// TODO(tross): replace modules.GetModules with cfg.Modules
 			Modules:                     modules.GetModules(),
 			RunWhileLockedRetryInterval: cfg.RunWhileLockedRetryInterval,
+			ScopesFeatures:              cfg.ScopesFeatures,
 		})
 		if err != nil {
 			return nil, trace.Wrap(err)
@@ -624,7 +625,7 @@ func NewServer(cfg *InitConfig, opts ...ServerOption) (as *Server, err error) {
 	}
 
 	if cfg.ScopedTokenService == nil {
-		cfg.ScopedTokenService, err = local.NewScopedTokenService(cfg.Backend)
+		cfg.ScopedTokenService, err = local.NewScopedTokenService(cfg.Backend, cfg.ScopesFeatures)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
@@ -732,6 +733,7 @@ func NewServer(cfg *InitConfig, opts ...ServerOption) (as *Server, err error) {
 	as = &Server{
 		bk:                           cfg.Backend,
 		clock:                        cfg.Clock,
+		scopesFeatures:               cfg.ScopesFeatures,
 		fakePasswordHash:             cfg.FakePasswordHash,
 		fakeRecoveryCodeHash:         cfg.FakeRecoveryCodeHash,
 		limiter:                      limiter,
@@ -1330,6 +1332,8 @@ type Server struct {
 	lock  sync.RWMutex
 	clock clockwork.Clock
 	bk    backend.Backend
+	// scopesFeatures dictates which scoped components are enabled for this auth server.
+	scopesFeatures scopes.Features
 
 	closeCtx   context.Context
 	cancelFunc context.CancelFunc
@@ -3670,7 +3674,7 @@ func generateCert(ctx context.Context, a *Server, req cert.Request, caType types
 	_, isScoped := req.CheckerContext.ScopePin()
 	if isScoped {
 		// require that the scope feature is enabled for scoped certificate creation
-		if err := scopes.AssertFeatureEnabled(); err != nil {
+		if err := a.scopesFeatures.AssertEnabled(); err != nil {
 			return nil, trace.Wrap(err)
 		}
 	}
@@ -5569,7 +5573,7 @@ func (a *Server) GenerateHostCerts(ctx context.Context, params HostCertsParams) 
 	if params.AgentScope != "" {
 		// We are in the process of switching over the format of scoped agent certificates. Until the
 		// transition is complete, the new agent pin format is behind a feature flag.
-		useAgentPin = scopes.AgentPinEnabled()
+		useAgentPin = a.scopesFeatures.AgentPinEnabled
 	}
 
 	if req.Role == types.RoleInstance && len(req.SystemRoles) == 0 {
@@ -7865,12 +7869,12 @@ func (a *Server) Ping(ctx context.Context) (proto.PingResponse, error) {
 		LoadAllCAs:              a.loadAllCAs,
 		SignatureAlgorithmSuite: authPref.GetSignatureAlgorithmSuite(),
 		LicenseExpiry:           &licenseExpiry,
-		ScopesStatus:            scopesStatusFromFeatureFlag(),
+		ScopesStatus:            a.scopesStatusFromFeatureFlag(),
 	}, nil
 }
 
-func scopesStatusFromFeatureFlag() proto.ScopesStatus {
-	if scopes.FeatureEnabled() {
+func (a *Server) scopesStatusFromFeatureFlag() proto.ScopesStatus {
+	if a.scopesFeatures.Enabled {
 		return proto.ScopesStatus_SCOPES_STATUS_ENABLED
 	}
 	return proto.ScopesStatus_SCOPES_STATUS_DISABLED

--- a/lib/auth/auth_login_test.go
+++ b/lib/auth/auth_login_test.go
@@ -52,6 +52,7 @@ import (
 	"github.com/gravitational/teleport/lib/events/eventstest"
 	"github.com/gravitational/teleport/lib/modules"
 	"github.com/gravitational/teleport/lib/modules/modulestest"
+	"github.com/gravitational/teleport/lib/scopes"
 	scopedaccess "github.com/gravitational/teleport/lib/scopes/access"
 	"github.com/gravitational/teleport/lib/scopes/pinning"
 	scopedutils "github.com/gravitational/teleport/lib/scopes/utils"
@@ -942,10 +943,9 @@ func TestServer_AuthenticateUser_passwordOnly(t *testing.T) {
 // TestBasicSSHScopedLogin verifies the basic expected behavior of a scoped login attempt using password-only
 // auth and a rudimentary set of scoped roles.
 func TestBasicSSHScopedLogin(t *testing.T) {
-	t.Setenv("TELEPORT_UNSTABLE_SCOPES", "yes")
-
+	t.Parallel()
 	ctx := context.Background()
-	testServer := newTestTLSServer(t)
+	testServer := newTestTLSServer(t, withScopesFeatures(scopes.Features{Enabled: true}))
 	authServer := testServer.Auth()
 
 	adminClient, err := testServer.NewClient(authtest.TestBuiltin(types.RoleAdmin))

--- a/lib/auth/auth_test.go
+++ b/lib/auth/auth_test.go
@@ -89,6 +89,7 @@ import (
 	"github.com/gravitational/teleport/lib/itertools/stream"
 	"github.com/gravitational/teleport/lib/modules"
 	"github.com/gravitational/teleport/lib/modules/modulestest"
+	"github.com/gravitational/teleport/lib/scopes"
 	"github.com/gravitational/teleport/lib/service/servicecfg"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/services/local"
@@ -107,13 +108,12 @@ type testPack struct {
 	mockEmitter    *eventstest.MockRecorderEmitter
 }
 
-func newTestPack(
-	ctx context.Context, dataDir string, opts ...auth.ServerOption,
-) (testPack, error) {
-	var (
-		p   testPack
-		err error
-	)
+type testPackOptions struct {
+	DataDir        string
+	ScopesFeatures scopes.Features
+}
+
+func newTestPack(ctx context.Context, opts testPackOptions) (p testPack, err error) {
 	p.bk, err = memory.New(memory.Config{})
 	if err != nil {
 		return p, trace.Wrap(err)
@@ -122,14 +122,14 @@ func newTestPack(
 		ClusterName: "test.localhost",
 	})
 	if err != nil {
-		return p, trace.Wrap(err)
+		return testPack{}, trace.Wrap(err)
 	}
 
 	p.versionStorage = authtest.NewFakeTeleportVersion()
 
 	identityService, err := local.NewTestIdentityService(p.bk)
 	if err != nil {
-		return p, trace.Wrap(err)
+		return testPack{}, trace.Wrap(err)
 	}
 
 	// TODO(tross): replace modules.GetModules with opts.Modules
@@ -140,7 +140,7 @@ func newTestPack(
 
 	p.mockEmitter = &eventstest.MockRecorderEmitter{}
 	authConfig := &auth.InitConfig{
-		DataDir:        dataDir,
+		DataDir:        opts.DataDir,
 		Backend:        p.bk,
 		VersionStorage: p.versionStorage,
 		ClusterName:    p.clusterName,
@@ -150,10 +150,11 @@ func newTestPack(
 		Identity:               identityService,
 		SkipPeriodicOperations: true,
 		HostUUID:               uuid.NewString(),
+		ScopesFeatures:         opts.ScopesFeatures,
 	}
-	p.a, err = auth.NewServer(authConfig, opts...)
+	p.a, err = auth.NewServer(authConfig)
 	if err != nil {
-		return p, trace.Wrap(err)
+		return testPack{}, trace.Wrap(err)
 	}
 
 	// set lock watcher
@@ -164,7 +165,7 @@ func newTestPack(
 		},
 	})
 	if err != nil {
-		return p, trace.Wrap(err)
+		return testPack{}, trace.Wrap(err)
 	}
 	p.a.SetLockWatcher(lockWatcher)
 
@@ -177,14 +178,14 @@ func newTestPack(
 		ResourceGetter: p.a,
 	})
 	if err != nil {
-		return p, trace.Wrap(err)
+		return testPack{}, trace.Wrap(err)
 	}
 
 	p.a.SetUnifiedResourcesCache(urc)
 
 	// set cluster name
 	if err := p.a.SetClusterName(p.clusterName); err != nil {
-		return p, trace.Wrap(err)
+		return testPack{}, trace.Wrap(err)
 	}
 
 	// set static tokens
@@ -192,11 +193,11 @@ func newTestPack(
 		StaticTokens: []types.ProvisionTokenV1{},
 	})
 	if err != nil {
-		return p, trace.Wrap(err)
+		return testPack{}, trace.Wrap(err)
 	}
 	err = p.a.SetStaticTokens(staticTokens)
 	if err != nil {
-		return p, trace.Wrap(err)
+		return testPack{}, trace.Wrap(err)
 	}
 
 	authPreference, err := types.NewAuthPreference(types.AuthPreferenceSpecV2{
@@ -204,19 +205,19 @@ func newTestPack(
 		SecondFactor: constants.SecondFactorOff,
 	})
 	if err != nil {
-		return p, trace.Wrap(err)
+		return testPack{}, trace.Wrap(err)
 	}
 	if _, err = p.a.UpsertAuthPreference(ctx, authPreference); err != nil {
-		return p, trace.Wrap(err)
+		return testPack{}, trace.Wrap(err)
 	}
 	if err := p.a.SetClusterAuditConfig(ctx, types.DefaultClusterAuditConfig()); err != nil {
-		return p, trace.Wrap(err)
+		return testPack{}, trace.Wrap(err)
 	}
 	if _, err := p.a.UpsertClusterNetworkingConfig(ctx, types.DefaultClusterNetworkingConfig()); err != nil {
-		return p, trace.Wrap(err)
+		return testPack{}, trace.Wrap(err)
 	}
 	if _, err := p.a.UpsertSessionRecordingConfig(ctx, types.DefaultSessionRecordingConfig()); err != nil {
-		return p, trace.Wrap(err)
+		return testPack{}, trace.Wrap(err)
 	}
 
 	clusterName := p.clusterName.GetClusterName()
@@ -238,7 +239,7 @@ func newTestPack(
 }
 
 func newAuthSuite(t *testing.T) *testPack {
-	s, err := newTestPack(context.Background(), t.TempDir())
+	s, err := newTestPack(t.Context(), testPackOptions{DataDir: t.TempDir()})
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		if s.bk != nil {
@@ -2788,7 +2789,7 @@ func contextWithGRPCClientUserAgent(ctx context.Context, userAgent string) conte
 func TestGenerateUserCertWithCertExtension(t *testing.T) {
 	t.Parallel()
 	ctx := contextWithGRPCClientUserAgent(context.Background(), "test-user-agent/1.0")
-	p, err := newTestPack(ctx, t.TempDir())
+	p, err := newTestPack(ctx, testPackOptions{DataDir: t.TempDir()})
 	require.NoError(t, err)
 
 	user, role, err := authtest.CreateUserAndRole(p.a, "test-user", []string{}, nil)
@@ -2857,7 +2858,7 @@ func TestGenerateOpenSSHCert(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
-	p, err := newTestPack(ctx, t.TempDir())
+	p, err := newTestPack(ctx, testPackOptions{DataDir: t.TempDir()})
 	require.NoError(t, err)
 
 	// create keypair and sign with OpenSSH CA
@@ -2945,10 +2946,14 @@ func TestGenerateOpenSSHCert(t *testing.T) {
 }
 
 func TestGenerateOpenSSHCertScoped(t *testing.T) {
-	t.Setenv("TELEPORT_UNSTABLE_SCOPES", "yes")
-
+	t.Parallel()
 	ctx := t.Context()
-	p := newAuthSuite(t)
+	p, err := newTestPack(t.Context(), testPackOptions{
+		DataDir:        t.TempDir(),
+		ScopesFeatures: scopes.Features{Enabled: true},
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { p.bk.Close() })
 
 	normalRoleLogins := []string{"login1", "login2"}
 	u, r, err := authtest.CreateUserAndRole(p.a, "scoped-user", normalRoleLogins, nil)
@@ -3050,7 +3055,7 @@ func TestGenerateOpenSSHCertScoped(t *testing.T) {
 func TestGenerateUserCertWithLocks(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
-	p, err := newTestPack(ctx, t.TempDir())
+	p, err := newTestPack(ctx, testPackOptions{DataDir: t.TempDir()})
 	require.NoError(t, err)
 
 	user, _, err := authtest.CreateUserAndRole(p.a, "test-user", []string{}, nil)
@@ -3116,7 +3121,7 @@ func TestGenerateUserCertWithLocks(t *testing.T) {
 func TestGenerateHostCertWithLocks(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
-	p, err := newTestPack(ctx, t.TempDir())
+	p, err := newTestPack(ctx, testPackOptions{DataDir: t.TempDir()})
 	require.NoError(t, err)
 
 	hostID := uuid.New().String()
@@ -3159,7 +3164,7 @@ func TestGenerateHostCertWithLocks(t *testing.T) {
 func TestGenerateUserCertWithUserLoginState(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
-	p, err := newTestPack(ctx, t.TempDir())
+	p, err := newTestPack(ctx, testPackOptions{DataDir: t.TempDir()})
 	require.NoError(t, err)
 
 	user, role, err := authtest.CreateUserAndRole(p.a, "test-user", []string{}, nil)
@@ -3247,7 +3252,7 @@ func TestGenerateUserCertWithUserLoginState(t *testing.T) {
 
 func TestGenerateUserCertWithHardwareKeySupport(t *testing.T) {
 	ctx := context.Background()
-	p, err := newTestPack(ctx, t.TempDir())
+	p, err := newTestPack(ctx, testPackOptions{DataDir: t.TempDir()})
 	require.NoError(t, err)
 
 	user, _, err := authtest.CreateUserAndRole(p.a, "test-user", []string{}, nil)
@@ -3488,7 +3493,7 @@ func TestGenerateKubernetesUserCert(t *testing.T) {
 func TestNewWebSession(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
-	p, err := newTestPack(ctx, t.TempDir())
+	p, err := newTestPack(ctx, testPackOptions{DataDir: t.TempDir()})
 	require.NoError(t, err)
 
 	// Set a web idle timeout.
@@ -4570,7 +4575,7 @@ func TestAccessRequestAuditLog(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
 
-	p, err := newTestPack(ctx, t.TempDir())
+	p, err := newTestPack(ctx, testPackOptions{DataDir: t.TempDir()})
 	require.NoError(t, err)
 
 	fakeClock := clockwork.NewFakeClock()
@@ -5157,28 +5162,32 @@ func testCreateAccessListReminderNotifications(t *testing.T) {
 }
 
 func TestPing(t *testing.T) {
+	t.Parallel()
 	type fixture struct {
-		name         string
-		envVar       string
-		scopesStatus proto.ScopesStatus
+		name           string
+		scopesFeatures scopes.Features
+		scopesStatus   proto.ScopesStatus
 	}
 	fixtures := []fixture{
 		{
 			name:         "scopes disabled",
-			envVar:       "",
 			scopesStatus: proto.ScopesStatus_SCOPES_STATUS_DISABLED,
 		},
 		{
-			name:         "scopes enabled",
-			envVar:       "yes",
-			scopesStatus: proto.ScopesStatus_SCOPES_STATUS_ENABLED,
+			name:           "scopes enabled",
+			scopesFeatures: scopes.Features{Enabled: true},
+			scopesStatus:   proto.ScopesStatus_SCOPES_STATUS_ENABLED,
 		},
 	}
 
 	for _, f := range fixtures {
 		t.Run(f.name, func(t *testing.T) {
-			t.Setenv("TELEPORT_UNSTABLE_SCOPES", f.envVar)
-			s := newAuthSuite(t)
+			s, err := newTestPack(t.Context(), testPackOptions{
+				DataDir:        t.TempDir(),
+				ScopesFeatures: f.scopesFeatures,
+			})
+			require.NoError(t, err)
+			t.Cleanup(func() { s.bk.Close() })
 			resp, err := s.a.Ping(t.Context())
 			require.NoError(t, err)
 			assert.Equal(t, "test.localhost", resp.ClusterName)

--- a/lib/auth/auth_with_roles_test.go
+++ b/lib/auth/auth_with_roles_test.go
@@ -27,7 +27,6 @@ import (
 	"encoding/pem"
 	"fmt"
 	"net/url"
-	"os"
 	"slices"
 	"strconv"
 	"strings"
@@ -93,6 +92,7 @@ import (
 	"github.com/gravitational/teleport/lib/modules"
 	"github.com/gravitational/teleport/lib/modules/modulestest"
 	"github.com/gravitational/teleport/lib/okta/oktatest"
+	"github.com/gravitational/teleport/lib/scopes"
 	scopedaccess "github.com/gravitational/teleport/lib/scopes/access"
 	"github.com/gravitational/teleport/lib/scopes/joining"
 	"github.com/gravitational/teleport/lib/services"
@@ -1100,10 +1100,9 @@ func TestSSODiagnosticInfo(t *testing.T) {
 }
 
 func TestGenerateUserCertsForHeadlessKube(t *testing.T) {
-	t.Setenv("TELEPORT_UNSTABLE_SCOPES", "yes")
-
+	t.Parallel()
 	ctx := context.Background()
-	srv := newTestTLSServer(t)
+	srv := newTestTLSServer(t, withScopesFeatures(scopes.Features{Enabled: true}))
 
 	const kubeClusterName = "kube-cluster-1"
 	kubeCluster, err := types.NewKubernetesClusterV3(
@@ -5510,9 +5509,9 @@ func TestIsLocalOrRemoteServerAction(t *testing.T) {
 }
 
 func TestListResources_KindKubernetesCluster(t *testing.T) {
-	t.Setenv("TELEPORT_UNSTABLE_SCOPES", "yes")
+	t.Parallel()
 	ctx := t.Context()
-	srv := newTestTLSServer(t)
+	srv := newTestTLSServer(t, withScopesFeatures(scopes.Features{Enabled: true}))
 
 	scopedAccess := srv.Auth().ScopedAccess()
 	scopes := []string{"/test", "/other"}
@@ -5773,9 +5772,9 @@ func createKubeServer(t *testing.T, s *auth.Server, clusterNames []string, hostI
 }
 
 func TestListResourcesScopedPagination(t *testing.T) {
-	t.Setenv("TELEPORT_UNSTABLE_SCOPES", "yes")
+	t.Parallel()
 	ctx := t.Context()
-	srv := newTestTLSServer(t)
+	srv := newTestTLSServer(t, withScopesFeatures(scopes.Features{Enabled: true}))
 
 	client, err := srv.NewClient(authtest.TestBuiltin(types.RoleProxy))
 	require.NoError(t, err)
@@ -5908,9 +5907,9 @@ func TestListResourcesScopedPagination(t *testing.T) {
 // TestListResourcesScopedPaginateKubeClusters tests that scoped kube clusters can be paginated properly even when
 // there are resources that will be deduplicated.
 func TestListResourcesPaginateKubeClusters(t *testing.T) {
-	t.Setenv("TELEPORT_UNSTABLE_SCOPES", "yes")
+	t.Parallel()
 	ctx := t.Context()
-	srv := newTestTLSServer(t)
+	srv := newTestTLSServer(t, withScopesFeatures(scopes.Features{Enabled: true}))
 
 	client, err := srv.NewClient(authtest.TestBuiltin(types.RoleProxy))
 	require.NoError(t, err)
@@ -8877,15 +8876,10 @@ func TestUpsertNode(t *testing.T) {
 // of the associated feature flag and verifies the old format is still the default behavior. This
 // test will be simplified once the agent scope pin feature is complete.
 func TestGenerateHostCertsAgentScopePin(t *testing.T) {
-	t.Setenv("TELEPORT_UNSTABLE_SCOPES", "yes")
-	ctx := t.Context()
+	t.Parallel()
 
 	const scope = "/aa/bb"
 	const hostID = "testhost"
-
-	as, err := authtest.NewAuthServer(authtest.AuthServerConfig{Dir: t.TempDir()})
-	require.NoError(t, err)
-	t.Cleanup(func() { require.NoError(t, as.Close()) })
 
 	type certIdents struct {
 		tls *tlsca.Identity
@@ -8905,7 +8899,7 @@ func TestGenerateHostCertsAgentScopePin(t *testing.T) {
 		return certIdents{tls: tlsIdent, ssh: sshIdent}
 	}
 
-	generateCerts := func(t *testing.T, role types.SystemRole) certIdents {
+	generateCerts := func(t *testing.T, as *authtest.AuthServer, role types.SystemRole) certIdents {
 		t.Helper()
 		s := newScopedTestServerForHost(t, as, hostID, scope, role)
 
@@ -8916,7 +8910,7 @@ func TestGenerateHostCertsAgentScopePin(t *testing.T) {
 		tlsPubPEM, err := keys.MarshalPublicKey(tlsKey.Public())
 		require.NoError(t, err)
 
-		certs, err := s.GenerateHostCerts(ctx, &proto.HostCertsRequest{
+		certs, err := s.GenerateHostCerts(t.Context(), &proto.HostCertsRequest{
 			PublicTLSKey: tlsPubPEM,
 			PublicSSHKey: sshPub,
 			HostID:       hostID,
@@ -8926,7 +8920,7 @@ func TestGenerateHostCertsAgentScopePin(t *testing.T) {
 		return parseIdents(t, certs)
 	}
 
-	generateInstanceCerts := func(t *testing.T, systemRoles types.SystemRoles) certIdents {
+	generateInstanceCerts := func(t *testing.T, as *authtest.AuthServer, systemRoles types.SystemRoles) certIdents {
 		t.Helper()
 		s := newScopedTestServerForHost(t, as, hostID, scope, systemRoles...)
 
@@ -8937,7 +8931,7 @@ func TestGenerateHostCertsAgentScopePin(t *testing.T) {
 		tlsPubPEM, err := keys.MarshalPublicKey(tlsKey.Public())
 		require.NoError(t, err)
 
-		certs, err := s.GenerateHostCerts(ctx, &proto.HostCertsRequest{
+		certs, err := s.GenerateHostCerts(t.Context(), &proto.HostCertsRequest{
 			PublicTLSKey: tlsPubPEM,
 			PublicSSHKey: sshPub,
 			HostID:       hostID,
@@ -8951,7 +8945,11 @@ func TestGenerateHostCertsAgentScopePin(t *testing.T) {
 	// verify that the legacy scoped agent cert format is still the one generated when
 	// the agent scope pin feature is not enabled
 	t.Run("legacy format", func(t *testing.T) {
-		idents := generateCerts(t, types.RoleNode)
+		t.Parallel()
+		as, err := authtest.NewAuthServer(authtest.AuthServerConfig{Dir: t.TempDir(), ScopesFeatures: scopes.Features{Enabled: true}})
+		require.NoError(t, err)
+		t.Cleanup(func() { require.NoError(t, as.Close()) })
+		idents := generateCerts(t, as, types.RoleNode)
 
 		// Legacy path: Groups contains the role, AgentScope is set, ScopePin is nil.
 		require.Contains(t, idents.tls.Groups, types.RoleNode.String())
@@ -8963,76 +8961,78 @@ func TestGenerateHostCertsAgentScopePin(t *testing.T) {
 		require.Nil(t, idents.ssh.ScopePin)
 	})
 
-	// verify agent pin created correctly for service certs
-	t.Run("agent pin service cert", func(t *testing.T) {
-		t.Setenv("TELEPORT_UNSTABLE_AGENT_SCOPE_PIN", "yes")
-
-		idents := generateCerts(t, types.RoleNode)
-		require.Empty(t, idents.tls.Groups)
-		require.Empty(t, idents.tls.AgentScope)
-		require.NotNil(t, idents.tls.ScopePin)
-		require.Equal(t, scope, idents.tls.ScopePin.GetScope())
-		require.Equal(t, types.RoleNode.String(), idents.tls.ScopePin.GetSystemRoles().GetPrimary())
-
-		require.NotNil(t, idents.ssh.ScopePin)
-		require.Equal(t, scope, idents.ssh.ScopePin.GetScope())
-		require.Equal(t, types.RoleNode.String(), idents.ssh.ScopePin.GetSystemRoles().GetPrimary())
-	})
-
-	// verify agent pin created correctly for instance certs
-	t.Run("agent pin instance cert", func(t *testing.T) {
-		t.Setenv("TELEPORT_UNSTABLE_AGENT_SCOPE_PIN", "yes")
-
-		systemRoles := types.SystemRoles{types.RoleNode, types.RoleKube}
-		idents := generateInstanceCerts(t, systemRoles)
-
-		require.Empty(t, idents.tls.Groups)
-		require.NotNil(t, idents.tls.ScopePin)
-		require.Equal(t, scope, idents.tls.ScopePin.GetScope())
-		require.Equal(t, types.RoleInstance.String(), idents.tls.ScopePin.GetSystemRoles().GetPrimary())
-		tlsAdditional := idents.tls.ScopePin.GetSystemRoles().GetAdditional()
-		for _, role := range systemRoles {
-			require.Contains(t, tlsAdditional, role.String())
-		}
-
-		require.NotNil(t, idents.ssh.ScopePin)
-		require.Equal(t, scope, idents.ssh.ScopePin.GetScope())
-		require.Equal(t, types.RoleInstance.String(), idents.ssh.ScopePin.GetSystemRoles().GetPrimary())
-		sshAdditional := idents.ssh.ScopePin.GetSystemRoles().GetAdditional()
-		for _, role := range systemRoles {
-			require.Contains(t, sshAdditional, role.String())
-		}
-	})
-
-	// verify that scope pins are not set for unscoped agents
-	t.Run("unscoped agent has no pin", func(t *testing.T) {
-		t.Setenv("TELEPORT_UNSTABLE_AGENT_SCOPE_PIN", "yes")
-
-		_, sshPub, err := testauthority.GenerateKeyPair()
+	t.Run("agent pin enabled", func(t *testing.T) {
+		t.Parallel()
+		as, err := authtest.NewAuthServer(authtest.AuthServerConfig{Dir: t.TempDir(), ScopesFeatures: scopes.Features{Enabled: true, AgentPinEnabled: true}})
 		require.NoError(t, err)
-		tlsKey, err := cryptosuites.GenerateKeyWithAlgorithm(cryptosuites.ECDSAP256)
-		require.NoError(t, err)
-		tlsPubPEM, err := keys.MarshalPublicKey(tlsKey.Public())
-		require.NoError(t, err)
+		t.Cleanup(func() { require.NoError(t, as.Close()) })
 
-		certs, err := as.AuthServer.GenerateHostCerts(ctx, auth.HostCertsParams{
-			Req: &proto.HostCertsRequest{
-				PublicTLSKey: tlsPubPEM,
-				PublicSSHKey: sshPub,
-				HostID:       hostID,
-				NodeName:     hostID,
-				Role:         types.RoleNode,
-			},
+		// verify agent pin created correctly for service certs
+		t.Run("agent pin service cert", func(t *testing.T) {
+
+			idents := generateCerts(t, as, types.RoleNode)
+			require.Empty(t, idents.tls.Groups)
+			require.Empty(t, idents.tls.AgentScope)
+			require.NotNil(t, idents.tls.ScopePin)
+			require.Equal(t, scope, idents.tls.ScopePin.GetScope())
+			require.Equal(t, types.RoleNode.String(), idents.tls.ScopePin.GetSystemRoles().GetPrimary())
+
+			require.NotNil(t, idents.ssh.ScopePin)
+			require.Equal(t, scope, idents.ssh.ScopePin.GetScope())
+			require.Equal(t, types.RoleNode.String(), idents.ssh.ScopePin.GetSystemRoles().GetPrimary())
 		})
-		require.NoError(t, err)
 
-		idents := parseIdents(t, certs)
-		require.Contains(t, idents.tls.Groups, types.RoleNode.String())
-		require.Empty(t, idents.tls.AgentScope)
-		require.Nil(t, idents.tls.ScopePin)
+		// verify agent pin created correctly for instance certs
+		t.Run("agent pin instance cert", func(t *testing.T) {
+			systemRoles := types.SystemRoles{types.RoleNode, types.RoleKube}
+			idents := generateInstanceCerts(t, as, systemRoles)
 
-		require.Empty(t, idents.ssh.AgentScope)
-		require.Nil(t, idents.ssh.ScopePin)
+			require.Empty(t, idents.tls.Groups)
+			require.NotNil(t, idents.tls.ScopePin)
+			require.Equal(t, scope, idents.tls.ScopePin.GetScope())
+			require.Equal(t, types.RoleInstance.String(), idents.tls.ScopePin.GetSystemRoles().GetPrimary())
+			tlsAdditional := idents.tls.ScopePin.GetSystemRoles().GetAdditional()
+			for _, role := range systemRoles {
+				require.Contains(t, tlsAdditional, role.String())
+			}
+
+			require.NotNil(t, idents.ssh.ScopePin)
+			require.Equal(t, scope, idents.ssh.ScopePin.GetScope())
+			require.Equal(t, types.RoleInstance.String(), idents.ssh.ScopePin.GetSystemRoles().GetPrimary())
+			sshAdditional := idents.ssh.ScopePin.GetSystemRoles().GetAdditional()
+			for _, role := range systemRoles {
+				require.Contains(t, sshAdditional, role.String())
+			}
+		})
+
+		// verify that scope pins are not set for unscoped agents
+		t.Run("unscoped agent has no pin", func(t *testing.T) {
+			_, sshPub, err := testauthority.GenerateKeyPair()
+			require.NoError(t, err)
+			tlsKey, err := cryptosuites.GenerateKeyWithAlgorithm(cryptosuites.ECDSAP256)
+			require.NoError(t, err)
+			tlsPubPEM, err := keys.MarshalPublicKey(tlsKey.Public())
+			require.NoError(t, err)
+
+			certs, err := as.AuthServer.GenerateHostCerts(t.Context(), auth.HostCertsParams{
+				Req: &proto.HostCertsRequest{
+					PublicTLSKey: tlsPubPEM,
+					PublicSSHKey: sshPub,
+					HostID:       hostID,
+					NodeName:     hostID,
+					Role:         types.RoleNode,
+				},
+			})
+			require.NoError(t, err)
+
+			idents := parseIdents(t, certs)
+			require.Contains(t, idents.tls.Groups, types.RoleNode.String())
+			require.Empty(t, idents.tls.AgentScope)
+			require.Nil(t, idents.tls.ScopePin)
+
+			require.Empty(t, idents.ssh.AgentScope)
+			require.Nil(t, idents.ssh.ScopePin)
+		})
 	})
 }
 
@@ -13036,9 +13036,8 @@ func TestRegisterInventoryControlStreamImmutableLabels(t *testing.T) {
 
 // assert that common user cert generation cases are properly handled for scoped identities
 func TestScopedUserCertGeneration(t *testing.T) {
-	os.Setenv("TELEPORT_UNSTABLE_SCOPES", "true")
 	clock := clockwork.NewFakeClock()
-	srv := newTestTLSServer(t, withClock(clock))
+	srv := newTestTLSServer(t, withScopesFeatures(scopes.Features{Enabled: true}), withClock(clock))
 	modulestest.SetTestModules(t, modulestest.Modules{
 		TestBuildType: modules.BuildEnterprise,
 		TestFeatures: modules.Features{

--- a/lib/auth/authtest/authtest.go
+++ b/lib/auth/authtest/authtest.go
@@ -66,6 +66,7 @@ import (
 	"github.com/gravitational/teleport/lib/limiter"
 	"github.com/gravitational/teleport/lib/modules"
 	"github.com/gravitational/teleport/lib/multiplexer"
+	"github.com/gravitational/teleport/lib/scopes"
 	"github.com/gravitational/teleport/lib/service/servicecfg"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/services/local"
@@ -119,6 +120,8 @@ type AuthServerConfig struct {
 	FIPS bool
 	// KeystoreConfig is configuration for the CA keystore.
 	KeystoreConfig servicecfg.KeystoreConfig
+	// ScopesFeatures dictates which scoped components are enabled for the test auth server.
+	ScopesFeatures scopes.Features
 }
 
 // CheckAndSetDefaults checks and sets defaults
@@ -383,6 +386,7 @@ func NewAuthServer(cfg AuthServerConfig) (*AuthServer, error) {
 		AWSOrganizationsClientGetter: cfg.AWSOrganizationsClientGetter,
 		FakePasswordHash:             []byte(FakePasswordHash),
 		FakeRecoveryCodeHash:         []byte(FakeRecoveryCodeHash),
+		ScopesFeatures:               cfg.ScopesFeatures,
 	},
 		WithClock(cfg.Clock),
 		// Reduce auth.Server bcrypt costs when testing.
@@ -533,6 +537,7 @@ func NewAuthServer(cfg AuthServerConfig) (*AuthServer, error) {
 		ReadOnlyAccessPoint: srv.AuthServer.ReadOnlyCache,
 		ScopedRoleReader:    srv.AuthServer.ScopedAccessCache,
 		LockWatcher:         srv.LockWatcher,
+		ScopesFeatures:      cfg.ScopesFeatures,
 		// AuthServer does explicit device authorization checks.
 		DeviceAuthorization: authz.DeviceAuthorizationOpts{
 			DisableGlobalMode: true,

--- a/lib/auth/bot_test.go
+++ b/lib/auth/bot_test.go
@@ -70,6 +70,7 @@ import (
 	"github.com/gravitational/teleport/lib/kube/token"
 	"github.com/gravitational/teleport/lib/oidc/fakeissuer"
 	"github.com/gravitational/teleport/lib/reversetunnelclient"
+	"github.com/gravitational/teleport/lib/scopes"
 	scopedaccess "github.com/gravitational/teleport/lib/scopes/access"
 	"github.com/gravitational/teleport/lib/scopes/joining"
 	"github.com/gravitational/teleport/lib/tbot/identity"
@@ -670,7 +671,7 @@ func TestRegisterBot_RemoteAddr(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
 
-	p, err := newTestPack(ctx, t.TempDir())
+	p, err := newTestPack(ctx, testPackOptions{DataDir: t.TempDir()})
 	require.NoError(t, err)
 	a := p.a
 
@@ -690,7 +691,7 @@ func TestRegisterBot_RemoteAddr(t *testing.T) {
 		Spec: &machineidv1pb.BotSpec{
 			Roles: []string{roleName},
 		},
-	}, a.GetClock().Now(), "")
+	}, a.GetClock().Now(), "", scopes.Features{})
 	require.NoError(t, err)
 
 	remoteAddr := "42.42.42.42:42"
@@ -948,7 +949,7 @@ func TestRegisterBot_BotInstanceRejoin(t *testing.T) {
 		Spec: &machineidv1pb.BotSpec{
 			Roles: []string{roleName},
 		},
-	}, a.GetClock().Now(), "")
+	}, a.GetClock().Now(), "", scopes.Features{})
 	require.NoError(t, err)
 
 	// Create k8s and IAM join tokens
@@ -1104,7 +1105,7 @@ func TestRegisterBotWithInvalidInstanceID(t *testing.T) {
 		Spec: &machineidv1pb.BotSpec{
 			Roles: []string{roleName},
 		},
-	}, a.GetClock().Now(), "")
+	}, a.GetClock().Now(), "", scopes.Features{})
 	require.NoError(t, err)
 
 	client, err := srv.NewClient(authtest.TestAdmin())
@@ -1213,7 +1214,7 @@ func TestRegisterBotWithInvalidUserLoginState(t *testing.T) {
 		Spec: &machineidv1pb.BotSpec{
 			Roles: []string{roleName},
 		},
-	}, a.GetClock().Now(), "")
+	}, a.GetClock().Now(), "", scopes.Features{})
 	require.NoError(t, err)
 
 	client, err := srv.NewClient(authtest.TestAdmin())
@@ -1438,11 +1439,10 @@ func createScopedBot(t *testing.T, srv *authtest.TLSServer, adminClient *authcli
 }
 
 func TestRegisterBotWithScopedKubernetesToken(t *testing.T) {
-	t.Setenv("TELEPORT_UNSTABLE_SCOPES", "yes")
-
+	t.Parallel()
 	ctx := t.Context()
 
-	srv := newTestTLSServer(t)
+	srv := newTestTLSServer(t, withScopesFeatures(scopes.Features{Enabled: true}))
 	addr := utils.MustParseAddr(srv.Addr().String())
 
 	// Initial setup, create a bot and join token.

--- a/lib/auth/desktop_test.go
+++ b/lib/auth/desktop_test.go
@@ -51,7 +51,7 @@ func TestDesktopAccessDisabled(t *testing.T) {
 	})
 
 	ctx := context.Background()
-	p, err := newTestPack(ctx, t.TempDir())
+	p, err := newTestPack(ctx, testPackOptions{DataDir: t.TempDir()})
 	require.NoError(t, err)
 
 	r, err := p.a.GenerateWindowsDesktopCert(ctx, &proto.WindowsDesktopCertRequest{})

--- a/lib/auth/grpcserver.go
+++ b/lib/auth/grpcserver.go
@@ -6161,6 +6161,7 @@ func NewGRPCServer(cfg GRPCServerConfig) (*GRPCServer, error) {
 		Emitter:          cfg.Emitter,
 		Clock:            cfg.AuthServer.GetClock(),
 		Logger:           cfg.AuthServer.logger.With(teleport.ComponentKey, "bot.service"),
+		ScopesFeatures:   cfg.AuthServer.scopesFeatures,
 	})
 	if err != nil {
 		return nil, trace.Wrap(err, "creating bot service")
@@ -6320,6 +6321,7 @@ func NewGRPCServer(cfg GRPCServerConfig) (*GRPCServer, error) {
 		Writer:           cfg.AuthServer.scopedAccessBackend,
 		BackendReader:    cfg.AuthServer.scopedAccessBackend,
 		Logger:           logger,
+		ScopesFeatures:   cfg.AuthServer.scopesFeatures,
 	})
 	if err != nil {
 		return nil, trace.Wrap(err, "creating scoped access control service")
@@ -6412,6 +6414,7 @@ func NewGRPCServer(cfg GRPCServerConfig) (*GRPCServer, error) {
 			FIPS:               cfg.AuthServer.fips,
 			OracleHTTPClient:   cfg.OracleHTTPClient,
 			ScopedTokenService: cfg.AuthServer.Services,
+			ScopesFeatures:     cfg.AuthServer.scopesFeatures,
 		}))
 	}
 
@@ -6698,6 +6701,7 @@ func NewGRPCServer(cfg GRPCServerConfig) (*GRPCServer, error) {
 	issuanceSvc, err := issuancev1.NewService(&issuancev1.ServiceConfig{
 		ScopedAuthorizer: cfg.ScopedAuthorizer,
 		AuthServer:       cfg.AuthServer,
+		ScopesFeatures:   cfg.AuthServer.scopesFeatures,
 	})
 	if err != nil {
 		return nil, trace.Wrap(err, "instantiating issuancev1 service")

--- a/lib/auth/grpcserver_test.go
+++ b/lib/auth/grpcserver_test.go
@@ -91,6 +91,7 @@ import (
 	iterstream "github.com/gravitational/teleport/lib/itertools/stream"
 	"github.com/gravitational/teleport/lib/modules"
 	"github.com/gravitational/teleport/lib/modules/modulestest"
+	"github.com/gravitational/teleport/lib/scopes"
 	scopedaccess "github.com/gravitational/teleport/lib/scopes/access"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/session"
@@ -6806,8 +6807,7 @@ func TestGRPCServingStatus(t *testing.T) {
 }
 
 func TestGenerateUserCertsScopedBot(t *testing.T) {
-	t.Setenv("TELEPORT_UNSTABLE_SCOPES", "yes")
-	testServer := newTestTLSServer(t)
+	testServer := newTestTLSServer(t, withScopesFeatures(scopes.Features{Enabled: true}))
 	modulestest.SetTestModules(t, modulestest.Modules{
 		TestBuildType: modules.BuildEnterprise, // required for Device Trust.
 		TestFeatures: modules.Features{

--- a/lib/auth/init.go
+++ b/lib/auth/init.go
@@ -70,6 +70,7 @@ import (
 	"github.com/gravitational/teleport/lib/events"
 	"github.com/gravitational/teleport/lib/join/iamjoin"
 	"github.com/gravitational/teleport/lib/modules"
+	"github.com/gravitational/teleport/lib/scopes"
 	"github.com/gravitational/teleport/lib/service/servicecfg"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/services/local"
@@ -460,6 +461,9 @@ type InitConfig struct {
 	// RemoteClusterRefreshBuckets is the maximum number of refresh cycles that should guarantee the status update
 	// of all remote clusters if their number exceeds RemoteClusterRefreshLimit × RemoteClusterRefreshBuckets.
 	RemoteClusterRefreshBuckets int
+
+	// ScopesFeatures dictate which scoped components are enabled.
+	ScopesFeatures scopes.Features
 }
 
 // Init instantiates and configures an instance of AuthServer
@@ -538,7 +542,7 @@ func initCluster(ctx context.Context, cfg InitConfig, asrv *Server) error {
 	if len(cfg.ApplyOnStartupResources) > 0 {
 		asrv.logger.InfoContext(ctx, "Applying resources (apply-on-startup)", "resource_count", len(cfg.ApplyOnStartupResources))
 
-		if err := applyResources(ctx, asrv.Services, cfg.ApplyOnStartupResources); err != nil {
+		if err := applyResources(ctx, asrv.Services, cfg.ApplyOnStartupResources, cfg.ScopesFeatures); err != nil {
 			return trace.Wrap(err, "applying resources failed")
 		}
 	}
@@ -1793,7 +1797,7 @@ var ResourceApplyPriority = map[string]int{
 // Unlike when resources are loaded via --bootstrap, we're inserting elements via their service.
 // This means consistency is checked. This function support applying resources
 // with dependencies (like a user referring to a role).
-func applyResources(ctx context.Context, service *Services, resources []types.Resource) error {
+func applyResources(ctx context.Context, service *Services, resources []types.Resource, scopesFeatures scopes.Features) error {
 	var err error
 	slices.SortFunc(resources, func(a, b types.Resource) int {
 		priorityA := ResourceApplyPriority[a.GetKind()]
@@ -1826,7 +1830,7 @@ func applyResources(ctx context.Context, service *Services, resources []types.Re
 		case types.AuthPreference:
 			_, err = service.ClusterConfigurationInternal.UpsertAuthPreference(ctx, r)
 		case types.Resource153UnwrapperT[*machineidv1pb.Bot]:
-			_, err = machineidv1.UpsertBot(ctx, service, r.UnwrapT(), time.Now(), "system")
+			_, err = machineidv1.UpsertBot(ctx, service, r.UnwrapT(), time.Now(), "system", scopesFeatures)
 		case types.Resource153UnwrapperT[*autoupdatev1pb.AutoUpdateConfig]:
 			_, err = autoupdatev1.UpsertAutoUpdateConfig(ctx, service, r.UnwrapT())
 		case types.Resource153UnwrapperT[*autoupdatev1pb.AutoUpdateVersion]:

--- a/lib/auth/issuance/v1/service.go
+++ b/lib/auth/issuance/v1/service.go
@@ -60,12 +60,16 @@ type Service struct {
 	issuancev1pb.UnimplementedIssuanceServiceServer
 	scopedAuthorizer authz.ScopedAuthorizer
 	authServer       authServer
+	// scopesFeatures dictates whether scoped certificate issuance is enabled.
+	scopesFeatures scopes.Features
 }
 
 // ServiceConfig is the config for instantiating a [Service].
 type ServiceConfig struct {
 	ScopedAuthorizer authz.ScopedAuthorizer
 	AuthServer       authServer
+	// ScopesFeatures dictates which scoped issuance components are enabled.
+	ScopesFeatures scopes.Features
 }
 
 // NewService returns a new [Service].
@@ -80,6 +84,7 @@ func NewService(cfg *ServiceConfig) (*Service, error) {
 	return &Service{
 		scopedAuthorizer: cfg.ScopedAuthorizer,
 		authServer:       cfg.AuthServer,
+		scopesFeatures:   cfg.ScopesFeatures,
 	}, nil
 }
 
@@ -95,7 +100,7 @@ func (s *Service) IssueScopedBotCerts(
 ) (*issuancev1pb.IssueScopedBotCertsResponse, error) {
 	// Temporarily, we need to check that Scopes is enabled to derisk
 	// introduction of this RPC.
-	if err := scopes.AssertFeatureEnabled(); err != nil {
+	if err := s.scopesFeatures.AssertEnabled(); err != nil {
 		return nil, trace.Wrap(err)
 	}
 

--- a/lib/auth/issuance/v1/service_test.go
+++ b/lib/auth/issuance/v1/service_test.go
@@ -44,6 +44,7 @@ import (
 	"github.com/gravitational/teleport/lib/cryptosuites"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/modules"
+	"github.com/gravitational/teleport/lib/scopes"
 	scopedaccess "github.com/gravitational/teleport/lib/scopes/access"
 	"github.com/gravitational/teleport/lib/tlsca"
 )
@@ -54,9 +55,14 @@ func TestMain(m *testing.M) {
 }
 
 func newTestTLSServer(t testing.TB) *authtest.TLSServer {
+	return newTestTLSServerWithScopesFeatures(t, scopes.Features{})
+}
+
+func newTestTLSServerWithScopesFeatures(t testing.TB, scopesFeatures scopes.Features) *authtest.TLSServer {
 	as, err := authtest.NewAuthServer(authtest.AuthServerConfig{
-		Dir:   t.TempDir(),
-		Clock: clockwork.NewFakeClockAt(time.Now().Round(time.Second).UTC()),
+		Dir:            t.TempDir(),
+		Clock:          clockwork.NewFakeClockAt(time.Now().Round(time.Second).UTC()),
+		ScopesFeatures: scopesFeatures,
 	})
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, as.Close()) })
@@ -75,10 +81,10 @@ func newTestTLSServer(t testing.TB) *authtest.TLSServer {
 }
 
 func TestIssueScopedBotCerts(t *testing.T) {
-	t.Setenv("TELEPORT_UNSTABLE_SCOPES", "yes")
+	t.Parallel()
 
 	ctx := t.Context()
-	srv := newTestTLSServer(t)
+	srv := newTestTLSServerWithScopesFeatures(t, scopes.Features{Enabled: true})
 
 	const botScope = "/test-scope"
 
@@ -272,7 +278,7 @@ func TestIssueScopedBotCerts(t *testing.T) {
 }
 
 func TestIssueScopedBotCerts_FeatureFlagRequired(t *testing.T) {
-	// Do NOT set the feature flag env vars.
+	t.Parallel()
 	ctx := t.Context()
 	srv := newTestTLSServer(t)
 
@@ -299,10 +305,10 @@ func TestIssueScopedBotCerts_FeatureFlagRequired(t *testing.T) {
 }
 
 func TestIssueScopedBotCerts_Unauthorized(t *testing.T) {
-	t.Setenv("TELEPORT_UNSTABLE_SCOPES", "yes")
+	t.Parallel()
 
 	ctx := t.Context()
-	srv := newTestTLSServer(t)
+	srv := newTestTLSServerWithScopesFeatures(t, scopes.Features{Enabled: true})
 
 	const testScope = "/test-scope"
 

--- a/lib/auth/join/join_test.go
+++ b/lib/auth/join/join_test.go
@@ -48,6 +48,7 @@ import (
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/events"
 	"github.com/gravitational/teleport/lib/modules"
+	"github.com/gravitational/teleport/lib/scopes"
 	"github.com/gravitational/teleport/lib/tlsca"
 	"github.com/gravitational/teleport/lib/utils"
 )
@@ -171,7 +172,7 @@ func TestRegister_Bot(t *testing.T) {
 		Spec: &machineidv1pb.BotSpec{
 			Roles: []string{},
 		},
-	}, srv.Clock().Now(), "")
+	}, srv.Clock().Now(), "", scopes.Features{})
 	require.NoError(t, err)
 
 	later := srv.Clock().Now().Add(4 * time.Hour)
@@ -316,7 +317,7 @@ func TestRegister_Bot_Expiry(t *testing.T) {
 					Roles:  []string{},
 					Traits: []*machineidv1pb.Trait{},
 				},
-			}, srv.Clock().Now(), "")
+			}, srv.Clock().Now(), "", scopes.Features{})
 			require.NoError(t, err)
 			tok := newBotToken(t, uuid.NewString(), botName, types.RoleBot, srv.Clock().Now().Add(time.Hour))
 			require.NoError(t, srv.Auth().UpsertToken(ctx, tok))

--- a/lib/auth/join_oracle_test.go
+++ b/lib/auth/join_oracle_test.go
@@ -242,7 +242,7 @@ func TestOracleTokenValidation(t *testing.T) {
 func TestRegisterUsingOracleMethod(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
-	p, err := newTestPack(ctx, t.TempDir())
+	p, err := newTestPack(ctx, testPackOptions{DataDir: t.TempDir()})
 	require.NoError(t, err)
 	a := p.a
 

--- a/lib/auth/join_test.go
+++ b/lib/auth/join_test.go
@@ -42,6 +42,7 @@ import (
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/events"
 	"github.com/gravitational/teleport/lib/join/joinclient"
+	"github.com/gravitational/teleport/lib/scopes"
 	"github.com/gravitational/teleport/lib/tlsca"
 	"github.com/gravitational/teleport/lib/utils"
 )
@@ -316,7 +317,7 @@ func TestJoin_Bot(t *testing.T) {
 		Spec: &machineidv1pb.BotSpec{
 			Roles: []string{},
 		},
-	}, srv.Clock().Now(), "")
+	}, srv.Clock().Now(), "", scopes.Features{})
 	require.NoError(t, err)
 
 	later := srv.Clock().Now().Add(4 * time.Hour)
@@ -460,7 +461,7 @@ func TestJoin_Bot_Expiry(t *testing.T) {
 					Roles:  []string{},
 					Traits: []*machineidv1pb.Trait{},
 				},
-			}, srv.Clock().Now(), "")
+			}, srv.Clock().Now(), "", scopes.Features{})
 			require.NoError(t, err)
 			tok := newBotToken(t, uuid.NewString(), botName, types.RoleBot, srv.Clock().Now().Add(time.Hour))
 			require.NoError(t, srv.Auth().UpsertToken(ctx, tok))

--- a/lib/auth/machineid/machineidv1/bot_service.go
+++ b/lib/auth/machineid/machineidv1/bot_service.go
@@ -123,6 +123,8 @@ type BotServiceConfig struct {
 	Emitter          apievents.Emitter
 	Reporter         usagereporter.UsageReporter
 	Clock            clockwork.Clock
+	// ScopesFeatures dictates whether scoped bot functionality is enabled.
+	ScopesFeatures scopes.Features
 }
 
 // NewBotService returns a new instance of the BotService.
@@ -154,6 +156,7 @@ func NewBotService(cfg BotServiceConfig) (*BotService, error) {
 		emitter:          cfg.Emitter,
 		reporter:         cfg.Reporter,
 		clock:            cfg.Clock,
+		scopesFeatures:   cfg.ScopesFeatures,
 	}, nil
 }
 
@@ -168,6 +171,8 @@ type BotService struct {
 	emitter          apievents.Emitter
 	reporter         usagereporter.UsageReporter
 	clock            clockwork.Clock
+	// scopesFeatures dictates whether scoped bot functionality is enabled.
+	scopesFeatures scopes.Features
 }
 
 // GetBot gets a bot by name. It will throw an error if the bot does not exist.
@@ -407,7 +412,7 @@ func (bs *BotService) createScopedBot(
 	authCtx *authz.ScopedContext,
 	bot *pb.Bot,
 ) (*pb.Bot, error) {
-	if err := scopes.AssertFeatureEnabled(); err != nil {
+	if err := bs.scopesFeatures.AssertEnabled(); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
@@ -470,9 +475,10 @@ func UpsertBot(
 	bot *pb.Bot,
 	now time.Time,
 	createdBy string,
+	scopesFeatures scopes.Features,
 ) (*pb.Bot, error) {
 	if bot.Scope != "" {
-		if err := scopes.AssertFeatureEnabled(); err != nil {
+		if err := scopesFeatures.AssertEnabled(); err != nil {
 			return nil, trace.Wrap(err)
 		}
 	}
@@ -597,7 +603,7 @@ func (bs *BotService) UpsertBot(ctx context.Context, req *pb.UpsertBotRequest) (
 	}
 
 	bot, err := UpsertBot(
-		ctx, bs.backend, req.Bot, bs.clock.Now(), authCtx.User.GetName(),
+		ctx, bs.backend, req.Bot, bs.clock.Now(), authCtx.User.GetName(), bs.scopesFeatures,
 	)
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/auth/machineid/machineidv1/machineidv1_test.go
+++ b/lib/auth/machineid/machineidv1/machineidv1_test.go
@@ -55,6 +55,7 @@ import (
 	"github.com/gravitational/teleport/lib/events/eventstest"
 	"github.com/gravitational/teleport/lib/itertools/stream"
 	"github.com/gravitational/teleport/lib/modules"
+	"github.com/gravitational/teleport/lib/scopes"
 	scopedaccess "github.com/gravitational/teleport/lib/scopes/access"
 	"github.com/gravitational/teleport/lib/tlsca"
 )
@@ -79,8 +80,8 @@ func TestBotResourceName(t *testing.T) {
 
 // TestCreateBot is an integration test that uses a real gRPC client/server.
 func TestCreateBot(t *testing.T) {
-	t.Setenv("TELEPORT_UNSTABLE_SCOPES", "yes")
-	srv, _ := newTestTLSServer(t)
+	t.Parallel()
+	srv, _ := newTestTLSServerWithScopesFeatures(t, scopes.Features{Enabled: true})
 	ctx := context.Background()
 
 	botCreator, _, err := authtest.CreateUserAndRole(
@@ -1185,8 +1186,8 @@ func TestUpdateBot(t *testing.T) {
 
 // TestUpsertBot is an integration test that uses a real gRPC client/server.
 func TestUpsertBot(t *testing.T) {
-	t.Setenv("TELEPORT_UNSTABLE_SCOPES", "yes")
-	srv, _ := newTestTLSServer(t)
+	t.Parallel()
+	srv, _ := newTestTLSServerWithScopesFeatures(t, scopes.Features{Enabled: true})
 	ctx := context.Background()
 
 	botCreator, _, err := authtest.CreateUserAndRole(srv.Auth(), "bot-creator", []string{}, []types.Rule{
@@ -1954,8 +1955,8 @@ func TestUpsertBot(t *testing.T) {
 
 // TestGetBot is an integration test that uses a real gRPC client/server.
 func TestGetBot(t *testing.T) {
-	t.Setenv("TELEPORT_UNSTABLE_SCOPES", "yes")
-	srv, _ := newTestTLSServer(t)
+	t.Parallel()
+	srv, _ := newTestTLSServerWithScopesFeatures(t, scopes.Features{Enabled: true})
 	ctx := context.Background()
 
 	botGetterUser, _, err := authtest.CreateUserAndRole(
@@ -2227,8 +2228,8 @@ func TestGetBot(t *testing.T) {
 
 // TestListBots is an integration test that uses a real gRPC client/server.
 func TestListBots(t *testing.T) {
-	t.Setenv("TELEPORT_UNSTABLE_SCOPES", "yes")
-	srv, _ := newTestTLSServer(t)
+	t.Parallel()
+	srv, _ := newTestTLSServerWithScopesFeatures(t, scopes.Features{Enabled: true})
 	ctx := context.Background()
 
 	botListerUser, _, err := authtest.CreateUserAndRole(
@@ -2485,8 +2486,8 @@ func TestListBots(t *testing.T) {
 
 // TestDeleteBot is an integration test that uses a real gRPC client/server.
 func TestDeleteBot(t *testing.T) {
-	t.Setenv("TELEPORT_UNSTABLE_SCOPES", "yes")
-	srv, _ := newTestTLSServer(t)
+	t.Parallel()
+	srv, _ := newTestTLSServerWithScopesFeatures(t, scopes.Features{Enabled: true})
 	ctx := context.Background()
 
 	botDeleterUser, _, err := authtest.CreateUserAndRole(
@@ -3116,8 +3117,8 @@ func createBotInstance(
 }
 
 func TestBotInstanceService_DeleteBotInstance(t *testing.T) {
-	t.Setenv("TELEPORT_UNSTABLE_SCOPES", "yes")
-	srv, _ := newTestTLSServer(t)
+	t.Parallel()
+	srv, _ := newTestTLSServerWithScopesFeatures(t, scopes.Features{Enabled: true})
 	ctx := t.Context()
 
 	unscopedUser, _, err := authtest.CreateUserAndRole(
@@ -3243,8 +3244,8 @@ func TestBotInstanceService_DeleteBotInstance(t *testing.T) {
 }
 
 func TestBotInstanceService_GetBotInstance(t *testing.T) {
-	t.Setenv("TELEPORT_UNSTABLE_SCOPES", "yes")
-	srv, _ := newTestTLSServer(t)
+	t.Parallel()
+	srv, _ := newTestTLSServerWithScopesFeatures(t, scopes.Features{Enabled: true})
 	ctx := t.Context()
 
 	unscopedUser, _, err := authtest.CreateUserAndRole(
@@ -3370,8 +3371,8 @@ func TestBotInstanceService_GetBotInstance(t *testing.T) {
 }
 
 func TestBotInstanceService_ListBotInstancesV2(t *testing.T) {
-	t.Setenv("TELEPORT_UNSTABLE_SCOPES", "yes")
-	srv, _ := newTestTLSServer(t)
+	t.Parallel()
+	srv, _ := newTestTLSServerWithScopesFeatures(t, scopes.Features{Enabled: true})
 	ctx := t.Context()
 
 	unscopedUser, _, err := authtest.CreateUserAndRole(
@@ -3529,8 +3530,8 @@ func TestBotInstanceService_ListBotInstancesV2(t *testing.T) {
 }
 
 func TestBotInstanceService_SubmitHeartbeat(t *testing.T) {
-	t.Setenv("TELEPORT_UNSTABLE_SCOPES", "yes")
-	srv, _ := newTestTLSServer(t)
+	t.Parallel()
+	srv, _ := newTestTLSServerWithScopesFeatures(t, scopes.Features{Enabled: true})
 	ctx := t.Context()
 
 	adminClient, err := srv.NewClient(authtest.TestAdmin())
@@ -3654,9 +3655,14 @@ func TestBotInstanceService_SubmitHeartbeat(t *testing.T) {
 }
 
 func newTestTLSServer(t testing.TB) (*authtest.TLSServer, *eventstest.MockRecorderEmitter) {
+	return newTestTLSServerWithScopesFeatures(t, scopes.Features{})
+}
+
+func newTestTLSServerWithScopesFeatures(t testing.TB, scopesFeatures scopes.Features) (*authtest.TLSServer, *eventstest.MockRecorderEmitter) {
 	as, err := authtest.NewAuthServer(authtest.AuthServerConfig{
-		Dir:   t.TempDir(),
-		Clock: clockwork.NewFakeClockAt(time.Now().Round(time.Second).UTC()),
+		Dir:            t.TempDir(),
+		Clock:          clockwork.NewFakeClockAt(time.Now().Round(time.Second).UTC()),
+		ScopesFeatures: scopesFeatures,
 	})
 	require.NoError(t, err)
 

--- a/lib/auth/scopes/access/service.go
+++ b/lib/auth/scopes/access/service.go
@@ -40,6 +40,8 @@ type Config struct {
 	Writer           services.ScopedAccessWriter
 	BackendReader    services.ScopedAccessReader
 	Logger           *slog.Logger
+	// ScopesFeatures dictates whether scoped access control RPCs are enabled.
+	ScopesFeatures scopes.Features
 }
 
 // CheckAndSetDefaults checks the config for missing parameters and sets default values.
@@ -87,7 +89,7 @@ func New(cfg Config) (*Server, error) {
 
 // CreateScopedRole implements [scopedaccessv1.ScopedRoleServiceServer].
 func (s *Server) CreateScopedRole(ctx context.Context, req *scopedaccessv1.CreateScopedRoleRequest) (*scopedaccessv1.CreateScopedRoleResponse, error) {
-	if err := scopes.AssertFeatureEnabled(); err != nil {
+	if err := s.cfg.ScopesFeatures.AssertEnabled(); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
@@ -114,7 +116,7 @@ func (s *Server) CreateScopedRole(ctx context.Context, req *scopedaccessv1.Creat
 
 // CreateScopedRoleAssignment implements [scopedaccessv1.ScopedRoleServiceServer].
 func (s *Server) CreateScopedRoleAssignment(ctx context.Context, req *scopedaccessv1.CreateScopedRoleAssignmentRequest) (*scopedaccessv1.CreateScopedRoleAssignmentResponse, error) {
-	if err := scopes.AssertFeatureEnabled(); err != nil {
+	if err := s.cfg.ScopesFeatures.AssertEnabled(); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
@@ -433,7 +435,7 @@ func (s *Server) ListScopedRoles(ctx context.Context, req *scopedaccessv1.ListSc
 
 // UpdateScopedRole implements [scopedaccessv1.ScopedRoleServiceServer].
 func (s *Server) UpdateScopedRole(ctx context.Context, req *scopedaccessv1.UpdateScopedRoleRequest) (*scopedaccessv1.UpdateScopedRoleResponse, error) {
-	if err := scopes.AssertFeatureEnabled(); err != nil {
+	if err := s.cfg.ScopesFeatures.AssertEnabled(); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
@@ -462,7 +464,7 @@ func (s *Server) UpdateScopedRole(ctx context.Context, req *scopedaccessv1.Updat
 
 // UpdateScopedRoleAssignment implements [scopedaccessv1.ScopedAccessServiceServer].
 func (s *Server) UpdateScopedRoleAssignment(ctx context.Context, req *scopedaccessv1.UpdateScopedRoleAssignmentRequest) (*scopedaccessv1.UpdateScopedRoleAssignmentResponse, error) {
-	if err := scopes.AssertFeatureEnabled(); err != nil {
+	if err := s.cfg.ScopesFeatures.AssertEnabled(); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
@@ -498,7 +500,7 @@ func (s *Server) UpdateScopedRoleAssignment(ctx context.Context, req *scopedacce
 
 // UpsertScopedRole implements [scopedaccessv1.ScopedAccessServiceServer].
 func (s *Server) UpsertScopedRole(ctx context.Context, req *scopedaccessv1.UpsertScopedRoleRequest) (*scopedaccessv1.UpsertScopedRoleResponse, error) {
-	if err := scopes.AssertFeatureEnabled(); err != nil {
+	if err := s.cfg.ScopesFeatures.AssertEnabled(); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
@@ -523,7 +525,7 @@ func (s *Server) UpsertScopedRole(ctx context.Context, req *scopedaccessv1.Upser
 
 // UpsertScopedRoleAssignment implements [scopedaccessv1.ScopedAccessServiceServer].
 func (s *Server) UpsertScopedRoleAssignment(ctx context.Context, req *scopedaccessv1.UpsertScopedRoleAssignmentRequest) (*scopedaccessv1.UpsertScopedRoleAssignmentResponse, error) {
-	if err := scopes.AssertFeatureEnabled(); err != nil {
+	if err := s.cfg.ScopesFeatures.AssertEnabled(); err != nil {
 		return nil, trace.Wrap(err)
 	}
 

--- a/lib/auth/scopes/access/service_test.go
+++ b/lib/auth/scopes/access/service_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/gravitational/teleport/lib/backend"
 	"github.com/gravitational/teleport/lib/backend/memory"
 	"github.com/gravitational/teleport/lib/modules/modulestest"
+	"github.com/gravitational/teleport/lib/scopes"
 	scopedaccess "github.com/gravitational/teleport/lib/scopes/access"
 	scopedaccesscache "github.com/gravitational/teleport/lib/scopes/cache/access"
 	"github.com/gravitational/teleport/lib/scopes/pinning"
@@ -112,6 +113,7 @@ func newServerForIdentity(t *testing.T, bk *backendPack, accessInfo *services.Ac
 		Reader:           bk.cache,
 		Writer:           bk.service,
 		BackendReader:    bk.service,
+		ScopesFeatures:   scopes.Features{Enabled: true},
 	})
 	require.NoError(t, err)
 
@@ -172,7 +174,7 @@ func newBackendPack(t *testing.T) *backendPack {
 // TestRoleBasics verifies that basic CRUD operations on scoped roles work as expected, with a focus on ensuring that
 // pinned scopes and role permissions are being properly enforced.
 func TestRoleBasics(t *testing.T) {
-	t.Setenv("TELEPORT_UNSTABLE_SCOPES", "yes")
+	t.Parallel()
 
 	ctx := t.Context()
 	bk := newBackendPack(t)
@@ -476,7 +478,7 @@ func TestRoleBasics(t *testing.T) {
 // TestAssignmentBasics verifies that basic CRUD operations on scoped role assignments work as expected, with a focus on ensuring that
 // pinned scopes and role permissions are being properly enforced.
 func TestAssignmentBasics(t *testing.T) {
-	t.Setenv("TELEPORT_UNSTABLE_SCOPES", "yes")
+	t.Parallel()
 
 	ctx := t.Context()
 	newForgedStatus := func() *scopedaccessv1.ScopedRoleAssignmentStatus {
@@ -804,7 +806,7 @@ func newScopedRoleAssignmentAtScope(roleName string, scope string) *scopedaccess
 
 // TestUnscopedBasics verifies that unscoped access control works as expected.
 func TestUnscopedBasics(t *testing.T) {
-	t.Setenv("TELEPORT_UNSTABLE_SCOPES", "yes")
+	t.Parallel()
 
 	ctx := t.Context()
 	bk := newBackendPack(t)
@@ -1098,7 +1100,7 @@ func TestUnscopedBasics(t *testing.T) {
 // Earlier iterations of scoped APIs used transactional logic to prevent malformed assignments, but that
 // presented usability and maintainability issues.
 func TestAccessChecksSkipInconsistentAssignments(t *testing.T) {
-	t.Setenv("TELEPORT_UNSTABLE_SCOPES", "yes")
+	t.Parallel()
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/lib/auth/scopes/joining/service_test.go
+++ b/lib/auth/scopes/joining/service_test.go
@@ -39,6 +39,7 @@ import (
 	"github.com/gravitational/teleport/lib/authz"
 	"github.com/gravitational/teleport/lib/backend"
 	"github.com/gravitational/teleport/lib/backend/memory"
+	"github.com/gravitational/teleport/lib/scopes"
 	scopedaccess "github.com/gravitational/teleport/lib/scopes/access"
 	jointoken "github.com/gravitational/teleport/lib/scopes/joining"
 	"github.com/gravitational/teleport/lib/scopes/pinning"
@@ -542,7 +543,7 @@ func newBackendPack(t *testing.T) *backendPack {
 
 	service := local.NewScopedAccessService(backend)
 	classicService := local.NewAccessService(backend)
-	scopedTokenService, err := local.NewScopedTokenService(backend)
+	scopedTokenService, err := local.NewScopedTokenService(backend, scopes.Features{Enabled: true})
 	require.NoError(t, err)
 
 	roles := []*scopedaccessv1.ScopedRole{

--- a/lib/auth/tls_test.go
+++ b/lib/auth/tls_test.go
@@ -80,6 +80,7 @@ import (
 	"github.com/gravitational/teleport/lib/jwt"
 	"github.com/gravitational/teleport/lib/modules"
 	"github.com/gravitational/teleport/lib/modules/modulestest"
+	"github.com/gravitational/teleport/lib/scopes"
 	scopedaccess "github.com/gravitational/teleport/lib/scopes/access"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/sshca"
@@ -1523,9 +1524,8 @@ func TestAuthPreferenceSettings(t *testing.T) {
 }
 
 func TestAuthPreferenceSettings_ScopedIdentity(t *testing.T) {
-	t.Setenv("TELEPORT_UNSTABLE_SCOPES", "yes")
-
-	srv := newTestTLSServer(t)
+	t.Parallel()
+	srv := newTestTLSServer(t, withScopesFeatures(scopes.Features{Enabled: true}))
 	ctx := t.Context()
 
 	adminClient, err := srv.NewClient(authtest.TestAdmin())
@@ -2610,9 +2610,8 @@ func TestGetCertAuthority(t *testing.T) {
 }
 
 func TestGetCertAuthority_ScopedIdentity(t *testing.T) {
-	t.Setenv("TELEPORT_UNSTABLE_SCOPES", "yes")
-
-	srv := newTestTLSServer(t)
+	t.Parallel()
+	srv := newTestTLSServer(t, withScopesFeatures(scopes.Features{Enabled: true}))
 	ctx := t.Context()
 
 	adminClient, err := srv.NewClient(authtest.TestAdmin())
@@ -5025,9 +5024,8 @@ func eventsTestKinds(tests []eventTest) []types.WatchKind {
 // WatchEvents RPC to watch CertAuthorities without secrets (implicit permission),
 // and that watching with secrets is correctly denied.
 func TestWatchEvents_ScopedIdentity(t *testing.T) {
-	t.Setenv("TELEPORT_UNSTABLE_SCOPES", "yes")
-
-	srv := newTestTLSServer(t)
+	t.Parallel()
+	srv := newTestTLSServer(t, withScopesFeatures(scopes.Features{Enabled: true}))
 	ctx := t.Context()
 
 	adminClient, err := srv.NewClient(authtest.TestAdmin())
@@ -6031,6 +6029,7 @@ type testTLSServerOptions struct {
 	accessGraph     *auth.AccessGraphConfig
 	clock           clockwork.Clock
 	bufconnListener bool
+	scopesFeatures  scopes.Features
 }
 
 type testTLSServerOption func(*testTLSServerOptions)
@@ -6059,6 +6058,12 @@ func withBufconnListener() testTLSServerOption {
 	}
 }
 
+func withScopesFeatures(scopesFeatures scopes.Features) testTLSServerOption {
+	return func(options *testTLSServerOptions) {
+		options.scopesFeatures = scopesFeatures
+	}
+}
+
 // newTestTLSServer is a helper that returns a *authtest.TLSServer with sensible
 // defaults for most tests that are exercising Auth Service RPCs.
 //
@@ -6073,9 +6078,10 @@ func newTestTLSServer(t testing.TB, opts ...testTLSServerOption) *authtest.TLSSe
 		options.clock = clockwork.NewFakeClockAt(time.Now().Round(time.Second).UTC())
 	}
 	as, err := authtest.NewAuthServer(authtest.AuthServerConfig{
-		Dir:          t.TempDir(),
-		Clock:        options.clock,
-		CacheEnabled: options.cacheEnabled,
+		Dir:            t.TempDir(),
+		Clock:          options.clock,
+		CacheEnabled:   options.cacheEnabled,
+		ScopesFeatures: options.scopesFeatures,
 	})
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, as.Close()) })

--- a/lib/auth/usage_test.go
+++ b/lib/auth/usage_test.go
@@ -119,7 +119,7 @@ func setUpAccessRequestLimitForJulyAndAugust(t *testing.T, username string, role
 	})
 
 	ctx := context.Background()
-	p, err := newTestPack(ctx, t.TempDir())
+	p, err := newTestPack(ctx, testPackOptions{DataDir: t.TempDir()})
 	require.NoError(t, err)
 
 	// Set up RBAC

--- a/lib/authz/permissions.go
+++ b/lib/authz/permissions.go
@@ -45,6 +45,7 @@ import (
 	"github.com/gravitational/teleport/api/utils"
 	"github.com/gravitational/teleport/api/utils/keys"
 	dtauthz "github.com/gravitational/teleport/lib/devicetrust/authz"
+	"github.com/gravitational/teleport/lib/scopes"
 	scopedaccess "github.com/gravitational/teleport/lib/scopes/access"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/services/readonly"
@@ -95,6 +96,8 @@ type AuthorizerOpts struct {
 	MFAAuthenticator    MFAAuthenticator
 	LockWatcher         *services.LockWatcher
 	Logger              *slog.Logger
+	// ScopesFeatures dictates which scoped authorization components are enabled.
+	ScopesFeatures scopes.Features
 
 	// DeviceAuthorization holds Device Trust authorization options.
 	//
@@ -147,6 +150,7 @@ func newAuthorizer(opts AuthorizerOpts) (*authorizer, error) {
 		mfaAuthenticator:        opts.MFAAuthenticator,
 		lockWatcher:             opts.LockWatcher,
 		logger:                  logger,
+		scopesFeatures:          opts.ScopesFeatures,
 		disableGlobalDeviceMode: opts.DeviceAuthorization.DisableGlobalMode,
 		disableRoleDeviceMode:   opts.DeviceAuthorization.DisableRoleMode,
 	}, nil
@@ -241,6 +245,8 @@ type authorizer struct {
 	mfaAuthenticator    MFAAuthenticator
 	lockWatcher         *services.LockWatcher
 	logger              *slog.Logger
+	// scopesFeatures dictates whether scoped authorization is enabled.
+	scopesFeatures scopes.Features
 
 	disableGlobalDeviceMode bool
 	disableRoleDeviceMode   bool

--- a/lib/authz/permissions_test.go
+++ b/lib/authz/permissions_test.go
@@ -50,6 +50,7 @@ import (
 	"github.com/gravitational/teleport/lib/fixtures"
 	"github.com/gravitational/teleport/lib/modules"
 	"github.com/gravitational/teleport/lib/modules/modulestest"
+	"github.com/gravitational/teleport/lib/scopes"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/services/local"
 	"github.com/gravitational/teleport/lib/services/readonly"
@@ -1719,7 +1720,6 @@ func (f *brokenScopedRoleReader) ListScopedRoles(_ context.Context, _ *scopedacc
 // TestAuthorizeScopedWithLocksForScopedBuiltinRole verifies that a server lock blocks
 // a scoped agent from calling AuthorizeScoped.
 func TestAuthorizeScopedWithLocksForScopedBuiltinRole(t *testing.T) {
-	t.Setenv("TELEPORT_UNSTABLE_SCOPES", "yes")
 	ctx := t.Context()
 
 	client, watcher, _ := newTestResources(t)
@@ -1728,6 +1728,7 @@ func TestAuthorizeScopedWithLocksForScopedBuiltinRole(t *testing.T) {
 		AccessPoint:      client,
 		LockWatcher:      watcher,
 		ScopedRoleReader: &brokenScopedRoleReader{},
+		ScopesFeatures:   scopes.Features{Enabled: true},
 	})
 	require.NoError(t, err)
 
@@ -1768,7 +1769,6 @@ func TestAuthorizeScopedWithLocksForScopedBuiltinRole(t *testing.T) {
 // TestAuthorizeScopedBuiltinRolePartialSkip verifies that AuthorizeScoped succeeds when a scoped agent
 // pin contains a mix of known and unrecognized system roles.
 func TestAuthorizeScopedBuiltinRolePartialSkip(t *testing.T) {
-	t.Setenv("TELEPORT_UNSTABLE_SCOPES", "yes")
 	ctx := t.Context()
 
 	client, watcher, _ := newTestResources(t)
@@ -1777,6 +1777,7 @@ func TestAuthorizeScopedBuiltinRolePartialSkip(t *testing.T) {
 		AccessPoint:      client,
 		LockWatcher:      watcher,
 		ScopedRoleReader: &brokenScopedRoleReader{},
+		ScopesFeatures:   scopes.Features{Enabled: true},
 	})
 	require.NoError(t, err)
 
@@ -1844,7 +1845,6 @@ func TestAuthorizeScopedBuiltinRolePartialSkip(t *testing.T) {
 // TestAuthorizeScopedWithLocksForScopedLocalUser verifies that a user lock blocks
 // a scoped user from calling AuthorizeScoped.
 func TestAuthorizeScopedWithLocksForScopedLocalUser(t *testing.T) {
-	t.Setenv("TELEPORT_UNSTABLE_SCOPES", "yes")
 	ctx := t.Context()
 
 	client, watcher, _ := newTestResources(t)
@@ -1853,6 +1853,7 @@ func TestAuthorizeScopedWithLocksForScopedLocalUser(t *testing.T) {
 		AccessPoint:      client,
 		LockWatcher:      watcher,
 		ScopedRoleReader: &brokenScopedRoleReader{},
+		ScopesFeatures:   scopes.Features{Enabled: true},
 	})
 	require.NoError(t, err)
 

--- a/lib/authz/scoped.go
+++ b/lib/authz/scoped.go
@@ -26,7 +26,6 @@ import (
 	"github.com/gravitational/trace"
 
 	"github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/teleport/lib/scopes"
 	"github.com/gravitational/teleport/lib/scopes/pinning"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/services/readonly"
@@ -90,7 +89,7 @@ func (a *authorizer) authorizeScoped(ctx context.Context) (scopedCtx *ScopedCont
 		}
 	}()
 
-	if !scopes.FeatureEnabled() {
+	if !a.scopesFeatures.Enabled {
 		return nil, trace.AccessDenied("cannot authorize scoped identity, scoping is not enabled for this cluster")
 	}
 

--- a/lib/client/api_login_test.go
+++ b/lib/client/api_login_test.go
@@ -60,6 +60,7 @@ import (
 	"github.com/gravitational/teleport/lib/cloud/imds"
 	"github.com/gravitational/teleport/lib/defaults"
 	dtauthntypes "github.com/gravitational/teleport/lib/devicetrust/authn/types"
+	"github.com/gravitational/teleport/lib/scopes"
 	scopedaccess "github.com/gravitational/teleport/lib/scopes/access"
 	"github.com/gravitational/teleport/lib/scopes/pinning"
 	"github.com/gravitational/teleport/lib/service"
@@ -71,8 +72,6 @@ import (
 )
 
 func TestTeleportClient_Login_local(t *testing.T) {
-	t.Setenv("TELEPORT_UNSTABLE_SCOPES", "yes")
-
 	type webauthnFunc func(ctx context.Context, origin string, assertion *wantypes.CredentialAssertion, prompt wancli.LoginPrompt) (*proto.MFAAuthenticateResponse, error)
 
 	waitForCancelFn := func(ctx context.Context) (string, error) {
@@ -288,8 +287,8 @@ func TestTeleportClient_Login_local(t *testing.T) {
 			t.Parallel()
 
 			// Start Teleport.
-			clock := clockwork.NewFakeClockAt(time.Now())
-			sa := newStandaloneTeleport(t, clock)
+			clock := clockwork.NewFakeClock()
+			sa := newStandaloneScopedTeleport(t, clock, scopes.Features{Enabled: true})
 			username := sa.Username
 			password := sa.Password
 			webID := sa.WebAuthnID
@@ -569,7 +568,8 @@ type standaloneBundle struct {
 
 // TODO(codingllama): Consider refactoring newStandaloneTeleport into a public
 // function and reusing in other places.
-func newStandaloneTeleport(t *testing.T, clock clockwork.Clock) *standaloneBundle {
+func newStandaloneScopedTeleport(t *testing.T, clock clockwork.Clock, scopeFeatures scopes.Features) *standaloneBundle {
+
 	randomAddr := utils.NetAddr{AddrNetwork: "tcp", Addr: "127.0.0.1:0"}
 
 	staticToken := uuid.New().String()
@@ -601,6 +601,7 @@ func newStandaloneTeleport(t *testing.T, clock clockwork.Clock) *standaloneBundl
 	// AuthServer setup.
 	cfg := servicecfg.MakeDefaultConfig()
 	cfg.DataDir = makeDataDir()
+	cfg.ScopesFeatures = scopeFeatures
 	cfg.Hostname = "localhost"
 	cfg.Clock = clock
 	cfg.Logger = logtest.NewLogger()
@@ -688,6 +689,7 @@ func newStandaloneTeleport(t *testing.T, clock clockwork.Clock) *standaloneBundl
 	// Proxy setup.
 	cfg = servicecfg.MakeDefaultConfig()
 	cfg.DataDir = makeDataDir()
+	cfg.ScopesFeatures = scopeFeatures
 	cfg.Hostname = "localhost"
 	cfg.SetToken(staticToken)
 	cfg.Clock = clock
@@ -718,6 +720,12 @@ func newStandaloneTeleport(t *testing.T, clock clockwork.Clock) *standaloneBundl
 		Auth:         authProcess,
 		Proxy:        proxyProcess,
 	}
+}
+
+// TODO(codingllama): Consider refactoring newStandaloneTeleport into a public
+// function and reusing in other places.
+func newStandaloneTeleport(t *testing.T, clock clockwork.Clock) *standaloneBundle {
+	return newStandaloneScopedTeleport(t, clock, scopes.Features{})
 }
 
 // createAndAssignScopedRoles creates two scoped roles and assigns them to the given user, one at /aa and one at /bb. this provides

--- a/lib/join/azurejoin/join_azure_test.go
+++ b/lib/join/azurejoin/join_azure_test.go
@@ -54,6 +54,7 @@ import (
 	"github.com/gravitational/teleport/lib/join/azurejoin"
 	"github.com/gravitational/teleport/lib/join/joinclient"
 	"github.com/gravitational/teleport/lib/join/jointest"
+	"github.com/gravitational/teleport/lib/scopes"
 	"github.com/gravitational/teleport/lib/scopes/joining"
 	"github.com/gravitational/teleport/lib/tlsca"
 )
@@ -156,12 +157,13 @@ func makeToken(issuer, tenantID, managedIdentityResourceID, azureResourceID stri
 }
 
 func TestJoinAzure(t *testing.T) {
-	t.Setenv("TELEPORT_UNSTABLE_SCOPES", "yes")
+	t.Parallel()
 	ctx := t.Context()
 
 	server, err := authtest.NewTestServer(authtest.ServerConfig{
 		Auth: authtest.AuthServerConfig{
-			Dir: t.TempDir(),
+			Dir:            t.TempDir(),
+			ScopesFeatures: scopes.Features{Enabled: true},
 		},
 	})
 	require.NoError(t, err)
@@ -656,12 +658,13 @@ func TestJoinAzure(t *testing.T) {
 // TestAuth_RegisterUsingAzureClaims tests the Azure join method by verifying
 // joining VMs by the token claims rather than from the Azure VM API.
 func TestJoinAzureClaims(t *testing.T) {
-	t.Setenv("TELEPORT_UNSTABLE_SCOPES", "yes")
+	t.Parallel()
 	ctx := t.Context()
 
 	server, err := authtest.NewTestServer(authtest.ServerConfig{
 		Auth: authtest.AuthServerConfig{
-			Dir: t.TempDir(),
+			Dir:            t.TempDir(),
+			ScopesFeatures: scopes.Features{Enabled: true},
 		},
 	})
 	require.NoError(t, err)
@@ -701,7 +704,7 @@ func TestJoinAzureClaims(t *testing.T) {
 			Name: botName,
 		},
 		Spec: &machineidv1pb.BotSpec{},
-	}, a.GetClock().Now(), "")
+	}, a.GetClock().Now(), "", scopes.Features{})
 	require.NoError(t, err)
 
 	tests := []struct {

--- a/lib/join/join_azuredevops_test.go
+++ b/lib/join/join_azuredevops_test.go
@@ -35,6 +35,7 @@ import (
 	"github.com/gravitational/teleport/lib/join/azuredevops"
 	"github.com/gravitational/teleport/lib/join/joinclient"
 	"github.com/gravitational/teleport/lib/join/jointest"
+	"github.com/gravitational/teleport/lib/scopes"
 	"github.com/gravitational/teleport/lib/scopes/joining"
 )
 
@@ -58,7 +59,7 @@ func (m *mockAzureDevopsTokenValidator) Validate(
 }
 
 func TestJoinAzureDevops(t *testing.T) {
-	t.Setenv("TELEPORT_UNSTABLE_SCOPES", "yes")
+	t.Parallel()
 	const (
 		validIDToken          = "test.fake.jwt"
 		validOrgID            = "0000-0000-0000-1337"
@@ -94,7 +95,8 @@ func TestJoinAzureDevops(t *testing.T) {
 	ctx := t.Context()
 	server, err := authtest.NewTestServer(authtest.ServerConfig{
 		Auth: authtest.AuthServerConfig{
-			Dir: t.TempDir(),
+			Dir:            t.TempDir(),
+			ScopesFeatures: scopes.Features{Enabled: true},
 		},
 	})
 	require.NoError(t, err)

--- a/lib/join/join_bound_keypair_test.go
+++ b/lib/join/join_bound_keypair_test.go
@@ -51,6 +51,7 @@ import (
 	"github.com/gravitational/teleport/lib/boundkeypair"
 	"github.com/gravitational/teleport/lib/cryptosuites"
 	"github.com/gravitational/teleport/lib/join/joinclient"
+	"github.com/gravitational/teleport/lib/scopes"
 	scopedaccess "github.com/gravitational/teleport/lib/scopes/access"
 	"github.com/gravitational/teleport/lib/scopes/joining"
 	"github.com/gravitational/teleport/lib/tlsca"
@@ -76,9 +77,14 @@ func parseJoinState(t *testing.T, state []byte) *boundkeypair.JoinState {
 }
 
 func newTestTLSServer(t *testing.T, clock clockwork.Clock, opts ...authtest.TestTLSServerOption) *authtest.TLSServer {
+	return newTestTLSServerWithScopesFeatures(t, clock, scopes.Features{}, opts...)
+}
+
+func newTestTLSServerWithScopesFeatures(t *testing.T, clock clockwork.Clock, scopesFeatures scopes.Features, opts ...authtest.TestTLSServerOption) *authtest.TLSServer {
 	as, err := authtest.NewAuthServer(authtest.AuthServerConfig{
-		Dir:   t.TempDir(),
-		Clock: clock,
+		Dir:            t.TempDir(),
+		Clock:          clock,
+		ScopesFeatures: scopesFeatures,
 	})
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, as.Close()) })
@@ -1885,7 +1891,7 @@ func createScopedBot(t *testing.T, srv *authtest.TLSServer, adminClient *authcli
 }
 
 func TestJoinBoundKeypair_ScopedToken(t *testing.T) {
-	t.Setenv("TELEPORT_UNSTABLE_SCOPES", "yes")
+	t.Parallel()
 
 	ctx := t.Context()
 
@@ -1896,7 +1902,7 @@ func TestJoinBoundKeypair_ScopedToken(t *testing.T) {
 
 	clock := clockwork.NewFakeClockAt(time.Now().Round(time.Second).UTC())
 
-	srv := newTestTLSServer(t, clock)
+	srv := newTestTLSServerWithScopesFeatures(t, clock, scopes.Features{Enabled: true})
 	authServer := srv.Auth()
 
 	_, err := authtest.CreateRole(ctx, authServer, "example", types.RoleSpecV6{})

--- a/lib/join/join_ec2_test.go
+++ b/lib/join/join_ec2_test.go
@@ -38,6 +38,7 @@ import (
 	"github.com/gravitational/teleport/lib/join/ec2join"
 	"github.com/gravitational/teleport/lib/join/joinclient"
 	"github.com/gravitational/teleport/lib/join/jointest"
+	"github.com/gravitational/teleport/lib/scopes"
 	"github.com/gravitational/teleport/lib/scopes/joining"
 )
 
@@ -149,12 +150,13 @@ func (c ec2ClientRunning) DescribeInstances(ctx context.Context, params *ec2.Des
 }
 
 func TestJoinEC2(t *testing.T) {
-	t.Setenv("TELEPORT_UNSTABLE_SCOPES", "yes")
+	t.Parallel()
 	ctx := context.Background()
 
 	testServer, err := authtest.NewTestServer(authtest.ServerConfig{
 		Auth: authtest.AuthServerConfig{
-			Dir: t.TempDir(),
+			Dir:            t.TempDir(),
+			ScopesFeatures: scopes.Features{Enabled: true},
 		},
 	})
 	require.NoError(t, err)

--- a/lib/join/join_gcp_test.go
+++ b/lib/join/join_gcp_test.go
@@ -36,6 +36,7 @@ import (
 	"github.com/gravitational/teleport/lib/join/gcp"
 	"github.com/gravitational/teleport/lib/join/joinclient"
 	"github.com/gravitational/teleport/lib/join/jointest"
+	"github.com/gravitational/teleport/lib/scopes"
 	"github.com/gravitational/teleport/lib/scopes/joining"
 )
 
@@ -52,8 +53,7 @@ func (m *mockGCPTokenValidator) Validate(_ context.Context, token string) (*gcp.
 }
 
 func TestJoinGCP(t *testing.T) {
-	t.Setenv("TELEPORT_UNSTABLE_SCOPES", "yes")
-
+	t.Parallel()
 	validIDToken := "test.fake.jwt"
 	idTokenValidator := &mockGCPTokenValidator{
 		tokens: map[string]gcp.IDTokenClaims{
@@ -75,7 +75,8 @@ func TestJoinGCP(t *testing.T) {
 
 	authServer, err := authtest.NewTestServer(authtest.ServerConfig{
 		Auth: authtest.AuthServerConfig{
-			Dir: t.TempDir(),
+			Dir:            t.TempDir(),
+			ScopesFeatures: scopes.Features{Enabled: true},
 		},
 	})
 	require.NoError(t, err)

--- a/lib/join/join_iam_test.go
+++ b/lib/join/join_iam_test.go
@@ -51,6 +51,7 @@ import (
 	"github.com/gravitational/teleport/lib/join/iamjoin"
 	"github.com/gravitational/teleport/lib/join/joinclient"
 	"github.com/gravitational/teleport/lib/join/jointest"
+	"github.com/gravitational/teleport/lib/scopes"
 	"github.com/gravitational/teleport/lib/scopes/joining"
 	"github.com/gravitational/teleport/lib/utils"
 )
@@ -136,7 +137,7 @@ type iamJoinTestCase struct {
 }
 
 func TestJoinIAM(t *testing.T) {
-	t.Setenv("TELEPORT_UNSTABLE_SCOPES", "yes")
+	t.Parallel()
 	ctx := t.Context()
 
 	allowedOrgIDUsingAmbientCredentials := "o-allowedorg"
@@ -172,6 +173,7 @@ func TestJoinIAM(t *testing.T) {
 		Auth: authtest.AuthServerConfig{
 			Dir:                          t.TempDir(),
 			AWSOrganizationsClientGetter: organizationsClientGetter,
+			ScopesFeatures:               scopes.Features{Enabled: true},
 		},
 	})
 	require.NoError(t, err)
@@ -179,8 +181,9 @@ func TestJoinIAM(t *testing.T) {
 
 	fipsServer, err := authtest.NewTestServer(authtest.ServerConfig{
 		Auth: authtest.AuthServerConfig{
-			Dir:  t.TempDir(),
-			FIPS: true,
+			Dir:            t.TempDir(),
+			FIPS:           true,
+			ScopesFeatures: scopes.Features{Enabled: true},
 		},
 	})
 	require.NoError(t, err)

--- a/lib/join/join_kubernetes_test.go
+++ b/lib/join/join_kubernetes_test.go
@@ -37,6 +37,7 @@ import (
 	"github.com/gravitational/teleport/lib/join/jointest"
 	kubetoken "github.com/gravitational/teleport/lib/kube/token"
 	"github.com/gravitational/teleport/lib/oidc/fakeissuer"
+	"github.com/gravitational/teleport/lib/scopes"
 	"github.com/gravitational/teleport/lib/scopes/joining"
 )
 
@@ -61,7 +62,7 @@ func newFakeIDP(t *testing.T) *fakeissuer.IDP {
 }
 
 func TestJoinKubernetes(t *testing.T) {
-	t.Setenv("TELEPORT_UNSTABLE_SCOPES", "yes")
+	t.Parallel()
 	// Test setup
 
 	// Creating an auth server with mock Kubernetes token validator
@@ -97,7 +98,8 @@ func TestJoinKubernetes(t *testing.T) {
 
 	authServer, err := authtest.NewTestServer(authtest.ServerConfig{
 		Auth: authtest.AuthServerConfig{
-			Dir: t.TempDir(),
+			Dir:            t.TempDir(),
+			ScopesFeatures: scopes.Features{Enabled: true},
 		},
 	})
 	require.NoError(t, err)

--- a/lib/join/join_test.go
+++ b/lib/join/join_test.go
@@ -51,6 +51,7 @@ import (
 	"github.com/gravitational/teleport/lib/events"
 	"github.com/gravitational/teleport/lib/join/joinclient"
 	"github.com/gravitational/teleport/lib/join/joinv1"
+	"github.com/gravitational/teleport/lib/scopes"
 	"github.com/gravitational/teleport/lib/scopes/joining"
 	"github.com/gravitational/teleport/lib/srv/alpnproxy/common"
 	"github.com/gravitational/teleport/lib/utils"
@@ -68,7 +69,7 @@ import (
 // Finally, it tests various scenarios where a node attempts to join by
 // connecting to the proxy's gRPC join service.
 func TestJoinToken(t *testing.T) {
-	t.Setenv("TELEPORT_UNSTABLE_SCOPES", "yes")
+	t.Parallel()
 
 	token1, err := types.NewProvisionTokenFromSpec("token1", time.Now().Add(time.Minute), types.ProvisionTokenSpecV2{
 		Roles: []types.SystemRole{
@@ -89,7 +90,17 @@ func TestJoinToken(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	authService := newFakeAuthService(t)
+	testServer, err := authtest.NewTestServer(authtest.ServerConfig{
+		Auth: authtest.AuthServerConfig{
+			Dir:            t.TempDir(),
+			ClusterName:    "testcluster",
+			ScopesFeatures: scopes.Features{Enabled: true},
+		},
+	})
+	require.NoError(t, err)
+	authService := &fakeAuthService{
+		Server: testServer,
+	}
 	require.NoError(t, authService.Auth().UpsertToken(t.Context(), token1))
 	require.NoError(t, authService.Auth().UpsertToken(t.Context(), token2))
 

--- a/lib/join/oraclejoin/join_test.go
+++ b/lib/join/oraclejoin/join_test.go
@@ -59,6 +59,7 @@ import (
 	"github.com/gravitational/teleport/lib/join/jointest"
 	"github.com/gravitational/teleport/lib/join/joinutils"
 	"github.com/gravitational/teleport/lib/join/oraclejoin"
+	"github.com/gravitational/teleport/lib/scopes"
 	"github.com/gravitational/teleport/lib/scopes/joining"
 	"github.com/gravitational/teleport/lib/tlsca"
 	"github.com/gravitational/teleport/lib/utils"
@@ -67,7 +68,7 @@ import (
 
 // TestJoinOracle tests the Oracle join method, with faked OCI IMDS and API servers.
 func TestJoinOracle(t *testing.T) {
-	t.Setenv("TELEPORT_UNSTABLE_SCOPES", "yes")
+	t.Parallel()
 
 	imdsListener, err := net.Listen("tcp", "127.0.0.1:0")
 	require.NoError(t, err)
@@ -109,7 +110,8 @@ func TestJoinOracle(t *testing.T) {
 
 	server, err := authtest.NewTestServer(authtest.ServerConfig{
 		Auth: authtest.AuthServerConfig{
-			Dir: t.TempDir(),
+			Dir:            t.TempDir(),
+			ScopesFeatures: scopes.Features{Enabled: true},
 		},
 		TLS: &authtest.TLSServerConfig{
 			APIConfig: &auth.APIConfig{

--- a/lib/join/server.go
+++ b/lib/join/server.go
@@ -65,6 +65,7 @@ import (
 	"github.com/gravitational/teleport/lib/join/terraformcloud"
 	"github.com/gravitational/teleport/lib/join/tpmjoin"
 	kubetoken "github.com/gravitational/teleport/lib/kube/token"
+	"github.com/gravitational/teleport/lib/scopes"
 	"github.com/gravitational/teleport/lib/scopes/joining"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/services/readonly"
@@ -123,6 +124,8 @@ type ServerConfig struct {
 	OracleHTTPClient   utils.HTTPDoClient
 	ScopedTokenService services.ScopedTokenService
 	Logger             *slog.Logger
+	// ScopesFeatures dictate which scoped components are enabled.
+	ScopesFeatures scopes.Features
 }
 
 // Server implements cluster joining for nodes and bots.
@@ -180,7 +183,7 @@ func (s *Server) getProvisionToken(ctx context.Context, name string) (provision.
 			scopedErr = err
 			return
 		}
-		if err := joining.ValidateTokenForUse(res.GetToken()); err != nil {
+		if err := joining.ValidateTokenForUse(res.GetToken(), s.cfg.ScopesFeatures); err != nil {
 			scopedErr = err
 			return
 		}

--- a/lib/kube/grpc/utils_test.go
+++ b/lib/kube/grpc/utils_test.go
@@ -67,6 +67,7 @@ import (
 	"github.com/gravitational/teleport/lib/modules"
 	"github.com/gravitational/teleport/lib/multiplexer"
 	"github.com/gravitational/teleport/lib/reversetunnelclient"
+	"github.com/gravitational/teleport/lib/scopes"
 	"github.com/gravitational/teleport/lib/services"
 	sessPkg "github.com/gravitational/teleport/lib/session"
 	"github.com/gravitational/teleport/lib/tlsca"
@@ -110,6 +111,7 @@ type TestConfig struct {
 	OnEvent              func(apievents.AuditEvent)
 	ClusterFeatures      func() proto.Features
 	CreateAuditStreamErr error
+	ScopesFeatures       scopes.Features
 }
 
 // SetupTestContext creates a kube service with clusters configured.
@@ -191,6 +193,7 @@ func SetupTestContext(ctx context.Context, t *testing.T, cfg TestConfig) *TestCo
 		AccessPoint:      proxyAuthClient,
 		ScopedRoleReader: proxyAuthClient.ScopedRoleReader(),
 		LockWatcher:      testCtx.lockWatcher,
+		ScopesFeatures:   cfg.ScopesFeatures,
 	}
 
 	testCtx.Authz, err = authz.NewAuthorizer(authOpts)

--- a/lib/kube/proxy/utils_test.go
+++ b/lib/kube/proxy/utils_test.go
@@ -67,6 +67,7 @@ import (
 	"github.com/gravitational/teleport/lib/modules"
 	"github.com/gravitational/teleport/lib/multiplexer"
 	"github.com/gravitational/teleport/lib/reversetunnelclient"
+	"github.com/gravitational/teleport/lib/scopes"
 	"github.com/gravitational/teleport/lib/services"
 	sessPkg "github.com/gravitational/teleport/lib/session"
 	"github.com/gravitational/teleport/lib/tlsca"
@@ -110,6 +111,7 @@ type TestConfig struct {
 	ClusterFeatures      func() proto.Features
 	CreateAuditStreamErr error
 	WrapAuthClient       func(authclient.ClientI) authclient.ClientI
+	ScopesFeatures       scopes.Features
 }
 
 // SetupTestContext creates a kube service with clusters configured.
@@ -200,6 +202,7 @@ func SetupTestContext(ctx context.Context, t *testing.T, cfg TestConfig) *TestCo
 		AccessPoint:      proxyAuthClient,
 		ScopedRoleReader: proxyAuthClient.ScopedRoleReader(),
 		LockWatcher:      testCtx.lockWatcher,
+		ScopesFeatures:   cfg.ScopesFeatures,
 	})
 	require.NoError(t, err)
 

--- a/lib/scopes/feature.go
+++ b/lib/scopes/feature.go
@@ -35,26 +35,43 @@ const (
 	agentPinVarName = "TELEPORT_UNSTABLE_AGENT_SCOPE_PIN"
 )
 
-// FeatureEnabled checks if the scopes feature is enabled.
-func FeatureEnabled() bool {
-	enabled, err := apiutils.ParseBool(os.Getenv(featureVarName))
-	return enabled && err == nil
+// Features describes which scopes-related functionality is enabled.
+type Features struct {
+	// Enabled indicates whether the base scopes feature is enabled.
+	Enabled bool
+
+	// AgentPinEnabled checks if the agent scope pin feature is enabled.
+	AgentPinEnabled bool
 }
 
-// AssertFeatureEnabled checks if the scopes feature is enabled, and returns a helpful
-// error message if it is not.
-func AssertFeatureEnabled() error {
-	if !FeatureEnabled() {
+// AssertEnabled returns an error if the base scopes feature is disabled.
+func (f Features) AssertEnabled() error {
+	if !f.Enabled {
 		return trace.Errorf("scoping features are not enabled, set " + featureVarName + "=yes to enable scoping features (caution: not ready for production use)")
 	}
 
 	return nil
 }
 
-// AgentPinEnabled checks if the agent scope pin feature is enabled.
-func AgentPinEnabled() bool {
-	enabled, err := apiutils.ParseBool(os.Getenv(agentPinVarName))
-	return enabled && err == nil
+// FeaturesFromEnv builds Features from scopes-related environment variables.
+func FeaturesFromEnv() Features {
+	var f Features
+	enabled, err := apiutils.ParseBool(os.Getenv(featureVarName))
+	f.Enabled = enabled && err == nil
+	agentPinEnabled, err := apiutils.ParseBool(os.Getenv(agentPinVarName))
+	f.AgentPinEnabled = agentPinEnabled && err == nil
+	return f
+}
+
+// AssertFeatureEnabled checks if the scopes feature is enabled, and returns a helpful
+// error message if it is not.
+// Deprecated: inject scopes.Features instead.
+func AssertFeatureEnabled() error {
+	if !FeaturesFromEnv().Enabled {
+		return trace.Errorf("scoping features are not enabled, set " + featureVarName + "=yes to enable scoping features (caution: not ready for production use)")
+	}
+
+	return nil
 }
 
 // ScopesStatusToString returns a user friendly status message based on [proto.ScopesStatus].

--- a/lib/scopes/feature_test.go
+++ b/lib/scopes/feature_test.go
@@ -16,17 +16,26 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-package scopes
+package scopes_test
 
 import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport/lib/scopes"
 )
 
-// TestFeatureEnabled verifies the expected behavior of the scope feature flag.
-func TestFeatureEnabled(t *testing.T) {
-	require.Error(t, AssertFeatureEnabled())
+// TestFeatures verifies the expected behavior of scope feature parsing.
+func TestFeatures(t *testing.T) {
+	require.False(t, scopes.FeaturesFromEnv().Enabled)
+	require.False(t, scopes.FeaturesFromEnv().AgentPinEnabled)
 	t.Setenv("TELEPORT_UNSTABLE_SCOPES", "yes")
-	require.NoError(t, AssertFeatureEnabled())
+	require.True(t, scopes.FeaturesFromEnv().Enabled)
+	require.False(t, scopes.FeaturesFromEnv().AgentPinEnabled)
+	require.NoError(t, scopes.Features{Enabled: true}.AssertEnabled())
+	require.Error(t, scopes.Features{}.AssertEnabled())
+	t.Setenv("TELEPORT_UNSTABLE_AGENT_SCOPE_PIN", "yes")
+	require.True(t, scopes.FeaturesFromEnv().Enabled)
+	require.True(t, scopes.FeaturesFromEnv().AgentPinEnabled)
 }

--- a/lib/scopes/joining/token.go
+++ b/lib/scopes/joining/token.go
@@ -506,8 +506,8 @@ var ErrTokenExhausted = &trace.LimitExceededError{Message: "scoped token usage e
 
 // ValidateTokenForUse checks if a given scoped token can be used for
 // provisioning. Returns a [*trace.LimitExceededError] if the token is expired
-func ValidateTokenForUse(token *joiningv1.ScopedToken) error {
-	if err := scopes.AssertFeatureEnabled(); err != nil {
+func ValidateTokenForUse(token *joiningv1.ScopedToken, features scopes.Features) error {
+	if err := features.AssertEnabled(); err != nil {
 		return trace.Wrap(err)
 	}
 
@@ -531,7 +531,7 @@ func ValidateTokenForUse(token *joiningv1.ScopedToken) error {
 	}
 	// if agent scope pins are enabled, all system roles are allowed to join
 	// with a scoped token
-	if scopes.AgentPinEnabled() {
+	if features.AgentPinEnabled {
 		return nil
 	}
 

--- a/lib/scopes/joining/token_test.go
+++ b/lib/scopes/joining/token_test.go
@@ -30,6 +30,7 @@ import (
 	joiningv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/joining/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/join/jointest"
+	"github.com/gravitational/teleport/lib/scopes"
 	"github.com/gravitational/teleport/lib/scopes/joining"
 )
 
@@ -1467,9 +1468,7 @@ func TestValidateTokenUpdate(t *testing.T) {
 }
 
 func TestValidateTokenForUse(t *testing.T) {
-	// TODO (eriktate): remove env var manipulation in this test once we've
-	// backported the [scopes.Features] work from #67073
-	t.Setenv("TELEPORT_UNSTABLE_SCOPES", "yes")
+	t.Parallel()
 	token := &joiningv1.ScopedToken{
 		Scope: "/test",
 		Spec: &joiningv1.ScopedTokenSpec{
@@ -1482,13 +1481,14 @@ func TestValidateTokenForUse(t *testing.T) {
 			Secret: "secret",
 		},
 	}
+	features := scopes.Features{Enabled: true}
 	// we want to ensure that token validation before use is always the strongest
 	// available, so we confirm that the test token passes weak validation and then
 	// assert that StrongValidateToken and ValidateTokenForUse fail with the same error
 	assert.NoError(t, joining.WeakValidateToken(token))
 	strongValidateErr := joining.StrongValidateToken(token)
 	assert.Error(t, strongValidateErr)
-	assert.ErrorIs(t, strongValidateErr, joining.ValidateTokenForUse(token))
+	assert.ErrorIs(t, strongValidateErr, joining.ValidateTokenForUse(token, features))
 
 	// fix token so StrongValidate succeeds
 	token.Kind = types.KindScopedToken
@@ -1498,20 +1498,20 @@ func TestValidateTokenForUse(t *testing.T) {
 	}
 
 	// validation should succeed for node role if scopes are enabled
-	require.NoError(t, joining.ValidateTokenForUse(token))
+	require.NoError(t, joining.ValidateTokenForUse(token, features))
 
-	t.Setenv("TELEPORT_UNSTABLE_SCOPES", "no")
+	features.Enabled = false
 	// validation should fail if scopes are disabled
-	require.ErrorContains(t, joining.ValidateTokenForUse(token), "scoping features are not enabled")
+	require.ErrorContains(t, joining.ValidateTokenForUse(token, features), "scoping features are not enabled")
 
-	t.Setenv("TELEPORT_UNSTABLE_SCOPES", "yes")
+	features.Enabled = true
 	// validation should fail for kube role if agent pinning is disabled
 	token.Spec.Roles = append(token.Spec.Roles, string(types.RoleKube))
-	require.ErrorContains(t, joining.ValidateTokenForUse(token), "scoped token cannot be used to join [Node, Kube] role(s) without TELEPORT_UNSTABLE_AGENT_SCOPE_PIN=yes")
+	require.ErrorContains(t, joining.ValidateTokenForUse(token, features), "scoped token cannot be used to join [Node, Kube] role(s) without TELEPORT_UNSTABLE_AGENT_SCOPE_PIN=yes")
 
-	t.Setenv("TELEPORT_UNSTABLE_AGENT_SCOPE_PIN", "yes")
+	features.AgentPinEnabled = true
 	// validation should succeed for kube role if agent pinning is enabled
-	require.NoError(t, joining.ValidateTokenForUse(token))
+	require.NoError(t, joining.ValidateTokenForUse(token, features))
 
 	// validation should succeed for bot role even if agent scope pins are disabled
 	token.Spec.BotName = "bot-name"
@@ -1520,5 +1520,5 @@ func TestValidateTokenForUse(t *testing.T) {
 	token.Spec.JoinMethod = string(types.JoinMethodBoundKeypair)
 	token.Spec.UsageMode = string(joining.TokenUsageModeBot)
 	token.Spec.Roles = []string{string(types.RoleBot)}
-	require.NoError(t, joining.ValidateTokenForUse(token))
+	require.NoError(t, joining.ValidateTokenForUse(token, features))
 }

--- a/lib/service/db.go
+++ b/lib/service/db.go
@@ -101,10 +101,11 @@ func (process *TeleportProcess) initDatabaseService() (retErr error) {
 
 	clusterName := conn.ClusterName()
 	authorizer, err := authz.NewAuthorizer(authz.AuthorizerOpts{
-		ClusterName: clusterName,
-		AccessPoint: accessPoint,
-		LockWatcher: lockWatcher,
-		Logger:      process.logger.With(teleport.ComponentKey, teleport.Component(teleport.ComponentDatabase, process.id)),
+		ClusterName:    clusterName,
+		AccessPoint:    accessPoint,
+		LockWatcher:    lockWatcher,
+		Logger:         process.logger.With(teleport.ComponentKey, teleport.Component(teleport.ComponentDatabase, process.id)),
+		ScopesFeatures: process.scopesFeatures,
 	})
 	if err != nil {
 		return trace.Wrap(err)

--- a/lib/service/desktop.go
+++ b/lib/service/desktop.go
@@ -158,10 +158,11 @@ func (process *TeleportProcess) initWindowsDesktopServiceRegistered(logger *slog
 	clusterName := conn.ClusterName()
 
 	authorizer, err := authz.NewAuthorizer(authz.AuthorizerOpts{
-		ClusterName: clusterName,
-		AccessPoint: accessPoint,
-		LockWatcher: lockWatcher,
-		Logger:      process.logger.With(teleport.ComponentKey, teleport.Component(teleport.ComponentWindowsDesktop, process.id)),
+		ClusterName:    clusterName,
+		AccessPoint:    accessPoint,
+		LockWatcher:    lockWatcher,
+		Logger:         process.logger.With(teleport.ComponentKey, teleport.Component(teleport.ComponentWindowsDesktop, process.id)),
+		ScopesFeatures: process.scopesFeatures,
 		DeviceAuthorization: authz.DeviceAuthorizationOpts{
 			// Ignore the global device_trust.mode toggle, but allow role-based
 			// settings to be applied.

--- a/lib/service/kubernetes.go
+++ b/lib/service/kubernetes.go
@@ -225,6 +225,7 @@ func (process *TeleportProcess) initKubernetesService(logger *slog.Logger, conn 
 		ScopedRoleReader: accessPoint.ScopedRoleReader(),
 		LockWatcher:      lockWatcher,
 		Logger:           process.logger.With(teleport.ComponentKey, teleport.Component(teleport.ComponentKube, process.id)),
+		ScopesFeatures:   process.scopesFeatures,
 	})
 	if err != nil {
 		return trace.Wrap(err)

--- a/lib/service/relay.go
+++ b/lib/service/relay.go
@@ -111,6 +111,7 @@ func (process *TeleportProcess) runRelayService() error {
 		LockWatcher:      lockWatcher,
 		Logger:           sublogger("authorizer"),
 		PermitCaching:    process.Config.CachePolicy.Enabled,
+		ScopesFeatures:   process.scopesFeatures,
 	}
 
 	authorizer, err := authz.NewAuthorizer(authorizerOpts)

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -160,6 +160,7 @@ import (
 	"github.com/gravitational/teleport/lib/resumption"
 	"github.com/gravitational/teleport/lib/reversetunnel"
 	"github.com/gravitational/teleport/lib/reversetunnelclient"
+	"github.com/gravitational/teleport/lib/scopes"
 	secretsscannerproxy "github.com/gravitational/teleport/lib/secretsscanner/proxy"
 	"github.com/gravitational/teleport/lib/service/servicecfg"
 	"github.com/gravitational/teleport/lib/services"
@@ -705,6 +706,9 @@ type TeleportProcess struct {
 
 	// clusterFeatures contain flags for supported and unsupported features.
 	clusterFeatures proto.Features
+
+	// scopesFeatures dictates which scoped components are enabled for this process.
+	scopesFeatures scopes.Features
 
 	// authSubjectiveAddr is the peer address of this process as seen by the auth
 	// server during the most recent ping (may be empty).
@@ -1318,6 +1322,8 @@ func NewTeleport(cfg *servicecfg.Config) (_ *TeleportProcess, err error) {
 		}
 	}
 
+	scopesFeatures := cfg.ScopesFeatures
+
 	process := &TeleportProcess{
 		PluginRegistry:         cfg.PluginRegistry,
 		Clock:                  cfg.Clock,
@@ -1333,6 +1339,7 @@ func NewTeleport(cfg *servicecfg.Config) (_ *TeleportProcess, err error) {
 		id:                     processID,
 		logger:                 cfg.Logger,
 		cloudLabels:            cloudLabels,
+		scopesFeatures:         scopesFeatures,
 		TracingProvider:        tracing.NoopProvider(),
 		metricsRegistry:        metricsRegistry,
 		SyncGatherers: metrics.NewSyncGatherers(
@@ -2422,6 +2429,7 @@ func (process *TeleportProcess) initAuthService() error {
 		process.ExitContext(),
 		auth.InitConfig{
 			Backend:                   b,
+			ScopesFeatures:            process.scopesFeatures,
 			VersionStorage:            process.storage,
 			SkipVersionCheck:          cfg.SkipVersionCheck || skipVersionCheckFromEnv,
 			Authority:                 cfg.Keygen,
@@ -2642,6 +2650,7 @@ func (process *TeleportProcess) initAuthService() error {
 		MFAAuthenticator:    authServer,
 		LockWatcher:         lockWatcher,
 		Logger:              process.logger.With(teleport.ComponentKey, teleport.Component(teleport.ComponentAuth, process.id)),
+		ScopesFeatures:      process.scopesFeatures,
 		// Auth Server does explicit device authorization.
 		// Various Auth APIs must allow access to unauthorized devices, otherwise it
 		// is not possible to acquire device-aware certificates in the first place.
@@ -5507,11 +5516,12 @@ func (process *TeleportProcess) initProxyEndpoint(conn *Connector) error {
 		}
 
 		authorizer, err := authz.NewAuthorizer(authz.AuthorizerOpts{
-			ClusterName:   cn.GetClusterName(),
-			AccessPoint:   accessPoint,
-			LockWatcher:   lockWatcher,
-			Logger:        process.logger,
-			PermitCaching: process.Config.CachePolicy.Enabled,
+			ClusterName:    cn.GetClusterName(),
+			AccessPoint:    accessPoint,
+			LockWatcher:    lockWatcher,
+			Logger:         process.logger,
+			PermitCaching:  process.Config.CachePolicy.Enabled,
+			ScopesFeatures: process.scopesFeatures,
 		})
 		if err != nil {
 			return trace.Wrap(err)
@@ -5824,6 +5834,7 @@ func (process *TeleportProcess) initProxyEndpoint(conn *Connector) error {
 		LockWatcher:      lockWatcher,
 		Logger:           process.logger.With(teleport.ComponentKey, teleport.Component(teleport.ComponentReverseTunnelServer, process.id)),
 		PermitCaching:    process.Config.CachePolicy.Enabled,
+		ScopesFeatures:   process.scopesFeatures,
 	}
 
 	authorizer, err := authz.NewAuthorizer(authorizerOpts)
@@ -6001,6 +6012,7 @@ func (process *TeleportProcess) initProxyEndpoint(conn *Connector) error {
 			ScopedRoleReader: accessPoint.ScopedRoleReader(),
 			LockWatcher:      lockWatcher,
 			Logger:           process.logger.With(teleport.ComponentKey, teleport.Component(teleport.ComponentReverseTunnelServer, process.id)),
+			ScopesFeatures:   process.scopesFeatures,
 			PermitCaching:    process.Config.CachePolicy.Enabled,
 		})
 		if err != nil {
@@ -6118,11 +6130,12 @@ func (process *TeleportProcess) initProxyEndpoint(conn *Connector) error {
 	// framework.
 	if (!listeners.db.Empty() || alpnRouter != nil) && !process.Config.Proxy.DisableReverseTunnel {
 		authorizer, err := authz.NewAuthorizer(authz.AuthorizerOpts{
-			ClusterName:   clusterName,
-			AccessPoint:   accessPoint,
-			LockWatcher:   lockWatcher,
-			Logger:        process.logger.With(teleport.ComponentKey, teleport.Component(teleport.ComponentReverseTunnelServer, process.id)),
-			PermitCaching: process.Config.CachePolicy.Enabled,
+			ClusterName:    clusterName,
+			AccessPoint:    accessPoint,
+			LockWatcher:    lockWatcher,
+			Logger:         process.logger.With(teleport.ComponentKey, teleport.Component(teleport.ComponentReverseTunnelServer, process.id)),
+			PermitCaching:  process.Config.CachePolicy.Enabled,
+			ScopesFeatures: process.scopesFeatures,
 		})
 		if err != nil {
 			return trace.Wrap(err)
@@ -6895,10 +6908,11 @@ func (process *TeleportProcess) initApps() {
 			return trace.Wrap(err)
 		}
 		authorizer, err := authz.NewAuthorizer(authz.AuthorizerOpts{
-			ClusterName: clusterName,
-			AccessPoint: accessPoint,
-			LockWatcher: lockWatcher,
-			Logger:      process.logger.With(teleport.ComponentKey, component),
+			ClusterName:    clusterName,
+			AccessPoint:    accessPoint,
+			LockWatcher:    lockWatcher,
+			Logger:         process.logger.With(teleport.ComponentKey, component),
+			ScopesFeatures: process.scopesFeatures,
 			DeviceAuthorization: authz.DeviceAuthorizationOpts{
 				// Ignore the global device_trust.mode toggle, but allow role-based
 				// settings to be applied.
@@ -7469,11 +7483,12 @@ func (process *TeleportProcess) initSecureGRPCServer(cfg initSecureGRPCServerCfg
 	}
 
 	authorizer, err := authz.NewAuthorizer(authz.AuthorizerOpts{
-		ClusterName:   clusterName,
-		AccessPoint:   cfg.accessPoint,
-		LockWatcher:   cfg.lockWatcher,
-		Logger:        process.logger.With(teleport.ComponentKey, teleport.Component(teleport.ComponentProxySecureGRPC, process.id)),
-		PermitCaching: process.Config.CachePolicy.Enabled,
+		ClusterName:    clusterName,
+		AccessPoint:    cfg.accessPoint,
+		LockWatcher:    cfg.lockWatcher,
+		Logger:         process.logger.With(teleport.ComponentKey, teleport.Component(teleport.ComponentProxySecureGRPC, process.id)),
+		PermitCaching:  process.Config.CachePolicy.Enabled,
+		ScopesFeatures: process.scopesFeatures,
 	})
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/service/servicecfg/config.go
+++ b/lib/service/servicecfg/config.go
@@ -48,6 +48,7 @@ import (
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/events"
 	"github.com/gravitational/teleport/lib/plugin"
+	"github.com/gravitational/teleport/lib/scopes"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/sshca"
 	"github.com/gravitational/teleport/lib/utils"
@@ -62,6 +63,9 @@ type Config struct {
 	Version string
 	// DataDir is the directory where teleport stores its local state, e.g. keys
 	DataDir string
+
+	// ScopesFeatures dictates which scoped components are enabled for this process.
+	ScopesFeatures scopes.Features
 
 	// Hostname is a node host name
 	Hostname string

--- a/lib/services/local/access_list.go
+++ b/lib/services/local/access_list.go
@@ -77,11 +77,13 @@ const (
 // consistent view to the rest of the Teleport application. It makes no decisions
 // about granting or withholding list membership.
 type AccessListService struct {
-	backend       backend.Backend
-	modules       modules.Modules
-	service       *generic.Service[*accesslist.AccessList]
-	memberService *generic.Service[*accesslist.AccessListMember]
-	reviewService *generic.Service[*accesslist.Review]
+	backend backend.Backend
+	modules modules.Modules
+	// scopesFeatures dictates whether scoped role grants are enabled.
+	scopesFeatures scopes.Features
+	service        *generic.Service[*accesslist.AccessList]
+	memberService  *generic.Service[*accesslist.AccessListMember]
+	reviewService  *generic.Service[*accesslist.Review]
 }
 
 type accessListAndMembersGetter struct {
@@ -117,6 +119,8 @@ type AccessListServiceConfig struct {
 	// RunWhileLockedRetryInterval alters locking behavior when interacting with the backend.
 	// This allows tests to run faster.
 	RunWhileLockedRetryInterval time.Duration
+	// ScopesFeatures specifies which scopes features are enabled.
+	ScopesFeatures scopes.Features
 }
 
 // NewAccessListServiceV2 creates a new AccessListService.
@@ -165,11 +169,12 @@ func NewAccessListServiceV2(cfg AccessListServiceConfig) (*AccessListService, er
 	}
 
 	return &AccessListService{
-		backend:       cfg.Backend,
-		modules:       cfg.Modules,
-		service:       service,
-		memberService: memberService,
-		reviewService: reviewService,
+		backend:        cfg.Backend,
+		modules:        cfg.Modules,
+		scopesFeatures: cfg.ScopesFeatures,
+		service:        service,
+		memberService:  memberService,
+		reviewService:  reviewService,
 	}, nil
 }
 
@@ -913,7 +918,7 @@ func (a *AccessListService) checkScopedRoleGrants(existingList, newList *accessl
 	}
 
 	// This list has new scoped role grants, the scopes feature must be enabled.
-	return trace.Wrap(scopes.AssertFeatureEnabled())
+	return trace.Wrap(a.scopesFeatures.AssertEnabled())
 }
 
 // UpsertAccessListWithMembers creates or updates an access list resource and its members.

--- a/lib/services/local/access_list_test.go
+++ b/lib/services/local/access_list_test.go
@@ -50,6 +50,7 @@ import (
 	"github.com/gravitational/teleport/lib/itertools/stream"
 	"github.com/gravitational/teleport/lib/modules"
 	"github.com/gravitational/teleport/lib/modules/modulestest"
+	"github.com/gravitational/teleport/lib/scopes"
 	scopedaccess "github.com/gravitational/teleport/lib/scopes/access"
 	"github.com/gravitational/teleport/lib/utils"
 	sliceutils "github.com/gravitational/teleport/lib/utils/slices"
@@ -157,7 +158,7 @@ func TestAccessListCRUD(t *testing.T) {
 }
 
 func TestAccessListCRUDScopedRoleGrants(t *testing.T) {
-	t.Setenv("TELEPORT_UNSTABLE_SCOPES", "yes")
+	t.Parallel()
 	ctx := t.Context()
 	clock := clockwork.NewFakeClock()
 
@@ -167,7 +168,13 @@ func TestAccessListCRUDScopedRoleGrants(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	service := newAccessListService(t, mem, modulestest.EnterpriseModules())
+	service, err := NewAccessListServiceV2(AccessListServiceConfig{
+		Backend:        backend.NewSanitizer(mem),
+		Modules:        modulestest.EnterpriseModules(),
+		ScopesFeatures: scopes.Features{Enabled: true},
+	})
+	require.NoError(t, err)
+
 	scopedAccessService := NewScopedAccessService(mem)
 
 	for _, role := range []string{"scoped-role-1", "scoped-role-2", "scoped-role-3"} {

--- a/lib/services/local/provisioning_test.go
+++ b/lib/services/local/provisioning_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/backend/memory"
 	"github.com/gravitational/teleport/lib/defaults"
+	"github.com/gravitational/teleport/lib/scopes"
 	"github.com/gravitational/teleport/lib/scopes/joining"
 	"github.com/gravitational/teleport/lib/services/local"
 )
@@ -312,7 +313,7 @@ func TestProvisioningServiceTokenNameConflict(t *testing.T) {
 	require.NoError(t, err)
 
 	service := local.NewProvisioningService(bk)
-	scopedTokenService, err := local.NewScopedTokenService(bk)
+	scopedTokenService, err := local.NewScopedTokenService(bk, scopes.Features{Enabled: true})
 	require.NoError(t, err)
 
 	ctx := t.Context()

--- a/lib/services/local/scoped_tokens.go
+++ b/lib/services/local/scoped_tokens.go
@@ -48,12 +48,13 @@ const (
 
 // ScopedTokenService exposes backend functionality for working with scoped token resources.
 type ScopedTokenService struct {
-	svc     *generic.ServiceWrapper[*joiningv1.ScopedToken]
-	backend backend.Backend
+	svc      *generic.ServiceWrapper[*joiningv1.ScopedToken]
+	backend  backend.Backend
+	features scopes.Features
 }
 
 // NewScopedTokenService creates a new ScopedTokenService.
-func NewScopedTokenService(b backend.Backend) (*ScopedTokenService, error) {
+func NewScopedTokenService(b backend.Backend, features scopes.Features) (*ScopedTokenService, error) {
 	const pageLimit = 100
 	svc, err := generic.NewServiceWrapper(generic.ServiceConfig[*joiningv1.ScopedToken]{
 		Backend:       b,
@@ -68,8 +69,9 @@ func NewScopedTokenService(b backend.Backend) (*ScopedTokenService, error) {
 	}
 
 	return &ScopedTokenService{
-		svc:     svc,
-		backend: b,
+		svc:      svc,
+		backend:  b,
+		features: features,
 	}, nil
 }
 
@@ -172,7 +174,7 @@ const tokenReuseDuration = time.Minute * 30
 // retry a failed join due to spurious errors even after the token has been
 // consumed.
 func (s *ScopedTokenService) UseScopedToken(ctx context.Context, token *joiningv1.ScopedToken, publicKey []byte) (*joiningv1.ScopedToken, error) {
-	if err := joining.ValidateTokenForUse(token); err != nil {
+	if err := joining.ValidateTokenForUse(token, s.features); err != nil {
 		return nil, trace.Wrap(err)
 	}
 

--- a/lib/services/local/scoped_tokens_test.go
+++ b/lib/services/local/scoped_tokens_test.go
@@ -40,17 +40,17 @@ import (
 	joiningv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/joining/v1"
 	scopesv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/v1"
 	"github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/teleport/lib/backend"
 	"github.com/gravitational/teleport/lib/backend/memory"
+	"github.com/gravitational/teleport/lib/scopes"
 	"github.com/gravitational/teleport/lib/scopes/joining"
 	"github.com/gravitational/teleport/lib/services/local"
 )
 
 func TestScopedTokenService(t *testing.T) {
-	t.Setenv("TELEPORT_UNSTABLE_SCOPES", "yes")
+	t.Parallel()
 	bk, err := memory.New(memory.Config{})
 	require.NoError(t, err)
-	service, err := local.NewScopedTokenService(bk)
+	service, err := local.NewScopedTokenService(bk, scopes.Features{Enabled: true})
 	require.NoError(t, err)
 
 	ctx := t.Context()
@@ -161,7 +161,7 @@ func TestScopedTokenService(t *testing.T) {
 func TestScopedTokenList(t *testing.T) {
 	bk, err := memory.New(memory.Config{})
 	require.NoError(t, err)
-	service, err := local.NewScopedTokenService(bk)
+	service, err := local.NewScopedTokenService(bk, scopes.Features{Enabled: true})
 	require.NoError(t, err)
 
 	ctx := t.Context()
@@ -407,7 +407,7 @@ func TestScopedTokenList(t *testing.T) {
 func TestScopedTokenNameCollisions(t *testing.T) {
 	bk, err := memory.New(memory.Config{})
 	require.NoError(t, err)
-	service, err := local.NewScopedTokenService(bk)
+	service, err := local.NewScopedTokenService(bk, scopes.Features{Enabled: true})
 	require.NoError(t, err)
 
 	provisioningService := local.NewProvisioningService(bk)
@@ -514,11 +514,11 @@ func TestScopedTokenNameCollisions(t *testing.T) {
 }
 
 func TestScopedTokenUse(t *testing.T) {
-	t.Setenv("TELEPORT_UNSTABLE_SCOPES", "yes")
+	t.Parallel()
 	synctest.Test(t, func(t *testing.T) {
 		bk, err := memory.New(memory.Config{})
 		require.NoError(t, err)
-		service, err := local.NewScopedTokenService(backend.NewSanitizer(bk))
+		service, err := local.NewScopedTokenService(bk, scopes.Features{Enabled: true})
 		require.NoError(t, err)
 
 		ctx := t.Context()
@@ -625,7 +625,7 @@ func TestScopedTokenUpdate(t *testing.T) {
 	t.Parallel()
 	bk, err := memory.New(memory.Config{})
 	require.NoError(t, err)
-	service, err := local.NewScopedTokenService(backend.NewSanitizer(bk))
+	service, err := local.NewScopedTokenService(bk, scopes.Features{Enabled: true})
 	require.NoError(t, err)
 
 	ctx := t.Context()
@@ -734,7 +734,7 @@ func TestScopedTokenUpsert(t *testing.T) {
 	t.Parallel()
 	bk, err := memory.New(memory.Config{})
 	require.NoError(t, err)
-	service, err := local.NewScopedTokenService(backend.NewSanitizer(bk))
+	service, err := local.NewScopedTokenService(bk, scopes.Features{Enabled: true})
 	require.NoError(t, err)
 
 	ctx := t.Context()
@@ -1005,7 +1005,7 @@ func TestScopedTokenCreate(t *testing.T) {
 	t.Parallel()
 	bk, err := memory.New(memory.Config{})
 	require.NoError(t, err)
-	service, err := local.NewScopedTokenService(backend.NewSanitizer(bk))
+	service, err := local.NewScopedTokenService(bk, scopes.Features{Enabled: true})
 	require.NoError(t, err)
 
 	ctx := t.Context()

--- a/lib/tbot/tbot_test.go
+++ b/lib/tbot/tbot_test.go
@@ -71,6 +71,7 @@ import (
 	"github.com/gravitational/teleport/lib/cryptosuites/cryptosuitestest"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/observability/tracing"
+	"github.com/gravitational/teleport/lib/scopes"
 	scopedaccess "github.com/gravitational/teleport/lib/scopes/access"
 	jointoken "github.com/gravitational/teleport/lib/scopes/joining"
 	"github.com/gravitational/teleport/lib/scopes/pinning"
@@ -1395,7 +1396,7 @@ func TestBotJoiningURI(t *testing.T) {
 // TestScopedBotSSH tests that a scoped bot can produce an identity output
 // with scope pins, and that the identity can be used to SSH to a scoped node.
 func TestScopedBotSSH(t *testing.T) {
-	t.Setenv("TELEPORT_UNSTABLE_SCOPES", "yes")
+	t.Parallel()
 
 	ctx := t.Context()
 	log := logtest.NewLogger()
@@ -1414,6 +1415,7 @@ func TestScopedBotSSH(t *testing.T) {
 	process, err := testenv.NewTeleportProcess(
 		t.TempDir(),
 		defaultTestServerOpts(log),
+		testenv.WithScopesFeatures(scopes.Features{Enabled: true}),
 	)
 	require.NoError(t, err)
 	t.Cleanup(func() {
@@ -1555,6 +1557,7 @@ func TestScopedBotSSH(t *testing.T) {
 	// Start a second Teleport process as an SSH-only node, joining with the
 	// scoped token so the node gets scope "/test-scope".
 	nodeCfg := servicecfg.MakeDefaultConfig()
+	nodeCfg.ScopesFeatures = scopes.Features{Enabled: true}
 	nodeCfg.Hostname = nodeHostname
 	nodeCfg.DataDir = t.TempDir()
 	nodeCfg.SetToken(nodeTokenResp.Token.Metadata.Name)

--- a/lib/vnet/escalate_nodaemon_darwin.go
+++ b/lib/vnet/escalate_nodaemon_darwin.go
@@ -46,12 +46,12 @@ on run argv
   set subCommand to item 2 of argv
   set addr to item 3 of argv
   set credPath to item 4 of argv
-  do shell script quoted form of executableName & `+
-		`" " & quoted form of subCommand & `+
-		`" -d --addr " & quoted form of addr & `+
-		`" --cred-path " & quoted form of credPath & `+
-		`" >/var/log/vnet.log 2>&1" `+
-		`with prompt "Teleport VNet wants to set up a virtual network device." `+
+  do shell script quoted form of executableName & ` +
+		`" " & quoted form of subCommand & ` +
+		`" -d --addr " & quoted form of addr & ` +
+		`" --cred-path " & quoted form of credPath & ` +
+		`" >/var/log/vnet.log 2>&1" ` +
+		`with prompt "Teleport VNet wants to set up a virtual network device." ` +
 		`with administrator privileges
 end run
 `

--- a/lib/web/apiserver_ping_test.go
+++ b/lib/web/apiserver_ping_test.go
@@ -41,6 +41,7 @@ import (
 	"github.com/gravitational/teleport/lib/client"
 	"github.com/gravitational/teleport/lib/modules"
 	"github.com/gravitational/teleport/lib/modules/modulestest"
+	"github.com/gravitational/teleport/lib/scopes"
 )
 
 func TestPing(t *testing.T) {
@@ -237,21 +238,21 @@ func TestPing(t *testing.T) {
 }
 
 func TestPing_scopesEnabled(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name                        string
-		envValue                    string
+		scopesFeatures              scopes.Features
 		expectProxyEnabled          bool
 		expectAuthServerScopesField string
 	}{
 		{
 			name:                        "scopes disabled by default",
-			envValue:                    "",
 			expectProxyEnabled:          false,
 			expectAuthServerScopesField: "disabled",
 		},
 		{
 			name:                        "scopes enabled",
-			envValue:                    "yes",
+			scopesFeatures:              scopes.Features{Enabled: true},
 			expectProxyEnabled:          true,
 			expectAuthServerScopesField: "enabled",
 		},
@@ -259,8 +260,8 @@ func TestPing_scopesEnabled(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			t.Setenv("TELEPORT_UNSTABLE_SCOPES", test.envValue)
-			env := newWebPack(t, 1)
+			t.Parallel()
+			env := newWebPack(t, 1, withScopesFeatures(test.scopesFeatures))
 
 			clt, err := client.NewWebClient(env.proxies[0].webURL.String(), roundtrip.HTTPClient(client.NewInsecureWebClient()))
 			require.NoError(t, err)

--- a/lib/web/apiserver_test.go
+++ b/lib/web/apiserver_test.go
@@ -135,6 +135,7 @@ import (
 	"github.com/gravitational/teleport/lib/proxy"
 	"github.com/gravitational/teleport/lib/reversetunnel"
 	"github.com/gravitational/teleport/lib/reversetunnelclient"
+	"github.com/gravitational/teleport/lib/scopes"
 	"github.com/gravitational/teleport/lib/secret"
 	"github.com/gravitational/teleport/lib/service/servicecfg"
 	"github.com/gravitational/teleport/lib/services"
@@ -8590,6 +8591,7 @@ func decodeSessionCookie(t *testing.T, value string) (sessionID string) {
 type WebPackOptions struct {
 	proxyOptions    []proxyOption
 	enableAuthCache bool
+	scopesFeatures  scopes.Features
 }
 
 type webPackOptions func(*WebPackOptions)
@@ -8606,6 +8608,12 @@ func withWebPackAuthCacheEnabled(enable bool) webPackOptions {
 	}
 }
 
+func withScopesFeatures(scopesFeatures scopes.Features) webPackOptions {
+	return func(cfg *WebPackOptions) {
+		cfg.scopesFeatures = scopesFeatures
+	}
+}
+
 func newWebPack(t *testing.T, numProxies int, opts ...webPackOptions) *webPack {
 	options := &WebPackOptions{}
 
@@ -8618,11 +8626,12 @@ func newWebPack(t *testing.T, numProxies int, opts ...webPackOptions) *webPack {
 
 	server, err := authtest.NewTestServer(authtest.ServerConfig{
 		Auth: authtest.AuthServerConfig{
-			ClusterName:  "localhost",
-			Dir:          t.TempDir(),
-			Clock:        clock,
-			AuditLog:     events.NewDiscardAuditLog(),
-			CacheEnabled: options.enableAuthCache,
+			ClusterName:    "localhost",
+			Dir:            t.TempDir(),
+			Clock:          clock,
+			AuditLog:       events.NewDiscardAuditLog(),
+			CacheEnabled:   options.enableAuthCache,
+			ScopesFeatures: options.scopesFeatures,
 		},
 	})
 	require.NoError(t, err)
@@ -8736,7 +8745,7 @@ func newWebPack(t *testing.T, numProxies int, opts ...webPackOptions) *webPack {
 	var proxies []*testProxy
 	for p := 0; p < numProxies; p++ {
 		proxyID := fmt.Sprintf("proxy%v", p)
-		proxies = append(proxies, createProxy(ctx, t, proxyID, node, server.TLS, hostSigners, clock, options.proxyOptions...))
+		proxies = append(proxies, createProxy(ctx, t, proxyID, node, server.TLS, hostSigners, clock, options.scopesFeatures, options.proxyOptions...))
 	}
 
 	// Wait for proxies to fully register before starting the test.
@@ -8792,7 +8801,7 @@ func withKubeProxy() proxyOption {
 }
 
 func createProxy(ctx context.Context, t *testing.T, proxyID string, node *regular.Server, authServer *authtest.TLSServer,
-	hostSigners []ssh.Signer, clock *clockwork.FakeClock, opts ...proxyOption,
+	hostSigners []ssh.Signer, clock *clockwork.FakeClock, scopesFeatures scopes.Features, opts ...proxyOption,
 ) *testProxy {
 	t.Helper()
 	cfg := proxyConfig{}
@@ -9065,6 +9074,10 @@ func createProxy(ctx context.Context, t *testing.T, proxyID string, node *regula
 	require.NoError(t, err)
 	proxyClientCert, err := keys.X509KeyPair(proxyIdentity.TLSCertBytes, proxyIdentity.KeyBytes)
 	require.NoError(t, err)
+
+	handlerCfg := servicecfg.MakeDefaultConfig()
+	handlerCfg.ScopesFeatures = scopesFeatures
+
 	handler, err := NewHandler(Config{
 		Proxy:            revTunServer,
 		AuthServers:      utils.FromAddr(authServer.Addr()),
@@ -9076,7 +9089,7 @@ func createProxy(ctx context.Context, t *testing.T, proxyID string, node *regula
 		HostUUID:         proxyID,
 		Emitter:          client,
 		ProxySettings: &ProxySettings{
-			ServiceConfig: servicecfg.MakeDefaultConfig(),
+			ServiceConfig: handlerCfg,
 			ProxySSHAddr:  "127.0.0.1",
 			AccessPoint:   client,
 		},

--- a/lib/web/proxy_settings.go
+++ b/lib/web/proxy_settings.go
@@ -26,7 +26,6 @@ import (
 	"github.com/gravitational/teleport/api/client/webclient"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/defaults"
-	"github.com/gravitational/teleport/lib/scopes"
 	"github.com/gravitational/teleport/lib/service/servicecfg"
 )
 
@@ -77,7 +76,7 @@ func (p *ProxySettings) buildProxySettings(proxyListenerMode types.ProxyListener
 			WebListenAddr:    p.ServiceConfig.Proxy.WebAddr.String(),
 			DialTimeout:      sshDialTimeout,
 		},
-		ScopesEnabled: scopes.FeatureEnabled(),
+		ScopesEnabled: p.ServiceConfig.ScopesFeatures.Enabled,
 	}
 
 	p.setProxyPublicAddressesSettings(&proxySettings)

--- a/tool/tctl/common/helpers_test.go
+++ b/tool/tctl/common/helpers_test.go
@@ -42,6 +42,7 @@ import (
 	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/cloud/imds"
 	"github.com/gravitational/teleport/lib/config"
+	"github.com/gravitational/teleport/lib/scopes"
 	"github.com/gravitational/teleport/lib/service"
 	"github.com/gravitational/teleport/lib/service/servicecfg"
 	"github.com/gravitational/teleport/lib/services"
@@ -260,6 +261,7 @@ type testServerOptions struct {
 	fileConfig      *config.FileConfig
 	fileDescriptors []*servicecfg.FileDescriptor
 	fakeClock       *clockwork.FakeClock
+	scopesFeatures  scopes.Features
 	enableCache     bool
 }
 
@@ -283,6 +285,12 @@ func withFakeClock(fakeClock *clockwork.FakeClock) testServerOptionFunc {
 	}
 }
 
+func withScopesFeatures(features scopes.Features) testServerOptionFunc {
+	return func(options *testServerOptions) {
+		options.scopesFeatures = features
+	}
+}
+
 func withEnableCache(enableCache bool) testServerOptionFunc {
 	return func(options *testServerOptions) {
 		options.enableCache = enableCache
@@ -298,6 +306,7 @@ func makeAndRunTestAuthServer(t *testing.T, opts ...testServerOptionFunc) (auth 
 	var err error
 	cfg := servicecfg.MakeDefaultConfig()
 	cfg.CircuitBreakerConfig = breaker.NoopBreakerConfig()
+	cfg.ScopesFeatures = options.scopesFeatures
 	cfg.FileDescriptors = options.fileDescriptors
 	if options.fileConfig != nil {
 		err = config.ApplyFileConfig(options.fileConfig, cfg)

--- a/tool/tctl/common/resource_command_test.go
+++ b/tool/tctl/common/resource_command_test.go
@@ -59,6 +59,7 @@ import (
 	"github.com/gravitational/teleport/lib/fixtures"
 	"github.com/gravitational/teleport/lib/modules"
 	"github.com/gravitational/teleport/lib/modules/modulestest"
+	"github.com/gravitational/teleport/lib/scopes"
 	scopedaccess "github.com/gravitational/teleport/lib/scopes/access"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/utils/log/logtest"
@@ -331,6 +332,8 @@ func TestDatabaseServiceResource(t *testing.T) {
 }
 
 func TestScopedRoleAndAssignmentResource(t *testing.T) {
+	t.Parallel()
+
 	const scopedRoleYAML = `kind: scoped_role
 metadata:
   name: some-role
@@ -349,8 +352,6 @@ spec:
       scope: /foo
 version: v1
 `
-
-	t.Setenv("TELEPORT_UNSTABLE_SCOPES", "yes")
 
 	dynAddr := helpers.NewDynamicServiceAddr(t)
 
@@ -373,7 +374,7 @@ version: v1
 		},
 	}
 
-	auth := makeAndRunTestAuthServer(t, withFileConfig(fileConfig), withFileDescriptors(dynAddr.Descriptors))
+	auth := makeAndRunTestAuthServer(t, withFileConfig(fileConfig), withFileDescriptors(dynAddr.Descriptors), withScopesFeatures(scopes.Features{Enabled: true}))
 	clt, err := testenv.NewDefaultAuthClient(auth)
 	require.NoError(t, err)
 
@@ -568,6 +569,8 @@ version: v1
 }
 
 func TestScopedToken(t *testing.T) {
+	t.Parallel()
+
 	const scopedTokenYAML = `kind: scoped_token
 version: v1
 metadata:
@@ -602,8 +605,6 @@ spec:
           - 123456789-compute@developer.gserviceaccount.com
 `
 
-	t.Setenv("TELEPORT_UNSTABLE_SCOPES", "yes")
-
 	dynAddr := helpers.NewDynamicServiceAddr(t)
 
 	fileConfig := &config.FileConfig{
@@ -625,7 +626,7 @@ spec:
 		},
 	}
 
-	auth := makeAndRunTestAuthServer(t, withFileConfig(fileConfig), withFileDescriptors(dynAddr.Descriptors))
+	auth := makeAndRunTestAuthServer(t, withFileConfig(fileConfig), withFileDescriptors(dynAddr.Descriptors), withScopesFeatures(scopes.Features{Enabled: true}))
 	clt, err := testenv.NewDefaultAuthClient(auth)
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = clt.Close() })

--- a/tool/tctl/common/scoped_assignments_command_test.go
+++ b/tool/tctl/common/scoped_assignments_command_test.go
@@ -31,12 +31,13 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/integration/helpers"
 	"github.com/gravitational/teleport/lib/config"
+	"github.com/gravitational/teleport/lib/scopes"
 	scopedaccess "github.com/gravitational/teleport/lib/scopes/access"
 	"github.com/gravitational/teleport/tool/teleport/testenv"
 )
 
 func TestScopedAssignmentListCommand(t *testing.T) {
-	t.Setenv("TELEPORT_UNSTABLE_SCOPES", "yes")
+	t.Parallel()
 
 	dynAddr := helpers.NewDynamicServiceAddr(t)
 	fileConfig := &config.FileConfig{
@@ -56,7 +57,7 @@ func TestScopedAssignmentListCommand(t *testing.T) {
 		},
 	}
 
-	process := makeAndRunTestAuthServer(t, withFileConfig(fileConfig), withFileDescriptors(dynAddr.Descriptors))
+	process := makeAndRunTestAuthServer(t, withFileConfig(fileConfig), withFileDescriptors(dynAddr.Descriptors), withScopesFeatures(scopes.Features{Enabled: true}))
 	clt, err := testenv.NewDefaultAuthClient(process)
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = clt.Close() })

--- a/tool/teleport/common/teleport.go
+++ b/tool/teleport/common/teleport.go
@@ -51,6 +51,7 @@ import (
 	"github.com/gravitational/teleport/lib/defaults"
 	dtconfig "github.com/gravitational/teleport/lib/devicetrust/config"
 	"github.com/gravitational/teleport/lib/modules"
+	"github.com/gravitational/teleport/lib/scopes"
 	"github.com/gravitational/teleport/lib/service"
 	"github.com/gravitational/teleport/lib/service/servicecfg"
 	"github.com/gravitational/teleport/lib/srv/server/installer"
@@ -707,6 +708,7 @@ Examples:
 
 	// Create default configuration.
 	conf = servicecfg.MakeDefaultConfig()
+	conf.ScopesFeatures = scopes.FeaturesFromEnv()
 
 	// If FIPS mode is specified update defaults to be FIPS appropriate and
 	// cross-validate the current config.

--- a/tool/teleport/testenv/test_server.go
+++ b/tool/teleport/testenv/test_server.go
@@ -47,6 +47,7 @@ import (
 	"github.com/gravitational/teleport/lib/cloud/imds"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/modules"
+	"github.com/gravitational/teleport/lib/scopes"
 	"github.com/gravitational/teleport/lib/service"
 	"github.com/gravitational/teleport/lib/service/servicecfg"
 	"github.com/gravitational/teleport/lib/tlsca"
@@ -394,6 +395,12 @@ func WithAuthPreference(authPref types.AuthPreference) TestServerOptFunc {
 func WithLogger(log *slog.Logger) TestServerOptFunc {
 	return WithConfig(func(cfg *servicecfg.Config) {
 		cfg.Logger = log
+	})
+}
+
+func WithScopesFeatures(features scopes.Features) TestServerOptFunc {
+	return WithConfig(func(cfg *servicecfg.Config) {
+		cfg.ScopesFeatures = features
 	})
 }
 


### PR DESCRIPTION
Backport #67073 to branch/v18

## Manual Test Plan

### Test Environment

Local cluster

### Test Cases
- [x] Scopes reported enabled via /webapi/ping when env set
- [x] Scopes reported disabled via /webapi/ping when env not set