### PR TITLE
[v18] Add interative mode to tsh apps login aws-console

### DIFF
--- a/docs/cspell.json
+++ b/docs/cspell.json
@@ -606,6 +606,7 @@
     "highavailabilitycertmanager",
     "highavailabilitycertmanageraddcommonname",
     "hiro",
+    "hjkl",
     "homelab",
     "homelabs",
     "hostcert",

--- a/docs/pages/enroll-resources/application-access/cloud-apis/aws-console-roles-anywhere.mdx
+++ b/docs/pages/enroll-resources/application-access/cloud-apis/aws-console-roles-anywhere.mdx
@@ -269,6 +269,19 @@ Example AWS CLI commands:
     AWS_PROFILE=example-read-only-access aws s3 ls
 ```
 
+The `tsh apps login` command supports interactive login when you pass
+`--interactive` (or `-T`) or set `TELEPORT_AWS_LOGIN_INTERACTIVE=true`.
+
+```code
+$ tsh apps login aws-console --interactive
+Available AWS roles:
+
+> ExampleReadOnlyAccess [arn:aws:iam::000000000000:role/ExampleReadOnlyAccess]
+  ExampleAdminAccess [arn:aws:iam::000000000001:role/ExampleAdminAccess]
+
+(Use arrows or hjkl to navigate, enter to select, q to quit)
+```
+
 #### Access AWS using AWS CLI
 You can now access all your AWS resources from the command line using the `aws` command line tool.
 

--- a/docs/pages/enroll-resources/application-access/cloud-apis/aws-console.mdx
+++ b/docs/pages/enroll-resources/application-access/cloud-apis/aws-console.mdx
@@ -610,6 +610,19 @@ to AWS, users can access AWS resources through Teleport.
    ExampleReadOnlyAccess` or a full role ARN like
    `arn:aws:iam::0000000000:role/ExampleReadOnlyAccess`.
 
+   The `tsh apps login` command supports interactive login when you pass
+   `--interactive` (or `-T`) or set `TELEPORT_AWS_LOGIN_INTERACTIVE=true`.
+
+   ```code
+   $ tsh apps login aws-console --interactive
+   Available AWS roles:
+
+   > ExampleReadOnlyAccess [arn:aws:iam::000000000000:role/ExampleReadOnlyAccess]
+     ExampleAdminAccess [arn:aws:iam::000000000001:role/ExampleAdminAccess]
+
+   (Use arrows or hjkl to navigate, enter to select, q to quit)
+   ```
+
 1. Now you can use the `tsh aws` command like the native `aws` command-line
    tool:
 

--- a/docs/pages/reference/cli/tsh.mdx
+++ b/docs/pages/reference/cli/tsh.mdx
@@ -99,6 +99,12 @@ Usage:
 $ tsh apps login [<flags>] <app>
 ```
 
+Environment variables:
+
+|Variable|Default|Description|
+|---|---|---|
+|`TELEPORT_AWS_LOGIN_INTERACTIVE`|`false`|Prompt for AWS Roles interactively (--aws-role takes precedence).|
+
 Flags:
 
 |Flag|Default|Description|
@@ -108,6 +114,7 @@ Flags:
 |`--gcp-service-account`|*no default*|(For GCP CLI access only) GCP service account name.|
 |`-q`, `--[no-]quiet`|`false`|Quiet mode|
 |`--target-port`|*no default*|Port to which connections made using this cert should be routed to. Valid only for multi-port TCP apps.|
+|`-T`, `--[no-]interactive`|`false`|Prompt for AWS Roles interactively (--aws-role takes precedence).|
 
 Arguments:
 

--- a/lib/utils/prompt/prompt.go
+++ b/lib/utils/prompt/prompt.go
@@ -1,0 +1,149 @@
+/*
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package prompt
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/gravitational/trace"
+)
+
+// ErrInterrupted is an error when prompt is interrupted with ctrl-c or a signal.
+var ErrInterrupted = errors.New("interrupted")
+
+// ErrCanceled is an error when quit option was selected.
+var ErrCanceled = errors.New("canceled")
+
+// SelectModel is a generic struct that holds the options, context, and state.
+type SelectModel[T any] struct {
+	caption     string
+	options     []T
+	cursor      int
+	selected    *T
+	renderRow   func(T) string
+	quitting    bool
+	interrupted bool
+}
+
+// NewSelectPrompt initializes the generic model with options, a renderer, and a context.
+func NewSelectPrompt[T any](caption string, options []T, renderRow func(T) string) SelectModel[T] {
+	if renderRow == nil {
+		renderRow = func(t T) string {
+			return fmt.Sprintf("%v", t)
+		}
+	}
+
+	return SelectModel[T]{
+		caption:   caption,
+		options:   options,
+		renderRow: renderRow,
+	}
+}
+
+func (m SelectModel[T]) Init() tea.Cmd {
+	return nil
+}
+
+func (m SelectModel[T]) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.KeyMsg:
+		switch msg.String() {
+		case "ctrl+c":
+			m.interrupted = true
+			return m, tea.Quit
+		case "q":
+			m.quitting = true
+			return m, tea.Quit
+		case "up", "k":
+			if m.cursor > 0 {
+				m.cursor--
+			}
+		case "down", "j":
+			if m.cursor < len(m.options)-1 {
+				m.cursor++
+			}
+		case "enter":
+			if len(m.options) > 0 {
+				m.selected = &m.options[m.cursor]
+			}
+			return m, tea.Quit
+		}
+	}
+	return m, nil
+}
+
+func (m SelectModel[T]) View() string {
+	if m.interrupted {
+		return "Prompt interrupted.\n"
+	}
+	if m.quitting {
+		return "Prompt canceled by user.\n"
+	}
+	if m.selected != nil {
+		return fmt.Sprintf("Selected: %s\n", m.renderRow(*m.selected))
+	}
+
+	sb := &strings.Builder{}
+
+	fmt.Fprintf(sb, "%s:\n\n", m.caption)
+
+	for i, option := range m.options {
+		cursor := " "
+		if m.cursor == i {
+			cursor = ">"
+		}
+		fmt.Fprintf(sb, "%s %s\n", cursor, m.renderRow(option))
+	}
+
+	fmt.Fprintln(sb, "\n(Use arrows or hjkl to navigate, enter to select, q to quit)")
+	return sb.String()
+}
+
+// Run helper handles running the program and extracting the generic result.
+func (m SelectModel[T]) Run(ctx context.Context) (T, error) {
+	if err := ctx.Err(); err != nil {
+		return *new(T), trace.Wrap(err)
+	}
+
+	if len(m.options) == 0 {
+		return *new(T), trace.BadParameter("no options provided")
+	}
+
+	p := tea.NewProgram(m, tea.WithContext(ctx))
+	finalModel, err := p.Run()
+	if err != nil {
+		return *new(T), trace.Wrap(err)
+	}
+
+	typedModel := finalModel.(SelectModel[T])
+
+	if typedModel.quitting {
+		return *new(T), trace.Wrap(ErrCanceled)
+	}
+
+	if typedModel.interrupted || typedModel.selected == nil {
+		return *new(T), trace.Wrap(ErrInterrupted)
+	}
+
+	return *typedModel.selected, nil
+}

--- a/lib/utils/prompt/prompt_test.go
+++ b/lib/utils/prompt/prompt_test.go
@@ -1,0 +1,153 @@
+/*
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package prompt_test
+
+import (
+	"context"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport/lib/utils/prompt"
+)
+
+func TestSelectPromptView(t *testing.T) {
+	t.Parallel()
+
+	model := newTestSelectModel()
+
+	require.Equal(t, "Pick a service:\n\n> proxy\n  auth\n  node\n\n(Use arrows or hjkl to navigate, enter to select, q to quit)\n", model.View())
+}
+
+func TestSelectPromptKeyboardSelection(t *testing.T) {
+	t.Parallel()
+
+	model := newTestSelectModel()
+
+	updated, cmd := model.Update(tea.KeyMsg{Type: tea.KeyDown})
+	model = updated.(prompt.SelectModel[string])
+	require.Nil(t, cmd)
+	require.Equal(t, "Pick a service:\n\n  proxy\n> auth\n  node\n\n(Use arrows or hjkl to navigate, enter to select, q to quit)\n", model.View())
+
+	updated, cmd = model.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("j")})
+	model = updated.(prompt.SelectModel[string])
+	require.Nil(t, cmd)
+	require.Equal(t, "Pick a service:\n\n  proxy\n  auth\n> node\n\n(Use arrows or hjkl to navigate, enter to select, q to quit)\n", model.View())
+
+	updated, cmd = model.Update(tea.KeyMsg{Type: tea.KeyDown})
+	model = updated.(prompt.SelectModel[string])
+	require.Nil(t, cmd)
+	require.Equal(t, "Pick a service:\n\n  proxy\n  auth\n> node\n\n(Use arrows or hjkl to navigate, enter to select, q to quit)\n", model.View(), "cursor should stay on the last option")
+
+	updated, cmd = model.Update(tea.KeyMsg{Type: tea.KeyUp})
+	model = updated.(prompt.SelectModel[string])
+	require.Nil(t, cmd)
+	require.Equal(t, "Pick a service:\n\n  proxy\n> auth\n  node\n\n(Use arrows or hjkl to navigate, enter to select, q to quit)\n", model.View())
+
+	updated, cmd = model.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("k")})
+	model = updated.(prompt.SelectModel[string])
+	require.Nil(t, cmd)
+	require.Equal(t, "Pick a service:\n\n> proxy\n  auth\n  node\n\n(Use arrows or hjkl to navigate, enter to select, q to quit)\n", model.View())
+
+	updated, cmd = model.Update(tea.KeyMsg{Type: tea.KeyUp})
+	model = updated.(prompt.SelectModel[string])
+	require.Nil(t, cmd)
+	require.Equal(t, "Pick a service:\n\n> proxy\n  auth\n  node\n\n(Use arrows or hjkl to navigate, enter to select, q to quit)\n", model.View(), "cursor should stay on the first option")
+
+	updated, cmd = model.Update(tea.KeyMsg{Type: tea.KeyDown})
+	model = updated.(prompt.SelectModel[string])
+	require.Nil(t, cmd)
+
+	updated, cmd = model.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	model = updated.(prompt.SelectModel[string])
+	requireQuitCommand(t, cmd)
+	require.Equal(t, "Selected: auth\n", model.View())
+}
+
+func TestSelectPromptKeyboardCancellation(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		key      tea.KeyMsg
+		expected string
+	}{
+		{
+			name:     "q",
+			key:      tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("q")},
+			expected: "Prompt canceled by user.\n",
+		},
+		{
+			name:     "ctrl-c",
+			key:      tea.KeyMsg{Type: tea.KeyCtrlC},
+			expected: "Prompt interrupted.\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			model := newTestSelectModel()
+
+			updated, cmd := model.Update(tt.key)
+			model = updated.(prompt.SelectModel[string])
+
+			requireQuitCommand(t, cmd)
+			require.Equal(t, tt.expected, model.View())
+		})
+	}
+}
+
+func TestSelectPromptContextCancellation(t *testing.T) {
+	t.Parallel()
+
+	t.Run("init has no cancellation command", func(t *testing.T) {
+		t.Parallel()
+
+		model := newTestSelectModel()
+
+		require.Nil(t, model.Init())
+	})
+
+	t.Run("run returns pre-canceled context error", func(t *testing.T) {
+		t.Parallel()
+
+		ctx, cancel := context.WithCancel(t.Context())
+		cancel()
+
+		got, err := newTestSelectModel().Run(ctx)
+		require.ErrorIs(t, err, context.Canceled)
+		require.Empty(t, got)
+	})
+}
+
+func newTestSelectModel() prompt.SelectModel[string] {
+	return prompt.NewSelectPrompt("Pick a service", []string{"proxy", "auth", "node"}, func(option string) string {
+		return option
+	})
+}
+
+func requireQuitCommand(t *testing.T, cmd tea.Cmd) {
+	t.Helper()
+
+	require.NotNil(t, cmd)
+	require.IsType(t, tea.QuitMsg{}, cmd())
+}

--- a/tool/tsh/common/app_aws.go
+++ b/tool/tsh/common/app_aws.go
@@ -40,6 +40,7 @@ import (
 	"github.com/gravitational/teleport/lib/tlsca"
 	awsutils "github.com/gravitational/teleport/lib/utils/aws"
 	logutils "github.com/gravitational/teleport/lib/utils/log"
+	"github.com/gravitational/teleport/lib/utils/prompt"
 )
 
 const (
@@ -223,10 +224,33 @@ func getARNFromFlags(cf *CLIConf, app types.Application, logins []string) (strin
 	// roles are returned.
 	roles := awsutils.FilterAWSRoles(logins, app.GetAWSAccountID())
 
+	if len(roles) == 0 {
+		return "", trace.NotFound("there are no roles configured for the AWS app")
+	}
+
 	if cf.AWSRole == "" {
 		if len(roles) == 1 {
 			logger.InfoContext(cf.Context, "AWS Role is selected by default as it is the only role configured for this AWS app", "role", roles[0].Display)
 			return roles[0].ARN, nil
+		}
+
+		if cf.Interactive {
+			selectPrompt := prompt.NewSelectPrompt(
+				"Available AWS roles",
+				roles,
+				func(role awsutils.Role) string {
+					return fmt.Sprintf("%s \x1b[35m[%s]\x1b[0m", role.Name, role.ARN)
+				},
+			)
+
+			selected, err := selectPrompt.Run(cf.Context)
+			if err != nil {
+				printAWSRoles(cf.Stdout(), roles)
+				return "", trace.Wrap(err)
+			}
+
+			cf.AWSRole = selected.ARN
+			return selected.ARN, nil
 		}
 
 		printAWSRoles(cf.Stdout(), roles)

--- a/tool/tsh/common/app_aws_test.go
+++ b/tool/tsh/common/app_aws_test.go
@@ -163,6 +163,87 @@ func TestAWS(t *testing.T) {
 	require.NoError(t, err)
 }
 
+const (
+	promptAlphaRoleARN = "arn:aws:iam::123456789012:role/Alpha"
+	promptBetaRoleARN  = "arn:aws:iam::123456789012:role/Beta"
+)
+
+func promptTestAWSApp(t *testing.T) types.Application {
+	t.Helper()
+
+	app, err := types.NewAppV3(types.Metadata{Name: "aws-test"}, types.AppSpecV3{
+		URI: constants.AWSConsoleURL,
+	})
+	require.NoError(t, err)
+	return app
+}
+
+func TestGetARNFromFlagsInteractive(t *testing.T) {
+	t.Parallel()
+
+	testRoleARNs := []string{
+		promptAlphaRoleARN,
+		promptBetaRoleARN,
+	}
+
+	tests := []struct {
+		name          string
+		logins        []string
+		cancelContext bool
+		wantARN       string
+		wantAWSRole   string
+		wantPrompt    bool
+		wantErr       error
+	}{
+		{
+			name:          "multiple roles prompts interactively",
+			logins:        testRoleARNs,
+			cancelContext: true,
+			wantPrompt:    true,
+			wantErr:       context.Canceled,
+		},
+		{
+			name:    "single role skips prompt",
+			logins:  []string{promptAlphaRoleARN},
+			wantARN: promptAlphaRoleARN,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx := t.Context()
+			if tt.cancelContext {
+				canceledCtx, cancel := context.WithCancel(ctx)
+				cancel()
+				ctx = canceledCtx
+			}
+
+			stdout := new(bytes.Buffer)
+			cf := &CLIConf{
+				Context:        ctx,
+				Interactive:    true,
+				OverrideStdout: stdout,
+			}
+
+			arn, err := getARNFromFlags(cf, promptTestAWSApp(t), tt.logins)
+			if tt.wantErr != nil {
+				require.ErrorIs(t, err, tt.wantErr)
+			} else {
+				require.NoError(t, err)
+			}
+			require.Equal(t, tt.wantARN, arn)
+			require.Equal(t, tt.wantAWSRole, cf.AWSRole)
+			if tt.wantPrompt {
+				require.Contains(t, stdout.String(), "Available AWS roles:")
+				return
+			}
+			require.NotContains(t, stdout.String(), "Select AWS role number")
+		})
+	}
+}
+
 func TestAWSRolesAnywhereBasedAccess(t *testing.T) {
 	ctx := context.Background()
 

--- a/tool/tsh/common/tsh.go
+++ b/tool/tsh/common/tsh.go
@@ -829,6 +829,7 @@ const (
 	awsRegionEnvVar           = "TELEPORT_AWS_REGION"
 	awsKeystoreEnvVar         = "TELEPORT_AWS_KEYSTORE"
 	awsWorkgroupEnvVar        = "TELEPORT_AWS_WORKGROUP"
+	awsLoginInteractive       = "TELEPORT_AWS_LOGIN_INTERACTIVE"
 	proxyKubeConfigEnvVar     = "TELEPORT_KUBECONFIG"
 	noResumeEnvVar            = "TELEPORT_NO_RESUME"
 	requestModeEnvVar         = "TELEPORT_REQUEST_MODE"
@@ -1092,6 +1093,7 @@ func Run(ctx context.Context, args []string, opts ...CliOption) error {
 	appLogin.Flag("azure-identity", "(For Azure CLI access only) Azure managed identity name.").StringVar(&cf.AzureIdentity)
 	appLogin.Flag("gcp-service-account", "(For GCP CLI access only) GCP service account name.").StringVar(&cf.GCPServiceAccount)
 	appLogin.Flag("target-port", "Port to which connections made using this cert should be routed to. Valid only for multi-port TCP apps.").Uint16Var(&cf.TargetPort)
+	appLogin.Flag("interactive", "Prompt for AWS Roles interactively (--aws-role takes precedence).").Short('T').Envar(awsLoginInteractive).BoolVar(&cf.Interactive)
 	appLogin.Flag("quiet", "Quiet mode").Short('q').BoolVar(&cf.Quiet)
 	appLogout := apps.Command("logout", "Remove app certificate.")
 	appLogout.Arg("app", "App to remove credentials for.").StringVar(&cf.AppName)


### PR DESCRIPTION
Issue: https://github.com/gravitational/customer-sensitive-requests/issues/657 -> Interactive aws console login.
Original PR: https://github.com/gravitational/teleport/pull/67755

## Changes comparing to v19 (master):
Unlike v19, the `--interactive` flag in `tsh app login <aws-console>` command is not the default and interactive mode won't be activated unless the flag is specified.

So the changes include:
1. change interactive flag default to false
1. update unit tests.
1. update documentation (stating that interactive mode is enabled with --interactive flag vs information how to disable the default behaviour).

## What

Add interactive interface to the `tsh apps login aws-console` command. If `--aws-role` flag is not provided, the tsh should fetch the list of the available roles, print a list and take input, like below:
```bash
$ tsh app login aws-console
Available AWS roles:

> example-admin [arn:aws:iam::123456789012:role/example-admin]
  example-readonly [arn:aws:iam::123456789012:role/example-readonly]

(Use arrows or hjkl to navigate, enter to select, q to quit)
```

The only corners is backward compatibility but this can be discussed and hidden behind `--interactive` flag.
The implementation is fairly trivial and won't require TUI 3rd party dependencies.


## Why

Customers using AWS with IAM roles in Teleport roles cannot list these roles without first triggering an error. For Expedia, they are using AWS Roles Anywhere to access Bedrock, as a part of a broader initiative to move their engineering org to AWS behind Teleport.

Changelog: Add `--interactive` flag to prompt for role from stdin if `--interactive` flag is provided.

## Manual Test Plan

request for `aws-console` should be filed and approved before testing.

- [x] test interactive workflow
```
$ tsh apps login aws-console --interactive
Available AWS roles:

> example-admin [arn:aws:iam::123456789012:role/example-admin]
  example-readonly [arn:aws:iam::123456789012:role/example-readonly]

(Use arrows or hjkl to navigate, enter to select, q to quit)
```
- [x] Manual cancel (ctrl-c):
```bash
$ tsh apps login aws-console
Prompt interrupted.
Available AWS roles:
Role Name        Role ARN
---------------- -----------------------------------------------
example-admin    arn:aws:iam::123456789012:role/example-admin
example-readonly arn:aws:iam::123456789012:role/example-readonly

ERROR: interrupted
```
- [x] Make sure the the old behaviour exists unless the interactive flag is provided
```bash
$ tsh apps login aws-console
Available AWS roles:
Role Name        Role ARN
---------------- -----------------------------------------------
example-admin    arn:aws:iam::123456789012:role/example-admin
example-readonly arn:aws:iam::123456789012:role/example-readonly

ERROR: --aws-role flag is required
```

### Test Environment

- Teleport instance with configured aws-console app.
```yaml
app_service:
  enabled: "yes"
  apps:
    - name: "aws-console"
      description: "Local Teleport Access to AWS Management Console"
      uri: "https://console.aws.amazon.com"
      aws:
        external_id: ""
```
- The active user should aws role assigned. Eg. something like below:

```yaml
kind: role
version: v7
metadata:
  name: aws-teleport-access
  labels:
    team: platform
spec:
  allow:
    app_labels:
      aws-account:
      '*': '*'
    aws_role_arns:
    - arn:aws:iam::123456789012:role/example-admin
    - arn:aws:iam::123456789012:role/example-readonly
    request:
      roles:
      - aws-teleport-access
      search_as_roles:
      - aws-teleport-access
```


### Test Cases

1. Test input range or invalid input, invalid input should report an error and cycle back to a prompt.


There are also some unit tests that test the interactive mode.