### PR TITLE
Change slack oauth call to use formdata instead of url params

### DIFF
--- a/integrations/access/slack/oauth.go
+++ b/integrations/access/slack/oauth.go
@@ -80,10 +80,11 @@ func (a *Authorizer) Exchange(ctx context.Context, authorizationCode string, red
 
 	_, err := a.client.R().
 		SetContext(ctx).
-		SetQueryParam("client_id", a.clientID).
-		SetQueryParam("client_secret", a.clientSecret).
-		SetQueryParam("code", authorizationCode).
-		SetQueryParam("redirect_uri", redirectURI).
+		SetBasicAuth(a.clientID, a.clientSecret).
+		SetFormData(map[string]string{
+			"code":         authorizationCode,
+			"redirect_uri": redirectURI,
+		}).
 		SetResult(&result).
 		Post("oauth.v2.access")
 
@@ -112,10 +113,11 @@ func (a *Authorizer) Refresh(ctx context.Context, refreshToken string) (*storage
 
 	_, err := a.client.R().
 		SetContext(ctx).
-		SetQueryParam("client_id", a.clientID).
-		SetQueryParam("client_secret", a.clientSecret).
-		SetQueryParam("grant_type", "refresh_token").
-		SetQueryParam("refresh_token", refreshToken).
+		SetBasicAuth(a.clientID, a.clientSecret).
+		SetFormData(map[string]string{
+			"grant_type":    "refresh_token",
+			"refresh_token": refreshToken,
+		}).
 		SetResult(&result).
 		Post("oauth.v2.access")
 

--- a/integrations/access/slack/oauth_test.go
+++ b/integrations/access/slack/oauth_test.go
@@ -52,7 +52,7 @@ type testOAuthServer struct {
 }
 
 func (s *testOAuthServer) handler(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
-	if grantType := r.URL.Query().Get("grant_type"); grantType == "refresh_token" {
+	if r.PostFormValue("grant_type") == "refresh_token" {
 		s.refresh(w, r)
 	} else {
 		s.exchange(w, r)
@@ -60,11 +60,12 @@ func (s *testOAuthServer) handler(w http.ResponseWriter, r *http.Request, _ http
 }
 
 func (s *testOAuthServer) exchange(w http.ResponseWriter, r *http.Request) {
-	q := r.URL.Query()
-	require.Equal(s.t, s.clientID, q.Get("client_id"))
-	require.Equal(s.t, s.clientSecret, q.Get("client_secret"))
-	require.Equal(s.t, s.redirectURI, q.Get("redirect_uri"))
-	require.Equal(s.t, s.authorizationCode, q.Get("code"))
+	clientID, clientSecret, ok := r.BasicAuth()
+	require.True(s.t, ok)
+	require.Equal(s.t, s.clientID, clientID)
+	require.Equal(s.t, s.clientSecret, clientSecret)
+	require.Equal(s.t, s.redirectURI, r.PostFormValue("redirect_uri"))
+	require.Equal(s.t, s.authorizationCode, r.PostFormValue("code"))
 
 	w.Header().Add("Content-Type", "application/json")
 	err := json.NewEncoder(w).Encode(s.exchangeResponse)
@@ -72,10 +73,11 @@ func (s *testOAuthServer) exchange(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *testOAuthServer) refresh(w http.ResponseWriter, r *http.Request) {
-	q := r.URL.Query()
-	require.Equal(s.t, s.clientID, q.Get("client_id"))
-	require.Equal(s.t, s.clientSecret, q.Get("client_secret"))
-	require.Equal(s.t, s.refreshToken, q.Get("refresh_token"))
+	clientID, clientSecret, ok := r.BasicAuth()
+	require.True(s.t, ok)
+	require.Equal(s.t, s.clientID, clientID)
+	require.Equal(s.t, s.clientSecret, clientSecret)
+	require.Equal(s.t, s.refreshToken, r.PostFormValue("refresh_token"))
 
 	w.Header().Add("Content-Type", "application/json")
 	err := json.NewEncoder(w).Encode(s.refreshResponse)


### PR DESCRIPTION
Closes https://github.com/gravitational/pressure-washing/issues/299

Migrated from https://github.com/gravitational/teleport-private/pull/2600

Changelog: Fixed cloud-hosted Slack plugin exposing credentials in request URLs

## Manual Test Plan
### Test Environment

Teleport Cloud. Cloud-hosted Slack plugin

### Test Cases
- [x] Cloud-hosted Slack plugin successfully exchanges/refreshes access token; restarts plugin
