### PR TITLE
RFD 229C: Issuance RPCs, `tbot` changes for Scoped SPIFFE (5/5)

### DIFF
--- a/api/gen/proto/go/teleport/workloadidentity/v1/issuance_service.pb.go
+++ b/api/gen/proto/go/teleport/workloadidentity/v1/issuance_service.pb.go
@@ -729,7 +729,11 @@ type IssueWorkloadIdentityRequest struct {
 	// The TTL that the client is requesting for the resulting credentials.
 	// This may be adjusted by the server and therefore the client MUST check the
 	// returned TTL rather than assuming that the requested TTL was granted.
-	RequestedTtl  *durationpb.Duration `protobuf:"bytes,5,opt,name=requested_ttl,json=requestedTtl,proto3" json:"requested_ttl,omitempty"`
+	RequestedTtl *durationpb.Duration `protobuf:"bytes,5,opt,name=requested_ttl,json=requestedTtl,proto3" json:"requested_ttl,omitempty"`
+	// The scope the named WorkloadIdentity is expected to belong to. If unset, the
+	// WorkloadIdentity is expected to be unscoped. If the named WorkloadIdentity
+	// does not belong to this scope, a not found error is returned.
+	Scope         string `protobuf:"bytes,6,opt,name=scope,proto3" json:"scope,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -805,6 +809,13 @@ func (x *IssueWorkloadIdentityRequest) GetRequestedTtl() *durationpb.Duration {
 	return nil
 }
 
+func (x *IssueWorkloadIdentityRequest) GetScope() string {
+	if x != nil {
+		return x.Scope
+	}
+	return ""
+}
+
 func (x *IssueWorkloadIdentityRequest) SetName(v string) {
 	x.Name = v
 }
@@ -831,6 +842,10 @@ func (x *IssueWorkloadIdentityRequest) SetWorkloadAttrs(v *WorkloadAttrs) {
 
 func (x *IssueWorkloadIdentityRequest) SetRequestedTtl(v *durationpb.Duration) {
 	x.RequestedTtl = v
+}
+
+func (x *IssueWorkloadIdentityRequest) SetScope(v string) {
+	x.Scope = v
 }
 
 func (x *IssueWorkloadIdentityRequest) HasCredential() bool {
@@ -931,6 +946,10 @@ type IssueWorkloadIdentityRequest_builder struct {
 	// This may be adjusted by the server and therefore the client MUST check the
 	// returned TTL rather than assuming that the requested TTL was granted.
 	RequestedTtl *durationpb.Duration
+	// The scope the named WorkloadIdentity is expected to belong to. If unset, the
+	// WorkloadIdentity is expected to be unscoped. If the named WorkloadIdentity
+	// does not belong to this scope, a not found error is returned.
+	Scope string
 }
 
 func (b0 IssueWorkloadIdentityRequest_builder) Build() *IssueWorkloadIdentityRequest {
@@ -946,6 +965,7 @@ func (b0 IssueWorkloadIdentityRequest_builder) Build() *IssueWorkloadIdentityReq
 	}
 	x.WorkloadAttrs = b.WorkloadAttrs
 	x.RequestedTtl = b.RequestedTtl
+	x.Scope = b.Scope
 	return m0
 }
 
@@ -1951,13 +1971,14 @@ const file_teleport_workloadidentity_v1_issuance_service_proto_rawDesc = "" +
 	"\tx509_svid\x18\a \x01(\v20.teleport.workloadidentity.v1.X509SVIDCredentialH\x00R\bx509Svid\x12L\n" +
 	"\bjwt_svid\x18\b \x01(\v2/.teleport.workloadidentity.v1.JWTSVIDCredentialH\x00R\ajwtSvidB\f\n" +
 	"\n" +
-	"credential\"\x85\x03\n" +
+	"credential\"\x9b\x03\n" +
 	"\x1cIssueWorkloadIdentityRequest\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12X\n" +
 	"\x10x509_svid_params\x18\x02 \x01(\v2,.teleport.workloadidentity.v1.X509SVIDParamsH\x00R\x0ex509SvidParams\x12U\n" +
 	"\x0fjwt_svid_params\x18\x03 \x01(\v2+.teleport.workloadidentity.v1.JWTSVIDParamsH\x00R\rjwtSvidParams\x12R\n" +
 	"\x0eworkload_attrs\x18\x04 \x01(\v2+.teleport.workloadidentity.v1.WorkloadAttrsR\rworkloadAttrs\x12>\n" +
-	"\rrequested_ttl\x18\x05 \x01(\v2\x19.google.protobuf.DurationR\frequestedTtlB\f\n" +
+	"\rrequested_ttl\x18\x05 \x01(\v2\x19.google.protobuf.DurationR\frequestedTtl\x12\x14\n" +
+	"\x05scope\x18\x06 \x01(\tR\x05scopeB\f\n" +
 	"\n" +
 	"credential\"i\n" +
 	"\x1dIssueWorkloadIdentityResponse\x12H\n" +

--- a/api/gen/proto/go/teleport/workloadidentity/v1/issuance_service_protoopaque.pb.go
+++ b/api/gen/proto/go/teleport/workloadidentity/v1/issuance_service_protoopaque.pb.go
@@ -687,6 +687,7 @@ type IssueWorkloadIdentityRequest struct {
 	xxx_hidden_Credential    isIssueWorkloadIdentityRequest_Credential `protobuf_oneof:"credential"`
 	xxx_hidden_WorkloadAttrs *WorkloadAttrs                            `protobuf:"bytes,4,opt,name=workload_attrs,json=workloadAttrs,proto3"`
 	xxx_hidden_RequestedTtl  *durationpb.Duration                      `protobuf:"bytes,5,opt,name=requested_ttl,json=requestedTtl,proto3"`
+	xxx_hidden_Scope         string                                    `protobuf:"bytes,6,opt,name=scope,proto3"`
 	unknownFields            protoimpl.UnknownFields
 	sizeCache                protoimpl.SizeCache
 }
@@ -755,6 +756,13 @@ func (x *IssueWorkloadIdentityRequest) GetRequestedTtl() *durationpb.Duration {
 	return nil
 }
 
+func (x *IssueWorkloadIdentityRequest) GetScope() string {
+	if x != nil {
+		return x.xxx_hidden_Scope
+	}
+	return ""
+}
+
 func (x *IssueWorkloadIdentityRequest) SetName(v string) {
 	x.xxx_hidden_Name = v
 }
@@ -781,6 +789,10 @@ func (x *IssueWorkloadIdentityRequest) SetWorkloadAttrs(v *WorkloadAttrs) {
 
 func (x *IssueWorkloadIdentityRequest) SetRequestedTtl(v *durationpb.Duration) {
 	x.xxx_hidden_RequestedTtl = v
+}
+
+func (x *IssueWorkloadIdentityRequest) SetScope(v string) {
+	x.xxx_hidden_Scope = v
 }
 
 func (x *IssueWorkloadIdentityRequest) HasCredential() bool {
@@ -881,6 +893,10 @@ type IssueWorkloadIdentityRequest_builder struct {
 	// This may be adjusted by the server and therefore the client MUST check the
 	// returned TTL rather than assuming that the requested TTL was granted.
 	RequestedTtl *durationpb.Duration
+	// The scope the named WorkloadIdentity is expected to belong to. If unset, the
+	// WorkloadIdentity is expected to be unscoped. If the named WorkloadIdentity
+	// does not belong to this scope, a not found error is returned.
+	Scope string
 }
 
 func (b0 IssueWorkloadIdentityRequest_builder) Build() *IssueWorkloadIdentityRequest {
@@ -896,6 +912,7 @@ func (b0 IssueWorkloadIdentityRequest_builder) Build() *IssueWorkloadIdentityReq
 	}
 	x.xxx_hidden_WorkloadAttrs = b.WorkloadAttrs
 	x.xxx_hidden_RequestedTtl = b.RequestedTtl
+	x.xxx_hidden_Scope = b.Scope
 	return m0
 }
 
@@ -1847,13 +1864,14 @@ const file_teleport_workloadidentity_v1_issuance_service_proto_rawDesc = "" +
 	"\tx509_svid\x18\a \x01(\v20.teleport.workloadidentity.v1.X509SVIDCredentialH\x00R\bx509Svid\x12L\n" +
 	"\bjwt_svid\x18\b \x01(\v2/.teleport.workloadidentity.v1.JWTSVIDCredentialH\x00R\ajwtSvidB\f\n" +
 	"\n" +
-	"credential\"\x85\x03\n" +
+	"credential\"\x9b\x03\n" +
 	"\x1cIssueWorkloadIdentityRequest\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12X\n" +
 	"\x10x509_svid_params\x18\x02 \x01(\v2,.teleport.workloadidentity.v1.X509SVIDParamsH\x00R\x0ex509SvidParams\x12U\n" +
 	"\x0fjwt_svid_params\x18\x03 \x01(\v2+.teleport.workloadidentity.v1.JWTSVIDParamsH\x00R\rjwtSvidParams\x12R\n" +
 	"\x0eworkload_attrs\x18\x04 \x01(\v2+.teleport.workloadidentity.v1.WorkloadAttrsR\rworkloadAttrs\x12>\n" +
-	"\rrequested_ttl\x18\x05 \x01(\v2\x19.google.protobuf.DurationR\frequestedTtlB\f\n" +
+	"\rrequested_ttl\x18\x05 \x01(\v2\x19.google.protobuf.DurationR\frequestedTtl\x12\x14\n" +
+	"\x05scope\x18\x06 \x01(\tR\x05scopeB\f\n" +
 	"\n" +
 	"credential\"i\n" +
 	"\x1dIssueWorkloadIdentityResponse\x12H\n" +

--- a/api/proto/teleport/workloadidentity/v1/issuance_service.proto
+++ b/api/proto/teleport/workloadidentity/v1/issuance_service.proto
@@ -119,6 +119,10 @@ message IssueWorkloadIdentityRequest {
   // This may be adjusted by the server and therefore the client MUST check the
   // returned TTL rather than assuming that the requested TTL was granted.
   google.protobuf.Duration requested_ttl = 5;
+  // The scope the named WorkloadIdentity is expected to belong to. If unset, the
+  // WorkloadIdentity is expected to be unscoped. If the named WorkloadIdentity
+  // does not belong to this scope, a not found error is returned.
+  string scope = 6;
 }
 
 // The response for the IssueWorkloadIdentity RPC.

--- a/lib/auth/grpcserver.go
+++ b/lib/auth/grpcserver.go
@@ -6180,6 +6180,7 @@ func NewGRPCServer(cfg GRPCServerConfig) (*GRPCServer, error) {
 	}
 	workloadIdentityIssuanceService, err := workloadidentityv1.NewIssuanceService(&workloadidentityv1.IssuanceServiceConfig{
 		Authorizer:                 cfg.Authorizer,
+		ScopedAuthorizer:           cfg.ScopedAuthorizer,
 		Cache:                      cfg.AuthServer.Cache,
 		Emitter:                    cfg.Emitter,
 		Clock:                      cfg.AuthServer.GetClock(),

--- a/lib/auth/machineid/workloadidentityv1/issuer_service.go
+++ b/lib/auth/machineid/workloadidentityv1/issuer_service.go
@@ -177,13 +177,19 @@ func (s *IssuanceService) deriveAttrs(
 	user types.User,
 	workloadAttrs *workloadidentityv1pb.WorkloadAttrs,
 ) (*workloadidentityv1pb.Attrs, error) {
+	// user is nil for non-user identities (e.g. scoped agents); in that case,
+	// no user labels are exposed.
+	var userLabels map[string]string
+	if user != nil {
+		userLabels = user.GetAllLabels()
+	}
 	attrs := workloadidentityv1pb.Attrs_builder{
 		Workload: workloadAttrs,
 		User: workloadidentityv1pb.UserAttrs_builder{
 			Name:    identity.GetIdentity().Username,
 			IsBot:   identity.GetIdentity().BotName != "",
 			BotName: identity.GetIdentity().BotName,
-			Labels:  user.GetAllLabels(),
+			Labels:  userLabels,
 		}.Build(),
 		Join: identity.GetIdentity().JoinAttributes,
 	}.Build()

--- a/lib/auth/machineid/workloadidentityv1/issuer_service.go
+++ b/lib/auth/machineid/workloadidentityv1/issuer_service.go
@@ -100,6 +100,7 @@ type issuerCache interface {
 // IssuanceServiceConfig holds configuration options for the IssuanceService.
 type IssuanceServiceConfig struct {
 	Authorizer                 authz.Authorizer
+	ScopedAuthorizer           authz.ScopedAuthorizer
 	Cache                      issuerCache
 	Clock                      clockwork.Clock
 	Emitter                    apievents.Emitter
@@ -117,6 +118,7 @@ type IssuanceService struct {
 	workloadidentityv1pb.UnimplementedWorkloadIdentityIssuanceServiceServer
 
 	authorizer                 authz.Authorizer
+	scopedAuthorizer           authz.ScopedAuthorizer
 	cache                      issuerCache
 	clock                      clockwork.Clock
 	emitter                    apievents.Emitter
@@ -135,6 +137,8 @@ func NewIssuanceService(cfg *IssuanceServiceConfig) (*IssuanceService, error) {
 		return nil, trace.BadParameter("cache service is required")
 	case cfg.Authorizer == nil:
 		return nil, trace.BadParameter("authorizer is required")
+	case cfg.ScopedAuthorizer == nil:
+		return nil, trace.BadParameter("scoped authorizer is required")
 	case cfg.Emitter == nil:
 		return nil, trace.BadParameter("emitter is required")
 	case cfg.KeyStore == nil:
@@ -155,6 +159,7 @@ func NewIssuanceService(cfg *IssuanceServiceConfig) (*IssuanceService, error) {
 	}
 	return &IssuanceService{
 		authorizer:                 cfg.Authorizer,
+		scopedAuthorizer:           cfg.ScopedAuthorizer,
 		cache:                      cfg.Cache,
 		clock:                      cfg.Clock,
 		emitter:                    cfg.Emitter,
@@ -168,21 +173,22 @@ func NewIssuanceService(cfg *IssuanceServiceConfig) (*IssuanceService, error) {
 }
 
 func (s *IssuanceService) deriveAttrs(
-	authzCtx *authz.Context,
+	identity authz.IdentityGetter,
+	user types.User,
 	workloadAttrs *workloadidentityv1pb.WorkloadAttrs,
 ) (*workloadidentityv1pb.Attrs, error) {
 	attrs := workloadidentityv1pb.Attrs_builder{
 		Workload: workloadAttrs,
 		User: workloadidentityv1pb.UserAttrs_builder{
-			Name:    authzCtx.Identity.GetIdentity().Username,
-			IsBot:   authzCtx.Identity.GetIdentity().BotName != "",
-			BotName: authzCtx.Identity.GetIdentity().BotName,
-			Labels:  authzCtx.User.GetAllLabels(),
+			Name:    identity.GetIdentity().Username,
+			IsBot:   identity.GetIdentity().BotName != "",
+			BotName: identity.GetIdentity().BotName,
+			Labels:  user.GetAllLabels(),
 		}.Build(),
-		Join: authzCtx.Identity.GetIdentity().JoinAttributes,
+		Join: identity.GetIdentity().JoinAttributes,
 	}.Build()
 
-	for key, values := range authzCtx.Identity.GetIdentity().Traits {
+	for key, values := range identity.GetIdentity().Traits {
 		attrs.GetUser().SetTraits(append(attrs.GetUser().GetTraits(), traitv1.Trait_builder{
 			Key:    key,
 			Values: values,
@@ -212,14 +218,11 @@ func (s *IssuanceService) IssueWorkloadIdentity(
 		return nil, trace.BadParameter("at least one credential type must be requested")
 	}
 
-	authCtx, err := s.authorizer.Authorize(ctx)
+	authCtx, err := s.scopedAuthorizer.AuthorizeScoped(ctx)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	if err := authCtx.CheckAccessToKind(types.KindWorkloadIdentity, types.VerbRead); err != nil {
-		return nil, trace.Wrap(err)
-	}
-	attrs, err := s.deriveAttrs(authCtx, req.GetWorkloadAttrs())
+	attrs, err := s.deriveAttrs(authCtx.Identity, authCtx.User, req.GetWorkloadAttrs())
 	if err != nil {
 		return nil, trace.Wrap(err, "deriving attributes")
 	}
@@ -231,18 +234,28 @@ func (s *IssuanceService) IssueWorkloadIdentity(
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	// Check the principal has access to the workload identity resource by
-	// virtue of WorkloadIdentityLabels on a role.
-	if err := authCtx.Checker.CheckAccess(
-		types.Resource153ToResourceWithLabels(wi),
-		services.AccessState{},
-	); err != nil {
+
+	// TODO(strideynet): This check will be redundant once the backend/cache
+	// supports scope namespacing.
+	if wi.GetScope() != req.GetScope() {
+		return nil, trace.NotFound("workload_identity %q not found", req.GetName())
+	}
+
+	// Check the caller is authorized to issue using this WorkloadIdentity: within
+	// the resource's scope they must hold the read rule for the workload_identity
+	// kind AND match it via a workload_identity label selector.
+	if err := s.authorizeIssuance(ctx, authCtx, wi, types.VerbReadNoSecrets); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
 	decision := decide(ctx, wi, attrs, s.getSigstorePolicyEvaluator())
 	if !decision.shouldIssue {
 		return nil, trace.Wrap(decision.reason, "workload identity failed evaluation")
+	}
+	// Defense-in-depth: ensure templating did not produce a SPIFFE ID that
+	// violates our rules.
+	if err := validateRenderedWorkloadIdentity(decision.templatedWorkloadIdentity); err != nil {
+		return nil, trace.Wrap(err)
 	}
 
 	var cred *workloadidentityv1pb.Credential
@@ -315,14 +328,19 @@ func (s *IssuanceService) IssueWorkloadIdentities(
 		return nil, trace.BadParameter("at least one credential type must be requested")
 	}
 
-	authCtx, err := s.authorizer.Authorize(ctx)
+	authCtx, err := s.scopedAuthorizer.AuthorizeScoped(ctx)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	if err := authCtx.CheckAccessToKind(types.KindWorkloadIdentity, types.VerbRead, types.VerbList); err != nil {
+	// Before we hit the db, perform cheap check to ensure user could issue
+	// /any/ workload identity at all.
+	ruleCtx := authCtx.RuleContext()
+	if err := authCtx.CheckerContext.CheckMaybeHasAccessToRules(
+		&ruleCtx, types.KindWorkloadIdentity, types.VerbReadNoSecrets, types.VerbList,
+	); err != nil {
 		return nil, trace.Wrap(err)
 	}
-	attrs, err := s.deriveAttrs(authCtx, req.GetWorkloadAttrs())
+	attrs, err := s.deriveAttrs(authCtx.Identity, authCtx.User, req.GetWorkloadAttrs())
 	if err != nil {
 		return nil, trace.Wrap(err, "deriving attributes")
 	}
@@ -343,6 +361,11 @@ func (s *IssuanceService) IssueWorkloadIdentities(
 
 		decision := decide(ctx, wi, attrs, s.getSigstorePolicyEvaluator())
 		if decision.shouldIssue {
+			// Defense-in-depth: ensure templating did not produce a SPIFFE ID
+			// that escapes the WorkloadIdentity's scope.
+			if err := validateRenderedWorkloadIdentity(decision.templatedWorkloadIdentity); err != nil {
+				return nil, trace.Wrap(err)
+			}
 			shouldIssue = append(shouldIssue, decision.templatedWorkloadIdentity)
 		}
 		if len(shouldIssue) > maxWorkloadIdentitiesIssued {
@@ -854,6 +877,7 @@ func baseEvent(
 		Hint:                     wi.GetSpec().GetSpiffe().GetHint(),
 		WorkloadIdentity:         wi.GetMetadata().GetName(),
 		WorkloadIdentityRevision: wi.GetMetadata().GetRevision(),
+		WorkloadIdentityScope:    wi.GetScope(),
 		Attributes:               structAttrs,
 		NameSelector:             nameSelector,
 		LabelSelectors:           labelSelectorsToAudit(labelSelectors),
@@ -1149,26 +1173,20 @@ func (s *IssuanceService) issueJWTSVID(ctx context.Context, params issueJWTSVIDP
 }
 
 // matchingAndAuthorizedWorkloadIdentities returns a stream of the workload
-// identities that match the provided labels and that the principal has access
-// to.
+// identities that match the provided labels and that the caller is authorized
+// to issue using.
 func (s *IssuanceService) matchingAndAuthorizedWorkloadIdentities(
 	ctx context.Context,
-	authCtx *authz.Context,
+	authCtx *authz.ScopedContext,
 	labels types.Labels,
 ) iter.Seq2[*workloadidentityv1pb.WorkloadIdentity, error] {
 	return func(yield func(*workloadidentityv1pb.WorkloadIdentity, error) bool) {
-		for wid, err := range s.cache.RangeWorkloadIdentities(ctx, "", "", "", false) {
+		for wid, err := range s.cache.RangeWorkloadIdentities(
+			ctx, "", "", "", false,
+		) {
 			if err != nil {
 				yield(nil, trace.Wrap(err))
 				return
-			}
-
-			// Filter out WI the principal cannot access.
-			if err := authCtx.Checker.CheckAccess(
-				types.Resource153ToResourceWithLabels(wid),
-				services.AccessState{},
-			); err != nil {
-				continue
 			}
 
 			// Filter out WI that do not match the label selector.
@@ -1184,11 +1202,66 @@ func (s *IssuanceService) matchingAndAuthorizedWorkloadIdentities(
 				continue
 			}
 
+			// Silently skip WI the caller is not authorized to issue using.
+			if err := s.authorizeIssuance(
+				ctx, authCtx, wid, types.VerbReadNoSecrets, types.VerbList,
+			); err != nil {
+				continue
+			}
+
 			if !yield(wid, nil) {
 				return
 			}
 		}
 	}
+}
+
+func (s *IssuanceService) authorizeIssuance(
+	ctx context.Context,
+	authCtx *authz.ScopedContext,
+	wi *workloadidentityv1pb.WorkloadIdentity,
+	verbs ...string,
+) error {
+	ruleCtx := authCtx.RuleContext()
+	ruleCtx.Resource153 = wi
+	// Rule-based access: the caller must hold the read/list verbs in the scope.
+	if err := authCtx.CheckerContext.Decision(
+		ctx, wi.GetScope(), func(checker *services.ScopedAccessChecker) error {
+			return checker.CheckAccessToRules(&ruleCtx, types.KindWorkloadIdentity, verbs...)
+		},
+	); err != nil {
+		return trace.Wrap(err)
+	}
+
+	// TODO(strideynet): Can we merge these two decision checks into a single
+	// check? I assume yes - even better if CheckAccessToWorkloadIdentity
+	// also checks access to rules??
+
+	// Label-based issuance grant: the caller must match the resource by virtue of
+	// a workload_identity label selector in the scope.
+	if err := authCtx.CheckerContext.Decision(
+		ctx, wi.GetScope(), func(checker *services.ScopedAccessChecker) error {
+			return checker.CheckAccessToWorkloadIdentity(wi)
+		},
+	); err != nil {
+		return trace.Wrap(err)
+	}
+	return nil
+}
+
+// validateRenderedWorkloadIdentity re-validates that a scoped WorkloadIdentity's
+// rendered (post-templating) SPIFFE ID still conforms to its scope.
+func validateRenderedWorkloadIdentity(wi *workloadidentityv1pb.WorkloadIdentity) error {
+	// No special rules for unscoped workload identities.
+	if wi.GetScope() == "" {
+		return nil
+	}
+	if err := services.ValidateScopedSPIFFEID(
+		wi.GetScope(), wi.GetSpec().GetSpiffe().GetId(),
+	); err != nil {
+		return trace.Wrap(err, "validating rendered SPIFFE ID against scope")
+	}
+	return nil
 }
 
 func convertLabels(selectors []*workloadidentityv1pb.LabelSelector) types.Labels {

--- a/lib/auth/machineid/workloadidentityv1/issuer_service.go
+++ b/lib/auth/machineid/workloadidentityv1/issuer_service.go
@@ -1217,29 +1217,19 @@ func (s *IssuanceService) authorizeIssuance(
 ) error {
 	ruleCtx := authCtx.RuleContext()
 	ruleCtx.Resource153 = wi
-	// Rule-based access: the caller must hold the read/list verbs in the scope.
-	if err := authCtx.CheckerContext.Decision(
+	// The caller must hold the given verbs for the workload_identity kind and
+	// match the resource via a workload_identity label selector. Both checks
+	// run within a single Decision so that, for scoped identities, a single
+	// role must carry both grants - grants do not aggregate across scoped
+	// roles.
+	return trace.Wrap(authCtx.CheckerContext.Decision(
 		ctx, wi.GetScope(), func(checker *services.ScopedAccessChecker) error {
-			return checker.CheckAccessToRules(&ruleCtx, types.KindWorkloadIdentity, verbs...)
+			if err := checker.CheckAccessToRules(&ruleCtx, types.KindWorkloadIdentity, verbs...); err != nil {
+				return trace.Wrap(err)
+			}
+			return trace.Wrap(checker.CheckAccessToWorkloadIdentity(wi))
 		},
-	); err != nil {
-		return trace.Wrap(err)
-	}
-
-	// TODO(strideynet): Can we merge these two decision checks into a single
-	// check? I assume yes - even better if CheckAccessToWorkloadIdentity
-	// also checks access to rules??
-
-	// Label-based issuance grant: the caller must match the resource by virtue of
-	// a workload_identity label selector in the scope.
-	if err := authCtx.CheckerContext.Decision(
-		ctx, wi.GetScope(), func(checker *services.ScopedAccessChecker) error {
-			return checker.CheckAccessToWorkloadIdentity(wi)
-		},
-	); err != nil {
-		return trace.Wrap(err)
-	}
-	return nil
+	))
 }
 
 // validateRenderedWorkloadIdentity re-validates that a scoped WorkloadIdentity's

--- a/lib/auth/machineid/workloadidentityv1/issuer_service.go
+++ b/lib/auth/machineid/workloadidentityv1/issuer_service.go
@@ -227,18 +227,12 @@ func (s *IssuanceService) IssueWorkloadIdentity(
 		return nil, trace.Wrap(err, "deriving attributes")
 	}
 
-	// TODO(strideynet): Update to accept scope param and pass down here.
 	wi, err := s.cache.GetWorkloadIdentity(ctx, workloadidentityv1pb.GetWorkloadIdentityRequest_builder{
-		Name: req.GetName(),
+		Scope: req.GetScope(),
+		Name:  req.GetName(),
 	}.Build())
 	if err != nil {
 		return nil, trace.Wrap(err)
-	}
-
-	// TODO(strideynet): This check will be redundant once the backend/cache
-	// supports scope namespacing.
-	if wi.GetScope() != req.GetScope() {
-		return nil, trace.NotFound("workload_identity %q not found", req.GetName())
 	}
 
 	// Check the caller is authorized to issue using this WorkloadIdentity: within

--- a/lib/auth/machineid/workloadidentityv1/issuer_service.go
+++ b/lib/auth/machineid/workloadidentityv1/issuer_service.go
@@ -235,9 +235,6 @@ func (s *IssuanceService) IssueWorkloadIdentity(
 		return nil, trace.Wrap(err)
 	}
 
-	// Check the caller is authorized to issue using this WorkloadIdentity: within
-	// the resource's scope they must hold the read rule for the workload_identity
-	// kind AND match it via a workload_identity label selector.
 	if err := s.authorizeIssuance(ctx, authCtx, wi, types.VerbReadNoSecrets); err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -246,8 +243,6 @@ func (s *IssuanceService) IssueWorkloadIdentity(
 	if !decision.shouldIssue {
 		return nil, trace.Wrap(decision.reason, "workload identity failed evaluation")
 	}
-	// Defense-in-depth: ensure templating did not produce a SPIFFE ID that
-	// violates our rules.
 	if err := validateRenderedWorkloadIdentity(decision.templatedWorkloadIdentity); err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -355,8 +350,6 @@ func (s *IssuanceService) IssueWorkloadIdentities(
 
 		decision := decide(ctx, wi, attrs, s.getSigstorePolicyEvaluator())
 		if decision.shouldIssue {
-			// Defense-in-depth: ensure templating did not produce a SPIFFE ID
-			// that escapes the WorkloadIdentity's scope.
 			if err := validateRenderedWorkloadIdentity(decision.templatedWorkloadIdentity); err != nil {
 				return nil, trace.Wrap(err)
 			}

--- a/lib/auth/machineid/workloadidentityv1/workloadidentityv1_test.go
+++ b/lib/auth/machineid/workloadidentityv1/workloadidentityv1_test.go
@@ -677,6 +677,24 @@ func TestIssueWorkloadIdentity(t *testing.T) {
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = scopedIssuerClient.Close() })
 
+	// A user whose verb and label grants are split across two scoped roles in
+	// the same scope. Issuance requires a single role to hold both grants.
+	splitRulesRole := createScopedWorkloadIdentityRole(
+		t, adminClient, "split-rules-role", scopedScope,
+		[]string{types.VerbReadNoSecrets, types.VerbList}, nil,
+	)
+	splitLabelsRole := createScopedWorkloadIdentityRole(
+		t, adminClient, "split-labels-role", scopedScope,
+		nil, map[string][]string{"foo": {"bar"}},
+	)
+	splitGrantIssuer := createScopedWorkloadIdentityUser(
+		t, tp.srv, adminClient, "split-grant-issuer", scopedScope,
+		splitRulesRole, splitLabelsRole,
+	)
+	splitGrantClient, err := tp.srv.NewClient(authtest.TestScopedUser(splitGrantIssuer, scopedScope))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = splitGrantClient.Close() })
+
 	// A WorkloadIdentity in the issuer's scope it can access (label match).
 	scopedWI, err := tp.srv.Auth().CreateWorkloadIdentity(ctx,
 		scopedWorkloadIdentityWithLabels("scoped-wi", scopedScope, scopedScope+"/_/foo", map[string]string{"foo": "bar"}))
@@ -752,6 +770,22 @@ func TestIssueWorkloadIdentity(t *testing.T) {
 			req: workloadidentityv1pb.IssueWorkloadIdentityRequest_builder{
 				Name:          otherScopeWI.GetMetadata().GetName(),
 				Scope:         otherScope,
+				JwtSvidParams: workloadidentityv1pb.JWTSVIDParams_builder{Audiences: []string{"example.com"}}.Build(),
+				WorkloadAttrs: workloadAttrs(nil),
+			}.Build(),
+			requireErr: func(t require.TestingT, err error, i ...any) {
+				require.True(t, trace.IsAccessDenied(err), "expected AccessDenied, got %v", err)
+			},
+		},
+		{
+			// The verb and label grants are split across two roles in the
+			// scope; scoped roles are evaluated in isolation, so a single role
+			// must hold both grants and issuance is denied.
+			name:   "scoped split-role grants denied",
+			client: splitGrantClient,
+			req: workloadidentityv1pb.IssueWorkloadIdentityRequest_builder{
+				Name:          scopedWI.GetMetadata().GetName(),
+				Scope:         scopedScope,
 				JwtSvidParams: workloadidentityv1pb.JWTSVIDParams_builder{Audiences: []string{"example.com"}}.Build(),
 				WorkloadAttrs: workloadAttrs(nil),
 			}.Build(),
@@ -4671,56 +4705,80 @@ func scopedWorkloadIdentityWithLabels(name, scope, spiffeID string, labels map[s
 	return wi
 }
 
-// newScopedWorkloadIdentityIssuer creates a user assigned a scoped role that
-// grants both the rules (read_no_secrets + list) and the workload_identity
-// label selector required to issue SVIDs using scoped WorkloadIdentities within
-// the given scope. It returns the username, which can be used with
-// authtest.TestScopedUser to mint a client pinned to that scope.
-func newScopedWorkloadIdentityIssuer(
+// createScopedWorkloadIdentityRole creates a scoped role assignable within the
+// given scope, granting the given rule verbs for the workload_identity kind
+// (if any) and the given workload_identity label selector (if any). Returns
+// the role name.
+func createScopedWorkloadIdentityRole(
 	t *testing.T,
-	srv *authtest.TLSServer,
 	adminClient *authclient.Client,
-	username string,
+	roleName string,
 	scope string,
+	verbs []string,
 	labels map[string][]string,
 ) string {
 	t.Helper()
 	ctx := t.Context()
 
-	wiLabels := make([]*labelv1.Label, 0, len(labels))
-	for name, values := range labels {
-		wiLabels = append(wiLabels, labelv1.Label_builder{Name: name, Values: values}.Build())
+	spec := scopedaccessv1.ScopedRoleSpec_builder{
+		AssignableScopes: []string{scope},
+	}
+	if len(verbs) > 0 {
+		spec.Rules = []*scopedaccessv1.ScopedRule{
+			scopedaccessv1.ScopedRule_builder{
+				Resources: []string{types.KindWorkloadIdentity},
+				Verbs:     verbs,
+			}.Build(),
+		}
+	}
+	if len(labels) > 0 {
+		wiLabels := make([]*labelv1.Label, 0, len(labels))
+		for labelName, values := range labels {
+			wiLabels = append(wiLabels, labelv1.Label_builder{Name: labelName, Values: values}.Build())
+		}
+		spec.WorkloadIdentity = scopedaccessv1.ScopedRoleWorkloadIdentity_builder{
+			Labels: wiLabels,
+		}.Build()
 	}
 
-	scopedSvc := adminClient.ScopedAccessServiceClient()
-	role, err := scopedSvc.CreateScopedRole(ctx, scopedaccessv1.CreateScopedRoleRequest_builder{
+	role, err := adminClient.ScopedAccessServiceClient().CreateScopedRole(ctx, scopedaccessv1.CreateScopedRoleRequest_builder{
 		Role: scopedaccessv1.ScopedRole_builder{
 			Kind:    scopedaccess.KindScopedRole,
 			Version: types.V1,
 			Metadata: headerv1.Metadata_builder{
-				Name: username + "-role",
+				Name: roleName,
 			}.Build(),
 			Scope: "/scopes",
-			Spec: scopedaccessv1.ScopedRoleSpec_builder{
-				AssignableScopes: []string{scope},
-				Rules: []*scopedaccessv1.ScopedRule{
-					scopedaccessv1.ScopedRule_builder{
-						Resources: []string{types.KindWorkloadIdentity},
-						Verbs:     []string{types.VerbReadNoSecrets, types.VerbList},
-					}.Build(),
-				},
-				WorkloadIdentity: scopedaccessv1.ScopedRoleWorkloadIdentity_builder{
-					Labels: wiLabels,
-				}.Build(),
-			}.Build(),
+			Spec:  spec.Build(),
 		}.Build(),
 	}.Build())
 	require.NoError(t, err)
+	return role.GetRole().GetMetadata().GetName()
+}
+
+// createScopedWorkloadIdentityUser creates a user assigned the given scoped
+// roles within the given scope, and waits for the assignment to propagate to
+// the cache used by the authorizer. It returns the username, which can be used
+// with authtest.TestScopedUser to mint a client pinned to that scope.
+func createScopedWorkloadIdentityUser(
+	t *testing.T,
+	srv *authtest.TLSServer,
+	adminClient *authclient.Client,
+	username string,
+	scope string,
+	roleNames ...string,
+) string {
+	t.Helper()
+	ctx := t.Context()
 
 	user, err := authtest.CreateUser(ctx, srv.Auth(), username)
 	require.NoError(t, err)
 
-	resp, err := scopedSvc.CreateScopedRoleAssignment(ctx, scopedaccessv1.CreateScopedRoleAssignmentRequest_builder{
+	assignments := make([]*scopedaccessv1.Assignment, 0, len(roleNames))
+	for _, roleName := range roleNames {
+		assignments = append(assignments, scopedaccessv1.Assignment_builder{Role: roleName, Scope: scope}.Build())
+	}
+	resp, err := adminClient.ScopedAccessServiceClient().CreateScopedRoleAssignment(ctx, scopedaccessv1.CreateScopedRoleAssignmentRequest_builder{
 		Assignment: scopedaccessv1.ScopedRoleAssignment_builder{
 			Kind:    scopedaccess.KindScopedRoleAssignment,
 			SubKind: scopedaccess.SubKindDynamic,
@@ -4730,10 +4788,8 @@ func newScopedWorkloadIdentityIssuer(
 			}.Build(),
 			Scope: "/scopes",
 			Spec: scopedaccessv1.ScopedRoleAssignmentSpec_builder{
-				User: user.GetName(),
-				Assignments: []*scopedaccessv1.Assignment{
-					scopedaccessv1.Assignment_builder{Role: role.GetRole().GetMetadata().GetName(), Scope: scope}.Build(),
-				},
+				User:        user.GetName(),
+				Assignments: assignments,
 			}.Build(),
 		}.Build(),
 	}.Build())
@@ -4749,4 +4805,25 @@ func newScopedWorkloadIdentityIssuer(
 	}, 10*time.Second, 100*time.Millisecond)
 
 	return user.GetName()
+}
+
+// newScopedWorkloadIdentityIssuer creates a user assigned a single scoped role
+// that grants both the rules (read_no_secrets + list) and the workload_identity
+// label selector required to issue SVIDs using scoped WorkloadIdentities within
+// the given scope. It returns the username, which can be used with
+// authtest.TestScopedUser to mint a client pinned to that scope.
+func newScopedWorkloadIdentityIssuer(
+	t *testing.T,
+	srv *authtest.TLSServer,
+	adminClient *authclient.Client,
+	username string,
+	scope string,
+	labels map[string][]string,
+) string {
+	t.Helper()
+	role := createScopedWorkloadIdentityRole(
+		t, adminClient, username+"-role", scope,
+		[]string{types.VerbReadNoSecrets, types.VerbList}, labels,
+	)
+	return createScopedWorkloadIdentityUser(t, srv, adminClient, username, scope, role)
 }

--- a/lib/auth/machineid/workloadidentityv1/workloadidentityv1_test.go
+++ b/lib/auth/machineid/workloadidentityv1/workloadidentityv1_test.go
@@ -661,11 +661,9 @@ func TestIssueWorkloadIdentity(t *testing.T) {
 		return attrs
 	}
 
-	// Scoped issuance setup: a user authorized to issue using WorkloadIdentities
-	// labeled foo=bar within /test-scope (holding both the read_no_secrets/list
-	// rules and the workload_identity label selector), plus scoped resources
-	// covering the success, scope-mismatch, label-mismatch, cross-scope, and
-	// templating-escape paths.
+	// Scoped issuance setup: a user authorized to issue using foo=bar-labeled
+	// WorkloadIdentities within its scope, plus scoped resources for the
+	// scoped table cases below.
 	adminClient, err := tp.srv.NewClient(authtest.TestAdmin())
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = adminClient.Close() })
@@ -679,11 +677,11 @@ func TestIssueWorkloadIdentity(t *testing.T) {
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = scopedIssuerClient.Close() })
 
-	// A WorkloadIdentity in /test-scope the issuer can access (label match).
+	// A WorkloadIdentity in the issuer's scope it can access (label match).
 	scopedWI, err := tp.srv.Auth().CreateWorkloadIdentity(ctx,
 		scopedWorkloadIdentityWithLabels("scoped-wi", scopedScope, scopedScope+"/_/foo", map[string]string{"foo": "bar"}))
 	require.NoError(t, err)
-	// A WorkloadIdentity in /test-scope the issuer cannot access (label mismatch).
+	// A WorkloadIdentity in the issuer's scope it cannot access (label mismatch).
 	unmatchedWI, err := tp.srv.Auth().CreateWorkloadIdentity(ctx,
 		scopedWorkloadIdentityWithLabels("unmatched-wi", scopedScope, scopedScope+"/_/nope", map[string]string{"foo": "other"}))
 	require.NoError(t, err)
@@ -733,8 +731,8 @@ func TestIssueWorkloadIdentity(t *testing.T) {
 			},
 		},
 		{
-			// The issuer holds the rules in /test-scope but the resource's labels
-			// do not match its workload_identity label selector.
+			// The issuer holds the rules in the resource's scope but the resource's
+			// labels do not match its workload_identity label selector.
 			name:   "scoped label mismatch denied",
 			client: scopedIssuerClient,
 			req: workloadidentityv1pb.IssueWorkloadIdentityRequest_builder{
@@ -748,7 +746,7 @@ func TestIssueWorkloadIdentity(t *testing.T) {
 			},
 		},
 		{
-			// The issuer is not assigned any role in /other-scope.
+			// The issuer is not assigned any role in the resource's scope.
 			name:   "scoped cross-scope denied",
 			client: scopedIssuerClient,
 			req: workloadidentityv1pb.IssueWorkloadIdentityRequest_builder{
@@ -1598,9 +1596,8 @@ func TestIssueWorkloadIdentities(t *testing.T) {
 		}
 		return attrs
 	}
-	// Scoped issuance: a user pinned to /test-scope, granted the rules and a
-	// scoped=plural label selector, may only issue using scoped WorkloadIdentities
-	// in /test-scope — not identically-labeled ones in other scopes.
+	// Scoped issuance setup: an issuer scoped to one scope, with
+	// identically-labeled WorkloadIdentities in two scopes.
 	adminClient, err := tp.srv.NewClient(authtest.TestAdmin())
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = adminClient.Close() })
@@ -1628,8 +1625,9 @@ func TestIssueWorkloadIdentities(t *testing.T) {
 		assert     func(*testing.T, *workloadidentityv1pb.IssueWorkloadIdentitiesResponse)
 	}{
 		{
-			// Only the /test-scope identity is issued; the identically-labeled
-			// /other-scope identity is filtered out by per-item scope authz.
+			// Only the identity in the issuer's scope is issued; the
+			// identically-labeled one in the other scope is filtered out by
+			// per-item scope authz.
 			name:   "scoped filtered by scope",
 			client: scopedIssuerClient,
 			req: workloadidentityv1pb.IssueWorkloadIdentitiesRequest_builder{

--- a/lib/auth/machineid/workloadidentityv1/workloadidentityv1_test.go
+++ b/lib/auth/machineid/workloadidentityv1/workloadidentityv1_test.go
@@ -662,7 +662,7 @@ func TestIssueWorkloadIdentity(t *testing.T) {
 	}
 
 	// Scoped issuance setup: a user authorized to issue using WorkloadIdentities
-	// labelled foo=bar within /test-scope (holding both the read_no_secrets/list
+	// labeled foo=bar within /test-scope (holding both the read_no_secrets/list
 	// rules and the workload_identity label selector), plus scoped resources
 	// covering the success, scope-mismatch, label-mismatch, cross-scope, and
 	// templating-escape paths.
@@ -1600,7 +1600,7 @@ func TestIssueWorkloadIdentities(t *testing.T) {
 	}
 	// Scoped issuance: a user pinned to /test-scope, granted the rules and a
 	// scoped=plural label selector, may only issue using scoped WorkloadIdentities
-	// in /test-scope — not identically-labelled ones in other scopes.
+	// in /test-scope — not identically-labeled ones in other scopes.
 	adminClient, err := tp.srv.NewClient(authtest.TestAdmin())
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = adminClient.Close() })
@@ -1628,7 +1628,7 @@ func TestIssueWorkloadIdentities(t *testing.T) {
 		assert     func(*testing.T, *workloadidentityv1pb.IssueWorkloadIdentitiesResponse)
 	}{
 		{
-			// Only the /test-scope identity is issued; the identically-labelled
+			// Only the /test-scope identity is issued; the identically-labeled
 			// /other-scope identity is filtered out by per-item scope authz.
 			name:   "scoped filtered by scope",
 			client: scopedIssuerClient,

--- a/lib/auth/machineid/workloadidentityv1/workloadidentityv1_test.go
+++ b/lib/auth/machineid/workloadidentityv1/workloadidentityv1_test.go
@@ -57,6 +57,7 @@ import (
 
 	apiproto "github.com/gravitational/teleport/api/client/proto"
 	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
+	labelv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/label/v1"
 	machineidv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/machineid/v1"
 	scopedaccessv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/access/v1"
 	workloadidentityv1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/workloadidentity/v1"
@@ -141,7 +142,10 @@ type issuanceTestPack struct {
 }
 
 func newIssuanceTestPack(t *testing.T, ctx context.Context) *issuanceTestPack {
-	srv, eventRecorder := newTestTLSServer(t)
+	// Scopes are enabled so the issuance RPCs (which authorize via the scoped
+	// authorizer) can serve both unscoped and scoped identities. Unscoped
+	// issuance is unaffected by enabling the feature.
+	srv, eventRecorder := newTestTLSServerWithScopesFeatures(t, scopes.Features{Enabled: true})
 	clock := srv.Auth().GetClock()
 	fakeClock, ok := clock.(*clockwork.FakeClock)
 	require.True(t, ok, "expected to be a clockwork.FakeClock but got %T", clock)
@@ -656,6 +660,43 @@ func TestIssueWorkloadIdentity(t *testing.T) {
 		}
 		return attrs
 	}
+
+	// Scoped issuance setup: a user authorized to issue using WorkloadIdentities
+	// labelled foo=bar within /test-scope (holding both the read_no_secrets/list
+	// rules and the workload_identity label selector), plus scoped resources
+	// covering the success, scope-mismatch, label-mismatch, cross-scope, and
+	// templating-escape paths.
+	adminClient, err := tp.srv.NewClient(authtest.TestAdmin())
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = adminClient.Close() })
+	const scopedScope = "/scopes/test"
+	const otherScope = "/scopes/other"
+	scopedIssuer := newScopedWorkloadIdentityIssuer(
+		t, tp.srv, adminClient, "scoped-issuer", scopedScope,
+		map[string][]string{"foo": {"bar"}},
+	)
+	scopedIssuerClient, err := tp.srv.NewClient(authtest.TestScopedUser(scopedIssuer, scopedScope))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = scopedIssuerClient.Close() })
+
+	// A WorkloadIdentity in /test-scope the issuer can access (label match).
+	scopedWI, err := tp.srv.Auth().CreateWorkloadIdentity(ctx,
+		scopedWorkloadIdentityWithLabels("scoped-wi", scopedScope, scopedScope+"/_/foo", map[string]string{"foo": "bar"}))
+	require.NoError(t, err)
+	// A WorkloadIdentity in /test-scope the issuer cannot access (label mismatch).
+	unmatchedWI, err := tp.srv.Auth().CreateWorkloadIdentity(ctx,
+		scopedWorkloadIdentityWithLabels("unmatched-wi", scopedScope, scopedScope+"/_/nope", map[string]string{"foo": "other"}))
+	require.NoError(t, err)
+	// A WorkloadIdentity in a scope the issuer is not assigned to.
+	otherScopeWI, err := tp.srv.Auth().CreateWorkloadIdentity(ctx,
+		scopedWorkloadIdentityWithLabels("other-scope-wi", otherScope, otherScope+"/_/foo", map[string]string{"foo": "bar"}))
+	require.NoError(t, err)
+	// A WorkloadIdentity whose templated SPIFFE ID can be made to escape its
+	// scope at issuance time.
+	templateEscapeWI, err := tp.srv.Auth().CreateWorkloadIdentity(ctx,
+		scopedWorkloadIdentityWithLabels("template-escape-wi", scopedScope, scopedScope+"/_/{{ workload.kubernetes.namespace }}", map[string]string{"foo": "bar"}))
+	require.NoError(t, err)
+
 	tests := []struct {
 		name       string
 		client     *authclient.Client
@@ -663,6 +704,80 @@ func TestIssueWorkloadIdentity(t *testing.T) {
 		requireErr require.ErrorAssertionFunc
 		assert     func(*testing.T, *workloadidentityv1pb.IssueWorkloadIdentityResponse)
 	}{
+		{
+			name:   "scoped success",
+			client: scopedIssuerClient,
+			req: workloadidentityv1pb.IssueWorkloadIdentityRequest_builder{
+				Name:          scopedWI.GetMetadata().GetName(),
+				Scope:         scopedScope,
+				JwtSvidParams: workloadidentityv1pb.JWTSVIDParams_builder{Audiences: []string{"example.com"}}.Build(),
+				WorkloadAttrs: workloadAttrs(nil),
+			}.Build(),
+			requireErr: require.NoError,
+			assert: func(t *testing.T, res *workloadidentityv1pb.IssueWorkloadIdentityResponse) {
+				require.Equal(t, "spiffe://localhost/scopes/test/_/foo", res.GetCredential().GetSpiffeId())
+			},
+		},
+		{
+			// Addressing a scoped WorkloadIdentity without the matching scope
+			// (here, as unscoped) must not reveal its existence.
+			name:   "scoped scope mismatch is not found",
+			client: scopedIssuerClient,
+			req: workloadidentityv1pb.IssueWorkloadIdentityRequest_builder{
+				Name:          scopedWI.GetMetadata().GetName(),
+				JwtSvidParams: workloadidentityv1pb.JWTSVIDParams_builder{Audiences: []string{"example.com"}}.Build(),
+				WorkloadAttrs: workloadAttrs(nil),
+			}.Build(),
+			requireErr: func(t require.TestingT, err error, i ...any) {
+				require.True(t, trace.IsNotFound(err), "expected NotFound, got %v", err)
+			},
+		},
+		{
+			// The issuer holds the rules in /test-scope but the resource's labels
+			// do not match its workload_identity label selector.
+			name:   "scoped label mismatch denied",
+			client: scopedIssuerClient,
+			req: workloadidentityv1pb.IssueWorkloadIdentityRequest_builder{
+				Name:          unmatchedWI.GetMetadata().GetName(),
+				Scope:         scopedScope,
+				JwtSvidParams: workloadidentityv1pb.JWTSVIDParams_builder{Audiences: []string{"example.com"}}.Build(),
+				WorkloadAttrs: workloadAttrs(nil),
+			}.Build(),
+			requireErr: func(t require.TestingT, err error, i ...any) {
+				require.True(t, trace.IsAccessDenied(err), "expected AccessDenied, got %v", err)
+			},
+		},
+		{
+			// The issuer is not assigned any role in /other-scope.
+			name:   "scoped cross-scope denied",
+			client: scopedIssuerClient,
+			req: workloadidentityv1pb.IssueWorkloadIdentityRequest_builder{
+				Name:          otherScopeWI.GetMetadata().GetName(),
+				Scope:         otherScope,
+				JwtSvidParams: workloadidentityv1pb.JWTSVIDParams_builder{Audiences: []string{"example.com"}}.Build(),
+				WorkloadAttrs: workloadAttrs(nil),
+			}.Build(),
+			requireErr: func(t require.TestingT, err error, i ...any) {
+				require.True(t, trace.IsAccessDenied(err), "expected AccessDenied, got %v", err)
+			},
+		},
+		{
+			// Defense-in-depth: templating renders a SPIFFE ID that escapes the
+			// scope (two separators), which the rendered-ID re-validation rejects.
+			name:   "scoped templating escape rejected",
+			client: scopedIssuerClient,
+			req: workloadidentityv1pb.IssueWorkloadIdentityRequest_builder{
+				Name:          templateEscapeWI.GetMetadata().GetName(),
+				Scope:         scopedScope,
+				JwtSvidParams: workloadidentityv1pb.JWTSVIDParams_builder{Audiences: []string{"example.com"}}.Build(),
+				WorkloadAttrs: workloadAttrs(func(attrs *workloadidentityv1pb.WorkloadAttrs) {
+					attrs.GetKubernetes().SetNamespace("escaped/_/elevated")
+				}),
+			}.Build(),
+			requireErr: func(t require.TestingT, err error, i ...any) {
+				require.True(t, trace.IsBadParameter(err), "expected BadParameter, got %v", err)
+			},
+		},
 		{
 			name:   "jwt svid",
 			client: wilcardAccessClient,
@@ -1483,6 +1598,28 @@ func TestIssueWorkloadIdentities(t *testing.T) {
 		}
 		return attrs
 	}
+	// Scoped issuance: a user pinned to /test-scope, granted the rules and a
+	// scoped=plural label selector, may only issue using scoped WorkloadIdentities
+	// in /test-scope — not identically-labelled ones in other scopes.
+	adminClient, err := tp.srv.NewClient(authtest.TestAdmin())
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = adminClient.Close() })
+	const scopedScope = "/scopes/test"
+	const otherScope = "/scopes/other"
+	scopedIssuer := newScopedWorkloadIdentityIssuer(
+		t, tp.srv, adminClient, "scoped-issuer", scopedScope,
+		map[string][]string{"scoped": {"plural"}},
+	)
+	scopedIssuerClient, err := tp.srv.NewClient(authtest.TestScopedUser(scopedIssuer, scopedScope))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = scopedIssuerClient.Close() })
+	_, err = tp.srv.Auth().CreateWorkloadIdentity(ctx,
+		scopedWorkloadIdentityWithLabels("scoped-plural-a", scopedScope, scopedScope+"/_/a", map[string]string{"scoped": "plural"}))
+	require.NoError(t, err)
+	_, err = tp.srv.Auth().CreateWorkloadIdentity(ctx,
+		scopedWorkloadIdentityWithLabels("scoped-plural-other", otherScope, otherScope+"/_/b", map[string]string{"scoped": "plural"}))
+	require.NoError(t, err)
+
 	tests := []struct {
 		name       string
 		client     *authclient.Client
@@ -1490,6 +1627,32 @@ func TestIssueWorkloadIdentities(t *testing.T) {
 		requireErr require.ErrorAssertionFunc
 		assert     func(*testing.T, *workloadidentityv1pb.IssueWorkloadIdentitiesResponse)
 	}{
+		{
+			// Only the /test-scope identity is issued; the identically-labelled
+			// /other-scope identity is filtered out by per-item scope authz.
+			name:   "scoped filtered by scope",
+			client: scopedIssuerClient,
+			req: workloadidentityv1pb.IssueWorkloadIdentitiesRequest_builder{
+				LabelSelectors: []*workloadidentityv1pb.LabelSelector{
+					workloadidentityv1pb.LabelSelector_builder{
+						Key:    "scoped",
+						Values: []string{"plural"},
+					}.Build(),
+				},
+				JwtSvidParams: workloadidentityv1pb.JWTSVIDParams_builder{
+					Audiences: []string{"example.com"},
+				}.Build(),
+				WorkloadAttrs: workloadAttrs(nil),
+			}.Build(),
+			requireErr: require.NoError,
+			assert: func(t *testing.T, res *workloadidentityv1pb.IssueWorkloadIdentitiesResponse) {
+				issued := []string{}
+				for _, cred := range res.GetCredentials() {
+					issued = append(issued, cred.GetWorkloadIdentityName())
+				}
+				require.ElementsMatch(t, []string{"scoped-plural-a"}, issued)
+			},
+		},
 		{
 			name:   "jwt svid",
 			client: client,
@@ -4499,4 +4662,93 @@ func scopedWorkloadIdentity(name, scope, spiffeID string) *workloadidentityv1pb.
 			}.Build(),
 		}.Build(),
 	}.Build()
+}
+
+// scopedWorkloadIdentityWithLabels is like scopedWorkloadIdentity but also sets
+// resource labels, used to exercise workload_identity label-selector grants on
+// scoped roles.
+func scopedWorkloadIdentityWithLabels(name, scope, spiffeID string, labels map[string]string) *workloadidentityv1pb.WorkloadIdentity {
+	wi := scopedWorkloadIdentity(name, scope, spiffeID)
+	wi.GetMetadata().SetLabels(labels)
+	return wi
+}
+
+// newScopedWorkloadIdentityIssuer creates a user assigned a scoped role that
+// grants both the rules (read_no_secrets + list) and the workload_identity
+// label selector required to issue SVIDs using scoped WorkloadIdentities within
+// the given scope. It returns the username, which can be used with
+// authtest.TestScopedUser to mint a client pinned to that scope.
+func newScopedWorkloadIdentityIssuer(
+	t *testing.T,
+	srv *authtest.TLSServer,
+	adminClient *authclient.Client,
+	username string,
+	scope string,
+	labels map[string][]string,
+) string {
+	t.Helper()
+	ctx := t.Context()
+
+	wiLabels := make([]*labelv1.Label, 0, len(labels))
+	for name, values := range labels {
+		wiLabels = append(wiLabels, labelv1.Label_builder{Name: name, Values: values}.Build())
+	}
+
+	scopedSvc := adminClient.ScopedAccessServiceClient()
+	role, err := scopedSvc.CreateScopedRole(ctx, scopedaccessv1.CreateScopedRoleRequest_builder{
+		Role: scopedaccessv1.ScopedRole_builder{
+			Kind:    scopedaccess.KindScopedRole,
+			Version: types.V1,
+			Metadata: headerv1.Metadata_builder{
+				Name: username + "-role",
+			}.Build(),
+			Scope: "/scopes",
+			Spec: scopedaccessv1.ScopedRoleSpec_builder{
+				AssignableScopes: []string{scope},
+				Rules: []*scopedaccessv1.ScopedRule{
+					scopedaccessv1.ScopedRule_builder{
+						Resources: []string{types.KindWorkloadIdentity},
+						Verbs:     []string{types.VerbReadNoSecrets, types.VerbList},
+					}.Build(),
+				},
+				WorkloadIdentity: scopedaccessv1.ScopedRoleWorkloadIdentity_builder{
+					Labels: wiLabels,
+				}.Build(),
+			}.Build(),
+		}.Build(),
+	}.Build())
+	require.NoError(t, err)
+
+	user, err := authtest.CreateUser(ctx, srv.Auth(), username)
+	require.NoError(t, err)
+
+	resp, err := scopedSvc.CreateScopedRoleAssignment(ctx, scopedaccessv1.CreateScopedRoleAssignmentRequest_builder{
+		Assignment: scopedaccessv1.ScopedRoleAssignment_builder{
+			Kind:    scopedaccess.KindScopedRoleAssignment,
+			SubKind: scopedaccess.SubKindDynamic,
+			Version: types.V1,
+			Metadata: headerv1.Metadata_builder{
+				Name: uuid.NewString(),
+			}.Build(),
+			Scope: "/scopes",
+			Spec: scopedaccessv1.ScopedRoleAssignmentSpec_builder{
+				User: user.GetName(),
+				Assignments: []*scopedaccessv1.Assignment{
+					scopedaccessv1.Assignment_builder{Role: role.GetRole().GetMetadata().GetName(), Scope: scope}.Build(),
+				},
+			}.Build(),
+		}.Build(),
+	}.Build())
+	require.NoError(t, err)
+
+	// Wait for the assignment to propagate to the cache used by the authorizer.
+	require.EventuallyWithT(t, func(t *assert.CollectT) {
+		_, err := srv.Auth().ScopedAccessCache.GetScopedRoleAssignment(ctx, scopedaccessv1.GetScopedRoleAssignmentRequest_builder{
+			Name:    resp.GetAssignment().GetMetadata().GetName(),
+			SubKind: resp.GetAssignment().GetSubKind(),
+		}.Build())
+		require.NoError(t, err)
+	}, 10*time.Second, 100*time.Millisecond)
+
+	return user.GetName()
 }

--- a/lib/services/scoped_access_checker.go
+++ b/lib/services/scoped_access_checker.go
@@ -28,6 +28,7 @@ import (
 	apidefaults "github.com/gravitational/teleport/api/defaults"
 	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
 	scopedaccessv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/access/v1"
+	workloadidentityv1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/workloadidentity/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/types/wrappers"
 	"github.com/gravitational/teleport/api/utils/keys"
@@ -278,6 +279,17 @@ func (c *ScopedAccessChecker) CheckAccessToRemoteCluster(cluster types.RemoteClu
 	// at the type-level. this has been implemented experimentally to explore the pattern of having the scoped access checker
 	// implement methods that always deny for unsupported features.
 	return trace.AccessDenied("remote cluster access is not permitted for scoped identities")
+}
+
+// CheckAccessToWorkloadIdentity checks access to a workload identity resource by
+// matching it against the WorkloadIdentityLabels granted by the checker's roles.
+// This is the scoped equivalent of the label-based access check used by the
+// unscoped issuance path.
+func (c *ScopedAccessChecker) CheckAccessToWorkloadIdentity(wi *workloadidentityv1pb.WorkloadIdentity) error {
+	if !c.isScoped() {
+		return c.unscopedChecker.CheckAccess(types.Resource153ToResourceWithLabels(wi), AccessState{})
+	}
+	return c.scopedCompatChecker.CheckAccess(types.Resource153ToResourceWithLabels(wi), AccessState{})
 }
 
 // AdjustSessionTTL will reduce the requested ttl to the lowest max allowed TTL for this role set.

--- a/lib/services/workload_identity.go
+++ b/lib/services/workload_identity.go
@@ -143,7 +143,7 @@ func ValidateWorkloadIdentity(s *workloadidentityv1pb.WorkloadIdentity) error {
 		if scopes.Compare(s.GetScope(), scopes.Root) == scopes.Equivalent {
 			return trace.BadParameter("scope: must not be the root scope")
 		}
-		if err := validateScopedSPIFFEID(s.GetScope(), s.GetSpec().GetSpiffe().GetId()); err != nil {
+		if err := ValidateScopedSPIFFEID(s.GetScope(), s.GetSpec().GetSpiffe().GetId()); err != nil {
 			return trace.Wrap(err)
 		}
 
@@ -193,7 +193,7 @@ func ValidateWorkloadIdentity(s *workloadidentityv1pb.WorkloadIdentity) error {
 // keeps the boundary between the two sections unambiguous.
 const scopedSPIFFEIDSeparator = "_"
 
-// validateScopedSPIFFEID validates that the given SPIFFE ID path conforms to
+// ValidateScopedSPIFFEID validates that the given SPIFFE ID path conforms to
 // the scoped SPIFFE ID structure for the given scope, as defined in RFD 0229c.
 //
 // A scoped SPIFFE ID path consists of three sections:
@@ -207,7 +207,11 @@ const scopedSPIFFEIDSeparator = "_"
 // scope of /foo matches an ID beginning /foo/... but not /foo-buzz/.... The
 // scope section must match the scope of origin exactly: it may not be an
 // ancestor or descendant of it.
-func validateScopedSPIFFEID(scope, id string) error {
+//
+// It is used both at create/update time (on the unrendered ID) and at issuance
+// time (on the rendered ID) as defense-in-depth against templating that would
+// otherwise escape the WorkloadIdentity's scope.
+func ValidateScopedSPIFFEID(scope, id string) error {
 	if !strings.HasPrefix(id, "/") {
 		return trace.BadParameter("spec.spiffe.id: must begin with a forward slash")
 	}

--- a/lib/services/workload_identity_test.go
+++ b/lib/services/workload_identity_test.go
@@ -659,7 +659,7 @@ func TestValidateScopedSPIFFEID(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			tt.assertErr(t, validateScopedSPIFFEID(tt.scope, tt.id))
+			tt.assertErr(t, ValidateScopedSPIFFEID(tt.scope, tt.id))
 		})
 	}
 }

--- a/lib/tbot/services/clientcredentials/service.go
+++ b/lib/tbot/services/clientcredentials/service.go
@@ -71,6 +71,7 @@ func NewSidecar(deps bot.ServiceDependencies, credentialLifetime bot.CredentialL
 		identityGenerator:  deps.IdentityGenerator,
 		statusReporter:     readyz.NoopReporter(),
 		log:                deps.Logger,
+		scoped:             deps.Scoped,
 	}
 	return svc, cfg
 }

--- a/lib/tbot/services/workloadidentity/jwt_output.go
+++ b/lib/tbot/services/workloadidentity/jwt_output.go
@@ -56,6 +56,7 @@ func JWTOutputServiceBuilder(
 			trustBundleCache:          trustBundleCache,
 			log:                       deps.Logger,
 			statusReporter:            deps.GetStatusReporter(),
+			scoped:                    deps.Scoped,
 		}
 		return svc, nil
 	}
@@ -76,6 +77,10 @@ type JWTOutputService struct {
 	trustBundleCache  TrustBundleGetter
 	identityGenerator *identity.Generator
 	clientBuilder     *client.Builder
+	// scoped indicates whether the bot is running in scoped mode. When set, the
+	// service uses the bot's internal scoped identity rather than a role-
+	// impersonated identity to issue SVIDs.
+	scoped bool
 }
 
 // String returns a human-readable description of the service.
@@ -167,6 +172,22 @@ func (s *JWTOutputService) Run(ctx context.Context) error {
 	}
 }
 
+// generateIdentity returns the identity facade used to issue SVIDs. In scoped
+// mode this is the bot's internal scoped identity; otherwise it is a role-
+// impersonated identity.
+func (s *JWTOutputService) generateIdentity(ctx context.Context) (*identity.Facade, error) {
+	effectiveLifetime := cmp.Or(s.cfg.CredentialLifetime, s.defaultCredentialLifetime)
+	if s.scoped {
+		return s.identityGenerator.GenerateScopedFacade(
+			ctx, effectiveLifetime.TTL, effectiveLifetime.RenewalInterval,
+		)
+	}
+	return s.identityGenerator.GenerateFacade(ctx,
+		identity.WithLifetime(effectiveLifetime.TTL, effectiveLifetime.RenewalInterval),
+		identity.WithLogger(s.log),
+	)
+}
+
 func (s *JWTOutputService) requestJWTSVID(
 	ctx context.Context,
 ) (
@@ -180,25 +201,22 @@ func (s *JWTOutputService) requestJWTSVID(
 	defer span.End()
 
 	effectiveLifetime := cmp.Or(s.cfg.CredentialLifetime, s.defaultCredentialLifetime)
-	id, err := s.identityGenerator.GenerateFacade(ctx,
-		identity.WithLifetime(effectiveLifetime.TTL, effectiveLifetime.RenewalInterval),
-		identity.WithLogger(s.log),
-	)
+	id, err := s.generateIdentity(ctx)
 	if err != nil {
 		return nil, trace.Wrap(err, "generating identity")
 	}
-	// create a client that uses the impersonated identity, so that when we
-	// fetch information, we can ensure access rights are enforced.
-	impersonatedClient, err := s.clientBuilder.Build(ctx, id)
+	// create a client that uses the issuing identity, so that when we fetch
+	// information, we can ensure access rights are enforced.
+	issuingClient, err := s.clientBuilder.Build(ctx, id)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	defer impersonatedClient.Close()
+	defer issuingClient.Close()
 
 	credentials, err := workloadidentity.IssueJWTWorkloadIdentity(
 		ctx,
 		s.log,
-		impersonatedClient,
+		issuingClient,
 		s.cfg.Selector,
 		s.cfg.Audiences,
 		effectiveLifetime.TTL,

--- a/lib/tbot/services/workloadidentity/jwt_output.go
+++ b/lib/tbot/services/workloadidentity/jwt_output.go
@@ -77,9 +77,7 @@ type JWTOutputService struct {
 	trustBundleCache  TrustBundleGetter
 	identityGenerator *identity.Generator
 	clientBuilder     *client.Builder
-	// scoped indicates whether the bot is running in scoped mode. When set, the
-	// service uses the bot's internal scoped identity rather than a role-
-	// impersonated identity to issue SVIDs.
+	// scoped indicates whether the bot is running in scoped mode.
 	scoped bool
 }
 

--- a/lib/tbot/services/workloadidentity/jwt_output_config.go
+++ b/lib/tbot/services/workloadidentity/jwt_output_config.go
@@ -65,9 +65,6 @@ func (o *JWTOutputConfig) Init(ctx context.Context) error {
 
 // CheckAndSetDefaults checks the WorkloadIdentityJWTService values and sets any defaults.
 func (o *JWTOutputConfig) CheckAndSetDefaults(scoped bool) error {
-	if scoped {
-		return trace.BadParameter("service type %q is not supported in scoped mode", JWTOutputServiceType)
-	}
 	if o.Destination == nil {
 		return trace.BadParameter("no destination configured for output")
 	}

--- a/lib/tbot/services/workloadidentity/jwt_output_config_test.go
+++ b/lib/tbot/services/workloadidentity/jwt_output_config_test.go
@@ -151,7 +151,7 @@ func TestWorkloadIdentityJWTService_CheckAndSetDefaults(t *testing.T) {
 			wantErr: "no destination configured for output",
 		},
 		{
-			name:   "scoped",
+			name:   "valid scoped",
 			scoped: true,
 			in: func() *JWTOutputConfig {
 				return &JWTOutputConfig{
@@ -166,7 +166,6 @@ func TestWorkloadIdentityJWTService_CheckAndSetDefaults(t *testing.T) {
 					Audiences: []string{"audience1"},
 				}
 			},
-			wantErr: "is not supported in scoped mode",
 		},
 	}
 	testCheckAndSetDefaults(t, tests)

--- a/lib/tbot/services/workloadidentity/workload_api_config.go
+++ b/lib/tbot/services/workloadidentity/workload_api_config.go
@@ -50,9 +50,6 @@ type WorkloadAPIConfig struct {
 
 // CheckAndSetDefaults checks the SPIFFESVIDOutput values and sets any defaults.
 func (o *WorkloadAPIConfig) CheckAndSetDefaults(scoped bool) error {
-	if scoped {
-		return trace.BadParameter("service type %q is not supported in scoped mode", WorkloadAPIServiceType)
-	}
 	if o.Listen == "" {
 		return trace.BadParameter("listen: should not be empty")
 	}

--- a/lib/tbot/services/workloadidentity/workload_api_config_test.go
+++ b/lib/tbot/services/workloadidentity/workload_api_config_test.go
@@ -165,7 +165,7 @@ func TestWorkloadIdentityAPIService_CheckAndSetDefaults(t *testing.T) {
 			wantErr: "listen: should not be empty",
 		},
 		{
-			name:   "scoped",
+			name:   "valid scoped",
 			scoped: true,
 			in: func() *WorkloadAPIConfig {
 				return &WorkloadAPIConfig{
@@ -175,7 +175,17 @@ func TestWorkloadIdentityAPIService_CheckAndSetDefaults(t *testing.T) {
 					Listen: "tcp://0.0.0.0:4040",
 				}
 			},
-			wantErr: "is not supported in scoped mode",
+			want: &WorkloadAPIConfig{
+				Selector: bot.WorkloadIdentitySelector{
+					Name: "my-workload-identity",
+				},
+				Listen: "tcp://0.0.0.0:4040",
+				Attestors: workloadattest.Config{
+					Unix: workloadattest.UnixAttestorConfig{
+						BinaryHashMaxSizeBytes: workloadattest.DefaultBinaryHashMaxBytes,
+					},
+				},
+			},
 		},
 		{
 			name: "valid trust domains",

--- a/lib/tbot/services/workloadidentity/x509_output.go
+++ b/lib/tbot/services/workloadidentity/x509_output.go
@@ -70,6 +70,7 @@ func X509OutputServiceBuilder(
 			crlCache:                  crlCache,
 			log:                       deps.Logger,
 			statusReporter:            deps.GetStatusReporter(),
+			scoped:                    deps.Scoped,
 		}
 		return svc, nil
 	}
@@ -91,6 +92,10 @@ type X509OutputService struct {
 	crlCache          CRLGetter
 	identityGenerator *identity.Generator
 	clientBuilder     *client.Builder
+	// scoped indicates whether the bot is running in scoped mode. When set, the
+	// service uses the bot's internal scoped identity rather than a role-
+	// impersonated identity to issue SVIDs.
+	scoped bool
 }
 
 // String returns a human-readable description of the service.
@@ -222,6 +227,22 @@ func (s *X509OutputService) Run(ctx context.Context) error {
 	}
 }
 
+// generateIdentity returns the identity facade used to issue SVIDs. In scoped
+// mode this is the bot's internal scoped identity; otherwise it is a role-
+// impersonated identity.
+func (s *X509OutputService) generateIdentity(ctx context.Context) (*identity.Facade, error) {
+	effectiveLifetime := cmp.Or(s.cfg.CredentialLifetime, s.defaultCredentialLifetime)
+	if s.scoped {
+		return s.identityGenerator.GenerateScopedFacade(
+			ctx, effectiveLifetime.TTL, effectiveLifetime.RenewalInterval,
+		)
+	}
+	return s.identityGenerator.GenerateFacade(ctx,
+		identity.WithLifetime(effectiveLifetime.TTL, effectiveLifetime.RenewalInterval),
+		identity.WithLogger(s.log),
+	)
+}
+
 func (s *X509OutputService) requestSVID(
 	ctx context.Context,
 ) (
@@ -235,27 +256,23 @@ func (s *X509OutputService) requestSVID(
 	)
 	defer span.End()
 
-	effectiveLifetime := cmp.Or(s.cfg.CredentialLifetime, s.defaultCredentialLifetime)
-	id, err := s.identityGenerator.GenerateFacade(ctx,
-		identity.WithLifetime(effectiveLifetime.TTL, effectiveLifetime.RenewalInterval),
-		identity.WithLogger(s.log),
-	)
+	id, err := s.generateIdentity(ctx)
 	if err != nil {
 		return nil, nil, trace.Wrap(err, "generating identity")
 	}
 
-	// create a client that uses the impersonated identity, so that when we
-	// fetch information, we can ensure access rights are enforced.
-	impersonatedClient, err := s.clientBuilder.Build(ctx, id)
+	// create a client that uses the issuing identity, so that when we fetch
+	// information, we can ensure access rights are enforced.
+	issuingClient, err := s.clientBuilder.Build(ctx, id)
 	if err != nil {
 		return nil, nil, trace.Wrap(err)
 	}
-	defer impersonatedClient.Close()
+	defer issuingClient.Close()
 
 	x509Credentials, privateKey, err := workloadidentity.IssueX509WorkloadIdentity(
 		ctx,
 		s.log,
-		impersonatedClient,
+		issuingClient,
 		s.cfg.Selector,
 		cmp.Or(s.cfg.CredentialLifetime, s.defaultCredentialLifetime).TTL,
 		nil,

--- a/lib/tbot/services/workloadidentity/x509_output.go
+++ b/lib/tbot/services/workloadidentity/x509_output.go
@@ -92,9 +92,7 @@ type X509OutputService struct {
 	crlCache          CRLGetter
 	identityGenerator *identity.Generator
 	clientBuilder     *client.Builder
-	// scoped indicates whether the bot is running in scoped mode. When set, the
-	// service uses the bot's internal scoped identity rather than a role-
-	// impersonated identity to issue SVIDs.
+	// scoped indicates whether the bot is running in scoped mode.
 	scoped bool
 }
 

--- a/lib/tbot/services/workloadidentity/x509_output_config.go
+++ b/lib/tbot/services/workloadidentity/x509_output_config.go
@@ -74,9 +74,6 @@ func (o *X509OutputConfig) GetDestination() destination.Destination {
 
 // CheckAndSetDefaults checks the SPIFFESVIDOutput values and sets any defaults.
 func (o *X509OutputConfig) CheckAndSetDefaults(scoped bool) error {
-	if scoped {
-		return trace.BadParameter("service type %q is not supported in scoped mode", X509OutputServiceType)
-	}
 	if o.Destination == nil {
 		return trace.BadParameter("no destination configured for output")
 	}

--- a/lib/tbot/services/workloadidentity/x509_output_config_test.go
+++ b/lib/tbot/services/workloadidentity/x509_output_config_test.go
@@ -146,7 +146,7 @@ func TestWorkloadIdentityX509Service_CheckAndSetDefaults(t *testing.T) {
 			wantErr: "no destination configured for output",
 		},
 		{
-			name:   "scoped",
+			name:   "valid scoped",
 			scoped: true,
 			in: func() *X509OutputConfig {
 				return &X509OutputConfig{
@@ -160,7 +160,6 @@ func TestWorkloadIdentityX509Service_CheckAndSetDefaults(t *testing.T) {
 					},
 				}
 			},
-			wantErr: "is not supported in scoped mode",
 		},
 		{
 			name: "valid trust domains",

--- a/lib/tbot/tbot_test.go
+++ b/lib/tbot/tbot_test.go
@@ -2013,52 +2013,60 @@ func TestScopedBotWorkloadIdentity(t *testing.T) {
 
 	expectedSPIFFEID := "spiffe://" + clusterName + scopeName + "/_/" + wiName
 
-	// The x509 output should write an SVID with a SPIFFE ID inside the bot's
-	// scope.
-	var svid *x509svid.SVID
-	require.EventuallyWithT(t, func(t *assert.CollectT) {
-		var err error
-		svid, err = x509svid.Load(
-			filepath.Join(tmpDir, internal.SVIDPEMPath),
-			filepath.Join(tmpDir, internal.SVIDKeyPEMPath),
-		)
-		require.NoError(t, err)
-	}, 10*time.Second, 100*time.Millisecond)
-	require.Equal(t, expectedSPIFFEID, svid.ID.String())
-
-	// The same WorkloadIdentity should be fetchable over the workload API
-	// socket.
-	require.EventuallyWithT(t, func(t *assert.CollectT) {
-		_, err := os.Stat(listenURL.Path)
-		require.NoError(t, err)
-	}, 10*time.Second, 100*time.Millisecond)
-	apiClient, err := workloadapi.New(ctx, workloadapi.WithAddr(listenURL.String()))
-	require.NoError(t, err)
-	t.Cleanup(func() { _ = apiClient.Close() })
-	source, err := workloadapi.NewX509Source(ctx, workloadapi.WithClient(apiClient))
-	require.NoError(t, err)
-	t.Cleanup(func() { _ = source.Close() })
-	apiSVID, err := source.GetX509SVID()
-	require.NoError(t, err)
-	require.Equal(t, expectedSPIFFEID, apiSVID.ID.String())
-
-	// The jwt output should write a JWT SVID with the same scoped SPIFFE ID.
-	var jwt *jwtsvid.SVID
-	require.EventuallyWithT(t, func(t *assert.CollectT) {
-		jwtBytes, err := os.ReadFile(filepath.Join(jwtDir, internal.JWTSVIDPath))
-		require.NoError(t, err)
-		jwt, err = jwtsvid.ParseInsecure(string(jwtBytes), []string{audience})
-		require.NoError(t, err)
-	}, 10*time.Second, 100*time.Millisecond)
-	require.Equal(t, expectedSPIFFEID, jwt.ID.String())
-
-	// JWT SVIDs fetched over the workload API socket should also carry the
-	// scoped SPIFFE ID.
-	apiJWTSVID, err := apiClient.FetchJWTSVID(ctx, jwtsvid.Params{
-		Audience: audience,
+	t.Run("x509 output", func(t *testing.T) {
+		// The x509 output should write an SVID with a SPIFFE ID inside the
+		// bot's scope.
+		var svid *x509svid.SVID
+		require.EventuallyWithT(t, func(t *assert.CollectT) {
+			var err error
+			svid, err = x509svid.Load(
+				filepath.Join(tmpDir, internal.SVIDPEMPath),
+				filepath.Join(tmpDir, internal.SVIDKeyPEMPath),
+			)
+			require.NoError(t, err)
+		}, 10*time.Second, 100*time.Millisecond)
+		require.Equal(t, expectedSPIFFEID, svid.ID.String())
 	})
-	require.NoError(t, err)
-	require.Equal(t, expectedSPIFFEID, apiJWTSVID.ID.String())
+
+	t.Run("jwt output", func(t *testing.T) {
+		// The jwt output should write a JWT SVID with the same scoped SPIFFE
+		// ID.
+		var jwt *jwtsvid.SVID
+		require.EventuallyWithT(t, func(t *assert.CollectT) {
+			jwtBytes, err := os.ReadFile(filepath.Join(jwtDir, internal.JWTSVIDPath))
+			require.NoError(t, err)
+			jwt, err = jwtsvid.ParseInsecure(string(jwtBytes), []string{audience})
+			require.NoError(t, err)
+		}, 10*time.Second, 100*time.Millisecond)
+		require.Equal(t, expectedSPIFFEID, jwt.ID.String())
+	})
+
+	t.Run("workload api", func(t *testing.T) {
+		ctx := t.Context()
+
+		// X.509 and JWT SVIDs fetched over the workload API socket should
+		// carry the same scoped SPIFFE ID.
+		require.EventuallyWithT(t, func(t *assert.CollectT) {
+			_, err := os.Stat(listenURL.Path)
+			require.NoError(t, err)
+		}, 10*time.Second, 100*time.Millisecond)
+		apiClient, err := workloadapi.New(ctx, workloadapi.WithAddr(listenURL.String()))
+		require.NoError(t, err)
+		t.Cleanup(func() { _ = apiClient.Close() })
+
+		source, err := workloadapi.NewX509Source(ctx, workloadapi.WithClient(apiClient))
+		require.NoError(t, err)
+		t.Cleanup(func() { _ = source.Close() })
+		apiSVID, err := source.GetX509SVID()
+		require.NoError(t, err)
+		require.Equal(t, expectedSPIFFEID, apiSVID.ID.String())
+
+		apiJWTSVID, err := apiClient.FetchJWTSVID(ctx, jwtsvid.Params{
+			Audience: audience,
+		})
+		require.NoError(t, err)
+		require.Equal(t, expectedSPIFFEID, apiJWTSVID.ID.String())
+	})
 }
 
 func waitForSRACache(t *testing.T, authServer *auth.Server, resps ...*scopedaccessv1.CreateScopedRoleAssignmentResponse) {

--- a/lib/tbot/tbot_test.go
+++ b/lib/tbot/tbot_test.go
@@ -1868,6 +1868,8 @@ func TestScopedBotKubernetes(t *testing.T) {
 // which scoped bots cannot mint) to call IssueWorkloadIdentity, and a scope-
 // qualified name selector ("<scope>::<name>") addresses the scoped resource.
 func TestScopedBotWorkloadIdentityX509(t *testing.T) {
+	t.Parallel()
+
 	ctx := t.Context()
 	log := logtest.NewLogger()
 
@@ -1896,9 +1898,7 @@ func TestScopedBotWorkloadIdentityX509(t *testing.T) {
 
 	clusterName := process.Config.Auth.ClusterName.GetClusterName()
 
-	// Create a scoped role granting issuance using prod-labeled
-	// WorkloadIdentities within the scope: the read_no_secrets+list rules for the
-	// workload_identity kind, plus a workload_identity label selector.
+	// Create a scoped role granting issuance using prod-labeled WorkloadIdentities.
 	scopedSvc := rootClient.ScopedAccessServiceClient()
 	_, err = scopedSvc.CreateScopedRole(ctx, scopedaccessv1.CreateScopedRoleRequest_builder{
 		Role: scopedaccessv1.ScopedRole_builder{
@@ -1928,8 +1928,7 @@ func TestScopedBotWorkloadIdentityX509(t *testing.T) {
 
 	botOnboarding := createScopedBot(t, process, rootClient, botName, scopeName, scopedRoleName)
 
-	// Create a scoped WorkloadIdentity at the backend. Its SPIFFE ID is a scoped
-	// SPIFFE ID rooted at the bot's scope.
+	// Create a scoped WorkloadIdentity at the backend.
 	_, err = process.GetAuthServer().CreateWorkloadIdentity(ctx, workloadidentityv1pb.WorkloadIdentity_builder{
 		Kind:    types.KindWorkloadIdentity,
 		Version: types.V1,
@@ -1946,9 +1945,8 @@ func TestScopedBotWorkloadIdentityX509(t *testing.T) {
 	}.Build())
 	require.NoError(t, err)
 
-	// Configure and run tbot with a workload-identity-x509 output in scoped
-	// mode. The selector uses a scope-qualified name to address the scoped
-	// resource. defaultBotConfig sets Oneshot, so Run issues once and returns.
+	// Configure and run tbot with a workload-identity-x509 output.
+	// defaultBotConfig sets Oneshot, so Run issues once and returns.
 	tmpDir := t.TempDir()
 	botConfig := defaultBotConfig(
 		t, process, botOnboarding,

--- a/lib/tbot/tbot_test.go
+++ b/lib/tbot/tbot_test.go
@@ -1896,7 +1896,7 @@ func TestScopedBotWorkloadIdentityX509(t *testing.T) {
 
 	clusterName := process.Config.Auth.ClusterName.GetClusterName()
 
-	// Create a scoped role granting issuance using prod-labelled
+	// Create a scoped role granting issuance using prod-labeled
 	// WorkloadIdentities within the scope: the read_no_secrets+list rules for the
 	// workload_identity kind, plus a workload_identity label selector.
 	scopedSvc := rootClient.ScopedAccessServiceClient()

--- a/lib/tbot/tbot_test.go
+++ b/lib/tbot/tbot_test.go
@@ -32,6 +32,7 @@ import (
 	"maps"
 	"net"
 	"net/http"
+	"net/url"
 	"os"
 	"os/user"
 	"path/filepath"
@@ -46,7 +47,9 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/spiffe/go-spiffe/v2/svid/jwtsvid"
 	"github.com/spiffe/go-spiffe/v2/svid/x509svid"
+	"github.com/spiffe/go-spiffe/v2/workloadapi"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/crypto/ssh"
@@ -110,6 +113,7 @@ import (
 	"github.com/gravitational/teleport/lib/tbot/services/k8s"
 	sshsvc "github.com/gravitational/teleport/lib/tbot/services/ssh"
 	workloadidentitysvc "github.com/gravitational/teleport/lib/tbot/services/workloadidentity"
+	"github.com/gravitational/teleport/lib/tbot/workloadidentity/workloadattest"
 	"github.com/gravitational/teleport/lib/tlsca"
 	"github.com/gravitational/teleport/lib/utils"
 	"github.com/gravitational/teleport/lib/utils/log/logtest"
@@ -1862,12 +1866,13 @@ func TestScopedBotKubernetes(t *testing.T) {
 	})
 }
 
-// TestScopedBotWorkloadIdentityX509 tests that a scoped bot can issue an X.509
-// SVID via the workload-identity-x509 service in scoped mode: the service uses
-// the bot's internal scoped identity (rather than a role-impersonated identity,
-// which scoped bots cannot mint) to call IssueWorkloadIdentity, and a scope-
-// qualified name selector ("<scope>::<name>") addresses the scoped resource.
-func TestScopedBotWorkloadIdentityX509(t *testing.T) {
+// TestScopedBotWorkloadIdentity tests that a scoped bot can issue X.509 and
+// JWT SVIDs for a scoped WorkloadIdentity addressed by a scope-qualified name
+// selector ("<scope>::<name>"), via the x509/jwt file outputs and the SPIFFE
+// workload API. In scoped mode these services use the bot's internal scoped
+// identity (rather than a role-impersonated identity, which scoped bots cannot
+// mint) to call the issuance RPCs.
+func TestScopedBotWorkloadIdentity(t *testing.T) {
 	t.Parallel()
 
 	ctx := t.Context()
@@ -1878,6 +1883,7 @@ func TestScopedBotWorkloadIdentityX509(t *testing.T) {
 		scopedRoleName = "scoped-wi-issuer"
 		botName        = "scoped-wi-bot"
 		wiName         = "scoped-svc"
+		audience       = "example.com"
 	)
 
 	// Start the main Teleport process (auth + proxy).
@@ -1945,18 +1951,42 @@ func TestScopedBotWorkloadIdentityX509(t *testing.T) {
 	}.Build())
 	require.NoError(t, err)
 
-	// Configure and run tbot with a workload-identity-x509 output.
-	// defaultBotConfig sets Oneshot, so Run issues once and returns.
+	// Configure tbot with workload-identity x509 and jwt outputs and a
+	// workload API listening on a unix socket, all addressing the
+	// WorkloadIdentity by scope-qualified name. The workload API is a
+	// long-running service, so the bot runs in daemon mode rather than oneshot.
 	tmpDir := t.TempDir()
+	jwtDir := t.TempDir()
+	listenURL := url.URL{
+		Scheme: "unix",
+		Path:   filepath.Join(t.TempDir(), "workload.sock"),
+	}
+	selector := bot.WorkloadIdentitySelector{
+		Name: scopes.QualifiedName{Scope: scopeName, Name: wiName}.String(),
+	}
 	botConfig := defaultBotConfig(
 		t, process, botOnboarding,
 		config.ServiceConfigs{
 			&workloadidentitysvc.X509OutputConfig{
-				Selector: bot.WorkloadIdentitySelector{
-					Name: scopes.QualifiedName{Scope: scopeName, Name: wiName}.String(),
-				},
+				Selector: selector,
 				Destination: &destination.Directory{
 					Path: tmpDir,
+				},
+			},
+			&workloadidentitysvc.JWTOutputConfig{
+				Selector: selector,
+				Destination: &destination.Directory{
+					Path: jwtDir,
+				},
+				Audiences: []string{audience},
+			},
+			&workloadidentitysvc.WorkloadAPIConfig{
+				Selector: selector,
+				Listen:   listenURL.String(),
+				Attestors: workloadattest.Config{
+					Unix: workloadattest.UnixAttestorConfig{
+						BinaryHashMaxSizeBytes: workloadattest.TestBinaryHashMaxBytes,
+					},
 				},
 			},
 		},
@@ -1966,19 +1996,69 @@ func TestScopedBotWorkloadIdentityX509(t *testing.T) {
 		},
 	)
 	botConfig.Scoped = true
+	botConfig.Oneshot = false
 	b := New(botConfig, log)
-	require.NoError(t, b.Run(ctx))
 
-	// The SVID should have been issued with a SPIFFE ID inside the bot's scope.
-	svid, err := x509svid.Load(
-		filepath.Join(tmpDir, internal.SVIDPEMPath),
-		filepath.Join(tmpDir, internal.SVIDKeyPEMPath),
-	)
+	botCtx, cancelBot := context.WithCancel(ctx)
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		assert.NoError(t, b.Run(botCtx), "bot should not exit with error")
+	}()
+	t.Cleanup(func() {
+		cancelBot()
+		wg.Wait()
+	})
+
+	expectedSPIFFEID := "spiffe://" + clusterName + scopeName + "/_/" + wiName
+
+	// The x509 output should write an SVID with a SPIFFE ID inside the bot's
+	// scope.
+	var svid *x509svid.SVID
+	require.EventuallyWithT(t, func(t *assert.CollectT) {
+		var err error
+		svid, err = x509svid.Load(
+			filepath.Join(tmpDir, internal.SVIDPEMPath),
+			filepath.Join(tmpDir, internal.SVIDKeyPEMPath),
+		)
+		require.NoError(t, err)
+	}, 10*time.Second, 100*time.Millisecond)
+	require.Equal(t, expectedSPIFFEID, svid.ID.String())
+
+	// The same WorkloadIdentity should be fetchable over the workload API
+	// socket.
+	require.EventuallyWithT(t, func(t *assert.CollectT) {
+		_, err := os.Stat(listenURL.Path)
+		require.NoError(t, err)
+	}, 10*time.Second, 100*time.Millisecond)
+	apiClient, err := workloadapi.New(ctx, workloadapi.WithAddr(listenURL.String()))
 	require.NoError(t, err)
-	require.Equal(t,
-		"spiffe://"+clusterName+scopeName+"/_/"+wiName,
-		svid.ID.String(),
-	)
+	t.Cleanup(func() { _ = apiClient.Close() })
+	source, err := workloadapi.NewX509Source(ctx, workloadapi.WithClient(apiClient))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = source.Close() })
+	apiSVID, err := source.GetX509SVID()
+	require.NoError(t, err)
+	require.Equal(t, expectedSPIFFEID, apiSVID.ID.String())
+
+	// The jwt output should write a JWT SVID with the same scoped SPIFFE ID.
+	var jwt *jwtsvid.SVID
+	require.EventuallyWithT(t, func(t *assert.CollectT) {
+		jwtBytes, err := os.ReadFile(filepath.Join(jwtDir, internal.JWTSVIDPath))
+		require.NoError(t, err)
+		jwt, err = jwtsvid.ParseInsecure(string(jwtBytes), []string{audience})
+		require.NoError(t, err)
+	}, 10*time.Second, 100*time.Millisecond)
+	require.Equal(t, expectedSPIFFEID, jwt.ID.String())
+
+	// JWT SVIDs fetched over the workload API socket should also carry the
+	// scoped SPIFFE ID.
+	apiJWTSVID, err := apiClient.FetchJWTSVID(ctx, jwtsvid.Params{
+		Audience: audience,
+	})
+	require.NoError(t, err)
+	require.Equal(t, expectedSPIFFEID, apiJWTSVID.ID.String())
 }
 
 func waitForSRACache(t *testing.T, authServer *auth.Server, resps ...*scopedaccessv1.CreateScopedRoleAssignmentResponse) {

--- a/lib/tbot/tbot_test.go
+++ b/lib/tbot/tbot_test.go
@@ -46,6 +46,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/spiffe/go-spiffe/v2/svid/x509svid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/crypto/ssh"
@@ -65,6 +66,7 @@ import (
 	scopedaccessv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/access/v1"
 	joiningv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/joining/v1"
 	scopesv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/v1"
+	workloadidentityv1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/workloadidentity/v1"
 	apissh "github.com/gravitational/teleport/api/ssh"
 	"github.com/gravitational/teleport/api/types"
 	apievents "github.com/gravitational/teleport/api/types/events"
@@ -93,6 +95,7 @@ import (
 	"github.com/gravitational/teleport/lib/srv/db/postgres"
 	"github.com/gravitational/teleport/lib/sshca"
 	apisshutils "github.com/gravitational/teleport/lib/sshutils"
+	"github.com/gravitational/teleport/lib/tbot/bot"
 	"github.com/gravitational/teleport/lib/tbot/bot/connection"
 	"github.com/gravitational/teleport/lib/tbot/bot/destination"
 	"github.com/gravitational/teleport/lib/tbot/bot/onboarding"
@@ -106,6 +109,7 @@ import (
 	identitysvc "github.com/gravitational/teleport/lib/tbot/services/identity"
 	"github.com/gravitational/teleport/lib/tbot/services/k8s"
 	sshsvc "github.com/gravitational/teleport/lib/tbot/services/ssh"
+	workloadidentitysvc "github.com/gravitational/teleport/lib/tbot/services/workloadidentity"
 	"github.com/gravitational/teleport/lib/tlsca"
 	"github.com/gravitational/teleport/lib/utils"
 	"github.com/gravitational/teleport/lib/utils/log/logtest"
@@ -1856,6 +1860,127 @@ func TestScopedBotKubernetes(t *testing.T) {
 		}
 		require.ElementsMatch(t, []string{"default", "test", "dev", "prod"}, gotNamespaces)
 	})
+}
+
+// TestScopedBotWorkloadIdentityX509 tests that a scoped bot can issue an X.509
+// SVID via the workload-identity-x509 service in scoped mode: the service uses
+// the bot's internal scoped identity (rather than a role-impersonated identity,
+// which scoped bots cannot mint) to call IssueWorkloadIdentity, and a scope-
+// qualified name selector ("<scope>::<name>") addresses the scoped resource.
+func TestScopedBotWorkloadIdentityX509(t *testing.T) {
+	ctx := t.Context()
+	log := logtest.NewLogger()
+
+	const (
+		scopeName      = "/test-scope"
+		scopedRoleName = "scoped-wi-issuer"
+		botName        = "scoped-wi-bot"
+		wiName         = "scoped-svc"
+	)
+
+	// Start the main Teleport process (auth + proxy).
+	process, err := testenv.NewTeleportProcess(
+		t.TempDir(),
+		defaultTestServerOpts(log),
+		testenv.WithScopesFeatures(scopes.Features{Enabled: true}),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, process.Close())
+		require.NoError(t, process.Wait())
+	})
+
+	rootClient, err := testenv.NewDefaultAuthClient(process)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = rootClient.Close() })
+
+	clusterName := process.Config.Auth.ClusterName.GetClusterName()
+
+	// Create a scoped role granting issuance using prod-labelled
+	// WorkloadIdentities within the scope: the read_no_secrets+list rules for the
+	// workload_identity kind, plus a workload_identity label selector.
+	scopedSvc := rootClient.ScopedAccessServiceClient()
+	_, err = scopedSvc.CreateScopedRole(ctx, scopedaccessv1.CreateScopedRoleRequest_builder{
+		Role: scopedaccessv1.ScopedRole_builder{
+			Kind:    scopedaccess.KindScopedRole,
+			Version: types.V1,
+			Metadata: headerv1.Metadata_builder{
+				Name: scopedRoleName,
+			}.Build(),
+			Scope: scopeName,
+			Spec: scopedaccessv1.ScopedRoleSpec_builder{
+				AssignableScopes: []string{scopeName},
+				Rules: []*scopedaccessv1.ScopedRule{
+					scopedaccessv1.ScopedRule_builder{
+						Resources: []string{types.KindWorkloadIdentity},
+						Verbs:     []string{types.VerbReadNoSecrets, types.VerbList},
+					}.Build(),
+				},
+				WorkloadIdentity: scopedaccessv1.ScopedRoleWorkloadIdentity_builder{
+					Labels: []*labelv1.Label{
+						labelv1.Label_builder{Name: "env", Values: []string{"prod"}}.Build(),
+					},
+				}.Build(),
+			}.Build(),
+		}.Build(),
+	}.Build())
+	require.NoError(t, err)
+
+	botOnboarding := createScopedBot(t, process, rootClient, botName, scopeName, scopedRoleName)
+
+	// Create a scoped WorkloadIdentity at the backend. Its SPIFFE ID is a scoped
+	// SPIFFE ID rooted at the bot's scope.
+	_, err = process.GetAuthServer().CreateWorkloadIdentity(ctx, workloadidentityv1pb.WorkloadIdentity_builder{
+		Kind:    types.KindWorkloadIdentity,
+		Version: types.V1,
+		Metadata: headerv1.Metadata_builder{
+			Name:   wiName,
+			Labels: map[string]string{"env": "prod"},
+		}.Build(),
+		Scope: scopeName,
+		Spec: workloadidentityv1pb.WorkloadIdentitySpec_builder{
+			Spiffe: workloadidentityv1pb.WorkloadIdentitySPIFFE_builder{
+				Id: scopeName + "/_/" + wiName,
+			}.Build(),
+		}.Build(),
+	}.Build())
+	require.NoError(t, err)
+
+	// Configure and run tbot with a workload-identity-x509 output in scoped
+	// mode. The selector uses a scope-qualified name to address the scoped
+	// resource. defaultBotConfig sets Oneshot, so Run issues once and returns.
+	tmpDir := t.TempDir()
+	botConfig := defaultBotConfig(
+		t, process, botOnboarding,
+		config.ServiceConfigs{
+			&workloadidentitysvc.X509OutputConfig{
+				Selector: bot.WorkloadIdentitySelector{
+					Name: scopes.QualifiedName{Scope: scopeName, Name: wiName}.String(),
+				},
+				Destination: &destination.Directory{
+					Path: tmpDir,
+				},
+			},
+		},
+		defaultBotConfigOpts{
+			useAuthServer: true,
+			insecure:      true,
+		},
+	)
+	botConfig.Scoped = true
+	b := New(botConfig, log)
+	require.NoError(t, b.Run(ctx))
+
+	// The SVID should have been issued with a SPIFFE ID inside the bot's scope.
+	svid, err := x509svid.Load(
+		filepath.Join(tmpDir, internal.SVIDPEMPath),
+		filepath.Join(tmpDir, internal.SVIDKeyPEMPath),
+	)
+	require.NoError(t, err)
+	require.Equal(t,
+		"spiffe://"+clusterName+scopeName+"/_/"+wiName,
+		svid.ID.String(),
+	)
 }
 
 func waitForSRACache(t *testing.T, authServer *auth.Server, resps ...*scopedaccessv1.CreateScopedRoleAssignmentResponse) {

--- a/lib/tbot/workloadidentity/issue.go
+++ b/lib/tbot/workloadidentity/issue.go
@@ -21,6 +21,7 @@ import (
 	"crypto"
 	"crypto/x509"
 	"log/slog"
+	"strings"
 	"time"
 
 	"github.com/gravitational/trace"
@@ -28,9 +29,29 @@ import (
 
 	workloadidentityv1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/workloadidentity/v1"
 	"github.com/gravitational/teleport/lib/cryptosuites"
+	"github.com/gravitational/teleport/lib/scopes"
 	"github.com/gravitational/teleport/lib/tbot/bot"
 	"github.com/gravitational/teleport/lib/tbot/workloadidentity/attrs"
 )
+
+// parseNameSelector splits a "name" workload identity selector into its name and
+// (optional) scope. A scope-qualified name ("<scope>::<name>") targets a scoped
+// WorkloadIdentity; a bare name targets an unscoped one. The scope, if any,
+// travels in the issuance request and the server matches it against the named
+// resource's scope.
+func parseNameSelector(selector string) (name, scope string, err error) {
+	if !strings.Contains(selector, scopes.QualifiedNameSeparator) {
+		return selector, "", nil
+	}
+	qn, err := scopes.ParseQualifiedName(selector)
+	if err != nil {
+		return "", "", trace.Wrap(err)
+	}
+	if err := qn.StrongValidate(); err != nil {
+		return "", "", trace.Wrap(err)
+	}
+	return qn.Name, qn.Scope, nil
+}
 
 // WorkloadIdentityLogValue returns a slog.Value for a given
 // *workloadidentityv1pb.Credential
@@ -102,16 +123,22 @@ func IssueX509WorkloadIdentity(
 
 	switch {
 	case workloadIdentity.Name != "":
+		name, scope, err := parseNameSelector(workloadIdentity.Name)
+		if err != nil {
+			return nil, nil, trace.Wrap(err)
+		}
 		log.DebugContext(
 			ctx,
 			"Requesting issuance of X509 workload identity credential using name of WorkloadIdentity resource",
-			"name", workloadIdentity.Name,
+			"name", name,
+			"scope", scope,
 		)
 		// When using the "name" based selector, we either get a single WIC back,
 		// or an error. We don't need to worry about selecting the right one.
 		res, err := clt.WorkloadIdentityIssuanceClient().IssueWorkloadIdentity(ctx,
 			workloadidentityv1pb.IssueWorkloadIdentityRequest_builder{
-				Name: workloadIdentity.Name,
+				Name:  name,
+				Scope: scope,
 				X509SvidParams: workloadidentityv1pb.X509SVIDParams_builder{
 					PublicKey:          pubBytes,
 					UseIssuerOverrides: true,
@@ -195,16 +222,22 @@ func IssueJWTWorkloadIdentity(
 
 	switch {
 	case workloadIdentity.Name != "":
+		name, scope, err := parseNameSelector(workloadIdentity.Name)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
 		log.DebugContext(
 			ctx,
 			"Requesting issuance of JWT workload identity credential using name of WorkloadIdentity resource",
-			"name", workloadIdentity.Name,
+			"name", name,
+			"scope", scope,
 		)
 		// When using the "name" based selector, we either get a single WIC back,
 		// or an error. We don't need to worry about selecting the right one.
 		res, err := clt.WorkloadIdentityIssuanceClient().IssueWorkloadIdentity(ctx,
 			workloadidentityv1pb.IssueWorkloadIdentityRequest_builder{
-				Name: workloadIdentity.Name,
+				Name:  name,
+				Scope: scope,
 				JwtSvidParams: workloadidentityv1pb.JWTSVIDParams_builder{
 					Audiences: audiences,
 				}.Build(),


### PR DESCRIPTION
Depends on https://github.com/gravitational/teleport/pull/67929

Updates https://github.com/gravitational/teleport/issues/66349

PR 5/5

Final PR in change-set, updates the Issuance RPCs and `tbot` to correctly handle scoped Workload Identities and Scoped SPIFFE issuance.

## Manual Test Plan
### Test Environment

Local cluster

### Test Cases

Human Test Plan:

- [x] `tctl` and CRUD APIs
  - [x] Regression: Create, Upsert, Get, List unscoped Workload Identities as **unscoped identity**
  - [x] Create, Upsert, Get, List scoped Workload Identities as **unscoped identity**
  - [x] Create, Upsert, Get, List scoped Workload Identities as **scoped identity**
    - [x] RBAC: Cannot access scoped Workload Identities outside of scope or unscoped Workload Identities.
    - [x] Validation: ensure SPIFFE ID must match established pattern rules.
    - [x] Validation: name cannot include characters which are not scope safe.
- [x] Issuance
  - [x] Regression: Issue unscoped Workload Identity by label and name using unscoped tbot
    - [x] API by label
    - [x] API by name
    - [x] X509 by label
    - [x] X509 by name
    - [x] JWT by label
    - [x] JWT by name
  - [x] Issue scoped Workload Identity by label and name using scoped tbot
    - [x] API by label
    - [x] API by name
    - [x] X509 by label
    - [x] X509 by name
    - [x] JWT by label
    - [x] JWT by name
  - [x] Fail to issue unscoped Workload Identity by label and name using scoped tbot
  - [x] Fail to issue scoped Workload Identity outside of scope  by label and name using scoped tbot

Agentic Test Plan: https://gist.github.com/strideynet/a202c89cd1d5835a96c2f39dfd2fefb0