### PR TITLE
feat: deny root login for beam nodes

### DIFF
--- a/lib/services/access_checker.go
+++ b/lib/services/access_checker.go
@@ -1181,7 +1181,25 @@ func (a *accessChecker) GetAllowedLoginsForResource(resource AccessCheckable) ([
 		}
 	}
 
+	// Only show the dedicated "beams" login for beam nodes.
+	if resource.GetKind() == types.KindNode && hasBeamLabel(resource.GetAllLabels()) {
+		allowed = slices.DeleteFunc(allowed, func(login string) bool {
+			return login != types.BeamsLogin
+		})
+	}
+
 	return allowed, nil
+}
+
+// hasBeamLabel reports whether the given labels include any internal beams
+// label, identifying the resource as part of a beam.
+func hasBeamLabel(labels map[string]string) bool {
+	for key := range labels {
+		if strings.HasPrefix(key, types.BeamsInternalLabelPrefix) {
+			return true
+		}
+	}
+	return false
 }
 
 // CheckAccessToRemoteCluster checks if a role has access to remote cluster. Deny rules are

--- a/lib/services/role_test.go
+++ b/lib/services/role_test.go
@@ -5331,6 +5331,8 @@ func TestGetAllowedLoginsForResource(t *testing.T) {
 		labels         map[string]string
 		roleSet        RoleSet
 		expectedLogins []string
+		// expectedServerLogins overrides expectedLogins for beam nodes.
+		expectedServerLogins []string
 	}{
 		{
 			name: "env dev login is added",
@@ -5472,6 +5474,21 @@ func TestGetAllowedLoginsForResource(t *testing.T) {
 			),
 			expectedLogins: nil,
 		},
+		{
+			name: "beam node is filtered to the beams login",
+			labels: map[string]string{
+				types.BeamIDLabel:    "abc123",
+				types.BeamOwnerLabel: "alice",
+				"env":                "dev",
+			},
+			roleSet: NewRoleSet(
+				newRole(
+					[]string{"root", types.BeamsLogin},
+					types.Labels{types.Wildcard: []string{types.Wildcard}}, []string{}, types.Labels{}),
+			),
+			expectedLogins:       []string{"root", types.BeamsLogin},
+			expectedServerLogins: []string{types.BeamsLogin},
+		},
 	}
 	for _, tc := range tt {
 		accessChecker := makeAccessCheckerWithRoleSet(tc.roleSet)
@@ -5487,7 +5504,11 @@ func TestGetAllowedLoginsForResource(t *testing.T) {
 			awsARNLogins, err := accessChecker.GetAllowedLoginsForResource(app)
 			require.NoError(t, err)
 
-			require.ElementsMatch(t, tc.expectedLogins, serverLogins)
+			expectedServerLogins := tc.expectedLogins
+			if tc.expectedServerLogins != nil {
+				expectedServerLogins = tc.expectedServerLogins
+			}
+			require.ElementsMatch(t, expectedServerLogins, serverLogins)
 			require.ElementsMatch(t, tc.expectedLogins, desktopLogins)
 			require.ElementsMatch(t, tc.expectedLogins, awsARNLogins)
 		})

--- a/lib/srv/authhandlers.go
+++ b/lib/srv/authhandlers.go
@@ -1146,6 +1146,12 @@ func (a *ahLoginChecker) evaluateScopedSSHAccess(ident *sshca.Identity, ca types
 		return nil, trace.BadParameter("expected target to be of type *types.ServerV2, got %T", target)
 	}
 
+	// Only show the dedicated "beams" login for beam nodes.
+	if isBeamServer(target) && osUser != types.BeamsLogin {
+		return nil, trace.AccessDenied("user %s@%s is not authorized to login as %v@%s: beams may only be accessed as %q",
+			ident.Username, ca.GetClusterName(), osUser, clusterName, types.BeamsLogin)
+	}
+
 	agentScope := scopes.Root
 	if serverV2.Scope != "" {
 		agentScope = serverV2.Scope
@@ -1241,6 +1247,16 @@ func (a *ahLoginChecker) evaluateScopedSSHAccess(ident *sshca.Identity, ca types
 	return permit, nil
 }
 
+// isBeamServer reports whether the target server is a beam microVM, identified
+// by the internal beam ID label stamped on the node when the beam is created.
+func isBeamServer(target types.Server) bool {
+	if target == nil {
+		return false
+	}
+	_, ok := target.GetAllLabels()[types.BeamIDLabel]
+	return ok
+}
+
 // evaluateSSHAccess checks the given certificate (supplied by a connected
 // client) to see if this certificate can be allowed to login as user:login
 // pair to requested server and if RBAC rules allow login.
@@ -1286,6 +1302,11 @@ func (a *ahLoginChecker) evaluateSSHAccess(ident *sshca.Identity, ca types.CertA
 
 	// Perform the primary node access check unless bypass is allowed.
 	if !bypassAccessCheck {
+		if isBeamServer(target) && osUser != types.BeamsLogin {
+			return nil, trace.AccessDenied("user %s@%s is not authorized to login as %v@%s: beams may only be accessed as %q",
+				ident.Username, ca.GetClusterName(), osUser, clusterName, types.BeamsLogin)
+		}
+
 		if preconds, err = accessChecker.CheckConditionalAccess(
 			target,
 			state,

--- a/lib/srv/authhandlers_test.go
+++ b/lib/srv/authhandlers_test.go
@@ -1032,6 +1032,114 @@ func TestRBACJoinMFA(t *testing.T) {
 	}
 }
 
+func TestEvaluateSSHAccessBeam(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+
+	const clusterName = "localhost"
+	const username = "testuser"
+
+	userCAPriv, err := cryptosuites.GeneratePrivateKeyWithAlgorithm(cryptosuites.ECDSAP256)
+	require.NoError(t, err)
+	userCA, err := types.NewCertAuthority(types.CertAuthoritySpecV2{
+		Type:        types.UserCA,
+		ClusterName: clusterName,
+		ActiveKeys: types.CAKeySet{
+			SSH: []*types.SSHKeyPair{{
+				PublicKey:      userCAPriv.MarshalSSHPublicKey(),
+				PrivateKey:     userCAPriv.PrivateKeyPEM(),
+				PrivateKeyType: types.PrivateKeyType_RAW,
+			}},
+		},
+	})
+	require.NoError(t, err)
+
+	server := newMockServer(t)
+	cn, err := types.NewClusterName(types.ClusterNameSpecV2{
+		ClusterName: clusterName,
+		ClusterID:   "cluster_id",
+	})
+	require.NoError(t, err)
+	require.NoError(t, server.auth.SetClusterName(cn))
+
+	authPref, err := types.NewAuthPreference(types.AuthPreferenceSpecV2{
+		SecondFactor:   constants.SecondFactorOTP,
+		RequireMFAType: types.RequireMFAType_OFF,
+	})
+	require.NoError(t, err)
+
+	accessPoint := &mockCAandAuthPrefGetter{
+		AccessPoint: server.auth,
+		authPref:    authPref,
+		cas: map[types.CertAuthType][]types.CertAuthority{
+			types.UserCA: {userCA},
+		},
+	}
+
+	config := &AuthHandlerConfig{
+		Server:                        server,
+		Emitter:                       &eventstest.MockRecorderEmitter{},
+		AccessPoint:                   accessPoint,
+		ValidatedMFAChallengeVerifier: &mockMFAServiceClient{},
+	}
+	ah, err := NewAuthHandlers(config)
+	require.NoError(t, err)
+
+	_, err = server.auth.CreateClusterNetworkingConfig(ctx, types.DefaultClusterNetworkingConfig())
+	require.NoError(t, err)
+
+	role, err := types.NewRole("node-access", types.RoleSpecV6{
+		Allow: types.RoleConditions{
+			Logins:     []string{"root", types.BeamsLogin},
+			NodeLabels: types.Labels{types.Wildcard: []string{types.Wildcard}},
+		},
+	})
+	require.NoError(t, err)
+	_, err = server.auth.CreateRole(ctx, role)
+	require.NoError(t, err)
+
+	regularNode, err := types.NewNode("regular", types.SubKindOpenSSHNode, types.ServerSpecV2{
+		Addr:     "1.2.3.4:22",
+		Hostname: "regular",
+	}, map[string]string{"env": "test"})
+	require.NoError(t, err)
+
+	beamNode, err := types.NewNode("beam", types.SubKindOpenSSHNode, types.ServerSpecV2{
+		Addr:     "1.2.3.4:22",
+		Hostname: "beam-abc",
+	}, map[string]string{types.BeamIDLabel: "abc", types.BeamOwnerLabel: username})
+	require.NoError(t, err)
+
+	tests := []struct {
+		name       string
+		target     types.Server
+		osUser     string
+		wantDenied bool
+	}{
+		{name: "root on regular node allowed", target: regularNode, osUser: "root"},
+		{name: "beams on beam node allowed", target: beamNode, osUser: types.BeamsLogin},
+		{name: "root on beam node denied", target: beamNode, osUser: "root", wantDenied: true},
+		{name: "arbitrary login on beam node denied", target: beamNode, osUser: "ubuntu", wantDenied: true},
+	}
+
+	ident := &sshca.Identity{
+		Username: username,
+		Roles:    []string{role.GetName()},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := ah.evaluateSSHAccess(ident, userCA, clusterName, tt.target, tt.osUser)
+			if tt.wantDenied {
+				require.True(t, trace.IsAccessDenied(err), "expected access denied, got %v", err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
 func TestAuthorityForCert(t *testing.T) {
 	rawCA1, _, err := ed25519.GenerateKey(rand.Reader)
 	require.NoError(t, err)


### PR DESCRIPTION
## Changes
Beam access is granted via the beams login only but user's other roles (e.g. NewPresetAccessRole(), which is node_labels: '*':'*' + logins: {{internal.logins}}) would otherwise also match the beam node and offer root. That is how users today get root access to beams. 

But to prevent root login applying changes in two places:
1. At connection time in `evaluateScopedSSHAccess()`, any login other than beams is rejected for a beam node, this covers the web-ui, tsh ssh, and tsh beams ssh alike.
2. In the login list in `GetAllowedLoginsForResource()` we are now filtering out non-beam logins, so in all UI for beam nodes will only show beam as the login not root.



<!-- Provide a descriptive entry for the changelog of the next release. -->



<!-- Include manual testing efforts to verify the change. -->
<!-- Detail where the tests where run and what configurations were used. -->
<!-- Include all the test cases which were run to validate the change. -->

## Manual Test Plan
### Test Environment
- Enterprise Teleport cluster with the Beams entitlement enabled.

### Test Cases
- [ ] Create a beam and open connect on a beam node from the resources page and validate `root` is not in the login dropdown
