### PR TITLE
Set some reasonable defaults for load test node agent resources

### DIFF
--- a/assets/loadtest/helm/node-agent/values.yaml
+++ b/assets/loadtest/helm/node-agent/values.yaml
@@ -36,7 +36,10 @@ extraEnv: []
 
 # resource requirements for each container
 # https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.33/#resourcerequirements-v1-core
-resources: {}
+resources:
+  requests:
+    cpu: 5m
+    memory: 48Mi
 
 # Teleport labels
 labels: {}


### PR DESCRIPTION
Set some default node agent resource requests based on observed idle usage such that a load test with a large number of replicas does not completely overwhelm a single k8s node. Both CPU and memory are above the requirements at rest but I preferred to err on the side of caution as these will typically be short-lived and stability is more useful than cost for the duration of any given load test.