### PR TITLE
web: Update IAM join token assumed-role arn placeholder

### DIFF
--- a/web/packages/teleport/src/JoinTokens/JoinTokenForms.tsx
+++ b/web/packages/teleport/src/JoinTokens/JoinTokenForms.tsx
@@ -111,7 +111,7 @@ export const JoinTokenIAMForm = ({
           <FieldInput
             label="ARN"
             toolTipContent={`The joining nodes must match this ARN. Supports wildcards "*" and "?"`}
-            placeholder="arn:aws:iam::account-id:role/*"
+            placeholder="arn:aws:sts::<account-id>:assumed-role/<role-name>/*"
             value={rule.aws_arn}
             onChange={e => setTokenRulesField(index, 'aws_arn', e.target.value)}
             readonly={readonly}


### PR DESCRIPTION
In IAM joining ARN matcher, we usually use STS's `assumed-role` ARN, rather than actual role arn:
- https://goteleport.com/docs/installation/agents/aws-iam/#step-23-create-the-aws-joining-token

As such, placeholder on the web-ui should reflect that.

