### PR TITLE
[v18] docs: Adds a left-nav Beams entry to the docs navigation

### DIFF
--- a/docs/sidebar.json
+++ b/docs/sidebar.json
@@ -163,6 +163,14 @@
       "customProps": { "tag": "new" }
     },
     {
+      "type": "doc",
+      "label": "Beams",
+      "id": "beams",
+      "customProps": {
+        "tag": "new"
+      }
+    },
+    {
       "type": "category",
       "label": "User Guides",
       "collapsible": true,

--- a/docs/sidebar.json
+++ b/docs/sidebar.json
@@ -165,7 +165,7 @@
     {
       "type": "doc",
       "label": "Beams",
-      "id": "beams",
+      "id": "beams/beams",
       "customProps": {
         "tag": "new"
       }


### PR DESCRIPTION
Backport #68070 to branch/v18