### PR TITLE
[v18] scope-qualified names

### DIFF
--- a/docs/pages/reference/cli/tctl.mdx
+++ b/docs/pages/reference/cli/tctl.mdx
@@ -1141,13 +1141,14 @@ Edit a Teleport resource.
 Usage:
 
 ```code
-$ tctl edit [<resource type/resource name>]
+$ tctl edit [<resource type/resource name>] [<id>]
 ```
 
 Arguments:
 
 |Argument|Default|Description|
 |---|---|---|
+|id|*no default* (optional)|Resource identifier: scope-qualified name (e.g. "/staging/west::myrole") or bare name for unscoped kinds|
 |resource type/resource name|*no default* (optional)|Resource to update, e.g., "user/myuser"|
 
 ## tctl get
@@ -1157,7 +1158,7 @@ Print a YAML declaration of various Teleport resources.
 Usage:
 
 ```code
-$ tctl get [<flags>] <resources>
+$ tctl get [<flags>] <resources> [<id>]
 ```
 
 Flags:
@@ -1172,6 +1173,7 @@ Arguments:
 
 |Argument|Default|Description|
 |---|---|---|
+|id|*no default* (optional)|Resource identifier: scope-qualified name (e.g. "/staging/west::myrole") or bare name for unscoped kinds|
 |resources|*no default* (required)|Resource spec: 'type/\[name\]\[,...\]' or 'all'|
 
 ## tctl help
@@ -1973,13 +1975,14 @@ Delete a resource.
 Usage:
 
 ```code
-$ tctl rm [<resource type/resource name>]
+$ tctl rm [<resource type/resource name>] [<id>]
 ```
 
 Arguments:
 
 |Argument|Default|Description|
 |---|---|---|
+|id|*no default* (optional)|Resource identifier: scope-qualified name (e.g. "/staging/west::myrole") or bare name for unscoped kinds|
 |resource type/resource name|*no default* (optional)|Resource to delete
 	\<resource type\>  Type of a resource \[for example: connector,user,cluster,token\]
 	\<resource name\>  Resource name to delete
@@ -2358,7 +2361,7 @@ Update resource fields.
 Usage:
 
 ```code
-$ tctl update [<flags>] [<resource type/resource name>]
+$ tctl update [<flags>] [<resource type/resource name>] [<id>]
 ```
 
 Flags:
@@ -2372,6 +2375,7 @@ Arguments:
 
 |Argument|Default|Description|
 |---|---|---|
+|id|*no default* (optional)|Resource identifier: scope-qualified name (e.g. "/staging/west::myrole") or bare name for unscoped kinds|
 |resource type/resource name|*no default* (optional)|Resource to update
 	\<resource type\>  Type of a resource \[for example: rc\]
 	\<resource name\>  Resource name to update

--- a/fuzz/oss-fuzz-build.sh
+++ b/fuzz/oss-fuzz-build.sh
@@ -128,6 +128,11 @@ build_teleport_fuzzers() {
   compile_native_go_fuzzer $TELEPORT_PREFIX/lib/multiplexer \
     FuzzReadProxyLineV2 fuzz_read_proxy_linec_v2
 
+  compile_native_go_fuzzer $TELEPORT_PREFIX/lib/scopes \
+    FuzzParseQualifiedName fuzz_parse_qualified_name
+
+  compile_native_go_fuzzer $TELEPORT_PREFIX/lib/scopes \
+    FuzzValidateQualifiedName fuzz_validate_qualified_name
 }
 
 build_teleport_api_fuzzers() {

--- a/lib/scopes/fuzz_test.go
+++ b/lib/scopes/fuzz_test.go
@@ -1,0 +1,101 @@
+/*
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package scopes
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// FuzzParseQualifiedName verifies that ParseQualifiedName never panics and that
+// any successfully parsed value round-trips through String() unchanged.
+func FuzzParseQualifiedName(f *testing.F) {
+	// valid SQNs
+	f.Add("/staging/west::myrole")
+	f.Add("/staging::myrole")
+	f.Add("/::myrole")
+	f.Add("/staging::my-role")
+	f.Add("/staging::318ea8be-129c-41f4-ad95-fd830e14e3e7")
+	// multiple separators — splits on first
+	f.Add("/staging::my::role")
+	// invalid but parseable
+	f.Add("staging::myrole")
+	// parse errors
+	f.Add("")
+	f.Add("::")
+	f.Add("::myrole")
+	f.Add("/staging::")
+	f.Add("no-separator")
+	f.Add("/staging/west::my role")
+
+	f.Fuzz(func(t *testing.T, sqn string) {
+		var qn QualifiedName
+		var err error
+		require.NotPanics(t, func() { qn, err = ParseQualifiedName(sqn) })
+		if err != nil {
+			return
+		}
+
+		// round-trip: String() must re-parse to the same value
+		require.NotPanics(t, func() {
+			qn2, err2 := ParseQualifiedName(qn.String())
+			require.NoError(t, err2, "String() of a parsed QualifiedName must re-parse without error")
+			require.Equal(t, qn, qn2, "String() of a parsed QualifiedName must round-trip to an identical value")
+		})
+	})
+}
+
+// FuzzValidateQualifiedName verifies that neither validate function panics, and that
+// strong validation passing implies weak validation passing.
+func FuzzValidateQualifiedName(f *testing.F) {
+	// valid under both
+	f.Add("/staging/west::myrole")
+	f.Add("/staging::myrole")
+	f.Add("/::myrole")
+	f.Add("/staging::my-role")
+	f.Add("/staging::318ea8be-129c-41f4-ad95-fd830e14e3e7")
+	// valid under weak only
+	f.Add("staging::myrole")
+	f.Add("/Staging/west::myrole")
+	f.Add("/staging::MyRole")
+	f.Add("/a/west::myrole")
+	f.Add("/staging::x")
+	// invalid under both
+	f.Add("")
+	f.Add("::")
+	f.Add("::myrole")
+	f.Add("/staging::")
+	f.Add("no-separator")
+	f.Add("/staging::my role")
+	f.Add("/stag@ing::myrole")
+	f.Add("/staging::my::role")
+
+	f.Fuzz(func(t *testing.T, sqn string) {
+		var strongErr, weakErr error
+
+		require.NotPanics(t, func() { strongErr = StrongValidateQualifiedName(sqn) })
+		require.NotPanics(t, func() { weakErr = WeakValidateQualifiedName(sqn) })
+
+		// strong passing must imply weak passing
+		if strongErr == nil {
+			require.NoError(t, weakErr, "StrongValidateQualifiedName passed but WeakValidateQualifiedName failed for %q", sqn)
+		}
+	})
+}

--- a/lib/scopes/qualified.go
+++ b/lib/scopes/qualified.go
@@ -1,0 +1,141 @@
+/*
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package scopes
+
+import (
+	"strings"
+
+	"github.com/gravitational/trace"
+)
+
+// QualifiedNameSeparator is the separator between scope and name in a
+// scope-qualified name. This separator must never appear in scope segements.
+const QualifiedNameSeparator = "::"
+
+// QualifiedName pairs a scope with a resource name to uniquely identify a scoped
+// resource. The canonical form of a scope-qualified name (SQN) is "<scope>::<name>",
+// e.g. "/staging/west::myrole". SQNs take the place of bare names in configuration
+// resource specs, CLI interfaces, and user-facing messages (e.g. errors) where it
+// is necessary to fully specify the unique identifier of a scoped resource. Internally,
+// teleport APIs should generally continue to use separate scope and name fields, as
+// should structured logs/events.
+type QualifiedName struct {
+	// Scope is the resource's scope path, e.g. "/staging/west".
+	Scope string
+	// Name is the resource's name within its scope, e.g. "myrole".
+	Name string
+}
+
+// String returns encodes the string representation of the QualifiedName.
+func (q QualifiedName) String() string {
+	return q.Scope + QualifiedNameSeparator + q.Name
+}
+
+// StrongValidate validates this QualifiedName using strong validation rules. This method
+// *must* be called on all QualifiedName values derived from user input and/or cluster-external
+// sources. Use [QualifiedName.WeakValidate] when checking values from the control plane in
+// logic that may run agent-side.
+func (q QualifiedName) StrongValidate() error {
+	if err := StrongValidate(q.Scope); err != nil {
+		return trace.BadParameter("scope-qualified name %q has invalid scope: %v", q, err)
+	}
+
+	if err := StrongValidateSegment(q.Name); err != nil {
+		return trace.BadParameter("scope-qualified name %q has invalid name: %v", q, err)
+	}
+
+	// as an extra precaution, also run all weak checks just to be certain we didn't accidentally
+	// construct a weak check that rejects something that would otherwise pass a strong check.
+	if err := q.WeakValidate(); err != nil {
+		return trace.Wrap(err)
+	}
+
+	return nil
+}
+
+// WeakValidate performs a weak form of validation on this QualifiedName. This is useful for
+// ensuring that values received from trusted sources (e.g. the control plane) haven't been
+// altered beyond our ability to reason effectively about them. Prefer [QualifiedName.StrongValidate]
+// for values derived from external sources (e.g. user input).
+func (q QualifiedName) WeakValidate() error {
+	if err := WeakValidate(q.Scope); err != nil {
+		return trace.BadParameter("scope-qualified name %q has invalid scope: %v", q, err)
+	}
+
+	if err := WeakValidateSegment(q.Name); err != nil {
+		return trace.BadParameter("scope-qualified name %q has invalid name: %v", q, err)
+	}
+
+	return nil
+}
+
+// ParseQualifiedName parses a scope-qualified name string into its scope and name
+// components by splitting on the first occurrence of "::". Returns an error if the
+// separator is absent or either component is empty. This function does not validate
+// the format of the scope or name components; use [QualifiedName.StrongValidate] or
+// [QualifiedName.WeakValidate] for validation.
+func ParseQualifiedName(sqn string) (QualifiedName, error) {
+	idx := strings.Index(sqn, QualifiedNameSeparator)
+	if idx < 0 {
+		return QualifiedName{}, trace.BadParameter("scope-qualified name %q missing %q separator", sqn, QualifiedNameSeparator)
+	}
+
+	scope := sqn[:idx]
+	name := sqn[idx+len(QualifiedNameSeparator):]
+
+	if scope == "" {
+		return QualifiedName{}, trace.BadParameter("scope-qualified name %q has empty scope component", sqn)
+	}
+
+	if name == "" {
+		return QualifiedName{}, trace.BadParameter("scope-qualified name %q has empty name component", sqn)
+	}
+
+	return QualifiedName{Scope: scope, Name: name}, nil
+}
+
+// StrongValidateQualifiedName validates a scope-qualified name string using strong validation
+// rules. This function *must* be called on all scope-qualified name values received from
+// user input and/or cluster-external sources. Use [WeakValidateQualifiedName] when
+// checking values from the control plane in logic that may run agent-side.
+//
+// Prefer parsing with [ParseQualifiedName] and then calling [QualifiedName.StrongValidate]
+// directly when the parsed value is needed, to avoid parsing twice.
+func StrongValidateQualifiedName(sqn string) error {
+	qn, err := ParseQualifiedName(sqn)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	return qn.StrongValidate()
+}
+
+// WeakValidateQualifiedName performs a weak form of validation on a scope-qualified name string.
+// This is useful for ensuring that values received from trusted sources (e.g. the control
+// plane) haven't been altered beyond our ability to reason effectively about them. Prefer
+// [StrongValidateQualifiedName] for values received from external sources (e.g. user input).
+//
+// Prefer parsing with [ParseQualifiedName] and then calling [QualifiedName.WeakValidate]
+// directly when the parsed value is needed, to avoid parsing twice.
+func WeakValidateQualifiedName(sqn string) error {
+	qn, err := ParseQualifiedName(sqn)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	return qn.WeakValidate()
+}

--- a/lib/scopes/qualified_test.go
+++ b/lib/scopes/qualified_test.go
@@ -1,0 +1,299 @@
+/*
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package scopes
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestQualifiedNameRoundTrip verifies encoding/decoding of scope-qualified names,
+// including cases that parse successfully but fail strong or weak validation.
+func TestQualifiedNameRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	tts := []struct {
+		name      string
+		scope     string
+		rname     string
+		sqn       string
+		strongErr bool
+		weakErr   bool
+	}{
+		{
+			name:  "basic",
+			scope: "/staging/west",
+			rname: "myrole",
+			sqn:   "/staging/west::myrole",
+		},
+		{
+			name:  "single-segment scope",
+			scope: "/staging",
+			rname: "myrole",
+			sqn:   "/staging::myrole",
+		},
+		{
+			name:  "root scope",
+			scope: "/",
+			rname: "myrole",
+			sqn:   "/::myrole",
+		},
+		{
+			name:  "hyphenated name",
+			scope: "/staging/west",
+			rname: "my-role",
+			sqn:   "/staging/west::my-role",
+		},
+		{
+			name:  "uuid name",
+			scope: "/staging",
+			rname: "318ea8be-129c-41f4-ad95-fd830e14e3e7",
+			sqn:   "/staging::318ea8be-129c-41f4-ad95-fd830e14e3e7",
+		},
+		{
+			name:      "multiple separators split on first",
+			scope:     "/staging",
+			rname:     "my::role",
+			sqn:       "/staging::my::role",
+			strongErr: true,
+		},
+		{
+			name:      "scope without leading slash",
+			scope:     "staging",
+			rname:     "myrole",
+			sqn:       "staging::myrole",
+			strongErr: true,
+		},
+		{
+			name:      "name with breaking character",
+			scope:     "/staging",
+			rname:     "my role",
+			sqn:       "/staging::my role",
+			strongErr: true,
+			weakErr:   true,
+		},
+	}
+
+	for _, tt := range tts {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if tt.strongErr {
+				require.Error(t, StrongValidateQualifiedName(tt.sqn))
+			} else {
+				require.NoError(t, StrongValidateQualifiedName(tt.sqn))
+			}
+
+			if tt.weakErr {
+				require.Error(t, WeakValidateQualifiedName(tt.sqn))
+			} else {
+				require.NoError(t, WeakValidateQualifiedName(tt.sqn))
+			}
+
+			require.Equal(t, tt.sqn, QualifiedName{Scope: tt.scope, Name: tt.rname}.String())
+
+			qn, err := ParseQualifiedName(tt.sqn)
+			require.NoError(t, err)
+			require.Equal(t, tt.scope, qn.Scope)
+			require.Equal(t, tt.rname, qn.Name)
+		})
+	}
+}
+
+// TestParseQualifiedNameErrors verifies expected error cases for ParseQualifiedName.
+func TestParseQualifiedNameErrors(t *testing.T) {
+	t.Parallel()
+
+	tts := []struct {
+		name string
+		sqn  string
+	}{
+		{
+			name: "no separator",
+			sqn:  "staging-west-myrole",
+		},
+		{
+			name: "empty scope",
+			sqn:  "::myrole",
+		},
+		{
+			name: "empty name",
+			sqn:  "/staging/west::",
+		},
+		{
+			name: "empty string",
+			sqn:  "",
+		},
+		{
+			name: "separator only",
+			sqn:  "::",
+		},
+	}
+
+	for _, tt := range tts {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := ParseQualifiedName(tt.sqn)
+			require.Error(t, err)
+			require.Error(t, WeakValidateQualifiedName(tt.sqn))
+			require.Error(t, StrongValidateQualifiedName(tt.sqn))
+		})
+	}
+}
+
+func TestValidateQualifiedName(t *testing.T) {
+	t.Parallel()
+
+	tts := []struct {
+		name     string
+		sqn      string
+		strongOk bool
+		weakOk   bool
+	}{
+		{
+			name:     "basic valid",
+			sqn:      "/staging/west::myrole",
+			strongOk: true,
+			weakOk:   true,
+		},
+		{
+			name:     "root scope",
+			sqn:      "/::myrole",
+			strongOk: true,
+			weakOk:   true,
+		},
+		{
+			name:     "single-segment scope",
+			sqn:      "/staging::myrole",
+			strongOk: true,
+			weakOk:   true,
+		},
+		{
+			name:     "hyphenated name",
+			sqn:      "/staging::my-role",
+			strongOk: true,
+			weakOk:   true,
+		},
+		{
+			name:     "uuid name",
+			sqn:      "/staging::318ea8be-129c-41f4-ad95-fd830e14e3e7",
+			strongOk: true,
+			weakOk:   true,
+		},
+		{
+			name:     "scope with breaking char",
+			sqn:      "/stag@ing::myrole",
+			strongOk: false,
+			weakOk:   false,
+		},
+		{
+			name:     "scope with space",
+			sqn:      "/stag ing::myrole",
+			strongOk: false,
+			weakOk:   false,
+		},
+		{
+			name:     "uppercase scope segment",
+			sqn:      "/Staging/west::myrole",
+			strongOk: false,
+			weakOk:   true,
+		},
+		{
+			name:     "scope segment too short",
+			sqn:      "/a/west::myrole",
+			strongOk: false,
+			weakOk:   true,
+		},
+		{
+			name:     "missing leading slash in scope",
+			sqn:      "staging::myrole",
+			strongOk: false,
+			weakOk:   true,
+		},
+		{
+			name:     "name with breaking char",
+			sqn:      "/staging::my@role",
+			strongOk: false,
+			weakOk:   false,
+		},
+		{
+			name:     "name with whitespace",
+			sqn:      "/staging::my role",
+			strongOk: false,
+			weakOk:   false,
+		},
+		{
+			name:     "name with slash",
+			sqn:      "/staging::my/role",
+			strongOk: false,
+			weakOk:   false,
+		},
+		{
+			name:     "uppercase name",
+			sqn:      "/staging::MyRole",
+			strongOk: false,
+			weakOk:   true,
+		},
+		{
+			name:     "name too short",
+			sqn:      "/staging::x",
+			strongOk: false,
+			weakOk:   true,
+		},
+		{
+			name:     "no separator",
+			sqn:      "/staging-myrole",
+			strongOk: false,
+			weakOk:   false,
+		},
+		{
+			name:     "empty scope component",
+			sqn:      "::myrole",
+			strongOk: false,
+			weakOk:   false,
+		},
+		{
+			name:     "empty name component",
+			sqn:      "/staging::",
+			strongOk: false,
+			weakOk:   false,
+		},
+	}
+
+	for _, tt := range tts {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := StrongValidateQualifiedName(tt.sqn)
+			if tt.strongOk {
+				require.NoError(t, err)
+			} else {
+				require.Error(t, err)
+			}
+
+			err = WeakValidateQualifiedName(tt.sqn)
+			if tt.weakOk {
+				require.NoError(t, err)
+			} else {
+				require.Error(t, err)
+			}
+		})
+	}
+}

--- a/tool/tctl/common/collection.go
+++ b/tool/tctl/common/collection.go
@@ -19,7 +19,6 @@
 package common
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -43,7 +42,6 @@ import (
 	healthcheckconfigv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/healthcheckconfig/v1"
 	loginrulepb "github.com/gravitational/teleport/api/gen/proto/go/teleport/loginrule/v1"
 	machineidv1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/machineid/v1"
-	joiningv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/joining/v1"
 	userprovisioningpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/userprovisioning/v2"
 	usertasksv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/usertasks/v1"
 	"github.com/gravitational/teleport/api/gen/proto/go/teleport/vnet/v1"
@@ -2126,45 +2124,6 @@ type autoUpdateBotInstanceReportCollection struct {
 
 func (c *autoUpdateBotInstanceReportCollection) Resources() []types.Resource {
 	return []types.Resource{types.ProtoResource153ToLegacy(c.report)}
-}
-
-func scopedTokenTextHelper(tokens []*joiningv1.ScopedToken, withSecrets bool) *bytes.Buffer {
-	headers := []string{
-		"Token",
-		"Type",
-		"Scope",
-		"Assigns Scope",
-		"Labels",
-		"Expiry Time (UTC)",
-	}
-	if withSecrets {
-		headers = slices.Insert(headers, 1, "Secret")
-	}
-	table := asciitable.MakeTable(headers)
-
-	now := time.Now()
-	for _, t := range tokens {
-		expiry := "never"
-		expiresAt := t.GetMetadata().GetExpires().AsTime()
-		if !expiresAt.IsZero() && expiresAt.Unix() != 0 {
-			exptime := expiresAt.Format(time.RFC822)
-			expdur := expiresAt.Sub(now).Round(time.Second)
-			expiry = fmt.Sprintf("%s (%s)", exptime, expdur.String())
-		}
-		row := []string{
-			t.GetMetadata().GetName(),
-			strings.Join(t.GetSpec().GetRoles(), ","),
-			t.GetScope(),
-			t.GetSpec().GetAssignedScope(),
-			printMetadataLabels(t.GetMetadata().Labels),
-			expiry,
-		}
-		if withSecrets {
-			row = slices.Insert(row, 1, t.GetStatus().GetSecret())
-		}
-		table.AddRow(row)
-	}
-	return table.AsBuffer()
 }
 
 func (c *autoUpdateBotInstanceReportCollection) WriteText(w io.Writer, _ bool) error {

--- a/tool/tctl/common/edit_command.go
+++ b/tool/tctl/common/edit_command.go
@@ -53,7 +53,8 @@ type EditCommand struct {
 	app     *kingpin.Application
 	cmd     *kingpin.CmdClause
 	config  *servicecfg.Config
-	ref     services.Ref
+	ref     string
+	id      string
 	confirm bool
 
 	// Editor is used by tests to inject the editing mechanism
@@ -65,7 +66,8 @@ func (e *EditCommand) Initialize(app *kingpin.Application, _ *tctlcfg.GlobalCLIF
 	e.app = app
 	e.config = config
 	e.cmd = app.Command("edit", "Edit a Teleport resource.")
-	e.cmd.Arg("resource type/resource name", `Resource to update, e.g., "user/myuser"`).SetValue(&e.ref)
+	e.cmd.Arg("resource type/resource name", `Resource to update, e.g., "user/myuser"`).StringVar(&e.ref)
+	e.cmd.Arg("id", `Resource identifier: scope-qualified name (e.g. "/staging/west::myrole") or bare name for unscoped kinds`).StringVar(&e.id)
 	e.cmd.Flag("confirm", "Confirm an unsafe or temporary resource update").Hidden().BoolVar(&e.confirm)
 }
 
@@ -116,7 +118,8 @@ func (e *EditCommand) editResource(ctx context.Context, client *authclient.Clien
 	}()
 
 	rc := &ResourceCommand{
-		refs:        services.Refs{e.ref},
+		ref:         e.ref,
+		id:          e.id,
 		format:      teleport.YAML,
 		Stdout:      f,
 		filename:    f.Name(),
@@ -134,12 +137,19 @@ func (e *EditCommand) editResource(ctx context.Context, client *authclient.Clien
 		return trace.Wrap(err)
 	}
 
+	// Build a user-facing resource descriptor that includes the id (SQN or bare
+	// name) when one was provided, so error messages reflect what the user typed.
+	resourceDesc := e.ref
+	if e.id != "" {
+		resourceDesc = e.ref + " " + e.id
+	}
+
 	err = rc.Get(ctx, client)
 	if closeErr := f.Close(); closeErr != nil {
 		return trace.Wrap(err)
 	}
 	if err != nil {
-		return trace.Wrap(err, "could not get resource %v", rc.ref.String())
+		return trace.Wrap(err, "could not get resource %v", resourceDesc)
 	}
 
 	originalSum, err := checksum(f.Name())
@@ -162,12 +172,13 @@ func (e *EditCommand) editResource(ctx context.Context, client *authclient.Clien
 	if len(originalResourcesMap) != len(originalResources) {
 		slog.DebugContext(ctx, "tctl edit clobbered resources on originalResourcesMap",
 			"ref", e.ref,
+			"id", e.id,
 			"original_resources_map_len", len(originalResourcesMap),
 			"original_resources_len", len(originalResources),
 		)
 		return trace.BadParameter(
 			"tctl edit cannot handle multiple resources of kind %q, please specify a single resource to edit",
-			e.ref.Kind,
+			e.ref,
 		)
 	}
 
@@ -217,14 +228,22 @@ func (e *EditCommand) editResource(ctx context.Context, client *authclient.Clien
 			continue
 		}
 
-		// Try looking for a resource handler first; resources that have been
-		// migrated to the [resources.Handler] format are handled here.
+		opts := resources.CreateOpts{
+			Force:   rc.force,
+			Confirm: rc.confirm,
+		}
+
+		// Try looking for a resource handler
 		if resourceHandler, found := resources.Handlers()[newResource.Kind]; found {
-			opts := resources.CreateOpts{
-				Force:   rc.force,
-				Confirm: rc.confirm,
-			}
 			if err := editUpdateWithFallback(ctx, client, resourceHandler, newResource, opts); err != nil {
+				return trace.Wrap(err)
+			}
+			continue
+		}
+
+		// Try looking for a scoped resource handler
+		if scopedHandler, found := resources.ScopedHandlers()[newResource.Kind]; found {
+			if err := editUpdateWithFallbackScoped(ctx, client, scopedHandler, newResource, opts); err != nil {
 				return trace.Wrap(err)
 			}
 			continue
@@ -274,6 +293,25 @@ func editUpdateWithFallback(
 	// TODO(tross) remove the fallback to CreateHandlers once all the resources
 	// have been updated to implement an UpdateHandler.
 	if err := resourceHandler.Create(ctx, client, resource, opts); trace.IsNotImplemented(err) {
+		return trace.BadParameter("updating resources of type %q is not supported", resource.Kind)
+	} else {
+		return trace.Wrap(err)
+	}
+}
+
+func editUpdateWithFallbackScoped(
+	ctx context.Context,
+	client *authclient.Client,
+	handler resources.ScopedHandler,
+	resource services.UnknownResource,
+	opts resources.CreateOpts,
+) error {
+	err := handler.Update(ctx, client, resource, opts)
+	if err == nil || !trace.IsNotImplemented(err) {
+		return trace.Wrap(err)
+	}
+
+	if err := handler.Create(ctx, client, resource, opts); trace.IsNotImplemented(err) {
 		return trace.BadParameter("updating resources of type %q is not supported", resource.Kind)
 	} else {
 		return trace.Wrap(err)

--- a/tool/tctl/common/edit_command_test.go
+++ b/tool/tctl/common/edit_command_test.go
@@ -743,7 +743,7 @@ func testEditScopedToken(t *testing.T, clt *authclient.Client) {
 		return trace.NewAggregate(writeYAML(collection, f), f.Close())
 	}
 
-	_, err = runEditCommand(t, clt, []string{"edit", types.KindScopedToken + "/" + created.GetMetadata().GetName()}, withEditor(editor))
+	_, err = runEditCommand(t, clt, []string{"edit", types.KindScopedToken, "/staging::" + created.GetMetadata().GetName()}, withEditor(editor))
 	require.NoError(t, err)
 
 	actual, err := clt.GetScopedToken(ctx, created.GetMetadata().GetName(), true)
@@ -751,7 +751,7 @@ func testEditScopedToken(t *testing.T, clt *authclient.Client) {
 	require.Equal(t, "test", actual.GetMetadata().GetLabels()["env"])
 
 	// Second edit with the stale original revision should fail.
-	_, err = runEditCommand(t, clt, []string{"edit", types.KindScopedToken + "/" + created.GetMetadata().GetName()}, withEditor(editor))
+	_, err = runEditCommand(t, clt, []string{"edit", types.KindScopedToken, "/staging::" + created.GetMetadata().GetName()}, withEditor(editor))
 	require.Error(t, err)
 	require.True(t, trace.IsCompareFailed(err))
 }

--- a/tool/tctl/common/resource_cert_authority_override.go
+++ b/tool/tctl/common/resource_cert_authority_override.go
@@ -86,8 +86,8 @@ func (c *certAuthorityOverrideCollection) WriteText(w io.Writer, verbose bool) e
 func (rc *ResourceCommand) getCAOverrides(
 	ctx context.Context,
 	authClient *authclient.Client,
+	ref services.Ref,
 ) (resources.Collection, error) {
-	ref := rc.ref
 
 	// Defensive. Shouldn't happen. Only 3 forms of ref are possible:
 	//   - kind ("tctl get ca_overrides")
@@ -224,8 +224,8 @@ func (rc *ResourceCommand) updateCAOverride(
 func (rc *ResourceCommand) deleteCAOverride(
 	ctx context.Context,
 	authClient *authclient.Client,
+	ref services.Ref,
 ) error {
-	ref := rc.ref
 
 	if ref.Kind != types.KindCertAuthorityOverride ||
 		ref.SubKind != "" ||

--- a/tool/tctl/common/resource_command.go
+++ b/tool/tctl/common/resource_command.go
@@ -96,8 +96,8 @@ type ResourceKind string
 // Teleport resources
 type ResourceCommand struct {
 	config      *servicecfg.Config
-	ref         services.Ref
-	refs        services.Refs
+	ref         string
+	id          string
 	format      string
 	namespace   string
 	withSecrets bool
@@ -242,7 +242,8 @@ func (rc *ResourceCommand) Initialize(app *kingpin.Application, _ *tctlcfg.Globa
 	<resource name>  Resource name to update
 
 	Example:
-	$ tctl update rc/remote`).SetValue(&rc.ref)
+	$ tctl update rc/remote`).StringVar(&rc.ref)
+	rc.updateCmd.Arg("id", `Resource identifier: scope-qualified name (e.g. "/staging/west::myrole") or bare name for unscoped kinds`).StringVar(&rc.id)
 	rc.updateCmd.Flag("set-labels", "Set labels").StringVar(&rc.labels)
 	rc.updateCmd.Flag("set-ttl", "Set TTL").StringVar(&rc.ttl)
 
@@ -253,10 +254,12 @@ func (rc *ResourceCommand) Initialize(app *kingpin.Application, _ *tctlcfg.Globa
 
 	Examples:
 	$ tctl rm role/devs
-	$ tctl rm cluster/main`).SetValue(&rc.ref)
+	$ tctl rm cluster/main`).StringVar(&rc.ref)
+	rc.deleteCmd.Arg("id", `Resource identifier: scope-qualified name (e.g. "/staging/west::myrole") or bare name for unscoped kinds`).StringVar(&rc.id)
 
 	rc.getCmd = app.Command("get", "Print a YAML declaration of various Teleport resources.")
-	rc.getCmd.Arg("resources", "Resource spec: 'type/[name][,...]' or 'all'").Required().SetValue(&rc.refs)
+	rc.getCmd.Arg("resources", "Resource spec: 'type/[name][,...]' or 'all'").Required().StringVar(&rc.ref)
+	rc.getCmd.Arg("id", `Resource identifier: scope-qualified name (e.g. "/staging/west::myrole") or bare name for unscoped kinds`).StringVar(&rc.id)
 	rc.getCmd.Flag("format", "Output format: 'yaml', 'json' or 'text'").Default(teleport.YAML).StringVar(&rc.format)
 	rc.getCmd.Flag("namespace", "Namespace of the resources").Hidden().Default(apidefaults.Namespace).StringVar(&rc.namespace)
 	rc.getCmd.Flag("with-secrets", "Include secrets in resources like certificate authorities or OIDC connectors").Default("false").BoolVar(&rc.withSecrets)
@@ -304,93 +307,126 @@ func (rc *ResourceCommand) IsDeleteSubcommand(cmd string) bool {
 	return cmd == rc.deleteCmd.FullCommand()
 }
 
-// GetRef returns the reference (basically type/name pair) of the resource
-// the command is operating on
-func (rc *ResourceCommand) GetRef() services.Ref {
-	return rc.ref
-}
-
 // Get prints one or many resources of a certain type
 func (rc *ResourceCommand) Get(ctx context.Context, client *authclient.Client) error {
 	// Some resources require MFA to list with secrets. Check if we are trying to
 	// get any such resources so we can prompt for MFA preemptively.
 	mfaKinds := []string{types.KindToken, types.KindCertAuthority}
-
-	withSecrets := rc.withSecrets || slices.ContainsFunc(rc.refs, func(r services.Ref) bool {
-		// tokens cannot be retrieved without secrets.
-		return r.Kind == types.KindToken
-	})
-
-	mfaRequired := withSecrets && slices.ContainsFunc(rc.refs, func(r services.Ref) bool {
-		return slices.Contains(mfaKinds, r.Kind)
-	})
-
-	// Check if MFA has already been provided.
-	if _, err := mfa.MFAResponseFromContext(ctx); err == nil {
-		mfaRequired = false
+	for kind, handler := range resources.Handlers() {
+		if handler.MFARequired() {
+			mfaKinds = append(mfaKinds, kind)
+		}
+	}
+	for kind, handler := range resources.ScopedHandlers() {
+		if handler.MFARequired() {
+			mfaKinds = append(mfaKinds, kind)
+		}
 	}
 
-	if mfaRequired {
+	// performMFAIfNeeded runs the MFA ceremony when required is true and MFA
+	// has not already been provided. It updates ctx in-place on success.
+	performMFAIfNeeded := func(required bool) error {
+		if !required {
+			return nil
+		}
+		if _, err := mfa.MFAResponseFromContext(ctx); err == nil {
+			return nil // already provided
+		}
 		mfaResponse, err := mfa.PerformAdminActionMFACeremony(ctx, client.PerformMFACeremony, true /*allowReuse*/)
 		if err == nil {
 			ctx = mfa.ContextWithMFAResponse(ctx, mfaResponse)
 		} else if !errors.Is(err, &mfa.ErrMFANotRequired) && !errors.Is(err, &mfa.ErrMFANotSupported) {
 			return trace.Wrap(err)
 		}
+		return nil
 	}
 
-	if rc.refs.IsAll() {
-		return rc.GetAll(ctx, client)
+	// writeCollection writes a collection to rc.Stdout in the requested format.
+	// Note that only YAML is officially supported; text and JSON are experimental.
+	writeCollection := func(coll resources.Collection) error {
+		switch rc.format {
+		case teleport.Text:
+			return coll.WriteText(rc.Stdout, rc.verbose)
+		case teleport.YAML:
+			return writeYAML(coll, rc.Stdout)
+		case teleport.JSON:
+			return writeJSON(coll, rc.Stdout)
+		}
+		return trace.BadParameter("unsupported format")
 	}
-	if len(rc.refs) != 1 {
-		return rc.GetMany(ctx, client)
+
+	// When a second positional arg (id) is present, short-circuit to the
+	// single-resource/scoped-resource path (note: this path relies on ScopedRef,
+	// but the underlying logic supports lookup of scoped and unscoped resources).
+	if rc.id != "" {
+		sr, err := ParseScopedRef(rc.ref, rc.id)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+		withSecrets := rc.withSecrets
+		if err := performMFAIfNeeded(withSecrets && slices.Contains(mfaKinds, sr.Kind)); err != nil {
+			return trace.Wrap(err)
+		}
+		collection, err := rc.getCollectionByScopedRef(ctx, client, sr, resources.GetOpts{WithSecrets: withSecrets})
+		if err != nil {
+			return trace.Wrap(err)
+		}
+		return writeCollection(collection)
 	}
-	rc.ref = rc.refs[0]
-	collection, err := rc.getCollection(ctx, client)
+
+	// No id: parse the full ref string, which may be "all", a comma-separated
+	// list, or a single kind[/subkind[/name]].
+	refs, err := services.ParseRefs(rc.ref)
 	if err != nil {
 		return trace.Wrap(err)
 	}
-
-	// Note that only YAML is officially supported. Support for text and JSON
-	// is experimental.
-	switch rc.format {
-	case teleport.Text:
-		return collection.WriteText(rc.Stdout, rc.verbose)
-	case teleport.YAML:
-		return writeYAML(collection, rc.Stdout)
-	case teleport.JSON:
-		return writeJSON(collection, rc.Stdout)
+	withSecrets := rc.withSecrets || slices.ContainsFunc(refs, func(r services.Ref) bool {
+		return r.Kind == types.KindToken // tokens cannot be retrieved without secrets
+	})
+	mfaRequired := withSecrets && slices.ContainsFunc(refs, func(r services.Ref) bool {
+		return slices.Contains(mfaKinds, r.Kind)
+	})
+	if err := performMFAIfNeeded(mfaRequired); err != nil {
+		return trace.Wrap(err)
 	}
-	return trace.BadParameter("unsupported format")
-}
 
-func (rc *ResourceCommand) GetMany(ctx context.Context, client *authclient.Client) error {
-	const skipNotSupported = false
-	return trace.Wrap(rc.getMany(ctx, client, skipNotSupported))
+	if refs.IsAll() {
+		return rc.GetAll(ctx, client)
+	}
+	if len(refs) != 1 {
+		return rc.getMany(ctx, client, false, refs)
+	}
+	collection, err := rc.getCollectionByRef(ctx, client, refs[0], resources.GetOpts{WithSecrets: withSecrets})
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	return writeCollection(collection)
 }
 
 func (rc *ResourceCommand) getMany(
 	ctx context.Context,
 	client *authclient.Client,
 	skipNotSupported bool,
+	refs services.Refs,
 ) error {
 	if rc.format != teleport.YAML {
 		return trace.BadParameter("mixed resource types only support YAML formatting")
 	}
 
-	var resources []types.Resource
-	for _, ref := range rc.refs {
-		rc.ref = ref
-		collection, err := rc.getCollection(ctx, client)
-		if skipNotSupported && trace.IsNotImplemented(err) {
+	opts := resources.GetOpts{WithSecrets: rc.withSecrets}
+	var allResources []types.Resource
+	for _, ref := range refs {
+		collection, err := rc.getCollectionByRef(ctx, client, ref, opts)
+		// trace.IsNotImplemented covers not-yet-migrated kinds in the legacy switch that return a raw NotImplemented.
+		if skipNotSupported && (errors.As(err, new(*errNotSupported)) || trace.IsNotImplemented(err)) {
 			continue
 		}
 		if err != nil {
 			return trace.Wrap(err)
 		}
-		resources = append(resources, collection.Resources()...)
+		allResources = append(allResources, collection.Resources()...)
 	}
-	if err := utils.WriteYAML(rc.Stdout, resources); err != nil {
+	if err := utils.WriteYAML(rc.Stdout, allResources); err != nil {
 		return trace.Wrap(err)
 	}
 	return nil
@@ -399,20 +435,16 @@ func (rc *ResourceCommand) getMany(
 func (rc *ResourceCommand) GetAll(ctx context.Context, client *authclient.Client) error {
 	rc.withSecrets = true
 	allKinds := services.GetResourceMarshalerKinds()
-	allRefs := make([]services.Ref, 0, len(allKinds))
+	allRefs := make(services.Refs, 0, len(allKinds))
 	for _, kind := range allKinds {
-		ref := services.Ref{
-			Kind: kind,
-		}
-		allRefs = append(allRefs, ref)
+		allRefs = append(allRefs, services.Ref{Kind: kind})
 	}
-	rc.refs = services.Refs(allRefs)
 
 	// This lets OSS query Enterprise-only kinds without failing when the
 	// corresponding RPCs return "NotImplemented".
 	const skipNotSupported = true
 
-	return rc.getMany(ctx, client, skipNotSupported)
+	return rc.getMany(ctx, client, skipNotSupported, allRefs)
 }
 
 // Create updates or inserts one or many resources
@@ -460,15 +492,15 @@ func (rc *ResourceCommand) Create(ctx context.Context, client *authclient.Client
 
 		count++
 
-		// Try looking for a resource handler first; resources that have been
-		// migrated to the [resources.Handler] format are handled here.
+		opts := resources.CreateOpts{
+			Force:   rc.force,
+			Confirm: rc.confirm,
+		}
+
+		// Try looking for a resource handler
 		if resourceHandler, found := resources.Handlers()[raw.Kind]; found {
 			// only return in case of error, to create multiple resources
 			// in case if yaml spec is a list
-			opts := resources.CreateOpts{
-				Force:   rc.force,
-				Confirm: rc.confirm,
-			}
 			if err := resourceHandler.Create(ctx, client, raw, opts); err != nil {
 				if trace.IsAlreadyExists(err) {
 					return trace.Wrap(err, "use -f or --force flag to overwrite")
@@ -481,7 +513,22 @@ func (rc *ResourceCommand) Create(ctx context.Context, client *authclient.Client
 			// continue to next resource
 			continue
 		}
-		// Else fallback to the legacy logic.
+
+		// Try looking for a scoped resource handler
+		if scopedHandler, found := resources.ScopedHandlers()[raw.Kind]; found {
+			if err := scopedHandler.Create(ctx, client, raw, opts); err != nil {
+				if trace.IsAlreadyExists(err) {
+					return trace.Wrap(err, "use -f or --force flag to overwrite")
+				}
+				if trace.IsNotImplemented(err) {
+					return trace.BadParameter("creating resources of type %q is not supported", raw.Kind)
+				}
+				return trace.Wrap(err)
+			}
+			continue
+		}
+
+		// Else fallback to the legacy logic
 
 		// locate the creator function for a given resource kind:
 		creator, found := rc.CreateHandlers[ResourceKind(raw.Kind)]
@@ -1811,18 +1858,65 @@ func (rc *ResourceCommand) updateStaticHostUser(ctx context.Context, client *aut
 
 // Delete deletes resource by name
 func (rc *ResourceCommand) Delete(ctx context.Context, client *authclient.Client) (err error) {
+	sr, err := ParseScopedRef(rc.ref, rc.id)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	// Connectors are a special case. As it's the only meta-resource we have,
+	// it's easier to special-case it here instead of adding a case in the
+	// generic [resources.Handler].
+	if sr.Kind == types.KindConnectors {
+		return trace.BadParameter(
+			"Deleting connector resources requires using an explicit connector type. Please try again with the appropriate type: %s",
+			[]string{
+				types.KindGithubConnector + "/" + sr.Name,
+				types.KindOIDCConnector + "/" + sr.Name,
+				types.KindSAMLConnector + "/" + sr.Name,
+			},
+		)
+	}
+
+	if sr.Scope != "" {
+		handler, found := resources.ScopedHandlers()[sr.Kind]
+		if !found {
+			return trace.BadParameter("resource type %q does not support scope-qualified names", sr.Kind)
+		}
+		return trace.Wrap(handler.Delete(ctx, client, sr.SubKind, sr.SQN()))
+	}
+
+	// if scope was not set, we're about to interact with a bunch of functions that expect
+	// an explicitly unscoped ref.
+	ref := sr.Ref()
+
 	// Try looking for a resource handler
-	if resourceHandler, found := resources.Handlers()[rc.ref.Kind]; found {
-		if err := resourceHandler.Delete(ctx, client, rc.ref); err != nil {
+	if resourceHandler, found := resources.Handlers()[ref.Kind]; found {
+		if err := resourceHandler.Delete(ctx, client, ref); err != nil {
 			if trace.IsNotImplemented(err) {
-				return trace.BadParameter("deleting resources of type %q is not supported", rc.ref.Kind)
+				return trace.BadParameter("deleting resources of type %q is not supported", ref.Kind)
 			}
-			return trace.Wrap(err, "error deleting resource %q of type %q", rc.ref.Name, rc.ref.Kind)
+			return trace.Wrap(err, "error deleting resource %q of type %q", ref.Name, ref.Kind)
 		}
 		return nil
 	}
 	// Else fallback to the legacy logic.
 
+	// check if this kind has a scoped handler. note that we check this *after* checking for an unscoped handler. resource
+	// kinds can be "double registered" as both a scoped and unscoped handler if/when we want to support a mix of scoped and
+	// unscoped interaction with the resource, so a missing scope isn't necessarily an error until we confirm that there
+	// isn't a suitable unscoped handler.
+	if _, found := resources.ScopedHandlers()[ref.Kind]; found {
+		kindSpec := ref.Kind
+		if ref.SubKind != "" {
+			kindSpec = ref.Kind + "/" + ref.SubKind
+		}
+		if sr.Name != "" {
+			return trace.BadParameter("resource type %q requires a scope-qualified name: tctl rm %s <scope>::%s", ref.Kind, kindSpec, sr.Name)
+		}
+		return trace.BadParameter("use 'tctl rm %s <scope>::<name>' to delete a %s", kindSpec, ref.Kind)
+	}
+
+	// Else fallback to the legacy logic
 	singletonResources := []string{
 		types.KindClusterAuthPreference,
 		types.KindClusterMaintenanceConfig,
@@ -1836,75 +1930,71 @@ func (rc *ResourceCommand) Delete(ctx context.Context, client *authclient.Client
 		types.KindAutoUpdateAgentRollout,
 		types.KindAutoUpdateBotInstanceReport,
 	}
-	if !slices.Contains(singletonResources, rc.ref.Kind) && (rc.ref.Kind == "" || rc.ref.Name == "") {
+	if !slices.Contains(singletonResources, ref.Kind) && (ref.Kind == "" || ref.Name == "") {
 		return trace.BadParameter("provide a full resource name to delete, for example:\n$ tctl rm cluster/east\n")
 	}
 
-	errNotSupported := func() error {
-		return trace.BadParameter("deleting resources of type %q is not supported", rc.ref.Kind)
-	}
-
-	switch rc.ref.Kind {
+	switch ref.Kind {
 	case types.KindUser:
-		if err = client.DeleteUser(ctx, rc.ref.Name); err != nil {
+		if err = client.DeleteUser(ctx, ref.Name); err != nil {
 			return trace.Wrap(err)
 		}
-		fmt.Printf("user %q has been deleted\n", rc.ref.Name)
+		fmt.Printf("user %q has been deleted\n", ref.Name)
 	case types.KindRole:
-		if err = client.DeleteRole(ctx, rc.ref.Name); err != nil {
+		if err = client.DeleteRole(ctx, ref.Name); err != nil {
 			return trace.Wrap(err)
 		}
-		fmt.Printf("role %q has been deleted\n", rc.ref.Name)
+		fmt.Printf("role %q has been deleted\n", ref.Name)
 	case types.KindToken:
-		if err = client.DeleteToken(ctx, rc.ref.Name); err != nil {
+		if err = client.DeleteToken(ctx, ref.Name); err != nil {
 			return trace.Wrap(err)
 		}
-		fmt.Printf("token %q has been deleted\n", rc.ref.Name)
+		fmt.Printf("token %q has been deleted\n", ref.Name)
 	case types.KindSAMLConnector:
-		if err = client.DeleteSAMLConnector(ctx, rc.ref.Name); err != nil {
+		if err = client.DeleteSAMLConnector(ctx, ref.Name); err != nil {
 			return trace.Wrap(err)
 		}
-		fmt.Printf("SAML connector %v has been deleted\n", rc.ref.Name)
+		fmt.Printf("SAML connector %v has been deleted\n", ref.Name)
 	case types.KindOIDCConnector:
-		if err = client.DeleteOIDCConnector(ctx, rc.ref.Name); err != nil {
+		if err = client.DeleteOIDCConnector(ctx, ref.Name); err != nil {
 			return trace.Wrap(err)
 		}
-		fmt.Printf("OIDC connector %v has been deleted\n", rc.ref.Name)
+		fmt.Printf("OIDC connector %v has been deleted\n", ref.Name)
 	case types.KindGithubConnector:
-		if err = client.DeleteGithubConnector(ctx, rc.ref.Name); err != nil {
+		if err = client.DeleteGithubConnector(ctx, ref.Name); err != nil {
 			return trace.Wrap(err)
 		}
-		fmt.Printf("github connector %q has been deleted\n", rc.ref.Name)
+		fmt.Printf("github connector %q has been deleted\n", ref.Name)
 	case types.KindReverseTunnel:
-		if err := client.DeleteReverseTunnel(ctx, rc.ref.Name); err != nil {
+		if err := client.DeleteReverseTunnel(ctx, ref.Name); err != nil {
 			return trace.Wrap(err)
 		}
-		fmt.Printf("reverse tunnel %v has been deleted\n", rc.ref.Name)
+		fmt.Printf("reverse tunnel %v has been deleted\n", ref.Name)
 	case types.KindTrustedCluster:
-		if err = client.DeleteTrustedCluster(ctx, rc.ref.Name); err != nil {
+		if err = client.DeleteTrustedCluster(ctx, ref.Name); err != nil {
 			return trace.Wrap(err)
 		}
-		fmt.Printf("trusted cluster %q has been deleted\n", rc.ref.Name)
+		fmt.Printf("trusted cluster %q has been deleted\n", ref.Name)
 	case types.KindRemoteCluster:
-		if err = client.DeleteRemoteCluster(ctx, rc.ref.Name); err != nil {
+		if err = client.DeleteRemoteCluster(ctx, ref.Name); err != nil {
 			return trace.Wrap(err)
 		}
-		fmt.Printf("remote cluster %q has been deleted\n", rc.ref.Name)
+		fmt.Printf("remote cluster %q has been deleted\n", ref.Name)
 	case types.KindSemaphore:
-		if rc.ref.SubKind == "" || rc.ref.Name == "" {
+		if ref.SubKind == "" || ref.Name == "" {
 			return trace.BadParameter(
 				"full semaphore path must be specified (e.g. '%s/%s/alice@example.com')",
 				types.KindSemaphore, types.SemaphoreKindConnection,
 			)
 		}
 		err := client.DeleteSemaphore(ctx, types.SemaphoreFilter{
-			SemaphoreKind: rc.ref.SubKind,
-			SemaphoreName: rc.ref.Name,
+			SemaphoreKind: ref.SubKind,
+			SemaphoreName: ref.Name,
 		})
 		if err != nil {
 			return trace.Wrap(err)
 		}
-		fmt.Printf("semaphore '%s/%s' has been deleted\n", rc.ref.SubKind, rc.ref.Name)
+		fmt.Printf("semaphore '%s/%s' has been deleted\n", ref.SubKind, ref.Name)
 	case types.KindClusterAuthPreference:
 		if err = resetAuthPreference(ctx, client); err != nil {
 			return trace.Wrap(err)
@@ -1926,7 +2016,7 @@ func (rc *ResourceCommand) Delete(ctx context.Context, client *authclient.Client
 		}
 		fmt.Printf("session recording configuration has been reset to defaults\n")
 	case types.KindExternalAuditStorage:
-		if rc.ref.Name == types.MetaNameExternalAuditStorageCluster {
+		if ref.Name == types.MetaNameExternalAuditStorageCluster {
 			if err := client.ExternalAuditStorageClient().DisableClusterExternalAuditStorage(ctx); err != nil {
 				return trace.Wrap(err)
 			}
@@ -1938,9 +2028,9 @@ func (rc *ResourceCommand) Delete(ctx context.Context, client *authclient.Client
 			fmt.Printf("draft External Audit Storage configuration has been deleted\n")
 		}
 	case types.KindLock:
-		name := rc.ref.Name
-		if rc.ref.SubKind != "" {
-			name = rc.ref.SubKind + "/" + name
+		name := ref.Name
+		if ref.SubKind != "" {
+			name = ref.SubKind + "/" + name
 		}
 		if err = client.DeleteLock(ctx, name); err != nil {
 			return trace.Wrap(err)
@@ -1952,8 +2042,8 @@ func (rc *ResourceCommand) Delete(ctx context.Context, client *authclient.Client
 			return trace.Wrap(err)
 		}
 		resDesc := "database server"
-		servers = filterByNameOrDiscoveredName(servers, rc.ref.Name)
-		name, err := getOneResourceNameToDelete(servers, rc.ref, resDesc)
+		servers = filterByNameOrDiscoveredName(servers, ref.Name)
+		name, err := getOneResourceNameToDelete(servers, ref, resDesc)
 		if err != nil {
 			return trace.Wrap(err)
 		}
@@ -1970,10 +2060,10 @@ func (rc *ResourceCommand) Delete(ctx context.Context, client *authclient.Client
 		}
 		fmt.Printf("network restrictions have been reset to defaults (allow all)\n")
 	case types.KindApp:
-		if err = client.DeleteApp(ctx, rc.ref.Name); err != nil {
+		if err = client.DeleteApp(ctx, ref.Name); err != nil {
 			return trace.Wrap(err)
 		}
-		fmt.Printf("application %q has been deleted\n", rc.ref.Name)
+		fmt.Printf("application %q has been deleted\n", ref.Name)
 	case types.KindDatabase:
 		// TODO(okraport) DELETE IN v21.0.0, replace with regular Collect
 		databases, err := clientutils.CollectWithFallback(ctx, client.ListDatabases, client.GetDatabases)
@@ -1981,8 +2071,8 @@ func (rc *ResourceCommand) Delete(ctx context.Context, client *authclient.Client
 			return trace.Wrap(err)
 		}
 		resDesc := "database"
-		databases = filterByNameOrDiscoveredName(databases, rc.ref.Name)
-		name, err := getOneResourceNameToDelete(databases, rc.ref, resDesc)
+		databases = filterByNameOrDiscoveredName(databases, ref.Name)
+		name, err := getOneResourceNameToDelete(databases, ref, resDesc)
 		if err != nil {
 			return trace.Wrap(err)
 		}
@@ -1997,8 +2087,8 @@ func (rc *ResourceCommand) Delete(ctx context.Context, client *authclient.Client
 			return trace.Wrap(err)
 		}
 		resDesc := "Kubernetes cluster"
-		clusters = filterByNameOrDiscoveredName(clusters, rc.ref.Name)
-		name, err := getOneResourceNameToDelete(clusters, rc.ref, resDesc)
+		clusters = filterByNameOrDiscoveredName(clusters, ref.Name)
+		name, err := getOneResourceNameToDelete(clusters, ref, resDesc)
 		if err != nil {
 			return trace.Wrap(err)
 		}
@@ -2007,34 +2097,34 @@ func (rc *ResourceCommand) Delete(ctx context.Context, client *authclient.Client
 		}
 		fmt.Printf("%s %q has been deleted\n", resDesc, name)
 	case types.KindCrownJewel:
-		if err := client.CrownJewelsClient().DeleteCrownJewel(ctx, rc.ref.Name); err != nil {
+		if err := client.CrownJewelsClient().DeleteCrownJewel(ctx, ref.Name); err != nil {
 			return trace.Wrap(err)
 		}
-		fmt.Printf("crown_jewel %q has been deleted\n", rc.ref.Name)
+		fmt.Printf("crown_jewel %q has been deleted\n", ref.Name)
 	case types.KindWindowsDesktopService:
-		if err = client.DeleteWindowsDesktopService(ctx, rc.ref.Name); err != nil {
+		if err = client.DeleteWindowsDesktopService(ctx, ref.Name); err != nil {
 			return trace.Wrap(err)
 		}
-		fmt.Printf("windows desktop service %q has been deleted\n", rc.ref.Name)
+		fmt.Printf("windows desktop service %q has been deleted\n", ref.Name)
 	case types.KindDynamicWindowsDesktop:
-		if err = client.DynamicDesktopClient().DeleteDynamicWindowsDesktop(ctx, rc.ref.Name); err != nil {
+		if err = client.DynamicDesktopClient().DeleteDynamicWindowsDesktop(ctx, ref.Name); err != nil {
 			return trace.Wrap(err)
 		}
-		fmt.Printf("dynamic windows desktop %q has been deleted\n", rc.ref.Name)
+		fmt.Printf("dynamic windows desktop %q has been deleted\n", ref.Name)
 	case types.KindWindowsDesktop:
 		desktops, err := client.GetWindowsDesktops(ctx,
-			types.WindowsDesktopFilter{Name: rc.ref.Name})
+			types.WindowsDesktopFilter{Name: ref.Name})
 		if err != nil {
 			return trace.Wrap(err)
 		}
 		if len(desktops) == 0 {
-			return trace.NotFound("no desktops with name %q were found", rc.ref.Name)
+			return trace.NotFound("no desktops with name %q were found", ref.Name)
 		}
 		deleted := 0
 		var errs []error
 		for _, desktop := range desktops {
-			if desktop.GetName() == rc.ref.Name {
-				if err = client.DeleteWindowsDesktop(ctx, desktop.GetHostID(), rc.ref.Name); err != nil {
+			if desktop.GetName() == ref.Name {
+				if err = client.DeleteWindowsDesktop(ctx, desktop.GetHostID(), ref.Name); err != nil {
 					errs = append(errs, err)
 					continue
 				}
@@ -2044,37 +2134,37 @@ func (rc *ResourceCommand) Delete(ctx context.Context, client *authclient.Client
 		if deleted == 0 {
 			errs = append(errs,
 				trace.Errorf("failed to delete any desktops with the name %q, %d were found",
-					rc.ref.Name, len(desktops)))
+					ref.Name, len(desktops)))
 		}
 		fmts := "%d windows desktops with name %q have been deleted"
 		if err := trace.NewAggregate(errs...); err != nil {
-			fmt.Printf(fmts+" with errors while deleting\n", deleted, rc.ref.Name)
+			fmt.Printf(fmts+" with errors while deleting\n", deleted, ref.Name)
 			return err
 		}
-		fmt.Printf(fmts+"\n", deleted, rc.ref.Name)
+		fmt.Printf(fmts+"\n", deleted, ref.Name)
 	case types.KindCertAuthority:
-		if rc.ref.SubKind == "" || rc.ref.Name == "" {
+		if ref.SubKind == "" || ref.Name == "" {
 			return trace.BadParameter(
 				"full %s path must be specified (e.g. '%s/%s/clustername')",
 				types.KindCertAuthority, types.KindCertAuthority, types.HostCA,
 			)
 		}
 		err := client.DeleteCertAuthority(ctx, types.CertAuthID{
-			Type:       types.CertAuthType(rc.ref.SubKind),
-			DomainName: rc.ref.Name,
+			Type:       types.CertAuthType(ref.SubKind),
+			DomainName: ref.Name,
 		})
 		if err != nil {
 			return trace.Wrap(err)
 		}
-		fmt.Printf("%s '%s/%s' has been deleted\n", types.KindCertAuthority, rc.ref.SubKind, rc.ref.Name)
+		fmt.Printf("%s '%s/%s' has been deleted\n", types.KindCertAuthority, ref.SubKind, ref.Name)
 	case types.KindKubeServer:
 		servers, err := client.GetKubernetesServers(ctx)
 		if err != nil {
 			return trace.Wrap(err)
 		}
 		resDesc := "Kubernetes server"
-		servers = filterByNameOrDiscoveredName(servers, rc.ref.Name)
-		name, err := getOneResourceNameToDelete(servers, rc.ref, resDesc)
+		servers = filterByNameOrDiscoveredName(servers, ref.Name)
+		name, err := getOneResourceNameToDelete(servers, ref, resDesc)
 		if err != nil {
 			return trace.Wrap(err)
 		}
@@ -2092,32 +2182,32 @@ func (rc *ResourceCommand) Delete(ctx context.Context, client *authclient.Client
 		}
 		fmt.Printf("%s has been deleted\n", types.KindUIConfig)
 	case types.KindInstaller:
-		err := client.DeleteInstaller(ctx, rc.ref.Name)
+		err := client.DeleteInstaller(ctx, ref.Name)
 		if err != nil {
 			return trace.Wrap(err)
 		}
-		if rc.ref.Name == installers.InstallerScriptName {
-			fmt.Printf("%s has been reset to a default value\n", rc.ref.Name)
+		if ref.Name == installers.InstallerScriptName {
+			fmt.Printf("%s has been reset to a default value\n", ref.Name)
 		} else {
-			fmt.Printf("%s has been deleted\n", rc.ref.Name)
+			fmt.Printf("%s has been deleted\n", ref.Name)
 		}
 	case types.KindLoginRule:
 		loginRuleClient := client.LoginRuleClient()
 		_, err := loginRuleClient.DeleteLoginRule(ctx, &loginrulepb.DeleteLoginRuleRequest{
-			Name: rc.ref.Name,
+			Name: ref.Name,
 		})
 		if err != nil {
 			return trail.FromGRPC(err)
 		}
-		fmt.Printf("login rule %q has been deleted\n", rc.ref.Name)
+		fmt.Printf("login rule %q has been deleted\n", ref.Name)
 	case types.KindSAMLIdPServiceProvider:
-		if err := client.DeleteSAMLIdPServiceProvider(ctx, rc.ref.Name); err != nil {
+		if err := client.DeleteSAMLIdPServiceProvider(ctx, ref.Name); err != nil {
 			return trace.Wrap(err)
 		}
-		fmt.Printf("SAML IdP service provider %q has been deleted\n", rc.ref.Name)
+		fmt.Printf("SAML IdP service provider %q has been deleted\n", ref.Name)
 	case types.KindDevice:
 		remote := client.DevicesClient()
-		device, err := findDeviceByIDOrTag(ctx, remote, rc.ref.Name)
+		device, err := findDeviceByIDOrTag(ctx, remote, ref.Name)
 		if err != nil {
 			return trace.Wrap(err)
 		}
@@ -2127,26 +2217,26 @@ func (rc *ResourceCommand) Delete(ctx context.Context, client *authclient.Client
 		}); err != nil {
 			return trace.Wrap(err)
 		}
-		fmt.Printf("Device %q removed\n", rc.ref.Name)
+		fmt.Printf("Device %q removed\n", ref.Name)
 
 	case types.KindIntegration:
-		if err := client.DeleteIntegration(ctx, rc.ref.Name); err != nil {
+		if err := client.DeleteIntegration(ctx, ref.Name); err != nil {
 			return trace.Wrap(err)
 		}
-		fmt.Printf("Integration %q removed\n", rc.ref.Name)
+		fmt.Printf("Integration %q removed\n", ref.Name)
 
 	case types.KindUserTask:
-		if err := client.UserTasksServiceClient().DeleteUserTask(ctx, rc.ref.Name); err != nil {
+		if err := client.UserTasksServiceClient().DeleteUserTask(ctx, ref.Name); err != nil {
 			return trace.Wrap(err)
 		}
-		fmt.Printf("user task %q has been deleted\n", rc.ref.Name)
+		fmt.Printf("user task %q has been deleted\n", ref.Name)
 
 	case types.KindDiscoveryConfig:
 		remote := client.DiscoveryConfigClient()
-		if err := remote.DeleteDiscoveryConfig(ctx, rc.ref.Name); err != nil {
+		if err := remote.DeleteDiscoveryConfig(ctx, ref.Name); err != nil {
 			return trace.Wrap(err)
 		}
-		fmt.Printf("DiscoveryConfig %q removed\n", rc.ref.Name)
+		fmt.Printf("DiscoveryConfig %q removed\n", ref.Name)
 
 	case types.KindAppServer:
 		appServers, err := client.GetApplicationServers(ctx, rc.namespace)
@@ -2155,7 +2245,7 @@ func (rc *ResourceCommand) Delete(ctx context.Context, client *authclient.Client
 		}
 		deleted := false
 		for _, server := range appServers {
-			if server.GetName() == rc.ref.Name {
+			if server.GetName() == ref.Name {
 				if err := client.DeleteApplicationServer(ctx, server.GetNamespace(), server.GetHostID(), server.GetName()); err != nil {
 					return trace.Wrap(err)
 				}
@@ -2163,100 +2253,100 @@ func (rc *ResourceCommand) Delete(ctx context.Context, client *authclient.Client
 			}
 		}
 		if !deleted {
-			return trace.NotFound("application server %q not found", rc.ref.Name)
+			return trace.NotFound("application server %q not found", ref.Name)
 		}
-		fmt.Printf("application server %q has been deleted\n", rc.ref.Name)
+		fmt.Printf("application server %q has been deleted\n", ref.Name)
 	case types.KindOktaImportRule:
-		if err := client.OktaClient().DeleteOktaImportRule(ctx, rc.ref.Name); err != nil {
+		if err := client.OktaClient().DeleteOktaImportRule(ctx, ref.Name); err != nil {
 			return trace.Wrap(err)
 		}
-		fmt.Printf("Okta import rule %q has been deleted\n", rc.ref.Name)
+		fmt.Printf("Okta import rule %q has been deleted\n", ref.Name)
 	case types.KindOktaAssignment:
-		if err := client.OktaClient().DeleteOktaAssignment(ctx, rc.ref.Name); err != nil {
+		if err := client.OktaClient().DeleteOktaAssignment(ctx, ref.Name); err != nil {
 			return trace.Wrap(err)
 		}
-		fmt.Printf("Okta assignment %q has been deleted\n", rc.ref.Name)
+		fmt.Printf("Okta assignment %q has been deleted\n", ref.Name)
 	case types.KindUserGroup:
-		if err := client.DeleteUserGroup(ctx, rc.ref.Name); err != nil {
+		if err := client.DeleteUserGroup(ctx, ref.Name); err != nil {
 			return trace.Wrap(err)
 		}
-		fmt.Printf("User group %q has been deleted\n", rc.ref.Name)
+		fmt.Printf("User group %q has been deleted\n", ref.Name)
 	case types.KindProxy:
-		if err := client.DeleteProxy(ctx, rc.ref.Name); err != nil {
+		if err := client.DeleteProxy(ctx, ref.Name); err != nil {
 			return trace.Wrap(err)
 		}
-		fmt.Printf("Proxy %q has been deleted\n", rc.ref.Name)
+		fmt.Printf("Proxy %q has been deleted\n", ref.Name)
 	case types.KindAccessList:
-		if err := client.AccessListClient().DeleteAccessList(ctx, rc.ref.Name); err != nil {
+		if err := client.AccessListClient().DeleteAccessList(ctx, ref.Name); err != nil {
 			return trace.Wrap(err)
 		}
-		fmt.Printf("Access list %q has been deleted\n", rc.ref.Name)
+		fmt.Printf("Access list %q has been deleted\n", ref.Name)
 	case types.KindAuditQuery:
-		if err := client.SecReportsClient().DeleteSecurityAuditQuery(ctx, rc.ref.Name); err != nil {
+		if err := client.SecReportsClient().DeleteSecurityAuditQuery(ctx, ref.Name); err != nil {
 			return trace.Wrap(err)
 		}
-		fmt.Printf("Audit query %q has been deleted\n", rc.ref.Name)
+		fmt.Printf("Audit query %q has been deleted\n", ref.Name)
 	case types.KindSecurityReport:
-		if err := client.SecReportsClient().DeleteSecurityReport(ctx, rc.ref.Name); err != nil {
+		if err := client.SecReportsClient().DeleteSecurityReport(ctx, ref.Name); err != nil {
 			return trace.Wrap(err)
 		}
-		fmt.Printf("Security report %q has been deleted\n", rc.ref.Name)
+		fmt.Printf("Security report %q has been deleted\n", ref.Name)
 	case types.KindServerInfo:
-		if err := client.DeleteServerInfo(ctx, rc.ref.Name); err != nil {
+		if err := client.DeleteServerInfo(ctx, ref.Name); err != nil {
 			return trace.Wrap(err)
 		}
-		fmt.Printf("Server info %q has been deleted\n", rc.ref.Name)
+		fmt.Printf("Server info %q has been deleted\n", ref.Name)
 	case types.KindBot:
-		if _, err := client.BotServiceClient().DeleteBot(ctx, &machineidv1pb.DeleteBotRequest{BotName: rc.ref.Name}); err != nil {
+		if _, err := client.BotServiceClient().DeleteBot(ctx, &machineidv1pb.DeleteBotRequest{BotName: ref.Name}); err != nil {
 			return trace.Wrap(err)
 		}
-		fmt.Printf("Bot %q has been deleted\n", rc.ref.Name)
+		fmt.Printf("Bot %q has been deleted\n", ref.Name)
 	case types.KindDatabaseObjectImportRule:
-		if _, err := client.DatabaseObjectImportRuleClient().DeleteDatabaseObjectImportRule(ctx, &dbobjectimportrulev1.DeleteDatabaseObjectImportRuleRequest{Name: rc.ref.Name}); err != nil {
+		if _, err := client.DatabaseObjectImportRuleClient().DeleteDatabaseObjectImportRule(ctx, &dbobjectimportrulev1.DeleteDatabaseObjectImportRuleRequest{Name: ref.Name}); err != nil {
 			return trace.Wrap(err)
 		}
-		fmt.Printf("Rule %q has been deleted\n", rc.ref.Name)
+		fmt.Printf("Rule %q has been deleted\n", ref.Name)
 	case types.KindDatabaseObject:
-		if err := client.DatabaseObjectsClient().DeleteDatabaseObject(ctx, rc.ref.Name); err != nil {
+		if err := client.DatabaseObjectsClient().DeleteDatabaseObject(ctx, ref.Name); err != nil {
 			return trace.Wrap(err)
 		}
-		fmt.Printf("Object %q has been deleted\n", rc.ref.Name)
+		fmt.Printf("Object %q has been deleted\n", ref.Name)
 	case types.KindAccessMonitoringRule:
-		if err := client.AccessMonitoringRuleClient().DeleteAccessMonitoringRule(ctx, rc.ref.Name); err != nil {
+		if err := client.AccessMonitoringRuleClient().DeleteAccessMonitoringRule(ctx, ref.Name); err != nil {
 			return trace.Wrap(err)
 		}
-		fmt.Printf("Access monitoring rule %q has been deleted\n", rc.ref.Name)
+		fmt.Printf("Access monitoring rule %q has been deleted\n", ref.Name)
 	case types.KindSPIFFEFederation:
 		if _, err := client.SPIFFEFederationServiceClient().DeleteSPIFFEFederation(
 			ctx, &machineidv1pb.DeleteSPIFFEFederationRequest{
-				Name: rc.ref.Name,
+				Name: ref.Name,
 			},
 		); err != nil {
 			return trace.Wrap(err)
 		}
-		fmt.Printf("SPIFFE federation %q has been deleted\n", rc.ref.Name)
+		fmt.Printf("SPIFFE federation %q has been deleted\n", ref.Name)
 	case types.KindWorkloadIdentity:
 		if _, err := client.WorkloadIdentityResourceServiceClient().DeleteWorkloadIdentity(
 			ctx, &workloadidentityv1pb.DeleteWorkloadIdentityRequest{
-				Name: rc.ref.Name,
+				Name: ref.Name,
 			}); err != nil {
 			return trace.Wrap(err)
 		}
-		fmt.Printf("Workload identity %q has been deleted\n", rc.ref.Name)
+		fmt.Printf("Workload identity %q has been deleted\n", ref.Name)
 	case types.KindWorkloadIdentityX509Revocation:
 		if _, err := client.WorkloadIdentityRevocationServiceClient().DeleteWorkloadIdentityX509Revocation(
 			ctx, &workloadidentityv1pb.DeleteWorkloadIdentityX509RevocationRequest{
-				Name: rc.ref.Name,
+				Name: ref.Name,
 			}); err != nil {
 			return trace.Wrap(err)
 		}
-		fmt.Printf("Workload identity X509 revocation %q has been deleted\n", rc.ref.Name)
+		fmt.Printf("Workload identity X509 revocation %q has been deleted\n", ref.Name)
 	case types.KindWorkloadIdentityX509IssuerOverride:
 		c := client.WorkloadIdentityX509OverridesClient()
 		if _, err := c.DeleteX509IssuerOverride(
 			ctx,
 			&workloadidentityv1pb.DeleteX509IssuerOverrideRequest{
-				Name: rc.ref.Name,
+				Name: ref.Name,
 			},
 		); err != nil {
 			return trace.Wrap(err)
@@ -2264,14 +2354,14 @@ func (rc *ResourceCommand) Delete(ctx context.Context, client *authclient.Client
 		fmt.Fprintf(
 			rc.Stdout,
 			types.KindWorkloadIdentityX509IssuerOverride+" %q has been deleted\n",
-			rc.ref.Name,
+			ref.Name,
 		)
 	case types.KindSigstorePolicy:
 		c := client.SigstorePolicyResourceServiceClient()
 		if _, err := c.DeleteSigstorePolicy(
 			ctx,
 			&workloadidentityv1pb.DeleteSigstorePolicyRequest{
-				Name: rc.ref.Name,
+				Name: ref.Name,
 			},
 		); err != nil {
 			return trace.Wrap(err)
@@ -2279,18 +2369,18 @@ func (rc *ResourceCommand) Delete(ctx context.Context, client *authclient.Client
 		fmt.Fprintf(
 			rc.Stdout,
 			types.KindSigstorePolicy+" %q has been deleted\n",
-			rc.ref.Name,
+			ref.Name,
 		)
 	case types.KindStaticHostUser:
-		if err := client.StaticHostUserClient().DeleteStaticHostUser(ctx, rc.ref.Name); err != nil {
+		if err := client.StaticHostUserClient().DeleteStaticHostUser(ctx, ref.Name); err != nil {
 			return trace.Wrap(err)
 		}
-		fmt.Printf("static host user %q has been deleted\n", rc.ref.Name)
+		fmt.Printf("static host user %q has been deleted\n", ref.Name)
 	case types.KindGitServer:
-		if err := client.GitServerClient().DeleteGitServer(ctx, rc.ref.Name); err != nil {
+		if err := client.GitServerClient().DeleteGitServer(ctx, ref.Name); err != nil {
 			return trace.Wrap(err)
 		}
-		fmt.Printf("git_server %q has been deleted\n", rc.ref.Name)
+		fmt.Printf("git_server %q has been deleted\n", ref.Name)
 	case types.KindAutoUpdateConfig:
 		if err := client.DeleteAutoUpdateConfig(ctx); err != nil {
 			return trace.Wrap(err)
@@ -2312,31 +2402,31 @@ func (rc *ResourceCommand) Delete(ctx context.Context, client *authclient.Client
 		}
 		fmt.Printf("%s has been deleted\n", types.KindAutoUpdateBotInstanceReport)
 	case types.KindHealthCheckConfig:
-		return trace.Wrap(rc.deleteHealthCheckConfig(ctx, client))
+		return trace.Wrap(rc.deleteHealthCheckConfig(ctx, client, ref.Name))
 	case types.KindRelayServer:
-		if err := client.DeleteRelayServer(ctx, rc.ref.Name); err != nil {
+		if err := client.DeleteRelayServer(ctx, ref.Name); err != nil {
 			return trace.Wrap(err)
 		}
-		fmt.Printf("relay_server %+q has been deleted\n", rc.ref.Name)
+		fmt.Printf("relay_server %+q has been deleted\n", ref.Name)
 	case types.KindWorkloadCluster:
 		if _, err := client.WorkloadClustersClient().DeleteWorkloadCluster(ctx, &workloadclusterv1.DeleteWorkloadClusterRequest{
-			Name: rc.ref.Name,
+			Name: ref.Name,
 		}); err != nil {
 			return trace.Wrap(err)
 		}
-		fmt.Printf("workload_cluster %q has been deleted\n", rc.ref.Name)
+		fmt.Printf("workload_cluster %q has been deleted\n", ref.Name)
 	case types.KindInferenceModel:
-		return trace.Wrap(rc.deleteInferenceModel(ctx, client))
+		return trace.Wrap(rc.deleteInferenceModel(ctx, client, ref))
 	case types.KindInferenceSecret:
-		return trace.Wrap(rc.deleteInferenceSecret(ctx, client))
+		return trace.Wrap(rc.deleteInferenceSecret(ctx, client, ref))
 	case types.KindInferencePolicy:
-		return trace.Wrap(rc.deleteInferencePolicy(ctx, client))
+		return trace.Wrap(rc.deleteInferencePolicy(ctx, client, ref))
 	case types.KindRetrievalModel:
 		return trace.Wrap(rc.deleteRetrievalModel(ctx, client))
 	case types.KindCertAuthorityOverride:
-		return trace.Wrap(rc.deleteCAOverride(ctx, client))
+		return trace.Wrap(rc.deleteCAOverride(ctx, client, ref))
 	default:
-		return errNotSupported()
+		return trace.BadParameter("deleting resources of type %q is not supported", ref.Kind)
 	}
 	return nil
 }
@@ -2389,11 +2479,17 @@ func resetNetworkRestrictions(ctx context.Context, client *authclient.Client) er
 
 // UpdateFields updates select resource fields: expiry and labels
 func (rc *ResourceCommand) UpdateFields(ctx context.Context, clt *authclient.Client) error {
-	if rc.ref.Kind == "" || rc.ref.Name == "" {
+	sr, err := ParseScopedRef(rc.ref, rc.id)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	if sr.Kind == "" || sr.Name == "" {
 		return trace.BadParameter("provide a full resource name to update, for example:\n$ tctl update rc/remote --set-labels=env=prod\n")
 	}
+	if sr.Scope != "" {
+		return trace.BadParameter("resource type %q does not support scope-qualified names", sr.Kind)
+	}
 
-	var err error
 	var labels map[string]string
 	if rc.labels != "" {
 		labels, err = client.ParseLabelSpec(rc.labels)
@@ -2415,9 +2511,9 @@ func (rc *ResourceCommand) UpdateFields(ctx context.Context, clt *authclient.Cli
 		return trace.BadParameter("use at least one of --set-labels or --set-ttl")
 	}
 
-	switch rc.ref.Kind {
+	switch sr.Kind {
 	case types.KindRemoteCluster:
-		cluster, err := clt.GetRemoteCluster(ctx, rc.ref.Name)
+		cluster, err := clt.GetRemoteCluster(ctx, sr.Name)
 		if err != nil {
 			return trace.Wrap(err)
 		}
@@ -2432,9 +2528,9 @@ func (rc *ResourceCommand) UpdateFields(ctx context.Context, clt *authclient.Cli
 		if _, err = clt.UpdateRemoteCluster(ctx, cluster); err != nil {
 			return trace.Wrap(err)
 		}
-		fmt.Printf("cluster %v has been updated\n", rc.ref.Name)
+		fmt.Printf("cluster %v has been updated\n", sr.Name)
 	default:
-		return trace.BadParameter("updating resources of type %q is not supported, supported are: %q", rc.ref.Kind, types.KindRemoteCluster)
+		return trace.BadParameter("updating resources of type %q is not supported, supported are: %q", sr.Kind, types.KindRemoteCluster)
 	}
 	return nil
 }
@@ -2444,40 +2540,112 @@ func (rc *ResourceCommand) IsForced() bool {
 	return rc.force
 }
 
-func (rc *ResourceCommand) getCollection(ctx context.Context, client *authclient.Client) (resources.Collection, error) {
-	if rc.ref.Kind == "" {
+// errNotSupported is used to mark NotImplemented errors that were transformed
+// into BadParameter, so they can later be identified.
+type errNotSupported struct {
+	cause error
+}
+
+func (e *errNotSupported) Error() string {
+	return e.cause.Error()
+}
+
+func (e *errNotSupported) Unwrap() error {
+	return e.cause
+}
+
+func (rc *ResourceCommand) getCollectionByScopedRef(ctx context.Context, client *authclient.Client, sr ScopedRef, opts resources.GetOpts) (resources.Collection, error) {
+	if sr.Scope != "" {
+		handler, found := resources.ScopedHandlers()[sr.Kind]
+		if !found {
+			return nil, trace.BadParameter("resource type %q does not support scope-qualified names", sr.Kind)
+		}
+		sqn := sr.SQN()
+		return handler.Get(ctx, client, sr.SubKind, &sqn, opts)
+	}
+
+	// get was invoked without a scope being specified. this is valid for unscoped types, or when doing a list operation
+	// for a scoped type. some types are registered as both scoped and unscoped. therefore we specifically want to
+	// reject attempts to invoke a single-resource get at this point only if it targets a type that *does* have a scoped
+	// handler and *does not* have an unscoped handler.
+	if sr.Name != "" {
+		_, classicFound := resources.Handlers()[sr.Kind]
+		_, scopedFound := resources.ScopedHandlers()[sr.Kind]
+		if !classicFound && scopedFound {
+			kindSpec := sr.Kind
+			if sr.SubKind != "" {
+				kindSpec = fmt.Sprintf("%s/%s", sr.Kind, sr.SubKind)
+			}
+			return nil, trace.BadParameter(
+				"resource type %q requires a scope-qualified name, e.g.:\n  tctl get %s <scope>::%s",
+				kindSpec, kindSpec, sr.Name,
+			)
+		}
+	}
+
+	// fallthrough to the general getCollectionByRef logic. getCollectionByRef handles unscoped types, but it also handles
+	// invocations for scoped list operations.
+	return rc.getCollectionByRef(ctx, client, sr.Ref(), opts)
+}
+
+func (rc *ResourceCommand) getCollectionByRef(ctx context.Context, client *authclient.Client, ref services.Ref, opts resources.GetOpts) (resources.Collection, error) {
+	if ref.Kind == "" {
 		return nil, trace.BadParameter("specify resource to list, e.g. 'tctl get roles'")
 	}
 
-	// Try looking for a resource handler first; resources that have been
-	// migrated to the [resources.Handler] format are handled here.
-	if handler, found := resources.Handlers()[rc.ref.Kind]; found {
-		coll, err := handler.Get(ctx, client, rc.ref, resources.GetOpts{WithSecrets: rc.withSecrets})
+	if handler, found := resources.Handlers()[ref.Kind]; found {
+		coll, err := handler.Get(ctx, client, ref, opts)
 		if err != nil {
-			return nil, trace.Wrap(err)
+			if trace.IsNotImplemented(err) {
+				return nil, &errNotSupported{trace.BadParameter("getting %q is not supported", ref.String())}
+			}
+			return nil, trace.Wrap(err, "getting resource %q of type %q", ref.Name, ref.Kind)
 		}
 		return coll, nil
 	}
-	// Else fallback to the legacy logic.
 
-	switch rc.ref.Kind {
+	// Scoped handler path: list-all only. Single-resource lookup for purely-scoped
+	// kinds requires a scope-qualified name, handled by getCollectionByScopedRef.
+	if handler, found := resources.ScopedHandlers()[ref.Kind]; found {
+		if ref.Name != "" {
+			kindSpec := ref.Kind
+			if ref.SubKind != "" {
+				kindSpec = fmt.Sprintf("%s/%s", ref.Kind, ref.SubKind)
+			}
+			return nil, trace.BadParameter(
+				"resource type %q requires a scope-qualified name, e.g.:\n  tctl get %s <scope>::%s\nuse 'tctl get %s' to list all resources of this type",
+				kindSpec, kindSpec, ref.Name, ref.Kind,
+			)
+		}
+		if ref.SubKind != "" {
+			// technically our current CLI syntax does not support specifying a sub-kind without specifying
+			// a name so this should currently be unreachable, but its a good defensive check since hander.Get
+			// will likely not know how to handle sub-kind listing if future changes make it possible to express.
+			return nil, trace.BadParameter("listing resources by sub-kind is not supported, use 'tctl get %s' to list all resources of this kind", ref.Kind)
+		}
+		return handler.Get(ctx, client, "", nil, opts)
+	}
+
+	// The resource hasn't been migrated yet, falling back to the old logic.
+
+	switch ref.Kind {
 	case types.KindUser:
-		if rc.ref.Name == "" {
+		if ref.Name == "" {
 			users, err := client.GetUsers(ctx, rc.withSecrets)
 			if err != nil {
 				return nil, trace.Wrap(err)
 			}
 			return &userCollection{users: users}, nil
 		}
-		user, err := client.GetUser(ctx, rc.ref.Name, rc.withSecrets)
+		user, err := client.GetUser(ctx, ref.Name, rc.withSecrets)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
 		return &userCollection{users: services.Users{user}}, nil
 	case types.KindConnectors:
-		sc, scErr := getSAMLConnectors(ctx, client, rc.ref.Name, rc.withSecrets)
-		oc, ocErr := getOIDCConnectors(ctx, client, rc.ref.Name, rc.withSecrets)
-		gc, gcErr := getGithubConnectors(ctx, client, rc.ref.Name, rc.withSecrets)
+		sc, scErr := getSAMLConnectors(ctx, client, ref.Name, rc.withSecrets)
+		oc, ocErr := getOIDCConnectors(ctx, client, ref.Name, rc.withSecrets)
+		gc, gcErr := getGithubConnectors(ctx, client, ref.Name, rc.withSecrets)
 		errs := []error{scErr, ocErr, gcErr}
 		allEmpty := len(sc) == 0 && len(oc) == 0 && len(gc) == 0
 		reportErr := false
@@ -2497,25 +2665,25 @@ func (rc *ResourceCommand) getCollection(ctx context.Context, client *authclient
 			github: gc,
 		}, finalErr
 	case types.KindSAMLConnector:
-		connectors, err := getSAMLConnectors(ctx, client, rc.ref.Name, rc.withSecrets)
+		connectors, err := getSAMLConnectors(ctx, client, ref.Name, rc.withSecrets)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
 		return &samlCollection{connectors}, nil
 	case types.KindOIDCConnector:
-		connectors, err := getOIDCConnectors(ctx, client, rc.ref.Name, rc.withSecrets)
+		connectors, err := getOIDCConnectors(ctx, client, ref.Name, rc.withSecrets)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
 		return &oidcCollection{connectors}, nil
 	case types.KindGithubConnector:
-		connectors, err := getGithubConnectors(ctx, client, rc.ref.Name, rc.withSecrets)
+		connectors, err := getGithubConnectors(ctx, client, ref.Name, rc.withSecrets)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
 		return &githubCollection{connectors}, nil
 	case types.KindReverseTunnel:
-		if rc.ref.Name != "" {
+		if ref.Name != "" {
 			return nil, trace.BadParameter("reverse tunnel cannot be searched by name")
 		}
 
@@ -2528,7 +2696,7 @@ func (rc *ResourceCommand) getCollection(ctx context.Context, client *authclient
 	case types.KindCertAuthority:
 		switch {
 		// `tctl get cert_authority`.
-		case rc.ref.SubKind == "" && rc.ref.Name == "":
+		case ref.SubKind == "" && ref.Name == "":
 			var allAuthorities []types.CertAuthority
 			for _, caType := range types.CertAuthTypes {
 				authorities, err := client.GetCertAuthorities(ctx, caType, rc.withSecrets)
@@ -2543,8 +2711,8 @@ func (rc *ResourceCommand) getCollection(ctx context.Context, client *authclient
 			}
 			return &authorityCollection{cas: allAuthorities}, nil
 		// Eg: `tctl get cert_authority/user`.
-		case rc.ref.SubKind == "":
-			caType := rc.ref.Name // ref.Name is set first.
+		case ref.SubKind == "":
+			caType := ref.Name // ref.Name is set first.
 			authorities, err := client.GetCertAuthorities(ctx, types.CertAuthType(caType), rc.withSecrets)
 			if err != nil {
 				return nil, trace.Wrap(err)
@@ -2552,8 +2720,8 @@ func (rc *ResourceCommand) getCollection(ctx context.Context, client *authclient
 			return &authorityCollection{cas: authorities}, nil
 		// Eg: `tctl get cert_authority/user/example.com`.
 		default:
-			caType := rc.ref.SubKind // ref.SubKind is set first.
-			name := rc.ref.Name
+			caType := ref.SubKind // ref.SubKind is set first.
+			name := ref.Name
 			id := types.CertAuthID{
 				Type:       types.CertAuthType(caType),
 				DomainName: name,
@@ -2570,39 +2738,39 @@ func (rc *ResourceCommand) getCollection(ctx context.Context, client *authclient
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
-		if rc.ref.Name == "" {
+		if ref.Name == "" {
 			return resources.NewServerCollection(servers), nil
 		}
 		for _, server := range servers {
-			if server.GetName() == rc.ref.Name || server.GetHostname() == rc.ref.Name {
+			if server.GetName() == ref.Name || server.GetHostname() == ref.Name {
 				return resources.NewServerCollection([]types.Server{server}), nil
 			}
 		}
-		return nil, trace.NotFound("auth server with ID %q not found", rc.ref.Name)
+		return nil, trace.NotFound("auth server with ID %q not found", ref.Name)
 	case types.KindProxy:
 		//nolint:staticcheck // TODO(kiosion): DELETE IN 21.0.0
 		servers, err := client.GetProxies()
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
-		if rc.ref.Name == "" {
+		if ref.Name == "" {
 			return resources.NewServerCollection(servers), nil
 		}
 		for _, server := range servers {
-			if server.GetName() == rc.ref.Name || server.GetHostname() == rc.ref.Name {
+			if server.GetName() == ref.Name || server.GetHostname() == ref.Name {
 				return resources.NewServerCollection([]types.Server{server}), nil
 			}
 		}
-		return nil, trace.NotFound("proxy with ID %q not found", rc.ref.Name)
+		return nil, trace.NotFound("proxy with ID %q not found", ref.Name)
 	case types.KindRole:
-		if rc.ref.Name == "" {
+		if ref.Name == "" {
 			roles, err := client.GetRoles(ctx)
 			if err != nil {
 				return nil, trace.Wrap(err)
 			}
 			return &roleCollection{roles: roles}, nil
 		}
-		role, err := client.GetRole(ctx, rc.ref.Name)
+		role, err := client.GetRole(ctx, ref.Name)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
@@ -2611,7 +2779,7 @@ func (rc *ResourceCommand) getCollection(ctx context.Context, client *authclient
 	case types.KindNamespace:
 		return &namespaceCollection{namespaces: []types.Namespace{types.DefaultNamespace()}}, nil
 	case types.KindTrustedCluster:
-		if rc.ref.Name == "" {
+		if ref.Name == "" {
 			// TODO(okraport): DELETE IN v21.0.0, replace with regular Collect
 			trustedClusters, err := clientutils.CollectWithFallback(
 				ctx,
@@ -2624,28 +2792,28 @@ func (rc *ResourceCommand) getCollection(ctx context.Context, client *authclient
 
 			return &trustedClusterCollection{trustedClusters: trustedClusters}, nil
 		}
-		trustedCluster, err := client.GetTrustedCluster(ctx, rc.ref.Name)
+		trustedCluster, err := client.GetTrustedCluster(ctx, ref.Name)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
 		return &trustedClusterCollection{trustedClusters: []types.TrustedCluster{trustedCluster}}, nil
 	case types.KindRemoteCluster:
-		if rc.ref.Name == "" {
+		if ref.Name == "" {
 			remoteClusters, err := client.GetRemoteClusters(ctx)
 			if err != nil {
 				return nil, trace.Wrap(err)
 			}
 			return &remoteClusterCollection{remoteClusters: remoteClusters}, nil
 		}
-		remoteCluster, err := client.GetRemoteCluster(ctx, rc.ref.Name)
+		remoteCluster, err := client.GetRemoteCluster(ctx, ref.Name)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
 		return &remoteClusterCollection{remoteClusters: []types.RemoteCluster{remoteCluster}}, nil
 	case types.KindSemaphore:
 		filter := types.SemaphoreFilter{
-			SemaphoreKind: rc.ref.SubKind,
-			SemaphoreName: rc.ref.Name,
+			SemaphoreKind: ref.SubKind,
+			SemaphoreName: ref.Name,
 		}
 		sems, err := clientutils.CollectWithFallback(ctx,
 			func(ctx context.Context, pageSize int, pageToken string) ([]types.Semaphore, string, error) {
@@ -2661,7 +2829,7 @@ func (rc *ResourceCommand) getCollection(ctx context.Context, client *authclient
 		}
 		return &semaphoreCollection{sems: sems}, nil
 	case types.KindClusterAuthPreference:
-		if rc.ref.Name != "" {
+		if ref.Name != "" {
 			return nil, trace.BadParameter("only simple `tctl get %v` can be used", types.KindClusterAuthPreference)
 		}
 		authPref, err := client.GetAuthPreference(ctx)
@@ -2670,7 +2838,7 @@ func (rc *ResourceCommand) getCollection(ctx context.Context, client *authclient
 		}
 		return &authPrefCollection{authPref}, nil
 	case types.KindClusterNetworkingConfig:
-		if rc.ref.Name != "" {
+		if ref.Name != "" {
 			return nil, trace.BadParameter("only simple `tctl get %v` can be used", types.KindClusterNetworkingConfig)
 		}
 		netConfig, err := client.GetClusterNetworkingConfig(ctx)
@@ -2679,7 +2847,7 @@ func (rc *ResourceCommand) getCollection(ctx context.Context, client *authclient
 		}
 		return &netConfigCollection{netConfig}, nil
 	case types.KindClusterMaintenanceConfig:
-		if rc.ref.Name != "" {
+		if ref.Name != "" {
 			return nil, trace.BadParameter("only simple `tctl get %v` can be used", types.KindClusterMaintenanceConfig)
 		}
 
@@ -2690,7 +2858,7 @@ func (rc *ResourceCommand) getCollection(ctx context.Context, client *authclient
 
 		return &maintenanceWindowCollection{cmc}, nil
 	case types.KindSessionRecordingConfig:
-		if rc.ref.Name != "" {
+		if ref.Name != "" {
 			return nil, trace.BadParameter("only simple `tctl get %v` can be used", types.KindSessionRecordingConfig)
 		}
 		recConfig, err := client.GetSessionRecordingConfig(ctx)
@@ -2699,7 +2867,7 @@ func (rc *ResourceCommand) getCollection(ctx context.Context, client *authclient
 		}
 		return &recConfigCollection{recConfig}, nil
 	case types.KindLock:
-		if rc.ref.Name == "" {
+		if ref.Name == "" {
 			locks, err := clientutils.CollectWithFallback(
 				ctx,
 				func(ctx context.Context, limit int, start string) ([]types.Lock, string, error) {
@@ -2717,9 +2885,9 @@ func (rc *ResourceCommand) getCollection(ctx context.Context, client *authclient
 			}
 			return &lockCollection{locks: locks}, nil
 		}
-		name := rc.ref.Name
-		if rc.ref.SubKind != "" {
-			name = rc.ref.SubKind + "/" + name
+		name := ref.Name
+		if ref.SubKind != "" {
+			name = ref.SubKind + "/" + name
 		}
 		lock, err := client.GetLock(ctx, name)
 		if err != nil {
@@ -2731,13 +2899,13 @@ func (rc *ResourceCommand) getCollection(ctx context.Context, client *authclient
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
-		if rc.ref.Name == "" {
+		if ref.Name == "" {
 			return &databaseServerCollection{servers: servers}, nil
 		}
 
-		servers = filterByNameOrDiscoveredName(servers, rc.ref.Name)
+		servers = filterByNameOrDiscoveredName(servers, ref.Name)
 		if len(servers) == 0 {
-			return nil, trace.NotFound("database server %q not found", rc.ref.Name)
+			return nil, trace.NotFound("database server %q not found", ref.Name)
 		}
 		return &databaseServerCollection{servers: servers}, nil
 	case types.KindKubeServer:
@@ -2745,15 +2913,15 @@ func (rc *ResourceCommand) getCollection(ctx context.Context, client *authclient
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
-		if rc.ref.Name == "" {
+		if ref.Name == "" {
 			return &kubeServerCollection{servers: servers}, nil
 		}
 		altNameFn := func(r types.KubeServer) string {
 			return r.GetHostname()
 		}
-		servers = filterByNameOrDiscoveredName(servers, rc.ref.Name, altNameFn)
+		servers = filterByNameOrDiscoveredName(servers, ref.Name, altNameFn)
 		if len(servers) == 0 {
-			return nil, trace.NotFound("Kubernetes server %q not found", rc.ref.Name)
+			return nil, trace.NotFound("Kubernetes server %q not found", ref.Name)
 		}
 		return &kubeServerCollection{servers: servers}, nil
 
@@ -2762,18 +2930,18 @@ func (rc *ResourceCommand) getCollection(ctx context.Context, client *authclient
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
-		if rc.ref.Name == "" {
+		if ref.Name == "" {
 			return &appServerCollection{servers: servers}, nil
 		}
 
 		var out []types.AppServer
 		for _, server := range servers {
-			if server.GetName() == rc.ref.Name || server.GetHostname() == rc.ref.Name {
+			if server.GetName() == ref.Name || server.GetHostname() == ref.Name {
 				out = append(out, server)
 			}
 		}
 		if len(out) == 0 {
-			return nil, trace.NotFound("application server %q not found", rc.ref.Name)
+			return nil, trace.NotFound("application server %q not found", ref.Name)
 		}
 		return &appServerCollection{servers: out}, nil
 	case types.KindNetworkRestrictions:
@@ -2783,7 +2951,7 @@ func (rc *ResourceCommand) getCollection(ctx context.Context, client *authclient
 		}
 		return &netRestrictionsCollection{nr}, nil
 	case types.KindApp:
-		if rc.ref.Name == "" {
+		if ref.Name == "" {
 			// TODO(tross): DELETE IN v21.0.0, replace with regular Collect
 			apps, err := clientutils.CollectWithFallback(ctx, client.ListApps, client.GetApps)
 			if err != nil {
@@ -2793,7 +2961,7 @@ func (rc *ResourceCommand) getCollection(ctx context.Context, client *authclient
 			return &appCollection{apps: apps}, nil
 		}
 
-		app, err := client.GetApp(ctx, rc.ref.Name)
+		app, err := client.GetApp(ctx, ref.Name)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
@@ -2805,12 +2973,12 @@ func (rc *ResourceCommand) getCollection(ctx context.Context, client *authclient
 			return nil, trace.Wrap(err)
 		}
 
-		if rc.ref.Name == "" {
+		if ref.Name == "" {
 			return &databaseCollection{databases: databases}, nil
 		}
-		databases = filterByNameOrDiscoveredName(databases, rc.ref.Name)
+		databases = filterByNameOrDiscoveredName(databases, ref.Name)
 		if len(databases) == 0 {
-			return nil, trace.NotFound("database %q not found", rc.ref.Name)
+			return nil, trace.NotFound("database %q not found", ref.Name)
 		}
 		return &databaseCollection{databases: databases}, nil
 	case types.KindKubernetesCluster:
@@ -2819,12 +2987,12 @@ func (rc *ResourceCommand) getCollection(ctx context.Context, client *authclient
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
-		if rc.ref.Name == "" {
+		if ref.Name == "" {
 			return &kubeClusterCollection{clusters: clusters}, nil
 		}
-		clusters = filterByNameOrDiscoveredName(clusters, rc.ref.Name)
+		clusters = filterByNameOrDiscoveredName(clusters, ref.Name)
 		if len(clusters) == 0 {
-			return nil, trace.NotFound("Kubernetes cluster %q not found", rc.ref.Name)
+			return nil, trace.NotFound("Kubernetes cluster %q not found", ref.Name)
 		}
 		return &kubeClusterCollection{clusters: clusters}, nil
 	case types.KindCrownJewel:
@@ -2837,11 +3005,11 @@ func (rc *ResourceCommand) getCollection(ctx context.Context, client *authclient
 
 		return &crownJewelCollection{items: jewels}, nil
 	case types.KindWindowsDesktopService:
-		if rc.ref.Name != "" {
-			service, err := client.GetWindowsDesktopService(ctx, rc.ref.Name)
+		if ref.Name != "" {
+			service, err := client.GetWindowsDesktopService(ctx, ref.Name)
 			if err != nil {
 				if trace.IsNotFound(err) {
-					return nil, trace.NotFound("Windows desktop service %q not found", rc.ref.Name)
+					return nil, trace.NotFound("Windows desktop service %q not found", ref.Name)
 				}
 				return nil, trace.Wrap(err)
 			}
@@ -2855,11 +3023,11 @@ func (rc *ResourceCommand) getCollection(ctx context.Context, client *authclient
 		}
 		return &windowsDesktopServiceCollection{services: services}, nil
 	case types.KindWindowsDesktop:
-		if rc.ref.Name != "" {
-			desktops, err := client.GetWindowsDesktops(ctx, types.WindowsDesktopFilter{Name: rc.ref.Name})
+		if ref.Name != "" {
+			desktops, err := client.GetWindowsDesktops(ctx, types.WindowsDesktopFilter{Name: ref.Name})
 			if err != nil {
 				if trace.IsNotFound(err) {
-					return nil, trace.NotFound("Windows desktop %q not found", rc.ref.Name)
+					return nil, trace.NotFound("Windows desktop %q not found", ref.Name)
 				}
 				return nil, trace.Wrap(err)
 			}
@@ -2893,8 +3061,8 @@ func (rc *ResourceCommand) getCollection(ctx context.Context, client *authclient
 		return &windowsDesktopCollection{desktops: desktops}, nil
 	case types.KindDynamicWindowsDesktop:
 		dynamicDesktopClient := client.DynamicDesktopClient()
-		if rc.ref.Name != "" {
-			desktop, err := dynamicDesktopClient.GetDynamicWindowsDesktop(ctx, rc.ref.Name)
+		if ref.Name != "" {
+			desktop, err := dynamicDesktopClient.GetDynamicWindowsDesktop(ctx, ref.Name)
 			if err != nil {
 				return nil, trace.Wrap(err)
 			}
@@ -2910,20 +3078,20 @@ func (rc *ResourceCommand) getCollection(ctx context.Context, client *authclient
 
 		return &dynamicWindowsDesktopCollection{desktops}, nil
 	case types.KindToken:
-		if rc.ref.Name == "" {
+		if ref.Name == "" {
 			tokens, err := getAllTokens(ctx, client)
 			if err != nil {
 				return nil, trace.Wrap(err)
 			}
 			return &tokenCollection{tokens: tokens}, nil
 		}
-		token, err := client.GetToken(ctx, rc.ref.Name)
+		token, err := client.GetToken(ctx, ref.Name)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
 		return &tokenCollection{tokens: []types.ProvisionToken{token}}, nil
 	case types.KindInstaller:
-		if rc.ref.Name == "" {
+		if ref.Name == "" {
 			// TODO(okraport): DELETE IN v21.0.0, replace with regular collect.
 			installers, err := clientutils.CollectWithFallback(ctx, client.ListInstallers, client.GetInstallers)
 			if err != nil {
@@ -2931,13 +3099,13 @@ func (rc *ResourceCommand) getCollection(ctx context.Context, client *authclient
 			}
 			return &installerCollection{installers: installers}, nil
 		}
-		inst, err := client.GetInstaller(ctx, rc.ref.Name)
+		inst, err := client.GetInstaller(ctx, ref.Name)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
 		return &installerCollection{installers: []types.Installer{inst}}, nil
 	case types.KindUIConfig:
-		if rc.ref.Name != "" {
+		if ref.Name != "" {
 			return nil, trace.BadParameter("only simple `tctl get %v` can be used", types.KindUIConfig)
 		}
 		uiconfig, err := client.GetUIConfig(ctx)
@@ -2946,7 +3114,7 @@ func (rc *ResourceCommand) getCollection(ctx context.Context, client *authclient
 		}
 		return &uiConfigCollection{uiconfig}, nil
 	case types.KindDatabaseService:
-		resourceName := rc.ref.Name
+		resourceName := ref.Name
 		listReq := proto.ListResourcesRequest{
 			ResourceType: types.KindDatabaseService,
 		}
@@ -2971,7 +3139,7 @@ func (rc *ResourceCommand) getCollection(ctx context.Context, client *authclient
 		return &databaseServiceCollection{databaseServices: databaseServices}, nil
 	case types.KindLoginRule:
 		loginRuleClient := client.LoginRuleClient()
-		if rc.ref.Name == "" {
+		if ref.Name == "" {
 			rules, err := stream.Collect(clientutils.Resources(ctx, func(ctx context.Context, limit int, token string) ([]*loginrulepb.LoginRule, string, error) {
 				resp, err := loginRuleClient.ListLoginRules(ctx, &loginrulepb.ListLoginRulesRequest{
 					PageSize:  int32(limit),
@@ -2986,12 +3154,12 @@ func (rc *ResourceCommand) getCollection(ctx context.Context, client *authclient
 			return &loginRuleCollection{rules}, trace.Wrap(err)
 		}
 		rule, err := loginRuleClient.GetLoginRule(ctx, &loginrulepb.GetLoginRuleRequest{
-			Name: rc.ref.Name,
+			Name: ref.Name,
 		})
 		return &loginRuleCollection{[]*loginrulepb.LoginRule{rule}}, trail.FromGRPC(err)
 	case types.KindSAMLIdPServiceProvider:
-		if rc.ref.Name != "" {
-			serviceProvider, err := client.GetSAMLIdPServiceProvider(ctx, rc.ref.Name)
+		if ref.Name != "" {
+			serviceProvider, err := client.GetSAMLIdPServiceProvider(ctx, ref.Name)
 			if err != nil {
 				return nil, trace.Wrap(err)
 			}
@@ -3005,9 +3173,9 @@ func (rc *ResourceCommand) getCollection(ctx context.Context, client *authclient
 		return &samlIdPServiceProviderCollection{serviceProviders: resources}, nil
 	case types.KindDevice:
 		remote := client.DevicesClient()
-		if rc.ref.Name != "" {
+		if ref.Name != "" {
 			resp, err := remote.FindDevices(ctx, &devicepb.FindDevicesRequest{
-				IdOrTag: rc.ref.Name,
+				IdOrTag: ref.Name,
 			})
 			if err != nil {
 				return nil, trace.Wrap(err)
@@ -3048,9 +3216,9 @@ func (rc *ResourceCommand) getCollection(ctx context.Context, client *authclient
 		return &deviceCollection{devices: devs}, nil
 	case types.KindBot:
 		remote := client.BotServiceClient()
-		if rc.ref.Name != "" {
+		if ref.Name != "" {
 			bot, err := remote.GetBot(ctx, &machineidv1pb.GetBotRequest{
-				BotName: rc.ref.Name,
+				BotName: ref.Name,
 			})
 			if err != nil {
 				return nil, trace.Wrap(err)
@@ -3074,8 +3242,8 @@ func (rc *ResourceCommand) getCollection(ctx context.Context, client *authclient
 		return &botCollection{bots: bots}, nil
 	case types.KindDatabaseObjectImportRule:
 		remote := client.DatabaseObjectImportRuleClient()
-		if rc.ref.Name != "" {
-			rule, err := remote.GetDatabaseObjectImportRule(ctx, &dbobjectimportrulev1.GetDatabaseObjectImportRuleRequest{Name: rc.ref.Name})
+		if ref.Name != "" {
+			rule, err := remote.GetDatabaseObjectImportRule(ctx, &dbobjectimportrulev1.GetDatabaseObjectImportRuleRequest{Name: ref.Name})
 			if err != nil {
 				return nil, trace.Wrap(err)
 			}
@@ -3097,8 +3265,8 @@ func (rc *ResourceCommand) getCollection(ctx context.Context, client *authclient
 		return &databaseObjectImportRuleCollection{rules: rules}, nil
 	case types.KindDatabaseObject:
 		remote := client.DatabaseObjectsClient()
-		if rc.ref.Name != "" {
-			object, err := remote.GetDatabaseObject(ctx, rc.ref.Name)
+		if ref.Name != "" {
+			object, err := remote.GetDatabaseObject(ctx, ref.Name)
 			if err != nil {
 				return nil, trace.Wrap(err)
 			}
@@ -3112,8 +3280,8 @@ func (rc *ResourceCommand) getCollection(ctx context.Context, client *authclient
 
 		return &databaseObjectCollection{objects: objects}, nil
 	case types.KindOktaImportRule:
-		if rc.ref.Name != "" {
-			importRule, err := client.OktaClient().GetOktaImportRule(ctx, rc.ref.Name)
+		if ref.Name != "" {
+			importRule, err := client.OktaClient().GetOktaImportRule(ctx, ref.Name)
 			if err != nil {
 				return nil, trace.Wrap(err)
 			}
@@ -3127,8 +3295,8 @@ func (rc *ResourceCommand) getCollection(ctx context.Context, client *authclient
 
 		return &oktaImportRuleCollection{importRules: resources}, nil
 	case types.KindOktaAssignment:
-		if rc.ref.Name != "" {
-			assignment, err := client.OktaClient().GetOktaAssignment(ctx, rc.ref.Name)
+		if ref.Name != "" {
+			assignment, err := client.OktaClient().GetOktaAssignment(ctx, ref.Name)
 			if err != nil {
 				return nil, trace.Wrap(err)
 			}
@@ -3142,8 +3310,8 @@ func (rc *ResourceCommand) getCollection(ctx context.Context, client *authclient
 
 		return &oktaAssignmentCollection{assignments: resources}, nil
 	case types.KindUserGroup:
-		if rc.ref.Name != "" {
-			userGroup, err := client.GetUserGroup(ctx, rc.ref.Name)
+		if ref.Name != "" {
+			userGroup, err := client.GetUserGroup(ctx, ref.Name)
 			if err != nil {
 				return nil, trace.Wrap(err)
 			}
@@ -3158,7 +3326,7 @@ func (rc *ResourceCommand) getCollection(ctx context.Context, client *authclient
 		return &userGroupCollection{userGroups: resources}, nil
 	case types.KindExternalAuditStorage:
 		out := []*externalauditstorage.ExternalAuditStorage{}
-		name := rc.ref.Name
+		name := ref.Name
 		switch name {
 		case "":
 			cluster, err := client.ExternalAuditStorageClient().GetClusterExternalAuditStorage(ctx)
@@ -3194,8 +3362,8 @@ func (rc *ResourceCommand) getCollection(ctx context.Context, client *authclient
 			return nil, trace.BadParameter("unsupported resource name for external_audit_storage, valid for get are: '', %q, %q", types.MetaNameExternalAuditStorageDraft, types.MetaNameExternalAuditStorageCluster)
 		}
 	case types.KindIntegration:
-		if rc.ref.Name != "" {
-			ig, err := client.GetIntegration(ctx, rc.ref.Name)
+		if ref.Name != "" {
+			ig, err := client.GetIntegration(ctx, ref.Name)
 			if err != nil {
 				return nil, trace.Wrap(err)
 			}
@@ -3210,8 +3378,8 @@ func (rc *ResourceCommand) getCollection(ctx context.Context, client *authclient
 		return &integrationCollection{integrations: resources}, nil
 	case types.KindUserTask:
 		userTasksClient := client.UserTasksClient()
-		if rc.ref.Name != "" {
-			uit, err := userTasksClient.GetUserTask(ctx, rc.ref.Name)
+		if ref.Name != "" {
+			uit, err := userTasksClient.GetUserTask(ctx, ref.Name)
 			if err != nil {
 				return nil, trace.Wrap(err)
 			}
@@ -3227,8 +3395,8 @@ func (rc *ResourceCommand) getCollection(ctx context.Context, client *authclient
 		return &userTaskCollection{items: tasks}, nil
 	case types.KindDiscoveryConfig:
 		remote := client.DiscoveryConfigClient()
-		if rc.ref.Name != "" {
-			dc, err := remote.GetDiscoveryConfig(ctx, rc.ref.Name)
+		if ref.Name != "" {
+			dc, err := remote.GetDiscoveryConfig(ctx, ref.Name)
 			if err != nil {
 				return nil, trace.Wrap(err)
 			}
@@ -3242,8 +3410,8 @@ func (rc *ResourceCommand) getCollection(ctx context.Context, client *authclient
 
 		return &discoveryConfigCollection{discoveryConfigs: resources}, nil
 	case types.KindAuditQuery:
-		if rc.ref.Name != "" {
-			auditQuery, err := client.SecReportsClient().GetSecurityAuditQuery(ctx, rc.ref.Name)
+		if ref.Name != "" {
+			auditQuery, err := client.SecReportsClient().GetSecurityAuditQuery(ctx, ref.Name)
 			if err != nil {
 				return nil, trace.Wrap(err)
 			}
@@ -3257,9 +3425,9 @@ func (rc *ResourceCommand) getCollection(ctx context.Context, client *authclient
 
 		return &auditQueryCollection{auditQueries: resources}, nil
 	case types.KindSecurityReport:
-		if rc.ref.Name != "" {
+		if ref.Name != "" {
 
-			resource, err := client.SecReportsClient().GetSecurityReport(ctx, rc.ref.Name)
+			resource, err := client.SecReportsClient().GetSecurityReport(ctx, ref.Name)
 			if err != nil {
 				return nil, trace.Wrap(err)
 			}
@@ -3271,8 +3439,8 @@ func (rc *ResourceCommand) getCollection(ctx context.Context, client *authclient
 		}
 		return &securityReportCollection{items: resources}, nil
 	case types.KindServerInfo:
-		if rc.ref.Name != "" {
-			si, err := client.GetServerInfo(ctx, rc.ref.Name)
+		if ref.Name != "" {
+			si, err := client.GetServerInfo(ctx, ref.Name)
 			if err != nil {
 				return nil, trace.Wrap(err)
 			}
@@ -3284,8 +3452,8 @@ func (rc *ResourceCommand) getCollection(ctx context.Context, client *authclient
 		}
 		return &serverInfoCollection{serverInfos: serverInfos}, nil
 	case types.KindAccessList:
-		if rc.ref.Name != "" {
-			resource, err := client.AccessListClient().GetAccessList(ctx, rc.ref.Name)
+		if ref.Name != "" {
+			resource, err := client.AccessListClient().GetAccessList(ctx, ref.Name)
 			if err != nil {
 				return nil, trace.Wrap(err)
 			}
@@ -3301,11 +3469,11 @@ func (rc *ResourceCommand) getCollection(ctx context.Context, client *authclient
 		}
 		return &vnetConfigCollection{vnetConfig: vnetConfig}, nil
 	case types.KindAccessRequest:
-		resource, err := client.GetAccessRequests(ctx, types.AccessRequestFilter{ID: rc.ref.Name})
+		resource, err := client.GetAccessRequests(ctx, types.AccessRequestFilter{ID: ref.Name})
 		return &accessRequestCollection{accessRequests: resource}, trace.Wrap(err)
 	case types.KindPlugin:
-		if rc.ref.Name != "" {
-			plugin, err := client.PluginsClient().GetPlugin(ctx, &pluginsv1.GetPluginRequest{Name: rc.ref.Name})
+		if ref.Name != "" {
+			plugin, err := client.PluginsClient().GetPlugin(ctx, &pluginsv1.GetPluginRequest{Name: ref.Name})
 			if err != nil {
 				return nil, trace.Wrap(err)
 			}
@@ -3342,9 +3510,9 @@ func (rc *ResourceCommand) getCollection(ctx context.Context, client *authclient
 		}
 		return &accessGraphSettings{accessGraphSettings: rec}, nil
 	case types.KindSPIFFEFederation:
-		if rc.ref.Name != "" {
+		if ref.Name != "" {
 			resource, err := client.SPIFFEFederationServiceClient().GetSPIFFEFederation(ctx, &machineidv1pb.GetSPIFFEFederationRequest{
-				Name: rc.ref.Name,
+				Name: ref.Name,
 			})
 			if err != nil {
 				return nil, trace.Wrap(err)
@@ -3372,9 +3540,9 @@ func (rc *ResourceCommand) getCollection(ctx context.Context, client *authclient
 
 		return &spiffeFederationCollection{items: resources}, nil
 	case types.KindWorkloadIdentity:
-		if rc.ref.Name != "" {
+		if ref.Name != "" {
 			resource, err := client.WorkloadIdentityResourceServiceClient().GetWorkloadIdentity(ctx, &workloadidentityv1pb.GetWorkloadIdentityRequest{
-				Name: rc.ref.Name,
+				Name: ref.Name,
 			})
 			if err != nil {
 				return nil, trace.Wrap(err)
@@ -3396,11 +3564,11 @@ func (rc *ResourceCommand) getCollection(ctx context.Context, client *authclient
 
 		return &workloadIdentityCollection{items: resources}, nil
 	case types.KindWorkloadIdentityX509Revocation:
-		if rc.ref.Name != "" {
+		if ref.Name != "" {
 			resource, err := client.
 				WorkloadIdentityRevocationServiceClient().
 				GetWorkloadIdentityX509Revocation(ctx, &workloadidentityv1pb.GetWorkloadIdentityX509RevocationRequest{
-					Name: rc.ref.Name,
+					Name: ref.Name,
 				})
 			if err != nil {
 				return nil, trace.Wrap(err)
@@ -3422,11 +3590,11 @@ func (rc *ResourceCommand) getCollection(ctx context.Context, client *authclient
 
 		return &workloadIdentityX509RevocationCollection{items: resources}, nil
 	case types.KindBotInstance:
-		if rc.ref.Name != "" && rc.ref.SubKind != "" {
+		if ref.Name != "" && ref.SubKind != "" {
 			// Gets a specific bot instance, e.g. bot_instance/<bot name>/<instance id>
 			bi, err := client.BotInstanceServiceClient().GetBotInstance(ctx, &machineidv1pb.GetBotInstanceRequest{
-				BotName:    rc.ref.SubKind,
-				InstanceId: rc.ref.Name,
+				BotName:    ref.SubKind,
+				InstanceId: ref.Name,
 			})
 			if err != nil {
 				return nil, trace.Wrap(err)
@@ -3443,7 +3611,7 @@ func (rc *ResourceCommand) getCollection(ctx context.Context, client *authclient
 				PageToken: pageToken,
 
 				// Note: empty filter lists all bot instances
-				FilterBotName: rc.ref.Name,
+				FilterBotName: ref.Name,
 			})
 
 			return resp.GetBotInstances(), resp.GetNextPageToken(), trace.Wrap(err)
@@ -3455,8 +3623,8 @@ func (rc *ResourceCommand) getCollection(ctx context.Context, client *authclient
 		return &botInstanceCollection{items: instances}, nil
 	case types.KindStaticHostUser:
 		hostUserClient := client.StaticHostUserClient()
-		if rc.ref.Name != "" {
-			hostUser, err := hostUserClient.GetStaticHostUser(ctx, rc.ref.Name)
+		if ref.Name != "" {
+			hostUser, err := hostUserClient.GetStaticHostUser(ctx, ref.Name)
 			if err != nil {
 				return nil, trace.Wrap(err)
 			}
@@ -3488,8 +3656,8 @@ func (rc *ResourceCommand) getCollection(ctx context.Context, client *authclient
 		}
 		return &autoUpdateAgentRolloutCollection{version}, nil
 	case types.KindAutoUpdateAgentReport:
-		if rc.ref.Name != "" {
-			report, err := client.GetAutoUpdateAgentReport(ctx, rc.ref.Name)
+		if ref.Name != "" {
+			report, err := client.GetAutoUpdateAgentReport(ctx, ref.Name)
 			if err != nil {
 				return nil, trace.Wrap(err)
 			}
@@ -3502,7 +3670,7 @@ func (rc *ResourceCommand) getCollection(ctx context.Context, client *authclient
 		}
 		return &autoUpdateAgentReportCollection{reports: reports}, nil
 	case types.KindAutoUpdateBotInstanceReport:
-		if rc.ref.Name != "" {
+		if ref.Name != "" {
 			return nil, trace.BadParameter("only simple `tctl get %v` can be used", types.KindAutoUpdateBotInstanceReport)
 		}
 		report, err := client.GetAutoUpdateBotInstanceReport(ctx)
@@ -3511,8 +3679,8 @@ func (rc *ResourceCommand) getCollection(ctx context.Context, client *authclient
 		}
 		return &autoUpdateBotInstanceReportCollection{report}, nil
 	case types.KindAccessMonitoringRule:
-		if rc.ref.Name != "" {
-			rule, err := client.AccessMonitoringRuleClient().GetAccessMonitoringRule(ctx, rc.ref.Name)
+		if ref.Name != "" {
+			rule, err := client.AccessMonitoringRuleClient().GetAccessMonitoringRule(ctx, ref.Name)
 			if err != nil {
 				return nil, trace.Wrap(err)
 			}
@@ -3525,8 +3693,8 @@ func (rc *ResourceCommand) getCollection(ctx context.Context, client *authclient
 		}
 		return &accessMonitoringRuleCollection{items: rules}, nil
 	case types.KindGitServer:
-		if rc.ref.Name != "" {
-			server, err := client.GitServerClient().GetGitServer(ctx, rc.ref.Name)
+		if ref.Name != "" {
+			server, err := client.GitServerClient().GetGitServer(ctx, ref.Name)
 			if err != nil {
 				return nil, trace.Wrap(err)
 			}
@@ -3543,11 +3711,11 @@ func (rc *ResourceCommand) getCollection(ctx context.Context, client *authclient
 
 	case types.KindWorkloadIdentityX509IssuerOverride:
 		c := client.WorkloadIdentityX509OverridesClient()
-		if rc.ref.Name != "" {
+		if ref.Name != "" {
 			r, err := c.GetX509IssuerOverride(
 				ctx,
 				&workloadidentityv1pb.GetX509IssuerOverrideRequest{
-					Name: rc.ref.Name,
+					Name: ref.Name,
 				},
 			)
 			if err != nil {
@@ -3582,11 +3750,11 @@ func (rc *ResourceCommand) getCollection(ctx context.Context, client *authclient
 		return namedResourceCollection(resources), nil
 	case types.KindSigstorePolicy:
 		c := client.SigstorePolicyResourceServiceClient()
-		if rc.ref.Name != "" {
+		if ref.Name != "" {
 			r, err := c.GetSigstorePolicy(
 				ctx,
 				&workloadidentityv1pb.GetSigstorePolicyRequest{
-					Name: rc.ref.Name,
+					Name: ref.Name,
 				},
 			)
 			if err != nil {
@@ -3620,8 +3788,8 @@ func (rc *ResourceCommand) getCollection(ctx context.Context, client *authclient
 
 		return namedResourceCollection(resources), nil
 	case types.KindHealthCheckConfig:
-		if rc.ref.Name != "" {
-			cfg, err := client.GetHealthCheckConfig(ctx, rc.ref.Name)
+		if ref.Name != "" {
+			cfg, err := client.GetHealthCheckConfig(ctx, ref.Name)
 			if err != nil {
 				return nil, trace.Wrap(err)
 			}
@@ -3637,8 +3805,8 @@ func (rc *ResourceCommand) getCollection(ctx context.Context, client *authclient
 
 		return &healthCheckConfigCollection{items: items}, nil
 	case types.KindRelayServer:
-		if rc.ref.Name != "" {
-			rs, err := client.GetRelayServer(ctx, rc.ref.Name)
+		if ref.Name != "" {
+			rs, err := client.GetRelayServer(ctx, ref.Name)
 			if err != nil {
 				return nil, trace.Wrap(err)
 			}
@@ -3653,23 +3821,23 @@ func (rc *ResourceCommand) getCollection(ctx context.Context, client *authclient
 		}
 		return c, nil
 	case types.KindInferenceModel:
-		models, err := rc.getInferenceModels(ctx, client)
+		models, err := rc.getInferenceModels(ctx, client, ref)
 		return models, trace.Wrap(err)
 	case types.KindInferenceSecret:
-		secrets, err := rc.getInferenceSecrets(ctx, client)
+		secrets, err := rc.getInferenceSecrets(ctx, client, ref)
 		return secrets, trace.Wrap(err)
 	case types.KindInferencePolicy:
-		policies, err := rc.getInferencePolicies(ctx, client)
+		policies, err := rc.getInferencePolicies(ctx, client, ref)
 		return policies, trace.Wrap(err)
 	case types.KindRetrievalModel:
 		models, err := rc.getRetrievalModel(ctx, client)
 		return models, trace.Wrap(err)
 	case types.KindWorkloadCluster:
-		if rc.ref.Name != "" {
-			cluster, err := client.GetWorkloadCluster(ctx, rc.ref.Name)
+		if ref.Name != "" {
+			cluster, err := client.GetWorkloadCluster(ctx, ref.Name)
 			if err != nil {
 				if trace.IsNotFound(err) {
-					return nil, trace.NotFound("workload_cluster %q not found", rc.ref.Name)
+					return nil, trace.NotFound("workload_cluster %q not found", ref.Name)
 				}
 				return nil, trace.Wrap(err)
 			}
@@ -3683,9 +3851,9 @@ func (rc *ResourceCommand) getCollection(ctx context.Context, client *authclient
 		}
 		return &workloadClusterCollection{workloadClusters: clusters}, nil
 	case types.KindCertAuthorityOverride:
-		return rc.getCAOverrides(ctx, client)
+		return rc.getCAOverrides(ctx, client, ref)
 	}
-	return nil, trace.BadParameter("getting %q is not supported", rc.ref.String())
+	return nil, trace.BadParameter("getting %q is not supported", ref.String())
 }
 
 func getSAMLConnectors(ctx context.Context, client *authclient.Client, name string, withSecrets bool) ([]types.SAMLConnector, error) {
@@ -4065,7 +4233,6 @@ func (rc *ResourceCommand) createAutoUpdateConfig(ctx context.Context, client *a
 	if err != nil {
 		return trace.Wrap(err)
 	}
-
 	if config.GetMetadata() == nil {
 		config.Metadata = &headerv1.Metadata{}
 	}

--- a/tool/tctl/common/resource_command_test.go
+++ b/tool/tctl/common/resource_command_test.go
@@ -390,7 +390,7 @@ version: v1
 	var raw []byte
 	for {
 		// Get the scoped role
-		buff, err := runResourceCommand(t, clt, []string{"get", "scoped_role/some-role", "--format=json"})
+		buff, err := runResourceCommand(t, clt, []string{"get", "scoped_role", "/::some-role", "--format=json"})
 		if err == nil {
 			raw = buff.Bytes()
 			break
@@ -424,6 +424,33 @@ version: v1
 	}
 
 	require.Empty(t, cmp.Diff(expected, rs[0], protocmp.Transform(), protocmp.IgnoreFields(&headerv1.Metadata{}, "revision")))
+
+	// list-all for scoped_role (no SQN)
+	buff, err := runResourceCommand(t, clt, []string{"get", "scoped_role", "--format=json"})
+	require.NoError(t, err)
+	allRoles, err := services.UnmarshalProtoResourceArray[*scopedaccessv1.ScopedRole](buff.Bytes(), services.DisallowUnknown())
+	require.NoError(t, err)
+	require.Len(t, allRoles, 1)
+	require.Equal(t, "some-role", allRoles[0].GetMetadata().GetName())
+
+	// bare name without SQN separator should require a scope-qualified name
+	_, err = runResourceCommand(t, clt, []string{"get", "scoped_role", "some-role"})
+	require.True(t, trace.IsBadParameter(err), "expected BadParameter for bare name, got %v", err)
+	require.ErrorContains(t, err, "scope-qualified name")
+
+	// sub-kind segment on a type with no sub-kinds should be rejected on get
+	_, err = runResourceCommand(t, clt, []string{"get", "scoped_role/badsubkind", "/::some-role"})
+	require.True(t, trace.IsBadParameter(err), "expected BadParameter for invalid sub-kind on get, got %v", err)
+	require.ErrorContains(t, err, "does not support sub-kinds")
+
+	// sub-kind segment on a type with no sub-kinds should be rejected on delete
+	_, err = runResourceCommand(t, clt, []string{"rm", "scoped_role/badsubkind", "/::some-role"})
+	require.True(t, trace.IsBadParameter(err), "expected BadParameter for invalid sub-kind on delete, got %v", err)
+	require.ErrorContains(t, err, "does not support sub-kinds")
+
+	// scope mismatch on delete should return NotFound (role lives at "/", not "/wrong")
+	_, err = runResourceCommand(t, clt, []string{"rm", "scoped_role", "/wrong::some-role"})
+	require.True(t, trace.IsNotFound(err), "expected NotFound for scope mismatch on delete, got %v", err)
 
 	// now that a role exists, test commands for assignment creation
 
@@ -476,15 +503,15 @@ version: v1
 	assignmentName := as[0].GetMetadata().GetName()
 
 	// Ensure that retrieving the scoped role assignment with incorrect sub_kind fails.
-	_, err = runResourceCommand(t, clt, []string{"get", "scoped_role_assignment/materialized/" + assignmentName, "--format=json"})
+	_, err = runResourceCommand(t, clt, []string{"get", "scoped_role_assignment/materialized", "/::" + assignmentName, "--format=json"})
 	require.True(t, trace.IsNotFound(err), "expected NotFound error, got %v", err)
 
 	// Ensure that trying to retrieve the scoped role assignment without a subkind fails.
-	_, err = runResourceCommand(t, clt, []string{"get", "scoped_role_assignment/" + assignmentName, "--format=json"})
-	require.ErrorContains(t, err, "requires an explicit subkind")
+	_, err = runResourceCommand(t, clt, []string{"get", "scoped_role_assignment", "/::" + assignmentName, "--format=json"})
+	require.ErrorContains(t, err, "requires a sub-kind")
 
 	// Ensure that retrieving the scoped role assignment by name with explicit sub_kind works.
-	buff, err := runResourceCommand(t, clt, []string{"get", "scoped_role_assignment/dynamic/" + assignmentName, "--format=json"})
+	buff, err = runResourceCommand(t, clt, []string{"get", "scoped_role_assignment/dynamic", "/::" + assignmentName, "--format=json"})
 	require.NoError(t, err)
 	var asByName []*scopedaccessv1.ScopedRoleAssignment
 	err = json.Unmarshal(buff.Bytes(), &asByName)
@@ -514,23 +541,33 @@ version: v1
 
 	require.Empty(t, cmp.Diff(expectedAssignment, as[0], protocmp.Transform(), protocmp.IgnoreFields(&headerv1.Metadata{}, "revision")))
 
+	// a bare segment for a scoped-only resource (previously treated as a name)
+	// should now be an explicit error rather than silently returning all resources.
+	_, err = runResourceCommand(t, clt, []string{"get", "scoped_role_assignment/dynamic"})
+	require.True(t, trace.IsBadParameter(err), "expected BadParameter for old-format subkind filter, got %v", err)
+	require.ErrorContains(t, err, "scope-qualified name")
+
+	// scope mismatch on delete should return NotFound (assignment lives at "/", not "/wrong")
+	_, err = runResourceCommand(t, clt, []string{"rm", "scoped_role_assignment/dynamic", "/wrong::" + assignmentName})
+	require.True(t, trace.IsNotFound(err), "expected NotFound for scope mismatch on assignment delete, got %v", err)
+
 	// verify delete of assignment fails without subkind
-	_, err = runResourceCommand(t, clt, []string{"rm", "scoped_role_assignment/" + assignmentName})
-	require.ErrorContains(t, err, "requires an explicit subkind")
+	_, err = runResourceCommand(t, clt, []string{"rm", "scoped_role_assignment", "/::" + assignmentName})
+	require.ErrorContains(t, err, "requires a sub-kind")
 
 	// verify delete of assignment fails without materialized subkind.
-	_, err = runResourceCommand(t, clt, []string{"rm", "scoped_role_assignment/materialized/" + assignmentName})
+	_, err = runResourceCommand(t, clt, []string{"rm", "scoped_role_assignment/materialized", "/::" + assignmentName})
 	require.ErrorContains(t, err, "cannot be deleted")
 
 	// verify delete of assignment
-	_, err = runResourceCommand(t, clt, []string{"rm", "scoped_role_assignment/dynamic/" + assignmentName})
+	_, err = runResourceCommand(t, clt, []string{"rm", "scoped_role_assignment/dynamic", "/::" + assignmentName})
 	require.NoError(t, err)
 
 	// wait for delete cache propagation
 	timeout = time.After(time.Second * 30)
 	for {
 		// verify assignment is gone
-		_, err = runResourceCommand(t, clt, []string{"get", "scoped_role_assignment/dynamic/" + assignmentName, "--format=json"})
+		_, err = runResourceCommand(t, clt, []string{"get", "scoped_role_assignment/dynamic", "/::" + assignmentName, "--format=json"})
 		if err != nil {
 			require.True(t, trace.IsNotFound(err), "expected a NotFound error, got %v", err)
 			break
@@ -544,14 +581,14 @@ version: v1
 	}
 
 	// verify delete of role
-	_, err = runResourceCommand(t, clt, []string{"rm", "scoped_role/some-role"})
+	_, err = runResourceCommand(t, clt, []string{"rm", "scoped_role", "/::some-role"})
 	require.NoError(t, err)
 
 	// wait for delete cache propagation
 	timeout = time.After(time.Second * 30)
 	for {
 		// verify role is gone
-		_, err = runResourceCommand(t, clt, []string{"get", "scoped_role/some-role", "--format=json"})
+		_, err = runResourceCommand(t, clt, []string{"get", "scoped_role", "/::some-role", "--format=json"})
 		if err != nil {
 			require.True(t, trace.IsNotFound(err), "expected a NotFound error, got %v", err)
 			break
@@ -639,7 +676,7 @@ spec:
 	var raw []byte
 	require.EventuallyWithT(t, func(ct *assert.CollectT) {
 		// Get the scoped token by name
-		buff, err := runResourceCommand(t, clt, []string{"get", "scoped_token/test-token", "--format=json"})
+		buff, err := runResourceCommand(t, clt, []string{"get", "scoped_token", "/::test-token", "--format=json"})
 		require.NoError(t, err)
 		raw = buff.Bytes()
 	}, time.Second*30, time.Millisecond*100, "Timed out waiting for scoped token cache propagation")
@@ -659,6 +696,26 @@ spec:
 	require.Equal(t, "unlimited", token.GetSpec().GetUsageMode())
 	// Secret is stripped server-side when not requested with --with-secrets.
 	require.Empty(t, token.GetStatus().GetSecret())
+
+	// A bare name (no :: separator) should produce a helpful "scope-qualified name" error.
+	_, err = runResourceCommand(t, clt, []string{"get", "scoped_token", "test-token"})
+	require.ErrorContains(t, err, "scope-qualified name")
+	_, err = runResourceCommand(t, clt, []string{"rm", "scoped_token", "test-token"})
+	require.ErrorContains(t, err, "scope-qualified name")
+
+	// sub-kind segment on a type with no sub-kinds should be rejected on get
+	_, err = runResourceCommand(t, clt, []string{"get", "scoped_token/badsubkind", "/::test-token"})
+	require.True(t, trace.IsBadParameter(err), "expected BadParameter for invalid sub-kind on get, got %v", err)
+	require.ErrorContains(t, err, "does not support sub-kinds")
+
+	// sub-kind segment on a type with no sub-kinds should be rejected on delete
+	_, err = runResourceCommand(t, clt, []string{"rm", "scoped_token/badsubkind", "/::test-token"})
+	require.True(t, trace.IsBadParameter(err), "expected BadParameter for invalid sub-kind on delete, got %v", err)
+	require.ErrorContains(t, err, "does not support sub-kinds")
+
+	// scope mismatch on delete should return NotFound (token lives at "/", not "/wrong")
+	_, err = runResourceCommand(t, clt, []string{"rm", "scoped_token", "/wrong::test-token"})
+	require.True(t, trace.IsNotFound(err), "expected NotFound for scope mismatch on delete, got %v", err)
 
 	// Get all scoped tokens
 	buff, err := runResourceCommand(t, clt, []string{"get", "scoped_token", "--format=json", "--with-secrets"})
@@ -694,7 +751,7 @@ spec:
 
 	// Wait for cache propagation and verify the update took effect
 	require.EventuallyWithT(t, func(ct *assert.CollectT) {
-		buff, err := runResourceCommand(t, clt, []string{"get", "scoped_token/test-token", "--format=json"})
+		buff, err := runResourceCommand(t, clt, []string{"get", "scoped_token", "/::test-token", "--format=json"})
 		require.NoError(t, err)
 		updated, err := services.UnmarshalProtoResourceArray[*joiningv1.ScopedToken](buff.Bytes(), services.DisallowUnknown())
 		require.NoError(t, err)
@@ -705,12 +762,12 @@ spec:
 	}, time.Second*30, time.Millisecond*100, "Timed out waiting for upserted scoped token cache propagation")
 
 	// verify delete of token
-	_, err = runResourceCommand(t, clt, []string{"rm", "scoped_token/test-token"})
+	_, err = runResourceCommand(t, clt, []string{"rm", "scoped_token", "/::test-token"})
 	require.NoError(t, err)
 
 	// wait for delete cache propagation
 	require.EventuallyWithT(t, func(ct *assert.CollectT) {
-		_, err = runResourceCommand(t, clt, []string{"get", "scoped_token/test-token", "--format=json"})
+		_, err = runResourceCommand(t, clt, []string{"get", "scoped_token", "/::test-token", "--format=json"})
 		require.True(ct, trace.IsNotFound(err))
 	}, time.Second*30, time.Millisecond*100, "Timed out waiting for scoped token cache propagation")
 
@@ -723,7 +780,7 @@ spec:
 
 	// Wait for cache propagation.
 	require.EventuallyWithT(t, func(ct *assert.CollectT) {
-		_, err := runResourceCommand(t, clt, []string{"get", "scoped_token/gcp-test-token", "--format=json"})
+		_, err := runResourceCommand(t, clt, []string{"get", "scoped_token", "/::gcp-test-token", "--format=json"})
 		require.NoError(ct, err)
 	}, time.Second*30, time.Millisecond*100, "Timed out waiting for GCP scoped token cache propagation")
 
@@ -737,6 +794,203 @@ spec:
 	require.Equal(t, "gcp", gcpTokens[0].GetSpec().GetJoinMethod())
 	require.Len(t, gcpTokens[0].GetSpec().GetGcp().GetAllow(), 1)
 	require.Equal(t, []string{"example-project-123456"}, gcpTokens[0].GetSpec().GetGcp().GetAllow()[0].GetProjectIds())
+
+	// Verify scope mismatch: name exists at "/" but a different scope is requested. Must produce
+	// a NotFound error to comply with namespacing behavior. Future iterations may not be able
+	// to provide hints as namespacing may prevent it.
+	_, err = runResourceCommand(t, clt, []string{"get", "scoped_token", "/other-scope::gcp-test-token", "--format=json"})
+	require.True(t, trace.IsNotFound(err), "expected NotFound for scope mismatch, got: %v", err)
+	require.ErrorContains(t, err, "tctl get scoped_token /::gcp-test-token")
+}
+
+// TestScopedAndUnscopedNodeResource exercises tctl get/rm on nodes which are double
+// registered as both a scoped and unscoped resource handler in order to support a
+// mix of scope and classic style interactions. This test is intended specifically
+// to help verify that we are handling double-registration sensibly.
+func TestScopedAndUnscopedNodeResource(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	dynAddr := helpers.NewDynamicServiceAddr(t)
+	fileConfig := &config.FileConfig{
+		Global: config.Global{DataDir: t.TempDir()},
+		Proxy: config.Proxy{
+			Service: config.Service{EnabledFlag: "true"},
+			WebAddr: dynAddr.WebAddr,
+			TunAddr: dynAddr.TunnelAddr,
+		},
+		Auth: config.Auth{
+			Service: config.Service{
+				EnabledFlag:   "true",
+				ListenAddress: dynAddr.AuthAddr,
+			},
+		},
+	}
+	auth := makeAndRunTestAuthServer(t, withFileConfig(fileConfig), withFileDescriptors(dynAddr.Descriptors))
+	clt, err := testenv.NewDefaultAuthClient(auth)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = clt.Close() })
+
+	// classicNode has no explicit scope (scope == "").
+	classicNode, err := types.NewServer("unscoped-node", types.KindNode, types.ServerSpecV2{
+		Hostname: "unscoped-host",
+		Addr:     "127.0.0.1:22",
+	})
+	require.NoError(t, err)
+	_, err = clt.UpsertNode(ctx, classicNode)
+	require.NoError(t, err)
+
+	// scopedNode has scope "/" so SQN lookups with "/::scoped-node" succeed.
+	scopedNode, err := types.NewServer("scoped-node", types.KindNode, types.ServerSpecV2{
+		Hostname: "scoped-host",
+		Addr:     "127.0.0.1:23",
+	})
+	require.NoError(t, err)
+	scopedNode.(*types.ServerV2).Scope = "/staging"
+	_, err = clt.UpsertNode(ctx, scopedNode)
+	require.NoError(t, err)
+
+	// Poll until both nodes appear via the unified-resource list (cache propagation).
+	timeout := time.After(30 * time.Second)
+	for {
+		buf, err := runResourceCommand(t, clt, []string{"get", "node", "--format=json"})
+		if err == nil && strings.Contains(buf.String(), "scoped-node") && strings.Contains(buf.String(), "unscoped-node") {
+			break
+		}
+		select {
+		case <-timeout:
+			require.FailNow(t, "timed out waiting for nodes to appear in list")
+		case <-time.After(100 * time.Millisecond):
+		}
+	}
+
+	t.Run("list all", func(t *testing.T) {
+		buf, err := runResourceCommand(t, clt, []string{"get", "node", "--format=json"})
+		require.NoError(t, err)
+		out := buf.String()
+		require.Contains(t, out, "unscoped-node")
+		require.Contains(t, out, "scoped-node")
+	})
+
+	t.Run("single-arg unscoped get", func(t *testing.T) {
+		buf, err := runResourceCommand(t, clt, []string{"get", "node/unscoped-node", "--format=json"})
+		require.NoError(t, err)
+		require.Contains(t, buf.String(), "unscoped-node")
+	})
+
+	t.Run("two-arg unscoped get", func(t *testing.T) {
+		buf, err := runResourceCommand(t, clt, []string{"get", "node", "unscoped-node", "--format=json"})
+		require.NoError(t, err)
+		require.Contains(t, buf.String(), "unscoped-node")
+	})
+
+	t.Run("scope-qualified get", func(t *testing.T) {
+		buf, err := runResourceCommand(t, clt, []string{"get", "node", "/staging::scoped-node", "--format=json"})
+		require.NoError(t, err)
+		require.Contains(t, buf.String(), "scoped-node")
+	})
+
+	t.Run("scope-qualified get with scope mismatch", func(t *testing.T) {
+		_, err := runResourceCommand(t, clt, []string{"get", "node", "/prod::scoped-node", "--format=json"})
+		require.True(t, trace.IsNotFound(err), "expected NotFound on scope mismatch, got: %v", err)
+	})
+
+	t.Run("scope-qualified delete with scope mismatch", func(t *testing.T) {
+		_, err := runResourceCommand(t, clt, []string{"rm", "node", "/prod::scoped-node"})
+		require.True(t, trace.IsNotFound(err), "expected NotFound on scope mismatch delete, got: %v", err)
+	})
+
+	t.Run("edit via single-arg classic form", func(t *testing.T) {
+		editor := func(name string) error {
+			data, err := os.ReadFile(name)
+			if err != nil {
+				return err
+			}
+			data = bytes.ReplaceAll(data, []byte("unscoped-host"), []byte("unscoped-host-edited"))
+			return os.WriteFile(name, data, 0600)
+		}
+		_, err := runEditCommand(t, clt, []string{"edit", "node/unscoped-node"}, withEditor(editor))
+		require.NoError(t, err)
+
+		timeout := time.After(30 * time.Second)
+		for {
+			node, err := clt.GetNode(ctx, apidefaults.Namespace, "unscoped-node")
+			if err == nil && node.GetHostname() == "unscoped-host-edited" {
+				break
+			}
+			require.NoError(t, err, "unexpected error waiting for unscoped-node edit")
+			select {
+			case <-timeout:
+				require.FailNow(t, "timed out waiting for unscoped-node hostname edit")
+			case <-time.After(100 * time.Millisecond):
+			}
+		}
+	})
+
+	t.Run("edit via two-arg SQN form", func(t *testing.T) {
+		editor := func(name string) error {
+			data, err := os.ReadFile(name)
+			if err != nil {
+				return err
+			}
+			data = bytes.ReplaceAll(data, []byte("scoped-host"), []byte("scoped-host-edited"))
+			return os.WriteFile(name, data, 0600)
+		}
+		_, err := runEditCommand(t, clt, []string{"edit", "node", "/staging::scoped-node"}, withEditor(editor))
+		require.NoError(t, err)
+
+		timeout := time.After(30 * time.Second)
+		for {
+			node, err := clt.GetNode(ctx, apidefaults.Namespace, "scoped-node")
+			if err == nil && node.GetHostname() == "scoped-host-edited" {
+				break
+			}
+			require.NoError(t, err, "unexpected error waiting for scoped-node edit")
+			select {
+			case <-timeout:
+				require.FailNow(t, "timed out waiting for scoped-node hostname edit")
+			case <-time.After(100 * time.Millisecond):
+			}
+		}
+	})
+
+	t.Run("scope-qualified delete", func(t *testing.T) {
+		_, err := runResourceCommand(t, clt, []string{"rm", "node", "/staging::scoped-node"})
+		require.NoError(t, err)
+
+		timeout := time.After(30 * time.Second)
+		for {
+			_, err = clt.GetNode(ctx, apidefaults.Namespace, "scoped-node")
+			if trace.IsNotFound(err) {
+				break
+			}
+			require.NoError(t, err, "unexpected error waiting for scoped-node deletion")
+			select {
+			case <-timeout:
+				require.FailNow(t, "timed out waiting for scoped-node to be deleted")
+			case <-time.After(100 * time.Millisecond):
+			}
+		}
+	})
+
+	t.Run("two-arg unscoped delete", func(t *testing.T) {
+		_, err := runResourceCommand(t, clt, []string{"rm", "node", "unscoped-node"})
+		require.NoError(t, err)
+
+		timeout := time.After(30 * time.Second)
+		for {
+			_, err = clt.GetNode(ctx, apidefaults.Namespace, "unscoped-node")
+			if trace.IsNotFound(err) {
+				break
+			}
+			require.NoError(t, err, "unexpected error waiting for unscoped-node deletion")
+			select {
+			case <-timeout:
+				require.FailNow(t, "timed out waiting for unscoped-node to be deleted")
+			case <-time.After(100 * time.Millisecond):
+			}
+		}
+	})
 }
 
 // TestIntegrationResource tests tctl integration commands.
@@ -3161,6 +3415,80 @@ func TestPluginResourceWrapper(t *testing.T) {
 			err = json.Unmarshal(buff, &item)
 			require.NoError(t, err)
 			require.Empty(t, cmp.Diff(tc.plugin, item.PluginV1))
+		})
+	}
+}
+
+func TestParseScopedRef(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		ref     string
+		id      string
+		want    ScopedRef
+		wantErr bool
+	}{
+		{
+			name: "empty id returns ref unchanged",
+			ref:  "role/myrole",
+			id:   "",
+			want: ScopedRef{Kind: "role", Name: "myrole"},
+		},
+		{
+			name: "bare name, no subkind",
+			ref:  "scoped_role",
+			id:   "myrole",
+			want: ScopedRef{Kind: "scoped_role", Name: "myrole"},
+		},
+		{
+			name: "bare name with subkind promotion",
+			ref:  "scoped_role_assignment/dynamic",
+			id:   "myassignment",
+			want: ScopedRef{Kind: "scoped_role_assignment", SubKind: "dynamic", Name: "myassignment"},
+		},
+		{
+			name: "SQN, no subkind",
+			ref:  "scoped_role",
+			id:   "/staging/west::myrole",
+			want: ScopedRef{Kind: "scoped_role", Scope: "/staging/west", Name: "myrole"},
+		},
+		{
+			name: "SQN with subkind promotion",
+			ref:  "scoped_role_assignment/dynamic",
+			id:   "/staging/west::myassignment",
+			want: ScopedRef{Kind: "scoped_role_assignment", SubKind: "dynamic", Scope: "/staging/west", Name: "myassignment"},
+		},
+		{
+			name: "root scope SQN",
+			ref:  "scoped_token",
+			id:   "/::test-token",
+			want: ScopedRef{Kind: "scoped_token", Scope: "/", Name: "test-token"},
+		},
+		{
+			name:    "three-segment first arg with second arg is an error",
+			ref:     "scoped_role_assignment/dynamic/myassignment",
+			id:      "/staging::extra",
+			wantErr: true,
+		},
+		{
+			name:    "invalid SQN is an error",
+			ref:     "scoped_role",
+			id:      "/staging::my role",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := ParseScopedRef(tt.ref, tt.id)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tt.want, got)
 		})
 	}
 }

--- a/tool/tctl/common/resource_health_check_config.go
+++ b/tool/tctl/common/resource_health_check_config.go
@@ -56,10 +56,10 @@ func (rc *ResourceCommand) updateHealthCheckConfig(ctx context.Context, clt *aut
 	return nil
 }
 
-func (rc *ResourceCommand) deleteHealthCheckConfig(ctx context.Context, clt *authclient.Client) error {
-	if err := clt.DeleteHealthCheckConfig(ctx, rc.ref.Name); err != nil {
+func (rc *ResourceCommand) deleteHealthCheckConfig(ctx context.Context, clt *authclient.Client, name string) error {
+	if err := clt.DeleteHealthCheckConfig(ctx, name); err != nil {
 		return trace.Wrap(err)
 	}
-	fmt.Printf("health_check_config %q has been deleted\n", rc.ref.Name)
+	fmt.Printf("health_check_config %q has been deleted\n", name)
 	return nil
 }

--- a/tool/tctl/common/resource_summarizer.go
+++ b/tool/tctl/common/resource_summarizer.go
@@ -87,12 +87,12 @@ func (rc *ResourceCommand) updateInferenceModel(
 
 // getInferenceModels retrieves one or more inference model resources.
 func (rc *ResourceCommand) getInferenceModels(
-	ctx context.Context, clt *authclient.Client,
+	ctx context.Context, clt *authclient.Client, ref services.Ref,
 ) (resources.Collection, error) {
 	ssclt := clt.SummarizerServiceClient()
-	if rc.ref.Name != "" {
+	if ref.Name != "" {
 		req := &summarizerv1.GetInferenceModelRequest{
-			Name: rc.ref.Name,
+			Name: ref.Name,
 		}
 		res, err := ssclt.GetInferenceModel(ctx, req)
 		if err != nil {
@@ -121,15 +121,15 @@ func (rc *ResourceCommand) getInferenceModels(
 
 // deleteInferenceModel deletes an inference model resource.
 func (rc *ResourceCommand) deleteInferenceModel(
-	ctx context.Context, clt *authclient.Client,
+	ctx context.Context, clt *authclient.Client, ref services.Ref,
 ) error {
 	req := &summarizerv1.DeleteInferenceModelRequest{
-		Name: rc.ref.Name,
+		Name: ref.Name,
 	}
 	if _, err := clt.SummarizerServiceClient().DeleteInferenceModel(ctx, req); err != nil {
 		return trace.Wrap(err)
 	}
-	fmt.Printf("inference_model %q has been deleted\n", rc.ref.Name)
+	fmt.Printf("inference_model %q has been deleted\n", ref.Name)
 	return nil
 }
 
@@ -211,12 +211,12 @@ func (rc *ResourceCommand) createInferenceSecret(
 
 // getInferenceSecrets retrieves one or more inference secret resources.
 func (rc *ResourceCommand) getInferenceSecrets(
-	ctx context.Context, clt *authclient.Client,
+	ctx context.Context, clt *authclient.Client, ref services.Ref,
 ) (resources.Collection, error) {
 	ssclt := clt.SummarizerServiceClient()
-	if rc.ref.Name != "" {
+	if ref.Name != "" {
 		req := &summarizerv1.GetInferenceSecretRequest{
-			Name: rc.ref.Name,
+			Name: ref.Name,
 		}
 		res, err := ssclt.GetInferenceSecret(ctx, req)
 		if err != nil {
@@ -244,15 +244,15 @@ func (rc *ResourceCommand) getInferenceSecrets(
 }
 
 func (rc *ResourceCommand) deleteInferenceSecret(
-	ctx context.Context, clt *authclient.Client,
+	ctx context.Context, clt *authclient.Client, ref services.Ref,
 ) error {
 	req := &summarizerv1.DeleteInferenceSecretRequest{
-		Name: rc.ref.Name,
+		Name: ref.Name,
 	}
 	if _, err := clt.SummarizerServiceClient().DeleteInferenceSecret(ctx, req); err != nil {
 		return trace.Wrap(err)
 	}
-	fmt.Printf("inference_secret %q has been deleted\n", rc.ref.Name)
+	fmt.Printf("inference_secret %q has been deleted\n", ref.Name)
 	return nil
 }
 
@@ -344,12 +344,12 @@ func (rc *ResourceCommand) updateInferencePolicy(
 
 // getInferencePolicies retrieves one or more inference policy resources.
 func (rc *ResourceCommand) getInferencePolicies(
-	ctx context.Context, clt *authclient.Client,
+	ctx context.Context, clt *authclient.Client, ref services.Ref,
 ) (resources.Collection, error) {
 	ssclt := clt.SummarizerServiceClient()
-	if rc.ref.Name != "" {
+	if ref.Name != "" {
 		req := &summarizerv1.GetInferencePolicyRequest{
-			Name: rc.ref.Name,
+			Name: ref.Name,
 		}
 		res, err := ssclt.GetInferencePolicy(ctx, req)
 		if err != nil {
@@ -378,15 +378,15 @@ func (rc *ResourceCommand) getInferencePolicies(
 
 // deleteInferencePolicy deletes an inference policy resource.
 func (rc *ResourceCommand) deleteInferencePolicy(
-	ctx context.Context, clt *authclient.Client,
+	ctx context.Context, clt *authclient.Client, ref services.Ref,
 ) error {
 	req := &summarizerv1.DeleteInferencePolicyRequest{
-		Name: rc.ref.Name,
+		Name: ref.Name,
 	}
 	if _, err := clt.SummarizerServiceClient().DeleteInferencePolicy(ctx, req); err != nil {
 		return trace.Wrap(err)
 	}
-	fmt.Printf("inference_policy %q has been deleted\n", rc.ref.Name)
+	fmt.Printf("inference_policy %q has been deleted\n", ref.Name)
 	return nil
 }
 

--- a/tool/tctl/common/resources/resource.go
+++ b/tool/tctl/common/resources/resource.go
@@ -25,7 +25,6 @@ import (
 
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/auth/authclient"
-	scopedaccess "github.com/gravitational/teleport/lib/scopes/access"
 	"github.com/gravitational/teleport/lib/services"
 )
 
@@ -34,11 +33,10 @@ import (
 // to the Handler format.
 func Handlers() map[string]Handler {
 	// When adding resources, please keep the map alphabetically ordered.
+	// Note: scoped_role, scoped_role_assignment, and scoped_token are registered in
+	// ScopedHandlers() rather than here because they require scope-qualified names.
 	return map[string]Handler{
-		scopedaccess.KindScopedRole:           scopedRoleHandler(),
-		scopedaccess.KindScopedRoleAssignment: scopedRoleAssignmentHandler(),
-		scopedaccess.KindScopedToken:          scopedTokenHandler(),
-		types.KindNode:                        serverHandler(),
+		types.KindNode: serverHandler(),
 	}
 }
 

--- a/tool/tctl/common/resources/scoped_handler.go
+++ b/tool/tctl/common/resources/scoped_handler.go
@@ -1,0 +1,165 @@
+// Teleport
+// Copyright (C) 2026  Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package resources
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/gravitational/trace"
+
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/auth/authclient"
+	"github.com/gravitational/teleport/lib/scopes"
+	scopedaccess "github.com/gravitational/teleport/lib/scopes/access"
+	"github.com/gravitational/teleport/lib/services"
+)
+
+// ScopedHandlers returns a map of ScopedHandler per kind for resource types that
+// require scope-qualified names. Resource types that also support classic (unscoped)
+// access can register in both Handlers() and ScopedHandlers().
+func ScopedHandlers() map[string]ScopedHandler {
+	return map[string]ScopedHandler{
+		types.KindNode:                        serverScopedHandler(),
+		scopedaccess.KindScopedRole:           scopedRoleScopedHandler(),
+		types.KindScopedToken:                 scopedTokenScopedHandler(),
+		scopedaccess.KindScopedRoleAssignment: scopedRoleAssignmentScopedHandler(),
+	}
+}
+
+// ScopedHandler represents a scoped resource supported by tctl resource commands.
+// Get and delete operations for scoped handlers require an explicit scope-qualified
+// name to disambiguate types in different scopes.
+//
+// Create and update retain the classic [services.UnknownResource] signature because
+// the scope travels in the resource itself, not in the CLI args.
+type ScopedHandler struct {
+	// getHandler powers "tctl get <kind>[/<subkind>] <scope>::<name>" and "tctl get <kind>"
+	// (list all). A nil qn lists all resources; a non-nil qn fetches a single resource.
+	getHandler func(ctx context.Context, client *authclient.Client, subKind string, sqn *scopes.QualifiedName, opts GetOpts) (Collection, error)
+	// deleteHandler powers "tctl rm <kind>[/<subkind>] <scope>::<name>". The SQN is always
+	// non-nil at call time. subKind is empty when the user omits the sub-kind segment.
+	deleteHandler func(ctx context.Context, client *authclient.Client, subKind string, sqn scopes.QualifiedName) error
+	// createHandler powers "tctl create". Scope comes from the resource.
+	createHandler func(ctx context.Context, client *authclient.Client, raw services.UnknownResource, opts CreateOpts) error
+	// updateHandler powers "tctl edit". Scope comes from the resource.
+	updateHandler func(ctx context.Context, client *authclient.Client, raw services.UnknownResource, opts CreateOpts) error
+	// description is a resource description used by "tctl list-kinds".
+	description string
+	// mfaRequired informs "tctl get" whether the resource is read sensitive.
+	mfaRequired bool
+}
+
+// Get queries the cluster for a scoped resource collection.
+// A nil sqn lists all resources of this kind.
+// A non-nil sqn returns only the resource matching that scope and name.
+func (h *ScopedHandler) Get(ctx context.Context, clt *authclient.Client, subKind string, sqn *scopes.QualifiedName, opts GetOpts) (Collection, error) {
+	if h.getHandler == nil {
+		return nil, trace.NotImplemented("resource does not support 'tctl get'")
+	}
+	return h.getHandler(ctx, clt, subKind, sqn, opts)
+}
+
+// Create takes a raw resource manifest and creates the resource.
+func (h *ScopedHandler) Create(ctx context.Context, clt *authclient.Client, raw services.UnknownResource, opts CreateOpts) error {
+	if h.createHandler == nil {
+		return trace.NotImplemented("resource does not support 'tctl create'")
+	}
+	return h.createHandler(ctx, clt, raw, opts)
+}
+
+// Update takes a raw resource manifest and updates the resource.
+func (h *ScopedHandler) Update(ctx context.Context, clt *authclient.Client, raw services.UnknownResource, opts CreateOpts) error {
+	if h.updateHandler == nil {
+		return trace.NotImplemented("resource does not have an update handler")
+	}
+	return h.updateHandler(ctx, clt, raw, opts)
+}
+
+// Delete deletes a scoped resource by its qualified name.
+// subKind is required for resource types that have sub-kinds; pass "" otherwise.
+func (h *ScopedHandler) Delete(ctx context.Context, clt *authclient.Client, subKind string, sqn scopes.QualifiedName) error {
+	if h.deleteHandler == nil {
+		return trace.NotImplemented("resource does not support 'tctl rm'")
+	}
+	return h.deleteHandler(ctx, clt, subKind, sqn)
+}
+
+// MFARequired indicates that this resource requires MFA to Get.
+func (h *ScopedHandler) MFARequired() bool {
+	return h.mfaRequired
+}
+
+// Description returns the description of the handler's resource.
+func (h *ScopedHandler) Description() string {
+	return h.description
+}
+
+// SupportedCommands returns the list of tctl commands this handler supports.
+func (h *ScopedHandler) SupportedCommands() []string {
+	var verbs []string
+	if h.getHandler != nil {
+		verbs = append(verbs, "get")
+	}
+	if h.createHandler != nil {
+		verbs = append(verbs, "create")
+	}
+	if h.deleteHandler != nil {
+		verbs = append(verbs, "rm")
+	}
+	// No check on the update handler for the "update" command because it is not
+	// doing anything useful today: https://github.com/gravitational/teleport/issues/61381
+
+	return verbs
+}
+
+// rejectSubKind returns an error for resource types that don't support sub-kinds.
+// The error message also covers the case where the user may have intended the segment
+// as a resource name, directing them toward the scope-qualified name form.
+func rejectSubKind(kind, subKind string) error {
+	return trace.BadParameter(
+		"resource type %q does not support sub-kinds (got %q)\n"+
+			"hint: if %q was intended as a resource name, provide it as a scope-qualified name:\n"+
+			"  tctl get %s <scope>::%s",
+		kind, subKind, subKind, kind, subKind,
+	)
+}
+
+// scopeMismatchNotFound builds a NotFound error for the pre-namespacing case where a
+// resource was found by name but lives in a different scope than requested. This mirrors
+// the behavior that namespacing will make automatic: from the perspective of the requested
+// scope, the resource does not exist.
+//
+// Note: this check is client-side and inherently racy as the resource's scope could change
+// between the lookup and the caller's subsequent action. It is a temporary measure to
+// prevent obviously misleading results until the backend APIs are updated to accept
+// scope-qualified identifiers natively and enforce the scope constraint server-side.
+func scopeMismatchNotFound(kind string, requested scopes.QualifiedName, actualScope string) error {
+	var hint string
+	if actualScope == "" {
+		// Resource is unscoped; the SQN form is not valid for unscoped resources.
+		hint = fmt.Sprintf("tctl get %s/%s", kind, requested.Name)
+	} else {
+		hint = fmt.Sprintf("tctl get %s %s::%s", kind, actualScope, requested.Name)
+	}
+	return trace.NotFound(
+		"%s %q not found in scope %q (a %s with that name exists in scope %q, try: %s)",
+		kind, requested.Name, requested.Scope,
+		kind, actualScope,
+		hint,
+	)
+}

--- a/tool/tctl/common/resources/scoped_role.go
+++ b/tool/tctl/common/resources/scoped_role.go
@@ -27,6 +27,7 @@ import (
 	"github.com/gravitational/teleport/lib/asciitable"
 	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/itertools/stream"
+	"github.com/gravitational/teleport/lib/scopes"
 	scopedaccess "github.com/gravitational/teleport/lib/scopes/access"
 	scopedutils "github.com/gravitational/teleport/lib/scopes/utils"
 	"github.com/gravitational/teleport/lib/services"
@@ -51,13 +52,10 @@ func (c *scopedRoleCollection) Resources() []types.Resource {
 }
 
 func (c *scopedRoleCollection) WriteText(w io.Writer, verbose bool) error {
-	headers := []string{"Scope", "Name"}
+	headers := []string{"ID"}
 	rows := make([][]string, len(c.roles))
 	for i, item := range c.roles {
-		rows[i] = []string{
-			item.GetScope(),
-			item.GetMetadata().GetName(),
-		}
+		rows[i] = []string{scopes.QualifiedName{Scope: item.GetScope(), Name: item.GetMetadata().GetName()}.String()}
 	}
 
 	t := asciitable.MakeTable(headers, rows...)
@@ -66,8 +64,8 @@ func (c *scopedRoleCollection) WriteText(w io.Writer, verbose bool) error {
 	return trace.Wrap(err)
 }
 
-func scopedRoleHandler() Handler {
-	return Handler{
+func scopedRoleScopedHandler() ScopedHandler {
+	return ScopedHandler{
 		getHandler:    getScopedRole,
 		createHandler: createScopedRole,
 		updateHandler: updateScopedRole,
@@ -133,16 +131,23 @@ func updateScopedRole(ctx context.Context, client *authclient.Client, raw servic
 	return nil
 }
 
-func getScopedRole(ctx context.Context, client *authclient.Client, ref services.Ref, opts GetOpts) (Collection, error) {
-	if ref.Name != "" {
+func getScopedRole(ctx context.Context, client *authclient.Client, subKind string, sqn *scopes.QualifiedName, opts GetOpts) (Collection, error) {
+	if subKind != "" {
+		return nil, rejectSubKind(scopedaccess.KindScopedRole, subKind)
+	}
+
+	if sqn != nil {
 		rsp, err := client.ScopedAccessServiceClient().GetScopedRole(ctx, scopedaccessv1.GetScopedRoleRequest_builder{
-			Name: ref.Name,
+			Name: sqn.Name,
 		}.Build())
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
-
-		return &scopedRoleCollection{roles: []*scopedaccessv1.ScopedRole{rsp.GetRole()}}, nil
+		role := rsp.GetRole()
+		if role.GetScope() != sqn.Scope {
+			return nil, scopeMismatchNotFound(scopedaccess.KindScopedRole, *sqn, role.GetScope())
+		}
+		return &scopedRoleCollection{roles: []*scopedaccessv1.ScopedRole{role}}, nil
 	}
 
 	items, err := stream.Collect(scopedutils.RangeScopedRoles(ctx, client.ScopedAccessServiceClient(), &scopedaccessv1.ListScopedRolesRequest{}))
@@ -152,16 +157,31 @@ func getScopedRole(ctx context.Context, client *authclient.Client, ref services.
 	return &scopedRoleCollection{roles: items}, nil
 }
 
-func deleteScopedRole(ctx context.Context, client *authclient.Client, ref services.Ref) error {
+func deleteScopedRole(ctx context.Context, client *authclient.Client, subKind string, sqn scopes.QualifiedName) error {
+	if subKind != "" {
+		return rejectSubKind(scopedaccess.KindScopedRole, subKind)
+	}
+
+	// Fetch first to verify scope before deleting.
+	rsp, err := client.ScopedAccessServiceClient().GetScopedRole(ctx, scopedaccessv1.GetScopedRoleRequest_builder{
+		Name: sqn.Name,
+	}.Build())
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	if rsp.GetRole().GetScope() != sqn.Scope {
+		return scopeMismatchNotFound(scopedaccess.KindScopedRole, sqn, rsp.GetRole().GetScope())
+	}
+
 	if _, err := client.ScopedAccessServiceClient().DeleteScopedRole(ctx, scopedaccessv1.DeleteScopedRoleRequest_builder{
-		Name: ref.Name,
+		Name: sqn.Name,
 	}.Build()); err != nil {
 		return trace.Wrap(err)
 	}
 	fmt.Printf(
 		"%v %q has been deleted\n",
 		scopedaccess.KindScopedRole,
-		ref.Name,
+		sqn.Name,
 	)
 	return nil
 }

--- a/tool/tctl/common/resources/scoped_role_assignment.go
+++ b/tool/tctl/common/resources/scoped_role_assignment.go
@@ -29,6 +29,7 @@ import (
 	"github.com/gravitational/teleport/lib/asciitable"
 	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/itertools/stream"
+	"github.com/gravitational/teleport/lib/scopes"
 	scopedaccess "github.com/gravitational/teleport/lib/scopes/access"
 	scopedutils "github.com/gravitational/teleport/lib/scopes/utils"
 	"github.com/gravitational/teleport/lib/services"
@@ -53,7 +54,7 @@ func (c *ScopedRoleAssignmentCollection) Resources() []types.Resource {
 }
 
 func (c *ScopedRoleAssignmentCollection) WriteText(w io.Writer, verbose bool) error {
-	headers := []string{"SubKind", "Scope", "Name", "User", "Assigns"}
+	headers := []string{"SubKind", "ID", "User", "Assigns"}
 	rows := make([][]string, len(c.roleAssignments))
 
 	for i, item := range c.roleAssignments {
@@ -61,11 +62,9 @@ func (c *ScopedRoleAssignmentCollection) WriteText(w io.Writer, verbose bool) er
 		for j, subAssignment := range item.GetSpec().GetAssignments() {
 			assigns[j] = fmt.Sprintf("%s -> %s", subAssignment.GetRole(), subAssignment.GetScope())
 		}
-
 		rows[i] = []string{
 			item.GetSubKind(),
-			item.GetScope(),
-			item.GetMetadata().GetName(),
+			scopes.QualifiedName{Scope: item.GetScope(), Name: item.GetMetadata().GetName()}.String(),
 			item.GetSpec().GetUser(),
 			strings.Join(assigns, ", "),
 		}
@@ -77,8 +76,8 @@ func (c *ScopedRoleAssignmentCollection) WriteText(w io.Writer, verbose bool) er
 	return trace.Wrap(err)
 }
 
-func scopedRoleAssignmentHandler() Handler {
-	return Handler{
+func scopedRoleAssignmentScopedHandler() ScopedHandler {
+	return ScopedHandler{
 		getHandler:    getScopedRoleAssignment,
 		createHandler: createScopedRoleAssignment,
 		updateHandler: updateScopedRoleAssignment,
@@ -148,20 +147,28 @@ func updateScopedRoleAssignment(ctx context.Context, client *authclient.Client, 
 	return nil
 }
 
-func getScopedRoleAssignment(ctx context.Context, client *authclient.Client, ref services.Ref, opts GetOpts) (Collection, error) {
-	if ref.Name != "" {
-		if ref.SubKind == "" {
-			return nil, trace.BadParameter("scoped_role_assignment requires an explicit subkind when getting a single resource, try: tctl get scoped_role_assignment/dynamic/%s", ref.Name)
+func getScopedRoleAssignment(ctx context.Context, client *authclient.Client, subKind string, sqn *scopes.QualifiedName, opts GetOpts) (Collection, error) {
+	if sqn != nil {
+		if subKind == "" {
+			return nil, trace.BadParameter(
+				"%s requires a sub-kind to get a specific resource, try:\n  tctl get %s/%s %s::%s",
+				scopedaccess.KindScopedRoleAssignment,
+				scopedaccess.KindScopedRoleAssignment, scopedaccess.SubKindDynamic,
+				sqn.Scope, sqn.Name,
+			)
 		}
 		rsp, err := client.ScopedAccessServiceClient().GetScopedRoleAssignment(ctx, scopedaccessv1.GetScopedRoleAssignmentRequest_builder{
-			Name:    ref.Name,
-			SubKind: ref.SubKind,
+			Name:    sqn.Name,
+			SubKind: subKind,
 		}.Build())
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
-
-		return &ScopedRoleAssignmentCollection{roleAssignments: []*scopedaccessv1.ScopedRoleAssignment{rsp.GetAssignment()}}, nil
+		assignment := rsp.GetAssignment()
+		if assignment.GetScope() != sqn.Scope {
+			return nil, scopeMismatchNotFound(scopedaccess.KindScopedRoleAssignment, *sqn, assignment.GetScope())
+		}
+		return &ScopedRoleAssignmentCollection{roleAssignments: []*scopedaccessv1.ScopedRoleAssignment{assignment}}, nil
 	}
 
 	items, err := stream.Collect(scopedutils.RangeScopedRoleAssignments(ctx, client.ScopedAccessServiceClient(), &scopedaccessv1.ListScopedRoleAssignmentsRequest{}))
@@ -171,23 +178,41 @@ func getScopedRoleAssignment(ctx context.Context, client *authclient.Client, ref
 	return NewScopedRoleAssignmentCollection(items), nil
 }
 
-func deleteScopedRoleAssignment(ctx context.Context, client *authclient.Client, ref services.Ref) error {
-	if ref.SubKind == "" {
-		return trace.BadParameter("scoped_role_assignment requires an explicit subkind when deleting a resource, try: tctl rm scoped_role_assignment/%s/%s", scopedaccess.SubKindDynamic, ref.Name)
+func deleteScopedRoleAssignment(ctx context.Context, client *authclient.Client, subKind string, sqn scopes.QualifiedName) error {
+	if subKind == "" {
+		return trace.BadParameter(
+			"%s requires a sub-kind to delete a resource, try:\n  tctl rm %s/%s %s::%s",
+			scopedaccess.KindScopedRoleAssignment,
+			scopedaccess.KindScopedRoleAssignment, scopedaccess.SubKindDynamic,
+			sqn.Scope, sqn.Name,
+		)
 	}
-	if ref.SubKind == scopedaccess.SubKindMaterialized {
+	if subKind == scopedaccess.SubKindMaterialized {
 		return trace.BadParameter("%s scoped_role_assignments are derived from access lists and cannot be deleted directly", scopedaccess.SubKindMaterialized)
 	}
+
+	// Fetch first to verify scope before deleting.
+	rsp, err := client.ScopedAccessServiceClient().GetScopedRoleAssignment(ctx, scopedaccessv1.GetScopedRoleAssignmentRequest_builder{
+		Name:    sqn.Name,
+		SubKind: subKind,
+	}.Build())
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	if rsp.GetAssignment().GetScope() != sqn.Scope {
+		return scopeMismatchNotFound(scopedaccess.KindScopedRoleAssignment, sqn, rsp.GetAssignment().GetScope())
+	}
+
 	if _, err := client.ScopedAccessServiceClient().DeleteScopedRoleAssignment(ctx, scopedaccessv1.DeleteScopedRoleAssignmentRequest_builder{
-		Name:    ref.Name,
-		SubKind: ref.SubKind,
+		Name:    sqn.Name,
+		SubKind: subKind,
 	}.Build()); err != nil {
 		return trace.Wrap(err)
 	}
 	fmt.Printf(
 		"%v %q has been deleted\n",
 		scopedaccess.KindScopedRoleAssignment,
-		ref.Name,
+		sqn.Name,
 	)
 	return nil
 }

--- a/tool/tctl/common/resources/scoped_token.go
+++ b/tool/tctl/common/resources/scoped_token.go
@@ -32,6 +32,7 @@ import (
 	"github.com/gravitational/teleport/lib/asciitable"
 	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/itertools/stream"
+	"github.com/gravitational/teleport/lib/scopes"
 	"github.com/gravitational/teleport/lib/services"
 )
 
@@ -59,8 +60,8 @@ func (c *scopedTokenCollection) WriteText(w io.Writer, verbose bool) error {
 	return trace.Wrap(err)
 }
 
-func scopedTokenHandler() Handler {
-	return Handler{
+func scopedTokenScopedHandler() ScopedHandler {
+	return ScopedHandler{
 		getHandler:    getScopedToken,
 		createHandler: createScopedToken,
 		deleteHandler: deleteScopedToken,
@@ -111,18 +112,22 @@ func updateScopedToken(ctx context.Context, client *authclient.Client, raw servi
 	return nil
 }
 
-func getScopedToken(ctx context.Context, client *authclient.Client, ref services.Ref, opts GetOpts) (Collection, error) {
-	// If a specific token name is requested, filter the results
-	if ref.Name != "" {
-		token, err := client.GetScopedToken(ctx, ref.Name, opts.WithSecrets)
+func getScopedToken(ctx context.Context, client *authclient.Client, subKind string, sqn *scopes.QualifiedName, opts GetOpts) (Collection, error) {
+	if subKind != "" {
+		return nil, rejectSubKind(types.KindScopedToken, subKind)
+	}
+
+	if sqn != nil {
+		token, err := client.GetScopedToken(ctx, sqn.Name, opts.WithSecrets)
 		if err != nil {
 			return nil, trace.Wrap(err)
+		}
+		if token.GetScope() != sqn.Scope {
+			return nil, scopeMismatchNotFound(types.KindScopedToken, *sqn, token.GetScope())
 		}
 		if !opts.WithSecrets && token.GetStatus().GetSecret() != "" {
 			token.GetStatus().SetSecret("******")
 		}
-		// As a note, this seems to be dead code, these secrets are always empty
-		// if WithSecrets is unset, since the server will strip the value.
 		if !opts.WithSecrets && token.GetStatus().GetUsage().GetBoundKeypair().GetRegistrationSecret() != "" {
 			token.GetStatus().GetUsage().GetBoundKeypair().SetRegistrationSecret("******")
 		}
@@ -158,23 +163,35 @@ func getScopedToken(ctx context.Context, client *authclient.Client, ref services
 	return &scopedTokenCollection{tokens: tokens}, nil
 }
 
-func deleteScopedToken(ctx context.Context, client *authclient.Client, ref services.Ref) error {
-	if err := client.DeleteScopedToken(ctx, ref.Name); err != nil {
+func deleteScopedToken(ctx context.Context, client *authclient.Client, subKind string, sqn scopes.QualifiedName) error {
+	if subKind != "" {
+		return rejectSubKind(types.KindScopedToken, subKind)
+	}
+
+	// Fetch first to verify scope before deleting.
+	token, err := client.GetScopedToken(ctx, sqn.Name, false)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	if token.GetScope() != sqn.Scope {
+		return scopeMismatchNotFound(types.KindScopedToken, sqn, token.GetScope())
+	}
+
+	if err := client.DeleteScopedToken(ctx, sqn.Name); err != nil {
 		return trace.Wrap(err)
 	}
 	fmt.Printf(
 		"%v %q has been deleted\n",
 		types.KindScopedToken,
-		ref.Name,
+		sqn.Name,
 	)
 	return nil
 }
 
 func ScopedTokenTextHelper(tokens []*joiningv1.ScopedToken, withSecrets bool) *bytes.Buffer {
 	headers := []string{
-		"Token",
+		"ID",
 		"Type",
-		"Scope",
 		"Assigns Scope",
 		"Labels",
 		"Expiry Time (UTC)",
@@ -194,9 +211,8 @@ func ScopedTokenTextHelper(tokens []*joiningv1.ScopedToken, withSecrets bool) *b
 			expiry = fmt.Sprintf("%s (%s)", exptime, expdur.String())
 		}
 		row := []string{
-			t.GetMetadata().GetName(),
+			scopes.QualifiedName{Scope: t.GetScope(), Name: t.GetMetadata().GetName()}.String(),
 			strings.Join(t.GetSpec().GetRoles(), ","),
-			t.GetScope(),
 			t.GetSpec().GetAssignedScope(),
 			PrintMetadataLabels(t.GetMetadata().GetLabels()),
 			expiry,

--- a/tool/tctl/common/resources/server.go
+++ b/tool/tctl/common/resources/server.go
@@ -30,6 +30,7 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/asciitable"
 	"github.com/gravitational/teleport/lib/auth/authclient"
+	"github.com/gravitational/teleport/lib/scopes"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/utils"
 	logutils "github.com/gravitational/teleport/lib/utils/log"
@@ -58,11 +59,15 @@ func (s *ServerCollection) WriteText(w io.Writer, verbose bool) error {
 	rows := make([][]string, 0, len(s.servers))
 	for _, se := range s.servers {
 		labels := common.FormatLabels(se.GetAllLabels(), verbose)
+		id := se.GetName()
+		if scope := se.GetScope(); scope != "" {
+			id = scopes.QualifiedName{Scope: scope, Name: se.GetName()}.String()
+		}
 		rows = append(rows, []string{
-			se.GetHostname(), se.GetName(), se.GetAddr(), labels, se.GetTeleportVersion(),
+			se.GetHostname(), id, se.GetAddr(), labels, se.GetTeleportVersion(),
 		})
 	}
-	headers := []string{"Host", "UUID", "Public Address", "Labels", "Version"}
+	headers := []string{"Host", "ID", "Public Address", "Labels", "Version"}
 	var t asciitable.Table
 	if verbose {
 		t = asciitable.MakeTable(headers, rows...)
@@ -91,6 +96,56 @@ func serverHandler() Handler {
 		mfaRequired:   false,
 		description:   "Represents an SSH instance in the cluster, either a Teleport SSH agent or OpenSSH",
 	}
+}
+
+// serverScopedHandler returns a limited [ScopedHandler] for nodes that are registered with a scope. This is necessary to support
+// nodes being accessed with a mix of scoped and unscoped semantics.
+//
+// TODO(fspmmarshall/scopes): revisit this pattern. would it be better to represent handlers with mixed semantics in some more
+// unified manner?
+func serverScopedHandler() ScopedHandler {
+	return ScopedHandler{
+		getHandler:    getScopedNode,
+		deleteHandler: deleteScopedNode,
+		description:   "Represents an SSH instance in the cluster, either a Teleport SSH agent or OpenSSH",
+	}
+}
+
+func getScopedNode(ctx context.Context, client *authclient.Client, subKind string, sqn *scopes.QualifiedName, opts GetOpts) (Collection, error) {
+	if subKind != "" {
+		return nil, rejectSubKind(types.KindNode, subKind)
+	}
+	if sqn == nil {
+		// this isn't expected to happen, the unscoped handler should catch anything that didn't include an explicit SQN, but there's no
+		// harm in falling back to the unscoped handler here.
+		return getServer(ctx, client, services.Ref{Kind: types.KindNode}, opts)
+	}
+	node, err := client.GetNode(ctx, defaults.Namespace, sqn.Name)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	if node.GetScope() != sqn.Scope {
+		return nil, scopeMismatchNotFound(types.KindNode, *sqn, node.GetScope())
+	}
+	return &ServerCollection{servers: []types.Server{node}}, nil
+}
+
+func deleteScopedNode(ctx context.Context, client *authclient.Client, subKind string, sqn scopes.QualifiedName) error {
+	if subKind != "" {
+		return rejectSubKind(types.KindNode, subKind)
+	}
+	node, err := client.GetNode(ctx, defaults.Namespace, sqn.Name)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	if node.GetScope() != sqn.Scope {
+		return scopeMismatchNotFound(types.KindNode, sqn, node.GetScope())
+	}
+	if err := client.DeleteNode(ctx, defaults.Namespace, sqn.Name); err != nil {
+		return trace.Wrap(err)
+	}
+	fmt.Printf("node %v has been deleted\n", sqn.String())
+	return nil
 }
 
 func createServer(ctx context.Context, client *authclient.Client, raw services.UnknownResource, opts CreateOpts) error {

--- a/tool/tctl/common/scoped_ref.go
+++ b/tool/tctl/common/scoped_ref.go
@@ -1,0 +1,119 @@
+/*
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package common
+
+import (
+	"strings"
+
+	"github.com/gravitational/trace"
+
+	"github.com/gravitational/teleport/lib/scopes"
+	"github.com/gravitational/teleport/lib/services"
+)
+
+// ScopedRef is the fully-resolved representation of a tctl resource reference,
+// produced by ParseScopedRef from the two CLI positional arguments and encompasses
+// both the more standard kind[/subkind]/name format, and the newer kind[/subkind] [scope::]name
+// format.
+//
+// When Scope is empty the reference is unscoped and equivalent to a services.Ref,
+// suitable for classic Handlers. When Scope is non-empty the reference is scope-qualified.
+type ScopedRef struct {
+	Kind    string
+	SubKind string
+	Name    string
+	Scope   string // non-empty iff scope-qualified
+}
+
+// String returns the user-facing representation of the reference, approximately matching
+// what the user originally typed on the command line (note that a user who typed in the
+// newer space-separated format without a scope will see the older slash separated format
+// since the scope qualification is what determines the format, not the original input).
+func (sr ScopedRef) String() string {
+	var b strings.Builder
+	b.WriteString(sr.Kind)
+	if sr.SubKind != "" {
+		b.WriteByte('/')
+		b.WriteString(sr.SubKind)
+	}
+	if sr.Scope != "" {
+		b.WriteByte(' ')
+		b.WriteString(scopes.QualifiedName{Scope: sr.Scope, Name: sr.Name}.String())
+	} else if sr.Name != "" {
+		b.WriteByte('/')
+		b.WriteString(sr.Name)
+	}
+	return b.String()
+}
+
+// Ref converts the ScopedRef to a services.Ref for use with classic (unscoped)
+// Handlers. Only meaningful when Scope is empty.
+func (sr ScopedRef) Ref() services.Ref {
+	return services.Ref{Kind: sr.Kind, SubKind: sr.SubKind, Name: sr.Name}
+}
+
+// SQN returns the scope-qualified name for use with ScopedHandlers.
+// Only meaningful when Scope is non-empty.
+func (sr ScopedRef) SQN() scopes.QualifiedName {
+	return scopes.QualifiedName{Scope: sr.Scope, Name: sr.Name}
+}
+
+// ParseScopedRef resolves the two tctl positional CLI arguments into a ScopedRef. The ref and id
+// positional arguments must be decoded together as we support two different formats and resource name
+// may appear in either argument depending on the format.
+//
+// - Older/Unscoped Format: <kind>[/<subkind>]/<name>
+// - Newer/Scoped Format: <kind>[/<subkind>] [<scope>::]<name>
+//
+// The resulting ScopedRef will have Scope set iff the input was the newer/scoped format *and* scope qualification
+// was not present. When scope qualification is absent, the two formats convey the same information.
+func ParseScopedRef(ref, id string) (ScopedRef, error) {
+	// start with older/unscoped format parssing. this should succeed for both formats, but the older
+	// style may have misinterpreted the subkind as a name if the caller is using the newer format.
+	r, err := services.ParseRef(ref)
+	if err != nil {
+		return ScopedRef{}, trace.Wrap(err)
+	}
+	if id == "" {
+		return ScopedRef{Kind: r.Kind, SubKind: r.SubKind, Name: r.Name}, nil
+	}
+
+	if r.SubKind != "" {
+		// Three-segment first arg (kind/subkind/name) with a second arg is one
+		// identifier too many.
+		return ScopedRef{}, trace.BadParameter(
+			"arguments must take the form '<kind>[/<subkind>] [<scope>::]<name>' or '<kind>[/<subkind>]/<name>'",
+		)
+	}
+
+	// the old format always treats token/token as kind/name, but if id was set then the second token
+	// is actually a subkind in the new format.
+	subKind := r.Name
+	if strings.Contains(id, scopes.QualifiedNameSeparator) {
+		if err := scopes.StrongValidateQualifiedName(id); err != nil {
+			return ScopedRef{}, trace.Wrap(err)
+		}
+		qn, err := scopes.ParseQualifiedName(id)
+		if err != nil {
+			return ScopedRef{}, trace.Wrap(err)
+		}
+		return ScopedRef{Kind: r.Kind, SubKind: subKind, Scope: qn.Scope, Name: qn.Name}, nil
+	}
+	return ScopedRef{Kind: r.Kind, SubKind: subKind, Name: id}, nil
+}

--- a/tool/tctl/common/scoped_token_command.go
+++ b/tool/tctl/common/scoped_token_command.go
@@ -45,6 +45,7 @@ import (
 	"github.com/gravitational/teleport/lib/scopes/joining"
 	"github.com/gravitational/teleport/lib/utils"
 	commonclient "github.com/gravitational/teleport/tool/tctl/common/client"
+	"github.com/gravitational/teleport/tool/tctl/common/resources"
 )
 
 // ScopedTokensCommand implements `tctl scoped tokens` group of commands
@@ -325,7 +326,7 @@ func (c *ScopedTokensCommand) List(ctx context.Context, client *authclient.Clien
 			fmt.Fprintln(c.Stdout, token.GetMetadata().GetName())
 		}
 	default:
-		fmt.Fprint(c.Stdout, scopedTokenTextHelper(tokens, c.withSecrets).String())
+		fmt.Fprint(c.Stdout, resources.ScopedTokenTextHelper(tokens, c.withSecrets).String())
 	}
 	return nil
 }

--- a/tool/tctl/common/scoped_token_command_test.go
+++ b/tool/tctl/common/scoped_token_command_test.go
@@ -125,7 +125,7 @@ func TestScopedTokens(t *testing.T) {
 	// Test all output formats of "tokens ls".
 	buf, err = runScopedCommand(t, clt, []string{"tokens", "ls"})
 	require.NoError(t, err)
-	require.True(t, strings.HasPrefix(buf.String(), "Token "))
+	require.True(t, strings.HasPrefix(buf.String(), "ID"))
 	require.Equal(t, 8, strings.Count(buf.String(), "\n")) // account for header lines
 
 	buf, err = runScopedCommand(t, clt, []string{"tokens", "ls", "--format", teleport.Text})


### PR DESCRIPTION
Backport #67364 to branch/v18.

Depends on: https://github.com/gravitational/teleport/pull/68015

## Manual Test Plan
### Test Environment

Local env.

### Test Cases
- [x] Verify that unscoped tctl resource APIs work as expected.
- [x] Verify the new syntax/behavior of scoped tclt resource APIs.
- [x] Verify that nodes offer expected mix of both interaction styles.
