### PR TITLE
[v18] Close expired app connections

### DIFF
--- a/lib/web/app/handler.go
+++ b/lib/web/app/handler.go
@@ -618,6 +618,42 @@ func HasClientCert(r *http.Request) bool {
 	return r.TLS != nil && len(r.TLS.PeerCertificates) > 0
 }
 
+// certIdentity returns the TLS identity backing a certificate-authenticated
+// request, following the same precedence as [Handler.getAppSession]: the HTTPS
+// tunnel identity first, then a direct client certificate. It returns nil for
+// cookie/browser clients, which don't authenticate with a certificate.
+func certIdentity(r *http.Request) *tlsca.Identity {
+	switch {
+	case IsHTTPSTunnelConn(r):
+		identity, err := getIdentityFromHTTPSTunnelRequest(r)
+		if err != nil {
+			return nil
+		}
+		return identity
+	case HasClientCert(r):
+		cert := r.TLS.PeerCertificates[0]
+		identity, err := tlsca.FromSubject(cert.Subject, cert.NotAfter)
+		if err != nil {
+			return nil
+		}
+		return identity
+	default:
+		return nil
+	}
+}
+
+// connectionCredentialExpired reports whether a certificate-authenticated
+// request is backed by a credential that has already expired as of now. Returns
+// false for cookie/browser clients, which don't authenticate with a
+// certificate.
+func connectionCredentialExpired(r *http.Request, now time.Time) bool {
+	identity := certIdentity(r)
+	if identity == nil {
+		return false
+	}
+	return identity.Expires.Before(now)
+}
+
 // isBrowserRequest reports whether the request originated from a browser.
 // Sec-Fetch-Site is sent on every request by all modern browsers, and
 // non-browser clients (curl, SDKs) do not send it.

--- a/lib/web/app/handler.go
+++ b/lib/web/app/handler.go
@@ -618,28 +618,26 @@ func HasClientCert(r *http.Request) bool {
 	return r.TLS != nil && len(r.TLS.PeerCertificates) > 0
 }
 
-// certIdentity returns the TLS identity backing a certificate-authenticated
-// request, following the same precedence as [Handler.getAppSession]: the HTTPS
-// tunnel identity first, then a direct client certificate. It returns nil for
-// cookie/browser clients, which don't authenticate with a certificate.
-func certIdentity(r *http.Request) *tlsca.Identity {
-	switch {
-	case IsHTTPSTunnelConn(r):
+// appAuthCertificateIdentities returns certificate-backed identities that
+// participate in app auth for the request. HTTPS-tunneled requests validate the
+// outer tunnel identity and, when present, the inner client cert identity.
+// Cookie/browser clients return no identities.
+func appAuthCertificateIdentities(r *http.Request) []*tlsca.Identity {
+	var identities []*tlsca.Identity
+	if IsHTTPSTunnelConn(r) {
 		identity, err := getIdentityFromHTTPSTunnelRequest(r)
-		if err != nil {
-			return nil
+		if err == nil {
+			identities = append(identities, identity)
 		}
-		return identity
-	case HasClientCert(r):
+	}
+	if HasClientCert(r) {
 		cert := r.TLS.PeerCertificates[0]
 		identity, err := tlsca.FromSubject(cert.Subject, cert.NotAfter)
-		if err != nil {
-			return nil
+		if err == nil {
+			identities = append(identities, identity)
 		}
-		return identity
-	default:
-		return nil
 	}
+	return identities
 }
 
 // connectionCredentialExpired reports whether a certificate-authenticated
@@ -647,11 +645,12 @@ func certIdentity(r *http.Request) *tlsca.Identity {
 // false for cookie/browser clients, which don't authenticate with a
 // certificate.
 func connectionCredentialExpired(r *http.Request, now time.Time) bool {
-	identity := certIdentity(r)
-	if identity == nil {
-		return false
+	for _, identity := range appAuthCertificateIdentities(r) {
+		if identity.Expires.Before(now) {
+			return true
+		}
 	}
-	return identity.Expires.Before(now)
+	return false
 }
 
 // isBrowserRequest reports whether the request originated from a browser.

--- a/lib/web/app/handler_test.go
+++ b/lib/web/app/handler_test.go
@@ -1466,15 +1466,38 @@ func makeHTTPSTunnelConnFromAppSession(session types.WebSession, appName string)
 					ClusterName: "test-cluster",
 					PublicAddr:  "app.example.com",
 				},
+				Expires: session.Expiry(),
+			},
+		},
+	}
+}
+
+func makeHTTPSTunnelConnWithExpiry(t *testing.T, publicAddr string, expiry time.Time) *httpsTunnelConn {
+	t.Helper()
+
+	return &httpsTunnelConn{
+		TLSConn: &mockTLSConn{},
+		user: authz.LocalUser{
+			Username: "testuser",
+			Identity: tlsca.Identity{
+				Username:        "testuser",
+				TeleportCluster: "test-cluster",
+				RouteToApp: tlsca.RouteToApp{
+					SessionID:   "test-session-id",
+					Name:        "testapp",
+					ClusterName: "test-cluster",
+					PublicAddr:  publicAddr,
+				},
+				Expires: expiry,
 			},
 		},
 	}
 }
 
 // newClientCertRequest builds a request authenticated with a client certificate
-// for the given user, whose credential expires at notAfter. certIdentity only
-// reads the certificate Subject and NotAfter, so the certificate need not be
-// signed.
+// for the given user, whose credential expires at notAfter.
+// appAuthCertificateIdentities only reads the certificate Subject and NotAfter,
+// so the certificate need not be signed.
 func newClientCertRequest(t *testing.T, publicAddr, username string, notAfter time.Time) *http.Request {
 	t.Helper()
 	subject, err := (&tlsca.Identity{
@@ -1499,18 +1522,36 @@ func TestConnectionCredentialExpired(t *testing.T) {
 
 	t.Run("cookie/browser client has no certificate identity", func(t *testing.T) {
 		r := httptest.NewRequest("GET", "https://"+publicAddr, nil)
-		require.Nil(t, certIdentity(r))
+		require.Empty(t, appAuthCertificateIdentities(r))
 		require.False(t, connectionCredentialExpired(r, now))
 	})
 
 	t.Run("valid certificate is not expired", func(t *testing.T) {
 		r := newClientCertRequest(t, publicAddr, "testuser", now.Add(time.Minute))
-		require.NotNil(t, certIdentity(r))
+		require.Len(t, appAuthCertificateIdentities(r), 1)
 		require.False(t, connectionCredentialExpired(r, now))
 	})
 
 	t.Run("expired certificate is reported expired", func(t *testing.T) {
 		r := newClientCertRequest(t, publicAddr, "testuser", now.Add(-time.Second))
+		require.True(t, connectionCredentialExpired(r, now))
+	})
+
+	t.Run("HTTPS tunnel with valid outer identity and expired inner client cert is expired", func(t *testing.T) {
+		tunnelConn := makeHTTPSTunnelConnWithExpiry(t, publicAddr, now.Add(time.Minute))
+		r := newClientCertRequest(t, publicAddr, "testuser", now.Add(-time.Second))
+		r = r.WithContext(authz.ContextWithConn(r.Context(), tunnelConn))
+
+		require.Len(t, appAuthCertificateIdentities(r), 2)
+		require.True(t, connectionCredentialExpired(r, now))
+	})
+
+	t.Run("HTTPS tunnel with expired outer identity and valid inner client cert is expired", func(t *testing.T) {
+		tunnelConn := makeHTTPSTunnelConnWithExpiry(t, publicAddr, now.Add(-time.Second))
+		r := newClientCertRequest(t, publicAddr, "testuser", now.Add(time.Minute))
+		r = r.WithContext(authz.ContextWithConn(r.Context(), tunnelConn))
+
+		require.Len(t, appAuthCertificateIdentities(r), 2)
 		require.True(t, connectionCredentialExpired(r, now))
 	})
 }

--- a/lib/web/app/handler_test.go
+++ b/lib/web/app/handler_test.go
@@ -1470,3 +1470,119 @@ func makeHTTPSTunnelConnFromAppSession(session types.WebSession, appName string)
 		},
 	}
 }
+
+// newClientCertRequest builds a request authenticated with a client certificate
+// for the given user, whose credential expires at notAfter. certIdentity only
+// reads the certificate Subject and NotAfter, so the certificate need not be
+// signed.
+func newClientCertRequest(t *testing.T, publicAddr, username string, notAfter time.Time) *http.Request {
+	t.Helper()
+	subject, err := (&tlsca.Identity{
+		Username: username,
+		Groups:   []string{"access"},
+		RouteToApp: tlsca.RouteToApp{
+			PublicAddr:  publicAddr,
+			ClusterName: "test-cluster",
+			Name:        "testapp",
+		},
+	}).Subject()
+	require.NoError(t, err)
+
+	r := httptest.NewRequest("GET", "https://"+publicAddr, nil)
+	r.TLS.PeerCertificates = []*x509.Certificate{{Subject: subject, NotAfter: notAfter}}
+	return r
+}
+
+func TestConnectionCredentialExpired(t *testing.T) {
+	const publicAddr = "app.example.com"
+	now := time.Now()
+
+	t.Run("cookie/browser client has no certificate identity", func(t *testing.T) {
+		r := httptest.NewRequest("GET", "https://"+publicAddr, nil)
+		require.Nil(t, certIdentity(r))
+		require.False(t, connectionCredentialExpired(r, now))
+	})
+
+	t.Run("valid certificate is not expired", func(t *testing.T) {
+		r := newClientCertRequest(t, publicAddr, "testuser", now.Add(time.Minute))
+		require.NotNil(t, certIdentity(r))
+		require.False(t, connectionCredentialExpired(r, now))
+	})
+
+	t.Run("expired certificate is reported expired", func(t *testing.T) {
+		r := newClientCertRequest(t, publicAddr, "testuser", now.Add(-time.Second))
+		require.True(t, connectionCredentialExpired(r, now))
+	})
+}
+
+// newExpiryTestHandler builds an app Handler backed by a mock auth client whose
+// app session expires 5 minutes from the fake clock's current time.
+func newExpiryTestHandler(t *testing.T, ctx context.Context, fakeClock *clockwork.FakeClock) (*Handler, *mockAuthClient, string) {
+	t.Helper()
+	clusterName := "test-cluster"
+	publicAddr := "app.example.com"
+	key, cert, err := tlsca.GenerateSelfSignedCA(
+		pkix.Name{CommonName: clusterName},
+		[]string{publicAddr, apiutils.EncodeClusterName(clusterName)},
+		defaults.CATTL,
+	)
+	require.NoError(t, err)
+
+	authClient := &mockAuthClient{
+		clusterName: clusterName,
+		appSession:  createAppSession(t, fakeClock, key, cert, clusterName, publicAddr, "testapp"),
+		appServers:  []types.AppServer{createAppServer(t, publicAddr)},
+		caKey:       key,
+		caCert:      cert,
+	}
+	fakeCluster := startFakeAppServerOnCluster(t, clusterName, authClient, cert, key)
+	appHandler, err := NewHandler(ctx, &HandlerConfig{
+		Clock:       fakeClock,
+		AuthClient:  authClient,
+		AccessPoint: authClient,
+		ClusterGetter: &reversetunnelclient.FakeServer{
+			FakeClusters: []reversetunnelclient.Cluster{fakeCluster},
+		},
+		CipherSuites:          utils.DefaultCipherSuites(),
+		IntegrationAppHandler: &mockIntegrationAppHandler{},
+	})
+	require.NoError(t, err)
+	return appHandler, authClient, publicAddr
+}
+
+func TestWithAuthExpiredConnectionClose(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	t.Run("expired session on a client cert asks the client to reconnect", func(t *testing.T) {
+		fakeClock := clockwork.NewFakeClock()
+		appHandler, authClient, publicAddr := newExpiryTestHandler(t, ctx, fakeClock)
+
+		// The certificate and its app session expire together. Advance past
+		// expiry to reproduce a long-lived connection whose credential lapsed.
+		certExpiry := authClient.appSession.Expiry()
+		fakeClock.Advance(certExpiry.Sub(fakeClock.Now()) + time.Minute)
+
+		r := newClientCertRequest(t, publicAddr, "testuser", certExpiry)
+		w := httptest.NewRecorder()
+		appHandler.ServeHTTP(w, r)
+
+		require.Equal(t, http.StatusForbidden, w.Code)
+		require.Equal(t, "close", w.Header().Get("Connection"))
+	})
+
+	t.Run("denial on a still-valid client cert is left intact", func(t *testing.T) {
+		fakeClock := clockwork.NewFakeClock()
+		appHandler, _, publicAddr := newExpiryTestHandler(t, ctx, fakeClock)
+
+		// Owner mismatch is a genuine denial. The certificate is still valid, so
+		// reconnecting would not help: we must not mislabel it as expired or ask
+		// the client to close the connection.
+		r := newClientCertRequest(t, publicAddr, "wronguser", fakeClock.Now().Add(time.Hour))
+		w := httptest.NewRecorder()
+		appHandler.ServeHTTP(w, r)
+
+		require.Equal(t, http.StatusForbidden, w.Code)
+		require.Empty(t, w.Header().Get("Connection"))
+	})
+}

--- a/lib/web/app/middleware.go
+++ b/lib/web/app/middleware.go
@@ -51,14 +51,10 @@ func (h *Handler) withAuth(handler handlerAuthFunc) http.HandlerFunc {
 	return makeHandler(func(w http.ResponseWriter, r *http.Request) error {
 		session, err := h.authenticate(r.Context(), r)
 		if err != nil {
-			// A long-lived connection is pinned to the client certificate it
-			// presented at handshake. When that certificate (and the app
-			// session welded to it) expires, every subsequent request over the
-			// still-open connection keeps failing, leaving a "zombie" connection
-			// that returns 403s forever. If the certificate has expired, ask the
-			// client to close the connection so its next request establishes a
-			// fresh one with a renewed certificate. Cookie/browser clients have
-			// no certificate and recover via the launcher redirect instead.
+			// If a certificate-backed app session expires on a reused
+			// connection, ask the client to reconnect with fresh credentials.
+			// Cookie/browser clients have no certificate and use the launcher
+			// redirect path below.
 			// See https://github.com/gravitational/teleport/issues/57697.
 			if connectionCredentialExpired(r, h.c.Clock.Now()) {
 				h.logger.DebugContext(r.Context(),

--- a/lib/web/app/middleware.go
+++ b/lib/web/app/middleware.go
@@ -49,9 +49,26 @@ func (h *Handler) withRouterAuth(handler routerAuthFunc) httprouter.Handle {
 // handler.
 func (h *Handler) withAuth(handler handlerAuthFunc) http.HandlerFunc {
 	return makeHandler(func(w http.ResponseWriter, r *http.Request) error {
-		// If the caller fails to authenticate, redirect the caller to Teleport.
 		session, err := h.authenticate(r.Context(), r)
 		if err != nil {
+			// A long-lived connection is pinned to the client certificate it
+			// presented at handshake. When that certificate (and the app
+			// session welded to it) expires, every subsequent request over the
+			// still-open connection keeps failing, leaving a "zombie" connection
+			// that returns 403s forever. If the certificate has expired, ask the
+			// client to close the connection so its next request establishes a
+			// fresh one with a renewed certificate. Cookie/browser clients have
+			// no certificate and recover via the launcher redirect instead.
+			// See https://github.com/gravitational/teleport/issues/57697.
+			if connectionCredentialExpired(r, h.c.Clock.Now()) {
+				h.logger.DebugContext(r.Context(),
+					"Closing connection with expired application session so the client can reconnect",
+					"error", err)
+				w.Header().Set("Connection", "close")
+				return trace.Wrap(err)
+			}
+			// Otherwise, if the caller fails to authenticate, redirect the
+			// caller to Teleport.
 			if redirectErr := h.redirectToLauncher(w, r, launcherURLParams{}); redirectErr == nil {
 				return nil
 			}


### PR DESCRIPTION
Backport #67937 to branch/v18

changelog: Fixed HTTP application access connections returning repeated 403 errors after certificate renewal. When the certificate behind a long-lived connection expires, the proxy now sends `Connection: close` so the client reestablishes the connection with a renewed certificate instead of reusing a dead one.
