### PR TITLE
gha: include kvstore action in workflows

### DIFF
--- a/.github/workflows/backport.yaml
+++ b/.github/workflows/backport.yaml
@@ -13,6 +13,7 @@ on:
 permissions:
   pull-requests: write
   contents: write
+  id-token: write
 
 jobs:
   backport-pull-request:

--- a/.github/workflows/backport.yaml
+++ b/.github/workflows/backport.yaml
@@ -20,6 +20,17 @@ jobs:
     if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     steps:
+      - name: Get runtime values from kvstore
+        id: kvstore
+        uses: gravitational/shared-workflows/tools/env-kvstore@tools/env-kvstore/v1.0.0
+        with:
+          cognito-identity-pool-id: "us-west-2:da53389e-a459-4a28-bd54-43eeb8e4b579"
+          cognito-role-arn: "arn:aws:iam::247230412011:role/github-actions-cognito-oidc"
+          existing-gh-secrets: "${{ toJSON(secrets) }}"
+          existing-gh-variables: "${{ toJSON(vars) }}"
+          # values: |
+          #   BACKPORT_APP_ID,secret
+          #   BACKPORT_PRIVATE_KEY,secret
       - name: Generate GitHub Token
         id: generate_token
         uses: actions/create-github-app-token@v3

--- a/.github/workflows/bloat.yaml
+++ b/.github/workflows/bloat.yaml
@@ -28,6 +28,7 @@ jobs:
 
     permissions:
       contents: read
+      id-token: write
 
     container:
       image: ghcr.io/gravitational/teleport-buildbox:teleport19

--- a/.github/workflows/bloat.yaml
+++ b/.github/workflows/bloat.yaml
@@ -33,6 +33,18 @@ jobs:
       image: ghcr.io/gravitational/teleport-buildbox:teleport19
 
     steps:
+      - name: Get runtime values from kvstore
+        id: kvstore
+        uses: gravitational/shared-workflows/tools/env-kvstore@tools/env-kvstore/v1.0.0
+        with:
+          cognito-identity-pool-id: "us-west-2:da53389e-a459-4a28-bd54-43eeb8e4b579"
+          cognito-role-arn: "arn:aws:iam::247230412011:role/github-actions-cognito-oidc"
+          existing-gh-secrets: "${{ toJSON(secrets) }}"
+          existing-gh-variables: "${{ toJSON(vars) }}"
+          # values: |
+          #   REVIEWERS_APP_ID,secret
+          #   REVIEWERS_PRIVATE_KEY,secret
+          #   REVIEWERS,secret
       - name: Checkout base
         uses: actions/checkout@v6
         with:

--- a/.github/workflows/build-usage-image.yaml
+++ b/.github/workflows/build-usage-image.yaml
@@ -18,9 +18,7 @@ jobs:
           existing-gh-secrets: "${{ toJSON(secrets) }}"
           existing-gh-variables: "${{ toJSON(vars) }}"
           # values: |
-          #   REVIEWERS_APP_ID,secret
-          #   REVIEWERS_PRIVATE_KEY,secret
-          #   REVIEWERS,secret
+          #   TELEPORT_USAGE_IAM_ROLE_ARN,secret
       # This step is used to extract the version of the usage script.
       - name: Trim leading v in release
         id: version

--- a/.github/workflows/build-usage-image.yaml
+++ b/.github/workflows/build-usage-image.yaml
@@ -3,12 +3,24 @@ on:
   release:
     types: ["published"]
 permissions:
-  id-token: write
   contents: read
+  id-token: write
 jobs:
   image:
     runs-on: ubuntu-latest
     steps:
+      - name: Get runtime values from kvstore
+        id: kvstore
+        uses: gravitational/shared-workflows/tools/env-kvstore@tools/env-kvstore/v1.0.0
+        with:
+          cognito-identity-pool-id: "us-west-2:da53389e-a459-4a28-bd54-43eeb8e4b579"
+          cognito-role-arn: "arn:aws:iam::247230412011:role/github-actions-cognito-oidc"
+          existing-gh-secrets: "${{ toJSON(secrets) }}"
+          existing-gh-variables: "${{ toJSON(vars) }}"
+          # values: |
+          #   REVIEWERS_APP_ID,secret
+          #   REVIEWERS_PRIVATE_KEY,secret
+          #   REVIEWERS,secret
       # This step is used to extract the version of the usage script.
       - name: Trim leading v in release
         id: version

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -28,6 +28,7 @@ permissions:
     repository-projects: none
     security-events: none
     statuses: none
+    id-token: write
 
 jobs:
   check-reviews:
@@ -35,6 +36,18 @@ jobs:
     if: ${{ !github.event.pull_request.draft && !startsWith(github.head_ref, 'dependabot/') }}
     runs-on: ubuntu-latest
     steps:
+      - name: Get runtime values from kvstore
+        id: kvstore
+        uses: gravitational/shared-workflows/tools/env-kvstore@tools/env-kvstore/v1.0.0
+        with:
+          cognito-identity-pool-id: "us-west-2:da53389e-a459-4a28-bd54-43eeb8e4b579"
+          cognito-role-arn: "arn:aws:iam::247230412011:role/github-actions-cognito-oidc"
+          existing-gh-secrets: "${{ toJSON(secrets) }}"
+          existing-gh-variables: "${{ toJSON(vars) }}"
+          # values: |
+          #   REVIEWERS_APP_ID,secret
+          #   REVIEWERS_PRIVATE_KEY,secret
+          #   REVIEWERS,secret
       - name: Generate GitHub Token
         id: generate_token
         uses: actions/create-github-app-token@v3

--- a/.github/workflows/doc-tests.yaml
+++ b/.github/workflows/doc-tests.yaml
@@ -45,6 +45,19 @@ jobs:
       contents: read
 
     steps:
+      - name: Get runtime values from kvstore
+        id: kvstore
+        uses: gravitational/shared-workflows/tools/env-kvstore@tools/env-kvstore/v1.0.0
+        with:
+          cognito-identity-pool-id: "us-west-2:da53389e-a459-4a28-bd54-43eeb8e4b579"
+          cognito-role-arn: "arn:aws:iam::247230412011:role/github-actions-cognito-oidc"
+          existing-gh-secrets: "${{ toJSON(secrets) }}"
+          existing-gh-variables: "${{ toJSON(vars) }}"
+          # values: |
+          #   REVIEWERS_APP_ID,secret
+          #   REVIEWERS_PRIVATE_KEY,secret
+          #   REVIEWERS,secret
+
       - name: Check out teleport
         uses: actions/checkout@v6
         with:
@@ -69,7 +82,7 @@ jobs:
         with:
           repository: gravitational/shared-workflows
           path: shared-workflows
-          ref: 6f388765b8ce993721502083c74cb9af1fc5658f 
+          ref: 6f388765b8ce993721502083c74cb9af1fc5658f
 
       - name: Install Go
         uses: actions/setup-go@faf52423ec0d44c58f68e83b614bfcd99dded66f # v6.0.0
@@ -105,7 +118,7 @@ jobs:
         # To do this, we delete the three submodules we use for building the
         # live docs site and copy a gravitational/teleport clone into the
         # content directory.
-        # 
+        #
         # The docs engine expects a config.json file at the root of the
         # gravitational/docs clone that associates directories with git
         # submodules. By default, these directories represent versioned branches
@@ -147,7 +160,7 @@ jobs:
         run: yarn markdown-lint
 
       - name: Download vale
-        env: 
+        env:
           GH_TOKEN: ${{ github.token }}
           VALE_VERSION: 3.12.0
           # The sha256 checksum must be changed based on the downloaded package

--- a/.github/workflows/doc-tests.yaml
+++ b/.github/workflows/doc-tests.yaml
@@ -43,6 +43,7 @@ jobs:
 
     permissions:
       contents: read
+      id-token: write
 
     steps:
       - name: Get runtime values from kvstore

--- a/.github/workflows/docs-amplify.yaml
+++ b/.github/workflows/docs-amplify.yaml
@@ -5,17 +5,30 @@ on:
       - 'docs/**'
       - .github/workflows/docs-amplify.yaml
   workflow_dispatch:
-  
+
 permissions:
   pull-requests: write
   id-token: write
-  
+
 jobs:
   amplify-preview:
     name: Prepare Amplify preview URL
     runs-on: ubuntu-slim
     environment: docs-amplify
-    steps:    
+    steps:
+    - name: Get runtime values from kvstore
+      id: kvstore
+      uses: gravitational/shared-workflows/tools/env-kvstore@tools/env-kvstore/v1.0.0
+      with:
+        cognito-identity-pool-id: "us-west-2:da53389e-a459-4a28-bd54-43eeb8e4b579"
+        cognito-role-arn: "arn:aws:iam::247230412011:role/github-actions-cognito-oidc"
+        existing-gh-secrets: "${{ toJSON(secrets) }}"
+        existing-gh-variables: "${{ toJSON(vars) }}"
+        # values: |
+        #   REVIEWERS_APP_ID,secret
+        #   REVIEWERS_PRIVATE_KEY,secret
+        #   REVIEWERS,secret
+
     - name: Configure AWS credentials
       uses: aws-actions/configure-aws-credentials@a03048d87541d1d9fcf2ecf528a4a65ba9bd7838 # v4
       with:

--- a/.github/workflows/docs-amplify.yaml
+++ b/.github/workflows/docs-amplify.yaml
@@ -25,9 +25,8 @@ jobs:
         existing-gh-secrets: "${{ toJSON(secrets) }}"
         existing-gh-variables: "${{ toJSON(vars) }}"
         # values: |
-        #   REVIEWERS_APP_ID,secret
-        #   REVIEWERS_PRIVATE_KEY,secret
-        #   REVIEWERS,secret
+        #   AMPLIFY_APP_IDS,variable
+        #   IAM_ROLE,variable
 
     - name: Configure AWS credentials
       uses: aws-actions/configure-aws-credentials@a03048d87541d1d9fcf2ecf528a4a65ba9bd7838 # v4

--- a/.github/workflows/flaky-tests.yaml
+++ b/.github/workflows/flaky-tests.yaml
@@ -44,6 +44,19 @@ jobs:
           - 3379:3379
 
     steps:
+      - name: Get runtime values from kvstore
+        id: kvstore
+        uses: gravitational/shared-workflows/tools/env-kvstore@tools/env-kvstore/v1.0.0
+        with:
+          cognito-identity-pool-id: "us-west-2:da53389e-a459-4a28-bd54-43eeb8e4b579"
+          cognito-role-arn: "arn:aws:iam::247230412011:role/github-actions-cognito-oidc"
+          existing-gh-secrets: "${{ toJSON(secrets) }}"
+          existing-gh-variables: "${{ toJSON(vars) }}"
+          # values: |
+          #   REVIEWERS_APP_ID,secret
+          #   REVIEWERS_PRIVATE_KEY,secret
+          #   REVIEWERS,secret
+
       - name: Checkout Teleport
         uses: actions/checkout@v6
         with:

--- a/.github/workflows/flaky-tests.yaml
+++ b/.github/workflows/flaky-tests.yaml
@@ -20,6 +20,7 @@ jobs:
     permissions:
       contents: read
       packages: read
+      id-token: write
 
     container:
       image: ghcr.io/gravitational/teleport-buildbox:teleport19

--- a/.github/workflows/post-release.yaml
+++ b/.github/workflows/post-release.yaml
@@ -20,19 +20,6 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Get runtime values from kvstore
-        id: kvstore
-        uses: gravitational/shared-workflows/tools/env-kvstore@tools/env-kvstore/v1.0.0
-        with:
-          cognito-identity-pool-id: "us-west-2:da53389e-a459-4a28-bd54-43eeb8e4b579"
-          cognito-role-arn: "arn:aws:iam::247230412011:role/github-actions-cognito-oidc"
-          existing-gh-secrets: "${{ toJSON(secrets) }}"
-          existing-gh-variables: "${{ toJSON(vars) }}"
-          # values: |
-          #   REVIEWERS_APP_ID,secret
-          #   REVIEWERS_PRIVATE_KEY,secret
-          #   REVIEWERS,secret
-
       - name: Checkout repository
         uses: actions/checkout@v6
         with:
@@ -70,6 +57,19 @@ jobs:
     runs-on: ubuntu-latest
     environment: post-release
     steps:
+      - name: Get runtime values from kvstore
+        id: kvstore
+        uses: gravitational/shared-workflows/tools/env-kvstore@tools/env-kvstore/v1.0.0
+        with:
+          cognito-identity-pool-id: "us-west-2:da53389e-a459-4a28-bd54-43eeb8e4b579"
+          cognito-role-arn: "arn:aws:iam::247230412011:role/github-actions-cognito-oidc"
+          existing-gh-secrets: "${{ toJSON(secrets) }}"
+          existing-gh-variables: "${{ toJSON(vars) }}"
+          # values: |
+          #   REVIEWERS_APP_ID,secret
+          #   REVIEWERS_PRIVATE_KEY,secret
+          #   REVIEWERS,secret
+
       - name: Get Release Branch
         id: get-branch
         env:

--- a/.github/workflows/post-release.yaml
+++ b/.github/workflows/post-release.yaml
@@ -66,9 +66,8 @@ jobs:
           existing-gh-secrets: "${{ toJSON(secrets) }}"
           existing-gh-variables: "${{ toJSON(vars) }}"
           # values: |
-          #   REVIEWERS_APP_ID,secret
-          #   REVIEWERS_PRIVATE_KEY,secret
-          #   REVIEWERS,secret
+          #   APP_ID,variable
+          #   PRIVATE_KEY,secret
 
       - name: Get Release Branch
         id: get-branch

--- a/.github/workflows/post-release.yaml
+++ b/.github/workflows/post-release.yaml
@@ -20,6 +20,19 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Get runtime values from kvstore
+        id: kvstore
+        uses: gravitational/shared-workflows/tools/env-kvstore@tools/env-kvstore/v1.0.0
+        with:
+          cognito-identity-pool-id: "us-west-2:da53389e-a459-4a28-bd54-43eeb8e4b579"
+          cognito-role-arn: "arn:aws:iam::247230412011:role/github-actions-cognito-oidc"
+          existing-gh-secrets: "${{ toJSON(secrets) }}"
+          existing-gh-variables: "${{ toJSON(vars) }}"
+          # values: |
+          #   REVIEWERS_APP_ID,secret
+          #   REVIEWERS_PRIVATE_KEY,secret
+          #   REVIEWERS,secret
+
       - name: Checkout repository
         uses: actions/checkout@v6
         with:

--- a/.github/workflows/update-ami-ids.yaml
+++ b/.github/workflows/update-ami-ids.yaml
@@ -37,9 +37,8 @@ jobs:
           existing-gh-secrets: "${{ toJSON(secrets) }}"
           existing-gh-variables: "${{ toJSON(vars) }}"
           # values: |
-          #   REVIEWERS_APP_ID,secret
-          #   REVIEWERS_PRIVATE_KEY,secret
-          #   REVIEWERS,secret
+          #   APP_ID,variable
+          #   PRIVATE_KEY,secret
 
       - name: Generate Github token
         id: generate_token

--- a/.github/workflows/update-ami-ids.yaml
+++ b/.github/workflows/update-ami-ids.yaml
@@ -28,6 +28,19 @@ jobs:
     environment: post-release
 
     steps:
+      - name: Get runtime values from kvstore
+        id: kvstore
+        uses: gravitational/shared-workflows/tools/env-kvstore@tools/env-kvstore/v1.0.0
+        with:
+          cognito-identity-pool-id: "us-west-2:da53389e-a459-4a28-bd54-43eeb8e4b579"
+          cognito-role-arn: "arn:aws:iam::247230412011:role/github-actions-cognito-oidc"
+          existing-gh-secrets: "${{ toJSON(secrets) }}"
+          existing-gh-variables: "${{ toJSON(vars) }}"
+          # values: |
+          #   REVIEWERS_APP_ID,secret
+          #   REVIEWERS_PRIVATE_KEY,secret
+          #   REVIEWERS,secret
+
       - name: Generate Github token
         id: generate_token
         uses: actions/create-github-app-token@v3

--- a/.github/workflows/update-docs-webhook.yaml
+++ b/.github/workflows/update-docs-webhook.yaml
@@ -11,6 +11,9 @@ on:
       - branch/v*
   workflow_dispatch:
 
+permissions:
+  id-token: write
+
 jobs:
   update-webhook:
     name: Update docs webhook
@@ -19,6 +22,18 @@ jobs:
     strategy:
       fail-fast: false
     steps:
+      - name: Get runtime values from kvstore
+        id: kvstore
+        uses: gravitational/shared-workflows/tools/env-kvstore@tools/env-kvstore/v1.0.0
+        with:
+          cognito-identity-pool-id: "us-west-2:da53389e-a459-4a28-bd54-43eeb8e4b579"
+          cognito-role-arn: "arn:aws:iam::247230412011:role/github-actions-cognito-oidc"
+          existing-gh-secrets: "${{ toJSON(secrets) }}"
+          existing-gh-variables: "${{ toJSON(vars) }}"
+          # values: |
+          #   REVIEWERS_APP_ID,secret
+          #   REVIEWERS_PRIVATE_KEY,secret
+          #   REVIEWERS,secret
       - name: Call deployment webhook
         env:
           WEBHOOK_URL: ${{ secrets.AMPLIFY_DOCS_DEPLOY_HOOK }}

--- a/.github/workflows/update-docs-webhook.yaml
+++ b/.github/workflows/update-docs-webhook.yaml
@@ -31,9 +31,7 @@ jobs:
           existing-gh-secrets: "${{ toJSON(secrets) }}"
           existing-gh-variables: "${{ toJSON(vars) }}"
           # values: |
-          #   REVIEWERS_APP_ID,secret
-          #   REVIEWERS_PRIVATE_KEY,secret
-          #   REVIEWERS,secret
+          #   AMPLIFY_DOCS_DEPLOY_HOOK,secret
       - name: Call deployment webhook
         env:
           WEBHOOK_URL: ${{ secrets.AMPLIFY_DOCS_DEPLOY_HOOK }}


### PR DESCRIPTION
Contributes to https://github.com/gravitational/cloud/issues/14222

Adds the env-kvstore action from shared-workflows to all jobs that use GHA vars.* or secrets.*.

Once we've collected all the values, will raise follow-up PRs:

Add secrets and variables to SOPS files in kvstore repo.
Replace references to vars.* and secrets.* in workflows.
Disable migration
Then we can delete all secret and variable values from GHA for this repo.

## Manual Test Plan
### Test Environment

### Test Cases
- [ ] 
