### PR TITLE
Add missing `type` modifier to `FilterMap` re-export

### DIFF
--- a/web/packages/shared/components/ListFilters/index.ts
+++ b/web/packages/shared/components/ListFilters/index.ts
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { FilterMap, ListFilters } from './ListFilters';
+import { type FilterMap, ListFilters } from './ListFilters';
 import { applyFilters } from './utilities';
 
 export { ListFilters, type FilterMap, applyFilters };


### PR DESCRIPTION
When testing https://github.com/gravitational/teleport/pull/67554 on v18, I noticed that I get the same warning for `FilterMap`, though just a single one whereas `ResourceIconName` reported multiple warnings.

The culprit was `web/packages/shared/components/ListFilters/index.ts` which imported `FilterMap` as a value but exported it as a type, which tripped up `@babel/plugin-transform-typescript`.

I looked into how we could make sure we don't reintroduce this problem and unfortunately the only way is to do it through [`typescript/consistent-type-imports`](https://oxc.rs/docs/guide/usage/linter/rules/typescript/consistent-type-imports.html). It currently flags 2.5k+ violations. While they can be trivially fixed with an autofix, at the moment just one violation of it poses a very minor problem. I don't want to enable what is ultimately a stylistic rule unless every person on the team has autofix enabled. Otherwise I don't want to bog people down with adding a commit with `pnpm lint-fix` because of a lint violation that's inconsequential in 95% of cases it reports.

We could scope the rule to just `index` files, but that's still 33 violations where only one of them is consequential in a minor way.

And personally I believe the problem should be solved on Babel/TypeScript/bundler level – the damn computer should know which value is a type and which one is not. Why would I need to explicitly mark that for it?


## Manual Test Plan
### Test Environment

My laptop.

### Test Cases
- [x] `pnpm test` doesn't return a warning about `FilterMap`.
