### PR TITLE
docs: Update CA overrides

### DIFF
--- a/docs/pages/zero-trust-access/management/security/ca-overrides.mdx
+++ b/docs/pages/zero-trust-access/management/security/ca-overrides.mdx
@@ -5,7 +5,7 @@ tags:
  - how-to
  - platform-wide
  - resiliency
-enterprise: true
+enterprise: Certificate Authority Overrides
 ---
 
 Certificate Authority Overrides let a cluster administrator override a
@@ -55,7 +55,7 @@ The `cert_authority_override` resource targets a CA with the following fields:
 
 ## Prerequisites
 
-(!docs/pages/includes/edition-prereqs-tabs.mdx edition="Teleport Enterprise"!)
+(!docs/pages/includes/edition-prereqs-tabs.mdx edition="Teleport Enterprise (v18.9.0 or higher)"!)
 
 - Only the following CAs are currently supported: `db_client` and `windows`.
 - All Auth Service instances and related services, such as Windows Desktop


### PR DESCRIPTION
Updates:
- Include the enterprise title so "is only available.." header shows cleanly. Shows as below currently.
- min version is shown which is 18.9.0

<img width="606" height="194" alt="image" src="https://github.com/user-attachments/assets/f959d3f9-63f7-4eaf-82d1-3766cfe3510e" />

