### PR TITLE
Flush enhanced recording events before closing a BPF session

### DIFF
--- a/lib/bpf/bpf.go
+++ b/lib/bpf/bpf.go
@@ -57,11 +57,97 @@ const (
 	// eventSendTimeout is the maximum time to wait for an event to be sent
 	// to be emitted to the Audit log.
 	eventSendTimeout = 10 * time.Second
+
+	// sessionDrainTimeout is a safety net bounding how long CloseSession waits
+	// for in-flight events to drain. The drain normally completes near-instantly.
+	sessionDrainTimeout = 2 * time.Second
 )
 
 type sessionHandler interface {
 	startSession(auditSessionID uint32) error
 	endSession(auditSessionID uint32) error
+	// drainSession blocks until events already emitted for the session have been
+	// processed, so the caller can stop matching it without dropping them.
+	drainSession()
+}
+
+// bpfEvent is an item read off a ring buffer: either a raw event payload or a
+// drain barrier. Sharing one FIFO channel means that when the emitter sees a
+// barrier it has emitted every event ahead of it; it then closes the channel.
+type bpfEvent struct {
+	data    []byte
+	barrier chan struct{}
+}
+
+// drainQueue coordinates flush barriers between the ring buffer reader
+// (sendEvents) and callers draining a session (drainSession).
+type drainQueue struct {
+	mu      sync.Mutex
+	closed  bool
+	pending []chan struct{}
+}
+
+// enqueue registers a barrier. ok is false if the queue is closed (shutting
+// down), in which case the caller must not wait.
+func (d *drainQueue) enqueue() (barrier chan struct{}, ok bool) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if d.closed {
+		return nil, false
+	}
+	b := make(chan struct{})
+	d.pending = append(d.pending, b)
+	return b, true
+}
+
+// takePending returns and clears the registered barriers. keepGoing is false
+// once closed, telling the reader loop to exit rather than drain.
+func (d *drainQueue) takePending() (barriers []chan struct{}, keepGoing bool) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if d.closed {
+		return nil, false
+	}
+	barriers, d.pending = d.pending, nil
+	return barriers, true
+}
+
+// close marks the queue closed so the reader loop exits on its next flush.
+func (d *drainQueue) close() {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	d.closed = true
+}
+
+// drainPipelines flushes the queues' ring buffer(s) and waits for their
+// in-flight events to be emitted, bounded by sessionDrainTimeout. The traced
+// process has already exited, so the buffer is finite and ordered.
+func drainPipelines(eventType string, flush func() error, queues ...*drainQueue) {
+	barriers := make([]chan struct{}, 0, len(queues))
+	for _, q := range queues {
+		if b, ok := q.enqueue(); ok {
+			barriers = append(barriers, b)
+		}
+	}
+	if len(barriers) == 0 {
+		// All pipelines closed; nothing to drain.
+		return
+	}
+
+	if err := flush(); err != nil {
+		logger.WarnContext(context.Background(), "Failed to flush ring buffer for session drain", "event_type", eventType, "error", err)
+	}
+
+	timer := time.NewTimer(sessionDrainTimeout)
+	defer timer.Stop()
+	for _, b := range barriers {
+		select {
+		case <-b:
+		case <-timer.C:
+			logger.WarnContext(context.Background(), "Timed out draining BPF events on session close, some events may be missing", "event_type", eventType)
+			return
+		}
+	}
 }
 
 // Service manages BPF and control groups orchestration.
@@ -172,22 +258,38 @@ func New(config *servicecfg.BPFConfig) (bpf BPF, err error) {
 	// Audit Log.
 	s.wg.Go(func() {
 		for event := range s.exec.events() {
-			s.emitCommandEvent(event)
+			if event.barrier != nil {
+				close(event.barrier)
+				continue
+			}
+			s.emitCommandEvent(event.data)
 		}
 	})
 	s.wg.Go(func() {
 		for event := range s.open.events() {
-			s.emitDiskEvent(event)
+			if event.barrier != nil {
+				close(event.barrier)
+				continue
+			}
+			s.emitDiskEvent(event.data)
 		}
 	})
 	s.wg.Go(func() {
 		for event := range s.conn.v4Events() {
-			s.emit4NetworkEvent(event)
+			if event.barrier != nil {
+				close(event.barrier)
+				continue
+			}
+			s.emit4NetworkEvent(event.data)
 		}
 	})
 	s.wg.Go(func() {
 		for event := range s.conn.v6Events() {
-			s.emit6NetworkEvent(event)
+			if event.barrier != nil {
+				close(event.barrier)
+				continue
+			}
+			s.emit6NetworkEvent(event.data)
 		}
 	})
 
@@ -275,11 +377,9 @@ func (s *Service) OpenSession(ctx *SessionContext) error {
 
 // CloseSession will stop monitoring events from a particular session.
 func (s *Service) CloseSession(ctx *SessionContext) error {
-	// Stop watching for events for this session.
-	s.sessions.Delete(ctx.AuditSessionID)
-
 	var errs []error
 
+	monitored := make([]sessionHandler, 0, 3)
 	for _, m := range []struct {
 		eventName string
 		module    sessionHandler
@@ -293,12 +393,22 @@ func (s *Service) CloseSession(ctx *SessionContext) error {
 		if _, ok := ctx.Events[m.eventName]; !ok {
 			continue
 		}
+		monitored = append(monitored, m.module)
 
-		// Remove the audit session ID from BPF module.
+		// Stop the kernel emitting for this session; the process has exited.
 		if err := m.module.endSession(ctx.AuditSessionID); err != nil {
 			errs = append(errs, trace.Wrap(err))
 		}
 	}
+
+	// Drain events still in flight before we stop matching the session below,
+	// or the emitter would fail to look it up and drop them (e.g. on termination).
+	for _, m := range monitored {
+		m.drainSession()
+	}
+
+	// Stop watching for events for this session.
+	s.sessions.Delete(ctx.AuditSessionID)
 
 	return trace.NewAggregate(errs...)
 }
@@ -317,7 +427,7 @@ func (s *Service) LostEvents() EventCount {
 	}
 }
 
-func sendEvents(eventType string, bpfEvents chan []byte, eventBuf *ringbuf.Reader) {
+func sendEvents(eventType string, bpfEvents chan bpfEvent, eventBuf *ringbuf.Reader, drain *drainQueue) {
 	defer eventBuf.Close()
 	defer close(bpfEvents)
 
@@ -327,9 +437,29 @@ func sendEvents(eventType string, bpfEvents chan []byte, eventBuf *ringbuf.Reade
 	for {
 		rec, err := eventBuf.Read()
 		if err != nil {
-			if errors.Is(err, ringbuf.ErrClosed) || errors.Is(err, ringbuf.ErrFlushed) {
-				logger.DebugContext(context.Background(), "Received signal, exiting")
+			if errors.Is(err, ringbuf.ErrClosed) {
+				logger.DebugContext(context.Background(), "Ring buffer closed, exiting")
 				return
+			}
+			if errors.Is(err, ringbuf.ErrFlushed) {
+				// On flush, every record committed beforehand has already been
+				// forwarded, so a barrier posted now sits behind all of them.
+				barriers, keepGoing := drain.takePending()
+				if !keepGoing {
+					logger.DebugContext(context.Background(), "Ring buffer flushed for shutdown, exiting")
+					return
+				}
+				for _, b := range barriers {
+					// Bound the send like the data path below so a stalled
+					// emitter can't wedge the reader; a drop falls back to the drain timeout.
+					timer.Reset(eventSendTimeout)
+					select {
+					case bpfEvents <- bpfEvent{barrier: b}:
+					case <-timer.C:
+						logger.WarnContext(context.Background(), "Timed out posting drain barrier", "event_type", eventType)
+					}
+				}
+				continue
 			}
 			logger.ErrorContext(context.Background(), "Error reading from ring buffer", "error", err)
 			return
@@ -339,7 +469,7 @@ func sendEvents(eventType string, bpfEvents chan []byte, eventBuf *ringbuf.Reade
 		// could prevent the service from shutting down.
 		timer.Reset(eventSendTimeout)
 		select {
-		case bpfEvents <- rec.RawSample[:]:
+		case bpfEvents <- bpfEvent{data: rec.RawSample[:]}:
 		case <-timer.C:
 			logger.WarnContext(context.Background(), "Enhanced session recording event buffer is full, dropping event", "event_type", eventType)
 		}

--- a/lib/bpf/command.go
+++ b/lib/bpf/command.go
@@ -47,12 +47,13 @@ type exec struct {
 	// session
 	objs commandObjects
 
-	bpfEvents   chan []byte
+	bpfEvents   chan bpfEvent
 	lostCounter *Counter
 	toClose     []io.Closer
 
 	closed   bool
 	flushBuf func() error
+	drain    drainQueue
 
 	mtx sync.Mutex
 	wg  sync.WaitGroup
@@ -134,10 +135,15 @@ func startExec(bufferSize int) (*exec, error) {
 		flushBuf:    eventBuf.Flush,
 	}
 
-	e.bpfEvents = make(chan []byte, bufferSize)
-	e.wg.Go(func() { sendEvents("command", e.bpfEvents, eventBuf) })
+	e.bpfEvents = make(chan bpfEvent, bufferSize)
+	e.wg.Go(func() { sendEvents("command", e.bpfEvents, eventBuf, &e.drain) })
 
 	return e, nil
+}
+
+// drainSession waits for in-flight command events to be emitted before close.
+func (e *exec) drainSession() {
+	drainPipelines("command", e.flushBuf, &e.drain)
 }
 
 func (e *exec) startSession(auditSessionID uint32) error {
@@ -181,6 +187,8 @@ func (e *exec) close() {
 	}
 
 	e.closed = true
+	// Close the drain queue so the flush below makes the reader exit, not drain.
+	e.drain.close()
 
 	if err := e.flushBuf(); err != nil {
 		logger.WarnContext(context.Background(), "failed to flush command ring buffer", "error", err)
@@ -211,6 +219,6 @@ func (e *exec) close() {
 }
 
 // events contains raw events off the perf buffer.
-func (e *exec) events() <-chan []byte {
+func (e *exec) events() <-chan bpfEvent {
 	return e.bpfEvents
 }

--- a/lib/bpf/disk.go
+++ b/lib/bpf/disk.go
@@ -46,12 +46,13 @@ var lostDiskEvents = prometheus.NewCounter(
 type open struct {
 	objs diskObjects
 
-	bpfEvents   chan []byte
+	bpfEvents   chan bpfEvent
 	lostCounter *Counter
 	toClose     []io.Closer
 
 	closed   bool
 	flushBuf func() error
+	drain    drainQueue
 
 	mtx sync.Mutex
 	wg  sync.WaitGroup
@@ -118,10 +119,15 @@ func startOpen(bufferSize int) (*open, error) {
 		flushBuf:    eventBuf.Flush,
 	}
 
-	o.bpfEvents = make(chan []byte, bufferSize)
-	o.wg.Go(func() { sendEvents("disk", o.bpfEvents, eventBuf) })
+	o.bpfEvents = make(chan bpfEvent, bufferSize)
+	o.wg.Go(func() { sendEvents("disk", o.bpfEvents, eventBuf, &o.drain) })
 
 	return o, nil
+}
+
+// drainSession waits for in-flight disk events to be emitted before close.
+func (o *open) drainSession() {
+	drainPipelines("disk", o.flushBuf, &o.drain)
 }
 
 func (o *open) startSession(auditSessionID uint32) error {
@@ -165,6 +171,8 @@ func (o *open) close() {
 	}
 
 	o.closed = true
+	// Close the drain queue so the flush below makes the reader exit, not drain.
+	o.drain.close()
 
 	if err := o.flushBuf(); err != nil {
 		logger.WarnContext(context.Background(), "failed to flush disk ring buffer", "error", err)
@@ -195,6 +203,6 @@ func (o *open) close() {
 }
 
 // events contains raw events off the perf buffer.
-func (o *open) events() <-chan []byte {
+func (o *open) events() <-chan bpfEvent {
 	return o.bpfEvents
 }

--- a/lib/bpf/drain_test.go
+++ b/lib/bpf/drain_test.go
@@ -1,0 +1,101 @@
+//go:build bpf && !386
+
+/*
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bpf
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestDrainQueue(t *testing.T) {
+	t.Parallel()
+
+	var q drainQueue
+
+	b, ok := q.enqueue()
+	require.True(t, ok)
+	require.NotNil(t, b)
+
+	// takePending returns the registered barriers and clears them.
+	pending, keepGoing := q.takePending()
+	require.True(t, keepGoing)
+	require.Len(t, pending, 1)
+	require.Equal(t, b, pending[0])
+
+	pending, keepGoing = q.takePending()
+	require.True(t, keepGoing)
+	require.Empty(t, pending)
+
+	// Once closed, nothing is registered and the reader is told to stop.
+	q.close()
+
+	_, ok = q.enqueue()
+	require.False(t, ok)
+
+	_, keepGoing = q.takePending()
+	require.False(t, keepGoing)
+}
+
+// TestDrainPipelines checks that drainPipelines blocks until every barrier it
+// registered is signaled, as sendEvents and the emit goroutine do at runtime.
+func TestDrainPipelines(t *testing.T) {
+	t.Parallel()
+
+	var q1, q2 drainQueue
+
+	flushed := make(chan struct{}, 1)
+	flush := func() error {
+		// Stand in for the reader and emitter: take the pending barriers and
+		// close them. drainPipelines hangs (test timeout) if it doesn't wait.
+		go func() {
+			for _, q := range []*drainQueue{&q1, &q2} {
+				barriers, _ := q.takePending()
+				for _, b := range barriers {
+					close(b)
+				}
+			}
+		}()
+		flushed <- struct{}{}
+		return nil
+	}
+
+	drainPipelines("test", flush, &q1, &q2)
+
+	require.Len(t, flushed, 1, "flush should have been called exactly once")
+}
+
+// TestDrainPipelinesSkipsClosed checks that draining a closed pipeline is a
+// no-op: nothing is registered and the ring buffer is not flushed.
+func TestDrainPipelinesSkipsClosed(t *testing.T) {
+	t.Parallel()
+
+	var q drainQueue
+	q.close()
+
+	flushCalled := false
+	drainPipelines("test", func() error {
+		flushCalled = true
+		return nil
+	}, &q)
+
+	require.False(t, flushCalled, "flush must not run when there is nothing to drain")
+}

--- a/lib/bpf/network.go
+++ b/lib/bpf/network.go
@@ -47,13 +47,15 @@ var lostNetworkEvents = prometheus.NewCounter(
 type conn struct {
 	objs networkObjects
 
-	bpf4Events  chan []byte
-	bpf6Events  chan []byte
+	bpf4Events  chan bpfEvent
+	bpf6Events  chan bpfEvent
 	lostCounter *Counter
 	toClose     []io.Closer
 
 	closed   bool
 	flushBuf func() error
+	drain4   drainQueue
+	drain6   drainQueue
 
 	mtx sync.Mutex
 	wg  sync.WaitGroup
@@ -147,13 +149,19 @@ func startConn(bufferSize int) (*conn, error) {
 		flushBuf:    flush,
 	}
 
-	c.bpf4Events = make(chan []byte, bufferSize)
-	c.wg.Go(func() { sendEvents("network", c.bpf4Events, eventBufV4) })
+	c.bpf4Events = make(chan bpfEvent, bufferSize)
+	c.wg.Go(func() { sendEvents("network", c.bpf4Events, eventBufV4, &c.drain4) })
 
-	c.bpf6Events = make(chan []byte, bufferSize)
-	c.wg.Go(func() { sendEvents("network", c.bpf6Events, eventBufV6) })
+	c.bpf6Events = make(chan bpfEvent, bufferSize)
+	c.wg.Go(func() { sendEvents("network", c.bpf6Events, eventBufV6, &c.drain6) })
 
 	return c, nil
+}
+
+// drainSession waits for in-flight network events to be emitted before close.
+// One flush covers both the IPv4 and IPv6 buffers.
+func (c *conn) drainSession() {
+	drainPipelines("network", c.flushBuf, &c.drain4, &c.drain6)
 }
 
 func (c *conn) startSession(auditSessionID uint32) error {
@@ -197,6 +205,9 @@ func (c *conn) close() {
 	}
 
 	c.closed = true
+	// Close the drain queues so the flush below makes the readers exit, not drain.
+	c.drain4.close()
+	c.drain6.close()
 
 	if err := c.flushBuf(); err != nil {
 		logger.WarnContext(context.Background(), "failed to flush network ring buffer", "error", err)
@@ -227,11 +238,11 @@ func (c *conn) close() {
 }
 
 // v4Events contains raw events off the perf buffer.
-func (c *conn) v4Events() <-chan []byte {
+func (c *conn) v4Events() <-chan bpfEvent {
 	return c.bpf4Events
 }
 
 // v6Events contains raw events off the perf buffer.
-func (c *conn) v6Events() <-chan []byte {
+func (c *conn) v6Events() <-chan bpfEvent {
 	return c.bpf6Events
 }

--- a/lib/srv/mock_test.go
+++ b/lib/srv/mock_test.go
@@ -87,6 +87,7 @@ func newTestServerContext(t *testing.T, srv Server, sessionJoiningRoleSet servic
 		SessionRecordingConfig: recConfig,
 		IsTestStub:             true,
 		ClusterName:            clusterName,
+		ExecResultCh:           make(chan ExecResult, 10),
 		srv:                    srv,
 		Identity: IdentityContext{
 			UnmappedIdentity: ident,

--- a/lib/srv/sess.go
+++ b/lib/srv/sess.go
@@ -792,6 +792,8 @@ type session struct {
 
 	doneCh chan struct{}
 
+	closedCh chan struct{}
+
 	displayParticipantRequirements bool
 
 	// endingContext is the server context which closed this session.
@@ -882,6 +884,7 @@ func newSession(ctx context.Context, r *SessionRegistry, scx *ServerContext, ch 
 		presenceEnabled: scx.Identity.UnmappedIdentity.MFAVerified != "",
 		io:              NewTermManager(),
 		doneCh:          make(chan struct{}),
+		closedCh:        make(chan struct{}),
 		initiator: sessionInitiatorInfo{
 			user:    scx.Identity.TeleportUser,
 			cluster: scx.Identity.OriginClusterName,
@@ -1043,6 +1046,8 @@ func (s *session) Close() error {
 				s.logger.WarnContext(s.serverCtx, "Failed to close recorder.", "error", err)
 			}
 		}
+
+		close(s.closedCh)
 	})
 	return nil
 }
@@ -1534,7 +1539,7 @@ func (s *session) startInteractive(ctx context.Context, scx *ServerContext, p *p
 		// broadcasting the result (which will close the pty) if it has not been
 		// closed already.
 		select {
-		case <-time.After(defaults.WaitCopyTimeout):
+		case <-s.registry.clock.After(defaults.WaitCopyTimeout):
 			s.logger.DebugContext(ctx, "Timed out waiting for PTY copy to finish, session data may be missing.")
 		case <-s.doneCh:
 		}
@@ -1725,7 +1730,10 @@ func (s *session) startExec(ctx context.Context, channel ssh.Channel, scx *Serve
 		// to the client. The SSH server code in handleSessionRequests
 		// should be refactored to consistently wait for the exit result
 		// before cleaning up.
-		time.Sleep(2 * time.Second)
+		select {
+		case <-time.After(2 * time.Second):
+		case <-s.registry.clock.After(2 * time.Second):
+		}
 
 		if sessionContext != nil {
 			err = scx.srv.GetBPF().CloseSession(sessionContext)

--- a/lib/srv/sess.go
+++ b/lib/srv/sess.go
@@ -1722,22 +1722,15 @@ func (s *session) startExec(ctx context.Context, channel ssh.Channel, scx *Serve
 		result := execRequest.Wait()
 		scx.SendExecResult(ctx, result)
 
-		// Wait a little bit to let all events filter through before
-		// closing the BPF session so everything can be recorded.
-		//
-		// TODO: This sleep is also necessary to prevent the SSH server
-		// from closing an SSH session without sending the exit status
-		// to the client. The SSH server code in handleSessionRequests
-		// should be refactored to consistently wait for the exit result
-		// before cleaning up.
-		select {
-		case <-time.After(2 * time.Second):
-		case <-s.registry.clock.After(2 * time.Second):
-		}
+		// Wait for the request handler to deliver the exit status before we tear
+		// down the session (which closes the channel). handleSessionRequests
+		// sends "exit-status" and only then cancels the context, so the client
+		// is guaranteed to receive it first.
+		<-scx.CancelContext().Done()
 
 		if sessionContext != nil {
-			err = scx.srv.GetBPF().CloseSession(sessionContext)
-			if err != nil {
+			// CloseSession drains in-flight events itself, so no delay is needed.
+			if err := scx.srv.GetBPF().CloseSession(sessionContext); err != nil {
 				s.logger.ErrorContext(ctx, "Failed to close enhanced recording (exec) session.", "error", err)
 			}
 		}

--- a/lib/srv/sess_test.go
+++ b/lib/srv/sess_test.go
@@ -22,7 +22,6 @@ import (
 	"context"
 	"crypto/ed25519"
 	"io"
-	"maps"
 	"net"
 	"os/user"
 	"slices"
@@ -532,7 +531,7 @@ func TestSession_emitAuditEvent(t *testing.T) {
 		// Wait for the events on the new recorder
 		require.Eventually(t, func() bool {
 			return len(srv.Events()) == 2
-		}, 1000*time.Second, 100*time.Millisecond)
+		}, 5*time.Second, 10*time.Millisecond)
 	})
 }
 
@@ -581,43 +580,14 @@ func TestInteractiveSession(t *testing.T) {
 	// to end and cleanup in the background
 	scx.party.s.Stop()
 
-	// Wait for the session to be removed from the registry.
-	require.Eventually(t, func() bool {
-		_, found := reg.findSession(scx.party.s.id)
-		return !found
-	}, time.Second*15, time.Millisecond*500)
+	// Wait for Close() to complete, advancing the fake clock past
+	// WaitCopyTimeout so the cleanup goroutine doesn't block.
+	waitSessionClosedWithClock(t, scx.party.s, srv.clock)
 
-	// Validate that the expected audit events were emitted.
+	// Events are emitted before Close() so they're guaranteed present now
 	expectedEvents := []string{events.SessionStartEvent, events.ResizeEvent, events.SessionEndEvent, events.SessionLeaveEvent}
-	require.Eventually(t, func() bool {
-		actual := srv.MockRecorderEmitter.Events()
-
-		for _, evt := range expectedEvents {
-			contains := slices.ContainsFunc(actual, func(event apievents.AuditEvent) bool {
-				return event.GetType() == evt
-			})
-			if !contains {
-				return false
-			}
-		}
-		return true
-	}, 15*time.Second, 500*time.Millisecond)
-
-	// Validate that the expected recording events were emitted.
-	require.Eventually(t, func() bool {
-		actual := srv.MockRecorderEmitter.RecordedEvents()
-
-		for _, evt := range expectedEvents {
-			contains := slices.ContainsFunc(actual, func(event apievents.PreparedSessionEvent) bool {
-				return event.GetAuditEvent().GetType() == evt
-			})
-			if !contains {
-				return false
-			}
-		}
-
-		return true
-	}, 15*time.Second, 500*time.Millisecond)
+	requireEventsEmitted(t, srv.MockRecorderEmitter, expectedEvents)
+	requireRecordedEventsEmitted(t, srv.MockRecorderEmitter, expectedEvents)
 }
 
 // TestNonInteractiveSession tests non-interactive session lifecycles
@@ -659,28 +629,14 @@ func TestNonInteractiveSession(t *testing.T) {
 		require.NoError(t, reg.OpenExecSession(ctx, serverChan, scx))
 		require.NotNil(t, scx.party)
 
-		// Wait for the command execution to complete and the session to be terminated.
-		require.Eventually(t, func() bool {
-			_, found := reg.findSession(scx.party.s.id)
-			return !found
-		}, time.Second*15, time.Millisecond*500)
+		// Simulate what handleSessionRequests does; drain exec result
+		// and close the server context
+		drainExecResult(t, scx)
+		waitSessionClosedWithClock(t, scx.party.s, srv.clock)
 
-		// Verify that all the expected audit events are eventually emitted.
+		// Events are emitted before Close() so they're guaranteed present now
 		expected := []string{events.SessionStartEvent, events.ExecEvent, events.SessionEndEvent, events.SessionLeaveEvent}
-		require.Eventually(t, func() bool {
-			actual := srv.MockRecorderEmitter.Events()
-
-			for _, evt := range expected {
-				contains := slices.ContainsFunc(actual, func(event apievents.AuditEvent) bool {
-					return event.GetType() == evt
-				})
-				if !contains {
-					return false
-				}
-			}
-
-			return true
-		}, 15*time.Second, 500*time.Millisecond)
+		requireEventsEmitted(t, srv.MockRecorderEmitter, expected)
 
 		// Verify that NO recordings were emitted
 		require.Empty(t, srv.MockRecorderEmitter.RecordedEvents())
@@ -722,47 +678,19 @@ func TestNonInteractiveSession(t *testing.T) {
 		require.NoError(t, reg.OpenExecSession(ctx, serverChan, scx))
 		require.NotNil(t, scx.party)
 
-		// Wait for the command execution to complete and the session to be terminated.
-		require.Eventually(t, func() bool {
-			_, found := reg.findSession(scx.party.s.id)
-			return !found
-		}, time.Second*15, time.Millisecond*500)
+		// Simulate what handleSessionRequests does; drain exec result
+		// and close the server context
+		drainExecResult(t, scx)
+		waitSessionClosedWithClock(t, scx.party.s, srv.clock)
 
-		// Verify that all the expected audit events are eventually emitted.
+		// Events are emitted before Close() so they're guaranteed present now
 		expectedEvents := []string{events.SessionStartEvent, events.ExecEvent, events.SessionEndEvent, events.SessionLeaveEvent}
-		require.Eventually(t, func() bool {
-			actual := srv.MockRecorderEmitter.Events()
-
-			for _, evt := range expectedEvents {
-				contains := slices.ContainsFunc(actual, func(event apievents.AuditEvent) bool {
-					return event.GetType() == evt
-				})
-				if !contains {
-					return false
-				}
-			}
-
-			return true
-		}, 15*time.Second, 500*time.Millisecond)
+		requireEventsEmitted(t, srv.MockRecorderEmitter, expectedEvents)
 
 		// Validate that the expected recording events were emitted.
-		require.Eventually(t, func() bool {
-			actual := srv.MockRecorderEmitter.RecordedEvents()
-
-			for _, evt := range expectedEvents {
-				if evt == events.ExecEvent {
-					continue
-				}
-				contains := slices.ContainsFunc(actual, func(event apievents.PreparedSessionEvent) bool {
-					return event.GetAuditEvent().GetType() == evt
-				})
-				if !contains {
-					return false
-				}
-			}
-
-			return true
-		}, 15*time.Second, 500*time.Millisecond)
+		requireRecordedEventsEmitted(t, srv.MockRecorderEmitter, slices.DeleteFunc(slices.Clone(expectedEvents), func(e string) bool {
+			return e == events.ExecEvent
+		}))
 	})
 }
 
@@ -799,11 +727,7 @@ func TestStopUnstarted(t *testing.T) {
 	// to end and cleanup in the background
 	sess.Stop()
 
-	sessionClosed := func() bool {
-		_, found := reg.findSession(sess.id)
-		return !found
-	}
-	require.Eventually(t, sessionClosed, time.Second*15, time.Millisecond*500)
+	waitSessionClosedWithClock(t, sess, srv.clock)
 }
 
 func TestModeratedSessionPresence(t *testing.T) {
@@ -909,24 +833,23 @@ func TestModeratedSessionPresence(t *testing.T) {
 	require.Equal(t, moderatorParticipant.ID, refreshedParticipant.ID)
 	require.Equal(t, presenceUpdateTime, refreshedParticipant.LastActive)
 
-	require.Never(t, func() bool {
-		updatedTracker, err := srv.auth.GetSessionTracker(ctx, sess.id.String())
-		require.NoError(t, err)
-		return updatedTracker.GetState() != types.SessionState_SessionStateRunning
-	}, 500*time.Millisecond, 100*time.Millisecond)
+	// The session should still be running.
+	updatedTracker, err := srv.auth.GetSessionTracker(ctx, sess.id.String())
+	require.NoError(t, err)
+	require.Equal(t, types.SessionState_SessionStateRunning, updatedTracker.GetState())
 
 	// Advance the server clock so that the moderator is stale. The session should terminate.
 	srv.clock.Advance(srv.GetPresenceMaxDuration())
 
-	require.Eventually(t, sess.isStopped, time.Second, 10*time.Millisecond)
-	require.EventuallyWithT(t, func(t *assert.CollectT) {
-		updatedTracker, err := srv.auth.GetSessionTracker(ctx, sess.id.String())
-		require.NoError(t, err)
-		require.Equal(t, types.SessionState_SessionStateTerminated, updatedTracker.GetState())
-		for _, participant := range updatedTracker.GetParticipants() {
-			require.NotEqual(t, moderatorParticipant.ID, participant.ID)
-		}
-	}, 5*time.Second, 100*time.Millisecond)
+	waitSessionClosed(t, sess)
+
+	// Tracker state should be set to Terminated inside Close().
+	terminatedTracker, err := srv.auth.GetSessionTracker(ctx, sess.id.String())
+	require.NoError(t, err)
+	require.Equal(t, types.SessionState_SessionStateTerminated, terminatedTracker.GetState())
+	for _, participant := range terminatedTracker.GetParticipants() {
+		require.NotEqual(t, moderatorParticipant.ID, participant.ID)
+	}
 }
 
 // TestParties tests the party mechanisms within an interactive session,
@@ -962,7 +885,7 @@ func TestParties(t *testing.T) {
 	partyIsRemoved := func() bool {
 		return len(sess.getParties()) == 2 && !sess.isStopped()
 	}
-	require.Eventually(t, partyIsRemoved, time.Second*5, time.Millisecond*500)
+	require.Eventually(t, partyIsRemoved, time.Second*5, 10*time.Millisecond)
 
 	// If a party's session context is closed, the party should leave the session.
 	p = sess.getParties()[0]
@@ -979,7 +902,7 @@ func TestParties(t *testing.T) {
 	partyIsRemoved = func() bool {
 		return len(sess.getParties()) == 1 && !sess.isStopped()
 	}
-	require.Eventually(t, partyIsRemoved, time.Second*5, time.Millisecond*500)
+	require.Eventually(t, partyIsRemoved, time.Second*5, 10*time.Millisecond)
 
 	p.closeOnce.Do(func() {
 		t.Fatalf("party should be closed already")
@@ -1011,7 +934,11 @@ func TestParties(t *testing.T) {
 
 	// Session should close.
 	regClock.Advance(defaults.SessionIdlePeriod)
-	require.Eventually(t, sess.isStopped, time.Second*5, time.Millisecond*500)
+	select {
+	case <-sess.stopC:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for session to stop")
+	}
 }
 
 func TestSessionRecordingModes(t *testing.T) {
@@ -1067,22 +994,14 @@ func TestSessionRecordingModes(t *testing.T) {
 				sess.Stop()
 			}
 
-			// Wait until the session is stopped.
-			require.Eventually(t, sess.isStopped, time.Second*5, time.Millisecond*500)
+			waitSessionClosedWithClock(t, sess, srv.clock)
 
-			// Wait until server receives all non-print events.
-			require.EventuallyWithT(t, func(t *assert.CollectT) {
-				// Events can appear in different orders. Use a set to track.
-				eventsNotReceived := map[string]struct{}{
-					events.SessionStartEvent: {},
-					events.SessionLeaveEvent: {},
-					events.SessionEndEvent:   {},
-				}
-				for _, e := range srv.Events() {
-					delete(eventsNotReceived, e.GetType())
-				}
-				require.Empty(t, slices.Collect(maps.Keys(eventsNotReceived)))
-			}, time.Second*5, time.Millisecond*500, "Some events not received")
+			// Events are emitted before Close(), so they're guaranteed present now.
+			requireEventsEmitted(t, srv.MockRecorderEmitter, []string{
+				events.SessionStartEvent,
+				events.SessionLeaveEvent,
+				events.SessionEndEvent,
+			})
 		})
 	}
 }
@@ -1114,11 +1033,10 @@ func TestBPFEnabledAndNoPermitEvents(t *testing.T) {
 
 	sess := scx.getSession()
 	require.NotNil(t, sess)
-	select {
-	case <-sess.doneCh:
-	case <-time.After(3 * time.Second):
-		require.Fail(t, "exec session did not complete")
-	}
+
+	// Drain the exec result so the cleanup goroutine proceeds immediately.
+	drainExecResult(t, scx)
+	waitSessionClosedWithClock(t, sess, srv.clock)
 
 	require.Zero(t, bpfSrv.openSessionCalls.Load())
 	require.Zero(t, bpfSrv.closeSessionCalls.Load())
@@ -1192,6 +1110,88 @@ func TestStopSessionWithoutClientDisconnect(t *testing.T) {
 			}
 		})
 	}
+}
+
+// waitSessionClosed waits for the session's closedCh to be closed, indicating
+// the session has been fully cleaned up. Since events are emitted before Close()
+// all audit and recording events are guaranteed to be present after this returns.
+func waitSessionClosed(t *testing.T, sess *session) {
+	t.Helper()
+	select {
+	case <-sess.closedCh:
+	case <-time.After(15 * time.Second):
+		t.Fatal("timed out waiting for session to close")
+	}
+}
+
+// waitSessionClosedWithClock advances the fake clock until the session is fully closed.
+// Interactive session cleanup goroutine blocks on clock.After(WaitCopyTimeout),
+// which may not be registered yet when the test tries to advance the clock.
+func waitSessionClosedWithClock(t *testing.T, sess *session, clock interface{ Advance(time.Duration) }) {
+	t.Helper()
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for {
+			select {
+			case <-sess.closedCh:
+				return
+			case <-time.After(10 * time.Millisecond):
+				clock.Advance(defaults.WaitCopyTimeout)
+			}
+		}
+	}()
+	select {
+	case <-done:
+	case <-time.After(15 * time.Second):
+		t.Fatal("timed out waiting for session to close")
+	}
+}
+
+// requireEventsEmitted asserts that all expected audit event types are present
+// in the mock emitter. Should be called after waitSessionClosed, which
+// guarantees events have been flushed.
+func requireEventsEmitted(t *testing.T, emitter *eventstest.MockRecorderEmitter, expectedEvents []string) {
+	t.Helper()
+	actual := emitter.Events()
+	for _, evt := range expectedEvents {
+		require.True(t, slices.ContainsFunc(actual, func(event apievents.AuditEvent) bool {
+			return event.GetType() == evt
+		}), "missing audit event: %s (got: %v)", evt, eventTypes(actual))
+	}
+}
+
+// requireRecordedEventsEmitted asserts that all expected recording event types
+// are present in the mock emitter. Should be called after waitSessionClosed.
+func requireRecordedEventsEmitted(t *testing.T, emitter *eventstest.MockRecorderEmitter, expectedEvents []string) {
+	t.Helper()
+	actual := emitter.RecordedEvents()
+	for _, evt := range expectedEvents {
+		require.True(t, slices.ContainsFunc(actual, func(event apievents.PreparedSessionEvent) bool {
+			return event.GetAuditEvent().GetType() == evt
+		}), "missing recorded event: %s", evt)
+	}
+}
+
+// drainExecResult reads the exec result from ExecResultCh then closes
+// the server context, which unblocks the exec cleanup goroutine.
+func drainExecResult(t *testing.T, scx *ServerContext) {
+	t.Helper()
+	go func() {
+		select {
+		case <-scx.ExecResultCh:
+			scx.Close()
+		case <-time.After(15 * time.Second):
+		}
+	}()
+}
+
+func eventTypes(events []apievents.AuditEvent) []string {
+	types := make([]string, len(events))
+	for i, e := range events {
+		types[i] = e.GetType()
+	}
+	return types
 }
 
 func testOpenSession(t *testing.T, reg *SessionRegistry, sessionJoiningRoleSet services.RoleSet, accessPermit *decisionpb.SSHAccessPermit) (*session, ssh.Channel) {


### PR DESCRIPTION
## Context
Enhanced session recording correlates command/disk/network events to a session via an audit session ID. On close, `CloseSession` deleted that mapping before events still in-flight (in kernel ring buffer or the internal chan) were emitted so the emitter failed to match them and dropped them. This is most visible on force-termination.

The non-interactive exec path hid the problem via an unconditional `time.Sleep(2*time.Second)`. That sleep also served a second unrelated purpose of keeping the SSH chan open long enough for the request handler to deliver `exit-status` to the client before teardown.

## Changes
- Events and a flush barrier now share the same chan, so a barrier is only observed after every event ahead of it is emitted
- `CloseSession` is reordered to 1) `endSession` (stop the kernel emitting), 2) `drainSession` (flush the ring buf and wait for the barrier), 3) delete the session
- A `sessionDrainTimeout` bounds the wait as a safety net to ensure worst-case is no more than the existing 2s hardcoded sleep
- `startExec` waits on the server ctx's cancellation instead of sleeping `handleSessionRequests` (regular and forwarding srvs) sends exit-status and only then returns, cancelling the ctx, so delivery of exit-status is guaranteed to come before teardown

Changelog: Fixed enhanced session recordings occasionally dropping command, disk, and network events generated immediately before a session ends, most notably when force-terminating.

## Manual Test Plan
### Test Environment
- Auth/Proxy from a release, and SSH service built from this branch with BPF support
- SSH service has `enhanced_recording.enabeld: true`
- User with SSH access to the node
- User who can view audit events
- Admin user and moderated-session setup, for the force-termination case

### Test Cases
- [ ] Verify that enhanced recording is active. Run `tsh ssh <node> id` and confirm a `session.command` event for `id` appears in the Audit Log for that session.
- [ ] Verify that exec exit codes are correct and returned promptly. run `tsh ssh <node> 'exit 7'; echo $?` and confirm it prints `7` and returns in ~1s with no multi-second hang.
- [ ] Verify that a self-terminating exec session records its near-exit events: run `tsh ssh <node> 'cat /etc/hostname'` and confirm the Audit Log shows a `session.command` for `cat` and a `session.disk` for opening `/etc/hostname`, plus `session.end`.
- [ ] Verify that an interactive session records all commands on normal exit. run `tsh ssh <node>`, execute `whoami` and `cat /etc/hostname`, then exit; confirm the Audit Log shows `session.command` (for both) and `session.disk` events plus `session.end`.
- [ ] Verify that force-terminating a session preserves its near-exit events. In the moderated setup, as the user run `tsh ssh <node>` and start `while true; do cat /etc/hostname >/dev/null; done;` as the moderator run `tsh join --mode=moderator <session-id>` and press `t` to terminate; confirm the Audit Log for that session still contains `session.command`/`session.disk` events from immediately before termination, plus `session.end`.
- [ ] Verify no regression with enhanced recording disabled. Set `enhanced_recording.enabled: false`, restart the node, run `tsh ssh <node> id`; confirm the session completes and exits promptly, no `session.command` events are emitted, and `session.end` is present.
- [ ] (Optional A/B) verify this fix is responsible. Repeat the force-termination case against a node built from master; confirm trailing `session.command`/`session.disk` events are missing or fewer there, and present on this branch.
