### PR TITLE
mcp: allow large SSE event lines

### DIFF
--- a/lib/utils/mcputils/event.go
+++ b/lib/utils/mcputils/event.go
@@ -17,6 +17,8 @@ import (
 	"iter"
 	"net/http"
 	"strings"
+
+	"github.com/gravitational/teleport"
 )
 
 // An Event is a server-sent event.
@@ -27,6 +29,8 @@ type Event struct {
 	Data  []byte // the "data" field
 	Retry string // the "retry" field
 }
+
+const maxSSEEventLineSize = teleport.MaxHTTPResponseSize
 
 // Empty reports whether the Event is empty.
 func (e Event) Empty() bool {
@@ -60,9 +64,7 @@ func writeEvent(w io.Writer, evt Event) (int, error) {
 // TODO(rfindley): consider a different API here that makes failure modes more
 // apparent.
 func scanEvents(r io.Reader) iter.Seq2[Event, error] {
-	scanner := bufio.NewScanner(r)
-	const maxTokenSize = 1 * 1024 * 1024 // 1 MiB max line size
-	scanner.Buffer(nil, maxTokenSize)
+	reader := bufio.NewReader(r)
 
 	// TODO: investigate proper behavior when events are out of order, or have
 	// non-standard names.
@@ -87,30 +89,42 @@ func scanEvents(r io.Reader) iter.Seq2[Event, error] {
 			evt     Event
 			dataBuf *bytes.Buffer // if non-nil, preceding field was also data
 		)
-		flushData := func() {
+		yieldEvent := func() bool {
 			if dataBuf != nil {
 				evt.Data = dataBuf.Bytes()
 				dataBuf = nil
 			}
+			if evt.Empty() {
+				return true
+			}
+			if !yield(evt, nil) {
+				return false
+			}
+			evt = Event{}
+			return true
 		}
-		for scanner.Scan() {
-			line := scanner.Bytes()
+		for {
+			line, err := readSSEEventLine(reader)
+			if err != nil && !errors.Is(err, io.EOF) {
+				yield(Event{}, fmt.Errorf("error reading event: %w", err))
+				return
+			}
+			line = bytes.TrimRight(line, "\r\n")
+			isEOF := errors.Is(err, io.EOF)
+
 			if len(line) == 0 {
-				flushData()
-				// \n\n is the record delimiter
-				if !evt.Empty() && !yield(evt, nil) {
+				if !yieldEvent() {
 					return
 				}
-				evt = Event{}
+				if isEOF {
+					return
+				}
 				continue
 			}
 			before, after, found := bytes.Cut(line, []byte{':'})
 			if !found {
 				yield(Event{}, fmt.Errorf("malformed line in SSE stream: %q", string(line)))
 				return
-			}
-			if !bytes.Equal(before, dataKey) {
-				flushData()
 			}
 			switch {
 			case bytes.Equal(before, eventKey):
@@ -121,26 +135,33 @@ func scanEvents(r io.Reader) iter.Seq2[Event, error] {
 				evt.Retry = strings.TrimSpace(string(after))
 			case bytes.Equal(before, dataKey):
 				data := bytes.TrimSpace(after)
-				if dataBuf != nil {
-					dataBuf.WriteByte('\n')
+				if dataBuf == nil {
+					dataBuf = new(bytes.Buffer)
 					dataBuf.Write(data)
 				} else {
-					dataBuf = new(bytes.Buffer)
+					dataBuf.WriteByte('\n')
 					dataBuf.Write(data)
 				}
 			}
-		}
-		if err := scanner.Err(); err != nil {
-			if errors.Is(err, bufio.ErrTooLong) {
-				err = fmt.Errorf("event exceeded max line length of %d", maxTokenSize)
-			}
-			if !yield(Event{}, err) {
+
+			if isEOF {
+				yieldEvent()
 				return
 			}
 		}
-		flushData()
-		if !evt.Empty() {
-			yield(evt, nil)
+	}
+}
+
+func readSSEEventLine(reader *bufio.Reader) ([]byte, error) {
+	var line []byte
+	for {
+		fragment, err := reader.ReadSlice('\n')
+		if len(line)+len(fragment) > maxSSEEventLineSize {
+			return nil, bufio.ErrTooLong
+		}
+		line = append(line, fragment...)
+		if !errors.Is(err, bufio.ErrBufferFull) {
+			return line, err
 		}
 	}
 }

--- a/lib/utils/mcputils/event_test.go
+++ b/lib/utils/mcputils/event_test.go
@@ -9,6 +9,9 @@
 package mcputils
 
 import (
+	"bufio"
+	"bytes"
+	"errors"
 	"strings"
 	"testing"
 )
@@ -99,5 +102,47 @@ func TestScanEvents(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestScanEventsLargeDataLine(t *testing.T) {
+	data := bytes.Repeat([]byte("x"), 2*1024*1024)
+	input := "event: message\ndata: " + string(data) + "\n\n"
+
+	var got []Event
+	var err error
+	for e, err2 := range scanEvents(strings.NewReader(input)) {
+		if err2 != nil {
+			err = err2
+			break
+		}
+		got = append(got, e)
+	}
+
+	if err != nil {
+		t.Fatalf("scanEvents() returned unexpected error: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("scanEvents() got %d events, want 1", len(got))
+	}
+	if got[0].Name != "message" {
+		t.Fatalf("event name = %q, want message", got[0].Name)
+	}
+	if !bytes.Equal(got[0].Data, data) {
+		t.Fatalf("event data length = %d, want %d", len(got[0].Data), len(data))
+	}
+}
+
+func TestScanEventsRejectsTooLargeLine(t *testing.T) {
+	input := "data: " + strings.Repeat("x", maxSSEEventLineSize+1)
+
+	var err error
+	for _, err2 := range scanEvents(strings.NewReader(input)) {
+		err = err2
+		break
+	}
+
+	if !errors.Is(err, bufio.ErrTooLong) {
+		t.Fatalf("scanEvents() error = %v, want %v", err, bufio.ErrTooLong)
 	}
 }


### PR DESCRIPTION
## Summary

Teleport's MCP SSE proxy still parses `lib/utils/mcputils` events with `bufio.Scanner`, capped at a 1 MiB token. Large single-line MCP `tools/call` responses can exceed that limit and terminate the stream before the event reaches the client.

## Changes

- Replace the scanner loop in `scanEvents` with a chunked line reader capped at `teleport.MaxHTTPResponseSize` so long SSE `data:` lines are handled without the scanner token cap or unbounded reads.
- Preserve the existing SSE parsing behavior for blank-line event flushing, consecutive `data:` fields, malformed lines, and trailing events without a final blank line.
- Add regressions covering a 2 MiB single-line `data:` event and an over-limit line.

## Verification

```bash
go test ./lib/utils/mcputils
go test ./lib/utils/mcputils ./lib/httplib/sse
git diff --check origin/master...HEAD
```

Fixes #67000.
