### PR TITLE
[v18] MCP: Protect against potential session ID forgery

### DIFF
--- a/lib/srv/mcp/auth_test.go
+++ b/lib/srv/mcp/auth_test.go
@@ -27,6 +27,8 @@ import (
 
 	"github.com/gravitational/teleport/api/constants"
 	"github.com/gravitational/teleport/api/types"
+	libevents "github.com/gravitational/teleport/lib/events"
+	"github.com/gravitational/teleport/lib/utils"
 )
 
 func Test_rewriteAuthDetails(t *testing.T) {
@@ -183,4 +185,50 @@ func Test_generateJWTAndTraits(t *testing.T) {
 	require.Len(t, appTokenRequests, 6)
 	require.Equal(t, testCtx.Identity.Expires, appTokenRequests[4].Expires)
 	require.Equal(t, testCtx.Identity.Expires, appTokenRequests[5].Expires)
+}
+
+// TestServer_getSessionHandlerWithJWT_perUserCache verifies that if the user somehow can forge
+// their session ID, they can't access another user's cached session.
+func TestServer_getSessionHandlerWithJWT_perUserCache(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+
+	role, err := types.NewRole("access", types.RoleSpecV6{})
+	require.NoError(t, err)
+
+	alice, err := types.NewUser("alice")
+	require.NoError(t, err)
+
+	bob, err := types.NewUser("bob")
+	require.NoError(t, err)
+
+	aliceSessionCtx := setupTestContext(t, withUser(alice), withRole(role)).SessionCtx
+	bobSessionCtx := setupTestContext(t, withUser(bob), withRole(role)).SessionCtx
+
+	const sharedSessionID = "test_shared_session_id"
+	aliceSessionCtx.sessionID = sharedSessionID
+	bobSessionCtx.sessionID = sharedSessionID
+
+	srv, err := NewServer(ServerConfig{
+		Emitter:       &libevents.DiscardEmitter{},
+		ParentContext: t.Context(),
+		HostID:        "host-id",
+		AccessPoint:   fakeAccessPoint{},
+		CipherSuites:  utils.DefaultCipherSuites(),
+		AuthClient:    &mockAuthClient{},
+	})
+	require.NoError(t, err)
+
+	aliceSessionHandler, err := srv.getSessionHandlerWithJWT(ctx, aliceSessionCtx)
+	require.NoError(t, err)
+
+	bobSessionHandler, err := srv.getSessionHandlerWithJWT(ctx, bobSessionCtx)
+	require.NoError(t, err)
+
+	// Verify that for different users, even the session ctx has the same sessionID, it is
+	// stored under a different cache key.
+	require.Equal(t, aliceSessionCtx.sessionID, bobSessionCtx.sessionID)
+	require.NotEqual(t, aliceSessionCtx.Identity.Username, bobSessionCtx.Identity.Username)
+	require.Equal(t, aliceSessionCtx, aliceSessionHandler.sessionCtx)
+	require.Equal(t, bobSessionCtx, bobSessionHandler.sessionCtx)
 }

--- a/lib/srv/mcp/helpers_test.go
+++ b/lib/srv/mcp/helpers_test.go
@@ -57,6 +57,7 @@ func TestMain(m *testing.M) {
 }
 
 type setupTestContextOptions struct {
+	user       types.User
 	roleSet    services.RoleSet
 	app        types.Application
 	clientConn net.Conn
@@ -67,6 +68,12 @@ type setupTestContextOptionFunc func(*setupTestContextOptions)
 func withApp(app types.Application) setupTestContextOptionFunc {
 	return func(o *setupTestContextOptions) {
 		o.app = app
+	}
+}
+
+func withUser(user types.User) setupTestContextOptionFunc {
+	return func(opts *setupTestContextOptions) {
+		opts.user = user
 	}
 }
 
@@ -182,7 +189,7 @@ func setupTestContext(t *testing.T, applyOpts ...setupTestContextOptionFunc) tes
 	sessionCtx := &SessionCtx{
 		ClientConn: clientDestConn,
 		App:        opts.app,
-		AuthCtx:    makeTestAuthContext(t, opts.roleSet, opts.app),
+		AuthCtx:    makeTestAuthContext(t, opts.user, opts.roleSet, opts.app),
 	}
 	require.NoError(t, sessionCtx.checkAndSetDefaults())
 
@@ -192,11 +199,14 @@ func setupTestContext(t *testing.T, applyOpts ...setupTestContextOptionFunc) tes
 	}
 }
 
-func makeTestAuthContext(t *testing.T, roleSet services.RoleSet, app types.Application) *authz.Context {
+func makeTestAuthContext(t *testing.T, user types.User, roleSet services.RoleSet, app types.Application) *authz.Context {
 	t.Helper()
+	var err error
 
-	user, err := types.NewUser("ai")
-	require.NoError(t, err)
+	if user == nil {
+		user, err = types.NewUser("ai")
+		require.NoError(t, err)
+	}
 	user.SetRoles(slices.Collect(types.ResourceNames(roleSet)))
 
 	identity := authz.LocalUser{

--- a/lib/srv/mcp/server.go
+++ b/lib/srv/mcp/server.go
@@ -35,6 +35,7 @@ import (
 	"github.com/gravitational/teleport/lib/events"
 	"github.com/gravitational/teleport/lib/observability/metrics"
 	"github.com/gravitational/teleport/lib/services"
+	"github.com/gravitational/teleport/lib/session"
 	appcommon "github.com/gravitational/teleport/lib/srv/app/common"
 	"github.com/gravitational/teleport/lib/utils"
 )
@@ -265,8 +266,17 @@ func (s *Server) makeSessionHandler(ctx context.Context, sessionCtx *SessionCtx)
 }
 
 func (s *Server) getSessionHandlerWithJWT(ctx context.Context, sessionCtx *SessionCtx) (*sessionHandler, error) {
+	key := sessionKey{
+		Username:  sessionCtx.Identity.Username,
+		SessionID: sessionCtx.sessionID,
+	}
 	ttl := min(sessionCtx.Identity.Expires.Sub(s.cfg.clock.Now()), appcommon.MaxSessionChunkDuration)
-	return utils.FnCacheGetWithTTL(ctx, s.sessionCache, sessionCtx.sessionID, ttl, func(ctx context.Context) (*sessionHandler, error) {
+	return utils.FnCacheGetWithTTL(ctx, s.sessionCache, key, ttl, func(ctx context.Context) (*sessionHandler, error) {
 		return s.makeSessionHandler(ctx, sessionCtx)
 	})
+}
+
+type sessionKey struct {
+	Username  string
+	SessionID session.ID
 }


### PR DESCRIPTION
Backport #67397 to branch/v18

## Manual Test Plan

### Test Environment

Teleport with streamable-HTTP app.

### Test Cases
- [x] For streamable-HTTP transport
  - [x] Verify the server responds to a normal initialization flow and tools/list call
  - [x] Verify the server responds to a tools/call for an RBAC-allowed tool