### PR TITLE
Add `genericoidc` library

### DIFF
--- a/lib/join/genericoidc/conditions.go
+++ b/lib/join/genericoidc/conditions.go
@@ -1,0 +1,133 @@
+/*
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package genericoidc
+
+import (
+	"strconv"
+	"strings"
+
+	"github.com/gravitational/trace"
+
+	"github.com/gravitational/teleport/api/types"
+)
+
+// allowClaimMatches verifies that the given claim value matches the configured
+// token value. We diverge from workloadidentity's string coercion here because
+// string conversion of JSON numbers/float64 will not necessarily behave
+// correctly, meaning we should perform actual numeric comparison.
+func allowClaimMatches(claimValue any, expected string) (bool, error) {
+	switch v := claimValue.(type) {
+	case string:
+		return v == expected, nil
+	case bool:
+		expectBool, err := strconv.ParseBool(expected)
+		if err != nil {
+			return false, trace.BadParameter("boolean claim value requires boolean expected value, but got %q", expected)
+		}
+
+		return v == expectBool, nil
+	case float64:
+		expectFloat, err := strconv.ParseFloat(expected, 64)
+		if err != nil {
+			return false, trace.BadParameter("numeric claim value requires numeric expected value, but got %q", expected)
+		}
+
+		return v == expectFloat, nil
+	default:
+		return false, trace.BadParameter("claim of type %T cannot be compared against a scalar expected value", claimValue)
+	}
+}
+
+// evaluateAllowAnyConditions evaluates `allow_any` conditions (not expressions)
+// and returns an error if any rules could not be evaluated, or if access was
+// denied due to rule failure. Note that all conditions must match; OR semantics
+// are at the top `allow_any` level, not within a conditions block.
+func evaluateAllowAnyConditions(conditions []*types.ProvisionTokenSpecV2GenericOIDC_Condition, claims *IDTokenClaims) error {
+	for i, cond := range conditions {
+		fieldParts := strings.Split(cond.Attribute, ".")
+		claimValue, err := getByFields(claims.Claims, fieldParts)
+		if err != nil {
+			return trace.AccessDenied("required claim attribute %q not found on incoming claims", cond.Attribute)
+		}
+
+		// Note, ProvisionTokenV2's checkAndSetDefaults() (or the scoped
+		// variant's oneof) ensures only one operator variant is set at creation
+		// time, so we can pick any evaluation order here without exhaustive
+		// checking.
+		switch {
+		case cond.Eq != nil:
+			matches, err := allowClaimMatches(claimValue, cond.Eq.Value)
+			if err != nil {
+				return trace.Wrap(err, "conditions[%d]: evaluating `eq` matcher", i)
+			}
+
+			if !matches {
+				return trace.AccessDenied("conditions[%d]: claim %q did not match required value", i, cond.Attribute)
+			}
+		case cond.NotEq != nil:
+			matches, err := allowClaimMatches(claimValue, cond.NotEq.Value)
+			if err != nil {
+				return trace.Wrap(err, "conditions[%d]: evaluating `not_eq` matcher", i)
+			}
+
+			if matches {
+				// Must *not* be ok.
+				return trace.AccessDenied("conditions[%d]: claim %q cannot match specified value", i, cond.Attribute)
+			}
+		case cond.In != nil:
+			anyMatch := false
+			for _, inValue := range cond.In.Values {
+				matches, err := allowClaimMatches(claimValue, inValue)
+				if err != nil {
+					return trace.Wrap(err, "conditions[%d]: evaluating `in` matcher", i)
+				}
+
+				if matches {
+					anyMatch = true
+					break
+				}
+			}
+
+			if !anyMatch {
+				return trace.AccessDenied("conditions[%d]: claim %q did not match any allowed value", i, cond.Attribute)
+			}
+		case cond.NotIn != nil:
+			anyMatch := false
+			for _, inValue := range cond.NotIn.Values {
+				matches, err := allowClaimMatches(claimValue, inValue)
+				if err != nil {
+					return trace.Wrap(err, "conditions[%d]: evaluating `not_in` matcher", i)
+				}
+
+				if matches {
+					anyMatch = true
+					break
+				}
+			}
+
+			if anyMatch {
+				return trace.AccessDenied("conditions[%d]: claim %q cannot match provided value", i, cond.Attribute)
+			}
+		default:
+			return trace.BadParameter("conditions[%d]: no supported operator specified", i)
+		}
+	}
+
+	return nil
+}

--- a/lib/join/genericoidc/conditions.go
+++ b/lib/join/genericoidc/conditions.go
@@ -19,6 +19,7 @@
 package genericoidc
 
 import (
+	"math"
 	"strconv"
 	"strings"
 
@@ -26,6 +27,19 @@ import (
 
 	"github.com/gravitational/teleport/api/types"
 )
+
+// isUnsafeInteger determines if a given floating point value is an integer
+// (equals itself when truncated) and is too large to be uniquely represented by
+// 64bit floats.
+func isUnsafeInteger(f float64) bool {
+	if f != math.Trunc(f) {
+		// Not an integer, allow it
+		return false
+	}
+
+	// If larger than 2^53-1, reject.
+	return math.Abs(f) >= (1 << 53)
+}
 
 // allowClaimMatches verifies that the given claim value matches the configured
 // token value. We diverge from workloadidentity's string coercion here because
@@ -46,6 +60,15 @@ func allowClaimMatches(claimValue any, expected string) (bool, error) {
 		expectFloat, err := strconv.ParseFloat(expected, 64)
 		if err != nil {
 			return false, trace.BadParameter("numeric claim value requires numeric expected value, but got %q", expected)
+		}
+
+		// Fail loudly and stop all processing by rejecting with a BadParameter
+		// error. We could technically keep processing, but then users would
+		// never see the error.
+		if isUnsafeInteger(expectFloat) {
+			return false, trace.BadParameter("integers of this size cannot be safely compared: %s", expected)
+		} else if isUnsafeInteger(v) {
+			return false, trace.BadParameter("claim contains an integer value too large for safe comparison: %v", v)
 		}
 
 		return v == expectFloat, nil

--- a/lib/join/genericoidc/conditions_test.go
+++ b/lib/join/genericoidc/conditions_test.go
@@ -1,0 +1,183 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package genericoidc
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport/api/types"
+)
+
+const exampleGCPClaimsString = `{
+  "aud": "example.teleport.sh",
+  "azp": "1234567890",
+  "email": "123456789012-compute@developer.gserviceaccount.com",
+  "email_verified": true,
+  "exp": 1781580107,
+  "google": {
+    "compute_engine": {
+      "instance_creation_timestamp": 1666452409,
+      "instance_id": "12345678901234567",
+      "instance_name": "hello-world",
+      "project_id": "example-123456",
+      "project_number": 123456123456,
+      "zone": "us-central1-a"
+    }
+  },
+  "custom": {
+	"float": 123.456,
+	"list": ["a", "b", "c"]
+  },
+  "iat": 1781576507,
+  "iss": "https://accounts.google.com",
+  "sub": "1234567890"
+}`
+
+// claims is a helper that parses a JSON document inline as IDTokenClaims
+func idTokenClaims(t *testing.T, doc string) *IDTokenClaims {
+	t.Helper()
+	var parsed IDTokenClaims
+	require.NoError(t, json.Unmarshal([]byte(doc), &parsed))
+
+	// hacky, but we expect zitadel to set this
+	parsed.Claims = claims(t, doc)
+
+	return &parsed
+}
+
+func eqCondition(attribute, value string) *types.ProvisionTokenSpecV2GenericOIDC_Condition {
+	return &types.ProvisionTokenSpecV2GenericOIDC_Condition{
+		Attribute: attribute,
+		Eq: &types.ProvisionTokenSpecV2GenericOIDC_ConditionEq{
+			Value: value,
+		},
+	}
+}
+
+func notEqCondition(attribute, value string) *types.ProvisionTokenSpecV2GenericOIDC_Condition {
+	return &types.ProvisionTokenSpecV2GenericOIDC_Condition{
+		Attribute: attribute,
+		NotEq: &types.ProvisionTokenSpecV2GenericOIDC_ConditionNotEq{
+			Value: value,
+		},
+	}
+}
+
+func inCondition(attribute string, values ...string) *types.ProvisionTokenSpecV2GenericOIDC_Condition {
+	return &types.ProvisionTokenSpecV2GenericOIDC_Condition{
+		Attribute: attribute,
+		In: &types.ProvisionTokenSpecV2GenericOIDC_ConditionIn{
+			Values: values,
+		},
+	}
+}
+
+func notInCondition(attribute string, values ...string) *types.ProvisionTokenSpecV2GenericOIDC_Condition {
+	return &types.ProvisionTokenSpecV2GenericOIDC_Condition{
+		Attribute: attribute,
+		NotIn: &types.ProvisionTokenSpecV2GenericOIDC_ConditionNotIn{
+			Values: values,
+		},
+	}
+}
+
+func conditions(conditions ...*types.ProvisionTokenSpecV2GenericOIDC_Condition) []*types.ProvisionTokenSpecV2GenericOIDC_Condition {
+	// silly wrapper to save characters
+	return conditions
+}
+
+func TestEvaluateAllowConditions(t *testing.T) {
+	t.Parallel()
+
+	parsedClaims := idTokenClaims(t, exampleGCPClaimsString)
+
+	tests := []struct {
+		name        string
+		conditions  []*types.ProvisionTokenSpecV2GenericOIDC_Condition
+		expectError require.ErrorAssertionFunc
+	}{
+		{
+			name: "all types success",
+			conditions: conditions(
+				eqCondition("google.compute_engine.instance_name", "hello-world"),
+				eqCondition("google.compute_engine.project_number", "123456123456"), // string coercion test
+				notEqCondition("email_verified", "false"),                           // contrived, but a realistic boolean test
+				inCondition("azp", "1234567800", "1234567000", "1234567890"),
+				notInCondition("google.compute_engine.zone", "us-central1-b", "us-central1-c", "us-central1-d"), // ban some AZs
+			),
+			expectError: require.NoError,
+		},
+		{
+			name: "invalid field path, top level",
+			conditions: conditions(
+				eqCondition("foo", "12345"),
+			),
+			expectError: func(t require.TestingT, err error, i ...any) {
+				require.ErrorContains(t, err, `required claim attribute "foo" not found`)
+			},
+		},
+		{
+			name: "invalid field path, nested",
+			conditions: conditions(
+				eqCondition("google.foo.bar", "12345"),
+			),
+			expectError: func(t require.TestingT, err error, i ...any) {
+				require.ErrorContains(t, err, `required claim attribute "google.foo.bar" not found`)
+			},
+		},
+		{
+			name: "invalid field path, nested",
+			conditions: conditions(
+				eqCondition("google.foo.bar", "12345"),
+			),
+			expectError: func(t require.TestingT, err error, i ...any) {
+				require.ErrorContains(t, err, `required claim attribute "google.foo.bar" not found`)
+			},
+		},
+		{
+			name: "successful bool coercion",
+			conditions: conditions(
+				eqCondition("email_verified", "true"),
+				notEqCondition("email_verified", "false"),
+				inCondition("email_verified", "true"),
+				notEqCondition("email_verified", "false"),
+			),
+			expectError: require.NoError,
+		},
+		{
+			name: "successful number coercion",
+			conditions: conditions(
+				eqCondition("custom.float", "123.456"),
+				notEqCondition("custom.float", "123.45"),
+				notEqCondition("custom.float", "123.4567"),
+				inCondition("custom.float", "123.0", "123", "123.456"),
+				notInCondition("custom.float", "123", "123.4", "123.45", "123.4567"),
+			),
+			expectError: require.NoError,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := evaluateAllowAnyConditions(tt.conditions, parsedClaims)
+			tt.expectError(t, err)
+		})
+	}
+}

--- a/lib/join/genericoidc/conditions_test.go
+++ b/lib/join/genericoidc/conditions_test.go
@@ -43,7 +43,8 @@ const exampleGCPClaimsString = `{
   },
   "custom": {
 	"float": 123.456,
-	"list": ["a", "b", "c"]
+	"list": ["a", "b", "c"],
+	"largeInt": 9007199254740992
   },
   "iat": 1781576507,
   "iss": "https://accounts.google.com",
@@ -171,6 +172,42 @@ func TestEvaluateAllowConditions(t *testing.T) {
 				notInCondition("custom.float", "123", "123.4", "123.45", "123.4567"),
 			),
 			expectError: require.NoError,
+		},
+		{
+			name: "rejects integer comparisons with large claims",
+			conditions: conditions(
+				eqCondition("custom.largeInt", "123"),
+			),
+			expectError: func(t require.TestingT, err error, i ...any) {
+				require.ErrorContains(t, err, "claim contains an integer value too large for safe comparison")
+			},
+		},
+		{
+			name: "rejects integer comparisons with large spec rule",
+			conditions: conditions(
+				eqCondition("custom.float", "9007199254740993"),
+			),
+			expectError: func(t require.TestingT, err error, i ...any) {
+				require.ErrorContains(t, err, "integers of this size cannot be safely compared")
+			},
+		},
+		{
+			name: "rejects integer comparisons with large spec rule via not_eq",
+			conditions: conditions(
+				notEqCondition("custom.float", "9007199254740993"),
+			),
+			expectError: func(t require.TestingT, err error, i ...any) {
+				require.ErrorContains(t, err, "integers of this size cannot be safely compared")
+			},
+		},
+		{
+			name: "rejects integer comparisons with large spec rule via not_in",
+			conditions: conditions(
+				notInCondition("custom.float", "9007199254740993"),
+			),
+			expectError: func(t require.TestingT, err error, i ...any) {
+				require.ErrorContains(t, err, "integers of this size cannot be safely compared")
+			},
 		},
 	}
 

--- a/lib/join/genericoidc/expression.go
+++ b/lib/join/genericoidc/expression.go
@@ -1,0 +1,103 @@
+/*
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package genericoidc
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/gravitational/trace"
+
+	"github.com/gravitational/teleport/lib/expression"
+	"github.com/gravitational/teleport/lib/utils/typical"
+)
+
+// Environment in which expressions will be evaluated.
+type Environment struct {
+	// Claims will be exposed under the `claims` field.
+	Claims map[string]any
+}
+
+var booleanExpressionParser = func() *typical.Parser[*Environment, any] {
+	spec := expression.DefaultParserSpec[*Environment]()
+	spec.GetUnknownIdentifier = func(env *Environment, fields []string) (any, error) {
+		if len(fields) == 0 {
+			return nil, trace.BadParameter("cannot get empty field")
+		}
+
+		if fields[0] != "claims" {
+			return nil, trace.BadParameter("identifier %q is not defined", fields[0])
+		}
+
+		return getByFields(env.Claims, fields[1:])
+	}
+
+	parser, err := typical.NewParser[*Environment, any](spec)
+	if err != nil {
+		panic(fmt.Sprintf("failed to construct parser: %v", err))
+	}
+	return parser
+}()
+
+// getByFields attempts to fetch the value within `parent` by navigating
+// sequentially through the fields named in `fields`.
+func getByFields(parent map[string]any, fields []string) (any, error) {
+	var field any = parent
+
+	for i, key := range fields {
+		identifier := strings.Join(fields[0:i+1], ".")
+
+		// first, make sure `field` is actually a map before we try accessing
+		// its children
+		fieldAsMap, ok := field.(map[string]any)
+		if !ok {
+			return nil, trace.BadParameter("field at %q cannot have children", identifier)
+		}
+
+		// now try to find the child value
+		child, ok := fieldAsMap[key]
+		if !ok {
+			return nil, trace.BadParameter("field not found: %s", identifier)
+		}
+
+		field = child
+	}
+
+	return field, nil
+}
+
+// evaluateExpression evaluates the given predicate expression using the
+// `booleanExpressionParser` and provided environment.
+func evaluateExpression(expr string, env *Environment) (bool, error) {
+	e, err := booleanExpressionParser.Parse(expr)
+	if err != nil {
+		return false, trace.Wrap(err, "parsing expression: %s", expr)
+	}
+
+	rsp, err := e.Evaluate(env)
+	if err != nil {
+		return false, trace.Wrap(err, "evaluating expression: %s", expr)
+	}
+
+	if result, ok := rsp.(bool); ok {
+		return result, nil
+	}
+
+	return false, trace.Errorf("expression evaluated to %T instead of boolean: %s", rsp, expr)
+}

--- a/lib/join/genericoidc/expression_test.go
+++ b/lib/join/genericoidc/expression_test.go
@@ -123,7 +123,7 @@ func TestEvaluateExpression(t *testing.T) {
 				Claims: tt.claims,
 			})
 			tt.expectError(t, err)
-			require.True(t, tt.expect == result)
+			require.Equal(t, tt.expect, result)
 		})
 	}
 }

--- a/lib/join/genericoidc/expression_test.go
+++ b/lib/join/genericoidc/expression_test.go
@@ -1,0 +1,129 @@
+/*
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package genericoidc
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// claims is a helper that parses a JSON document inline
+func claims(t *testing.T, doc string) map[string]any {
+	t.Helper()
+	var m map[string]any
+	require.NoError(t, json.Unmarshal([]byte(doc), &m))
+	return m
+}
+
+func TestEvaluateExpression(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		claims      map[string]any
+		expression  string
+		expect      bool
+		expectError require.ErrorAssertionFunc
+	}{
+		{
+			name: "simple success",
+			claims: claims(t, `{
+				"organization_name": "acme-corp"
+			}`),
+			expression:  `claims.organization_name == "acme-corp"`,
+			expect:      true,
+			expectError: require.NoError,
+		},
+		{
+			name: "nested success",
+			claims: claims(t, `{
+				"organization": {
+					"id": "abc123",
+					"http://acme-corp.com/": {
+						"name": "acme-corp"
+					}
+				}
+			}`),
+			// note: predicate can't accept f["a"].foo - once you use a index
+			// expression, all following terms must remain index expressions
+			expression:  `claims.organization["http://acme-corp.com/"]["name"] == "acme-corp" && claims.organization.id == "abc123"`,
+			expect:      true,
+			expectError: require.NoError,
+		},
+		{
+			name: "invalid variable",
+			claims: claims(t, `{
+				"organization_id": "acme-corp"
+			}`),
+			expression: `claims.organization_name == "acme-corp"`,
+			expect:     false,
+			expectError: func(t require.TestingT, err error, i ...interface{}) {
+				require.ErrorContains(t, err, "field not found: organization_name")
+			},
+		},
+		{
+			name: "invalid nested variable first level",
+			claims: claims(t, `{
+				"organization_id": "acme-corp"
+			}`),
+			expression: `claims.foo.bar == "acme-corp"`,
+			expect:     false,
+			expectError: func(t require.TestingT, err error, i ...interface{}) {
+				require.ErrorContains(t, err, "field not found: foo")
+			},
+		},
+		{
+			name: "invalid nested variable second level",
+			claims: claims(t, `{
+				"foo": {
+					"organization_id": "acme-corp"
+				}
+			}`),
+			expression: `claims.foo.bar == "acme-corp"`,
+			expect:     false,
+			expectError: func(t require.TestingT, err error, i ...interface{}) {
+				require.ErrorContains(t, err, "field not found: foo")
+			},
+		},
+		{
+			name: "floats not supported",
+			claims: claims(t, `{
+				"number": 1
+			}`),
+			expression: `claims.number == 1.0`,
+			expect:     false,
+			expectError: func(t require.TestingT, err error, i ...interface{}) {
+				// typical is bad and it should feel bad
+				require.ErrorContains(t, err, "operator (==) not supported for type: float64")
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := evaluateExpression(tt.expression, &Environment{
+				Claims: tt.claims,
+			})
+			tt.expectError(t, err)
+			require.True(t, tt.expect == result)
+		})
+	}
+}

--- a/lib/join/genericoidc/expression_test.go
+++ b/lib/join/genericoidc/expression_test.go
@@ -100,7 +100,7 @@ func TestEvaluateExpression(t *testing.T) {
 			expression: `claims.foo.bar == "acme-corp"`,
 			expect:     false,
 			expectError: func(t require.TestingT, err error, i ...interface{}) {
-				require.ErrorContains(t, err, "field not found: foo")
+				require.ErrorContains(t, err, "field not found: foo.bar")
 			},
 		},
 		{

--- a/lib/join/genericoidc/field_rules.go
+++ b/lib/join/genericoidc/field_rules.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 
 	gogotypes "github.com/gogo/protobuf/types"
+	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/trace"
 )
 
@@ -29,7 +30,7 @@ import (
 // least one true value assertion that isn't just nested structs. Generic rules
 // can be used to evaluate nested structures, so this recurses on the struct
 // field to find at least one valid, supported value comparison.
-func validateFieldRulesContainsAnyRule(str *gogotypes.Struct) (bool, error) {
+func validateFieldRulesContainsAnyRule(str *types.Struct) (bool, error) {
 	for _, v := range str.Fields {
 		switch f := v.Kind.(type) {
 		case *gogotypes.Value_BoolValue:
@@ -48,7 +49,7 @@ func validateFieldRulesContainsAnyRule(str *gogotypes.Struct) (bool, error) {
 		case *gogotypes.Value_StructValue:
 			// recurse and check the child values to see if there are any actual
 			// rules.
-			hasAny, err := validateFieldRulesContainsAnyRule(f.StructValue)
+			hasAny, err := validateFieldRulesContainsAnyRule(types.NewStruct(f.StructValue))
 			if err != nil {
 				return false, trace.Wrap(err)
 			} else if hasAny {
@@ -64,7 +65,7 @@ func validateFieldRulesContainsAnyRule(str *gogotypes.Struct) (bool, error) {
 
 // evaluateFieldRules evaluates `must_match_fields` rules defined in the given
 // arbitrary spec struct and compares them against the given claims.
-func evaluateFieldRules(specStruct *gogotypes.Struct, claimStruct map[string]any, path ...string) error {
+func evaluateFieldRules(specStruct *types.Struct, claimStruct map[string]any, path ...string) error {
 	for specKey, specValue := range specStruct.GetFields() {
 		fieldPath := append(append([]string{}, path...), specKey)
 		identifier := strings.Join(fieldPath, ".")
@@ -143,7 +144,7 @@ func evaluateFieldRules(specStruct *gogotypes.Struct, claimStruct map[string]any
 			}
 
 			// recurse on the child field
-			if err := evaluateFieldRules(spec.StructValue, claimNest, fieldPath...); err != nil {
+			if err := evaluateFieldRules(types.NewStruct(spec.StructValue), claimNest, fieldPath...); err != nil {
 				return trace.Wrap(err)
 			}
 		default:

--- a/lib/join/genericoidc/field_rules.go
+++ b/lib/join/genericoidc/field_rules.go
@@ -54,6 +54,8 @@ func validateFieldRulesContainsAnyRule(str *gogotypes.Struct) (bool, error) {
 			} else if hasAny {
 				return true, nil
 			}
+
+			// no default branch, fails closed if nothing matches
 		}
 	}
 
@@ -144,6 +146,8 @@ func evaluateFieldRules(specStruct *gogotypes.Struct, claimStruct map[string]any
 			if err := evaluateFieldRules(spec.StructValue, claimNest, fieldPath...); err != nil {
 				return trace.Wrap(err)
 			}
+		default:
+			return trace.BadParameter("unsupported comparison field type %T", spec)
 		}
 	}
 

--- a/lib/join/genericoidc/field_rules.go
+++ b/lib/join/genericoidc/field_rules.go
@@ -103,6 +103,14 @@ func evaluateFieldRules(specStruct *types.Struct, claimStruct map[string]any, pa
 					claimValue, identifier)
 			}
 
+			// Hard fail if either side of the comparison is too large to be
+			// reliably compared.
+			if isUnsafeInteger(claimFloat) {
+				return trace.BadParameter("claim contains an integer too large to be safely compared: %s", identifier)
+			} else if isUnsafeInteger(spec.NumberValue) {
+				return trace.BadParameter("field rule cannot safely compare integers of this size: %s", identifier)
+			}
+
 			if spec.NumberValue != claimFloat {
 				return trace.CompareFailed(
 					"incorrect value in claim: %v must be %v but got %v",

--- a/lib/join/genericoidc/field_rules.go
+++ b/lib/join/genericoidc/field_rules.go
@@ -22,8 +22,9 @@ import (
 	"strings"
 
 	gogotypes "github.com/gogo/protobuf/types"
-	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/trace"
+
+	"github.com/gravitational/teleport/api/types"
 )
 
 // validateFieldRulesContainsAnyRule ensures `must_match_fields` contains at

--- a/lib/join/genericoidc/field_rules.go
+++ b/lib/join/genericoidc/field_rules.go
@@ -66,6 +66,11 @@ func validateFieldRulesContainsAnyRule(str *types.Struct) (bool, error) {
 // evaluateFieldRules evaluates `must_match_fields` rules defined in the given
 // arbitrary spec struct and compares them against the given claims.
 func evaluateFieldRules(specStruct *types.Struct, claimStruct map[string]any, path ...string) error {
+	if specStruct == nil {
+		// Nothing to do
+		return nil
+	}
+
 	for specKey, specValue := range specStruct.GetFields() {
 		fieldPath := append(append([]string{}, path...), specKey)
 		identifier := strings.Join(fieldPath, ".")

--- a/lib/join/genericoidc/field_rules.go
+++ b/lib/join/genericoidc/field_rules.go
@@ -1,0 +1,151 @@
+/*
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package genericoidc
+
+import (
+	"strings"
+
+	gogotypes "github.com/gogo/protobuf/types"
+	"github.com/gravitational/trace"
+)
+
+// validateFieldRulesContainsAnyRule ensures `must_match_fields` contains at
+// least one true value assertion that isn't just nested structs. Generic rules
+// can be used to evaluate nested structures, so this recurses on the struct
+// field to find at least one valid, supported value comparison.
+func validateFieldRulesContainsAnyRule(str *gogotypes.Struct) (bool, error) {
+	for _, v := range str.Fields {
+		switch f := v.Kind.(type) {
+		case *gogotypes.Value_BoolValue:
+			return true, nil
+		case *gogotypes.Value_NumberValue:
+			return true, nil
+		case *gogotypes.Value_StringValue:
+			return true, nil
+		case *gogotypes.Value_NullValue:
+			// Don't treat nulls as sufficient to meet our "one actual value
+			// comparison" rule, since they can only assert nonexistence.
+			continue
+		case *gogotypes.Value_ListValue:
+			// List values not currently supported, skip.
+			return false, trace.BadParameter("list fields cannot be used in `must_match_fields`")
+		case *gogotypes.Value_StructValue:
+			// recurse and check the child values to see if there are any actual
+			// rules.
+			hasAny, err := validateFieldRulesContainsAnyRule(f.StructValue)
+			if err != nil {
+				return false, trace.Wrap(err)
+			} else if hasAny {
+				return true, nil
+			}
+		}
+	}
+
+	return false, nil
+}
+
+// evaluateFieldRules evaluates `must_match_fields` rules defined in the given
+// arbitrary spec struct and compares them against the given claims.
+func evaluateFieldRules(specStruct *gogotypes.Struct, claimStruct map[string]any, path ...string) error {
+	for specKey, specValue := range specStruct.GetFields() {
+		fieldPath := append(append([]string{}, path...), specKey)
+		identifier := strings.Join(fieldPath, ".")
+
+		claimValue, ok := claimStruct[specKey]
+		if !ok {
+			if _, isNull := specValue.Kind.(*gogotypes.Value_NullValue); isNull {
+				// rules called for this field to be null, so allow the missing
+				// field explicitly
+				continue
+			}
+
+			return trace.CompareFailed("claims missing expected key: %v", identifier)
+		}
+
+		switch spec := specValue.Kind.(type) {
+		case *gogotypes.Value_BoolValue:
+			claimBool, ok := claimValue.(bool)
+			if !ok {
+				return trace.CompareFailed(
+					"field must be a boolean but got %T: %v",
+					claimValue, identifier)
+			}
+
+			if spec.BoolValue != claimBool {
+				return trace.CompareFailed(
+					"incorrect value in claim: %v must be %v but got %v",
+					identifier, spec.BoolValue, claimBool)
+			}
+		case *gogotypes.Value_NumberValue:
+			claimFloat, ok := claimValue.(float64)
+			if !ok {
+				return trace.CompareFailed(
+					"field must be a number but got %T: %v",
+					claimValue, identifier)
+			}
+
+			if spec.NumberValue != claimFloat {
+				return trace.CompareFailed(
+					"incorrect value in claim: %v must be %v but got %v",
+					identifier, spec.NumberValue, claimFloat)
+			}
+		case *gogotypes.Value_StringValue:
+			claimString, ok := claimValue.(string)
+			if !ok {
+				return trace.CompareFailed(
+					"field must be a string but got %T: %v",
+					claimValue, identifier)
+			}
+
+			if spec.StringValue != claimString {
+				return trace.CompareFailed(
+					"incorrect value in claim: %v must be %q but got %v",
+					identifier, spec.StringValue, claimString)
+			}
+		case *gogotypes.Value_NullValue:
+			// Slightly special handling: we'll accept either a null or a
+			// nonexistent value; `null` here can be used to assert no value on
+			// the incoming JWT. We won't bother with JS-style truthy values
+			// beyond accepting literal nulls, at least for now, so "" / 0 will
+			// count as value-ful.
+
+			if claimValue != nil {
+				return trace.CompareFailed(
+					"incorrect value in claim: %v must be null or unset but had a value",
+					identifier)
+			}
+		case *gogotypes.Value_ListValue:
+			return trace.BadParameter("list comparison in %v is not supported, token rules cannot be evaluated", identifier)
+		case *gogotypes.Value_StructValue:
+			claimNest, ok := claimValue.(map[string]any)
+			if !ok {
+				return trace.CompareFailed(
+					"field must be a nested struct but got %T: %v",
+					claimValue, identifier)
+			}
+
+			// recurse on the child field
+			if err := evaluateFieldRules(spec.StructValue, claimNest, fieldPath...); err != nil {
+				return trace.Wrap(err)
+			}
+		}
+	}
+
+	return nil
+}

--- a/lib/join/genericoidc/field_rules_test.go
+++ b/lib/join/genericoidc/field_rules_test.go
@@ -310,6 +310,28 @@ func TestEvaluateFieldRules(t *testing.T) {
 				require.ErrorContains(t, err, "list comparison in custom.list is not supported")
 			},
 		},
+		{
+			name: "rejects large integers in claim",
+			spec: specStruct(t, `{
+				"custom": {
+					"largeInt": 123
+				}
+			}`),
+			expectError: func(t require.TestingT, err error, i ...any) {
+				require.ErrorContains(t, err, "claim contains an integer too large to be safely compared")
+			},
+		},
+		{
+			name: "rejects large integers in spec",
+			spec: specStruct(t, `{
+				"custom": {
+					"float": 9007199254740993
+				}
+			}`),
+			expectError: func(t require.TestingT, err error, i ...any) {
+				require.ErrorContains(t, err, "field rule cannot safely compare integers of this size: custom.float")
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/lib/join/genericoidc/field_rules_test.go
+++ b/lib/join/genericoidc/field_rules_test.go
@@ -24,8 +24,9 @@ import (
 	"testing"
 
 	gogotypes "github.com/gogo/protobuf/types"
-	"github.com/gravitational/teleport/api/types"
 	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport/api/types"
 )
 
 func specStruct(t *testing.T, doc string) *types.Struct {

--- a/lib/join/genericoidc/field_rules_test.go
+++ b/lib/join/genericoidc/field_rules_test.go
@@ -24,10 +24,11 @@ import (
 	"testing"
 
 	gogotypes "github.com/gogo/protobuf/types"
+	"github.com/gravitational/teleport/api/types"
 	"github.com/stretchr/testify/require"
 )
 
-func specStruct(t *testing.T, doc string) *gogotypes.Struct {
+func specStruct(t *testing.T, doc string) *types.Struct {
 	t.Helper()
 
 	// we could just use jsonpb to parse it directly, but depguard and forbidigo
@@ -38,7 +39,7 @@ func specStruct(t *testing.T, doc string) *gogotypes.Struct {
 	s, err := mapToGogoStruct(m)
 	require.NoError(t, err)
 
-	return s
+	return types.NewStruct(s)
 }
 
 // mapToGogoStruct converts a map to a gogo struct
@@ -99,7 +100,7 @@ func TestValidateFieldRulesContainsAnyRule(t *testing.T) {
 
 	tests := []struct {
 		name        string
-		spec        *gogotypes.Struct
+		spec        *types.Struct
 		expect      bool
 		expectError require.ErrorAssertionFunc
 	}{
@@ -170,7 +171,7 @@ func TestEvaluateFieldRules(t *testing.T) {
 
 	tests := []struct {
 		name        string
-		spec        *gogotypes.Struct
+		spec        *types.Struct
 		expectError require.ErrorAssertionFunc
 	}{
 		{

--- a/lib/join/genericoidc/field_rules_test.go
+++ b/lib/join/genericoidc/field_rules_test.go
@@ -19,18 +19,79 @@
 package genericoidc
 
 import (
+	"encoding/json"
+	"fmt"
 	"testing"
 
-	"github.com/gogo/protobuf/jsonpb"
 	gogotypes "github.com/gogo/protobuf/types"
 	"github.com/stretchr/testify/require"
 )
 
 func specStruct(t *testing.T, doc string) *gogotypes.Struct {
 	t.Helper()
-	s := &gogotypes.Struct{}
-	require.NoError(t, jsonpb.UnmarshalString(doc, s))
+
+	// we could just use jsonpb to parse it directly, but depguard and forbidigo
+	// complain, so instead we have this dubious roundabout implementation
+	var m map[string]any
+	require.NoError(t, json.Unmarshal([]byte(doc), &m))
+
+	s, err := mapToGogoStruct(m)
+	require.NoError(t, err)
+
 	return s
+}
+
+// mapToGogoStruct converts a map to a gogo struct
+func mapToGogoStruct(m map[string]any) (*gogotypes.Struct, error) {
+	// dubiously-valued depguard+forbidigo appeasement
+	fields := make(map[string]*gogotypes.Value, len(m))
+	for k, v := range m {
+		val, err := anyToGogoValue(v)
+		if err != nil {
+			return nil, err
+		}
+
+		fields[k] = val
+	}
+
+	return &gogotypes.Struct{Fields: fields}, nil
+}
+
+// anyToGogoValue converts a JSON-compatible primitive type to a gogo value.
+func anyToGogoValue(v any) (*gogotypes.Value, error) {
+	switch t := v.(type) {
+	case nil:
+		return &gogotypes.Value{Kind: &gogotypes.Value_NullValue{}}, nil
+	case bool:
+		return &gogotypes.Value{Kind: &gogotypes.Value_BoolValue{BoolValue: t}}, nil
+	case float64:
+		return &gogotypes.Value{Kind: &gogotypes.Value_NumberValue{NumberValue: t}}, nil
+	case string:
+		return &gogotypes.Value{Kind: &gogotypes.Value_StringValue{StringValue: t}}, nil
+	case map[string]any:
+		s, err := mapToGogoStruct(t)
+		if err != nil {
+			return nil, err
+		}
+
+		return &gogotypes.Value{Kind: &gogotypes.Value_StructValue{StructValue: s}}, nil
+	case []any:
+		vals := make([]*gogotypes.Value, len(t))
+		for i, item := range t {
+			val, err := anyToGogoValue(item)
+			if err != nil {
+				return nil, err
+			}
+
+			vals[i] = val
+		}
+
+		return &gogotypes.Value{Kind: &gogotypes.Value_ListValue{
+			ListValue: &gogotypes.ListValue{Values: vals},
+		}}, nil
+	default:
+		return nil, fmt.Errorf("unsupported json type %T", v)
+	}
 }
 
 func TestValidateFieldRulesContainsAnyRule(t *testing.T) {

--- a/lib/join/genericoidc/field_rules_test.go
+++ b/lib/join/genericoidc/field_rules_test.go
@@ -1,0 +1,259 @@
+/*
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package genericoidc
+
+import (
+	"testing"
+
+	"github.com/gogo/protobuf/jsonpb"
+	gogotypes "github.com/gogo/protobuf/types"
+	"github.com/stretchr/testify/require"
+)
+
+func specStruct(t *testing.T, doc string) *gogotypes.Struct {
+	t.Helper()
+	s := &gogotypes.Struct{}
+	require.NoError(t, jsonpb.UnmarshalString(doc, s))
+	return s
+}
+
+func TestValidateFieldRulesContainsAnyRule(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		spec        *gogotypes.Struct
+		expect      bool
+		expectError require.ErrorAssertionFunc
+	}{
+		{
+			name: "simple",
+			spec: specStruct(t, `{
+				"email": "123456789012-compute@developer.gserviceaccount.com"
+			}`),
+			expect:      true,
+			expectError: require.NoError,
+		},
+		{
+			name: "only fields",
+			spec: specStruct(t, `{
+				"google": {
+					"compute_engine": {}
+				},
+				"custom": {}
+			}`),
+			expect:      false,
+			expectError: require.NoError,
+		},
+		{
+			name: "one nested check",
+			spec: specStruct(t, `{
+				"google": {
+					"compute_engine": {
+						"instance_name": "hello-world"
+					}
+				},
+				"custom": {}
+			}`),
+			// empty checks that only assert a field's existence are allowed,
+			// just not sufficient on their own. at least one value needs to be
+			// compared in some rule.
+			expect:      true,
+			expectError: require.NoError,
+		},
+		{
+			name: "contains a list rule",
+			spec: specStruct(t, `{
+				"google": {
+					"compute_engine": {
+						"instance_name": ["hello-world"]
+					}
+				}
+			}`),
+			expect: false,
+			expectError: func(t require.TestingT, err error, i ...any) {
+				require.ErrorContains(t, err, "list fields cannot be used")
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ret, err := validateFieldRulesContainsAnyRule(tt.spec)
+			tt.expectError(t, err)
+			require.Equal(t, tt.expect, ret)
+		})
+	}
+}
+
+func TestEvaluateFieldRules(t *testing.T) {
+	t.Parallel()
+
+	parsedClaims := claims(t, exampleGCPClaimsString)
+
+	tests := []struct {
+		name        string
+		spec        *gogotypes.Struct
+		expectError require.ErrorAssertionFunc
+	}{
+		{
+			name: "success",
+			spec: specStruct(t, `{
+				"email_verified": true,
+				"google": {
+					"compute_engine": {
+						"instance_name": "hello-world",
+						"project_number": 123456123456,
+						"zone": "us-central1-a"
+					}
+				},
+				"custom": {
+					"float": 123.456
+				},
+				"azp": "1234567890"
+			}`),
+			expectError: require.NoError,
+		},
+		{
+			name: "string failure",
+			spec: specStruct(t, `{
+				"email_verified": true,
+				"google": {
+					"compute_engine": {
+						"instance_name": "foo",
+						"project_number": 123456123456,
+						"zone": "us-central1-a"
+					}
+				},
+				"custom": {
+					"float": 123.456
+				},
+				"azp": "1234567890"
+			}`),
+			expectError: func(t require.TestingT, err error, i ...any) {
+				require.ErrorContains(t, err, "incorrect value in claim: google.compute_engine.instance_name")
+			},
+		},
+		{
+			name: "bool failure",
+			spec: specStruct(t, `{
+				"email_verified": false,
+				"google": {
+					"compute_engine": {
+						"instance_name": "hello-world",
+						"project_number": 123456123456,
+						"zone": "us-central1-a"
+					}
+				},
+				"custom": {
+					"float": 123.456
+				},
+				"azp": "1234567890"
+			}`),
+			expectError: func(t require.TestingT, err error, i ...any) {
+				require.ErrorContains(t, err, "incorrect value in claim: email_verified must be false")
+			},
+		},
+		{
+			name: "int failure",
+			spec: specStruct(t, `{
+				"email_verified": true,
+				"google": {
+					"compute_engine": {
+						"instance_name": "hello-world",
+						"project_number": 1234561234567,
+						"zone": "us-central1-a"
+					}
+				},
+				"custom": {
+					"float": 123.456
+				},
+				"azp": "1234567890"
+			}`),
+			expectError: func(t require.TestingT, err error, i ...any) {
+				// Renders as engineering notation but is collision-safe below
+				// 2^53, which GCP project numbers are with some margin.
+				require.ErrorContains(t, err, "incorrect value in claim: google.compute_engine.project_number must be")
+			},
+		},
+		{
+			name: "float failure",
+			spec: specStruct(t, `{
+				"custom": {
+					"float": 123.457
+				}
+			}`),
+			expectError: func(t require.TestingT, err error, i ...any) {
+				require.ErrorContains(t, err, "incorrect value in claim: custom.float must be 123.457")
+			},
+		},
+		{
+			name: "can assert struct existence, successful pass",
+			spec: specStruct(t, `{
+				"google": {}
+			}`),
+			expectError: require.NoError,
+		},
+		{
+			name: "can assert struct existence, successful fail",
+			spec: specStruct(t, `{
+				"foo": {}
+			}`),
+			expectError: func(t require.TestingT, err error, i ...any) {
+				require.ErrorContains(t, err, "claims missing expected key: foo")
+			},
+		},
+		{
+			name: "can assert non-existence, successful pass",
+			spec: specStruct(t, `{
+				"foo": null
+			}`),
+			expectError: require.NoError,
+		},
+		{
+			name: "can assert non-existence, successful fail",
+			spec: specStruct(t, `{
+				"google": {
+					"compute_engine": null
+				}
+			}`),
+			expectError: func(t require.TestingT, err error, i ...any) {
+				require.ErrorContains(t, err, "google.compute_engine must be null or unset")
+			},
+		},
+		{
+			name: "cannot assert lists",
+			spec: specStruct(t, `{
+				"custom": {
+					"list": ["a", "b", "c"]
+				}
+			}`),
+			expectError: func(t require.TestingT, err error, i ...any) {
+				require.ErrorContains(t, err, "list comparison in custom.list is not supported")
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := evaluateFieldRules(tt.spec, parsedClaims)
+			tt.expectError(t, err)
+		})
+	}
+}

--- a/lib/join/genericoidc/generic_oidc.go
+++ b/lib/join/genericoidc/generic_oidc.go
@@ -1,0 +1,53 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package genericoidc
+
+import (
+	"github.com/gravitational/trace"
+	"github.com/zitadel/oidc/v3/pkg/oidc"
+	"google.golang.org/protobuf/types/known/structpb"
+
+	workloadidentityv1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/workloadidentity/v1"
+)
+
+// IDTokenClaims contains all parsed claims for an OIDC token. It just wraps the
+// upstream IDTokenClaims, which already contains duplicates of all JWT values
+// in its `Claims` field.
+type IDTokenClaims oidc.IDTokenClaims
+
+func (c *IDTokenClaims) JoinAttrs() (*workloadidentityv1pb.JoinAttrsGenericOIDC, error) {
+	claims, err := structpb.NewStruct(c.Claims)
+	if err != nil {
+		return nil, trace.Wrap(err, "converting claims to a protobuf struct")
+	}
+
+	return &workloadidentityv1pb.JoinAttrsGenericOIDC{
+		Claims: claims,
+	}, nil
+}
+
+// MarshalJSON delegates our wrapper type's marshal/unmarshal to the upstream
+// IDTokenClaims, which has special handling for custom claims.
+func (c *IDTokenClaims) MarshalJSON() ([]byte, error) {
+	return (*oidc.IDTokenClaims)(c).MarshalJSON()
+}
+
+// UnmarshalJSON delegates our wrapper type's marshal/unmarshal to the upstream
+// IDTokenClaims, which has special handling for custom claims.
+func (c *IDTokenClaims) UnmarshalJSON(data []byte) error {
+	return (*oidc.IDTokenClaims)(c).UnmarshalJSON(data)
+}

--- a/lib/join/genericoidc/generic_oidc.go
+++ b/lib/join/genericoidc/generic_oidc.go
@@ -35,9 +35,9 @@ func (c *IDTokenClaims) JoinAttrs() (*workloadidentityv1pb.JoinAttrsGenericOIDC,
 		return nil, trace.Wrap(err, "converting claims to a protobuf struct")
 	}
 
-	return &workloadidentityv1pb.JoinAttrsGenericOIDC{
+	return workloadidentityv1pb.JoinAttrsGenericOIDC_builder{
 		Claims: claims,
-	}, nil
+	}.Build(), nil
 }
 
 // MarshalJSON delegates our wrapper type's marshal/unmarshal to the upstream

--- a/lib/join/genericoidc/token_source.go
+++ b/lib/join/genericoidc/token_source.go
@@ -1,0 +1,111 @@
+/*
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package genericoidc
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+	"unicode/utf8"
+
+	"github.com/gravitational/trace"
+)
+
+type envGetter func(key string) string
+
+type commandRunner func(ctx context.Context, command ...string) ([]byte, error)
+
+// IDTokenSource allows a Env0 OIDC token to be fetched whilst within a job
+// execution.
+type IDTokenSource struct {
+	getEnv     envGetter
+	runCommand commandRunner
+}
+
+// GetIDTokenFromEnvironment fetches a JWT from the local node's environment
+func (its *IDTokenSource) GetIDTokenFromEnvironment(key string) (string, error) {
+	tok := its.getEnv(key)
+	if tok == "" {
+		return "", trace.BadParameter(
+			"environment variable %q is missing, ensure it exists and contains a valid JWT for OIDC joining",
+			key,
+		)
+	}
+
+	return strings.TrimSpace(tok), nil
+}
+
+// GetIDTokenFromCommand executes a command to fetch a JWT. The caller can at
+// their option provide a context with a timeout or deadline, but otherwise this
+// may wait indefinitely for the command to return.
+func (its *IDTokenSource) GetIDTokenFromCommand(ctx context.Context, timeout time.Duration, command ...string) (string, error) {
+	if len(command) == 0 {
+		return "", trace.BadParameter("at least one command argument is required")
+	}
+
+	timeoutCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	bytes, err := its.runCommand(timeoutCtx, command...)
+
+	// Do some minimal validation. We'd otherwise like to check that this is a
+	// parseable JWT, but doing so isn't worth including JWT libraries in client
+	// binaries.
+	if !utf8.Valid(bytes) {
+		return "", trace.BadParameter("generic_oidc: retrieved token with invalid content")
+	}
+
+	return strings.TrimSpace(string(bytes)), err
+}
+
+func DefaultCommandRunner(ctx context.Context, command ...string) ([]byte, error) {
+	executable := command[0]
+	args := command[1:]
+
+	dir, err := os.UserHomeDir()
+	if err != nil {
+		return nil, trace.Wrap(err, "determining home directory")
+	}
+
+	cmd := exec.CommandContext(ctx, executable, args...)
+	cmd.Dir = dir
+
+	// Inherit stderr - if errors are printed, they should be visible to the
+	// user. We could buffer them, and wrap them in our own log, but that may
+	// make debugging more difficult.
+	cmd.Stderr = os.Stderr
+
+	bytes, err := cmd.Output()
+	if err != nil {
+		return nil, trace.Wrap(err, "generic_oidc: failed to run command to fetch token, see previous output for details")
+	}
+
+	return bytes, nil
+}
+
+// NewIDTokenSource creates a new generic token source with the given audience
+// tag.
+func NewIDTokenSource(getEnv envGetter, runCommand commandRunner) *IDTokenSource {
+	return &IDTokenSource{
+		getEnv,
+		runCommand,
+	}
+}

--- a/lib/join/genericoidc/token_source.go
+++ b/lib/join/genericoidc/token_source.go
@@ -53,9 +53,9 @@ func (its *IDTokenSource) GetIDTokenFromEnvironment(key string) (string, error) 
 	return strings.TrimSpace(tok), nil
 }
 
-// GetIDTokenFromCommand executes a command to fetch a JWT. The caller can at
-// their option provide a context with a timeout or deadline, but otherwise this
-// may wait indefinitely for the command to return.
+// GetIDTokenFromCommand executes a command to fetch a JWT. The command may take
+// up to the given timeout to execute, and callers are recommended to provide a
+// sensible default timeout (e.g. 1 minute) by default.
 func (its *IDTokenSource) GetIDTokenFromCommand(ctx context.Context, timeout time.Duration, command ...string) (string, error) {
 	if len(command) == 0 {
 		return "", trace.BadParameter("at least one command argument is required")
@@ -92,7 +92,7 @@ func DefaultCommandRunner(ctx context.Context, command ...string) ([]byte, error
 	cmd.Dir = dir
 
 	// Inherit stderr - if errors are printed, they should be visible to the
-	// user. We could buffer them, and wrap them in our own log, but that may
+	// user. We could buffer them and wrap them in our own log, but that may
 	// make debugging more difficult.
 	cmd.Stderr = os.Stderr
 

--- a/lib/join/genericoidc/token_source.go
+++ b/lib/join/genericoidc/token_source.go
@@ -33,7 +33,7 @@ type envGetter func(key string) string
 
 type commandRunner func(ctx context.Context, command ...string) ([]byte, error)
 
-// IDTokenSource allows a Env0 OIDC token to be fetched whilst within a job
+// IDTokenSource allows a generic OIDC token to be fetched whilst within a job
 // execution.
 type IDTokenSource struct {
 	getEnv     envGetter
@@ -65,6 +65,9 @@ func (its *IDTokenSource) GetIDTokenFromCommand(ctx context.Context, timeout tim
 	defer cancel()
 
 	bytes, err := its.runCommand(timeoutCtx, command...)
+	if err != nil {
+		return "", trace.Wrap(err)
+	}
 
 	// Do some minimal validation. We'd otherwise like to check that this is a
 	// parseable JWT, but doing so isn't worth including JWT libraries in client
@@ -73,7 +76,7 @@ func (its *IDTokenSource) GetIDTokenFromCommand(ctx context.Context, timeout tim
 		return "", trace.BadParameter("generic_oidc: retrieved token with invalid content")
 	}
 
-	return strings.TrimSpace(string(bytes)), err
+	return strings.TrimSpace(string(bytes)), nil
 }
 
 func DefaultCommandRunner(ctx context.Context, command ...string) ([]byte, error) {
@@ -105,7 +108,7 @@ func DefaultCommandRunner(ctx context.Context, command ...string) ([]byte, error
 // tag.
 func NewIDTokenSource(getEnv envGetter, runCommand commandRunner) *IDTokenSource {
 	return &IDTokenSource{
-		getEnv,
-		runCommand,
+		getEnv:     getEnv,
+		runCommand: runCommand,
 	}
 }

--- a/lib/join/genericoidc/token_source_test.go
+++ b/lib/join/genericoidc/token_source_test.go
@@ -92,8 +92,6 @@ func TestGetIDTokenFromCommand(t *testing.T) {
 		}
 	}
 
-	const keyName = "OIDC_TEST"
-
 	tests := []struct {
 		name        string
 		runner      commandRunner

--- a/lib/join/genericoidc/token_source_test.go
+++ b/lib/join/genericoidc/token_source_test.go
@@ -1,0 +1,146 @@
+/*
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package genericoidc
+
+import (
+	"context"
+	"errors"
+	"os"
+	"testing"
+	"testing/synctest"
+	"time"
+
+	"github.com/gravitational/trace"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetIDTokenFromEnvironment(t *testing.T) {
+	t.Parallel()
+
+	fakeGetEnv := func(expectKey, env string) envGetter {
+		return func(key string) string {
+			if key == expectKey {
+				return env
+			}
+
+			return ""
+		}
+	}
+
+	const keyName = "OIDC_TEST"
+
+	tests := []struct {
+		name        string
+		getEnv      envGetter
+		wantString  string
+		assertError require.ErrorAssertionFunc
+	}{
+		{
+			name:        "success",
+			getEnv:      fakeGetEnv(keyName, "foobarbizz"),
+			wantString:  "foobarbizz",
+			assertError: require.NoError,
+		},
+		{
+			name:   "unset",
+			getEnv: fakeGetEnv(keyName, ""),
+			assertError: func(t require.TestingT, err error, i ...any) {
+				require.True(t, trace.IsBadParameter(err))
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			v := NewIDTokenSource(tt.getEnv, DefaultCommandRunner)
+			str, err := v.GetIDTokenFromEnvironment(keyName)
+			require.Equal(t, tt.wantString, str)
+			tt.assertError(t, err)
+		})
+	}
+}
+
+func TestGetIDTokenFromCommand(t *testing.T) {
+	t.Parallel()
+
+	// fakeRunner produces command runners that simulate a delay and return a
+	// set value; fast when run under synctest.
+	fakeRunner := func(delay time.Duration, ret func() ([]byte, error)) commandRunner {
+		return func(ctx context.Context, command ...string) ([]byte, error) {
+			select {
+			case <-time.After(delay):
+				return ret()
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			}
+		}
+	}
+
+	const keyName = "OIDC_TEST"
+
+	tests := []struct {
+		name        string
+		runner      commandRunner
+		timeout     time.Duration
+		wantString  string
+		assertError require.ErrorAssertionFunc
+	}{
+		{
+			name:    "success",
+			timeout: time.Minute,
+			runner: fakeRunner(time.Second, func() ([]byte, error) {
+				return []byte("foo"), nil
+			}),
+			wantString:  "foo",
+			assertError: require.NoError,
+		},
+		{
+			name:    "error",
+			timeout: time.Minute,
+			runner: fakeRunner(time.Second, func() ([]byte, error) {
+				return nil, errors.New("oops")
+			}),
+			assertError: func(t require.TestingT, err error, i ...any) {
+				require.ErrorContains(t, err, "oops")
+			},
+		},
+		{
+			name:    "timeout",
+			timeout: time.Minute,
+			runner: fakeRunner(time.Hour, func() ([]byte, error) {
+				return []byte("impossible"), nil
+			}),
+			assertError: func(t require.TestingT, err error, i ...any) {
+				require.ErrorIs(t, err, context.DeadlineExceeded)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			synctest.Test(t, func(t *testing.T) {
+				v := NewIDTokenSource(os.Getenv, tt.runner)
+
+				str, err := v.GetIDTokenFromCommand(t.Context(), tt.timeout, "foo")
+				require.Equal(t, tt.wantString, str)
+				tt.assertError(t, err)
+			})
+		})
+	}
+}

--- a/lib/join/genericoidc/validator.go
+++ b/lib/join/genericoidc/validator.go
@@ -412,7 +412,7 @@ func evaluateAllowAnyRules(spec *types.ProvisionTokenSpecV2GenericOIDC, claims *
 	return trace.AccessDenied("claims matched no allow_any rules")
 }
 
-// newOIDCTokenValidator constructs an IDTokenValidator.
+// newIDTokenValidatorWithClock constructs an IDTokenValidator.
 func newIDTokenValidatorWithClock(clock clockwork.Clock) (*IDTokenValidator, error) {
 	validator, err := oidc.NewCachingTokenValidator[*IDTokenClaims, GenericOIDCKey](clock)
 	if err != nil {

--- a/lib/join/genericoidc/validator.go
+++ b/lib/join/genericoidc/validator.go
@@ -202,7 +202,7 @@ func (v *IDTokenValidator) validateStaticJWKS(
 		return nil, trace.Wrap(err, "parsing provided jwks")
 	}
 
-	algs := allowedAlgorithmsFromJWKS(jwks)
+	algs, filteredKeys := filterAllowedAlgorithmsFromJWKS(jwks)
 	if len(algs) == 0 {
 		return nil, trace.BadParameter("static_jwks contains no keys with a usable signature algorithm")
 	}
@@ -220,7 +220,7 @@ func (v *IDTokenValidator) validateStaticJWKS(
 	// this.
 	stdClaims := josejwt.Claims{}
 	claims := IDTokenClaims{}
-	if err := parsed.Claims(jwks, &stdClaims, &claims); err != nil {
+	if err := parsed.Claims(filteredKeys, &stdClaims, &claims); err != nil {
 		if errors.Is(err, jose.ErrJWKSKidNotFound) {
 			log.WarnContext(
 				ctx, "unable to validate incoming jwt without a `kid`",
@@ -258,7 +258,11 @@ func (v *IDTokenValidator) validateStaticJWKS(
 // allowedAlgorithmsFromJWKS computes the list of algorithms we should pass to
 // jose, by computing the intersection of our allowed algorithms
 // (acceptableStaticJWKSAlgs) and the algorithms in the `static_jwks` keys.
-func allowedAlgorithmsFromJWKS(jwks jose.JSONWebKeySet) []jose.SignatureAlgorithm {
+func filterAllowedAlgorithmsFromJWKS(jwks jose.JSONWebKeySet) ([]jose.SignatureAlgorithm, jose.JSONWebKeySet) {
+	filteredSet := jose.JSONWebKeySet{
+		Keys: []jose.JSONWebKey{},
+	}
+
 	candidates := make(map[jose.SignatureAlgorithm]struct{})
 	for _, key := range jwks.Keys {
 		if key.Use != "" && key.Use != "sig" {
@@ -268,9 +272,11 @@ func allowedAlgorithmsFromJWKS(jwks jose.JSONWebKeySet) []jose.SignatureAlgorith
 			continue
 		}
 
+		acceptable := false
 		alg := jose.SignatureAlgorithm(key.Algorithm)
 		if _, ok := acceptableStaticJWKSAlgs[alg]; ok {
 			candidates[alg] = struct{}{}
+			acceptable = true
 		} else if key.Algorithm == "" {
 			// `alg` is optional, so if not specified, include based on the key
 			// type
@@ -280,27 +286,36 @@ func allowedAlgorithmsFromJWKS(jwks jose.JSONWebKeySet) []jose.SignatureAlgorith
 				// Note, technically ambiguous between 256/384/512, but without
 				// a hint we have to guess, and RS256 is mandated.
 				candidates[jose.RS256] = struct{}{}
+				acceptable = true
 			case *ecdsa.PublicKey:
 				switch k.Curve {
 				case elliptic.P256():
 					candidates[jose.ES256] = struct{}{}
+					acceptable = true
 				case elliptic.P384():
 					candidates[jose.ES384] = struct{}{}
+					acceptable = true
 				case elliptic.P521():
 					// P521 -> ES512 (confusingly)
 					// https://datatracker.ietf.org/doc/html/rfc7518#section-3.4
 					candidates[jose.ES512] = struct{}{}
+					acceptable = true
 				}
 			case ed25519.PublicKey:
 				candidates[jose.EdDSA] = struct{}{}
+				acceptable = true
 			}
 
 			// If nothing matches, it's a no-op, it certainly wouldn't appear in
 			// our list.
 		}
+
+		if acceptable {
+			filteredSet.Keys = append(filteredSet.Keys, key)
+		}
 	}
 
-	return slices.Collect(maps.Keys(candidates))
+	return slices.Collect(maps.Keys(candidates)), filteredSet
 }
 
 // evaluateGenericOIDCRules evaluates all types of user-defined rules on a

--- a/lib/join/genericoidc/validator.go
+++ b/lib/join/genericoidc/validator.go
@@ -1,0 +1,395 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package genericoidc
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/ed25519"
+	"crypto/elliptic"
+	"crypto/rsa"
+	"crypto/sha256"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"maps"
+	"net/http"
+	"slices"
+	"time"
+
+	"github.com/go-jose/go-jose/v4"
+	josejwt "github.com/go-jose/go-jose/v4/jwt"
+	"github.com/gravitational/trace"
+	"github.com/jonboulle/clockwork"
+	"github.com/zitadel/oidc/v3/pkg/client/rp"
+	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
+
+	"github.com/gravitational/teleport"
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/defaults"
+	"github.com/gravitational/teleport/lib/join/provision"
+	"github.com/gravitational/teleport/lib/oidc"
+	logutils "github.com/gravitational/teleport/lib/utils/log"
+)
+
+var log = logutils.NewPackageLogger(teleport.ComponentKey, teleport.Component("genericoidc"))
+
+// acceptableStaticJWKSAlgs is a list of algorithms considered acceptable for
+// static_jwks verification attempts. This only includes asymmetric algorithms,
+// see also:
+// - https://trufflesecurity.com/blog/stop-recommending-jwts
+// - https://datatracker.ietf.org/doc/html/rfc8725#section-2.1
+// This list isn't passed directly to jose, instead we compute the intersection
+// of this set and the set of algorithms specified in the static_jwks keys.
+var acceptableStaticJWKSAlgs = map[jose.SignatureAlgorithm]struct{}{
+	jose.RS256: {},
+	jose.RS384: {},
+	jose.RS512: {},
+
+	jose.PS256: {},
+	jose.PS384: {},
+	jose.PS512: {},
+
+	jose.ES256: {},
+	jose.ES384: {},
+	jose.ES512: {},
+
+	jose.EdDSA: {},
+}
+
+const (
+	// httpTimeout is a limit on the amount of time any single HTTP request can
+	// take when discovering OIDC parameters (configuration, JWKS, etc).
+	httpTimeout = 10 * time.Second
+)
+
+// GenericOIDCKey is the client cache key used to identify a particular cached
+// OIDC client instance. This additionally includes a hash of the TLS CA (if
+// any) to ensure a new client is constructed if the CA is changed.
+type GenericOIDCKey struct {
+	oidc.StandardValidatorKey
+
+	// tlsCAHash is a hash of the TLS CA config (which may be empty), used to
+	// invalidate validator instances if the user updates their CA.
+	tlsCAHash string
+}
+
+// IDTokenValidator can be used to validate generic OIDC tokens.
+type IDTokenValidator struct {
+	validator *oidc.CachingTokenValidator[*IDTokenClaims, GenericOIDCKey]
+}
+
+// ValidateToken validates a generic OIDC token using a remote, cached OIDC
+// endpoint
+func (v *IDTokenValidator) ValidateToken(
+	ctx context.Context,
+	provisionToken provision.Token,
+	idToken []byte,
+) (*IDTokenClaims, error) {
+	spec, err := provisionToken.GetGenericOIDC()
+	if err != nil {
+		return nil, trace.Wrap(err, "retrieving normalized generic_oidc token configuration")
+	}
+
+	var claims *IDTokenClaims
+	if spec.StaticJWKS != "" {
+		claims, err = v.validateStaticJWKS(ctx, spec, idToken, time.Now())
+		if err != nil {
+			log.InfoContext(ctx, "denying generic_oidc join attempt with static_jwks", "error", err)
+			return nil, trace.AccessDenied("unable to validate generic_oidc join attempt")
+		}
+	} else {
+		claims, err = v.validateOIDC(ctx, spec, idToken)
+		if err != nil {
+			log.InfoContext(ctx, "denying generic_oidc join attempt", "error", err)
+			return nil, trace.AccessDenied("unable to validate generic_oidc join attempt")
+		}
+	}
+
+	if err := evaluateGenericOIDCRules(spec, claims); err != nil {
+		log.InfoContext(ctx, "denying generic_oidc join attempt due to rules evaluation error", "error", err)
+		return nil, trace.AccessDenied("unable to validate generic_oidc join attempt")
+	}
+
+	return claims, nil
+}
+
+// keyForToken returns a caching for the given token, used to fetch the existing
+// cached OIDC validator, if any, or to identify a new one if necessary.
+func keyForToken(spec *types.ProvisionTokenSpecV2GenericOIDC) GenericOIDCKey {
+	key := GenericOIDCKey{
+		StandardValidatorKey: oidc.NewStandardValidatorKey(spec.Issuer, spec.Audience),
+	}
+
+	if spec.TLSCA != "" {
+		hash := sha256.Sum256([]byte(spec.TLSCA))
+		key.tlsCAHash = hex.EncodeToString(hash[:])
+	}
+
+	return key
+}
+
+func (v *IDTokenValidator) validateOIDC(
+	ctx context.Context,
+	spec *types.ProvisionTokenSpecV2GenericOIDC,
+	idToken []byte,
+) (*IDTokenClaims, error) {
+	key := keyForToken(spec)
+
+	validator, err := v.validator.GetValidatorWithKey(ctx, key, func(client *http.Client) error {
+		transport, err := defaults.Transport()
+		if err != nil {
+			return trace.Wrap(err)
+		}
+
+		if len(spec.TLSCA) > 0 {
+			pool := x509.NewCertPool()
+			if !pool.AppendCertsFromPEM([]byte(spec.TLSCA)) {
+				return trace.BadParameter("no valid certificates in `tls_ca`")
+			}
+
+			transport.TLSClientConfig = &tls.Config{
+				RootCAs: pool,
+			}
+		}
+
+		client.Timeout = httpTimeout
+		client.Transport = oidc.NewOIDCRoundTripper(otelhttp.NewTransport(transport))
+		return nil
+	})
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	// We always skip AZP verification. Per the spec, this check is optional,
+	// and the actual check as implemented by zitadel/oidc is a simple string
+	// compare; if users want to check azp, they can add a check rule
+	// themselves.
+	withoutAZPVerifier := rp.WithAZPVerifier(func(string) error {
+		return nil
+	})
+
+	claims, err := validator.ValidateToken(ctx, string(idToken), withoutAZPVerifier)
+	if err != nil {
+		return nil, trace.Wrap(err, "validating OIDC token")
+	}
+
+	return claims, nil
+}
+
+func (v *IDTokenValidator) validateStaticJWKS(
+	ctx context.Context,
+	spec *types.ProvisionTokenSpecV2GenericOIDC,
+	idToken []byte,
+	now time.Time,
+) (*IDTokenClaims, error) {
+	jwks := jose.JSONWebKeySet{}
+	if err := json.Unmarshal([]byte(spec.StaticJWKS), &jwks); err != nil {
+		return nil, trace.Wrap(err, "parsing provided jwks")
+	}
+
+	algs := allowedAlgorithmsFromJWKS(jwks)
+	if len(algs) == 0 {
+		return nil, trace.BadParameter("static_jwks contains no keys with a usable signature algorithm")
+	}
+
+	parsed, err := josejwt.ParseSigned(string(idToken), algs)
+	if err != nil {
+		return nil, trace.Wrap(err, "parsing jwt")
+	}
+
+	// Parse claims both to stdClaims (for validation) and our "custom" claims.
+	// Note that go-jose/v4 requires that `kid` is set. It's technically
+	// possible for an issuer to omit `kid` and serve just one (technically
+	// unambiguous) key, which will then fail validation. We'll fail on that for
+	// now, and can reconsider if we encounter an IdP in the wild that does
+	// this.
+	stdClaims := josejwt.Claims{}
+	claims := IDTokenClaims{}
+	if err := parsed.Claims(jwks, &stdClaims, &claims); err != nil {
+		if errors.Is(err, jose.ErrJWKSKidNotFound) {
+			log.WarnContext(
+				ctx, "unable to validate incoming jwt without a `kid`",
+				"error", err,
+			)
+		}
+		return nil, trace.Wrap(err, "validating jwt signature")
+	}
+
+	leeway := time.Second * 10
+	err = stdClaims.ValidateWithLeeway(josejwt.Expected{
+		Issuer:      spec.Issuer,
+		AnyAudience: josejwt.Audience{spec.Audience},
+		Time:        now,
+	}, leeway)
+	if err != nil {
+		return nil, trace.Wrap(err, "validating standard claims")
+	}
+
+	return &claims, nil
+}
+
+// allowedAlgorithmsFromJWKS computes the list of algorithms we should pass to
+// jose, by computing the intersection of our allowed algorithms
+// (acceptableStaticJWKSAlgs) and the algorithms in the `static_jwks` keys.
+func allowedAlgorithmsFromJWKS(jwks jose.JSONWebKeySet) []jose.SignatureAlgorithm {
+	candidates := make(map[jose.SignatureAlgorithm]struct{})
+	for _, key := range jwks.Keys {
+		if key.Use != "" && key.Use != "sig" {
+			// If "use" is set and it isn't for signing, don't try to include
+			// it. "sig" is a well known value per
+			// https://datatracker.ietf.org/doc/html/rfc7517#section-4.2
+			continue
+		}
+
+		alg := jose.SignatureAlgorithm(key.Algorithm)
+		if _, ok := acceptableStaticJWKSAlgs[alg]; ok {
+			candidates[alg] = struct{}{}
+		} else if key.Algorithm == "" {
+			// `alg` is optional, so if not specified, include based on the key
+			// type
+			// https://datatracker.ietf.org/doc/html/rfc7517#section-4.4
+			switch k := key.Key.(type) {
+			case *rsa.PublicKey:
+				// Note, technically ambiguous between 256/384/512, but without
+				// a hint we have to guess, and RS256 is mandated.
+				candidates[jose.RS256] = struct{}{}
+			case *ecdsa.PublicKey:
+				switch k.Curve {
+				case elliptic.P256():
+					candidates[jose.ES256] = struct{}{}
+				case elliptic.P384():
+					candidates[jose.ES384] = struct{}{}
+				case elliptic.P521():
+					// P521 -> ES512 (confusingly)
+					// https://datatracker.ietf.org/doc/html/rfc7518#section-3.4
+					candidates[jose.ES512] = struct{}{}
+				}
+			case ed25519.PublicKey:
+				candidates[jose.EdDSA] = struct{}{}
+			}
+
+			// If nothing matches, it's a no-op, it certainly wouldn't appear in
+			// our list.
+		}
+	}
+
+	return slices.Collect(maps.Keys(candidates))
+}
+
+// evaluateGenericOIDCRules evaluates all types of user-defined rules on a
+// generic_oidc-type token, following their defined evaluation order and
+// semantics. It also performs final rule-sanity checks to ensure the end user
+// has configured at least some proper rule.
+func evaluateGenericOIDCRules(spec *types.ProvisionTokenSpecV2GenericOIDC, claims *IDTokenClaims) error {
+	allowAnyHasAny := len(spec.AllowAny) > 0
+
+	var err error
+	mustMatchFieldsHasAny := false
+	if spec.MustMatchFields != nil {
+		// We can't trust non-nil to actually have a useful rule. Instead, we'll
+		// use an explicit helper that traverses the struct to make sure an
+		// actual comparison is made somewhere in the tree.
+		mustMatchFieldsHasAny, err = validateFieldRulesContainsAnyRule(spec.MustMatchFields)
+		if err != nil {
+			return trace.Wrap(err, "validating must_match_fields")
+		}
+	}
+
+	// If no rules were defined, this token is invalid and cannot be used.
+	if !mustMatchFieldsHasAny && !allowAnyHasAny {
+		return trace.BadParameter("generic OIDC token has no rules configured")
+	}
+
+	// If field rules were defined, evaluate them first.
+	if mustMatchFieldsHasAny {
+		if err := evaluateFieldRules(spec.MustMatchFields, claims.Claims); err != nil {
+			return trace.Wrap(err, "validating field rules")
+		}
+	}
+
+	// If allow rules were defined, evaluate them last.
+	if allowAnyHasAny {
+		if err := evaluateAllowAnyRules(spec, claims); err != nil {
+			return trace.Wrap(err, "validating allow rules")
+		}
+	}
+
+	return nil
+}
+
+// evaluateAllowAnyRules evaluates rules under `allow_any`, returning
+// successfully for the first entry that does not return an error or an explicit
+// denial
+func evaluateAllowAnyRules(spec *types.ProvisionTokenSpecV2GenericOIDC, claims *IDTokenClaims) error {
+	for i, rule := range spec.AllowAny {
+		switch {
+		case len(rule.Conditions) > 0 && rule.Expression != "":
+			return trace.BadParameter("allow_any[%d]: cannot contain both `conditions` and `expression`", i)
+		case len(rule.Conditions) > 0:
+			err := evaluateAllowAnyConditions(rule.Conditions, claims)
+			if err != nil && !trace.IsAccessDenied(err) {
+				// non access denied error (e.g. structurally invalid rule),
+				// return early
+				return trace.Wrap(err, "allow_any[%d]: evaluating conditions", i)
+			}
+
+			if err == nil {
+				// all conditions passed, allow the attempt
+				return nil
+			}
+		case rule.Expression != "":
+			result, err := evaluateExpression(rule.Expression, &Environment{
+				Claims: claims.Claims,
+			})
+			if err != nil {
+				// Expressions return an explicit allowed bool so we return on
+				// any error. Technically we could continue trying other rules,
+				// but for now we'll raise excessive errors to convince the user
+				// to fix their broken expression.
+				return trace.Wrap(err, "allow_any[%d]: evaluating allow expression", i)
+			}
+
+			if result {
+				return nil
+			}
+		default:
+			return trace.BadParameter("allow_any[%d]: exactly one of `conditions` or `expression` must be set", i)
+		}
+	}
+
+	return trace.AccessDenied("claims matched no allow_any rules")
+}
+
+// newOIDCTokenValidator constructs an IDTokenValidator.
+func newIDTokenValidatorWithClock(clock clockwork.Clock) (*IDTokenValidator, error) {
+	validator, err := oidc.NewCachingTokenValidator[*IDTokenClaims, GenericOIDCKey](clock)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return &IDTokenValidator{
+		validator: validator,
+	}, nil
+}
+
+// NewOIDCTokenValidator constructs an IDTokenValidator.
+func NewIDTokenValidator() (*IDTokenValidator, error) {
+	return newIDTokenValidatorWithClock(clockwork.NewRealClock())
+}

--- a/lib/join/genericoidc/validator.go
+++ b/lib/join/genericoidc/validator.go
@@ -57,6 +57,10 @@ var log = logutils.NewPackageLogger(teleport.ComponentKey, teleport.Component("g
 // - https://datatracker.ietf.org/doc/html/rfc8725#section-2.1
 // This list isn't passed directly to jose, instead we compute the intersection
 // of this set and the set of algorithms specified in the static_jwks keys.
+// Additionally, note that all of these algorithms are technically allowable for
+// verification in FIPS builds, however some may be rejected by BoringCrypto
+// (especially EdDSA) or may qualify as allowed but legacy verification
+// (RS* /PS* < 2048).
 var acceptableStaticJWKSAlgs = map[jose.SignatureAlgorithm]struct{}{
 	jose.RS256: {},
 	jose.RS384: {},

--- a/lib/join/genericoidc/validator.go
+++ b/lib/join/genericoidc/validator.go
@@ -315,11 +315,9 @@ func evaluateGenericOIDCRules(spec *types.ProvisionTokenSpecV2GenericOIDC, claim
 		return trace.BadParameter("generic OIDC token has no rules configured")
 	}
 
-	// If field rules were defined, evaluate them first.
-	if mustMatchFieldsHasAny {
-		if err := evaluateFieldRules(spec.MustMatchFields, claims.Claims); err != nil {
-			return trace.Wrap(err, "validating field rules")
-		}
+	// Always try to evaluate field rules, regardless of `mustMatchFieldsHasAny`
+	if err := evaluateFieldRules(spec.MustMatchFields, claims.Claims); err != nil {
+		return trace.Wrap(err, "validating field rules")
 	}
 
 	// If allow rules were defined, evaluate them last.

--- a/lib/join/genericoidc/validator.go
+++ b/lib/join/genericoidc/validator.go
@@ -111,20 +111,18 @@ func (v *IDTokenValidator) ValidateToken(
 	if spec.StaticJWKS != "" {
 		claims, err = v.validateStaticJWKS(ctx, spec, idToken, time.Now())
 		if err != nil {
-			log.InfoContext(ctx, "denying generic_oidc join attempt with static_jwks", "error", err)
-			return nil, trace.AccessDenied("unable to validate generic_oidc join attempt")
+			return nil, trace.Wrap(err, "validating via static_jwks")
 		}
 	} else {
 		claims, err = v.validateOIDC(ctx, spec, idToken)
 		if err != nil {
 			log.InfoContext(ctx, "denying generic_oidc join attempt", "error", err)
-			return nil, trace.AccessDenied("unable to validate generic_oidc join attempt")
+			return nil, trace.Wrap(err, "validating via oidc")
 		}
 	}
 
 	if err := evaluateGenericOIDCRules(spec, claims); err != nil {
-		log.InfoContext(ctx, "denying generic_oidc join attempt due to rules evaluation error", "error", err)
-		return nil, trace.AccessDenied("unable to validate generic_oidc join attempt")
+		return nil, trace.Wrap(err, "validating generic_oidc rules")
 	}
 
 	return claims, nil

--- a/lib/join/genericoidc/validator.go
+++ b/lib/join/genericoidc/validator.go
@@ -230,6 +230,18 @@ func (v *IDTokenValidator) validateStaticJWKS(
 		return nil, trace.Wrap(err, "validating jwt signature")
 	}
 
+	// go-jose/v4 only checks exp/iat/nbf when present, so make sure they are
+	// present manually so we can be sure they'll be validated, for parity with
+	// the OIDC path. We'll leave `nbf` optional as it is also optional for
+	// OIDC.
+	if stdClaims.Expiry == nil {
+		return nil, trace.AccessDenied("token must have an `exp` claim")
+	}
+
+	if stdClaims.IssuedAt == nil {
+		return nil, trace.AccessDenied("token must have an `iat` claim")
+	}
+
 	leeway := time.Second * 10
 	err = stdClaims.ValidateWithLeeway(josejwt.Expected{
 		Issuer:      spec.Issuer,

--- a/lib/join/genericoidc/validator.go
+++ b/lib/join/genericoidc/validator.go
@@ -273,6 +273,10 @@ func filterAllowedAlgorithmsFromJWKS(jwks jose.JSONWebKeySet) ([]jose.SignatureA
 			// If "use" is set and it isn't for signing, don't try to include
 			// it. "sig" is a well known value per
 			// https://datatracker.ietf.org/doc/html/rfc7517#section-4.2
+			// Note that we honor `use` here but don't check `key_ops`. This
+			// mirrors zitadel/oidc, and in practice since go-jose/v4 drops the
+			// field, it isn't worth re-parsing for what is not a realistic
+			// exploit path especially given the nature of static_jwks keys.
 			continue
 		}
 

--- a/lib/join/genericoidc/validator.go
+++ b/lib/join/genericoidc/validator.go
@@ -230,9 +230,9 @@ func (v *IDTokenValidator) validateStaticJWKS(
 		return nil, trace.Wrap(err, "validating jwt signature")
 	}
 
-	// go-jose/v4 only checks exp/iat/nbf when present, so make sure they are
-	// present manually so we can be sure they'll be validated, for parity with
-	// the OIDC path. We'll leave `nbf` optional as it is also optional for
+	// go-jose/v4 only checks exp/iat/sub/nbf when present, so make sure they
+	// are present manually so we can be sure they'll be validated, for parity
+	// with the OIDC path. We'll leave `nbf` optional as it is also optional for
 	// OIDC.
 	if stdClaims.Expiry == nil {
 		return nil, trace.AccessDenied("token must have an `exp` claim")
@@ -240,6 +240,10 @@ func (v *IDTokenValidator) validateStaticJWKS(
 
 	if stdClaims.IssuedAt == nil {
 		return nil, trace.AccessDenied("token must have an `iat` claim")
+	}
+
+	if stdClaims.Subject == "" {
+		return nil, trace.AccessDenied("token must have a `sub` claim")
 	}
 
 	leeway := time.Second * 10

--- a/lib/join/genericoidc/validator_test.go
+++ b/lib/join/genericoidc/validator_test.go
@@ -471,6 +471,29 @@ func TestGenericOIDC(t *testing.T) {
 				require.ErrorContains(t, err, "generic OIDC token has no rules configured")
 			},
 		},
+		{
+			name: "field rules must always be evaluated",
+			mutateToken: func(token *types.ProvisionTokenV2) {
+				// Negative rule doesn't count for
+				// validateFieldRulesContainsAnyRule() but should still be
+				// honored if set.
+				token.Spec.GenericOIDC.MustMatchFields = specStruct(t, `{
+					"google": {
+						"compute_engine": null
+					}
+				}`)
+				token.Spec.GenericOIDC.AllowAny = []*types.ProvisionTokenSpecV2GenericOIDC_Rule{
+					{
+						Conditions: conditions(
+							eqCondition("google.compute_engine.instance_name", "hello-world"),
+						),
+					},
+				}
+			},
+			expectError: func(t require.TestingT, err error, i ...any) {
+				require.ErrorContains(t, err, "must be null or unset but had a value")
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/lib/join/genericoidc/validator_test.go
+++ b/lib/join/genericoidc/validator_test.go
@@ -373,7 +373,8 @@ func TestGenericOIDC(t *testing.T) {
 				}
 			},
 			expectError: func(t require.TestingT, err error, i ...any) {
-				require.ErrorContains(t, err, `incorrect value in claim: google.compute_engine.project_id must be "foo"`)
+				// real error is logged
+				require.ErrorContains(t, err, "unable to validate generic_oidc join attempt")
 			},
 		},
 		{
@@ -396,7 +397,8 @@ func TestGenericOIDC(t *testing.T) {
 				}
 			},
 			expectError: func(t require.TestingT, err error, i ...any) {
-				require.ErrorContains(t, err, "claims matched no allow_any rules")
+				// real error is logged
+				require.ErrorContains(t, err, "unable to validate generic_oidc join attempt")
 			},
 		},
 		{
@@ -428,7 +430,8 @@ func TestGenericOIDC(t *testing.T) {
 				}`)
 			},
 			expectError: func(t require.TestingT, err error, i ...any) {
-				require.ErrorContains(t, err, "incorrect value in claim: google.compute_engine.project_number must be 11111")
+				// real error is logged
+				require.ErrorContains(t, err, "unable to validate generic_oidc join attempt")
 			},
 		},
 		{
@@ -459,13 +462,15 @@ func TestGenericOIDC(t *testing.T) {
 				}
 			},
 			expectError: func(t require.TestingT, err error, i ...any) {
-				require.ErrorContains(t, err, "claims matched no allow_any rules")
+				// real error is logged
+				require.ErrorContains(t, err, "unable to validate generic_oidc join attempt")
 			},
 		},
 		{
 			name: "error when no rules are configured",
 			expectError: func(t require.TestingT, err error, i ...any) {
-				require.ErrorContains(t, err, "generic OIDC token has no rules configured")
+				// real error is logged
+				require.ErrorContains(t, err, "unable to validate generic_oidc join attempt")
 			},
 		},
 	}
@@ -575,7 +580,8 @@ func TestGenericOIDCStaticJWKS(t *testing.T) {
 				}
 			},
 			expectError: func(t require.TestingT, err error, i ...any) {
-				require.ErrorContains(t, err, "claims matched no allow_any rules")
+				// real error is logged
+				require.ErrorContains(t, err, "unable to validate generic_oidc join attempt")
 			},
 			expectClaims: func(t *testing.T, claims *IDTokenClaims) {
 				require.Nil(t, claims)
@@ -584,7 +590,8 @@ func TestGenericOIDCStaticJWKS(t *testing.T) {
 		{
 			name: "denies with no rules configured",
 			expectError: func(t require.TestingT, err error, i ...any) {
-				require.ErrorContains(t, err, "token has no rules configured")
+				// real error is logged
+				require.ErrorContains(t, err, "unable to validate generic_oidc join attempt")
 			},
 			expectClaims: func(t *testing.T, claims *IDTokenClaims) {
 				require.Nil(t, claims)

--- a/lib/join/genericoidc/validator_test.go
+++ b/lib/join/genericoidc/validator_test.go
@@ -1,0 +1,1034 @@
+/*
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package genericoidc
+
+import (
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"encoding/json"
+	"errors"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/go-jose/go-jose/v4"
+	"github.com/go-jose/go-jose/v4/jwt"
+	"github.com/jonboulle/clockwork"
+	"github.com/stretchr/testify/require"
+	"github.com/zitadel/oidc/v3/pkg/oidc"
+
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/cryptosuites"
+	"github.com/gravitational/teleport/lib/utils/cert"
+)
+
+// fakeIDP provides a minimal fake OIDC provider for use in tests
+type fakeIDP struct {
+	t          *testing.T
+	clock      *clockwork.FakeClock
+	privateKey crypto.Signer
+	signer     jose.Signer
+	publicKey  crypto.PublicKey
+	server     *httptest.Server
+	mux        *http.ServeMux
+	keyID      string
+
+	audience string
+}
+
+func newFakeIDP(t *testing.T, clock *clockwork.FakeClock, audience string) *fakeIDP {
+	privateKey, err := cryptosuites.GenerateKeyWithAlgorithm(cryptosuites.RSA2048)
+	require.NoError(t, err)
+
+	const keyID = "test-key-id"
+	signer, err := jose.NewSigner(
+		jose.SigningKey{
+			Algorithm: jose.RS256,
+			Key: jose.JSONWebKey{
+				Key:       privateKey,
+				KeyID:     keyID,
+				Algorithm: string(jose.RS256),
+			},
+		},
+		(&jose.SignerOptions{}).WithType("JWT"),
+	)
+	require.NoError(t, err)
+
+	f := &fakeIDP{
+		clock:      clock,
+		signer:     signer,
+		privateKey: privateKey,
+		publicKey:  privateKey.Public(),
+		t:          t,
+		audience:   audience,
+		keyID:      keyID,
+	}
+
+	providerMux := http.NewServeMux()
+	providerMux.HandleFunc(
+		"/.well-known/openid-configuration",
+		f.handleOpenIDConfig,
+	)
+	providerMux.HandleFunc(
+		"/.well-known/jwks",
+		f.handleJWKSEndpoint,
+	)
+	providerMux.HandleFunc(
+		"/.well-known/jwks-alt",
+		f.handleJWKSEndpoint,
+	)
+	f.mux = providerMux
+
+	srv := httptest.NewServer(providerMux)
+	t.Cleanup(srv.Close)
+	f.server = srv
+	return f
+}
+
+func (f *fakeIDP) issuer() string {
+	return f.server.URL
+}
+
+func (f *fakeIDP) handleOpenIDConfig(w http.ResponseWriter, r *http.Request) {
+	// Lie about our issuer since the request might be coming via the HTTPS
+	// endpoint.
+	var issuer string
+	if r.TLS != nil {
+		issuer = "https://" + r.Host
+	} else {
+		issuer = "http://" + r.Host
+	}
+
+	jwksURI := issuer + "/.well-known/jwks"
+
+	response := map[string]any{
+		"claims_supported": []string{
+			"sub",
+			"iss",
+		},
+		"id_token_signing_alg_values_supported": []string{"RS256"},
+		"issuer":                                issuer,
+		"jwks_uri":                              jwksURI,
+		"response_types_supported":              []string{"id_token"},
+		"scopes_supported":                      []string{"openid"},
+		"subject_types_supported":               []string{"public"},
+	}
+	responseBytes, err := json.Marshal(response)
+	require.NoError(f.t, err)
+	_, err = w.Write(responseBytes)
+	require.NoError(f.t, err)
+}
+
+func (f *fakeIDP) handleJWKSEndpoint(w http.ResponseWriter, r *http.Request) {
+	jwks := jose.JSONWebKeySet{
+		Keys: []jose.JSONWebKey{
+			{
+				Key:   f.publicKey,
+				KeyID: f.keyID,
+			},
+		},
+	}
+	responseBytes, err := json.Marshal(jwks)
+	require.NoError(f.t, err)
+	_, err = w.Write(responseBytes)
+	require.NoError(f.t, err)
+}
+
+func (f *fakeIDP) issueTokenWithIssuerAndSigner(
+	t *testing.T,
+	signer jose.Signer,
+	issuer, audience, sub string,
+	ttl time.Duration,
+) string {
+	claims := IDTokenClaims{
+		TokenClaims: oidc.TokenClaims{
+			Issuer:          issuer,
+			Subject:         sub,
+			Audience:        oidc.Audience{audience},
+			IssuedAt:        oidc.FromTime(f.clock.Now()),
+			NotBefore:       oidc.FromTime(f.clock.Now()),
+			Expiration:      oidc.FromTime(f.clock.Now().Add(ttl)),
+			AuthorizedParty: "1234567890",
+		},
+
+		// Custom MarshalJSON on oidc.IDTokenClaims should merge these into the
+		// final doc.
+		Claims: map[string]any{
+			"email":          "123456789012-compute@developer.gserviceaccount.com",
+			"email_verified": true,
+			"google": map[string]any{
+				"compute_engine": map[string]any{
+					"instance_creation_timestamp": 1666452409.0,
+					"instance_id":                 "12345678901234567",
+					"instance_name":               "hello-world",
+					"project_id":                  "example-123456",
+					"project_number":              123456123456.0,
+					"zone":                        "us-central1-a",
+				},
+			},
+			"custom": map[string]any{
+				"float": 123.456,
+				"list":  []string{"a", "b", "c"},
+			},
+		},
+	}
+
+	token, err := jwt.Signed(signer).
+		Claims(&claims).
+		Serialize()
+	require.NoError(t, err)
+
+	return token
+}
+
+func (f *fakeIDP) issueTokenWithIssuer(
+	t *testing.T,
+	issuer, audience, sub string,
+	ttl time.Duration,
+) string {
+	return f.issueTokenWithIssuerAndSigner(t, f.signer, issuer, audience, sub, ttl)
+}
+
+func (f *fakeIDP) issueToken(
+	t *testing.T,
+	audience, sub string,
+	ttl time.Duration,
+) string {
+	return f.issueTokenWithIssuer(t, f.issuer(), audience, sub, ttl)
+}
+
+func (f *fakeIDP) staticJWKSConfig(t *testing.T) string {
+	// Essentially the same as the handler above, but without HTTP. Not quite
+	// worth reusing it due to err handling requirements.
+	t.Helper()
+
+	jwks := jose.JSONWebKeySet{
+		Keys: []jose.JSONWebKey{{Key: f.publicKey, KeyID: f.keyID}},
+	}
+
+	bytes, err := json.Marshal(jwks)
+	require.NoError(t, err)
+
+	return string(bytes)
+}
+
+type fakeHTTPSIDP struct {
+	inner *fakeIDP
+
+	httpsListener net.Listener
+	currentCert   atomic.Pointer[tls.Certificate]
+}
+
+func newFakeHTTPSIDP(t *testing.T, idp *fakeIDP) *fakeHTTPSIDP {
+	// Mildly cursed testing fixture courtesy of Claude; we need a way to swap
+	// the cert without creating a new listener.
+
+	outer := &fakeHTTPSIDP{
+		inner: idp,
+	}
+
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	outer.httpsListener = l
+
+	srv := &http.Server{
+		Handler: idp.mux,
+		TLSConfig: &tls.Config{
+			GetCertificate: func(*tls.ClientHelloInfo) (*tls.Certificate, error) {
+				if c := outer.currentCert.Load(); c != nil {
+					return c, nil
+				}
+				return nil, errors.New("fakeIDP: no cert set")
+			},
+		},
+	}
+
+	// Empty certFile and keyFile are okay due to GetCertificate.
+	go srv.ServeTLS(l, "", "")
+
+	t.Cleanup(func() { _ = srv.Close() })
+
+	return outer
+}
+
+func (f *fakeHTTPSIDP) issuer() string {
+	return "https://" + f.httpsListener.Addr().String()
+}
+
+func (f *fakeHTTPSIDP) issueToken(
+	t *testing.T,
+	audience, sub string,
+	ttl time.Duration,
+) string {
+	return f.inner.issueTokenWithIssuer(t, f.issuer(), audience, sub, ttl)
+}
+
+func (f *fakeHTTPSIDP) rotateCA(t *testing.T) (caPEM string) {
+	t.Helper()
+
+	creds, err := cert.GenerateSelfSignedCert(nil, []string{"127.0.0.1"}, nil, time.Now)
+	require.NoError(t, err)
+
+	tlsCert, err := tls.X509KeyPair(creds.Cert, creds.PrivateKey)
+	require.NoError(t, err)
+
+	f.currentCert.Store(&tlsCert)
+	return string(creds.Cert)
+}
+
+func TestGenericOIDC(t *testing.T) {
+	t.Parallel()
+
+	const audience = "example.teleport.sh"
+
+	expires := time.Now().Add(time.Hour)
+	baseToken := &types.ProvisionTokenV2{
+		Metadata: types.Metadata{
+			Name:    "test",
+			Expires: &expires,
+		},
+		Spec: types.ProvisionTokenSpecV2{
+			JoinMethod: types.JoinMethodGenericOIDC,
+			BotName:    "example",
+			Roles:      []types.SystemRole{types.RoleBot},
+			GenericOIDC: &types.ProvisionTokenSpecV2GenericOIDC{
+				Audience: audience,
+			},
+		},
+	}
+
+	tests := []struct {
+		name         string
+		mutateToken  func(token *types.ProvisionTokenV2)
+		expectError  require.ErrorAssertionFunc
+		expectClaims func(t *testing.T, claims *IDTokenClaims)
+	}{
+		{
+			name: "simple success",
+			mutateToken: func(token *types.ProvisionTokenV2) {
+				token.Spec.GenericOIDC.MustMatchFields = specStruct(t, `{
+					"google": {
+						"compute_engine": {
+							"project_id": "example-123456",
+							"project_number": 123456123456
+						}
+					}
+				}`)
+				token.Spec.GenericOIDC.AllowAny = []*types.ProvisionTokenSpecV2GenericOIDC_Rule{
+					{
+						Conditions: conditions(
+							eqCondition("google.compute_engine.instance_name", "hello-world"),
+							notEqCondition("email_verified", "false"),
+							inCondition("azp", "1234567800", "1234567000", "1234567890"),
+							notInCondition("google.compute_engine.zone", "us-central1-b", "us-central1-c", "us-central1-d"),
+						),
+					},
+				}
+			},
+			expectError: require.NoError,
+			expectClaims: func(t *testing.T, claims *IDTokenClaims) {
+				require.NotNil(t, claims)
+				require.Equal(t, "123456789012-compute@developer.gserviceaccount.com", claims.Claims["email"])
+			},
+		},
+		{
+			name: "single mismatched must_match_fields fails",
+			mutateToken: func(token *types.ProvisionTokenV2) {
+				token.Spec.GenericOIDC.MustMatchFields = specStruct(t, `{
+					"google": {
+						"compute_engine": {
+							"project_id": "foo",
+							"project_number": 123456123456
+						}
+					}
+				}`)
+				token.Spec.GenericOIDC.AllowAny = []*types.ProvisionTokenSpecV2GenericOIDC_Rule{
+					{
+						Conditions: conditions(
+							eqCondition("google.compute_engine.instance_name", "hello-world"),
+						),
+					},
+				}
+			},
+			expectError: func(t require.TestingT, err error, i ...any) {
+				require.ErrorContains(t, err, `incorrect value in claim: google.compute_engine.project_id must be "foo"`)
+			},
+		},
+		{
+			name: "single mismatched allow_any fails",
+			mutateToken: func(token *types.ProvisionTokenV2) {
+				token.Spec.GenericOIDC.MustMatchFields = specStruct(t, `{
+					"google": {
+						"compute_engine": {
+							"project_id": "example-123456",
+							"project_number": 123456123456
+						}
+					}
+				}`)
+				token.Spec.GenericOIDC.AllowAny = []*types.ProvisionTokenSpecV2GenericOIDC_Rule{
+					{
+						Conditions: conditions(
+							eqCondition("google.compute_engine.instance_name", "foo"),
+						),
+					},
+				}
+			},
+			expectError: func(t require.TestingT, err error, i ...any) {
+				require.ErrorContains(t, err, "claims matched no allow_any rules")
+			},
+		},
+		{
+			name: "only must_match_fields allows correctly",
+			mutateToken: func(token *types.ProvisionTokenV2) {
+				token.Spec.GenericOIDC.MustMatchFields = specStruct(t, `{
+					"google": {
+						"compute_engine": {
+							"project_id": "example-123456",
+							"project_number": 123456123456
+						}
+					}
+				}`)
+			},
+			expectError: require.NoError,
+			expectClaims: func(t *testing.T, claims *IDTokenClaims) {
+				require.NotNil(t, claims)
+			},
+		},
+		{
+			name: "only must_match_fields denies correctly",
+			mutateToken: func(token *types.ProvisionTokenV2) {
+				token.Spec.GenericOIDC.MustMatchFields = specStruct(t, `{
+					"google": {
+						"compute_engine": {
+							"project_number": 11111
+						}
+					}
+				}`)
+			},
+			expectError: func(t require.TestingT, err error, i ...any) {
+				require.ErrorContains(t, err, "incorrect value in claim: google.compute_engine.project_number must be 11111")
+			},
+		},
+		{
+			name: "only allow_any rules allow correctly",
+			mutateToken: func(token *types.ProvisionTokenV2) {
+				token.Spec.GenericOIDC.AllowAny = []*types.ProvisionTokenSpecV2GenericOIDC_Rule{
+					{
+						Conditions: conditions(
+							eqCondition("google.compute_engine.instance_name", "hello-world"),
+						),
+					},
+				}
+			},
+			expectError: require.NoError,
+			expectClaims: func(t *testing.T, claims *IDTokenClaims) {
+				require.NotNil(t, claims)
+			},
+		},
+		{
+			name: "only allow_any rules deny correctly",
+			mutateToken: func(token *types.ProvisionTokenV2) {
+				token.Spec.GenericOIDC.AllowAny = []*types.ProvisionTokenSpecV2GenericOIDC_Rule{
+					{
+						Conditions: conditions(
+							eqCondition("google.compute_engine.instance_name", "foo"),
+						),
+					},
+				}
+			},
+			expectError: func(t require.TestingT, err error, i ...any) {
+				require.ErrorContains(t, err, "claims matched no allow_any rules")
+			},
+		},
+		{
+			name: "error when no rules are configured",
+			expectError: func(t require.TestingT, err error, i ...any) {
+				require.ErrorContains(t, err, "generic OIDC token has no rules configured")
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			clock := clockwork.NewFakeClock()
+			idp := newFakeIDP(t, clock, audience)
+
+			validator, err := newIDTokenValidatorWithClock(clock)
+			require.NoError(t, err)
+
+			token, ok := baseToken.Clone().(*types.ProvisionTokenV2)
+			require.True(t, ok)
+
+			token.Spec.GenericOIDC.Issuer = idp.issuer()
+			if tt.mutateToken != nil {
+				tt.mutateToken(token)
+			}
+
+			claims, err := validator.ValidateToken(
+				t.Context(),
+				token,
+				[]byte(idp.issueToken(t, audience, "example", time.Hour)),
+			)
+			tt.expectError(t, err)
+
+			if tt.expectClaims != nil {
+				tt.expectClaims(t, claims)
+			} else {
+				require.Nil(t, claims)
+			}
+		})
+	}
+}
+
+func TestGenericOIDCStaticJWKS(t *testing.T) {
+	t.Parallel()
+
+	const audience = "example.teleport.sh"
+	const issuer = "https://not-a-real-url"
+
+	expires := time.Now().Add(time.Hour)
+	baseToken := &types.ProvisionTokenV2{
+		Metadata: types.Metadata{
+			Name:    "test",
+			Expires: &expires,
+		},
+		Spec: types.ProvisionTokenSpecV2{
+			JoinMethod: types.JoinMethodGenericOIDC,
+			BotName:    "example",
+			Roles:      []types.SystemRole{types.RoleBot},
+			GenericOIDC: &types.ProvisionTokenSpecV2GenericOIDC{
+				Audience: audience,
+
+				// hard-code issuer to an invalid value to make sure we aren't
+				// hitting the discovery endpoint of an otherwise-working OIDC
+				// issuer
+				Issuer: issuer,
+			},
+		},
+	}
+
+	tests := []struct {
+		name         string
+		mutateToken  func(token *types.ProvisionTokenV2)
+		expectError  require.ErrorAssertionFunc
+		expectClaims func(t *testing.T, claims *IDTokenClaims)
+	}{
+		{
+			name: "success with all rule types",
+			mutateToken: func(token *types.ProvisionTokenV2) {
+				token.Spec.GenericOIDC.MustMatchFields = specStruct(t, `{
+					"google": {
+						"compute_engine": {
+							"project_id": "example-123456",
+							"project_number": 123456123456
+						}
+					}
+				}`)
+				token.Spec.GenericOIDC.AllowAny = []*types.ProvisionTokenSpecV2GenericOIDC_Rule{
+					{
+						Conditions: conditions(
+							eqCondition("google.compute_engine.instance_name", "hello-world"),
+							notEqCondition("email_verified", "false"),
+							inCondition("azp", "1234567800", "1234567000", "1234567890"),
+							notInCondition("google.compute_engine.zone", "us-central1-b", "us-central1-c", "us-central1-d"),
+						),
+					},
+				}
+			},
+			expectError: require.NoError,
+			expectClaims: func(t *testing.T, claims *IDTokenClaims) {
+				require.NotNil(t, claims)
+				require.Equal(t, "123456789012-compute@developer.gserviceaccount.com", claims.Claims["email"])
+			},
+		},
+		{
+			name: "denies with a failing rule",
+			mutateToken: func(token *types.ProvisionTokenV2) {
+				token.Spec.GenericOIDC.AllowAny = []*types.ProvisionTokenSpecV2GenericOIDC_Rule{
+					{
+						Conditions: conditions(
+							eqCondition("google.compute_engine.instance_name", "incorrect"),
+						),
+					},
+				}
+			},
+			expectError: func(t require.TestingT, err error, i ...any) {
+				require.ErrorContains(t, err, "claims matched no allow_any rules")
+			},
+			expectClaims: func(t *testing.T, claims *IDTokenClaims) {
+				require.Nil(t, claims)
+			},
+		},
+		{
+			name: "denies with no rules configured",
+			expectError: func(t require.TestingT, err error, i ...any) {
+				require.ErrorContains(t, err, "token has no rules configured")
+			},
+			expectClaims: func(t *testing.T, claims *IDTokenClaims) {
+				require.Nil(t, claims)
+			},
+		},
+		{
+			name: "denies with invalid jwks",
+			mutateToken: func(token *types.ProvisionTokenV2) {
+				token.Spec.GenericOIDC.AllowAny = []*types.ProvisionTokenSpecV2GenericOIDC_Rule{
+					{
+						Conditions: conditions(
+							eqCondition("google.compute_engine.instance_name", "incorrect"),
+						),
+					},
+				}
+				token.Spec.GenericOIDC.StaticJWKS = "{asdfasdfasdf"
+			},
+			expectError: func(t require.TestingT, err error, i ...any) {
+				// generic failure message
+				require.ErrorContains(t, err, "unable to validate generic_oidc join attempt")
+			},
+			expectClaims: func(t *testing.T, claims *IDTokenClaims) {
+				require.Nil(t, claims)
+			},
+		},
+		{
+			name: "denies with incorrect signature",
+			mutateToken: func(token *types.ProvisionTokenV2) {
+				token.Spec.GenericOIDC.AllowAny = []*types.ProvisionTokenSpecV2GenericOIDC_Rule{
+					{
+						Conditions: conditions(
+							eqCondition("google.compute_engine.instance_name", "incorrect"),
+						),
+					},
+				}
+
+				other := createPubKey(t, cryptosuites.RSA2048)
+				b, err := json.Marshal(jose.JSONWebKeySet{Keys: []jose.JSONWebKey{
+					{
+						Key: other,
+						// set KeyID to make it as far down the validation path
+						// as possible (log should indicate "error in
+						// cryptographic primitive")
+						KeyID: "test-key-id",
+					},
+				}})
+				require.NoError(t, err)
+				token.Spec.GenericOIDC.StaticJWKS = string(b)
+
+			},
+			expectError: func(t require.TestingT, err error, i ...any) {
+				// generic failure message
+				require.ErrorContains(t, err, "unable to validate generic_oidc join attempt")
+			},
+			expectClaims: func(t *testing.T, claims *IDTokenClaims) {
+				require.Nil(t, claims)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			clock := clockwork.NewFakeClock()
+			idp := newFakeIDP(t, clock, audience)
+
+			validator, err := newIDTokenValidatorWithClock(clock)
+			require.NoError(t, err)
+
+			token, ok := baseToken.Clone().(*types.ProvisionTokenV2)
+			require.True(t, ok)
+
+			token.Spec.GenericOIDC.StaticJWKS = idp.staticJWKSConfig(t)
+			if tt.mutateToken != nil {
+				tt.mutateToken(token)
+			}
+
+			claims, err := validator.ValidateToken(
+				t.Context(),
+				token,
+				[]byte(idp.issueTokenWithIssuer(t, issuer, audience, "example", time.Hour)),
+			)
+			tt.expectError(t, err)
+
+			if tt.expectClaims != nil {
+				tt.expectClaims(t, claims)
+			} else {
+				require.Nil(t, claims)
+			}
+		})
+	}
+}
+
+func TestGenericOIDCWithCustomCA(t *testing.T) {
+	t.Parallel()
+
+	const audience = "example.teleport.sh"
+
+	clock := clockwork.NewFakeClock()
+	idp := newFakeIDP(t, clock, audience)
+	httpsIDP := newFakeHTTPSIDP(t, idp)
+
+	expires := time.Now().Add(time.Hour)
+	token := &types.ProvisionTokenV2{
+		Metadata: types.Metadata{
+			Name:    "test",
+			Expires: &expires,
+		},
+		Spec: types.ProvisionTokenSpecV2{
+			JoinMethod: types.JoinMethodGenericOIDC,
+			BotName:    "example",
+			Roles:      []types.SystemRole{types.RoleBot},
+			GenericOIDC: &types.ProvisionTokenSpecV2GenericOIDC{
+				Audience: audience,
+				Issuer:   httpsIDP.issuer(),
+				TLSCA:    httpsIDP.rotateCA(t),
+				MustMatchFields: specStruct(t, `{
+					"email": "123456789012-compute@developer.gserviceaccount.com"
+				}`),
+			},
+		},
+	}
+
+	validator, err := newIDTokenValidatorWithClock(clock)
+	require.NoError(t, err)
+
+	// First, make a request that should fail: rotate (discarding the CA) and
+	// try using the old one. We need to do this first since otherwise a working
+	// validator would be cached.
+	_ = httpsIDP.rotateCA(t)
+	claims, err := validator.ValidateToken(
+		t.Context(),
+		token,
+		[]byte(httpsIDP.issueToken(t, audience, "example", time.Hour)),
+	)
+	// real error is only logged, but should indicate a bad cert
+	require.ErrorContains(t, err, "unable to validate generic_oidc join attempt")
+	require.Nil(t, claims)
+
+	// Now make a real validation request. It should fetch using the custom CA.
+	token.Spec.GenericOIDC.TLSCA = httpsIDP.rotateCA(t)
+	claims, err = validator.ValidateToken(
+		t.Context(),
+		token,
+		[]byte(httpsIDP.issueToken(t, audience, "example", time.Hour)),
+	)
+	require.NoError(t, err)
+	require.NotNil(t, claims)
+
+	// Try again, but with the new CA. If the old client is used, then it would
+	// try using the old cached CA and fail.
+	token.Spec.GenericOIDC.TLSCA = httpsIDP.rotateCA(t)
+
+	claims, err = validator.ValidateToken(
+		t.Context(),
+		token,
+		[]byte(httpsIDP.issueToken(t, audience, "example", time.Hour)),
+	)
+	require.NoError(t, err)
+	require.NotNil(t, claims)
+
+	// One more try to prove the original caching claim: rotate the CA, but
+	// don't update the token. It'll use a cached validator and succeed, since
+	// it'll never make a request in the first place.
+	_ = httpsIDP.rotateCA(t)
+
+	claims, err = validator.ValidateToken(
+		t.Context(),
+		token,
+		[]byte(httpsIDP.issueToken(t, audience, "example", time.Hour)),
+	)
+	require.NoError(t, err)
+	require.NotNil(t, claims)
+}
+
+// TestKeyForToken ensures unique caching keys are generated when the CA changes
+// but iss/aud remain the same.
+func TestKeyForToken(t *testing.T) {
+	spec := func(ca string) *types.ProvisionTokenSpecV2GenericOIDC {
+		return &types.ProvisionTokenSpecV2GenericOIDC{Issuer: "iss", Audience: "aud", TLSCA: ca}
+	}
+
+	none := keyForToken(spec(""))
+	caA := keyForToken(spec("ca-A"))
+	caA2 := keyForToken(spec("ca-A"))
+	caB := keyForToken(spec("ca-B"))
+
+	require.Equal(t, caA, caA2, "same CA must reuse the cached instance")
+	require.NotEqual(t, caA, caB, "different CA must build a new instance")
+	require.NotEqual(t, none, caA, "absent vs present CA must differ")
+	require.Empty(t, none.tlsCAHash)
+	require.NotEmpty(t, caA.tlsCAHash)
+}
+
+func TestValidateStaticJWKS(t *testing.T) {
+	clock := clockwork.NewFakeClock()
+
+	idp := newFakeIDP(t, clock, "aud")
+	v, err := newIDTokenValidatorWithClock(clock)
+	require.NoError(t, err)
+
+	const issuer = "https://static.example.test"
+
+	// validToken is a valid token jose accepts, with a `kid`
+	validToken := []byte(idp.issueTokenWithIssuer(t, issuer, "aud", "sub", time.Hour))
+
+	// noKidToken is missing the `kid` field
+	noKidSigner, err := jose.NewSigner(
+		jose.SigningKey{Algorithm: jose.RS256, Key: idp.privateKey},
+		(&jose.SignerOptions{}).WithType("JWT"),
+	)
+	require.NoError(t, err)
+	noKidToken := []byte(idp.issueTokenWithIssuerAndSigner(
+		t, noKidSigner, issuer, "aud", "sub", time.Hour,
+	))
+
+	tests := []struct {
+		name         string
+		token        []byte
+		mutateSpec   func(spec *types.ProvisionTokenSpecV2GenericOIDC)
+		nowOffset    time.Duration
+		expectError  require.ErrorAssertionFunc
+		expectClaims bool
+	}{
+		{
+			name:         "success with sane values",
+			token:        validToken,
+			expectError:  require.NoError,
+			expectClaims: true,
+		},
+		{
+			name:      "fails when expired",
+			token:     validToken,
+			nowOffset: 2 * time.Hour,
+			expectError: func(t require.TestingT, err error, i ...any) {
+				require.ErrorContains(t, err, "validating standard claims")
+			},
+		},
+		{
+			name:  "fails with mismatched audience",
+			token: validToken,
+			mutateSpec: func(spec *types.ProvisionTokenSpecV2GenericOIDC) {
+				spec.Audience = "invalid"
+			},
+			expectError: func(t require.TestingT, err error, i ...any) {
+				require.ErrorContains(t, err, "validating standard claims")
+			},
+		},
+		{
+			name:  "fails when token is missing kid",
+			token: noKidToken,
+			expectError: func(t require.TestingT, err error, i ...any) {
+				require.ErrorContains(t, err, "JWK with matching kid not found")
+			},
+		},
+		{
+			name:  "fails with unusable key",
+			token: validToken,
+			mutateSpec: func(spec *types.ProvisionTokenSpecV2GenericOIDC) {
+				b, err := json.Marshal(jose.JSONWebKeySet{Keys: []jose.JSONWebKey{{
+					Key:       []byte("fake-symmetric-key"),
+					KeyID:     "test-key-id",
+					Algorithm: string(jose.HS256),
+					Use:       "sig",
+				}}})
+				require.NoError(t, err)
+
+				spec.StaticJWKS = string(b)
+			},
+			expectError: func(t require.TestingT, err error, i ...any) {
+				require.ErrorContains(t, err, "contains no keys with a usable signature algorithm")
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			spec := &types.ProvisionTokenSpecV2GenericOIDC{
+				Issuer:     issuer,
+				Audience:   "aud",
+				StaticJWKS: idp.staticJWKSConfig(t),
+			}
+			if tt.mutateSpec != nil {
+				tt.mutateSpec(spec)
+			}
+
+			claims, err := v.validateStaticJWKS(t.Context(), spec, tt.token, clock.Now().Add(tt.nowOffset))
+			tt.expectError(t, err)
+
+			if tt.expectClaims {
+				require.NotNil(t, claims)
+			} else {
+				require.Nil(t, claims)
+			}
+		})
+	}
+}
+
+func createPubKey(t *testing.T, alg cryptosuites.Algorithm) crypto.PublicKey {
+	t.Helper()
+	priv, err := cryptosuites.GenerateKeyWithAlgorithm(alg)
+	require.NoError(t, err)
+	return priv.Public()
+}
+
+func createECPubKey(t *testing.T, curve elliptic.Curve) crypto.PublicKey {
+	t.Helper()
+	priv, err := ecdsa.GenerateKey(curve, rand.Reader)
+	require.NoError(t, err)
+	return priv.Public()
+}
+
+func TestAllowedAlgorithmsFromJWKS(t *testing.T) {
+	rsaPub := createPubKey(t, cryptosuites.RSA2048)
+	ecP256 := createPubKey(t, cryptosuites.ECDSAP256)
+	ecP384 := createECPubKey(t, elliptic.P384())
+	ecP521 := createECPubKey(t, elliptic.P521())
+	edPub := createPubKey(t, cryptosuites.Ed25519)
+
+	key := func(key crypto.PublicKey, alg jose.SignatureAlgorithm) jose.JSONWebKey {
+		return jose.JSONWebKey{
+			Key:       key,
+			Algorithm: string(alg),
+		}
+	}
+
+	keys := func(keys ...jose.JSONWebKey) []jose.JSONWebKey {
+		return keys
+	}
+
+	algs := func(algs ...jose.SignatureAlgorithm) []jose.SignatureAlgorithm {
+		// stupid helper to save typing
+		return algs
+	}
+
+	tests := []struct {
+		name string
+		keys []jose.JSONWebKey
+		want []jose.SignatureAlgorithm
+	}{
+		{
+			name: "acceptable algorithms are passed through",
+			keys: keys(
+				key(rsaPub, jose.RS256),
+				key(rsaPub, jose.RS384),
+				key(rsaPub, jose.RS512),
+				key(ecP256, jose.ES256),
+				key(ecP384, jose.ES384),
+				key(ecP521, jose.ES512),
+				key(edPub, jose.EdDSA),
+			),
+			want: algs(
+				jose.RS256, jose.RS384, jose.RS512,
+				jose.ES256, jose.ES384, jose.ES512,
+				jose.EdDSA,
+			),
+		},
+		{
+			name: "symmetric requests are dropped",
+			keys: keys(
+				key(rsaPub, jose.HS256),
+				key(rsaPub, jose.HS384),
+				key(rsaPub, jose.HS512),
+			),
+			want: algs(), // empty
+		},
+		{
+			name: "only allowed keys pass",
+			keys: keys(
+				// all allowed key types...
+				key(rsaPub, jose.RS256),
+				key(rsaPub, jose.RS384),
+				key(rsaPub, jose.RS512),
+				key(ecP256, jose.ES256),
+				key(ecP384, jose.ES384),
+				key(ecP521, jose.ES512),
+				key(edPub, jose.EdDSA),
+
+				// various banned key types
+				key(rsaPub, jose.HS256),
+				key(rsaPub, jose.HS384),
+				key(rsaPub, jose.HS512),
+			),
+			want: algs(
+				jose.RS256, jose.RS384, jose.RS512,
+				jose.ES256, jose.ES384, jose.ES512,
+				jose.EdDSA,
+			),
+		},
+		{
+			name: "rsa without alg defaults to RS256",
+			keys: keys(key(rsaPub, "")),
+			want: algs(jose.RS256),
+		},
+		{
+			name: "ecdsa P-256 without alg",
+			keys: keys(key(ecP256, "")),
+			want: algs(jose.ES256),
+		},
+		{
+			name: "ecdsa P-384 without alg",
+			keys: keys(key(ecP384, "")),
+			want: algs(jose.ES384),
+		},
+		{
+			name: "ecdsa P-521 without alg maps to ES512",
+			keys: keys(key(ecP521, "")),
+			want: algs(jose.ES512),
+		},
+		{
+			name: "ed25519 without alg",
+			keys: keys(key(edPub, "")),
+			want: algs(jose.EdDSA),
+		},
+		{
+			name: "duplicates are removed",
+			keys: keys(key(rsaPub, jose.RS256), key(rsaPub, jose.RS256)),
+			want: algs(jose.RS256),
+		},
+		{
+			name: "none is ignored",
+			keys: keys(
+				key([]byte{}, jose.SignatureAlgorithm("none")),
+			),
+			want: []jose.SignatureAlgorithm{},
+		},
+		{
+			name: "encryption-use key is skipped",
+			keys: keys(jose.JSONWebKey{Key: rsaPub, Use: "enc"}),
+			want: []jose.SignatureAlgorithm{},
+		},
+		{
+			name: "empty",
+			// weirdly, nothing to do
+		},
+		{
+			name: "nil",
+			keys: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := allowedAlgorithmsFromJWKS(jose.JSONWebKeySet{Keys: tt.keys})
+			require.ElementsMatch(t, tt.want, got)
+		})
+	}
+}

--- a/lib/join/genericoidc/validator_test.go
+++ b/lib/join/genericoidc/validator_test.go
@@ -373,8 +373,7 @@ func TestGenericOIDC(t *testing.T) {
 				}
 			},
 			expectError: func(t require.TestingT, err error, i ...any) {
-				// real error is logged
-				require.ErrorContains(t, err, "unable to validate generic_oidc join attempt")
+				require.ErrorContains(t, err, "incorrect value in claim: google.compute_engine.project_id must be \"foo\"")
 			},
 		},
 		{
@@ -397,8 +396,7 @@ func TestGenericOIDC(t *testing.T) {
 				}
 			},
 			expectError: func(t require.TestingT, err error, i ...any) {
-				// real error is logged
-				require.ErrorContains(t, err, "unable to validate generic_oidc join attempt")
+				require.ErrorContains(t, err, "claims matched no allow_any rules")
 			},
 		},
 		{
@@ -431,7 +429,7 @@ func TestGenericOIDC(t *testing.T) {
 			},
 			expectError: func(t require.TestingT, err error, i ...any) {
 				// real error is logged
-				require.ErrorContains(t, err, "unable to validate generic_oidc join attempt")
+				require.ErrorContains(t, err, "incorrect value in claim: google.compute_engine.project_number must be 11111")
 			},
 		},
 		{
@@ -463,14 +461,14 @@ func TestGenericOIDC(t *testing.T) {
 			},
 			expectError: func(t require.TestingT, err error, i ...any) {
 				// real error is logged
-				require.ErrorContains(t, err, "unable to validate generic_oidc join attempt")
+				require.ErrorContains(t, err, "claims matched no allow_any rules")
 			},
 		},
 		{
 			name: "error when no rules are configured",
 			expectError: func(t require.TestingT, err error, i ...any) {
 				// real error is logged
-				require.ErrorContains(t, err, "unable to validate generic_oidc join attempt")
+				require.ErrorContains(t, err, "generic OIDC token has no rules configured")
 			},
 		},
 	}
@@ -580,8 +578,7 @@ func TestGenericOIDCStaticJWKS(t *testing.T) {
 				}
 			},
 			expectError: func(t require.TestingT, err error, i ...any) {
-				// real error is logged
-				require.ErrorContains(t, err, "unable to validate generic_oidc join attempt")
+				require.ErrorContains(t, err, "claims matched no allow_any rules")
 			},
 			expectClaims: func(t *testing.T, claims *IDTokenClaims) {
 				require.Nil(t, claims)
@@ -591,7 +588,7 @@ func TestGenericOIDCStaticJWKS(t *testing.T) {
 			name: "denies with no rules configured",
 			expectError: func(t require.TestingT, err error, i ...any) {
 				// real error is logged
-				require.ErrorContains(t, err, "unable to validate generic_oidc join attempt")
+				require.ErrorContains(t, err, "generic OIDC token has no rules configured")
 			},
 			expectClaims: func(t *testing.T, claims *IDTokenClaims) {
 				require.Nil(t, claims)
@@ -610,8 +607,7 @@ func TestGenericOIDCStaticJWKS(t *testing.T) {
 				token.Spec.GenericOIDC.StaticJWKS = "{asdfasdfasdf"
 			},
 			expectError: func(t require.TestingT, err error, i ...any) {
-				// generic failure message
-				require.ErrorContains(t, err, "unable to validate generic_oidc join attempt")
+				require.ErrorContains(t, err, "parsing provided jwks")
 			},
 			expectClaims: func(t *testing.T, claims *IDTokenClaims) {
 				require.Nil(t, claims)
@@ -643,8 +639,7 @@ func TestGenericOIDCStaticJWKS(t *testing.T) {
 
 			},
 			expectError: func(t require.TestingT, err error, i ...any) {
-				// generic failure message
-				require.ErrorContains(t, err, "unable to validate generic_oidc join attempt")
+				require.ErrorContains(t, err, "validating jwt signature")
 			},
 			expectClaims: func(t *testing.T, claims *IDTokenClaims) {
 				require.Nil(t, claims)
@@ -726,8 +721,7 @@ func TestGenericOIDCWithCustomCA(t *testing.T) {
 		token,
 		[]byte(httpsIDP.issueToken(t, audience, "example", time.Hour)),
 	)
-	// real error is only logged, but should indicate a bad cert
-	require.ErrorContains(t, err, "unable to validate generic_oidc join attempt")
+	require.ErrorContains(t, err, "x509: certificate signed by unknown authority")
 	require.Nil(t, claims)
 
 	// Now make a real validation request. It should fetch using the custom CA.

--- a/lib/join/genericoidc/validator_test.go
+++ b/lib/join/genericoidc/validator_test.go
@@ -161,6 +161,7 @@ func (f *fakeIDP) issueTokenWithIssuerAndSigner(
 	signer jose.Signer,
 	issuer, audience, sub string,
 	ttl time.Duration,
+	claimsMutators ...func(*IDTokenClaims),
 ) string {
 	claims := IDTokenClaims{
 		TokenClaims: oidc.TokenClaims{
@@ -195,6 +196,12 @@ func (f *fakeIDP) issueTokenWithIssuerAndSigner(
 		},
 	}
 
+	for _, mut := range claimsMutators {
+		if mut != nil {
+			mut(&claims)
+		}
+	}
+
 	token, err := jwt.Signed(signer).
 		Claims(&claims).
 		Serialize()
@@ -207,8 +214,9 @@ func (f *fakeIDP) issueTokenWithIssuer(
 	t *testing.T,
 	issuer, audience, sub string,
 	ttl time.Duration,
+	claimsMutators ...func(*IDTokenClaims),
 ) string {
-	return f.issueTokenWithIssuerAndSigner(t, f.signer, issuer, audience, sub, ttl)
+	return f.issueTokenWithIssuerAndSigner(t, f.signer, issuer, audience, sub, ttl, claimsMutators...)
 }
 
 func (f *fakeIDP) issueToken(
@@ -560,6 +568,7 @@ func TestGenericOIDCStaticJWKS(t *testing.T) {
 		mutateToken  func(token *types.ProvisionTokenV2)
 		expectError  require.ErrorAssertionFunc
 		expectClaims func(t *testing.T, claims *IDTokenClaims)
+		mutateClaims func(*IDTokenClaims)
 	}{
 		{
 			name: "success with all rule types",
@@ -668,6 +677,60 @@ func TestGenericOIDCStaticJWKS(t *testing.T) {
 				require.Nil(t, claims)
 			},
 		},
+		{
+			name: "rejects token without iat",
+			mutateClaims: func(c *IDTokenClaims) {
+				c.IssuedAt = 0
+			},
+			mutateToken: func(token *types.ProvisionTokenV2) {
+				token.Spec.GenericOIDC.AllowAny = []*types.ProvisionTokenSpecV2GenericOIDC_Rule{
+					{
+						Conditions: conditions(
+							eqCondition("google.compute_engine.instance_name", "hello-world"),
+						),
+					},
+				}
+			},
+			expectError: func(t require.TestingT, err error, i ...any) {
+				require.ErrorContains(t, err, "token must have an `iat` claim")
+			},
+		},
+		{
+			name: "rejects token without exp",
+			mutateClaims: func(c *IDTokenClaims) {
+				c.Expiration = 0
+			},
+			mutateToken: func(token *types.ProvisionTokenV2) {
+				token.Spec.GenericOIDC.AllowAny = []*types.ProvisionTokenSpecV2GenericOIDC_Rule{
+					{
+						Conditions: conditions(
+							eqCondition("google.compute_engine.instance_name", "hello-world"),
+						),
+					},
+				}
+			},
+			expectError: func(t require.TestingT, err error, i ...any) {
+				require.ErrorContains(t, err, "token must have an `exp` claim")
+			},
+		},
+		{
+			name: "rejects token without sub",
+			mutateClaims: func(c *IDTokenClaims) {
+				c.Subject = ""
+			},
+			mutateToken: func(token *types.ProvisionTokenV2) {
+				token.Spec.GenericOIDC.AllowAny = []*types.ProvisionTokenSpecV2GenericOIDC_Rule{
+					{
+						Conditions: conditions(
+							eqCondition("google.compute_engine.instance_name", "hello-world"),
+						),
+					},
+				}
+			},
+			expectError: func(t require.TestingT, err error, i ...any) {
+				require.ErrorContains(t, err, "token must have a `sub` claim")
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -689,7 +752,7 @@ func TestGenericOIDCStaticJWKS(t *testing.T) {
 			claims, err := validator.ValidateToken(
 				t.Context(),
 				token,
-				[]byte(idp.issueTokenWithIssuer(t, issuer, audience, "example", time.Hour)),
+				[]byte(idp.issueTokenWithIssuer(t, issuer, audience, "example", time.Hour, tt.mutateClaims)),
 			)
 			tt.expectError(t, err)
 

--- a/lib/join/genericoidc/validator_test.go
+++ b/lib/join/genericoidc/validator_test.go
@@ -502,6 +502,53 @@ func TestGenericOIDC(t *testing.T) {
 				require.ErrorContains(t, err, "must be null or unset but had a value")
 			},
 		},
+		{
+			name: "allow_any expression allows correctly",
+			mutateToken: func(token *types.ProvisionTokenV2) {
+				token.Spec.GenericOIDC.AllowAny = []*types.ProvisionTokenSpecV2GenericOIDC_Rule{
+					{
+						Expression: "claims.google.compute_engine.instance_name == \"hello-world\"",
+					},
+				}
+			},
+			expectError: require.NoError,
+			expectClaims: func(t *testing.T, claims *IDTokenClaims) {
+				require.NotNil(t, claims)
+			},
+		},
+		{
+			name: "allow_any expression denies correctly",
+			mutateToken: func(token *types.ProvisionTokenV2) {
+				token.Spec.GenericOIDC.AllowAny = []*types.ProvisionTokenSpecV2GenericOIDC_Rule{
+					{
+						Expression: "claims.google.compute_engine.instance_name == \"asdf\"",
+					},
+				}
+			},
+			expectError: func(t require.TestingT, err error, i ...any) {
+				require.ErrorContains(t, err, "claims matched no allow_any rules")
+			},
+			expectClaims: func(t *testing.T, claims *IDTokenClaims) {
+				require.Nil(t, claims)
+			},
+		},
+		{
+			name: "multiple allow_any expressions allow eventually",
+			mutateToken: func(token *types.ProvisionTokenV2) {
+				token.Spec.GenericOIDC.AllowAny = []*types.ProvisionTokenSpecV2GenericOIDC_Rule{
+					{
+						Expression: "claims.google.compute_engine.instance_name == \"asdf\"",
+					},
+					{
+						Expression: "claims.google.compute_engine.instance_name == \"hello-world\"",
+					},
+				}
+			},
+			expectError: require.NoError,
+			expectClaims: func(t *testing.T, claims *IDTokenClaims) {
+				require.NotNil(t, claims)
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/lib/join/genericoidc/validator_test.go
+++ b/lib/join/genericoidc/validator_test.go
@@ -944,9 +944,10 @@ func TestAllowedAlgorithmsFromJWKS(t *testing.T) {
 	}
 
 	tests := []struct {
-		name string
-		keys []jose.JSONWebKey
-		want []jose.SignatureAlgorithm
+		name     string
+		keys     []jose.JSONWebKey
+		wantAlgs []jose.SignatureAlgorithm
+		wantKeys []jose.JSONWebKey
 	}{
 		{
 			name: "acceptable algorithms are passed through",
@@ -959,10 +960,19 @@ func TestAllowedAlgorithmsFromJWKS(t *testing.T) {
 				key(ecP521, jose.ES512),
 				key(edPub, jose.EdDSA),
 			),
-			want: algs(
+			wantAlgs: algs(
 				jose.RS256, jose.RS384, jose.RS512,
 				jose.ES256, jose.ES384, jose.ES512,
 				jose.EdDSA,
+			),
+			wantKeys: keys(
+				key(rsaPub, jose.RS256),
+				key(rsaPub, jose.RS384),
+				key(rsaPub, jose.RS512),
+				key(ecP256, jose.ES256),
+				key(ecP384, jose.ES384),
+				key(ecP521, jose.ES512),
+				key(edPub, jose.EdDSA),
 			),
 		},
 		{
@@ -972,7 +982,8 @@ func TestAllowedAlgorithmsFromJWKS(t *testing.T) {
 				key(rsaPub, jose.HS384),
 				key(rsaPub, jose.HS512),
 			),
-			want: algs(), // empty
+			wantAlgs: algs(), // empty
+			wantKeys: keys(),
 		},
 		{
 			name: "only allowed keys pass",
@@ -991,53 +1002,70 @@ func TestAllowedAlgorithmsFromJWKS(t *testing.T) {
 				key(rsaPub, jose.HS384),
 				key(rsaPub, jose.HS512),
 			),
-			want: algs(
+			wantAlgs: algs(
 				jose.RS256, jose.RS384, jose.RS512,
 				jose.ES256, jose.ES384, jose.ES512,
 				jose.EdDSA,
 			),
+			wantKeys: keys(
+				key(rsaPub, jose.RS256),
+				key(rsaPub, jose.RS384),
+				key(rsaPub, jose.RS512),
+				key(ecP256, jose.ES256),
+				key(ecP384, jose.ES384),
+				key(ecP521, jose.ES512),
+				key(edPub, jose.EdDSA),
+			),
 		},
 		{
-			name: "rsa without alg defaults to RS256",
-			keys: keys(key(rsaPub, "")),
-			want: algs(jose.RS256),
+			name:     "rsa without alg defaults to RS256",
+			keys:     keys(key(rsaPub, "")),
+			wantAlgs: algs(jose.RS256),
+			wantKeys: keys(key(rsaPub, "")), // alg passes through unmodified
 		},
 		{
-			name: "ecdsa P-256 without alg",
-			keys: keys(key(ecP256, "")),
-			want: algs(jose.ES256),
+			name:     "ecdsa P-256 without alg",
+			keys:     keys(key(ecP256, "")),
+			wantAlgs: algs(jose.ES256),
+			wantKeys: keys(key(ecP256, "")),
 		},
 		{
-			name: "ecdsa P-384 without alg",
-			keys: keys(key(ecP384, "")),
-			want: algs(jose.ES384),
+			name:     "ecdsa P-384 without alg",
+			keys:     keys(key(ecP384, "")),
+			wantAlgs: algs(jose.ES384),
+			wantKeys: keys(key(ecP384, "")),
 		},
 		{
-			name: "ecdsa P-521 without alg maps to ES512",
-			keys: keys(key(ecP521, "")),
-			want: algs(jose.ES512),
+			name:     "ecdsa P-521 without alg maps to ES512",
+			keys:     keys(key(ecP521, "")),
+			wantAlgs: algs(jose.ES512),
+			wantKeys: keys(key(ecP521, "")),
 		},
 		{
-			name: "ed25519 without alg",
-			keys: keys(key(edPub, "")),
-			want: algs(jose.EdDSA),
+			name:     "ed25519 without alg",
+			keys:     keys(key(edPub, "")),
+			wantAlgs: algs(jose.EdDSA),
+			wantKeys: keys(key(edPub, "")),
 		},
 		{
-			name: "duplicates are removed",
-			keys: keys(key(rsaPub, jose.RS256), key(rsaPub, jose.RS256)),
-			want: algs(jose.RS256),
+			name:     "duplicates are removed",
+			keys:     keys(key(rsaPub, jose.RS256), key(rsaPub, jose.RS256)),
+			wantAlgs: algs(jose.RS256),
+
+			// keys are not deduped, only algs
+			wantKeys: keys(key(rsaPub, jose.RS256), key(rsaPub, jose.RS256)),
 		},
 		{
 			name: "none is ignored",
 			keys: keys(
 				key([]byte{}, jose.SignatureAlgorithm("none")),
 			),
-			want: []jose.SignatureAlgorithm{},
+			wantAlgs: []jose.SignatureAlgorithm{},
 		},
 		{
-			name: "encryption-use key is skipped",
-			keys: keys(jose.JSONWebKey{Key: rsaPub, Use: "enc"}),
-			want: []jose.SignatureAlgorithm{},
+			name:     "encryption-use key is skipped",
+			keys:     keys(jose.JSONWebKey{Key: rsaPub, Use: "enc"}),
+			wantAlgs: []jose.SignatureAlgorithm{},
 		},
 		{
 			name: "empty",
@@ -1051,8 +1079,9 @@ func TestAllowedAlgorithmsFromJWKS(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := allowedAlgorithmsFromJWKS(jose.JSONWebKeySet{Keys: tt.keys})
-			require.ElementsMatch(t, tt.want, got)
+			algs, keys := filterAllowedAlgorithmsFromJWKS(jose.JSONWebKeySet{Keys: tt.keys})
+			require.ElementsMatch(t, tt.wantAlgs, algs)
+			require.ElementsMatch(t, tt.wantKeys, keys.Keys)
 		})
 	}
 }


### PR DESCRIPTION
This adds the library component of the generic_oidc join method, including the validator and token source. As the library is isolated and not (as of this PR) exercised by any codepaths within Teleport, it cannot be evaluated in situ without the depending PR noted below.

Despite what the diff may say, ~2/3rds of the PR is tests, so it's not _quite_ as scary as it looks.

## PR Stack

RFD: https://github.com/gravitational/rfd/pull/8

1. https://github.com/gravitational/teleport/pull/67991 (top of stack)
2. This PR (library)
3. https://github.com/gravitational/teleport/pull/67914
4. https://github.com/gravitational/teleport/pull/67913

#67991 is required to actually exercise any of this code. It's not called from Teleport as of this PR.

## Manual Test Plan

No test plan for this library PR. Nothing in Teleport calls anything added in this PR; see https://github.com/gravitational/teleport/pull/67991 which actually exercises it.