### PR TITLE
reversetunnel: fix smoothed round trip time test flakiness

### DIFF
--- a/lib/reversetunnel/agent.go
+++ b/lib/reversetunnel/agent.go
@@ -661,7 +661,6 @@ func (a *agent) sendKeepalives() error {
 		const wantReplyTrue = true
 		now := a.clock.Now()
 		_, _, err := a.client.SendRequest(a.ctx, teleport.KeepAliveReqType, wantReplyTrue, nil)
-		ticker.Reset(retryutils.SeventhJitter(a.keepAlive))
 		if err != nil {
 			if !utils.IsOKNetworkError(err) {
 				a.logger.WarnContext(
@@ -686,6 +685,7 @@ func (a *agent) sendKeepalives() error {
 		a.logger.DebugContext(a.ctx, "Computed new SRTT", "srtt", a.smoothedRTT.String())
 		a.mu.Unlock()
 
+		ticker.Reset(retryutils.SeventhJitter(a.keepAlive))
 		if !first {
 			continue
 		}

--- a/lib/reversetunnel/agent.go
+++ b/lib/reversetunnel/agent.go
@@ -748,10 +748,11 @@ func (a *agent) handleDiscovery(ch ssh.Channel, reqC <-chan *ssh.Request) {
 // round trip time and a new round trip time measurement. The new measurement
 // has a weight of 1/8 to avoid overreacting to temporary network jitter.
 func calculateSmoothedRTT(srtt time.Duration, rtt time.Duration) time.Duration {
-	if srtt == 0 {
-		return rtt
-	}
-	return (7*srtt + rtt) / 8
+	const (
+		newRttWeight    = 1
+		smoothingFactor = 8
+	)
+	return ((smoothingFactor-newRttWeight)*srtt + newRttWeight*rtt) / smoothingFactor
 }
 
 const (

--- a/lib/reversetunnel/agent.go
+++ b/lib/reversetunnel/agent.go
@@ -748,6 +748,9 @@ func (a *agent) handleDiscovery(ch ssh.Channel, reqC <-chan *ssh.Request) {
 // round trip time and a new round trip time measurement. The new measurement
 // has a weight of 1/8 to avoid overreacting to temporary network jitter.
 func calculateSmoothedRTT(srtt time.Duration, rtt time.Duration) time.Duration {
+	if srtt == 0 {
+		return rtt
+	}
 	const (
 		newRttWeight    = 1
 		smoothingFactor = 8

--- a/lib/reversetunnel/agent.go
+++ b/lib/reversetunnel/agent.go
@@ -744,6 +744,9 @@ func (a *agent) handleDiscovery(ch ssh.Channel, reqC <-chan *ssh.Request) {
 	}
 }
 
+// calculateSmoothedRTT computes a weighted average of the previous smoothed
+// round trip time and a new round trip time measurement. The new measurement
+// has a weight of 1/8 to avoid overreacting to temporary network jitter.
 func calculateSmoothedRTT(srtt time.Duration, rtt time.Duration) time.Duration {
 	if srtt == 0 {
 		return rtt

--- a/lib/reversetunnel/agent.go
+++ b/lib/reversetunnel/agent.go
@@ -661,6 +661,7 @@ func (a *agent) sendKeepalives() error {
 		const wantReplyTrue = true
 		now := a.clock.Now()
 		_, _, err := a.client.SendRequest(a.ctx, teleport.KeepAliveReqType, wantReplyTrue, nil)
+		ticker.Reset(retryutils.SeventhJitter(a.keepAlive))
 		if err != nil {
 			if !utils.IsOKNetworkError(err) {
 				a.logger.WarnContext(
@@ -676,16 +677,10 @@ func (a *agent) sendKeepalives() error {
 		}
 
 		a.mu.Lock()
-		rtt := a.clock.Since(now)
-		if a.smoothedRTT == 0 {
-			a.smoothedRTT = rtt
-		} else {
-			a.smoothedRTT = (7*a.smoothedRTT + rtt) / 8
-		}
+		a.smoothedRTT = calculateSmoothedRTT(a.smoothedRTT, a.clock.Since(now))
 		a.logger.DebugContext(a.ctx, "Computed new SRTT", "srtt", a.smoothedRTT.String())
 		a.mu.Unlock()
 
-		ticker.Reset(retryutils.SeventhJitter(a.keepAlive))
 		if !first {
 			continue
 		}
@@ -747,6 +742,13 @@ func (a *agent) handleDiscovery(ch ssh.Channel, reqC <-chan *ssh.Request) {
 			a.tracker.TrackExpected(r.TrackProxies()...)
 		}
 	}
+}
+
+func calculateSmoothedRTT(srtt time.Duration, rtt time.Duration) time.Duration {
+	if srtt == 0 {
+		return rtt
+	}
+	return (7*srtt + rtt) / 8
 }
 
 const (

--- a/lib/reversetunnel/agent_test.go
+++ b/lib/reversetunnel/agent_test.go
@@ -403,7 +403,6 @@ func TestAgentSmoothedRTT(t *testing.T) {
 			clock.Advance(100 * time.Millisecond)
 		default:
 			return false, nil, trace.Errorf("err")
-
 		}
 		return true, nil, nil
 	}

--- a/lib/reversetunnel/agent_test.go
+++ b/lib/reversetunnel/agent_test.go
@@ -381,7 +381,7 @@ func TestAgentStart(t *testing.T) {
 func TestAgentSmoothedRTT(t *testing.T) {
 	agent, client := testAgent(t, agentConfig{
 		staleConnTimeoutDisabled: true,
-		keepAlive:                1 * time.Nanosecond,
+		keepAlive:                5 * time.Millisecond,
 	})
 
 	ctx, cancel := context.WithCancel(t.Context())

--- a/lib/reversetunnel/agent_test.go
+++ b/lib/reversetunnel/agent_test.go
@@ -29,7 +29,6 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/gravitational/trace"
-	"github.com/jonboulle/clockwork"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/crypto/ssh"
@@ -380,11 +379,9 @@ func TestAgentStart(t *testing.T) {
 }
 
 func TestAgentSmoothedRTT(t *testing.T) {
-	clock := clockwork.NewFakeClock()
 	agent, client := testAgent(t, agentConfig{
 		staleConnTimeoutDisabled: true,
-		keepAlive:                time.Minute,
-		clock:                    clock,
+		keepAlive:                1 * time.Nanosecond,
 	})
 
 	ctx, cancel := context.WithCancel(t.Context())
@@ -396,27 +393,20 @@ func TestAgentSmoothedRTT(t *testing.T) {
 
 	count := &atomic.Int32{}
 	client.MockSendRequest = func(ctx context.Context, name string, wantReply bool, payload []byte) (bool, []byte, error) {
-		switch count.Add(1) {
-		case 1:
-			clock.Advance(20 * time.Millisecond)
-		case 2:
-			clock.Advance(100 * time.Millisecond)
-		default:
+		if count.Add(1) > 2 {
 			return false, nil, trace.Errorf("err")
 		}
 		return true, nil, nil
 	}
 
-	go agent.sendKeepalives()
-
-	require.NoError(t, clock.BlockUntilContext(ctx, 1))
-	clock.Advance(time.Minute)
-	require.NoError(t, clock.BlockUntilContext(ctx, 1))
+	err := agent.sendKeepalives()
+	require.Error(t, err)
 
 	rtt, ok := agent.RTT()
 	require.True(t, ok)
-	require.Equal(t, 2, int(count.Load()))
-	assert.Equal(t, 30*time.Millisecond, rtt)
+	if rtt <= time.Duration(0) {
+		t.Fatalf("expected smoothed RTT to be greater than zero: %s", rtt)
+	}
 }
 
 func TestAgentStateTransitions(t *testing.T) {
@@ -675,4 +665,31 @@ func TestAgentTimeout(t *testing.T) {
 		})
 	}
 
+}
+
+func TestCalculateSmoothedRTT(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		rtts []time.Duration
+		srtt time.Duration
+	}{
+		{
+			name: "single measurement equals srtt",
+			rtts: []time.Duration{time.Second},
+			srtt: time.Second,
+		},
+		{
+			name: "multiple measurements are smoothed",
+			rtts: []time.Duration{time.Second, 2 * time.Second},
+			srtt: 1125 * time.Millisecond,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var srtt time.Duration
+			for _, rtt := range tc.rtts {
+				srtt = calculateSmoothedRTT(srtt, rtt)
+			}
+			require.Equal(t, tc.srtt, srtt)
+		})
+	}
 }


### PR DESCRIPTION
In order to ensure we don't advance the clock until after the srtt measurement is taken we must not reset the timer until after the measurement is taken.

This ensures BlockUntilContext does not return until after the measurement is taken.

Fixes https://github.com/gravitational/teleport/issues/67916


## Manual Test Plan
### Test Environment
Local

### Test Cases
- [x] `go test ./lib/reversetunnel -run ^TestAgentSmoothedRTT$ -race  -count=100000`
- [x] Run agent with debug logging and observe smoothed round trip is calculated and logged as expected

