### PR TITLE
Azure Server Discovery: fix User Tasks classification

### DIFF
--- a/lib/cloud/azure/errors.go
+++ b/lib/cloud/azure/errors.go
@@ -22,6 +22,7 @@ import (
 	"encoding/json"
 	"errors"
 	"net/http"
+	"strings"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
@@ -40,11 +41,20 @@ func ConvertResponseError(err error) error {
 	var authenticationFailedErr *azidentity.AuthenticationFailedError
 	switch {
 	case errors.As(err, &responseErr):
+		apiResponseErr := apiErrorFromResponse(responseErr)
+
 		switch responseErr.StatusCode {
 		case http.StatusForbidden:
 			return trace.AccessDenied("%s", responseErr)
 		case http.StatusConflict:
-			return trace.AlreadyExists("%s", responseErr)
+			switch {
+			case isVMNotRunningError(apiResponseErr):
+				return NewVMNotRunningError(responseErr)
+			case isVMAgentNotAvailableError(apiResponseErr):
+				return NewVMAgentNotAvailableError(responseErr)
+			default:
+				return trace.AlreadyExists("%s", responseErr)
+			}
 		case http.StatusNotFound:
 			return trace.NotFound("%s", responseErr)
 		case http.StatusTooManyRequests:
@@ -53,7 +63,7 @@ func ConvertResponseError(err error) error {
 
 		case http.StatusBadRequest:
 			// Azure API return BadRequest in multiple scenarios, so we need to inspect the error details to ensure we return the most accurate error type.
-			if errorDetails := errorDetails(responseErr); errorDetails != nil {
+			if errorDetails := apiResponseErr.errorDetails(); errorDetails != nil {
 				switch errorDetails.Code {
 				case "SubscriptionsContainInvalidGuids":
 					return trace.BadParameter("%s", responseErr)
@@ -69,8 +79,7 @@ func ConvertResponseError(err error) error {
 	return err // Return unmodified.
 }
 
-// errorDetails does a best-effort attempt to extract error details, and may return nil if the detail cannot be extracted for any reason.
-func errorDetails(responseErr *azcore.ResponseError) *apiErrorDetail {
+func apiErrorFromResponse(responseErr *azcore.ResponseError) *apiResponseError {
 	if responseErr == nil || responseErr.RawResponse == nil {
 		return nil
 	}
@@ -82,15 +91,13 @@ func errorDetails(responseErr *azcore.ResponseError) *apiErrorDetail {
 		return nil
 	}
 
-	if len(apiErrResp.Error.Details) == 0 {
-		return nil
-	}
-
-	return &apiErrResp.Error.Details[0]
+	return &apiErrResp
 }
 
 type apiResponseError struct {
 	Error struct {
+		Code    string           `json:"code"`
+		Message string           `json:"message"`
 		Details []apiErrorDetail `json:"details"`
 	} `json:"error"`
 }
@@ -98,4 +105,95 @@ type apiResponseError struct {
 type apiErrorDetail struct {
 	Code    string `json:"code"`
 	Message string `json:"message"`
+}
+
+func (a *apiResponseError) errorDetails() *apiErrorDetail {
+	if a == nil || len(a.Error.Details) == 0 {
+		return nil
+	}
+
+	return &a.Error.Details[0]
+}
+
+func (a *apiResponseError) code() string {
+	if a == nil {
+		return ""
+	}
+
+	return a.Error.Code
+}
+func (a *apiResponseError) message() string {
+	if a == nil {
+		return ""
+	}
+
+	return a.Error.Message
+}
+
+const (
+	operationNotAllowedCode = "OperationNotAllowed"
+)
+
+func isVMNotRunningError(apiErr *apiResponseError) bool {
+	return apiErr.code() == operationNotAllowedCode && strings.Contains(apiErr.message(), "VM is not running")
+}
+
+// NewVMNotRunningError creates a new VMNotRunningError with the provided inner error.
+func NewVMNotRunningError(inner error) *VMNotRunningError {
+	return &VMNotRunningError{
+		inner: inner,
+	}
+}
+
+// VMNotRunningError is returned when an operation is attempted on a virtual machine that is not in a running state.
+type VMNotRunningError struct {
+	inner error
+}
+
+// Unwrap returns the underlying error that caused the VMNotRunningError.
+func (e *VMNotRunningError) Unwrap() error {
+	return e.inner
+}
+
+// Is checks if the target error is of type VMNotRunningError.
+func (e *VMNotRunningError) Is(target error) bool {
+	_, ok := target.(*VMNotRunningError)
+	return ok
+}
+
+// Error returns a message indicating that the virtual machine is not running.
+func (e *VMNotRunningError) Error() string {
+	return "VM is not running"
+}
+
+func isVMAgentNotAvailableError(apiErr *apiResponseError) bool {
+	return apiErr.code() == operationNotAllowedCode && strings.Contains(apiErr.message(), "extension operations are disallowed")
+}
+
+// NewVMAgentNotAvailableError creates a new VMAgentNotAvailableError with the provided inner error.
+func NewVMAgentNotAvailableError(inner error) *VMAgentNotAvailableError {
+	return &VMAgentNotAvailableError{
+		inner: inner,
+	}
+}
+
+// VMAgentNotAvailableError is returned when an operation is attempted on a virtual machine whose agent is not available.
+type VMAgentNotAvailableError struct {
+	inner error
+}
+
+// Unwrap returns the underlying error that caused the VMAgentNotAvailableError.
+func (e *VMAgentNotAvailableError) Unwrap() error {
+	return e.inner
+}
+
+// Is checks if the target error is of type VMAgentNotAvailableError.
+func (e *VMAgentNotAvailableError) Is(target error) bool {
+	_, ok := target.(*VMAgentNotAvailableError)
+	return ok
+}
+
+// Error returns a message indicating that the virtual machine's agent is not available.
+func (e *VMAgentNotAvailableError) Error() string {
+	return "VM agent is not available"
 }

--- a/lib/cloud/azure/errors_test.go
+++ b/lib/cloud/azure/errors_test.go
@@ -32,7 +32,7 @@ import (
 )
 
 // responseWithBody builds an *http.Response carrying the given JSON body so
-// ConvertResponseError's BadRequest branch can exercise errorDetails decoding.
+// ConvertResponseError can exercise response body decoding.
 func responseWithBody(status int, body string) *http.Response {
 	return &http.Response{
 		StatusCode: status,
@@ -186,6 +186,65 @@ func TestConvertResponseError(t *testing.T) {
 	}
 }
 
+func TestConvertResponseError_VMConflictErrors(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name  string
+		body  string
+		check require.ErrorAssertionFunc
+	}{
+		{
+			name: "OperationNotAllowed VM not running maps to VMNotRunningError",
+			body: `{"error":{"code":"OperationNotAllowed","message":"Cannot modify extensions in the VM when the VM is not running"}}`,
+			check: func(tt require.TestingT, err error, i ...any) {
+				require.Error(t, err)
+				require.ErrorIs(t, err, &VMNotRunningError{}, "got %T: %v", err, err)
+				require.NotErrorIs(t, err, &VMAgentNotAvailableError{}, "got %T: %v", err, err)
+			},
+		},
+		{
+			name: "OperationNotAllowed extension operations disallowed maps to VMAgentNotAvailableError",
+			body: `{"error":{"code":"OperationNotAllowed","message":"This operation cannot be performed when extension operations are disallowed. To allow, please ensure VM Agent is installed on the VM and the osProfile.allowExtensionOperations property is true."}}`,
+			check: func(tt require.TestingT, err error, i ...any) {
+				require.Error(t, err)
+				require.ErrorIs(t, err, &VMAgentNotAvailableError{}, "got %T: %v", err, err)
+				require.NotErrorIs(t, err, &VMNotRunningError{}, "got %T: %v", err, err)
+			},
+		},
+		{
+			name: "OperationNotAllowed without VM-specific message maps to AlreadyExists",
+			body: `{"error":{"code":"OperationNotAllowed","message":"some other operation is not allowed"}}`,
+			check: func(tt require.TestingT, err error, i ...any) {
+				require.True(t, trace.IsAlreadyExists(err), "got %T: %v", err, err)
+			},
+		},
+		{
+			name: "VM-specific message with wrong code maps to AlreadyExists",
+			body: `{"error":{"code":"SomeOtherCode","message":"Cannot modify extensions in the VM when the VM is not running"}}`,
+			check: func(tt require.TestingT, err error, i ...any) {
+				require.True(t, trace.IsAlreadyExists(err), "got %T: %v", err, err)
+			},
+		},
+		{
+			name: "invalid JSON maps to AlreadyExists",
+			body: `not-json`,
+			check: func(tt require.TestingT, err error, i ...any) {
+				require.True(t, trace.IsAlreadyExists(err), "got %T: %v", err, err)
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			responseWithBody := responseWithBody(http.StatusConflict, tc.body)
+			defer responseWithBody.Body.Close()
+			err := &azcore.ResponseError{
+				StatusCode:  http.StatusConflict,
+				RawResponse: responseWithBody,
+			}
+			tc.check(t, ConvertResponseError(err))
+		})
+	}
+}
+
 func TestConvertResponseError_WrappedErrors(t *testing.T) {
 	t.Parallel()
 
@@ -202,4 +261,34 @@ func TestConvertResponseError_WrappedErrors(t *testing.T) {
 		require.Error(t, got)
 		require.True(t, trace.IsAccessDenied(got), "got %T: %v", got, got)
 	})
+
+	t.Run("wrapped ResponseError still maps VM-specific 409 errors", func(t *testing.T) {
+		responseWithBody := responseWithBody(http.StatusConflict, `{"error":{"code":"OperationNotAllowed","message":"Cannot modify extensions in the VM when the VM is not running"}}`)
+		defer responseWithBody.Body.Close()
+		wrapped := trace.Wrap(&azcore.ResponseError{
+			StatusCode:  http.StatusConflict,
+			RawResponse: responseWithBody,
+		}, "while running command")
+		got := ConvertResponseError(wrapped)
+		require.Error(t, got)
+		require.ErrorIs(t, got, &VMNotRunningError{}, "got %T: %v", got, got)
+	})
+}
+
+func TestVMErrorTypes(t *testing.T) {
+	t.Parallel()
+
+	inner := errors.New("inner")
+
+	vmNotRunningErr := NewVMNotRunningError(inner)
+	require.Equal(t, "VM is not running", vmNotRunningErr.Error())
+	require.ErrorIs(t, vmNotRunningErr, inner)
+	require.ErrorIs(t, vmNotRunningErr, &VMNotRunningError{})
+	require.NotErrorIs(t, vmNotRunningErr, &VMAgentNotAvailableError{})
+
+	vmAgentNotAvailableErr := NewVMAgentNotAvailableError(inner)
+	require.Equal(t, "VM agent is not available", vmAgentNotAvailableErr.Error())
+	require.ErrorIs(t, vmAgentNotAvailableErr, inner)
+	require.ErrorIs(t, vmAgentNotAvailableErr, &VMAgentNotAvailableError{})
+	require.NotErrorIs(t, vmAgentNotAvailableErr, &VMNotRunningError{})
 }

--- a/lib/srv/discovery/azure_vm_error_parser.go
+++ b/lib/srv/discovery/azure_vm_error_parser.go
@@ -20,9 +20,10 @@ import (
 	"errors"
 	"strings"
 
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/gravitational/trace"
 
 	"github.com/gravitational/teleport/api/types/usertasks"
+	"github.com/gravitational/teleport/lib/cloud/azure"
 	"github.com/gravitational/teleport/lib/srv/server"
 )
 
@@ -43,26 +44,18 @@ func classifyAzureVMEnrollmentError(err error) string {
 	if err == nil {
 		return ""
 	}
+	switch {
+	case errors.Is(err, &azure.VMNotRunningError{}):
+		return usertasks.AutoDiscoverAzureVMIssueVMNotRunning
 
-	errMsg := err.Error()
+	case errors.Is(err, &azure.VMAgentNotAvailableError{}):
+		return usertasks.AutoDiscoverAzureVMIssueVMAgentNotAvailable
 
-	var respErr *azcore.ResponseError
-	if errors.As(err, &respErr) {
-		switch {
-		case respErr.StatusCode == 403 && respErr.ErrorCode == "AuthorizationFailed":
-			if strings.Contains(errMsg, "runCommands") {
-				return usertasks.AutoDiscoverAzureVMIssueMissingRunCommandsPermission
-			}
-		case respErr.StatusCode == 409 && respErr.ErrorCode == "OperationNotAllowed":
-			if strings.Contains(errMsg, "VM is not running") {
-				return usertasks.AutoDiscoverAzureVMIssueVMNotRunning
-			}
-			if strings.Contains(errMsg, "extension operations are disallowed") {
-				return usertasks.AutoDiscoverAzureVMIssueVMAgentNotAvailable
-			}
-		}
+	case trace.IsAccessDenied(err) && strings.Contains(err.Error(), "runCommands"):
+		return usertasks.AutoDiscoverAzureVMIssueMissingRunCommandsPermission
+
+	default:
+		// generic error
+		return usertasks.AutoDiscoverAzureVMIssueEnrollmentError
 	}
-
-	// generic error
-	return usertasks.AutoDiscoverAzureVMIssueEnrollmentError
 }

--- a/lib/srv/discovery/azure_vm_error_parser_test.go
+++ b/lib/srv/discovery/azure_vm_error_parser_test.go
@@ -18,6 +18,7 @@ package discovery
 
 import (
 	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"net/url"
@@ -25,19 +26,25 @@ import (
 	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
+	"github.com/gravitational/trace"
 	"github.com/stretchr/testify/require"
 
 	"github.com/gravitational/teleport/api/types/usertasks"
+	"github.com/gravitational/teleport/lib/cloud/azure"
 )
 
 func TestClassifyAzureVMEnrollmentError(t *testing.T) {
 	azureError := func(statusCode int, errorCode, errorMessage string) error {
 		resp := &http.Response{
 			StatusCode: statusCode,
-			Body:       io.NopCloser(strings.NewReader(errorMessage)),
-			Request:    &http.Request{Method: http.MethodPut, URL: &url.URL{}},
+			Body: io.NopCloser(strings.NewReader(fmt.Sprintf(
+				`{"error":{"code":%q,"message":%q}}`,
+				errorCode,
+				errorMessage,
+			))),
+			Request: &http.Request{Method: http.MethodPut, URL: &url.URL{}},
 		}
-		return runtime.NewResponseErrorWithErrorCode(resp, errorCode)
+		return trace.Wrap(azure.ConvertResponseError(runtime.NewResponseErrorWithErrorCode(resp, errorCode)))
 	}
 
 	tests := []struct {

--- a/lib/srv/discovery/discovery_test.go
+++ b/lib/srv/discovery/discovery_test.go
@@ -25,7 +25,6 @@ import (
 	"fmt"
 	"io"
 	"maps"
-	"net/http"
 	"net/url"
 	"os"
 	"regexp"
@@ -39,7 +38,6 @@ import (
 
 	"cloud.google.com/go/container/apiv1/containerpb"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
-	azruntime "github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v6"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/redis/armredis/v3"
@@ -3293,16 +3291,7 @@ func (m *mockAzureRunCommandClient) Run(_ context.Context, req azure.RunCommandR
 	m.attemptedVMs[req.VMName] = m.attemptedVMs[req.VMName] + 1
 
 	if strings.HasPrefix(req.VMName, azureApiErrorPrefix) {
-		const statusCode = 403
-		const errorCode = "AuthorizationFailed"
-		const message = "does not have authorization to perform action 'Microsoft.Compute/virtualMachines/runCommands/write'"
-
-		resp := &http.Response{
-			StatusCode: statusCode,
-			Body:       io.NopCloser(strings.NewReader(message)),
-			Request:    &http.Request{Method: http.MethodPut, URL: &url.URL{}},
-		}
-		return nil, azruntime.NewResponseErrorWithErrorCode(resp, errorCode)
+		return nil, trace.AccessDenied("does not have authorization to perform action 'Microsoft.Compute/virtualMachines/runCommands/write'")
 	}
 
 	if strings.HasPrefix(req.VMName, azureInstallErrorPrefix) {


### PR DESCRIPTION
We were always creating generic failure errors (ie, enrollment-error).

Now, we correctly identify the error and map to a proper issue type.



<!-- Provide a descriptive entry for the changelog of the next release. -->

Changelog: Fixed User Task issue identification when handling Azure Server Discovery failures.


<!-- Include manual testing efforts to verify the change. -->
<!-- Detail where the tests where run and what configurations were used. -->
<!-- Include all the test cases which were run to validate the change. -->

## Manual Test Plan
### Test Environment

Local env

### Test Cases
- [x] Try to enroll a non-running VM

Output from `tctl get user_task` after trying to enroll a non-running VM
Before:
```yaml
kind: user_task
metadata:
  expires: "2026-06-24T17:26:14.067020Z"
  name: 79682f90-3221-5b6e-b1e0-604eac80f9f1
  revision: 7e498f8b-d3ff-44d7-b544-4fc399893b8b
spec:
  discover_azure_vm:
    instances:
      123:
        discovery_config: teleport-dev
        discovery_group: aws-prod
        name: MarcoLinuxBox
        resource_id: /subscriptions/456/resourceGroups/marco-discover/providers/Microsoft.Compute/virtualMachines/MarcoLinuxBox
        sync_time: "2026-06-24T17:16:14.060185Z"
        vm_id: 123
    region: westeurope
    resource_group: marco-discover
    subscription_id: 456
  integration: static
  issue_type: azure-vm-enrollment-error
  state: OPEN
  task_type: discover-azure-vm
status:
  last_state_change: "2026-06-24T17:15:54.704507Z"
version: v1
```

After:
```yaml
kind: user_task
metadata:
  expires: "2026-06-24T17:34:30.598013Z"
  name: fb468be6-537f-54e2-8e26-2ce63cd04bef
  revision: 7efa855f-3bd5-4fcb-bffa-4c22d7558ae1
spec:
  discover_azure_vm:
    instances:
      123:
        discovery_config: teleport-dev
        discovery_group: aws-prod
        name: MarcoLinuxBox
        resource_id: /subscriptions/456/resourceGroups/marco-discover/providers/Microsoft.Compute/virtualMachines/MarcoLinuxBox
        sync_time: "2026-06-24T17:24:30.591094Z"
        vm_id: 123
    region: westeurope
    resource_group: marco-discover
    subscription_id: 456
  integration: static
  issue_type: azure-vm-not-running
  state: OPEN
  task_type: discover-azure-vm
status:
  last_state_change: "2026-06-24T17:24:30.600552Z"
version: v1
```

(check the `spec.issue_type` value)
