### PR TITLE
Verify client version on agent reconnect

### DIFF
--- a/integration/joinversion_test.go
+++ b/integration/joinversion_test.go
@@ -1,0 +1,132 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package integration
+
+import (
+	"bytes"
+	"fmt"
+	"log/slog"
+	"path/filepath"
+	"testing"
+
+	"github.com/coreos/go-semver/semver"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport"
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/integration/helpers"
+	"github.com/gravitational/teleport/lib/auth/state"
+	"github.com/gravitational/teleport/lib/join/joinclient"
+	"github.com/gravitational/teleport/lib/service/servicecfg"
+	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/log/logtest"
+)
+
+// TestJoinClientVersionCheck exercises the client-side minimum version check in
+// joinclient.joinViaProxy against a real proxy.
+func TestJoinClientVersionCheck(t *testing.T) {
+	testDir := t.TempDir()
+
+	cfg := helpers.InstanceConfig{
+		ClusterName: "root.example.com",
+		HostID:      uuid.New().String(),
+		NodeName:    Loopback,
+		Logger:      logtest.NewLogger(),
+	}
+	cfg.Listeners = helpers.StandardListenerSetup(t, &cfg.Fds)
+	cluster := helpers.NewInstance(t, cfg)
+
+	clusterCfg := servicecfg.MakeDefaultConfig()
+	clusterCfg.DataDir = filepath.Join(testDir, "cluster")
+	clusterCfg.Auth.Enabled = true
+	clusterCfg.Proxy.Enabled = true
+	clusterCfg.Proxy.DisableWebInterface = true
+	clusterCfg.SSH.Enabled = false
+	clusterCfg.Version = "v3"
+	staticTokens, err := types.NewStaticTokens(types.StaticTokensSpecV2{
+		StaticTokens: []types.ProvisionTokenV1{{
+			Roles: []types.SystemRole{types.RoleInstance},
+			Token: "token",
+		}},
+	})
+	require.NoError(t, err)
+	clusterCfg.Auth.StaticTokens = staticTokens
+
+	require.NoError(t, cluster.CreateEx(t, nil, clusterCfg))
+	require.NoError(t, cluster.Start())
+	defer cluster.StopAll()
+
+	proxyServer := utils.NetAddr{AddrNetwork: "tcp", Addr: cluster.Web}
+
+	tooOldVersion := semver.Version{Major: teleport.MinClientSemVer().Major - 1}.String()
+
+	t.Run("client too old is rejected", func(t *testing.T) {
+		_, err := joinclient.Join(t.Context(), joinclient.JoinParams{
+			Token:       "token",
+			ID:          state.IdentityID{Role: types.RoleInstance},
+			ProxyServer: proxyServer,
+			JoinMethod:  types.JoinMethodToken,
+			Insecure:    true,
+			Testing:     joinclient.JoinTestingParams{TeleportVersion: tooOldVersion},
+		})
+		require.ErrorIs(t, err, joinclient.ErrClientTooOld)
+		// The error must name the client version and that a minimum exists so a
+		// user knows what to upgrade.
+		require.ErrorContains(t, err, "client v"+tooOldVersion)
+		require.ErrorContains(t, err, fmt.Sprintf("minimum v%d", teleport.MinClientSemVer().Major))
+	})
+
+	t.Run("too old client joins when version check is skipped", func(t *testing.T) {
+		// TeleportVersion is not sent over the wire, so this test is just
+		// exercising the client-side version check skipping logic. In this
+		// case, the client will be allowed to join even though TeleportVersion
+		// is below the proxy's advertised minimum because the version the auth
+		// service will check is the api.Version of the client.
+		var logs bytes.Buffer
+		result, err := joinclient.Join(t.Context(), joinclient.JoinParams{
+			Token:            "token",
+			ID:               state.IdentityID{Role: types.RoleInstance},
+			ProxyServer:      proxyServer,
+			JoinMethod:       types.JoinMethodToken,
+			Insecure:         true,
+			SkipVersionCheck: true,
+			Log:              slog.New(slog.NewTextHandler(&logs, &slog.HandlerOptions{Level: slog.LevelWarn})),
+			Testing:          joinclient.JoinTestingParams{TeleportVersion: tooOldVersion},
+		})
+		require.NoError(t, err)
+		require.NotNil(t, result)
+
+		// The bypass must be logged, naming the flag and the client version, so
+		// an operator can see why a too-old client was allowed to connect.
+		output := logs.String()
+		require.Contains(t, output, "--skip-version-check")
+		require.Contains(t, output, "client v"+tooOldVersion)
+	})
+
+	t.Run("current client joins successfully", func(t *testing.T) {
+		result, err := joinclient.Join(t.Context(), joinclient.JoinParams{
+			Token:       "token",
+			ID:          state.IdentityID{Role: types.RoleInstance},
+			ProxyServer: proxyServer,
+			JoinMethod:  types.JoinMethodToken,
+			Insecure:    true,
+		})
+		require.NoError(t, err)
+		require.NotNil(t, result)
+	})
+}

--- a/integration/joinversion_test.go
+++ b/integration/joinversion_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/integration/helpers"
 	"github.com/gravitational/teleport/lib/auth/state"
+	"github.com/gravitational/teleport/lib/clientversion"
 	"github.com/gravitational/teleport/lib/join/joinclient"
 	"github.com/gravitational/teleport/lib/service/servicecfg"
 	"github.com/gravitational/teleport/lib/utils"
@@ -84,7 +85,7 @@ func TestJoinClientVersionCheck(t *testing.T) {
 			Insecure:    true,
 			Testing:     joinclient.JoinTestingParams{TeleportVersion: tooOldVersion},
 		})
-		require.ErrorIs(t, err, joinclient.ErrClientTooOld)
+		require.ErrorIs(t, err, clientversion.ErrClientTooOld)
 		// The error must name the client version and that a minimum exists so a
 		// user knows what to upgrade.
 		require.ErrorContains(t, err, "client v"+tooOldVersion)

--- a/lib/auth/join/join.go
+++ b/lib/auth/join/join.go
@@ -201,6 +201,17 @@ type RegisterParams struct {
 	// Log is the logger to use for emitting log messages.
 	// If not specified, this defaults to the global logger.
 	Log *slog.Logger
+	// SkipVersionCheck bypasses the client-side minimum version check performed
+	// when joining via a proxy.
+	SkipVersionCheck bool
+	// Testing holds parameters that are only set in tests.
+	Testing RegisterTestingParams
+}
+
+// RegisterTestingParams holds fields for [RegisterParams] that are only set in tests.
+type RegisterTestingParams struct {
+	// TeleportVersion is used to control the Teleport version in tests.
+	TeleportVersion string
 }
 
 func (r *RegisterParams) CheckAndSetDefaults() error {

--- a/lib/clientversion/clientversion.go
+++ b/lib/clientversion/clientversion.go
@@ -1,0 +1,125 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package clientversion
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+
+	"github.com/gravitational/teleport"
+	"github.com/gravitational/trace"
+
+	"github.com/gravitational/teleport/api/client/webclient"
+	"github.com/gravitational/teleport/lib/utils"
+)
+
+// ErrClientTooOld indicates this client is older than the cluster's minimum
+// client version.
+var ErrClientTooOld = errors.New("this client is older than the minimum supported version required by the cluster and will not be able to connect until it is upgraded")
+
+// Config configures [Check].
+type Config struct {
+	// ProxyAddr is the address of the proxy.
+	ProxyAddr string
+	// Insecure skips verification of the proxy's certificate.
+	Insecure bool
+	// Skip bypasses the check with a warning when the client is too old.
+	Skip bool
+	// Log is used for the fail-open and skip warnings. It defaults to
+	// [slog.Default] when nil.
+	Log *slog.Logger
+	// Testing is a group of properties that are used in tests.
+	Testing TestingConfig
+}
+
+// TestingConfig holds overrides used only for testing purposes.
+type TestingConfig struct {
+	// ClientVersion is used to override the local version in tests.
+	ClientVersion string
+}
+
+// Check fetches the cluster's advertised minimum client version from the
+// proxy and returns [ErrClientTooOld] when the local version is below it. It is
+// best-effort and fails open, returning nil when the minimum can't be fetched
+// or parsed. It is bypassed with a warning when too old and [Config.Skip] is set.
+func Check(ctx context.Context, cfg Config) error {
+	log := cfg.Log
+	if log == nil {
+		log = slog.Default()
+	}
+
+	resp, err := webclient.Find(&webclient.Config{
+		Context:   ctx,
+		ProxyAddr: cfg.ProxyAddr,
+		Insecure:  cfg.Insecure,
+	})
+	if err != nil {
+		log.WarnContext(ctx,
+			"Could not fetch the cluster's minimum client version from the proxy's web API, skipping check.",
+			"proxy_addr", cfg.ProxyAddr,
+			"error", err,
+		)
+		return nil
+	}
+
+	localVersion := teleport.Version
+	if cfg.Testing.ClientVersion != "" {
+		localVersion = cfg.Testing.ClientVersion
+	}
+
+	err = meetsMinVersion(localVersion, resp.MinClientVersion)
+	if err == nil {
+		return nil
+	}
+	if !errors.Is(err, ErrClientTooOld) {
+		log.WarnContext(ctx,
+			"Could not parse the cluster's minimum client version, skipping check.",
+			"error", err,
+			"min_client_version", resp.MinClientVersion,
+		)
+		return nil
+	}
+	if cfg.Skip {
+		log.WarnContext(ctx,
+			"This client is older than the cluster's minimum supported version, ignoring the version check because --skip-version-check is set.",
+			"error", err,
+		)
+		return nil
+	}
+	return trace.Wrap(err)
+}
+
+// meetsMinVersion returns [ErrClientTooOld] when clientVersion is below
+// minVersion. An empty minimum is treated as no constraint; a malformed minimum
+// returns a parse error that is not [ErrClientTooOld] so callers can fail open.
+func meetsMinVersion(clientVersion, minVersion string) error {
+	if minVersion == "" {
+		return nil
+	}
+	// Stripping the pre-release both validates the advertised minimum and yields a
+	// clean version for the user-facing error message.
+	minWithoutPreRelease, err := utils.VersionWithoutPreRelease(minVersion)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	if !utils.MeetsMinVersion(clientVersion, minVersion) {
+		return fmt.Errorf("%w (client v%s, minimum v%s)", ErrClientTooOld, clientVersion, minWithoutPreRelease)
+	}
+	return nil
+}

--- a/lib/clientversion/clientversion_test.go
+++ b/lib/clientversion/clientversion_test.go
@@ -1,0 +1,197 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package clientversion
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport/api/client/webclient"
+	"github.com/gravitational/teleport/lib/utils/log/logtest"
+)
+
+func requireClientTooOld(t require.TestingT, err error, _ ...any) {
+	require.ErrorIs(t, err, ErrClientTooOld)
+}
+
+func TestMeetsMinVersion(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name          string
+		clientVersion string
+		minVersion    string
+		assertErr     require.ErrorAssertionFunc
+	}{
+		{
+			name:          "client too old",
+			clientVersion: "1.0.0",
+			minVersion:    "2.0.0",
+			assertErr:     requireClientTooOld,
+		},
+		{
+			// The pre-release suffix is stripped from the minimum reported in
+			// the error so the user-facing message shows a clean version.
+			name:          "client too old with pre-release minimum",
+			clientVersion: "1.0.0",
+			minVersion:    "2.0.0-aa",
+			assertErr: func(t require.TestingT, err error, _ ...any) {
+				requireClientTooOld(t, err)
+				require.Contains(t, err.Error(), "minimum v2.0.0)")
+			},
+		},
+		{
+			name:          "pre-release client too old for release minimum",
+			clientVersion: "2.0.0-dev",
+			minVersion:    "2.0.0",
+			assertErr:     requireClientTooOld,
+		},
+		{
+			// The proxy advertises "<major>.0.0-aa" so that pre-release builds
+			// of the minimum version are permitted. This case fails if the
+			// comparison ever switches to the stripped minimum (2.0.0-dev is
+			// below 2.0.0 but above 2.0.0-aa).
+			name:          "pre-release client meets pre-release minimum",
+			clientVersion: "2.0.0-dev",
+			minVersion:    "2.0.0-aa",
+			assertErr:     require.NoError,
+		},
+		{
+			name:          "client meets minimum",
+			clientVersion: "2.0.0",
+			minVersion:    "1.0.0",
+			assertErr:     require.NoError,
+		},
+		{
+			name:          "client exactly meets minimum",
+			clientVersion: "1.0.0",
+			minVersion:    "1.0.0",
+			assertErr:     require.NoError,
+		},
+		{
+			name:          "no minimum advertised",
+			clientVersion: "1.0.0",
+			minVersion:    "",
+			assertErr:     require.NoError,
+		},
+		{
+			name:          "malformed minimum returns parse error",
+			clientVersion: "1.0.0",
+			minVersion:    "not-a-version",
+			assertErr: func(t require.TestingT, err error, _ ...any) {
+				require.Error(t, err)
+				require.NotErrorIs(t, err, ErrClientTooOld)
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			tc.assertErr(t, meetsMinVersion(tc.clientVersion, tc.minVersion))
+		})
+	}
+}
+
+func TestCheck(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name             string
+		clientVersion    string
+		minClientVersion string
+		findError        bool
+		skipVersionCheck bool
+		assertErr        require.ErrorAssertionFunc
+	}{
+		{
+			name:             "too old",
+			clientVersion:    "1.0.0",
+			minClientVersion: "2.0.0",
+			assertErr:        requireClientTooOld,
+		},
+		{
+			name:             "too old but skip version check",
+			clientVersion:    "1.0.0",
+			minClientVersion: "2.0.0",
+			skipVersionCheck: true,
+			assertErr:        require.NoError,
+		},
+		{
+			name:             "meets minimum",
+			clientVersion:    "2.0.0",
+			minClientVersion: "1.0.0",
+			assertErr:        require.NoError,
+		},
+		{
+			name:             "malformed minimum fails open",
+			clientVersion:    "1.0.0",
+			minClientVersion: "not-a-version",
+			assertErr:        require.NoError,
+		},
+		{
+			name:          "find error fails open",
+			clientVersion: "1.0.0",
+			findError:     true,
+			assertErr:     require.NoError,
+		},
+		{
+			// An empty version must resolve to teleport.Version, not "", since
+			// an empty version "meets" any minimum. A minimum above any real
+			// release proves the default kicks in.
+			name:             "empty version defaults to teleport.Version",
+			clientVersion:    "",
+			minClientVersion: "9999.0.0",
+			assertErr:        requireClientTooOld,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if tc.findError {
+					http.Error(w, "unavailable", http.StatusServiceUnavailable)
+					return
+				}
+				assert.Equal(t, "/webapi/find", r.URL.Path)
+				assert.NoError(t, json.NewEncoder(w).Encode(webclient.PingResponse{
+					MinClientVersion: tc.minClientVersion,
+				}))
+			}))
+			t.Cleanup(srv.Close)
+
+			err := Check(t.Context(), Config{
+				ProxyAddr: strings.TrimPrefix(srv.URL, "https://"),
+				Insecure:  true,
+				Skip:      tc.skipVersionCheck,
+				Log:       logtest.NewLogger(),
+				Testing: TestingConfig{
+					ClientVersion: tc.clientVersion,
+				},
+			})
+			tc.assertErr(t, err)
+		})
+	}
+}

--- a/lib/join/joinclient/join.go
+++ b/lib/join/joinclient/join.go
@@ -22,12 +22,15 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 	"errors"
+	"fmt"
 	"os"
 
 	"github.com/gravitational/trace"
 	"golang.org/x/crypto/ssh"
 
+	"github.com/gravitational/teleport/api"
 	"github.com/gravitational/teleport/api/client/proto"
+	"github.com/gravitational/teleport/api/client/webclient"
 	joiningv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/joining/v1"
 	"github.com/gravitational/teleport/api/types"
 	authjoin "github.com/gravitational/teleport/lib/auth/join"
@@ -45,14 +48,16 @@ import (
 	"github.com/gravitational/teleport/lib/join/spacelift"
 	"github.com/gravitational/teleport/lib/join/terraformcloud"
 	kubetoken "github.com/gravitational/teleport/lib/kube/token"
+	"github.com/gravitational/teleport/lib/utils"
 	"github.com/gravitational/teleport/lib/utils/hostid"
 )
 
 type (
-	JoinParams   = authjoin.RegisterParams
-	JoinResult   = authjoin.RegisterResult
-	AzureParams  = authjoin.AzureParams
-	GitlabParams = authjoin.GitlabParams
+	JoinParams        = authjoin.RegisterParams
+	JoinTestingParams = authjoin.RegisterTestingParams
+	JoinResult        = authjoin.RegisterResult
+	AzureParams       = authjoin.AzureParams
+	GitlabParams      = authjoin.GitlabParams
 )
 
 // Join is used to join a cluster. A host or bot calls this with the name of a
@@ -166,7 +171,73 @@ func joinNew(ctx context.Context, params JoinParams) (*JoinResult, error) {
 	return nil, trace.NewAggregate(errs...)
 }
 
+// checkClientVersionSupported returns [ErrClientTooOld] when this client is
+// older than the proxy's advertised minimum client version. It is best-effort
+// and fails open, returning nil when the minimum can't be determined. It is
+// bypassed with a warning when too old and [JoinParams.SkipVersionCheck] is set.
+func checkClientVersionSupported(ctx context.Context, params JoinParams, proxyAddr string) error {
+	resp, err := webclient.Find(&webclient.Config{
+		Context:   ctx,
+		ProxyAddr: proxyAddr,
+		Insecure:  params.Insecure,
+	})
+	if err != nil {
+		params.Log.WarnContext(ctx,
+			"Could not fetch the cluster's minimum client version from the proxy's web API, skipping check.",
+			"proxy_addr", proxyAddr,
+			"error", err,
+		)
+		return nil
+	}
+
+	localVersion := api.Version
+	if params.Testing.TeleportVersion != "" {
+		localVersion = params.Testing.TeleportVersion
+	}
+
+	err = checkClientMeetsMinVersion(localVersion, resp.MinClientVersion)
+	if err == nil {
+		return nil
+	}
+	if !errors.Is(err, ErrClientTooOld) {
+		params.Log.WarnContext(ctx,
+			"Could not parse the cluster's minimum client version, skipping check.",
+			"error", err,
+			"min_client_version", resp.MinClientVersion,
+		)
+		return nil
+	}
+	if params.SkipVersionCheck {
+		params.Log.WarnContext(ctx,
+			"This client is older than the cluster's minimum supported version, ignoring the version check because --skip-version-check is set.",
+			"error", err,
+		)
+		return nil
+	}
+	return trace.Wrap(err)
+}
+
+func checkClientMeetsMinVersion(clientVersion, minVersion string) error {
+	if minVersion == "" {
+		return nil
+	}
+	// Stripping the pre-release both validates the advertised minimum and yields a
+	// clean version for the user-facing error message.
+	minWithoutPreRelease, err := utils.VersionWithoutPreRelease(minVersion)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	if !utils.MeetsMinVersion(clientVersion, minVersion) {
+		return fmt.Errorf("%w (client v%s, minimum v%s)", ErrClientTooOld, clientVersion, minWithoutPreRelease)
+	}
+	return nil
+}
+
 func joinViaProxy(ctx context.Context, params JoinParams, proxyAddr string) (*JoinResult, error) {
+	if err := checkClientVersionSupported(ctx, params, proxyAddr); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
 	// Connect to the proxy's insecure gRPC listener (this is regular TLS, the
 	// client is not authenticated because it doesn't have certs yet).
 	conn, err := proxyinsecureclient.NewConnection(ctx,
@@ -569,3 +640,7 @@ func (e *LegacyJoinError) Error() string {
 func (e *LegacyJoinError) Unwrap() error {
 	return e.wrapped
 }
+
+// ErrClientTooOld indicates this client is older than the cluster's minimum
+// client version.
+var ErrClientTooOld = errors.New("this client is older than the minimum supported version required by the cluster and will not be able to connect until it is upgraded")

--- a/lib/join/joinclient/join.go
+++ b/lib/join/joinclient/join.go
@@ -22,19 +22,17 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 	"errors"
-	"fmt"
 	"os"
 
 	"github.com/gravitational/trace"
 	"golang.org/x/crypto/ssh"
 
-	"github.com/gravitational/teleport/api"
 	"github.com/gravitational/teleport/api/client/proto"
-	"github.com/gravitational/teleport/api/client/webclient"
 	joiningv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/joining/v1"
 	"github.com/gravitational/teleport/api/types"
 	authjoin "github.com/gravitational/teleport/lib/auth/join"
 	proxyinsecureclient "github.com/gravitational/teleport/lib/client/proxy/insecure"
+	"github.com/gravitational/teleport/lib/clientversion"
 	"github.com/gravitational/teleport/lib/cloud/imds/gcp"
 	"github.com/gravitational/teleport/lib/cryptosuites"
 	"github.com/gravitational/teleport/lib/join/azuredevops"
@@ -48,7 +46,6 @@ import (
 	"github.com/gravitational/teleport/lib/join/spacelift"
 	"github.com/gravitational/teleport/lib/join/terraformcloud"
 	kubetoken "github.com/gravitational/teleport/lib/kube/token"
-	"github.com/gravitational/teleport/lib/utils"
 	"github.com/gravitational/teleport/lib/utils/hostid"
 )
 
@@ -171,70 +168,16 @@ func joinNew(ctx context.Context, params JoinParams) (*JoinResult, error) {
 	return nil, trace.NewAggregate(errs...)
 }
 
-// checkClientVersionSupported returns [ErrClientTooOld] when this client is
-// older than the proxy's advertised minimum client version. It is best-effort
-// and fails open, returning nil when the minimum can't be determined. It is
-// bypassed with a warning when too old and [JoinParams.SkipVersionCheck] is set.
-func checkClientVersionSupported(ctx context.Context, params JoinParams, proxyAddr string) error {
-	resp, err := webclient.Find(&webclient.Config{
-		Context:   ctx,
+func joinViaProxy(ctx context.Context, params JoinParams, proxyAddr string) (*JoinResult, error) {
+	if err := clientversion.Check(ctx, clientversion.Config{
 		ProxyAddr: proxyAddr,
 		Insecure:  params.Insecure,
-	})
-	if err != nil {
-		params.Log.WarnContext(ctx,
-			"Could not fetch the cluster's minimum client version from the proxy's web API, skipping check.",
-			"proxy_addr", proxyAddr,
-			"error", err,
-		)
-		return nil
-	}
-
-	localVersion := api.Version
-	if params.Testing.TeleportVersion != "" {
-		localVersion = params.Testing.TeleportVersion
-	}
-
-	err = checkClientMeetsMinVersion(localVersion, resp.MinClientVersion)
-	if err == nil {
-		return nil
-	}
-	if !errors.Is(err, ErrClientTooOld) {
-		params.Log.WarnContext(ctx,
-			"Could not parse the cluster's minimum client version, skipping check.",
-			"error", err,
-			"min_client_version", resp.MinClientVersion,
-		)
-		return nil
-	}
-	if params.SkipVersionCheck {
-		params.Log.WarnContext(ctx,
-			"This client is older than the cluster's minimum supported version, ignoring the version check because --skip-version-check is set.",
-			"error", err,
-		)
-		return nil
-	}
-	return trace.Wrap(err)
-}
-
-func checkClientMeetsMinVersion(clientVersion, minVersion string) error {
-	if minVersion == "" {
-		return nil
-	}
-	// Stripping the pre-release both validates the advertised minimum and yields a
-	// clean version for the user-facing error message.
-	minWithoutPreRelease, err := utils.VersionWithoutPreRelease(minVersion)
-	if err != nil {
-		return trace.Wrap(err)
-	}
-	if !utils.MeetsMinVersion(clientVersion, minVersion) {
-		return fmt.Errorf("%w (client v%s, minimum v%s)", ErrClientTooOld, clientVersion, minWithoutPreRelease)
-	}
-	return nil
-}
-
-func joinViaProxy(ctx context.Context, params JoinParams, proxyAddr string) (*JoinResult, error) {
-	if err := checkClientVersionSupported(ctx, params, proxyAddr); err != nil {
+		Skip:      params.SkipVersionCheck,
+		Log:       params.Log,
+		Testing: clientversion.TestingConfig{
+			ClientVersion: params.Testing.TeleportVersion,
+		},
+	}); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
@@ -640,7 +583,3 @@ func (e *LegacyJoinError) Error() string {
 func (e *LegacyJoinError) Unwrap() error {
 	return e.wrapped
 }
-
-// ErrClientTooOld indicates this client is older than the cluster's minimum
-// client version.
-var ErrClientTooOld = errors.New("this client is older than the minimum supported version required by the cluster and will not be able to connect until it is upgraded")

--- a/lib/join/joinclient/version_test.go
+++ b/lib/join/joinclient/version_test.go
@@ -1,0 +1,243 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package joinclient
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/coreos/go-semver/semver"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport"
+	"github.com/gravitational/teleport/api/client/proto"
+	"github.com/gravitational/teleport/api/client/webclient"
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/auth/state"
+	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/log/logtest"
+)
+
+func requireClientTooOld(t require.TestingT, err error, _ ...any) {
+	require.ErrorIs(t, err, ErrClientTooOld)
+}
+
+func TestCheckClientMeetsMinVersion(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name          string
+		clientVersion string
+		minVersion    string
+		assertErr     require.ErrorAssertionFunc
+	}{
+		{
+			name:          "client too old",
+			clientVersion: "1.0.0",
+			minVersion:    "2.0.0",
+			assertErr:     requireClientTooOld,
+		},
+		{
+			// The pre-release suffix is stripped from the minimum reported in
+			// the error so the user-facing message shows a clean version.
+			name:          "client too old with pre-release minimum",
+			clientVersion: "1.0.0",
+			minVersion:    "2.0.0-aa",
+			assertErr: func(t require.TestingT, err error, _ ...any) {
+				requireClientTooOld(t, err)
+				require.Contains(t, err.Error(), "minimum v2.0.0)")
+			},
+		},
+		{
+			name:          "pre-release client too old for release minimum",
+			clientVersion: "2.0.0-dev",
+			minVersion:    "2.0.0",
+			assertErr:     requireClientTooOld,
+		},
+		{
+			// The proxy advertises "<major>.0.0-aa" so that pre-release builds
+			// of the minimum version are permitted. This case fails if the
+			// comparison ever switches to the stripped minimum (2.0.0-dev is
+			// below 2.0.0 but above 2.0.0-aa).
+			name:          "pre-release client meets pre-release minimum",
+			clientVersion: "2.0.0-dev",
+			minVersion:    "2.0.0-aa",
+			assertErr:     require.NoError,
+		},
+		{
+			name:          "client meets minimum",
+			clientVersion: "2.0.0",
+			minVersion:    "1.0.0",
+			assertErr:     require.NoError,
+		},
+		{
+			name:          "client exactly meets minimum",
+			clientVersion: "1.0.0",
+			minVersion:    "1.0.0",
+			assertErr:     require.NoError,
+		},
+		{
+			name:          "no minimum advertised",
+			clientVersion: "1.0.0",
+			minVersion:    "",
+			assertErr:     require.NoError,
+		},
+		{
+			name:          "malformed minimum returns parse error",
+			clientVersion: "1.0.0",
+			minVersion:    "not-a-version",
+			assertErr: func(t require.TestingT, err error, _ ...any) {
+				require.Error(t, err)
+				require.NotErrorIs(t, err, ErrClientTooOld)
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			tc.assertErr(t, checkClientMeetsMinVersion(tc.clientVersion, tc.minVersion))
+		})
+	}
+}
+
+func TestCheckClientVersionSupported(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name             string
+		clientVersion    string
+		minClientVersion string
+		findError        bool
+		skipVersionCheck bool
+		assertErr        require.ErrorAssertionFunc
+	}{
+		{
+			name:             "too old",
+			clientVersion:    "1.0.0",
+			minClientVersion: "2.0.0",
+			assertErr:        requireClientTooOld,
+		},
+		{
+			name:             "too old but skip version check",
+			clientVersion:    "1.0.0",
+			minClientVersion: "2.0.0",
+			skipVersionCheck: true,
+			assertErr:        require.NoError,
+		},
+		{
+			name:             "meets minimum",
+			clientVersion:    "2.0.0",
+			minClientVersion: "1.0.0",
+			assertErr:        require.NoError,
+		},
+		{
+			name:             "malformed minimum fails open",
+			clientVersion:    "1.0.0",
+			minClientVersion: "not-a-version",
+			assertErr:        require.NoError,
+		},
+		{
+			name:          "find error fails open",
+			clientVersion: "1.0.0",
+			findError:     true,
+			assertErr:     require.NoError,
+		},
+		{
+			// An empty version must resolve to api.Version, not "". A minimum
+			// above any real release proves the default kicks in: "" would pass
+			// (an empty version "meets" any minimum), while api.Version is
+			// correctly rejected as too old.
+			name:             "empty version defaults to api.Version",
+			clientVersion:    "",
+			minClientVersion: "9999.0.0",
+			assertErr:        requireClientTooOld,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if tc.findError {
+					http.Error(w, "unavailable", http.StatusServiceUnavailable)
+					return
+				}
+				assert.Equal(t, "/webapi/find", r.URL.Path)
+				assert.NoError(t, json.NewEncoder(w).Encode(webclient.PingResponse{
+					MinClientVersion: tc.minClientVersion,
+				}))
+			}))
+			t.Cleanup(srv.Close)
+
+			params := JoinParams{
+				Insecure:         true,
+				SkipVersionCheck: tc.skipVersionCheck,
+				Log:              logtest.NewLogger(),
+				Testing:          JoinTestingParams{TeleportVersion: tc.clientVersion},
+			}
+			addr := strings.TrimPrefix(srv.URL, "https://")
+			tc.assertErr(t, checkClientVersionSupported(t.Context(), params, addr))
+		})
+	}
+}
+
+// TestJoinFailsFastWhenClientTooOld ensures a confirmed too-old client gets
+// [ErrClientTooOld] back from [Join] itself. If the error were ever classified as
+// a connection error anywhere in the chain, [Join] would instead fall back to
+// the legacy join service, which has no version check and discards the
+// original error.
+func TestJoinFailsFastWhenClientTooOld(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/webapi/find" {
+			http.NotFound(w, r)
+			return
+		}
+		assert.NoError(t, json.NewEncoder(w).Encode(webclient.PingResponse{
+			MinClientVersion: teleport.MinClientSemVer().String(),
+		}))
+	}))
+	t.Cleanup(srv.Close)
+
+	tooOldVersion := semver.Version{Major: teleport.MinClientSemVer().Major - 1}
+
+	_, err := Join(t.Context(), JoinParams{
+		Token:       "token",
+		ID:          state.IdentityID{Role: types.RoleInstance},
+		ProxyServer: utils.NetAddr{AddrNetwork: "tcp", Addr: strings.TrimPrefix(srv.URL, "https://")},
+		JoinMethod:  types.JoinMethodToken,
+		Insecure:    true,
+		Log:         logtest.NewLogger(),
+		Testing:     JoinTestingParams{TeleportVersion: tooOldVersion.String()},
+		// GetHostCredentials is only reached if the version check error is
+		// misclassified and the legacy fallback engages. This stub makes that
+		// regression fail legibly instead of panicking.
+		GetHostCredentials: func(context.Context, string, bool, types.RegisterUsingTokenRequest) (*proto.Certs, error) {
+			return nil, errors.New("host credentials unavailable")
+		},
+	})
+	requireClientTooOld(t, err)
+}

--- a/lib/join/joinclient/version_test.go
+++ b/lib/join/joinclient/version_test.go
@@ -34,180 +34,16 @@ import (
 	"github.com/gravitational/teleport/api/client/webclient"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/auth/state"
+	"github.com/gravitational/teleport/lib/clientversion"
 	"github.com/gravitational/teleport/lib/utils"
 	"github.com/gravitational/teleport/lib/utils/log/logtest"
 )
 
-func requireClientTooOld(t require.TestingT, err error, _ ...any) {
-	require.ErrorIs(t, err, ErrClientTooOld)
-}
-
-func TestCheckClientMeetsMinVersion(t *testing.T) {
-	t.Parallel()
-
-	cases := []struct {
-		name          string
-		clientVersion string
-		minVersion    string
-		assertErr     require.ErrorAssertionFunc
-	}{
-		{
-			name:          "client too old",
-			clientVersion: "1.0.0",
-			minVersion:    "2.0.0",
-			assertErr:     requireClientTooOld,
-		},
-		{
-			// The pre-release suffix is stripped from the minimum reported in
-			// the error so the user-facing message shows a clean version.
-			name:          "client too old with pre-release minimum",
-			clientVersion: "1.0.0",
-			minVersion:    "2.0.0-aa",
-			assertErr: func(t require.TestingT, err error, _ ...any) {
-				requireClientTooOld(t, err)
-				require.Contains(t, err.Error(), "minimum v2.0.0)")
-			},
-		},
-		{
-			name:          "pre-release client too old for release minimum",
-			clientVersion: "2.0.0-dev",
-			minVersion:    "2.0.0",
-			assertErr:     requireClientTooOld,
-		},
-		{
-			// The proxy advertises "<major>.0.0-aa" so that pre-release builds
-			// of the minimum version are permitted. This case fails if the
-			// comparison ever switches to the stripped minimum (2.0.0-dev is
-			// below 2.0.0 but above 2.0.0-aa).
-			name:          "pre-release client meets pre-release minimum",
-			clientVersion: "2.0.0-dev",
-			minVersion:    "2.0.0-aa",
-			assertErr:     require.NoError,
-		},
-		{
-			name:          "client meets minimum",
-			clientVersion: "2.0.0",
-			minVersion:    "1.0.0",
-			assertErr:     require.NoError,
-		},
-		{
-			name:          "client exactly meets minimum",
-			clientVersion: "1.0.0",
-			minVersion:    "1.0.0",
-			assertErr:     require.NoError,
-		},
-		{
-			name:          "no minimum advertised",
-			clientVersion: "1.0.0",
-			minVersion:    "",
-			assertErr:     require.NoError,
-		},
-		{
-			name:          "malformed minimum returns parse error",
-			clientVersion: "1.0.0",
-			minVersion:    "not-a-version",
-			assertErr: func(t require.TestingT, err error, _ ...any) {
-				require.Error(t, err)
-				require.NotErrorIs(t, err, ErrClientTooOld)
-			},
-		},
-	}
-
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
-			tc.assertErr(t, checkClientMeetsMinVersion(tc.clientVersion, tc.minVersion))
-		})
-	}
-}
-
-func TestCheckClientVersionSupported(t *testing.T) {
-	t.Parallel()
-
-	cases := []struct {
-		name             string
-		clientVersion    string
-		minClientVersion string
-		findError        bool
-		skipVersionCheck bool
-		assertErr        require.ErrorAssertionFunc
-	}{
-		{
-			name:             "too old",
-			clientVersion:    "1.0.0",
-			minClientVersion: "2.0.0",
-			assertErr:        requireClientTooOld,
-		},
-		{
-			name:             "too old but skip version check",
-			clientVersion:    "1.0.0",
-			minClientVersion: "2.0.0",
-			skipVersionCheck: true,
-			assertErr:        require.NoError,
-		},
-		{
-			name:             "meets minimum",
-			clientVersion:    "2.0.0",
-			minClientVersion: "1.0.0",
-			assertErr:        require.NoError,
-		},
-		{
-			name:             "malformed minimum fails open",
-			clientVersion:    "1.0.0",
-			minClientVersion: "not-a-version",
-			assertErr:        require.NoError,
-		},
-		{
-			name:          "find error fails open",
-			clientVersion: "1.0.0",
-			findError:     true,
-			assertErr:     require.NoError,
-		},
-		{
-			// An empty version must resolve to api.Version, not "". A minimum
-			// above any real release proves the default kicks in: "" would pass
-			// (an empty version "meets" any minimum), while api.Version is
-			// correctly rejected as too old.
-			name:             "empty version defaults to api.Version",
-			clientVersion:    "",
-			minClientVersion: "9999.0.0",
-			assertErr:        requireClientTooOld,
-		},
-	}
-
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
-
-			srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				if tc.findError {
-					http.Error(w, "unavailable", http.StatusServiceUnavailable)
-					return
-				}
-				assert.Equal(t, "/webapi/find", r.URL.Path)
-				assert.NoError(t, json.NewEncoder(w).Encode(webclient.PingResponse{
-					MinClientVersion: tc.minClientVersion,
-				}))
-			}))
-			t.Cleanup(srv.Close)
-
-			params := JoinParams{
-				Insecure:         true,
-				SkipVersionCheck: tc.skipVersionCheck,
-				Log:              logtest.NewLogger(),
-				Testing:          JoinTestingParams{TeleportVersion: tc.clientVersion},
-			}
-			addr := strings.TrimPrefix(srv.URL, "https://")
-			tc.assertErr(t, checkClientVersionSupported(t.Context(), params, addr))
-		})
-	}
-}
-
 // TestJoinFailsFastWhenClientTooOld ensures a confirmed too-old client gets
-// [ErrClientTooOld] back from [Join] itself. If the error were ever classified as
-// a connection error anywhere in the chain, [Join] would instead fall back to
-// the legacy join service, which has no version check and discards the
-// original error.
+// [clientversion.ErrClientTooOld] back from [Join] itself. If the error were
+// ever classified as a connection error anywhere in the chain, [Join] would
+// instead fall back to the legacy join service, which has no version check
+// and discards the original error.
 func TestJoinFailsFastWhenClientTooOld(t *testing.T) {
 	t.Parallel()
 
@@ -239,5 +75,5 @@ func TestJoinFailsFastWhenClientTooOld(t *testing.T) {
 			return nil, errors.New("host credentials unavailable")
 		},
 	})
-	requireClientTooOld(t, err)
+	require.ErrorIs(t, err, clientversion.ErrClientTooOld)
 }

--- a/lib/service/connect.go
+++ b/lib/service/connect.go
@@ -94,7 +94,10 @@ func (process *TeleportProcess) reconnectToAuthService(role types.SystemRole) (*
 			return connector, nil
 		} else {
 			switch {
-			case errors.As(connectErr, &invalidVersionErr{}):
+			// Version incompatibilities (the client is too new or too old for
+			// the cluster) are fatal. Retrying is pointless until the client is
+			// up or downgraded, so surface the error and stop reconnecting.
+			case errors.As(connectErr, &invalidVersionErr{}), errors.Is(connectErr, joinclient.ErrClientTooOld):
 				return nil, trace.Wrap(connectErr)
 			case strings.Contains(connectErr.Error(), auth.TokenExpiredOrNotFound):
 				process.logger.ErrorContext(process.ExitContext(), "Can not join the cluster, the token is expired or not found. Regenerate the token and try again.")
@@ -813,6 +816,10 @@ func (process *TeleportProcess) makeJoinParams(
 		CircuitBreakerConfig: breaker.NoopBreakerConfig(),
 		FIPS:                 process.Config.FIPS,
 		Insecure:             process.Config.InsecureMode,
+		SkipVersionCheck:     process.Config.SkipVersionCheck,
+		Testing: joinclient.JoinTestingParams{
+			TeleportVersion: process.Config.Testing.TeleportVersion,
+		},
 	}
 	if joinParams.JoinMethod == types.JoinMethodAzure {
 		joinParams.AzureParams = joinclient.AzureParams{

--- a/lib/service/connect.go
+++ b/lib/service/connect.go
@@ -53,6 +53,7 @@ import (
 	"github.com/gravitational/teleport/lib/auth/join/boundkeypair"
 	"github.com/gravitational/teleport/lib/auth/state"
 	"github.com/gravitational/teleport/lib/client"
+	"github.com/gravitational/teleport/lib/clientversion"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/join/joinclient"
 	"github.com/gravitational/teleport/lib/observability/metrics"
@@ -97,7 +98,7 @@ func (process *TeleportProcess) reconnectToAuthService(role types.SystemRole) (*
 			// Version incompatibilities (the client is too new or too old for
 			// the cluster) are fatal. Retrying is pointless until the client is
 			// up or downgraded, so surface the error and stop reconnecting.
-			case errors.As(connectErr, &invalidVersionErr{}), errors.Is(connectErr, joinclient.ErrClientTooOld):
+			case errors.As(connectErr, &invalidVersionErr{}), errors.Is(connectErr, clientversion.ErrClientTooOld):
 				return nil, trace.Wrap(connectErr)
 			case strings.Contains(connectErr.Error(), auth.TokenExpiredOrNotFound):
 				process.logger.ErrorContext(process.ExitContext(), "Can not join the cluster, the token is expired or not found. Regenerate the token and try again.")
@@ -1453,6 +1454,27 @@ func (process *TeleportProcess) getConnector(clientIdentity, serverIdentity *sta
 // For config v1 and v2, it will attempt to direct dial the auth server, and fallback to trying to tunnel
 // to the Auth Server through the proxy.
 func (process *TeleportProcess) newClient(connector *Connector) (*authclient.Client, *proto.PingResponse, error) {
+	// Fail fast if this instance is older than the cluster's minimum client
+	// version, before connecting, otherwise a too-old agent would be
+	// disconnected by auth with an opaque error.
+	var proxyAddr utils.NetAddr
+	if process.Config.Version == defaults.TeleportConfigVersionV3 && !process.Config.ProxyServer.IsEmpty() {
+		proxyAddr = process.Config.ProxyServer
+	} else {
+		proxyAddr = process.Config.AuthServerAddresses()[0]
+	}
+	if err := clientversion.Check(process.ExitContext(), clientversion.Config{
+		ProxyAddr: proxyAddr.String(),
+		Insecure:  process.Config.InsecureMode,
+		Skip:      process.Config.SkipVersionCheck,
+		Log:       process.logger,
+		Testing: clientversion.TestingConfig{
+			ClientVersion: process.Config.Testing.TeleportVersion,
+		},
+	}); err != nil {
+		return nil, nil, trace.Wrap(err)
+	}
+
 	tlsConfig := utils.TLSConfig(process.Config.CipherSuites)
 	tlsConfig.GetClientCertificate = func(*tls.CertificateRequestInfo) (*tls.Certificate, error) {
 		tlsCert, err := connector.ClientGetCertificate()

--- a/lib/service/connect_test.go
+++ b/lib/service/connect_test.go
@@ -48,6 +48,7 @@ import (
 	"github.com/gravitational/teleport/lib/auth/state"
 	"github.com/gravitational/teleport/lib/auth/storage"
 	"github.com/gravitational/teleport/lib/backend/memory"
+	"github.com/gravitational/teleport/lib/clientversion"
 	"github.com/gravitational/teleport/lib/cryptosuites"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/join/joinclient"
@@ -94,7 +95,7 @@ func TestTeleportProcessMinClientVersionCheck(t *testing.T) {
 		t.Cleanup(func() { _ = process.Close() })
 
 		c, err := process.reconnectToAuthService(types.RoleInstance)
-		require.ErrorIs(t, err, joinclient.ErrClientTooOld)
+		require.ErrorIs(t, err, clientversion.ErrClientTooOld)
 		require.Nil(t, c)
 	})
 
@@ -114,8 +115,28 @@ func TestTeleportProcessMinClientVersionCheck(t *testing.T) {
 		// and bypassed the check.
 		c, err := process.connectToAuthService(types.RoleInstance)
 		require.Error(t, err)
-		require.NotErrorIs(t, err, joinclient.ErrClientTooOld)
+		require.NotErrorIs(t, err, clientversion.ErrClientTooOld)
 		require.Nil(t, c)
+	})
+
+	t.Run("previously joined client too old fails creating the auth client", func(t *testing.T) {
+		cfg := newConfig(t)
+		process, err := NewTeleport(cfg)
+		require.NoError(t, err)
+		t.Cleanup(func() { _ = process.Close() })
+
+		// A previously joined agent reconnects via getConnector -> newClient,
+		// not the join path. newClient runs the version check before dialing, so
+		// a minimal connector is enough to exercise it without a real identity.
+		identity := &state.Identity{
+			ID:          state.IdentityID{Role: types.RoleInstance, HostUUID: "test-host"},
+			ClusterName: "test-cluster",
+		}
+		conn, err := newConnector(identity, identity)
+		require.NoError(t, err)
+
+		_, _, err = process.newClient(conn)
+		require.ErrorIs(t, err, clientversion.ErrClientTooOld)
 	})
 }
 

--- a/lib/service/connect_test.go
+++ b/lib/service/connect_test.go
@@ -21,20 +21,25 @@ package service
 import (
 	"crypto/tls"
 	"crypto/x509"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"slices"
 	"strings"
 	"testing"
 
+	"github.com/coreos/go-semver/semver"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/crypto/ssh"
 	"golang.org/x/sync/errgroup"
 
 	"github.com/gravitational/teleport"
+	"github.com/gravitational/teleport/api/client/webclient"
 	apiconstants "github.com/gravitational/teleport/api/constants"
 	apidefaults "github.com/gravitational/teleport/api/defaults"
 	apissh "github.com/gravitational/teleport/api/ssh"
@@ -44,12 +49,75 @@ import (
 	"github.com/gravitational/teleport/lib/auth/storage"
 	"github.com/gravitational/teleport/lib/backend/memory"
 	"github.com/gravitational/teleport/lib/cryptosuites"
+	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/join/joinclient"
 	"github.com/gravitational/teleport/lib/reversetunnelclient"
 	"github.com/gravitational/teleport/lib/service/servicecfg"
 	"github.com/gravitational/teleport/lib/utils"
 	"github.com/gravitational/teleport/lib/utils/log/logtest"
 )
+
+func TestTeleportProcessMinClientVersionCheck(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// The skipped-check variant proceeds past the version check and hits
+		// join endpoints this stub doesn't implement before failing.
+		if r.URL.Path != "/webapi/find" {
+			http.NotFound(w, r)
+			return
+		}
+		require.NoError(t, json.NewEncoder(w).Encode(webclient.PingResponse{
+			MinClientVersion: teleport.MinClientSemVer().String(),
+		}))
+	}))
+	t.Cleanup(srv.Close)
+
+	newConfig := func(t *testing.T) *servicecfg.Config {
+		cfg := servicecfg.MakeDefaultConfig()
+		cfg.Version = defaults.TeleportConfigVersionV3
+		cfg.ProxyServer = utils.NetAddr{AddrNetwork: "tcp", Addr: strings.TrimPrefix(srv.URL, "https://")}
+		cfg.InsecureMode = true
+		cfg.DataDir = makeTempDir(t)
+		cfg.SetToken("join-token")
+		cfg.Auth.Enabled = false
+		cfg.Proxy.Enabled = false
+		cfg.SSH.Enabled = true
+		cfg.Testing.TeleportVersion = semver.Version{Major: teleport.MinClientSemVer().Major - 1}.String()
+		return cfg
+	}
+
+	t.Run("client too old stops reconnect retries", func(t *testing.T) {
+		cfg := newConfig(t)
+		process, err := NewTeleport(cfg)
+		require.NoError(t, err)
+		t.Cleanup(func() { _ = process.Close() })
+
+		c, err := process.reconnectToAuthService(types.RoleInstance)
+		require.ErrorIs(t, err, joinclient.ErrClientTooOld)
+		require.Nil(t, c)
+	})
+
+	t.Run("skip version check bypasses the failure", func(t *testing.T) {
+		cfg := newConfig(t)
+		cfg.SkipVersionCheck = true
+
+		process, err := NewTeleport(cfg)
+		require.NoError(t, err)
+		t.Cleanup(func() { _ = process.Close() })
+
+		// Deliberately call connectToAuthService, not reconnectToAuthService.
+		// With the check skipped the join fails against the stub with an
+		// ordinary connection error, which reconnectToAuthService treats as
+		// retryable and would loop on forever. Failing with anything other
+		// than ErrClientTooOld proves SkipVersionCheck was plumbed through
+		// and bypassed the check.
+		c, err := process.connectToAuthService(types.RoleInstance)
+		require.Error(t, err)
+		require.NotErrorIs(t, err, joinclient.ErrClientTooOld)
+		require.Nil(t, c)
+	})
+}
 
 func TestMakeJoinParams_BoundKeypair(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
Extend Teleport's client-side minimum version check to the agent reconnect path, and extract it into a shared `lib/clientversion` package.

A previously joined agent that is older than the cluster's minimum client version reconnects through `newClient` rather than the join flow, so the existing `lib/join/joinclient` version check never runs for it. Auth disconnects the outdated agent and the failure surfaces as an opaque closed-connection (EOF) error, with nothing to indicate that the client needs to be upgraded.

Extract the check out of `lib/join/joinclient` into a new `lib/clientversion` package and run it at the top of `newClient`, before any transport is attempted. It stays best-effort, failing open when the cluster's advertised minimum can't be fetched or parsed, and is bypassed with a warning when `--skip-version-check` is set.

Changelog: Previously joined agents that are older than the cluster's minimum supported version now fail fast on startup with a clear and actionable error message, instead of being transparently disconnected from the auth service.

## Manual Test Plan
### Test Environment
- A Teleport cluster at version N whose advertised minimum client version is above the test agent's version.
- A too-old agent binary, plus one at a supported version for the control case.

_note: The agent in test must be built with the current changes. For this test, the version in `version.go` was manually bumped to build the auth, proxy, and supported version agent images._ 

### Test Cases
- [ ] A too-old agent **joining** exits immediately with the "client is older than the minimum supported version" error, not an opaque connection error.
- [ ] A previously joined, too-old agent exits on startup with the same clear error and does not retry.
- [ ] Starting the too-old agent with `--skip-version-check` proceeds past the check and logs a warning.
- [ ] With the proxy's `/webapi/find` unreachable, the agent does not block on the check (fails open) and connects as before.
- [ ] An agent at a supported version joins and reconnects normally (no behavior change).
