### PR TITLE
[scopes] support nested list ownership including scoped access lists

### DIFF
--- a/api/types/accesslist/accesslist.go
+++ b/api/types/accesslist/accesslist.go
@@ -242,9 +242,14 @@ type Owner struct {
 }
 
 // IsMembershipKindUser returns true if the owner is of kind user.
-// All types expect "MEMBERSHIP_KIND_LIST" are treated as "MEMBERSHIP_KIND_USER".
+// "" and "MEMBERSHIP_KIND_UNSPECIFIED" are treated as "MEMBERSHIP_KIND_USER".
 func (o *Owner) IsMembershipKindUser() bool {
 	return isMembershipKindUser(o.MembershipKind)
+}
+
+// IsMembershipKindList returns true if the owner is an access list.
+func (o *Owner) IsMembershipKindList() bool {
+	return IsMembershipKindList(o.MembershipKind)
 }
 
 func isMembershipKindUser(membershipKind string) bool {
@@ -253,6 +258,17 @@ func isMembershipKindUser(membershipKind string) bool {
 		return true
 	default:
 		// In case if MembershipKind was extended.
+		return false
+	}
+}
+
+// IsMembershipKindList returns true if the membership kind is
+// MembershipKindList or MembershipKindScopedList.
+func IsMembershipKindList(membershipKind string) bool {
+	switch membershipKind {
+	case MembershipKindList, MembershipKindScopedList:
+		return true
+	default:
 		return false
 	}
 }

--- a/api/types/accesslist/member.go
+++ b/api/types/accesslist/member.go
@@ -164,7 +164,12 @@ func (a *AccessListMember) IsExpired(t time.Time) bool {
 }
 
 // IsUser returns true if the membership kind is User
-// All types expect "MEMBERSHIP_KIND_LIST" are treated as "MEMBERSHIP_KIND_USER".
+// "" and "MEMBERSHIP_KIND_UNSPECIFIED" are treated as "MEMBERSHIP_KIND_USER".
 func (a *AccessListMember) IsUser() bool {
 	return isMembershipKindUser(a.Spec.MembershipKind)
+}
+
+// IsList returns true if the member is an access list.
+func (a *AccessListMember) IsList() bool {
+	return IsMembershipKindList(a.Spec.MembershipKind)
 }

--- a/lib/accesslists/collection.go
+++ b/lib/accesslists/collection.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/gravitational/trace"
 
+	accesslistv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/accesslist/v1"
 	"github.com/gravitational/teleport/api/types/accesslist"
 )
 
@@ -101,6 +102,16 @@ func (b *Collection) GetAccessList(ctx context.Context, name string) (*accesslis
 		return nil, trace.NotFound("access list %q not found in batch", name)
 	}
 	return al, nil
+}
+
+// GetAccessListV2 retrieves an access list from the batch by scoped name.
+// Implements accesslists.AccessListAndMembersGetter interface.
+func (b *Collection) GetAccessListV2(ctx context.Context, req *accesslistv1.GetAccessListRequest) (*accesslist.AccessList, error) {
+	// TODO(nklaassen): support collections of scoped access lists.
+	if req.GetScope() != "" {
+		return nil, trace.BadParameter("Collection does not support scoped access lists")
+	}
+	return b.GetAccessList(ctx, req.GetName())
 }
 
 // ListAccessListMembers retrieves members for an access list from the batch.

--- a/lib/accesslists/hierarchy.go
+++ b/lib/accesslists/hierarchy.go
@@ -54,6 +54,24 @@ type AccessListMembersLister interface {
 	ListAccessListMembers(ctx context.Context, accessListName string, pageSize int, pageToken string) (members []*accesslist.AccessListMember, nextToken string, err error)
 }
 
+// TODO(nklaassen): delete this when everything used as an
+// [AccessListAndMembersGetter] implements GetAccessListV2.
+func getAccessList(ctx context.Context, g AccessListAndMembersGetter, accessListName NormalizedSQN) (*accesslist.AccessList, error) {
+	type accessListGetterV2 interface {
+		GetAccessListV2(ctx context.Context, req *accesslistv1.GetAccessListRequest) (*accesslist.AccessList, error)
+	}
+	if g, ok := g.(accessListGetterV2); ok {
+		return g.GetAccessListV2(ctx, accesslistv1.GetAccessListRequest_builder{
+			Scope: accessListName.Scope,
+			Name:  accessListName.Name,
+		}.Build())
+	}
+	if accessListName.Scope != "" {
+		return nil, trace.NotFound("access list %v not found", accessListName)
+	}
+	return g.GetAccessList(ctx, accessListName.Name)
+}
+
 // lockGetter is a service that gets locks.
 type lockGetter interface {
 	// GetLocks is here for compatibility with older Teleport versions.
@@ -76,7 +94,8 @@ func getMembersFor(ctx context.Context, accessListName string, g AccessListMembe
 	}
 	visited[accessListName] = struct{}{}
 
-	members, err := fetchMembers(ctx, accessListName, g)
+	// TODO(nklaassen): support scoped access list members
+	members, err := fetchMembers(ctx, NormalizedSQN{Name: accessListName}, g)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -98,11 +117,16 @@ func getMembersFor(ctx context.Context, accessListName string, g AccessListMembe
 }
 
 // fetchMembers is a simple helper to fetch all top-level AccessListMembers for an AccessList.
-func fetchMembers(ctx context.Context, accessListName string, g AccessListMembersLister) ([]*accesslist.AccessListMember, error) {
+func fetchMembers(ctx context.Context, accessListName NormalizedSQN, g AccessListMembersLister) ([]*accesslist.AccessListMember, error) {
+	if accessListName.Scope != "" {
+		// Scoped access lists currently cannot have any members
+		// TODO(nklaassen): support scoped access list members.
+		return nil, nil
+	}
 	var allMembers []*accesslist.AccessListMember
 	pageToken := ""
 	for {
-		page, nextToken, err := g.ListAccessListMembers(ctx, accessListName, 0, pageToken)
+		page, nextToken, err := g.ListAccessListMembers(ctx, accessListName.Name, 0, pageToken)
 		if err != nil {
 			// If the AccessList doesn't exist yet, should return an empty list of members
 			if trace.IsNotFound(err) {
@@ -120,26 +144,41 @@ func fetchMembers(ctx context.Context, accessListName string, g AccessListMember
 }
 
 // collectOwners is a helper to recursively collect all Owners for an Access List, including inherited Owners.
-func collectOwners(ctx context.Context, accessList *accesslist.AccessList, g AccessListMembersLister, owners map[string]*accesslist.Owner, visited map[string]struct{}) error {
-	if _, ok := visited[accessList.GetName()]; ok {
+func collectOwners(
+	ctx context.Context,
+	accessList *accesslist.AccessList,
+	g AccessListMembersLister,
+	owners map[NormalizedSQN]*accesslist.Owner,
+	visited map[NormalizedSQN]struct{},
+) error {
+	if _, ok := visited[ScopeQualifiedName(accessList)]; ok {
 		return nil
 	}
-	visited[accessList.GetName()] = struct{}{}
+	visited[ScopeQualifiedName(accessList)] = struct{}{}
 
 	for _, owner := range accessList.Spec.Owners {
-		if owner.MembershipKind != accesslist.MembershipKindList {
+		ownerName, err := OwnerScopeQualifiedName(owner)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+
+		if owner.IsMembershipKindUser() {
 			// Collect direct owner users
-			owners[owner.Name] = &owner
+			owners[ownerName] = &owner
 			continue
 		}
 
 		// For owner lists, we need to collect their members as owners
-		ownerMembers, err := collectMembersAsOwners(ctx, owner.Name, g, visited)
+		ownerMembers, err := collectMembersAsOwners(ctx, ownerName, g, visited)
 		if err != nil {
 			return trace.Wrap(err)
 		}
 		for _, ownerMember := range ownerMembers {
-			owners[ownerMember.Name] = ownerMember
+			ownerMemberName, err := OwnerScopeQualifiedName(*ownerMember)
+			if err != nil {
+				return trace.Wrap(err)
+			}
+			owners[ownerMemberName] = ownerMember
 		}
 	}
 
@@ -147,14 +186,19 @@ func collectOwners(ctx context.Context, accessList *accesslist.AccessList, g Acc
 }
 
 // collectMembersAsOwners is a helper to collect all nested members of an AccessList and return them cast as Owners.
-func collectMembersAsOwners(ctx context.Context, accessListName string, g AccessListMembersLister, visited map[string]struct{}) ([]*accesslist.Owner, error) {
+func collectMembersAsOwners(ctx context.Context, accessListName NormalizedSQN, g AccessListMembersLister, visited map[NormalizedSQN]struct{}) ([]*accesslist.Owner, error) {
+	// TODO(nklaassen): support scoped access list members.
+	if accessListName.Scope != "" {
+		return nil, nil
+	}
+
 	owners := make([]*accesslist.Owner, 0)
 	if _, ok := visited[accessListName]; ok {
 		return owners, nil
 	}
 	visited[accessListName] = struct{}{}
 
-	listMembers, err := GetMembersFor(ctx, accessListName, g)
+	listMembers, err := GetMembersFor(ctx, accessListName.Name, g)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -176,8 +220,8 @@ func collectMembersAsOwners(ctx context.Context, accessListName string, g Access
 // Returned Owners are not validated for expiration or other requirements – use IsAccessListOwner
 // to validate an Owner's ownership status.
 func GetOwnersFor(ctx context.Context, accessList *accesslist.AccessList, g AccessListMembersLister) ([]*accesslist.Owner, error) {
-	ownersMap := make(map[string]*accesslist.Owner)
-	if err := collectOwners(ctx, accessList, g, ownersMap, make(map[string]struct{})); err != nil {
+	ownersMap := make(map[NormalizedSQN]*accesslist.Owner)
+	if err := collectOwners(ctx, accessList, g, ownersMap, make(map[NormalizedSQN]struct{})); err != nil {
 		return nil, trace.Wrap(err)
 	}
 	owners := make([]*accesslist.Owner, 0, len(ownersMap))
@@ -189,8 +233,8 @@ func GetOwnersFor(ctx context.Context, accessList *accesslist.AccessList, g Acce
 
 func maxDepthDownwards(
 	ctx context.Context,
-	currentListName string,
-	seen map[string]struct{},
+	currentListName NormalizedSQN,
+	seen map[NormalizedSQN]struct{},
 	g AccessListAndMembersGetter,
 ) (int, error) {
 	if _, ok := seen[currentListName]; ok {
@@ -205,17 +249,19 @@ func maxDepthDownwards(
 		return 0, trace.Wrap(err)
 	}
 	for _, member := range listMembers {
-		if member.Spec.MembershipKind == accesslist.MembershipKindList {
-			childListName := member.GetName()
-			depth, err := maxDepthDownwards(ctx, childListName, seen, g)
-			if err != nil {
-				return 0, trace.Wrap(err)
-			}
-			depth += 1 // Edge to the child
-			if depth > maxDepth {
-				maxDepth = depth
-			}
+		if !member.IsList() {
+			continue
 		}
+		childListName, err := MemberScopeQualifiedName(member)
+		if err != nil {
+			return 0, trace.Wrap(err)
+		}
+		depth, err := maxDepthDownwards(ctx, childListName, seen, g)
+		if err != nil {
+			return 0, trace.Wrap(err)
+		}
+		depth += 1 // Edge to the child
+		maxDepth = max(maxDepth, depth)
 	}
 
 	delete(seen, currentListName)
@@ -226,19 +272,23 @@ func maxDepthDownwards(
 func maxDepthUpwards(
 	ctx context.Context,
 	currentList *accesslist.AccessList,
-	seen map[string]struct{},
+	seen map[NormalizedSQN]struct{},
 	g AccessListAndMembersGetter,
 ) (int, error) {
-	if _, ok := seen[currentList.GetName()]; ok {
+	if _, ok := seen[ScopeQualifiedName(currentList)]; ok {
 		return 0, nil
 	}
-	seen[currentList.GetName()] = struct{}{}
+	seen[ScopeQualifiedName(currentList)] = struct{}{}
 
 	maxDepth := 0
 
 	// Traverse MemberOf relationships
-	for _, parentListName := range currentList.Status.MemberOf {
-		parentList, err := g.GetAccessList(ctx, parentListName)
+	allParentLists, err := AllParentLists(currentList)
+	if err != nil {
+		return 0, trace.Wrap(err)
+	}
+	for _, parentListName := range allParentLists {
+		parentList, err := getAccessList(ctx, g, parentListName)
 		if err != nil {
 			return 0, trace.Wrap(err) // Treat missing lists as depth 0
 		}
@@ -247,12 +297,10 @@ func maxDepthUpwards(
 			return 0, trace.Wrap(err)
 		}
 		depth += 1 // Edge to the parent
-		if depth > maxDepth {
-			maxDepth = depth
-		}
+		maxDepth = max(maxDepth, depth)
 	}
 
-	delete(seen, currentList.GetName())
+	delete(seen, ScopeQualifiedName(currentList))
 
 	return maxDepth, nil
 }
@@ -315,8 +363,11 @@ func IsAccessListOwner(
 	var ownershipErr error
 
 	for _, owner := range accessList.Spec.Owners {
-		// Is user an explicit owner?
-		if owner.MembershipKind != accesslist.MembershipKindList && owner.Name == user.GetName() {
+		if owner.IsMembershipKindUser() {
+			// Is user an explicit owner?
+			if owner.Name != user.GetName() {
+				continue
+			}
 			if !UserMeetsRequirements(user, accessList.Spec.OwnershipRequires) {
 				// Avoid non-deterministic behavior in these checks. Rather than returning immediately, continue
 				// through all owners to make sure there isn't a valid match later on.
@@ -325,9 +376,13 @@ func IsAccessListOwner(
 			}
 			return accesslistv1.AccessListUserAssignmentType_ACCESS_LIST_USER_ASSIGNMENT_TYPE_EXPLICIT, nil
 		}
-		// Is user an inherited owner through any potential owner AccessLists?
-		if owner.MembershipKind == accesslist.MembershipKindList {
-			ownerAccessList, err := g.GetAccessList(ctx, owner.Name)
+		if owner.IsMembershipKindList() {
+			// Is user an inherited owner through any potential owner AccessLists?
+			ownerName, err := OwnerScopeQualifiedName(owner)
+			if err != nil {
+				return accesslistv1.AccessListUserAssignmentType_ACCESS_LIST_USER_ASSIGNMENT_TYPE_UNSPECIFIED, trace.Wrap(err)
+			}
+			ownerAccessList, err := getAccessList(ctx, g, ownerName)
 			if err != nil {
 				return accesslistv1.AccessListUserAssignmentType_ACCESS_LIST_USER_ASSIGNMENT_TYPE_UNSPECIFIED, trace.Wrap(err)
 			}
@@ -451,6 +506,7 @@ type ancestorOptions struct {
 	validateUserRequirement bool
 	clock                   clockwork.Clock
 	user                    types.User
+	ignoreScoped            bool
 }
 
 func (o *ancestorOptions) validate() error {
@@ -476,12 +532,23 @@ func withUserRequirementsCheck(user types.User, clock clockwork.Clock) ancestorO
 	}
 }
 
+func withIgnoreScoped(ignore bool) ancestorOption {
+	return func(opts *ancestorOptions) {
+		opts.ignoreScoped = ignore
+	}
+}
+
 // HierarchyConfig holds dependencies for building access list hierarchies.
 type HierarchyConfig struct {
 	// AccessListService is used to fetch Access Lists and their members.
 	AccessListsService AccessListAndMembersGetter
 	// Clock is used to check if memberships are expired.
 	Clock clockwork.Clock
+	// IgnoreScoped specifies that the hierarchy should ignore scoped access lists and members.
+	// This should be set during user login state generation, where scoped
+	// access lists should have no effect (scoped access list only affect user
+	// login via materialized scoped role assignments).
+	IgnoreScoped bool
 }
 
 // CheckAndSetDefaults validates the config and sets default values.
@@ -517,6 +584,10 @@ func NewHierarchy(cfg HierarchyConfig) (*Hierarchy, error) {
 // lists where the user satisfies membership or ownership requirements.
 // If the user fails to meet the requirements at any point, that branch is excluded.
 func (s *Hierarchy) GetHierarchyForUser(ctx context.Context, accessList *accesslist.AccessList, user types.User) (memberHierarchy, ownerHierarchy []*accesslist.AccessList, err error) {
+	if s.IgnoreScoped && accessList.Scope != "" {
+		return memberHierarchy, ownerHierarchy, nil
+	}
+
 	if s.validDirectOwner(user, accessList) {
 		// User Is direct owner and meet the ownership requirements
 		// Include access list from the owner hierarchy
@@ -540,7 +611,13 @@ func (s *Hierarchy) GetHierarchyForUser(ctx context.Context, accessList *accessl
 	memberHierarchy = append(memberHierarchy, accessList)
 
 	// Fetch ancestors via MemberOf edges while checking user requirements
-	ancestors, err := getAncestors(ctx, accessList, RelationshipKindMember, s.AccessListsService, withUserRequirementsCheck(user, s.Clock))
+	ancestors, err := getAncestors(
+		ctx,
+		accessList,
+		RelationshipKindMember,
+		s.AccessListsService,
+		withUserRequirementsCheck(user, s.Clock),
+		withIgnoreScoped(s.IgnoreScoped))
 	if err != nil {
 		return nil, nil, trace.Wrap(err)
 	}
@@ -584,8 +661,12 @@ func (s *Hierarchy) validMembership(ctx context.Context, list *accesslist.Access
 func (s *Hierarchy) expandOwnerOf(ctx context.Context, accessList *accesslist.AccessList, ancestors []*accesslist.AccessList, user types.User) ([]*accesslist.AccessList, error) {
 	var out []*accesslist.AccessList
 	processFn := func(al *accesslist.AccessList) error {
-		for _, name := range al.Status.OwnerOf {
-			ownerList, err := s.AccessListsService.GetAccessList(ctx, name)
+		ownedListNames, err := ownedListsForTraversal(al, s.IgnoreScoped)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+		for _, name := range ownedListNames {
+			ownerList, err := getAccessList(ctx, s.AccessListsService, name)
 			if err != nil {
 				return trace.Wrap(err)
 			}
@@ -605,6 +686,28 @@ func (s *Hierarchy) expandOwnerOf(ctx context.Context, accessList *accesslist.Ac
 		}
 	}
 	return out, nil
+}
+
+func ownedListsForTraversal(list *accesslist.AccessList, ignoreScoped bool) ([]NormalizedSQN, error) {
+	if !ignoreScoped {
+		return AllOwnedLists(list)
+	}
+	ownedListNames := make([]NormalizedSQN, 0, len(list.Status.OwnerOf))
+	for _, ownedListName := range list.Status.OwnerOf {
+		ownedListNames = append(ownedListNames, NormalizedSQN{Name: ownedListName})
+	}
+	return ownedListNames, nil
+}
+
+func parentListsForTraversal(list *accesslist.AccessList, ignoreScoped bool) ([]NormalizedSQN, error) {
+	if !ignoreScoped {
+		return AllParentLists(list)
+	}
+	parentListNames := make([]NormalizedSQN, 0, len(list.Status.MemberOf))
+	for _, parentListName := range list.Status.MemberOf {
+		parentListNames = append(parentListNames, NormalizedSQN{Name: parentListName})
+	}
+	return parentListNames, nil
 }
 
 func (s *Hierarchy) validDirectOwner(user types.User, acl *accesslist.AccessList) bool {
@@ -631,15 +734,23 @@ func GetAncestorsFor(ctx context.Context, accessList *accesslist.AccessList, kin
 }
 
 func getAncestors(ctx context.Context, accessList *accesslist.AccessList, kind RelationshipKind, g AccessListAndMembersGetter, opts ...ancestorOption) ([]*accesslist.AccessList, trace.Error) {
-	ancestorsMap := make(map[string]*accesslist.AccessList)
-	if err := collectAncestors(ctx, accessList, kind, g, make(map[string]struct{}), ancestorsMap, opts...); err != nil {
+	ancestorsMap := make(map[NormalizedSQN]*accesslist.AccessList)
+	if err := collectAncestors(ctx, accessList, kind, g, make(map[NormalizedSQN]struct{}), ancestorsMap, opts...); err != nil {
 		return nil, trace.Wrap(err)
 	}
 	ancestors := slices.Collect(maps.Values(ancestorsMap))
 	return ancestors, nil
 }
 
-func collectAncestors(ctx context.Context, accessList *accesslist.AccessList, kind RelationshipKind, g AccessListAndMembersGetter, visited map[string]struct{}, ancestors map[string]*accesslist.AccessList, opts ...ancestorOption) error {
+func collectAncestors(
+	ctx context.Context,
+	accessList *accesslist.AccessList,
+	kind RelationshipKind,
+	g AccessListAndMembersGetter,
+	visited map[NormalizedSQN]struct{},
+	ancestors map[NormalizedSQN]*accesslist.AccessList,
+	opts ...ancestorOption,
+) error {
 	options := &ancestorOptions{}
 	for _, opt := range opts {
 		opt(options)
@@ -647,16 +758,20 @@ func collectAncestors(ctx context.Context, accessList *accesslist.AccessList, ki
 	if err := options.validate(); err != nil {
 		return trace.Wrap(err)
 	}
-	if _, ok := visited[accessList.GetName()]; ok {
+	if _, ok := visited[ScopeQualifiedName(accessList)]; ok {
 		return nil
 	}
-	visited[accessList.GetName()] = struct{}{}
+	visited[ScopeQualifiedName(accessList)] = struct{}{}
 
-	isDirectMembershipExpired := func(acl, member string) (bool, error) {
+	isDirectMembershipExpired := func(acl, member NormalizedSQN) (bool, error) {
+		// TODO(nklaassen): support scoped access list members.
+		if acl.Scope != "" || member.Scope != "" {
+			return false, trace.BadParameter("scoped access list members are not yet supported")
+		}
 		if !options.validateUserRequirement {
 			return false, nil
 		}
-		m, err := g.GetAccessListMember(ctx, acl, member)
+		m, err := g.GetAccessListMember(ctx, acl.Name, member.Name)
 		if err != nil {
 			return false, trace.Wrap(err)
 		}
@@ -672,8 +787,12 @@ func collectAncestors(ctx context.Context, accessList *accesslist.AccessList, ki
 
 	if kind == RelationshipKindOwner {
 		// Add parents where this list is an owner to ancestors
-		for _, ownerParent := range accessList.Status.OwnerOf {
-			ownerParentAcl, err := g.GetAccessList(ctx, ownerParent)
+		ownedListNames, err := ownedListsForTraversal(accessList, options.ignoreScoped)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+		for _, ownerParent := range ownedListNames {
+			ownerParentAcl, err := getAccessList(ctx, g, ownerParent)
 			if err != nil {
 				return trace.Wrap(err)
 			}
@@ -683,12 +802,16 @@ func collectAncestors(ctx context.Context, accessList *accesslist.AccessList, ki
 			ancestors[ownerParent] = ownerParentAcl
 		}
 	}
-	for _, memberParent := range accessList.Status.MemberOf {
-		memberParentAcl, err := g.GetAccessList(ctx, memberParent)
+	parentListNames, err := parentListsForTraversal(accessList, options.ignoreScoped)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	for _, memberParent := range parentListNames {
+		memberParentAcl, err := getAccessList(ctx, g, memberParent)
 		if err != nil {
 			return trace.Wrap(err)
 		}
-		expired, err := isDirectMembershipExpired(memberParent, accessList.GetName())
+		expired, err := isDirectMembershipExpired(memberParent, ScopeQualifiedName(accessList))
 		if err != nil {
 			return trace.Wrap(err)
 		}

--- a/lib/accesslists/hierarchy_test.go
+++ b/lib/accesslists/hierarchy_test.go
@@ -74,7 +74,7 @@ func (m *mockAccessListAndMembersGetter) GetAccessListV2(ctx context.Context, re
 	})
 	accessList, exists := m.accessLists[accessListName]
 	if !exists {
-		return nil, trace.NotFound("access list %v not found", accessListName)
+		return nil, trace.NotFound("access list %s not found", accessListName.String())
 	}
 	return accessList, nil
 }
@@ -249,6 +249,58 @@ func TestAccessListHierarchyIsOwner(t *testing.T) {
 	require.Error(t, err)
 	require.ErrorAs(t, err, new(*trace.AccessDeniedError))
 	require.Equal(t, accesslistv1.AccessListUserAssignmentType_ACCESS_LIST_USER_ASSIGNMENT_TYPE_UNSPECIFIED, ownershipType)
+}
+
+// TestIsAccessListOwnerScopedNameCollision asserts that IsAccessListOwner does
+// not consider a user to be an owner of a scoped access list if they are
+// actually a member of an unscoped access list with the same unqualified name
+// as a legimate scoped owner list.
+func TestIsAccessListOwnerScopedNameCollision(t *testing.T) {
+	clock := clockwork.NewFakeClock()
+	ctx := context.Background()
+
+	unscopedOwnerList := newAccessList(t, "owners", clock)
+	scopedOwnerList := newAccessList(t, "owners", clock)
+	scopedOwnerList.Scope = "/eng"
+	targetList := newAccessList(t, "target", clock)
+	targetList.Scope = "/eng/app"
+	targetList.Spec.Owners = []accesslist.Owner{{
+		Name:           ScopeQualifiedName(scopedOwnerList).String(),
+		MembershipKind: accesslist.MembershipKindScopedList,
+	}}
+
+	unscopedOwnerMember := newAccessListMember(t, unscopedOwnerList.GetName(), member1, accesslist.MembershipKindUser, clock)
+	accessListAndMembersGetter := &mockAccessListAndMembersGetter{
+		members:     mockAccessListMembers(unscopedOwnerMember),
+		accessLists: mockAccessLists(unscopedOwnerList, scopedOwnerList, targetList),
+	}
+
+	stubUser, err := types.NewUser(member1)
+	require.NoError(t, err)
+	stubUser.SetTraits(map[string][]string{
+		"mtrait1": {"mvalue1", "mvalue2"},
+		"mtrait2": {"mvalue3", "mvalue4"},
+		"otrait1": {"ovalue1", "ovalue2"},
+		"otrait2": {"ovalue3", "ovalue4"},
+	})
+	stubUser.SetRoles([]string{"mrole1", "mrole2", "orole1", "orole2"})
+
+	// Sanity check the user is legimately a member of the unscoped access list.
+	_, err = IsAccessListMember(ctx, stubUser, unscopedOwnerList, accessListAndMembersGetter, nil, clock)
+	require.NoError(t, err)
+
+	// IsAccessListOwner must return an error when checking if the user is an owner of the target list.
+	_, err = IsAccessListOwner(ctx, stubUser, targetList, accessListAndMembersGetter, nil, clock)
+	require.ErrorAs(t, err, new(*trace.AccessDeniedError))
+
+	// If we make the unscoped owner list an owner, the user becomes a legimate owner.
+	targetList.Spec.Owners = append(targetList.Spec.Owners, accesslist.Owner{
+		Name:           unscopedOwnerList.GetName(),
+		MembershipKind: accesslist.MembershipKindList,
+	})
+	assignmentType, err := IsAccessListOwner(ctx, stubUser, targetList, accessListAndMembersGetter, nil, clock)
+	require.NoError(t, err)
+	require.Equal(t, accesslistv1.AccessListUserAssignmentType_ACCESS_LIST_USER_ASSIGNMENT_TYPE_INHERITED, assignmentType)
 }
 
 func TestAccessListIsMember(t *testing.T) {

--- a/lib/accesslists/scopequalifiedname.go
+++ b/lib/accesslists/scopequalifiedname.go
@@ -17,6 +17,8 @@
 package accesslists
 
 import (
+	"github.com/gravitational/trace"
+
 	"github.com/gravitational/teleport/api/types/accesslist"
 	"github.com/gravitational/teleport/lib/scopes"
 )
@@ -47,10 +49,90 @@ func (n NormalizedSQN) ToScopesQualifiedName() scopes.QualifiedName {
 	}
 }
 
+// String formates the NormalizedSQN as a string.
+func (n NormalizedSQN) String() string {
+	return n.ToScopesQualifiedName().String()
+}
+
+// ParseScopeQualifiedName parses the given scope-qualified name string,
+// applies weak validation, and normalizes it.
+func ParseScopeQualifiedName(str string) (NormalizedSQN, error) {
+	sqn, err := scopes.ParseQualifiedName(str)
+	if err != nil {
+		return NormalizedSQN{}, trace.Wrap(err)
+	}
+	if err := sqn.WeakValidate(); err != nil {
+		return NormalizedSQN{}, trace.Wrap(err)
+	}
+	return NormalizeSQN(sqn), nil
+}
+
 // ScopeQualifiedName returns the normalized scope-qualified name of the given access list.
 func ScopeQualifiedName(list *accesslist.AccessList) NormalizedSQN {
 	return NormalizeSQN(scopes.QualifiedName{
 		Scope: list.Scope,
 		Name:  list.Metadata.Name,
 	})
+}
+
+// OwnerScopeQualifiedName returns the scope-qualified name of an access list owner.
+func OwnerScopeQualifiedName(owner accesslist.Owner) (NormalizedSQN, error) {
+	switch owner.MembershipKind {
+	case accesslist.MembershipKindUser, accesslist.MembershipKindList, accesslist.MembershipKindUnspecified, "":
+		return NormalizedSQN{
+			Name: owner.Name,
+		}, nil
+	case accesslist.MembershipKindScopedList:
+		return ParseScopeQualifiedName(owner.Name)
+	default:
+		return NormalizedSQN{}, trace.BadParameter("unhandled membership kind %s", owner.MembershipKind)
+	}
+}
+
+// MemberScopeQualifiedName returns the scope-qualified name of an access list member.
+func MemberScopeQualifiedName(member *accesslist.AccessListMember) (NormalizedSQN, error) {
+	switch member.Spec.MembershipKind {
+	case accesslist.MembershipKindUser, accesslist.MembershipKindList, accesslist.MembershipKindUnspecified, "":
+		return NormalizedSQN{
+			Name: member.GetName(),
+		}, nil
+	case accesslist.MembershipKindScopedList:
+		return ParseScopeQualifiedName(member.GetName())
+	default:
+		return NormalizedSQN{}, trace.BadParameter("unhandled membership kind %s", member.Spec.MembershipKind)
+	}
+}
+
+// AllOwnedLists returns the scope-qualified names of all access lists owned by
+// the given list, as recorded in Status.OwnerOf and Status.ScopedOwnerOf.
+func AllOwnedLists(list *accesslist.AccessList) ([]NormalizedSQN, error) {
+	ownedLists := make([]NormalizedSQN, 0, len(list.Status.OwnerOf)+len(list.Status.ScopedOwnerOf))
+	for _, ownerOf := range list.Status.OwnerOf {
+		ownedLists = append(ownedLists, NormalizedSQN{Name: ownerOf})
+	}
+	for _, scopedOwnerOf := range list.Status.ScopedOwnerOf {
+		ownedSQN, err := ParseScopeQualifiedName(scopedOwnerOf)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		ownedLists = append(ownedLists, ownedSQN)
+	}
+	return ownedLists, nil
+}
+
+// AllParentLists returns the scope-qualified names of all direct parent access
+// lists of the given list, as recorded in Status.MemberOf and Status.ScopedMemberOf.
+func AllParentLists(list *accesslist.AccessList) ([]NormalizedSQN, error) {
+	parentLists := make([]NormalizedSQN, 0, len(list.Status.MemberOf)+len(list.Status.ScopedMemberOf))
+	for _, memberOf := range list.Status.MemberOf {
+		parentLists = append(parentLists, NormalizedSQN{Name: memberOf})
+	}
+	for _, scopedMemberOf := range list.Status.ScopedMemberOf {
+		parentSQN, err := ParseScopeQualifiedName(scopedMemberOf)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		parentLists = append(parentLists, parentSQN)
+	}
+	return parentLists, nil
 }

--- a/lib/accesslists/validate.go
+++ b/lib/accesslists/validate.go
@@ -121,12 +121,11 @@ func validateAccessList(a *accesslist.AccessList) error {
 			return trace.BadParameter("scoped access lists cannot grant traits")
 		}
 
-		for _, owner := range a.Spec.Owners {
-			switch owner.MembershipKind {
-			case accesslist.MembershipKindList, accesslist.MembershipKindScopedList:
-				return trace.BadParameter("access list owners are not yet supported for scoped access lists")
-			}
-		}
+		// TODO(nklaassen): after scoped role assignments have been updated to
+		// refer to scoped access lists with scope-qualified names, access
+		// lists should do the same. At that point we must validate that the
+		// scope of origin of each granted scoped role is equal or ancestor to
+		// the scope of the access list.
 	}
 
 	if err := validateScopedRoleGrants(a); err != nil {
@@ -148,18 +147,22 @@ func validateScopedRoleGrants(a *accesslist.AccessList) error {
 		case grant.Scope == "":
 			return trace.BadParameter("scope is empty")
 		}
+
 		if err := scopes.StrongValidate(grant.Scope); err != nil {
 			return trace.Wrap(err, "validating scope")
 		}
+
 		if scopes.Compare(grant.Scope, scopes.Root) == scopes.Equivalent {
 			return trace.BadParameter("root scope cannot be used as a scope of effect")
 		}
+
 		if a.Scope != "" {
 			// Scoped access lists can only assign scoped roles to their own scope or a descendent scope.
 			if !scopes.ScopeOfOrigin(a.Scope).IsAssignableToScopeOfEffect(grant.Scope) {
 				return trace.BadParameter("scoped role grant has scope %q that is not a sub-scope of the access list's scope %q", grant.Scope, a.Scope)
 			}
 		}
+
 		uniqueScopedRoleGrants[grant] = struct{}{}
 		return nil
 	}
@@ -174,8 +177,8 @@ func validateScopedRoleGrants(a *accesslist.AccessList) error {
 		}
 	}
 	// Unique scoped role grants per access list have the same limit as role
-	// grants per scoped_role_assignment for the same reason: each role may
-	// require two backend.ConditionalActions to include in an AtomicWrite.
+	// grants per scoped role assignment, because each access list materializes
+	// to a single scoped roles assignment.
 	if len(uniqueScopedRoleGrants) > scopedaccess.MaxRolesPerAssignment {
 		return trace.BadParameter("access list contains too many unique scoped role grants (max %d)", scopedaccess.MaxRolesPerAssignment)
 	}
@@ -217,6 +220,7 @@ func validateAccessListNesting(ctx context.Context, accessList *accesslist.Acces
 		}
 	}
 	if accessList.Scope != "" && len(members) > 0 {
+		// TODO(nklaassen): support scoped access list members.
 		return trace.BadParameter("scoped access list members are not yet supported")
 	}
 	for _, member := range members {
@@ -238,7 +242,11 @@ func ValidateAccessListMember(
 	if err := validateAccessListMemberBasic(parentList, member); err != nil {
 		return trace.Wrap(err)
 	}
-	if err := validateAccessListMemberOrOwnerNesting(ctx, parentList, member.GetName(), RelationshipKindMember, member.Spec.MembershipKind, g); err != nil {
+	memberName, err := MemberScopeQualifiedName(member)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	if err := validateAccessListMemberOrOwnerNesting(ctx, parentList, memberName, RelationshipKindMember, member.Spec.MembershipKind, g); err != nil {
 		return trace.Wrap(err)
 	}
 	return nil
@@ -278,14 +286,16 @@ func validateAccessListOwner(
 	owner accesslist.Owner,
 	g AccessListAndMembersGetter,
 ) error {
-	// TODO(nklaassen): support non-user scoped access list owners.
-	if parentList.Scope != "" && owner.MembershipKind == accesslist.MembershipKindList {
-		return trace.BadParameter("scoped access lists do not yet support nested list ownership")
+	ownerName, err := OwnerScopeQualifiedName(owner)
+	if err != nil {
+		return trace.Wrap(err)
 	}
-	if owner.MembershipKind == accesslist.MembershipKindScopedList {
-		return trace.BadParameter("scoped access lists do not yet support nested list ownership")
+	if ownerName.Scope != "" {
+		if err := ownerName.ToScopesQualifiedName().StrongValidate(); err != nil {
+			return trace.Wrap(err)
+		}
 	}
-	if err := validateAccessListMemberOrOwnerNesting(ctx, parentList, owner.Name, RelationshipKindOwner, owner.MembershipKind, g); err != nil {
+	if err := validateAccessListMemberOrOwnerNesting(ctx, parentList, ownerName, RelationshipKindOwner, owner.MembershipKind, g); err != nil {
 		return trace.Wrap(err)
 	}
 	return nil
@@ -294,22 +304,60 @@ func validateAccessListOwner(
 func validateAccessListMemberOrOwnerNesting(
 	ctx context.Context,
 	parentList *accesslist.AccessList,
-	memberOrOwnerName string,
+	memberOrOwnerName NormalizedSQN,
 	relationshipKind RelationshipKind,
 	membershipKind string,
 	g AccessListAndMembersGetter,
 ) error {
-	if membershipKind != accesslist.MembershipKindList {
+	if !accesslist.IsMembershipKindList(membershipKind) {
 		return nil
 	}
+
+	if err := validateMemberOrOwnerScopeHierarchy(parentList, memberOrOwnerName, relationshipKind); err != nil {
+		return trace.Wrap(err)
+	}
+
 	// If it is a AccessList member/owner then the referenced AccessList must exist.
-	memberOrOwnerList, err := g.GetAccessList(ctx, memberOrOwnerName)
+	memberOrOwnerList, err := getAccessList(ctx, g, memberOrOwnerName)
 	if err != nil {
 		return trace.Wrap(err)
 	}
 	if err := validateAddition(ctx, parentList, memberOrOwnerList, relationshipKind, g); err != nil {
 		return trace.Wrap(err)
 	}
+	return nil
+}
+
+func validateMemberOrOwnerScopeHierarchy(
+	list *accesslist.AccessList,
+	memberOrOwnerName NormalizedSQN,
+	relationshipKind RelationshipKind,
+) error {
+	if memberOrOwnerName.Scope == "" {
+		// Unscoped access lists can be members or owners of scoped or unscoped lists.
+		return nil
+	}
+
+	if list.GetScope() == memberOrOwnerName.Scope {
+		// Members or owners are always allowed at the same scope of the parent/owned list.
+		return nil
+	}
+
+	kindStr := "a Member"
+	if relationshipKind == RelationshipKindOwner {
+		kindStr = "an Owner"
+	}
+
+	if list.GetScope() == "" {
+		return trace.BadParameter("Access List '%s' cannot name '%s' as %s because scoped access lists cannot be members or owners of unscoped access lists",
+			list.Spec.Title, memberOrOwnerName.String(), kindStr)
+	}
+
+	if !scopes.PolicyResourceScope(list.GetScope()).CanDependOnStateFromPolicyResourceAtScope(memberOrOwnerName.Scope) {
+		return trace.BadParameter("Access List '%s' cannot name '%s' as %s because it is not at an equal or ancestor scope",
+			list.Spec.Title, memberOrOwnerName.String(), kindStr)
+	}
+
 	return nil
 }
 
@@ -326,7 +374,7 @@ func validateAddition(
 	}
 
 	// Cycle detection
-	reachable, err := isReachable(ctx, childList, parentList, make(map[string]struct{}), g)
+	reachable, err := isReachable(ctx, childList, parentList, make(map[NormalizedSQN]struct{}), g)
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -352,52 +400,62 @@ func isReachable(
 	ctx context.Context,
 	currentList *accesslist.AccessList,
 	targetList *accesslist.AccessList,
-	visited map[string]struct{},
+	visited map[NormalizedSQN]struct{},
 	g AccessListAndMembersGetter,
 ) (bool, error) {
-	if currentList.GetName() == targetList.GetName() {
+	if ScopeQualifiedName(currentList) == ScopeQualifiedName(targetList) {
 		return true, nil
 	}
-	if _, ok := visited[currentList.GetName()]; ok {
+	if _, ok := visited[ScopeQualifiedName(currentList)]; ok {
 		return false, nil
 	}
-	visited[currentList.GetName()] = struct{}{}
+	visited[ScopeQualifiedName(currentList)] = struct{}{}
 
 	// Traverse member lists
-	listMembers, err := fetchMembers(ctx, currentList.GetName(), g)
+	listMembers, err := fetchMembers(ctx, ScopeQualifiedName(currentList), g)
 	if err != nil {
 		return false, trace.Wrap(err)
 	}
 	for _, member := range listMembers {
-		if member.Spec.MembershipKind == accesslist.MembershipKindList {
-			childList, err := g.GetAccessList(ctx, member.GetName())
-			if err != nil {
-				return false, trace.Wrap(err)
-			}
-			reachable, err := isReachable(ctx, childList, targetList, visited, g)
-			if err != nil {
-				return false, trace.Wrap(err)
-			}
-			if reachable {
-				return true, nil
-			}
+		if !member.IsList() {
+			continue
+		}
+		childListName, err := MemberScopeQualifiedName(member)
+		if err != nil {
+			return false, trace.Wrap(err)
+		}
+		childList, err := getAccessList(ctx, g, childListName)
+		if err != nil {
+			return false, trace.Wrap(err)
+		}
+		reachable, err := isReachable(ctx, childList, targetList, visited, g)
+		if err != nil {
+			return false, trace.Wrap(err)
+		}
+		if reachable {
+			return true, nil
 		}
 	}
 
 	// Traverse owner lists
 	for _, owner := range currentList.Spec.Owners {
-		if owner.MembershipKind == accesslist.MembershipKindList {
-			ownerList, err := g.GetAccessList(ctx, owner.Name)
-			if err != nil {
-				return false, trace.Wrap(err)
-			}
-			reachable, err := isReachable(ctx, ownerList, targetList, visited, g)
-			if err != nil {
-				return false, trace.Wrap(err)
-			}
-			if reachable {
-				return true, nil
-			}
+		if !owner.IsMembershipKindList() {
+			continue
+		}
+		ownerName, err := OwnerScopeQualifiedName(owner)
+		if err != nil {
+			return false, trace.Wrap(err)
+		}
+		ownerList, err := getAccessList(ctx, g, ownerName)
+		if err != nil {
+			return false, trace.Wrap(err)
+		}
+		reachable, err := isReachable(ctx, ownerList, targetList, visited, g)
+		if err != nil {
+			return false, trace.Wrap(err)
+		}
+		if reachable {
+			return true, nil
 		}
 	}
 
@@ -414,18 +472,18 @@ func exceedsMaxDepth(
 	switch kind {
 	case RelationshipKindOwner:
 		// For Owners, only consider the depth downwards from the child node
-		depthDownwards, err := maxDepthDownwards(ctx, childList.GetName(), make(map[string]struct{}), g)
+		depthDownwards, err := maxDepthDownwards(ctx, ScopeQualifiedName(childList), make(map[NormalizedSQN]struct{}), g)
 		if err != nil {
 			return false, trace.Wrap(err)
 		}
 		return depthDownwards > accesslist.MaxAllowedDepth, nil
 	default:
 		// For Members, consider the depth upwards from the parent node, downwards from the child node, and the edge between them
-		depthUpwards, err := maxDepthUpwards(ctx, parentList, make(map[string]struct{}), g)
+		depthUpwards, err := maxDepthUpwards(ctx, parentList, make(map[NormalizedSQN]struct{}), g)
 		if err != nil {
 			return false, trace.Wrap(err)
 		}
-		depthDownwards, err := maxDepthDownwards(ctx, childList.GetName(), make(map[string]struct{}), g)
+		depthDownwards, err := maxDepthDownwards(ctx, ScopeQualifiedName(childList), make(map[NormalizedSQN]struct{}), g)
 		if err != nil {
 			return false, trace.Wrap(err)
 		}

--- a/lib/accesslists/validate_test.go
+++ b/lib/accesslists/validate_test.go
@@ -326,6 +326,80 @@ func TestAccessListValidateWithMembers_basic(t *testing.T) {
 			}
 		})
 
+		t.Run("owner list scope hierarchy is validated", func(t *testing.T) {
+			testCases := []struct {
+				name       string
+				listScope  string
+				ownerScope string
+				ownerKind  string
+				wantErr    string
+			}{
+				{
+					name:       "unscoped owner can own scoped list",
+					listScope:  "/eng/platform",
+					ownerScope: "",
+					ownerKind:  accesslist.MembershipKindList,
+				},
+				{
+					name:       "same scope owner can own scoped list",
+					listScope:  "/eng/platform",
+					ownerScope: "/eng/platform",
+					ownerKind:  accesslist.MembershipKindScopedList,
+				},
+				{
+					name:       "ancestor scope owner can own scoped list",
+					listScope:  "/eng/platform",
+					ownerScope: "/eng",
+					ownerKind:  accesslist.MembershipKindScopedList,
+				},
+				{
+					name:       "descendant scope owner is rejected",
+					listScope:  "/eng/platform",
+					ownerScope: "/eng/platform/team",
+					ownerKind:  accesslist.MembershipKindScopedList,
+					wantErr:    "because it is not at an equal or ancestor scope",
+				},
+				{
+					name:       "sibling scope owner is rejected",
+					listScope:  "/eng/platform",
+					ownerScope: "/eng/infra",
+					ownerKind:  accesslist.MembershipKindScopedList,
+					wantErr:    "because it is not at an equal or ancestor scope",
+				},
+				{
+					name:       "unscoped list cannot name scoped owner",
+					listScope:  "",
+					ownerScope: "/eng",
+					ownerKind:  accesslist.MembershipKindScopedList,
+					wantErr:    "because scoped access lists cannot be members or owners of unscoped access lists",
+				},
+			}
+
+			for _, tc := range testCases {
+				t.Run(tc.name, func(t *testing.T) {
+					accessList := newScopedAccessList("test_scoped_access_list_owner_scope")
+					accessList.Scope = tc.listScope
+					ownerList := newScopedAccessList("owner-list")
+					ownerList.Scope = tc.ownerScope
+
+					accessList.Spec.Owners = []accesslist.Owner{{
+						Name:           ScopeQualifiedName(ownerList).String(),
+						MembershipKind: tc.ownerKind,
+					}}
+
+					getter := &mockAccessListAndMembersGetter{
+						accessLists: mockAccessLists(accessList, ownerList),
+					}
+					err := ValidateAccessListWithMembers(ctx, nil, accessList, nil, getter)
+					if tc.wantErr != "" {
+						require.ErrorContains(t, err, tc.wantErr)
+						return
+					}
+					require.NoError(t, err)
+				})
+			}
+		})
+
 		t.Run("owner scoped role grant scope must be equal or descendant", func(t *testing.T) {
 			accessList := newScopedAccessList("test_scoped_access_list_owner_grant_scope")
 			accessList.Scope = "/eng/platform"
@@ -381,22 +455,6 @@ func TestAccessListValidateWithMembers_basic(t *testing.T) {
 
 			err := ValidateAccessListWithMembers(ctx, nil, accessList, nil, &mockAccessListAndMembersGetter{})
 			require.ErrorContains(t, err, "scoped access lists cannot grant traits")
-		})
-
-		t.Run("nested list owners are rejected", func(t *testing.T) {
-			accessList := newScopedAccessList("test_scoped_access_list_owner_list")
-			accessList.Spec.Owners = []accesslist.Owner{{Name: "owner-list", MembershipKind: accesslist.MembershipKindList}}
-
-			err := ValidateAccessListWithMembers(ctx, nil, accessList, nil, &mockAccessListAndMembersGetter{})
-			require.ErrorContains(t, err, "access list owners are not yet supported for scoped access lists")
-		})
-
-		t.Run("scoped list owners are rejected", func(t *testing.T) {
-			accessList := newScopedAccessList("test_scoped_access_list_scoped_owner_list")
-			accessList.Spec.Owners = []accesslist.Owner{{Name: "/eng::owner-list", MembershipKind: accesslist.MembershipKindScopedList}}
-
-			err := ValidateAccessListWithMembers(ctx, nil, accessList, nil, &mockAccessListAndMembersGetter{})
-			require.ErrorContains(t, err, "access list owners are not yet supported for scoped access lists")
 		})
 
 		t.Run("members are rejected", func(t *testing.T) {

--- a/lib/accesslists/walk.go
+++ b/lib/accesslists/walk.go
@@ -214,7 +214,7 @@ func walk(ctx context.Context, config walkConfig, walkFn walkFunc) error {
 		return trace.Wrap(err)
 	}
 	stack = append(stack, accessPath{firstLeg})
-	seen := map[string]struct{}{config.root.GetName(): {}}
+	seen := map[NormalizedSQN]struct{}{ScopeQualifiedName(config.root): {}}
 
 	var path accessPath
 	var list *accesslist.AccessList
@@ -230,6 +230,11 @@ func walk(ctx context.Context, config walkConfig, walkFn walkFunc) error {
 		var leg accessLeg
 		var member *accesslist.AccessListMember
 
+		// TODO(nklaassen): support scoped access list members.
+		if list.GetScope() != "" {
+			continue
+		}
+
 		// We iterate over every member of the considered list
 		listMembersFn := func(ctx context.Context, pageSize int, pageToken string) ([]*accesslist.AccessListMember, string, error) {
 			r, token, err := config.getter.ListAccessListMembers(ctx, list.GetName(), pageSize, pageToken)
@@ -243,7 +248,10 @@ func walk(ctx context.Context, config walkConfig, walkFn walkFunc) error {
 
 			if member.Spec.MembershipKind == accesslist.MembershipKindList {
 				// The member is a nested list.
-				name := member.GetName()
+				name, err := MemberScopeQualifiedName(member)
+				if err != nil {
+					return trace.Wrap(err)
+				}
 
 				// If we already walked a valid path to this list, skip it.
 				if _, seen := seen[name]; seen {
@@ -254,7 +262,7 @@ func walk(ctx context.Context, config walkConfig, walkFn walkFunc) error {
 				// get the same AL several times if the accessLeg is filtered out.
 				// It's a bit inefficient but should not happen often, it's
 				// more relevant for us to avoid keeping everything in-memory.
-				nestedList, err = config.getter.GetAccessList(ctx, name)
+				nestedList, err = getAccessList(ctx, config.getter, name)
 				if err != nil {
 					// Gracefully handle the missing access list case,
 					// to avoid breaking everything in case of membership inconsistency.

--- a/lib/auth/userloginstate/generator.go
+++ b/lib/auth/userloginstate/generator.go
@@ -272,6 +272,7 @@ func (g *Generator) addAccessListsToState(ctx context.Context, user types.User, 
 	h, err := accesslists.NewHierarchy(accesslists.HierarchyConfig{
 		AccessListsService: g.accessLists,
 		Clock:              g.clock,
+		IgnoreScoped:       true,
 	})
 	if err != nil {
 		return nil, nil, trace.Wrap(err)

--- a/lib/services/local/access_list.go
+++ b/lib/services/local/access_list.go
@@ -56,7 +56,8 @@ const (
 
 	accessListReviewPrefix      = "access_list_review"
 	accessListReviewMaxPageSize = 200
-	scopedPrefix                = "scoped"
+
+	scopedPrefix = "scoped"
 
 	// This lock is necessary to prevent a race condition between access lists and members and to ensure
 	// consistency of the one-to-many relationship between them.
@@ -98,7 +99,18 @@ func (s *accessListAndMembersGetter) ListAccessListMembers(ctx context.Context, 
 }
 
 func (s *accessListAndMembersGetter) GetAccessList(ctx context.Context, name string) (*accesslist.AccessList, error) {
-	return s.service.GetResource(ctx, scopes.QualifiedName{Name: name})
+	return s.getAccessList(ctx, accesslists.NormalizedSQN{Name: name})
+}
+
+func (s *accessListAndMembersGetter) GetAccessListV2(ctx context.Context, req *accesslistv1.GetAccessListRequest) (*accesslist.AccessList, error) {
+	return s.getAccessList(ctx, accesslists.NormalizedSQN(scopes.QualifiedName{
+		Scope: req.GetScope(),
+		Name:  req.GetName(),
+	}))
+}
+
+func (s *accessListAndMembersGetter) getAccessList(ctx context.Context, listName accesslists.NormalizedSQN) (*accesslist.AccessList, error) {
+	return s.service.GetResource(ctx, listName.ToScopesQualifiedName())
 }
 
 // GetAccessListMember returns the specified access list member resource.
@@ -287,7 +299,7 @@ func (a *AccessListService) runOpWithLock(ctx context.Context, accessList *acces
 			return trace.Wrap(err)
 		}
 
-		if err := a.checkScopedRoleGrants(existingAccessList, accessList); err != nil {
+		if err := a.checkScopesFeatures(existingAccessList, accessList); err != nil {
 			return trace.Wrap(err)
 		}
 
@@ -295,25 +307,39 @@ func (a *AccessListService) runOpWithLock(ctx context.Context, accessList *acces
 	}
 
 	reconcileOldOwners := func() error {
-		currentOwnersMap := make(map[string]struct{})
+		if existingAccessList == nil {
+			return nil
+		}
+
+		currentOwnersMap := make(map[accesslists.NormalizedSQN]struct{})
 		for _, owner := range accessList.Spec.Owners {
-			if owner.MembershipKind == accesslist.MembershipKindList {
-				currentOwnersMap[owner.Name] = struct{}{}
+			if !owner.IsMembershipKindList() {
+				continue
 			}
+
+			ownerSQN, err := accesslists.OwnerScopeQualifiedName(owner)
+			if err != nil {
+				return trace.Wrap(err, "getting scope-qualified name of access list owner")
+			}
+			currentOwnersMap[ownerSQN] = struct{}{}
 		}
 
 		// update references for old owners
-		if existingAccessList != nil {
-			for _, owner := range existingAccessList.Spec.Owners {
-				if owner.MembershipKind != accesslist.MembershipKindList {
-					continue
-				}
-				// If this owner access list is not an owner anymore after the
-				// update/upsert, its status.owner_of has to be updated.
-				if _, exists := currentOwnersMap[owner.Name]; !exists {
-					if err := a.updateAccessListOwnerOf(ctx, accessList.GetName(), owner.Name, false); err != nil {
-						return trace.Wrap(err)
-					}
+		for _, owner := range existingAccessList.Spec.Owners {
+			if !owner.IsMembershipKindList() {
+				continue
+			}
+
+			ownerSQN, err := accesslists.OwnerScopeQualifiedName(owner)
+			if err != nil {
+				return trace.Wrap(err, "getting scope-qualified name of existing access list owner")
+			}
+
+			// If this owner access list is not an owner anymore after the
+			// update/upsert, its status.owner_of has to be updated.
+			if _, exists := currentOwnersMap[ownerSQN]; !exists {
+				if err := a.updateAccessListOwnerOf(ctx, accesslists.ScopeQualifiedName(accessList), ownerSQN, false); err != nil {
+					return trace.Wrap(err)
 				}
 			}
 		}
@@ -328,10 +354,15 @@ func (a *AccessListService) runOpWithLock(ctx context.Context, accessList *acces
 
 	reconcileNewOwners := func() error {
 		for _, owner := range accessList.Spec.Owners {
-			if owner.MembershipKind == accesslist.MembershipKindList {
-				if err := a.updateAccessListOwnerOf(ctx, accessList.GetName(), owner.Name, true); err != nil {
-					return trace.Wrap(err)
-				}
+			if !owner.IsMembershipKindList() {
+				continue
+			}
+			ownerScopedName, err := accesslists.OwnerScopeQualifiedName(owner)
+			if err != nil {
+				return trace.Wrap(err)
+			}
+			if err := a.updateAccessListOwnerOf(ctx, accesslists.ScopeQualifiedName(accessList), ownerScopedName, true); err != nil {
+				return trace.Wrap(err)
 			}
 		}
 		return nil
@@ -399,8 +430,9 @@ func (a *AccessListService) DeleteAccessListV2(ctx context.Context, req *accessl
 			return trace.Wrap(err)
 		}
 
-		// Delete all associated members.
+		// TODO(nklaassen): support scoped access list members
 		if name.Scope == "" {
+			// Delete all associated members.
 			members, err := a.memberService.WithPrefix(name.Name).GetResources(ctx)
 			if err != nil {
 				return trace.Wrap(err)
@@ -428,10 +460,14 @@ func (a *AccessListService) DeleteAccessListV2(ctx context.Context, req *accessl
 
 		// Update ownerOf refs.
 		for _, owner := range accessList.Spec.Owners {
-			if owner.MembershipKind != accesslist.MembershipKindList {
+			if !owner.IsMembershipKindList() {
 				continue
 			}
-			if err := a.updateAccessListOwnerOf(ctx, name.Name, owner.Name, false); err != nil {
+			ownerSQN, err := accesslists.OwnerScopeQualifiedName(owner)
+			if err != nil {
+				return trace.Wrap(err)
+			}
+			if err := a.updateAccessListOwnerOf(ctx, name, ownerSQN, false); err != nil {
 				return trace.Wrap(err)
 			}
 		}
@@ -486,7 +522,7 @@ func (a *AccessListService) CountAccessListMembers(ctx context.Context, accessLi
 
 // ListAccessListMembers returns a paginated list of all access list members.
 func (a *AccessListService) ListAccessListMembers(ctx context.Context, accessListName string, pageSize int, nextToken string) ([]*accesslist.AccessListMember, string, error) {
-	_, err := a.service.UnscopedService.GetResource(ctx, accessListName)
+	_, err := a.getAccessList(ctx, accesslists.NormalizedSQN{Name: accessListName})
 	if err != nil {
 		return nil, "", trace.Wrap(err)
 	}
@@ -513,7 +549,7 @@ func (a *AccessListService) ListAllAccessListMembers(ctx context.Context, pageSi
 
 // GetAccessListMember returns the specified access list member resource.
 func (a *AccessListService) GetAccessListMember(ctx context.Context, accessList string, memberName string) (*accesslist.AccessListMember, error) {
-	_, err := a.service.UnscopedService.GetResource(ctx, accessList)
+	_, err := a.getAccessList(ctx, accesslists.NormalizedSQN{Name: accessList})
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -525,12 +561,12 @@ func (a *AccessListService) GetAccessListMember(ctx context.Context, accessList 
 // adding or removing the specified accessListName to the field of targetName.
 func (a *AccessListService) updateAccessListRefField(
 	ctx context.Context,
-	accessListName string,
-	targetName string,
+	ref accesslists.NormalizedSQN,
+	target accesslists.NormalizedSQN,
 	new bool,
 	fieldSelector func(status *accesslist.Status) *[]string,
 ) error {
-	targetAccessList, err := a.service.UnscopedService.GetResource(ctx, targetName)
+	targetAccessList, err := a.getAccessList(ctx, target)
 	if err != nil {
 		if trace.IsNotFound(err) {
 			// If list is not found, it's possible that it was deleted. Regardless, there's nothing to update.
@@ -541,17 +577,19 @@ func (a *AccessListService) updateAccessListRefField(
 
 	field := fieldSelector(&targetAccessList.Status)
 
+	value := ref.String()
+
 	// If the field already contains the Access List, and we're adding,
 	// or doesn't contain it, and we're removing, there's nothing to do.
-	if slices.Contains(*field, accessListName) == new {
+	if slices.Contains(*field, value) == new {
 		return nil
 	}
 
 	if new {
-		*field = append(*field, accessListName)
+		*field = append(*field, value)
 	} else {
 		*field = slices.DeleteFunc(*field, func(e string) bool {
-			return e == accessListName
+			return e == value
 		})
 	}
 
@@ -565,16 +603,22 @@ func (a *AccessListService) updateAccessListRefField(
 // updateAccessListMemberOf updates the memberOf field for the specified memberName and accessListName.
 // Should only be called after the relevant member has been successfully upserted or deleted.
 func (a *AccessListService) updateAccessListMemberOf(ctx context.Context, accessListName, memberName string, new bool) error {
-	return a.updateAccessListRefField(ctx, accessListName, memberName, new, func(status *accesslist.Status) *[]string {
+	// TODO(nklaassen): support scoped access list members.
+	listSQN := accesslists.NormalizedSQN{Name: accessListName}
+	memberSQN := accesslists.NormalizedSQN{Name: memberName}
+	return a.updateAccessListRefField(ctx, listSQN, memberSQN, new, func(status *accesslist.Status) *[]string {
 		return &status.MemberOf
 	})
 }
 
 // updateAccessListOwnerOf updates the ownerOf field for the specified ownerName and accessListName.
 // Should only be called after the relevant owner has been successfully upserted or deleted.
-func (a *AccessListService) updateAccessListOwnerOf(ctx context.Context, accessListName, ownerName string, new bool) error {
+func (a *AccessListService) updateAccessListOwnerOf(ctx context.Context, accessListName, ownerName accesslists.NormalizedSQN, new bool) error {
 	return a.updateAccessListRefField(ctx, accessListName, ownerName, new, func(status *accesslist.Status) *[]string {
-		return &status.OwnerOf
+		if accessListName.Scope == "" {
+			return &status.OwnerOf
+		}
+		return &status.ScopedOwnerOf
 	})
 }
 
@@ -582,8 +626,21 @@ func (a *AccessListService) updateAccessListOwnerOf(ctx context.Context, accessL
 //
 // Returned Owners are not validated for ownership requirements – use `IsAccessListOwner` for validation.
 func (a *AccessListService) GetAccessListOwners(ctx context.Context, accessListName string) ([]*accesslist.Owner, error) {
+	return a.GetAccessListOwnersV2(ctx, accesslistv1.GetAccessListOwnersRequest_builder{
+		AccessList: accessListName,
+	}.Build())
+}
+
+// GetAccessListOwnersV2 returns a list of all owners in an Access List, including those inherited from nested Access Lists.
+//
+// Returned Owners are not validated for ownership requirements – use `IsAccessListOwner` for validation.
+func (a *AccessListService) GetAccessListOwnersV2(ctx context.Context, req *accesslistv1.GetAccessListOwnersRequest) ([]*accesslist.Owner, error) {
+	accessListName := accesslists.NormalizeSQN(scopes.QualifiedName{
+		Scope: req.GetAccessListScope(),
+		Name:  req.GetAccessList(),
+	})
 	var owners []*accesslist.Owner
-	accessList, err := a.service.UnscopedService.GetResource(ctx, accessListName)
+	accessList, err := a.getAccessList(ctx, accessListName)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -595,7 +652,7 @@ func (a *AccessListService) GetAccessListOwners(ctx context.Context, accessListN
 func (a *AccessListService) UpsertAccessListMember(ctx context.Context, member *accesslist.AccessListMember) (*accesslist.AccessListMember, error) {
 	var upserted *accesslist.AccessListMember
 	action := func(ctx context.Context, _ backend.Backend) error {
-		memberList, err := a.service.UnscopedService.GetResource(ctx, member.Spec.AccessList)
+		memberList, err := a.GetAccessList(ctx, member.Spec.AccessList)
 		if err != nil {
 			return trace.Wrap(err)
 		}
@@ -642,7 +699,7 @@ func (a *AccessListService) UpdateAccessListMember(ctx context.Context, member *
 	}
 	err := a.service.RunWhileLocked(ctx, []string{accessListResourceLockName}, accessListLockTTL, func(ctx context.Context, _ backend.Backend) error {
 		return a.service.RunWhileLocked(ctx, lockName(member.Spec.AccessList), accessListLockTTL, func(ctx context.Context, _ backend.Backend) error {
-			memberList, err := a.service.UnscopedService.GetResource(ctx, member.Spec.AccessList)
+			memberList, err := a.GetAccessList(ctx, member.Spec.AccessList)
 			if err != nil {
 				return trace.Wrap(err)
 			}
@@ -677,7 +734,7 @@ func (a *AccessListService) UpdateAccessListMember(ctx context.Context, member *
 func (a *AccessListService) DeleteAccessListMember(ctx context.Context, accessList string, memberName string) error {
 	err := a.service.RunWhileLocked(ctx, []string{accessListResourceLockName}, accessListLockTTL, func(ctx context.Context, _ backend.Backend) error {
 		return a.service.RunWhileLocked(ctx, lockName(accessList), accessListLockTTL, func(ctx context.Context, _ backend.Backend) error {
-			_, err := a.service.UnscopedService.GetResource(ctx, accessList)
+			_, err := a.GetAccessList(ctx, accessList)
 			if err != nil {
 				return trace.Wrap(err)
 			}
@@ -710,7 +767,7 @@ func (a *AccessListService) DeleteAccessListMember(ctx context.Context, accessLi
 func (a *AccessListService) DeleteAllAccessListMembersForAccessList(ctx context.Context, accessList string) error {
 	err := a.service.RunWhileLocked(ctx, []string{accessListResourceLockName}, accessListLockTTL, func(ctx context.Context, _ backend.Backend) error {
 		return a.service.RunWhileLocked(ctx, lockName(accessList), accessListLockTTL, func(ctx context.Context, _ backend.Backend) error {
-			_, err := a.service.UnscopedService.GetResource(ctx, accessList)
+			_, err := a.GetAccessList(ctx, accessList)
 			if err != nil {
 				return trace.Wrap(err)
 			}
@@ -798,7 +855,7 @@ func (a *AccessListService) writeAccessListWithMembers(ctx context.Context, acce
 			return trace.Wrap(err)
 		}
 
-		if err := a.checkScopedRoleGrants(existingAccessList, accessList); err != nil {
+		if err := a.checkScopesFeatures(existingAccessList, accessList); err != nil {
 			return trace.Wrap(err)
 		}
 
@@ -806,6 +863,14 @@ func (a *AccessListService) writeAccessListWithMembers(ctx context.Context, acce
 	}
 
 	reconcileMembers := func() error {
+		// TODO(nklaassen): support scoped access list members.
+		if accessList.Scope != "" {
+			if len(membersIn) > 0 {
+				return trace.BadParameter("scoped access list members are not yet supported")
+			}
+			return nil
+		}
+
 		// Convert the members slice to a map for easier lookup.
 		membersMap := utils.FromSlice(membersIn, types.GetName)
 
@@ -880,13 +945,26 @@ func (a *AccessListService) writeAccessListWithMembers(ctx context.Context, acce
 			return nil
 		}
 		for _, existingOwner := range existingAccessList.Spec.Owners {
-			if existingOwner.MembershipKind == accesslist.MembershipKindList {
-				if !slices.ContainsFunc(accessList.Spec.Owners, func(owner accesslist.Owner) bool {
-					return owner.Name == existingOwner.Name
-				}) {
-					if err := a.updateAccessListOwnerOf(ctx, existingAccessList.GetName(), existingOwner.Name, false); err != nil {
-						return trace.Wrap(err)
-					}
+			if !existingOwner.IsMembershipKindList() {
+				continue
+			}
+			existingOwnerName, err := accesslists.OwnerScopeQualifiedName(existingOwner)
+			if err != nil {
+				return trace.Wrap(err)
+			}
+			isStillAnOwnerList := slices.ContainsFunc(accessList.Spec.Owners, func(owner accesslist.Owner) bool {
+				if !owner.IsMembershipKindList() {
+					return false
+				}
+				ownerName, err := accesslists.OwnerScopeQualifiedName(owner)
+				if err != nil {
+					return false
+				}
+				return ownerName == existingOwnerName
+			})
+			if !isStillAnOwnerList {
+				if err := a.updateAccessListOwnerOf(ctx, accesslists.ScopeQualifiedName(existingAccessList), existingOwnerName, false); err != nil {
+					return trace.Wrap(err)
 				}
 			}
 		}
@@ -900,10 +978,15 @@ func (a *AccessListService) writeAccessListWithMembers(ctx context.Context, acce
 
 	reconcileNewOwners := func() error {
 		for _, owner := range accessList.Spec.Owners {
-			if owner.MembershipKind == accesslist.MembershipKindList {
-				if err := a.updateAccessListOwnerOf(ctx, accessList.GetName(), owner.Name, true); err != nil {
-					return trace.Wrap(err)
-				}
+			if !owner.IsMembershipKindList() {
+				continue
+			}
+			ownerName, err := accesslists.OwnerScopeQualifiedName(owner)
+			if err != nil {
+				return trace.Wrap(err)
+			}
+			if err := a.updateAccessListOwnerOf(ctx, accesslists.ScopeQualifiedName(accessList), ownerName, true); err != nil {
+				return trace.Wrap(err)
 			}
 		}
 		return nil
@@ -926,8 +1009,12 @@ func (a *AccessListService) writeAccessListWithMembers(ctx context.Context, acce
 	// interrupted as we use status.owner_of to calculate hierarchy.
 	actions = append(actions, validateAccessList, reconcileMembers, reconcileOldOwners, writeAccessList, reconcileNewOwners)
 
+	lockName, err := scopeAwareLockName(accesslists.ScopeQualifiedName(accessList))
+	if err != nil {
+		return nil, nil, trace.Wrap(err)
+	}
 	if err := a.service.RunWhileLocked(ctx, []string{accessListResourceLockName}, 2*accessListLockTTL, func(ctx context.Context, _ backend.Backend) error {
-		return a.service.RunWhileLocked(ctx, lockName(accessList.GetName()), 2*accessListLockTTL, func(ctx context.Context, _ backend.Backend) error {
+		return a.service.RunWhileLocked(ctx, lockName, 2*accessListLockTTL, func(ctx context.Context, _ backend.Backend) error {
 			for _, action := range actions {
 				if err := action(); err != nil {
 					return trace.Wrap(err)
@@ -942,9 +1029,18 @@ func (a *AccessListService) writeAccessListWithMembers(ctx context.Context, acce
 	return accessList, membersIn, nil
 }
 
-// checkScopedRoleGrants checks if there are any *new* scoped role grants in the list. If there are, it
-// requires the scopes feature to be enabled.
-func (a *AccessListService) checkScopedRoleGrants(existingList, newList *accesslist.AccessList) error {
+// checkScopesFeatures requires the scopes feature to be enabled if a new
+// scoped access list is being created or there are any *new* scoped role
+// grants in a list update.
+func (a *AccessListService) checkScopesFeatures(existingList, newList *accesslist.AccessList) error {
+	if a.scopesFeatures.Enabled {
+		return nil
+	}
+
+	if existingList == nil && newList.GetScope() != "" {
+		return trace.Wrap(a.scopesFeatures.AssertEnabled())
+	}
+
 	if len(newList.Spec.Grants.ScopedRoles) == 0 && len(newList.Spec.OwnerGrants.ScopedRoles) == 0 {
 		// The new list does not grant any scoped roles, so no checks are needed.
 		return nil
@@ -993,7 +1089,7 @@ func (a *AccessListService) AccessRequestPromote(_ context.Context, _ *accesslis
 
 // ListAccessListReviews will list access list reviews for a particular access list.
 func (a *AccessListService) ListAccessListReviews(ctx context.Context, accessList string, pageSize int, pageToken string) (reviews []*accesslist.Review, nextToken string, err error) {
-	_, err = a.service.UnscopedService.GetResource(ctx, accessList)
+	_, err = a.GetAccessList(ctx, accessList)
 	if err != nil {
 		return nil, "", trace.Wrap(err)
 	}
@@ -1040,7 +1136,7 @@ func (a *AccessListService) CreateAccessListReview(ctx context.Context, review *
 	var nextAuditDate time.Time
 
 	err = a.service.RunWhileLocked(ctx, lockName(review.Spec.AccessList), accessListLockTTL, func(ctx context.Context, _ backend.Backend) error {
-		accessList, err := a.service.UnscopedService.GetResource(ctx, review.Spec.AccessList)
+		accessList, err := a.GetAccessList(ctx, review.Spec.AccessList)
 		if err != nil {
 			return trace.Wrap(err)
 		}
@@ -1154,7 +1250,7 @@ func accessListRequiresEqual(a, b accesslist.Requires) bool {
 
 // DeleteAccessListReview will delete an access list review from the backend.
 func (a *AccessListService) DeleteAccessListReview(ctx context.Context, accessListName, reviewName string) error {
-	_, err := a.service.UnscopedService.GetResource(ctx, accessListName)
+	_, err := a.GetAccessList(ctx, accessListName)
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -1227,10 +1323,15 @@ func preserveAccessListFields(existingAccessList, accessList *accesslist.AccessL
 		// Set MemberOf/OwnerOf to the existing values to prevent them from being updated.
 		accessList.Status.MemberOf = existingAccessList.Status.MemberOf
 		accessList.Status.OwnerOf = existingAccessList.Status.OwnerOf
+		accessList.Status.ScopedMemberOf = existingAccessList.Status.ScopedMemberOf
+		accessList.Status.ScopedOwnerOf = existingAccessList.Status.ScopedOwnerOf
 	} else {
 		// For newly created AccessList make sure MemberOf/OwnerOf are empty.
 		accessList.Status.MemberOf = []string{}
 		accessList.Status.OwnerOf = []string{}
+		// Must be nil for the tests in teleport.e to pass.
+		accessList.Status.ScopedMemberOf = nil
+		accessList.Status.ScopedOwnerOf = nil
 	}
 }
 
@@ -1307,15 +1408,39 @@ func (a *AccessListService) updatedMembersNestedRelationships(ctx context.Contex
 
 // CleanupAccessListStatus removes invalid Status.OwnerOf and Status.MemberOf references.
 func (a *AccessListService) CleanupAccessListStatus(ctx context.Context, accessListName string) (*accesslist.AccessList, error) {
+	return a.CleanupAccessListStatusV2(ctx, accesslists.NormalizedSQN{Name: accessListName})
+}
+
+// CleanupAccessListStatusV2 removes invalid Status.(Scoped)OwnerOf and Status.(Scoped)MemberOf references.
+func (a *AccessListService) CleanupAccessListStatusV2(ctx context.Context, accessListName accesslists.NormalizedSQN) (*accesslist.AccessList, error) {
 	return a.runWithGlobalLockAccessList(ctx, accessListName, func() (*accesslist.AccessList, error) {
-		accessList, err := a.service.UnscopedService.GetResource(ctx, accessListName)
+		accessList, err := a.getAccessList(ctx, accessListName)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
 
+		isActualOwner := func(ownedList *accesslist.AccessList) bool {
+			return slices.ContainsFunc(ownedList.Spec.Owners, func(ownedListOwner accesslist.Owner) bool {
+				if !ownedListOwner.IsMembershipKindList() {
+					return false
+				}
+				ownedListOwnerName, err := accesslists.OwnerScopeQualifiedName(ownedListOwner)
+				if err != nil {
+					return false
+				}
+				return ownedListOwnerName == accessListName
+			})
+		}
+
 		var ownerRefreshErr error
+
+		// OwnerOf names unscoped access lists that this access list supposedly owns.
 		accessList.Status.OwnerOf = slices.DeleteFunc(accessList.Status.OwnerOf, func(ownerOf string) bool {
-			ownedList, err := a.service.UnscopedService.GetResource(ctx, ownerOf)
+			if accessList.Scope != "" {
+				// Scoped access lists can never own unscoped access lists.
+				return true
+			}
+			ownedList, err := a.GetAccessList(ctx, ownerOf)
 			if err != nil {
 				if trace.IsNotFound(err) {
 					return true
@@ -1323,27 +1448,48 @@ func (a *AccessListService) CleanupAccessListStatus(ctx context.Context, accessL
 				ownerRefreshErr = err
 				return false
 			}
-			isActualOwner := slices.ContainsFunc(ownedList.Spec.Owners, func(ownedListOwner accesslist.Owner) bool {
-				return ownedListOwner.MembershipKind == accesslist.MembershipKindList && ownedListOwner.Name == accessList.GetName()
-			})
-			return !isActualOwner
+			return !isActualOwner(ownedList)
 		})
 		if ownerRefreshErr != nil {
 			return nil, trace.Wrap(ownerRefreshErr)
 		}
 
-		var memberRefreshErr error
-		accessList.Status.MemberOf = slices.DeleteFunc(accessList.Status.MemberOf, func(memberOf string) bool {
-			if _, err := a.memberService.WithPrefix(memberOf).GetResource(ctx, accessList.GetName()); err != nil {
+		// ScopedOwnerOf names scoped access lists that this access list supposedly owns.
+		accessList.Status.ScopedOwnerOf = slices.DeleteFunc(accessList.Status.ScopedOwnerOf, func(scopedOwnerOf string) bool {
+			ownedListName, err := accesslists.ParseScopeQualifiedName(scopedOwnerOf)
+			if err != nil {
+				// If we can't parse the name, it is invalid and should be removed.
+				return true
+			}
+			ownedList, err := a.getAccessList(ctx, ownedListName)
+			if err != nil {
 				if trace.IsNotFound(err) {
 					return true
 				}
-				memberRefreshErr = err
+				ownerRefreshErr = err
+				return false
 			}
-			return false
+			return !isActualOwner(ownedList)
 		})
-		if memberRefreshErr != nil {
-			return nil, trace.Wrap(memberRefreshErr)
+		if ownerRefreshErr != nil {
+			return nil, trace.Wrap(ownerRefreshErr)
+		}
+
+		// TODO(nklaassen): support scoped access list members.
+		if accessListName.Scope == "" {
+			var memberRefreshErr error
+			accessList.Status.MemberOf = slices.DeleteFunc(accessList.Status.MemberOf, func(memberOf string) bool {
+				if _, err := a.memberService.WithPrefix(memberOf).GetResource(ctx, accessList.GetName()); err != nil {
+					if trace.IsNotFound(err) {
+						return true
+					}
+					memberRefreshErr = err
+				}
+				return false
+			})
+			if memberRefreshErr != nil {
+				return nil, trace.Wrap(memberRefreshErr)
+			}
 		}
 
 		accessList, err = a.service.UpdateResource(ctx, accessList)
@@ -1354,28 +1500,42 @@ func (a *AccessListService) CleanupAccessListStatus(ctx context.Context, accessL
 // EnsureNestedAccessListStatuses goes over all nested owners and nested members of the named
 // access list and ensures nested lists' statuses owner_of/member_of contain the access list name.
 func (a *AccessListService) EnsureNestedAccessListStatuses(ctx context.Context, accessListName string) error {
+	return a.EnsureNestedAccessListStatusesV2(ctx, accesslists.NormalizedSQN{Name: accessListName})
+}
+
+// EnsureNestedAccessListStatusesV2 goes over all nested owners and nested members of the named
+// access list and ensures nested lists' statuses owner_of/member_of contain the access list name.
+func (a *AccessListService) EnsureNestedAccessListStatusesV2(ctx context.Context, accessListName accesslists.NormalizedSQN) error {
 	return a.runWithGlobalLock(ctx, accessListName, func() error {
-		accessList, err := a.service.UnscopedService.GetResource(ctx, accessListName)
+		accessList, err := a.getAccessList(ctx, accessListName)
 		if err != nil {
 			return trace.Wrap(err)
 		}
 
 		for _, owner := range accessList.Spec.Owners {
-			if owner.MembershipKind == accesslist.MembershipKindList {
-				if err := a.updateAccessListOwnerOf(ctx, accessListName, owner.Name, true); err != nil {
-					return trace.Wrap(err)
-				}
+			if !owner.IsMembershipKindList() {
+				continue
+			}
+			ownerName, err := accesslists.OwnerScopeQualifiedName(owner)
+			if err != nil {
+				return trace.Wrap(err)
+			}
+			if err := a.updateAccessListOwnerOf(ctx, accessListName, ownerName, true); err != nil {
+				return trace.Wrap(err)
 			}
 		}
 
-		members, err := a.memberService.WithPrefix(accessListName).GetResources(ctx)
-		if err != nil {
-			return trace.Wrap(err)
-		}
-		for _, member := range members {
-			if member.Spec.MembershipKind == accesslist.MembershipKindList {
-				if err := a.updateAccessListMemberOf(ctx, accessListName, member.GetName(), true); err != nil {
-					return trace.Wrap(err)
+		// TODO(nklaassen): support scoped access list members.
+		if accessListName.Scope == "" {
+			members, err := a.memberService.WithPrefix(accessListName.Name).GetResources(ctx)
+			if err != nil {
+				return trace.Wrap(err)
+			}
+			for _, member := range members {
+				if member.Spec.MembershipKind == accesslist.MembershipKindList {
+					if err := a.updateAccessListMemberOf(ctx, accessListName.Name, member.GetName(), true); err != nil {
+						return trace.Wrap(err)
+					}
 				}
 			}
 		}
@@ -1441,6 +1601,7 @@ func (a *AccessListService) collectionToBackendItemsIter(collection *accesslists
 					return
 				}
 			}
+			// TODO(nklaassen): support collections of scoped access lists.
 			item, err := a.service.UnscopedService.MakeBackendItem(acl)
 			if err != nil {
 				yield(backend.Item{}, trace.Wrap(err))
@@ -1453,15 +1614,19 @@ func (a *AccessListService) collectionToBackendItemsIter(collection *accesslists
 	}
 }
 
-func (a *AccessListService) runWithGlobalLock(ctx context.Context, accessListName string, fn func() error) error {
+func (a *AccessListService) runWithGlobalLock(ctx context.Context, accessListName accesslists.NormalizedSQN, fn func() error) error {
+	lockName, err := scopeAwareLockName(accessListName)
+	if err != nil {
+		return trace.Wrap(err)
+	}
 	return a.service.RunWhileLocked(ctx, []string{accessListResourceLockName}, 2*accessListLockTTL, func(ctx context.Context, _ backend.Backend) error {
-		return a.service.RunWhileLocked(ctx, lockName(accessListName), 2*accessListLockTTL, func(ctx context.Context, _ backend.Backend) error {
+		return a.service.RunWhileLocked(ctx, lockName, 2*accessListLockTTL, func(ctx context.Context, _ backend.Backend) error {
 			return trace.Wrap(fn())
 		})
 	})
 }
 
-func (a *AccessListService) runWithGlobalLockAccessList(ctx context.Context, accessListName string, fn func() (*accesslist.AccessList, error)) (*accesslist.AccessList, error) {
+func (a *AccessListService) runWithGlobalLockAccessList(ctx context.Context, accessListName accesslists.NormalizedSQN, fn func() (*accesslist.AccessList, error)) (*accesslist.AccessList, error) {
 	var res *accesslist.AccessList
 	err := a.runWithGlobalLock(ctx, accessListName, func() error {
 		var err error
@@ -1491,7 +1656,7 @@ func (a *AccessListService) checkDeletionBlockingMemberRelationships(ctx context
 
 	memberOfTitles := make([]string, 0, len(memberOf))
 	for _, memberOf := range memberOf {
-		parentList, err := a.service.UnscopedService.GetResource(ctx, memberOf)
+		parentList, err := a.GetAccessList(ctx, memberOf)
 		if err != nil {
 			if trace.IsNotFound(err) {
 				continue
@@ -1521,27 +1686,33 @@ func (a *AccessListService) checkDeletionBlockingMemberRelationships(ctx context
 
 // checkDeletionBlockingOwnerRelationships checks if the access list owns any other access lists that would block deletion
 func (a *AccessListService) checkDeletionBlockingOwnerRelationships(ctx context.Context, accessList *accesslist.AccessList) error {
-	ownerOf := accessList.GetStatus().OwnerOf
-	if len(ownerOf) == 0 {
+	allOwnedLists, err := accesslists.AllOwnedLists(accessList)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	if len(allOwnedLists) == 0 {
 		return nil
 	}
 
-	ownerOfTitles := make([]string, 0, len(ownerOf))
-	for _, ownerOf := range ownerOf {
-		ownedList, err := a.service.UnscopedService.GetResource(ctx, ownerOf)
+	ownerOfTitles := make([]string, 0, len(allOwnedLists))
+	for _, ownedListName := range allOwnedLists {
+		ownedList, err := a.getAccessList(ctx, ownedListName)
 		if err != nil {
 			if trace.IsNotFound(err) {
 				continue
 			}
-			return trace.Wrap(err, `fetching owned list "%s"`, ownerOf)
+			return trace.Wrap(err, `fetching owned list "%s"`, ownedListName.String())
 		}
-		isActualOwner := false
-		for _, owner := range ownedList.Spec.Owners {
-			if owner.Name == accessList.GetName() && owner.MembershipKind == accesslist.MembershipKindList {
-				isActualOwner = true
-				break
+		isActualOwner := slices.ContainsFunc(ownedList.Spec.Owners, func(owner accesslist.Owner) bool {
+			if !owner.IsMembershipKindList() {
+				return false
 			}
-		}
+			actualOwnerSQN, err := accesslists.OwnerScopeQualifiedName(owner)
+			if err != nil {
+				return false
+			}
+			return actualOwnerSQN == accesslists.ScopeQualifiedName(accessList)
+		})
 		if isActualOwner {
 			ownerOfTitles = append(ownerOfTitles, ownedList.Spec.Title)
 		}

--- a/lib/services/local/access_list_test.go
+++ b/lib/services/local/access_list_test.go
@@ -168,7 +168,12 @@ func TestAccessListCRUDScoped(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	service := newAccessListService(t, mem, modulestest.EnterpriseModules())
+	service, err := NewAccessListServiceV2(AccessListServiceConfig{
+		Backend:        backend.NewSanitizer(mem),
+		Modules:        modulestest.EnterpriseModules(),
+		ScopesFeatures: scopes.Features{Enabled: true},
+	})
+	require.NoError(t, err)
 
 	newScopedAccessList := func(name, scope string) *accesslist.AccessList {
 		acl := newAccessList(t, name, clock,


### PR DESCRIPTION
Part of [RFD 308](https://github.com/gravitational/rfd/pull/22)

This PR adds support for scoped access lists to have owners that are nested (scoped or unscoped) access lists.

Changes:

- Add scope-qualified access list name helpers for owners, members, parent lists, and owned lists.
- Teach nesting validation, cycle detection, and max-depth checks to use scope-qualified list names.
- Allow scoped access lists to use unscoped, same-scope, or ancestor-scope list owners.
- Reject scoped list owners from descendant/sibling scopes, and reject scoped owners on unscoped lists.
- Update local service owner status reconciliation to track scoped owned lists in `ScopedOwnerOf`.
- Ensure delete/status repair paths account for scoped owner relationships.

Note: scoped access list members remain unsupported in this PR. Scoped owner lists can be referenced and tracked, but inherited ownership through scoped owner list members is not possible until scoped members are implemented.

Parent: https://github.com/gravitational/teleport/pull/68030
Child: https://github.com/gravitational/teleport/pull/68095