### PR TITLE
Add the `tctl auth delete-override` command

### DIFF
--- a/docs/pages/reference/cli/tctl.mdx
+++ b/docs/pages/reference/cli/tctl.mdx
@@ -588,6 +588,24 @@ Flags:
 |`--out`|*no default*|If set, writes exported revocation lists to files with the given path prefix|
 |`--type`|*no default* (one of: `host`, `db`, `db_client`, `user`)|Certificate authority type.|
 
+## tctl auth delete-override
+
+Delete a single certificate override from a CA override resource
+
+Usage:
+
+```code
+$ tctl auth delete-override --type=TYPE --public-key=PUBLIC-KEY [<flags>]
+```
+
+Flags:
+
+|Flag|Default|Description|
+|---|---|---|
+|`--[no-]force`|`false`|If true attempts to force deletion. May be used to delete live overrides.|
+|`--public-key`|*no default*|Public key hash of the certificate override to be targeted|
+|`--type`|*no default*|CA type (db-client, windows)|
+
 ## tctl auth export
 
 Export public cluster CA certificates to stdout.

--- a/tool/tctl/common/subca/subca_command.go
+++ b/tool/tctl/common/subca/subca_command.go
@@ -128,6 +128,7 @@ type Command struct {
 
 	createOverrideCSR createOverrideCSRCommand
 	createOverride    createOverrideCommand
+	deleteOverride    deleteOverrideCommand
 	pubKeyHash        pubKeyHashCommand
 }
 
@@ -186,6 +187,16 @@ func (c *Command) Initialize(
 	c.createOverride.Flag("force", "If true attempts to force creation, ignoring select state validation").
 		BoolVar(&c.createOverride.force)
 
+	c.deleteOverride.CmdClause = parent.Command("delete-override", "Delete a single certificate override from a CA override resource")
+	c.deleteOverride.Flag("type", caTypesHelp).
+		Required().
+		StringVar(&c.deleteOverride.cliCAType)
+	c.deleteOverride.Flag("public-key", "Public key hash of the certificate override to be targeted").
+		Required().
+		StringVar(&c.deleteOverride.publicKey)
+	c.deleteOverride.Flag("force", "If true attempts to force deletion. May be used to delete live overrides.").
+		BoolVar(&c.deleteOverride.force)
+
 	c.pubKeyHash.CmdClause = parent.Command(
 		"pub-key-hash", "Extract and print the public key hash of a PEM certificate")
 	c.pubKeyHash.Flag("cert", "Certificate file in PEM format. Use '-' to read from stdin.").
@@ -205,6 +216,7 @@ func (c *Command) TryRun(
 	for _, cmd := range []subCommand{
 		&c.createOverrideCSR,
 		&c.createOverride,
+		&c.deleteOverride,
 		&c.pubKeyHash,
 	} {
 		if selectedCommand == cmd.FullCommand() {
@@ -488,4 +500,42 @@ func readCertFile(certFile string) (pem []byte, _ *x509.Certificate, _ error) {
 		return nil, nil, trace.Wrap(err, "parse certificate")
 	}
 	return certPEM, cert, nil
+}
+
+type deleteOverrideCommand struct {
+	*kingpin.CmdClause
+
+	cliCAType string
+	publicKey string
+	force     bool
+}
+
+func (c *deleteOverrideCommand) Run(
+	ctx context.Context,
+	clientFunc InitFunc,
+	s *commandState,
+) error {
+	caType := cliCATypes.Convert(c.cliCAType)
+
+	authClient, closeFn, err := clientFunc(ctx)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	defer closeFn(ctx)
+
+	_, err = authClient.SubCAClient().RemoveCertificateOverride(ctx, &subcav1.RemoveCertificateOverrideRequest{
+		CertificateOverrideId: subcav1.CertificateOverrideID_builder{
+			CaType: caType,
+			PublicKeyHash: subcav1.PublicKeyHash_builder{
+				Value: c.publicKey,
+			}.Build(),
+		}.Build(),
+		ForceImmediateDelete: c.force,
+	})
+	if err != nil {
+		return trace.Wrap(err, "delete certificate override")
+	}
+	fmt.Fprintf(s.Stdout, "%s/%s: certificate override %s deleted\n", types.KindCertAuthorityOverride, caType, c.publicKey)
+
+	return nil
 }

--- a/tool/tctl/common/subca/subca_command.go
+++ b/tool/tctl/common/subca/subca_command.go
@@ -523,7 +523,7 @@ func (c *deleteOverrideCommand) Run(
 	}
 	defer closeFn(ctx)
 
-	_, err = authClient.SubCAClient().RemoveCertificateOverride(ctx, &subcav1.RemoveCertificateOverrideRequest{
+	_, err = authClient.SubCAClient().RemoveCertificateOverride(ctx, subcav1.RemoveCertificateOverrideRequest_builder{
 		CertificateOverrideId: subcav1.CertificateOverrideID_builder{
 			CaType: caType,
 			PublicKeyHash: subcav1.PublicKeyHash_builder{
@@ -531,7 +531,7 @@ func (c *deleteOverrideCommand) Run(
 			}.Build(),
 		}.Build(),
 		ForceImmediateDelete: c.force,
-	})
+	}.Build())
 	if err != nil {
 		return trace.Wrap(err, "delete certificate override")
 	}

--- a/tool/tctl/common/subca/subca_command_test.go
+++ b/tool/tctl/common/subca/subca_command_test.go
@@ -408,6 +408,78 @@ func TestCommand_CreateOverride(t *testing.T) {
 	}
 }
 
+func TestCommand_DeleteOverride(t *testing.T) {
+	t.Parallel()
+
+	var certPubKey string
+	{
+		cert, err := tlsutils.ParseCertificatePEM([]byte(overridePEM))
+		require.NoError(t, err)
+		certPubKey = libsubca.HashCertificatePublicKey(cert)
+	}
+
+	coID := subcav1.CertificateOverrideID_builder{
+		CaType: string(types.DatabaseClientCA),
+		PublicKeyHash: subcav1.PublicKeyHash_builder{
+			Value: certPubKey,
+		}.Build(),
+	}.Build()
+
+	tests := []struct {
+		name    string
+		flags   []string // flags after "tctl auth delete-override"
+		wantReq *subcav1.RemoveCertificateOverrideRequest
+	}{
+		{
+			name: "ok",
+			flags: []string{
+				"--type", "db-client",
+				"--public-key", certPubKey,
+			},
+			wantReq: subcav1.RemoveCertificateOverrideRequest_builder{
+				CertificateOverrideId: coID,
+			}.Build(),
+		},
+		{
+			name: "use --force",
+			flags: []string{
+				"--type", "db-client",
+				"--public-key", certPubKey,
+				"--force",
+			},
+			wantReq: subcav1.RemoveCertificateOverrideRequest_builder{
+				CertificateOverrideId: coID,
+				ForceImmediateDelete:  true,
+			}.Build(),
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			fakeClient := &fakeAuthClient{}
+			clientFunc := func(ctx context.Context) (_ subca.SubCAClientSource, closeFn func(context.Context), _ error) {
+				return fakeClient, func(ctx context.Context) {}, nil
+			}
+
+			env := newCommand(t)
+
+			flags := append([]string{"auth", "delete-override"}, test.flags...)
+			selectedCommand, err := env.App.Parse(flags)
+			require.NoError(t, err, "app.Parse()")
+
+			match, err := env.Cmd.TryRun(t.Context(), selectedCommand, clientFunc)
+			assert.True(t, match)
+			require.NoError(t, err, "Command errored")
+
+			// Verify server request.
+			if diff := cmp.Diff(test.wantReq, fakeClient.lastRemoveCertificateRequest, protocmp.Transform()); diff != "" {
+				t.Errorf("RemoveCertificateOverrideRequest mismatch (-want +got)\n%s", diff)
+			}
+		})
+	}
+}
+
 // CSR PEMs for testing.
 // The simplest way to get these is to run the "tctl auth create-override-csr"
 // command.
@@ -518,9 +590,10 @@ gT/2q6LYL8NGcL6ParNRimdwhm+0+xOe
 type fakeAuthClient struct {
 	subcav1.SubCAServiceClient
 
-	csrPEMs                   []string
-	lastCSRRequest            *subcav1.CreateCSRRequest
-	lastAddCertificateRequest *subcav1.AddCertificateOverrideRequest
+	csrPEMs                      []string
+	lastCSRRequest               *subcav1.CreateCSRRequest
+	lastAddCertificateRequest    *subcav1.AddCertificateOverrideRequest
+	lastRemoveCertificateRequest *subcav1.RemoveCertificateOverrideRequest
 }
 
 func (f *fakeAuthClient) SubCAClient() subcav1.SubCAServiceClient {
@@ -553,6 +626,15 @@ func (f *fakeAuthClient) AddCertificateOverride(
 ) (*subcav1.AddCertificateOverrideResponse, error) {
 	f.lastAddCertificateRequest = req
 	return &subcav1.AddCertificateOverrideResponse{}, nil
+}
+
+func (f *fakeAuthClient) RemoveCertificateOverride(
+	ctx context.Context,
+	req *subcav1.RemoveCertificateOverrideRequest,
+	opts ...grpc.CallOption,
+) (*subcav1.RemoveCertificateOverrideResponse, error) {
+	f.lastRemoveCertificateRequest = req
+	return &subcav1.RemoveCertificateOverrideResponse{}, nil
 }
 
 func TestCommand_PubKeyHash(t *testing.T) {


### PR DESCRIPTION
Add the [`tctl auth delete-override`][1] command.

[1]: https://github.com/gravitational/teleport/blob/master/rfd/0237-sub-ca-support.md#alice-deletes-the-db_client-override

Changelog: Added the Sub CA `tctl auth delete-override` command, a user-friendly alternative over `tctl edit ca_overrides` or `tctl rm ca_overrides`

https://github.com/gravitational/teleport.e/issues/7675

## Manual Test Plan
### Test Environment

Local environment built with https://github.com/gravitational/teleport.e/pull/8951.

### Test Cases
- [x] `tctl auth delete-override --type=db-client --public-key=ABCDE...` ("vanilla" invocation)
- [x] `tctl auth delete-override --force ...` (deletes enabled override)
