### PR TITLE
Add configurable backoff values to Okta sync settings

### DIFF
--- a/api/proto/teleport/legacy/types/types.proto
+++ b/api/proto/teleport/legacy/types/types.proto
@@ -7711,6 +7711,16 @@ message PluginOktaSyncSettings {
   // For most use cases the default value should NOT be changed.
   // A blank string results in the default value of 5min.
   string time_between_assignment_process_loops = 15;
+
+  // TargetProcessingBackoffStep controls the step value for linear backoff when reprocessing Okta assignment targets.
+  // For most use cases the default value should NOT be changed.
+  // A blank string results in the default value of 15m.
+  string target_processing_backoff_step = 16;
+
+  // TargetProcessingBackoffMax controls the max duration for linear backoff when reprocessing Okta assignment targets.
+  // For most use cases the default value should NOT be changed.
+  // A blank string results in the default value of 24h.
+  string target_processing_backoff_max = 17;
 }
 
 // Defines a set of discord channel IDs

--- a/api/proto/teleport/legacy/types/types.proto
+++ b/api/proto/teleport/legacy/types/types.proto
@@ -7713,12 +7713,12 @@ message PluginOktaSyncSettings {
   string time_between_assignment_process_loops = 15;
 
   // TargetProcessingBackoffStep controls the step value for linear backoff when reprocessing Okta assignment targets.
-  // A blank string results in the default value being used.
+  // Value is parsed as Go duration string, e.g. 1h15m. A blank string results in the default value being used.
   // For most use cases the default value should NOT be changed.
   string target_processing_backoff_step = 16;
 
   // TargetProcessingBackoffMax controls the max duration for linear backoff when reprocessing Okta assignment targets.
-  // A blank string results in the default value being used.
+  // Value is parsed as Go duration string, e.g. 1h15m. A blank string results in the default value being used.
   // For most use cases the default value should NOT be changed.
   string target_processing_backoff_max = 17;
 }

--- a/api/proto/teleport/legacy/types/types.proto
+++ b/api/proto/teleport/legacy/types/types.proto
@@ -7713,13 +7713,13 @@ message PluginOktaSyncSettings {
   string time_between_assignment_process_loops = 15;
 
   // TargetProcessingBackoffStep controls the step value for linear backoff when reprocessing Okta assignment targets.
+  // A blank string results in the default value being used.
   // For most use cases the default value should NOT be changed.
-  // A blank string results in the default value of 15m.
   string target_processing_backoff_step = 16;
 
   // TargetProcessingBackoffMax controls the max duration for linear backoff when reprocessing Okta assignment targets.
+  // A blank string results in the default value being used.
   // For most use cases the default value should NOT be changed.
-  // A blank string results in the default value of 24h.
   string target_processing_backoff_max = 17;
 }
 


### PR DESCRIPTION
This PR introduces fields to `PluginOktaSyncSettings` to configure values used for linear backoff when reprocessing Okta assignments so that they can be configured relative to `time_between_assignment_process_loops`. 

Corresponding `e` changes to follow. 

No manual test plan or changelog, since no changes to functionality introduced. 