### PR TITLE
Azure Server Discovery: ignore non-linux VMs

### DIFF
--- a/lib/cloud/azure/vm.go
+++ b/lib/cloud/azure/vm.go
@@ -102,6 +102,13 @@ type VirtualMachine struct {
 	Identities []Identity
 	// Tags are the VM tags, e.g. {"env": "prod"}. Empty map (not nil) when the VM has no tags.
 	Tags map[string]string
+
+	operatingSystem *armcompute.OperatingSystemTypes
+}
+
+// IsLinuxOrUnknown returns whether the VM is running Linux or if the operating system is unknown.
+func (vm *VirtualMachine) IsLinuxOrUnknown() bool {
+	return vm.operatingSystem == nil || *vm.operatingSystem == armcompute.OperatingSystemTypesLinux
 }
 
 // Identity represents an Azure virtual machine identity.
@@ -610,8 +617,12 @@ func virtualMachineFromARMComputeVirtualMachine(vm *armcompute.VirtualMachine) (
 	}
 
 	var vmid string
+	var operatingSystem *armcompute.OperatingSystemTypes
 	if vm.Properties != nil {
 		vmid = StringVal(vm.Properties.VMID)
+		if vm.Properties.StorageProfile != nil && vm.Properties.StorageProfile.OSDisk != nil {
+			operatingSystem = vm.Properties.StorageProfile.OSDisk.OSType
+		}
 	}
 
 	// The ARM resource ID should never fail to parse, unless Azure changes the contract.
@@ -621,14 +632,15 @@ func virtualMachineFromARMComputeVirtualMachine(vm *armcompute.VirtualMachine) (
 	}
 
 	return &VirtualMachine{
-		ID:            StringVal(vm.ID),
-		VMID:          vmid,
-		Name:          StringVal(vm.Name),
-		Location:      StringVal(vm.Location),
-		Subscription:  resourceMetadata.SubscriptionID,
-		ResourceGroup: resourceMetadata.ResourceGroupName,
-		Identities:    parseVMIdentities(vm.Identity),
-		Tags:          ConvertTags(vm.Tags),
+		ID:              StringVal(vm.ID),
+		VMID:            vmid,
+		Name:            StringVal(vm.Name),
+		Location:        StringVal(vm.Location),
+		Subscription:    resourceMetadata.SubscriptionID,
+		ResourceGroup:   resourceMetadata.ResourceGroupName,
+		Identities:      parseVMIdentities(vm.Identity),
+		Tags:            ConvertTags(vm.Tags),
+		operatingSystem: operatingSystem,
 	}, nil
 }
 
@@ -638,8 +650,12 @@ func virtualMachineFromARMComputeVirtualMachineScaleSetVM(vm *armcompute.Virtual
 	}
 
 	var vmid string
+	var operatingSystem *armcompute.OperatingSystemTypes
 	if vm.Properties != nil {
 		vmid = StringVal(vm.Properties.VMID)
+		if vm.Properties.StorageProfile != nil && vm.Properties.StorageProfile.OSDisk != nil {
+			operatingSystem = vm.Properties.StorageProfile.OSDisk.OSType
+		}
 	}
 
 	return &VirtualMachine{
@@ -653,6 +669,7 @@ func virtualMachineFromARMComputeVirtualMachineScaleSetVM(vm *armcompute.Virtual
 		Tags:                        ConvertTags(vm.Tags),
 		UniformScaleSetName:         scaleSetName,
 		UniformScaleSetVMInstanceID: StringVal(vm.InstanceID),
+		operatingSystem:             operatingSystem,
 	}, nil
 }
 

--- a/lib/cloud/azure/vm_test.go
+++ b/lib/cloud/azure/vm_test.go
@@ -732,6 +732,7 @@ func TestVirtualMachineFromVirtualMachine(t *testing.T) {
 		subscriptionID  = "11111111-1111-1111-1111-111111111111"
 		resourceGroup   = "rg"
 	)
+	linuxOS := armcompute.OperatingSystemTypesLinux
 
 	for _, tc := range []struct {
 		desc        string
@@ -835,6 +836,46 @@ func TestVirtualMachineFromVirtualMachine(t *testing.T) {
 			assertError: require.Error,
 			assertVM:    require.Nil,
 		},
+		{
+			desc: "vm with operating system defined",
+			vm: &armcompute.VirtualMachine{
+				ID:       to.Ptr(validResourceID),
+				Name:     to.Ptr("vm-name"),
+				Location: to.Ptr("eastus"),
+				Properties: &armcompute.VirtualMachineProperties{
+					VMID: to.Ptr("22222222-2222-2222-2222-222222222222"),
+					StorageProfile: &armcompute.StorageProfile{
+						OSDisk: &armcompute.OSDisk{
+							OSType: &linuxOS,
+						},
+					},
+				},
+				Tags: map[string]*string{
+					"env":  to.Ptr("prod"),
+					"team": to.Ptr("infra"),
+				},
+			},
+			assertError: require.NoError,
+			assertVM: func(t require.TestingT, val any, _ ...any) {
+				require.NotNil(t, val)
+				vm, ok := val.(*VirtualMachine)
+				require.Truef(t, ok, "expected *VirtualMachine, got %T", val)
+				require.Equal(t, &VirtualMachine{
+					ID:            validResourceID,
+					VMID:          "22222222-2222-2222-2222-222222222222",
+					Name:          "vm-name",
+					Location:      "eastus",
+					Subscription:  subscriptionID,
+					ResourceGroup: resourceGroup,
+					Tags: map[string]string{
+						"env":  "prod",
+						"team": "infra",
+					},
+					operatingSystem: &linuxOS,
+				}, vm)
+				require.True(t, vm.IsLinuxOrUnknown(), "expected IsLinuxOrUnknown() to return true for Linux VM")
+			},
+		},
 	} {
 		t.Run(tc.desc, func(t *testing.T) {
 			vm, err := virtualMachineFromARMComputeVirtualMachine(tc.vm)
@@ -851,6 +892,7 @@ func TestVirtualMachineFromVirtualMachineScaleSetVM(t *testing.T) {
 		resourceGroup   = "rg"
 		scaleSetName    = "vmss"
 	)
+	linuxOS := armcompute.OperatingSystemTypesLinux
 
 	for _, tc := range []struct {
 		desc           string
@@ -970,11 +1012,100 @@ func TestVirtualMachineFromVirtualMachineScaleSetVM(t *testing.T) {
 			assertError:    require.Error,
 			assertVM:       require.Nil,
 		},
+		{
+			desc: "scale set vm with all fields populated",
+			vm: &armcompute.VirtualMachineScaleSetVM{
+				ID:         to.Ptr(validResourceID),
+				Name:       to.Ptr("vmss_0"),
+				Location:   to.Ptr("eastus"),
+				InstanceID: to.Ptr("0"),
+				Properties: &armcompute.VirtualMachineScaleSetVMProperties{
+					VMID: to.Ptr("22222222-2222-2222-2222-222222222222"),
+					StorageProfile: &armcompute.StorageProfile{
+						OSDisk: &armcompute.OSDisk{
+							OSType: &linuxOS,
+						},
+					},
+				},
+				Tags: map[string]*string{
+					"env":  to.Ptr("prod"),
+					"team": to.Ptr("infra"),
+				},
+			},
+			scaleSetName:   scaleSetName,
+			resourceGroup:  resourceGroup,
+			subscriptionID: subscriptionID,
+			assertError:    require.NoError,
+			assertVM: func(t require.TestingT, val any, _ ...any) {
+				require.NotNil(t, val)
+				vm, ok := val.(*VirtualMachine)
+				require.Truef(t, ok, "expected *VirtualMachine, got %T", val)
+				require.Equal(t, &VirtualMachine{
+					ID:                          validResourceID,
+					VMID:                        "22222222-2222-2222-2222-222222222222",
+					Name:                        "vmss_0",
+					Location:                    "eastus",
+					Subscription:                subscriptionID,
+					ResourceGroup:               resourceGroup,
+					UniformScaleSetName:         scaleSetName,
+					UniformScaleSetVMInstanceID: "0",
+					Tags: map[string]string{
+						"env":  "prod",
+						"team": "infra",
+					},
+					operatingSystem: &linuxOS,
+				}, vm)
+				require.True(t, vm.IsLinuxOrUnknown(), "expected IsLinuxOrUnknown() to return true for Linux VM")
+			},
+		},
 	} {
 		t.Run(tc.desc, func(t *testing.T) {
 			vm, err := virtualMachineFromARMComputeVirtualMachineScaleSetVM(tc.vm, tc.subscriptionID, tc.resourceGroup, tc.scaleSetName)
 			tc.assertError(t, err)
 			tc.assertVM(t, vm)
+		})
+	}
+}
+
+func TestVirtualMachineIsLinuxOrUnknown(t *testing.T) {
+	t.Parallel()
+	linuxOS := armcompute.OperatingSystemTypesLinux
+	windowsOS := armcompute.OperatingSystemTypesWindows
+
+	for _, tc := range []struct {
+		desc     string
+		vm       *VirtualMachine
+		want     bool
+		wantDesc string
+	}{
+		{
+			desc: "Linux VM",
+			vm: &VirtualMachine{
+				operatingSystem: &linuxOS,
+			},
+			want:     true,
+			wantDesc: "Linux",
+		},
+		{
+			desc: "Windows VM",
+			vm: &VirtualMachine{
+				operatingSystem: &windowsOS,
+			},
+			want:     false,
+			wantDesc: "Windows",
+		},
+		{
+			desc: "Unknown OSType",
+			vm: &VirtualMachine{
+				operatingSystem: nil,
+			},
+			want:     true,
+			wantDesc: "Unknown",
+		},
+	} {
+		t.Run(tc.desc, func(t *testing.T) {
+			got := tc.vm.IsLinuxOrUnknown()
+			require.Equal(t, tc.want, got, "expected IsLinuxOrUnknown() to return %v for %s VM, got %v", tc.want, tc.wantDesc, got)
 		})
 	}
 }

--- a/lib/srv/server/azure_watcher.go
+++ b/lib/srv/server/azure_watcher.go
@@ -309,10 +309,12 @@ func (f *azureInstanceFetcher) GetInstances(ctx context.Context, _ bool) ([]*Azu
 
 	allowAllLocations := slices.Contains(f.Regions, types.Wildcard)
 
+	nonLinuxVMIDs := make([]string, 0)
 	for _, vm := range vms {
 		// Teleport only supports Linux nodes, so we filter out non-Linux VMs.
 		// If the OS is unknown, we allow it because the OS type might not always be present in the API response.
 		if !vm.IsLinuxOrUnknown() {
+			nonLinuxVMIDs = append(nonLinuxVMIDs, vm.ID)
 			continue
 		}
 
@@ -329,6 +331,19 @@ func (f *azureInstanceFetcher) GetInstances(ctx context.Context, _ bool) ([]*Azu
 		}
 
 		instanceGroups[batchGroup] = append(instanceGroups[batchGroup], vm)
+	}
+	if len(nonLinuxVMIDs) > 0 {
+		// Show at most 10 non-Linux VM IDs in the log message to avoid spamming the logs.
+		sampleSize := min(len(nonLinuxVMIDs), 10)
+		nonLinuxVMIDsSample := make([]string, sampleSize)
+		copy(nonLinuxVMIDsSample, nonLinuxVMIDs[:sampleSize])
+
+		f.Logger.DebugContext(ctx, "Skipped non Linux VMs in Azure Server Discovery",
+			"fetcher", f,
+			"total_vms", len(vms),
+			"skipped_vms", len(nonLinuxVMIDs),
+			"skipped_vms_sample", nonLinuxVMIDsSample,
+		)
 	}
 
 	var instances []*AzureInstances

--- a/lib/srv/server/azure_watcher.go
+++ b/lib/srv/server/azure_watcher.go
@@ -310,6 +310,12 @@ func (f *azureInstanceFetcher) GetInstances(ctx context.Context, _ bool) ([]*Azu
 	allowAllLocations := slices.Contains(f.Regions, types.Wildcard)
 
 	for _, vm := range vms {
+		// Teleport only supports Linux nodes, so we filter out non-Linux VMs.
+		// If the OS is unknown, we allow it because the OS type might not always be present in the API response.
+		if !vm.IsLinuxOrUnknown() {
+			continue
+		}
+
 		if !slices.Contains(f.Regions, vm.Location) && !allowAllLocations {
 			continue
 		}

--- a/lib/srv/server/azure_watcher_test.go
+++ b/lib/srv/server/azure_watcher_test.go
@@ -98,6 +98,17 @@ func TestAzureWatcher(t *testing.T) {
 								ID:       to.Ptr(makeAzureVMID(sub1, "rg2", "vm6")),
 								Location: to.Ptr("location2"),
 							},
+							{
+								ID:       to.Ptr(makeAzureVMID(sub1, "rg2", "vm7")),
+								Location: to.Ptr("location2"),
+								Properties: &armcompute.VirtualMachineProperties{
+									StorageProfile: &armcompute.StorageProfile{
+										OSDisk: &armcompute.OSDisk{
+											OSType: to.Ptr(armcompute.OperatingSystemTypesWindows),
+										},
+									},
+								},
+							},
 						},
 					},
 				},
@@ -234,6 +245,16 @@ func TestAzureWatcher(t *testing.T) {
 				Subscriptions:  []string{"*"},
 			},
 			wantVMs: []string{"vm1", "vm2", "vm3", "vm4", "vm5", "vm6", "vm7", "vm8", "vm9", "vm10", "vm11", "vm12"},
+		},
+		{
+			name: "filter by operating system",
+			matcher: types.AzureMatcher{
+				ResourceGroups: []string{"rg1", "rg2"},
+				Regions:        []string{"location1", "location2"},
+				ResourceTags:   types.Labels{"teleport": []string{"yes"}},
+				Subscriptions:  []string{sub1},
+			},
+			wantVMs: []string{"vm2", "vm4"},
 		},
 	}
 


### PR DESCRIPTION
Azure Server Discovery only supports installing teleport into Linux VMs. Currently, when a Windows VM matches the criteria, the Discovery Service tries to install teleport into it.
This produces ugly errors because the script we run in the VM is interpreted by powershell and we get syntax errors all over.

This PR ensures that VMs that report their OS and their OS is not Linux, are discarded.

When a VM is skipped because of this, a debug log is emitted.

<!-- Provide a descriptive entry for the changelog of the next release. -->

Changelog: Fixed the Azure Server Discovery so that it ignores non-Linux VMs.


<!-- Include manual testing efforts to verify the change. -->
<!-- Detail where the tests where run and what configurations were used. -->
<!-- Include all the test cases which were run to validate the change. -->

## Manual Test Plan
### Test Environment

Local env

### Test Cases
- [x] Run the Discovery Service with a config that matches a Windows and a Linux VM


## Demo
```
2026-06-24T16:40:47.155+01:00 DEBU [DISCOVERY] Skipped non Linux VMs in Azure Server Discovery pid:38010.1 fetcher.labels:map[Discover:[Marco]] fetcher.regions:[*] fetcher.discovery_config:teleport-dev fetcher.integration: fetcher.resource_group:marco-discover fetcher.subscription_id:060a97ea-3a57-4218-9be5-dba3f19ff2b5 total_vms:2 skipped_vms:1 skipped_vms_sample:[/subscriptions/060a97ea-3a57-4218-9be5-dba3f19ff2b5/resourceGroups/marco-discover/providers/Microsoft.Compute/virtualMachines/MarcoWindowsBox] server/azure_watcher.go:344
```