### PR TITLE
discovery: add tctl discovery status command

### DIFF
--- a/docs/pages/reference/cli/tbot.mdx
+++ b/docs/pages/reference/cli/tbot.mdx
@@ -66,7 +66,7 @@ Flags:
 |`--certificate-ttl`|*no default*|TTL of short-lived machine certificates.|
 |`--destination`|*no default*|A destination URI, such as file:///foo/bar|
 |`--diag-addr`|*no default*|If set and the bot is in debug mode, a diagnostics service will listen on specified address.|
-|`--join-method`|*no default* (one of: `azure`, `azure_devops`, `bitbucket`, `circleci`, `gcp`, `github`, `gitlab`, `iam`, `kubernetes`, `spacelift`, `token`, `tpm`, `terraform_cloud`, `oracle`, `bound_keypair`, `env0`)|Method to use to join the cluster.|
+|`--join-method`|*no default* (one of: `azure`, `azure_devops`, `bitbucket`, `circleci`, `gcp`, `github`, `gitlab`, `iam`, `kubernetes`, `spacelift`, `token`, `tpm`, `terraform_cloud`, `oracle`, `bound_keypair`, `env0`, `generic_oidc`)|Method to use to join the cluster.|
 |`--join-uri`|*no default*|An optional URI with joining and authentication parameters. Individual flags for proxy, join method, token, etc may be used instead.|
 |`--[no-]oneshot`|`false`|If set, quit after the first renewal.|
 |`--[no-]scoped`|`false`|Indicates whether tbot should run in scoped mode. This is required when authenticating as a scoped Bot.|
@@ -108,7 +108,7 @@ Flags:
 |`--ca-pin`|*no default*|CA pin to validate the Teleport Auth Server; used on first connect.|
 |`--certificate-ttl`|*no default*|TTL of short-lived machine certificates.|
 |`--diag-addr`|*no default*|If set and the bot is in debug mode, a diagnostics service will listen on specified address.|
-|`--join-method`|*no default* (one of: `azure`, `azure_devops`, `bitbucket`, `circleci`, `gcp`, `github`, `gitlab`, `iam`, `kubernetes`, `spacelift`, `token`, `tpm`, `terraform_cloud`, `oracle`, `bound_keypair`, `env0`)|Method to use to join the cluster.|
+|`--join-method`|*no default* (one of: `azure`, `azure_devops`, `bitbucket`, `circleci`, `gcp`, `github`, `gitlab`, `iam`, `kubernetes`, `spacelift`, `token`, `tpm`, `terraform_cloud`, `oracle`, `bound_keypair`, `env0`, `generic_oidc`)|Method to use to join the cluster.|
 |`--join-uri`|*no default*|An optional URI with joining and authentication parameters. Individual flags for proxy, join method, token, etc may be used instead.|
 |`--listen`|*no default*|The socket URI on which the local proxy should listen, such as `tcp://0.0.0.0:8080`.|
 |`--[no-]oneshot`|`false`|If set, quit after the first renewal.|
@@ -149,7 +149,7 @@ Flags:
 |`--ca-pin`|*no default*|CA pin to validate the Teleport Auth Server; used on first connect.|
 |`--certificate-ttl`|*no default*|TTL of short-lived machine certificates.|
 |`--diag-addr`|*no default*|If set and the bot is in debug mode, a diagnostics service will listen on specified address.|
-|`--join-method`|*no default* (one of: `azure`, `azure_devops`, `bitbucket`, `circleci`, `gcp`, `github`, `gitlab`, `iam`, `kubernetes`, `spacelift`, `token`, `tpm`, `terraform_cloud`, `oracle`, `bound_keypair`, `env0`)|Method to use to join the cluster.|
+|`--join-method`|*no default* (one of: `azure`, `azure_devops`, `bitbucket`, `circleci`, `gcp`, `github`, `gitlab`, `iam`, `kubernetes`, `spacelift`, `token`, `tpm`, `terraform_cloud`, `oracle`, `bound_keypair`, `env0`, `generic_oidc`)|Method to use to join the cluster.|
 |`--join-uri`|*no default*|An optional URI with joining and authentication parameters. Individual flags for proxy, join method, token, etc may be used instead.|
 |`--listen`|*no default*|The socket URI on which the tunnel should listen, such as `tcp://0.0.0.0:8080`.|
 |`--[no-]oneshot`|`false`|If set, quit after the first renewal.|
@@ -192,7 +192,7 @@ Flags:
 |`--destination`|*no default*|A destination URI, such as file:///foo/bar|
 |`--diag-addr`|*no default*|If set and the bot is in debug mode, a diagnostics service will listen on specified address.|
 |`--format`|`` (one of: ``, `tls`, `mongo`, `cockroach`)|The format of the credentials to generate.|
-|`--join-method`|*no default* (one of: `azure`, `azure_devops`, `bitbucket`, `circleci`, `gcp`, `github`, `gitlab`, `iam`, `kubernetes`, `spacelift`, `token`, `tpm`, `terraform_cloud`, `oracle`, `bound_keypair`, `env0`)|Method to use to join the cluster.|
+|`--join-method`|*no default* (one of: `azure`, `azure_devops`, `bitbucket`, `circleci`, `gcp`, `github`, `gitlab`, `iam`, `kubernetes`, `spacelift`, `token`, `tpm`, `terraform_cloud`, `oracle`, `bound_keypair`, `env0`, `generic_oidc`)|Method to use to join the cluster.|
 |`--join-uri`|*no default*|An optional URI with joining and authentication parameters. Individual flags for proxy, join method, token, etc may be used instead.|
 |`--[no-]oneshot`|`false`|If set, quit after the first renewal.|
 |`--[no-]scoped`|`false`|Indicates whether tbot should run in scoped mode. This is required when authenticating as a scoped Bot.|
@@ -236,7 +236,7 @@ Flags:
 |`--certificate-ttl`|*no default*|TTL of short-lived machine certificates.|
 |`--database`|*no default*|The name of the database available in the requested database service.|
 |`--diag-addr`|*no default*|If set and the bot is in debug mode, a diagnostics service will listen on specified address.|
-|`--join-method`|*no default* (one of: `azure`, `azure_devops`, `bitbucket`, `circleci`, `gcp`, `github`, `gitlab`, `iam`, `kubernetes`, `spacelift`, `token`, `tpm`, `terraform_cloud`, `oracle`, `bound_keypair`, `env0`)|Method to use to join the cluster.|
+|`--join-method`|*no default* (one of: `azure`, `azure_devops`, `bitbucket`, `circleci`, `gcp`, `github`, `gitlab`, `iam`, `kubernetes`, `spacelift`, `token`, `tpm`, `terraform_cloud`, `oracle`, `bound_keypair`, `env0`, `generic_oidc`)|Method to use to join the cluster.|
 |`--join-uri`|*no default*|An optional URI with joining and authentication parameters. Individual flags for proxy, join method, token, etc may be used instead.|
 |`--listen`|*no default*|A socket URI to listen on, such as `tcp://0.0.0.0:3306`.|
 |`--[no-]oneshot`|`false`|If set, quit after the first renewal.|
@@ -280,7 +280,7 @@ Flags:
 |`--cluster`|*no default*|The name of a specific cluster for which to issue an identity if using a leaf cluster.|
 |`--destination`|*no default*|A destination URI, such as file:///foo/bar|
 |`--diag-addr`|*no default*|If set and the bot is in debug mode, a diagnostics service will listen on specified address.|
-|`--join-method`|*no default* (one of: `azure`, `azure_devops`, `bitbucket`, `circleci`, `gcp`, `github`, `gitlab`, `iam`, `kubernetes`, `spacelift`, `token`, `tpm`, `terraform_cloud`, `oracle`, `bound_keypair`, `env0`)|Method to use to join the cluster.|
+|`--join-method`|*no default* (one of: `azure`, `azure_devops`, `bitbucket`, `circleci`, `gcp`, `github`, `gitlab`, `iam`, `kubernetes`, `spacelift`, `token`, `tpm`, `terraform_cloud`, `oracle`, `bound_keypair`, `env0`, `generic_oidc`)|Method to use to join the cluster.|
 |`--join-uri`|*no default*|An optional URI with joining and authentication parameters. Individual flags for proxy, join method, token, etc may be used instead.|
 |`--[no-]allow-reissue`|`false`|Allow the credentials output by this command to be reissued.|
 |`--[no-]oneshot`|`false`|If set, quit after the first renewal.|
@@ -323,7 +323,7 @@ Flags:
 |`--certificate-ttl`|*no default*|TTL of short-lived machine certificates.|
 |`--destination`|*no default*|A destination URI, such as file:///foo/bar|
 |`--diag-addr`|*no default*|If set and the bot is in debug mode, a diagnostics service will listen on specified address.|
-|`--join-method`|*no default* (one of: `azure`, `azure_devops`, `bitbucket`, `circleci`, `gcp`, `github`, `gitlab`, `iam`, `kubernetes`, `spacelift`, `token`, `tpm`, `terraform_cloud`, `oracle`, `bound_keypair`, `env0`)|Method to use to join the cluster.|
+|`--join-method`|*no default* (one of: `azure`, `azure_devops`, `bitbucket`, `circleci`, `gcp`, `github`, `gitlab`, `iam`, `kubernetes`, `spacelift`, `token`, `tpm`, `terraform_cloud`, `oracle`, `bound_keypair`, `env0`, `generic_oidc`)|Method to use to join the cluster.|
 |`--join-uri`|*no default*|An optional URI with joining and authentication parameters. Individual flags for proxy, join method, token, etc may be used instead.|
 |`--kubernetes-cluster`|*no default*|The name of the Kubernetes cluster in Teleport for which to fetch credentials.|
 |`--[no-]disable-exec-plugin`|`false`|If set, disables the exec plugin. This allows credentials to be used without the `tbot` binary.|
@@ -367,7 +367,7 @@ Flags:
 |`--certificate-ttl`|*no default*|TTL of short-lived machine certificates.|
 |`--destination`|*no default*|A destination URI, such as file:///foo/bar|
 |`--diag-addr`|*no default*|If set and the bot is in debug mode, a diagnostics service will listen on specified address.|
-|`--join-method`|*no default* (one of: `azure`, `azure_devops`, `bitbucket`, `circleci`, `gcp`, `github`, `gitlab`, `iam`, `kubernetes`, `spacelift`, `token`, `tpm`, `terraform_cloud`, `oracle`, `bound_keypair`, `env0`)|Method to use to join the cluster.|
+|`--join-method`|*no default* (one of: `azure`, `azure_devops`, `bitbucket`, `circleci`, `gcp`, `github`, `gitlab`, `iam`, `kubernetes`, `spacelift`, `token`, `tpm`, `terraform_cloud`, `oracle`, `bound_keypair`, `env0`, `generic_oidc`)|Method to use to join the cluster.|
 |`--join-uri`|*no default*|An optional URI with joining and authentication parameters. Individual flags for proxy, join method, token, etc may be used instead.|
 |`--label-selector`|*no default*|A set of Kubernetes labels to match in k1=v1,k2=v2 form. Repeatable.|
 |`--name-selector`|*no default*|An explicit Kubernetes cluster name to include. Repeatable.|
@@ -413,7 +413,7 @@ Flags:
 |`--data-dir`|*no default*|Directory to store internal bot data. Access to this directory should be limited.|
 |`--destination-dir`|*no default*|Directory to write short-lived machine certificates.|
 |`--diag-addr`|*no default*|If set and the bot is in debug mode, a diagnostics service will listen on specified address.|
-|`--join-method`|*no default* (one of: `azure`, `azure_devops`, `bitbucket`, `circleci`, `gcp`, `github`, `gitlab`, `iam`, `kubernetes`, `spacelift`, `token`, `tpm`, `terraform_cloud`, `oracle`, `bound_keypair`, `env0`)|Method to use to join the cluster.|
+|`--join-method`|*no default* (one of: `azure`, `azure_devops`, `bitbucket`, `circleci`, `gcp`, `github`, `gitlab`, `iam`, `kubernetes`, `spacelift`, `token`, `tpm`, `terraform_cloud`, `oracle`, `bound_keypair`, `env0`, `generic_oidc`)|Method to use to join the cluster.|
 |`--[no-]oneshot`|`false`|If set, quit after the first renewal.|
 |`--[no-]scoped`|`false`|Indicates whether tbot should run in scoped mode. This is required when authenticating as a scoped Bot.|
 |`--pid-file`|*no default*|Full path to the PID file. By default no PID file will be created.|
@@ -447,7 +447,7 @@ Flags:
 |`--ca-pin`|*no default*|CA pin to validate the Teleport Auth Server; used on first connect.|
 |`--certificate-ttl`|*no default*|TTL of short-lived machine certificates.|
 |`--diag-addr`|*no default*|If set and the bot is in debug mode, a diagnostics service will listen on specified address.|
-|`--join-method`|*no default* (one of: `azure`, `azure_devops`, `bitbucket`, `circleci`, `gcp`, `github`, `gitlab`, `iam`, `kubernetes`, `spacelift`, `token`, `tpm`, `terraform_cloud`, `oracle`, `bound_keypair`, `env0`)|Method to use to join the cluster.|
+|`--join-method`|*no default* (one of: `azure`, `azure_devops`, `bitbucket`, `circleci`, `gcp`, `github`, `gitlab`, `iam`, `kubernetes`, `spacelift`, `token`, `tpm`, `terraform_cloud`, `oracle`, `bound_keypair`, `env0`, `generic_oidc`)|Method to use to join the cluster.|
 |`--join-uri`|*no default*|An optional URI with joining and authentication parameters. Individual flags for proxy, join method, token, etc may be used instead.|
 |`--[no-]oneshot`|`false`|If set, quit after the first renewal.|
 |`--[no-]scoped`|`false`|Indicates whether tbot should run in scoped mode. This is required when authenticating as a scoped Bot.|
@@ -487,7 +487,7 @@ Flags:
 |`--certificate-ttl`|*no default*|TTL of short-lived machine certificates.|
 |`--destination`|*no default*|A destination URI, such as file:///foo/bar|
 |`--diag-addr`|*no default*|If set and the bot is in debug mode, a diagnostics service will listen on specified address.|
-|`--join-method`|*no default* (one of: `azure`, `azure_devops`, `bitbucket`, `circleci`, `gcp`, `github`, `gitlab`, `iam`, `kubernetes`, `spacelift`, `token`, `tpm`, `terraform_cloud`, `oracle`, `bound_keypair`, `env0`)|Method to use to join the cluster.|
+|`--join-method`|*no default* (one of: `azure`, `azure_devops`, `bitbucket`, `circleci`, `gcp`, `github`, `gitlab`, `iam`, `kubernetes`, `spacelift`, `token`, `tpm`, `terraform_cloud`, `oracle`, `bound_keypair`, `env0`, `generic_oidc`)|Method to use to join the cluster.|
 |`--join-uri`|*no default*|An optional URI with joining and authentication parameters. Individual flags for proxy, join method, token, etc may be used instead.|
 |`--[no-]enable-resumption`|`false`|If set, disables SSH session resumption.|
 |`--[no-]oneshot`|`false`|If set, quit after the first renewal.|
@@ -532,7 +532,7 @@ Flags:
 |`--ca-pin`|*no default*|CA pin to validate the Teleport Auth Server; used on first connect.|
 |`--certificate-ttl`|*no default*|TTL of short-lived machine certificates.|
 |`--diag-addr`|*no default*|If set and the bot is in debug mode, a diagnostics service will listen on specified address.|
-|`--join-method`|*no default* (one of: `azure`, `azure_devops`, `bitbucket`, `circleci`, `gcp`, `github`, `gitlab`, `iam`, `kubernetes`, `spacelift`, `token`, `tpm`, `terraform_cloud`, `oracle`, `bound_keypair`, `env0`)|Method to use to join the cluster.|
+|`--join-method`|*no default* (one of: `azure`, `azure_devops`, `bitbucket`, `circleci`, `gcp`, `github`, `gitlab`, `iam`, `kubernetes`, `spacelift`, `token`, `tpm`, `terraform_cloud`, `oracle`, `bound_keypair`, `env0`, `generic_oidc`)|Method to use to join the cluster.|
 |`--join-uri`|*no default*|An optional URI with joining and authentication parameters. Individual flags for proxy, join method, token, etc may be used instead.|
 |`--label-selector`|*no default*|A label-based selector for which workload identities to issue. Multiple labels can be provided using ','. Mutually exclusive with --name-selector.|
 |`--listen`|*no default*|The address on which the workload identity API should listen. This should either be prefixed with 'unix://' or 'tcp://'.|
@@ -576,7 +576,7 @@ Flags:
 |`--certificate-ttl`|*no default*|TTL of short-lived machine certificates.|
 |`--destination`|*no default*|A destination URI, such as file:///foo/bar|
 |`--diag-addr`|*no default*|If set and the bot is in debug mode, a diagnostics service will listen on specified address.|
-|`--join-method`|*no default* (one of: `azure`, `azure_devops`, `bitbucket`, `circleci`, `gcp`, `github`, `gitlab`, `iam`, `kubernetes`, `spacelift`, `token`, `tpm`, `terraform_cloud`, `oracle`, `bound_keypair`, `env0`)|Method to use to join the cluster.|
+|`--join-method`|*no default* (one of: `azure`, `azure_devops`, `bitbucket`, `circleci`, `gcp`, `github`, `gitlab`, `iam`, `kubernetes`, `spacelift`, `token`, `tpm`, `terraform_cloud`, `oracle`, `bound_keypair`, `env0`, `generic_oidc`)|Method to use to join the cluster.|
 |`--join-uri`|*no default*|An optional URI with joining and authentication parameters. Individual flags for proxy, join method, token, etc may be used instead.|
 |`--label-selector`|*no default*|A label-based selector for which workload identities to issue. Multiple labels can be provided using ','. Mutually exclusive with --name-selector.|
 |`--name-selector`|*no default*|The name of the workload identity to issue. Mutually exclusive with --label-selector.|
@@ -627,7 +627,7 @@ Flags:
 |`--certificate-ttl`|*no default*|TTL of short-lived machine certificates.|
 |`--destination`|*no default*|A destination URI, such as file:///foo/bar|
 |`--diag-addr`|*no default*|If set and the bot is in debug mode, a diagnostics service will listen on specified address.|
-|`--join-method`|*no default* (one of: `azure`, `azure_devops`, `bitbucket`, `circleci`, `gcp`, `github`, `gitlab`, `iam`, `kubernetes`, `spacelift`, `token`, `tpm`, `terraform_cloud`, `oracle`, `bound_keypair`, `env0`)|Method to use to join the cluster.|
+|`--join-method`|*no default* (one of: `azure`, `azure_devops`, `bitbucket`, `circleci`, `gcp`, `github`, `gitlab`, `iam`, `kubernetes`, `spacelift`, `token`, `tpm`, `terraform_cloud`, `oracle`, `bound_keypair`, `env0`, `generic_oidc`)|Method to use to join the cluster.|
 |`--join-uri`|*no default*|An optional URI with joining and authentication parameters. Individual flags for proxy, join method, token, etc may be used instead.|
 |`--label-selector`|*no default*|A label-based selector for which workload identities to issue. Multiple labels can be provided using ','. Mutually exclusive with --name-selector.|
 |`--name-selector`|*no default*|The name of the workload identity to issue. Mutually exclusive with --label-selector.|
@@ -671,7 +671,7 @@ Flags:
 |`--certificate-ttl`|*no default*|TTL of short-lived machine certificates.|
 |`--destination`|*no default*|A destination URI, such as file:///foo/bar|
 |`--diag-addr`|*no default*|If set and the bot is in debug mode, a diagnostics service will listen on specified address.|
-|`--join-method`|*no default* (one of: `azure`, `azure_devops`, `bitbucket`, `circleci`, `gcp`, `github`, `gitlab`, `iam`, `kubernetes`, `spacelift`, `token`, `tpm`, `terraform_cloud`, `oracle`, `bound_keypair`, `env0`)|Method to use to join the cluster.|
+|`--join-method`|*no default* (one of: `azure`, `azure_devops`, `bitbucket`, `circleci`, `gcp`, `github`, `gitlab`, `iam`, `kubernetes`, `spacelift`, `token`, `tpm`, `terraform_cloud`, `oracle`, `bound_keypair`, `env0`, `generic_oidc`)|Method to use to join the cluster.|
 |`--join-uri`|*no default*|An optional URI with joining and authentication parameters. Individual flags for proxy, join method, token, etc may be used instead.|
 |`--label-selector`|*no default*|A label-based selector for which workload identities to issue. Multiple labels can be provided using ','. Mutually exclusive with --name-selector.|
 |`--name-selector`|*no default*|The name of the workload identity to issue. Mutually exclusive with --label-selector.|
@@ -911,7 +911,7 @@ Flags:
 |`--certificate-ttl`|*no default*|TTL of short-lived machine certificates.|
 |`--destination`|*no default*|A destination URI, such as file:///foo/bar|
 |`--diag-addr`|*no default*|If set and the bot is in debug mode, a diagnostics service will listen on specified address.|
-|`--join-method`|*no default* (one of: `azure`, `azure_devops`, `bitbucket`, `circleci`, `gcp`, `github`, `gitlab`, `iam`, `kubernetes`, `spacelift`, `token`, `tpm`, `terraform_cloud`, `oracle`, `bound_keypair`, `env0`)|Method to use to join the cluster.|
+|`--join-method`|*no default* (one of: `azure`, `azure_devops`, `bitbucket`, `circleci`, `gcp`, `github`, `gitlab`, `iam`, `kubernetes`, `spacelift`, `token`, `tpm`, `terraform_cloud`, `oracle`, `bound_keypair`, `env0`, `generic_oidc`)|Method to use to join the cluster.|
 |`--join-uri`|*no default*|An optional URI with joining and authentication parameters. Individual flags for proxy, join method, token, etc may be used instead.|
 |`--[no-]oneshot`|`false`|If set, quit after the first renewal.|
 |`--[no-]scoped`|`false`|Indicates whether tbot should run in scoped mode. This is required when authenticating as a scoped Bot.|
@@ -953,7 +953,7 @@ Flags:
 |`--ca-pin`|*no default*|CA pin to validate the Teleport Auth Server; used on first connect.|
 |`--certificate-ttl`|*no default*|TTL of short-lived machine certificates.|
 |`--diag-addr`|*no default*|If set and the bot is in debug mode, a diagnostics service will listen on specified address.|
-|`--join-method`|*no default* (one of: `azure`, `azure_devops`, `bitbucket`, `circleci`, `gcp`, `github`, `gitlab`, `iam`, `kubernetes`, `spacelift`, `token`, `tpm`, `terraform_cloud`, `oracle`, `bound_keypair`, `env0`)|Method to use to join the cluster.|
+|`--join-method`|*no default* (one of: `azure`, `azure_devops`, `bitbucket`, `circleci`, `gcp`, `github`, `gitlab`, `iam`, `kubernetes`, `spacelift`, `token`, `tpm`, `terraform_cloud`, `oracle`, `bound_keypair`, `env0`, `generic_oidc`)|Method to use to join the cluster.|
 |`--join-uri`|*no default*|An optional URI with joining and authentication parameters. Individual flags for proxy, join method, token, etc may be used instead.|
 |`--listen`|*no default*|The socket URI on which the local proxy should listen, such as `tcp://0.0.0.0:8080`.|
 |`--[no-]oneshot`|`false`|If set, quit after the first renewal.|
@@ -994,7 +994,7 @@ Flags:
 |`--ca-pin`|*no default*|CA pin to validate the Teleport Auth Server; used on first connect.|
 |`--certificate-ttl`|*no default*|TTL of short-lived machine certificates.|
 |`--diag-addr`|*no default*|If set and the bot is in debug mode, a diagnostics service will listen on specified address.|
-|`--join-method`|*no default* (one of: `azure`, `azure_devops`, `bitbucket`, `circleci`, `gcp`, `github`, `gitlab`, `iam`, `kubernetes`, `spacelift`, `token`, `tpm`, `terraform_cloud`, `oracle`, `bound_keypair`, `env0`)|Method to use to join the cluster.|
+|`--join-method`|*no default* (one of: `azure`, `azure_devops`, `bitbucket`, `circleci`, `gcp`, `github`, `gitlab`, `iam`, `kubernetes`, `spacelift`, `token`, `tpm`, `terraform_cloud`, `oracle`, `bound_keypair`, `env0`, `generic_oidc`)|Method to use to join the cluster.|
 |`--join-uri`|*no default*|An optional URI with joining and authentication parameters. Individual flags for proxy, join method, token, etc may be used instead.|
 |`--listen`|*no default*|The socket URI on which the tunnel should listen, such as `tcp://0.0.0.0:8080`.|
 |`--[no-]oneshot`|`false`|If set, quit after the first renewal.|
@@ -1037,7 +1037,7 @@ Flags:
 |`--destination`|*no default*|A destination URI, such as file:///foo/bar|
 |`--diag-addr`|*no default*|If set and the bot is in debug mode, a diagnostics service will listen on specified address.|
 |`--format`|`` (one of: ``, `tls`, `mongo`, `cockroach`)|The format of the credentials to generate.|
-|`--join-method`|*no default* (one of: `azure`, `azure_devops`, `bitbucket`, `circleci`, `gcp`, `github`, `gitlab`, `iam`, `kubernetes`, `spacelift`, `token`, `tpm`, `terraform_cloud`, `oracle`, `bound_keypair`, `env0`)|Method to use to join the cluster.|
+|`--join-method`|*no default* (one of: `azure`, `azure_devops`, `bitbucket`, `circleci`, `gcp`, `github`, `gitlab`, `iam`, `kubernetes`, `spacelift`, `token`, `tpm`, `terraform_cloud`, `oracle`, `bound_keypair`, `env0`, `generic_oidc`)|Method to use to join the cluster.|
 |`--join-uri`|*no default*|An optional URI with joining and authentication parameters. Individual flags for proxy, join method, token, etc may be used instead.|
 |`--[no-]oneshot`|`false`|If set, quit after the first renewal.|
 |`--[no-]scoped`|`false`|Indicates whether tbot should run in scoped mode. This is required when authenticating as a scoped Bot.|
@@ -1081,7 +1081,7 @@ Flags:
 |`--certificate-ttl`|*no default*|TTL of short-lived machine certificates.|
 |`--database`|*no default*|The name of the database available in the requested database service.|
 |`--diag-addr`|*no default*|If set and the bot is in debug mode, a diagnostics service will listen on specified address.|
-|`--join-method`|*no default* (one of: `azure`, `azure_devops`, `bitbucket`, `circleci`, `gcp`, `github`, `gitlab`, `iam`, `kubernetes`, `spacelift`, `token`, `tpm`, `terraform_cloud`, `oracle`, `bound_keypair`, `env0`)|Method to use to join the cluster.|
+|`--join-method`|*no default* (one of: `azure`, `azure_devops`, `bitbucket`, `circleci`, `gcp`, `github`, `gitlab`, `iam`, `kubernetes`, `spacelift`, `token`, `tpm`, `terraform_cloud`, `oracle`, `bound_keypair`, `env0`, `generic_oidc`)|Method to use to join the cluster.|
 |`--join-uri`|*no default*|An optional URI with joining and authentication parameters. Individual flags for proxy, join method, token, etc may be used instead.|
 |`--listen`|*no default*|A socket URI to listen on, such as `tcp://0.0.0.0:3306`.|
 |`--[no-]oneshot`|`false`|If set, quit after the first renewal.|
@@ -1125,7 +1125,7 @@ Flags:
 |`--cluster`|*no default*|The name of a specific cluster for which to issue an identity if using a leaf cluster.|
 |`--destination`|*no default*|A destination URI, such as file:///foo/bar|
 |`--diag-addr`|*no default*|If set and the bot is in debug mode, a diagnostics service will listen on specified address.|
-|`--join-method`|*no default* (one of: `azure`, `azure_devops`, `bitbucket`, `circleci`, `gcp`, `github`, `gitlab`, `iam`, `kubernetes`, `spacelift`, `token`, `tpm`, `terraform_cloud`, `oracle`, `bound_keypair`, `env0`)|Method to use to join the cluster.|
+|`--join-method`|*no default* (one of: `azure`, `azure_devops`, `bitbucket`, `circleci`, `gcp`, `github`, `gitlab`, `iam`, `kubernetes`, `spacelift`, `token`, `tpm`, `terraform_cloud`, `oracle`, `bound_keypair`, `env0`, `generic_oidc`)|Method to use to join the cluster.|
 |`--join-uri`|*no default*|An optional URI with joining and authentication parameters. Individual flags for proxy, join method, token, etc may be used instead.|
 |`--[no-]allow-reissue`|`false`|Allow the credentials output by this command to be reissued.|
 |`--[no-]oneshot`|`false`|If set, quit after the first renewal.|
@@ -1168,7 +1168,7 @@ Flags:
 |`--certificate-ttl`|*no default*|TTL of short-lived machine certificates.|
 |`--destination`|*no default*|A destination URI, such as file:///foo/bar|
 |`--diag-addr`|*no default*|If set and the bot is in debug mode, a diagnostics service will listen on specified address.|
-|`--join-method`|*no default* (one of: `azure`, `azure_devops`, `bitbucket`, `circleci`, `gcp`, `github`, `gitlab`, `iam`, `kubernetes`, `spacelift`, `token`, `tpm`, `terraform_cloud`, `oracle`, `bound_keypair`, `env0`)|Method to use to join the cluster.|
+|`--join-method`|*no default* (one of: `azure`, `azure_devops`, `bitbucket`, `circleci`, `gcp`, `github`, `gitlab`, `iam`, `kubernetes`, `spacelift`, `token`, `tpm`, `terraform_cloud`, `oracle`, `bound_keypair`, `env0`, `generic_oidc`)|Method to use to join the cluster.|
 |`--join-uri`|*no default*|An optional URI with joining and authentication parameters. Individual flags for proxy, join method, token, etc may be used instead.|
 |`--kubernetes-cluster`|*no default*|The name of the Kubernetes cluster in Teleport for which to fetch credentials.|
 |`--[no-]disable-exec-plugin`|`false`|If set, disables the exec plugin. This allows credentials to be used without the `tbot` binary.|
@@ -1212,7 +1212,7 @@ Flags:
 |`--certificate-ttl`|*no default*|TTL of short-lived machine certificates.|
 |`--destination`|*no default*|A destination URI, such as file:///foo/bar|
 |`--diag-addr`|*no default*|If set and the bot is in debug mode, a diagnostics service will listen on specified address.|
-|`--join-method`|*no default* (one of: `azure`, `azure_devops`, `bitbucket`, `circleci`, `gcp`, `github`, `gitlab`, `iam`, `kubernetes`, `spacelift`, `token`, `tpm`, `terraform_cloud`, `oracle`, `bound_keypair`, `env0`)|Method to use to join the cluster.|
+|`--join-method`|*no default* (one of: `azure`, `azure_devops`, `bitbucket`, `circleci`, `gcp`, `github`, `gitlab`, `iam`, `kubernetes`, `spacelift`, `token`, `tpm`, `terraform_cloud`, `oracle`, `bound_keypair`, `env0`, `generic_oidc`)|Method to use to join the cluster.|
 |`--join-uri`|*no default*|An optional URI with joining and authentication parameters. Individual flags for proxy, join method, token, etc may be used instead.|
 |`--label-selector`|*no default*|A set of Kubernetes labels to match in k1=v1,k2=v2 form. Repeatable.|
 |`--name-selector`|*no default*|An explicit Kubernetes cluster name to include. Repeatable.|
@@ -1258,7 +1258,7 @@ Flags:
 |`--data-dir`|*no default*|Directory to store internal bot data. Access to this directory should be limited.|
 |`--destination-dir`|*no default*|Directory to write short-lived machine certificates.|
 |`--diag-addr`|*no default*|If set and the bot is in debug mode, a diagnostics service will listen on specified address.|
-|`--join-method`|*no default* (one of: `azure`, `azure_devops`, `bitbucket`, `circleci`, `gcp`, `github`, `gitlab`, `iam`, `kubernetes`, `spacelift`, `token`, `tpm`, `terraform_cloud`, `oracle`, `bound_keypair`, `env0`)|Method to use to join the cluster.|
+|`--join-method`|*no default* (one of: `azure`, `azure_devops`, `bitbucket`, `circleci`, `gcp`, `github`, `gitlab`, `iam`, `kubernetes`, `spacelift`, `token`, `tpm`, `terraform_cloud`, `oracle`, `bound_keypair`, `env0`, `generic_oidc`)|Method to use to join the cluster.|
 |`--[no-]oneshot`|`false`|If set, quit after the first renewal.|
 |`--[no-]scoped`|`false`|Indicates whether tbot should run in scoped mode. This is required when authenticating as a scoped Bot.|
 |`--pid-file`|*no default*|Full path to the PID file. By default no PID file will be created.|
@@ -1292,7 +1292,7 @@ Flags:
 |`--ca-pin`|*no default*|CA pin to validate the Teleport Auth Server; used on first connect.|
 |`--certificate-ttl`|*no default*|TTL of short-lived machine certificates.|
 |`--diag-addr`|*no default*|If set and the bot is in debug mode, a diagnostics service will listen on specified address.|
-|`--join-method`|*no default* (one of: `azure`, `azure_devops`, `bitbucket`, `circleci`, `gcp`, `github`, `gitlab`, `iam`, `kubernetes`, `spacelift`, `token`, `tpm`, `terraform_cloud`, `oracle`, `bound_keypair`, `env0`)|Method to use to join the cluster.|
+|`--join-method`|*no default* (one of: `azure`, `azure_devops`, `bitbucket`, `circleci`, `gcp`, `github`, `gitlab`, `iam`, `kubernetes`, `spacelift`, `token`, `tpm`, `terraform_cloud`, `oracle`, `bound_keypair`, `env0`, `generic_oidc`)|Method to use to join the cluster.|
 |`--join-uri`|*no default*|An optional URI with joining and authentication parameters. Individual flags for proxy, join method, token, etc may be used instead.|
 |`--[no-]oneshot`|`false`|If set, quit after the first renewal.|
 |`--[no-]scoped`|`false`|Indicates whether tbot should run in scoped mode. This is required when authenticating as a scoped Bot.|
@@ -1332,7 +1332,7 @@ Flags:
 |`--certificate-ttl`|*no default*|TTL of short-lived machine certificates.|
 |`--destination`|*no default*|A destination URI, such as file:///foo/bar|
 |`--diag-addr`|*no default*|If set and the bot is in debug mode, a diagnostics service will listen on specified address.|
-|`--join-method`|*no default* (one of: `azure`, `azure_devops`, `bitbucket`, `circleci`, `gcp`, `github`, `gitlab`, `iam`, `kubernetes`, `spacelift`, `token`, `tpm`, `terraform_cloud`, `oracle`, `bound_keypair`, `env0`)|Method to use to join the cluster.|
+|`--join-method`|*no default* (one of: `azure`, `azure_devops`, `bitbucket`, `circleci`, `gcp`, `github`, `gitlab`, `iam`, `kubernetes`, `spacelift`, `token`, `tpm`, `terraform_cloud`, `oracle`, `bound_keypair`, `env0`, `generic_oidc`)|Method to use to join the cluster.|
 |`--join-uri`|*no default*|An optional URI with joining and authentication parameters. Individual flags for proxy, join method, token, etc may be used instead.|
 |`--[no-]enable-resumption`|`false`|If set, disables SSH session resumption.|
 |`--[no-]oneshot`|`false`|If set, quit after the first renewal.|
@@ -1377,7 +1377,7 @@ Flags:
 |`--ca-pin`|*no default*|CA pin to validate the Teleport Auth Server; used on first connect.|
 |`--certificate-ttl`|*no default*|TTL of short-lived machine certificates.|
 |`--diag-addr`|*no default*|If set and the bot is in debug mode, a diagnostics service will listen on specified address.|
-|`--join-method`|*no default* (one of: `azure`, `azure_devops`, `bitbucket`, `circleci`, `gcp`, `github`, `gitlab`, `iam`, `kubernetes`, `spacelift`, `token`, `tpm`, `terraform_cloud`, `oracle`, `bound_keypair`, `env0`)|Method to use to join the cluster.|
+|`--join-method`|*no default* (one of: `azure`, `azure_devops`, `bitbucket`, `circleci`, `gcp`, `github`, `gitlab`, `iam`, `kubernetes`, `spacelift`, `token`, `tpm`, `terraform_cloud`, `oracle`, `bound_keypair`, `env0`, `generic_oidc`)|Method to use to join the cluster.|
 |`--join-uri`|*no default*|An optional URI with joining and authentication parameters. Individual flags for proxy, join method, token, etc may be used instead.|
 |`--label-selector`|*no default*|A label-based selector for which workload identities to issue. Multiple labels can be provided using ','. Mutually exclusive with --name-selector.|
 |`--listen`|*no default*|The address on which the workload identity API should listen. This should either be prefixed with 'unix://' or 'tcp://'.|
@@ -1421,7 +1421,7 @@ Flags:
 |`--certificate-ttl`|*no default*|TTL of short-lived machine certificates.|
 |`--destination`|*no default*|A destination URI, such as file:///foo/bar|
 |`--diag-addr`|*no default*|If set and the bot is in debug mode, a diagnostics service will listen on specified address.|
-|`--join-method`|*no default* (one of: `azure`, `azure_devops`, `bitbucket`, `circleci`, `gcp`, `github`, `gitlab`, `iam`, `kubernetes`, `spacelift`, `token`, `tpm`, `terraform_cloud`, `oracle`, `bound_keypair`, `env0`)|Method to use to join the cluster.|
+|`--join-method`|*no default* (one of: `azure`, `azure_devops`, `bitbucket`, `circleci`, `gcp`, `github`, `gitlab`, `iam`, `kubernetes`, `spacelift`, `token`, `tpm`, `terraform_cloud`, `oracle`, `bound_keypair`, `env0`, `generic_oidc`)|Method to use to join the cluster.|
 |`--join-uri`|*no default*|An optional URI with joining and authentication parameters. Individual flags for proxy, join method, token, etc may be used instead.|
 |`--label-selector`|*no default*|A label-based selector for which workload identities to issue. Multiple labels can be provided using ','. Mutually exclusive with --name-selector.|
 |`--name-selector`|*no default*|The name of the workload identity to issue. Mutually exclusive with --label-selector.|
@@ -1472,7 +1472,7 @@ Flags:
 |`--certificate-ttl`|*no default*|TTL of short-lived machine certificates.|
 |`--destination`|*no default*|A destination URI, such as file:///foo/bar|
 |`--diag-addr`|*no default*|If set and the bot is in debug mode, a diagnostics service will listen on specified address.|
-|`--join-method`|*no default* (one of: `azure`, `azure_devops`, `bitbucket`, `circleci`, `gcp`, `github`, `gitlab`, `iam`, `kubernetes`, `spacelift`, `token`, `tpm`, `terraform_cloud`, `oracle`, `bound_keypair`, `env0`)|Method to use to join the cluster.|
+|`--join-method`|*no default* (one of: `azure`, `azure_devops`, `bitbucket`, `circleci`, `gcp`, `github`, `gitlab`, `iam`, `kubernetes`, `spacelift`, `token`, `tpm`, `terraform_cloud`, `oracle`, `bound_keypair`, `env0`, `generic_oidc`)|Method to use to join the cluster.|
 |`--join-uri`|*no default*|An optional URI with joining and authentication parameters. Individual flags for proxy, join method, token, etc may be used instead.|
 |`--label-selector`|*no default*|A label-based selector for which workload identities to issue. Multiple labels can be provided using ','. Mutually exclusive with --name-selector.|
 |`--name-selector`|*no default*|The name of the workload identity to issue. Mutually exclusive with --label-selector.|
@@ -1516,7 +1516,7 @@ Flags:
 |`--certificate-ttl`|*no default*|TTL of short-lived machine certificates.|
 |`--destination`|*no default*|A destination URI, such as file:///foo/bar|
 |`--diag-addr`|*no default*|If set and the bot is in debug mode, a diagnostics service will listen on specified address.|
-|`--join-method`|*no default* (one of: `azure`, `azure_devops`, `bitbucket`, `circleci`, `gcp`, `github`, `gitlab`, `iam`, `kubernetes`, `spacelift`, `token`, `tpm`, `terraform_cloud`, `oracle`, `bound_keypair`, `env0`)|Method to use to join the cluster.|
+|`--join-method`|*no default* (one of: `azure`, `azure_devops`, `bitbucket`, `circleci`, `gcp`, `github`, `gitlab`, `iam`, `kubernetes`, `spacelift`, `token`, `tpm`, `terraform_cloud`, `oracle`, `bound_keypair`, `env0`, `generic_oidc`)|Method to use to join the cluster.|
 |`--join-uri`|*no default*|An optional URI with joining and authentication parameters. Individual flags for proxy, join method, token, etc may be used instead.|
 |`--label-selector`|*no default*|A label-based selector for which workload identities to issue. Multiple labels can be provided using ','. Mutually exclusive with --name-selector.|
 |`--name-selector`|*no default*|The name of the workload identity to issue. Mutually exclusive with --label-selector.|

--- a/docs/pages/reference/cli/tctl.mdx
+++ b/docs/pages/reference/cli/tctl.mdx
@@ -1388,6 +1388,23 @@ Flags:
 |`--last`|`1h`|Time window to look back for failures in Teleport audit log (e.g. 1h, 24h, 30m).|
 |`--[no-]failures-only`|`false`|Only show instances with enrollment failures.|
 
+## tctl discovery status
+
+Show auto-discovery status and enrollment progress.
+
+Usage:
+
+```code
+$ tctl discovery status [<flags>]
+```
+
+Flags:
+
+|Flag|Default|Description|
+|---|---|---|
+|`--cloud`|``|Comma-separated list of cloud providers to include (allowed: aws, azure). Empty (default) returns all.|
+|`--format`|`text` (one of: `text`, `json`, `yaml`)|Output format.|
+
 ## tctl edit
 
 Edit a Teleport resource.

--- a/docs/pages/reference/cli/teleport.mdx
+++ b/docs/pages/reference/cli/teleport.mdx
@@ -159,7 +159,7 @@ Flags:
 |`--cert-file`|*no default*|Path to a TLS certificate file for the proxy.|
 |`--cluster-name`|*no default*|Unique cluster name, e.g. example.com.|
 |`--data-dir`|`/var/lib/teleport`|Path to a directory where Teleport keep its data.|
-|`--join-method`|`token` (one of: `azure`, `azure_devops`, `bitbucket`, `circleci`, `ec2`, `gcp`, `github`, `gitlab`, `iam`, `kubernetes`, `spacelift`, `token`, `tpm`, `terraform_cloud`, `oracle`, `bound_keypair`, `env0`)|Method to use to join the cluster.|
+|`--join-method`|`token` (one of: `azure`, `azure_devops`, `bitbucket`, `circleci`, `ec2`, `gcp`, `github`, `gitlab`, `iam`, `kubernetes`, `spacelift`, `token`, `tpm`, `terraform_cloud`, `oracle`, `bound_keypair`, `env0`, `generic_oidc`)|Method to use to join the cluster.|
 |`--key-file`|*no default*|Path to a TLS key file for the proxy.|
 |`--[no-]acme`|`false`|Get automatic certificate from Letsencrypt.org using ACME.|
 |`--node-labels`|*no default*|Comma-separated list of labels to add to newly created nodes, for example env=staging,cloud=aws.|
@@ -822,7 +822,7 @@ Flags:
 |`--ca-pin`|*no default*|Comma-separated list of SKPI hashes for the CA used to verify the auth server.|
 |`--cluster-name`|*no default*|Unique cluster name, e.g. example.com.|
 |`--data-dir`|`/var/lib/teleport`|Path to a directory where Teleport keep its data.|
-|`--join-method`|`token` (one of: `azure`, `azure_devops`, `bitbucket`, `circleci`, `ec2`, `gcp`, `github`, `gitlab`, `iam`, `kubernetes`, `spacelift`, `token`, `tpm`, `terraform_cloud`, `oracle`, `bound_keypair`, `env0`)|Method to use to join the cluster.|
+|`--join-method`|`token` (one of: `azure`, `azure_devops`, `bitbucket`, `circleci`, `ec2`, `gcp`, `github`, `gitlab`, `iam`, `kubernetes`, `spacelift`, `token`, `tpm`, `terraform_cloud`, `oracle`, `bound_keypair`, `env0`, `generic_oidc`)|Method to use to join the cluster.|
 |`--labels`|*no default*|Comma-separated list of labels to add to newly created nodes ex) env=staging,cloud=aws.|
 |`--node-name`|*no default*|Name for the Teleport node.|
 |`--[no-]silent`|`false`|Suppress user hint message.|

--- a/tool/tctl/common/discovery/command.go
+++ b/tool/tctl/common/discovery/command.go
@@ -50,7 +50,8 @@ type discoveryClient interface {
 type Command struct {
 	stdout io.Writer
 
-	nodes nodesArgs
+	nodes  nodesArgs
+	status statusArgs
 }
 
 // Initialize registers the "discovery" command and its subcommands with the CLI parser.
@@ -61,6 +62,7 @@ func (c *Command) Initialize(app *kingpin.Application, _ *tctlcfg.GlobalCLIFlags
 
 	discovery := app.Command("discovery", "Troubleshoot auto-discovery issues.")
 	c.nodes.initNodes(discovery)
+	c.status.initStatus(discovery)
 }
 
 // TryRun attempts to run the matched subcommand.
@@ -70,6 +72,8 @@ func (c *Command) TryRun(ctx context.Context, cmd string, clientFunc commonclien
 	switch cmd {
 	case c.nodes.cmd.FullCommand():
 		commandFunc = c.nodes.run
+	case c.status.cmd.FullCommand():
+		commandFunc = c.status.run
 	default:
 		return false, nil
 	}

--- a/tool/tctl/common/discovery/status.go
+++ b/tool/tctl/common/discovery/status.go
@@ -1,0 +1,53 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package discovery
+
+import (
+	"time"
+)
+
+type discoverySummary []configSummary
+
+type configSummary struct {
+	Name           string          `json:"name" yaml:"name"`
+	DiscoveryGroup string          `json:"discovery_group" yaml:"discovery_group"`
+	State          string          `json:"state" yaml:"state"`
+	ErrorMessage   string          `json:"error_message,omitempty" yaml:"error_message,omitempty"`
+	LastSyncTime   *time.Time      `json:"last_sync_time,omitempty" yaml:"last_sync_time,omitempty"`
+	Servers        []serverSummary `json:"servers,omitempty" yaml:"servers,omitempty"`
+}
+
+type serverSummary struct {
+	ServerID     string               `json:"server_id" yaml:"server_id"`
+	PollInterval string               `json:"poll_interval,omitempty" yaml:"poll_interval,omitempty"`
+	LastUpdate   *time.Time           `json:"last_update,omitempty" yaml:"last_update,omitempty"`
+	Integrations []integrationSummary `json:"integrations,omitempty" yaml:"integrations,omitempty"`
+}
+
+type integrationSummary struct {
+	Integration string           `json:"integration,omitempty" yaml:"integration,omitempty"`
+	Resources   []resourceResult `json:"resources,omitempty" yaml:"resources,omitempty"`
+}
+
+type resourceResult struct {
+	Kind      string     `json:"kind" yaml:"kind"`
+	Found     uint64     `json:"found" yaml:"found"`
+	Enrolled  uint64     `json:"enrolled" yaml:"enrolled"`
+	Failed    uint64     `json:"failed" yaml:"failed"`
+	SyncStart *time.Time `json:"sync_start,omitempty" yaml:"sync_start,omitempty"`
+	SyncEnd   *time.Time `json:"sync_end,omitempty" yaml:"sync_end,omitempty"`
+}

--- a/tool/tctl/common/discovery/status_command.go
+++ b/tool/tctl/common/discovery/status_command.go
@@ -1,0 +1,74 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package discovery
+
+import (
+	"context"
+	"io"
+	"time"
+
+	"github.com/alecthomas/kingpin/v2"
+	"github.com/gravitational/trace"
+
+	"github.com/gravitational/teleport"
+	"github.com/gravitational/teleport/api/utils/clientutils"
+	"github.com/gravitational/teleport/lib/itertools/stream"
+	"github.com/gravitational/teleport/lib/utils"
+)
+
+type statusArgs struct {
+	cmd *kingpin.CmdClause
+
+	format      string
+	cloudFilter string
+}
+
+func (s *statusArgs) initStatus(app *kingpin.CmdClause) {
+	statusCmd := app.Command("status", "Show auto-discovery status and enrollment progress.")
+
+	statusCmd.Flag("format", "Output format.").
+		Default(teleport.Text).
+		EnumVar(&s.format, teleport.Text, teleport.JSON, teleport.YAML)
+	statusCmd.Flag("cloud", "Comma-separated list of cloud providers to include (allowed: aws, azure). Empty (default) returns all.").
+		Default("").
+		StringVar(&s.cloudFilter)
+
+	s.cmd = statusCmd
+}
+
+func (s *statusArgs) run(ctx context.Context, clt discoveryClient, w io.Writer) error {
+	cloudProviders, err := parseCloudProviders(s.cloudFilter)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	discoveryConfigs, err := stream.Collect(clientutils.Resources(ctx, clt.DiscoveryConfigClient().ListDiscoveryConfigs))
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	status := newDiscoverySummary(discoveryConfigs, cloudProviders)
+	switch s.format {
+	case teleport.Text:
+		return trace.Wrap(status.renderText(w, time.Now()))
+	case teleport.JSON:
+		return trace.Wrap(utils.WriteJSONArray(w, status))
+	case teleport.YAML:
+		return trace.Wrap(utils.WriteYAML(w, status))
+	default:
+		return trace.BadParameter("unknown format %q", s.format)
+	}
+}

--- a/tool/tctl/common/discovery/status_render.go
+++ b/tool/tctl/common/discovery/status_render.go
@@ -1,0 +1,154 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package discovery
+
+import (
+	"fmt"
+	"io"
+	"strings"
+	"time"
+
+	"github.com/dustin/go-humanize"
+	"github.com/gravitational/trace"
+
+	discoveryconfigv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/discoveryconfig/v1"
+)
+
+const discoveryServiceSetupDocsURL = "https://goteleport.com/docs/reference/deployment/config/#discovery-service"
+
+func (s discoverySummary) renderText(w io.Writer, now time.Time) error {
+	var out strings.Builder
+	if len(s) == 0 {
+		writeSummaryLine(&out, "No discovery_config resources are configured.")
+	} else {
+		for i, config := range s {
+			if i > 0 {
+				out.WriteByte('\n')
+			}
+			config.writeText(&out, now)
+		}
+	}
+
+	_, err := io.WriteString(w, out.String())
+	return trace.Wrap(err)
+}
+
+func (c configSummary) writeText(w *strings.Builder, now time.Time) {
+	writeSummaryLine(w, "Discovery config %s:", c.Name)
+	writeSummaryLine(w, "  Discovery group: %s", c.DiscoveryGroup)
+	writeSummaryLine(w, "  Status: %s", formatSummaryState(c.State))
+	if c.LastSyncTime != nil {
+		writeSummaryLine(w, "  Last run: %s", formatSummaryLastRun(c.LastSyncTime, now))
+	}
+	if c.ErrorMessage != "" {
+		writeSummaryLine(w, "  Error: %s", c.ErrorMessage)
+	}
+	if len(c.Servers) == 0 {
+		writeSummaryLine(w, "  No Discovery Services running for %s. See %s.", c.DiscoveryGroup, discoveryServiceSetupDocsURL)
+		return
+	}
+	w.WriteByte('\n')
+	for _, server := range c.Servers {
+		server.writeText(w, now)
+	}
+}
+
+func (s serverSummary) writeText(w *strings.Builder, now time.Time) {
+	writeSummaryLine(w, "  Service (%s):", s.ServerID)
+	if s.PollInterval != "" {
+		writeSummaryLine(w, "    Poll interval: %s", formatPollInterval(s.PollInterval))
+	}
+	if s.LastUpdate != nil {
+		writeSummaryLine(w, "    Last update: %s", formatSummaryLastRun(s.LastUpdate, now))
+	}
+	for _, integration := range s.Integrations {
+		integration.writeText(w, now)
+	}
+}
+
+func (i integrationSummary) writeText(w *strings.Builder, now time.Time) {
+	writeSummaryLine(w, "    %s:", formatIntegrationName(i.Integration))
+	for _, resource := range i.Resources {
+		resource.writeText(w, now)
+	}
+}
+
+func (r resourceResult) writeText(w *strings.Builder, now time.Time) {
+	writeSummaryLine(w, "      %s:", r.Kind)
+	writeSummaryLine(w, "        Previous sync: %s%s", formatSummaryLastRun(r.SyncEnd, now), formatSyncDuration(r.SyncStart, r.SyncEnd))
+	writeSummaryLine(w, "        Result: %s", formatResourceResult(r))
+}
+
+func writeSummaryLine(w *strings.Builder, format string, args ...any) {
+	line := fmt.Sprintf(format, args...)
+	w.WriteString(strings.TrimRight(line, " "))
+	w.WriteByte('\n')
+}
+
+func formatSummaryState(state string) string {
+	switch state {
+	case "", discoveryconfigv1.DiscoveryConfigState_DISCOVERY_CONFIG_STATE_UNSPECIFIED.String():
+		return summaryStatusNotReporting
+	case discoveryconfigv1.DiscoveryConfigState_DISCOVERY_CONFIG_STATE_ERROR.String():
+		return "error"
+	case discoveryconfigv1.DiscoveryConfigState_DISCOVERY_CONFIG_STATE_SYNCING.String():
+		return "syncing"
+	case discoveryconfigv1.DiscoveryConfigState_DISCOVERY_CONFIG_STATE_RUNNING.String():
+		return "healthy"
+	default:
+		return strings.ToLower(strings.TrimPrefix(state, "DISCOVERY_CONFIG_STATE_"))
+	}
+}
+
+func formatIntegrationName(integration string) string {
+	if integration == "" {
+		return "ambient credentials"
+	}
+	return integration
+}
+
+func formatPollInterval(pollInterval string) string {
+	duration, err := time.ParseDuration(pollInterval)
+	if err != nil {
+		return pollInterval
+	}
+	return strings.TrimSpace(humanize.RelTime(time.Time{}, time.Time{}.Add(duration), "", ""))
+}
+
+func formatSyncDuration(start, end *time.Time) string {
+	if start == nil || end == nil {
+		return ""
+	}
+	duration := end.Sub(*start).Round(time.Second)
+	return " (took " + duration.String() + ")"
+}
+
+func formatResourceResult(result resourceResult) string {
+	return fmt.Sprintf(
+		"%d found, %d enrolled, %d failed",
+		result.Found,
+		result.Enrolled,
+		result.Failed,
+	)
+}
+
+func formatSummaryLastRun(t *time.Time, now time.Time) string {
+	if t == nil || t.IsZero() {
+		return "never"
+	}
+	return humanize.RelTime(*t, now, "ago", "from now")
+}

--- a/tool/tctl/common/discovery/status_render_test.go
+++ b/tool/tctl/common/discovery/status_render_test.go
@@ -1,0 +1,200 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package discovery
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	discoveryconfigv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/discoveryconfig/v1"
+)
+
+func TestRenderSummaryText(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 1, 15, 12, 0, 0, 0, time.UTC)
+
+	t.Run("empty input shows no-configurations message", func(t *testing.T) {
+		var buf bytes.Buffer
+		require.NoError(t, discoverySummary(nil).renderText(&buf, now))
+		require.Equal(t, "No discovery_config resources are configured.\n", buf.String())
+	})
+
+	t.Run("renders no-service warning", func(t *testing.T) {
+		lastRun := now.Add(-5 * time.Minute)
+		var buf bytes.Buffer
+		require.NoError(t, discoverySummary{
+			{
+				Name:           "empty-config",
+				DiscoveryGroup: "prod",
+				State:          discoveryconfigv1.DiscoveryConfigState_DISCOVERY_CONFIG_STATE_ERROR.String(),
+				ErrorMessage:   "AccessDenied: missing ec2:DescribeInstances permission",
+				LastSyncTime:   &lastRun,
+			},
+		}.renderText(&buf, now))
+
+		out := buf.String()
+		requireNoTrailingWhitespace(t, out)
+		require.Equal(t, `Discovery config empty-config:
+  Discovery group: prod
+  Status: error
+  Last run: 5 minutes ago
+  Error: AccessDenied: missing ec2:DescribeInstances permission
+  No Discovery Services running for prod. See https://goteleport.com/docs/reference/deployment/config/#discovery-service.
+`, out)
+	})
+
+	t.Run("renders service hierarchy", func(t *testing.T) {
+		out := renderMultiServerSummary(t, now)
+		requireNoTrailingWhitespace(t, out)
+		require.Equal(t, `Discovery config multi-config:
+  Discovery group: prod
+  Status: healthy
+  Last run: 2 minutes ago
+
+  Service (server-a):
+    Poll interval: 5 minutes
+    Last update: 1 minute ago
+    ambient credentials:
+      AWS EC2:
+        Previous sync: 4 minutes ago (took 12s)
+        Result: 10 found, 8 enrolled, 2 failed
+      AWS RDS:
+        Previous sync: 3 minutes ago (took 30s)
+        Result: 5 found, 4 enrolled, 1 failed
+    aws-prod:
+      AWS EC2:
+        Previous sync: 2 minutes ago (took 30s)
+        Result: 8 found, 7 enrolled, 1 failed
+      AWS RDS:
+        Previous sync: 1 minute ago (took 30s)
+        Result: 6 found, 6 enrolled, 0 failed
+  Service (server-b):
+    Poll interval: 10 minutes
+    Last update: 3 minutes ago
+    ambient credentials:
+      AWS RDS:
+        Previous sync: 4 minutes ago (took 30s)
+        Result: 3 found, 2 enrolled, 1 failed
+      Azure VM:
+        Previous sync: 3 minutes ago (took 30s)
+        Result: 7 found, 6 enrolled, 1 failed
+    azure-prod:
+      Azure VM:
+        Previous sync: 2 minutes ago (took 30s)
+        Result: 4 found, 4 enrolled, 0 failed
+`, out)
+		require.Contains(t, out, "\n  Last run: 2 minutes ago\n\n  Service (server-a):")
+		require.Contains(t, out, "\n        Result: 10 found, 8 enrolled, 2 failed")
+		require.NotContains(t, out, "AWS EKS:")
+		requireResultIndentation(t, out)
+	})
+}
+
+func renderMultiServerSummary(t *testing.T, now time.Time) string {
+	t.Helper()
+
+	roundsToDisplayDuration := 11*time.Second + 832865310*time.Nanosecond
+	var buf bytes.Buffer
+	require.NoError(t, discoverySummary{
+		{
+			Name:           "multi-config",
+			DiscoveryGroup: "prod",
+			State:          discoveryconfigv1.DiscoveryConfigState_DISCOVERY_CONFIG_STATE_RUNNING.String(),
+			LastSyncTime:   new(now.Add(-2 * time.Minute)),
+			Servers: []serverSummary{
+				{
+					ServerID:     "server-a",
+					PollInterval: "5m0s",
+					LastUpdate:   new(now.Add(-time.Minute)),
+					Integrations: []integrationSummary{
+						{
+							Resources: []resourceResult{
+								testResourceResult(resourceKindAWSEC2, 10, 8, 2, now.Add(-4*time.Minute-roundsToDisplayDuration), now.Add(-4*time.Minute)),
+								testResourceResult(resourceKindAWSRDS, 5, 4, 1, now.Add(-3*time.Minute-30*time.Second), now.Add(-3*time.Minute)),
+							},
+						},
+						{
+							Integration: "aws-prod",
+							Resources: []resourceResult{
+								testResourceResult(resourceKindAWSEC2, 8, 7, 1, now.Add(-2*time.Minute-30*time.Second), now.Add(-2*time.Minute)),
+								testResourceResult(resourceKindAWSRDS, 6, 6, 0, now.Add(-time.Minute-30*time.Second), now.Add(-time.Minute)),
+							},
+						},
+					},
+				},
+				{
+					ServerID:     "server-b",
+					PollInterval: "10m0s",
+					LastUpdate:   new(now.Add(-3 * time.Minute)),
+					Integrations: []integrationSummary{
+						{
+							Resources: []resourceResult{
+								testResourceResult(resourceKindAWSRDS, 3, 2, 1, now.Add(-4*time.Minute-30*time.Second), now.Add(-4*time.Minute)),
+								testResourceResult(resourceKindAzureVM, 7, 6, 1, now.Add(-3*time.Minute-30*time.Second), now.Add(-3*time.Minute)),
+							},
+						},
+						{
+							Integration: "azure-prod",
+							Resources: []resourceResult{
+								testResourceResult(resourceKindAzureVM, 4, 4, 0, now.Add(-2*time.Minute-30*time.Second), now.Add(-2*time.Minute)),
+							},
+						},
+					},
+				},
+			},
+		},
+	}.renderText(&buf, now))
+	return buf.String()
+}
+
+func testResourceResult(kind string, found, enrolled, failed uint64, syncStart, syncEnd time.Time) resourceResult {
+	return resourceResult{
+		Kind:      kind,
+		Found:     found,
+		Enrolled:  enrolled,
+		Failed:    failed,
+		SyncStart: &syncStart,
+		SyncEnd:   &syncEnd,
+	}
+}
+
+func requireResultIndentation(t *testing.T, out string) {
+	t.Helper()
+
+	var sawService bool
+	for _, line := range strings.Split(strings.TrimRight(out, "\n"), "\n") {
+		if strings.HasPrefix(line, "  Service (") {
+			sawService = true
+		}
+		if strings.Contains(line, "Result:") {
+			require.True(t, sawService, "result line rendered before service: %q", line)
+			require.True(t, strings.HasPrefix(line, "        Result:"), "result line has wrong indentation: %q", line)
+		}
+	}
+}
+
+func requireNoTrailingWhitespace(t *testing.T, out string) {
+	t.Helper()
+	for _, line := range strings.Split(strings.TrimRight(out, "\n"), "\n") {
+		require.False(t, strings.HasSuffix(line, " "), "trailing whitespace: %q", line)
+	}
+}

--- a/tool/tctl/common/discovery/status_test.go
+++ b/tool/tctl/common/discovery/status_test.go
@@ -1,0 +1,382 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package discovery
+
+import (
+	"bytes"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/durationpb"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	discoveryconfigv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/discoveryconfig/v1"
+	"github.com/gravitational/teleport/api/types/discoveryconfig"
+	"github.com/gravitational/teleport/api/types/header"
+	"github.com/gravitational/teleport/lib/utils"
+)
+
+func TestBuildDiscoverySummaryFromServerStatus(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 1, 15, 12, 0, 0, 0, time.UTC)
+	multiConfig := newTestDiscoveryConfig(t, "multi-config", "prod")
+	multiConfig.Status = discoveryconfig.Status{
+		State:        discoveryconfigv1.DiscoveryConfigState_DISCOVERY_CONFIG_STATE_RUNNING.String(),
+		LastSyncTime: now.Add(-2 * time.Minute),
+		ServerStatus: map[string]*discoveryconfig.DiscoveryStatusServer{
+			"server-b": testServerStatus(now.Add(-3*time.Minute), 10*time.Minute, map[string]*discoveryconfigv1.DiscoverSummary{
+				"": testDiscoverSummary(
+					withPreviousRDS(discoveryResourcesSummary(3, 2, 1, now.Add(-5*time.Minute), now.Add(-4*time.Minute))),
+					withPreviousAzureVM(discoveryResourcesSummary(7, 6, 1, now.Add(-4*time.Minute), now.Add(-3*time.Minute))),
+				),
+				"azure-prod": testDiscoverSummary(
+					withPreviousAzureVM(discoveryResourcesSummary(4, 4, 0, now.Add(-3*time.Minute), now.Add(-2*time.Minute))),
+				),
+			}),
+			"server-a": testServerStatus(now.Add(-time.Minute), 5*time.Minute, map[string]*discoveryconfigv1.DiscoverSummary{
+				"": testDiscoverSummary(
+					withPreviousEC2(discoveryResourcesSummary(10, 8, 2, now.Add(-5*time.Minute), now.Add(-4*time.Minute-time.Second))),
+					withPreviousRDS(discoveryResourcesSummary(5, 4, 1, now.Add(-4*time.Minute), now.Add(-3*time.Minute-time.Second))),
+				),
+				"aws-prod": testDiscoverSummary(
+					withPreviousEC2(discoveryResourcesSummary(8, 7, 1, now.Add(-3*time.Minute), now.Add(-2*time.Minute-time.Second))),
+					withCurrentEKS(discoveryResourcesSummary(99, 0, 0, now.Add(-time.Minute), now)),
+					withPreviousRDS(discoveryResourcesSummary(6, 6, 0, now.Add(-2*time.Minute), now.Add(-time.Minute-time.Second))),
+				),
+			}),
+		},
+	}
+
+	errorMessage := "AccessDenied: missing ec2:DescribeInstances permission"
+	noServiceConfig := newTestDiscoveryConfig(t, "empty-config", "prod")
+	noServiceConfig.Status = discoveryconfig.Status{
+		State:        discoveryconfigv1.DiscoveryConfigState_DISCOVERY_CONFIG_STATE_ERROR.String(),
+		LastSyncTime: now.Add(-5 * time.Minute),
+		ErrorMessage: &errorMessage,
+	}
+
+	summaries := newDiscoverySummary(
+		[]*discoveryconfig.DiscoveryConfig{multiConfig, noServiceConfig},
+		cloudProviderConfig{aws: true, azure: true},
+	)
+	require.Len(t, summaries, 2)
+
+	emptySummary := requireConfigSummary(t, summaries, "empty-config")
+	require.Equal(t, "prod", emptySummary.DiscoveryGroup)
+	require.Equal(t, discoveryconfigv1.DiscoveryConfigState_DISCOVERY_CONFIG_STATE_ERROR.String(), emptySummary.State)
+	require.Equal(t, errorMessage, emptySummary.ErrorMessage)
+	require.NotNil(t, emptySummary.LastSyncTime)
+	require.Equal(t, now.Add(-5*time.Minute), *emptySummary.LastSyncTime)
+	require.Empty(t, emptySummary.Servers)
+
+	multiSummary := requireConfigSummary(t, summaries, "multi-config")
+	require.Equal(t, discoveryconfigv1.DiscoveryConfigState_DISCOVERY_CONFIG_STATE_RUNNING.String(), multiSummary.State)
+	require.NotNil(t, multiSummary.LastSyncTime)
+	require.Equal(t, now.Add(-2*time.Minute), *multiSummary.LastSyncTime)
+	require.Len(t, multiSummary.Servers, 2)
+	require.Equal(t, "server-a", multiSummary.Servers[0].ServerID)
+	require.Equal(t, "server-b", multiSummary.Servers[1].ServerID)
+	require.Equal(t, "5m0s", multiSummary.Servers[0].PollInterval)
+	require.NotNil(t, multiSummary.Servers[0].LastUpdate)
+	require.Equal(t, now.Add(-time.Minute), *multiSummary.Servers[0].LastUpdate)
+
+	serverA := multiSummary.Servers[0]
+	require.Len(t, serverA.Integrations, 2)
+	require.Empty(t, serverA.Integrations[0].Integration)
+	require.Equal(t, "aws-prod", serverA.Integrations[1].Integration)
+	require.Equal(t, []string{resourceKindAWSEC2, resourceKindAWSRDS}, resourceKinds(serverA.Integrations[0].Resources))
+	require.Equal(t, []string{resourceKindAWSEC2, resourceKindAWSRDS}, resourceKinds(serverA.Integrations[1].Resources), "current-only EKS summary must be skipped")
+	require.Equal(t, resourceResult{
+		Kind:      resourceKindAWSEC2,
+		Found:     10,
+		Enrolled:  8,
+		Failed:    2,
+		SyncStart: new(now.Add(-5 * time.Minute)),
+		SyncEnd:   new(now.Add(-4*time.Minute - time.Second)),
+	}, serverA.Integrations[0].Resources[0])
+
+	serverB := multiSummary.Servers[1]
+	require.Len(t, serverB.Integrations, 2)
+	require.Empty(t, serverB.Integrations[0].Integration)
+	require.Equal(t, "azure-prod", serverB.Integrations[1].Integration)
+	require.Equal(t, []string{resourceKindAWSRDS, resourceKindAzureVM}, resourceKinds(serverB.Integrations[0].Resources))
+	require.Equal(t, []string{resourceKindAzureVM}, resourceKinds(serverB.Integrations[1].Resources))
+}
+
+func TestBuildDiscoverySummaryCloudFilter(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 1, 15, 12, 0, 0, 0, time.UTC)
+	config := newTestDiscoveryConfig(t, "multi-cloud", "prod")
+	config.Status = discoveryconfig.Status{
+		State: discoveryconfigv1.DiscoveryConfigState_DISCOVERY_CONFIG_STATE_RUNNING.String(),
+		ServerStatus: map[string]*discoveryconfig.DiscoveryStatusServer{
+			"server-a": testServerStatus(now, time.Minute, map[string]*discoveryconfigv1.DiscoverSummary{
+				"": testDiscoverSummary(
+					withPreviousEC2(discoveryResourcesSummary(10, 8, 2, now.Add(-time.Minute), now)),
+					withPreviousAzureVM(discoveryResourcesSummary(7, 6, 1, now.Add(-time.Minute), now)),
+				),
+			}),
+		},
+	}
+
+	awsSummary := newDiscoverySummary([]*discoveryconfig.DiscoveryConfig{config}, cloudProviderConfig{aws: true})
+	require.Equal(t, []string{resourceKindAWSEC2}, resourceKinds(awsSummary[0].Servers[0].Integrations[0].Resources))
+
+	azureSummary := newDiscoverySummary([]*discoveryconfig.DiscoveryConfig{config}, cloudProviderConfig{azure: true})
+	require.Equal(t, []string{resourceKindAzureVM}, resourceKinds(azureSummary[0].Servers[0].Integrations[0].Resources))
+}
+
+func TestConfigSummaryStructuredOutputGolden(t *testing.T) {
+	t.Parallel()
+
+	lastRun := time.Date(2026, 1, 15, 11, 58, 0, 0, time.UTC)
+	lastUpdate := time.Date(2026, 1, 15, 11, 59, 0, 0, time.UTC)
+	syncStart := time.Date(2026, 1, 15, 11, 55, 0, 0, time.UTC)
+	syncEnd := time.Date(2026, 1, 15, 11, 56, 0, 0, time.UTC)
+	errorRun := time.Date(2026, 1, 15, 11, 55, 0, 0, time.UTC)
+
+	summaries := discoverySummary{
+		{
+			Name:           "healthy-config",
+			DiscoveryGroup: "prod",
+			State:          discoveryconfigv1.DiscoveryConfigState_DISCOVERY_CONFIG_STATE_RUNNING.String(),
+			LastSyncTime:   &lastRun,
+			Servers: []serverSummary{
+				{
+					ServerID:     "server-a",
+					PollInterval: "5m0s",
+					LastUpdate:   &lastUpdate,
+					Integrations: []integrationSummary{
+						{
+							Resources: []resourceResult{
+								{
+									Kind:      resourceKindAWSEC2,
+									Found:     10,
+									Enrolled:  8,
+									Failed:    2,
+									SyncStart: &syncStart,
+									SyncEnd:   &syncEnd,
+								},
+							},
+						},
+						{
+							Integration: "aws-prod",
+							Resources: []resourceResult{
+								{
+									Kind:      resourceKindAWSRDS,
+									Found:     5,
+									Enrolled:  4,
+									Failed:    1,
+									SyncStart: &syncStart,
+									SyncEnd:   &syncEnd,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			Name:           "error-config",
+			DiscoveryGroup: "prod",
+			State:          discoveryconfigv1.DiscoveryConfigState_DISCOVERY_CONFIG_STATE_ERROR.String(),
+			ErrorMessage:   "AccessDenied: missing ec2:DescribeInstances permission",
+			LastSyncTime:   &errorRun,
+		},
+	}
+
+	var jsonBuf bytes.Buffer
+	require.NoError(t, utils.WriteJSONArray(&jsonBuf, summaries))
+	require.Equal(t, `[
+    {
+        "name": "healthy-config",
+        "discovery_group": "prod",
+        "state": "DISCOVERY_CONFIG_STATE_RUNNING",
+        "last_sync_time": "2026-01-15T11:58:00Z",
+        "servers": [
+            {
+                "server_id": "server-a",
+                "poll_interval": "5m0s",
+                "last_update": "2026-01-15T11:59:00Z",
+                "integrations": [
+                    {
+                        "resources": [
+                            {
+                                "kind": "AWS EC2",
+                                "found": 10,
+                                "enrolled": 8,
+                                "failed": 2,
+                                "sync_start": "2026-01-15T11:55:00Z",
+                                "sync_end": "2026-01-15T11:56:00Z"
+                            }
+                        ]
+                    },
+                    {
+                        "integration": "aws-prod",
+                        "resources": [
+                            {
+                                "kind": "AWS RDS",
+                                "found": 5,
+                                "enrolled": 4,
+                                "failed": 1,
+                                "sync_start": "2026-01-15T11:55:00Z",
+                                "sync_end": "2026-01-15T11:56:00Z"
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    },
+    {
+        "name": "error-config",
+        "discovery_group": "prod",
+        "state": "DISCOVERY_CONFIG_STATE_ERROR",
+        "error_message": "AccessDenied: missing ec2:DescribeInstances permission",
+        "last_sync_time": "2026-01-15T11:55:00Z"
+    }
+]
+`, jsonBuf.String())
+
+	var yamlBuf bytes.Buffer
+	require.NoError(t, utils.WriteYAML(&yamlBuf, summaries))
+	require.Equal(t, `discovery_group: prod
+last_sync_time: "2026-01-15T11:58:00Z"
+name: healthy-config
+servers:
+- integrations:
+  - resources:
+    - enrolled: 8
+      failed: 2
+      found: 10
+      kind: AWS EC2
+      sync_end: "2026-01-15T11:56:00Z"
+      sync_start: "2026-01-15T11:55:00Z"
+  - integration: aws-prod
+    resources:
+    - enrolled: 4
+      failed: 1
+      found: 5
+      kind: AWS RDS
+      sync_end: "2026-01-15T11:56:00Z"
+      sync_start: "2026-01-15T11:55:00Z"
+  last_update: "2026-01-15T11:59:00Z"
+  poll_interval: 5m0s
+  server_id: server-a
+state: DISCOVERY_CONFIG_STATE_RUNNING
+---
+discovery_group: prod
+error_message: 'AccessDenied: missing ec2:DescribeInstances permission'
+last_sync_time: "2026-01-15T11:55:00Z"
+name: error-config
+state: DISCOVERY_CONFIG_STATE_ERROR
+`, yamlBuf.String())
+}
+
+func newTestDiscoveryConfig(t *testing.T, name, discoveryGroup string) *discoveryconfig.DiscoveryConfig {
+	t.Helper()
+
+	dc, err := discoveryconfig.NewDiscoveryConfig(
+		header.Metadata{Name: name},
+		discoveryconfig.Spec{DiscoveryGroup: discoveryGroup},
+	)
+	require.NoError(t, err)
+	return dc
+}
+
+func testServerStatus(lastUpdate time.Time, pollInterval time.Duration, integrationSummaries map[string]*discoveryconfigv1.DiscoverSummary) *discoveryconfig.DiscoveryStatusServer {
+	return &discoveryconfig.DiscoveryStatusServer{
+		DiscoveryStatusServer: discoveryconfigv1.DiscoveryStatusServer_builder{
+			LastUpdate:           timestamppb.New(lastUpdate),
+			PollInterval:         durationpb.New(pollInterval),
+			IntegrationSummaries: integrationSummaries,
+		}.Build(),
+	}
+}
+
+type discoverSummaryOption func(*discoveryconfigv1.DiscoverSummary_builder)
+
+func testDiscoverSummary(opts ...discoverSummaryOption) *discoveryconfigv1.DiscoverSummary {
+	builder := discoveryconfigv1.DiscoverSummary_builder{}
+	for _, opt := range opts {
+		opt(&builder)
+	}
+	return builder.Build()
+}
+
+func withPreviousEC2(summary *discoveryconfigv1.ResourcesDiscoveredSummary) discoverSummaryOption {
+	return func(builder *discoveryconfigv1.DiscoverSummary_builder) {
+		builder.AwsEc2 = testResourceSummary(summary, nil)
+	}
+}
+
+func withPreviousRDS(summary *discoveryconfigv1.ResourcesDiscoveredSummary) discoverSummaryOption {
+	return func(builder *discoveryconfigv1.DiscoverSummary_builder) {
+		builder.AwsRds = testResourceSummary(summary, nil)
+	}
+}
+
+func withPreviousAzureVM(summary *discoveryconfigv1.ResourcesDiscoveredSummary) discoverSummaryOption {
+	return func(builder *discoveryconfigv1.DiscoverSummary_builder) {
+		builder.AzureVms = testResourceSummary(summary, nil)
+	}
+}
+
+func withCurrentEKS(summary *discoveryconfigv1.ResourcesDiscoveredSummary) discoverSummaryOption {
+	return func(builder *discoveryconfigv1.DiscoverSummary_builder) {
+		builder.AwsEks = testResourceSummary(nil, summary)
+	}
+}
+
+func testResourceSummary(previous, current *discoveryconfigv1.ResourcesDiscoveredSummary) *discoveryconfigv1.ResourceSummary {
+	return discoveryconfigv1.ResourceSummary_builder{
+		Previous: previous,
+		Current:  current,
+	}.Build()
+}
+
+func discoveryResourcesSummary(found, enrolled, failed uint64, syncStart, syncEnd time.Time) *discoveryconfigv1.ResourcesDiscoveredSummary {
+	return discoveryconfigv1.ResourcesDiscoveredSummary_builder{
+		Found:     found,
+		Enrolled:  enrolled,
+		Failed:    failed,
+		SyncStart: timestamppb.New(syncStart),
+		SyncEnd:   timestamppb.New(syncEnd),
+	}.Build()
+}
+
+func requireConfigSummary(t *testing.T, summaries discoverySummary, name string) configSummary {
+	t.Helper()
+	for _, summary := range summaries {
+		if summary.Name == name {
+			return summary
+		}
+	}
+	require.FailNowf(t, "config summary not found", "name=%q", name)
+	return configSummary{}
+}
+
+func resourceKinds(resources []resourceResult) []string {
+	kinds := make([]string, 0, len(resources))
+	for _, resource := range resources {
+		kinds = append(kinds, resource.Kind)
+	}
+	return kinds
+}

--- a/tool/tctl/common/discovery/status_text.go
+++ b/tool/tctl/common/discovery/status_text.go
@@ -1,0 +1,135 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package discovery
+
+import (
+	"cmp"
+	"slices"
+
+	discoveryconfigv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/discoveryconfig/v1"
+	"github.com/gravitational/teleport/api/types/discoveryconfig"
+)
+
+const (
+	summaryStatusNotReporting = "not reporting yet"
+
+	resourceKindAWSEC2  = "AWS EC2"
+	resourceKindAWSRDS  = "AWS RDS"
+	resourceKindAWSEKS  = "AWS EKS"
+	resourceKindAzureVM = "Azure VM"
+)
+
+func newDiscoverySummary(configs []*discoveryconfig.DiscoveryConfig, cloudProviders cloudProviderConfig) discoverySummary {
+	out := make(discoverySummary, 0, len(configs))
+	for _, dc := range configs {
+		summary := configSummary{
+			Name:           dc.GetName(),
+			DiscoveryGroup: dc.Spec.DiscoveryGroup,
+			State:          dc.Status.State,
+			Servers:        buildServerSummaries(dc.Status.ServerStatus, cloudProviders),
+		}
+		if dc.Status.ErrorMessage != nil {
+			summary.ErrorMessage = *dc.Status.ErrorMessage
+		}
+		if !dc.Status.LastSyncTime.IsZero() {
+			summary.LastSyncTime = new(dc.Status.LastSyncTime)
+		}
+
+		out = append(out, summary)
+	}
+
+	slices.SortFunc(out, func(a, b configSummary) int {
+		return cmp.Compare(a.Name, b.Name)
+	})
+	return out
+}
+
+func buildServerSummaries(status map[string]*discoveryconfig.DiscoveryStatusServer, cloudProviders cloudProviderConfig) []serverSummary {
+	servers := make([]serverSummary, 0, len(status))
+	for serverID, serverStatus := range status {
+		server := serverSummary{
+			ServerID: serverID,
+		}
+		if serverStatus != nil && serverStatus.DiscoveryStatusServer != nil {
+			if pollInterval := serverStatus.GetPollInterval(); pollInterval != nil {
+				server.PollInterval = pollInterval.AsDuration().String()
+			}
+			if lastUpdate := serverStatus.GetLastUpdate(); lastUpdate != nil {
+				server.LastUpdate = new(lastUpdate.AsTime())
+			}
+			server.Integrations = buildIntegrationSummaries(serverStatus.GetIntegrationSummaries(), cloudProviders)
+		}
+		servers = append(servers, server)
+	}
+
+	slices.SortFunc(servers, func(a, b serverSummary) int {
+		return cmp.Compare(a.ServerID, b.ServerID)
+	})
+	return servers
+}
+
+func buildIntegrationSummaries(status map[string]*discoveryconfigv1.DiscoverSummary, cloudProviders cloudProviderConfig) []integrationSummary {
+	integrations := make([]integrationSummary, 0, len(status))
+	for integrationName, summary := range status {
+		integrations = append(integrations, integrationSummary{
+			Integration: integrationName,
+			Resources:   buildResourceResults(summary, cloudProviders),
+		})
+	}
+
+	slices.SortFunc(integrations, func(a, b integrationSummary) int {
+		return cmp.Compare(a.Integration, b.Integration)
+	})
+	return integrations
+}
+
+func buildResourceResults(summary *discoveryconfigv1.DiscoverSummary, cloudProviders cloudProviderConfig) []resourceResult {
+	var resources []resourceResult
+	if cloudProviders.aws {
+		addResourceResult(&resources, resourceKindAWSEC2, summary.GetAwsEc2())
+		addResourceResult(&resources, resourceKindAWSRDS, summary.GetAwsRds())
+		addResourceResult(&resources, resourceKindAWSEKS, summary.GetAwsEks())
+	}
+	if cloudProviders.azure {
+		addResourceResult(&resources, resourceKindAzureVM, summary.GetAzureVms())
+	}
+	return resources
+}
+
+func addResourceResult(resources *[]resourceResult, kind string, summary *discoveryconfigv1.ResourceSummary) {
+	previous := summary.GetPrevious()
+	if previous == nil {
+		return
+	}
+	*resources = append(*resources, newResourceResult(kind, previous))
+}
+
+func newResourceResult(kind string, summary *discoveryconfigv1.ResourcesDiscoveredSummary) resourceResult {
+	result := resourceResult{
+		Kind:     kind,
+		Found:    summary.GetFound(),
+		Enrolled: summary.GetEnrolled(),
+		Failed:   summary.GetFailed(),
+	}
+	if syncStart := summary.GetSyncStart(); syncStart != nil {
+		result.SyncStart = new(syncStart.AsTime())
+	}
+	if syncEnd := summary.GetSyncEnd(); syncEnd != nil {
+		result.SyncEnd = new(syncEnd.AsTime())
+	}
+	return result
+}


### PR DESCRIPTION
## Summary

Adds tctl discovery status (part of [#65608](https://github.com/gravitational/teleport/issues/65608)): fetches dynamic discovery_config resources and prints their auto-discovery status in a human and machine readable form.

Counts come from `discovery_config.status.server_status`, which reports per Discovery Service — a discovery group can have several, so results are shown per service (config → service → integration → resource kind) rather than collapsed into one. Configs with no Discovery Service running are flagged, since otherwise they look identical to "nothing found". Static `teleport.yaml` matchers don't report status and aren't included.

`text` humanizes values for readability; json/yaml keep raw machine-stable values (state enum, Go-duration poll interval, RFC3339 times).

changelog: Added the tctl discovery status command to show AWS and Azure auto-discovery configuration and enrollment status.

### Example output

`text` (default), a healthy config with two discovery targets:

```
Discovery config 70367dad-2b50-4b78-ab69-e0db65e4e624:
  Discovery group: cloud-discovery-group
  Status: syncing
  Last run: 4 minutes ago

  Service (33524d2c-de8f-4137-b1c9-6744fb01c567):
    Poll interval: 5 minutes
    Last update: 4 minutes ago
    mpm-68242-test:
      AWS EC2 discovery:
        Previous sync: 4 minutes ago (took 12s)
        Result: 2 found, 2 enrolled, 0 failed

  Service (fc39dc62-ff1e-4b08-94ed-f2bfc24adde0):
    Poll interval: 5 minutes
    Last update: 4 minutes ago
    mpm-68242-test:
      AWS EC2 discovery:
        Previous sync: 4 minutes ago (took 11s)
        Result: 2 found, 2 enrolled, 0 failed
```

A config using ambient credentials (no integration name):
```
Discovery config azure-prod-discovery:
  Discovery group: mpm-onboarding
  Status: syncing
  Last run: 1 minute ago

  Service (404ee56e-6c21-40c5-afad-23888d7902f5):
    Poll interval: 30 seconds
    Last update: 1 minute ago
    ambient credentials:
      Azure VM discovery:
        Previous sync: 1 minute ago (took 1s)
        Result: 0 found, 0 enrolled, 0 failed
```
A config with no Discovery Service running for its group:
```
Discovery config empty-config:
  Discovery group: prod
  Status: error
  Last run: 5 minutes ago
  Error: AccessDenied: missing ec2:DescribeInstances permission
  No Discovery Services running for prod. See https://goteleport.com/docs/reference/deployment/config/#discovery-service.
  ```
 ` --format json ` produces raw, machine-stable values, with ambient-credential results omitting the integration field:
 ```
 [
  {
    "name": "70367dad-2b50-4b78-ab69-e0db65e4e624",
    "discovery_group": "cloud-discovery-group",
    "state": "DISCOVERY_CONFIG_STATE_SYNCING",
    "last_sync_time": "2026-07-07T15:41:05.707995411Z",
    "servers": [
      {
        "server_id": "33524d2c-de8f-4137-b1c9-6744fb01c567",
        "poll_interval": "5m0s",
        "last_update": "2026-07-07T15:41:05.717201682Z",
        "integrations": [
          {
            "integration": "mpm-68242-test",
            "resources": [
              {
                "kind": "AWS EC2",
                "found": 2,
                "enrolled": 2,
                "failed": 0,
                "sync_start": "2026-07-07T15:40:53.765239598Z",
                "sync_end": "2026-07-07T15:41:05.707990797Z"
              }
            ]
          }
        ]
      }
    ]
  },
  {
    "name": "azure-prod-discovery",
    "discovery_group": "mpm-onboarding",
    "state": "DISCOVERY_CONFIG_STATE_SYNCING",
    "last_sync_time": "2026-07-07T15:42:19.423666783Z",
    "servers": [
      {
        "server_id": "404ee56e-6c21-40c5-afad-23888d7902f5",
        "poll_interval": "30s",
        "last_update": "2026-07-07T15:42:19.460271426Z",
        "integrations": [
          {
            "resources": [
              {
                "kind": "Azure VM",
                "found": 0,
                "enrolled": 0,
                "failed": 0,
                "sync_start": "2026-07-07T15:42:19.324559797Z",
                "sync_end": "2026-07-07T15:42:19.42366135Z"
              }
            ]
          }
        ]
      }
    ]
  }
]
```
<!-- Include manual testing efforts to verify the change. -->
<!-- Detail where the tests where run and what configurations were used. -->
<!-- Include all the test cases which were run to validate the change. -->

## Manual Test Plan
### Test Environment
Tested changes from this branch against: https://mpmonboarding.cloud.gravitational.io/

### Test Cases

- [x]  `text`, `json`, and `yaml` output all render against a cluster with configs reporting `server_status`.
- [x]  A config with multiple Discovery Services shows a separate `Service (<host id>)` block per service, each with its own results.
- [x]  Integration-backed results appear under the integration name; ambient-credential results appear under "ambient credentials".
- [x]  Multiple resource kinds under one integration render in a stable order (EC2, RDS, EKS, VM).
- [ ]  A config with no Discovery Service running for its group shows the warning and docs link.
- [x]  `--cloud aws` and `--cloud azure` restrict which resource kinds are shown; omitting `--cloud returns` both.
- [ ]  A cluster with only static `teleport.yaml` matchers (no dynamic `discovery_config`) prints the empty-state message.

## Backport
- [x] backport/branch/v18
