### PR TITLE
docs: fix client request k8s example

### DIFF
--- a/docs/pages/connect-your-client/teleport-clients/request-access.mdx
+++ b/docs/pages/connect-your-client/teleport-clients/request-access.mdx
@@ -111,7 +111,7 @@ resource by running the following command, where <Var name="resource-id" /> is
 the ID of the resource:
 
 ```code
-$ tsh request create <Var name="resource-id" />
+$ tsh request create --resource <Var name="resource-id" />
 ```
 
 ### Namespace-scoped resources


### PR DESCRIPTION
Fixes `tsh request create` k8s example. You have to use `--resource` parameter
