### PR TITLE
[v17] Connect: Use `os.Root` for directory sharing

### DIFF
--- a/lib/teleterm/daemon/daemon.go
+++ b/lib/teleterm/daemon/daemon.go
@@ -262,6 +262,9 @@ func (s *Service) newDesktopSession(desktopURI uri.ResourceURI, login string) (*
 		defer s.desktopSessionsMu.Unlock()
 
 		delete(s.desktopSessions, key)
+		if err := session.CloseSharedDirectory(); err != nil {
+			s.cfg.Log.Warn("Failed to close shared directory for desktop session", "error", err)
+		}
 	}
 
 	return session, cleanup, nil

--- a/lib/teleterm/services/desktop/desktop.go
+++ b/lib/teleterm/services/desktop/desktop.go
@@ -93,6 +93,20 @@ func (s *Session) GetDirectoryAccess() (*DirectoryAccess, error) {
 	return s.dirAccess, nil
 }
 
+// CloseSharedDirectory releases the shared directory handle, if one was opened
+// via SetSharedDirectory. Safe to call multiple times.
+func (s *Session) CloseSharedDirectory() error {
+	s.dirAccessMu.Lock()
+	defer s.dirAccessMu.Unlock()
+
+	if s.dirAccess == nil {
+		return nil
+	}
+	err := s.dirAccess.Close()
+	s.dirAccess = nil
+	return trace.Wrap(err)
+}
+
 // Start starts a remote desktop session.
 func (s *Session) Start(ctx context.Context, stream grpc.BidiStreamingServer[api.ConnectToDesktopRequest, api.ConnectToDesktopResponse], clusterClient *client.TeleportClient, proxyClient *proxy.Client) error {
 	keyRing, err := clusterClient.IssueUserCertsWithMFA(ctx, client.ReissueParams{

--- a/lib/teleterm/services/desktop/desktop_test.go
+++ b/lib/teleterm/services/desktop/desktop_test.go
@@ -17,7 +17,6 @@
 package desktop
 
 import (
-	"path/filepath"
 	"testing"
 
 	"github.com/gravitational/trace"
@@ -56,7 +55,6 @@ func TestGetDirectory(t *testing.T) {
 
 	access, err := session.GetDirectoryAccess()
 	require.NoError(t, err)
-	resolvedPath, err := filepath.EvalSymlinks(path)
+	_, err = access.Stat("")
 	require.NoError(t, err)
-	require.Equal(t, resolvedPath, access.basePath)
 }

--- a/lib/teleterm/services/desktop/directorysharing.go
+++ b/lib/teleterm/services/desktop/directorysharing.go
@@ -21,8 +21,8 @@ import (
 	"io"
 	"io/fs"
 	"os"
+	"path"
 	"path/filepath"
-	"strings"
 
 	"github.com/gravitational/trace"
 )
@@ -31,11 +31,7 @@ import (
 // Should be kept in sync with web/packages/shared/libs/tdp/sharedDirectoryAccess.ts
 // where FS events are handled for Web UI.
 type DirectoryAccess struct {
-	// basePath is a shared directory path.
-	// Must not be used directly, but only through getSafePath.
-	// TODO(gzdunek): This code can be greatly simplified with os.OpenRoot.
-	// Switch to it when branch/v17 is updated to Go 1.24.
-	basePath string
+	root *os.Root
 }
 
 // FileOrDirInfo contains metadata about a file or a directory.
@@ -58,65 +54,28 @@ const StandardDirSize = 4096
 
 // NewDirectoryAccess initializes a DirectoryAccess instance for the given directory.
 func NewDirectoryAccess(baseDir string) (*DirectoryAccess, error) {
-	basePath, err := filepath.EvalSymlinks(baseDir)
+	root, err := os.OpenRoot(baseDir)
 	if err != nil {
 		return nil, trace.ConvertSystemError(err)
 	}
-
-	stat, err := os.Stat(basePath)
-	if err != nil {
-		return nil, trace.ConvertSystemError(err)
-	}
-	if !stat.IsDir() {
-		return nil, trace.BadParameter("%q is not a directory", baseDir)
-	}
-
-	return &DirectoryAccess{
-		basePath: basePath,
-	}, nil
-
+	return &DirectoryAccess{root: root}, nil
 }
 
-// getSafePath allows building a safe path by joining the base path
-// and a relative path.
-// Returns an error if the resolved path escapes the basePath, preventing directory traversal attacks.
-func (d *DirectoryAccess) getSafePath(relativePath string) (string, error) {
-	full := filepath.Join(d.basePath, relativePath)
-	resolved, err := filepath.EvalSymlinks(full)
-	if err != nil {
-		// EvalSymlinks returns an error if the target file does not exist.
-		// In that case, attempt to resolve the symlinks of the parent directory instead.
-		if errors.Is(err, fs.ErrNotExist) {
-			parent := filepath.Dir(full)
-			resolvedParent, perr := filepath.EvalSymlinks(parent)
-			if perr != nil {
-				return "", trace.ConvertSystemError(perr)
-			}
-
-			// Reconstruct the full path by joining the resolved parent with the original file name.
-			resolved = filepath.Join(resolvedParent, filepath.Base(full))
-		} else {
-			return "", trace.ConvertSystemError(err)
-		}
-	}
-	if !isSubPath(d.basePath, resolved) {
-		return "", trace.BadParameter("path escapes from parent")
-	}
-	return resolved, nil
+// Close releases the underlying directory handle.
+func (d *DirectoryAccess) Close() error {
+	return trace.ConvertSystemError(d.root.Close())
 }
 
-func isSubPath(parent, child string) bool {
-	return child == parent || strings.HasPrefix(child, parent+string(filepath.Separator))
+// rootRel converts the externally-supplied relative path into a form os.Root accepts.
+// The RDP-to-TDP conversion in lib/srv/desktop/rdp/rdpclient/src/rdpdr/path.rs maps "\" to "".
+// os.Root rejects empty paths, so map "" to "." here (path.Clean does this for us).
+func rootRel(relativePath string) string {
+	return path.Clean(relativePath)
 }
 
 // Stat retrieves metadata about a file or directory at the given path.
 func (d *DirectoryAccess) Stat(relativePath string) (*FileOrDirInfo, error) {
-	path, err := d.getSafePath(relativePath)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-
-	stat, err := os.Stat(path)
+	stat, err := d.root.Stat(rootRel(relativePath))
 	if err != nil {
 		return nil, trace.ConvertSystemError(err)
 	}
@@ -127,26 +86,27 @@ func (d *DirectoryAccess) Stat(relativePath string) (*FileOrDirInfo, error) {
 
 // ReadDir lists files and directories within the given directory path, skips symlinks.
 func (d *DirectoryAccess) ReadDir(relativePath string) ([]*FileOrDirInfo, error) {
-	path, err := d.getSafePath(relativePath)
+	dir, err := d.root.Open(rootRel(relativePath))
 	if err != nil {
-		return nil, trace.Wrap(err)
+		return nil, trace.ConvertSystemError(err)
 	}
+	defer dir.Close()
 
-	entries, err := os.ReadDir(path)
+	entries, err := dir.ReadDir(-1)
 	if err != nil {
 		return nil, trace.ConvertSystemError(err)
 	}
 
 	var results []*FileOrDirInfo
 	for _, entry := range entries {
+		// Skip symlinks, we can't present them properly in the remote machine.
+		if entry.Type()&os.ModeSymlink != 0 {
+			continue
+		}
+
 		fileInfo, err := entry.Info()
 		if err != nil {
 			return nil, trace.ConvertSystemError(err)
-		}
-
-		// Skip symlinks, we can't present them properly in the remote machine.
-		if fileInfo.Mode().Type()&os.ModeSymlink != 0 {
-			continue
 		}
 
 		entryRelativePath := filepath.Join(relativePath, fileInfo.Name())
@@ -163,12 +123,7 @@ func (d *DirectoryAccess) ReadDir(relativePath string) ([]*FileOrDirInfo, error)
 
 // Read reads a slice of a file into buf. Returns the number of read bytes.
 func (d *DirectoryAccess) Read(relativePath string, offset int64, buf []byte) (n int, err error) {
-	path, err := d.getSafePath(relativePath)
-	if err != nil {
-		return 0, trace.Wrap(err)
-	}
-
-	file, err := os.Open(path)
+	file, err := d.root.Open(rootRel(relativePath))
 	if err != nil {
 		return 0, trace.ConvertSystemError(err)
 	}
@@ -194,12 +149,7 @@ func (d *DirectoryAccess) Read(relativePath string, offset int64, buf []byte) (n
 
 // Write writes data to a file at a given offset.
 func (d *DirectoryAccess) Write(relativePath string, offset int64, data []byte) (n int, err error) {
-	path, err := d.getSafePath(relativePath)
-	if err != nil {
-		return 0, trace.Wrap(err)
-	}
-
-	file, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE, 0644)
+	file, err := d.root.OpenFile(rootRel(relativePath), os.O_RDWR|os.O_CREATE, 0644)
 	if err != nil {
 		return 0, trace.ConvertSystemError(err)
 	}
@@ -223,33 +173,27 @@ func (d *DirectoryAccess) Write(relativePath string, offset int64, data []byte) 
 
 // Truncate truncates a file to the specified size.
 func (d *DirectoryAccess) Truncate(relativePath string, size int64) error {
-	path, err := d.getSafePath(relativePath)
+	file, err := d.root.OpenFile(rootRel(relativePath), os.O_WRONLY, 0)
 	if err != nil {
-		return trace.Wrap(err)
+		return trace.ConvertSystemError(err)
 	}
+	defer file.Close()
 
-	return trace.ConvertSystemError(os.Truncate(path, size))
+	return trace.ConvertSystemError(file.Truncate(size))
 }
 
 // Create creates a new file or directory at the given path.
 func (d *DirectoryAccess) Create(relativePath string, fileType FileType) error {
-	path, err := d.getSafePath(relativePath)
-	if err != nil {
-		return trace.Wrap(err)
-	}
-
+	path := rootRel(relativePath)
 	switch fileType {
 	case FileTypeFile:
-		file, err := os.Create(path)
+		file, err := d.root.Create(path)
 		if err != nil {
-			if errors.Is(err, fs.ErrExist) {
-				return nil // Ignore if file already exists
-			}
 			return trace.ConvertSystemError(err)
 		}
 		return trace.ConvertSystemError(file.Close())
 	case FileTypeDir:
-		err := os.Mkdir(path, 0700)
+		err := d.root.Mkdir(path, 0700)
 		if errors.Is(err, fs.ErrExist) {
 			return nil // Ignore if directory already exists
 		}
@@ -261,21 +205,11 @@ func (d *DirectoryAccess) Create(relativePath string, fileType FileType) error {
 
 // Delete removes a file or directory at the given path.
 func (d *DirectoryAccess) Delete(relativePath string) error {
-	path, err := d.getSafePath(relativePath)
-	if err != nil {
-		return trace.Wrap(err)
-	}
-
-	err = os.RemoveAll(path)
+	err := d.root.RemoveAll(rootRel(relativePath))
 	return trace.ConvertSystemError(err)
 }
 
 func (d *DirectoryAccess) readFileOrDirInfo(relativePath string, f os.FileInfo) (info *FileOrDirInfo, err error) {
-	path, err := d.getSafePath(relativePath)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-
 	info = &FileOrDirInfo{
 		Size:         f.Size(),
 		LastModified: f.ModTime().UnixMilli(),
@@ -288,7 +222,7 @@ func (d *DirectoryAccess) readFileOrDirInfo(relativePath string, f os.FileInfo) 
 		return info, nil
 	}
 
-	opened, err := os.Open(path)
+	opened, err := d.root.Open(rootRel(relativePath))
 	if err != nil {
 		return nil, trace.ConvertSystemError(err)
 	}

--- a/lib/teleterm/services/desktop/directorysharing_test.go
+++ b/lib/teleterm/services/desktop/directorysharing_test.go
@@ -21,7 +21,6 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/gravitational/trace"
 	"github.com/stretchr/testify/require"
 )
 
@@ -37,7 +36,7 @@ func TestNewDirectoryAccess(t *testing.T) {
 	err := os.WriteFile(filePath, []byte("test"), 0600)
 	require.NoError(t, err)
 	_, err = NewDirectoryAccess(filePath)
-	require.True(t, trace.IsBadParameter(err), "%q is not a directory", filePath)
+	require.ErrorContains(t, err, "not a directory")
 }
 
 func setUpSharedDir(t *testing.T) (*DirectoryAccess, string) {


### PR DESCRIPTION
Backport #67377 to branch/v17

## Manual Test Plan
### Test Environment
Locally built app.

### Test Cases
- [x] Directory sharing operations work.
