### PR TITLE
RFD 229C: `tctl` support for scoped Workload Identities (4/5)

### DIFF
--- a/docs/pages/reference/cli/tctl.mdx
+++ b/docs/pages/reference/cli/tctl.mdx
@@ -3008,7 +3008,7 @@ Arguments:
 
 |Argument|Default|Description|
 |---|---|---|
-|name|*no default* (required)|Name of the workload identity configuration to delete.|
+|name|*no default* (required)|Name of the workload identity configuration to delete. For a scoped workload identity, provide a scope-qualified name of the form '\<scope\>::\<name\>'.|
 
 ## tctl workload-identity x509-issuer-overrides create
 

--- a/tool/tctl/common/helpers_test.go
+++ b/tool/tctl/common/helpers_test.go
@@ -84,7 +84,7 @@ func runCommand(t require.TestingT, client *authclient.Client, cmd cliCommand, a
 	return err
 }
 
-func runResourceCommand(t *testing.T, client *authclient.Client, args []string) (*bytes.Buffer, error) {
+func runResourceCommand(t require.TestingT, client *authclient.Client, args []string) (*bytes.Buffer, error) {
 	var stdoutBuff bytes.Buffer
 	command := &ResourceCommand{
 		Stdout: &stdoutBuff,

--- a/tool/tctl/common/resource_command_test.go
+++ b/tool/tctl/common/resource_command_test.go
@@ -1039,7 +1039,7 @@ func TestScopedAndUnscopedWorkloadIdentityResource(t *testing.T) {
 			},
 		},
 	}
-	auth := makeAndRunTestAuthServer(t, withFileConfig(fileConfig), withFileDescriptors(dynAddr.Descriptors))
+	auth := makeAndRunTestAuthServer(t, withFileConfig(fileConfig), withFileDescriptors(dynAddr.Descriptors), withScopesFeatures(scopes.Features{Enabled: true}))
 	clt, err := testenv.NewDefaultAuthClient(auth)
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = clt.Close() })
@@ -1073,19 +1073,13 @@ func TestScopedAndUnscopedWorkloadIdentityResource(t *testing.T) {
 	}.Build())
 	require.NoError(t, err)
 
-	// Poll until both workload identities appear via the list (cache propagation).
-	timeout := time.After(30 * time.Second)
-	for {
+	// Wait until both workload identities appear via the list (cache propagation).
+	require.EventuallyWithT(t, func(t *assert.CollectT) {
 		buf, err := runResourceCommand(t, clt, []string{"get", types.KindWorkloadIdentity, "--format=json"})
-		if err == nil && strings.Contains(buf.String(), "classic-wi") && strings.Contains(buf.String(), "staging-wi") {
-			break
-		}
-		select {
-		case <-timeout:
-			require.FailNow(t, "timed out waiting for workload identities to appear in list")
-		case <-time.After(100 * time.Millisecond):
-		}
-	}
+		require.NoError(t, err)
+		require.Contains(t, buf.String(), "classic-wi")
+		require.Contains(t, buf.String(), "staging-wi")
+	}, 30*time.Second, 100*time.Millisecond)
 
 	t.Run("list all shows scope-qualified name for scoped identities", func(t *testing.T) {
 		buf, err := runResourceCommand(t, clt, []string{"get", types.KindWorkloadIdentity, "--format=text"})
@@ -1124,19 +1118,10 @@ func TestScopedAndUnscopedWorkloadIdentityResource(t *testing.T) {
 		_, err := runResourceCommand(t, clt, []string{"rm", types.KindWorkloadIdentity, "/staging::staging-wi"})
 		require.NoError(t, err)
 
-		timeout := time.After(30 * time.Second)
-		for {
+		require.EventuallyWithT(t, func(t *assert.CollectT) {
 			_, err := runResourceCommand(t, clt, []string{"get", types.KindWorkloadIdentity, "/staging::staging-wi", "--format=json"})
-			if trace.IsNotFound(err) {
-				break
-			}
-			require.NoError(t, err, "unexpected error waiting for staging-wi deletion")
-			select {
-			case <-timeout:
-				require.FailNow(t, "timed out waiting for staging-wi to be deleted")
-			case <-time.After(100 * time.Millisecond):
-			}
-		}
+			require.True(t, trace.IsNotFound(err), "expected NotFound waiting for staging-wi deletion, got: %v", err)
+		}, 30*time.Second, 100*time.Millisecond)
 	})
 
 	t.Run("unscoped delete", func(t *testing.T) {

--- a/tool/tctl/common/resource_command_test.go
+++ b/tool/tctl/common/resource_command_test.go
@@ -47,6 +47,7 @@ import (
 	scopedaccessv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/access/v1"
 	joiningv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/joining/v1"
 	userprovisioningpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/userprovisioning/v2"
+	workloadidentityv1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/workloadidentity/v1"
 	"github.com/gravitational/teleport/api/types"
 	apicommon "github.com/gravitational/teleport/api/types/common"
 	"github.com/gravitational/teleport/api/types/discoveryconfig"
@@ -1013,6 +1014,134 @@ func TestScopedAndUnscopedNodeResource(t *testing.T) {
 			case <-time.After(100 * time.Millisecond):
 			}
 		}
+	})
+}
+
+// TestScopedAndUnscopedWorkloadIdentityResource exercises tctl get/rm on workload
+// identities, which are double-registered as both a scoped and unscoped resource
+// handler to support a mix of scope-qualified and classic interactions.
+func TestScopedAndUnscopedWorkloadIdentityResource(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	dynAddr := helpers.NewDynamicServiceAddr(t)
+	fileConfig := &config.FileConfig{
+		Global: config.Global{DataDir: t.TempDir()},
+		Proxy: config.Proxy{
+			Service: config.Service{EnabledFlag: "true"},
+			WebAddr: dynAddr.WebAddr,
+			TunAddr: dynAddr.TunnelAddr,
+		},
+		Auth: config.Auth{
+			Service: config.Service{
+				EnabledFlag:   "true",
+				ListenAddress: dynAddr.AuthAddr,
+			},
+		},
+	}
+	auth := makeAndRunTestAuthServer(t, withFileConfig(fileConfig), withFileDescriptors(dynAddr.Descriptors))
+	clt, err := testenv.NewDefaultAuthClient(auth)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = clt.Close() })
+
+	wiClient := clt.WorkloadIdentityResourceServiceClient()
+
+	// unscopedWI has no scope (classic behavior).
+	_, err = wiClient.UpsertWorkloadIdentity(ctx, workloadidentityv1pb.UpsertWorkloadIdentityRequest_builder{
+		WorkloadIdentity: workloadidentityv1pb.WorkloadIdentity_builder{
+			Kind:     types.KindWorkloadIdentity,
+			Version:  types.V1,
+			Metadata: headerv1.Metadata_builder{Name: "classic-wi"}.Build(),
+			Spec: workloadidentityv1pb.WorkloadIdentitySpec_builder{
+				Spiffe: workloadidentityv1pb.WorkloadIdentitySPIFFE_builder{Id: "/unscoped"}.Build(),
+			}.Build(),
+		}.Build(),
+	}.Build())
+	require.NoError(t, err)
+
+	// scopedWI lives in scope "/staging" so SQN lookups with "/staging::staging-wi" succeed.
+	_, err = wiClient.UpsertWorkloadIdentity(ctx, workloadidentityv1pb.UpsertWorkloadIdentityRequest_builder{
+		WorkloadIdentity: workloadidentityv1pb.WorkloadIdentity_builder{
+			Kind:     types.KindWorkloadIdentity,
+			Version:  types.V1,
+			Metadata: headerv1.Metadata_builder{Name: "staging-wi"}.Build(),
+			Scope:    "/staging",
+			Spec: workloadidentityv1pb.WorkloadIdentitySpec_builder{
+				Spiffe: workloadidentityv1pb.WorkloadIdentitySPIFFE_builder{Id: "/staging/_/svc"}.Build(),
+			}.Build(),
+		}.Build(),
+	}.Build())
+	require.NoError(t, err)
+
+	// Poll until both workload identities appear via the list (cache propagation).
+	timeout := time.After(30 * time.Second)
+	for {
+		buf, err := runResourceCommand(t, clt, []string{"get", types.KindWorkloadIdentity, "--format=json"})
+		if err == nil && strings.Contains(buf.String(), "classic-wi") && strings.Contains(buf.String(), "staging-wi") {
+			break
+		}
+		select {
+		case <-timeout:
+			require.FailNow(t, "timed out waiting for workload identities to appear in list")
+		case <-time.After(100 * time.Millisecond):
+		}
+	}
+
+	t.Run("list all shows scope-qualified name for scoped identities", func(t *testing.T) {
+		buf, err := runResourceCommand(t, clt, []string{"get", types.KindWorkloadIdentity, "--format=text"})
+		require.NoError(t, err)
+		out := buf.String()
+		// Scoped identities are shown as a scope-qualified name; unscoped ones
+		// keep their bare name.
+		require.Contains(t, out, "/staging::staging-wi")
+		require.Contains(t, out, "classic-wi")
+	})
+
+	t.Run("single-arg unscoped get", func(t *testing.T) {
+		buf, err := runResourceCommand(t, clt, []string{"get", "workload_identity/classic-wi", "--format=json"})
+		require.NoError(t, err)
+		require.Contains(t, buf.String(), "classic-wi")
+	})
+
+	t.Run("two-arg unscoped get", func(t *testing.T) {
+		buf, err := runResourceCommand(t, clt, []string{"get", types.KindWorkloadIdentity, "classic-wi", "--format=json"})
+		require.NoError(t, err)
+		require.Contains(t, buf.String(), "classic-wi")
+	})
+
+	t.Run("scope-qualified get", func(t *testing.T) {
+		buf, err := runResourceCommand(t, clt, []string{"get", types.KindWorkloadIdentity, "/staging::staging-wi", "--format=json"})
+		require.NoError(t, err)
+		require.Contains(t, buf.String(), "staging-wi")
+	})
+
+	t.Run("scope-qualified get with scope mismatch", func(t *testing.T) {
+		_, err := runResourceCommand(t, clt, []string{"get", types.KindWorkloadIdentity, "/prod::staging-wi", "--format=json"})
+		require.True(t, trace.IsNotFound(err), "expected NotFound on scope mismatch, got: %v", err)
+	})
+
+	t.Run("scope-qualified delete", func(t *testing.T) {
+		_, err := runResourceCommand(t, clt, []string{"rm", types.KindWorkloadIdentity, "/staging::staging-wi"})
+		require.NoError(t, err)
+
+		timeout := time.After(30 * time.Second)
+		for {
+			_, err := runResourceCommand(t, clt, []string{"get", types.KindWorkloadIdentity, "/staging::staging-wi", "--format=json"})
+			if trace.IsNotFound(err) {
+				break
+			}
+			require.NoError(t, err, "unexpected error waiting for staging-wi deletion")
+			select {
+			case <-timeout:
+				require.FailNow(t, "timed out waiting for staging-wi to be deleted")
+			case <-time.After(100 * time.Millisecond):
+			}
+		}
+	})
+
+	t.Run("unscoped delete", func(t *testing.T) {
+		_, err := runResourceCommand(t, clt, []string{"rm", "workload_identity/classic-wi"})
+		require.NoError(t, err)
 	})
 }
 

--- a/tool/tctl/common/resources/scoped_handler.go
+++ b/tool/tctl/common/resources/scoped_handler.go
@@ -35,6 +35,7 @@ import (
 func ScopedHandlers() map[string]ScopedHandler {
 	return map[string]ScopedHandler{
 		types.KindNode:                        serverScopedHandler(),
+		types.KindWorkloadIdentity:            workloadIdentityScopedHandler(),
 		scopedaccess.KindScopedRole:           scopedRoleScopedHandler(),
 		types.KindScopedToken:                 scopedTokenScopedHandler(),
 		scopedaccess.KindScopedRoleAssignment: scopedRoleAssignmentScopedHandler(),

--- a/tool/tctl/common/resources/workload_identity.go
+++ b/tool/tctl/common/resources/workload_identity.go
@@ -29,6 +29,7 @@ import (
 	"github.com/gravitational/teleport/lib/asciitable"
 	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/itertools/stream"
+	"github.com/gravitational/teleport/lib/scopes"
 	"github.com/gravitational/teleport/lib/services"
 )
 
@@ -49,8 +50,14 @@ func (c *workloadIdentityCollection) WriteText(w io.Writer, verbose bool) error 
 
 	var rows [][]string
 	for _, item := range c.items {
+		// Scoped workload identities are identified by their scope-qualified
+		// name; unscoped ones by their bare name.
+		name := item.GetMetadata().GetName()
+		if scope := item.GetScope(); scope != "" {
+			name = scopes.QualifiedName{Scope: scope, Name: name}.String()
+		}
 		rows = append(rows, []string{
-			item.GetMetadata().GetName(),
+			name,
 			item.GetSpec().GetSpiffe().GetId(),
 		})
 	}
@@ -105,6 +112,73 @@ func getWorkloadIdentity(
 	}
 
 	return &workloadIdentityCollection{items: resources}, nil
+}
+
+// workloadIdentityScopedHandler returns a [ScopedHandler] for workload identities
+// that are registered with a scope. Workload identities support both classic
+// (unscoped) and scope-qualified access, so this is registered alongside the
+// classic handler in ScopedHandlers().
+func workloadIdentityScopedHandler() ScopedHandler {
+	return ScopedHandler{
+		getHandler:    getWorkloadIdentityScoped,
+		deleteHandler: deleteWorkloadIdentityScoped,
+		description:   "Configures the issuance of SPIFFE SVIDs to workloads.",
+	}
+}
+
+func getWorkloadIdentityScoped(
+	ctx context.Context,
+	client *authclient.Client,
+	subKind string,
+	sqn *scopes.QualifiedName,
+	opts GetOpts,
+) (Collection, error) {
+	if subKind != "" {
+		return nil, rejectSubKind(types.KindWorkloadIdentity, subKind)
+	}
+	if sqn == nil {
+		// No SQN was provided, so this is a list-all. The classic handler
+		// normally serves list-all (workload_identity is registered in both
+		// maps), but fall back to it here for safety.
+		return getWorkloadIdentity(ctx, client, services.Ref{Kind: types.KindWorkloadIdentity}, opts)
+	}
+
+	// The scope travels in the request: the server matches it against the stored
+	// resource's scope and returns a not-found error when they differ, so no
+	// client-side scope comparison is needed.
+	c := client.WorkloadIdentityResourceServiceClient()
+	resource, err := c.GetWorkloadIdentity(ctx, workloadidentityv1pb.GetWorkloadIdentityRequest_builder{
+		Name:  sqn.Name,
+		Scope: sqn.Scope,
+	}.Build())
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return &workloadIdentityCollection{items: []*workloadidentityv1pb.WorkloadIdentity{resource}}, nil
+}
+
+func deleteWorkloadIdentityScoped(
+	ctx context.Context,
+	client *authclient.Client,
+	subKind string,
+	sqn scopes.QualifiedName,
+) error {
+	if subKind != "" {
+		return rejectSubKind(types.KindWorkloadIdentity, subKind)
+	}
+
+	// The caller declares the scope it is addressing; the server authorizes
+	// against it directly.
+	c := client.WorkloadIdentityResourceServiceClient()
+	_, err := c.DeleteWorkloadIdentity(ctx, workloadidentityv1pb.DeleteWorkloadIdentityRequest_builder{
+		Name:  sqn.Name,
+		Scope: sqn.Scope,
+	}.Build())
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	fmt.Printf("Workload Identity %q has been deleted\n", sqn.String())
+	return nil
 }
 
 func createWorkloadIdentity(

--- a/tool/tctl/common/resources/workload_identity.go
+++ b/tool/tctl/common/resources/workload_identity.go
@@ -50,14 +50,8 @@ func (c *workloadIdentityCollection) WriteText(w io.Writer, verbose bool) error 
 
 	var rows [][]string
 	for _, item := range c.items {
-		// Scoped workload identities are identified by their scope-qualified
-		// name; unscoped ones by their bare name.
-		name := item.GetMetadata().GetName()
-		if scope := item.GetScope(); scope != "" {
-			name = scopes.QualifiedName{Scope: scope, Name: name}.String()
-		}
 		rows = append(rows, []string{
-			name,
+			scopes.QualifiedName{Scope: item.GetScope(), Name: item.GetMetadata().GetName()}.String(),
 			item.GetSpec().GetSpiffe().GetId(),
 		})
 	}

--- a/tool/tctl/common/workload_identity_command.go
+++ b/tool/tctl/common/workload_identity_command.go
@@ -40,6 +40,7 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/asciitable"
 	"github.com/gravitational/teleport/lib/auth/authclient"
+	"github.com/gravitational/teleport/lib/scopes"
 	"github.com/gravitational/teleport/lib/service/servicecfg"
 	"github.com/gravitational/teleport/lib/tlsca"
 	"github.com/gravitational/teleport/lib/utils"
@@ -110,7 +111,7 @@ func (c *WorkloadIdentityCommand) Initialize(
 		"Delete a workload identity configuration.",
 	)
 	c.rmCmd.
-		Arg("name", "Name of the workload identity configuration to delete.").
+		Arg("name", "Name of the workload identity configuration to delete. For a scoped workload identity, provide a scope-qualified name of the form '<scope>::<name>'.").
 		Required().
 		StringVar(&c.workloadIdentityName)
 
@@ -251,10 +252,27 @@ func (c *WorkloadIdentityCommand) DeleteWorkloadIdentity(
 	ctx context.Context,
 	client *authclient.Client,
 ) error {
+	// A scope-qualified name ("<scope>::<name>") deletes a scoped workload
+	// identity; a bare name deletes an unscoped one. The scope (if any) travels
+	// in the request and the server authorizes against it directly.
+	name := c.workloadIdentityName
+	var scope string
+	if strings.Contains(name, scopes.QualifiedNameSeparator) {
+		qn, err := scopes.ParseQualifiedName(name)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+		if err := qn.StrongValidate(); err != nil {
+			return trace.Wrap(err)
+		}
+		scope, name = qn.Scope, qn.Name
+	}
+
 	workloadIdentityClient := client.WorkloadIdentityResourceServiceClient()
 	_, err := workloadIdentityClient.DeleteWorkloadIdentity(
 		ctx, workloadidentityv1pb.DeleteWorkloadIdentityRequest_builder{
-			Name: c.workloadIdentityName,
+			Name:  name,
+			Scope: scope,
 		}.Build())
 	if err != nil {
 		return trace.Wrap(err)
@@ -297,10 +315,18 @@ func (c *WorkloadIdentityCommand) ListWorkloadIdentities(
 			fmt.Fprintln(c.stdout, "No workload identities configured")
 			return nil
 		}
+		// TODO(strideynet): Should we just display SQN in Name rather than
+		// splitting name/scope fields?
 		t := asciitable.MakeTable([]string{"Name", "SPIFFE ID"})
 		for _, u := range workloadIdentities {
+			// Scoped workload identities are identified by their scope-qualified
+			// name; unscoped ones by their bare name.
+			name := u.GetMetadata().GetName()
+			if scope := u.GetScope(); scope != "" {
+				name = scopes.QualifiedName{Scope: scope, Name: name}.String()
+			}
 			t.AddRow([]string{
-				u.GetMetadata().GetName(), u.GetSpec().GetSpiffe().GetId(),
+				name, u.GetSpec().GetSpiffe().GetId(),
 			})
 		}
 		fmt.Fprintln(c.stdout, t.AsBuffer().String())

--- a/tool/tctl/common/workload_identity_command.go
+++ b/tool/tctl/common/workload_identity_command.go
@@ -315,18 +315,11 @@ func (c *WorkloadIdentityCommand) ListWorkloadIdentities(
 			fmt.Fprintln(c.stdout, "No workload identities configured")
 			return nil
 		}
-		// TODO(strideynet): Should we just display SQN in Name rather than
-		// splitting name/scope fields?
 		t := asciitable.MakeTable([]string{"Name", "SPIFFE ID"})
 		for _, u := range workloadIdentities {
-			// Scoped workload identities are identified by their scope-qualified
-			// name; unscoped ones by their bare name.
-			name := u.GetMetadata().GetName()
-			if scope := u.GetScope(); scope != "" {
-				name = scopes.QualifiedName{Scope: scope, Name: name}.String()
-			}
 			t.AddRow([]string{
-				name, u.GetSpec().GetSpiffe().GetId(),
+				scopes.QualifiedName{Scope: u.GetScope(), Name: u.GetMetadata().GetName()}.String(),
+				u.GetSpec().GetSpiffe().GetId(),
 			})
 		}
 		fmt.Fprintln(c.stdout, t.AsBuffer().String())

--- a/tool/tctl/common/workload_identity_command.go
+++ b/tool/tctl/common/workload_identity_command.go
@@ -252,9 +252,7 @@ func (c *WorkloadIdentityCommand) DeleteWorkloadIdentity(
 	ctx context.Context,
 	client *authclient.Client,
 ) error {
-	// A scope-qualified name ("<scope>::<name>") deletes a scoped workload
-	// identity; a bare name deletes an unscoped one. The scope (if any) travels
-	// in the request and the server authorizes against it directly.
+	// Provided name may be unscoped or an SQN
 	name := c.workloadIdentityName
 	var scope string
 	if strings.Contains(name, scopes.QualifiedNameSeparator) {

--- a/tool/tctl/common/workload_identity_test.go
+++ b/tool/tctl/common/workload_identity_test.go
@@ -174,6 +174,61 @@ spec:
 		resources := mustDecodeJSON[[]*workloadidentityv1pb.WorkloadIdentity](t, buf)
 		require.Empty(t, resources)
 	})
+
+	// Scoped workload identities are shown by their scope-qualified name and are
+	// addressable by an SQN for rm. These run after the unscoped lifecycle above
+	// leaves the cluster empty, so the exact-output/golden assertions there stay
+	// valid; they seed their own resources via `tctl create`.
+	createWorkloadIdentity := func(t *testing.T, yamlData string) {
+		yamlPath := filepath.Join(t.TempDir(), "workload_identity.yaml")
+		require.NoError(t, os.WriteFile(yamlPath, []byte(yamlData), 0644))
+		_, err := runResourceCommand(t, rootClient, []string{"create", yamlPath})
+		require.NoError(t, err)
+	}
+
+	t.Run("scoped create", func(t *testing.T) {
+		createWorkloadIdentity(t, `kind: workload_identity
+version: v1
+metadata:
+  name: classic-wi
+spec:
+  spiffe:
+    id: /classic
+`)
+		createWorkloadIdentity(t, `kind: workload_identity
+version: v1
+metadata:
+  name: staging-wi
+scope: /staging
+spec:
+  spiffe:
+    id: /staging/_/svc
+`)
+	})
+
+	t.Run("scoped ls shows scope-qualified name", func(t *testing.T) {
+		buf, err := runWorkloadIdentityCommand(t, rootClient, []string{"workload-identity", "ls"})
+		require.NoError(t, err)
+		out := buf.String()
+		// Scoped identities are shown as a scope-qualified name; unscoped ones
+		// keep their bare name.
+		require.Contains(t, out, "/staging::staging-wi")
+		require.Contains(t, out, "classic-wi")
+	})
+
+	t.Run("scoped rm by scope-qualified name", func(t *testing.T) {
+		_, err := runWorkloadIdentityCommand(t, rootClient, []string{"workload-identity", "rm", "/staging::staging-wi"})
+		require.NoError(t, err)
+
+		buf, err := runWorkloadIdentityCommand(t, rootClient, []string{"workload-identity", "ls"})
+		require.NoError(t, err)
+		require.NotContains(t, buf.String(), "staging-wi")
+	})
+
+	t.Run("rm remaining unscoped by bare name", func(t *testing.T) {
+		_, err := runWorkloadIdentityCommand(t, rootClient, []string{"workload-identity", "rm", "classic-wi"})
+		require.NoError(t, err)
+	})
 }
 
 func TestWorkloadIdentityRevocation(t *testing.T) {

--- a/tool/tctl/common/workload_identity_test.go
+++ b/tool/tctl/common/workload_identity_test.go
@@ -37,6 +37,7 @@ import (
 	workloadidentityv1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/workloadidentity/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/auth/authclient"
+	"github.com/gravitational/teleport/lib/scopes"
 	"github.com/gravitational/teleport/lib/utils/log/logtest"
 	"github.com/gravitational/teleport/lib/utils/testutils/golden"
 	"github.com/gravitational/teleport/tool/teleport/testenv"
@@ -58,7 +59,12 @@ func runWorkloadIdentityCommand(
 func TestWorkloadIdentity(t *testing.T) {
 	t.Parallel()
 
-	process, err := testenv.NewTeleportProcess(t.TempDir(), testenv.WithLogger(logtest.NewLogger()))
+	process, err := testenv.NewTeleportProcess(
+		t.TempDir(),
+		testenv.WithLogger(logtest.NewLogger()),
+		// Scoped workload identity writes are feature-gated.
+		testenv.WithScopesFeatures(scopes.Features{Enabled: true}),
+	)
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		require.NoError(t, process.Close())
@@ -175,10 +181,6 @@ spec:
 		require.Empty(t, resources)
 	})
 
-	// Scoped workload identities are shown by their scope-qualified name and are
-	// addressable by an SQN for rm. These run after the unscoped lifecycle above
-	// leaves the cluster empty, so the exact-output/golden assertions there stay
-	// valid; they seed their own resources via `tctl create`.
 	createWorkloadIdentity := func(t *testing.T, yamlData string) {
 		yamlPath := filepath.Join(t.TempDir(), "workload_identity.yaml")
 		require.NoError(t, os.WriteFile(yamlPath, []byte(yamlData), 0644))


### PR DESCRIPTION
Depends on https://github.com/gravitational/teleport/pull/67917

Updates https://github.com/gravitational/teleport/issues/66349

Smaller PR in the stack that updates `tctl` to handle scoped Workload Identities correctly.

## Manual Test Plan
### Test Environment

Local cluster

### Test Cases

- [x] Stack test plan @ https://github.com/gravitational/teleport/pull/67979
