### PR TITLE
Remove prerelease note from 18.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,6 @@
 
 ## 18.9.0 (06/16/26)
 
-Pre-releases of Teleport (versions with suffixes like -alpha, -beta, -rc) should not be run in production environments.
-
 ### Device Bound Session Credentials for App Access
 
 Application access session cookies are now compatible with Google's Device Bound


### PR DESCRIPTION
Just noticed that I forgot to remove the "prerelease" note when converting 18.9.0-rc to 18.9.0.
