### PR TITLE
Desktop Access: Plumb Directory IDs through TDPB

### DIFF
--- a/api/gen/proto/go/teleport/desktop/v1/tdpb.pb.go
+++ b/api/gen/proto/go/teleport/desktop/v1/tdpb.pb.go
@@ -326,14 +326,15 @@ func (b0 ClientHello_builder) Build() *ClientHello {
 
 // Sent by server in response to a 'Client Hello'. Advertises server capabilities.
 type ServerHello struct {
-	state                    protoimpl.MessageState `protogen:"hybrid.v1"`
-	ActivationSpec           *ConnectionActivated   `protobuf:"bytes,1,opt,name=activation_spec,json=activationSpec,proto3" json:"activation_spec,omitempty"`
-	ClipboardEnabled         bool                   `protobuf:"varint,2,opt,name=clipboard_enabled,json=clipboardEnabled,proto3" json:"clipboard_enabled,omitempty"`
-	DirectoryRemoveSupported bool                   `protobuf:"varint,3,opt,name=directory_remove_supported,json=directoryRemoveSupported,proto3" json:"directory_remove_supported,omitempty"`
-	Sessions                 []*SessionIdentifier   `protobuf:"bytes,4,rep,name=sessions,proto3" json:"sessions,omitempty"`
-	HidpiSupported           bool                   `protobuf:"varint,5,opt,name=hidpi_supported,json=hidpiSupported,proto3" json:"hidpi_supported,omitempty"`
-	unknownFields            protoimpl.UnknownFields
-	sizeCache                protoimpl.SizeCache
+	state                          protoimpl.MessageState `protogen:"hybrid.v1"`
+	ActivationSpec                 *ConnectionActivated   `protobuf:"bytes,1,opt,name=activation_spec,json=activationSpec,proto3" json:"activation_spec,omitempty"`
+	ClipboardEnabled               bool                   `protobuf:"varint,2,opt,name=clipboard_enabled,json=clipboardEnabled,proto3" json:"clipboard_enabled,omitempty"`
+	DirectoryRemoveSupported       bool                   `protobuf:"varint,3,opt,name=directory_remove_supported,json=directoryRemoveSupported,proto3" json:"directory_remove_supported,omitempty"`
+	Sessions                       []*SessionIdentifier   `protobuf:"bytes,4,rep,name=sessions,proto3" json:"sessions,omitempty"`
+	HidpiSupported                 bool                   `protobuf:"varint,5,opt,name=hidpi_supported,json=hidpiSupported,proto3" json:"hidpi_supported,omitempty"`
+	MultidirectorySharingSupported bool                   `protobuf:"varint,6,opt,name=multidirectory_sharing_supported,json=multidirectorySharingSupported,proto3" json:"multidirectory_sharing_supported,omitempty"`
+	unknownFields                  protoimpl.UnknownFields
+	sizeCache                      protoimpl.SizeCache
 }
 
 func (x *ServerHello) Reset() {
@@ -396,6 +397,13 @@ func (x *ServerHello) GetHidpiSupported() bool {
 	return false
 }
 
+func (x *ServerHello) GetMultidirectorySharingSupported() bool {
+	if x != nil {
+		return x.MultidirectorySharingSupported
+	}
+	return false
+}
+
 func (x *ServerHello) SetActivationSpec(v *ConnectionActivated) {
 	x.ActivationSpec = v
 }
@@ -416,6 +424,10 @@ func (x *ServerHello) SetHidpiSupported(v bool) {
 	x.HidpiSupported = v
 }
 
+func (x *ServerHello) SetMultidirectorySharingSupported(v bool) {
+	x.MultidirectorySharingSupported = v
+}
+
 func (x *ServerHello) HasActivationSpec() bool {
 	if x == nil {
 		return false
@@ -430,11 +442,12 @@ func (x *ServerHello) ClearActivationSpec() {
 type ServerHello_builder struct {
 	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
 
-	ActivationSpec           *ConnectionActivated
-	ClipboardEnabled         bool
-	DirectoryRemoveSupported bool
-	Sessions                 []*SessionIdentifier
-	HidpiSupported           bool
+	ActivationSpec                 *ConnectionActivated
+	ClipboardEnabled               bool
+	DirectoryRemoveSupported       bool
+	Sessions                       []*SessionIdentifier
+	HidpiSupported                 bool
+	MultidirectorySharingSupported bool
 }
 
 func (b0 ServerHello_builder) Build() *ServerHello {
@@ -446,6 +459,7 @@ func (b0 ServerHello_builder) Build() *ServerHello {
 	x.DirectoryRemoveSupported = b.DirectoryRemoveSupported
 	x.Sessions = b.Sessions
 	x.HidpiSupported = b.HidpiSupported
+	x.MultidirectorySharingSupported = b.MultidirectorySharingSupported
 	return m0
 }
 
@@ -5268,13 +5282,14 @@ const file_teleport_desktop_v1_tdpb_proto_rawDesc = "" +
 	"\busername\x18\x01 \x01(\tR\busername\x12F\n" +
 	"\vscreen_spec\x18\x02 \x01(\v2%.teleport.desktop.v1.ClientScreenSpecR\n" +
 	"screenSpec\x12'\n" +
-	"\x0fkeyboard_layout\x18\x03 \x01(\rR\x0ekeyboardLayout\"\xb8\x02\n" +
+	"\x0fkeyboard_layout\x18\x03 \x01(\rR\x0ekeyboardLayout\"\x82\x03\n" +
 	"\vServerHello\x12Q\n" +
 	"\x0factivation_spec\x18\x01 \x01(\v2(.teleport.desktop.v1.ConnectionActivatedR\x0eactivationSpec\x12+\n" +
 	"\x11clipboard_enabled\x18\x02 \x01(\bR\x10clipboardEnabled\x12<\n" +
 	"\x1adirectory_remove_supported\x18\x03 \x01(\bR\x18directoryRemoveSupported\x12B\n" +
 	"\bsessions\x18\x04 \x03(\v2&.teleport.desktop.v1.SessionIdentifierR\bsessions\x12'\n" +
-	"\x0fhidpi_supported\x18\x05 \x01(\bR\x0ehidpiSupported\"'\n" +
+	"\x0fhidpi_supported\x18\x05 \x01(\bR\x0ehidpiSupported\x12H\n" +
+	" multidirectory_sharing_supported\x18\x06 \x01(\bR\x1emultidirectorySharingSupported\"'\n" +
 	"\x11SessionIdentifier\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\"T\n" +
 	"\x10SessionSelection\x12@\n" +

--- a/api/gen/proto/go/teleport/desktop/v1/tdpb.pb.go
+++ b/api/gen/proto/go/teleport/desktop/v1/tdpb.pb.go
@@ -2417,6 +2417,7 @@ type SharedDirectoryResponse struct {
 	// Common fields used for all response types.
 	CompletionId uint32 `protobuf:"varint,1,opt,name=completion_id,json=completionId,proto3" json:"completion_id,omitempty"`
 	ErrorCode    uint32 `protobuf:"varint,2,opt,name=error_code,json=errorCode,proto3" json:"error_code,omitempty"`
+	DirectoryId  uint32 `protobuf:"varint,11,opt,name=directory_id,json=directoryId,proto3" json:"directory_id,omitempty"`
 	// operation is the particular operation type that
 	// this response is intended for.
 	//
@@ -2470,6 +2471,13 @@ func (x *SharedDirectoryResponse) GetCompletionId() uint32 {
 func (x *SharedDirectoryResponse) GetErrorCode() uint32 {
 	if x != nil {
 		return x.ErrorCode
+	}
+	return 0
+}
+
+func (x *SharedDirectoryResponse) GetDirectoryId() uint32 {
+	if x != nil {
+		return x.DirectoryId
 	}
 	return 0
 }
@@ -2559,6 +2567,10 @@ func (x *SharedDirectoryResponse) SetCompletionId(v uint32) {
 
 func (x *SharedDirectoryResponse) SetErrorCode(v uint32) {
 	x.ErrorCode = v
+}
+
+func (x *SharedDirectoryResponse) SetDirectoryId(v uint32) {
+	x.DirectoryId = v
 }
 
 func (x *SharedDirectoryResponse) SetInfo(v *SharedDirectoryResponse_Info) {
@@ -2790,6 +2802,7 @@ type SharedDirectoryResponse_builder struct {
 	// Common fields used for all response types.
 	CompletionId uint32
 	ErrorCode    uint32
+	DirectoryId  uint32
 	// operation is the particular operation type that
 	// this response is intended for.
 
@@ -2811,6 +2824,7 @@ func (b0 SharedDirectoryResponse_builder) Build() *SharedDirectoryResponse {
 	_, _ = b, x
 	x.CompletionId = b.CompletionId
 	x.ErrorCode = b.ErrorCode
+	x.DirectoryId = b.DirectoryId
 	if b.Info != nil {
 		x.Operation = &SharedDirectoryResponse_Info_{b.Info}
 	}
@@ -5359,11 +5373,12 @@ const file_teleport_desktop_v1_tdpb_proto_rawDesc = "" +
 	"\bTruncate\x12\x12\n" +
 	"\x04path\x18\x01 \x01(\tR\x04path\x12\x12\n" +
 	"\x04size\x18\x03 \x01(\x04R\x04sizeJ\x04\b\x02\x10\x03R\vend_of_fileB\v\n" +
-	"\toperation\"\x83\b\n" +
+	"\toperation\"\xa6\b\n" +
 	"\x17SharedDirectoryResponse\x12#\n" +
 	"\rcompletion_id\x18\x01 \x01(\rR\fcompletionId\x12\x1d\n" +
 	"\n" +
-	"error_code\x18\x02 \x01(\rR\terrorCode\x12G\n" +
+	"error_code\x18\x02 \x01(\rR\terrorCode\x12!\n" +
+	"\fdirectory_id\x18\v \x01(\rR\vdirectoryId\x12G\n" +
 	"\x04info\x18\x03 \x01(\v21.teleport.desktop.v1.SharedDirectoryResponse.InfoH\x00R\x04info\x12M\n" +
 	"\x06create\x18\x04 \x01(\v23.teleport.desktop.v1.SharedDirectoryResponse.CreateH\x00R\x06create\x12M\n" +
 	"\x06delete\x18\x05 \x01(\v23.teleport.desktop.v1.SharedDirectoryResponse.DeleteH\x00R\x06delete\x12G\n" +

--- a/api/gen/proto/go/teleport/desktop/v1/tdpb_protoopaque.pb.go
+++ b/api/gen/proto/go/teleport/desktop/v1/tdpb_protoopaque.pb.go
@@ -326,14 +326,15 @@ func (b0 ClientHello_builder) Build() *ClientHello {
 
 // Sent by server in response to a 'Client Hello'. Advertises server capabilities.
 type ServerHello struct {
-	state                               protoimpl.MessageState `protogen:"opaque.v1"`
-	xxx_hidden_ActivationSpec           *ConnectionActivated   `protobuf:"bytes,1,opt,name=activation_spec,json=activationSpec,proto3"`
-	xxx_hidden_ClipboardEnabled         bool                   `protobuf:"varint,2,opt,name=clipboard_enabled,json=clipboardEnabled,proto3"`
-	xxx_hidden_DirectoryRemoveSupported bool                   `protobuf:"varint,3,opt,name=directory_remove_supported,json=directoryRemoveSupported,proto3"`
-	xxx_hidden_Sessions                 *[]*SessionIdentifier  `protobuf:"bytes,4,rep,name=sessions,proto3"`
-	xxx_hidden_HidpiSupported           bool                   `protobuf:"varint,5,opt,name=hidpi_supported,json=hidpiSupported,proto3"`
-	unknownFields                       protoimpl.UnknownFields
-	sizeCache                           protoimpl.SizeCache
+	state                                     protoimpl.MessageState `protogen:"opaque.v1"`
+	xxx_hidden_ActivationSpec                 *ConnectionActivated   `protobuf:"bytes,1,opt,name=activation_spec,json=activationSpec,proto3"`
+	xxx_hidden_ClipboardEnabled               bool                   `protobuf:"varint,2,opt,name=clipboard_enabled,json=clipboardEnabled,proto3"`
+	xxx_hidden_DirectoryRemoveSupported       bool                   `protobuf:"varint,3,opt,name=directory_remove_supported,json=directoryRemoveSupported,proto3"`
+	xxx_hidden_Sessions                       *[]*SessionIdentifier  `protobuf:"bytes,4,rep,name=sessions,proto3"`
+	xxx_hidden_HidpiSupported                 bool                   `protobuf:"varint,5,opt,name=hidpi_supported,json=hidpiSupported,proto3"`
+	xxx_hidden_MultidirectorySharingSupported bool                   `protobuf:"varint,6,opt,name=multidirectory_sharing_supported,json=multidirectorySharingSupported,proto3"`
+	unknownFields                             protoimpl.UnknownFields
+	sizeCache                                 protoimpl.SizeCache
 }
 
 func (x *ServerHello) Reset() {
@@ -398,6 +399,13 @@ func (x *ServerHello) GetHidpiSupported() bool {
 	return false
 }
 
+func (x *ServerHello) GetMultidirectorySharingSupported() bool {
+	if x != nil {
+		return x.xxx_hidden_MultidirectorySharingSupported
+	}
+	return false
+}
+
 func (x *ServerHello) SetActivationSpec(v *ConnectionActivated) {
 	x.xxx_hidden_ActivationSpec = v
 }
@@ -418,6 +426,10 @@ func (x *ServerHello) SetHidpiSupported(v bool) {
 	x.xxx_hidden_HidpiSupported = v
 }
 
+func (x *ServerHello) SetMultidirectorySharingSupported(v bool) {
+	x.xxx_hidden_MultidirectorySharingSupported = v
+}
+
 func (x *ServerHello) HasActivationSpec() bool {
 	if x == nil {
 		return false
@@ -432,11 +444,12 @@ func (x *ServerHello) ClearActivationSpec() {
 type ServerHello_builder struct {
 	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
 
-	ActivationSpec           *ConnectionActivated
-	ClipboardEnabled         bool
-	DirectoryRemoveSupported bool
-	Sessions                 []*SessionIdentifier
-	HidpiSupported           bool
+	ActivationSpec                 *ConnectionActivated
+	ClipboardEnabled               bool
+	DirectoryRemoveSupported       bool
+	Sessions                       []*SessionIdentifier
+	HidpiSupported                 bool
+	MultidirectorySharingSupported bool
 }
 
 func (b0 ServerHello_builder) Build() *ServerHello {
@@ -448,6 +461,7 @@ func (b0 ServerHello_builder) Build() *ServerHello {
 	x.xxx_hidden_DirectoryRemoveSupported = b.DirectoryRemoveSupported
 	x.xxx_hidden_Sessions = &b.Sessions
 	x.xxx_hidden_HidpiSupported = b.HidpiSupported
+	x.xxx_hidden_MultidirectorySharingSupported = b.MultidirectorySharingSupported
 	return m0
 }
 
@@ -5198,13 +5212,14 @@ const file_teleport_desktop_v1_tdpb_proto_rawDesc = "" +
 	"\busername\x18\x01 \x01(\tR\busername\x12F\n" +
 	"\vscreen_spec\x18\x02 \x01(\v2%.teleport.desktop.v1.ClientScreenSpecR\n" +
 	"screenSpec\x12'\n" +
-	"\x0fkeyboard_layout\x18\x03 \x01(\rR\x0ekeyboardLayout\"\xb8\x02\n" +
+	"\x0fkeyboard_layout\x18\x03 \x01(\rR\x0ekeyboardLayout\"\x82\x03\n" +
 	"\vServerHello\x12Q\n" +
 	"\x0factivation_spec\x18\x01 \x01(\v2(.teleport.desktop.v1.ConnectionActivatedR\x0eactivationSpec\x12+\n" +
 	"\x11clipboard_enabled\x18\x02 \x01(\bR\x10clipboardEnabled\x12<\n" +
 	"\x1adirectory_remove_supported\x18\x03 \x01(\bR\x18directoryRemoveSupported\x12B\n" +
 	"\bsessions\x18\x04 \x03(\v2&.teleport.desktop.v1.SessionIdentifierR\bsessions\x12'\n" +
-	"\x0fhidpi_supported\x18\x05 \x01(\bR\x0ehidpiSupported\"'\n" +
+	"\x0fhidpi_supported\x18\x05 \x01(\bR\x0ehidpiSupported\x12H\n" +
+	" multidirectory_sharing_supported\x18\x06 \x01(\bR\x1emultidirectorySharingSupported\"'\n" +
 	"\x11SessionIdentifier\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\"T\n" +
 	"\x10SessionSelection\x12@\n" +

--- a/api/gen/proto/go/teleport/desktop/v1/tdpb_protoopaque.pb.go
+++ b/api/gen/proto/go/teleport/desktop/v1/tdpb_protoopaque.pb.go
@@ -2397,6 +2397,7 @@ type SharedDirectoryResponse struct {
 	state                   protoimpl.MessageState              `protogen:"opaque.v1"`
 	xxx_hidden_CompletionId uint32                              `protobuf:"varint,1,opt,name=completion_id,json=completionId,proto3"`
 	xxx_hidden_ErrorCode    uint32                              `protobuf:"varint,2,opt,name=error_code,json=errorCode,proto3"`
+	xxx_hidden_DirectoryId  uint32                              `protobuf:"varint,11,opt,name=directory_id,json=directoryId,proto3"`
 	xxx_hidden_Operation    isSharedDirectoryResponse_Operation `protobuf_oneof:"operation"`
 	unknownFields           protoimpl.UnknownFields
 	sizeCache               protoimpl.SizeCache
@@ -2437,6 +2438,13 @@ func (x *SharedDirectoryResponse) GetCompletionId() uint32 {
 func (x *SharedDirectoryResponse) GetErrorCode() uint32 {
 	if x != nil {
 		return x.xxx_hidden_ErrorCode
+	}
+	return 0
+}
+
+func (x *SharedDirectoryResponse) GetDirectoryId() uint32 {
+	if x != nil {
+		return x.xxx_hidden_DirectoryId
 	}
 	return 0
 }
@@ -2519,6 +2527,10 @@ func (x *SharedDirectoryResponse) SetCompletionId(v uint32) {
 
 func (x *SharedDirectoryResponse) SetErrorCode(v uint32) {
 	x.xxx_hidden_ErrorCode = v
+}
+
+func (x *SharedDirectoryResponse) SetDirectoryId(v uint32) {
+	x.xxx_hidden_DirectoryId = v
 }
 
 func (x *SharedDirectoryResponse) SetInfo(v *SharedDirectoryResponse_Info) {
@@ -2750,6 +2762,7 @@ type SharedDirectoryResponse_builder struct {
 	// Common fields used for all response types.
 	CompletionId uint32
 	ErrorCode    uint32
+	DirectoryId  uint32
 	// operation is the particular operation type that
 	// this response is intended for.
 
@@ -2771,6 +2784,7 @@ func (b0 SharedDirectoryResponse_builder) Build() *SharedDirectoryResponse {
 	_, _ = b, x
 	x.xxx_hidden_CompletionId = b.CompletionId
 	x.xxx_hidden_ErrorCode = b.ErrorCode
+	x.xxx_hidden_DirectoryId = b.DirectoryId
 	if b.Info != nil {
 		x.xxx_hidden_Operation = &sharedDirectoryResponse_Info_{b.Info}
 	}
@@ -5289,11 +5303,12 @@ const file_teleport_desktop_v1_tdpb_proto_rawDesc = "" +
 	"\bTruncate\x12\x12\n" +
 	"\x04path\x18\x01 \x01(\tR\x04path\x12\x12\n" +
 	"\x04size\x18\x03 \x01(\x04R\x04sizeJ\x04\b\x02\x10\x03R\vend_of_fileB\v\n" +
-	"\toperation\"\x83\b\n" +
+	"\toperation\"\xa6\b\n" +
 	"\x17SharedDirectoryResponse\x12#\n" +
 	"\rcompletion_id\x18\x01 \x01(\rR\fcompletionId\x12\x1d\n" +
 	"\n" +
-	"error_code\x18\x02 \x01(\rR\terrorCode\x12G\n" +
+	"error_code\x18\x02 \x01(\rR\terrorCode\x12!\n" +
+	"\fdirectory_id\x18\v \x01(\rR\vdirectoryId\x12G\n" +
 	"\x04info\x18\x03 \x01(\v21.teleport.desktop.v1.SharedDirectoryResponse.InfoH\x00R\x04info\x12M\n" +
 	"\x06create\x18\x04 \x01(\v23.teleport.desktop.v1.SharedDirectoryResponse.CreateH\x00R\x06create\x12M\n" +
 	"\x06delete\x18\x05 \x01(\v23.teleport.desktop.v1.SharedDirectoryResponse.DeleteH\x00R\x06delete\x12G\n" +

--- a/api/proto/teleport/desktop/v1/tdpb.proto
+++ b/api/proto/teleport/desktop/v1/tdpb.proto
@@ -269,6 +269,7 @@ message SharedDirectoryResponse {
   // Common fields used for all response types.
   uint32 completion_id = 1;
   uint32 error_code = 2;
+  uint32 directory_id = 11;
 
   // Info response.
   message Info {

--- a/api/proto/teleport/desktop/v1/tdpb.proto
+++ b/api/proto/teleport/desktop/v1/tdpb.proto
@@ -39,6 +39,7 @@ message ServerHello {
   bool directory_remove_supported = 3;
   repeated SessionIdentifier sessions = 4;
   bool hidpi_supported = 5;
+  bool multidirectory_sharing_supported = 6;
 }
 
 // Used to identify sessions available to and selected by users

--- a/gen/proto/ts/teleport/desktop/v1/tdpb_pb.ts
+++ b/gen/proto/ts/teleport/desktop/v1/tdpb_pb.ts
@@ -77,6 +77,10 @@ export interface ServerHello {
      * @generated from protobuf field: bool hidpi_supported = 5;
      */
     hidpiSupported: boolean;
+    /**
+     * @generated from protobuf field: bool multidirectory_sharing_supported = 6;
+     */
+    multidirectorySharingSupported: boolean;
 }
 /**
  * Used to identify sessions available to and selected by users
@@ -1077,7 +1081,8 @@ class ServerHello$Type extends MessageType<ServerHello> {
             { no: 2, name: "clipboard_enabled", kind: "scalar", T: 8 /*ScalarType.BOOL*/ },
             { no: 3, name: "directory_remove_supported", kind: "scalar", T: 8 /*ScalarType.BOOL*/ },
             { no: 4, name: "sessions", kind: "message", repeat: 1 /*RepeatType.PACKED*/, T: () => SessionIdentifier },
-            { no: 5, name: "hidpi_supported", kind: "scalar", T: 8 /*ScalarType.BOOL*/ }
+            { no: 5, name: "hidpi_supported", kind: "scalar", T: 8 /*ScalarType.BOOL*/ },
+            { no: 6, name: "multidirectory_sharing_supported", kind: "scalar", T: 8 /*ScalarType.BOOL*/ }
         ]);
     }
     create(value?: PartialMessage<ServerHello>): ServerHello {
@@ -1086,6 +1091,7 @@ class ServerHello$Type extends MessageType<ServerHello> {
         message.directoryRemoveSupported = false;
         message.sessions = [];
         message.hidpiSupported = false;
+        message.multidirectorySharingSupported = false;
         if (value !== undefined)
             reflectionMergePartial<ServerHello>(this, message, value);
         return message;
@@ -1109,6 +1115,9 @@ class ServerHello$Type extends MessageType<ServerHello> {
                     break;
                 case /* bool hidpi_supported */ 5:
                     message.hidpiSupported = reader.bool();
+                    break;
+                case /* bool multidirectory_sharing_supported */ 6:
+                    message.multidirectorySharingSupported = reader.bool();
                     break;
                 default:
                     let u = options.readUnknownField;
@@ -1137,6 +1146,9 @@ class ServerHello$Type extends MessageType<ServerHello> {
         /* bool hidpi_supported = 5; */
         if (message.hidpiSupported !== false)
             writer.tag(5, WireType.Varint).bool(message.hidpiSupported);
+        /* bool multidirectory_sharing_supported = 6; */
+        if (message.multidirectorySharingSupported !== false)
+            writer.tag(6, WireType.Varint).bool(message.multidirectorySharingSupported);
         let u = options.writeUnknownFields;
         if (u !== false)
             (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);

--- a/gen/proto/ts/teleport/desktop/v1/tdpb_pb.ts
+++ b/gen/proto/ts/teleport/desktop/v1/tdpb_pb.ts
@@ -588,6 +588,10 @@ export interface SharedDirectoryResponse {
      */
     errorCode: number;
     /**
+     * @generated from protobuf field: uint32 directory_id = 11;
+     */
+    directoryId: number;
+    /**
      * @generated from protobuf oneof: operation
      */
     operation: {
@@ -2782,6 +2786,7 @@ class SharedDirectoryResponse$Type extends MessageType<SharedDirectoryResponse> 
         super("teleport.desktop.v1.SharedDirectoryResponse", [
             { no: 1, name: "completion_id", kind: "scalar", T: 13 /*ScalarType.UINT32*/ },
             { no: 2, name: "error_code", kind: "scalar", T: 13 /*ScalarType.UINT32*/ },
+            { no: 11, name: "directory_id", kind: "scalar", T: 13 /*ScalarType.UINT32*/ },
             { no: 3, name: "info", kind: "message", oneof: "operation", T: () => SharedDirectoryResponse_Info },
             { no: 4, name: "create", kind: "message", oneof: "operation", T: () => SharedDirectoryResponse_Create },
             { no: 5, name: "delete", kind: "message", oneof: "operation", T: () => SharedDirectoryResponse_Delete },
@@ -2796,6 +2801,7 @@ class SharedDirectoryResponse$Type extends MessageType<SharedDirectoryResponse> 
         const message = globalThis.Object.create((this.messagePrototype!));
         message.completionId = 0;
         message.errorCode = 0;
+        message.directoryId = 0;
         message.operation = { oneofKind: undefined };
         if (value !== undefined)
             reflectionMergePartial<SharedDirectoryResponse>(this, message, value);
@@ -2811,6 +2817,9 @@ class SharedDirectoryResponse$Type extends MessageType<SharedDirectoryResponse> 
                     break;
                 case /* uint32 error_code */ 2:
                     message.errorCode = reader.uint32();
+                    break;
+                case /* uint32 directory_id */ 11:
+                    message.directoryId = reader.uint32();
                     break;
                 case /* teleport.desktop.v1.SharedDirectoryResponse.Info info */ 3:
                     message.operation = {
@@ -2878,6 +2887,9 @@ class SharedDirectoryResponse$Type extends MessageType<SharedDirectoryResponse> 
         /* uint32 error_code = 2; */
         if (message.errorCode !== 0)
             writer.tag(2, WireType.Varint).uint32(message.errorCode);
+        /* uint32 directory_id = 11; */
+        if (message.directoryId !== 0)
+            writer.tag(11, WireType.Varint).uint32(message.directoryId);
         /* teleport.desktop.v1.SharedDirectoryResponse.Info info = 3; */
         if (message.operation.oneofKind === "info")
             SharedDirectoryResponse_Info.internalBinaryWrite(message.operation.info, writer.tag(3, WireType.LengthDelimited).fork(), options).join();

--- a/lib/srv/desktop/rdp/rdpclient/client.go
+++ b/lib/srv/desktop/rdp/rdpclient/client.go
@@ -751,6 +751,7 @@ func (c *Client) handleTDPInput(msg tdp.Message) error {
 				defer C.free(unsafe.Pointer(path))
 				if errCode := C.client_handle_tdp_sd_info_response(C.uintptr_t(c.handle), C.CGOSharedDirectoryInfoResponse{
 					completion_id: C.uint32_t(m.CompletionId),
+					directory_id:  C.uint32_t(m.DirectoryId),
 					err_code:      m.ErrorCode,
 					fso: C.CGOFileSystemObject{
 						last_modified: C.uint64_t(op.Info.Fso.LastModified),
@@ -769,6 +770,7 @@ func (c *Client) handleTDPInput(msg tdp.Message) error {
 				defer C.free(unsafe.Pointer(path))
 				if errCode := C.client_handle_tdp_sd_create_response(C.uintptr_t(c.handle), C.CGOSharedDirectoryCreateResponse{
 					completion_id: C.uint32_t(m.CompletionId),
+					directory_id:  C.uint32_t(m.DirectoryId),
 					err_code:      m.ErrorCode,
 					fso: C.CGOFileSystemObject{
 						last_modified: C.uint64_t(op.Create.Fso.LastModified),
@@ -785,6 +787,7 @@ func (c *Client) handleTDPInput(msg tdp.Message) error {
 			if c.cfg.AllowDirectorySharing {
 				if errCode := C.client_handle_tdp_sd_delete_response(C.uintptr_t(c.handle), C.CGOSharedDirectoryDeleteResponse{
 					completion_id: C.uint32_t(m.CompletionId),
+					directory_id:  C.uint32_t(m.DirectoryId),
 					err_code:      m.ErrorCode,
 				}); errCode != C.ErrCodeSuccess {
 					return trace.Errorf("SharedDirectoryDeleteResponse failed: %v", errCode)
@@ -796,7 +799,6 @@ func (c *Client) handleTDPInput(msg tdp.Message) error {
 				for _, fso := range op.List.FsoList {
 					path := C.CString(fso.Path)
 					defer C.free(unsafe.Pointer(path))
-
 					fsoList = append(fsoList, C.CGOFileSystemObject{
 						last_modified: C.uint64_t(fso.LastModified),
 						size:          C.uint64_t(fso.Size),
@@ -817,6 +819,7 @@ func (c *Client) handleTDPInput(msg tdp.Message) error {
 
 				if errCode := C.client_handle_tdp_sd_list_response(C.uintptr_t(c.handle), C.CGOSharedDirectoryListResponse{
 					completion_id:   C.uint32_t(m.CompletionId),
+					directory_id:    C.uint32_t(m.DirectoryId),
 					err_code:        m.ErrorCode,
 					fso_list_length: C.uint32_t(fsoListLen),
 					fso_list:        cgoFsoList,
@@ -835,6 +838,7 @@ func (c *Client) handleTDPInput(msg tdp.Message) error {
 
 				if errCode := C.client_handle_tdp_sd_read_response(C.uintptr_t(c.handle), C.CGOSharedDirectoryReadResponse{
 					completion_id:    C.uint32_t(m.CompletionId),
+					directory_id:     C.uint32_t(m.DirectoryId),
 					err_code:         m.ErrorCode,
 					read_data_length: C.uint32_t(len(op.Read.Data)),
 					read_data:        readData,
@@ -846,6 +850,7 @@ func (c *Client) handleTDPInput(msg tdp.Message) error {
 			if c.cfg.AllowDirectorySharing {
 				if errCode := C.client_handle_tdp_sd_write_response(C.uintptr_t(c.handle), C.CGOSharedDirectoryWriteResponse{
 					completion_id: C.uint32_t(m.CompletionId),
+					directory_id:  C.uint32_t(m.DirectoryId),
 					err_code:      m.ErrorCode,
 					bytes_written: C.uint32_t(op.Write.BytesWritten),
 				}); errCode != C.ErrCodeSuccess {
@@ -856,6 +861,7 @@ func (c *Client) handleTDPInput(msg tdp.Message) error {
 			if c.cfg.AllowDirectorySharing {
 				if errCode := C.client_handle_tdp_sd_move_response(C.uintptr_t(c.handle), C.CGOSharedDirectoryMoveResponse{
 					completion_id: C.uint32_t(m.CompletionId),
+					directory_id:  C.uint32_t(m.DirectoryId),
 					err_code:      m.ErrorCode,
 				}); errCode != C.ErrCodeSuccess {
 					return trace.Errorf("SharedDirectoryMoveResponse failed: %v", errCode)
@@ -865,6 +871,7 @@ func (c *Client) handleTDPInput(msg tdp.Message) error {
 			if c.cfg.AllowDirectorySharing {
 				if errCode := C.client_handle_tdp_sd_truncate_response(C.uintptr_t(c.handle), C.CGOSharedDirectoryTruncateResponse{
 					completion_id: C.uint32_t(m.CompletionId),
+					directory_id:  C.uint32_t(m.DirectoryId),
 					err_code:      m.ErrorCode,
 				}); errCode != C.ErrCodeSuccess {
 					return trace.Errorf("SharedDirectoryTruncateResponse failed: %v", errCode)

--- a/lib/srv/desktop/rdp/rdpclient/src/lib.rs
+++ b/lib/srv/desktop/rdp/rdpclient/src/lib.rs
@@ -642,6 +642,7 @@ pub struct CGOSharedDirectoryInfoRequest {
 #[repr(C)]
 pub struct CGOSharedDirectoryInfoResponse {
     pub completion_id: u32,
+    pub directory_id: u32,
     pub err_code: TdpErrCode,
     pub fso: CGOFileSystemObject,
 }
@@ -701,6 +702,7 @@ pub struct CGOSharedDirectoryReadRequest {
 #[repr(C)]
 pub struct CGOSharedDirectoryReadResponse {
     pub completion_id: u32,
+    pub directory_id: u32,
     pub err_code: TdpErrCode,
     pub read_data_length: u32,
     pub read_data: *mut u8,
@@ -719,6 +721,7 @@ pub struct CGOSharedDirectoryCreateRequest {
 #[repr(C)]
 pub struct CGOSharedDirectoryListResponse {
     completion_id: u32,
+    directory_id: u32,
     err_code: TdpErrCode,
     fso_list_length: u32,
     fso_list: *mut CGOFileSystemObject,
@@ -735,6 +738,7 @@ pub struct CGOSharedDirectoryMoveRequest {
 #[repr(C)]
 pub struct CGOSharedDirectoryCreateResponse {
     pub completion_id: u32,
+    pub directory_id: u32,
     pub err_code: TdpErrCode,
     pub fso: CGOFileSystemObject,
 }

--- a/lib/srv/desktop/rdp/rdpclient/src/rdpdr/tdp.rs
+++ b/lib/srv/desktop/rdp/rdpclient/src/rdpdr/tdp.rs
@@ -119,6 +119,7 @@ impl From<&DeviceCreateRequest> for SharedDirectoryInfoRequest {
 /// in response to a `Shared Directory Info Request`.
 #[derive(Debug)]
 pub struct SharedDirectoryInfoResponse {
+    pub device_id: u32,
     pub completion_id: u32,
     pub err_code: TdpErrCode,
     pub fso: FileSystemObject,
@@ -132,6 +133,7 @@ impl From<CGOSharedDirectoryInfoResponse> for SharedDirectoryInfoResponse {
         // In other words, all pointer data that needs to persist after this function returns MUST
         // be copied into Rust-owned memory.
         SharedDirectoryInfoResponse {
+            device_id: cgo_res.directory_id,
             completion_id: cgo_res.completion_id,
             err_code: cgo_res.err_code,
             fso: cgo_res.fso.into(),
@@ -344,6 +346,7 @@ impl SharedDirectoryReadRequest {
 #[repr(C)]
 pub struct SharedDirectoryReadResponse {
     pub completion_id: u32,
+    pub directory_id: u32,
     pub err_code: TdpErrCode,
     pub read_data: Vec<u8>,
 }
@@ -362,6 +365,7 @@ impl From<CGOSharedDirectoryReadResponse> for SharedDirectoryReadResponse {
     fn from(cgo_response: CGOSharedDirectoryReadResponse) -> SharedDirectoryReadResponse {
         unsafe {
             SharedDirectoryReadResponse {
+                directory_id: cgo_response.directory_id,
                 completion_id: cgo_response.completion_id,
                 err_code: cgo_response.err_code,
                 read_data: from_go_array(cgo_response.read_data, cgo_response.read_data_length),
@@ -376,6 +380,7 @@ impl From<CGOSharedDirectoryReadResponse> for SharedDirectoryReadResponse {
 #[repr(C)]
 pub struct SharedDirectoryWriteResponse {
     pub completion_id: u32,
+    pub directory_id: u32,
     pub err_code: TdpErrCode,
     pub bytes_written: u32,
 }
@@ -420,6 +425,7 @@ impl SharedDirectoryCreateRequest {
 #[derive(Debug)]
 pub struct SharedDirectoryListResponse {
     pub completion_id: u32,
+    pub directory_id: u32,
     pub err_code: TdpErrCode,
     pub fso_list: Vec<FileSystemObject>,
 }
@@ -440,6 +446,7 @@ impl From<CGOSharedDirectoryListResponse> for SharedDirectoryListResponse {
 
             SharedDirectoryListResponse {
                 completion_id: cgo.completion_id,
+                directory_id: cgo.directory_id,
                 err_code: cgo.err_code,
                 fso_list,
             }
@@ -478,6 +485,7 @@ impl SharedDirectoryMoveRequest {
 /// to acknowledge a SharedDirectoryCreateRequest was received and executed.
 #[derive(Debug)]
 pub struct SharedDirectoryCreateResponse {
+    pub directory_id: u32,
     pub completion_id: u32,
     pub err_code: TdpErrCode,
     pub fso: FileSystemObject,
@@ -492,6 +500,7 @@ impl From<CGOSharedDirectoryCreateResponse> for SharedDirectoryCreateResponse {
         // be copied into Rust-owned memory.
         SharedDirectoryCreateResponse {
             completion_id: cgo_res.completion_id,
+            directory_id: cgo_res.directory_id,
             err_code: cgo_res.err_code,
             fso: cgo_res.fso.into(),
         }
@@ -546,6 +555,7 @@ impl From<&DeviceCreateRequest> for SharedDirectoryDeleteRequest {
 #[repr(C)]
 pub struct SharedDirectoryDeleteResponse {
     pub completion_id: u32,
+    pub directory_id: u32,
     pub err_code: TdpErrCode,
 }
 
@@ -555,6 +565,7 @@ pub struct SharedDirectoryDeleteResponse {
 #[repr(C)]
 pub struct SharedDirectoryMoveResponse {
     pub completion_id: u32,
+    pub directory_id: u32,
     pub err_code: TdpErrCode,
 }
 
@@ -614,6 +625,7 @@ impl SharedDirectoryTruncateRequest {
 #[repr(C)]
 pub struct SharedDirectoryTruncateResponse {
     pub completion_id: u32,
+    pub directory_id: u32,
     pub err_code: TdpErrCode,
 }
 

--- a/web/packages/shared/libs/tdp/client.ts
+++ b/web/packages/shared/libs/tdp/client.ts
@@ -637,6 +637,7 @@ export class TdpClient extends EventEmitter<EventMap> {
       const info = await sharedDirectory.stat(path);
       this.sendSharedDirectoryInfoResponse({
         completionId: req.completionId,
+        directoryId: req.directoryId,
         errCode: SharedDirectoryErrCode.Nil,
         fso: this.toFso(info),
       });
@@ -644,6 +645,7 @@ export class TdpClient extends EventEmitter<EventMap> {
       if (e.constructor === PathDoesNotExistError) {
         this.sendSharedDirectoryInfoResponse({
           completionId: req.completionId,
+          directoryId: req.directoryId,
           errCode: SharedDirectoryErrCode.DoesNotExist,
           fso: {
             lastModified: BigInt(0),
@@ -666,12 +668,14 @@ export class TdpClient extends EventEmitter<EventMap> {
       const info = await sharedDirectory.stat(req.path);
       this.sendSharedDirectoryCreateResponse({
         completionId: req.completionId,
+        directoryId: req.directoryId,
         errCode: SharedDirectoryErrCode.Nil,
         fso: this.toFso(info),
       });
     } catch (e) {
       this.sendSharedDirectoryCreateResponse({
         completionId: req.completionId,
+        directoryId: req.directoryId,
         errCode: SharedDirectoryErrCode.Failed,
         fso: {
           lastModified: BigInt(0),
@@ -692,11 +696,13 @@ export class TdpClient extends EventEmitter<EventMap> {
       await sharedDirectory.delete(req.path);
       this.sendSharedDirectoryDeleteResponse({
         completionId: req.completionId,
+        directoryId: req.directoryId,
         errCode: SharedDirectoryErrCode.Nil,
       });
     } catch (e) {
       this.sendSharedDirectoryDeleteResponse({
         completionId: req.completionId,
+        directoryId: req.directoryId,
         errCode: SharedDirectoryErrCode.Failed,
       });
       this.handleWarning(e.message, TdpClientEvent.CLIENT_WARNING);
@@ -713,6 +719,7 @@ export class TdpClient extends EventEmitter<EventMap> {
     );
     this.sendSharedDirectoryReadResponse({
       completionId: req.completionId,
+      directoryId: req.directoryId,
       errCode: SharedDirectoryErrCode.Nil,
       readDataLength: readData.length,
       readData,
@@ -730,6 +737,7 @@ export class TdpClient extends EventEmitter<EventMap> {
 
     this.sendSharedDirectoryWriteResponse({
       completionId: req.completionId,
+      directoryId: req.directoryId,
       errCode: SharedDirectoryErrCode.Nil,
       bytesWritten,
     });
@@ -739,6 +747,7 @@ export class TdpClient extends EventEmitter<EventMap> {
     // Always send back Failed for now, see https://github.com/gravitational/webapps/issues/1064
     this.sendSharedDirectoryMoveResponse({
       completionId: req.completionId,
+      directoryId: req.directoryId,
       errCode: SharedDirectoryErrCode.Failed,
     });
     this.handleWarning(
@@ -757,6 +766,7 @@ export class TdpClient extends EventEmitter<EventMap> {
 
     this.sendSharedDirectoryListResponse({
       completionId: req.completionId,
+      directoryId: req.directoryId,
       errCode: SharedDirectoryErrCode.Nil,
       fsoList,
     });
@@ -772,6 +782,7 @@ export class TdpClient extends EventEmitter<EventMap> {
       );
       this.sendSharedDirectoryTruncateResponse({
         completionId: req.completionId,
+        directoryId: req.directoryId,
         errCode: SharedDirectoryErrCode.Failed,
       });
       return;
@@ -782,6 +793,7 @@ export class TdpClient extends EventEmitter<EventMap> {
     await sharedDirectory.truncate(req.path, Number(req.endOfFile));
     this.sendSharedDirectoryTruncateResponse({
       completionId: req.completionId,
+      directoryId: req.directoryId,
       errCode: SharedDirectoryErrCode.Nil,
     });
   }

--- a/web/packages/shared/libs/tdp/codec.ts
+++ b/web/packages/shared/libs/tdp/codec.ts
@@ -218,6 +218,7 @@ export type SharedDirectoryInfoResponse = {
   completionId: number;
   errCode: SharedDirectoryErrCode;
   fso: FileSystemObject;
+  directoryId: number;
 };
 
 // | message type (15) | completion_id uint32 | directory_id uint32 | file_type uint32 | path_length uint32 | path []byte |
@@ -233,6 +234,7 @@ export type SharedDirectoryCreateResponse = {
   completionId: number;
   errCode: SharedDirectoryErrCode;
   fso: FileSystemObject;
+  directoryId: number;
 };
 
 // | message type (17) | completion_id uint32 | directory_id uint32 | path_length uint32 | path []byte |
@@ -246,6 +248,7 @@ export type SharedDirectoryDeleteRequest = {
 export type SharedDirectoryDeleteResponse = {
   completionId: number;
   errCode: SharedDirectoryErrCode;
+  directoryId: number;
 };
 
 // | message type (19) | completion_id uint32 | directory_id uint32 | path_length uint32 | path []byte | offset uint64 | length uint32 |
@@ -264,6 +267,7 @@ export type SharedDirectoryReadResponse = {
   errCode: SharedDirectoryErrCode;
   readDataLength: number;
   readData: Uint8Array;
+  directoryId: number;
 };
 
 // | message type (21) | completion_id uint32 | directory_id uint32 | path_length uint32 | path []byte | offset uint64 | write_data_length uint32 | write_data []byte |
@@ -281,6 +285,7 @@ export type SharedDirectoryWriteResponse = {
   completionId: number;
   errCode: number;
   bytesWritten: number;
+  directoryId: number;
 };
 
 // | message type (23) | completion_id uint32 | directory_id uint32 | original_path_length uint32 | original_path []byte | new_path_length uint32 | new_path []byte |
@@ -297,6 +302,7 @@ export type SharedDirectoryMoveRequest = {
 export type SharedDirectoryMoveResponse = {
   completionId: number;
   errCode: SharedDirectoryErrCode;
+  directoryId: number;
 };
 
 // | message type (25) | completion_id uint32 | directory_id uint32 | path_length uint32 | path []byte |
@@ -311,6 +317,7 @@ export type SharedDirectoryListResponse = {
   completionId: number;
   errCode: SharedDirectoryErrCode;
   fsoList: FileSystemObject[];
+  directoryId: number;
 };
 
 // | message type (33) | completion_id uint32 | directory_id uint32 | path_length uint32 | path []byte | end_of_file uint32 |
@@ -325,6 +332,7 @@ export type SharedDirectoryTruncateRequest = {
 export type SharedDirectoryTruncateResponse = {
   completionId: number;
   errCode: SharedDirectoryErrCode;
+  directoryId: number;
 };
 
 // | last_modified uint64 | size uint64 | file_type uint32 | is_empty bool | path_length uint32 | path byte[] |
@@ -935,6 +943,7 @@ export class TdpbCodec implements Codec {
       oneofKind: 'sharedDirectoryResponse',
       sharedDirectoryResponse: SharedDirectoryResponse.create({
         completionId: res.completionId,
+        directoryId: res.directoryId,
         errorCode: res.errCode,
         operation: {
           oneofKind: 'info',
@@ -949,6 +958,7 @@ export class TdpbCodec implements Codec {
       oneofKind: 'sharedDirectoryResponse',
       sharedDirectoryResponse: SharedDirectoryResponse.create({
         completionId: res.completionId,
+        directoryId: res.directoryId,
         errorCode: res.errCode,
         operation: {
           oneofKind: 'read',
@@ -963,6 +973,7 @@ export class TdpbCodec implements Codec {
       oneofKind: 'sharedDirectoryResponse',
       sharedDirectoryResponse: SharedDirectoryResponse.create({
         completionId: res.completionId,
+        directoryId: res.directoryId,
         errorCode: res.errCode,
         operation: {
           oneofKind: 'move',
@@ -977,6 +988,7 @@ export class TdpbCodec implements Codec {
       oneofKind: 'sharedDirectoryResponse',
       sharedDirectoryResponse: SharedDirectoryResponse.create({
         completionId: res.completionId,
+        directoryId: res.directoryId,
         errorCode: res.errCode,
         operation: {
           oneofKind: 'list',
@@ -1002,6 +1014,7 @@ export class TdpbCodec implements Codec {
       oneofKind: 'sharedDirectoryResponse',
       sharedDirectoryResponse: SharedDirectoryResponse.create({
         completionId: resp.completionId,
+        directoryId: resp.directoryId,
         errorCode: resp.errCode,
         operation: {
           oneofKind: 'create',
@@ -1020,6 +1033,7 @@ export class TdpbCodec implements Codec {
       oneofKind: 'sharedDirectoryResponse',
       sharedDirectoryResponse: SharedDirectoryResponse.create({
         completionId: resp.completionId,
+        directoryId: resp.directoryId,
         errorCode: resp.errCode,
         operation: {
           oneofKind: 'delete',
@@ -1036,6 +1050,7 @@ export class TdpbCodec implements Codec {
       oneofKind: 'sharedDirectoryResponse',
       sharedDirectoryResponse: SharedDirectoryResponse.create({
         completionId: resp.completionId,
+        directoryId: resp.directoryId,
         errorCode: resp.errCode,
         operation: {
           oneofKind: 'write',
@@ -1054,6 +1069,7 @@ export class TdpbCodec implements Codec {
       oneofKind: 'sharedDirectoryResponse',
       sharedDirectoryResponse: SharedDirectoryResponse.create({
         completionId: resp.completionId,
+        directoryId: resp.directoryId,
         errorCode: resp.errCode,
         operation: {
           oneofKind: 'truncate',


### PR DESCRIPTION
The current TDP/TDPB implementation does not offer complete support for sharing multiple directories. While request messages include a directoryId field, response messages do not and instead include only a completionId. Per [MS-RDPEFS 3.1.5.1](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpefs/1a8715b1-3afc-4bd7-8ec2-9625a9ce9610), responses are matched to requests by the tuple `(DeviceId, CompletionId)`.

This PR adds a directoryId field to TDPB's shared directory response messages, populates this field from the client, and updates the FFI to carry the directoryId/devicedId to the RDP client's filesystem implementation. Note that this PR does not implement the necessary filesystem backend changes to support multiple directories. Those changes will follow in #68034. This PR just handles the plumbing of the directoryId/deviceId.

I've also added a new advertisement, `multidirectory_sharing_supported`, to the `ServerHello` message. This communicates to the client that the server supports sharing multiple directories.


<!-- Provide a descriptive entry for the changelog of the next release. -->


<!-- Include manual testing efforts to verify the change. -->
<!-- Detail where the tests where run and what configurations were used. -->
<!-- Include all the test cases which were run to validate the change. -->

## Manual Test Plan
There aren't any functional changes to test, so maybe just look for regressions.
### Test Environment
Local cluster with at least one accessible Windows desktop
### Test Cases
- [x] Desktop Connection succeeds
- [x] Share a directory
- [x] Verify that common directory operations succeed (read, write, copy/paste into and out of the directory, etc.)
