### PR TITLE
[FIX] Remove skill installation from `tctl investigate` command

### DIFF
--- a/docs/pages/reference/cli/tctl.mdx
+++ b/docs/pages/reference/cli/tctl.mdx
@@ -1360,11 +1360,6 @@ Flags:
 
 Search and explore Identity Security activity logs.
 
-To let an AI agent drive this command, install the matching Agent Skill:
-
-`npx skills add
-https://github.com/gravitational/teleport/tree/master/skills/teleport-investigate`
-
 Usage:
 
 ```code

--- a/tool/tctl/common/accessgraph/investigate_command.go
+++ b/tool/tctl/common/accessgraph/investigate_command.go
@@ -159,9 +159,7 @@ func (a *investigateArgs) luceneToFlagMap() map[string]string {
 
 // initInvestigate registers `tctl investigate` and all its flags.
 func (c *AccessGraphCommand) initInvestigate(app *kingpin.Application) {
-	cmd := app.Command("investigate", "Search and explore Identity Security activity logs.\n\n"+
-		"To let an AI agent drive this command, install the matching Agent Skill:\n\n"+
-		"`npx skills add https://github.com/gravitational/teleport/tree/master/skills/teleport-investigate`")
+	cmd := app.Command("investigate", "Search and explore Identity Security activity logs.")
 
 	cmd.Flag("from", fmt.Sprintf("Include activity at or after this time. (Examples: %s, %s, 24h, 7d; negative durations like -1h are future-relative. Default: 1d)", time.RFC3339, time.DateOnly)).
 		Default("1d").


### PR DESCRIPTION
@boxofrad flagged that the `tctl investigate` skill installation message was bleeding to the top level `tctl help` command and breaking the overall top level help message. This PR removes the help message fully in favour of waiting for a more standard way of managing teleport skills as described in [RFD 0037e](https://github.com/gravitational/teleport.e/blob/master/rfd/0037e-skills.md).

I did look into using `HelpLong` for the command, but it looks like that would require a change to the kingpin templates, so I opted against it. 

## Before 
<img width="869" height="160" alt="Screenshot 2026-06-18 at 10 01 31 AM" src="https://github.com/user-attachments/assets/ff5fa7e0-07ab-4b38-bf01-5bbfa66fd9dd" />

### After
<img width="756" height="124" alt="Screenshot 2026-06-18 at 10 00 44 AM" src="https://github.com/user-attachments/assets/1c6e0b01-b70a-46a0-ba4a-00f2e286ec27" />

## Manual Test Plan
### Test Environment

- Local Dev Build

### Test Cases
- [X] Check that the `tctl help`/`tctl --help` message renders correctly
- [X] Check that the `tctl investigate --help`/`tctl help investigate` renders correctly. 
- [X] Sanity check that `tctl investigate` still works as expected. 