### PR TITLE
docs: Adds a left-nav Beams entry to the docs navigation

### DIFF
--- a/docs/sidebar.json
+++ b/docs/sidebar.json
@@ -170,7 +170,7 @@
     {
       "type": "doc",
       "label": "Beams",
-      "id": "beams",
+      "id": "beams/beams",
       "customProps": {
         "tag": "new"
       }

--- a/docs/sidebar.json
+++ b/docs/sidebar.json
@@ -168,6 +168,14 @@
       ]
     },
     {
+      "type": "doc",
+      "label": "Beams",
+      "id": "beams",
+      "customProps": {
+        "tag": "new"
+      }
+    },
+    {
       "type": "category",
       "label": "User Guides",
       "collapsible": true,


### PR DESCRIPTION
Adds a top-level Beams entry to the docs **left navigation** (`docs/sidebar.json`), positioned between Agentic Identity Framework and User Guides, with a "new" badge.

```
{
  "type": "doc",
  "label": "Beams",
  "id": "beams/beams",
  "customProps": { "tag": "new" }
}
```

The Beams page (`docs/pages/beams/beams.mdx`) is published and reachable, but had no entry in the left sidebar, so it was undiscoverable from navigation. The top navbar entry was added separately in gravitational/docs-website (`data/docs-navigation.json`) via https://github.com/gravitational/docs-website/pull/721; this PR completes the wiring by giving Beams a home in the left sidebar.

