### PR TITLE
MCP: Fix HTTPS support for SSE

### DIFF
--- a/integration/appaccess/appaccess_test.go
+++ b/integration/appaccess/appaccess_test.go
@@ -58,20 +58,38 @@ import (
 // It allows to make the entire cluster set up once, instead of per test,
 // which speeds things up significantly.
 func TestAppAccess(t *testing.T) {
-	// Enable MCP test servers.
-	sseServerURL := mcptest.MustStartSSETestServer(t)
-	streamableHTTPServer := mcpserver.NewTestStreamableHTTPServer(mcptest.NewServer())
-	streamableHTTPServerURL := fmt.Sprintf("mcp+%s/mcp", streamableHTTPServer.URL)
+	sseServer := httptest.NewTLSServer(mcpserver.NewSSEServer(mcptest.NewServer()))
+	sseServerURL := "mcp+sse+" + sseServer.URL + "/sse"
+	t.Cleanup(sseServer.Close)
+
+	sseTLSServer := httptest.NewTLSServer(mcpserver.NewSSEServer(mcptest.NewServer()))
+	sseTLSServerURL := "mcp+sse+" + sseTLSServer.URL + "/sse"
+	t.Cleanup(sseTLSServer.Close)
+
+	streamableHTTPServer := httptest.NewServer(mcpserver.NewStreamableHTTPServer(mcptest.NewServer()))
+	streamableHTTPServerURL := "mcp+" + streamableHTTPServer.URL + "/mcp"
+	t.Cleanup(streamableHTTPServer.Close)
+
+	streamableHTTPTLSServer := httptest.NewTLSServer(mcpserver.NewStreamableHTTPServer(mcptest.NewServer()))
+	streamableHTTPTLSServerURL := "mcp+" + streamableHTTPTLSServer.URL + "/mcp"
 	t.Cleanup(streamableHTTPServer.Close)
 
 	extraApps := []servicecfg.App{
 		{
 			Name: "test-sse",
-			URI:  "mcp+sse+" + sseServerURL,
+			URI:  sseServerURL,
+		},
+		{
+			Name: "test-sse-https",
+			URI:  sseTLSServerURL,
 		},
 		{
 			Name: "test-http",
 			URI:  streamableHTTPServerURL,
+		},
+		{
+			Name: "test-https",
+			URI:  streamableHTTPTLSServerURL,
 		},
 	}
 

--- a/integration/appaccess/mcp_test.go
+++ b/integration/appaccess/mcp_test.go
@@ -53,6 +53,10 @@ func testMCP(pack *Pack, t *testing.T) {
 		testMCPDialStdioToSSE(t, pack, "test-sse")
 	})
 
+	t.Run("stdio to sse over HTTPS success", func(t *testing.T) {
+		testMCPDialStdioToSSE(t, pack, "test-sse-https")
+	})
+
 	t.Run("proxy streamable HTTP success", func(t *testing.T) {
 		testMCPProxyStreamableHTTP(t, pack, "test-http")
 	})

--- a/integration/appaccess/mcp_test.go
+++ b/integration/appaccess/mcp_test.go
@@ -61,8 +61,16 @@ func testMCP(pack *Pack, t *testing.T) {
 		testMCPProxyStreamableHTTP(t, pack, "test-http")
 	})
 
+	t.Run("proxy streamable HTTP over HTTPS success", func(t *testing.T) {
+		testMCPProxyStreamableHTTP(t, pack, "test-https")
+	})
+
 	t.Run("stdio to streamable HTTP success", func(t *testing.T) {
 		testMCPStdioToStreamableHTTP(t, pack, "test-http")
+	})
+
+	t.Run("stdio to streamable HTTP over HTTPS success", func(t *testing.T) {
+		testMCPStdioToStreamableHTTP(t, pack, "test-https")
 	})
 }
 

--- a/lib/srv/mcp/sse.go
+++ b/lib/srv/mcp/sse.go
@@ -114,10 +114,10 @@ func makeSSEBaseURI(app types.Application) (*url.URL, error) {
 		return nil, trace.Wrap(err, "parsing SSE URI")
 	}
 	switch {
-	case strings.HasPrefix(app.GetURI(), types.SchemeMCPSSEHTTP):
-		baseURL.Scheme = "http"
 	case strings.HasPrefix(app.GetURI(), types.SchemeMCPSSEHTTPS):
 		baseURL.Scheme = "https"
+	case strings.HasPrefix(app.GetURI(), types.SchemeMCPSSEHTTP):
+		baseURL.Scheme = "http"
 	default:
 		return nil, trace.BadParameter("unknown scheme type: %v", baseURL.Scheme)
 	}

--- a/lib/srv/mcp/sse.go
+++ b/lib/srv/mcp/sse.go
@@ -114,10 +114,10 @@ func makeSSEBaseURI(app types.Application) (*url.URL, error) {
 		return nil, trace.Wrap(err, "parsing SSE URI")
 	}
 	switch {
-	case strings.HasPrefix(app.GetURI(), types.SchemeMCPSSEHTTPS):
-		baseURL.Scheme = "https"
-	case strings.HasPrefix(app.GetURI(), types.SchemeMCPSSEHTTP):
+	case strings.HasPrefix(app.GetURI(), types.SchemeMCPSSEHTTP+"://"):
 		baseURL.Scheme = "http"
+	case strings.HasPrefix(app.GetURI(), types.SchemeMCPSSEHTTPS+"://"):
+		baseURL.Scheme = "https"
 	default:
 		return nil, trace.BadParameter("unknown scheme type: %v", baseURL.Scheme)
 	}


### PR DESCRIPTION
Changelog: Fix configuring HTTPS SSE MCP servers. Before the fix they were treated as HTTP SSE servers.

## Backports

- https://github.com/gravitational/teleport/pull/68058

## Manual Test Plan
### Test Environment

- Local Teleport cluster
- Local MCP server with a callable tool serving SSE transport over HTTPS

Server configuration:

 ```yaml
   - name: "my-mcp-server"
     uri: "mcp+sse+https://127.0.0.1:9000"
     labels:
       env: dev
 ```

### Test Cases
- [x] Call an MCP tool and verify there is some content.
