### PR TITLE
[RFD] Amend RFD 230 to cover "agent-less" resource cases

### DIFF
--- a/rfd/0230-component-feature-advertisement.md
+++ b/rfd/0230-component-feature-advertisement.md
@@ -37,6 +37,11 @@ In this RFD:
   resources and heartbeats.
 - **Consumer** means a process that reads feature support and derives higher-level behavior from it, such as
   Proxy/Web UI and Auth.
+- **Agentless resource** means a resource whose `ComponentFeatures` is empty because no serving agent heartbeats it over
+  the inventory control stream, either because it has no serving agent (an integration-backed app, an OpenSSH node) or
+  because its serving agent never heartbeats the resource itself (a Windows desktop, registered through the authorized
+  desktop API). Its complement, an **agent-served** resource, carries the advertisement its serving agent sets over the
+  inventory stream. The same kind can appear either way.
 
 Auth plays both roles:
 
@@ -85,25 +90,103 @@ include "true" values, the payloads stay compact, and omission naturally encodes
 
 ### Advertising from services
 
+A feature works for a resource only if every component along its serving path was built with it. `ComponentFeatures` is
+how each component advertises what its own build supports, so consumers intersect those advertisements rather than infer
+support from version numbers; a component built without a feature never advertises it.
+
 Each service that advertises features exposes a list of its current `ComponentFeatures`. For heartbeat-ing services,
 this payload is attached to the presence resources they already send over the inventory control stream (e.g.,
 `AppServerSpecV3` for App Service). No changes are required in the heartbeat
 machinery itself; services simply add a `ComponentFeatures` field to the Spec of the presence resources they are
 already constructing.
 
+The value lives on the resource, not on the serving service's own record: a single app can be served by several
+`app_service`s at once, so carrying it on each `AppServer` lets the unified-resource cache intersect across them and
+lets a consumer ask one resource whether a flow is supported end to end.
+
+The field is server-managed: only the serving agent sets it, over the inventory control stream that carries its
+heartbeat, and the authorized resource-write APIs nil it. This keeps a client from over-reporting support it cannot
+honor, the same way `status` and `revision` are not client-set. The boundary is one of authenticity, not authorization:
+consistent with the note above, the signal only hides or shows flows and never grants access.
+
 A service should advertise a flag only when:
 
 - the implementation is present in the build, and
 - it is usable with the current configuration and dependencies.
 
-For the initial Resource Constraints work, support is not configuration-dependent. If the code path is compiled into the
-binary, the service can unconditionally advertise the flag for the resources that participate in that flow.
+For the initial Resource Constraints work, support is not configuration-dependent: a build either implements the flow or
+it does not. A service must advertise the flag only once its build can honor the flow end to end, not merely once the
+field exists. Because the field can be present on a build that predates enforcement, such a build would advertise support
+it cannot honor; consumers version-gate those builds out until they age past support.
 
 Auth stores these payloads alongside existing status information so they are available through the same APIs that
 already expose presence and cluster state.
 
-Auth itself won't carry `ComponentFeatures` on an auth-server presence resource. Instead, it can expose its own feature
-support via adding some `AuthComponentFeatures` field to its Spec when heartbeating.
+Auth advertises its own support by carrying `ComponentFeatures` on the `ServerSpecV2` it heartbeats as the auth-server
+presence resource, so consumers read it through the same APIs.
+
+### Agentless resources
+
+The same kind can be agent-served in one cluster and agentless in another. An `AppServer` served by an `app_service` is
+agent-served; one backed by an integration is agentless and served by Proxy directly. What makes a resource agentless is
+that no serving agent heartbeats it over the inventory control stream, so nothing sets a trustworthy advertisement and
+its `ComponentFeatures` stays empty (see [Advertising from services](#advertising-from-services)).
+
+The two cases are read differently. An agent-served resource is read as-is: an older agent that never advertised a
+feature reads as not supporting it, so the mixed-version case keeps working. An agentless resource has no advertisement
+to read, so its eligibility is derived from its type (which says only whether the kind is eligible) and then intersected
+with the advertisements of the components serving it (the serving service where there is one, plus Proxy and Auth).
+
+A shared derive-at-read step implements that split: for the agentless patterns it recognizes (an integration-served app,
+an OpenSSH or OpenSSH-EICE node) it derives eligibility from the resource type; otherwise it reads the agent's
+advertisement, with the transitional version-gate from [Advertising from services](#advertising-from-services) applied.
+
+This derivation runs wherever resources are read out, both at Auth's unified-resource cache and at the Proxy's resource
+API. Running it in both places lets the value survive mixed-version clusters: Auth fills it in, and the Proxy re-derives
+when an older Auth has not. Every read path that gates on a feature must run the same derivation; a path that reads the
+stored `ComponentFeatures` directly returns nothing for an agentless resource, and that under-reporting is silent. A
+lint rule can forbid reading the stored field directly outside the shared accessor, the way other "read through the
+wrapper" rules are enforced.
+
+The handling per kind follows. Git servers, bare `KubeCluster` records, and SAML IdP service providers are out of scope:
+they have no feature consumer or no `ComponentFeatures` to carry.
+
+#### Apps
+
+An app is agent-served when an `app_service` proxies it, and agentless when an integration serves it directly (an app
+with a non-empty integration). An agent-served app's `AppServer` carries the advertisement and is read as-is; an
+agentless app has none, so its eligibility is derived from the app type.
+
+#### SSH nodes
+
+A Teleport SSH node advertises its support on its own heartbeat. OpenSSH and OpenSSH-EICE nodes have no agent (discovery
+registers them through the authorized node API) and are identified by their subkind; their eligibility is derived from
+the node type at read, the same shape as apps.
+
+#### Databases
+
+A `database_service` always heartbeats the `DatabaseServer` wrapper over the inventory stream, and a `Database` has no
+integration, so a database is never agentless. Support is carried on the heartbeat and intersected across the servers
+backing a database, reusing the per-resource aggregation apps use.
+
+#### Kubernetes
+
+A `kube_service` heartbeats the `KubeServer` wrapper, so Kubernetes is agent-served like databases. There is no agentless
+form: the persisted `KubeCluster` has no integration, and the integration is known only at discovery time and not
+persisted on the resource. Integration-served Kubernetes access would first need that signal persisted, mirroring apps.
+
+#### Windows desktops
+
+A `windows_desktop_service` serves Windows desktops but registers each `WindowsDesktop` through the authorized desktop
+API rather than the inventory stream, so a desktop never carries an advertisement of its own. Its eligibility is derived
+from the desktop type and intersected with the serving service's advertisement (located by host ID and carried on the
+`windows_desktop_service`'s own record) plus Auth and Proxy. Where that service advertisement lives is an open question,
+since the service's own record is also written through the authorized API.
+
+#### Linux desktops
+
+A `LinuxDesktop` has no serving agent at all, so it carries no advertisement. Its eligibility is derived from the desktop
+type and intersected with Auth and Proxy only.
 
 ### Consuming feature information
 
@@ -116,7 +199,7 @@ In practice,
 - Consumers obtain per-service `ComponentFeatures` by reading presence resources from Auth (e.g., app servers,
   database servers, and nodes).
 - If the feature requires auth support, consumers also obtain all present Auth instances (e.g., via
-  `accessPoint.GetAuthServers()` in Web handlers), which contain Auth's own `ComponentFeatures` on their Specs.
+  `accessPoint.ListAuthServers()` in Web handlers), which contain Auth's own `ComponentFeatures` on their Specs.
 - They then compute an intersection of these sets for the path or resource in question and gate UX or other
   behavior on that intersection.
 
@@ -137,6 +220,9 @@ In v1, the implementation is limited to:
 - App Service advertising `ComponentFeatures` on `AppServerV3` presence records for AWS Console applications.
 - Auth and Proxy exposing their own `ComponentFeatures` via their `ServerSpecV2` when heartbeating.
 - Proxy/Web UI consuming these feature sets to gate Resource Constraint-dependent flows.
+- Derive-at-read handling for agentless `AppServerV3` resources (integration-backed apps) and agentless `ServerV2` SSH
+  nodes (OpenSSH/EICE). Databases and Kubernetes advertise via their agent heartbeats; desktops are out of v1 scope (see
+  [Agentless resources](#agentless-resources)).
 
 The design is intentionally generic so that other services can adopt `ComponentFeatures` for future features without
 changing any core model.
@@ -175,33 +261,25 @@ To advertise feature support from App Service, `AppServerSpecV3` is extended wit
 ```protobuf
 message AppServerSpecV3 {
   // existing fields...
-  ComponentFeatures component_features = N;
+  ComponentFeatures component_features = 9;
 }
 ```
 
 For Resource Constraints, this flag is per-application, not per-process. Only AWS Console apps (initially) are
-eligible for Resource Constraints. `getServerInfoFunc()` is extended so that the `AppServerV3` it returns marks only
-those apps as supporting the feature:
+eligible for Resource Constraints. Before each heartbeat, the App Service sets `ComponentFeatures` on the `AppServerV3`
+via a centralized helper that determines features from the app type:
 
 ```go
-func (s *Server) getServerInfoFunc(app types.Application) func(ctx context.Context) (*types.AppServerV3, error) {
-    return func(ctx context.Context) (*types.AppServerV3, error) {
-        server, err := s.buildAppServerV3(app) // existing metadata / labels / spec
-        if err != nil {
-            return nil, trace.Wrap(err)
-        }
-
-		if app.IsAWSConsole() {
-            server.Spec.ComponentFeatures = &presence.ComponentFeatures{
-                Features: []presence.ComponentFeatureID{
-                    presence.COMPONENT_FEATURE_ID_RESOURCE_CONSTRAINTS_V1,
-                },
-            }
-        }
-
-        return server, nil
+// In lib/componentfeatures/advertisement.go
+func ForAppServer(g appServerInfoGetter) *componentfeaturesv1.ComponentFeatures {
+    if app := g.GetApp(); !app.IsAWSConsole() {
+        return New()
     }
+    return New(FeatureResourceConstraintsV1)
 }
+
+// In lib/srv/app/server.go, called before each heartbeat
+server.SetComponentFeatures(componentfeatures.ForAppServer(server))
 ```
 
 As multiple app servers may serve a single application, the aggregation logic used in `UnifiedResourcesCache` should
@@ -211,7 +289,7 @@ be updated to intersect the `ComponentFeatures` of all `AppServerV3` records bac
 // New wrappers around types.AppServer to hold aggregated features
 type aggregatedAppServer struct {
 	types.AppServer
-	features *presence.ComponentFeatures
+	features *componentfeaturesv1.ComponentFeatures
 }
 func (a *aggregatedAppServer) Copy() types.AppServer {
     out := a.AppServer.Copy()
@@ -225,7 +303,7 @@ func (a *aggregatedAppServer) CloneResource() types.ResourceWithLabels {
 }
 
 // Compute intersection of features across multiple app servers
-func intersectComponentFeaturesApp(servers map[string]types.AppServer) *presence.ComponentFeatures { /*...*/ }
+func intersectComponentFeaturesApp(servers map[string]types.AppServer) *componentfeaturesv1.ComponentFeatures { /*...*/ }
 
 // Wire up in newResourceCollection
 func newResourceCollection(r resource) resourceCollection {
@@ -277,9 +355,9 @@ heartbeat, err := srv.NewHeartbeat(srv.HeartbeatConfig{
                 Addr:     authAddr,
                 Hostname: process.Config.Hostname,
                 Version:  teleport.Version,
-				ComponentFeatures: &presence.ComponentFeatures{
-                    Features: []presence.ComponentFeatureID{
-						presence.COMPONENT_FEATURE_ID_RESOURCE_CONSTRAINTS_V1,
+				ComponentFeatures: &componentfeaturesv1.ComponentFeatures{
+                    Features: []componentfeaturesv1.ComponentFeatureID{
+						componentfeaturesv1.ComponentFeatureID_COMPONENT_FEATURE_ID_RESOURCE_CONSTRAINTS_V1,
                     },
                 },
             },
@@ -294,8 +372,8 @@ heartbeat, err := srv.NewHeartbeat(srv.HeartbeatConfig{
 When serving Web APIs such as `ClusterUnifiedResourcesGet` (used by the Web UI to list resources as `UnifiedResource`
 records), Proxy:
 
-1. Uses its Auth `accessPoint` to `ListAuthServers()` and `ListProxies()`, computing the intersection of all Auth and
-   Proxy servers' `ComponentFeatures`, then
+1. Uses its Auth `accessPoint` to `ListAuthServers()` and `ListProxyServers()`, computing the intersection of all Auth
+   and Proxy servers' `ComponentFeatures`, then
 2. Intersects that with each `AppServerV3` presence record backing a given AWS Console app, then
 3. Sets a flag (e.g., `SupportsResourceConstraints`) from that intersection on the relevant `UnifiedResource` record.
 
@@ -333,3 +411,12 @@ feature set must be stable for the lifetime of the process (or at least between 
 **Not a config/health channel:** Do not encode configuration values, environment health, or per-tenant state as
 "features". If richer or non-Boolean data is ever needed for coordination, we should introduce a separate, purpose-built
 payload or evolve `ComponentFeatures` with a new field that does not change per-request.
+
+**Agentless resources require explicit handling:** The advertising model assumes a serving agent that heartbeats its own
+capability. An agentless resource has nothing to advertise, so before adding `ComponentFeatures` to a new kind, check
+whether it can reach presence agentless and add that derivation to the derive-at-read step. Do not derive from type for
+agent-served resources, that discards the agent's advertisement and would assume support an older agent does not have.
+See [Agentless resources](#agentless-resources).
+
+**Keep the field server-managed:** Only a serving agent's heartbeat should set `ComponentFeatures`, the same way `status`
+and `revision` are not client-set. Client writes must nil it so a client can't claim support a resource doesn't have.

--- a/rfd/cspell.json
+++ b/rfd/cspell.json
@@ -227,6 +227,7 @@
     "ECSEC",
     "Edoardo",
     "edwarddowling",
+    "EICE",
     "ekcert",
     "ekpub",
     "eksctl",


### PR DESCRIPTION
## Context
RFD 230 introduced `ComponentFeatures`, a small capability payload that services attach to the presence resources they already heartbeat, so consumers like Proxy/Web can intersect support across a request path and hide flows the path can't honor. Its first use was in gating Resource Constraints (RFD 228).

The original design assumed every resource is served by some agent that heartbeats its own capability onto the resource item. That assumption breaks for resources that reach presence without such a heartbeat, e.g., an app served by an integration (AWS console apps via an OIDC or Roles Anywhere integration), an OpenSSH or OpenSSH-EICE node, or a desktop. These carry no advertisement, so a naïve read treats them as unsupported, and the integration-served app case slipped through during Resource Constraints implementation and surfaced as incorrect gating. The model needed to say, per resource kind, whether it can be "agentless", how to detect that, and how to determine support without a heartbeat for those cases.

## Changes
- **Outlines trust boundary:** Makes explicit that an advertisement is only trustworthy when an agent sets it over the inventory control stream (which reaches Auth directly); anything that reaches presence through the authorized API carries none. The authorized `Upsert*` paths must nil the field so a client can't forge support.
- **Adds agentless resources section:** Adds `GetEffectiveServerFeatures`, the shared derive-at-read function run by both Auth's unified-resource cache and Proxy's handler, and explains how agentless support is derived from type and intersected with the components that serve it.
- **Per-rsource-kind decisions:** Records, for each kind (apps, SSH nodes, databases, Kubernetes, Windows and Linux desktops), whether it can be agentless, the detection signal, and the handling. Desktops are a notable case as they reach presence through the authorized API, so they never carry an advertisement and should always be derived.
- **Terminology and follow-up:** Defines "agent-less" and "agent-served" and records open items (the API-write nil-ing is not yet implemented, the Proxy SSH read path still reads the raw field, and where the `windows_desktop_service`'s own advertisement lives is an open sub-decision).

## Related
Split from gravitational/teleport#68165.
