### PR TITLE
hash public_addr support for scoped apps

### DIFF
--- a/api/types/appserver.go
+++ b/api/types/appserver.go
@@ -111,7 +111,7 @@ func NewAppServerV3FromApp(app *AppV3, hostname, hostID string) (*AppServerV3, e
 		Hostname: hostname,
 		HostID:   hostID,
 		App:      app,
-	})
+	}, app.GetScope())
 }
 
 // NewAppServerForAWSOIDCIntegration creates a new AppServer that will be used to grant AWS App Access

--- a/lib/inventory/controller.go
+++ b/lib/inventory/controller.go
@@ -44,6 +44,7 @@ import (
 	"github.com/gravitational/teleport/api/utils/retryutils"
 	"github.com/gravitational/teleport/lib/inventory/internal/delay"
 	"github.com/gravitational/teleport/lib/scopes"
+	scopedapp "github.com/gravitational/teleport/lib/scopes/app"
 	"github.com/gravitational/teleport/lib/services"
 	usagereporter "github.com/gravitational/teleport/lib/usagereporter/teleport"
 	"github.com/gravitational/teleport/lib/utils"
@@ -1067,9 +1068,15 @@ func (c *Controller) handleAppServerHB(handle *upstreamHandle, appServer *types.
 		return trace.AccessDenied("incorrect app server scope (expected %q, got %q)", handle.Hello().GetScope(), appServer.Scope)
 	}
 
+	app := appServer.GetApp()
+
 	// Require the embedded app scope to equal the server scope.
-	if app := appServer.GetApp(); app != nil && !services.AppServerScopesEqual(appServer.Scope, app.GetScope()) {
+	if app != nil && !services.AppServerScopesEqual(appServer.Scope, app.GetScope()) {
 		return trace.AccessDenied("incorrect embedded app scope (server scope %q does not match app scope %q)", appServer.Scope, app.GetScope())
+	}
+
+	if appServer.Scope != "" && !scopedapp.ScopedAppPublicAddrValid(app.GetScope(), app.GetName(), app.GetPublicAddr()) {
+		return trace.AccessDenied("scoped app %q public address %q does not match its derived address for scope %q", app.GetName(), app.GetPublicAddr(), app.GetScope())
 	}
 
 	// Older agents send mixed-case names and URL-shaped public_addr;

--- a/lib/inventory/controller_test.go
+++ b/lib/inventory/controller_test.go
@@ -45,6 +45,7 @@ import (
 	joiningv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/joining/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/inventory/metadata"
+	scopedapp "github.com/gravitational/teleport/lib/scopes/app"
 	usagereporter "github.com/gravitational/teleport/lib/usagereporter/teleport"
 	"github.com/gravitational/teleport/lib/utils"
 	"github.com/gravitational/teleport/lib/utils/log/logtest"
@@ -931,9 +932,11 @@ func TestScopedAppServer(t *testing.T) {
 	t.Parallel()
 
 	// happy path: server and app scopes match the hello scope (static registration).
-	synctest.Test(t, testAppServerScoped("/test", "/test", "/test", true))
+	synctest.Test(t, testAppServerScoped("/test", "/test", "/test", "", true))
 	// embedded app scope is different from the server scope.
-	synctest.Test(t, testAppServerScoped("/test", "/test", "/test/child", false))
+	synctest.Test(t, testAppServerScoped("/test", "/test", "/test/child", "", false))
+	// add incorrect app computed public addr
+	synctest.Test(t, testAppServerScoped("/test", "/test", "/test", "overridenpublicaddr.com", false))
 }
 
 // appTestController bundles the pieces an app-server heartbeat test needs from a
@@ -1044,9 +1047,14 @@ func testAppServerHeartbeatNormalization(t *testing.T) {
 	require.Equal(t, "mixedcaseapp.example.com", srv.resource.GetApp().GetPublicAddr())
 }
 
-func testAppServerScoped(initialScope, serverScope, appScope string, expectOK bool) func(t *testing.T) {
+func testAppServerScoped(initialScope, serverScope, appScope, publicAddrOverride string, expectOK bool) func(t *testing.T) {
 	return func(t *testing.T) {
 		c := newAppTestController(t, initialScope)
+
+		pubAddr := scopedapp.ScopedAppPublicAddr(appScope, "app", "teleport.example.com")
+		if publicAddrOverride != "" {
+			pubAddr = publicAddrOverride
+		}
 
 		err := c.downstream.Send(c.ctx, proto.InventoryHeartbeat_builder{
 			AppServer: &types.AppServerV3{
@@ -1059,7 +1067,10 @@ func testAppServerScoped(initialScope, serverScope, appScope string, expectOK bo
 						Version:  types.V3,
 						Scope:    appScope,
 						Metadata: types.Metadata{Name: "app"},
-						Spec:     types.AppSpecV3{URI: "http://localhost:8080"},
+						Spec: types.AppSpecV3{
+							URI:        "http://localhost:8080",
+							PublicAddr: pubAddr,
+						},
 					},
 				},
 			},

--- a/lib/scopes/app/appsqdn.go
+++ b/lib/scopes/app/appsqdn.go
@@ -1,0 +1,84 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package app
+
+import (
+	"crypto/sha3"
+	"encoding/base32"
+	"net"
+	"strings"
+)
+
+const (
+	// scopedPubAddrHashBytes is the number of hash bytes kept before base32
+	// encoding. 20 bytes (160 bits) is collision-free for any realistic number
+	// of scoped apps.
+	scopedPubAddrHashBytes = 20
+
+	// scopedSubdomainLen is the length of an encoded scope/app subdomain: a 20-byte hash
+	// base32-encodes to exactly 32 characters.
+	scopedSubdomainLen = 32
+)
+
+// scopeEncoder is base32 without padding.
+var scopedAppEncoder = base32.StdEncoding.WithPadding(base32.NoPadding)
+
+// scopedSubdomain encodes a scoped app's (name, scope) into a single DNS label
+func generateScopedSubDomain(appName, scope string) string {
+	h := sha3.Sum256([]byte(appName + "\x00" + scope))
+	return strings.ToLower(scopedAppEncoder.EncodeToString(h[:scopedPubAddrHashBytes]))
+}
+
+// scopeSubdomainOk reports whether the subdomain is a valid string produced by
+// ScopedSubdomain: exactly 32 lowercase base32 characters (a-z, 2-7).
+func scopeSubdomainOk(subdomain string) bool {
+	if len(subdomain) != scopedSubdomainLen {
+		return false
+	}
+	for _, r := range subdomain {
+		if (r < 'a' || r > 'z') && (r < '2' || r > '7') {
+			return false
+		}
+	}
+	return true
+}
+
+// ScopedAppPublicAddr returns the derived public address for a scoped app (Scope Qualified SubDomain):
+// "<ScopedSubdomain(name, scope)>.<proxy>".
+// The trailing port on the proxy is stripped and the host is lowercased so the result
+// is a valid public address.
+func ScopedAppPublicAddr(scope, appName, localProxyDNSName string) string {
+	if host, _, err := net.SplitHostPort(localProxyDNSName); err == nil {
+		localProxyDNSName = host
+	}
+	return generateScopedSubDomain(appName, scope) + "." + strings.ToLower(localProxyDNSName)
+}
+
+// ScopedAppPublicAddrValid reports whether publicAddr is a valid derived address
+// for the scoped app (appName, scope).
+func ScopedAppPublicAddrValid(scope, appName, publicAddr string) bool {
+	parts := strings.Split(strings.TrimSuffix(publicAddr, "."), ".")
+	if len(parts) < 2 {
+		return false
+	}
+
+	if !scopeSubdomainOk(parts[0]) {
+		return false
+	}
+	subdomain := parts[0]
+	return subdomain == generateScopedSubDomain(appName, scope)
+}

--- a/lib/scopes/app/appsqdn_test.go
+++ b/lib/scopes/app/appsqdn_test.go
@@ -1,0 +1,116 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package app
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func FuzzScopedAppPublicAddr(f *testing.F) {
+	f.Add("grafana", "/staging/west", "grafana", "/prod")
+	f.Add("some-app", "/test", "other-app", "/dev")
+	f.Add("app", "/team", "app", "/team")
+
+	const proxy = "proxy.example.com"
+	f.Fuzz(func(t *testing.T, name1, scope1, name2, scope2 string) {
+		addr := ScopedAppPublicAddr(scope1, name1, proxy)
+		// same named apps and scopes should always pass
+		if name1 == name2 && scope1 == scope2 {
+			require.True(t, ScopedAppPublicAddrValid(scope2, name2, addr))
+		} else {
+			require.False(t, ScopedAppPublicAddrValid(scope2, name2, addr),
+				"address for (%q, %q) must not validate for (%q, %q)", name1, scope1, name2, scope2)
+		}
+	})
+}
+
+func TestScopedAppPublicAddr(t *testing.T) {
+	const proxy = "proxy.example.com"
+	// This is the computed value for the app grafana on the /staging/west scope
+	// Any changes to the ScopedAppPublicAddr function should also change the const value here.
+	const addr = "r6rav2u7627smkmskj5ep2ttwizny3gn" + "." + proxy
+	require.Equal(t, addr, ScopedAppPublicAddr("/staging/west", "grafana", proxy))
+
+	// Distinct (name, scope) pairs hash to distinct labels.
+	require.NotEqual(t, addr, ScopedAppPublicAddr("/prod", "grafana", proxy))
+	require.NotEqual(t, addr, ScopedAppPublicAddr("/staging/west", "other", proxy))
+
+	// A trailing port on the proxy is stripped and the host is lowercased.
+	require.Equal(t, addr, ScopedAppPublicAddr("/staging/west", "grafana", "Proxy.Example.com:443"))
+}
+
+func TestVerifyScopedAppPublicAddr(t *testing.T) {
+	const proxy = "teleport.example.com"
+	validAddr := ScopedAppPublicAddr("/staging/west", "grafana", proxy)
+
+	tests := []struct {
+		name             string
+		scope, app, addr string
+		want             bool
+	}{
+		{
+			name:  "matches",
+			scope: "/staging/west",
+			app:   "grafana",
+			addr:  validAddr,
+			want:  true,
+		},
+		{
+			name:  "wrong scope",
+			scope: "/prod",
+			app:   "grafana",
+			addr:  validAddr,
+			want:  false,
+		},
+		{
+			name:  "wrong name",
+			scope: "/staging/west",
+			app:   "other",
+			addr:  validAddr,
+			want:  false,
+		},
+		{
+			name:  "empty addr",
+			scope: "/staging/west",
+			app:   "grafana",
+			addr:  "",
+			want:  false,
+		},
+		{
+			name:  "plain app name, not a hash label",
+			scope: "/staging/west",
+			app:   "grafana",
+			addr:  "grafana." + proxy,
+			want:  false,
+		},
+		{
+			name:  "without proxy",
+			scope: "/staging/west",
+			app:   "grafana",
+			addr:  generateScopedSubDomain("grafana", "/staging/west"),
+			want:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, ScopedAppPublicAddrValid(tt.scope, tt.app, tt.addr))
+		})
+	}
+}

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -6917,7 +6917,12 @@ func (process *TeleportProcess) initApps() {
 		// Loop over each application and create a server.
 		var applications types.Apps
 		for _, app := range process.Config.Apps.Apps {
-			publicAddr, err := getPublicAddr(process.ExitContext(), accessPoint, app)
+			// A scoped app's public_addr is derived from its (name, scope); a
+			// user must not set it.
+			if scopePin.GetScope() != "" && app.PublicAddr != "" {
+				return trace.BadParameter("app %q is scoped and must not set public_addr; it is derived from the app name and scope", app.Name)
+			}
+			publicAddr, err := getPublicAddr(process.ExitContext(), accessPoint, app, scopePin.GetScope())
 			if err != nil {
 				return trace.Wrap(err)
 			}
@@ -7476,8 +7481,9 @@ func dumperHandler(w http.ResponseWriter, r *http.Request) {
 	fmt.Fprint(w, string(requestDump))
 }
 
-// getPublicAddr waits for a proxy to be registered with Teleport.
-func getPublicAddr(ctx context.Context, authClient authclient.ReadAppsAccessPoint, a servicecfg.App) (string, error) {
+// getPublicAddr waits for a proxy to be registered with Teleport. For a scoped
+// app (scope != ""), the returned address is the derived scope-qualified subdomain.
+func getPublicAddr(ctx context.Context, authClient authclient.ReadAppsAccessPoint, a servicecfg.App, scope string) (string, error) {
 	ticker := time.NewTicker(500 * time.Millisecond)
 	defer ticker.Stop()
 	timeout := time.NewTimer(5 * time.Second)
@@ -7486,7 +7492,7 @@ func getPublicAddr(ctx context.Context, authClient authclient.ReadAppsAccessPoin
 	for {
 		select {
 		case <-ticker.C:
-			publicAddr, err := app.FindPublicAddr(ctx, authClient, a.PublicAddr, a.Name)
+			publicAddr, err := app.FindPublicAddr(ctx, authClient, a.PublicAddr, a.Name, scope)
 			if err == nil {
 				return publicAddr, nil
 			}

--- a/lib/services/app.go
+++ b/lib/services/app.go
@@ -49,6 +49,7 @@ import (
 	"github.com/gravitational/teleport/api/utils/tlsutils"
 	"github.com/gravitational/teleport/lib/backend"
 	"github.com/gravitational/teleport/lib/scopes"
+	scopedapp "github.com/gravitational/teleport/lib/scopes/app"
 	"github.com/gravitational/teleport/lib/utils"
 )
 
@@ -134,6 +135,12 @@ func ValidateApp(app types.Application, proxyGetter ProxyGetter) error {
 				app.GetName(),
 				region,
 			)
+		}
+	}
+
+	if scope := app.GetScope(); scope != "" {
+		if !scopedapp.ScopedAppPublicAddrValid(scope, app.GetName(), app.GetPublicAddr()) {
+			return trace.BadParameter("scoped app %q public address %q does not match its derived address for scope %q", app.GetName(), app.GetPublicAddr(), scope)
 		}
 	}
 
@@ -310,11 +317,13 @@ func ValidateAppServer(server types.AppServer, proxyGetter ProxyGetter) error {
 		return trace.BadParameter("app server name %q must be a valid DNS name (lowercase alphanumeric, '-', '_', or '.', must start and end with alphanumeric, max 253 chars): %s", server.GetName(), strings.Join(errs, ", "))
 	}
 
-	if app := server.GetApp(); app != nil && !AppServerScopesEqual(server.GetScope(), app.GetScope()) {
+	app := server.GetApp()
+
+	if app != nil && !AppServerScopesEqual(server.GetScope(), app.GetScope()) {
 		return trace.BadParameter("app server %q scope %q does not match its embedded app scope %q", server.GetName(), server.GetScope(), app.GetScope())
 	}
 
-	return trace.Wrap(ValidateApp(server.GetApp(), proxyGetter))
+	return trace.Wrap(ValidateApp(app, proxyGetter))
 }
 
 // AppServerScopesEqual reports whether an app server's scope and its embedded

--- a/lib/services/app_test.go
+++ b/lib/services/app_test.go
@@ -29,6 +29,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/gravitational/trace"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	v1 "k8s.io/api/core/v1"
@@ -36,12 +37,29 @@ import (
 
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/cryptosuites"
+	scopedapp "github.com/gravitational/teleport/lib/scopes/app"
 	"github.com/gravitational/teleport/lib/tlsca"
 	"github.com/gravitational/teleport/lib/tlscatest"
 	"github.com/gravitational/teleport/lib/utils"
 )
 
 func TestValidateApp(t *testing.T) {
+	// A scoped app's public_addr must be the derived "<hash(name,scope)>.<proxy>"
+	// address; any other value is rejected. The proxy suffix is not checked
+	// (label-only), and a scoped app skips the proxy-collision check entirely.
+	const scopedScope = "/staging/west"
+	scopedApp := func(name, scope, publicAddr string) types.Application {
+		app, err := types.NewAppV3(types.Metadata{Name: name}, types.AppSpecV3{
+			URI:        "http://localhost:3000",
+			PublicAddr: publicAddr,
+		}, scope)
+		require.NoError(t, err)
+		return app
+	}
+	scopedDerived := scopedapp.ScopedAppPublicAddr(scopedScope, "grafana", "proxy.example.com")
+	// Derived for a different scope, so it does not match scopedScope.
+	wrongScopeDerived := scopedapp.ScopedAppPublicAddr("/prod", "grafana", "proxy.example.com")
+
 	tests := []struct {
 		name       string
 		app        types.Application
@@ -228,6 +246,30 @@ func TestValidateApp(t *testing.T) {
 			}(),
 			wantErr: "invalid AWS region",
 		},
+		// Scoped apps: public_addr must be the derived address for (name, scope).
+		{
+			name: "correct derived public_addr accepted",
+			app:  scopedApp("grafana", scopedScope, scopedDerived),
+		},
+		{
+			name: "public_addr with different proxy suffix accepted",
+			app:  scopedApp("grafana", scopedScope, scopedapp.ScopedAppPublicAddr(scopedScope, "grafana", "other.example.com")),
+		},
+		{
+			name:    "empty public_addr rejected",
+			app:     scopedApp("grafana", scopedScope, ""),
+			wantErr: `scoped app "grafana" public address "" does not match its derived address for scope "/staging/west"`,
+		},
+		{
+			name:    "wrong scope's derived address rejected",
+			app:     scopedApp("grafana", scopedScope, wrongScopeDerived),
+			wantErr: `scoped app "grafana" public address "` + wrongScopeDerived + `" does not match its derived address for scope "/staging/west"`,
+		},
+		{
+			name:    "non-derived public_addr rejected",
+			app:     scopedApp("grafana", scopedScope, "grafana.proxy.example.com"),
+			wantErr: `scoped app "grafana" public address "grafana.proxy.example.com" does not match its derived address for scope "/staging/west"`,
+		},
 	}
 
 	for _, tt := range tests {
@@ -242,9 +284,9 @@ func TestValidateApp(t *testing.T) {
 	}
 }
 
-func makeServer(t *testing.T, outerName, innerName, serverScope, appScope string) types.AppServer {
+func makeServer(t *testing.T, outerName, innerName, serverScope, appScope, publicAddr string) types.AppServer {
 	t.Helper()
-	app, err := types.NewAppV3(types.Metadata{Name: innerName}, types.AppSpecV3{URI: "http://localhost:8080"}, appScope)
+	app, err := types.NewAppV3(types.Metadata{Name: innerName}, types.AppSpecV3{URI: "http://localhost:8080", PublicAddr: publicAddr}, appScope)
 	require.NoError(t, err)
 	srv, err := types.NewAppServerV3FromApp(app, "localhost", "host-id")
 	require.NoError(t, err)
@@ -257,13 +299,18 @@ func makeServer(t *testing.T, outerName, innerName, serverScope, appScope string
 func TestValidateAppServer(t *testing.T) {
 	proxyGetter := &mockProxyGetter{addrs: []string{"proxy.example.com:443"}}
 
+	// A scoped app server's embedded app must carry the derived public_addr for
+	// the server's scope; the proxy suffix is not checked (label-only).
+	derivedProd := scopedapp.ScopedAppPublicAddr("/prod", "my-app", "proxy.example.com")
+
 	tests := []struct {
-		name     string
-		srvName  string
-		appName  string
-		srvScope string
-		appScope string
-		wantErr  string
+		name          string
+		srvName       string
+		appName       string
+		srvScope      string
+		appScope      string
+		appPublicAddr string
+		wantErr       string
 	}{
 		// Name validation.
 		{
@@ -289,11 +336,13 @@ func TestValidateAppServer(t *testing.T) {
 		},
 		// Scope validation: the embedded app scope must equal the server scope.
 		{
-			name:     "equal scope accepted",
-			srvName:  "my-srv",
-			appName:  "my-app",
-			srvScope: "/prod",
-			appScope: "/prod"},
+			name:          "equal scope accepted",
+			srvName:       "my-srv",
+			appName:       "my-app",
+			srvScope:      "/prod",
+			appScope:      "/prod",
+			appPublicAddr: derivedProd,
+		},
 		{
 			name:    "unscoped server and app accepted",
 			srvName: "my-srv",
@@ -323,12 +372,22 @@ func TestValidateAppServer(t *testing.T) {
 			appScope: "/prod",
 			wantErr:  `app server "my-srv" scope "" does not match its embedded app scope "/prod"`,
 		},
+		{
+			name:          "scoped non-derived public_addr rejected",
+			srvName:       "my-srv",
+			appName:       "my-app",
+			srvScope:      "/prod",
+			appScope:      "/prod",
+			appPublicAddr: "my-app.proxy.example.com",
+			wantErr:       `scoped app "my-app" public address "my-app.proxy.example.com" does not match its derived address for scope "/prod"`,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := ValidateAppServer(makeServer(t, tt.srvName, tt.appName, tt.srvScope, tt.appScope), proxyGetter)
+			err := ValidateAppServer(makeServer(t, tt.srvName, tt.appName, tt.srvScope, tt.appScope, tt.appPublicAddr), proxyGetter)
 			if tt.wantErr != "" {
 				require.EqualError(t, err, tt.wantErr)
+				require.True(t, trace.IsBadParameter(err), "want BadParameter, got %v", err)
 			} else {
 				require.NoError(t, err)
 			}

--- a/lib/services/readonly/readonly.go
+++ b/lib/services/readonly/readonly.go
@@ -244,6 +244,8 @@ type Application interface {
 	GetRequiredAppNames() []string
 	// GetCORS returns the CORS configuration for the app.
 	GetCORS() *types.CORSPolicy
+	// GetScope returns the scope
+	GetScope() string
 }
 
 var _ Application = types.Application(nil)

--- a/lib/srv/app/server.go
+++ b/lib/srv/app/server.go
@@ -372,6 +372,7 @@ func (s *Server) getServerInfo(app types.Application) (*types.AppServerV3, error
 	s.mu.RLock()
 	copy := s.appWithUpdatedLabelsLocked(app)
 	s.mu.RUnlock()
+
 	expires := s.c.Clock.Now().UTC().Add(apidefaults.ServerAnnounceTTL)
 	server, err := types.NewAppServerV3(types.Metadata{
 		Name:    copy.GetName(),
@@ -709,6 +710,17 @@ func (s *Server) appWithUpdatedLabelsLocked(app types.Application) *types.AppV3 
 	// Add in the cloud labels if the app has them.
 	if s.c.CloudLabels != nil {
 		s.c.CloudLabels.Apply(copy)
+	}
+
+	// A statically configured app on a scoped agent carries no scope, so use the agent's scope
+	// onto it.
+	// An app that already has a scope keeps it, rather than being silently re-scoped to the
+	// agent's scope.
+	// If it doesn't match this agent's scope, the resulting server/app scope mismatch
+	// is rejected via heartbeat (ValidateAppServer and the inventory controller).
+	// TODO (williamo/scopes) - reject scoped app creation via tctl
+	if copy.GetScope() == "" {
+		copy.Scope = s.c.GetScope()
 	}
 
 	return copy

--- a/lib/srv/app/watcher.go
+++ b/lib/srv/app/watcher.go
@@ -26,6 +26,7 @@ import (
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/utils/clientutils"
+	scopedapp "github.com/gravitational/teleport/lib/scopes/app"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/services/readonly"
 	"github.com/gravitational/teleport/lib/utils"
@@ -96,7 +97,9 @@ func (s *Server) startResourceWatcher(ctx context.Context) (*services.GenericWat
 			case apps := <-watcher.ResourcesC:
 				for _, app := range apps {
 					if app.GetPublicAddr() == "" {
-						pubAddr, err := FindPublicAddr(ctx, s.c.AccessPoint, app.GetPublicAddr(), app.GetName())
+						// TODO (williamo/scopes): Dynamic app registration does not support scoped apps
+						// add scoped app here when we do support it.
+						pubAddr, err := FindPublicAddr(ctx, s.c.AccessPoint, app.GetPublicAddr(), app.GetName(), "")
 						if err == nil {
 							app.SetPublicAddr(pubAddr)
 						} else {
@@ -139,9 +142,23 @@ type FindPublicAddrClient interface {
 }
 
 // FindPublicAddr tries to resolve the public address of the proxy of this cluster.
-func FindPublicAddr(ctx context.Context, client FindPublicAddrClient, appPublicAddr string, appName string) (string, error) {
-	// If the application has a public address already set, use it.
-	if appPublicAddr != "" {
+//
+// For a scoped app, the address is always derived as the
+// scope-qualified FQDN "<hash(name,scope)>.<proxy>"
+// TODO(williamo/scopes): We added a scopeVar as a variadic parameter to not break the e submodule.
+// This will be amended in a future PR.
+func FindPublicAddr(ctx context.Context, client FindPublicAddrClient, appPublicAddr, appName string, scopeVar ...string) (string, error) {
+	// If the application has a public address already set, use it. Scoped apps
+	// always derive their address, so the config value is not honored.
+	scope := ""
+	switch len(scopeVar) {
+	case 1:
+		scope = scopeVar[0]
+	case 0:
+	default:
+		return "", trace.BadParameter("multiple scopes not allowed")
+	}
+	if appPublicAddr != "" && scope == "" {
 		return appPublicAddr, nil
 	}
 
@@ -161,6 +178,9 @@ func FindPublicAddr(ctx context.Context, client FindPublicAddrClient, appPublicA
 		if err != nil {
 			return "", trace.Wrap(err)
 		}
+		if scope != "" {
+			return scopedapp.ScopedAppPublicAddr(scope, appName, addr.Host()), nil
+		}
 		return utils.DefaultAppFQDN(appName, addr.Host(), ""), nil
 	}
 
@@ -168,6 +188,10 @@ func FindPublicAddr(ctx context.Context, client FindPublicAddrClient, appPublicA
 	cn, err := client.GetClusterName(context.TODO())
 	if err != nil {
 		return "", trace.Wrap(err)
+	}
+
+	if scope != "" {
+		return scopedapp.ScopedAppPublicAddr(scope, appName, cn.GetClusterName()), nil
 	}
 	return utils.DefaultAppFQDN(appName, "", cn.GetClusterName()), nil
 }

--- a/lib/utils/app.go
+++ b/lib/utils/app.go
@@ -23,6 +23,7 @@ import (
 	"strings"
 
 	"github.com/gravitational/teleport/api/types"
+	scopedapp "github.com/gravitational/teleport/lib/scopes/app"
 )
 
 // AssembleAppFQDN returns the application's FQDN.
@@ -32,8 +33,14 @@ import (
 //
 // In all other cases, i.e. if the public address is not set or the application
 // is running in a remote cluster, the FQDN is formatted as
-// <appName>.<localProxyDNSName>
+// <appName>.<localProxyDNSName>.
+// A scoped app is always addressed by its computed hash label under the
+// selected proxy as <hash(appName, scope)>.<localProxyDNSName>.
 func AssembleAppFQDN(localClusterName string, localProxyDNSName string, appClusterName string, app types.Application) string {
+	if scope := app.GetScope(); scope != "" {
+		return scopedapp.ScopedAppPublicAddr(scope, app.GetName(), localProxyDNSName)
+	}
+
 	isLocalCluster := localClusterName == appClusterName
 	if isLocalCluster && app.GetPublicAddr() != "" && !app.GetUseAnyProxyPublicAddr() {
 		return app.GetPublicAddr()

--- a/lib/utils/app_test.go
+++ b/lib/utils/app_test.go
@@ -20,6 +20,9 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport/api/types"
+	scopedapp "github.com/gravitational/teleport/lib/scopes/app"
 )
 
 func TestDefaultAppFQDN(t *testing.T) {
@@ -63,6 +66,67 @@ func TestDefaultAppFQDN(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			got := DefaultAppFQDN(tt.appName, tt.proxyPublicAddrHost, tt.clusterName)
 			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestAssembleAppFQDN(t *testing.T) {
+	const (
+		cluster = "cluster.example.com"
+		proxy   = "proxy.example.com"
+	)
+
+	tests := []struct {
+		name        string
+		appName     string
+		publicAddr  string
+		scope       string
+		useAnyProxy bool
+		want        string
+	}{
+		{
+			name:       "unscoped uses public_addr",
+			appName:    "grafana",
+			publicAddr: "grafana.example.com",
+			want:       "grafana.example.com",
+		},
+		{
+			name:        "unscoped use_any_proxy_public_addr falls back to <name>.<proxy>",
+			appName:     "grafana",
+			publicAddr:  "grafana.example.com",
+			useAnyProxy: true,
+			want:        "grafana.proxy.example.com",
+		},
+		{
+			name:        "scoped app derives hash under selected proxy despite use_any_proxy_public_addr",
+			appName:     "grafana",
+			scope:       "/staging/west",
+			publicAddr:  scopedapp.ScopedAppPublicAddr("/staging/west", "grafana", proxy),
+			useAnyProxy: true,
+			want:        scopedapp.ScopedAppPublicAddr("/staging/west", "grafana", proxy),
+		},
+		{
+			name:    "scoped app in /east derives its own hash",
+			appName: "grafana",
+			scope:   "/east",
+			want:    scopedapp.ScopedAppPublicAddr("/east", "grafana", proxy),
+		},
+		{
+			name:    "scoped app in /west derives its own hash",
+			appName: "grafana",
+			scope:   "/west",
+			want:    scopedapp.ScopedAppPublicAddr("/west", "grafana", proxy),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			app, err := types.NewAppV3(types.Metadata{Name: tt.appName}, types.AppSpecV3{
+				URI:                   "http://localhost:8080",
+				PublicAddr:            tt.publicAddr,
+				UseAnyProxyPublicAddr: tt.useAnyProxy,
+			}, tt.scope)
+			require.NoError(t, err)
+			require.Equal(t, tt.want, AssembleAppFQDN(cluster, proxy, cluster, app))
 		})
 	}
 }

--- a/lib/web/apiserver_test.go
+++ b/lib/web/apiserver_test.go
@@ -142,6 +142,7 @@ import (
 	"github.com/gravitational/teleport/lib/reversetunnel"
 	"github.com/gravitational/teleport/lib/reversetunnelclient"
 	"github.com/gravitational/teleport/lib/scopes"
+	scopedapp "github.com/gravitational/teleport/lib/scopes/app"
 	"github.com/gravitational/teleport/lib/secret"
 	"github.com/gravitational/teleport/lib/service/servicecfg"
 	"github.com/gravitational/teleport/lib/services"
@@ -5003,11 +5004,43 @@ func TestGetAppDetails(t *testing.T) {
 
 	clientFQDN := "client.example.com"
 
+	const scope = "/staging/west"
+	const proxyDNS = "localhost"
+
+	scopedApp, err := types.NewAppV3(types.Metadata{
+		Name: "scoped-app",
+	}, types.AppSpecV3{
+		URI:                   "http://127.0.0.1:8080",
+		PublicAddr:            scopedapp.ScopedAppPublicAddr(scope, "scoped-app", proxyDNS),
+		UseAnyProxyPublicAddr: true,
+		RequiredAppNames:      []string{},
+	}, scope)
+	require.NoError(t, err)
+	scopedClientServer, err := types.NewAppServerV3FromApp(scopedApp, "host", uuid.New().String())
+	require.NoError(t, err)
+	_, err = s.server.Auth().UpsertApplicationServer(s.ctx, scopedClientServer)
+	require.NoError(t, err)
+
+	scopedAppWithRequiredApp, err := types.NewAppV3(types.Metadata{
+		Name: "bad-app",
+	}, types.AppSpecV3{
+		URI:                   "http://127.0.0.1:8080",
+		PublicAddr:            scopedapp.ScopedAppPublicAddr(scope, "bad-app", proxyDNS),
+		UseAnyProxyPublicAddr: true,
+		RequiredAppNames:      []string{"scoped-dependency"},
+	}, scope)
+	require.NoError(t, err)
+	scopedClientServer2, err := types.NewAppServerV3FromApp(scopedAppWithRequiredApp, "host", uuid.New().String())
+	require.NoError(t, err)
+	_, err = s.server.Auth().UpsertApplicationServer(s.ctx, scopedClientServer2)
+	require.NoError(t, err)
+
 	tests := []struct {
 		name             string
 		endpoint         string
 		fqdn             string
 		expectedResponse GetAppDetailsResponse
+		wantErr          string
 	}{
 		{
 			name:     "request app details with clientName and publicAddr",
@@ -5041,6 +5074,19 @@ func TestGetAppDetails(t *testing.T) {
 				RequiredAppFQDNs: []string{"client.web.localhost"},
 			},
 		},
+		{
+			name:     "scoped app derives hash FQDNs for itself",
+			endpoint: pack.clt.Endpoint("webapi", "apps", scopedApp.GetPublicAddr(), s.server.ClusterName(), scopedApp.GetPublicAddr()),
+			expectedResponse: GetAppDetailsResponse{
+				FQDN:             scopedapp.ScopedAppPublicAddr(scope, "scoped-app", proxyDNS),
+				RequiredAppFQDNs: []string{scopedapp.ScopedAppPublicAddr(scope, "scoped-app", proxyDNS)},
+			},
+		},
+		{
+			name:     "scoped app with required apps fails",
+			endpoint: pack.clt.Endpoint("webapi", "apps", scopedAppWithRequiredApp.GetPublicAddr(), s.server.ClusterName(), scopedAppWithRequiredApp.GetPublicAddr()),
+			wantErr:  "scoped apps do not support required app redirects",
+		},
 	}
 
 	for _, tc := range tests {
@@ -5048,6 +5094,10 @@ func TestGetAppDetails(t *testing.T) {
 			t.Parallel()
 
 			re, err := pack.clt.Get(ctx, tc.endpoint, url.Values{})
+			if tc.wantErr != "" {
+				require.ErrorContains(t, err, tc.wantErr)
+				return
+			}
 			require.NoError(t, err)
 			resp := GetAppDetailsResponse{}
 

--- a/lib/web/app/match.go
+++ b/lib/web/app/match.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/reversetunnelclient"
+	scopedapp "github.com/gravitational/teleport/lib/scopes/app"
 	"github.com/gravitational/teleport/lib/services/readonly"
 	"github.com/gravitational/teleport/lib/utils"
 )
@@ -61,7 +62,7 @@ type Matcher func(readonly.AppServer) bool
 func MatchAppServerForRoute(name, publicAddr string) Matcher {
 	return func(appServer readonly.AppServer) bool {
 		app := appServer.GetApp()
-		if publicAddr != "" && app.GetPublicAddr() != publicAddr {
+		if publicAddr != "" && !appMatchesPublicAddr(app, publicAddr) {
 			return false
 		}
 		if name != "" && app.GetName() != name {
@@ -74,8 +75,21 @@ func MatchAppServerForRoute(name, publicAddr string) Matcher {
 // MatchPublicAddr matches on the public address of an application.
 func MatchPublicAddr(publicAddr string) Matcher {
 	return func(appServer readonly.AppServer) bool {
-		return appServer.GetApp().GetPublicAddr() == publicAddr
+		return appMatchesPublicAddr(appServer.GetApp(), publicAddr)
 	}
+}
+
+// appMatchesPublicAddr reports whether the app should answer for the requested
+// public address.
+// Scoped apps match on the computed subdomain only,
+// so the app resolves regardless of which proxy the FQDN was assembled under.
+// Unscoped apps require an exact public_addr match.
+func appMatchesPublicAddr(app readonly.Application, publicAddr string) bool {
+	if scope := app.GetScope(); scope != "" {
+		return scopedapp.ScopedAppPublicAddrValid(scope, app.GetName(), publicAddr)
+	}
+
+	return app.GetPublicAddr() == publicAddr
 }
 
 // MatchName matches on the name of an application.
@@ -115,7 +129,21 @@ func ResolveFQDN(
 	// Try and match FQDN to public address of application within cluster.
 	servers, err := MatchUnshuffled(ctx, clusterClient, MatchPublicAddr(fqdn))
 	if err == nil && len(servers) > 0 {
-		return pickAppServer(servers, canAccess), localClusterName, nil
+		srv := pickAppServer(servers, canAccess)
+		// A scoped app is addressed as <hash>.<proxy> and its hashed subdomain matches regardless of the
+		// suffix, so confirm the FQDN actually sits under a configured proxy DNS name before trusting a
+		// scoped match, otherwise "<hash>.somewebsite.com" resolves.
+		if srv.GetApp().GetScope() != "" {
+			host := strings.Split(fqdn, ":")[0]
+			// In the case where FindMatchingProxyDNS finds an actual found proxy match, this check is redundant.
+			// In the case where it finds no matches, FindMatchingProxyDNS returns the first element of proxyDNSNames,
+			// we must recheck to make sure that the proxy found matches, and reject if it doesn't.
+			proxyMatch := strings.Split(utils.FindMatchingProxyDNS(fqdn, proxyDNSNames), ":")[0]
+			if host != proxyMatch && !strings.HasSuffix(host, "."+proxyMatch) {
+				return nil, "", trace.BadParameter("FQDN %q is not a subdomain of the proxy", fqdn)
+			}
+		}
+		return srv, localClusterName, nil
 	}
 
 	proxyPublicAddr := utils.FindMatchingProxyDNS(fqdn, proxyDNSNames)

--- a/lib/web/app/match_test.go
+++ b/lib/web/app/match_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/gravitational/teleport/api/types"
+	scopedapp "github.com/gravitational/teleport/lib/scopes/app"
 )
 
 func TestMatchAppServerForRoute(t *testing.T) {
@@ -31,8 +32,9 @@ func TestMatchAppServerForRoute(t *testing.T) {
 	for _, test := range []struct {
 		desc string
 
-		appName string
-		appAddr string
+		appName  string
+		appAddr  string
+		appScope string
 
 		name string
 		addr string
@@ -103,6 +105,25 @@ func TestMatchAppServerForRoute(t *testing.T) {
 			addr:      "",
 			wantMatch: false,
 		},
+		// scoped app matching - matches based on its computed app name and scope as the subdomain.
+		{
+			desc:      "scoped app matches its hash under a different proxy",
+			appName:   "grafana",
+			appScope:  "/staging/west",
+			appAddr:   scopedapp.ScopedAppPublicAddr("/staging/west", "grafana", "teleport.example.com"),
+			name:      "grafana",
+			addr:      scopedapp.ScopedAppPublicAddr("/staging/west", "grafana", "teleportalt.example.com"),
+			wantMatch: true,
+		},
+		{
+			desc:      "scoped app does not match a different scope's hash",
+			appName:   "grafana",
+			appScope:  "/staging/west",
+			appAddr:   scopedapp.ScopedAppPublicAddr("/staging/west", "grafana", "teleport.example.com"),
+			name:      "grafana",
+			addr:      scopedapp.ScopedAppPublicAddr("/prod", "grafana", "teleportalt.example.com"),
+			wantMatch: false,
+		},
 	} {
 		t.Run(test.desc, func(t *testing.T) {
 			appServer, err := types.NewAppServerV3(
@@ -111,6 +132,7 @@ func TestMatchAppServerForRoute(t *testing.T) {
 					HostID: "test-host-id",
 					App: &types.AppV3{
 						Metadata: types.Metadata{Name: test.appName},
+						Scope:    test.appScope,
 						Spec: types.AppSpecV3{
 							PublicAddr: test.appAddr,
 							URI:        "http://localhost:12345",

--- a/lib/web/apps.go
+++ b/lib/web/apps.go
@@ -87,6 +87,10 @@ func (h *Handler) getAppDetails(w http.ResponseWriter, r *http.Request, p httpro
 		if clusterName == "" {
 			clusterName = result.ClusterName
 		}
+		// TODO (williamo/scopes): Scoped apps currently won't support required_apps.
+		if scope := result.App.GetScope(); scope != "" && len(requiredAppNames) > 0 {
+			return nil, trace.AccessDenied("scoped apps do not support required app redirects")
+		}
 		for _, requiredAppName := range requiredAppNames {
 			if result.App.GetUseAnyProxyPublicAddr() {
 				proxyDNSName := utils.FindMatchingProxyDNS(req.FQDNHint, h.proxyDNSNames())


### PR DESCRIPTION
Scoped applications will not be allowed to configure their own `public_addr`. This is to make sure that we cannot have cross scope app collisions. This PR supports this RFD https://github.com/gravitational/rfd/pull/24.

We will additionally update this in `e`:

https://github.com/gravitational/teleport.e/pull/9047
<!-- Provide a descriptive entry for the changelog of the next release. -->

Changelog: Teleport will now derive a computed public address for scoped applications


<!-- Include manual testing efforts to verify the change. -->
<!-- Detail where the tests where run and what configurations were used. -->
<!-- Include all the test cases which were run to validate the change. -->

## Manual Test Plan
### Test Environment
Local cluster + local app agent + docker apps

### Test Cases
- [x] Make sure the scope qualified app public addr is shown in tsh apps ls
- [x] Logging into an app shows the full public addr in the curl output
- [x] Unscoped apps with public addresses configured still show normally
- [x] Users aren't able to register scoped apps with public addrs set
- [x] Configure 2 public proxy addresses and ensure the application can be routed to them in the UI (routing still doesn't work, but confirmed the agent served the request until failing rbac)
