### PR TITLE
[scopes] backend support for members of scoped access lists

### DIFF
--- a/lib/accesslists/collection.go
+++ b/lib/accesslists/collection.go
@@ -51,11 +51,17 @@ func (b *Collection) Validate(ctx context.Context) error {
 		if err := accessList.CheckAndSetDefaults(); err != nil {
 			return trace.Wrap(err)
 		}
+		if accessList.Scope != "" {
+			return trace.BadParameter("collections do not support scoped access lists")
+		}
 	}
 	for _, members := range b.MembersByAccessList {
 		for _, member := range members {
 			if err := member.CheckAndSetDefaults(); err != nil {
 				return trace.Wrap(err)
+			}
+			if member.Scope != "" {
+				return trace.BadParameter("collections do not support scoped access list members")
 			}
 		}
 	}
@@ -158,6 +164,15 @@ func (b *Collection) ListAccessListMembers(ctx context.Context, accessListName s
 	return pageMembers, nextToken, nil
 }
 
+// ListAccessListMembersV2 retrieves members for an access list from the batch.
+func (b *Collection) ListAccessListMembersV2(ctx context.Context, req *accesslistv1.ListAccessListMembersRequest) ([]*accesslist.AccessListMember, string, error) {
+	// TODO(nklaassen): support collections of scoped access lists.
+	if req.GetAccessListScope() != "" {
+		return nil, "", trace.BadParameter("collection does not support scoped access lists")
+	}
+	return b.ListAccessListMembers(ctx, req.GetAccessList(), int(req.GetPageSize()), req.GetPageToken())
+}
+
 // GetAccessListMember retrieves a specific member from an access list in the batch.
 // Implements accesslists.AccessListAndMembersGetter interface.
 func (b *Collection) GetAccessListMember(ctx context.Context, accessListName, memberName string) (*accesslist.AccessListMember, error) {
@@ -171,6 +186,15 @@ func (b *Collection) GetAccessListMember(ctx context.Context, accessListName, me
 		}
 	}
 	return nil, trace.NotFound("member %q not found in access list %q", memberName, accessListName)
+}
+
+// GetAccessListMemberV2 retrieves a specific member from an access list in the batch.
+func (b *Collection) GetAccessListMemberV2(ctx context.Context, req *accesslistv1.GetAccessListMemberRequest) (*accesslist.AccessListMember, error) {
+	// TODO(nklaassen): support collections of scoped access lists.
+	if req.GetAccessListScope() != "" || req.GetMemberScope() != "" {
+		return nil, trace.BadParameter("collection does not support scoped access lists")
+	}
+	return b.GetAccessListMember(ctx, req.GetAccessList(), req.GetMemberName())
 }
 
 // RefUpdates calculates and applies reference updates (Status.MemberOf and Status.OwnerOf)

--- a/lib/accesslists/hierarchy.go
+++ b/lib/accesslists/hierarchy.go
@@ -55,6 +55,36 @@ type AccessListMembersLister interface {
 }
 
 // TODO(nklaassen): delete this when everything used as an
+// [AccessListAndMembersGetter] implements ListAccessListMembersV2.
+func listAccessListMembers(ctx context.Context, g AccessListMembersLister, req *accesslistv1.ListAccessListMembersRequest) (members []*accesslist.AccessListMember, nextToken string, err error) {
+	type accessListMembersListerV2 interface {
+		ListAccessListMembersV2(ctx context.Context, req *accesslistv1.ListAccessListMembersRequest) (members []*accesslist.AccessListMember, nextToken string, err error)
+	}
+	if g, ok := g.(accessListMembersListerV2); ok {
+		return g.ListAccessListMembersV2(ctx, req)
+	}
+	if req.GetAccessListScope() != "" {
+		return nil, "", trace.BadParameter("can't list members of scoped access list when g does not implement ListAccessListMembersV2")
+	}
+	return g.ListAccessListMembers(ctx, req.GetAccessList(), int(req.GetPageSize()), req.GetPageToken())
+}
+
+// TODO(nklaassen): delete this when everything used as an
+// [AccessListAndMembersGetter] implements GetAccessListMemberV2.
+func getAccessListMember(ctx context.Context, g AccessListAndMembersGetter, req *accesslistv1.GetAccessListMemberRequest) (*accesslist.AccessListMember, error) {
+	type accessListMemberGetterV2 interface {
+		GetAccessListMemberV2(ctx context.Context, req *accesslistv1.GetAccessListMemberRequest) (*accesslist.AccessListMember, error)
+	}
+	if g, ok := g.(accessListMemberGetterV2); ok {
+		return g.GetAccessListMemberV2(ctx, req)
+	}
+	if req.GetAccessListScope() != "" || req.GetMemberScope() != "" {
+		return nil, trace.BadParameter("cannot get scoped access list members when g does not implement GetAccessListMemberV2")
+	}
+	return g.GetAccessListMember(ctx, req.GetAccessList(), req.GetMemberName())
+}
+
+// TODO(nklaassen): delete this when everything used as an
 // [AccessListAndMembersGetter] implements GetAccessListV2.
 func getAccessList(ctx context.Context, g AccessListAndMembersGetter, accessListName NormalizedSQN) (*accesslist.AccessList, error) {
 	type accessListGetterV2 interface {
@@ -85,28 +115,39 @@ type lockGetter interface {
 // Returned Members are not validated for expiration or other requirements – use IsAccessListMember
 // to validate a Member's membership status.
 func GetMembersFor(ctx context.Context, accessListName string, g AccessListMembersLister) ([]*accesslist.AccessListMember, error) {
-	return getMembersFor(ctx, accessListName, g, make(map[string]struct{}))
+	return getMembersFor(ctx, NormalizedSQN{Name: accessListName}, g, make(map[NormalizedSQN]struct{}))
 }
 
-func getMembersFor(ctx context.Context, accessListName string, g AccessListMembersLister, visited map[string]struct{}) ([]*accesslist.AccessListMember, error) {
+// GetMembersForV2 returns a flattened list of Members for an Access List, including inherited Members.
+//
+// Returned Members are not validated for expiration or other requirements – use IsAccessListMember
+// to validate a Member's membership status.
+func GetMembersForV2(ctx context.Context, accessListName NormalizedSQN, g AccessListMembersLister) ([]*accesslist.AccessListMember, error) {
+	return getMembersFor(ctx, accessListName, g, make(map[NormalizedSQN]struct{}))
+}
+
+func getMembersFor(ctx context.Context, accessListName NormalizedSQN, g AccessListMembersLister, visited map[NormalizedSQN]struct{}) ([]*accesslist.AccessListMember, error) {
 	if _, ok := visited[accessListName]; ok {
 		return nil, nil
 	}
 	visited[accessListName] = struct{}{}
 
-	// TODO(nklaassen): support scoped access list members
-	members, err := fetchMembers(ctx, NormalizedSQN{Name: accessListName}, g)
+	members, err := fetchMembers(ctx, accessListName, g)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
 	var allMembers []*accesslist.AccessListMember
 	for _, member := range members {
-		if member.Spec.MembershipKind != accesslist.MembershipKindList {
+		if !member.IsList() {
 			allMembers = append(allMembers, member)
 			continue
 		}
-		childMembers, err := getMembersFor(ctx, member.GetName(), g, visited)
+		memberName, err := MemberScopeQualifiedName(member)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		childMembers, err := getMembersFor(ctx, memberName, g, visited)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
@@ -118,15 +159,13 @@ func getMembersFor(ctx context.Context, accessListName string, g AccessListMembe
 
 // fetchMembers is a simple helper to fetch all top-level AccessListMembers for an AccessList.
 func fetchMembers(ctx context.Context, accessListName NormalizedSQN, g AccessListMembersLister) ([]*accesslist.AccessListMember, error) {
-	if accessListName.Scope != "" {
-		// Scoped access lists currently cannot have any members
-		// TODO(nklaassen): support scoped access list members.
-		return nil, nil
-	}
 	var allMembers []*accesslist.AccessListMember
-	pageToken := ""
+	req := accesslistv1.ListAccessListMembersRequest_builder{
+		AccessListScope: accessListName.Scope,
+		AccessList:      accessListName.Name,
+	}.Build()
 	for {
-		page, nextToken, err := g.ListAccessListMembers(ctx, accessListName.Name, 0, pageToken)
+		page, nextToken, err := listAccessListMembers(ctx, g, req)
 		if err != nil {
 			// If the AccessList doesn't exist yet, should return an empty list of members
 			if trace.IsNotFound(err) {
@@ -138,7 +177,7 @@ func fetchMembers(ctx context.Context, accessListName NormalizedSQN, g AccessLis
 		if nextToken == "" {
 			break
 		}
-		pageToken = nextToken
+		req.SetPageToken(nextToken)
 	}
 	return allMembers, nil
 }
@@ -187,18 +226,13 @@ func collectOwners(
 
 // collectMembersAsOwners is a helper to collect all nested members of an AccessList and return them cast as Owners.
 func collectMembersAsOwners(ctx context.Context, accessListName NormalizedSQN, g AccessListMembersLister, visited map[NormalizedSQN]struct{}) ([]*accesslist.Owner, error) {
-	// TODO(nklaassen): support scoped access list members.
-	if accessListName.Scope != "" {
-		return nil, nil
-	}
-
 	owners := make([]*accesslist.Owner, 0)
 	if _, ok := visited[accessListName]; ok {
 		return owners, nil
 	}
 	visited[accessListName] = struct{}{}
 
-	listMembers, err := GetMembersFor(ctx, accessListName.Name, g)
+	listMembers, err := GetMembersForV2(ctx, accessListName, g)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -639,7 +673,11 @@ func (s *Hierarchy) GetHierarchyForUser(ctx context.Context, accessList *accessl
 }
 
 func (s *Hierarchy) validMembership(ctx context.Context, list *accesslist.AccessList, user types.User) (bool, error) {
-	m, err := s.AccessListsService.GetAccessListMember(ctx, list.GetName(), user.GetName())
+	m, err := getAccessListMember(ctx, s.AccessListsService, accesslistv1.GetAccessListMemberRequest_builder{
+		AccessListScope: list.GetScope(),
+		AccessList:      list.GetName(),
+		MemberName:      user.GetName(),
+	}.Build())
 	if err != nil {
 		if trace.IsNotFound(err) {
 			return false, nil
@@ -764,14 +802,15 @@ func collectAncestors(
 	visited[ScopeQualifiedName(accessList)] = struct{}{}
 
 	isDirectMembershipExpired := func(acl, member NormalizedSQN) (bool, error) {
-		// TODO(nklaassen): support scoped access list members.
-		if acl.Scope != "" || member.Scope != "" {
-			return false, trace.BadParameter("scoped access list members are not yet supported")
-		}
 		if !options.validateUserRequirement {
 			return false, nil
 		}
-		m, err := g.GetAccessListMember(ctx, acl.Name, member.Name)
+		m, err := getAccessListMember(ctx, g, accesslistv1.GetAccessListMemberRequest_builder{
+			AccessListScope: acl.Scope,
+			AccessList:      acl.Name,
+			MemberScope:     member.Scope,
+			MemberName:      member.Name,
+		}.Build())
 		if err != nil {
 			return false, trace.Wrap(err)
 		}

--- a/lib/accesslists/hierarchy_test.go
+++ b/lib/accesslists/hierarchy_test.go
@@ -48,17 +48,35 @@ type mockAccessListAndMembersGetter struct {
 }
 
 func (m *mockAccessListAndMembersGetter) GetAccessListMember(ctx context.Context, accessListName, memberName string) (*accesslist.AccessListMember, error) {
-	// TODO(nklaassen): support scoped access list members.
-	member, exists := m.members[NormalizedSQN{Name: accessListName}]
+	return m.GetAccessListMemberV2(ctx, accesslistv1.GetAccessListMemberRequest_builder{
+		AccessList: accessListName,
+		MemberName: memberName,
+	}.Build())
+}
+
+func (m *mockAccessListAndMembersGetter) GetAccessListMemberV2(ctx context.Context, req *accesslistv1.GetAccessListMemberRequest) (*accesslist.AccessListMember, error) {
+	accessListName := NormalizeSQN(scopes.QualifiedName{
+		Scope: req.GetAccessListScope(),
+		Name:  req.GetAccessList(),
+	})
+	memberName := NormalizedSQN(scopes.QualifiedName{
+		Scope: req.GetMemberScope(),
+		Name:  req.GetMemberName(),
+	})
+	members, exists := m.members[accessListName]
 	if !exists {
-		return nil, trace.NotFound("access list %v member %v not found", accessListName, memberName)
+		return nil, trace.NotFound("access list %s member %s not found", accessListName.String(), memberName.String())
 	}
-	for _, m := range member {
-		if m.GetName() == memberName {
+	for _, m := range members {
+		memberSQN, err := MemberScopeQualifiedName(m)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		if memberSQN == memberName {
 			return m, nil
 		}
 	}
-	return nil, trace.NotFound("access list %v member %v not found", accessListName, memberName)
+	return nil, trace.NotFound("access list %s member %s not found", accessListName.String(), memberName.String())
 }
 
 func (m *mockAccessListAndMembersGetter) GetAccessList(ctx context.Context, accessListName string) (*accesslist.AccessList, error) {
@@ -80,8 +98,19 @@ func (m *mockAccessListAndMembersGetter) GetAccessListV2(ctx context.Context, re
 }
 
 func (m *mockAccessListAndMembersGetter) ListAccessListMembers(ctx context.Context, accessListName string, pageSize int, pageToken string) ([]*accesslist.AccessListMember, string, error) {
-	// TODO(nklaassen): support scoped access list members.
-	members, exists := m.members[NormalizedSQN{Name: accessListName}]
+	return m.ListAccessListMembersV2(ctx, accesslistv1.ListAccessListMembersRequest_builder{
+		AccessList: accessListName,
+		PageSize:   int32(pageSize),
+		PageToken:  pageToken,
+	}.Build())
+}
+
+func (m *mockAccessListAndMembersGetter) ListAccessListMembersV2(ctx context.Context, req *accesslistv1.ListAccessListMembersRequest) ([]*accesslist.AccessListMember, string, error) {
+	accessListName := NormalizeSQN(scopes.QualifiedName{
+		Scope: req.GetAccessListScope(),
+		Name:  req.GetAccessList(),
+	})
+	members, exists := m.members[accessListName]
 	if !exists {
 		return nil, "", nil
 	}
@@ -96,10 +125,11 @@ func mockAccessLists(accessLists ...*accesslist.AccessList) map[NormalizedSQN]*a
 	return out
 }
 
-func mockAccessListMembers(members ...*accesslist.AccessListMember) map[NormalizedSQN][]*accesslist.AccessListMember {
+func mockAccessListMembers(t testing.TB, members ...*accesslist.AccessListMember) map[NormalizedSQN][]*accesslist.AccessListMember {
 	out := make(map[NormalizedSQN][]*accesslist.AccessListMember)
 	for _, member := range members {
-		listName := NormalizedSQN{Name: member.Spec.AccessList}
+		listName, err := ParentListOf(member)
+		require.NoError(t, err)
 		out[listName] = append(out[listName], member)
 	}
 	return out
@@ -199,7 +229,7 @@ func TestAccessListHierarchyIsOwner(t *testing.T) {
 	acl1.Status.OwnerOf = append(acl1.Status.OwnerOf, acl4.GetName())
 
 	accessListAndMembersGetter := &mockAccessListAndMembersGetter{
-		members:     mockAccessListMembers(acl1m1, acl1m2, acl2m1, acl4m1),
+		members:     mockAccessListMembers(t, acl1m1, acl1m2, acl2m1, acl4m1),
 		accessLists: mockAccessLists(acl1, acl2, acl3, acl4),
 	}
 
@@ -271,7 +301,7 @@ func TestIsAccessListOwnerScopedNameCollision(t *testing.T) {
 
 	unscopedOwnerMember := newAccessListMember(t, unscopedOwnerList.GetName(), member1, accesslist.MembershipKindUser, clock)
 	accessListAndMembersGetter := &mockAccessListAndMembersGetter{
-		members:     mockAccessListMembers(unscopedOwnerMember),
+		members:     mockAccessListMembers(t, unscopedOwnerMember),
 		accessLists: mockAccessLists(unscopedOwnerList, scopedOwnerList, targetList),
 	}
 
@@ -303,6 +333,163 @@ func TestIsAccessListOwnerScopedNameCollision(t *testing.T) {
 	require.Equal(t, accesslistv1.AccessListUserAssignmentType_ACCESS_LIST_USER_ASSIGNMENT_TYPE_INHERITED, assignmentType)
 }
 
+// TestMembershipScopedNameCollision asserts that GetHierarchyForUser and
+// IsAccessListMember keep direct memberships separate for scoped and unscoped
+// access lists with the same unqualified name.
+func TestMembershipScopedNameCollision(t *testing.T) {
+	clock := clockwork.NewFakeClock()
+	ctx := context.Background()
+
+	unscopedList := newAccessList(t, "team", clock)
+	scopedList := newAccessList(t, "team", clock)
+	scopedList.Scope = "/eng"
+	parentList := newAccessList(t, "parent", clock)
+	parentList.Scope = "/eng/test"
+
+	scopedListName := ScopeQualifiedName(scopedList)
+	parentListName := ScopeQualifiedName(parentList)
+
+	unscopedList.Status.ScopedMemberOf = []string{parentListName.String()}
+	scopedList.Status.ScopedMemberOf = []string{parentListName.String()}
+
+	unscopedUserMember := newAccessListMember(t, unscopedList.GetName(), member1, accesslist.MembershipKindUser, clock)
+	scopedUserMember, err := accesslist.NewAccessListMemberWithScope(
+		header.Metadata{Name: member2},
+		accesslist.AccessListMemberSpec{
+			AccessList:     scopedListName.String(),
+			Name:           member2,
+			Joined:         clock.Now().UTC(),
+			Expires:        clock.Now().UTC().Add(24 * time.Hour),
+			Reason:         "because",
+			AddedBy:        "tester",
+			MembershipKind: accesslist.MembershipKindUser,
+		},
+		scopedList.GetScope(),
+	)
+	require.NoError(t, err)
+	unscopedListMember, err := accesslist.NewAccessListMemberWithScope(
+		header.Metadata{Name: unscopedList.GetName()},
+		accesslist.AccessListMemberSpec{
+			AccessList:     parentListName.String(),
+			Name:           unscopedList.GetName(),
+			Joined:         clock.Now().UTC(),
+			Expires:        clock.Now().UTC().Add(24 * time.Hour),
+			Reason:         "because",
+			AddedBy:        "tester",
+			MembershipKind: accesslist.MembershipKindList,
+		},
+		parentList.GetScope(),
+	)
+	require.NoError(t, err)
+	scopedListMember, err := accesslist.NewAccessListMemberWithScope(
+		header.Metadata{Name: scopedListName.String()},
+		accesslist.AccessListMemberSpec{
+			AccessList:     parentListName.String(),
+			Name:           scopedListName.String(),
+			Joined:         clock.Now().UTC(),
+			Expires:        clock.Now().UTC().Add(24 * time.Hour),
+			Reason:         "because",
+			AddedBy:        "tester",
+			MembershipKind: accesslist.MembershipKindScopedList,
+		},
+		parentList.GetScope(),
+	)
+	require.NoError(t, err)
+
+	accessListAndMembersGetter := &mockAccessListAndMembersGetter{
+		members:     mockAccessListMembers(t, unscopedUserMember, scopedUserMember, unscopedListMember, scopedListMember),
+		accessLists: mockAccessLists(unscopedList, scopedList, parentList),
+	}
+
+	unscopedUser, err := types.NewUser(member1)
+	require.NoError(t, err)
+	unscopedUser.SetTraits(map[string][]string{
+		"mtrait1": {"mvalue1", "mvalue2"},
+		"mtrait2": {"mvalue3", "mvalue4"},
+	})
+	unscopedUser.SetRoles([]string{"mrole1", "mrole2"})
+
+	scopedUser, err := types.NewUser(member2)
+	require.NoError(t, err)
+	scopedUser.SetTraits(map[string][]string{
+		"mtrait1": {"mvalue1", "mvalue2"},
+		"mtrait2": {"mvalue3", "mvalue4"},
+	})
+	scopedUser.SetRoles([]string{"mrole1", "mrole2"})
+
+	locksGetter := &mockLocksGetter{
+		targets: map[string][]types.Lock{},
+	}
+
+	t.Run("GetHierarchyForUser", func(t *testing.T) {
+		hierarchy, err := NewHierarchy(HierarchyConfig{
+			AccessListsService: accessListAndMembersGetter,
+			Clock:              clock,
+		})
+		require.NoError(t, err)
+
+		// GetHierarchyForUser must not consider a user to be a member of the scoped
+		// access list if they are actually a member of the unscoped access list with
+		// the same unqualified name.
+		memberOf, ownerOf, err := hierarchy.GetHierarchyForUser(ctx, scopedList, unscopedUser)
+		require.NoError(t, err)
+		require.Empty(t, memberOf)
+		require.Empty(t, ownerOf)
+
+		// Sanity check the user is legitimately a member of the unscoped access list.
+		memberOf, ownerOf, err = hierarchy.GetHierarchyForUser(ctx, unscopedList, unscopedUser)
+		require.NoError(t, err, trace.DebugReport(err))
+		require.Equal(t, []*accesslist.AccessList{unscopedList, parentList}, memberOf)
+		require.Empty(t, ownerOf)
+
+		// GetHierarchyForUser must not consider a user to be a member of the unscoped
+		// access list if they are actually a member of the scoped access list with
+		// the same unqualified name.
+		memberOf, ownerOf, err = hierarchy.GetHierarchyForUser(ctx, unscopedList, scopedUser)
+		require.NoError(t, err)
+		require.Empty(t, memberOf)
+		require.Empty(t, ownerOf)
+
+		// Sanity check the user is legitimately a member of the scoped access list.
+		memberOf, ownerOf, err = hierarchy.GetHierarchyForUser(ctx, scopedList, scopedUser)
+		require.NoError(t, err)
+		require.Equal(t, []*accesslist.AccessList{scopedList, parentList}, memberOf)
+		require.Empty(t, ownerOf)
+	})
+
+	t.Run("IsAccessListMember", func(t *testing.T) {
+		// IsAccessListMember must not consider a user to be a member of the scoped
+		// access list if they are actually a member of the unscoped access list with
+		// the same unqualified name.
+		_, err := IsAccessListMember(ctx, unscopedUser, scopedList, accessListAndMembersGetter, locksGetter, clock)
+		require.ErrorAs(t, err, new(*trace.AccessDeniedError))
+
+		// Sanity check the user is legitimately a member of the unscoped access list.
+		assignmentType, err := IsAccessListMember(ctx, unscopedUser, unscopedList, accessListAndMembersGetter, locksGetter, clock)
+		require.NoError(t, err)
+		require.Equal(t, accesslistv1.AccessListUserAssignmentType_ACCESS_LIST_USER_ASSIGNMENT_TYPE_EXPLICIT, assignmentType)
+
+		// GetHierarchyForUser must not consider a user to be a member of the unscoped
+		// access list if they are actually a member of the scoped access list with
+		// the same unqualified name.
+		_, err = IsAccessListMember(ctx, scopedUser, unscopedList, accessListAndMembersGetter, locksGetter, clock)
+		require.ErrorAs(t, err, new(*trace.AccessDeniedError))
+
+		// Sanity check the user is legitimately a member of the scoped access list.
+		assignmentType, err = IsAccessListMember(ctx, scopedUser, scopedList, accessListAndMembersGetter, locksGetter, clock)
+		require.NoError(t, err)
+		require.Equal(t, accesslistv1.AccessListUserAssignmentType_ACCESS_LIST_USER_ASSIGNMENT_TYPE_EXPLICIT, assignmentType)
+
+		// IsAccessListMember should consider both users to be an inherited member of the common parent list.
+		assignmentType, err = IsAccessListMember(ctx, unscopedUser, parentList, accessListAndMembersGetter, locksGetter, clock)
+		require.NoError(t, err)
+		require.Equal(t, accesslistv1.AccessListUserAssignmentType_ACCESS_LIST_USER_ASSIGNMENT_TYPE_INHERITED, assignmentType)
+		assignmentType, err = IsAccessListMember(ctx, scopedUser, parentList, accessListAndMembersGetter, locksGetter, clock)
+		require.NoError(t, err)
+		require.Equal(t, accesslistv1.AccessListUserAssignmentType_ACCESS_LIST_USER_ASSIGNMENT_TYPE_INHERITED, assignmentType)
+	})
+}
+
 func TestAccessListIsMember(t *testing.T) {
 	clock := clockwork.NewFakeClock()
 	ctx := context.Background()
@@ -314,7 +501,7 @@ func TestAccessListIsMember(t *testing.T) {
 		targets: map[string][]types.Lock{},
 	}
 	accessListAndMembersGetter := &mockAccessListAndMembersGetter{
-		members:     mockAccessListMembers(acl1m1),
+		members:     mockAccessListMembers(t, acl1m1),
 		accessLists: mockAccessLists(acl1),
 	}
 
@@ -354,7 +541,7 @@ func TestAccessListIsMember_RequirementsAndExpiry(t *testing.T) {
 	member := newAccessListMember(t, "acl", "u", accesslist.MembershipKindUser, clock)
 	aclGetter := &mockAccessListAndMembersGetter{
 		accessLists: mockAccessLists(acl),
-		members:     mockAccessListMembers(member),
+		members:     mockAccessListMembers(t, member),
 	}
 
 	u, _ := types.NewUser("u")
@@ -412,7 +599,7 @@ func TestAccessListIsMember_NestedRequirements(t *testing.T) {
 
 		aclGetter := &mockAccessListAndMembersGetter{
 			accessLists: mockAccessLists(rootList, middleList, leafList),
-			members:     mockAccessListMembers(middleInRoot, leafInMiddle, userMember),
+			members:     mockAccessListMembers(t, middleInRoot, leafInMiddle, userMember),
 		}
 
 		user, err := types.NewUser(userName)
@@ -463,7 +650,7 @@ func TestAccessListIsMember_NestedRequirements(t *testing.T) {
 
 		aclGetter := &mockAccessListAndMembersGetter{
 			accessLists: mockAccessLists(rootList, middleList, leafList),
-			members:     mockAccessListMembers(middleInRoot, leafInMiddle, userMember),
+			members:     mockAccessListMembers(t, middleInRoot, leafInMiddle, userMember),
 		}
 
 		user, err := types.NewUser(userName)
@@ -495,7 +682,7 @@ func TestAccessListIsMember_NestedRequirements(t *testing.T) {
 
 		aclGetter := &mockAccessListAndMembersGetter{
 			accessLists: mockAccessLists(firstList, secondList, thirdList),
-			members:     mockAccessListMembers(firstArc, secondArc, thirdArc),
+			members:     mockAccessListMembers(t, firstArc, secondArc, thirdArc),
 		}
 
 		user, err := types.NewUser("alice")
@@ -536,7 +723,7 @@ func TestAccessListIsMember_NestedRequirements(t *testing.T) {
 
 		aclGetter := &mockAccessListAndMembersGetter{
 			accessLists: mockAccessLists(firstList, secondList, thirdList),
-			members:     mockAccessListMembers(firstArc, secondArc, thirdArc, userMembership),
+			members:     mockAccessListMembers(t, firstArc, secondArc, thirdArc, userMembership),
 		}
 
 		typ, err := IsAccessListMember(ctx, user, firstList, aclGetter, locks, clock)
@@ -602,7 +789,7 @@ func TestGetOwners(t *testing.T) {
 	acl3m1 := newAccessListMember(t, acl3.GetName(), "memberC", accesslist.MembershipKindUser, clock)
 
 	accessListAndMembersGetter := &mockAccessListAndMembersGetter{
-		members: mockAccessListMembers(acl2m1, acl3m1),
+		members: mockAccessListMembers(t, acl2m1, acl3m1),
 	}
 
 	// Test GetOwners for acl1
@@ -960,7 +1147,7 @@ func TestGetMembersFor_FlattensAndStopsOnCycles(t *testing.T) {
 
 	getter := &mockAccessListAndMembersGetter{
 		accessLists: mockAccessLists(a, b, c),
-		members: mockAccessListMembers(
+		members: mockAccessListMembers(t,
 			newAccessListMember(t, "A", "userA", accesslist.MembershipKindUser, clock),
 			newAccessListMember(t, "A", "B", accesslist.MembershipKindList, clock),
 			newAccessListMember(t, "B", "userB", accesslist.MembershipKindUser, clock),
@@ -970,7 +1157,7 @@ func TestGetMembersFor_FlattensAndStopsOnCycles(t *testing.T) {
 		),
 	}
 
-	members, err := GetMembersFor(ctx, "A", getter)
+	members, err := GetMembersForV2(ctx, ScopeQualifiedName(a), getter)
 	require.NoError(t, err)
 
 	names := make([]string, 0, len(members))
@@ -1173,7 +1360,7 @@ func BenchmarkIsAccessListMember(b *testing.B) {
 
 		mock := &mockAccessListAndMembersGetter{
 			accessLists: mockAccessLists(accessList),
-			members:     mockAccessListMembers(members...),
+			members:     mockAccessListMembers(b, members...),
 		}
 
 		for b.Loop() {
@@ -1211,7 +1398,7 @@ func BenchmarkIsAccessListMember(b *testing.B) {
 
 		mock := &mockAccessListAndMembersGetter{
 			accessLists: mockAccessLists(accessList),
-			members:     mockAccessListMembers(members...),
+			members:     mockAccessListMembers(b, members...),
 		}
 
 		for b.Loop() {

--- a/lib/accesslists/scopequalifiedname.go
+++ b/lib/accesslists/scopequalifiedname.go
@@ -136,3 +136,15 @@ func AllParentLists(list *accesslist.AccessList) ([]NormalizedSQN, error) {
 	}
 	return parentLists, nil
 }
+
+// ParentListOf returns the scope-qualified name of the parent list of the
+// given access list member.
+func ParentListOf(member *accesslist.AccessListMember) (NormalizedSQN, error) {
+	if member.Scope == "" {
+		if member.Spec.AccessList == "" {
+			return NormalizedSQN{}, trace.BadParameter("member spec.access_list field empty")
+		}
+		return NormalizedSQN{Name: member.Spec.AccessList}, nil
+	}
+	return ParseScopeQualifiedName(member.Spec.AccessList)
+}

--- a/lib/accesslists/validate.go
+++ b/lib/accesslists/validate.go
@@ -219,10 +219,6 @@ func validateAccessListNesting(ctx context.Context, accessList *accesslist.Acces
 			return trace.Wrap(err)
 		}
 	}
-	if accessList.Scope != "" && len(members) > 0 {
-		// TODO(nklaassen): support scoped access list members.
-		return trace.BadParameter("scoped access list members are not yet supported")
-	}
 	for _, member := range members {
 		if err := ValidateAccessListMember(ctx, accessList, member, g); err != nil {
 			return trace.Wrap(err)
@@ -255,25 +251,49 @@ func ValidateAccessListMember(
 // validateAccessListMemberBasic performs basic fields validation for AccessListMember
 // and performs the cross membership integrity check.
 func validateAccessListMemberBasic(parent *accesslist.AccessList, member *accesslist.AccessListMember) error {
-	if member.Scope != "" {
-		// TODO(nklaassen): support scoped access list members.
-		return trace.BadParameter("scoped access list members are not yet supported")
-	}
 	if member.Spec.AccessList == "" {
 		return trace.BadParameter("member %s: access_list field empty", member.Metadata.Name)
 	}
 	if member.Spec.Name != member.Metadata.Name {
 		return trace.BadParameter("member metadata name = %q and spec name = %q must be equal", member.Metadata.Name, member.Spec.Name)
 	}
+	if member.Scope != parent.Scope {
+		return trace.BadParameter("member resource scope %q must be equal to parent list scope %q", member.Scope, parent.Scope)
+	}
+	parentName := ScopeQualifiedName(parent)
+	if member.Scope != "" {
+		if err := scopes.StrongValidate(member.Scope); err != nil {
+			return trace.Wrap(err, "access list member has invalid scope")
+		}
+		memberSQN, err := MemberScopeQualifiedName(member)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+		if memberSQN.Scope != "" {
+			if err := memberSQN.ToScopesQualifiedName().StrongValidate(); err != nil {
+				return trace.Wrap(err)
+			}
+		}
+		// The member must belong to the parent access list.
+		memberParentName, err := ParentListOf(member)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+		if memberParentName != parentName {
+			return trace.BadParameter("member spec.access_list %q must match parent list name %q",
+				member.Spec.AccessList, parentName.String())
+		}
+	} else {
+		// The member must belong to the parent access list.
+		if member.Spec.AccessList != parent.GetName() {
+			return trace.BadParameter("member %s: spec.access_list field %q doesn't match parent list name %q", member.Metadata.Name, member.Spec.AccessList, parent.GetName())
+		}
+	}
 	if member.Spec.Joined.IsZero() || member.Spec.Joined.Unix() == 0 {
 		return trace.BadParameter("member %s: joined field empty or missing", member.Metadata.Name)
 	}
 	if member.Spec.AddedBy == "" {
 		return trace.BadParameter("member %s: added_by field is empty", member.Metadata.Name)
-	}
-	// The member must belong to the parent access list.
-	if member.Spec.AccessList != parent.GetName() {
-		return trace.BadParameter("member %s: spec.access_list field %q doesn't match parent list name %q", member.Metadata.Name, member.Spec.AccessList, parent.GetName())
 	}
 	return nil
 }

--- a/lib/accesslists/validate_test.go
+++ b/lib/accesslists/validate_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/gravitational/teleport/api/types/accesslist"
+	"github.com/gravitational/teleport/api/types/header"
 	scopedaccess "github.com/gravitational/teleport/lib/scopes/access"
 )
 
@@ -50,7 +51,7 @@ func TestAccessListHierarchyCircularRefsCheck(t *testing.T) {
 	acl3m1 := newAccessListMember(t, acl3.GetName(), acl1.GetName(), accesslist.MembershipKindList, clock)
 
 	accessListAndMembersGetter := &mockAccessListAndMembersGetter{
-		members:     mockAccessListMembers(acl1m1, acl2m1),
+		members:     mockAccessListMembers(t, acl1m1, acl2m1),
 		accessLists: mockAccessLists(acl1, acl2, acl3),
 	}
 
@@ -84,7 +85,7 @@ func TestAccessListHierarchyCircularRefsCheck(t *testing.T) {
 	acl4.Status.OwnerOf = append(acl4.Status.OwnerOf, acl5.GetName())
 
 	accessListAndMembersGetter = &mockAccessListAndMembersGetter{
-		members:     mockAccessListMembers(acl4m1),
+		members:     mockAccessListMembers(t, acl4m1),
 		accessLists: mockAccessLists(acl4, acl5),
 	}
 
@@ -326,6 +327,101 @@ func TestAccessListValidateWithMembers_basic(t *testing.T) {
 			}
 		})
 
+		t.Run("member list scope hierarchy is validated", func(t *testing.T) {
+			testCases := []struct {
+				name        string
+				listScope   string
+				memberScope string
+				memberKind  string
+				wantErr     string
+			}{
+				{
+					name:        "unscoped list can be member of scoped list",
+					listScope:   "/eng/platform",
+					memberScope: "",
+					memberKind:  accesslist.MembershipKindList,
+				},
+				{
+					name:        "same scope member can be member of scoped list",
+					listScope:   "/eng/platform",
+					memberScope: "/eng/platform",
+					memberKind:  accesslist.MembershipKindScopedList,
+				},
+				{
+					name:        "ancestor scope member can be member of scoped list",
+					listScope:   "/eng/platform",
+					memberScope: "/eng",
+					memberKind:  accesslist.MembershipKindScopedList,
+				},
+				{
+					name:        "descendant scope member is rejected",
+					listScope:   "/eng/platform",
+					memberScope: "/eng/platform/team",
+					memberKind:  accesslist.MembershipKindScopedList,
+					wantErr:     "because it is not at an equal or ancestor scope",
+				},
+				{
+					name:        "sibling scope member is rejected",
+					listScope:   "/eng/platform",
+					memberScope: "/eng/infra",
+					memberKind:  accesslist.MembershipKindScopedList,
+					wantErr:     "because it is not at an equal or ancestor scope",
+				},
+				{
+					name:        "unscoped list cannot have scoped member",
+					listScope:   "",
+					memberScope: "/eng",
+					memberKind:  accesslist.MembershipKindScopedList,
+					wantErr:     "because scoped access lists cannot be members or owners of unscoped access lists",
+				},
+			}
+
+			for _, tc := range testCases {
+				t.Run(tc.name, func(t *testing.T) {
+					parentList := newScopedAccessList("parent-list")
+					parentList.Scope = tc.listScope
+					memberList := newScopedAccessList("member-list")
+					memberList.Scope = tc.memberScope
+
+					parentListName := ScopeQualifiedName(parentList)
+					memberName := ScopeQualifiedName(memberList)
+
+					memberResource, err := accesslist.NewAccessListMemberWithScope(
+						header.Metadata{
+							Name: memberName.String(),
+						},
+						accesslist.AccessListMemberSpec{
+							AccessList:     parentListName.String(),
+							Name:           memberName.String(),
+							MembershipKind: tc.memberKind,
+							Joined:         clock.Now().UTC(),
+							Expires:        clock.Now().UTC().Add(24 * time.Hour),
+							Reason:         "because",
+							AddedBy:        "tester",
+						},
+						tc.listScope,
+					)
+					require.NoError(t, err)
+
+					getter := &mockAccessListAndMembersGetter{
+						accessLists: mockAccessLists(parentList, memberList),
+					}
+					err = ValidateAccessListWithMembers(
+						ctx,
+						nil, // existingList
+						parentList,
+						[]*accesslist.AccessListMember{memberResource},
+						getter,
+					)
+					if tc.wantErr != "" {
+						require.ErrorContains(t, err, tc.wantErr)
+						return
+					}
+					require.NoError(t, err)
+				})
+			}
+		})
+
 		t.Run("owner list scope hierarchy is validated", func(t *testing.T) {
 			testCases := []struct {
 				name       string
@@ -457,12 +553,76 @@ func TestAccessListValidateWithMembers_basic(t *testing.T) {
 			require.ErrorContains(t, err, "scoped access lists cannot grant traits")
 		})
 
-		t.Run("members are rejected", func(t *testing.T) {
+		t.Run("mismatched member scope is rejected", func(t *testing.T) {
 			accessList := newScopedAccessList("test_scoped_access_list_members")
 			member := newAccessListMember(t, accessList.GetName(), "alice", accesslist.MembershipKindUser, clock)
+			member.Scope = "/other/scope"
 
 			err := ValidateAccessListWithMembers(ctx, nil, accessList, []*accesslist.AccessListMember{member}, &mockAccessListAndMembersGetter{})
-			require.ErrorContains(t, err, "scoped access list members are not yet supported")
+			require.ErrorContains(t, err, `member resource scope "/other/scope" must be equal to parent list scope "/eng"`)
+		})
+
+		t.Run("mismatched member access list scope is rejected", func(t *testing.T) {
+			accessList := newScopedAccessList("test_scoped_access_list_members")
+			member, err := accesslist.NewAccessListMemberWithScope(
+				header.Metadata{Name: "alice"},
+				accesslist.AccessListMemberSpec{
+					AccessList:     "/other::" + accessList.GetName(),
+					Name:           "alice",
+					MembershipKind: accesslist.MembershipKindUser,
+					Joined:         clock.Now().UTC(),
+					Expires:        clock.Now().UTC().Add(24 * time.Hour),
+					Reason:         "because",
+					AddedBy:        "tester",
+				},
+				accessList.GetScope(),
+			)
+			require.NoError(t, err)
+
+			err = ValidateAccessListWithMembers(ctx, nil, accessList, []*accesslist.AccessListMember{member}, &mockAccessListAndMembersGetter{})
+			require.ErrorContains(t, err, `member spec.access_list "/other::test_scoped_access_list_members" must match parent list name "/eng::test_scoped_access_list_members"`)
+		})
+
+		t.Run("plain list kind with scoped member name is rejected", func(t *testing.T) {
+			accessList := newScopedAccessList("test_scoped_access_list_members")
+			member, err := accesslist.NewAccessListMemberWithScope(
+				header.Metadata{Name: "/eng::member-list"},
+				accesslist.AccessListMemberSpec{
+					AccessList:     ScopeQualifiedName(accessList).String(),
+					Name:           "/eng::member-list",
+					MembershipKind: accesslist.MembershipKindList,
+					Joined:         clock.Now().UTC(),
+					Expires:        clock.Now().UTC().Add(24 * time.Hour),
+					Reason:         "because",
+					AddedBy:        "tester",
+				},
+				accessList.GetScope(),
+			)
+			require.NoError(t, err)
+
+			err = ValidateAccessListWithMembers(ctx, nil, accessList, []*accesslist.AccessListMember{member}, &mockAccessListAndMembersGetter{})
+			require.ErrorContains(t, err, `access list /eng::member-list not found`)
+		})
+
+		t.Run("scoped list kind with plain member name is rejected", func(t *testing.T) {
+			accessList := newScopedAccessList("test_scoped_access_list_members")
+			member, err := accesslist.NewAccessListMemberWithScope(
+				header.Metadata{Name: "member-list"},
+				accesslist.AccessListMemberSpec{
+					AccessList:     ScopeQualifiedName(accessList).String(),
+					Name:           "member-list",
+					MembershipKind: accesslist.MembershipKindScopedList,
+					Joined:         clock.Now().UTC(),
+					Expires:        clock.Now().UTC().Add(24 * time.Hour),
+					Reason:         "because",
+					AddedBy:        "tester",
+				},
+				accessList.GetScope(),
+			)
+			require.NoError(t, err)
+
+			err = ValidateAccessListWithMembers(ctx, nil, accessList, []*accesslist.AccessListMember{member}, &mockAccessListAndMembersGetter{})
+			require.ErrorContains(t, err, `scope-qualified name "member-list" missing "::" separator`)
 		})
 	})
 

--- a/lib/accesslists/walk.go
+++ b/lib/accesslists/walk.go
@@ -230,23 +230,24 @@ func walk(ctx context.Context, config walkConfig, walkFn walkFunc) error {
 		var leg accessLeg
 		var member *accesslist.AccessListMember
 
-		// TODO(nklaassen): support scoped access list members.
-		if list.GetScope() != "" {
-			continue
-		}
-
 		// We iterate over every member of the considered list
 		listMembersFn := func(ctx context.Context, pageSize int, pageToken string) ([]*accesslist.AccessListMember, string, error) {
-			r, token, err := config.getter.ListAccessListMembers(ctx, list.GetName(), pageSize, pageToken)
+			r, token, err := listAccessListMembers(ctx, config.getter, accesslistv1.ListAccessListMembersRequest_builder{
+				AccessListScope: list.GetScope(),
+				AccessList:      list.GetName(),
+				PageSize:        int32(pageSize),
+				PageToken:       pageToken,
+			}.Build())
 			return r, token, trace.Wrap(err)
 		}
 
 		for member, err = range clientutils.Resources(ctx, listMembersFn) {
 			if err != nil {
-				return trace.Wrap(err, "getting access list members for %q", list.GetName())
+				return trace.Wrap(err, "getting access list members for %q", ScopeQualifiedName(list).String())
 			}
 
-			if member.Spec.MembershipKind == accesslist.MembershipKindList {
+			switch member.Spec.MembershipKind {
+			case accesslist.MembershipKindList, accesslist.MembershipKindScopedList:
 				// The member is a nested list.
 				name, err := MemberScopeQualifiedName(member)
 				if err != nil {

--- a/lib/services/local/access_list.go
+++ b/lib/services/local/access_list.go
@@ -43,21 +43,28 @@ import (
 	"github.com/gravitational/teleport/lib/scopes"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/services/local/generic"
-	"github.com/gravitational/teleport/lib/utils"
 	"github.com/gravitational/teleport/lib/utils/set"
 )
 
 const (
+	scopedPrefix = "scoped"
+
+	// Access lists are stored under one of the following key ranges, depending
+	// on their scope:
+	// - /access_list/<list-name>                             (for unscoped lists)
+	// - /scoped/access_list/<encoded-list-scope>/<list-name> (for scoped lists)
 	accessListPrefix      = "access_list"
 	accessListMaxPageSize = 100
 
+	// Access list members are stored under one of the following key ranges,
+	// depending on the scope of the parent list:
+	// - /access_list_member/<list-name>/<member-name>                                                    (for unscoped lists)
+	// - /scoped/access_list_member/<encoded-list-scope>/<list-name>/<encoded-member-scope>/<member-name> (for scoped lists)
 	accessListMemberPrefix      = "access_list_member"
 	accessListMemberMaxPageSize = 200
 
 	accessListReviewPrefix      = "access_list_review"
 	accessListReviewMaxPageSize = 200
-
-	scopedPrefix = "scoped"
 
 	// This lock is necessary to prevent a race condition between access lists and members and to ensure
 	// consistency of the one-to-many relationship between them.
@@ -85,17 +92,35 @@ type AccessListService struct {
 	// scopesFeatures dictates whether scoped role grants are enabled.
 	scopesFeatures scopes.Features
 	service        *generic.ScopeAwareService[*accesslist.AccessList]
-	memberService  *generic.Service[*accesslist.AccessListMember]
+	memberService  *generic.ScopeAwareService[*accesslist.AccessListMember]
 	reviewService  *generic.Service[*accesslist.Review]
 }
 
 type accessListAndMembersGetter struct {
 	service       *generic.ScopeAwareService[*accesslist.AccessList]
-	memberService *generic.Service[*accesslist.AccessListMember]
+	memberService *generic.ScopeAwareService[*accesslist.AccessListMember]
 }
 
 func (s *accessListAndMembersGetter) ListAccessListMembers(ctx context.Context, accessListName string, pageSize int, pageToken string) ([]*accesslist.AccessListMember, string, error) {
-	return s.memberService.WithPrefix(accessListName).ListResources(ctx, pageSize, pageToken)
+	membersService, err := membersServiceForAccessList(s.memberService, accesslists.NormalizedSQN{
+		Name: accessListName,
+	})
+	if err != nil {
+		return nil, "", trace.Wrap(err)
+	}
+	return membersService.listResources(ctx, pageSize, pageToken)
+}
+
+func (s *accessListAndMembersGetter) ListAccessListMembersV2(ctx context.Context, req *accesslistv1.ListAccessListMembersRequest) ([]*accesslist.AccessListMember, string, error) {
+	listName := accesslists.NormalizeSQN(scopes.QualifiedName{
+		Scope: req.GetAccessListScope(),
+		Name:  req.GetAccessList(),
+	})
+	membersService, err := membersServiceForAccessList(s.memberService, listName)
+	if err != nil {
+		return nil, "", trace.Wrap(err)
+	}
+	return membersService.listResources(ctx, int(req.GetPageSize()), req.GetPageToken())
 }
 
 func (s *accessListAndMembersGetter) GetAccessList(ctx context.Context, name string) (*accesslist.AccessList, error) {
@@ -116,7 +141,155 @@ func (s *accessListAndMembersGetter) getAccessList(ctx context.Context, listName
 // GetAccessListMember returns the specified access list member resource.
 // If a user is not directly a member of the access list the NotFound error is returned.
 func (s *accessListAndMembersGetter) GetAccessListMember(ctx context.Context, accessListName, memberName string) (*accesslist.AccessListMember, error) {
-	return s.memberService.WithPrefix(accessListName).GetResource(ctx, memberName)
+	memberService, err := memberServiceForNamedMember(s.memberService,
+		accesslists.NormalizedSQN{Name: accessListName},
+		accesslists.NormalizedSQN{Name: memberName},
+	)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return memberService.get(ctx)
+}
+
+// GetAccessListMemberV2 returns the specified access list member resource.
+// If a user is not directly a member of the access list the NotFound error is returned.
+func (s *accessListAndMembersGetter) GetAccessListMemberV2(ctx context.Context, req *accesslistv1.GetAccessListMemberRequest) (*accesslist.AccessListMember, error) {
+	accessListName := accesslists.NormalizeSQN(scopes.QualifiedName{
+		Scope: req.GetAccessListScope(),
+		Name:  req.GetAccessList(),
+	})
+	memberName := accesslists.NormalizeSQN(scopes.QualifiedName{
+		Scope: req.GetMemberScope(),
+		Name:  req.GetMemberName(),
+	})
+	memberService, err := memberServiceForNamedMember(s.memberService, accessListName, memberName)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return memberService.get(ctx)
+}
+
+// membersServiceForAccessList returns a [*membersService] valid only for
+// operations on _all_ members of the given access list, it cannot be used to
+// get, create, or delete any single member, use [memberServiceForNamedMember]
+// in those cases.
+func membersServiceForAccessList(
+	genericService *generic.ScopeAwareService[*accesslist.AccessListMember],
+	listName accesslists.NormalizedSQN,
+) (*membersService, error) {
+	service, err := genericService.WithScopedResourcePrefix(listName.ToScopesQualifiedName())
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return &membersService{service}, nil
+}
+
+type membersService struct {
+	service *generic.Service[*accesslist.AccessListMember]
+}
+
+func (s *membersService) resources(ctx context.Context, startKey, endKey string) iter.Seq2[*accesslist.AccessListMember, error] {
+	return s.service.Resources(ctx, startKey, endKey)
+}
+
+func (s *membersService) listResources(ctx context.Context, pageSize int, pageToken string) ([]*accesslist.AccessListMember, string, error) {
+	return s.service.ListResources(ctx, pageSize, pageToken)
+}
+
+func (s *membersService) getResources(ctx context.Context) ([]*accesslist.AccessListMember, error) {
+	return s.service.GetResources(ctx)
+}
+
+func (s *membersService) deleteAllResources(ctx context.Context) error {
+	return s.service.DeleteAllResources(ctx)
+}
+
+// memberServiceForNamedMember returns a [*memberService] valid for only the
+// exact named member, with an appropriate backend prefix and NameKeyFunc configured.
+func memberServiceForNamedMember(
+	membersService *generic.ScopeAwareService[*accesslist.AccessListMember],
+	listName, memberName accesslists.NormalizedSQN,
+) (*memberService, error) {
+	service, err := membersService.WithScopedResourcePrefix(listName.ToScopesQualifiedName())
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	if listName.Scope == "" {
+		// For unscoped parent lists we need only the following backend prefix,
+		// which we will already have after calling WithScopedResourcePrefix.
+		// We just need to assert that the member is unscoped.
+		// - /access_list_member/<list-name>
+		if memberName.Scope != "" {
+			return nil, trace.BadParameter("unscoped access lists cannot have scoped members")
+		}
+	} else {
+		// For scoped parent lists we need the following backend prefix, after
+		// calling WithScopedResourcePrefix we need only to append the encoded
+		// member scope. Even if the member has the empty scope, it must be
+		// encoded and included in the key.
+		// - /scoped/access_list_member/<encoded-list-scope>/<list-name>/<encoded-member-scope>
+		encodedMemberScope, err := scopes.EncodeForKey(memberName.Scope)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		service = service.WithPrefix(encodedMemberScope)
+	}
+
+	// For scoped members, the metadata.name is a scope-qualified name.
+	// The scope is already encoded in the backend prefix, so we must
+	// override the NameKeyFunc to use only the plain name.
+	// We do this unconditionally even for unscoped members, so that we can
+	// return a [memberService] that operates on a single member without
+	// requiring a name parameter that may be inaccurate or misleading.
+	service = service.WithNameKeyFunc(func() backend.Key {
+		return backend.NewKey(memberName.Name)
+	})
+
+	return &memberService{
+		service:    service,
+		memberName: memberName.String(),
+	}, nil
+}
+
+// memberService wraps a generic service with an overridden NameKeyFunc so that
+// is valid for exactly one access list member. The get and delete methods
+// don't accept a name parameter to make it clear that it will not be used.
+type memberService struct {
+	service    *generic.Service[*accesslist.AccessListMember]
+	memberName string
+}
+
+func (s *memberService) get(ctx context.Context) (*accesslist.AccessListMember, error) {
+	// NameKeyFunc has been set, so the name param does not matter except that
+	// it will be shown in error messages.
+	return s.service.GetResource(ctx, s.memberName)
+}
+
+func (s *memberService) delete(ctx context.Context) error {
+	// NameKeyFunc has been set, so the name param does not matter except that
+	// it will be shown in error messages.
+	return s.service.DeleteResource(ctx, s.memberName)
+}
+
+func (s *memberService) makeBackendItem(member *accesslist.AccessListMember) (backend.Item, error) {
+	// service.MakeBackendItem respects the overridden NameKeyFunc.
+	return s.service.MakeBackendItem(member)
+}
+
+func (s *memberService) upsert(ctx context.Context, member *accesslist.AccessListMember) (*accesslist.AccessListMember, error) {
+	// service.UpsertResource respects the overridden NameKeyFunc.
+	return s.service.UpsertResource(ctx, member)
+}
+
+func (s *memberService) conditionalUpdateResource(ctx context.Context, member *accesslist.AccessListMember) (*accesslist.AccessListMember, error) {
+	// service.ConditionalUpdateResource respects the overridden NameKeyFunc.
+	updated, err := s.service.ConditionalUpdateResource(ctx, member)
+	if trace.IsNotFound(err) {
+		// Re-write NotFound errors to include the member scope.
+		return nil, trace.NotFound("%s %q doesn't exist", types.KindAccessListMember, s.memberName)
+	}
+	return updated, trace.Wrap(err)
 }
 
 // compile-time assertion that the AccessListService implements the AccessLists
@@ -157,11 +330,12 @@ func NewAccessListServiceV2(cfg AccessListServiceConfig) (*AccessListService, er
 		return nil, trace.Wrap(err)
 	}
 
-	memberService, err := generic.NewService(&generic.ServiceConfig[*accesslist.AccessListMember]{
+	memberService, err := generic.NewScopeAwareService(&generic.ScopeAwareServiceConfig[*accesslist.AccessListMember]{
 		Backend:                     cfg.Backend,
 		PageLimit:                   accessListMemberMaxPageSize,
 		ResourceKind:                types.KindAccessListMember,
-		BackendPrefix:               backend.NewKey(accessListMemberPrefix),
+		UnscopedBackendPrefix:       backend.NewKey(accessListMemberPrefix),
+		ScopedBackendPrefix:         backend.NewKey(scopedPrefix, accessListMemberPrefix),
 		MarshalFunc:                 services.MarshalAccessListMember,
 		UnmarshalFunc:               services.UnmarshalAccessListMember,
 		RunWhileLockedRetryInterval: cfg.RunWhileLockedRetryInterval,
@@ -274,6 +448,11 @@ func (a *AccessListService) runOpWithLock(ctx context.Context, accessList *acces
 	var upserted *accesslist.AccessList
 	var existingAccessList *accesslist.AccessList
 
+	membersService, err := a.membersServiceForAccessList(accesslists.ScopeQualifiedName(accessList))
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
 	validateAccessList := func() error {
 		var err error
 
@@ -286,13 +465,9 @@ func (a *AccessListService) runOpWithLock(ctx context.Context, accessList *acces
 		}
 		preserveAccessListFields(existingAccessList, accessList)
 
-		// TODO(nklaassen): support scoped access list members.
-		var listMembers []*accesslist.AccessListMember
-		if accessList.Scope == "" {
-			listMembers, err = a.memberService.WithPrefix(accessList.GetName()).GetResources(ctx)
-			if err != nil {
-				return trace.Wrap(err)
-			}
+		listMembers, err := membersService.getResources(ctx)
+		if err != nil {
+			return trace.Wrap(err)
 		}
 
 		if err := accesslists.ValidateAccessListWithMembers(ctx, existingAccessList, accessList, listMembers, &accessListAndMembersGetter{a.service, a.memberService}); err != nil {
@@ -418,6 +593,11 @@ func (a *AccessListService) DeleteAccessListV2(ctx context.Context, req *accessl
 		Scope: req.GetScope(),
 		Name:  req.GetName(),
 	})
+	membersService, err := a.membersServiceForAccessList(name)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
 	action := func(ctx context.Context, _ backend.Backend) error {
 		// Get list resource.
 		accessList, err := a.getAccessList(ctx, name)
@@ -430,26 +610,27 @@ func (a *AccessListService) DeleteAccessListV2(ctx context.Context, req *accessl
 			return trace.Wrap(err)
 		}
 
-		// TODO(nklaassen): support scoped access list members
-		if name.Scope == "" {
-			// Delete all associated members.
-			members, err := a.memberService.WithPrefix(name.Name).GetResources(ctx)
+		// Delete all associated members.
+		members, err := membersService.getResources(ctx)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+
+		if err := membersService.deleteAllResources(ctx); err != nil {
+			return trace.Wrap(err)
+		}
+
+		// Update memberOf refs.
+		for _, member := range members {
+			if !member.IsList() {
+				continue
+			}
+			memberName, err := accesslists.MemberScopeQualifiedName(member)
 			if err != nil {
 				return trace.Wrap(err)
 			}
-
-			if err := a.memberService.WithPrefix(name.Name).DeleteAllResources(ctx); err != nil {
+			if err := a.updateAccessListMemberOf(ctx, name, memberName, false); err != nil {
 				return trace.Wrap(err)
-			}
-
-			// Update memberOf refs.
-			for _, member := range members {
-				if member.Spec.MembershipKind != accesslist.MembershipKindList {
-					continue
-				}
-				if err := a.updateAccessListMemberOf(ctx, name.Name, member.GetName(), false); err != nil {
-					return trace.Wrap(err)
-				}
 			}
 		}
 
@@ -503,14 +684,28 @@ func (a *AccessListService) GetSuggestedAccessLists(ctx context.Context, accessR
 
 // CountAccessListMembers will count all access list members.
 func (a *AccessListService) CountAccessListMembers(ctx context.Context, accessListName string) (users uint32, lists uint32, err error) {
+	return a.CountAccessListMembersV2(ctx, accesslistv1.CountAccessListMembersRequest_builder{
+		AccessListName: accessListName,
+	}.Build())
+}
+
+// CountAccessListMembersV2 will count all access list members.
+func (a *AccessListService) CountAccessListMembersV2(ctx context.Context, req *accesslistv1.CountAccessListMembersRequest) (users uint32, lists uint32, err error) {
 	count := uint(0)
 	listCount := uint(0)
-	members, err := a.memberService.WithPrefix(accessListName).GetResources(ctx)
+	membersService, err := a.membersServiceForAccessList(accesslists.NormalizeSQN(scopes.QualifiedName{
+		Scope: req.GetAccessListScope(),
+		Name:  req.GetAccessListName(),
+	}))
 	if err != nil {
 		return 0, 0, trace.Wrap(err)
 	}
-	for _, member := range members {
-		if member.Spec.MembershipKind == accesslist.MembershipKindList {
+	for member, err := range membersService.resources(ctx, "", "") {
+		if err != nil {
+			return 0, 0, trace.Wrap(err)
+		}
+
+		if member.IsList() {
 			listCount++
 		} else {
 			count++
@@ -520,41 +715,80 @@ func (a *AccessListService) CountAccessListMembers(ctx context.Context, accessLi
 	return uint32(count), uint32(listCount), trace.Wrap(err)
 }
 
-// ListAccessListMembers returns a paginated list of all access list members.
+// ListAccessListMembers returns a paginated list of all members of the given list.
 func (a *AccessListService) ListAccessListMembers(ctx context.Context, accessListName string, pageSize int, nextToken string) ([]*accesslist.AccessListMember, string, error) {
-	_, err := a.getAccessList(ctx, accesslists.NormalizedSQN{Name: accessListName})
-	if err != nil {
-		return nil, "", trace.Wrap(err)
-	}
-	members, nextToken, err := a.memberService.WithPrefix(accessListName).ListResources(ctx, pageSize, nextToken)
+	return a.ListAccessListMembersV2(ctx, accesslistv1.ListAccessListMembersRequest_builder{
+		AccessList: accessListName,
+		PageSize:   int32(pageSize),
+		PageToken:  nextToken,
+	}.Build())
+}
 
+// ListAccessListMembersV2 returns a paginated list of all members of the given list.
+func (a *AccessListService) ListAccessListMembersV2(ctx context.Context, req *accesslistv1.ListAccessListMembersRequest) ([]*accesslist.AccessListMember, string, error) {
+	accessListName := accesslists.NormalizeSQN(scopes.QualifiedName{
+		Scope: req.GetAccessListScope(),
+		Name:  req.GetAccessList(),
+	})
+	_, err := a.getAccessList(ctx, accessListName)
 	if err != nil {
 		return nil, "", trace.Wrap(err)
 	}
-	return members, nextToken, nil
+	membersService, err := a.membersServiceForAccessList(accessListName)
+	if err != nil {
+		return nil, "", trace.Wrap(err)
+	}
+	return membersService.listResources(ctx, int(req.GetPageSize()), req.GetPageToken())
 }
 
 // ListAllAccessListMembers returns a paginated list of all access list members for all access lists.
 func (a *AccessListService) ListAllAccessListMembers(ctx context.Context, pageSize int, pageToken string) ([]*accesslist.AccessListMember, string, error) {
-	members, next, err := a.memberService.ListResourcesReturnNextResource(ctx, pageSize, pageToken)
-	if err != nil {
-		return nil, "", trace.Wrap(err)
-	}
-	var nextKey string
-	if next != nil {
-		nextKey = (*next).Spec.AccessList + string(backend.Separator) + (*next).Metadata.Name
-	}
-	return members, nextKey, nil
+	// TODO(nklaassen): support listing scoped access list members with opt-in.
+	return a.memberService.UnscopedService.ListResources(ctx, pageSize, pageToken)
 }
 
 // GetAccessListMember returns the specified access list member resource.
 func (a *AccessListService) GetAccessListMember(ctx context.Context, accessList string, memberName string) (*accesslist.AccessListMember, error) {
-	_, err := a.getAccessList(ctx, accesslists.NormalizedSQN{Name: accessList})
+	return a.GetAccessListMemberV2(ctx, accesslistv1.GetAccessListMemberRequest_builder{
+		AccessList: accessList,
+		MemberName: memberName,
+	}.Build())
+}
+
+// GetAccessListMemberV2 returns the specified access list member resource.
+func (a *AccessListService) GetAccessListMemberV2(ctx context.Context, req *accesslistv1.GetAccessListMemberRequest) (*accesslist.AccessListMember, error) {
+	accessListName := accesslists.NormalizeSQN(scopes.QualifiedName{
+		Scope: req.GetAccessListScope(),
+		Name:  req.GetAccessList(),
+	})
+	memberName := accesslists.NormalizeSQN(scopes.QualifiedName{
+		Scope: req.GetMemberScope(),
+		Name:  req.GetMemberName(),
+	})
+	_, err := a.getAccessList(ctx, accessListName)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	member, err := a.memberService.WithPrefix(accessList).GetResource(ctx, memberName)
+	memberService, err := a.memberServiceForNamedMember(accessListName, memberName)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	member, err := memberService.get(ctx)
 	return member, trace.Wrap(err)
+}
+
+// memberServiceForNamedMember returns a [*memberService] valid for only the
+// exact named member, with an appropriate backend prefix and NameKeyFunc configured.
+func (a *AccessListService) memberServiceForNamedMember(listName, memberName accesslists.NormalizedSQN) (*memberService, error) {
+	return memberServiceForNamedMember(a.memberService, listName, memberName)
+}
+
+// membersServiceForAccessList returns a [*membersService] valid only for
+// operations on _all_ members of the given access list, it cannot be used to
+// get, create, or delete any single member, use [memberServiceForNamedMember]
+// in those cases.
+func (a *AccessListService) membersServiceForAccessList(listName accesslists.NormalizedSQN) (*membersService, error) {
+	return membersServiceForAccessList(a.memberService, listName)
 }
 
 // updateAccessListRefField is a helper that updates the specified field (memberOf or ownerOf) of an Access List,
@@ -602,12 +836,12 @@ func (a *AccessListService) updateAccessListRefField(
 
 // updateAccessListMemberOf updates the memberOf field for the specified memberName and accessListName.
 // Should only be called after the relevant member has been successfully upserted or deleted.
-func (a *AccessListService) updateAccessListMemberOf(ctx context.Context, accessListName, memberName string, new bool) error {
-	// TODO(nklaassen): support scoped access list members.
-	listSQN := accesslists.NormalizedSQN{Name: accessListName}
-	memberSQN := accesslists.NormalizedSQN{Name: memberName}
-	return a.updateAccessListRefField(ctx, listSQN, memberSQN, new, func(status *accesslist.Status) *[]string {
-		return &status.MemberOf
+func (a *AccessListService) updateAccessListMemberOf(ctx context.Context, accessListName, memberName accesslists.NormalizedSQN, new bool) error {
+	return a.updateAccessListRefField(ctx, accessListName, memberName, new, func(status *accesslist.Status) *[]string {
+		if accessListName.Scope == "" {
+			return &status.MemberOf
+		}
+		return &status.ScopedMemberOf
 	})
 }
 
@@ -650,29 +884,42 @@ func (a *AccessListService) GetAccessListOwnersV2(ctx context.Context, req *acce
 
 // UpsertAccessListMember creates or updates an access list member resource.
 func (a *AccessListService) UpsertAccessListMember(ctx context.Context, member *accesslist.AccessListMember) (*accesslist.AccessListMember, error) {
+	parentListName, err := accesslists.ParentListOf(member)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	memberName, err := accesslists.MemberScopeQualifiedName(member)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	memberService, err := a.memberServiceForNamedMember(parentListName, memberName)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
 	var upserted *accesslist.AccessListMember
 	action := func(ctx context.Context, _ backend.Backend) error {
-		memberList, err := a.GetAccessList(ctx, member.Spec.AccessList)
+		parentList, err := a.getAccessList(ctx, parentListName)
 		if err != nil {
 			return trace.Wrap(err)
 		}
-		existingMember, err := a.memberService.GetResource(ctx, member.GetName())
+		existingMember, err := memberService.get(ctx)
 		if err != nil && !trace.IsNotFound(err) {
 			return trace.Wrap(err)
 		}
 		keepAWSIdentityCenterLabels(existingMember, member)
 
-		if err := accesslists.ValidateAccessListMember(ctx, memberList, member, &accessListAndMembersGetter{a.service, a.memberService}); err != nil {
+		if err := accesslists.ValidateAccessListMember(ctx, parentList, member, &accessListAndMembersGetter{a.service, a.memberService}); err != nil {
 			return trace.Wrap(err)
 		}
 
-		upserted, err = a.memberService.WithPrefix(member.Spec.AccessList).UpsertResource(ctx, member)
+		upserted, err = memberService.upsert(ctx, member)
 		if err != nil {
 			return trace.Wrap(err)
 		}
 
-		if member.Spec.MembershipKind == accesslist.MembershipKindList {
-			if err := a.updateAccessListMemberOf(ctx, member.Spec.AccessList, member.Spec.Name, true); err != nil {
+		if member.IsList() {
+			if err := a.updateAccessListMemberOf(ctx, parentListName, memberName, true); err != nil {
 				return trace.Wrap(err)
 			}
 		}
@@ -680,30 +927,43 @@ func (a *AccessListService) UpsertAccessListMember(ctx context.Context, member *
 		return nil
 	}
 
-	// without this check creating the lock may fail with "special characters are not allowed in resource names"
-	if member.Spec.AccessList == "" {
-		return nil, trace.BadParameter("access_list_member %s: spec.access_list field empty", member.GetName())
+	lockName, err := scopeAwareLockName(parentListName)
+	if err != nil {
+		return nil, trace.Wrap(err)
 	}
-	err := a.service.RunWhileLocked(ctx, []string{accessListResourceLockName}, accessListLockTTL, func(ctx context.Context, _ backend.Backend) error {
-		return a.service.RunWhileLocked(ctx, lockName(member.Spec.AccessList), accessListLockTTL, action)
+	err = a.service.RunWhileLocked(ctx, []string{accessListResourceLockName}, accessListLockTTL, func(ctx context.Context, _ backend.Backend) error {
+		return a.service.RunWhileLocked(ctx, lockName, accessListLockTTL, action)
 	})
 	return upserted, trace.Wrap(err)
 }
 
 // UpdateAccessListMember conditionally updates an access list member resource.
 func (a *AccessListService) UpdateAccessListMember(ctx context.Context, member *accesslist.AccessListMember) (*accesslist.AccessListMember, error) {
-	var updated *accesslist.AccessListMember
-	// without this check creating the lock may fail with "special characters are not allowed in resource names"
-	if member.Spec.AccessList == "" {
-		return nil, trace.BadParameter("access_list_member %s: spec.access_list field empty", member.GetName())
+	parentListName, err := accesslists.ParentListOf(member)
+	if err != nil {
+		return nil, trace.Wrap(err)
 	}
-	err := a.service.RunWhileLocked(ctx, []string{accessListResourceLockName}, accessListLockTTL, func(ctx context.Context, _ backend.Backend) error {
-		return a.service.RunWhileLocked(ctx, lockName(member.Spec.AccessList), accessListLockTTL, func(ctx context.Context, _ backend.Backend) error {
-			memberList, err := a.GetAccessList(ctx, member.Spec.AccessList)
+	memberName, err := accesslists.MemberScopeQualifiedName(member)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	memberService, err := a.memberServiceForNamedMember(parentListName, memberName)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	var updated *accesslist.AccessListMember
+	lockName, err := scopeAwareLockName(parentListName)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	err = a.service.RunWhileLocked(ctx, []string{accessListResourceLockName}, accessListLockTTL, func(ctx context.Context, _ backend.Backend) error {
+		return a.service.RunWhileLocked(ctx, lockName, accessListLockTTL, func(ctx context.Context, _ backend.Backend) error {
+			memberList, err := a.getAccessList(ctx, parentListName)
 			if err != nil {
 				return trace.Wrap(err)
 			}
-			existingMember, err := a.memberService.GetResource(ctx, member.GetName())
+			existingMember, err := memberService.get(ctx)
 			if err != nil && !trace.IsNotFound(err) {
 				return trace.Wrap(err)
 			}
@@ -713,13 +973,13 @@ func (a *AccessListService) UpdateAccessListMember(ctx context.Context, member *
 				return trace.Wrap(err)
 			}
 
-			updated, err = a.memberService.WithPrefix(member.Spec.AccessList).ConditionalUpdateResource(ctx, member)
+			updated, err = memberService.conditionalUpdateResource(ctx, member)
 			if err != nil {
 				return trace.Wrap(err)
 			}
 
-			if member.Spec.MembershipKind == accesslist.MembershipKindList {
-				if err := a.updateAccessListMemberOf(ctx, member.Spec.AccessList, member.Spec.Name, true); err != nil {
+			if member.IsList() {
+				if err := a.updateAccessListMemberOf(ctx, parentListName, memberName, true); err != nil {
 					return trace.Wrap(err)
 				}
 			}
@@ -732,24 +992,48 @@ func (a *AccessListService) UpdateAccessListMember(ctx context.Context, member *
 
 // DeleteAccessListMember hard deletes the specified access list member resource.
 func (a *AccessListService) DeleteAccessListMember(ctx context.Context, accessList string, memberName string) error {
-	err := a.service.RunWhileLocked(ctx, []string{accessListResourceLockName}, accessListLockTTL, func(ctx context.Context, _ backend.Backend) error {
-		return a.service.RunWhileLocked(ctx, lockName(accessList), accessListLockTTL, func(ctx context.Context, _ backend.Backend) error {
-			_, err := a.GetAccessList(ctx, accessList)
+	return a.DeleteAccessListMemberV2(ctx, accesslistv1.DeleteAccessListMemberRequest_builder{
+		AccessList: accessList,
+		MemberName: memberName,
+	}.Build())
+}
+
+// DeleteAccessListMemberV2 hard deletes the specified access list member resource.
+func (a *AccessListService) DeleteAccessListMemberV2(ctx context.Context, req *accesslistv1.DeleteAccessListMemberRequest) error {
+	accessListName := accesslists.NormalizeSQN(scopes.QualifiedName{
+		Scope: req.GetAccessListScope(),
+		Name:  req.GetAccessList(),
+	})
+	memberName := accesslists.NormalizedSQN(scopes.QualifiedName{
+		Scope: req.GetMemberScope(),
+		Name:  req.GetMemberName(),
+	})
+	lockName, err := scopeAwareLockName(accessListName)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	memberService, err := a.memberServiceForNamedMember(accessListName, memberName)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	err = a.service.RunWhileLocked(ctx, []string{accessListResourceLockName}, accessListLockTTL, func(ctx context.Context, _ backend.Backend) error {
+		return a.service.RunWhileLocked(ctx, lockName, accessListLockTTL, func(ctx context.Context, _ backend.Backend) error {
+			_, err := a.getAccessList(ctx, accessListName)
 			if err != nil {
 				return trace.Wrap(err)
 			}
 
-			member, err := a.memberService.WithPrefix(accessList).GetResource(ctx, memberName)
+			member, err := memberService.get(ctx)
 			if err != nil {
 				return trace.Wrap(err)
 			}
 
-			if err := a.memberService.WithPrefix(accessList).DeleteResource(ctx, memberName); err != nil {
+			if err := memberService.delete(ctx); err != nil {
 				return trace.Wrap(err)
 			}
 
-			if member.Spec.MembershipKind == accesslist.MembershipKindList {
-				if err := a.updateAccessListMemberOf(ctx, accessList, memberName, false); err != nil {
+			if member.IsList() {
+				if err := a.updateAccessListMemberOf(ctx, accessListName, memberName, false); err != nil {
 					return trace.Wrap(err)
 				}
 			}
@@ -765,27 +1049,53 @@ func (a *AccessListService) DeleteAccessListMember(ctx context.Context, accessLi
 // allowed on a list with implicit membership, as it provides a mechanism for
 // cleaning out the user list if a list is converted from explicit to implicit.
 func (a *AccessListService) DeleteAllAccessListMembersForAccessList(ctx context.Context, accessList string) error {
-	err := a.service.RunWhileLocked(ctx, []string{accessListResourceLockName}, accessListLockTTL, func(ctx context.Context, _ backend.Backend) error {
-		return a.service.RunWhileLocked(ctx, lockName(accessList), accessListLockTTL, func(ctx context.Context, _ backend.Backend) error {
-			_, err := a.GetAccessList(ctx, accessList)
+	return a.DeleteAllAccessListMembersForAccessListV2(ctx, accesslistv1.DeleteAllAccessListMembersForAccessListRequest_builder{
+		AccessList: accessList,
+	}.Build())
+}
+
+// DeleteAllAccessListMembersForAccessListV2 hard deletes all access list members
+// for an access list. Note that deleting all members is the only member operation
+// allowed on a list with implicit membership, as it provides a mechanism for
+// cleaning out the user list if a list is converted from explicit to implicit.
+func (a *AccessListService) DeleteAllAccessListMembersForAccessListV2(ctx context.Context, req *accesslistv1.DeleteAllAccessListMembersForAccessListRequest) error {
+	accessListName := accesslists.NormalizeSQN(scopes.QualifiedName{
+		Scope: req.GetAccessListScope(),
+		Name:  req.GetAccessList(),
+	})
+	membersService, err := a.membersServiceForAccessList(accessListName)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	lockName, err := scopeAwareLockName(accessListName)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	err = a.service.RunWhileLocked(ctx, []string{accessListResourceLockName}, accessListLockTTL, func(ctx context.Context, _ backend.Backend) error {
+		return a.service.RunWhileLocked(ctx, lockName, accessListLockTTL, func(ctx context.Context, _ backend.Backend) error {
+			_, err := a.getAccessList(ctx, accessListName)
 			if err != nil {
 				return trace.Wrap(err)
 			}
 
-			allMembers, err := a.memberService.WithPrefix(accessList).GetResources(ctx)
+			allMembers, err := membersService.getResources(ctx)
 			if err != nil {
 				return trace.Wrap(err)
 			}
 
-			if err := a.memberService.WithPrefix(accessList).DeleteAllResources(ctx); err != nil {
+			if err := membersService.deleteAllResources(ctx); err != nil {
 				return trace.Wrap(err)
 			}
 
 			for _, member := range allMembers {
-				if member.Spec.MembershipKind != accesslist.MembershipKindList {
+				if !member.IsList() {
 					continue
 				}
-				if err := a.updateAccessListMemberOf(ctx, accessList, member.Spec.Name, false); err != nil {
+				memberName, err := accesslists.MemberScopeQualifiedName(member)
+				if err != nil {
+					return trace.Wrap(err)
+				}
+				if err := a.updateAccessListMemberOf(ctx, accessListName, memberName, false); err != nil {
 					return trace.Wrap(err)
 				}
 			}
@@ -818,11 +1128,12 @@ func (a *AccessListService) writeAccessList(
 }
 
 // writeAccessListWithMembers holds all of the common logic for updating and
-// upserting an access list and it's collection of members.
+// upserting an access list and its collection of members.
 func (a *AccessListService) writeAccessListWithMembers(ctx context.Context, accessList *accesslist.AccessList, membersIn []*accesslist.AccessListMember, op opType) (*accesslist.AccessList, []*accesslist.AccessListMember, error) {
 	if err := accessList.CheckAndSetDefaults(); err != nil {
 		return nil, nil, trace.Wrap(err)
 	}
+	accessListName := accesslists.ScopeQualifiedName(accessList)
 
 	for _, m := range membersIn {
 		if err := m.CheckAndSetDefaults(); err != nil {
@@ -834,7 +1145,7 @@ func (a *AccessListService) writeAccessListWithMembers(ctx context.Context, acce
 
 	validateAccessList := func() error {
 		var err error
-		existingAccessList, err = a.getAccessList(ctx, accesslists.ScopeQualifiedName(accessList))
+		existingAccessList, err = a.getAccessList(ctx, accessListName)
 		if err != nil {
 			// a not found error is totally legal for an upsert operation, but
 			// fatal for an update.
@@ -863,78 +1174,77 @@ func (a *AccessListService) writeAccessListWithMembers(ctx context.Context, acce
 	}
 
 	reconcileMembers := func() error {
-		// TODO(nklaassen): support scoped access list members.
-		if accessList.Scope != "" {
-			if len(membersIn) > 0 {
-				return trace.BadParameter("scoped access list members are not yet supported")
+		// Convert the members slice to a map for easier lookup.
+		membersMap := make(map[accesslists.NormalizedSQN]*accesslist.AccessListMember, len(membersIn))
+		for _, member := range membersIn {
+			memberName, err := accesslists.MemberScopeQualifiedName(member)
+			if err != nil {
+				return trace.Wrap(err)
 			}
-			return nil
+			membersMap[memberName] = member
 		}
 
-		// Convert the members slice to a map for easier lookup.
-		membersMap := utils.FromSlice(membersIn, types.GetName)
+		membersService, err := a.membersServiceForAccessList(accessListName)
+		if err != nil {
+			return trace.Wrap(err)
+		}
 
-		var (
-			members      []*accesslist.AccessListMember
-			membersToken string
-		)
-
-		for {
-			// List all members for the access list.
-			var err error
-			members, membersToken, err = a.memberService.WithPrefix(accessList.GetName()).ListResources(ctx, 0 /* default size */, membersToken)
+		for existingMember, err := range membersService.resources(ctx, "", "") {
 			if err != nil {
 				return trace.Wrap(err)
 			}
 
-			for _, existingMember := range members {
-				// If the member is not in the new members map (request), delete it.
-				if newMember, ok := membersMap[existingMember.GetName()]; !ok {
-					err = a.memberService.WithPrefix(accessList.GetName()).DeleteResource(ctx, existingMember.GetName())
+			existingMemberName, err := accesslists.MemberScopeQualifiedName(existingMember)
+			if err != nil {
+				return trace.Wrap(err)
+			}
+
+			memberService, err := a.memberServiceForNamedMember(accessListName, existingMemberName)
+			if err != nil {
+				return trace.Wrap(err)
+			}
+
+			// If the member is not in the new members map (request), delete it.
+			if newMember, ok := membersMap[existingMemberName]; !ok {
+				if err := memberService.delete(ctx); err != nil {
+					return trace.Wrap(err)
+				}
+				// Update memberOf field if nested list.
+				if existingMember.IsList() {
+					if err := a.updateAccessListMemberOf(ctx, accessListName, existingMemberName, false); err != nil {
+						return trace.Wrap(err)
+					}
+				}
+			} else {
+				// Preserve the membership metadata for any existing members
+				// to suppress member records flipping back and forth due
+				// due SCIM pushes or Sync Service updates.
+				if !existingMember.Spec.Expires.IsZero() {
+					newMember.Spec.Expires = existingMember.Spec.Expires
+				}
+				if existingMember.Spec.Reason != "" {
+					newMember.Spec.Reason = existingMember.Spec.Reason
+				}
+				keepAWSIdentityCenterLabels(existingMember, newMember)
+				newMember.Spec.AddedBy = existingMember.Spec.AddedBy
+
+				// Compare members and update if necessary.
+				if !newMember.IsEqual(existingMember) {
+					// Update the member.
+					upserted, err := memberService.upsert(ctx, newMember)
 					if err != nil {
 						return trace.Wrap(err)
 					}
-					// Update memberOf field if nested list.
-					if existingMember.Spec.MembershipKind == accesslist.MembershipKindList {
-						if err := a.updateAccessListMemberOf(ctx, accessList.GetName(), existingMember.GetName(), false); err != nil {
-							return trace.Wrap(err)
-						}
-					}
-				} else {
-					// Preserve the membership metadata for any existing members
-					// to suppress member records flipping back and forth due
-					// due SCIM pushes or Sync Service updates.
-					if !existingMember.Spec.Expires.IsZero() {
-						newMember.Spec.Expires = existingMember.Spec.Expires
-					}
-					if existingMember.Spec.Reason != "" {
-						newMember.Spec.Reason = existingMember.Spec.Reason
-					}
-					keepAWSIdentityCenterLabels(existingMember, newMember)
-					newMember.Spec.AddedBy = existingMember.Spec.AddedBy
 
-					// Compare members and update if necessary.
-					if !newMember.IsEqual(existingMember) {
-						// Update the member.
-						upserted, err := a.memberService.WithPrefix(accessList.GetName()).UpsertResource(ctx, newMember)
-						if err != nil {
-							return trace.Wrap(err)
-						}
-
-						existingMember.SetRevision(upserted.GetRevision())
-					}
+					existingMember.SetRevision(upserted.GetRevision())
 				}
-
-				// Remove the member from the map.
-				delete(membersMap, existingMember.GetName())
 			}
 
-			if membersToken == "" {
-				break
-			}
+			// Remove the member from the map.
+			delete(membersMap, existingMemberName)
 		}
 
-		if err := a.insertMembersAndUpdateNestedRelationships(ctx, accessList.GetName(), slices.Collect(maps.Values(membersMap))); err != nil {
+		if err := a.insertMembersAndUpdateNestedRelationships(ctx, accessListName, slices.Collect(maps.Values(membersMap))); err != nil {
 			return trace.Wrap(err)
 		}
 		return nil
@@ -985,7 +1295,7 @@ func (a *AccessListService) writeAccessListWithMembers(ctx context.Context, acce
 			if err != nil {
 				return trace.Wrap(err)
 			}
-			if err := a.updateAccessListOwnerOf(ctx, accesslists.ScopeQualifiedName(accessList), ownerName, true); err != nil {
+			if err := a.updateAccessListOwnerOf(ctx, accessListName, ownerName, true); err != nil {
 				return trace.Wrap(err)
 			}
 		}
@@ -999,7 +1309,7 @@ func (a *AccessListService) writeAccessListWithMembers(ctx context.Context, acce
 	// access lists in the cluster in order to  prevent un-authorized use of the
 	// AccessList feature
 	if !a.modules.Features().GetEntitlement(entitlements.Identity).Enabled {
-		actions = append(actions, func() error { return a.verifyAccessListCreateLimit(ctx, accesslists.ScopeQualifiedName(accessList)) })
+		actions = append(actions, func() error { return a.verifyAccessListCreateLimit(ctx, accessListName) })
 	}
 
 	// Note we need to reconcile the old owners (clean status.owner_of for the owner lists
@@ -1009,7 +1319,7 @@ func (a *AccessListService) writeAccessListWithMembers(ctx context.Context, acce
 	// interrupted as we use status.owner_of to calculate hierarchy.
 	actions = append(actions, validateAccessList, reconcileMembers, reconcileOldOwners, writeAccessList, reconcileNewOwners)
 
-	lockName, err := scopeAwareLockName(accesslists.ScopeQualifiedName(accessList))
+	lockName, err := scopeAwareLockName(accessListName)
 	if err != nil {
 		return nil, nil, trace.Wrap(err)
 	}
@@ -1116,6 +1426,11 @@ func (a *AccessListService) ListAllAccessListReviews(ctx context.Context, pageSi
 
 // CreateAccessListReview will create a new review for an access list.
 func (a *AccessListService) CreateAccessListReview(ctx context.Context, review *accesslist.Review) (*accesslist.Review, time.Time, error) {
+	if review.Scope != "" {
+		// TODO(nklaassen): support scoped access list reviews.
+		return nil, time.Time{}, trace.BadParameter("scoped access list reviews are not yet supported")
+	}
+
 	reviewName := uuid.New().String()
 	createdReview, err := accesslist.NewReview(header.Metadata{
 		Name:        reviewName,
@@ -1180,19 +1495,22 @@ func (a *AccessListService) CreateAccessListReview(ctx context.Context, review *
 		}
 		accessList.Spec.Audit.NextAuditDate = nextAuditDate
 
+		// TODO(nklaassen): support scoped access list reviews.
+		reviewedListName := accesslists.NormalizedSQN{Name: review.Spec.AccessList}
+
 		for _, removedMember := range review.Spec.Changes.RemovedMembers {
-			_, err := a.memberService.WithPrefix(review.Spec.AccessList).GetResource(ctx, removedMember)
+			_, err := a.memberService.UnscopedService.WithPrefix(review.Spec.AccessList).GetResource(ctx, removedMember)
 			if err != nil && !trace.IsNotFound(err) {
 				return trace.Wrap(err)
 			}
 			isAccessListMember := err == nil
 
 			if isAccessListMember {
-				if err := a.updateAccessListMemberOf(ctx, review.Spec.AccessList, removedMember, false); err != nil {
+				if err := a.updateAccessListMemberOf(ctx, reviewedListName, accesslists.NormalizedSQN{Name: removedMember}, false); err != nil {
 					return trace.Wrap(err)
 				}
 			}
-			if err := a.memberService.WithPrefix(review.Spec.AccessList).DeleteResource(ctx, removedMember); err != nil {
+			if err := a.memberService.UnscopedService.WithPrefix(review.Spec.AccessList).DeleteResource(ctx, removedMember); err != nil {
 				return trace.Wrap(err)
 			}
 		}
@@ -1354,7 +1672,7 @@ func (a *AccessListService) ListUserAccessLists(ctx context.Context, req *access
 	return nil, "", trace.NotImplemented("ListUserAccessLists should not be called on local service")
 }
 
-func (a *AccessListService) insertMembersAndUpdateNestedRelationships(ctx context.Context, accessListName string, members []*accesslist.AccessListMember) error {
+func (a *AccessListService) insertMembersAndUpdateNestedRelationships(ctx context.Context, accessListName accesslists.NormalizedSQN, members []*accesslist.AccessListMember) error {
 	if err := a.insertMembers(ctx, accessListName, members); err != nil {
 		return trace.Wrap(err)
 	}
@@ -1365,7 +1683,7 @@ func (a *AccessListService) insertMembersAndUpdateNestedRelationships(ctx contex
 	return nil
 }
 
-func (a *AccessListService) insertMembers(ctx context.Context, acl string, members []*accesslist.AccessListMember) error {
+func (a *AccessListService) insertMembers(ctx context.Context, acl accesslists.NormalizedSQN, members []*accesslist.AccessListMember) error {
 	items, err := a.membersToBackendItems(acl, members)
 	if err != nil {
 		return trace.Wrap(err)
@@ -1381,10 +1699,18 @@ func (a *AccessListService) insertMembers(ctx context.Context, acl string, membe
 	return nil
 }
 
-func (a *AccessListService) membersToBackendItems(acl string, members []*accesslist.AccessListMember) ([]backend.Item, error) {
+func (a *AccessListService) membersToBackendItems(acl accesslists.NormalizedSQN, members []*accesslist.AccessListMember) ([]backend.Item, error) {
 	out := make([]backend.Item, 0, len(members))
 	for _, member := range members {
-		item, err := a.memberService.WithPrefix(acl).MakeBackendItem(member)
+		memberName, err := accesslists.MemberScopeQualifiedName(member)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		memberService, err := a.memberServiceForNamedMember(acl, memberName)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		item, err := memberService.makeBackendItem(member)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
@@ -1393,13 +1719,17 @@ func (a *AccessListService) membersToBackendItems(acl string, members []*accessl
 	return out, nil
 }
 
-func (a *AccessListService) updatedMembersNestedRelationships(ctx context.Context, acl string, members []*accesslist.AccessListMember) error {
+func (a *AccessListService) updatedMembersNestedRelationships(ctx context.Context, acl accesslists.NormalizedSQN, members []*accesslist.AccessListMember) error {
 	for _, member := range members {
-		if member.Spec.MembershipKind != accesslist.MembershipKindList {
+		if !member.IsList() {
 			continue
 		}
+		memberName, err := accesslists.MemberScopeQualifiedName(member)
+		if err != nil {
+			return trace.Wrap(err)
+		}
 		// Update memberOf field if nested list.
-		if err := a.updateAccessListMemberOf(ctx, acl, member.Spec.Name, true); err != nil {
+		if err := a.updateAccessListMemberOf(ctx, acl, memberName, true); err != nil {
 			return trace.Wrap(err)
 		}
 	}
@@ -1475,21 +1805,48 @@ func (a *AccessListService) CleanupAccessListStatusV2(ctx context.Context, acces
 			return nil, trace.Wrap(ownerRefreshErr)
 		}
 
-		// TODO(nklaassen): support scoped access list members.
-		if accessListName.Scope == "" {
-			var memberRefreshErr error
-			accessList.Status.MemberOf = slices.DeleteFunc(accessList.Status.MemberOf, func(memberOf string) bool {
-				if _, err := a.memberService.WithPrefix(memberOf).GetResource(ctx, accessList.GetName()); err != nil {
-					if trace.IsNotFound(err) {
-						return true
-					}
-					memberRefreshErr = err
-				}
-				return false
-			})
-			if memberRefreshErr != nil {
-				return nil, trace.Wrap(memberRefreshErr)
+		var memberRefreshErr error
+
+		// MemberOf names unscoped access lists that this access list is supposedly a member of.
+		accessList.Status.MemberOf = slices.DeleteFunc(accessList.Status.MemberOf, func(memberOf string) bool {
+			if accessList.Scope != "" {
+				// Scoped access lists can never be members of unscoped access lists.
+				return true
 			}
+			if _, err := a.memberService.UnscopedService.WithPrefix(memberOf).GetResource(ctx, accessList.GetName()); err != nil {
+				if trace.IsNotFound(err) {
+					return true
+				}
+				memberRefreshErr = err
+			}
+			return false
+		})
+		if memberRefreshErr != nil {
+			return nil, trace.Wrap(memberRefreshErr)
+		}
+
+		// ScopedMemberOf names scoped access lists that this access list is supposedly a member of.
+		accessList.Status.ScopedMemberOf = slices.DeleteFunc(accessList.Status.ScopedMemberOf, func(scopedMemberOf string) bool {
+			parentListName, err := accesslists.ParseScopeQualifiedName(scopedMemberOf)
+			if err != nil {
+				// If we can't parse the name, it is invalid and should be removed.
+				return true
+			}
+			memberService, err := a.memberServiceForNamedMember(parentListName, accessListName)
+			if err != nil {
+				memberRefreshErr = err
+				return false
+			}
+			if _, err := memberService.get(ctx); err != nil {
+				if trace.IsNotFound(err) {
+					return true
+				}
+				memberRefreshErr = err
+			}
+			return false
+		})
+		if memberRefreshErr != nil {
+			return nil, trace.Wrap(memberRefreshErr)
 		}
 
 		accessList, err = a.service.UpdateResource(ctx, accessList)
@@ -1525,18 +1882,23 @@ func (a *AccessListService) EnsureNestedAccessListStatusesV2(ctx context.Context
 			}
 		}
 
-		// TODO(nklaassen): support scoped access list members.
-		if accessListName.Scope == "" {
-			members, err := a.memberService.WithPrefix(accessListName.Name).GetResources(ctx)
+		membersService, err := a.membersServiceForAccessList(accessListName)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+		for member, err := range membersService.resources(ctx, "", "") {
 			if err != nil {
 				return trace.Wrap(err)
 			}
-			for _, member := range members {
-				if member.Spec.MembershipKind == accesslist.MembershipKindList {
-					if err := a.updateAccessListMemberOf(ctx, accessListName.Name, member.GetName(), true); err != nil {
-						return trace.Wrap(err)
-					}
-				}
+			if !member.IsList() {
+				continue
+			}
+			memberName, err := accesslists.MemberScopeQualifiedName(member)
+			if err != nil {
+				return trace.Wrap(err)
+			}
+			if err := a.updateAccessListMemberOf(ctx, accessListName, memberName, true); err != nil {
+				return trace.Wrap(err)
 			}
 		}
 
@@ -1591,8 +1953,9 @@ func (a *AccessListService) collectionToBackendItemsIter(collection *accesslists
 				yield(backend.Item{}, trace.NotFound("access list %q not found", aclName))
 				return
 			}
+			// TODO(nklaassen): support collections of scoped access lists.
 			for _, member := range members {
-				item, err := a.memberService.WithPrefix(member.Spec.AccessList).MakeBackendItem(member)
+				item, err := a.memberService.UnscopedService.WithPrefix(member.Spec.AccessList).MakeBackendItem(member)
 				if err != nil {
 					yield(backend.Item{}, trace.Wrap(err))
 					return
@@ -1649,28 +2012,36 @@ func (a *AccessListService) checkDeletionBlockingRelationships(ctx context.Conte
 
 // checkDeletionBlockingMemberRelationships checks if the access list is a member of any other access lists that would block deletion
 func (a *AccessListService) checkDeletionBlockingMemberRelationships(ctx context.Context, accessList *accesslist.AccessList) error {
-	memberOf := accessList.GetStatus().MemberOf
-	if len(memberOf) == 0 {
+	accessListName := accesslists.ScopeQualifiedName(accessList)
+	allParentLists, err := accesslists.AllParentLists(accessList)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	if len(allParentLists) == 0 {
 		return nil
 	}
 
-	memberOfTitles := make([]string, 0, len(memberOf))
-	for _, memberOf := range memberOf {
-		parentList, err := a.GetAccessList(ctx, memberOf)
+	memberOfTitles := make([]string, 0, len(allParentLists))
+	for _, parentListName := range allParentLists {
+		parentList, err := a.getAccessList(ctx, parentListName)
 		if err != nil {
 			if trace.IsNotFound(err) {
 				continue
 			}
-			return trace.Wrap(err, `fetching parent list "%s"`, memberOf)
+			return trace.Wrap(err, `fetching parent list "%s"`, parentListName)
 		}
-		member, err := a.memberService.WithPrefix(parentList.GetName()).GetResource(ctx, accessList.GetName())
+		memberService, err := a.memberServiceForNamedMember(parentListName, accessListName)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+		member, err := memberService.get(ctx)
 		if err != nil {
 			if trace.IsNotFound(err) {
 				continue
 			}
-			return trace.Wrap(err, `fetching access list member for "%s"`, memberOf)
+			return trace.Wrap(err, `fetching access list member for "%s"`, parentListName.String())
 		}
-		if member.Spec.MembershipKind == accesslist.MembershipKindList {
+		if member.IsList() {
 			memberOfTitles = append(memberOfTitles, parentList.Spec.Title)
 		}
 	}

--- a/lib/services/local/access_list_test.go
+++ b/lib/services/local/access_list_test.go
@@ -837,109 +837,134 @@ func getAccessListMembers(t *testing.T, service *AccessListService, listName str
 	return members
 }
 
+// getScopedAccessListMembers fetches the current list of members for the given access
+// list, sorted by name
+func getScopedAccessListMembers(t *testing.T, service *AccessListService, listName scopes.QualifiedName) []*accesslist.AccessListMember {
+	getPage := func(ctx context.Context, pageSize int, pageToken string) ([]*accesslist.AccessListMember, string, error) {
+		return service.ListAccessListMembersV2(ctx, accesslistv1.ListAccessListMembersRequest_builder{
+			AccessListScope: listName.Scope,
+			AccessList:      listName.Name,
+			PageSize:        int32(pageSize),
+			PageToken:       pageToken,
+		}.Build())
+	}
+	members, err := stream.Collect(clientutils.Resources(t.Context(), getPage))
+	require.NoError(t, err)
+	return members
+}
+
 type writeAccessListWithMembersFn func(context.Context, *accesslist.AccessList, []*accesslist.AccessListMember) (*accesslist.AccessList, []*accesslist.AccessListMember, error)
 
 func testAddAndRemoveAccessListMembers(t *testing.T, service *AccessListService, clock clockwork.Clock, fnUnderTest writeAccessListWithMembersFn) {
-	t.Run("add and remove members", func(t *testing.T) {
-		const listName = "test-add-members-list"
-		t.Cleanup(deleteAllAccessLists(t, service))
-		ctx := t.Context()
+	for _, listName := range []scopes.QualifiedName{
+		{Name: "test-add-member-list"},
+		{Scope: "/test", Name: "test-scoped-add-member-list"},
+	} {
+		t.Run("add and remove members "+listName.String(), func(t *testing.T) {
+			t.Cleanup(deleteAllAccessLists(t, service))
+			ctx := t.Context()
 
-		toAccessListMember := func(name string) *accesslist.AccessListMember {
-			return newAccessListMember(t, listName, name)
-		}
+			toAccessListMember := func(name string) *accesslist.AccessListMember {
+				return newScopedAccessListMember(t, listName, scopes.QualifiedName{Name: name})
+			}
 
-		cmpOpts := []cmp.Option{
-			cmpopts.IgnoreFields(header.Metadata{}, "Revision"),
-			cmpopts.EquateEmpty(),
-		}
+			cmpOpts := []cmp.Option{
+				cmpopts.IgnoreFields(header.Metadata{}, "Revision"),
+				cmpopts.EquateEmpty(),
+			}
 
-		// GIVEN an existing Access List
-		acl, err := service.UpsertAccessList(ctx, newAccessList(t, listName, clock))
-		require.NoError(t, err)
-
-		var expectedMemberNames []string
-		for _, memberName := range []string{"alice", "bob", "carol", "dave"} {
-			expectedMemberNames = append(expectedMemberNames, memberName)
-			members := sliceutils.Map(expectedMemberNames, toAccessListMember)
-
-			// WHEN I update the Access List to have one or more users,
-			// EXPECT that the operation succeeds and all member are present
-			// in both the returned member list and in the backend service
-			updatedACL, updatedMembers, err := fnUnderTest(ctx, acl, members)
+			// GIVEN an existing Access List
+			acl, err := service.UpsertAccessList(ctx, newScopedAccessList(t, listName, clock))
 			require.NoError(t, err)
-			require.Empty(t, cmp.Diff(acl, updatedACL, cmpOpts...))
-			require.Empty(t, cmp.Diff(members, updatedMembers, cmpOpts...))
 
-			backendMembers := getAccessListMembers(t, service, listName)
-			require.Empty(t, cmp.Diff(members, backendMembers, cmpOpts...))
-		}
+			var expectedMemberNames []string
+			for _, memberName := range []string{"alice", "bob", "carol", "dave"} {
+				expectedMemberNames = append(expectedMemberNames, memberName)
+				members := sliceutils.Map(expectedMemberNames, toAccessListMember)
 
-		for len(expectedMemberNames) > 0 {
-			expectedMemberNames = expectedMemberNames[1:]
-			members := sliceutils.Map(expectedMemberNames, toAccessListMember)
+				// WHEN I update the Access List to have one or more users,
+				// EXPECT that the operation succeeds and all member are present
+				// in both the returned member list and in the backend service
+				updatedACL, updatedMembers, err := fnUnderTest(ctx, acl, members)
+				require.NoError(t, err)
+				require.Empty(t, cmp.Diff(acl, updatedACL, cmpOpts...))
+				require.Empty(t, cmp.Diff(members, updatedMembers, cmpOpts...))
 
-			// WHEN I update the Access List to remove a user, EXPECT that
-			// the operation succeeds and that only the expected members
-			// are present in the returned member list and in the backend
-			// service
-			updatedACL, updatedMembers, err := fnUnderTest(ctx, acl, members)
-			require.NoError(t, err)
-			require.Empty(t, cmp.Diff(acl, updatedACL, cmpOpts...))
-			require.Empty(t, cmp.Diff(members, updatedMembers, cmpOpts...))
+				backendMembers := getScopedAccessListMembers(t, service, listName)
+				require.Empty(t, cmp.Diff(members, backendMembers, cmpOpts...))
+			}
 
-			backendMembers := getAccessListMembers(t, service, listName)
-			require.Empty(t, cmp.Diff(members, backendMembers, cmpOpts...))
-		}
-	})
+			for len(expectedMemberNames) > 0 {
+				expectedMemberNames = expectedMemberNames[1:]
+				members := sliceutils.Map(expectedMemberNames, toAccessListMember)
+
+				// WHEN I update the Access List to remove a user, EXPECT that
+				// the operation succeeds and that only the expected members
+				// are present in the returned member list and in the backend
+				// service
+				updatedACL, updatedMembers, err := fnUnderTest(ctx, acl, members)
+				require.NoError(t, err)
+				require.Empty(t, cmp.Diff(acl, updatedACL, cmpOpts...))
+				require.Empty(t, cmp.Diff(members, updatedMembers, cmpOpts...))
+
+				backendMembers := getScopedAccessListMembers(t, service, listName)
+				require.Empty(t, cmp.Diff(members, backendMembers, cmpOpts...))
+			}
+
+		})
+	}
 }
 
 func testSetEmptyAccessListMembers(t *testing.T, service *AccessListService, clock clockwork.Clock, fnUnderTest writeAccessListWithMembersFn) {
-	t.Run("setting empty member list deletes members", func(t *testing.T) {
-		ctx := t.Context()
+	for _, listName := range []scopes.QualifiedName{
+		{Name: "test-add-member-list"},
+		{Scope: "/test", Name: "test-scoped-add-member-list"},
+	} {
+		t.Run("setting empty member list deletes members "+listName.String(), func(t *testing.T) {
+			ctx := t.Context()
 
-		emptyLists := []struct {
-			name  string
-			value []*accesslist.AccessListMember
-		}{
-			{
-				name:  "nil",
-				value: nil,
-			},
-			{
-				name:  "zero-length",
-				value: []*accesslist.AccessListMember{},
-			},
-		}
+			emptyLists := []struct {
+				name  string
+				value []*accesslist.AccessListMember
+			}{
+				{
+					name:  "nil",
+					value: nil,
+				},
+				{
+					name:  "zero-length",
+					value: []*accesslist.AccessListMember{},
+				},
+			}
 
-		for _, emptyList := range emptyLists {
-			t.Run(emptyList.name, func(t *testing.T) {
-				t.Cleanup(deleteAllAccessLists(t, service))
-				listName := "test-set-empty-members-list" + emptyList.name
+			for _, emptyList := range emptyLists {
+				t.Run(emptyList.name, func(t *testing.T) {
+					t.Cleanup(deleteAllAccessLists(t, service))
 
-				// GIVEN an access list with several members...
-				acl, _, err := service.UpsertAccessListWithMembers(ctx,
-					newAccessList(t, listName, clock),
-					[]*accesslist.AccessListMember{
-						newAccessListMember(t, listName, "alice"),
-						newAccessListMember(t, listName, "bob"),
-						newAccessListMember(t, listName, "carol"),
-						newAccessListMember(t, listName, "dave"),
-					})
-				require.NoError(t, err)
-				require.Len(t, getAccessListMembers(t, service, listName), 4)
+					// GIVEN an access list with several members...
+					acl, _, err := service.UpsertAccessListWithMembers(ctx,
+						newScopedAccessList(t, listName, clock),
+						[]*accesslist.AccessListMember{
+							newScopedAccessListMember(t, listName, scopes.QualifiedName{Name: "alice"}),
+							newScopedAccessListMember(t, listName, scopes.QualifiedName{Name: "bob"}),
+							newScopedAccessListMember(t, listName, scopes.QualifiedName{Name: "carol"}),
+							newScopedAccessListMember(t, listName, scopes.QualifiedName{Name: "dave"}),
+						})
+					require.NoError(t, err)
+					require.Len(t, getScopedAccessListMembers(t, service, listName), 4)
 
-				// WHEN I update it with an empty member list
-				_, members, err := fnUnderTest(ctx, acl, emptyList.value)
-				require.NoError(t, err)
+					// WHEN I update it with an empty member list
+					_, members, err := fnUnderTest(ctx, acl, emptyList.value)
+					require.NoError(t, err)
 
-				// EXPECT that both the returned member list and the member
-				// collection from the backend are empty
-				require.Empty(t, members)
-				require.Empty(t, getAccessListMembers(t, service, listName))
-			})
-		}
-	})
+					// EXPECT that both the returned member list and the member
+					// collection from the backend are empty
+					require.Empty(t, members)
+					require.Empty(t, getScopedAccessListMembers(t, service, listName))
+				})
+			}
+		})
+	}
 }
 
 func TestUpsertAccessListWithMembers(t *testing.T) {
@@ -1318,6 +1343,145 @@ func TestAccessListMembersCRUD(t *testing.T) {
 	require.ErrorIs(t, err, trace.NotFound("access_list %q doesn't exist", accessList2.GetName()))
 }
 
+func TestAccessListMembersCRUDScoped(t *testing.T) {
+	ctx := t.Context()
+	clock := clockwork.NewFakeClock()
+
+	mem, err := memory.New(memory.Config{
+		Context: ctx,
+		Clock:   clock,
+	})
+	require.NoError(t, err)
+
+	service := newAccessListService(t, mem, modulestest.EnterpriseModules())
+
+	cmpOpts := []cmp.Option{
+		cmpopts.IgnoreFields(header.Metadata{}, "Revision"),
+		cmpopts.EquateEmpty(),
+	}
+
+	t.Run("scoped parent separates unscoped and scoped members with the same name", func(t *testing.T) {
+		t.Cleanup(deleteAllAccessLists(t, service))
+
+		getAccessListMemberRequest := func(listName, memberName scopes.QualifiedName) *accesslistv1.GetAccessListMemberRequest {
+			return accesslistv1.GetAccessListMemberRequest_builder{
+				AccessListScope: listName.Scope,
+				AccessList:      listName.Name,
+				MemberScope:     memberName.Scope,
+				MemberName:      memberName.Name,
+			}.Build()
+		}
+
+		parentName := scopes.QualifiedName{Scope: "/eng/platform", Name: "parent"}
+		unscopedChildName := scopes.QualifiedName{Name: "team"}
+		scopedChildName := scopes.QualifiedName{Scope: "/eng", Name: "team"}
+
+		parent, err := service.UpsertAccessList(ctx, newScopedAccessList(t, parentName, clock))
+		require.NoError(t, err)
+		_, err = service.UpsertAccessList(ctx, newScopedAccessList(t, unscopedChildName, clock))
+		require.NoError(t, err)
+		_, err = service.UpsertAccessList(ctx, newScopedAccessList(t, scopedChildName, clock))
+		require.NoError(t, err)
+
+		unscopedChildMember := newScopedAccessListMember(t, parentName, unscopedChildName, withMembershipKind(accesslist.MembershipKindList))
+		scopedChildMember := newScopedAccessListMember(t, parentName, scopedChildName, withMembershipKind(accesslist.MembershipKindScopedList))
+		userMember := newScopedAccessListMember(t, parentName, scopes.QualifiedName{Name: "alice"}, withMembershipKind(accesslist.MembershipKindUser))
+		expectedMembers := []*accesslist.AccessListMember{userMember, unscopedChildMember, scopedChildMember}
+
+		_, returnedMembers, err := service.UpsertAccessListWithMembers(ctx, parent, expectedMembers)
+		require.NoError(t, err)
+		require.Empty(t, cmp.Diff(expectedMembers, returnedMembers, cmpOpts...))
+
+		gotUnscoped, err := service.GetAccessListMemberV2(ctx, getAccessListMemberRequest(parentName, unscopedChildName))
+		require.NoError(t, err)
+		require.Empty(t, cmp.Diff(unscopedChildMember, gotUnscoped, cmpOpts...))
+
+		gotScoped, err := service.GetAccessListMemberV2(ctx, getAccessListMemberRequest(parentName, scopedChildName))
+		require.NoError(t, err)
+		require.Empty(t, cmp.Diff(scopedChildMember, gotScoped, cmpOpts...))
+
+		users, lists, err := service.CountAccessListMembersV2(ctx, accesslistv1.CountAccessListMembersRequest_builder{
+			AccessListScope: parentName.Scope,
+			AccessListName:  parentName.Name,
+		}.Build())
+		require.NoError(t, err)
+		require.Equal(t, uint32(1), users)
+		require.Equal(t, uint32(2), lists)
+
+		var paginatedMembers []*accesslist.AccessListMember
+		req := accesslistv1.ListAccessListMembersRequest_builder{
+			AccessListScope: parentName.Scope,
+			AccessList:      parentName.Name,
+			PageSize:        1,
+		}.Build()
+		for {
+			members, next, err := service.ListAccessListMembersV2(ctx, req)
+			require.NoError(t, err)
+			paginatedMembers = append(paginatedMembers, members...)
+			if next == "" {
+				break
+			}
+			req.SetPageToken(next)
+		}
+		require.Empty(t, cmp.Diff(expectedMembers, paginatedMembers, append(cmpOpts, cmpopts.SortSlices(func(a, b *accesslist.AccessListMember) bool {
+			// Access list member metadata names are scope-qualified for scoped-list members,
+			// so this orders by the same identity used in the backend key
+			return a.GetName() < b.GetName()
+		}))...))
+
+		err = service.DeleteAccessListMemberV2(ctx, accesslistv1.DeleteAccessListMemberRequest_builder{
+			AccessListScope: parentName.Scope,
+			AccessList:      parentName.Name,
+			MemberScope:     unscopedChildName.Scope,
+			MemberName:      unscopedChildName.Name,
+		}.Build())
+		require.NoError(t, err)
+		_, err = service.GetAccessListMemberV2(ctx, getAccessListMemberRequest(parentName, unscopedChildName))
+		require.True(t, trace.IsNotFound(err), "expected not found error, got %v", err)
+		_, err = service.GetAccessListMemberV2(ctx, getAccessListMemberRequest(parentName, scopedChildName))
+		require.NoError(t, err)
+
+		_, returnedMembers, err = service.UpsertAccessListWithMembers(ctx, parent, []*accesslist.AccessListMember{userMember, unscopedChildMember})
+		require.NoError(t, err)
+		require.Empty(t, cmp.Diff([]*accesslist.AccessListMember{userMember, unscopedChildMember}, returnedMembers, cmpOpts...))
+		_, err = service.GetAccessListMemberV2(ctx, getAccessListMemberRequest(parentName, scopedChildName))
+		require.True(t, trace.IsNotFound(err), "expected not found error, got %v", err)
+		_, err = service.GetAccessListMemberV2(ctx, getAccessListMemberRequest(parentName, unscopedChildName))
+		require.NoError(t, err)
+	})
+
+	t.Run("old member APIs only see unscoped lists and members", func(t *testing.T) {
+		t.Cleanup(deleteAllAccessLists(t, service))
+
+		unscopedParentName := scopes.QualifiedName{Name: "parent"}
+		scopedParentName := scopes.QualifiedName{Scope: "/eng", Name: "parent"}
+
+		unscopedParent, err := service.UpsertAccessList(ctx, newScopedAccessList(t, unscopedParentName, clock))
+		require.NoError(t, err)
+		scopedParent, err := service.UpsertAccessList(ctx, newScopedAccessList(t, scopedParentName, clock))
+		require.NoError(t, err)
+
+		unscopedMember := newScopedAccessListMember(t, unscopedParentName, scopes.QualifiedName{Name: "alice"}, withMembershipKind(accesslist.MembershipKindUser))
+		scopedMember := newScopedAccessListMember(t, scopedParentName, scopes.QualifiedName{Name: "bob"}, withMembershipKind(accesslist.MembershipKindUser))
+		_, _, err = service.UpsertAccessListWithMembers(ctx, unscopedParent, []*accesslist.AccessListMember{unscopedMember})
+		require.NoError(t, err)
+		_, _, err = service.UpsertAccessListWithMembers(ctx, scopedParent, []*accesslist.AccessListMember{scopedMember})
+		require.NoError(t, err)
+
+		members, _, err := service.ListAccessListMembers(ctx, unscopedParentName.Name, 0, "")
+		require.NoError(t, err)
+		require.Empty(t, cmp.Diff([]*accesslist.AccessListMember{unscopedMember}, members, cmpOpts...))
+
+		_, err = service.GetAccessListMember(ctx, unscopedParentName.Name, scopedMember.GetName())
+		require.True(t, trace.IsNotFound(err), "expected not found error, got %v", err)
+
+		users, lists, err := service.CountAccessListMembers(ctx, unscopedParentName.Name)
+		require.NoError(t, err)
+		require.Equal(t, uint32(1), users)
+		require.Equal(t, uint32(0), lists)
+	})
+}
+
 func Test_AccessListMember_Validation(t *testing.T) {
 	ctx := context.Background()
 	clock := clockwork.NewFakeClock()
@@ -1414,7 +1578,6 @@ func runAccessListMemberValidationSuite(
 	makeBad, makeGood func(*accesslist.AccessListMember),
 	errorCheck func(t *testing.T, err error),
 ) {
-	t.Helper()
 	ctx := context.Background()
 
 	makeBad(member)
@@ -1905,6 +2068,10 @@ func withMemberRequires(requires accesslist.Requires) newAccessListOpt {
 }
 
 func newAccessList(t *testing.T, name string, clock clockwork.Clock, opts ...newAccessListOpt) *accesslist.AccessList {
+	return newScopedAccessList(t, scopes.QualifiedName{Name: name}, clock, opts...)
+}
+
+func newScopedAccessList(t *testing.T, name scopes.QualifiedName, clock clockwork.Clock, opts ...newAccessListOpt) *accesslist.AccessList {
 	t.Helper()
 
 	options := newAccessListOptions{
@@ -1918,20 +2085,22 @@ func newAccessList(t *testing.T, name string, clock clockwork.Clock, opts ...new
 				Description: "test user 2",
 			},
 		},
-		memberRequires: accesslist.Requires{
+	}
+	if name.Scope == "" {
+		options.memberRequires = accesslist.Requires{
 			Roles: []string{"mrole1", "mrole2"},
 			Traits: map[string][]string{
 				"mtrait1": {"mvalue1", "mvalue2"},
 				"mtrait2": {"mvalue3", "mvalue4"},
 			},
-		},
-		ownerRequires: accesslist.Requires{
+		}
+		options.ownerRequires = accesslist.Requires{
 			Roles: []string{"orole1", "orole2"},
 			Traits: map[string][]string{
 				"otrait1": {"ovalue1", "ovalue2"},
 				"otrait2": {"ovalue3", "ovalue4"},
 			},
-		},
+		}
 	}
 	for _, o := range opts {
 		o(&options)
@@ -1942,28 +2111,35 @@ func newAccessList(t *testing.T, name string, clock clockwork.Clock, opts ...new
 		audit.NextAuditDate = clock.Now()
 	}
 
-	accessList, err := accesslist.NewAccessList(
+	accessList, err := accesslist.NewAccessListWithScope(
 		header.Metadata{
-			Name: name,
+			Name: name.Name,
 		},
 		accesslist.Spec{
 			Type:               options.typ,
-			Title:              name + " title",
+			Title:              name.String() + " title",
 			Description:        "test access list",
 			Owners:             options.owners,
 			Audit:              audit,
 			MembershipRequires: options.memberRequires,
 			OwnershipRequires:  options.ownerRequires,
-			Grants: accesslist.Grants{
-				Roles: []string{"grole1", "grole2"},
-				Traits: map[string][]string{
-					"gtrait1": {"gvalue1", "gvalue2"},
-					"gtrait2": {"gvalue3", "gvalue4"},
-				},
-			},
 		},
+		name.Scope,
 	)
 	require.NoError(t, err)
+
+	if name.Scope == "" {
+		accessList.Spec.Grants.Roles = []string{"grole1", "grole2"}
+		accessList.Spec.Grants.Traits = map[string][]string{
+			"gtrait1": {"gvalue1", "gvalue2"},
+			"gtrait2": {"gvalue3", "gvalue4"},
+		}
+	} else {
+		accessList.Spec.Grants.ScopedRoles = []accesslist.ScopedRoleGrant{
+			{Role: "gscopedrole1", Scope: name.Scope},
+			{Role: "gscopedrole2", Scope: name.Scope},
+		}
+	}
 
 	return accessList
 }
@@ -2023,6 +2199,36 @@ func newAccessListMember(t *testing.T, accessList, name string, opts ...accessLi
 			AddedBy:        "dummy",
 			MembershipKind: options.membershipKind,
 		},
+	)
+	require.NoError(t, err)
+
+	return member
+}
+
+func newScopedAccessListMember(t *testing.T, accessList, memberName scopes.QualifiedName, opts ...accessListMemberOpt) *accesslist.AccessListMember {
+	t.Helper()
+
+	options := accessListMemberOptions{
+		expires: time.Now().Add(time.Hour * 24),
+	}
+	for _, o := range opts {
+		o(&options)
+	}
+
+	member, err := accesslist.NewAccessListMemberWithScope(
+		header.Metadata{
+			Name: memberName.String(),
+		},
+		accesslist.AccessListMemberSpec{
+			AccessList:     accessList.String(),
+			Name:           memberName.String(),
+			Joined:         time.Now(),
+			Expires:        options.expires,
+			Reason:         "a reason",
+			AddedBy:        "dummy",
+			MembershipKind: options.membershipKind,
+		},
+		accessList.Scope,
 	)
 	require.NoError(t, err)
 
@@ -2501,7 +2707,7 @@ func TestAccessListService_Status_MemberOf(t *testing.T) {
 
 		requireStatusMemberOf(t, service, nestedAccessList.GetName(), []string{accessList.GetName()})
 
-		err = service.updateAccessListMemberOf(ctx, accessList.GetName(), nestedAccessList.GetName(), false /* new - this will delete */)
+		err = service.updateAccessListMemberOf(ctx, accesslists.ScopeQualifiedName(accessList), accesslists.ScopeQualifiedName(nestedAccessList), false /* new - this will delete */)
 		require.NoError(t, err)
 		requireStatusMemberOf(t, service, nestedAccessList.GetName(), []string{})
 
@@ -2509,13 +2715,76 @@ func TestAccessListService_Status_MemberOf(t *testing.T) {
 		require.NoError(t, err)
 		requireStatusMemberOf(t, service, nestedAccessList.GetName(), []string{accessList.GetName()})
 
-		err = service.updateAccessListMemberOf(ctx, accessList.GetName(), nestedAccessList.GetName(), false /* new - this will delete */)
+		err = service.updateAccessListMemberOf(ctx, accesslists.ScopeQualifiedName(accessList), accesslists.ScopeQualifiedName(nestedAccessList), false /* new - this will delete */)
 		require.NoError(t, err)
 		requireStatusMemberOf(t, service, nestedAccessList.GetName(), []string{})
 
 		_, err = service.UpsertAccessListMember(ctx, updatedMember)
 		require.NoError(t, err)
 		requireStatusMemberOf(t, service, nestedAccessList.GetName(), []string{accessList.GetName()})
+	})
+
+	t.Run("scoped parent updates scoped_member_of for scoped and unscoped child lists", func(t *testing.T) {
+		suffix := uuid.NewString()[:8]
+		parentName := scopes.QualifiedName{Scope: "/eng/platform", Name: "acl-" + suffix}
+		unscopedChildName := scopes.QualifiedName{Name: "child-u-" + suffix}
+		scopedChildName := scopes.QualifiedName{Scope: "/eng", Name: "child-s-" + suffix}
+		parentRef := parentName.String()
+
+		_, err = service.UpsertAccessList(ctx, newScopedAccessList(t, parentName, clock))
+		require.NoError(t, err)
+		_, err = service.UpsertAccessList(ctx, newScopedAccessList(t, unscopedChildName, clock))
+		require.NoError(t, err)
+		_, err = service.UpsertAccessList(ctx, newScopedAccessList(t, scopedChildName, clock))
+		require.NoError(t, err)
+
+		unscopedMember, err := service.UpsertAccessListMember(ctx, newScopedAccessListMember(t,
+			parentName,
+			unscopedChildName,
+			withMembershipKind(accesslist.MembershipKindList),
+		))
+		require.NoError(t, err)
+		scopedMember, err := service.UpsertAccessListMember(ctx, newScopedAccessListMember(t,
+			parentName,
+			scopedChildName,
+			withMembershipKind(accesslist.MembershipKindScopedList),
+		))
+		require.NoError(t, err)
+
+		requireStatusMemberOfV2(t, service, unscopedChildName, nil)
+		requireStatusScopedMemberOf(t, service, unscopedChildName, []string{parentRef})
+		requireStatusMemberOfV2(t, service, scopedChildName, nil)
+		requireStatusScopedMemberOf(t, service, scopedChildName, []string{parentRef})
+
+		unscopedMember, err = service.UpdateAccessListMember(ctx, unscopedMember)
+		require.NoError(t, err)
+		scopedMember, err = service.UpdateAccessListMember(ctx, scopedMember)
+		require.NoError(t, err)
+		requireStatusScopedMemberOf(t, service, unscopedChildName, []string{parentRef})
+		requireStatusScopedMemberOf(t, service, scopedChildName, []string{parentRef})
+
+		_, err = service.UpsertAccessListMember(ctx, unscopedMember)
+		require.NoError(t, err)
+		_, err = service.UpsertAccessListMember(ctx, scopedMember)
+		require.NoError(t, err)
+		requireStatusScopedMemberOf(t, service, unscopedChildName, []string{parentRef})
+		requireStatusScopedMemberOf(t, service, scopedChildName, []string{parentRef})
+
+		err = service.DeleteAccessListMemberV2(ctx, accesslistv1.DeleteAccessListMemberRequest_builder{
+			AccessListScope: parentName.Scope,
+			AccessList:      parentName.Name,
+			MemberName:      unscopedChildName.Name,
+		}.Build())
+		require.NoError(t, err)
+		requireStatusScopedMemberOf(t, service, unscopedChildName, nil)
+		requireStatusScopedMemberOf(t, service, scopedChildName, []string{parentRef})
+
+		err = service.DeleteAllAccessListMembersForAccessListV2(ctx, accesslistv1.DeleteAllAccessListMembersForAccessListRequest_builder{
+			AccessListScope: parentName.Scope,
+			AccessList:      parentName.Name,
+		}.Build())
+		require.NoError(t, err)
+		requireStatusScopedMemberOf(t, service, scopedChildName, nil)
 	})
 }
 
@@ -2563,7 +2832,7 @@ func TestAccessListService_CleanupAccessListStatus(t *testing.T) {
 	service.service.UnscopedService.DeleteResource(ctx, a3)
 	a4List.Spec.Owners = []accesslist.Owner{userOwner} // remove a1Owner
 	service.service.UnscopedService.UpdateResource(ctx, a4List)
-	service.memberService.WithPrefix(a6).DeleteResource(ctx, a1)
+	service.memberService.UnscopedService.WithPrefix(a6).DeleteResource(ctx, a1)
 
 	// Let's check the status remain untouched:
 	// - a3 should be removed from owner_of because it doesn't exist anymore
@@ -2591,7 +2860,7 @@ func TestAccessListService_CleanupAccessListStatus(t *testing.T) {
 	a2List := getAccessList(t, service, a2)
 	a2List.Spec.Owners = []accesslist.Owner{userOwner} // remove a1Owner
 	service.service.UnscopedService.UpdateResource(ctx, a2List)
-	service.memberService.WithPrefix(a5).DeleteResource(ctx, a1)
+	service.memberService.UnscopedService.WithPrefix(a5).DeleteResource(ctx, a1)
 
 	// Verify the status is broken now as it should be empty
 	requireStatusOwnerOf(t, service, a1, []string{a2})
@@ -2737,6 +3006,10 @@ type testAccessListGetter interface {
 	GetAccessList(ctx context.Context, name string) (*accesslist.AccessList, error)
 }
 
+type testAccessListGetterV2 interface {
+	GetAccessListV2(ctx context.Context, req *accesslistv1.GetAccessListRequest) (*accesslist.AccessList, error)
+}
+
 type testAccessListGetterFunc func(ctx context.Context, name string) (*accesslist.AccessList, error)
 
 func (fn testAccessListGetterFunc) GetAccessList(ctx context.Context, name string) (*accesslist.AccessList, error) {
@@ -2748,8 +3021,6 @@ func requireStatusOwnerOf(t *testing.T, service testAccessListGetter, accessList
 	ctx := context.Background()
 	accessList, err := service.GetAccessList(ctx, accessListName)
 	require.NoError(t, err)
-	slices.Sort(ownerOf)
-	slices.Sort(accessList.Status.OwnerOf)
 	require.ElementsMatch(t, ownerOf, accessList.Status.OwnerOf)
 }
 
@@ -2758,9 +3029,29 @@ func requireStatusMemberOf(t *testing.T, service testAccessListGetter, accessLis
 	ctx := context.Background()
 	accessList, err := service.GetAccessList(ctx, accessListName)
 	require.NoError(t, err)
-	slices.Sort(memberOf)
-	slices.Sort(accessList.Status.MemberOf)
 	require.ElementsMatch(t, memberOf, accessList.Status.MemberOf)
+}
+
+func requireStatusMemberOfV2(t *testing.T, service testAccessListGetterV2, accessListName scopes.QualifiedName, memberOf []string) {
+	t.Helper()
+	ctx := context.Background()
+	accessList, err := service.GetAccessListV2(ctx, accesslistv1.GetAccessListRequest_builder{
+		Scope: accessListName.Scope,
+		Name:  accessListName.Name,
+	}.Build())
+	require.NoError(t, err)
+	require.ElementsMatch(t, memberOf, accessList.Status.MemberOf)
+}
+
+func requireStatusScopedMemberOf(t *testing.T, service testAccessListGetterV2, accessListName scopes.QualifiedName, memberOf []string) {
+	t.Helper()
+	ctx := context.Background()
+	accessList, err := service.GetAccessListV2(ctx, accesslistv1.GetAccessListRequest_builder{
+		Scope: accessListName.Scope,
+		Name:  accessListName.Name,
+	}.Build())
+	require.NoError(t, err)
+	require.ElementsMatch(t, memberOf, accessList.Status.ScopedMemberOf)
 }
 
 func newAccessListService(t *testing.T, b backend.Backend, m *modulestest.Modules) *AccessListService {
@@ -2769,6 +3060,9 @@ func newAccessListService(t *testing.T, b backend.Backend, m *modulestest.Module
 	service, err := NewAccessListServiceV2(AccessListServiceConfig{
 		Backend: backend.NewSanitizer(b),
 		Modules: m,
+		ScopesFeatures: scopes.Features{
+			Enabled: true,
+		},
 	})
 	require.NoError(t, err)
 
@@ -2910,15 +3204,15 @@ func TestInsertAccessListCollection(t *testing.T) {
 		require.NoError(t, err)
 		require.Len(t, acls, 3)
 
-		allMembers1, err := service.memberService.WithPrefix(list1.GetName()).GetResources(ctx)
+		allMembers1, err := service.memberService.UnscopedService.WithPrefix(list1.GetName()).GetResources(ctx)
 		require.NoError(t, err)
 		require.Len(t, allMembers1, 500)
 
-		allMembers2, err := service.memberService.WithPrefix(list2.GetName()).GetResources(ctx)
+		allMembers2, err := service.memberService.UnscopedService.WithPrefix(list2.GetName()).GetResources(ctx)
 		require.NoError(t, err)
 		require.Len(t, allMembers2, 600)
 
-		allMembers3, err := service.memberService.WithPrefix(list3.GetName()).GetResources(ctx)
+		allMembers3, err := service.memberService.UnscopedService.WithPrefix(list3.GetName()).GetResources(ctx)
 		require.NoError(t, err)
 		require.Len(t, allMembers3, 400)
 	})
@@ -3092,7 +3386,7 @@ func TestAccessListDeletePrevention_MissingReferences(t *testing.T) {
 			for _, parent := range related {
 				err := service.service.UnscopedService.DeleteResource(ctx, parent.GetName())
 				require.NoError(t, err)
-				err = service.memberService.WithPrefix(parent.GetName()).DeleteAllResources(ctx)
+				err = service.memberService.UnscopedService.WithPrefix(parent.GetName()).DeleteAllResources(ctx)
 				require.NoError(t, err)
 			}
 		},
@@ -3124,7 +3418,7 @@ func TestAccessListDeletePrevention_MissingReferences(t *testing.T) {
 			for _, owned := range related {
 				err := service.service.UnscopedService.DeleteResource(ctx, owned.GetName())
 				require.NoError(t, err)
-				err = service.memberService.WithPrefix(owned.GetName()).DeleteAllResources(ctx)
+				err = service.memberService.UnscopedService.WithPrefix(owned.GetName()).DeleteAllResources(ctx)
 				require.NoError(t, err)
 			}
 		},


### PR DESCRIPTION
Part of [RFD 308](https://github.com/gravitational/rfd/pull/22)

This PR adds backend support for members of scoped access lists. Following the design in the RFD, a member of a scoped access list may be a user, and unscoped access list, or a scoped access list at a scope that is equal or ancestor to the parent list.

The implementation supports basic CRUD backend operations for members of scoped access lists, with full validation. Membership checks and hierarchy traversals are also updated to support scoped members.

The main limitation is that `ListAllAccessListMembers` will _not_ list any members of scoped access lists, until we decide how to handle this for mixed-scope resources in general https://github.com/gravitational/rfd/pull/36#discussion_r3423045629

This also does not include cache or event support, which will come in a later PR.

Parent: https://github.com/gravitational/teleport/pull/68031
Child: #68179

## Manual Test Plan
### Test Environment

A cluster running this branch.
Scoped access lists aren't yet supported at the API layer, so the manual testplan will be meant to catch any regressions

### Test Cases
- [x] can create unscoped access list with user members
- [x] user members receive roles and traits granted by their access lists
- [x] owners can add/remove members
- [x] can add a nested access list membership, members of the child list receive all roles and traits granted by both lists
