### PR TITLE
docs: Add docs for `review_requests.submit_for_users`

### DIFF
--- a/docs/pages/identity-governance/access-requests/access-request-configuration.mdx
+++ b/docs/pages/identity-governance/access-requests/access-request-configuration.mdx
@@ -723,15 +723,15 @@ UUID as provided by the Access Request.
 ## Submitting for other users
 
 You can configure a Teleport role to submit Access Request reviews on behalf of other users.
-This is primarily used by Teleport Access Request plugins to allow users from the connected integration
+This is used by Teleport Access Request plugins to allow users from the connected integration
 to approve and deny Access Requests natively in the integration.
 
 Currently, only the self-hosted Slack plugin supports native Access Request reviews. We highly
 recommend using the preset role `access-plugin-with-review` which provides the plugin with permissions
 to submit for any other user (via the wildcard `*`).
 
-To grant or deny a user the ability to submit reviews on behalf of other users,
-use the `allow.review_requests.submit_for_users` and `deny.review_requests.submit_for_users` fields in the user's roles:
+To grant or deny a plugin user the ability to submit reviews on behalf of other users,
+use the `allow.review_requests.submit_for_users` and `deny.review_requests.submit_for_users` fields in the plugin user's roles:
 ```yaml
 kind: role
 version: v8
@@ -744,9 +744,10 @@ spec:
         - '*'
 ```
 
-When the condition for `submit_for_users` is matched from a plugin user's role, all other `review_requests` conditions are ignored.
-This is because review permission checks will be performed on the user that the plugin is submitting on behalf of, instead
-of the plugin's own review permissions. This ensures that RBAC is enforced on the correct user identity and not the plugin's identity.
+When an Access Request review matches a plugin user's role with `submit_for_users`, the review will ignore all other
+`review_requests` conditions. This is because the Teleport Auth Service will perform review permission checks against the
+user that the plugin is submitting on behalf of, instead of the plugin's own review permissions.
+This ensures that RBAC is enforced on the correct user identity and not the plugin's identity.
 
 ## Request annotations
 

--- a/docs/pages/identity-governance/access-requests/access-request-configuration.mdx
+++ b/docs/pages/identity-governance/access-requests/access-request-configuration.mdx
@@ -720,6 +720,34 @@ protected by Teleport, such as deployments and pods.
 Without the ability to preview a resource, reviewers can only see the resource's
 UUID as provided by the Access Request.
 
+## Submitting for other users
+
+You can configure a Teleport role to submit Access Request reviews on behalf of other users.
+This is primarily used by Teleport Access Request plugins to allow users from the connected integration
+to approve and deny Access Requests natively in the integration.
+
+Currently, only the self-hosted Slack plugin supports native Access Request reviews. We highly
+recommend using the preset role `access-plugin-with-review` which provides the plugin with permissions
+to submit for any other user (via the wildcard `*`).
+
+To grant or deny a user the ability to submit reviews on behalf of other users,
+use the `allow.review_requests.submit_for_users` and `deny.review_requests.submit_for_users` fields in the user's roles:
+```yaml
+kind: role
+version: v8
+metadata:
+  name: access-plugin-with-review
+spec:
+  allow:
+    review_requests:
+      submit_for_users:
+        - '*'
+```
+
+When the condition for `submit_for_users` is matched from a plugin user's role, all other `review_requests` conditions are ignored.
+This is because review permission checks will be performed on the user that the plugin is submitting on behalf of, instead
+of the plugin's own review permissions. This ensures that RBAC is enforced on the correct user identity and not the plugin's identity.
+
 ## Request annotations
 
 When a user creates an Access Request, the Teleport Auth Service can write

--- a/docs/pages/includes/preset-roles-table.mdx
+++ b/docs/pages/includes/preset-roles-table.mdx
@@ -4,6 +4,7 @@
 | `editor` | Allows editing of cluster configuration settings. |  |
 | `auditor`| Allows reading cluster events, audit logs, and playing back session records. |  |
 | `access-plugin` | Enables self-hosted Access Request plugin features. |  |
+| `access-plugin-with-review` | Enables self-hosted Access Request plugin features including native Access Request reviews. |  |
 | `list-access-request-resources` | Allows reading Access Request resources. |  |
 | `requester`| Allows a user to create Access Requests. | ✔ |
 | `reviewer`| Allows review of Access Requests. | ✔ |

--- a/docs/pages/includes/role-spec.mdx
+++ b/docs/pages/includes/role-spec.mdx
@@ -376,6 +376,9 @@ spec:
       # the reviewer can preview details about resources accessible by any roles
       # listed in preview_as_roles when reviewing Resource Access Requests
       preview_as_roles: ['dbadmin']
+      # the reviewer can submit reviews on behalf of other users;
+      # only to be used by Access Request plugins (eg. Slack plugin)
+      submit_for_users: ['*']
 
     # request allows a user to request roles matching
     # expressions below

--- a/docs/pages/reference/access-controls/roles.mdx
+++ b/docs/pages/reference/access-controls/roles.mdx
@@ -724,10 +724,11 @@ Requests, and like `request`, can fall under `allow` or `deny`:
 
 |Role Field|Description|Further Information|
 |---|---|---|
-|`review_requests.roles`|Allows or denies the ability to review requests for particular roles.|[Reviews for specific roles](../../identity-governance/access-requests/access-request-configuration.mdx)|
-|`review_requests.where`|Configures conditions in which a user with the role may review an Access Request|[`where` expressions](../../identity-governance/access-requests/access-request-configuration.mdx)|
-|`review_requests.preview_as_roles`|Allows or denies the ability to list resources that a user with the requested role can access|[Inspecting requested resources](../../identity-governance/access-requests/access-request-configuration.mdx)|
-|`review_requests.claims_to_roles`|Teleport roles that a user can or cannot review requests for based on their traits.|[Reviews for specific roles](../../identity-governance/access-requests/access-request-configuration.mdx)|
+|`review_requests.roles`|Allows or denies the ability to review requests for particular roles.|[Reviews for specific roles](../../identity-governance/access-requests/access-request-configuration.mdx#roles-that-a-reviewer-can-grant-access-to)|
+|`review_requests.where`|Configures conditions in which a user with the role may review an Access Request|[`where` expressions](../../identity-governance/access-requests/access-request-configuration.mdx#where-expressions)|
+|`review_requests.preview_as_roles`|Allows or denies the ability to list resources that a user with the requested role can access|[Inspecting requested resources](../../identity-governance/access-requests/access-request-configuration.mdx#inspecting-requested-resources)|
+|`review_requests.claims_to_roles`|Teleport roles that a user can or cannot review requests for based on their traits.|[Reviews for specific roles](../../identity-governance/access-requests/access-request-configuration.mdx#roles-that-a-reviewer-can-grant-access-to)|
+|`review_requests.submit_for_users`|Allows or denies the ability to submit reviews on behalf of other users. Ignores all other `review_requests` conditions if matched. Only to be used by Teleport Access Request plugins.|[Submitting reviews for other users](../../identity-governance/access-requests/access-request-configuration.mdx#submitting-for-other-users)|
 
 ### Client options
 


### PR DESCRIPTION
Updates the reference docs for RBAC role spec: `review_requests.submit_for_users`

Also added subsection links to Access Request review configuration page.

Context for reviewers: This supports the upcoming feature for native reviews in Slack, where the Teleport Slack plugin submits Access Request reviews to the Teleport Auth Server on behalf of human Slack users.

It should be noted that while the rule is not specific to plugin users (regular users should be unaffected even if the rule is set), we only really use the rule for Teleport Access Request plugins (and only currently for Slack plugin, which implements the native review feature).

