### PR TITLE
Generic OIDC joining: protos

### DIFF
--- a/api/gen/proto/go/teleport/scopes/joining/v1/token.pb.go
+++ b/api/gen/proto/go/teleport/scopes/joining/v1/token.pb.go
@@ -26,6 +26,7 @@ import (
 	v1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
+	structpb "google.golang.org/protobuf/types/known/structpb"
 	timestamppb "google.golang.org/protobuf/types/known/timestamppb"
 	reflect "reflect"
 	unsafe "unsafe"
@@ -271,7 +272,9 @@ type ScopedTokenSpec struct {
 	// scope.
 	//
 	// Mutually exclusive with assigned_scope.
-	Bot           string `protobuf:"bytes,15,opt,name=bot,proto3" json:"bot,omitempty"`
+	Bot string `protobuf:"bytes,15,opt,name=bot,proto3" json:"bot,omitempty"`
+	// Configuration specific to the "generic_oidc" join method.
+	GenericOidc   *GenericOIDC `protobuf:"bytes,16,opt,name=generic_oidc,json=genericOidc,proto3" json:"generic_oidc,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -392,6 +395,13 @@ func (x *ScopedTokenSpec) GetBot() string {
 	return ""
 }
 
+func (x *ScopedTokenSpec) GetGenericOidc() *GenericOIDC {
+	if x != nil {
+		return x.GenericOidc
+	}
+	return nil
+}
+
 func (x *ScopedTokenSpec) SetAssignedScope(v string) {
 	x.AssignedScope = v
 }
@@ -442,6 +452,10 @@ func (x *ScopedTokenSpec) SetBoundKeypair(v *BoundKeypairSpec) {
 
 func (x *ScopedTokenSpec) SetBot(v string) {
 	x.Bot = v
+}
+
+func (x *ScopedTokenSpec) SetGenericOidc(v *GenericOIDC) {
+	x.GenericOidc = v
 }
 
 func (x *ScopedTokenSpec) HasImmutableLabels() bool {
@@ -500,6 +514,13 @@ func (x *ScopedTokenSpec) HasBoundKeypair() bool {
 	return x.BoundKeypair != nil
 }
 
+func (x *ScopedTokenSpec) HasGenericOidc() bool {
+	if x == nil {
+		return false
+	}
+	return x.GenericOidc != nil
+}
+
 func (x *ScopedTokenSpec) ClearImmutableLabels() {
 	x.ImmutableLabels = nil
 }
@@ -530,6 +551,10 @@ func (x *ScopedTokenSpec) ClearKubernetes() {
 
 func (x *ScopedTokenSpec) ClearBoundKeypair() {
 	x.BoundKeypair = nil
+}
+
+func (x *ScopedTokenSpec) ClearGenericOidc() {
+	x.GenericOidc = nil
 }
 
 type ScopedTokenSpec_builder struct {
@@ -574,6 +599,8 @@ type ScopedTokenSpec_builder struct {
 	//
 	// Mutually exclusive with assigned_scope.
 	Bot string
+	// Configuration specific to the "generic_oidc" join method.
+	GenericOidc *GenericOIDC
 }
 
 func (b0 ScopedTokenSpec_builder) Build() *ScopedTokenSpec {
@@ -593,6 +620,7 @@ func (b0 ScopedTokenSpec_builder) Build() *ScopedTokenSpec {
 	x.Kubernetes = b.Kubernetes
 	x.BoundKeypair = b.BoundKeypair
 	x.Bot = b.Bot
+	x.GenericOidc = b.GenericOidc
 	return m0
 }
 
@@ -2297,6 +2325,261 @@ func (b0 BoundKeypairStatus_builder) Build() *BoundKeypairStatus {
 	return m0
 }
 
+// Configuration for `generic_oidc`-type tokens.
+type GenericOIDC struct {
+	state protoimpl.MessageState `protogen:"hybrid.v1"`
+	// The expected `iss` value as written in the JWT you wish to trust. Unless
+	// `static_jwks` is configured, this issuer must be accessible over HTTPS to
+	// the Teleport cluster and must serve valid OIDC metadata, including
+	// discovery configuration and JWKS keys.
+	Issuer string `protobuf:"bytes,1,opt,name=issuer,proto3" json:"issuer,omitempty"`
+	// If set, disables the requirement that the issuer must use HTTPS.
+	InsecureAllowHttpIssuer bool `protobuf:"varint,2,opt,name=insecure_allow_http_issuer,json=insecureAllowHttpIssuer,proto3" json:"insecure_allow_http_issuer,omitempty"`
+	// The expected JWT audience. If unset, this value will be set to the name of
+	// this Teleport cluster (e.g. example.teleport.sh). Where possible, this
+	// value should be unique to the Teleport cluster; issuing JWTs using the
+	// cluster as the audience is preferred. On providers where this is not
+	// possible, you can specify their server-defined value in this field. This
+	// value must match the audience in issued JWTs for join attempts to succeed.
+	Audience string `protobuf:"bytes,3,opt,name=audience,proto3" json:"audience,omitempty"`
+	// An optional static JWKS value that can be used to specify JWKS keys when
+	// either OIDC discovery is either not supported by the provider or the
+	// discovery configuration is not accessible to Teleport. When set,
+	// configuration and JWKS keys will not be fetched from the URL contained in
+	// `issuer` and JWTs will be validated using the key set specified here.
+	StaticJwks string `protobuf:"bytes,4,opt,name=static_jwks,json=staticJwks,proto3" json:"static_jwks,omitempty"`
+	// A TLS CA certificate that should be used to verify requests for OIDC
+	// metadata from the issuer instead of Teleport's CA store, useful if the
+	// issuer is not public or otherwise uses a self-signed certificate. If unset,
+	// the standard web PKI root certificates will be used to verify the
+	// connection to the issuer when fetching OIDC metadata. Note that this value
+	// only applies to requests using this token, and will be used instead of and
+	// not in addition to the system CA store, and will need to be updated
+	// manually if the remote CA is updated.
+	TlsCa string `protobuf:"bytes,5,opt,name=tls_ca,json=tlsCa,proto3" json:"tls_ca,omitempty"`
+	// "Must match" fields perform simple comparison matches using "AND"
+	// semantics. Rules are specified by mirroring the structure of the JWT, using
+	// values that are expected to be equal to those on the incoming token. These
+	// field matching rules can only be used to compare simple values: strings,
+	// numbers, booleans, and nested fields. Complex values, including lists, will
+	// need to use `allow_any` expression rules instead.
+	//
+	// If any field match rules are specified, all must be equal to corresponding
+	// JWT fields for the join attempt to succeed. If complex rules are specified
+	// in `allow_any`, those are evaluated after `must_match_fields`. If
+	// `must_match_fields` is not specified or is empty, only rules in `allow_any`
+	// are evaluated.
+	//
+	// These rules can be used as "global" rules that apply to all join attempts.
+	// For example, you can use these to ensure all attempts originate from your
+	// organization, then use `allow_any` rules to allow individual repositories,
+	// pipelines, or workspaces.
+	//
+	// Note that at least one rule, either in `must_match_fields` or `allow_any`,
+	// must be specified for any join attempts to succeed.
+	MustMatchFields *structpb.Struct `protobuf:"bytes,6,opt,name=must_match_fields,json=mustMatchFields,proto3" json:"must_match_fields,omitempty"`
+	// Complex rules evaluated using "OR" semantics. If any rules are specified,
+	// at least one rule must evaluate to `true` for the join attempt/ to be
+	// allowed. These rules are evaluated after `must_match_fields`, if any field
+	// matchers are specified in that block.
+	//
+	// Note that at least one rule, either in `must_match_fields` or `allow_any`,
+	// must be specified for any join attempts to succeed.
+	AllowAny      []*GenericOIDC_Rule `protobuf:"bytes,7,rep,name=allow_any,json=allowAny,proto3" json:"allow_any,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GenericOIDC) Reset() {
+	*x = GenericOIDC{}
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[17]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GenericOIDC) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GenericOIDC) ProtoMessage() {}
+
+func (x *GenericOIDC) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[17]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+func (x *GenericOIDC) GetIssuer() string {
+	if x != nil {
+		return x.Issuer
+	}
+	return ""
+}
+
+func (x *GenericOIDC) GetInsecureAllowHttpIssuer() bool {
+	if x != nil {
+		return x.InsecureAllowHttpIssuer
+	}
+	return false
+}
+
+func (x *GenericOIDC) GetAudience() string {
+	if x != nil {
+		return x.Audience
+	}
+	return ""
+}
+
+func (x *GenericOIDC) GetStaticJwks() string {
+	if x != nil {
+		return x.StaticJwks
+	}
+	return ""
+}
+
+func (x *GenericOIDC) GetTlsCa() string {
+	if x != nil {
+		return x.TlsCa
+	}
+	return ""
+}
+
+func (x *GenericOIDC) GetMustMatchFields() *structpb.Struct {
+	if x != nil {
+		return x.MustMatchFields
+	}
+	return nil
+}
+
+func (x *GenericOIDC) GetAllowAny() []*GenericOIDC_Rule {
+	if x != nil {
+		return x.AllowAny
+	}
+	return nil
+}
+
+func (x *GenericOIDC) SetIssuer(v string) {
+	x.Issuer = v
+}
+
+func (x *GenericOIDC) SetInsecureAllowHttpIssuer(v bool) {
+	x.InsecureAllowHttpIssuer = v
+}
+
+func (x *GenericOIDC) SetAudience(v string) {
+	x.Audience = v
+}
+
+func (x *GenericOIDC) SetStaticJwks(v string) {
+	x.StaticJwks = v
+}
+
+func (x *GenericOIDC) SetTlsCa(v string) {
+	x.TlsCa = v
+}
+
+func (x *GenericOIDC) SetMustMatchFields(v *structpb.Struct) {
+	x.MustMatchFields = v
+}
+
+func (x *GenericOIDC) SetAllowAny(v []*GenericOIDC_Rule) {
+	x.AllowAny = v
+}
+
+func (x *GenericOIDC) HasMustMatchFields() bool {
+	if x == nil {
+		return false
+	}
+	return x.MustMatchFields != nil
+}
+
+func (x *GenericOIDC) ClearMustMatchFields() {
+	x.MustMatchFields = nil
+}
+
+type GenericOIDC_builder struct {
+	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
+
+	// The expected `iss` value as written in the JWT you wish to trust. Unless
+	// `static_jwks` is configured, this issuer must be accessible over HTTPS to
+	// the Teleport cluster and must serve valid OIDC metadata, including
+	// discovery configuration and JWKS keys.
+	Issuer string
+	// If set, disables the requirement that the issuer must use HTTPS.
+	InsecureAllowHttpIssuer bool
+	// The expected JWT audience. If unset, this value will be set to the name of
+	// this Teleport cluster (e.g. example.teleport.sh). Where possible, this
+	// value should be unique to the Teleport cluster; issuing JWTs using the
+	// cluster as the audience is preferred. On providers where this is not
+	// possible, you can specify their server-defined value in this field. This
+	// value must match the audience in issued JWTs for join attempts to succeed.
+	Audience string
+	// An optional static JWKS value that can be used to specify JWKS keys when
+	// either OIDC discovery is either not supported by the provider or the
+	// discovery configuration is not accessible to Teleport. When set,
+	// configuration and JWKS keys will not be fetched from the URL contained in
+	// `issuer` and JWTs will be validated using the key set specified here.
+	StaticJwks string
+	// A TLS CA certificate that should be used to verify requests for OIDC
+	// metadata from the issuer instead of Teleport's CA store, useful if the
+	// issuer is not public or otherwise uses a self-signed certificate. If unset,
+	// the standard web PKI root certificates will be used to verify the
+	// connection to the issuer when fetching OIDC metadata. Note that this value
+	// only applies to requests using this token, and will be used instead of and
+	// not in addition to the system CA store, and will need to be updated
+	// manually if the remote CA is updated.
+	TlsCa string
+	// "Must match" fields perform simple comparison matches using "AND"
+	// semantics. Rules are specified by mirroring the structure of the JWT, using
+	// values that are expected to be equal to those on the incoming token. These
+	// field matching rules can only be used to compare simple values: strings,
+	// numbers, booleans, and nested fields. Complex values, including lists, will
+	// need to use `allow_any` expression rules instead.
+	//
+	// If any field match rules are specified, all must be equal to corresponding
+	// JWT fields for the join attempt to succeed. If complex rules are specified
+	// in `allow_any`, those are evaluated after `must_match_fields`. If
+	// `must_match_fields` is not specified or is empty, only rules in `allow_any`
+	// are evaluated.
+	//
+	// These rules can be used as "global" rules that apply to all join attempts.
+	// For example, you can use these to ensure all attempts originate from your
+	// organization, then use `allow_any` rules to allow individual repositories,
+	// pipelines, or workspaces.
+	//
+	// Note that at least one rule, either in `must_match_fields` or `allow_any`,
+	// must be specified for any join attempts to succeed.
+	MustMatchFields *structpb.Struct
+	// Complex rules evaluated using "OR" semantics. If any rules are specified,
+	// at least one rule must evaluate to `true` for the join attempt/ to be
+	// allowed. These rules are evaluated after `must_match_fields`, if any field
+	// matchers are specified in that block.
+	//
+	// Note that at least one rule, either in `must_match_fields` or `allow_any`,
+	// must be specified for any join attempts to succeed.
+	AllowAny []*GenericOIDC_Rule
+}
+
+func (b0 GenericOIDC_builder) Build() *GenericOIDC {
+	m0 := &GenericOIDC{}
+	b, x := &b0, m0
+	_, _ = b, x
+	x.Issuer = b.Issuer
+	x.InsecureAllowHttpIssuer = b.InsecureAllowHttpIssuer
+	x.Audience = b.Audience
+	x.StaticJwks = b.StaticJwks
+	x.TlsCa = b.TlsCa
+	x.MustMatchFields = b.MustMatchFields
+	x.AllowAny = b.AllowAny
+	return m0
+}
+
 // A rule that a joining node must match in order to use the associated token
 // with AWS join methods.
 type AWS_Rule struct {
@@ -2321,7 +2604,7 @@ type AWS_Rule struct {
 
 func (x *AWS_Rule) Reset() {
 	*x = AWS_Rule{}
-	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[18]
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[19]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2333,7 +2616,7 @@ func (x *AWS_Rule) String() string {
 func (*AWS_Rule) ProtoMessage() {}
 
 func (x *AWS_Rule) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[18]
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[19]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2446,7 +2729,7 @@ type GCP_Rule struct {
 
 func (x *GCP_Rule) Reset() {
 	*x = GCP_Rule{}
-	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[19]
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[20]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2458,7 +2741,7 @@ func (x *GCP_Rule) String() string {
 func (*GCP_Rule) ProtoMessage() {}
 
 func (x *GCP_Rule) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[19]
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[20]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2539,7 +2822,7 @@ type Azure_Rule struct {
 
 func (x *Azure_Rule) Reset() {
 	*x = Azure_Rule{}
-	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[20]
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[21]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2551,7 +2834,7 @@ func (x *Azure_Rule) String() string {
 func (*Azure_Rule) ProtoMessage() {}
 
 func (x *Azure_Rule) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[20]
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[21]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2658,7 +2941,7 @@ type AzureDevops_Rule struct {
 
 func (x *AzureDevops_Rule) Reset() {
 	*x = AzureDevops_Rule{}
-	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[21]
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[22]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2670,7 +2953,7 @@ func (x *AzureDevops_Rule) String() string {
 func (*AzureDevops_Rule) ProtoMessage() {}
 
 func (x *AzureDevops_Rule) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[21]
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[22]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2842,7 +3125,7 @@ type Oracle_Rule struct {
 
 func (x *Oracle_Rule) Reset() {
 	*x = Oracle_Rule{}
-	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[22]
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[23]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2854,7 +3137,7 @@ func (x *Oracle_Rule) String() string {
 func (*Oracle_Rule) ProtoMessage() {}
 
 func (x *Oracle_Rule) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[22]
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[23]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2948,7 +3231,7 @@ type Kubernetes_StaticJWKSConfig struct {
 
 func (x *Kubernetes_StaticJWKSConfig) Reset() {
 	*x = Kubernetes_StaticJWKSConfig{}
-	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[23]
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[24]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2960,7 +3243,7 @@ func (x *Kubernetes_StaticJWKSConfig) String() string {
 func (*Kubernetes_StaticJWKSConfig) ProtoMessage() {}
 
 func (x *Kubernetes_StaticJWKSConfig) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[23]
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[24]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3013,7 +3296,7 @@ type Kubernetes_OIDCConfig struct {
 
 func (x *Kubernetes_OIDCConfig) Reset() {
 	*x = Kubernetes_OIDCConfig{}
-	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[24]
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[25]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3025,7 +3308,7 @@ func (x *Kubernetes_OIDCConfig) String() string {
 func (*Kubernetes_OIDCConfig) ProtoMessage() {}
 
 func (x *Kubernetes_OIDCConfig) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[24]
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[25]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3105,7 +3388,7 @@ type Kubernetes_Rule struct {
 
 func (x *Kubernetes_Rule) Reset() {
 	*x = Kubernetes_Rule{}
-	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[25]
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[26]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3117,7 +3400,7 @@ func (x *Kubernetes_Rule) String() string {
 func (*Kubernetes_Rule) ProtoMessage() {}
 
 func (x *Kubernetes_Rule) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[25]
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[26]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3220,7 +3503,7 @@ type BoundKeypairSpec_OnboardingSpec struct {
 
 func (x *BoundKeypairSpec_OnboardingSpec) Reset() {
 	*x = BoundKeypairSpec_OnboardingSpec{}
-	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[26]
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[27]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3232,7 +3515,7 @@ func (x *BoundKeypairSpec_OnboardingSpec) String() string {
 func (*BoundKeypairSpec_OnboardingSpec) ProtoMessage() {}
 
 func (x *BoundKeypairSpec_OnboardingSpec) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[26]
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[27]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3355,7 +3638,7 @@ type BoundKeypairSpec_RecoverySpec struct {
 
 func (x *BoundKeypairSpec_RecoverySpec) Reset() {
 	*x = BoundKeypairSpec_RecoverySpec{}
-	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[27]
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[28]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3367,7 +3650,7 @@ func (x *BoundKeypairSpec_RecoverySpec) String() string {
 func (*BoundKeypairSpec_RecoverySpec) ProtoMessage() {}
 
 func (x *BoundKeypairSpec_RecoverySpec) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[27]
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[28]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3437,11 +3720,623 @@ func (b0 BoundKeypairSpec_RecoverySpec_builder) Build() *BoundKeypairSpec_Recove
 	return m0
 }
 
+// The attribute casted to a string must be equal to the value.
+type GenericOIDC_ConditionEq struct {
+	state protoimpl.MessageState `protogen:"hybrid.v1"`
+	// The value to compare the attribute against.
+	Value         string `protobuf:"bytes,1,opt,name=value,proto3" json:"value,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GenericOIDC_ConditionEq) Reset() {
+	*x = GenericOIDC_ConditionEq{}
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[29]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GenericOIDC_ConditionEq) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GenericOIDC_ConditionEq) ProtoMessage() {}
+
+func (x *GenericOIDC_ConditionEq) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[29]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+func (x *GenericOIDC_ConditionEq) GetValue() string {
+	if x != nil {
+		return x.Value
+	}
+	return ""
+}
+
+func (x *GenericOIDC_ConditionEq) SetValue(v string) {
+	x.Value = v
+}
+
+type GenericOIDC_ConditionEq_builder struct {
+	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
+
+	// The value to compare the attribute against.
+	Value string
+}
+
+func (b0 GenericOIDC_ConditionEq_builder) Build() *GenericOIDC_ConditionEq {
+	m0 := &GenericOIDC_ConditionEq{}
+	b, x := &b0, m0
+	_, _ = b, x
+	x.Value = b.Value
+	return m0
+}
+
+// The attribute casted to a string must not be equal to the value.
+type GenericOIDC_ConditionNotEq struct {
+	state protoimpl.MessageState `protogen:"hybrid.v1"`
+	// The value to compare the attribute against.
+	Value         string `protobuf:"bytes,1,opt,name=value,proto3" json:"value,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GenericOIDC_ConditionNotEq) Reset() {
+	*x = GenericOIDC_ConditionNotEq{}
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[30]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GenericOIDC_ConditionNotEq) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GenericOIDC_ConditionNotEq) ProtoMessage() {}
+
+func (x *GenericOIDC_ConditionNotEq) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[30]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+func (x *GenericOIDC_ConditionNotEq) GetValue() string {
+	if x != nil {
+		return x.Value
+	}
+	return ""
+}
+
+func (x *GenericOIDC_ConditionNotEq) SetValue(v string) {
+	x.Value = v
+}
+
+type GenericOIDC_ConditionNotEq_builder struct {
+	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
+
+	// The value to compare the attribute against.
+	Value string
+}
+
+func (b0 GenericOIDC_ConditionNotEq_builder) Build() *GenericOIDC_ConditionNotEq {
+	m0 := &GenericOIDC_ConditionNotEq{}
+	b, x := &b0, m0
+	_, _ = b, x
+	x.Value = b.Value
+	return m0
+}
+
+// The attribute casted to a string must be in the list of values.
+type GenericOIDC_ConditionIn struct {
+	state protoimpl.MessageState `protogen:"hybrid.v1"`
+	// The list of values to compare the attribute against.
+	Values        []string `protobuf:"bytes,1,rep,name=values,proto3" json:"values,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GenericOIDC_ConditionIn) Reset() {
+	*x = GenericOIDC_ConditionIn{}
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[31]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GenericOIDC_ConditionIn) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GenericOIDC_ConditionIn) ProtoMessage() {}
+
+func (x *GenericOIDC_ConditionIn) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[31]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+func (x *GenericOIDC_ConditionIn) GetValues() []string {
+	if x != nil {
+		return x.Values
+	}
+	return nil
+}
+
+func (x *GenericOIDC_ConditionIn) SetValues(v []string) {
+	x.Values = v
+}
+
+type GenericOIDC_ConditionIn_builder struct {
+	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
+
+	// The list of values to compare the attribute against.
+	Values []string
+}
+
+func (b0 GenericOIDC_ConditionIn_builder) Build() *GenericOIDC_ConditionIn {
+	m0 := &GenericOIDC_ConditionIn{}
+	b, x := &b0, m0
+	_, _ = b, x
+	x.Values = b.Values
+	return m0
+}
+
+// The attribute casted to a string must not be in the list of values.
+type GenericOIDC_ConditionNotIn struct {
+	state protoimpl.MessageState `protogen:"hybrid.v1"`
+	// The list of values to compare the attribute against.
+	Values        []string `protobuf:"bytes,1,rep,name=values,proto3" json:"values,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GenericOIDC_ConditionNotIn) Reset() {
+	*x = GenericOIDC_ConditionNotIn{}
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[32]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GenericOIDC_ConditionNotIn) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GenericOIDC_ConditionNotIn) ProtoMessage() {}
+
+func (x *GenericOIDC_ConditionNotIn) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[32]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+func (x *GenericOIDC_ConditionNotIn) GetValues() []string {
+	if x != nil {
+		return x.Values
+	}
+	return nil
+}
+
+func (x *GenericOIDC_ConditionNotIn) SetValues(v []string) {
+	x.Values = v
+}
+
+type GenericOIDC_ConditionNotIn_builder struct {
+	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
+
+	// The list of values to compare the attribute against.
+	Values []string
+}
+
+func (b0 GenericOIDC_ConditionNotIn_builder) Build() *GenericOIDC_ConditionNotIn {
+	m0 := &GenericOIDC_ConditionNotIn{}
+	b, x := &b0, m0
+	_, _ = b, x
+	x.Values = b.Values
+	return m0
+}
+
+// An allow rule condition for simple checks against a specific field.
+type GenericOIDC_Condition struct {
+	state     protoimpl.MessageState `protogen:"hybrid.v1"`
+	Attribute string                 `protobuf:"bytes,1,opt,name=attribute,proto3" json:"attribute,omitempty"`
+	// Types that are valid to be assigned to Operator:
+	//
+	//	*GenericOIDC_Condition_Eq
+	//	*GenericOIDC_Condition_NotEq
+	//	*GenericOIDC_Condition_In
+	//	*GenericOIDC_Condition_NotIn
+	Operator      isGenericOIDC_Condition_Operator `protobuf_oneof:"operator"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GenericOIDC_Condition) Reset() {
+	*x = GenericOIDC_Condition{}
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[33]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GenericOIDC_Condition) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GenericOIDC_Condition) ProtoMessage() {}
+
+func (x *GenericOIDC_Condition) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[33]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+func (x *GenericOIDC_Condition) GetAttribute() string {
+	if x != nil {
+		return x.Attribute
+	}
+	return ""
+}
+
+func (x *GenericOIDC_Condition) GetOperator() isGenericOIDC_Condition_Operator {
+	if x != nil {
+		return x.Operator
+	}
+	return nil
+}
+
+func (x *GenericOIDC_Condition) GetEq() *GenericOIDC_ConditionEq {
+	if x != nil {
+		if x, ok := x.Operator.(*GenericOIDC_Condition_Eq); ok {
+			return x.Eq
+		}
+	}
+	return nil
+}
+
+func (x *GenericOIDC_Condition) GetNotEq() *GenericOIDC_ConditionNotEq {
+	if x != nil {
+		if x, ok := x.Operator.(*GenericOIDC_Condition_NotEq); ok {
+			return x.NotEq
+		}
+	}
+	return nil
+}
+
+func (x *GenericOIDC_Condition) GetIn() *GenericOIDC_ConditionIn {
+	if x != nil {
+		if x, ok := x.Operator.(*GenericOIDC_Condition_In); ok {
+			return x.In
+		}
+	}
+	return nil
+}
+
+func (x *GenericOIDC_Condition) GetNotIn() *GenericOIDC_ConditionNotIn {
+	if x != nil {
+		if x, ok := x.Operator.(*GenericOIDC_Condition_NotIn); ok {
+			return x.NotIn
+		}
+	}
+	return nil
+}
+
+func (x *GenericOIDC_Condition) SetAttribute(v string) {
+	x.Attribute = v
+}
+
+func (x *GenericOIDC_Condition) SetEq(v *GenericOIDC_ConditionEq) {
+	if v == nil {
+		x.Operator = nil
+		return
+	}
+	x.Operator = &GenericOIDC_Condition_Eq{v}
+}
+
+func (x *GenericOIDC_Condition) SetNotEq(v *GenericOIDC_ConditionNotEq) {
+	if v == nil {
+		x.Operator = nil
+		return
+	}
+	x.Operator = &GenericOIDC_Condition_NotEq{v}
+}
+
+func (x *GenericOIDC_Condition) SetIn(v *GenericOIDC_ConditionIn) {
+	if v == nil {
+		x.Operator = nil
+		return
+	}
+	x.Operator = &GenericOIDC_Condition_In{v}
+}
+
+func (x *GenericOIDC_Condition) SetNotIn(v *GenericOIDC_ConditionNotIn) {
+	if v == nil {
+		x.Operator = nil
+		return
+	}
+	x.Operator = &GenericOIDC_Condition_NotIn{v}
+}
+
+func (x *GenericOIDC_Condition) HasOperator() bool {
+	if x == nil {
+		return false
+	}
+	return x.Operator != nil
+}
+
+func (x *GenericOIDC_Condition) HasEq() bool {
+	if x == nil {
+		return false
+	}
+	_, ok := x.Operator.(*GenericOIDC_Condition_Eq)
+	return ok
+}
+
+func (x *GenericOIDC_Condition) HasNotEq() bool {
+	if x == nil {
+		return false
+	}
+	_, ok := x.Operator.(*GenericOIDC_Condition_NotEq)
+	return ok
+}
+
+func (x *GenericOIDC_Condition) HasIn() bool {
+	if x == nil {
+		return false
+	}
+	_, ok := x.Operator.(*GenericOIDC_Condition_In)
+	return ok
+}
+
+func (x *GenericOIDC_Condition) HasNotIn() bool {
+	if x == nil {
+		return false
+	}
+	_, ok := x.Operator.(*GenericOIDC_Condition_NotIn)
+	return ok
+}
+
+func (x *GenericOIDC_Condition) ClearOperator() {
+	x.Operator = nil
+}
+
+func (x *GenericOIDC_Condition) ClearEq() {
+	if _, ok := x.Operator.(*GenericOIDC_Condition_Eq); ok {
+		x.Operator = nil
+	}
+}
+
+func (x *GenericOIDC_Condition) ClearNotEq() {
+	if _, ok := x.Operator.(*GenericOIDC_Condition_NotEq); ok {
+		x.Operator = nil
+	}
+}
+
+func (x *GenericOIDC_Condition) ClearIn() {
+	if _, ok := x.Operator.(*GenericOIDC_Condition_In); ok {
+		x.Operator = nil
+	}
+}
+
+func (x *GenericOIDC_Condition) ClearNotIn() {
+	if _, ok := x.Operator.(*GenericOIDC_Condition_NotIn); ok {
+		x.Operator = nil
+	}
+}
+
+const GenericOIDC_Condition_Operator_not_set_case case_GenericOIDC_Condition_Operator = 0
+const GenericOIDC_Condition_Eq_case case_GenericOIDC_Condition_Operator = 2
+const GenericOIDC_Condition_NotEq_case case_GenericOIDC_Condition_Operator = 3
+const GenericOIDC_Condition_In_case case_GenericOIDC_Condition_Operator = 4
+const GenericOIDC_Condition_NotIn_case case_GenericOIDC_Condition_Operator = 5
+
+func (x *GenericOIDC_Condition) WhichOperator() case_GenericOIDC_Condition_Operator {
+	if x == nil {
+		return GenericOIDC_Condition_Operator_not_set_case
+	}
+	switch x.Operator.(type) {
+	case *GenericOIDC_Condition_Eq:
+		return GenericOIDC_Condition_Eq_case
+	case *GenericOIDC_Condition_NotEq:
+		return GenericOIDC_Condition_NotEq_case
+	case *GenericOIDC_Condition_In:
+		return GenericOIDC_Condition_In_case
+	case *GenericOIDC_Condition_NotIn:
+		return GenericOIDC_Condition_NotIn_case
+	default:
+		return GenericOIDC_Condition_Operator_not_set_case
+	}
+}
+
+type GenericOIDC_Condition_builder struct {
+	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
+
+	Attribute string
+	// Fields of oneof Operator:
+	Eq    *GenericOIDC_ConditionEq
+	NotEq *GenericOIDC_ConditionNotEq
+	In    *GenericOIDC_ConditionIn
+	NotIn *GenericOIDC_ConditionNotIn
+	// -- end of Operator
+}
+
+func (b0 GenericOIDC_Condition_builder) Build() *GenericOIDC_Condition {
+	m0 := &GenericOIDC_Condition{}
+	b, x := &b0, m0
+	_, _ = b, x
+	x.Attribute = b.Attribute
+	if b.Eq != nil {
+		x.Operator = &GenericOIDC_Condition_Eq{b.Eq}
+	}
+	if b.NotEq != nil {
+		x.Operator = &GenericOIDC_Condition_NotEq{b.NotEq}
+	}
+	if b.In != nil {
+		x.Operator = &GenericOIDC_Condition_In{b.In}
+	}
+	if b.NotIn != nil {
+		x.Operator = &GenericOIDC_Condition_NotIn{b.NotIn}
+	}
+	return m0
+}
+
+type case_GenericOIDC_Condition_Operator protoreflect.FieldNumber
+
+func (x case_GenericOIDC_Condition_Operator) String() string {
+	md := file_teleport_scopes_joining_v1_token_proto_msgTypes[33].Descriptor()
+	if x == 0 {
+		return "not set"
+	}
+	return protoimpl.X.MessageFieldStringOf(md, protoreflect.FieldNumber(x))
+}
+
+type isGenericOIDC_Condition_Operator interface {
+	isGenericOIDC_Condition_Operator()
+}
+
+type GenericOIDC_Condition_Eq struct {
+	Eq *GenericOIDC_ConditionEq `protobuf:"bytes,2,opt,name=eq,proto3,oneof"`
+}
+
+type GenericOIDC_Condition_NotEq struct {
+	NotEq *GenericOIDC_ConditionNotEq `protobuf:"bytes,3,opt,name=not_eq,json=notEq,proto3,oneof"`
+}
+
+type GenericOIDC_Condition_In struct {
+	In *GenericOIDC_ConditionIn `protobuf:"bytes,4,opt,name=in,proto3,oneof"`
+}
+
+type GenericOIDC_Condition_NotIn struct {
+	NotIn *GenericOIDC_ConditionNotIn `protobuf:"bytes,5,opt,name=not_in,json=notIn,proto3,oneof"`
+}
+
+func (*GenericOIDC_Condition_Eq) isGenericOIDC_Condition_Operator() {}
+
+func (*GenericOIDC_Condition_NotEq) isGenericOIDC_Condition_Operator() {}
+
+func (*GenericOIDC_Condition_In) isGenericOIDC_Condition_Operator() {}
+
+func (*GenericOIDC_Condition_NotIn) isGenericOIDC_Condition_Operator() {}
+
+// An allow rule, containing either a predict expression or simple field
+// check.
+type GenericOIDC_Rule struct {
+	state protoimpl.MessageState `protogen:"hybrid.v1"`
+	// Conditions are simple eq/not_eq/in/not_in conditions that check
+	// individual fields. All conditions must be satisfied for a join attempt to
+	// be allowed. Mutually exclusive with `expression`.
+	Conditions []*GenericOIDC_Condition `protobuf:"bytes,1,rep,name=conditions,proto3" json:"conditions,omitempty"`
+	// A predicate expression that must evaluate to `true` for the join attempt
+	// to be allowed. It is mutually exclusive with `conditions`.
+	// TODO: Include name of variable available to the expr in docs
+	Expression    string `protobuf:"bytes,2,opt,name=expression,proto3" json:"expression,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GenericOIDC_Rule) Reset() {
+	*x = GenericOIDC_Rule{}
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[34]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GenericOIDC_Rule) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GenericOIDC_Rule) ProtoMessage() {}
+
+func (x *GenericOIDC_Rule) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[34]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+func (x *GenericOIDC_Rule) GetConditions() []*GenericOIDC_Condition {
+	if x != nil {
+		return x.Conditions
+	}
+	return nil
+}
+
+func (x *GenericOIDC_Rule) GetExpression() string {
+	if x != nil {
+		return x.Expression
+	}
+	return ""
+}
+
+func (x *GenericOIDC_Rule) SetConditions(v []*GenericOIDC_Condition) {
+	x.Conditions = v
+}
+
+func (x *GenericOIDC_Rule) SetExpression(v string) {
+	x.Expression = v
+}
+
+type GenericOIDC_Rule_builder struct {
+	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
+
+	// Conditions are simple eq/not_eq/in/not_in conditions that check
+	// individual fields. All conditions must be satisfied for a join attempt to
+	// be allowed. Mutually exclusive with `expression`.
+	Conditions []*GenericOIDC_Condition
+	// A predicate expression that must evaluate to `true` for the join attempt
+	// to be allowed. It is mutually exclusive with `conditions`.
+	// TODO: Include name of variable available to the expr in docs
+	Expression string
+}
+
+func (b0 GenericOIDC_Rule_builder) Build() *GenericOIDC_Rule {
+	m0 := &GenericOIDC_Rule{}
+	b, x := &b0, m0
+	_, _ = b, x
+	x.Conditions = b.Conditions
+	x.Expression = b.Expression
+	return m0
+}
+
 var File_teleport_scopes_joining_v1_token_proto protoreflect.FileDescriptor
 
 const file_teleport_scopes_joining_v1_token_proto_rawDesc = "" +
 	"\n" +
-	"&teleport/scopes/joining/v1/token.proto\x12\x1ateleport.scopes.joining.v1\x1a\x1fgoogle/protobuf/timestamp.proto\x1a!teleport/header/v1/metadata.proto\"\xae\x02\n" +
+	"&teleport/scopes/joining/v1/token.proto\x12\x1ateleport.scopes.joining.v1\x1a\x1cgoogle/protobuf/struct.proto\x1a\x1fgoogle/protobuf/timestamp.proto\x1a!teleport/header/v1/metadata.proto\"\xae\x02\n" +
 	"\vScopedToken\x12\x12\n" +
 	"\x04kind\x18\x01 \x01(\tR\x04kind\x12\x19\n" +
 	"\bsub_kind\x18\x02 \x01(\tR\asubKind\x12\x18\n" +
@@ -3449,7 +4344,7 @@ const file_teleport_scopes_joining_v1_token_proto_rawDesc = "" +
 	"\bmetadata\x18\x04 \x01(\v2\x1c.teleport.header.v1.MetadataR\bmetadata\x12\x14\n" +
 	"\x05scope\x18\x05 \x01(\tR\x05scope\x12?\n" +
 	"\x04spec\x18\x06 \x01(\v2+.teleport.scopes.joining.v1.ScopedTokenSpecR\x04spec\x12E\n" +
-	"\x06status\x18\a \x01(\v2-.teleport.scopes.joining.v1.ScopedTokenStatusR\x06status\"\xdb\x05\n" +
+	"\x06status\x18\a \x01(\v2-.teleport.scopes.joining.v1.ScopedTokenStatusR\x06status\"\xa7\x06\n" +
 	"\x0fScopedTokenSpec\x12%\n" +
 	"\x0eassigned_scope\x18\x01 \x01(\tR\rassignedScope\x12\x14\n" +
 	"\x05roles\x18\x02 \x03(\tR\x05roles\x12\x1f\n" +
@@ -3468,7 +4363,8 @@ const file_teleport_scopes_joining_v1_token_proto_rawDesc = "" +
 	"kubernetes\x18\v \x01(\v2&.teleport.scopes.joining.v1.KubernetesR\n" +
 	"kubernetes\x12Q\n" +
 	"\rbound_keypair\x18\f \x01(\v2,.teleport.scopes.joining.v1.BoundKeypairSpecR\fboundKeypair\x12\x10\n" +
-	"\x03bot\x18\x0f \x01(\tR\x03botJ\x04\b\r\x10\x0eJ\x04\b\x0e\x10\x0fR\bbot_nameR\tbot_scope\"\xb6\x01\n" +
+	"\x03bot\x18\x0f \x01(\tR\x03bot\x12J\n" +
+	"\fgeneric_oidc\x18\x10 \x01(\v2'.teleport.scopes.joining.v1.GenericOIDCR\vgenericOidcJ\x04\b\r\x10\x0eJ\x04\b\x0e\x10\x0fR\bbot_nameR\tbot_scope\"\xb6\x01\n" +
 	"\x0eHostCertParams\x12\x17\n" +
 	"\ahost_id\x18\x01 \x01(\tR\x06hostId\x12\x1b\n" +
 	"\tnode_name\x18\x02 \x01(\tR\bnodeName\x12\x12\n" +
@@ -3584,9 +4480,41 @@ const file_teleport_scopes_joining_v1_token_proto_rawDesc = "" +
 	"\x0erecovery_count\x18\x04 \x01(\rR\rrecoveryCount\x12F\n" +
 	"\x11last_recovered_at\x18\x05 \x01(\v2\x1a.google.protobuf.TimestampR\x0flastRecoveredAt\x12B\n" +
 	"\x0flast_rotated_at\x18\x06 \x01(\v2\x1a.google.protobuf.TimestampR\rlastRotatedAt\x12\"\n" +
-	"\rbound_host_id\x18\a \x01(\tR\vboundHostIdBYZWgithub.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/joining/v1;joiningv1b\x06proto3"
+	"\rbound_host_id\x18\a \x01(\tR\vboundHostId\"\xc7\a\n" +
+	"\vGenericOIDC\x12\x16\n" +
+	"\x06issuer\x18\x01 \x01(\tR\x06issuer\x12;\n" +
+	"\x1ainsecure_allow_http_issuer\x18\x02 \x01(\bR\x17insecureAllowHttpIssuer\x12\x1a\n" +
+	"\baudience\x18\x03 \x01(\tR\baudience\x12\x1f\n" +
+	"\vstatic_jwks\x18\x04 \x01(\tR\n" +
+	"staticJwks\x12\x15\n" +
+	"\x06tls_ca\x18\x05 \x01(\tR\x05tlsCa\x12C\n" +
+	"\x11must_match_fields\x18\x06 \x01(\v2\x17.google.protobuf.StructR\x0fmustMatchFields\x12I\n" +
+	"\tallow_any\x18\a \x03(\v2,.teleport.scopes.joining.v1.GenericOIDC.RuleR\ballowAny\x1a#\n" +
+	"\vConditionEq\x12\x14\n" +
+	"\x05value\x18\x01 \x01(\tR\x05value\x1a&\n" +
+	"\x0eConditionNotEq\x12\x14\n" +
+	"\x05value\x18\x01 \x01(\tR\x05value\x1a%\n" +
+	"\vConditionIn\x12\x16\n" +
+	"\x06values\x18\x01 \x03(\tR\x06values\x1a(\n" +
+	"\x0eConditionNotIn\x12\x16\n" +
+	"\x06values\x18\x01 \x03(\tR\x06values\x1a\xe5\x02\n" +
+	"\tCondition\x12\x1c\n" +
+	"\tattribute\x18\x01 \x01(\tR\tattribute\x12E\n" +
+	"\x02eq\x18\x02 \x01(\v23.teleport.scopes.joining.v1.GenericOIDC.ConditionEqH\x00R\x02eq\x12O\n" +
+	"\x06not_eq\x18\x03 \x01(\v26.teleport.scopes.joining.v1.GenericOIDC.ConditionNotEqH\x00R\x05notEq\x12E\n" +
+	"\x02in\x18\x04 \x01(\v23.teleport.scopes.joining.v1.GenericOIDC.ConditionInH\x00R\x02in\x12O\n" +
+	"\x06not_in\x18\x05 \x01(\v26.teleport.scopes.joining.v1.GenericOIDC.ConditionNotInH\x00R\x05notInB\n" +
+	"\n" +
+	"\boperator\x1ay\n" +
+	"\x04Rule\x12Q\n" +
+	"\n" +
+	"conditions\x18\x01 \x03(\v21.teleport.scopes.joining.v1.GenericOIDC.ConditionR\n" +
+	"conditions\x12\x1e\n" +
+	"\n" +
+	"expression\x18\x02 \x01(\tR\n" +
+	"expressionBYZWgithub.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/joining/v1;joiningv1b\x06proto3"
 
-var file_teleport_scopes_joining_v1_token_proto_msgTypes = make([]protoimpl.MessageInfo, 28)
+var file_teleport_scopes_joining_v1_token_proto_msgTypes = make([]protoimpl.MessageInfo, 35)
 var file_teleport_scopes_joining_v1_token_proto_goTypes = []any{
 	(*ScopedToken)(nil),                     // 0: teleport.scopes.joining.v1.ScopedToken
 	(*ScopedTokenSpec)(nil),                 // 1: teleport.scopes.joining.v1.ScopedTokenSpec
@@ -3605,22 +4533,30 @@ var file_teleport_scopes_joining_v1_token_proto_goTypes = []any{
 	(*Kubernetes)(nil),                      // 14: teleport.scopes.joining.v1.Kubernetes
 	(*BoundKeypairSpec)(nil),                // 15: teleport.scopes.joining.v1.BoundKeypairSpec
 	(*BoundKeypairStatus)(nil),              // 16: teleport.scopes.joining.v1.BoundKeypairStatus
-	nil,                                     // 17: teleport.scopes.joining.v1.ImmutableLabels.SshEntry
-	(*AWS_Rule)(nil),                        // 18: teleport.scopes.joining.v1.AWS.Rule
-	(*GCP_Rule)(nil),                        // 19: teleport.scopes.joining.v1.GCP.Rule
-	(*Azure_Rule)(nil),                      // 20: teleport.scopes.joining.v1.Azure.Rule
-	(*AzureDevops_Rule)(nil),                // 21: teleport.scopes.joining.v1.AzureDevops.Rule
-	(*Oracle_Rule)(nil),                     // 22: teleport.scopes.joining.v1.Oracle.Rule
-	(*Kubernetes_StaticJWKSConfig)(nil),     // 23: teleport.scopes.joining.v1.Kubernetes.StaticJWKSConfig
-	(*Kubernetes_OIDCConfig)(nil),           // 24: teleport.scopes.joining.v1.Kubernetes.OIDCConfig
-	(*Kubernetes_Rule)(nil),                 // 25: teleport.scopes.joining.v1.Kubernetes.Rule
-	(*BoundKeypairSpec_OnboardingSpec)(nil), // 26: teleport.scopes.joining.v1.BoundKeypairSpec.OnboardingSpec
-	(*BoundKeypairSpec_RecoverySpec)(nil),   // 27: teleport.scopes.joining.v1.BoundKeypairSpec.RecoverySpec
-	(*v1.Metadata)(nil),                     // 28: teleport.header.v1.Metadata
-	(*timestamppb.Timestamp)(nil),           // 29: google.protobuf.Timestamp
+	(*GenericOIDC)(nil),                     // 17: teleport.scopes.joining.v1.GenericOIDC
+	nil,                                     // 18: teleport.scopes.joining.v1.ImmutableLabels.SshEntry
+	(*AWS_Rule)(nil),                        // 19: teleport.scopes.joining.v1.AWS.Rule
+	(*GCP_Rule)(nil),                        // 20: teleport.scopes.joining.v1.GCP.Rule
+	(*Azure_Rule)(nil),                      // 21: teleport.scopes.joining.v1.Azure.Rule
+	(*AzureDevops_Rule)(nil),                // 22: teleport.scopes.joining.v1.AzureDevops.Rule
+	(*Oracle_Rule)(nil),                     // 23: teleport.scopes.joining.v1.Oracle.Rule
+	(*Kubernetes_StaticJWKSConfig)(nil),     // 24: teleport.scopes.joining.v1.Kubernetes.StaticJWKSConfig
+	(*Kubernetes_OIDCConfig)(nil),           // 25: teleport.scopes.joining.v1.Kubernetes.OIDCConfig
+	(*Kubernetes_Rule)(nil),                 // 26: teleport.scopes.joining.v1.Kubernetes.Rule
+	(*BoundKeypairSpec_OnboardingSpec)(nil), // 27: teleport.scopes.joining.v1.BoundKeypairSpec.OnboardingSpec
+	(*BoundKeypairSpec_RecoverySpec)(nil),   // 28: teleport.scopes.joining.v1.BoundKeypairSpec.RecoverySpec
+	(*GenericOIDC_ConditionEq)(nil),         // 29: teleport.scopes.joining.v1.GenericOIDC.ConditionEq
+	(*GenericOIDC_ConditionNotEq)(nil),      // 30: teleport.scopes.joining.v1.GenericOIDC.ConditionNotEq
+	(*GenericOIDC_ConditionIn)(nil),         // 31: teleport.scopes.joining.v1.GenericOIDC.ConditionIn
+	(*GenericOIDC_ConditionNotIn)(nil),      // 32: teleport.scopes.joining.v1.GenericOIDC.ConditionNotIn
+	(*GenericOIDC_Condition)(nil),           // 33: teleport.scopes.joining.v1.GenericOIDC.Condition
+	(*GenericOIDC_Rule)(nil),                // 34: teleport.scopes.joining.v1.GenericOIDC.Rule
+	(*v1.Metadata)(nil),                     // 35: teleport.header.v1.Metadata
+	(*timestamppb.Timestamp)(nil),           // 36: google.protobuf.Timestamp
+	(*structpb.Struct)(nil),                 // 37: google.protobuf.Struct
 }
 var file_teleport_scopes_joining_v1_token_proto_depIdxs = []int32{
-	28, // 0: teleport.scopes.joining.v1.ScopedToken.metadata:type_name -> teleport.header.v1.Metadata
+	35, // 0: teleport.scopes.joining.v1.ScopedToken.metadata:type_name -> teleport.header.v1.Metadata
 	1,  // 1: teleport.scopes.joining.v1.ScopedToken.spec:type_name -> teleport.scopes.joining.v1.ScopedTokenSpec
 	5,  // 2: teleport.scopes.joining.v1.ScopedToken.status:type_name -> teleport.scopes.joining.v1.ScopedTokenStatus
 	6,  // 3: teleport.scopes.joining.v1.ScopedTokenSpec.immutable_labels:type_name -> teleport.scopes.joining.v1.ImmutableLabels
@@ -3631,35 +4567,43 @@ var file_teleport_scopes_joining_v1_token_proto_depIdxs = []int32{
 	13, // 8: teleport.scopes.joining.v1.ScopedTokenSpec.oracle:type_name -> teleport.scopes.joining.v1.Oracle
 	14, // 9: teleport.scopes.joining.v1.ScopedTokenSpec.kubernetes:type_name -> teleport.scopes.joining.v1.Kubernetes
 	15, // 10: teleport.scopes.joining.v1.ScopedTokenSpec.bound_keypair:type_name -> teleport.scopes.joining.v1.BoundKeypairSpec
-	29, // 11: teleport.scopes.joining.v1.SingleUseStatus.used_at:type_name -> google.protobuf.Timestamp
-	29, // 12: teleport.scopes.joining.v1.SingleUseStatus.reusable_until:type_name -> google.protobuf.Timestamp
-	2,  // 13: teleport.scopes.joining.v1.SingleUseStatus.host_cert_params:type_name -> teleport.scopes.joining.v1.HostCertParams
-	3,  // 14: teleport.scopes.joining.v1.UsageStatus.single_use:type_name -> teleport.scopes.joining.v1.SingleUseStatus
-	16, // 15: teleport.scopes.joining.v1.UsageStatus.bound_keypair:type_name -> teleport.scopes.joining.v1.BoundKeypairStatus
-	4,  // 16: teleport.scopes.joining.v1.ScopedTokenStatus.usage:type_name -> teleport.scopes.joining.v1.UsageStatus
-	17, // 17: teleport.scopes.joining.v1.ImmutableLabels.ssh:type_name -> teleport.scopes.joining.v1.ImmutableLabels.SshEntry
-	28, // 18: teleport.scopes.joining.v1.StaticScopedTokens.metadata:type_name -> teleport.header.v1.Metadata
-	8,  // 19: teleport.scopes.joining.v1.StaticScopedTokens.spec:type_name -> teleport.scopes.joining.v1.StaticScopedTokensSpec
-	0,  // 20: teleport.scopes.joining.v1.StaticScopedTokensSpec.tokens:type_name -> teleport.scopes.joining.v1.ScopedToken
-	18, // 21: teleport.scopes.joining.v1.AWS.allow:type_name -> teleport.scopes.joining.v1.AWS.Rule
-	19, // 22: teleport.scopes.joining.v1.GCP.allow:type_name -> teleport.scopes.joining.v1.GCP.Rule
-	20, // 23: teleport.scopes.joining.v1.Azure.allow:type_name -> teleport.scopes.joining.v1.Azure.Rule
-	21, // 24: teleport.scopes.joining.v1.AzureDevops.allow:type_name -> teleport.scopes.joining.v1.AzureDevops.Rule
-	22, // 25: teleport.scopes.joining.v1.Oracle.allow:type_name -> teleport.scopes.joining.v1.Oracle.Rule
-	25, // 26: teleport.scopes.joining.v1.Kubernetes.allow:type_name -> teleport.scopes.joining.v1.Kubernetes.Rule
-	23, // 27: teleport.scopes.joining.v1.Kubernetes.static_jwks:type_name -> teleport.scopes.joining.v1.Kubernetes.StaticJWKSConfig
-	24, // 28: teleport.scopes.joining.v1.Kubernetes.oidc:type_name -> teleport.scopes.joining.v1.Kubernetes.OIDCConfig
-	26, // 29: teleport.scopes.joining.v1.BoundKeypairSpec.onboarding:type_name -> teleport.scopes.joining.v1.BoundKeypairSpec.OnboardingSpec
-	27, // 30: teleport.scopes.joining.v1.BoundKeypairSpec.recovery:type_name -> teleport.scopes.joining.v1.BoundKeypairSpec.RecoverySpec
-	29, // 31: teleport.scopes.joining.v1.BoundKeypairSpec.rotate_after:type_name -> google.protobuf.Timestamp
-	29, // 32: teleport.scopes.joining.v1.BoundKeypairStatus.last_recovered_at:type_name -> google.protobuf.Timestamp
-	29, // 33: teleport.scopes.joining.v1.BoundKeypairStatus.last_rotated_at:type_name -> google.protobuf.Timestamp
-	29, // 34: teleport.scopes.joining.v1.BoundKeypairSpec.OnboardingSpec.must_register_before:type_name -> google.protobuf.Timestamp
-	35, // [35:35] is the sub-list for method output_type
-	35, // [35:35] is the sub-list for method input_type
-	35, // [35:35] is the sub-list for extension type_name
-	35, // [35:35] is the sub-list for extension extendee
-	0,  // [0:35] is the sub-list for field type_name
+	17, // 11: teleport.scopes.joining.v1.ScopedTokenSpec.generic_oidc:type_name -> teleport.scopes.joining.v1.GenericOIDC
+	36, // 12: teleport.scopes.joining.v1.SingleUseStatus.used_at:type_name -> google.protobuf.Timestamp
+	36, // 13: teleport.scopes.joining.v1.SingleUseStatus.reusable_until:type_name -> google.protobuf.Timestamp
+	2,  // 14: teleport.scopes.joining.v1.SingleUseStatus.host_cert_params:type_name -> teleport.scopes.joining.v1.HostCertParams
+	3,  // 15: teleport.scopes.joining.v1.UsageStatus.single_use:type_name -> teleport.scopes.joining.v1.SingleUseStatus
+	16, // 16: teleport.scopes.joining.v1.UsageStatus.bound_keypair:type_name -> teleport.scopes.joining.v1.BoundKeypairStatus
+	4,  // 17: teleport.scopes.joining.v1.ScopedTokenStatus.usage:type_name -> teleport.scopes.joining.v1.UsageStatus
+	18, // 18: teleport.scopes.joining.v1.ImmutableLabels.ssh:type_name -> teleport.scopes.joining.v1.ImmutableLabels.SshEntry
+	35, // 19: teleport.scopes.joining.v1.StaticScopedTokens.metadata:type_name -> teleport.header.v1.Metadata
+	8,  // 20: teleport.scopes.joining.v1.StaticScopedTokens.spec:type_name -> teleport.scopes.joining.v1.StaticScopedTokensSpec
+	0,  // 21: teleport.scopes.joining.v1.StaticScopedTokensSpec.tokens:type_name -> teleport.scopes.joining.v1.ScopedToken
+	19, // 22: teleport.scopes.joining.v1.AWS.allow:type_name -> teleport.scopes.joining.v1.AWS.Rule
+	20, // 23: teleport.scopes.joining.v1.GCP.allow:type_name -> teleport.scopes.joining.v1.GCP.Rule
+	21, // 24: teleport.scopes.joining.v1.Azure.allow:type_name -> teleport.scopes.joining.v1.Azure.Rule
+	22, // 25: teleport.scopes.joining.v1.AzureDevops.allow:type_name -> teleport.scopes.joining.v1.AzureDevops.Rule
+	23, // 26: teleport.scopes.joining.v1.Oracle.allow:type_name -> teleport.scopes.joining.v1.Oracle.Rule
+	26, // 27: teleport.scopes.joining.v1.Kubernetes.allow:type_name -> teleport.scopes.joining.v1.Kubernetes.Rule
+	24, // 28: teleport.scopes.joining.v1.Kubernetes.static_jwks:type_name -> teleport.scopes.joining.v1.Kubernetes.StaticJWKSConfig
+	25, // 29: teleport.scopes.joining.v1.Kubernetes.oidc:type_name -> teleport.scopes.joining.v1.Kubernetes.OIDCConfig
+	27, // 30: teleport.scopes.joining.v1.BoundKeypairSpec.onboarding:type_name -> teleport.scopes.joining.v1.BoundKeypairSpec.OnboardingSpec
+	28, // 31: teleport.scopes.joining.v1.BoundKeypairSpec.recovery:type_name -> teleport.scopes.joining.v1.BoundKeypairSpec.RecoverySpec
+	36, // 32: teleport.scopes.joining.v1.BoundKeypairSpec.rotate_after:type_name -> google.protobuf.Timestamp
+	36, // 33: teleport.scopes.joining.v1.BoundKeypairStatus.last_recovered_at:type_name -> google.protobuf.Timestamp
+	36, // 34: teleport.scopes.joining.v1.BoundKeypairStatus.last_rotated_at:type_name -> google.protobuf.Timestamp
+	37, // 35: teleport.scopes.joining.v1.GenericOIDC.must_match_fields:type_name -> google.protobuf.Struct
+	34, // 36: teleport.scopes.joining.v1.GenericOIDC.allow_any:type_name -> teleport.scopes.joining.v1.GenericOIDC.Rule
+	36, // 37: teleport.scopes.joining.v1.BoundKeypairSpec.OnboardingSpec.must_register_before:type_name -> google.protobuf.Timestamp
+	29, // 38: teleport.scopes.joining.v1.GenericOIDC.Condition.eq:type_name -> teleport.scopes.joining.v1.GenericOIDC.ConditionEq
+	30, // 39: teleport.scopes.joining.v1.GenericOIDC.Condition.not_eq:type_name -> teleport.scopes.joining.v1.GenericOIDC.ConditionNotEq
+	31, // 40: teleport.scopes.joining.v1.GenericOIDC.Condition.in:type_name -> teleport.scopes.joining.v1.GenericOIDC.ConditionIn
+	32, // 41: teleport.scopes.joining.v1.GenericOIDC.Condition.not_in:type_name -> teleport.scopes.joining.v1.GenericOIDC.ConditionNotIn
+	33, // 42: teleport.scopes.joining.v1.GenericOIDC.Rule.conditions:type_name -> teleport.scopes.joining.v1.GenericOIDC.Condition
+	43, // [43:43] is the sub-list for method output_type
+	43, // [43:43] is the sub-list for method input_type
+	43, // [43:43] is the sub-list for extension type_name
+	43, // [43:43] is the sub-list for extension extendee
+	0,  // [0:43] is the sub-list for field type_name
 }
 
 func init() { file_teleport_scopes_joining_v1_token_proto_init() }
@@ -3671,13 +4615,19 @@ func file_teleport_scopes_joining_v1_token_proto_init() {
 		(*UsageStatus_SingleUse)(nil),
 		(*UsageStatus_BoundKeypair)(nil),
 	}
+	file_teleport_scopes_joining_v1_token_proto_msgTypes[33].OneofWrappers = []any{
+		(*GenericOIDC_Condition_Eq)(nil),
+		(*GenericOIDC_Condition_NotEq)(nil),
+		(*GenericOIDC_Condition_In)(nil),
+		(*GenericOIDC_Condition_NotIn)(nil),
+	}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_teleport_scopes_joining_v1_token_proto_rawDesc), len(file_teleport_scopes_joining_v1_token_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   28,
+			NumMessages:   35,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/api/gen/proto/go/teleport/scopes/joining/v1/token.pb.go
+++ b/api/gen/proto/go/teleport/scopes/joining/v1/token.pb.go
@@ -2522,12 +2522,21 @@ type GenericOIDC_builder struct {
 	Issuer string
 	// If set, disables the requirement that the issuer must use HTTPS.
 	InsecureAllowHttpIssuer bool
-	// The expected JWT audience. If unset, this value will be set to the name of
-	// this Teleport cluster (e.g. example.teleport.sh). Where possible, this
-	// value should be unique to the Teleport cluster; issuing JWTs using the
-	// cluster as the audience is preferred. On providers where this is not
-	// possible, you can specify their server-defined value in this field. This
-	// value must match the audience in issued JWTs for join attempts to succeed.
+	// The expected JWT audience value (required). This must match or be included
+	// in the list of `aud` values in the JWT provided by the client when joining.
+	//
+	// For providers that do not allow you to configure this value yourself (this
+	// is technically an OIDC spec violation, but is common), use the value they
+	// provide. Otherwise, we recommend using a value that uniquely identifies the
+	// Teleport cluster and join token. For example, you can use this scheme:
+	//
+	//	$clusterName/$tokenName
+	//
+	// For a cluster named `example.teleport.sh` and a token named `example`, this
+	// would result in an audience of `example.teleport.sh/example`. If you
+	// prefer, you can also use a UUID instead of the token name. Note that you
+	// will need to configure the matching value with the issuer, usually at
+	// request time.
 	Audience string
 	// An optional static JWKS value that can be used to specify JWKS keys when
 	// either OIDC discovery is either not supported by the provider or the
@@ -3971,15 +3980,18 @@ func (b0 GenericOIDC_ConditionNotIn_builder) Build() *GenericOIDC_ConditionNotIn
 
 // An allow rule condition for simple checks against a specific field.
 type GenericOIDC_Condition struct {
-	state     protoimpl.MessageState `protogen:"hybrid.v1"`
-	Attribute string                 `protobuf:"bytes,1,opt,name=attribute,proto3" json:"attribute,omitempty"`
-	// Types that are valid to be assigned to Operator:
-	//
-	//	*GenericOIDC_Condition_Eq
-	//	*GenericOIDC_Condition_NotEq
-	//	*GenericOIDC_Condition_In
-	//	*GenericOIDC_Condition_NotIn
-	Operator      isGenericOIDC_Condition_Operator `protobuf_oneof:"operator"`
+	state protoimpl.MessageState `protogen:"hybrid.v1"`
+	// The name of the field this condition should check, separated by "." for
+	// nested fields.
+	Attribute string `protobuf:"bytes,1,opt,name=attribute,proto3" json:"attribute,omitempty"`
+	// An "equals" operator. Only one operator may be set within a condition.
+	Eq *GenericOIDC_ConditionEq `protobuf:"bytes,2,opt,name=eq,proto3" json:"eq,omitempty"`
+	// A "not equals" operator. Only one operator may be set within a condition.
+	NotEq *GenericOIDC_ConditionNotEq `protobuf:"bytes,3,opt,name=not_eq,json=notEq,proto3" json:"not_eq,omitempty"`
+	// An "in" operator. Only one operator may be set within a condition.
+	In *GenericOIDC_ConditionIn `protobuf:"bytes,4,opt,name=in,proto3" json:"in,omitempty"`
+	// A "not in" operator. Only one operator may be set within a condition.
+	NotIn         *GenericOIDC_ConditionNotIn `protobuf:"bytes,5,opt,name=not_in,json=notIn,proto3" json:"not_in,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -4016,45 +4028,30 @@ func (x *GenericOIDC_Condition) GetAttribute() string {
 	return ""
 }
 
-func (x *GenericOIDC_Condition) GetOperator() isGenericOIDC_Condition_Operator {
-	if x != nil {
-		return x.Operator
-	}
-	return nil
-}
-
 func (x *GenericOIDC_Condition) GetEq() *GenericOIDC_ConditionEq {
 	if x != nil {
-		if x, ok := x.Operator.(*GenericOIDC_Condition_Eq); ok {
-			return x.Eq
-		}
+		return x.Eq
 	}
 	return nil
 }
 
 func (x *GenericOIDC_Condition) GetNotEq() *GenericOIDC_ConditionNotEq {
 	if x != nil {
-		if x, ok := x.Operator.(*GenericOIDC_Condition_NotEq); ok {
-			return x.NotEq
-		}
+		return x.NotEq
 	}
 	return nil
 }
 
 func (x *GenericOIDC_Condition) GetIn() *GenericOIDC_ConditionIn {
 	if x != nil {
-		if x, ok := x.Operator.(*GenericOIDC_Condition_In); ok {
-			return x.In
-		}
+		return x.In
 	}
 	return nil
 }
 
 func (x *GenericOIDC_Condition) GetNotIn() *GenericOIDC_ConditionNotIn {
 	if x != nil {
-		if x, ok := x.Operator.(*GenericOIDC_Condition_NotIn); ok {
-			return x.NotIn
-		}
+		return x.NotIn
 	}
 	return nil
 }
@@ -4064,138 +4061,79 @@ func (x *GenericOIDC_Condition) SetAttribute(v string) {
 }
 
 func (x *GenericOIDC_Condition) SetEq(v *GenericOIDC_ConditionEq) {
-	if v == nil {
-		x.Operator = nil
-		return
-	}
-	x.Operator = &GenericOIDC_Condition_Eq{v}
+	x.Eq = v
 }
 
 func (x *GenericOIDC_Condition) SetNotEq(v *GenericOIDC_ConditionNotEq) {
-	if v == nil {
-		x.Operator = nil
-		return
-	}
-	x.Operator = &GenericOIDC_Condition_NotEq{v}
+	x.NotEq = v
 }
 
 func (x *GenericOIDC_Condition) SetIn(v *GenericOIDC_ConditionIn) {
-	if v == nil {
-		x.Operator = nil
-		return
-	}
-	x.Operator = &GenericOIDC_Condition_In{v}
+	x.In = v
 }
 
 func (x *GenericOIDC_Condition) SetNotIn(v *GenericOIDC_ConditionNotIn) {
-	if v == nil {
-		x.Operator = nil
-		return
-	}
-	x.Operator = &GenericOIDC_Condition_NotIn{v}
-}
-
-func (x *GenericOIDC_Condition) HasOperator() bool {
-	if x == nil {
-		return false
-	}
-	return x.Operator != nil
+	x.NotIn = v
 }
 
 func (x *GenericOIDC_Condition) HasEq() bool {
 	if x == nil {
 		return false
 	}
-	_, ok := x.Operator.(*GenericOIDC_Condition_Eq)
-	return ok
+	return x.Eq != nil
 }
 
 func (x *GenericOIDC_Condition) HasNotEq() bool {
 	if x == nil {
 		return false
 	}
-	_, ok := x.Operator.(*GenericOIDC_Condition_NotEq)
-	return ok
+	return x.NotEq != nil
 }
 
 func (x *GenericOIDC_Condition) HasIn() bool {
 	if x == nil {
 		return false
 	}
-	_, ok := x.Operator.(*GenericOIDC_Condition_In)
-	return ok
+	return x.In != nil
 }
 
 func (x *GenericOIDC_Condition) HasNotIn() bool {
 	if x == nil {
 		return false
 	}
-	_, ok := x.Operator.(*GenericOIDC_Condition_NotIn)
-	return ok
-}
-
-func (x *GenericOIDC_Condition) ClearOperator() {
-	x.Operator = nil
+	return x.NotIn != nil
 }
 
 func (x *GenericOIDC_Condition) ClearEq() {
-	if _, ok := x.Operator.(*GenericOIDC_Condition_Eq); ok {
-		x.Operator = nil
-	}
+	x.Eq = nil
 }
 
 func (x *GenericOIDC_Condition) ClearNotEq() {
-	if _, ok := x.Operator.(*GenericOIDC_Condition_NotEq); ok {
-		x.Operator = nil
-	}
+	x.NotEq = nil
 }
 
 func (x *GenericOIDC_Condition) ClearIn() {
-	if _, ok := x.Operator.(*GenericOIDC_Condition_In); ok {
-		x.Operator = nil
-	}
+	x.In = nil
 }
 
 func (x *GenericOIDC_Condition) ClearNotIn() {
-	if _, ok := x.Operator.(*GenericOIDC_Condition_NotIn); ok {
-		x.Operator = nil
-	}
-}
-
-const GenericOIDC_Condition_Operator_not_set_case case_GenericOIDC_Condition_Operator = 0
-const GenericOIDC_Condition_Eq_case case_GenericOIDC_Condition_Operator = 2
-const GenericOIDC_Condition_NotEq_case case_GenericOIDC_Condition_Operator = 3
-const GenericOIDC_Condition_In_case case_GenericOIDC_Condition_Operator = 4
-const GenericOIDC_Condition_NotIn_case case_GenericOIDC_Condition_Operator = 5
-
-func (x *GenericOIDC_Condition) WhichOperator() case_GenericOIDC_Condition_Operator {
-	if x == nil {
-		return GenericOIDC_Condition_Operator_not_set_case
-	}
-	switch x.Operator.(type) {
-	case *GenericOIDC_Condition_Eq:
-		return GenericOIDC_Condition_Eq_case
-	case *GenericOIDC_Condition_NotEq:
-		return GenericOIDC_Condition_NotEq_case
-	case *GenericOIDC_Condition_In:
-		return GenericOIDC_Condition_In_case
-	case *GenericOIDC_Condition_NotIn:
-		return GenericOIDC_Condition_NotIn_case
-	default:
-		return GenericOIDC_Condition_Operator_not_set_case
-	}
+	x.NotIn = nil
 }
 
 type GenericOIDC_Condition_builder struct {
 	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
 
+	// The name of the field this condition should check, separated by "." for
+	// nested fields.
 	Attribute string
-	// Fields of oneof Operator:
-	Eq    *GenericOIDC_ConditionEq
+	// An "equals" operator. Only one operator may be set within a condition.
+	Eq *GenericOIDC_ConditionEq
+	// A "not equals" operator. Only one operator may be set within a condition.
 	NotEq *GenericOIDC_ConditionNotEq
-	In    *GenericOIDC_ConditionIn
+	// An "in" operator. Only one operator may be set within a condition.
+	In *GenericOIDC_ConditionIn
+	// A "not in" operator. Only one operator may be set within a condition.
 	NotIn *GenericOIDC_ConditionNotIn
-	// -- end of Operator
 }
 
 func (b0 GenericOIDC_Condition_builder) Build() *GenericOIDC_Condition {
@@ -4203,58 +4141,12 @@ func (b0 GenericOIDC_Condition_builder) Build() *GenericOIDC_Condition {
 	b, x := &b0, m0
 	_, _ = b, x
 	x.Attribute = b.Attribute
-	if b.Eq != nil {
-		x.Operator = &GenericOIDC_Condition_Eq{b.Eq}
-	}
-	if b.NotEq != nil {
-		x.Operator = &GenericOIDC_Condition_NotEq{b.NotEq}
-	}
-	if b.In != nil {
-		x.Operator = &GenericOIDC_Condition_In{b.In}
-	}
-	if b.NotIn != nil {
-		x.Operator = &GenericOIDC_Condition_NotIn{b.NotIn}
-	}
+	x.Eq = b.Eq
+	x.NotEq = b.NotEq
+	x.In = b.In
+	x.NotIn = b.NotIn
 	return m0
 }
-
-type case_GenericOIDC_Condition_Operator protoreflect.FieldNumber
-
-func (x case_GenericOIDC_Condition_Operator) String() string {
-	md := file_teleport_scopes_joining_v1_token_proto_msgTypes[33].Descriptor()
-	if x == 0 {
-		return "not set"
-	}
-	return protoimpl.X.MessageFieldStringOf(md, protoreflect.FieldNumber(x))
-}
-
-type isGenericOIDC_Condition_Operator interface {
-	isGenericOIDC_Condition_Operator()
-}
-
-type GenericOIDC_Condition_Eq struct {
-	Eq *GenericOIDC_ConditionEq `protobuf:"bytes,2,opt,name=eq,proto3,oneof"`
-}
-
-type GenericOIDC_Condition_NotEq struct {
-	NotEq *GenericOIDC_ConditionNotEq `protobuf:"bytes,3,opt,name=not_eq,json=notEq,proto3,oneof"`
-}
-
-type GenericOIDC_Condition_In struct {
-	In *GenericOIDC_ConditionIn `protobuf:"bytes,4,opt,name=in,proto3,oneof"`
-}
-
-type GenericOIDC_Condition_NotIn struct {
-	NotIn *GenericOIDC_ConditionNotIn `protobuf:"bytes,5,opt,name=not_in,json=notIn,proto3,oneof"`
-}
-
-func (*GenericOIDC_Condition_Eq) isGenericOIDC_Condition_Operator() {}
-
-func (*GenericOIDC_Condition_NotEq) isGenericOIDC_Condition_Operator() {}
-
-func (*GenericOIDC_Condition_In) isGenericOIDC_Condition_Operator() {}
-
-func (*GenericOIDC_Condition_NotIn) isGenericOIDC_Condition_Operator() {}
 
 // An allow rule, containing either a predict expression or simple field
 // check.
@@ -4489,7 +4381,7 @@ const file_teleport_scopes_joining_v1_token_proto_rawDesc = "" +
 	"\x0erecovery_count\x18\x04 \x01(\rR\rrecoveryCount\x12F\n" +
 	"\x11last_recovered_at\x18\x05 \x01(\v2\x1a.google.protobuf.TimestampR\x0flastRecoveredAt\x12B\n" +
 	"\x0flast_rotated_at\x18\x06 \x01(\v2\x1a.google.protobuf.TimestampR\rlastRotatedAt\x12\"\n" +
-	"\rbound_host_id\x18\a \x01(\tR\vboundHostId\"\xc7\a\n" +
+	"\rbound_host_id\x18\a \x01(\tR\vboundHostId\"\xb3\a\n" +
 	"\vGenericOIDC\x12\x16\n" +
 	"\x06issuer\x18\x01 \x01(\tR\x06issuer\x12;\n" +
 	"\x1ainsecure_allow_http_issuer\x18\x02 \x01(\bR\x17insecureAllowHttpIssuer\x12\x1a\n" +
@@ -4506,15 +4398,13 @@ const file_teleport_scopes_joining_v1_token_proto_rawDesc = "" +
 	"\vConditionIn\x12\x16\n" +
 	"\x06values\x18\x01 \x03(\tR\x06values\x1a(\n" +
 	"\x0eConditionNotIn\x12\x16\n" +
-	"\x06values\x18\x01 \x03(\tR\x06values\x1a\xe5\x02\n" +
+	"\x06values\x18\x01 \x03(\tR\x06values\x1a\xd1\x02\n" +
 	"\tCondition\x12\x1c\n" +
-	"\tattribute\x18\x01 \x01(\tR\tattribute\x12E\n" +
-	"\x02eq\x18\x02 \x01(\v23.teleport.scopes.joining.v1.GenericOIDC.ConditionEqH\x00R\x02eq\x12O\n" +
-	"\x06not_eq\x18\x03 \x01(\v26.teleport.scopes.joining.v1.GenericOIDC.ConditionNotEqH\x00R\x05notEq\x12E\n" +
-	"\x02in\x18\x04 \x01(\v23.teleport.scopes.joining.v1.GenericOIDC.ConditionInH\x00R\x02in\x12O\n" +
-	"\x06not_in\x18\x05 \x01(\v26.teleport.scopes.joining.v1.GenericOIDC.ConditionNotInH\x00R\x05notInB\n" +
-	"\n" +
-	"\boperator\x1ay\n" +
+	"\tattribute\x18\x01 \x01(\tR\tattribute\x12C\n" +
+	"\x02eq\x18\x02 \x01(\v23.teleport.scopes.joining.v1.GenericOIDC.ConditionEqR\x02eq\x12M\n" +
+	"\x06not_eq\x18\x03 \x01(\v26.teleport.scopes.joining.v1.GenericOIDC.ConditionNotEqR\x05notEq\x12C\n" +
+	"\x02in\x18\x04 \x01(\v23.teleport.scopes.joining.v1.GenericOIDC.ConditionInR\x02in\x12M\n" +
+	"\x06not_in\x18\x05 \x01(\v26.teleport.scopes.joining.v1.GenericOIDC.ConditionNotInR\x05notIn\x1ay\n" +
 	"\x04Rule\x12Q\n" +
 	"\n" +
 	"conditions\x18\x01 \x03(\v21.teleport.scopes.joining.v1.GenericOIDC.ConditionR\n" +
@@ -4623,12 +4513,6 @@ func file_teleport_scopes_joining_v1_token_proto_init() {
 	file_teleport_scopes_joining_v1_token_proto_msgTypes[4].OneofWrappers = []any{
 		(*UsageStatus_SingleUse)(nil),
 		(*UsageStatus_BoundKeypair)(nil),
-	}
-	file_teleport_scopes_joining_v1_token_proto_msgTypes[33].OneofWrappers = []any{
-		(*GenericOIDC_Condition_Eq)(nil),
-		(*GenericOIDC_Condition_NotEq)(nil),
-		(*GenericOIDC_Condition_In)(nil),
-		(*GenericOIDC_Condition_NotIn)(nil),
 	}
 	type x struct{}
 	out := protoimpl.TypeBuilder{

--- a/api/gen/proto/go/teleport/scopes/joining/v1/token.pb.go
+++ b/api/gen/proto/go/teleport/scopes/joining/v1/token.pb.go
@@ -2335,12 +2335,21 @@ type GenericOIDC struct {
 	Issuer string `protobuf:"bytes,1,opt,name=issuer,proto3" json:"issuer,omitempty"`
 	// If set, disables the requirement that the issuer must use HTTPS.
 	InsecureAllowHttpIssuer bool `protobuf:"varint,2,opt,name=insecure_allow_http_issuer,json=insecureAllowHttpIssuer,proto3" json:"insecure_allow_http_issuer,omitempty"`
-	// The expected JWT audience. If unset, this value will be set to the name of
-	// this Teleport cluster (e.g. example.teleport.sh). Where possible, this
-	// value should be unique to the Teleport cluster; issuing JWTs using the
-	// cluster as the audience is preferred. On providers where this is not
-	// possible, you can specify their server-defined value in this field. This
-	// value must match the audience in issued JWTs for join attempts to succeed.
+	// The expected JWT audience value (required). This must match or be included
+	// in the list of `aud` values in the JWT provided by the client when joining.
+	//
+	// For providers that do not allow you to configure this value yourself (this
+	// is technically an OIDC spec violation, but is common), use the value they
+	// provide. Otherwise, we recommend using a value that uniquely identifies the
+	// Teleport cluster and join token. For example, you can use this scheme:
+	//
+	//	$clusterName/$tokenName
+	//
+	// For a cluster named `example.teleport.sh` and a token named `example`, this
+	// would result in an audience of `example.teleport.sh/example`. If you
+	// prefer, you can also use a UUID instead of the token name. Note that you
+	// will need to configure the matching value with the issuer, usually at
+	// request time.
 	Audience string `protobuf:"bytes,3,opt,name=audience,proto3" json:"audience,omitempty"`
 	// An optional static JWKS value that can be used to specify JWKS keys when
 	// either OIDC discovery is either not supported by the provider or the

--- a/api/gen/proto/go/teleport/scopes/joining/v1/token_protoopaque.pb.go
+++ b/api/gen/proto/go/teleport/scopes/joining/v1/token_protoopaque.pb.go
@@ -2346,12 +2346,21 @@ type GenericOIDC_builder struct {
 	Issuer string
 	// If set, disables the requirement that the issuer must use HTTPS.
 	InsecureAllowHttpIssuer bool
-	// The expected JWT audience. If unset, this value will be set to the name of
-	// this Teleport cluster (e.g. example.teleport.sh). Where possible, this
-	// value should be unique to the Teleport cluster; issuing JWTs using the
-	// cluster as the audience is preferred. On providers where this is not
-	// possible, you can specify their server-defined value in this field. This
-	// value must match the audience in issued JWTs for join attempts to succeed.
+	// The expected JWT audience value (required). This must match or be included
+	// in the list of `aud` values in the JWT provided by the client when joining.
+	//
+	// For providers that do not allow you to configure this value yourself (this
+	// is technically an OIDC spec violation, but is common), use the value they
+	// provide. Otherwise, we recommend using a value that uniquely identifies the
+	// Teleport cluster and join token. For example, you can use this scheme:
+	//
+	//	$clusterName/$tokenName
+	//
+	// For a cluster named `example.teleport.sh` and a token named `example`, this
+	// would result in an audience of `example.teleport.sh/example`. If you
+	// prefer, you can also use a UUID instead of the token name. Note that you
+	// will need to configure the matching value with the issuer, usually at
+	// request time.
 	Audience string
 	// An optional static JWKS value that can be used to specify JWKS keys when
 	// either OIDC discovery is either not supported by the provider or the
@@ -3689,9 +3698,12 @@ func (b0 GenericOIDC_ConditionNotIn_builder) Build() *GenericOIDC_ConditionNotIn
 
 // An allow rule condition for simple checks against a specific field.
 type GenericOIDC_Condition struct {
-	state                protoimpl.MessageState           `protogen:"opaque.v1"`
-	xxx_hidden_Attribute string                           `protobuf:"bytes,1,opt,name=attribute,proto3"`
-	xxx_hidden_Operator  isGenericOIDC_Condition_Operator `protobuf_oneof:"operator"`
+	state                protoimpl.MessageState      `protogen:"opaque.v1"`
+	xxx_hidden_Attribute string                      `protobuf:"bytes,1,opt,name=attribute,proto3"`
+	xxx_hidden_Eq        *GenericOIDC_ConditionEq    `protobuf:"bytes,2,opt,name=eq,proto3"`
+	xxx_hidden_NotEq     *GenericOIDC_ConditionNotEq `protobuf:"bytes,3,opt,name=not_eq,json=notEq,proto3"`
+	xxx_hidden_In        *GenericOIDC_ConditionIn    `protobuf:"bytes,4,opt,name=in,proto3"`
+	xxx_hidden_NotIn     *GenericOIDC_ConditionNotIn `protobuf:"bytes,5,opt,name=not_in,json=notIn,proto3"`
 	unknownFields        protoimpl.UnknownFields
 	sizeCache            protoimpl.SizeCache
 }
@@ -3730,36 +3742,28 @@ func (x *GenericOIDC_Condition) GetAttribute() string {
 
 func (x *GenericOIDC_Condition) GetEq() *GenericOIDC_ConditionEq {
 	if x != nil {
-		if x, ok := x.xxx_hidden_Operator.(*genericOIDC_Condition_Eq); ok {
-			return x.Eq
-		}
+		return x.xxx_hidden_Eq
 	}
 	return nil
 }
 
 func (x *GenericOIDC_Condition) GetNotEq() *GenericOIDC_ConditionNotEq {
 	if x != nil {
-		if x, ok := x.xxx_hidden_Operator.(*genericOIDC_Condition_NotEq); ok {
-			return x.NotEq
-		}
+		return x.xxx_hidden_NotEq
 	}
 	return nil
 }
 
 func (x *GenericOIDC_Condition) GetIn() *GenericOIDC_ConditionIn {
 	if x != nil {
-		if x, ok := x.xxx_hidden_Operator.(*genericOIDC_Condition_In); ok {
-			return x.In
-		}
+		return x.xxx_hidden_In
 	}
 	return nil
 }
 
 func (x *GenericOIDC_Condition) GetNotIn() *GenericOIDC_ConditionNotIn {
 	if x != nil {
-		if x, ok := x.xxx_hidden_Operator.(*genericOIDC_Condition_NotIn); ok {
-			return x.NotIn
-		}
+		return x.xxx_hidden_NotIn
 	}
 	return nil
 }
@@ -3769,138 +3773,79 @@ func (x *GenericOIDC_Condition) SetAttribute(v string) {
 }
 
 func (x *GenericOIDC_Condition) SetEq(v *GenericOIDC_ConditionEq) {
-	if v == nil {
-		x.xxx_hidden_Operator = nil
-		return
-	}
-	x.xxx_hidden_Operator = &genericOIDC_Condition_Eq{v}
+	x.xxx_hidden_Eq = v
 }
 
 func (x *GenericOIDC_Condition) SetNotEq(v *GenericOIDC_ConditionNotEq) {
-	if v == nil {
-		x.xxx_hidden_Operator = nil
-		return
-	}
-	x.xxx_hidden_Operator = &genericOIDC_Condition_NotEq{v}
+	x.xxx_hidden_NotEq = v
 }
 
 func (x *GenericOIDC_Condition) SetIn(v *GenericOIDC_ConditionIn) {
-	if v == nil {
-		x.xxx_hidden_Operator = nil
-		return
-	}
-	x.xxx_hidden_Operator = &genericOIDC_Condition_In{v}
+	x.xxx_hidden_In = v
 }
 
 func (x *GenericOIDC_Condition) SetNotIn(v *GenericOIDC_ConditionNotIn) {
-	if v == nil {
-		x.xxx_hidden_Operator = nil
-		return
-	}
-	x.xxx_hidden_Operator = &genericOIDC_Condition_NotIn{v}
-}
-
-func (x *GenericOIDC_Condition) HasOperator() bool {
-	if x == nil {
-		return false
-	}
-	return x.xxx_hidden_Operator != nil
+	x.xxx_hidden_NotIn = v
 }
 
 func (x *GenericOIDC_Condition) HasEq() bool {
 	if x == nil {
 		return false
 	}
-	_, ok := x.xxx_hidden_Operator.(*genericOIDC_Condition_Eq)
-	return ok
+	return x.xxx_hidden_Eq != nil
 }
 
 func (x *GenericOIDC_Condition) HasNotEq() bool {
 	if x == nil {
 		return false
 	}
-	_, ok := x.xxx_hidden_Operator.(*genericOIDC_Condition_NotEq)
-	return ok
+	return x.xxx_hidden_NotEq != nil
 }
 
 func (x *GenericOIDC_Condition) HasIn() bool {
 	if x == nil {
 		return false
 	}
-	_, ok := x.xxx_hidden_Operator.(*genericOIDC_Condition_In)
-	return ok
+	return x.xxx_hidden_In != nil
 }
 
 func (x *GenericOIDC_Condition) HasNotIn() bool {
 	if x == nil {
 		return false
 	}
-	_, ok := x.xxx_hidden_Operator.(*genericOIDC_Condition_NotIn)
-	return ok
-}
-
-func (x *GenericOIDC_Condition) ClearOperator() {
-	x.xxx_hidden_Operator = nil
+	return x.xxx_hidden_NotIn != nil
 }
 
 func (x *GenericOIDC_Condition) ClearEq() {
-	if _, ok := x.xxx_hidden_Operator.(*genericOIDC_Condition_Eq); ok {
-		x.xxx_hidden_Operator = nil
-	}
+	x.xxx_hidden_Eq = nil
 }
 
 func (x *GenericOIDC_Condition) ClearNotEq() {
-	if _, ok := x.xxx_hidden_Operator.(*genericOIDC_Condition_NotEq); ok {
-		x.xxx_hidden_Operator = nil
-	}
+	x.xxx_hidden_NotEq = nil
 }
 
 func (x *GenericOIDC_Condition) ClearIn() {
-	if _, ok := x.xxx_hidden_Operator.(*genericOIDC_Condition_In); ok {
-		x.xxx_hidden_Operator = nil
-	}
+	x.xxx_hidden_In = nil
 }
 
 func (x *GenericOIDC_Condition) ClearNotIn() {
-	if _, ok := x.xxx_hidden_Operator.(*genericOIDC_Condition_NotIn); ok {
-		x.xxx_hidden_Operator = nil
-	}
-}
-
-const GenericOIDC_Condition_Operator_not_set_case case_GenericOIDC_Condition_Operator = 0
-const GenericOIDC_Condition_Eq_case case_GenericOIDC_Condition_Operator = 2
-const GenericOIDC_Condition_NotEq_case case_GenericOIDC_Condition_Operator = 3
-const GenericOIDC_Condition_In_case case_GenericOIDC_Condition_Operator = 4
-const GenericOIDC_Condition_NotIn_case case_GenericOIDC_Condition_Operator = 5
-
-func (x *GenericOIDC_Condition) WhichOperator() case_GenericOIDC_Condition_Operator {
-	if x == nil {
-		return GenericOIDC_Condition_Operator_not_set_case
-	}
-	switch x.xxx_hidden_Operator.(type) {
-	case *genericOIDC_Condition_Eq:
-		return GenericOIDC_Condition_Eq_case
-	case *genericOIDC_Condition_NotEq:
-		return GenericOIDC_Condition_NotEq_case
-	case *genericOIDC_Condition_In:
-		return GenericOIDC_Condition_In_case
-	case *genericOIDC_Condition_NotIn:
-		return GenericOIDC_Condition_NotIn_case
-	default:
-		return GenericOIDC_Condition_Operator_not_set_case
-	}
+	x.xxx_hidden_NotIn = nil
 }
 
 type GenericOIDC_Condition_builder struct {
 	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
 
+	// The name of the field this condition should check, separated by "." for
+	// nested fields.
 	Attribute string
-	// Fields of oneof xxx_hidden_Operator:
-	Eq    *GenericOIDC_ConditionEq
+	// An "equals" operator. Only one operator may be set within a condition.
+	Eq *GenericOIDC_ConditionEq
+	// A "not equals" operator. Only one operator may be set within a condition.
 	NotEq *GenericOIDC_ConditionNotEq
-	In    *GenericOIDC_ConditionIn
+	// An "in" operator. Only one operator may be set within a condition.
+	In *GenericOIDC_ConditionIn
+	// A "not in" operator. Only one operator may be set within a condition.
 	NotIn *GenericOIDC_ConditionNotIn
-	// -- end of xxx_hidden_Operator
 }
 
 func (b0 GenericOIDC_Condition_builder) Build() *GenericOIDC_Condition {
@@ -3908,58 +3853,12 @@ func (b0 GenericOIDC_Condition_builder) Build() *GenericOIDC_Condition {
 	b, x := &b0, m0
 	_, _ = b, x
 	x.xxx_hidden_Attribute = b.Attribute
-	if b.Eq != nil {
-		x.xxx_hidden_Operator = &genericOIDC_Condition_Eq{b.Eq}
-	}
-	if b.NotEq != nil {
-		x.xxx_hidden_Operator = &genericOIDC_Condition_NotEq{b.NotEq}
-	}
-	if b.In != nil {
-		x.xxx_hidden_Operator = &genericOIDC_Condition_In{b.In}
-	}
-	if b.NotIn != nil {
-		x.xxx_hidden_Operator = &genericOIDC_Condition_NotIn{b.NotIn}
-	}
+	x.xxx_hidden_Eq = b.Eq
+	x.xxx_hidden_NotEq = b.NotEq
+	x.xxx_hidden_In = b.In
+	x.xxx_hidden_NotIn = b.NotIn
 	return m0
 }
-
-type case_GenericOIDC_Condition_Operator protoreflect.FieldNumber
-
-func (x case_GenericOIDC_Condition_Operator) String() string {
-	md := file_teleport_scopes_joining_v1_token_proto_msgTypes[33].Descriptor()
-	if x == 0 {
-		return "not set"
-	}
-	return protoimpl.X.MessageFieldStringOf(md, protoreflect.FieldNumber(x))
-}
-
-type isGenericOIDC_Condition_Operator interface {
-	isGenericOIDC_Condition_Operator()
-}
-
-type genericOIDC_Condition_Eq struct {
-	Eq *GenericOIDC_ConditionEq `protobuf:"bytes,2,opt,name=eq,proto3,oneof"`
-}
-
-type genericOIDC_Condition_NotEq struct {
-	NotEq *GenericOIDC_ConditionNotEq `protobuf:"bytes,3,opt,name=not_eq,json=notEq,proto3,oneof"`
-}
-
-type genericOIDC_Condition_In struct {
-	In *GenericOIDC_ConditionIn `protobuf:"bytes,4,opt,name=in,proto3,oneof"`
-}
-
-type genericOIDC_Condition_NotIn struct {
-	NotIn *GenericOIDC_ConditionNotIn `protobuf:"bytes,5,opt,name=not_in,json=notIn,proto3,oneof"`
-}
-
-func (*genericOIDC_Condition_Eq) isGenericOIDC_Condition_Operator() {}
-
-func (*genericOIDC_Condition_NotEq) isGenericOIDC_Condition_Operator() {}
-
-func (*genericOIDC_Condition_In) isGenericOIDC_Condition_Operator() {}
-
-func (*genericOIDC_Condition_NotIn) isGenericOIDC_Condition_Operator() {}
 
 // An allow rule, containing either a predict expression or simple field
 // check.
@@ -4190,7 +4089,7 @@ const file_teleport_scopes_joining_v1_token_proto_rawDesc = "" +
 	"\x0erecovery_count\x18\x04 \x01(\rR\rrecoveryCount\x12F\n" +
 	"\x11last_recovered_at\x18\x05 \x01(\v2\x1a.google.protobuf.TimestampR\x0flastRecoveredAt\x12B\n" +
 	"\x0flast_rotated_at\x18\x06 \x01(\v2\x1a.google.protobuf.TimestampR\rlastRotatedAt\x12\"\n" +
-	"\rbound_host_id\x18\a \x01(\tR\vboundHostId\"\xc7\a\n" +
+	"\rbound_host_id\x18\a \x01(\tR\vboundHostId\"\xb3\a\n" +
 	"\vGenericOIDC\x12\x16\n" +
 	"\x06issuer\x18\x01 \x01(\tR\x06issuer\x12;\n" +
 	"\x1ainsecure_allow_http_issuer\x18\x02 \x01(\bR\x17insecureAllowHttpIssuer\x12\x1a\n" +
@@ -4207,15 +4106,13 @@ const file_teleport_scopes_joining_v1_token_proto_rawDesc = "" +
 	"\vConditionIn\x12\x16\n" +
 	"\x06values\x18\x01 \x03(\tR\x06values\x1a(\n" +
 	"\x0eConditionNotIn\x12\x16\n" +
-	"\x06values\x18\x01 \x03(\tR\x06values\x1a\xe5\x02\n" +
+	"\x06values\x18\x01 \x03(\tR\x06values\x1a\xd1\x02\n" +
 	"\tCondition\x12\x1c\n" +
-	"\tattribute\x18\x01 \x01(\tR\tattribute\x12E\n" +
-	"\x02eq\x18\x02 \x01(\v23.teleport.scopes.joining.v1.GenericOIDC.ConditionEqH\x00R\x02eq\x12O\n" +
-	"\x06not_eq\x18\x03 \x01(\v26.teleport.scopes.joining.v1.GenericOIDC.ConditionNotEqH\x00R\x05notEq\x12E\n" +
-	"\x02in\x18\x04 \x01(\v23.teleport.scopes.joining.v1.GenericOIDC.ConditionInH\x00R\x02in\x12O\n" +
-	"\x06not_in\x18\x05 \x01(\v26.teleport.scopes.joining.v1.GenericOIDC.ConditionNotInH\x00R\x05notInB\n" +
-	"\n" +
-	"\boperator\x1ay\n" +
+	"\tattribute\x18\x01 \x01(\tR\tattribute\x12C\n" +
+	"\x02eq\x18\x02 \x01(\v23.teleport.scopes.joining.v1.GenericOIDC.ConditionEqR\x02eq\x12M\n" +
+	"\x06not_eq\x18\x03 \x01(\v26.teleport.scopes.joining.v1.GenericOIDC.ConditionNotEqR\x05notEq\x12C\n" +
+	"\x02in\x18\x04 \x01(\v23.teleport.scopes.joining.v1.GenericOIDC.ConditionInR\x02in\x12M\n" +
+	"\x06not_in\x18\x05 \x01(\v26.teleport.scopes.joining.v1.GenericOIDC.ConditionNotInR\x05notIn\x1ay\n" +
 	"\x04Rule\x12Q\n" +
 	"\n" +
 	"conditions\x18\x01 \x03(\v21.teleport.scopes.joining.v1.GenericOIDC.ConditionR\n" +
@@ -4324,12 +4221,6 @@ func file_teleport_scopes_joining_v1_token_proto_init() {
 	file_teleport_scopes_joining_v1_token_proto_msgTypes[4].OneofWrappers = []any{
 		(*usageStatus_SingleUse)(nil),
 		(*usageStatus_BoundKeypair)(nil),
-	}
-	file_teleport_scopes_joining_v1_token_proto_msgTypes[33].OneofWrappers = []any{
-		(*genericOIDC_Condition_Eq)(nil),
-		(*genericOIDC_Condition_NotEq)(nil),
-		(*genericOIDC_Condition_In)(nil),
-		(*genericOIDC_Condition_NotIn)(nil),
 	}
 	type x struct{}
 	out := protoimpl.TypeBuilder{

--- a/api/gen/proto/go/teleport/scopes/joining/v1/token_protoopaque.pb.go
+++ b/api/gen/proto/go/teleport/scopes/joining/v1/token_protoopaque.pb.go
@@ -26,6 +26,7 @@ import (
 	v1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
+	structpb "google.golang.org/protobuf/types/known/structpb"
 	timestamppb "google.golang.org/protobuf/types/known/timestamppb"
 	reflect "reflect"
 	unsafe "unsafe"
@@ -239,6 +240,7 @@ type ScopedTokenSpec struct {
 	xxx_hidden_Kubernetes      *Kubernetes            `protobuf:"bytes,11,opt,name=kubernetes,proto3"`
 	xxx_hidden_BoundKeypair    *BoundKeypairSpec      `protobuf:"bytes,12,opt,name=bound_keypair,json=boundKeypair,proto3"`
 	xxx_hidden_Bot             string                 `protobuf:"bytes,15,opt,name=bot,proto3"`
+	xxx_hidden_GenericOidc     *GenericOIDC           `protobuf:"bytes,16,opt,name=generic_oidc,json=genericOidc,proto3"`
 	unknownFields              protoimpl.UnknownFields
 	sizeCache                  protoimpl.SizeCache
 }
@@ -359,6 +361,13 @@ func (x *ScopedTokenSpec) GetBot() string {
 	return ""
 }
 
+func (x *ScopedTokenSpec) GetGenericOidc() *GenericOIDC {
+	if x != nil {
+		return x.xxx_hidden_GenericOidc
+	}
+	return nil
+}
+
 func (x *ScopedTokenSpec) SetAssignedScope(v string) {
 	x.xxx_hidden_AssignedScope = v
 }
@@ -409,6 +418,10 @@ func (x *ScopedTokenSpec) SetBoundKeypair(v *BoundKeypairSpec) {
 
 func (x *ScopedTokenSpec) SetBot(v string) {
 	x.xxx_hidden_Bot = v
+}
+
+func (x *ScopedTokenSpec) SetGenericOidc(v *GenericOIDC) {
+	x.xxx_hidden_GenericOidc = v
 }
 
 func (x *ScopedTokenSpec) HasImmutableLabels() bool {
@@ -467,6 +480,13 @@ func (x *ScopedTokenSpec) HasBoundKeypair() bool {
 	return x.xxx_hidden_BoundKeypair != nil
 }
 
+func (x *ScopedTokenSpec) HasGenericOidc() bool {
+	if x == nil {
+		return false
+	}
+	return x.xxx_hidden_GenericOidc != nil
+}
+
 func (x *ScopedTokenSpec) ClearImmutableLabels() {
 	x.xxx_hidden_ImmutableLabels = nil
 }
@@ -497,6 +517,10 @@ func (x *ScopedTokenSpec) ClearKubernetes() {
 
 func (x *ScopedTokenSpec) ClearBoundKeypair() {
 	x.xxx_hidden_BoundKeypair = nil
+}
+
+func (x *ScopedTokenSpec) ClearGenericOidc() {
+	x.xxx_hidden_GenericOidc = nil
 }
 
 type ScopedTokenSpec_builder struct {
@@ -541,6 +565,8 @@ type ScopedTokenSpec_builder struct {
 	//
 	// Mutually exclusive with assigned_scope.
 	Bot string
+	// Configuration specific to the "generic_oidc" join method.
+	GenericOidc *GenericOIDC
 }
 
 func (b0 ScopedTokenSpec_builder) Build() *ScopedTokenSpec {
@@ -560,6 +586,7 @@ func (b0 ScopedTokenSpec_builder) Build() *ScopedTokenSpec {
 	x.xxx_hidden_Kubernetes = b.Kubernetes
 	x.xxx_hidden_BoundKeypair = b.BoundKeypair
 	x.xxx_hidden_Bot = b.Bot
+	x.xxx_hidden_GenericOidc = b.GenericOidc
 	return m0
 }
 
@@ -2180,6 +2207,212 @@ func (b0 BoundKeypairStatus_builder) Build() *BoundKeypairStatus {
 	return m0
 }
 
+// Configuration for `generic_oidc`-type tokens.
+type GenericOIDC struct {
+	state                              protoimpl.MessageState `protogen:"opaque.v1"`
+	xxx_hidden_Issuer                  string                 `protobuf:"bytes,1,opt,name=issuer,proto3"`
+	xxx_hidden_InsecureAllowHttpIssuer bool                   `protobuf:"varint,2,opt,name=insecure_allow_http_issuer,json=insecureAllowHttpIssuer,proto3"`
+	xxx_hidden_Audience                string                 `protobuf:"bytes,3,opt,name=audience,proto3"`
+	xxx_hidden_StaticJwks              string                 `protobuf:"bytes,4,opt,name=static_jwks,json=staticJwks,proto3"`
+	xxx_hidden_TlsCa                   string                 `protobuf:"bytes,5,opt,name=tls_ca,json=tlsCa,proto3"`
+	xxx_hidden_MustMatchFields         *structpb.Struct       `protobuf:"bytes,6,opt,name=must_match_fields,json=mustMatchFields,proto3"`
+	xxx_hidden_AllowAny                *[]*GenericOIDC_Rule   `protobuf:"bytes,7,rep,name=allow_any,json=allowAny,proto3"`
+	unknownFields                      protoimpl.UnknownFields
+	sizeCache                          protoimpl.SizeCache
+}
+
+func (x *GenericOIDC) Reset() {
+	*x = GenericOIDC{}
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[17]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GenericOIDC) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GenericOIDC) ProtoMessage() {}
+
+func (x *GenericOIDC) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[17]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+func (x *GenericOIDC) GetIssuer() string {
+	if x != nil {
+		return x.xxx_hidden_Issuer
+	}
+	return ""
+}
+
+func (x *GenericOIDC) GetInsecureAllowHttpIssuer() bool {
+	if x != nil {
+		return x.xxx_hidden_InsecureAllowHttpIssuer
+	}
+	return false
+}
+
+func (x *GenericOIDC) GetAudience() string {
+	if x != nil {
+		return x.xxx_hidden_Audience
+	}
+	return ""
+}
+
+func (x *GenericOIDC) GetStaticJwks() string {
+	if x != nil {
+		return x.xxx_hidden_StaticJwks
+	}
+	return ""
+}
+
+func (x *GenericOIDC) GetTlsCa() string {
+	if x != nil {
+		return x.xxx_hidden_TlsCa
+	}
+	return ""
+}
+
+func (x *GenericOIDC) GetMustMatchFields() *structpb.Struct {
+	if x != nil {
+		return x.xxx_hidden_MustMatchFields
+	}
+	return nil
+}
+
+func (x *GenericOIDC) GetAllowAny() []*GenericOIDC_Rule {
+	if x != nil {
+		if x.xxx_hidden_AllowAny != nil {
+			return *x.xxx_hidden_AllowAny
+		}
+	}
+	return nil
+}
+
+func (x *GenericOIDC) SetIssuer(v string) {
+	x.xxx_hidden_Issuer = v
+}
+
+func (x *GenericOIDC) SetInsecureAllowHttpIssuer(v bool) {
+	x.xxx_hidden_InsecureAllowHttpIssuer = v
+}
+
+func (x *GenericOIDC) SetAudience(v string) {
+	x.xxx_hidden_Audience = v
+}
+
+func (x *GenericOIDC) SetStaticJwks(v string) {
+	x.xxx_hidden_StaticJwks = v
+}
+
+func (x *GenericOIDC) SetTlsCa(v string) {
+	x.xxx_hidden_TlsCa = v
+}
+
+func (x *GenericOIDC) SetMustMatchFields(v *structpb.Struct) {
+	x.xxx_hidden_MustMatchFields = v
+}
+
+func (x *GenericOIDC) SetAllowAny(v []*GenericOIDC_Rule) {
+	x.xxx_hidden_AllowAny = &v
+}
+
+func (x *GenericOIDC) HasMustMatchFields() bool {
+	if x == nil {
+		return false
+	}
+	return x.xxx_hidden_MustMatchFields != nil
+}
+
+func (x *GenericOIDC) ClearMustMatchFields() {
+	x.xxx_hidden_MustMatchFields = nil
+}
+
+type GenericOIDC_builder struct {
+	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
+
+	// The expected `iss` value as written in the JWT you wish to trust. Unless
+	// `static_jwks` is configured, this issuer must be accessible over HTTPS to
+	// the Teleport cluster and must serve valid OIDC metadata, including
+	// discovery configuration and JWKS keys.
+	Issuer string
+	// If set, disables the requirement that the issuer must use HTTPS.
+	InsecureAllowHttpIssuer bool
+	// The expected JWT audience. If unset, this value will be set to the name of
+	// this Teleport cluster (e.g. example.teleport.sh). Where possible, this
+	// value should be unique to the Teleport cluster; issuing JWTs using the
+	// cluster as the audience is preferred. On providers where this is not
+	// possible, you can specify their server-defined value in this field. This
+	// value must match the audience in issued JWTs for join attempts to succeed.
+	Audience string
+	// An optional static JWKS value that can be used to specify JWKS keys when
+	// either OIDC discovery is either not supported by the provider or the
+	// discovery configuration is not accessible to Teleport. When set,
+	// configuration and JWKS keys will not be fetched from the URL contained in
+	// `issuer` and JWTs will be validated using the key set specified here.
+	StaticJwks string
+	// A TLS CA certificate that should be used to verify requests for OIDC
+	// metadata from the issuer instead of Teleport's CA store, useful if the
+	// issuer is not public or otherwise uses a self-signed certificate. If unset,
+	// the standard web PKI root certificates will be used to verify the
+	// connection to the issuer when fetching OIDC metadata. Note that this value
+	// only applies to requests using this token, and will be used instead of and
+	// not in addition to the system CA store, and will need to be updated
+	// manually if the remote CA is updated.
+	TlsCa string
+	// "Must match" fields perform simple comparison matches using "AND"
+	// semantics. Rules are specified by mirroring the structure of the JWT, using
+	// values that are expected to be equal to those on the incoming token. These
+	// field matching rules can only be used to compare simple values: strings,
+	// numbers, booleans, and nested fields. Complex values, including lists, will
+	// need to use `allow_any` expression rules instead.
+	//
+	// If any field match rules are specified, all must be equal to corresponding
+	// JWT fields for the join attempt to succeed. If complex rules are specified
+	// in `allow_any`, those are evaluated after `must_match_fields`. If
+	// `must_match_fields` is not specified or is empty, only rules in `allow_any`
+	// are evaluated.
+	//
+	// These rules can be used as "global" rules that apply to all join attempts.
+	// For example, you can use these to ensure all attempts originate from your
+	// organization, then use `allow_any` rules to allow individual repositories,
+	// pipelines, or workspaces.
+	//
+	// Note that at least one rule, either in `must_match_fields` or `allow_any`,
+	// must be specified for any join attempts to succeed.
+	MustMatchFields *structpb.Struct
+	// Complex rules evaluated using "OR" semantics. If any rules are specified,
+	// at least one rule must evaluate to `true` for the join attempt/ to be
+	// allowed. These rules are evaluated after `must_match_fields`, if any field
+	// matchers are specified in that block.
+	//
+	// Note that at least one rule, either in `must_match_fields` or `allow_any`,
+	// must be specified for any join attempts to succeed.
+	AllowAny []*GenericOIDC_Rule
+}
+
+func (b0 GenericOIDC_builder) Build() *GenericOIDC {
+	m0 := &GenericOIDC{}
+	b, x := &b0, m0
+	_, _ = b, x
+	x.xxx_hidden_Issuer = b.Issuer
+	x.xxx_hidden_InsecureAllowHttpIssuer = b.InsecureAllowHttpIssuer
+	x.xxx_hidden_Audience = b.Audience
+	x.xxx_hidden_StaticJwks = b.StaticJwks
+	x.xxx_hidden_TlsCa = b.TlsCa
+	x.xxx_hidden_MustMatchFields = b.MustMatchFields
+	x.xxx_hidden_AllowAny = &b.AllowAny
+	return m0
+}
+
 // A rule that a joining node must match in order to use the associated token
 // with AWS join methods.
 type AWS_Rule struct {
@@ -2195,7 +2428,7 @@ type AWS_Rule struct {
 
 func (x *AWS_Rule) Reset() {
 	*x = AWS_Rule{}
-	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[18]
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[19]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2207,7 +2440,7 @@ func (x *AWS_Rule) String() string {
 func (*AWS_Rule) ProtoMessage() {}
 
 func (x *AWS_Rule) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[18]
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[19]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2317,7 +2550,7 @@ type GCP_Rule struct {
 
 func (x *GCP_Rule) Reset() {
 	*x = GCP_Rule{}
-	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[19]
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[20]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2329,7 +2562,7 @@ func (x *GCP_Rule) String() string {
 func (*GCP_Rule) ProtoMessage() {}
 
 func (x *GCP_Rule) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[19]
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[20]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2407,7 +2640,7 @@ type Azure_Rule struct {
 
 func (x *Azure_Rule) Reset() {
 	*x = Azure_Rule{}
-	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[20]
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[21]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2419,7 +2652,7 @@ func (x *Azure_Rule) String() string {
 func (*Azure_Rule) ProtoMessage() {}
 
 func (x *Azure_Rule) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[20]
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[21]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2502,7 +2735,7 @@ type AzureDevops_Rule struct {
 
 func (x *AzureDevops_Rule) Reset() {
 	*x = AzureDevops_Rule{}
-	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[21]
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[22]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2514,7 +2747,7 @@ func (x *AzureDevops_Rule) String() string {
 func (*AzureDevops_Rule) ProtoMessage() {}
 
 func (x *AzureDevops_Rule) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[21]
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[22]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2679,7 +2912,7 @@ type Oracle_Rule struct {
 
 func (x *Oracle_Rule) Reset() {
 	*x = Oracle_Rule{}
-	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[22]
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[23]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2691,7 +2924,7 @@ func (x *Oracle_Rule) String() string {
 func (*Oracle_Rule) ProtoMessage() {}
 
 func (x *Oracle_Rule) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[22]
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[23]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2783,7 +3016,7 @@ type Kubernetes_StaticJWKSConfig struct {
 
 func (x *Kubernetes_StaticJWKSConfig) Reset() {
 	*x = Kubernetes_StaticJWKSConfig{}
-	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[23]
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[24]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2795,7 +3028,7 @@ func (x *Kubernetes_StaticJWKSConfig) String() string {
 func (*Kubernetes_StaticJWKSConfig) ProtoMessage() {}
 
 func (x *Kubernetes_StaticJWKSConfig) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[23]
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[24]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2844,7 +3077,7 @@ type Kubernetes_OIDCConfig struct {
 
 func (x *Kubernetes_OIDCConfig) Reset() {
 	*x = Kubernetes_OIDCConfig{}
-	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[24]
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[25]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2856,7 +3089,7 @@ func (x *Kubernetes_OIDCConfig) String() string {
 func (*Kubernetes_OIDCConfig) ProtoMessage() {}
 
 func (x *Kubernetes_OIDCConfig) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[24]
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[25]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2925,7 +3158,7 @@ type Kubernetes_Rule struct {
 
 func (x *Kubernetes_Rule) Reset() {
 	*x = Kubernetes_Rule{}
-	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[25]
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[26]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2937,7 +3170,7 @@ func (x *Kubernetes_Rule) String() string {
 func (*Kubernetes_Rule) ProtoMessage() {}
 
 func (x *Kubernetes_Rule) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[25]
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[26]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3022,7 +3255,7 @@ type BoundKeypairSpec_OnboardingSpec struct {
 
 func (x *BoundKeypairSpec_OnboardingSpec) Reset() {
 	*x = BoundKeypairSpec_OnboardingSpec{}
-	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[26]
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[27]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3034,7 +3267,7 @@ func (x *BoundKeypairSpec_OnboardingSpec) String() string {
 func (*BoundKeypairSpec_OnboardingSpec) ProtoMessage() {}
 
 func (x *BoundKeypairSpec_OnboardingSpec) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[26]
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[27]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3136,7 +3369,7 @@ type BoundKeypairSpec_RecoverySpec struct {
 
 func (x *BoundKeypairSpec_RecoverySpec) Reset() {
 	*x = BoundKeypairSpec_RecoverySpec{}
-	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[27]
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[28]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3148,7 +3381,7 @@ func (x *BoundKeypairSpec_RecoverySpec) String() string {
 func (*BoundKeypairSpec_RecoverySpec) ProtoMessage() {}
 
 func (x *BoundKeypairSpec_RecoverySpec) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[27]
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[28]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3218,11 +3451,602 @@ func (b0 BoundKeypairSpec_RecoverySpec_builder) Build() *BoundKeypairSpec_Recove
 	return m0
 }
 
+// The attribute casted to a string must be equal to the value.
+type GenericOIDC_ConditionEq struct {
+	state            protoimpl.MessageState `protogen:"opaque.v1"`
+	xxx_hidden_Value string                 `protobuf:"bytes,1,opt,name=value,proto3"`
+	unknownFields    protoimpl.UnknownFields
+	sizeCache        protoimpl.SizeCache
+}
+
+func (x *GenericOIDC_ConditionEq) Reset() {
+	*x = GenericOIDC_ConditionEq{}
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[29]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GenericOIDC_ConditionEq) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GenericOIDC_ConditionEq) ProtoMessage() {}
+
+func (x *GenericOIDC_ConditionEq) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[29]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+func (x *GenericOIDC_ConditionEq) GetValue() string {
+	if x != nil {
+		return x.xxx_hidden_Value
+	}
+	return ""
+}
+
+func (x *GenericOIDC_ConditionEq) SetValue(v string) {
+	x.xxx_hidden_Value = v
+}
+
+type GenericOIDC_ConditionEq_builder struct {
+	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
+
+	// The value to compare the attribute against.
+	Value string
+}
+
+func (b0 GenericOIDC_ConditionEq_builder) Build() *GenericOIDC_ConditionEq {
+	m0 := &GenericOIDC_ConditionEq{}
+	b, x := &b0, m0
+	_, _ = b, x
+	x.xxx_hidden_Value = b.Value
+	return m0
+}
+
+// The attribute casted to a string must not be equal to the value.
+type GenericOIDC_ConditionNotEq struct {
+	state            protoimpl.MessageState `protogen:"opaque.v1"`
+	xxx_hidden_Value string                 `protobuf:"bytes,1,opt,name=value,proto3"`
+	unknownFields    protoimpl.UnknownFields
+	sizeCache        protoimpl.SizeCache
+}
+
+func (x *GenericOIDC_ConditionNotEq) Reset() {
+	*x = GenericOIDC_ConditionNotEq{}
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[30]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GenericOIDC_ConditionNotEq) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GenericOIDC_ConditionNotEq) ProtoMessage() {}
+
+func (x *GenericOIDC_ConditionNotEq) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[30]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+func (x *GenericOIDC_ConditionNotEq) GetValue() string {
+	if x != nil {
+		return x.xxx_hidden_Value
+	}
+	return ""
+}
+
+func (x *GenericOIDC_ConditionNotEq) SetValue(v string) {
+	x.xxx_hidden_Value = v
+}
+
+type GenericOIDC_ConditionNotEq_builder struct {
+	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
+
+	// The value to compare the attribute against.
+	Value string
+}
+
+func (b0 GenericOIDC_ConditionNotEq_builder) Build() *GenericOIDC_ConditionNotEq {
+	m0 := &GenericOIDC_ConditionNotEq{}
+	b, x := &b0, m0
+	_, _ = b, x
+	x.xxx_hidden_Value = b.Value
+	return m0
+}
+
+// The attribute casted to a string must be in the list of values.
+type GenericOIDC_ConditionIn struct {
+	state             protoimpl.MessageState `protogen:"opaque.v1"`
+	xxx_hidden_Values []string               `protobuf:"bytes,1,rep,name=values,proto3"`
+	unknownFields     protoimpl.UnknownFields
+	sizeCache         protoimpl.SizeCache
+}
+
+func (x *GenericOIDC_ConditionIn) Reset() {
+	*x = GenericOIDC_ConditionIn{}
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[31]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GenericOIDC_ConditionIn) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GenericOIDC_ConditionIn) ProtoMessage() {}
+
+func (x *GenericOIDC_ConditionIn) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[31]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+func (x *GenericOIDC_ConditionIn) GetValues() []string {
+	if x != nil {
+		return x.xxx_hidden_Values
+	}
+	return nil
+}
+
+func (x *GenericOIDC_ConditionIn) SetValues(v []string) {
+	x.xxx_hidden_Values = v
+}
+
+type GenericOIDC_ConditionIn_builder struct {
+	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
+
+	// The list of values to compare the attribute against.
+	Values []string
+}
+
+func (b0 GenericOIDC_ConditionIn_builder) Build() *GenericOIDC_ConditionIn {
+	m0 := &GenericOIDC_ConditionIn{}
+	b, x := &b0, m0
+	_, _ = b, x
+	x.xxx_hidden_Values = b.Values
+	return m0
+}
+
+// The attribute casted to a string must not be in the list of values.
+type GenericOIDC_ConditionNotIn struct {
+	state             protoimpl.MessageState `protogen:"opaque.v1"`
+	xxx_hidden_Values []string               `protobuf:"bytes,1,rep,name=values,proto3"`
+	unknownFields     protoimpl.UnknownFields
+	sizeCache         protoimpl.SizeCache
+}
+
+func (x *GenericOIDC_ConditionNotIn) Reset() {
+	*x = GenericOIDC_ConditionNotIn{}
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[32]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GenericOIDC_ConditionNotIn) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GenericOIDC_ConditionNotIn) ProtoMessage() {}
+
+func (x *GenericOIDC_ConditionNotIn) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[32]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+func (x *GenericOIDC_ConditionNotIn) GetValues() []string {
+	if x != nil {
+		return x.xxx_hidden_Values
+	}
+	return nil
+}
+
+func (x *GenericOIDC_ConditionNotIn) SetValues(v []string) {
+	x.xxx_hidden_Values = v
+}
+
+type GenericOIDC_ConditionNotIn_builder struct {
+	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
+
+	// The list of values to compare the attribute against.
+	Values []string
+}
+
+func (b0 GenericOIDC_ConditionNotIn_builder) Build() *GenericOIDC_ConditionNotIn {
+	m0 := &GenericOIDC_ConditionNotIn{}
+	b, x := &b0, m0
+	_, _ = b, x
+	x.xxx_hidden_Values = b.Values
+	return m0
+}
+
+// An allow rule condition for simple checks against a specific field.
+type GenericOIDC_Condition struct {
+	state                protoimpl.MessageState           `protogen:"opaque.v1"`
+	xxx_hidden_Attribute string                           `protobuf:"bytes,1,opt,name=attribute,proto3"`
+	xxx_hidden_Operator  isGenericOIDC_Condition_Operator `protobuf_oneof:"operator"`
+	unknownFields        protoimpl.UnknownFields
+	sizeCache            protoimpl.SizeCache
+}
+
+func (x *GenericOIDC_Condition) Reset() {
+	*x = GenericOIDC_Condition{}
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[33]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GenericOIDC_Condition) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GenericOIDC_Condition) ProtoMessage() {}
+
+func (x *GenericOIDC_Condition) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[33]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+func (x *GenericOIDC_Condition) GetAttribute() string {
+	if x != nil {
+		return x.xxx_hidden_Attribute
+	}
+	return ""
+}
+
+func (x *GenericOIDC_Condition) GetEq() *GenericOIDC_ConditionEq {
+	if x != nil {
+		if x, ok := x.xxx_hidden_Operator.(*genericOIDC_Condition_Eq); ok {
+			return x.Eq
+		}
+	}
+	return nil
+}
+
+func (x *GenericOIDC_Condition) GetNotEq() *GenericOIDC_ConditionNotEq {
+	if x != nil {
+		if x, ok := x.xxx_hidden_Operator.(*genericOIDC_Condition_NotEq); ok {
+			return x.NotEq
+		}
+	}
+	return nil
+}
+
+func (x *GenericOIDC_Condition) GetIn() *GenericOIDC_ConditionIn {
+	if x != nil {
+		if x, ok := x.xxx_hidden_Operator.(*genericOIDC_Condition_In); ok {
+			return x.In
+		}
+	}
+	return nil
+}
+
+func (x *GenericOIDC_Condition) GetNotIn() *GenericOIDC_ConditionNotIn {
+	if x != nil {
+		if x, ok := x.xxx_hidden_Operator.(*genericOIDC_Condition_NotIn); ok {
+			return x.NotIn
+		}
+	}
+	return nil
+}
+
+func (x *GenericOIDC_Condition) SetAttribute(v string) {
+	x.xxx_hidden_Attribute = v
+}
+
+func (x *GenericOIDC_Condition) SetEq(v *GenericOIDC_ConditionEq) {
+	if v == nil {
+		x.xxx_hidden_Operator = nil
+		return
+	}
+	x.xxx_hidden_Operator = &genericOIDC_Condition_Eq{v}
+}
+
+func (x *GenericOIDC_Condition) SetNotEq(v *GenericOIDC_ConditionNotEq) {
+	if v == nil {
+		x.xxx_hidden_Operator = nil
+		return
+	}
+	x.xxx_hidden_Operator = &genericOIDC_Condition_NotEq{v}
+}
+
+func (x *GenericOIDC_Condition) SetIn(v *GenericOIDC_ConditionIn) {
+	if v == nil {
+		x.xxx_hidden_Operator = nil
+		return
+	}
+	x.xxx_hidden_Operator = &genericOIDC_Condition_In{v}
+}
+
+func (x *GenericOIDC_Condition) SetNotIn(v *GenericOIDC_ConditionNotIn) {
+	if v == nil {
+		x.xxx_hidden_Operator = nil
+		return
+	}
+	x.xxx_hidden_Operator = &genericOIDC_Condition_NotIn{v}
+}
+
+func (x *GenericOIDC_Condition) HasOperator() bool {
+	if x == nil {
+		return false
+	}
+	return x.xxx_hidden_Operator != nil
+}
+
+func (x *GenericOIDC_Condition) HasEq() bool {
+	if x == nil {
+		return false
+	}
+	_, ok := x.xxx_hidden_Operator.(*genericOIDC_Condition_Eq)
+	return ok
+}
+
+func (x *GenericOIDC_Condition) HasNotEq() bool {
+	if x == nil {
+		return false
+	}
+	_, ok := x.xxx_hidden_Operator.(*genericOIDC_Condition_NotEq)
+	return ok
+}
+
+func (x *GenericOIDC_Condition) HasIn() bool {
+	if x == nil {
+		return false
+	}
+	_, ok := x.xxx_hidden_Operator.(*genericOIDC_Condition_In)
+	return ok
+}
+
+func (x *GenericOIDC_Condition) HasNotIn() bool {
+	if x == nil {
+		return false
+	}
+	_, ok := x.xxx_hidden_Operator.(*genericOIDC_Condition_NotIn)
+	return ok
+}
+
+func (x *GenericOIDC_Condition) ClearOperator() {
+	x.xxx_hidden_Operator = nil
+}
+
+func (x *GenericOIDC_Condition) ClearEq() {
+	if _, ok := x.xxx_hidden_Operator.(*genericOIDC_Condition_Eq); ok {
+		x.xxx_hidden_Operator = nil
+	}
+}
+
+func (x *GenericOIDC_Condition) ClearNotEq() {
+	if _, ok := x.xxx_hidden_Operator.(*genericOIDC_Condition_NotEq); ok {
+		x.xxx_hidden_Operator = nil
+	}
+}
+
+func (x *GenericOIDC_Condition) ClearIn() {
+	if _, ok := x.xxx_hidden_Operator.(*genericOIDC_Condition_In); ok {
+		x.xxx_hidden_Operator = nil
+	}
+}
+
+func (x *GenericOIDC_Condition) ClearNotIn() {
+	if _, ok := x.xxx_hidden_Operator.(*genericOIDC_Condition_NotIn); ok {
+		x.xxx_hidden_Operator = nil
+	}
+}
+
+const GenericOIDC_Condition_Operator_not_set_case case_GenericOIDC_Condition_Operator = 0
+const GenericOIDC_Condition_Eq_case case_GenericOIDC_Condition_Operator = 2
+const GenericOIDC_Condition_NotEq_case case_GenericOIDC_Condition_Operator = 3
+const GenericOIDC_Condition_In_case case_GenericOIDC_Condition_Operator = 4
+const GenericOIDC_Condition_NotIn_case case_GenericOIDC_Condition_Operator = 5
+
+func (x *GenericOIDC_Condition) WhichOperator() case_GenericOIDC_Condition_Operator {
+	if x == nil {
+		return GenericOIDC_Condition_Operator_not_set_case
+	}
+	switch x.xxx_hidden_Operator.(type) {
+	case *genericOIDC_Condition_Eq:
+		return GenericOIDC_Condition_Eq_case
+	case *genericOIDC_Condition_NotEq:
+		return GenericOIDC_Condition_NotEq_case
+	case *genericOIDC_Condition_In:
+		return GenericOIDC_Condition_In_case
+	case *genericOIDC_Condition_NotIn:
+		return GenericOIDC_Condition_NotIn_case
+	default:
+		return GenericOIDC_Condition_Operator_not_set_case
+	}
+}
+
+type GenericOIDC_Condition_builder struct {
+	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
+
+	Attribute string
+	// Fields of oneof xxx_hidden_Operator:
+	Eq    *GenericOIDC_ConditionEq
+	NotEq *GenericOIDC_ConditionNotEq
+	In    *GenericOIDC_ConditionIn
+	NotIn *GenericOIDC_ConditionNotIn
+	// -- end of xxx_hidden_Operator
+}
+
+func (b0 GenericOIDC_Condition_builder) Build() *GenericOIDC_Condition {
+	m0 := &GenericOIDC_Condition{}
+	b, x := &b0, m0
+	_, _ = b, x
+	x.xxx_hidden_Attribute = b.Attribute
+	if b.Eq != nil {
+		x.xxx_hidden_Operator = &genericOIDC_Condition_Eq{b.Eq}
+	}
+	if b.NotEq != nil {
+		x.xxx_hidden_Operator = &genericOIDC_Condition_NotEq{b.NotEq}
+	}
+	if b.In != nil {
+		x.xxx_hidden_Operator = &genericOIDC_Condition_In{b.In}
+	}
+	if b.NotIn != nil {
+		x.xxx_hidden_Operator = &genericOIDC_Condition_NotIn{b.NotIn}
+	}
+	return m0
+}
+
+type case_GenericOIDC_Condition_Operator protoreflect.FieldNumber
+
+func (x case_GenericOIDC_Condition_Operator) String() string {
+	md := file_teleport_scopes_joining_v1_token_proto_msgTypes[33].Descriptor()
+	if x == 0 {
+		return "not set"
+	}
+	return protoimpl.X.MessageFieldStringOf(md, protoreflect.FieldNumber(x))
+}
+
+type isGenericOIDC_Condition_Operator interface {
+	isGenericOIDC_Condition_Operator()
+}
+
+type genericOIDC_Condition_Eq struct {
+	Eq *GenericOIDC_ConditionEq `protobuf:"bytes,2,opt,name=eq,proto3,oneof"`
+}
+
+type genericOIDC_Condition_NotEq struct {
+	NotEq *GenericOIDC_ConditionNotEq `protobuf:"bytes,3,opt,name=not_eq,json=notEq,proto3,oneof"`
+}
+
+type genericOIDC_Condition_In struct {
+	In *GenericOIDC_ConditionIn `protobuf:"bytes,4,opt,name=in,proto3,oneof"`
+}
+
+type genericOIDC_Condition_NotIn struct {
+	NotIn *GenericOIDC_ConditionNotIn `protobuf:"bytes,5,opt,name=not_in,json=notIn,proto3,oneof"`
+}
+
+func (*genericOIDC_Condition_Eq) isGenericOIDC_Condition_Operator() {}
+
+func (*genericOIDC_Condition_NotEq) isGenericOIDC_Condition_Operator() {}
+
+func (*genericOIDC_Condition_In) isGenericOIDC_Condition_Operator() {}
+
+func (*genericOIDC_Condition_NotIn) isGenericOIDC_Condition_Operator() {}
+
+// An allow rule, containing either a predict expression or simple field
+// check.
+type GenericOIDC_Rule struct {
+	state                 protoimpl.MessageState    `protogen:"opaque.v1"`
+	xxx_hidden_Conditions *[]*GenericOIDC_Condition `protobuf:"bytes,1,rep,name=conditions,proto3"`
+	xxx_hidden_Expression string                    `protobuf:"bytes,2,opt,name=expression,proto3"`
+	unknownFields         protoimpl.UnknownFields
+	sizeCache             protoimpl.SizeCache
+}
+
+func (x *GenericOIDC_Rule) Reset() {
+	*x = GenericOIDC_Rule{}
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[34]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GenericOIDC_Rule) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GenericOIDC_Rule) ProtoMessage() {}
+
+func (x *GenericOIDC_Rule) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[34]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+func (x *GenericOIDC_Rule) GetConditions() []*GenericOIDC_Condition {
+	if x != nil {
+		if x.xxx_hidden_Conditions != nil {
+			return *x.xxx_hidden_Conditions
+		}
+	}
+	return nil
+}
+
+func (x *GenericOIDC_Rule) GetExpression() string {
+	if x != nil {
+		return x.xxx_hidden_Expression
+	}
+	return ""
+}
+
+func (x *GenericOIDC_Rule) SetConditions(v []*GenericOIDC_Condition) {
+	x.xxx_hidden_Conditions = &v
+}
+
+func (x *GenericOIDC_Rule) SetExpression(v string) {
+	x.xxx_hidden_Expression = v
+}
+
+type GenericOIDC_Rule_builder struct {
+	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
+
+	// Conditions are simple eq/not_eq/in/not_in conditions that check
+	// individual fields. All conditions must be satisfied for a join attempt to
+	// be allowed. Mutually exclusive with `expression`.
+	Conditions []*GenericOIDC_Condition
+	// A predicate expression that must evaluate to `true` for the join attempt
+	// to be allowed. It is mutually exclusive with `conditions`.
+	// TODO: Include name of variable available to the expr in docs
+	Expression string
+}
+
+func (b0 GenericOIDC_Rule_builder) Build() *GenericOIDC_Rule {
+	m0 := &GenericOIDC_Rule{}
+	b, x := &b0, m0
+	_, _ = b, x
+	x.xxx_hidden_Conditions = &b.Conditions
+	x.xxx_hidden_Expression = b.Expression
+	return m0
+}
+
 var File_teleport_scopes_joining_v1_token_proto protoreflect.FileDescriptor
 
 const file_teleport_scopes_joining_v1_token_proto_rawDesc = "" +
 	"\n" +
-	"&teleport/scopes/joining/v1/token.proto\x12\x1ateleport.scopes.joining.v1\x1a\x1fgoogle/protobuf/timestamp.proto\x1a!teleport/header/v1/metadata.proto\"\xae\x02\n" +
+	"&teleport/scopes/joining/v1/token.proto\x12\x1ateleport.scopes.joining.v1\x1a\x1cgoogle/protobuf/struct.proto\x1a\x1fgoogle/protobuf/timestamp.proto\x1a!teleport/header/v1/metadata.proto\"\xae\x02\n" +
 	"\vScopedToken\x12\x12\n" +
 	"\x04kind\x18\x01 \x01(\tR\x04kind\x12\x19\n" +
 	"\bsub_kind\x18\x02 \x01(\tR\asubKind\x12\x18\n" +
@@ -3230,7 +4054,7 @@ const file_teleport_scopes_joining_v1_token_proto_rawDesc = "" +
 	"\bmetadata\x18\x04 \x01(\v2\x1c.teleport.header.v1.MetadataR\bmetadata\x12\x14\n" +
 	"\x05scope\x18\x05 \x01(\tR\x05scope\x12?\n" +
 	"\x04spec\x18\x06 \x01(\v2+.teleport.scopes.joining.v1.ScopedTokenSpecR\x04spec\x12E\n" +
-	"\x06status\x18\a \x01(\v2-.teleport.scopes.joining.v1.ScopedTokenStatusR\x06status\"\xdb\x05\n" +
+	"\x06status\x18\a \x01(\v2-.teleport.scopes.joining.v1.ScopedTokenStatusR\x06status\"\xa7\x06\n" +
 	"\x0fScopedTokenSpec\x12%\n" +
 	"\x0eassigned_scope\x18\x01 \x01(\tR\rassignedScope\x12\x14\n" +
 	"\x05roles\x18\x02 \x03(\tR\x05roles\x12\x1f\n" +
@@ -3249,7 +4073,8 @@ const file_teleport_scopes_joining_v1_token_proto_rawDesc = "" +
 	"kubernetes\x18\v \x01(\v2&.teleport.scopes.joining.v1.KubernetesR\n" +
 	"kubernetes\x12Q\n" +
 	"\rbound_keypair\x18\f \x01(\v2,.teleport.scopes.joining.v1.BoundKeypairSpecR\fboundKeypair\x12\x10\n" +
-	"\x03bot\x18\x0f \x01(\tR\x03botJ\x04\b\r\x10\x0eJ\x04\b\x0e\x10\x0fR\bbot_nameR\tbot_scope\"\xb6\x01\n" +
+	"\x03bot\x18\x0f \x01(\tR\x03bot\x12J\n" +
+	"\fgeneric_oidc\x18\x10 \x01(\v2'.teleport.scopes.joining.v1.GenericOIDCR\vgenericOidcJ\x04\b\r\x10\x0eJ\x04\b\x0e\x10\x0fR\bbot_nameR\tbot_scope\"\xb6\x01\n" +
 	"\x0eHostCertParams\x12\x17\n" +
 	"\ahost_id\x18\x01 \x01(\tR\x06hostId\x12\x1b\n" +
 	"\tnode_name\x18\x02 \x01(\tR\bnodeName\x12\x12\n" +
@@ -3365,9 +4190,41 @@ const file_teleport_scopes_joining_v1_token_proto_rawDesc = "" +
 	"\x0erecovery_count\x18\x04 \x01(\rR\rrecoveryCount\x12F\n" +
 	"\x11last_recovered_at\x18\x05 \x01(\v2\x1a.google.protobuf.TimestampR\x0flastRecoveredAt\x12B\n" +
 	"\x0flast_rotated_at\x18\x06 \x01(\v2\x1a.google.protobuf.TimestampR\rlastRotatedAt\x12\"\n" +
-	"\rbound_host_id\x18\a \x01(\tR\vboundHostIdBYZWgithub.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/joining/v1;joiningv1b\x06proto3"
+	"\rbound_host_id\x18\a \x01(\tR\vboundHostId\"\xc7\a\n" +
+	"\vGenericOIDC\x12\x16\n" +
+	"\x06issuer\x18\x01 \x01(\tR\x06issuer\x12;\n" +
+	"\x1ainsecure_allow_http_issuer\x18\x02 \x01(\bR\x17insecureAllowHttpIssuer\x12\x1a\n" +
+	"\baudience\x18\x03 \x01(\tR\baudience\x12\x1f\n" +
+	"\vstatic_jwks\x18\x04 \x01(\tR\n" +
+	"staticJwks\x12\x15\n" +
+	"\x06tls_ca\x18\x05 \x01(\tR\x05tlsCa\x12C\n" +
+	"\x11must_match_fields\x18\x06 \x01(\v2\x17.google.protobuf.StructR\x0fmustMatchFields\x12I\n" +
+	"\tallow_any\x18\a \x03(\v2,.teleport.scopes.joining.v1.GenericOIDC.RuleR\ballowAny\x1a#\n" +
+	"\vConditionEq\x12\x14\n" +
+	"\x05value\x18\x01 \x01(\tR\x05value\x1a&\n" +
+	"\x0eConditionNotEq\x12\x14\n" +
+	"\x05value\x18\x01 \x01(\tR\x05value\x1a%\n" +
+	"\vConditionIn\x12\x16\n" +
+	"\x06values\x18\x01 \x03(\tR\x06values\x1a(\n" +
+	"\x0eConditionNotIn\x12\x16\n" +
+	"\x06values\x18\x01 \x03(\tR\x06values\x1a\xe5\x02\n" +
+	"\tCondition\x12\x1c\n" +
+	"\tattribute\x18\x01 \x01(\tR\tattribute\x12E\n" +
+	"\x02eq\x18\x02 \x01(\v23.teleport.scopes.joining.v1.GenericOIDC.ConditionEqH\x00R\x02eq\x12O\n" +
+	"\x06not_eq\x18\x03 \x01(\v26.teleport.scopes.joining.v1.GenericOIDC.ConditionNotEqH\x00R\x05notEq\x12E\n" +
+	"\x02in\x18\x04 \x01(\v23.teleport.scopes.joining.v1.GenericOIDC.ConditionInH\x00R\x02in\x12O\n" +
+	"\x06not_in\x18\x05 \x01(\v26.teleport.scopes.joining.v1.GenericOIDC.ConditionNotInH\x00R\x05notInB\n" +
+	"\n" +
+	"\boperator\x1ay\n" +
+	"\x04Rule\x12Q\n" +
+	"\n" +
+	"conditions\x18\x01 \x03(\v21.teleport.scopes.joining.v1.GenericOIDC.ConditionR\n" +
+	"conditions\x12\x1e\n" +
+	"\n" +
+	"expression\x18\x02 \x01(\tR\n" +
+	"expressionBYZWgithub.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/joining/v1;joiningv1b\x06proto3"
 
-var file_teleport_scopes_joining_v1_token_proto_msgTypes = make([]protoimpl.MessageInfo, 28)
+var file_teleport_scopes_joining_v1_token_proto_msgTypes = make([]protoimpl.MessageInfo, 35)
 var file_teleport_scopes_joining_v1_token_proto_goTypes = []any{
 	(*ScopedToken)(nil),                     // 0: teleport.scopes.joining.v1.ScopedToken
 	(*ScopedTokenSpec)(nil),                 // 1: teleport.scopes.joining.v1.ScopedTokenSpec
@@ -3386,22 +4243,30 @@ var file_teleport_scopes_joining_v1_token_proto_goTypes = []any{
 	(*Kubernetes)(nil),                      // 14: teleport.scopes.joining.v1.Kubernetes
 	(*BoundKeypairSpec)(nil),                // 15: teleport.scopes.joining.v1.BoundKeypairSpec
 	(*BoundKeypairStatus)(nil),              // 16: teleport.scopes.joining.v1.BoundKeypairStatus
-	nil,                                     // 17: teleport.scopes.joining.v1.ImmutableLabels.SshEntry
-	(*AWS_Rule)(nil),                        // 18: teleport.scopes.joining.v1.AWS.Rule
-	(*GCP_Rule)(nil),                        // 19: teleport.scopes.joining.v1.GCP.Rule
-	(*Azure_Rule)(nil),                      // 20: teleport.scopes.joining.v1.Azure.Rule
-	(*AzureDevops_Rule)(nil),                // 21: teleport.scopes.joining.v1.AzureDevops.Rule
-	(*Oracle_Rule)(nil),                     // 22: teleport.scopes.joining.v1.Oracle.Rule
-	(*Kubernetes_StaticJWKSConfig)(nil),     // 23: teleport.scopes.joining.v1.Kubernetes.StaticJWKSConfig
-	(*Kubernetes_OIDCConfig)(nil),           // 24: teleport.scopes.joining.v1.Kubernetes.OIDCConfig
-	(*Kubernetes_Rule)(nil),                 // 25: teleport.scopes.joining.v1.Kubernetes.Rule
-	(*BoundKeypairSpec_OnboardingSpec)(nil), // 26: teleport.scopes.joining.v1.BoundKeypairSpec.OnboardingSpec
-	(*BoundKeypairSpec_RecoverySpec)(nil),   // 27: teleport.scopes.joining.v1.BoundKeypairSpec.RecoverySpec
-	(*v1.Metadata)(nil),                     // 28: teleport.header.v1.Metadata
-	(*timestamppb.Timestamp)(nil),           // 29: google.protobuf.Timestamp
+	(*GenericOIDC)(nil),                     // 17: teleport.scopes.joining.v1.GenericOIDC
+	nil,                                     // 18: teleport.scopes.joining.v1.ImmutableLabels.SshEntry
+	(*AWS_Rule)(nil),                        // 19: teleport.scopes.joining.v1.AWS.Rule
+	(*GCP_Rule)(nil),                        // 20: teleport.scopes.joining.v1.GCP.Rule
+	(*Azure_Rule)(nil),                      // 21: teleport.scopes.joining.v1.Azure.Rule
+	(*AzureDevops_Rule)(nil),                // 22: teleport.scopes.joining.v1.AzureDevops.Rule
+	(*Oracle_Rule)(nil),                     // 23: teleport.scopes.joining.v1.Oracle.Rule
+	(*Kubernetes_StaticJWKSConfig)(nil),     // 24: teleport.scopes.joining.v1.Kubernetes.StaticJWKSConfig
+	(*Kubernetes_OIDCConfig)(nil),           // 25: teleport.scopes.joining.v1.Kubernetes.OIDCConfig
+	(*Kubernetes_Rule)(nil),                 // 26: teleport.scopes.joining.v1.Kubernetes.Rule
+	(*BoundKeypairSpec_OnboardingSpec)(nil), // 27: teleport.scopes.joining.v1.BoundKeypairSpec.OnboardingSpec
+	(*BoundKeypairSpec_RecoverySpec)(nil),   // 28: teleport.scopes.joining.v1.BoundKeypairSpec.RecoverySpec
+	(*GenericOIDC_ConditionEq)(nil),         // 29: teleport.scopes.joining.v1.GenericOIDC.ConditionEq
+	(*GenericOIDC_ConditionNotEq)(nil),      // 30: teleport.scopes.joining.v1.GenericOIDC.ConditionNotEq
+	(*GenericOIDC_ConditionIn)(nil),         // 31: teleport.scopes.joining.v1.GenericOIDC.ConditionIn
+	(*GenericOIDC_ConditionNotIn)(nil),      // 32: teleport.scopes.joining.v1.GenericOIDC.ConditionNotIn
+	(*GenericOIDC_Condition)(nil),           // 33: teleport.scopes.joining.v1.GenericOIDC.Condition
+	(*GenericOIDC_Rule)(nil),                // 34: teleport.scopes.joining.v1.GenericOIDC.Rule
+	(*v1.Metadata)(nil),                     // 35: teleport.header.v1.Metadata
+	(*timestamppb.Timestamp)(nil),           // 36: google.protobuf.Timestamp
+	(*structpb.Struct)(nil),                 // 37: google.protobuf.Struct
 }
 var file_teleport_scopes_joining_v1_token_proto_depIdxs = []int32{
-	28, // 0: teleport.scopes.joining.v1.ScopedToken.metadata:type_name -> teleport.header.v1.Metadata
+	35, // 0: teleport.scopes.joining.v1.ScopedToken.metadata:type_name -> teleport.header.v1.Metadata
 	1,  // 1: teleport.scopes.joining.v1.ScopedToken.spec:type_name -> teleport.scopes.joining.v1.ScopedTokenSpec
 	5,  // 2: teleport.scopes.joining.v1.ScopedToken.status:type_name -> teleport.scopes.joining.v1.ScopedTokenStatus
 	6,  // 3: teleport.scopes.joining.v1.ScopedTokenSpec.immutable_labels:type_name -> teleport.scopes.joining.v1.ImmutableLabels
@@ -3412,35 +4277,43 @@ var file_teleport_scopes_joining_v1_token_proto_depIdxs = []int32{
 	13, // 8: teleport.scopes.joining.v1.ScopedTokenSpec.oracle:type_name -> teleport.scopes.joining.v1.Oracle
 	14, // 9: teleport.scopes.joining.v1.ScopedTokenSpec.kubernetes:type_name -> teleport.scopes.joining.v1.Kubernetes
 	15, // 10: teleport.scopes.joining.v1.ScopedTokenSpec.bound_keypair:type_name -> teleport.scopes.joining.v1.BoundKeypairSpec
-	29, // 11: teleport.scopes.joining.v1.SingleUseStatus.used_at:type_name -> google.protobuf.Timestamp
-	29, // 12: teleport.scopes.joining.v1.SingleUseStatus.reusable_until:type_name -> google.protobuf.Timestamp
-	2,  // 13: teleport.scopes.joining.v1.SingleUseStatus.host_cert_params:type_name -> teleport.scopes.joining.v1.HostCertParams
-	3,  // 14: teleport.scopes.joining.v1.UsageStatus.single_use:type_name -> teleport.scopes.joining.v1.SingleUseStatus
-	16, // 15: teleport.scopes.joining.v1.UsageStatus.bound_keypair:type_name -> teleport.scopes.joining.v1.BoundKeypairStatus
-	4,  // 16: teleport.scopes.joining.v1.ScopedTokenStatus.usage:type_name -> teleport.scopes.joining.v1.UsageStatus
-	17, // 17: teleport.scopes.joining.v1.ImmutableLabels.ssh:type_name -> teleport.scopes.joining.v1.ImmutableLabels.SshEntry
-	28, // 18: teleport.scopes.joining.v1.StaticScopedTokens.metadata:type_name -> teleport.header.v1.Metadata
-	8,  // 19: teleport.scopes.joining.v1.StaticScopedTokens.spec:type_name -> teleport.scopes.joining.v1.StaticScopedTokensSpec
-	0,  // 20: teleport.scopes.joining.v1.StaticScopedTokensSpec.tokens:type_name -> teleport.scopes.joining.v1.ScopedToken
-	18, // 21: teleport.scopes.joining.v1.AWS.allow:type_name -> teleport.scopes.joining.v1.AWS.Rule
-	19, // 22: teleport.scopes.joining.v1.GCP.allow:type_name -> teleport.scopes.joining.v1.GCP.Rule
-	20, // 23: teleport.scopes.joining.v1.Azure.allow:type_name -> teleport.scopes.joining.v1.Azure.Rule
-	21, // 24: teleport.scopes.joining.v1.AzureDevops.allow:type_name -> teleport.scopes.joining.v1.AzureDevops.Rule
-	22, // 25: teleport.scopes.joining.v1.Oracle.allow:type_name -> teleport.scopes.joining.v1.Oracle.Rule
-	25, // 26: teleport.scopes.joining.v1.Kubernetes.allow:type_name -> teleport.scopes.joining.v1.Kubernetes.Rule
-	23, // 27: teleport.scopes.joining.v1.Kubernetes.static_jwks:type_name -> teleport.scopes.joining.v1.Kubernetes.StaticJWKSConfig
-	24, // 28: teleport.scopes.joining.v1.Kubernetes.oidc:type_name -> teleport.scopes.joining.v1.Kubernetes.OIDCConfig
-	26, // 29: teleport.scopes.joining.v1.BoundKeypairSpec.onboarding:type_name -> teleport.scopes.joining.v1.BoundKeypairSpec.OnboardingSpec
-	27, // 30: teleport.scopes.joining.v1.BoundKeypairSpec.recovery:type_name -> teleport.scopes.joining.v1.BoundKeypairSpec.RecoverySpec
-	29, // 31: teleport.scopes.joining.v1.BoundKeypairSpec.rotate_after:type_name -> google.protobuf.Timestamp
-	29, // 32: teleport.scopes.joining.v1.BoundKeypairStatus.last_recovered_at:type_name -> google.protobuf.Timestamp
-	29, // 33: teleport.scopes.joining.v1.BoundKeypairStatus.last_rotated_at:type_name -> google.protobuf.Timestamp
-	29, // 34: teleport.scopes.joining.v1.BoundKeypairSpec.OnboardingSpec.must_register_before:type_name -> google.protobuf.Timestamp
-	35, // [35:35] is the sub-list for method output_type
-	35, // [35:35] is the sub-list for method input_type
-	35, // [35:35] is the sub-list for extension type_name
-	35, // [35:35] is the sub-list for extension extendee
-	0,  // [0:35] is the sub-list for field type_name
+	17, // 11: teleport.scopes.joining.v1.ScopedTokenSpec.generic_oidc:type_name -> teleport.scopes.joining.v1.GenericOIDC
+	36, // 12: teleport.scopes.joining.v1.SingleUseStatus.used_at:type_name -> google.protobuf.Timestamp
+	36, // 13: teleport.scopes.joining.v1.SingleUseStatus.reusable_until:type_name -> google.protobuf.Timestamp
+	2,  // 14: teleport.scopes.joining.v1.SingleUseStatus.host_cert_params:type_name -> teleport.scopes.joining.v1.HostCertParams
+	3,  // 15: teleport.scopes.joining.v1.UsageStatus.single_use:type_name -> teleport.scopes.joining.v1.SingleUseStatus
+	16, // 16: teleport.scopes.joining.v1.UsageStatus.bound_keypair:type_name -> teleport.scopes.joining.v1.BoundKeypairStatus
+	4,  // 17: teleport.scopes.joining.v1.ScopedTokenStatus.usage:type_name -> teleport.scopes.joining.v1.UsageStatus
+	18, // 18: teleport.scopes.joining.v1.ImmutableLabels.ssh:type_name -> teleport.scopes.joining.v1.ImmutableLabels.SshEntry
+	35, // 19: teleport.scopes.joining.v1.StaticScopedTokens.metadata:type_name -> teleport.header.v1.Metadata
+	8,  // 20: teleport.scopes.joining.v1.StaticScopedTokens.spec:type_name -> teleport.scopes.joining.v1.StaticScopedTokensSpec
+	0,  // 21: teleport.scopes.joining.v1.StaticScopedTokensSpec.tokens:type_name -> teleport.scopes.joining.v1.ScopedToken
+	19, // 22: teleport.scopes.joining.v1.AWS.allow:type_name -> teleport.scopes.joining.v1.AWS.Rule
+	20, // 23: teleport.scopes.joining.v1.GCP.allow:type_name -> teleport.scopes.joining.v1.GCP.Rule
+	21, // 24: teleport.scopes.joining.v1.Azure.allow:type_name -> teleport.scopes.joining.v1.Azure.Rule
+	22, // 25: teleport.scopes.joining.v1.AzureDevops.allow:type_name -> teleport.scopes.joining.v1.AzureDevops.Rule
+	23, // 26: teleport.scopes.joining.v1.Oracle.allow:type_name -> teleport.scopes.joining.v1.Oracle.Rule
+	26, // 27: teleport.scopes.joining.v1.Kubernetes.allow:type_name -> teleport.scopes.joining.v1.Kubernetes.Rule
+	24, // 28: teleport.scopes.joining.v1.Kubernetes.static_jwks:type_name -> teleport.scopes.joining.v1.Kubernetes.StaticJWKSConfig
+	25, // 29: teleport.scopes.joining.v1.Kubernetes.oidc:type_name -> teleport.scopes.joining.v1.Kubernetes.OIDCConfig
+	27, // 30: teleport.scopes.joining.v1.BoundKeypairSpec.onboarding:type_name -> teleport.scopes.joining.v1.BoundKeypairSpec.OnboardingSpec
+	28, // 31: teleport.scopes.joining.v1.BoundKeypairSpec.recovery:type_name -> teleport.scopes.joining.v1.BoundKeypairSpec.RecoverySpec
+	36, // 32: teleport.scopes.joining.v1.BoundKeypairSpec.rotate_after:type_name -> google.protobuf.Timestamp
+	36, // 33: teleport.scopes.joining.v1.BoundKeypairStatus.last_recovered_at:type_name -> google.protobuf.Timestamp
+	36, // 34: teleport.scopes.joining.v1.BoundKeypairStatus.last_rotated_at:type_name -> google.protobuf.Timestamp
+	37, // 35: teleport.scopes.joining.v1.GenericOIDC.must_match_fields:type_name -> google.protobuf.Struct
+	34, // 36: teleport.scopes.joining.v1.GenericOIDC.allow_any:type_name -> teleport.scopes.joining.v1.GenericOIDC.Rule
+	36, // 37: teleport.scopes.joining.v1.BoundKeypairSpec.OnboardingSpec.must_register_before:type_name -> google.protobuf.Timestamp
+	29, // 38: teleport.scopes.joining.v1.GenericOIDC.Condition.eq:type_name -> teleport.scopes.joining.v1.GenericOIDC.ConditionEq
+	30, // 39: teleport.scopes.joining.v1.GenericOIDC.Condition.not_eq:type_name -> teleport.scopes.joining.v1.GenericOIDC.ConditionNotEq
+	31, // 40: teleport.scopes.joining.v1.GenericOIDC.Condition.in:type_name -> teleport.scopes.joining.v1.GenericOIDC.ConditionIn
+	32, // 41: teleport.scopes.joining.v1.GenericOIDC.Condition.not_in:type_name -> teleport.scopes.joining.v1.GenericOIDC.ConditionNotIn
+	33, // 42: teleport.scopes.joining.v1.GenericOIDC.Rule.conditions:type_name -> teleport.scopes.joining.v1.GenericOIDC.Condition
+	43, // [43:43] is the sub-list for method output_type
+	43, // [43:43] is the sub-list for method input_type
+	43, // [43:43] is the sub-list for extension type_name
+	43, // [43:43] is the sub-list for extension extendee
+	0,  // [0:43] is the sub-list for field type_name
 }
 
 func init() { file_teleport_scopes_joining_v1_token_proto_init() }
@@ -3452,13 +4325,19 @@ func file_teleport_scopes_joining_v1_token_proto_init() {
 		(*usageStatus_SingleUse)(nil),
 		(*usageStatus_BoundKeypair)(nil),
 	}
+	file_teleport_scopes_joining_v1_token_proto_msgTypes[33].OneofWrappers = []any{
+		(*genericOIDC_Condition_Eq)(nil),
+		(*genericOIDC_Condition_NotEq)(nil),
+		(*genericOIDC_Condition_In)(nil),
+		(*genericOIDC_Condition_NotIn)(nil),
+	}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_teleport_scopes_joining_v1_token_proto_rawDesc), len(file_teleport_scopes_joining_v1_token_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   28,
+			NumMessages:   35,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/api/gen/proto/go/teleport/workloadidentity/v1/join_attrs.pb.go
+++ b/api/gen/proto/go/teleport/workloadidentity/v1/join_attrs.pb.go
@@ -25,6 +25,7 @@ package workloadidentityv1
 import (
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
+	structpb "google.golang.org/protobuf/types/known/structpb"
 	reflect "reflect"
 	unsafe "unsafe"
 )
@@ -69,7 +70,9 @@ type JoinAttrs struct {
 	// Attributes that are specific to the Azure Devops (`azure_devops`) join method.
 	AzureDevops *JoinAttrsAzureDevops `protobuf:"bytes,14,opt,name=azure_devops,json=azureDevops,proto3" json:"azure_devops,omitempty"`
 	// Attributes that are specific to the Env0 (`env0`) join method.
-	Env0          *JoinAttrsEnv0 `protobuf:"bytes,15,opt,name=env0,proto3" json:"env0,omitempty"`
+	Env0 *JoinAttrsEnv0 `protobuf:"bytes,15,opt,name=env0,proto3" json:"env0,omitempty"`
+	// Attributes that are specific to the generic OIDC (`generic_oidc`) join method.
+	GenericOidc   *JoinAttrsGenericOIDC `protobuf:"bytes,16,opt,name=generic_oidc,json=genericOidc,proto3" json:"generic_oidc,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -204,6 +207,13 @@ func (x *JoinAttrs) GetEnv0() *JoinAttrsEnv0 {
 	return nil
 }
 
+func (x *JoinAttrs) GetGenericOidc() *JoinAttrsGenericOIDC {
+	if x != nil {
+		return x.GenericOidc
+	}
+	return nil
+}
+
 func (x *JoinAttrs) SetMeta(v *JoinAttrsMeta) {
 	x.Meta = v
 }
@@ -262,6 +272,10 @@ func (x *JoinAttrs) SetAzureDevops(v *JoinAttrsAzureDevops) {
 
 func (x *JoinAttrs) SetEnv0(v *JoinAttrsEnv0) {
 	x.Env0 = v
+}
+
+func (x *JoinAttrs) SetGenericOidc(v *JoinAttrsGenericOIDC) {
+	x.GenericOidc = v
 }
 
 func (x *JoinAttrs) HasMeta() bool {
@@ -369,6 +383,13 @@ func (x *JoinAttrs) HasEnv0() bool {
 	return x.Env0 != nil
 }
 
+func (x *JoinAttrs) HasGenericOidc() bool {
+	if x == nil {
+		return false
+	}
+	return x.GenericOidc != nil
+}
+
 func (x *JoinAttrs) ClearMeta() {
 	x.Meta = nil
 }
@@ -429,6 +450,10 @@ func (x *JoinAttrs) ClearEnv0() {
 	x.Env0 = nil
 }
 
+func (x *JoinAttrs) ClearGenericOidc() {
+	x.GenericOidc = nil
+}
+
 type JoinAttrs_builder struct {
 	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
 
@@ -463,6 +488,8 @@ type JoinAttrs_builder struct {
 	AzureDevops *JoinAttrsAzureDevops
 	// Attributes that are specific to the Env0 (`env0`) join method.
 	Env0 *JoinAttrsEnv0
+	// Attributes that are specific to the generic OIDC (`generic_oidc`) join method.
+	GenericOidc *JoinAttrsGenericOIDC
 }
 
 func (b0 JoinAttrs_builder) Build() *JoinAttrs {
@@ -484,6 +511,7 @@ func (b0 JoinAttrs_builder) Build() *JoinAttrs {
 	x.Oracle = b.Oracle
 	x.AzureDevops = b.AzureDevops
 	x.Env0 = b.Env0
+	x.GenericOidc = b.GenericOidc
 	return m0
 }
 
@@ -3147,11 +3175,82 @@ func (b0 JoinAttrsEnv0_builder) Build() *JoinAttrsEnv0 {
 	return m0
 }
 
+// Attributes that are specific to the generic OIDC (`generic_oidc`) join method.
+type JoinAttrsGenericOIDC struct {
+	state protoimpl.MessageState `protogen:"hybrid.v1"`
+	// A complete set of token claims.
+	Claims        *structpb.Struct `protobuf:"bytes,1,opt,name=claims,proto3" json:"claims,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *JoinAttrsGenericOIDC) Reset() {
+	*x = JoinAttrsGenericOIDC{}
+	mi := &file_teleport_workloadidentity_v1_join_attrs_proto_msgTypes[20]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *JoinAttrsGenericOIDC) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*JoinAttrsGenericOIDC) ProtoMessage() {}
+
+func (x *JoinAttrsGenericOIDC) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_workloadidentity_v1_join_attrs_proto_msgTypes[20]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+func (x *JoinAttrsGenericOIDC) GetClaims() *structpb.Struct {
+	if x != nil {
+		return x.Claims
+	}
+	return nil
+}
+
+func (x *JoinAttrsGenericOIDC) SetClaims(v *structpb.Struct) {
+	x.Claims = v
+}
+
+func (x *JoinAttrsGenericOIDC) HasClaims() bool {
+	if x == nil {
+		return false
+	}
+	return x.Claims != nil
+}
+
+func (x *JoinAttrsGenericOIDC) ClearClaims() {
+	x.Claims = nil
+}
+
+type JoinAttrsGenericOIDC_builder struct {
+	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
+
+	// A complete set of token claims.
+	Claims *structpb.Struct
+}
+
+func (b0 JoinAttrsGenericOIDC_builder) Build() *JoinAttrsGenericOIDC {
+	m0 := &JoinAttrsGenericOIDC{}
+	b, x := &b0, m0
+	_, _ = b, x
+	x.Claims = b.Claims
+	return m0
+}
+
 var File_teleport_workloadidentity_v1_join_attrs_proto protoreflect.FileDescriptor
 
 const file_teleport_workloadidentity_v1_join_attrs_proto_rawDesc = "" +
 	"\n" +
-	"-teleport/workloadidentity/v1/join_attrs.proto\x12\x1cteleport.workloadidentity.v1\"\xda\b\n" +
+	"-teleport/workloadidentity/v1/join_attrs.proto\x12\x1cteleport.workloadidentity.v1\x1a\x1cgoogle/protobuf/struct.proto\"\xb1\t\n" +
 	"\tJoinAttrs\x12?\n" +
 	"\x04meta\x18\x01 \x01(\v2+.teleport.workloadidentity.v1.JoinAttrsMetaR\x04meta\x12E\n" +
 	"\x06gitlab\x18\x02 \x01(\v2-.teleport.workloadidentity.v1.JoinAttrsGitLabR\x06gitlab\x12E\n" +
@@ -3170,7 +3269,8 @@ const file_teleport_workloadidentity_v1_join_attrs_proto_rawDesc = "" +
 	"kubernetes\x12E\n" +
 	"\x06oracle\x18\r \x01(\v2-.teleport.workloadidentity.v1.JoinAttrsOracleR\x06oracle\x12U\n" +
 	"\fazure_devops\x18\x0e \x01(\v22.teleport.workloadidentity.v1.JoinAttrsAzureDevopsR\vazureDevops\x12?\n" +
-	"\x04env0\x18\x0f \x01(\v2+.teleport.workloadidentity.v1.JoinAttrsEnv0R\x04env0\"X\n" +
+	"\x04env0\x18\x0f \x01(\v2+.teleport.workloadidentity.v1.JoinAttrsEnv0R\x04env0\x12U\n" +
+	"\fgeneric_oidc\x18\x10 \x01(\v22.teleport.workloadidentity.v1.JoinAttrsGenericOIDCR\vgenericOidc\"X\n" +
 	"\rJoinAttrsMeta\x12&\n" +
 	"\x0fjoin_token_name\x18\x01 \x01(\tR\rjoinTokenName\x12\x1f\n" +
 	"\vjoin_method\x18\x02 \x01(\tR\n" +
@@ -3315,9 +3415,11 @@ const file_teleport_workloadidentity_v1_join_attrs_proto_rawDesc = "" +
 	" \x01(\tR\x0fdeploymentLogId\x12'\n" +
 	"\x0fdeployment_type\x18\v \x01(\tR\x0edeploymentType\x12%\n" +
 	"\x0edeployer_email\x18\f \x01(\tR\rdeployerEmail\x12\x19\n" +
-	"\benv0_tag\x18\r \x01(\tR\aenv0TagBdZbgithub.com/gravitational/teleport/api/gen/proto/go/teleport/workloadidentity/v1;workloadidentityv1b\x06proto3"
+	"\benv0_tag\x18\r \x01(\tR\aenv0Tag\"G\n" +
+	"\x14JoinAttrsGenericOIDC\x12/\n" +
+	"\x06claims\x18\x01 \x01(\v2\x17.google.protobuf.StructR\x06claimsBdZbgithub.com/gravitational/teleport/api/gen/proto/go/teleport/workloadidentity/v1;workloadidentityv1b\x06proto3"
 
-var file_teleport_workloadidentity_v1_join_attrs_proto_msgTypes = make([]protoimpl.MessageInfo, 20)
+var file_teleport_workloadidentity_v1_join_attrs_proto_msgTypes = make([]protoimpl.MessageInfo, 21)
 var file_teleport_workloadidentity_v1_join_attrs_proto_goTypes = []any{
 	(*JoinAttrs)(nil),                         // 0: teleport.workloadidentity.v1.JoinAttrs
 	(*JoinAttrsMeta)(nil),                     // 1: teleport.workloadidentity.v1.JoinAttrsMeta
@@ -3339,6 +3441,8 @@ var file_teleport_workloadidentity_v1_join_attrs_proto_goTypes = []any{
 	(*JoinAttrsAzureDevops)(nil),              // 17: teleport.workloadidentity.v1.JoinAttrsAzureDevops
 	(*JoinAttrsAzureDevopsPipeline)(nil),      // 18: teleport.workloadidentity.v1.JoinAttrsAzureDevopsPipeline
 	(*JoinAttrsEnv0)(nil),                     // 19: teleport.workloadidentity.v1.JoinAttrsEnv0
+	(*JoinAttrsGenericOIDC)(nil),              // 20: teleport.workloadidentity.v1.JoinAttrsGenericOIDC
+	(*structpb.Struct)(nil),                   // 21: google.protobuf.Struct
 }
 var file_teleport_workloadidentity_v1_join_attrs_proto_depIdxs = []int32{
 	1,  // 0: teleport.workloadidentity.v1.JoinAttrs.meta:type_name -> teleport.workloadidentity.v1.JoinAttrsMeta
@@ -3356,15 +3460,17 @@ var file_teleport_workloadidentity_v1_join_attrs_proto_depIdxs = []int32{
 	16, // 12: teleport.workloadidentity.v1.JoinAttrs.oracle:type_name -> teleport.workloadidentity.v1.JoinAttrsOracle
 	17, // 13: teleport.workloadidentity.v1.JoinAttrs.azure_devops:type_name -> teleport.workloadidentity.v1.JoinAttrsAzureDevops
 	19, // 14: teleport.workloadidentity.v1.JoinAttrs.env0:type_name -> teleport.workloadidentity.v1.JoinAttrsEnv0
-	11, // 15: teleport.workloadidentity.v1.JoinAttrsGCP.gce:type_name -> teleport.workloadidentity.v1.JoinAttrsGCPGCE
-	14, // 16: teleport.workloadidentity.v1.JoinAttrsKubernetes.service_account:type_name -> teleport.workloadidentity.v1.JoinAttrsKubernetesServiceAccount
-	13, // 17: teleport.workloadidentity.v1.JoinAttrsKubernetes.pod:type_name -> teleport.workloadidentity.v1.JoinAttrsKubernetesPod
-	18, // 18: teleport.workloadidentity.v1.JoinAttrsAzureDevops.pipeline:type_name -> teleport.workloadidentity.v1.JoinAttrsAzureDevopsPipeline
-	19, // [19:19] is the sub-list for method output_type
-	19, // [19:19] is the sub-list for method input_type
-	19, // [19:19] is the sub-list for extension type_name
-	19, // [19:19] is the sub-list for extension extendee
-	0,  // [0:19] is the sub-list for field type_name
+	20, // 15: teleport.workloadidentity.v1.JoinAttrs.generic_oidc:type_name -> teleport.workloadidentity.v1.JoinAttrsGenericOIDC
+	11, // 16: teleport.workloadidentity.v1.JoinAttrsGCP.gce:type_name -> teleport.workloadidentity.v1.JoinAttrsGCPGCE
+	14, // 17: teleport.workloadidentity.v1.JoinAttrsKubernetes.service_account:type_name -> teleport.workloadidentity.v1.JoinAttrsKubernetesServiceAccount
+	13, // 18: teleport.workloadidentity.v1.JoinAttrsKubernetes.pod:type_name -> teleport.workloadidentity.v1.JoinAttrsKubernetesPod
+	18, // 19: teleport.workloadidentity.v1.JoinAttrsAzureDevops.pipeline:type_name -> teleport.workloadidentity.v1.JoinAttrsAzureDevopsPipeline
+	21, // 20: teleport.workloadidentity.v1.JoinAttrsGenericOIDC.claims:type_name -> google.protobuf.Struct
+	21, // [21:21] is the sub-list for method output_type
+	21, // [21:21] is the sub-list for method input_type
+	21, // [21:21] is the sub-list for extension type_name
+	21, // [21:21] is the sub-list for extension extendee
+	0,  // [0:21] is the sub-list for field type_name
 }
 
 func init() { file_teleport_workloadidentity_v1_join_attrs_proto_init() }
@@ -3378,7 +3484,7 @@ func file_teleport_workloadidentity_v1_join_attrs_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_teleport_workloadidentity_v1_join_attrs_proto_rawDesc), len(file_teleport_workloadidentity_v1_join_attrs_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   20,
+			NumMessages:   21,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/api/gen/proto/go/teleport/workloadidentity/v1/join_attrs_protoopaque.pb.go
+++ b/api/gen/proto/go/teleport/workloadidentity/v1/join_attrs_protoopaque.pb.go
@@ -25,6 +25,7 @@ package workloadidentityv1
 import (
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
+	structpb "google.golang.org/protobuf/types/known/structpb"
 	reflect "reflect"
 	unsafe "unsafe"
 )
@@ -54,6 +55,7 @@ type JoinAttrs struct {
 	xxx_hidden_Oracle         *JoinAttrsOracle         `protobuf:"bytes,13,opt,name=oracle,proto3"`
 	xxx_hidden_AzureDevops    *JoinAttrsAzureDevops    `protobuf:"bytes,14,opt,name=azure_devops,json=azureDevops,proto3"`
 	xxx_hidden_Env0           *JoinAttrsEnv0           `protobuf:"bytes,15,opt,name=env0,proto3"`
+	xxx_hidden_GenericOidc    *JoinAttrsGenericOIDC    `protobuf:"bytes,16,opt,name=generic_oidc,json=genericOidc,proto3"`
 	unknownFields             protoimpl.UnknownFields
 	sizeCache                 protoimpl.SizeCache
 }
@@ -188,6 +190,13 @@ func (x *JoinAttrs) GetEnv0() *JoinAttrsEnv0 {
 	return nil
 }
 
+func (x *JoinAttrs) GetGenericOidc() *JoinAttrsGenericOIDC {
+	if x != nil {
+		return x.xxx_hidden_GenericOidc
+	}
+	return nil
+}
+
 func (x *JoinAttrs) SetMeta(v *JoinAttrsMeta) {
 	x.xxx_hidden_Meta = v
 }
@@ -246,6 +255,10 @@ func (x *JoinAttrs) SetAzureDevops(v *JoinAttrsAzureDevops) {
 
 func (x *JoinAttrs) SetEnv0(v *JoinAttrsEnv0) {
 	x.xxx_hidden_Env0 = v
+}
+
+func (x *JoinAttrs) SetGenericOidc(v *JoinAttrsGenericOIDC) {
+	x.xxx_hidden_GenericOidc = v
 }
 
 func (x *JoinAttrs) HasMeta() bool {
@@ -353,6 +366,13 @@ func (x *JoinAttrs) HasEnv0() bool {
 	return x.xxx_hidden_Env0 != nil
 }
 
+func (x *JoinAttrs) HasGenericOidc() bool {
+	if x == nil {
+		return false
+	}
+	return x.xxx_hidden_GenericOidc != nil
+}
+
 func (x *JoinAttrs) ClearMeta() {
 	x.xxx_hidden_Meta = nil
 }
@@ -413,6 +433,10 @@ func (x *JoinAttrs) ClearEnv0() {
 	x.xxx_hidden_Env0 = nil
 }
 
+func (x *JoinAttrs) ClearGenericOidc() {
+	x.xxx_hidden_GenericOidc = nil
+}
+
 type JoinAttrs_builder struct {
 	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
 
@@ -447,6 +471,8 @@ type JoinAttrs_builder struct {
 	AzureDevops *JoinAttrsAzureDevops
 	// Attributes that are specific to the Env0 (`env0`) join method.
 	Env0 *JoinAttrsEnv0
+	// Attributes that are specific to the generic OIDC (`generic_oidc`) join method.
+	GenericOidc *JoinAttrsGenericOIDC
 }
 
 func (b0 JoinAttrs_builder) Build() *JoinAttrs {
@@ -468,6 +494,7 @@ func (b0 JoinAttrs_builder) Build() *JoinAttrs {
 	x.xxx_hidden_Oracle = b.Oracle
 	x.xxx_hidden_AzureDevops = b.AzureDevops
 	x.xxx_hidden_Env0 = b.Env0
+	x.xxx_hidden_GenericOidc = b.GenericOidc
 	return m0
 }
 
@@ -2982,11 +3009,81 @@ func (b0 JoinAttrsEnv0_builder) Build() *JoinAttrsEnv0 {
 	return m0
 }
 
+// Attributes that are specific to the generic OIDC (`generic_oidc`) join method.
+type JoinAttrsGenericOIDC struct {
+	state             protoimpl.MessageState `protogen:"opaque.v1"`
+	xxx_hidden_Claims *structpb.Struct       `protobuf:"bytes,1,opt,name=claims,proto3"`
+	unknownFields     protoimpl.UnknownFields
+	sizeCache         protoimpl.SizeCache
+}
+
+func (x *JoinAttrsGenericOIDC) Reset() {
+	*x = JoinAttrsGenericOIDC{}
+	mi := &file_teleport_workloadidentity_v1_join_attrs_proto_msgTypes[20]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *JoinAttrsGenericOIDC) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*JoinAttrsGenericOIDC) ProtoMessage() {}
+
+func (x *JoinAttrsGenericOIDC) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_workloadidentity_v1_join_attrs_proto_msgTypes[20]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+func (x *JoinAttrsGenericOIDC) GetClaims() *structpb.Struct {
+	if x != nil {
+		return x.xxx_hidden_Claims
+	}
+	return nil
+}
+
+func (x *JoinAttrsGenericOIDC) SetClaims(v *structpb.Struct) {
+	x.xxx_hidden_Claims = v
+}
+
+func (x *JoinAttrsGenericOIDC) HasClaims() bool {
+	if x == nil {
+		return false
+	}
+	return x.xxx_hidden_Claims != nil
+}
+
+func (x *JoinAttrsGenericOIDC) ClearClaims() {
+	x.xxx_hidden_Claims = nil
+}
+
+type JoinAttrsGenericOIDC_builder struct {
+	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
+
+	// A complete set of token claims.
+	Claims *structpb.Struct
+}
+
+func (b0 JoinAttrsGenericOIDC_builder) Build() *JoinAttrsGenericOIDC {
+	m0 := &JoinAttrsGenericOIDC{}
+	b, x := &b0, m0
+	_, _ = b, x
+	x.xxx_hidden_Claims = b.Claims
+	return m0
+}
+
 var File_teleport_workloadidentity_v1_join_attrs_proto protoreflect.FileDescriptor
 
 const file_teleport_workloadidentity_v1_join_attrs_proto_rawDesc = "" +
 	"\n" +
-	"-teleport/workloadidentity/v1/join_attrs.proto\x12\x1cteleport.workloadidentity.v1\"\xda\b\n" +
+	"-teleport/workloadidentity/v1/join_attrs.proto\x12\x1cteleport.workloadidentity.v1\x1a\x1cgoogle/protobuf/struct.proto\"\xb1\t\n" +
 	"\tJoinAttrs\x12?\n" +
 	"\x04meta\x18\x01 \x01(\v2+.teleport.workloadidentity.v1.JoinAttrsMetaR\x04meta\x12E\n" +
 	"\x06gitlab\x18\x02 \x01(\v2-.teleport.workloadidentity.v1.JoinAttrsGitLabR\x06gitlab\x12E\n" +
@@ -3005,7 +3102,8 @@ const file_teleport_workloadidentity_v1_join_attrs_proto_rawDesc = "" +
 	"kubernetes\x12E\n" +
 	"\x06oracle\x18\r \x01(\v2-.teleport.workloadidentity.v1.JoinAttrsOracleR\x06oracle\x12U\n" +
 	"\fazure_devops\x18\x0e \x01(\v22.teleport.workloadidentity.v1.JoinAttrsAzureDevopsR\vazureDevops\x12?\n" +
-	"\x04env0\x18\x0f \x01(\v2+.teleport.workloadidentity.v1.JoinAttrsEnv0R\x04env0\"X\n" +
+	"\x04env0\x18\x0f \x01(\v2+.teleport.workloadidentity.v1.JoinAttrsEnv0R\x04env0\x12U\n" +
+	"\fgeneric_oidc\x18\x10 \x01(\v22.teleport.workloadidentity.v1.JoinAttrsGenericOIDCR\vgenericOidc\"X\n" +
 	"\rJoinAttrsMeta\x12&\n" +
 	"\x0fjoin_token_name\x18\x01 \x01(\tR\rjoinTokenName\x12\x1f\n" +
 	"\vjoin_method\x18\x02 \x01(\tR\n" +
@@ -3150,9 +3248,11 @@ const file_teleport_workloadidentity_v1_join_attrs_proto_rawDesc = "" +
 	" \x01(\tR\x0fdeploymentLogId\x12'\n" +
 	"\x0fdeployment_type\x18\v \x01(\tR\x0edeploymentType\x12%\n" +
 	"\x0edeployer_email\x18\f \x01(\tR\rdeployerEmail\x12\x19\n" +
-	"\benv0_tag\x18\r \x01(\tR\aenv0TagBdZbgithub.com/gravitational/teleport/api/gen/proto/go/teleport/workloadidentity/v1;workloadidentityv1b\x06proto3"
+	"\benv0_tag\x18\r \x01(\tR\aenv0Tag\"G\n" +
+	"\x14JoinAttrsGenericOIDC\x12/\n" +
+	"\x06claims\x18\x01 \x01(\v2\x17.google.protobuf.StructR\x06claimsBdZbgithub.com/gravitational/teleport/api/gen/proto/go/teleport/workloadidentity/v1;workloadidentityv1b\x06proto3"
 
-var file_teleport_workloadidentity_v1_join_attrs_proto_msgTypes = make([]protoimpl.MessageInfo, 20)
+var file_teleport_workloadidentity_v1_join_attrs_proto_msgTypes = make([]protoimpl.MessageInfo, 21)
 var file_teleport_workloadidentity_v1_join_attrs_proto_goTypes = []any{
 	(*JoinAttrs)(nil),                         // 0: teleport.workloadidentity.v1.JoinAttrs
 	(*JoinAttrsMeta)(nil),                     // 1: teleport.workloadidentity.v1.JoinAttrsMeta
@@ -3174,6 +3274,8 @@ var file_teleport_workloadidentity_v1_join_attrs_proto_goTypes = []any{
 	(*JoinAttrsAzureDevops)(nil),              // 17: teleport.workloadidentity.v1.JoinAttrsAzureDevops
 	(*JoinAttrsAzureDevopsPipeline)(nil),      // 18: teleport.workloadidentity.v1.JoinAttrsAzureDevopsPipeline
 	(*JoinAttrsEnv0)(nil),                     // 19: teleport.workloadidentity.v1.JoinAttrsEnv0
+	(*JoinAttrsGenericOIDC)(nil),              // 20: teleport.workloadidentity.v1.JoinAttrsGenericOIDC
+	(*structpb.Struct)(nil),                   // 21: google.protobuf.Struct
 }
 var file_teleport_workloadidentity_v1_join_attrs_proto_depIdxs = []int32{
 	1,  // 0: teleport.workloadidentity.v1.JoinAttrs.meta:type_name -> teleport.workloadidentity.v1.JoinAttrsMeta
@@ -3191,15 +3293,17 @@ var file_teleport_workloadidentity_v1_join_attrs_proto_depIdxs = []int32{
 	16, // 12: teleport.workloadidentity.v1.JoinAttrs.oracle:type_name -> teleport.workloadidentity.v1.JoinAttrsOracle
 	17, // 13: teleport.workloadidentity.v1.JoinAttrs.azure_devops:type_name -> teleport.workloadidentity.v1.JoinAttrsAzureDevops
 	19, // 14: teleport.workloadidentity.v1.JoinAttrs.env0:type_name -> teleport.workloadidentity.v1.JoinAttrsEnv0
-	11, // 15: teleport.workloadidentity.v1.JoinAttrsGCP.gce:type_name -> teleport.workloadidentity.v1.JoinAttrsGCPGCE
-	14, // 16: teleport.workloadidentity.v1.JoinAttrsKubernetes.service_account:type_name -> teleport.workloadidentity.v1.JoinAttrsKubernetesServiceAccount
-	13, // 17: teleport.workloadidentity.v1.JoinAttrsKubernetes.pod:type_name -> teleport.workloadidentity.v1.JoinAttrsKubernetesPod
-	18, // 18: teleport.workloadidentity.v1.JoinAttrsAzureDevops.pipeline:type_name -> teleport.workloadidentity.v1.JoinAttrsAzureDevopsPipeline
-	19, // [19:19] is the sub-list for method output_type
-	19, // [19:19] is the sub-list for method input_type
-	19, // [19:19] is the sub-list for extension type_name
-	19, // [19:19] is the sub-list for extension extendee
-	0,  // [0:19] is the sub-list for field type_name
+	20, // 15: teleport.workloadidentity.v1.JoinAttrs.generic_oidc:type_name -> teleport.workloadidentity.v1.JoinAttrsGenericOIDC
+	11, // 16: teleport.workloadidentity.v1.JoinAttrsGCP.gce:type_name -> teleport.workloadidentity.v1.JoinAttrsGCPGCE
+	14, // 17: teleport.workloadidentity.v1.JoinAttrsKubernetes.service_account:type_name -> teleport.workloadidentity.v1.JoinAttrsKubernetesServiceAccount
+	13, // 18: teleport.workloadidentity.v1.JoinAttrsKubernetes.pod:type_name -> teleport.workloadidentity.v1.JoinAttrsKubernetesPod
+	18, // 19: teleport.workloadidentity.v1.JoinAttrsAzureDevops.pipeline:type_name -> teleport.workloadidentity.v1.JoinAttrsAzureDevopsPipeline
+	21, // 20: teleport.workloadidentity.v1.JoinAttrsGenericOIDC.claims:type_name -> google.protobuf.Struct
+	21, // [21:21] is the sub-list for method output_type
+	21, // [21:21] is the sub-list for method input_type
+	21, // [21:21] is the sub-list for extension type_name
+	21, // [21:21] is the sub-list for extension extendee
+	0,  // [0:21] is the sub-list for field type_name
 }
 
 func init() { file_teleport_workloadidentity_v1_join_attrs_proto_init() }
@@ -3213,7 +3317,7 @@ func file_teleport_workloadidentity_v1_join_attrs_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_teleport_workloadidentity_v1_join_attrs_proto_rawDesc), len(file_teleport_workloadidentity_v1_join_attrs_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   20,
+			NumMessages:   21,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/api/proto/teleport/legacy/types/types.proto
+++ b/api/proto/teleport/legacy/types/types.proto
@@ -18,6 +18,7 @@ package types;
 
 import "gogoproto/gogo.proto";
 import "google/protobuf/duration.proto";
+import "google/protobuf/struct.proto";
 import "google/protobuf/timestamp.proto";
 import "teleport/attestation/v1/attestation.proto";
 import "teleport/componentfeatures/v1/component_features.proto";
@@ -1637,6 +1638,8 @@ message ProvisionTokenSpecV2 {
   // Integration name which provides credentials for validating join attempts.
   // Currently only in use for validating the AWS Organization ID in the IAM Join method.
   string Integration = 22 [(gogoproto.jsontag) = "integration,omitempty"];
+  // GenericOIDC allows the configuration of generic OIDC join tokens.
+  ProvisionTokenSpecV2GenericOIDC GenericOIDC = 23 [(gogoproto.jsontag) = "generic_oidc,omitempty"];
 }
 
 // ProvisionTokenSpecV2AzureDevops contains the Azure Devops-specific
@@ -2223,6 +2226,131 @@ message ProvisionTokenSpecV2Env0 {
   // Allow is a list of Rules, jobs using this token must match at least one
   // allow rule to use this token.
   repeated Rule Allow = 1 [(gogoproto.jsontag) = "allow,omitempty"];
+}
+
+// ProvisionTokenSpecV2GenericOIDC contains configuration for generic_oidc join
+// tokens.
+message ProvisionTokenSpecV2GenericOIDC {
+  // The attribute casted to a string must be equal to the value.
+  message ConditionEq {
+    // The value to compare the attribute against.
+    string Value = 1 [(gogoproto.jsontag) = "value"];
+  }
+
+  // The attribute casted to a string must not be equal to the value.
+  message ConditionNotEq {
+    // The value to compare the attribute against.
+    string Value = 1 [(gogoproto.jsontag) = "value"];
+  }
+
+  // The attribute casted to a string must be in the list of values.
+  message ConditionIn {
+    // The list of values to compare the attribute against.
+    repeated string Values = 1 [(gogoproto.jsontag) = "values"];
+  }
+
+  // The attribute casted to a string must not be in the list of values.
+  message ConditionNotIn {
+    // The list of values to compare the attribute against.
+    repeated string Values = 1 [(gogoproto.jsontag) = "values"];
+  }
+
+  // An allow rule condition for simple checks against a specific field.
+  message Condition {
+    string Attribute = 1 [(gogoproto.jsontag) = "attribute"];
+    oneof operator {
+      ConditionEq Eq = 2 [(gogoproto.jsontag) = "eq"];
+      ConditionNotEq NotEq = 3 [(gogoproto.jsontag) = "not_eq"];
+      ConditionIn In = 4 [(gogoproto.jsontag) = "in"];
+      ConditionNotIn NotIn = 5 [(gogoproto.jsontag) = "not_in"];
+    }
+  }
+
+  // An allow rule, containing either a predict expression or simple field
+  // check.
+  message Rule {
+    // Conditions are simple eq/not_eq/in/not_in conditions that check
+    // individual fields. All conditions must be satisfied for a join attempt to
+    // be allowed. Mutually exclusive with `expression`.
+    repeated Condition Conditions = 1 [(gogoproto.jsontag) = "conditions,omitempty"];
+
+    // Expression is a predicate expression that must evaluate to `true` for the
+    // join attempt to be allowed. Expressions are provided the `claims` object,
+    // containing all claims extracted from the incoming JWT. It is mutually
+    // exclusive with `conditions`.
+    string Expression = 2 [(gogoproto.jsontag) = "expression,omitempty"];
+  }
+
+  // Issuer contains the expected `iss` value as written in the JWT you wish to
+  // trust. Unless `static_jwks` is configured, this issuer must be accessible
+  // over HTTPS to the Teleport cluster and must serve valid OIDC metadata,
+  // including discovery configuration and JWKS keys.
+  string Issuer = 1 [(gogoproto.jsontag) = "issuer"];
+
+  // InsecureAllowHTTPIssuer is a flag that, if set, disables the requirement
+  // that the issuer must use HTTPS.
+  bool InsecureAllowHTTPIssuer = 2 [(gogoproto.jsontag) = "insecure_allow_http_issuer"];
+
+  // Audience The expected audience value (required). This must match or be
+  // included in the list of `aud` values in the JWT provided by the client when
+  // joining.
+  // For providers that do not allow you to configure this value yourself (this
+  // is technically an OIDC spec violation, but is common), use the value they
+  // provide. Otherwise, we recommend using a value that uniquely identifies the
+  // Teleport cluster and join token. For example, you can use this scheme:
+  //   $clusterName/$tokenName
+  // For a cluster named `example.teleport.sh` and a token named `example`, this
+  // would result in an audience of `example.teleport.sh/example`. If you
+  // prefer, you can also use a UUID instead of the token name. Note that you
+  // will need to configure the matching value with the issuer, usually at
+  // request time.
+  string Audience = 3 [(gogoproto.jsontag) = "audience,omitempty"];
+
+  // StaticJWKS is an optional static JWKS value that can be used to specify
+  // JWKS keys when either OIDC discovery is either not supported by the
+  // provider or the discovery configuration is not accessible to Teleport. When
+  // set, configuration and JWKS keys will not be fetched from the URL contained
+  // in `issuer` and JWTs will be validated using the key set specified here.
+  string StaticJWKS = 4 [(gogoproto.jsontag) = "static_jwks,omitempty"];
+
+  // TLSCA is a TLS CA certificate that should be used to verify requests for
+  // OIDC metadata from the issuer instead of Teleport's CA store, useful if the
+  // issuer is not public or otherwise uses a self-signed certificate. Note that
+  // this value only applies to requests using this token, and will be used
+  // instead of and not in addition to the system CA store, and will need to be
+  // updated manually if the remote CA is updated.
+  string TLSCA = 5 [(gogoproto.jsontag) = "tls_ca,omitempty"];
+
+  // MustMatchFields perform simple comparison matches using "AND" semantics.
+  // Rules are specified by mirroring the structure of the JWT, using values
+  // that are expected to be equal to those on the incoming token. These field
+  // matching rules can only be used to compare simple values: strings, numbers,
+  // booleans, and nested fields. Complex values, including lists, will need to
+  // use `allow_any` expression rules instead.
+  //
+  // If any field match rules are specified, all must be equal to corresponding
+  // JWT fields for the join attempt to succeed. If complex rules are specified
+  // in `allow_any`, those are evaluated after `must_match_fields`. If
+  // `must_match_fields` is not specified or is empty, only rules in `allow_any`
+  // are evaluated.
+  //
+  // These rules can be used as "global" rules that apply to all join attempts.
+  // For example, you can use these to ensure all attempts originate from your
+  // organization, then use `allow_any` rules to allow individual repositories,
+  // pipelines, or workspaces.
+  //
+  // Note that at least one rule, either in `must_match_fields` or `allow_any`,
+  // must be specified for any join attempts to succeed.
+  google.protobuf.Struct MustMatchFields = 6 [(gogoproto.jsontag) = "must_match_fields"];
+
+  // AllowAny evaluates complex rules using "OR" semantics. If any rules are
+  // specified, at least one rule must evaluate to `true` for the join attempt
+  // to be allowed. These rules are evaluated after `must_match_fields`, if any
+  // field matchers are specified in that block.
+  //
+  // Note that at least one rule, either in `must_match_fields` or `allow_any`,
+  // must be specified for any join attempts to succeed.
+  repeated Rule AllowAny = 7 [(gogoproto.jsontag) = "allow_any"];
 }
 
 // ProvisionTokenSpecV2BoundKeypair contains configuration for bound_keypair

--- a/api/proto/teleport/legacy/types/types.proto
+++ b/api/proto/teleport/legacy/types/types.proto
@@ -2257,6 +2257,8 @@ message ProvisionTokenSpecV2GenericOIDC {
 
   // An allow rule condition for simple checks against a specific field.
   message Condition {
+    // The name of the field this condition should check, separated by "." for
+    // nested fields.
     string Attribute = 1 [(gogoproto.jsontag) = "attribute"];
 
     // An "equals" operator. Only one operator may be set within a condition.

--- a/api/proto/teleport/legacy/types/types.proto
+++ b/api/proto/teleport/legacy/types/types.proto
@@ -2349,7 +2349,10 @@ message ProvisionTokenSpecV2GenericOIDC {
   //
   // Note that at least one rule, either in `must_match_fields` or `allow_any`,
   // must be specified for any join attempts to succeed.
-  google.protobuf.Struct MustMatchFields = 6 [(gogoproto.jsontag) = "must_match_fields"];
+  google.protobuf.Struct MustMatchFields = 6 [
+    (gogoproto.jsontag) = "must_match_fields",
+    (gogoproto.casttype) = "Struct"
+  ];
 
   // AllowAny evaluates complex rules using "OR" semantics. If any rules are
   // specified, at least one rule must evaluate to `true` for the join attempt

--- a/api/proto/teleport/legacy/types/types.proto
+++ b/api/proto/teleport/legacy/types/types.proto
@@ -2258,12 +2258,18 @@ message ProvisionTokenSpecV2GenericOIDC {
   // An allow rule condition for simple checks against a specific field.
   message Condition {
     string Attribute = 1 [(gogoproto.jsontag) = "attribute"];
-    oneof operator {
-      ConditionEq Eq = 2 [(gogoproto.jsontag) = "eq"];
-      ConditionNotEq NotEq = 3 [(gogoproto.jsontag) = "not_eq"];
-      ConditionIn In = 4 [(gogoproto.jsontag) = "in"];
-      ConditionNotIn NotIn = 5 [(gogoproto.jsontag) = "not_in"];
-    }
+
+    // An "equals" operator. Only one operator may be set within a condition.
+    ConditionEq Eq = 2 [(gogoproto.jsontag) = "eq"];
+
+    // A "not equals" operator. Only one operator may be set within a condition.
+    ConditionNotEq NotEq = 3 [(gogoproto.jsontag) = "not_eq"];
+
+    // An "in" operator. Only one operator may be set within a condition.
+    ConditionIn In = 4 [(gogoproto.jsontag) = "in"];
+
+    // A "not in" operator. Only one operator may be set within a condition.
+    ConditionNotIn NotIn = 5 [(gogoproto.jsontag) = "not_in"];
   }
 
   // An allow rule, containing either a predict expression or simple field

--- a/api/proto/teleport/legacy/types/types.proto
+++ b/api/proto/teleport/legacy/types/types.proto
@@ -2297,7 +2297,7 @@ message ProvisionTokenSpecV2GenericOIDC {
   // that the issuer must use HTTPS.
   bool InsecureAllowHTTPIssuer = 2 [(gogoproto.jsontag) = "insecure_allow_http_issuer"];
 
-  // Audience The expected audience value (required). This must match or be
+  // Audience is the expected audience value (required). This must match or be
   // included in the list of `aud` values in the JWT provided by the client when
   // joining.
   // For providers that do not allow you to configure this value yourself (this

--- a/api/proto/teleport/scopes/joining/v1/token.proto
+++ b/api/proto/teleport/scopes/joining/v1/token.proto
@@ -533,13 +533,21 @@ message GenericOIDC {
 
   // An allow rule condition for simple checks against a specific field.
   message Condition {
+    // The name of the field this condition should check, separated by "." for
+    // nested fields.
     string attribute = 1;
-    oneof operator {
-      ConditionEq eq = 2;
-      ConditionNotEq not_eq = 3;
-      ConditionIn in = 4;
-      ConditionNotIn not_in = 5;
-    }
+
+    // An "equals" operator. Only one operator may be set within a condition.
+    ConditionEq eq = 2;
+
+    // A "not equals" operator. Only one operator may be set within a condition.
+    ConditionNotEq not_eq = 3;
+
+    // An "in" operator. Only one operator may be set within a condition.
+    ConditionIn in = 4;
+
+    // A "not in" operator. Only one operator may be set within a condition.
+    ConditionNotIn not_in = 5;
   }
 
   // An allow rule, containing either a predict expression or simple field

--- a/api/proto/teleport/scopes/joining/v1/token.proto
+++ b/api/proto/teleport/scopes/joining/v1/token.proto
@@ -16,6 +16,7 @@ syntax = "proto3";
 
 package teleport.scopes.joining.v1;
 
+import "google/protobuf/struct.proto";
 import "google/protobuf/timestamp.proto";
 import "teleport/header/v1/metadata.proto";
 
@@ -104,6 +105,9 @@ message ScopedTokenSpec {
   //
   // Mutually exclusive with assigned_scope.
   string bot = 15;
+
+  // Configuration specific to the "generic_oidc" join method.
+  GenericOIDC generic_oidc = 16;
 }
 
 // The host certificate parameters that should be cached and leveraged for
@@ -499,4 +503,121 @@ message BoundKeypairStatus {
   // a bot, or if no agent has joined yet. It is mutually exclusive with
   // bound_bot_instance_id but otherwise behaves identically.
   string bound_host_id = 7;
+}
+
+// Configuration for `generic_oidc`-type tokens.
+message GenericOIDC {
+  // The attribute casted to a string must be equal to the value.
+  message ConditionEq {
+    // The value to compare the attribute against.
+    string value = 1;
+  }
+
+  // The attribute casted to a string must not be equal to the value.
+  message ConditionNotEq {
+    // The value to compare the attribute against.
+    string value = 1;
+  }
+
+  // The attribute casted to a string must be in the list of values.
+  message ConditionIn {
+    // The list of values to compare the attribute against.
+    repeated string values = 1;
+  }
+
+  // The attribute casted to a string must not be in the list of values.
+  message ConditionNotIn {
+    // The list of values to compare the attribute against.
+    repeated string values = 1;
+  }
+
+  // An allow rule condition for simple checks against a specific field.
+  message Condition {
+    string attribute = 1;
+    oneof operator {
+      ConditionEq eq = 2;
+      ConditionNotEq not_eq = 3;
+      ConditionIn in = 4;
+      ConditionNotIn not_in = 5;
+    }
+  }
+
+  // An allow rule, containing either a predict expression or simple field
+  // check.
+  message Rule {
+    // Conditions are simple eq/not_eq/in/not_in conditions that check
+    // individual fields. All conditions must be satisfied for a join attempt to
+    // be allowed. Mutually exclusive with `expression`.
+    repeated Condition conditions = 1;
+
+    // A predicate expression that must evaluate to `true` for the join attempt
+    // to be allowed. It is mutually exclusive with `conditions`.
+    // TODO: Include name of variable available to the expr in docs
+    string expression = 2;
+  }
+
+  // The expected `iss` value as written in the JWT you wish to trust. Unless
+  // `static_jwks` is configured, this issuer must be accessible over HTTPS to
+  // the Teleport cluster and must serve valid OIDC metadata, including
+  // discovery configuration and JWKS keys.
+  string issuer = 1;
+
+  // If set, disables the requirement that the issuer must use HTTPS.
+  bool insecure_allow_http_issuer = 2;
+
+  // The expected JWT audience. If unset, this value will be set to the name of
+  // this Teleport cluster (e.g. example.teleport.sh). Where possible, this
+  // value should be unique to the Teleport cluster; issuing JWTs using the
+  // cluster as the audience is preferred. On providers where this is not
+  // possible, you can specify their server-defined value in this field. This
+  // value must match the audience in issued JWTs for join attempts to succeed.
+  string audience = 3;
+
+  // An optional static JWKS value that can be used to specify JWKS keys when
+  // either OIDC discovery is either not supported by the provider or the
+  // discovery configuration is not accessible to Teleport. When set,
+  // configuration and JWKS keys will not be fetched from the URL contained in
+  // `issuer` and JWTs will be validated using the key set specified here.
+  string static_jwks = 4;
+
+  // A TLS CA certificate that should be used to verify requests for OIDC
+  // metadata from the issuer instead of Teleport's CA store, useful if the
+  // issuer is not public or otherwise uses a self-signed certificate. If unset,
+  // the standard web PKI root certificates will be used to verify the
+  // connection to the issuer when fetching OIDC metadata. Note that this value
+  // only applies to requests using this token, and will be used instead of and
+  // not in addition to the system CA store, and will need to be updated
+  // manually if the remote CA is updated.
+  string tls_ca = 5;
+
+  // "Must match" fields perform simple comparison matches using "AND"
+  // semantics. Rules are specified by mirroring the structure of the JWT, using
+  // values that are expected to be equal to those on the incoming token. These
+  // field matching rules can only be used to compare simple values: strings,
+  // numbers, booleans, and nested fields. Complex values, including lists, will
+  // need to use `allow_any` expression rules instead.
+  //
+  // If any field match rules are specified, all must be equal to corresponding
+  // JWT fields for the join attempt to succeed. If complex rules are specified
+  // in `allow_any`, those are evaluated after `must_match_fields`. If
+  // `must_match_fields` is not specified or is empty, only rules in `allow_any`
+  // are evaluated.
+  //
+  // These rules can be used as "global" rules that apply to all join attempts.
+  // For example, you can use these to ensure all attempts originate from your
+  // organization, then use `allow_any` rules to allow individual repositories,
+  // pipelines, or workspaces.
+  //
+  // Note that at least one rule, either in `must_match_fields` or `allow_any`,
+  // must be specified for any join attempts to succeed.
+  google.protobuf.Struct must_match_fields = 6;
+
+  // Complex rules evaluated using "OR" semantics. If any rules are specified,
+  // at least one rule must evaluate to `true` for the join attempt/ to be
+  // allowed. These rules are evaluated after `must_match_fields`, if any field
+  // matchers are specified in that block.
+  //
+  // Note that at least one rule, either in `must_match_fields` or `allow_any`,
+  // must be specified for any join attempts to succeed.
+  repeated Rule allow_any = 7;
 }

--- a/api/proto/teleport/scopes/joining/v1/token.proto
+++ b/api/proto/teleport/scopes/joining/v1/token.proto
@@ -565,12 +565,20 @@ message GenericOIDC {
   // If set, disables the requirement that the issuer must use HTTPS.
   bool insecure_allow_http_issuer = 2;
 
-  // The expected JWT audience. If unset, this value will be set to the name of
-  // this Teleport cluster (e.g. example.teleport.sh). Where possible, this
-  // value should be unique to the Teleport cluster; issuing JWTs using the
-  // cluster as the audience is preferred. On providers where this is not
-  // possible, you can specify their server-defined value in this field. This
-  // value must match the audience in issued JWTs for join attempts to succeed.
+  // The expected JWT audience value (required). This must match or be included
+  // in the list of `aud` values in the JWT provided by the client when joining.
+  //
+  // For providers that do not allow you to configure this value yourself (this
+  // is technically an OIDC spec violation, but is common), use the value they
+  // provide. Otherwise, we recommend using a value that uniquely identifies the
+  // Teleport cluster and join token. For example, you can use this scheme:
+  //   $clusterName/$tokenName
+  //
+  // For a cluster named `example.teleport.sh` and a token named `example`, this
+  // would result in an audience of `example.teleport.sh/example`. If you
+  // prefer, you can also use a UUID instead of the token name. Note that you
+  // will need to configure the matching value with the issuer, usually at
+  // request time.
   string audience = 3;
 
   // An optional static JWKS value that can be used to specify JWKS keys when

--- a/api/proto/teleport/workloadidentity/v1/join_attrs.proto
+++ b/api/proto/teleport/workloadidentity/v1/join_attrs.proto
@@ -16,6 +16,8 @@ syntax = "proto3";
 
 package teleport.workloadidentity.v1;
 
+import "google/protobuf/struct.proto";
+
 option go_package = "github.com/gravitational/teleport/api/gen/proto/go/teleport/workloadidentity/v1;workloadidentityv1";
 
 // The collection of attributes that result from the join process.
@@ -51,6 +53,8 @@ message JoinAttrs {
   JoinAttrsAzureDevops azure_devops = 14;
   // Attributes that are specific to the Env0 (`env0`) join method.
   JoinAttrsEnv0 env0 = 15;
+  // Attributes that are specific to the generic OIDC (`generic_oidc`) join method.
+  JoinAttrsGenericOIDC generic_oidc = 16;
 }
 
 // The collection of attributes that result from the join process but are not
@@ -406,4 +410,10 @@ message JoinAttrsEnv0 {
   string deployer_email = 12;
   // A custom tag value corresponding to `env0Tag` when `ENV0_OIDC_TAG` is set.
   string env0_tag = 13;
+}
+
+// Attributes that are specific to the generic OIDC (`generic_oidc`) join method.
+message JoinAttrsGenericOIDC {
+  // A complete set of token claims.
+  google.protobuf.Struct claims = 1;
 }

--- a/api/types/provisioning.go
+++ b/api/types/provisioning.go
@@ -113,7 +113,6 @@ var JoinMethods = []JoinMethod{
 	JoinMethodOracle,
 	JoinMethodBoundKeypair,
 	JoinMethodEnv0,
-	JoinMethodGenericOIDC,
 }
 
 func ValidateJoinMethod(method JoinMethod) error {

--- a/api/types/provisioning.go
+++ b/api/types/provisioning.go
@@ -17,6 +17,7 @@ limitations under the License.
 package types
 
 import (
+	"bytes"
 	"crypto/x509"
 	"encoding/pem"
 	"fmt"
@@ -25,6 +26,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/gogo/protobuf/jsonpb" //nolint:depguard // needed for backwards compatibility
 	"github.com/gravitational/trace"
 
 	"github.com/gravitational/teleport/api/defaults"
@@ -1252,6 +1254,32 @@ func (a *ProvisionTokenSpecV2Env0) checkAndSetDefaults() error {
 	}
 
 	return nil
+}
+
+// MarshalJSON is a custom marshal implementation that uses jsonpb instead of
+// jsoniter-based `utils.FastMarshal`, which does not support struct fields and
+// instead silently discards their content. This uses jsonpb instead, which
+// properly preserves content.
+func (s *ProvisionTokenSpecV2GenericOIDC) MarshalJSON() ([]byte, error) {
+	// Note, preexisting precedent for this evil impl in PluginSyncFilter and
+	// others
+	var buf bytes.Buffer
+	if err := (&jsonpb.Marshaler{}).Marshal(&buf, s); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return buf.Bytes(), nil
+}
+
+// UnmarshalJSON is a custom unmarshal implementation that uses jsonpb instead
+// of the jsoniter-based `utils.FastUnmarshal`, which does not support struct
+// fields and instead silently discards their content.
+func (s *ProvisionTokenSpecV2GenericOIDC) UnmarshalJSON(data []byte) error {
+	unmarshaler := jsonpb.Unmarshaler{
+		AllowUnknownFields: true,
+	}
+
+	return trace.Wrap(unmarshaler.Unmarshal(bytes.NewReader(data), s))
 }
 
 func (a *ProvisionTokenSpecV2GenericOIDC) checkAndSetDefaults() error {

--- a/api/types/provisioning.go
+++ b/api/types/provisioning.go
@@ -90,6 +90,9 @@ const (
 	JoinMethodBoundKeypair JoinMethod = "bound_keypair"
 	// JoinMethodEnv0 indicates the node will join using the env0 join method.
 	JoinMethodEnv0 JoinMethod = "env0"
+	// JoinMethodGenericOIDC indicates the node will join using the generic_oidc
+	// join method.
+	JoinMethodGenericOIDC JoinMethod = "generic_oidc"
 )
 
 var JoinMethods = []JoinMethod{
@@ -110,6 +113,7 @@ var JoinMethods = []JoinMethod{
 	JoinMethodOracle,
 	JoinMethodBoundKeypair,
 	JoinMethodEnv0,
+	JoinMethodGenericOIDC,
 }
 
 func ValidateJoinMethod(method JoinMethod) error {
@@ -172,6 +176,8 @@ type ProvisionToken interface {
 	GetBoundKeypair() *ProvisionTokenSpecV2BoundKeypair
 	// GetBoundKeypairStatus returns bound keypair status for this token.
 	GetBoundKeypairStatus() *ProvisionTokenStatusV2BoundKeypair
+	// GetGenericOIDC returns generic_oidc-specific configuration for this token.
+	GetGenericOIDC() (*ProvisionTokenSpecV2GenericOIDC, error)
 	// GetAWSIIDTTL returns the TTL of EC2 IIDs
 	GetAWSIIDTTL() Duration
 	// GetJoinMethod returns joining method that must be used with this token.
@@ -505,6 +511,14 @@ func (p *ProvisionTokenV2) CheckAndSetDefaults() error {
 		if err := p.Spec.Env0.checkAndSetDefaults(); err != nil {
 			return trace.Wrap(err, "spec.env0: failed validation")
 		}
+	case JoinMethodGenericOIDC:
+		if p.Spec.GenericOIDC == nil {
+			p.Spec.GenericOIDC = &ProvisionTokenSpecV2GenericOIDC{}
+		}
+
+		if err := p.Spec.GenericOIDC.checkAndSetDefaults(); err != nil {
+			return trace.Wrap(err, "spec.generic_oidc: failed validation")
+		}
 	default:
 		return trace.BadParameter("unknown join method %q", p.Spec.JoinMethod)
 	}
@@ -600,6 +614,11 @@ func (p *ProvisionTokenV2) GetBoundKeypairStatus() *ProvisionTokenStatusV2BoundK
 		return nil
 	}
 	return p.Status.BoundKeypair
+}
+
+// GetGenericOIDC returns generic_oidc-specific configuration for this token.
+func (p *ProvisionTokenV2) GetGenericOIDC() (*ProvisionTokenSpecV2GenericOIDC, error) {
+	return p.Spec.GenericOIDC, nil
 }
 
 // GetJoinMethod returns joining method that must be used with this token.
@@ -1231,6 +1250,77 @@ func (a *ProvisionTokenSpecV2Env0) checkAndSetDefaults() error {
 		if allowRule.ProjectID == "" && allowRule.ProjectName == "" {
 			return trace.BadParameter("allow[%d]: at least one of ['project_id', 'project_name'] must be set", i)
 		}
+	}
+
+	return nil
+}
+
+func (a *ProvisionTokenSpecV2GenericOIDC) checkAndSetDefaults() error {
+	if a.Issuer == "" {
+		return trace.BadParameter("%s: issuer is required", JoinMethodGenericOIDC)
+	}
+
+	if a.Audience == "" {
+		return trace.BadParameter("%s: audience is required", JoinMethodGenericOIDC)
+	}
+
+	hasAnyAllowAny := len(a.AllowAny) > 0
+	hasAnyMustMatchFields := false
+	if a.MustMatchFields != nil {
+		hasAnyMustMatchFields = len(a.MustMatchFields.Fields) > 0
+	}
+
+	// At least one must_match_fields or allow_any rule is required; this check
+	// is a simpler variant of the one in genericoidc's
+	// `validateFieldRulesContainsAnyRule` and won't catch useless nesting
+	// checks; we'll catch those at runtime to avoid an unnecessary api/ import.
+	if !hasAnyAllowAny && !hasAnyMustMatchFields {
+		return trace.BadParameter("the %q join method requires at least "+
+			"one rule under either `must_match_fields` or `allow_any`",
+			JoinMethodGenericOIDC)
+	}
+
+	for i, rule := range a.AllowAny {
+		if rule.Expression != "" && len(rule.Conditions) > 0 {
+			return trace.BadParameter("allow_any[%d]: only one of `expression` or `conditions` may be set", i)
+		}
+
+		for j, cond := range rule.Conditions {
+			if cond.Attribute == "" {
+				return trace.BadParameter("allow_any[%d].conditions[%d]: attribute is required", i, j)
+			}
+
+			conds := 0
+			if cond.Eq != nil {
+				conds++
+			}
+			if cond.NotEq != nil {
+				conds++
+			}
+			if cond.In != nil {
+				conds++
+			}
+			if cond.NotIn != nil {
+				conds++
+			}
+
+			if conds == 0 || conds > 1 {
+				return trace.BadParameter("allow_any[%d].conditions[%d]: exactly one operator is required", i, j)
+			}
+		}
+	}
+
+	parsed, err := url.Parse(a.Issuer)
+	if err != nil {
+		return trace.BadParameter("issuer: must be a valid URL")
+	}
+
+	if parsed.Scheme == "http" {
+		if !a.InsecureAllowHTTPIssuer {
+			return trace.BadParameter("issuer: must be https:// unless insecure_allow_http_issuer is set")
+		}
+	} else if parsed.Scheme != "https" {
+		return trace.BadParameter("issuer: invalid URL scheme, must be https://")
 	}
 
 	return nil

--- a/api/types/provisioning.go
+++ b/api/types/provisioning.go
@@ -17,7 +17,6 @@ limitations under the License.
 package types
 
 import (
-	"bytes"
 	"crypto/x509"
 	"encoding/pem"
 	"fmt"
@@ -26,7 +25,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/gogo/protobuf/jsonpb" //nolint:depguard // needed for backwards compatibility
 	"github.com/gravitational/trace"
 
 	"github.com/gravitational/teleport/api/defaults"
@@ -1254,32 +1252,6 @@ func (a *ProvisionTokenSpecV2Env0) checkAndSetDefaults() error {
 	}
 
 	return nil
-}
-
-// MarshalJSON is a custom marshal implementation that uses jsonpb instead of
-// jsoniter-based `utils.FastMarshal`, which does not support struct fields and
-// instead silently discards their content. This uses jsonpb instead, which
-// properly preserves content.
-func (s *ProvisionTokenSpecV2GenericOIDC) MarshalJSON() ([]byte, error) {
-	// Note, preexisting precedent for this evil impl in PluginSyncFilter and
-	// others
-	var buf bytes.Buffer
-	if err := (&jsonpb.Marshaler{}).Marshal(&buf, s); err != nil {
-		return nil, trace.Wrap(err)
-	}
-
-	return buf.Bytes(), nil
-}
-
-// UnmarshalJSON is a custom unmarshal implementation that uses jsonpb instead
-// of the jsoniter-based `utils.FastUnmarshal`, which does not support struct
-// fields and instead silently discards their content.
-func (s *ProvisionTokenSpecV2GenericOIDC) UnmarshalJSON(data []byte) error {
-	unmarshaler := jsonpb.Unmarshaler{
-		AllowUnknownFields: true,
-	}
-
-	return trace.Wrap(unmarshaler.Unmarshal(bytes.NewReader(data), s))
 }
 
 func (a *ProvisionTokenSpecV2GenericOIDC) checkAndSetDefaults() error {

--- a/api/types/provisioning_test.go
+++ b/api/types/provisioning_test.go
@@ -1920,15 +1920,13 @@ func TestProvisionTokenV2_CheckAndSetDefaults(t *testing.T) {
 						Audience:                "example.teleport.sh",
 						StaticJWKS:              "asdf",
 						TLSCA:                   "zxcv",
-						MustMatchFields: &types.Struct{
-							Fields: map[string]*types.Value{
-								"foo": {
-									Kind: &types.Value_StringValue{
-										StringValue: "bar",
-									},
+						MustMatchFields: NewStructFromGogoValues(map[string]*types.Value{
+							"foo": {
+								Kind: &types.Value_StringValue{
+									StringValue: "bar",
 								},
 							},
-						},
+						}),
 						AllowAny: []*ProvisionTokenSpecV2GenericOIDC_Rule{
 							{
 								Expression: "claims.foo == \"bar\"",
@@ -1962,10 +1960,8 @@ func TestProvisionTokenV2_CheckAndSetDefaults(t *testing.T) {
 						Audience:                "example.teleport.sh",
 						StaticJWKS:              "asdf",
 						TLSCA:                   "zxcv",
-						MustMatchFields: &types.Struct{
-							Fields: map[string]*types.Value{},
-						},
-						AllowAny: []*ProvisionTokenSpecV2GenericOIDC_Rule{},
+						MustMatchFields:         NewStructFromGogoValues(map[string]*types.Value{}),
+						AllowAny:                []*ProvisionTokenSpecV2GenericOIDC_Rule{},
 					},
 				},
 			},
@@ -1986,9 +1982,7 @@ func TestProvisionTokenV2_CheckAndSetDefaults(t *testing.T) {
 						Audience:                "example.teleport.sh",
 						StaticJWKS:              "asdf",
 						TLSCA:                   "zxcv",
-						MustMatchFields: &types.Struct{
-							Fields: map[string]*types.Value{},
-						},
+						MustMatchFields:         NewStructFromGogoValues(map[string]*types.Value{}),
 						AllowAny: []*ProvisionTokenSpecV2GenericOIDC_Rule{
 							{Expression: "claims.foo == \"bar\""},
 						},
@@ -2012,9 +2006,7 @@ func TestProvisionTokenV2_CheckAndSetDefaults(t *testing.T) {
 						Audience:                "example.teleport.sh",
 						StaticJWKS:              "asdf",
 						TLSCA:                   "zxcv",
-						MustMatchFields: &types.Struct{
-							Fields: map[string]*types.Value{},
-						},
+						MustMatchFields:         NewStructFromGogoValues(map[string]*types.Value{}),
 						AllowAny: []*ProvisionTokenSpecV2GenericOIDC_Rule{
 							{Expression: "claims.foo == \"bar\""},
 						},
@@ -2038,9 +2030,7 @@ func TestProvisionTokenV2_CheckAndSetDefaults(t *testing.T) {
 						Audience:                "example.teleport.sh",
 						StaticJWKS:              "asdf",
 						TLSCA:                   "zxcv",
-						MustMatchFields: &types.Struct{
-							Fields: map[string]*types.Value{},
-						},
+						MustMatchFields:         NewStructFromGogoValues(map[string]*types.Value{}),
 						AllowAny: []*ProvisionTokenSpecV2GenericOIDC_Rule{
 							{Expression: "claims.foo == \"bar\""},
 						},

--- a/api/types/provisioning_test.go
+++ b/api/types/provisioning_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/gogo/protobuf/types"
 	"github.com/gravitational/trace"
 	"github.com/stretchr/testify/require"
 
@@ -1903,6 +1904,150 @@ func TestProvisionTokenV2_CheckAndSetDefaults(t *testing.T) {
 				},
 			},
 			wantErr: true,
+		},
+		{
+			desc: "generic oidc success",
+			token: &ProvisionTokenV2{
+				Metadata: Metadata{
+					Name: "test",
+				},
+				Spec: ProvisionTokenSpecV2{
+					Roles:      []SystemRole{RoleNode},
+					JoinMethod: JoinMethodGenericOIDC,
+					GenericOIDC: &ProvisionTokenSpecV2GenericOIDC{
+						Issuer:                  "https://example.teleport.sh",
+						InsecureAllowHTTPIssuer: false,
+						Audience:                "example.teleport.sh",
+						StaticJWKS:              "asdf",
+						TLSCA:                   "zxcv",
+						MustMatchFields: &types.Struct{
+							Fields: map[string]*types.Value{
+								"foo": {
+									Kind: &types.Value_StringValue{
+										StringValue: "bar",
+									},
+								},
+							},
+						},
+						AllowAny: []*ProvisionTokenSpecV2GenericOIDC_Rule{
+							{
+								Expression: "claims.foo == \"bar\"",
+							},
+							{
+								Conditions: []*ProvisionTokenSpecV2GenericOIDC_Condition{
+									{
+										Attribute: "foo",
+										Eq:        &ProvisionTokenSpecV2GenericOIDC_ConditionEq{Value: "bar"},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			desc: "generic oidc failure with no rules",
+			token: &ProvisionTokenV2{
+				Metadata: Metadata{
+					Name: "test",
+				},
+				Spec: ProvisionTokenSpecV2{
+					Roles:      []SystemRole{RoleNode},
+					JoinMethod: JoinMethodGenericOIDC,
+					GenericOIDC: &ProvisionTokenSpecV2GenericOIDC{
+						Issuer:                  "https://example.teleport.sh",
+						InsecureAllowHTTPIssuer: false,
+						Audience:                "example.teleport.sh",
+						StaticJWKS:              "asdf",
+						TLSCA:                   "zxcv",
+						MustMatchFields: &types.Struct{
+							Fields: map[string]*types.Value{},
+						},
+						AllowAny: []*ProvisionTokenSpecV2GenericOIDC_Rule{},
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			desc: "generic oidc failure with invalid issuer",
+			token: &ProvisionTokenV2{
+				Metadata: Metadata{
+					Name: "test",
+				},
+				Spec: ProvisionTokenSpecV2{
+					Roles:      []SystemRole{RoleNode},
+					JoinMethod: JoinMethodGenericOIDC,
+					GenericOIDC: &ProvisionTokenSpecV2GenericOIDC{
+						Issuer:                  "invalid",
+						InsecureAllowHTTPIssuer: false,
+						Audience:                "example.teleport.sh",
+						StaticJWKS:              "asdf",
+						TLSCA:                   "zxcv",
+						MustMatchFields: &types.Struct{
+							Fields: map[string]*types.Value{},
+						},
+						AllowAny: []*ProvisionTokenSpecV2GenericOIDC_Rule{
+							{Expression: "claims.foo == \"bar\""},
+						},
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			desc: "generic oidc failure with http issuer without opt-in",
+			token: &ProvisionTokenV2{
+				Metadata: Metadata{
+					Name: "test",
+				},
+				Spec: ProvisionTokenSpecV2{
+					Roles:      []SystemRole{RoleNode},
+					JoinMethod: JoinMethodGenericOIDC,
+					GenericOIDC: &ProvisionTokenSpecV2GenericOIDC{
+						Issuer:                  "http://invalid.com",
+						InsecureAllowHTTPIssuer: false,
+						Audience:                "example.teleport.sh",
+						StaticJWKS:              "asdf",
+						TLSCA:                   "zxcv",
+						MustMatchFields: &types.Struct{
+							Fields: map[string]*types.Value{},
+						},
+						AllowAny: []*ProvisionTokenSpecV2GenericOIDC_Rule{
+							{Expression: "claims.foo == \"bar\""},
+						},
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			desc: "generic oidc sucess with http issuer with opt-in",
+			token: &ProvisionTokenV2{
+				Metadata: Metadata{
+					Name: "test",
+				},
+				Spec: ProvisionTokenSpecV2{
+					Roles:      []SystemRole{RoleNode},
+					JoinMethod: JoinMethodGenericOIDC,
+					GenericOIDC: &ProvisionTokenSpecV2GenericOIDC{
+						Issuer:                  "http://invalid.com",
+						InsecureAllowHTTPIssuer: true,
+						Audience:                "example.teleport.sh",
+						StaticJWKS:              "asdf",
+						TLSCA:                   "zxcv",
+						MustMatchFields: &types.Struct{
+							Fields: map[string]*types.Value{},
+						},
+						AllowAny: []*ProvisionTokenSpecV2GenericOIDC_Rule{
+							{Expression: "claims.foo == \"bar\""},
+						},
+					},
+				},
+			},
+			wantErr: false,
 		},
 	}
 

--- a/api/types/provisioning_test.go
+++ b/api/types/provisioning_test.go
@@ -2024,7 +2024,7 @@ func TestProvisionTokenV2_CheckAndSetDefaults(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			desc: "generic oidc sucess with http issuer with opt-in",
+			desc: "generic oidc success with http issuer with opt-in",
 			token: &ProvisionTokenV2{
 				Metadata: Metadata{
 					Name: "test",

--- a/api/types/struct.go
+++ b/api/types/struct.go
@@ -1,0 +1,63 @@
+/*
+Copyright 2026 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package types
+
+import (
+	"bytes"
+
+	"github.com/gogo/protobuf/jsonpb"
+	gogotypes "github.com/gogo/protobuf/types"
+	"github.com/gravitational/trace"
+)
+
+// Struct is a wrapper around [gogotypes.Struct] mirroring a similar variant in
+// api/types/struct.go, which we can't import here as it would cause a cycle.
+type Struct struct {
+	gogotypes.Struct
+}
+
+func (s *Struct) MarshalJSON() ([]byte, error) {
+	var buf bytes.Buffer
+	if err := (&jsonpb.Marshaler{}).Marshal(&buf, &s.Struct); err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return buf.Bytes(), nil
+}
+
+func (s *Struct) UnmarshalJSON(data []byte) error {
+	if len(data) == 0 {
+		return nil
+	}
+
+	if err := (&jsonpb.Unmarshaler{
+		AllowUnknownFields: true,
+	}).Unmarshal(bytes.NewReader(data), &s.Struct); err != nil {
+		return trace.Wrap(err)
+	}
+
+	return nil
+}
+
+// NewStructFromGogoValues returns a new struct wrapper from an unpacked map of
+// [gogotypes.Value], useful for constructing struct types in tests.
+func NewStructFromGogoValues(fields map[string]*gogotypes.Value) *Struct {
+	return &Struct{
+		Struct: gogotypes.Struct{
+			Fields: fields,
+		},
+	}
+}

--- a/api/types/struct.go
+++ b/api/types/struct.go
@@ -19,7 +19,7 @@ package types
 import (
 	"bytes"
 
-	"github.com/gogo/protobuf/jsonpb"
+	"github.com/gogo/protobuf/jsonpb" //nolint:depguard // needed for backwards compatibility
 	gogotypes "github.com/gogo/protobuf/types"
 	"github.com/gravitational/trace"
 )

--- a/api/types/struct.go
+++ b/api/types/struct.go
@@ -52,6 +52,15 @@ func (s *Struct) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+// GogoStruct returns the inner gogo-style struct
+func (s *Struct) GogoStruct() *gogotypes.Struct {
+	if s == nil {
+		return nil
+	}
+
+	return &s.Struct
+}
+
 // NewStructFromGogoValues returns a new struct wrapper from an unpacked map of
 // [gogotypes.Value], useful for constructing struct types in tests.
 func NewStructFromGogoValues(fields map[string]*gogotypes.Value) *Struct {
@@ -60,4 +69,13 @@ func NewStructFromGogoValues(fields map[string]*gogotypes.Value) *Struct {
 			Fields: fields,
 		},
 	}
+}
+
+// NewStruct converts a gogo struct to our wrapped variant
+func NewStruct(s *gogotypes.Struct) *Struct {
+	if s == nil {
+		return nil
+	}
+
+	return &Struct{Struct: *s}
 }

--- a/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-provisiontokens.mdx
+++ b/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-provisiontokens.mdx
@@ -39,6 +39,7 @@ resource, which you can apply after installing the Teleport Kubernetes operator.
 |circleci|[object](#speccircleci)|CircleCI allows the configuration of options specific to the "circleci" join method.|
 |env0|[object](#specenv0)|Env0 allows the configuration of options specific to the "env0" join method.|
 |gcp|[object](#specgcp)|GCP allows the configuration of options specific to the "gcp" join method.|
+|generic_oidc|[object](#specgeneric_oidc)|GenericOIDC allows the configuration of generic OIDC join tokens.|
 |github|[object](#specgithub)|GitHub allows the configuration of options specific to the "github" join method.|
 |gitlab|[object](#specgitlab)|GitLab allows the configuration of options specific to the "gitlab" join method.|
 |integration|string|Integration name which provides credentials for validating join attempts. Currently only in use for validating the AWS Organization ID in the IAM Join method.|
@@ -193,6 +194,59 @@ resource, which you can apply after installing the Teleport Kubernetes operator.
 |locations|[]string||
 |project_ids|[]string||
 |service_accounts|[]string||
+
+### spec.generic_oidc
+
+|Field|Type|Description|
+|---|---|---|
+|allow_any|[][object](#specgeneric_oidcallow_any-items)|AllowAny evaluates complex rules using "OR" semantics. If any rules are specified, at least one rule must evaluate to `true` for the join attempt to be allowed. These rules are evaluated after `must_match_fields`, if any field matchers are specified in that block.  Note that at least one rule, either in `must_match_fields` or `allow_any`, must be specified for any join attempts to succeed.|
+|audience|string|Audience is the expected audience value (required). This must match or be included in the list of `aud` values in the JWT provided by the client when joining. For providers that do not allow you to configure this value yourself (this is technically an OIDC spec violation, but is common), use the value they provide. Otherwise, we recommend using a value that uniquely identifies the Teleport cluster and join token. For example, you can use this scheme: $clusterName/$tokenName For a cluster named `example.teleport.sh` and a token named `example`, this would result in an audience of `example.teleport.sh/example`. If you prefer, you can also use a UUID instead of the token name. Note that you will need to configure the matching value with the issuer, usually at request time.|
+|insecure_allow_http_issuer|boolean|InsecureAllowHTTPIssuer is a flag that, if set, disables the requirement that the issuer must use HTTPS.|
+|issuer|string|Issuer contains the expected `iss` value as written in the JWT you wish to trust. Unless `static_jwks` is configured, this issuer must be accessible over HTTPS to the Teleport cluster and must serve valid OIDC metadata, including discovery configuration and JWKS keys.|
+|must_match_fields|object|MustMatchFields perform simple comparison matches using "AND" semantics. Rules are specified by mirroring the structure of the JWT, using values that are expected to be equal to those on the incoming token. These field matching rules can only be used to compare simple values: strings, numbers, booleans, and nested fields. Complex values, including lists, will need to use `allow_any` expression rules instead.  If any field match rules are specified, all must be equal to corresponding JWT fields for the join attempt to succeed. If complex rules are specified in `allow_any`, those are evaluated after `must_match_fields`. If `must_match_fields` is not specified or is empty, only rules in `allow_any` are evaluated.  These rules can be used as "global" rules that apply to all join attempts. For example, you can use these to ensure all attempts originate from your organization, then use `allow_any` rules to allow individual repositories, pipelines, or workspaces.  Note that at least one rule, either in `must_match_fields` or `allow_any`, must be specified for any join attempts to succeed.|
+|static_jwks|string|StaticJWKS is an optional static JWKS value that can be used to specify JWKS keys when either OIDC discovery is either not supported by the provider or the discovery configuration is not accessible to Teleport. When set, configuration and JWKS keys will not be fetched from the URL contained in `issuer` and JWTs will be validated using the key set specified here.|
+|tls_ca|string|TLSCA is a TLS CA certificate that should be used to verify requests for OIDC metadata from the issuer instead of Teleport's CA store, useful if the issuer is not public or otherwise uses a self-signed certificate. Note that this value only applies to requests using this token, and will be used instead of and not in addition to the system CA store, and will need to be updated manually if the remote CA is updated.|
+
+### spec.generic_oidc.allow_any items
+
+|Field|Type|Description|
+|---|---|---|
+|conditions|[][object](#specgeneric_oidcallow_any-itemsconditions-items)||
+|expression|string||
+
+### spec.generic_oidc.allow_any items.conditions items
+
+|Field|Type|Description|
+|---|---|---|
+|attribute|string||
+|eq|[object](#specgeneric_oidcallow_any-itemsconditions-itemseq)||
+|in|[object](#specgeneric_oidcallow_any-itemsconditions-itemsin)||
+|not_eq|[object](#specgeneric_oidcallow_any-itemsconditions-itemsnot_eq)||
+|not_in|[object](#specgeneric_oidcallow_any-itemsconditions-itemsnot_in)||
+
+### spec.generic_oidc.allow_any items.conditions items.eq
+
+|Field|Type|Description|
+|---|---|---|
+|value|string||
+
+### spec.generic_oidc.allow_any items.conditions items.in
+
+|Field|Type|Description|
+|---|---|---|
+|values|[]string||
+
+### spec.generic_oidc.allow_any items.conditions items.not_eq
+
+|Field|Type|Description|
+|---|---|---|
+|value|string||
+
+### spec.generic_oidc.allow_any items.conditions items.not_in
+
+|Field|Type|Description|
+|---|---|---|
+|values|[]string||
 
 ### spec.github
 

--- a/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-scopedtokensv1.mdx
+++ b/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-scopedtokensv1.mdx
@@ -37,6 +37,7 @@ resource, which you can apply after installing the Teleport Kubernetes operator.
 |bot|string|The bot associated with this join token, if any, as a scope-qualified name of the form `<scope>::<bot-name>` (e.g. "/staging/west::mybot"). The scope component must be a descendant of or equivalent to the token's resource scope.  Mutually exclusive with assigned_scope.|
 |bound_keypair|[object](#specbound_keypair)|Configuration specific to the "bound_keypair" join method.|
 |gcp|[object](#specgcp)|The GCP-specific configuration used with the "gcp" join method.|
+|generic_oidc|[object](#specgeneric_oidc)|Configuration specific to the "generic_oidc" join method.|
 |immutable_labels|[object](#specimmutable_labels)|Immutable labels that should be applied to any resulting resources provisioned using this token.|
 |join_method|string|The joining method required in order to use this token. Note that not all join methods support joining with scoped tokens.|
 |kubernetes|[object](#speckubernetes)|The Kubernetes-specific configuration used with the "kubernetes" join method.|
@@ -132,6 +133,59 @@ resource, which you can apply after installing the Teleport Kubernetes operator.
 |locations|[]string||
 |project_ids|[]string||
 |service_accounts|[]string||
+
+### spec.generic_oidc
+
+|Field|Type|Description|
+|---|---|---|
+|allow_any|[][object](#specgeneric_oidcallow_any-items)|Complex rules evaluated using "OR" semantics. If any rules are specified, at least one rule must evaluate to `true` for the join attempt/ to be allowed. These rules are evaluated after `must_match_fields`, if any field matchers are specified in that block.  Note that at least one rule, either in `must_match_fields` or `allow_any`, must be specified for any join attempts to succeed.|
+|audience|string|The expected JWT audience value (required). This must match or be included in the list of `aud` values in the JWT provided by the client when joining.  For providers that do not allow you to configure this value yourself (this is technically an OIDC spec violation, but is common), use the value they provide. Otherwise, we recommend using a value that uniquely identifies the Teleport cluster and join token. For example, you can use this scheme: $clusterName/$tokenName  For a cluster named `example.teleport.sh` and a token named `example`, this would result in an audience of `example.teleport.sh/example`. If you prefer, you can also use a UUID instead of the token name. Note that you will need to configure the matching value with the issuer, usually at request time.|
+|insecure_allow_http_issuer|boolean|If set, disables the requirement that the issuer must use HTTPS.|
+|issuer|string|The expected `iss` value as written in the JWT you wish to trust. Unless `static_jwks` is configured, this issuer must be accessible over HTTPS to the Teleport cluster and must serve valid OIDC metadata, including discovery configuration and JWKS keys.|
+|must_match_fields|object|"Must match" fields perform simple comparison matches using "AND" semantics. Rules are specified by mirroring the structure of the JWT, using values that are expected to be equal to those on the incoming token. These field matching rules can only be used to compare simple values: strings, numbers, booleans, and nested fields. Complex values, including lists, will need to use `allow_any` expression rules instead.  If any field match rules are specified, all must be equal to corresponding JWT fields for the join attempt to succeed. If complex rules are specified in `allow_any`, those are evaluated after `must_match_fields`. If `must_match_fields` is not specified or is empty, only rules in `allow_any` are evaluated.  These rules can be used as "global" rules that apply to all join attempts. For example, you can use these to ensure all attempts originate from your organization, then use `allow_any` rules to allow individual repositories, pipelines, or workspaces.  Note that at least one rule, either in `must_match_fields` or `allow_any`, must be specified for any join attempts to succeed.|
+|static_jwks|string|An optional static JWKS value that can be used to specify JWKS keys when either OIDC discovery is either not supported by the provider or the discovery configuration is not accessible to Teleport. When set, configuration and JWKS keys will not be fetched from the URL contained in `issuer` and JWTs will be validated using the key set specified here.|
+|tls_ca|string|A TLS CA certificate that should be used to verify requests for OIDC metadata from the issuer instead of Teleport's CA store, useful if the issuer is not public or otherwise uses a self-signed certificate. If unset, the standard web PKI root certificates will be used to verify the connection to the issuer when fetching OIDC metadata. Note that this value only applies to requests using this token, and will be used instead of and not in addition to the system CA store, and will need to be updated manually if the remote CA is updated.|
+
+### spec.generic_oidc.allow_any items
+
+|Field|Type|Description|
+|---|---|---|
+|conditions|[][object](#specgeneric_oidcallow_any-itemsconditions-items)||
+|expression|string||
+
+### spec.generic_oidc.allow_any items.conditions items
+
+|Field|Type|Description|
+|---|---|---|
+|attribute|string||
+|eq|[object](#specgeneric_oidcallow_any-itemsconditions-itemseq)||
+|in|[object](#specgeneric_oidcallow_any-itemsconditions-itemsin)||
+|not_eq|[object](#specgeneric_oidcallow_any-itemsconditions-itemsnot_eq)||
+|not_in|[object](#specgeneric_oidcallow_any-itemsconditions-itemsnot_in)||
+
+### spec.generic_oidc.allow_any items.conditions items.eq
+
+|Field|Type|Description|
+|---|---|---|
+|value|string||
+
+### spec.generic_oidc.allow_any items.conditions items.in
+
+|Field|Type|Description|
+|---|---|---|
+|values|[]string||
+
+### spec.generic_oidc.allow_any items.conditions items.not_eq
+
+|Field|Type|Description|
+|---|---|---|
+|value|string||
+
+### spec.generic_oidc.allow_any items.conditions items.not_in
+
+|Field|Type|Description|
+|---|---|---|
+|values|[]string||
 
 ### spec.immutable_labels
 

--- a/docs/pages/reference/infrastructure-as-code/teleport-resources/bot-instance.mdx
+++ b/docs/pages/reference/infrastructure-as-code/teleport-resources/bot-instance.mdx
@@ -228,6 +228,7 @@ kubernetes: # [...]
 oracle: # [...]
 azure_devops: # [...]
 env0: # [...]
+generic_oidc: # [...]
 ```
 
 |Field Name|Description|Type|
@@ -238,6 +239,7 @@ env0: # [...]
 |circleci|Attributes that are specific to the CircleCI (`circleci`) join method.|[Join Attrs CircleCI](#join-attrs-circleci)|
 |env0|Attributes that are specific to the Env0 (`env0`) join method.|[Join Attrs Env0](#join-attrs-env0)|
 |gcp|Attributes that are specific to the GCP (`gcp`) join method.|[Join Attrs GCP](#join-attrs-gcp)|
+|generic_oidc|Attributes that are specific to the generic OIDC (`generic_oidc`) join method.|[Join Attrs Generic OIDC](#join-attrs-generic-oidc)|
 |github|Attributes that are specific to the GitHub (`github`) join method.|[Join Attrs GitHub](#join-attrs-github)|
 |gitlab|Attributes that are specific to the GitLab (`gitlab`) join method.|[Join Attrs GitLab](#join-attrs-gitlab)|
 |iam|Attributes that are specific to the AWS IAM (`iam`) join method.|[Join Attrs AWS IAM](#join-attrs-aws-iam)|
@@ -459,6 +461,21 @@ project: "string"
 |name|The name of the GCE instance that the joining entity is running on.|string|
 |project|The project ID of the GCP project that the instance is running within.|string|
 |zone|The zone of the GCE instance that the joining entity is running on.|string|
+
+## Join Attrs Generic OIDC
+
+Attributes that are specific to the generic OIDC (`generic_oidc`) join method.
+
+
+Example:
+
+```yaml
+claims: # See description
+```
+
+|Field Name|Description|Type|
+|---|---|---|
+|claims|A complete set of token claims.||
 
 ## Join Attrs GitHub
 

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/provision_token.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/provision_token.mdx
@@ -50,6 +50,7 @@ Optional:
 - `circleci` (Attributes) CircleCI allows the configuration of options specific to the "circleci" join method. (see [below for nested schema](#nested-schema-for-speccircleci))
 - `env0` (Attributes) Env0 allows the configuration of options specific to the "env0" join method. (see [below for nested schema](#nested-schema-for-specenv0))
 - `gcp` (Attributes) GCP allows the configuration of options specific to the "gcp" join method. (see [below for nested schema](#nested-schema-for-specgcp))
+- `generic_oidc` (Attributes) GenericOIDC allows the configuration of generic OIDC join tokens. (see [below for nested schema](#nested-schema-for-specgeneric_oidc))
 - `github` (Attributes) GitHub allows the configuration of options specific to the "github" join method. (see [below for nested schema](#nested-schema-for-specgithub))
 - `gitlab` (Attributes) GitLab allows the configuration of options specific to the "gitlab" join method. (see [below for nested schema](#nested-schema-for-specgitlab))
 - `integration` (String) Integration name which provides credentials for validating join attempts. Currently only in use for validating the AWS Organization ID in the IAM Join method.
@@ -218,6 +219,65 @@ Optional:
 - `locations` (List of String) Locations is a list of regions (e.g. "us-west1") and/or zones (e.g. "us-west1-b").
 - `project_ids` (List of String) ProjectIDs is a list of project IDs (e.g. `<example-id-123456>`).
 - `service_accounts` (List of String) ServiceAccounts is a list of service account emails (e.g. `<project-number>-compute@developer.gserviceaccount.com`).
+
+
+
+### Nested Schema for `spec.generic_oidc`
+
+Optional:
+
+- `allow_any` (Attributes List) AllowAny evaluates complex rules using "OR" semantics. If any rules are specified, at least one rule must evaluate to `true` for the join attempt to be allowed. These rules are evaluated after `must_match_fields`, if any field matchers are specified in that block.  Note that at least one rule, either in `must_match_fields` or `allow_any`, must be specified for any join attempts to succeed. (see [below for nested schema](#nested-schema-for-specgeneric_oidcallow_any))
+- `audience` (String) Audience is the expected audience value (required). This must match or be included in the list of `aud` values in the JWT provided by the client when joining. For providers that do not allow you to configure this value yourself (this is technically an OIDC spec violation, but is common), use the value they provide. Otherwise, we recommend using a value that uniquely identifies the Teleport cluster and join token. For example, you can use this scheme: $clusterName/$tokenName For a cluster named `example.teleport.sh` and a token named `example`, this would result in an audience of `example.teleport.sh/example`. If you prefer, you can also use a UUID instead of the token name. Note that you will need to configure the matching value with the issuer, usually at request time.
+- `insecure_allow_http_issuer` (Boolean) InsecureAllowHTTPIssuer is a flag that, if set, disables the requirement that the issuer must use HTTPS.
+- `issuer` (String) Issuer contains the expected `iss` value as written in the JWT you wish to trust. Unless `static_jwks` is configured, this issuer must be accessible over HTTPS to the Teleport cluster and must serve valid OIDC metadata, including discovery configuration and JWKS keys.
+- `static_jwks` (String) StaticJWKS is an optional static JWKS value that can be used to specify JWKS keys when either OIDC discovery is either not supported by the provider or the discovery configuration is not accessible to Teleport. When set, configuration and JWKS keys will not be fetched from the URL contained in `issuer` and JWTs will be validated using the key set specified here.
+- `tls_ca` (String) TLSCA is a TLS CA certificate that should be used to verify requests for OIDC metadata from the issuer instead of Teleport's CA store, useful if the issuer is not public or otherwise uses a self-signed certificate. Note that this value only applies to requests using this token, and will be used instead of and not in addition to the system CA store, and will need to be updated manually if the remote CA is updated.
+
+### Nested Schema for `spec.generic_oidc.allow_any`
+
+Optional:
+
+- `conditions` (Attributes List) Conditions are simple eq/not_eq/in/not_in conditions that check individual fields. All conditions must be satisfied for a join attempt to be allowed. Mutually exclusive with `expression`. (see [below for nested schema](#nested-schema-for-specgeneric_oidcallow_anyconditions))
+- `expression` (String) Expression is a predicate expression that must evaluate to `true` for the join attempt to be allowed. Expressions are provided the `claims` object, containing all claims extracted from the incoming JWT. It is mutually exclusive with `conditions`.
+
+### Nested Schema for `spec.generic_oidc.allow_any.conditions`
+
+Optional:
+
+- `attribute` (String) The name of the field this condition should check, separated by "." for nested fields.
+- `eq` (Attributes) An "equals" operator. Only one operator may be set within a condition. (see [below for nested schema](#nested-schema-for-specgeneric_oidcallow_anyconditionseq))
+- `in` (Attributes) An "in" operator. Only one operator may be set within a condition. (see [below for nested schema](#nested-schema-for-specgeneric_oidcallow_anyconditionsin))
+- `not_eq` (Attributes) A "not equals" operator. Only one operator may be set within a condition. (see [below for nested schema](#nested-schema-for-specgeneric_oidcallow_anyconditionsnot_eq))
+- `not_in` (Attributes) A "not in" operator. Only one operator may be set within a condition. (see [below for nested schema](#nested-schema-for-specgeneric_oidcallow_anyconditionsnot_in))
+
+### Nested Schema for `spec.generic_oidc.allow_any.conditions.eq`
+
+Optional:
+
+- `value` (String) The value to compare the attribute against.
+
+
+### Nested Schema for `spec.generic_oidc.allow_any.conditions.in`
+
+Optional:
+
+- `values` (List of String) The list of values to compare the attribute against.
+
+
+### Nested Schema for `spec.generic_oidc.allow_any.conditions.not_eq`
+
+Optional:
+
+- `value` (String) The value to compare the attribute against.
+
+
+### Nested Schema for `spec.generic_oidc.allow_any.conditions.not_in`
+
+Optional:
+
+- `values` (List of String) The list of values to compare the attribute against.
+
+
 
 
 

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/scoped_token.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/scoped_token.mdx
@@ -62,6 +62,7 @@ Optional:
 - `bot` (String) The bot associated with this join token, if any, as a scope-qualified name of the form `<scope>::<bot-name>` (e.g. "/staging/west::mybot"). The scope component must be a descendant of or equivalent to the token's resource scope.  Mutually exclusive with assigned_scope.
 - `bound_keypair` (Attributes) Configuration specific to the "bound_keypair" join method. (see [below for nested schema](#nested-schema-for-specbound_keypair))
 - `gcp` (Attributes) The GCP-specific configuration used with the "gcp" join method. (see [below for nested schema](#nested-schema-for-specgcp))
+- `generic_oidc` (Attributes) Configuration specific to the "generic_oidc" join method. (see [below for nested schema](#nested-schema-for-specgeneric_oidc))
 - `immutable_labels` (Attributes) Immutable labels that should be applied to any resulting resources provisioned using this token. (see [below for nested schema](#nested-schema-for-specimmutable_labels))
 - `kubernetes` (Attributes) The Kubernetes-specific configuration used with the "kubernetes" join method. (see [below for nested schema](#nested-schema-for-speckubernetes))
 - `oracle` (Attributes) The Oracle-specific configuration used with the "oracle" join method. (see [below for nested schema](#nested-schema-for-specoracle))
@@ -163,6 +164,65 @@ Optional:
 - `locations` (List of String) A list of regions (e.g. "us-west1") and/or zones (e.g. "us-west1-b").
 - `project_ids` (List of String) A list of project IDs (e.g. `<example-id-123456>`).
 - `service_accounts` (List of String) A list of service account emails (e.g. `<project-number>-compute@developer.gserviceaccount.com`).
+
+
+
+### Nested Schema for `spec.generic_oidc`
+
+Optional:
+
+- `allow_any` (Attributes List) Complex rules evaluated using "OR" semantics. If any rules are specified, at least one rule must evaluate to `true` for the join attempt/ to be allowed. These rules are evaluated after `must_match_fields`, if any field matchers are specified in that block.  Note that at least one rule, either in `must_match_fields` or `allow_any`, must be specified for any join attempts to succeed. (see [below for nested schema](#nested-schema-for-specgeneric_oidcallow_any))
+- `audience` (String) The expected JWT audience value (required). This must match or be included in the list of `aud` values in the JWT provided by the client when joining.  For providers that do not allow you to configure this value yourself (this is technically an OIDC spec violation, but is common), use the value they provide. Otherwise, we recommend using a value that uniquely identifies the Teleport cluster and join token. For example, you can use this scheme: $clusterName/$tokenName  For a cluster named `example.teleport.sh` and a token named `example`, this would result in an audience of `example.teleport.sh/example`. If you prefer, you can also use a UUID instead of the token name. Note that you will need to configure the matching value with the issuer, usually at request time.
+- `insecure_allow_http_issuer` (Boolean) If set, disables the requirement that the issuer must use HTTPS.
+- `issuer` (String) The expected `iss` value as written in the JWT you wish to trust. Unless `static_jwks` is configured, this issuer must be accessible over HTTPS to the Teleport cluster and must serve valid OIDC metadata, including discovery configuration and JWKS keys.
+- `static_jwks` (String) An optional static JWKS value that can be used to specify JWKS keys when either OIDC discovery is either not supported by the provider or the discovery configuration is not accessible to Teleport. When set, configuration and JWKS keys will not be fetched from the URL contained in `issuer` and JWTs will be validated using the key set specified here.
+- `tls_ca` (String) A TLS CA certificate that should be used to verify requests for OIDC metadata from the issuer instead of Teleport's CA store, useful if the issuer is not public or otherwise uses a self-signed certificate. If unset, the standard web PKI root certificates will be used to verify the connection to the issuer when fetching OIDC metadata. Note that this value only applies to requests using this token, and will be used instead of and not in addition to the system CA store, and will need to be updated manually if the remote CA is updated.
+
+### Nested Schema for `spec.generic_oidc.allow_any`
+
+Optional:
+
+- `conditions` (Attributes List) Conditions are simple eq/not_eq/in/not_in conditions that check individual fields. All conditions must be satisfied for a join attempt to be allowed. Mutually exclusive with `expression`. (see [below for nested schema](#nested-schema-for-specgeneric_oidcallow_anyconditions))
+- `expression` (String) A predicate expression that must evaluate to `true` for the join attempt to be allowed. It is mutually exclusive with `conditions`. TODO: Include name of variable available to the expr in docs
+
+### Nested Schema for `spec.generic_oidc.allow_any.conditions`
+
+Optional:
+
+- `attribute` (String) The name of the field this condition should check, separated by "." for nested fields.
+- `eq` (Attributes) An "equals" operator. Only one operator may be set within a condition. (see [below for nested schema](#nested-schema-for-specgeneric_oidcallow_anyconditionseq))
+- `in` (Attributes) An "in" operator. Only one operator may be set within a condition. (see [below for nested schema](#nested-schema-for-specgeneric_oidcallow_anyconditionsin))
+- `not_eq` (Attributes) A "not equals" operator. Only one operator may be set within a condition. (see [below for nested schema](#nested-schema-for-specgeneric_oidcallow_anyconditionsnot_eq))
+- `not_in` (Attributes) A "not in" operator. Only one operator may be set within a condition. (see [below for nested schema](#nested-schema-for-specgeneric_oidcallow_anyconditionsnot_in))
+
+### Nested Schema for `spec.generic_oidc.allow_any.conditions.eq`
+
+Optional:
+
+- `value` (String) The value to compare the attribute against.
+
+
+### Nested Schema for `spec.generic_oidc.allow_any.conditions.in`
+
+Optional:
+
+- `values` (List of String) The list of values to compare the attribute against.
+
+
+### Nested Schema for `spec.generic_oidc.allow_any.conditions.not_eq`
+
+Optional:
+
+- `value` (String) The value to compare the attribute against.
+
+
+### Nested Schema for `spec.generic_oidc.allow_any.conditions.not_in`
+
+Optional:
+
+- `values` (List of String) The list of values to compare the attribute against.
+
+
 
 
 

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/provision_token.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/provision_token.mdx
@@ -86,6 +86,7 @@ Optional:
 - `circleci` (Attributes) CircleCI allows the configuration of options specific to the "circleci" join method. (see [below for nested schema](#nested-schema-for-speccircleci))
 - `env0` (Attributes) Env0 allows the configuration of options specific to the "env0" join method. (see [below for nested schema](#nested-schema-for-specenv0))
 - `gcp` (Attributes) GCP allows the configuration of options specific to the "gcp" join method. (see [below for nested schema](#nested-schema-for-specgcp))
+- `generic_oidc` (Attributes) GenericOIDC allows the configuration of generic OIDC join tokens. (see [below for nested schema](#nested-schema-for-specgeneric_oidc))
 - `github` (Attributes) GitHub allows the configuration of options specific to the "github" join method. (see [below for nested schema](#nested-schema-for-specgithub))
 - `gitlab` (Attributes) GitLab allows the configuration of options specific to the "gitlab" join method. (see [below for nested schema](#nested-schema-for-specgitlab))
 - `integration` (String) Integration name which provides credentials for validating join attempts. Currently only in use for validating the AWS Organization ID in the IAM Join method.
@@ -254,6 +255,65 @@ Optional:
 - `locations` (List of String) Locations is a list of regions (e.g. "us-west1") and/or zones (e.g. "us-west1-b").
 - `project_ids` (List of String) ProjectIDs is a list of project IDs (e.g. `<example-id-123456>`).
 - `service_accounts` (List of String) ServiceAccounts is a list of service account emails (e.g. `<project-number>-compute@developer.gserviceaccount.com`).
+
+
+
+### Nested Schema for `spec.generic_oidc`
+
+Optional:
+
+- `allow_any` (Attributes List) AllowAny evaluates complex rules using "OR" semantics. If any rules are specified, at least one rule must evaluate to `true` for the join attempt to be allowed. These rules are evaluated after `must_match_fields`, if any field matchers are specified in that block.  Note that at least one rule, either in `must_match_fields` or `allow_any`, must be specified for any join attempts to succeed. (see [below for nested schema](#nested-schema-for-specgeneric_oidcallow_any))
+- `audience` (String) Audience is the expected audience value (required). This must match or be included in the list of `aud` values in the JWT provided by the client when joining. For providers that do not allow you to configure this value yourself (this is technically an OIDC spec violation, but is common), use the value they provide. Otherwise, we recommend using a value that uniquely identifies the Teleport cluster and join token. For example, you can use this scheme: $clusterName/$tokenName For a cluster named `example.teleport.sh` and a token named `example`, this would result in an audience of `example.teleport.sh/example`. If you prefer, you can also use a UUID instead of the token name. Note that you will need to configure the matching value with the issuer, usually at request time.
+- `insecure_allow_http_issuer` (Boolean) InsecureAllowHTTPIssuer is a flag that, if set, disables the requirement that the issuer must use HTTPS.
+- `issuer` (String) Issuer contains the expected `iss` value as written in the JWT you wish to trust. Unless `static_jwks` is configured, this issuer must be accessible over HTTPS to the Teleport cluster and must serve valid OIDC metadata, including discovery configuration and JWKS keys.
+- `static_jwks` (String) StaticJWKS is an optional static JWKS value that can be used to specify JWKS keys when either OIDC discovery is either not supported by the provider or the discovery configuration is not accessible to Teleport. When set, configuration and JWKS keys will not be fetched from the URL contained in `issuer` and JWTs will be validated using the key set specified here.
+- `tls_ca` (String) TLSCA is a TLS CA certificate that should be used to verify requests for OIDC metadata from the issuer instead of Teleport's CA store, useful if the issuer is not public or otherwise uses a self-signed certificate. Note that this value only applies to requests using this token, and will be used instead of and not in addition to the system CA store, and will need to be updated manually if the remote CA is updated.
+
+### Nested Schema for `spec.generic_oidc.allow_any`
+
+Optional:
+
+- `conditions` (Attributes List) Conditions are simple eq/not_eq/in/not_in conditions that check individual fields. All conditions must be satisfied for a join attempt to be allowed. Mutually exclusive with `expression`. (see [below for nested schema](#nested-schema-for-specgeneric_oidcallow_anyconditions))
+- `expression` (String) Expression is a predicate expression that must evaluate to `true` for the join attempt to be allowed. Expressions are provided the `claims` object, containing all claims extracted from the incoming JWT. It is mutually exclusive with `conditions`.
+
+### Nested Schema for `spec.generic_oidc.allow_any.conditions`
+
+Optional:
+
+- `attribute` (String) The name of the field this condition should check, separated by "." for nested fields.
+- `eq` (Attributes) An "equals" operator. Only one operator may be set within a condition. (see [below for nested schema](#nested-schema-for-specgeneric_oidcallow_anyconditionseq))
+- `in` (Attributes) An "in" operator. Only one operator may be set within a condition. (see [below for nested schema](#nested-schema-for-specgeneric_oidcallow_anyconditionsin))
+- `not_eq` (Attributes) A "not equals" operator. Only one operator may be set within a condition. (see [below for nested schema](#nested-schema-for-specgeneric_oidcallow_anyconditionsnot_eq))
+- `not_in` (Attributes) A "not in" operator. Only one operator may be set within a condition. (see [below for nested schema](#nested-schema-for-specgeneric_oidcallow_anyconditionsnot_in))
+
+### Nested Schema for `spec.generic_oidc.allow_any.conditions.eq`
+
+Optional:
+
+- `value` (String) The value to compare the attribute against.
+
+
+### Nested Schema for `spec.generic_oidc.allow_any.conditions.in`
+
+Optional:
+
+- `values` (List of String) The list of values to compare the attribute against.
+
+
+### Nested Schema for `spec.generic_oidc.allow_any.conditions.not_eq`
+
+Optional:
+
+- `value` (String) The value to compare the attribute against.
+
+
+### Nested Schema for `spec.generic_oidc.allow_any.conditions.not_in`
+
+Optional:
+
+- `values` (List of String) The list of values to compare the attribute against.
+
+
 
 
 

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/scoped_token.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/scoped_token.mdx
@@ -106,6 +106,7 @@ Optional:
 - `bot` (String) The bot associated with this join token, if any, as a scope-qualified name of the form `<scope>::<bot-name>` (e.g. "/staging/west::mybot"). The scope component must be a descendant of or equivalent to the token's resource scope.  Mutually exclusive with assigned_scope.
 - `bound_keypair` (Attributes) Configuration specific to the "bound_keypair" join method. (see [below for nested schema](#nested-schema-for-specbound_keypair))
 - `gcp` (Attributes) The GCP-specific configuration used with the "gcp" join method. (see [below for nested schema](#nested-schema-for-specgcp))
+- `generic_oidc` (Attributes) Configuration specific to the "generic_oidc" join method. (see [below for nested schema](#nested-schema-for-specgeneric_oidc))
 - `immutable_labels` (Attributes) Immutable labels that should be applied to any resulting resources provisioned using this token. (see [below for nested schema](#nested-schema-for-specimmutable_labels))
 - `kubernetes` (Attributes) The Kubernetes-specific configuration used with the "kubernetes" join method. (see [below for nested schema](#nested-schema-for-speckubernetes))
 - `oracle` (Attributes) The Oracle-specific configuration used with the "oracle" join method. (see [below for nested schema](#nested-schema-for-specoracle))
@@ -207,6 +208,65 @@ Optional:
 - `locations` (List of String) A list of regions (e.g. "us-west1") and/or zones (e.g. "us-west1-b").
 - `project_ids` (List of String) A list of project IDs (e.g. `<example-id-123456>`).
 - `service_accounts` (List of String) A list of service account emails (e.g. `<project-number>-compute@developer.gserviceaccount.com`).
+
+
+
+### Nested Schema for `spec.generic_oidc`
+
+Optional:
+
+- `allow_any` (Attributes List) Complex rules evaluated using "OR" semantics. If any rules are specified, at least one rule must evaluate to `true` for the join attempt/ to be allowed. These rules are evaluated after `must_match_fields`, if any field matchers are specified in that block.  Note that at least one rule, either in `must_match_fields` or `allow_any`, must be specified for any join attempts to succeed. (see [below for nested schema](#nested-schema-for-specgeneric_oidcallow_any))
+- `audience` (String) The expected JWT audience value (required). This must match or be included in the list of `aud` values in the JWT provided by the client when joining.  For providers that do not allow you to configure this value yourself (this is technically an OIDC spec violation, but is common), use the value they provide. Otherwise, we recommend using a value that uniquely identifies the Teleport cluster and join token. For example, you can use this scheme: $clusterName/$tokenName  For a cluster named `example.teleport.sh` and a token named `example`, this would result in an audience of `example.teleport.sh/example`. If you prefer, you can also use a UUID instead of the token name. Note that you will need to configure the matching value with the issuer, usually at request time.
+- `insecure_allow_http_issuer` (Boolean) If set, disables the requirement that the issuer must use HTTPS.
+- `issuer` (String) The expected `iss` value as written in the JWT you wish to trust. Unless `static_jwks` is configured, this issuer must be accessible over HTTPS to the Teleport cluster and must serve valid OIDC metadata, including discovery configuration and JWKS keys.
+- `static_jwks` (String) An optional static JWKS value that can be used to specify JWKS keys when either OIDC discovery is either not supported by the provider or the discovery configuration is not accessible to Teleport. When set, configuration and JWKS keys will not be fetched from the URL contained in `issuer` and JWTs will be validated using the key set specified here.
+- `tls_ca` (String) A TLS CA certificate that should be used to verify requests for OIDC metadata from the issuer instead of Teleport's CA store, useful if the issuer is not public or otherwise uses a self-signed certificate. If unset, the standard web PKI root certificates will be used to verify the connection to the issuer when fetching OIDC metadata. Note that this value only applies to requests using this token, and will be used instead of and not in addition to the system CA store, and will need to be updated manually if the remote CA is updated.
+
+### Nested Schema for `spec.generic_oidc.allow_any`
+
+Optional:
+
+- `conditions` (Attributes List) Conditions are simple eq/not_eq/in/not_in conditions that check individual fields. All conditions must be satisfied for a join attempt to be allowed. Mutually exclusive with `expression`. (see [below for nested schema](#nested-schema-for-specgeneric_oidcallow_anyconditions))
+- `expression` (String) A predicate expression that must evaluate to `true` for the join attempt to be allowed. It is mutually exclusive with `conditions`. TODO: Include name of variable available to the expr in docs
+
+### Nested Schema for `spec.generic_oidc.allow_any.conditions`
+
+Optional:
+
+- `attribute` (String) The name of the field this condition should check, separated by "." for nested fields.
+- `eq` (Attributes) An "equals" operator. Only one operator may be set within a condition. (see [below for nested schema](#nested-schema-for-specgeneric_oidcallow_anyconditionseq))
+- `in` (Attributes) An "in" operator. Only one operator may be set within a condition. (see [below for nested schema](#nested-schema-for-specgeneric_oidcallow_anyconditionsin))
+- `not_eq` (Attributes) A "not equals" operator. Only one operator may be set within a condition. (see [below for nested schema](#nested-schema-for-specgeneric_oidcallow_anyconditionsnot_eq))
+- `not_in` (Attributes) A "not in" operator. Only one operator may be set within a condition. (see [below for nested schema](#nested-schema-for-specgeneric_oidcallow_anyconditionsnot_in))
+
+### Nested Schema for `spec.generic_oidc.allow_any.conditions.eq`
+
+Optional:
+
+- `value` (String) The value to compare the attribute against.
+
+
+### Nested Schema for `spec.generic_oidc.allow_any.conditions.in`
+
+Optional:
+
+- `values` (List of String) The list of values to compare the attribute against.
+
+
+### Nested Schema for `spec.generic_oidc.allow_any.conditions.not_eq`
+
+Optional:
+
+- `value` (String) The value to compare the attribute against.
+
+
+### Nested Schema for `spec.generic_oidc.allow_any.conditions.not_in`
+
+Optional:
+
+- `values` (List of String) The list of values to compare the attribute against.
+
+
 
 
 

--- a/examples/chart/teleport-cluster/charts/teleport-operator/operator-crds/resources.teleport.dev_provisiontokens.yaml
+++ b/examples/chart/teleport-cluster/charts/teleport-operator/operator-crds/resources.teleport.dev_provisiontokens.yaml
@@ -333,6 +333,130 @@ spec:
                     nullable: true
                     type: array
                 type: object
+              generic_oidc:
+                description: GenericOIDC allows the configuration of generic OIDC
+                  join tokens.
+                nullable: true
+                properties:
+                  allow_any:
+                    description: AllowAny evaluates complex rules using "OR" semantics.
+                      If any rules are specified, at least one rule must evaluate
+                      to `true` for the join attempt to be allowed. These rules are
+                      evaluated after `must_match_fields`, if any field matchers are
+                      specified in that block.  Note that at least one rule, either
+                      in `must_match_fields` or `allow_any`, must be specified for
+                      any join attempts to succeed.
+                    items:
+                      properties:
+                        conditions:
+                          items:
+                            properties:
+                              attribute:
+                                type: string
+                              eq:
+                                nullable: true
+                                properties:
+                                  value:
+                                    type: string
+                                type: object
+                              in:
+                                nullable: true
+                                properties:
+                                  values:
+                                    items:
+                                      type: string
+                                    nullable: true
+                                    type: array
+                                type: object
+                              not_eq:
+                                nullable: true
+                                properties:
+                                  value:
+                                    type: string
+                                type: object
+                              not_in:
+                                nullable: true
+                                properties:
+                                  values:
+                                    items:
+                                      type: string
+                                    nullable: true
+                                    type: array
+                                type: object
+                            type: object
+                          nullable: true
+                          type: array
+                        expression:
+                          type: string
+                      type: object
+                    nullable: true
+                    type: array
+                  audience:
+                    description: 'Audience is the expected audience value (required).
+                      This must match or be included in the list of `aud` values in
+                      the JWT provided by the client when joining. For providers that
+                      do not allow you to configure this value yourself (this is technically
+                      an OIDC spec violation, but is common), use the value they provide.
+                      Otherwise, we recommend using a value that uniquely identifies
+                      the Teleport cluster and join token. For example, you can use
+                      this scheme: $clusterName/$tokenName For a cluster named `example.teleport.sh`
+                      and a token named `example`, this would result in an audience
+                      of `example.teleport.sh/example`. If you prefer, you can also
+                      use a UUID instead of the token name. Note that you will need
+                      to configure the matching value with the issuer, usually at
+                      request time.'
+                    type: string
+                  insecure_allow_http_issuer:
+                    description: InsecureAllowHTTPIssuer is a flag that, if set, disables
+                      the requirement that the issuer must use HTTPS.
+                    type: boolean
+                  issuer:
+                    description: Issuer contains the expected `iss` value as written
+                      in the JWT you wish to trust. Unless `static_jwks` is configured,
+                      this issuer must be accessible over HTTPS to the Teleport cluster
+                      and must serve valid OIDC metadata, including discovery configuration
+                      and JWKS keys.
+                    type: string
+                  must_match_fields:
+                    additionalProperties: true
+                    description: 'MustMatchFields perform simple comparison matches
+                      using "AND" semantics. Rules are specified by mirroring the
+                      structure of the JWT, using values that are expected to be equal
+                      to those on the incoming token. These field matching rules can
+                      only be used to compare simple values: strings, numbers, booleans,
+                      and nested fields. Complex values, including lists, will need
+                      to use `allow_any` expression rules instead.  If any field match
+                      rules are specified, all must be equal to corresponding JWT
+                      fields for the join attempt to succeed. If complex rules are
+                      specified in `allow_any`, those are evaluated after `must_match_fields`.
+                      If `must_match_fields` is not specified or is empty, only rules
+                      in `allow_any` are evaluated.  These rules can be used as "global"
+                      rules that apply to all join attempts. For example, you can
+                      use these to ensure all attempts originate from your organization,
+                      then use `allow_any` rules to allow individual repositories,
+                      pipelines, or workspaces.  Note that at least one rule, either
+                      in `must_match_fields` or `allow_any`, must be specified for
+                      any join attempts to succeed.'
+                    nullable: true
+                    type: object
+                  static_jwks:
+                    description: StaticJWKS is an optional static JWKS value that
+                      can be used to specify JWKS keys when either OIDC discovery
+                      is either not supported by the provider or the discovery configuration
+                      is not accessible to Teleport. When set, configuration and JWKS
+                      keys will not be fetched from the URL contained in `issuer`
+                      and JWTs will be validated using the key set specified here.
+                    type: string
+                  tls_ca:
+                    description: TLSCA is a TLS CA certificate that should be used
+                      to verify requests for OIDC metadata from the issuer instead
+                      of Teleport's CA store, useful if the issuer is not public or
+                      otherwise uses a self-signed certificate. Note that this value
+                      only applies to requests using this token, and will be used
+                      instead of and not in addition to the system CA store, and will
+                      need to be updated manually if the remote CA is updated.
+                    type: string
+                type: object
               github:
                 description: GitHub allows the configuration of options specific to
                   the "github" join method.

--- a/examples/chart/teleport-cluster/charts/teleport-operator/operator-crds/resources.teleport.dev_scopedtokensv1.yaml
+++ b/examples/chart/teleport-cluster/charts/teleport-operator/operator-crds/resources.teleport.dev_scopedtokensv1.yaml
@@ -227,6 +227,131 @@ spec:
                     nullable: true
                     type: array
                 type: object
+              generic_oidc:
+                description: Configuration specific to the "generic_oidc" join method.
+                nullable: true
+                properties:
+                  allow_any:
+                    description: Complex rules evaluated using "OR" semantics. If
+                      any rules are specified, at least one rule must evaluate to
+                      `true` for the join attempt/ to be allowed. These rules are
+                      evaluated after `must_match_fields`, if any field matchers are
+                      specified in that block.  Note that at least one rule, either
+                      in `must_match_fields` or `allow_any`, must be specified for
+                      any join attempts to succeed.
+                    items:
+                      properties:
+                        conditions:
+                          items:
+                            properties:
+                              attribute:
+                                type: string
+                              eq:
+                                nullable: true
+                                properties:
+                                  value:
+                                    type: string
+                                type: object
+                              in:
+                                nullable: true
+                                properties:
+                                  values:
+                                    items:
+                                      type: string
+                                    nullable: true
+                                    type: array
+                                type: object
+                              not_eq:
+                                nullable: true
+                                properties:
+                                  value:
+                                    type: string
+                                type: object
+                              not_in:
+                                nullable: true
+                                properties:
+                                  values:
+                                    items:
+                                      type: string
+                                    nullable: true
+                                    type: array
+                                type: object
+                            type: object
+                          nullable: true
+                          type: array
+                        expression:
+                          type: string
+                      type: object
+                    nullable: true
+                    type: array
+                  audience:
+                    description: 'The expected JWT audience value (required). This
+                      must match or be included in the list of `aud` values in the
+                      JWT provided by the client when joining.  For providers that
+                      do not allow you to configure this value yourself (this is technically
+                      an OIDC spec violation, but is common), use the value they provide.
+                      Otherwise, we recommend using a value that uniquely identifies
+                      the Teleport cluster and join token. For example, you can use
+                      this scheme: $clusterName/$tokenName  For a cluster named `example.teleport.sh`
+                      and a token named `example`, this would result in an audience
+                      of `example.teleport.sh/example`. If you prefer, you can also
+                      use a UUID instead of the token name. Note that you will need
+                      to configure the matching value with the issuer, usually at
+                      request time.'
+                    type: string
+                  insecure_allow_http_issuer:
+                    description: If set, disables the requirement that the issuer
+                      must use HTTPS.
+                    type: boolean
+                  issuer:
+                    description: The expected `iss` value as written in the JWT you
+                      wish to trust. Unless `static_jwks` is configured, this issuer
+                      must be accessible over HTTPS to the Teleport cluster and must
+                      serve valid OIDC metadata, including discovery configuration
+                      and JWKS keys.
+                    type: string
+                  must_match_fields:
+                    additionalProperties: true
+                    description: '"Must match" fields perform simple comparison matches
+                      using "AND" semantics. Rules are specified by mirroring the
+                      structure of the JWT, using values that are expected to be equal
+                      to those on the incoming token. These field matching rules can
+                      only be used to compare simple values: strings, numbers, booleans,
+                      and nested fields. Complex values, including lists, will need
+                      to use `allow_any` expression rules instead.  If any field match
+                      rules are specified, all must be equal to corresponding JWT
+                      fields for the join attempt to succeed. If complex rules are
+                      specified in `allow_any`, those are evaluated after `must_match_fields`.
+                      If `must_match_fields` is not specified or is empty, only rules
+                      in `allow_any` are evaluated.  These rules can be used as "global"
+                      rules that apply to all join attempts. For example, you can
+                      use these to ensure all attempts originate from your organization,
+                      then use `allow_any` rules to allow individual repositories,
+                      pipelines, or workspaces.  Note that at least one rule, either
+                      in `must_match_fields` or `allow_any`, must be specified for
+                      any join attempts to succeed.'
+                    nullable: true
+                    type: object
+                  static_jwks:
+                    description: An optional static JWKS value that can be used to
+                      specify JWKS keys when either OIDC discovery is either not supported
+                      by the provider or the discovery configuration is not accessible
+                      to Teleport. When set, configuration and JWKS keys will not
+                      be fetched from the URL contained in `issuer` and JWTs will
+                      be validated using the key set specified here.
+                    type: string
+                  tls_ca:
+                    description: A TLS CA certificate that should be used to verify
+                      requests for OIDC metadata from the issuer instead of Teleport's
+                      CA store, useful if the issuer is not public or otherwise uses
+                      a self-signed certificate. If unset, the standard web PKI root
+                      certificates will be used to verify the connection to the issuer
+                      when fetching OIDC metadata. Note that this value only applies
+                      to requests using this token, and will be used instead of and
+                      not in addition to the system CA store, and will need to be
+                      updated manually if the remote CA is updated.
+                    type: string
+                type: object
               immutable_labels:
                 description: Immutable labels that should be applied to any resulting
                   resources provisioned using this token.

--- a/integrations/operator/config/crd/bases/resources.teleport.dev_provisiontokens.yaml
+++ b/integrations/operator/config/crd/bases/resources.teleport.dev_provisiontokens.yaml
@@ -333,6 +333,130 @@ spec:
                     nullable: true
                     type: array
                 type: object
+              generic_oidc:
+                description: GenericOIDC allows the configuration of generic OIDC
+                  join tokens.
+                nullable: true
+                properties:
+                  allow_any:
+                    description: AllowAny evaluates complex rules using "OR" semantics.
+                      If any rules are specified, at least one rule must evaluate
+                      to `true` for the join attempt to be allowed. These rules are
+                      evaluated after `must_match_fields`, if any field matchers are
+                      specified in that block.  Note that at least one rule, either
+                      in `must_match_fields` or `allow_any`, must be specified for
+                      any join attempts to succeed.
+                    items:
+                      properties:
+                        conditions:
+                          items:
+                            properties:
+                              attribute:
+                                type: string
+                              eq:
+                                nullable: true
+                                properties:
+                                  value:
+                                    type: string
+                                type: object
+                              in:
+                                nullable: true
+                                properties:
+                                  values:
+                                    items:
+                                      type: string
+                                    nullable: true
+                                    type: array
+                                type: object
+                              not_eq:
+                                nullable: true
+                                properties:
+                                  value:
+                                    type: string
+                                type: object
+                              not_in:
+                                nullable: true
+                                properties:
+                                  values:
+                                    items:
+                                      type: string
+                                    nullable: true
+                                    type: array
+                                type: object
+                            type: object
+                          nullable: true
+                          type: array
+                        expression:
+                          type: string
+                      type: object
+                    nullable: true
+                    type: array
+                  audience:
+                    description: 'Audience is the expected audience value (required).
+                      This must match or be included in the list of `aud` values in
+                      the JWT provided by the client when joining. For providers that
+                      do not allow you to configure this value yourself (this is technically
+                      an OIDC spec violation, but is common), use the value they provide.
+                      Otherwise, we recommend using a value that uniquely identifies
+                      the Teleport cluster and join token. For example, you can use
+                      this scheme: $clusterName/$tokenName For a cluster named `example.teleport.sh`
+                      and a token named `example`, this would result in an audience
+                      of `example.teleport.sh/example`. If you prefer, you can also
+                      use a UUID instead of the token name. Note that you will need
+                      to configure the matching value with the issuer, usually at
+                      request time.'
+                    type: string
+                  insecure_allow_http_issuer:
+                    description: InsecureAllowHTTPIssuer is a flag that, if set, disables
+                      the requirement that the issuer must use HTTPS.
+                    type: boolean
+                  issuer:
+                    description: Issuer contains the expected `iss` value as written
+                      in the JWT you wish to trust. Unless `static_jwks` is configured,
+                      this issuer must be accessible over HTTPS to the Teleport cluster
+                      and must serve valid OIDC metadata, including discovery configuration
+                      and JWKS keys.
+                    type: string
+                  must_match_fields:
+                    additionalProperties: true
+                    description: 'MustMatchFields perform simple comparison matches
+                      using "AND" semantics. Rules are specified by mirroring the
+                      structure of the JWT, using values that are expected to be equal
+                      to those on the incoming token. These field matching rules can
+                      only be used to compare simple values: strings, numbers, booleans,
+                      and nested fields. Complex values, including lists, will need
+                      to use `allow_any` expression rules instead.  If any field match
+                      rules are specified, all must be equal to corresponding JWT
+                      fields for the join attempt to succeed. If complex rules are
+                      specified in `allow_any`, those are evaluated after `must_match_fields`.
+                      If `must_match_fields` is not specified or is empty, only rules
+                      in `allow_any` are evaluated.  These rules can be used as "global"
+                      rules that apply to all join attempts. For example, you can
+                      use these to ensure all attempts originate from your organization,
+                      then use `allow_any` rules to allow individual repositories,
+                      pipelines, or workspaces.  Note that at least one rule, either
+                      in `must_match_fields` or `allow_any`, must be specified for
+                      any join attempts to succeed.'
+                    nullable: true
+                    type: object
+                  static_jwks:
+                    description: StaticJWKS is an optional static JWKS value that
+                      can be used to specify JWKS keys when either OIDC discovery
+                      is either not supported by the provider or the discovery configuration
+                      is not accessible to Teleport. When set, configuration and JWKS
+                      keys will not be fetched from the URL contained in `issuer`
+                      and JWTs will be validated using the key set specified here.
+                    type: string
+                  tls_ca:
+                    description: TLSCA is a TLS CA certificate that should be used
+                      to verify requests for OIDC metadata from the issuer instead
+                      of Teleport's CA store, useful if the issuer is not public or
+                      otherwise uses a self-signed certificate. Note that this value
+                      only applies to requests using this token, and will be used
+                      instead of and not in addition to the system CA store, and will
+                      need to be updated manually if the remote CA is updated.
+                    type: string
+                type: object
               github:
                 description: GitHub allows the configuration of options specific to
                   the "github" join method.

--- a/integrations/operator/config/crd/bases/resources.teleport.dev_scopedtokensv1.yaml
+++ b/integrations/operator/config/crd/bases/resources.teleport.dev_scopedtokensv1.yaml
@@ -227,6 +227,131 @@ spec:
                     nullable: true
                     type: array
                 type: object
+              generic_oidc:
+                description: Configuration specific to the "generic_oidc" join method.
+                nullable: true
+                properties:
+                  allow_any:
+                    description: Complex rules evaluated using "OR" semantics. If
+                      any rules are specified, at least one rule must evaluate to
+                      `true` for the join attempt/ to be allowed. These rules are
+                      evaluated after `must_match_fields`, if any field matchers are
+                      specified in that block.  Note that at least one rule, either
+                      in `must_match_fields` or `allow_any`, must be specified for
+                      any join attempts to succeed.
+                    items:
+                      properties:
+                        conditions:
+                          items:
+                            properties:
+                              attribute:
+                                type: string
+                              eq:
+                                nullable: true
+                                properties:
+                                  value:
+                                    type: string
+                                type: object
+                              in:
+                                nullable: true
+                                properties:
+                                  values:
+                                    items:
+                                      type: string
+                                    nullable: true
+                                    type: array
+                                type: object
+                              not_eq:
+                                nullable: true
+                                properties:
+                                  value:
+                                    type: string
+                                type: object
+                              not_in:
+                                nullable: true
+                                properties:
+                                  values:
+                                    items:
+                                      type: string
+                                    nullable: true
+                                    type: array
+                                type: object
+                            type: object
+                          nullable: true
+                          type: array
+                        expression:
+                          type: string
+                      type: object
+                    nullable: true
+                    type: array
+                  audience:
+                    description: 'The expected JWT audience value (required). This
+                      must match or be included in the list of `aud` values in the
+                      JWT provided by the client when joining.  For providers that
+                      do not allow you to configure this value yourself (this is technically
+                      an OIDC spec violation, but is common), use the value they provide.
+                      Otherwise, we recommend using a value that uniquely identifies
+                      the Teleport cluster and join token. For example, you can use
+                      this scheme: $clusterName/$tokenName  For a cluster named `example.teleport.sh`
+                      and a token named `example`, this would result in an audience
+                      of `example.teleport.sh/example`. If you prefer, you can also
+                      use a UUID instead of the token name. Note that you will need
+                      to configure the matching value with the issuer, usually at
+                      request time.'
+                    type: string
+                  insecure_allow_http_issuer:
+                    description: If set, disables the requirement that the issuer
+                      must use HTTPS.
+                    type: boolean
+                  issuer:
+                    description: The expected `iss` value as written in the JWT you
+                      wish to trust. Unless `static_jwks` is configured, this issuer
+                      must be accessible over HTTPS to the Teleport cluster and must
+                      serve valid OIDC metadata, including discovery configuration
+                      and JWKS keys.
+                    type: string
+                  must_match_fields:
+                    additionalProperties: true
+                    description: '"Must match" fields perform simple comparison matches
+                      using "AND" semantics. Rules are specified by mirroring the
+                      structure of the JWT, using values that are expected to be equal
+                      to those on the incoming token. These field matching rules can
+                      only be used to compare simple values: strings, numbers, booleans,
+                      and nested fields. Complex values, including lists, will need
+                      to use `allow_any` expression rules instead.  If any field match
+                      rules are specified, all must be equal to corresponding JWT
+                      fields for the join attempt to succeed. If complex rules are
+                      specified in `allow_any`, those are evaluated after `must_match_fields`.
+                      If `must_match_fields` is not specified or is empty, only rules
+                      in `allow_any` are evaluated.  These rules can be used as "global"
+                      rules that apply to all join attempts. For example, you can
+                      use these to ensure all attempts originate from your organization,
+                      then use `allow_any` rules to allow individual repositories,
+                      pipelines, or workspaces.  Note that at least one rule, either
+                      in `must_match_fields` or `allow_any`, must be specified for
+                      any join attempts to succeed.'
+                    nullable: true
+                    type: object
+                  static_jwks:
+                    description: An optional static JWKS value that can be used to
+                      specify JWKS keys when either OIDC discovery is either not supported
+                      by the provider or the discovery configuration is not accessible
+                      to Teleport. When set, configuration and JWKS keys will not
+                      be fetched from the URL contained in `issuer` and JWTs will
+                      be validated using the key set specified here.
+                    type: string
+                  tls_ca:
+                    description: A TLS CA certificate that should be used to verify
+                      requests for OIDC metadata from the issuer instead of Teleport's
+                      CA store, useful if the issuer is not public or otherwise uses
+                      a self-signed certificate. If unset, the standard web PKI root
+                      certificates will be used to verify the connection to the issuer
+                      when fetching OIDC metadata. Note that this value only applies
+                      to requests using this token, and will be used instead of and
+                      not in addition to the system CA store, and will need to be
+                      updated manually if the remote CA is updated.
+                    type: string
+                type: object
               immutable_labels:
                 description: Immutable labels that should be applied to any resulting
                   resources provisioned using this token.

--- a/integrations/terraform/protoc-gen-terraform-scopedtoken.yaml
+++ b/integrations/terraform/protoc-gen-terraform-scopedtoken.yaml
@@ -32,6 +32,9 @@ exclude_fields:
   - "ScopedToken.metadata.id"
   # Usage tracking is server-side only
   - "ScopedToken.status"
+  # Uses a google.protobuf.Struct field that isn't supported (see
+  # https://github.com/gravitational/protoc-gen-terraform/issues/52)
+  - "ScopedToken.spec.generic_oidc.must_match_fields"
 
 # These fields will be marked as Computed: true
 computed_fields:

--- a/integrations/terraform/protoc-gen-terraform-teleport.yaml
+++ b/integrations/terraform/protoc-gen-terraform-teleport.yaml
@@ -235,7 +235,11 @@ exclude_fields:
     # credentials is excluded intentionally so that we dont have to handle plugin credentials, which are stored separately.
     - "IntegrationV1.Spec.credentials"
     - "IntegrationV1.Spec.GitHub"
-    
+
+    # Uses a google.protobuf.Struct field that isn't supported (see
+    # https://github.com/gravitational/protoc-gen-terraform/issues/52)
+    - "ProvisionTokenV2.Spec.GenericOIDC.MustMatchFields"
+
 name_overrides:
 
 # These fields will be marked as Computed: true

--- a/integrations/terraform/tfschema/scopes/joining/v1/token_terraform.go
+++ b/integrations/terraform/tfschema/scopes/joining/v1/token_terraform.go
@@ -33,6 +33,7 @@ import (
 	github_com_hashicorp_terraform_plugin_framework_tfsdk "github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	github_com_hashicorp_terraform_plugin_framework_types "github.com/hashicorp/terraform-plugin-framework/types"
 	github_com_hashicorp_terraform_plugin_go_tftypes "github.com/hashicorp/terraform-plugin-go/tftypes"
+	_ "google.golang.org/protobuf/types/known/structpb"
 	_ "google.golang.org/protobuf/types/known/timestamppb"
 )
 
@@ -318,6 +319,95 @@ func GenSchemaScopedToken(ctx context.Context) (github_com_hashicorp_terraform_p
 						Optional:    true,
 					}}),
 					Description: "The GCP-specific configuration used with the \"gcp\" join method.",
+					Optional:    true,
+				},
+				"generic_oidc": {
+					Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.SingleNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
+						"allow_any": {
+							Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.ListNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
+								"conditions": {
+									Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.ListNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
+										"attribute": {
+											Description: "",
+											Optional:    true,
+											Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
+										},
+										"eq": {
+											Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.SingleNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{"value": {
+												Description: "The value to compare the attribute against.",
+												Optional:    true,
+												Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
+											}}),
+											Description: "",
+											Optional:    true,
+										},
+										"in": {
+											Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.SingleNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{"values": {
+												Description: "The list of values to compare the attribute against.",
+												Optional:    true,
+												Type:        github_com_hashicorp_terraform_plugin_framework_types.ListType{ElemType: github_com_hashicorp_terraform_plugin_framework_types.StringType},
+											}}),
+											Description: "",
+											Optional:    true,
+										},
+										"not_eq": {
+											Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.SingleNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{"value": {
+												Description: "The value to compare the attribute against.",
+												Optional:    true,
+												Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
+											}}),
+											Description: "",
+											Optional:    true,
+										},
+										"not_in": {
+											Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.SingleNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{"values": {
+												Description: "The list of values to compare the attribute against.",
+												Optional:    true,
+												Type:        github_com_hashicorp_terraform_plugin_framework_types.ListType{ElemType: github_com_hashicorp_terraform_plugin_framework_types.StringType},
+											}}),
+											Description: "",
+											Optional:    true,
+										},
+									}),
+									Description: "Conditions are simple eq/not_eq/in/not_in conditions that check individual fields. All conditions must be satisfied for a join attempt to be allowed. Mutually exclusive with `expression`.",
+									Optional:    true,
+								},
+								"expression": {
+									Description: "A predicate expression that must evaluate to `true` for the join attempt to be allowed. It is mutually exclusive with `conditions`. TODO: Include name of variable available to the expr in docs",
+									Optional:    true,
+									Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
+								},
+							}),
+							Description: "Complex rules evaluated using \"OR\" semantics. If any rules are specified, at least one rule must evaluate to `true` for the join attempt/ to be allowed. These rules are evaluated after `must_match_fields`, if any field matchers are specified in that block.  Note that at least one rule, either in `must_match_fields` or `allow_any`, must be specified for any join attempts to succeed.",
+							Optional:    true,
+						},
+						"audience": {
+							Description: "The expected JWT audience value (required). This must match or be included in the list of `aud` values in the JWT provided by the client when joining.  For providers that do not allow you to configure this value yourself (this is technically an OIDC spec violation, but is common), use the value they provide. Otherwise, we recommend using a value that uniquely identifies the Teleport cluster and join token. For example, you can use this scheme: $clusterName/$tokenName  For a cluster named `example.teleport.sh` and a token named `example`, this would result in an audience of `example.teleport.sh/example`. If you prefer, you can also use a UUID instead of the token name. Note that you will need to configure the matching value with the issuer, usually at request time.",
+							Optional:    true,
+							Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
+						},
+						"insecure_allow_http_issuer": {
+							Description: "If set, disables the requirement that the issuer must use HTTPS.",
+							Optional:    true,
+							Type:        github_com_hashicorp_terraform_plugin_framework_types.BoolType,
+						},
+						"issuer": {
+							Description: "The expected `iss` value as written in the JWT you wish to trust. Unless `static_jwks` is configured, this issuer must be accessible over HTTPS to the Teleport cluster and must serve valid OIDC metadata, including discovery configuration and JWKS keys.",
+							Optional:    true,
+							Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
+						},
+						"static_jwks": {
+							Description: "An optional static JWKS value that can be used to specify JWKS keys when either OIDC discovery is either not supported by the provider or the discovery configuration is not accessible to Teleport. When set, configuration and JWKS keys will not be fetched from the URL contained in `issuer` and JWTs will be validated using the key set specified here.",
+							Optional:    true,
+							Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
+						},
+						"tls_ca": {
+							Description: "A TLS CA certificate that should be used to verify requests for OIDC metadata from the issuer instead of Teleport's CA store, useful if the issuer is not public or otherwise uses a self-signed certificate. If unset, the standard web PKI root certificates will be used to verify the connection to the issuer when fetching OIDC metadata. Note that this value only applies to requests using this token, and will be used instead of and not in addition to the system CA store, and will need to be updated manually if the remote CA is updated.",
+							Optional:    true,
+							Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
+						},
+					}),
+					Description: "Configuration specific to the \"generic_oidc\" join method.",
 					Optional:    true,
 				},
 				"immutable_labels": {
@@ -1885,6 +1975,362 @@ func CopyScopedTokenFromTerraform(_ context.Context, tf github_com_hashicorp_ter
 									t = string(v.Value)
 								}
 								obj.Bot = t
+							}
+						}
+					}
+					{
+						a, ok := tf.Attrs["generic_oidc"]
+						if !ok {
+							diags.Append(attrReadMissingDiag{"ScopedToken.spec.generic_oidc"})
+						} else {
+							v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.Object)
+							if !ok {
+								diags.Append(attrReadConversionFailureDiag{"ScopedToken.spec.generic_oidc", "github.com/hashicorp/terraform-plugin-framework/types.Object"})
+							} else {
+								obj.GenericOidc = nil
+								if !v.Null && !v.Unknown {
+									tf := v
+									obj.GenericOidc = &github_com_gravitational_teleport_api_gen_proto_go_teleport_scopes_joining_v1.GenericOIDC{}
+									obj := obj.GenericOidc
+									{
+										a, ok := tf.Attrs["issuer"]
+										if !ok {
+											diags.Append(attrReadMissingDiag{"ScopedToken.spec.generic_oidc.issuer"})
+										} else {
+											v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.String)
+											if !ok {
+												diags.Append(attrReadConversionFailureDiag{"ScopedToken.spec.generic_oidc.issuer", "github.com/hashicorp/terraform-plugin-framework/types.String"})
+											} else {
+												var t string
+												if !v.Null && !v.Unknown {
+													t = string(v.Value)
+												}
+												obj.Issuer = t
+											}
+										}
+									}
+									{
+										a, ok := tf.Attrs["insecure_allow_http_issuer"]
+										if !ok {
+											diags.Append(attrReadMissingDiag{"ScopedToken.spec.generic_oidc.insecure_allow_http_issuer"})
+										} else {
+											v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.Bool)
+											if !ok {
+												diags.Append(attrReadConversionFailureDiag{"ScopedToken.spec.generic_oidc.insecure_allow_http_issuer", "github.com/hashicorp/terraform-plugin-framework/types.Bool"})
+											} else {
+												var t bool
+												if !v.Null && !v.Unknown {
+													t = bool(v.Value)
+												}
+												obj.InsecureAllowHttpIssuer = t
+											}
+										}
+									}
+									{
+										a, ok := tf.Attrs["audience"]
+										if !ok {
+											diags.Append(attrReadMissingDiag{"ScopedToken.spec.generic_oidc.audience"})
+										} else {
+											v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.String)
+											if !ok {
+												diags.Append(attrReadConversionFailureDiag{"ScopedToken.spec.generic_oidc.audience", "github.com/hashicorp/terraform-plugin-framework/types.String"})
+											} else {
+												var t string
+												if !v.Null && !v.Unknown {
+													t = string(v.Value)
+												}
+												obj.Audience = t
+											}
+										}
+									}
+									{
+										a, ok := tf.Attrs["static_jwks"]
+										if !ok {
+											diags.Append(attrReadMissingDiag{"ScopedToken.spec.generic_oidc.static_jwks"})
+										} else {
+											v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.String)
+											if !ok {
+												diags.Append(attrReadConversionFailureDiag{"ScopedToken.spec.generic_oidc.static_jwks", "github.com/hashicorp/terraform-plugin-framework/types.String"})
+											} else {
+												var t string
+												if !v.Null && !v.Unknown {
+													t = string(v.Value)
+												}
+												obj.StaticJwks = t
+											}
+										}
+									}
+									{
+										a, ok := tf.Attrs["tls_ca"]
+										if !ok {
+											diags.Append(attrReadMissingDiag{"ScopedToken.spec.generic_oidc.tls_ca"})
+										} else {
+											v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.String)
+											if !ok {
+												diags.Append(attrReadConversionFailureDiag{"ScopedToken.spec.generic_oidc.tls_ca", "github.com/hashicorp/terraform-plugin-framework/types.String"})
+											} else {
+												var t string
+												if !v.Null && !v.Unknown {
+													t = string(v.Value)
+												}
+												obj.TlsCa = t
+											}
+										}
+									}
+									{
+										a, ok := tf.Attrs["allow_any"]
+										if !ok {
+											diags.Append(attrReadMissingDiag{"ScopedToken.spec.generic_oidc.allow_any"})
+										} else {
+											v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.List)
+											if !ok {
+												diags.Append(attrReadConversionFailureDiag{"ScopedToken.spec.generic_oidc.allow_any", "github.com/hashicorp/terraform-plugin-framework/types.List"})
+											} else {
+												obj.AllowAny = make([]*github_com_gravitational_teleport_api_gen_proto_go_teleport_scopes_joining_v1.GenericOIDC_Rule, len(v.Elems))
+												if !v.Null && !v.Unknown {
+													for k, a := range v.Elems {
+														v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.Object)
+														if !ok {
+															diags.Append(attrReadConversionFailureDiag{"ScopedToken.spec.generic_oidc.allow_any", "github_com_hashicorp_terraform_plugin_framework_types.Object"})
+														} else {
+															var t *github_com_gravitational_teleport_api_gen_proto_go_teleport_scopes_joining_v1.GenericOIDC_Rule
+															if !v.Null && !v.Unknown {
+																tf := v
+																t = &github_com_gravitational_teleport_api_gen_proto_go_teleport_scopes_joining_v1.GenericOIDC_Rule{}
+																obj := t
+																{
+																	a, ok := tf.Attrs["conditions"]
+																	if !ok {
+																		diags.Append(attrReadMissingDiag{"ScopedToken.spec.generic_oidc.allow_any.conditions"})
+																	} else {
+																		v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.List)
+																		if !ok {
+																			diags.Append(attrReadConversionFailureDiag{"ScopedToken.spec.generic_oidc.allow_any.conditions", "github.com/hashicorp/terraform-plugin-framework/types.List"})
+																		} else {
+																			obj.Conditions = make([]*github_com_gravitational_teleport_api_gen_proto_go_teleport_scopes_joining_v1.GenericOIDC_Condition, len(v.Elems))
+																			if !v.Null && !v.Unknown {
+																				for k, a := range v.Elems {
+																					v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.Object)
+																					if !ok {
+																						diags.Append(attrReadConversionFailureDiag{"ScopedToken.spec.generic_oidc.allow_any.conditions", "github_com_hashicorp_terraform_plugin_framework_types.Object"})
+																					} else {
+																						var t *github_com_gravitational_teleport_api_gen_proto_go_teleport_scopes_joining_v1.GenericOIDC_Condition
+																						if !v.Null && !v.Unknown {
+																							tf := v
+																							t = &github_com_gravitational_teleport_api_gen_proto_go_teleport_scopes_joining_v1.GenericOIDC_Condition{}
+																							obj := t
+																							obj.Operator = nil
+																							{
+																								a, ok := tf.Attrs["attribute"]
+																								if !ok {
+																									diags.Append(attrReadMissingDiag{"ScopedToken.spec.generic_oidc.allow_any.conditions.attribute"})
+																								} else {
+																									v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.String)
+																									if !ok {
+																										diags.Append(attrReadConversionFailureDiag{"ScopedToken.spec.generic_oidc.allow_any.conditions.attribute", "github.com/hashicorp/terraform-plugin-framework/types.String"})
+																									} else {
+																										var t string
+																										if !v.Null && !v.Unknown {
+																											t = string(v.Value)
+																										}
+																										obj.Attribute = t
+																									}
+																								}
+																							}
+																							{
+																								a, ok := tf.Attrs["eq"]
+																								if !ok {
+																									diags.Append(attrReadMissingDiag{"ScopedToken.spec.generic_oidc.allow_any.conditions.eq"})
+																								} else {
+																									v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.Object)
+																									if !ok {
+																										diags.Append(attrReadConversionFailureDiag{"ScopedToken.spec.generic_oidc.allow_any.conditions.eq", "github.com/hashicorp/terraform-plugin-framework/types.Object"})
+																									} else {
+																										if !v.Null && !v.Unknown {
+																											b := &github_com_gravitational_teleport_api_gen_proto_go_teleport_scopes_joining_v1.GenericOIDC_ConditionEq{}
+																											obj.Operator = &github_com_gravitational_teleport_api_gen_proto_go_teleport_scopes_joining_v1.Condition_Eq{Eq: b}
+																											obj := b
+																											tf := v
+																											{
+																												a, ok := tf.Attrs["value"]
+																												if !ok {
+																													diags.Append(attrReadMissingDiag{"ScopedToken.spec.generic_oidc.allow_any.conditions.eq.value"})
+																												} else {
+																													v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.String)
+																													if !ok {
+																														diags.Append(attrReadConversionFailureDiag{"ScopedToken.spec.generic_oidc.allow_any.conditions.eq.value", "github.com/hashicorp/terraform-plugin-framework/types.String"})
+																													} else {
+																														var t string
+																														if !v.Null && !v.Unknown {
+																															t = string(v.Value)
+																														}
+																														obj.Value = t
+																													}
+																												}
+																											}
+																										}
+																									}
+																								}
+																							}
+																							{
+																								a, ok := tf.Attrs["not_eq"]
+																								if !ok {
+																									diags.Append(attrReadMissingDiag{"ScopedToken.spec.generic_oidc.allow_any.conditions.not_eq"})
+																								} else {
+																									v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.Object)
+																									if !ok {
+																										diags.Append(attrReadConversionFailureDiag{"ScopedToken.spec.generic_oidc.allow_any.conditions.not_eq", "github.com/hashicorp/terraform-plugin-framework/types.Object"})
+																									} else {
+																										if !v.Null && !v.Unknown {
+																											b := &github_com_gravitational_teleport_api_gen_proto_go_teleport_scopes_joining_v1.GenericOIDC_ConditionNotEq{}
+																											obj.Operator = &github_com_gravitational_teleport_api_gen_proto_go_teleport_scopes_joining_v1.Condition_NotEq{NotEq: b}
+																											obj := b
+																											tf := v
+																											{
+																												a, ok := tf.Attrs["value"]
+																												if !ok {
+																													diags.Append(attrReadMissingDiag{"ScopedToken.spec.generic_oidc.allow_any.conditions.not_eq.value"})
+																												} else {
+																													v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.String)
+																													if !ok {
+																														diags.Append(attrReadConversionFailureDiag{"ScopedToken.spec.generic_oidc.allow_any.conditions.not_eq.value", "github.com/hashicorp/terraform-plugin-framework/types.String"})
+																													} else {
+																														var t string
+																														if !v.Null && !v.Unknown {
+																															t = string(v.Value)
+																														}
+																														obj.Value = t
+																													}
+																												}
+																											}
+																										}
+																									}
+																								}
+																							}
+																							{
+																								a, ok := tf.Attrs["in"]
+																								if !ok {
+																									diags.Append(attrReadMissingDiag{"ScopedToken.spec.generic_oidc.allow_any.conditions.in"})
+																								} else {
+																									v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.Object)
+																									if !ok {
+																										diags.Append(attrReadConversionFailureDiag{"ScopedToken.spec.generic_oidc.allow_any.conditions.in", "github.com/hashicorp/terraform-plugin-framework/types.Object"})
+																									} else {
+																										if !v.Null && !v.Unknown {
+																											b := &github_com_gravitational_teleport_api_gen_proto_go_teleport_scopes_joining_v1.GenericOIDC_ConditionIn{}
+																											obj.Operator = &github_com_gravitational_teleport_api_gen_proto_go_teleport_scopes_joining_v1.Condition_In{In: b}
+																											obj := b
+																											tf := v
+																											{
+																												a, ok := tf.Attrs["values"]
+																												if !ok {
+																													diags.Append(attrReadMissingDiag{"ScopedToken.spec.generic_oidc.allow_any.conditions.in.values"})
+																												} else {
+																													v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.List)
+																													if !ok {
+																														diags.Append(attrReadConversionFailureDiag{"ScopedToken.spec.generic_oidc.allow_any.conditions.in.values", "github.com/hashicorp/terraform-plugin-framework/types.List"})
+																													} else {
+																														obj.Values = make([]string, len(v.Elems))
+																														if !v.Null && !v.Unknown {
+																															for k, a := range v.Elems {
+																																v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.String)
+																																if !ok {
+																																	diags.Append(attrReadConversionFailureDiag{"ScopedToken.spec.generic_oidc.allow_any.conditions.in.values", "github_com_hashicorp_terraform_plugin_framework_types.String"})
+																																} else {
+																																	var t string
+																																	if !v.Null && !v.Unknown {
+																																		t = string(v.Value)
+																																	}
+																																	obj.Values[k] = t
+																																}
+																															}
+																														}
+																													}
+																												}
+																											}
+																										}
+																									}
+																								}
+																							}
+																							{
+																								a, ok := tf.Attrs["not_in"]
+																								if !ok {
+																									diags.Append(attrReadMissingDiag{"ScopedToken.spec.generic_oidc.allow_any.conditions.not_in"})
+																								} else {
+																									v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.Object)
+																									if !ok {
+																										diags.Append(attrReadConversionFailureDiag{"ScopedToken.spec.generic_oidc.allow_any.conditions.not_in", "github.com/hashicorp/terraform-plugin-framework/types.Object"})
+																									} else {
+																										if !v.Null && !v.Unknown {
+																											b := &github_com_gravitational_teleport_api_gen_proto_go_teleport_scopes_joining_v1.GenericOIDC_ConditionNotIn{}
+																											obj.Operator = &github_com_gravitational_teleport_api_gen_proto_go_teleport_scopes_joining_v1.Condition_NotIn{NotIn: b}
+																											obj := b
+																											tf := v
+																											{
+																												a, ok := tf.Attrs["values"]
+																												if !ok {
+																													diags.Append(attrReadMissingDiag{"ScopedToken.spec.generic_oidc.allow_any.conditions.not_in.values"})
+																												} else {
+																													v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.List)
+																													if !ok {
+																														diags.Append(attrReadConversionFailureDiag{"ScopedToken.spec.generic_oidc.allow_any.conditions.not_in.values", "github.com/hashicorp/terraform-plugin-framework/types.List"})
+																													} else {
+																														obj.Values = make([]string, len(v.Elems))
+																														if !v.Null && !v.Unknown {
+																															for k, a := range v.Elems {
+																																v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.String)
+																																if !ok {
+																																	diags.Append(attrReadConversionFailureDiag{"ScopedToken.spec.generic_oidc.allow_any.conditions.not_in.values", "github_com_hashicorp_terraform_plugin_framework_types.String"})
+																																} else {
+																																	var t string
+																																	if !v.Null && !v.Unknown {
+																																		t = string(v.Value)
+																																	}
+																																	obj.Values[k] = t
+																																}
+																															}
+																														}
+																													}
+																												}
+																											}
+																										}
+																									}
+																								}
+																							}
+																						}
+																						obj.Conditions[k] = t
+																					}
+																				}
+																			}
+																		}
+																	}
+																}
+																{
+																	a, ok := tf.Attrs["expression"]
+																	if !ok {
+																		diags.Append(attrReadMissingDiag{"ScopedToken.spec.generic_oidc.allow_any.expression"})
+																	} else {
+																		v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.String)
+																		if !ok {
+																			diags.Append(attrReadConversionFailureDiag{"ScopedToken.spec.generic_oidc.allow_any.expression", "github.com/hashicorp/terraform-plugin-framework/types.String"})
+																		} else {
+																			var t string
+																			if !v.Null && !v.Unknown {
+																				t = string(v.Value)
+																			}
+																			obj.Expression = t
+																		}
+																	}
+																}
+															}
+															obj.AllowAny[k] = t
+														}
+													}
+												}
+											}
+										}
+									}
+								}
 							}
 						}
 					}
@@ -4197,6 +4643,602 @@ func CopyScopedTokenToTerraform(ctx context.Context, obj *github_com_gravitation
 							v.Value = string(obj.Bot)
 							v.Unknown = false
 							tf.Attrs["bot"] = v
+						}
+					}
+					{
+						a, ok := tf.AttrTypes["generic_oidc"]
+						if !ok {
+							diags.Append(attrWriteMissingDiag{"ScopedToken.spec.generic_oidc"})
+						} else {
+							o, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.ObjectType)
+							if !ok {
+								diags.Append(attrWriteConversionFailureDiag{"ScopedToken.spec.generic_oidc", "github.com/hashicorp/terraform-plugin-framework/types.ObjectType"})
+							} else {
+								v, ok := tf.Attrs["generic_oidc"].(github_com_hashicorp_terraform_plugin_framework_types.Object)
+								if !ok {
+									v = github_com_hashicorp_terraform_plugin_framework_types.Object{
+
+										AttrTypes: o.AttrTypes,
+										Attrs:     make(map[string]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(o.AttrTypes)),
+									}
+								} else {
+									if v.Attrs == nil {
+										v.Attrs = make(map[string]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(tf.AttrTypes))
+									}
+								}
+								if obj.GenericOidc == nil {
+									v.Null = true
+								} else {
+									obj := obj.GenericOidc
+									tf := &v
+									{
+										t, ok := tf.AttrTypes["issuer"]
+										if !ok {
+											diags.Append(attrWriteMissingDiag{"ScopedToken.spec.generic_oidc.issuer"})
+										} else {
+											v, ok := tf.Attrs["issuer"].(github_com_hashicorp_terraform_plugin_framework_types.String)
+											if !ok {
+												i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
+												if err != nil {
+													diags.Append(attrWriteGeneralError{"ScopedToken.spec.generic_oidc.issuer", err})
+												}
+												v, ok = i.(github_com_hashicorp_terraform_plugin_framework_types.String)
+												if !ok {
+													diags.Append(attrWriteConversionFailureDiag{"ScopedToken.spec.generic_oidc.issuer", "github.com/hashicorp/terraform-plugin-framework/types.String"})
+												}
+												v.Null = string(obj.Issuer) == ""
+											}
+											v.Value = string(obj.Issuer)
+											v.Unknown = false
+											tf.Attrs["issuer"] = v
+										}
+									}
+									{
+										t, ok := tf.AttrTypes["insecure_allow_http_issuer"]
+										if !ok {
+											diags.Append(attrWriteMissingDiag{"ScopedToken.spec.generic_oidc.insecure_allow_http_issuer"})
+										} else {
+											v, ok := tf.Attrs["insecure_allow_http_issuer"].(github_com_hashicorp_terraform_plugin_framework_types.Bool)
+											if !ok {
+												i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
+												if err != nil {
+													diags.Append(attrWriteGeneralError{"ScopedToken.spec.generic_oidc.insecure_allow_http_issuer", err})
+												}
+												v, ok = i.(github_com_hashicorp_terraform_plugin_framework_types.Bool)
+												if !ok {
+													diags.Append(attrWriteConversionFailureDiag{"ScopedToken.spec.generic_oidc.insecure_allow_http_issuer", "github.com/hashicorp/terraform-plugin-framework/types.Bool"})
+												}
+												v.Null = bool(obj.InsecureAllowHttpIssuer) == false
+											}
+											v.Value = bool(obj.InsecureAllowHttpIssuer)
+											v.Unknown = false
+											tf.Attrs["insecure_allow_http_issuer"] = v
+										}
+									}
+									{
+										t, ok := tf.AttrTypes["audience"]
+										if !ok {
+											diags.Append(attrWriteMissingDiag{"ScopedToken.spec.generic_oidc.audience"})
+										} else {
+											v, ok := tf.Attrs["audience"].(github_com_hashicorp_terraform_plugin_framework_types.String)
+											if !ok {
+												i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
+												if err != nil {
+													diags.Append(attrWriteGeneralError{"ScopedToken.spec.generic_oidc.audience", err})
+												}
+												v, ok = i.(github_com_hashicorp_terraform_plugin_framework_types.String)
+												if !ok {
+													diags.Append(attrWriteConversionFailureDiag{"ScopedToken.spec.generic_oidc.audience", "github.com/hashicorp/terraform-plugin-framework/types.String"})
+												}
+												v.Null = string(obj.Audience) == ""
+											}
+											v.Value = string(obj.Audience)
+											v.Unknown = false
+											tf.Attrs["audience"] = v
+										}
+									}
+									{
+										t, ok := tf.AttrTypes["static_jwks"]
+										if !ok {
+											diags.Append(attrWriteMissingDiag{"ScopedToken.spec.generic_oidc.static_jwks"})
+										} else {
+											v, ok := tf.Attrs["static_jwks"].(github_com_hashicorp_terraform_plugin_framework_types.String)
+											if !ok {
+												i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
+												if err != nil {
+													diags.Append(attrWriteGeneralError{"ScopedToken.spec.generic_oidc.static_jwks", err})
+												}
+												v, ok = i.(github_com_hashicorp_terraform_plugin_framework_types.String)
+												if !ok {
+													diags.Append(attrWriteConversionFailureDiag{"ScopedToken.spec.generic_oidc.static_jwks", "github.com/hashicorp/terraform-plugin-framework/types.String"})
+												}
+												v.Null = string(obj.StaticJwks) == ""
+											}
+											v.Value = string(obj.StaticJwks)
+											v.Unknown = false
+											tf.Attrs["static_jwks"] = v
+										}
+									}
+									{
+										t, ok := tf.AttrTypes["tls_ca"]
+										if !ok {
+											diags.Append(attrWriteMissingDiag{"ScopedToken.spec.generic_oidc.tls_ca"})
+										} else {
+											v, ok := tf.Attrs["tls_ca"].(github_com_hashicorp_terraform_plugin_framework_types.String)
+											if !ok {
+												i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
+												if err != nil {
+													diags.Append(attrWriteGeneralError{"ScopedToken.spec.generic_oidc.tls_ca", err})
+												}
+												v, ok = i.(github_com_hashicorp_terraform_plugin_framework_types.String)
+												if !ok {
+													diags.Append(attrWriteConversionFailureDiag{"ScopedToken.spec.generic_oidc.tls_ca", "github.com/hashicorp/terraform-plugin-framework/types.String"})
+												}
+												v.Null = string(obj.TlsCa) == ""
+											}
+											v.Value = string(obj.TlsCa)
+											v.Unknown = false
+											tf.Attrs["tls_ca"] = v
+										}
+									}
+									{
+										a, ok := tf.AttrTypes["allow_any"]
+										if !ok {
+											diags.Append(attrWriteMissingDiag{"ScopedToken.spec.generic_oidc.allow_any"})
+										} else {
+											o, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.ListType)
+											if !ok {
+												diags.Append(attrWriteConversionFailureDiag{"ScopedToken.spec.generic_oidc.allow_any", "github.com/hashicorp/terraform-plugin-framework/types.ListType"})
+											} else {
+												c, ok := tf.Attrs["allow_any"].(github_com_hashicorp_terraform_plugin_framework_types.List)
+												if !ok {
+													c = github_com_hashicorp_terraform_plugin_framework_types.List{
+
+														ElemType: o.ElemType,
+														Elems:    make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.AllowAny)),
+														Null:     true,
+													}
+												} else {
+													if c.Elems == nil {
+														c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.AllowAny))
+													}
+												}
+												if obj.AllowAny != nil {
+													o := o.ElemType.(github_com_hashicorp_terraform_plugin_framework_types.ObjectType)
+													if len(obj.AllowAny) != len(c.Elems) {
+														c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.AllowAny))
+													}
+													for k, a := range obj.AllowAny {
+														v, ok := tf.Attrs["allow_any"].(github_com_hashicorp_terraform_plugin_framework_types.Object)
+														if !ok {
+															v = github_com_hashicorp_terraform_plugin_framework_types.Object{
+
+																AttrTypes: o.AttrTypes,
+																Attrs:     make(map[string]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(o.AttrTypes)),
+															}
+														} else {
+															if v.Attrs == nil {
+																v.Attrs = make(map[string]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(tf.AttrTypes))
+															}
+														}
+														if a == nil {
+															v.Null = true
+														} else {
+															obj := a
+															tf := &v
+															{
+																a, ok := tf.AttrTypes["conditions"]
+																if !ok {
+																	diags.Append(attrWriteMissingDiag{"ScopedToken.spec.generic_oidc.allow_any.conditions"})
+																} else {
+																	o, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.ListType)
+																	if !ok {
+																		diags.Append(attrWriteConversionFailureDiag{"ScopedToken.spec.generic_oidc.allow_any.conditions", "github.com/hashicorp/terraform-plugin-framework/types.ListType"})
+																	} else {
+																		c, ok := tf.Attrs["conditions"].(github_com_hashicorp_terraform_plugin_framework_types.List)
+																		if !ok {
+																			c = github_com_hashicorp_terraform_plugin_framework_types.List{
+
+																				ElemType: o.ElemType,
+																				Elems:    make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.Conditions)),
+																				Null:     true,
+																			}
+																		} else {
+																			if c.Elems == nil {
+																				c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.Conditions))
+																			}
+																		}
+																		if obj.Conditions != nil {
+																			o := o.ElemType.(github_com_hashicorp_terraform_plugin_framework_types.ObjectType)
+																			if len(obj.Conditions) != len(c.Elems) {
+																				c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.Conditions))
+																			}
+																			for k, a := range obj.Conditions {
+																				v, ok := tf.Attrs["conditions"].(github_com_hashicorp_terraform_plugin_framework_types.Object)
+																				if !ok {
+																					v = github_com_hashicorp_terraform_plugin_framework_types.Object{
+
+																						AttrTypes: o.AttrTypes,
+																						Attrs:     make(map[string]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(o.AttrTypes)),
+																					}
+																				} else {
+																					if v.Attrs == nil {
+																						v.Attrs = make(map[string]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(tf.AttrTypes))
+																					}
+																				}
+																				if a == nil {
+																					v.Null = true
+																				} else {
+																					obj := a
+																					tf := &v
+																					{
+																						t, ok := tf.AttrTypes["attribute"]
+																						if !ok {
+																							diags.Append(attrWriteMissingDiag{"ScopedToken.spec.generic_oidc.allow_any.conditions.attribute"})
+																						} else {
+																							v, ok := tf.Attrs["attribute"].(github_com_hashicorp_terraform_plugin_framework_types.String)
+																							if !ok {
+																								i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
+																								if err != nil {
+																									diags.Append(attrWriteGeneralError{"ScopedToken.spec.generic_oidc.allow_any.conditions.attribute", err})
+																								}
+																								v, ok = i.(github_com_hashicorp_terraform_plugin_framework_types.String)
+																								if !ok {
+																									diags.Append(attrWriteConversionFailureDiag{"ScopedToken.spec.generic_oidc.allow_any.conditions.attribute", "github.com/hashicorp/terraform-plugin-framework/types.String"})
+																								}
+																								v.Null = string(obj.Attribute) == ""
+																							}
+																							v.Value = string(obj.Attribute)
+																							v.Unknown = false
+																							tf.Attrs["attribute"] = v
+																						}
+																					}
+																					{
+																						a, ok := tf.AttrTypes["eq"]
+																						if !ok {
+																							diags.Append(attrWriteMissingDiag{"ScopedToken.spec.generic_oidc.allow_any.conditions.eq"})
+																						} else {
+																							obj, ok := obj.Operator.(*github_com_gravitational_teleport_api_gen_proto_go_teleport_scopes_joining_v1.Condition_Eq)
+																							if !ok {
+																								obj = &github_com_gravitational_teleport_api_gen_proto_go_teleport_scopes_joining_v1.Condition_Eq{}
+																							}
+																							o, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.ObjectType)
+																							if !ok {
+																								diags.Append(attrWriteConversionFailureDiag{"ScopedToken.spec.generic_oidc.allow_any.conditions.eq", "github.com/hashicorp/terraform-plugin-framework/types.ObjectType"})
+																							} else {
+																								v, ok := tf.Attrs["eq"].(github_com_hashicorp_terraform_plugin_framework_types.Object)
+																								if !ok {
+																									v = github_com_hashicorp_terraform_plugin_framework_types.Object{
+
+																										AttrTypes: o.AttrTypes,
+																										Attrs:     make(map[string]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(o.AttrTypes)),
+																									}
+																								} else {
+																									if v.Attrs == nil {
+																										v.Attrs = make(map[string]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(tf.AttrTypes))
+																									}
+																								}
+																								if obj.Eq == nil {
+																									v.Null = true
+																								} else {
+																									obj := obj.Eq
+																									tf := &v
+																									{
+																										t, ok := tf.AttrTypes["value"]
+																										if !ok {
+																											diags.Append(attrWriteMissingDiag{"ScopedToken.spec.generic_oidc.allow_any.conditions.eq.value"})
+																										} else {
+																											v, ok := tf.Attrs["value"].(github_com_hashicorp_terraform_plugin_framework_types.String)
+																											if !ok {
+																												i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
+																												if err != nil {
+																													diags.Append(attrWriteGeneralError{"ScopedToken.spec.generic_oidc.allow_any.conditions.eq.value", err})
+																												}
+																												v, ok = i.(github_com_hashicorp_terraform_plugin_framework_types.String)
+																												if !ok {
+																													diags.Append(attrWriteConversionFailureDiag{"ScopedToken.spec.generic_oidc.allow_any.conditions.eq.value", "github.com/hashicorp/terraform-plugin-framework/types.String"})
+																												}
+																												v.Null = string(obj.Value) == ""
+																											}
+																											v.Value = string(obj.Value)
+																											v.Unknown = false
+																											tf.Attrs["value"] = v
+																										}
+																									}
+																								}
+																								v.Unknown = false
+																								tf.Attrs["eq"] = v
+																							}
+																						}
+																					}
+																					{
+																						a, ok := tf.AttrTypes["not_eq"]
+																						if !ok {
+																							diags.Append(attrWriteMissingDiag{"ScopedToken.spec.generic_oidc.allow_any.conditions.not_eq"})
+																						} else {
+																							obj, ok := obj.Operator.(*github_com_gravitational_teleport_api_gen_proto_go_teleport_scopes_joining_v1.Condition_NotEq)
+																							if !ok {
+																								obj = &github_com_gravitational_teleport_api_gen_proto_go_teleport_scopes_joining_v1.Condition_NotEq{}
+																							}
+																							o, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.ObjectType)
+																							if !ok {
+																								diags.Append(attrWriteConversionFailureDiag{"ScopedToken.spec.generic_oidc.allow_any.conditions.not_eq", "github.com/hashicorp/terraform-plugin-framework/types.ObjectType"})
+																							} else {
+																								v, ok := tf.Attrs["not_eq"].(github_com_hashicorp_terraform_plugin_framework_types.Object)
+																								if !ok {
+																									v = github_com_hashicorp_terraform_plugin_framework_types.Object{
+
+																										AttrTypes: o.AttrTypes,
+																										Attrs:     make(map[string]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(o.AttrTypes)),
+																									}
+																								} else {
+																									if v.Attrs == nil {
+																										v.Attrs = make(map[string]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(tf.AttrTypes))
+																									}
+																								}
+																								if obj.NotEq == nil {
+																									v.Null = true
+																								} else {
+																									obj := obj.NotEq
+																									tf := &v
+																									{
+																										t, ok := tf.AttrTypes["value"]
+																										if !ok {
+																											diags.Append(attrWriteMissingDiag{"ScopedToken.spec.generic_oidc.allow_any.conditions.not_eq.value"})
+																										} else {
+																											v, ok := tf.Attrs["value"].(github_com_hashicorp_terraform_plugin_framework_types.String)
+																											if !ok {
+																												i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
+																												if err != nil {
+																													diags.Append(attrWriteGeneralError{"ScopedToken.spec.generic_oidc.allow_any.conditions.not_eq.value", err})
+																												}
+																												v, ok = i.(github_com_hashicorp_terraform_plugin_framework_types.String)
+																												if !ok {
+																													diags.Append(attrWriteConversionFailureDiag{"ScopedToken.spec.generic_oidc.allow_any.conditions.not_eq.value", "github.com/hashicorp/terraform-plugin-framework/types.String"})
+																												}
+																												v.Null = string(obj.Value) == ""
+																											}
+																											v.Value = string(obj.Value)
+																											v.Unknown = false
+																											tf.Attrs["value"] = v
+																										}
+																									}
+																								}
+																								v.Unknown = false
+																								tf.Attrs["not_eq"] = v
+																							}
+																						}
+																					}
+																					{
+																						a, ok := tf.AttrTypes["in"]
+																						if !ok {
+																							diags.Append(attrWriteMissingDiag{"ScopedToken.spec.generic_oidc.allow_any.conditions.in"})
+																						} else {
+																							obj, ok := obj.Operator.(*github_com_gravitational_teleport_api_gen_proto_go_teleport_scopes_joining_v1.Condition_In)
+																							if !ok {
+																								obj = &github_com_gravitational_teleport_api_gen_proto_go_teleport_scopes_joining_v1.Condition_In{}
+																							}
+																							o, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.ObjectType)
+																							if !ok {
+																								diags.Append(attrWriteConversionFailureDiag{"ScopedToken.spec.generic_oidc.allow_any.conditions.in", "github.com/hashicorp/terraform-plugin-framework/types.ObjectType"})
+																							} else {
+																								v, ok := tf.Attrs["in"].(github_com_hashicorp_terraform_plugin_framework_types.Object)
+																								if !ok {
+																									v = github_com_hashicorp_terraform_plugin_framework_types.Object{
+
+																										AttrTypes: o.AttrTypes,
+																										Attrs:     make(map[string]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(o.AttrTypes)),
+																									}
+																								} else {
+																									if v.Attrs == nil {
+																										v.Attrs = make(map[string]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(tf.AttrTypes))
+																									}
+																								}
+																								if obj.In == nil {
+																									v.Null = true
+																								} else {
+																									obj := obj.In
+																									tf := &v
+																									{
+																										a, ok := tf.AttrTypes["values"]
+																										if !ok {
+																											diags.Append(attrWriteMissingDiag{"ScopedToken.spec.generic_oidc.allow_any.conditions.in.values"})
+																										} else {
+																											o, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.ListType)
+																											if !ok {
+																												diags.Append(attrWriteConversionFailureDiag{"ScopedToken.spec.generic_oidc.allow_any.conditions.in.values", "github.com/hashicorp/terraform-plugin-framework/types.ListType"})
+																											} else {
+																												c, ok := tf.Attrs["values"].(github_com_hashicorp_terraform_plugin_framework_types.List)
+																												if !ok {
+																													c = github_com_hashicorp_terraform_plugin_framework_types.List{
+
+																														ElemType: o.ElemType,
+																														Elems:    make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.Values)),
+																														Null:     true,
+																													}
+																												} else {
+																													if c.Elems == nil {
+																														c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.Values))
+																													}
+																												}
+																												if obj.Values != nil {
+																													t := o.ElemType
+																													if len(obj.Values) != len(c.Elems) {
+																														c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.Values))
+																													}
+																													for k, a := range obj.Values {
+																														v, ok := tf.Attrs["values"].(github_com_hashicorp_terraform_plugin_framework_types.String)
+																														if !ok {
+																															i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
+																															if err != nil {
+																																diags.Append(attrWriteGeneralError{"ScopedToken.spec.generic_oidc.allow_any.conditions.in.values", err})
+																															}
+																															v, ok = i.(github_com_hashicorp_terraform_plugin_framework_types.String)
+																															if !ok {
+																																diags.Append(attrWriteConversionFailureDiag{"ScopedToken.spec.generic_oidc.allow_any.conditions.in.values", "github.com/hashicorp/terraform-plugin-framework/types.String"})
+																															}
+																															v.Null = string(a) == ""
+																														}
+																														v.Value = string(a)
+																														v.Unknown = false
+																														c.Elems[k] = v
+																													}
+																													if len(obj.Values) > 0 {
+																														c.Null = false
+																													}
+																												}
+																												c.Unknown = false
+																												tf.Attrs["values"] = c
+																											}
+																										}
+																									}
+																								}
+																								v.Unknown = false
+																								tf.Attrs["in"] = v
+																							}
+																						}
+																					}
+																					{
+																						a, ok := tf.AttrTypes["not_in"]
+																						if !ok {
+																							diags.Append(attrWriteMissingDiag{"ScopedToken.spec.generic_oidc.allow_any.conditions.not_in"})
+																						} else {
+																							obj, ok := obj.Operator.(*github_com_gravitational_teleport_api_gen_proto_go_teleport_scopes_joining_v1.Condition_NotIn)
+																							if !ok {
+																								obj = &github_com_gravitational_teleport_api_gen_proto_go_teleport_scopes_joining_v1.Condition_NotIn{}
+																							}
+																							o, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.ObjectType)
+																							if !ok {
+																								diags.Append(attrWriteConversionFailureDiag{"ScopedToken.spec.generic_oidc.allow_any.conditions.not_in", "github.com/hashicorp/terraform-plugin-framework/types.ObjectType"})
+																							} else {
+																								v, ok := tf.Attrs["not_in"].(github_com_hashicorp_terraform_plugin_framework_types.Object)
+																								if !ok {
+																									v = github_com_hashicorp_terraform_plugin_framework_types.Object{
+
+																										AttrTypes: o.AttrTypes,
+																										Attrs:     make(map[string]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(o.AttrTypes)),
+																									}
+																								} else {
+																									if v.Attrs == nil {
+																										v.Attrs = make(map[string]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(tf.AttrTypes))
+																									}
+																								}
+																								if obj.NotIn == nil {
+																									v.Null = true
+																								} else {
+																									obj := obj.NotIn
+																									tf := &v
+																									{
+																										a, ok := tf.AttrTypes["values"]
+																										if !ok {
+																											diags.Append(attrWriteMissingDiag{"ScopedToken.spec.generic_oidc.allow_any.conditions.not_in.values"})
+																										} else {
+																											o, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.ListType)
+																											if !ok {
+																												diags.Append(attrWriteConversionFailureDiag{"ScopedToken.spec.generic_oidc.allow_any.conditions.not_in.values", "github.com/hashicorp/terraform-plugin-framework/types.ListType"})
+																											} else {
+																												c, ok := tf.Attrs["values"].(github_com_hashicorp_terraform_plugin_framework_types.List)
+																												if !ok {
+																													c = github_com_hashicorp_terraform_plugin_framework_types.List{
+
+																														ElemType: o.ElemType,
+																														Elems:    make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.Values)),
+																														Null:     true,
+																													}
+																												} else {
+																													if c.Elems == nil {
+																														c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.Values))
+																													}
+																												}
+																												if obj.Values != nil {
+																													t := o.ElemType
+																													if len(obj.Values) != len(c.Elems) {
+																														c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.Values))
+																													}
+																													for k, a := range obj.Values {
+																														v, ok := tf.Attrs["values"].(github_com_hashicorp_terraform_plugin_framework_types.String)
+																														if !ok {
+																															i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
+																															if err != nil {
+																																diags.Append(attrWriteGeneralError{"ScopedToken.spec.generic_oidc.allow_any.conditions.not_in.values", err})
+																															}
+																															v, ok = i.(github_com_hashicorp_terraform_plugin_framework_types.String)
+																															if !ok {
+																																diags.Append(attrWriteConversionFailureDiag{"ScopedToken.spec.generic_oidc.allow_any.conditions.not_in.values", "github.com/hashicorp/terraform-plugin-framework/types.String"})
+																															}
+																															v.Null = string(a) == ""
+																														}
+																														v.Value = string(a)
+																														v.Unknown = false
+																														c.Elems[k] = v
+																													}
+																													if len(obj.Values) > 0 {
+																														c.Null = false
+																													}
+																												}
+																												c.Unknown = false
+																												tf.Attrs["values"] = c
+																											}
+																										}
+																									}
+																								}
+																								v.Unknown = false
+																								tf.Attrs["not_in"] = v
+																							}
+																						}
+																					}
+																				}
+																				v.Unknown = false
+																				c.Elems[k] = v
+																			}
+																			if len(obj.Conditions) > 0 {
+																				c.Null = false
+																			}
+																		}
+																		c.Unknown = false
+																		tf.Attrs["conditions"] = c
+																	}
+																}
+															}
+															{
+																t, ok := tf.AttrTypes["expression"]
+																if !ok {
+																	diags.Append(attrWriteMissingDiag{"ScopedToken.spec.generic_oidc.allow_any.expression"})
+																} else {
+																	v, ok := tf.Attrs["expression"].(github_com_hashicorp_terraform_plugin_framework_types.String)
+																	if !ok {
+																		i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
+																		if err != nil {
+																			diags.Append(attrWriteGeneralError{"ScopedToken.spec.generic_oidc.allow_any.expression", err})
+																		}
+																		v, ok = i.(github_com_hashicorp_terraform_plugin_framework_types.String)
+																		if !ok {
+																			diags.Append(attrWriteConversionFailureDiag{"ScopedToken.spec.generic_oidc.allow_any.expression", "github.com/hashicorp/terraform-plugin-framework/types.String"})
+																		}
+																		v.Null = string(obj.Expression) == ""
+																	}
+																	v.Value = string(obj.Expression)
+																	v.Unknown = false
+																	tf.Attrs["expression"] = v
+																}
+															}
+														}
+														v.Unknown = false
+														c.Elems[k] = v
+													}
+													if len(obj.AllowAny) > 0 {
+														c.Null = false
+													}
+												}
+												c.Unknown = false
+												tf.Attrs["allow_any"] = c
+											}
+										}
+									}
+								}
+								v.Unknown = false
+								tf.Attrs["generic_oidc"] = v
+							}
 						}
 					}
 				}

--- a/integrations/terraform/tfschema/scopes/joining/v1/token_terraform.go
+++ b/integrations/terraform/tfschema/scopes/joining/v1/token_terraform.go
@@ -328,7 +328,7 @@ func GenSchemaScopedToken(ctx context.Context) (github_com_hashicorp_terraform_p
 								"conditions": {
 									Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.ListNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
 										"attribute": {
-											Description: "",
+											Description: "The name of the field this condition should check, separated by \".\" for nested fields.",
 											Optional:    true,
 											Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
 										},
@@ -338,7 +338,7 @@ func GenSchemaScopedToken(ctx context.Context) (github_com_hashicorp_terraform_p
 												Optional:    true,
 												Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
 											}}),
-											Description: "",
+											Description: "An \"equals\" operator. Only one operator may be set within a condition.",
 											Optional:    true,
 										},
 										"in": {
@@ -347,7 +347,7 @@ func GenSchemaScopedToken(ctx context.Context) (github_com_hashicorp_terraform_p
 												Optional:    true,
 												Type:        github_com_hashicorp_terraform_plugin_framework_types.ListType{ElemType: github_com_hashicorp_terraform_plugin_framework_types.StringType},
 											}}),
-											Description: "",
+											Description: "An \"in\" operator. Only one operator may be set within a condition.",
 											Optional:    true,
 										},
 										"not_eq": {
@@ -356,7 +356,7 @@ func GenSchemaScopedToken(ctx context.Context) (github_com_hashicorp_terraform_p
 												Optional:    true,
 												Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
 											}}),
-											Description: "",
+											Description: "A \"not equals\" operator. Only one operator may be set within a condition.",
 											Optional:    true,
 										},
 										"not_in": {
@@ -365,7 +365,7 @@ func GenSchemaScopedToken(ctx context.Context) (github_com_hashicorp_terraform_p
 												Optional:    true,
 												Type:        github_com_hashicorp_terraform_plugin_framework_types.ListType{ElemType: github_com_hashicorp_terraform_plugin_framework_types.StringType},
 											}}),
-											Description: "",
+											Description: "A \"not in\" operator. Only one operator may be set within a condition.",
 											Optional:    true,
 										},
 									}),
@@ -2119,7 +2119,6 @@ func CopyScopedTokenFromTerraform(_ context.Context, tf github_com_hashicorp_ter
 																							tf := v
 																							t = &github_com_gravitational_teleport_api_gen_proto_go_teleport_scopes_joining_v1.GenericOIDC_Condition{}
 																							obj := t
-																							obj.Operator = nil
 																							{
 																								a, ok := tf.Attrs["attribute"]
 																								if !ok {
@@ -2146,11 +2145,11 @@ func CopyScopedTokenFromTerraform(_ context.Context, tf github_com_hashicorp_ter
 																									if !ok {
 																										diags.Append(attrReadConversionFailureDiag{"ScopedToken.spec.generic_oidc.allow_any.conditions.eq", "github.com/hashicorp/terraform-plugin-framework/types.Object"})
 																									} else {
+																										obj.Eq = nil
 																										if !v.Null && !v.Unknown {
-																											b := &github_com_gravitational_teleport_api_gen_proto_go_teleport_scopes_joining_v1.GenericOIDC_ConditionEq{}
-																											obj.Operator = &github_com_gravitational_teleport_api_gen_proto_go_teleport_scopes_joining_v1.Condition_Eq{Eq: b}
-																											obj := b
 																											tf := v
+																											obj.Eq = &github_com_gravitational_teleport_api_gen_proto_go_teleport_scopes_joining_v1.GenericOIDC_ConditionEq{}
+																											obj := obj.Eq
 																											{
 																												a, ok := tf.Attrs["value"]
 																												if !ok {
@@ -2181,11 +2180,11 @@ func CopyScopedTokenFromTerraform(_ context.Context, tf github_com_hashicorp_ter
 																									if !ok {
 																										diags.Append(attrReadConversionFailureDiag{"ScopedToken.spec.generic_oidc.allow_any.conditions.not_eq", "github.com/hashicorp/terraform-plugin-framework/types.Object"})
 																									} else {
+																										obj.NotEq = nil
 																										if !v.Null && !v.Unknown {
-																											b := &github_com_gravitational_teleport_api_gen_proto_go_teleport_scopes_joining_v1.GenericOIDC_ConditionNotEq{}
-																											obj.Operator = &github_com_gravitational_teleport_api_gen_proto_go_teleport_scopes_joining_v1.Condition_NotEq{NotEq: b}
-																											obj := b
 																											tf := v
+																											obj.NotEq = &github_com_gravitational_teleport_api_gen_proto_go_teleport_scopes_joining_v1.GenericOIDC_ConditionNotEq{}
+																											obj := obj.NotEq
 																											{
 																												a, ok := tf.Attrs["value"]
 																												if !ok {
@@ -2216,11 +2215,11 @@ func CopyScopedTokenFromTerraform(_ context.Context, tf github_com_hashicorp_ter
 																									if !ok {
 																										diags.Append(attrReadConversionFailureDiag{"ScopedToken.spec.generic_oidc.allow_any.conditions.in", "github.com/hashicorp/terraform-plugin-framework/types.Object"})
 																									} else {
+																										obj.In = nil
 																										if !v.Null && !v.Unknown {
-																											b := &github_com_gravitational_teleport_api_gen_proto_go_teleport_scopes_joining_v1.GenericOIDC_ConditionIn{}
-																											obj.Operator = &github_com_gravitational_teleport_api_gen_proto_go_teleport_scopes_joining_v1.Condition_In{In: b}
-																											obj := b
 																											tf := v
+																											obj.In = &github_com_gravitational_teleport_api_gen_proto_go_teleport_scopes_joining_v1.GenericOIDC_ConditionIn{}
+																											obj := obj.In
 																											{
 																												a, ok := tf.Attrs["values"]
 																												if !ok {
@@ -2261,11 +2260,11 @@ func CopyScopedTokenFromTerraform(_ context.Context, tf github_com_hashicorp_ter
 																									if !ok {
 																										diags.Append(attrReadConversionFailureDiag{"ScopedToken.spec.generic_oidc.allow_any.conditions.not_in", "github.com/hashicorp/terraform-plugin-framework/types.Object"})
 																									} else {
+																										obj.NotIn = nil
 																										if !v.Null && !v.Unknown {
-																											b := &github_com_gravitational_teleport_api_gen_proto_go_teleport_scopes_joining_v1.GenericOIDC_ConditionNotIn{}
-																											obj.Operator = &github_com_gravitational_teleport_api_gen_proto_go_teleport_scopes_joining_v1.Condition_NotIn{NotIn: b}
-																											obj := b
 																											tf := v
+																											obj.NotIn = &github_com_gravitational_teleport_api_gen_proto_go_teleport_scopes_joining_v1.GenericOIDC_ConditionNotIn{}
+																											obj := obj.NotIn
 																											{
 																												a, ok := tf.Attrs["values"]
 																												if !ok {
@@ -4898,10 +4897,6 @@ func CopyScopedTokenToTerraform(ctx context.Context, obj *github_com_gravitation
 																						if !ok {
 																							diags.Append(attrWriteMissingDiag{"ScopedToken.spec.generic_oidc.allow_any.conditions.eq"})
 																						} else {
-																							obj, ok := obj.Operator.(*github_com_gravitational_teleport_api_gen_proto_go_teleport_scopes_joining_v1.Condition_Eq)
-																							if !ok {
-																								obj = &github_com_gravitational_teleport_api_gen_proto_go_teleport_scopes_joining_v1.Condition_Eq{}
-																							}
 																							o, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.ObjectType)
 																							if !ok {
 																								diags.Append(attrWriteConversionFailureDiag{"ScopedToken.spec.generic_oidc.allow_any.conditions.eq", "github.com/hashicorp/terraform-plugin-framework/types.ObjectType"})
@@ -4956,10 +4951,6 @@ func CopyScopedTokenToTerraform(ctx context.Context, obj *github_com_gravitation
 																						if !ok {
 																							diags.Append(attrWriteMissingDiag{"ScopedToken.spec.generic_oidc.allow_any.conditions.not_eq"})
 																						} else {
-																							obj, ok := obj.Operator.(*github_com_gravitational_teleport_api_gen_proto_go_teleport_scopes_joining_v1.Condition_NotEq)
-																							if !ok {
-																								obj = &github_com_gravitational_teleport_api_gen_proto_go_teleport_scopes_joining_v1.Condition_NotEq{}
-																							}
 																							o, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.ObjectType)
 																							if !ok {
 																								diags.Append(attrWriteConversionFailureDiag{"ScopedToken.spec.generic_oidc.allow_any.conditions.not_eq", "github.com/hashicorp/terraform-plugin-framework/types.ObjectType"})
@@ -5014,10 +5005,6 @@ func CopyScopedTokenToTerraform(ctx context.Context, obj *github_com_gravitation
 																						if !ok {
 																							diags.Append(attrWriteMissingDiag{"ScopedToken.spec.generic_oidc.allow_any.conditions.in"})
 																						} else {
-																							obj, ok := obj.Operator.(*github_com_gravitational_teleport_api_gen_proto_go_teleport_scopes_joining_v1.Condition_In)
-																							if !ok {
-																								obj = &github_com_gravitational_teleport_api_gen_proto_go_teleport_scopes_joining_v1.Condition_In{}
-																							}
 																							o, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.ObjectType)
 																							if !ok {
 																								diags.Append(attrWriteConversionFailureDiag{"ScopedToken.spec.generic_oidc.allow_any.conditions.in", "github.com/hashicorp/terraform-plugin-framework/types.ObjectType"})
@@ -5103,10 +5090,6 @@ func CopyScopedTokenToTerraform(ctx context.Context, obj *github_com_gravitation
 																						if !ok {
 																							diags.Append(attrWriteMissingDiag{"ScopedToken.spec.generic_oidc.allow_any.conditions.not_in"})
 																						} else {
-																							obj, ok := obj.Operator.(*github_com_gravitational_teleport_api_gen_proto_go_teleport_scopes_joining_v1.Condition_NotIn)
-																							if !ok {
-																								obj = &github_com_gravitational_teleport_api_gen_proto_go_teleport_scopes_joining_v1.Condition_NotIn{}
-																							}
 																							o, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.ObjectType)
 																							if !ok {
 																								diags.Append(attrWriteConversionFailureDiag{"ScopedToken.spec.generic_oidc.allow_any.conditions.not_in", "github.com/hashicorp/terraform-plugin-framework/types.ObjectType"})

--- a/integrations/terraform/tfschema/types_terraform.go
+++ b/integrations/terraform/tfschema/types_terraform.go
@@ -36,6 +36,7 @@ import (
 	github_com_hashicorp_terraform_plugin_framework_types "github.com/hashicorp/terraform-plugin-framework/types"
 	github_com_hashicorp_terraform_plugin_go_tftypes "github.com/hashicorp/terraform-plugin-go/tftypes"
 	_ "google.golang.org/protobuf/types/known/durationpb"
+	_ "google.golang.org/protobuf/types/known/structpb"
 	_ "google.golang.org/protobuf/types/known/timestamppb"
 )
 
@@ -1633,6 +1634,95 @@ func GenSchemaProvisionTokenV2(ctx context.Context) (github_com_hashicorp_terraf
 						Optional:    true,
 					}}),
 					Description: "GCP allows the configuration of options specific to the \"gcp\" join method.",
+					Optional:    true,
+				},
+				"generic_oidc": {
+					Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.SingleNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
+						"allow_any": {
+							Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.ListNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
+								"conditions": {
+									Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.ListNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
+										"attribute": {
+											Description: "",
+											Optional:    true,
+											Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
+										},
+										"eq": {
+											Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.SingleNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{"value": {
+												Description: "The value to compare the attribute against.",
+												Optional:    true,
+												Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
+											}}),
+											Description: "An \"equals\" operator. Only one operator may be set within a condition.",
+											Optional:    true,
+										},
+										"in": {
+											Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.SingleNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{"values": {
+												Description: "The list of values to compare the attribute against.",
+												Optional:    true,
+												Type:        github_com_hashicorp_terraform_plugin_framework_types.ListType{ElemType: github_com_hashicorp_terraform_plugin_framework_types.StringType},
+											}}),
+											Description: "An \"in\" operator. Only one operator may be set within a condition.",
+											Optional:    true,
+										},
+										"not_eq": {
+											Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.SingleNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{"value": {
+												Description: "The value to compare the attribute against.",
+												Optional:    true,
+												Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
+											}}),
+											Description: "A \"not equals\" operator. Only one operator may be set within a condition.",
+											Optional:    true,
+										},
+										"not_in": {
+											Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.SingleNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{"values": {
+												Description: "The list of values to compare the attribute against.",
+												Optional:    true,
+												Type:        github_com_hashicorp_terraform_plugin_framework_types.ListType{ElemType: github_com_hashicorp_terraform_plugin_framework_types.StringType},
+											}}),
+											Description: "A \"not in\" operator. Only one operator may be set within a condition.",
+											Optional:    true,
+										},
+									}),
+									Description: "Conditions are simple eq/not_eq/in/not_in conditions that check individual fields. All conditions must be satisfied for a join attempt to be allowed. Mutually exclusive with `expression`.",
+									Optional:    true,
+								},
+								"expression": {
+									Description: "Expression is a predicate expression that must evaluate to `true` for the join attempt to be allowed. Expressions are provided the `claims` object, containing all claims extracted from the incoming JWT. It is mutually exclusive with `conditions`.",
+									Optional:    true,
+									Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
+								},
+							}),
+							Description: "AllowAny evaluates complex rules using \"OR\" semantics. If any rules are specified, at least one rule must evaluate to `true` for the join attempt to be allowed. These rules are evaluated after `must_match_fields`, if any field matchers are specified in that block.  Note that at least one rule, either in `must_match_fields` or `allow_any`, must be specified for any join attempts to succeed.",
+							Optional:    true,
+						},
+						"audience": {
+							Description: "Audience is the expected audience value (required). This must match or be included in the list of `aud` values in the JWT provided by the client when joining. For providers that do not allow you to configure this value yourself (this is technically an OIDC spec violation, but is common), use the value they provide. Otherwise, we recommend using a value that uniquely identifies the Teleport cluster and join token. For example, you can use this scheme: $clusterName/$tokenName For a cluster named `example.teleport.sh` and a token named `example`, this would result in an audience of `example.teleport.sh/example`. If you prefer, you can also use a UUID instead of the token name. Note that you will need to configure the matching value with the issuer, usually at request time.",
+							Optional:    true,
+							Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
+						},
+						"insecure_allow_http_issuer": {
+							Description: "InsecureAllowHTTPIssuer is a flag that, if set, disables the requirement that the issuer must use HTTPS.",
+							Optional:    true,
+							Type:        github_com_hashicorp_terraform_plugin_framework_types.BoolType,
+						},
+						"issuer": {
+							Description: "Issuer contains the expected `iss` value as written in the JWT you wish to trust. Unless `static_jwks` is configured, this issuer must be accessible over HTTPS to the Teleport cluster and must serve valid OIDC metadata, including discovery configuration and JWKS keys.",
+							Optional:    true,
+							Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
+						},
+						"static_jwks": {
+							Description: "StaticJWKS is an optional static JWKS value that can be used to specify JWKS keys when either OIDC discovery is either not supported by the provider or the discovery configuration is not accessible to Teleport. When set, configuration and JWKS keys will not be fetched from the URL contained in `issuer` and JWTs will be validated using the key set specified here.",
+							Optional:    true,
+							Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
+						},
+						"tls_ca": {
+							Description: "TLSCA is a TLS CA certificate that should be used to verify requests for OIDC metadata from the issuer instead of Teleport's CA store, useful if the issuer is not public or otherwise uses a self-signed certificate. Note that this value only applies to requests using this token, and will be used instead of and not in addition to the system CA store, and will need to be updated manually if the remote CA is updated.",
+							Optional:    true,
+							Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
+						},
+					}),
+					Description: "GenericOIDC allows the configuration of generic OIDC join tokens.",
 					Optional:    true,
 				},
 				"github": {
@@ -19323,6 +19413,361 @@ func CopyProvisionTokenV2FromTerraform(_ context.Context, tf github_com_hashicor
 							}
 						}
 					}
+					{
+						a, ok := tf.Attrs["generic_oidc"]
+						if !ok {
+							diags.Append(attrReadMissingDiag{"ProvisionTokenV2.Spec.GenericOIDC"})
+						} else {
+							v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.Object)
+							if !ok {
+								diags.Append(attrReadConversionFailureDiag{"ProvisionTokenV2.Spec.GenericOIDC", "github.com/hashicorp/terraform-plugin-framework/types.Object"})
+							} else {
+								obj.GenericOIDC = nil
+								if !v.Null && !v.Unknown {
+									tf := v
+									obj.GenericOIDC = &github_com_gravitational_teleport_api_types.ProvisionTokenSpecV2GenericOIDC{}
+									obj := obj.GenericOIDC
+									{
+										a, ok := tf.Attrs["issuer"]
+										if !ok {
+											diags.Append(attrReadMissingDiag{"ProvisionTokenV2.Spec.GenericOIDC.Issuer"})
+										} else {
+											v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.String)
+											if !ok {
+												diags.Append(attrReadConversionFailureDiag{"ProvisionTokenV2.Spec.GenericOIDC.Issuer", "github.com/hashicorp/terraform-plugin-framework/types.String"})
+											} else {
+												var t string
+												if !v.Null && !v.Unknown {
+													t = string(v.Value)
+												}
+												obj.Issuer = t
+											}
+										}
+									}
+									{
+										a, ok := tf.Attrs["insecure_allow_http_issuer"]
+										if !ok {
+											diags.Append(attrReadMissingDiag{"ProvisionTokenV2.Spec.GenericOIDC.InsecureAllowHTTPIssuer"})
+										} else {
+											v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.Bool)
+											if !ok {
+												diags.Append(attrReadConversionFailureDiag{"ProvisionTokenV2.Spec.GenericOIDC.InsecureAllowHTTPIssuer", "github.com/hashicorp/terraform-plugin-framework/types.Bool"})
+											} else {
+												var t bool
+												if !v.Null && !v.Unknown {
+													t = bool(v.Value)
+												}
+												obj.InsecureAllowHTTPIssuer = t
+											}
+										}
+									}
+									{
+										a, ok := tf.Attrs["audience"]
+										if !ok {
+											diags.Append(attrReadMissingDiag{"ProvisionTokenV2.Spec.GenericOIDC.Audience"})
+										} else {
+											v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.String)
+											if !ok {
+												diags.Append(attrReadConversionFailureDiag{"ProvisionTokenV2.Spec.GenericOIDC.Audience", "github.com/hashicorp/terraform-plugin-framework/types.String"})
+											} else {
+												var t string
+												if !v.Null && !v.Unknown {
+													t = string(v.Value)
+												}
+												obj.Audience = t
+											}
+										}
+									}
+									{
+										a, ok := tf.Attrs["static_jwks"]
+										if !ok {
+											diags.Append(attrReadMissingDiag{"ProvisionTokenV2.Spec.GenericOIDC.StaticJWKS"})
+										} else {
+											v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.String)
+											if !ok {
+												diags.Append(attrReadConversionFailureDiag{"ProvisionTokenV2.Spec.GenericOIDC.StaticJWKS", "github.com/hashicorp/terraform-plugin-framework/types.String"})
+											} else {
+												var t string
+												if !v.Null && !v.Unknown {
+													t = string(v.Value)
+												}
+												obj.StaticJWKS = t
+											}
+										}
+									}
+									{
+										a, ok := tf.Attrs["tls_ca"]
+										if !ok {
+											diags.Append(attrReadMissingDiag{"ProvisionTokenV2.Spec.GenericOIDC.TLSCA"})
+										} else {
+											v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.String)
+											if !ok {
+												diags.Append(attrReadConversionFailureDiag{"ProvisionTokenV2.Spec.GenericOIDC.TLSCA", "github.com/hashicorp/terraform-plugin-framework/types.String"})
+											} else {
+												var t string
+												if !v.Null && !v.Unknown {
+													t = string(v.Value)
+												}
+												obj.TLSCA = t
+											}
+										}
+									}
+									{
+										a, ok := tf.Attrs["allow_any"]
+										if !ok {
+											diags.Append(attrReadMissingDiag{"ProvisionTokenV2.Spec.GenericOIDC.AllowAny"})
+										} else {
+											v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.List)
+											if !ok {
+												diags.Append(attrReadConversionFailureDiag{"ProvisionTokenV2.Spec.GenericOIDC.AllowAny", "github.com/hashicorp/terraform-plugin-framework/types.List"})
+											} else {
+												obj.AllowAny = make([]*github_com_gravitational_teleport_api_types.ProvisionTokenSpecV2GenericOIDC_Rule, len(v.Elems))
+												if !v.Null && !v.Unknown {
+													for k, a := range v.Elems {
+														v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.Object)
+														if !ok {
+															diags.Append(attrReadConversionFailureDiag{"ProvisionTokenV2.Spec.GenericOIDC.AllowAny", "github_com_hashicorp_terraform_plugin_framework_types.Object"})
+														} else {
+															var t *github_com_gravitational_teleport_api_types.ProvisionTokenSpecV2GenericOIDC_Rule
+															if !v.Null && !v.Unknown {
+																tf := v
+																t = &github_com_gravitational_teleport_api_types.ProvisionTokenSpecV2GenericOIDC_Rule{}
+																obj := t
+																{
+																	a, ok := tf.Attrs["conditions"]
+																	if !ok {
+																		diags.Append(attrReadMissingDiag{"ProvisionTokenV2.Spec.GenericOIDC.AllowAny.Conditions"})
+																	} else {
+																		v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.List)
+																		if !ok {
+																			diags.Append(attrReadConversionFailureDiag{"ProvisionTokenV2.Spec.GenericOIDC.AllowAny.Conditions", "github.com/hashicorp/terraform-plugin-framework/types.List"})
+																		} else {
+																			obj.Conditions = make([]*github_com_gravitational_teleport_api_types.ProvisionTokenSpecV2GenericOIDC_Condition, len(v.Elems))
+																			if !v.Null && !v.Unknown {
+																				for k, a := range v.Elems {
+																					v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.Object)
+																					if !ok {
+																						diags.Append(attrReadConversionFailureDiag{"ProvisionTokenV2.Spec.GenericOIDC.AllowAny.Conditions", "github_com_hashicorp_terraform_plugin_framework_types.Object"})
+																					} else {
+																						var t *github_com_gravitational_teleport_api_types.ProvisionTokenSpecV2GenericOIDC_Condition
+																						if !v.Null && !v.Unknown {
+																							tf := v
+																							t = &github_com_gravitational_teleport_api_types.ProvisionTokenSpecV2GenericOIDC_Condition{}
+																							obj := t
+																							{
+																								a, ok := tf.Attrs["attribute"]
+																								if !ok {
+																									diags.Append(attrReadMissingDiag{"ProvisionTokenV2.Spec.GenericOIDC.AllowAny.Conditions.Attribute"})
+																								} else {
+																									v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.String)
+																									if !ok {
+																										diags.Append(attrReadConversionFailureDiag{"ProvisionTokenV2.Spec.GenericOIDC.AllowAny.Conditions.Attribute", "github.com/hashicorp/terraform-plugin-framework/types.String"})
+																									} else {
+																										var t string
+																										if !v.Null && !v.Unknown {
+																											t = string(v.Value)
+																										}
+																										obj.Attribute = t
+																									}
+																								}
+																							}
+																							{
+																								a, ok := tf.Attrs["eq"]
+																								if !ok {
+																									diags.Append(attrReadMissingDiag{"ProvisionTokenV2.Spec.GenericOIDC.AllowAny.Conditions.Eq"})
+																								} else {
+																									v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.Object)
+																									if !ok {
+																										diags.Append(attrReadConversionFailureDiag{"ProvisionTokenV2.Spec.GenericOIDC.AllowAny.Conditions.Eq", "github.com/hashicorp/terraform-plugin-framework/types.Object"})
+																									} else {
+																										obj.Eq = nil
+																										if !v.Null && !v.Unknown {
+																											tf := v
+																											obj.Eq = &github_com_gravitational_teleport_api_types.ProvisionTokenSpecV2GenericOIDC_ConditionEq{}
+																											obj := obj.Eq
+																											{
+																												a, ok := tf.Attrs["value"]
+																												if !ok {
+																													diags.Append(attrReadMissingDiag{"ProvisionTokenV2.Spec.GenericOIDC.AllowAny.Conditions.Eq.Value"})
+																												} else {
+																													v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.String)
+																													if !ok {
+																														diags.Append(attrReadConversionFailureDiag{"ProvisionTokenV2.Spec.GenericOIDC.AllowAny.Conditions.Eq.Value", "github.com/hashicorp/terraform-plugin-framework/types.String"})
+																													} else {
+																														var t string
+																														if !v.Null && !v.Unknown {
+																															t = string(v.Value)
+																														}
+																														obj.Value = t
+																													}
+																												}
+																											}
+																										}
+																									}
+																								}
+																							}
+																							{
+																								a, ok := tf.Attrs["not_eq"]
+																								if !ok {
+																									diags.Append(attrReadMissingDiag{"ProvisionTokenV2.Spec.GenericOIDC.AllowAny.Conditions.NotEq"})
+																								} else {
+																									v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.Object)
+																									if !ok {
+																										diags.Append(attrReadConversionFailureDiag{"ProvisionTokenV2.Spec.GenericOIDC.AllowAny.Conditions.NotEq", "github.com/hashicorp/terraform-plugin-framework/types.Object"})
+																									} else {
+																										obj.NotEq = nil
+																										if !v.Null && !v.Unknown {
+																											tf := v
+																											obj.NotEq = &github_com_gravitational_teleport_api_types.ProvisionTokenSpecV2GenericOIDC_ConditionNotEq{}
+																											obj := obj.NotEq
+																											{
+																												a, ok := tf.Attrs["value"]
+																												if !ok {
+																													diags.Append(attrReadMissingDiag{"ProvisionTokenV2.Spec.GenericOIDC.AllowAny.Conditions.NotEq.Value"})
+																												} else {
+																													v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.String)
+																													if !ok {
+																														diags.Append(attrReadConversionFailureDiag{"ProvisionTokenV2.Spec.GenericOIDC.AllowAny.Conditions.NotEq.Value", "github.com/hashicorp/terraform-plugin-framework/types.String"})
+																													} else {
+																														var t string
+																														if !v.Null && !v.Unknown {
+																															t = string(v.Value)
+																														}
+																														obj.Value = t
+																													}
+																												}
+																											}
+																										}
+																									}
+																								}
+																							}
+																							{
+																								a, ok := tf.Attrs["in"]
+																								if !ok {
+																									diags.Append(attrReadMissingDiag{"ProvisionTokenV2.Spec.GenericOIDC.AllowAny.Conditions.In"})
+																								} else {
+																									v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.Object)
+																									if !ok {
+																										diags.Append(attrReadConversionFailureDiag{"ProvisionTokenV2.Spec.GenericOIDC.AllowAny.Conditions.In", "github.com/hashicorp/terraform-plugin-framework/types.Object"})
+																									} else {
+																										obj.In = nil
+																										if !v.Null && !v.Unknown {
+																											tf := v
+																											obj.In = &github_com_gravitational_teleport_api_types.ProvisionTokenSpecV2GenericOIDC_ConditionIn{}
+																											obj := obj.In
+																											{
+																												a, ok := tf.Attrs["values"]
+																												if !ok {
+																													diags.Append(attrReadMissingDiag{"ProvisionTokenV2.Spec.GenericOIDC.AllowAny.Conditions.In.Values"})
+																												} else {
+																													v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.List)
+																													if !ok {
+																														diags.Append(attrReadConversionFailureDiag{"ProvisionTokenV2.Spec.GenericOIDC.AllowAny.Conditions.In.Values", "github.com/hashicorp/terraform-plugin-framework/types.List"})
+																													} else {
+																														obj.Values = make([]string, len(v.Elems))
+																														if !v.Null && !v.Unknown {
+																															for k, a := range v.Elems {
+																																v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.String)
+																																if !ok {
+																																	diags.Append(attrReadConversionFailureDiag{"ProvisionTokenV2.Spec.GenericOIDC.AllowAny.Conditions.In.Values", "github_com_hashicorp_terraform_plugin_framework_types.String"})
+																																} else {
+																																	var t string
+																																	if !v.Null && !v.Unknown {
+																																		t = string(v.Value)
+																																	}
+																																	obj.Values[k] = t
+																																}
+																															}
+																														}
+																													}
+																												}
+																											}
+																										}
+																									}
+																								}
+																							}
+																							{
+																								a, ok := tf.Attrs["not_in"]
+																								if !ok {
+																									diags.Append(attrReadMissingDiag{"ProvisionTokenV2.Spec.GenericOIDC.AllowAny.Conditions.NotIn"})
+																								} else {
+																									v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.Object)
+																									if !ok {
+																										diags.Append(attrReadConversionFailureDiag{"ProvisionTokenV2.Spec.GenericOIDC.AllowAny.Conditions.NotIn", "github.com/hashicorp/terraform-plugin-framework/types.Object"})
+																									} else {
+																										obj.NotIn = nil
+																										if !v.Null && !v.Unknown {
+																											tf := v
+																											obj.NotIn = &github_com_gravitational_teleport_api_types.ProvisionTokenSpecV2GenericOIDC_ConditionNotIn{}
+																											obj := obj.NotIn
+																											{
+																												a, ok := tf.Attrs["values"]
+																												if !ok {
+																													diags.Append(attrReadMissingDiag{"ProvisionTokenV2.Spec.GenericOIDC.AllowAny.Conditions.NotIn.Values"})
+																												} else {
+																													v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.List)
+																													if !ok {
+																														diags.Append(attrReadConversionFailureDiag{"ProvisionTokenV2.Spec.GenericOIDC.AllowAny.Conditions.NotIn.Values", "github.com/hashicorp/terraform-plugin-framework/types.List"})
+																													} else {
+																														obj.Values = make([]string, len(v.Elems))
+																														if !v.Null && !v.Unknown {
+																															for k, a := range v.Elems {
+																																v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.String)
+																																if !ok {
+																																	diags.Append(attrReadConversionFailureDiag{"ProvisionTokenV2.Spec.GenericOIDC.AllowAny.Conditions.NotIn.Values", "github_com_hashicorp_terraform_plugin_framework_types.String"})
+																																} else {
+																																	var t string
+																																	if !v.Null && !v.Unknown {
+																																		t = string(v.Value)
+																																	}
+																																	obj.Values[k] = t
+																																}
+																															}
+																														}
+																													}
+																												}
+																											}
+																										}
+																									}
+																								}
+																							}
+																						}
+																						obj.Conditions[k] = t
+																					}
+																				}
+																			}
+																		}
+																	}
+																}
+																{
+																	a, ok := tf.Attrs["expression"]
+																	if !ok {
+																		diags.Append(attrReadMissingDiag{"ProvisionTokenV2.Spec.GenericOIDC.AllowAny.Expression"})
+																	} else {
+																		v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.String)
+																		if !ok {
+																			diags.Append(attrReadConversionFailureDiag{"ProvisionTokenV2.Spec.GenericOIDC.AllowAny.Expression", "github.com/hashicorp/terraform-plugin-framework/types.String"})
+																		} else {
+																			var t string
+																			if !v.Null && !v.Unknown {
+																				t = string(v.Value)
+																			}
+																			obj.Expression = t
+																		}
+																	}
+																}
+															}
+															obj.AllowAny[k] = t
+														}
+													}
+												}
+											}
+										}
+									}
+								}
+							}
+						}
+					}
 				}
 			}
 		}
@@ -24080,6 +24525,586 @@ func CopyProvisionTokenV2ToTerraform(ctx context.Context, obj *github_com_gravit
 							v.Value = string(obj.Integration)
 							v.Unknown = false
 							tf.Attrs["integration"] = v
+						}
+					}
+					{
+						a, ok := tf.AttrTypes["generic_oidc"]
+						if !ok {
+							diags.Append(attrWriteMissingDiag{"ProvisionTokenV2.Spec.GenericOIDC"})
+						} else {
+							o, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.ObjectType)
+							if !ok {
+								diags.Append(attrWriteConversionFailureDiag{"ProvisionTokenV2.Spec.GenericOIDC", "github.com/hashicorp/terraform-plugin-framework/types.ObjectType"})
+							} else {
+								v, ok := tf.Attrs["generic_oidc"].(github_com_hashicorp_terraform_plugin_framework_types.Object)
+								if !ok {
+									v = github_com_hashicorp_terraform_plugin_framework_types.Object{
+
+										AttrTypes: o.AttrTypes,
+										Attrs:     make(map[string]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(o.AttrTypes)),
+									}
+								} else {
+									if v.Attrs == nil {
+										v.Attrs = make(map[string]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(tf.AttrTypes))
+									}
+								}
+								if obj.GenericOIDC == nil {
+									v.Null = true
+								} else {
+									obj := obj.GenericOIDC
+									tf := &v
+									{
+										t, ok := tf.AttrTypes["issuer"]
+										if !ok {
+											diags.Append(attrWriteMissingDiag{"ProvisionTokenV2.Spec.GenericOIDC.Issuer"})
+										} else {
+											v, ok := tf.Attrs["issuer"].(github_com_hashicorp_terraform_plugin_framework_types.String)
+											if !ok {
+												i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
+												if err != nil {
+													diags.Append(attrWriteGeneralError{"ProvisionTokenV2.Spec.GenericOIDC.Issuer", err})
+												}
+												v, ok = i.(github_com_hashicorp_terraform_plugin_framework_types.String)
+												if !ok {
+													diags.Append(attrWriteConversionFailureDiag{"ProvisionTokenV2.Spec.GenericOIDC.Issuer", "github.com/hashicorp/terraform-plugin-framework/types.String"})
+												}
+												v.Null = string(obj.Issuer) == ""
+											}
+											v.Value = string(obj.Issuer)
+											v.Unknown = false
+											tf.Attrs["issuer"] = v
+										}
+									}
+									{
+										t, ok := tf.AttrTypes["insecure_allow_http_issuer"]
+										if !ok {
+											diags.Append(attrWriteMissingDiag{"ProvisionTokenV2.Spec.GenericOIDC.InsecureAllowHTTPIssuer"})
+										} else {
+											v, ok := tf.Attrs["insecure_allow_http_issuer"].(github_com_hashicorp_terraform_plugin_framework_types.Bool)
+											if !ok {
+												i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
+												if err != nil {
+													diags.Append(attrWriteGeneralError{"ProvisionTokenV2.Spec.GenericOIDC.InsecureAllowHTTPIssuer", err})
+												}
+												v, ok = i.(github_com_hashicorp_terraform_plugin_framework_types.Bool)
+												if !ok {
+													diags.Append(attrWriteConversionFailureDiag{"ProvisionTokenV2.Spec.GenericOIDC.InsecureAllowHTTPIssuer", "github.com/hashicorp/terraform-plugin-framework/types.Bool"})
+												}
+												v.Null = bool(obj.InsecureAllowHTTPIssuer) == false
+											}
+											v.Value = bool(obj.InsecureAllowHTTPIssuer)
+											v.Unknown = false
+											tf.Attrs["insecure_allow_http_issuer"] = v
+										}
+									}
+									{
+										t, ok := tf.AttrTypes["audience"]
+										if !ok {
+											diags.Append(attrWriteMissingDiag{"ProvisionTokenV2.Spec.GenericOIDC.Audience"})
+										} else {
+											v, ok := tf.Attrs["audience"].(github_com_hashicorp_terraform_plugin_framework_types.String)
+											if !ok {
+												i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
+												if err != nil {
+													diags.Append(attrWriteGeneralError{"ProvisionTokenV2.Spec.GenericOIDC.Audience", err})
+												}
+												v, ok = i.(github_com_hashicorp_terraform_plugin_framework_types.String)
+												if !ok {
+													diags.Append(attrWriteConversionFailureDiag{"ProvisionTokenV2.Spec.GenericOIDC.Audience", "github.com/hashicorp/terraform-plugin-framework/types.String"})
+												}
+												v.Null = string(obj.Audience) == ""
+											}
+											v.Value = string(obj.Audience)
+											v.Unknown = false
+											tf.Attrs["audience"] = v
+										}
+									}
+									{
+										t, ok := tf.AttrTypes["static_jwks"]
+										if !ok {
+											diags.Append(attrWriteMissingDiag{"ProvisionTokenV2.Spec.GenericOIDC.StaticJWKS"})
+										} else {
+											v, ok := tf.Attrs["static_jwks"].(github_com_hashicorp_terraform_plugin_framework_types.String)
+											if !ok {
+												i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
+												if err != nil {
+													diags.Append(attrWriteGeneralError{"ProvisionTokenV2.Spec.GenericOIDC.StaticJWKS", err})
+												}
+												v, ok = i.(github_com_hashicorp_terraform_plugin_framework_types.String)
+												if !ok {
+													diags.Append(attrWriteConversionFailureDiag{"ProvisionTokenV2.Spec.GenericOIDC.StaticJWKS", "github.com/hashicorp/terraform-plugin-framework/types.String"})
+												}
+												v.Null = string(obj.StaticJWKS) == ""
+											}
+											v.Value = string(obj.StaticJWKS)
+											v.Unknown = false
+											tf.Attrs["static_jwks"] = v
+										}
+									}
+									{
+										t, ok := tf.AttrTypes["tls_ca"]
+										if !ok {
+											diags.Append(attrWriteMissingDiag{"ProvisionTokenV2.Spec.GenericOIDC.TLSCA"})
+										} else {
+											v, ok := tf.Attrs["tls_ca"].(github_com_hashicorp_terraform_plugin_framework_types.String)
+											if !ok {
+												i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
+												if err != nil {
+													diags.Append(attrWriteGeneralError{"ProvisionTokenV2.Spec.GenericOIDC.TLSCA", err})
+												}
+												v, ok = i.(github_com_hashicorp_terraform_plugin_framework_types.String)
+												if !ok {
+													diags.Append(attrWriteConversionFailureDiag{"ProvisionTokenV2.Spec.GenericOIDC.TLSCA", "github.com/hashicorp/terraform-plugin-framework/types.String"})
+												}
+												v.Null = string(obj.TLSCA) == ""
+											}
+											v.Value = string(obj.TLSCA)
+											v.Unknown = false
+											tf.Attrs["tls_ca"] = v
+										}
+									}
+									{
+										a, ok := tf.AttrTypes["allow_any"]
+										if !ok {
+											diags.Append(attrWriteMissingDiag{"ProvisionTokenV2.Spec.GenericOIDC.AllowAny"})
+										} else {
+											o, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.ListType)
+											if !ok {
+												diags.Append(attrWriteConversionFailureDiag{"ProvisionTokenV2.Spec.GenericOIDC.AllowAny", "github.com/hashicorp/terraform-plugin-framework/types.ListType"})
+											} else {
+												c, ok := tf.Attrs["allow_any"].(github_com_hashicorp_terraform_plugin_framework_types.List)
+												if !ok {
+													c = github_com_hashicorp_terraform_plugin_framework_types.List{
+
+														ElemType: o.ElemType,
+														Elems:    make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.AllowAny)),
+														Null:     true,
+													}
+												} else {
+													if c.Elems == nil {
+														c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.AllowAny))
+													}
+												}
+												if obj.AllowAny != nil {
+													o := o.ElemType.(github_com_hashicorp_terraform_plugin_framework_types.ObjectType)
+													if len(obj.AllowAny) != len(c.Elems) {
+														c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.AllowAny))
+													}
+													for k, a := range obj.AllowAny {
+														v, ok := tf.Attrs["allow_any"].(github_com_hashicorp_terraform_plugin_framework_types.Object)
+														if !ok {
+															v = github_com_hashicorp_terraform_plugin_framework_types.Object{
+
+																AttrTypes: o.AttrTypes,
+																Attrs:     make(map[string]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(o.AttrTypes)),
+															}
+														} else {
+															if v.Attrs == nil {
+																v.Attrs = make(map[string]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(tf.AttrTypes))
+															}
+														}
+														if a == nil {
+															v.Null = true
+														} else {
+															obj := a
+															tf := &v
+															{
+																a, ok := tf.AttrTypes["conditions"]
+																if !ok {
+																	diags.Append(attrWriteMissingDiag{"ProvisionTokenV2.Spec.GenericOIDC.AllowAny.Conditions"})
+																} else {
+																	o, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.ListType)
+																	if !ok {
+																		diags.Append(attrWriteConversionFailureDiag{"ProvisionTokenV2.Spec.GenericOIDC.AllowAny.Conditions", "github.com/hashicorp/terraform-plugin-framework/types.ListType"})
+																	} else {
+																		c, ok := tf.Attrs["conditions"].(github_com_hashicorp_terraform_plugin_framework_types.List)
+																		if !ok {
+																			c = github_com_hashicorp_terraform_plugin_framework_types.List{
+
+																				ElemType: o.ElemType,
+																				Elems:    make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.Conditions)),
+																				Null:     true,
+																			}
+																		} else {
+																			if c.Elems == nil {
+																				c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.Conditions))
+																			}
+																		}
+																		if obj.Conditions != nil {
+																			o := o.ElemType.(github_com_hashicorp_terraform_plugin_framework_types.ObjectType)
+																			if len(obj.Conditions) != len(c.Elems) {
+																				c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.Conditions))
+																			}
+																			for k, a := range obj.Conditions {
+																				v, ok := tf.Attrs["conditions"].(github_com_hashicorp_terraform_plugin_framework_types.Object)
+																				if !ok {
+																					v = github_com_hashicorp_terraform_plugin_framework_types.Object{
+
+																						AttrTypes: o.AttrTypes,
+																						Attrs:     make(map[string]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(o.AttrTypes)),
+																					}
+																				} else {
+																					if v.Attrs == nil {
+																						v.Attrs = make(map[string]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(tf.AttrTypes))
+																					}
+																				}
+																				if a == nil {
+																					v.Null = true
+																				} else {
+																					obj := a
+																					tf := &v
+																					{
+																						t, ok := tf.AttrTypes["attribute"]
+																						if !ok {
+																							diags.Append(attrWriteMissingDiag{"ProvisionTokenV2.Spec.GenericOIDC.AllowAny.Conditions.Attribute"})
+																						} else {
+																							v, ok := tf.Attrs["attribute"].(github_com_hashicorp_terraform_plugin_framework_types.String)
+																							if !ok {
+																								i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
+																								if err != nil {
+																									diags.Append(attrWriteGeneralError{"ProvisionTokenV2.Spec.GenericOIDC.AllowAny.Conditions.Attribute", err})
+																								}
+																								v, ok = i.(github_com_hashicorp_terraform_plugin_framework_types.String)
+																								if !ok {
+																									diags.Append(attrWriteConversionFailureDiag{"ProvisionTokenV2.Spec.GenericOIDC.AllowAny.Conditions.Attribute", "github.com/hashicorp/terraform-plugin-framework/types.String"})
+																								}
+																								v.Null = string(obj.Attribute) == ""
+																							}
+																							v.Value = string(obj.Attribute)
+																							v.Unknown = false
+																							tf.Attrs["attribute"] = v
+																						}
+																					}
+																					{
+																						a, ok := tf.AttrTypes["eq"]
+																						if !ok {
+																							diags.Append(attrWriteMissingDiag{"ProvisionTokenV2.Spec.GenericOIDC.AllowAny.Conditions.Eq"})
+																						} else {
+																							o, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.ObjectType)
+																							if !ok {
+																								diags.Append(attrWriteConversionFailureDiag{"ProvisionTokenV2.Spec.GenericOIDC.AllowAny.Conditions.Eq", "github.com/hashicorp/terraform-plugin-framework/types.ObjectType"})
+																							} else {
+																								v, ok := tf.Attrs["eq"].(github_com_hashicorp_terraform_plugin_framework_types.Object)
+																								if !ok {
+																									v = github_com_hashicorp_terraform_plugin_framework_types.Object{
+
+																										AttrTypes: o.AttrTypes,
+																										Attrs:     make(map[string]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(o.AttrTypes)),
+																									}
+																								} else {
+																									if v.Attrs == nil {
+																										v.Attrs = make(map[string]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(tf.AttrTypes))
+																									}
+																								}
+																								if obj.Eq == nil {
+																									v.Null = true
+																								} else {
+																									obj := obj.Eq
+																									tf := &v
+																									{
+																										t, ok := tf.AttrTypes["value"]
+																										if !ok {
+																											diags.Append(attrWriteMissingDiag{"ProvisionTokenV2.Spec.GenericOIDC.AllowAny.Conditions.Eq.Value"})
+																										} else {
+																											v, ok := tf.Attrs["value"].(github_com_hashicorp_terraform_plugin_framework_types.String)
+																											if !ok {
+																												i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
+																												if err != nil {
+																													diags.Append(attrWriteGeneralError{"ProvisionTokenV2.Spec.GenericOIDC.AllowAny.Conditions.Eq.Value", err})
+																												}
+																												v, ok = i.(github_com_hashicorp_terraform_plugin_framework_types.String)
+																												if !ok {
+																													diags.Append(attrWriteConversionFailureDiag{"ProvisionTokenV2.Spec.GenericOIDC.AllowAny.Conditions.Eq.Value", "github.com/hashicorp/terraform-plugin-framework/types.String"})
+																												}
+																												v.Null = string(obj.Value) == ""
+																											}
+																											v.Value = string(obj.Value)
+																											v.Unknown = false
+																											tf.Attrs["value"] = v
+																										}
+																									}
+																								}
+																								v.Unknown = false
+																								tf.Attrs["eq"] = v
+																							}
+																						}
+																					}
+																					{
+																						a, ok := tf.AttrTypes["not_eq"]
+																						if !ok {
+																							diags.Append(attrWriteMissingDiag{"ProvisionTokenV2.Spec.GenericOIDC.AllowAny.Conditions.NotEq"})
+																						} else {
+																							o, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.ObjectType)
+																							if !ok {
+																								diags.Append(attrWriteConversionFailureDiag{"ProvisionTokenV2.Spec.GenericOIDC.AllowAny.Conditions.NotEq", "github.com/hashicorp/terraform-plugin-framework/types.ObjectType"})
+																							} else {
+																								v, ok := tf.Attrs["not_eq"].(github_com_hashicorp_terraform_plugin_framework_types.Object)
+																								if !ok {
+																									v = github_com_hashicorp_terraform_plugin_framework_types.Object{
+
+																										AttrTypes: o.AttrTypes,
+																										Attrs:     make(map[string]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(o.AttrTypes)),
+																									}
+																								} else {
+																									if v.Attrs == nil {
+																										v.Attrs = make(map[string]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(tf.AttrTypes))
+																									}
+																								}
+																								if obj.NotEq == nil {
+																									v.Null = true
+																								} else {
+																									obj := obj.NotEq
+																									tf := &v
+																									{
+																										t, ok := tf.AttrTypes["value"]
+																										if !ok {
+																											diags.Append(attrWriteMissingDiag{"ProvisionTokenV2.Spec.GenericOIDC.AllowAny.Conditions.NotEq.Value"})
+																										} else {
+																											v, ok := tf.Attrs["value"].(github_com_hashicorp_terraform_plugin_framework_types.String)
+																											if !ok {
+																												i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
+																												if err != nil {
+																													diags.Append(attrWriteGeneralError{"ProvisionTokenV2.Spec.GenericOIDC.AllowAny.Conditions.NotEq.Value", err})
+																												}
+																												v, ok = i.(github_com_hashicorp_terraform_plugin_framework_types.String)
+																												if !ok {
+																													diags.Append(attrWriteConversionFailureDiag{"ProvisionTokenV2.Spec.GenericOIDC.AllowAny.Conditions.NotEq.Value", "github.com/hashicorp/terraform-plugin-framework/types.String"})
+																												}
+																												v.Null = string(obj.Value) == ""
+																											}
+																											v.Value = string(obj.Value)
+																											v.Unknown = false
+																											tf.Attrs["value"] = v
+																										}
+																									}
+																								}
+																								v.Unknown = false
+																								tf.Attrs["not_eq"] = v
+																							}
+																						}
+																					}
+																					{
+																						a, ok := tf.AttrTypes["in"]
+																						if !ok {
+																							diags.Append(attrWriteMissingDiag{"ProvisionTokenV2.Spec.GenericOIDC.AllowAny.Conditions.In"})
+																						} else {
+																							o, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.ObjectType)
+																							if !ok {
+																								diags.Append(attrWriteConversionFailureDiag{"ProvisionTokenV2.Spec.GenericOIDC.AllowAny.Conditions.In", "github.com/hashicorp/terraform-plugin-framework/types.ObjectType"})
+																							} else {
+																								v, ok := tf.Attrs["in"].(github_com_hashicorp_terraform_plugin_framework_types.Object)
+																								if !ok {
+																									v = github_com_hashicorp_terraform_plugin_framework_types.Object{
+
+																										AttrTypes: o.AttrTypes,
+																										Attrs:     make(map[string]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(o.AttrTypes)),
+																									}
+																								} else {
+																									if v.Attrs == nil {
+																										v.Attrs = make(map[string]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(tf.AttrTypes))
+																									}
+																								}
+																								if obj.In == nil {
+																									v.Null = true
+																								} else {
+																									obj := obj.In
+																									tf := &v
+																									{
+																										a, ok := tf.AttrTypes["values"]
+																										if !ok {
+																											diags.Append(attrWriteMissingDiag{"ProvisionTokenV2.Spec.GenericOIDC.AllowAny.Conditions.In.Values"})
+																										} else {
+																											o, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.ListType)
+																											if !ok {
+																												diags.Append(attrWriteConversionFailureDiag{"ProvisionTokenV2.Spec.GenericOIDC.AllowAny.Conditions.In.Values", "github.com/hashicorp/terraform-plugin-framework/types.ListType"})
+																											} else {
+																												c, ok := tf.Attrs["values"].(github_com_hashicorp_terraform_plugin_framework_types.List)
+																												if !ok {
+																													c = github_com_hashicorp_terraform_plugin_framework_types.List{
+
+																														ElemType: o.ElemType,
+																														Elems:    make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.Values)),
+																														Null:     true,
+																													}
+																												} else {
+																													if c.Elems == nil {
+																														c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.Values))
+																													}
+																												}
+																												if obj.Values != nil {
+																													t := o.ElemType
+																													if len(obj.Values) != len(c.Elems) {
+																														c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.Values))
+																													}
+																													for k, a := range obj.Values {
+																														v, ok := tf.Attrs["values"].(github_com_hashicorp_terraform_plugin_framework_types.String)
+																														if !ok {
+																															i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
+																															if err != nil {
+																																diags.Append(attrWriteGeneralError{"ProvisionTokenV2.Spec.GenericOIDC.AllowAny.Conditions.In.Values", err})
+																															}
+																															v, ok = i.(github_com_hashicorp_terraform_plugin_framework_types.String)
+																															if !ok {
+																																diags.Append(attrWriteConversionFailureDiag{"ProvisionTokenV2.Spec.GenericOIDC.AllowAny.Conditions.In.Values", "github.com/hashicorp/terraform-plugin-framework/types.String"})
+																															}
+																															v.Null = string(a) == ""
+																														}
+																														v.Value = string(a)
+																														v.Unknown = false
+																														c.Elems[k] = v
+																													}
+																													if len(obj.Values) > 0 {
+																														c.Null = false
+																													}
+																												}
+																												c.Unknown = false
+																												tf.Attrs["values"] = c
+																											}
+																										}
+																									}
+																								}
+																								v.Unknown = false
+																								tf.Attrs["in"] = v
+																							}
+																						}
+																					}
+																					{
+																						a, ok := tf.AttrTypes["not_in"]
+																						if !ok {
+																							diags.Append(attrWriteMissingDiag{"ProvisionTokenV2.Spec.GenericOIDC.AllowAny.Conditions.NotIn"})
+																						} else {
+																							o, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.ObjectType)
+																							if !ok {
+																								diags.Append(attrWriteConversionFailureDiag{"ProvisionTokenV2.Spec.GenericOIDC.AllowAny.Conditions.NotIn", "github.com/hashicorp/terraform-plugin-framework/types.ObjectType"})
+																							} else {
+																								v, ok := tf.Attrs["not_in"].(github_com_hashicorp_terraform_plugin_framework_types.Object)
+																								if !ok {
+																									v = github_com_hashicorp_terraform_plugin_framework_types.Object{
+
+																										AttrTypes: o.AttrTypes,
+																										Attrs:     make(map[string]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(o.AttrTypes)),
+																									}
+																								} else {
+																									if v.Attrs == nil {
+																										v.Attrs = make(map[string]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(tf.AttrTypes))
+																									}
+																								}
+																								if obj.NotIn == nil {
+																									v.Null = true
+																								} else {
+																									obj := obj.NotIn
+																									tf := &v
+																									{
+																										a, ok := tf.AttrTypes["values"]
+																										if !ok {
+																											diags.Append(attrWriteMissingDiag{"ProvisionTokenV2.Spec.GenericOIDC.AllowAny.Conditions.NotIn.Values"})
+																										} else {
+																											o, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.ListType)
+																											if !ok {
+																												diags.Append(attrWriteConversionFailureDiag{"ProvisionTokenV2.Spec.GenericOIDC.AllowAny.Conditions.NotIn.Values", "github.com/hashicorp/terraform-plugin-framework/types.ListType"})
+																											} else {
+																												c, ok := tf.Attrs["values"].(github_com_hashicorp_terraform_plugin_framework_types.List)
+																												if !ok {
+																													c = github_com_hashicorp_terraform_plugin_framework_types.List{
+
+																														ElemType: o.ElemType,
+																														Elems:    make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.Values)),
+																														Null:     true,
+																													}
+																												} else {
+																													if c.Elems == nil {
+																														c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.Values))
+																													}
+																												}
+																												if obj.Values != nil {
+																													t := o.ElemType
+																													if len(obj.Values) != len(c.Elems) {
+																														c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.Values))
+																													}
+																													for k, a := range obj.Values {
+																														v, ok := tf.Attrs["values"].(github_com_hashicorp_terraform_plugin_framework_types.String)
+																														if !ok {
+																															i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
+																															if err != nil {
+																																diags.Append(attrWriteGeneralError{"ProvisionTokenV2.Spec.GenericOIDC.AllowAny.Conditions.NotIn.Values", err})
+																															}
+																															v, ok = i.(github_com_hashicorp_terraform_plugin_framework_types.String)
+																															if !ok {
+																																diags.Append(attrWriteConversionFailureDiag{"ProvisionTokenV2.Spec.GenericOIDC.AllowAny.Conditions.NotIn.Values", "github.com/hashicorp/terraform-plugin-framework/types.String"})
+																															}
+																															v.Null = string(a) == ""
+																														}
+																														v.Value = string(a)
+																														v.Unknown = false
+																														c.Elems[k] = v
+																													}
+																													if len(obj.Values) > 0 {
+																														c.Null = false
+																													}
+																												}
+																												c.Unknown = false
+																												tf.Attrs["values"] = c
+																											}
+																										}
+																									}
+																								}
+																								v.Unknown = false
+																								tf.Attrs["not_in"] = v
+																							}
+																						}
+																					}
+																				}
+																				v.Unknown = false
+																				c.Elems[k] = v
+																			}
+																			if len(obj.Conditions) > 0 {
+																				c.Null = false
+																			}
+																		}
+																		c.Unknown = false
+																		tf.Attrs["conditions"] = c
+																	}
+																}
+															}
+															{
+																t, ok := tf.AttrTypes["expression"]
+																if !ok {
+																	diags.Append(attrWriteMissingDiag{"ProvisionTokenV2.Spec.GenericOIDC.AllowAny.Expression"})
+																} else {
+																	v, ok := tf.Attrs["expression"].(github_com_hashicorp_terraform_plugin_framework_types.String)
+																	if !ok {
+																		i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
+																		if err != nil {
+																			diags.Append(attrWriteGeneralError{"ProvisionTokenV2.Spec.GenericOIDC.AllowAny.Expression", err})
+																		}
+																		v, ok = i.(github_com_hashicorp_terraform_plugin_framework_types.String)
+																		if !ok {
+																			diags.Append(attrWriteConversionFailureDiag{"ProvisionTokenV2.Spec.GenericOIDC.AllowAny.Expression", "github.com/hashicorp/terraform-plugin-framework/types.String"})
+																		}
+																		v.Null = string(obj.Expression) == ""
+																	}
+																	v.Value = string(obj.Expression)
+																	v.Unknown = false
+																	tf.Attrs["expression"] = v
+																}
+															}
+														}
+														v.Unknown = false
+														c.Elems[k] = v
+													}
+													if len(obj.AllowAny) > 0 {
+														c.Null = false
+													}
+												}
+												c.Unknown = false
+												tf.Attrs["allow_any"] = c
+											}
+										}
+									}
+								}
+								v.Unknown = false
+								tf.Attrs["generic_oidc"] = v
+							}
 						}
 					}
 				}

--- a/integrations/terraform/tfschema/types_terraform.go
+++ b/integrations/terraform/tfschema/types_terraform.go
@@ -1643,7 +1643,7 @@ func GenSchemaProvisionTokenV2(ctx context.Context) (github_com_hashicorp_terraf
 								"conditions": {
 									Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.ListNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
 										"attribute": {
-											Description: "",
+											Description: "The name of the field this condition should check, separated by \".\" for nested fields.",
 											Optional:    true,
 											Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
 										},

--- a/lib/join/provision/token.go
+++ b/lib/join/provision/token.go
@@ -77,4 +77,6 @@ type Token interface {
 	GetBoundKeypair() *types.ProvisionTokenSpecV2BoundKeypair
 	// GetBoundKeypairStatus returns bound keypair status for this token.
 	GetBoundKeypairStatus() *types.ProvisionTokenStatusV2BoundKeypair
+	// GetGenericOIDC returns the generic_oidc-specific configuration for this token.
+	GetGenericOIDC() (*types.ProvisionTokenSpecV2GenericOIDC, error)
 }

--- a/lib/scopes/joining/token.go
+++ b/lib/scopes/joining/token.go
@@ -17,6 +17,7 @@
 package joining
 
 import (
+	"bytes"
 	"cmp"
 	"crypto/sha256"
 	"encoding/base64"
@@ -27,7 +28,11 @@ import (
 	"strings"
 	"time"
 
+	"github.com/gogo/protobuf/jsonpb"
+	gogotypes "github.com/gogo/protobuf/types"
 	"github.com/gravitational/trace"
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/types/known/structpb"
 
 	joiningv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/joining/v1"
 	"github.com/gravitational/teleport/api/types"
@@ -823,6 +828,100 @@ func (t *Token) GetBoundKeypair() *types.ProvisionTokenSpecV2BoundKeypair {
 // token.
 func (t *Token) GetBoundKeypairStatus() *types.ProvisionTokenStatusV2BoundKeypair {
 	return BoundKeypairStatusFromScopedToken(t.scoped)
+}
+
+// convertStructPB converts a structpb.Struct to a gogo-compatible
+// `types.Struct`. Inspired by `apievents.Resource153ToStruct()`] but avoiding a
+// potentially heavyweight import.
+func convertStructPB(s *structpb.Struct) (*gogotypes.Struct, error) {
+	encoded, err := protojson.Marshal(s)
+	if err != nil {
+		return nil, trace.Wrap(err, "marshaling protojson")
+	}
+
+	out := &gogotypes.Struct{}
+	if err = (&jsonpb.Unmarshaler{
+		AllowUnknownFields: true,
+	}).Unmarshal(bytes.NewReader(encoded), out); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return out, nil
+}
+
+// convertGenericOIDCCondition converts a scoped generic_oidc condition to a
+// ProvisionTokenV2-style condition (with gogoproto semantics).
+func convertGenericOIDCCondition(c *joiningv1.GenericOIDC_Condition) (*types.ProvisionTokenSpecV2GenericOIDC_Condition, error) {
+	v := &types.ProvisionTokenSpecV2GenericOIDC_Condition{
+		Attribute: c.GetAttribute(),
+	}
+
+	switch t := c.GetOperator().(type) {
+	case *joiningv1.GenericOIDC_Condition_Eq:
+		v.Eq = &types.ProvisionTokenSpecV2GenericOIDC_ConditionEq{
+			Value: t.Eq.GetValue(),
+		}
+	case *joiningv1.GenericOIDC_Condition_NotEq:
+		v.NotEq = &types.ProvisionTokenSpecV2GenericOIDC_ConditionNotEq{
+			Value: t.NotEq.GetValue(),
+		}
+	case *joiningv1.GenericOIDC_Condition_In:
+		v.In = &types.ProvisionTokenSpecV2GenericOIDC_ConditionIn{
+			Values: t.In.GetValues(),
+		}
+	case *joiningv1.GenericOIDC_Condition_NotIn:
+		v.NotIn = &types.ProvisionTokenSpecV2GenericOIDC_ConditionNotIn{
+			Values: t.NotIn.GetValues(),
+		}
+	default:
+		return nil, trace.BadParameter("unexpected condition operator type %T", t)
+	}
+
+	return v, nil
+}
+
+// GetGenericOIDC returns the generic_oidc-specific configuration for this token.
+func (t *Token) GetGenericOIDC() (*types.ProvisionTokenSpecV2GenericOIDC, error) {
+	spec := t.scoped.GetSpec().GetGenericOidc()
+
+	var globalMatchers *gogotypes.Struct
+	if gm := spec.GetMustMatchFields(); gm != nil {
+		gogo, err := convertStructPB(spec.GetMustMatchFields())
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+
+		globalMatchers = gogo
+	}
+
+	allow := make([]*types.ProvisionTokenSpecV2GenericOIDC_Rule, len(spec.GetAllowAny()))
+	for i, rule := range spec.GetAllowAny() {
+		conditions := make([]*types.ProvisionTokenSpecV2GenericOIDC_Condition, len(rule.GetConditions()))
+		for j, condition := range rule.GetConditions() {
+			converted, err := convertGenericOIDCCondition(condition)
+			if err != nil {
+				return nil, trace.Wrap(err)
+			}
+
+			conditions[j] = converted
+		}
+
+		allow[i] = &types.ProvisionTokenSpecV2GenericOIDC_Rule{
+			Expression: rule.GetExpression(),
+			Conditions: conditions,
+		}
+	}
+
+	return &types.ProvisionTokenSpecV2GenericOIDC{
+		Issuer:                  spec.GetIssuer(),
+		InsecureAllowHTTPIssuer: spec.GetInsecureAllowHttpIssuer(),
+		Audience:                spec.GetAudience(),
+		StaticJWKS:              spec.GetStaticJwks(),
+		TLSCA:                   spec.GetTlsCa(),
+
+		MustMatchFields: globalMatchers,
+		AllowAny:        allow,
+	}, nil
 }
 
 // GetScoped returns the inner scoped token wrapped by this [provision.Token].

--- a/lib/scopes/joining/token.go
+++ b/lib/scopes/joining/token.go
@@ -17,7 +17,6 @@
 package joining
 
 import (
-	"bytes"
 	"cmp"
 	"crypto/sha256"
 	"encoding/base64"
@@ -28,11 +27,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/gogo/protobuf/jsonpb"
 	gogotypes "github.com/gogo/protobuf/types"
 	"github.com/gravitational/trace"
-	"google.golang.org/protobuf/encoding/protojson"
-	"google.golang.org/protobuf/types/known/structpb"
 
 	joiningv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/joining/v1"
 	"github.com/gravitational/teleport/api/types"
@@ -830,25 +826,6 @@ func (t *Token) GetBoundKeypairStatus() *types.ProvisionTokenStatusV2BoundKeypai
 	return BoundKeypairStatusFromScopedToken(t.scoped)
 }
 
-// convertStructPB converts a structpb.Struct to a gogo-compatible
-// `types.Struct`. Inspired by `apievents.Resource153ToStruct()`] but avoiding a
-// potentially heavyweight import.
-func convertStructPB(s *structpb.Struct) (*gogotypes.Struct, error) {
-	encoded, err := protojson.Marshal(s)
-	if err != nil {
-		return nil, trace.Wrap(err, "marshaling protojson")
-	}
-
-	out := &gogotypes.Struct{}
-	if err = (&jsonpb.Unmarshaler{
-		AllowUnknownFields: true,
-	}).Unmarshal(bytes.NewReader(encoded), out); err != nil {
-		return nil, trace.Wrap(err)
-	}
-
-	return out, nil
-}
-
 // convertGenericOIDCCondition converts a scoped generic_oidc condition to a
 // ProvisionTokenV2-style condition (with gogoproto semantics).
 func convertGenericOIDCCondition(c *joiningv1.GenericOIDC_Condition) (*types.ProvisionTokenSpecV2GenericOIDC_Condition, error) {
@@ -856,25 +833,25 @@ func convertGenericOIDCCondition(c *joiningv1.GenericOIDC_Condition) (*types.Pro
 		Attribute: c.GetAttribute(),
 	}
 
-	switch t := c.GetOperator().(type) {
-	case *joiningv1.GenericOIDC_Condition_Eq:
+	switch {
+	case c.GetEq() != nil:
 		v.Eq = &types.ProvisionTokenSpecV2GenericOIDC_ConditionEq{
-			Value: t.Eq.GetValue(),
+			Value: c.GetEq().GetValue(),
 		}
-	case *joiningv1.GenericOIDC_Condition_NotEq:
+	case c.GetNotEq() != nil:
 		v.NotEq = &types.ProvisionTokenSpecV2GenericOIDC_ConditionNotEq{
-			Value: t.NotEq.GetValue(),
+			Value: c.GetNotEq().GetValue(),
 		}
-	case *joiningv1.GenericOIDC_Condition_In:
+	case c.GetIn() != nil:
 		v.In = &types.ProvisionTokenSpecV2GenericOIDC_ConditionIn{
-			Values: t.In.GetValues(),
+			Values: c.GetIn().GetValues(),
 		}
-	case *joiningv1.GenericOIDC_Condition_NotIn:
+	case c.GetNotIn() != nil:
 		v.NotIn = &types.ProvisionTokenSpecV2GenericOIDC_ConditionNotIn{
-			Values: t.NotIn.GetValues(),
+			Values: c.GetNotIn().GetValues(),
 		}
 	default:
-		return nil, trace.BadParameter("unexpected condition operator type %T", t)
+		return nil, trace.BadParameter("an operator is required but found none")
 	}
 
 	return v, nil

--- a/lib/scopes/joining/token.go
+++ b/lib/scopes/joining/token.go
@@ -27,7 +27,6 @@ import (
 	"strings"
 	"time"
 
-	gogotypes "github.com/gogo/protobuf/types"
 	"github.com/gravitational/trace"
 
 	joiningv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/joining/v1"
@@ -861,7 +860,7 @@ func convertGenericOIDCCondition(c *joiningv1.GenericOIDC_Condition) (*types.Pro
 func (t *Token) GetGenericOIDC() (*types.ProvisionTokenSpecV2GenericOIDC, error) {
 	spec := t.scoped.GetSpec().GetGenericOidc()
 
-	var globalMatchers *gogotypes.Struct
+	var globalMatchers *types.Struct
 	if gm := spec.GetMustMatchFields(); gm != nil {
 		gogo, err := convertStructPB(spec.GetMustMatchFields())
 		if err != nil {

--- a/lib/scopes/joining/token_convert.go
+++ b/lib/scopes/joining/token_convert.go
@@ -17,11 +17,8 @@
 package joining
 
 import (
-	"bytes"
-
-	"github.com/gogo/protobuf/jsonpb" //nolint:depguard // needed for backwards compatibility with gogoproto-generated types.Struct
 	"github.com/gravitational/trace"
-	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/structpb"
 
 	"github.com/gravitational/teleport/api/types"
@@ -29,18 +26,19 @@ import (
 
 // convertStructPB converts a structpb.Struct to a gogo-compatible
 // `types.Struct`. Inspired by `apievents.Resource153ToStruct()`] but avoiding a
-// potentially heavyweight import.
+// potentially heavyweight import, and skipping an unnecessary jsonpb
+// conversion.
 func convertStructPB(s *structpb.Struct) (*types.Struct, error) {
-	encoded, err := protojson.Marshal(s)
+	encoded, err := proto.Marshal(s)
 	if err != nil {
-		return nil, trace.Wrap(err, "marshaling protojson")
+		return nil, trace.Wrap(err, "marshaling proto struct")
 	}
 
+	// unmarshal directly into the wrapper's inner type to avoid a json
+	// conversion.
 	out := &types.Struct{}
-	if err = (&jsonpb.Unmarshaler{
-		AllowUnknownFields: true,
-	}).Unmarshal(bytes.NewReader(encoded), out); err != nil {
-		return nil, trace.Wrap(err)
+	if err := out.Struct.Unmarshal(encoded); err != nil {
+		return nil, trace.Wrap(err, "unmarshaling into gogo struct")
 	}
 
 	return out, nil

--- a/lib/scopes/joining/token_convert.go
+++ b/lib/scopes/joining/token_convert.go
@@ -20,22 +20,23 @@ import (
 	"bytes"
 
 	"github.com/gogo/protobuf/jsonpb" //nolint:depguard // needed for backwards compatibility with gogoproto-generated types.Struct
-	gogotypes "github.com/gogo/protobuf/types"
 	"github.com/gravitational/trace"
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/types/known/structpb"
+
+	"github.com/gravitational/teleport/api/types"
 )
 
 // convertStructPB converts a structpb.Struct to a gogo-compatible
 // `types.Struct`. Inspired by `apievents.Resource153ToStruct()`] but avoiding a
 // potentially heavyweight import.
-func convertStructPB(s *structpb.Struct) (*gogotypes.Struct, error) {
+func convertStructPB(s *structpb.Struct) (*types.Struct, error) {
 	encoded, err := protojson.Marshal(s)
 	if err != nil {
 		return nil, trace.Wrap(err, "marshaling protojson")
 	}
 
-	out := &gogotypes.Struct{}
+	out := &types.Struct{}
 	if err = (&jsonpb.Unmarshaler{
 		AllowUnknownFields: true,
 	}).Unmarshal(bytes.NewReader(encoded), out); err != nil {

--- a/lib/scopes/joining/token_convert.go
+++ b/lib/scopes/joining/token_convert.go
@@ -1,0 +1,46 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package joining
+
+import (
+	"bytes"
+
+	"github.com/gogo/protobuf/jsonpb" //nolint:depguard // needed for backwards compatibility with gogoproto-generated types.Struct
+	gogotypes "github.com/gogo/protobuf/types"
+	"github.com/gravitational/trace"
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/types/known/structpb"
+)
+
+// convertStructPB converts a structpb.Struct to a gogo-compatible
+// `types.Struct`. Inspired by `apievents.Resource153ToStruct()`] but avoiding a
+// potentially heavyweight import.
+func convertStructPB(s *structpb.Struct) (*gogotypes.Struct, error) {
+	encoded, err := protojson.Marshal(s)
+	if err != nil {
+		return nil, trace.Wrap(err, "marshaling protojson")
+	}
+
+	out := &gogotypes.Struct{}
+	if err = (&jsonpb.Unmarshaler{
+		AllowUnknownFields: true,
+	}).Unmarshal(bytes.NewReader(encoded), out); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return out, nil
+}

--- a/lib/services/provisioning_test.go
+++ b/lib/services/provisioning_test.go
@@ -21,7 +21,10 @@ package services_test
 import (
 	"testing"
 
+	gogotypes "github.com/gogo/protobuf/types"
+	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/testing/protocmp"
 
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/services"
@@ -189,4 +192,139 @@ func TestDefaultsAppliedDuringMarshal(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Equal(t, types.KubernetesJoinTypeInCluster, unmarshaled.GetKubernetes().Type)
+}
+
+// TestGenericOIDCStructSurvivesRoundTrip ensures `MustMatchFields` (a Struct
+// type) roundtrips correctly, i.e. it's custom marshal/unmarshal is executed
+// since the standard jsoniter implementation can't handle struct fields.
+func TestGenericOIDCStructSurvivesRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	token := &types.ProvisionTokenV2{
+		Version: types.V2,
+		Metadata: types.Metadata{
+			Name: "generic-oidc-token",
+		},
+		Spec: types.ProvisionTokenSpecV2{
+			Roles:      []types.SystemRole{types.RoleNode},
+			JoinMethod: types.JoinMethodGenericOIDC,
+			GenericOIDC: &types.ProvisionTokenSpecV2GenericOIDC{
+				Issuer:   "https://example.com",
+				Audience: "example.teleport.sh/generic-oidc-token",
+				MustMatchFields: &gogotypes.Struct{
+					Fields: map[string]*gogotypes.Value{
+						"example": {Kind: &gogotypes.Value_StringValue{
+							StringValue: "foo",
+						}},
+						"nested": {
+							Kind: &gogotypes.Value_StructValue{
+								StructValue: &gogotypes.Struct{Fields: map[string]*gogotypes.Value{
+									"number": {Kind: &gogotypes.Value_NumberValue{
+										NumberValue: 123.456,
+									}},
+									"string": {Kind: &gogotypes.Value_StringValue{
+										StringValue: "string value",
+									}},
+									"bool": {Kind: &gogotypes.Value_BoolValue{
+										BoolValue: true,
+									}},
+								}},
+							},
+						},
+					},
+				},
+				AllowAny: []*types.ProvisionTokenSpecV2GenericOIDC_Rule{
+					{
+						Expression: "claims.foo == \"bar\"",
+					},
+					{
+						Conditions: []*types.ProvisionTokenSpecV2GenericOIDC_Condition{
+							{
+								Attribute: "foo",
+								Eq: &types.ProvisionTokenSpecV2GenericOIDC_ConditionEq{
+									Value: "bar",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	marshaled, err := services.MarshalProvisionToken(token)
+	require.NoError(t, err)
+
+	unmarshaled, err := services.UnmarshalProvisionToken(marshaled)
+	require.NoError(t, err)
+
+	require.Empty(t, cmp.Diff(token, unmarshaled, protocmp.Transform()), "generic_oidc structs must roundtrip correctly")
+
+	token = &types.ProvisionTokenV2{
+		Version: types.V2,
+		Metadata: types.Metadata{
+			Name: "generic-oidc-token",
+		},
+		Spec: types.ProvisionTokenSpecV2{
+			Roles:      []types.SystemRole{types.RoleNode},
+			JoinMethod: types.JoinMethodGenericOIDC,
+			GenericOIDC: &types.ProvisionTokenSpecV2GenericOIDC{
+				Issuer:          "https://example.com",
+				Audience:        "example.teleport.sh/generic-oidc-token",
+				MustMatchFields: nil,
+				AllowAny: []*types.ProvisionTokenSpecV2GenericOIDC_Rule{
+					{
+						Expression: "claims.foo == \"bar\"",
+					},
+					{
+						Conditions: []*types.ProvisionTokenSpecV2GenericOIDC_Condition{
+							{
+								Attribute: "foo",
+								Eq: &types.ProvisionTokenSpecV2GenericOIDC_ConditionEq{
+									Value: "bar",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	marshaled, err = services.MarshalProvisionToken(token)
+	require.NoError(t, err)
+
+	unmarshaled, err = services.UnmarshalProvisionToken(marshaled)
+	require.NoError(t, err)
+
+	require.Empty(t, cmp.Diff(token, unmarshaled, protocmp.Transform()), "nil MustMatchFields must roundtrip correctly")
+}
+
+// TestGenericOIDCStructSurvivesRoundTrip_FastMarshal ensures struct
+// roundtripping works explicitly through FastMarshal.
+func TestGenericOIDCStructSurvivesRoundTrip_FastMarshal(t *testing.T) {
+	t.Parallel()
+
+	want := &types.ProvisionTokenSpecV2GenericOIDC{
+		Issuer:   "https://example.com",
+		Audience: "example",
+		MustMatchFields: &gogotypes.Struct{
+			Fields: map[string]*gogotypes.Value{
+				"sub":    {Kind: &gogotypes.Value_StringValue{StringValue: "repo:foo/bar"}},
+				"count":  {Kind: &gogotypes.Value_NumberValue{NumberValue: 3}},
+				"active": {Kind: &gogotypes.Value_BoolValue{BoolValue: true}},
+			},
+		},
+	}
+
+	// Explicitly route through FastMarshal to ensure it calls our overridden
+	// marshal impl, otherwise the test could plausibly be testing jsonpb
+	// and the actual impl could fail.
+	data, err := utils.FastMarshal(want)
+	require.NoError(t, err)
+
+	var got types.ProvisionTokenSpecV2GenericOIDC
+	require.NoError(t, utils.FastUnmarshal(data, &got))
+
+	require.Empty(t, cmp.Diff(want, &got, protocmp.Transform()), "generic_oidc must_match_fields must survive round-trip")
 }

--- a/lib/services/provisioning_test.go
+++ b/lib/services/provisioning_test.go
@@ -211,28 +211,26 @@ func TestGenericOIDCStructSurvivesRoundTrip(t *testing.T) {
 			GenericOIDC: &types.ProvisionTokenSpecV2GenericOIDC{
 				Issuer:   "https://example.com",
 				Audience: "example.teleport.sh/generic-oidc-token",
-				MustMatchFields: &gogotypes.Struct{
-					Fields: map[string]*gogotypes.Value{
-						"example": {Kind: &gogotypes.Value_StringValue{
-							StringValue: "foo",
-						}},
-						"nested": {
-							Kind: &gogotypes.Value_StructValue{
-								StructValue: &gogotypes.Struct{Fields: map[string]*gogotypes.Value{
-									"number": {Kind: &gogotypes.Value_NumberValue{
-										NumberValue: 123.456,
-									}},
-									"string": {Kind: &gogotypes.Value_StringValue{
-										StringValue: "string value",
-									}},
-									"bool": {Kind: &gogotypes.Value_BoolValue{
-										BoolValue: true,
-									}},
+				MustMatchFields: types.NewStructFromGogoValues(map[string]*gogotypes.Value{
+					"example": {Kind: &gogotypes.Value_StringValue{
+						StringValue: "foo",
+					}},
+					"nested": {
+						Kind: &gogotypes.Value_StructValue{
+							StructValue: &gogotypes.Struct{Fields: map[string]*gogotypes.Value{
+								"number": {Kind: &gogotypes.Value_NumberValue{
+									NumberValue: 123.456,
 								}},
-							},
+								"string": {Kind: &gogotypes.Value_StringValue{
+									StringValue: "string value",
+								}},
+								"bool": {Kind: &gogotypes.Value_BoolValue{
+									BoolValue: true,
+								}},
+							}},
 						},
 					},
-				},
+				}),
 				AllowAny: []*types.ProvisionTokenSpecV2GenericOIDC_Rule{
 					{
 						Expression: "claims.foo == \"bar\"",
@@ -308,13 +306,11 @@ func TestGenericOIDCStructSurvivesRoundTrip_FastMarshal(t *testing.T) {
 	want := &types.ProvisionTokenSpecV2GenericOIDC{
 		Issuer:   "https://example.com",
 		Audience: "example",
-		MustMatchFields: &gogotypes.Struct{
-			Fields: map[string]*gogotypes.Value{
-				"sub":    {Kind: &gogotypes.Value_StringValue{StringValue: "repo:foo/bar"}},
-				"count":  {Kind: &gogotypes.Value_NumberValue{NumberValue: 3}},
-				"active": {Kind: &gogotypes.Value_BoolValue{BoolValue: true}},
-			},
-		},
+		MustMatchFields: types.NewStructFromGogoValues(map[string]*gogotypes.Value{
+			"sub":    {Kind: &gogotypes.Value_StringValue{StringValue: "repo:foo/bar"}},
+			"count":  {Kind: &gogotypes.Value_NumberValue{NumberValue: 3}},
+			"active": {Kind: &gogotypes.Value_BoolValue{BoolValue: true}},
+		}),
 	}
 
 	// Explicitly route through FastMarshal to ensure it calls our overridden
@@ -327,4 +323,30 @@ func TestGenericOIDCStructSurvivesRoundTrip_FastMarshal(t *testing.T) {
 	require.NoError(t, utils.FastUnmarshal(data, &got))
 
 	require.Empty(t, cmp.Diff(want, &got, protocmp.Transform()), "generic_oidc must_match_fields must survive round-trip")
+}
+
+func TestGenericOIDCUnmarshalDocumentedFieldNames(t *testing.T) {
+	raw := []byte(`{
+		"kind": "token",
+		"version": "v2",
+		"metadata": {"name":"go"},
+		"spec":{
+			"roles": ["Node"],
+			"join_method": "generic_oidc",
+			"generic_oidc": {
+				"issuer": "https://example.com",
+				"audience": "aud",
+				"allow_any":[{"expression":"x == 1"}],
+				"must_match_fields": {"sub":"repo:foo/bar"}
+			}
+		}
+	}`)
+
+	tok, err := services.UnmarshalProvisionToken(raw)
+	require.NoError(t, err) // fails today: CheckAndSetDefaults rejects empty config
+	spec, err := tok.GetGenericOIDC()
+	require.NoError(t, err)
+	require.Equal(t, "https://example.com", spec.Issuer)
+	require.Len(t, spec.AllowAny, 1)
+	require.Equal(t, "repo:foo/bar", spec.MustMatchFields.GetFields()["sub"].GetStringValue())
 }


### PR DESCRIPTION
This adds proto changes to support generic OIDC joining. It includes some conversion functionality for scoped tokens to `types.ProvisionTokenV2`, but is otherwise functionally inert and does not add any functionality that will be exercised on a Teleport cluster.

## PR Stack

RFD: https://github.com/gravitational/rfd/pull/8

1. https://github.com/gravitational/teleport/pull/67991
2. https://github.com/gravitational/teleport/pull/68075
3. This PR (protos)
4. https://github.com/gravitational/teleport/pull/67913

This PR does not actually depend on the caching OIDC validator change and can be merged to master directly, which I may do first pending approval.

## Manual Test Plan
### Test Environment

See https://github.com/gravitational/teleport/pull/67991

### Test Cases
- [x] Teleport joining still works (see https://github.com/gravitational/teleport/pull/67991)
