### PR TITLE
[scopes] add scopes to access list protos

### DIFF
--- a/api/gen/proto/go/teleport/accesslist/v1/accesslist.pb.go
+++ b/api/gen/proto/go/teleport/accesslist/v1/accesslist.pb.go
@@ -150,6 +150,8 @@ const (
 	MembershipKind_MEMBERSHIP_KIND_USER MembershipKind = 1
 	// MEMBERSHIP_KIND_LIST represents list members that are nested Access Lists
 	MembershipKind_MEMBERSHIP_KIND_LIST MembershipKind = 2
+	// MEMBERSHIP_KIND_SCOPED_LIST represents list members that are nested scoped Access Lists
+	MembershipKind_MEMBERSHIP_KIND_SCOPED_LIST MembershipKind = 3
 )
 
 // Enum value maps for MembershipKind.
@@ -158,11 +160,13 @@ var (
 		0: "MEMBERSHIP_KIND_UNSPECIFIED",
 		1: "MEMBERSHIP_KIND_USER",
 		2: "MEMBERSHIP_KIND_LIST",
+		3: "MEMBERSHIP_KIND_SCOPED_LIST",
 	}
 	MembershipKind_value = map[string]int32{
 		"MEMBERSHIP_KIND_UNSPECIFIED": 0,
 		"MEMBERSHIP_KIND_USER":        1,
 		"MEMBERSHIP_KIND_LIST":        2,
+		"MEMBERSHIP_KIND_SCOPED_LIST": 3,
 	}
 )
 
@@ -248,8 +252,8 @@ func (x IneligibleStatus) Number() protoreflect.EnumNumber {
 	return protoreflect.EnumNumber(x)
 }
 
-// AccessListUserAssignmentType describes the type of membership anr/or ownership
-// a user has in an access list.
+// AccessListUserAssignmentType describes the type of membership and/or ownership
+// a user has in an Access List.
 type AccessListUserAssignmentType int32
 
 const (
@@ -307,7 +311,9 @@ type AccessList struct {
 	// spec is the specification for the Access List.
 	Spec *AccessListSpec `protobuf:"bytes,2,opt,name=spec,proto3" json:"spec,omitempty"`
 	// status contains dynamically calculated fields.
-	Status        *AccessListStatus `protobuf:"bytes,3,opt,name=status,proto3" json:"status,omitempty"`
+	Status *AccessListStatus `protobuf:"bytes,3,opt,name=status,proto3" json:"status,omitempty"`
+	// scope is the scope of the Access List.
+	Scope         string `protobuf:"bytes,4,opt,name=scope,proto3" json:"scope,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -358,6 +364,13 @@ func (x *AccessList) GetStatus() *AccessListStatus {
 	return nil
 }
 
+func (x *AccessList) GetScope() string {
+	if x != nil {
+		return x.Scope
+	}
+	return ""
+}
+
 func (x *AccessList) SetHeader(v *v1.ResourceHeader) {
 	x.Header = v
 }
@@ -368,6 +381,10 @@ func (x *AccessList) SetSpec(v *AccessListSpec) {
 
 func (x *AccessList) SetStatus(v *AccessListStatus) {
 	x.Status = v
+}
+
+func (x *AccessList) SetScope(v string) {
+	x.Scope = v
 }
 
 func (x *AccessList) HasHeader() bool {
@@ -412,6 +429,8 @@ type AccessList_builder struct {
 	Spec *AccessListSpec
 	// status contains dynamically calculated fields.
 	Status *AccessListStatus
+	// scope is the scope of the Access List.
+	Scope string
 }
 
 func (b0 AccessList_builder) Build() *AccessList {
@@ -421,6 +440,7 @@ func (b0 AccessList_builder) Build() *AccessList {
 	x.Header = b.Header
 	x.Spec = b.Spec
 	x.Status = b.Status
+	x.Scope = b.Scope
 	return m0
 }
 
@@ -686,7 +706,10 @@ func (b0 AccessListSpec_builder) Build() *AccessListSpec {
 // AccessListOwner is an owner of an Access List.
 type AccessListOwner struct {
 	state protoimpl.MessageState `protogen:"hybrid.v1"`
-	// name is the username of the owner.
+	// name is the name of the owner, depending on MembershipKind:
+	// MEMBERSHIP_KIND_USER: the username of the owner.
+	// MEMBERSHIP_KIND_LIST: the name of the owner Access List.
+	// MEMBERSHIP_KIND_SCOPED_LIST: the scope-qualified name of the owner Access List.
 	Name string `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
 	// description is the plaintext description of the owner and why they are an
 	// owner.
@@ -695,7 +718,7 @@ type AccessListOwner struct {
 	// and if not, describes how they're lacking eligibility.
 	IneligibleStatus IneligibleStatus `protobuf:"varint,3,opt,name=ineligible_status,json=ineligibleStatus,proto3,enum=teleport.accesslist.v1.IneligibleStatus" json:"ineligible_status,omitempty"`
 	// membership_kind describes the type of membership, either
-	// `MEMBERSHIP_KIND_USER` or `MEMBERSHIP_KIND_LIST`.
+	// `MEMBERSHIP_KIND_USER` or `MEMBERSHIP_KIND_LIST` or `MEMBERSHIP_KIND_SCOPED_LIST`.
 	MembershipKind MembershipKind `protobuf:"varint,4,opt,name=membership_kind,json=membershipKind,proto3,enum=teleport.accesslist.v1.MembershipKind" json:"membership_kind,omitempty"`
 	unknownFields  protoimpl.UnknownFields
 	sizeCache      protoimpl.SizeCache
@@ -773,7 +796,10 @@ func (x *AccessListOwner) SetMembershipKind(v MembershipKind) {
 type AccessListOwner_builder struct {
 	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
 
-	// name is the username of the owner.
+	// name is the name of the owner, depending on MembershipKind:
+	// MEMBERSHIP_KIND_USER: the username of the owner.
+	// MEMBERSHIP_KIND_LIST: the name of the owner Access List.
+	// MEMBERSHIP_KIND_SCOPED_LIST: the scope-qualified name of the owner Access List.
 	Name string
 	// description is the plaintext description of the owner and why they are an
 	// owner.
@@ -782,7 +808,7 @@ type AccessListOwner_builder struct {
 	// and if not, describes how they're lacking eligibility.
 	IneligibleStatus IneligibleStatus
 	// membership_kind describes the type of membership, either
-	// `MEMBERSHIP_KIND_USER` or `MEMBERSHIP_KIND_LIST`.
+	// `MEMBERSHIP_KIND_USER` or `MEMBERSHIP_KIND_LIST` or `MEMBERSHIP_KIND_SCOPED_LIST`.
 	MembershipKind MembershipKind
 }
 
@@ -1253,9 +1279,9 @@ func (b0 AccessListGrants_builder) Build() *AccessListGrants {
 // ScopedRoleGrant describes a scoped role granted at a specific scope.
 type ScopedRoleGrant struct {
 	state protoimpl.MessageState `protogen:"hybrid.v1"`
-	// role is the name of the scoped role to be granted.
+	// role is scope-qualified name of the scoped role to be granted.
 	Role string `protobuf:"bytes,1,opt,name=role,proto3" json:"role,omitempty"`
-	// scope is the scope the role will be assigned at. It must be an assignable
+	// scope is the scope the role will be granted at. It must be an assignable
 	// scope of the role.
 	Scope         string `protobuf:"bytes,2,opt,name=scope,proto3" json:"scope,omitempty"`
 	unknownFields protoimpl.UnknownFields
@@ -1312,9 +1338,9 @@ func (x *ScopedRoleGrant) SetScope(v string) {
 type ScopedRoleGrant_builder struct {
 	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
 
-	// role is the name of the scoped role to be granted.
+	// role is scope-qualified name of the scoped role to be granted.
 	Role string
-	// scope is the scope the role will be assigned at. It must be an assignable
+	// scope is the scope the role will be granted at. It must be an assignable
 	// scope of the role.
 	Scope string
 }
@@ -1334,7 +1360,10 @@ type Member struct {
 	// header is the header for the resource.
 	Header *v1.ResourceHeader `protobuf:"bytes,1,opt,name=header,proto3" json:"header,omitempty"`
 	// spec is the specification for the Access List member.
-	Spec          *MemberSpec `protobuf:"bytes,2,opt,name=spec,proto3" json:"spec,omitempty"`
+	Spec *MemberSpec `protobuf:"bytes,2,opt,name=spec,proto3" json:"spec,omitempty"`
+	// scope is the scope of the Access List member, it must be equal to the
+	// scope of the parent Access List.
+	Scope         string `protobuf:"bytes,3,opt,name=scope,proto3" json:"scope,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -1378,12 +1407,23 @@ func (x *Member) GetSpec() *MemberSpec {
 	return nil
 }
 
+func (x *Member) GetScope() string {
+	if x != nil {
+		return x.Scope
+	}
+	return ""
+}
+
 func (x *Member) SetHeader(v *v1.ResourceHeader) {
 	x.Header = v
 }
 
 func (x *Member) SetSpec(v *MemberSpec) {
 	x.Spec = v
+}
+
+func (x *Member) SetScope(v string) {
+	x.Scope = v
 }
 
 func (x *Member) HasHeader() bool {
@@ -1415,6 +1455,9 @@ type Member_builder struct {
 	Header *v1.ResourceHeader
 	// spec is the specification for the Access List member.
 	Spec *MemberSpec
+	// scope is the scope of the Access List member, it must be equal to the
+	// scope of the parent Access List.
+	Scope string
 }
 
 func (b0 Member_builder) Build() *Member {
@@ -1423,6 +1466,7 @@ func (b0 Member_builder) Build() *Member {
 	_, _ = b, x
 	x.Header = b.Header
 	x.Spec = b.Spec
+	x.Scope = b.Scope
 	return m0
 }
 
@@ -1431,7 +1475,10 @@ type MemberSpec struct {
 	state protoimpl.MessageState `protogen:"hybrid.v1"`
 	// associated Access List
 	AccessList string `protobuf:"bytes,1,opt,name=access_list,json=accessList,proto3" json:"access_list,omitempty"`
-	// name is the name of the member of the Access List.
+	// name is the name of the member of the Access List, depending on MembershipKind:
+	// MEMBERSHIP_KIND_USER: the username of the member.
+	// MEMBERSHIP_KIND_LIST: the name of the member Access List.
+	// MEMBERSHIP_KIND_SCOPED_LIST: the scope-qualified name of the member scope Access List.
 	Name string `protobuf:"bytes,2,opt,name=name,proto3" json:"name,omitempty"`
 	// joined is when the user joined the Access List.
 	Joined *timestamppb.Timestamp `protobuf:"bytes,3,opt,name=joined,proto3" json:"joined,omitempty"`
@@ -1445,7 +1492,7 @@ type MemberSpec struct {
 	// and if not, describes how they're lacking eligibility.
 	IneligibleStatus IneligibleStatus `protobuf:"varint,7,opt,name=ineligible_status,json=ineligibleStatus,proto3,enum=teleport.accesslist.v1.IneligibleStatus" json:"ineligible_status,omitempty"`
 	// membership_kind describes the type of membership, either
-	// `MEMBERSHIP_KIND_USER` or `MEMBERSHIP_KIND_LIST`.
+	// `MEMBERSHIP_KIND_USER` or `MEMBERSHIP_KIND_LIST` or `MEMBERSHIP_KIND_SCOPED_LIST`.
 	MembershipKind MembershipKind `protobuf:"varint,9,opt,name=membership_kind,json=membershipKind,proto3,enum=teleport.accesslist.v1.MembershipKind" json:"membership_kind,omitempty"`
 	unknownFields  protoimpl.UnknownFields
 	sizeCache      protoimpl.SizeCache
@@ -1591,7 +1638,10 @@ type MemberSpec_builder struct {
 
 	// associated Access List
 	AccessList string
-	// name is the name of the member of the Access List.
+	// name is the name of the member of the Access List, depending on MembershipKind:
+	// MEMBERSHIP_KIND_USER: the username of the member.
+	// MEMBERSHIP_KIND_LIST: the name of the member Access List.
+	// MEMBERSHIP_KIND_SCOPED_LIST: the scope-qualified name of the member scope Access List.
 	Name string
 	// joined is when the user joined the Access List.
 	Joined *timestamppb.Timestamp
@@ -1605,7 +1655,7 @@ type MemberSpec_builder struct {
 	// and if not, describes how they're lacking eligibility.
 	IneligibleStatus IneligibleStatus
 	// membership_kind describes the type of membership, either
-	// `MEMBERSHIP_KIND_USER` or `MEMBERSHIP_KIND_LIST`.
+	// `MEMBERSHIP_KIND_USER` or `MEMBERSHIP_KIND_LIST` or `MEMBERSHIP_KIND_SCOPED_LIST`.
 	MembershipKind MembershipKind
 }
 
@@ -1630,7 +1680,10 @@ type Review struct {
 	// header is the header for the resource.
 	Header *v1.ResourceHeader `protobuf:"bytes,1,opt,name=header,proto3" json:"header,omitempty"`
 	// spec is the specification for the Access List review.
-	Spec          *ReviewSpec `protobuf:"bytes,2,opt,name=spec,proto3" json:"spec,omitempty"`
+	Spec *ReviewSpec `protobuf:"bytes,2,opt,name=spec,proto3" json:"spec,omitempty"`
+	// scope is the scope of the Access List review. It must be equal to the
+	// scope of the reviewed Access List.
+	Scope         string `protobuf:"bytes,3,opt,name=scope,proto3" json:"scope,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -1674,12 +1727,23 @@ func (x *Review) GetSpec() *ReviewSpec {
 	return nil
 }
 
+func (x *Review) GetScope() string {
+	if x != nil {
+		return x.Scope
+	}
+	return ""
+}
+
 func (x *Review) SetHeader(v *v1.ResourceHeader) {
 	x.Header = v
 }
 
 func (x *Review) SetSpec(v *ReviewSpec) {
 	x.Spec = v
+}
+
+func (x *Review) SetScope(v string) {
+	x.Scope = v
 }
 
 func (x *Review) HasHeader() bool {
@@ -1711,6 +1775,9 @@ type Review_builder struct {
 	Header *v1.ResourceHeader
 	// spec is the specification for the Access List review.
 	Spec *ReviewSpec
+	// scope is the scope of the Access List review. It must be equal to the
+	// scope of the reviewed Access List.
+	Scope string
 }
 
 func (b0 Review_builder) Build() *Review {
@@ -1719,6 +1786,7 @@ func (b0 Review_builder) Build() *Review {
 	_, _ = b, x
 	x.Header = b.Header
 	x.Spec = b.Spec
+	x.Scope = b.Scope
 	return m0
 }
 
@@ -1726,6 +1794,8 @@ func (b0 Review_builder) Build() *Review {
 type ReviewSpec struct {
 	state protoimpl.MessageState `protogen:"hybrid.v1"`
 	// access_list is the name of the Access List that this review is for.
+	// If the review is scoped, this is the scope-qualified name of the reviewed
+	// scoped Access List.
 	AccessList string `protobuf:"bytes,1,opt,name=access_list,json=accessList,proto3" json:"access_list,omitempty"`
 	// reviewers are the users who performed the review.
 	Reviewers []string `protobuf:"bytes,2,rep,name=reviewers,proto3" json:"reviewers,omitempty"`
@@ -1846,6 +1916,8 @@ type ReviewSpec_builder struct {
 	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
 
 	// access_list is the name of the Access List that this review is for.
+	// If the review is scoped, this is the scope-qualified name of the reviewed
+	// scoped Access List.
 	AccessList string
 	// reviewers are the users who performed the review.
 	Reviewers []string
@@ -1884,8 +1956,11 @@ type ReviewChanges struct {
 	// review_day_of_month_changed is populated if the review day of month has
 	// changed.
 	ReviewDayOfMonthChanged ReviewDayOfMonth `protobuf:"varint,5,opt,name=review_day_of_month_changed,json=reviewDayOfMonthChanged,proto3,enum=teleport.accesslist.v1.ReviewDayOfMonth" json:"review_day_of_month_changed,omitempty"`
-	unknownFields           protoimpl.UnknownFields
-	sizeCache               protoimpl.SizeCache
+	// scoped_removed_members contains the scope-qualified names of members that
+	// were removed as part of this review.
+	ScopedRemovedMembers []string `protobuf:"bytes,6,rep,name=scoped_removed_members,json=scopedRemovedMembers,proto3" json:"scoped_removed_members,omitempty"`
+	unknownFields        protoimpl.UnknownFields
+	sizeCache            protoimpl.SizeCache
 }
 
 func (x *ReviewChanges) Reset() {
@@ -1941,6 +2016,13 @@ func (x *ReviewChanges) GetReviewDayOfMonthChanged() ReviewDayOfMonth {
 	return ReviewDayOfMonth_REVIEW_DAY_OF_MONTH_UNSPECIFIED
 }
 
+func (x *ReviewChanges) GetScopedRemovedMembers() []string {
+	if x != nil {
+		return x.ScopedRemovedMembers
+	}
+	return nil
+}
+
 func (x *ReviewChanges) SetMembershipRequirementsChanged(v *AccessListRequires) {
 	x.MembershipRequirementsChanged = v
 }
@@ -1955,6 +2037,10 @@ func (x *ReviewChanges) SetReviewFrequencyChanged(v ReviewFrequency) {
 
 func (x *ReviewChanges) SetReviewDayOfMonthChanged(v ReviewDayOfMonth) {
 	x.ReviewDayOfMonthChanged = v
+}
+
+func (x *ReviewChanges) SetScopedRemovedMembers(v []string) {
+	x.ScopedRemovedMembers = v
 }
 
 func (x *ReviewChanges) HasMembershipRequirementsChanged() bool {
@@ -1982,6 +2068,9 @@ type ReviewChanges_builder struct {
 	// review_day_of_month_changed is populated if the review day of month has
 	// changed.
 	ReviewDayOfMonthChanged ReviewDayOfMonth
+	// scoped_removed_members contains the scope-qualified names of members that
+	// were removed as part of this review.
+	ScopedRemovedMembers []string
 }
 
 func (b0 ReviewChanges_builder) Build() *ReviewChanges {
@@ -1992,15 +2081,16 @@ func (b0 ReviewChanges_builder) Build() *ReviewChanges {
 	x.RemovedMembers = b.RemovedMembers
 	x.ReviewFrequencyChanged = b.ReviewFrequencyChanged
 	x.ReviewDayOfMonthChanged = b.ReviewDayOfMonthChanged
+	x.ScopedRemovedMembers = b.ScopedRemovedMembers
 	return m0
 }
 
-// CurrentUserAssignments describes the current user's ownership and membership status in the access list.
+// CurrentUserAssignments describes the current user's ownership and membership status in the Access List.
 type CurrentUserAssignments struct {
 	state protoimpl.MessageState `protogen:"hybrid.v1"`
-	// ownership_type represents the current user's ownership type (explicit, inherited, or none) in the access list.
+	// ownership_type represents the current user's ownership type (explicit, inherited, or none) in the Access List.
 	OwnershipType AccessListUserAssignmentType `protobuf:"varint,1,opt,name=ownership_type,json=ownershipType,proto3,enum=teleport.accesslist.v1.AccessListUserAssignmentType" json:"ownership_type,omitempty"`
-	// membership_type represents the current user's membership type (explicit, inherited, or none) in the access list.
+	// membership_type represents the current user's membership type (explicit, inherited, or none) in the Access List.
 	MembershipType AccessListUserAssignmentType `protobuf:"varint,2,opt,name=membership_type,json=membershipType,proto3,enum=teleport.accesslist.v1.AccessListUserAssignmentType" json:"membership_type,omitempty"`
 	unknownFields  protoimpl.UnknownFields
 	sizeCache      protoimpl.SizeCache
@@ -2056,9 +2146,9 @@ func (x *CurrentUserAssignments) SetMembershipType(v AccessListUserAssignmentTyp
 type CurrentUserAssignments_builder struct {
 	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
 
-	// ownership_type represents the current user's ownership type (explicit, inherited, or none) in the access list.
+	// ownership_type represents the current user's ownership type (explicit, inherited, or none) in the Access List.
 	OwnershipType AccessListUserAssignmentType
-	// membership_type represents the current user's membership type (explicit, inherited, or none) in the access list.
+	// membership_type represents the current user's membership type (explicit, inherited, or none) in the Access List.
 	MembershipType AccessListUserAssignmentType
 }
 
@@ -2071,12 +2161,12 @@ func (b0 CurrentUserAssignments_builder) Build() *CurrentUserAssignments {
 	return m0
 }
 
-// UserAssignments describes the requested user's ownership and membership assignment types in the access list.
+// UserAssignments describes the requested user's ownership and membership assignment types in the Access List.
 type UserAssignments struct {
 	state protoimpl.MessageState `protogen:"hybrid.v1"`
-	// ownership_type represents the requested user's ownership type (explicit, inherited, or none) in the access list.
+	// ownership_type represents the requested user's ownership type (explicit, inherited, or none) in the Access List.
 	OwnershipType AccessListUserAssignmentType `protobuf:"varint,1,opt,name=ownership_type,json=ownershipType,proto3,enum=teleport.accesslist.v1.AccessListUserAssignmentType" json:"ownership_type,omitempty"`
-	// membership_type represents the requested user's membership type (explicit, inherited, or none) in the access list.
+	// membership_type represents the requested user's membership type (explicit, inherited, or none) in the Access List.
 	MembershipType AccessListUserAssignmentType `protobuf:"varint,2,opt,name=membership_type,json=membershipType,proto3,enum=teleport.accesslist.v1.AccessListUserAssignmentType" json:"membership_type,omitempty"`
 	unknownFields  protoimpl.UnknownFields
 	sizeCache      protoimpl.SizeCache
@@ -2132,9 +2222,9 @@ func (x *UserAssignments) SetMembershipType(v AccessListUserAssignmentType) {
 type UserAssignments_builder struct {
 	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
 
-	// ownership_type represents the requested user's ownership type (explicit, inherited, or none) in the access list.
+	// ownership_type represents the requested user's ownership type (explicit, inherited, or none) in the Access List.
 	OwnershipType AccessListUserAssignmentType
-	// membership_type represents the requested user's membership type (explicit, inherited, or none) in the access list.
+	// membership_type represents the requested user's membership type (explicit, inherited, or none) in the Access List.
 	MembershipType AccessListUserAssignmentType
 }
 
@@ -2158,12 +2248,18 @@ type AccessListStatus struct {
 	OwnerOf []string `protobuf:"bytes,3,rep,name=owner_of,json=ownerOf,proto3" json:"owner_of,omitempty"`
 	// member_of describes Access Lists where this Access List is an explicit member.
 	MemberOf []string `protobuf:"bytes,4,rep,name=member_of,json=memberOf,proto3" json:"member_of,omitempty"`
-	// current_user_assignments describes the current user's ownership and membership status in the access list.
+	// current_user_assignments describes the current user's ownership and membership status in the Access List.
 	CurrentUserAssignments *CurrentUserAssignments `protobuf:"bytes,5,opt,name=current_user_assignments,json=currentUserAssignments,proto3" json:"current_user_assignments,omitempty"`
-	// user_assignments describes the requested user's ownership and membership assignment types in the access list.
+	// user_assignments describes the requested user's ownership and membership assignment types in the Access List.
 	UserAssignments *UserAssignments `protobuf:"bytes,6,opt,name=user_assignments,json=userAssignments,proto3" json:"user_assignments,omitempty"`
-	unknownFields   protoimpl.UnknownFields
-	sizeCache       protoimpl.SizeCache
+	// scoped_owner_of describes scoped Access Lists where this Access List is an explicit owner.
+	// Each item is the scope-qualified name of the owned scoped Access List.
+	ScopedOwnerOf []string `protobuf:"bytes,7,rep,name=scoped_owner_of,json=scopedOwnerOf,proto3" json:"scoped_owner_of,omitempty"`
+	// scoped_member_of describes scoped Access Lists where this Access List is an explicit member.
+	// Each item is the scope-qualified name of the parent scoped Access List.
+	ScopedMemberOf []string `protobuf:"bytes,8,rep,name=scoped_member_of,json=scopedMemberOf,proto3" json:"scoped_member_of,omitempty"`
+	unknownFields  protoimpl.UnknownFields
+	sizeCache      protoimpl.SizeCache
 }
 
 func (x *AccessListStatus) Reset() {
@@ -2233,6 +2329,20 @@ func (x *AccessListStatus) GetUserAssignments() *UserAssignments {
 	return nil
 }
 
+func (x *AccessListStatus) GetScopedOwnerOf() []string {
+	if x != nil {
+		return x.ScopedOwnerOf
+	}
+	return nil
+}
+
+func (x *AccessListStatus) GetScopedMemberOf() []string {
+	if x != nil {
+		return x.ScopedMemberOf
+	}
+	return nil
+}
+
 func (x *AccessListStatus) SetMemberCount(v uint32) {
 	x.MemberCount = &v
 }
@@ -2255,6 +2365,14 @@ func (x *AccessListStatus) SetCurrentUserAssignments(v *CurrentUserAssignments) 
 
 func (x *AccessListStatus) SetUserAssignments(v *UserAssignments) {
 	x.UserAssignments = v
+}
+
+func (x *AccessListStatus) SetScopedOwnerOf(v []string) {
+	x.ScopedOwnerOf = v
+}
+
+func (x *AccessListStatus) SetScopedMemberOf(v []string) {
+	x.ScopedMemberOf = v
 }
 
 func (x *AccessListStatus) HasMemberCount() bool {
@@ -2312,10 +2430,16 @@ type AccessListStatus_builder struct {
 	OwnerOf []string
 	// member_of describes Access Lists where this Access List is an explicit member.
 	MemberOf []string
-	// current_user_assignments describes the current user's ownership and membership status in the access list.
+	// current_user_assignments describes the current user's ownership and membership status in the Access List.
 	CurrentUserAssignments *CurrentUserAssignments
-	// user_assignments describes the requested user's ownership and membership assignment types in the access list.
+	// user_assignments describes the requested user's ownership and membership assignment types in the Access List.
 	UserAssignments *UserAssignments
+	// scoped_owner_of describes scoped Access Lists where this Access List is an explicit owner.
+	// Each item is the scope-qualified name of the owned scoped Access List.
+	ScopedOwnerOf []string
+	// scoped_member_of describes scoped Access Lists where this Access List is an explicit member.
+	// Each item is the scope-qualified name of the parent scoped Access List.
+	ScopedMemberOf []string
 }
 
 func (b0 AccessListStatus_builder) Build() *AccessListStatus {
@@ -2328,6 +2452,8 @@ func (b0 AccessListStatus_builder) Build() *AccessListStatus {
 	x.MemberOf = b.MemberOf
 	x.CurrentUserAssignments = b.CurrentUserAssignments
 	x.UserAssignments = b.UserAssignments
+	x.ScopedOwnerOf = b.ScopedOwnerOf
+	x.ScopedMemberOf = b.ScopedMemberOf
 	return m0
 }
 
@@ -2335,12 +2461,13 @@ var File_teleport_accesslist_v1_accesslist_proto protoreflect.FileDescriptor
 
 const file_teleport_accesslist_v1_accesslist_proto_rawDesc = "" +
 	"\n" +
-	"'teleport/accesslist/v1/accesslist.proto\x12\x16teleport.accesslist.v1\x1a\x1egoogle/protobuf/duration.proto\x1a\x1fgoogle/protobuf/timestamp.proto\x1a'teleport/header/v1/resourceheader.proto\x1a\x1dteleport/trait/v1/trait.proto\"\xc6\x01\n" +
+	"'teleport/accesslist/v1/accesslist.proto\x12\x16teleport.accesslist.v1\x1a\x1egoogle/protobuf/duration.proto\x1a\x1fgoogle/protobuf/timestamp.proto\x1a'teleport/header/v1/resourceheader.proto\x1a\x1dteleport/trait/v1/trait.proto\"\xdc\x01\n" +
 	"\n" +
 	"AccessList\x12:\n" +
 	"\x06header\x18\x01 \x01(\v2\".teleport.header.v1.ResourceHeaderR\x06header\x12:\n" +
 	"\x04spec\x18\x02 \x01(\v2&.teleport.accesslist.v1.AccessListSpecR\x04spec\x12@\n" +
-	"\x06status\x18\x03 \x01(\v2(.teleport.accesslist.v1.AccessListStatusR\x06status\"\xd5\x04\n" +
+	"\x06status\x18\x03 \x01(\v2(.teleport.accesslist.v1.AccessListStatusR\x06status\x12\x14\n" +
+	"\x05scope\x18\x04 \x01(\tR\x05scope\"\xd5\x04\n" +
 	"\x0eAccessListSpec\x12 \n" +
 	"\vdescription\x18\x01 \x01(\tR\vdescription\x12?\n" +
 	"\x06owners\x18\x02 \x03(\v2'.teleport.accesslist.v1.AccessListOwnerR\x06owners\x12=\n" +
@@ -2381,10 +2508,11 @@ const file_teleport_accesslist_v1_accesslist_proto_rawDesc = "" +
 	"\fscoped_roles\x18\x03 \x03(\v2'.teleport.accesslist.v1.ScopedRoleGrantR\vscopedRoles\";\n" +
 	"\x0fScopedRoleGrant\x12\x12\n" +
 	"\x04role\x18\x01 \x01(\tR\x04role\x12\x14\n" +
-	"\x05scope\x18\x02 \x01(\tR\x05scope\"|\n" +
+	"\x05scope\x18\x02 \x01(\tR\x05scope\"\x92\x01\n" +
 	"\x06Member\x12:\n" +
 	"\x06header\x18\x01 \x01(\v2\".teleport.header.v1.ResourceHeaderR\x06header\x126\n" +
-	"\x04spec\x18\x02 \x01(\v2\".teleport.accesslist.v1.MemberSpecR\x04spec\"\x98\x03\n" +
+	"\x04spec\x18\x02 \x01(\v2\".teleport.accesslist.v1.MemberSpecR\x04spec\x12\x14\n" +
+	"\x05scope\x18\x03 \x01(\tR\x05scope\"\x98\x03\n" +
 	"\n" +
 	"MemberSpec\x12\x1f\n" +
 	"\vaccess_list\x18\x01 \x01(\tR\n" +
@@ -2396,10 +2524,11 @@ const file_teleport_accesslist_v1_accesslist_proto_rawDesc = "" +
 	"\badded_by\x18\x06 \x01(\tR\aaddedBy\x12U\n" +
 	"\x11ineligible_status\x18\a \x01(\x0e2(.teleport.accesslist.v1.IneligibleStatusR\x10ineligibleStatus\x12O\n" +
 	"\x0fmembership_kind\x18\t \x01(\x0e2&.teleport.accesslist.v1.MembershipKindR\x0emembershipKindJ\x04\b\b\x10\tR\n" +
-	"membership\"|\n" +
+	"membership\"\x92\x01\n" +
 	"\x06Review\x12:\n" +
 	"\x06header\x18\x01 \x01(\v2\".teleport.header.v1.ResourceHeaderR\x06header\x126\n" +
-	"\x04spec\x18\x02 \x01(\v2\".teleport.accesslist.v1.ReviewSpecR\x04spec\"\xdf\x01\n" +
+	"\x04spec\x18\x02 \x01(\v2\".teleport.accesslist.v1.ReviewSpecR\x04spec\x12\x14\n" +
+	"\x05scope\x18\x03 \x01(\tR\x05scope\"\xdf\x01\n" +
 	"\n" +
 	"ReviewSpec\x12\x1f\n" +
 	"\vaccess_list\x18\x01 \x01(\tR\n" +
@@ -2408,25 +2537,28 @@ const file_teleport_accesslist_v1_accesslist_proto_rawDesc = "" +
 	"\vreview_date\x18\x03 \x01(\v2\x1a.google.protobuf.TimestampR\n" +
 	"reviewDate\x12\x14\n" +
 	"\x05notes\x18\x04 \x01(\tR\x05notes\x12?\n" +
-	"\achanges\x18\x05 \x01(\v2%.teleport.accesslist.v1.ReviewChangesR\achanges\"\x90\x03\n" +
+	"\achanges\x18\x05 \x01(\v2%.teleport.accesslist.v1.ReviewChangesR\achanges\"\xc6\x03\n" +
 	"\rReviewChanges\x12r\n" +
 	"\x1fmembership_requirements_changed\x18\x02 \x01(\v2*.teleport.accesslist.v1.AccessListRequiresR\x1dmembershipRequirementsChanged\x12'\n" +
 	"\x0fremoved_members\x18\x03 \x03(\tR\x0eremovedMembers\x12a\n" +
 	"\x18review_frequency_changed\x18\x04 \x01(\x0e2'.teleport.accesslist.v1.ReviewFrequencyR\x16reviewFrequencyChanged\x12f\n" +
-	"\x1breview_day_of_month_changed\x18\x05 \x01(\x0e2(.teleport.accesslist.v1.ReviewDayOfMonthR\x17reviewDayOfMonthChangedJ\x04\b\x01\x10\x02R\x11frequency_changed\"\xd4\x01\n" +
+	"\x1breview_day_of_month_changed\x18\x05 \x01(\x0e2(.teleport.accesslist.v1.ReviewDayOfMonthR\x17reviewDayOfMonthChanged\x124\n" +
+	"\x16scoped_removed_members\x18\x06 \x03(\tR\x14scopedRemovedMembersJ\x04\b\x01\x10\x02R\x11frequency_changed\"\xd4\x01\n" +
 	"\x16CurrentUserAssignments\x12[\n" +
 	"\x0eownership_type\x18\x01 \x01(\x0e24.teleport.accesslist.v1.AccessListUserAssignmentTypeR\rownershipType\x12]\n" +
 	"\x0fmembership_type\x18\x02 \x01(\x0e24.teleport.accesslist.v1.AccessListUserAssignmentTypeR\x0emembershipType\"\xcd\x01\n" +
 	"\x0fUserAssignments\x12[\n" +
 	"\x0eownership_type\x18\x01 \x01(\x0e24.teleport.accesslist.v1.AccessListUserAssignmentTypeR\rownershipType\x12]\n" +
-	"\x0fmembership_type\x18\x02 \x01(\x0e24.teleport.accesslist.v1.AccessListUserAssignmentTypeR\x0emembershipType\"\x88\x03\n" +
+	"\x0fmembership_type\x18\x02 \x01(\x0e24.teleport.accesslist.v1.AccessListUserAssignmentTypeR\x0emembershipType\"\xda\x03\n" +
 	"\x10AccessListStatus\x12&\n" +
 	"\fmember_count\x18\x01 \x01(\rH\x00R\vmemberCount\x88\x01\x01\x12/\n" +
 	"\x11member_list_count\x18\x02 \x01(\rH\x01R\x0fmemberListCount\x88\x01\x01\x12\x19\n" +
 	"\bowner_of\x18\x03 \x03(\tR\aownerOf\x12\x1b\n" +
 	"\tmember_of\x18\x04 \x03(\tR\bmemberOf\x12h\n" +
 	"\x18current_user_assignments\x18\x05 \x01(\v2..teleport.accesslist.v1.CurrentUserAssignmentsR\x16currentUserAssignments\x12R\n" +
-	"\x10user_assignments\x18\x06 \x01(\v2'.teleport.accesslist.v1.UserAssignmentsR\x0fuserAssignmentsB\x0f\n" +
+	"\x10user_assignments\x18\x06 \x01(\v2'.teleport.accesslist.v1.UserAssignmentsR\x0fuserAssignments\x12&\n" +
+	"\x0fscoped_owner_of\x18\a \x03(\tR\rscopedOwnerOf\x12(\n" +
+	"\x10scoped_member_of\x18\b \x03(\tR\x0escopedMemberOfB\x0f\n" +
 	"\r_member_countB\x14\n" +
 	"\x12_member_list_count*\xb6\x01\n" +
 	"\x0fReviewFrequency\x12 \n" +
@@ -2439,11 +2571,12 @@ const file_teleport_accesslist_v1_accesslist_proto_rawDesc = "" +
 	"\x1fREVIEW_DAY_OF_MONTH_UNSPECIFIED\x10\x00\x12\x1d\n" +
 	"\x19REVIEW_DAY_OF_MONTH_FIRST\x10\x01\x12!\n" +
 	"\x1dREVIEW_DAY_OF_MONTH_FIFTEENTH\x10\x0f\x12\x1c\n" +
-	"\x18REVIEW_DAY_OF_MONTH_LAST\x10\x1f*e\n" +
+	"\x18REVIEW_DAY_OF_MONTH_LAST\x10\x1f*\x86\x01\n" +
 	"\x0eMembershipKind\x12\x1f\n" +
 	"\x1bMEMBERSHIP_KIND_UNSPECIFIED\x10\x00\x12\x18\n" +
 	"\x14MEMBERSHIP_KIND_USER\x10\x01\x12\x18\n" +
-	"\x14MEMBERSHIP_KIND_LIST\x10\x02*\xc6\x01\n" +
+	"\x14MEMBERSHIP_KIND_LIST\x10\x02\x12\x1f\n" +
+	"\x1bMEMBERSHIP_KIND_SCOPED_LIST\x10\x03*\xc6\x01\n" +
 	"\x10IneligibleStatus\x12!\n" +
 	"\x1dINELIGIBLE_STATUS_UNSPECIFIED\x10\x00\x12\x1e\n" +
 	"\x1aINELIGIBLE_STATUS_ELIGIBLE\x10\x01\x12$\n" +

--- a/api/gen/proto/go/teleport/accesslist/v1/accesslist_protoopaque.pb.go
+++ b/api/gen/proto/go/teleport/accesslist/v1/accesslist_protoopaque.pb.go
@@ -150,6 +150,8 @@ const (
 	MembershipKind_MEMBERSHIP_KIND_USER MembershipKind = 1
 	// MEMBERSHIP_KIND_LIST represents list members that are nested Access Lists
 	MembershipKind_MEMBERSHIP_KIND_LIST MembershipKind = 2
+	// MEMBERSHIP_KIND_SCOPED_LIST represents list members that are nested scoped Access Lists
+	MembershipKind_MEMBERSHIP_KIND_SCOPED_LIST MembershipKind = 3
 )
 
 // Enum value maps for MembershipKind.
@@ -158,11 +160,13 @@ var (
 		0: "MEMBERSHIP_KIND_UNSPECIFIED",
 		1: "MEMBERSHIP_KIND_USER",
 		2: "MEMBERSHIP_KIND_LIST",
+		3: "MEMBERSHIP_KIND_SCOPED_LIST",
 	}
 	MembershipKind_value = map[string]int32{
 		"MEMBERSHIP_KIND_UNSPECIFIED": 0,
 		"MEMBERSHIP_KIND_USER":        1,
 		"MEMBERSHIP_KIND_LIST":        2,
+		"MEMBERSHIP_KIND_SCOPED_LIST": 3,
 	}
 )
 
@@ -248,8 +252,8 @@ func (x IneligibleStatus) Number() protoreflect.EnumNumber {
 	return protoreflect.EnumNumber(x)
 }
 
-// AccessListUserAssignmentType describes the type of membership anr/or ownership
-// a user has in an access list.
+// AccessListUserAssignmentType describes the type of membership and/or ownership
+// a user has in an Access List.
 type AccessListUserAssignmentType int32
 
 const (
@@ -305,6 +309,7 @@ type AccessList struct {
 	xxx_hidden_Header *v1.ResourceHeader     `protobuf:"bytes,1,opt,name=header,proto3"`
 	xxx_hidden_Spec   *AccessListSpec        `protobuf:"bytes,2,opt,name=spec,proto3"`
 	xxx_hidden_Status *AccessListStatus      `protobuf:"bytes,3,opt,name=status,proto3"`
+	xxx_hidden_Scope  string                 `protobuf:"bytes,4,opt,name=scope,proto3"`
 	unknownFields     protoimpl.UnknownFields
 	sizeCache         protoimpl.SizeCache
 }
@@ -355,6 +360,13 @@ func (x *AccessList) GetStatus() *AccessListStatus {
 	return nil
 }
 
+func (x *AccessList) GetScope() string {
+	if x != nil {
+		return x.xxx_hidden_Scope
+	}
+	return ""
+}
+
 func (x *AccessList) SetHeader(v *v1.ResourceHeader) {
 	x.xxx_hidden_Header = v
 }
@@ -365,6 +377,10 @@ func (x *AccessList) SetSpec(v *AccessListSpec) {
 
 func (x *AccessList) SetStatus(v *AccessListStatus) {
 	x.xxx_hidden_Status = v
+}
+
+func (x *AccessList) SetScope(v string) {
+	x.xxx_hidden_Scope = v
 }
 
 func (x *AccessList) HasHeader() bool {
@@ -409,6 +425,8 @@ type AccessList_builder struct {
 	Spec *AccessListSpec
 	// status contains dynamically calculated fields.
 	Status *AccessListStatus
+	// scope is the scope of the Access List.
+	Scope string
 }
 
 func (b0 AccessList_builder) Build() *AccessList {
@@ -418,6 +436,7 @@ func (b0 AccessList_builder) Build() *AccessList {
 	x.xxx_hidden_Header = b.Header
 	x.xxx_hidden_Spec = b.Spec
 	x.xxx_hidden_Status = b.Status
+	x.xxx_hidden_Scope = b.Scope
 	return m0
 }
 
@@ -748,7 +767,10 @@ func (x *AccessListOwner) SetMembershipKind(v MembershipKind) {
 type AccessListOwner_builder struct {
 	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
 
-	// name is the username of the owner.
+	// name is the name of the owner, depending on MembershipKind:
+	// MEMBERSHIP_KIND_USER: the username of the owner.
+	// MEMBERSHIP_KIND_LIST: the name of the owner Access List.
+	// MEMBERSHIP_KIND_SCOPED_LIST: the scope-qualified name of the owner Access List.
 	Name string
 	// description is the plaintext description of the owner and why they are an
 	// owner.
@@ -757,7 +779,7 @@ type AccessListOwner_builder struct {
 	// and if not, describes how they're lacking eligibility.
 	IneligibleStatus IneligibleStatus
 	// membership_kind describes the type of membership, either
-	// `MEMBERSHIP_KIND_USER` or `MEMBERSHIP_KIND_LIST`.
+	// `MEMBERSHIP_KIND_USER` or `MEMBERSHIP_KIND_LIST` or `MEMBERSHIP_KIND_SCOPED_LIST`.
 	MembershipKind MembershipKind
 }
 
@@ -1274,9 +1296,9 @@ func (x *ScopedRoleGrant) SetScope(v string) {
 type ScopedRoleGrant_builder struct {
 	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
 
-	// role is the name of the scoped role to be granted.
+	// role is scope-qualified name of the scoped role to be granted.
 	Role string
-	// scope is the scope the role will be assigned at. It must be an assignable
+	// scope is the scope the role will be granted at. It must be an assignable
 	// scope of the role.
 	Scope string
 }
@@ -1295,6 +1317,7 @@ type Member struct {
 	state             protoimpl.MessageState `protogen:"opaque.v1"`
 	xxx_hidden_Header *v1.ResourceHeader     `protobuf:"bytes,1,opt,name=header,proto3"`
 	xxx_hidden_Spec   *MemberSpec            `protobuf:"bytes,2,opt,name=spec,proto3"`
+	xxx_hidden_Scope  string                 `protobuf:"bytes,3,opt,name=scope,proto3"`
 	unknownFields     protoimpl.UnknownFields
 	sizeCache         protoimpl.SizeCache
 }
@@ -1338,12 +1361,23 @@ func (x *Member) GetSpec() *MemberSpec {
 	return nil
 }
 
+func (x *Member) GetScope() string {
+	if x != nil {
+		return x.xxx_hidden_Scope
+	}
+	return ""
+}
+
 func (x *Member) SetHeader(v *v1.ResourceHeader) {
 	x.xxx_hidden_Header = v
 }
 
 func (x *Member) SetSpec(v *MemberSpec) {
 	x.xxx_hidden_Spec = v
+}
+
+func (x *Member) SetScope(v string) {
+	x.xxx_hidden_Scope = v
 }
 
 func (x *Member) HasHeader() bool {
@@ -1375,6 +1409,9 @@ type Member_builder struct {
 	Header *v1.ResourceHeader
 	// spec is the specification for the Access List member.
 	Spec *MemberSpec
+	// scope is the scope of the Access List member, it must be equal to the
+	// scope of the parent Access List.
+	Scope string
 }
 
 func (b0 Member_builder) Build() *Member {
@@ -1383,6 +1420,7 @@ func (b0 Member_builder) Build() *Member {
 	_, _ = b, x
 	x.xxx_hidden_Header = b.Header
 	x.xxx_hidden_Spec = b.Spec
+	x.xxx_hidden_Scope = b.Scope
 	return m0
 }
 
@@ -1541,7 +1579,10 @@ type MemberSpec_builder struct {
 
 	// associated Access List
 	AccessList string
-	// name is the name of the member of the Access List.
+	// name is the name of the member of the Access List, depending on MembershipKind:
+	// MEMBERSHIP_KIND_USER: the username of the member.
+	// MEMBERSHIP_KIND_LIST: the name of the member Access List.
+	// MEMBERSHIP_KIND_SCOPED_LIST: the scope-qualified name of the member scope Access List.
 	Name string
 	// joined is when the user joined the Access List.
 	Joined *timestamppb.Timestamp
@@ -1555,7 +1596,7 @@ type MemberSpec_builder struct {
 	// and if not, describes how they're lacking eligibility.
 	IneligibleStatus IneligibleStatus
 	// membership_kind describes the type of membership, either
-	// `MEMBERSHIP_KIND_USER` or `MEMBERSHIP_KIND_LIST`.
+	// `MEMBERSHIP_KIND_USER` or `MEMBERSHIP_KIND_LIST` or `MEMBERSHIP_KIND_SCOPED_LIST`.
 	MembershipKind MembershipKind
 }
 
@@ -1579,6 +1620,7 @@ type Review struct {
 	state             protoimpl.MessageState `protogen:"opaque.v1"`
 	xxx_hidden_Header *v1.ResourceHeader     `protobuf:"bytes,1,opt,name=header,proto3"`
 	xxx_hidden_Spec   *ReviewSpec            `protobuf:"bytes,2,opt,name=spec,proto3"`
+	xxx_hidden_Scope  string                 `protobuf:"bytes,3,opt,name=scope,proto3"`
 	unknownFields     protoimpl.UnknownFields
 	sizeCache         protoimpl.SizeCache
 }
@@ -1622,12 +1664,23 @@ func (x *Review) GetSpec() *ReviewSpec {
 	return nil
 }
 
+func (x *Review) GetScope() string {
+	if x != nil {
+		return x.xxx_hidden_Scope
+	}
+	return ""
+}
+
 func (x *Review) SetHeader(v *v1.ResourceHeader) {
 	x.xxx_hidden_Header = v
 }
 
 func (x *Review) SetSpec(v *ReviewSpec) {
 	x.xxx_hidden_Spec = v
+}
+
+func (x *Review) SetScope(v string) {
+	x.xxx_hidden_Scope = v
 }
 
 func (x *Review) HasHeader() bool {
@@ -1659,6 +1712,9 @@ type Review_builder struct {
 	Header *v1.ResourceHeader
 	// spec is the specification for the Access List review.
 	Spec *ReviewSpec
+	// scope is the scope of the Access List review. It must be equal to the
+	// scope of the reviewed Access List.
+	Scope string
 }
 
 func (b0 Review_builder) Build() *Review {
@@ -1667,6 +1723,7 @@ func (b0 Review_builder) Build() *Review {
 	_, _ = b, x
 	x.xxx_hidden_Header = b.Header
 	x.xxx_hidden_Spec = b.Spec
+	x.xxx_hidden_Scope = b.Scope
 	return m0
 }
 
@@ -1788,6 +1845,8 @@ type ReviewSpec_builder struct {
 	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
 
 	// access_list is the name of the Access List that this review is for.
+	// If the review is scoped, this is the scope-qualified name of the reviewed
+	// scoped Access List.
 	AccessList string
 	// reviewers are the users who performed the review.
 	Reviewers []string
@@ -1819,6 +1878,7 @@ type ReviewChanges struct {
 	xxx_hidden_RemovedMembers                []string               `protobuf:"bytes,3,rep,name=removed_members,json=removedMembers,proto3"`
 	xxx_hidden_ReviewFrequencyChanged        ReviewFrequency        `protobuf:"varint,4,opt,name=review_frequency_changed,json=reviewFrequencyChanged,proto3,enum=teleport.accesslist.v1.ReviewFrequency"`
 	xxx_hidden_ReviewDayOfMonthChanged       ReviewDayOfMonth       `protobuf:"varint,5,opt,name=review_day_of_month_changed,json=reviewDayOfMonthChanged,proto3,enum=teleport.accesslist.v1.ReviewDayOfMonth"`
+	xxx_hidden_ScopedRemovedMembers          []string               `protobuf:"bytes,6,rep,name=scoped_removed_members,json=scopedRemovedMembers,proto3"`
 	unknownFields                            protoimpl.UnknownFields
 	sizeCache                                protoimpl.SizeCache
 }
@@ -1876,6 +1936,13 @@ func (x *ReviewChanges) GetReviewDayOfMonthChanged() ReviewDayOfMonth {
 	return ReviewDayOfMonth_REVIEW_DAY_OF_MONTH_UNSPECIFIED
 }
 
+func (x *ReviewChanges) GetScopedRemovedMembers() []string {
+	if x != nil {
+		return x.xxx_hidden_ScopedRemovedMembers
+	}
+	return nil
+}
+
 func (x *ReviewChanges) SetMembershipRequirementsChanged(v *AccessListRequires) {
 	x.xxx_hidden_MembershipRequirementsChanged = v
 }
@@ -1890,6 +1957,10 @@ func (x *ReviewChanges) SetReviewFrequencyChanged(v ReviewFrequency) {
 
 func (x *ReviewChanges) SetReviewDayOfMonthChanged(v ReviewDayOfMonth) {
 	x.xxx_hidden_ReviewDayOfMonthChanged = v
+}
+
+func (x *ReviewChanges) SetScopedRemovedMembers(v []string) {
+	x.xxx_hidden_ScopedRemovedMembers = v
 }
 
 func (x *ReviewChanges) HasMembershipRequirementsChanged() bool {
@@ -1917,6 +1988,9 @@ type ReviewChanges_builder struct {
 	// review_day_of_month_changed is populated if the review day of month has
 	// changed.
 	ReviewDayOfMonthChanged ReviewDayOfMonth
+	// scoped_removed_members contains the scope-qualified names of members that
+	// were removed as part of this review.
+	ScopedRemovedMembers []string
 }
 
 func (b0 ReviewChanges_builder) Build() *ReviewChanges {
@@ -1927,10 +2001,11 @@ func (b0 ReviewChanges_builder) Build() *ReviewChanges {
 	x.xxx_hidden_RemovedMembers = b.RemovedMembers
 	x.xxx_hidden_ReviewFrequencyChanged = b.ReviewFrequencyChanged
 	x.xxx_hidden_ReviewDayOfMonthChanged = b.ReviewDayOfMonthChanged
+	x.xxx_hidden_ScopedRemovedMembers = b.ScopedRemovedMembers
 	return m0
 }
 
-// CurrentUserAssignments describes the current user's ownership and membership status in the access list.
+// CurrentUserAssignments describes the current user's ownership and membership status in the Access List.
 type CurrentUserAssignments struct {
 	state                     protoimpl.MessageState       `protogen:"opaque.v1"`
 	xxx_hidden_OwnershipType  AccessListUserAssignmentType `protobuf:"varint,1,opt,name=ownership_type,json=ownershipType,proto3,enum=teleport.accesslist.v1.AccessListUserAssignmentType"`
@@ -1989,9 +2064,9 @@ func (x *CurrentUserAssignments) SetMembershipType(v AccessListUserAssignmentTyp
 type CurrentUserAssignments_builder struct {
 	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
 
-	// ownership_type represents the current user's ownership type (explicit, inherited, or none) in the access list.
+	// ownership_type represents the current user's ownership type (explicit, inherited, or none) in the Access List.
 	OwnershipType AccessListUserAssignmentType
-	// membership_type represents the current user's membership type (explicit, inherited, or none) in the access list.
+	// membership_type represents the current user's membership type (explicit, inherited, or none) in the Access List.
 	MembershipType AccessListUserAssignmentType
 }
 
@@ -2004,7 +2079,7 @@ func (b0 CurrentUserAssignments_builder) Build() *CurrentUserAssignments {
 	return m0
 }
 
-// UserAssignments describes the requested user's ownership and membership assignment types in the access list.
+// UserAssignments describes the requested user's ownership and membership assignment types in the Access List.
 type UserAssignments struct {
 	state                     protoimpl.MessageState       `protogen:"opaque.v1"`
 	xxx_hidden_OwnershipType  AccessListUserAssignmentType `protobuf:"varint,1,opt,name=ownership_type,json=ownershipType,proto3,enum=teleport.accesslist.v1.AccessListUserAssignmentType"`
@@ -2063,9 +2138,9 @@ func (x *UserAssignments) SetMembershipType(v AccessListUserAssignmentType) {
 type UserAssignments_builder struct {
 	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
 
-	// ownership_type represents the requested user's ownership type (explicit, inherited, or none) in the access list.
+	// ownership_type represents the requested user's ownership type (explicit, inherited, or none) in the Access List.
 	OwnershipType AccessListUserAssignmentType
-	// membership_type represents the requested user's membership type (explicit, inherited, or none) in the access list.
+	// membership_type represents the requested user's membership type (explicit, inherited, or none) in the Access List.
 	MembershipType AccessListUserAssignmentType
 }
 
@@ -2087,6 +2162,8 @@ type AccessListStatus struct {
 	xxx_hidden_MemberOf               []string                `protobuf:"bytes,4,rep,name=member_of,json=memberOf,proto3"`
 	xxx_hidden_CurrentUserAssignments *CurrentUserAssignments `protobuf:"bytes,5,opt,name=current_user_assignments,json=currentUserAssignments,proto3"`
 	xxx_hidden_UserAssignments        *UserAssignments        `protobuf:"bytes,6,opt,name=user_assignments,json=userAssignments,proto3"`
+	xxx_hidden_ScopedOwnerOf          []string                `protobuf:"bytes,7,rep,name=scoped_owner_of,json=scopedOwnerOf,proto3"`
+	xxx_hidden_ScopedMemberOf         []string                `protobuf:"bytes,8,rep,name=scoped_member_of,json=scopedMemberOf,proto3"`
 	XXX_raceDetectHookData            protoimpl.RaceDetectHookData
 	XXX_presence                      [1]uint32
 	unknownFields                     protoimpl.UnknownFields
@@ -2160,14 +2237,28 @@ func (x *AccessListStatus) GetUserAssignments() *UserAssignments {
 	return nil
 }
 
+func (x *AccessListStatus) GetScopedOwnerOf() []string {
+	if x != nil {
+		return x.xxx_hidden_ScopedOwnerOf
+	}
+	return nil
+}
+
+func (x *AccessListStatus) GetScopedMemberOf() []string {
+	if x != nil {
+		return x.xxx_hidden_ScopedMemberOf
+	}
+	return nil
+}
+
 func (x *AccessListStatus) SetMemberCount(v uint32) {
 	x.xxx_hidden_MemberCount = v
-	protoimpl.X.SetPresent(&(x.XXX_presence[0]), 0, 6)
+	protoimpl.X.SetPresent(&(x.XXX_presence[0]), 0, 8)
 }
 
 func (x *AccessListStatus) SetMemberListCount(v uint32) {
 	x.xxx_hidden_MemberListCount = v
-	protoimpl.X.SetPresent(&(x.XXX_presence[0]), 1, 6)
+	protoimpl.X.SetPresent(&(x.XXX_presence[0]), 1, 8)
 }
 
 func (x *AccessListStatus) SetOwnerOf(v []string) {
@@ -2184,6 +2275,14 @@ func (x *AccessListStatus) SetCurrentUserAssignments(v *CurrentUserAssignments) 
 
 func (x *AccessListStatus) SetUserAssignments(v *UserAssignments) {
 	x.xxx_hidden_UserAssignments = v
+}
+
+func (x *AccessListStatus) SetScopedOwnerOf(v []string) {
+	x.xxx_hidden_ScopedOwnerOf = v
+}
+
+func (x *AccessListStatus) SetScopedMemberOf(v []string) {
+	x.xxx_hidden_ScopedMemberOf = v
 }
 
 func (x *AccessListStatus) HasMemberCount() bool {
@@ -2243,10 +2342,16 @@ type AccessListStatus_builder struct {
 	OwnerOf []string
 	// member_of describes Access Lists where this Access List is an explicit member.
 	MemberOf []string
-	// current_user_assignments describes the current user's ownership and membership status in the access list.
+	// current_user_assignments describes the current user's ownership and membership status in the Access List.
 	CurrentUserAssignments *CurrentUserAssignments
-	// user_assignments describes the requested user's ownership and membership assignment types in the access list.
+	// user_assignments describes the requested user's ownership and membership assignment types in the Access List.
 	UserAssignments *UserAssignments
+	// scoped_owner_of describes scoped Access Lists where this Access List is an explicit owner.
+	// Each item is the scope-qualified name of the owned scoped Access List.
+	ScopedOwnerOf []string
+	// scoped_member_of describes scoped Access Lists where this Access List is an explicit member.
+	// Each item is the scope-qualified name of the parent scoped Access List.
+	ScopedMemberOf []string
 }
 
 func (b0 AccessListStatus_builder) Build() *AccessListStatus {
@@ -2254,17 +2359,19 @@ func (b0 AccessListStatus_builder) Build() *AccessListStatus {
 	b, x := &b0, m0
 	_, _ = b, x
 	if b.MemberCount != nil {
-		protoimpl.X.SetPresentNonAtomic(&(x.XXX_presence[0]), 0, 6)
+		protoimpl.X.SetPresentNonAtomic(&(x.XXX_presence[0]), 0, 8)
 		x.xxx_hidden_MemberCount = *b.MemberCount
 	}
 	if b.MemberListCount != nil {
-		protoimpl.X.SetPresentNonAtomic(&(x.XXX_presence[0]), 1, 6)
+		protoimpl.X.SetPresentNonAtomic(&(x.XXX_presence[0]), 1, 8)
 		x.xxx_hidden_MemberListCount = *b.MemberListCount
 	}
 	x.xxx_hidden_OwnerOf = b.OwnerOf
 	x.xxx_hidden_MemberOf = b.MemberOf
 	x.xxx_hidden_CurrentUserAssignments = b.CurrentUserAssignments
 	x.xxx_hidden_UserAssignments = b.UserAssignments
+	x.xxx_hidden_ScopedOwnerOf = b.ScopedOwnerOf
+	x.xxx_hidden_ScopedMemberOf = b.ScopedMemberOf
 	return m0
 }
 
@@ -2272,12 +2379,13 @@ var File_teleport_accesslist_v1_accesslist_proto protoreflect.FileDescriptor
 
 const file_teleport_accesslist_v1_accesslist_proto_rawDesc = "" +
 	"\n" +
-	"'teleport/accesslist/v1/accesslist.proto\x12\x16teleport.accesslist.v1\x1a\x1egoogle/protobuf/duration.proto\x1a\x1fgoogle/protobuf/timestamp.proto\x1a'teleport/header/v1/resourceheader.proto\x1a\x1dteleport/trait/v1/trait.proto\"\xc6\x01\n" +
+	"'teleport/accesslist/v1/accesslist.proto\x12\x16teleport.accesslist.v1\x1a\x1egoogle/protobuf/duration.proto\x1a\x1fgoogle/protobuf/timestamp.proto\x1a'teleport/header/v1/resourceheader.proto\x1a\x1dteleport/trait/v1/trait.proto\"\xdc\x01\n" +
 	"\n" +
 	"AccessList\x12:\n" +
 	"\x06header\x18\x01 \x01(\v2\".teleport.header.v1.ResourceHeaderR\x06header\x12:\n" +
 	"\x04spec\x18\x02 \x01(\v2&.teleport.accesslist.v1.AccessListSpecR\x04spec\x12@\n" +
-	"\x06status\x18\x03 \x01(\v2(.teleport.accesslist.v1.AccessListStatusR\x06status\"\xd5\x04\n" +
+	"\x06status\x18\x03 \x01(\v2(.teleport.accesslist.v1.AccessListStatusR\x06status\x12\x14\n" +
+	"\x05scope\x18\x04 \x01(\tR\x05scope\"\xd5\x04\n" +
 	"\x0eAccessListSpec\x12 \n" +
 	"\vdescription\x18\x01 \x01(\tR\vdescription\x12?\n" +
 	"\x06owners\x18\x02 \x03(\v2'.teleport.accesslist.v1.AccessListOwnerR\x06owners\x12=\n" +
@@ -2318,10 +2426,11 @@ const file_teleport_accesslist_v1_accesslist_proto_rawDesc = "" +
 	"\fscoped_roles\x18\x03 \x03(\v2'.teleport.accesslist.v1.ScopedRoleGrantR\vscopedRoles\";\n" +
 	"\x0fScopedRoleGrant\x12\x12\n" +
 	"\x04role\x18\x01 \x01(\tR\x04role\x12\x14\n" +
-	"\x05scope\x18\x02 \x01(\tR\x05scope\"|\n" +
+	"\x05scope\x18\x02 \x01(\tR\x05scope\"\x92\x01\n" +
 	"\x06Member\x12:\n" +
 	"\x06header\x18\x01 \x01(\v2\".teleport.header.v1.ResourceHeaderR\x06header\x126\n" +
-	"\x04spec\x18\x02 \x01(\v2\".teleport.accesslist.v1.MemberSpecR\x04spec\"\x98\x03\n" +
+	"\x04spec\x18\x02 \x01(\v2\".teleport.accesslist.v1.MemberSpecR\x04spec\x12\x14\n" +
+	"\x05scope\x18\x03 \x01(\tR\x05scope\"\x98\x03\n" +
 	"\n" +
 	"MemberSpec\x12\x1f\n" +
 	"\vaccess_list\x18\x01 \x01(\tR\n" +
@@ -2333,10 +2442,11 @@ const file_teleport_accesslist_v1_accesslist_proto_rawDesc = "" +
 	"\badded_by\x18\x06 \x01(\tR\aaddedBy\x12U\n" +
 	"\x11ineligible_status\x18\a \x01(\x0e2(.teleport.accesslist.v1.IneligibleStatusR\x10ineligibleStatus\x12O\n" +
 	"\x0fmembership_kind\x18\t \x01(\x0e2&.teleport.accesslist.v1.MembershipKindR\x0emembershipKindJ\x04\b\b\x10\tR\n" +
-	"membership\"|\n" +
+	"membership\"\x92\x01\n" +
 	"\x06Review\x12:\n" +
 	"\x06header\x18\x01 \x01(\v2\".teleport.header.v1.ResourceHeaderR\x06header\x126\n" +
-	"\x04spec\x18\x02 \x01(\v2\".teleport.accesslist.v1.ReviewSpecR\x04spec\"\xdf\x01\n" +
+	"\x04spec\x18\x02 \x01(\v2\".teleport.accesslist.v1.ReviewSpecR\x04spec\x12\x14\n" +
+	"\x05scope\x18\x03 \x01(\tR\x05scope\"\xdf\x01\n" +
 	"\n" +
 	"ReviewSpec\x12\x1f\n" +
 	"\vaccess_list\x18\x01 \x01(\tR\n" +
@@ -2345,25 +2455,28 @@ const file_teleport_accesslist_v1_accesslist_proto_rawDesc = "" +
 	"\vreview_date\x18\x03 \x01(\v2\x1a.google.protobuf.TimestampR\n" +
 	"reviewDate\x12\x14\n" +
 	"\x05notes\x18\x04 \x01(\tR\x05notes\x12?\n" +
-	"\achanges\x18\x05 \x01(\v2%.teleport.accesslist.v1.ReviewChangesR\achanges\"\x90\x03\n" +
+	"\achanges\x18\x05 \x01(\v2%.teleport.accesslist.v1.ReviewChangesR\achanges\"\xc6\x03\n" +
 	"\rReviewChanges\x12r\n" +
 	"\x1fmembership_requirements_changed\x18\x02 \x01(\v2*.teleport.accesslist.v1.AccessListRequiresR\x1dmembershipRequirementsChanged\x12'\n" +
 	"\x0fremoved_members\x18\x03 \x03(\tR\x0eremovedMembers\x12a\n" +
 	"\x18review_frequency_changed\x18\x04 \x01(\x0e2'.teleport.accesslist.v1.ReviewFrequencyR\x16reviewFrequencyChanged\x12f\n" +
-	"\x1breview_day_of_month_changed\x18\x05 \x01(\x0e2(.teleport.accesslist.v1.ReviewDayOfMonthR\x17reviewDayOfMonthChangedJ\x04\b\x01\x10\x02R\x11frequency_changed\"\xd4\x01\n" +
+	"\x1breview_day_of_month_changed\x18\x05 \x01(\x0e2(.teleport.accesslist.v1.ReviewDayOfMonthR\x17reviewDayOfMonthChanged\x124\n" +
+	"\x16scoped_removed_members\x18\x06 \x03(\tR\x14scopedRemovedMembersJ\x04\b\x01\x10\x02R\x11frequency_changed\"\xd4\x01\n" +
 	"\x16CurrentUserAssignments\x12[\n" +
 	"\x0eownership_type\x18\x01 \x01(\x0e24.teleport.accesslist.v1.AccessListUserAssignmentTypeR\rownershipType\x12]\n" +
 	"\x0fmembership_type\x18\x02 \x01(\x0e24.teleport.accesslist.v1.AccessListUserAssignmentTypeR\x0emembershipType\"\xcd\x01\n" +
 	"\x0fUserAssignments\x12[\n" +
 	"\x0eownership_type\x18\x01 \x01(\x0e24.teleport.accesslist.v1.AccessListUserAssignmentTypeR\rownershipType\x12]\n" +
-	"\x0fmembership_type\x18\x02 \x01(\x0e24.teleport.accesslist.v1.AccessListUserAssignmentTypeR\x0emembershipType\"\x88\x03\n" +
+	"\x0fmembership_type\x18\x02 \x01(\x0e24.teleport.accesslist.v1.AccessListUserAssignmentTypeR\x0emembershipType\"\xda\x03\n" +
 	"\x10AccessListStatus\x12&\n" +
 	"\fmember_count\x18\x01 \x01(\rH\x00R\vmemberCount\x88\x01\x01\x12/\n" +
 	"\x11member_list_count\x18\x02 \x01(\rH\x01R\x0fmemberListCount\x88\x01\x01\x12\x19\n" +
 	"\bowner_of\x18\x03 \x03(\tR\aownerOf\x12\x1b\n" +
 	"\tmember_of\x18\x04 \x03(\tR\bmemberOf\x12h\n" +
 	"\x18current_user_assignments\x18\x05 \x01(\v2..teleport.accesslist.v1.CurrentUserAssignmentsR\x16currentUserAssignments\x12R\n" +
-	"\x10user_assignments\x18\x06 \x01(\v2'.teleport.accesslist.v1.UserAssignmentsR\x0fuserAssignmentsB\x0f\n" +
+	"\x10user_assignments\x18\x06 \x01(\v2'.teleport.accesslist.v1.UserAssignmentsR\x0fuserAssignments\x12&\n" +
+	"\x0fscoped_owner_of\x18\a \x03(\tR\rscopedOwnerOf\x12(\n" +
+	"\x10scoped_member_of\x18\b \x03(\tR\x0escopedMemberOfB\x0f\n" +
 	"\r_member_countB\x14\n" +
 	"\x12_member_list_count*\xb6\x01\n" +
 	"\x0fReviewFrequency\x12 \n" +
@@ -2376,11 +2489,12 @@ const file_teleport_accesslist_v1_accesslist_proto_rawDesc = "" +
 	"\x1fREVIEW_DAY_OF_MONTH_UNSPECIFIED\x10\x00\x12\x1d\n" +
 	"\x19REVIEW_DAY_OF_MONTH_FIRST\x10\x01\x12!\n" +
 	"\x1dREVIEW_DAY_OF_MONTH_FIFTEENTH\x10\x0f\x12\x1c\n" +
-	"\x18REVIEW_DAY_OF_MONTH_LAST\x10\x1f*e\n" +
+	"\x18REVIEW_DAY_OF_MONTH_LAST\x10\x1f*\x86\x01\n" +
 	"\x0eMembershipKind\x12\x1f\n" +
 	"\x1bMEMBERSHIP_KIND_UNSPECIFIED\x10\x00\x12\x18\n" +
 	"\x14MEMBERSHIP_KIND_USER\x10\x01\x12\x18\n" +
-	"\x14MEMBERSHIP_KIND_LIST\x10\x02*\xc6\x01\n" +
+	"\x14MEMBERSHIP_KIND_LIST\x10\x02\x12\x1f\n" +
+	"\x1bMEMBERSHIP_KIND_SCOPED_LIST\x10\x03*\xc6\x01\n" +
 	"\x10IneligibleStatus\x12!\n" +
 	"\x1dINELIGIBLE_STATUS_UNSPECIFIED\x10\x00\x12\x1e\n" +
 	"\x1aINELIGIBLE_STATUS_ELIGIBLE\x10\x01\x12$\n" +

--- a/api/proto/teleport/accesslist/v1/accesslist.proto
+++ b/api/proto/teleport/accesslist/v1/accesslist.proto
@@ -35,6 +35,9 @@ message AccessList {
 
   // status contains dynamically calculated fields.
   AccessListStatus status = 3;
+
+  // scope is the scope of the Access List.
+  string scope = 4;
 }
 
 // AccessListSpec is the specification for an Access List.
@@ -80,7 +83,10 @@ message AccessListSpec {
 
 // AccessListOwner is an owner of an Access List.
 message AccessListOwner {
-  // name is the username of the owner.
+  // name is the name of the owner, depending on MembershipKind:
+  // MEMBERSHIP_KIND_USER: the username of the owner.
+  // MEMBERSHIP_KIND_LIST: the name of the owner Access List.
+  // MEMBERSHIP_KIND_SCOPED_LIST: the scope-qualified name of the owner Access List.
   string name = 1;
 
   // description is the plaintext description of the owner and why they are an
@@ -92,7 +98,7 @@ message AccessListOwner {
   IneligibleStatus ineligible_status = 3;
 
   // membership_kind describes the type of membership, either
-  // `MEMBERSHIP_KIND_USER` or `MEMBERSHIP_KIND_LIST`.
+  // `MEMBERSHIP_KIND_USER` or `MEMBERSHIP_KIND_LIST` or `MEMBERSHIP_KIND_SCOPED_LIST`.
   MembershipKind membership_kind = 4;
 }
 
@@ -174,9 +180,9 @@ message AccessListGrants {
 
 // ScopedRoleGrant describes a scoped role granted at a specific scope.
 message ScopedRoleGrant {
-  // role is the name of the scoped role to be granted.
+  // role is scope-qualified name of the scoped role to be granted.
   string role = 1;
-  // scope is the scope the role will be assigned at. It must be an assignable
+  // scope is the scope the role will be granted at. It must be an assignable
   // scope of the role.
   string scope = 2;
 }
@@ -188,6 +194,10 @@ message Member {
 
   // spec is the specification for the Access List member.
   MemberSpec spec = 2;
+
+  // scope is the scope of the Access List member, it must be equal to the
+  // scope of the parent Access List.
+  string scope = 3;
 }
 
 // MemberSpec is the specification for an Access List member.
@@ -198,7 +208,10 @@ message MemberSpec {
   // associated Access List
   string access_list = 1;
 
-  // name is the name of the member of the Access List.
+  // name is the name of the member of the Access List, depending on MembershipKind:
+  // MEMBERSHIP_KIND_USER: the username of the member.
+  // MEMBERSHIP_KIND_LIST: the name of the member Access List.
+  // MEMBERSHIP_KIND_SCOPED_LIST: the scope-qualified name of the member scope Access List.
   string name = 2;
 
   // joined is when the user joined the Access List.
@@ -218,7 +231,7 @@ message MemberSpec {
   IneligibleStatus ineligible_status = 7;
 
   // membership_kind describes the type of membership, either
-  // `MEMBERSHIP_KIND_USER` or `MEMBERSHIP_KIND_LIST`.
+  // `MEMBERSHIP_KIND_USER` or `MEMBERSHIP_KIND_LIST` or `MEMBERSHIP_KIND_SCOPED_LIST`.
   MembershipKind membership_kind = 9;
 }
 
@@ -231,6 +244,8 @@ enum MembershipKind {
   MEMBERSHIP_KIND_USER = 1;
   // MEMBERSHIP_KIND_LIST represents list members that are nested Access Lists
   MEMBERSHIP_KIND_LIST = 2;
+  // MEMBERSHIP_KIND_SCOPED_LIST represents list members that are nested scoped Access Lists
+  MEMBERSHIP_KIND_SCOPED_LIST = 3;
 }
 
 // IneligibleStatus describes how the user is ineligible.
@@ -258,11 +273,17 @@ message Review {
 
   // spec is the specification for the Access List review.
   ReviewSpec spec = 2;
+
+  // scope is the scope of the Access List review. It must be equal to the
+  // scope of the reviewed Access List.
+  string scope = 3;
 }
 
 // ReviewSpec is the specification for an Access List review.
 message ReviewSpec {
   // access_list is the name of the Access List that this review is for.
+  // If the review is scoped, this is the scope-qualified name of the reviewed
+  // scoped Access List.
   string access_list = 1;
 
   // reviewers are the users who performed the review.
@@ -298,10 +319,14 @@ message ReviewChanges {
   // review_day_of_month_changed is populated if the review day of month has
   // changed.
   ReviewDayOfMonth review_day_of_month_changed = 5;
+
+  // scoped_removed_members contains the scope-qualified names of members that
+  // were removed as part of this review.
+  repeated string scoped_removed_members = 6;
 }
 
-// AccessListUserAssignmentType describes the type of membership anr/or ownership
-// a user has in an access list.
+// AccessListUserAssignmentType describes the type of membership and/or ownership
+// a user has in an Access List.
 enum AccessListUserAssignmentType {
   // ACCESS_LIST_USER_ASSIGNMENT_TYPE_UNSPECIFIED means the user is not an explicit nor an inherited member or owner
   ACCESS_LIST_USER_ASSIGNMENT_TYPE_UNSPECIFIED = 0;
@@ -311,19 +336,19 @@ enum AccessListUserAssignmentType {
   ACCESS_LIST_USER_ASSIGNMENT_TYPE_INHERITED = 2;
 }
 
-// CurrentUserAssignments describes the current user's ownership and membership status in the access list.
+// CurrentUserAssignments describes the current user's ownership and membership status in the Access List.
 message CurrentUserAssignments {
-  // ownership_type represents the current user's ownership type (explicit, inherited, or none) in the access list.
+  // ownership_type represents the current user's ownership type (explicit, inherited, or none) in the Access List.
   AccessListUserAssignmentType ownership_type = 1;
-  // membership_type represents the current user's membership type (explicit, inherited, or none) in the access list.
+  // membership_type represents the current user's membership type (explicit, inherited, or none) in the Access List.
   AccessListUserAssignmentType membership_type = 2;
 }
 
-// UserAssignments describes the requested user's ownership and membership assignment types in the access list.
+// UserAssignments describes the requested user's ownership and membership assignment types in the Access List.
 message UserAssignments {
-  // ownership_type represents the requested user's ownership type (explicit, inherited, or none) in the access list.
+  // ownership_type represents the requested user's ownership type (explicit, inherited, or none) in the Access List.
   AccessListUserAssignmentType ownership_type = 1;
-  // membership_type represents the requested user's membership type (explicit, inherited, or none) in the access list.
+  // membership_type represents the requested user's membership type (explicit, inherited, or none) in the Access List.
   AccessListUserAssignmentType membership_type = 2;
 }
 
@@ -337,8 +362,14 @@ message AccessListStatus {
   repeated string owner_of = 3;
   // member_of describes Access Lists where this Access List is an explicit member.
   repeated string member_of = 4;
-  // current_user_assignments describes the current user's ownership and membership status in the access list.
+  // current_user_assignments describes the current user's ownership and membership status in the Access List.
   CurrentUserAssignments current_user_assignments = 5;
-  // user_assignments describes the requested user's ownership and membership assignment types in the access list.
+  // user_assignments describes the requested user's ownership and membership assignment types in the Access List.
   UserAssignments user_assignments = 6;
+  // scoped_owner_of describes scoped Access Lists where this Access List is an explicit owner.
+  // Each item is the scope-qualified name of the owned scoped Access List.
+  repeated string scoped_owner_of = 7;
+  // scoped_member_of describes scoped Access Lists where this Access List is an explicit member.
+  // Each item is the scope-qualified name of the parent scoped Access List.
+  repeated string scoped_member_of = 8;
 }

--- a/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-accesslists.mdx
+++ b/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-accesslists.mdx
@@ -72,8 +72,8 @@ resource, which you can apply after installing the Teleport Kubernetes operator.
 
 |Field|Type|Description|
 |---|---|---|
-|role|string|role is the name of the scoped role to be granted.|
-|scope|string|scope is the scope the role will be assigned at. It must be an assignable scope of the role.|
+|role|string|role is scope-qualified name of the scoped role to be granted.|
+|scope|string|scope is the scope the role will be granted at. It must be an assignable scope of the role.|
 
 ### spec.grants.traits
 
@@ -108,8 +108,8 @@ resource, which you can apply after installing the Teleport Kubernetes operator.
 
 |Field|Type|Description|
 |---|---|---|
-|role|string|role is the name of the scoped role to be granted.|
-|scope|string|scope is the scope the role will be assigned at. It must be an assignable scope of the role.|
+|role|string|role is scope-qualified name of the scoped role to be granted.|
+|scope|string|scope is the scope the role will be granted at. It must be an assignable scope of the role.|
 
 ### spec.owner_grants.traits
 
@@ -124,8 +124,8 @@ resource, which you can apply after installing the Teleport Kubernetes operator.
 |---|---|---|
 |description|string|description is the plaintext description of the owner and why they are an owner.|
 |ineligible_status|string or integer|ineligible_status describes if this owner is eligible or not and if not, describes how they're lacking eligibility. Can be either the string or the integer representation of each option.|
-|membership_kind|string or integer|membership_kind describes the type of membership, either `MEMBERSHIP_KIND_USER` or `MEMBERSHIP_KIND_LIST`. Can be either the string or the integer representation of each option.|
-|name|string|name is the username of the owner.|
+|membership_kind|string or integer|membership_kind describes the type of membership, either `MEMBERSHIP_KIND_USER` or `MEMBERSHIP_KIND_LIST` or `MEMBERSHIP_KIND_SCOPED_LIST`. Can be either the string or the integer representation of each option.|
+|name|string|name is the name of the owner, depending on MembershipKind: MEMBERSHIP_KIND_USER: the username of the owner. MEMBERSHIP_KIND_LIST: the name of the owner Access List. MEMBERSHIP_KIND_SCOPED_LIST: the scope-qualified name of the owner Access List.|
 
 ### spec.ownership_requires
 

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/access_list.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/access_list.mdx
@@ -24,6 +24,7 @@ Teleport Terraform provider.
 ### Optional
 
 - `header` (Attributes) header is the header for the resource. (see [below for nested schema](#nested-schema-for-header))
+- `scope` (String) scope is the scope of the Access List.
 - `spec` (Attributes) spec is the specification for the Access List. (see [below for nested schema](#nested-schema-for-spec))
 
 ### Nested Schema for `header`
@@ -76,8 +77,8 @@ Optional:
 Optional:
 
 - `description` (String) description is the plaintext description of the owner and why they are an owner.
-- `membership_kind` (Number) membership_kind describes the type of membership, either `MEMBERSHIP_KIND_USER` or `MEMBERSHIP_KIND_LIST`.
-- `name` (String) name is the username of the owner.
+- `membership_kind` (Number) membership_kind describes the type of membership, either `MEMBERSHIP_KIND_USER` or `MEMBERSHIP_KIND_LIST` or `MEMBERSHIP_KIND_SCOPED_LIST`.
+- `name` (String) name is the name of the owner, depending on MembershipKind: MEMBERSHIP_KIND_USER: the username of the owner. MEMBERSHIP_KIND_LIST: the name of the owner Access List. MEMBERSHIP_KIND_SCOPED_LIST: the scope-qualified name of the owner Access List.
 
 
 ### Nested Schema for `spec.audit`
@@ -116,8 +117,8 @@ Optional:
 
 Optional:
 
-- `role` (String) role is the name of the scoped role to be granted.
-- `scope` (String) scope is the scope the role will be assigned at. It must be an assignable scope of the role.
+- `role` (String) role is scope-qualified name of the scoped role to be granted.
+- `scope` (String) scope is the scope the role will be granted at. It must be an assignable scope of the role.
 
 
 ### Nested Schema for `spec.grants.traits`
@@ -157,8 +158,8 @@ Optional:
 
 Optional:
 
-- `role` (String) role is the name of the scoped role to be granted.
-- `scope` (String) scope is the scope the role will be assigned at. It must be an assignable scope of the role.
+- `role` (String) role is scope-qualified name of the scoped role to be granted.
+- `scope` (String) scope is the scope the role will be granted at. It must be an assignable scope of the role.
 
 
 ### Nested Schema for `spec.owner_grants.traits`

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/access_list_member.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/access_list_member.mdx
@@ -24,6 +24,7 @@ Teleport Terraform provider.
 ### Optional
 
 - `header` (Attributes) header is the header for the resource. (see [below for nested schema](#nested-schema-for-header))
+- `scope` (String) scope is the scope of the Access List member, it must be equal to the scope of the parent Access List.
 - `spec` (Attributes) spec is the specification for the Access List member. (see [below for nested schema](#nested-schema-for-spec))
 
 ### Nested Schema for `header`
@@ -59,13 +60,13 @@ Optional:
 Required:
 
 - `access_list` (String) associated Access List
-- `membership_kind` (Number) membership_kind describes the type of membership, either `MEMBERSHIP_KIND_USER` or `MEMBERSHIP_KIND_LIST`.
+- `membership_kind` (Number) membership_kind describes the type of membership, either `MEMBERSHIP_KIND_USER` or `MEMBERSHIP_KIND_LIST` or `MEMBERSHIP_KIND_SCOPED_LIST`.
 
 Optional:
 
 - `added_by` (String) added_by is the user that added this user to the Access List.
 - `expires` (String) expires is when the user's membership to the Access List expires.
 - `joined` (String) joined is when the user joined the Access List.
-- `name` (String) name is the name of the member of the Access List.
+- `name` (String) name is the name of the member of the Access List, depending on MembershipKind: MEMBERSHIP_KIND_USER: the username of the member. MEMBERSHIP_KIND_LIST: the name of the member Access List. MEMBERSHIP_KIND_SCOPED_LIST: the scope-qualified name of the member scope Access List.
 - `reason` (String) reason is the reason this user was added to the Access List.
 

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/access_list.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/access_list.mdx
@@ -67,6 +67,7 @@ resource "teleport_access_list" "crane-operation" {
 ### Optional
 
 - `header` (Attributes) header is the header for the resource. (see [below for nested schema](#nested-schema-for-header))
+- `scope` (String) scope is the scope of the Access List.
 - `spec` (Attributes) spec is the specification for the Access List. (see [below for nested schema](#nested-schema-for-spec))
 
 ### Nested Schema for `header`
@@ -119,8 +120,8 @@ Optional:
 Optional:
 
 - `description` (String) description is the plaintext description of the owner and why they are an owner.
-- `membership_kind` (Number) membership_kind describes the type of membership, either `MEMBERSHIP_KIND_USER` or `MEMBERSHIP_KIND_LIST`.
-- `name` (String) name is the username of the owner.
+- `membership_kind` (Number) membership_kind describes the type of membership, either `MEMBERSHIP_KIND_USER` or `MEMBERSHIP_KIND_LIST` or `MEMBERSHIP_KIND_SCOPED_LIST`.
+- `name` (String) name is the name of the owner, depending on MembershipKind: MEMBERSHIP_KIND_USER: the username of the owner. MEMBERSHIP_KIND_LIST: the name of the owner Access List. MEMBERSHIP_KIND_SCOPED_LIST: the scope-qualified name of the owner Access List.
 
 
 ### Nested Schema for `spec.audit`
@@ -159,8 +160,8 @@ Optional:
 
 Optional:
 
-- `role` (String) role is the name of the scoped role to be granted.
-- `scope` (String) scope is the scope the role will be assigned at. It must be an assignable scope of the role.
+- `role` (String) role is scope-qualified name of the scoped role to be granted.
+- `scope` (String) scope is the scope the role will be granted at. It must be an assignable scope of the role.
 
 
 ### Nested Schema for `spec.grants.traits`
@@ -200,8 +201,8 @@ Optional:
 
 Optional:
 
-- `role` (String) role is the name of the scoped role to be granted.
-- `scope` (String) scope is the scope the role will be assigned at. It must be an assignable scope of the role.
+- `role` (String) role is scope-qualified name of the scoped role to be granted.
+- `scope` (String) scope is the scope the role will be granted at. It must be an assignable scope of the role.
 
 
 ### Nested Schema for `spec.owner_grants.traits`

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/access_list_member.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/access_list_member.mdx
@@ -99,6 +99,7 @@ resource "teleport_access_list_member" "npcs" {
 ### Optional
 
 - `header` (Attributes) header is the header for the resource. (see [below for nested schema](#nested-schema-for-header))
+- `scope` (String) scope is the scope of the Access List member, it must be equal to the scope of the parent Access List.
 - `spec` (Attributes) spec is the specification for the Access List member. (see [below for nested schema](#nested-schema-for-spec))
 
 ### Nested Schema for `header`
@@ -134,12 +135,12 @@ Optional:
 Required:
 
 - `access_list` (String) associated Access List
-- `membership_kind` (Number) membership_kind describes the type of membership, either `MEMBERSHIP_KIND_USER` or `MEMBERSHIP_KIND_LIST`.
+- `membership_kind` (Number) membership_kind describes the type of membership, either `MEMBERSHIP_KIND_USER` or `MEMBERSHIP_KIND_LIST` or `MEMBERSHIP_KIND_SCOPED_LIST`.
 
 Optional:
 
 - `added_by` (String) added_by is the user that added this user to the Access List.
 - `expires` (String) expires is when the user's membership to the Access List expires.
 - `joined` (String) joined is when the user joined the Access List.
-- `name` (String) name is the name of the member of the Access List.
+- `name` (String) name is the name of the member of the Access List, depending on MembershipKind: MEMBERSHIP_KIND_USER: the username of the member. MEMBERSHIP_KIND_LIST: the name of the member Access List. MEMBERSHIP_KIND_SCOPED_LIST: the scope-qualified name of the member scope Access List.
 - `reason` (String) reason is the reason this user was added to the Access List.

--- a/examples/chart/teleport-cluster/charts/teleport-operator/operator-crds/resources.teleport.dev_accesslists.yaml
+++ b/examples/chart/teleport-cluster/charts/teleport-operator/operator-crds/resources.teleport.dev_accesslists.yaml
@@ -91,10 +91,11 @@ spec:
                     items:
                       properties:
                         role:
-                          description: role is the name of the scoped role to be granted.
+                          description: role is scope-qualified name of the scoped
+                            role to be granted.
                           type: string
                         scope:
-                          description: scope is the scope the role will be assigned
+                          description: scope is the scope the role will be granted
                             at. It must be an assignable scope of the role.
                           type: string
                       type: object
@@ -147,10 +148,11 @@ spec:
                     items:
                       properties:
                         role:
-                          description: role is the name of the scoped role to be granted.
+                          description: role is scope-qualified name of the scoped
+                            role to be granted.
                           type: string
                         scope:
-                          description: scope is the scope the role will be assigned
+                          description: scope is the scope the role will be granted
                             at. It must be an assignable scope of the role.
                           type: string
                       type: object
@@ -178,10 +180,14 @@ spec:
                       x-kubernetes-int-or-string: true
                     membership_kind:
                       description: membership_kind describes the type of membership,
-                        either `MEMBERSHIP_KIND_USER` or `MEMBERSHIP_KIND_LIST`.
+                        either `MEMBERSHIP_KIND_USER` or `MEMBERSHIP_KIND_LIST` or
+                        `MEMBERSHIP_KIND_SCOPED_LIST`.
                       x-kubernetes-int-or-string: true
                     name:
-                      description: name is the username of the owner.
+                      description: 'name is the name of the owner, depending on MembershipKind:
+                        MEMBERSHIP_KIND_USER: the username of the owner. MEMBERSHIP_KIND_LIST:
+                        the name of the owner Access List. MEMBERSHIP_KIND_SCOPED_LIST:
+                        the scope-qualified name of the owner Access List.'
                       type: string
                   type: object
                 nullable: true

--- a/gen/proto/ts/teleport/accesslist/v1/accesslist_pb.ts
+++ b/gen/proto/ts/teleport/accesslist/v1/accesslist_pb.ts
@@ -57,6 +57,12 @@ export interface AccessList {
      * @generated from protobuf field: teleport.accesslist.v1.AccessListStatus status = 3;
      */
     status?: AccessListStatus;
+    /**
+     * scope is the scope of the Access List.
+     *
+     * @generated from protobuf field: string scope = 4;
+     */
+    scope: string;
 }
 /**
  * AccessListSpec is the specification for an Access List.
@@ -134,7 +140,10 @@ export interface AccessListSpec {
  */
 export interface AccessListOwner {
     /**
-     * name is the username of the owner.
+     * name is the name of the owner, depending on MembershipKind:
+     * MEMBERSHIP_KIND_USER: the username of the owner.
+     * MEMBERSHIP_KIND_LIST: the name of the owner Access List.
+     * MEMBERSHIP_KIND_SCOPED_LIST: the scope-qualified name of the owner Access List.
      *
      * @generated from protobuf field: string name = 1;
      */
@@ -155,7 +164,7 @@ export interface AccessListOwner {
     ineligibleStatus: IneligibleStatus;
     /**
      * membership_kind describes the type of membership, either
-     * `MEMBERSHIP_KIND_USER` or `MEMBERSHIP_KIND_LIST`.
+     * `MEMBERSHIP_KIND_USER` or `MEMBERSHIP_KIND_LIST` or `MEMBERSHIP_KIND_SCOPED_LIST`.
      *
      * @generated from protobuf field: teleport.accesslist.v1.MembershipKind membership_kind = 4;
      */
@@ -277,13 +286,13 @@ export interface AccessListGrants {
  */
 export interface ScopedRoleGrant {
     /**
-     * role is the name of the scoped role to be granted.
+     * role is scope-qualified name of the scoped role to be granted.
      *
      * @generated from protobuf field: string role = 1;
      */
     role: string;
     /**
-     * scope is the scope the role will be assigned at. It must be an assignable
+     * scope is the scope the role will be granted at. It must be an assignable
      * scope of the role.
      *
      * @generated from protobuf field: string scope = 2;
@@ -308,6 +317,13 @@ export interface Member {
      * @generated from protobuf field: teleport.accesslist.v1.MemberSpec spec = 2;
      */
     spec?: MemberSpec;
+    /**
+     * scope is the scope of the Access List member, it must be equal to the
+     * scope of the parent Access List.
+     *
+     * @generated from protobuf field: string scope = 3;
+     */
+    scope: string;
 }
 /**
  * MemberSpec is the specification for an Access List member.
@@ -322,7 +338,10 @@ export interface MemberSpec {
      */
     accessList: string;
     /**
-     * name is the name of the member of the Access List.
+     * name is the name of the member of the Access List, depending on MembershipKind:
+     * MEMBERSHIP_KIND_USER: the username of the member.
+     * MEMBERSHIP_KIND_LIST: the name of the member Access List.
+     * MEMBERSHIP_KIND_SCOPED_LIST: the scope-qualified name of the member scope Access List.
      *
      * @generated from protobuf field: string name = 2;
      */
@@ -360,7 +379,7 @@ export interface MemberSpec {
     ineligibleStatus: IneligibleStatus;
     /**
      * membership_kind describes the type of membership, either
-     * `MEMBERSHIP_KIND_USER` or `MEMBERSHIP_KIND_LIST`.
+     * `MEMBERSHIP_KIND_USER` or `MEMBERSHIP_KIND_LIST` or `MEMBERSHIP_KIND_SCOPED_LIST`.
      *
      * @generated from protobuf field: teleport.accesslist.v1.MembershipKind membership_kind = 9;
      */
@@ -384,6 +403,13 @@ export interface Review {
      * @generated from protobuf field: teleport.accesslist.v1.ReviewSpec spec = 2;
      */
     spec?: ReviewSpec;
+    /**
+     * scope is the scope of the Access List review. It must be equal to the
+     * scope of the reviewed Access List.
+     *
+     * @generated from protobuf field: string scope = 3;
+     */
+    scope: string;
 }
 /**
  * ReviewSpec is the specification for an Access List review.
@@ -393,6 +419,8 @@ export interface Review {
 export interface ReviewSpec {
     /**
      * access_list is the name of the Access List that this review is for.
+     * If the review is scoped, this is the scope-qualified name of the reviewed
+     * scoped Access List.
      *
      * @generated from protobuf field: string access_list = 1;
      */
@@ -456,40 +484,47 @@ export interface ReviewChanges {
      * @generated from protobuf field: teleport.accesslist.v1.ReviewDayOfMonth review_day_of_month_changed = 5;
      */
     reviewDayOfMonthChanged: ReviewDayOfMonth;
+    /**
+     * scoped_removed_members contains the scope-qualified names of members that
+     * were removed as part of this review.
+     *
+     * @generated from protobuf field: repeated string scoped_removed_members = 6;
+     */
+    scopedRemovedMembers: string[];
 }
 /**
- * CurrentUserAssignments describes the current user's ownership and membership status in the access list.
+ * CurrentUserAssignments describes the current user's ownership and membership status in the Access List.
  *
  * @generated from protobuf message teleport.accesslist.v1.CurrentUserAssignments
  */
 export interface CurrentUserAssignments {
     /**
-     * ownership_type represents the current user's ownership type (explicit, inherited, or none) in the access list.
+     * ownership_type represents the current user's ownership type (explicit, inherited, or none) in the Access List.
      *
      * @generated from protobuf field: teleport.accesslist.v1.AccessListUserAssignmentType ownership_type = 1;
      */
     ownershipType: AccessListUserAssignmentType;
     /**
-     * membership_type represents the current user's membership type (explicit, inherited, or none) in the access list.
+     * membership_type represents the current user's membership type (explicit, inherited, or none) in the Access List.
      *
      * @generated from protobuf field: teleport.accesslist.v1.AccessListUserAssignmentType membership_type = 2;
      */
     membershipType: AccessListUserAssignmentType;
 }
 /**
- * UserAssignments describes the requested user's ownership and membership assignment types in the access list.
+ * UserAssignments describes the requested user's ownership and membership assignment types in the Access List.
  *
  * @generated from protobuf message teleport.accesslist.v1.UserAssignments
  */
 export interface UserAssignments {
     /**
-     * ownership_type represents the requested user's ownership type (explicit, inherited, or none) in the access list.
+     * ownership_type represents the requested user's ownership type (explicit, inherited, or none) in the Access List.
      *
      * @generated from protobuf field: teleport.accesslist.v1.AccessListUserAssignmentType ownership_type = 1;
      */
     ownershipType: AccessListUserAssignmentType;
     /**
-     * membership_type represents the requested user's membership type (explicit, inherited, or none) in the access list.
+     * membership_type represents the requested user's membership type (explicit, inherited, or none) in the Access List.
      *
      * @generated from protobuf field: teleport.accesslist.v1.AccessListUserAssignmentType membership_type = 2;
      */
@@ -526,17 +561,31 @@ export interface AccessListStatus {
      */
     memberOf: string[];
     /**
-     * current_user_assignments describes the current user's ownership and membership status in the access list.
+     * current_user_assignments describes the current user's ownership and membership status in the Access List.
      *
      * @generated from protobuf field: teleport.accesslist.v1.CurrentUserAssignments current_user_assignments = 5;
      */
     currentUserAssignments?: CurrentUserAssignments;
     /**
-     * user_assignments describes the requested user's ownership and membership assignment types in the access list.
+     * user_assignments describes the requested user's ownership and membership assignment types in the Access List.
      *
      * @generated from protobuf field: teleport.accesslist.v1.UserAssignments user_assignments = 6;
      */
     userAssignments?: UserAssignments;
+    /**
+     * scoped_owner_of describes scoped Access Lists where this Access List is an explicit owner.
+     * Each item is the scope-qualified name of the owned scoped Access List.
+     *
+     * @generated from protobuf field: repeated string scoped_owner_of = 7;
+     */
+    scopedOwnerOf: string[];
+    /**
+     * scoped_member_of describes scoped Access Lists where this Access List is an explicit member.
+     * Each item is the scope-qualified name of the parent scoped Access List.
+     *
+     * @generated from protobuf field: repeated string scoped_member_of = 8;
+     */
+    scopedMemberOf: string[];
 }
 /**
  * ReviewFrequency is the frequency of reviews.
@@ -612,7 +661,13 @@ export enum MembershipKind {
      *
      * @generated from protobuf enum value: MEMBERSHIP_KIND_LIST = 2;
      */
-    LIST = 2
+    LIST = 2,
+    /**
+     * MEMBERSHIP_KIND_SCOPED_LIST represents list members that are nested scoped Access Lists
+     *
+     * @generated from protobuf enum value: MEMBERSHIP_KIND_SCOPED_LIST = 3;
+     */
+    SCOPED_LIST = 3
 }
 /**
  * IneligibleStatus describes how the user is ineligible.
@@ -656,8 +711,8 @@ export enum IneligibleStatus {
     EXPIRED = 4
 }
 /**
- * AccessListUserAssignmentType describes the type of membership anr/or ownership
- * a user has in an access list.
+ * AccessListUserAssignmentType describes the type of membership and/or ownership
+ * a user has in an Access List.
  *
  * @generated from protobuf enum teleport.accesslist.v1.AccessListUserAssignmentType
  */
@@ -687,11 +742,13 @@ class AccessList$Type extends MessageType<AccessList> {
         super("teleport.accesslist.v1.AccessList", [
             { no: 1, name: "header", kind: "message", T: () => ResourceHeader },
             { no: 2, name: "spec", kind: "message", T: () => AccessListSpec },
-            { no: 3, name: "status", kind: "message", T: () => AccessListStatus }
+            { no: 3, name: "status", kind: "message", T: () => AccessListStatus },
+            { no: 4, name: "scope", kind: "scalar", T: 9 /*ScalarType.STRING*/ }
         ]);
     }
     create(value?: PartialMessage<AccessList>): AccessList {
         const message = globalThis.Object.create((this.messagePrototype!));
+        message.scope = "";
         if (value !== undefined)
             reflectionMergePartial<AccessList>(this, message, value);
         return message;
@@ -709,6 +766,9 @@ class AccessList$Type extends MessageType<AccessList> {
                     break;
                 case /* teleport.accesslist.v1.AccessListStatus status */ 3:
                     message.status = AccessListStatus.internalBinaryRead(reader, reader.uint32(), options, message.status);
+                    break;
+                case /* string scope */ 4:
+                    message.scope = reader.string();
                     break;
                 default:
                     let u = options.readUnknownField;
@@ -731,6 +791,9 @@ class AccessList$Type extends MessageType<AccessList> {
         /* teleport.accesslist.v1.AccessListStatus status = 3; */
         if (message.status)
             AccessListStatus.internalBinaryWrite(message.status, writer.tag(3, WireType.LengthDelimited).fork(), options).join();
+        /* string scope = 4; */
+        if (message.scope !== "")
+            writer.tag(4, WireType.LengthDelimited).string(message.scope);
         let u = options.writeUnknownFields;
         if (u !== false)
             (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
@@ -1257,11 +1320,13 @@ class Member$Type extends MessageType<Member> {
     constructor() {
         super("teleport.accesslist.v1.Member", [
             { no: 1, name: "header", kind: "message", T: () => ResourceHeader },
-            { no: 2, name: "spec", kind: "message", T: () => MemberSpec }
+            { no: 2, name: "spec", kind: "message", T: () => MemberSpec },
+            { no: 3, name: "scope", kind: "scalar", T: 9 /*ScalarType.STRING*/ }
         ]);
     }
     create(value?: PartialMessage<Member>): Member {
         const message = globalThis.Object.create((this.messagePrototype!));
+        message.scope = "";
         if (value !== undefined)
             reflectionMergePartial<Member>(this, message, value);
         return message;
@@ -1276,6 +1341,9 @@ class Member$Type extends MessageType<Member> {
                     break;
                 case /* teleport.accesslist.v1.MemberSpec spec */ 2:
                     message.spec = MemberSpec.internalBinaryRead(reader, reader.uint32(), options, message.spec);
+                    break;
+                case /* string scope */ 3:
+                    message.scope = reader.string();
                     break;
                 default:
                     let u = options.readUnknownField;
@@ -1295,6 +1363,9 @@ class Member$Type extends MessageType<Member> {
         /* teleport.accesslist.v1.MemberSpec spec = 2; */
         if (message.spec)
             MemberSpec.internalBinaryWrite(message.spec, writer.tag(2, WireType.LengthDelimited).fork(), options).join();
+        /* string scope = 3; */
+        if (message.scope !== "")
+            writer.tag(3, WireType.LengthDelimited).string(message.scope);
         let u = options.writeUnknownFields;
         if (u !== false)
             (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
@@ -1411,11 +1482,13 @@ class Review$Type extends MessageType<Review> {
     constructor() {
         super("teleport.accesslist.v1.Review", [
             { no: 1, name: "header", kind: "message", T: () => ResourceHeader },
-            { no: 2, name: "spec", kind: "message", T: () => ReviewSpec }
+            { no: 2, name: "spec", kind: "message", T: () => ReviewSpec },
+            { no: 3, name: "scope", kind: "scalar", T: 9 /*ScalarType.STRING*/ }
         ]);
     }
     create(value?: PartialMessage<Review>): Review {
         const message = globalThis.Object.create((this.messagePrototype!));
+        message.scope = "";
         if (value !== undefined)
             reflectionMergePartial<Review>(this, message, value);
         return message;
@@ -1430,6 +1503,9 @@ class Review$Type extends MessageType<Review> {
                     break;
                 case /* teleport.accesslist.v1.ReviewSpec spec */ 2:
                     message.spec = ReviewSpec.internalBinaryRead(reader, reader.uint32(), options, message.spec);
+                    break;
+                case /* string scope */ 3:
+                    message.scope = reader.string();
                     break;
                 default:
                     let u = options.readUnknownField;
@@ -1449,6 +1525,9 @@ class Review$Type extends MessageType<Review> {
         /* teleport.accesslist.v1.ReviewSpec spec = 2; */
         if (message.spec)
             ReviewSpec.internalBinaryWrite(message.spec, writer.tag(2, WireType.LengthDelimited).fork(), options).join();
+        /* string scope = 3; */
+        if (message.scope !== "")
+            writer.tag(3, WireType.LengthDelimited).string(message.scope);
         let u = options.writeUnknownFields;
         if (u !== false)
             (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
@@ -1543,7 +1622,8 @@ class ReviewChanges$Type extends MessageType<ReviewChanges> {
             { no: 2, name: "membership_requirements_changed", kind: "message", T: () => AccessListRequires },
             { no: 3, name: "removed_members", kind: "scalar", repeat: 2 /*RepeatType.UNPACKED*/, T: 9 /*ScalarType.STRING*/ },
             { no: 4, name: "review_frequency_changed", kind: "enum", T: () => ["teleport.accesslist.v1.ReviewFrequency", ReviewFrequency, "REVIEW_FREQUENCY_"] },
-            { no: 5, name: "review_day_of_month_changed", kind: "enum", T: () => ["teleport.accesslist.v1.ReviewDayOfMonth", ReviewDayOfMonth, "REVIEW_DAY_OF_MONTH_"] }
+            { no: 5, name: "review_day_of_month_changed", kind: "enum", T: () => ["teleport.accesslist.v1.ReviewDayOfMonth", ReviewDayOfMonth, "REVIEW_DAY_OF_MONTH_"] },
+            { no: 6, name: "scoped_removed_members", kind: "scalar", repeat: 2 /*RepeatType.UNPACKED*/, T: 9 /*ScalarType.STRING*/ }
         ]);
     }
     create(value?: PartialMessage<ReviewChanges>): ReviewChanges {
@@ -1551,6 +1631,7 @@ class ReviewChanges$Type extends MessageType<ReviewChanges> {
         message.removedMembers = [];
         message.reviewFrequencyChanged = 0;
         message.reviewDayOfMonthChanged = 0;
+        message.scopedRemovedMembers = [];
         if (value !== undefined)
             reflectionMergePartial<ReviewChanges>(this, message, value);
         return message;
@@ -1571,6 +1652,9 @@ class ReviewChanges$Type extends MessageType<ReviewChanges> {
                     break;
                 case /* teleport.accesslist.v1.ReviewDayOfMonth review_day_of_month_changed */ 5:
                     message.reviewDayOfMonthChanged = reader.int32();
+                    break;
+                case /* repeated string scoped_removed_members */ 6:
+                    message.scopedRemovedMembers.push(reader.string());
                     break;
                 default:
                     let u = options.readUnknownField;
@@ -1596,6 +1680,9 @@ class ReviewChanges$Type extends MessageType<ReviewChanges> {
         /* teleport.accesslist.v1.ReviewDayOfMonth review_day_of_month_changed = 5; */
         if (message.reviewDayOfMonthChanged !== 0)
             writer.tag(5, WireType.Varint).int32(message.reviewDayOfMonthChanged);
+        /* repeated string scoped_removed_members = 6; */
+        for (let i = 0; i < message.scopedRemovedMembers.length; i++)
+            writer.tag(6, WireType.LengthDelimited).string(message.scopedRemovedMembers[i]);
         let u = options.writeUnknownFields;
         if (u !== false)
             (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
@@ -1725,13 +1812,17 @@ class AccessListStatus$Type extends MessageType<AccessListStatus> {
             { no: 3, name: "owner_of", kind: "scalar", repeat: 2 /*RepeatType.UNPACKED*/, T: 9 /*ScalarType.STRING*/ },
             { no: 4, name: "member_of", kind: "scalar", repeat: 2 /*RepeatType.UNPACKED*/, T: 9 /*ScalarType.STRING*/ },
             { no: 5, name: "current_user_assignments", kind: "message", T: () => CurrentUserAssignments },
-            { no: 6, name: "user_assignments", kind: "message", T: () => UserAssignments }
+            { no: 6, name: "user_assignments", kind: "message", T: () => UserAssignments },
+            { no: 7, name: "scoped_owner_of", kind: "scalar", repeat: 2 /*RepeatType.UNPACKED*/, T: 9 /*ScalarType.STRING*/ },
+            { no: 8, name: "scoped_member_of", kind: "scalar", repeat: 2 /*RepeatType.UNPACKED*/, T: 9 /*ScalarType.STRING*/ }
         ]);
     }
     create(value?: PartialMessage<AccessListStatus>): AccessListStatus {
         const message = globalThis.Object.create((this.messagePrototype!));
         message.ownerOf = [];
         message.memberOf = [];
+        message.scopedOwnerOf = [];
+        message.scopedMemberOf = [];
         if (value !== undefined)
             reflectionMergePartial<AccessListStatus>(this, message, value);
         return message;
@@ -1758,6 +1849,12 @@ class AccessListStatus$Type extends MessageType<AccessListStatus> {
                     break;
                 case /* teleport.accesslist.v1.UserAssignments user_assignments */ 6:
                     message.userAssignments = UserAssignments.internalBinaryRead(reader, reader.uint32(), options, message.userAssignments);
+                    break;
+                case /* repeated string scoped_owner_of */ 7:
+                    message.scopedOwnerOf.push(reader.string());
+                    break;
+                case /* repeated string scoped_member_of */ 8:
+                    message.scopedMemberOf.push(reader.string());
                     break;
                 default:
                     let u = options.readUnknownField;
@@ -1789,6 +1886,12 @@ class AccessListStatus$Type extends MessageType<AccessListStatus> {
         /* teleport.accesslist.v1.UserAssignments user_assignments = 6; */
         if (message.userAssignments)
             UserAssignments.internalBinaryWrite(message.userAssignments, writer.tag(6, WireType.LengthDelimited).fork(), options).join();
+        /* repeated string scoped_owner_of = 7; */
+        for (let i = 0; i < message.scopedOwnerOf.length; i++)
+            writer.tag(7, WireType.LengthDelimited).string(message.scopedOwnerOf[i]);
+        /* repeated string scoped_member_of = 8; */
+        for (let i = 0; i < message.scopedMemberOf.length; i++)
+            writer.tag(8, WireType.LengthDelimited).string(message.scopedMemberOf[i]);
         let u = options.writeUnknownFields;
         if (u !== false)
             (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);

--- a/integrations/operator/config/crd/bases/resources.teleport.dev_accesslists.yaml
+++ b/integrations/operator/config/crd/bases/resources.teleport.dev_accesslists.yaml
@@ -91,10 +91,11 @@ spec:
                     items:
                       properties:
                         role:
-                          description: role is the name of the scoped role to be granted.
+                          description: role is scope-qualified name of the scoped
+                            role to be granted.
                           type: string
                         scope:
-                          description: scope is the scope the role will be assigned
+                          description: scope is the scope the role will be granted
                             at. It must be an assignable scope of the role.
                           type: string
                       type: object
@@ -147,10 +148,11 @@ spec:
                     items:
                       properties:
                         role:
-                          description: role is the name of the scoped role to be granted.
+                          description: role is scope-qualified name of the scoped
+                            role to be granted.
                           type: string
                         scope:
-                          description: scope is the scope the role will be assigned
+                          description: scope is the scope the role will be granted
                             at. It must be an assignable scope of the role.
                           type: string
                       type: object
@@ -178,10 +180,14 @@ spec:
                       x-kubernetes-int-or-string: true
                     membership_kind:
                       description: membership_kind describes the type of membership,
-                        either `MEMBERSHIP_KIND_USER` or `MEMBERSHIP_KIND_LIST`.
+                        either `MEMBERSHIP_KIND_USER` or `MEMBERSHIP_KIND_LIST` or
+                        `MEMBERSHIP_KIND_SCOPED_LIST`.
                       x-kubernetes-int-or-string: true
                     name:
-                      description: name is the username of the owner.
+                      description: 'name is the name of the owner, depending on MembershipKind:
+                        MEMBERSHIP_KIND_USER: the username of the owner. MEMBERSHIP_KIND_LIST:
+                        the name of the owner Access List. MEMBERSHIP_KIND_SCOPED_LIST:
+                        the scope-qualified name of the owner Access List.'
                       type: string
                   type: object
                 nullable: true

--- a/integrations/terraform/tfschema/accesslist/v1/accesslist_terraform.go
+++ b/integrations/terraform/tfschema/accesslist/v1/accesslist_terraform.go
@@ -120,6 +120,11 @@ func GenSchemaAccessList(ctx context.Context) (github_com_hashicorp_terraform_pl
 			Required:      false,
 			Type:          github_com_hashicorp_terraform_plugin_framework_types.StringType,
 		},
+		"scope": {
+			Description: "scope is the scope of the Access List.",
+			Optional:    true,
+			Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
+		},
 		"spec": {
 			Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.SingleNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
 				"audit": {
@@ -173,12 +178,12 @@ func GenSchemaAccessList(ctx context.Context) (github_com_hashicorp_terraform_pl
 						"scoped_roles": {
 							Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.ListNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
 								"role": {
-									Description: "role is the name of the scoped role to be granted.",
+									Description: "role is scope-qualified name of the scoped role to be granted.",
 									Optional:    true,
 									Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
 								},
 								"scope": {
-									Description: "scope is the scope the role will be assigned at. It must be an assignable scope of the role.",
+									Description: "scope is the scope the role will be granted at. It must be an assignable scope of the role.",
 									Optional:    true,
 									Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
 								},
@@ -243,12 +248,12 @@ func GenSchemaAccessList(ctx context.Context) (github_com_hashicorp_terraform_pl
 						"scoped_roles": {
 							Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.ListNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
 								"role": {
-									Description: "role is the name of the scoped role to be granted.",
+									Description: "role is scope-qualified name of the scoped role to be granted.",
 									Optional:    true,
 									Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
 								},
 								"scope": {
-									Description: "scope is the scope the role will be assigned at. It must be an assignable scope of the role.",
+									Description: "scope is the scope the role will be granted at. It must be an assignable scope of the role.",
 									Optional:    true,
 									Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
 								},
@@ -284,12 +289,12 @@ func GenSchemaAccessList(ctx context.Context) (github_com_hashicorp_terraform_pl
 							Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
 						},
 						"membership_kind": {
-							Description: "membership_kind describes the type of membership, either `MEMBERSHIP_KIND_USER` or `MEMBERSHIP_KIND_LIST`.",
+							Description: "membership_kind describes the type of membership, either `MEMBERSHIP_KIND_USER` or `MEMBERSHIP_KIND_LIST` or `MEMBERSHIP_KIND_SCOPED_LIST`.",
 							Optional:    true,
 							Type:        github_com_hashicorp_terraform_plugin_framework_types.Int64Type,
 						},
 						"name": {
-							Description: "name is the username of the owner.",
+							Description: "name is the name of the owner, depending on MembershipKind: MEMBERSHIP_KIND_USER: the username of the owner. MEMBERSHIP_KIND_LIST: the name of the owner Access List. MEMBERSHIP_KIND_SCOPED_LIST: the scope-qualified name of the owner Access List.",
 							Optional:    true,
 							Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
 						},
@@ -417,6 +422,11 @@ func GenSchemaMember(ctx context.Context) (github_com_hashicorp_terraform_plugin
 			Required:      false,
 			Type:          github_com_hashicorp_terraform_plugin_framework_types.StringType,
 		},
+		"scope": {
+			Description: "scope is the scope of the Access List member, it must be equal to the scope of the parent Access List.",
+			Optional:    true,
+			Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
+		},
 		"spec": {
 			Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.SingleNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
 				"access_list": {
@@ -443,14 +453,14 @@ func GenSchemaMember(ctx context.Context) (github_com_hashicorp_terraform_plugin
 					PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributePlanModifier{github_com_hashicorp_terraform_plugin_framework_tfsdk.UseStateForUnknown()},
 				}),
 				"membership_kind": {
-					Description:   "membership_kind describes the type of membership, either `MEMBERSHIP_KIND_USER` or `MEMBERSHIP_KIND_LIST`.",
+					Description:   "membership_kind describes the type of membership, either `MEMBERSHIP_KIND_USER` or `MEMBERSHIP_KIND_LIST` or `MEMBERSHIP_KIND_SCOPED_LIST`.",
 					PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributePlanModifier{github_com_hashicorp_terraform_plugin_framework_tfsdk.RequiresReplace()},
 					Required:      true,
 					Type:          github_com_hashicorp_terraform_plugin_framework_types.Int64Type,
 				},
 				"name": {
 					Computed:      true,
-					Description:   "name is the name of the member of the Access List.",
+					Description:   "name is the name of the member of the Access List, depending on MembershipKind: MEMBERSHIP_KIND_USER: the username of the member. MEMBERSHIP_KIND_LIST: the name of the member Access List. MEMBERSHIP_KIND_SCOPED_LIST: the scope-qualified name of the member scope Access List.",
 					Optional:      true,
 					PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributePlanModifier{github_com_hashicorp_terraform_plugin_framework_tfsdk.UseStateForUnknown()},
 					Type:          github_com_hashicorp_terraform_plugin_framework_types.StringType,
@@ -1505,6 +1515,23 @@ func CopyAccessListFromTerraform(_ context.Context, tf github_com_hashicorp_terr
 						}
 					}
 				}
+			}
+		}
+	}
+	{
+		a, ok := tf.Attrs["scope"]
+		if !ok {
+			diags.Append(attrReadMissingDiag{"AccessList.scope"})
+		} else {
+			v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.String)
+			if !ok {
+				diags.Append(attrReadConversionFailureDiag{"AccessList.scope", "github.com/hashicorp/terraform-plugin-framework/types.String"})
+			} else {
+				var t string
+				if !v.Null && !v.Unknown {
+					t = string(v.Value)
+				}
+				obj.Scope = t
 			}
 		}
 	}
@@ -3252,6 +3279,28 @@ func CopyAccessListToTerraform(ctx context.Context, obj *github_com_gravitationa
 			}
 		}
 	}
+	{
+		t, ok := tf.AttrTypes["scope"]
+		if !ok {
+			diags.Append(attrWriteMissingDiag{"AccessList.scope"})
+		} else {
+			v, ok := tf.Attrs["scope"].(github_com_hashicorp_terraform_plugin_framework_types.String)
+			if !ok {
+				i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
+				if err != nil {
+					diags.Append(attrWriteGeneralError{"AccessList.scope", err})
+				}
+				v, ok = i.(github_com_hashicorp_terraform_plugin_framework_types.String)
+				if !ok {
+					diags.Append(attrWriteConversionFailureDiag{"AccessList.scope", "github.com/hashicorp/terraform-plugin-framework/types.String"})
+				}
+				v.Null = string(obj.Scope) == ""
+			}
+			v.Value = string(obj.Scope)
+			v.Unknown = false
+			tf.Attrs["scope"] = v
+		}
+	}
 	return diags
 }
 
@@ -3561,6 +3610,23 @@ func CopyMemberFromTerraform(_ context.Context, tf github_com_hashicorp_terrafor
 						}
 					}
 				}
+			}
+		}
+	}
+	{
+		a, ok := tf.Attrs["scope"]
+		if !ok {
+			diags.Append(attrReadMissingDiag{"Member.scope"})
+		} else {
+			v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.String)
+			if !ok {
+				diags.Append(attrReadConversionFailureDiag{"Member.scope", "github.com/hashicorp/terraform-plugin-framework/types.String"})
+			} else {
+				var t string
+				if !v.Null && !v.Unknown {
+					t = string(v.Value)
+				}
+				obj.Scope = t
 			}
 		}
 	}
@@ -4010,6 +4076,28 @@ func CopyMemberToTerraform(ctx context.Context, obj *github_com_gravitational_te
 				v.Unknown = false
 				tf.Attrs["spec"] = v
 			}
+		}
+	}
+	{
+		t, ok := tf.AttrTypes["scope"]
+		if !ok {
+			diags.Append(attrWriteMissingDiag{"Member.scope"})
+		} else {
+			v, ok := tf.Attrs["scope"].(github_com_hashicorp_terraform_plugin_framework_types.String)
+			if !ok {
+				i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
+				if err != nil {
+					diags.Append(attrWriteGeneralError{"Member.scope", err})
+				}
+				v, ok = i.(github_com_hashicorp_terraform_plugin_framework_types.String)
+				if !ok {
+					diags.Append(attrWriteConversionFailureDiag{"Member.scope", "github.com/hashicorp/terraform-plugin-framework/types.String"})
+				}
+				v.Null = string(obj.Scope) == ""
+			}
+			v.Value = string(obj.Scope)
+			v.Unknown = false
+			tf.Attrs["scope"] = v
 		}
 	}
 	return diags


### PR DESCRIPTION
Part of [RFD 308](https://github.com/gravitational/rfd/pull/22)

This PR adds scope fields to access list, member, and review fields as specified in the RFD. It does not include any actual support for persisting or handling these fields yet, that will be added in following PRs.

Child: https://github.com/gravitational/teleport/pull/67989