### PR TITLE
[scopes] add scope to access list api types

### DIFF
--- a/api/types/accesslist/accesslist.go
+++ b/api/types/accesslist/accesslist.go
@@ -87,6 +87,9 @@ var (
 
 	// MembershipKindList is the list membership kind.
 	MembershipKindList = accesslistv1.MembershipKind_MEMBERSHIP_KIND_LIST.String()
+
+	// MembershipKindScopedList is the scoped list membership kind.
+	MembershipKindScopedList = accesslistv1.MembershipKind_MEMBERSHIP_KIND_SCOPED_LIST.String()
 )
 
 // ReviewDayOfMonth is the day of month the review should be repeated on.
@@ -138,6 +141,9 @@ type AccessList struct {
 
 	// Status contains dynamically calculated fields.
 	Status Status `json:"status" yaml:"status"`
+
+	// Scope is the scope of the access list.
+	Scope string `json:"scope" yaml:"scope"`
 }
 
 // Spec is the specification for an access list.
@@ -214,7 +220,10 @@ func (t Type) Equals(other Type) bool {
 
 // Owner is an owner of an access list.
 type Owner struct {
-	// Name is the username of the owner.
+	// Name is the username of the owner, depending on MembershipKind:
+	// MEMBERSHIP_KIND_USER: the username of the owner.
+	// MEMBERSHIP_KIND_LIST: the name of the owner access list.
+	// MEMBERSHIP_KIND_SCOPED_LIST: the scope-qualified name of the owner access list.
 	Name string `json:"name" yaml:"name"`
 
 	// Title is the title of an owner if it is of type MEMBERSHIP_KIND_LIST.
@@ -228,7 +237,7 @@ type Owner struct {
 	IneligibleStatus string `json:"ineligible_status" yaml:"ineligible_status"`
 
 	// MembershipKind describes the kind of ownership,
-	// either "MEMBERSHIP_KIND_USER" or "MEMBERSHIP_KIND_LIST".
+	// either "MEMBERSHIP_KIND_USER" or "MEMBERSHIP_KIND_LIST" or "MEMBERSHIP_KIND_SCOPED_LIST".
 	MembershipKind string `json:"membership_kind" yaml:"membership_kind"`
 }
 
@@ -348,6 +357,13 @@ type Status struct {
 	// MemberOf is a list of Access List UUIDs where this access list is an explicit member.
 	MemberOf []string `json:"member_of" yaml:"member_of"`
 
+	// ScopedOwnerOf is a list of scope-qualified names of scoped access lists
+	// where this access list is an explicit owner.
+	ScopedOwnerOf []string `json:"scoped_owner_of" yaml:"scoped_owner_of"`
+	// ScopedMemberOf is a list of scope-qualified names of scoped access lists
+	// where this access list is an explicit member.
+	ScopedMemberOf []string `json:"scoped_member_of" yaml:"scoped_member_of"`
+
 	// CurrentUserAssignments describes the current user's ownership and membership in the access list.
 	CurrentUserAssignments *CurrentUserAssignments `json:"-" yaml:"-"`
 	// UserAssignments describes the requested user's ownership and membership assignment types in the access list.
@@ -392,9 +408,15 @@ func (u *UserAssignments) IsOwner() bool {
 
 // NewAccessList will create a new access list.
 func NewAccessList(metadata header.Metadata, spec Spec) (*AccessList, error) {
+	return NewAccessListWithScope(metadata, spec, "")
+}
+
+// NewAccessListWithScope will create a new access list with a scope.
+func NewAccessListWithScope(metadata header.Metadata, spec Spec, scope string) (*AccessList, error) {
 	accessList := &AccessList{
 		ResourceHeader: header.ResourceHeaderFromMetadata(metadata),
 		Spec:           spec,
+		Scope:          scope,
 	}
 
 	if err := accessList.CheckAndSetDefaults(); err != nil {
@@ -464,6 +486,11 @@ func (a *AccessList) CheckAndSetDefaults() error {
 	a.Spec.Owners = deduplicatedOwners
 
 	return nil
+}
+
+// GetScope returns the scope of the access list resource.
+func (a *AccessList) GetScope() string {
+	return a.Scope
 }
 
 // GetOwners returns the list of owners from the access list.

--- a/api/types/accesslist/convert/v1/accesslist.go
+++ b/api/types/accesslist/convert/v1/accesslist.go
@@ -52,7 +52,7 @@ func FromProto(msg *accesslistv1.AccessList, opts ...AccessListOption) (*accessl
 		OwnerGrants:        ConvertGrantsFromProto(spec.GetOwnerGrants()),
 	}
 
-	accessList, err := accesslist.NewAccessList(metadata, accessListSpec)
+	accessList, err := accesslist.NewAccessListWithScope(metadata, accessListSpec, msg.Scope)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -76,6 +76,7 @@ func ToProto(accessList *accesslist.AccessList) *accesslistv1.AccessList {
 
 	return &accesslistv1.AccessList{
 		Header: headerv1.ToResourceHeaderProto(accessList.ResourceHeader),
+		Scope:  accessList.Scope,
 		Spec: &accesslistv1.AccessListSpec{
 			Type:               string(accessList.Spec.Type),
 			Title:              accessList.Spec.Title,
@@ -239,6 +240,8 @@ func convertStatusToProto(status *accesslist.Status) *accesslistv1.AccessListSta
 		MemberOf:               status.MemberOf,
 		CurrentUserAssignments: toCurrentUserAssignmentsProto(status.CurrentUserAssignments),
 		UserAssignments:        toUserAssignmentsProto(status.UserAssignments),
+		ScopedOwnerOf:          status.ScopedOwnerOf,
+		ScopedMemberOf:         status.ScopedMemberOf,
 	}
 }
 
@@ -255,6 +258,8 @@ func fromStatusProto(msg *accesslistv1.AccessList) *accesslist.Status {
 		MemberOf:               protoStatus.GetMemberOf(),
 		CurrentUserAssignments: fromCurrentUserAssignmentsProto(protoStatus.GetCurrentUserAssignments()),
 		UserAssignments:        fromUserAssignmentsProto(protoStatus.GetUserAssignments()),
+		ScopedOwnerOf:          protoStatus.GetScopedOwnerOf(),
+		ScopedMemberOf:         protoStatus.GetScopedMemberOf(),
 	}
 }
 

--- a/api/types/accesslist/convert/v1/accesslist_test.go
+++ b/api/types/accesslist/convert/v1/accesslist_test.go
@@ -292,7 +292,11 @@ func newAccessList(t *testing.T, name string) *accesslist.AccessList {
 	require.NoError(t, err)
 
 	accessList.Status = accesslist.Status{
-		MemberCount: &memberCount,
+		MemberCount:    &memberCount,
+		OwnerOf:        []string{"ownerof"},
+		MemberOf:       []string{"memberof"},
+		ScopedOwnerOf:  []string{"scopedownerof"},
+		ScopedMemberOf: []string{"scopedmemberof"},
 	}
 
 	return accessList

--- a/api/types/accesslist/convert/v1/member.go
+++ b/api/types/accesslist/convert/v1/member.go
@@ -37,7 +37,7 @@ func FromMemberProto(msg *accesslistv1.Member, opts ...MemberOption) (*accesslis
 		return nil, trace.BadParameter("spec is missing")
 	}
 
-	member, err := accesslist.NewAccessListMember(headerv1.FromMetadataProto(msg.GetHeader().GetMetadata()), accesslist.AccessListMemberSpec{
+	member, err := accesslist.NewAccessListMemberWithScope(headerv1.FromMetadataProto(msg.GetHeader().GetMetadata()), accesslist.AccessListMemberSpec{
 		AccessList: msg.GetSpec().GetAccessList(),
 		Name:       msg.GetSpec().GetName(),
 		Joined:     utils.TimeFromProto(msg.GetSpec().GetJoined()),
@@ -48,7 +48,7 @@ func FromMemberProto(msg *accesslistv1.Member, opts ...MemberOption) (*accesslis
 		// Must provide as options to set it with the provided value.
 		IneligibleStatus: "",
 		MembershipKind:   msg.Spec.MembershipKind.String(),
-	})
+	}, msg.Scope)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -87,6 +87,7 @@ func ToMemberProto(member *accesslist.AccessListMember) *accesslistv1.Member {
 
 	return &accesslistv1.Member{
 		Header: headerv1.ToResourceHeaderProto(member.ResourceHeader),
+		Scope:  member.Scope,
 		Spec: &accesslistv1.MemberSpec{
 			AccessList:       member.Spec.AccessList,
 			Name:             member.Spec.Name,

--- a/api/types/accesslist/convert/v1/review.go
+++ b/api/types/accesslist/convert/v1/review.go
@@ -54,17 +54,18 @@ func FromReviewProto(msg *accesslistv1.Review) (*accesslist.Review, error) {
 			}
 		}
 		reviewChanges.RemovedMembers = msg.GetSpec().GetChanges().GetRemovedMembers()
+		reviewChanges.ScopedRemovedMembers = msg.GetSpec().GetChanges().GetScopedRemovedMembers()
 		reviewChanges.ReviewFrequencyChanged = accesslist.ReviewFrequency(msg.GetSpec().GetChanges().GetReviewFrequencyChanged())
 		reviewChanges.ReviewDayOfMonthChanged = accesslist.ReviewDayOfMonth(msg.GetSpec().GetChanges().GetReviewDayOfMonthChanged())
 	}
 
-	member, err := accesslist.NewReview(headerv1.FromMetadataProto(msg.GetHeader().GetMetadata()), accesslist.ReviewSpec{
+	member, err := accesslist.NewReviewWithScope(headerv1.FromMetadataProto(msg.GetHeader().GetMetadata()), accesslist.ReviewSpec{
 		AccessList: msg.GetSpec().GetAccessList(),
 		Reviewers:  msg.GetSpec().GetReviewers(),
 		ReviewDate: reviewDate,
 		Notes:      msg.GetSpec().GetNotes(),
 		Changes:    reviewChanges,
-	})
+	}, msg.Scope)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -90,6 +91,13 @@ func ToReviewProto(review *accesslist.Review) *accesslistv1.Review {
 
 		reviewChanges.RemovedMembers = review.Spec.Changes.RemovedMembers
 	}
+	if len(review.Spec.Changes.ScopedRemovedMembers) > 0 {
+		if reviewChanges == nil {
+			reviewChanges = &accesslistv1.ReviewChanges{}
+		}
+
+		reviewChanges.ScopedRemovedMembers = review.Spec.Changes.ScopedRemovedMembers
+	}
 	if review.Spec.Changes.ReviewFrequencyChanged > 0 {
 		if reviewChanges == nil {
 			reviewChanges = &accesslistv1.ReviewChanges{}
@@ -107,6 +115,7 @@ func ToReviewProto(review *accesslist.Review) *accesslistv1.Review {
 
 	return &accesslistv1.Review{
 		Header: headerv1.ToResourceHeaderProto(review.ResourceHeader),
+		Scope:  review.Scope,
 		Spec: &accesslistv1.ReviewSpec{
 			AccessList: review.Spec.AccessList,
 			Reviewers:  review.Spec.Reviewers,

--- a/api/types/accesslist/derived.gen.go
+++ b/api/types/accesslist/derived.gen.go
@@ -12,7 +12,8 @@ func deriveTeleportEqualAccessList(this, that *AccessList) bool {
 	return (this == nil && that == nil) ||
 		this != nil && that != nil &&
 			deriveTeleportEqual(&this.ResourceHeader, &that.ResourceHeader) &&
-			deriveTeleportEqual_(&this.Spec, &that.Spec)
+			deriveTeleportEqual_(&this.Spec, &that.Spec) &&
+			this.Scope == that.Scope
 }
 
 // deriveTeleportEqualAccessListMember returns whether this and that are equal.
@@ -20,7 +21,8 @@ func deriveTeleportEqualAccessListMember(this, that *AccessListMember) bool {
 	return (this == nil && that == nil) ||
 		this != nil && that != nil &&
 			deriveTeleportEqual(&this.ResourceHeader, &that.ResourceHeader) &&
-			deriveTeleportEqual_1(&this.Spec, &that.Spec)
+			deriveTeleportEqual_1(&this.Spec, &that.Spec) &&
+			this.Scope == that.Scope
 }
 
 // deriveDeepCopyAccessList recursively copies the contents of src into dst.
@@ -40,6 +42,7 @@ func deriveDeepCopyAccessList(dst, src *AccessList) {
 		deriveDeepCopy_1(field, &src.Status)
 		dst.Status = *field
 	}()
+	dst.Scope = src.Scope
 }
 
 // deriveDeepCopyAccessListMember recursively copies the contents of src into dst.
@@ -54,6 +57,7 @@ func deriveDeepCopyAccessListMember(dst, src *AccessListMember) {
 		deriveDeepCopy_2(field, &src.Spec)
 		dst.Spec = *field
 	}()
+	dst.Scope = src.Scope
 }
 
 // deriveDeepCopyReview recursively copies the contents of src into dst.
@@ -68,6 +72,7 @@ func deriveDeepCopyReview(dst, src *Review) {
 		deriveDeepCopy_3(field, &src.Spec)
 		dst.Spec = *field
 	}()
+	dst.Scope = src.Scope
 }
 
 // deriveTeleportEqual returns whether this and that are equal.
@@ -221,6 +226,42 @@ func deriveDeepCopy_1(dst, src *Status) {
 			dst.MemberOf = make([]string, len(src.MemberOf))
 		}
 		copy(dst.MemberOf, src.MemberOf)
+	}
+	if src.ScopedOwnerOf == nil {
+		dst.ScopedOwnerOf = nil
+	} else {
+		if dst.ScopedOwnerOf != nil {
+			if len(src.ScopedOwnerOf) > len(dst.ScopedOwnerOf) {
+				if cap(dst.ScopedOwnerOf) >= len(src.ScopedOwnerOf) {
+					dst.ScopedOwnerOf = (dst.ScopedOwnerOf)[:len(src.ScopedOwnerOf)]
+				} else {
+					dst.ScopedOwnerOf = make([]string, len(src.ScopedOwnerOf))
+				}
+			} else if len(src.ScopedOwnerOf) < len(dst.ScopedOwnerOf) {
+				dst.ScopedOwnerOf = (dst.ScopedOwnerOf)[:len(src.ScopedOwnerOf)]
+			}
+		} else {
+			dst.ScopedOwnerOf = make([]string, len(src.ScopedOwnerOf))
+		}
+		copy(dst.ScopedOwnerOf, src.ScopedOwnerOf)
+	}
+	if src.ScopedMemberOf == nil {
+		dst.ScopedMemberOf = nil
+	} else {
+		if dst.ScopedMemberOf != nil {
+			if len(src.ScopedMemberOf) > len(dst.ScopedMemberOf) {
+				if cap(dst.ScopedMemberOf) >= len(src.ScopedMemberOf) {
+					dst.ScopedMemberOf = (dst.ScopedMemberOf)[:len(src.ScopedMemberOf)]
+				} else {
+					dst.ScopedMemberOf = make([]string, len(src.ScopedMemberOf))
+				}
+			} else if len(src.ScopedMemberOf) < len(dst.ScopedMemberOf) {
+				dst.ScopedMemberOf = (dst.ScopedMemberOf)[:len(src.ScopedMemberOf)]
+			}
+		} else {
+			dst.ScopedMemberOf = make([]string, len(src.ScopedMemberOf))
+		}
+		copy(dst.ScopedMemberOf, src.ScopedMemberOf)
 	}
 	if src.CurrentUserAssignments == nil {
 		dst.CurrentUserAssignments = nil
@@ -479,6 +520,24 @@ func deriveDeepCopy_9(dst, src *ReviewChanges) {
 	}
 	dst.ReviewFrequencyChanged = src.ReviewFrequencyChanged
 	dst.ReviewDayOfMonthChanged = src.ReviewDayOfMonthChanged
+	if src.ScopedRemovedMembers == nil {
+		dst.ScopedRemovedMembers = nil
+	} else {
+		if dst.ScopedRemovedMembers != nil {
+			if len(src.ScopedRemovedMembers) > len(dst.ScopedRemovedMembers) {
+				if cap(dst.ScopedRemovedMembers) >= len(src.ScopedRemovedMembers) {
+					dst.ScopedRemovedMembers = (dst.ScopedRemovedMembers)[:len(src.ScopedRemovedMembers)]
+				} else {
+					dst.ScopedRemovedMembers = make([]string, len(src.ScopedRemovedMembers))
+				}
+			} else if len(src.ScopedRemovedMembers) < len(dst.ScopedRemovedMembers) {
+				dst.ScopedRemovedMembers = (dst.ScopedRemovedMembers)[:len(src.ScopedRemovedMembers)]
+			}
+		} else {
+			dst.ScopedRemovedMembers = make([]string, len(src.ScopedRemovedMembers))
+		}
+		copy(dst.ScopedRemovedMembers, src.ScopedRemovedMembers)
+	}
 }
 
 // deriveTeleportEqual_7 returns whether this and that are equal.

--- a/api/types/accesslist/member.go
+++ b/api/types/accesslist/member.go
@@ -34,14 +34,22 @@ type AccessListMember struct {
 
 	// Spec is the specification for the access list member.
 	Spec AccessListMemberSpec `json:"spec" yaml:"spec"`
+
+	// Scope is the scope of the access list member, it must be equal to the
+	// scope of the parent access list.
+	Scope string `json:"scope" yaml:"scope"`
 }
 
 // AccessListMemberSpec describes the specification of a member of an access list.
 type AccessListMemberSpec struct {
 	// AccessList is the name of the associated access list.
+	// If the member is scoped, this is a scope-qualified name.
 	AccessList string `json:"access_list" yaml:"access_list"`
 
-	// Name is the name of the member of the access list.
+	// Name is the name of the member of the access list, depending on MembershipKind:
+	// MEMBERSHIP_KIND_USER: the username of the member.
+	// MEMBERSHIP_KIND_LIST: the name of the member Access List.
+	// MEMBERSHIP_KIND_SCOPED_LIST: the scope-qualified name of the member scope Access List.
 	Name string `json:"name" yaml:"name"`
 
 	// TODO (avatus): eventually populate this in the backend/cache.
@@ -66,15 +74,21 @@ type AccessListMemberSpec struct {
 	IneligibleStatus string `json:"ineligible_status" yaml:"ineligible_status"`
 
 	// MembershipKind describes the kind of membership,
-	// either "MEMBERSHIP_KIND_USER" or "MEMBERSHIP_KIND_LIST".
+	// either "MEMBERSHIP_KIND_USER" or "MEMBERSHIP_KIND_LIST" or "MEMBERSHIP_KIND_SCOPED_LIST".
 	MembershipKind string `json:"membership_kind" yaml:"membership_kind"`
 }
 
 // NewAccessListMember will create a new AccessListMember.
 func NewAccessListMember(metadata header.Metadata, spec AccessListMemberSpec) (*AccessListMember, error) {
+	return NewAccessListMemberWithScope(metadata, spec, "")
+}
+
+// NewAccessListMemberWithScope will create a new AccessListMember.
+func NewAccessListMemberWithScope(metadata header.Metadata, spec AccessListMemberSpec, scope string) (*AccessListMember, error) {
 	member := &AccessListMember{
 		ResourceHeader: header.ResourceHeaderFromMetadata(metadata),
 		Spec:           spec,
+		Scope:          scope,
 	}
 
 	if err := member.CheckAndSetDefaults(); err != nil {
@@ -106,6 +120,10 @@ func (a *AccessListMember) CheckAndSetDefaults() error {
 // and should be removed when possible.
 func (a *AccessListMember) GetMetadata() types.Metadata {
 	return legacy.FromHeaderMetadata(a.Metadata)
+}
+
+func (a *AccessListMember) GetScope() string {
+	return a.Scope
 }
 
 // MatchSearch goes through select field values of a resource

--- a/api/types/accesslist/review.go
+++ b/api/types/accesslist/review.go
@@ -32,6 +32,10 @@ type Review struct {
 
 	// Spec is the specification for the access list review.
 	Spec ReviewSpec `json:"spec" yaml:"spec"`
+
+	// Scope is the scope of the access list review, must match the scope of
+	// the reviewed access list.
+	Scope string `json:"scope" yaml:"scope"`
 }
 
 const (
@@ -71,12 +75,31 @@ type ReviewChanges struct {
 
 	// ReviewDayOfMonthChanged is populated if the review day of month has changed.
 	ReviewDayOfMonthChanged ReviewDayOfMonth `json:"review_day_of_month_changed" yaml:"review_day_of_month_changed"`
+
+	// ScopedRemovedMembers contains the scope-qualified names of scoped
+	// members that were removed as part of this review.
+	ScopedRemovedMembers []string `json:"scoped_removed_members" yaml:"scoped_removed_members"`
 }
 
 // NewReview will create a new access list review.
 func NewReview(metadata header.Metadata, spec ReviewSpec) (*Review, error) {
 	review := &Review{
 		ResourceHeader: header.ResourceHeaderFromMetadata(metadata),
+		Spec:           spec,
+	}
+
+	if err := review.CheckAndSetDefaults(); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return review, nil
+}
+
+// NewReviewWithScope will create a new access list review.
+func NewReviewWithScope(metadata header.Metadata, spec ReviewSpec, scope string) (*Review, error) {
+	review := &Review{
+		ResourceHeader: header.ResourceHeaderFromMetadata(metadata),
+		Scope:          scope,
 		Spec:           spec,
 	}
 
@@ -119,6 +142,10 @@ func (r *Review) CheckAndSetDefaults() error {
 // and should be removed when possible.
 func (r *Review) GetMetadata() types.Metadata {
 	return legacy.FromHeaderMetadata(r.Metadata)
+}
+
+func (r *Review) GetScope() string {
+	return r.Scope
 }
 
 // Clone returns a copy of the review.

--- a/api/types/accesslist/review_test.go
+++ b/api/types/accesslist/review_test.go
@@ -69,7 +69,7 @@ func TestReviewSpecMarshaling(t *testing.T) {
 	require.Equal(t, `{"review_date":"2023-01-01T00:00:00Z","access_list":"access-list","reviewers":["user1","user2"],`+
 		`"notes":"Some notes","changes":{"review_frequency_changed":"6 months","review_day_of_month_changed":"1",`+
 		`"membership_requirements_changed":{"roles":["member1","member2"],"traits":{"trait1":["value1","value2"],"trait2":["value1","value2"]}},`+
-		`"removed_members":["member1","member2"]}}`, string(data))
+		`"removed_members":["member1","member2"],"scoped_removed_members":null}}`, string(data))
 
 	raw := map[string]interface{}{}
 	require.NoError(t, json.Unmarshal(data, &raw))


### PR DESCRIPTION
Part of [RFD 308](https://github.com/gravitational/rfd/pull/22)

This PR adds scope fields to the access list types in `api/types/accesslist`. It does not include any support for actually handling these fields, that will be added in following PRs.

Parent: https://github.com/gravitational/teleport/pull/67988
Child: https://github.com/gravitational/teleport/pull/67990