### PR TITLE
Caching OIDC validator improvements

### DIFF
--- a/lib/join/env0/validator.go
+++ b/lib/join/env0/validator.go
@@ -39,7 +39,7 @@ const (
 
 // IDTokenValidator can be used to validate env0 OIDC tokens.
 type IDTokenValidator struct {
-	validator *oidc.CachingTokenValidator[*IDTokenClaims]
+	validator *oidc.CachingTokenValidator[*IDTokenClaims, oidc.StandardValidatorKey]
 }
 
 // ValidateToken validates an env0 OIDC token using a remote, cached OIDC
@@ -48,7 +48,7 @@ func (v *IDTokenValidator) ValidateToken(
 	ctx context.Context,
 	token []byte,
 ) (*IDTokenClaims, error) {
-	validator, err := v.validator.GetValidator(ctx, env0IssuerURL, env0Audience)
+	validator, err := v.validator.GetValidatorWithKey(ctx, oidc.NewStandardValidatorKey(env0IssuerURL, env0Audience))
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -69,7 +69,7 @@ func (v *IDTokenValidator) ValidateToken(
 
 // NewOIDCTokenValidator constructs a KubernetesOIDCTokenValidator.
 func NewIDTokenValidator() (*IDTokenValidator, error) {
-	validator, err := oidc.NewCachingTokenValidator[*IDTokenClaims](clockwork.NewRealClock())
+	validator, err := oidc.NewCachingTokenValidator[*IDTokenClaims, oidc.StandardValidatorKey](clockwork.NewRealClock())
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/kube/token/validator.go
+++ b/lib/kube/token/validator.go
@@ -341,7 +341,7 @@ func ValidateTokenWithJWKS(
 
 // NewKubernetesOIDCTokenValidator constructs a KubernetesOIDCTokenValidator.
 func NewKubernetesOIDCTokenValidator() (*KubernetesOIDCTokenValidator, error) {
-	validator, err := oidc.NewCachingTokenValidator[*tokenclaims.OIDCServiceAccountClaims](clockwork.NewRealClock())
+	validator, err := oidc.NewCachingTokenValidator[*tokenclaims.OIDCServiceAccountClaims, oidc.StandardValidatorKey](clockwork.NewRealClock())
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -354,7 +354,7 @@ func NewKubernetesOIDCTokenValidator() (*KubernetesOIDCTokenValidator, error) {
 // KubernetesOIDCTokenValidator is a validator that can validate Kubernetes
 // projected service account tokens against an external OIDC compatible IdP.
 type KubernetesOIDCTokenValidator struct {
-	validator *oidc.CachingTokenValidator[*tokenclaims.OIDCServiceAccountClaims]
+	validator *oidc.CachingTokenValidator[*tokenclaims.OIDCServiceAccountClaims, oidc.StandardValidatorKey]
 }
 
 // ValidateTokenWithJWKS validates a Kubernetes Service Account JWT using an
@@ -365,7 +365,7 @@ func (v *KubernetesOIDCTokenValidator) ValidateToken(
 	clusterName string,
 	token string,
 ) (*ValidationResult, error) {
-	validator, err := v.validator.GetValidator(ctx, issuerURL, clusterName)
+	validator, err := v.validator.GetValidatorWithKey(ctx, oidc.NewStandardValidatorKey(issuerURL, clusterName))
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/oidc/caching_token_validator.go
+++ b/lib/oidc/caching_token_validator.go
@@ -56,15 +56,40 @@ const (
 	validatorTTL = time.Hour * 24 * 2
 )
 
-// validatorKey is a composite key for the validator instance map
-type validatorKey struct {
+// ValidatorKey is a caching key for validator instances. Keys at minimum must
+// contain an issuer an audience (required to construct validators) but may also
+// contain other caching keys as desired.
+type ValidatorKey interface {
+	comparable
+
+	GetIssuer() string
+	GetAudience() string
+}
+
+// StandardValidatorKey is a composite key for the validator instance map
+type StandardValidatorKey struct {
 	issuer   string
 	audience string
 }
 
+func (k StandardValidatorKey) GetIssuer() string {
+	return k.issuer
+}
+
+func (k StandardValidatorKey) GetAudience() string {
+	return k.audience
+}
+
+func NewStandardValidatorKey(issuer, audience string) StandardValidatorKey {
+	return StandardValidatorKey{
+		issuer:   issuer,
+		audience: audience,
+	}
+}
+
 // NewCachingTokenValidator creates a caching validator for the given issuer and
 // audience, using a real clock.
-func NewCachingTokenValidator[C oidc.Claims](clock clockwork.Clock) (*CachingTokenValidator[C], error) {
+func NewCachingTokenValidator[C oidc.Claims, K ValidatorKey](clock clockwork.Clock) (*CachingTokenValidator[C, K], error) {
 	if clock == nil {
 		clock = clockwork.NewRealClock()
 	}
@@ -78,7 +103,7 @@ func NewCachingTokenValidator[C oidc.Claims](clock clockwork.Clock) (*CachingTok
 		return nil, err
 	}
 
-	return &CachingTokenValidator[C]{
+	return &CachingTokenValidator[C, K]{
 		clock: clock,
 		cache: cache,
 	}, nil
@@ -89,31 +114,52 @@ func NewCachingTokenValidator[C oidc.Claims](clock clockwork.Clock) (*CachingTok
 // (issuer, audience) pair. This helps to ensure validators and key sets don't
 // remain in memory indefinitely if e.g. a Teleport auth token is modified to
 // use a different issuer or removed outright.
-type CachingTokenValidator[C oidc.Claims] struct {
+type CachingTokenValidator[C oidc.Claims, K ValidatorKey] struct {
 	clock clockwork.Clock
 
 	cache *utils.FnCache
 }
 
-// GetValidator retreives a validator for the given issuer and audience. This
-// will create a new validator instance if necessary, and will occasionally
-// prune old instances that have not been used to validate any tokens in some
-// time.
-func (v *CachingTokenValidator[C]) GetValidator(ctx context.Context, issuer, audience string) (*CachingValidatorInstance[C], error) {
-	key := validatorKey{issuer: issuer, audience: audience}
+// ClientMutator is used to modify settings on the constructed http client.
+// Note that if your downstream use case contains user-configurable client
+// options (e.g. custom CA, insecure verification, timeout, etc) you MUST
+// include those parameters as components of a custom caching key or changes to
+// those parameters will not take effect until the cache is busted (min 48 hours
+// or a change to something in the key). It is okay to hash values (e.g. CA
+// PEM) or similar.
+type ClientMutator func(client *http.Client) error
+
+// GetValidatorWithKey returns a caching token validator using a custom caching
+// key. See the ClientMutator docstring for notes about using client mutators
+// with caching.
+func (v *CachingTokenValidator[C, K]) GetValidatorWithKey(
+	ctx context.Context,
+	key K,
+	opts ...ClientMutator,
+) (*CachingValidatorInstance[C], error) {
 	instance, err := utils.FnCacheGet(ctx, v.cache, key, func(ctx context.Context) (*CachingValidatorInstance[C], error) {
 		transport, err := defaults.Transport()
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
 
+		client := &http.Client{
+			Transport: NewOIDCRoundTripper(otelhttp.NewTransport(transport)),
+		}
+
+		for _, mutator := range opts {
+			if err := mutator(client); err != nil {
+				return nil, trace.Wrap(err, "constructing cached http client")
+			}
+		}
+
 		return &CachingValidatorInstance[C]{
-			client:     &http.Client{Transport: otelhttp.NewTransport(transport)},
+			client:     client,
 			clock:      v.clock,
-			issuer:     issuer,
-			audience:   audience,
+			issuer:     key.GetIssuer(),
+			audience:   key.GetAudience(),
 			verifierFn: zoidcTokenVerifier[C],
-			logger:     log.With("issuer", issuer, "audience", audience),
+			logger:     log.With("key", key),
 		}, nil
 	})
 

--- a/lib/oidc/caching_token_validator.go
+++ b/lib/oidc/caching_token_validator.go
@@ -159,7 +159,7 @@ func (v *CachingTokenValidator[C, K]) GetValidatorWithKey(
 			issuer:     key.GetIssuer(),
 			audience:   key.GetAudience(),
 			verifierFn: zoidcTokenVerifier[C],
-			logger:     log.With("key", key),
+			logger:     log.With("issuer", key.GetIssuer(), "audience", key.GetAudience()),
 		}, nil
 	})
 

--- a/lib/oidc/caching_token_validator_test.go
+++ b/lib/oidc/caching_token_validator_test.go
@@ -30,6 +30,7 @@ import (
 
 	"github.com/go-jose/go-jose/v4"
 	"github.com/go-jose/go-jose/v4/jwt"
+	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
 	"github.com/stretchr/testify/require"
 	"github.com/zitadel/oidc/v3/pkg/client/rp"
@@ -203,12 +204,12 @@ func TestCachingTokenValidator(t *testing.T) {
 	tests := []struct {
 		name     string
 		audience string
-		execute  func(t *testing.T, idp *fakeIDP, v *CachingTokenValidator[*oidc.TokenClaims])
+		execute  func(t *testing.T, idp *fakeIDP, v *CachingTokenValidator[*oidc.TokenClaims, StandardValidatorKey])
 	}{
 		{
 			name:     "empty",
 			audience: defaultAudience,
-			execute: func(t *testing.T, idp *fakeIDP, v *CachingTokenValidator[*oidc.TokenClaims]) {
+			execute: func(t *testing.T, idp *fakeIDP, v *CachingTokenValidator[*oidc.TokenClaims, StandardValidatorKey]) {
 				// Do nothing.
 				require.Zero(t, idp.configRequests.Load())
 				require.Zero(t, idp.jwksRequests.Load())
@@ -217,8 +218,8 @@ func TestCachingTokenValidator(t *testing.T) {
 		{
 			name:     "single validator",
 			audience: defaultAudience,
-			execute: func(t *testing.T, idp *fakeIDP, v *CachingTokenValidator[*oidc.TokenClaims]) {
-				val, err := v.GetValidator(t.Context(), idp.issuer(), defaultAudience)
+			execute: func(t *testing.T, idp *fakeIDP, v *CachingTokenValidator[*oidc.TokenClaims, StandardValidatorKey]) {
+				val, err := v.GetValidatorWithKey(t.Context(), NewStandardValidatorKey(idp.issuer(), defaultAudience))
 				require.NoError(t, err)
 
 				token := idp.issueToken(t, defaultAudience, "a", time.Hour)
@@ -241,10 +242,10 @@ func TestCachingTokenValidator(t *testing.T) {
 		{
 			name:     "multiple validators",
 			audience: defaultAudience,
-			execute: func(t *testing.T, idp *fakeIDP, v *CachingTokenValidator[*oidc.TokenClaims]) {
-				v1, err := v.GetValidator(t.Context(), idp.issuer(), "a.teleport.sh")
+			execute: func(t *testing.T, idp *fakeIDP, v *CachingTokenValidator[*oidc.TokenClaims, StandardValidatorKey]) {
+				v1, err := v.GetValidatorWithKey(t.Context(), NewStandardValidatorKey(idp.issuer(), "a.teleport.sh"))
 				require.NoError(t, err)
-				v2, err := v.GetValidator(t.Context(), idp.issuer(), "b.teleport.sh")
+				v2, err := v.GetValidatorWithKey(t.Context(), NewStandardValidatorKey(idp.issuer(), "b.teleport.sh"))
 				require.NoError(t, err)
 
 				token := idp.issueToken(t, "a.teleport.sh", "a", time.Hour)
@@ -276,8 +277,8 @@ func TestCachingTokenValidator(t *testing.T) {
 		{
 			name:     "expired config",
 			audience: defaultAudience,
-			execute: func(t *testing.T, idp *fakeIDP, v *CachingTokenValidator[*oidc.TokenClaims]) {
-				val, err := v.GetValidator(t.Context(), idp.issuer(), defaultAudience)
+			execute: func(t *testing.T, idp *fakeIDP, v *CachingTokenValidator[*oidc.TokenClaims, StandardValidatorKey]) {
+				val, err := v.GetValidatorWithKey(t.Context(), NewStandardValidatorKey(idp.issuer(), defaultAudience))
 				require.NoError(t, err)
 				val.verifierFn = minimalValidator()
 
@@ -300,8 +301,8 @@ func TestCachingTokenValidator(t *testing.T) {
 		{
 			name:     "stale config",
 			audience: defaultAudience,
-			execute: func(t *testing.T, idp *fakeIDP, v *CachingTokenValidator[*oidc.TokenClaims]) {
-				val, err := v.GetValidator(t.Context(), idp.issuer(), defaultAudience)
+			execute: func(t *testing.T, idp *fakeIDP, v *CachingTokenValidator[*oidc.TokenClaims, StandardValidatorKey]) {
+				val, err := v.GetValidatorWithKey(t.Context(), NewStandardValidatorKey(idp.issuer(), defaultAudience))
 				require.NoError(t, err)
 				val.verifierFn = minimalValidator()
 
@@ -329,8 +330,8 @@ func TestCachingTokenValidator(t *testing.T) {
 		{
 			name:     "changed jwks uri",
 			audience: defaultAudience,
-			execute: func(t *testing.T, idp *fakeIDP, v *CachingTokenValidator[*oidc.TokenClaims]) {
-				val, err := v.GetValidator(t.Context(), idp.issuer(), defaultAudience)
+			execute: func(t *testing.T, idp *fakeIDP, v *CachingTokenValidator[*oidc.TokenClaims, StandardValidatorKey]) {
+				val, err := v.GetValidatorWithKey(t.Context(), NewStandardValidatorKey(idp.issuer(), defaultAudience))
 				require.NoError(t, err)
 				val.verifierFn = minimalValidator()
 
@@ -361,21 +362,21 @@ func TestCachingTokenValidator(t *testing.T) {
 		{
 			name:     "validator pruning",
 			audience: defaultAudience,
-			execute: func(t *testing.T, idp *fakeIDP, v *CachingTokenValidator[*oidc.TokenClaims]) {
-				valOld, err := v.GetValidator(t.Context(), idp.issuer(), "a")
+			execute: func(t *testing.T, idp *fakeIDP, v *CachingTokenValidator[*oidc.TokenClaims, StandardValidatorKey]) {
+				valOld, err := v.GetValidatorWithKey(t.Context(), NewStandardValidatorKey(idp.issuer(), "a"))
 				require.NoError(t, err)
 
 				// After just 1 hour, it should return the same pointer
 				idp.clock.Advance(time.Hour + time.Minute)
 
-				valTemp, err := v.GetValidator(t.Context(), idp.issuer(), "a")
+				valTemp, err := v.GetValidatorWithKey(t.Context(), NewStandardValidatorKey(idp.issuer(), "a"))
 				require.NoError(t, err)
 				require.Same(t, valOld, valTemp)
 
 				// After 48 hours, make the request again. It's now past its
 				// TTL and should be recreated.
 				idp.clock.Advance(validatorTTL + time.Minute)
-				valNew, err := v.GetValidator(t.Context(), idp.issuer(), "a")
+				valNew, err := v.GetValidatorWithKey(t.Context(), NewStandardValidatorKey(idp.issuer(), "a"))
 				require.NoError(t, err)
 				require.NotSame(t, valNew, valOld)
 			},
@@ -387,10 +388,178 @@ func TestCachingTokenValidator(t *testing.T) {
 			clock := clockwork.NewFakeClock()
 			idp := newFakeIDP(t, clock, tt.audience)
 
-			validator, err := NewCachingTokenValidator[*oidc.TokenClaims](clock)
+			validator, err := NewCachingTokenValidator[*oidc.TokenClaims, StandardValidatorKey](clock)
 			require.NoError(t, err)
 
 			tt.execute(t, idp, validator)
 		})
 	}
+}
+
+func TestCachingTokenValidatorCustomKeys(t *testing.T) {
+	type customKey struct {
+		StandardValidatorKey
+
+		custom string
+	}
+
+	newCustomKey := func(custom string) customKey {
+		return customKey{
+			StandardValidatorKey: StandardValidatorKey{
+				issuer:   "issuer",
+				audience: "audience",
+			},
+			custom: custom,
+		}
+	}
+
+	ctx := t.Context()
+	clock := clockwork.NewFakeClock()
+
+	validator, err := NewCachingTokenValidator[*oidc.TokenClaims, customKey](clock)
+	require.NoError(t, err)
+
+	// Make sure inherited iss/aud are sane
+	fooKey := newCustomKey("foo")
+	require.Equal(t, "issuer", fooKey.GetIssuer())
+	require.Equal(t, "audience", fooKey.GetAudience())
+
+	foo, err := validator.GetValidatorWithKey(ctx, fooKey)
+	require.NoError(t, err)
+
+	foo2, err := validator.GetValidatorWithKey(ctx, fooKey)
+	require.NoError(t, err)
+
+	barKey := newCustomKey("bar")
+	bar, err := validator.GetValidatorWithKey(ctx, barKey)
+	require.NoError(t, err)
+
+	require.True(t, foo == foo2, "pointers with same cache key must be equal")
+	require.True(t, foo != bar, "pointers with different cache key must not be equal")
+}
+
+// countingRoundTripper is an http.RoundTripper that counts requests and
+// delegates to a wrapped transport.
+type countingRoundTripper struct {
+	next  http.RoundTripper
+	count atomic.Uint32
+}
+
+func (c *countingRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	c.count.Add(1)
+	return c.next.RoundTrip(req)
+}
+
+// TestCachingTokenValidatorWithClientMutator ensures HTTP client mutators are
+// actually applied when new validators are created.
+func TestCachingTokenValidatorWithClientMutator(t *testing.T) {
+	t.Parallel()
+
+	const defaultAudience = "example.teleport.sh"
+
+	t.Run("mutator is applied to the live client", func(t *testing.T) {
+		clock := clockwork.NewFakeClock()
+		idp := newFakeIDP(t, clock, defaultAudience)
+
+		validator, err := NewCachingTokenValidator[*oidc.TokenClaims, StandardValidatorKey](clock)
+		require.NoError(t, err)
+
+		// Mutate the client to include the countingRoundTripper.
+		crt := &countingRoundTripper{}
+		mutator := func(client *http.Client) error {
+			crt.next = client.Transport
+			client.Transport = crt
+			return nil
+		}
+
+		val, err := validator.GetValidatorWithKey(
+			t.Context(),
+			NewStandardValidatorKey(idp.issuer(), defaultAudience),
+			mutator,
+		)
+		require.NoError(t, err)
+
+		// Should start empty...
+		require.Zero(t, crt.count.Load())
+
+		token := idp.issueToken(t, defaultAudience, "a", time.Hour)
+		claims, err := val.ValidateToken(t.Context(), token)
+		require.NoError(t, err)
+		require.Equal(t, "a", claims.Subject)
+
+		// Validation triggers a discovery fetch and a JWKS fetch, both of
+		// which must go through our wrapped transport.
+		require.EqualValues(t, idp.configRequests.Load()+idp.jwksRequests.Load(), crt.count.Load())
+		require.Greater(t, crt.count.Load(), uint32(0))
+	})
+
+	t.Run("mutator is not applied on cache hit", func(t *testing.T) {
+		clock := clockwork.NewFakeClock()
+		idp := newFakeIDP(t, clock, defaultAudience)
+
+		validator, err := NewCachingTokenValidator[*oidc.TokenClaims, StandardValidatorKey](clock)
+		require.NoError(t, err)
+
+		// Mutate the client to include the countingRoundTripper.
+		crt := &countingRoundTripper{}
+		mutator := func(client *http.Client) error {
+			crt.next = client.Transport
+			client.Transport = crt
+			return nil
+		}
+
+		// Get without a mutator first.
+		val, err := validator.GetValidatorWithKey(
+			t.Context(),
+			NewStandardValidatorKey(idp.issuer(), defaultAudience),
+		)
+		require.NoError(t, err)
+
+		// As before, count should start empty.
+		require.Zero(t, crt.count.Load())
+
+		token := idp.issueToken(t, defaultAudience, "a", time.Hour)
+		claims, err := val.ValidateToken(t.Context(), token)
+		require.NoError(t, err)
+		require.Equal(t, "a", claims.Subject)
+
+		// Should not be incremented.
+		require.Zero(t, crt.count.Load(), uint32(0))
+
+		// Fetch again but include the mutator
+		val, err = validator.GetValidatorWithKey(
+			t.Context(),
+			NewStandardValidatorKey(idp.issuer(), defaultAudience),
+			mutator,
+		)
+		require.NoError(t, err)
+
+		// Issue and validate again...
+		token = idp.issueToken(t, defaultAudience, "a", time.Hour)
+		claims, err = val.ValidateToken(t.Context(), token)
+		require.NoError(t, err)
+		require.Equal(t, "a", claims.Subject)
+
+		// Still should not be incremented, despite including the mutator.
+		require.Zero(t, crt.count.Load(), uint32(0))
+	})
+
+	t.Run("mutator error fails construction", func(t *testing.T) {
+		clock := clockwork.NewFakeClock()
+		idp := newFakeIDP(t, clock, defaultAudience)
+
+		validator, err := NewCachingTokenValidator[*oidc.TokenClaims, StandardValidatorKey](clock)
+		require.NoError(t, err)
+
+		mutator := func(client *http.Client) error {
+			return trace.BadParameter("fail")
+		}
+
+		_, err = validator.GetValidatorWithKey(
+			t.Context(),
+			NewStandardValidatorKey(idp.issuer(), defaultAudience),
+			mutator,
+		)
+		require.ErrorContains(t, err, "fail")
+	})
 }

--- a/lib/oidc/caching_token_validator_test.go
+++ b/lib/oidc/caching_token_validator_test.go
@@ -541,7 +541,7 @@ func TestCachingTokenValidatorWithClientMutator(t *testing.T) {
 		require.Equal(t, "a", claims.Subject)
 
 		// Still should not be incremented, despite including the mutator.
-		require.Zero(t, crt.count.Load(), uint32(0))
+		require.Zero(t, crt.count.Load())
 	})
 
 	t.Run("mutator error fails construction", func(t *testing.T) {

--- a/lib/oidc/caching_token_validator_test.go
+++ b/lib/oidc/caching_token_validator_test.go
@@ -434,8 +434,8 @@ func TestCachingTokenValidatorCustomKeys(t *testing.T) {
 	bar, err := validator.GetValidatorWithKey(ctx, barKey)
 	require.NoError(t, err)
 
-	require.True(t, foo == foo2, "pointers with same cache key must be equal")
-	require.True(t, foo != bar, "pointers with different cache key must not be equal")
+	require.Same(t, foo, foo2, "pointers with same cache key must be equal")
+	require.NotSame(t, foo, bar, "pointers with different cache key must not be equal")
 }
 
 // countingRoundTripper is an http.RoundTripper that counts requests and

--- a/lib/oidc/round_tripper.go
+++ b/lib/oidc/round_tripper.go
@@ -88,8 +88,10 @@ func newLimitReadCloser(reader io.Reader, closer io.Closer) *limitReadCloser {
 
 func (r *limitReadCloser) Read(p []byte) (int, error) {
 	if r.n <= 0 {
-		// discard rest of the body to free up connection
-		io.Copy(io.Discard, r.reader)
+		// Return an error immediately without attempting to drain the
+		// connection: a malfunctioning or malicious remote server could slowly
+		// keep writing bytes indefinitely and block our reader. If it exceeds
+		// our max size, just kill the connection.
 		return 0, trace.Errorf("response exceeds maximum size of %d bytes", maxDataSize)
 	}
 

--- a/lib/oidc/round_tripper.go
+++ b/lib/oidc/round_tripper.go
@@ -1,0 +1,113 @@
+/*
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package oidc
+
+import (
+	"io"
+	"net/http"
+
+	"github.com/gravitational/trace"
+)
+
+// OIDCRoundTripper wrapps the [http.RoundTripper] provided to the
+// [rp.RelyingParty] to prevent reading response bodies that exceed
+// [maxDataSize].
+//
+// TODO(tross): remove this when https://github.com/zitadel/oidc/issues/738
+// is resolved.
+type OIDCRoundTripper struct {
+	rt http.RoundTripper
+}
+
+func (l *OIDCRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	resp, err := l.rt.RoundTrip(req)
+	if err != nil {
+		return nil, err
+	}
+
+	return &http.Response{
+		Status:           resp.Status,
+		StatusCode:       resp.StatusCode,
+		Proto:            resp.Proto,
+		ProtoMajor:       resp.ProtoMajor,
+		ProtoMinor:       resp.ProtoMinor,
+		Header:           resp.Header,
+		Body:             newLimitReadCloser(resp.Body, resp.Body),
+		ContentLength:    resp.ContentLength,
+		TransferEncoding: resp.TransferEncoding,
+		Close:            resp.Close,
+		Uncompressed:     resp.Uncompressed,
+		Trailer:          resp.Trailer,
+		Request:          resp.Request,
+		TLS:              resp.TLS,
+	}, nil
+}
+
+func (l *OIDCRoundTripper) CloseIdleConnections() {
+	type closeIdler interface {
+		CloseIdleConnections()
+	}
+	if tr, ok := l.rt.(closeIdler); ok {
+		tr.CloseIdleConnections()
+	}
+}
+
+const maxDataSize = 1024 * 1024
+
+// limitReadCloser is an [io.ReadCloser] that limits reading
+// less than [maxDataSize] from the reader.
+type limitReadCloser struct {
+	n      int64
+	reader io.Reader
+	closer io.Closer
+}
+
+func newLimitReadCloser(reader io.Reader, closer io.Closer) *limitReadCloser {
+	return &limitReadCloser{
+		n:      maxDataSize + 1,
+		reader: reader,
+		closer: closer,
+	}
+}
+
+func (r *limitReadCloser) Read(p []byte) (int, error) {
+	if r.n <= 0 {
+		// discard rest of the body to free up connection
+		io.Copy(io.Discard, r.reader)
+		return 0, trace.Errorf("response exceeds maximum size of %d bytes", maxDataSize)
+	}
+
+	if int64(len(p)) > r.n {
+		p = p[0:r.n]
+	}
+	n, err := r.reader.Read(p)
+	r.n -= int64(n)
+	return n, err
+}
+
+func (r *limitReadCloser) Close() error {
+	return r.closer.Close()
+}
+
+// NewOIDCRoundTripper returns a round tripper that enforces
+func NewOIDCRoundTripper(rt http.RoundTripper) http.RoundTripper {
+	return &OIDCRoundTripper{
+		rt: rt,
+	}
+}

--- a/lib/oidc/round_tripper.go
+++ b/lib/oidc/round_tripper.go
@@ -107,7 +107,8 @@ func (r *limitReadCloser) Close() error {
 	return r.closer.Close()
 }
 
-// NewOIDCRoundTripper returns a round tripper that enforces
+// NewOIDCRoundTripper returns a round tripper that enforces a maximum response
+// size limit ([maxDataSize]).
 func NewOIDCRoundTripper(rt http.RoundTripper) http.RoundTripper {
 	return &OIDCRoundTripper{
 		rt: rt,

--- a/lib/oidc/round_tripper_test.go
+++ b/lib/oidc/round_tripper_test.go
@@ -1,0 +1,64 @@
+/*
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package oidc
+
+import (
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// countingReader returns zeroes forever, counting the number of Read() calls
+type countingReader struct {
+	reads int
+}
+
+func (c *countingReader) Read(p []byte) (int, error) {
+	c.reads++
+	for i := range p {
+		p[i] = 0
+	}
+	return len(p), nil
+}
+
+// TestLimitReadCloserErrorsWhenExceeded ensures the limitReadCloser actually
+// returns an error when the limit is exceeded instead of trying to discard
+// everything.
+func TestLimitReadCloserErrorsWhenExceeded(t *testing.T) {
+	t.Parallel()
+
+	reader := &countingReader{}
+	lrc := newLimitReadCloser(reader, io.NopCloser(nil))
+
+	// Make a buffer guaranteed to be larger than maxDataSize.
+	buf := make([]byte, maxDataSize+1)
+
+	// The first read should succeed...
+	n, err := lrc.Read(buf)
+	require.NoError(t, err)
+	require.Equal(t, maxDataSize+1, n)
+	require.Equal(t, 1, reader.reads)
+
+	// ...but the next read should error immediately without hitting the
+	// underlying reader
+	_, err = lrc.Read(buf)
+	require.ErrorContains(t, err, "response exceeds maximum size of")
+	require.Equal(t, 1, reader.reads)
+}


### PR DESCRIPTION
This makes a number of improvements to the caching OIDC validator to facilitate the upcoming `generic_oidc` join method, including:
- Added the ability to specify HTTP client options to enable use of custom CA certs
- Added support for custom caching keys so we can create new HTTP clients if users change their configured custom CA cert
- Moved e/'s `OIDCRoundTripper` to OSS and the caching validator now uses it by default. This ensures our clients will not try to read a problematically large response; luckily we already had an impl. I'll remove it from e/ once this merges, and swap the calls there to use the OSS variant.

<!-- Include manual testing efforts to verify the change. -->
<!-- Detail where the tests where run and what configurations were used. -->
<!-- Include all the test cases which were run to validate the change. -->

## Manual Test Plan
### Test Environment

Local cluster with bots running against a local OIDC server (`generic_oidc`) and in Kubernetes. For k8s testing, use this fake OIDC provider: https://gist.github.com/timothyb89/e2f132e2a009d162c90f4d6ae7ed100e

If accessible via valid HTTPS (either standard PKI/letsencrypt or a custom CA installed on the Teleport host) it can be used to issue Kubernetes service account tokens that the kubernetes/oidc join method will accept without actually running Teleport in Kubernetes, which is not fun.

### Test Cases
- [x] `generic_oidc` works with custom caching key & HTTP client params (https://github.com/gravitational/teleport/pull/67991)
- [x] Kubernetes OIDC joining still works as expected
