### PR TITLE
Add scope to ScopedToken get/delete APIs and token abstractions

### DIFF
--- a/api/gen/proto/go/teleport/scopes/joining/v1/service.pb.go
+++ b/api/gen/proto/go/teleport/scopes/joining/v1/service.pb.go
@@ -43,7 +43,9 @@ type GetScopedTokenRequest struct {
 	// Name is the name of the scoped token.
 	Name string `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
 	// If true, include the token secret in the response.
-	WithSecret    bool `protobuf:"varint,2,opt,name=with_secret,json=withSecret,proto3" json:"with_secret,omitempty"`
+	WithSecret bool `protobuf:"varint,2,opt,name=with_secret,json=withSecret,proto3" json:"with_secret,omitempty"`
+	// The scope which the token exists in.
+	Scope         string `protobuf:"bytes,3,opt,name=scope,proto3" json:"scope,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -87,12 +89,23 @@ func (x *GetScopedTokenRequest) GetWithSecret() bool {
 	return false
 }
 
+func (x *GetScopedTokenRequest) GetScope() string {
+	if x != nil {
+		return x.Scope
+	}
+	return ""
+}
+
 func (x *GetScopedTokenRequest) SetName(v string) {
 	x.Name = v
 }
 
 func (x *GetScopedTokenRequest) SetWithSecret(v bool) {
 	x.WithSecret = v
+}
+
+func (x *GetScopedTokenRequest) SetScope(v string) {
+	x.Scope = v
 }
 
 type GetScopedTokenRequest_builder struct {
@@ -102,6 +115,8 @@ type GetScopedTokenRequest_builder struct {
 	Name string
 	// If true, include the token secret in the response.
 	WithSecret bool
+	// The scope which the token exists in.
+	Scope string
 }
 
 func (b0 GetScopedTokenRequest_builder) Build() *GetScopedTokenRequest {
@@ -110,6 +125,7 @@ func (b0 GetScopedTokenRequest_builder) Build() *GetScopedTokenRequest {
 	_, _ = b, x
 	x.Name = b.Name
 	x.WithSecret = b.WithSecret
+	x.Scope = b.Scope
 	return m0
 }
 
@@ -728,7 +744,9 @@ type DeleteScopedTokenRequest struct {
 	// Name is the name of the scoped token to delete.
 	Name string `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
 	// Revision asserts the revision of the scoped token to delete (optional).
-	Revision      string `protobuf:"bytes,2,opt,name=revision,proto3" json:"revision,omitempty"`
+	Revision string `protobuf:"bytes,2,opt,name=revision,proto3" json:"revision,omitempty"`
+	// The scope which the token exists in.
+	Scope         string `protobuf:"bytes,3,opt,name=scope,proto3" json:"scope,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -772,12 +790,23 @@ func (x *DeleteScopedTokenRequest) GetRevision() string {
 	return ""
 }
 
+func (x *DeleteScopedTokenRequest) GetScope() string {
+	if x != nil {
+		return x.Scope
+	}
+	return ""
+}
+
 func (x *DeleteScopedTokenRequest) SetName(v string) {
 	x.Name = v
 }
 
 func (x *DeleteScopedTokenRequest) SetRevision(v string) {
 	x.Revision = v
+}
+
+func (x *DeleteScopedTokenRequest) SetScope(v string) {
+	x.Scope = v
 }
 
 type DeleteScopedTokenRequest_builder struct {
@@ -787,6 +816,8 @@ type DeleteScopedTokenRequest_builder struct {
 	Name string
 	// Revision asserts the revision of the scoped token to delete (optional).
 	Revision string
+	// The scope which the token exists in.
+	Scope string
 }
 
 func (b0 DeleteScopedTokenRequest_builder) Build() *DeleteScopedTokenRequest {
@@ -795,6 +826,7 @@ func (b0 DeleteScopedTokenRequest_builder) Build() *DeleteScopedTokenRequest {
 	_, _ = b, x
 	x.Name = b.Name
 	x.Revision = b.Revision
+	x.Scope = b.Scope
 	return m0
 }
 
@@ -988,11 +1020,12 @@ var File_teleport_scopes_joining_v1_service_proto protoreflect.FileDescriptor
 
 const file_teleport_scopes_joining_v1_service_proto_rawDesc = "" +
 	"\n" +
-	"(teleport/scopes/joining/v1/service.proto\x12\x1ateleport.scopes.joining.v1\x1a&teleport/scopes/joining/v1/token.proto\x1a\x1fteleport/scopes/v1/scopes.proto\"L\n" +
+	"(teleport/scopes/joining/v1/service.proto\x12\x1ateleport.scopes.joining.v1\x1a&teleport/scopes/joining/v1/token.proto\x1a\x1fteleport/scopes/v1/scopes.proto\"b\n" +
 	"\x15GetScopedTokenRequest\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12\x1f\n" +
 	"\vwith_secret\x18\x02 \x01(\bR\n" +
-	"withSecret\"W\n" +
+	"withSecret\x12\x14\n" +
+	"\x05scope\x18\x03 \x01(\tR\x05scope\"W\n" +
 	"\x16GetScopedTokenResponse\x12=\n" +
 	"\x05token\x18\x01 \x01(\v2'.teleport.scopes.joining.v1.ScopedTokenR\x05token\"\x9a\x03\n" +
 	"\x17ListScopedTokensRequest\x12A\n" +
@@ -1016,10 +1049,11 @@ const file_teleport_scopes_joining_v1_service_proto_rawDesc = "" +
 	"\x18UpsertScopedTokenRequest\x12=\n" +
 	"\x05token\x18\x01 \x01(\v2'.teleport.scopes.joining.v1.ScopedTokenR\x05token\"Z\n" +
 	"\x19UpsertScopedTokenResponse\x12=\n" +
-	"\x05token\x18\x01 \x01(\v2'.teleport.scopes.joining.v1.ScopedTokenR\x05token\"J\n" +
+	"\x05token\x18\x01 \x01(\v2'.teleport.scopes.joining.v1.ScopedTokenR\x05token\"`\n" +
 	"\x18DeleteScopedTokenRequest\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12\x1a\n" +
-	"\brevision\x18\x02 \x01(\tR\brevision\"\x1b\n" +
+	"\brevision\x18\x02 \x01(\tR\brevision\x12\x14\n" +
+	"\x05scope\x18\x03 \x01(\tR\x05scope\"\x1b\n" +
 	"\x19DeleteScopedTokenResponse\"Y\n" +
 	"\x18UpdateScopedTokenRequest\x12=\n" +
 	"\x05token\x18\x01 \x01(\v2'.teleport.scopes.joining.v1.ScopedTokenR\x05token\"Z\n" +

--- a/api/gen/proto/go/teleport/scopes/joining/v1/service_protoopaque.pb.go
+++ b/api/gen/proto/go/teleport/scopes/joining/v1/service_protoopaque.pb.go
@@ -42,6 +42,7 @@ type GetScopedTokenRequest struct {
 	state                 protoimpl.MessageState `protogen:"opaque.v1"`
 	xxx_hidden_Name       string                 `protobuf:"bytes,1,opt,name=name,proto3"`
 	xxx_hidden_WithSecret bool                   `protobuf:"varint,2,opt,name=with_secret,json=withSecret,proto3"`
+	xxx_hidden_Scope      string                 `protobuf:"bytes,3,opt,name=scope,proto3"`
 	unknownFields         protoimpl.UnknownFields
 	sizeCache             protoimpl.SizeCache
 }
@@ -85,12 +86,23 @@ func (x *GetScopedTokenRequest) GetWithSecret() bool {
 	return false
 }
 
+func (x *GetScopedTokenRequest) GetScope() string {
+	if x != nil {
+		return x.xxx_hidden_Scope
+	}
+	return ""
+}
+
 func (x *GetScopedTokenRequest) SetName(v string) {
 	x.xxx_hidden_Name = v
 }
 
 func (x *GetScopedTokenRequest) SetWithSecret(v bool) {
 	x.xxx_hidden_WithSecret = v
+}
+
+func (x *GetScopedTokenRequest) SetScope(v string) {
+	x.xxx_hidden_Scope = v
 }
 
 type GetScopedTokenRequest_builder struct {
@@ -100,6 +112,8 @@ type GetScopedTokenRequest_builder struct {
 	Name string
 	// If true, include the token secret in the response.
 	WithSecret bool
+	// The scope which the token exists in.
+	Scope string
 }
 
 func (b0 GetScopedTokenRequest_builder) Build() *GetScopedTokenRequest {
@@ -108,6 +122,7 @@ func (b0 GetScopedTokenRequest_builder) Build() *GetScopedTokenRequest {
 	_, _ = b, x
 	x.xxx_hidden_Name = b.Name
 	x.xxx_hidden_WithSecret = b.WithSecret
+	x.xxx_hidden_Scope = b.Scope
 	return m0
 }
 
@@ -713,6 +728,7 @@ type DeleteScopedTokenRequest struct {
 	state               protoimpl.MessageState `protogen:"opaque.v1"`
 	xxx_hidden_Name     string                 `protobuf:"bytes,1,opt,name=name,proto3"`
 	xxx_hidden_Revision string                 `protobuf:"bytes,2,opt,name=revision,proto3"`
+	xxx_hidden_Scope    string                 `protobuf:"bytes,3,opt,name=scope,proto3"`
 	unknownFields       protoimpl.UnknownFields
 	sizeCache           protoimpl.SizeCache
 }
@@ -756,12 +772,23 @@ func (x *DeleteScopedTokenRequest) GetRevision() string {
 	return ""
 }
 
+func (x *DeleteScopedTokenRequest) GetScope() string {
+	if x != nil {
+		return x.xxx_hidden_Scope
+	}
+	return ""
+}
+
 func (x *DeleteScopedTokenRequest) SetName(v string) {
 	x.xxx_hidden_Name = v
 }
 
 func (x *DeleteScopedTokenRequest) SetRevision(v string) {
 	x.xxx_hidden_Revision = v
+}
+
+func (x *DeleteScopedTokenRequest) SetScope(v string) {
+	x.xxx_hidden_Scope = v
 }
 
 type DeleteScopedTokenRequest_builder struct {
@@ -771,6 +798,8 @@ type DeleteScopedTokenRequest_builder struct {
 	Name string
 	// Revision asserts the revision of the scoped token to delete (optional).
 	Revision string
+	// The scope which the token exists in.
+	Scope string
 }
 
 func (b0 DeleteScopedTokenRequest_builder) Build() *DeleteScopedTokenRequest {
@@ -779,6 +808,7 @@ func (b0 DeleteScopedTokenRequest_builder) Build() *DeleteScopedTokenRequest {
 	_, _ = b, x
 	x.xxx_hidden_Name = b.Name
 	x.xxx_hidden_Revision = b.Revision
+	x.xxx_hidden_Scope = b.Scope
 	return m0
 }
 
@@ -970,11 +1000,12 @@ var File_teleport_scopes_joining_v1_service_proto protoreflect.FileDescriptor
 
 const file_teleport_scopes_joining_v1_service_proto_rawDesc = "" +
 	"\n" +
-	"(teleport/scopes/joining/v1/service.proto\x12\x1ateleport.scopes.joining.v1\x1a&teleport/scopes/joining/v1/token.proto\x1a\x1fteleport/scopes/v1/scopes.proto\"L\n" +
+	"(teleport/scopes/joining/v1/service.proto\x12\x1ateleport.scopes.joining.v1\x1a&teleport/scopes/joining/v1/token.proto\x1a\x1fteleport/scopes/v1/scopes.proto\"b\n" +
 	"\x15GetScopedTokenRequest\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12\x1f\n" +
 	"\vwith_secret\x18\x02 \x01(\bR\n" +
-	"withSecret\"W\n" +
+	"withSecret\x12\x14\n" +
+	"\x05scope\x18\x03 \x01(\tR\x05scope\"W\n" +
 	"\x16GetScopedTokenResponse\x12=\n" +
 	"\x05token\x18\x01 \x01(\v2'.teleport.scopes.joining.v1.ScopedTokenR\x05token\"\x9a\x03\n" +
 	"\x17ListScopedTokensRequest\x12A\n" +
@@ -998,10 +1029,11 @@ const file_teleport_scopes_joining_v1_service_proto_rawDesc = "" +
 	"\x18UpsertScopedTokenRequest\x12=\n" +
 	"\x05token\x18\x01 \x01(\v2'.teleport.scopes.joining.v1.ScopedTokenR\x05token\"Z\n" +
 	"\x19UpsertScopedTokenResponse\x12=\n" +
-	"\x05token\x18\x01 \x01(\v2'.teleport.scopes.joining.v1.ScopedTokenR\x05token\"J\n" +
+	"\x05token\x18\x01 \x01(\v2'.teleport.scopes.joining.v1.ScopedTokenR\x05token\"`\n" +
 	"\x18DeleteScopedTokenRequest\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12\x1a\n" +
-	"\brevision\x18\x02 \x01(\tR\brevision\"\x1b\n" +
+	"\brevision\x18\x02 \x01(\tR\brevision\x12\x14\n" +
+	"\x05scope\x18\x03 \x01(\tR\x05scope\"\x1b\n" +
 	"\x19DeleteScopedTokenResponse\"Y\n" +
 	"\x18UpdateScopedTokenRequest\x12=\n" +
 	"\x05token\x18\x01 \x01(\v2'.teleport.scopes.joining.v1.ScopedTokenR\x05token\"Z\n" +

--- a/api/proto/teleport/scopes/joining/v1/service.proto
+++ b/api/proto/teleport/scopes/joining/v1/service.proto
@@ -49,6 +49,9 @@ message GetScopedTokenRequest {
 
   // If true, include the token secret in the response.
   bool with_secret = 2;
+
+  // The scope which the token exists in.
+  string scope = 3;
 }
 
 // GetScopedTokenResponse is the response to get a scoped token.
@@ -121,6 +124,9 @@ message DeleteScopedTokenRequest {
 
   // Revision asserts the revision of the scoped token to delete (optional).
   string revision = 2;
+
+  // The scope which the token exists in.
+  string scope = 3;
 }
 
 // DeleteScopedTokenResponse is the response to delete a scoped token.

--- a/api/types/provisioning.go
+++ b/api/types/provisioning.go
@@ -205,6 +205,10 @@ type ProvisionToken interface {
 	// unscoped
 	GetAssignedScope() string
 
+	// GetScope always returns an empty string because a [ProvisionToken] is always
+	// unscoped
+	GetScope() string
+
 	// GetSecret returns the token's secret value and a bool representing whether
 	// or not the token had a secret..
 	GetSecret() (string, bool)
@@ -739,6 +743,12 @@ func (p *ProvisionTokenV2) GetSafeName() string {
 // GetAssignedScope always returns an empty string because a [ProvisionTokenV2] is always
 // unscoped
 func (p *ProvisionTokenV2) GetAssignedScope() string {
+	return ""
+}
+
+// GetScope always returns an empty string because a [ProvisionTokenV2] is always
+// unscoped
+func (p *ProvisionTokenV2) GetScope() string {
 	return ""
 }
 

--- a/lib/join/provision/token.go
+++ b/lib/join/provision/token.go
@@ -51,6 +51,8 @@ type Token interface {
 	// GetAssignedScope returns the scope that will be assigned to provisioned resources
 	// provisioned using the wrapped [joiningv1.ScopedToken].
 	GetAssignedScope() string
+	// GetScope returns the scope that token exists in.
+	GetScope() string
 	// GetImmutableLabels returns labels that must be applied to resources
 	// provisioned with this token.
 	GetImmutableLabels() *joiningv1.ImmutableLabels

--- a/lib/scopes/joining/token.go
+++ b/lib/scopes/joining/token.go
@@ -665,6 +665,11 @@ func (t *Token) GetAssignedScope() string {
 	return t.scoped.GetSpec().GetAssignedScope()
 }
 
+// GetScope returns the scope of the wrapped [joiningv1.ScopedToken].
+func (t *Token) GetScope() string {
+	return t.scoped.GetScope()
+}
+
 // GetSecret returns the token's secret value.
 func (t *Token) GetSecret() (string, bool) {
 	return t.scoped.GetStatus().GetSecret(), t.GetJoinMethod() == types.JoinMethodToken


### PR DESCRIPTION
In preparation for making ScopedTokens fully namespaced this adds a scope field to GetScopedTokenRequest and DeleteScopedTokenRequest. Additionally, the provision.Token interface was updated to include a GetScope method that will be consumed to populate APIs that require a scope in follow up changes.