### PR TITLE
[v18] Connect: Fix progress reporting for empty file uploads

### DIFF
--- a/lib/teleterm/clusters/cluster_file_transfer.go
+++ b/lib/teleterm/clusters/cluster_file_transfer.go
@@ -122,7 +122,7 @@ func (p *fileTransferProgress) maybeUpdateProgress(bytes []byte) (int, error) {
 	defer p.lock.Unlock()
 
 	p.sentSize += int64(bytesLength)
-	percentage := uint32(p.sentSize * 100 / p.fileSize)
+	percentage := calculatePercentage(p.sentSize, p.fileSize)
 
 	if p.shouldSendProgress(percentage) {
 		err := p.sendProgress(&api.FileTransferProgress{Percentage: percentage})
@@ -134,6 +134,13 @@ func (p *fileTransferProgress) maybeUpdateProgress(bytes []byte) (int, error) {
 	}
 
 	return bytesLength, nil
+}
+
+func calculatePercentage(part, total int64) uint32 {
+	if total <= 0 {
+		return 100
+	}
+	return uint32(part * 100 / total)
 }
 
 func (p *fileTransferProgress) shouldSendProgress(percentage uint32) bool {

--- a/web/packages/teleport/src/Console/DocumentSsh/Terminal/Terminal.tsx
+++ b/web/packages/teleport/src/Console/DocumentSsh/Terminal/Terminal.tsx
@@ -153,7 +153,8 @@ const TerminalAddonsContainer = styled.div`
   flex-direction: column;
   align-items: flex-end;
   gap: 8px;
-  min-width: 500px;
+  width: 100%;
+  max-width: 500px;
 `;
 
 export interface TerminalRef {

--- a/web/packages/teleport/src/SessionRecordings/view/Xterm/Xterm.tsx
+++ b/web/packages/teleport/src/SessionRecordings/view/Xterm/Xterm.tsx
@@ -143,5 +143,6 @@ const TerminalAddonsContainer = styled.div`
   flex-direction: column;
   align-items: flex-end;
   gap: ${p => p.theme.space[2]}px;
-  min-width: 500px;
+  width: 100%;
+  max-width: 500px;
 `;

--- a/web/packages/teleterm/src/ui/DocumentTerminal/Terminal/Terminal.tsx
+++ b/web/packages/teleterm/src/ui/DocumentTerminal/Terminal/Terminal.tsx
@@ -167,7 +167,8 @@ const TerminalAddonsContainer = styled.div`
   flex-direction: column;
   align-items: flex-end;
   gap: 8px;
-  min-width: 500px;
+  width: 100%;
+  max-width: 500px;
 `;
 
 const StyledXterm = styled(Box)`


### PR DESCRIPTION
Backport #67885 to branch/v18

changelog: Fixed Teleport Connect file uploads for empty files

## Manual Test Plan
### Test Environment
Locally built app.

### Test Cases
- [x] Uploading zero-length files don't cause handler panic.
- [x] The file transfer container doesn't exceeds expected width in Connect.
- [x] Terminal search and file transfer look the same as before in the Web UI.