### PR TITLE
Add `aws` commands for IAM steps in four guides

### DIFF
--- a/docs/pages/enroll-resources/auto-discovery/servers/ec2-discovery/ec2-discovery-guided.mdx
+++ b/docs/pages/enroll-resources/auto-discovery/servers/ec2-discovery/ec2-discovery-guided.mdx
@@ -33,9 +33,13 @@ If you manage multiple AWS accounts in an AWS Organization, see [Organization-le
 
 - AWS account with EC2 instances and permissions to create and attach IAM
 policies.
-- EC2 instances running Ubuntu/Debian/RHEL/Amazon Linux 2/Amazon Linux 2023 and SSM agent version 3.1 or greater if making use of the
-default Teleport install script. (For other Linux distributions, you can
-install Teleport manually.)
+- EC2 instances to enroll with your Teleport cluster. These instances must be
+  running Ubuntu/Debian/RHEL/Amazon Linux 2/Amazon Linux 2023 and SSM agent
+  version 3.1 or greater if making use of the default Teleport install script.
+  (For other Linux distributions, you can install Teleport manually.)
+- An EC2 instance to run the Teleport Discovery Service. This instance must have
+  an instance profile. In this guide, we assume the instance role is called
+  `TeleportDiscoveryService`.
 - (!docs/pages/includes/tctl.mdx!)
 
 All EC2 instances that are to be added to the Teleport cluster by the Discovery
@@ -53,33 +57,44 @@ documentation](https://docs.aws.amazon.com/aws-managed-policy/latest/reference/A
 The `teleport discovery bootstrap` command will automate the process of
 defining and implementing IAM policies required to make auto-discovery work. It
 requires only a single pre-defined policy, attached to the EC2 instance running
-the command:
+the command.
 
-```json
-{
-    "Version": "2012-10-17",
-    "Statement": [
-        {
-            "Effect": "Allow",
-            "Action": [
-                "iam:GetPolicy",
-                "iam:TagPolicy",
-                "iam:ListPolicyVersions",
-                "iam:CreatePolicyVersion",
-                "iam:CreatePolicy",
-                "iam:GetRole",
-                "ssm:CreateDocument",
-                "iam:DeletePolicyVersion",
-                "iam:AttachRolePolicy",
-                "iam:PutRolePermissionsBoundary"
-            ],
-            "Resource": "*"
-        }
-    ]
-}
-```
+1. Create the following policy and save it to a file called
+   `discovery-service.json`:
 
-Create this policy and apply it to the Node (EC2 instance) that will run the Discovery Service.
+   ```json
+   {
+       "Version": "2012-10-17",
+       "Statement": [
+           {
+               "Effect": "Allow",
+               "Action": [
+                   "iam:GetPolicy",
+                   "iam:TagPolicy",
+                   "iam:ListPolicyVersions",
+                   "iam:CreatePolicyVersion",
+                   "iam:CreatePolicy",
+                   "iam:GetRole",
+                   "ssm:CreateDocument",
+                   "iam:DeletePolicyVersion",
+                   "iam:AttachRolePolicy",
+                   "iam:PutRolePermissionsBoundary"
+               ],
+               "Resource": "*"
+           }
+       ]
+   }
+   ```
+
+1. Create the policy, retrieving its ARN, and attach it to the Discovery Service
+   IAM role:
+
+   ```code
+   $ POLICY_ARN=$(aws iam create-policy --policy-name TeleportDiscoveryServicePolicy \
+     --policy-document file://discovery-service.json --query 'Policy.Arn' --output text)
+   $ aws iam attach-role-policy --role-name TeleportDiscoveryService \
+     --policy-arn ${POLICY_ARN}
+   ```
 
 ## Step 3/6. Install Teleport on the Discovery Node
 

--- a/docs/pages/enroll-resources/auto-discovery/servers/ec2-discovery/ec2-discovery-manual.mdx
+++ b/docs/pages/enroll-resources/auto-discovery/servers/ec2-discovery/ec2-discovery-manual.mdx
@@ -32,10 +32,14 @@ If you manage multiple AWS accounts in an AWS Organization, see [Organization-le
 (!docs/pages/includes/edition-prereqs-tabs.mdx!)
 
 - AWS account with EC2 instances and permissions to create and attach IAM
-policies.
-- EC2 instances running Ubuntu/Debian/RHEL/Amazon Linux 2/Amazon Linux 2023 and SSM agent version 3.1 or greater if making use of the
-default Teleport install script. (For other Linux distributions, you can
-install Teleport manually.)
+  policies.
+- EC2 instances to enroll with your Teleport cluster. These instances must be
+  running Ubuntu/Debian/RHEL/Amazon Linux 2/Amazon Linux 2023 and SSM agent
+  version 3.1 or greater if making use of the default Teleport install script.
+  (For other Linux distributions, you can install Teleport manually.)
+- An EC2 instance to run the Teleport Discovery Service. This instance must have
+  an instance profile. In this guide, we assume the instance role is called
+  `TeleportDiscoveryService`.
 - (!docs/pages/includes/tctl.mdx!)
 
 All EC2 instances that are to be added to the Teleport cluster by the Discovery
@@ -50,30 +54,43 @@ documentation](https://docs.aws.amazon.com/aws-managed-policy/latest/reference/A
 
 ## Step 2/5. Configure IAM policies
 
-Create the following policy and attach it to the EC2 instance that will run
-the Discovery Service:
+Authorize the EC2 instance that runs the Teleport Discovery Service to detect
+Linux servers running on your AWS infrastructure and install Teleport on them.
 
-```json
-{
-    "Version": "2012-10-17",
-    "Statement": [
-        {
-            "Effect": "Allow",
-            "Action": [
-                "account:ListRegions",
-                "ec2:DescribeInstances",
-                "ssm:DescribeInstanceInformation",
-                "ssm:GetCommandInvocation",
-                "ssm:ListCommandInvocations",
-                "ssm:SendCommand"
-            ],
-            "Resource": [
-                "*"
-            ]
-        }
-    ]
-}
-```
+1. Create the following policy and save it to a file called
+   `discovery-service.json`:
+
+   ```json
+   {
+       "Version": "2012-10-17",
+       "Statement": [
+           {
+               "Effect": "Allow",
+               "Action": [
+                   "account:ListRegions",
+                   "ec2:DescribeInstances",
+                   "ssm:DescribeInstanceInformation",
+                   "ssm:GetCommandInvocation",
+                   "ssm:ListCommandInvocations",
+                   "ssm:SendCommand"
+               ],
+               "Resource": [
+                   "*"
+               ]
+           }
+       ]
+   }
+   ```
+
+1. Create the policy, retrieving its ARN, and attach it to the Discovery Service
+   IAM role:
+
+   ```code
+   $ POLICY_ARN=$(aws iam create-policy --policy-name TeleportDiscoveryServicePolicy \
+     --policy-document file://discovery-service.json | jq -r '.Policy.Arn')
+   $ aws iam attach-role-policy --role-name TeleportDiscoveryService \
+     --policy-arn ${POLICY_ARN}
+   ```
 
 ## Step 3/5. Install Teleport on the Discovery Node
 

--- a/docs/pages/enroll-resources/database-access/getting-started.mdx
+++ b/docs/pages/enroll-resources/database-access/getting-started.mdx
@@ -31,8 +31,21 @@ page_type: how-to
 
 - An AWS account with a PostgreSQL Amazon Aurora database and permissions to create
   and attach IAM policies.
+
 - A host, e.g., an EC2 instance, where you will run the Teleport Database
   Service.
+
+- An AWS IAM principal for the host. For this guide, we assume that this is
+  either an instance profile or an IAM user. If you select an instance profile,
+  we assume the name of the attached role is `TeleportDatabaseServiceRole`. If
+  you select a user, we assume the name of the user is
+  `TeleportDatabaseServiceUser`.
+
+  You can provide the IAM credentials to Teleport through a shared configuration
+  file or environment variables. See
+  [Specifying Credentials](https://docs.aws.amazon.com/sdk-for-go/v2/developer-guide/configure-gosdk.html#specifying-credentials)
+  for details.
+
 - (!docs/pages/includes/tctl.mdx!)
 
 ## Step 1/5. Set up Aurora
@@ -48,48 +61,82 @@ Make sure to choose the "Standard create" database creation method and enable
 For existing Aurora instances, the status of IAM authentication is displayed on
 the Configuration tab and can be enabled by modifying the database instance.
 
-Next, create the following IAM policy and attach it to the AWS user or service
-account. The Teleport Database Service will need to use the credentials of this
-AWS user or service account in order to use this policy.
+Next, create an IAM policy and attach it to the AWS user or service account
+role. The Teleport Database Service will need to use the credentials of this AWS
+user or service account in order to use this policy.
 
-```json
-{
-   "Version": "2012-10-17",
-   "Statement": [
-      {
-         "Effect": "Allow",
-         "Action": [
-             "rds-db:connect"
-         ],
-         "Resource": [
-             "arn:aws:rds-db:<region>:<account-id>:dbuser:<resource-id>/*"
-         ]
-      }
-   ]
-}
-```
+1. Add the following to a file called `database-service-policy.json`:
 
-This policy allows any database account to connect to the Aurora instance specified
-with resource ID using IAM auth.
+   ```json
+   {
+      "Version": "2012-10-17",
+      "Statement": [
+         {
+            "Effect": "Allow",
+            "Action": [
+                "rds-db:connect"
+            ],
+            "Resource": [
+                "arn:aws:rds-db:<region>:<account-id>:dbuser:<resource-id>/*"
+            ]
+         }
+      ]
+   }
+   ```
 
-<Admonition
-  type="note"
-  title="Resource ID"
->
-  The database resource ID is shown on the Configuration tab of a particular
-  database instance in the RDS control panel, under "Resource id". For regular
-  RDS database it starts with `db-` prefix. For Aurora, use the database
-  cluster resource ID (`cluster-`), not the individual instance ID.
-</Admonition>
+   This policy allows the Teleport Database Service to connect to the Aurora
+   instance as any database user using IAM auth.
 
-Finally, connect to the database and create a database account with IAM auth
-support (or update an existing one). Once connected, execute the following
-SQL statements to create a new database account and allow IAM auth for it:
+   <Admonition
+     type="note"
+     title="Resource ID"
+   >
+     The database resource ID is shown on the Configuration tab of a particular
+     database instance in the RDS control panel, under "Resource id". For regular
+     RDS database it starts with `db-` prefix. For Aurora, use the database
+     cluster resource ID (`cluster-`), not the individual instance ID.
+   </Admonition>
 
-```sql
-CREATE USER alice;
-GRANT rds_iam TO alice;
-```
+1. Create the policy:
+
+   ```code
+   $ aws iam create-policy --policy-name RDSConnect \
+        --policy-document file://database-service-policy.json
+   ```
+
+1. Note the ARN of the policy you created for the next section. Assign it to
+   <Var name="policy ARN" />.
+
+1. Attach the `RDSConnect` policy to either an EC2 instance role or an IAM user:
+
+   <Tabs>
+   <TabItem label="EC2 instance">
+
+   ```code
+   $ aws iam attach-role-policy --role-name TeleportDatabaseServiceRole \
+        --policy-arn <Var name="policy ARN" />
+   ```
+
+   </TabItem>
+   <TabItem label="IAM user">
+
+   ```code
+   $ aws iam attach-user-policy --user-name TeleportDatabaseServiceUser \
+        --policy-arn <Var name="policy ARN" />
+   ```
+
+   </TabItem>
+   </Tabs>
+
+1. Connect to the database and create a database account with IAM auth support
+   (or update an existing one). Once connected, execute the following SQL
+   statements to create a new database account and allow IAM auth for it:
+
+   ```sql
+   CREATE USER alice;
+   GRANT rds_iam TO alice;
+   ```
+
 For more information about connecting to the PostgreSQL instance directly,
 see the AWS [documentation](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_ConnectToPostgreSQLInstance.html).
 

--- a/docs/pages/installation/agents/aws-ec2.mdx
+++ b/docs/pages/installation/agents/aws-ec2.mdx
@@ -46,10 +46,21 @@ Teleport processes joining the cluster.
 (!docs/pages/includes/edition-prereqs-tabs.mdx edition="self-hosted Teleport"!)
 
 - (!docs/pages/includes/iac-clients.mdx!)
+
 - An AWS EC2 instance to host a Teleport process, with the Teleport binary
   installed. The host should not have an existing data dir (`/var/lib/teleport`
   by default). Remove the data directory if this instance has previously joined
   a Teleport cluster.
+
+- An AWS IAM principal for the Teleport Auth Service. This can either be an
+  instance profile or an IAM user. If you select an instance profile, we assume
+  the name of the attached role is `TeleportAuthServiceRole`. If you select a
+  user, we assume the name of the user is `TeleportAuthServiceUser`.
+
+  You can provide the IAM credentials to Teleport through a shared configuration
+  file or environment variables. See
+  [Specifying Credentials](https://docs.aws.amazon.com/sdk-for-go/v2/developer-guide/configure-gosdk.html#specifying-credentials)
+  for details.
 
 ## Step 1/5. Set up AWS IAM credentials
 
@@ -60,37 +71,52 @@ currently running.
 ### Create the IAM policy
 
 Create the following AWS IAM policy named `teleport-DescribeInstances-policy` in
-your account:
+your account.
 
-```json
-{
-   "Version": "2012-10-17",
-   "Statement": [
-	   {
-		   "Effect": "Allow",
-		   "Action": "ec2:DescribeInstances",
-		   "Resource": "*"
-	   }
-   ]
-}
-```
+1. Add the following to a file named `describe-instances.json`:
+
+   ```json
+   {
+      "Version": "2012-10-17",
+      "Statement": [
+   	   {
+   		   "Effect": "Allow",
+   		   "Action": "ec2:DescribeInstances",
+   		   "Resource": "*"
+   	   }
+      ]
+   }
+   ```
+
+1. Create the policy:
+
+   ```code
+   $ aws iam create-policy --policy-name teleport-DescribeInstances-policy \
+        --policy-document file://describe-instances.json
+   ```
+
+1. Note the ARN of the policy you created for the next section. Assign it to
+   <Var name="policy ARN" />.
 
 ### Attach the IAM policy
 
 If your Teleport Auth Service is running on an EC2 instance and already has an
 attached "IAM role for Amazon EC2", add the above
-`teleport-DescribeInstances-policy` to the existing role. If the instance
-does not already have an attached role, create an IAM role with the above
-policy and attach it to your EC2 instance running the Teleport Auth Service.
+`teleport-DescribeInstances-policy` to the existing role:
+
+```code
+$ aws iam attach-role-policy --role-name TeleportAuthServiceRole \
+     --policy-arn <Var name="policy ARN" />
+```
 
 If you are running your Teleport Auth Service outside of AWS you can attach
 the `teleport-DescribeInstances-policy` directly to an IAM user which
-Teleport will use to authenticate.
+Teleport will use to authenticate:
 
-You can provide the IAM credentials to Teleport through a shared configuration
-file or environment variables. See
-[Specifying Credentials](https://docs.aws.amazon.com/sdk-for-go/v2/developer-guide/configure-gosdk.html#specifying-credentials)
-for details.
+```code
+$ aws iam attach-user-policy --user-name TeleportAuthServiceUser \
+     --policy-arn <Var name="policy ARN" />
+```
 
 ## Step 2/5. Create the AWS joining token
 


### PR DESCRIPTION
Help us standardize on, in how-to guides, ensuring that CLI users such as AI agents can easily follow the steps in the body of each guide. In four guides, add `aws` commands to create IAM policies and attach them to principals. While users can likely follow these steps without the command examples, the commands allow them to do so with less friction and thought.

This change edits the following guides:

- Guided and manual EC2 instance discovery guides
- Database enrollment getting started guide
- AWS EC2 join method guide