### PR TITLE
[v18] Add the `tctl auth create-override` command

### DIFF
--- a/docs/pages/reference/cli/tctl.mdx
+++ b/docs/pages/reference/cli/tctl.mdx
@@ -459,6 +459,31 @@ Usage:
 $ tctl audit schema
 ```
 
+## tctl auth create-override
+
+Add a single certificate override to a CA override resource
+
+Usage:
+
+```code
+$ tctl auth create-override --type=TYPE [<flags>] <cert.pem> [<chain.pem>...]
+```
+
+Flags:
+
+|Flag|Default|Description|
+|---|---|---|
+|`--[no-]disabled`|`false`|If true creates a disabled override|
+|`--[no-]force`|`false`|If true attempts to force creation, ignoring select state validation|
+|`--type`|*no default*|CA type (db-client, windows)|
+
+Arguments:
+
+|Argument|Default|Description|
+|---|---|---|
+|cert.pem|*no default* (required)|CA override certificate file in PEM form|
+|chain.pem|*no default* (optional)|CA override trust chain files in PEM form|
+
 ## tctl auth create-override-csr
 
 Create a CSR in preparation for CA certificate override

--- a/tool/tctl/common/subca/subca_command.go
+++ b/tool/tctl/common/subca/subca_command.go
@@ -172,7 +172,7 @@ func (c *Command) Initialize(
 		Flag("subject", `Customized certificate subject. Example: "O=MyClusterName,OU=MyOrgUnit,CN=MyCommonName"`).
 		StringVar(&c.createOverrideCSR.subject)
 
-	c.createOverride.CmdClause = parent.Command("create-override", "Create a CA override resource")
+	c.createOverride.CmdClause = parent.Command("create-override", "Add a single certificate override to a CA override resource")
 	c.createOverride.Flag("type", caTypesHelp).
 		Required().
 		StringVar(&c.createOverride.cliCAType)
@@ -183,7 +183,7 @@ func (c *Command) Initialize(
 		SetValue(&c.createOverride.chainFiles)
 	c.createOverride.Flag("disabled", "If true creates a disabled override").
 		BoolVar(&c.createOverride.disabled)
-	c.createOverride.Flag("force", "If true attempts to forces creation, ignoring select state validation").
+	c.createOverride.Flag("force", "If true attempts to force creation, ignoring select state validation").
 		BoolVar(&c.createOverride.force)
 
 	c.pubKeyHash.CmdClause = parent.Command(

--- a/tool/tctl/common/subca/subca_command.go
+++ b/tool/tctl/common/subca/subca_command.go
@@ -455,7 +455,7 @@ func (c *createOverrideCommand) Run(
 	}
 	defer closeFn(ctx)
 
-	_, err = authClient.SubCAClient().AddCertificateOverride(ctx, &subcav1.AddCertificateOverrideRequest{
+	_, err = authClient.SubCAClient().AddCertificateOverride(ctx, subcav1.AddCertificateOverrideRequest_builder{
 		CaId: subcav1.CertAuthorityOverrideID_builder{
 			CaType: caType,
 		}.Build(),
@@ -466,7 +466,7 @@ func (c *createOverrideCommand) Run(
 			Disabled:    c.disabled,
 		}.Build(),
 		ForceImmediateDisable: c.force,
-	})
+	}.Build())
 	if err != nil {
 		return trace.Wrap(err, "create certificate override")
 	}

--- a/tool/tctl/common/subca/subca_command.go
+++ b/tool/tctl/common/subca/subca_command.go
@@ -17,6 +17,7 @@
 package subca
 
 import (
+	"bytes"
 	"context"
 	"crypto/x509"
 	"encoding/pem"
@@ -30,12 +31,29 @@ import (
 	"github.com/gravitational/trace"
 
 	subcav1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/subca/v1"
+	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/utils/pkixname"
 	"github.com/gravitational/teleport/api/utils/tlsutils"
 	"github.com/gravitational/teleport/lib/service/servicecfg"
 	"github.com/gravitational/teleport/lib/subca"
 	tctlcfg "github.com/gravitational/teleport/tool/tctl/common/config"
 )
+
+type pemFileList []string
+
+func (p *pemFileList) Set(val string) error {
+	*p = append(*p, val)
+	return nil
+}
+
+func (p *pemFileList) String() string {
+	return ""
+}
+
+// IsCumulative tells kingpin that it's OK to call Set multiple times.
+func (p *pemFileList) IsCumulative() bool {
+	return true
+}
 
 // cliCATypes maps subca.SupportedCATypes() into their CLI-friendly counterparts
 // (typically by replacing "_" with "-").
@@ -109,6 +127,7 @@ type Command struct {
 	Stdout, Stderr io.Writer
 
 	createOverrideCSR createOverrideCSRCommand
+	createOverride    createOverrideCommand
 	pubKeyHash        pubKeyHashCommand
 }
 
@@ -131,15 +150,16 @@ func (c *Command) Initialize(
 		c.Stderr = os.Stderr
 	}
 
-	c.createOverrideCSR.CmdClause = parent.Command(
-		"create-override-csr", "Create a CSR in preparation for CA certificate override")
 	// Don't over-validate CA types on the client. That's the server's responsibility.
-	createCSRHelp := fmt.Sprintf(
+	caTypesHelp := fmt.Sprintf(
 		"CA type (%s)",
 		strings.Join(cliCATypes.Names, ", "),
 	)
+
+	c.createOverrideCSR.CmdClause = parent.Command(
+		"create-override-csr", "Create a CSR in preparation for CA certificate override")
 	c.createOverrideCSR.
-		Flag("type", createCSRHelp). // --type mimics other "tctl auth" commands
+		Flag("type", caTypesHelp). // --type mimics other "tctl auth" commands
 		Required().
 		StringVar(&c.createOverrideCSR.cliCAType)
 	c.createOverrideCSR.
@@ -151,6 +171,20 @@ func (c *Command) Initialize(
 	c.createOverrideCSR.
 		Flag("subject", `Customized certificate subject. Example: "O=MyClusterName,OU=MyOrgUnit,CN=MyCommonName"`).
 		StringVar(&c.createOverrideCSR.subject)
+
+	c.createOverride.CmdClause = parent.Command("create-override", "Create a CA override resource")
+	c.createOverride.Flag("type", caTypesHelp).
+		Required().
+		StringVar(&c.createOverride.cliCAType)
+	c.createOverride.Arg("cert.pem", "CA override certificate file in PEM form").
+		Required().
+		StringVar(&c.createOverride.certFile)
+	c.createOverride.Arg("chain.pem", "CA override trust chain files in PEM form").
+		SetValue(&c.createOverride.chainFiles)
+	c.createOverride.Flag("disabled", "If true creates a disabled override").
+		BoolVar(&c.createOverride.disabled)
+	c.createOverride.Flag("force", "If true attempts to forces creation, ignoring select state validation").
+		BoolVar(&c.createOverride.force)
 
 	c.pubKeyHash.CmdClause = parent.Command(
 		"pub-key-hash", "Extract and print the public key hash of a PEM certificate")
@@ -170,6 +204,7 @@ func (c *Command) TryRun(
 ) (match bool, err error) {
 	for _, cmd := range []subCommand{
 		&c.createOverrideCSR,
+		&c.createOverride,
 		&c.pubKeyHash,
 	} {
 		if selectedCommand == cmd.FullCommand() {
@@ -379,4 +414,78 @@ func (c *pubKeyHashCommand) Run(
 
 	fmt.Fprintln(s.Stdout, subca.HashCertificatePublicKey(cert))
 	return nil
+}
+
+type createOverrideCommand struct {
+	*kingpin.CmdClause
+
+	cliCAType  string
+	certFile   string
+	chainFiles pemFileList
+	disabled   bool
+	force      bool
+}
+
+func (c *createOverrideCommand) Run(
+	ctx context.Context,
+	clientFunc InitFunc,
+	s *commandState,
+) error {
+	caType := cliCATypes.Convert(c.cliCAType)
+
+	certPEM, cert, err := readCertFile(c.certFile)
+	if err != nil {
+		return trace.Wrap(err, "cert.pem")
+	}
+	pkh := subca.HashCertificatePublicKey(cert)
+
+	var chain []string
+	for i, chainFile := range c.chainFiles {
+		// Parse the cert so know it's valid, but otherwise we only need the PEM.
+		chainPEM, _, err := readCertFile(chainFile)
+		if err != nil {
+			return trace.Wrap(err, "chain%d.pem", i)
+		}
+		chain = append(chain, string(chainPEM))
+	}
+
+	authClient, closeFn, err := clientFunc(ctx)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	defer closeFn(ctx)
+
+	_, err = authClient.SubCAClient().AddCertificateOverride(ctx, &subcav1.AddCertificateOverrideRequest{
+		CaId: subcav1.CertAuthorityOverrideID_builder{
+			CaType: caType,
+		}.Build(),
+		CertificateOverride: subcav1.CertificateOverride_builder{
+			PublicKey:   pkh,
+			Certificate: string(certPEM),
+			Chain:       chain,
+			Disabled:    c.disabled,
+		}.Build(),
+		ForceImmediateDisable: c.force,
+	})
+	if err != nil {
+		return trace.Wrap(err, "create certificate override")
+	}
+	fmt.Fprintf(s.Stdout, "%s/%s: certificate override %s created\n", types.KindCertAuthorityOverride, caType, pkh)
+
+	return nil
+}
+
+func readCertFile(certFile string) (pem []byte, _ *x509.Certificate, _ error) {
+	certPEM, err := os.ReadFile(certFile)
+	if err != nil {
+		return nil, nil, trace.Wrap(err, "read certificate file")
+	}
+	// Trim spaces. Strict server validation doesn't allow it.
+	certPEM = bytes.TrimSpace(certPEM)
+
+	cert, err := tlsutils.ParseCertificatePEMStrict(certPEM)
+	if err != nil {
+		return nil, nil, trace.Wrap(err, "parse certificate")
+	}
+	return certPEM, cert, nil
 }

--- a/tool/tctl/common/subca/subca_command_test.go
+++ b/tool/tctl/common/subca/subca_command_test.go
@@ -33,6 +33,8 @@ import (
 
 	subcav1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/subca/v1"
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/api/utils/tlsutils"
+	libsubca "github.com/gravitational/teleport/lib/subca"
 	"github.com/gravitational/teleport/tool/tctl/common/subca"
 )
 
@@ -283,6 +285,129 @@ func TestMakeCATypeNames(t *testing.T) {
 	)
 }
 
+func TestCommand_CreateOverride(t *testing.T) {
+	t.Parallel()
+
+	// Write input certificates to files.
+	// Add trailing spaces to some files for testing purposes.
+	tempDir := t.TempDir()
+	certFile := filepath.Join(tempDir, "cert.pem")
+	chain0File := filepath.Join(tempDir, "chain0.pem")
+	chain1File := filepath.Join(tempDir, "chain1.pem")
+	require.NoError(t, os.WriteFile(certFile, []byte(overridePEM+"  \n\n  "), 0644))
+	require.NoError(t, os.WriteFile(chain0File, []byte(chain0PEM+"  \n\n  "), 0644))
+	require.NoError(t, os.WriteFile(chain1File, []byte(chain1PEM), 0644))
+
+	var certPubKey string
+	{
+		cert, err := tlsutils.ParseCertificatePEM([]byte(overridePEM))
+		require.NoError(t, err)
+		certPubKey = libsubca.HashCertificatePublicKey(cert)
+	}
+
+	caID := subcav1.CertAuthorityOverrideID_builder{
+		CaType: string(types.DatabaseClientCA),
+	}.Build()
+
+	tests := []struct {
+		name    string
+		flags   []string // flags after "tctl auth create-override"
+		wantReq *subcav1.AddCertificateOverrideRequest
+	}{
+		{
+			name: "ok",
+			flags: []string{
+				"--type", "db-client",
+				certFile,
+			},
+			wantReq: subcav1.AddCertificateOverrideRequest_builder{
+				CaId: caID,
+				CertificateOverride: subcav1.CertificateOverride_builder{
+					PublicKey:   certPubKey,
+					Certificate: overridePEM,
+				}.Build(),
+			}.Build(),
+		},
+		{
+			name: "use --disabled",
+			flags: []string{
+				"--type", "db-client",
+				"--disabled",
+				certFile,
+			},
+			wantReq: subcav1.AddCertificateOverrideRequest_builder{
+				CaId: caID,
+				CertificateOverride: subcav1.CertificateOverride_builder{
+					PublicKey:   certPubKey,
+					Certificate: overridePEM,
+					Disabled:    true,
+				}.Build(),
+			}.Build(),
+		},
+		{
+			name: "use --force",
+			flags: []string{
+				"--type", "db-client",
+				"--force",
+				certFile,
+			},
+			wantReq: subcav1.AddCertificateOverrideRequest_builder{
+				CaId: caID,
+				CertificateOverride: subcav1.CertificateOverride_builder{
+					PublicKey:   certPubKey,
+					Certificate: overridePEM,
+				}.Build(),
+				ForceImmediateDisable: true,
+			}.Build(),
+		},
+		{
+			name: "chain",
+			flags: []string{
+				"--type", "db-client",
+				certFile,
+				chain0File,
+				chain1File,
+			},
+			wantReq: subcav1.AddCertificateOverrideRequest_builder{
+				CaId: caID,
+				CertificateOverride: subcav1.CertificateOverride_builder{
+					PublicKey:   certPubKey,
+					Certificate: overridePEM,
+					Chain: []string{
+						chain0PEM,
+						chain1PEM,
+					},
+				}.Build(),
+			}.Build(),
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			fakeClient := &fakeAuthClient{}
+			clientFunc := func(ctx context.Context) (_ subca.SubCAClientSource, closeFn func(context.Context), _ error) {
+				return fakeClient, func(ctx context.Context) {}, nil
+			}
+
+			env := newCommand(t)
+
+			flags := append([]string{"auth", "create-override"}, test.flags...)
+			selectedCommand, err := env.App.Parse(flags)
+			require.NoError(t, err, "app.Parse()")
+
+			match, err := env.Cmd.TryRun(t.Context(), selectedCommand, clientFunc)
+			assert.True(t, match)
+			require.NoError(t, err, "Command errored")
+
+			// Verify server request.
+			if diff := cmp.Diff(test.wantReq, fakeClient.lastAddCertificateRequest, protocmp.Transform()); diff != "" {
+				t.Errorf("AddCertificateOverrideRequest mismatch (-want +got)\n%s", diff)
+			}
+		})
+	}
+}
+
 // CSR PEMs for testing.
 // The simplest way to get these is to run the "tctl auth create-override-csr"
 // command.
@@ -332,11 +457,70 @@ cxI=
 -----END CERTIFICATE REQUEST-----`
 )
 
+// Certificate PEMs for testing.
+const (
+	// overridePEM is a CA override certificate.
+	//
+	// subject=O=zarquon2, CN=zarquon2
+	// issuer=O=Llama Corp, OU=Llama CA, CN=Llama Database CA
+	overridePEM = `-----BEGIN CERTIFICATE-----
+MIICmjCCAkCgAwIBAgIUNvMJUfqbjR1o7ID+GlCEVfvADF4wCgYIKoZIzj0EAwIw
+RDETMBEGA1UEChMKTGxhbWEgQ29ycDERMA8GA1UECxMITGxhbWEgQ0ExGjAYBgNV
+BAMTEUxsYW1hIERhdGFiYXNlIENBMB4XDTI2MDYxMDE2MzUwMFoXDTMxMDYwOTE2
+MzUwMFowJjERMA8GA1UEChMIemFycXVvbjIxETAPBgNVBAMTCHphcnF1b24yMIIB
+IjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAm2wHhbEzHddPlg8RJxyeAArV
+Ku+jMLGWSVjSVH5Pn2301cSe28KC5iaRuYfzf6sdEftElyV7fUdeZ+i07QTWYuMT
+3B8x5J62n/g3R4RQxYY4ivNaISnApO435cPYDvDIpAzZ3qBKRdvXDAsc0/bjiG39
+qIi04V29WRz1IjS/BPWyRP6hoeP6gbtl4Z2YE4y1MwGvl3a0L4wEFvWrhZrhlpKu
+3IzryaE/lqAaE6H4zRGNL7qPUAxxnr4n1YdDN/0BGY7OYOvea9BPseHHzIAXo/v3
+5T1pn7aVhso4pkgb5Jj715LYw7uWlXV3y/f0R4Y2BP73SqkRhRzvMgQL+1DRBQID
+AQABo2MwYTAOBgNVHQ8BAf8EBAMCAQYwDwYDVR0TAQH/BAUwAwEB/zAdBgNVHQ4E
+FgQUYsc7XihR9bNRm8UdGZ1dlRZGVUQwHwYDVR0jBBgwFoAUDC1GIwweTul8uBzi
+Q4FKcCFBuhowCgYIKoZIzj0EAwIDSAAwRQIgebCxPjXntz2l3XtVzPYa63ayFwNX
+42EJAwazCrdS26sCIQC5koQINAk8I1+j3y3PmSw27DzTByWtnYtk9PI7xz9blQ==
+-----END CERTIFICATE-----`
+
+	// chain0PEM is an external (non-Teleport) intermediate CA.
+	//
+	// subject=O=Llama Corp, OU=Llama CA, CN=Llama Database CA
+	// issuer=O=Llama Corp, OU=Llama CA, CN=Llama Root CA
+	chain0PEM = `-----BEGIN CERTIFICATE-----
+MIIB7DCCAZKgAwIBAgIUZeRuKuCUiD7KiNfNp6Gg5vDb5nowCgYIKoZIzj0EAwIw
+QDETMBEGA1UEChMKTGxhbWEgQ29ycDERMA8GA1UECxMITGxhbWEgQ0ExFjAUBgNV
+BAMTDUxsYW1hIFJvb3QgQ0EwHhcNMjYwNTA3MTk0NjAwWhcNMzEwNTA2MTk0NjAw
+WjBEMRMwEQYDVQQKEwpMbGFtYSBDb3JwMREwDwYDVQQLEwhMbGFtYSBDQTEaMBgG
+A1UEAxMRTGxhbWEgRGF0YWJhc2UgQ0EwWTATBgcqhkjOPQIBBggqhkjOPQMBBwNC
+AAQf57W1nn+Tbgi0VHurKbPlhIQP9nA1TnM79SLevTlxnNCQXsCI/vUhAcyhdZbs
+O58AEuUijPK7k7+egL8AdlUmo2YwZDAOBgNVHQ8BAf8EBAMCAQYwEgYDVR0TAQH/
+BAgwBgEB/wIBATAdBgNVHQ4EFgQUDC1GIwweTul8uBziQ4FKcCFBuhowHwYDVR0j
+BBgwFoAUc4PZtEUN3muyF188EO3IJ2CPZdQwCgYIKoZIzj0EAwIDSAAwRQIhAJmN
+S5xRejN6jfAJsJG1pkyg8GD05sfyhe65DhjyvawOAiAuS+595Kfk16K0L+ngkRMb
+tktSPZQPhhfZHqhU+9F3uw==
+-----END CERTIFICATE-----`
+
+	// chain1PEM is an external (non-Teleport) self-signed root CA.
+	//
+	// subject=O=Llama Corp, OU=Llama CA, CN=Llama Root CA
+	chain1PEM = `-----BEGIN CERTIFICATE-----
+MIIBxDCCAWqgAwIBAgIUScZfsbAZPKpWwCnCn/98vsNJw30wCgYIKoZIzj0EAwIw
+QDETMBEGA1UEChMKTGxhbWEgQ29ycDERMA8GA1UECxMITGxhbWEgQ0ExFjAUBgNV
+BAMTDUxsYW1hIFJvb3QgQ0EwHhcNMjYwNDAxMjAxMjAwWhcNMzEwMzMxMjAxMjAw
+WjBAMRMwEQYDVQQKEwpMbGFtYSBDb3JwMREwDwYDVQQLEwhMbGFtYSBDQTEWMBQG
+A1UEAxMNTGxhbWEgUm9vdCBDQTBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABPk4
+01BUTEnyJjj6ao3hVwJPiTfdyhAdK6ZnBLUO4J5bapHd7qgO0UfRMWCPAprynBuW
+4kQpit787juRVtOLaQyjQjBAMA4GA1UdDwEB/wQEAwIBBjAPBgNVHRMBAf8EBTAD
+AQH/MB0GA1UdDgQWBBRzg9m0RQ3ea7IXXzwQ7cgnYI9l1DAKBggqhkjOPQQDAgNI
+ADBFAiBtpWrwZUPUFZTmSdlYX12oS0ZCy+sY0f7OtXHusCMo3gIhAM0c86jXYpq9
+gT/2q6LYL8NGcL6ParNRimdwhm+0+xOe
+-----END CERTIFICATE-----`
+)
+
 type fakeAuthClient struct {
 	subcav1.SubCAServiceClient
 
-	csrPEMs        []string
-	lastCSRRequest *subcav1.CreateCSRRequest
+	csrPEMs                   []string
+	lastCSRRequest            *subcav1.CreateCSRRequest
+	lastAddCertificateRequest *subcav1.AddCertificateOverrideRequest
 }
 
 func (f *fakeAuthClient) SubCAClient() subcav1.SubCAServiceClient {
@@ -360,6 +544,15 @@ func (f *fakeAuthClient) CreateCSR(
 		}.Build()
 	}
 	return resp, nil
+}
+
+func (f *fakeAuthClient) AddCertificateOverride(
+	ctx context.Context,
+	req *subcav1.AddCertificateOverrideRequest,
+	opts ...grpc.CallOption,
+) (*subcav1.AddCertificateOverrideResponse, error) {
+	f.lastAddCertificateRequest = req
+	return &subcav1.AddCertificateOverrideResponse{}, nil
 }
 
 func TestCommand_PubKeyHash(t *testing.T) {


### PR DESCRIPTION
Backport #67907 to branch/v18

changelog: Added the Sub CA `tctl auth create-override` command, a user-friendly alternative over `tctl create ca_override.yaml`

https://github.com/gravitational/teleport.e/issues/7675

## Manual Test Plan
### Test Environment

Local environment built with https://github.com/gravitational/teleport.e/pull/8981.

### Test Cases
- [x] `tctl auth create-override --type=db-client cert.pem` ("vanilla" invocation)
- [x] `tctl auth create-override --type=db-client --disabled cert.pem chain0.pem chain1.pem` (all flags)