### PR TITLE
[v18] msgraphtest: monkeypatch user and group delta endpoint

### DIFF
--- a/lib/msgraph/msgraphtest/msgraphtest.go
+++ b/lib/msgraph/msgraphtest/msgraphtest.go
@@ -39,6 +39,11 @@ type Server struct {
 	mu        sync.RWMutex
 	TLSServer *httptest.Server
 	Storage   *Storage
+
+	MonkeyPatch struct {
+		HandleListUsersDelta  func(w http.ResponseWriter, r *http.Request)
+		HandleListGroupsDelta func(w http.ResponseWriter, r *http.Request)
+	}
 }
 
 // ServerOption is a custom opt for [NewServer].
@@ -103,6 +108,16 @@ func (s *Server) handleListUsers(w http.ResponseWriter, r *http.Request) {
 // increments delta token counter by one and responds with the
 // new delta token.
 func (s *Server) handleListUsersDelta(w http.ResponseWriter, r *http.Request) {
+	if s.MonkeyPatch.HandleListUsersDelta != nil {
+		s.MonkeyPatch.HandleListUsersDelta(w, r)
+		return
+	}
+
+	s.ListUsersDelta(w, r)
+}
+
+// ListGroupsDelta lists users delta diff.
+func (s *Server) ListUsersDelta(w http.ResponseWriter, r *http.Request) {
 	currentKey := 0
 	isLatest := false
 	users := make([]models.ListUsersDeltaResponse, 0)
@@ -110,6 +125,7 @@ func (s *Server) handleListUsersDelta(w http.ResponseWriter, r *http.Request) {
 	switch token {
 	case "latest":
 		// latest request is the starting point.
+		s.Storage.UsersDelta = make(map[int][]models.ListUsersDeltaResponse)
 		isLatest = true
 	default:
 		i, err := parseToken(token)
@@ -157,6 +173,15 @@ func (s *Server) handleListGroups(w http.ResponseWriter, r *http.Request) {
 // increments delta token counter by one and responds with the
 // new delta token.
 func (s *Server) handleListGroupsDelta(w http.ResponseWriter, r *http.Request) {
+	if s.MonkeyPatch.HandleListGroupsDelta != nil {
+		s.MonkeyPatch.HandleListGroupsDelta(w, r)
+		return
+	}
+	s.ListGroupsDelta(w, r)
+}
+
+// ListGroupsDelta lists groups delta diff.
+func (s *Server) ListGroupsDelta(w http.ResponseWriter, r *http.Request) {
 	currentKey := 0
 	isLatest := false
 	groups := make([]models.ListGroupsDeltaResponse, 0)
@@ -164,6 +189,7 @@ func (s *Server) handleListGroupsDelta(w http.ResponseWriter, r *http.Request) {
 	switch token {
 	case "latest":
 		// latest request is the starting point.
+		s.Storage.GroupsDelta = make(map[int][]models.ListGroupsDeltaResponse)
 		isLatest = true
 	default:
 		i, err := parseToken(token)

--- a/lib/msgraph/msgraphtest/msgraphtest.go
+++ b/lib/msgraph/msgraphtest/msgraphtest.go
@@ -116,7 +116,7 @@ func (s *Server) handleListUsersDelta(w http.ResponseWriter, r *http.Request) {
 	s.ListUsersDelta(w, r)
 }
 
-// ListGroupsDelta lists users delta diff.
+// ListUsersDelta lists users delta diff.
 func (s *Server) ListUsersDelta(w http.ResponseWriter, r *http.Request) {
 	currentKey := 0
 	isLatest := false
@@ -125,7 +125,6 @@ func (s *Server) ListUsersDelta(w http.ResponseWriter, r *http.Request) {
 	switch token {
 	case "latest":
 		// latest request is the starting point.
-		s.Storage.UsersDelta = make(map[int][]models.ListUsersDeltaResponse)
 		isLatest = true
 	default:
 		i, err := parseToken(token)
@@ -137,7 +136,9 @@ func (s *Server) ListUsersDelta(w http.ResponseWriter, r *http.Request) {
 	}
 
 	s.mu.Lock()
-	if !isLatest {
+	if isLatest {
+		s.Storage.UsersDelta = make(map[int][]models.ListUsersDeltaResponse)
+	} else {
 		users = append(users, s.Storage.UsersDelta[currentKey]...)
 	}
 	currentKey++
@@ -189,7 +190,6 @@ func (s *Server) ListGroupsDelta(w http.ResponseWriter, r *http.Request) {
 	switch token {
 	case "latest":
 		// latest request is the starting point.
-		s.Storage.GroupsDelta = make(map[int][]models.ListGroupsDeltaResponse)
 		isLatest = true
 	default:
 		i, err := parseToken(token)
@@ -201,7 +201,9 @@ func (s *Server) ListGroupsDelta(w http.ResponseWriter, r *http.Request) {
 	}
 
 	s.mu.Lock()
-	if !isLatest {
+	if isLatest {
+		s.Storage.GroupsDelta = make(map[int][]models.ListGroupsDeltaResponse)
+	} else {
 		groups = append(groups, s.Storage.GroupsDelta[currentKey]...)
 	}
 	currentKey++

--- a/lib/msgraph/msgraphtest/msgraphtest.go
+++ b/lib/msgraph/msgraphtest/msgraphtest.go
@@ -40,9 +40,10 @@ type Server struct {
 	TLSServer *httptest.Server
 	Storage   *Storage
 
-	MonkeyPatch struct {
-		HandleListUsersDelta  func(w http.ResponseWriter, r *http.Request)
-		HandleListGroupsDelta func(w http.ResponseWriter, r *http.Request)
+	monkeyPatchMu sync.RWMutex
+	monkeyPatch   struct {
+		handleListUsersDelta  func(w http.ResponseWriter, r *http.Request)
+		handleListGroupsDelta func(w http.ResponseWriter, r *http.Request)
 	}
 }
 
@@ -88,6 +89,20 @@ func (s *Server) Handler() http.Handler {
 	return r
 }
 
+// SetHandleListUsersDelta monkey patches user delta API handler.
+func (s *Server) SetHandleListUsersDelta(fn func(w http.ResponseWriter, r *http.Request)) {
+	s.monkeyPatchMu.Lock()
+	defer s.monkeyPatchMu.Unlock()
+	s.monkeyPatch.handleListUsersDelta = fn
+}
+
+// SetHandleListGroupsDelta monkey patches group delta API handler.
+func (s *Server) SetHandleListGroupsDelta(fn func(w http.ResponseWriter, r *http.Request)) {
+	s.monkeyPatchMu.Lock()
+	defer s.monkeyPatchMu.Unlock()
+	s.monkeyPatch.handleListGroupsDelta = fn
+}
+
 func (s *Server) handleListUsers(w http.ResponseWriter, r *http.Request) {
 	s.mu.RLock()
 	users := make([]*models.User, 0, len(s.Storage.Users))
@@ -108,8 +123,12 @@ func (s *Server) handleListUsers(w http.ResponseWriter, r *http.Request) {
 // increments delta token counter by one and responds with the
 // new delta token.
 func (s *Server) handleListUsersDelta(w http.ResponseWriter, r *http.Request) {
-	if s.MonkeyPatch.HandleListUsersDelta != nil {
-		s.MonkeyPatch.HandleListUsersDelta(w, r)
+	s.monkeyPatchMu.RLock()
+	fn := s.monkeyPatch.handleListUsersDelta
+	s.monkeyPatchMu.RUnlock()
+
+	if fn != nil {
+		fn(w, r)
 		return
 	}
 
@@ -174,10 +193,15 @@ func (s *Server) handleListGroups(w http.ResponseWriter, r *http.Request) {
 // increments delta token counter by one and responds with the
 // new delta token.
 func (s *Server) handleListGroupsDelta(w http.ResponseWriter, r *http.Request) {
-	if s.MonkeyPatch.HandleListGroupsDelta != nil {
-		s.MonkeyPatch.HandleListGroupsDelta(w, r)
+	s.monkeyPatchMu.RLock()
+	fn := s.monkeyPatch.handleListGroupsDelta
+	s.monkeyPatchMu.RUnlock()
+
+	if fn != nil {
+		fn(w, r)
 		return
 	}
+
 	s.ListGroupsDelta(w, r)
 }
 


### PR DESCRIPTION
Backports https://github.com/gravitational/teleport/pull/67980 to branch/v18

`msgraphtest` implements a fake Microsoft Graph API used in integration tests for Entra ID plugin. 

This PR adds monkey patch methods so the API response can be customized in test. 

Used in `e` PR https://github.com/gravitational/teleport.e/pull/8984
