### PR TITLE
Desktop Access: Support Multiple Devices in Filesystem Backend

### DIFF
--- a/lib/srv/desktop/rdp/rdpclient/client.go
+++ b/lib/srv/desktop/rdp/rdpclient/client.go
@@ -727,7 +727,6 @@ func (c *Client) handleTDPInput(msg tdp.Message) error {
 	case *tdpb.SharedDirectoryAnnounce:
 		if c.cfg.AllowDirectorySharing {
 			if m.DirectoryId == 0 {
-				// See "SharedDirectoryResponse" handling.
 				return trace.BadParameter("Zero is not a valid directory identifier")
 			}
 
@@ -749,16 +748,6 @@ func (c *Client) handleTDPInput(msg tdp.Message) error {
 			}
 		}
 	case *tdpb.SharedDirectoryResponse:
-		// TODO(rhammonds): Remove in v20
-		// Some V18 and older clients assume that TDP connections support only a single
-		// shared directory. For this reason, they omit the DirectoryId from their
-		// response messages. These clients also hardcode the DirectoryId to '2'.
-		// To ensure conflicts are avoided, the backend will reject directory announcements
-		// that choose DirectoryId 0 and "fix" omitted DirectoryId fields.
-		if m.DirectoryId == 0 {
-			m.DirectoryId = 2
-		}
-
 		switch op := m.Operation.(type) {
 		case *tdpbv1.SharedDirectoryResponse_Info_:
 			if c.cfg.AllowDirectorySharing {

--- a/lib/srv/desktop/rdp/rdpclient/client.go
+++ b/lib/srv/desktop/rdp/rdpclient/client.go
@@ -726,6 +726,11 @@ func (c *Client) handleTDPInput(msg tdp.Message) error {
 		}
 	case *tdpb.SharedDirectoryAnnounce:
 		if c.cfg.AllowDirectorySharing {
+			if m.DirectoryId == 0 {
+				// See "SharedDirectoryResponse" handling.
+				return trace.BadParameter("Zero is not a valid directory identifier")
+			}
+
 			driveName := C.CString(m.Name)
 			defer C.free(unsafe.Pointer(driveName))
 			if errCode := C.client_handle_tdp_sd_announce(C.uintptr_t(c.handle), C.CGOSharedDirectoryAnnounce{
@@ -744,6 +749,16 @@ func (c *Client) handleTDPInput(msg tdp.Message) error {
 			}
 		}
 	case *tdpb.SharedDirectoryResponse:
+		// TODO(rhammonds): Remove in v20
+		// Some V18 and older clients assume that TDP connections support only a single
+		// shared directory. For this reason, they omit the DirectoryId from their
+		// response messages. These clients also hardcode the DirectoryId to '2'.
+		// To ensure conflicts are avoided, the backend will reject directory announcements
+		// that choose DirectoryId 0 and "fix" omitted DirectoryId fields.
+		if m.DirectoryId == 0 {
+			m.DirectoryId = 2
+		}
+
 		switch op := m.Operation.(type) {
 		case *tdpbv1.SharedDirectoryResponse_Info_:
 			if c.cfg.AllowDirectorySharing {
@@ -1074,9 +1089,10 @@ func (c *Client) handleRDPConnectionActivated(ioChannelID, userChannelID, screen
 			ScreenWidth:   uint32(screenWidth),
 			ScreenHeight:  uint32(screenHeight),
 		},
-		ClipboardEnabled:         true,
-		DirectoryRemoveSupported: true,
-		HidpiSupported:           true,
+		ClipboardEnabled:               true,
+		DirectoryRemoveSupported:       true,
+		HidpiSupported:                 true,
+		MultidirectorySharingSupported: true,
 	}); err != nil {
 		c.cfg.Logger.ErrorContext(context.Background(), "failed handling connection initialization", "error", err)
 		return C.ErrCodeFailure

--- a/lib/srv/desktop/rdp/rdpclient/src/client.rs
+++ b/lib/srv/desktop/rdp/rdpclient/src/client.rs
@@ -1029,10 +1029,6 @@ impl Client {
         }
 
         Ok(cancel_pdus)
-
-        // Bulk send any cancellations for pending I/O requests.
-        //Self::write_rdpdr_pdus(write_stream, x224_processor.clone(), cancel_pdus).await?;
-        //Ok(())
     }
 
     /// Processes an x224 frame on a blocking thread.

--- a/lib/srv/desktop/rdp/rdpclient/src/client.rs
+++ b/lib/srv/desktop/rdp/rdpclient/src/client.rs
@@ -52,7 +52,7 @@ use ironrdp_pdu::rdp::client_info::{PerformanceFlags, TimezoneInfo};
 use ironrdp_pdu::PduError;
 use ironrdp_pdu::PduResult;
 use ironrdp_pdu::{encode_err, pdu_other_err};
-use ironrdp_rdpdr::pdu::efs::{ClientDeviceListAnnounce, ClientDeviceListRemove};
+use ironrdp_rdpdr::pdu::efs::ClientDeviceListAnnounce;
 use ironrdp_rdpdr::pdu::RdpdrPdu;
 use ironrdp_rdpdr::Rdpdr;
 use ironrdp_rdpsnd::client::{NoopRdpsndBackend, Rdpsnd};
@@ -710,6 +710,27 @@ impl Client {
         Ok(())
     }
 
+    async fn write_rdpdr_pdus(
+        write_stream: &mut RdpWriteStream,
+        x224_processor: Arc<Mutex<x224::Processor>>,
+        pdus: Vec<RdpdrPdu>,
+    ) -> ClientResult<()> {
+        debug!("sending rdp: {:?}", pdus);
+
+        let svc_messages: Vec<SvcMessage> = pdus.into_iter().map(SvcMessage::from).collect();
+
+        // Process the RDPDR PDU.
+        let encoded = Client::x224_process_svc_messages(
+            x224_processor,
+            SvcProcessorMessages::<Rdpdr>::new(svc_messages),
+        )
+        .await?;
+
+        // Write the RDPDR PDU to the RDP server.
+        write_stream.write_all(&encoded).await?;
+        Ok(())
+    }
+
     async fn write_rdpdr(
         write_stream: &mut RdpWriteStream,
         x224_processor: Arc<Mutex<x224::Processor>>,
@@ -841,23 +862,31 @@ impl Client {
         sdr: tdp::SharedDirectoryRemove,
     ) -> ClientResult<()> {
         debug!("received tdp: {:?}", sdr);
-        let pdu = Self::remove_drive(x224_processor.clone(), sdr.directory_id).await;
+        // Attempt to remove the device
+        let (cancel_pdus, remove_complete) =
+            Self::remove_drive(x224_processor.clone(), sdr.directory_id).await?;
+        // Bulk send any cancellations for pending I/O requests.
+        Self::write_rdpdr_pdus(write_stream, x224_processor.clone(), cancel_pdus).await?;
 
-        match pdu {
-            Ok(remove) => {
-                Self::write_rdpdr(
-                    write_stream,
-                    x224_processor,
-                    RdpdrPdu::ClientDeviceListRemove(remove),
-                )
-                .await?;
-                Ok(())
-            }
-            Err(ClientError::UnknownDevice(id)) => {
-                warn!("attempted to remove unknown device id: {:?}", id);
-                Ok(())
-            }
-            Err(other) => Err(other),
+        // If the device was successfully removed from the backend, then remove it from
+        // the top level rdpdr instance and send the device remove pdu. Otherwise,
+        // do nothing. The the rdpdr backend will synthesize another TDP shared directory remove
+        // message once the instance is ready for deletion (leading us right back here again to retry).
+        if remove_complete {
+            let remove_pdu = Self::x224_lock(&x224_processor)?
+                .get_svc_processor_mut::<Rdpdr>()
+                .ok_or(ClientError::UnknownDevice(sdr.directory_id))?
+                .remove_device(sdr.directory_id)
+                .ok_or(ClientError::UnknownDevice(sdr.directory_id))?;
+
+            Self::write_rdpdr(
+                write_stream,
+                x224_processor,
+                RdpdrPdu::ClientDeviceListRemove(remove_pdu),
+            )
+            .await
+        } else {
+            Ok(())
         }
     }
 
@@ -991,25 +1020,17 @@ impl Client {
     async fn remove_drive(
         x224_processor: Arc<Mutex<x224::Processor>>,
         device_id: u32,
-    ) -> ClientResult<ClientDeviceListRemove> {
+    ) -> ClientResult<(Vec<RdpdrPdu>, bool)> {
         task::spawn_blocking(move || {
             let mut x224_processor = Self::x224_lock(&x224_processor)?;
             // Remove from the device from the teleport backend. In some cases, the device needs to
             // respond to outstanding file I/O before we can actually remove it. The filesystem
             // implementation will synthesize and send a TDP "SharedDirectoryRemove" message when
             // pending I/O is complete, which will lead us back into this function to try again.
-            let can_remove = Self::rdpdr_backend(&mut x224_processor)?
+            Self::rdpdr_backend(&mut x224_processor)?
                 .remove_device(device_id)
-                .inspect_err(|e| warn!("could not remove device from teleport backend: {}", e))?;
-
-            // Check if it's safe to actually remove the device.
-            if can_remove {
-                let rdpdr = Self::get_svc_processor_mut::<Rdpdr>(&mut x224_processor)?;
-                if let Some(pdu) = rdpdr.remove_device(device_id) {
-                    return Ok(pdu);
-                }
-            }
-            Err(ClientError::UnknownDevice(device_id))
+                .inspect_err(|e| warn!("could not remove device from teleport backend: {}", e))
+                .map_err(ClientError::PduError)
         })
         .await?
     }

--- a/lib/srv/desktop/rdp/rdpclient/src/client.rs
+++ b/lib/srv/desktop/rdp/rdpclient/src/client.rs
@@ -862,32 +862,12 @@ impl Client {
         sdr: tdp::SharedDirectoryRemove,
     ) -> ClientResult<()> {
         debug!("received tdp: {:?}", sdr);
-        // Attempt to remove the device
-        let (cancel_pdus, remove_complete) =
-            Self::remove_drive(x224_processor.clone(), sdr.directory_id).await?;
+
+        let cancel_pdus = Self::remove_drive(x224_processor.clone(), sdr.directory_id)?;
+
         // Bulk send any cancellations for pending I/O requests.
         Self::write_rdpdr_pdus(write_stream, x224_processor.clone(), cancel_pdus).await?;
-
-        // If the device was successfully removed from the backend, then remove it from
-        // the top level rdpdr instance and send the device remove pdu. Otherwise,
-        // do nothing. The the rdpdr backend will synthesize another TDP shared directory remove
-        // message once the instance is ready for deletion (leading us right back here again to retry).
-        if remove_complete {
-            let remove_pdu = Self::x224_lock(&x224_processor)?
-                .get_svc_processor_mut::<Rdpdr>()
-                .ok_or(ClientError::UnknownDevice(sdr.directory_id))?
-                .remove_device(sdr.directory_id)
-                .ok_or(ClientError::UnknownDevice(sdr.directory_id))?;
-
-            Self::write_rdpdr(
-                write_stream,
-                x224_processor,
-                RdpdrPdu::ClientDeviceListRemove(remove_pdu),
-            )
-            .await
-        } else {
-            Ok(())
-        }
+        Ok(())
     }
 
     async fn handle_tdp_sd_info_response(
@@ -1017,22 +997,42 @@ impl Client {
         .await?
     }
 
-    async fn remove_drive(
+    fn remove_drive(
         x224_processor: Arc<Mutex<x224::Processor>>,
         device_id: u32,
-    ) -> ClientResult<(Vec<RdpdrPdu>, bool)> {
-        task::spawn_blocking(move || {
-            let mut x224_processor = Self::x224_lock(&x224_processor)?;
-            // Remove from the device from the teleport backend. In some cases, the device needs to
-            // respond to outstanding file I/O before we can actually remove it. The filesystem
-            // implementation will synthesize and send a TDP "SharedDirectoryRemove" message when
-            // pending I/O is complete, which will lead us back into this function to try again.
-            Self::rdpdr_backend(&mut x224_processor)?
+    ) -> ClientResult<Vec<RdpdrPdu>> {
+        // Lock the x224 processor before calling "remove_drive" so that the read loop
+        // doesn't try to process an inbound message for a device that we're in the process
+        // of removing.
+        let mut processor = Self::x224_lock(&x224_processor)?;
+        let backend = Self::rdpdr_backend(&mut processor)?;
+
+        // Attempt to remove the device from the Teleport Rdpdr backend
+        let (mut cancel_pdus, remove_complete) = backend
+            .remove_device(device_id)
+            .inspect_err(|e| warn!("could not remove device from teleport backend: {}", e))
+            .map_err(ClientError::PduError)?;
+
+        if remove_complete {
+            // If the device was successfully removed from the backend, then remove it from
+            // the top level rdpdr instance and send the device remove pdu. Otherwise,
+            // do nothing. The the rdpdr backend will synthesize another TDP shared directory remove
+            // message once the instance is ready for deletion (leading us right back here again to retry).
+            let remove_pdu = processor
+                .get_svc_processor_mut::<Rdpdr>()
+                .ok_or(ClientError::UnknownDevice(device_id))?
                 .remove_device(device_id)
-                .inspect_err(|e| warn!("could not remove device from teleport backend: {}", e))
-                .map_err(ClientError::PduError)
-        })
-        .await?
+                .ok_or(ClientError::UnknownDevice(device_id))?;
+
+            // Make sure the remove PDU is pushed last.
+            cancel_pdus.push(RdpdrPdu::ClientDeviceListRemove(remove_pdu))
+        }
+
+        Ok(cancel_pdus)
+
+        // Bulk send any cancellations for pending I/O requests.
+        //Self::write_rdpdr_pdus(write_stream, x224_processor.clone(), cancel_pdus).await?;
+        //Ok(())
     }
 
     /// Processes an x224 frame on a blocking thread.

--- a/lib/srv/desktop/rdp/rdpclient/src/client.rs
+++ b/lib/srv/desktop/rdp/rdpclient/src/client.rs
@@ -979,9 +979,11 @@ impl Client {
     ) -> ClientResult<ClientDeviceListAnnounce> {
         task::spawn_blocking(move || {
             let mut x224_processor = Self::x224_lock(&x224_processor)?;
-            let rdpdr = Self::get_svc_processor_mut::<Rdpdr>(&mut x224_processor)?;
-            let pdu = rdpdr.add_drive(sda.directory_id, sda.name);
-            Ok(pdu)
+            // Make sure the teleport backend knows about this new drive.
+            Self::rdpdr_backend(&mut x224_processor)?.add_device(sda.directory_id)?;
+            // The Base Rdpdr instance must also know about the device.
+            Ok(Self::get_svc_processor_mut::<Rdpdr>(&mut x224_processor)?
+                .add_drive(sda.directory_id, sda.name))
         })
         .await?
     }
@@ -992,9 +994,20 @@ impl Client {
     ) -> ClientResult<ClientDeviceListRemove> {
         task::spawn_blocking(move || {
             let mut x224_processor = Self::x224_lock(&x224_processor)?;
-            let rdpdr = Self::get_svc_processor_mut::<Rdpdr>(&mut x224_processor)?;
-            if let Some(pdu) = rdpdr.remove_device(device_id) {
-                return Ok(pdu);
+            // Remove from the device from the teleport backend. In some cases, the device needs to
+            // respond to outstanding file I/O before we can actually remove it. The filesystem
+            // implementation will synthesize and send a TDP "SharedDirectoryRemove" message when
+            // pending I/O is complete, which will lead us back into this function to try again.
+            let can_remove = Self::rdpdr_backend(&mut x224_processor)?
+                .remove_device(device_id)
+                .inspect_err(|e| warn!("could not remove device from teleport backend: {}", e))?;
+
+            // Check if it's safe to actually remove the device.
+            if can_remove {
+                let rdpdr = Self::get_svc_processor_mut::<Rdpdr>(&mut x224_processor)?;
+                if let Some(pdu) = rdpdr.remove_device(device_id) {
+                    return Ok(pdu);
+                }
             }
             Err(ClientError::UnknownDevice(device_id))
         })
@@ -1591,7 +1604,7 @@ impl Display for ClientError {
             ClientError::InternalError(msg) => Display::fmt(&msg.to_string(), f),
             ClientError::UnknownAddress => Display::fmt("Unknown address", f),
             ClientError::EncodeError(e) => Display::fmt(e, f),
-            ClientError::PduError(e) => Display::fmt(e, f),
+            ClientError::PduError(e) => Display::fmt(&e.report(), f),
             ClientError::UrlError(e) => Display::fmt(e, f),
             ClientError::UnknownDevice(e) => Display::fmt(e, f),
             #[cfg(feature = "fips")]

--- a/lib/srv/desktop/rdp/rdpclient/src/rdpdr.rs
+++ b/lib/srv/desktop/rdp/rdpclient/src/rdpdr.rs
@@ -118,6 +118,15 @@ impl TeleportRdpdrBackend {
         }
     }
 
+    pub fn add_device(&mut self, device_id: u32) -> PduResult<()> {
+        self.fs.add_device(device_id)
+    }
+
+    // It's only safe to remove the device if the result is Ok(true)
+    pub fn remove_device(&mut self, device_id: u32) -> PduResult<bool> {
+        self.fs.tombstone_device(device_id)
+    }
+
     pub fn handle_tdp_sd_info_response(
         &mut self,
         tdp_resp: SharedDirectoryInfoResponse,

--- a/lib/srv/desktop/rdp/rdpclient/src/rdpdr.rs
+++ b/lib/srv/desktop/rdp/rdpclient/src/rdpdr.rs
@@ -34,6 +34,7 @@ use ironrdp_rdpdr::pdu::efs::{
     DeviceControlRequest, NtStatus, ServerDeviceAnnounceResponse, ServerDriveIoRequest,
 };
 use ironrdp_rdpdr::pdu::esc::{ScardCall, ScardIoCtlCode};
+use ironrdp_rdpdr::pdu::RdpdrPdu;
 use ironrdp_rdpdr::RdpdrBackend;
 use ironrdp_svc::SvcMessage;
 
@@ -123,8 +124,8 @@ impl TeleportRdpdrBackend {
     }
 
     // It's only safe to remove the device if the result is Ok(true)
-    pub fn remove_device(&mut self, device_id: u32) -> PduResult<bool> {
-        self.fs.tombstone_device(device_id)
+    pub fn remove_device(&mut self, device_id: u32) -> PduResult<(Vec<RdpdrPdu>, bool)> {
+        self.fs.mark_device_for_deletion(device_id)
     }
 
     pub fn handle_tdp_sd_info_response(

--- a/lib/srv/desktop/rdp/rdpclient/src/rdpdr/filesystem.rs
+++ b/lib/srv/desktop/rdp/rdpclient/src/rdpdr/filesystem.rs
@@ -23,7 +23,7 @@ use crate::{
     cgo_tdp_sd_acknowledge, cgo_tdp_sd_create_request, cgo_tdp_sd_delete_request,
     cgo_tdp_sd_info_request, cgo_tdp_sd_list_request, cgo_tdp_sd_move_request,
     cgo_tdp_sd_read_request, cgo_tdp_sd_truncate_request, cgo_tdp_sd_write_request,
-    client::ClientHandle, CGOErrCode, CgoHandle,
+    client::ClientHandle, rdpdr::tdp::SharedDirectoryRemove, CGOErrCode, CgoHandle,
 };
 use ironrdp_core::{cast_length, EncodeError};
 use ironrdp_pdu::PduResult;
@@ -31,9 +31,9 @@ use ironrdp_pdu::{pdu_other_err, PduError, PduErrorExt};
 use ironrdp_rdpdr::pdu::{
     self,
     efs::{self, NtStatus},
-    esc,
+    esc, RdpdrPdu,
 };
-use log::{debug, warn};
+use log::{debug, trace, warn};
 use std::collections::HashMap;
 use std::convert::TryInto;
 use std::fmt::Debug;
@@ -48,6 +48,183 @@ pub(crate) fn cast_length<T, S: TryInto<T, Error: Debug>>(
     })
 }
 
+#[derive(Debug)]
+struct DirectoryContext {
+    /// FileId-indexed cache of [`FileCacheObject`]s.
+    ///
+    /// See the documentation for [`FileCacheObject`].
+    file_cache: FileCache,
+    /// tombstoned indicates that this DirectoryContext has been
+    /// marked for deletion. All inbound requests will be canceled.
+    tombstoned: bool,
+    /// response_cache holds all pending I/O response handlers for
+    /// I/O requests against this DirectoryContext.
+    response_cache: ResponseCache,
+}
+
+impl DirectoryContext {
+    fn new() -> Self {
+        DirectoryContext {
+            file_cache: FileCache::new(),
+            tombstoned: false,
+            response_cache: ResponseCache::new(),
+        }
+    }
+
+    fn insert_file(&mut self, file: FileCacheObject) -> Result<u32, FilesystemBackendError> {
+        let path = file.fso.path.path.clone();
+        self.file_cache.insert(file).inspect(|id| {
+            warn!(
+                "inserted file id: {}, path: {} file_entries {}",
+                id,
+                path,
+                self.file_cache.cache.len()
+            )
+        })
+    }
+
+    fn remove_file(&mut self, file_id: u32) -> Option<FileCacheObject> {
+        self.file_cache.remove(file_id).inspect(|fco| {
+            warn!(
+                "removed file id: {}, path: {} file_entries {}",
+                file_id,
+                &fco.path().path,
+                self.file_cache.cache.len()
+            )
+        })
+    }
+
+    fn get_file(&self, file_id: u32) -> Option<&FileCacheObject> {
+        self.file_cache.get(file_id)
+    }
+
+    fn get_file_mut(&mut self, file_id: u32) -> Option<&mut FileCacheObject> {
+        self.file_cache.get_mut(file_id)
+    }
+
+    fn insert_handler(
+        &mut self,
+        completion_id: CompletionId,
+        handler: ResponseKind,
+    ) -> Result<(), FilesystemBackendError> {
+        self.response_cache.insert(completion_id, handler)
+    }
+
+    fn remove_handler(&mut self, completion_id: CompletionId) -> Option<ResponseKind> {
+        self.response_cache.remove(&completion_id)
+    }
+}
+
+#[derive(Debug)]
+struct DirectoryCache(HashMap<u32, DirectoryContext>);
+
+impl DirectoryCache {
+    fn new() -> Self {
+        Self(HashMap::new())
+    }
+
+    fn get_context_mut(
+        &mut self,
+        device_id: u32,
+    ) -> Result<&mut DirectoryContext, FilesystemBackendError> {
+        self.0.get_mut(&device_id).ok_or(FilesystemBackendError(
+            format!("filesytem device with id {} not found", device_id).to_string(),
+        ))
+    }
+
+    fn get_context(&self, device_id: u32) -> Result<&DirectoryContext, FilesystemBackendError> {
+        self.0.get(&device_id).ok_or(FilesystemBackendError(
+            format!("filesytem device with id {} not found", device_id).to_string(),
+        ))
+    }
+
+    fn add_device(&mut self, device_id: u32) -> Result<(), FilesystemBackendError> {
+        if self.0.contains_key(&device_id) {
+            return Err(FilesystemBackendError(format!(
+                "device {} already exists",
+                device_id
+            )));
+        }
+
+        self.0.insert(device_id, DirectoryContext::new());
+        Ok(())
+    }
+
+    // Remove device. Clear all pending handlers
+    fn remove_device(
+        &mut self,
+        device_id: u32,
+    ) -> Result<DirectoryContext, FilesystemBackendError> {
+        self.0
+            .remove(&device_id)
+            .ok_or(FilesystemBackendError(format!(
+                "cannot remove unknown deviceId {}",
+                device_id
+            )))
+    }
+
+    fn add_file(
+        &mut self,
+        device_id: u32,
+        file: FileCacheObject,
+    ) -> Result<u32, FilesystemBackendError> {
+        self.get_context_mut(device_id)
+            .inspect_err(|e| warn!("Failed to add file: {}", e))?
+            .insert_file(file)
+    }
+
+    fn remove_file(&mut self, device_id: u32, file_id: u32) -> Option<FileCacheObject> {
+        self.get_context_mut(device_id)
+            .inspect_err(|e| warn!("Failed to remove file: {}", e))
+            .ok()?
+            .remove_file(file_id)
+    }
+
+    fn get_file(&self, device_id: u32, file_id: u32) -> Option<&FileCacheObject> {
+        self.get_context(device_id)
+            .inspect_err(|e| warn!("Failed to retreive file: {}", e))
+            .ok()?
+            .get_file(file_id)
+    }
+
+    fn get_file_mut(&mut self, device_id: u32, file_id: u32) -> Option<&mut FileCacheObject> {
+        self.get_context_mut(device_id)
+            .inspect_err(|e| warn!("Failed to retreive file: {}", e))
+            .ok()?
+            .get_file_mut(file_id)
+    }
+
+    fn insert_handler<H: Into<ResponseKind>>(
+        &mut self,
+        device_id: u32,
+        completion_id: CompletionId,
+        handler: H,
+    ) -> Result<(), FilesystemBackendError> {
+        self.get_context_mut(device_id)
+            .inspect_err(|e| warn!("Failed to insert response handler: {}", e))?
+            .insert_handler(completion_id, handler.into())
+    }
+
+    fn remove_handler<H>(
+        &mut self,
+        device_id: u32,
+        completion_id: CompletionId,
+    ) -> Result<H, FilesystemBackendError>
+    where
+        H: TryFrom<ResponseKind>,
+        H::Error: Into<FilesystemBackendError>,
+    {
+        let handler = self
+            .get_context_mut(device_id)?
+            .remove_handler(completion_id)
+            .ok_or(FilesystemBackendError(
+                "failed to remove response handler".to_string(),
+            ))?;
+
+        H::try_from(handler).map_err(|op| op.into())
+    }
+}
+
 /// `FilesystemBackend` implements the filesystem redirection backend as described in [\[MS-RDPEFS\]: Remote Desktop Protocol: File System Virtual Channel Extension].
 /// It does so in concert with the TDP directory sharing extension described in [RFD 0067].
 ///
@@ -57,18 +234,7 @@ pub(crate) fn cast_length<T, S: TryInto<T, Error: Debug>>(
 pub struct FilesystemBackend {
     cgo_handle: CgoHandle,
     client_handle: ClientHandle,
-    /// FileId-indexed cache of [`FileCacheObject`]s.
-    ///
-    /// See the documentation for [`FileCacheObject`].
-    file_cache: FileCache,
-    pending_sd_info_resp_handlers: ResponseCache<tdp::SharedDirectoryInfoResponse>,
-    pending_sd_create_resp_handlers: ResponseCache<tdp::SharedDirectoryCreateResponse>,
-    pending_sd_delete_resp_handlers: ResponseCache<tdp::SharedDirectoryDeleteResponse>,
-    pending_sd_list_resp_handlers: ResponseCache<tdp::SharedDirectoryListResponse>,
-    pending_sd_read_resp_handlers: ResponseCache<tdp::SharedDirectoryReadResponse>,
-    pending_sd_write_resp_handlers: ResponseCache<tdp::SharedDirectoryWriteResponse>,
-    pending_sd_move_resp_handlers: ResponseCache<tdp::SharedDirectoryMoveResponse>,
-    pending_sd_truncate_resp_handlers: ResponseCache<tdp::SharedDirectoryTruncateResponse>,
+    cache: DirectoryCache,
 }
 
 impl FilesystemBackend {
@@ -76,15 +242,53 @@ impl FilesystemBackend {
         Self {
             cgo_handle,
             client_handle,
-            file_cache: FileCache::new(),
-            pending_sd_info_resp_handlers: ResponseCache::new(),
-            pending_sd_create_resp_handlers: ResponseCache::new(),
-            pending_sd_delete_resp_handlers: ResponseCache::new(),
-            pending_sd_list_resp_handlers: ResponseCache::new(),
-            pending_sd_read_resp_handlers: ResponseCache::new(),
-            pending_sd_write_resp_handlers: ResponseCache::new(),
-            pending_sd_move_resp_handlers: ResponseCache::new(),
-            pending_sd_truncate_resp_handlers: ResponseCache::new(),
+            cache: DirectoryCache::new(),
+        }
+    }
+
+    pub fn add_device(&mut self, device_id: u32) -> PduResult<()> {
+        // Create/insert new cache for this device.
+        trace!("Adding device cache for device: {}", device_id);
+        self.cache.add_device(device_id).map_err(|err| err.into())
+    }
+
+    // Cancels all pending I/O requests on this device and marks the device as
+    // "tombstoned", which means all pending I/O requests will be automatically
+    // cancelled. This function returns Ok(true) and actually removes the device
+    // if it has no open file handlers, otherwise it returns Ok(false) and removal
+    // must be retried after closing any open handles.
+    pub fn tombstone_device(&mut self, device_id: u32) -> PduResult<bool> {
+        let directory_context = self.cache.get_context_mut(device_id)?;
+        let pending_handlers: Vec<(CompletionId, ResponseKind)> =
+            directory_context.response_cache.drain().collect();
+
+        directory_context.tombstoned = true;
+        // Drain the response cache for this directory context and cancel each handler.
+        pending_handlers
+            .into_iter()
+            .for_each(|(completion_id, handler)| {
+                let _ = handler.cancel(self).inspect_err(|e| {
+                    warn!(
+                        "Failed to send cancellation response for deviceId {}, completionId {}: {}",
+                        device_id, completion_id, e
+                    )
+                });
+            });
+
+        if self
+            .cache
+            .get_context_mut(device_id)?
+            .file_cache
+            .cache
+            .is_empty()
+        {
+            // File cache is empty. It's safe to remove this device.
+            self.cache.remove_device(device_id)?;
+            Ok(true)
+        } else {
+            // File cache is not empty. We'll need to wait for the server to
+            // close any open file handles first.
+            Ok(false)
         }
     }
 
@@ -115,6 +319,21 @@ impl FilesystemBackend {
 
     /// Handles an RDP [`efs::ServerDriveIoRequest`] received from the RDP server.
     pub fn handle_rdp_drive_io_request(&mut self, req: efs::ServerDriveIoRequest) -> PduResult<()> {
+        trace!("received {:?}", &req);
+
+        let device_is_tombstoned = self
+            .cache
+            .get_context(DeviceId::from(&req).into())?
+            .tombstoned;
+        if device_is_tombstoned {
+            // A tombstoned device is only allowed to handle device close requests.
+            // All other requests are cancelled.
+            match req {
+                efs::ServerDriveIoRequest::DeviceCloseRequest(_) => {}
+                _ => return req.cancel(self),
+            }
+        }
+
         match req {
             efs::ServerDriveIoRequest::ServerCreateDriveRequest(req) => {
                 self.handle_rdp_device_create_req(req)
@@ -123,7 +342,23 @@ impl FilesystemBackend {
                 self.handle_rdp_query_information_req(req)
             }
             efs::ServerDriveIoRequest::DeviceCloseRequest(req) => {
-                self.handle_rdp_device_close_req(req)
+                // If the device is tombstoned AND this request closes that final file
+                // in the cache, then we'll finally send the request to remove the device.
+                let device_id = req.device_io_request.device_id;
+                let res = self.handle_rdp_device_close_req(req);
+                if device_is_tombstoned {
+                    // HACK(rhammonds): We need to remove this device id from the rdpdr ServiceProcessor,
+                    // but can't obtain a reference to it because the 'rdpdr' instance already holds
+                    // a reference to us. We'll synthesize a new directory removal message for the for
+                    // the client to process which will attempt to remove the device/directory again.
+                    let _ = self
+                        .client_handle
+                        .handle_tdp_sd_remove(SharedDirectoryRemove {
+                            directory_id: device_id,
+                        });
+                }
+                //Return original close response
+                res
             }
             efs::ServerDriveIoRequest::ServerDriveQueryDirectoryRequest(req) => {
                 self.handle_rdp_query_directory_req(req)
@@ -156,16 +391,20 @@ impl FilesystemBackend {
     fn handle_rdp_device_create_req(&mut self, rdp_req: efs::DeviceCreateRequest) -> PduResult<()> {
         // https://github.com/FreeRDP/FreeRDP/blob/511444a65e7aa2f537c5e531fa68157a50c1bd4d/channels/drive/client/drive_file.c#L210
         self.send_tdp_sd_info_request(tdp::SharedDirectoryInfoRequest::from(&rdp_req))?;
-        self.pending_sd_info_resp_handlers.insert(
+
+        self.cache.insert_handler(
+            rdp_req.device_io_request.device_id,
             rdp_req.device_io_request.completion_id,
-            SharedDirectoryInfoResponseHandler::new(
+            ResponseKind::Info(SharedDirectoryInfoResponseHandler::new(
+                rdp_req,
                 |this: &mut FilesystemBackend,
-                 tdp_resp: tdp::SharedDirectoryInfoResponse|
+                 tdp_resp: tdp::SharedDirectoryInfoResponse,
+                 rdp_req: efs::DeviceCreateRequest|
                  -> PduResult<()> {
                     this.handle_rdp_device_create_req_continued(rdp_req, tdp_resp)
                 },
-            ),
-        );
+            )),
+        )?;
         Ok(())
     }
 
@@ -262,9 +501,10 @@ impl FilesystemBackend {
             efs::CreateDisposition::FILE_OPEN => {
                 // If the file already exists, open it instead of creating a new file. If it does not, fail the request and do not create a new file.
                 if res.err_code == TdpErrCode::Nil {
-                    let file_id = self
-                        .file_cache
-                        .insert(FileCacheObject::new(UnixPath::from(&req.path), res.fso))?;
+                    let file_id = self.cache.add_file(
+                        req.device_io_request.device_id,
+                        FileCacheObject::new(UnixPath::from(&req.path), res.fso),
+                    )?;
                     return self.send_rdp_device_create_response(
                         &req,
                         efs::NtStatus::SUCCESS,
@@ -294,9 +534,10 @@ impl FilesystemBackend {
             efs::CreateDisposition::FILE_OPEN_IF => {
                 // If the file already exists, open it. If it does not, create the given file.
                 if res.err_code == TdpErrCode::Nil {
-                    let file_id = self
-                        .file_cache
-                        .insert(FileCacheObject::new(UnixPath::from(&req.path), res.fso))?;
+                    let file_id = self.cache.add_file(
+                        req.device_io_request.device_id,
+                        FileCacheObject::new(UnixPath::from(&req.path), res.fso),
+                    )?;
                     return self.send_rdp_device_create_response(
                         &req,
                         efs::NtStatus::SUCCESS,
@@ -351,14 +592,20 @@ impl FilesystemBackend {
         &mut self,
         rdp_req: efs::ServerDriveQueryInformationRequest,
     ) -> PduResult<()> {
-        let file = self.file_cache.get(rdp_req.device_io_request.file_id);
+        let file = self.cache.get_file(
+            rdp_req.device_io_request.device_id,
+            rdp_req.device_io_request.file_id,
+        );
         self.send_rdp_client_drive_query_info_response(rdp_req, file)?;
         Ok(())
     }
 
     /// Handles an RDP [`efs::DeviceCloseRequest`] received from the RDP server.
     fn handle_rdp_device_close_req(&mut self, rdp_req: efs::DeviceCloseRequest) -> PduResult<()> {
-        if let Some(file) = self.file_cache.remove(rdp_req.device_io_request.file_id) {
+        if let Some(file) = self.cache.remove_file(
+            rdp_req.device_io_request.device_id,
+            rdp_req.device_io_request.file_id,
+        ) {
             if file.delete_pending {
                 return self.tdp_sd_delete(rdp_req, file);
             }
@@ -375,13 +622,19 @@ impl FilesystemBackend {
     ) -> PduResult<()> {
         let file_id = rdp_req.device_io_request.file_id;
         // https://github.com/FreeRDP/FreeRDP/blob/511444a65e7aa2f537c5e531fa68157a50c1bd4d/channels/drive/client/drive_main.c#L610
-        match self.file_cache.get(file_id) {
+        match self
+            .cache
+            .get_file(rdp_req.device_io_request.device_id, file_id)
+        {
             // File not found in cache, return a failure
-            None => self.send_rdp_drive_query_dir_response(
-                rdp_req.device_io_request,
-                NtStatus::UNSUCCESSFUL,
-                None,
-            ),
+            None => {
+                warn!("FILE NOT FOUND IN handle_rdp_query_directory_req ");
+                self.send_rdp_drive_query_dir_response(
+                    rdp_req.device_io_request,
+                    NtStatus::UNSUCCESSFUL,
+                    None,
+                )
+            }
             Some(dir) => {
                 if dir.fso.file_type != tdp::FileType::Directory {
                     return Err(pdu_other_err!("received ServerDriveQueryDirectoryRequest request for a file rather than a directory"));
@@ -406,16 +659,19 @@ impl FilesystemBackend {
                 })?;
 
                 // When we get the response for that list of files...
-                self.pending_sd_list_resp_handlers.insert(
+                self.cache.insert_handler(
+                    rdp_req.device_io_request.device_id,
                     rdp_req.device_io_request.completion_id,
                     SharedDirectoryListResponseHandler::new(
+                        rdp_req,
                         move |cli: &mut Self,
-                              tdp_resp: tdp::SharedDirectoryListResponse|
+                              tdp_resp: tdp::SharedDirectoryListResponse,
+                              rdp_req: efs::ServerDriveQueryDirectoryRequest|
                               -> PduResult<()> {
                             cli.handle_rdp_query_directory_req_continued(rdp_req, tdp_resp)
                         },
                     ),
-                );
+                )?;
 
                 // Return nothing yet, an RDP message will be returned when the pending_sd_list_resp_handlers
                 // closure gets called.
@@ -447,7 +703,10 @@ impl FilesystemBackend {
         // If SharedDirectoryListRequest succeeded, move the
         // list of FileSystemObjects that correspond to this directory's
         // contents to its entry in the file cache.
-        if let Some(dir) = self.file_cache.get_mut(rdp_req.device_io_request.file_id) {
+        if let Some(dir) = self.cache.get_file_mut(
+            rdp_req.device_io_request.device_id,
+            rdp_req.device_io_request.file_id,
+        ) {
             dir.contents = tdp_resp.fso_list;
             // And send back the "." directory over RDP
             return self.send_rdp_next_drive_query_dir_response(&rdp_req);
@@ -461,7 +720,7 @@ impl FilesystemBackend {
     }
 
     fn handle_rdp_notify_change_directory_req(
-        &self,
+        &mut self,
         rdp_req: efs::ServerDriveNotifyChangeDirectoryRequest,
     ) -> PduResult<()> {
         // https://github.com/FreeRDP/FreeRDP/blob/511444a65e7aa2f537c5e531fa68157a50c1bd4d/channels/drive/client/drive_main.c#L661
@@ -474,7 +733,10 @@ impl FilesystemBackend {
         &mut self,
         rdp_req: efs::ServerDriveQueryVolumeInformationRequest,
     ) -> PduResult<()> {
-        match self.file_cache.get(rdp_req.device_io_request.file_id) {
+        match self.cache.get_file(
+            rdp_req.device_io_request.device_id,
+            rdp_req.device_io_request.file_id,
+        ) {
             // File not found in cache
             None => Err(pdu_other_err!(
                 "",
@@ -602,7 +864,10 @@ impl FilesystemBackend {
         // Determine whether to send back a STATUS_DIRECTORY_NOT_EMPTY
         // or STATUS_SUCCESS in the case of a succesful operation
         // https://github.com/FreeRDP/FreeRDP/blob/dfa231c0a55b005af775b833f92f6bcd30363d77/channels/drive/client/drive_main.c#L430-L431
-        let io_status = match self.file_cache.get(rdp_req.device_io_request.file_id) {
+        let io_status = match self.cache.get_file(
+            rdp_req.device_io_request.device_id,
+            rdp_req.device_io_request.file_id,
+        ) {
             Some(file) => {
                 if file.fso.is_non_empty_directory() {
                     NtStatus::DIRECTORY_NOT_EMPTY
@@ -621,7 +886,10 @@ impl FilesystemBackend {
                 self.tdp_sd_rename(rdp_req.clone(), rename_info, io_status)
             }
             efs::FileInformationClass::Disposition(ref info) => {
-                match self.file_cache.get_mut(rdp_req.device_io_request.file_id) {
+                match self.cache.get_file_mut(
+                    rdp_req.device_io_request.device_id,
+                    rdp_req.device_io_request.file_id,
+                ) {
                     // File not found in cache
                     None => self.send_rdp_set_info_response(&rdp_req, NtStatus::UNSUCCESSFUL),
                     Some(file) => {
@@ -671,11 +939,14 @@ impl FilesystemBackend {
         self.send_tdp_sd_create_request(tdp::SharedDirectoryCreateRequest::from(
             &rdp_req, file_type,
         ))?;
-        self.pending_sd_create_resp_handlers.insert(
+        self.cache.insert_handler(
+            rdp_req.device_io_request.device_id,
             rdp_req.device_io_request.completion_id,
             SharedDirectoryCreateResponseHandler::new(
+                rdp_req,
                 move |this: &mut FilesystemBackend,
-                      tdp_resp: tdp::SharedDirectoryCreateResponse|
+                      tdp_resp: tdp::SharedDirectoryCreateResponse,
+                      rdp_req: efs::DeviceCreateRequest|
                       -> PduResult<()> {
                     if tdp_resp.err_code != TdpErrCode::Nil {
                         return this.send_rdp_device_create_response(
@@ -684,14 +955,14 @@ impl FilesystemBackend {
                             0,
                         );
                     }
-                    let file_id = this.file_cache.insert(FileCacheObject::new(
-                        UnixPath::from(&rdp_req.path),
-                        tdp_resp.fso,
-                    ))?;
+                    let file_id = this.cache.add_file(
+                        rdp_req.device_io_request.device_id,
+                        FileCacheObject::new(UnixPath::from(&rdp_req.path), tdp_resp.fso),
+                    )?;
                     this.send_rdp_device_create_response(&rdp_req, NtStatus::SUCCESS, file_id)
                 },
             ),
-        );
+        )?;
         Ok(())
     }
 
@@ -700,11 +971,14 @@ impl FilesystemBackend {
     fn tdp_sd_overwrite(&mut self, rdp_req: efs::DeviceCreateRequest) -> PduResult<()> {
         let tdp_req = tdp::SharedDirectoryDeleteRequest::from(&rdp_req);
         self.send_tdp_sd_delete_request(tdp_req)?;
-        self.pending_sd_delete_resp_handlers.insert(
+        self.cache.insert_handler(
+            rdp_req.device_io_request.device_id,
             rdp_req.device_io_request.completion_id,
             SharedDirectoryDeleteResponseHandler::new(
+                rdp_req,
                 move |this: &mut FilesystemBackend,
-                      tdp_resp: tdp::SharedDirectoryDeleteResponse|
+                      tdp_resp: tdp::SharedDirectoryDeleteResponse,
+                      rdp_req: efs::DeviceCreateRequest|
                       -> PduResult<()> {
                     match tdp_resp.err_code {
                         TdpErrCode::Nil => {
@@ -719,7 +993,7 @@ impl FilesystemBackend {
                     }
                 },
             ),
-        );
+        )?;
         Ok(())
     }
 
@@ -732,11 +1006,14 @@ impl FilesystemBackend {
     ) -> PduResult<()> {
         let tdp_req = tdp::SharedDirectoryDeleteRequest::from_fco(&rdp_req, file);
         self.send_tdp_sd_delete_request(tdp_req)?;
-        self.pending_sd_delete_resp_handlers.insert(
+        self.cache.insert_handler(
+            rdp_req.device_io_request.device_id,
             rdp_req.device_io_request.completion_id,
             SharedDirectoryDeleteResponseHandler::new(
+                rdp_req,
                 move |this: &mut FilesystemBackend,
-                      tdp_resp: tdp::SharedDirectoryDeleteResponse|
+                      tdp_resp: tdp::SharedDirectoryDeleteResponse,
+                      rdp_req: efs::DeviceCloseRequest|
                       -> PduResult<()> {
                     let io_status = if tdp_resp.err_code == TdpErrCode::Nil {
                         NtStatus::SUCCESS
@@ -746,14 +1023,17 @@ impl FilesystemBackend {
                     this.send_rdp_device_close_response(rdp_req, io_status)
                 },
             ),
-        );
+        )?;
         Ok(())
     }
 
     /// Helper function for sending a [`tdp::SharedDirectoryReadRequest`] to the browser
     /// and handling the [`tdp::SharedDirectoryReadResponse`] that is received in response.
     fn tdp_sd_read(&mut self, rdp_req: efs::DeviceReadRequest) -> PduResult<()> {
-        match self.file_cache.get(rdp_req.device_io_request.file_id) {
+        match self.cache.get_file(
+            rdp_req.device_io_request.device_id,
+            rdp_req.device_io_request.file_id,
+        ) {
             // File not found in cache
             None => self.send_rdp_read_response(
                 rdp_req.device_io_request,
@@ -763,16 +1043,19 @@ impl FilesystemBackend {
             Some(file) => {
                 let tdp_req = tdp::SharedDirectoryReadRequest::from_fco(&rdp_req, file);
                 self.send_tdp_sd_read_request(tdp_req)?;
-                self.pending_sd_read_resp_handlers.insert(
+                self.cache.insert_handler(
+                    rdp_req.device_io_request.device_id,
                     rdp_req.device_io_request.completion_id,
                     SharedDirectoryReadResponseHandler::new(
+                        rdp_req,
                         move |this: &mut FilesystemBackend,
-                              tdp_res: tdp::SharedDirectoryReadResponse|
+                              tdp_res: tdp::SharedDirectoryReadResponse,
+                              rdp_req: efs::DeviceReadRequest|
                               -> PduResult<()> {
                             this.tdp_sd_read_continued(rdp_req, tdp_res)
                         },
                     ),
-                );
+                )?;
 
                 Ok(())
             }
@@ -801,7 +1084,10 @@ impl FilesystemBackend {
     /// Helper function for sending a [`tdp::SharedDirectoryWriteRequest`] to the browser
     /// and handling the [`tdp::SharedDirectoryWriteResponse`] that is received in response.
     fn tdp_sd_write(&mut self, rdp_req: efs::DeviceWriteRequest) -> PduResult<()> {
-        match self.file_cache.get(rdp_req.device_io_request.file_id) {
+        match self.cache.get_file(
+            rdp_req.device_io_request.device_id,
+            rdp_req.device_io_request.file_id,
+        ) {
             // File not found in cache
             None => {
                 self.send_rdp_write_response(rdp_req.device_io_request, NtStatus::UNSUCCESSFUL, 0)
@@ -810,16 +1096,19 @@ impl FilesystemBackend {
                 self.send_tdp_sd_write_request(tdp::SharedDirectoryWriteRequest::from_fco(
                     &rdp_req, file,
                 ))?;
-                self.pending_sd_write_resp_handlers.insert(
+                self.cache.insert_handler(
+                    rdp_req.device_io_request.device_id,
                     rdp_req.device_io_request.completion_id,
                     SharedDirectoryWriteResponseHandler::new(
+                        rdp_req,
                         move |this: &mut FilesystemBackend,
-                              tdp_res: tdp::SharedDirectoryWriteResponse|
+                              tdp_res: tdp::SharedDirectoryWriteResponse,
+                              rdp_req: efs::DeviceWriteRequest|
                               -> PduResult<()> {
                             this.tdp_sd_write_continued(rdp_req, tdp_res)
                         },
                     ),
-                );
+                )?;
 
                 Ok(())
             }
@@ -863,11 +1152,15 @@ impl FilesystemBackend {
                 })?;
 
                 let rename_info = (*rename_info).clone();
-                self.pending_sd_info_resp_handlers.insert(
+
+                self.cache.insert_handler(
+                    rdp_req.device_io_request.device_id,
                     rdp_req.device_io_request.completion_id,
-                    SharedDirectoryInfoResponseHandler::new(
+                    ResponseKind::Info(SharedDirectoryInfoResponseHandler::new(
+                        rdp_req,
                         move |this: &mut FilesystemBackend,
-                              res: tdp::SharedDirectoryInfoResponse|
+                              res: tdp::SharedDirectoryInfoResponse,
+                              rdp_req: efs::ServerDriveSetInformationRequest|
                               -> PduResult<()> {
                             if res.err_code == TdpErrCode::DoesNotExist {
                                 // If the file doesn't already exist, send a move request.
@@ -879,8 +1172,8 @@ impl FilesystemBackend {
                                 NtStatus::OBJECT_NAME_COLLISION,
                             )
                         },
-                    ),
-                );
+                    )),
+                )?;
 
                 Ok(())
             }
@@ -895,7 +1188,10 @@ impl FilesystemBackend {
         eof: &efs::FileEndOfFileInformation,
         io_status: NtStatus,
     ) -> PduResult<()> {
-        if let Some(file) = self.file_cache.get(rdp_req.device_io_request.file_id) {
+        if let Some(file) = self.cache.get_file(
+            rdp_req.device_io_request.device_id,
+            rdp_req.device_io_request.file_id,
+        ) {
             let end_of_file = eof.end_of_file;
             self.send_tdp_truncate_request(tdp::SharedDirectoryTruncateRequest {
                 completion_id: rdp_req.device_io_request.completion_id,
@@ -904,20 +1200,24 @@ impl FilesystemBackend {
                 end_of_file: cast_length("tdp_sd_truncate", "end_of_file", eof.end_of_file)?,
             })?;
 
-            self.pending_sd_truncate_resp_handlers.insert(
+            self.cache.insert_handler(
+                rdp_req.device_io_request.device_id,
                 rdp_req.device_io_request.completion_id,
                 SharedDirectoryTruncateResponseHandler::new(
+                    rdp_req,
                     move |this: &mut FilesystemBackend,
-                          res: tdp::SharedDirectoryTruncateResponse|
+                          res: tdp::SharedDirectoryTruncateResponse,
+                          rdp_req: efs::ServerDriveSetInformationRequest|
                           -> PduResult<()> {
                         if res.err_code != TdpErrCode::Nil {
                             return this
                                 .send_rdp_set_info_response(&rdp_req, NtStatus::UNSUCCESSFUL);
                         }
 
-                        let io_status = if let Some(file) =
-                            this.file_cache.get_mut(rdp_req.device_io_request.file_id)
-                        {
+                        let io_status = if let Some(file) = this.cache.get_file_mut(
+                            rdp_req.device_io_request.device_id,
+                            rdp_req.device_io_request.file_id,
+                        ) {
                             // Truncate succeeded, update our internal books to reflect the new size.
                             file.fso.size =
                                 cast_length("tdp_sd_truncate", "end_of_file", end_of_file)?;
@@ -931,7 +1231,7 @@ impl FilesystemBackend {
                         this.send_rdp_set_info_response(&rdp_req, io_status)
                     },
                 ),
-            );
+            )?;
 
             return Ok(());
         }
@@ -949,7 +1249,10 @@ impl FilesystemBackend {
         rename_info: efs::FileRenameInformation,
         io_status: NtStatus,
     ) -> PduResult<()> {
-        if let Some(file) = self.file_cache.get(rdp_req.device_io_request.file_id) {
+        if let Some(file) = self.cache.get_file(
+            rdp_req.device_io_request.device_id,
+            rdp_req.device_io_request.file_id,
+        ) {
             self.send_tdp_sd_move_request(tdp::SharedDirectoryMoveRequest {
                 completion_id: rdp_req.device_io_request.completion_id,
                 directory_id: rdp_req.device_io_request.device_id,
@@ -957,11 +1260,14 @@ impl FilesystemBackend {
                 new_path: UnixPath::from(&rename_info.file_name),
             })?;
 
-            self.pending_sd_move_resp_handlers.insert(
+            self.cache.insert_handler(
+                rdp_req.device_io_request.device_id,
                 rdp_req.device_io_request.completion_id,
                 SharedDirectoryMoveResponseHandler::new(
+                    rdp_req,
                     move |this: &mut FilesystemBackend,
-                          res: tdp::SharedDirectoryMoveResponse|
+                          res: tdp::SharedDirectoryMoveResponse,
+                          rdp_req: efs::ServerDriveSetInformationRequest|
                           -> PduResult<()> {
                         if res.err_code != TdpErrCode::Nil {
                             return this
@@ -971,7 +1277,7 @@ impl FilesystemBackend {
                         this.send_rdp_set_info_response(&rdp_req, io_status)
                     },
                 ),
-            );
+            )?;
 
             return Ok(());
         }
@@ -1155,19 +1461,12 @@ impl FilesystemBackend {
         &mut self,
         tdp_resp: tdp::SharedDirectoryInfoResponse,
     ) -> PduResult<()> {
-        match self
-            .pending_sd_info_resp_handlers
-            .remove(&tdp_resp.completion_id)
-        {
-            Some(handler) => handler.call(self, tdp_resp),
-            None => Err(pdu_other_err!(
-                "",
-                source:FilesystemBackendError(format!(
-                    "received invalid completion id: {}",
-                    tdp_resp.completion_id
-                ))
-            )),
-        }
+        self.cache
+            .remove_handler::<SharedDirectoryInfoResponseHandler>(
+                tdp_resp.device_id,
+                tdp_resp.completion_id,
+            )?
+            .call(self, tdp_resp)
     }
 
     /// Called from the Go code when a [`tdp::SharedDirectoryCreateResponse`] is received from the browser.
@@ -1178,19 +1477,12 @@ impl FilesystemBackend {
         &mut self,
         tdp_resp: tdp::SharedDirectoryCreateResponse,
     ) -> PduResult<()> {
-        match self
-            .pending_sd_create_resp_handlers
-            .remove(&tdp_resp.completion_id)
-        {
-            Some(handler) => handler.call(self, tdp_resp),
-            None => Err(pdu_other_err!(
-                "",
-                source:FilesystemBackendError(format!(
-                    "received invalid completion id: {}",
-                    tdp_resp.completion_id
-                ))
-            )),
-        }
+        self.cache
+            .remove_handler::<SharedDirectoryCreateResponseHandler>(
+                tdp_resp.directory_id,
+                tdp_resp.completion_id,
+            )?
+            .call(self, tdp_resp)
     }
 
     /// Called from the Go code when a [`tdp::SharedDirectoryDeleteResponse`] is received from the browser.
@@ -1201,19 +1493,12 @@ impl FilesystemBackend {
         &mut self,
         tdp_resp: tdp::SharedDirectoryDeleteResponse,
     ) -> PduResult<()> {
-        match self
-            .pending_sd_delete_resp_handlers
-            .remove(&tdp_resp.completion_id)
-        {
-            Some(handler) => handler.call(self, tdp_resp),
-            None => Err(pdu_other_err!(
-                "",
-                source:FilesystemBackendError(format!(
-                    "received invalid completion id: {}",
-                    tdp_resp.completion_id
-                ))
-            )),
-        }
+        self.cache
+            .remove_handler::<SharedDirectoryDeleteResponseHandler>(
+                tdp_resp.directory_id,
+                tdp_resp.completion_id,
+            )?
+            .call(self, tdp_resp)
     }
 
     /// Called from the Go code when a [`tdp::SharedDirectoryListResponse`] is received from the browser.
@@ -1224,19 +1509,12 @@ impl FilesystemBackend {
         &mut self,
         tdp_resp: tdp::SharedDirectoryListResponse,
     ) -> PduResult<()> {
-        match self
-            .pending_sd_list_resp_handlers
-            .remove(&tdp_resp.completion_id)
-        {
-            Some(handler) => handler.call(self, tdp_resp),
-            None => Err(pdu_other_err!(
-                "",
-                source:FilesystemBackendError(format!(
-                    "received invalid completion id: {}",
-                    tdp_resp.completion_id
-                ))
-            )),
-        }
+        self.cache
+            .remove_handler::<SharedDirectoryListResponseHandler>(
+                tdp_resp.directory_id,
+                tdp_resp.completion_id,
+            )?
+            .call(self, tdp_resp)
     }
 
     /// Called from the Go code when a [`tdp::SharedDirectoryReadResponse`] is received from the browser.
@@ -1247,19 +1525,12 @@ impl FilesystemBackend {
         &mut self,
         tdp_resp: tdp::SharedDirectoryReadResponse,
     ) -> PduResult<()> {
-        match self
-            .pending_sd_read_resp_handlers
-            .remove(&tdp_resp.completion_id)
-        {
-            Some(handler) => handler.call(self, tdp_resp),
-            None => Err(pdu_other_err!(
-                "",
-                source:FilesystemBackendError(format!(
-                    "received invalid completion id: {}",
-                    tdp_resp.completion_id
-                ))
-            )),
-        }
+        self.cache
+            .remove_handler::<SharedDirectoryReadResponseHandler>(
+                tdp_resp.directory_id,
+                tdp_resp.completion_id,
+            )?
+            .call(self, tdp_resp)
     }
 
     /// Called from the Go code when a [`tdp::SharedDirectoryWriteResponse`] is received from the browser.
@@ -1270,57 +1541,36 @@ impl FilesystemBackend {
         &mut self,
         tdp_resp: tdp::SharedDirectoryWriteResponse,
     ) -> PduResult<()> {
-        match self
-            .pending_sd_write_resp_handlers
-            .remove(&tdp_resp.completion_id)
-        {
-            Some(handler) => handler.call(self, tdp_resp),
-            None => Err(pdu_other_err!(
-                "",
-                source:FilesystemBackendError(format!(
-                    "received invalid completion id: {}",
-                    tdp_resp.completion_id
-                ))
-            )),
-        }
+        self.cache
+            .remove_handler::<SharedDirectoryWriteResponseHandler>(
+                tdp_resp.directory_id,
+                tdp_resp.completion_id,
+            )?
+            .call(self, tdp_resp)
     }
 
     pub fn handle_tdp_sd_move_response(
         &mut self,
         tdp_resp: tdp::SharedDirectoryMoveResponse,
     ) -> PduResult<()> {
-        match self
-            .pending_sd_move_resp_handlers
-            .remove(&tdp_resp.completion_id)
-        {
-            Some(handler) => handler.call(self, tdp_resp),
-            None => Err(pdu_other_err!(
-                "",
-                source:FilesystemBackendError(format!(
-                    "received invalid completion id: {}",
-                    tdp_resp.completion_id
-                ))
-            )),
-        }
+        self.cache
+            .remove_handler::<SharedDirectoryMoveResponseHandler>(
+                tdp_resp.directory_id,
+                tdp_resp.completion_id,
+            )?
+            .call(self, tdp_resp)
     }
 
     pub fn handle_tdp_sd_truncate_response(
         &mut self,
         tdp_resp: tdp::SharedDirectoryTruncateResponse,
     ) -> PduResult<()> {
-        match self
-            .pending_sd_truncate_resp_handlers
-            .remove(&tdp_resp.completion_id)
-        {
-            Some(handler) => handler.call(self, tdp_resp),
-            None => Err(pdu_other_err!(
-                "",
-                source:FilesystemBackendError(format!(
-                    "received invalid completion id: {}",
-                    tdp_resp.completion_id
-                ))
-            )),
-        }
+        self.cache
+            .remove_handler::<SharedDirectoryTruncateResponseHandler>(
+                tdp_resp.directory_id,
+                tdp_resp.completion_id,
+            )?
+            .call(self, tdp_resp)
     }
 
     /// Helper function for sending an RDP [`efs::DeviceCreateResponse`] based on an RDP [`efs::DeviceCreateRequest`].
@@ -1352,6 +1602,11 @@ impl FilesystemBackend {
             ))
         }?;
 
+        warn!(
+            "sending efs::DeviceCreateResponse - status: {}, kind: {:?}",
+            u32::from(io_status),
+            &information
+        );
         self.client_handle.write_rdpdr(
             efs::DeviceCreateResponse {
                 device_io_reply: efs::DeviceIoResponse::new(
@@ -1533,7 +1788,10 @@ impl FilesystemBackend {
         // next() FileSystemObject (starting with ".", then "..", then iterating through the contents
         // of the target directory), which we then convert to an RDP FileInformationClass for sending back
         // to the RDP server.
-        if let Some(dir) = self.file_cache.get_mut(req.device_io_request.file_id) {
+        if let Some(dir) = self.cache.get_file_mut(
+            req.device_io_request.device_id,
+            req.device_io_request.file_id,
+        ) {
             if let Some(fso) = dir.next() {
                 let buffer = match req.file_info_class_lvl {
                     efs::FileInformationClassLevel::FILE_BOTH_DIRECTORY_INFORMATION => Some(
@@ -1593,6 +1851,10 @@ impl FilesystemBackend {
         io_status: NtStatus,
         buffer: Option<efs::FileInformationClass>,
     ) -> PduResult<()> {
+        warn!(
+            "sending efs::ClientDriveQueryDirectoryResponse to request: {:?}",
+            &device_io_request
+        );
         self.client_handle.write_rdpdr(
             efs::ClientDriveQueryDirectoryResponse {
                 device_io_reply: efs::DeviceIoResponse::new(device_io_request, io_status),
@@ -1610,6 +1872,7 @@ impl FilesystemBackend {
         io_status: NtStatus,
         buffer: Option<efs::FileSystemInformationClass>,
     ) -> PduResult<()> {
+        warn!("sending efs::ClientDriveQueryVolumeInformationResponse");
         self.client_handle.write_rdpdr(
             efs::ClientDriveQueryVolumeInformationResponse::new(
                 device_io_request,
@@ -1700,12 +1963,12 @@ impl FileCache {
     ///
     /// Returns the `file_id` of the inserted [`FileCacheObject`],
     /// or an error if the `file_id` already exists in the cache.
-    fn insert(&mut self, file: FileCacheObject) -> PduResult<u32> {
+    fn insert(&mut self, file: FileCacheObject) -> Result<u32, FilesystemBackendError> {
         self.next_file_id = self.next_file_id.wrapping_add(1);
         if self.cache.insert(self.next_file_id, file).is_none() {
             Ok(self.next_file_id)
         } else {
-            Err(pdu_other_err!("attempted to insert a FileCacheObject into the file cache with a file_id that already exists in the cache"))
+            Err(FilesystemBackendError("attempted to insert a FileCacheObject into the file cache with a file_id that already exists in the cache".to_string()))
         }
     }
 
@@ -1839,30 +2102,153 @@ impl Iterator for FileCacheObject {
 #[allow(dead_code)] // The internal `String` is "dead code" according to the compiler, but we want it for debugging purposes.
 struct FilesystemBackendError(pub String);
 
+impl From<FilesystemBackendError> for PduError {
+    fn from(value: FilesystemBackendError) -> Self {
+        PduError::new(
+            "filesystem",
+            ironrdp_pdu::PduErrorKind::Other { description: "" },
+        )
+        .with_source(value)
+    }
+}
+
 impl std::fmt::Display for FilesystemBackendError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{:#?}", self)
+        write!(f, "{}", self.0)
     }
 }
 
 impl std::error::Error for FilesystemBackendError {}
 
-type Handler<T> = Box<dyn FnOnce(&mut FilesystemBackend, T) -> PduResult<()> + Send>;
+// Cancel allows us implement generic cancellation methods for various efs::<request> types
+trait Cancel {
+    fn cancel(&self, this: &mut FilesystemBackend) -> PduResult<()>;
+}
 
-/// When we send a TDP Shared Directory Request to the browser, we expect a response
-/// which we will need to call a function on. A [`ResponseHandler`] is a wrapper around
-/// the function that will be called when the response is received.
-struct ResponseHandler<T>(Handler<T>);
+impl Cancel for efs::DeviceCreateRequest {
+    fn cancel(&self, this: &mut FilesystemBackend) -> PduResult<()> {
+        this.send_rdp_device_create_response(self, NtStatus::UNSUCCESSFUL, 0)
+    }
+}
 
+impl Cancel for efs::ServerDriveQueryDirectoryRequest {
+    fn cancel(&self, this: &mut FilesystemBackend) -> PduResult<()> {
+        this.send_rdp_drive_query_dir_response(
+            self.device_io_request.clone(),
+            NtStatus::UNSUCCESSFUL,
+            None,
+        )
+    }
+}
+
+impl Cancel for efs::DeviceReadRequest {
+    fn cancel(&self, this: &mut FilesystemBackend) -> PduResult<()> {
+        this.send_rdp_read_response(
+            self.device_io_request.clone(),
+            NtStatus::UNSUCCESSFUL,
+            vec![],
+        )
+    }
+}
+
+impl Cancel for efs::DeviceWriteRequest {
+    fn cancel(&self, this: &mut FilesystemBackend) -> PduResult<()> {
+        this.send_rdp_write_response(self.device_io_request.clone(), NtStatus::UNSUCCESSFUL, 0)
+    }
+}
+
+impl Cancel for efs::ServerDriveSetInformationRequest {
+    fn cancel(&self, this: &mut FilesystemBackend) -> PduResult<()> {
+        this.send_rdp_set_info_response(self, NtStatus::UNSUCCESSFUL)
+    }
+}
+
+impl Cancel for efs::DeviceCloseRequest {
+    fn cancel(&self, this: &mut FilesystemBackend) -> PduResult<()> {
+        this.send_rdp_device_close_response(self.clone(), NtStatus::UNSUCCESSFUL)
+    }
+}
+
+impl Cancel for efs::ServerDriveNotifyChangeDirectoryRequest {
+    fn cancel(&self, this: &mut FilesystemBackend) -> PduResult<()> {
+        this.client_handle
+            .write_rdpdr(RdpdrPdu::ClientDriveQueryDirectoryResponse(
+                efs::ClientDriveQueryDirectoryResponse {
+                    device_io_reply: efs::DeviceIoResponse {
+                        device_id: self.device_io_request.device_id,
+                        completion_id: self.device_io_request.completion_id,
+                        // https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-erref/596a1078-e883-4972-9bbc-49e60bebca55
+                        // STATUS_CANCELLED - 0xC0000120
+                        io_status: NtStatus::from(0xC0000120),
+                    },
+                    buffer: None,
+                },
+            ))?;
+        Ok(())
+    }
+}
+
+impl Cancel for efs::ServerDriveQueryInformationRequest {
+    fn cancel(&self, this: &mut FilesystemBackend) -> PduResult<()> {
+        this.send_rdp_client_drive_query_info_response(self.clone(), None)?;
+        Ok(())
+    }
+}
+impl Cancel for efs::ServerDriveQueryVolumeInformationRequest {
+    fn cancel(&self, this: &mut FilesystemBackend) -> PduResult<()> {
+        this.handle_rdp_query_volume_req(self.clone())?;
+        Ok(())
+    }
+}
+impl Cancel for efs::DeviceControlRequest<efs::AnyIoCtlCode> {
+    fn cancel(&self, this: &mut FilesystemBackend) -> PduResult<()> {
+        this.handle_rdp_device_control_req(self.clone())?;
+        Ok(())
+    }
+}
+impl Cancel for efs::ServerDriveLockControlRequest {
+    fn cancel(&self, this: &mut FilesystemBackend) -> PduResult<()> {
+        this.handle_rdp_lock_req(self.clone())?;
+        Ok(())
+    }
+}
+
+enum HandlerInput<T> {
+    Response(T),
+    Cancel,
+}
+
+trait HandlerFn<T>: FnOnce(&mut FilesystemBackend, HandlerInput<T>) -> PduResult<()> + Send {}
+
+impl<T, F> HandlerFn<T> for F where
+    F: FnOnce(&mut FilesystemBackend, HandlerInput<T>) -> PduResult<()> + Send
+{
+}
+
+struct ResponseHandler<T> {
+    handler: Box<dyn HandlerFn<T>>,
+}
+
+// ResponseHandler is allowed to either invoke 'call' XOR 'cancel' exactly once.
 impl<T> ResponseHandler<T> {
-    fn new(
-        handler: impl FnOnce(&mut FilesystemBackend, T) -> PduResult<()> + Send + 'static,
+    fn new<R: Cancel + Send + 'static>(
+        req: R,
+        handler: impl FnOnce(&mut FilesystemBackend, T, R) -> PduResult<()> + Send + 'static,
     ) -> Self {
-        Self(Box::new(handler))
+        Self {
+            handler: Box::new(move |this, input| match input {
+                HandlerInput::Response(res) => handler(this, res, req),
+                HandlerInput::Cancel => req.cancel(this),
+            }),
+        }
     }
 
     fn call(self, this: &mut FilesystemBackend, res: T) -> PduResult<()> {
-        (self.0)(this, res)
+        (self.handler)(this, HandlerInput::Response(res))
+    }
+
+    fn cancel(self, this: &mut FilesystemBackend) -> PduResult<()> {
+        (self.handler)(this, HandlerInput::Cancel)
     }
 }
 
@@ -1881,26 +2267,268 @@ type SharedDirectoryWriteResponseHandler = ResponseHandler<tdp::SharedDirectoryW
 type SharedDirectoryMoveResponseHandler = ResponseHandler<tdp::SharedDirectoryMoveResponse>;
 type SharedDirectoryTruncateResponseHandler = ResponseHandler<tdp::SharedDirectoryTruncateResponse>;
 
+#[derive(Debug)]
+enum ResponseKind {
+    Info(SharedDirectoryInfoResponseHandler),
+    Create(SharedDirectoryCreateResponseHandler),
+    Delete(SharedDirectoryDeleteResponseHandler),
+    List(SharedDirectoryListResponseHandler),
+    Read(SharedDirectoryReadResponseHandler),
+    Write(SharedDirectoryWriteResponseHandler),
+    Move(SharedDirectoryMoveResponseHandler),
+    Truncate(SharedDirectoryTruncateResponseHandler),
+}
+
+impl ResponseKind {
+    fn cancel(self, this: &mut FilesystemBackend) -> PduResult<()> {
+        match self {
+            ResponseKind::Info(h) => h.cancel(this),
+            ResponseKind::Create(h) => h.cancel(this),
+            ResponseKind::Delete(h) => h.cancel(this),
+            ResponseKind::List(h) => h.cancel(this),
+            ResponseKind::Read(h) => h.cancel(this),
+            ResponseKind::Write(h) => h.cancel(this),
+            ResponseKind::Move(h) => h.cancel(this),
+            ResponseKind::Truncate(h) => h.cancel(this),
+        }
+    }
+}
+
+impl TryFrom<ResponseKind> for SharedDirectoryInfoResponseHandler {
+    type Error = FilesystemBackendError;
+    fn try_from(value: ResponseKind) -> Result<Self, Self::Error> {
+        match value {
+            ResponseKind::Info(h) => Ok(h),
+            _ => Err(FilesystemBackendError("unexpected handler".to_string())),
+        }
+    }
+}
+
+impl TryFrom<ResponseKind> for SharedDirectoryCreateResponseHandler {
+    type Error = FilesystemBackendError;
+    fn try_from(value: ResponseKind) -> Result<Self, Self::Error> {
+        match value {
+            ResponseKind::Create(h) => Ok(h),
+            _ => Err(FilesystemBackendError("unexpected handler".to_string())),
+        }
+    }
+}
+
+impl TryFrom<ResponseKind> for SharedDirectoryDeleteResponseHandler {
+    type Error = FilesystemBackendError;
+    fn try_from(value: ResponseKind) -> Result<Self, Self::Error> {
+        match value {
+            ResponseKind::Delete(h) => Ok(h),
+            _ => Err(FilesystemBackendError("unexpected handler".to_string())),
+        }
+    }
+}
+
+impl TryFrom<ResponseKind> for SharedDirectoryListResponseHandler {
+    type Error = FilesystemBackendError;
+    fn try_from(value: ResponseKind) -> Result<Self, Self::Error> {
+        match value {
+            ResponseKind::List(h) => Ok(h),
+            _ => Err(FilesystemBackendError("unexpected handler".to_string())),
+        }
+    }
+}
+
+impl TryFrom<ResponseKind> for SharedDirectoryReadResponseHandler {
+    type Error = FilesystemBackendError;
+    fn try_from(value: ResponseKind) -> Result<Self, Self::Error> {
+        match value {
+            ResponseKind::Read(h) => Ok(h),
+            _ => Err(FilesystemBackendError("unexpected handler".to_string())),
+        }
+    }
+}
+
+impl TryFrom<ResponseKind> for SharedDirectoryWriteResponseHandler {
+    type Error = FilesystemBackendError;
+    fn try_from(value: ResponseKind) -> Result<Self, Self::Error> {
+        match value {
+            ResponseKind::Write(h) => Ok(h),
+            _ => Err(FilesystemBackendError("unexpected handler".to_string())),
+        }
+    }
+}
+
+impl TryFrom<ResponseKind> for SharedDirectoryMoveResponseHandler {
+    type Error = FilesystemBackendError;
+    fn try_from(value: ResponseKind) -> Result<Self, Self::Error> {
+        match value {
+            ResponseKind::Move(h) => Ok(h),
+            _ => Err(FilesystemBackendError("unexpected handler".to_string())),
+        }
+    }
+}
+
+impl TryFrom<ResponseKind> for SharedDirectoryTruncateResponseHandler {
+    type Error = FilesystemBackendError;
+    fn try_from(value: ResponseKind) -> Result<Self, Self::Error> {
+        match value {
+            ResponseKind::Truncate(h) => Ok(h),
+            _ => Err(FilesystemBackendError("unexpected handler".to_string())),
+        }
+    }
+}
+
+impl From<SharedDirectoryInfoResponseHandler> for ResponseKind {
+    fn from(value: SharedDirectoryInfoResponseHandler) -> Self {
+        ResponseKind::Info(value)
+    }
+}
+
+impl From<SharedDirectoryCreateResponseHandler> for ResponseKind {
+    fn from(value: SharedDirectoryCreateResponseHandler) -> Self {
+        ResponseKind::Create(value)
+    }
+}
+
+impl From<SharedDirectoryDeleteResponseHandler> for ResponseKind {
+    fn from(value: SharedDirectoryDeleteResponseHandler) -> Self {
+        ResponseKind::Delete(value)
+    }
+}
+
+impl From<SharedDirectoryReadResponseHandler> for ResponseKind {
+    fn from(value: SharedDirectoryReadResponseHandler) -> Self {
+        ResponseKind::Read(value)
+    }
+}
+
+impl From<SharedDirectoryWriteResponseHandler> for ResponseKind {
+    fn from(value: SharedDirectoryWriteResponseHandler) -> Self {
+        ResponseKind::Write(value)
+    }
+}
+
+impl From<SharedDirectoryListResponseHandler> for ResponseKind {
+    fn from(value: SharedDirectoryListResponseHandler) -> Self {
+        ResponseKind::List(value)
+    }
+}
+
+impl From<SharedDirectoryMoveResponseHandler> for ResponseKind {
+    fn from(value: SharedDirectoryMoveResponseHandler) -> Self {
+        ResponseKind::Move(value)
+    }
+}
+
+impl From<SharedDirectoryTruncateResponseHandler> for ResponseKind {
+    fn from(value: SharedDirectoryTruncateResponseHandler) -> Self {
+        ResponseKind::Truncate(value)
+    }
+}
+
 type CompletionId = u32;
 
 /// A generic cache for storing [`ResponseHandler`]s indexed by [`CompletionId`].
 #[derive(Debug)]
-struct ResponseCache<T> {
-    cache: HashMap<CompletionId, ResponseHandler<T>>,
+struct ResponseCache {
+    cache: HashMap<CompletionId, ResponseKind>,
 }
 
-impl<T> ResponseCache<T> {
+impl ResponseCache {
     fn new() -> Self {
         Self {
             cache: HashMap::new(),
         }
     }
 
-    fn insert(&mut self, completion_id: CompletionId, handler: ResponseHandler<T>) {
-        self.cache.insert(completion_id, handler);
+    fn contains(&self, completion_id: CompletionId) -> bool {
+        self.cache.contains_key(&completion_id)
     }
 
-    fn remove(&mut self, completion_id: &CompletionId) -> Option<ResponseHandler<T>> {
+    fn insert(
+        &mut self,
+        completion_id: u32,
+        handler: ResponseKind,
+    ) -> Result<(), FilesystemBackendError> {
+        if self.contains(completion_id) {
+            return Err(FilesystemBackendError(format!(
+                "completion id {} already exists",
+                completion_id
+            )));
+        };
+
+        self.cache.insert(completion_id, handler);
+        Ok(())
+    }
+
+    fn remove(&mut self, completion_id: &CompletionId) -> Option<ResponseKind> {
         self.cache.remove(completion_id)
+    }
+
+    fn drain(&mut self) -> impl std::iter::Iterator<Item = (CompletionId, ResponseKind)> + '_ {
+        self.cache.drain()
+    }
+}
+
+impl Cancel for efs::ServerDriveIoRequest {
+    fn cancel(&self, this: &mut FilesystemBackend) -> PduResult<()> {
+        match self {
+            efs::ServerDriveIoRequest::ServerCreateDriveRequest(h) => h.cancel(this),
+            efs::ServerDriveIoRequest::ServerDriveQueryInformationRequest(h) => h.cancel(this),
+            efs::ServerDriveIoRequest::DeviceCloseRequest(h) => h.cancel(this),
+            efs::ServerDriveIoRequest::ServerDriveQueryDirectoryRequest(h) => h.cancel(this),
+            efs::ServerDriveIoRequest::ServerDriveNotifyChangeDirectoryRequest(h) => h.cancel(this),
+            efs::ServerDriveIoRequest::ServerDriveQueryVolumeInformationRequest(h) => {
+                h.cancel(this)
+            }
+            efs::ServerDriveIoRequest::DeviceControlRequest(h) => h.cancel(this),
+            efs::ServerDriveIoRequest::DeviceReadRequest(h) => h.cancel(this),
+            efs::ServerDriveIoRequest::DeviceWriteRequest(h) => h.cancel(this),
+            efs::ServerDriveIoRequest::ServerDriveSetInformationRequest(h) => h.cancel(this),
+            efs::ServerDriveIoRequest::ServerDriveLockControlRequest(h) => h.cancel(this),
+        }
+    }
+}
+
+struct DeviceId(u32);
+
+impl From<DeviceId> for u32 {
+    fn from(value: DeviceId) -> Self {
+        value.0
+    }
+}
+
+// Grab the DeviceId from any IO request
+impl From<&efs::ServerDriveIoRequest> for DeviceId {
+    fn from(value: &efs::ServerDriveIoRequest) -> Self {
+        match value {
+            efs::ServerDriveIoRequest::ServerCreateDriveRequest(h) => {
+                DeviceId(h.device_io_request.device_id)
+            }
+            efs::ServerDriveIoRequest::ServerDriveQueryInformationRequest(h) => {
+                DeviceId(h.device_io_request.device_id)
+            }
+            efs::ServerDriveIoRequest::DeviceCloseRequest(h) => {
+                DeviceId(h.device_io_request.device_id)
+            }
+            efs::ServerDriveIoRequest::ServerDriveQueryDirectoryRequest(h) => {
+                DeviceId(h.device_io_request.device_id)
+            }
+            efs::ServerDriveIoRequest::ServerDriveNotifyChangeDirectoryRequest(h) => {
+                DeviceId(h.device_io_request.device_id)
+            }
+            efs::ServerDriveIoRequest::ServerDriveQueryVolumeInformationRequest(h) => {
+                DeviceId(h.device_io_request.device_id)
+            }
+            efs::ServerDriveIoRequest::DeviceControlRequest(h) => DeviceId(h.header.device_id),
+            efs::ServerDriveIoRequest::DeviceReadRequest(h) => {
+                DeviceId(h.device_io_request.device_id)
+            }
+            efs::ServerDriveIoRequest::DeviceWriteRequest(h) => {
+                DeviceId(h.device_io_request.device_id)
+            }
+            efs::ServerDriveIoRequest::ServerDriveSetInformationRequest(h) => {
+                DeviceId(h.device_io_request.device_id)
+            }
+            efs::ServerDriveIoRequest::ServerDriveLockControlRequest(h) => {
+                DeviceId(h.device_io_request.device_id)
+            }
+        }
     }
 }

--- a/lib/srv/desktop/rdp/rdpclient/src/rdpdr/filesystem.rs
+++ b/lib/srv/desktop/rdp/rdpclient/src/rdpdr/filesystem.rs
@@ -54,9 +54,9 @@ struct DirectoryContext {
     ///
     /// See the documentation for [`FileCacheObject`].
     file_cache: FileCache,
-    /// tombstoned indicates that this DirectoryContext has been
+    /// marked_for_deletion indicates that this DirectoryContext has been
     /// marked for deletion. All inbound requests will be canceled.
-    tombstoned: bool,
+    marked_for_deletion: bool,
     /// response_cache holds all pending I/O response handlers for
     /// I/O requests against this DirectoryContext.
     response_cache: ResponseCache,
@@ -66,7 +66,7 @@ impl DirectoryContext {
     fn new() -> Self {
         DirectoryContext {
             file_cache: FileCache::new(),
-            tombstoned: false,
+            marked_for_deletion: false,
             response_cache: ResponseCache::new(),
         }
     }
@@ -253,16 +253,16 @@ impl FilesystemBackend {
     }
 
     // Cancels all pending I/O requests on this device and marks the device as
-    // "tombstoned", which means all pending I/O requests will be automatically
+    // for deletion, which means all pending I/O requests will be automatically
     // cancelled. This function returns Ok(true) and actually removes the device
     // if it has no open file handlers, otherwise it returns Ok(false) and removal
     // must be retried after closing any open handles.
-    pub fn tombstone_device(&mut self, device_id: u32) -> PduResult<bool> {
+    pub fn mark_device_for_deletion(&mut self, device_id: u32) -> PduResult<bool> {
         let directory_context = self.cache.get_context_mut(device_id)?;
         let pending_handlers: Vec<(CompletionId, ResponseKind)> =
             directory_context.response_cache.drain().collect();
 
-        directory_context.tombstoned = true;
+        directory_context.marked_for_deletion = true;
         // Drain the response cache for this directory context and cancel each handler.
         pending_handlers
             .into_iter()
@@ -321,12 +321,12 @@ impl FilesystemBackend {
     pub fn handle_rdp_drive_io_request(&mut self, req: efs::ServerDriveIoRequest) -> PduResult<()> {
         trace!("received {:?}", &req);
 
-        let device_is_tombstoned = self
+        let device_pending_deletion = self
             .cache
             .get_context(DeviceId::from(&req).into())?
-            .tombstoned;
-        if device_is_tombstoned {
-            // A tombstoned device is only allowed to handle device close requests.
+            .marked_for_deletion;
+        if device_pending_deletion {
+            // A device pending deletion is only allowed to handle device close requests.
             // All other requests are cancelled.
             match req {
                 efs::ServerDriveIoRequest::DeviceCloseRequest(_) => {}
@@ -342,11 +342,11 @@ impl FilesystemBackend {
                 self.handle_rdp_query_information_req(req)
             }
             efs::ServerDriveIoRequest::DeviceCloseRequest(req) => {
-                // If the device is tombstoned AND this request closes that final file
+                // If the device is marked for deltion AND this request closes that final file
                 // in the cache, then we'll finally send the request to remove the device.
                 let device_id = req.device_io_request.device_id;
                 let res = self.handle_rdp_device_close_req(req);
-                if device_is_tombstoned {
+                if device_pending_deletion {
                     // HACK(rhammonds): We need to remove this device id from the rdpdr ServiceProcessor,
                     // but can't obtain a reference to it because the 'rdpdr' instance already holds
                     // a reference to us. We'll synthesize a new directory removal message for the for

--- a/lib/srv/desktop/rdp/rdpclient/src/rdpdr/filesystem.rs
+++ b/lib/srv/desktop/rdp/rdpclient/src/rdpdr/filesystem.rs
@@ -345,7 +345,7 @@ impl FilesystemBackend {
                 self.handle_rdp_query_information_req(req)
             }
             efs::ServerDriveIoRequest::DeviceCloseRequest(req) => {
-                // If the device is marked for deltion AND this request closes that final file
+                // If the device is marked for deletion AND this request closes that final file
                 // in the cache, then we'll finally send the request to remove the device.
                 let device_id = req.device_io_request.device_id;
                 let res = self.handle_rdp_device_close_req(req);

--- a/lib/srv/desktop/rdp/rdpclient/src/rdpdr/filesystem.rs
+++ b/lib/srv/desktop/rdp/rdpclient/src/rdpdr/filesystem.rs
@@ -74,7 +74,7 @@ impl DirectoryContext {
     fn insert_file(&mut self, file: FileCacheObject) -> Result<u32, FilesystemBackendError> {
         let path = file.fso.path.path.clone();
         self.file_cache.insert(file).inspect(|id| {
-            warn!(
+            debug!(
                 "inserted file id: {}, path: {} file_entries {}",
                 id,
                 path,
@@ -85,7 +85,7 @@ impl DirectoryContext {
 
     fn remove_file(&mut self, file_id: u32) -> Option<FileCacheObject> {
         self.file_cache.remove(file_id).inspect(|fco| {
-            warn!(
+            debug!(
                 "removed file id: {}, path: {} file_entries {}",
                 file_id,
                 &fco.path().path,
@@ -1602,11 +1602,6 @@ impl FilesystemBackend {
             ))
         }?;
 
-        warn!(
-            "sending efs::DeviceCreateResponse - status: {}, kind: {:?}",
-            u32::from(io_status),
-            &information
-        );
         self.client_handle.write_rdpdr(
             efs::DeviceCreateResponse {
                 device_io_reply: efs::DeviceIoResponse::new(
@@ -1851,10 +1846,6 @@ impl FilesystemBackend {
         io_status: NtStatus,
         buffer: Option<efs::FileInformationClass>,
     ) -> PduResult<()> {
-        warn!(
-            "sending efs::ClientDriveQueryDirectoryResponse to request: {:?}",
-            &device_io_request
-        );
         self.client_handle.write_rdpdr(
             efs::ClientDriveQueryDirectoryResponse {
                 device_io_reply: efs::DeviceIoResponse::new(device_io_request, io_status),
@@ -1872,7 +1863,6 @@ impl FilesystemBackend {
         io_status: NtStatus,
         buffer: Option<efs::FileSystemInformationClass>,
     ) -> PduResult<()> {
-        warn!("sending efs::ClientDriveQueryVolumeInformationResponse");
         self.client_handle.write_rdpdr(
             efs::ClientDriveQueryVolumeInformationResponse::new(
                 device_io_request,

--- a/lib/srv/desktop/rdp/rdpclient/src/rdpdr/filesystem.rs
+++ b/lib/srv/desktop/rdp/rdpclient/src/rdpdr/filesystem.rs
@@ -727,7 +727,8 @@ impl FilesystemBackend {
         rdp_req: efs::ServerDriveNotifyChangeDirectoryRequest,
     ) -> PduResult<()> {
         // https://github.com/FreeRDP/FreeRDP/blob/511444a65e7aa2f537c5e531fa68157a50c1bd4d/channels/drive/client/drive_main.c#L661
-        debug!("Received NotifyChangeDirectory, ignoring: {:?}", rdp_req);
+        debug!("Received NotifyChangeDirectory, cancelling: {:?}", rdp_req);
+        self.client_handle.write_rdpdr(rdp_req.cancel())?;
         Ok(())
     }
 
@@ -2213,7 +2214,9 @@ impl Cancel for efs::ServerDriveQueryInformationRequest {
         efs::ClientDriveQueryInformationResponse {
             device_io_response: efs::DeviceIoResponse::new(
                 self.device_io_request.clone(),
-                NtStatus::UNSUCCESSFUL,
+                // Testing shows that we MUST set this to "cancel" rather than UNSUCCESSFUL
+                // otherwise the rdpdr channel can end up in a broken state upon device removal.
+                NtStatus::from(0xC0000120),
             ),
             buffer: None,
         }

--- a/lib/srv/desktop/rdp/rdpclient/src/rdpdr/filesystem.rs
+++ b/lib/srv/desktop/rdp/rdpclient/src/rdpdr/filesystem.rs
@@ -259,31 +259,20 @@ impl FilesystemBackend {
     // must be retried after closing any open handles.
     pub fn mark_device_for_deletion(&mut self, device_id: u32) -> PduResult<(Vec<RdpdrPdu>, bool)> {
         let directory_context = self.cache.get_context_mut(device_id)?;
+        // Drain all pending I/O handlers and collect a list of cancellation responses.
         let cancel_pdus: Vec<RdpdrPdu> = directory_context
             .response_cache
             .drain()
             .map(|(_completion, handler)| handler.cancel())
             .collect();
 
+        // Mark as pending deletion. The FilesystemBackend will inspect this flag
+        // and automatically cancel any new I/O requests from the server.
         directory_context.marked_for_deletion = true;
-        // Drain the response cache for this directory context and cancel each handler.
 
-        // let cancel_pdus: Vec<RdpdrPdu> = pending_handlers
-        //     .iter()
-        //     .map(|(_completion, handler)| handler.cancel())
-        //     .collect();
-        //
-        //pending_handlers
-        //    .into_iter()
-        //    .for_each(|(completion_id, handler)| {
-        //        let _ = handler.cancel(self).inspect_err(|e| {
-        //            warn!(
-        //                "Failed to send cancellation response for deviceId {}, completionId {}: {}",
-        //                device_id, completion_id, e
-        //            )
-        //        });
-        //    });
-        //
+        // If the file cache is empty, then we can remove the device right away.
+        // Otherwise, we'll wait for the next device close request to try again.
+        // Pending I/O responses will be sent immediately regardless.
         if self
             .cache
             .get_context_mut(device_id)?

--- a/lib/srv/desktop/rdp/rdpclient/src/rdpdr/filesystem.rs
+++ b/lib/srv/desktop/rdp/rdpclient/src/rdpdr/filesystem.rs
@@ -30,13 +30,13 @@ use ironrdp_pdu::PduResult;
 use ironrdp_pdu::{pdu_other_err, PduError, PduErrorExt};
 use ironrdp_rdpdr::pdu::{
     self,
-    efs::{self, NtStatus},
+    efs::{self, DeviceIoResponse, NtStatus},
     esc, RdpdrPdu,
 };
 use log::{debug, trace, warn};
-use std::collections::HashMap;
 use std::convert::TryInto;
 use std::fmt::Debug;
+use std::{collections::HashMap, vec};
 
 pub(crate) fn cast_length<T, S: TryInto<T, Error: Debug>>(
     ctx: &str,
@@ -257,24 +257,33 @@ impl FilesystemBackend {
     // cancelled. This function returns Ok(true) and actually removes the device
     // if it has no open file handlers, otherwise it returns Ok(false) and removal
     // must be retried after closing any open handles.
-    pub fn mark_device_for_deletion(&mut self, device_id: u32) -> PduResult<bool> {
+    pub fn mark_device_for_deletion(&mut self, device_id: u32) -> PduResult<(Vec<RdpdrPdu>, bool)> {
         let directory_context = self.cache.get_context_mut(device_id)?;
-        let pending_handlers: Vec<(CompletionId, ResponseKind)> =
-            directory_context.response_cache.drain().collect();
+        let cancel_pdus: Vec<RdpdrPdu> = directory_context
+            .response_cache
+            .drain()
+            .map(|(_completion, handler)| handler.cancel())
+            .collect();
 
         directory_context.marked_for_deletion = true;
         // Drain the response cache for this directory context and cancel each handler.
-        pending_handlers
-            .into_iter()
-            .for_each(|(completion_id, handler)| {
-                let _ = handler.cancel(self).inspect_err(|e| {
-                    warn!(
-                        "Failed to send cancellation response for deviceId {}, completionId {}: {}",
-                        device_id, completion_id, e
-                    )
-                });
-            });
 
+        // let cancel_pdus: Vec<RdpdrPdu> = pending_handlers
+        //     .iter()
+        //     .map(|(_completion, handler)| handler.cancel())
+        //     .collect();
+        //
+        //pending_handlers
+        //    .into_iter()
+        //    .for_each(|(completion_id, handler)| {
+        //        let _ = handler.cancel(self).inspect_err(|e| {
+        //            warn!(
+        //                "Failed to send cancellation response for deviceId {}, completionId {}: {}",
+        //                device_id, completion_id, e
+        //            )
+        //        });
+        //    });
+        //
         if self
             .cache
             .get_context_mut(device_id)?
@@ -284,11 +293,11 @@ impl FilesystemBackend {
         {
             // File cache is empty. It's safe to remove this device.
             self.cache.remove_device(device_id)?;
-            Ok(true)
+            Ok((cancel_pdus, true))
         } else {
             // File cache is not empty. We'll need to wait for the server to
             // close any open file handles first.
-            Ok(false)
+            Ok((cancel_pdus, false))
         }
     }
 
@@ -330,7 +339,12 @@ impl FilesystemBackend {
             // All other requests are cancelled.
             match req {
                 efs::ServerDriveIoRequest::DeviceCloseRequest(_) => {}
-                _ => return req.cancel(self),
+                _ => {
+                    return self
+                        .client_handle
+                        .write_rdpdr(req.cancel())
+                        .map_err(|err| err.into())
+                }
             }
         }
 
@@ -2112,133 +2126,161 @@ impl std::error::Error for FilesystemBackendError {}
 
 // Cancel allows us implement generic cancellation methods for various efs::<request> types
 trait Cancel {
-    fn cancel(&self, this: &mut FilesystemBackend) -> PduResult<()>;
+    fn cancel(&self) -> RdpdrPdu;
 }
 
 impl Cancel for efs::DeviceCreateRequest {
-    fn cancel(&self, this: &mut FilesystemBackend) -> PduResult<()> {
-        this.send_rdp_device_create_response(self, NtStatus::UNSUCCESSFUL, 0)
+    fn cancel(&self) -> RdpdrPdu {
+        efs::DeviceCreateResponse {
+            device_io_reply: DeviceIoResponse {
+                device_id: self.device_io_request.device_id,
+                completion_id: self.device_io_request.completion_id,
+                io_status: NtStatus::UNSUCCESSFUL,
+            },
+            file_id: 0,
+            information: efs::Information::empty(),
+        }
+        .into()
     }
 }
 
 impl Cancel for efs::ServerDriveQueryDirectoryRequest {
-    fn cancel(&self, this: &mut FilesystemBackend) -> PduResult<()> {
-        this.send_rdp_drive_query_dir_response(
-            self.device_io_request.clone(),
-            NtStatus::UNSUCCESSFUL,
-            None,
-        )
+    fn cancel(&self) -> RdpdrPdu {
+        efs::ClientDriveQueryDirectoryResponse {
+            device_io_reply: efs::DeviceIoResponse::new(
+                self.device_io_request.clone(),
+                NtStatus::UNSUCCESSFUL,
+            ),
+            buffer: None,
+        }
+        .into()
     }
 }
 
 impl Cancel for efs::DeviceReadRequest {
-    fn cancel(&self, this: &mut FilesystemBackend) -> PduResult<()> {
-        this.send_rdp_read_response(
-            self.device_io_request.clone(),
-            NtStatus::UNSUCCESSFUL,
-            vec![],
-        )
+    fn cancel(&self) -> RdpdrPdu {
+        efs::DeviceReadResponse {
+            device_io_reply: efs::DeviceIoResponse::new(
+                self.device_io_request.clone(),
+                NtStatus::UNSUCCESSFUL,
+            ),
+            read_data: vec![],
+        }
+        .into()
     }
 }
 
 impl Cancel for efs::DeviceWriteRequest {
-    fn cancel(&self, this: &mut FilesystemBackend) -> PduResult<()> {
-        this.send_rdp_write_response(self.device_io_request.clone(), NtStatus::UNSUCCESSFUL, 0)
+    fn cancel(&self) -> RdpdrPdu {
+        efs::DeviceWriteResponse {
+            device_io_reply: efs::DeviceIoResponse::new(
+                self.device_io_request.clone(),
+                NtStatus::UNSUCCESSFUL,
+            ),
+            length: 0,
+        }
+        .into()
     }
 }
 
 impl Cancel for efs::ServerDriveSetInformationRequest {
-    fn cancel(&self, this: &mut FilesystemBackend) -> PduResult<()> {
-        this.send_rdp_set_info_response(self, NtStatus::UNSUCCESSFUL)
+    fn cancel(&self) -> RdpdrPdu {
+        efs::ClientDriveSetInformationResponse::new(self, NtStatus::UNSUCCESSFUL)
+            .map(|resp| resp.into())
+            .unwrap_or(RdpdrPdu::EmptyResponse)
     }
 }
 
 impl Cancel for efs::DeviceCloseRequest {
-    fn cancel(&self, this: &mut FilesystemBackend) -> PduResult<()> {
-        this.send_rdp_device_close_response(self.clone(), NtStatus::UNSUCCESSFUL)
+    fn cancel(&self) -> RdpdrPdu {
+        efs::DeviceCloseResponse {
+            device_io_response: efs::DeviceIoResponse::new(
+                self.device_io_request.clone(),
+                NtStatus::UNSUCCESSFUL,
+            ),
+        }
+        .into()
     }
 }
 
 impl Cancel for efs::ServerDriveNotifyChangeDirectoryRequest {
-    fn cancel(&self, this: &mut FilesystemBackend) -> PduResult<()> {
-        this.client_handle
-            .write_rdpdr(RdpdrPdu::ClientDriveQueryDirectoryResponse(
-                efs::ClientDriveQueryDirectoryResponse {
-                    device_io_reply: efs::DeviceIoResponse {
-                        device_id: self.device_io_request.device_id,
-                        completion_id: self.device_io_request.completion_id,
-                        // https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-erref/596a1078-e883-4972-9bbc-49e60bebca55
-                        // STATUS_CANCELLED - 0xC0000120
-                        io_status: NtStatus::from(0xC0000120),
-                    },
-                    buffer: None,
-                },
-            ))?;
-        Ok(())
+    fn cancel(&self) -> RdpdrPdu {
+        efs::ClientDriveQueryDirectoryResponse {
+            device_io_reply: efs::DeviceIoResponse {
+                device_id: self.device_io_request.device_id,
+                completion_id: self.device_io_request.completion_id,
+                // https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-erref/596a1078-e883-4972-9bbc-49e60bebca55
+                // STATUS_CANCELLED - 0xC0000120
+                io_status: NtStatus::from(0xC0000120),
+            },
+            buffer: None,
+        }
+        .into()
     }
 }
 
 impl Cancel for efs::ServerDriveQueryInformationRequest {
-    fn cancel(&self, this: &mut FilesystemBackend) -> PduResult<()> {
-        this.send_rdp_client_drive_query_info_response(self.clone(), None)?;
-        Ok(())
+    fn cancel(&self) -> RdpdrPdu {
+        efs::ClientDriveQueryInformationResponse {
+            device_io_response: efs::DeviceIoResponse::new(
+                self.device_io_request.clone(),
+                NtStatus::UNSUCCESSFUL,
+            ),
+            buffer: None,
+        }
+        .into()
     }
 }
 impl Cancel for efs::ServerDriveQueryVolumeInformationRequest {
-    fn cancel(&self, this: &mut FilesystemBackend) -> PduResult<()> {
-        this.handle_rdp_query_volume_req(self.clone())?;
-        Ok(())
+    fn cancel(&self) -> RdpdrPdu {
+        efs::ClientDriveQueryVolumeInformationResponse::new(
+            self.device_io_request.clone(),
+            NtStatus::UNSUCCESSFUL,
+            None,
+        )
+        .into()
     }
 }
 impl Cancel for efs::DeviceControlRequest<efs::AnyIoCtlCode> {
-    fn cancel(&self, this: &mut FilesystemBackend) -> PduResult<()> {
-        this.handle_rdp_device_control_req(self.clone())?;
-        Ok(())
+    fn cancel(&self) -> RdpdrPdu {
+        efs::DeviceControlResponse::new(self.clone(), NtStatus::UNSUCCESSFUL, None).into()
     }
 }
 impl Cancel for efs::ServerDriveLockControlRequest {
-    fn cancel(&self, this: &mut FilesystemBackend) -> PduResult<()> {
-        this.handle_rdp_lock_req(self.clone())?;
-        Ok(())
+    fn cancel(&self) -> RdpdrPdu {
+        RdpdrPdu::EmptyResponse
     }
 }
 
-enum HandlerInput<T> {
-    Response(T),
-    Cancel,
-}
+trait HandlerFn<T>: FnOnce(&mut FilesystemBackend, T) -> PduResult<()> + Send {}
 
-trait HandlerFn<T>: FnOnce(&mut FilesystemBackend, HandlerInput<T>) -> PduResult<()> + Send {}
-
-impl<T, F> HandlerFn<T> for F where
-    F: FnOnce(&mut FilesystemBackend, HandlerInput<T>) -> PduResult<()> + Send
-{
-}
+impl<T, F> HandlerFn<T> for F where F: FnOnce(&mut FilesystemBackend, T) -> PduResult<()> + Send {}
 
 struct ResponseHandler<T> {
+    cancellable: Box<dyn Cancel + Send>,
     handler: Box<dyn HandlerFn<T>>,
 }
 
+// Write a function whose return type depends on the input
+
 // ResponseHandler is allowed to either invoke 'call' XOR 'cancel' exactly once.
 impl<T> ResponseHandler<T> {
-    fn new<R: Cancel + Send + 'static>(
+    fn new<R: Cancel + Clone + Send + 'static>(
         req: R,
         handler: impl FnOnce(&mut FilesystemBackend, T, R) -> PduResult<()> + Send + 'static,
     ) -> Self {
         Self {
-            handler: Box::new(move |this, input| match input {
-                HandlerInput::Response(res) => handler(this, res, req),
-                HandlerInput::Cancel => req.cancel(this),
-            }),
+            cancellable: Box::new(req.clone()),
+            handler: Box::new(move |this, input| handler(this, input, req)),
         }
     }
 
     fn call(self, this: &mut FilesystemBackend, res: T) -> PduResult<()> {
-        (self.handler)(this, HandlerInput::Response(res))
+        (self.handler)(this, res)
     }
 
-    fn cancel(self, this: &mut FilesystemBackend) -> PduResult<()> {
-        (self.handler)(this, HandlerInput::Cancel)
+    fn cancel(self) -> RdpdrPdu {
+        self.cancellable.cancel()
     }
 }
 
@@ -2270,16 +2312,16 @@ enum ResponseKind {
 }
 
 impl ResponseKind {
-    fn cancel(self, this: &mut FilesystemBackend) -> PduResult<()> {
+    fn cancel(self) -> RdpdrPdu {
         match self {
-            ResponseKind::Info(h) => h.cancel(this),
-            ResponseKind::Create(h) => h.cancel(this),
-            ResponseKind::Delete(h) => h.cancel(this),
-            ResponseKind::List(h) => h.cancel(this),
-            ResponseKind::Read(h) => h.cancel(this),
-            ResponseKind::Write(h) => h.cancel(this),
-            ResponseKind::Move(h) => h.cancel(this),
-            ResponseKind::Truncate(h) => h.cancel(this),
+            ResponseKind::Info(h) => h.cancel(),
+            ResponseKind::Create(h) => h.cancel(),
+            ResponseKind::Delete(h) => h.cancel(),
+            ResponseKind::List(h) => h.cancel(),
+            ResponseKind::Read(h) => h.cancel(),
+            ResponseKind::Write(h) => h.cancel(),
+            ResponseKind::Move(h) => h.cancel(),
+            ResponseKind::Truncate(h) => h.cancel(),
         }
     }
 }
@@ -2457,21 +2499,19 @@ impl ResponseCache {
 }
 
 impl Cancel for efs::ServerDriveIoRequest {
-    fn cancel(&self, this: &mut FilesystemBackend) -> PduResult<()> {
+    fn cancel(&self) -> RdpdrPdu {
         match self {
-            efs::ServerDriveIoRequest::ServerCreateDriveRequest(h) => h.cancel(this),
-            efs::ServerDriveIoRequest::ServerDriveQueryInformationRequest(h) => h.cancel(this),
-            efs::ServerDriveIoRequest::DeviceCloseRequest(h) => h.cancel(this),
-            efs::ServerDriveIoRequest::ServerDriveQueryDirectoryRequest(h) => h.cancel(this),
-            efs::ServerDriveIoRequest::ServerDriveNotifyChangeDirectoryRequest(h) => h.cancel(this),
-            efs::ServerDriveIoRequest::ServerDriveQueryVolumeInformationRequest(h) => {
-                h.cancel(this)
-            }
-            efs::ServerDriveIoRequest::DeviceControlRequest(h) => h.cancel(this),
-            efs::ServerDriveIoRequest::DeviceReadRequest(h) => h.cancel(this),
-            efs::ServerDriveIoRequest::DeviceWriteRequest(h) => h.cancel(this),
-            efs::ServerDriveIoRequest::ServerDriveSetInformationRequest(h) => h.cancel(this),
-            efs::ServerDriveIoRequest::ServerDriveLockControlRequest(h) => h.cancel(this),
+            efs::ServerDriveIoRequest::ServerCreateDriveRequest(h) => h.cancel(),
+            efs::ServerDriveIoRequest::ServerDriveQueryInformationRequest(h) => h.cancel(),
+            efs::ServerDriveIoRequest::DeviceCloseRequest(h) => h.cancel(),
+            efs::ServerDriveIoRequest::ServerDriveQueryDirectoryRequest(h) => h.cancel(),
+            efs::ServerDriveIoRequest::ServerDriveNotifyChangeDirectoryRequest(h) => h.cancel(),
+            efs::ServerDriveIoRequest::ServerDriveQueryVolumeInformationRequest(h) => h.cancel(),
+            efs::ServerDriveIoRequest::DeviceControlRequest(h) => h.cancel(),
+            efs::ServerDriveIoRequest::DeviceReadRequest(h) => h.cancel(),
+            efs::ServerDriveIoRequest::DeviceWriteRequest(h) => h.cancel(),
+            efs::ServerDriveIoRequest::ServerDriveSetInformationRequest(h) => h.cancel(),
+            efs::ServerDriveIoRequest::ServerDriveLockControlRequest(h) => h.cancel(),
         }
     }
 }

--- a/lib/srv/desktop/windows_server.go
+++ b/lib/srv/desktop/windows_server.go
@@ -900,10 +900,27 @@ func (s *WindowsService) connectRDP(ctx context.Context, log *slog.Logger, tdpCo
 	sendInterceptor := asInterceptor(s.makeTDPSendAuditor(ctx, recorder, delay, audit))
 	receiveInterceptor := asInterceptor(s.makeTDPReceiveAuditor(ctx, recorder, delay, audit))
 
+	// TODO(rhammonds): Remove in v20
+	// Some v18 and older clients assume that TDP connections support only a single
+	// shared directory. For this reason, they omit the DirectoryId from their
+	// response messages. These clients also hardcode the DirectoryId to '2'.
+	// To ensure conflicts are avoided, the backend will reject directory announcements
+	// that choose DirectoryId 0 and "fix" omitted DirectoryId fields.
+	// We need to run this mutation early in the connection so that it gets picked up
+	// by the inbound audit interceptor.
+	sharedDirectoryResponseModernizer := tdp.NewReadWriteInterceptor(translatedConn, func(message tdp.Message) ([]tdp.Message, error) {
+		if sdResponse, ok := message.(*tdpb.SharedDirectoryResponse); ok {
+			if sdResponse.DirectoryId == 0 {
+				sdResponse.DirectoryId = 2
+			}
+		}
+		return []tdp.Message{message}, nil
+	}, nil /* No write handler needed */)
+
 	// These hooks snoop for TDPB messages (ignoring legacy TDP) to create necessary audit events.
 	// The client emits only TDPB messages natively, so as long as we run these hooks *above* the translation
 	// interceptors they will be able to properly interpret inbound/outbound messages for audit.
-	auditedConn := tdp.NewReadWriteInterceptor(translatedConn, receiveInterceptor, sendInterceptor)
+	auditedConn := tdp.NewReadWriteInterceptor(sharedDirectoryResponseModernizer, receiveInterceptor, sendInterceptor)
 
 	//nolint:staticcheck // SA4023. False positive, depends on build tags.
 	rdpc, err := rdpclient.New(auditedConn, hello, rdpclient.Config{


### PR DESCRIPTION
This PR prepares the Windows Desktop backend for multi-directory sharing support by addressing two issues:
1. Pending response handlers must be scoped to a tuple (DeviceId, CompletionId), rather than just a CompletionId as it is currently implemented. ([MS-RDPEFS 3.1.5.1](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpefs/1a8715b1-3afc-4bd7-8ec2-9625a9ce9610))
2. Fixes an issue that occurs when a directory is unshared while the RDP Server has open file handles with the client. When the client wishes to close a directory, we cannot simply emit a removal message ([DR_DEVICELIST_REMOVE](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpefs/13bd4c0a-e674-47a5-b317-50a835defb55)). Instead, we must cancel all pending I/O responses and wait for the server to close any open files. Otherwise, the RDP Server will enter an error state and ignore any future requests on the RDPDR channel. 


The latter is implemented by putting "removed" devices in an intermediate state where all pending and future I/O requests are immediately cancelled. Only device close requests are processed. Only once all outstanding file handles are closed can we finally announce to the RDP Server that we're removing the device.

<!-- Provide a descriptive entry for the changelog of the next release. -->


<!-- Include manual testing efforts to verify the change. -->
<!-- Detail where the tests where run and what configurations were used. -->
<!-- Include all the test cases which were run to validate the change. -->

## Manual Test Plan
### Test Environment
Two local clusters each with at least one Windows Desktop resource. 
The cluster first should be built directly off of this branch. The other should merge this branch into the working branch for #65952 so that we can test against a client that supports sharing multiple directories.

### Test Cases
- Current Client (supports single directory sharing)
  - [x] Directory sharing succeeds and typical shared directory operations behave as expected.
- "New" client (supports sharing multiple directories)
  - [x] Directory sharing succeeds and typical shared directory operations behave as expected.
  - [x] Open a shared directory in Windows Explorer that has at least a dozen files. While Explorer enumerates the root directory, unshare the it. The progress bar in Explorer should abruptly complete and Explorer should remove the shared directory from the side panel. 
  - [x] Repeat the test above several times (The behavior that this PR fixes is a race, but it is consistently reproducible. It occurs more often than one).
  - [x] Confirm that subsequent share/remove operations succeed after the tests above. 