### PR TITLE
iOS: Core Framework

### DIFF
--- a/mobile/Verify/Core/EnrollClient.swift
+++ b/mobile/Verify/Core/EnrollClient.swift
@@ -1,0 +1,53 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see http://www.gnu.org/licenses/
+
+import DependenciesMacros
+import Enroll
+import Foundation
+
+/// Handles requests around enrolling the current device in Device Trust
+@DependencyClient
+public struct EnrollClient: Sendable {
+	/// Sends a request for an enrollment token
+	public var requestEnrollmentToken: @Sendable (
+		_ hostName: String,
+		_ port: Int,
+		_ pairingToken: String,
+	) async throws -> String
+}
+
+public enum EnrollClientError: Error, Sendable {
+	case clientCreationFailed
+}
+
+public extension EnrollClient {
+	static let liveValue = EnrollClient(
+		requestEnrollmentToken: { hostName, port, pairingToken in
+			try await Task.detached(priority: .userInitiated) {
+				let proxyServer = "\(hostName):\(port)"
+				guard let client = Enroll.EnrollClient(proxyServer, insecure: false) else {
+					throw EnrollClientError.clientCreationFailed
+				}
+
+				let token = try client.createMobileEnrollToken(
+					pairingToken,
+					deviceData: Enroll.EnrollDeviceCollectedData(),
+				)
+				return token.token
+			}.value
+		},
+	)
+}

--- a/mobile/Verify/Core/EnrollClient.swift
+++ b/mobile/Verify/Core/EnrollClient.swift
@@ -33,8 +33,8 @@ public enum EnrollClientError: Error, Sendable {
 	case clientCreationFailed
 }
 
-public extension EnrollClient {
-	static let liveValue = EnrollClient(
+extension EnrollClient {
+	public static let liveValue = EnrollClient(
 		requestEnrollmentToken: { hostName, port, pairingToken in
 			try await Task.detached(priority: .userInitiated) {
 				let proxyServer = "\(hostName):\(port)"

--- a/mobile/Verify/Verify.xcodeproj/project.pbxproj
+++ b/mobile/Verify/Verify.xcodeproj/project.pbxproj
@@ -8,7 +8,22 @@
 
 /* Begin PBXBuildFile section */
 		0C94C8CE2FA35F3D00C13C9A /* libresolv.9.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 0C94C8CD2FA35ED900C13C9A /* libresolv.9.tbd */; };
+		CD7999232FE33AE000133048 /* Core.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CD79991B2FE33AE000133048 /* Core.framework */; };
+		CD7999242FE33AE000133048 /* Core.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = CD79991B2FE33AE000133048 /* Core.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		CD79992C2FE33F0600133048 /* libresolv.9.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = CD79992B2FE33EFF00133048 /* libresolv.9.tbd */; };
+		CD7999332FE345D400133048 /* Dependencies in Frameworks */ = {isa = PBXBuildFile; productRef = CD7999322FE345D400133048 /* Dependencies */; };
+		CD7999352FE346B800133048 /* DependenciesMacros in Frameworks */ = {isa = PBXBuildFile; productRef = CD7999342FE346B800133048 /* DependenciesMacros */; };
 /* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		CD7999212FE33AE000133048 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 0C94C84A2FA232E600C13C9A /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = CD79991A2FE33AE000133048;
+			remoteInfo = Core;
+		};
+/* End PBXContainerItemProxy section */
 
 /* Begin PBXCopyFilesBuildPhase section */
 		0C94C8CA2FA35ECB00C13C9A /* Embed Frameworks */ = {
@@ -17,6 +32,7 @@
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
+				CD7999242FE33AE000133048 /* Core.framework in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -26,6 +42,8 @@
 /* Begin PBXFileReference section */
 		0C94C8522FA232E600C13C9A /* Verify.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Verify.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		0C94C8CD2FA35ED900C13C9A /* libresolv.9.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libresolv.9.tbd; path = usr/lib/libresolv.9.tbd; sourceTree = SDKROOT; };
+		CD79991B2FE33AE000133048 /* Core.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Core.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		CD79992B2FE33EFF00133048 /* libresolv.9.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libresolv.9.tbd; path = Platforms/MacOSX.platform/Developer/SDKs/MacOSX26.5.sdk/usr/lib/libresolv.9.tbd; sourceTree = DEVELOPER_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
@@ -47,6 +65,11 @@
 			path = Verify;
 			sourceTree = "<group>";
 		};
+		CD79991C2FE33AE000133048 /* Core */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			path = Core;
+			sourceTree = "<group>";
+		};
 /* End PBXFileSystemSynchronizedRootGroup section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -55,6 +78,17 @@
 			buildActionMask = 2147483647;
 			files = (
 				0C94C8CE2FA35F3D00C13C9A /* libresolv.9.tbd in Frameworks */,
+				CD7999232FE33AE000133048 /* Core.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		CD7999182FE33AE000133048 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				CD79992C2FE33F0600133048 /* libresolv.9.tbd in Frameworks */,
+				CD7999332FE345D400133048 /* Dependencies in Frameworks */,
+				CD7999352FE346B800133048 /* DependenciesMacros in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -65,6 +99,7 @@
 			isa = PBXGroup;
 			children = (
 				0C94C8542FA232E600C13C9A /* Verify */,
+				CD79991C2FE33AE000133048 /* Core */,
 				0C94C8CC2FA35ED900C13C9A /* Frameworks */,
 				0C94C8532FA232E600C13C9A /* Products */,
 			);
@@ -74,6 +109,7 @@
 			isa = PBXGroup;
 			children = (
 				0C94C8522FA232E600C13C9A /* Verify.app */,
+				CD79991B2FE33AE000133048 /* Core.framework */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -81,12 +117,23 @@
 		0C94C8CC2FA35ED900C13C9A /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				CD79992B2FE33EFF00133048 /* libresolv.9.tbd */,
 				0C94C8CD2FA35ED900C13C9A /* libresolv.9.tbd */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
+
+/* Begin PBXHeadersBuildPhase section */
+		CD7999162FE33AE000133048 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXHeadersBuildPhase section */
 
 /* Begin PBXNativeTarget section */
 		0C94C8512FA232E600C13C9A /* Verify */ = {
@@ -103,6 +150,7 @@
 			);
 			dependencies = (
 				CDDEB8772FE1F5FC0052BC27 /* PBXTargetDependency */,
+				CD7999222FE33AE000133048 /* PBXTargetDependency */,
 			);
 			fileSystemSynchronizedGroups = (
 				0C94C8542FA232E600C13C9A /* Verify */,
@@ -114,6 +162,33 @@
 			productReference = 0C94C8522FA232E600C13C9A /* Verify.app */;
 			productType = "com.apple.product-type.application";
 		};
+		CD79991A2FE33AE000133048 /* Core */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = CD7999272FE33AE000133048 /* Build configuration list for PBXNativeTarget "Core" */;
+			buildPhases = (
+				CD7999162FE33AE000133048 /* Headers */,
+				CD79992A2FE33CF300133048 /* ShellScript */,
+				CD7999172FE33AE000133048 /* Sources */,
+				CD7999182FE33AE000133048 /* Frameworks */,
+				CD7999192FE33AE000133048 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				CD7999292FE33B7E00133048 /* PBXTargetDependency */,
+			);
+			fileSystemSynchronizedGroups = (
+				CD79991C2FE33AE000133048 /* Core */,
+			);
+			name = Core;
+			packageProductDependencies = (
+				CD7999322FE345D400133048 /* Dependencies */,
+				CD7999342FE346B800133048 /* DependenciesMacros */,
+			);
+			productName = Core;
+			productReference = CD79991B2FE33AE000133048 /* Core.framework */;
+			productType = "com.apple.product-type.framework";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -121,11 +196,14 @@
 			isa = PBXProject;
 			attributes = {
 				BuildIndependentTargetsInParallel = 1;
-				LastSwiftUpdateCheck = 2640;
+				LastSwiftUpdateCheck = 2650;
 				LastUpgradeCheck = 2650;
 				TargetAttributes = {
 					0C94C8512FA232E600C13C9A = {
 						CreatedOnToolsVersion = 26.4.1;
+					};
+					CD79991A2FE33AE000133048 = {
+						CreatedOnToolsVersion = 26.5;
 					};
 				};
 			};
@@ -140,6 +218,7 @@
 			minimizedProjectReferenceProxies = 1;
 			packageReferences = (
 				CDDEB8752FE1F5F10052BC27 /* XCRemoteSwiftPackageReference "SwiftLintPlugins" */,
+				CD7999312FE345D400133048 /* XCRemoteSwiftPackageReference "swift-dependencies" */,
 			);
 			preferredProjectObjectVersion = 77;
 			productRefGroup = 0C94C8532FA232E600C13C9A /* Products */;
@@ -147,12 +226,20 @@
 			projectRoot = "";
 			targets = (
 				0C94C8512FA232E600C13C9A /* Verify */,
+				CD79991A2FE33AE000133048 /* Core */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
 		0C94C8502FA232E600C13C9A /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		CD7999192FE33AE000133048 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -172,12 +259,29 @@
 			);
 			inputPaths = (
 				"$(SRCROOT)/Scripts/build-enroll-framework.sh",
-				"$(SRCROOT)/Scripts/helpers.sh",
 			);
 			outputFileListPaths = (
 			);
 			outputPaths = (
 				"$(TARGET_TEMP_DIR)/GeneratedFrameworks/Enroll.xcframework",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "$SRCROOT/Scripts/build-enroll-framework.sh\n";
+		};
+		CD79992A2FE33CF300133048 /* ShellScript */ = {
+			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			outputFileListPaths = (
+			);
+			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -193,9 +297,25 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		CD7999172FE33AE000133048 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
+		CD7999222FE33AE000133048 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = CD79991A2FE33AE000133048 /* Core */;
+			targetProxy = CD7999212FE33AE000133048 /* PBXContainerItemProxy */;
+		};
+		CD7999292FE33B7E00133048 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			productRef = CD7999282FE33B7E00133048 /* SwiftLintBuildToolPlugin */;
+		};
 		CDDEB8772FE1F5FC0052BC27 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			productRef = CDDEB8762FE1F5FC0052BC27 /* SwiftLintBuildToolPlugin */;
@@ -241,7 +361,7 @@
 				DEVELOPMENT_TEAM = K497G57PDJ;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
-				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = NO;
 				GCC_C_LANGUAGE_STANDARD = gnu17;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_NO_COMMON_BLOCKS = YES;
@@ -256,7 +376,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 26.4;
+				IPHONEOS_DEPLOYMENT_TARGET = 26.5;
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
@@ -264,7 +384,10 @@
 				SDKROOT = iphoneos;
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
+				SWIFT_APPROACHABLE_CONCURRENCY = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_UPCOMING_FEATURE_EXISTENTIAL_ANY = YES;
+				SWIFT_UPCOMING_FEATURE_INTERNAL_IMPORTS_BY_DEFAULT = YES;
 				SWIFT_VERSION = 6.0;
 			};
 			name = Debug;
@@ -307,7 +430,7 @@
 				DEVELOPMENT_TEAM = K497G57PDJ;
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = NO;
 				GCC_C_LANGUAGE_STANDARD = gnu17;
 				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
@@ -316,13 +439,16 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 26.4;
+				IPHONEOS_DEPLOYMENT_TARGET = 26.5;
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
 				SDKROOT = iphoneos;
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;
+				SWIFT_APPROACHABLE_CONCURRENCY = YES;
 				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_UPCOMING_FEATURE_EXISTENTIAL_ANY = YES;
+				SWIFT_UPCOMING_FEATURE_INTERNAL_IMPORTS_BY_DEFAULT = YES;
 				SWIFT_VERSION = 6.0;
 				VALIDATE_PRODUCT = YES;
 			};
@@ -354,15 +480,13 @@
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				IPHONEOS_DEPLOYMENT_TARGET = 26.5;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				OTHER_LDFLAGS = (
-					"-framework",
-					Enroll,
-				);
+				OTHER_LDFLAGS = "";
 				PRODUCT_BUNDLE_IDENTIFIER = com.gravitational.Verify;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;
@@ -374,7 +498,7 @@
 				SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
-				SWIFT_VERSION = 5.0;
+				SWIFT_VERSION = 6.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
@@ -405,15 +529,13 @@
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				IPHONEOS_DEPLOYMENT_TARGET = 26.5;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				OTHER_LDFLAGS = (
-					"-framework",
-					Enroll,
-				);
+				OTHER_LDFLAGS = "";
 				PRODUCT_BUNDLE_IDENTIFIER = com.gravitational.Verify;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;
@@ -425,8 +547,118 @@
 				SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
-				SWIFT_VERSION = 5.0;
+				SWIFT_VERSION = 6.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+		CD7999252FE33AE000133048 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUILD_LIBRARY_FOR_DISTRIBUTION = YES;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = K497G57PDJ;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_MODULE_VERIFIER = YES;
+				"FRAMEWORK_SEARCH_PATHS[sdk=iphoneos*]" = (
+					"$(inherited)",
+					"$(TARGET_TEMP_DIR)/GeneratedFrameworks/Enroll.xcframework/ios-arm64",
+				);
+				"FRAMEWORK_SEARCH_PATHS[sdk=iphonesimulator*]" = (
+					"$(inherited)",
+					"$(TARGET_TEMP_DIR)/GeneratedFrameworks/Enroll.xcframework/ios-arm64_x86_64-simulator",
+				);
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 26.5;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				MODULE_VERIFIER_SUPPORTED_LANGUAGES = "objective-c objective-c++";
+				MODULE_VERIFIER_SUPPORTED_LANGUAGE_STANDARDS = "gnu17 gnu++20";
+				OTHER_LDFLAGS = (
+					"-framework",
+					Enroll,
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.gravitational.Core;
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SKIP_INSTALL = YES;
+				STRING_CATALOG_GENERATE_SYMBOLS = YES;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SWIFT_APPROACHABLE_CONCURRENCY = YES;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_INSTALL_MODULE = YES;
+				SWIFT_INSTALL_OBJC_HEADER = NO;
+				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
+				SWIFT_VERSION = 6.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
+		CD7999262FE33AE000133048 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUILD_LIBRARY_FOR_DISTRIBUTION = YES;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = K497G57PDJ;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_MODULE_VERIFIER = YES;
+				"FRAMEWORK_SEARCH_PATHS[sdk=iphoneos*]" = (
+					"$(inherited)",
+					"$(TARGET_TEMP_DIR)/GeneratedFrameworks/Enroll.xcframework/ios-arm64",
+				);
+				"FRAMEWORK_SEARCH_PATHS[sdk=iphonesimulator*]" = (
+					"$(inherited)",
+					"$(TARGET_TEMP_DIR)/GeneratedFrameworks/Enroll.xcframework/ios-arm64_x86_64-simulator",
+				);
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 26.5;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				MODULE_VERIFIER_SUPPORTED_LANGUAGES = "objective-c objective-c++";
+				MODULE_VERIFIER_SUPPORTED_LANGUAGE_STANDARDS = "gnu17 gnu++20";
+				OTHER_LDFLAGS = (
+					"-framework",
+					Enroll,
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.gravitational.Core;
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SKIP_INSTALL = YES;
+				STRING_CATALOG_GENERATE_SYMBOLS = YES;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SWIFT_APPROACHABLE_CONCURRENCY = YES;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_INSTALL_MODULE = YES;
+				SWIFT_INSTALL_OBJC_HEADER = NO;
+				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
+				SWIFT_VERSION = 6.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
 			};
 			name = Release;
 		};
@@ -451,9 +683,26 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
+		CD7999272FE33AE000133048 /* Build configuration list for PBXNativeTarget "Core" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				CD7999252FE33AE000133048 /* Debug */,
+				CD7999262FE33AE000133048 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
+		CD7999312FE345D400133048 /* XCRemoteSwiftPackageReference "swift-dependencies" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/pointfreeco/swift-dependencies";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 1.14.0;
+			};
+		};
 		CDDEB8752FE1F5F10052BC27 /* XCRemoteSwiftPackageReference "SwiftLintPlugins" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/SimplyDanny/SwiftLintPlugins";
@@ -465,6 +714,21 @@
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
+		CD7999282FE33B7E00133048 /* SwiftLintBuildToolPlugin */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = CDDEB8752FE1F5F10052BC27 /* XCRemoteSwiftPackageReference "SwiftLintPlugins" */;
+			productName = "plugin:SwiftLintBuildToolPlugin";
+		};
+		CD7999322FE345D400133048 /* Dependencies */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = CD7999312FE345D400133048 /* XCRemoteSwiftPackageReference "swift-dependencies" */;
+			productName = Dependencies;
+		};
+		CD7999342FE346B800133048 /* DependenciesMacros */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = CD7999312FE345D400133048 /* XCRemoteSwiftPackageReference "swift-dependencies" */;
+			productName = DependenciesMacros;
+		};
 		CDDEB8762FE1F5FC0052BC27 /* SwiftLintBuildToolPlugin */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = CDDEB8752FE1F5F10052BC27 /* XCRemoteSwiftPackageReference "SwiftLintPlugins" */;

--- a/mobile/Verify/Verify.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/mobile/Verify/Verify.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,6 +1,51 @@
 {
-  "originHash" : "1fa961aa1dc717cea452f3389668f0f99a254f07e4eb11d190768a53798f744f",
+  "originHash" : "428e700f3859a8b1bdd9f3f67144b4126b55781048f23958507c71164e5245e6",
   "pins" : [
+    {
+      "identity" : "combine-schedulers",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/combine-schedulers",
+      "state" : {
+        "revision" : "dcccb979a2183b8df3334237e3dc1ae2b4116a86",
+        "version" : "1.2.0"
+      }
+    },
+    {
+      "identity" : "swift-clocks",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-clocks",
+      "state" : {
+        "revision" : "72d749bf341b78851203066ab421869b783ec42a",
+        "version" : "1.1.0"
+      }
+    },
+    {
+      "identity" : "swift-concurrency-extras",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-concurrency-extras",
+      "state" : {
+        "revision" : "a90e2e40a7a840a853dd29e57cbef5dbb72c9d5b",
+        "version" : "1.4.0"
+      }
+    },
+    {
+      "identity" : "swift-dependencies",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-dependencies",
+      "state" : {
+        "revision" : "008b012380623976ce2b9c92c5bf2bda8bcf5e55",
+        "version" : "1.14.0"
+      }
+    },
+    {
+      "identity" : "swift-syntax",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swiftlang/swift-syntax",
+      "state" : {
+        "revision" : "79e4b74a295b6eb74a8b585e3a39d29e70c1dbd1",
+        "version" : "603.0.2"
+      }
+    },
     {
       "identity" : "swiftlintplugins",
       "kind" : "remoteSourceControl",
@@ -8,6 +53,15 @@
       "state" : {
         "revision" : "18d8d2d18e1668006d1d209e0b5f5e06c1da7cb5",
         "version" : "0.63.3"
+      }
+    },
+    {
+      "identity" : "xctest-dynamic-overlay",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/xctest-dynamic-overlay",
+      "state" : {
+        "revision" : "cb281f343fd953280336dcbd3822cdf47c182f5b",
+        "version" : "1.10.0"
       }
     }
   ],

--- a/mobile/Verify/Verify.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/mobile/Verify/Verify.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "428e700f3859a8b1bdd9f3f67144b4126b55781048f23958507c71164e5245e6",
+  "originHash" : "607d9506e8d7561d7b28a75c3a23aa6ba2a4f751152a768b7e0ab6c8878b2e86",
   "pins" : [
     {
       "identity" : "combine-schedulers",

--- a/mobile/Verify/Verify/DeepLink.swift
+++ b/mobile/Verify/Verify/DeepLink.swift
@@ -14,6 +14,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+import Core
 import Foundation
 import os
 

--- a/mobile/Verify/Verify/EnrollMobileDeviceViewModel.swift
+++ b/mobile/Verify/Verify/EnrollMobileDeviceViewModel.swift
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import Enroll
+import Core
 import Observation
 
 @Observable
@@ -24,7 +24,7 @@ class EnrollMobileDeviceViewModel {
 		case idle
 		case loading
 		case success(token: String)
-		case failure(Error)
+		case failure(any Error)
 
 		var isLoading: Bool {
 			if case .loading = self { return true }
@@ -34,35 +34,25 @@ class EnrollMobileDeviceViewModel {
 
 	var attempt: Attempt = .idle
 	private let deepURL: EnrollMobileDeviceDeepURL
+	private let enrollClient: EnrollClient
 
-	init(deepURL: EnrollMobileDeviceDeepURL) {
+	init(deepURL: EnrollMobileDeviceDeepURL, enrollClient: EnrollClient = .liveValue) {
 		self.deepURL = deepURL
+		self.enrollClient = enrollClient
 	}
 
 	func requestEnrollToken() async {
 		attempt = .loading
-		let proxyServer = "\(deepURL.url.hostname):\(deepURL.url.port ?? 443)"
-		let pairingToken = deepURL.enrollPairingToken
-
-		let outcome: Attempt = await Task.detached(priority: .userInitiated) {
-			guard let client = EnrollClient(proxyServer, insecure: false) else {
-				return .failure(EnrollViewModelError.clientCreationFailed)
-			}
-			do {
-				let token = try client.createMobileEnrollToken(
-					pairingToken,
-					deviceData: EnrollDeviceCollectedData(),
-				)
-				return .success(token: token.token)
-			} catch {
-				return .failure(error)
-			}
-		}.value
-
-		attempt = outcome
+		let defaultHTTPSPort = 443
+		do {
+			let token = try await enrollClient.requestEnrollmentToken(
+				hostName: deepURL.url.hostname,
+				port: deepURL.url.port ?? defaultHTTPSPort,
+				pairingToken: deepURL.enrollPairingToken,
+			)
+			attempt = .success(token: token)
+		} catch {
+			attempt = .failure(error)
+		}
 	}
-}
-
-enum EnrollViewModelError: Error {
-	case clientCreationFailed
 }


### PR DESCRIPTION
This PR introduces a Core framework (as per the [RFD](https://github.com/gravitational/rfd/pull/51)) that serves as the boundary layer between Swift and Go code. It becomes a layer of indirection where we can put any code related to the boundary and allows us to consume idiomatic Swift APIs in our view models.

This work includes:
- Updating the build in Xcode to have a new `Core` framework target.
- Moving the code that depends on the `Enroll.xcframework` to this new target.
- Wrapping the existing behavior for enrolling an XCFramework in a new `EnrollClient` that participates in our dependency system via the newly introduced `swift-dependencies` package.