### PR TITLE
Generic RFD153 Scopes Aware Service

### DIFF
--- a/lib/services/local/generic/resource_adapter.go
+++ b/lib/services/local/generic/resource_adapter.go
@@ -47,3 +47,20 @@ func (w resourceMetadataAdapter[T]) GetMetadata() *headerv1.Metadata {
 func (w resourceMetadataAdapter[T]) GetName() string {
 	return w.resource.GetMetadata().GetName()
 }
+
+// scopedResourceMetadataAdapter extends resourceMetadataAdapter for RFD 153-style
+// resources that additionally carry a scope. For inner types T which implement
+// ScopedResourceMetadata, the adapter implements ScopedResource, making the
+// resource usable with ScopeAwareService.
+type scopedResourceMetadataAdapter[T ScopedResourceMetadata] struct {
+	resourceMetadataAdapter[T]
+}
+
+func newScopedResourceMetadataAdapter[T ScopedResourceMetadata](t T) scopedResourceMetadataAdapter[T] {
+	return scopedResourceMetadataAdapter[T]{newResourceMetadataAdapter(t)}
+}
+
+// GetScope returns the scope of the inner resource. Required for ScopedResource.
+func (w scopedResourceMetadataAdapter[T]) GetScope() string {
+	return w.resource.GetScope()
+}

--- a/lib/services/local/generic/scopeaware_wrapper.go
+++ b/lib/services/local/generic/scopeaware_wrapper.go
@@ -40,7 +40,7 @@ type ScopedResourceMetadata interface {
 }
 
 // NewScopeAwareServiceWrapper returns a new scope-aware generic service wrapper.
-// It is the RFD 153 analogue of ScopeAwareService: scoped resources are stored
+// It is the RFD 153 analog of ScopeAwareService: scoped resources are stored
 // in a separate, scope-namespaced key range from unscoped resources, and the
 // wrapper transparently routes reads and writes to the correct range.
 func NewScopeAwareServiceWrapper[T ScopedResourceMetadata](cfg ScopeAwareServiceWrapperConfig[T]) (*ScopeAwareServiceWrapper[T], error) {

--- a/lib/services/local/generic/scopeaware_wrapper.go
+++ b/lib/services/local/generic/scopeaware_wrapper.go
@@ -1,0 +1,214 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package generic
+
+import (
+	"context"
+	"iter"
+	"time"
+
+	"github.com/gravitational/trace"
+
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/backend"
+	"github.com/gravitational/teleport/lib/scopes"
+	"github.com/gravitational/teleport/lib/services"
+)
+
+// ScopedResourceMetadata is an RFD 153-style resource that additionally carries
+// a scope. The scope may be empty on any individual resource, in which case the
+// resource is unscoped (classic behavior).
+type ScopedResourceMetadata interface {
+	types.ResourceMetadata
+	// GetScope returns the scope of the resource. An empty scope indicates the
+	// resource is unscoped.
+	GetScope() string
+}
+
+// NewScopeAwareServiceWrapper returns a new scope-aware generic service wrapper.
+// It is the RFD 153 analogue of ScopeAwareService: scoped resources are stored
+// in a separate, scope-namespaced key range from unscoped resources, and the
+// wrapper transparently routes reads and writes to the correct range.
+func NewScopeAwareServiceWrapper[T ScopedResourceMetadata](cfg ScopeAwareServiceWrapperConfig[T]) (*ScopeAwareServiceWrapper[T], error) {
+	serviceConfig := &ScopeAwareServiceConfig[scopedResourceMetadataAdapter[T]]{
+		Backend:               cfg.Backend,
+		ResourceKind:          cfg.ResourceKind,
+		PageLimit:             cfg.PageLimit,
+		UnscopedBackendPrefix: cfg.UnscopedBackendPrefix,
+		ScopedBackendPrefix:   cfg.ScopedBackendPrefix,
+		MarshalFunc: func(w scopedResourceMetadataAdapter[T], opts ...services.MarshalOption) ([]byte, error) {
+			return cfg.MarshalFunc(w.resource, opts...)
+		},
+		UnmarshalFunc: func(bytes []byte, opts ...services.MarshalOption) (scopedResourceMetadataAdapter[T], error) {
+			r, err := cfg.UnmarshalFunc(bytes, opts...)
+			return newScopedResourceMetadataAdapter(r), trace.Wrap(err)
+		},
+		RunWhileLockedRetryInterval: cfg.RunWhileLockedRetryInterval,
+	}
+
+	if cfg.ValidateFunc != nil {
+		serviceConfig.ValidateFunc = func(w scopedResourceMetadataAdapter[T]) error {
+			return cfg.ValidateFunc(w.resource)
+		}
+	}
+
+	service, err := NewScopeAwareService(serviceConfig)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return &ScopeAwareServiceWrapper[T]{service: service}, nil
+}
+
+// ScopeAwareServiceWrapperConfig holds configuration options for a
+// ScopeAwareServiceWrapper. It mirrors ScopeAwareServiceConfig but operates on
+// the bare RFD 153 resource type T rather than an adapter.
+type ScopeAwareServiceWrapperConfig[T ScopedResourceMetadata] struct {
+	// Backend used to persist the resource.
+	Backend backend.Backend
+	// ResourceKind is the friendly name of the resource.
+	ResourceKind string
+	// UnscopedBackendPrefix used when constructing the [backend.Item.Key] for unscoped resources.
+	UnscopedBackendPrefix backend.Key
+	// ScopedBackendPrefix used when constructing the [backend.Item.Key] for scoped resources.
+	ScopedBackendPrefix backend.Key
+	// PageLimit is the maximum number of resources returned in a single page.
+	PageLimit uint
+	// MarshalFunc converts the resource to bytes for persistence.
+	MarshalFunc MarshalFunc[T]
+	// UnmarshalFunc converts the bytes read from the backend to the resource.
+	UnmarshalFunc UnmarshalFunc[T]
+	// ValidateFunc optionally validates the resource prior to persisting it. Any errors
+	// returned from the validation function will prevent writes to the backend.
+	ValidateFunc func(T) error
+	// RunWhileLockedRetryInterval is the interval to retry the RunWhileLocked function.
+	// If set to 0, the default interval of 250ms will be used.
+	// WARNING: If set to a negative value, the RunWhileLocked function will retry immediately.
+	RunWhileLockedRetryInterval time.Duration
+}
+
+// ScopeAwareServiceWrapper is an adapter for ScopeAwareService that makes it
+// usable with RFD 153-style resources which implement ScopedResourceMetadata.
+//
+// As with ServiceWrapper, not all methods of the underlying service are
+// exported; additional methods may be exported in the future as needed.
+type ScopeAwareServiceWrapper[T ScopedResourceMetadata] struct {
+	service *ScopeAwareService[scopedResourceMetadataAdapter[T]]
+}
+
+// CreateResource creates the given resource if it doesn't already exist. The
+// resource is stored in the unscoped key range if its scope is empty, else in
+// the scope-namespaced key range.
+func (s *ScopeAwareServiceWrapper[T]) CreateResource(ctx context.Context, resource T) (T, error) {
+	adapter, err := s.service.CreateResource(ctx, newScopedResourceMetadataAdapter(resource))
+	return adapter.resource, trace.Wrap(err)
+}
+
+// UpsertResource upserts the given resource into the key range determined by its scope.
+func (s *ScopeAwareServiceWrapper[T]) UpsertResource(ctx context.Context, resource T) (T, error) {
+	adapter, err := s.service.UpsertResource(ctx, newScopedResourceMetadataAdapter(resource))
+	return adapter.resource, trace.Wrap(err)
+}
+
+// ConditionalUpdateResource updates the given resource if the provided and
+// existing revisions match, in the key range determined by its scope.
+func (s *ScopeAwareServiceWrapper[T]) ConditionalUpdateResource(ctx context.Context, resource T) (T, error) {
+	adapter, err := s.service.ConditionalUpdateResource(ctx, newScopedResourceMetadataAdapter(resource))
+	return adapter.resource, trace.Wrap(err)
+}
+
+// GetResource returns the resource for the given scope-qualified name. An empty
+// scope reads from the unscoped key range.
+func (s *ScopeAwareServiceWrapper[T]) GetResource(ctx context.Context, name scopes.QualifiedName) (T, error) {
+	adapter, err := s.service.GetResource(ctx, name)
+	return adapter.resource, trace.Wrap(err)
+}
+
+// DeleteResource deletes the resource for the given scope-qualified name. An
+// empty scope deletes from the unscoped key range.
+func (s *ScopeAwareServiceWrapper[T]) DeleteResource(ctx context.Context, name scopes.QualifiedName) error {
+	return trace.Wrap(s.service.DeleteResource(ctx, name))
+}
+
+// DeleteAllResources deletes all scoped and unscoped resources.
+func (s *ScopeAwareServiceWrapper[T]) DeleteAllResources(ctx context.Context) error {
+	return trace.Wrap(s.service.DeleteAllResources(ctx))
+}
+
+// ListResources returns a page of resources over the unified scoped and
+// unscoped collection. All unscoped resources are returned before scoped ones.
+func (s *ScopeAwareServiceWrapper[T]) ListResources(ctx context.Context, pageSize int, nextToken string) ([]T, string, error) {
+	return s.ListResourcesWithFilter(ctx, pageSize, nextToken, func(T) bool { return true })
+}
+
+// ListResourcesWithFilter returns a page of matching resources over the unified
+// scoped and unscoped collection. All matching unscoped resources are returned
+// before matching scoped ones.
+func (s *ScopeAwareServiceWrapper[T]) ListResourcesWithFilter(ctx context.Context, pageSize int, nextToken string, matcher func(T) bool) ([]T, string, error) {
+	adapters, next, err := s.service.ListResourcesWithFilter(ctx, pageSize, nextToken, func(w scopedResourceMetadataAdapter[T]) bool {
+		return matcher(w.resource)
+	})
+	if err != nil {
+		return nil, "", trace.Wrap(err)
+	}
+	out := make([]T, 0, len(adapters))
+	for _, adapter := range adapters {
+		out = append(out, adapter.resource)
+	}
+	return out, next, nil
+}
+
+// Resources returns a stream of resources within the unified scope-aware range
+// [startKey, endKey). Unscoped resources are ordered before scoped resources.
+// The startKey and endKey values are resource cursors as defined by
+// [scopes.MakeResourceCursor].
+//
+// This method may be used to implement RangeFoo.
+func (s *ScopeAwareServiceWrapper[T]) Resources(ctx context.Context, startKey, endKey string) iter.Seq2[T, error] {
+	return func(yield func(T, error) bool) {
+		for adapter, err := range s.service.Resources(ctx, startKey, endKey) {
+			if err != nil {
+				var t T
+				yield(t, err)
+				return
+			}
+			if !yield(adapter.resource, nil) {
+				return
+			}
+		}
+	}
+}
+
+// MakeBackendItem returns a backend.Item for the given resource, keyed within
+// the unscoped or scope-namespaced range according to the resource's scope.
+func (s *ScopeAwareServiceWrapper[T]) MakeBackendItem(resource T) (backend.Item, error) {
+	svc, err := s.service.WithScopePrefix(resource.GetScope())
+	if err != nil {
+		return backend.Item{}, trace.Wrap(err)
+	}
+	return svc.MakeBackendItem(newScopedResourceMetadataAdapter(resource))
+}
+
+// BackendKey returns the backend.Key for the resource with the given
+// scope-qualified name, within the unscoped or scope-namespaced range according
+// to its scope.
+func (s *ScopeAwareServiceWrapper[T]) BackendKey(name scopes.QualifiedName) (backend.Key, error) {
+	svc, err := s.service.WithScopePrefix(name.Scope)
+	if err != nil {
+		return backend.Key{}, trace.Wrap(err)
+	}
+	return svc.resourceKey(name.Name), nil
+}

--- a/lib/services/local/generic/scopeaware_wrapper_test.go
+++ b/lib/services/local/generic/scopeaware_wrapper_test.go
@@ -1,0 +1,599 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package generic
+
+import (
+	"fmt"
+	"iter"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gravitational/trace"
+	"github.com/jonboulle/clockwork"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
+	"github.com/gravitational/teleport/lib/backend"
+	"github.com/gravitational/teleport/lib/backend/memory"
+	"github.com/gravitational/teleport/lib/scopes"
+	"github.com/gravitational/teleport/lib/services"
+	"github.com/gravitational/teleport/lib/utils"
+)
+
+const (
+	// testUnscopedPrefix is the backend prefix the test wrapper uses for unscoped
+	// resources.
+	testUnscopedPrefix = "generic_prefix"
+	// testScopedTopPrefix is the top-level backend prefix under which the test
+	// wrapper namespaces scoped resources.
+	testScopedTopPrefix = "scoped"
+)
+
+type scopedTestResource153 struct {
+	Metadata *headerv1.Metadata
+	Scope    string
+	Spec     scopedTestResource153Spec
+}
+
+type scopedTestResource153Spec struct {
+	Data string
+}
+
+func (t *scopedTestResource153) GetMetadata() *headerv1.Metadata {
+	return t.Metadata
+}
+
+func (t *scopedTestResource153) GetScope() string {
+	return t.Scope
+}
+
+func specDataFor(sqn scopes.QualifiedName) string {
+	return fmt.Sprintf("spec-data(scope=%q,name=%q)", sqn.Scope, sqn.Name)
+}
+
+func newScopedTestResource153(sqn scopes.QualifiedName) *scopedTestResource153 {
+	tr := &scopedTestResource153{
+		Metadata: headerv1.Metadata_builder{Name: sqn.Name}.Build(),
+		Scope:    sqn.Scope,
+		Spec:     scopedTestResource153Spec{Data: specDataFor(sqn)},
+	}
+	tr.Metadata.SetExpires(timestamppb.New(time.Now().AddDate(0, 0, 3)))
+	return tr
+}
+
+func marshalScopedResource153(resource *scopedTestResource153, opts ...services.MarshalOption) ([]byte, error) {
+	// TODO(strideynet): It feels a little janky utilising fast marshal rather
+	// than Proto marshal (which is what 99.9% of RFD153 resources are going to
+	// use). Could we add a "foo" resource to `/api` for testing?
+	return utils.FastMarshal(resource)
+}
+
+func unmarshalScopedResource153(data []byte, opts ...services.MarshalOption) (*scopedTestResource153, error) {
+	if len(data) == 0 {
+		return nil, trace.BadParameter("missing resource data")
+	}
+	cfg, err := services.CollectOptions(opts)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	var r scopedTestResource153
+	if err := utils.FastUnmarshal(data, &r); err != nil {
+		return nil, trace.BadParameter("%s", err)
+	}
+	if r.Metadata == nil {
+		r.Metadata = &headerv1.Metadata{}
+	}
+	if cfg.Revision != "" {
+		r.Metadata.SetRevision(cfg.Revision)
+	}
+	if !cfg.Expires.IsZero() {
+		r.Metadata.SetExpires(timestamppb.New(cfg.Expires))
+	}
+	return &r, nil
+}
+
+func newScopeAwareWrapperForTest(t *testing.T) *ScopeAwareServiceWrapper[*scopedTestResource153] {
+	t.Helper()
+
+	memBackend, err := memory.New(memory.Config{
+		Context: t.Context(),
+		Clock:   clockwork.NewFakeClock(),
+	})
+	require.NoError(t, err)
+
+	service, err := NewScopeAwareServiceWrapper(ScopeAwareServiceWrapperConfig[*scopedTestResource153]{
+		Backend:               memBackend,
+		ResourceKind:          "scoped_generic_resource",
+		UnscopedBackendPrefix: backend.NewKey(testUnscopedPrefix),
+		ScopedBackendPrefix:   backend.NewKey(testScopedTopPrefix, testUnscopedPrefix),
+		PageLimit:             200,
+		MarshalFunc:           marshalScopedResource153,
+		UnmarshalFunc:         unmarshalScopedResource153,
+	})
+	require.NoError(t, err)
+	return service
+}
+
+func names(resources []*scopedTestResource153) []scopes.QualifiedName {
+	out := make([]scopes.QualifiedName, 0, len(resources))
+	for _, r := range resources {
+		out = append(out, scopes.QualifiedName{Scope: r.GetScope(), Name: r.GetMetadata().GetName()})
+	}
+	return out
+}
+
+func collectStream(t *testing.T, seq iter.Seq2[*scopedTestResource153, error]) []*scopedTestResource153 {
+	t.Helper()
+	var out []*scopedTestResource153
+	for r, err := range seq {
+		require.NoError(t, err)
+		out = append(out, r)
+	}
+	return out
+}
+
+// requireResourceBody asserts the resource read back carries exactly the body we
+// stored for the given scope-qualified name. Because the spec data is never
+// encoded in the backend key, its correct round-trip proves the whole resource
+// body — including its scope — is sourced from the persisted value, and not
+// reconstructed from the storage key.
+func requireResourceBody(t *testing.T, want scopes.QualifiedName, got *scopedTestResource153) {
+	t.Helper()
+	require.Equal(t, want.Name, got.GetMetadata().GetName())
+	require.Equal(t, want.Scope, got.GetScope())
+	require.Equal(t, specDataFor(want), got.Spec.Data)
+}
+
+// TestScopeAwareServiceWrapper_E2E is an end-to-end smoke test that
+// exercises the key behaviors in order.
+func TestScopeAwareServiceWrapper_E2E(t *testing.T) {
+	t.Parallel()
+	svc := newScopeAwareWrapperForTest(t)
+	ctx := t.Context()
+
+	unscoped := scopes.QualifiedName{Name: "foo"}
+	scoped := scopes.QualifiedName{Scope: "/security", Name: "foo"}
+
+	// A scoped and an unscoped resource may share a name; they live in distinct
+	// key ranges.
+	_, err := svc.CreateResource(ctx, newScopedTestResource153(unscoped))
+	require.NoError(t, err)
+	_, err = svc.CreateResource(ctx, newScopedTestResource153(scoped))
+	require.NoError(t, err)
+
+	// Each resolves only under its own scope-qualified name, returning the body
+	// stored for that scope.
+	got, err := svc.GetResource(ctx, unscoped)
+	require.NoError(t, err)
+	requireResourceBody(t, unscoped, got)
+
+	got, err = svc.GetResource(ctx, scoped)
+	require.NoError(t, err)
+	requireResourceBody(t, scoped, got)
+
+	// An unscoped name does not resolve under a scope, and a scoped name does
+	// not resolve as unscoped.
+	_, err = svc.GetResource(ctx, scopes.QualifiedName{Scope: "/other", Name: "foo"})
+	require.True(t, trace.IsNotFound(err), "expected not found, got %v", err)
+
+	// Deleting one leaves the other intact.
+	require.NoError(t, svc.DeleteResource(ctx, unscoped))
+	_, err = svc.GetResource(ctx, unscoped)
+	require.True(t, trace.IsNotFound(err), "expected not found, got %v", err)
+	_, err = svc.GetResource(ctx, scoped)
+	require.NoError(t, err)
+}
+
+func TestScopeAwareServiceWrapper_CreateResource(t *testing.T) {
+	t.Parallel()
+	svc := newScopeAwareWrapperForTest(t)
+	ctx := t.Context()
+
+	t.Run("creates unscoped and scoped resources", func(t *testing.T) {
+		for _, qn := range []scopes.QualifiedName{
+			{Name: "foo"},
+			{Scope: "/security", Name: "foo"},
+		} {
+			created, err := svc.CreateResource(ctx, newScopedTestResource153(qn))
+			require.NoError(t, err)
+			require.NotEmpty(t, created.GetMetadata().GetRevision(), "create must populate a revision")
+
+			got, err := svc.GetResource(ctx, qn)
+			require.NoError(t, err)
+			requireResourceBody(t, qn, got)
+		}
+	})
+
+	t.Run("rejects duplicate within the same scope", func(t *testing.T) {
+		qn := scopes.QualifiedName{Scope: "/eng", Name: "dup"}
+		_, err := svc.CreateResource(ctx, newScopedTestResource153(qn))
+		require.NoError(t, err)
+		_, err = svc.CreateResource(ctx, newScopedTestResource153(qn))
+		require.True(t, trace.IsAlreadyExists(err), "expected AlreadyExists, got %v", err)
+	})
+
+	t.Run("same name in different scopes does not conflict", func(t *testing.T) {
+		a := scopes.QualifiedName{Scope: "/a", Name: "shared"}
+		b := scopes.QualifiedName{Scope: "/b", Name: "shared"}
+		_, err := svc.CreateResource(ctx, newScopedTestResource153(a))
+		require.NoError(t, err)
+		_, err = svc.CreateResource(ctx, newScopedTestResource153(b))
+		require.NoError(t, err)
+
+		gotA, err := svc.GetResource(ctx, a)
+		require.NoError(t, err)
+		requireResourceBody(t, a, gotA)
+		gotB, err := svc.GetResource(ctx, b)
+		require.NoError(t, err)
+		requireResourceBody(t, b, gotB)
+	})
+}
+
+func TestScopeAwareServiceWrapper_UpsertResource(t *testing.T) {
+	t.Parallel()
+	svc := newScopeAwareWrapperForTest(t)
+	ctx := t.Context()
+
+	for _, tc := range []struct {
+		name string
+		qn   scopes.QualifiedName
+	}{
+		{"unscoped", scopes.QualifiedName{Name: "up"}},
+		{"scoped", scopes.QualifiedName{Scope: "/security", Name: "up"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			// Upsert creates when absent.
+			first := newScopedTestResource153(tc.qn)
+			first.Spec.Data = "first"
+			_, err := svc.UpsertResource(ctx, first)
+			require.NoError(t, err)
+			got, err := svc.GetResource(ctx, tc.qn)
+			require.NoError(t, err)
+			require.Equal(t, "first", got.Spec.Data)
+
+			// Upsert overwrites when present, with no revision and no AlreadyExists.
+			second := newScopedTestResource153(tc.qn)
+			second.Spec.Data = "second"
+			_, err = svc.UpsertResource(ctx, second)
+			require.NoError(t, err)
+			got, err = svc.GetResource(ctx, tc.qn)
+			require.NoError(t, err)
+			require.Equal(t, "second", got.Spec.Data)
+		})
+	}
+
+	t.Run("routes by scope", func(t *testing.T) {
+		// Upserting a scoped resource must not clobber an unscoped one of the
+		// same name.
+		unscoped := scopes.QualifiedName{Name: "router"}
+		scoped := scopes.QualifiedName{Scope: "/eng", Name: "router"}
+
+		u := newScopedTestResource153(unscoped)
+		u.Spec.Data = "unscoped"
+		_, err := svc.UpsertResource(ctx, u)
+		require.NoError(t, err)
+
+		s := newScopedTestResource153(scoped)
+		s.Spec.Data = "scoped"
+		_, err = svc.UpsertResource(ctx, s)
+		require.NoError(t, err)
+
+		gotU, err := svc.GetResource(ctx, unscoped)
+		require.NoError(t, err)
+		require.Equal(t, "unscoped", gotU.Spec.Data)
+		gotS, err := svc.GetResource(ctx, scoped)
+		require.NoError(t, err)
+		require.Equal(t, "scoped", gotS.Spec.Data)
+	})
+}
+
+func TestScopeAwareServiceWrapper_ConditionalUpdateResource(t *testing.T) {
+	t.Parallel()
+	svc := newScopeAwareWrapperForTest(t)
+	ctx := t.Context()
+
+	for _, tc := range []struct {
+		name string
+		qn   scopes.QualifiedName
+	}{
+		{"unscoped", scopes.QualifiedName{Name: "cu"}},
+		{"scoped", scopes.QualifiedName{Scope: "/security", Name: "cu"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			created, err := svc.CreateResource(ctx, newScopedTestResource153(tc.qn))
+			require.NoError(t, err)
+			revBefore := created.GetMetadata().GetRevision()
+
+			// A matching revision updates the body in place and rotates the revision.
+			created.Spec.Data = "updated"
+			updated, err := svc.ConditionalUpdateResource(ctx, created)
+			require.NoError(t, err)
+			require.Equal(t, "updated", updated.Spec.Data)
+			require.NotEqual(t, revBefore, updated.GetMetadata().GetRevision(), "update must rotate the revision")
+
+			got, err := svc.GetResource(ctx, tc.qn)
+			require.NoError(t, err)
+			require.Equal(t, "updated", got.Spec.Data)
+			require.Equal(t, tc.qn.Scope, got.GetScope())
+
+			// A stale revision is rejected and leaves the stored resource untouched.
+			updated.GetMetadata().SetRevision("not-the-right-revision")
+			updated.Spec.Data = "should-not-persist"
+			_, err = svc.ConditionalUpdateResource(ctx, updated)
+			require.True(t, trace.IsCompareFailed(err), "expected CompareFailed, got %v", err)
+
+			got, err = svc.GetResource(ctx, tc.qn)
+			require.NoError(t, err)
+			require.Equal(t, "updated", got.Spec.Data)
+		})
+	}
+
+	t.Run("missing resource errors", func(t *testing.T) {
+		_, err := svc.ConditionalUpdateResource(ctx, newScopedTestResource153(scopes.QualifiedName{Name: "ghost"}))
+		require.Error(t, err)
+	})
+}
+
+func TestScopeAwareServiceWrapper_GetResource(t *testing.T) {
+	t.Parallel()
+	svc := newScopeAwareWrapperForTest(t)
+	ctx := t.Context()
+
+	unscoped := scopes.QualifiedName{Name: "foo"}
+	scoped := scopes.QualifiedName{Scope: "/security/eu", Name: "foo"}
+	scopedOnly := scopes.QualifiedName{Scope: "/security", Name: "sec-only"}
+	for _, qn := range []scopes.QualifiedName{unscoped, scoped, scopedOnly} {
+		_, err := svc.CreateResource(ctx, newScopedTestResource153(qn))
+		require.NoError(t, err)
+	}
+
+	t.Run("unscoped", func(t *testing.T) {
+		got, err := svc.GetResource(ctx, unscoped)
+		require.NoError(t, err)
+		requireResourceBody(t, unscoped, got)
+	})
+
+	t.Run("scoped", func(t *testing.T) {
+		got, err := svc.GetResource(ctx, scoped)
+		require.NoError(t, err)
+		requireResourceBody(t, scoped, got)
+	})
+
+	t.Run("wrong scope is not found", func(t *testing.T) {
+		_, err := svc.GetResource(ctx, scopes.QualifiedName{Scope: "/other", Name: "foo"})
+		require.True(t, trace.IsNotFound(err), "expected NotFound, got %v", err)
+	})
+
+	t.Run("scoped resource does not leak into the unscoped range", func(t *testing.T) {
+		_, err := svc.GetResource(ctx, scopes.QualifiedName{Name: "sec-only"})
+		require.True(t, trace.IsNotFound(err), "expected NotFound, got %v", err)
+	})
+}
+
+func TestScopeAwareServiceWrapper_DeleteResource(t *testing.T) {
+	t.Parallel()
+	svc := newScopeAwareWrapperForTest(t)
+	ctx := t.Context()
+
+	t.Run("deletes only the addressed scope", func(t *testing.T) {
+		unscoped := scopes.QualifiedName{Name: "foo"}
+		scoped := scopes.QualifiedName{Scope: "/security", Name: "foo"}
+		for _, qn := range []scopes.QualifiedName{unscoped, scoped} {
+			_, err := svc.CreateResource(ctx, newScopedTestResource153(qn))
+			require.NoError(t, err)
+		}
+
+		// Deleting the unscoped resource leaves the scoped one intact.
+		require.NoError(t, svc.DeleteResource(ctx, unscoped))
+		_, err := svc.GetResource(ctx, unscoped)
+		require.True(t, trace.IsNotFound(err), "expected NotFound, got %v", err)
+		got, err := svc.GetResource(ctx, scoped)
+		require.NoError(t, err)
+		requireResourceBody(t, scoped, got)
+
+		// And deleting the scoped resource removes it too.
+		require.NoError(t, svc.DeleteResource(ctx, scoped))
+		_, err = svc.GetResource(ctx, scoped)
+		require.True(t, trace.IsNotFound(err), "expected NotFound, got %v", err)
+	})
+
+	t.Run("wrong scope does not delete", func(t *testing.T) {
+		qn := scopes.QualifiedName{Scope: "/eng", Name: "keep"}
+		_, err := svc.CreateResource(ctx, newScopedTestResource153(qn))
+		require.NoError(t, err)
+
+		// Deleting under a different scope must not remove it, and is NotFound.
+		err = svc.DeleteResource(ctx, scopes.QualifiedName{Scope: "/other", Name: "keep"})
+		require.True(t, trace.IsNotFound(err), "expected NotFound, got %v", err)
+		got, err := svc.GetResource(ctx, qn)
+		require.NoError(t, err)
+		requireResourceBody(t, qn, got)
+	})
+
+	t.Run("missing is not found", func(t *testing.T) {
+		err := svc.DeleteResource(ctx, scopes.QualifiedName{Name: "ghost"})
+		require.True(t, trace.IsNotFound(err), "expected NotFound, got %v", err)
+	})
+}
+
+func TestScopeAwareServiceWrapper_DeleteAllResources(t *testing.T) {
+	t.Parallel()
+	svc := newScopeAwareWrapperForTest(t)
+	ctx := t.Context()
+
+	for _, qn := range []scopes.QualifiedName{
+		{Name: "a"},
+		{Name: "b"},
+		{Scope: "/security", Name: "x"},
+		{Scope: "/security/eu", Name: "y"},
+	} {
+		_, err := svc.CreateResource(ctx, newScopedTestResource153(qn))
+		require.NoError(t, err)
+	}
+
+	require.NoError(t, svc.DeleteAllResources(ctx))
+
+	// Both the scoped and unscoped ranges are emptied.
+	page, next, err := svc.ListResources(ctx, 100, "")
+	require.NoError(t, err)
+	require.Empty(t, next)
+	require.Empty(t, page)
+}
+
+func TestScopeAwareServiceWrapper_ListResourcesWithFilter(t *testing.T) {
+	t.Parallel()
+	svc := newScopeAwareWrapperForTest(t)
+	ctx := t.Context()
+
+	created := []scopes.QualifiedName{
+		{Name: "keep-a"},
+		{Name: "drop-a"},
+		{Scope: "/security", Name: "keep-b"},
+		{Scope: "/security", Name: "drop-b"},
+		{Scope: "/security/eu", Name: "keep-c"},
+	}
+	for _, qn := range created {
+		_, err := svc.CreateResource(ctx, newScopedTestResource153(qn))
+		require.NoError(t, err)
+	}
+
+	keep := func(r *scopedTestResource153) bool {
+		return strings.HasPrefix(r.GetMetadata().GetName(), "keep-")
+	}
+	// The matcher must apply across both the unscoped and scoped ranges, with
+	// unscoped matches ordered first.
+	want := []scopes.QualifiedName{
+		{Name: "keep-a"},
+		{Scope: "/security", Name: "keep-b"},
+		{Scope: "/security/eu", Name: "keep-c"},
+	}
+
+	t.Run("single page", func(t *testing.T) {
+		got, next, err := svc.ListResourcesWithFilter(ctx, 100, "", keep)
+		require.NoError(t, err)
+		require.Empty(t, next)
+		require.Equal(t, want, names(got))
+	})
+
+	t.Run("paginated preserves filter and order across the boundary", func(t *testing.T) {
+		var paged []*scopedTestResource153
+		token := ""
+		for {
+			page, nextToken, err := svc.ListResourcesWithFilter(ctx, 1, token, keep)
+			require.NoError(t, err)
+			paged = append(paged, page...)
+			if nextToken == "" {
+				break
+			}
+			token = nextToken
+		}
+		require.Equal(t, want, names(paged))
+	})
+}
+
+func TestScopeAwareServiceWrapper_Resources(t *testing.T) {
+	t.Parallel()
+
+	t.Run("empty", func(t *testing.T) {
+		svc := newScopeAwareWrapperForTest(t)
+		require.Empty(t, collectStream(t, svc.Resources(t.Context(), "", "")))
+	})
+
+	t.Run("orders unscoped before scoped and honours the cursor range", func(t *testing.T) {
+		svc := newScopeAwareWrapperForTest(t)
+		ctx := t.Context()
+
+		want := []scopes.QualifiedName{
+			{Name: "a"},
+			{Name: "b"},
+			{Scope: "/security", Name: "x"},
+			{Scope: "/security/eu", Name: "y"},
+		}
+		for _, qn := range want {
+			_, err := svc.CreateResource(ctx, newScopedTestResource153(qn))
+			require.NoError(t, err)
+		}
+
+		// The full range yields everything, unscoped first.
+		require.Equal(t, want, names(collectStream(t, svc.Resources(ctx, "", ""))))
+
+		// The scoped-start cursor is the boundary between the unscoped and scoped
+		// halves of the unified stream.
+		unscopedOnly := collectStream(t, svc.Resources(ctx, "", scopes.ResourceCursorScopedStart()))
+		require.Equal(t, []scopes.QualifiedName{{Name: "a"}, {Name: "b"}}, names(unscopedOnly))
+
+		scopedOnly := collectStream(t, svc.Resources(ctx, scopes.ResourceCursorScopedStart(), ""))
+		require.Equal(t, []scopes.QualifiedName{
+			{Scope: "/security", Name: "x"},
+			{Scope: "/security/eu", Name: "y"},
+		}, names(scopedOnly))
+	})
+}
+
+func TestScopeAwareServiceWrapper_MakeBackendItem(t *testing.T) {
+	t.Parallel()
+	svc := newScopeAwareWrapperForTest(t)
+
+	for _, tc := range []struct {
+		name string
+		qn   scopes.QualifiedName
+	}{
+		{"unscoped", scopes.QualifiedName{Name: "foo"}},
+		{"scoped", scopes.QualifiedName{Scope: "/security", Name: "foo"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			item, err := svc.MakeBackendItem(newScopedTestResource153(tc.qn))
+			require.NoError(t, err)
+
+			// The item is keyed exactly where BackendKey reports.
+			wantKey, err := svc.BackendKey(tc.qn)
+			require.NoError(t, err)
+			require.Equal(t, wantKey.String(), item.Key.String())
+
+			// The stored value is the marshalled body and round-trips.
+			require.NotEmpty(t, item.Value)
+			decoded, err := unmarshalScopedResource153(item.Value)
+			require.NoError(t, err)
+			requireResourceBody(t, tc.qn, decoded)
+		})
+	}
+}
+
+func TestScopeAwareServiceWrapper_BackendKey(t *testing.T) {
+	t.Parallel()
+	svc := newScopeAwareWrapperForTest(t)
+
+	t.Run("unscoped", func(t *testing.T) {
+		key, err := svc.BackendKey(scopes.QualifiedName{Name: "foo"})
+		require.NoError(t, err)
+		require.Equal(t, backend.NewKey(testUnscopedPrefix, "foo").String(), key.String())
+	})
+
+	t.Run("scoped is namespaced by encoded scope", func(t *testing.T) {
+		encodedScope, err := scopes.EncodeForKey("/security")
+		require.NoError(t, err)
+		key, err := svc.BackendKey(scopes.QualifiedName{Scope: "/security", Name: "foo"})
+		require.NoError(t, err)
+		require.Equal(t,
+			backend.NewKey(testScopedTopPrefix, testUnscopedPrefix, encodedScope, "foo").String(),
+			key.String(),
+		)
+	})
+}

--- a/lib/services/local/generic/scopeaware_wrapper_test.go
+++ b/lib/services/local/generic/scopeaware_wrapper_test.go
@@ -78,7 +78,7 @@ func newScopedTestResource153(sqn scopes.QualifiedName) *scopedTestResource153 {
 }
 
 func marshalScopedResource153(resource *scopedTestResource153, opts ...services.MarshalOption) ([]byte, error) {
-	// TODO(strideynet): It feels a little janky utilising fast marshal rather
+	// TODO(strideynet): It feels a little janky utilizing fast marshal rather
 	// than Proto marshal (which is what 99.9% of RFD153 resources are going to
 	// use). Could we add a "foo" resource to `/api` for testing?
 	return utils.FastMarshal(resource)
@@ -516,7 +516,7 @@ func TestScopeAwareServiceWrapper_Resources(t *testing.T) {
 		require.Empty(t, collectStream(t, svc.Resources(t.Context(), "", "")))
 	})
 
-	t.Run("orders unscoped before scoped and honours the cursor range", func(t *testing.T) {
+	t.Run("orders unscoped before scoped and honors the cursor range", func(t *testing.T) {
 		svc := newScopeAwareWrapperForTest(t)
 		ctx := t.Context()
 
@@ -567,7 +567,7 @@ func TestScopeAwareServiceWrapper_MakeBackendItem(t *testing.T) {
 			require.NoError(t, err)
 			require.Equal(t, wantKey.String(), item.Key.String())
 
-			// The stored value is the marshalled body and round-trips.
+			// The stored value is the marshaled body and round-trips.
 			require.NotEmpty(t, item.Value)
 			decoded, err := unmarshalScopedResource153(item.Value)
 			require.NoError(t, err)


### PR DESCRIPTION
Introduces a Generic RFD153-compatible Scopes Aware backend service.

Updates https://github.com/gravitational/teleport/issues/66349

Largely based on Nic's work in https://github.com/gravitational/teleport/pull/67682

I've gone with a fairly light-weight wrapper around Nic's impl here - the same way we handle this for the un-scoped RFD153 wrapper. I'm open to alternative approaches.
