### PR TITLE
Fix TestHandleConnectionHTTP2WS and TestHandleConnectionWS slowness

### DIFF
--- a/lib/srv/app/server_test.go
+++ b/lib/srv/app/server_test.go
@@ -269,6 +269,10 @@ func SetUpSuiteWithConfig(t *testing.T, config suiteConfig) *Suite {
 
 			err = ws.WriteMessage(websocket.TextMessage, []byte(s.message))
 			require.NoError(t, err)
+
+			// Close the upstream websocket once the message has been written so
+			// the backend->client copy direction reaches EOF promptly.
+			require.NoError(t, ws.Close())
 		} else {
 			fmt.Fprintln(w, s.message)
 		}


### PR DESCRIPTION
I've been noodling on an agent/skill for investigating flaky/slow tests with Claude, and figured a good test bed would be tests which are particularly slow according to our CI metrics.

TestHandleConnectionWS and TestHandleConnectionHTTP2WS stood out to me because they both are recorded as having a P90 around 120 seconds - and the tests themselves looked fairly trivial.

Claude identified that under certain circumstances (when a large suite of tests is running/or the tests are run for multiple counts) that the tests performance degrades from under a second to the 60-120 second range.

The root cause here is https://go-review.googlesource.com/c/go/+/637939. Before this CL, `httputil.ReverseProxy` would treat a half-closed websocket connection (i.e closed by one side, but not the other) as fatal and tear down the other side. After this CL, it will continue to proxy until both sides have indicated a close.

Prior to this PR, the fake websocket server is "interesting" in that it does not close its websocket (or even react to the client closing theirs). Prior to the Go lib changes, this was fine as the client closed its half upon receiving the message and then the old impl of ReverseProxy would tear down the server side and then itself return.

When the Go lib changed, it meant that the httputil.ReverseProxy now stays in a blocked state. As the test waits for the connection handler to finish, this meant that the test remains in a blocked state.

The test does not remain in a blocked state forever - fortunately, the GC notices there are no longer any references to the conn and triggers the finalizer. When running the test by itself, the GC runs pretty "often" - however - when running our test in amongst the full suite, our GC is running less often - which explain why we see this test balloon in duration in CI.

This PR modifies the fake websocket server to close when it has finished sending the message.
