### PR TITLE
app access: disambiguate the web launch path

### DIFF
--- a/lib/web/apiserver_test.go
+++ b/lib/web/apiserver_test.go
@@ -5153,6 +5153,77 @@ func (l *listenerAddrOverride) Accept() (net.Conn, error) {
 	return &connRemoteAddrOverride{Conn: conn}, nil
 }
 
+func TestCreateAppSessionRBACAwareWebUI(t *testing.T) {
+	s := newWebSuite(t)
+
+	const sharedPublicAddr = "dup.example.com"
+
+	for _, appName := range []string{"dup-app-1", "dup-app-2"} {
+		a, err := types.NewAppV3(
+			types.Metadata{
+				Name:   appName,
+				Labels: map[string]string{"app_name": appName},
+			},
+			types.AppSpecV3{
+				URI:        "http://127.0.0.1:8080",
+				PublicAddr: sharedPublicAddr,
+			})
+		require.NoError(t, err)
+
+		server, err := types.NewAppServerV3FromApp(a, "host-"+appName, uuid.New().String())
+		require.NoError(t, err)
+
+		_, err = s.server.Auth().UpsertApplicationServer(s.ctx, server)
+		require.NoError(t, err)
+	}
+
+	// The default user role grants wildcard app access, so deny dup-app-2 to
+	// ensure the user can reach dup-app-1 but not dup-app-2.
+	denyRole, err := types.NewRole("deny-dup-app-2-by-cluster", types.RoleSpecV6{
+		Deny: types.RoleConditions{
+			AppLabels: types.Labels{"app_name": []string{"dup-app-2"}},
+		},
+	})
+	require.NoError(t, err)
+	_, err = s.server.Auth().UpsertRole(s.ctx, denyRole)
+	require.NoError(t, err)
+
+	pack := s.authPack(t, "bar@example.com", denyRole.GetName())
+
+	// The web launcher used to send cluster name + public address (but no app name).
+	// When multiple apps share a public address, the session must be pinned to the app
+	// the user can access.
+	//
+	// Note: The web launcher does attach the app name nowadays, but this test serves
+	// as a helpful check for both regressions and backwards compatibility.
+	endpoint := pack.clt.Endpoint("webapi", "sessions", "app")
+	for range 20 {
+		resp, err := pack.clt.PostJSON(s.ctx, endpoint, &CreateAppSessionRequest{
+			ResolveAppParams: ResolveAppParams{
+				ClusterName: s.server.ClusterName(),
+				PublicAddr:  sharedPublicAddr,
+			},
+		})
+		require.NoError(t, err)
+
+		var response CreateAppSessionResponse
+		require.NoError(t, json.Unmarshal(resp.Bytes(), &response))
+
+		sess, err := s.server.Auth().GetAppSession(s.ctx, types.GetAppSessionRequest{
+			SessionID: response.CookieValue,
+		})
+		require.NoError(t, err)
+
+		certificate, err := tlsca.ParseCertificatePEM(sess.GetTLSCert())
+		require.NoError(t, err)
+		identity, err := tlsca.FromSubject(certificate.Subject, certificate.NotAfter)
+		require.NoError(t, err)
+
+		require.Equal(t, "dup-app-1", identity.RouteToApp.Name)
+		require.Equal(t, sharedPublicAddr, identity.RouteToApp.PublicAddr)
+	}
+}
+
 // TODO(tross): move this functionality into modulestest.Modules
 // once modulestest.SetTestModules is removed.
 type safeModules struct {

--- a/lib/web/app/auth.go
+++ b/lib/web/app/auth.go
@@ -113,6 +113,7 @@ func (h *Handler) startAppAuthExchange(w http.ResponseWriter, r *http.Request, p
 			clusterName: q.Get("cluster"),
 			publicAddr:  q.Get("addr"),
 			arn:         q.Get("arn"),
+			appName:     q.Get("app_name"),
 			path:        q.Get("path"),
 			// The state token concats both the secret token and the cookie ID.
 			// The server will break this token to its individual parts:

--- a/lib/web/app/handler.go
+++ b/lib/web/app/handler.go
@@ -772,6 +772,9 @@ func makeAppRedirectURL(r *http.Request, proxyPublicAddr, addr string, req launc
 		}
 		v.Add("path", req.path)
 		v.Add("required-apps", req.requiredAppFQDNs)
+		if req.appName != "" {
+			v.Add("app_name", req.appName)
+		}
 		u.RawQuery = v.Encode()
 
 		urlPath := []string{"web", "launch", addr}

--- a/lib/web/app/handler_test.go
+++ b/lib/web/app/handler_test.go
@@ -958,6 +958,16 @@ func TestMakeAppRedirectURL(t *testing.T) {
 			expectedURL: "https://proxy.com/web/launch/grafana.localhost/im-a-cluster-name/grafana.localhost/arn:aws:iam::123456789012:role%2Frole-name?path=%2Ffoo%2Fbar%3Fqux%3Dqex&required-apps=api.example.com%2Cgrafana.localhost&state=abc123",
 		},
 		{
+			name: "OK - with clusterId, publicAddr, and appName",
+			launderURLParams: launcherURLParams{
+				stateToken:  "abc123",
+				clusterName: "im-a-cluster-name",
+				publicAddr:  "grafana.localhost",
+				appName:     "dup-app-1",
+			},
+			expectedURL: "https://proxy.com/web/launch/grafana.localhost/im-a-cluster-name/grafana.localhost?app_name=dup-app-1&path=&required-apps=&state=abc123",
+		},
+		{
 			name: "OK - with ARN containing multi-level path",
 			launderURLParams: launcherURLParams{
 				stateToken:  "abc123",

--- a/lib/web/app/match.go
+++ b/lib/web/app/match.go
@@ -115,7 +115,7 @@ func ResolveFQDN(
 	// Try and match FQDN to public address of application within cluster.
 	servers, err := MatchUnshuffled(ctx, clusterClient, MatchPublicAddr(fqdn))
 	if err == nil && len(servers) > 0 {
-		return pickAppServer(servers, canAccess), localClusterName, nil
+		return PickAppServer(servers, canAccess), localClusterName, nil
 	}
 
 	proxyPublicAddr := utils.FindMatchingProxyDNS(fqdn, proxyDNSNames)
@@ -133,19 +133,19 @@ func ResolveFQDN(
 	for _, clusterClient := range clusterClients {
 		servers, err = MatchUnshuffled(ctx, clusterClient, MatchName(appName))
 		if err == nil && len(servers) > 0 {
-			return pickAppServer(servers, canAccess), clusterClient.GetName(), nil
+			return PickAppServer(servers, canAccess), clusterClient.GetName(), nil
 		}
 	}
 
 	return nil, "", trace.NotFound("failed to resolve %v to any application within any cluster", fqdn)
 }
 
-// pickAppServer chooses one app server from a set of matches. When canAccess is
+// PickAppServer chooses one app server from a set of matches. When canAccess is
 // provided it prefers servers the user is allowed to access.
 //
 // If no apps are accessible or canAccess is nil it falls back to a random match,
 // leaving the final access decision to the app_service.
-func pickAppServer(servers []types.AppServer, canAccess func(types.Application) bool) types.AppServer {
+func PickAppServer(servers []types.AppServer, canAccess func(types.Application) bool) types.AppServer {
 	if canAccess != nil {
 		accessible := make([]types.AppServer, 0, len(servers))
 		for _, s := range servers {

--- a/lib/web/app/match_test.go
+++ b/lib/web/app/match_test.go
@@ -154,17 +154,17 @@ func TestPickAppServer(t *testing.T) {
 
 	t.Run("prefers the accessible app", func(t *testing.T) {
 		for range 100 {
-			require.Equal(t, "dup-app-1", pickAppServer(servers, onlyApp1).GetApp().GetName())
+			require.Equal(t, "dup-app-1", PickAppServer(servers, onlyApp1).GetApp().GetName())
 		}
 	})
 
 	t.Run("nil filter picks among all (legacy behavior)", func(t *testing.T) {
-		got := pickAppServer(servers, nil)
+		got := PickAppServer(servers, nil)
 		require.Contains(t, []string{"dup-app-1", "dup-app-2"}, got.GetApp().GetName())
 	})
 
 	t.Run("no accessible match falls back to all", func(t *testing.T) {
-		got := pickAppServer(servers, none)
+		got := PickAppServer(servers, none)
 		require.NotNil(t, got)
 		require.Contains(t, []string{"dup-app-1", "dup-app-2"}, got.GetApp().GetName())
 	})

--- a/lib/web/app/middleware.go
+++ b/lib/web/app/middleware.go
@@ -167,6 +167,10 @@ type launcherURLParams struct {
 	publicAddr string
 	// arn is the AWS role name, defined only when accessing AWS management console.
 	arn string
+	// appName is the name of this application. It disambiguates apps that share a
+	// public address so the session is pinned to the app the user selected, rather
+	// than resolved at random.
+	appName string
 	// stateToken if defined means initiating an app access auth exchange.
 	stateToken string
 	// path is the application URL path.

--- a/lib/web/apps.go
+++ b/lib/web/apps.go
@@ -24,7 +24,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"math/rand/v2"
 	"net/http"
 
 	"github.com/gravitational/trace"
@@ -250,10 +249,13 @@ func (h *Handler) resolveApp(ctx context.Context, scx *SessionContext, params Re
 	// application that the caller is requesting. If it does not, do best effort FQDN resolution.
 	switch {
 	case params.ClusterName != "" && (params.AppName != "" || params.PublicAddr != ""):
-		server, appClusterName, err = h.resolveAppForCluster(ctx, proxy, params.AppName, params.PublicAddr, params.ClusterName)
+		// Multiple apps can have the same public address, so filter based
+		// on those the user has access to.
+		var canAccess func(types.Application) bool
+		if canAccess, err = h.userAppAccessFilter(ctx, scx); err == nil {
+			server, appClusterName, err = h.resolveAppForCluster(ctx, proxy, params.AppName, params.PublicAddr, params.ClusterName, canAccess)
+		}
 	case params.FQDNHint != "":
-		// Multiple apps can have the same FQDN - prefer those the user
-		// can actually access.
 		var canAccess func(types.Application) bool
 		if canAccess, err = h.userAppAccessFilter(ctx, scx); err == nil {
 			server, appClusterName, err = app.ResolveFQDN(ctx, proxy, h.auth.clusterName, h.proxyDNSNames(), params.FQDNHint, canAccess)
@@ -310,6 +312,7 @@ func (h *Handler) resolveAppForCluster(
 	ctx context.Context,
 	clusterGetter reversetunnelclient.ClusterGetter,
 	appName, publicAddr, clusterName string,
+	canAccess func(types.Application) bool,
 ) (types.AppServer, string, error) {
 	clusterClient, err := clusterGetter.Cluster(ctx, clusterName)
 	if err != nil {
@@ -325,7 +328,7 @@ func (h *Handler) resolveAppForCluster(
 		return nil, "", trace.NotFound("failed to match applications with addr %s and name %q", publicAddr, appName)
 	}
 
-	return servers[rand.N(len(servers))], clusterName, nil
+	return app.PickAppServer(servers, canAccess), clusterName, nil
 }
 
 // proxyDNSName is a DNS name the HTTP proxy is available at, where

--- a/web/packages/teleport/src/AppLauncher/AppLauncher.test.tsx
+++ b/web/packages/teleport/src/AppLauncher/AppLauncher.test.tsx
@@ -59,6 +59,12 @@ const launcherPathTestCases: {
       'x-teleport-auth?path=%2Ffoo%2Fbar&cluster=some-cluster-id&addr=some-public-addr&arn=arn%3A%3A123%2Fname',
   },
   {
+    name: 'no state forwards app_name to the auth exchange',
+    path: '/some-cluster-id/some-public-addr?app_name=dup-app-1',
+    expectedPath:
+      'x-teleport-auth?cluster=some-cluster-id&addr=some-public-addr&app_name=dup-app-1',
+  },
+  {
     name: 'with state',
     path: '?state=ABC',
     expectedPath:
@@ -361,6 +367,39 @@ describe('fqdn is matched', () => {
       expect(screen.queryByText(/access denied/i)).not.toBeInTheDocument();
     }
   );
+
+  // Ensure that we send app_name as a query param, which is used
+  // to disambiguate when multiple apps share the same public addr.
+  test('forwards app_name query param to createAppSession', async () => {
+    jest.spyOn(service, 'getAppDetails').mockResolvedValue({
+      fqdn: 'dup.test.teleport',
+    });
+    jest.spyOn(service, 'createAppSession');
+    const windowLocation = {
+      replace: jest.fn(),
+    };
+
+    render(
+      <MemoryRouter
+        initialEntries={[
+          '/web/launch/dup.test.teleport/test.teleport/dup.test.teleport?state=ABC&app_name=dup-app-1',
+        ]}
+      >
+        <Routes>
+          <Route
+            path={appLauncherRoute}
+            element={<AppLauncher windowLocation={windowLocation} />}
+          />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    await waitFor(() => {
+      expect(service.createAppSession).toHaveBeenCalledWith(
+        expect.objectContaining({ app_name: 'dup-app-1' })
+      );
+    });
+  });
 
   test('not matching FQDN throws error', async () => {
     jest.spyOn(service, 'getAppDetails').mockResolvedValue({

--- a/web/packages/teleport/src/AppLauncher/AppLauncher.tsx
+++ b/web/packages/teleport/src/AppLauncher/AppLauncher.tsx
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { useLocation, useParams } from 'react-router';
 
 import { Flex, Indicator } from 'design';
@@ -142,6 +142,7 @@ export function AppLauncher({
             path,
             params,
             requiredApps,
+            appName: queryParams.get('app_name') || undefined,
           });
           // Pass the fragment to the second leg via the URL hash
           // so it stays client-side. Skip on a required-apps chain
@@ -168,6 +169,8 @@ export function AppLauncher({
           fqdn: params.fqdn,
           cluster_name: params.clusterId,
           public_addr: params.publicAddr,
+          // When the param is absent, return undefined, not the null that get() returns.
+          app_name: queryParams.get('app_name') || undefined,
           arn: params.arn,
           mfaResponse: await mfa.getChallengeResponse(),
         };
@@ -306,6 +309,7 @@ function getNewAuthExchangeUrl({
   params,
   path,
   requiredApps,
+  appName,
 }: {
   fqdn: string;
   port: string;
@@ -323,6 +327,7 @@ function getNewAuthExchangeUrl({
   // only builds the path and query parts.
   path: string;
   requiredApps: string[];
+  appName?: string;
 }) {
   const url = getXTeleportAuthUrl({ fqdn, port });
 
@@ -349,6 +354,9 @@ function getNewAuthExchangeUrl({
   }
   if (params.arn) {
     url.searchParams.set('arn', params.arn);
+  }
+  if (appName) {
+    url.searchParams.set('app_name', appName);
   }
 
   return url;

--- a/web/packages/teleport/src/config.ts
+++ b/web/packages/teleport/src/config.ts
@@ -2061,9 +2061,13 @@ export interface UrlAppParams {
 
 export interface CreateAppSessionParams {
   fqdn: string;
-  // This API requires cluster_name and public_addr with underscores.
+  // This API requires cluster_name, public_addr and app_name with underscores.
   cluster_name?: string;
   public_addr?: string;
+  // app_name disambiguates apps that share a public address. The launcher knows
+  // which app was clicked, so it sends the name to keep the proxy from resolving
+  // the shared address to a different app.
+  app_name?: string;
   arn?: string;
   mfaResponse?: MfaChallengeResponse;
 }

--- a/web/packages/teleport/src/services/apps/apps.test.ts
+++ b/web/packages/teleport/src/services/apps/apps.test.ts
@@ -41,7 +41,7 @@ test('correct formatting of apps fetch response', async () => {
         fqdn: 'app-name.example.com',
         friendlyName: '',
         launchUrl:
-          '/web/launch/app-name.example.com/cluster-id/app-name.example.com',
+          '/web/launch/app-name.example.com/cluster-id/app-name.example.com?app_name=app-name',
         awsRoles: [],
         awsConsole: false,
         isCloud: false,
@@ -215,7 +215,8 @@ test('correct formatting of apps fetch response', async () => {
         clusterId: 'cluster-id',
         fqdn: 'app-with-other-proxy-addr.localhost',
         friendlyName: '',
-        launchUrl: '/web/launch/app-with-other-proxy-addr.localhost',
+        launchUrl:
+          '/web/launch/app-with-other-proxy-addr.localhost?app_name=app-with-other-proxy-addr',
         awsRoles: [],
         awsConsole: false,
         isCloud: false,

--- a/web/packages/teleport/src/services/apps/makeApps.ts
+++ b/web/packages/teleport/src/services/apps/makeApps.ts
@@ -30,24 +30,31 @@ function getLaunchUrl({
   clusterId,
   publicAddr,
   useAnyProxyPublicAddr,
+  name,
 }: {
   fqdn: string;
   clusterId: string;
   useAnyProxyPublicAddr: boolean;
   publicAddr: string;
+  name: string;
 }) {
+  let route = '';
   if (useAnyProxyPublicAddr) {
     if (!fqdn) {
       return '';
     }
-    return cfg.getAppLauncherRoute({ fqdn });
+    route = cfg.getAppLauncherRoute({ fqdn });
+  } else if (publicAddr && clusterId && fqdn) {
+    route = cfg.getAppLauncherRoute({ fqdn, publicAddr, clusterId });
   }
 
-  if (publicAddr && clusterId && fqdn) {
-    return cfg.getAppLauncherRoute({ fqdn, publicAddr, clusterId });
+  // Inlcude the app name so the launcher can disambiguate apps that share a
+  // public address.
+  if (route && name) {
+    route += `?app_name=${encodeURIComponent(name)}`;
   }
 
-  return '';
+  return route;
 }
 
 export default function makeApp(json: any): App {
@@ -77,6 +84,7 @@ export default function makeApp(json: any): App {
     clusterId,
     publicAddr,
     useAnyProxyPublicAddr,
+    name,
   });
   const id = `${clusterId}-${name}-${publicAddr || uri}`;
   const labels = json.labels || [];


### PR DESCRIPTION
This is a follow up to #67519, which disambiguates apps sharing a common public address by name and ensures that the app selection process is RBAC aware in order to avoid routing users to an app they don't have access to.

That PR missed the path where a user clicks the "launch" button in the web UI.

Close the gap by both:
- passing the clicked app_name to the proxy via query param
- making sure that the app selection process is RBAC aware in this code path as well


Note: no changelog because this will be included in the backport at #67947.


## Manual Test Plan

### Test Environment

Local cluster running with this change.

### Test Cases

Create two different apps with the same public addr.
Set up RBAC such that your user has access to only one of these apps.

- [x] Log in, find the app in the web UI, and click launch. Repeat the process 15-20 times. Verify that you always see the app response and that you never see a "not found" error (which would indicate that you were routed to the app you don't have access to).
