### PR TITLE
[v17] Add ConditionalDelete to generic.Service

### DIFF
--- a/lib/services/local/generic/generic.go
+++ b/lib/services/local/generic/generic.go
@@ -428,6 +428,27 @@ func (s *Service[T]) DeleteAllResources(ctx context.Context) error {
 	return trace.Wrap(s.backend.DeleteRange(ctx, startKey, backend.RangeEnd(startKey)))
 }
 
+// ConditionalDeleteResource conditionally deletes the resource based on its
+// revision.
+// Returns a trace.CompareFailedError if the item is not found or the revision
+// is incorrect.
+func (s *Service[T]) ConditionalDeleteResource(ctx context.Context, name, revision string) error {
+	if revision == "" {
+		return trace.BadParameter("revision required")
+	}
+	err := s.backend.ConditionalDelete(ctx, s.resourceKey(name), revision)
+	if trace.IsCompareFailed(err) {
+		// Specialize the message from backend.ErrIncorrectRevision so we mention
+		// the resource name and don't mention --force. Deletes often don't have a
+		// --force flag.
+		return trace.CompareFailed(
+			"%s %q does not exist or revision does not match, it may have been concurrently created|modified|deleted; please work from the latest state",
+			s.resourceKind, name,
+		)
+	}
+	return trace.Wrap(err)
+}
+
 // UpdateAndSwapResource will get the resource from the backend, modify it, and swap the new value into the backend.
 func (s *Service[T]) UpdateAndSwapResource(ctx context.Context, name string, modify func(T) error) (T, error) {
 	var t T

--- a/lib/services/local/generic/generic.go
+++ b/lib/services/local/generic/generic.go
@@ -436,7 +436,8 @@ func (s *Service[T]) ConditionalDeleteResource(ctx context.Context, name, revisi
 	if revision == "" {
 		return trace.BadParameter("revision required")
 	}
-	err := s.backend.ConditionalDelete(ctx, s.resourceKey(name), revision)
+	key := s.MakeKey(backend.NewKey(s.nameKey(name)))
+	err := s.backend.ConditionalDelete(ctx, key, revision)
 	if trace.IsCompareFailed(err) {
 		// Specialize the message from backend.ErrIncorrectRevision so we mention
 		// the resource name and don't mention --force. Deletes often don't have a

--- a/lib/services/local/generic/generic_test.go
+++ b/lib/services/local/generic/generic_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/gravitational/teleport/api/types"
@@ -330,6 +331,105 @@ func TestGenericCRUD(t *testing.T) {
 	count, err = service.CountResources(ctx)
 	require.NoError(t, err)
 	require.Equal(t, uint(0), count)
+}
+
+func TestGenericConditionalDelete(t *testing.T) {
+	t.Parallel()
+
+	memBackend, err := memory.New(memory.Config{})
+	require.NoError(t, err)
+
+	service, err := NewService(&ServiceConfig[*testResource]{
+		Backend:       memBackend,
+		ResourceKind:  "generic resource",
+		PageLimit:     200,
+		BackendPrefix: backend.NewKey("generic_prefix"),
+		UnmarshalFunc: unmarshalResource,
+		MarshalFunc:   marshalResource,
+	})
+	require.NoError(t, err)
+
+	// services methods modify their inputs. Take a defensive copy before calling.
+	cloneResource := func(r *testResource) *testResource {
+		r2 := *r
+		return &r2
+	}
+
+	// Create a couple revisions of a resource.
+	res := newTestResource("myresource")
+	res.Metadata.Expires = nil
+	res.Spec = testResourceSpec{PropA: "1"}
+	rev1, err := service.CreateResource(t.Context(), cloneResource(res))
+	require.NoError(t, err)
+
+	res.SetRevision(rev1.GetRevision())
+	rev2, err := service.ConditionalUpdateResource(t.Context(), cloneResource(res))
+	require.NoError(t, err)
+	// Sanity check.
+	require.NotEqual(t, rev1.GetRevision(), rev2.GetRevision())
+
+	const errNotFoundOrRevision = "does not exist or revision does not match"
+	tests := []struct {
+		desc        string
+		name        string
+		revision    string
+		wantErr     string
+		wantErrType any
+	}{
+		{
+			desc:        "unknown resource",
+			name:        "unknown-resource",
+			revision:    rev2.GetRevision(),
+			wantErr:     errNotFoundOrRevision,
+			wantErrType: new(*trace.CompareFailedError),
+		},
+		{
+			desc:        "unknown revision",
+			name:        rev2.GetName(),
+			revision:    rev1.GetRevision(),
+			wantErr:     errNotFoundOrRevision,
+			wantErrType: new(*trace.CompareFailedError),
+		},
+		{
+			desc:        "empty name", // same as unknown resource
+			revision:    rev2.GetRevision(),
+			wantErr:     errNotFoundOrRevision,
+			wantErrType: new(*trace.CompareFailedError),
+		},
+		{
+			desc:        "empty revision",
+			name:        rev2.GetName(),
+			wantErr:     "revision required",
+			wantErrType: new(*trace.BadParameterError),
+		},
+		{
+			desc:     "ok",
+			name:     rev2.GetName(),
+			revision: rev2.GetRevision(),
+			// success: no error wanted.
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.desc, func(t *testing.T) {
+			t.Parallel()
+
+			err := service.ConditionalDeleteResource(t.Context(), test.name, test.revision)
+			if test.wantErr != "" {
+				assert.ErrorContains(t, err, test.wantErr, "ConditionalDeleteResource error mismatch")
+			}
+			if test.wantErrType != nil {
+				assert.ErrorAs(t, err, test.wantErrType, "ConditionalDeleteResource error type mismatch")
+			}
+			if test.wantErr != "" && test.wantErrType != nil {
+				return // Asserted above.
+			}
+			require.NoError(t, err)
+
+			// Verify effective deletion.
+			_, err = service.GetResource(t.Context(), test.name)
+			assert.ErrorAs(t, err, new(*trace.NotFoundError), "Get error mismatch after ConditionalDelete")
+		})
+	}
 }
 
 func TestGenericListResourcesReturnNextResource(t *testing.T) {

--- a/lib/services/local/generic/generic_wrapper.go
+++ b/lib/services/local/generic/generic_wrapper.go
@@ -117,6 +117,14 @@ func (s ServiceWrapper[T]) DeleteAllResources(ctx context.Context) error {
 	return trace.Wrap(s.service.backend.DeleteRange(ctx, startKey, backend.RangeEnd(startKey)))
 }
 
+// ConditionalDeleteResource conditionally deletes the resource based on its
+// revision.
+// Returns a trace.CompareFailedError if the item is not found or the revision
+// is incorrect.
+func (s *ServiceWrapper[T]) ConditionalDeleteResource(ctx context.Context, name, revision string) error {
+	return trace.Wrap(s.service.ConditionalDeleteResource(ctx, name, revision))
+}
+
 // ListResources returns a paginated list of resources.
 func (s ServiceWrapper[T]) ListResources(ctx context.Context, pageSize int, pageToken string) ([]T, string, error) {
 	adapters, nextToken, err := s.service.ListResources(ctx, pageSize, pageToken)

--- a/lib/services/local/generic/generic_wrapper_test.go
+++ b/lib/services/local/generic/generic_wrapper_test.go
@@ -25,7 +25,9 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
@@ -233,6 +235,63 @@ func TestGenericWrapperCRUD(t *testing.T) {
 	// Try to delete a resource that doesn't exist.
 	err = service.DeleteResource(ctx, "doesnotexist")
 	require.True(t, trace.IsNotFound(err))
+}
+
+func TestGenericWrapperConditionalDelete(t *testing.T) {
+	t.Parallel()
+
+	memBackend, err := memory.New(memory.Config{})
+	require.NoError(t, err)
+
+	service, err := NewServiceWrapper(
+		ServiceConfig[*testResource153]{
+			Backend:       memBackend,
+			ResourceKind:  "generic resource",
+			BackendPrefix: backend.NewKey("generic_prefix"),
+			MarshalFunc:   marshalResource153,
+			UnmarshalFunc: unmarshalResource153,
+		})
+	require.NoError(t, err)
+
+	// services methods modify their inputs. Take a defensive copy before calling.
+	cloneResource := func(r *testResource153) *testResource153 {
+		return &testResource153{
+			Metadata: proto.Clone(r.Metadata).(*headerv1.Metadata),
+		}
+	}
+
+	// Create a couple revisions of a resource.
+	res := newTestResource153("myresource")
+	res.Metadata.SetExpires(nil)
+	res.Metadata.SetDescription("r1")
+	rev1, err := service.CreateResource(t.Context(), cloneResource(res))
+	require.NoError(t, err)
+
+	res.Metadata.SetDescription("r2")
+	res.Metadata.SetRevision(rev1.Metadata.GetRevision())
+	rev2, err := service.ConditionalUpdateResource(t.Context(), cloneResource(res))
+	require.NoError(t, err)
+
+	t.Run("unknown revision errors", func(t *testing.T) {
+		err := service.ConditionalDeleteResource(
+			t.Context(),
+			rev2.Metadata.GetName(),
+			rev1.Metadata.GetRevision(),
+		)
+		assert.ErrorAs(t, err, new(*trace.CompareFailedError))
+	})
+
+	t.Run("ok", func(t *testing.T) {
+		err := service.ConditionalDeleteResource(
+			t.Context(),
+			rev2.Metadata.GetName(),
+			rev2.Metadata.GetRevision(),
+		)
+		require.NoError(t, err)
+
+		_, err = service.GetResource(t.Context(), rev2.Metadata.GetName())
+		assert.ErrorAs(t, err, new(*trace.NotFoundError), "Get error mismatch after ConditionalDelete")
+	})
 }
 
 // TestGenericWrapperWithPrefix tests the withPrefix method of the generic service wrapper.

--- a/lib/services/local/generic/generic_wrapper_test.go
+++ b/lib/services/local/generic/generic_wrapper_test.go
@@ -262,13 +262,13 @@ func TestGenericWrapperConditionalDelete(t *testing.T) {
 
 	// Create a couple revisions of a resource.
 	res := newTestResource153("myresource")
-	res.Metadata.SetExpires(nil)
-	res.Metadata.SetDescription("r1")
+	res.Metadata.Expires = nil
+	res.Metadata.Description = "r1"
 	rev1, err := service.CreateResource(t.Context(), cloneResource(res))
 	require.NoError(t, err)
 
-	res.Metadata.SetDescription("r2")
-	res.Metadata.SetRevision(rev1.Metadata.GetRevision())
+	res.Metadata.Description = "r2"
+	res.Metadata.Revision = rev1.Metadata.GetRevision()
 	rev2, err := service.ConditionalUpdateResource(t.Context(), cloneResource(res))
 	require.NoError(t, err)
 


### PR DESCRIPTION
Backport #67870 to branch/v17, minus the CA override parts (which don't exist on v17).

https://github.com/gravitational/teleport.e/issues/7675