### PR TITLE
[scopes] key by scope-qualified name in mockAccessListAndMembersGetter

### DIFF
--- a/lib/accesslists/hierarchy_test.go
+++ b/lib/accesslists/hierarchy_test.go
@@ -38,17 +38,18 @@ import (
 	"github.com/gravitational/teleport/api/types/header"
 	"github.com/gravitational/teleport/api/types/trait"
 	"github.com/gravitational/teleport/lib/itertools/stream"
+	"github.com/gravitational/teleport/lib/scopes"
 )
 
 // Mock implementation of AccessListAndMembersGetter.
 type mockAccessListAndMembersGetter struct {
-	accessLists map[accesslist.ScopeQualifiedName]*accesslist.AccessList
-	members     map[accesslist.ScopeQualifiedName][]*accesslist.AccessListMember
+	accessLists map[scopes.QualifiedName]*accesslist.AccessList
+	members     map[scopes.QualifiedName][]*accesslist.AccessListMember
 }
 
 func (m *mockAccessListAndMembersGetter) GetAccessListMember(ctx context.Context, accessListName, memberName string) (*accesslist.AccessListMember, error) {
 	// TODO(nklaassen): support scoped access list members.
-	member, exists := m.members[accesslist.ScopeQualifiedName{Name: accessListName}]
+	member, exists := m.members[scopes.QualifiedName{Name: accessListName}]
 	if !exists {
 		return nil, trace.NotFound("access list %v member %v not found", accessListName, memberName)
 	}
@@ -61,10 +62,16 @@ func (m *mockAccessListAndMembersGetter) GetAccessListMember(ctx context.Context
 }
 
 func (m *mockAccessListAndMembersGetter) GetAccessList(ctx context.Context, accessListName string) (*accesslist.AccessList, error) {
-	return m.GetAccessListV2(ctx, accesslist.ScopeQualifiedName{Name: accessListName})
+	return m.GetAccessListV2(ctx, accesslistv1.GetAccessListRequest_builder{
+		Name: accessListName,
+	}.Build())
 }
 
-func (m *mockAccessListAndMembersGetter) GetAccessListV2(ctx context.Context, accessListName accesslist.ScopeQualifiedName) (*accesslist.AccessList, error) {
+func (m *mockAccessListAndMembersGetter) GetAccessListV2(ctx context.Context, req *accesslistv1.GetAccessListRequest) (*accesslist.AccessList, error) {
+	accessListName := scopes.QualifiedName{
+		Scope: req.GetScope(),
+		Name:  req.GetName(),
+	}
 	accessList, exists := m.accessLists[accessListName]
 	if !exists {
 		return nil, trace.NotFound("access list %v not found", accessListName)
@@ -74,25 +81,25 @@ func (m *mockAccessListAndMembersGetter) GetAccessListV2(ctx context.Context, ac
 
 func (m *mockAccessListAndMembersGetter) ListAccessListMembers(ctx context.Context, accessListName string, pageSize int, pageToken string) ([]*accesslist.AccessListMember, string, error) {
 	// TODO(nklaassen): support scoped access list members.
-	members, exists := m.members[accesslist.ScopeQualifiedName{Name: accessListName}]
+	members, exists := m.members[scopes.QualifiedName{Name: accessListName}]
 	if !exists {
 		return nil, "", nil
 	}
 	return members, "", nil
 }
 
-func mockAccessLists(accessLists ...*accesslist.AccessList) map[accesslist.ScopeQualifiedName]*accesslist.AccessList {
-	out := make(map[accesslist.ScopeQualifiedName]*accesslist.AccessList, len(accessLists))
+func mockAccessLists(accessLists ...*accesslist.AccessList) map[scopes.QualifiedName]*accesslist.AccessList {
+	out := make(map[scopes.QualifiedName]*accesslist.AccessList, len(accessLists))
 	for _, accessList := range accessLists {
-		out[accessList.GetScopeQualifiedName()] = accessList
+		out[ScopeQualifiedName(accessList)] = accessList
 	}
 	return out
 }
 
-func mockAccessListMembers(members ...*accesslist.AccessListMember) map[accesslist.ScopeQualifiedName][]*accesslist.AccessListMember {
-	out := make(map[accesslist.ScopeQualifiedName][]*accesslist.AccessListMember)
+func mockAccessListMembers(members ...*accesslist.AccessListMember) map[scopes.QualifiedName][]*accesslist.AccessListMember {
+	out := make(map[scopes.QualifiedName][]*accesslist.AccessListMember)
 	for _, member := range members {
-		listName := accesslist.ScopeQualifiedName{Name: member.Spec.AccessList}
+		listName := scopes.QualifiedName{Name: member.Spec.AccessList}
 		out[listName] = append(out[listName], member)
 	}
 	return out
@@ -843,7 +850,7 @@ func TestGetInheritedRequires(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			listsByID := make(map[accesslist.ScopeQualifiedName]*accesslist.AccessList, len(tc.lists))
+			listsByID := make(map[scopes.QualifiedName]*accesslist.AccessList, len(tc.lists))
 			listsByName := make(map[string]*accesslist.AccessList, len(tc.lists))
 			for _, ls := range tc.lists {
 				acl, err := accesslist.NewAccessList(
@@ -857,17 +864,17 @@ func TestGetInheritedRequires(t *testing.T) {
 					},
 				)
 				require.NoError(t, err)
-				listsByID[acl.GetScopeQualifiedName()] = acl
+				listsByID[ScopeQualifiedName(acl)] = acl
 				listsByName[ls.name] = acl
 			}
 
-			members := make(map[accesslist.ScopeQualifiedName][]*accesslist.AccessListMember)
+			members := make(map[scopes.QualifiedName][]*accesslist.AccessListMember)
 			for _, ls := range tc.lists {
 				child := listsByName[ls.name]
 				for _, parentName := range ls.memberOf {
 					parent := listsByName[parentName]
 					child.Status.MemberOf = append(child.Status.MemberOf, parent.GetName())
-					members[parent.GetScopeQualifiedName()] = append(members[parent.GetScopeQualifiedName()], newAccessListMember(t, parent.GetName(), child.GetName(), accesslist.MembershipKindList, clock))
+					members[ScopeQualifiedName(parent)] = append(members[ScopeQualifiedName(parent)], newAccessListMember(t, parent.GetName(), child.GetName(), accesslist.MembershipKindList, clock))
 				}
 			}
 
@@ -999,9 +1006,9 @@ func generateAccessList(name string) *accesslist.AccessList {
 	}
 }
 
-func generateNestedALs(level, directMembers int, rootListName, userName string) (map[accesslist.ScopeQualifiedName]*accesslist.AccessList, map[accesslist.ScopeQualifiedName][]*accesslist.AccessListMember) {
+func generateNestedALs(level, directMembers int, rootListName, userName string) (map[scopes.QualifiedName]*accesslist.AccessList, map[scopes.QualifiedName][]*accesslist.AccessListMember) {
 	accesslists := []*accesslist.AccessList{generateAccessList(rootListName)}
-	members := make(map[accesslist.ScopeQualifiedName][]*accesslist.AccessListMember)
+	members := make(map[scopes.QualifiedName][]*accesslist.AccessListMember)
 
 	for i := range level - 1 {
 		parentName := accesslists[i].GetName()
@@ -1035,12 +1042,12 @@ func generateNestedALs(level, directMembers int, rootListName, userName string) 
 			},
 		})
 
-		members[accesslist.ScopeQualifiedName{Name: parentName}] = listMembers
+		members[scopes.QualifiedName{Name: parentName}] = listMembers
 	}
 
-	alMap := make(map[accesslist.ScopeQualifiedName]*accesslist.AccessList)
+	alMap := make(map[scopes.QualifiedName]*accesslist.AccessList)
 	for _, al := range accesslists {
-		alMap[al.GetScopeQualifiedName()] = al
+		alMap[ScopeQualifiedName(al)] = al
 	}
 	return alMap, members
 }

--- a/lib/accesslists/hierarchy_test.go
+++ b/lib/accesslists/hierarchy_test.go
@@ -42,12 +42,13 @@ import (
 
 // Mock implementation of AccessListAndMembersGetter.
 type mockAccessListAndMembersGetter struct {
-	accessLists map[string]*accesslist.AccessList
-	members     map[string][]*accesslist.AccessListMember
+	accessLists map[accesslist.ScopeQualifiedName]*accesslist.AccessList
+	members     map[accesslist.ScopeQualifiedName][]*accesslist.AccessListMember
 }
 
 func (m *mockAccessListAndMembersGetter) GetAccessListMember(ctx context.Context, accessListName, memberName string) (*accesslist.AccessListMember, error) {
-	member, exists := m.members[accessListName]
+	// TODO(nklaassen): support scoped access list members.
+	member, exists := m.members[accesslist.ScopeQualifiedName{Name: accessListName}]
 	if !exists {
 		return nil, trace.NotFound("access list %v member %v not found", accessListName, memberName)
 	}
@@ -60,6 +61,10 @@ func (m *mockAccessListAndMembersGetter) GetAccessListMember(ctx context.Context
 }
 
 func (m *mockAccessListAndMembersGetter) GetAccessList(ctx context.Context, accessListName string) (*accesslist.AccessList, error) {
+	return m.GetAccessListV2(ctx, accesslist.ScopeQualifiedName{Name: accessListName})
+}
+
+func (m *mockAccessListAndMembersGetter) GetAccessListV2(ctx context.Context, accessListName accesslist.ScopeQualifiedName) (*accesslist.AccessList, error) {
 	accessList, exists := m.accessLists[accessListName]
 	if !exists {
 		return nil, trace.NotFound("access list %v not found", accessListName)
@@ -68,11 +73,29 @@ func (m *mockAccessListAndMembersGetter) GetAccessList(ctx context.Context, acce
 }
 
 func (m *mockAccessListAndMembersGetter) ListAccessListMembers(ctx context.Context, accessListName string, pageSize int, pageToken string) ([]*accesslist.AccessListMember, string, error) {
-	members, exists := m.members[accessListName]
+	// TODO(nklaassen): support scoped access list members.
+	members, exists := m.members[accesslist.ScopeQualifiedName{Name: accessListName}]
 	if !exists {
 		return nil, "", nil
 	}
 	return members, "", nil
+}
+
+func mockAccessLists(accessLists ...*accesslist.AccessList) map[accesslist.ScopeQualifiedName]*accesslist.AccessList {
+	out := make(map[accesslist.ScopeQualifiedName]*accesslist.AccessList, len(accessLists))
+	for _, accessList := range accessLists {
+		out[accessList.GetScopeQualifiedName()] = accessList
+	}
+	return out
+}
+
+func mockAccessListMembers(members ...*accesslist.AccessListMember) map[accesslist.ScopeQualifiedName][]*accesslist.AccessListMember {
+	out := make(map[accesslist.ScopeQualifiedName][]*accesslist.AccessListMember)
+	for _, member := range members {
+		listName := accesslist.ScopeQualifiedName{Name: member.Spec.AccessList}
+		out[listName] = append(out[listName], member)
+	}
+	return out
 }
 
 type mockLocksGetter struct {
@@ -169,18 +192,8 @@ func TestAccessListHierarchyIsOwner(t *testing.T) {
 	acl1.Status.OwnerOf = append(acl1.Status.OwnerOf, acl4.GetName())
 
 	accessListAndMembersGetter := &mockAccessListAndMembersGetter{
-		members: map[string][]*accesslist.AccessListMember{
-			acl1.GetName(): {acl1m1, acl1m2},
-			acl2.GetName(): {acl2m1},
-			acl3.GetName(): {},
-			acl4.GetName(): {acl4m1},
-		},
-		accessLists: map[string]*accesslist.AccessList{
-			acl1.GetName(): acl1,
-			acl2.GetName(): acl2,
-			acl3.GetName(): acl3,
-			acl4.GetName(): acl4,
-		},
+		members:     mockAccessListMembers(acl1m1, acl1m2, acl2m1, acl4m1),
+		accessLists: mockAccessLists(acl1, acl2, acl3, acl4),
 	}
 
 	// User which does not meet acl1's Membership requirements.
@@ -242,12 +255,8 @@ func TestAccessListIsMember(t *testing.T) {
 		targets: map[string][]types.Lock{},
 	}
 	accessListAndMembersGetter := &mockAccessListAndMembersGetter{
-		members: map[string][]*accesslist.AccessListMember{
-			acl1.GetName(): {acl1m1},
-		},
-		accessLists: map[string]*accesslist.AccessList{
-			acl1.GetName(): acl1,
-		},
+		members:     mockAccessListMembers(acl1m1),
+		accessLists: mockAccessLists(acl1),
 	}
 
 	stubMember1, err := types.NewUser(member1)
@@ -285,8 +294,8 @@ func TestAccessListIsMember_RequirementsAndExpiry(t *testing.T) {
 	// single user member
 	member := newAccessListMember(t, "acl", "u", accesslist.MembershipKindUser, clock)
 	aclGetter := &mockAccessListAndMembersGetter{
-		accessLists: map[string]*accesslist.AccessList{"acl": acl},
-		members:     map[string][]*accesslist.AccessListMember{"acl": {member}},
+		accessLists: mockAccessLists(acl),
+		members:     mockAccessListMembers(member),
 	}
 
 	u, _ := types.NewUser("u")
@@ -343,16 +352,8 @@ func TestAccessListIsMember_NestedRequirements(t *testing.T) {
 		middleInRoot := newAccessListMember(t, rootList.GetName(), middleList.GetName(), accesslist.MembershipKindList, clock)
 
 		aclGetter := &mockAccessListAndMembersGetter{
-			accessLists: map[string]*accesslist.AccessList{
-				"root":   rootList,
-				"middle": middleList,
-				"leaf":   leafList,
-			},
-			members: map[string][]*accesslist.AccessListMember{
-				"root":   {middleInRoot},
-				"middle": {leafInMiddle},
-				"leaf":   {userMember},
-			},
+			accessLists: mockAccessLists(rootList, middleList, leafList),
+			members:     mockAccessListMembers(middleInRoot, leafInMiddle, userMember),
 		}
 
 		user, err := types.NewUser(userName)
@@ -402,16 +403,8 @@ func TestAccessListIsMember_NestedRequirements(t *testing.T) {
 		middleInRoot := newAccessListMember(t, rootList.GetName(), middleList.GetName(), accesslist.MembershipKindList, clock)
 
 		aclGetter := &mockAccessListAndMembersGetter{
-			accessLists: map[string]*accesslist.AccessList{
-				"root":   rootList,
-				"middle": middleList,
-				"leaf":   leafList,
-			},
-			members: map[string][]*accesslist.AccessListMember{
-				"root":   {middleInRoot},
-				"middle": {leafInMiddle},
-				"leaf":   {userMember},
-			},
+			accessLists: mockAccessLists(rootList, middleList, leafList),
+			members:     mockAccessListMembers(middleInRoot, leafInMiddle, userMember),
 		}
 
 		user, err := types.NewUser(userName)
@@ -442,16 +435,8 @@ func TestAccessListIsMember_NestedRequirements(t *testing.T) {
 		thirdArc := newAccessListMember(t, thirdList.GetName(), firstList.GetName(), accesslist.MembershipKindList, clock)
 
 		aclGetter := &mockAccessListAndMembersGetter{
-			accessLists: map[string]*accesslist.AccessList{
-				firstList.GetName():  firstList,
-				secondList.GetName(): secondList,
-				thirdList.GetName():  thirdList,
-			},
-			members: map[string][]*accesslist.AccessListMember{
-				firstList.GetName():  {firstArc},
-				secondList.GetName(): {secondArc},
-				thirdList.GetName():  {thirdArc},
-			},
+			accessLists: mockAccessLists(firstList, secondList, thirdList),
+			members:     mockAccessListMembers(firstArc, secondArc, thirdArc),
 		}
 
 		user, err := types.NewUser("alice")
@@ -491,16 +476,8 @@ func TestAccessListIsMember_NestedRequirements(t *testing.T) {
 		userMembership := newAccessListMember(t, thirdList.GetName(), user.GetName(), accesslist.MembershipKindUser, clock)
 
 		aclGetter := &mockAccessListAndMembersGetter{
-			accessLists: map[string]*accesslist.AccessList{
-				firstList.GetName():  firstList,
-				secondList.GetName(): secondList,
-				thirdList.GetName():  thirdList,
-			},
-			members: map[string][]*accesslist.AccessListMember{
-				firstList.GetName():  {firstArc},
-				secondList.GetName(): {secondArc},
-				thirdList.GetName():  {thirdArc, userMembership},
-			},
+			accessLists: mockAccessLists(firstList, secondList, thirdList),
+			members:     mockAccessListMembers(firstArc, secondArc, thirdArc, userMembership),
 		}
 
 		typ, err := IsAccessListMember(ctx, user, firstList, aclGetter, locks, clock)
@@ -566,10 +543,7 @@ func TestGetOwners(t *testing.T) {
 	acl3m1 := newAccessListMember(t, acl3.GetName(), "memberC", accesslist.MembershipKindUser, clock)
 
 	accessListAndMembersGetter := &mockAccessListAndMembersGetter{
-		members: map[string][]*accesslist.AccessListMember{
-			acl2.GetName(): {acl2m1},
-			acl3.GetName(): {acl3m1},
-		},
+		members: mockAccessListMembers(acl2m1, acl3m1),
 	}
 
 	// Test GetOwners for acl1
@@ -674,11 +648,7 @@ func TestGetInheritedGrants(t *testing.T) {
 	acl1.Status.OwnerOf = append(acl1.Status.OwnerOf, aclroot.GetName())
 
 	accessListAndMembersGetter := &mockAccessListAndMembersGetter{
-		accessLists: map[string]*accesslist.AccessList{
-			aclroot.GetName(): aclroot,
-			acl1.GetName():    acl1,
-			acl2.GetName():    acl2,
-		},
+		accessLists: mockAccessLists(aclroot, acl1, acl2),
 	}
 
 	// acl1 is an Owner of aclroot, and acl2 is a Member of acl1.
@@ -873,7 +843,7 @@ func TestGetInheritedRequires(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			listsByID := make(map[string]*accesslist.AccessList, len(tc.lists))
+			listsByID := make(map[accesslist.ScopeQualifiedName]*accesslist.AccessList, len(tc.lists))
 			listsByName := make(map[string]*accesslist.AccessList, len(tc.lists))
 			for _, ls := range tc.lists {
 				acl, err := accesslist.NewAccessList(
@@ -887,17 +857,17 @@ func TestGetInheritedRequires(t *testing.T) {
 					},
 				)
 				require.NoError(t, err)
-				listsByID[acl.GetName()] = acl
+				listsByID[acl.GetScopeQualifiedName()] = acl
 				listsByName[ls.name] = acl
 			}
 
-			members := make(map[string][]*accesslist.AccessListMember)
+			members := make(map[accesslist.ScopeQualifiedName][]*accesslist.AccessListMember)
 			for _, ls := range tc.lists {
 				child := listsByName[ls.name]
 				for _, parentName := range ls.memberOf {
 					parent := listsByName[parentName]
 					child.Status.MemberOf = append(child.Status.MemberOf, parent.GetName())
-					members[parent.GetName()] = append(members[parent.GetName()], newAccessListMember(t, parent.GetName(), child.GetName(), accesslist.MembershipKindList, clock))
+					members[parent.GetScopeQualifiedName()] = append(members[parent.GetScopeQualifiedName()], newAccessListMember(t, parent.GetName(), child.GetName(), accesslist.MembershipKindList, clock))
 				}
 			}
 
@@ -929,17 +899,15 @@ func TestGetMembersFor_FlattensAndStopsOnCycles(t *testing.T) {
 	c := newAccessList(t, "C", clock)
 
 	getter := &mockAccessListAndMembersGetter{
-		accessLists: map[string]*accesslist.AccessList{
-			"A": a, "B": b, "C": c,
-		},
-		members: map[string][]*accesslist.AccessListMember{
-			"A": {newAccessListMember(t, "A", "userA", accesslist.MembershipKindUser, clock),
-				newAccessListMember(t, "A", "B", accesslist.MembershipKindList, clock)},
-			"B": {newAccessListMember(t, "B", "userB", accesslist.MembershipKindUser, clock),
-				newAccessListMember(t, "B", "C", accesslist.MembershipKindList, clock)},
-			"C": {newAccessListMember(t, "C", "userC", accesslist.MembershipKindUser, clock),
-				newAccessListMember(t, "C", "B", accesslist.MembershipKindList, clock)}, // cycle back
-		},
+		accessLists: mockAccessLists(a, b, c),
+		members: mockAccessListMembers(
+			newAccessListMember(t, "A", "userA", accesslist.MembershipKindUser, clock),
+			newAccessListMember(t, "A", "B", accesslist.MembershipKindList, clock),
+			newAccessListMember(t, "B", "userB", accesslist.MembershipKindUser, clock),
+			newAccessListMember(t, "B", "C", accesslist.MembershipKindList, clock),
+			newAccessListMember(t, "C", "userC", accesslist.MembershipKindUser, clock),
+			newAccessListMember(t, "C", "B", accesslist.MembershipKindList, clock), // cycle back
+		),
 	}
 
 	members, err := GetMembersFor(ctx, "A", getter)
@@ -1031,9 +999,9 @@ func generateAccessList(name string) *accesslist.AccessList {
 	}
 }
 
-func generateNestedALs(level, directMembers int, rootListName, userName string) (map[string]*accesslist.AccessList, map[string][]*accesslist.AccessListMember) {
+func generateNestedALs(level, directMembers int, rootListName, userName string) (map[accesslist.ScopeQualifiedName]*accesslist.AccessList, map[accesslist.ScopeQualifiedName][]*accesslist.AccessListMember) {
 	accesslists := []*accesslist.AccessList{generateAccessList(rootListName)}
-	members := make(map[string][]*accesslist.AccessListMember)
+	members := make(map[accesslist.ScopeQualifiedName][]*accesslist.AccessListMember)
 
 	for i := range level - 1 {
 		parentName := accesslists[i].GetName()
@@ -1067,12 +1035,12 @@ func generateNestedALs(level, directMembers int, rootListName, userName string) 
 			},
 		})
 
-		members[parentName] = listMembers
+		members[accesslist.ScopeQualifiedName{Name: parentName}] = listMembers
 	}
 
-	alMap := make(map[string]*accesslist.AccessList)
+	alMap := make(map[accesslist.ScopeQualifiedName]*accesslist.AccessList)
 	for _, al := range accesslists {
-		alMap[al.GetName()] = al
+		alMap[al.GetScopeQualifiedName()] = al
 	}
 	return alMap, members
 }
@@ -1105,20 +1073,16 @@ func BenchmarkIsAccessListMember(b *testing.B) {
 	clock := clockwork.NewFakeClock()
 
 	b.Run("no accessPaths", func(b *testing.B) {
+		accessList := generateAccessList(mainAccessListName)
 		mock := &mockAccessListAndMembersGetter{
-			accessLists: map[string]*accesslist.AccessList{
-				mainAccessListName: generateAccessList(mainAccessListName),
-			},
-			members: map[string][]*accesslist.AccessListMember{
-				mainAccessListName: {},
-			},
+			accessLists: mockAccessLists(accessList),
 		}
 
 		for b.Loop() {
 			_, err := IsAccessListMember(
 				b.Context(),
 				&types.UserV2{Metadata: types.Metadata{Name: testUserName}},
-				generateAccessList(mainAccessListName),
+				accessList,
 				mock,
 				lockGetter,
 				clock)
@@ -1129,6 +1093,7 @@ func BenchmarkIsAccessListMember(b *testing.B) {
 	})
 
 	b.Run("single-page direct member", func(b *testing.B) {
+		accessList := generateAccessList(mainAccessListName)
 		member := &accesslist.AccessListMember{
 			ResourceHeader: header.ResourceHeader{
 				Metadata: header.Metadata{
@@ -1147,19 +1112,15 @@ func BenchmarkIsAccessListMember(b *testing.B) {
 		members = append(members, generatedMembers[25:]...)
 
 		mock := &mockAccessListAndMembersGetter{
-			accessLists: map[string]*accesslist.AccessList{
-				mainAccessListName: generateAccessList(mainAccessListName),
-			},
-			members: map[string][]*accesslist.AccessListMember{
-				mainAccessListName: members,
-			},
+			accessLists: mockAccessLists(accessList),
+			members:     mockAccessListMembers(members...),
 		}
 
 		for b.Loop() {
 			_, err := IsAccessListMember(
 				b.Context(),
 				&types.UserV2{Metadata: types.Metadata{Name: testUserName}},
-				generateAccessList(mainAccessListName),
+				accessList,
 				mock,
 				lockGetter,
 				clock)
@@ -1170,6 +1131,7 @@ func BenchmarkIsAccessListMember(b *testing.B) {
 	})
 
 	b.Run("multiple-pages direct member", func(b *testing.B) {
+		accessList := generateAccessList(mainAccessListName)
 		member := &accesslist.AccessListMember{
 			ResourceHeader: header.ResourceHeader{
 				Metadata: header.Metadata{
@@ -1188,19 +1150,15 @@ func BenchmarkIsAccessListMember(b *testing.B) {
 		members = append(members, generatedMembers[250:]...)
 
 		mock := &mockAccessListAndMembersGetter{
-			accessLists: map[string]*accesslist.AccessList{
-				mainAccessListName: generateAccessList(mainAccessListName),
-			},
-			members: map[string][]*accesslist.AccessListMember{
-				mainAccessListName: members,
-			},
+			accessLists: mockAccessLists(accessList),
+			members:     mockAccessListMembers(members...),
 		}
 
 		for b.Loop() {
 			_, err := IsAccessListMember(
 				b.Context(),
 				&types.UserV2{Metadata: types.Metadata{Name: testUserName}},
-				generateAccessList(mainAccessListName),
+				accessList,
 				mock,
 				lockGetter,
 				clock)

--- a/lib/accesslists/hierarchy_test.go
+++ b/lib/accesslists/hierarchy_test.go
@@ -43,13 +43,13 @@ import (
 
 // Mock implementation of AccessListAndMembersGetter.
 type mockAccessListAndMembersGetter struct {
-	accessLists map[scopes.QualifiedName]*accesslist.AccessList
-	members     map[scopes.QualifiedName][]*accesslist.AccessListMember
+	accessLists map[NormalizedSQN]*accesslist.AccessList
+	members     map[NormalizedSQN][]*accesslist.AccessListMember
 }
 
 func (m *mockAccessListAndMembersGetter) GetAccessListMember(ctx context.Context, accessListName, memberName string) (*accesslist.AccessListMember, error) {
 	// TODO(nklaassen): support scoped access list members.
-	member, exists := m.members[scopes.QualifiedName{Name: accessListName}]
+	member, exists := m.members[NormalizedSQN{Name: accessListName}]
 	if !exists {
 		return nil, trace.NotFound("access list %v member %v not found", accessListName, memberName)
 	}
@@ -68,10 +68,10 @@ func (m *mockAccessListAndMembersGetter) GetAccessList(ctx context.Context, acce
 }
 
 func (m *mockAccessListAndMembersGetter) GetAccessListV2(ctx context.Context, req *accesslistv1.GetAccessListRequest) (*accesslist.AccessList, error) {
-	accessListName := scopes.QualifiedName{
+	accessListName := NormalizeSQN(scopes.QualifiedName{
 		Scope: req.GetScope(),
 		Name:  req.GetName(),
-	}
+	})
 	accessList, exists := m.accessLists[accessListName]
 	if !exists {
 		return nil, trace.NotFound("access list %v not found", accessListName)
@@ -81,25 +81,25 @@ func (m *mockAccessListAndMembersGetter) GetAccessListV2(ctx context.Context, re
 
 func (m *mockAccessListAndMembersGetter) ListAccessListMembers(ctx context.Context, accessListName string, pageSize int, pageToken string) ([]*accesslist.AccessListMember, string, error) {
 	// TODO(nklaassen): support scoped access list members.
-	members, exists := m.members[scopes.QualifiedName{Name: accessListName}]
+	members, exists := m.members[NormalizedSQN{Name: accessListName}]
 	if !exists {
 		return nil, "", nil
 	}
 	return members, "", nil
 }
 
-func mockAccessLists(accessLists ...*accesslist.AccessList) map[scopes.QualifiedName]*accesslist.AccessList {
-	out := make(map[scopes.QualifiedName]*accesslist.AccessList, len(accessLists))
+func mockAccessLists(accessLists ...*accesslist.AccessList) map[NormalizedSQN]*accesslist.AccessList {
+	out := make(map[NormalizedSQN]*accesslist.AccessList, len(accessLists))
 	for _, accessList := range accessLists {
 		out[ScopeQualifiedName(accessList)] = accessList
 	}
 	return out
 }
 
-func mockAccessListMembers(members ...*accesslist.AccessListMember) map[scopes.QualifiedName][]*accesslist.AccessListMember {
-	out := make(map[scopes.QualifiedName][]*accesslist.AccessListMember)
+func mockAccessListMembers(members ...*accesslist.AccessListMember) map[NormalizedSQN][]*accesslist.AccessListMember {
+	out := make(map[NormalizedSQN][]*accesslist.AccessListMember)
 	for _, member := range members {
-		listName := scopes.QualifiedName{Name: member.Spec.AccessList}
+		listName := NormalizedSQN{Name: member.Spec.AccessList}
 		out[listName] = append(out[listName], member)
 	}
 	return out
@@ -850,7 +850,7 @@ func TestGetInheritedRequires(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			listsByID := make(map[scopes.QualifiedName]*accesslist.AccessList, len(tc.lists))
+			listsByID := make(map[NormalizedSQN]*accesslist.AccessList, len(tc.lists))
 			listsByName := make(map[string]*accesslist.AccessList, len(tc.lists))
 			for _, ls := range tc.lists {
 				acl, err := accesslist.NewAccessList(
@@ -868,13 +868,14 @@ func TestGetInheritedRequires(t *testing.T) {
 				listsByName[ls.name] = acl
 			}
 
-			members := make(map[scopes.QualifiedName][]*accesslist.AccessListMember)
+			members := make(map[NormalizedSQN][]*accesslist.AccessListMember)
 			for _, ls := range tc.lists {
 				child := listsByName[ls.name]
 				for _, parentName := range ls.memberOf {
 					parent := listsByName[parentName]
 					child.Status.MemberOf = append(child.Status.MemberOf, parent.GetName())
-					members[ScopeQualifiedName(parent)] = append(members[ScopeQualifiedName(parent)], newAccessListMember(t, parent.GetName(), child.GetName(), accesslist.MembershipKindList, clock))
+					members[ScopeQualifiedName(parent)] = append(members[ScopeQualifiedName(parent)],
+						newAccessListMember(t, parent.GetName(), child.GetName(), accesslist.MembershipKindList, clock))
 				}
 			}
 
@@ -1006,9 +1007,9 @@ func generateAccessList(name string) *accesslist.AccessList {
 	}
 }
 
-func generateNestedALs(level, directMembers int, rootListName, userName string) (map[scopes.QualifiedName]*accesslist.AccessList, map[scopes.QualifiedName][]*accesslist.AccessListMember) {
+func generateNestedALs(level, directMembers int, rootListName, userName string) (map[NormalizedSQN]*accesslist.AccessList, map[NormalizedSQN][]*accesslist.AccessListMember) {
 	accesslists := []*accesslist.AccessList{generateAccessList(rootListName)}
-	members := make(map[scopes.QualifiedName][]*accesslist.AccessListMember)
+	members := make(map[NormalizedSQN][]*accesslist.AccessListMember)
 
 	for i := range level - 1 {
 		parentName := accesslists[i].GetName()
@@ -1042,10 +1043,10 @@ func generateNestedALs(level, directMembers int, rootListName, userName string) 
 			},
 		})
 
-		members[scopes.QualifiedName{Name: parentName}] = listMembers
+		members[NormalizedSQN{Name: parentName}] = listMembers
 	}
 
-	alMap := make(map[scopes.QualifiedName]*accesslist.AccessList)
+	alMap := make(map[NormalizedSQN]*accesslist.AccessList)
 	for _, al := range accesslists {
 		alMap[ScopeQualifiedName(al)] = al
 	}

--- a/lib/accesslists/scopequalifiedname.go
+++ b/lib/accesslists/scopequalifiedname.go
@@ -21,10 +21,36 @@ import (
 	"github.com/gravitational/teleport/lib/scopes"
 )
 
-// ScopeQualifiedName returns the scope-qualified name of the given access list.
-func ScopeQualifiedName(list *accesslist.AccessList) scopes.QualifiedName {
+// NormalizedSQN is a scope-qualified name that has been normalized for
+// comparisons and usage as a map key.
+type NormalizedSQN struct {
+	// Scope is the resource's normalized scope path, e.g. "/staging/west".
+	Scope string
+	// Name is the resource's name within its scope, e.g. "mylist".
+	Name string
+}
+
+// NormalizeSQN returns a scope-qualified name that has been normalized for
+// comparisons and usage as a map key.
+func NormalizeSQN(sqn scopes.QualifiedName) NormalizedSQN {
+	return NormalizedSQN{
+		Scope: scopes.NormalizeForEquality(sqn.Scope),
+		Name:  sqn.Name,
+	}
+}
+
+// ToScopesQualifiedName converts the NormalizedSQN to a [scopes.QualifiedName].
+func (n NormalizedSQN) ToScopesQualifiedName() scopes.QualifiedName {
 	return scopes.QualifiedName{
+		Scope: n.Scope,
+		Name:  n.Name,
+	}
+}
+
+// ScopeQualifiedName returns the normalized scope-qualified name of the given access list.
+func ScopeQualifiedName(list *accesslist.AccessList) NormalizedSQN {
+	return NormalizeSQN(scopes.QualifiedName{
 		Scope: list.Scope,
 		Name:  list.Metadata.Name,
-	}
+	})
 }

--- a/lib/accesslists/validate_test.go
+++ b/lib/accesslists/validate_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/gravitational/teleport/api/types/accesslist"
+	"github.com/gravitational/teleport/lib/scopes"
 	scopedaccess "github.com/gravitational/teleport/lib/scopes/access"
 )
 
@@ -62,8 +63,8 @@ func TestAccessListHierarchyCircularRefsCheck(t *testing.T) {
 	require.ErrorIs(t, err, ErrCyclicMembership)
 
 	// By removing acl3 as a member of acl2, the relationship should be valid.
-	accessListAndMembersGetter.members[acl2.GetScopeQualifiedName()] = []*accesslist.AccessListMember{}
-	accessListAndMembersGetter.accessLists[acl3.GetScopeQualifiedName()].Status.MemberOf = []string{}
+	accessListAndMembersGetter.members[ScopeQualifiedName(acl2)] = []*accesslist.AccessListMember{}
+	accessListAndMembersGetter.accessLists[ScopeQualifiedName(acl3)].Status.MemberOf = []string{}
 	err = ValidateAccessListMember(ctx, acl3, acl3m1, accessListAndMembersGetter)
 	require.NoError(t, err)
 
@@ -107,25 +108,25 @@ func TestAccessListHierarchyDepthCheck(t *testing.T) {
 	}
 
 	accessListAndMembersGetter := &mockAccessListAndMembersGetter{
-		members:     make(map[accesslist.ScopeQualifiedName][]*accesslist.AccessListMember),
-		accessLists: make(map[accesslist.ScopeQualifiedName]*accesslist.AccessList),
+		members:     make(map[scopes.QualifiedName][]*accesslist.AccessListMember),
+		accessLists: make(map[scopes.QualifiedName]*accesslist.AccessList),
 	}
 
 	// Create members up to MaxAllowedDepth
 	for i := range accesslist.MaxAllowedDepth {
 		member := newAccessListMember(t, acls[i].GetName(), acls[i+1].GetName(), accesslist.MembershipKindList, clock)
 		acls[i+1].Status.MemberOf = append(acls[i+1].Status.MemberOf, acls[i].GetName())
-		accessListAndMembersGetter.members[acls[i].GetScopeQualifiedName()] = []*accesslist.AccessListMember{member}
-		accessListAndMembersGetter.accessLists[acls[i].GetScopeQualifiedName()] = acls[i]
+		accessListAndMembersGetter.members[ScopeQualifiedName(acls[i])] = []*accesslist.AccessListMember{member}
+		accessListAndMembersGetter.accessLists[ScopeQualifiedName(acls[i])] = acls[i]
 	}
 	// Set remaining Access Lists' members to empty slices
 	for i := accesslist.MaxAllowedDepth; i < numAcls; i++ {
-		accessListAndMembersGetter.members[acls[i].GetScopeQualifiedName()] = []*accesslist.AccessListMember{}
-		accessListAndMembersGetter.accessLists[acls[i].GetScopeQualifiedName()] = acls[i]
+		accessListAndMembersGetter.members[ScopeQualifiedName(acls[i])] = []*accesslist.AccessListMember{}
+		accessListAndMembersGetter.accessLists[ScopeQualifiedName(acls[i])] = acls[i]
 	}
 
 	// Should be valid with existing member < MaxAllowedDepth
-	err := ValidateAccessListMember(ctx, acls[accesslist.MaxAllowedDepth-1], accessListAndMembersGetter.members[acls[accesslist.MaxAllowedDepth-1].GetScopeQualifiedName()][0], accessListAndMembersGetter)
+	err := ValidateAccessListMember(ctx, acls[accesslist.MaxAllowedDepth-1], accessListAndMembersGetter.members[ScopeQualifiedName(acls[accesslist.MaxAllowedDepth-1])][0], accessListAndMembersGetter)
 	require.NoError(t, err)
 
 	// Now, attempt to add a member that increases the depth beyond MaxAllowedDepth
@@ -507,22 +508,22 @@ func TestAccessListValidateWithMembers_members(t *testing.T) {
 	}
 
 	accessListAndMembersGetter := &mockAccessListAndMembersGetter{
-		members: map[accesslist.ScopeQualifiedName][]*accesslist.AccessListMember{
-			rootAcl.GetScopeQualifiedName(): {},
+		members: map[scopes.QualifiedName][]*accesslist.AccessListMember{
+			ScopeQualifiedName(rootAcl): {},
 		},
 		accessLists: mockAccessLists(rootAcl),
 	}
 	for i := range accesslist.MaxAllowedDepth + 1 {
 		if i < accesslist.MaxAllowedDepth {
-			accessListAndMembersGetter.members[nestedAcls[i].GetScopeQualifiedName()] = []*accesslist.AccessListMember{members[i]}
+			accessListAndMembersGetter.members[ScopeQualifiedName(nestedAcls[i])] = []*accesslist.AccessListMember{members[i]}
 		}
-		accessListAndMembersGetter.accessLists[nestedAcls[i].GetScopeQualifiedName()] = nestedAcls[i]
+		accessListAndMembersGetter.accessLists[ScopeQualifiedName(nestedAcls[i])] = nestedAcls[i]
 	}
 
 	// Should validate successfully, as acl-0 -> acl-10 is a valid hierarchy of depth 10.
 	err := ValidateAccessListWithMembers(ctx, nil, rootAcl, []*accesslist.AccessListMember{}, accessListAndMembersGetter)
 	require.NoError(t, err)
-	err = ValidateAccessListWithMembers(ctx, nil, nestedAcls[0], []*accesslist.AccessListMember{accessListAndMembersGetter.members[nestedAcls[0].GetScopeQualifiedName()][0]}, accessListAndMembersGetter)
+	err = ValidateAccessListWithMembers(ctx, nil, nestedAcls[0], []*accesslist.AccessListMember{accessListAndMembersGetter.members[ScopeQualifiedName(nestedAcls[0])][0]}, accessListAndMembersGetter)
 	require.NoError(t, err)
 
 	// Calling `ValidateAccessListWithMembers`, with `rootAclm1`, should fail, as it would exceed the maximum nesting depth.
@@ -549,33 +550,33 @@ func TestAccessListValidateWithMembers_members(t *testing.T) {
 	}
 
 	accessListAndMembersGetter = &mockAccessListAndMembersGetter{
-		members:     map[accesslist.ScopeQualifiedName][]*accesslist.AccessListMember{},
-		accessLists: map[accesslist.ScopeQualifiedName]*accesslist.AccessList{},
+		members:     map[scopes.QualifiedName][]*accesslist.AccessListMember{},
+		accessLists: map[scopes.QualifiedName]*accesslist.AccessList{},
 	}
 
 	// Create the members for the first hierarchy.
 	for i := range Length {
 		member := newAccessListMember(t, nestedAcls1[i].GetName(), nestedAcls1[i+1].GetName(), accesslist.MembershipKindList, clock)
 		nestedAcls1[i+1].Status.MemberOf = append(nestedAcls1[i+1].Status.MemberOf, nestedAcls1[i].GetName())
-		accessListAndMembersGetter.members[nestedAcls1[i].GetScopeQualifiedName()] = []*accesslist.AccessListMember{member}
-		accessListAndMembersGetter.accessLists[nestedAcls1[i].GetScopeQualifiedName()] = nestedAcls1[i]
+		accessListAndMembersGetter.members[ScopeQualifiedName(nestedAcls1[i])] = []*accesslist.AccessListMember{member}
+		accessListAndMembersGetter.accessLists[ScopeQualifiedName(nestedAcls1[i])] = nestedAcls1[i]
 	}
 
 	// Create the members for the second hierarchy.
 	for i := range Length {
 		member := newAccessListMember(t, nestedAcls2[i].GetName(), nestedAcls2[i+1].GetName(), accesslist.MembershipKindList, clock)
 		nestedAcls2[i+1].Status.MemberOf = append(nestedAcls2[i+1].Status.MemberOf, nestedAcls2[i].GetName())
-		accessListAndMembersGetter.members[nestedAcls2[i].GetScopeQualifiedName()] = []*accesslist.AccessListMember{member}
-		accessListAndMembersGetter.accessLists[nestedAcls2[i].GetScopeQualifiedName()] = nestedAcls2[i]
+		accessListAndMembersGetter.members[ScopeQualifiedName(nestedAcls2[i])] = []*accesslist.AccessListMember{member}
+		accessListAndMembersGetter.accessLists[ScopeQualifiedName(nestedAcls2[i])] = nestedAcls2[i]
 	}
 
 	// For the first hierarchy
 	nestedAcls1Last := nestedAcls1[len(nestedAcls1)-1]
-	accessListAndMembersGetter.accessLists[nestedAcls1Last.GetScopeQualifiedName()] = nestedAcls1Last
+	accessListAndMembersGetter.accessLists[ScopeQualifiedName(nestedAcls1Last)] = nestedAcls1Last
 
 	// For the second hierarchy
 	nestedAcls2Last := nestedAcls2[len(nestedAcls2)-1]
-	accessListAndMembersGetter.accessLists[nestedAcls2Last.GetScopeQualifiedName()] = nestedAcls2Last
+	accessListAndMembersGetter.accessLists[ScopeQualifiedName(nestedAcls2Last)] = nestedAcls2Last
 
 	// Should validate successfully when adding another list, as both hierarchies are valid.
 	err = ValidateAccessListWithMembers(ctx, nil, nestedAcls1Last, []*accesslist.AccessListMember{newAccessListMember(t, nestedAcls1Last.GetName(), nestedAcls2Last.GetName(), accesslist.MembershipKindList, clock)}, accessListAndMembersGetter)
@@ -598,8 +599,8 @@ func Test_ValidateAccessListWithMembers_audit(t *testing.T) {
 	var accessList *accesslist.AccessList
 
 	accessListAndMembersGetter := &mockAccessListAndMembersGetter{
-		members: map[accesslist.ScopeQualifiedName][]*accesslist.AccessListMember{},
-		accessLists: map[accesslist.ScopeQualifiedName]*accesslist.AccessList{
+		members: map[scopes.QualifiedName][]*accesslist.AccessListMember{},
+		accessLists: map[scopes.QualifiedName]*accesslist.AccessList{
 			{Name: accessListName}: accessList,
 		},
 	}

--- a/lib/accesslists/validate_test.go
+++ b/lib/accesslists/validate_test.go
@@ -50,16 +50,8 @@ func TestAccessListHierarchyCircularRefsCheck(t *testing.T) {
 	acl3m1 := newAccessListMember(t, acl3.GetName(), acl1.GetName(), accesslist.MembershipKindList, clock)
 
 	accessListAndMembersGetter := &mockAccessListAndMembersGetter{
-		members: map[string][]*accesslist.AccessListMember{
-			acl1.GetName(): {acl1m1},
-			acl2.GetName(): {acl2m1},
-			acl3.GetName(): {},
-		},
-		accessLists: map[string]*accesslist.AccessList{
-			acl1.GetName(): acl1,
-			acl2.GetName(): acl2,
-			acl3.GetName(): acl3,
-		},
+		members:     mockAccessListMembers(acl1m1, acl2m1),
+		accessLists: mockAccessLists(acl1, acl2, acl3),
 	}
 
 	// Circular references should not be allowed.
@@ -70,8 +62,8 @@ func TestAccessListHierarchyCircularRefsCheck(t *testing.T) {
 	require.ErrorIs(t, err, ErrCyclicMembership)
 
 	// By removing acl3 as a member of acl2, the relationship should be valid.
-	accessListAndMembersGetter.members[acl2.GetName()] = []*accesslist.AccessListMember{}
-	accessListAndMembersGetter.accessLists[acl3.GetName()].Status.MemberOf = []string{}
+	accessListAndMembersGetter.members[acl2.GetScopeQualifiedName()] = []*accesslist.AccessListMember{}
+	accessListAndMembersGetter.accessLists[acl3.GetScopeQualifiedName()].Status.MemberOf = []string{}
 	err = ValidateAccessListMember(ctx, acl3, acl3m1, accessListAndMembersGetter)
 	require.NoError(t, err)
 
@@ -92,14 +84,8 @@ func TestAccessListHierarchyCircularRefsCheck(t *testing.T) {
 	acl4.Status.OwnerOf = append(acl4.Status.OwnerOf, acl5.GetName())
 
 	accessListAndMembersGetter = &mockAccessListAndMembersGetter{
-		members: map[string][]*accesslist.AccessListMember{
-			acl4.GetName(): {acl4m1},
-			acl5.GetName(): {},
-		},
-		accessLists: map[string]*accesslist.AccessList{
-			acl4.GetName(): acl4,
-			acl5.GetName(): acl5,
-		},
+		members:     mockAccessListMembers(acl4m1),
+		accessLists: mockAccessLists(acl4, acl5),
 	}
 
 	err = ValidateAccessListWithMembers(ctx, nil, acl5, []*accesslist.AccessListMember{acl4m1}, accessListAndMembersGetter)
@@ -121,25 +107,25 @@ func TestAccessListHierarchyDepthCheck(t *testing.T) {
 	}
 
 	accessListAndMembersGetter := &mockAccessListAndMembersGetter{
-		members:     make(map[string][]*accesslist.AccessListMember),
-		accessLists: make(map[string]*accesslist.AccessList),
+		members:     make(map[accesslist.ScopeQualifiedName][]*accesslist.AccessListMember),
+		accessLists: make(map[accesslist.ScopeQualifiedName]*accesslist.AccessList),
 	}
 
 	// Create members up to MaxAllowedDepth
 	for i := range accesslist.MaxAllowedDepth {
 		member := newAccessListMember(t, acls[i].GetName(), acls[i+1].GetName(), accesslist.MembershipKindList, clock)
 		acls[i+1].Status.MemberOf = append(acls[i+1].Status.MemberOf, acls[i].GetName())
-		accessListAndMembersGetter.members[acls[i].GetName()] = []*accesslist.AccessListMember{member}
-		accessListAndMembersGetter.accessLists[acls[i].GetName()] = acls[i]
+		accessListAndMembersGetter.members[acls[i].GetScopeQualifiedName()] = []*accesslist.AccessListMember{member}
+		accessListAndMembersGetter.accessLists[acls[i].GetScopeQualifiedName()] = acls[i]
 	}
 	// Set remaining Access Lists' members to empty slices
 	for i := accesslist.MaxAllowedDepth; i < numAcls; i++ {
-		accessListAndMembersGetter.members[acls[i].GetName()] = []*accesslist.AccessListMember{}
-		accessListAndMembersGetter.accessLists[acls[i].GetName()] = acls[i]
+		accessListAndMembersGetter.members[acls[i].GetScopeQualifiedName()] = []*accesslist.AccessListMember{}
+		accessListAndMembersGetter.accessLists[acls[i].GetScopeQualifiedName()] = acls[i]
 	}
 
 	// Should be valid with existing member < MaxAllowedDepth
-	err := ValidateAccessListMember(ctx, acls[accesslist.MaxAllowedDepth-1], accessListAndMembersGetter.members[acls[accesslist.MaxAllowedDepth-1].GetName()][0], accessListAndMembersGetter)
+	err := ValidateAccessListMember(ctx, acls[accesslist.MaxAllowedDepth-1], accessListAndMembersGetter.members[acls[accesslist.MaxAllowedDepth-1].GetScopeQualifiedName()][0], accessListAndMembersGetter)
 	require.NoError(t, err)
 
 	// Now, attempt to add a member that increases the depth beyond MaxAllowedDepth
@@ -521,24 +507,22 @@ func TestAccessListValidateWithMembers_members(t *testing.T) {
 	}
 
 	accessListAndMembersGetter := &mockAccessListAndMembersGetter{
-		members: map[string][]*accesslist.AccessListMember{
-			rootAcl.GetName(): {},
+		members: map[accesslist.ScopeQualifiedName][]*accesslist.AccessListMember{
+			rootAcl.GetScopeQualifiedName(): {},
 		},
-		accessLists: map[string]*accesslist.AccessList{
-			rootAcl.GetName(): rootAcl,
-		},
+		accessLists: mockAccessLists(rootAcl),
 	}
 	for i := range accesslist.MaxAllowedDepth + 1 {
 		if i < accesslist.MaxAllowedDepth {
-			accessListAndMembersGetter.members[nestedAcls[i].GetName()] = []*accesslist.AccessListMember{members[i]}
+			accessListAndMembersGetter.members[nestedAcls[i].GetScopeQualifiedName()] = []*accesslist.AccessListMember{members[i]}
 		}
-		accessListAndMembersGetter.accessLists[nestedAcls[i].GetName()] = nestedAcls[i]
+		accessListAndMembersGetter.accessLists[nestedAcls[i].GetScopeQualifiedName()] = nestedAcls[i]
 	}
 
 	// Should validate successfully, as acl-0 -> acl-10 is a valid hierarchy of depth 10.
 	err := ValidateAccessListWithMembers(ctx, nil, rootAcl, []*accesslist.AccessListMember{}, accessListAndMembersGetter)
 	require.NoError(t, err)
-	err = ValidateAccessListWithMembers(ctx, nil, nestedAcls[0], []*accesslist.AccessListMember{accessListAndMembersGetter.members[nestedAcls[0].GetName()][0]}, accessListAndMembersGetter)
+	err = ValidateAccessListWithMembers(ctx, nil, nestedAcls[0], []*accesslist.AccessListMember{accessListAndMembersGetter.members[nestedAcls[0].GetScopeQualifiedName()][0]}, accessListAndMembersGetter)
 	require.NoError(t, err)
 
 	// Calling `ValidateAccessListWithMembers`, with `rootAclm1`, should fail, as it would exceed the maximum nesting depth.
@@ -565,33 +549,33 @@ func TestAccessListValidateWithMembers_members(t *testing.T) {
 	}
 
 	accessListAndMembersGetter = &mockAccessListAndMembersGetter{
-		members:     map[string][]*accesslist.AccessListMember{},
-		accessLists: map[string]*accesslist.AccessList{},
+		members:     map[accesslist.ScopeQualifiedName][]*accesslist.AccessListMember{},
+		accessLists: map[accesslist.ScopeQualifiedName]*accesslist.AccessList{},
 	}
 
 	// Create the members for the first hierarchy.
 	for i := range Length {
 		member := newAccessListMember(t, nestedAcls1[i].GetName(), nestedAcls1[i+1].GetName(), accesslist.MembershipKindList, clock)
 		nestedAcls1[i+1].Status.MemberOf = append(nestedAcls1[i+1].Status.MemberOf, nestedAcls1[i].GetName())
-		accessListAndMembersGetter.members[nestedAcls1[i].GetName()] = []*accesslist.AccessListMember{member}
-		accessListAndMembersGetter.accessLists[nestedAcls1[i].GetName()] = nestedAcls1[i]
+		accessListAndMembersGetter.members[nestedAcls1[i].GetScopeQualifiedName()] = []*accesslist.AccessListMember{member}
+		accessListAndMembersGetter.accessLists[nestedAcls1[i].GetScopeQualifiedName()] = nestedAcls1[i]
 	}
 
 	// Create the members for the second hierarchy.
 	for i := range Length {
 		member := newAccessListMember(t, nestedAcls2[i].GetName(), nestedAcls2[i+1].GetName(), accesslist.MembershipKindList, clock)
 		nestedAcls2[i+1].Status.MemberOf = append(nestedAcls2[i+1].Status.MemberOf, nestedAcls2[i].GetName())
-		accessListAndMembersGetter.members[nestedAcls2[i].GetName()] = []*accesslist.AccessListMember{member}
-		accessListAndMembersGetter.accessLists[nestedAcls2[i].GetName()] = nestedAcls2[i]
+		accessListAndMembersGetter.members[nestedAcls2[i].GetScopeQualifiedName()] = []*accesslist.AccessListMember{member}
+		accessListAndMembersGetter.accessLists[nestedAcls2[i].GetScopeQualifiedName()] = nestedAcls2[i]
 	}
 
 	// For the first hierarchy
 	nestedAcls1Last := nestedAcls1[len(nestedAcls1)-1]
-	accessListAndMembersGetter.accessLists[nestedAcls1Last.GetName()] = nestedAcls1Last
+	accessListAndMembersGetter.accessLists[nestedAcls1Last.GetScopeQualifiedName()] = nestedAcls1Last
 
 	// For the second hierarchy
 	nestedAcls2Last := nestedAcls2[len(nestedAcls2)-1]
-	accessListAndMembersGetter.accessLists[nestedAcls2Last.GetName()] = nestedAcls2Last
+	accessListAndMembersGetter.accessLists[nestedAcls2Last.GetScopeQualifiedName()] = nestedAcls2Last
 
 	// Should validate successfully when adding another list, as both hierarchies are valid.
 	err = ValidateAccessListWithMembers(ctx, nil, nestedAcls1Last, []*accesslist.AccessListMember{newAccessListMember(t, nestedAcls1Last.GetName(), nestedAcls2Last.GetName(), accesslist.MembershipKindList, clock)}, accessListAndMembersGetter)
@@ -614,9 +598,9 @@ func Test_ValidateAccessListWithMembers_audit(t *testing.T) {
 	var accessList *accesslist.AccessList
 
 	accessListAndMembersGetter := &mockAccessListAndMembersGetter{
-		members: map[string][]*accesslist.AccessListMember{},
-		accessLists: map[string]*accesslist.AccessList{
-			accessListName: accessList,
+		members: map[accesslist.ScopeQualifiedName][]*accesslist.AccessListMember{},
+		accessLists: map[accesslist.ScopeQualifiedName]*accesslist.AccessList{
+			{Name: accessListName}: accessList,
 		},
 	}
 

--- a/lib/accesslists/validate_test.go
+++ b/lib/accesslists/validate_test.go
@@ -29,7 +29,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/gravitational/teleport/api/types/accesslist"
-	"github.com/gravitational/teleport/lib/scopes"
 	scopedaccess "github.com/gravitational/teleport/lib/scopes/access"
 )
 
@@ -108,8 +107,8 @@ func TestAccessListHierarchyDepthCheck(t *testing.T) {
 	}
 
 	accessListAndMembersGetter := &mockAccessListAndMembersGetter{
-		members:     make(map[scopes.QualifiedName][]*accesslist.AccessListMember),
-		accessLists: make(map[scopes.QualifiedName]*accesslist.AccessList),
+		members:     make(map[NormalizedSQN][]*accesslist.AccessListMember),
+		accessLists: make(map[NormalizedSQN]*accesslist.AccessList),
 	}
 
 	// Create members up to MaxAllowedDepth
@@ -508,7 +507,7 @@ func TestAccessListValidateWithMembers_members(t *testing.T) {
 	}
 
 	accessListAndMembersGetter := &mockAccessListAndMembersGetter{
-		members: map[scopes.QualifiedName][]*accesslist.AccessListMember{
+		members: map[NormalizedSQN][]*accesslist.AccessListMember{
 			ScopeQualifiedName(rootAcl): {},
 		},
 		accessLists: mockAccessLists(rootAcl),
@@ -550,8 +549,8 @@ func TestAccessListValidateWithMembers_members(t *testing.T) {
 	}
 
 	accessListAndMembersGetter = &mockAccessListAndMembersGetter{
-		members:     map[scopes.QualifiedName][]*accesslist.AccessListMember{},
-		accessLists: map[scopes.QualifiedName]*accesslist.AccessList{},
+		members:     map[NormalizedSQN][]*accesslist.AccessListMember{},
+		accessLists: map[NormalizedSQN]*accesslist.AccessList{},
 	}
 
 	// Create the members for the first hierarchy.
@@ -599,8 +598,8 @@ func Test_ValidateAccessListWithMembers_audit(t *testing.T) {
 	var accessList *accesslist.AccessList
 
 	accessListAndMembersGetter := &mockAccessListAndMembersGetter{
-		members: map[scopes.QualifiedName][]*accesslist.AccessListMember{},
-		accessLists: map[scopes.QualifiedName]*accesslist.AccessList{
+		members: map[NormalizedSQN][]*accesslist.AccessListMember{},
+		accessLists: map[NormalizedSQN]*accesslist.AccessList{
 			{Name: accessListName}: accessList,
 		},
 	}

--- a/lib/services/local/access_list.go
+++ b/lib/services/local/access_list.go
@@ -216,20 +216,20 @@ func (a *AccessListService) ListAccessListsV2(ctx context.Context, req *accessli
 
 // GetAccessList returns the specified access list resource.
 func (a *AccessListService) GetAccessList(ctx context.Context, name string) (*accesslist.AccessList, error) {
-	return a.getAccessList(ctx, scopes.QualifiedName{Name: name})
+	return a.getAccessList(ctx, accesslists.NormalizedSQN{Name: name})
 }
 
 // GetAccessListV2 returns the specified access list resource, supporting
 // scoped or unscoped access lists.
 func (a *AccessListService) GetAccessListV2(ctx context.Context, req *accesslistv1.GetAccessListRequest) (*accesslist.AccessList, error) {
-	return a.getAccessList(ctx, scopes.QualifiedName{
+	return a.getAccessList(ctx, accesslists.NormalizeSQN(scopes.QualifiedName{
 		Scope: req.GetScope(),
 		Name:  req.GetName(),
-	})
+	}))
 }
 
-func (a *AccessListService) getAccessList(ctx context.Context, listName scopes.QualifiedName) (*accesslist.AccessList, error) {
-	return a.service.GetResource(ctx, listName)
+func (a *AccessListService) getAccessList(ctx context.Context, listName accesslists.NormalizedSQN) (*accesslist.AccessList, error) {
+	return a.service.GetResource(ctx, listName.ToScopesQualifiedName())
 }
 
 // GetAccessListsToReview returns access lists that the user needs to review. This is not implemented in the local service.
@@ -383,10 +383,10 @@ func (a *AccessListService) DeleteAccessList(ctx context.Context, name string) e
 // DeleteAccessListV2 removes the specified access list resource, supporting
 // scoped or unscoped access lists.
 func (a *AccessListService) DeleteAccessListV2(ctx context.Context, req *accesslistv1.DeleteAccessListRequest) error {
-	name := scopes.QualifiedName{
+	name := accesslists.NormalizeSQN(scopes.QualifiedName{
 		Scope: req.GetScope(),
 		Name:  req.GetName(),
-	}
+	})
 	action := func(ctx context.Context, _ backend.Backend) error {
 		// Get list resource.
 		accessList, err := a.getAccessList(ctx, name)
@@ -422,7 +422,7 @@ func (a *AccessListService) DeleteAccessListV2(ctx context.Context, req *accessl
 		}
 
 		// Delete list itself.
-		if err := a.service.DeleteResource(ctx, name); err != nil {
+		if err := a.service.DeleteResource(ctx, name.ToScopesQualifiedName()); err != nil {
 			return trace.Wrap(err)
 		}
 
@@ -1172,7 +1172,7 @@ func lockName(accessListName string) []string {
 	return []string{accessListPrefix, accessListName}
 }
 
-func scopeAwareLockName(accessListName scopes.QualifiedName) ([]string, error) {
+func scopeAwareLockName(accessListName accesslists.NormalizedSQN) ([]string, error) {
 	if accessListName.Scope == "" {
 		return lockName(accessListName.Name), nil
 	}
@@ -1187,7 +1187,7 @@ func scopeAwareLockName(accessListName scopes.QualifiedName) ([]string, error) {
 // It differentiates request for `creating` and `updating` by checking to see if the request
 // access list name matches the ones we retrieved.
 // Returns error if limit has been reached.
-func (a *AccessListService) verifyAccessListCreateLimit(ctx context.Context, targetAccessListName scopes.QualifiedName) error {
+func (a *AccessListService) verifyAccessListCreateLimit(ctx context.Context, targetAccessListName accesslists.NormalizedSQN) error {
 	f := a.modules.Features()
 	if f.GetEntitlement(entitlements.Identity).Enabled {
 		return nil // unlimited


### PR DESCRIPTION
Part of [RFD 308](https://github.com/gravitational/rfd/pull/22)

This PR updates `mockAccessListAndMembersGetter` to key by `accesslist.ScopeQualifiedName` instead of plain names, to facilitate future tests with scoped access lists.

Parent: https://github.com/gravitational/teleport/pull/67990
Child: https://github.com/gravitational/teleport/pull/68031