### PR TITLE
Avoid reentrancy in Cache.GetAccessListOwners

### DIFF
--- a/lib/accesslists/hierarchy.go
+++ b/lib/accesslists/hierarchy.go
@@ -45,9 +45,13 @@ const (
 
 // AccessListAndMembersGetter is a minimal interface for fetching AccessLists by name, and AccessListMembers for an Access List.
 type AccessListAndMembersGetter interface {
-	ListAccessListMembers(ctx context.Context, accessListName string, pageSize int, pageToken string) (members []*accesslist.AccessListMember, nextToken string, err error)
 	GetAccessList(ctx context.Context, accessListName string) (*accesslist.AccessList, error)
 	GetAccessListMember(ctx context.Context, accessList string, memberName string) (*accesslist.AccessListMember, error)
+	AccessListMembersLister
+}
+
+type AccessListMembersLister interface {
+	ListAccessListMembers(ctx context.Context, accessListName string, pageSize int, pageToken string) (members []*accesslist.AccessListMember, nextToken string, err error)
 }
 
 // lockGetter is a service that gets locks.
@@ -62,11 +66,11 @@ type lockGetter interface {
 //
 // Returned Members are not validated for expiration or other requirements – use IsAccessListMember
 // to validate a Member's membership status.
-func GetMembersFor(ctx context.Context, accessListName string, g AccessListAndMembersGetter) ([]*accesslist.AccessListMember, error) {
+func GetMembersFor(ctx context.Context, accessListName string, g AccessListMembersLister) ([]*accesslist.AccessListMember, error) {
 	return getMembersFor(ctx, accessListName, g, make(map[string]struct{}))
 }
 
-func getMembersFor(ctx context.Context, accessListName string, g AccessListAndMembersGetter, visited map[string]struct{}) ([]*accesslist.AccessListMember, error) {
+func getMembersFor(ctx context.Context, accessListName string, g AccessListMembersLister, visited map[string]struct{}) ([]*accesslist.AccessListMember, error) {
 	if _, ok := visited[accessListName]; ok {
 		return nil, nil
 	}
@@ -94,7 +98,7 @@ func getMembersFor(ctx context.Context, accessListName string, g AccessListAndMe
 }
 
 // fetchMembers is a simple helper to fetch all top-level AccessListMembers for an AccessList.
-func fetchMembers(ctx context.Context, accessListName string, g AccessListAndMembersGetter) ([]*accesslist.AccessListMember, error) {
+func fetchMembers(ctx context.Context, accessListName string, g AccessListMembersLister) ([]*accesslist.AccessListMember, error) {
 	var allMembers []*accesslist.AccessListMember
 	pageToken := ""
 	for {
@@ -116,7 +120,7 @@ func fetchMembers(ctx context.Context, accessListName string, g AccessListAndMem
 }
 
 // collectOwners is a helper to recursively collect all Owners for an Access List, including inherited Owners.
-func collectOwners(ctx context.Context, accessList *accesslist.AccessList, g AccessListAndMembersGetter, owners map[string]*accesslist.Owner, visited map[string]struct{}) error {
+func collectOwners(ctx context.Context, accessList *accesslist.AccessList, g AccessListMembersLister, owners map[string]*accesslist.Owner, visited map[string]struct{}) error {
 	if _, ok := visited[accessList.GetName()]; ok {
 		return nil
 	}
@@ -143,7 +147,7 @@ func collectOwners(ctx context.Context, accessList *accesslist.AccessList, g Acc
 }
 
 // collectMembersAsOwners is a helper to collect all nested members of an AccessList and return them cast as Owners.
-func collectMembersAsOwners(ctx context.Context, accessListName string, g AccessListAndMembersGetter, visited map[string]struct{}) ([]*accesslist.Owner, error) {
+func collectMembersAsOwners(ctx context.Context, accessListName string, g AccessListMembersLister, visited map[string]struct{}) ([]*accesslist.Owner, error) {
 	owners := make([]*accesslist.Owner, 0)
 	if _, ok := visited[accessListName]; ok {
 		return owners, nil
@@ -171,7 +175,7 @@ func collectMembersAsOwners(ctx context.Context, accessListName string, g Access
 //
 // Returned Owners are not validated for expiration or other requirements – use IsAccessListOwner
 // to validate an Owner's ownership status.
-func GetOwnersFor(ctx context.Context, accessList *accesslist.AccessList, g AccessListAndMembersGetter) ([]*accesslist.Owner, error) {
+func GetOwnersFor(ctx context.Context, accessList *accesslist.AccessList, g AccessListMembersLister) ([]*accesslist.Owner, error) {
 	ownersMap := make(map[string]*accesslist.Owner)
 	if err := collectOwners(ctx, accessList, g, ownersMap, make(map[string]struct{})); err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/cache/access_list.go
+++ b/lib/cache/access_list.go
@@ -353,11 +353,13 @@ func (c *Cache) GetAccessListMember(ctx context.Context, accessList string, memb
 	return member.Clone(), nil
 }
 
-type accessListMemberListerStore store[*accesslist.AccessListMember, accessListMemberIndex]
+type accessListMembersListerStore struct {
+	store *store[*accesslist.AccessListMember, accessListMemberIndex]
+}
 
 // ListAccessListMembers implements [accesslists.AccessListMembersLister].
-func (s *accessListMemberListerStore) ListAccessListMembers(ctx context.Context, accessListName string, pageSize int, pageToken string) (members []*accesslist.AccessListMember, nextToken string, err error) {
-	return listAccessListMembers((*store[*accesslist.AccessListMember, accessListMemberIndex])(s), accessListName, pageSize, pageToken)
+func (l accessListMembersListerStore) ListAccessListMembers(ctx context.Context, accessListName string, pageSize int, pageToken string) (members []*accesslist.AccessListMember, nextToken string, err error) {
+	return listAccessListMembers(l.store, accessListName, pageSize, pageToken)
 }
 
 // GetAccessListOwners returns the owners of the specified access list, including those inherited.
@@ -380,7 +382,7 @@ func (c *Cache) GetAccessListOwners(ctx context.Context, accessListName string) 
 		return accesslists.GetOwnersFor(ctx, accessList, c.Config.AccessLists)
 	}
 
-	return accesslists.GetOwnersFor(ctx, accessList, (*accessListMemberListerStore)(rg.store))
+	return accesslists.GetOwnersFor(ctx, accessList, accessListMembersListerStore{store: rg.store})
 }
 
 type accessListReviewIndex string

--- a/lib/cache/access_list.go
+++ b/lib/cache/access_list.go
@@ -284,6 +284,10 @@ func (c *Cache) ListAccessListMembers(ctx context.Context, accessListName string
 		return out, next, trace.Wrap(err)
 	}
 
+	return listAccessListMembers(rg.store, accessListName, pageSize, pageToken)
+}
+
+func listAccessListMembers(store *store[*accesslist.AccessListMember, accessListMemberIndex], accessListName string, pageSize int, pageToken string) ([]*accesslist.AccessListMember, string, error) {
 	// The ending "/" is very important here, otherwise we can start listing members of access
 	// lists which names are prefixed with this access list name. E.g. we'd list members of
 	// "dev-suffix" for list "dev".
@@ -296,7 +300,7 @@ func (c *Cache) ListAccessListMembers(ctx context.Context, accessListName string
 	}
 
 	var out []*accesslist.AccessListMember
-	for member := range rg.store.resources(accessListMemberNameIndex, current, end) {
+	for member := range store.resources(accessListMemberNameIndex, current, end) {
 		if len(out) == pageSize {
 			return out, member.GetName(), nil
 		}
@@ -304,7 +308,7 @@ func (c *Cache) ListAccessListMembers(ctx context.Context, accessListName string
 		out = append(out, member.Clone())
 	}
 
-	return out, "", trace.Wrap(err)
+	return out, "", nil
 }
 
 // ListAllAccessListMembers returns a paginated list of all access list members for all access lists.
@@ -349,27 +353,34 @@ func (c *Cache) GetAccessListMember(ctx context.Context, accessList string, memb
 	return member.Clone(), nil
 }
 
+type accessListMemberListerStore store[*accesslist.AccessListMember, accessListMemberIndex]
+
+// ListAccessListMembers implements [accesslists.AccessListMembersLister].
+func (s *accessListMemberListerStore) ListAccessListMembers(ctx context.Context, accessListName string, pageSize int, pageToken string) (members []*accesslist.AccessListMember, nextToken string, err error) {
+	return listAccessListMembers((*store[*accesslist.AccessListMember, accessListMemberIndex])(s), accessListName, pageSize, pageToken)
+}
+
 // GetAccessListOwners returns the owners of the specified access list, including those inherited.
 func (c *Cache) GetAccessListOwners(ctx context.Context, accessListName string) ([]*accesslist.Owner, error) {
 	ctx, span := c.Tracer.Start(ctx, "cache/GetAccessListOwners")
 	defer span.End()
-
-	rg, err := acquireReadGuard(c, c.collections.accessLists)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	defer rg.Release()
-
-	if !rg.ReadCache() {
-		return c.Config.AccessLists.GetAccessListOwners(ctx, accessListName)
-	}
 
 	accessList, err := c.GetAccessList(ctx, accessListName)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
-	return accesslists.GetOwnersFor(ctx, accessList, c)
+	rg, err := acquireReadGuard(c, c.collections.accessListMembers)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	defer rg.Release()
+
+	if !rg.ReadCache() {
+		return accesslists.GetOwnersFor(ctx, accessList, c.Config.AccessLists)
+	}
+
+	return accesslists.GetOwnersFor(ctx, accessList, (*accessListMemberListerStore)(rg.store))
 }
 
 type accessListReviewIndex string

--- a/lib/cache/access_list_test.go
+++ b/lib/cache/access_list_test.go
@@ -19,7 +19,10 @@ package cache
 import (
 	"context"
 	"fmt"
+	"runtime"
 	"strconv"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -362,7 +365,12 @@ func TestGetAccessListOwners(t *testing.T) {
 		require.NoError(t, err)
 
 		require.EventuallyWithT(t, func(t *assert.CollectT) {
+			// this busyloop will eventually hit a deadlock if
+			// GetAccessListOwners becomes reentrant again
+			stop := spinloopRWMutex(&p.cache.rw)
+			defer stop()
 			owners, err := p.cache.GetAccessListOwners(ctx, al.GetName())
+			stop()
 			assert.NoError(t, err)
 
 			names := make([]string, 0, len(owners))
@@ -414,7 +422,12 @@ func TestGetAccessListOwners(t *testing.T) {
 		require.NoError(t, err)
 
 		require.EventuallyWithT(t, func(t *assert.CollectT) {
+			// this busyloop will eventually hit a deadlock if
+			// GetAccessListOwners becomes reentrant again
+			stop := spinloopRWMutex(&p.cache.rw)
+			defer stop()
 			owners, err := p.cache.GetAccessListOwners(ctx, parentList.GetName())
+			stop()
 			assert.NoError(t, err)
 
 			names := make([]string, 0, len(owners))
@@ -425,6 +438,25 @@ func TestGetAccessListOwners(t *testing.T) {
 			assert.ElementsMatch(t, []string{"nested-member-1", "nested-member-2"}, names)
 		}, 15*time.Second, 100*time.Millisecond)
 	})
+}
+
+func spinloopRWMutex(mu *sync.RWMutex) (stop func()) {
+	var wg sync.WaitGroup
+	var done atomic.Bool
+	wg.Go(func() {
+		for !done.Load() {
+			mu.Lock()
+			// this critical section is deliberately left empty
+			_ = 0
+			mu.Unlock()
+			// Gosched is generally discouraged but so are spinloops...
+			runtime.Gosched()
+		}
+	})
+	return func() {
+		done.Store(true)
+		wg.Wait()
+	}
 }
 
 func TestListAccessListsV2(t *testing.T) {


### PR DESCRIPTION
This PR gets rid of the reentrancy in acquiring the cache read lock in `(cache.Cache).GetAccessListOwners` by means of giving `accesslists.GetOwnersFor` a reader of access list members from the cache that does not require acquiring the lock repeatedly.

Fixes gravitational/pressure-washing#146

Changelog: Fixed potential deadlock when reading access list owners from the cache as the cache becomes unhealthy

