### PR TITLE
Add check against accidental reentrancy in the cache

### DIFF
--- a/lib/cache/access_list_test.go
+++ b/lib/cache/access_list_test.go
@@ -19,10 +19,7 @@ package cache
 import (
 	"context"
 	"fmt"
-	"runtime"
 	"strconv"
-	"sync"
-	"sync/atomic"
 	"testing"
 	"time"
 
@@ -365,12 +362,7 @@ func TestGetAccessListOwners(t *testing.T) {
 		require.NoError(t, err)
 
 		require.EventuallyWithT(t, func(t *assert.CollectT) {
-			// this busyloop will eventually hit a deadlock if
-			// GetAccessListOwners becomes reentrant again
-			stop := spinloopRWMutex(&p.cache.rw)
-			defer stop()
 			owners, err := p.cache.GetAccessListOwners(ctx, al.GetName())
-			stop()
 			assert.NoError(t, err)
 
 			names := make([]string, 0, len(owners))
@@ -422,12 +414,7 @@ func TestGetAccessListOwners(t *testing.T) {
 		require.NoError(t, err)
 
 		require.EventuallyWithT(t, func(t *assert.CollectT) {
-			// this busyloop will eventually hit a deadlock if
-			// GetAccessListOwners becomes reentrant again
-			stop := spinloopRWMutex(&p.cache.rw)
-			defer stop()
 			owners, err := p.cache.GetAccessListOwners(ctx, parentList.GetName())
-			stop()
 			assert.NoError(t, err)
 
 			names := make([]string, 0, len(owners))
@@ -438,25 +425,6 @@ func TestGetAccessListOwners(t *testing.T) {
 			assert.ElementsMatch(t, []string{"nested-member-1", "nested-member-2"}, names)
 		}, 15*time.Second, 100*time.Millisecond)
 	})
-}
-
-func spinloopRWMutex(mu *sync.RWMutex) (stop func()) {
-	var wg sync.WaitGroup
-	var done atomic.Bool
-	wg.Go(func() {
-		for !done.Load() {
-			mu.Lock()
-			// this critical section is deliberately left empty
-			_ = 0
-			mu.Unlock()
-			// Gosched is generally discouraged but so are spinloops...
-			runtime.Gosched()
-		}
-	})
-	return func() {
-		done.Store(true)
-		wg.Wait()
-	}
 }
 
 func TestListAccessListsV2(t *testing.T) {

--- a/lib/cache/cache.go
+++ b/lib/cache/cache.go
@@ -540,7 +540,12 @@ type Cache struct {
 	// when checking the `ok` or `confirmedKinds` fields. Since the write
 	// lock must be held in order to modify the `ok` field, this serves
 	// to ensure that all in-progress reads complete *before* a reset can begin.
-	rw sync.RWMutex
+	//
+	// In test builds with the race detector enabled, it's a read-write mutex
+	// that must be unlocked for reading in the same goroutine that acquired the
+	// read lock. This is currently the case and shouldn't be particularly
+	// restricting in the future.
+	rw rwMutex
 	// ok indicates whether the cache is in a valid state for reads.
 	// If `ok` is `false`, reads are forwarded directly to the backend.
 	ok bool

--- a/lib/cache/cache_norlockcheck.go
+++ b/lib/cache/cache_norlockcheck.go
@@ -1,0 +1,30 @@
+//go:build !race
+
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package cache
+
+import "sync"
+
+func enableRLockCheck() {}
+
+func finalRLockCheck() {}
+
+// rwMutex in this build is just [sync.RWMutex]. Care should still be taken to
+// always use RUnlock in the same goroutine that called RLock, or the code will
+// not work in builds where the check is enabled.
+type rwMutex = sync.RWMutex

--- a/lib/cache/cache_rlockcheck.go
+++ b/lib/cache/cache_rlockcheck.go
@@ -1,0 +1,115 @@
+//go:build race
+
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package cache
+
+import (
+	"bytes"
+	"fmt"
+	"runtime"
+	"strconv"
+	"sync"
+)
+
+// activeRLocks is a hashset of [activeRLocksItem] (i.e. the key is
+// activeRLocksItem and the value is always an untyped nil) used by [rwMutex].
+var activeRLocks sync.Map
+
+type activeRLocksItem struct {
+	mu   *rwMutex
+	goid uint64
+}
+
+var rLockChecking bool
+
+// enableRLockCheck makes it so that [rwMutex] will keep track of the goroutine
+// ID that RLocked and RUnlocked the mutex, panicking in case of reentrant
+// locking. It should be called before tests start.
+func enableRLockCheck() {
+	rLockChecking = true
+}
+
+// finalRLockCheck checks that all instances of [rwMutex] are no longer locked.
+// It should be called after tests are done.
+func finalRLockCheck() {
+	if !rLockChecking {
+		return
+	}
+
+	activeRLocks.Range(func(key, value any) bool {
+		i := key.(activeRLocksItem)
+		panic(fmt.Sprintf("RWMutex at %p left RLocked by goroutine %d", i.mu, i.goid))
+	})
+}
+
+// rwMutex is a [sync.RWMutex] with optional checking against reentrancy.
+// Because of the checks, an acquired RLock must be RUnlocked in the same
+// goroutine (unlike sync.RWMutex, which doesn't care about that).
+type rwMutex struct {
+	mu sync.RWMutex
+}
+
+// rLockCheckGoid returns the goroutine ID of the calling goroutine. It should
+// only be called in test code, as the performance is terrible.
+func rLockCheckGoid() uint64 {
+	// "goroutine 18446744073709551616 [" is 32 characters
+	buf := make([]byte, 32)
+	const allGoroutinesFalse = false
+	buf = buf[:runtime.Stack(buf, allGoroutinesFalse)]
+	buf, found := bytes.CutPrefix(buf, []byte("goroutine "))
+	if !found {
+		panic("could not find goroutine id from stack dump")
+	}
+	buf, _, found = bytes.Cut(buf, []byte(" ["))
+	if !found {
+		panic("could not find goroutine id from stack dump")
+	}
+	goid, err := strconv.ParseUint(string(buf), 10, 64)
+	if err != nil {
+		panic(err)
+	}
+	return goid
+}
+
+func (mu *rwMutex) RLock() {
+	if rLockChecking {
+		goid := rLockCheckGoid()
+		_, alreadyPresent := activeRLocks.LoadOrStore(activeRLocksItem{mu: mu, goid: goid}, nil)
+		if alreadyPresent {
+			panic(fmt.Sprintf("goroutine %d attempted to RLock the RWMutex at %p twice", goid, mu))
+		}
+	}
+	mu.mu.RLock()
+}
+func (mu *rwMutex) RUnlock() {
+	if rLockChecking {
+		goid := rLockCheckGoid()
+		_, deleted := activeRLocks.LoadAndDelete(activeRLocksItem{mu: mu, goid: goid})
+		if !deleted {
+			panic(fmt.Sprintf("goroutine %d attempted to RUnlock the RWMutex at %p without holding the RLock", goid, mu))
+		}
+	}
+	mu.mu.RUnlock()
+}
+
+func (mu *rwMutex) Lock() {
+	mu.mu.Lock()
+}
+func (mu *rwMutex) Unlock() {
+	mu.mu.Unlock()
+}

--- a/lib/cache/cache_test.go
+++ b/lib/cache/cache_test.go
@@ -100,6 +100,7 @@ import (
 const eventBufferSize = 1024
 
 func TestMain(m *testing.M) {
+	enableRLockCheck()
 	modules.SetModules(&modulestest.Modules{
 		TestFeatures: modules.Features{
 			Entitlements: map[entitlements.EntitlementKind]modules.EntitlementInfo{
@@ -112,7 +113,11 @@ func TestMain(m *testing.M) {
 		},
 	})
 	logtest.InitLogger(testing.Verbose)
-	os.Exit(m.Run())
+	code := m.Run()
+	if code == 0 {
+		finalRLockCheck()
+	}
+	os.Exit(code)
 }
 
 // TestNodesDontCacheHighVolumeResources verifies that resources classified as "high volume" aren't


### PR DESCRIPTION
This PR adds a check against accidental reentrancy when acquiring the `cache.Cache` rwmutex for reading. The check is only compiled in builds with tsan enabled, and it's only enabled by the lib/cache tests.

This change will add the restriction that the read lock of the `cache.Cache.rw` read-write mutex must be released  in the same goroutine that acquired the read lock, but it shouldn't be a particularly heavy restriction.