### PR TITLE
Azure Client Join: discard non-Microsoft hosted AIA intermediate CAs

### DIFF
--- a/lib/join/joinclient/join_azure.go
+++ b/lib/join/joinclient/join_azure.go
@@ -172,7 +172,9 @@ func getIntermediateChain(ctx context.Context, httpClient utils.HTTPDoClient, ad
 
 		url, err := validateAzureCertIssuerURL(cert.IssuingCertificateURL[0])
 		if err != nil {
-			return nil, trace.BadParameter("invalid cert issuer URL: %s", cert.IssuingCertificateURL[0])
+			// failing to validate the URL may not guarantee an invalid state, so we log, break out
+			// of the loop, and return the intermediates we've collected so far
+			break
 		}
 		if _, ok := seen[url]; ok {
 			return nil, trace.Errorf("found cycle in intermediate chain")

--- a/lib/join/joinclient/join_azure.go
+++ b/lib/join/joinclient/join_azure.go
@@ -172,6 +172,12 @@ func getIntermediateChain(ctx context.Context, httpClient utils.HTTPDoClient, ad
 
 		url, err := validateAzureCertIssuerURL(cert.IssuingCertificateURL[0])
 		if err != nil {
+			slog.InfoContext(ctx,
+				"failed to validate issuing certificate URL while joining with azure, continuing with existing chain",
+				"chain_length", len(seen),
+				"error", err,
+				"url", cert.IssuingCertificateURL[0],
+			)
 			// failing to validate the URL may not guarantee an invalid state, so we log, break out
 			// of the loop, and return the intermediates we've collected so far
 			break


### PR DESCRIPTION
The initial step of the Azure Joining procedure is to request attested data, using the IMDS endpoint in each instance.
This attested data contains the X.509 cert, which might have multiple intermediate CAs in the Authority Information Access (AIA).

When iterating over the intermediate CAs, we were, wrongly, checking whether the intermediate CA URL was part of Microsoft infra (ie, hosted in `www.microsoft.com`) before sending the data to the Auth Server.
Error when trying to join:
```
        runtime/asm_amd64.s:1771 runtime.goexit
User Message: getting intermediate CA for attested data
        invalid cert issuer URL: http://cacerts.digicert.com/DigiCertGlobalRootG2.crt] service/connect.go:102
2026-06-19T13:15:02.577Z WARN [UPLOAD:1]  The Instance connector is still not available, process-wide services will not function pid:1783.1 service/service.go:3994
```

This check was not suppose to happen, and was added in [linked](https://github.com/gravitational/teleport/pull/66727) PR.

Azure/Microsoft never documented that constraint.

We don't have this problem in v18, where the code looks like this:
https://github.com/gravitational/teleport/blob/a935b33d555d56c1a119040608b3539252ba0d06/lib/join/joinclient/join_azure.go#L174-L178

My best guess is that this was fixed during v18 tests but never forward ported


## Manual Test Plan
### Test Environment

Local

### Test Cases
- [x] Tested against a VM which did not present the DigiCert as intermediate CA in the attested data
